### PR TITLE
dyninst/irgen: only add needed types based on reference limits

### DIFF
--- a/pkg/dyninst/compiler/generate.go
+++ b/pkg/dyninst/compiler/generate.go
@@ -336,6 +336,9 @@ func (g *generator) addTypeHandler(t ir.Type) (FunctionID, bool, error) {
 	case *ir.VoidPointerType:
 		// Nothing to process. We don't know what the pointee is.
 
+	case *ir.UnresolvedPointeeType:
+		// Nothing to process.
+
 	case *ir.PointerType:
 		g.typeQueue = append(g.typeQueue, t.Pointee)
 		needed = true

--- a/pkg/dyninst/compiler/generate.go
+++ b/pkg/dyninst/compiler/generate.go
@@ -118,6 +118,24 @@ func GenerateProgram(program *ir.Program) (Program, error) {
 	for _, t := range program.Types {
 		types = append(types, t)
 	}
+	slices.SortStableFunc(g.functions, func(a, b Function) int {
+		at, aOk := a.ID.(ProcessType)
+		bt, bOk := b.ID.(ProcessType)
+		switch {
+		case !aOk && !bOk:
+			return 0
+		case !aOk:
+			return -1
+		case !bOk:
+			return 1
+		default:
+			return cmp.Or(
+				cmp.Compare(at.Type.GetName(), bt.Type.GetName()),
+				cmp.Compare(at.Type.GetID(), bt.Type.GetID()),
+			)
+
+		}
+	})
 	return Program{
 		ID:               uint32(program.ID),
 		Functions:        g.functions,

--- a/pkg/dyninst/compiler/testdata/snapshot/simple.arch=amd64,toolchain=go1.23.11.sm.txt
+++ b/pkg/dyninst/compiler/testdata/snapshot/simple.arch=amd64,toolchain=go1.23.11.sm.txt
@@ -135,76 +135,76 @@
 	Call 08 02 00 00 // ProcessExpression[Probe[main.stringSliceArg]@0x4a62aa.expr[0]]
 	Return 
 // 0x240: ProcessType[*****int]
-	ProcessPointer 03 00 00 00 
+	ProcessPointer 3e 00 00 00 
 	Return 
 // 0x246: ProcessType[****int]
-	ProcessPointer 04 00 00 00 
+	ProcessPointer 3f 00 00 00 
 	Return 
 // 0x24c: ProcessType[***int]
-	ProcessPointer 05 00 00 00 
+	ProcessPointer 40 00 00 00 
 	Return 
 // 0x252: ProcessType[**int]
-	ProcessPointer 06 00 00 00 
-	Return 
-// 0x258: ProcessType[*[]*runtime.bmap]
-	ProcessPointer 1d 00 00 00 
-	Return 
-// 0x25e: ProcessType[*bool]
-	ProcessPointer 2a 00 00 00 
-	Return 
-// 0x264: ProcessType[*bucket<string,int>]
-	ProcessPointer 15 00 00 00 
-	Return 
-// 0x26a: ProcessType[*bucket<string,main.bigStruct>]
-	ProcessPointer 25 00 00 00 
-	Return 
-// 0x270: ProcessType[*error]
-	ProcessPointer 34 00 00 00 
-	Return 
-// 0x276: ProcessType[*float32]
-	ProcessPointer 32 00 00 00 
-	Return 
-// 0x27c: ProcessType[*float64]
-	ProcessPointer 33 00 00 00 
-	Return 
-// 0x282: ProcessType[*int]
-	ProcessPointer 01 00 00 00 
-	Return 
-// 0x288: ProcessType[*int32]
-	ProcessPointer 2e 00 00 00 
-	Return 
-// 0x28e: ProcessType[*int64]
-	ProcessPointer 2f 00 00 00 
-	Return 
-// 0x294: ProcessType[*main.bigStruct]
-	ProcessPointer 28 00 00 00 
-	Return 
-// 0x29a: ProcessType[*runtime.bmap]
-	ProcessPointer 20 00 00 00 
-	Return 
-// 0x2a0: ProcessType[*runtime.mapextra]
 	ProcessPointer 1b 00 00 00 
 	Return 
-// 0x2a6: ProcessType[*string]
-	ProcessPointer 07 00 00 00 
+// 0x258: ProcessType[*[]*runtime.bmap]
+	ProcessPointer 30 00 00 00 
 	Return 
-// 0x2ac: ProcessType[*uint]
-	ProcessPointer 31 00 00 00 
+// 0x25e: ProcessType[*bool]
+	ProcessPointer 04 00 00 00 
 	Return 
-// 0x2b2: ProcessType[*uint16]
+// 0x264: ProcessType[*bucket<string,int>]
+	ProcessPointer 29 00 00 00 
+	Return 
+// 0x26a: ProcessType[*bucket<string,main.bigStruct>]
+	ProcessPointer 38 00 00 00 
+	Return 
+// 0x270: ProcessType[*error]
 	ProcessPointer 12 00 00 00 
 	Return 
-// 0x2b8: ProcessType[*uint32]
-	ProcessPointer 13 00 00 00 
+// 0x276: ProcessType[*float32]
+	ProcessPointer 10 00 00 00 
 	Return 
-// 0x2be: ProcessType[*uint64]
-	ProcessPointer 2d 00 00 00 
+// 0x27c: ProcessType[*float64]
+	ProcessPointer 11 00 00 00 
 	Return 
-// 0x2c4: ProcessType[*uint8]
+// 0x282: ProcessType[*int]
 	ProcessPointer 09 00 00 00 
 	Return 
+// 0x288: ProcessType[*int32]
+	ProcessPointer 0c 00 00 00 
+	Return 
+// 0x28e: ProcessType[*int64]
+	ProcessPointer 0d 00 00 00 
+	Return 
+// 0x294: ProcessType[*main.bigStruct]
+	ProcessPointer 3b 00 00 00 
+	Return 
+// 0x29a: ProcessType[*runtime.bmap]
+	ProcessPointer 33 00 00 00 
+	Return 
+// 0x2a0: ProcessType[*runtime.mapextra]
+	ProcessPointer 2e 00 00 00 
+	Return 
+// 0x2a6: ProcessType[*string]
+	ProcessPointer 0a 00 00 00 
+	Return 
+// 0x2ac: ProcessType[*uint]
+	ProcessPointer 0f 00 00 00 
+	Return 
+// 0x2b2: ProcessType[*uint16]
+	ProcessPointer 07 00 00 00 
+	Return 
+// 0x2b8: ProcessType[*uint32]
+	ProcessPointer 02 00 00 00 
+	Return 
+// 0x2be: ProcessType[*uint64]
+	ProcessPointer 0b 00 00 00 
+	Return 
+// 0x2c4: ProcessType[*uint8]
+	ProcessPointer 03 00 00 00 
+	Return 
 // 0x2ca: ProcessType[*uintptr]
-	ProcessPointer 19 00 00 00 
+	ProcessPointer 01 00 00 00 
 	Return 
 // 0x2d0: ProcessType[[3]string]
 	ProcessArrayDataPrep 30 00 00 00 
@@ -272,10 +272,10 @@
 	ProcessGoHmap 4a 00 00 00 d0 00 00 00 08 09 10 18 
 	Return 
 // 0x396: ProcessType[map[string]int]
-	ProcessPointer 11 00 00 00 
+	ProcessPointer 27 00 00 00 
 	Return 
 // 0x39c: ProcessType[map[string]main.bigStruct]
-	ProcessPointer 23 00 00 00 
+	ProcessPointer 36 00 00 00 
 	Return 
 // 0x3a2: ProcessType[runtime.mapextra]
 	Call 58 02 00 00 // ProcessType[*[]*runtime.bmap]
@@ -303,69 +303,69 @@
 	Illegal 
 // Types
 ID: 1 Len: 8 Enqueue: 0
-ID: 2 Len: 8 Enqueue: 576
-ID: 3 Len: 8 Enqueue: 582
-ID: 4 Len: 8 Enqueue: 588
-ID: 5 Len: 8 Enqueue: 594
-ID: 6 Len: 8 Enqueue: 642
-ID: 7 Len: 16 Enqueue: 956
-ID: 8 Len: 8 Enqueue: 708
-ID: 9 Len: 1 Enqueue: 0
-ID: 10 Len: 24 Enqueue: 782
-ID: 11 Len: 24 Enqueue: 0
-ID: 12 Len: 24 Enqueue: 808
-ID: 13 Len: 8 Enqueue: 678
-ID: 14 Len: 48 Enqueue: 720
-ID: 15 Len: 8 Enqueue: 918
-ID: 16 Len: 8 Enqueue: 0
-ID: 17 Len: 48 Enqueue: 890
-ID: 18 Len: 2 Enqueue: 0
-ID: 19 Len: 4 Enqueue: 0
-ID: 20 Len: 8 Enqueue: 612
-ID: 21 Len: 208 Enqueue: 846
-ID: 22 Len: 8 Enqueue: 0
-ID: 23 Len: 128 Enqueue: 792
-ID: 24 Len: 64 Enqueue: 0
-ID: 25 Len: 8 Enqueue: 0
-ID: 26 Len: 8 Enqueue: 672
-ID: 27 Len: 24 Enqueue: 930
-ID: 28 Len: 8 Enqueue: 600
-ID: 29 Len: 24 Enqueue: 736
-ID: 30 Len: 8 Enqueue: 0
-ID: 31 Len: 8 Enqueue: 666
-ID: 32 Len: 8 Enqueue: 0
-ID: 33 Len: 8 Enqueue: 924
-ID: 34 Len: 8 Enqueue: 0
-ID: 35 Len: 48 Enqueue: 904
-ID: 36 Len: 8 Enqueue: 618
-ID: 37 Len: 208 Enqueue: 867
-ID: 38 Len: 64 Enqueue: 830
-ID: 39 Len: 8 Enqueue: 660
-ID: 40 Len: 184 Enqueue: 0
-ID: 41 Len: 128 Enqueue: 0
-ID: 42 Len: 1 Enqueue: 0
-ID: 43 Len: 8 Enqueue: 606
-ID: 44 Len: 8 Enqueue: 714
-ID: 45 Len: 8 Enqueue: 0
-ID: 46 Len: 4 Enqueue: 0
-ID: 47 Len: 8 Enqueue: 0
-ID: 48 Len: 1 Enqueue: 0
+ID: 2 Len: 4 Enqueue: 0
+ID: 3 Len: 1 Enqueue: 0
+ID: 4 Len: 1 Enqueue: 0
+ID: 5 Len: 8 Enqueue: 606
+ID: 6 Len: 8 Enqueue: 708
+ID: 7 Len: 2 Enqueue: 0
+ID: 8 Len: 8 Enqueue: 714
+ID: 9 Len: 8 Enqueue: 0
+ID: 10 Len: 16 Enqueue: 956
+ID: 11 Len: 8 Enqueue: 0
+ID: 12 Len: 4 Enqueue: 0
+ID: 13 Len: 8 Enqueue: 0
+ID: 14 Len: 1 Enqueue: 0
+ID: 15 Len: 8 Enqueue: 0
+ID: 16 Len: 4 Enqueue: 0
+ID: 17 Len: 8 Enqueue: 0
+ID: 18 Len: 16 Enqueue: 888
+ID: 19 Len: 8 Enqueue: 0
+ID: 20 Len: 8 Enqueue: 648
+ID: 21 Len: 8 Enqueue: 696
+ID: 22 Len: 8 Enqueue: 678
+ID: 23 Len: 8 Enqueue: 0
+ID: 24 Len: 16 Enqueue: 0
+ID: 25 Len: 8 Enqueue: 636
+ID: 26 Len: 8 Enqueue: 654
+ID: 27 Len: 8 Enqueue: 642
+ID: 28 Len: 8 Enqueue: 702
+ID: 29 Len: 8 Enqueue: 624
+ID: 30 Len: 8 Enqueue: 630
+ID: 31 Len: 8 Enqueue: 684
+ID: 32 Len: 8 Enqueue: 690
+ID: 33 Len: 24 Enqueue: 782
+ID: 34 Len: 24 Enqueue: 0
+ID: 35 Len: 24 Enqueue: 808
+ID: 36 Len: 48 Enqueue: 720
+ID: 37 Len: 8 Enqueue: 918
+ID: 38 Len: 8 Enqueue: 0
+ID: 39 Len: 48 Enqueue: 890
+ID: 40 Len: 8 Enqueue: 612
+ID: 41 Len: 208 Enqueue: 846
+ID: 42 Len: 8 Enqueue: 0
+ID: 43 Len: 128 Enqueue: 792
+ID: 44 Len: 64 Enqueue: 0
+ID: 45 Len: 8 Enqueue: 672
+ID: 46 Len: 24 Enqueue: 930
+ID: 47 Len: 8 Enqueue: 600
+ID: 48 Len: 24 Enqueue: 736
 ID: 49 Len: 8 Enqueue: 0
-ID: 50 Len: 4 Enqueue: 0
+ID: 50 Len: 8 Enqueue: 666
 ID: 51 Len: 8 Enqueue: 0
-ID: 52 Len: 16 Enqueue: 888
+ID: 52 Len: 8 Enqueue: 924
 ID: 53 Len: 8 Enqueue: 0
-ID: 54 Len: 8 Enqueue: 648
-ID: 55 Len: 8 Enqueue: 696
-ID: 56 Len: 8 Enqueue: 0
-ID: 57 Len: 16 Enqueue: 0
-ID: 58 Len: 8 Enqueue: 636
-ID: 59 Len: 8 Enqueue: 654
-ID: 60 Len: 8 Enqueue: 702
-ID: 61 Len: 8 Enqueue: 624
-ID: 62 Len: 8 Enqueue: 630
-ID: 63 Len: 8 Enqueue: 684
-ID: 64 Len: 8 Enqueue: 690
+ID: 54 Len: 48 Enqueue: 904
+ID: 55 Len: 8 Enqueue: 618
+ID: 56 Len: 208 Enqueue: 867
+ID: 57 Len: 64 Enqueue: 830
+ID: 58 Len: 8 Enqueue: 660
+ID: 59 Len: 184 Enqueue: 0
+ID: 60 Len: 128 Enqueue: 0
+ID: 61 Len: 8 Enqueue: 576
+ID: 62 Len: 8 Enqueue: 582
+ID: 63 Len: 8 Enqueue: 588
+ID: 64 Len: 8 Enqueue: 594
 ID: 65 Len: 2048 Enqueue: 0
 ID: 66 Len: 8 Enqueue: 0
 ID: 67 Len: 2048 Enqueue: 0

--- a/pkg/dyninst/compiler/testdata/snapshot/simple.arch=amd64,toolchain=go1.23.11.sm.txt
+++ b/pkg/dyninst/compiler/testdata/snapshot/simple.arch=amd64,toolchain=go1.23.11.sm.txt
@@ -135,19 +135,19 @@
 	Call 08 02 00 00 // ProcessExpression[Probe[main.stringSliceArg]@0x4a62aa.expr[0]]
 	Return 
 // 0x240: ProcessType[*****int]
-	ProcessPointer 3e 00 00 00 
+	ProcessPointer 32 00 00 00 
 	Return 
 // 0x246: ProcessType[****int]
-	ProcessPointer 3f 00 00 00 
+	ProcessPointer 3e 00 00 00 
 	Return 
 // 0x24c: ProcessType[***int]
-	ProcessPointer 40 00 00 00 
+	ProcessPointer 33 00 00 00 
 	Return 
 // 0x252: ProcessType[**int]
 	ProcessPointer 1b 00 00 00 
 	Return 
 // 0x258: ProcessType[*[]*runtime.bmap]
-	ProcessPointer 30 00 00 00 
+	ProcessPointer 38 00 00 00 
 	Return 
 // 0x25e: ProcessType[*bool]
 	ProcessPointer 04 00 00 00 
@@ -156,7 +156,7 @@
 	ProcessPointer 29 00 00 00 
 	Return 
 // 0x26a: ProcessType[*bucket<string,main.bigStruct>]
-	ProcessPointer 38 00 00 00 
+	ProcessPointer 30 00 00 00 
 	Return 
 // 0x270: ProcessType[*error]
 	ProcessPointer 12 00 00 00 
@@ -177,13 +177,13 @@
 	ProcessPointer 0d 00 00 00 
 	Return 
 // 0x294: ProcessType[*main.bigStruct]
-	ProcessPointer 3b 00 00 00 
+	ProcessPointer 3d 00 00 00 
 	Return 
 // 0x29a: ProcessType[*runtime.bmap]
-	ProcessPointer 33 00 00 00 
+	ProcessPointer 3a 00 00 00 
 	Return 
 // 0x2a0: ProcessType[*runtime.mapextra]
-	ProcessPointer 2e 00 00 00 
+	ProcessPointer 2b 00 00 00 
 	Return 
 // 0x2a6: ProcessType[*string]
 	ProcessPointer 0a 00 00 00 
@@ -212,7 +212,7 @@
 	ProcessSliceDataRepeat 10 00 00 00 
 	Return 
 // 0x2e0: ProcessType[[]*runtime.bmap]
-	ProcessSlice 48 00 00 00 08 00 00 00 
+	ProcessSlice 49 00 00 00 08 00 00 00 
 	Return 
 // 0x2ea: ProcessType[[]*runtime.bmap.array]
 	ProcessSliceDataPrep 
@@ -269,13 +269,13 @@
 	ProcessGoHmap 47 00 00 00 d0 00 00 00 08 09 10 18 
 	Return 
 // 0x388: ProcessType[hash<string,main.bigStruct>]
-	ProcessGoHmap 4a 00 00 00 d0 00 00 00 08 09 10 18 
+	ProcessGoHmap 48 00 00 00 d0 00 00 00 08 09 10 18 
 	Return 
 // 0x396: ProcessType[map[string]int]
 	ProcessPointer 27 00 00 00 
 	Return 
 // 0x39c: ProcessType[map[string]main.bigStruct]
-	ProcessPointer 36 00 00 00 
+	ProcessPointer 2e 00 00 00 
 	Return 
 // 0x3a2: ProcessType[runtime.mapextra]
 	Call 58 02 00 00 // ProcessType[*[]*runtime.bmap]
@@ -343,29 +343,29 @@ ID: 38 Len: 8 Enqueue: 0
 ID: 39 Len: 48 Enqueue: 890
 ID: 40 Len: 8 Enqueue: 612
 ID: 41 Len: 208 Enqueue: 846
-ID: 42 Len: 8 Enqueue: 0
-ID: 43 Len: 128 Enqueue: 792
-ID: 44 Len: 64 Enqueue: 0
-ID: 45 Len: 8 Enqueue: 672
-ID: 46 Len: 24 Enqueue: 930
-ID: 47 Len: 8 Enqueue: 600
-ID: 48 Len: 24 Enqueue: 736
-ID: 49 Len: 8 Enqueue: 0
-ID: 50 Len: 8 Enqueue: 666
-ID: 51 Len: 8 Enqueue: 0
-ID: 52 Len: 8 Enqueue: 924
-ID: 53 Len: 8 Enqueue: 0
-ID: 54 Len: 48 Enqueue: 904
-ID: 55 Len: 8 Enqueue: 618
-ID: 56 Len: 208 Enqueue: 867
-ID: 57 Len: 64 Enqueue: 830
-ID: 58 Len: 8 Enqueue: 660
-ID: 59 Len: 184 Enqueue: 0
-ID: 60 Len: 128 Enqueue: 0
-ID: 61 Len: 8 Enqueue: 576
-ID: 62 Len: 8 Enqueue: 582
-ID: 63 Len: 8 Enqueue: 588
-ID: 64 Len: 8 Enqueue: 594
+ID: 42 Len: 8 Enqueue: 672
+ID: 43 Len: 24 Enqueue: 930
+ID: 44 Len: 8 Enqueue: 924
+ID: 45 Len: 8 Enqueue: 0
+ID: 46 Len: 48 Enqueue: 904
+ID: 47 Len: 8 Enqueue: 618
+ID: 48 Len: 208 Enqueue: 867
+ID: 49 Len: 8 Enqueue: 576
+ID: 50 Len: 8 Enqueue: 582
+ID: 51 Len: 8 Enqueue: 594
+ID: 52 Len: 8 Enqueue: 0
+ID: 53 Len: 128 Enqueue: 792
+ID: 54 Len: 64 Enqueue: 0
+ID: 55 Len: 8 Enqueue: 600
+ID: 56 Len: 24 Enqueue: 736
+ID: 57 Len: 8 Enqueue: 666
+ID: 58 Len: 8 Enqueue: 0
+ID: 59 Len: 64 Enqueue: 830
+ID: 60 Len: 8 Enqueue: 660
+ID: 61 Len: 184 Enqueue: 0
+ID: 62 Len: 8 Enqueue: 588
+ID: 63 Len: 8 Enqueue: 0
+ID: 64 Len: 128 Enqueue: 0
 ID: 65 Len: 2048 Enqueue: 0
 ID: 66 Len: 8 Enqueue: 0
 ID: 67 Len: 2048 Enqueue: 0
@@ -373,9 +373,9 @@ ID: 68 Len: 8 Enqueue: 0
 ID: 69 Len: 2048 Enqueue: 818
 ID: 70 Len: 8 Enqueue: 0
 ID: 71 Len: 2048 Enqueue: 758
-ID: 72 Len: 2048 Enqueue: 746
-ID: 73 Len: 8 Enqueue: 0
-ID: 74 Len: 2048 Enqueue: 770
+ID: 72 Len: 2048 Enqueue: 770
+ID: 73 Len: 2048 Enqueue: 746
+ID: 74 Len: 8 Enqueue: 0
 ID: 75 Len: 9 Enqueue: 0
 ID: 76 Len: 17 Enqueue: 0
 ID: 77 Len: 25 Enqueue: 0

--- a/pkg/dyninst/compiler/testdata/snapshot/simple.arch=amd64,toolchain=go1.23.11.sm.txt
+++ b/pkg/dyninst/compiler/testdata/snapshot/simple.arch=amd64,toolchain=go1.23.11.sm.txt
@@ -3,289 +3,289 @@
 // 0x1: ChasePointers
 	ChasePointers 
 	Return 
-// 0x3: ProcessType[*****int]
-	ProcessPointer 03 00 00 00 
-	Return 
-// 0x9: ProcessExpression[Probe[main.PointerChainArg]@0x4a6006.expr[0]]
+// 0x3: ProcessExpression[Probe[main.PointerChainArg]@0x4a6006.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
-	Call 03 00 00 00 // ProcessType[*****int]
+	Call 40 02 00 00 // ProcessType[*****int]
 	Return 
-// 0x24: ProcessEvent[Probe[main.PointerChainArg]@4a6006]
+// 0x1e: ProcessEvent[Probe[main.PointerChainArg]@4a6006]
 	PrepareEventRoot 55 00 00 00 09 00 00 00 
-	Call 09 00 00 00 // ProcessExpression[Probe[main.PointerChainArg]@0x4a6006.expr[0]]
+	Call 03 00 00 00 // ProcessExpression[Probe[main.PointerChainArg]@0x4a6006.expr[0]]
 	Return 
-// 0x33: ProcessType[**int]
-	ProcessPointer 06 00 00 00 
-	Return 
-// 0x39: ProcessExpression[Probe[main.PointerSmallChainArg]@0x4a6050.expr[0]]
+// 0x2d: ProcessExpression[Probe[main.PointerSmallChainArg]@0x4a6050.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 01 08 00 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
-	Call 33 00 00 00 // ProcessType[**int]
+	Call 52 02 00 00 // ProcessType[**int]
 	Return 
-// 0x54: ProcessEvent[Probe[main.PointerSmallChainArg]@4a6050]
+// 0x48: ProcessEvent[Probe[main.PointerSmallChainArg]@4a6050]
 	PrepareEventRoot 56 00 00 00 09 00 00 00 
-	Call 39 00 00 00 // ProcessExpression[Probe[main.PointerSmallChainArg]@0x4a6050.expr[0]]
+	Call 2d 00 00 00 // ProcessExpression[Probe[main.PointerSmallChainArg]@0x4a6050.expr[0]]
 	Return 
-// 0x63: ProcessType[map[string]main.bigStruct]
-	ProcessPointer 23 00 00 00 
-	Return 
-// 0x69: ProcessExpression[Probe[main.bigMapArg]@0x4a64f3.expr[0]]
+// 0x57: ProcessExpression[Probe[main.bigMapArg]@0x4a64f3.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
-	Call 63 00 00 00 // ProcessType[map[string]main.bigStruct]
+	Call 9c 03 00 00 // ProcessType[map[string]main.bigStruct]
 	Return 
-// 0x84: ProcessEvent[Probe[main.bigMapArg]@4a64f3]
+// 0x72: ProcessEvent[Probe[main.bigMapArg]@4a64f3]
 	PrepareEventRoot 53 00 00 00 09 00 00 00 
-	Call 69 00 00 00 // ProcessExpression[Probe[main.bigMapArg]@0x4a64f3.expr[0]]
+	Call 57 00 00 00 // ProcessExpression[Probe[main.bigMapArg]@0x4a64f3.expr[0]]
 	Return 
-// 0x93: ProcessExpression[Probe[main.inlined]@0x4a63ca.expr[0]]
+// 0x81: ProcessExpression[Probe[main.inlined]@0x4a63ca.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
 	Return 
-// 0xa9: ProcessEvent[Probe[main.inlined]@4a63ca]
+// 0x97: ProcessEvent[Probe[main.inlined]@4a63ca]
 	PrepareEventRoot 54 00 00 00 09 00 00 00 
-	Call 93 00 00 00 // ProcessExpression[Probe[main.inlined]@0x4a63ca.expr[0]]
+	Call 81 00 00 00 // ProcessExpression[Probe[main.inlined]@0x4a63ca.expr[0]]
 	Return 
-// 0xb8: ProcessExpression[Probe[main.inlined]@0x4a5dce.expr[0]]
+// 0xa6: ProcessExpression[Probe[main.inlined]@0x4a5dce.expr[0]]
 	ExprPrepare 
 	Return 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
 	Return 
-// 0xc8: ProcessEvent[Probe[main.inlined]@4a5dce]
+// 0xb6: ProcessEvent[Probe[main.inlined]@4a5dce]
 	PrepareEventRoot 54 00 00 00 09 00 00 00 
-	Call b8 00 00 00 // ProcessExpression[Probe[main.inlined]@0x4a5dce.expr[0]]
+	Call a6 00 00 00 // ProcessExpression[Probe[main.inlined]@0x4a5dce.expr[0]]
 	Return 
-// 0xd7: ProcessExpression[Probe[main.intArg]@0x4a60aa.expr[0]]
+// 0xc5: ProcessExpression[Probe[main.intArg]@0x4a60aa.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
 	Return 
-// 0xed: ProcessEvent[Probe[main.intArg]@4a60aa]
+// 0xdb: ProcessEvent[Probe[main.intArg]@4a60aa]
 	PrepareEventRoot 4b 00 00 00 09 00 00 00 
-	Call d7 00 00 00 // ProcessExpression[Probe[main.intArg]@0x4a60aa.expr[0]]
+	Call c5 00 00 00 // ProcessExpression[Probe[main.intArg]@0x4a60aa.expr[0]]
 	Return 
-// 0xfc: ProcessExpression[Probe[main.intArrayArg]@0x4a622a.expr[0]]
+// 0xea: ProcessExpression[Probe[main.intArrayArg]@0x4a622a.expr[0]]
 	ExprPrepare 
 	ExprDereferenceCfa 00 00 00 00 18 00 00 00 00 00 00 00 
 	ExprSave 01 00 00 00 18 00 00 00 00 00 00 00 
 	Return 
-// 0x118: ProcessEvent[Probe[main.intArrayArg]@4a622a]
+// 0x106: ProcessEvent[Probe[main.intArrayArg]@4a622a]
 	PrepareEventRoot 4e 00 00 00 19 00 00 00 
-	Call fc 00 00 00 // ProcessExpression[Probe[main.intArrayArg]@0x4a622a.expr[0]]
+	Call ea 00 00 00 // ProcessExpression[Probe[main.intArrayArg]@0x4a622a.expr[0]]
 	Return 
-// 0x127: ProcessType[string]
-	ProcessString 41 00 00 00 
-	Return 
-// 0x12d: ProcessType[[3]string]
-	ProcessArrayDataPrep 30 00 00 00 
-	Call 27 01 00 00 // ProcessType[string]
-	ProcessSliceDataRepeat 10 00 00 00 
-	Return 
-// 0x13d: ProcessExpression[Probe[main.stringArrayArgFrameless]@0x4a63a0.expr[0]]
+// 0x115: ProcessExpression[Probe[main.stringArrayArgFrameless]@0x4a63a0.expr[0]]
 	ExprPrepare 
 	ExprDereferenceCfa 00 00 00 00 30 00 00 00 00 00 00 00 
 	ExprSave 01 00 00 00 30 00 00 00 00 00 00 00 
-	Call 2d 01 00 00 // ProcessType[[3]string]
+	Call d0 02 00 00 // ProcessType[[3]string]
 	Return 
-// 0x15e: ProcessEvent[Probe[main.stringArrayArgFrameless]@4a63a0]
+// 0x136: ProcessEvent[Probe[main.stringArrayArgFrameless]@4a63a0]
 	PrepareEventRoot 51 00 00 00 31 00 00 00 
-	Call 3d 01 00 00 // ProcessExpression[Probe[main.stringArrayArgFrameless]@0x4a63a0.expr[0]]
+	Call 15 01 00 00 // ProcessExpression[Probe[main.stringArrayArgFrameless]@0x4a63a0.expr[0]]
 	Return 
-// 0x16d: ProcessType[[]int]
-	ProcessSlice 43 00 00 00 08 00 00 00 
-	Return 
-// 0x177: ProcessExpression[Probe[main.intSliceArg]@0x4a61aa.expr[0]]
+// 0x145: ProcessExpression[Probe[main.intSliceArg]@0x4a61aa.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprReadRegister 03 08 08 00 00 00 
 	ExprReadRegister 02 08 10 00 00 00 
 	ExprSave 01 00 00 00 18 00 00 00 00 00 00 00 
-	Call 6d 01 00 00 // ProcessType[[]int]
+	Call 0e 03 00 00 // ProcessType[[]int]
 	Return 
-// 0x1a0: ProcessEvent[Probe[main.intSliceArg]@4a61aa]
+// 0x16e: ProcessEvent[Probe[main.intSliceArg]@4a61aa]
 	PrepareEventRoot 4d 00 00 00 19 00 00 00 
-	Call 77 01 00 00 // ProcessExpression[Probe[main.intSliceArg]@0x4a61aa.expr[0]]
+	Call 45 01 00 00 // ProcessExpression[Probe[main.intSliceArg]@0x4a61aa.expr[0]]
 	Return 
-// 0x1af: ProcessType[map[string]int]
-	ProcessPointer 11 00 00 00 
-	Return 
-// 0x1b5: ProcessExpression[Probe[main.mapArg]@0x4a648a.expr[0]]
+// 0x17d: ProcessExpression[Probe[main.mapArg]@0x4a648a.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
-	Call af 01 00 00 // ProcessType[map[string]int]
+	Call 96 03 00 00 // ProcessType[map[string]int]
 	Return 
-// 0x1d0: ProcessEvent[Probe[main.mapArg]@4a648a]
+// 0x198: ProcessEvent[Probe[main.mapArg]@4a648a]
 	PrepareEventRoot 52 00 00 00 09 00 00 00 
-	Call b5 01 00 00 // ProcessExpression[Probe[main.mapArg]@0x4a648a.expr[0]]
+	Call 7d 01 00 00 // ProcessExpression[Probe[main.mapArg]@0x4a648a.expr[0]]
 	Return 
-// 0x1df: ProcessExpression[Probe[main.stringArg]@0x4a612a.expr[0]]
+// 0x1a7: ProcessExpression[Probe[main.stringArg]@0x4a612a.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprReadRegister 03 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call 27 01 00 00 // ProcessType[string]
+	Call bc 03 00 00 // ProcessType[string]
 	Return 
-// 0x201: ProcessEvent[Probe[main.stringArg]@4a612a]
+// 0x1c9: ProcessEvent[Probe[main.stringArg]@4a612a]
 	PrepareEventRoot 4c 00 00 00 11 00 00 00 
-	Call df 01 00 00 // ProcessExpression[Probe[main.stringArg]@0x4a612a.expr[0]]
+	Call a7 01 00 00 // ProcessExpression[Probe[main.stringArg]@0x4a612a.expr[0]]
 	Return 
-// 0x210: ProcessExpression[Probe[main.stringArrayArg]@0x4a632a.expr[0]]
+// 0x1d8: ProcessExpression[Probe[main.stringArrayArg]@0x4a632a.expr[0]]
 	ExprPrepare 
 	ExprDereferenceCfa 00 00 00 00 30 00 00 00 00 00 00 00 
 	ExprSave 01 00 00 00 30 00 00 00 00 00 00 00 
-	Call 2d 01 00 00 // ProcessType[[3]string]
+	Call d0 02 00 00 // ProcessType[[3]string]
 	Return 
-// 0x231: ProcessEvent[Probe[main.stringArrayArg]@4a632a]
+// 0x1f9: ProcessEvent[Probe[main.stringArrayArg]@4a632a]
 	PrepareEventRoot 50 00 00 00 31 00 00 00 
-	Call 10 02 00 00 // ProcessExpression[Probe[main.stringArrayArg]@0x4a632a.expr[0]]
+	Call d8 01 00 00 // ProcessExpression[Probe[main.stringArrayArg]@0x4a632a.expr[0]]
 	Return 
-// 0x240: ProcessType[[]string]
-	ProcessSlice 45 00 00 00 10 00 00 00 
-	Return 
-// 0x24a: ProcessExpression[Probe[main.stringSliceArg]@0x4a62aa.expr[0]]
+// 0x208: ProcessExpression[Probe[main.stringSliceArg]@0x4a62aa.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprReadRegister 03 08 08 00 00 00 
 	ExprReadRegister 02 08 10 00 00 00 
 	ExprSave 01 00 00 00 18 00 00 00 00 00 00 00 
-	Call 40 02 00 00 // ProcessType[[]string]
+	Call 28 03 00 00 // ProcessType[[]string]
 	Return 
-// 0x273: ProcessEvent[Probe[main.stringSliceArg]@4a62aa]
+// 0x231: ProcessEvent[Probe[main.stringSliceArg]@4a62aa]
 	PrepareEventRoot 4f 00 00 00 19 00 00 00 
-	Call 4a 02 00 00 // ProcessExpression[Probe[main.stringSliceArg]@0x4a62aa.expr[0]]
+	Call 08 02 00 00 // ProcessExpression[Probe[main.stringSliceArg]@0x4a62aa.expr[0]]
 	Return 
-// 0x282: ProcessType[****int]
+// 0x240: ProcessType[*****int]
+	ProcessPointer 03 00 00 00 
+	Return 
+// 0x246: ProcessType[****int]
 	ProcessPointer 04 00 00 00 
 	Return 
-// 0x288: ProcessType[***int]
+// 0x24c: ProcessType[***int]
 	ProcessPointer 05 00 00 00 
 	Return 
-// 0x28e: ProcessType[*int]
-	ProcessPointer 01 00 00 00 
+// 0x252: ProcessType[**int]
+	ProcessPointer 06 00 00 00 
 	Return 
-// 0x294: ProcessType[*uint8]
-	ProcessPointer 09 00 00 00 
-	Return 
-// 0x29a: ProcessType[*string]
-	ProcessPointer 07 00 00 00 
-	Return 
-// 0x2a0: ProcessType[hash<string,int>]
-	ProcessGoHmap 47 00 00 00 d0 00 00 00 08 09 10 18 
-	Return 
-// 0x2ae: ProcessType[*runtime.mapextra]
-	ProcessPointer 1b 00 00 00 
-	Return 
-// 0x2b4: ProcessType[*[]*runtime.bmap]
+// 0x258: ProcessType[*[]*runtime.bmap]
 	ProcessPointer 1d 00 00 00 
 	Return 
-// 0x2ba: ProcessType[*runtime.bmap]
-	ProcessPointer 20 00 00 00 
-	Return 
-// 0x2c0: ProcessType[runtime.mapextra]
-	Call b4 02 00 00 // ProcessType[*[]*runtime.bmap]
-	IncrementOutputOffset 08 00 00 00 
-	Call b4 02 00 00 // ProcessType[*[]*runtime.bmap]
-	IncrementOutputOffset 08 00 00 00 
-	Call ba 02 00 00 // ProcessType[*runtime.bmap]
-	Return 
-// 0x2da: ProcessType[[]*runtime.bmap]
-	ProcessSlice 48 00 00 00 08 00 00 00 
-	Return 
-// 0x2e4: ProcessType[hash<string,main.bigStruct>]
-	ProcessGoHmap 4a 00 00 00 d0 00 00 00 08 09 10 18 
-	Return 
-// 0x2f2: ProcessType[*main.bigStruct]
-	ProcessPointer 28 00 00 00 
-	Return 
-// 0x2f8: ProcessType[*bool]
+// 0x25e: ProcessType[*bool]
 	ProcessPointer 2a 00 00 00 
 	Return 
-// 0x2fe: ProcessType[*uintptr]
-	ProcessPointer 19 00 00 00 
-	Return 
-// 0x304: ProcessType[error]
-	ProcessGoInterface 
-	Return 
-// 0x306: ProcessType[*int32]
-	ProcessPointer 2e 00 00 00 
-	Return 
-// 0x30c: ProcessType[*uint32]
-	ProcessPointer 13 00 00 00 
-	Return 
-// 0x312: ProcessType[*float64]
-	ProcessPointer 33 00 00 00 
-	Return 
-// 0x318: ProcessType[*int64]
-	ProcessPointer 2f 00 00 00 
-	Return 
-// 0x31e: ProcessType[*uint64]
-	ProcessPointer 2d 00 00 00 
-	Return 
-// 0x324: ProcessType[*error]
-	ProcessPointer 34 00 00 00 
-	Return 
-// 0x32a: ProcessType[*float32]
-	ProcessPointer 32 00 00 00 
-	Return 
-// 0x330: ProcessType[*uint]
-	ProcessPointer 31 00 00 00 
-	Return 
-// 0x336: ProcessType[*uint16]
-	ProcessPointer 12 00 00 00 
-	Return 
-// 0x33c: ProcessType[[]string.array]
-	ProcessSliceDataPrep 
-	Call 27 01 00 00 // ProcessType[string]
-	ProcessSliceDataRepeat 10 00 00 00 
-	Return 
-// 0x348: ProcessType[[]key<string>]
-	ProcessArrayDataPrep 80 00 00 00 
-	Call 27 01 00 00 // ProcessType[string]
-	ProcessSliceDataRepeat 10 00 00 00 
-	Return 
-// 0x358: ProcessType[*bucket<string,int>]
+// 0x264: ProcessType[*bucket<string,int>]
 	ProcessPointer 15 00 00 00 
 	Return 
-// 0x35e: ProcessType[bucket<string,int>]
-	IncrementOutputOffset 08 00 00 00 
-	Call 48 03 00 00 // ProcessType[[]key<string>]
-	IncrementOutputOffset 40 00 00 00 
-	Call 58 03 00 00 // ProcessType[*bucket<string,int>]
-	Return 
-// 0x373: ProcessType[[]bucket<string,int>.array]
-	ProcessSliceDataPrep 
-	Call 5e 03 00 00 // ProcessType[bucket<string,int>]
-	ProcessSliceDataRepeat 08 00 00 00 
-	Return 
-// 0x37f: ProcessType[[]*runtime.bmap.array]
-	ProcessSliceDataPrep 
-	Call ba 02 00 00 // ProcessType[*runtime.bmap]
-	ProcessSliceDataRepeat 08 00 00 00 
-	Return 
-// 0x38b: ProcessType[[]val<main.bigStruct>]
-	ProcessArrayDataPrep 40 00 00 00 
-	Call f2 02 00 00 // ProcessType[*main.bigStruct]
-	ProcessSliceDataRepeat 08 00 00 00 
-	Return 
-// 0x39b: ProcessType[*bucket<string,main.bigStruct>]
+// 0x26a: ProcessType[*bucket<string,main.bigStruct>]
 	ProcessPointer 25 00 00 00 
 	Return 
-// 0x3a1: ProcessType[bucket<string,main.bigStruct>]
-	IncrementOutputOffset 08 00 00 00 
-	Call 48 03 00 00 // ProcessType[[]key<string>]
-	Call 8b 03 00 00 // ProcessType[[]val<main.bigStruct>]
-	Call 9b 03 00 00 // ProcessType[*bucket<string,main.bigStruct>]
+// 0x270: ProcessType[*error]
+	ProcessPointer 34 00 00 00 
 	Return 
-// 0x3b6: ProcessType[[]bucket<string,main.bigStruct>.array]
+// 0x276: ProcessType[*float32]
+	ProcessPointer 32 00 00 00 
+	Return 
+// 0x27c: ProcessType[*float64]
+	ProcessPointer 33 00 00 00 
+	Return 
+// 0x282: ProcessType[*int]
+	ProcessPointer 01 00 00 00 
+	Return 
+// 0x288: ProcessType[*int32]
+	ProcessPointer 2e 00 00 00 
+	Return 
+// 0x28e: ProcessType[*int64]
+	ProcessPointer 2f 00 00 00 
+	Return 
+// 0x294: ProcessType[*main.bigStruct]
+	ProcessPointer 28 00 00 00 
+	Return 
+// 0x29a: ProcessType[*runtime.bmap]
+	ProcessPointer 20 00 00 00 
+	Return 
+// 0x2a0: ProcessType[*runtime.mapextra]
+	ProcessPointer 1b 00 00 00 
+	Return 
+// 0x2a6: ProcessType[*string]
+	ProcessPointer 07 00 00 00 
+	Return 
+// 0x2ac: ProcessType[*uint]
+	ProcessPointer 31 00 00 00 
+	Return 
+// 0x2b2: ProcessType[*uint16]
+	ProcessPointer 12 00 00 00 
+	Return 
+// 0x2b8: ProcessType[*uint32]
+	ProcessPointer 13 00 00 00 
+	Return 
+// 0x2be: ProcessType[*uint64]
+	ProcessPointer 2d 00 00 00 
+	Return 
+// 0x2c4: ProcessType[*uint8]
+	ProcessPointer 09 00 00 00 
+	Return 
+// 0x2ca: ProcessType[*uintptr]
+	ProcessPointer 19 00 00 00 
+	Return 
+// 0x2d0: ProcessType[[3]string]
+	ProcessArrayDataPrep 30 00 00 00 
+	Call bc 03 00 00 // ProcessType[string]
+	ProcessSliceDataRepeat 10 00 00 00 
+	Return 
+// 0x2e0: ProcessType[[]*runtime.bmap]
+	ProcessSlice 48 00 00 00 08 00 00 00 
+	Return 
+// 0x2ea: ProcessType[[]*runtime.bmap.array]
 	ProcessSliceDataPrep 
-	Call a1 03 00 00 // ProcessType[bucket<string,main.bigStruct>]
+	Call 9a 02 00 00 // ProcessType[*runtime.bmap]
 	ProcessSliceDataRepeat 08 00 00 00 
+	Return 
+// 0x2f6: ProcessType[[]bucket<string,int>.array]
+	ProcessSliceDataPrep 
+	Call 4e 03 00 00 // ProcessType[bucket<string,int>]
+	ProcessSliceDataRepeat 08 00 00 00 
+	Return 
+// 0x302: ProcessType[[]bucket<string,main.bigStruct>.array]
+	ProcessSliceDataPrep 
+	Call 63 03 00 00 // ProcessType[bucket<string,main.bigStruct>]
+	ProcessSliceDataRepeat 08 00 00 00 
+	Return 
+// 0x30e: ProcessType[[]int]
+	ProcessSlice 43 00 00 00 08 00 00 00 
+	Return 
+// 0x318: ProcessType[[]key<string>]
+	ProcessArrayDataPrep 80 00 00 00 
+	Call bc 03 00 00 // ProcessType[string]
+	ProcessSliceDataRepeat 10 00 00 00 
+	Return 
+// 0x328: ProcessType[[]string]
+	ProcessSlice 45 00 00 00 10 00 00 00 
+	Return 
+// 0x332: ProcessType[[]string.array]
+	ProcessSliceDataPrep 
+	Call bc 03 00 00 // ProcessType[string]
+	ProcessSliceDataRepeat 10 00 00 00 
+	Return 
+// 0x33e: ProcessType[[]val<main.bigStruct>]
+	ProcessArrayDataPrep 40 00 00 00 
+	Call 94 02 00 00 // ProcessType[*main.bigStruct]
+	ProcessSliceDataRepeat 08 00 00 00 
+	Return 
+// 0x34e: ProcessType[bucket<string,int>]
+	IncrementOutputOffset 08 00 00 00 
+	Call 18 03 00 00 // ProcessType[[]key<string>]
+	IncrementOutputOffset 40 00 00 00 
+	Call 64 02 00 00 // ProcessType[*bucket<string,int>]
+	Return 
+// 0x363: ProcessType[bucket<string,main.bigStruct>]
+	IncrementOutputOffset 08 00 00 00 
+	Call 18 03 00 00 // ProcessType[[]key<string>]
+	Call 3e 03 00 00 // ProcessType[[]val<main.bigStruct>]
+	Call 6a 02 00 00 // ProcessType[*bucket<string,main.bigStruct>]
+	Return 
+// 0x378: ProcessType[error]
+	ProcessGoInterface 
+	Return 
+// 0x37a: ProcessType[hash<string,int>]
+	ProcessGoHmap 47 00 00 00 d0 00 00 00 08 09 10 18 
+	Return 
+// 0x388: ProcessType[hash<string,main.bigStruct>]
+	ProcessGoHmap 4a 00 00 00 d0 00 00 00 08 09 10 18 
+	Return 
+// 0x396: ProcessType[map[string]int]
+	ProcessPointer 11 00 00 00 
+	Return 
+// 0x39c: ProcessType[map[string]main.bigStruct]
+	ProcessPointer 23 00 00 00 
+	Return 
+// 0x3a2: ProcessType[runtime.mapextra]
+	Call 58 02 00 00 // ProcessType[*[]*runtime.bmap]
+	IncrementOutputOffset 08 00 00 00 
+	Call 58 02 00 00 // ProcessType[*[]*runtime.bmap]
+	IncrementOutputOffset 08 00 00 00 
+	Call 9a 02 00 00 // ProcessType[*runtime.bmap]
+	Return 
+// 0x3bc: ProcessType[string]
+	ProcessString 41 00 00 00 
 	Return 
 // Extra illegal ops to simplify code bound checks
 	Illegal 
@@ -303,49 +303,49 @@
 	Illegal 
 // Types
 ID: 1 Len: 8 Enqueue: 0
-ID: 2 Len: 8 Enqueue: 3
-ID: 3 Len: 8 Enqueue: 642
-ID: 4 Len: 8 Enqueue: 648
-ID: 5 Len: 8 Enqueue: 51
-ID: 6 Len: 8 Enqueue: 654
-ID: 7 Len: 16 Enqueue: 295
-ID: 8 Len: 8 Enqueue: 660
+ID: 2 Len: 8 Enqueue: 576
+ID: 3 Len: 8 Enqueue: 582
+ID: 4 Len: 8 Enqueue: 588
+ID: 5 Len: 8 Enqueue: 594
+ID: 6 Len: 8 Enqueue: 642
+ID: 7 Len: 16 Enqueue: 956
+ID: 8 Len: 8 Enqueue: 708
 ID: 9 Len: 1 Enqueue: 0
-ID: 10 Len: 24 Enqueue: 365
+ID: 10 Len: 24 Enqueue: 782
 ID: 11 Len: 24 Enqueue: 0
-ID: 12 Len: 24 Enqueue: 576
-ID: 13 Len: 8 Enqueue: 666
-ID: 14 Len: 48 Enqueue: 301
-ID: 15 Len: 8 Enqueue: 431
+ID: 12 Len: 24 Enqueue: 808
+ID: 13 Len: 8 Enqueue: 678
+ID: 14 Len: 48 Enqueue: 720
+ID: 15 Len: 8 Enqueue: 918
 ID: 16 Len: 8 Enqueue: 0
-ID: 17 Len: 48 Enqueue: 672
+ID: 17 Len: 48 Enqueue: 890
 ID: 18 Len: 2 Enqueue: 0
 ID: 19 Len: 4 Enqueue: 0
-ID: 20 Len: 8 Enqueue: 856
-ID: 21 Len: 208 Enqueue: 862
+ID: 20 Len: 8 Enqueue: 612
+ID: 21 Len: 208 Enqueue: 846
 ID: 22 Len: 8 Enqueue: 0
-ID: 23 Len: 128 Enqueue: 840
+ID: 23 Len: 128 Enqueue: 792
 ID: 24 Len: 64 Enqueue: 0
 ID: 25 Len: 8 Enqueue: 0
-ID: 26 Len: 8 Enqueue: 686
-ID: 27 Len: 24 Enqueue: 704
-ID: 28 Len: 8 Enqueue: 692
-ID: 29 Len: 24 Enqueue: 730
+ID: 26 Len: 8 Enqueue: 672
+ID: 27 Len: 24 Enqueue: 930
+ID: 28 Len: 8 Enqueue: 600
+ID: 29 Len: 24 Enqueue: 736
 ID: 30 Len: 8 Enqueue: 0
-ID: 31 Len: 8 Enqueue: 698
+ID: 31 Len: 8 Enqueue: 666
 ID: 32 Len: 8 Enqueue: 0
-ID: 33 Len: 8 Enqueue: 99
+ID: 33 Len: 8 Enqueue: 924
 ID: 34 Len: 8 Enqueue: 0
-ID: 35 Len: 48 Enqueue: 740
-ID: 36 Len: 8 Enqueue: 923
-ID: 37 Len: 208 Enqueue: 929
-ID: 38 Len: 64 Enqueue: 907
-ID: 39 Len: 8 Enqueue: 754
+ID: 35 Len: 48 Enqueue: 904
+ID: 36 Len: 8 Enqueue: 618
+ID: 37 Len: 208 Enqueue: 867
+ID: 38 Len: 64 Enqueue: 830
+ID: 39 Len: 8 Enqueue: 660
 ID: 40 Len: 184 Enqueue: 0
 ID: 41 Len: 128 Enqueue: 0
 ID: 42 Len: 1 Enqueue: 0
-ID: 43 Len: 8 Enqueue: 760
-ID: 44 Len: 8 Enqueue: 766
+ID: 43 Len: 8 Enqueue: 606
+ID: 44 Len: 8 Enqueue: 714
 ID: 45 Len: 8 Enqueue: 0
 ID: 46 Len: 4 Enqueue: 0
 ID: 47 Len: 8 Enqueue: 0
@@ -353,29 +353,29 @@ ID: 48 Len: 1 Enqueue: 0
 ID: 49 Len: 8 Enqueue: 0
 ID: 50 Len: 4 Enqueue: 0
 ID: 51 Len: 8 Enqueue: 0
-ID: 52 Len: 16 Enqueue: 772
+ID: 52 Len: 16 Enqueue: 888
 ID: 53 Len: 8 Enqueue: 0
-ID: 54 Len: 8 Enqueue: 774
-ID: 55 Len: 8 Enqueue: 780
+ID: 54 Len: 8 Enqueue: 648
+ID: 55 Len: 8 Enqueue: 696
 ID: 56 Len: 8 Enqueue: 0
 ID: 57 Len: 16 Enqueue: 0
-ID: 58 Len: 8 Enqueue: 786
-ID: 59 Len: 8 Enqueue: 792
-ID: 60 Len: 8 Enqueue: 798
-ID: 61 Len: 8 Enqueue: 804
-ID: 62 Len: 8 Enqueue: 810
-ID: 63 Len: 8 Enqueue: 816
-ID: 64 Len: 8 Enqueue: 822
+ID: 58 Len: 8 Enqueue: 636
+ID: 59 Len: 8 Enqueue: 654
+ID: 60 Len: 8 Enqueue: 702
+ID: 61 Len: 8 Enqueue: 624
+ID: 62 Len: 8 Enqueue: 630
+ID: 63 Len: 8 Enqueue: 684
+ID: 64 Len: 8 Enqueue: 690
 ID: 65 Len: 2048 Enqueue: 0
 ID: 66 Len: 8 Enqueue: 0
 ID: 67 Len: 2048 Enqueue: 0
 ID: 68 Len: 8 Enqueue: 0
-ID: 69 Len: 2048 Enqueue: 828
+ID: 69 Len: 2048 Enqueue: 818
 ID: 70 Len: 8 Enqueue: 0
-ID: 71 Len: 2048 Enqueue: 883
-ID: 72 Len: 2048 Enqueue: 895
+ID: 71 Len: 2048 Enqueue: 758
+ID: 72 Len: 2048 Enqueue: 746
 ID: 73 Len: 8 Enqueue: 0
-ID: 74 Len: 2048 Enqueue: 950
+ID: 74 Len: 2048 Enqueue: 770
 ID: 75 Len: 9 Enqueue: 0
 ID: 76 Len: 17 Enqueue: 0
 ID: 77 Len: 25 Enqueue: 0

--- a/pkg/dyninst/compiler/testdata/snapshot/simple.arch=amd64,toolchain=go1.23.11.sm.txt
+++ b/pkg/dyninst/compiler/testdata/snapshot/simple.arch=amd64,toolchain=go1.23.11.sm.txt
@@ -10,7 +10,7 @@
 	Call 40 02 00 00 // ProcessType[*****int]
 	Return 
 // 0x1e: ProcessEvent[Probe[main.PointerChainArg]@4a6006]
-	PrepareEventRoot 55 00 00 00 09 00 00 00 
+	PrepareEventRoot 4e 00 00 00 09 00 00 00 
 	Call 03 00 00 00 // ProcessExpression[Probe[main.PointerChainArg]@0x4a6006.expr[0]]
 	Return 
 // 0x2d: ProcessExpression[Probe[main.PointerSmallChainArg]@0x4a6050.expr[0]]
@@ -20,17 +20,17 @@
 	Call 52 02 00 00 // ProcessType[**int]
 	Return 
 // 0x48: ProcessEvent[Probe[main.PointerSmallChainArg]@4a6050]
-	PrepareEventRoot 56 00 00 00 09 00 00 00 
+	PrepareEventRoot 4f 00 00 00 09 00 00 00 
 	Call 2d 00 00 00 // ProcessExpression[Probe[main.PointerSmallChainArg]@0x4a6050.expr[0]]
 	Return 
 // 0x57: ProcessExpression[Probe[main.bigMapArg]@0x4a64f3.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
-	Call 9c 03 00 00 // ProcessType[map[string]main.bigStruct]
+	Call 7a 03 00 00 // ProcessType[map[string]main.bigStruct]
 	Return 
 // 0x72: ProcessEvent[Probe[main.bigMapArg]@4a64f3]
-	PrepareEventRoot 53 00 00 00 09 00 00 00 
+	PrepareEventRoot 4c 00 00 00 09 00 00 00 
 	Call 57 00 00 00 // ProcessExpression[Probe[main.bigMapArg]@0x4a64f3.expr[0]]
 	Return 
 // 0x81: ProcessExpression[Probe[main.inlined]@0x4a63ca.expr[0]]
@@ -39,7 +39,7 @@
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
 	Return 
 // 0x97: ProcessEvent[Probe[main.inlined]@4a63ca]
-	PrepareEventRoot 54 00 00 00 09 00 00 00 
+	PrepareEventRoot 4d 00 00 00 09 00 00 00 
 	Call 81 00 00 00 // ProcessExpression[Probe[main.inlined]@0x4a63ca.expr[0]]
 	Return 
 // 0xa6: ProcessExpression[Probe[main.inlined]@0x4a5dce.expr[0]]
@@ -48,7 +48,7 @@
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
 	Return 
 // 0xb6: ProcessEvent[Probe[main.inlined]@4a5dce]
-	PrepareEventRoot 54 00 00 00 09 00 00 00 
+	PrepareEventRoot 4d 00 00 00 09 00 00 00 
 	Call a6 00 00 00 // ProcessExpression[Probe[main.inlined]@0x4a5dce.expr[0]]
 	Return 
 // 0xc5: ProcessExpression[Probe[main.intArg]@0x4a60aa.expr[0]]
@@ -57,7 +57,7 @@
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
 	Return 
 // 0xdb: ProcessEvent[Probe[main.intArg]@4a60aa]
-	PrepareEventRoot 4b 00 00 00 09 00 00 00 
+	PrepareEventRoot 44 00 00 00 09 00 00 00 
 	Call c5 00 00 00 // ProcessExpression[Probe[main.intArg]@0x4a60aa.expr[0]]
 	Return 
 // 0xea: ProcessExpression[Probe[main.intArrayArg]@0x4a622a.expr[0]]
@@ -66,17 +66,17 @@
 	ExprSave 01 00 00 00 18 00 00 00 00 00 00 00 
 	Return 
 // 0x106: ProcessEvent[Probe[main.intArrayArg]@4a622a]
-	PrepareEventRoot 4e 00 00 00 19 00 00 00 
+	PrepareEventRoot 47 00 00 00 19 00 00 00 
 	Call ea 00 00 00 // ProcessExpression[Probe[main.intArrayArg]@0x4a622a.expr[0]]
 	Return 
 // 0x115: ProcessExpression[Probe[main.stringArrayArgFrameless]@0x4a63a0.expr[0]]
 	ExprPrepare 
 	ExprDereferenceCfa 00 00 00 00 30 00 00 00 00 00 00 00 
 	ExprSave 01 00 00 00 30 00 00 00 00 00 00 00 
-	Call d0 02 00 00 // ProcessType[[3]string]
+	Call c4 02 00 00 // ProcessType[[3]string]
 	Return 
 // 0x136: ProcessEvent[Probe[main.stringArrayArgFrameless]@4a63a0]
-	PrepareEventRoot 51 00 00 00 31 00 00 00 
+	PrepareEventRoot 4a 00 00 00 31 00 00 00 
 	Call 15 01 00 00 // ProcessExpression[Probe[main.stringArrayArgFrameless]@0x4a63a0.expr[0]]
 	Return 
 // 0x145: ProcessExpression[Probe[main.intSliceArg]@0x4a61aa.expr[0]]
@@ -85,20 +85,20 @@
 	ExprReadRegister 03 08 08 00 00 00 
 	ExprReadRegister 02 08 10 00 00 00 
 	ExprSave 01 00 00 00 18 00 00 00 00 00 00 00 
-	Call 0e 03 00 00 // ProcessType[[]int]
+	Call ec 02 00 00 // ProcessType[[]int]
 	Return 
 // 0x16e: ProcessEvent[Probe[main.intSliceArg]@4a61aa]
-	PrepareEventRoot 4d 00 00 00 19 00 00 00 
+	PrepareEventRoot 46 00 00 00 19 00 00 00 
 	Call 45 01 00 00 // ProcessExpression[Probe[main.intSliceArg]@0x4a61aa.expr[0]]
 	Return 
 // 0x17d: ProcessExpression[Probe[main.mapArg]@0x4a648a.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
-	Call 96 03 00 00 // ProcessType[map[string]int]
+	Call 74 03 00 00 // ProcessType[map[string]int]
 	Return 
 // 0x198: ProcessEvent[Probe[main.mapArg]@4a648a]
-	PrepareEventRoot 52 00 00 00 09 00 00 00 
+	PrepareEventRoot 4b 00 00 00 09 00 00 00 
 	Call 7d 01 00 00 // ProcessExpression[Probe[main.mapArg]@0x4a648a.expr[0]]
 	Return 
 // 0x1a7: ProcessExpression[Probe[main.stringArg]@0x4a612a.expr[0]]
@@ -106,20 +106,20 @@
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprReadRegister 03 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call bc 03 00 00 // ProcessType[string]
+	Call 80 03 00 00 // ProcessType[string]
 	Return 
 // 0x1c9: ProcessEvent[Probe[main.stringArg]@4a612a]
-	PrepareEventRoot 4c 00 00 00 11 00 00 00 
+	PrepareEventRoot 45 00 00 00 11 00 00 00 
 	Call a7 01 00 00 // ProcessExpression[Probe[main.stringArg]@0x4a612a.expr[0]]
 	Return 
 // 0x1d8: ProcessExpression[Probe[main.stringArrayArg]@0x4a632a.expr[0]]
 	ExprPrepare 
 	ExprDereferenceCfa 00 00 00 00 30 00 00 00 00 00 00 00 
 	ExprSave 01 00 00 00 30 00 00 00 00 00 00 00 
-	Call d0 02 00 00 // ProcessType[[3]string]
+	Call c4 02 00 00 // ProcessType[[3]string]
 	Return 
 // 0x1f9: ProcessEvent[Probe[main.stringArrayArg]@4a632a]
-	PrepareEventRoot 50 00 00 00 31 00 00 00 
+	PrepareEventRoot 49 00 00 00 31 00 00 00 
 	Call d8 01 00 00 // ProcessExpression[Probe[main.stringArrayArg]@0x4a632a.expr[0]]
 	Return 
 // 0x208: ProcessExpression[Probe[main.stringSliceArg]@0x4a62aa.expr[0]]
@@ -128,17 +128,17 @@
 	ExprReadRegister 03 08 08 00 00 00 
 	ExprReadRegister 02 08 10 00 00 00 
 	ExprSave 01 00 00 00 18 00 00 00 00 00 00 00 
-	Call 28 03 00 00 // ProcessType[[]string]
+	Call 06 03 00 00 // ProcessType[[]string]
 	Return 
 // 0x231: ProcessEvent[Probe[main.stringSliceArg]@4a62aa]
-	PrepareEventRoot 4f 00 00 00 19 00 00 00 
+	PrepareEventRoot 48 00 00 00 19 00 00 00 
 	Call 08 02 00 00 // ProcessExpression[Probe[main.stringSliceArg]@0x4a62aa.expr[0]]
 	Return 
 // 0x240: ProcessType[*****int]
 	ProcessPointer 32 00 00 00 
 	Return 
 // 0x246: ProcessType[****int]
-	ProcessPointer 3e 00 00 00 
+	ProcessPointer 42 00 00 00 
 	Return 
 // 0x24c: ProcessType[***int]
 	ProcessPointer 33 00 00 00 
@@ -146,146 +146,125 @@
 // 0x252: ProcessType[**int]
 	ProcessPointer 1b 00 00 00 
 	Return 
-// 0x258: ProcessType[*[]*runtime.bmap]
-	ProcessPointer 38 00 00 00 
-	Return 
-// 0x25e: ProcessType[*bool]
+// 0x258: ProcessType[*bool]
 	ProcessPointer 04 00 00 00 
 	Return 
-// 0x264: ProcessType[*bucket<string,int>]
+// 0x25e: ProcessType[*bucket<string,int>]
 	ProcessPointer 29 00 00 00 
 	Return 
-// 0x26a: ProcessType[*bucket<string,main.bigStruct>]
+// 0x264: ProcessType[*bucket<string,main.bigStruct>]
 	ProcessPointer 30 00 00 00 
 	Return 
-// 0x270: ProcessType[*error]
+// 0x26a: ProcessType[*error]
 	ProcessPointer 12 00 00 00 
 	Return 
-// 0x276: ProcessType[*float32]
+// 0x270: ProcessType[*float32]
 	ProcessPointer 10 00 00 00 
 	Return 
-// 0x27c: ProcessType[*float64]
+// 0x276: ProcessType[*float64]
 	ProcessPointer 11 00 00 00 
 	Return 
-// 0x282: ProcessType[*int]
+// 0x27c: ProcessType[*int]
 	ProcessPointer 09 00 00 00 
 	Return 
-// 0x288: ProcessType[*int32]
+// 0x282: ProcessType[*int32]
 	ProcessPointer 0c 00 00 00 
 	Return 
-// 0x28e: ProcessType[*int64]
+// 0x288: ProcessType[*int64]
 	ProcessPointer 0d 00 00 00 
 	Return 
-// 0x294: ProcessType[*main.bigStruct]
-	ProcessPointer 3d 00 00 00 
+// 0x28e: ProcessType[*main.bigStruct]
+	ProcessPointer 40 00 00 00 
 	Return 
-// 0x29a: ProcessType[*runtime.bmap]
-	ProcessPointer 3a 00 00 00 
-	Return 
-// 0x2a0: ProcessType[*runtime.mapextra]
+// 0x294: ProcessType[*runtime.mapextra]
 	ProcessPointer 2b 00 00 00 
 	Return 
-// 0x2a6: ProcessType[*string]
+// 0x29a: ProcessType[*string]
 	ProcessPointer 0a 00 00 00 
 	Return 
-// 0x2ac: ProcessType[*uint]
+// 0x2a0: ProcessType[*uint]
 	ProcessPointer 0f 00 00 00 
 	Return 
-// 0x2b2: ProcessType[*uint16]
+// 0x2a6: ProcessType[*uint16]
 	ProcessPointer 07 00 00 00 
 	Return 
-// 0x2b8: ProcessType[*uint32]
+// 0x2ac: ProcessType[*uint32]
 	ProcessPointer 02 00 00 00 
 	Return 
-// 0x2be: ProcessType[*uint64]
+// 0x2b2: ProcessType[*uint64]
 	ProcessPointer 0b 00 00 00 
 	Return 
-// 0x2c4: ProcessType[*uint8]
+// 0x2b8: ProcessType[*uint8]
 	ProcessPointer 03 00 00 00 
 	Return 
-// 0x2ca: ProcessType[*uintptr]
+// 0x2be: ProcessType[*uintptr]
 	ProcessPointer 01 00 00 00 
 	Return 
-// 0x2d0: ProcessType[[3]string]
+// 0x2c4: ProcessType[[3]string]
 	ProcessArrayDataPrep 30 00 00 00 
-	Call bc 03 00 00 // ProcessType[string]
+	Call 80 03 00 00 // ProcessType[string]
 	ProcessSliceDataRepeat 10 00 00 00 
 	Return 
-// 0x2e0: ProcessType[[]*runtime.bmap]
-	ProcessSlice 49 00 00 00 08 00 00 00 
-	Return 
-// 0x2ea: ProcessType[[]*runtime.bmap.array]
+// 0x2d4: ProcessType[[]bucket<string,int>.array]
 	ProcessSliceDataPrep 
-	Call 9a 02 00 00 // ProcessType[*runtime.bmap]
+	Call 2c 03 00 00 // ProcessType[bucket<string,int>]
 	ProcessSliceDataRepeat 08 00 00 00 
 	Return 
-// 0x2f6: ProcessType[[]bucket<string,int>.array]
+// 0x2e0: ProcessType[[]bucket<string,main.bigStruct>.array]
 	ProcessSliceDataPrep 
-	Call 4e 03 00 00 // ProcessType[bucket<string,int>]
+	Call 41 03 00 00 // ProcessType[bucket<string,main.bigStruct>]
 	ProcessSliceDataRepeat 08 00 00 00 
 	Return 
-// 0x302: ProcessType[[]bucket<string,main.bigStruct>.array]
-	ProcessSliceDataPrep 
-	Call 63 03 00 00 // ProcessType[bucket<string,main.bigStruct>]
-	ProcessSliceDataRepeat 08 00 00 00 
+// 0x2ec: ProcessType[[]int]
+	ProcessSlice 36 00 00 00 08 00 00 00 
 	Return 
-// 0x30e: ProcessType[[]int]
-	ProcessSlice 41 00 00 00 08 00 00 00 
-	Return 
-// 0x318: ProcessType[[]key<string>]
+// 0x2f6: ProcessType[[]key<string>]
 	ProcessArrayDataPrep 80 00 00 00 
-	Call bc 03 00 00 // ProcessType[string]
+	Call 80 03 00 00 // ProcessType[string]
 	ProcessSliceDataRepeat 10 00 00 00 
 	Return 
-// 0x328: ProcessType[[]string]
-	ProcessSlice 43 00 00 00 10 00 00 00 
+// 0x306: ProcessType[[]string]
+	ProcessSlice 38 00 00 00 10 00 00 00 
 	Return 
-// 0x332: ProcessType[[]string.array]
+// 0x310: ProcessType[[]string.array]
 	ProcessSliceDataPrep 
-	Call bc 03 00 00 // ProcessType[string]
+	Call 80 03 00 00 // ProcessType[string]
 	ProcessSliceDataRepeat 10 00 00 00 
 	Return 
-// 0x33e: ProcessType[[]val<main.bigStruct>]
+// 0x31c: ProcessType[[]val<main.bigStruct>]
 	ProcessArrayDataPrep 40 00 00 00 
-	Call 94 02 00 00 // ProcessType[*main.bigStruct]
+	Call 8e 02 00 00 // ProcessType[*main.bigStruct]
 	ProcessSliceDataRepeat 08 00 00 00 
 	Return 
-// 0x34e: ProcessType[bucket<string,int>]
+// 0x32c: ProcessType[bucket<string,int>]
 	IncrementOutputOffset 08 00 00 00 
-	Call 18 03 00 00 // ProcessType[[]key<string>]
+	Call f6 02 00 00 // ProcessType[[]key<string>]
 	IncrementOutputOffset 40 00 00 00 
-	Call 64 02 00 00 // ProcessType[*bucket<string,int>]
+	Call 5e 02 00 00 // ProcessType[*bucket<string,int>]
 	Return 
-// 0x363: ProcessType[bucket<string,main.bigStruct>]
+// 0x341: ProcessType[bucket<string,main.bigStruct>]
 	IncrementOutputOffset 08 00 00 00 
-	Call 18 03 00 00 // ProcessType[[]key<string>]
-	Call 3e 03 00 00 // ProcessType[[]val<main.bigStruct>]
-	Call 6a 02 00 00 // ProcessType[*bucket<string,main.bigStruct>]
+	Call f6 02 00 00 // ProcessType[[]key<string>]
+	Call 1c 03 00 00 // ProcessType[[]val<main.bigStruct>]
+	Call 64 02 00 00 // ProcessType[*bucket<string,main.bigStruct>]
 	Return 
-// 0x378: ProcessType[error]
+// 0x356: ProcessType[error]
 	ProcessGoInterface 
 	Return 
-// 0x37a: ProcessType[hash<string,int>]
-	ProcessGoHmap 45 00 00 00 d0 00 00 00 08 09 10 18 
+// 0x358: ProcessType[hash<string,int>]
+	ProcessGoHmap 3d 00 00 00 d0 00 00 00 08 09 10 18 
 	Return 
-// 0x388: ProcessType[hash<string,main.bigStruct>]
-	ProcessGoHmap 46 00 00 00 d0 00 00 00 08 09 10 18 
+// 0x366: ProcessType[hash<string,main.bigStruct>]
+	ProcessGoHmap 41 00 00 00 d0 00 00 00 08 09 10 18 
 	Return 
-// 0x396: ProcessType[map[string]int]
+// 0x374: ProcessType[map[string]int]
 	ProcessPointer 27 00 00 00 
 	Return 
-// 0x39c: ProcessType[map[string]main.bigStruct]
+// 0x37a: ProcessType[map[string]main.bigStruct]
 	ProcessPointer 2e 00 00 00 
 	Return 
-// 0x3a2: ProcessType[runtime.mapextra]
-	Call 58 02 00 00 // ProcessType[*[]*runtime.bmap]
-	IncrementOutputOffset 08 00 00 00 
-	Call 58 02 00 00 // ProcessType[*[]*runtime.bmap]
-	IncrementOutputOffset 08 00 00 00 
-	Call 9a 02 00 00 // ProcessType[*runtime.bmap]
-	Return 
-// 0x3bc: ProcessType[string]
-	ProcessString 3f 00 00 00 
+// 0x380: ProcessType[string]
+	ProcessString 34 00 00 00 
 	Return 
 // Extra illegal ops to simplify code bound checks
 	Illegal 
@@ -306,12 +285,12 @@ ID: 1 Len: 8 Enqueue: 0
 ID: 2 Len: 4 Enqueue: 0
 ID: 3 Len: 1 Enqueue: 0
 ID: 4 Len: 1 Enqueue: 0
-ID: 5 Len: 8 Enqueue: 606
-ID: 6 Len: 8 Enqueue: 708
+ID: 5 Len: 8 Enqueue: 600
+ID: 6 Len: 8 Enqueue: 696
 ID: 7 Len: 2 Enqueue: 0
-ID: 8 Len: 8 Enqueue: 714
+ID: 8 Len: 8 Enqueue: 702
 ID: 9 Len: 8 Enqueue: 0
-ID: 10 Len: 16 Enqueue: 956
+ID: 10 Len: 16 Enqueue: 896
 ID: 11 Len: 8 Enqueue: 0
 ID: 12 Len: 4 Enqueue: 0
 ID: 13 Len: 8 Enqueue: 0
@@ -319,72 +298,65 @@ ID: 14 Len: 1 Enqueue: 0
 ID: 15 Len: 8 Enqueue: 0
 ID: 16 Len: 4 Enqueue: 0
 ID: 17 Len: 8 Enqueue: 0
-ID: 18 Len: 16 Enqueue: 888
+ID: 18 Len: 16 Enqueue: 854
 ID: 19 Len: 8 Enqueue: 0
-ID: 20 Len: 8 Enqueue: 648
-ID: 21 Len: 8 Enqueue: 696
-ID: 22 Len: 8 Enqueue: 678
+ID: 20 Len: 8 Enqueue: 642
+ID: 21 Len: 8 Enqueue: 684
+ID: 22 Len: 8 Enqueue: 666
 ID: 23 Len: 8 Enqueue: 0
 ID: 24 Len: 16 Enqueue: 0
-ID: 25 Len: 8 Enqueue: 636
-ID: 26 Len: 8 Enqueue: 654
-ID: 27 Len: 8 Enqueue: 642
-ID: 28 Len: 8 Enqueue: 702
-ID: 29 Len: 8 Enqueue: 624
-ID: 30 Len: 8 Enqueue: 630
-ID: 31 Len: 8 Enqueue: 684
-ID: 32 Len: 8 Enqueue: 690
-ID: 33 Len: 24 Enqueue: 782
+ID: 25 Len: 8 Enqueue: 630
+ID: 26 Len: 8 Enqueue: 648
+ID: 27 Len: 8 Enqueue: 636
+ID: 28 Len: 8 Enqueue: 690
+ID: 29 Len: 8 Enqueue: 618
+ID: 30 Len: 8 Enqueue: 624
+ID: 31 Len: 8 Enqueue: 672
+ID: 32 Len: 8 Enqueue: 678
+ID: 33 Len: 24 Enqueue: 748
 ID: 34 Len: 24 Enqueue: 0
-ID: 35 Len: 24 Enqueue: 808
-ID: 36 Len: 48 Enqueue: 720
-ID: 37 Len: 8 Enqueue: 918
+ID: 35 Len: 24 Enqueue: 774
+ID: 36 Len: 48 Enqueue: 708
+ID: 37 Len: 8 Enqueue: 884
 ID: 38 Len: 8 Enqueue: 0
-ID: 39 Len: 48 Enqueue: 890
-ID: 40 Len: 8 Enqueue: 612
-ID: 41 Len: 208 Enqueue: 846
-ID: 42 Len: 8 Enqueue: 672
-ID: 43 Len: 24 Enqueue: 930
-ID: 44 Len: 8 Enqueue: 924
+ID: 39 Len: 48 Enqueue: 856
+ID: 40 Len: 8 Enqueue: 606
+ID: 41 Len: 208 Enqueue: 812
+ID: 42 Len: 8 Enqueue: 660
+ID: 43 Len: 8 Enqueue: 0
+ID: 44 Len: 8 Enqueue: 890
 ID: 45 Len: 8 Enqueue: 0
-ID: 46 Len: 48 Enqueue: 904
-ID: 47 Len: 8 Enqueue: 618
-ID: 48 Len: 208 Enqueue: 867
+ID: 46 Len: 48 Enqueue: 870
+ID: 47 Len: 8 Enqueue: 612
+ID: 48 Len: 208 Enqueue: 833
 ID: 49 Len: 8 Enqueue: 576
 ID: 50 Len: 8 Enqueue: 582
 ID: 51 Len: 8 Enqueue: 594
-ID: 52 Len: 8 Enqueue: 0
-ID: 53 Len: 128 Enqueue: 792
-ID: 54 Len: 64 Enqueue: 0
-ID: 55 Len: 8 Enqueue: 600
-ID: 56 Len: 24 Enqueue: 736
-ID: 57 Len: 8 Enqueue: 666
+ID: 52 Len: 2048 Enqueue: 0
+ID: 53 Len: 8 Enqueue: 0
+ID: 54 Len: 2048 Enqueue: 0
+ID: 55 Len: 8 Enqueue: 0
+ID: 56 Len: 2048 Enqueue: 784
+ID: 57 Len: 8 Enqueue: 0
 ID: 58 Len: 8 Enqueue: 0
-ID: 59 Len: 64 Enqueue: 830
-ID: 60 Len: 8 Enqueue: 660
-ID: 61 Len: 184 Enqueue: 0
-ID: 62 Len: 8 Enqueue: 588
-ID: 63 Len: 2048 Enqueue: 0
-ID: 64 Len: 8 Enqueue: 0
-ID: 65 Len: 2048 Enqueue: 0
-ID: 66 Len: 8 Enqueue: 0
-ID: 67 Len: 2048 Enqueue: 818
-ID: 68 Len: 8 Enqueue: 0
-ID: 69 Len: 2048 Enqueue: 758
-ID: 70 Len: 2048 Enqueue: 770
-ID: 71 Len: 8 Enqueue: 0
-ID: 72 Len: 128 Enqueue: 0
-ID: 73 Len: 2048 Enqueue: 746
-ID: 74 Len: 8 Enqueue: 0
+ID: 59 Len: 128 Enqueue: 758
+ID: 60 Len: 64 Enqueue: 0
+ID: 61 Len: 2048 Enqueue: 724
+ID: 62 Len: 64 Enqueue: 796
+ID: 63 Len: 8 Enqueue: 654
+ID: 64 Len: 184 Enqueue: 0
+ID: 65 Len: 2048 Enqueue: 736
+ID: 66 Len: 8 Enqueue: 588
+ID: 67 Len: 128 Enqueue: 0
+ID: 68 Len: 9 Enqueue: 0
+ID: 69 Len: 17 Enqueue: 0
+ID: 70 Len: 25 Enqueue: 0
+ID: 71 Len: 25 Enqueue: 0
+ID: 72 Len: 25 Enqueue: 0
+ID: 73 Len: 49 Enqueue: 0
+ID: 74 Len: 49 Enqueue: 0
 ID: 75 Len: 9 Enqueue: 0
-ID: 76 Len: 17 Enqueue: 0
-ID: 77 Len: 25 Enqueue: 0
-ID: 78 Len: 25 Enqueue: 0
-ID: 79 Len: 25 Enqueue: 0
-ID: 80 Len: 49 Enqueue: 0
-ID: 81 Len: 49 Enqueue: 0
-ID: 82 Len: 9 Enqueue: 0
-ID: 83 Len: 9 Enqueue: 0
-ID: 84 Len: 9 Enqueue: 0
-ID: 85 Len: 9 Enqueue: 0
-ID: 86 Len: 9 Enqueue: 0
+ID: 76 Len: 9 Enqueue: 0
+ID: 77 Len: 9 Enqueue: 0
+ID: 78 Len: 9 Enqueue: 0
+ID: 79 Len: 9 Enqueue: 0

--- a/pkg/dyninst/compiler/testdata/snapshot/simple.arch=amd64,toolchain=go1.23.11.sm.txt
+++ b/pkg/dyninst/compiler/testdata/snapshot/simple.arch=amd64,toolchain=go1.23.11.sm.txt
@@ -230,7 +230,7 @@
 	ProcessSliceDataRepeat 08 00 00 00 
 	Return 
 // 0x30e: ProcessType[[]int]
-	ProcessSlice 43 00 00 00 08 00 00 00 
+	ProcessSlice 41 00 00 00 08 00 00 00 
 	Return 
 // 0x318: ProcessType[[]key<string>]
 	ProcessArrayDataPrep 80 00 00 00 
@@ -238,7 +238,7 @@
 	ProcessSliceDataRepeat 10 00 00 00 
 	Return 
 // 0x328: ProcessType[[]string]
-	ProcessSlice 45 00 00 00 10 00 00 00 
+	ProcessSlice 43 00 00 00 10 00 00 00 
 	Return 
 // 0x332: ProcessType[[]string.array]
 	ProcessSliceDataPrep 
@@ -266,10 +266,10 @@
 	ProcessGoInterface 
 	Return 
 // 0x37a: ProcessType[hash<string,int>]
-	ProcessGoHmap 47 00 00 00 d0 00 00 00 08 09 10 18 
+	ProcessGoHmap 45 00 00 00 d0 00 00 00 08 09 10 18 
 	Return 
 // 0x388: ProcessType[hash<string,main.bigStruct>]
-	ProcessGoHmap 48 00 00 00 d0 00 00 00 08 09 10 18 
+	ProcessGoHmap 46 00 00 00 d0 00 00 00 08 09 10 18 
 	Return 
 // 0x396: ProcessType[map[string]int]
 	ProcessPointer 27 00 00 00 
@@ -285,7 +285,7 @@
 	Call 9a 02 00 00 // ProcessType[*runtime.bmap]
 	Return 
 // 0x3bc: ProcessType[string]
-	ProcessString 41 00 00 00 
+	ProcessString 3f 00 00 00 
 	Return 
 // Extra illegal ops to simplify code bound checks
 	Illegal 
@@ -364,16 +364,16 @@ ID: 59 Len: 64 Enqueue: 830
 ID: 60 Len: 8 Enqueue: 660
 ID: 61 Len: 184 Enqueue: 0
 ID: 62 Len: 8 Enqueue: 588
-ID: 63 Len: 8 Enqueue: 0
-ID: 64 Len: 128 Enqueue: 0
+ID: 63 Len: 2048 Enqueue: 0
+ID: 64 Len: 8 Enqueue: 0
 ID: 65 Len: 2048 Enqueue: 0
 ID: 66 Len: 8 Enqueue: 0
-ID: 67 Len: 2048 Enqueue: 0
+ID: 67 Len: 2048 Enqueue: 818
 ID: 68 Len: 8 Enqueue: 0
-ID: 69 Len: 2048 Enqueue: 818
-ID: 70 Len: 8 Enqueue: 0
-ID: 71 Len: 2048 Enqueue: 758
-ID: 72 Len: 2048 Enqueue: 770
+ID: 69 Len: 2048 Enqueue: 758
+ID: 70 Len: 2048 Enqueue: 770
+ID: 71 Len: 8 Enqueue: 0
+ID: 72 Len: 128 Enqueue: 0
 ID: 73 Len: 2048 Enqueue: 746
 ID: 74 Len: 8 Enqueue: 0
 ID: 75 Len: 9 Enqueue: 0

--- a/pkg/dyninst/compiler/testdata/snapshot/simple.arch=amd64,toolchain=go1.24.3.sm.txt
+++ b/pkg/dyninst/compiler/testdata/snapshot/simple.arch=amd64,toolchain=go1.24.3.sm.txt
@@ -3,293 +3,293 @@
 // 0x1: ChasePointers
 	ChasePointers 
 	Return 
-// 0x3: ProcessType[*****int]
-	ProcessPointer 03 00 00 00 
-	Return 
-// 0x9: ProcessExpression[Probe[main.PointerChainArg]@0x4a8006.expr[0]]
+// 0x3: ProcessExpression[Probe[main.PointerChainArg]@0x4a8006.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
-	Call 03 00 00 00 // ProcessType[*****int]
+	Call 40 02 00 00 // ProcessType[*****int]
 	Return 
-// 0x24: ProcessEvent[Probe[main.PointerChainArg]@4a8006]
+// 0x1e: ProcessEvent[Probe[main.PointerChainArg]@4a8006]
 	PrepareEventRoot 56 00 00 00 09 00 00 00 
-	Call 09 00 00 00 // ProcessExpression[Probe[main.PointerChainArg]@0x4a8006.expr[0]]
+	Call 03 00 00 00 // ProcessExpression[Probe[main.PointerChainArg]@0x4a8006.expr[0]]
 	Return 
-// 0x33: ProcessType[**int]
-	ProcessPointer 06 00 00 00 
-	Return 
-// 0x39: ProcessExpression[Probe[main.PointerSmallChainArg]@0x4a8050.expr[0]]
+// 0x2d: ProcessExpression[Probe[main.PointerSmallChainArg]@0x4a8050.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 01 08 00 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
-	Call 33 00 00 00 // ProcessType[**int]
+	Call 52 02 00 00 // ProcessType[**int]
 	Return 
-// 0x54: ProcessEvent[Probe[main.PointerSmallChainArg]@4a8050]
+// 0x48: ProcessEvent[Probe[main.PointerSmallChainArg]@4a8050]
 	PrepareEventRoot 57 00 00 00 09 00 00 00 
-	Call 39 00 00 00 // ProcessExpression[Probe[main.PointerSmallChainArg]@0x4a8050.expr[0]]
+	Call 2d 00 00 00 // ProcessExpression[Probe[main.PointerSmallChainArg]@0x4a8050.expr[0]]
 	Return 
-// 0x63: ProcessType[map[string]main.bigStruct]
-	ProcessPointer 1f 00 00 00 
-	Return 
-// 0x69: ProcessExpression[Probe[main.bigMapArg]@0x4a84f3.expr[0]]
+// 0x57: ProcessExpression[Probe[main.bigMapArg]@0x4a84f3.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
-	Call 63 00 00 00 // ProcessType[map[string]main.bigStruct]
+	Call 56 03 00 00 // ProcessType[map[string]main.bigStruct]
 	Return 
-// 0x84: ProcessEvent[Probe[main.bigMapArg]@4a84f3]
+// 0x72: ProcessEvent[Probe[main.bigMapArg]@4a84f3]
 	PrepareEventRoot 54 00 00 00 09 00 00 00 
-	Call 69 00 00 00 // ProcessExpression[Probe[main.bigMapArg]@0x4a84f3.expr[0]]
+	Call 57 00 00 00 // ProcessExpression[Probe[main.bigMapArg]@0x4a84f3.expr[0]]
 	Return 
-// 0x93: ProcessExpression[Probe[main.inlined]@0x4a83ca.expr[0]]
+// 0x81: ProcessExpression[Probe[main.inlined]@0x4a83ca.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
 	Return 
-// 0xa9: ProcessEvent[Probe[main.inlined]@4a83ca]
+// 0x97: ProcessEvent[Probe[main.inlined]@4a83ca]
 	PrepareEventRoot 55 00 00 00 09 00 00 00 
-	Call 93 00 00 00 // ProcessExpression[Probe[main.inlined]@0x4a83ca.expr[0]]
+	Call 81 00 00 00 // ProcessExpression[Probe[main.inlined]@0x4a83ca.expr[0]]
 	Return 
-// 0xb8: ProcessExpression[Probe[main.inlined]@0x4a7dce.expr[0]]
+// 0xa6: ProcessExpression[Probe[main.inlined]@0x4a7dce.expr[0]]
 	ExprPrepare 
 	Return 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
 	Return 
-// 0xc8: ProcessEvent[Probe[main.inlined]@4a7dce]
+// 0xb6: ProcessEvent[Probe[main.inlined]@4a7dce]
 	PrepareEventRoot 55 00 00 00 09 00 00 00 
-	Call b8 00 00 00 // ProcessExpression[Probe[main.inlined]@0x4a7dce.expr[0]]
+	Call a6 00 00 00 // ProcessExpression[Probe[main.inlined]@0x4a7dce.expr[0]]
 	Return 
-// 0xd7: ProcessExpression[Probe[main.intArg]@0x4a80aa.expr[0]]
+// 0xc5: ProcessExpression[Probe[main.intArg]@0x4a80aa.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
 	Return 
-// 0xed: ProcessEvent[Probe[main.intArg]@4a80aa]
+// 0xdb: ProcessEvent[Probe[main.intArg]@4a80aa]
 	PrepareEventRoot 4c 00 00 00 09 00 00 00 
-	Call d7 00 00 00 // ProcessExpression[Probe[main.intArg]@0x4a80aa.expr[0]]
+	Call c5 00 00 00 // ProcessExpression[Probe[main.intArg]@0x4a80aa.expr[0]]
 	Return 
-// 0xfc: ProcessExpression[Probe[main.intArrayArg]@0x4a822a.expr[0]]
+// 0xea: ProcessExpression[Probe[main.intArrayArg]@0x4a822a.expr[0]]
 	ExprPrepare 
 	ExprDereferenceCfa 00 00 00 00 18 00 00 00 00 00 00 00 
 	ExprSave 01 00 00 00 18 00 00 00 00 00 00 00 
 	Return 
-// 0x118: ProcessEvent[Probe[main.intArrayArg]@4a822a]
+// 0x106: ProcessEvent[Probe[main.intArrayArg]@4a822a]
 	PrepareEventRoot 4f 00 00 00 19 00 00 00 
-	Call fc 00 00 00 // ProcessExpression[Probe[main.intArrayArg]@0x4a822a.expr[0]]
+	Call ea 00 00 00 // ProcessExpression[Probe[main.intArrayArg]@0x4a822a.expr[0]]
 	Return 
-// 0x127: ProcessType[string]
-	ProcessString 42 00 00 00 
-	Return 
-// 0x12d: ProcessType[[3]string]
-	ProcessArrayDataPrep 30 00 00 00 
-	Call 27 01 00 00 // ProcessType[string]
-	ProcessSliceDataRepeat 10 00 00 00 
-	Return 
-// 0x13d: ProcessExpression[Probe[main.stringArrayArgFrameless]@0x4a83a0.expr[0]]
+// 0x115: ProcessExpression[Probe[main.stringArrayArgFrameless]@0x4a83a0.expr[0]]
 	ExprPrepare 
 	ExprDereferenceCfa 00 00 00 00 30 00 00 00 00 00 00 00 
 	ExprSave 01 00 00 00 30 00 00 00 00 00 00 00 
-	Call 2d 01 00 00 // ProcessType[[3]string]
+	Call be 02 00 00 // ProcessType[[3]string]
 	Return 
-// 0x15e: ProcessEvent[Probe[main.stringArrayArgFrameless]@4a83a0]
+// 0x136: ProcessEvent[Probe[main.stringArrayArgFrameless]@4a83a0]
 	PrepareEventRoot 52 00 00 00 31 00 00 00 
-	Call 3d 01 00 00 // ProcessExpression[Probe[main.stringArrayArgFrameless]@0x4a83a0.expr[0]]
+	Call 15 01 00 00 // ProcessExpression[Probe[main.stringArrayArgFrameless]@0x4a83a0.expr[0]]
 	Return 
-// 0x16d: ProcessType[[]int]
-	ProcessSlice 44 00 00 00 08 00 00 00 
-	Return 
-// 0x177: ProcessExpression[Probe[main.intSliceArg]@0x4a81aa.expr[0]]
+// 0x145: ProcessExpression[Probe[main.intSliceArg]@0x4a81aa.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprReadRegister 03 08 08 00 00 00 
 	ExprReadRegister 02 08 10 00 00 00 
 	ExprSave 01 00 00 00 18 00 00 00 00 00 00 00 
-	Call 6d 01 00 00 // ProcessType[[]int]
+	Call e6 02 00 00 // ProcessType[[]int]
 	Return 
-// 0x1a0: ProcessEvent[Probe[main.intSliceArg]@4a81aa]
+// 0x16e: ProcessEvent[Probe[main.intSliceArg]@4a81aa]
 	PrepareEventRoot 4e 00 00 00 19 00 00 00 
-	Call 77 01 00 00 // ProcessExpression[Probe[main.intSliceArg]@0x4a81aa.expr[0]]
+	Call 45 01 00 00 // ProcessExpression[Probe[main.intSliceArg]@0x4a81aa.expr[0]]
 	Return 
-// 0x1af: ProcessType[map[string]int]
-	ProcessPointer 11 00 00 00 
-	Return 
-// 0x1b5: ProcessExpression[Probe[main.mapArg]@0x4a848a.expr[0]]
+// 0x17d: ProcessExpression[Probe[main.mapArg]@0x4a848a.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
-	Call af 01 00 00 // ProcessType[map[string]int]
+	Call 50 03 00 00 // ProcessType[map[string]int]
 	Return 
-// 0x1d0: ProcessEvent[Probe[main.mapArg]@4a848a]
+// 0x198: ProcessEvent[Probe[main.mapArg]@4a848a]
 	PrepareEventRoot 53 00 00 00 09 00 00 00 
-	Call b5 01 00 00 // ProcessExpression[Probe[main.mapArg]@0x4a848a.expr[0]]
+	Call 7d 01 00 00 // ProcessExpression[Probe[main.mapArg]@0x4a848a.expr[0]]
 	Return 
-// 0x1df: ProcessExpression[Probe[main.stringArg]@0x4a812a.expr[0]]
+// 0x1a7: ProcessExpression[Probe[main.stringArg]@0x4a812a.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprReadRegister 03 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call 27 01 00 00 // ProcessType[string]
+	Call a8 03 00 00 // ProcessType[string]
 	Return 
-// 0x201: ProcessEvent[Probe[main.stringArg]@4a812a]
+// 0x1c9: ProcessEvent[Probe[main.stringArg]@4a812a]
 	PrepareEventRoot 4d 00 00 00 11 00 00 00 
-	Call df 01 00 00 // ProcessExpression[Probe[main.stringArg]@0x4a812a.expr[0]]
+	Call a7 01 00 00 // ProcessExpression[Probe[main.stringArg]@0x4a812a.expr[0]]
 	Return 
-// 0x210: ProcessExpression[Probe[main.stringArrayArg]@0x4a832a.expr[0]]
+// 0x1d8: ProcessExpression[Probe[main.stringArrayArg]@0x4a832a.expr[0]]
 	ExprPrepare 
 	ExprDereferenceCfa 00 00 00 00 30 00 00 00 00 00 00 00 
 	ExprSave 01 00 00 00 30 00 00 00 00 00 00 00 
-	Call 2d 01 00 00 // ProcessType[[3]string]
+	Call be 02 00 00 // ProcessType[[3]string]
 	Return 
-// 0x231: ProcessEvent[Probe[main.stringArrayArg]@4a832a]
+// 0x1f9: ProcessEvent[Probe[main.stringArrayArg]@4a832a]
 	PrepareEventRoot 51 00 00 00 31 00 00 00 
-	Call 10 02 00 00 // ProcessExpression[Probe[main.stringArrayArg]@0x4a832a.expr[0]]
+	Call d8 01 00 00 // ProcessExpression[Probe[main.stringArrayArg]@0x4a832a.expr[0]]
 	Return 
-// 0x240: ProcessType[[]string]
-	ProcessSlice 46 00 00 00 10 00 00 00 
-	Return 
-// 0x24a: ProcessExpression[Probe[main.stringSliceArg]@0x4a82aa.expr[0]]
+// 0x208: ProcessExpression[Probe[main.stringSliceArg]@0x4a82aa.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprReadRegister 03 08 08 00 00 00 
 	ExprReadRegister 02 08 10 00 00 00 
 	ExprSave 01 00 00 00 18 00 00 00 00 00 00 00 
-	Call 40 02 00 00 // ProcessType[[]string]
+	Call 08 03 00 00 // ProcessType[[]string]
 	Return 
-// 0x273: ProcessEvent[Probe[main.stringSliceArg]@4a82aa]
+// 0x231: ProcessEvent[Probe[main.stringSliceArg]@4a82aa]
 	PrepareEventRoot 50 00 00 00 19 00 00 00 
-	Call 4a 02 00 00 // ProcessExpression[Probe[main.stringSliceArg]@0x4a82aa.expr[0]]
+	Call 08 02 00 00 // ProcessExpression[Probe[main.stringSliceArg]@0x4a82aa.expr[0]]
 	Return 
-// 0x282: ProcessType[****int]
+// 0x240: ProcessType[*****int]
+	ProcessPointer 03 00 00 00 
+	Return 
+// 0x246: ProcessType[****int]
 	ProcessPointer 04 00 00 00 
 	Return 
-// 0x288: ProcessType[***int]
+// 0x24c: ProcessType[***int]
 	ProcessPointer 05 00 00 00 
 	Return 
-// 0x28e: ProcessType[*int]
-	ProcessPointer 01 00 00 00 
+// 0x252: ProcessType[**int]
+	ProcessPointer 06 00 00 00 
 	Return 
-// 0x294: ProcessType[*uint8]
-	ProcessPointer 09 00 00 00 
-	Return 
-// 0x29a: ProcessType[*string]
-	ProcessPointer 07 00 00 00 
-	Return 
-// 0x2a0: ProcessType[map<string,int>]
-	ProcessGoSwissMap 48 00 00 00 1a 00 00 00 10 18 
-	Return 
-// 0x2ac: ProcessType[noalg.struct { key string; elem int }]
-	Call 27 01 00 00 // ProcessType[string]
-	Return 
-// 0x2b2: ProcessType[noalg.[8]struct { key string; elem int }]
-	ProcessArrayDataPrep c0 00 00 00 
-	Call ac 02 00 00 // ProcessType[noalg.struct { key string; elem int }]
-	ProcessSliceDataRepeat 18 00 00 00 
-	Return 
-// 0x2c2: ProcessType[noalg.map.group[string]int]
-	IncrementOutputOffset 08 00 00 00 
-	Call b2 02 00 00 // ProcessType[noalg.[8]struct { key string; elem int }]
-	Return 
-// 0x2cd: ProcessType[map<string,main.bigStruct>]
-	ProcessGoSwissMap 4a 00 00 00 25 00 00 00 10 18 
-	Return 
-// 0x2d9: ProcessType[*main.bigStruct]
-	ProcessPointer 29 00 00 00 
-	Return 
-// 0x2df: ProcessType[noalg.struct { key string; elem *main.bigStruct }]
-	Call 27 01 00 00 // ProcessType[string]
-	IncrementOutputOffset 10 00 00 00 
-	Call d9 02 00 00 // ProcessType[*main.bigStruct]
-	Return 
-// 0x2ef: ProcessType[noalg.[8]struct { key string; elem *main.bigStruct }]
-	ProcessArrayDataPrep c0 00 00 00 
-	Call df 02 00 00 // ProcessType[noalg.struct { key string; elem *main.bigStruct }]
-	ProcessSliceDataRepeat 08 00 00 00 
-	Return 
-// 0x2ff: ProcessType[noalg.map.group[string]main.bigStruct]
-	IncrementOutputOffset 08 00 00 00 
-	Call ef 02 00 00 // ProcessType[noalg.[8]struct { key string; elem *main.bigStruct }]
-	Return 
-// 0x30a: ProcessType[*bool]
+// 0x258: ProcessType[*bool]
 	ProcessPointer 2c 00 00 00 
 	Return 
-// 0x310: ProcessType[error]
-	ProcessGoInterface 
-	Return 
-// 0x312: ProcessType[*uintptr]
-	ProcessPointer 13 00 00 00 
-	Return 
-// 0x318: ProcessType[*int32]
-	ProcessPointer 2d 00 00 00 
-	Return 
-// 0x31e: ProcessType[*uint32]
-	ProcessPointer 2b 00 00 00 
-	Return 
-// 0x324: ProcessType[*float64]
-	ProcessPointer 35 00 00 00 
-	Return 
-// 0x32a: ProcessType[*int64]
-	ProcessPointer 2f 00 00 00 
-	Return 
-// 0x330: ProcessType[*uint64]
-	ProcessPointer 12 00 00 00 
-	Return 
-// 0x336: ProcessType[*error]
+// 0x25e: ProcessType[*error]
 	ProcessPointer 30 00 00 00 
 	Return 
-// 0x33c: ProcessType[*float32]
+// 0x264: ProcessType[*float32]
 	ProcessPointer 34 00 00 00 
 	Return 
-// 0x342: ProcessType[*uint]
-	ProcessPointer 33 00 00 00 
+// 0x26a: ProcessType[*float64]
+	ProcessPointer 35 00 00 00 
 	Return 
-// 0x348: ProcessType[*uint16]
-	ProcessPointer 17 00 00 00 
+// 0x270: ProcessType[*int]
+	ProcessPointer 01 00 00 00 
 	Return 
-// 0x34e: ProcessType[[]string.array]
-	ProcessSliceDataPrep 
-	Call 27 01 00 00 // ProcessType[string]
-	ProcessSliceDataRepeat 10 00 00 00 
+// 0x276: ProcessType[*int32]
+	ProcessPointer 2d 00 00 00 
 	Return 
-// 0x35a: ProcessType[*table<string,int>]
+// 0x27c: ProcessType[*int64]
+	ProcessPointer 2f 00 00 00 
+	Return 
+// 0x282: ProcessType[*main.bigStruct]
+	ProcessPointer 29 00 00 00 
+	Return 
+// 0x288: ProcessType[*string]
+	ProcessPointer 07 00 00 00 
+	Return 
+// 0x28e: ProcessType[*table<string,int>]
 	ProcessPointer 16 00 00 00 
 	Return 
-// 0x360: ProcessType[[]*table<string,int>.array]
-	ProcessSliceDataPrep 
-	Call 5a 03 00 00 // ProcessType[*table<string,int>]
-	ProcessSliceDataRepeat 08 00 00 00 
-	Return 
-// 0x36c: ProcessType[*table<string,main.bigStruct>]
+// 0x294: ProcessType[*table<string,main.bigStruct>]
 	ProcessPointer 22 00 00 00 
 	Return 
-// 0x372: ProcessType[[]*table<string,main.bigStruct>.array]
+// 0x29a: ProcessType[*uint]
+	ProcessPointer 33 00 00 00 
+	Return 
+// 0x2a0: ProcessType[*uint16]
+	ProcessPointer 17 00 00 00 
+	Return 
+// 0x2a6: ProcessType[*uint32]
+	ProcessPointer 2b 00 00 00 
+	Return 
+// 0x2ac: ProcessType[*uint64]
+	ProcessPointer 12 00 00 00 
+	Return 
+// 0x2b2: ProcessType[*uint8]
+	ProcessPointer 09 00 00 00 
+	Return 
+// 0x2b8: ProcessType[*uintptr]
+	ProcessPointer 13 00 00 00 
+	Return 
+// 0x2be: ProcessType[[3]string]
+	ProcessArrayDataPrep 30 00 00 00 
+	Call a8 03 00 00 // ProcessType[string]
+	ProcessSliceDataRepeat 10 00 00 00 
+	Return 
+// 0x2ce: ProcessType[[]*table<string,int>.array]
 	ProcessSliceDataPrep 
-	Call 6c 03 00 00 // ProcessType[*table<string,main.bigStruct>]
+	Call 8e 02 00 00 // ProcessType[*table<string,int>]
 	ProcessSliceDataRepeat 08 00 00 00 
 	Return 
-// 0x37e: ProcessType[groupReference<string,int>]
+// 0x2da: ProcessType[[]*table<string,main.bigStruct>.array]
+	ProcessSliceDataPrep 
+	Call 94 02 00 00 // ProcessType[*table<string,main.bigStruct>]
+	ProcessSliceDataRepeat 08 00 00 00 
+	Return 
+// 0x2e6: ProcessType[[]int]
+	ProcessSlice 44 00 00 00 08 00 00 00 
+	Return 
+// 0x2f0: ProcessType[[]noalg.map.group[string]int.array]
+	ProcessSliceDataPrep 
+	Call 7c 03 00 00 // ProcessType[noalg.map.group[string]int]
+	ProcessSliceDataRepeat 00 00 00 00 
+	Return 
+// 0x2fc: ProcessType[[]noalg.map.group[string]main.bigStruct.array]
+	ProcessSliceDataPrep 
+	Call 87 03 00 00 // ProcessType[noalg.map.group[string]main.bigStruct]
+	ProcessSliceDataRepeat 00 00 00 00 
+	Return 
+// 0x308: ProcessType[[]string]
+	ProcessSlice 46 00 00 00 10 00 00 00 
+	Return 
+// 0x312: ProcessType[[]string.array]
+	ProcessSliceDataPrep 
+	Call a8 03 00 00 // ProcessType[string]
+	ProcessSliceDataRepeat 10 00 00 00 
+	Return 
+// 0x31e: ProcessType[error]
+	ProcessGoInterface 
+	Return 
+// 0x320: ProcessType[groupReference<string,int>]
 	ProcessGoSwissMapGroups 49 00 00 00 c8 00 00 00 00 08 
 	Return 
-// 0x38a: ProcessType[table<string,int>]
-	IncrementOutputOffset 10 00 00 00 
-	Call 7e 03 00 00 // ProcessType[groupReference<string,int>]
-	Return 
-// 0x395: ProcessType[groupReference<string,main.bigStruct>]
+// 0x32c: ProcessType[groupReference<string,main.bigStruct>]
 	ProcessGoSwissMapGroups 4b 00 00 00 c8 00 00 00 00 08 
 	Return 
-// 0x3a1: ProcessType[table<string,main.bigStruct>]
+// 0x338: ProcessType[map<string,int>]
+	ProcessGoSwissMap 48 00 00 00 1a 00 00 00 10 18 
+	Return 
+// 0x344: ProcessType[map<string,main.bigStruct>]
+	ProcessGoSwissMap 4a 00 00 00 25 00 00 00 10 18 
+	Return 
+// 0x350: ProcessType[map[string]int]
+	ProcessPointer 11 00 00 00 
+	Return 
+// 0x356: ProcessType[map[string]main.bigStruct]
+	ProcessPointer 1f 00 00 00 
+	Return 
+// 0x35c: ProcessType[noalg.[8]struct { key string; elem *main.bigStruct }]
+	ProcessArrayDataPrep c0 00 00 00 
+	Call 92 03 00 00 // ProcessType[noalg.struct { key string; elem *main.bigStruct }]
+	ProcessSliceDataRepeat 08 00 00 00 
+	Return 
+// 0x36c: ProcessType[noalg.[8]struct { key string; elem int }]
+	ProcessArrayDataPrep c0 00 00 00 
+	Call a2 03 00 00 // ProcessType[noalg.struct { key string; elem int }]
+	ProcessSliceDataRepeat 18 00 00 00 
+	Return 
+// 0x37c: ProcessType[noalg.map.group[string]int]
+	IncrementOutputOffset 08 00 00 00 
+	Call 6c 03 00 00 // ProcessType[noalg.[8]struct { key string; elem int }]
+	Return 
+// 0x387: ProcessType[noalg.map.group[string]main.bigStruct]
+	IncrementOutputOffset 08 00 00 00 
+	Call 5c 03 00 00 // ProcessType[noalg.[8]struct { key string; elem *main.bigStruct }]
+	Return 
+// 0x392: ProcessType[noalg.struct { key string; elem *main.bigStruct }]
+	Call a8 03 00 00 // ProcessType[string]
 	IncrementOutputOffset 10 00 00 00 
-	Call 95 03 00 00 // ProcessType[groupReference<string,main.bigStruct>]
+	Call 82 02 00 00 // ProcessType[*main.bigStruct]
 	Return 
-// 0x3ac: ProcessType[[]noalg.map.group[string]int.array]
-	ProcessSliceDataPrep 
-	Call c2 02 00 00 // ProcessType[noalg.map.group[string]int]
-	ProcessSliceDataRepeat 00 00 00 00 
+// 0x3a2: ProcessType[noalg.struct { key string; elem int }]
+	Call a8 03 00 00 // ProcessType[string]
 	Return 
-// 0x3b8: ProcessType[[]noalg.map.group[string]main.bigStruct.array]
-	ProcessSliceDataPrep 
-	Call ff 02 00 00 // ProcessType[noalg.map.group[string]main.bigStruct]
-	ProcessSliceDataRepeat 00 00 00 00 
+// 0x3a8: ProcessType[string]
+	ProcessString 42 00 00 00 
+	Return 
+// 0x3ae: ProcessType[table<string,int>]
+	IncrementOutputOffset 10 00 00 00 
+	Call 20 03 00 00 // ProcessType[groupReference<string,int>]
+	Return 
+// 0x3b9: ProcessType[table<string,main.bigStruct>]
+	IncrementOutputOffset 10 00 00 00 
+	Call 2c 03 00 00 // ProcessType[groupReference<string,main.bigStruct>]
 	Return 
 // Extra illegal ops to simplify code bound checks
 	Illegal 
@@ -307,80 +307,80 @@
 	Illegal 
 // Types
 ID: 1 Len: 8 Enqueue: 0
-ID: 2 Len: 8 Enqueue: 3
-ID: 3 Len: 8 Enqueue: 642
-ID: 4 Len: 8 Enqueue: 648
-ID: 5 Len: 8 Enqueue: 51
-ID: 6 Len: 8 Enqueue: 654
-ID: 7 Len: 16 Enqueue: 295
-ID: 8 Len: 8 Enqueue: 660
+ID: 2 Len: 8 Enqueue: 576
+ID: 3 Len: 8 Enqueue: 582
+ID: 4 Len: 8 Enqueue: 588
+ID: 5 Len: 8 Enqueue: 594
+ID: 6 Len: 8 Enqueue: 624
+ID: 7 Len: 16 Enqueue: 936
+ID: 8 Len: 8 Enqueue: 690
 ID: 9 Len: 1 Enqueue: 0
-ID: 10 Len: 24 Enqueue: 365
+ID: 10 Len: 24 Enqueue: 742
 ID: 11 Len: 24 Enqueue: 0
-ID: 12 Len: 24 Enqueue: 576
-ID: 13 Len: 8 Enqueue: 666
-ID: 14 Len: 48 Enqueue: 301
-ID: 15 Len: 8 Enqueue: 431
+ID: 12 Len: 24 Enqueue: 776
+ID: 13 Len: 8 Enqueue: 648
+ID: 14 Len: 48 Enqueue: 702
+ID: 15 Len: 8 Enqueue: 848
 ID: 16 Len: 8 Enqueue: 0
-ID: 17 Len: 48 Enqueue: 672
+ID: 17 Len: 48 Enqueue: 824
 ID: 18 Len: 8 Enqueue: 0
 ID: 19 Len: 8 Enqueue: 0
 ID: 20 Len: 8 Enqueue: 0
-ID: 21 Len: 8 Enqueue: 858
-ID: 22 Len: 32 Enqueue: 906
+ID: 21 Len: 8 Enqueue: 654
+ID: 22 Len: 32 Enqueue: 942
 ID: 23 Len: 2 Enqueue: 0
-ID: 24 Len: 16 Enqueue: 894
+ID: 24 Len: 16 Enqueue: 800
 ID: 25 Len: 8 Enqueue: 0
-ID: 26 Len: 200 Enqueue: 706
-ID: 27 Len: 192 Enqueue: 690
-ID: 28 Len: 24 Enqueue: 684
-ID: 29 Len: 8 Enqueue: 99
+ID: 26 Len: 200 Enqueue: 892
+ID: 27 Len: 192 Enqueue: 876
+ID: 28 Len: 24 Enqueue: 930
+ID: 29 Len: 8 Enqueue: 854
 ID: 30 Len: 8 Enqueue: 0
-ID: 31 Len: 48 Enqueue: 717
+ID: 31 Len: 48 Enqueue: 836
 ID: 32 Len: 8 Enqueue: 0
-ID: 33 Len: 8 Enqueue: 876
-ID: 34 Len: 32 Enqueue: 929
-ID: 35 Len: 16 Enqueue: 917
+ID: 33 Len: 8 Enqueue: 660
+ID: 34 Len: 32 Enqueue: 953
+ID: 35 Len: 16 Enqueue: 812
 ID: 36 Len: 8 Enqueue: 0
-ID: 37 Len: 200 Enqueue: 767
-ID: 38 Len: 192 Enqueue: 751
-ID: 39 Len: 24 Enqueue: 735
-ID: 40 Len: 8 Enqueue: 729
+ID: 37 Len: 200 Enqueue: 903
+ID: 38 Len: 192 Enqueue: 860
+ID: 39 Len: 24 Enqueue: 914
+ID: 40 Len: 8 Enqueue: 642
 ID: 41 Len: 184 Enqueue: 0
 ID: 42 Len: 128 Enqueue: 0
 ID: 43 Len: 4 Enqueue: 0
 ID: 44 Len: 1 Enqueue: 0
 ID: 45 Len: 4 Enqueue: 0
-ID: 46 Len: 8 Enqueue: 778
+ID: 46 Len: 8 Enqueue: 600
 ID: 47 Len: 8 Enqueue: 0
-ID: 48 Len: 16 Enqueue: 784
+ID: 48 Len: 16 Enqueue: 798
 ID: 49 Len: 8 Enqueue: 0
 ID: 50 Len: 1 Enqueue: 0
 ID: 51 Len: 8 Enqueue: 0
 ID: 52 Len: 4 Enqueue: 0
 ID: 53 Len: 8 Enqueue: 0
-ID: 54 Len: 8 Enqueue: 786
-ID: 55 Len: 8 Enqueue: 792
-ID: 56 Len: 8 Enqueue: 798
+ID: 54 Len: 8 Enqueue: 696
+ID: 55 Len: 8 Enqueue: 630
+ID: 56 Len: 8 Enqueue: 678
 ID: 57 Len: 8 Enqueue: 0
 ID: 58 Len: 16 Enqueue: 0
-ID: 59 Len: 8 Enqueue: 804
-ID: 60 Len: 8 Enqueue: 810
-ID: 61 Len: 8 Enqueue: 816
-ID: 62 Len: 8 Enqueue: 822
-ID: 63 Len: 8 Enqueue: 828
-ID: 64 Len: 8 Enqueue: 834
-ID: 65 Len: 8 Enqueue: 840
+ID: 59 Len: 8 Enqueue: 618
+ID: 60 Len: 8 Enqueue: 636
+ID: 61 Len: 8 Enqueue: 684
+ID: 62 Len: 8 Enqueue: 606
+ID: 63 Len: 8 Enqueue: 612
+ID: 64 Len: 8 Enqueue: 666
+ID: 65 Len: 8 Enqueue: 672
 ID: 66 Len: 2048 Enqueue: 0
 ID: 67 Len: 8 Enqueue: 0
 ID: 68 Len: 2048 Enqueue: 0
 ID: 69 Len: 8 Enqueue: 0
-ID: 70 Len: 2048 Enqueue: 846
+ID: 70 Len: 2048 Enqueue: 786
 ID: 71 Len: 8 Enqueue: 0
-ID: 72 Len: 8192 Enqueue: 864
-ID: 73 Len: 2048 Enqueue: 940
-ID: 74 Len: 8192 Enqueue: 882
-ID: 75 Len: 2048 Enqueue: 952
+ID: 72 Len: 8192 Enqueue: 718
+ID: 73 Len: 2048 Enqueue: 752
+ID: 74 Len: 8192 Enqueue: 730
+ID: 75 Len: 2048 Enqueue: 764
 ID: 76 Len: 9 Enqueue: 0
 ID: 77 Len: 17 Enqueue: 0
 ID: 78 Len: 25 Enqueue: 0

--- a/pkg/dyninst/compiler/testdata/snapshot/simple.arch=amd64,toolchain=go1.24.3.sm.txt
+++ b/pkg/dyninst/compiler/testdata/snapshot/simple.arch=amd64,toolchain=go1.24.3.sm.txt
@@ -135,67 +135,67 @@
 	Call 08 02 00 00 // ProcessExpression[Probe[main.stringSliceArg]@0x4a82aa.expr[0]]
 	Return 
 // 0x240: ProcessType[*****int]
-	ProcessPointer 03 00 00 00 
+	ProcessPointer 3f 00 00 00 
 	Return 
 // 0x246: ProcessType[****int]
-	ProcessPointer 04 00 00 00 
+	ProcessPointer 40 00 00 00 
 	Return 
 // 0x24c: ProcessType[***int]
-	ProcessPointer 05 00 00 00 
+	ProcessPointer 41 00 00 00 
 	Return 
 // 0x252: ProcessType[**int]
-	ProcessPointer 06 00 00 00 
+	ProcessPointer 1b 00 00 00 
 	Return 
 // 0x258: ProcessType[*bool]
-	ProcessPointer 2c 00 00 00 
+	ProcessPointer 04 00 00 00 
 	Return 
 // 0x25e: ProcessType[*error]
-	ProcessPointer 30 00 00 00 
+	ProcessPointer 0d 00 00 00 
 	Return 
 // 0x264: ProcessType[*float32]
-	ProcessPointer 34 00 00 00 
+	ProcessPointer 11 00 00 00 
 	Return 
 // 0x26a: ProcessType[*float64]
-	ProcessPointer 35 00 00 00 
-	Return 
-// 0x270: ProcessType[*int]
-	ProcessPointer 01 00 00 00 
-	Return 
-// 0x276: ProcessType[*int32]
-	ProcessPointer 2d 00 00 00 
-	Return 
-// 0x27c: ProcessType[*int64]
-	ProcessPointer 2f 00 00 00 
-	Return 
-// 0x282: ProcessType[*main.bigStruct]
-	ProcessPointer 29 00 00 00 
-	Return 
-// 0x288: ProcessType[*string]
-	ProcessPointer 07 00 00 00 
-	Return 
-// 0x28e: ProcessType[*table<string,int>]
-	ProcessPointer 16 00 00 00 
-	Return 
-// 0x294: ProcessType[*table<string,main.bigStruct>]
-	ProcessPointer 22 00 00 00 
-	Return 
-// 0x29a: ProcessType[*uint]
-	ProcessPointer 33 00 00 00 
-	Return 
-// 0x2a0: ProcessType[*uint16]
-	ProcessPointer 17 00 00 00 
-	Return 
-// 0x2a6: ProcessType[*uint32]
-	ProcessPointer 2b 00 00 00 
-	Return 
-// 0x2ac: ProcessType[*uint64]
 	ProcessPointer 12 00 00 00 
 	Return 
-// 0x2b2: ProcessType[*uint8]
+// 0x270: ProcessType[*int]
+	ProcessPointer 07 00 00 00 
+	Return 
+// 0x276: ProcessType[*int32]
+	ProcessPointer 0a 00 00 00 
+	Return 
+// 0x27c: ProcessType[*int64]
+	ProcessPointer 0c 00 00 00 
+	Return 
+// 0x282: ProcessType[*main.bigStruct]
+	ProcessPointer 3c 00 00 00 
+	Return 
+// 0x288: ProcessType[*string]
 	ProcessPointer 09 00 00 00 
 	Return 
+// 0x28e: ProcessType[*table<string,int>]
+	ProcessPointer 2a 00 00 00 
+	Return 
+// 0x294: ProcessType[*table<string,main.bigStruct>]
+	ProcessPointer 35 00 00 00 
+	Return 
+// 0x29a: ProcessType[*uint]
+	ProcessPointer 10 00 00 00 
+	Return 
+// 0x2a0: ProcessType[*uint16]
+	ProcessPointer 06 00 00 00 
+	Return 
+// 0x2a6: ProcessType[*uint32]
+	ProcessPointer 02 00 00 00 
+	Return 
+// 0x2ac: ProcessType[*uint64]
+	ProcessPointer 08 00 00 00 
+	Return 
+// 0x2b2: ProcessType[*uint8]
+	ProcessPointer 03 00 00 00 
+	Return 
 // 0x2b8: ProcessType[*uintptr]
-	ProcessPointer 13 00 00 00 
+	ProcessPointer 01 00 00 00 
 	Return 
 // 0x2be: ProcessType[[3]string]
 	ProcessArrayDataPrep 30 00 00 00 
@@ -243,16 +243,16 @@
 	ProcessGoSwissMapGroups 4b 00 00 00 c8 00 00 00 00 08 
 	Return 
 // 0x338: ProcessType[map<string,int>]
-	ProcessGoSwissMap 48 00 00 00 1a 00 00 00 10 18 
+	ProcessGoSwissMap 48 00 00 00 2d 00 00 00 10 18 
 	Return 
 // 0x344: ProcessType[map<string,main.bigStruct>]
-	ProcessGoSwissMap 4a 00 00 00 25 00 00 00 10 18 
+	ProcessGoSwissMap 4a 00 00 00 38 00 00 00 10 18 
 	Return 
 // 0x350: ProcessType[map[string]int]
-	ProcessPointer 11 00 00 00 
+	ProcessPointer 27 00 00 00 
 	Return 
 // 0x356: ProcessType[map[string]main.bigStruct]
-	ProcessPointer 1f 00 00 00 
+	ProcessPointer 32 00 00 00 
 	Return 
 // 0x35c: ProcessType[noalg.[8]struct { key string; elem *main.bigStruct }]
 	ProcessArrayDataPrep c0 00 00 00 
@@ -307,70 +307,70 @@
 	Illegal 
 // Types
 ID: 1 Len: 8 Enqueue: 0
-ID: 2 Len: 8 Enqueue: 576
-ID: 3 Len: 8 Enqueue: 582
-ID: 4 Len: 8 Enqueue: 588
-ID: 5 Len: 8 Enqueue: 594
-ID: 6 Len: 8 Enqueue: 624
-ID: 7 Len: 16 Enqueue: 936
-ID: 8 Len: 8 Enqueue: 690
-ID: 9 Len: 1 Enqueue: 0
-ID: 10 Len: 24 Enqueue: 742
-ID: 11 Len: 24 Enqueue: 0
-ID: 12 Len: 24 Enqueue: 776
-ID: 13 Len: 8 Enqueue: 648
-ID: 14 Len: 48 Enqueue: 702
-ID: 15 Len: 8 Enqueue: 848
+ID: 2 Len: 4 Enqueue: 0
+ID: 3 Len: 1 Enqueue: 0
+ID: 4 Len: 1 Enqueue: 0
+ID: 5 Len: 8 Enqueue: 690
+ID: 6 Len: 2 Enqueue: 0
+ID: 7 Len: 8 Enqueue: 0
+ID: 8 Len: 8 Enqueue: 0
+ID: 9 Len: 16 Enqueue: 936
+ID: 10 Len: 4 Enqueue: 0
+ID: 11 Len: 8 Enqueue: 600
+ID: 12 Len: 8 Enqueue: 0
+ID: 13 Len: 16 Enqueue: 798
+ID: 14 Len: 8 Enqueue: 0
+ID: 15 Len: 1 Enqueue: 0
 ID: 16 Len: 8 Enqueue: 0
-ID: 17 Len: 48 Enqueue: 824
+ID: 17 Len: 4 Enqueue: 0
 ID: 18 Len: 8 Enqueue: 0
-ID: 19 Len: 8 Enqueue: 0
-ID: 20 Len: 8 Enqueue: 0
-ID: 21 Len: 8 Enqueue: 654
-ID: 22 Len: 32 Enqueue: 942
-ID: 23 Len: 2 Enqueue: 0
-ID: 24 Len: 16 Enqueue: 800
-ID: 25 Len: 8 Enqueue: 0
-ID: 26 Len: 200 Enqueue: 892
-ID: 27 Len: 192 Enqueue: 876
-ID: 28 Len: 24 Enqueue: 930
-ID: 29 Len: 8 Enqueue: 854
-ID: 30 Len: 8 Enqueue: 0
-ID: 31 Len: 48 Enqueue: 836
-ID: 32 Len: 8 Enqueue: 0
-ID: 33 Len: 8 Enqueue: 660
-ID: 34 Len: 32 Enqueue: 953
-ID: 35 Len: 16 Enqueue: 812
-ID: 36 Len: 8 Enqueue: 0
-ID: 37 Len: 200 Enqueue: 903
-ID: 38 Len: 192 Enqueue: 860
-ID: 39 Len: 24 Enqueue: 914
-ID: 40 Len: 8 Enqueue: 642
-ID: 41 Len: 184 Enqueue: 0
-ID: 42 Len: 128 Enqueue: 0
-ID: 43 Len: 4 Enqueue: 0
-ID: 44 Len: 1 Enqueue: 0
-ID: 45 Len: 4 Enqueue: 0
-ID: 46 Len: 8 Enqueue: 600
-ID: 47 Len: 8 Enqueue: 0
-ID: 48 Len: 16 Enqueue: 798
+ID: 19 Len: 8 Enqueue: 696
+ID: 20 Len: 8 Enqueue: 630
+ID: 21 Len: 8 Enqueue: 678
+ID: 22 Len: 8 Enqueue: 648
+ID: 23 Len: 8 Enqueue: 0
+ID: 24 Len: 16 Enqueue: 0
+ID: 25 Len: 8 Enqueue: 618
+ID: 26 Len: 8 Enqueue: 636
+ID: 27 Len: 8 Enqueue: 624
+ID: 28 Len: 8 Enqueue: 684
+ID: 29 Len: 8 Enqueue: 606
+ID: 30 Len: 8 Enqueue: 612
+ID: 31 Len: 8 Enqueue: 666
+ID: 32 Len: 8 Enqueue: 672
+ID: 33 Len: 24 Enqueue: 742
+ID: 34 Len: 24 Enqueue: 0
+ID: 35 Len: 24 Enqueue: 776
+ID: 36 Len: 48 Enqueue: 702
+ID: 37 Len: 8 Enqueue: 848
+ID: 38 Len: 8 Enqueue: 0
+ID: 39 Len: 48 Enqueue: 824
+ID: 40 Len: 8 Enqueue: 0
+ID: 41 Len: 8 Enqueue: 654
+ID: 42 Len: 32 Enqueue: 942
+ID: 43 Len: 16 Enqueue: 800
+ID: 44 Len: 8 Enqueue: 0
+ID: 45 Len: 200 Enqueue: 892
+ID: 46 Len: 192 Enqueue: 876
+ID: 47 Len: 24 Enqueue: 930
+ID: 48 Len: 8 Enqueue: 854
 ID: 49 Len: 8 Enqueue: 0
-ID: 50 Len: 1 Enqueue: 0
+ID: 50 Len: 48 Enqueue: 836
 ID: 51 Len: 8 Enqueue: 0
-ID: 52 Len: 4 Enqueue: 0
-ID: 53 Len: 8 Enqueue: 0
-ID: 54 Len: 8 Enqueue: 696
-ID: 55 Len: 8 Enqueue: 630
-ID: 56 Len: 8 Enqueue: 678
-ID: 57 Len: 8 Enqueue: 0
-ID: 58 Len: 16 Enqueue: 0
-ID: 59 Len: 8 Enqueue: 618
-ID: 60 Len: 8 Enqueue: 636
-ID: 61 Len: 8 Enqueue: 684
-ID: 62 Len: 8 Enqueue: 606
-ID: 63 Len: 8 Enqueue: 612
-ID: 64 Len: 8 Enqueue: 666
-ID: 65 Len: 8 Enqueue: 672
+ID: 52 Len: 8 Enqueue: 660
+ID: 53 Len: 32 Enqueue: 953
+ID: 54 Len: 16 Enqueue: 812
+ID: 55 Len: 8 Enqueue: 0
+ID: 56 Len: 200 Enqueue: 903
+ID: 57 Len: 192 Enqueue: 860
+ID: 58 Len: 24 Enqueue: 914
+ID: 59 Len: 8 Enqueue: 642
+ID: 60 Len: 184 Enqueue: 0
+ID: 61 Len: 128 Enqueue: 0
+ID: 62 Len: 8 Enqueue: 576
+ID: 63 Len: 8 Enqueue: 582
+ID: 64 Len: 8 Enqueue: 588
+ID: 65 Len: 8 Enqueue: 594
 ID: 66 Len: 2048 Enqueue: 0
 ID: 67 Len: 8 Enqueue: 0
 ID: 68 Len: 2048 Enqueue: 0

--- a/pkg/dyninst/compiler/testdata/snapshot/simple.arch=amd64,toolchain=go1.24.3.sm.txt
+++ b/pkg/dyninst/compiler/testdata/snapshot/simple.arch=amd64,toolchain=go1.24.3.sm.txt
@@ -138,7 +138,7 @@
 	ProcessPointer 30 00 00 00 
 	Return 
 // 0x246: ProcessType[****int]
-	ProcessPointer 34 00 00 00 
+	ProcessPointer 4a 00 00 00 
 	Return 
 // 0x24c: ProcessType[***int]
 	ProcessPointer 31 00 00 00 
@@ -168,16 +168,16 @@
 	ProcessPointer 0c 00 00 00 
 	Return 
 // 0x282: ProcessType[*main.bigStruct]
-	ProcessPointer 48 00 00 00 
+	ProcessPointer 47 00 00 00 
 	Return 
 // 0x288: ProcessType[*string]
 	ProcessPointer 09 00 00 00 
 	Return 
 // 0x28e: ProcessType[*table<string,int>]
-	ProcessPointer 32 00 00 00 
+	ProcessPointer 38 00 00 00 
 	Return 
 // 0x294: ProcessType[*table<string,main.bigStruct>]
-	ProcessPointer 33 00 00 00 
+	ProcessPointer 40 00 00 00 
 	Return 
 // 0x29a: ProcessType[*uint]
 	ProcessPointer 10 00 00 00 
@@ -213,7 +213,7 @@
 	ProcessSliceDataRepeat 08 00 00 00 
 	Return 
 // 0x2e6: ProcessType[[]int]
-	ProcessSlice 37 00 00 00 08 00 00 00 
+	ProcessSlice 34 00 00 00 08 00 00 00 
 	Return 
 // 0x2f0: ProcessType[[]noalg.map.group[string]int.array]
 	ProcessSliceDataPrep 
@@ -226,7 +226,7 @@
 	ProcessSliceDataRepeat 00 00 00 00 
 	Return 
 // 0x308: ProcessType[[]string]
-	ProcessSlice 39 00 00 00 10 00 00 00 
+	ProcessSlice 36 00 00 00 10 00 00 00 
 	Return 
 // 0x312: ProcessType[[]string.array]
 	ProcessSliceDataPrep 
@@ -237,16 +237,16 @@
 	ProcessGoInterface 
 	Return 
 // 0x320: ProcessType[groupReference<string,int>]
-	ProcessGoSwissMapGroups 41 00 00 00 c8 00 00 00 00 08 
+	ProcessGoSwissMapGroups 3f 00 00 00 c8 00 00 00 00 08 
 	Return 
 // 0x32c: ProcessType[groupReference<string,main.bigStruct>]
-	ProcessGoSwissMapGroups 4a 00 00 00 c8 00 00 00 00 08 
+	ProcessGoSwissMapGroups 49 00 00 00 c8 00 00 00 00 08 
 	Return 
 // 0x338: ProcessType[map<string,int>]
-	ProcessGoSwissMap 40 00 00 00 3d 00 00 00 10 18 
+	ProcessGoSwissMap 3e 00 00 00 3b 00 00 00 10 18 
 	Return 
 // 0x344: ProcessType[map<string,main.bigStruct>]
-	ProcessGoSwissMap 49 00 00 00 44 00 00 00 10 18 
+	ProcessGoSwissMap 48 00 00 00 43 00 00 00 10 18 
 	Return 
 // 0x350: ProcessType[map[string]int]
 	ProcessPointer 27 00 00 00 
@@ -281,7 +281,7 @@
 	Call a8 03 00 00 // ProcessType[string]
 	Return 
 // 0x3a8: ProcessType[string]
-	ProcessString 35 00 00 00 
+	ProcessString 32 00 00 00 
 	Return 
 // 0x3ae: ProcessType[table<string,int>]
 	IncrementOutputOffset 10 00 00 00 
@@ -355,31 +355,31 @@ ID: 46 Len: 8 Enqueue: 660
 ID: 47 Len: 8 Enqueue: 576
 ID: 48 Len: 8 Enqueue: 582
 ID: 49 Len: 8 Enqueue: 594
-ID: 50 Len: 32 Enqueue: 942
-ID: 51 Len: 32 Enqueue: 953
-ID: 52 Len: 8 Enqueue: 588
-ID: 53 Len: 2048 Enqueue: 0
-ID: 54 Len: 8 Enqueue: 0
-ID: 55 Len: 2048 Enqueue: 0
-ID: 56 Len: 8 Enqueue: 0
-ID: 57 Len: 2048 Enqueue: 786
+ID: 50 Len: 2048 Enqueue: 0
+ID: 51 Len: 8 Enqueue: 0
+ID: 52 Len: 2048 Enqueue: 0
+ID: 53 Len: 8 Enqueue: 0
+ID: 54 Len: 2048 Enqueue: 786
+ID: 55 Len: 8 Enqueue: 0
+ID: 56 Len: 32 Enqueue: 942
+ID: 57 Len: 16 Enqueue: 800
 ID: 58 Len: 8 Enqueue: 0
-ID: 59 Len: 16 Enqueue: 800
-ID: 60 Len: 8 Enqueue: 0
-ID: 61 Len: 200 Enqueue: 892
-ID: 62 Len: 192 Enqueue: 876
-ID: 63 Len: 24 Enqueue: 930
-ID: 64 Len: 8192 Enqueue: 718
-ID: 65 Len: 2048 Enqueue: 752
-ID: 66 Len: 16 Enqueue: 812
-ID: 67 Len: 8 Enqueue: 0
-ID: 68 Len: 200 Enqueue: 903
-ID: 69 Len: 192 Enqueue: 860
-ID: 70 Len: 24 Enqueue: 914
-ID: 71 Len: 8 Enqueue: 642
-ID: 72 Len: 184 Enqueue: 0
-ID: 73 Len: 8192 Enqueue: 730
-ID: 74 Len: 2048 Enqueue: 764
+ID: 59 Len: 200 Enqueue: 892
+ID: 60 Len: 192 Enqueue: 876
+ID: 61 Len: 24 Enqueue: 930
+ID: 62 Len: 8192 Enqueue: 718
+ID: 63 Len: 2048 Enqueue: 752
+ID: 64 Len: 32 Enqueue: 953
+ID: 65 Len: 16 Enqueue: 812
+ID: 66 Len: 8 Enqueue: 0
+ID: 67 Len: 200 Enqueue: 903
+ID: 68 Len: 192 Enqueue: 860
+ID: 69 Len: 24 Enqueue: 914
+ID: 70 Len: 8 Enqueue: 642
+ID: 71 Len: 184 Enqueue: 0
+ID: 72 Len: 8192 Enqueue: 730
+ID: 73 Len: 2048 Enqueue: 764
+ID: 74 Len: 8 Enqueue: 588
 ID: 75 Len: 128 Enqueue: 0
 ID: 76 Len: 9 Enqueue: 0
 ID: 77 Len: 17 Enqueue: 0

--- a/pkg/dyninst/compiler/testdata/snapshot/simple.arch=amd64,toolchain=go1.24.3.sm.txt
+++ b/pkg/dyninst/compiler/testdata/snapshot/simple.arch=amd64,toolchain=go1.24.3.sm.txt
@@ -135,13 +135,13 @@
 	Call 08 02 00 00 // ProcessExpression[Probe[main.stringSliceArg]@0x4a82aa.expr[0]]
 	Return 
 // 0x240: ProcessType[*****int]
-	ProcessPointer 3f 00 00 00 
+	ProcessPointer 30 00 00 00 
 	Return 
 // 0x246: ProcessType[****int]
-	ProcessPointer 40 00 00 00 
+	ProcessPointer 34 00 00 00 
 	Return 
 // 0x24c: ProcessType[***int]
-	ProcessPointer 41 00 00 00 
+	ProcessPointer 31 00 00 00 
 	Return 
 // 0x252: ProcessType[**int]
 	ProcessPointer 1b 00 00 00 
@@ -168,16 +168,16 @@
 	ProcessPointer 0c 00 00 00 
 	Return 
 // 0x282: ProcessType[*main.bigStruct]
-	ProcessPointer 3c 00 00 00 
+	ProcessPointer 40 00 00 00 
 	Return 
 // 0x288: ProcessType[*string]
 	ProcessPointer 09 00 00 00 
 	Return 
 // 0x28e: ProcessType[*table<string,int>]
-	ProcessPointer 2a 00 00 00 
+	ProcessPointer 32 00 00 00 
 	Return 
 // 0x294: ProcessType[*table<string,main.bigStruct>]
-	ProcessPointer 35 00 00 00 
+	ProcessPointer 33 00 00 00 
 	Return 
 // 0x29a: ProcessType[*uint]
 	ProcessPointer 10 00 00 00 
@@ -243,16 +243,16 @@
 	ProcessGoSwissMapGroups 4b 00 00 00 c8 00 00 00 00 08 
 	Return 
 // 0x338: ProcessType[map<string,int>]
-	ProcessGoSwissMap 48 00 00 00 2d 00 00 00 10 18 
+	ProcessGoSwissMap 48 00 00 00 37 00 00 00 10 18 
 	Return 
 // 0x344: ProcessType[map<string,main.bigStruct>]
-	ProcessGoSwissMap 4a 00 00 00 38 00 00 00 10 18 
+	ProcessGoSwissMap 4a 00 00 00 3a 00 00 00 10 18 
 	Return 
 // 0x350: ProcessType[map[string]int]
 	ProcessPointer 27 00 00 00 
 	Return 
 // 0x356: ProcessType[map[string]main.bigStruct]
-	ProcessPointer 32 00 00 00 
+	ProcessPointer 2c 00 00 00 
 	Return 
 // 0x35c: ProcessType[noalg.[8]struct { key string; elem *main.bigStruct }]
 	ProcessArrayDataPrep c0 00 00 00 
@@ -347,30 +347,30 @@ ID: 38 Len: 8 Enqueue: 0
 ID: 39 Len: 48 Enqueue: 824
 ID: 40 Len: 8 Enqueue: 0
 ID: 41 Len: 8 Enqueue: 654
-ID: 42 Len: 32 Enqueue: 942
-ID: 43 Len: 16 Enqueue: 800
-ID: 44 Len: 8 Enqueue: 0
-ID: 45 Len: 200 Enqueue: 892
-ID: 46 Len: 192 Enqueue: 876
-ID: 47 Len: 24 Enqueue: 930
-ID: 48 Len: 8 Enqueue: 854
-ID: 49 Len: 8 Enqueue: 0
-ID: 50 Len: 48 Enqueue: 836
-ID: 51 Len: 8 Enqueue: 0
-ID: 52 Len: 8 Enqueue: 660
-ID: 53 Len: 32 Enqueue: 953
-ID: 54 Len: 16 Enqueue: 812
-ID: 55 Len: 8 Enqueue: 0
-ID: 56 Len: 200 Enqueue: 903
-ID: 57 Len: 192 Enqueue: 860
-ID: 58 Len: 24 Enqueue: 914
-ID: 59 Len: 8 Enqueue: 642
-ID: 60 Len: 184 Enqueue: 0
-ID: 61 Len: 128 Enqueue: 0
-ID: 62 Len: 8 Enqueue: 576
-ID: 63 Len: 8 Enqueue: 582
-ID: 64 Len: 8 Enqueue: 588
-ID: 65 Len: 8 Enqueue: 594
+ID: 42 Len: 8 Enqueue: 854
+ID: 43 Len: 8 Enqueue: 0
+ID: 44 Len: 48 Enqueue: 836
+ID: 45 Len: 8 Enqueue: 0
+ID: 46 Len: 8 Enqueue: 660
+ID: 47 Len: 8 Enqueue: 576
+ID: 48 Len: 8 Enqueue: 582
+ID: 49 Len: 8 Enqueue: 594
+ID: 50 Len: 32 Enqueue: 942
+ID: 51 Len: 32 Enqueue: 953
+ID: 52 Len: 8 Enqueue: 588
+ID: 53 Len: 16 Enqueue: 800
+ID: 54 Len: 8 Enqueue: 0
+ID: 55 Len: 200 Enqueue: 892
+ID: 56 Len: 16 Enqueue: 812
+ID: 57 Len: 8 Enqueue: 0
+ID: 58 Len: 200 Enqueue: 903
+ID: 59 Len: 192 Enqueue: 876
+ID: 60 Len: 24 Enqueue: 930
+ID: 61 Len: 192 Enqueue: 860
+ID: 62 Len: 24 Enqueue: 914
+ID: 63 Len: 8 Enqueue: 642
+ID: 64 Len: 184 Enqueue: 0
+ID: 65 Len: 128 Enqueue: 0
 ID: 66 Len: 2048 Enqueue: 0
 ID: 67 Len: 8 Enqueue: 0
 ID: 68 Len: 2048 Enqueue: 0

--- a/pkg/dyninst/compiler/testdata/snapshot/simple.arch=amd64,toolchain=go1.24.3.sm.txt
+++ b/pkg/dyninst/compiler/testdata/snapshot/simple.arch=amd64,toolchain=go1.24.3.sm.txt
@@ -168,7 +168,7 @@
 	ProcessPointer 0c 00 00 00 
 	Return 
 // 0x282: ProcessType[*main.bigStruct]
-	ProcessPointer 40 00 00 00 
+	ProcessPointer 48 00 00 00 
 	Return 
 // 0x288: ProcessType[*string]
 	ProcessPointer 09 00 00 00 
@@ -213,7 +213,7 @@
 	ProcessSliceDataRepeat 08 00 00 00 
 	Return 
 // 0x2e6: ProcessType[[]int]
-	ProcessSlice 44 00 00 00 08 00 00 00 
+	ProcessSlice 37 00 00 00 08 00 00 00 
 	Return 
 // 0x2f0: ProcessType[[]noalg.map.group[string]int.array]
 	ProcessSliceDataPrep 
@@ -226,7 +226,7 @@
 	ProcessSliceDataRepeat 00 00 00 00 
 	Return 
 // 0x308: ProcessType[[]string]
-	ProcessSlice 46 00 00 00 10 00 00 00 
+	ProcessSlice 39 00 00 00 10 00 00 00 
 	Return 
 // 0x312: ProcessType[[]string.array]
 	ProcessSliceDataPrep 
@@ -237,16 +237,16 @@
 	ProcessGoInterface 
 	Return 
 // 0x320: ProcessType[groupReference<string,int>]
-	ProcessGoSwissMapGroups 49 00 00 00 c8 00 00 00 00 08 
+	ProcessGoSwissMapGroups 41 00 00 00 c8 00 00 00 00 08 
 	Return 
 // 0x32c: ProcessType[groupReference<string,main.bigStruct>]
-	ProcessGoSwissMapGroups 4b 00 00 00 c8 00 00 00 00 08 
+	ProcessGoSwissMapGroups 4a 00 00 00 c8 00 00 00 00 08 
 	Return 
 // 0x338: ProcessType[map<string,int>]
-	ProcessGoSwissMap 48 00 00 00 37 00 00 00 10 18 
+	ProcessGoSwissMap 40 00 00 00 3d 00 00 00 10 18 
 	Return 
 // 0x344: ProcessType[map<string,main.bigStruct>]
-	ProcessGoSwissMap 4a 00 00 00 3a 00 00 00 10 18 
+	ProcessGoSwissMap 49 00 00 00 44 00 00 00 10 18 
 	Return 
 // 0x350: ProcessType[map[string]int]
 	ProcessPointer 27 00 00 00 
@@ -281,7 +281,7 @@
 	Call a8 03 00 00 // ProcessType[string]
 	Return 
 // 0x3a8: ProcessType[string]
-	ProcessString 42 00 00 00 
+	ProcessString 35 00 00 00 
 	Return 
 // 0x3ae: ProcessType[table<string,int>]
 	IncrementOutputOffset 10 00 00 00 
@@ -358,29 +358,29 @@ ID: 49 Len: 8 Enqueue: 594
 ID: 50 Len: 32 Enqueue: 942
 ID: 51 Len: 32 Enqueue: 953
 ID: 52 Len: 8 Enqueue: 588
-ID: 53 Len: 16 Enqueue: 800
+ID: 53 Len: 2048 Enqueue: 0
 ID: 54 Len: 8 Enqueue: 0
-ID: 55 Len: 200 Enqueue: 892
-ID: 56 Len: 16 Enqueue: 812
-ID: 57 Len: 8 Enqueue: 0
-ID: 58 Len: 200 Enqueue: 903
-ID: 59 Len: 192 Enqueue: 876
-ID: 60 Len: 24 Enqueue: 930
-ID: 61 Len: 192 Enqueue: 860
-ID: 62 Len: 24 Enqueue: 914
-ID: 63 Len: 8 Enqueue: 642
-ID: 64 Len: 184 Enqueue: 0
-ID: 65 Len: 128 Enqueue: 0
-ID: 66 Len: 2048 Enqueue: 0
+ID: 55 Len: 2048 Enqueue: 0
+ID: 56 Len: 8 Enqueue: 0
+ID: 57 Len: 2048 Enqueue: 786
+ID: 58 Len: 8 Enqueue: 0
+ID: 59 Len: 16 Enqueue: 800
+ID: 60 Len: 8 Enqueue: 0
+ID: 61 Len: 200 Enqueue: 892
+ID: 62 Len: 192 Enqueue: 876
+ID: 63 Len: 24 Enqueue: 930
+ID: 64 Len: 8192 Enqueue: 718
+ID: 65 Len: 2048 Enqueue: 752
+ID: 66 Len: 16 Enqueue: 812
 ID: 67 Len: 8 Enqueue: 0
-ID: 68 Len: 2048 Enqueue: 0
-ID: 69 Len: 8 Enqueue: 0
-ID: 70 Len: 2048 Enqueue: 786
-ID: 71 Len: 8 Enqueue: 0
-ID: 72 Len: 8192 Enqueue: 718
-ID: 73 Len: 2048 Enqueue: 752
-ID: 74 Len: 8192 Enqueue: 730
-ID: 75 Len: 2048 Enqueue: 764
+ID: 68 Len: 200 Enqueue: 903
+ID: 69 Len: 192 Enqueue: 860
+ID: 70 Len: 24 Enqueue: 914
+ID: 71 Len: 8 Enqueue: 642
+ID: 72 Len: 184 Enqueue: 0
+ID: 73 Len: 8192 Enqueue: 730
+ID: 74 Len: 2048 Enqueue: 764
+ID: 75 Len: 128 Enqueue: 0
 ID: 76 Len: 9 Enqueue: 0
 ID: 77 Len: 17 Enqueue: 0
 ID: 78 Len: 25 Enqueue: 0

--- a/pkg/dyninst/compiler/testdata/snapshot/simple.arch=amd64,toolchain=go1.25.0.sm.txt
+++ b/pkg/dyninst/compiler/testdata/snapshot/simple.arch=amd64,toolchain=go1.25.0.sm.txt
@@ -138,7 +138,7 @@
 	ProcessPointer 30 00 00 00 
 	Return 
 // 0x246: ProcessType[****int]
-	ProcessPointer 34 00 00 00 
+	ProcessPointer 4a 00 00 00 
 	Return 
 // 0x24c: ProcessType[***int]
 	ProcessPointer 31 00 00 00 
@@ -168,16 +168,16 @@
 	ProcessPointer 0c 00 00 00 
 	Return 
 // 0x282: ProcessType[*main.bigStruct]
-	ProcessPointer 48 00 00 00 
+	ProcessPointer 47 00 00 00 
 	Return 
 // 0x288: ProcessType[*string]
 	ProcessPointer 09 00 00 00 
 	Return 
 // 0x28e: ProcessType[*table<string,int>]
-	ProcessPointer 32 00 00 00 
+	ProcessPointer 38 00 00 00 
 	Return 
 // 0x294: ProcessType[*table<string,main.bigStruct>]
-	ProcessPointer 33 00 00 00 
+	ProcessPointer 40 00 00 00 
 	Return 
 // 0x29a: ProcessType[*uint]
 	ProcessPointer 11 00 00 00 
@@ -213,7 +213,7 @@
 	ProcessSliceDataRepeat 08 00 00 00 
 	Return 
 // 0x2e6: ProcessType[[]int]
-	ProcessSlice 37 00 00 00 08 00 00 00 
+	ProcessSlice 34 00 00 00 08 00 00 00 
 	Return 
 // 0x2f0: ProcessType[[]noalg.map.group[string]int.array]
 	ProcessSliceDataPrep 
@@ -226,7 +226,7 @@
 	ProcessSliceDataRepeat 00 00 00 00 
 	Return 
 // 0x308: ProcessType[[]string]
-	ProcessSlice 39 00 00 00 10 00 00 00 
+	ProcessSlice 36 00 00 00 10 00 00 00 
 	Return 
 // 0x312: ProcessType[[]string.array]
 	ProcessSliceDataPrep 
@@ -237,16 +237,16 @@
 	ProcessGoInterface 
 	Return 
 // 0x320: ProcessType[groupReference<string,int>]
-	ProcessGoSwissMapGroups 41 00 00 00 c8 00 00 00 00 08 
+	ProcessGoSwissMapGroups 3f 00 00 00 c8 00 00 00 00 08 
 	Return 
 // 0x32c: ProcessType[groupReference<string,main.bigStruct>]
-	ProcessGoSwissMapGroups 4a 00 00 00 c8 00 00 00 00 08 
+	ProcessGoSwissMapGroups 49 00 00 00 c8 00 00 00 00 08 
 	Return 
 // 0x338: ProcessType[map<string,int>]
-	ProcessGoSwissMap 40 00 00 00 3d 00 00 00 10 18 
+	ProcessGoSwissMap 3e 00 00 00 3b 00 00 00 10 18 
 	Return 
 // 0x344: ProcessType[map<string,main.bigStruct>]
-	ProcessGoSwissMap 49 00 00 00 44 00 00 00 10 18 
+	ProcessGoSwissMap 48 00 00 00 43 00 00 00 10 18 
 	Return 
 // 0x350: ProcessType[map[string]int]
 	ProcessPointer 27 00 00 00 
@@ -281,7 +281,7 @@
 	Call a8 03 00 00 // ProcessType[string]
 	Return 
 // 0x3a8: ProcessType[string]
-	ProcessString 35 00 00 00 
+	ProcessString 32 00 00 00 
 	Return 
 // 0x3ae: ProcessType[table<string,int>]
 	IncrementOutputOffset 10 00 00 00 
@@ -355,31 +355,31 @@ ID: 46 Len: 8 Enqueue: 660
 ID: 47 Len: 8 Enqueue: 576
 ID: 48 Len: 8 Enqueue: 582
 ID: 49 Len: 8 Enqueue: 594
-ID: 50 Len: 32 Enqueue: 942
-ID: 51 Len: 32 Enqueue: 953
-ID: 52 Len: 8 Enqueue: 588
-ID: 53 Len: 2048 Enqueue: 0
-ID: 54 Len: 8 Enqueue: 0
-ID: 55 Len: 2048 Enqueue: 0
-ID: 56 Len: 8 Enqueue: 0
-ID: 57 Len: 2048 Enqueue: 786
+ID: 50 Len: 2048 Enqueue: 0
+ID: 51 Len: 8 Enqueue: 0
+ID: 52 Len: 2048 Enqueue: 0
+ID: 53 Len: 8 Enqueue: 0
+ID: 54 Len: 2048 Enqueue: 786
+ID: 55 Len: 8 Enqueue: 0
+ID: 56 Len: 32 Enqueue: 942
+ID: 57 Len: 16 Enqueue: 800
 ID: 58 Len: 8 Enqueue: 0
-ID: 59 Len: 16 Enqueue: 800
-ID: 60 Len: 8 Enqueue: 0
-ID: 61 Len: 200 Enqueue: 892
-ID: 62 Len: 192 Enqueue: 876
-ID: 63 Len: 24 Enqueue: 930
-ID: 64 Len: 8192 Enqueue: 718
-ID: 65 Len: 2048 Enqueue: 752
-ID: 66 Len: 16 Enqueue: 812
-ID: 67 Len: 8 Enqueue: 0
-ID: 68 Len: 200 Enqueue: 903
-ID: 69 Len: 192 Enqueue: 860
-ID: 70 Len: 24 Enqueue: 914
-ID: 71 Len: 8 Enqueue: 642
-ID: 72 Len: 184 Enqueue: 0
-ID: 73 Len: 8192 Enqueue: 730
-ID: 74 Len: 2048 Enqueue: 764
+ID: 59 Len: 200 Enqueue: 892
+ID: 60 Len: 192 Enqueue: 876
+ID: 61 Len: 24 Enqueue: 930
+ID: 62 Len: 8192 Enqueue: 718
+ID: 63 Len: 2048 Enqueue: 752
+ID: 64 Len: 32 Enqueue: 953
+ID: 65 Len: 16 Enqueue: 812
+ID: 66 Len: 8 Enqueue: 0
+ID: 67 Len: 200 Enqueue: 903
+ID: 68 Len: 192 Enqueue: 860
+ID: 69 Len: 24 Enqueue: 914
+ID: 70 Len: 8 Enqueue: 642
+ID: 71 Len: 184 Enqueue: 0
+ID: 72 Len: 8192 Enqueue: 730
+ID: 73 Len: 2048 Enqueue: 764
+ID: 74 Len: 8 Enqueue: 588
 ID: 75 Len: 128 Enqueue: 0
 ID: 76 Len: 9 Enqueue: 0
 ID: 77 Len: 17 Enqueue: 0

--- a/pkg/dyninst/compiler/testdata/snapshot/simple.arch=amd64,toolchain=go1.25.0.sm.txt
+++ b/pkg/dyninst/compiler/testdata/snapshot/simple.arch=amd64,toolchain=go1.25.0.sm.txt
@@ -135,67 +135,67 @@
 	Call 08 02 00 00 // ProcessExpression[Probe[main.stringSliceArg]@0x4ae8aa.expr[0]]
 	Return 
 // 0x240: ProcessType[*****int]
-	ProcessPointer 03 00 00 00 
+	ProcessPointer 3f 00 00 00 
 	Return 
 // 0x246: ProcessType[****int]
-	ProcessPointer 04 00 00 00 
+	ProcessPointer 40 00 00 00 
 	Return 
 // 0x24c: ProcessType[***int]
-	ProcessPointer 05 00 00 00 
+	ProcessPointer 41 00 00 00 
 	Return 
 // 0x252: ProcessType[**int]
-	ProcessPointer 06 00 00 00 
+	ProcessPointer 1a 00 00 00 
 	Return 
 // 0x258: ProcessType[*bool]
-	ProcessPointer 1d 00 00 00 
+	ProcessPointer 04 00 00 00 
 	Return 
 // 0x25e: ProcessType[*error]
-	ProcessPointer 30 00 00 00 
+	ProcessPointer 0d 00 00 00 
 	Return 
 // 0x264: ProcessType[*float32]
-	ProcessPointer 35 00 00 00 
-	Return 
-// 0x26a: ProcessType[*float64]
-	ProcessPointer 32 00 00 00 
-	Return 
-// 0x270: ProcessType[*int]
-	ProcessPointer 01 00 00 00 
-	Return 
-// 0x276: ProcessType[*int32]
-	ProcessPointer 2d 00 00 00 
-	Return 
-// 0x27c: ProcessType[*int64]
-	ProcessPointer 2f 00 00 00 
-	Return 
-// 0x282: ProcessType[*main.bigStruct]
-	ProcessPointer 2a 00 00 00 
-	Return 
-// 0x288: ProcessType[*string]
-	ProcessPointer 07 00 00 00 
-	Return 
-// 0x28e: ProcessType[*table<string,int>]
-	ProcessPointer 16 00 00 00 
-	Return 
-// 0x294: ProcessType[*table<string,main.bigStruct>]
-	ProcessPointer 23 00 00 00 
-	Return 
-// 0x29a: ProcessType[*uint]
-	ProcessPointer 34 00 00 00 
-	Return 
-// 0x2a0: ProcessType[*uint16]
-	ProcessPointer 17 00 00 00 
-	Return 
-// 0x2a6: ProcessType[*uint32]
-	ProcessPointer 2c 00 00 00 
-	Return 
-// 0x2ac: ProcessType[*uint64]
 	ProcessPointer 12 00 00 00 
 	Return 
-// 0x2b2: ProcessType[*uint8]
+// 0x26a: ProcessType[*float64]
+	ProcessPointer 0f 00 00 00 
+	Return 
+// 0x270: ProcessType[*int]
+	ProcessPointer 07 00 00 00 
+	Return 
+// 0x276: ProcessType[*int32]
+	ProcessPointer 0a 00 00 00 
+	Return 
+// 0x27c: ProcessType[*int64]
+	ProcessPointer 0c 00 00 00 
+	Return 
+// 0x282: ProcessType[*main.bigStruct]
+	ProcessPointer 3c 00 00 00 
+	Return 
+// 0x288: ProcessType[*string]
 	ProcessPointer 09 00 00 00 
 	Return 
+// 0x28e: ProcessType[*table<string,int>]
+	ProcessPointer 2a 00 00 00 
+	Return 
+// 0x294: ProcessType[*table<string,main.bigStruct>]
+	ProcessPointer 35 00 00 00 
+	Return 
+// 0x29a: ProcessType[*uint]
+	ProcessPointer 11 00 00 00 
+	Return 
+// 0x2a0: ProcessType[*uint16]
+	ProcessPointer 06 00 00 00 
+	Return 
+// 0x2a6: ProcessType[*uint32]
+	ProcessPointer 02 00 00 00 
+	Return 
+// 0x2ac: ProcessType[*uint64]
+	ProcessPointer 08 00 00 00 
+	Return 
+// 0x2b2: ProcessType[*uint8]
+	ProcessPointer 03 00 00 00 
+	Return 
 // 0x2b8: ProcessType[*uintptr]
-	ProcessPointer 13 00 00 00 
+	ProcessPointer 01 00 00 00 
 	Return 
 // 0x2be: ProcessType[[3]string]
 	ProcessArrayDataPrep 30 00 00 00 
@@ -243,16 +243,16 @@
 	ProcessGoSwissMapGroups 4b 00 00 00 c8 00 00 00 00 08 
 	Return 
 // 0x338: ProcessType[map<string,int>]
-	ProcessGoSwissMap 48 00 00 00 1a 00 00 00 10 18 
+	ProcessGoSwissMap 48 00 00 00 2d 00 00 00 10 18 
 	Return 
 // 0x344: ProcessType[map<string,main.bigStruct>]
-	ProcessGoSwissMap 4a 00 00 00 26 00 00 00 10 18 
+	ProcessGoSwissMap 4a 00 00 00 38 00 00 00 10 18 
 	Return 
 // 0x350: ProcessType[map[string]int]
-	ProcessPointer 11 00 00 00 
+	ProcessPointer 27 00 00 00 
 	Return 
 // 0x356: ProcessType[map[string]main.bigStruct]
-	ProcessPointer 20 00 00 00 
+	ProcessPointer 32 00 00 00 
 	Return 
 // 0x35c: ProcessType[noalg.[8]struct { key string; elem *main.bigStruct }]
 	ProcessArrayDataPrep c0 00 00 00 
@@ -307,70 +307,70 @@
 	Illegal 
 // Types
 ID: 1 Len: 8 Enqueue: 0
-ID: 2 Len: 8 Enqueue: 576
-ID: 3 Len: 8 Enqueue: 582
-ID: 4 Len: 8 Enqueue: 588
-ID: 5 Len: 8 Enqueue: 594
-ID: 6 Len: 8 Enqueue: 624
-ID: 7 Len: 16 Enqueue: 936
-ID: 8 Len: 8 Enqueue: 690
-ID: 9 Len: 1 Enqueue: 0
-ID: 10 Len: 24 Enqueue: 742
-ID: 11 Len: 24 Enqueue: 0
-ID: 12 Len: 24 Enqueue: 776
-ID: 13 Len: 8 Enqueue: 648
-ID: 14 Len: 48 Enqueue: 702
-ID: 15 Len: 8 Enqueue: 848
-ID: 16 Len: 8 Enqueue: 0
-ID: 17 Len: 48 Enqueue: 824
-ID: 18 Len: 8 Enqueue: 0
-ID: 19 Len: 8 Enqueue: 0
-ID: 20 Len: 8 Enqueue: 0
-ID: 21 Len: 8 Enqueue: 654
-ID: 22 Len: 32 Enqueue: 942
-ID: 23 Len: 2 Enqueue: 0
-ID: 24 Len: 16 Enqueue: 800
-ID: 25 Len: 8 Enqueue: 0
-ID: 26 Len: 200 Enqueue: 892
-ID: 27 Len: 192 Enqueue: 876
-ID: 28 Len: 24 Enqueue: 930
-ID: 29 Len: 1 Enqueue: 0
-ID: 30 Len: 8 Enqueue: 854
-ID: 31 Len: 8 Enqueue: 0
-ID: 32 Len: 48 Enqueue: 836
-ID: 33 Len: 8 Enqueue: 0
-ID: 34 Len: 8 Enqueue: 660
-ID: 35 Len: 32 Enqueue: 953
-ID: 36 Len: 16 Enqueue: 812
-ID: 37 Len: 8 Enqueue: 0
-ID: 38 Len: 200 Enqueue: 903
-ID: 39 Len: 192 Enqueue: 860
-ID: 40 Len: 24 Enqueue: 914
-ID: 41 Len: 8 Enqueue: 642
-ID: 42 Len: 184 Enqueue: 0
-ID: 43 Len: 128 Enqueue: 0
-ID: 44 Len: 4 Enqueue: 0
-ID: 45 Len: 4 Enqueue: 0
-ID: 46 Len: 8 Enqueue: 600
-ID: 47 Len: 8 Enqueue: 0
-ID: 48 Len: 16 Enqueue: 798
+ID: 2 Len: 4 Enqueue: 0
+ID: 3 Len: 1 Enqueue: 0
+ID: 4 Len: 1 Enqueue: 0
+ID: 5 Len: 8 Enqueue: 690
+ID: 6 Len: 2 Enqueue: 0
+ID: 7 Len: 8 Enqueue: 0
+ID: 8 Len: 8 Enqueue: 0
+ID: 9 Len: 16 Enqueue: 936
+ID: 10 Len: 4 Enqueue: 0
+ID: 11 Len: 8 Enqueue: 600
+ID: 12 Len: 8 Enqueue: 0
+ID: 13 Len: 16 Enqueue: 798
+ID: 14 Len: 8 Enqueue: 0
+ID: 15 Len: 8 Enqueue: 0
+ID: 16 Len: 1 Enqueue: 0
+ID: 17 Len: 8 Enqueue: 0
+ID: 18 Len: 4 Enqueue: 0
+ID: 19 Len: 8 Enqueue: 696
+ID: 20 Len: 8 Enqueue: 630
+ID: 21 Len: 8 Enqueue: 678
+ID: 22 Len: 8 Enqueue: 648
+ID: 23 Len: 8 Enqueue: 0
+ID: 24 Len: 16 Enqueue: 0
+ID: 25 Len: 8 Enqueue: 618
+ID: 26 Len: 8 Enqueue: 624
+ID: 27 Len: 8 Enqueue: 636
+ID: 28 Len: 8 Enqueue: 684
+ID: 29 Len: 8 Enqueue: 606
+ID: 30 Len: 8 Enqueue: 612
+ID: 31 Len: 8 Enqueue: 666
+ID: 32 Len: 8 Enqueue: 672
+ID: 33 Len: 24 Enqueue: 742
+ID: 34 Len: 24 Enqueue: 0
+ID: 35 Len: 24 Enqueue: 776
+ID: 36 Len: 48 Enqueue: 702
+ID: 37 Len: 8 Enqueue: 848
+ID: 38 Len: 8 Enqueue: 0
+ID: 39 Len: 48 Enqueue: 824
+ID: 40 Len: 8 Enqueue: 0
+ID: 41 Len: 8 Enqueue: 654
+ID: 42 Len: 32 Enqueue: 942
+ID: 43 Len: 16 Enqueue: 800
+ID: 44 Len: 8 Enqueue: 0
+ID: 45 Len: 200 Enqueue: 892
+ID: 46 Len: 192 Enqueue: 876
+ID: 47 Len: 24 Enqueue: 930
+ID: 48 Len: 8 Enqueue: 854
 ID: 49 Len: 8 Enqueue: 0
-ID: 50 Len: 8 Enqueue: 0
-ID: 51 Len: 1 Enqueue: 0
-ID: 52 Len: 8 Enqueue: 0
-ID: 53 Len: 4 Enqueue: 0
-ID: 54 Len: 8 Enqueue: 696
-ID: 55 Len: 8 Enqueue: 630
-ID: 56 Len: 8 Enqueue: 678
-ID: 57 Len: 8 Enqueue: 0
-ID: 58 Len: 16 Enqueue: 0
-ID: 59 Len: 8 Enqueue: 618
-ID: 60 Len: 8 Enqueue: 636
-ID: 61 Len: 8 Enqueue: 684
-ID: 62 Len: 8 Enqueue: 606
-ID: 63 Len: 8 Enqueue: 612
-ID: 64 Len: 8 Enqueue: 666
-ID: 65 Len: 8 Enqueue: 672
+ID: 50 Len: 48 Enqueue: 836
+ID: 51 Len: 8 Enqueue: 0
+ID: 52 Len: 8 Enqueue: 660
+ID: 53 Len: 32 Enqueue: 953
+ID: 54 Len: 16 Enqueue: 812
+ID: 55 Len: 8 Enqueue: 0
+ID: 56 Len: 200 Enqueue: 903
+ID: 57 Len: 192 Enqueue: 860
+ID: 58 Len: 24 Enqueue: 914
+ID: 59 Len: 8 Enqueue: 642
+ID: 60 Len: 184 Enqueue: 0
+ID: 61 Len: 128 Enqueue: 0
+ID: 62 Len: 8 Enqueue: 576
+ID: 63 Len: 8 Enqueue: 582
+ID: 64 Len: 8 Enqueue: 588
+ID: 65 Len: 8 Enqueue: 594
 ID: 66 Len: 2048 Enqueue: 0
 ID: 67 Len: 8 Enqueue: 0
 ID: 68 Len: 2048 Enqueue: 0

--- a/pkg/dyninst/compiler/testdata/snapshot/simple.arch=amd64,toolchain=go1.25.0.sm.txt
+++ b/pkg/dyninst/compiler/testdata/snapshot/simple.arch=amd64,toolchain=go1.25.0.sm.txt
@@ -168,7 +168,7 @@
 	ProcessPointer 0c 00 00 00 
 	Return 
 // 0x282: ProcessType[*main.bigStruct]
-	ProcessPointer 40 00 00 00 
+	ProcessPointer 48 00 00 00 
 	Return 
 // 0x288: ProcessType[*string]
 	ProcessPointer 09 00 00 00 
@@ -213,7 +213,7 @@
 	ProcessSliceDataRepeat 08 00 00 00 
 	Return 
 // 0x2e6: ProcessType[[]int]
-	ProcessSlice 44 00 00 00 08 00 00 00 
+	ProcessSlice 37 00 00 00 08 00 00 00 
 	Return 
 // 0x2f0: ProcessType[[]noalg.map.group[string]int.array]
 	ProcessSliceDataPrep 
@@ -226,7 +226,7 @@
 	ProcessSliceDataRepeat 00 00 00 00 
 	Return 
 // 0x308: ProcessType[[]string]
-	ProcessSlice 46 00 00 00 10 00 00 00 
+	ProcessSlice 39 00 00 00 10 00 00 00 
 	Return 
 // 0x312: ProcessType[[]string.array]
 	ProcessSliceDataPrep 
@@ -237,16 +237,16 @@
 	ProcessGoInterface 
 	Return 
 // 0x320: ProcessType[groupReference<string,int>]
-	ProcessGoSwissMapGroups 49 00 00 00 c8 00 00 00 00 08 
+	ProcessGoSwissMapGroups 41 00 00 00 c8 00 00 00 00 08 
 	Return 
 // 0x32c: ProcessType[groupReference<string,main.bigStruct>]
-	ProcessGoSwissMapGroups 4b 00 00 00 c8 00 00 00 00 08 
+	ProcessGoSwissMapGroups 4a 00 00 00 c8 00 00 00 00 08 
 	Return 
 // 0x338: ProcessType[map<string,int>]
-	ProcessGoSwissMap 48 00 00 00 37 00 00 00 10 18 
+	ProcessGoSwissMap 40 00 00 00 3d 00 00 00 10 18 
 	Return 
 // 0x344: ProcessType[map<string,main.bigStruct>]
-	ProcessGoSwissMap 4a 00 00 00 3a 00 00 00 10 18 
+	ProcessGoSwissMap 49 00 00 00 44 00 00 00 10 18 
 	Return 
 // 0x350: ProcessType[map[string]int]
 	ProcessPointer 27 00 00 00 
@@ -281,7 +281,7 @@
 	Call a8 03 00 00 // ProcessType[string]
 	Return 
 // 0x3a8: ProcessType[string]
-	ProcessString 42 00 00 00 
+	ProcessString 35 00 00 00 
 	Return 
 // 0x3ae: ProcessType[table<string,int>]
 	IncrementOutputOffset 10 00 00 00 
@@ -358,29 +358,29 @@ ID: 49 Len: 8 Enqueue: 594
 ID: 50 Len: 32 Enqueue: 942
 ID: 51 Len: 32 Enqueue: 953
 ID: 52 Len: 8 Enqueue: 588
-ID: 53 Len: 16 Enqueue: 800
+ID: 53 Len: 2048 Enqueue: 0
 ID: 54 Len: 8 Enqueue: 0
-ID: 55 Len: 200 Enqueue: 892
-ID: 56 Len: 16 Enqueue: 812
-ID: 57 Len: 8 Enqueue: 0
-ID: 58 Len: 200 Enqueue: 903
-ID: 59 Len: 192 Enqueue: 876
-ID: 60 Len: 24 Enqueue: 930
-ID: 61 Len: 192 Enqueue: 860
-ID: 62 Len: 24 Enqueue: 914
-ID: 63 Len: 8 Enqueue: 642
-ID: 64 Len: 184 Enqueue: 0
-ID: 65 Len: 128 Enqueue: 0
-ID: 66 Len: 2048 Enqueue: 0
+ID: 55 Len: 2048 Enqueue: 0
+ID: 56 Len: 8 Enqueue: 0
+ID: 57 Len: 2048 Enqueue: 786
+ID: 58 Len: 8 Enqueue: 0
+ID: 59 Len: 16 Enqueue: 800
+ID: 60 Len: 8 Enqueue: 0
+ID: 61 Len: 200 Enqueue: 892
+ID: 62 Len: 192 Enqueue: 876
+ID: 63 Len: 24 Enqueue: 930
+ID: 64 Len: 8192 Enqueue: 718
+ID: 65 Len: 2048 Enqueue: 752
+ID: 66 Len: 16 Enqueue: 812
 ID: 67 Len: 8 Enqueue: 0
-ID: 68 Len: 2048 Enqueue: 0
-ID: 69 Len: 8 Enqueue: 0
-ID: 70 Len: 2048 Enqueue: 786
-ID: 71 Len: 8 Enqueue: 0
-ID: 72 Len: 8192 Enqueue: 718
-ID: 73 Len: 2048 Enqueue: 752
-ID: 74 Len: 8192 Enqueue: 730
-ID: 75 Len: 2048 Enqueue: 764
+ID: 68 Len: 200 Enqueue: 903
+ID: 69 Len: 192 Enqueue: 860
+ID: 70 Len: 24 Enqueue: 914
+ID: 71 Len: 8 Enqueue: 642
+ID: 72 Len: 184 Enqueue: 0
+ID: 73 Len: 8192 Enqueue: 730
+ID: 74 Len: 2048 Enqueue: 764
+ID: 75 Len: 128 Enqueue: 0
 ID: 76 Len: 9 Enqueue: 0
 ID: 77 Len: 17 Enqueue: 0
 ID: 78 Len: 25 Enqueue: 0

--- a/pkg/dyninst/compiler/testdata/snapshot/simple.arch=amd64,toolchain=go1.25.0.sm.txt
+++ b/pkg/dyninst/compiler/testdata/snapshot/simple.arch=amd64,toolchain=go1.25.0.sm.txt
@@ -135,13 +135,13 @@
 	Call 08 02 00 00 // ProcessExpression[Probe[main.stringSliceArg]@0x4ae8aa.expr[0]]
 	Return 
 // 0x240: ProcessType[*****int]
-	ProcessPointer 3f 00 00 00 
+	ProcessPointer 30 00 00 00 
 	Return 
 // 0x246: ProcessType[****int]
-	ProcessPointer 40 00 00 00 
+	ProcessPointer 34 00 00 00 
 	Return 
 // 0x24c: ProcessType[***int]
-	ProcessPointer 41 00 00 00 
+	ProcessPointer 31 00 00 00 
 	Return 
 // 0x252: ProcessType[**int]
 	ProcessPointer 1a 00 00 00 
@@ -168,16 +168,16 @@
 	ProcessPointer 0c 00 00 00 
 	Return 
 // 0x282: ProcessType[*main.bigStruct]
-	ProcessPointer 3c 00 00 00 
+	ProcessPointer 40 00 00 00 
 	Return 
 // 0x288: ProcessType[*string]
 	ProcessPointer 09 00 00 00 
 	Return 
 // 0x28e: ProcessType[*table<string,int>]
-	ProcessPointer 2a 00 00 00 
+	ProcessPointer 32 00 00 00 
 	Return 
 // 0x294: ProcessType[*table<string,main.bigStruct>]
-	ProcessPointer 35 00 00 00 
+	ProcessPointer 33 00 00 00 
 	Return 
 // 0x29a: ProcessType[*uint]
 	ProcessPointer 11 00 00 00 
@@ -243,16 +243,16 @@
 	ProcessGoSwissMapGroups 4b 00 00 00 c8 00 00 00 00 08 
 	Return 
 // 0x338: ProcessType[map<string,int>]
-	ProcessGoSwissMap 48 00 00 00 2d 00 00 00 10 18 
+	ProcessGoSwissMap 48 00 00 00 37 00 00 00 10 18 
 	Return 
 // 0x344: ProcessType[map<string,main.bigStruct>]
-	ProcessGoSwissMap 4a 00 00 00 38 00 00 00 10 18 
+	ProcessGoSwissMap 4a 00 00 00 3a 00 00 00 10 18 
 	Return 
 // 0x350: ProcessType[map[string]int]
 	ProcessPointer 27 00 00 00 
 	Return 
 // 0x356: ProcessType[map[string]main.bigStruct]
-	ProcessPointer 32 00 00 00 
+	ProcessPointer 2c 00 00 00 
 	Return 
 // 0x35c: ProcessType[noalg.[8]struct { key string; elem *main.bigStruct }]
 	ProcessArrayDataPrep c0 00 00 00 
@@ -347,30 +347,30 @@ ID: 38 Len: 8 Enqueue: 0
 ID: 39 Len: 48 Enqueue: 824
 ID: 40 Len: 8 Enqueue: 0
 ID: 41 Len: 8 Enqueue: 654
-ID: 42 Len: 32 Enqueue: 942
-ID: 43 Len: 16 Enqueue: 800
-ID: 44 Len: 8 Enqueue: 0
-ID: 45 Len: 200 Enqueue: 892
-ID: 46 Len: 192 Enqueue: 876
-ID: 47 Len: 24 Enqueue: 930
-ID: 48 Len: 8 Enqueue: 854
-ID: 49 Len: 8 Enqueue: 0
-ID: 50 Len: 48 Enqueue: 836
-ID: 51 Len: 8 Enqueue: 0
-ID: 52 Len: 8 Enqueue: 660
-ID: 53 Len: 32 Enqueue: 953
-ID: 54 Len: 16 Enqueue: 812
-ID: 55 Len: 8 Enqueue: 0
-ID: 56 Len: 200 Enqueue: 903
-ID: 57 Len: 192 Enqueue: 860
-ID: 58 Len: 24 Enqueue: 914
-ID: 59 Len: 8 Enqueue: 642
-ID: 60 Len: 184 Enqueue: 0
-ID: 61 Len: 128 Enqueue: 0
-ID: 62 Len: 8 Enqueue: 576
-ID: 63 Len: 8 Enqueue: 582
-ID: 64 Len: 8 Enqueue: 588
-ID: 65 Len: 8 Enqueue: 594
+ID: 42 Len: 8 Enqueue: 854
+ID: 43 Len: 8 Enqueue: 0
+ID: 44 Len: 48 Enqueue: 836
+ID: 45 Len: 8 Enqueue: 0
+ID: 46 Len: 8 Enqueue: 660
+ID: 47 Len: 8 Enqueue: 576
+ID: 48 Len: 8 Enqueue: 582
+ID: 49 Len: 8 Enqueue: 594
+ID: 50 Len: 32 Enqueue: 942
+ID: 51 Len: 32 Enqueue: 953
+ID: 52 Len: 8 Enqueue: 588
+ID: 53 Len: 16 Enqueue: 800
+ID: 54 Len: 8 Enqueue: 0
+ID: 55 Len: 200 Enqueue: 892
+ID: 56 Len: 16 Enqueue: 812
+ID: 57 Len: 8 Enqueue: 0
+ID: 58 Len: 200 Enqueue: 903
+ID: 59 Len: 192 Enqueue: 876
+ID: 60 Len: 24 Enqueue: 930
+ID: 61 Len: 192 Enqueue: 860
+ID: 62 Len: 24 Enqueue: 914
+ID: 63 Len: 8 Enqueue: 642
+ID: 64 Len: 184 Enqueue: 0
+ID: 65 Len: 128 Enqueue: 0
 ID: 66 Len: 2048 Enqueue: 0
 ID: 67 Len: 8 Enqueue: 0
 ID: 68 Len: 2048 Enqueue: 0

--- a/pkg/dyninst/compiler/testdata/snapshot/simple.arch=amd64,toolchain=go1.25.0.sm.txt
+++ b/pkg/dyninst/compiler/testdata/snapshot/simple.arch=amd64,toolchain=go1.25.0.sm.txt
@@ -3,293 +3,293 @@
 // 0x1: ChasePointers
 	ChasePointers 
 	Return 
-// 0x3: ProcessType[*****int]
-	ProcessPointer 03 00 00 00 
-	Return 
-// 0x9: ProcessExpression[Probe[main.PointerChainArg]@0x4ae606.expr[0]]
+// 0x3: ProcessExpression[Probe[main.PointerChainArg]@0x4ae606.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
-	Call 03 00 00 00 // ProcessType[*****int]
+	Call 40 02 00 00 // ProcessType[*****int]
 	Return 
-// 0x24: ProcessEvent[Probe[main.PointerChainArg]@4ae606]
+// 0x1e: ProcessEvent[Probe[main.PointerChainArg]@4ae606]
 	PrepareEventRoot 56 00 00 00 09 00 00 00 
-	Call 09 00 00 00 // ProcessExpression[Probe[main.PointerChainArg]@0x4ae606.expr[0]]
+	Call 03 00 00 00 // ProcessExpression[Probe[main.PointerChainArg]@0x4ae606.expr[0]]
 	Return 
-// 0x33: ProcessType[**int]
-	ProcessPointer 06 00 00 00 
-	Return 
-// 0x39: ProcessExpression[Probe[main.PointerSmallChainArg]@0x4ae650.expr[0]]
+// 0x2d: ProcessExpression[Probe[main.PointerSmallChainArg]@0x4ae650.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 01 08 00 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
-	Call 33 00 00 00 // ProcessType[**int]
+	Call 52 02 00 00 // ProcessType[**int]
 	Return 
-// 0x54: ProcessEvent[Probe[main.PointerSmallChainArg]@4ae650]
+// 0x48: ProcessEvent[Probe[main.PointerSmallChainArg]@4ae650]
 	PrepareEventRoot 57 00 00 00 09 00 00 00 
-	Call 39 00 00 00 // ProcessExpression[Probe[main.PointerSmallChainArg]@0x4ae650.expr[0]]
+	Call 2d 00 00 00 // ProcessExpression[Probe[main.PointerSmallChainArg]@0x4ae650.expr[0]]
 	Return 
-// 0x63: ProcessType[map[string]main.bigStruct]
-	ProcessPointer 20 00 00 00 
-	Return 
-// 0x69: ProcessExpression[Probe[main.bigMapArg]@0x4aeaf3.expr[0]]
+// 0x57: ProcessExpression[Probe[main.bigMapArg]@0x4aeaf3.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
-	Call 63 00 00 00 // ProcessType[map[string]main.bigStruct]
+	Call 56 03 00 00 // ProcessType[map[string]main.bigStruct]
 	Return 
-// 0x84: ProcessEvent[Probe[main.bigMapArg]@4aeaf3]
+// 0x72: ProcessEvent[Probe[main.bigMapArg]@4aeaf3]
 	PrepareEventRoot 54 00 00 00 09 00 00 00 
-	Call 69 00 00 00 // ProcessExpression[Probe[main.bigMapArg]@0x4aeaf3.expr[0]]
+	Call 57 00 00 00 // ProcessExpression[Probe[main.bigMapArg]@0x4aeaf3.expr[0]]
 	Return 
-// 0x93: ProcessExpression[Probe[main.inlined]@0x4ae9ca.expr[0]]
+// 0x81: ProcessExpression[Probe[main.inlined]@0x4ae9ca.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
 	Return 
-// 0xa9: ProcessEvent[Probe[main.inlined]@4ae9ca]
+// 0x97: ProcessEvent[Probe[main.inlined]@4ae9ca]
 	PrepareEventRoot 55 00 00 00 09 00 00 00 
-	Call 93 00 00 00 // ProcessExpression[Probe[main.inlined]@0x4ae9ca.expr[0]]
+	Call 81 00 00 00 // ProcessExpression[Probe[main.inlined]@0x4ae9ca.expr[0]]
 	Return 
-// 0xb8: ProcessExpression[Probe[main.inlined]@0x4ae3ce.expr[0]]
+// 0xa6: ProcessExpression[Probe[main.inlined]@0x4ae3ce.expr[0]]
 	ExprPrepare 
 	Return 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
 	Return 
-// 0xc8: ProcessEvent[Probe[main.inlined]@4ae3ce]
+// 0xb6: ProcessEvent[Probe[main.inlined]@4ae3ce]
 	PrepareEventRoot 55 00 00 00 09 00 00 00 
-	Call b8 00 00 00 // ProcessExpression[Probe[main.inlined]@0x4ae3ce.expr[0]]
+	Call a6 00 00 00 // ProcessExpression[Probe[main.inlined]@0x4ae3ce.expr[0]]
 	Return 
-// 0xd7: ProcessExpression[Probe[main.intArg]@0x4ae6aa.expr[0]]
+// 0xc5: ProcessExpression[Probe[main.intArg]@0x4ae6aa.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
 	Return 
-// 0xed: ProcessEvent[Probe[main.intArg]@4ae6aa]
+// 0xdb: ProcessEvent[Probe[main.intArg]@4ae6aa]
 	PrepareEventRoot 4c 00 00 00 09 00 00 00 
-	Call d7 00 00 00 // ProcessExpression[Probe[main.intArg]@0x4ae6aa.expr[0]]
+	Call c5 00 00 00 // ProcessExpression[Probe[main.intArg]@0x4ae6aa.expr[0]]
 	Return 
-// 0xfc: ProcessExpression[Probe[main.intArrayArg]@0x4ae82a.expr[0]]
+// 0xea: ProcessExpression[Probe[main.intArrayArg]@0x4ae82a.expr[0]]
 	ExprPrepare 
 	ExprDereferenceCfa 00 00 00 00 18 00 00 00 00 00 00 00 
 	ExprSave 01 00 00 00 18 00 00 00 00 00 00 00 
 	Return 
-// 0x118: ProcessEvent[Probe[main.intArrayArg]@4ae82a]
+// 0x106: ProcessEvent[Probe[main.intArrayArg]@4ae82a]
 	PrepareEventRoot 4f 00 00 00 19 00 00 00 
-	Call fc 00 00 00 // ProcessExpression[Probe[main.intArrayArg]@0x4ae82a.expr[0]]
+	Call ea 00 00 00 // ProcessExpression[Probe[main.intArrayArg]@0x4ae82a.expr[0]]
 	Return 
-// 0x127: ProcessType[string]
-	ProcessString 42 00 00 00 
-	Return 
-// 0x12d: ProcessType[[3]string]
-	ProcessArrayDataPrep 30 00 00 00 
-	Call 27 01 00 00 // ProcessType[string]
-	ProcessSliceDataRepeat 10 00 00 00 
-	Return 
-// 0x13d: ProcessExpression[Probe[main.stringArrayArgFrameless]@0x4ae9a0.expr[0]]
+// 0x115: ProcessExpression[Probe[main.stringArrayArgFrameless]@0x4ae9a0.expr[0]]
 	ExprPrepare 
 	ExprDereferenceCfa 00 00 00 00 30 00 00 00 00 00 00 00 
 	ExprSave 01 00 00 00 30 00 00 00 00 00 00 00 
-	Call 2d 01 00 00 // ProcessType[[3]string]
+	Call be 02 00 00 // ProcessType[[3]string]
 	Return 
-// 0x15e: ProcessEvent[Probe[main.stringArrayArgFrameless]@4ae9a0]
+// 0x136: ProcessEvent[Probe[main.stringArrayArgFrameless]@4ae9a0]
 	PrepareEventRoot 52 00 00 00 31 00 00 00 
-	Call 3d 01 00 00 // ProcessExpression[Probe[main.stringArrayArgFrameless]@0x4ae9a0.expr[0]]
+	Call 15 01 00 00 // ProcessExpression[Probe[main.stringArrayArgFrameless]@0x4ae9a0.expr[0]]
 	Return 
-// 0x16d: ProcessType[[]int]
-	ProcessSlice 44 00 00 00 08 00 00 00 
-	Return 
-// 0x177: ProcessExpression[Probe[main.intSliceArg]@0x4ae7aa.expr[0]]
+// 0x145: ProcessExpression[Probe[main.intSliceArg]@0x4ae7aa.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprReadRegister 03 08 08 00 00 00 
 	ExprReadRegister 02 08 10 00 00 00 
 	ExprSave 01 00 00 00 18 00 00 00 00 00 00 00 
-	Call 6d 01 00 00 // ProcessType[[]int]
+	Call e6 02 00 00 // ProcessType[[]int]
 	Return 
-// 0x1a0: ProcessEvent[Probe[main.intSliceArg]@4ae7aa]
+// 0x16e: ProcessEvent[Probe[main.intSliceArg]@4ae7aa]
 	PrepareEventRoot 4e 00 00 00 19 00 00 00 
-	Call 77 01 00 00 // ProcessExpression[Probe[main.intSliceArg]@0x4ae7aa.expr[0]]
+	Call 45 01 00 00 // ProcessExpression[Probe[main.intSliceArg]@0x4ae7aa.expr[0]]
 	Return 
-// 0x1af: ProcessType[map[string]int]
-	ProcessPointer 11 00 00 00 
-	Return 
-// 0x1b5: ProcessExpression[Probe[main.mapArg]@0x4aea8a.expr[0]]
+// 0x17d: ProcessExpression[Probe[main.mapArg]@0x4aea8a.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
-	Call af 01 00 00 // ProcessType[map[string]int]
+	Call 50 03 00 00 // ProcessType[map[string]int]
 	Return 
-// 0x1d0: ProcessEvent[Probe[main.mapArg]@4aea8a]
+// 0x198: ProcessEvent[Probe[main.mapArg]@4aea8a]
 	PrepareEventRoot 53 00 00 00 09 00 00 00 
-	Call b5 01 00 00 // ProcessExpression[Probe[main.mapArg]@0x4aea8a.expr[0]]
+	Call 7d 01 00 00 // ProcessExpression[Probe[main.mapArg]@0x4aea8a.expr[0]]
 	Return 
-// 0x1df: ProcessExpression[Probe[main.stringArg]@0x4ae72a.expr[0]]
+// 0x1a7: ProcessExpression[Probe[main.stringArg]@0x4ae72a.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprReadRegister 03 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call 27 01 00 00 // ProcessType[string]
+	Call a8 03 00 00 // ProcessType[string]
 	Return 
-// 0x201: ProcessEvent[Probe[main.stringArg]@4ae72a]
+// 0x1c9: ProcessEvent[Probe[main.stringArg]@4ae72a]
 	PrepareEventRoot 4d 00 00 00 11 00 00 00 
-	Call df 01 00 00 // ProcessExpression[Probe[main.stringArg]@0x4ae72a.expr[0]]
+	Call a7 01 00 00 // ProcessExpression[Probe[main.stringArg]@0x4ae72a.expr[0]]
 	Return 
-// 0x210: ProcessExpression[Probe[main.stringArrayArg]@0x4ae92a.expr[0]]
+// 0x1d8: ProcessExpression[Probe[main.stringArrayArg]@0x4ae92a.expr[0]]
 	ExprPrepare 
 	ExprDereferenceCfa 00 00 00 00 30 00 00 00 00 00 00 00 
 	ExprSave 01 00 00 00 30 00 00 00 00 00 00 00 
-	Call 2d 01 00 00 // ProcessType[[3]string]
+	Call be 02 00 00 // ProcessType[[3]string]
 	Return 
-// 0x231: ProcessEvent[Probe[main.stringArrayArg]@4ae92a]
+// 0x1f9: ProcessEvent[Probe[main.stringArrayArg]@4ae92a]
 	PrepareEventRoot 51 00 00 00 31 00 00 00 
-	Call 10 02 00 00 // ProcessExpression[Probe[main.stringArrayArg]@0x4ae92a.expr[0]]
+	Call d8 01 00 00 // ProcessExpression[Probe[main.stringArrayArg]@0x4ae92a.expr[0]]
 	Return 
-// 0x240: ProcessType[[]string]
-	ProcessSlice 46 00 00 00 10 00 00 00 
-	Return 
-// 0x24a: ProcessExpression[Probe[main.stringSliceArg]@0x4ae8aa.expr[0]]
+// 0x208: ProcessExpression[Probe[main.stringSliceArg]@0x4ae8aa.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprReadRegister 03 08 08 00 00 00 
 	ExprReadRegister 02 08 10 00 00 00 
 	ExprSave 01 00 00 00 18 00 00 00 00 00 00 00 
-	Call 40 02 00 00 // ProcessType[[]string]
+	Call 08 03 00 00 // ProcessType[[]string]
 	Return 
-// 0x273: ProcessEvent[Probe[main.stringSliceArg]@4ae8aa]
+// 0x231: ProcessEvent[Probe[main.stringSliceArg]@4ae8aa]
 	PrepareEventRoot 50 00 00 00 19 00 00 00 
-	Call 4a 02 00 00 // ProcessExpression[Probe[main.stringSliceArg]@0x4ae8aa.expr[0]]
+	Call 08 02 00 00 // ProcessExpression[Probe[main.stringSliceArg]@0x4ae8aa.expr[0]]
 	Return 
-// 0x282: ProcessType[****int]
+// 0x240: ProcessType[*****int]
+	ProcessPointer 03 00 00 00 
+	Return 
+// 0x246: ProcessType[****int]
 	ProcessPointer 04 00 00 00 
 	Return 
-// 0x288: ProcessType[***int]
+// 0x24c: ProcessType[***int]
 	ProcessPointer 05 00 00 00 
 	Return 
-// 0x28e: ProcessType[*int]
-	ProcessPointer 01 00 00 00 
+// 0x252: ProcessType[**int]
+	ProcessPointer 06 00 00 00 
 	Return 
-// 0x294: ProcessType[*uint8]
-	ProcessPointer 09 00 00 00 
-	Return 
-// 0x29a: ProcessType[*string]
-	ProcessPointer 07 00 00 00 
-	Return 
-// 0x2a0: ProcessType[map<string,int>]
-	ProcessGoSwissMap 48 00 00 00 1a 00 00 00 10 18 
-	Return 
-// 0x2ac: ProcessType[noalg.struct { key string; elem int }]
-	Call 27 01 00 00 // ProcessType[string]
-	Return 
-// 0x2b2: ProcessType[noalg.[8]struct { key string; elem int }]
-	ProcessArrayDataPrep c0 00 00 00 
-	Call ac 02 00 00 // ProcessType[noalg.struct { key string; elem int }]
-	ProcessSliceDataRepeat 18 00 00 00 
-	Return 
-// 0x2c2: ProcessType[noalg.map.group[string]int]
-	IncrementOutputOffset 08 00 00 00 
-	Call b2 02 00 00 // ProcessType[noalg.[8]struct { key string; elem int }]
-	Return 
-// 0x2cd: ProcessType[map<string,main.bigStruct>]
-	ProcessGoSwissMap 4a 00 00 00 26 00 00 00 10 18 
-	Return 
-// 0x2d9: ProcessType[*main.bigStruct]
-	ProcessPointer 2a 00 00 00 
-	Return 
-// 0x2df: ProcessType[noalg.struct { key string; elem *main.bigStruct }]
-	Call 27 01 00 00 // ProcessType[string]
-	IncrementOutputOffset 10 00 00 00 
-	Call d9 02 00 00 // ProcessType[*main.bigStruct]
-	Return 
-// 0x2ef: ProcessType[noalg.[8]struct { key string; elem *main.bigStruct }]
-	ProcessArrayDataPrep c0 00 00 00 
-	Call df 02 00 00 // ProcessType[noalg.struct { key string; elem *main.bigStruct }]
-	ProcessSliceDataRepeat 08 00 00 00 
-	Return 
-// 0x2ff: ProcessType[noalg.map.group[string]main.bigStruct]
-	IncrementOutputOffset 08 00 00 00 
-	Call ef 02 00 00 // ProcessType[noalg.[8]struct { key string; elem *main.bigStruct }]
-	Return 
-// 0x30a: ProcessType[*bool]
+// 0x258: ProcessType[*bool]
 	ProcessPointer 1d 00 00 00 
 	Return 
-// 0x310: ProcessType[error]
-	ProcessGoInterface 
-	Return 
-// 0x312: ProcessType[*uintptr]
-	ProcessPointer 13 00 00 00 
-	Return 
-// 0x318: ProcessType[*int32]
-	ProcessPointer 2d 00 00 00 
-	Return 
-// 0x31e: ProcessType[*uint32]
-	ProcessPointer 2c 00 00 00 
-	Return 
-// 0x324: ProcessType[*float64]
-	ProcessPointer 32 00 00 00 
-	Return 
-// 0x32a: ProcessType[*int64]
-	ProcessPointer 2f 00 00 00 
-	Return 
-// 0x330: ProcessType[*uint64]
-	ProcessPointer 12 00 00 00 
-	Return 
-// 0x336: ProcessType[*error]
+// 0x25e: ProcessType[*error]
 	ProcessPointer 30 00 00 00 
 	Return 
-// 0x33c: ProcessType[*float32]
+// 0x264: ProcessType[*float32]
 	ProcessPointer 35 00 00 00 
 	Return 
-// 0x342: ProcessType[*uint]
-	ProcessPointer 34 00 00 00 
+// 0x26a: ProcessType[*float64]
+	ProcessPointer 32 00 00 00 
 	Return 
-// 0x348: ProcessType[*uint16]
-	ProcessPointer 17 00 00 00 
+// 0x270: ProcessType[*int]
+	ProcessPointer 01 00 00 00 
 	Return 
-// 0x34e: ProcessType[[]string.array]
-	ProcessSliceDataPrep 
-	Call 27 01 00 00 // ProcessType[string]
-	ProcessSliceDataRepeat 10 00 00 00 
+// 0x276: ProcessType[*int32]
+	ProcessPointer 2d 00 00 00 
 	Return 
-// 0x35a: ProcessType[*table<string,int>]
+// 0x27c: ProcessType[*int64]
+	ProcessPointer 2f 00 00 00 
+	Return 
+// 0x282: ProcessType[*main.bigStruct]
+	ProcessPointer 2a 00 00 00 
+	Return 
+// 0x288: ProcessType[*string]
+	ProcessPointer 07 00 00 00 
+	Return 
+// 0x28e: ProcessType[*table<string,int>]
 	ProcessPointer 16 00 00 00 
 	Return 
-// 0x360: ProcessType[[]*table<string,int>.array]
-	ProcessSliceDataPrep 
-	Call 5a 03 00 00 // ProcessType[*table<string,int>]
-	ProcessSliceDataRepeat 08 00 00 00 
-	Return 
-// 0x36c: ProcessType[*table<string,main.bigStruct>]
+// 0x294: ProcessType[*table<string,main.bigStruct>]
 	ProcessPointer 23 00 00 00 
 	Return 
-// 0x372: ProcessType[[]*table<string,main.bigStruct>.array]
+// 0x29a: ProcessType[*uint]
+	ProcessPointer 34 00 00 00 
+	Return 
+// 0x2a0: ProcessType[*uint16]
+	ProcessPointer 17 00 00 00 
+	Return 
+// 0x2a6: ProcessType[*uint32]
+	ProcessPointer 2c 00 00 00 
+	Return 
+// 0x2ac: ProcessType[*uint64]
+	ProcessPointer 12 00 00 00 
+	Return 
+// 0x2b2: ProcessType[*uint8]
+	ProcessPointer 09 00 00 00 
+	Return 
+// 0x2b8: ProcessType[*uintptr]
+	ProcessPointer 13 00 00 00 
+	Return 
+// 0x2be: ProcessType[[3]string]
+	ProcessArrayDataPrep 30 00 00 00 
+	Call a8 03 00 00 // ProcessType[string]
+	ProcessSliceDataRepeat 10 00 00 00 
+	Return 
+// 0x2ce: ProcessType[[]*table<string,int>.array]
 	ProcessSliceDataPrep 
-	Call 6c 03 00 00 // ProcessType[*table<string,main.bigStruct>]
+	Call 8e 02 00 00 // ProcessType[*table<string,int>]
 	ProcessSliceDataRepeat 08 00 00 00 
 	Return 
-// 0x37e: ProcessType[groupReference<string,int>]
+// 0x2da: ProcessType[[]*table<string,main.bigStruct>.array]
+	ProcessSliceDataPrep 
+	Call 94 02 00 00 // ProcessType[*table<string,main.bigStruct>]
+	ProcessSliceDataRepeat 08 00 00 00 
+	Return 
+// 0x2e6: ProcessType[[]int]
+	ProcessSlice 44 00 00 00 08 00 00 00 
+	Return 
+// 0x2f0: ProcessType[[]noalg.map.group[string]int.array]
+	ProcessSliceDataPrep 
+	Call 7c 03 00 00 // ProcessType[noalg.map.group[string]int]
+	ProcessSliceDataRepeat 00 00 00 00 
+	Return 
+// 0x2fc: ProcessType[[]noalg.map.group[string]main.bigStruct.array]
+	ProcessSliceDataPrep 
+	Call 87 03 00 00 // ProcessType[noalg.map.group[string]main.bigStruct]
+	ProcessSliceDataRepeat 00 00 00 00 
+	Return 
+// 0x308: ProcessType[[]string]
+	ProcessSlice 46 00 00 00 10 00 00 00 
+	Return 
+// 0x312: ProcessType[[]string.array]
+	ProcessSliceDataPrep 
+	Call a8 03 00 00 // ProcessType[string]
+	ProcessSliceDataRepeat 10 00 00 00 
+	Return 
+// 0x31e: ProcessType[error]
+	ProcessGoInterface 
+	Return 
+// 0x320: ProcessType[groupReference<string,int>]
 	ProcessGoSwissMapGroups 49 00 00 00 c8 00 00 00 00 08 
 	Return 
-// 0x38a: ProcessType[table<string,int>]
-	IncrementOutputOffset 10 00 00 00 
-	Call 7e 03 00 00 // ProcessType[groupReference<string,int>]
-	Return 
-// 0x395: ProcessType[groupReference<string,main.bigStruct>]
+// 0x32c: ProcessType[groupReference<string,main.bigStruct>]
 	ProcessGoSwissMapGroups 4b 00 00 00 c8 00 00 00 00 08 
 	Return 
-// 0x3a1: ProcessType[table<string,main.bigStruct>]
+// 0x338: ProcessType[map<string,int>]
+	ProcessGoSwissMap 48 00 00 00 1a 00 00 00 10 18 
+	Return 
+// 0x344: ProcessType[map<string,main.bigStruct>]
+	ProcessGoSwissMap 4a 00 00 00 26 00 00 00 10 18 
+	Return 
+// 0x350: ProcessType[map[string]int]
+	ProcessPointer 11 00 00 00 
+	Return 
+// 0x356: ProcessType[map[string]main.bigStruct]
+	ProcessPointer 20 00 00 00 
+	Return 
+// 0x35c: ProcessType[noalg.[8]struct { key string; elem *main.bigStruct }]
+	ProcessArrayDataPrep c0 00 00 00 
+	Call 92 03 00 00 // ProcessType[noalg.struct { key string; elem *main.bigStruct }]
+	ProcessSliceDataRepeat 08 00 00 00 
+	Return 
+// 0x36c: ProcessType[noalg.[8]struct { key string; elem int }]
+	ProcessArrayDataPrep c0 00 00 00 
+	Call a2 03 00 00 // ProcessType[noalg.struct { key string; elem int }]
+	ProcessSliceDataRepeat 18 00 00 00 
+	Return 
+// 0x37c: ProcessType[noalg.map.group[string]int]
+	IncrementOutputOffset 08 00 00 00 
+	Call 6c 03 00 00 // ProcessType[noalg.[8]struct { key string; elem int }]
+	Return 
+// 0x387: ProcessType[noalg.map.group[string]main.bigStruct]
+	IncrementOutputOffset 08 00 00 00 
+	Call 5c 03 00 00 // ProcessType[noalg.[8]struct { key string; elem *main.bigStruct }]
+	Return 
+// 0x392: ProcessType[noalg.struct { key string; elem *main.bigStruct }]
+	Call a8 03 00 00 // ProcessType[string]
 	IncrementOutputOffset 10 00 00 00 
-	Call 95 03 00 00 // ProcessType[groupReference<string,main.bigStruct>]
+	Call 82 02 00 00 // ProcessType[*main.bigStruct]
 	Return 
-// 0x3ac: ProcessType[[]noalg.map.group[string]int.array]
-	ProcessSliceDataPrep 
-	Call c2 02 00 00 // ProcessType[noalg.map.group[string]int]
-	ProcessSliceDataRepeat 00 00 00 00 
+// 0x3a2: ProcessType[noalg.struct { key string; elem int }]
+	Call a8 03 00 00 // ProcessType[string]
 	Return 
-// 0x3b8: ProcessType[[]noalg.map.group[string]main.bigStruct.array]
-	ProcessSliceDataPrep 
-	Call ff 02 00 00 // ProcessType[noalg.map.group[string]main.bigStruct]
-	ProcessSliceDataRepeat 00 00 00 00 
+// 0x3a8: ProcessType[string]
+	ProcessString 42 00 00 00 
+	Return 
+// 0x3ae: ProcessType[table<string,int>]
+	IncrementOutputOffset 10 00 00 00 
+	Call 20 03 00 00 // ProcessType[groupReference<string,int>]
+	Return 
+// 0x3b9: ProcessType[table<string,main.bigStruct>]
+	IncrementOutputOffset 10 00 00 00 
+	Call 2c 03 00 00 // ProcessType[groupReference<string,main.bigStruct>]
 	Return 
 // Extra illegal ops to simplify code bound checks
 	Illegal 
@@ -307,80 +307,80 @@
 	Illegal 
 // Types
 ID: 1 Len: 8 Enqueue: 0
-ID: 2 Len: 8 Enqueue: 3
-ID: 3 Len: 8 Enqueue: 642
-ID: 4 Len: 8 Enqueue: 648
-ID: 5 Len: 8 Enqueue: 51
-ID: 6 Len: 8 Enqueue: 654
-ID: 7 Len: 16 Enqueue: 295
-ID: 8 Len: 8 Enqueue: 660
+ID: 2 Len: 8 Enqueue: 576
+ID: 3 Len: 8 Enqueue: 582
+ID: 4 Len: 8 Enqueue: 588
+ID: 5 Len: 8 Enqueue: 594
+ID: 6 Len: 8 Enqueue: 624
+ID: 7 Len: 16 Enqueue: 936
+ID: 8 Len: 8 Enqueue: 690
 ID: 9 Len: 1 Enqueue: 0
-ID: 10 Len: 24 Enqueue: 365
+ID: 10 Len: 24 Enqueue: 742
 ID: 11 Len: 24 Enqueue: 0
-ID: 12 Len: 24 Enqueue: 576
-ID: 13 Len: 8 Enqueue: 666
-ID: 14 Len: 48 Enqueue: 301
-ID: 15 Len: 8 Enqueue: 431
+ID: 12 Len: 24 Enqueue: 776
+ID: 13 Len: 8 Enqueue: 648
+ID: 14 Len: 48 Enqueue: 702
+ID: 15 Len: 8 Enqueue: 848
 ID: 16 Len: 8 Enqueue: 0
-ID: 17 Len: 48 Enqueue: 672
+ID: 17 Len: 48 Enqueue: 824
 ID: 18 Len: 8 Enqueue: 0
 ID: 19 Len: 8 Enqueue: 0
 ID: 20 Len: 8 Enqueue: 0
-ID: 21 Len: 8 Enqueue: 858
-ID: 22 Len: 32 Enqueue: 906
+ID: 21 Len: 8 Enqueue: 654
+ID: 22 Len: 32 Enqueue: 942
 ID: 23 Len: 2 Enqueue: 0
-ID: 24 Len: 16 Enqueue: 894
+ID: 24 Len: 16 Enqueue: 800
 ID: 25 Len: 8 Enqueue: 0
-ID: 26 Len: 200 Enqueue: 706
-ID: 27 Len: 192 Enqueue: 690
-ID: 28 Len: 24 Enqueue: 684
+ID: 26 Len: 200 Enqueue: 892
+ID: 27 Len: 192 Enqueue: 876
+ID: 28 Len: 24 Enqueue: 930
 ID: 29 Len: 1 Enqueue: 0
-ID: 30 Len: 8 Enqueue: 99
+ID: 30 Len: 8 Enqueue: 854
 ID: 31 Len: 8 Enqueue: 0
-ID: 32 Len: 48 Enqueue: 717
+ID: 32 Len: 48 Enqueue: 836
 ID: 33 Len: 8 Enqueue: 0
-ID: 34 Len: 8 Enqueue: 876
-ID: 35 Len: 32 Enqueue: 929
-ID: 36 Len: 16 Enqueue: 917
+ID: 34 Len: 8 Enqueue: 660
+ID: 35 Len: 32 Enqueue: 953
+ID: 36 Len: 16 Enqueue: 812
 ID: 37 Len: 8 Enqueue: 0
-ID: 38 Len: 200 Enqueue: 767
-ID: 39 Len: 192 Enqueue: 751
-ID: 40 Len: 24 Enqueue: 735
-ID: 41 Len: 8 Enqueue: 729
+ID: 38 Len: 200 Enqueue: 903
+ID: 39 Len: 192 Enqueue: 860
+ID: 40 Len: 24 Enqueue: 914
+ID: 41 Len: 8 Enqueue: 642
 ID: 42 Len: 184 Enqueue: 0
 ID: 43 Len: 128 Enqueue: 0
 ID: 44 Len: 4 Enqueue: 0
 ID: 45 Len: 4 Enqueue: 0
-ID: 46 Len: 8 Enqueue: 778
+ID: 46 Len: 8 Enqueue: 600
 ID: 47 Len: 8 Enqueue: 0
-ID: 48 Len: 16 Enqueue: 784
+ID: 48 Len: 16 Enqueue: 798
 ID: 49 Len: 8 Enqueue: 0
 ID: 50 Len: 8 Enqueue: 0
 ID: 51 Len: 1 Enqueue: 0
 ID: 52 Len: 8 Enqueue: 0
 ID: 53 Len: 4 Enqueue: 0
-ID: 54 Len: 8 Enqueue: 786
-ID: 55 Len: 8 Enqueue: 792
-ID: 56 Len: 8 Enqueue: 798
+ID: 54 Len: 8 Enqueue: 696
+ID: 55 Len: 8 Enqueue: 630
+ID: 56 Len: 8 Enqueue: 678
 ID: 57 Len: 8 Enqueue: 0
 ID: 58 Len: 16 Enqueue: 0
-ID: 59 Len: 8 Enqueue: 804
-ID: 60 Len: 8 Enqueue: 810
-ID: 61 Len: 8 Enqueue: 816
-ID: 62 Len: 8 Enqueue: 822
-ID: 63 Len: 8 Enqueue: 828
-ID: 64 Len: 8 Enqueue: 834
-ID: 65 Len: 8 Enqueue: 840
+ID: 59 Len: 8 Enqueue: 618
+ID: 60 Len: 8 Enqueue: 636
+ID: 61 Len: 8 Enqueue: 684
+ID: 62 Len: 8 Enqueue: 606
+ID: 63 Len: 8 Enqueue: 612
+ID: 64 Len: 8 Enqueue: 666
+ID: 65 Len: 8 Enqueue: 672
 ID: 66 Len: 2048 Enqueue: 0
 ID: 67 Len: 8 Enqueue: 0
 ID: 68 Len: 2048 Enqueue: 0
 ID: 69 Len: 8 Enqueue: 0
-ID: 70 Len: 2048 Enqueue: 846
+ID: 70 Len: 2048 Enqueue: 786
 ID: 71 Len: 8 Enqueue: 0
-ID: 72 Len: 8192 Enqueue: 864
-ID: 73 Len: 2048 Enqueue: 940
-ID: 74 Len: 8192 Enqueue: 882
-ID: 75 Len: 2048 Enqueue: 952
+ID: 72 Len: 8192 Enqueue: 718
+ID: 73 Len: 2048 Enqueue: 752
+ID: 74 Len: 8192 Enqueue: 730
+ID: 75 Len: 2048 Enqueue: 764
 ID: 76 Len: 9 Enqueue: 0
 ID: 77 Len: 17 Enqueue: 0
 ID: 78 Len: 25 Enqueue: 0

--- a/pkg/dyninst/compiler/testdata/snapshot/simple.arch=arm64,toolchain=go1.23.11.sm.txt
+++ b/pkg/dyninst/compiler/testdata/snapshot/simple.arch=arm64,toolchain=go1.23.11.sm.txt
@@ -10,7 +10,7 @@
 	Call 40 02 00 00 // ProcessType[*****int]
 	Return 
 // 0x1e: ProcessEvent[Probe[main.PointerChainArg]@b5338]
-	PrepareEventRoot 56 00 00 00 09 00 00 00 
+	PrepareEventRoot 4f 00 00 00 09 00 00 00 
 	Call 03 00 00 00 // ProcessExpression[Probe[main.PointerChainArg]@0xb5338.expr[0]]
 	Return 
 // 0x2d: ProcessExpression[Probe[main.PointerSmallChainArg]@0xb5370.expr[0]]
@@ -20,17 +20,17 @@
 	Call 52 02 00 00 // ProcessType[**int]
 	Return 
 // 0x48: ProcessEvent[Probe[main.PointerSmallChainArg]@b5370]
-	PrepareEventRoot 57 00 00 00 09 00 00 00 
+	PrepareEventRoot 50 00 00 00 09 00 00 00 
 	Call 2d 00 00 00 // ProcessExpression[Probe[main.PointerSmallChainArg]@0xb5370.expr[0]]
 	Return 
 // 0x57: ProcessExpression[Probe[main.bigMapArg]@0xb5820.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
-	Call 9c 03 00 00 // ProcessType[map[string]main.bigStruct]
+	Call 7a 03 00 00 // ProcessType[map[string]main.bigStruct]
 	Return 
 // 0x72: ProcessEvent[Probe[main.bigMapArg]@b5820]
-	PrepareEventRoot 54 00 00 00 09 00 00 00 
+	PrepareEventRoot 4d 00 00 00 09 00 00 00 
 	Call 57 00 00 00 // ProcessExpression[Probe[main.bigMapArg]@0xb5820.expr[0]]
 	Return 
 // 0x81: ProcessExpression[Probe[main.inlined]@0xb56ec.expr[0]]
@@ -39,7 +39,7 @@
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
 	Return 
 // 0x97: ProcessEvent[Probe[main.inlined]@b56ec]
-	PrepareEventRoot 55 00 00 00 09 00 00 00 
+	PrepareEventRoot 4e 00 00 00 09 00 00 00 
 	Call 81 00 00 00 // ProcessExpression[Probe[main.inlined]@0xb56ec.expr[0]]
 	Return 
 // 0xa6: ProcessExpression[Probe[main.inlined]@0xb514c.expr[0]]
@@ -48,7 +48,7 @@
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
 	Return 
 // 0xb6: ProcessEvent[Probe[main.inlined]@b514c]
-	PrepareEventRoot 55 00 00 00 09 00 00 00 
+	PrepareEventRoot 4e 00 00 00 09 00 00 00 
 	Call a6 00 00 00 // ProcessExpression[Probe[main.inlined]@0xb514c.expr[0]]
 	Return 
 // 0xc5: ProcessExpression[Probe[main.intArg]@0xb53cc.expr[0]]
@@ -57,7 +57,7 @@
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
 	Return 
 // 0xdb: ProcessEvent[Probe[main.intArg]@b53cc]
-	PrepareEventRoot 4c 00 00 00 09 00 00 00 
+	PrepareEventRoot 45 00 00 00 09 00 00 00 
 	Call c5 00 00 00 // ProcessExpression[Probe[main.intArg]@0xb53cc.expr[0]]
 	Return 
 // 0xea: ProcessExpression[Probe[main.intArrayArg]@0xb554c.expr[0]]
@@ -66,17 +66,17 @@
 	ExprSave 01 00 00 00 18 00 00 00 00 00 00 00 
 	Return 
 // 0x106: ProcessEvent[Probe[main.intArrayArg]@b554c]
-	PrepareEventRoot 4f 00 00 00 19 00 00 00 
+	PrepareEventRoot 48 00 00 00 19 00 00 00 
 	Call ea 00 00 00 // ProcessExpression[Probe[main.intArrayArg]@0xb554c.expr[0]]
 	Return 
 // 0x115: ProcessExpression[Probe[main.stringArrayArgFrameless]@0xb56d0.expr[0]]
 	ExprPrepare 
 	ExprDereferenceCfa 08 00 00 00 30 00 00 00 00 00 00 00 
 	ExprSave 01 00 00 00 30 00 00 00 00 00 00 00 
-	Call d0 02 00 00 // ProcessType[[3]string]
+	Call c4 02 00 00 // ProcessType[[3]string]
 	Return 
 // 0x136: ProcessEvent[Probe[main.stringArrayArgFrameless]@b56d0]
-	PrepareEventRoot 52 00 00 00 31 00 00 00 
+	PrepareEventRoot 4b 00 00 00 31 00 00 00 
 	Call 15 01 00 00 // ProcessExpression[Probe[main.stringArrayArgFrameless]@0xb56d0.expr[0]]
 	Return 
 // 0x145: ProcessExpression[Probe[main.intSliceArg]@0xb54bc.expr[0]]
@@ -85,20 +85,20 @@
 	ExprReadRegister 01 08 08 00 00 00 
 	ExprReadRegister 02 08 10 00 00 00 
 	ExprSave 01 00 00 00 18 00 00 00 00 00 00 00 
-	Call 0e 03 00 00 // ProcessType[[]int]
+	Call ec 02 00 00 // ProcessType[[]int]
 	Return 
 // 0x16e: ProcessEvent[Probe[main.intSliceArg]@b54bc]
-	PrepareEventRoot 4e 00 00 00 19 00 00 00 
+	PrepareEventRoot 47 00 00 00 19 00 00 00 
 	Call 45 01 00 00 // ProcessExpression[Probe[main.intSliceArg]@0xb54bc.expr[0]]
 	Return 
 // 0x17d: ProcessExpression[Probe[main.mapArg]@0xb57ac.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
-	Call 96 03 00 00 // ProcessType[map[string]int]
+	Call 74 03 00 00 // ProcessType[map[string]int]
 	Return 
 // 0x198: ProcessEvent[Probe[main.mapArg]@b57ac]
-	PrepareEventRoot 53 00 00 00 09 00 00 00 
+	PrepareEventRoot 4c 00 00 00 09 00 00 00 
 	Call 7d 01 00 00 // ProcessExpression[Probe[main.mapArg]@0xb57ac.expr[0]]
 	Return 
 // 0x1a7: ProcessExpression[Probe[main.stringArg]@0xb543c.expr[0]]
@@ -106,20 +106,20 @@
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprReadRegister 01 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call bc 03 00 00 // ProcessType[string]
+	Call 80 03 00 00 // ProcessType[string]
 	Return 
 // 0x1c9: ProcessEvent[Probe[main.stringArg]@b543c]
-	PrepareEventRoot 4d 00 00 00 11 00 00 00 
+	PrepareEventRoot 46 00 00 00 11 00 00 00 
 	Call a7 01 00 00 // ProcessExpression[Probe[main.stringArg]@0xb543c.expr[0]]
 	Return 
 // 0x1d8: ProcessExpression[Probe[main.stringArrayArg]@0xb565c.expr[0]]
 	ExprPrepare 
 	ExprDereferenceCfa 08 00 00 00 30 00 00 00 00 00 00 00 
 	ExprSave 01 00 00 00 30 00 00 00 00 00 00 00 
-	Call d0 02 00 00 // ProcessType[[3]string]
+	Call c4 02 00 00 // ProcessType[[3]string]
 	Return 
 // 0x1f9: ProcessEvent[Probe[main.stringArrayArg]@b565c]
-	PrepareEventRoot 51 00 00 00 31 00 00 00 
+	PrepareEventRoot 4a 00 00 00 31 00 00 00 
 	Call d8 01 00 00 // ProcessExpression[Probe[main.stringArrayArg]@0xb565c.expr[0]]
 	Return 
 // 0x208: ProcessExpression[Probe[main.stringSliceArg]@0xb55cc.expr[0]]
@@ -128,17 +128,17 @@
 	ExprReadRegister 01 08 08 00 00 00 
 	ExprReadRegister 02 08 10 00 00 00 
 	ExprSave 01 00 00 00 18 00 00 00 00 00 00 00 
-	Call 28 03 00 00 // ProcessType[[]string]
+	Call 06 03 00 00 // ProcessType[[]string]
 	Return 
 // 0x231: ProcessEvent[Probe[main.stringSliceArg]@b55cc]
-	PrepareEventRoot 50 00 00 00 19 00 00 00 
+	PrepareEventRoot 49 00 00 00 19 00 00 00 
 	Call 08 02 00 00 // ProcessExpression[Probe[main.stringSliceArg]@0xb55cc.expr[0]]
 	Return 
 // 0x240: ProcessType[*****int]
 	ProcessPointer 33 00 00 00 
 	Return 
 // 0x246: ProcessType[****int]
-	ProcessPointer 3f 00 00 00 
+	ProcessPointer 43 00 00 00 
 	Return 
 // 0x24c: ProcessType[***int]
 	ProcessPointer 34 00 00 00 
@@ -146,146 +146,125 @@
 // 0x252: ProcessType[**int]
 	ProcessPointer 1c 00 00 00 
 	Return 
-// 0x258: ProcessType[*[]*runtime.bmap]
-	ProcessPointer 39 00 00 00 
-	Return 
-// 0x25e: ProcessType[*bool]
+// 0x258: ProcessType[*bool]
 	ProcessPointer 04 00 00 00 
 	Return 
-// 0x264: ProcessType[*bucket<string,int>]
+// 0x25e: ProcessType[*bucket<string,int>]
 	ProcessPointer 2a 00 00 00 
 	Return 
-// 0x26a: ProcessType[*bucket<string,main.bigStruct>]
+// 0x264: ProcessType[*bucket<string,main.bigStruct>]
 	ProcessPointer 31 00 00 00 
 	Return 
-// 0x270: ProcessType[*error]
+// 0x26a: ProcessType[*error]
 	ProcessPointer 12 00 00 00 
 	Return 
-// 0x276: ProcessType[*float32]
+// 0x270: ProcessType[*float32]
 	ProcessPointer 10 00 00 00 
 	Return 
-// 0x27c: ProcessType[*float64]
+// 0x276: ProcessType[*float64]
 	ProcessPointer 11 00 00 00 
 	Return 
-// 0x282: ProcessType[*int]
+// 0x27c: ProcessType[*int]
 	ProcessPointer 09 00 00 00 
 	Return 
-// 0x288: ProcessType[*int32]
+// 0x282: ProcessType[*int32]
 	ProcessPointer 0d 00 00 00 
 	Return 
-// 0x28e: ProcessType[*int64]
+// 0x288: ProcessType[*int64]
 	ProcessPointer 0e 00 00 00 
 	Return 
-// 0x294: ProcessType[*main.bigStruct]
-	ProcessPointer 3e 00 00 00 
+// 0x28e: ProcessType[*main.bigStruct]
+	ProcessPointer 41 00 00 00 
 	Return 
-// 0x29a: ProcessType[*runtime.bmap]
-	ProcessPointer 3b 00 00 00 
-	Return 
-// 0x2a0: ProcessType[*runtime.mapextra]
+// 0x294: ProcessType[*runtime.mapextra]
 	ProcessPointer 2c 00 00 00 
 	Return 
-// 0x2a6: ProcessType[*string]
+// 0x29a: ProcessType[*string]
 	ProcessPointer 0a 00 00 00 
 	Return 
-// 0x2ac: ProcessType[*uint]
+// 0x2a0: ProcessType[*uint]
 	ProcessPointer 0c 00 00 00 
 	Return 
-// 0x2b2: ProcessType[*uint16]
+// 0x2a6: ProcessType[*uint16]
 	ProcessPointer 07 00 00 00 
 	Return 
-// 0x2b8: ProcessType[*uint32]
+// 0x2ac: ProcessType[*uint32]
 	ProcessPointer 02 00 00 00 
 	Return 
-// 0x2be: ProcessType[*uint64]
+// 0x2b2: ProcessType[*uint64]
 	ProcessPointer 0b 00 00 00 
 	Return 
-// 0x2c4: ProcessType[*uint8]
+// 0x2b8: ProcessType[*uint8]
 	ProcessPointer 03 00 00 00 
 	Return 
-// 0x2ca: ProcessType[*uintptr]
+// 0x2be: ProcessType[*uintptr]
 	ProcessPointer 01 00 00 00 
 	Return 
-// 0x2d0: ProcessType[[3]string]
+// 0x2c4: ProcessType[[3]string]
 	ProcessArrayDataPrep 30 00 00 00 
-	Call bc 03 00 00 // ProcessType[string]
+	Call 80 03 00 00 // ProcessType[string]
 	ProcessSliceDataRepeat 10 00 00 00 
 	Return 
-// 0x2e0: ProcessType[[]*runtime.bmap]
-	ProcessSlice 4a 00 00 00 08 00 00 00 
-	Return 
-// 0x2ea: ProcessType[[]*runtime.bmap.array]
+// 0x2d4: ProcessType[[]bucket<string,int>.array]
 	ProcessSliceDataPrep 
-	Call 9a 02 00 00 // ProcessType[*runtime.bmap]
+	Call 2c 03 00 00 // ProcessType[bucket<string,int>]
 	ProcessSliceDataRepeat 08 00 00 00 
 	Return 
-// 0x2f6: ProcessType[[]bucket<string,int>.array]
+// 0x2e0: ProcessType[[]bucket<string,main.bigStruct>.array]
 	ProcessSliceDataPrep 
-	Call 4e 03 00 00 // ProcessType[bucket<string,int>]
+	Call 41 03 00 00 // ProcessType[bucket<string,main.bigStruct>]
 	ProcessSliceDataRepeat 08 00 00 00 
 	Return 
-// 0x302: ProcessType[[]bucket<string,main.bigStruct>.array]
-	ProcessSliceDataPrep 
-	Call 63 03 00 00 // ProcessType[bucket<string,main.bigStruct>]
-	ProcessSliceDataRepeat 08 00 00 00 
+// 0x2ec: ProcessType[[]int]
+	ProcessSlice 37 00 00 00 08 00 00 00 
 	Return 
-// 0x30e: ProcessType[[]int]
-	ProcessSlice 42 00 00 00 08 00 00 00 
-	Return 
-// 0x318: ProcessType[[]key<string>]
+// 0x2f6: ProcessType[[]key<string>]
 	ProcessArrayDataPrep 80 00 00 00 
-	Call bc 03 00 00 // ProcessType[string]
+	Call 80 03 00 00 // ProcessType[string]
 	ProcessSliceDataRepeat 10 00 00 00 
 	Return 
-// 0x328: ProcessType[[]string]
-	ProcessSlice 44 00 00 00 10 00 00 00 
+// 0x306: ProcessType[[]string]
+	ProcessSlice 39 00 00 00 10 00 00 00 
 	Return 
-// 0x332: ProcessType[[]string.array]
+// 0x310: ProcessType[[]string.array]
 	ProcessSliceDataPrep 
-	Call bc 03 00 00 // ProcessType[string]
+	Call 80 03 00 00 // ProcessType[string]
 	ProcessSliceDataRepeat 10 00 00 00 
 	Return 
-// 0x33e: ProcessType[[]val<main.bigStruct>]
+// 0x31c: ProcessType[[]val<main.bigStruct>]
 	ProcessArrayDataPrep 40 00 00 00 
-	Call 94 02 00 00 // ProcessType[*main.bigStruct]
+	Call 8e 02 00 00 // ProcessType[*main.bigStruct]
 	ProcessSliceDataRepeat 08 00 00 00 
 	Return 
-// 0x34e: ProcessType[bucket<string,int>]
+// 0x32c: ProcessType[bucket<string,int>]
 	IncrementOutputOffset 08 00 00 00 
-	Call 18 03 00 00 // ProcessType[[]key<string>]
+	Call f6 02 00 00 // ProcessType[[]key<string>]
 	IncrementOutputOffset 40 00 00 00 
-	Call 64 02 00 00 // ProcessType[*bucket<string,int>]
+	Call 5e 02 00 00 // ProcessType[*bucket<string,int>]
 	Return 
-// 0x363: ProcessType[bucket<string,main.bigStruct>]
+// 0x341: ProcessType[bucket<string,main.bigStruct>]
 	IncrementOutputOffset 08 00 00 00 
-	Call 18 03 00 00 // ProcessType[[]key<string>]
-	Call 3e 03 00 00 // ProcessType[[]val<main.bigStruct>]
-	Call 6a 02 00 00 // ProcessType[*bucket<string,main.bigStruct>]
+	Call f6 02 00 00 // ProcessType[[]key<string>]
+	Call 1c 03 00 00 // ProcessType[[]val<main.bigStruct>]
+	Call 64 02 00 00 // ProcessType[*bucket<string,main.bigStruct>]
 	Return 
-// 0x378: ProcessType[error]
+// 0x356: ProcessType[error]
 	ProcessGoInterface 
 	Return 
-// 0x37a: ProcessType[hash<string,int>]
-	ProcessGoHmap 46 00 00 00 d0 00 00 00 08 09 10 18 
+// 0x358: ProcessType[hash<string,int>]
+	ProcessGoHmap 3e 00 00 00 d0 00 00 00 08 09 10 18 
 	Return 
-// 0x388: ProcessType[hash<string,main.bigStruct>]
-	ProcessGoHmap 47 00 00 00 d0 00 00 00 08 09 10 18 
+// 0x366: ProcessType[hash<string,main.bigStruct>]
+	ProcessGoHmap 42 00 00 00 d0 00 00 00 08 09 10 18 
 	Return 
-// 0x396: ProcessType[map[string]int]
+// 0x374: ProcessType[map[string]int]
 	ProcessPointer 28 00 00 00 
 	Return 
-// 0x39c: ProcessType[map[string]main.bigStruct]
+// 0x37a: ProcessType[map[string]main.bigStruct]
 	ProcessPointer 2f 00 00 00 
 	Return 
-// 0x3a2: ProcessType[runtime.mapextra]
-	Call 58 02 00 00 // ProcessType[*[]*runtime.bmap]
-	IncrementOutputOffset 08 00 00 00 
-	Call 58 02 00 00 // ProcessType[*[]*runtime.bmap]
-	IncrementOutputOffset 08 00 00 00 
-	Call 9a 02 00 00 // ProcessType[*runtime.bmap]
-	Return 
-// 0x3bc: ProcessType[string]
-	ProcessString 40 00 00 00 
+// 0x380: ProcessType[string]
+	ProcessString 35 00 00 00 
 	Return 
 // Extra illegal ops to simplify code bound checks
 	Illegal 
@@ -306,12 +285,12 @@ ID: 1 Len: 8 Enqueue: 0
 ID: 2 Len: 4 Enqueue: 0
 ID: 3 Len: 1 Enqueue: 0
 ID: 4 Len: 1 Enqueue: 0
-ID: 5 Len: 8 Enqueue: 606
-ID: 6 Len: 8 Enqueue: 708
+ID: 5 Len: 8 Enqueue: 600
+ID: 6 Len: 8 Enqueue: 696
 ID: 7 Len: 2 Enqueue: 0
-ID: 8 Len: 8 Enqueue: 714
+ID: 8 Len: 8 Enqueue: 702
 ID: 9 Len: 8 Enqueue: 0
-ID: 10 Len: 16 Enqueue: 956
+ID: 10 Len: 16 Enqueue: 896
 ID: 11 Len: 8 Enqueue: 0
 ID: 12 Len: 8 Enqueue: 0
 ID: 13 Len: 4 Enqueue: 0
@@ -319,73 +298,66 @@ ID: 14 Len: 8 Enqueue: 0
 ID: 15 Len: 1 Enqueue: 0
 ID: 16 Len: 4 Enqueue: 0
 ID: 17 Len: 8 Enqueue: 0
-ID: 18 Len: 16 Enqueue: 888
+ID: 18 Len: 16 Enqueue: 854
 ID: 19 Len: 8 Enqueue: 0
-ID: 20 Len: 8 Enqueue: 648
-ID: 21 Len: 8 Enqueue: 696
-ID: 22 Len: 8 Enqueue: 678
+ID: 20 Len: 8 Enqueue: 642
+ID: 21 Len: 8 Enqueue: 684
+ID: 22 Len: 8 Enqueue: 666
 ID: 23 Len: 2 Enqueue: 0
 ID: 24 Len: 8 Enqueue: 0
 ID: 25 Len: 16 Enqueue: 0
-ID: 26 Len: 8 Enqueue: 636
-ID: 27 Len: 8 Enqueue: 654
-ID: 28 Len: 8 Enqueue: 642
-ID: 29 Len: 8 Enqueue: 702
-ID: 30 Len: 8 Enqueue: 624
-ID: 31 Len: 8 Enqueue: 630
-ID: 32 Len: 8 Enqueue: 684
-ID: 33 Len: 8 Enqueue: 690
-ID: 34 Len: 24 Enqueue: 782
+ID: 26 Len: 8 Enqueue: 630
+ID: 27 Len: 8 Enqueue: 648
+ID: 28 Len: 8 Enqueue: 636
+ID: 29 Len: 8 Enqueue: 690
+ID: 30 Len: 8 Enqueue: 618
+ID: 31 Len: 8 Enqueue: 624
+ID: 32 Len: 8 Enqueue: 672
+ID: 33 Len: 8 Enqueue: 678
+ID: 34 Len: 24 Enqueue: 748
 ID: 35 Len: 24 Enqueue: 0
-ID: 36 Len: 24 Enqueue: 808
-ID: 37 Len: 48 Enqueue: 720
-ID: 38 Len: 8 Enqueue: 918
+ID: 36 Len: 24 Enqueue: 774
+ID: 37 Len: 48 Enqueue: 708
+ID: 38 Len: 8 Enqueue: 884
 ID: 39 Len: 8 Enqueue: 0
-ID: 40 Len: 48 Enqueue: 890
-ID: 41 Len: 8 Enqueue: 612
-ID: 42 Len: 208 Enqueue: 846
-ID: 43 Len: 8 Enqueue: 672
-ID: 44 Len: 24 Enqueue: 930
-ID: 45 Len: 8 Enqueue: 924
+ID: 40 Len: 48 Enqueue: 856
+ID: 41 Len: 8 Enqueue: 606
+ID: 42 Len: 208 Enqueue: 812
+ID: 43 Len: 8 Enqueue: 660
+ID: 44 Len: 8 Enqueue: 0
+ID: 45 Len: 8 Enqueue: 890
 ID: 46 Len: 8 Enqueue: 0
-ID: 47 Len: 48 Enqueue: 904
-ID: 48 Len: 8 Enqueue: 618
-ID: 49 Len: 208 Enqueue: 867
+ID: 47 Len: 48 Enqueue: 870
+ID: 48 Len: 8 Enqueue: 612
+ID: 49 Len: 208 Enqueue: 833
 ID: 50 Len: 8 Enqueue: 576
 ID: 51 Len: 8 Enqueue: 582
 ID: 52 Len: 8 Enqueue: 594
-ID: 53 Len: 8 Enqueue: 0
-ID: 54 Len: 128 Enqueue: 792
-ID: 55 Len: 64 Enqueue: 0
-ID: 56 Len: 8 Enqueue: 600
-ID: 57 Len: 24 Enqueue: 736
-ID: 58 Len: 8 Enqueue: 666
+ID: 53 Len: 2048 Enqueue: 0
+ID: 54 Len: 8 Enqueue: 0
+ID: 55 Len: 2048 Enqueue: 0
+ID: 56 Len: 8 Enqueue: 0
+ID: 57 Len: 2048 Enqueue: 784
+ID: 58 Len: 8 Enqueue: 0
 ID: 59 Len: 8 Enqueue: 0
-ID: 60 Len: 64 Enqueue: 830
-ID: 61 Len: 8 Enqueue: 660
-ID: 62 Len: 184 Enqueue: 0
-ID: 63 Len: 8 Enqueue: 588
-ID: 64 Len: 2048 Enqueue: 0
-ID: 65 Len: 8 Enqueue: 0
-ID: 66 Len: 2048 Enqueue: 0
-ID: 67 Len: 8 Enqueue: 0
-ID: 68 Len: 2048 Enqueue: 818
-ID: 69 Len: 8 Enqueue: 0
-ID: 70 Len: 2048 Enqueue: 758
-ID: 71 Len: 2048 Enqueue: 770
-ID: 72 Len: 8 Enqueue: 0
-ID: 73 Len: 128 Enqueue: 0
-ID: 74 Len: 2048 Enqueue: 746
-ID: 75 Len: 8 Enqueue: 0
+ID: 60 Len: 128 Enqueue: 758
+ID: 61 Len: 64 Enqueue: 0
+ID: 62 Len: 2048 Enqueue: 724
+ID: 63 Len: 64 Enqueue: 796
+ID: 64 Len: 8 Enqueue: 654
+ID: 65 Len: 184 Enqueue: 0
+ID: 66 Len: 2048 Enqueue: 736
+ID: 67 Len: 8 Enqueue: 588
+ID: 68 Len: 128 Enqueue: 0
+ID: 69 Len: 9 Enqueue: 0
+ID: 70 Len: 17 Enqueue: 0
+ID: 71 Len: 25 Enqueue: 0
+ID: 72 Len: 25 Enqueue: 0
+ID: 73 Len: 25 Enqueue: 0
+ID: 74 Len: 49 Enqueue: 0
+ID: 75 Len: 49 Enqueue: 0
 ID: 76 Len: 9 Enqueue: 0
-ID: 77 Len: 17 Enqueue: 0
-ID: 78 Len: 25 Enqueue: 0
-ID: 79 Len: 25 Enqueue: 0
-ID: 80 Len: 25 Enqueue: 0
-ID: 81 Len: 49 Enqueue: 0
-ID: 82 Len: 49 Enqueue: 0
-ID: 83 Len: 9 Enqueue: 0
-ID: 84 Len: 9 Enqueue: 0
-ID: 85 Len: 9 Enqueue: 0
-ID: 86 Len: 9 Enqueue: 0
-ID: 87 Len: 9 Enqueue: 0
+ID: 77 Len: 9 Enqueue: 0
+ID: 78 Len: 9 Enqueue: 0
+ID: 79 Len: 9 Enqueue: 0
+ID: 80 Len: 9 Enqueue: 0

--- a/pkg/dyninst/compiler/testdata/snapshot/simple.arch=arm64,toolchain=go1.23.11.sm.txt
+++ b/pkg/dyninst/compiler/testdata/snapshot/simple.arch=arm64,toolchain=go1.23.11.sm.txt
@@ -135,19 +135,19 @@
 	Call 08 02 00 00 // ProcessExpression[Probe[main.stringSliceArg]@0xb55cc.expr[0]]
 	Return 
 // 0x240: ProcessType[*****int]
-	ProcessPointer 3f 00 00 00 
+	ProcessPointer 33 00 00 00 
 	Return 
 // 0x246: ProcessType[****int]
-	ProcessPointer 40 00 00 00 
+	ProcessPointer 3f 00 00 00 
 	Return 
 // 0x24c: ProcessType[***int]
-	ProcessPointer 41 00 00 00 
+	ProcessPointer 34 00 00 00 
 	Return 
 // 0x252: ProcessType[**int]
 	ProcessPointer 1c 00 00 00 
 	Return 
 // 0x258: ProcessType[*[]*runtime.bmap]
-	ProcessPointer 31 00 00 00 
+	ProcessPointer 39 00 00 00 
 	Return 
 // 0x25e: ProcessType[*bool]
 	ProcessPointer 04 00 00 00 
@@ -156,7 +156,7 @@
 	ProcessPointer 2a 00 00 00 
 	Return 
 // 0x26a: ProcessType[*bucket<string,main.bigStruct>]
-	ProcessPointer 39 00 00 00 
+	ProcessPointer 31 00 00 00 
 	Return 
 // 0x270: ProcessType[*error]
 	ProcessPointer 12 00 00 00 
@@ -177,13 +177,13 @@
 	ProcessPointer 0e 00 00 00 
 	Return 
 // 0x294: ProcessType[*main.bigStruct]
-	ProcessPointer 3c 00 00 00 
+	ProcessPointer 3e 00 00 00 
 	Return 
 // 0x29a: ProcessType[*runtime.bmap]
-	ProcessPointer 34 00 00 00 
+	ProcessPointer 3b 00 00 00 
 	Return 
 // 0x2a0: ProcessType[*runtime.mapextra]
-	ProcessPointer 2f 00 00 00 
+	ProcessPointer 2c 00 00 00 
 	Return 
 // 0x2a6: ProcessType[*string]
 	ProcessPointer 0a 00 00 00 
@@ -212,7 +212,7 @@
 	ProcessSliceDataRepeat 10 00 00 00 
 	Return 
 // 0x2e0: ProcessType[[]*runtime.bmap]
-	ProcessSlice 49 00 00 00 08 00 00 00 
+	ProcessSlice 4a 00 00 00 08 00 00 00 
 	Return 
 // 0x2ea: ProcessType[[]*runtime.bmap.array]
 	ProcessSliceDataPrep 
@@ -269,13 +269,13 @@
 	ProcessGoHmap 48 00 00 00 d0 00 00 00 08 09 10 18 
 	Return 
 // 0x388: ProcessType[hash<string,main.bigStruct>]
-	ProcessGoHmap 4b 00 00 00 d0 00 00 00 08 09 10 18 
+	ProcessGoHmap 49 00 00 00 d0 00 00 00 08 09 10 18 
 	Return 
 // 0x396: ProcessType[map[string]int]
 	ProcessPointer 28 00 00 00 
 	Return 
 // 0x39c: ProcessType[map[string]main.bigStruct]
-	ProcessPointer 37 00 00 00 
+	ProcessPointer 2f 00 00 00 
 	Return 
 // 0x3a2: ProcessType[runtime.mapextra]
 	Call 58 02 00 00 // ProcessType[*[]*runtime.bmap]
@@ -344,29 +344,29 @@ ID: 39 Len: 8 Enqueue: 0
 ID: 40 Len: 48 Enqueue: 890
 ID: 41 Len: 8 Enqueue: 612
 ID: 42 Len: 208 Enqueue: 846
-ID: 43 Len: 8 Enqueue: 0
-ID: 44 Len: 128 Enqueue: 792
-ID: 45 Len: 64 Enqueue: 0
-ID: 46 Len: 8 Enqueue: 672
-ID: 47 Len: 24 Enqueue: 930
-ID: 48 Len: 8 Enqueue: 600
-ID: 49 Len: 24 Enqueue: 736
-ID: 50 Len: 8 Enqueue: 0
-ID: 51 Len: 8 Enqueue: 666
-ID: 52 Len: 8 Enqueue: 0
-ID: 53 Len: 8 Enqueue: 924
-ID: 54 Len: 8 Enqueue: 0
-ID: 55 Len: 48 Enqueue: 904
-ID: 56 Len: 8 Enqueue: 618
-ID: 57 Len: 208 Enqueue: 867
-ID: 58 Len: 64 Enqueue: 830
-ID: 59 Len: 8 Enqueue: 660
-ID: 60 Len: 184 Enqueue: 0
-ID: 61 Len: 128 Enqueue: 0
-ID: 62 Len: 8 Enqueue: 576
-ID: 63 Len: 8 Enqueue: 582
-ID: 64 Len: 8 Enqueue: 588
-ID: 65 Len: 8 Enqueue: 594
+ID: 43 Len: 8 Enqueue: 672
+ID: 44 Len: 24 Enqueue: 930
+ID: 45 Len: 8 Enqueue: 924
+ID: 46 Len: 8 Enqueue: 0
+ID: 47 Len: 48 Enqueue: 904
+ID: 48 Len: 8 Enqueue: 618
+ID: 49 Len: 208 Enqueue: 867
+ID: 50 Len: 8 Enqueue: 576
+ID: 51 Len: 8 Enqueue: 582
+ID: 52 Len: 8 Enqueue: 594
+ID: 53 Len: 8 Enqueue: 0
+ID: 54 Len: 128 Enqueue: 792
+ID: 55 Len: 64 Enqueue: 0
+ID: 56 Len: 8 Enqueue: 600
+ID: 57 Len: 24 Enqueue: 736
+ID: 58 Len: 8 Enqueue: 666
+ID: 59 Len: 8 Enqueue: 0
+ID: 60 Len: 64 Enqueue: 830
+ID: 61 Len: 8 Enqueue: 660
+ID: 62 Len: 184 Enqueue: 0
+ID: 63 Len: 8 Enqueue: 588
+ID: 64 Len: 8 Enqueue: 0
+ID: 65 Len: 128 Enqueue: 0
 ID: 66 Len: 2048 Enqueue: 0
 ID: 67 Len: 8 Enqueue: 0
 ID: 68 Len: 2048 Enqueue: 0
@@ -374,9 +374,9 @@ ID: 69 Len: 8 Enqueue: 0
 ID: 70 Len: 2048 Enqueue: 818
 ID: 71 Len: 8 Enqueue: 0
 ID: 72 Len: 2048 Enqueue: 758
-ID: 73 Len: 2048 Enqueue: 746
-ID: 74 Len: 8 Enqueue: 0
-ID: 75 Len: 2048 Enqueue: 770
+ID: 73 Len: 2048 Enqueue: 770
+ID: 74 Len: 2048 Enqueue: 746
+ID: 75 Len: 8 Enqueue: 0
 ID: 76 Len: 9 Enqueue: 0
 ID: 77 Len: 17 Enqueue: 0
 ID: 78 Len: 25 Enqueue: 0

--- a/pkg/dyninst/compiler/testdata/snapshot/simple.arch=arm64,toolchain=go1.23.11.sm.txt
+++ b/pkg/dyninst/compiler/testdata/snapshot/simple.arch=arm64,toolchain=go1.23.11.sm.txt
@@ -3,289 +3,289 @@
 // 0x1: ChasePointers
 	ChasePointers 
 	Return 
-// 0x3: ProcessType[*****int]
-	ProcessPointer 03 00 00 00 
-	Return 
-// 0x9: ProcessExpression[Probe[main.PointerChainArg]@0xb5338.expr[0]]
+// 0x3: ProcessExpression[Probe[main.PointerChainArg]@0xb5338.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
-	Call 03 00 00 00 // ProcessType[*****int]
+	Call 40 02 00 00 // ProcessType[*****int]
 	Return 
-// 0x24: ProcessEvent[Probe[main.PointerChainArg]@b5338]
+// 0x1e: ProcessEvent[Probe[main.PointerChainArg]@b5338]
 	PrepareEventRoot 56 00 00 00 09 00 00 00 
-	Call 09 00 00 00 // ProcessExpression[Probe[main.PointerChainArg]@0xb5338.expr[0]]
+	Call 03 00 00 00 // ProcessExpression[Probe[main.PointerChainArg]@0xb5338.expr[0]]
 	Return 
-// 0x33: ProcessType[**int]
-	ProcessPointer 06 00 00 00 
-	Return 
-// 0x39: ProcessExpression[Probe[main.PointerSmallChainArg]@0xb5370.expr[0]]
+// 0x2d: ProcessExpression[Probe[main.PointerSmallChainArg]@0xb5370.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 05 08 00 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
-	Call 33 00 00 00 // ProcessType[**int]
+	Call 52 02 00 00 // ProcessType[**int]
 	Return 
-// 0x54: ProcessEvent[Probe[main.PointerSmallChainArg]@b5370]
+// 0x48: ProcessEvent[Probe[main.PointerSmallChainArg]@b5370]
 	PrepareEventRoot 57 00 00 00 09 00 00 00 
-	Call 39 00 00 00 // ProcessExpression[Probe[main.PointerSmallChainArg]@0xb5370.expr[0]]
+	Call 2d 00 00 00 // ProcessExpression[Probe[main.PointerSmallChainArg]@0xb5370.expr[0]]
 	Return 
-// 0x63: ProcessType[map[string]main.bigStruct]
-	ProcessPointer 23 00 00 00 
-	Return 
-// 0x69: ProcessExpression[Probe[main.bigMapArg]@0xb5820.expr[0]]
+// 0x57: ProcessExpression[Probe[main.bigMapArg]@0xb5820.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
-	Call 63 00 00 00 // ProcessType[map[string]main.bigStruct]
+	Call 9c 03 00 00 // ProcessType[map[string]main.bigStruct]
 	Return 
-// 0x84: ProcessEvent[Probe[main.bigMapArg]@b5820]
+// 0x72: ProcessEvent[Probe[main.bigMapArg]@b5820]
 	PrepareEventRoot 54 00 00 00 09 00 00 00 
-	Call 69 00 00 00 // ProcessExpression[Probe[main.bigMapArg]@0xb5820.expr[0]]
+	Call 57 00 00 00 // ProcessExpression[Probe[main.bigMapArg]@0xb5820.expr[0]]
 	Return 
-// 0x93: ProcessExpression[Probe[main.inlined]@0xb56ec.expr[0]]
+// 0x81: ProcessExpression[Probe[main.inlined]@0xb56ec.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
 	Return 
-// 0xa9: ProcessEvent[Probe[main.inlined]@b56ec]
+// 0x97: ProcessEvent[Probe[main.inlined]@b56ec]
 	PrepareEventRoot 55 00 00 00 09 00 00 00 
-	Call 93 00 00 00 // ProcessExpression[Probe[main.inlined]@0xb56ec.expr[0]]
+	Call 81 00 00 00 // ProcessExpression[Probe[main.inlined]@0xb56ec.expr[0]]
 	Return 
-// 0xb8: ProcessExpression[Probe[main.inlined]@0xb514c.expr[0]]
+// 0xa6: ProcessExpression[Probe[main.inlined]@0xb514c.expr[0]]
 	ExprPrepare 
 	Return 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
 	Return 
-// 0xc8: ProcessEvent[Probe[main.inlined]@b514c]
+// 0xb6: ProcessEvent[Probe[main.inlined]@b514c]
 	PrepareEventRoot 55 00 00 00 09 00 00 00 
-	Call b8 00 00 00 // ProcessExpression[Probe[main.inlined]@0xb514c.expr[0]]
+	Call a6 00 00 00 // ProcessExpression[Probe[main.inlined]@0xb514c.expr[0]]
 	Return 
-// 0xd7: ProcessExpression[Probe[main.intArg]@0xb53cc.expr[0]]
+// 0xc5: ProcessExpression[Probe[main.intArg]@0xb53cc.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
 	Return 
-// 0xed: ProcessEvent[Probe[main.intArg]@b53cc]
+// 0xdb: ProcessEvent[Probe[main.intArg]@b53cc]
 	PrepareEventRoot 4c 00 00 00 09 00 00 00 
-	Call d7 00 00 00 // ProcessExpression[Probe[main.intArg]@0xb53cc.expr[0]]
+	Call c5 00 00 00 // ProcessExpression[Probe[main.intArg]@0xb53cc.expr[0]]
 	Return 
-// 0xfc: ProcessExpression[Probe[main.intArrayArg]@0xb554c.expr[0]]
+// 0xea: ProcessExpression[Probe[main.intArrayArg]@0xb554c.expr[0]]
 	ExprPrepare 
 	ExprDereferenceCfa 08 00 00 00 18 00 00 00 00 00 00 00 
 	ExprSave 01 00 00 00 18 00 00 00 00 00 00 00 
 	Return 
-// 0x118: ProcessEvent[Probe[main.intArrayArg]@b554c]
+// 0x106: ProcessEvent[Probe[main.intArrayArg]@b554c]
 	PrepareEventRoot 4f 00 00 00 19 00 00 00 
-	Call fc 00 00 00 // ProcessExpression[Probe[main.intArrayArg]@0xb554c.expr[0]]
+	Call ea 00 00 00 // ProcessExpression[Probe[main.intArrayArg]@0xb554c.expr[0]]
 	Return 
-// 0x127: ProcessType[string]
-	ProcessString 42 00 00 00 
-	Return 
-// 0x12d: ProcessType[[3]string]
-	ProcessArrayDataPrep 30 00 00 00 
-	Call 27 01 00 00 // ProcessType[string]
-	ProcessSliceDataRepeat 10 00 00 00 
-	Return 
-// 0x13d: ProcessExpression[Probe[main.stringArrayArgFrameless]@0xb56d0.expr[0]]
+// 0x115: ProcessExpression[Probe[main.stringArrayArgFrameless]@0xb56d0.expr[0]]
 	ExprPrepare 
 	ExprDereferenceCfa 08 00 00 00 30 00 00 00 00 00 00 00 
 	ExprSave 01 00 00 00 30 00 00 00 00 00 00 00 
-	Call 2d 01 00 00 // ProcessType[[3]string]
+	Call d0 02 00 00 // ProcessType[[3]string]
 	Return 
-// 0x15e: ProcessEvent[Probe[main.stringArrayArgFrameless]@b56d0]
+// 0x136: ProcessEvent[Probe[main.stringArrayArgFrameless]@b56d0]
 	PrepareEventRoot 52 00 00 00 31 00 00 00 
-	Call 3d 01 00 00 // ProcessExpression[Probe[main.stringArrayArgFrameless]@0xb56d0.expr[0]]
+	Call 15 01 00 00 // ProcessExpression[Probe[main.stringArrayArgFrameless]@0xb56d0.expr[0]]
 	Return 
-// 0x16d: ProcessType[[]int]
-	ProcessSlice 44 00 00 00 08 00 00 00 
-	Return 
-// 0x177: ProcessExpression[Probe[main.intSliceArg]@0xb54bc.expr[0]]
+// 0x145: ProcessExpression[Probe[main.intSliceArg]@0xb54bc.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprReadRegister 01 08 08 00 00 00 
 	ExprReadRegister 02 08 10 00 00 00 
 	ExprSave 01 00 00 00 18 00 00 00 00 00 00 00 
-	Call 6d 01 00 00 // ProcessType[[]int]
+	Call 0e 03 00 00 // ProcessType[[]int]
 	Return 
-// 0x1a0: ProcessEvent[Probe[main.intSliceArg]@b54bc]
+// 0x16e: ProcessEvent[Probe[main.intSliceArg]@b54bc]
 	PrepareEventRoot 4e 00 00 00 19 00 00 00 
-	Call 77 01 00 00 // ProcessExpression[Probe[main.intSliceArg]@0xb54bc.expr[0]]
+	Call 45 01 00 00 // ProcessExpression[Probe[main.intSliceArg]@0xb54bc.expr[0]]
 	Return 
-// 0x1af: ProcessType[map[string]int]
-	ProcessPointer 11 00 00 00 
-	Return 
-// 0x1b5: ProcessExpression[Probe[main.mapArg]@0xb57ac.expr[0]]
+// 0x17d: ProcessExpression[Probe[main.mapArg]@0xb57ac.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
-	Call af 01 00 00 // ProcessType[map[string]int]
+	Call 96 03 00 00 // ProcessType[map[string]int]
 	Return 
-// 0x1d0: ProcessEvent[Probe[main.mapArg]@b57ac]
+// 0x198: ProcessEvent[Probe[main.mapArg]@b57ac]
 	PrepareEventRoot 53 00 00 00 09 00 00 00 
-	Call b5 01 00 00 // ProcessExpression[Probe[main.mapArg]@0xb57ac.expr[0]]
+	Call 7d 01 00 00 // ProcessExpression[Probe[main.mapArg]@0xb57ac.expr[0]]
 	Return 
-// 0x1df: ProcessExpression[Probe[main.stringArg]@0xb543c.expr[0]]
+// 0x1a7: ProcessExpression[Probe[main.stringArg]@0xb543c.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprReadRegister 01 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call 27 01 00 00 // ProcessType[string]
+	Call bc 03 00 00 // ProcessType[string]
 	Return 
-// 0x201: ProcessEvent[Probe[main.stringArg]@b543c]
+// 0x1c9: ProcessEvent[Probe[main.stringArg]@b543c]
 	PrepareEventRoot 4d 00 00 00 11 00 00 00 
-	Call df 01 00 00 // ProcessExpression[Probe[main.stringArg]@0xb543c.expr[0]]
+	Call a7 01 00 00 // ProcessExpression[Probe[main.stringArg]@0xb543c.expr[0]]
 	Return 
-// 0x210: ProcessExpression[Probe[main.stringArrayArg]@0xb565c.expr[0]]
+// 0x1d8: ProcessExpression[Probe[main.stringArrayArg]@0xb565c.expr[0]]
 	ExprPrepare 
 	ExprDereferenceCfa 08 00 00 00 30 00 00 00 00 00 00 00 
 	ExprSave 01 00 00 00 30 00 00 00 00 00 00 00 
-	Call 2d 01 00 00 // ProcessType[[3]string]
+	Call d0 02 00 00 // ProcessType[[3]string]
 	Return 
-// 0x231: ProcessEvent[Probe[main.stringArrayArg]@b565c]
+// 0x1f9: ProcessEvent[Probe[main.stringArrayArg]@b565c]
 	PrepareEventRoot 51 00 00 00 31 00 00 00 
-	Call 10 02 00 00 // ProcessExpression[Probe[main.stringArrayArg]@0xb565c.expr[0]]
+	Call d8 01 00 00 // ProcessExpression[Probe[main.stringArrayArg]@0xb565c.expr[0]]
 	Return 
-// 0x240: ProcessType[[]string]
-	ProcessSlice 46 00 00 00 10 00 00 00 
-	Return 
-// 0x24a: ProcessExpression[Probe[main.stringSliceArg]@0xb55cc.expr[0]]
+// 0x208: ProcessExpression[Probe[main.stringSliceArg]@0xb55cc.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprReadRegister 01 08 08 00 00 00 
 	ExprReadRegister 02 08 10 00 00 00 
 	ExprSave 01 00 00 00 18 00 00 00 00 00 00 00 
-	Call 40 02 00 00 // ProcessType[[]string]
+	Call 28 03 00 00 // ProcessType[[]string]
 	Return 
-// 0x273: ProcessEvent[Probe[main.stringSliceArg]@b55cc]
+// 0x231: ProcessEvent[Probe[main.stringSliceArg]@b55cc]
 	PrepareEventRoot 50 00 00 00 19 00 00 00 
-	Call 4a 02 00 00 // ProcessExpression[Probe[main.stringSliceArg]@0xb55cc.expr[0]]
+	Call 08 02 00 00 // ProcessExpression[Probe[main.stringSliceArg]@0xb55cc.expr[0]]
 	Return 
-// 0x282: ProcessType[****int]
+// 0x240: ProcessType[*****int]
+	ProcessPointer 03 00 00 00 
+	Return 
+// 0x246: ProcessType[****int]
 	ProcessPointer 04 00 00 00 
 	Return 
-// 0x288: ProcessType[***int]
+// 0x24c: ProcessType[***int]
 	ProcessPointer 05 00 00 00 
 	Return 
-// 0x28e: ProcessType[*int]
-	ProcessPointer 01 00 00 00 
+// 0x252: ProcessType[**int]
+	ProcessPointer 06 00 00 00 
 	Return 
-// 0x294: ProcessType[*uint8]
-	ProcessPointer 09 00 00 00 
-	Return 
-// 0x29a: ProcessType[*string]
-	ProcessPointer 07 00 00 00 
-	Return 
-// 0x2a0: ProcessType[hash<string,int>]
-	ProcessGoHmap 48 00 00 00 d0 00 00 00 08 09 10 18 
-	Return 
-// 0x2ae: ProcessType[*runtime.mapextra]
-	ProcessPointer 1b 00 00 00 
-	Return 
-// 0x2b4: ProcessType[*[]*runtime.bmap]
+// 0x258: ProcessType[*[]*runtime.bmap]
 	ProcessPointer 1d 00 00 00 
 	Return 
-// 0x2ba: ProcessType[*runtime.bmap]
-	ProcessPointer 20 00 00 00 
-	Return 
-// 0x2c0: ProcessType[runtime.mapextra]
-	Call b4 02 00 00 // ProcessType[*[]*runtime.bmap]
-	IncrementOutputOffset 08 00 00 00 
-	Call b4 02 00 00 // ProcessType[*[]*runtime.bmap]
-	IncrementOutputOffset 08 00 00 00 
-	Call ba 02 00 00 // ProcessType[*runtime.bmap]
-	Return 
-// 0x2da: ProcessType[[]*runtime.bmap]
-	ProcessSlice 49 00 00 00 08 00 00 00 
-	Return 
-// 0x2e4: ProcessType[hash<string,main.bigStruct>]
-	ProcessGoHmap 4b 00 00 00 d0 00 00 00 08 09 10 18 
-	Return 
-// 0x2f2: ProcessType[*main.bigStruct]
-	ProcessPointer 28 00 00 00 
-	Return 
-// 0x2f8: ProcessType[*bool]
+// 0x25e: ProcessType[*bool]
 	ProcessPointer 2a 00 00 00 
 	Return 
-// 0x2fe: ProcessType[*uintptr]
-	ProcessPointer 19 00 00 00 
-	Return 
-// 0x304: ProcessType[error]
-	ProcessGoInterface 
-	Return 
-// 0x306: ProcessType[*int32]
-	ProcessPointer 2f 00 00 00 
-	Return 
-// 0x30c: ProcessType[*uint32]
-	ProcessPointer 13 00 00 00 
-	Return 
-// 0x312: ProcessType[*float64]
-	ProcessPointer 33 00 00 00 
-	Return 
-// 0x318: ProcessType[*int64]
-	ProcessPointer 30 00 00 00 
-	Return 
-// 0x31e: ProcessType[*uint64]
-	ProcessPointer 2d 00 00 00 
-	Return 
-// 0x324: ProcessType[*error]
-	ProcessPointer 34 00 00 00 
-	Return 
-// 0x32a: ProcessType[*float32]
-	ProcessPointer 32 00 00 00 
-	Return 
-// 0x330: ProcessType[*uint]
-	ProcessPointer 2e 00 00 00 
-	Return 
-// 0x336: ProcessType[*uint16]
-	ProcessPointer 12 00 00 00 
-	Return 
-// 0x33c: ProcessType[[]string.array]
-	ProcessSliceDataPrep 
-	Call 27 01 00 00 // ProcessType[string]
-	ProcessSliceDataRepeat 10 00 00 00 
-	Return 
-// 0x348: ProcessType[[]key<string>]
-	ProcessArrayDataPrep 80 00 00 00 
-	Call 27 01 00 00 // ProcessType[string]
-	ProcessSliceDataRepeat 10 00 00 00 
-	Return 
-// 0x358: ProcessType[*bucket<string,int>]
+// 0x264: ProcessType[*bucket<string,int>]
 	ProcessPointer 15 00 00 00 
 	Return 
-// 0x35e: ProcessType[bucket<string,int>]
-	IncrementOutputOffset 08 00 00 00 
-	Call 48 03 00 00 // ProcessType[[]key<string>]
-	IncrementOutputOffset 40 00 00 00 
-	Call 58 03 00 00 // ProcessType[*bucket<string,int>]
-	Return 
-// 0x373: ProcessType[[]bucket<string,int>.array]
-	ProcessSliceDataPrep 
-	Call 5e 03 00 00 // ProcessType[bucket<string,int>]
-	ProcessSliceDataRepeat 08 00 00 00 
-	Return 
-// 0x37f: ProcessType[[]*runtime.bmap.array]
-	ProcessSliceDataPrep 
-	Call ba 02 00 00 // ProcessType[*runtime.bmap]
-	ProcessSliceDataRepeat 08 00 00 00 
-	Return 
-// 0x38b: ProcessType[[]val<main.bigStruct>]
-	ProcessArrayDataPrep 40 00 00 00 
-	Call f2 02 00 00 // ProcessType[*main.bigStruct]
-	ProcessSliceDataRepeat 08 00 00 00 
-	Return 
-// 0x39b: ProcessType[*bucket<string,main.bigStruct>]
+// 0x26a: ProcessType[*bucket<string,main.bigStruct>]
 	ProcessPointer 25 00 00 00 
 	Return 
-// 0x3a1: ProcessType[bucket<string,main.bigStruct>]
-	IncrementOutputOffset 08 00 00 00 
-	Call 48 03 00 00 // ProcessType[[]key<string>]
-	Call 8b 03 00 00 // ProcessType[[]val<main.bigStruct>]
-	Call 9b 03 00 00 // ProcessType[*bucket<string,main.bigStruct>]
+// 0x270: ProcessType[*error]
+	ProcessPointer 34 00 00 00 
 	Return 
-// 0x3b6: ProcessType[[]bucket<string,main.bigStruct>.array]
+// 0x276: ProcessType[*float32]
+	ProcessPointer 32 00 00 00 
+	Return 
+// 0x27c: ProcessType[*float64]
+	ProcessPointer 33 00 00 00 
+	Return 
+// 0x282: ProcessType[*int]
+	ProcessPointer 01 00 00 00 
+	Return 
+// 0x288: ProcessType[*int32]
+	ProcessPointer 2f 00 00 00 
+	Return 
+// 0x28e: ProcessType[*int64]
+	ProcessPointer 30 00 00 00 
+	Return 
+// 0x294: ProcessType[*main.bigStruct]
+	ProcessPointer 28 00 00 00 
+	Return 
+// 0x29a: ProcessType[*runtime.bmap]
+	ProcessPointer 20 00 00 00 
+	Return 
+// 0x2a0: ProcessType[*runtime.mapextra]
+	ProcessPointer 1b 00 00 00 
+	Return 
+// 0x2a6: ProcessType[*string]
+	ProcessPointer 07 00 00 00 
+	Return 
+// 0x2ac: ProcessType[*uint]
+	ProcessPointer 2e 00 00 00 
+	Return 
+// 0x2b2: ProcessType[*uint16]
+	ProcessPointer 12 00 00 00 
+	Return 
+// 0x2b8: ProcessType[*uint32]
+	ProcessPointer 13 00 00 00 
+	Return 
+// 0x2be: ProcessType[*uint64]
+	ProcessPointer 2d 00 00 00 
+	Return 
+// 0x2c4: ProcessType[*uint8]
+	ProcessPointer 09 00 00 00 
+	Return 
+// 0x2ca: ProcessType[*uintptr]
+	ProcessPointer 19 00 00 00 
+	Return 
+// 0x2d0: ProcessType[[3]string]
+	ProcessArrayDataPrep 30 00 00 00 
+	Call bc 03 00 00 // ProcessType[string]
+	ProcessSliceDataRepeat 10 00 00 00 
+	Return 
+// 0x2e0: ProcessType[[]*runtime.bmap]
+	ProcessSlice 49 00 00 00 08 00 00 00 
+	Return 
+// 0x2ea: ProcessType[[]*runtime.bmap.array]
 	ProcessSliceDataPrep 
-	Call a1 03 00 00 // ProcessType[bucket<string,main.bigStruct>]
+	Call 9a 02 00 00 // ProcessType[*runtime.bmap]
 	ProcessSliceDataRepeat 08 00 00 00 
+	Return 
+// 0x2f6: ProcessType[[]bucket<string,int>.array]
+	ProcessSliceDataPrep 
+	Call 4e 03 00 00 // ProcessType[bucket<string,int>]
+	ProcessSliceDataRepeat 08 00 00 00 
+	Return 
+// 0x302: ProcessType[[]bucket<string,main.bigStruct>.array]
+	ProcessSliceDataPrep 
+	Call 63 03 00 00 // ProcessType[bucket<string,main.bigStruct>]
+	ProcessSliceDataRepeat 08 00 00 00 
+	Return 
+// 0x30e: ProcessType[[]int]
+	ProcessSlice 44 00 00 00 08 00 00 00 
+	Return 
+// 0x318: ProcessType[[]key<string>]
+	ProcessArrayDataPrep 80 00 00 00 
+	Call bc 03 00 00 // ProcessType[string]
+	ProcessSliceDataRepeat 10 00 00 00 
+	Return 
+// 0x328: ProcessType[[]string]
+	ProcessSlice 46 00 00 00 10 00 00 00 
+	Return 
+// 0x332: ProcessType[[]string.array]
+	ProcessSliceDataPrep 
+	Call bc 03 00 00 // ProcessType[string]
+	ProcessSliceDataRepeat 10 00 00 00 
+	Return 
+// 0x33e: ProcessType[[]val<main.bigStruct>]
+	ProcessArrayDataPrep 40 00 00 00 
+	Call 94 02 00 00 // ProcessType[*main.bigStruct]
+	ProcessSliceDataRepeat 08 00 00 00 
+	Return 
+// 0x34e: ProcessType[bucket<string,int>]
+	IncrementOutputOffset 08 00 00 00 
+	Call 18 03 00 00 // ProcessType[[]key<string>]
+	IncrementOutputOffset 40 00 00 00 
+	Call 64 02 00 00 // ProcessType[*bucket<string,int>]
+	Return 
+// 0x363: ProcessType[bucket<string,main.bigStruct>]
+	IncrementOutputOffset 08 00 00 00 
+	Call 18 03 00 00 // ProcessType[[]key<string>]
+	Call 3e 03 00 00 // ProcessType[[]val<main.bigStruct>]
+	Call 6a 02 00 00 // ProcessType[*bucket<string,main.bigStruct>]
+	Return 
+// 0x378: ProcessType[error]
+	ProcessGoInterface 
+	Return 
+// 0x37a: ProcessType[hash<string,int>]
+	ProcessGoHmap 48 00 00 00 d0 00 00 00 08 09 10 18 
+	Return 
+// 0x388: ProcessType[hash<string,main.bigStruct>]
+	ProcessGoHmap 4b 00 00 00 d0 00 00 00 08 09 10 18 
+	Return 
+// 0x396: ProcessType[map[string]int]
+	ProcessPointer 11 00 00 00 
+	Return 
+// 0x39c: ProcessType[map[string]main.bigStruct]
+	ProcessPointer 23 00 00 00 
+	Return 
+// 0x3a2: ProcessType[runtime.mapextra]
+	Call 58 02 00 00 // ProcessType[*[]*runtime.bmap]
+	IncrementOutputOffset 08 00 00 00 
+	Call 58 02 00 00 // ProcessType[*[]*runtime.bmap]
+	IncrementOutputOffset 08 00 00 00 
+	Call 9a 02 00 00 // ProcessType[*runtime.bmap]
+	Return 
+// 0x3bc: ProcessType[string]
+	ProcessString 42 00 00 00 
 	Return 
 // Extra illegal ops to simplify code bound checks
 	Illegal 
@@ -303,49 +303,49 @@
 	Illegal 
 // Types
 ID: 1 Len: 8 Enqueue: 0
-ID: 2 Len: 8 Enqueue: 3
-ID: 3 Len: 8 Enqueue: 642
-ID: 4 Len: 8 Enqueue: 648
-ID: 5 Len: 8 Enqueue: 51
-ID: 6 Len: 8 Enqueue: 654
-ID: 7 Len: 16 Enqueue: 295
-ID: 8 Len: 8 Enqueue: 660
+ID: 2 Len: 8 Enqueue: 576
+ID: 3 Len: 8 Enqueue: 582
+ID: 4 Len: 8 Enqueue: 588
+ID: 5 Len: 8 Enqueue: 594
+ID: 6 Len: 8 Enqueue: 642
+ID: 7 Len: 16 Enqueue: 956
+ID: 8 Len: 8 Enqueue: 708
 ID: 9 Len: 1 Enqueue: 0
-ID: 10 Len: 24 Enqueue: 365
+ID: 10 Len: 24 Enqueue: 782
 ID: 11 Len: 24 Enqueue: 0
-ID: 12 Len: 24 Enqueue: 576
-ID: 13 Len: 8 Enqueue: 666
-ID: 14 Len: 48 Enqueue: 301
-ID: 15 Len: 8 Enqueue: 431
+ID: 12 Len: 24 Enqueue: 808
+ID: 13 Len: 8 Enqueue: 678
+ID: 14 Len: 48 Enqueue: 720
+ID: 15 Len: 8 Enqueue: 918
 ID: 16 Len: 8 Enqueue: 0
-ID: 17 Len: 48 Enqueue: 672
+ID: 17 Len: 48 Enqueue: 890
 ID: 18 Len: 2 Enqueue: 0
 ID: 19 Len: 4 Enqueue: 0
-ID: 20 Len: 8 Enqueue: 856
-ID: 21 Len: 208 Enqueue: 862
+ID: 20 Len: 8 Enqueue: 612
+ID: 21 Len: 208 Enqueue: 846
 ID: 22 Len: 8 Enqueue: 0
-ID: 23 Len: 128 Enqueue: 840
+ID: 23 Len: 128 Enqueue: 792
 ID: 24 Len: 64 Enqueue: 0
 ID: 25 Len: 8 Enqueue: 0
-ID: 26 Len: 8 Enqueue: 686
-ID: 27 Len: 24 Enqueue: 704
-ID: 28 Len: 8 Enqueue: 692
-ID: 29 Len: 24 Enqueue: 730
+ID: 26 Len: 8 Enqueue: 672
+ID: 27 Len: 24 Enqueue: 930
+ID: 28 Len: 8 Enqueue: 600
+ID: 29 Len: 24 Enqueue: 736
 ID: 30 Len: 8 Enqueue: 0
-ID: 31 Len: 8 Enqueue: 698
+ID: 31 Len: 8 Enqueue: 666
 ID: 32 Len: 8 Enqueue: 0
-ID: 33 Len: 8 Enqueue: 99
+ID: 33 Len: 8 Enqueue: 924
 ID: 34 Len: 8 Enqueue: 0
-ID: 35 Len: 48 Enqueue: 740
-ID: 36 Len: 8 Enqueue: 923
-ID: 37 Len: 208 Enqueue: 929
-ID: 38 Len: 64 Enqueue: 907
-ID: 39 Len: 8 Enqueue: 754
+ID: 35 Len: 48 Enqueue: 904
+ID: 36 Len: 8 Enqueue: 618
+ID: 37 Len: 208 Enqueue: 867
+ID: 38 Len: 64 Enqueue: 830
+ID: 39 Len: 8 Enqueue: 660
 ID: 40 Len: 184 Enqueue: 0
 ID: 41 Len: 128 Enqueue: 0
 ID: 42 Len: 1 Enqueue: 0
-ID: 43 Len: 8 Enqueue: 760
-ID: 44 Len: 8 Enqueue: 766
+ID: 43 Len: 8 Enqueue: 606
+ID: 44 Len: 8 Enqueue: 714
 ID: 45 Len: 8 Enqueue: 0
 ID: 46 Len: 8 Enqueue: 0
 ID: 47 Len: 4 Enqueue: 0
@@ -353,30 +353,30 @@ ID: 48 Len: 8 Enqueue: 0
 ID: 49 Len: 1 Enqueue: 0
 ID: 50 Len: 4 Enqueue: 0
 ID: 51 Len: 8 Enqueue: 0
-ID: 52 Len: 16 Enqueue: 772
+ID: 52 Len: 16 Enqueue: 888
 ID: 53 Len: 8 Enqueue: 0
-ID: 54 Len: 8 Enqueue: 774
-ID: 55 Len: 8 Enqueue: 780
+ID: 54 Len: 8 Enqueue: 648
+ID: 55 Len: 8 Enqueue: 696
 ID: 56 Len: 2 Enqueue: 0
 ID: 57 Len: 8 Enqueue: 0
 ID: 58 Len: 16 Enqueue: 0
-ID: 59 Len: 8 Enqueue: 786
-ID: 60 Len: 8 Enqueue: 792
-ID: 61 Len: 8 Enqueue: 798
-ID: 62 Len: 8 Enqueue: 804
-ID: 63 Len: 8 Enqueue: 810
-ID: 64 Len: 8 Enqueue: 816
-ID: 65 Len: 8 Enqueue: 822
+ID: 59 Len: 8 Enqueue: 636
+ID: 60 Len: 8 Enqueue: 654
+ID: 61 Len: 8 Enqueue: 702
+ID: 62 Len: 8 Enqueue: 624
+ID: 63 Len: 8 Enqueue: 630
+ID: 64 Len: 8 Enqueue: 684
+ID: 65 Len: 8 Enqueue: 690
 ID: 66 Len: 2048 Enqueue: 0
 ID: 67 Len: 8 Enqueue: 0
 ID: 68 Len: 2048 Enqueue: 0
 ID: 69 Len: 8 Enqueue: 0
-ID: 70 Len: 2048 Enqueue: 828
+ID: 70 Len: 2048 Enqueue: 818
 ID: 71 Len: 8 Enqueue: 0
-ID: 72 Len: 2048 Enqueue: 883
-ID: 73 Len: 2048 Enqueue: 895
+ID: 72 Len: 2048 Enqueue: 758
+ID: 73 Len: 2048 Enqueue: 746
 ID: 74 Len: 8 Enqueue: 0
-ID: 75 Len: 2048 Enqueue: 950
+ID: 75 Len: 2048 Enqueue: 770
 ID: 76 Len: 9 Enqueue: 0
 ID: 77 Len: 17 Enqueue: 0
 ID: 78 Len: 25 Enqueue: 0

--- a/pkg/dyninst/compiler/testdata/snapshot/simple.arch=arm64,toolchain=go1.23.11.sm.txt
+++ b/pkg/dyninst/compiler/testdata/snapshot/simple.arch=arm64,toolchain=go1.23.11.sm.txt
@@ -230,7 +230,7 @@
 	ProcessSliceDataRepeat 08 00 00 00 
 	Return 
 // 0x30e: ProcessType[[]int]
-	ProcessSlice 44 00 00 00 08 00 00 00 
+	ProcessSlice 42 00 00 00 08 00 00 00 
 	Return 
 // 0x318: ProcessType[[]key<string>]
 	ProcessArrayDataPrep 80 00 00 00 
@@ -238,7 +238,7 @@
 	ProcessSliceDataRepeat 10 00 00 00 
 	Return 
 // 0x328: ProcessType[[]string]
-	ProcessSlice 46 00 00 00 10 00 00 00 
+	ProcessSlice 44 00 00 00 10 00 00 00 
 	Return 
 // 0x332: ProcessType[[]string.array]
 	ProcessSliceDataPrep 
@@ -266,10 +266,10 @@
 	ProcessGoInterface 
 	Return 
 // 0x37a: ProcessType[hash<string,int>]
-	ProcessGoHmap 48 00 00 00 d0 00 00 00 08 09 10 18 
+	ProcessGoHmap 46 00 00 00 d0 00 00 00 08 09 10 18 
 	Return 
 // 0x388: ProcessType[hash<string,main.bigStruct>]
-	ProcessGoHmap 49 00 00 00 d0 00 00 00 08 09 10 18 
+	ProcessGoHmap 47 00 00 00 d0 00 00 00 08 09 10 18 
 	Return 
 // 0x396: ProcessType[map[string]int]
 	ProcessPointer 28 00 00 00 
@@ -285,7 +285,7 @@
 	Call 9a 02 00 00 // ProcessType[*runtime.bmap]
 	Return 
 // 0x3bc: ProcessType[string]
-	ProcessString 42 00 00 00 
+	ProcessString 40 00 00 00 
 	Return 
 // Extra illegal ops to simplify code bound checks
 	Illegal 
@@ -365,16 +365,16 @@ ID: 60 Len: 64 Enqueue: 830
 ID: 61 Len: 8 Enqueue: 660
 ID: 62 Len: 184 Enqueue: 0
 ID: 63 Len: 8 Enqueue: 588
-ID: 64 Len: 8 Enqueue: 0
-ID: 65 Len: 128 Enqueue: 0
+ID: 64 Len: 2048 Enqueue: 0
+ID: 65 Len: 8 Enqueue: 0
 ID: 66 Len: 2048 Enqueue: 0
 ID: 67 Len: 8 Enqueue: 0
-ID: 68 Len: 2048 Enqueue: 0
+ID: 68 Len: 2048 Enqueue: 818
 ID: 69 Len: 8 Enqueue: 0
-ID: 70 Len: 2048 Enqueue: 818
-ID: 71 Len: 8 Enqueue: 0
-ID: 72 Len: 2048 Enqueue: 758
-ID: 73 Len: 2048 Enqueue: 770
+ID: 70 Len: 2048 Enqueue: 758
+ID: 71 Len: 2048 Enqueue: 770
+ID: 72 Len: 8 Enqueue: 0
+ID: 73 Len: 128 Enqueue: 0
 ID: 74 Len: 2048 Enqueue: 746
 ID: 75 Len: 8 Enqueue: 0
 ID: 76 Len: 9 Enqueue: 0

--- a/pkg/dyninst/compiler/testdata/snapshot/simple.arch=arm64,toolchain=go1.23.11.sm.txt
+++ b/pkg/dyninst/compiler/testdata/snapshot/simple.arch=arm64,toolchain=go1.23.11.sm.txt
@@ -135,76 +135,76 @@
 	Call 08 02 00 00 // ProcessExpression[Probe[main.stringSliceArg]@0xb55cc.expr[0]]
 	Return 
 // 0x240: ProcessType[*****int]
-	ProcessPointer 03 00 00 00 
+	ProcessPointer 3f 00 00 00 
 	Return 
 // 0x246: ProcessType[****int]
-	ProcessPointer 04 00 00 00 
+	ProcessPointer 40 00 00 00 
 	Return 
 // 0x24c: ProcessType[***int]
-	ProcessPointer 05 00 00 00 
+	ProcessPointer 41 00 00 00 
 	Return 
 // 0x252: ProcessType[**int]
-	ProcessPointer 06 00 00 00 
+	ProcessPointer 1c 00 00 00 
 	Return 
 // 0x258: ProcessType[*[]*runtime.bmap]
-	ProcessPointer 1d 00 00 00 
+	ProcessPointer 31 00 00 00 
 	Return 
 // 0x25e: ProcessType[*bool]
-	ProcessPointer 2a 00 00 00 
+	ProcessPointer 04 00 00 00 
 	Return 
 // 0x264: ProcessType[*bucket<string,int>]
-	ProcessPointer 15 00 00 00 
+	ProcessPointer 2a 00 00 00 
 	Return 
 // 0x26a: ProcessType[*bucket<string,main.bigStruct>]
-	ProcessPointer 25 00 00 00 
+	ProcessPointer 39 00 00 00 
 	Return 
 // 0x270: ProcessType[*error]
-	ProcessPointer 34 00 00 00 
-	Return 
-// 0x276: ProcessType[*float32]
-	ProcessPointer 32 00 00 00 
-	Return 
-// 0x27c: ProcessType[*float64]
-	ProcessPointer 33 00 00 00 
-	Return 
-// 0x282: ProcessType[*int]
-	ProcessPointer 01 00 00 00 
-	Return 
-// 0x288: ProcessType[*int32]
-	ProcessPointer 2f 00 00 00 
-	Return 
-// 0x28e: ProcessType[*int64]
-	ProcessPointer 30 00 00 00 
-	Return 
-// 0x294: ProcessType[*main.bigStruct]
-	ProcessPointer 28 00 00 00 
-	Return 
-// 0x29a: ProcessType[*runtime.bmap]
-	ProcessPointer 20 00 00 00 
-	Return 
-// 0x2a0: ProcessType[*runtime.mapextra]
-	ProcessPointer 1b 00 00 00 
-	Return 
-// 0x2a6: ProcessType[*string]
-	ProcessPointer 07 00 00 00 
-	Return 
-// 0x2ac: ProcessType[*uint]
-	ProcessPointer 2e 00 00 00 
-	Return 
-// 0x2b2: ProcessType[*uint16]
 	ProcessPointer 12 00 00 00 
 	Return 
-// 0x2b8: ProcessType[*uint32]
-	ProcessPointer 13 00 00 00 
+// 0x276: ProcessType[*float32]
+	ProcessPointer 10 00 00 00 
 	Return 
-// 0x2be: ProcessType[*uint64]
-	ProcessPointer 2d 00 00 00 
+// 0x27c: ProcessType[*float64]
+	ProcessPointer 11 00 00 00 
 	Return 
-// 0x2c4: ProcessType[*uint8]
+// 0x282: ProcessType[*int]
 	ProcessPointer 09 00 00 00 
 	Return 
+// 0x288: ProcessType[*int32]
+	ProcessPointer 0d 00 00 00 
+	Return 
+// 0x28e: ProcessType[*int64]
+	ProcessPointer 0e 00 00 00 
+	Return 
+// 0x294: ProcessType[*main.bigStruct]
+	ProcessPointer 3c 00 00 00 
+	Return 
+// 0x29a: ProcessType[*runtime.bmap]
+	ProcessPointer 34 00 00 00 
+	Return 
+// 0x2a0: ProcessType[*runtime.mapextra]
+	ProcessPointer 2f 00 00 00 
+	Return 
+// 0x2a6: ProcessType[*string]
+	ProcessPointer 0a 00 00 00 
+	Return 
+// 0x2ac: ProcessType[*uint]
+	ProcessPointer 0c 00 00 00 
+	Return 
+// 0x2b2: ProcessType[*uint16]
+	ProcessPointer 07 00 00 00 
+	Return 
+// 0x2b8: ProcessType[*uint32]
+	ProcessPointer 02 00 00 00 
+	Return 
+// 0x2be: ProcessType[*uint64]
+	ProcessPointer 0b 00 00 00 
+	Return 
+// 0x2c4: ProcessType[*uint8]
+	ProcessPointer 03 00 00 00 
+	Return 
 // 0x2ca: ProcessType[*uintptr]
-	ProcessPointer 19 00 00 00 
+	ProcessPointer 01 00 00 00 
 	Return 
 // 0x2d0: ProcessType[[3]string]
 	ProcessArrayDataPrep 30 00 00 00 
@@ -272,10 +272,10 @@
 	ProcessGoHmap 4b 00 00 00 d0 00 00 00 08 09 10 18 
 	Return 
 // 0x396: ProcessType[map[string]int]
-	ProcessPointer 11 00 00 00 
+	ProcessPointer 28 00 00 00 
 	Return 
 // 0x39c: ProcessType[map[string]main.bigStruct]
-	ProcessPointer 23 00 00 00 
+	ProcessPointer 37 00 00 00 
 	Return 
 // 0x3a2: ProcessType[runtime.mapextra]
 	Call 58 02 00 00 // ProcessType[*[]*runtime.bmap]
@@ -303,70 +303,70 @@
 	Illegal 
 // Types
 ID: 1 Len: 8 Enqueue: 0
-ID: 2 Len: 8 Enqueue: 576
-ID: 3 Len: 8 Enqueue: 582
-ID: 4 Len: 8 Enqueue: 588
-ID: 5 Len: 8 Enqueue: 594
-ID: 6 Len: 8 Enqueue: 642
-ID: 7 Len: 16 Enqueue: 956
-ID: 8 Len: 8 Enqueue: 708
-ID: 9 Len: 1 Enqueue: 0
-ID: 10 Len: 24 Enqueue: 782
-ID: 11 Len: 24 Enqueue: 0
-ID: 12 Len: 24 Enqueue: 808
-ID: 13 Len: 8 Enqueue: 678
-ID: 14 Len: 48 Enqueue: 720
-ID: 15 Len: 8 Enqueue: 918
-ID: 16 Len: 8 Enqueue: 0
-ID: 17 Len: 48 Enqueue: 890
-ID: 18 Len: 2 Enqueue: 0
-ID: 19 Len: 4 Enqueue: 0
-ID: 20 Len: 8 Enqueue: 612
-ID: 21 Len: 208 Enqueue: 846
-ID: 22 Len: 8 Enqueue: 0
-ID: 23 Len: 128 Enqueue: 792
-ID: 24 Len: 64 Enqueue: 0
-ID: 25 Len: 8 Enqueue: 0
-ID: 26 Len: 8 Enqueue: 672
-ID: 27 Len: 24 Enqueue: 930
-ID: 28 Len: 8 Enqueue: 600
-ID: 29 Len: 24 Enqueue: 736
-ID: 30 Len: 8 Enqueue: 0
-ID: 31 Len: 8 Enqueue: 666
-ID: 32 Len: 8 Enqueue: 0
-ID: 33 Len: 8 Enqueue: 924
-ID: 34 Len: 8 Enqueue: 0
-ID: 35 Len: 48 Enqueue: 904
-ID: 36 Len: 8 Enqueue: 618
-ID: 37 Len: 208 Enqueue: 867
-ID: 38 Len: 64 Enqueue: 830
-ID: 39 Len: 8 Enqueue: 660
-ID: 40 Len: 184 Enqueue: 0
-ID: 41 Len: 128 Enqueue: 0
-ID: 42 Len: 1 Enqueue: 0
-ID: 43 Len: 8 Enqueue: 606
-ID: 44 Len: 8 Enqueue: 714
-ID: 45 Len: 8 Enqueue: 0
-ID: 46 Len: 8 Enqueue: 0
-ID: 47 Len: 4 Enqueue: 0
-ID: 48 Len: 8 Enqueue: 0
-ID: 49 Len: 1 Enqueue: 0
-ID: 50 Len: 4 Enqueue: 0
-ID: 51 Len: 8 Enqueue: 0
-ID: 52 Len: 16 Enqueue: 888
-ID: 53 Len: 8 Enqueue: 0
-ID: 54 Len: 8 Enqueue: 648
-ID: 55 Len: 8 Enqueue: 696
-ID: 56 Len: 2 Enqueue: 0
-ID: 57 Len: 8 Enqueue: 0
-ID: 58 Len: 16 Enqueue: 0
-ID: 59 Len: 8 Enqueue: 636
-ID: 60 Len: 8 Enqueue: 654
-ID: 61 Len: 8 Enqueue: 702
-ID: 62 Len: 8 Enqueue: 624
-ID: 63 Len: 8 Enqueue: 630
-ID: 64 Len: 8 Enqueue: 684
-ID: 65 Len: 8 Enqueue: 690
+ID: 2 Len: 4 Enqueue: 0
+ID: 3 Len: 1 Enqueue: 0
+ID: 4 Len: 1 Enqueue: 0
+ID: 5 Len: 8 Enqueue: 606
+ID: 6 Len: 8 Enqueue: 708
+ID: 7 Len: 2 Enqueue: 0
+ID: 8 Len: 8 Enqueue: 714
+ID: 9 Len: 8 Enqueue: 0
+ID: 10 Len: 16 Enqueue: 956
+ID: 11 Len: 8 Enqueue: 0
+ID: 12 Len: 8 Enqueue: 0
+ID: 13 Len: 4 Enqueue: 0
+ID: 14 Len: 8 Enqueue: 0
+ID: 15 Len: 1 Enqueue: 0
+ID: 16 Len: 4 Enqueue: 0
+ID: 17 Len: 8 Enqueue: 0
+ID: 18 Len: 16 Enqueue: 888
+ID: 19 Len: 8 Enqueue: 0
+ID: 20 Len: 8 Enqueue: 648
+ID: 21 Len: 8 Enqueue: 696
+ID: 22 Len: 8 Enqueue: 678
+ID: 23 Len: 2 Enqueue: 0
+ID: 24 Len: 8 Enqueue: 0
+ID: 25 Len: 16 Enqueue: 0
+ID: 26 Len: 8 Enqueue: 636
+ID: 27 Len: 8 Enqueue: 654
+ID: 28 Len: 8 Enqueue: 642
+ID: 29 Len: 8 Enqueue: 702
+ID: 30 Len: 8 Enqueue: 624
+ID: 31 Len: 8 Enqueue: 630
+ID: 32 Len: 8 Enqueue: 684
+ID: 33 Len: 8 Enqueue: 690
+ID: 34 Len: 24 Enqueue: 782
+ID: 35 Len: 24 Enqueue: 0
+ID: 36 Len: 24 Enqueue: 808
+ID: 37 Len: 48 Enqueue: 720
+ID: 38 Len: 8 Enqueue: 918
+ID: 39 Len: 8 Enqueue: 0
+ID: 40 Len: 48 Enqueue: 890
+ID: 41 Len: 8 Enqueue: 612
+ID: 42 Len: 208 Enqueue: 846
+ID: 43 Len: 8 Enqueue: 0
+ID: 44 Len: 128 Enqueue: 792
+ID: 45 Len: 64 Enqueue: 0
+ID: 46 Len: 8 Enqueue: 672
+ID: 47 Len: 24 Enqueue: 930
+ID: 48 Len: 8 Enqueue: 600
+ID: 49 Len: 24 Enqueue: 736
+ID: 50 Len: 8 Enqueue: 0
+ID: 51 Len: 8 Enqueue: 666
+ID: 52 Len: 8 Enqueue: 0
+ID: 53 Len: 8 Enqueue: 924
+ID: 54 Len: 8 Enqueue: 0
+ID: 55 Len: 48 Enqueue: 904
+ID: 56 Len: 8 Enqueue: 618
+ID: 57 Len: 208 Enqueue: 867
+ID: 58 Len: 64 Enqueue: 830
+ID: 59 Len: 8 Enqueue: 660
+ID: 60 Len: 184 Enqueue: 0
+ID: 61 Len: 128 Enqueue: 0
+ID: 62 Len: 8 Enqueue: 576
+ID: 63 Len: 8 Enqueue: 582
+ID: 64 Len: 8 Enqueue: 588
+ID: 65 Len: 8 Enqueue: 594
 ID: 66 Len: 2048 Enqueue: 0
 ID: 67 Len: 8 Enqueue: 0
 ID: 68 Len: 2048 Enqueue: 0

--- a/pkg/dyninst/compiler/testdata/snapshot/simple.arch=arm64,toolchain=go1.24.3.sm.txt
+++ b/pkg/dyninst/compiler/testdata/snapshot/simple.arch=arm64,toolchain=go1.24.3.sm.txt
@@ -168,7 +168,7 @@
 	ProcessPointer 0d 00 00 00 
 	Return 
 // 0x282: ProcessType[*main.bigStruct]
-	ProcessPointer 41 00 00 00 
+	ProcessPointer 49 00 00 00 
 	Return 
 // 0x288: ProcessType[*string]
 	ProcessPointer 09 00 00 00 
@@ -213,7 +213,7 @@
 	ProcessSliceDataRepeat 08 00 00 00 
 	Return 
 // 0x2e6: ProcessType[[]int]
-	ProcessSlice 45 00 00 00 08 00 00 00 
+	ProcessSlice 38 00 00 00 08 00 00 00 
 	Return 
 // 0x2f0: ProcessType[[]noalg.map.group[string]int.array]
 	ProcessSliceDataPrep 
@@ -226,7 +226,7 @@
 	ProcessSliceDataRepeat 00 00 00 00 
 	Return 
 // 0x308: ProcessType[[]string]
-	ProcessSlice 47 00 00 00 10 00 00 00 
+	ProcessSlice 3a 00 00 00 10 00 00 00 
 	Return 
 // 0x312: ProcessType[[]string.array]
 	ProcessSliceDataPrep 
@@ -237,16 +237,16 @@
 	ProcessGoInterface 
 	Return 
 // 0x320: ProcessType[groupReference<string,int>]
-	ProcessGoSwissMapGroups 4a 00 00 00 c8 00 00 00 00 08 
+	ProcessGoSwissMapGroups 42 00 00 00 c8 00 00 00 00 08 
 	Return 
 // 0x32c: ProcessType[groupReference<string,main.bigStruct>]
-	ProcessGoSwissMapGroups 4c 00 00 00 c8 00 00 00 00 08 
+	ProcessGoSwissMapGroups 4b 00 00 00 c8 00 00 00 00 08 
 	Return 
 // 0x338: ProcessType[map<string,int>]
-	ProcessGoSwissMap 49 00 00 00 38 00 00 00 10 18 
+	ProcessGoSwissMap 41 00 00 00 3e 00 00 00 10 18 
 	Return 
 // 0x344: ProcessType[map<string,main.bigStruct>]
-	ProcessGoSwissMap 4b 00 00 00 3b 00 00 00 10 18 
+	ProcessGoSwissMap 4a 00 00 00 45 00 00 00 10 18 
 	Return 
 // 0x350: ProcessType[map[string]int]
 	ProcessPointer 28 00 00 00 
@@ -281,7 +281,7 @@
 	Call a8 03 00 00 // ProcessType[string]
 	Return 
 // 0x3a8: ProcessType[string]
-	ProcessString 43 00 00 00 
+	ProcessString 36 00 00 00 
 	Return 
 // 0x3ae: ProcessType[table<string,int>]
 	IncrementOutputOffset 10 00 00 00 
@@ -359,29 +359,29 @@ ID: 50 Len: 8 Enqueue: 594
 ID: 51 Len: 32 Enqueue: 942
 ID: 52 Len: 32 Enqueue: 953
 ID: 53 Len: 8 Enqueue: 588
-ID: 54 Len: 16 Enqueue: 800
+ID: 54 Len: 2048 Enqueue: 0
 ID: 55 Len: 8 Enqueue: 0
-ID: 56 Len: 200 Enqueue: 892
-ID: 57 Len: 16 Enqueue: 812
-ID: 58 Len: 8 Enqueue: 0
-ID: 59 Len: 200 Enqueue: 903
-ID: 60 Len: 192 Enqueue: 876
-ID: 61 Len: 24 Enqueue: 930
-ID: 62 Len: 192 Enqueue: 860
-ID: 63 Len: 24 Enqueue: 914
-ID: 64 Len: 8 Enqueue: 642
-ID: 65 Len: 184 Enqueue: 0
-ID: 66 Len: 128 Enqueue: 0
-ID: 67 Len: 2048 Enqueue: 0
+ID: 56 Len: 2048 Enqueue: 0
+ID: 57 Len: 8 Enqueue: 0
+ID: 58 Len: 2048 Enqueue: 786
+ID: 59 Len: 8 Enqueue: 0
+ID: 60 Len: 16 Enqueue: 800
+ID: 61 Len: 8 Enqueue: 0
+ID: 62 Len: 200 Enqueue: 892
+ID: 63 Len: 192 Enqueue: 876
+ID: 64 Len: 24 Enqueue: 930
+ID: 65 Len: 8192 Enqueue: 718
+ID: 66 Len: 2048 Enqueue: 752
+ID: 67 Len: 16 Enqueue: 812
 ID: 68 Len: 8 Enqueue: 0
-ID: 69 Len: 2048 Enqueue: 0
-ID: 70 Len: 8 Enqueue: 0
-ID: 71 Len: 2048 Enqueue: 786
-ID: 72 Len: 8 Enqueue: 0
-ID: 73 Len: 8192 Enqueue: 718
-ID: 74 Len: 2048 Enqueue: 752
-ID: 75 Len: 8192 Enqueue: 730
-ID: 76 Len: 2048 Enqueue: 764
+ID: 69 Len: 200 Enqueue: 903
+ID: 70 Len: 192 Enqueue: 860
+ID: 71 Len: 24 Enqueue: 914
+ID: 72 Len: 8 Enqueue: 642
+ID: 73 Len: 184 Enqueue: 0
+ID: 74 Len: 8192 Enqueue: 730
+ID: 75 Len: 2048 Enqueue: 764
+ID: 76 Len: 128 Enqueue: 0
 ID: 77 Len: 9 Enqueue: 0
 ID: 78 Len: 17 Enqueue: 0
 ID: 79 Len: 25 Enqueue: 0

--- a/pkg/dyninst/compiler/testdata/snapshot/simple.arch=arm64,toolchain=go1.24.3.sm.txt
+++ b/pkg/dyninst/compiler/testdata/snapshot/simple.arch=arm64,toolchain=go1.24.3.sm.txt
@@ -3,293 +3,293 @@
 // 0x1: ChasePointers
 	ChasePointers 
 	Return 
-// 0x3: ProcessType[*****int]
-	ProcessPointer 03 00 00 00 
-	Return 
-// 0x9: ProcessExpression[Probe[main.PointerChainArg]@0xb51cc.expr[0]]
+// 0x3: ProcessExpression[Probe[main.PointerChainArg]@0xb51cc.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
-	Call 03 00 00 00 // ProcessType[*****int]
+	Call 40 02 00 00 // ProcessType[*****int]
 	Return 
-// 0x24: ProcessEvent[Probe[main.PointerChainArg]@b51cc]
+// 0x1e: ProcessEvent[Probe[main.PointerChainArg]@b51cc]
 	PrepareEventRoot 57 00 00 00 09 00 00 00 
-	Call 09 00 00 00 // ProcessExpression[Probe[main.PointerChainArg]@0xb51cc.expr[0]]
+	Call 03 00 00 00 // ProcessExpression[Probe[main.PointerChainArg]@0xb51cc.expr[0]]
 	Return 
-// 0x33: ProcessType[**int]
-	ProcessPointer 06 00 00 00 
-	Return 
-// 0x39: ProcessExpression[Probe[main.PointerSmallChainArg]@0xb5204.expr[0]]
+// 0x2d: ProcessExpression[Probe[main.PointerSmallChainArg]@0xb5204.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 05 08 00 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
-	Call 33 00 00 00 // ProcessType[**int]
+	Call 52 02 00 00 // ProcessType[**int]
 	Return 
-// 0x54: ProcessEvent[Probe[main.PointerSmallChainArg]@b5204]
+// 0x48: ProcessEvent[Probe[main.PointerSmallChainArg]@b5204]
 	PrepareEventRoot 58 00 00 00 09 00 00 00 
-	Call 39 00 00 00 // ProcessExpression[Probe[main.PointerSmallChainArg]@0xb5204.expr[0]]
+	Call 2d 00 00 00 // ProcessExpression[Probe[main.PointerSmallChainArg]@0xb5204.expr[0]]
 	Return 
-// 0x63: ProcessType[map[string]main.bigStruct]
-	ProcessPointer 1f 00 00 00 
-	Return 
-// 0x69: ProcessExpression[Probe[main.bigMapArg]@0xb5690.expr[0]]
+// 0x57: ProcessExpression[Probe[main.bigMapArg]@0xb5690.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
-	Call 63 00 00 00 // ProcessType[map[string]main.bigStruct]
+	Call 56 03 00 00 // ProcessType[map[string]main.bigStruct]
 	Return 
-// 0x84: ProcessEvent[Probe[main.bigMapArg]@b5690]
+// 0x72: ProcessEvent[Probe[main.bigMapArg]@b5690]
 	PrepareEventRoot 55 00 00 00 09 00 00 00 
-	Call 69 00 00 00 // ProcessExpression[Probe[main.bigMapArg]@0xb5690.expr[0]]
+	Call 57 00 00 00 // ProcessExpression[Probe[main.bigMapArg]@0xb5690.expr[0]]
 	Return 
-// 0x93: ProcessExpression[Probe[main.inlined]@0xb555c.expr[0]]
+// 0x81: ProcessExpression[Probe[main.inlined]@0xb555c.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
 	Return 
-// 0xa9: ProcessEvent[Probe[main.inlined]@b555c]
+// 0x97: ProcessEvent[Probe[main.inlined]@b555c]
 	PrepareEventRoot 56 00 00 00 09 00 00 00 
-	Call 93 00 00 00 // ProcessExpression[Probe[main.inlined]@0xb555c.expr[0]]
+	Call 81 00 00 00 // ProcessExpression[Probe[main.inlined]@0xb555c.expr[0]]
 	Return 
-// 0xb8: ProcessExpression[Probe[main.inlined]@0xb4fec.expr[0]]
+// 0xa6: ProcessExpression[Probe[main.inlined]@0xb4fec.expr[0]]
 	ExprPrepare 
 	Return 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
 	Return 
-// 0xc8: ProcessEvent[Probe[main.inlined]@b4fec]
+// 0xb6: ProcessEvent[Probe[main.inlined]@b4fec]
 	PrepareEventRoot 56 00 00 00 09 00 00 00 
-	Call b8 00 00 00 // ProcessExpression[Probe[main.inlined]@0xb4fec.expr[0]]
+	Call a6 00 00 00 // ProcessExpression[Probe[main.inlined]@0xb4fec.expr[0]]
 	Return 
-// 0xd7: ProcessExpression[Probe[main.intArg]@0xb525c.expr[0]]
+// 0xc5: ProcessExpression[Probe[main.intArg]@0xb525c.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
 	Return 
-// 0xed: ProcessEvent[Probe[main.intArg]@b525c]
+// 0xdb: ProcessEvent[Probe[main.intArg]@b525c]
 	PrepareEventRoot 4d 00 00 00 09 00 00 00 
-	Call d7 00 00 00 // ProcessExpression[Probe[main.intArg]@0xb525c.expr[0]]
+	Call c5 00 00 00 // ProcessExpression[Probe[main.intArg]@0xb525c.expr[0]]
 	Return 
-// 0xfc: ProcessExpression[Probe[main.intArrayArg]@0xb53cc.expr[0]]
+// 0xea: ProcessExpression[Probe[main.intArrayArg]@0xb53cc.expr[0]]
 	ExprPrepare 
 	ExprDereferenceCfa 08 00 00 00 18 00 00 00 00 00 00 00 
 	ExprSave 01 00 00 00 18 00 00 00 00 00 00 00 
 	Return 
-// 0x118: ProcessEvent[Probe[main.intArrayArg]@b53cc]
+// 0x106: ProcessEvent[Probe[main.intArrayArg]@b53cc]
 	PrepareEventRoot 50 00 00 00 19 00 00 00 
-	Call fc 00 00 00 // ProcessExpression[Probe[main.intArrayArg]@0xb53cc.expr[0]]
+	Call ea 00 00 00 // ProcessExpression[Probe[main.intArrayArg]@0xb53cc.expr[0]]
 	Return 
-// 0x127: ProcessType[string]
-	ProcessString 43 00 00 00 
-	Return 
-// 0x12d: ProcessType[[3]string]
-	ProcessArrayDataPrep 30 00 00 00 
-	Call 27 01 00 00 // ProcessType[string]
-	ProcessSliceDataRepeat 10 00 00 00 
-	Return 
-// 0x13d: ProcessExpression[Probe[main.stringArrayArgFrameless]@0xb5540.expr[0]]
+// 0x115: ProcessExpression[Probe[main.stringArrayArgFrameless]@0xb5540.expr[0]]
 	ExprPrepare 
 	ExprDereferenceCfa 08 00 00 00 30 00 00 00 00 00 00 00 
 	ExprSave 01 00 00 00 30 00 00 00 00 00 00 00 
-	Call 2d 01 00 00 // ProcessType[[3]string]
+	Call be 02 00 00 // ProcessType[[3]string]
 	Return 
-// 0x15e: ProcessEvent[Probe[main.stringArrayArgFrameless]@b5540]
+// 0x136: ProcessEvent[Probe[main.stringArrayArgFrameless]@b5540]
 	PrepareEventRoot 53 00 00 00 31 00 00 00 
-	Call 3d 01 00 00 // ProcessExpression[Probe[main.stringArrayArgFrameless]@0xb5540.expr[0]]
+	Call 15 01 00 00 // ProcessExpression[Probe[main.stringArrayArgFrameless]@0xb5540.expr[0]]
 	Return 
-// 0x16d: ProcessType[[]int]
-	ProcessSlice 45 00 00 00 08 00 00 00 
-	Return 
-// 0x177: ProcessExpression[Probe[main.intSliceArg]@0xb534c.expr[0]]
+// 0x145: ProcessExpression[Probe[main.intSliceArg]@0xb534c.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprReadRegister 01 08 08 00 00 00 
 	ExprReadRegister 02 08 10 00 00 00 
 	ExprSave 01 00 00 00 18 00 00 00 00 00 00 00 
-	Call 6d 01 00 00 // ProcessType[[]int]
+	Call e6 02 00 00 // ProcessType[[]int]
 	Return 
-// 0x1a0: ProcessEvent[Probe[main.intSliceArg]@b534c]
+// 0x16e: ProcessEvent[Probe[main.intSliceArg]@b534c]
 	PrepareEventRoot 4f 00 00 00 19 00 00 00 
-	Call 77 01 00 00 // ProcessExpression[Probe[main.intSliceArg]@0xb534c.expr[0]]
+	Call 45 01 00 00 // ProcessExpression[Probe[main.intSliceArg]@0xb534c.expr[0]]
 	Return 
-// 0x1af: ProcessType[map[string]int]
-	ProcessPointer 11 00 00 00 
-	Return 
-// 0x1b5: ProcessExpression[Probe[main.mapArg]@0xb561c.expr[0]]
+// 0x17d: ProcessExpression[Probe[main.mapArg]@0xb561c.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
-	Call af 01 00 00 // ProcessType[map[string]int]
+	Call 50 03 00 00 // ProcessType[map[string]int]
 	Return 
-// 0x1d0: ProcessEvent[Probe[main.mapArg]@b561c]
+// 0x198: ProcessEvent[Probe[main.mapArg]@b561c]
 	PrepareEventRoot 54 00 00 00 09 00 00 00 
-	Call b5 01 00 00 // ProcessExpression[Probe[main.mapArg]@0xb561c.expr[0]]
+	Call 7d 01 00 00 // ProcessExpression[Probe[main.mapArg]@0xb561c.expr[0]]
 	Return 
-// 0x1df: ProcessExpression[Probe[main.stringArg]@0xb52cc.expr[0]]
+// 0x1a7: ProcessExpression[Probe[main.stringArg]@0xb52cc.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprReadRegister 01 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call 27 01 00 00 // ProcessType[string]
+	Call a8 03 00 00 // ProcessType[string]
 	Return 
-// 0x201: ProcessEvent[Probe[main.stringArg]@b52cc]
+// 0x1c9: ProcessEvent[Probe[main.stringArg]@b52cc]
 	PrepareEventRoot 4e 00 00 00 11 00 00 00 
-	Call df 01 00 00 // ProcessExpression[Probe[main.stringArg]@0xb52cc.expr[0]]
+	Call a7 01 00 00 // ProcessExpression[Probe[main.stringArg]@0xb52cc.expr[0]]
 	Return 
-// 0x210: ProcessExpression[Probe[main.stringArrayArg]@0xb54cc.expr[0]]
+// 0x1d8: ProcessExpression[Probe[main.stringArrayArg]@0xb54cc.expr[0]]
 	ExprPrepare 
 	ExprDereferenceCfa 08 00 00 00 30 00 00 00 00 00 00 00 
 	ExprSave 01 00 00 00 30 00 00 00 00 00 00 00 
-	Call 2d 01 00 00 // ProcessType[[3]string]
+	Call be 02 00 00 // ProcessType[[3]string]
 	Return 
-// 0x231: ProcessEvent[Probe[main.stringArrayArg]@b54cc]
+// 0x1f9: ProcessEvent[Probe[main.stringArrayArg]@b54cc]
 	PrepareEventRoot 52 00 00 00 31 00 00 00 
-	Call 10 02 00 00 // ProcessExpression[Probe[main.stringArrayArg]@0xb54cc.expr[0]]
+	Call d8 01 00 00 // ProcessExpression[Probe[main.stringArrayArg]@0xb54cc.expr[0]]
 	Return 
-// 0x240: ProcessType[[]string]
-	ProcessSlice 47 00 00 00 10 00 00 00 
-	Return 
-// 0x24a: ProcessExpression[Probe[main.stringSliceArg]@0xb544c.expr[0]]
+// 0x208: ProcessExpression[Probe[main.stringSliceArg]@0xb544c.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprReadRegister 01 08 08 00 00 00 
 	ExprReadRegister 02 08 10 00 00 00 
 	ExprSave 01 00 00 00 18 00 00 00 00 00 00 00 
-	Call 40 02 00 00 // ProcessType[[]string]
+	Call 08 03 00 00 // ProcessType[[]string]
 	Return 
-// 0x273: ProcessEvent[Probe[main.stringSliceArg]@b544c]
+// 0x231: ProcessEvent[Probe[main.stringSliceArg]@b544c]
 	PrepareEventRoot 51 00 00 00 19 00 00 00 
-	Call 4a 02 00 00 // ProcessExpression[Probe[main.stringSliceArg]@0xb544c.expr[0]]
+	Call 08 02 00 00 // ProcessExpression[Probe[main.stringSliceArg]@0xb544c.expr[0]]
 	Return 
-// 0x282: ProcessType[****int]
+// 0x240: ProcessType[*****int]
+	ProcessPointer 03 00 00 00 
+	Return 
+// 0x246: ProcessType[****int]
 	ProcessPointer 04 00 00 00 
 	Return 
-// 0x288: ProcessType[***int]
+// 0x24c: ProcessType[***int]
 	ProcessPointer 05 00 00 00 
 	Return 
-// 0x28e: ProcessType[*int]
-	ProcessPointer 01 00 00 00 
+// 0x252: ProcessType[**int]
+	ProcessPointer 06 00 00 00 
 	Return 
-// 0x294: ProcessType[*uint8]
-	ProcessPointer 09 00 00 00 
-	Return 
-// 0x29a: ProcessType[*string]
-	ProcessPointer 07 00 00 00 
-	Return 
-// 0x2a0: ProcessType[map<string,int>]
-	ProcessGoSwissMap 49 00 00 00 1a 00 00 00 10 18 
-	Return 
-// 0x2ac: ProcessType[noalg.struct { key string; elem int }]
-	Call 27 01 00 00 // ProcessType[string]
-	Return 
-// 0x2b2: ProcessType[noalg.[8]struct { key string; elem int }]
-	ProcessArrayDataPrep c0 00 00 00 
-	Call ac 02 00 00 // ProcessType[noalg.struct { key string; elem int }]
-	ProcessSliceDataRepeat 18 00 00 00 
-	Return 
-// 0x2c2: ProcessType[noalg.map.group[string]int]
-	IncrementOutputOffset 08 00 00 00 
-	Call b2 02 00 00 // ProcessType[noalg.[8]struct { key string; elem int }]
-	Return 
-// 0x2cd: ProcessType[map<string,main.bigStruct>]
-	ProcessGoSwissMap 4b 00 00 00 25 00 00 00 10 18 
-	Return 
-// 0x2d9: ProcessType[*main.bigStruct]
-	ProcessPointer 29 00 00 00 
-	Return 
-// 0x2df: ProcessType[noalg.struct { key string; elem *main.bigStruct }]
-	Call 27 01 00 00 // ProcessType[string]
-	IncrementOutputOffset 10 00 00 00 
-	Call d9 02 00 00 // ProcessType[*main.bigStruct]
-	Return 
-// 0x2ef: ProcessType[noalg.[8]struct { key string; elem *main.bigStruct }]
-	ProcessArrayDataPrep c0 00 00 00 
-	Call df 02 00 00 // ProcessType[noalg.struct { key string; elem *main.bigStruct }]
-	ProcessSliceDataRepeat 08 00 00 00 
-	Return 
-// 0x2ff: ProcessType[noalg.map.group[string]main.bigStruct]
-	IncrementOutputOffset 08 00 00 00 
-	Call ef 02 00 00 // ProcessType[noalg.[8]struct { key string; elem *main.bigStruct }]
-	Return 
-// 0x30a: ProcessType[*bool]
+// 0x258: ProcessType[*bool]
 	ProcessPointer 2c 00 00 00 
 	Return 
-// 0x310: ProcessType[error]
-	ProcessGoInterface 
-	Return 
-// 0x312: ProcessType[*uintptr]
-	ProcessPointer 13 00 00 00 
-	Return 
-// 0x318: ProcessType[*int32]
-	ProcessPointer 2f 00 00 00 
-	Return 
-// 0x31e: ProcessType[*uint32]
-	ProcessPointer 2b 00 00 00 
-	Return 
-// 0x324: ProcessType[*float64]
-	ProcessPointer 35 00 00 00 
-	Return 
-// 0x32a: ProcessType[*int64]
-	ProcessPointer 30 00 00 00 
-	Return 
-// 0x330: ProcessType[*uint64]
-	ProcessPointer 12 00 00 00 
-	Return 
-// 0x336: ProcessType[*error]
+// 0x25e: ProcessType[*error]
 	ProcessPointer 31 00 00 00 
 	Return 
-// 0x33c: ProcessType[*float32]
+// 0x264: ProcessType[*float32]
 	ProcessPointer 34 00 00 00 
 	Return 
-// 0x342: ProcessType[*uint]
-	ProcessPointer 2d 00 00 00 
+// 0x26a: ProcessType[*float64]
+	ProcessPointer 35 00 00 00 
 	Return 
-// 0x348: ProcessType[*uint16]
-	ProcessPointer 17 00 00 00 
+// 0x270: ProcessType[*int]
+	ProcessPointer 01 00 00 00 
 	Return 
-// 0x34e: ProcessType[[]string.array]
-	ProcessSliceDataPrep 
-	Call 27 01 00 00 // ProcessType[string]
-	ProcessSliceDataRepeat 10 00 00 00 
+// 0x276: ProcessType[*int32]
+	ProcessPointer 2f 00 00 00 
 	Return 
-// 0x35a: ProcessType[*table<string,int>]
+// 0x27c: ProcessType[*int64]
+	ProcessPointer 30 00 00 00 
+	Return 
+// 0x282: ProcessType[*main.bigStruct]
+	ProcessPointer 29 00 00 00 
+	Return 
+// 0x288: ProcessType[*string]
+	ProcessPointer 07 00 00 00 
+	Return 
+// 0x28e: ProcessType[*table<string,int>]
 	ProcessPointer 16 00 00 00 
 	Return 
-// 0x360: ProcessType[[]*table<string,int>.array]
-	ProcessSliceDataPrep 
-	Call 5a 03 00 00 // ProcessType[*table<string,int>]
-	ProcessSliceDataRepeat 08 00 00 00 
-	Return 
-// 0x36c: ProcessType[*table<string,main.bigStruct>]
+// 0x294: ProcessType[*table<string,main.bigStruct>]
 	ProcessPointer 22 00 00 00 
 	Return 
-// 0x372: ProcessType[[]*table<string,main.bigStruct>.array]
+// 0x29a: ProcessType[*uint]
+	ProcessPointer 2d 00 00 00 
+	Return 
+// 0x2a0: ProcessType[*uint16]
+	ProcessPointer 17 00 00 00 
+	Return 
+// 0x2a6: ProcessType[*uint32]
+	ProcessPointer 2b 00 00 00 
+	Return 
+// 0x2ac: ProcessType[*uint64]
+	ProcessPointer 12 00 00 00 
+	Return 
+// 0x2b2: ProcessType[*uint8]
+	ProcessPointer 09 00 00 00 
+	Return 
+// 0x2b8: ProcessType[*uintptr]
+	ProcessPointer 13 00 00 00 
+	Return 
+// 0x2be: ProcessType[[3]string]
+	ProcessArrayDataPrep 30 00 00 00 
+	Call a8 03 00 00 // ProcessType[string]
+	ProcessSliceDataRepeat 10 00 00 00 
+	Return 
+// 0x2ce: ProcessType[[]*table<string,int>.array]
 	ProcessSliceDataPrep 
-	Call 6c 03 00 00 // ProcessType[*table<string,main.bigStruct>]
+	Call 8e 02 00 00 // ProcessType[*table<string,int>]
 	ProcessSliceDataRepeat 08 00 00 00 
 	Return 
-// 0x37e: ProcessType[groupReference<string,int>]
+// 0x2da: ProcessType[[]*table<string,main.bigStruct>.array]
+	ProcessSliceDataPrep 
+	Call 94 02 00 00 // ProcessType[*table<string,main.bigStruct>]
+	ProcessSliceDataRepeat 08 00 00 00 
+	Return 
+// 0x2e6: ProcessType[[]int]
+	ProcessSlice 45 00 00 00 08 00 00 00 
+	Return 
+// 0x2f0: ProcessType[[]noalg.map.group[string]int.array]
+	ProcessSliceDataPrep 
+	Call 7c 03 00 00 // ProcessType[noalg.map.group[string]int]
+	ProcessSliceDataRepeat 00 00 00 00 
+	Return 
+// 0x2fc: ProcessType[[]noalg.map.group[string]main.bigStruct.array]
+	ProcessSliceDataPrep 
+	Call 87 03 00 00 // ProcessType[noalg.map.group[string]main.bigStruct]
+	ProcessSliceDataRepeat 00 00 00 00 
+	Return 
+// 0x308: ProcessType[[]string]
+	ProcessSlice 47 00 00 00 10 00 00 00 
+	Return 
+// 0x312: ProcessType[[]string.array]
+	ProcessSliceDataPrep 
+	Call a8 03 00 00 // ProcessType[string]
+	ProcessSliceDataRepeat 10 00 00 00 
+	Return 
+// 0x31e: ProcessType[error]
+	ProcessGoInterface 
+	Return 
+// 0x320: ProcessType[groupReference<string,int>]
 	ProcessGoSwissMapGroups 4a 00 00 00 c8 00 00 00 00 08 
 	Return 
-// 0x38a: ProcessType[table<string,int>]
-	IncrementOutputOffset 10 00 00 00 
-	Call 7e 03 00 00 // ProcessType[groupReference<string,int>]
-	Return 
-// 0x395: ProcessType[groupReference<string,main.bigStruct>]
+// 0x32c: ProcessType[groupReference<string,main.bigStruct>]
 	ProcessGoSwissMapGroups 4c 00 00 00 c8 00 00 00 00 08 
 	Return 
-// 0x3a1: ProcessType[table<string,main.bigStruct>]
+// 0x338: ProcessType[map<string,int>]
+	ProcessGoSwissMap 49 00 00 00 1a 00 00 00 10 18 
+	Return 
+// 0x344: ProcessType[map<string,main.bigStruct>]
+	ProcessGoSwissMap 4b 00 00 00 25 00 00 00 10 18 
+	Return 
+// 0x350: ProcessType[map[string]int]
+	ProcessPointer 11 00 00 00 
+	Return 
+// 0x356: ProcessType[map[string]main.bigStruct]
+	ProcessPointer 1f 00 00 00 
+	Return 
+// 0x35c: ProcessType[noalg.[8]struct { key string; elem *main.bigStruct }]
+	ProcessArrayDataPrep c0 00 00 00 
+	Call 92 03 00 00 // ProcessType[noalg.struct { key string; elem *main.bigStruct }]
+	ProcessSliceDataRepeat 08 00 00 00 
+	Return 
+// 0x36c: ProcessType[noalg.[8]struct { key string; elem int }]
+	ProcessArrayDataPrep c0 00 00 00 
+	Call a2 03 00 00 // ProcessType[noalg.struct { key string; elem int }]
+	ProcessSliceDataRepeat 18 00 00 00 
+	Return 
+// 0x37c: ProcessType[noalg.map.group[string]int]
+	IncrementOutputOffset 08 00 00 00 
+	Call 6c 03 00 00 // ProcessType[noalg.[8]struct { key string; elem int }]
+	Return 
+// 0x387: ProcessType[noalg.map.group[string]main.bigStruct]
+	IncrementOutputOffset 08 00 00 00 
+	Call 5c 03 00 00 // ProcessType[noalg.[8]struct { key string; elem *main.bigStruct }]
+	Return 
+// 0x392: ProcessType[noalg.struct { key string; elem *main.bigStruct }]
+	Call a8 03 00 00 // ProcessType[string]
 	IncrementOutputOffset 10 00 00 00 
-	Call 95 03 00 00 // ProcessType[groupReference<string,main.bigStruct>]
+	Call 82 02 00 00 // ProcessType[*main.bigStruct]
 	Return 
-// 0x3ac: ProcessType[[]noalg.map.group[string]int.array]
-	ProcessSliceDataPrep 
-	Call c2 02 00 00 // ProcessType[noalg.map.group[string]int]
-	ProcessSliceDataRepeat 00 00 00 00 
+// 0x3a2: ProcessType[noalg.struct { key string; elem int }]
+	Call a8 03 00 00 // ProcessType[string]
 	Return 
-// 0x3b8: ProcessType[[]noalg.map.group[string]main.bigStruct.array]
-	ProcessSliceDataPrep 
-	Call ff 02 00 00 // ProcessType[noalg.map.group[string]main.bigStruct]
-	ProcessSliceDataRepeat 00 00 00 00 
+// 0x3a8: ProcessType[string]
+	ProcessString 43 00 00 00 
+	Return 
+// 0x3ae: ProcessType[table<string,int>]
+	IncrementOutputOffset 10 00 00 00 
+	Call 20 03 00 00 // ProcessType[groupReference<string,int>]
+	Return 
+// 0x3b9: ProcessType[table<string,main.bigStruct>]
+	IncrementOutputOffset 10 00 00 00 
+	Call 2c 03 00 00 // ProcessType[groupReference<string,main.bigStruct>]
 	Return 
 // Extra illegal ops to simplify code bound checks
 	Illegal 
@@ -307,81 +307,81 @@
 	Illegal 
 // Types
 ID: 1 Len: 8 Enqueue: 0
-ID: 2 Len: 8 Enqueue: 3
-ID: 3 Len: 8 Enqueue: 642
-ID: 4 Len: 8 Enqueue: 648
-ID: 5 Len: 8 Enqueue: 51
-ID: 6 Len: 8 Enqueue: 654
-ID: 7 Len: 16 Enqueue: 295
-ID: 8 Len: 8 Enqueue: 660
+ID: 2 Len: 8 Enqueue: 576
+ID: 3 Len: 8 Enqueue: 582
+ID: 4 Len: 8 Enqueue: 588
+ID: 5 Len: 8 Enqueue: 594
+ID: 6 Len: 8 Enqueue: 624
+ID: 7 Len: 16 Enqueue: 936
+ID: 8 Len: 8 Enqueue: 690
 ID: 9 Len: 1 Enqueue: 0
-ID: 10 Len: 24 Enqueue: 365
+ID: 10 Len: 24 Enqueue: 742
 ID: 11 Len: 24 Enqueue: 0
-ID: 12 Len: 24 Enqueue: 576
-ID: 13 Len: 8 Enqueue: 666
-ID: 14 Len: 48 Enqueue: 301
-ID: 15 Len: 8 Enqueue: 431
+ID: 12 Len: 24 Enqueue: 776
+ID: 13 Len: 8 Enqueue: 648
+ID: 14 Len: 48 Enqueue: 702
+ID: 15 Len: 8 Enqueue: 848
 ID: 16 Len: 8 Enqueue: 0
-ID: 17 Len: 48 Enqueue: 672
+ID: 17 Len: 48 Enqueue: 824
 ID: 18 Len: 8 Enqueue: 0
 ID: 19 Len: 8 Enqueue: 0
 ID: 20 Len: 8 Enqueue: 0
-ID: 21 Len: 8 Enqueue: 858
-ID: 22 Len: 32 Enqueue: 906
+ID: 21 Len: 8 Enqueue: 654
+ID: 22 Len: 32 Enqueue: 942
 ID: 23 Len: 2 Enqueue: 0
-ID: 24 Len: 16 Enqueue: 894
+ID: 24 Len: 16 Enqueue: 800
 ID: 25 Len: 8 Enqueue: 0
-ID: 26 Len: 200 Enqueue: 706
-ID: 27 Len: 192 Enqueue: 690
-ID: 28 Len: 24 Enqueue: 684
-ID: 29 Len: 8 Enqueue: 99
+ID: 26 Len: 200 Enqueue: 892
+ID: 27 Len: 192 Enqueue: 876
+ID: 28 Len: 24 Enqueue: 930
+ID: 29 Len: 8 Enqueue: 854
 ID: 30 Len: 8 Enqueue: 0
-ID: 31 Len: 48 Enqueue: 717
+ID: 31 Len: 48 Enqueue: 836
 ID: 32 Len: 8 Enqueue: 0
-ID: 33 Len: 8 Enqueue: 876
-ID: 34 Len: 32 Enqueue: 929
-ID: 35 Len: 16 Enqueue: 917
+ID: 33 Len: 8 Enqueue: 660
+ID: 34 Len: 32 Enqueue: 953
+ID: 35 Len: 16 Enqueue: 812
 ID: 36 Len: 8 Enqueue: 0
-ID: 37 Len: 200 Enqueue: 767
-ID: 38 Len: 192 Enqueue: 751
-ID: 39 Len: 24 Enqueue: 735
-ID: 40 Len: 8 Enqueue: 729
+ID: 37 Len: 200 Enqueue: 903
+ID: 38 Len: 192 Enqueue: 860
+ID: 39 Len: 24 Enqueue: 914
+ID: 40 Len: 8 Enqueue: 642
 ID: 41 Len: 184 Enqueue: 0
 ID: 42 Len: 128 Enqueue: 0
 ID: 43 Len: 4 Enqueue: 0
 ID: 44 Len: 1 Enqueue: 0
 ID: 45 Len: 8 Enqueue: 0
-ID: 46 Len: 8 Enqueue: 778
+ID: 46 Len: 8 Enqueue: 600
 ID: 47 Len: 4 Enqueue: 0
 ID: 48 Len: 8 Enqueue: 0
-ID: 49 Len: 16 Enqueue: 784
+ID: 49 Len: 16 Enqueue: 798
 ID: 50 Len: 8 Enqueue: 0
 ID: 51 Len: 1 Enqueue: 0
 ID: 52 Len: 4 Enqueue: 0
 ID: 53 Len: 8 Enqueue: 0
-ID: 54 Len: 8 Enqueue: 786
-ID: 55 Len: 8 Enqueue: 792
-ID: 56 Len: 8 Enqueue: 798
+ID: 54 Len: 8 Enqueue: 696
+ID: 55 Len: 8 Enqueue: 630
+ID: 56 Len: 8 Enqueue: 678
 ID: 57 Len: 2 Enqueue: 0
 ID: 58 Len: 8 Enqueue: 0
 ID: 59 Len: 16 Enqueue: 0
-ID: 60 Len: 8 Enqueue: 804
-ID: 61 Len: 8 Enqueue: 810
-ID: 62 Len: 8 Enqueue: 816
-ID: 63 Len: 8 Enqueue: 822
-ID: 64 Len: 8 Enqueue: 828
-ID: 65 Len: 8 Enqueue: 834
-ID: 66 Len: 8 Enqueue: 840
+ID: 60 Len: 8 Enqueue: 618
+ID: 61 Len: 8 Enqueue: 636
+ID: 62 Len: 8 Enqueue: 684
+ID: 63 Len: 8 Enqueue: 606
+ID: 64 Len: 8 Enqueue: 612
+ID: 65 Len: 8 Enqueue: 666
+ID: 66 Len: 8 Enqueue: 672
 ID: 67 Len: 2048 Enqueue: 0
 ID: 68 Len: 8 Enqueue: 0
 ID: 69 Len: 2048 Enqueue: 0
 ID: 70 Len: 8 Enqueue: 0
-ID: 71 Len: 2048 Enqueue: 846
+ID: 71 Len: 2048 Enqueue: 786
 ID: 72 Len: 8 Enqueue: 0
-ID: 73 Len: 8192 Enqueue: 864
-ID: 74 Len: 2048 Enqueue: 940
-ID: 75 Len: 8192 Enqueue: 882
-ID: 76 Len: 2048 Enqueue: 952
+ID: 73 Len: 8192 Enqueue: 718
+ID: 74 Len: 2048 Enqueue: 752
+ID: 75 Len: 8192 Enqueue: 730
+ID: 76 Len: 2048 Enqueue: 764
 ID: 77 Len: 9 Enqueue: 0
 ID: 78 Len: 17 Enqueue: 0
 ID: 79 Len: 25 Enqueue: 0

--- a/pkg/dyninst/compiler/testdata/snapshot/simple.arch=arm64,toolchain=go1.24.3.sm.txt
+++ b/pkg/dyninst/compiler/testdata/snapshot/simple.arch=arm64,toolchain=go1.24.3.sm.txt
@@ -135,67 +135,67 @@
 	Call 08 02 00 00 // ProcessExpression[Probe[main.stringSliceArg]@0xb544c.expr[0]]
 	Return 
 // 0x240: ProcessType[*****int]
-	ProcessPointer 03 00 00 00 
+	ProcessPointer 40 00 00 00 
 	Return 
 // 0x246: ProcessType[****int]
-	ProcessPointer 04 00 00 00 
+	ProcessPointer 41 00 00 00 
 	Return 
 // 0x24c: ProcessType[***int]
-	ProcessPointer 05 00 00 00 
+	ProcessPointer 42 00 00 00 
 	Return 
 // 0x252: ProcessType[**int]
-	ProcessPointer 06 00 00 00 
+	ProcessPointer 1c 00 00 00 
 	Return 
 // 0x258: ProcessType[*bool]
-	ProcessPointer 2c 00 00 00 
+	ProcessPointer 04 00 00 00 
 	Return 
 // 0x25e: ProcessType[*error]
-	ProcessPointer 31 00 00 00 
+	ProcessPointer 0e 00 00 00 
 	Return 
 // 0x264: ProcessType[*float32]
-	ProcessPointer 34 00 00 00 
+	ProcessPointer 11 00 00 00 
 	Return 
 // 0x26a: ProcessType[*float64]
-	ProcessPointer 35 00 00 00 
-	Return 
-// 0x270: ProcessType[*int]
-	ProcessPointer 01 00 00 00 
-	Return 
-// 0x276: ProcessType[*int32]
-	ProcessPointer 2f 00 00 00 
-	Return 
-// 0x27c: ProcessType[*int64]
-	ProcessPointer 30 00 00 00 
-	Return 
-// 0x282: ProcessType[*main.bigStruct]
-	ProcessPointer 29 00 00 00 
-	Return 
-// 0x288: ProcessType[*string]
-	ProcessPointer 07 00 00 00 
-	Return 
-// 0x28e: ProcessType[*table<string,int>]
-	ProcessPointer 16 00 00 00 
-	Return 
-// 0x294: ProcessType[*table<string,main.bigStruct>]
-	ProcessPointer 22 00 00 00 
-	Return 
-// 0x29a: ProcessType[*uint]
-	ProcessPointer 2d 00 00 00 
-	Return 
-// 0x2a0: ProcessType[*uint16]
-	ProcessPointer 17 00 00 00 
-	Return 
-// 0x2a6: ProcessType[*uint32]
-	ProcessPointer 2b 00 00 00 
-	Return 
-// 0x2ac: ProcessType[*uint64]
 	ProcessPointer 12 00 00 00 
 	Return 
-// 0x2b2: ProcessType[*uint8]
+// 0x270: ProcessType[*int]
+	ProcessPointer 07 00 00 00 
+	Return 
+// 0x276: ProcessType[*int32]
+	ProcessPointer 0c 00 00 00 
+	Return 
+// 0x27c: ProcessType[*int64]
+	ProcessPointer 0d 00 00 00 
+	Return 
+// 0x282: ProcessType[*main.bigStruct]
+	ProcessPointer 3d 00 00 00 
+	Return 
+// 0x288: ProcessType[*string]
 	ProcessPointer 09 00 00 00 
 	Return 
+// 0x28e: ProcessType[*table<string,int>]
+	ProcessPointer 2b 00 00 00 
+	Return 
+// 0x294: ProcessType[*table<string,main.bigStruct>]
+	ProcessPointer 36 00 00 00 
+	Return 
+// 0x29a: ProcessType[*uint]
+	ProcessPointer 0a 00 00 00 
+	Return 
+// 0x2a0: ProcessType[*uint16]
+	ProcessPointer 06 00 00 00 
+	Return 
+// 0x2a6: ProcessType[*uint32]
+	ProcessPointer 02 00 00 00 
+	Return 
+// 0x2ac: ProcessType[*uint64]
+	ProcessPointer 08 00 00 00 
+	Return 
+// 0x2b2: ProcessType[*uint8]
+	ProcessPointer 03 00 00 00 
+	Return 
 // 0x2b8: ProcessType[*uintptr]
-	ProcessPointer 13 00 00 00 
+	ProcessPointer 01 00 00 00 
 	Return 
 // 0x2be: ProcessType[[3]string]
 	ProcessArrayDataPrep 30 00 00 00 
@@ -243,16 +243,16 @@
 	ProcessGoSwissMapGroups 4c 00 00 00 c8 00 00 00 00 08 
 	Return 
 // 0x338: ProcessType[map<string,int>]
-	ProcessGoSwissMap 49 00 00 00 1a 00 00 00 10 18 
+	ProcessGoSwissMap 49 00 00 00 2e 00 00 00 10 18 
 	Return 
 // 0x344: ProcessType[map<string,main.bigStruct>]
-	ProcessGoSwissMap 4b 00 00 00 25 00 00 00 10 18 
+	ProcessGoSwissMap 4b 00 00 00 39 00 00 00 10 18 
 	Return 
 // 0x350: ProcessType[map[string]int]
-	ProcessPointer 11 00 00 00 
+	ProcessPointer 28 00 00 00 
 	Return 
 // 0x356: ProcessType[map[string]main.bigStruct]
-	ProcessPointer 1f 00 00 00 
+	ProcessPointer 33 00 00 00 
 	Return 
 // 0x35c: ProcessType[noalg.[8]struct { key string; elem *main.bigStruct }]
 	ProcessArrayDataPrep c0 00 00 00 
@@ -307,71 +307,71 @@
 	Illegal 
 // Types
 ID: 1 Len: 8 Enqueue: 0
-ID: 2 Len: 8 Enqueue: 576
-ID: 3 Len: 8 Enqueue: 582
-ID: 4 Len: 8 Enqueue: 588
-ID: 5 Len: 8 Enqueue: 594
-ID: 6 Len: 8 Enqueue: 624
-ID: 7 Len: 16 Enqueue: 936
-ID: 8 Len: 8 Enqueue: 690
-ID: 9 Len: 1 Enqueue: 0
-ID: 10 Len: 24 Enqueue: 742
-ID: 11 Len: 24 Enqueue: 0
-ID: 12 Len: 24 Enqueue: 776
-ID: 13 Len: 8 Enqueue: 648
-ID: 14 Len: 48 Enqueue: 702
-ID: 15 Len: 8 Enqueue: 848
-ID: 16 Len: 8 Enqueue: 0
-ID: 17 Len: 48 Enqueue: 824
+ID: 2 Len: 4 Enqueue: 0
+ID: 3 Len: 1 Enqueue: 0
+ID: 4 Len: 1 Enqueue: 0
+ID: 5 Len: 8 Enqueue: 690
+ID: 6 Len: 2 Enqueue: 0
+ID: 7 Len: 8 Enqueue: 0
+ID: 8 Len: 8 Enqueue: 0
+ID: 9 Len: 16 Enqueue: 936
+ID: 10 Len: 8 Enqueue: 0
+ID: 11 Len: 8 Enqueue: 600
+ID: 12 Len: 4 Enqueue: 0
+ID: 13 Len: 8 Enqueue: 0
+ID: 14 Len: 16 Enqueue: 798
+ID: 15 Len: 8 Enqueue: 0
+ID: 16 Len: 1 Enqueue: 0
+ID: 17 Len: 4 Enqueue: 0
 ID: 18 Len: 8 Enqueue: 0
-ID: 19 Len: 8 Enqueue: 0
-ID: 20 Len: 8 Enqueue: 0
-ID: 21 Len: 8 Enqueue: 654
-ID: 22 Len: 32 Enqueue: 942
+ID: 19 Len: 8 Enqueue: 696
+ID: 20 Len: 8 Enqueue: 630
+ID: 21 Len: 8 Enqueue: 678
+ID: 22 Len: 8 Enqueue: 648
 ID: 23 Len: 2 Enqueue: 0
-ID: 24 Len: 16 Enqueue: 800
-ID: 25 Len: 8 Enqueue: 0
-ID: 26 Len: 200 Enqueue: 892
-ID: 27 Len: 192 Enqueue: 876
-ID: 28 Len: 24 Enqueue: 930
-ID: 29 Len: 8 Enqueue: 854
-ID: 30 Len: 8 Enqueue: 0
-ID: 31 Len: 48 Enqueue: 836
-ID: 32 Len: 8 Enqueue: 0
-ID: 33 Len: 8 Enqueue: 660
-ID: 34 Len: 32 Enqueue: 953
-ID: 35 Len: 16 Enqueue: 812
-ID: 36 Len: 8 Enqueue: 0
-ID: 37 Len: 200 Enqueue: 903
-ID: 38 Len: 192 Enqueue: 860
-ID: 39 Len: 24 Enqueue: 914
-ID: 40 Len: 8 Enqueue: 642
-ID: 41 Len: 184 Enqueue: 0
-ID: 42 Len: 128 Enqueue: 0
-ID: 43 Len: 4 Enqueue: 0
-ID: 44 Len: 1 Enqueue: 0
+ID: 24 Len: 8 Enqueue: 0
+ID: 25 Len: 16 Enqueue: 0
+ID: 26 Len: 8 Enqueue: 618
+ID: 27 Len: 8 Enqueue: 636
+ID: 28 Len: 8 Enqueue: 624
+ID: 29 Len: 8 Enqueue: 684
+ID: 30 Len: 8 Enqueue: 606
+ID: 31 Len: 8 Enqueue: 612
+ID: 32 Len: 8 Enqueue: 666
+ID: 33 Len: 8 Enqueue: 672
+ID: 34 Len: 24 Enqueue: 742
+ID: 35 Len: 24 Enqueue: 0
+ID: 36 Len: 24 Enqueue: 776
+ID: 37 Len: 48 Enqueue: 702
+ID: 38 Len: 8 Enqueue: 848
+ID: 39 Len: 8 Enqueue: 0
+ID: 40 Len: 48 Enqueue: 824
+ID: 41 Len: 8 Enqueue: 0
+ID: 42 Len: 8 Enqueue: 654
+ID: 43 Len: 32 Enqueue: 942
+ID: 44 Len: 16 Enqueue: 800
 ID: 45 Len: 8 Enqueue: 0
-ID: 46 Len: 8 Enqueue: 600
-ID: 47 Len: 4 Enqueue: 0
-ID: 48 Len: 8 Enqueue: 0
-ID: 49 Len: 16 Enqueue: 798
+ID: 46 Len: 200 Enqueue: 892
+ID: 47 Len: 192 Enqueue: 876
+ID: 48 Len: 24 Enqueue: 930
+ID: 49 Len: 8 Enqueue: 854
 ID: 50 Len: 8 Enqueue: 0
-ID: 51 Len: 1 Enqueue: 0
-ID: 52 Len: 4 Enqueue: 0
-ID: 53 Len: 8 Enqueue: 0
-ID: 54 Len: 8 Enqueue: 696
-ID: 55 Len: 8 Enqueue: 630
-ID: 56 Len: 8 Enqueue: 678
-ID: 57 Len: 2 Enqueue: 0
-ID: 58 Len: 8 Enqueue: 0
-ID: 59 Len: 16 Enqueue: 0
-ID: 60 Len: 8 Enqueue: 618
-ID: 61 Len: 8 Enqueue: 636
-ID: 62 Len: 8 Enqueue: 684
-ID: 63 Len: 8 Enqueue: 606
-ID: 64 Len: 8 Enqueue: 612
-ID: 65 Len: 8 Enqueue: 666
-ID: 66 Len: 8 Enqueue: 672
+ID: 51 Len: 48 Enqueue: 836
+ID: 52 Len: 8 Enqueue: 0
+ID: 53 Len: 8 Enqueue: 660
+ID: 54 Len: 32 Enqueue: 953
+ID: 55 Len: 16 Enqueue: 812
+ID: 56 Len: 8 Enqueue: 0
+ID: 57 Len: 200 Enqueue: 903
+ID: 58 Len: 192 Enqueue: 860
+ID: 59 Len: 24 Enqueue: 914
+ID: 60 Len: 8 Enqueue: 642
+ID: 61 Len: 184 Enqueue: 0
+ID: 62 Len: 128 Enqueue: 0
+ID: 63 Len: 8 Enqueue: 576
+ID: 64 Len: 8 Enqueue: 582
+ID: 65 Len: 8 Enqueue: 588
+ID: 66 Len: 8 Enqueue: 594
 ID: 67 Len: 2048 Enqueue: 0
 ID: 68 Len: 8 Enqueue: 0
 ID: 69 Len: 2048 Enqueue: 0

--- a/pkg/dyninst/compiler/testdata/snapshot/simple.arch=arm64,toolchain=go1.24.3.sm.txt
+++ b/pkg/dyninst/compiler/testdata/snapshot/simple.arch=arm64,toolchain=go1.24.3.sm.txt
@@ -138,7 +138,7 @@
 	ProcessPointer 31 00 00 00 
 	Return 
 // 0x246: ProcessType[****int]
-	ProcessPointer 35 00 00 00 
+	ProcessPointer 4b 00 00 00 
 	Return 
 // 0x24c: ProcessType[***int]
 	ProcessPointer 32 00 00 00 
@@ -168,16 +168,16 @@
 	ProcessPointer 0d 00 00 00 
 	Return 
 // 0x282: ProcessType[*main.bigStruct]
-	ProcessPointer 49 00 00 00 
+	ProcessPointer 48 00 00 00 
 	Return 
 // 0x288: ProcessType[*string]
 	ProcessPointer 09 00 00 00 
 	Return 
 // 0x28e: ProcessType[*table<string,int>]
-	ProcessPointer 33 00 00 00 
+	ProcessPointer 39 00 00 00 
 	Return 
 // 0x294: ProcessType[*table<string,main.bigStruct>]
-	ProcessPointer 34 00 00 00 
+	ProcessPointer 41 00 00 00 
 	Return 
 // 0x29a: ProcessType[*uint]
 	ProcessPointer 0a 00 00 00 
@@ -213,7 +213,7 @@
 	ProcessSliceDataRepeat 08 00 00 00 
 	Return 
 // 0x2e6: ProcessType[[]int]
-	ProcessSlice 38 00 00 00 08 00 00 00 
+	ProcessSlice 35 00 00 00 08 00 00 00 
 	Return 
 // 0x2f0: ProcessType[[]noalg.map.group[string]int.array]
 	ProcessSliceDataPrep 
@@ -226,7 +226,7 @@
 	ProcessSliceDataRepeat 00 00 00 00 
 	Return 
 // 0x308: ProcessType[[]string]
-	ProcessSlice 3a 00 00 00 10 00 00 00 
+	ProcessSlice 37 00 00 00 10 00 00 00 
 	Return 
 // 0x312: ProcessType[[]string.array]
 	ProcessSliceDataPrep 
@@ -237,16 +237,16 @@
 	ProcessGoInterface 
 	Return 
 // 0x320: ProcessType[groupReference<string,int>]
-	ProcessGoSwissMapGroups 42 00 00 00 c8 00 00 00 00 08 
+	ProcessGoSwissMapGroups 40 00 00 00 c8 00 00 00 00 08 
 	Return 
 // 0x32c: ProcessType[groupReference<string,main.bigStruct>]
-	ProcessGoSwissMapGroups 4b 00 00 00 c8 00 00 00 00 08 
+	ProcessGoSwissMapGroups 4a 00 00 00 c8 00 00 00 00 08 
 	Return 
 // 0x338: ProcessType[map<string,int>]
-	ProcessGoSwissMap 41 00 00 00 3e 00 00 00 10 18 
+	ProcessGoSwissMap 3f 00 00 00 3c 00 00 00 10 18 
 	Return 
 // 0x344: ProcessType[map<string,main.bigStruct>]
-	ProcessGoSwissMap 4a 00 00 00 45 00 00 00 10 18 
+	ProcessGoSwissMap 49 00 00 00 44 00 00 00 10 18 
 	Return 
 // 0x350: ProcessType[map[string]int]
 	ProcessPointer 28 00 00 00 
@@ -281,7 +281,7 @@
 	Call a8 03 00 00 // ProcessType[string]
 	Return 
 // 0x3a8: ProcessType[string]
-	ProcessString 36 00 00 00 
+	ProcessString 33 00 00 00 
 	Return 
 // 0x3ae: ProcessType[table<string,int>]
 	IncrementOutputOffset 10 00 00 00 
@@ -356,31 +356,31 @@ ID: 47 Len: 8 Enqueue: 660
 ID: 48 Len: 8 Enqueue: 576
 ID: 49 Len: 8 Enqueue: 582
 ID: 50 Len: 8 Enqueue: 594
-ID: 51 Len: 32 Enqueue: 942
-ID: 52 Len: 32 Enqueue: 953
-ID: 53 Len: 8 Enqueue: 588
-ID: 54 Len: 2048 Enqueue: 0
-ID: 55 Len: 8 Enqueue: 0
-ID: 56 Len: 2048 Enqueue: 0
-ID: 57 Len: 8 Enqueue: 0
-ID: 58 Len: 2048 Enqueue: 786
+ID: 51 Len: 2048 Enqueue: 0
+ID: 52 Len: 8 Enqueue: 0
+ID: 53 Len: 2048 Enqueue: 0
+ID: 54 Len: 8 Enqueue: 0
+ID: 55 Len: 2048 Enqueue: 786
+ID: 56 Len: 8 Enqueue: 0
+ID: 57 Len: 32 Enqueue: 942
+ID: 58 Len: 16 Enqueue: 800
 ID: 59 Len: 8 Enqueue: 0
-ID: 60 Len: 16 Enqueue: 800
-ID: 61 Len: 8 Enqueue: 0
-ID: 62 Len: 200 Enqueue: 892
-ID: 63 Len: 192 Enqueue: 876
-ID: 64 Len: 24 Enqueue: 930
-ID: 65 Len: 8192 Enqueue: 718
-ID: 66 Len: 2048 Enqueue: 752
-ID: 67 Len: 16 Enqueue: 812
-ID: 68 Len: 8 Enqueue: 0
-ID: 69 Len: 200 Enqueue: 903
-ID: 70 Len: 192 Enqueue: 860
-ID: 71 Len: 24 Enqueue: 914
-ID: 72 Len: 8 Enqueue: 642
-ID: 73 Len: 184 Enqueue: 0
-ID: 74 Len: 8192 Enqueue: 730
-ID: 75 Len: 2048 Enqueue: 764
+ID: 60 Len: 200 Enqueue: 892
+ID: 61 Len: 192 Enqueue: 876
+ID: 62 Len: 24 Enqueue: 930
+ID: 63 Len: 8192 Enqueue: 718
+ID: 64 Len: 2048 Enqueue: 752
+ID: 65 Len: 32 Enqueue: 953
+ID: 66 Len: 16 Enqueue: 812
+ID: 67 Len: 8 Enqueue: 0
+ID: 68 Len: 200 Enqueue: 903
+ID: 69 Len: 192 Enqueue: 860
+ID: 70 Len: 24 Enqueue: 914
+ID: 71 Len: 8 Enqueue: 642
+ID: 72 Len: 184 Enqueue: 0
+ID: 73 Len: 8192 Enqueue: 730
+ID: 74 Len: 2048 Enqueue: 764
+ID: 75 Len: 8 Enqueue: 588
 ID: 76 Len: 128 Enqueue: 0
 ID: 77 Len: 9 Enqueue: 0
 ID: 78 Len: 17 Enqueue: 0

--- a/pkg/dyninst/compiler/testdata/snapshot/simple.arch=arm64,toolchain=go1.24.3.sm.txt
+++ b/pkg/dyninst/compiler/testdata/snapshot/simple.arch=arm64,toolchain=go1.24.3.sm.txt
@@ -135,13 +135,13 @@
 	Call 08 02 00 00 // ProcessExpression[Probe[main.stringSliceArg]@0xb544c.expr[0]]
 	Return 
 // 0x240: ProcessType[*****int]
-	ProcessPointer 40 00 00 00 
+	ProcessPointer 31 00 00 00 
 	Return 
 // 0x246: ProcessType[****int]
-	ProcessPointer 41 00 00 00 
+	ProcessPointer 35 00 00 00 
 	Return 
 // 0x24c: ProcessType[***int]
-	ProcessPointer 42 00 00 00 
+	ProcessPointer 32 00 00 00 
 	Return 
 // 0x252: ProcessType[**int]
 	ProcessPointer 1c 00 00 00 
@@ -168,16 +168,16 @@
 	ProcessPointer 0d 00 00 00 
 	Return 
 // 0x282: ProcessType[*main.bigStruct]
-	ProcessPointer 3d 00 00 00 
+	ProcessPointer 41 00 00 00 
 	Return 
 // 0x288: ProcessType[*string]
 	ProcessPointer 09 00 00 00 
 	Return 
 // 0x28e: ProcessType[*table<string,int>]
-	ProcessPointer 2b 00 00 00 
+	ProcessPointer 33 00 00 00 
 	Return 
 // 0x294: ProcessType[*table<string,main.bigStruct>]
-	ProcessPointer 36 00 00 00 
+	ProcessPointer 34 00 00 00 
 	Return 
 // 0x29a: ProcessType[*uint]
 	ProcessPointer 0a 00 00 00 
@@ -243,16 +243,16 @@
 	ProcessGoSwissMapGroups 4c 00 00 00 c8 00 00 00 00 08 
 	Return 
 // 0x338: ProcessType[map<string,int>]
-	ProcessGoSwissMap 49 00 00 00 2e 00 00 00 10 18 
+	ProcessGoSwissMap 49 00 00 00 38 00 00 00 10 18 
 	Return 
 // 0x344: ProcessType[map<string,main.bigStruct>]
-	ProcessGoSwissMap 4b 00 00 00 39 00 00 00 10 18 
+	ProcessGoSwissMap 4b 00 00 00 3b 00 00 00 10 18 
 	Return 
 // 0x350: ProcessType[map[string]int]
 	ProcessPointer 28 00 00 00 
 	Return 
 // 0x356: ProcessType[map[string]main.bigStruct]
-	ProcessPointer 33 00 00 00 
+	ProcessPointer 2d 00 00 00 
 	Return 
 // 0x35c: ProcessType[noalg.[8]struct { key string; elem *main.bigStruct }]
 	ProcessArrayDataPrep c0 00 00 00 
@@ -348,30 +348,30 @@ ID: 39 Len: 8 Enqueue: 0
 ID: 40 Len: 48 Enqueue: 824
 ID: 41 Len: 8 Enqueue: 0
 ID: 42 Len: 8 Enqueue: 654
-ID: 43 Len: 32 Enqueue: 942
-ID: 44 Len: 16 Enqueue: 800
-ID: 45 Len: 8 Enqueue: 0
-ID: 46 Len: 200 Enqueue: 892
-ID: 47 Len: 192 Enqueue: 876
-ID: 48 Len: 24 Enqueue: 930
-ID: 49 Len: 8 Enqueue: 854
-ID: 50 Len: 8 Enqueue: 0
-ID: 51 Len: 48 Enqueue: 836
-ID: 52 Len: 8 Enqueue: 0
-ID: 53 Len: 8 Enqueue: 660
-ID: 54 Len: 32 Enqueue: 953
-ID: 55 Len: 16 Enqueue: 812
-ID: 56 Len: 8 Enqueue: 0
-ID: 57 Len: 200 Enqueue: 903
-ID: 58 Len: 192 Enqueue: 860
-ID: 59 Len: 24 Enqueue: 914
-ID: 60 Len: 8 Enqueue: 642
-ID: 61 Len: 184 Enqueue: 0
-ID: 62 Len: 128 Enqueue: 0
-ID: 63 Len: 8 Enqueue: 576
-ID: 64 Len: 8 Enqueue: 582
-ID: 65 Len: 8 Enqueue: 588
-ID: 66 Len: 8 Enqueue: 594
+ID: 43 Len: 8 Enqueue: 854
+ID: 44 Len: 8 Enqueue: 0
+ID: 45 Len: 48 Enqueue: 836
+ID: 46 Len: 8 Enqueue: 0
+ID: 47 Len: 8 Enqueue: 660
+ID: 48 Len: 8 Enqueue: 576
+ID: 49 Len: 8 Enqueue: 582
+ID: 50 Len: 8 Enqueue: 594
+ID: 51 Len: 32 Enqueue: 942
+ID: 52 Len: 32 Enqueue: 953
+ID: 53 Len: 8 Enqueue: 588
+ID: 54 Len: 16 Enqueue: 800
+ID: 55 Len: 8 Enqueue: 0
+ID: 56 Len: 200 Enqueue: 892
+ID: 57 Len: 16 Enqueue: 812
+ID: 58 Len: 8 Enqueue: 0
+ID: 59 Len: 200 Enqueue: 903
+ID: 60 Len: 192 Enqueue: 876
+ID: 61 Len: 24 Enqueue: 930
+ID: 62 Len: 192 Enqueue: 860
+ID: 63 Len: 24 Enqueue: 914
+ID: 64 Len: 8 Enqueue: 642
+ID: 65 Len: 184 Enqueue: 0
+ID: 66 Len: 128 Enqueue: 0
 ID: 67 Len: 2048 Enqueue: 0
 ID: 68 Len: 8 Enqueue: 0
 ID: 69 Len: 2048 Enqueue: 0

--- a/pkg/dyninst/compiler/testdata/snapshot/simple.arch=arm64,toolchain=go1.25.0.sm.txt
+++ b/pkg/dyninst/compiler/testdata/snapshot/simple.arch=arm64,toolchain=go1.25.0.sm.txt
@@ -135,13 +135,13 @@
 	Call 08 02 00 00 // ProcessExpression[Probe[main.stringSliceArg]@0xb7fbc.expr[0]]
 	Return 
 // 0x240: ProcessType[*****int]
-	ProcessPointer 40 00 00 00 
+	ProcessPointer 31 00 00 00 
 	Return 
 // 0x246: ProcessType[****int]
-	ProcessPointer 41 00 00 00 
+	ProcessPointer 35 00 00 00 
 	Return 
 // 0x24c: ProcessType[***int]
-	ProcessPointer 42 00 00 00 
+	ProcessPointer 32 00 00 00 
 	Return 
 // 0x252: ProcessType[**int]
 	ProcessPointer 1b 00 00 00 
@@ -168,16 +168,16 @@
 	ProcessPointer 0d 00 00 00 
 	Return 
 // 0x282: ProcessType[*main.bigStruct]
-	ProcessPointer 3d 00 00 00 
+	ProcessPointer 41 00 00 00 
 	Return 
 // 0x288: ProcessType[*string]
 	ProcessPointer 09 00 00 00 
 	Return 
 // 0x28e: ProcessType[*table<string,int>]
-	ProcessPointer 2b 00 00 00 
+	ProcessPointer 33 00 00 00 
 	Return 
 // 0x294: ProcessType[*table<string,main.bigStruct>]
-	ProcessPointer 36 00 00 00 
+	ProcessPointer 34 00 00 00 
 	Return 
 // 0x29a: ProcessType[*uint]
 	ProcessPointer 0a 00 00 00 
@@ -243,16 +243,16 @@
 	ProcessGoSwissMapGroups 4c 00 00 00 c8 00 00 00 00 08 
 	Return 
 // 0x338: ProcessType[map<string,int>]
-	ProcessGoSwissMap 49 00 00 00 2e 00 00 00 10 18 
+	ProcessGoSwissMap 49 00 00 00 38 00 00 00 10 18 
 	Return 
 // 0x344: ProcessType[map<string,main.bigStruct>]
-	ProcessGoSwissMap 4b 00 00 00 39 00 00 00 10 18 
+	ProcessGoSwissMap 4b 00 00 00 3b 00 00 00 10 18 
 	Return 
 // 0x350: ProcessType[map[string]int]
 	ProcessPointer 28 00 00 00 
 	Return 
 // 0x356: ProcessType[map[string]main.bigStruct]
-	ProcessPointer 33 00 00 00 
+	ProcessPointer 2d 00 00 00 
 	Return 
 // 0x35c: ProcessType[noalg.[8]struct { key string; elem *main.bigStruct }]
 	ProcessArrayDataPrep c0 00 00 00 
@@ -348,30 +348,30 @@ ID: 39 Len: 8 Enqueue: 0
 ID: 40 Len: 48 Enqueue: 824
 ID: 41 Len: 8 Enqueue: 0
 ID: 42 Len: 8 Enqueue: 654
-ID: 43 Len: 32 Enqueue: 942
-ID: 44 Len: 16 Enqueue: 800
-ID: 45 Len: 8 Enqueue: 0
-ID: 46 Len: 200 Enqueue: 892
-ID: 47 Len: 192 Enqueue: 876
-ID: 48 Len: 24 Enqueue: 930
-ID: 49 Len: 8 Enqueue: 854
-ID: 50 Len: 8 Enqueue: 0
-ID: 51 Len: 48 Enqueue: 836
-ID: 52 Len: 8 Enqueue: 0
-ID: 53 Len: 8 Enqueue: 660
-ID: 54 Len: 32 Enqueue: 953
-ID: 55 Len: 16 Enqueue: 812
-ID: 56 Len: 8 Enqueue: 0
-ID: 57 Len: 200 Enqueue: 903
-ID: 58 Len: 192 Enqueue: 860
-ID: 59 Len: 24 Enqueue: 914
-ID: 60 Len: 8 Enqueue: 642
-ID: 61 Len: 184 Enqueue: 0
-ID: 62 Len: 128 Enqueue: 0
-ID: 63 Len: 8 Enqueue: 576
-ID: 64 Len: 8 Enqueue: 582
-ID: 65 Len: 8 Enqueue: 588
-ID: 66 Len: 8 Enqueue: 594
+ID: 43 Len: 8 Enqueue: 854
+ID: 44 Len: 8 Enqueue: 0
+ID: 45 Len: 48 Enqueue: 836
+ID: 46 Len: 8 Enqueue: 0
+ID: 47 Len: 8 Enqueue: 660
+ID: 48 Len: 8 Enqueue: 576
+ID: 49 Len: 8 Enqueue: 582
+ID: 50 Len: 8 Enqueue: 594
+ID: 51 Len: 32 Enqueue: 942
+ID: 52 Len: 32 Enqueue: 953
+ID: 53 Len: 8 Enqueue: 588
+ID: 54 Len: 16 Enqueue: 800
+ID: 55 Len: 8 Enqueue: 0
+ID: 56 Len: 200 Enqueue: 892
+ID: 57 Len: 16 Enqueue: 812
+ID: 58 Len: 8 Enqueue: 0
+ID: 59 Len: 200 Enqueue: 903
+ID: 60 Len: 192 Enqueue: 876
+ID: 61 Len: 24 Enqueue: 930
+ID: 62 Len: 192 Enqueue: 860
+ID: 63 Len: 24 Enqueue: 914
+ID: 64 Len: 8 Enqueue: 642
+ID: 65 Len: 184 Enqueue: 0
+ID: 66 Len: 128 Enqueue: 0
 ID: 67 Len: 2048 Enqueue: 0
 ID: 68 Len: 8 Enqueue: 0
 ID: 69 Len: 2048 Enqueue: 0

--- a/pkg/dyninst/compiler/testdata/snapshot/simple.arch=arm64,toolchain=go1.25.0.sm.txt
+++ b/pkg/dyninst/compiler/testdata/snapshot/simple.arch=arm64,toolchain=go1.25.0.sm.txt
@@ -168,7 +168,7 @@
 	ProcessPointer 0d 00 00 00 
 	Return 
 // 0x282: ProcessType[*main.bigStruct]
-	ProcessPointer 41 00 00 00 
+	ProcessPointer 49 00 00 00 
 	Return 
 // 0x288: ProcessType[*string]
 	ProcessPointer 09 00 00 00 
@@ -213,7 +213,7 @@
 	ProcessSliceDataRepeat 08 00 00 00 
 	Return 
 // 0x2e6: ProcessType[[]int]
-	ProcessSlice 45 00 00 00 08 00 00 00 
+	ProcessSlice 38 00 00 00 08 00 00 00 
 	Return 
 // 0x2f0: ProcessType[[]noalg.map.group[string]int.array]
 	ProcessSliceDataPrep 
@@ -226,7 +226,7 @@
 	ProcessSliceDataRepeat 00 00 00 00 
 	Return 
 // 0x308: ProcessType[[]string]
-	ProcessSlice 47 00 00 00 10 00 00 00 
+	ProcessSlice 3a 00 00 00 10 00 00 00 
 	Return 
 // 0x312: ProcessType[[]string.array]
 	ProcessSliceDataPrep 
@@ -237,16 +237,16 @@
 	ProcessGoInterface 
 	Return 
 // 0x320: ProcessType[groupReference<string,int>]
-	ProcessGoSwissMapGroups 4a 00 00 00 c8 00 00 00 00 08 
+	ProcessGoSwissMapGroups 42 00 00 00 c8 00 00 00 00 08 
 	Return 
 // 0x32c: ProcessType[groupReference<string,main.bigStruct>]
-	ProcessGoSwissMapGroups 4c 00 00 00 c8 00 00 00 00 08 
+	ProcessGoSwissMapGroups 4b 00 00 00 c8 00 00 00 00 08 
 	Return 
 // 0x338: ProcessType[map<string,int>]
-	ProcessGoSwissMap 49 00 00 00 38 00 00 00 10 18 
+	ProcessGoSwissMap 41 00 00 00 3e 00 00 00 10 18 
 	Return 
 // 0x344: ProcessType[map<string,main.bigStruct>]
-	ProcessGoSwissMap 4b 00 00 00 3b 00 00 00 10 18 
+	ProcessGoSwissMap 4a 00 00 00 45 00 00 00 10 18 
 	Return 
 // 0x350: ProcessType[map[string]int]
 	ProcessPointer 28 00 00 00 
@@ -281,7 +281,7 @@
 	Call a8 03 00 00 // ProcessType[string]
 	Return 
 // 0x3a8: ProcessType[string]
-	ProcessString 43 00 00 00 
+	ProcessString 36 00 00 00 
 	Return 
 // 0x3ae: ProcessType[table<string,int>]
 	IncrementOutputOffset 10 00 00 00 
@@ -359,29 +359,29 @@ ID: 50 Len: 8 Enqueue: 594
 ID: 51 Len: 32 Enqueue: 942
 ID: 52 Len: 32 Enqueue: 953
 ID: 53 Len: 8 Enqueue: 588
-ID: 54 Len: 16 Enqueue: 800
+ID: 54 Len: 2048 Enqueue: 0
 ID: 55 Len: 8 Enqueue: 0
-ID: 56 Len: 200 Enqueue: 892
-ID: 57 Len: 16 Enqueue: 812
-ID: 58 Len: 8 Enqueue: 0
-ID: 59 Len: 200 Enqueue: 903
-ID: 60 Len: 192 Enqueue: 876
-ID: 61 Len: 24 Enqueue: 930
-ID: 62 Len: 192 Enqueue: 860
-ID: 63 Len: 24 Enqueue: 914
-ID: 64 Len: 8 Enqueue: 642
-ID: 65 Len: 184 Enqueue: 0
-ID: 66 Len: 128 Enqueue: 0
-ID: 67 Len: 2048 Enqueue: 0
+ID: 56 Len: 2048 Enqueue: 0
+ID: 57 Len: 8 Enqueue: 0
+ID: 58 Len: 2048 Enqueue: 786
+ID: 59 Len: 8 Enqueue: 0
+ID: 60 Len: 16 Enqueue: 800
+ID: 61 Len: 8 Enqueue: 0
+ID: 62 Len: 200 Enqueue: 892
+ID: 63 Len: 192 Enqueue: 876
+ID: 64 Len: 24 Enqueue: 930
+ID: 65 Len: 8192 Enqueue: 718
+ID: 66 Len: 2048 Enqueue: 752
+ID: 67 Len: 16 Enqueue: 812
 ID: 68 Len: 8 Enqueue: 0
-ID: 69 Len: 2048 Enqueue: 0
-ID: 70 Len: 8 Enqueue: 0
-ID: 71 Len: 2048 Enqueue: 786
-ID: 72 Len: 8 Enqueue: 0
-ID: 73 Len: 8192 Enqueue: 718
-ID: 74 Len: 2048 Enqueue: 752
-ID: 75 Len: 8192 Enqueue: 730
-ID: 76 Len: 2048 Enqueue: 764
+ID: 69 Len: 200 Enqueue: 903
+ID: 70 Len: 192 Enqueue: 860
+ID: 71 Len: 24 Enqueue: 914
+ID: 72 Len: 8 Enqueue: 642
+ID: 73 Len: 184 Enqueue: 0
+ID: 74 Len: 8192 Enqueue: 730
+ID: 75 Len: 2048 Enqueue: 764
+ID: 76 Len: 128 Enqueue: 0
 ID: 77 Len: 9 Enqueue: 0
 ID: 78 Len: 17 Enqueue: 0
 ID: 79 Len: 25 Enqueue: 0

--- a/pkg/dyninst/compiler/testdata/snapshot/simple.arch=arm64,toolchain=go1.25.0.sm.txt
+++ b/pkg/dyninst/compiler/testdata/snapshot/simple.arch=arm64,toolchain=go1.25.0.sm.txt
@@ -3,293 +3,293 @@
 // 0x1: ChasePointers
 	ChasePointers 
 	Return 
-// 0x3: ProcessType[*****int]
-	ProcessPointer 03 00 00 00 
-	Return 
-// 0x9: ProcessExpression[Probe[main.PointerChainArg]@0xb7d60.expr[0]]
+// 0x3: ProcessExpression[Probe[main.PointerChainArg]@0xb7d60.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
-	Call 03 00 00 00 // ProcessType[*****int]
+	Call 40 02 00 00 // ProcessType[*****int]
 	Return 
-// 0x24: ProcessEvent[Probe[main.PointerChainArg]@b7d60]
+// 0x1e: ProcessEvent[Probe[main.PointerChainArg]@b7d60]
 	PrepareEventRoot 57 00 00 00 09 00 00 00 
-	Call 09 00 00 00 // ProcessExpression[Probe[main.PointerChainArg]@0xb7d60.expr[0]]
+	Call 03 00 00 00 // ProcessExpression[Probe[main.PointerChainArg]@0xb7d60.expr[0]]
 	Return 
-// 0x33: ProcessType[**int]
-	ProcessPointer 06 00 00 00 
-	Return 
-// 0x39: ProcessExpression[Probe[main.PointerSmallChainArg]@0xb7d94.expr[0]]
+// 0x2d: ProcessExpression[Probe[main.PointerSmallChainArg]@0xb7d94.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 05 08 00 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
-	Call 33 00 00 00 // ProcessType[**int]
+	Call 52 02 00 00 // ProcessType[**int]
 	Return 
-// 0x54: ProcessEvent[Probe[main.PointerSmallChainArg]@b7d94]
+// 0x48: ProcessEvent[Probe[main.PointerSmallChainArg]@b7d94]
 	PrepareEventRoot 58 00 00 00 09 00 00 00 
-	Call 39 00 00 00 // ProcessExpression[Probe[main.PointerSmallChainArg]@0xb7d94.expr[0]]
+	Call 2d 00 00 00 // ProcessExpression[Probe[main.PointerSmallChainArg]@0xb7d94.expr[0]]
 	Return 
-// 0x63: ProcessType[map[string]main.bigStruct]
-	ProcessPointer 20 00 00 00 
-	Return 
-// 0x69: ProcessExpression[Probe[main.bigMapArg]@0xb81f0.expr[0]]
+// 0x57: ProcessExpression[Probe[main.bigMapArg]@0xb81f0.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
-	Call 63 00 00 00 // ProcessType[map[string]main.bigStruct]
+	Call 56 03 00 00 // ProcessType[map[string]main.bigStruct]
 	Return 
-// 0x84: ProcessEvent[Probe[main.bigMapArg]@b81f0]
+// 0x72: ProcessEvent[Probe[main.bigMapArg]@b81f0]
 	PrepareEventRoot 55 00 00 00 09 00 00 00 
-	Call 69 00 00 00 // ProcessExpression[Probe[main.bigMapArg]@0xb81f0.expr[0]]
+	Call 57 00 00 00 // ProcessExpression[Probe[main.bigMapArg]@0xb81f0.expr[0]]
 	Return 
-// 0x93: ProcessExpression[Probe[main.inlined]@0xb80bc.expr[0]]
+// 0x81: ProcessExpression[Probe[main.inlined]@0xb80bc.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
 	Return 
-// 0xa9: ProcessEvent[Probe[main.inlined]@b80bc]
+// 0x97: ProcessEvent[Probe[main.inlined]@b80bc]
 	PrepareEventRoot 56 00 00 00 09 00 00 00 
-	Call 93 00 00 00 // ProcessExpression[Probe[main.inlined]@0xb80bc.expr[0]]
+	Call 81 00 00 00 // ProcessExpression[Probe[main.inlined]@0xb80bc.expr[0]]
 	Return 
-// 0xb8: ProcessExpression[Probe[main.inlined]@0xb7b88.expr[0]]
+// 0xa6: ProcessExpression[Probe[main.inlined]@0xb7b88.expr[0]]
 	ExprPrepare 
 	Return 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
 	Return 
-// 0xc8: ProcessEvent[Probe[main.inlined]@b7b88]
+// 0xb6: ProcessEvent[Probe[main.inlined]@b7b88]
 	PrepareEventRoot 56 00 00 00 09 00 00 00 
-	Call b8 00 00 00 // ProcessExpression[Probe[main.inlined]@0xb7b88.expr[0]]
+	Call a6 00 00 00 // ProcessExpression[Probe[main.inlined]@0xb7b88.expr[0]]
 	Return 
-// 0xd7: ProcessExpression[Probe[main.intArg]@0xb7dec.expr[0]]
+// 0xc5: ProcessExpression[Probe[main.intArg]@0xb7dec.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
 	Return 
-// 0xed: ProcessEvent[Probe[main.intArg]@b7dec]
+// 0xdb: ProcessEvent[Probe[main.intArg]@b7dec]
 	PrepareEventRoot 4d 00 00 00 09 00 00 00 
-	Call d7 00 00 00 // ProcessExpression[Probe[main.intArg]@0xb7dec.expr[0]]
+	Call c5 00 00 00 // ProcessExpression[Probe[main.intArg]@0xb7dec.expr[0]]
 	Return 
-// 0xfc: ProcessExpression[Probe[main.intArrayArg]@0xb7f4c.expr[0]]
+// 0xea: ProcessExpression[Probe[main.intArrayArg]@0xb7f4c.expr[0]]
 	ExprPrepare 
 	ExprDereferenceCfa 08 00 00 00 18 00 00 00 00 00 00 00 
 	ExprSave 01 00 00 00 18 00 00 00 00 00 00 00 
 	Return 
-// 0x118: ProcessEvent[Probe[main.intArrayArg]@b7f4c]
+// 0x106: ProcessEvent[Probe[main.intArrayArg]@b7f4c]
 	PrepareEventRoot 50 00 00 00 19 00 00 00 
-	Call fc 00 00 00 // ProcessExpression[Probe[main.intArrayArg]@0xb7f4c.expr[0]]
+	Call ea 00 00 00 // ProcessExpression[Probe[main.intArrayArg]@0xb7f4c.expr[0]]
 	Return 
-// 0x127: ProcessType[string]
-	ProcessString 43 00 00 00 
-	Return 
-// 0x12d: ProcessType[[3]string]
-	ProcessArrayDataPrep 30 00 00 00 
-	Call 27 01 00 00 // ProcessType[string]
-	ProcessSliceDataRepeat 10 00 00 00 
-	Return 
-// 0x13d: ProcessExpression[Probe[main.stringArrayArgFrameless]@0xb80a0.expr[0]]
+// 0x115: ProcessExpression[Probe[main.stringArrayArgFrameless]@0xb80a0.expr[0]]
 	ExprPrepare 
 	ExprDereferenceCfa 08 00 00 00 30 00 00 00 00 00 00 00 
 	ExprSave 01 00 00 00 30 00 00 00 00 00 00 00 
-	Call 2d 01 00 00 // ProcessType[[3]string]
+	Call be 02 00 00 // ProcessType[[3]string]
 	Return 
-// 0x15e: ProcessEvent[Probe[main.stringArrayArgFrameless]@b80a0]
+// 0x136: ProcessEvent[Probe[main.stringArrayArgFrameless]@b80a0]
 	PrepareEventRoot 53 00 00 00 31 00 00 00 
-	Call 3d 01 00 00 // ProcessExpression[Probe[main.stringArrayArgFrameless]@0xb80a0.expr[0]]
+	Call 15 01 00 00 // ProcessExpression[Probe[main.stringArrayArgFrameless]@0xb80a0.expr[0]]
 	Return 
-// 0x16d: ProcessType[[]int]
-	ProcessSlice 45 00 00 00 08 00 00 00 
-	Return 
-// 0x177: ProcessExpression[Probe[main.intSliceArg]@0xb7ecc.expr[0]]
+// 0x145: ProcessExpression[Probe[main.intSliceArg]@0xb7ecc.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprReadRegister 01 08 08 00 00 00 
 	ExprReadRegister 02 08 10 00 00 00 
 	ExprSave 01 00 00 00 18 00 00 00 00 00 00 00 
-	Call 6d 01 00 00 // ProcessType[[]int]
+	Call e6 02 00 00 // ProcessType[[]int]
 	Return 
-// 0x1a0: ProcessEvent[Probe[main.intSliceArg]@b7ecc]
+// 0x16e: ProcessEvent[Probe[main.intSliceArg]@b7ecc]
 	PrepareEventRoot 4f 00 00 00 19 00 00 00 
-	Call 77 01 00 00 // ProcessExpression[Probe[main.intSliceArg]@0xb7ecc.expr[0]]
+	Call 45 01 00 00 // ProcessExpression[Probe[main.intSliceArg]@0xb7ecc.expr[0]]
 	Return 
-// 0x1af: ProcessType[map[string]int]
-	ProcessPointer 11 00 00 00 
-	Return 
-// 0x1b5: ProcessExpression[Probe[main.mapArg]@0xb817c.expr[0]]
+// 0x17d: ProcessExpression[Probe[main.mapArg]@0xb817c.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
-	Call af 01 00 00 // ProcessType[map[string]int]
+	Call 50 03 00 00 // ProcessType[map[string]int]
 	Return 
-// 0x1d0: ProcessEvent[Probe[main.mapArg]@b817c]
+// 0x198: ProcessEvent[Probe[main.mapArg]@b817c]
 	PrepareEventRoot 54 00 00 00 09 00 00 00 
-	Call b5 01 00 00 // ProcessExpression[Probe[main.mapArg]@0xb817c.expr[0]]
+	Call 7d 01 00 00 // ProcessExpression[Probe[main.mapArg]@0xb817c.expr[0]]
 	Return 
-// 0x1df: ProcessExpression[Probe[main.stringArg]@0xb7e5c.expr[0]]
+// 0x1a7: ProcessExpression[Probe[main.stringArg]@0xb7e5c.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprReadRegister 01 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call 27 01 00 00 // ProcessType[string]
+	Call a8 03 00 00 // ProcessType[string]
 	Return 
-// 0x201: ProcessEvent[Probe[main.stringArg]@b7e5c]
+// 0x1c9: ProcessEvent[Probe[main.stringArg]@b7e5c]
 	PrepareEventRoot 4e 00 00 00 11 00 00 00 
-	Call df 01 00 00 // ProcessExpression[Probe[main.stringArg]@0xb7e5c.expr[0]]
+	Call a7 01 00 00 // ProcessExpression[Probe[main.stringArg]@0xb7e5c.expr[0]]
 	Return 
-// 0x210: ProcessExpression[Probe[main.stringArrayArg]@0xb803c.expr[0]]
+// 0x1d8: ProcessExpression[Probe[main.stringArrayArg]@0xb803c.expr[0]]
 	ExprPrepare 
 	ExprDereferenceCfa 08 00 00 00 30 00 00 00 00 00 00 00 
 	ExprSave 01 00 00 00 30 00 00 00 00 00 00 00 
-	Call 2d 01 00 00 // ProcessType[[3]string]
+	Call be 02 00 00 // ProcessType[[3]string]
 	Return 
-// 0x231: ProcessEvent[Probe[main.stringArrayArg]@b803c]
+// 0x1f9: ProcessEvent[Probe[main.stringArrayArg]@b803c]
 	PrepareEventRoot 52 00 00 00 31 00 00 00 
-	Call 10 02 00 00 // ProcessExpression[Probe[main.stringArrayArg]@0xb803c.expr[0]]
+	Call d8 01 00 00 // ProcessExpression[Probe[main.stringArrayArg]@0xb803c.expr[0]]
 	Return 
-// 0x240: ProcessType[[]string]
-	ProcessSlice 47 00 00 00 10 00 00 00 
-	Return 
-// 0x24a: ProcessExpression[Probe[main.stringSliceArg]@0xb7fbc.expr[0]]
+// 0x208: ProcessExpression[Probe[main.stringSliceArg]@0xb7fbc.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprReadRegister 01 08 08 00 00 00 
 	ExprReadRegister 02 08 10 00 00 00 
 	ExprSave 01 00 00 00 18 00 00 00 00 00 00 00 
-	Call 40 02 00 00 // ProcessType[[]string]
+	Call 08 03 00 00 // ProcessType[[]string]
 	Return 
-// 0x273: ProcessEvent[Probe[main.stringSliceArg]@b7fbc]
+// 0x231: ProcessEvent[Probe[main.stringSliceArg]@b7fbc]
 	PrepareEventRoot 51 00 00 00 19 00 00 00 
-	Call 4a 02 00 00 // ProcessExpression[Probe[main.stringSliceArg]@0xb7fbc.expr[0]]
+	Call 08 02 00 00 // ProcessExpression[Probe[main.stringSliceArg]@0xb7fbc.expr[0]]
 	Return 
-// 0x282: ProcessType[****int]
+// 0x240: ProcessType[*****int]
+	ProcessPointer 03 00 00 00 
+	Return 
+// 0x246: ProcessType[****int]
 	ProcessPointer 04 00 00 00 
 	Return 
-// 0x288: ProcessType[***int]
+// 0x24c: ProcessType[***int]
 	ProcessPointer 05 00 00 00 
 	Return 
-// 0x28e: ProcessType[*int]
-	ProcessPointer 01 00 00 00 
+// 0x252: ProcessType[**int]
+	ProcessPointer 06 00 00 00 
 	Return 
-// 0x294: ProcessType[*uint8]
-	ProcessPointer 09 00 00 00 
-	Return 
-// 0x29a: ProcessType[*string]
-	ProcessPointer 07 00 00 00 
-	Return 
-// 0x2a0: ProcessType[map<string,int>]
-	ProcessGoSwissMap 49 00 00 00 1a 00 00 00 10 18 
-	Return 
-// 0x2ac: ProcessType[noalg.struct { key string; elem int }]
-	Call 27 01 00 00 // ProcessType[string]
-	Return 
-// 0x2b2: ProcessType[noalg.[8]struct { key string; elem int }]
-	ProcessArrayDataPrep c0 00 00 00 
-	Call ac 02 00 00 // ProcessType[noalg.struct { key string; elem int }]
-	ProcessSliceDataRepeat 18 00 00 00 
-	Return 
-// 0x2c2: ProcessType[noalg.map.group[string]int]
-	IncrementOutputOffset 08 00 00 00 
-	Call b2 02 00 00 // ProcessType[noalg.[8]struct { key string; elem int }]
-	Return 
-// 0x2cd: ProcessType[map<string,main.bigStruct>]
-	ProcessGoSwissMap 4b 00 00 00 26 00 00 00 10 18 
-	Return 
-// 0x2d9: ProcessType[*main.bigStruct]
-	ProcessPointer 2a 00 00 00 
-	Return 
-// 0x2df: ProcessType[noalg.struct { key string; elem *main.bigStruct }]
-	Call 27 01 00 00 // ProcessType[string]
-	IncrementOutputOffset 10 00 00 00 
-	Call d9 02 00 00 // ProcessType[*main.bigStruct]
-	Return 
-// 0x2ef: ProcessType[noalg.[8]struct { key string; elem *main.bigStruct }]
-	ProcessArrayDataPrep c0 00 00 00 
-	Call df 02 00 00 // ProcessType[noalg.struct { key string; elem *main.bigStruct }]
-	ProcessSliceDataRepeat 08 00 00 00 
-	Return 
-// 0x2ff: ProcessType[noalg.map.group[string]main.bigStruct]
-	IncrementOutputOffset 08 00 00 00 
-	Call ef 02 00 00 // ProcessType[noalg.[8]struct { key string; elem *main.bigStruct }]
-	Return 
-// 0x30a: ProcessType[*bool]
+// 0x258: ProcessType[*bool]
 	ProcessPointer 1d 00 00 00 
 	Return 
-// 0x310: ProcessType[error]
-	ProcessGoInterface 
-	Return 
-// 0x312: ProcessType[*uintptr]
-	ProcessPointer 13 00 00 00 
-	Return 
-// 0x318: ProcessType[*int32]
-	ProcessPointer 2f 00 00 00 
-	Return 
-// 0x31e: ProcessType[*uint32]
-	ProcessPointer 2c 00 00 00 
-	Return 
-// 0x324: ProcessType[*float64]
-	ProcessPointer 33 00 00 00 
-	Return 
-// 0x32a: ProcessType[*uint64]
-	ProcessPointer 12 00 00 00 
-	Return 
-// 0x330: ProcessType[*int64]
-	ProcessPointer 30 00 00 00 
-	Return 
-// 0x336: ProcessType[*error]
+// 0x25e: ProcessType[*error]
 	ProcessPointer 31 00 00 00 
 	Return 
-// 0x33c: ProcessType[*float32]
+// 0x264: ProcessType[*float32]
 	ProcessPointer 35 00 00 00 
 	Return 
-// 0x342: ProcessType[*uint]
-	ProcessPointer 2d 00 00 00 
+// 0x26a: ProcessType[*float64]
+	ProcessPointer 33 00 00 00 
 	Return 
-// 0x348: ProcessType[*uint16]
-	ProcessPointer 17 00 00 00 
+// 0x270: ProcessType[*int]
+	ProcessPointer 01 00 00 00 
 	Return 
-// 0x34e: ProcessType[[]string.array]
-	ProcessSliceDataPrep 
-	Call 27 01 00 00 // ProcessType[string]
-	ProcessSliceDataRepeat 10 00 00 00 
+// 0x276: ProcessType[*int32]
+	ProcessPointer 2f 00 00 00 
 	Return 
-// 0x35a: ProcessType[*table<string,int>]
+// 0x27c: ProcessType[*int64]
+	ProcessPointer 30 00 00 00 
+	Return 
+// 0x282: ProcessType[*main.bigStruct]
+	ProcessPointer 2a 00 00 00 
+	Return 
+// 0x288: ProcessType[*string]
+	ProcessPointer 07 00 00 00 
+	Return 
+// 0x28e: ProcessType[*table<string,int>]
 	ProcessPointer 16 00 00 00 
 	Return 
-// 0x360: ProcessType[[]*table<string,int>.array]
-	ProcessSliceDataPrep 
-	Call 5a 03 00 00 // ProcessType[*table<string,int>]
-	ProcessSliceDataRepeat 08 00 00 00 
-	Return 
-// 0x36c: ProcessType[*table<string,main.bigStruct>]
+// 0x294: ProcessType[*table<string,main.bigStruct>]
 	ProcessPointer 23 00 00 00 
 	Return 
-// 0x372: ProcessType[[]*table<string,main.bigStruct>.array]
+// 0x29a: ProcessType[*uint]
+	ProcessPointer 2d 00 00 00 
+	Return 
+// 0x2a0: ProcessType[*uint16]
+	ProcessPointer 17 00 00 00 
+	Return 
+// 0x2a6: ProcessType[*uint32]
+	ProcessPointer 2c 00 00 00 
+	Return 
+// 0x2ac: ProcessType[*uint64]
+	ProcessPointer 12 00 00 00 
+	Return 
+// 0x2b2: ProcessType[*uint8]
+	ProcessPointer 09 00 00 00 
+	Return 
+// 0x2b8: ProcessType[*uintptr]
+	ProcessPointer 13 00 00 00 
+	Return 
+// 0x2be: ProcessType[[3]string]
+	ProcessArrayDataPrep 30 00 00 00 
+	Call a8 03 00 00 // ProcessType[string]
+	ProcessSliceDataRepeat 10 00 00 00 
+	Return 
+// 0x2ce: ProcessType[[]*table<string,int>.array]
 	ProcessSliceDataPrep 
-	Call 6c 03 00 00 // ProcessType[*table<string,main.bigStruct>]
+	Call 8e 02 00 00 // ProcessType[*table<string,int>]
 	ProcessSliceDataRepeat 08 00 00 00 
 	Return 
-// 0x37e: ProcessType[groupReference<string,int>]
+// 0x2da: ProcessType[[]*table<string,main.bigStruct>.array]
+	ProcessSliceDataPrep 
+	Call 94 02 00 00 // ProcessType[*table<string,main.bigStruct>]
+	ProcessSliceDataRepeat 08 00 00 00 
+	Return 
+// 0x2e6: ProcessType[[]int]
+	ProcessSlice 45 00 00 00 08 00 00 00 
+	Return 
+// 0x2f0: ProcessType[[]noalg.map.group[string]int.array]
+	ProcessSliceDataPrep 
+	Call 7c 03 00 00 // ProcessType[noalg.map.group[string]int]
+	ProcessSliceDataRepeat 00 00 00 00 
+	Return 
+// 0x2fc: ProcessType[[]noalg.map.group[string]main.bigStruct.array]
+	ProcessSliceDataPrep 
+	Call 87 03 00 00 // ProcessType[noalg.map.group[string]main.bigStruct]
+	ProcessSliceDataRepeat 00 00 00 00 
+	Return 
+// 0x308: ProcessType[[]string]
+	ProcessSlice 47 00 00 00 10 00 00 00 
+	Return 
+// 0x312: ProcessType[[]string.array]
+	ProcessSliceDataPrep 
+	Call a8 03 00 00 // ProcessType[string]
+	ProcessSliceDataRepeat 10 00 00 00 
+	Return 
+// 0x31e: ProcessType[error]
+	ProcessGoInterface 
+	Return 
+// 0x320: ProcessType[groupReference<string,int>]
 	ProcessGoSwissMapGroups 4a 00 00 00 c8 00 00 00 00 08 
 	Return 
-// 0x38a: ProcessType[table<string,int>]
-	IncrementOutputOffset 10 00 00 00 
-	Call 7e 03 00 00 // ProcessType[groupReference<string,int>]
-	Return 
-// 0x395: ProcessType[groupReference<string,main.bigStruct>]
+// 0x32c: ProcessType[groupReference<string,main.bigStruct>]
 	ProcessGoSwissMapGroups 4c 00 00 00 c8 00 00 00 00 08 
 	Return 
-// 0x3a1: ProcessType[table<string,main.bigStruct>]
+// 0x338: ProcessType[map<string,int>]
+	ProcessGoSwissMap 49 00 00 00 1a 00 00 00 10 18 
+	Return 
+// 0x344: ProcessType[map<string,main.bigStruct>]
+	ProcessGoSwissMap 4b 00 00 00 26 00 00 00 10 18 
+	Return 
+// 0x350: ProcessType[map[string]int]
+	ProcessPointer 11 00 00 00 
+	Return 
+// 0x356: ProcessType[map[string]main.bigStruct]
+	ProcessPointer 20 00 00 00 
+	Return 
+// 0x35c: ProcessType[noalg.[8]struct { key string; elem *main.bigStruct }]
+	ProcessArrayDataPrep c0 00 00 00 
+	Call 92 03 00 00 // ProcessType[noalg.struct { key string; elem *main.bigStruct }]
+	ProcessSliceDataRepeat 08 00 00 00 
+	Return 
+// 0x36c: ProcessType[noalg.[8]struct { key string; elem int }]
+	ProcessArrayDataPrep c0 00 00 00 
+	Call a2 03 00 00 // ProcessType[noalg.struct { key string; elem int }]
+	ProcessSliceDataRepeat 18 00 00 00 
+	Return 
+// 0x37c: ProcessType[noalg.map.group[string]int]
+	IncrementOutputOffset 08 00 00 00 
+	Call 6c 03 00 00 // ProcessType[noalg.[8]struct { key string; elem int }]
+	Return 
+// 0x387: ProcessType[noalg.map.group[string]main.bigStruct]
+	IncrementOutputOffset 08 00 00 00 
+	Call 5c 03 00 00 // ProcessType[noalg.[8]struct { key string; elem *main.bigStruct }]
+	Return 
+// 0x392: ProcessType[noalg.struct { key string; elem *main.bigStruct }]
+	Call a8 03 00 00 // ProcessType[string]
 	IncrementOutputOffset 10 00 00 00 
-	Call 95 03 00 00 // ProcessType[groupReference<string,main.bigStruct>]
+	Call 82 02 00 00 // ProcessType[*main.bigStruct]
 	Return 
-// 0x3ac: ProcessType[[]noalg.map.group[string]int.array]
-	ProcessSliceDataPrep 
-	Call c2 02 00 00 // ProcessType[noalg.map.group[string]int]
-	ProcessSliceDataRepeat 00 00 00 00 
+// 0x3a2: ProcessType[noalg.struct { key string; elem int }]
+	Call a8 03 00 00 // ProcessType[string]
 	Return 
-// 0x3b8: ProcessType[[]noalg.map.group[string]main.bigStruct.array]
-	ProcessSliceDataPrep 
-	Call ff 02 00 00 // ProcessType[noalg.map.group[string]main.bigStruct]
-	ProcessSliceDataRepeat 00 00 00 00 
+// 0x3a8: ProcessType[string]
+	ProcessString 43 00 00 00 
+	Return 
+// 0x3ae: ProcessType[table<string,int>]
+	IncrementOutputOffset 10 00 00 00 
+	Call 20 03 00 00 // ProcessType[groupReference<string,int>]
+	Return 
+// 0x3b9: ProcessType[table<string,main.bigStruct>]
+	IncrementOutputOffset 10 00 00 00 
+	Call 2c 03 00 00 // ProcessType[groupReference<string,main.bigStruct>]
 	Return 
 // Extra illegal ops to simplify code bound checks
 	Illegal 
@@ -307,81 +307,81 @@
 	Illegal 
 // Types
 ID: 1 Len: 8 Enqueue: 0
-ID: 2 Len: 8 Enqueue: 3
-ID: 3 Len: 8 Enqueue: 642
-ID: 4 Len: 8 Enqueue: 648
-ID: 5 Len: 8 Enqueue: 51
-ID: 6 Len: 8 Enqueue: 654
-ID: 7 Len: 16 Enqueue: 295
-ID: 8 Len: 8 Enqueue: 660
+ID: 2 Len: 8 Enqueue: 576
+ID: 3 Len: 8 Enqueue: 582
+ID: 4 Len: 8 Enqueue: 588
+ID: 5 Len: 8 Enqueue: 594
+ID: 6 Len: 8 Enqueue: 624
+ID: 7 Len: 16 Enqueue: 936
+ID: 8 Len: 8 Enqueue: 690
 ID: 9 Len: 1 Enqueue: 0
-ID: 10 Len: 24 Enqueue: 365
+ID: 10 Len: 24 Enqueue: 742
 ID: 11 Len: 24 Enqueue: 0
-ID: 12 Len: 24 Enqueue: 576
-ID: 13 Len: 8 Enqueue: 666
-ID: 14 Len: 48 Enqueue: 301
-ID: 15 Len: 8 Enqueue: 431
+ID: 12 Len: 24 Enqueue: 776
+ID: 13 Len: 8 Enqueue: 648
+ID: 14 Len: 48 Enqueue: 702
+ID: 15 Len: 8 Enqueue: 848
 ID: 16 Len: 8 Enqueue: 0
-ID: 17 Len: 48 Enqueue: 672
+ID: 17 Len: 48 Enqueue: 824
 ID: 18 Len: 8 Enqueue: 0
 ID: 19 Len: 8 Enqueue: 0
 ID: 20 Len: 8 Enqueue: 0
-ID: 21 Len: 8 Enqueue: 858
-ID: 22 Len: 32 Enqueue: 906
+ID: 21 Len: 8 Enqueue: 654
+ID: 22 Len: 32 Enqueue: 942
 ID: 23 Len: 2 Enqueue: 0
-ID: 24 Len: 16 Enqueue: 894
+ID: 24 Len: 16 Enqueue: 800
 ID: 25 Len: 8 Enqueue: 0
-ID: 26 Len: 200 Enqueue: 706
-ID: 27 Len: 192 Enqueue: 690
-ID: 28 Len: 24 Enqueue: 684
+ID: 26 Len: 200 Enqueue: 892
+ID: 27 Len: 192 Enqueue: 876
+ID: 28 Len: 24 Enqueue: 930
 ID: 29 Len: 1 Enqueue: 0
-ID: 30 Len: 8 Enqueue: 99
+ID: 30 Len: 8 Enqueue: 854
 ID: 31 Len: 8 Enqueue: 0
-ID: 32 Len: 48 Enqueue: 717
+ID: 32 Len: 48 Enqueue: 836
 ID: 33 Len: 8 Enqueue: 0
-ID: 34 Len: 8 Enqueue: 876
-ID: 35 Len: 32 Enqueue: 929
-ID: 36 Len: 16 Enqueue: 917
+ID: 34 Len: 8 Enqueue: 660
+ID: 35 Len: 32 Enqueue: 953
+ID: 36 Len: 16 Enqueue: 812
 ID: 37 Len: 8 Enqueue: 0
-ID: 38 Len: 200 Enqueue: 767
-ID: 39 Len: 192 Enqueue: 751
-ID: 40 Len: 24 Enqueue: 735
-ID: 41 Len: 8 Enqueue: 729
+ID: 38 Len: 200 Enqueue: 903
+ID: 39 Len: 192 Enqueue: 860
+ID: 40 Len: 24 Enqueue: 914
+ID: 41 Len: 8 Enqueue: 642
 ID: 42 Len: 184 Enqueue: 0
 ID: 43 Len: 128 Enqueue: 0
 ID: 44 Len: 4 Enqueue: 0
 ID: 45 Len: 8 Enqueue: 0
-ID: 46 Len: 8 Enqueue: 778
+ID: 46 Len: 8 Enqueue: 600
 ID: 47 Len: 4 Enqueue: 0
 ID: 48 Len: 8 Enqueue: 0
-ID: 49 Len: 16 Enqueue: 784
+ID: 49 Len: 16 Enqueue: 798
 ID: 50 Len: 8 Enqueue: 0
 ID: 51 Len: 8 Enqueue: 0
 ID: 52 Len: 1 Enqueue: 0
 ID: 53 Len: 4 Enqueue: 0
-ID: 54 Len: 8 Enqueue: 786
-ID: 55 Len: 8 Enqueue: 792
-ID: 56 Len: 8 Enqueue: 798
+ID: 54 Len: 8 Enqueue: 696
+ID: 55 Len: 8 Enqueue: 630
+ID: 56 Len: 8 Enqueue: 678
 ID: 57 Len: 2 Enqueue: 0
 ID: 58 Len: 8 Enqueue: 0
 ID: 59 Len: 16 Enqueue: 0
-ID: 60 Len: 8 Enqueue: 804
-ID: 61 Len: 8 Enqueue: 810
-ID: 62 Len: 8 Enqueue: 816
-ID: 63 Len: 8 Enqueue: 822
-ID: 64 Len: 8 Enqueue: 828
-ID: 65 Len: 8 Enqueue: 834
-ID: 66 Len: 8 Enqueue: 840
+ID: 60 Len: 8 Enqueue: 618
+ID: 61 Len: 8 Enqueue: 684
+ID: 62 Len: 8 Enqueue: 636
+ID: 63 Len: 8 Enqueue: 606
+ID: 64 Len: 8 Enqueue: 612
+ID: 65 Len: 8 Enqueue: 666
+ID: 66 Len: 8 Enqueue: 672
 ID: 67 Len: 2048 Enqueue: 0
 ID: 68 Len: 8 Enqueue: 0
 ID: 69 Len: 2048 Enqueue: 0
 ID: 70 Len: 8 Enqueue: 0
-ID: 71 Len: 2048 Enqueue: 846
+ID: 71 Len: 2048 Enqueue: 786
 ID: 72 Len: 8 Enqueue: 0
-ID: 73 Len: 8192 Enqueue: 864
-ID: 74 Len: 2048 Enqueue: 940
-ID: 75 Len: 8192 Enqueue: 882
-ID: 76 Len: 2048 Enqueue: 952
+ID: 73 Len: 8192 Enqueue: 718
+ID: 74 Len: 2048 Enqueue: 752
+ID: 75 Len: 8192 Enqueue: 730
+ID: 76 Len: 2048 Enqueue: 764
 ID: 77 Len: 9 Enqueue: 0
 ID: 78 Len: 17 Enqueue: 0
 ID: 79 Len: 25 Enqueue: 0

--- a/pkg/dyninst/compiler/testdata/snapshot/simple.arch=arm64,toolchain=go1.25.0.sm.txt
+++ b/pkg/dyninst/compiler/testdata/snapshot/simple.arch=arm64,toolchain=go1.25.0.sm.txt
@@ -138,7 +138,7 @@
 	ProcessPointer 31 00 00 00 
 	Return 
 // 0x246: ProcessType[****int]
-	ProcessPointer 35 00 00 00 
+	ProcessPointer 4b 00 00 00 
 	Return 
 // 0x24c: ProcessType[***int]
 	ProcessPointer 32 00 00 00 
@@ -168,16 +168,16 @@
 	ProcessPointer 0d 00 00 00 
 	Return 
 // 0x282: ProcessType[*main.bigStruct]
-	ProcessPointer 49 00 00 00 
+	ProcessPointer 48 00 00 00 
 	Return 
 // 0x288: ProcessType[*string]
 	ProcessPointer 09 00 00 00 
 	Return 
 // 0x28e: ProcessType[*table<string,int>]
-	ProcessPointer 33 00 00 00 
+	ProcessPointer 39 00 00 00 
 	Return 
 // 0x294: ProcessType[*table<string,main.bigStruct>]
-	ProcessPointer 34 00 00 00 
+	ProcessPointer 41 00 00 00 
 	Return 
 // 0x29a: ProcessType[*uint]
 	ProcessPointer 0a 00 00 00 
@@ -213,7 +213,7 @@
 	ProcessSliceDataRepeat 08 00 00 00 
 	Return 
 // 0x2e6: ProcessType[[]int]
-	ProcessSlice 38 00 00 00 08 00 00 00 
+	ProcessSlice 35 00 00 00 08 00 00 00 
 	Return 
 // 0x2f0: ProcessType[[]noalg.map.group[string]int.array]
 	ProcessSliceDataPrep 
@@ -226,7 +226,7 @@
 	ProcessSliceDataRepeat 00 00 00 00 
 	Return 
 // 0x308: ProcessType[[]string]
-	ProcessSlice 3a 00 00 00 10 00 00 00 
+	ProcessSlice 37 00 00 00 10 00 00 00 
 	Return 
 // 0x312: ProcessType[[]string.array]
 	ProcessSliceDataPrep 
@@ -237,16 +237,16 @@
 	ProcessGoInterface 
 	Return 
 // 0x320: ProcessType[groupReference<string,int>]
-	ProcessGoSwissMapGroups 42 00 00 00 c8 00 00 00 00 08 
+	ProcessGoSwissMapGroups 40 00 00 00 c8 00 00 00 00 08 
 	Return 
 // 0x32c: ProcessType[groupReference<string,main.bigStruct>]
-	ProcessGoSwissMapGroups 4b 00 00 00 c8 00 00 00 00 08 
+	ProcessGoSwissMapGroups 4a 00 00 00 c8 00 00 00 00 08 
 	Return 
 // 0x338: ProcessType[map<string,int>]
-	ProcessGoSwissMap 41 00 00 00 3e 00 00 00 10 18 
+	ProcessGoSwissMap 3f 00 00 00 3c 00 00 00 10 18 
 	Return 
 // 0x344: ProcessType[map<string,main.bigStruct>]
-	ProcessGoSwissMap 4a 00 00 00 45 00 00 00 10 18 
+	ProcessGoSwissMap 49 00 00 00 44 00 00 00 10 18 
 	Return 
 // 0x350: ProcessType[map[string]int]
 	ProcessPointer 28 00 00 00 
@@ -281,7 +281,7 @@
 	Call a8 03 00 00 // ProcessType[string]
 	Return 
 // 0x3a8: ProcessType[string]
-	ProcessString 36 00 00 00 
+	ProcessString 33 00 00 00 
 	Return 
 // 0x3ae: ProcessType[table<string,int>]
 	IncrementOutputOffset 10 00 00 00 
@@ -356,31 +356,31 @@ ID: 47 Len: 8 Enqueue: 660
 ID: 48 Len: 8 Enqueue: 576
 ID: 49 Len: 8 Enqueue: 582
 ID: 50 Len: 8 Enqueue: 594
-ID: 51 Len: 32 Enqueue: 942
-ID: 52 Len: 32 Enqueue: 953
-ID: 53 Len: 8 Enqueue: 588
-ID: 54 Len: 2048 Enqueue: 0
-ID: 55 Len: 8 Enqueue: 0
-ID: 56 Len: 2048 Enqueue: 0
-ID: 57 Len: 8 Enqueue: 0
-ID: 58 Len: 2048 Enqueue: 786
+ID: 51 Len: 2048 Enqueue: 0
+ID: 52 Len: 8 Enqueue: 0
+ID: 53 Len: 2048 Enqueue: 0
+ID: 54 Len: 8 Enqueue: 0
+ID: 55 Len: 2048 Enqueue: 786
+ID: 56 Len: 8 Enqueue: 0
+ID: 57 Len: 32 Enqueue: 942
+ID: 58 Len: 16 Enqueue: 800
 ID: 59 Len: 8 Enqueue: 0
-ID: 60 Len: 16 Enqueue: 800
-ID: 61 Len: 8 Enqueue: 0
-ID: 62 Len: 200 Enqueue: 892
-ID: 63 Len: 192 Enqueue: 876
-ID: 64 Len: 24 Enqueue: 930
-ID: 65 Len: 8192 Enqueue: 718
-ID: 66 Len: 2048 Enqueue: 752
-ID: 67 Len: 16 Enqueue: 812
-ID: 68 Len: 8 Enqueue: 0
-ID: 69 Len: 200 Enqueue: 903
-ID: 70 Len: 192 Enqueue: 860
-ID: 71 Len: 24 Enqueue: 914
-ID: 72 Len: 8 Enqueue: 642
-ID: 73 Len: 184 Enqueue: 0
-ID: 74 Len: 8192 Enqueue: 730
-ID: 75 Len: 2048 Enqueue: 764
+ID: 60 Len: 200 Enqueue: 892
+ID: 61 Len: 192 Enqueue: 876
+ID: 62 Len: 24 Enqueue: 930
+ID: 63 Len: 8192 Enqueue: 718
+ID: 64 Len: 2048 Enqueue: 752
+ID: 65 Len: 32 Enqueue: 953
+ID: 66 Len: 16 Enqueue: 812
+ID: 67 Len: 8 Enqueue: 0
+ID: 68 Len: 200 Enqueue: 903
+ID: 69 Len: 192 Enqueue: 860
+ID: 70 Len: 24 Enqueue: 914
+ID: 71 Len: 8 Enqueue: 642
+ID: 72 Len: 184 Enqueue: 0
+ID: 73 Len: 8192 Enqueue: 730
+ID: 74 Len: 2048 Enqueue: 764
+ID: 75 Len: 8 Enqueue: 588
 ID: 76 Len: 128 Enqueue: 0
 ID: 77 Len: 9 Enqueue: 0
 ID: 78 Len: 17 Enqueue: 0

--- a/pkg/dyninst/compiler/testdata/snapshot/simple.arch=arm64,toolchain=go1.25.0.sm.txt
+++ b/pkg/dyninst/compiler/testdata/snapshot/simple.arch=arm64,toolchain=go1.25.0.sm.txt
@@ -135,67 +135,67 @@
 	Call 08 02 00 00 // ProcessExpression[Probe[main.stringSliceArg]@0xb7fbc.expr[0]]
 	Return 
 // 0x240: ProcessType[*****int]
-	ProcessPointer 03 00 00 00 
+	ProcessPointer 40 00 00 00 
 	Return 
 // 0x246: ProcessType[****int]
-	ProcessPointer 04 00 00 00 
+	ProcessPointer 41 00 00 00 
 	Return 
 // 0x24c: ProcessType[***int]
-	ProcessPointer 05 00 00 00 
+	ProcessPointer 42 00 00 00 
 	Return 
 // 0x252: ProcessType[**int]
-	ProcessPointer 06 00 00 00 
+	ProcessPointer 1b 00 00 00 
 	Return 
 // 0x258: ProcessType[*bool]
-	ProcessPointer 1d 00 00 00 
+	ProcessPointer 04 00 00 00 
 	Return 
 // 0x25e: ProcessType[*error]
-	ProcessPointer 31 00 00 00 
+	ProcessPointer 0e 00 00 00 
 	Return 
 // 0x264: ProcessType[*float32]
-	ProcessPointer 35 00 00 00 
-	Return 
-// 0x26a: ProcessType[*float64]
-	ProcessPointer 33 00 00 00 
-	Return 
-// 0x270: ProcessType[*int]
-	ProcessPointer 01 00 00 00 
-	Return 
-// 0x276: ProcessType[*int32]
-	ProcessPointer 2f 00 00 00 
-	Return 
-// 0x27c: ProcessType[*int64]
-	ProcessPointer 30 00 00 00 
-	Return 
-// 0x282: ProcessType[*main.bigStruct]
-	ProcessPointer 2a 00 00 00 
-	Return 
-// 0x288: ProcessType[*string]
-	ProcessPointer 07 00 00 00 
-	Return 
-// 0x28e: ProcessType[*table<string,int>]
-	ProcessPointer 16 00 00 00 
-	Return 
-// 0x294: ProcessType[*table<string,main.bigStruct>]
-	ProcessPointer 23 00 00 00 
-	Return 
-// 0x29a: ProcessType[*uint]
-	ProcessPointer 2d 00 00 00 
-	Return 
-// 0x2a0: ProcessType[*uint16]
-	ProcessPointer 17 00 00 00 
-	Return 
-// 0x2a6: ProcessType[*uint32]
-	ProcessPointer 2c 00 00 00 
-	Return 
-// 0x2ac: ProcessType[*uint64]
 	ProcessPointer 12 00 00 00 
 	Return 
-// 0x2b2: ProcessType[*uint8]
+// 0x26a: ProcessType[*float64]
+	ProcessPointer 10 00 00 00 
+	Return 
+// 0x270: ProcessType[*int]
+	ProcessPointer 07 00 00 00 
+	Return 
+// 0x276: ProcessType[*int32]
+	ProcessPointer 0c 00 00 00 
+	Return 
+// 0x27c: ProcessType[*int64]
+	ProcessPointer 0d 00 00 00 
+	Return 
+// 0x282: ProcessType[*main.bigStruct]
+	ProcessPointer 3d 00 00 00 
+	Return 
+// 0x288: ProcessType[*string]
 	ProcessPointer 09 00 00 00 
 	Return 
+// 0x28e: ProcessType[*table<string,int>]
+	ProcessPointer 2b 00 00 00 
+	Return 
+// 0x294: ProcessType[*table<string,main.bigStruct>]
+	ProcessPointer 36 00 00 00 
+	Return 
+// 0x29a: ProcessType[*uint]
+	ProcessPointer 0a 00 00 00 
+	Return 
+// 0x2a0: ProcessType[*uint16]
+	ProcessPointer 06 00 00 00 
+	Return 
+// 0x2a6: ProcessType[*uint32]
+	ProcessPointer 02 00 00 00 
+	Return 
+// 0x2ac: ProcessType[*uint64]
+	ProcessPointer 08 00 00 00 
+	Return 
+// 0x2b2: ProcessType[*uint8]
+	ProcessPointer 03 00 00 00 
+	Return 
 // 0x2b8: ProcessType[*uintptr]
-	ProcessPointer 13 00 00 00 
+	ProcessPointer 01 00 00 00 
 	Return 
 // 0x2be: ProcessType[[3]string]
 	ProcessArrayDataPrep 30 00 00 00 
@@ -243,16 +243,16 @@
 	ProcessGoSwissMapGroups 4c 00 00 00 c8 00 00 00 00 08 
 	Return 
 // 0x338: ProcessType[map<string,int>]
-	ProcessGoSwissMap 49 00 00 00 1a 00 00 00 10 18 
+	ProcessGoSwissMap 49 00 00 00 2e 00 00 00 10 18 
 	Return 
 // 0x344: ProcessType[map<string,main.bigStruct>]
-	ProcessGoSwissMap 4b 00 00 00 26 00 00 00 10 18 
+	ProcessGoSwissMap 4b 00 00 00 39 00 00 00 10 18 
 	Return 
 // 0x350: ProcessType[map[string]int]
-	ProcessPointer 11 00 00 00 
+	ProcessPointer 28 00 00 00 
 	Return 
 // 0x356: ProcessType[map[string]main.bigStruct]
-	ProcessPointer 20 00 00 00 
+	ProcessPointer 33 00 00 00 
 	Return 
 // 0x35c: ProcessType[noalg.[8]struct { key string; elem *main.bigStruct }]
 	ProcessArrayDataPrep c0 00 00 00 
@@ -307,71 +307,71 @@
 	Illegal 
 // Types
 ID: 1 Len: 8 Enqueue: 0
-ID: 2 Len: 8 Enqueue: 576
-ID: 3 Len: 8 Enqueue: 582
-ID: 4 Len: 8 Enqueue: 588
-ID: 5 Len: 8 Enqueue: 594
-ID: 6 Len: 8 Enqueue: 624
-ID: 7 Len: 16 Enqueue: 936
-ID: 8 Len: 8 Enqueue: 690
-ID: 9 Len: 1 Enqueue: 0
-ID: 10 Len: 24 Enqueue: 742
-ID: 11 Len: 24 Enqueue: 0
-ID: 12 Len: 24 Enqueue: 776
-ID: 13 Len: 8 Enqueue: 648
-ID: 14 Len: 48 Enqueue: 702
-ID: 15 Len: 8 Enqueue: 848
+ID: 2 Len: 4 Enqueue: 0
+ID: 3 Len: 1 Enqueue: 0
+ID: 4 Len: 1 Enqueue: 0
+ID: 5 Len: 8 Enqueue: 690
+ID: 6 Len: 2 Enqueue: 0
+ID: 7 Len: 8 Enqueue: 0
+ID: 8 Len: 8 Enqueue: 0
+ID: 9 Len: 16 Enqueue: 936
+ID: 10 Len: 8 Enqueue: 0
+ID: 11 Len: 8 Enqueue: 600
+ID: 12 Len: 4 Enqueue: 0
+ID: 13 Len: 8 Enqueue: 0
+ID: 14 Len: 16 Enqueue: 798
+ID: 15 Len: 8 Enqueue: 0
 ID: 16 Len: 8 Enqueue: 0
-ID: 17 Len: 48 Enqueue: 824
-ID: 18 Len: 8 Enqueue: 0
-ID: 19 Len: 8 Enqueue: 0
-ID: 20 Len: 8 Enqueue: 0
-ID: 21 Len: 8 Enqueue: 654
-ID: 22 Len: 32 Enqueue: 942
+ID: 17 Len: 1 Enqueue: 0
+ID: 18 Len: 4 Enqueue: 0
+ID: 19 Len: 8 Enqueue: 696
+ID: 20 Len: 8 Enqueue: 630
+ID: 21 Len: 8 Enqueue: 678
+ID: 22 Len: 8 Enqueue: 648
 ID: 23 Len: 2 Enqueue: 0
-ID: 24 Len: 16 Enqueue: 800
-ID: 25 Len: 8 Enqueue: 0
-ID: 26 Len: 200 Enqueue: 892
-ID: 27 Len: 192 Enqueue: 876
-ID: 28 Len: 24 Enqueue: 930
-ID: 29 Len: 1 Enqueue: 0
-ID: 30 Len: 8 Enqueue: 854
-ID: 31 Len: 8 Enqueue: 0
-ID: 32 Len: 48 Enqueue: 836
-ID: 33 Len: 8 Enqueue: 0
-ID: 34 Len: 8 Enqueue: 660
-ID: 35 Len: 32 Enqueue: 953
-ID: 36 Len: 16 Enqueue: 812
-ID: 37 Len: 8 Enqueue: 0
-ID: 38 Len: 200 Enqueue: 903
-ID: 39 Len: 192 Enqueue: 860
-ID: 40 Len: 24 Enqueue: 914
-ID: 41 Len: 8 Enqueue: 642
-ID: 42 Len: 184 Enqueue: 0
-ID: 43 Len: 128 Enqueue: 0
-ID: 44 Len: 4 Enqueue: 0
+ID: 24 Len: 8 Enqueue: 0
+ID: 25 Len: 16 Enqueue: 0
+ID: 26 Len: 8 Enqueue: 618
+ID: 27 Len: 8 Enqueue: 624
+ID: 28 Len: 8 Enqueue: 684
+ID: 29 Len: 8 Enqueue: 636
+ID: 30 Len: 8 Enqueue: 606
+ID: 31 Len: 8 Enqueue: 612
+ID: 32 Len: 8 Enqueue: 666
+ID: 33 Len: 8 Enqueue: 672
+ID: 34 Len: 24 Enqueue: 742
+ID: 35 Len: 24 Enqueue: 0
+ID: 36 Len: 24 Enqueue: 776
+ID: 37 Len: 48 Enqueue: 702
+ID: 38 Len: 8 Enqueue: 848
+ID: 39 Len: 8 Enqueue: 0
+ID: 40 Len: 48 Enqueue: 824
+ID: 41 Len: 8 Enqueue: 0
+ID: 42 Len: 8 Enqueue: 654
+ID: 43 Len: 32 Enqueue: 942
+ID: 44 Len: 16 Enqueue: 800
 ID: 45 Len: 8 Enqueue: 0
-ID: 46 Len: 8 Enqueue: 600
-ID: 47 Len: 4 Enqueue: 0
-ID: 48 Len: 8 Enqueue: 0
-ID: 49 Len: 16 Enqueue: 798
+ID: 46 Len: 200 Enqueue: 892
+ID: 47 Len: 192 Enqueue: 876
+ID: 48 Len: 24 Enqueue: 930
+ID: 49 Len: 8 Enqueue: 854
 ID: 50 Len: 8 Enqueue: 0
-ID: 51 Len: 8 Enqueue: 0
-ID: 52 Len: 1 Enqueue: 0
-ID: 53 Len: 4 Enqueue: 0
-ID: 54 Len: 8 Enqueue: 696
-ID: 55 Len: 8 Enqueue: 630
-ID: 56 Len: 8 Enqueue: 678
-ID: 57 Len: 2 Enqueue: 0
-ID: 58 Len: 8 Enqueue: 0
-ID: 59 Len: 16 Enqueue: 0
-ID: 60 Len: 8 Enqueue: 618
-ID: 61 Len: 8 Enqueue: 684
-ID: 62 Len: 8 Enqueue: 636
-ID: 63 Len: 8 Enqueue: 606
-ID: 64 Len: 8 Enqueue: 612
-ID: 65 Len: 8 Enqueue: 666
-ID: 66 Len: 8 Enqueue: 672
+ID: 51 Len: 48 Enqueue: 836
+ID: 52 Len: 8 Enqueue: 0
+ID: 53 Len: 8 Enqueue: 660
+ID: 54 Len: 32 Enqueue: 953
+ID: 55 Len: 16 Enqueue: 812
+ID: 56 Len: 8 Enqueue: 0
+ID: 57 Len: 200 Enqueue: 903
+ID: 58 Len: 192 Enqueue: 860
+ID: 59 Len: 24 Enqueue: 914
+ID: 60 Len: 8 Enqueue: 642
+ID: 61 Len: 184 Enqueue: 0
+ID: 62 Len: 128 Enqueue: 0
+ID: 63 Len: 8 Enqueue: 576
+ID: 64 Len: 8 Enqueue: 582
+ID: 65 Len: 8 Enqueue: 588
+ID: 66 Len: 8 Enqueue: 594
 ID: 67 Len: 2048 Enqueue: 0
 ID: 68 Len: 8 Enqueue: 0
 ID: 69 Len: 2048 Enqueue: 0

--- a/pkg/dyninst/gotype/testdata/snapshot/sample.arch=amd64,toolchain=go1.23.11.yaml
+++ b/pkg/dyninst/gotype/testdata/snapshot/sample.arch=amd64,toolchain=go1.23.11.yaml
@@ -1,4 +1,4 @@
-- offset: "0x000c81a0"
+- offset: "0x000c9500"
   size: 8
   kind: ptr
   nameEntry: "*lib_v2.V2Type (exported)"
@@ -9,16 +9,16 @@
     type: func()
   pointer:
     elem: lib_v2.V2Type
-- offset: "0x000e5b00"
+- offset: "0x000e71c0"
   size: 0
   kind: struct
   nameEntry: lib_v2.V2Type (exported)
   name: lib_v2.V2Type
   pkg: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.v2
-  ptrToThis: "0x000c81a0"
+  ptrToThis: "0x000c9500"
   struct:
     fields: []
-- offset: "0x000c7e40"
+- offset: "0x000c91a0"
   size: 8
   kind: ptr
   nameEntry: "*main.firstBehavior"
@@ -29,7 +29,7 @@
     type: func() string
   pointer:
     elem: main.firstBehavior
-- offset: "0x000c7ea0"
+- offset: "0x000c9200"
   size: 8
   kind: ptr
   nameEntry: "*main.secondBehavior"
@@ -40,7 +40,7 @@
     type: func() string
   pointer:
     elem: main.secondBehavior
-- offset: "0x000c7f00"
+- offset: "0x000c9260"
   size: 8
   kind: ptr
   nameEntry: "*main.somethingImpl"
@@ -51,7 +51,7 @@
     type: func()
   pointer:
     elem: main.somethingImpl
-- offset: "0x000d5220"
+- offset: "0x000d6580"
   size: 8
   kind: ptr
   nameEntry: "*main.typeWithGenerics[int]"
@@ -62,7 +62,7 @@
     type: func(int) bool
   pointer:
     elem: main.typeWithGenerics[int]
-- offset: "0x000d5280"
+- offset: "0x000d65e0"
   size: 8
   kind: ptr
   nameEntry: "*main.typeWithGenerics[string]"
@@ -73,23 +73,347 @@
     type: func(string) bool
   pointer:
     elem: main.typeWithGenerics[string]
-- offset: "0x000eda40"
+- offset: "0x000ef100"
   size: 16
   kind: interface
   nameEntry: main.behavior
   name: main.behavior
   pkg: main
-  ptrToThis: "0x00056660"
+  ptrToThis: "0x00056c00"
   interfaceMethods:
   - name: DoSomething (exported)
     type: func() string
-- offset: "0x0019d300"
+- offset: "0x0010c6a0"
+  size: 8
+  kind: struct
+  nameEntry: main.deepMap1
+  name: main.deepMap1
+  pkg: main
+  ptrToThis: "0x00056f00"
+  struct:
+    fields:
+    - name: a
+      type: map[int]*main.deepMap2
+      offset: 0
+- offset: "0x0010c620"
+  size: 8
+  kind: struct
+  nameEntry: main.deepMap2
+  name: main.deepMap2
+  pkg: main
+  ptrToThis: "0x00056ec0"
+  struct:
+    fields:
+    - name: a
+      type: map[int]*main.deepMap3
+      offset: 0
+- offset: "0x0010c5a0"
+  size: 8
+  kind: struct
+  nameEntry: main.deepMap3
+  name: main.deepMap3
+  pkg: main
+  ptrToThis: "0x00056e80"
+  struct:
+    fields:
+    - name: a
+      type: map[int]*main.deepMap4
+      offset: 0
+- offset: "0x0010c520"
+  size: 8
+  kind: struct
+  nameEntry: main.deepMap4
+  name: main.deepMap4
+  pkg: main
+  ptrToThis: "0x00056e40"
+  struct:
+    fields:
+    - name: a
+      type: map[int]*main.deepMap5
+      offset: 0
+- offset: "0x0010c4a0"
+  size: 8
+  kind: struct
+  nameEntry: main.deepMap5
+  name: main.deepMap5
+  pkg: main
+  ptrToThis: "0x00056e00"
+  struct:
+    fields:
+    - name: a
+      type: map[int]*main.deepMap6
+      offset: 0
+- offset: "0x0010c420"
+  size: 8
+  kind: struct
+  nameEntry: main.deepMap6
+  name: main.deepMap6
+  pkg: main
+  ptrToThis: "0x00056dc0"
+  struct:
+    fields:
+    - name: a
+      type: map[int]*main.deepMap7
+      offset: 0
+- offset: "0x0010c3a0"
+  size: 8
+  kind: struct
+  nameEntry: main.deepMap7
+  name: main.deepMap7
+  pkg: main
+  ptrToThis: "0x00056d80"
+  struct:
+    fields:
+    - name: a
+      type: map[int]*main.deepMap8
+      offset: 0
+- offset: "0x0010c320"
+  size: 8
+  kind: struct
+  nameEntry: main.deepMap8
+  name: main.deepMap8
+  pkg: main
+  ptrToThis: "0x00056d40"
+  struct:
+    fields:
+    - name: a
+      type: map[int]*main.deepMap9
+      offset: 0
+- offset: "0x0010c2a0"
+  size: 8
+  kind: struct
+  nameEntry: main.deepMap9
+  name: main.deepMap9
+  pkg: main
+  ptrToThis: "0x00056d00"
+  struct:
+    fields:
+    - name: a
+      type: map[int]interface {}
+      offset: 0
+- offset: "0x0010cb20"
+  size: 8
+  kind: struct
+  nameEntry: main.deepPtr1
+  name: main.deepPtr1
+  pkg: main
+  ptrToThis: "0x00057140"
+  struct:
+    fields:
+    - name: a
+      type: "*main.deepPtr2"
+      offset: 0
+- offset: "0x0010caa0"
+  size: 8
+  kind: struct
+  nameEntry: main.deepPtr2
+  name: main.deepPtr2
+  pkg: main
+  ptrToThis: "0x00057100"
+  struct:
+    fields:
+    - name: a
+      type: "*main.deepPtr3"
+      offset: 0
+- offset: "0x0010ca20"
+  size: 8
+  kind: struct
+  nameEntry: main.deepPtr3
+  name: main.deepPtr3
+  pkg: main
+  ptrToThis: "0x000570c0"
+  struct:
+    fields:
+    - name: a
+      type: "*main.deepPtr4"
+      offset: 0
+- offset: "0x0010c9a0"
+  size: 8
+  kind: struct
+  nameEntry: main.deepPtr4
+  name: main.deepPtr4
+  pkg: main
+  ptrToThis: "0x00057080"
+  struct:
+    fields:
+    - name: a
+      type: "*main.deepPtr5"
+      offset: 0
+- offset: "0x0010c920"
+  size: 8
+  kind: struct
+  nameEntry: main.deepPtr5
+  name: main.deepPtr5
+  pkg: main
+  ptrToThis: "0x00057040"
+  struct:
+    fields:
+    - name: a
+      type: "*main.deepPtr6"
+      offset: 0
+- offset: "0x0010c8a0"
+  size: 8
+  kind: struct
+  nameEntry: main.deepPtr6
+  name: main.deepPtr6
+  pkg: main
+  ptrToThis: "0x00057000"
+  struct:
+    fields:
+    - name: a
+      type: "*main.deepPtr7"
+      offset: 0
+- offset: "0x0010c820"
+  size: 8
+  kind: struct
+  nameEntry: main.deepPtr7
+  name: main.deepPtr7
+  pkg: main
+  ptrToThis: "0x00056fc0"
+  struct:
+    fields:
+    - name: a
+      type: "*main.deepPtr8"
+      offset: 0
+- offset: "0x0010c7a0"
+  size: 8
+  kind: struct
+  nameEntry: main.deepPtr8
+  name: main.deepPtr8
+  pkg: main
+  ptrToThis: "0x00056f80"
+  struct:
+    fields:
+    - name: a
+      type: "*main.deepPtr9"
+      offset: 0
+- offset: "0x0010c720"
+  size: 16
+  kind: struct
+  nameEntry: main.deepPtr9
+  name: main.deepPtr9
+  pkg: main
+  ptrToThis: "0x00056f40"
+  struct:
+    fields:
+    - name: a
+      type: interface {}
+      offset: 0
+- offset: "0x0010cfa0"
+  size: 24
+  kind: struct
+  nameEntry: main.deepSlice1
+  name: main.deepSlice1
+  pkg: main
+  ptrToThis: "0x00057380"
+  struct:
+    fields:
+    - name: a
+      type: "[]*main.deepSlice2"
+      offset: 0
+- offset: "0x0010cf20"
+  size: 24
+  kind: struct
+  nameEntry: main.deepSlice2
+  name: main.deepSlice2
+  pkg: main
+  ptrToThis: "0x00057340"
+  struct:
+    fields:
+    - name: a
+      type: "[]*main.deepSlice3"
+      offset: 0
+- offset: "0x0010cea0"
+  size: 24
+  kind: struct
+  nameEntry: main.deepSlice3
+  name: main.deepSlice3
+  pkg: main
+  ptrToThis: "0x00057300"
+  struct:
+    fields:
+    - name: a
+      type: "[]*main.deepSlice4"
+      offset: 0
+- offset: "0x0010ce20"
+  size: 24
+  kind: struct
+  nameEntry: main.deepSlice4
+  name: main.deepSlice4
+  pkg: main
+  ptrToThis: "0x000572c0"
+  struct:
+    fields:
+    - name: a
+      type: "[]*main.deepSlice5"
+      offset: 0
+- offset: "0x0010cda0"
+  size: 24
+  kind: struct
+  nameEntry: main.deepSlice5
+  name: main.deepSlice5
+  pkg: main
+  ptrToThis: "0x00057280"
+  struct:
+    fields:
+    - name: a
+      type: "[]*main.deepSlice6"
+      offset: 0
+- offset: "0x0010cd20"
+  size: 24
+  kind: struct
+  nameEntry: main.deepSlice6
+  name: main.deepSlice6
+  pkg: main
+  ptrToThis: "0x00057240"
+  struct:
+    fields:
+    - name: a
+      type: "[]*main.deepSlice7"
+      offset: 0
+- offset: "0x0010cca0"
+  size: 24
+  kind: struct
+  nameEntry: main.deepSlice7
+  name: main.deepSlice7
+  pkg: main
+  ptrToThis: "0x00057200"
+  struct:
+    fields:
+    - name: a
+      type: "[]*main.deepSlice8"
+      offset: 0
+- offset: "0x0010cc20"
+  size: 24
+  kind: struct
+  nameEntry: main.deepSlice8
+  name: main.deepSlice8
+  pkg: main
+  ptrToThis: "0x000571c0"
+  struct:
+    fields:
+    - name: a
+      type: "[]*main.deepSlice9"
+      offset: 0
+- offset: "0x0010cba0"
+  size: 24
+  kind: struct
+  nameEntry: main.deepSlice9
+  name: main.deepSlice9
+  pkg: main
+  ptrToThis: "0x00057180"
+  struct:
+    fields:
+    - name: a
+      type: "[]interface {}"
+      offset: 0
+- offset: "0x0019fe00"
   size: 112
   kind: struct
   nameEntry: main.esotericHeap
   name: main.esotericHeap
   pkg: main
-  ptrToThis: "0x00056760"
+  ptrToThis: "0x000573c0"
   struct:
     fields:
     - name: esotericStack (embedded)
@@ -107,13 +431,13 @@
     - name: a
       type: atomic.Int32
       offset: 104
-- offset: "0x001bc100"
+- offset: "0x001bec00"
   size: 64
   kind: struct
   nameEntry: main.esotericStack
   name: main.esotericStack
   pkg: main
-  ptrToThis: "0x000566e0"
+  ptrToThis: "0x00056c80"
   struct:
     fields:
     - name: _
@@ -137,13 +461,13 @@
     - name: foo
       type: func()
       offset: 56
-- offset: "0x0012a3c0"
+- offset: "0x0012c800"
   size: 16
   kind: struct
   nameEntry: main.firstBehavior
   name: main.firstBehavior
   pkg: main
-  ptrToThis: "0x000c7e40"
+  ptrToThis: "0x000c91a0"
   methods:
   - name: DoSomething (exported)
     type: func() string
@@ -152,13 +476,13 @@
     - name: s
       type: string
       offset: 0
-- offset: "0x00136100"
+- offset: "0x00138540"
   size: 24
   kind: struct
   nameEntry: main.nestedStruct
   name: main.nestedStruct
   pkg: main
-  ptrToThis: "0x000567e0"
+  ptrToThis: "0x00057440"
   struct:
     fields:
     - name: anotherInt
@@ -167,13 +491,13 @@
     - name: anotherString
       type: string
       offset: 8
-- offset: "0x00136060"
+- offset: "0x001384a0"
   size: 16
   kind: struct
   nameEntry: main.node
   name: main.node
   pkg: main
-  ptrToThis: "0x000567a0"
+  ptrToThis: "0x00057400"
   struct:
     fields:
     - name: val
@@ -182,13 +506,13 @@
     - name: b
       type: "*main.node"
       offset: 8
-- offset: "0x0012a460"
+- offset: "0x0012c8a0"
   size: 8
   kind: struct
   nameEntry: main.secondBehavior
   name: main.secondBehavior
   pkg: main
-  ptrToThis: "0x000c7ea0"
+  ptrToThis: "0x000c9200"
   methods:
   - name: DoSomething (exported)
     type: func() string
@@ -197,44 +521,44 @@
     - name: i
       type: int
       offset: 0
-- offset: "0x000edac0"
+- offset: "0x000ef180"
   size: 16
   kind: interface
   nameEntry: main.something
   name: main.something
   pkg: main
-  ptrToThis: "0x000566a0"
+  ptrToThis: "0x00056c40"
   interfaceMethods:
   - name: Do (exported)
     type: func()
-- offset: "0x000e5980"
+- offset: "0x000e7040"
   size: 0
   kind: struct
   nameEntry: main.somethingImpl
   name: main.somethingImpl
   pkg: main
-  ptrToThis: "0x000c7f00"
+  ptrToThis: "0x000c9260"
   struct:
     fields: []
-- offset: "0x0010ab60"
+- offset: "0x0010c220"
   size: 8
   kind: struct
   nameEntry: main.structWithMap
   name: main.structWithMap
   pkg: main
-  ptrToThis: "0x00056720"
+  ptrToThis: "0x00056cc0"
   struct:
     fields:
     - name: m
       type: map[int]int
       offset: 0
-- offset: "0x00133380"
+- offset: "0x001357c0"
   size: 8
   kind: struct
   nameEntry: main.typeWithGenerics[int]
   name: main.typeWithGenerics[int]
   pkg: main
-  ptrToThis: "0x000d5220"
+  ptrToThis: "0x000d6580"
   methods:
   - name: Guess (exported)
     type: func(int) bool
@@ -243,13 +567,13 @@
     - name: Value (exported)
       type: int
       offset: 0
-- offset: "0x00133420"
+- offset: "0x00135860"
   size: 16
   kind: struct
   nameEntry: main.typeWithGenerics[string]
   name: main.typeWithGenerics[string]
   pkg: main
-  ptrToThis: "0x000d5280"
+  ptrToThis: "0x000d65e0"
   methods:
   - name: Guess (exported)
     type: func(string) bool

--- a/pkg/dyninst/gotype/testdata/snapshot/sample.arch=amd64,toolchain=go1.24.3.yaml
+++ b/pkg/dyninst/gotype/testdata/snapshot/sample.arch=amd64,toolchain=go1.24.3.yaml
@@ -1,4 +1,4 @@
-- offset: "0x000d8740"
+- offset: "0x000d9ea0"
   size: 8
   kind: ptr
   nameEntry: "*lib_v2.V2Type (exported)"
@@ -9,16 +9,16 @@
     type: func()
   pointer:
     elem: lib_v2.V2Type
-- offset: "0x000eec60"
+- offset: "0x000f03c0"
   size: 0
   kind: struct
   nameEntry: lib_v2.V2Type (exported)
   name: lib_v2.V2Type
   pkg: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.v2
-  ptrToThis: "0x000d8740"
+  ptrToThis: "0x000d9ea0"
   struct:
     fields: []
-- offset: "0x000d83e0"
+- offset: "0x000d9b40"
   size: 8
   kind: ptr
   nameEntry: "*main.firstBehavior"
@@ -29,7 +29,7 @@
     type: func() string
   pointer:
     elem: main.firstBehavior
-- offset: "0x000d8440"
+- offset: "0x000d9ba0"
   size: 8
   kind: ptr
   nameEntry: "*main.secondBehavior"
@@ -40,7 +40,7 @@
     type: func() string
   pointer:
     elem: main.secondBehavior
-- offset: "0x000d84a0"
+- offset: "0x000d9c00"
   size: 8
   kind: ptr
   nameEntry: "*main.somethingImpl"
@@ -51,7 +51,7 @@
     type: func()
   pointer:
     elem: main.somethingImpl
-- offset: "0x000e5be0"
+- offset: "0x000e7340"
   size: 8
   kind: ptr
   nameEntry: "*main.typeWithGenerics[int]"
@@ -62,7 +62,7 @@
     type: func(int) bool
   pointer:
     elem: main.typeWithGenerics[int]
-- offset: "0x000e5c40"
+- offset: "0x000e73a0"
   size: 8
   kind: ptr
   nameEntry: "*main.typeWithGenerics[string]"
@@ -73,23 +73,347 @@
     type: func(string) bool
   pointer:
     elem: main.typeWithGenerics[string]
-- offset: "0x000f7160"
+- offset: "0x000f88c0"
   size: 16
   kind: interface
   nameEntry: main.behavior
   name: main.behavior
   pkg: main
-  ptrToThis: "0x0005cc40"
+  ptrToThis: "0x0005d540"
   interfaceMethods:
   - name: DoSomething (exported)
     type: func() string
-- offset: "0x001ba4e0"
+- offset: "0x00120860"
+  size: 8
+  kind: struct
+  nameEntry: main.deepMap1
+  name: main.deepMap1
+  pkg: main
+  ptrToThis: "0x0005d840"
+  struct:
+    fields:
+    - name: a
+      type: map[int]*main.deepMap2
+      offset: 0
+- offset: "0x001207e0"
+  size: 8
+  kind: struct
+  nameEntry: main.deepMap2
+  name: main.deepMap2
+  pkg: main
+  ptrToThis: "0x0005d800"
+  struct:
+    fields:
+    - name: a
+      type: map[int]*main.deepMap3
+      offset: 0
+- offset: "0x00120760"
+  size: 8
+  kind: struct
+  nameEntry: main.deepMap3
+  name: main.deepMap3
+  pkg: main
+  ptrToThis: "0x0005d7c0"
+  struct:
+    fields:
+    - name: a
+      type: map[int]*main.deepMap4
+      offset: 0
+- offset: "0x001206e0"
+  size: 8
+  kind: struct
+  nameEntry: main.deepMap4
+  name: main.deepMap4
+  pkg: main
+  ptrToThis: "0x0005d780"
+  struct:
+    fields:
+    - name: a
+      type: map[int]*main.deepMap5
+      offset: 0
+- offset: "0x00120660"
+  size: 8
+  kind: struct
+  nameEntry: main.deepMap5
+  name: main.deepMap5
+  pkg: main
+  ptrToThis: "0x0005d740"
+  struct:
+    fields:
+    - name: a
+      type: map[int]*main.deepMap6
+      offset: 0
+- offset: "0x001205e0"
+  size: 8
+  kind: struct
+  nameEntry: main.deepMap6
+  name: main.deepMap6
+  pkg: main
+  ptrToThis: "0x0005d700"
+  struct:
+    fields:
+    - name: a
+      type: map[int]*main.deepMap7
+      offset: 0
+- offset: "0x00120560"
+  size: 8
+  kind: struct
+  nameEntry: main.deepMap7
+  name: main.deepMap7
+  pkg: main
+  ptrToThis: "0x0005d6c0"
+  struct:
+    fields:
+    - name: a
+      type: map[int]*main.deepMap8
+      offset: 0
+- offset: "0x001204e0"
+  size: 8
+  kind: struct
+  nameEntry: main.deepMap8
+  name: main.deepMap8
+  pkg: main
+  ptrToThis: "0x0005d680"
+  struct:
+    fields:
+    - name: a
+      type: map[int]*main.deepMap9
+      offset: 0
+- offset: "0x00120460"
+  size: 8
+  kind: struct
+  nameEntry: main.deepMap9
+  name: main.deepMap9
+  pkg: main
+  ptrToThis: "0x0005d640"
+  struct:
+    fields:
+    - name: a
+      type: map[int]interface {}
+      offset: 0
+- offset: "0x00120ce0"
+  size: 8
+  kind: struct
+  nameEntry: main.deepPtr1
+  name: main.deepPtr1
+  pkg: main
+  ptrToThis: "0x0005da80"
+  struct:
+    fields:
+    - name: a
+      type: "*main.deepPtr2"
+      offset: 0
+- offset: "0x00120c60"
+  size: 8
+  kind: struct
+  nameEntry: main.deepPtr2
+  name: main.deepPtr2
+  pkg: main
+  ptrToThis: "0x0005da40"
+  struct:
+    fields:
+    - name: a
+      type: "*main.deepPtr3"
+      offset: 0
+- offset: "0x00120be0"
+  size: 8
+  kind: struct
+  nameEntry: main.deepPtr3
+  name: main.deepPtr3
+  pkg: main
+  ptrToThis: "0x0005da00"
+  struct:
+    fields:
+    - name: a
+      type: "*main.deepPtr4"
+      offset: 0
+- offset: "0x00120b60"
+  size: 8
+  kind: struct
+  nameEntry: main.deepPtr4
+  name: main.deepPtr4
+  pkg: main
+  ptrToThis: "0x0005d9c0"
+  struct:
+    fields:
+    - name: a
+      type: "*main.deepPtr5"
+      offset: 0
+- offset: "0x00120ae0"
+  size: 8
+  kind: struct
+  nameEntry: main.deepPtr5
+  name: main.deepPtr5
+  pkg: main
+  ptrToThis: "0x0005d980"
+  struct:
+    fields:
+    - name: a
+      type: "*main.deepPtr6"
+      offset: 0
+- offset: "0x00120a60"
+  size: 8
+  kind: struct
+  nameEntry: main.deepPtr6
+  name: main.deepPtr6
+  pkg: main
+  ptrToThis: "0x0005d940"
+  struct:
+    fields:
+    - name: a
+      type: "*main.deepPtr7"
+      offset: 0
+- offset: "0x001209e0"
+  size: 8
+  kind: struct
+  nameEntry: main.deepPtr7
+  name: main.deepPtr7
+  pkg: main
+  ptrToThis: "0x0005d900"
+  struct:
+    fields:
+    - name: a
+      type: "*main.deepPtr8"
+      offset: 0
+- offset: "0x00120960"
+  size: 8
+  kind: struct
+  nameEntry: main.deepPtr8
+  name: main.deepPtr8
+  pkg: main
+  ptrToThis: "0x0005d8c0"
+  struct:
+    fields:
+    - name: a
+      type: "*main.deepPtr9"
+      offset: 0
+- offset: "0x001208e0"
+  size: 16
+  kind: struct
+  nameEntry: main.deepPtr9
+  name: main.deepPtr9
+  pkg: main
+  ptrToThis: "0x0005d880"
+  struct:
+    fields:
+    - name: a
+      type: interface {}
+      offset: 0
+- offset: "0x00121160"
+  size: 24
+  kind: struct
+  nameEntry: main.deepSlice1
+  name: main.deepSlice1
+  pkg: main
+  ptrToThis: "0x0005dcc0"
+  struct:
+    fields:
+    - name: a
+      type: "[]*main.deepSlice2"
+      offset: 0
+- offset: "0x001210e0"
+  size: 24
+  kind: struct
+  nameEntry: main.deepSlice2
+  name: main.deepSlice2
+  pkg: main
+  ptrToThis: "0x0005dc80"
+  struct:
+    fields:
+    - name: a
+      type: "[]*main.deepSlice3"
+      offset: 0
+- offset: "0x00121060"
+  size: 24
+  kind: struct
+  nameEntry: main.deepSlice3
+  name: main.deepSlice3
+  pkg: main
+  ptrToThis: "0x0005dc40"
+  struct:
+    fields:
+    - name: a
+      type: "[]*main.deepSlice4"
+      offset: 0
+- offset: "0x00120fe0"
+  size: 24
+  kind: struct
+  nameEntry: main.deepSlice4
+  name: main.deepSlice4
+  pkg: main
+  ptrToThis: "0x0005dc00"
+  struct:
+    fields:
+    - name: a
+      type: "[]*main.deepSlice5"
+      offset: 0
+- offset: "0x00120f60"
+  size: 24
+  kind: struct
+  nameEntry: main.deepSlice5
+  name: main.deepSlice5
+  pkg: main
+  ptrToThis: "0x0005dbc0"
+  struct:
+    fields:
+    - name: a
+      type: "[]*main.deepSlice6"
+      offset: 0
+- offset: "0x00120ee0"
+  size: 24
+  kind: struct
+  nameEntry: main.deepSlice6
+  name: main.deepSlice6
+  pkg: main
+  ptrToThis: "0x0005db80"
+  struct:
+    fields:
+    - name: a
+      type: "[]*main.deepSlice7"
+      offset: 0
+- offset: "0x00120e60"
+  size: 24
+  kind: struct
+  nameEntry: main.deepSlice7
+  name: main.deepSlice7
+  pkg: main
+  ptrToThis: "0x0005db40"
+  struct:
+    fields:
+    - name: a
+      type: "[]*main.deepSlice8"
+      offset: 0
+- offset: "0x00120de0"
+  size: 24
+  kind: struct
+  nameEntry: main.deepSlice8
+  name: main.deepSlice8
+  pkg: main
+  ptrToThis: "0x0005db00"
+  struct:
+    fields:
+    - name: a
+      type: "[]*main.deepSlice9"
+      offset: 0
+- offset: "0x00120d60"
+  size: 24
+  kind: struct
+  nameEntry: main.deepSlice9
+  name: main.deepSlice9
+  pkg: main
+  ptrToThis: "0x0005dac0"
+  struct:
+    fields:
+    - name: a
+      type: "[]interface {}"
+      offset: 0
+- offset: "0x001bd740"
   size: 112
   kind: struct
   nameEntry: main.esotericHeap
   name: main.esotericHeap
   pkg: main
-  ptrToThis: "0x0005cd40"
+  ptrToThis: "0x0005dd00"
   struct:
     fields:
     - name: esotericStack (embedded)
@@ -107,13 +431,13 @@
     - name: a
       type: atomic.Int32
       offset: 104
-- offset: "0x001dafa0"
+- offset: "0x001de200"
   size: 64
   kind: struct
   nameEntry: main.esotericStack
   name: main.esotericStack
   pkg: main
-  ptrToThis: "0x0005ccc0"
+  ptrToThis: "0x0005d5c0"
   struct:
     fields:
     - name: _
@@ -137,13 +461,13 @@
     - name: foo
       type: func()
       offset: 56
-- offset: "0x00154860"
+- offset: "0x00157ac0"
   size: 16
   kind: struct
   nameEntry: main.firstBehavior
   name: main.firstBehavior
   pkg: main
-  ptrToThis: "0x000d83e0"
+  ptrToThis: "0x000d9b40"
   methods:
   - name: DoSomething (exported)
     type: func() string
@@ -152,13 +476,13 @@
     - name: s
       type: string
       offset: 0
-- offset: "0x001608e0"
+- offset: "0x00163b40"
   size: 24
   kind: struct
   nameEntry: main.nestedStruct
   name: main.nestedStruct
   pkg: main
-  ptrToThis: "0x0005cdc0"
+  ptrToThis: "0x0005dd80"
   struct:
     fields:
     - name: anotherInt
@@ -167,13 +491,13 @@
     - name: anotherString
       type: string
       offset: 8
-- offset: "0x00160840"
+- offset: "0x00163aa0"
   size: 16
   kind: struct
   nameEntry: main.node
   name: main.node
   pkg: main
-  ptrToThis: "0x0005cd80"
+  ptrToThis: "0x0005dd40"
   struct:
     fields:
     - name: val
@@ -182,13 +506,13 @@
     - name: b
       type: "*main.node"
       offset: 8
-- offset: "0x00154900"
+- offset: "0x00157b60"
   size: 8
   kind: struct
   nameEntry: main.secondBehavior
   name: main.secondBehavior
   pkg: main
-  ptrToThis: "0x000d8440"
+  ptrToThis: "0x000d9ba0"
   methods:
   - name: DoSomething (exported)
     type: func() string
@@ -197,44 +521,44 @@
     - name: i
       type: int
       offset: 0
-- offset: "0x000f71e0"
+- offset: "0x000f8940"
   size: 16
   kind: interface
   nameEntry: main.something
   name: main.something
   pkg: main
-  ptrToThis: "0x0005cc80"
+  ptrToThis: "0x0005d580"
   interfaceMethods:
   - name: Do (exported)
     type: func()
-- offset: "0x000eeae0"
+- offset: "0x000f0240"
   size: 0
   kind: struct
   nameEntry: main.somethingImpl
   name: main.somethingImpl
   pkg: main
-  ptrToThis: "0x000d84a0"
+  ptrToThis: "0x000d9c00"
   struct:
     fields: []
-- offset: "0x0011e800"
+- offset: "0x001203e0"
   size: 8
   kind: struct
   nameEntry: main.structWithMap
   name: main.structWithMap
   pkg: main
-  ptrToThis: "0x0005cd00"
+  ptrToThis: "0x0005d600"
   struct:
     fields:
     - name: m
       type: map[int]int
       offset: 0
-- offset: "0x0015dbe0"
+- offset: "0x00160e40"
   size: 8
   kind: struct
   nameEntry: main.typeWithGenerics[int]
   name: main.typeWithGenerics[int]
   pkg: main
-  ptrToThis: "0x000e5be0"
+  ptrToThis: "0x000e7340"
   methods:
   - name: Guess (exported)
     type: func(int) bool
@@ -243,13 +567,13 @@
     - name: Value (exported)
       type: int
       offset: 0
-- offset: "0x0015dc80"
+- offset: "0x00160ee0"
   size: 16
   kind: struct
   nameEntry: main.typeWithGenerics[string]
   name: main.typeWithGenerics[string]
   pkg: main
-  ptrToThis: "0x000e5c40"
+  ptrToThis: "0x000e73a0"
   methods:
   - name: Guess (exported)
     type: func(string) bool

--- a/pkg/dyninst/gotype/testdata/snapshot/sample.arch=amd64,toolchain=go1.25.0.yaml
+++ b/pkg/dyninst/gotype/testdata/snapshot/sample.arch=amd64,toolchain=go1.25.0.yaml
@@ -1,4 +1,4 @@
-- offset: "0x000d9860"
+- offset: "0x000dafc0"
   size: 8
   kind: ptr
   nameEntry: "*lib_v2.V2Type (exported)"
@@ -9,16 +9,16 @@
     type: func()
   pointer:
     elem: lib_v2.V2Type
-- offset: "0x000efda0"
+- offset: "0x000f1500"
   size: 0
   kind: struct
   nameEntry: lib_v2.V2Type (exported)
   name: lib_v2.V2Type
   pkg: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.v2
-  ptrToThis: "0x000d9860"
+  ptrToThis: "0x000dafc0"
   struct:
     fields: []
-- offset: "0x000d9500"
+- offset: "0x000dac60"
   size: 8
   kind: ptr
   nameEntry: "*main.firstBehavior"
@@ -29,7 +29,7 @@
     type: func() string
   pointer:
     elem: main.firstBehavior
-- offset: "0x000d9560"
+- offset: "0x000dacc0"
   size: 8
   kind: ptr
   nameEntry: "*main.secondBehavior"
@@ -40,7 +40,7 @@
     type: func() string
   pointer:
     elem: main.secondBehavior
-- offset: "0x000d95c0"
+- offset: "0x000dad20"
   size: 8
   kind: ptr
   nameEntry: "*main.somethingImpl"
@@ -51,7 +51,7 @@
     type: func()
   pointer:
     elem: main.somethingImpl
-- offset: "0x000e6e80"
+- offset: "0x000e85e0"
   size: 8
   kind: ptr
   nameEntry: "*main.typeWithGenerics[int]"
@@ -62,7 +62,7 @@
     type: func(int) bool
   pointer:
     elem: main.typeWithGenerics[int]
-- offset: "0x000e6ee0"
+- offset: "0x000e8640"
   size: 8
   kind: ptr
   nameEntry: "*main.typeWithGenerics[string]"
@@ -73,23 +73,347 @@
     type: func(string) bool
   pointer:
     elem: main.typeWithGenerics[string]
-- offset: "0x000f8220"
+- offset: "0x000f9980"
   size: 16
   kind: interface
   nameEntry: main.behavior
   name: main.behavior
   pkg: main
-  ptrToThis: "0x0005d740"
+  ptrToThis: "0x0005e040"
   interfaceMethods:
   - name: DoSomething (exported)
     type: func() string
-- offset: "0x001bc920"
+- offset: "0x00121800"
+  size: 8
+  kind: struct
+  nameEntry: main.deepMap1
+  name: main.deepMap1
+  pkg: main
+  ptrToThis: "0x0005e340"
+  struct:
+    fields:
+    - name: a
+      type: map[int]*main.deepMap2
+      offset: 0
+- offset: "0x00121780"
+  size: 8
+  kind: struct
+  nameEntry: main.deepMap2
+  name: main.deepMap2
+  pkg: main
+  ptrToThis: "0x0005e300"
+  struct:
+    fields:
+    - name: a
+      type: map[int]*main.deepMap3
+      offset: 0
+- offset: "0x00121700"
+  size: 8
+  kind: struct
+  nameEntry: main.deepMap3
+  name: main.deepMap3
+  pkg: main
+  ptrToThis: "0x0005e2c0"
+  struct:
+    fields:
+    - name: a
+      type: map[int]*main.deepMap4
+      offset: 0
+- offset: "0x00121680"
+  size: 8
+  kind: struct
+  nameEntry: main.deepMap4
+  name: main.deepMap4
+  pkg: main
+  ptrToThis: "0x0005e280"
+  struct:
+    fields:
+    - name: a
+      type: map[int]*main.deepMap5
+      offset: 0
+- offset: "0x00121600"
+  size: 8
+  kind: struct
+  nameEntry: main.deepMap5
+  name: main.deepMap5
+  pkg: main
+  ptrToThis: "0x0005e240"
+  struct:
+    fields:
+    - name: a
+      type: map[int]*main.deepMap6
+      offset: 0
+- offset: "0x00121580"
+  size: 8
+  kind: struct
+  nameEntry: main.deepMap6
+  name: main.deepMap6
+  pkg: main
+  ptrToThis: "0x0005e200"
+  struct:
+    fields:
+    - name: a
+      type: map[int]*main.deepMap7
+      offset: 0
+- offset: "0x00121500"
+  size: 8
+  kind: struct
+  nameEntry: main.deepMap7
+  name: main.deepMap7
+  pkg: main
+  ptrToThis: "0x0005e1c0"
+  struct:
+    fields:
+    - name: a
+      type: map[int]*main.deepMap8
+      offset: 0
+- offset: "0x00121480"
+  size: 8
+  kind: struct
+  nameEntry: main.deepMap8
+  name: main.deepMap8
+  pkg: main
+  ptrToThis: "0x0005e180"
+  struct:
+    fields:
+    - name: a
+      type: map[int]*main.deepMap9
+      offset: 0
+- offset: "0x00121400"
+  size: 8
+  kind: struct
+  nameEntry: main.deepMap9
+  name: main.deepMap9
+  pkg: main
+  ptrToThis: "0x0005e140"
+  struct:
+    fields:
+    - name: a
+      type: map[int]interface {}
+      offset: 0
+- offset: "0x00121c80"
+  size: 8
+  kind: struct
+  nameEntry: main.deepPtr1
+  name: main.deepPtr1
+  pkg: main
+  ptrToThis: "0x0005e580"
+  struct:
+    fields:
+    - name: a
+      type: "*main.deepPtr2"
+      offset: 0
+- offset: "0x00121c00"
+  size: 8
+  kind: struct
+  nameEntry: main.deepPtr2
+  name: main.deepPtr2
+  pkg: main
+  ptrToThis: "0x0005e540"
+  struct:
+    fields:
+    - name: a
+      type: "*main.deepPtr3"
+      offset: 0
+- offset: "0x00121b80"
+  size: 8
+  kind: struct
+  nameEntry: main.deepPtr3
+  name: main.deepPtr3
+  pkg: main
+  ptrToThis: "0x0005e500"
+  struct:
+    fields:
+    - name: a
+      type: "*main.deepPtr4"
+      offset: 0
+- offset: "0x00121b00"
+  size: 8
+  kind: struct
+  nameEntry: main.deepPtr4
+  name: main.deepPtr4
+  pkg: main
+  ptrToThis: "0x0005e4c0"
+  struct:
+    fields:
+    - name: a
+      type: "*main.deepPtr5"
+      offset: 0
+- offset: "0x00121a80"
+  size: 8
+  kind: struct
+  nameEntry: main.deepPtr5
+  name: main.deepPtr5
+  pkg: main
+  ptrToThis: "0x0005e480"
+  struct:
+    fields:
+    - name: a
+      type: "*main.deepPtr6"
+      offset: 0
+- offset: "0x00121a00"
+  size: 8
+  kind: struct
+  nameEntry: main.deepPtr6
+  name: main.deepPtr6
+  pkg: main
+  ptrToThis: "0x0005e440"
+  struct:
+    fields:
+    - name: a
+      type: "*main.deepPtr7"
+      offset: 0
+- offset: "0x00121980"
+  size: 8
+  kind: struct
+  nameEntry: main.deepPtr7
+  name: main.deepPtr7
+  pkg: main
+  ptrToThis: "0x0005e400"
+  struct:
+    fields:
+    - name: a
+      type: "*main.deepPtr8"
+      offset: 0
+- offset: "0x00121900"
+  size: 8
+  kind: struct
+  nameEntry: main.deepPtr8
+  name: main.deepPtr8
+  pkg: main
+  ptrToThis: "0x0005e3c0"
+  struct:
+    fields:
+    - name: a
+      type: "*main.deepPtr9"
+      offset: 0
+- offset: "0x00121880"
+  size: 16
+  kind: struct
+  nameEntry: main.deepPtr9
+  name: main.deepPtr9
+  pkg: main
+  ptrToThis: "0x0005e380"
+  struct:
+    fields:
+    - name: a
+      type: interface {}
+      offset: 0
+- offset: "0x00122100"
+  size: 24
+  kind: struct
+  nameEntry: main.deepSlice1
+  name: main.deepSlice1
+  pkg: main
+  ptrToThis: "0x0005e7c0"
+  struct:
+    fields:
+    - name: a
+      type: "[]*main.deepSlice2"
+      offset: 0
+- offset: "0x00122080"
+  size: 24
+  kind: struct
+  nameEntry: main.deepSlice2
+  name: main.deepSlice2
+  pkg: main
+  ptrToThis: "0x0005e780"
+  struct:
+    fields:
+    - name: a
+      type: "[]*main.deepSlice3"
+      offset: 0
+- offset: "0x00122000"
+  size: 24
+  kind: struct
+  nameEntry: main.deepSlice3
+  name: main.deepSlice3
+  pkg: main
+  ptrToThis: "0x0005e740"
+  struct:
+    fields:
+    - name: a
+      type: "[]*main.deepSlice4"
+      offset: 0
+- offset: "0x00121f80"
+  size: 24
+  kind: struct
+  nameEntry: main.deepSlice4
+  name: main.deepSlice4
+  pkg: main
+  ptrToThis: "0x0005e700"
+  struct:
+    fields:
+    - name: a
+      type: "[]*main.deepSlice5"
+      offset: 0
+- offset: "0x00121f00"
+  size: 24
+  kind: struct
+  nameEntry: main.deepSlice5
+  name: main.deepSlice5
+  pkg: main
+  ptrToThis: "0x0005e6c0"
+  struct:
+    fields:
+    - name: a
+      type: "[]*main.deepSlice6"
+      offset: 0
+- offset: "0x00121e80"
+  size: 24
+  kind: struct
+  nameEntry: main.deepSlice6
+  name: main.deepSlice6
+  pkg: main
+  ptrToThis: "0x0005e680"
+  struct:
+    fields:
+    - name: a
+      type: "[]*main.deepSlice7"
+      offset: 0
+- offset: "0x00121e00"
+  size: 24
+  kind: struct
+  nameEntry: main.deepSlice7
+  name: main.deepSlice7
+  pkg: main
+  ptrToThis: "0x0005e640"
+  struct:
+    fields:
+    - name: a
+      type: "[]*main.deepSlice8"
+      offset: 0
+- offset: "0x00121d80"
+  size: 24
+  kind: struct
+  nameEntry: main.deepSlice8
+  name: main.deepSlice8
+  pkg: main
+  ptrToThis: "0x0005e600"
+  struct:
+    fields:
+    - name: a
+      type: "[]*main.deepSlice9"
+      offset: 0
+- offset: "0x00121d00"
+  size: 24
+  kind: struct
+  nameEntry: main.deepSlice9
+  name: main.deepSlice9
+  pkg: main
+  ptrToThis: "0x0005e5c0"
+  struct:
+    fields:
+    - name: a
+      type: "[]interface {}"
+      offset: 0
+- offset: "0x001bfb80"
   size: 112
   kind: struct
   nameEntry: main.esotericHeap
   name: main.esotericHeap
   pkg: main
-  ptrToThis: "0x0005d840"
+  ptrToThis: "0x0005e800"
   struct:
     fields:
     - name: esotericStack (embedded)
@@ -107,13 +431,13 @@
     - name: a
       type: atomic.Int32
       offset: 104
-- offset: "0x001dd1e0"
+- offset: "0x001e0440"
   size: 64
   kind: struct
   nameEntry: main.esotericStack
   name: main.esotericStack
   pkg: main
-  ptrToThis: "0x0005d7c0"
+  ptrToThis: "0x0005e0c0"
   struct:
     fields:
     - name: _
@@ -137,13 +461,13 @@
     - name: foo
       type: func()
       offset: 56
-- offset: "0x00155780"
+- offset: "0x001589e0"
   size: 16
   kind: struct
   nameEntry: main.firstBehavior
   name: main.firstBehavior
   pkg: main
-  ptrToThis: "0x000d9500"
+  ptrToThis: "0x000dac60"
   methods:
   - name: DoSomething (exported)
     type: func() string
@@ -152,13 +476,13 @@
     - name: s
       type: string
       offset: 0
-- offset: "0x00161ac0"
+- offset: "0x00164d20"
   size: 24
   kind: struct
   nameEntry: main.nestedStruct
   name: main.nestedStruct
   pkg: main
-  ptrToThis: "0x0005d8c0"
+  ptrToThis: "0x0005e880"
   struct:
     fields:
     - name: anotherInt
@@ -167,13 +491,13 @@
     - name: anotherString
       type: string
       offset: 8
-- offset: "0x00161a20"
+- offset: "0x00164c80"
   size: 16
   kind: struct
   nameEntry: main.node
   name: main.node
   pkg: main
-  ptrToThis: "0x0005d880"
+  ptrToThis: "0x0005e840"
   struct:
     fields:
     - name: val
@@ -182,13 +506,13 @@
     - name: b
       type: "*main.node"
       offset: 8
-- offset: "0x00155820"
+- offset: "0x00158a80"
   size: 8
   kind: struct
   nameEntry: main.secondBehavior
   name: main.secondBehavior
   pkg: main
-  ptrToThis: "0x000d9560"
+  ptrToThis: "0x000dacc0"
   methods:
   - name: DoSomething (exported)
     type: func() string
@@ -197,44 +521,44 @@
     - name: i
       type: int
       offset: 0
-- offset: "0x000f82a0"
+- offset: "0x000f9a00"
   size: 16
   kind: interface
   nameEntry: main.something
   name: main.something
   pkg: main
-  ptrToThis: "0x0005d780"
+  ptrToThis: "0x0005e080"
   interfaceMethods:
   - name: Do (exported)
     type: func()
-- offset: "0x000efc20"
+- offset: "0x000f1380"
   size: 0
   kind: struct
   nameEntry: main.somethingImpl
   name: main.somethingImpl
   pkg: main
-  ptrToThis: "0x000d95c0"
+  ptrToThis: "0x000dad20"
   struct:
     fields: []
-- offset: "0x0011f7a0"
+- offset: "0x00121380"
   size: 8
   kind: struct
   nameEntry: main.structWithMap
   name: main.structWithMap
   pkg: main
-  ptrToThis: "0x0005d800"
+  ptrToThis: "0x0005e100"
   struct:
     fields:
     - name: m
       type: map[int]int
       offset: 0
-- offset: "0x0015ece0"
+- offset: "0x00161f40"
   size: 8
   kind: struct
   nameEntry: main.typeWithGenerics[int]
   name: main.typeWithGenerics[int]
   pkg: main
-  ptrToThis: "0x000e6e80"
+  ptrToThis: "0x000e85e0"
   methods:
   - name: Guess (exported)
     type: func(int) bool
@@ -243,13 +567,13 @@
     - name: Value (exported)
       type: int
       offset: 0
-- offset: "0x0015ed80"
+- offset: "0x00161fe0"
   size: 16
   kind: struct
   nameEntry: main.typeWithGenerics[string]
   name: main.typeWithGenerics[string]
   pkg: main
-  ptrToThis: "0x000e6ee0"
+  ptrToThis: "0x000e8640"
   methods:
   - name: Guess (exported)
     type: func(string) bool

--- a/pkg/dyninst/gotype/testdata/snapshot/sample.arch=arm64,toolchain=go1.23.11.yaml
+++ b/pkg/dyninst/gotype/testdata/snapshot/sample.arch=arm64,toolchain=go1.23.11.yaml
@@ -1,4 +1,4 @@
-- offset: "0x000c8200"
+- offset: "0x000c9560"
   size: 8
   kind: ptr
   nameEntry: "*lib_v2.V2Type (exported)"
@@ -9,16 +9,16 @@
     type: func()
   pointer:
     elem: lib_v2.V2Type
-- offset: "0x000e5bc0"
+- offset: "0x000e7280"
   size: 0
   kind: struct
   nameEntry: lib_v2.V2Type (exported)
   name: lib_v2.V2Type
   pkg: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.v2
-  ptrToThis: "0x000c8200"
+  ptrToThis: "0x000c9560"
   struct:
     fields: []
-- offset: "0x000c7ea0"
+- offset: "0x000c9200"
   size: 8
   kind: ptr
   nameEntry: "*main.firstBehavior"
@@ -29,7 +29,7 @@
     type: func() string
   pointer:
     elem: main.firstBehavior
-- offset: "0x000c7f00"
+- offset: "0x000c9260"
   size: 8
   kind: ptr
   nameEntry: "*main.secondBehavior"
@@ -40,7 +40,7 @@
     type: func() string
   pointer:
     elem: main.secondBehavior
-- offset: "0x000c7f60"
+- offset: "0x000c92c0"
   size: 8
   kind: ptr
   nameEntry: "*main.somethingImpl"
@@ -51,7 +51,7 @@
     type: func()
   pointer:
     elem: main.somethingImpl
-- offset: "0x000d5280"
+- offset: "0x000d65e0"
   size: 8
   kind: ptr
   nameEntry: "*main.typeWithGenerics[int]"
@@ -62,7 +62,7 @@
     type: func(int) bool
   pointer:
     elem: main.typeWithGenerics[int]
-- offset: "0x000d52e0"
+- offset: "0x000d6640"
   size: 8
   kind: ptr
   nameEntry: "*main.typeWithGenerics[string]"
@@ -73,23 +73,347 @@
     type: func(string) bool
   pointer:
     elem: main.typeWithGenerics[string]
-- offset: "0x000edb00"
+- offset: "0x000ef1c0"
   size: 16
   kind: interface
   nameEntry: main.behavior
   name: main.behavior
   pkg: main
-  ptrToThis: "0x000566a0"
+  ptrToThis: "0x00056c40"
   interfaceMethods:
   - name: DoSomething (exported)
     type: func() string
-- offset: "0x0019d520"
+- offset: "0x0010c760"
+  size: 8
+  kind: struct
+  nameEntry: main.deepMap1
+  name: main.deepMap1
+  pkg: main
+  ptrToThis: "0x00056f40"
+  struct:
+    fields:
+    - name: a
+      type: map[int]*main.deepMap2
+      offset: 0
+- offset: "0x0010c6e0"
+  size: 8
+  kind: struct
+  nameEntry: main.deepMap2
+  name: main.deepMap2
+  pkg: main
+  ptrToThis: "0x00056f00"
+  struct:
+    fields:
+    - name: a
+      type: map[int]*main.deepMap3
+      offset: 0
+- offset: "0x0010c660"
+  size: 8
+  kind: struct
+  nameEntry: main.deepMap3
+  name: main.deepMap3
+  pkg: main
+  ptrToThis: "0x00056ec0"
+  struct:
+    fields:
+    - name: a
+      type: map[int]*main.deepMap4
+      offset: 0
+- offset: "0x0010c5e0"
+  size: 8
+  kind: struct
+  nameEntry: main.deepMap4
+  name: main.deepMap4
+  pkg: main
+  ptrToThis: "0x00056e80"
+  struct:
+    fields:
+    - name: a
+      type: map[int]*main.deepMap5
+      offset: 0
+- offset: "0x0010c560"
+  size: 8
+  kind: struct
+  nameEntry: main.deepMap5
+  name: main.deepMap5
+  pkg: main
+  ptrToThis: "0x00056e40"
+  struct:
+    fields:
+    - name: a
+      type: map[int]*main.deepMap6
+      offset: 0
+- offset: "0x0010c4e0"
+  size: 8
+  kind: struct
+  nameEntry: main.deepMap6
+  name: main.deepMap6
+  pkg: main
+  ptrToThis: "0x00056e00"
+  struct:
+    fields:
+    - name: a
+      type: map[int]*main.deepMap7
+      offset: 0
+- offset: "0x0010c460"
+  size: 8
+  kind: struct
+  nameEntry: main.deepMap7
+  name: main.deepMap7
+  pkg: main
+  ptrToThis: "0x00056dc0"
+  struct:
+    fields:
+    - name: a
+      type: map[int]*main.deepMap8
+      offset: 0
+- offset: "0x0010c3e0"
+  size: 8
+  kind: struct
+  nameEntry: main.deepMap8
+  name: main.deepMap8
+  pkg: main
+  ptrToThis: "0x00056d80"
+  struct:
+    fields:
+    - name: a
+      type: map[int]*main.deepMap9
+      offset: 0
+- offset: "0x0010c360"
+  size: 8
+  kind: struct
+  nameEntry: main.deepMap9
+  name: main.deepMap9
+  pkg: main
+  ptrToThis: "0x00056d40"
+  struct:
+    fields:
+    - name: a
+      type: map[int]interface {}
+      offset: 0
+- offset: "0x0010cbe0"
+  size: 8
+  kind: struct
+  nameEntry: main.deepPtr1
+  name: main.deepPtr1
+  pkg: main
+  ptrToThis: "0x00057180"
+  struct:
+    fields:
+    - name: a
+      type: "*main.deepPtr2"
+      offset: 0
+- offset: "0x0010cb60"
+  size: 8
+  kind: struct
+  nameEntry: main.deepPtr2
+  name: main.deepPtr2
+  pkg: main
+  ptrToThis: "0x00057140"
+  struct:
+    fields:
+    - name: a
+      type: "*main.deepPtr3"
+      offset: 0
+- offset: "0x0010cae0"
+  size: 8
+  kind: struct
+  nameEntry: main.deepPtr3
+  name: main.deepPtr3
+  pkg: main
+  ptrToThis: "0x00057100"
+  struct:
+    fields:
+    - name: a
+      type: "*main.deepPtr4"
+      offset: 0
+- offset: "0x0010ca60"
+  size: 8
+  kind: struct
+  nameEntry: main.deepPtr4
+  name: main.deepPtr4
+  pkg: main
+  ptrToThis: "0x000570c0"
+  struct:
+    fields:
+    - name: a
+      type: "*main.deepPtr5"
+      offset: 0
+- offset: "0x0010c9e0"
+  size: 8
+  kind: struct
+  nameEntry: main.deepPtr5
+  name: main.deepPtr5
+  pkg: main
+  ptrToThis: "0x00057080"
+  struct:
+    fields:
+    - name: a
+      type: "*main.deepPtr6"
+      offset: 0
+- offset: "0x0010c960"
+  size: 8
+  kind: struct
+  nameEntry: main.deepPtr6
+  name: main.deepPtr6
+  pkg: main
+  ptrToThis: "0x00057040"
+  struct:
+    fields:
+    - name: a
+      type: "*main.deepPtr7"
+      offset: 0
+- offset: "0x0010c8e0"
+  size: 8
+  kind: struct
+  nameEntry: main.deepPtr7
+  name: main.deepPtr7
+  pkg: main
+  ptrToThis: "0x00057000"
+  struct:
+    fields:
+    - name: a
+      type: "*main.deepPtr8"
+      offset: 0
+- offset: "0x0010c860"
+  size: 8
+  kind: struct
+  nameEntry: main.deepPtr8
+  name: main.deepPtr8
+  pkg: main
+  ptrToThis: "0x00056fc0"
+  struct:
+    fields:
+    - name: a
+      type: "*main.deepPtr9"
+      offset: 0
+- offset: "0x0010c7e0"
+  size: 16
+  kind: struct
+  nameEntry: main.deepPtr9
+  name: main.deepPtr9
+  pkg: main
+  ptrToThis: "0x00056f80"
+  struct:
+    fields:
+    - name: a
+      type: interface {}
+      offset: 0
+- offset: "0x0010d060"
+  size: 24
+  kind: struct
+  nameEntry: main.deepSlice1
+  name: main.deepSlice1
+  pkg: main
+  ptrToThis: "0x000573c0"
+  struct:
+    fields:
+    - name: a
+      type: "[]*main.deepSlice2"
+      offset: 0
+- offset: "0x0010cfe0"
+  size: 24
+  kind: struct
+  nameEntry: main.deepSlice2
+  name: main.deepSlice2
+  pkg: main
+  ptrToThis: "0x00057380"
+  struct:
+    fields:
+    - name: a
+      type: "[]*main.deepSlice3"
+      offset: 0
+- offset: "0x0010cf60"
+  size: 24
+  kind: struct
+  nameEntry: main.deepSlice3
+  name: main.deepSlice3
+  pkg: main
+  ptrToThis: "0x00057340"
+  struct:
+    fields:
+    - name: a
+      type: "[]*main.deepSlice4"
+      offset: 0
+- offset: "0x0010cee0"
+  size: 24
+  kind: struct
+  nameEntry: main.deepSlice4
+  name: main.deepSlice4
+  pkg: main
+  ptrToThis: "0x00057300"
+  struct:
+    fields:
+    - name: a
+      type: "[]*main.deepSlice5"
+      offset: 0
+- offset: "0x0010ce60"
+  size: 24
+  kind: struct
+  nameEntry: main.deepSlice5
+  name: main.deepSlice5
+  pkg: main
+  ptrToThis: "0x000572c0"
+  struct:
+    fields:
+    - name: a
+      type: "[]*main.deepSlice6"
+      offset: 0
+- offset: "0x0010cde0"
+  size: 24
+  kind: struct
+  nameEntry: main.deepSlice6
+  name: main.deepSlice6
+  pkg: main
+  ptrToThis: "0x00057280"
+  struct:
+    fields:
+    - name: a
+      type: "[]*main.deepSlice7"
+      offset: 0
+- offset: "0x0010cd60"
+  size: 24
+  kind: struct
+  nameEntry: main.deepSlice7
+  name: main.deepSlice7
+  pkg: main
+  ptrToThis: "0x00057240"
+  struct:
+    fields:
+    - name: a
+      type: "[]*main.deepSlice8"
+      offset: 0
+- offset: "0x0010cce0"
+  size: 24
+  kind: struct
+  nameEntry: main.deepSlice8
+  name: main.deepSlice8
+  pkg: main
+  ptrToThis: "0x00057200"
+  struct:
+    fields:
+    - name: a
+      type: "[]*main.deepSlice9"
+      offset: 0
+- offset: "0x0010cc60"
+  size: 24
+  kind: struct
+  nameEntry: main.deepSlice9
+  name: main.deepSlice9
+  pkg: main
+  ptrToThis: "0x000571c0"
+  struct:
+    fields:
+    - name: a
+      type: "[]interface {}"
+      offset: 0
+- offset: "0x001a0020"
   size: 112
   kind: struct
   nameEntry: main.esotericHeap
   name: main.esotericHeap
   pkg: main
-  ptrToThis: "0x000567a0"
+  ptrToThis: "0x00057400"
   struct:
     fields:
     - name: esotericStack (embedded)
@@ -107,13 +431,13 @@
     - name: a
       type: atomic.Int32
       offset: 104
-- offset: "0x001bc320"
+- offset: "0x001bee20"
   size: 64
   kind: struct
   nameEntry: main.esotericStack
   name: main.esotericStack
   pkg: main
-  ptrToThis: "0x00056720"
+  ptrToThis: "0x00056cc0"
   struct:
     fields:
     - name: _
@@ -137,13 +461,13 @@
     - name: foo
       type: func()
       offset: 56
-- offset: "0x0012a480"
+- offset: "0x0012c8c0"
   size: 16
   kind: struct
   nameEntry: main.firstBehavior
   name: main.firstBehavior
   pkg: main
-  ptrToThis: "0x000c7ea0"
+  ptrToThis: "0x000c9200"
   methods:
   - name: DoSomething (exported)
     type: func() string
@@ -152,13 +476,13 @@
     - name: s
       type: string
       offset: 0
-- offset: "0x001361c0"
+- offset: "0x00138600"
   size: 24
   kind: struct
   nameEntry: main.nestedStruct
   name: main.nestedStruct
   pkg: main
-  ptrToThis: "0x00056820"
+  ptrToThis: "0x00057480"
   struct:
     fields:
     - name: anotherInt
@@ -167,13 +491,13 @@
     - name: anotherString
       type: string
       offset: 8
-- offset: "0x00136120"
+- offset: "0x00138560"
   size: 16
   kind: struct
   nameEntry: main.node
   name: main.node
   pkg: main
-  ptrToThis: "0x000567e0"
+  ptrToThis: "0x00057440"
   struct:
     fields:
     - name: val
@@ -182,13 +506,13 @@
     - name: b
       type: "*main.node"
       offset: 8
-- offset: "0x0012a520"
+- offset: "0x0012c960"
   size: 8
   kind: struct
   nameEntry: main.secondBehavior
   name: main.secondBehavior
   pkg: main
-  ptrToThis: "0x000c7f00"
+  ptrToThis: "0x000c9260"
   methods:
   - name: DoSomething (exported)
     type: func() string
@@ -197,44 +521,44 @@
     - name: i
       type: int
       offset: 0
-- offset: "0x000edb80"
+- offset: "0x000ef240"
   size: 16
   kind: interface
   nameEntry: main.something
   name: main.something
   pkg: main
-  ptrToThis: "0x000566e0"
+  ptrToThis: "0x00056c80"
   interfaceMethods:
   - name: Do (exported)
     type: func()
-- offset: "0x000e5a40"
+- offset: "0x000e7100"
   size: 0
   kind: struct
   nameEntry: main.somethingImpl
   name: main.somethingImpl
   pkg: main
-  ptrToThis: "0x000c7f60"
+  ptrToThis: "0x000c92c0"
   struct:
     fields: []
-- offset: "0x0010ac20"
+- offset: "0x0010c2e0"
   size: 8
   kind: struct
   nameEntry: main.structWithMap
   name: main.structWithMap
   pkg: main
-  ptrToThis: "0x00056760"
+  ptrToThis: "0x00056d00"
   struct:
     fields:
     - name: m
       type: map[int]int
       offset: 0
-- offset: "0x00133440"
+- offset: "0x00135880"
   size: 8
   kind: struct
   nameEntry: main.typeWithGenerics[int]
   name: main.typeWithGenerics[int]
   pkg: main
-  ptrToThis: "0x000d5280"
+  ptrToThis: "0x000d65e0"
   methods:
   - name: Guess (exported)
     type: func(int) bool
@@ -243,13 +567,13 @@
     - name: Value (exported)
       type: int
       offset: 0
-- offset: "0x001334e0"
+- offset: "0x00135920"
   size: 16
   kind: struct
   nameEntry: main.typeWithGenerics[string]
   name: main.typeWithGenerics[string]
   pkg: main
-  ptrToThis: "0x000d52e0"
+  ptrToThis: "0x000d6640"
   methods:
   - name: Guess (exported)
     type: func(string) bool

--- a/pkg/dyninst/gotype/testdata/snapshot/sample.arch=arm64,toolchain=go1.24.3.yaml
+++ b/pkg/dyninst/gotype/testdata/snapshot/sample.arch=arm64,toolchain=go1.24.3.yaml
@@ -1,4 +1,4 @@
-- offset: "0x000d8500"
+- offset: "0x000d9c40"
   size: 8
   kind: ptr
   nameEntry: "*lib_v2.V2Type (exported)"
@@ -9,16 +9,16 @@
     type: func()
   pointer:
     elem: lib_v2.V2Type
-- offset: "0x000ee9c0"
+- offset: "0x000f0100"
   size: 0
   kind: struct
   nameEntry: lib_v2.V2Type (exported)
   name: lib_v2.V2Type
   pkg: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.v2
-  ptrToThis: "0x000d8500"
+  ptrToThis: "0x000d9c40"
   struct:
     fields: []
-- offset: "0x000d81a0"
+- offset: "0x000d98e0"
   size: 8
   kind: ptr
   nameEntry: "*main.firstBehavior"
@@ -29,7 +29,7 @@
     type: func() string
   pointer:
     elem: main.firstBehavior
-- offset: "0x000d8200"
+- offset: "0x000d9940"
   size: 8
   kind: ptr
   nameEntry: "*main.secondBehavior"
@@ -40,7 +40,7 @@
     type: func() string
   pointer:
     elem: main.secondBehavior
-- offset: "0x000d8260"
+- offset: "0x000d99a0"
   size: 8
   kind: ptr
   nameEntry: "*main.somethingImpl"
@@ -51,7 +51,7 @@
     type: func()
   pointer:
     elem: main.somethingImpl
-- offset: "0x000e5940"
+- offset: "0x000e7080"
   size: 8
   kind: ptr
   nameEntry: "*main.typeWithGenerics[int]"
@@ -62,7 +62,7 @@
     type: func(int) bool
   pointer:
     elem: main.typeWithGenerics[int]
-- offset: "0x000e59a0"
+- offset: "0x000e70e0"
   size: 8
   kind: ptr
   nameEntry: "*main.typeWithGenerics[string]"
@@ -73,23 +73,347 @@
     type: func(string) bool
   pointer:
     elem: main.typeWithGenerics[string]
-- offset: "0x000f6ec0"
+- offset: "0x000f8600"
   size: 16
   kind: interface
   nameEntry: main.behavior
   name: main.behavior
   pkg: main
-  ptrToThis: "0x0005cc00"
+  ptrToThis: "0x0005d4e0"
   interfaceMethods:
   - name: DoSomething (exported)
     type: func() string
-- offset: "0x001ba2e0"
+- offset: "0x001205a0"
+  size: 8
+  kind: struct
+  nameEntry: main.deepMap1
+  name: main.deepMap1
+  pkg: main
+  ptrToThis: "0x0005d7e0"
+  struct:
+    fields:
+    - name: a
+      type: map[int]*main.deepMap2
+      offset: 0
+- offset: "0x00120520"
+  size: 8
+  kind: struct
+  nameEntry: main.deepMap2
+  name: main.deepMap2
+  pkg: main
+  ptrToThis: "0x0005d7a0"
+  struct:
+    fields:
+    - name: a
+      type: map[int]*main.deepMap3
+      offset: 0
+- offset: "0x001204a0"
+  size: 8
+  kind: struct
+  nameEntry: main.deepMap3
+  name: main.deepMap3
+  pkg: main
+  ptrToThis: "0x0005d760"
+  struct:
+    fields:
+    - name: a
+      type: map[int]*main.deepMap4
+      offset: 0
+- offset: "0x00120420"
+  size: 8
+  kind: struct
+  nameEntry: main.deepMap4
+  name: main.deepMap4
+  pkg: main
+  ptrToThis: "0x0005d720"
+  struct:
+    fields:
+    - name: a
+      type: map[int]*main.deepMap5
+      offset: 0
+- offset: "0x001203a0"
+  size: 8
+  kind: struct
+  nameEntry: main.deepMap5
+  name: main.deepMap5
+  pkg: main
+  ptrToThis: "0x0005d6e0"
+  struct:
+    fields:
+    - name: a
+      type: map[int]*main.deepMap6
+      offset: 0
+- offset: "0x00120320"
+  size: 8
+  kind: struct
+  nameEntry: main.deepMap6
+  name: main.deepMap6
+  pkg: main
+  ptrToThis: "0x0005d6a0"
+  struct:
+    fields:
+    - name: a
+      type: map[int]*main.deepMap7
+      offset: 0
+- offset: "0x001202a0"
+  size: 8
+  kind: struct
+  nameEntry: main.deepMap7
+  name: main.deepMap7
+  pkg: main
+  ptrToThis: "0x0005d660"
+  struct:
+    fields:
+    - name: a
+      type: map[int]*main.deepMap8
+      offset: 0
+- offset: "0x00120220"
+  size: 8
+  kind: struct
+  nameEntry: main.deepMap8
+  name: main.deepMap8
+  pkg: main
+  ptrToThis: "0x0005d620"
+  struct:
+    fields:
+    - name: a
+      type: map[int]*main.deepMap9
+      offset: 0
+- offset: "0x001201a0"
+  size: 8
+  kind: struct
+  nameEntry: main.deepMap9
+  name: main.deepMap9
+  pkg: main
+  ptrToThis: "0x0005d5e0"
+  struct:
+    fields:
+    - name: a
+      type: map[int]interface {}
+      offset: 0
+- offset: "0x00120a20"
+  size: 8
+  kind: struct
+  nameEntry: main.deepPtr1
+  name: main.deepPtr1
+  pkg: main
+  ptrToThis: "0x0005da20"
+  struct:
+    fields:
+    - name: a
+      type: "*main.deepPtr2"
+      offset: 0
+- offset: "0x001209a0"
+  size: 8
+  kind: struct
+  nameEntry: main.deepPtr2
+  name: main.deepPtr2
+  pkg: main
+  ptrToThis: "0x0005d9e0"
+  struct:
+    fields:
+    - name: a
+      type: "*main.deepPtr3"
+      offset: 0
+- offset: "0x00120920"
+  size: 8
+  kind: struct
+  nameEntry: main.deepPtr3
+  name: main.deepPtr3
+  pkg: main
+  ptrToThis: "0x0005d9a0"
+  struct:
+    fields:
+    - name: a
+      type: "*main.deepPtr4"
+      offset: 0
+- offset: "0x001208a0"
+  size: 8
+  kind: struct
+  nameEntry: main.deepPtr4
+  name: main.deepPtr4
+  pkg: main
+  ptrToThis: "0x0005d960"
+  struct:
+    fields:
+    - name: a
+      type: "*main.deepPtr5"
+      offset: 0
+- offset: "0x00120820"
+  size: 8
+  kind: struct
+  nameEntry: main.deepPtr5
+  name: main.deepPtr5
+  pkg: main
+  ptrToThis: "0x0005d920"
+  struct:
+    fields:
+    - name: a
+      type: "*main.deepPtr6"
+      offset: 0
+- offset: "0x001207a0"
+  size: 8
+  kind: struct
+  nameEntry: main.deepPtr6
+  name: main.deepPtr6
+  pkg: main
+  ptrToThis: "0x0005d8e0"
+  struct:
+    fields:
+    - name: a
+      type: "*main.deepPtr7"
+      offset: 0
+- offset: "0x00120720"
+  size: 8
+  kind: struct
+  nameEntry: main.deepPtr7
+  name: main.deepPtr7
+  pkg: main
+  ptrToThis: "0x0005d8a0"
+  struct:
+    fields:
+    - name: a
+      type: "*main.deepPtr8"
+      offset: 0
+- offset: "0x001206a0"
+  size: 8
+  kind: struct
+  nameEntry: main.deepPtr8
+  name: main.deepPtr8
+  pkg: main
+  ptrToThis: "0x0005d860"
+  struct:
+    fields:
+    - name: a
+      type: "*main.deepPtr9"
+      offset: 0
+- offset: "0x00120620"
+  size: 16
+  kind: struct
+  nameEntry: main.deepPtr9
+  name: main.deepPtr9
+  pkg: main
+  ptrToThis: "0x0005d820"
+  struct:
+    fields:
+    - name: a
+      type: interface {}
+      offset: 0
+- offset: "0x00120ea0"
+  size: 24
+  kind: struct
+  nameEntry: main.deepSlice1
+  name: main.deepSlice1
+  pkg: main
+  ptrToThis: "0x0005dc60"
+  struct:
+    fields:
+    - name: a
+      type: "[]*main.deepSlice2"
+      offset: 0
+- offset: "0x00120e20"
+  size: 24
+  kind: struct
+  nameEntry: main.deepSlice2
+  name: main.deepSlice2
+  pkg: main
+  ptrToThis: "0x0005dc20"
+  struct:
+    fields:
+    - name: a
+      type: "[]*main.deepSlice3"
+      offset: 0
+- offset: "0x00120da0"
+  size: 24
+  kind: struct
+  nameEntry: main.deepSlice3
+  name: main.deepSlice3
+  pkg: main
+  ptrToThis: "0x0005dbe0"
+  struct:
+    fields:
+    - name: a
+      type: "[]*main.deepSlice4"
+      offset: 0
+- offset: "0x00120d20"
+  size: 24
+  kind: struct
+  nameEntry: main.deepSlice4
+  name: main.deepSlice4
+  pkg: main
+  ptrToThis: "0x0005dba0"
+  struct:
+    fields:
+    - name: a
+      type: "[]*main.deepSlice5"
+      offset: 0
+- offset: "0x00120ca0"
+  size: 24
+  kind: struct
+  nameEntry: main.deepSlice5
+  name: main.deepSlice5
+  pkg: main
+  ptrToThis: "0x0005db60"
+  struct:
+    fields:
+    - name: a
+      type: "[]*main.deepSlice6"
+      offset: 0
+- offset: "0x00120c20"
+  size: 24
+  kind: struct
+  nameEntry: main.deepSlice6
+  name: main.deepSlice6
+  pkg: main
+  ptrToThis: "0x0005db20"
+  struct:
+    fields:
+    - name: a
+      type: "[]*main.deepSlice7"
+      offset: 0
+- offset: "0x00120ba0"
+  size: 24
+  kind: struct
+  nameEntry: main.deepSlice7
+  name: main.deepSlice7
+  pkg: main
+  ptrToThis: "0x0005dae0"
+  struct:
+    fields:
+    - name: a
+      type: "[]*main.deepSlice8"
+      offset: 0
+- offset: "0x00120b20"
+  size: 24
+  kind: struct
+  nameEntry: main.deepSlice8
+  name: main.deepSlice8
+  pkg: main
+  ptrToThis: "0x0005daa0"
+  struct:
+    fields:
+    - name: a
+      type: "[]*main.deepSlice9"
+      offset: 0
+- offset: "0x00120aa0"
+  size: 24
+  kind: struct
+  nameEntry: main.deepSlice9
+  name: main.deepSlice9
+  pkg: main
+  ptrToThis: "0x0005da60"
+  struct:
+    fields:
+    - name: a
+      type: "[]interface {}"
+      offset: 0
+- offset: "0x001bd520"
   size: 112
   kind: struct
   nameEntry: main.esotericHeap
   name: main.esotericHeap
   pkg: main
-  ptrToThis: "0x0005cd00"
+  ptrToThis: "0x0005dca0"
   struct:
     fields:
     - name: esotericStack (embedded)
@@ -107,13 +431,13 @@
     - name: a
       type: atomic.Int32
       offset: 104
-- offset: "0x001dacc0"
+- offset: "0x001ddf00"
   size: 64
   kind: struct
   nameEntry: main.esotericStack
   name: main.esotericStack
   pkg: main
-  ptrToThis: "0x0005cc80"
+  ptrToThis: "0x0005d560"
   struct:
     fields:
     - name: _
@@ -137,13 +461,13 @@
     - name: foo
       type: func()
       offset: 56
-- offset: "0x001545c0"
+- offset: "0x00157800"
   size: 16
   kind: struct
   nameEntry: main.firstBehavior
   name: main.firstBehavior
   pkg: main
-  ptrToThis: "0x000d81a0"
+  ptrToThis: "0x000d98e0"
   methods:
   - name: DoSomething (exported)
     type: func() string
@@ -152,13 +476,13 @@
     - name: s
       type: string
       offset: 0
-- offset: "0x00160640"
+- offset: "0x00163880"
   size: 24
   kind: struct
   nameEntry: main.nestedStruct
   name: main.nestedStruct
   pkg: main
-  ptrToThis: "0x0005cd80"
+  ptrToThis: "0x0005dd20"
   struct:
     fields:
     - name: anotherInt
@@ -167,13 +491,13 @@
     - name: anotherString
       type: string
       offset: 8
-- offset: "0x001605a0"
+- offset: "0x001637e0"
   size: 16
   kind: struct
   nameEntry: main.node
   name: main.node
   pkg: main
-  ptrToThis: "0x0005cd40"
+  ptrToThis: "0x0005dce0"
   struct:
     fields:
     - name: val
@@ -182,13 +506,13 @@
     - name: b
       type: "*main.node"
       offset: 8
-- offset: "0x00154660"
+- offset: "0x001578a0"
   size: 8
   kind: struct
   nameEntry: main.secondBehavior
   name: main.secondBehavior
   pkg: main
-  ptrToThis: "0x000d8200"
+  ptrToThis: "0x000d9940"
   methods:
   - name: DoSomething (exported)
     type: func() string
@@ -197,44 +521,44 @@
     - name: i
       type: int
       offset: 0
-- offset: "0x000f6f40"
+- offset: "0x000f8680"
   size: 16
   kind: interface
   nameEntry: main.something
   name: main.something
   pkg: main
-  ptrToThis: "0x0005cc40"
+  ptrToThis: "0x0005d520"
   interfaceMethods:
   - name: Do (exported)
     type: func()
-- offset: "0x000ee840"
+- offset: "0x000eff80"
   size: 0
   kind: struct
   nameEntry: main.somethingImpl
   name: main.somethingImpl
   pkg: main
-  ptrToThis: "0x000d8260"
+  ptrToThis: "0x000d99a0"
   struct:
     fields: []
-- offset: "0x0011e560"
+- offset: "0x00120120"
   size: 8
   kind: struct
   nameEntry: main.structWithMap
   name: main.structWithMap
   pkg: main
-  ptrToThis: "0x0005ccc0"
+  ptrToThis: "0x0005d5a0"
   struct:
     fields:
     - name: m
       type: map[int]int
       offset: 0
-- offset: "0x0015d940"
+- offset: "0x00160b80"
   size: 8
   kind: struct
   nameEntry: main.typeWithGenerics[int]
   name: main.typeWithGenerics[int]
   pkg: main
-  ptrToThis: "0x000e5940"
+  ptrToThis: "0x000e7080"
   methods:
   - name: Guess (exported)
     type: func(int) bool
@@ -243,13 +567,13 @@
     - name: Value (exported)
       type: int
       offset: 0
-- offset: "0x0015d9e0"
+- offset: "0x00160c20"
   size: 16
   kind: struct
   nameEntry: main.typeWithGenerics[string]
   name: main.typeWithGenerics[string]
   pkg: main
-  ptrToThis: "0x000e59a0"
+  ptrToThis: "0x000e70e0"
   methods:
   - name: Guess (exported)
     type: func(string) bool

--- a/pkg/dyninst/gotype/testdata/snapshot/sample.arch=arm64,toolchain=go1.25.0.yaml
+++ b/pkg/dyninst/gotype/testdata/snapshot/sample.arch=arm64,toolchain=go1.25.0.yaml
@@ -1,4 +1,4 @@
-- offset: "0x000d9600"
+- offset: "0x000dad60"
   size: 8
   kind: ptr
   nameEntry: "*lib_v2.V2Type (exported)"
@@ -9,16 +9,16 @@
     type: func()
   pointer:
     elem: lib_v2.V2Type
-- offset: "0x000efae0"
+- offset: "0x000f1240"
   size: 0
   kind: struct
   nameEntry: lib_v2.V2Type (exported)
   name: lib_v2.V2Type
   pkg: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.v2
-  ptrToThis: "0x000d9600"
+  ptrToThis: "0x000dad60"
   struct:
     fields: []
-- offset: "0x000d92a0"
+- offset: "0x000daa00"
   size: 8
   kind: ptr
   nameEntry: "*main.firstBehavior"
@@ -29,7 +29,7 @@
     type: func() string
   pointer:
     elem: main.firstBehavior
-- offset: "0x000d9300"
+- offset: "0x000daa60"
   size: 8
   kind: ptr
   nameEntry: "*main.secondBehavior"
@@ -40,7 +40,7 @@
     type: func() string
   pointer:
     elem: main.secondBehavior
-- offset: "0x000d9360"
+- offset: "0x000daac0"
   size: 8
   kind: ptr
   nameEntry: "*main.somethingImpl"
@@ -51,7 +51,7 @@
     type: func()
   pointer:
     elem: main.somethingImpl
-- offset: "0x000e6bc0"
+- offset: "0x000e8320"
   size: 8
   kind: ptr
   nameEntry: "*main.typeWithGenerics[int]"
@@ -62,7 +62,7 @@
     type: func(int) bool
   pointer:
     elem: main.typeWithGenerics[int]
-- offset: "0x000e6c20"
+- offset: "0x000e8380"
   size: 8
   kind: ptr
   nameEntry: "*main.typeWithGenerics[string]"
@@ -73,23 +73,347 @@
     type: func(string) bool
   pointer:
     elem: main.typeWithGenerics[string]
-- offset: "0x000f7f60"
+- offset: "0x000f96c0"
   size: 16
   kind: interface
   nameEntry: main.behavior
   name: main.behavior
   pkg: main
-  ptrToThis: "0x0005d6e0"
+  ptrToThis: "0x0005dfe0"
   interfaceMethods:
   - name: DoSomething (exported)
     type: func() string
-- offset: "0x001bc700"
+- offset: "0x00121540"
+  size: 8
+  kind: struct
+  nameEntry: main.deepMap1
+  name: main.deepMap1
+  pkg: main
+  ptrToThis: "0x0005e2e0"
+  struct:
+    fields:
+    - name: a
+      type: map[int]*main.deepMap2
+      offset: 0
+- offset: "0x001214c0"
+  size: 8
+  kind: struct
+  nameEntry: main.deepMap2
+  name: main.deepMap2
+  pkg: main
+  ptrToThis: "0x0005e2a0"
+  struct:
+    fields:
+    - name: a
+      type: map[int]*main.deepMap3
+      offset: 0
+- offset: "0x00121440"
+  size: 8
+  kind: struct
+  nameEntry: main.deepMap3
+  name: main.deepMap3
+  pkg: main
+  ptrToThis: "0x0005e260"
+  struct:
+    fields:
+    - name: a
+      type: map[int]*main.deepMap4
+      offset: 0
+- offset: "0x001213c0"
+  size: 8
+  kind: struct
+  nameEntry: main.deepMap4
+  name: main.deepMap4
+  pkg: main
+  ptrToThis: "0x0005e220"
+  struct:
+    fields:
+    - name: a
+      type: map[int]*main.deepMap5
+      offset: 0
+- offset: "0x00121340"
+  size: 8
+  kind: struct
+  nameEntry: main.deepMap5
+  name: main.deepMap5
+  pkg: main
+  ptrToThis: "0x0005e1e0"
+  struct:
+    fields:
+    - name: a
+      type: map[int]*main.deepMap6
+      offset: 0
+- offset: "0x001212c0"
+  size: 8
+  kind: struct
+  nameEntry: main.deepMap6
+  name: main.deepMap6
+  pkg: main
+  ptrToThis: "0x0005e1a0"
+  struct:
+    fields:
+    - name: a
+      type: map[int]*main.deepMap7
+      offset: 0
+- offset: "0x00121240"
+  size: 8
+  kind: struct
+  nameEntry: main.deepMap7
+  name: main.deepMap7
+  pkg: main
+  ptrToThis: "0x0005e160"
+  struct:
+    fields:
+    - name: a
+      type: map[int]*main.deepMap8
+      offset: 0
+- offset: "0x001211c0"
+  size: 8
+  kind: struct
+  nameEntry: main.deepMap8
+  name: main.deepMap8
+  pkg: main
+  ptrToThis: "0x0005e120"
+  struct:
+    fields:
+    - name: a
+      type: map[int]*main.deepMap9
+      offset: 0
+- offset: "0x00121140"
+  size: 8
+  kind: struct
+  nameEntry: main.deepMap9
+  name: main.deepMap9
+  pkg: main
+  ptrToThis: "0x0005e0e0"
+  struct:
+    fields:
+    - name: a
+      type: map[int]interface {}
+      offset: 0
+- offset: "0x001219c0"
+  size: 8
+  kind: struct
+  nameEntry: main.deepPtr1
+  name: main.deepPtr1
+  pkg: main
+  ptrToThis: "0x0005e520"
+  struct:
+    fields:
+    - name: a
+      type: "*main.deepPtr2"
+      offset: 0
+- offset: "0x00121940"
+  size: 8
+  kind: struct
+  nameEntry: main.deepPtr2
+  name: main.deepPtr2
+  pkg: main
+  ptrToThis: "0x0005e4e0"
+  struct:
+    fields:
+    - name: a
+      type: "*main.deepPtr3"
+      offset: 0
+- offset: "0x001218c0"
+  size: 8
+  kind: struct
+  nameEntry: main.deepPtr3
+  name: main.deepPtr3
+  pkg: main
+  ptrToThis: "0x0005e4a0"
+  struct:
+    fields:
+    - name: a
+      type: "*main.deepPtr4"
+      offset: 0
+- offset: "0x00121840"
+  size: 8
+  kind: struct
+  nameEntry: main.deepPtr4
+  name: main.deepPtr4
+  pkg: main
+  ptrToThis: "0x0005e460"
+  struct:
+    fields:
+    - name: a
+      type: "*main.deepPtr5"
+      offset: 0
+- offset: "0x001217c0"
+  size: 8
+  kind: struct
+  nameEntry: main.deepPtr5
+  name: main.deepPtr5
+  pkg: main
+  ptrToThis: "0x0005e420"
+  struct:
+    fields:
+    - name: a
+      type: "*main.deepPtr6"
+      offset: 0
+- offset: "0x00121740"
+  size: 8
+  kind: struct
+  nameEntry: main.deepPtr6
+  name: main.deepPtr6
+  pkg: main
+  ptrToThis: "0x0005e3e0"
+  struct:
+    fields:
+    - name: a
+      type: "*main.deepPtr7"
+      offset: 0
+- offset: "0x001216c0"
+  size: 8
+  kind: struct
+  nameEntry: main.deepPtr7
+  name: main.deepPtr7
+  pkg: main
+  ptrToThis: "0x0005e3a0"
+  struct:
+    fields:
+    - name: a
+      type: "*main.deepPtr8"
+      offset: 0
+- offset: "0x00121640"
+  size: 8
+  kind: struct
+  nameEntry: main.deepPtr8
+  name: main.deepPtr8
+  pkg: main
+  ptrToThis: "0x0005e360"
+  struct:
+    fields:
+    - name: a
+      type: "*main.deepPtr9"
+      offset: 0
+- offset: "0x001215c0"
+  size: 16
+  kind: struct
+  nameEntry: main.deepPtr9
+  name: main.deepPtr9
+  pkg: main
+  ptrToThis: "0x0005e320"
+  struct:
+    fields:
+    - name: a
+      type: interface {}
+      offset: 0
+- offset: "0x00121e40"
+  size: 24
+  kind: struct
+  nameEntry: main.deepSlice1
+  name: main.deepSlice1
+  pkg: main
+  ptrToThis: "0x0005e760"
+  struct:
+    fields:
+    - name: a
+      type: "[]*main.deepSlice2"
+      offset: 0
+- offset: "0x00121dc0"
+  size: 24
+  kind: struct
+  nameEntry: main.deepSlice2
+  name: main.deepSlice2
+  pkg: main
+  ptrToThis: "0x0005e720"
+  struct:
+    fields:
+    - name: a
+      type: "[]*main.deepSlice3"
+      offset: 0
+- offset: "0x00121d40"
+  size: 24
+  kind: struct
+  nameEntry: main.deepSlice3
+  name: main.deepSlice3
+  pkg: main
+  ptrToThis: "0x0005e6e0"
+  struct:
+    fields:
+    - name: a
+      type: "[]*main.deepSlice4"
+      offset: 0
+- offset: "0x00121cc0"
+  size: 24
+  kind: struct
+  nameEntry: main.deepSlice4
+  name: main.deepSlice4
+  pkg: main
+  ptrToThis: "0x0005e6a0"
+  struct:
+    fields:
+    - name: a
+      type: "[]*main.deepSlice5"
+      offset: 0
+- offset: "0x00121c40"
+  size: 24
+  kind: struct
+  nameEntry: main.deepSlice5
+  name: main.deepSlice5
+  pkg: main
+  ptrToThis: "0x0005e660"
+  struct:
+    fields:
+    - name: a
+      type: "[]*main.deepSlice6"
+      offset: 0
+- offset: "0x00121bc0"
+  size: 24
+  kind: struct
+  nameEntry: main.deepSlice6
+  name: main.deepSlice6
+  pkg: main
+  ptrToThis: "0x0005e620"
+  struct:
+    fields:
+    - name: a
+      type: "[]*main.deepSlice7"
+      offset: 0
+- offset: "0x00121b40"
+  size: 24
+  kind: struct
+  nameEntry: main.deepSlice7
+  name: main.deepSlice7
+  pkg: main
+  ptrToThis: "0x0005e5e0"
+  struct:
+    fields:
+    - name: a
+      type: "[]*main.deepSlice8"
+      offset: 0
+- offset: "0x00121ac0"
+  size: 24
+  kind: struct
+  nameEntry: main.deepSlice8
+  name: main.deepSlice8
+  pkg: main
+  ptrToThis: "0x0005e5a0"
+  struct:
+    fields:
+    - name: a
+      type: "[]*main.deepSlice9"
+      offset: 0
+- offset: "0x00121a40"
+  size: 24
+  kind: struct
+  nameEntry: main.deepSlice9
+  name: main.deepSlice9
+  pkg: main
+  ptrToThis: "0x0005e560"
+  struct:
+    fields:
+    - name: a
+      type: "[]interface {}"
+      offset: 0
+- offset: "0x001bf960"
   size: 112
   kind: struct
   nameEntry: main.esotericHeap
   name: main.esotericHeap
   pkg: main
-  ptrToThis: "0x0005d7e0"
+  ptrToThis: "0x0005e7a0"
   struct:
     fields:
     - name: esotericStack (embedded)
@@ -107,13 +431,13 @@
     - name: a
       type: atomic.Int32
       offset: 104
-- offset: "0x001dcee0"
+- offset: "0x001e0140"
   size: 64
   kind: struct
   nameEntry: main.esotericStack
   name: main.esotericStack
   pkg: main
-  ptrToThis: "0x0005d760"
+  ptrToThis: "0x0005e060"
   struct:
     fields:
     - name: _
@@ -137,13 +461,13 @@
     - name: foo
       type: func()
       offset: 56
-- offset: "0x001554c0"
+- offset: "0x00158720"
   size: 16
   kind: struct
   nameEntry: main.firstBehavior
   name: main.firstBehavior
   pkg: main
-  ptrToThis: "0x000d92a0"
+  ptrToThis: "0x000daa00"
   methods:
   - name: DoSomething (exported)
     type: func() string
@@ -152,13 +476,13 @@
     - name: s
       type: string
       offset: 0
-- offset: "0x00161800"
+- offset: "0x00164a60"
   size: 24
   kind: struct
   nameEntry: main.nestedStruct
   name: main.nestedStruct
   pkg: main
-  ptrToThis: "0x0005d860"
+  ptrToThis: "0x0005e820"
   struct:
     fields:
     - name: anotherInt
@@ -167,13 +491,13 @@
     - name: anotherString
       type: string
       offset: 8
-- offset: "0x00161760"
+- offset: "0x001649c0"
   size: 16
   kind: struct
   nameEntry: main.node
   name: main.node
   pkg: main
-  ptrToThis: "0x0005d820"
+  ptrToThis: "0x0005e7e0"
   struct:
     fields:
     - name: val
@@ -182,13 +506,13 @@
     - name: b
       type: "*main.node"
       offset: 8
-- offset: "0x00155560"
+- offset: "0x001587c0"
   size: 8
   kind: struct
   nameEntry: main.secondBehavior
   name: main.secondBehavior
   pkg: main
-  ptrToThis: "0x000d9300"
+  ptrToThis: "0x000daa60"
   methods:
   - name: DoSomething (exported)
     type: func() string
@@ -197,44 +521,44 @@
     - name: i
       type: int
       offset: 0
-- offset: "0x000f7fe0"
+- offset: "0x000f9740"
   size: 16
   kind: interface
   nameEntry: main.something
   name: main.something
   pkg: main
-  ptrToThis: "0x0005d720"
+  ptrToThis: "0x0005e020"
   interfaceMethods:
   - name: Do (exported)
     type: func()
-- offset: "0x000ef960"
+- offset: "0x000f10c0"
   size: 0
   kind: struct
   nameEntry: main.somethingImpl
   name: main.somethingImpl
   pkg: main
-  ptrToThis: "0x000d9360"
+  ptrToThis: "0x000daac0"
   struct:
     fields: []
-- offset: "0x0011f4e0"
+- offset: "0x001210c0"
   size: 8
   kind: struct
   nameEntry: main.structWithMap
   name: main.structWithMap
   pkg: main
-  ptrToThis: "0x0005d7a0"
+  ptrToThis: "0x0005e0a0"
   struct:
     fields:
     - name: m
       type: map[int]int
       offset: 0
-- offset: "0x0015ea20"
+- offset: "0x00161c80"
   size: 8
   kind: struct
   nameEntry: main.typeWithGenerics[int]
   name: main.typeWithGenerics[int]
   pkg: main
-  ptrToThis: "0x000e6bc0"
+  ptrToThis: "0x000e8320"
   methods:
   - name: Guess (exported)
     type: func(int) bool
@@ -243,13 +567,13 @@
     - name: Value (exported)
       type: int
       offset: 0
-- offset: "0x0015eac0"
+- offset: "0x00161d20"
   size: 16
   kind: struct
   nameEntry: main.typeWithGenerics[string]
   name: main.typeWithGenerics[string]
   pkg: main
-  ptrToThis: "0x000e6c20"
+  ptrToThis: "0x000e8380"
   methods:
   - name: Guess (exported)
     type: func(string) bool

--- a/pkg/dyninst/integration_test.go
+++ b/pkg/dyninst/integration_test.go
@@ -15,6 +15,7 @@ import (
 	"fmt"
 	"io"
 	"math"
+	"math/rand/v2"
 	"os"
 	"path"
 	"path/filepath"
@@ -45,12 +46,15 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/dyninst/object"
 	"github.com/DataDog/datadog-agent/pkg/dyninst/output"
 	"github.com/DataDog/datadog-agent/pkg/dyninst/procmon"
+	"github.com/DataDog/datadog-agent/pkg/dyninst/rcjson"
 	"github.com/DataDog/datadog-agent/pkg/dyninst/symbol"
 	"github.com/DataDog/datadog-agent/pkg/dyninst/testprogs"
 )
 
 //go:embed testdata/decoded
 var testdataFS embed.FS
+
+const runWithLimitEnvVar = "RUN_WITH_LIMIT_PERCENT"
 
 func TestDyninst(t *testing.T) {
 	dyninsttest.SkipIfKernelNotSupported(t)
@@ -86,13 +90,29 @@ func TestDyninst(t *testing.T) {
 		})
 	}
 	rewrite, _ := strconv.ParseBool(os.Getenv("REWRITE"))
+
+	const defaultRunWithLimitPercent = 25
+	var runWithLimitPercent float64
+	if !testing.Short() && !rewrite {
+		runWithLimitPercent = defaultRunWithLimitPercent
+		runWithLimitPercentStr := os.Getenv(runWithLimitEnvVar)
+		if runWithLimitPercentStr != "" {
+			var err error
+			runWithLimitPercent, err = strconv.ParseFloat(runWithLimitPercentStr, 64)
+			require.NoError(t, err)
+			require.GreaterOrEqual(t, runWithLimitPercent, 0.0)
+			require.LessOrEqual(t, runWithLimitPercent, 100.0)
+		}
+	}
 	for _, svc := range programs {
 		if _, ok := integrationTestPrograms[svc]; !ok {
 			t.Logf("%s is not used in integration tests", svc)
 			continue
 		}
 		t.Run(svc, func(t *testing.T) {
-			runIntegrationTestSuite(t, svc, rewrite, sem, cfgs...)
+			runIntegrationTestSuite(
+				t, svc, rewrite, sem, runWithLimitPercent, cfgs...,
+			)
 		})
 	}
 }
@@ -322,6 +342,7 @@ func runIntegrationTestSuite(
 	service string,
 	rewrite bool,
 	sem dyninsttest.Semaphore,
+	runWithLimitPercent float64,
 	cfgs ...testprogs.Config,
 ) {
 	var outputs = struct {
@@ -357,7 +378,8 @@ func runIntegrationTestSuite(
 				runTest := func(t *testing.T, probeSlice []ir.ProbeDefinition) {
 					t.Parallel()
 					actual := testDyninst(
-						t, service, bin, probeSlice, rewrite, expectedOutput, debug, sem,
+						t, service, bin, probeSlice, rewrite, expectedOutput,
+						debug, sem,
 					)
 					if t.Failed() {
 						return
@@ -382,9 +404,67 @@ func runIntegrationTestSuite(
 						})
 					}
 				})
+				t.Run("with-depth-limit", func(t *testing.T) {
+					if debug {
+						t.Skip("skipping all-probes-limited with debug")
+					}
+					if testing.Short() {
+						t.Skip("skipping all-probes-limited with short")
+					}
+					t.Parallel()
+					probes := testprogs.MustGetProbeDefinitions(t, service)
+					for _, probe := range probes {
+						// If there's already a limit, we don't need to run the
+						// test.
+						depth := probe.GetCaptureConfig().GetMaxReferenceDepth()
+						if depth < math.MaxUint32 {
+							continue
+						}
+						t.Run(probe.GetID(), func(t *testing.T) {
+							if rand.Float64()*100 > runWithLimitPercent {
+								t.Skipf(
+									"randomly skipping probe with limit due to %s %f",
+									runWithLimitEnvVar, runWithLimitPercent,
+								)
+							}
+							t.Parallel()
+							probes := probeConfigsWithMaxReferenceDepth([]ir.ProbeDefinition{probe}, 1)
+							const rewrite = true
+							var exp map[string][]json.RawMessage // no expectation
+							got := testDyninst(
+								t, service, bin, probes, rewrite, exp, debug, sem,
+							)
+							if t.Failed() {
+								return
+							}
+							require.Len(t, got, 1)
+							require.Contains(t, got, probe.GetID())
+						})
+					}
+				})
 			}
 		})
 	}
+}
+
+func probeConfigsWithMaxReferenceDepth(
+	probesCfgs []ir.ProbeDefinition, limit int,
+) []ir.ProbeDefinition {
+	for _, cfg := range probesCfgs {
+		switch cfg := cfg.(type) {
+		case *rcjson.LogProbe:
+			if cfg.Capture == nil {
+				cfg.Capture = new(rcjson.Capture)
+			}
+			cfg.Capture.MaxReferenceDepth = limit
+		case *rcjson.SnapshotProbe:
+			if cfg.Capture == nil {
+				cfg.Capture = new(rcjson.Capture)
+			}
+			cfg.Capture.MaxReferenceDepth = limit
+		}
+	}
+	return probesCfgs
 }
 
 // validateAndSaveOutputs ensures that the outputs for the same probe are consistent

--- a/pkg/dyninst/ir/types.go
+++ b/pkg/dyninst/ir/types.go
@@ -56,6 +56,7 @@ func (t *GoTypeAttributes) GetGoKind() (reflect.Kind, bool) {
 var (
 	_ Type = (*BaseType)(nil)
 	_ Type = (*PointerType)(nil)
+	_ Type = (*UnresolvedPointeeType)(nil)
 	_ Type = (*StructureType)(nil)
 	_ Type = (*ArrayType)(nil)
 
@@ -360,3 +361,12 @@ type RootExpression struct {
 	// value of the event.
 	Expression Expression
 }
+
+// UnresolvedPointeeType is a placeholder type that represents an unresolved
+// pointee type.
+type UnresolvedPointeeType struct {
+	TypeCommon
+	syntheticType
+}
+
+func (UnresolvedPointeeType) irType() {}

--- a/pkg/dyninst/irgen/irgen.go
+++ b/pkg/dyninst/irgen/irgen.go
@@ -600,6 +600,19 @@ func completeGoMapType(tc *typeCatalog, t *ir.GoMapType) error {
 			t.Name, t.HeaderType,
 		)
 	}
+
+	if current := tc.typesByID[headerType.ID]; current != headerType {
+		_, isHMapHeaderType := current.(*ir.GoHMapHeaderType)
+		_, isSwissMapHeaderType := current.(*ir.GoSwissMapHeaderType)
+		if isHMapHeaderType || isSwissMapHeaderType {
+			return nil // already completed
+		}
+		return fmt.Errorf(
+			"header type for map type %q has been completed to %T, expected %T",
+			t.Name, current, headerType,
+		)
+	}
+
 	// Use the type name to determine whether this is an hmap or a swiss map.
 	// We could alternatively use the go version or the structure field layout.
 	// This works for now.
@@ -610,8 +623,8 @@ func completeGoMapType(tc *typeCatalog, t *ir.GoMapType) error {
 		return completeHMapHeaderType(tc, headerType)
 	default:
 		return fmt.Errorf(
-			"unexpected header type for map type %q: %T",
-			t.Name, t.HeaderType,
+			"unexpected header type for map type %q: %q %T",
+			t.Name, t.HeaderType.GetName(), t.HeaderType,
 		)
 	}
 }

--- a/pkg/dyninst/irgen/testdata/snapshot/busyloop.arch=amd64,toolchain=go1.23.11.yaml
+++ b/pkg/dyninst/irgen/testdata/snapshot/busyloop.arch=amd64,toolchain=go1.23.11.yaml
@@ -20,30 +20,6 @@ Subprograms:
       InlinePCRanges: []
       Variables: []
 Types:
-    - __kind: BaseType
-      ID: 1
-      Name: uintptr
-      ByteSize: 8
-      GoRuntimeType: 37504
-      GoKind: 12
-    - __kind: BaseType
-      ID: 2
-      Name: uint32
-      ByteSize: 4
-      GoRuntimeType: 37184
-      GoKind: 10
-    - __kind: BaseType
-      ID: 3
-      Name: uint8
-      ByteSize: 1
-      GoRuntimeType: 36928
-      GoKind: 8
-    - __kind: BaseType
-      ID: 4
-      Name: bool
-      ByteSize: 1
-      GoRuntimeType: 37824
-      GoKind: 1
     - __kind: PointerType
       ID: 5
       Name: '*bool'
@@ -52,18 +28,94 @@ Types:
       GoKind: 22
       Pointee: 4 BaseType bool
     - __kind: PointerType
+      ID: 29
+      Name: '*error'
+      ByteSize: 8
+      GoRuntimeType: 25664
+      GoKind: 22
+      Pointee: 18 GoInterfaceType error
+    - __kind: PointerType
+      ID: 30
+      Name: '*float32'
+      ByteSize: 8
+      GoRuntimeType: 26624
+      GoKind: 22
+      Pointee: 16 BaseType float32
+    - __kind: PointerType
+      ID: 25
+      Name: '*float64'
+      ByteSize: 8
+      GoRuntimeType: 26688
+      GoKind: 22
+      Pointee: 17 BaseType float64
+    - __kind: PointerType
+      ID: 27
+      Name: '*int'
+      ByteSize: 8
+      GoRuntimeType: 26304
+      GoKind: 22
+      Pointee: 9 BaseType int
+    - __kind: PointerType
+      ID: 20
+      Name: '*int32'
+      ByteSize: 8
+      GoRuntimeType: 26048
+      GoKind: 22
+      Pointee: 12 BaseType int32
+    - __kind: PointerType
+      ID: 26
+      Name: '*int64'
+      ByteSize: 8
+      GoRuntimeType: 26176
+      GoKind: 22
+      Pointee: 13 BaseType int64
+    - __kind: PointerType
+      ID: 22
+      Name: '*string'
+      ByteSize: 8
+      GoRuntimeType: 25728
+      GoKind: 22
+      Pointee: 10 GoStringHeaderType string
+    - __kind: PointerType
+      ID: 34
+      Name: '*string.str'
+      ByteSize: 8
+      Pointee: 33 GoStringDataType string.str
+    - __kind: PointerType
+      ID: 31
+      Name: '*uint'
+      ByteSize: 8
+      GoRuntimeType: 26368
+      GoKind: 22
+      Pointee: 15 BaseType uint
+    - __kind: PointerType
+      ID: 32
+      Name: '*uint16'
+      ByteSize: 8
+      GoRuntimeType: 25984
+      GoKind: 22
+      Pointee: 7 BaseType uint16
+    - __kind: PointerType
+      ID: 21
+      Name: '*uint32'
+      ByteSize: 8
+      GoRuntimeType: 26112
+      GoKind: 22
+      Pointee: 2 BaseType uint32
+    - __kind: PointerType
+      ID: 28
+      Name: '*uint64'
+      ByteSize: 8
+      GoRuntimeType: 26240
+      GoKind: 22
+      Pointee: 11 BaseType uint64
+    - __kind: PointerType
       ID: 6
       Name: '*uint8'
       ByteSize: 8
       GoRuntimeType: 25856
       GoKind: 22
       Pointee: 3 BaseType uint8
-    - __kind: BaseType
-      ID: 7
-      Name: uint16
-      ByteSize: 2
-      GoRuntimeType: 37056
-      GoKind: 9
     - __kind: PointerType
       ID: 8
       Name: '*uintptr'
@@ -71,32 +123,58 @@ Types:
       GoRuntimeType: 26432
       GoKind: 22
       Pointee: 1 BaseType uintptr
+    - __kind: EventRootType
+      ID: 35
+      Name: Probe[main.noop]
+    - __kind: BaseType
+      ID: 4
+      Name: bool
+      ByteSize: 1
+      GoRuntimeType: 37824
+      GoKind: 1
+    - __kind: BaseType
+      ID: 24
+      Name: complex128
+      ByteSize: 16
+      GoRuntimeType: 37632
+      GoKind: 16
+    - __kind: BaseType
+      ID: 23
+      Name: complex64
+      ByteSize: 8
+      GoRuntimeType: 37568
+      GoKind: 15
+    - __kind: GoInterfaceType
+      ID: 18
+      Name: error
+      ByteSize: 16
+      GoRuntimeType: 57984
+      GoKind: 20
+      RawFields:
+        - Name: tab
+          Offset: 0
+          Type: 19 VoidPointerType unsafe.Pointer
+        - Name: data
+          Offset: 8
+          Type: 19 VoidPointerType unsafe.Pointer
+    - __kind: BaseType
+      ID: 16
+      Name: float32
+      ByteSize: 4
+      GoRuntimeType: 37696
+      GoKind: 13
+    - __kind: BaseType
+      ID: 17
+      Name: float64
+      ByteSize: 8
+      GoRuntimeType: 37760
+      GoKind: 14
     - __kind: BaseType
       ID: 9
       Name: int
       ByteSize: 8
       GoRuntimeType: 37376
       GoKind: 2
-    - __kind: GoStringHeaderType
-      ID: 10
-      Name: string
-      ByteSize: 16
-      GoRuntimeType: 36800
-      GoKind: 24
-      RawFields:
-        - Name: str
-          Offset: 0
-          Type: 34 PointerType *string.str
-        - Name: len
-          Offset: 8
-          Type: 9 BaseType int
-      Data: 33 GoStringDataType string.str
-    - __kind: BaseType
-      ID: 11
-      Name: uint64
-      ByteSize: 8
-      GoRuntimeType: 37312
-      GoKind: 11
     - __kind: BaseType
       ID: 12
       Name: int32
@@ -115,6 +193,24 @@ Types:
       ByteSize: 1
       GoRuntimeType: 36864
       GoKind: 3
+    - __kind: GoStringHeaderType
+      ID: 10
+      Name: string
+      ByteSize: 16
+      GoRuntimeType: 36800
+      GoKind: 24
+      RawFields:
+        - Name: str
+          Offset: 0
+          Type: 34 PointerType *string.str
+        - Name: len
+          Offset: 8
+          Type: 9 BaseType int
+      Data: 33 GoStringDataType string.str
+    - __kind: GoStringDataType
+      ID: 33
+      Name: string.str
+      ByteSize: 2048
     - __kind: BaseType
       ID: 15
       Name: uint
@@ -122,137 +218,41 @@ Types:
       GoRuntimeType: 37440
       GoKind: 7
     - __kind: BaseType
-      ID: 16
-      Name: float32
-      ByteSize: 4
-      GoRuntimeType: 37696
-      GoKind: 13
+      ID: 7
+      Name: uint16
+      ByteSize: 2
+      GoRuntimeType: 37056
+      GoKind: 9
     - __kind: BaseType
-      ID: 17
-      Name: float64
+      ID: 2
+      Name: uint32
+      ByteSize: 4
+      GoRuntimeType: 37184
+      GoKind: 10
+    - __kind: BaseType
+      ID: 11
+      Name: uint64
       ByteSize: 8
-      GoRuntimeType: 37760
-      GoKind: 14
-    - __kind: GoInterfaceType
-      ID: 18
-      Name: error
-      ByteSize: 16
-      GoRuntimeType: 57984
-      GoKind: 20
-      RawFields:
-        - Name: tab
-          Offset: 0
-          Type: 19 VoidPointerType unsafe.Pointer
-        - Name: data
-          Offset: 8
-          Type: 19 VoidPointerType unsafe.Pointer
+      GoRuntimeType: 37312
+      GoKind: 11
+    - __kind: BaseType
+      ID: 3
+      Name: uint8
+      ByteSize: 1
+      GoRuntimeType: 36928
+      GoKind: 8
+    - __kind: BaseType
+      ID: 1
+      Name: uintptr
+      ByteSize: 8
+      GoRuntimeType: 37504
+      GoKind: 12
     - __kind: VoidPointerType
       ID: 19
       Name: unsafe.Pointer
       ByteSize: 8
       GoRuntimeType: 37888
       GoKind: 26
-    - __kind: PointerType
-      ID: 20
-      Name: '*int32'
-      ByteSize: 8
-      GoRuntimeType: 26048
-      GoKind: 22
-      Pointee: 12 BaseType int32
-    - __kind: PointerType
-      ID: 21
-      Name: '*uint32'
-      ByteSize: 8
-      GoRuntimeType: 26112
-      GoKind: 22
-      Pointee: 2 BaseType uint32
-    - __kind: PointerType
-      ID: 22
-      Name: '*string'
-      ByteSize: 8
-      GoRuntimeType: 25728
-      GoKind: 22
-      Pointee: 10 GoStringHeaderType string
-    - __kind: BaseType
-      ID: 23
-      Name: complex64
-      ByteSize: 8
-      GoRuntimeType: 37568
-      GoKind: 15
-    - __kind: BaseType
-      ID: 24
-      Name: complex128
-      ByteSize: 16
-      GoRuntimeType: 37632
-      GoKind: 16
-    - __kind: PointerType
-      ID: 25
-      Name: '*float64'
-      ByteSize: 8
-      GoRuntimeType: 26688
-      GoKind: 22
-      Pointee: 17 BaseType float64
-    - __kind: PointerType
-      ID: 26
-      Name: '*int64'
-      ByteSize: 8
-      GoRuntimeType: 26176
-      GoKind: 22
-      Pointee: 13 BaseType int64
-    - __kind: PointerType
-      ID: 27
-      Name: '*int'
-      ByteSize: 8
-      GoRuntimeType: 26304
-      GoKind: 22
-      Pointee: 9 BaseType int
-    - __kind: PointerType
-      ID: 28
-      Name: '*uint64'
-      ByteSize: 8
-      GoRuntimeType: 26240
-      GoKind: 22
-      Pointee: 11 BaseType uint64
-    - __kind: PointerType
-      ID: 29
-      Name: '*error'
-      ByteSize: 8
-      GoRuntimeType: 25664
-      GoKind: 22
-      Pointee: 18 GoInterfaceType error
-    - __kind: PointerType
-      ID: 30
-      Name: '*float32'
-      ByteSize: 8
-      GoRuntimeType: 26624
-      GoKind: 22
-      Pointee: 16 BaseType float32
-    - __kind: PointerType
-      ID: 31
-      Name: '*uint'
-      ByteSize: 8
-      GoRuntimeType: 26368
-      GoKind: 22
-      Pointee: 15 BaseType uint
-    - __kind: PointerType
-      ID: 32
-      Name: '*uint16'
-      ByteSize: 8
-      GoRuntimeType: 25984
-      GoKind: 22
-      Pointee: 7 BaseType uint16
-    - __kind: GoStringDataType
-      ID: 33
-      Name: string.str
-      ByteSize: 2048
-    - __kind: PointerType
-      ID: 34
-      Name: '*string.str'
-      ByteSize: 8
-      Pointee: 33 GoStringDataType string.str
-    - __kind: EventRootType
-      ID: 35
-      Name: Probe[main.noop]
 MaxTypeID: 35
 Issues: []
 GoModuledataInfo: {FirstModuledataAddr: "0x572260", TypesOffset: 296}

--- a/pkg/dyninst/irgen/testdata/snapshot/busyloop.arch=amd64,toolchain=go1.24.3.yaml
+++ b/pkg/dyninst/irgen/testdata/snapshot/busyloop.arch=amd64,toolchain=go1.24.3.yaml
@@ -20,75 +20,6 @@ Subprograms:
       InlinePCRanges: []
       Variables: []
 Types:
-    - __kind: BaseType
-      ID: 1
-      Name: uintptr
-      ByteSize: 8
-      GoRuntimeType: 41312
-      GoKind: 12
-    - __kind: BaseType
-      ID: 2
-      Name: uint32
-      ByteSize: 4
-      GoRuntimeType: 40992
-      GoKind: 10
-    - __kind: BaseType
-      ID: 3
-      Name: uint8
-      ByteSize: 1
-      GoRuntimeType: 40736
-      GoKind: 8
-    - __kind: BaseType
-      ID: 4
-      Name: bool
-      ByteSize: 1
-      GoRuntimeType: 41632
-      GoKind: 1
-    - __kind: PointerType
-      ID: 5
-      Name: '*uint8'
-      ByteSize: 8
-      GoRuntimeType: 28352
-      GoKind: 22
-      Pointee: 3 BaseType uint8
-    - __kind: BaseType
-      ID: 6
-      Name: uint16
-      ByteSize: 2
-      GoRuntimeType: 40864
-      GoKind: 9
-    - __kind: BaseType
-      ID: 7
-      Name: int
-      ByteSize: 8
-      GoRuntimeType: 41184
-      GoKind: 2
-    - __kind: BaseType
-      ID: 8
-      Name: uint64
-      ByteSize: 8
-      GoRuntimeType: 41120
-      GoKind: 11
-    - __kind: GoStringHeaderType
-      ID: 9
-      Name: string
-      ByteSize: 16
-      GoRuntimeType: 40608
-      GoKind: 24
-      RawFields:
-        - Name: str
-          Offset: 0
-          Type: 34 PointerType *string.str
-        - Name: len
-          Offset: 8
-          Type: 7 BaseType int
-      Data: 33 GoStringDataType string.str
-    - __kind: BaseType
-      ID: 10
-      Name: int32
-      ByteSize: 4
-      GoRuntimeType: 40928
-      GoKind: 5
     - __kind: PointerType
       ID: 11
       Name: '*bool'
@@ -96,123 +27,6 @@ Types:
       GoRuntimeType: 29248
       GoKind: 22
       Pointee: 4 BaseType bool
-    - __kind: BaseType
-      ID: 12
-      Name: int64
-      ByteSize: 8
-      GoRuntimeType: 41056
-      GoKind: 6
-    - __kind: GoInterfaceType
-      ID: 13
-      Name: error
-      ByteSize: 16
-      GoRuntimeType: 62112
-      GoKind: 20
-      RawFields:
-        - Name: tab
-          Offset: 0
-          Type: 14 VoidPointerType unsafe.Pointer
-        - Name: data
-          Offset: 8
-          Type: 14 VoidPointerType unsafe.Pointer
-    - __kind: VoidPointerType
-      ID: 14
-      Name: unsafe.Pointer
-      ByteSize: 8
-      GoRuntimeType: 41696
-      GoKind: 26
-    - __kind: BaseType
-      ID: 15
-      Name: int8
-      ByteSize: 1
-      GoRuntimeType: 40672
-      GoKind: 3
-    - __kind: BaseType
-      ID: 16
-      Name: uint
-      ByteSize: 8
-      GoRuntimeType: 41248
-      GoKind: 7
-    - __kind: BaseType
-      ID: 17
-      Name: float32
-      ByteSize: 4
-      GoRuntimeType: 41504
-      GoKind: 13
-    - __kind: BaseType
-      ID: 18
-      Name: float64
-      ByteSize: 8
-      GoRuntimeType: 41568
-      GoKind: 14
-    - __kind: PointerType
-      ID: 19
-      Name: '*uintptr'
-      ByteSize: 8
-      GoRuntimeType: 28928
-      GoKind: 22
-      Pointee: 1 BaseType uintptr
-    - __kind: PointerType
-      ID: 20
-      Name: '*int32'
-      ByteSize: 8
-      GoRuntimeType: 28544
-      GoKind: 22
-      Pointee: 10 BaseType int32
-    - __kind: PointerType
-      ID: 21
-      Name: '*uint32'
-      ByteSize: 8
-      GoRuntimeType: 28608
-      GoKind: 22
-      Pointee: 2 BaseType uint32
-    - __kind: PointerType
-      ID: 22
-      Name: '*string'
-      ByteSize: 8
-      GoRuntimeType: 28224
-      GoKind: 22
-      Pointee: 9 GoStringHeaderType string
-    - __kind: BaseType
-      ID: 23
-      Name: complex64
-      ByteSize: 8
-      GoRuntimeType: 41376
-      GoKind: 15
-    - __kind: BaseType
-      ID: 24
-      Name: complex128
-      ByteSize: 16
-      GoRuntimeType: 41440
-      GoKind: 16
-    - __kind: PointerType
-      ID: 25
-      Name: '*float64'
-      ByteSize: 8
-      GoRuntimeType: 29184
-      GoKind: 22
-      Pointee: 18 BaseType float64
-    - __kind: PointerType
-      ID: 26
-      Name: '*int64'
-      ByteSize: 8
-      GoRuntimeType: 28672
-      GoKind: 22
-      Pointee: 12 BaseType int64
-    - __kind: PointerType
-      ID: 27
-      Name: '*int'
-      ByteSize: 8
-      GoRuntimeType: 28800
-      GoKind: 22
-      Pointee: 7 BaseType int
-    - __kind: PointerType
-      ID: 28
-      Name: '*uint64'
-      ByteSize: 8
-      GoRuntimeType: 28736
-      GoKind: 22
-      Pointee: 8 BaseType uint64
     - __kind: PointerType
       ID: 29
       Name: '*error'
@@ -228,6 +42,46 @@ Types:
       GoKind: 22
       Pointee: 17 BaseType float32
     - __kind: PointerType
+      ID: 25
+      Name: '*float64'
+      ByteSize: 8
+      GoRuntimeType: 29184
+      GoKind: 22
+      Pointee: 18 BaseType float64
+    - __kind: PointerType
+      ID: 27
+      Name: '*int'
+      ByteSize: 8
+      GoRuntimeType: 28800
+      GoKind: 22
+      Pointee: 7 BaseType int
+    - __kind: PointerType
+      ID: 20
+      Name: '*int32'
+      ByteSize: 8
+      GoRuntimeType: 28544
+      GoKind: 22
+      Pointee: 10 BaseType int32
+    - __kind: PointerType
+      ID: 26
+      Name: '*int64'
+      ByteSize: 8
+      GoRuntimeType: 28672
+      GoKind: 22
+      Pointee: 12 BaseType int64
+    - __kind: PointerType
+      ID: 22
+      Name: '*string'
+      ByteSize: 8
+      GoRuntimeType: 28224
+      GoKind: 22
+      Pointee: 9 GoStringHeaderType string
+    - __kind: PointerType
+      ID: 34
+      Name: '*string.str'
+      ByteSize: 8
+      Pointee: 33 GoStringDataType string.str
+    - __kind: PointerType
       ID: 31
       Name: '*uint'
       ByteSize: 8
@@ -241,18 +95,164 @@ Types:
       GoRuntimeType: 28480
       GoKind: 22
       Pointee: 6 BaseType uint16
+    - __kind: PointerType
+      ID: 21
+      Name: '*uint32'
+      ByteSize: 8
+      GoRuntimeType: 28608
+      GoKind: 22
+      Pointee: 2 BaseType uint32
+    - __kind: PointerType
+      ID: 28
+      Name: '*uint64'
+      ByteSize: 8
+      GoRuntimeType: 28736
+      GoKind: 22
+      Pointee: 8 BaseType uint64
+    - __kind: PointerType
+      ID: 5
+      Name: '*uint8'
+      ByteSize: 8
+      GoRuntimeType: 28352
+      GoKind: 22
+      Pointee: 3 BaseType uint8
+    - __kind: PointerType
+      ID: 19
+      Name: '*uintptr'
+      ByteSize: 8
+      GoRuntimeType: 28928
+      GoKind: 22
+      Pointee: 1 BaseType uintptr
+    - __kind: EventRootType
+      ID: 35
+      Name: Probe[main.noop]
+    - __kind: BaseType
+      ID: 4
+      Name: bool
+      ByteSize: 1
+      GoRuntimeType: 41632
+      GoKind: 1
+    - __kind: BaseType
+      ID: 24
+      Name: complex128
+      ByteSize: 16
+      GoRuntimeType: 41440
+      GoKind: 16
+    - __kind: BaseType
+      ID: 23
+      Name: complex64
+      ByteSize: 8
+      GoRuntimeType: 41376
+      GoKind: 15
+    - __kind: GoInterfaceType
+      ID: 13
+      Name: error
+      ByteSize: 16
+      GoRuntimeType: 62112
+      GoKind: 20
+      RawFields:
+        - Name: tab
+          Offset: 0
+          Type: 14 VoidPointerType unsafe.Pointer
+        - Name: data
+          Offset: 8
+          Type: 14 VoidPointerType unsafe.Pointer
+    - __kind: BaseType
+      ID: 17
+      Name: float32
+      ByteSize: 4
+      GoRuntimeType: 41504
+      GoKind: 13
+    - __kind: BaseType
+      ID: 18
+      Name: float64
+      ByteSize: 8
+      GoRuntimeType: 41568
+      GoKind: 14
+    - __kind: BaseType
+      ID: 7
+      Name: int
+      ByteSize: 8
+      GoRuntimeType: 41184
+      GoKind: 2
+    - __kind: BaseType
+      ID: 10
+      Name: int32
+      ByteSize: 4
+      GoRuntimeType: 40928
+      GoKind: 5
+    - __kind: BaseType
+      ID: 12
+      Name: int64
+      ByteSize: 8
+      GoRuntimeType: 41056
+      GoKind: 6
+    - __kind: BaseType
+      ID: 15
+      Name: int8
+      ByteSize: 1
+      GoRuntimeType: 40672
+      GoKind: 3
+    - __kind: GoStringHeaderType
+      ID: 9
+      Name: string
+      ByteSize: 16
+      GoRuntimeType: 40608
+      GoKind: 24
+      RawFields:
+        - Name: str
+          Offset: 0
+          Type: 34 PointerType *string.str
+        - Name: len
+          Offset: 8
+          Type: 7 BaseType int
+      Data: 33 GoStringDataType string.str
     - __kind: GoStringDataType
       ID: 33
       Name: string.str
       ByteSize: 2048
-    - __kind: PointerType
-      ID: 34
-      Name: '*string.str'
+    - __kind: BaseType
+      ID: 16
+      Name: uint
       ByteSize: 8
-      Pointee: 33 GoStringDataType string.str
-    - __kind: EventRootType
-      ID: 35
-      Name: Probe[main.noop]
+      GoRuntimeType: 41248
+      GoKind: 7
+    - __kind: BaseType
+      ID: 6
+      Name: uint16
+      ByteSize: 2
+      GoRuntimeType: 40864
+      GoKind: 9
+    - __kind: BaseType
+      ID: 2
+      Name: uint32
+      ByteSize: 4
+      GoRuntimeType: 40992
+      GoKind: 10
+    - __kind: BaseType
+      ID: 8
+      Name: uint64
+      ByteSize: 8
+      GoRuntimeType: 41120
+      GoKind: 11
+    - __kind: BaseType
+      ID: 3
+      Name: uint8
+      ByteSize: 1
+      GoRuntimeType: 40736
+      GoKind: 8
+    - __kind: BaseType
+      ID: 1
+      Name: uintptr
+      ByteSize: 8
+      GoRuntimeType: 41312
+      GoKind: 12
+    - __kind: VoidPointerType
+      ID: 14
+      Name: unsafe.Pointer
+      ByteSize: 8
+      GoRuntimeType: 41696
+      GoKind: 26
 MaxTypeID: 35
 Issues: []
 GoModuledataInfo: {FirstModuledataAddr: "0x57d340", TypesOffset: 296}

--- a/pkg/dyninst/irgen/testdata/snapshot/busyloop.arch=amd64,toolchain=go1.25.0.yaml
+++ b/pkg/dyninst/irgen/testdata/snapshot/busyloop.arch=amd64,toolchain=go1.25.0.yaml
@@ -20,75 +20,6 @@ Subprograms:
       InlinePCRanges: []
       Variables: []
 Types:
-    - __kind: BaseType
-      ID: 1
-      Name: uintptr
-      ByteSize: 8
-      GoRuntimeType: 42720
-      GoKind: 12
-    - __kind: BaseType
-      ID: 2
-      Name: uint32
-      ByteSize: 4
-      GoRuntimeType: 42400
-      GoKind: 10
-    - __kind: BaseType
-      ID: 3
-      Name: uint8
-      ByteSize: 1
-      GoRuntimeType: 42144
-      GoKind: 8
-    - __kind: BaseType
-      ID: 4
-      Name: bool
-      ByteSize: 1
-      GoRuntimeType: 43040
-      GoKind: 1
-    - __kind: PointerType
-      ID: 5
-      Name: '*uint8'
-      ByteSize: 8
-      GoRuntimeType: 29248
-      GoKind: 22
-      Pointee: 3 BaseType uint8
-    - __kind: BaseType
-      ID: 6
-      Name: uint16
-      ByteSize: 2
-      GoRuntimeType: 42272
-      GoKind: 9
-    - __kind: BaseType
-      ID: 7
-      Name: int
-      ByteSize: 8
-      GoRuntimeType: 42592
-      GoKind: 2
-    - __kind: BaseType
-      ID: 8
-      Name: uint64
-      ByteSize: 8
-      GoRuntimeType: 42528
-      GoKind: 11
-    - __kind: GoStringHeaderType
-      ID: 9
-      Name: string
-      ByteSize: 16
-      GoRuntimeType: 42016
-      GoKind: 24
-      RawFields:
-        - Name: str
-          Offset: 0
-          Type: 34 PointerType *string.str
-        - Name: len
-          Offset: 8
-          Type: 7 BaseType int
-      Data: 33 GoStringDataType string.str
-    - __kind: BaseType
-      ID: 10
-      Name: int32
-      ByteSize: 4
-      GoRuntimeType: 42336
-      GoKind: 5
     - __kind: PointerType
       ID: 11
       Name: '*bool'
@@ -96,123 +27,6 @@ Types:
       GoRuntimeType: 30144
       GoKind: 22
       Pointee: 4 BaseType bool
-    - __kind: BaseType
-      ID: 12
-      Name: int64
-      ByteSize: 8
-      GoRuntimeType: 42464
-      GoKind: 6
-    - __kind: GoInterfaceType
-      ID: 13
-      Name: error
-      ByteSize: 16
-      GoRuntimeType: 64832
-      GoKind: 20
-      RawFields:
-        - Name: tab
-          Offset: 0
-          Type: 14 VoidPointerType unsafe.Pointer
-        - Name: data
-          Offset: 8
-          Type: 14 VoidPointerType unsafe.Pointer
-    - __kind: VoidPointerType
-      ID: 14
-      Name: unsafe.Pointer
-      ByteSize: 8
-      GoRuntimeType: 43104
-      GoKind: 26
-    - __kind: BaseType
-      ID: 15
-      Name: float64
-      ByteSize: 8
-      GoRuntimeType: 42976
-      GoKind: 14
-    - __kind: BaseType
-      ID: 16
-      Name: int8
-      ByteSize: 1
-      GoRuntimeType: 42080
-      GoKind: 3
-    - __kind: BaseType
-      ID: 17
-      Name: uint
-      ByteSize: 8
-      GoRuntimeType: 42656
-      GoKind: 7
-    - __kind: BaseType
-      ID: 18
-      Name: float32
-      ByteSize: 4
-      GoRuntimeType: 42912
-      GoKind: 13
-    - __kind: PointerType
-      ID: 19
-      Name: '*uintptr'
-      ByteSize: 8
-      GoRuntimeType: 29824
-      GoKind: 22
-      Pointee: 1 BaseType uintptr
-    - __kind: PointerType
-      ID: 20
-      Name: '*int32'
-      ByteSize: 8
-      GoRuntimeType: 29440
-      GoKind: 22
-      Pointee: 10 BaseType int32
-    - __kind: PointerType
-      ID: 21
-      Name: '*uint32'
-      ByteSize: 8
-      GoRuntimeType: 29504
-      GoKind: 22
-      Pointee: 2 BaseType uint32
-    - __kind: PointerType
-      ID: 22
-      Name: '*string'
-      ByteSize: 8
-      GoRuntimeType: 29120
-      GoKind: 22
-      Pointee: 9 GoStringHeaderType string
-    - __kind: BaseType
-      ID: 23
-      Name: complex64
-      ByteSize: 8
-      GoRuntimeType: 42784
-      GoKind: 15
-    - __kind: BaseType
-      ID: 24
-      Name: complex128
-      ByteSize: 16
-      GoRuntimeType: 42848
-      GoKind: 16
-    - __kind: PointerType
-      ID: 25
-      Name: '*float64'
-      ByteSize: 8
-      GoRuntimeType: 30080
-      GoKind: 22
-      Pointee: 15 BaseType float64
-    - __kind: PointerType
-      ID: 26
-      Name: '*int'
-      ByteSize: 8
-      GoRuntimeType: 29696
-      GoKind: 22
-      Pointee: 7 BaseType int
-    - __kind: PointerType
-      ID: 27
-      Name: '*int64'
-      ByteSize: 8
-      GoRuntimeType: 29568
-      GoKind: 22
-      Pointee: 12 BaseType int64
-    - __kind: PointerType
-      ID: 28
-      Name: '*uint64'
-      ByteSize: 8
-      GoRuntimeType: 29632
-      GoKind: 22
-      Pointee: 8 BaseType uint64
     - __kind: PointerType
       ID: 29
       Name: '*error'
@@ -228,6 +42,46 @@ Types:
       GoKind: 22
       Pointee: 18 BaseType float32
     - __kind: PointerType
+      ID: 25
+      Name: '*float64'
+      ByteSize: 8
+      GoRuntimeType: 30080
+      GoKind: 22
+      Pointee: 15 BaseType float64
+    - __kind: PointerType
+      ID: 26
+      Name: '*int'
+      ByteSize: 8
+      GoRuntimeType: 29696
+      GoKind: 22
+      Pointee: 7 BaseType int
+    - __kind: PointerType
+      ID: 20
+      Name: '*int32'
+      ByteSize: 8
+      GoRuntimeType: 29440
+      GoKind: 22
+      Pointee: 10 BaseType int32
+    - __kind: PointerType
+      ID: 27
+      Name: '*int64'
+      ByteSize: 8
+      GoRuntimeType: 29568
+      GoKind: 22
+      Pointee: 12 BaseType int64
+    - __kind: PointerType
+      ID: 22
+      Name: '*string'
+      ByteSize: 8
+      GoRuntimeType: 29120
+      GoKind: 22
+      Pointee: 9 GoStringHeaderType string
+    - __kind: PointerType
+      ID: 34
+      Name: '*string.str'
+      ByteSize: 8
+      Pointee: 33 GoStringDataType string.str
+    - __kind: PointerType
       ID: 31
       Name: '*uint'
       ByteSize: 8
@@ -241,18 +95,164 @@ Types:
       GoRuntimeType: 29376
       GoKind: 22
       Pointee: 6 BaseType uint16
+    - __kind: PointerType
+      ID: 21
+      Name: '*uint32'
+      ByteSize: 8
+      GoRuntimeType: 29504
+      GoKind: 22
+      Pointee: 2 BaseType uint32
+    - __kind: PointerType
+      ID: 28
+      Name: '*uint64'
+      ByteSize: 8
+      GoRuntimeType: 29632
+      GoKind: 22
+      Pointee: 8 BaseType uint64
+    - __kind: PointerType
+      ID: 5
+      Name: '*uint8'
+      ByteSize: 8
+      GoRuntimeType: 29248
+      GoKind: 22
+      Pointee: 3 BaseType uint8
+    - __kind: PointerType
+      ID: 19
+      Name: '*uintptr'
+      ByteSize: 8
+      GoRuntimeType: 29824
+      GoKind: 22
+      Pointee: 1 BaseType uintptr
+    - __kind: EventRootType
+      ID: 35
+      Name: Probe[main.noop]
+    - __kind: BaseType
+      ID: 4
+      Name: bool
+      ByteSize: 1
+      GoRuntimeType: 43040
+      GoKind: 1
+    - __kind: BaseType
+      ID: 24
+      Name: complex128
+      ByteSize: 16
+      GoRuntimeType: 42848
+      GoKind: 16
+    - __kind: BaseType
+      ID: 23
+      Name: complex64
+      ByteSize: 8
+      GoRuntimeType: 42784
+      GoKind: 15
+    - __kind: GoInterfaceType
+      ID: 13
+      Name: error
+      ByteSize: 16
+      GoRuntimeType: 64832
+      GoKind: 20
+      RawFields:
+        - Name: tab
+          Offset: 0
+          Type: 14 VoidPointerType unsafe.Pointer
+        - Name: data
+          Offset: 8
+          Type: 14 VoidPointerType unsafe.Pointer
+    - __kind: BaseType
+      ID: 18
+      Name: float32
+      ByteSize: 4
+      GoRuntimeType: 42912
+      GoKind: 13
+    - __kind: BaseType
+      ID: 15
+      Name: float64
+      ByteSize: 8
+      GoRuntimeType: 42976
+      GoKind: 14
+    - __kind: BaseType
+      ID: 7
+      Name: int
+      ByteSize: 8
+      GoRuntimeType: 42592
+      GoKind: 2
+    - __kind: BaseType
+      ID: 10
+      Name: int32
+      ByteSize: 4
+      GoRuntimeType: 42336
+      GoKind: 5
+    - __kind: BaseType
+      ID: 12
+      Name: int64
+      ByteSize: 8
+      GoRuntimeType: 42464
+      GoKind: 6
+    - __kind: BaseType
+      ID: 16
+      Name: int8
+      ByteSize: 1
+      GoRuntimeType: 42080
+      GoKind: 3
+    - __kind: GoStringHeaderType
+      ID: 9
+      Name: string
+      ByteSize: 16
+      GoRuntimeType: 42016
+      GoKind: 24
+      RawFields:
+        - Name: str
+          Offset: 0
+          Type: 34 PointerType *string.str
+        - Name: len
+          Offset: 8
+          Type: 7 BaseType int
+      Data: 33 GoStringDataType string.str
     - __kind: GoStringDataType
       ID: 33
       Name: string.str
       ByteSize: 2048
-    - __kind: PointerType
-      ID: 34
-      Name: '*string.str'
+    - __kind: BaseType
+      ID: 17
+      Name: uint
       ByteSize: 8
-      Pointee: 33 GoStringDataType string.str
-    - __kind: EventRootType
-      ID: 35
-      Name: Probe[main.noop]
+      GoRuntimeType: 42656
+      GoKind: 7
+    - __kind: BaseType
+      ID: 6
+      Name: uint16
+      ByteSize: 2
+      GoRuntimeType: 42272
+      GoKind: 9
+    - __kind: BaseType
+      ID: 2
+      Name: uint32
+      ByteSize: 4
+      GoRuntimeType: 42400
+      GoKind: 10
+    - __kind: BaseType
+      ID: 8
+      Name: uint64
+      ByteSize: 8
+      GoRuntimeType: 42528
+      GoKind: 11
+    - __kind: BaseType
+      ID: 3
+      Name: uint8
+      ByteSize: 1
+      GoRuntimeType: 42144
+      GoKind: 8
+    - __kind: BaseType
+      ID: 1
+      Name: uintptr
+      ByteSize: 8
+      GoRuntimeType: 42720
+      GoKind: 12
+    - __kind: VoidPointerType
+      ID: 14
+      Name: unsafe.Pointer
+      ByteSize: 8
+      GoRuntimeType: 43104
+      GoKind: 26
 MaxTypeID: 35
 Issues: []
 GoModuledataInfo: {FirstModuledataAddr: "0x58b3a0", TypesOffset: 296}

--- a/pkg/dyninst/irgen/testdata/snapshot/busyloop.arch=arm64,toolchain=go1.23.11.yaml
+++ b/pkg/dyninst/irgen/testdata/snapshot/busyloop.arch=arm64,toolchain=go1.23.11.yaml
@@ -11,7 +11,7 @@ Probes:
       events:
         - ID: 1
           Type: 36 EventRootType Probe[main.noop]
-          InjectionPoints: [{PC: 742032, Frameless: true}]
+          InjectionPoints: [{PC: "0xb5290", Frameless: true}]
           Condition: null
 Subprograms:
     - ID: 1
@@ -20,30 +20,6 @@ Subprograms:
       InlinePCRanges: []
       Variables: []
 Types:
-    - __kind: BaseType
-      ID: 1
-      Name: uintptr
-      ByteSize: 8
-      GoRuntimeType: 37472
-      GoKind: 12
-    - __kind: BaseType
-      ID: 2
-      Name: uint32
-      ByteSize: 4
-      GoRuntimeType: 37152
-      GoKind: 10
-    - __kind: BaseType
-      ID: 3
-      Name: uint8
-      ByteSize: 1
-      GoRuntimeType: 36896
-      GoKind: 8
-    - __kind: BaseType
-      ID: 4
-      Name: bool
-      ByteSize: 1
-      GoRuntimeType: 37792
-      GoKind: 1
     - __kind: PointerType
       ID: 5
       Name: '*bool'
@@ -52,18 +28,94 @@ Types:
       GoKind: 22
       Pointee: 4 BaseType bool
     - __kind: PointerType
+      ID: 30
+      Name: '*error'
+      ByteSize: 8
+      GoRuntimeType: 25632
+      GoKind: 22
+      Pointee: 18 GoInterfaceType error
+    - __kind: PointerType
+      ID: 31
+      Name: '*float32'
+      ByteSize: 8
+      GoRuntimeType: 26592
+      GoKind: 22
+      Pointee: 16 BaseType float32
+    - __kind: PointerType
+      ID: 26
+      Name: '*float64'
+      ByteSize: 8
+      GoRuntimeType: 26656
+      GoKind: 22
+      Pointee: 17 BaseType float64
+    - __kind: PointerType
+      ID: 28
+      Name: '*int'
+      ByteSize: 8
+      GoRuntimeType: 26272
+      GoKind: 22
+      Pointee: 9 BaseType int
+    - __kind: PointerType
+      ID: 20
+      Name: '*int32'
+      ByteSize: 8
+      GoRuntimeType: 26016
+      GoKind: 22
+      Pointee: 13 BaseType int32
+    - __kind: PointerType
+      ID: 27
+      Name: '*int64'
+      ByteSize: 8
+      GoRuntimeType: 26144
+      GoKind: 22
+      Pointee: 14 BaseType int64
+    - __kind: PointerType
+      ID: 22
+      Name: '*string'
+      ByteSize: 8
+      GoRuntimeType: 25696
+      GoKind: 22
+      Pointee: 10 GoStringHeaderType string
+    - __kind: PointerType
+      ID: 35
+      Name: '*string.str'
+      ByteSize: 8
+      Pointee: 34 GoStringDataType string.str
+    - __kind: PointerType
+      ID: 32
+      Name: '*uint'
+      ByteSize: 8
+      GoRuntimeType: 26336
+      GoKind: 22
+      Pointee: 12 BaseType uint
+    - __kind: PointerType
+      ID: 33
+      Name: '*uint16'
+      ByteSize: 8
+      GoRuntimeType: 25952
+      GoKind: 22
+      Pointee: 7 BaseType uint16
+    - __kind: PointerType
+      ID: 21
+      Name: '*uint32'
+      ByteSize: 8
+      GoRuntimeType: 26080
+      GoKind: 22
+      Pointee: 2 BaseType uint32
+    - __kind: PointerType
+      ID: 29
+      Name: '*uint64'
+      ByteSize: 8
+      GoRuntimeType: 26208
+      GoKind: 22
+      Pointee: 11 BaseType uint64
+    - __kind: PointerType
       ID: 6
       Name: '*uint8'
       ByteSize: 8
       GoRuntimeType: 25824
       GoKind: 22
       Pointee: 3 BaseType uint8
-    - __kind: BaseType
-      ID: 7
-      Name: uint16
-      ByteSize: 2
-      GoRuntimeType: 37024
-      GoKind: 9
     - __kind: PointerType
       ID: 8
       Name: '*uintptr'
@@ -71,38 +123,64 @@ Types:
       GoRuntimeType: 26400
       GoKind: 22
       Pointee: 1 BaseType uintptr
+    - __kind: EventRootType
+      ID: 36
+      Name: Probe[main.noop]
+    - __kind: BaseType
+      ID: 4
+      Name: bool
+      ByteSize: 1
+      GoRuntimeType: 37792
+      GoKind: 1
+    - __kind: BaseType
+      ID: 25
+      Name: complex128
+      ByteSize: 16
+      GoRuntimeType: 37600
+      GoKind: 16
+    - __kind: BaseType
+      ID: 24
+      Name: complex64
+      ByteSize: 8
+      GoRuntimeType: 37536
+      GoKind: 15
+    - __kind: GoInterfaceType
+      ID: 18
+      Name: error
+      ByteSize: 16
+      GoRuntimeType: 57856
+      GoKind: 20
+      RawFields:
+        - Name: tab
+          Offset: 0
+          Type: 19 VoidPointerType unsafe.Pointer
+        - Name: data
+          Offset: 8
+          Type: 19 VoidPointerType unsafe.Pointer
+    - __kind: BaseType
+      ID: 16
+      Name: float32
+      ByteSize: 4
+      GoRuntimeType: 37664
+      GoKind: 13
+    - __kind: BaseType
+      ID: 17
+      Name: float64
+      ByteSize: 8
+      GoRuntimeType: 37728
+      GoKind: 14
     - __kind: BaseType
       ID: 9
       Name: int
       ByteSize: 8
       GoRuntimeType: 37344
       GoKind: 2
-    - __kind: GoStringHeaderType
-      ID: 10
-      Name: string
-      ByteSize: 16
-      GoRuntimeType: 36768
-      GoKind: 24
-      RawFields:
-        - Name: str
-          Offset: 0
-          Type: 35 PointerType *string.str
-        - Name: len
-          Offset: 8
-          Type: 9 BaseType int
-      Data: 34 GoStringDataType string.str
     - __kind: BaseType
-      ID: 11
-      Name: uint64
-      ByteSize: 8
-      GoRuntimeType: 37280
-      GoKind: 11
-    - __kind: BaseType
-      ID: 12
-      Name: uint
-      ByteSize: 8
-      GoRuntimeType: 37408
-      GoKind: 7
+      ID: 23
+      Name: int16
+      ByteSize: 2
+      GoRuntimeType: 36960
+      GoKind: 4
     - __kind: BaseType
       ID: 13
       Name: int32
@@ -121,144 +199,66 @@ Types:
       ByteSize: 1
       GoRuntimeType: 36832
       GoKind: 3
-    - __kind: BaseType
-      ID: 16
-      Name: float32
-      ByteSize: 4
-      GoRuntimeType: 37664
-      GoKind: 13
-    - __kind: BaseType
-      ID: 17
-      Name: float64
-      ByteSize: 8
-      GoRuntimeType: 37728
-      GoKind: 14
-    - __kind: GoInterfaceType
-      ID: 18
-      Name: error
+    - __kind: GoStringHeaderType
+      ID: 10
+      Name: string
       ByteSize: 16
-      GoRuntimeType: 57856
-      GoKind: 20
+      GoRuntimeType: 36768
+      GoKind: 24
       RawFields:
-        - Name: tab
+        - Name: str
           Offset: 0
-          Type: 19 VoidPointerType unsafe.Pointer
-        - Name: data
+          Type: 35 PointerType *string.str
+        - Name: len
           Offset: 8
-          Type: 19 VoidPointerType unsafe.Pointer
+          Type: 9 BaseType int
+      Data: 34 GoStringDataType string.str
+    - __kind: GoStringDataType
+      ID: 34
+      Name: string.str
+      ByteSize: 2048
+    - __kind: BaseType
+      ID: 12
+      Name: uint
+      ByteSize: 8
+      GoRuntimeType: 37408
+      GoKind: 7
+    - __kind: BaseType
+      ID: 7
+      Name: uint16
+      ByteSize: 2
+      GoRuntimeType: 37024
+      GoKind: 9
+    - __kind: BaseType
+      ID: 2
+      Name: uint32
+      ByteSize: 4
+      GoRuntimeType: 37152
+      GoKind: 10
+    - __kind: BaseType
+      ID: 11
+      Name: uint64
+      ByteSize: 8
+      GoRuntimeType: 37280
+      GoKind: 11
+    - __kind: BaseType
+      ID: 3
+      Name: uint8
+      ByteSize: 1
+      GoRuntimeType: 36896
+      GoKind: 8
+    - __kind: BaseType
+      ID: 1
+      Name: uintptr
+      ByteSize: 8
+      GoRuntimeType: 37472
+      GoKind: 12
     - __kind: VoidPointerType
       ID: 19
       Name: unsafe.Pointer
       ByteSize: 8
       GoRuntimeType: 37856
       GoKind: 26
-    - __kind: PointerType
-      ID: 20
-      Name: '*int32'
-      ByteSize: 8
-      GoRuntimeType: 26016
-      GoKind: 22
-      Pointee: 13 BaseType int32
-    - __kind: PointerType
-      ID: 21
-      Name: '*uint32'
-      ByteSize: 8
-      GoRuntimeType: 26080
-      GoKind: 22
-      Pointee: 2 BaseType uint32
-    - __kind: PointerType
-      ID: 22
-      Name: '*string'
-      ByteSize: 8
-      GoRuntimeType: 25696
-      GoKind: 22
-      Pointee: 10 GoStringHeaderType string
-    - __kind: BaseType
-      ID: 23
-      Name: int16
-      ByteSize: 2
-      GoRuntimeType: 36960
-      GoKind: 4
-    - __kind: BaseType
-      ID: 24
-      Name: complex64
-      ByteSize: 8
-      GoRuntimeType: 37536
-      GoKind: 15
-    - __kind: BaseType
-      ID: 25
-      Name: complex128
-      ByteSize: 16
-      GoRuntimeType: 37600
-      GoKind: 16
-    - __kind: PointerType
-      ID: 26
-      Name: '*float64'
-      ByteSize: 8
-      GoRuntimeType: 26656
-      GoKind: 22
-      Pointee: 17 BaseType float64
-    - __kind: PointerType
-      ID: 27
-      Name: '*int64'
-      ByteSize: 8
-      GoRuntimeType: 26144
-      GoKind: 22
-      Pointee: 14 BaseType int64
-    - __kind: PointerType
-      ID: 28
-      Name: '*int'
-      ByteSize: 8
-      GoRuntimeType: 26272
-      GoKind: 22
-      Pointee: 9 BaseType int
-    - __kind: PointerType
-      ID: 29
-      Name: '*uint64'
-      ByteSize: 8
-      GoRuntimeType: 26208
-      GoKind: 22
-      Pointee: 11 BaseType uint64
-    - __kind: PointerType
-      ID: 30
-      Name: '*error'
-      ByteSize: 8
-      GoRuntimeType: 25632
-      GoKind: 22
-      Pointee: 18 GoInterfaceType error
-    - __kind: PointerType
-      ID: 31
-      Name: '*float32'
-      ByteSize: 8
-      GoRuntimeType: 26592
-      GoKind: 22
-      Pointee: 16 BaseType float32
-    - __kind: PointerType
-      ID: 32
-      Name: '*uint'
-      ByteSize: 8
-      GoRuntimeType: 26336
-      GoKind: 22
-      Pointee: 12 BaseType uint
-    - __kind: PointerType
-      ID: 33
-      Name: '*uint16'
-      ByteSize: 8
-      GoRuntimeType: 25952
-      GoKind: 22
-      Pointee: 7 BaseType uint16
-    - __kind: GoStringDataType
-      ID: 34
-      Name: string.str
-      ByteSize: 2048
-    - __kind: PointerType
-      ID: 35
-      Name: '*string.str'
-      ByteSize: 8
-      Pointee: 34 GoStringDataType string.str
-    - __kind: EventRootType
-      ID: 36
-      Name: Probe[main.noop]
 MaxTypeID: 36
 Issues: []
 GoModuledataInfo: {FirstModuledataAddr: "0x191240", TypesOffset: 296}

--- a/pkg/dyninst/irgen/testdata/snapshot/busyloop.arch=arm64,toolchain=go1.24.3.yaml
+++ b/pkg/dyninst/irgen/testdata/snapshot/busyloop.arch=arm64,toolchain=go1.24.3.yaml
@@ -11,7 +11,7 @@ Probes:
       events:
         - ID: 1
           Type: 36 EventRootType Probe[main.noop]
-          InjectionPoints: [{PC: 741744, Frameless: true}]
+          InjectionPoints: [{PC: "0xb5170", Frameless: true}]
           Condition: null
 Subprograms:
     - ID: 1
@@ -20,75 +20,6 @@ Subprograms:
       InlinePCRanges: []
       Variables: []
 Types:
-    - __kind: BaseType
-      ID: 1
-      Name: uintptr
-      ByteSize: 8
-      GoRuntimeType: 41280
-      GoKind: 12
-    - __kind: BaseType
-      ID: 2
-      Name: uint32
-      ByteSize: 4
-      GoRuntimeType: 40960
-      GoKind: 10
-    - __kind: BaseType
-      ID: 3
-      Name: uint8
-      ByteSize: 1
-      GoRuntimeType: 40704
-      GoKind: 8
-    - __kind: BaseType
-      ID: 4
-      Name: bool
-      ByteSize: 1
-      GoRuntimeType: 41600
-      GoKind: 1
-    - __kind: PointerType
-      ID: 5
-      Name: '*uint8'
-      ByteSize: 8
-      GoRuntimeType: 28320
-      GoKind: 22
-      Pointee: 3 BaseType uint8
-    - __kind: BaseType
-      ID: 6
-      Name: uint16
-      ByteSize: 2
-      GoRuntimeType: 40832
-      GoKind: 9
-    - __kind: BaseType
-      ID: 7
-      Name: int
-      ByteSize: 8
-      GoRuntimeType: 41152
-      GoKind: 2
-    - __kind: BaseType
-      ID: 8
-      Name: uint64
-      ByteSize: 8
-      GoRuntimeType: 41088
-      GoKind: 11
-    - __kind: GoStringHeaderType
-      ID: 9
-      Name: string
-      ByteSize: 16
-      GoRuntimeType: 40576
-      GoKind: 24
-      RawFields:
-        - Name: str
-          Offset: 0
-          Type: 35 PointerType *string.str
-        - Name: len
-          Offset: 8
-          Type: 7 BaseType int
-      Data: 34 GoStringDataType string.str
-    - __kind: BaseType
-      ID: 10
-      Name: uint
-      ByteSize: 8
-      GoRuntimeType: 41216
-      GoKind: 7
     - __kind: PointerType
       ID: 11
       Name: '*bool'
@@ -96,129 +27,6 @@ Types:
       GoRuntimeType: 29216
       GoKind: 22
       Pointee: 4 BaseType bool
-    - __kind: BaseType
-      ID: 12
-      Name: int32
-      ByteSize: 4
-      GoRuntimeType: 40896
-      GoKind: 5
-    - __kind: BaseType
-      ID: 13
-      Name: int64
-      ByteSize: 8
-      GoRuntimeType: 41024
-      GoKind: 6
-    - __kind: GoInterfaceType
-      ID: 14
-      Name: error
-      ByteSize: 16
-      GoRuntimeType: 61984
-      GoKind: 20
-      RawFields:
-        - Name: tab
-          Offset: 0
-          Type: 15 VoidPointerType unsafe.Pointer
-        - Name: data
-          Offset: 8
-          Type: 15 VoidPointerType unsafe.Pointer
-    - __kind: VoidPointerType
-      ID: 15
-      Name: unsafe.Pointer
-      ByteSize: 8
-      GoRuntimeType: 41664
-      GoKind: 26
-    - __kind: BaseType
-      ID: 16
-      Name: int8
-      ByteSize: 1
-      GoRuntimeType: 40640
-      GoKind: 3
-    - __kind: BaseType
-      ID: 17
-      Name: float32
-      ByteSize: 4
-      GoRuntimeType: 41472
-      GoKind: 13
-    - __kind: BaseType
-      ID: 18
-      Name: float64
-      ByteSize: 8
-      GoRuntimeType: 41536
-      GoKind: 14
-    - __kind: PointerType
-      ID: 19
-      Name: '*uintptr'
-      ByteSize: 8
-      GoRuntimeType: 28896
-      GoKind: 22
-      Pointee: 1 BaseType uintptr
-    - __kind: PointerType
-      ID: 20
-      Name: '*int32'
-      ByteSize: 8
-      GoRuntimeType: 28512
-      GoKind: 22
-      Pointee: 12 BaseType int32
-    - __kind: PointerType
-      ID: 21
-      Name: '*uint32'
-      ByteSize: 8
-      GoRuntimeType: 28576
-      GoKind: 22
-      Pointee: 2 BaseType uint32
-    - __kind: PointerType
-      ID: 22
-      Name: '*string'
-      ByteSize: 8
-      GoRuntimeType: 28192
-      GoKind: 22
-      Pointee: 9 GoStringHeaderType string
-    - __kind: BaseType
-      ID: 23
-      Name: int16
-      ByteSize: 2
-      GoRuntimeType: 40768
-      GoKind: 4
-    - __kind: BaseType
-      ID: 24
-      Name: complex64
-      ByteSize: 8
-      GoRuntimeType: 41344
-      GoKind: 15
-    - __kind: BaseType
-      ID: 25
-      Name: complex128
-      ByteSize: 16
-      GoRuntimeType: 41408
-      GoKind: 16
-    - __kind: PointerType
-      ID: 26
-      Name: '*float64'
-      ByteSize: 8
-      GoRuntimeType: 29152
-      GoKind: 22
-      Pointee: 18 BaseType float64
-    - __kind: PointerType
-      ID: 27
-      Name: '*int64'
-      ByteSize: 8
-      GoRuntimeType: 28640
-      GoKind: 22
-      Pointee: 13 BaseType int64
-    - __kind: PointerType
-      ID: 28
-      Name: '*int'
-      ByteSize: 8
-      GoRuntimeType: 28768
-      GoKind: 22
-      Pointee: 7 BaseType int
-    - __kind: PointerType
-      ID: 29
-      Name: '*uint64'
-      ByteSize: 8
-      GoRuntimeType: 28704
-      GoKind: 22
-      Pointee: 8 BaseType uint64
     - __kind: PointerType
       ID: 30
       Name: '*error'
@@ -234,6 +42,46 @@ Types:
       GoKind: 22
       Pointee: 17 BaseType float32
     - __kind: PointerType
+      ID: 26
+      Name: '*float64'
+      ByteSize: 8
+      GoRuntimeType: 29152
+      GoKind: 22
+      Pointee: 18 BaseType float64
+    - __kind: PointerType
+      ID: 28
+      Name: '*int'
+      ByteSize: 8
+      GoRuntimeType: 28768
+      GoKind: 22
+      Pointee: 7 BaseType int
+    - __kind: PointerType
+      ID: 20
+      Name: '*int32'
+      ByteSize: 8
+      GoRuntimeType: 28512
+      GoKind: 22
+      Pointee: 12 BaseType int32
+    - __kind: PointerType
+      ID: 27
+      Name: '*int64'
+      ByteSize: 8
+      GoRuntimeType: 28640
+      GoKind: 22
+      Pointee: 13 BaseType int64
+    - __kind: PointerType
+      ID: 22
+      Name: '*string'
+      ByteSize: 8
+      GoRuntimeType: 28192
+      GoKind: 22
+      Pointee: 9 GoStringHeaderType string
+    - __kind: PointerType
+      ID: 35
+      Name: '*string.str'
+      ByteSize: 8
+      Pointee: 34 GoStringDataType string.str
+    - __kind: PointerType
       ID: 32
       Name: '*uint'
       ByteSize: 8
@@ -247,18 +95,170 @@ Types:
       GoRuntimeType: 28448
       GoKind: 22
       Pointee: 6 BaseType uint16
+    - __kind: PointerType
+      ID: 21
+      Name: '*uint32'
+      ByteSize: 8
+      GoRuntimeType: 28576
+      GoKind: 22
+      Pointee: 2 BaseType uint32
+    - __kind: PointerType
+      ID: 29
+      Name: '*uint64'
+      ByteSize: 8
+      GoRuntimeType: 28704
+      GoKind: 22
+      Pointee: 8 BaseType uint64
+    - __kind: PointerType
+      ID: 5
+      Name: '*uint8'
+      ByteSize: 8
+      GoRuntimeType: 28320
+      GoKind: 22
+      Pointee: 3 BaseType uint8
+    - __kind: PointerType
+      ID: 19
+      Name: '*uintptr'
+      ByteSize: 8
+      GoRuntimeType: 28896
+      GoKind: 22
+      Pointee: 1 BaseType uintptr
+    - __kind: EventRootType
+      ID: 36
+      Name: Probe[main.noop]
+    - __kind: BaseType
+      ID: 4
+      Name: bool
+      ByteSize: 1
+      GoRuntimeType: 41600
+      GoKind: 1
+    - __kind: BaseType
+      ID: 25
+      Name: complex128
+      ByteSize: 16
+      GoRuntimeType: 41408
+      GoKind: 16
+    - __kind: BaseType
+      ID: 24
+      Name: complex64
+      ByteSize: 8
+      GoRuntimeType: 41344
+      GoKind: 15
+    - __kind: GoInterfaceType
+      ID: 14
+      Name: error
+      ByteSize: 16
+      GoRuntimeType: 61984
+      GoKind: 20
+      RawFields:
+        - Name: tab
+          Offset: 0
+          Type: 15 VoidPointerType unsafe.Pointer
+        - Name: data
+          Offset: 8
+          Type: 15 VoidPointerType unsafe.Pointer
+    - __kind: BaseType
+      ID: 17
+      Name: float32
+      ByteSize: 4
+      GoRuntimeType: 41472
+      GoKind: 13
+    - __kind: BaseType
+      ID: 18
+      Name: float64
+      ByteSize: 8
+      GoRuntimeType: 41536
+      GoKind: 14
+    - __kind: BaseType
+      ID: 7
+      Name: int
+      ByteSize: 8
+      GoRuntimeType: 41152
+      GoKind: 2
+    - __kind: BaseType
+      ID: 23
+      Name: int16
+      ByteSize: 2
+      GoRuntimeType: 40768
+      GoKind: 4
+    - __kind: BaseType
+      ID: 12
+      Name: int32
+      ByteSize: 4
+      GoRuntimeType: 40896
+      GoKind: 5
+    - __kind: BaseType
+      ID: 13
+      Name: int64
+      ByteSize: 8
+      GoRuntimeType: 41024
+      GoKind: 6
+    - __kind: BaseType
+      ID: 16
+      Name: int8
+      ByteSize: 1
+      GoRuntimeType: 40640
+      GoKind: 3
+    - __kind: GoStringHeaderType
+      ID: 9
+      Name: string
+      ByteSize: 16
+      GoRuntimeType: 40576
+      GoKind: 24
+      RawFields:
+        - Name: str
+          Offset: 0
+          Type: 35 PointerType *string.str
+        - Name: len
+          Offset: 8
+          Type: 7 BaseType int
+      Data: 34 GoStringDataType string.str
     - __kind: GoStringDataType
       ID: 34
       Name: string.str
       ByteSize: 2048
-    - __kind: PointerType
-      ID: 35
-      Name: '*string.str'
+    - __kind: BaseType
+      ID: 10
+      Name: uint
       ByteSize: 8
-      Pointee: 34 GoStringDataType string.str
-    - __kind: EventRootType
-      ID: 36
-      Name: Probe[main.noop]
+      GoRuntimeType: 41216
+      GoKind: 7
+    - __kind: BaseType
+      ID: 6
+      Name: uint16
+      ByteSize: 2
+      GoRuntimeType: 40832
+      GoKind: 9
+    - __kind: BaseType
+      ID: 2
+      Name: uint32
+      ByteSize: 4
+      GoRuntimeType: 40960
+      GoKind: 10
+    - __kind: BaseType
+      ID: 8
+      Name: uint64
+      ByteSize: 8
+      GoRuntimeType: 41088
+      GoKind: 11
+    - __kind: BaseType
+      ID: 3
+      Name: uint8
+      ByteSize: 1
+      GoRuntimeType: 40704
+      GoKind: 8
+    - __kind: BaseType
+      ID: 1
+      Name: uintptr
+      ByteSize: 8
+      GoRuntimeType: 41280
+      GoKind: 12
+    - __kind: VoidPointerType
+      ID: 15
+      Name: unsafe.Pointer
+      ByteSize: 8
+      GoRuntimeType: 41664
+      GoKind: 26
 MaxTypeID: 36
 Issues: []
 GoModuledataInfo: {FirstModuledataAddr: "0x191360", TypesOffset: 296}

--- a/pkg/dyninst/irgen/testdata/snapshot/busyloop.arch=arm64,toolchain=go1.25.0.yaml
+++ b/pkg/dyninst/irgen/testdata/snapshot/busyloop.arch=arm64,toolchain=go1.25.0.yaml
@@ -11,7 +11,7 @@ Probes:
       events:
         - ID: 1
           Type: 36 EventRootType Probe[main.noop]
-          InjectionPoints: [{PC: 752912, Frameless: true}]
+          InjectionPoints: [{PC: "0xb7d10", Frameless: true}]
           Condition: null
 Subprograms:
     - ID: 1
@@ -20,75 +20,6 @@ Subprograms:
       InlinePCRanges: []
       Variables: []
 Types:
-    - __kind: BaseType
-      ID: 1
-      Name: uintptr
-      ByteSize: 8
-      GoRuntimeType: 42720
-      GoKind: 12
-    - __kind: BaseType
-      ID: 2
-      Name: uint32
-      ByteSize: 4
-      GoRuntimeType: 42400
-      GoKind: 10
-    - __kind: BaseType
-      ID: 3
-      Name: uint8
-      ByteSize: 1
-      GoRuntimeType: 42144
-      GoKind: 8
-    - __kind: BaseType
-      ID: 4
-      Name: bool
-      ByteSize: 1
-      GoRuntimeType: 43040
-      GoKind: 1
-    - __kind: PointerType
-      ID: 5
-      Name: '*uint8'
-      ByteSize: 8
-      GoRuntimeType: 29248
-      GoKind: 22
-      Pointee: 3 BaseType uint8
-    - __kind: BaseType
-      ID: 6
-      Name: uint16
-      ByteSize: 2
-      GoRuntimeType: 42272
-      GoKind: 9
-    - __kind: BaseType
-      ID: 7
-      Name: int
-      ByteSize: 8
-      GoRuntimeType: 42592
-      GoKind: 2
-    - __kind: BaseType
-      ID: 8
-      Name: uint64
-      ByteSize: 8
-      GoRuntimeType: 42528
-      GoKind: 11
-    - __kind: GoStringHeaderType
-      ID: 9
-      Name: string
-      ByteSize: 16
-      GoRuntimeType: 42016
-      GoKind: 24
-      RawFields:
-        - Name: str
-          Offset: 0
-          Type: 35 PointerType *string.str
-        - Name: len
-          Offset: 8
-          Type: 7 BaseType int
-      Data: 34 GoStringDataType string.str
-    - __kind: BaseType
-      ID: 10
-      Name: uint
-      ByteSize: 8
-      GoRuntimeType: 42656
-      GoKind: 7
     - __kind: PointerType
       ID: 11
       Name: '*bool'
@@ -96,129 +27,6 @@ Types:
       GoRuntimeType: 30144
       GoKind: 22
       Pointee: 4 BaseType bool
-    - __kind: BaseType
-      ID: 12
-      Name: int32
-      ByteSize: 4
-      GoRuntimeType: 42336
-      GoKind: 5
-    - __kind: BaseType
-      ID: 13
-      Name: int64
-      ByteSize: 8
-      GoRuntimeType: 42464
-      GoKind: 6
-    - __kind: GoInterfaceType
-      ID: 14
-      Name: error
-      ByteSize: 16
-      GoRuntimeType: 64736
-      GoKind: 20
-      RawFields:
-        - Name: tab
-          Offset: 0
-          Type: 15 VoidPointerType unsafe.Pointer
-        - Name: data
-          Offset: 8
-          Type: 15 VoidPointerType unsafe.Pointer
-    - __kind: VoidPointerType
-      ID: 15
-      Name: unsafe.Pointer
-      ByteSize: 8
-      GoRuntimeType: 43104
-      GoKind: 26
-    - __kind: BaseType
-      ID: 16
-      Name: float64
-      ByteSize: 8
-      GoRuntimeType: 42976
-      GoKind: 14
-    - __kind: BaseType
-      ID: 17
-      Name: int8
-      ByteSize: 1
-      GoRuntimeType: 42080
-      GoKind: 3
-    - __kind: BaseType
-      ID: 18
-      Name: float32
-      ByteSize: 4
-      GoRuntimeType: 42912
-      GoKind: 13
-    - __kind: PointerType
-      ID: 19
-      Name: '*uintptr'
-      ByteSize: 8
-      GoRuntimeType: 29824
-      GoKind: 22
-      Pointee: 1 BaseType uintptr
-    - __kind: PointerType
-      ID: 20
-      Name: '*int32'
-      ByteSize: 8
-      GoRuntimeType: 29440
-      GoKind: 22
-      Pointee: 12 BaseType int32
-    - __kind: PointerType
-      ID: 21
-      Name: '*uint32'
-      ByteSize: 8
-      GoRuntimeType: 29504
-      GoKind: 22
-      Pointee: 2 BaseType uint32
-    - __kind: PointerType
-      ID: 22
-      Name: '*string'
-      ByteSize: 8
-      GoRuntimeType: 29120
-      GoKind: 22
-      Pointee: 9 GoStringHeaderType string
-    - __kind: BaseType
-      ID: 23
-      Name: int16
-      ByteSize: 2
-      GoRuntimeType: 42208
-      GoKind: 4
-    - __kind: BaseType
-      ID: 24
-      Name: complex64
-      ByteSize: 8
-      GoRuntimeType: 42784
-      GoKind: 15
-    - __kind: BaseType
-      ID: 25
-      Name: complex128
-      ByteSize: 16
-      GoRuntimeType: 42848
-      GoKind: 16
-    - __kind: PointerType
-      ID: 26
-      Name: '*float64'
-      ByteSize: 8
-      GoRuntimeType: 30080
-      GoKind: 22
-      Pointee: 16 BaseType float64
-    - __kind: PointerType
-      ID: 27
-      Name: '*int'
-      ByteSize: 8
-      GoRuntimeType: 29696
-      GoKind: 22
-      Pointee: 7 BaseType int
-    - __kind: PointerType
-      ID: 28
-      Name: '*uint64'
-      ByteSize: 8
-      GoRuntimeType: 29632
-      GoKind: 22
-      Pointee: 8 BaseType uint64
-    - __kind: PointerType
-      ID: 29
-      Name: '*int64'
-      ByteSize: 8
-      GoRuntimeType: 29568
-      GoKind: 22
-      Pointee: 13 BaseType int64
     - __kind: PointerType
       ID: 30
       Name: '*error'
@@ -234,6 +42,46 @@ Types:
       GoKind: 22
       Pointee: 18 BaseType float32
     - __kind: PointerType
+      ID: 26
+      Name: '*float64'
+      ByteSize: 8
+      GoRuntimeType: 30080
+      GoKind: 22
+      Pointee: 16 BaseType float64
+    - __kind: PointerType
+      ID: 27
+      Name: '*int'
+      ByteSize: 8
+      GoRuntimeType: 29696
+      GoKind: 22
+      Pointee: 7 BaseType int
+    - __kind: PointerType
+      ID: 20
+      Name: '*int32'
+      ByteSize: 8
+      GoRuntimeType: 29440
+      GoKind: 22
+      Pointee: 12 BaseType int32
+    - __kind: PointerType
+      ID: 29
+      Name: '*int64'
+      ByteSize: 8
+      GoRuntimeType: 29568
+      GoKind: 22
+      Pointee: 13 BaseType int64
+    - __kind: PointerType
+      ID: 22
+      Name: '*string'
+      ByteSize: 8
+      GoRuntimeType: 29120
+      GoKind: 22
+      Pointee: 9 GoStringHeaderType string
+    - __kind: PointerType
+      ID: 35
+      Name: '*string.str'
+      ByteSize: 8
+      Pointee: 34 GoStringDataType string.str
+    - __kind: PointerType
       ID: 32
       Name: '*uint'
       ByteSize: 8
@@ -247,18 +95,170 @@ Types:
       GoRuntimeType: 29376
       GoKind: 22
       Pointee: 6 BaseType uint16
+    - __kind: PointerType
+      ID: 21
+      Name: '*uint32'
+      ByteSize: 8
+      GoRuntimeType: 29504
+      GoKind: 22
+      Pointee: 2 BaseType uint32
+    - __kind: PointerType
+      ID: 28
+      Name: '*uint64'
+      ByteSize: 8
+      GoRuntimeType: 29632
+      GoKind: 22
+      Pointee: 8 BaseType uint64
+    - __kind: PointerType
+      ID: 5
+      Name: '*uint8'
+      ByteSize: 8
+      GoRuntimeType: 29248
+      GoKind: 22
+      Pointee: 3 BaseType uint8
+    - __kind: PointerType
+      ID: 19
+      Name: '*uintptr'
+      ByteSize: 8
+      GoRuntimeType: 29824
+      GoKind: 22
+      Pointee: 1 BaseType uintptr
+    - __kind: EventRootType
+      ID: 36
+      Name: Probe[main.noop]
+    - __kind: BaseType
+      ID: 4
+      Name: bool
+      ByteSize: 1
+      GoRuntimeType: 43040
+      GoKind: 1
+    - __kind: BaseType
+      ID: 25
+      Name: complex128
+      ByteSize: 16
+      GoRuntimeType: 42848
+      GoKind: 16
+    - __kind: BaseType
+      ID: 24
+      Name: complex64
+      ByteSize: 8
+      GoRuntimeType: 42784
+      GoKind: 15
+    - __kind: GoInterfaceType
+      ID: 14
+      Name: error
+      ByteSize: 16
+      GoRuntimeType: 64736
+      GoKind: 20
+      RawFields:
+        - Name: tab
+          Offset: 0
+          Type: 15 VoidPointerType unsafe.Pointer
+        - Name: data
+          Offset: 8
+          Type: 15 VoidPointerType unsafe.Pointer
+    - __kind: BaseType
+      ID: 18
+      Name: float32
+      ByteSize: 4
+      GoRuntimeType: 42912
+      GoKind: 13
+    - __kind: BaseType
+      ID: 16
+      Name: float64
+      ByteSize: 8
+      GoRuntimeType: 42976
+      GoKind: 14
+    - __kind: BaseType
+      ID: 7
+      Name: int
+      ByteSize: 8
+      GoRuntimeType: 42592
+      GoKind: 2
+    - __kind: BaseType
+      ID: 23
+      Name: int16
+      ByteSize: 2
+      GoRuntimeType: 42208
+      GoKind: 4
+    - __kind: BaseType
+      ID: 12
+      Name: int32
+      ByteSize: 4
+      GoRuntimeType: 42336
+      GoKind: 5
+    - __kind: BaseType
+      ID: 13
+      Name: int64
+      ByteSize: 8
+      GoRuntimeType: 42464
+      GoKind: 6
+    - __kind: BaseType
+      ID: 17
+      Name: int8
+      ByteSize: 1
+      GoRuntimeType: 42080
+      GoKind: 3
+    - __kind: GoStringHeaderType
+      ID: 9
+      Name: string
+      ByteSize: 16
+      GoRuntimeType: 42016
+      GoKind: 24
+      RawFields:
+        - Name: str
+          Offset: 0
+          Type: 35 PointerType *string.str
+        - Name: len
+          Offset: 8
+          Type: 7 BaseType int
+      Data: 34 GoStringDataType string.str
     - __kind: GoStringDataType
       ID: 34
       Name: string.str
       ByteSize: 2048
-    - __kind: PointerType
-      ID: 35
-      Name: '*string.str'
+    - __kind: BaseType
+      ID: 10
+      Name: uint
       ByteSize: 8
-      Pointee: 34 GoStringDataType string.str
-    - __kind: EventRootType
-      ID: 36
-      Name: Probe[main.noop]
+      GoRuntimeType: 42656
+      GoKind: 7
+    - __kind: BaseType
+      ID: 6
+      Name: uint16
+      ByteSize: 2
+      GoRuntimeType: 42272
+      GoKind: 9
+    - __kind: BaseType
+      ID: 2
+      Name: uint32
+      ByteSize: 4
+      GoRuntimeType: 42400
+      GoKind: 10
+    - __kind: BaseType
+      ID: 8
+      Name: uint64
+      ByteSize: 8
+      GoRuntimeType: 42528
+      GoKind: 11
+    - __kind: BaseType
+      ID: 3
+      Name: uint8
+      ByteSize: 1
+      GoRuntimeType: 42144
+      GoKind: 8
+    - __kind: BaseType
+      ID: 1
+      Name: uintptr
+      ByteSize: 8
+      GoRuntimeType: 42720
+      GoKind: 12
+    - __kind: VoidPointerType
+      ID: 15
+      Name: unsafe.Pointer
+      ByteSize: 8
+      GoRuntimeType: 43104
+      GoKind: 26
 MaxTypeID: 36
 Issues: []
 GoModuledataInfo: {FirstModuledataAddr: "0x1a13a0", TypesOffset: 296}

--- a/pkg/dyninst/irgen/testdata/snapshot/rc_tester.arch=amd64,toolchain=go1.23.11.yaml
+++ b/pkg/dyninst/irgen/testdata/snapshot/rc_tester.arch=amd64,toolchain=go1.23.11.yaml
@@ -104,25 +104,473 @@ Subprograms:
           IsParameter: true
           IsReturn: false
 Types:
-    - __kind: GoInterfaceType
-      ID: 1
-      Name: net/http.ResponseWriter
-      ByteSize: 16
-      GoRuntimeType: 1.125248e+06
-      GoKind: 20
-      RawFields:
-        - Name: tab
-          Offset: 0
-          Type: 2 VoidPointerType unsafe.Pointer
-        - Name: data
-          Offset: 8
-          Type: 2 VoidPointerType unsafe.Pointer
-    - __kind: VoidPointerType
-      ID: 2
-      Name: unsafe.Pointer
+    - __kind: PointerType
+      ID: 56
+      Name: '**crypto/x509.Certificate'
       ByteSize: 8
-      GoRuntimeType: 543392
-      GoKind: 26
+      Pointee: 57 PointerType *crypto/x509.Certificate
+    - __kind: PointerType
+      ID: 174
+      Name: '**github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span'
+      ByteSize: 8
+      GoKind: 22
+      Pointee: 126 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span
+    - __kind: PointerType
+      ID: 164
+      Name: '**github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttributeValue'
+      ByteSize: 8
+      GoKind: 22
+      Pointee: 165 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttributeValue
+    - __kind: PointerType
+      ID: 48
+      Name: '**mime/multipart.FileHeader'
+      ByteSize: 8
+      GoKind: 22
+      Pointee: 49 PointerType *mime/multipart.FileHeader
+    - __kind: PointerType
+      ID: 98
+      Name: '**net.IPNet'
+      ByteSize: 8
+      GoKind: 22
+      Pointee: 99 PointerType *net.IPNet
+    - __kind: PointerType
+      ID: 96
+      Name: '**net/url.URL'
+      ByteSize: 8
+      GoKind: 22
+      Pointee: 9 PointerType *net/url.URL
+    - __kind: PointerType
+      ID: 31
+      Name: '**runtime.bmap'
+      ByteSize: 8
+      Pointee: 32 PointerType *runtime.bmap
+    - __kind: PointerType
+      ID: 106
+      Name: '*[]*crypto/x509.Certificate'
+      ByteSize: 8
+      GoKind: 22
+      Pointee: 55 GoSliceHeaderType []*crypto/x509.Certificate
+    - __kind: PointerType
+      ID: 216
+      Name: '*[]*crypto/x509.Certificate.array'
+      ByteSize: 8
+      Pointee: 215 GoSliceDataType []*crypto/x509.Certificate.array
+    - __kind: PointerType
+      ID: 262
+      Name: '*[]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span.array'
+      ByteSize: 8
+      Pointee: 261 GoSliceDataType []*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span.array
+    - __kind: PointerType
+      ID: 260
+      Name: '*[]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttributeValue.array'
+      ByteSize: 8
+      Pointee: 259 GoSliceDataType []*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttributeValue.array
+    - __kind: PointerType
+      ID: 212
+      Name: '*[]*mime/multipart.FileHeader.array'
+      ByteSize: 8
+      Pointee: 211 GoSliceDataType []*mime/multipart.FileHeader.array
+    - __kind: PointerType
+      ID: 240
+      Name: '*[]*net.IPNet.array'
+      ByteSize: 8
+      Pointee: 239 GoSliceDataType []*net.IPNet.array
+    - __kind: PointerType
+      ID: 238
+      Name: '*[]*net/url.URL.array'
+      ByteSize: 8
+      Pointee: 237 GoSliceDataType []*net/url.URL.array
+    - __kind: PointerType
+      ID: 29
+      Name: '*[]*runtime.bmap'
+      ByteSize: 8
+      GoRuntimeType: 470656
+      GoKind: 22
+      Pointee: 30 GoSliceHeaderType []*runtime.bmap
+    - __kind: PointerType
+      ID: 209
+      Name: '*[]*runtime.bmap.array'
+      ByteSize: 8
+      Pointee: 208 GoSliceDataType []*runtime.bmap.array
+    - __kind: PointerType
+      ID: 246
+      Name: '*[][]*crypto/x509.Certificate.array'
+      ByteSize: 8
+      Pointee: 245 GoSliceDataType [][]*crypto/x509.Certificate.array
+    - __kind: PointerType
+      ID: 248
+      Name: '*[][]uint8.array'
+      ByteSize: 8
+      Pointee: 247 GoSliceDataType [][]uint8.array
+    - __kind: PointerType
+      ID: 232
+      Name: '*[]crypto/x509.ExtKeyUsage.array'
+      ByteSize: 8
+      Pointee: 231 GoSliceDataType []crypto/x509.ExtKeyUsage.array
+    - __kind: PointerType
+      ID: 244
+      Name: '*[]crypto/x509.OID.array'
+      ByteSize: 8
+      Pointee: 243 GoSliceDataType []crypto/x509.OID.array
+    - __kind: PointerType
+      ID: 220
+      Name: '*[]crypto/x509/pkix.AttributeTypeAndValue.array'
+      ByteSize: 8
+      Pointee: 219 GoSliceDataType []crypto/x509/pkix.AttributeTypeAndValue.array
+    - __kind: PointerType
+      ID: 228
+      Name: '*[]crypto/x509/pkix.Extension.array'
+      ByteSize: 8
+      Pointee: 227 GoSliceDataType []crypto/x509/pkix.Extension.array
+    - __kind: PointerType
+      ID: 230
+      Name: '*[]encoding/asn1.ObjectIdentifier.array'
+      ByteSize: 8
+      Pointee: 229 GoSliceDataType []encoding/asn1.ObjectIdentifier.array
+    - __kind: PointerType
+      ID: 255
+      Name: '*[]github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink.array'
+      ByteSize: 8
+      Pointee: 254 GoSliceDataType []github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink.array
+    - __kind: PointerType
+      ID: 257
+      Name: '*[]github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent.array'
+      ByteSize: 8
+      Pointee: 256 GoSliceDataType []github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent.array
+    - __kind: PointerType
+      ID: 234
+      Name: '*[]net.IP.array'
+      ByteSize: 8
+      Pointee: 233 GoSliceDataType []net.IP.array
+    - __kind: PointerType
+      ID: 250
+      Name: '*[]net/http.segment.array'
+      ByteSize: 8
+      Pointee: 249 GoSliceDataType []net/http.segment.array
+    - __kind: PointerType
+      ID: 207
+      Name: '*[]string.array'
+      ByteSize: 8
+      Pointee: 206 GoSliceDataType []string.array
+    - __kind: PointerType
+      ID: 224
+      Name: '*[]time.zone.array'
+      ByteSize: 8
+      Pointee: 223 GoSliceDataType []time.zone.array
+    - __kind: PointerType
+      ID: 226
+      Name: '*[]time.zoneTrans.array'
+      ByteSize: 8
+      Pointee: 225 GoSliceDataType []time.zoneTrans.array
+    - __kind: PointerType
+      ID: 108
+      Name: '*[]uint8'
+      ByteSize: 8
+      GoRuntimeType: 456768
+      GoKind: 22
+      Pointee: 52 GoSliceHeaderType []uint8
+    - __kind: PointerType
+      ID: 214
+      Name: '*[]uint8.array'
+      ByteSize: 8
+      Pointee: 213 GoSliceDataType []uint8.array
+    - __kind: PointerType
+      ID: 184
+      Name: '*bool'
+      ByteSize: 8
+      GoRuntimeType: 377024
+      GoKind: 22
+      Pointee: 13 BaseType bool
+    - __kind: PointerType
+      ID: 155
+      Name: '*bucket<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>'
+      ByteSize: 8
+      Pointee: 156 GoHMapBucketType bucket<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
+    - __kind: PointerType
+      ID: 44
+      Name: '*bucket<string,[]*mime/multipart.FileHeader>'
+      ByteSize: 8
+      Pointee: 45 GoHMapBucketType bucket<string,[]*mime/multipart.FileHeader>
+    - __kind: PointerType
+      ID: 19
+      Name: '*bucket<string,[]string>'
+      ByteSize: 8
+      Pointee: 20 GoHMapBucketType bucket<string,[]string>
+    - __kind: PointerType
+      ID: 142
+      Name: '*bucket<string,float64>'
+      ByteSize: 8
+      Pointee: 143 GoHMapBucketType bucket<string,float64>
+    - __kind: PointerType
+      ID: 136
+      Name: '*bucket<string,interface {}>'
+      ByteSize: 8
+      Pointee: 137 GoHMapBucketType bucket<string,interface {}>
+    - __kind: PointerType
+      ID: 123
+      Name: '*bucket<string,string>'
+      ByteSize: 8
+      Pointee: 124 GoHMapBucketType bucket<string,string>
+    - __kind: PointerType
+      ID: 179
+      Name: '*bytes.Buffer'
+      ByteSize: 8
+      GoRuntimeType: 2.17632e+06
+      GoKind: 22
+      Pointee: 180 StructureType bytes.Buffer
+    - __kind: PointerType
+      ID: 53
+      Name: '*crypto/tls.ConnectionState'
+      ByteSize: 8
+      GoRuntimeType: 852192
+      GoKind: 22
+      Pointee: 54 StructureType crypto/tls.ConnectionState
+    - __kind: PointerType
+      ID: 57
+      Name: '*crypto/x509.Certificate'
+      ByteSize: 8
+      GoRuntimeType: 1.952864e+06
+      GoKind: 22
+      Pointee: 58 StructureType crypto/x509.Certificate
+    - __kind: PointerType
+      ID: 90
+      Name: '*crypto/x509.ExtKeyUsage'
+      ByteSize: 8
+      GoRuntimeType: 400640
+      GoKind: 22
+      Pointee: 91 BaseType crypto/x509.ExtKeyUsage
+    - __kind: PointerType
+      ID: 103
+      Name: '*crypto/x509.OID'
+      ByteSize: 8
+      GoRuntimeType: 1.761792e+06
+      GoKind: 22
+      Pointee: 104 StructureType crypto/x509.OID
+    - __kind: PointerType
+      ID: 69
+      Name: '*crypto/x509/pkix.AttributeTypeAndValue'
+      ByteSize: 8
+      GoRuntimeType: 417344
+      GoKind: 22
+      Pointee: 70 StructureType crypto/x509/pkix.AttributeTypeAndValue
+    - __kind: PointerType
+      ID: 85
+      Name: '*crypto/x509/pkix.Extension'
+      ByteSize: 8
+      GoRuntimeType: 417536
+      GoKind: 22
+      Pointee: 86 StructureType crypto/x509/pkix.Extension
+    - __kind: PointerType
+      ID: 88
+      Name: '*encoding/asn1.ObjectIdentifier'
+      ByteSize: 8
+      GoRuntimeType: 1.037248e+06
+      GoKind: 22
+      Pointee: 71 GoSliceHeaderType encoding/asn1.ObjectIdentifier
+    - __kind: PointerType
+      ID: 222
+      Name: '*encoding/asn1.ObjectIdentifier.array'
+      ByteSize: 8
+      Pointee: 221 GoSliceDataType encoding/asn1.ObjectIdentifier.array
+    - __kind: PointerType
+      ID: 200
+      Name: '*error'
+      ByteSize: 8
+      GoRuntimeType: 375936
+      GoKind: 22
+      Pointee: 189 GoInterfaceType error
+    - __kind: PointerType
+      ID: 202
+      Name: '*float32'
+      ByteSize: 8
+      GoRuntimeType: 376896
+      GoKind: 22
+      Pointee: 188 BaseType float32
+    - __kind: PointerType
+      ID: 175
+      Name: '*float64'
+      ByteSize: 8
+      GoRuntimeType: 376960
+      GoKind: 22
+      Pointee: 145 BaseType float64
+    - __kind: PointerType
+      ID: 126
+      Name: '*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span'
+      ByteSize: 8
+      GoRuntimeType: 2.187104e+06
+      GoKind: 22
+      Pointee: 127 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span
+    - __kind: PointerType
+      ID: 169
+      Name: '*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanContext'
+      ByteSize: 8
+      GoRuntimeType: 1.916704e+06
+      GoKind: 22
+      Pointee: 170 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanContext
+    - __kind: PointerType
+      ID: 147
+      Name: '*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink'
+      ByteSize: 8
+      GoRuntimeType: 1.129216e+06
+      GoKind: 22
+      Pointee: 148 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink
+    - __kind: PointerType
+      ID: 150
+      Name: '*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent'
+      ByteSize: 8
+      GoRuntimeType: 1.129344e+06
+      GoKind: 22
+      Pointee: 151 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent
+    - __kind: PointerType
+      ID: 161
+      Name: '*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttribute'
+      ByteSize: 8
+      GoRuntimeType: 1.129984e+06
+      GoKind: 22
+      Pointee: 162 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttribute
+    - __kind: PointerType
+      ID: 165
+      Name: '*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttributeValue'
+      ByteSize: 8
+      GoRuntimeType: 1.129728e+06
+      GoKind: 22
+      Pointee: 166 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttributeValue
+    - __kind: PointerType
+      ID: 158
+      Name: '*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute'
+      ByteSize: 8
+      GoRuntimeType: 1.130112e+06
+      GoKind: 22
+      Pointee: 159 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
+    - __kind: PointerType
+      ID: 171
+      Name: '*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.trace'
+      ByteSize: 8
+      GoRuntimeType: 2.131968e+06
+      GoKind: 22
+      Pointee: 172 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.trace
+    - __kind: PointerType
+      ID: 153
+      Name: '*hash<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>'
+      ByteSize: 8
+      Pointee: 154 GoHMapHeaderType hash<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
+    - __kind: PointerType
+      ID: 42
+      Name: '*hash<string,[]*mime/multipart.FileHeader>'
+      ByteSize: 8
+      Pointee: 43 GoHMapHeaderType hash<string,[]*mime/multipart.FileHeader>
+    - __kind: PointerType
+      ID: 15
+      Name: '*hash<string,[]string>'
+      ByteSize: 8
+      Pointee: 16 GoHMapHeaderType hash<string,[]string>
+    - __kind: PointerType
+      ID: 140
+      Name: '*hash<string,float64>'
+      ByteSize: 8
+      Pointee: 141 GoHMapHeaderType hash<string,float64>
+    - __kind: PointerType
+      ID: 134
+      Name: '*hash<string,interface {}>'
+      ByteSize: 8
+      Pointee: 135 GoHMapHeaderType hash<string,interface {}>
+    - __kind: PointerType
+      ID: 121
+      Name: '*hash<string,string>'
+      ByteSize: 8
+      Pointee: 122 GoHMapHeaderType hash<string,string>
+    - __kind: PointerType
+      ID: 72
+      Name: '*int'
+      ByteSize: 8
+      GoRuntimeType: 376576
+      GoKind: 22
+      Pointee: 8 BaseType int
+    - __kind: PointerType
+      ID: 197
+      Name: '*int16'
+      ByteSize: 8
+      GoRuntimeType: 376192
+      GoKind: 22
+      Pointee: 198 BaseType int16
+    - __kind: PointerType
+      ID: 190
+      Name: '*int32'
+      ByteSize: 8
+      GoRuntimeType: 376320
+      GoKind: 22
+      Pointee: 130 BaseType int32
+    - __kind: PointerType
+      ID: 194
+      Name: '*int64'
+      ByteSize: 8
+      GoRuntimeType: 376448
+      GoKind: 22
+      Pointee: 36 BaseType int64
+    - __kind: PointerType
+      ID: 199
+      Name: '*int8'
+      ByteSize: 8
+      GoRuntimeType: 376064
+      GoKind: 22
+      Pointee: 186 BaseType int8
+    - __kind: PointerType
+      ID: 62
+      Name: '*math/big.Int'
+      ByteSize: 8
+      GoRuntimeType: 2.296864e+06
+      GoKind: 22
+      Pointee: 63 StructureType math/big.Int
+    - __kind: PointerType
+      ID: 65
+      Name: '*math/big.Word'
+      ByteSize: 8
+      GoRuntimeType: 403456
+      GoKind: 22
+      Pointee: 66 BaseType math/big.Word
+    - __kind: PointerType
+      ID: 218
+      Name: '*math/big.nat.array'
+      ByteSize: 8
+      Pointee: 217 GoSliceDataType math/big.nat.array
+    - __kind: PointerType
+      ID: 49
+      Name: '*mime/multipart.FileHeader'
+      ByteSize: 8
+      GoRuntimeType: 853632
+      GoKind: 22
+      Pointee: 50 StructureType mime/multipart.FileHeader
+    - __kind: PointerType
+      ID: 38
+      Name: '*mime/multipart.Form'
+      ByteSize: 8
+      GoRuntimeType: 853728
+      GoKind: 22
+      Pointee: 39 StructureType mime/multipart.Form
+    - __kind: PointerType
+      ID: 93
+      Name: '*net.IP'
+      ByteSize: 8
+      GoRuntimeType: 2.028544e+06
+      GoKind: 22
+      Pointee: 94 GoSliceHeaderType net.IP
+    - __kind: PointerType
+      ID: 236
+      Name: '*net.IP.array'
+      ByteSize: 8
+      Pointee: 235 GoSliceDataType net.IP.array
+    - __kind: PointerType
+      ID: 242
+      Name: '*net.IPMask.array'
+      ByteSize: 8
+      Pointee: 241 GoSliceDataType net.IPMask.array
+    - __kind: PointerType
+      ID: 99
+      Name: '*net.IPNet'
+      ByteSize: 8
+      GoRuntimeType: 1.122688e+06
+      GoKind: 22
+      Pointee: 100 StructureType net.IPNet
     - __kind: PointerType
       ID: 3
       Name: '*net/http.Request'
@@ -130,124 +578,27 @@ Types:
       GoRuntimeType: 2.219392e+06
       GoKind: 22
       Pointee: 4 StructureType net/http.Request
-    - __kind: StructureType
-      ID: 4
-      Name: net/http.Request
-      ByteSize: 304
-      GoRuntimeType: 2.255712e+06
-      GoKind: 25
-      RawFields:
-        - Name: Method
-          Offset: 0
-          Type: 5 GoStringHeaderType string
-        - Name: URL
-          Offset: 16
-          Type: 9 PointerType *net/url.URL
-        - Name: Proto
-          Offset: 24
-          Type: 5 GoStringHeaderType string
-        - Name: ProtoMajor
-          Offset: 40
-          Type: 8 BaseType int
-        - Name: ProtoMinor
-          Offset: 48
-          Type: 8 BaseType int
-        - Name: Header
-          Offset: 56
-          Type: 14 GoMapType net/http.Header
-        - Name: Body
-          Offset: 64
-          Type: 34 GoInterfaceType io.ReadCloser
-        - Name: GetBody
-          Offset: 80
-          Type: 35 GoSubroutineType func() (io.ReadCloser, error)
-        - Name: ContentLength
-          Offset: 88
-          Type: 36 BaseType int64
-        - Name: TransferEncoding
-          Offset: 96
-          Type: 24 GoSliceHeaderType []string
-        - Name: Close
-          Offset: 120
-          Type: 13 BaseType bool
-        - Name: Host
-          Offset: 128
-          Type: 5 GoStringHeaderType string
-        - Name: Form
-          Offset: 144
-          Type: 37 GoMapType net/url.Values
-        - Name: PostForm
-          Offset: 152
-          Type: 37 GoMapType net/url.Values
-        - Name: MultipartForm
-          Offset: 160
-          Type: 38 PointerType *mime/multipart.Form
-        - Name: Trailer
-          Offset: 168
-          Type: 14 GoMapType net/http.Header
-        - Name: RemoteAddr
-          Offset: 176
-          Type: 5 GoStringHeaderType string
-        - Name: RequestURI
-          Offset: 192
-          Type: 5 GoStringHeaderType string
-        - Name: TLS
-          Offset: 208
-          Type: 53 PointerType *crypto/tls.ConnectionState
-        - Name: Cancel
-          Offset: 216
-          Type: 111 GoChannelType <-chan struct {}
-        - Name: Response
-          Offset: 224
-          Type: 112 PointerType *net/http.Response
-        - Name: Pattern
-          Offset: 232
-          Type: 5 GoStringHeaderType string
-        - Name: ctx
-          Offset: 248
-          Type: 114 GoInterfaceType context.Context
-        - Name: pat
-          Offset: 264
-          Type: 115 PointerType *net/http.pattern
-        - Name: matches
-          Offset: 272
-          Type: 24 GoSliceHeaderType []string
-        - Name: otherValues
-          Offset: 296
-          Type: 120 GoMapType map[string]string
-    - __kind: GoStringHeaderType
-      ID: 5
-      Name: string
-      ByteSize: 16
-      GoRuntimeType: 542304
-      GoKind: 24
-      RawFields:
-        - Name: str
-          Offset: 0
-          Type: 204 PointerType *string.str
-        - Name: len
-          Offset: 8
-          Type: 8 BaseType int
-      Data: 203 GoStringDataType string.str
     - __kind: PointerType
-      ID: 6
-      Name: '*uint8'
+      ID: 112
+      Name: '*net/http.Response'
       ByteSize: 8
-      GoRuntimeType: 376128
+      GoRuntimeType: 1.63216e+06
       GoKind: 22
-      Pointee: 7 BaseType uint8
-    - __kind: BaseType
-      ID: 7
-      Name: uint8
-      ByteSize: 1
-      GoRuntimeType: 542432
-      GoKind: 8
-    - __kind: BaseType
-      ID: 8
-      Name: int
+      Pointee: 113 StructureType net/http.Response
+    - __kind: PointerType
+      ID: 115
+      Name: '*net/http.pattern'
       ByteSize: 8
-      GoRuntimeType: 542880
-      GoKind: 2
+      GoRuntimeType: 1.45312e+06
+      GoKind: 22
+      Pointee: 116 StructureType net/http.pattern
+    - __kind: PointerType
+      ID: 118
+      Name: '*net/http.segment'
+      ByteSize: 8
+      GoRuntimeType: 367808
+      GoKind: 22
+      Pointee: 119 StructureType net/http.segment
     - __kind: PointerType
       ID: 9
       Name: '*net/url.URL'
@@ -255,46 +606,6 @@ Types:
       GoRuntimeType: 2.00192e+06
       GoKind: 22
       Pointee: 10 StructureType net/url.URL
-    - __kind: StructureType
-      ID: 10
-      Name: net/url.URL
-      ByteSize: 144
-      GoRuntimeType: 2.040992e+06
-      GoKind: 25
-      RawFields:
-        - Name: Scheme
-          Offset: 0
-          Type: 5 GoStringHeaderType string
-        - Name: Opaque
-          Offset: 16
-          Type: 5 GoStringHeaderType string
-        - Name: User
-          Offset: 32
-          Type: 11 PointerType *net/url.Userinfo
-        - Name: Host
-          Offset: 40
-          Type: 5 GoStringHeaderType string
-        - Name: Path
-          Offset: 56
-          Type: 5 GoStringHeaderType string
-        - Name: RawPath
-          Offset: 72
-          Type: 5 GoStringHeaderType string
-        - Name: OmitHost
-          Offset: 88
-          Type: 13 BaseType bool
-        - Name: ForceQuery
-          Offset: 89
-          Type: 13 BaseType bool
-        - Name: RawQuery
-          Offset: 96
-          Type: 5 GoStringHeaderType string
-        - Name: Fragment
-          Offset: 112
-          Type: 5 GoStringHeaderType string
-        - Name: RawFragment
-          Offset: 128
-          Type: 5 GoStringHeaderType string
     - __kind: PointerType
       ID: 11
       Name: '*net/url.Userinfo'
@@ -302,110 +613,139 @@ Types:
       GoRuntimeType: 1.141376e+06
       GoKind: 22
       Pointee: 12 StructureType net/url.Userinfo
-    - __kind: StructureType
-      ID: 12
-      Name: net/url.Userinfo
-      ByteSize: 40
-      GoRuntimeType: 1.469248e+06
-      GoKind: 25
-      RawFields:
-        - Name: username
-          Offset: 0
-          Type: 5 GoStringHeaderType string
-        - Name: password
-          Offset: 16
-          Type: 5 GoStringHeaderType string
-        - Name: passwordSet
-          Offset: 32
-          Type: 13 BaseType bool
-    - __kind: BaseType
-      ID: 13
-      Name: bool
-      ByteSize: 1
-      GoRuntimeType: 543328
-      GoKind: 1
-    - __kind: GoMapType
-      ID: 14
-      Name: net/http.Header
-      ByteSize: 8
-      GoRuntimeType: 1.963712e+06
-      GoKind: 21
-      HeaderType: 16 GoHMapHeaderType hash<string,[]string>
     - __kind: PointerType
-      ID: 15
-      Name: '*hash<string,[]string>'
+      ID: 32
+      Name: '*runtime.bmap'
       ByteSize: 8
-      Pointee: 16 GoHMapHeaderType hash<string,[]string>
-    - __kind: GoHMapHeaderType
-      ID: 16
-      Name: hash<string,[]string>
-      ByteSize: 48
-      RawFields:
-        - Name: count
-          Offset: 0
-          Type: 8 BaseType int
-        - Name: flags
-          Offset: 8
-          Type: 7 BaseType uint8
-        - Name: B
-          Offset: 9
-          Type: 7 BaseType uint8
-        - Name: noverflow
-          Offset: 10
-          Type: 17 BaseType uint16
-        - Name: hash0
-          Offset: 12
-          Type: 18 BaseType uint32
-        - Name: buckets
-          Offset: 16
-          Type: 19 PointerType *bucket<string,[]string>
-        - Name: oldbuckets
-          Offset: 24
-          Type: 19 PointerType *bucket<string,[]string>
-        - Name: nevacuate
-          Offset: 32
-          Type: 26 BaseType uintptr
-        - Name: extra
-          Offset: 40
-          Type: 27 PointerType *runtime.mapextra
-      BucketType: 20 GoHMapBucketType bucket<string,[]string>
-      BucketsType: 205 GoSliceDataType []bucket<string,[]string>.array
-    - __kind: BaseType
-      ID: 17
-      Name: uint16
-      ByteSize: 2
-      GoRuntimeType: 542560
-      GoKind: 9
-    - __kind: BaseType
-      ID: 18
-      Name: uint32
-      ByteSize: 4
-      GoRuntimeType: 542688
-      GoKind: 10
+      GoRuntimeType: 1.137024e+06
+      GoKind: 22
+      Pointee: 33 StructureType runtime.bmap
     - __kind: PointerType
-      ID: 19
-      Name: '*bucket<string,[]string>'
+      ID: 27
+      Name: '*runtime.mapextra'
       ByteSize: 8
-      Pointee: 20 GoHMapBucketType bucket<string,[]string>
-    - __kind: GoHMapBucketType
-      ID: 20
-      Name: bucket<string,[]string>
-      ByteSize: 336
-      RawFields:
-        - Name: tophash
-          Offset: 0
-          Type: 21 ArrayType [8]uint8
-        - Name: keys
-          Offset: 8
-          Type: 22 ArrayType []key<string>
-        - Name: values
-          Offset: 136
-          Type: 23 ArrayType []val<[]string>
-        - Name: overflow
-          Offset: 328
-          Type: 19 PointerType *bucket<string,[]string>
-      KeyType: 5 GoStringHeaderType string
-      ValueType: 24 GoSliceHeaderType []string
+      GoRuntimeType: 379904
+      GoKind: 22
+      Pointee: 28 StructureType runtime.mapextra
+    - __kind: PointerType
+      ID: 25
+      Name: '*string'
+      ByteSize: 8
+      GoRuntimeType: 376000
+      GoKind: 22
+      Pointee: 5 GoStringHeaderType string
+    - __kind: PointerType
+      ID: 204
+      Name: '*string.str'
+      ByteSize: 8
+      Pointee: 203 GoStringDataType string.str
+    - __kind: PointerType
+      ID: 75
+      Name: '*time.Location'
+      ByteSize: 8
+      GoRuntimeType: 1.458112e+06
+      GoKind: 22
+      Pointee: 76 StructureType time.Location
+    - __kind: PointerType
+      ID: 78
+      Name: '*time.zone'
+      ByteSize: 8
+      GoRuntimeType: 370880
+      GoKind: 22
+      Pointee: 79 StructureType time.zone
+    - __kind: PointerType
+      ID: 81
+      Name: '*time.zoneTrans'
+      ByteSize: 8
+      GoRuntimeType: 370944
+      GoKind: 22
+      Pointee: 82 StructureType time.zoneTrans
+    - __kind: PointerType
+      ID: 201
+      Name: '*uint'
+      ByteSize: 8
+      GoRuntimeType: 376640
+      GoKind: 22
+      Pointee: 187 BaseType uint
+    - __kind: PointerType
+      ID: 196
+      Name: '*uint16'
+      ByteSize: 8
+      GoRuntimeType: 376256
+      GoKind: 22
+      Pointee: 17 BaseType uint16
+    - __kind: PointerType
+      ID: 191
+      Name: '*uint32'
+      ByteSize: 8
+      GoRuntimeType: 376384
+      GoKind: 22
+      Pointee: 18 BaseType uint32
+    - __kind: PointerType
+      ID: 195
+      Name: '*uint64'
+      ByteSize: 8
+      GoRuntimeType: 376512
+      GoKind: 22
+      Pointee: 74 BaseType uint64
+    - __kind: PointerType
+      ID: 6
+      Name: '*uint8'
+      ByteSize: 8
+      GoRuntimeType: 376128
+      GoKind: 22
+      Pointee: 7 BaseType uint8
+    - __kind: PointerType
+      ID: 185
+      Name: '*uintptr'
+      ByteSize: 8
+      GoRuntimeType: 376704
+      GoKind: 22
+      Pointee: 26 BaseType uintptr
+    - __kind: GoChannelType
+      ID: 111
+      Name: <-chan struct {}
+      GoRuntimeType: 555296
+      GoKind: 18
+    - __kind: EventRootType
+      ID: 263
+      Name: Probe[main.HandleHTTP]
+      ByteSize: 25
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: w
+          Offset: 1
+          Expression:
+            Type: 1 GoInterfaceType net/http.ResponseWriter
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 1, index: 0, name: w}
+                  Offset: 0
+                  ByteSize: 16
+        - Name: r
+          Offset: 17
+          Expression:
+            Type: 3 PointerType *net/http.Request
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 1, index: 1, name: r}
+                  Offset: 0
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 264
+      Name: Probe[main.LookAtTheRequest]
+      ByteSize: 17
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: path
+          Offset: 1
+          Expression:
+            Type: 5 GoStringHeaderType string
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 2, index: 0, name: path}
+                  Offset: 0
+                  ByteSize: 16
     - __kind: ArrayType
       ID: 21
       Name: '[8]uint8'
@@ -415,80 +755,138 @@ Types:
       Count: 8
       HasCount: true
       Element: 7 BaseType uint8
-    - __kind: ArrayType
-      ID: 22
-      Name: '[]key<string>'
-      ByteSize: 128
-      Count: 8
-      HasCount: true
-      Element: 5 GoStringHeaderType string
-    - __kind: ArrayType
-      ID: 23
-      Name: '[]val<[]string>'
-      ByteSize: 192
-      Count: 8
-      HasCount: true
-      Element: 24 GoSliceHeaderType []string
     - __kind: GoSliceHeaderType
-      ID: 24
-      Name: '[]string'
+      ID: 55
+      Name: '[]*crypto/x509.Certificate'
       ByteSize: 24
-      GoRuntimeType: 468992
+      GoRuntimeType: 473760
       GoKind: 23
       RawFields:
         - Name: array
           Offset: 0
-          Type: 25 PointerType *string
+          Type: 56 PointerType **crypto/x509.Certificate
         - Name: len
           Offset: 8
           Type: 8 BaseType int
         - Name: cap
           Offset: 16
           Type: 8 BaseType int
-      Data: 206 GoSliceDataType []string.array
-    - __kind: PointerType
-      ID: 25
-      Name: '*string'
-      ByteSize: 8
-      GoRuntimeType: 376000
-      GoKind: 22
-      Pointee: 5 GoStringHeaderType string
-    - __kind: BaseType
-      ID: 26
-      Name: uintptr
-      ByteSize: 8
-      GoRuntimeType: 543008
-      GoKind: 12
-    - __kind: PointerType
-      ID: 27
-      Name: '*runtime.mapextra'
-      ByteSize: 8
-      GoRuntimeType: 379904
-      GoKind: 22
-      Pointee: 28 StructureType runtime.mapextra
-    - __kind: StructureType
-      ID: 28
-      Name: runtime.mapextra
+      Data: 215 GoSliceDataType []*crypto/x509.Certificate.array
+    - __kind: GoSliceDataType
+      ID: 215
+      Name: '[]*crypto/x509.Certificate.array'
+      ByteSize: 2048
+      Element: 57 PointerType *crypto/x509.Certificate
+    - __kind: GoSliceHeaderType
+      ID: 173
+      Name: '[]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span'
       ByteSize: 24
-      GoRuntimeType: 1.465216e+06
-      GoKind: 25
+      GoRuntimeType: 463872
+      GoKind: 23
       RawFields:
-        - Name: overflow
+        - Name: array
           Offset: 0
-          Type: 29 PointerType *[]*runtime.bmap
-        - Name: oldoverflow
+          Type: 174 PointerType **github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span
+        - Name: len
           Offset: 8
-          Type: 29 PointerType *[]*runtime.bmap
-        - Name: nextOverflow
+          Type: 8 BaseType int
+        - Name: cap
           Offset: 16
-          Type: 32 PointerType *runtime.bmap
-    - __kind: PointerType
-      ID: 29
-      Name: '*[]*runtime.bmap'
-      ByteSize: 8
-      GoRuntimeType: 470656
-      GoKind: 22
-      Pointee: 30 GoSliceHeaderType []*runtime.bmap
+          Type: 8 BaseType int
+      Data: 261 GoSliceDataType []*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span.array
+    - __kind: GoSliceDataType
+      ID: 261
+      Name: '[]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span.array'
+      ByteSize: 2048
+      Element: 126 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span
+    - __kind: GoSliceHeaderType
+      ID: 163
+      Name: '[]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttributeValue'
+      ByteSize: 24
+      GoRuntimeType: 463488
+      GoKind: 23
+      RawFields:
+        - Name: array
+          Offset: 0
+          Type: 164 PointerType **github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttributeValue
+        - Name: len
+          Offset: 8
+          Type: 8 BaseType int
+        - Name: cap
+          Offset: 16
+          Type: 8 BaseType int
+      Data: 259 GoSliceDataType []*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttributeValue.array
+    - __kind: GoSliceDataType
+      ID: 259
+      Name: '[]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttributeValue.array'
+      ByteSize: 2048
+      Element: 165 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttributeValue
+    - __kind: GoSliceHeaderType
+      ID: 47
+      Name: '[]*mime/multipart.FileHeader'
+      ByteSize: 24
+      GoRuntimeType: 461504
+      GoKind: 23
+      RawFields:
+        - Name: array
+          Offset: 0
+          Type: 48 PointerType **mime/multipart.FileHeader
+        - Name: len
+          Offset: 8
+          Type: 8 BaseType int
+        - Name: cap
+          Offset: 16
+          Type: 8 BaseType int
+      Data: 211 GoSliceDataType []*mime/multipart.FileHeader.array
+    - __kind: GoSliceDataType
+      ID: 211
+      Name: '[]*mime/multipart.FileHeader.array'
+      ByteSize: 2048
+      Element: 49 PointerType *mime/multipart.FileHeader
+    - __kind: GoSliceHeaderType
+      ID: 97
+      Name: '[]*net.IPNet'
+      ByteSize: 24
+      GoRuntimeType: 486816
+      GoKind: 23
+      RawFields:
+        - Name: array
+          Offset: 0
+          Type: 98 PointerType **net.IPNet
+        - Name: len
+          Offset: 8
+          Type: 8 BaseType int
+        - Name: cap
+          Offset: 16
+          Type: 8 BaseType int
+      Data: 239 GoSliceDataType []*net.IPNet.array
+    - __kind: GoSliceDataType
+      ID: 239
+      Name: '[]*net.IPNet.array'
+      ByteSize: 2048
+      Element: 99 PointerType *net.IPNet
+    - __kind: GoSliceHeaderType
+      ID: 95
+      Name: '[]*net/url.URL'
+      ByteSize: 24
+      GoRuntimeType: 486752
+      GoKind: 23
+      RawFields:
+        - Name: array
+          Offset: 0
+          Type: 96 PointerType **net/url.URL
+        - Name: len
+          Offset: 8
+          Type: 8 BaseType int
+        - Name: cap
+          Offset: 16
+          Type: 8 BaseType int
+      Data: 237 GoSliceDataType []*net/url.URL.array
+    - __kind: GoSliceDataType
+      ID: 237
+      Name: '[]*net/url.URL.array'
+      ByteSize: 2048
+      Element: 9 PointerType *net/url.URL
     - __kind: GoSliceHeaderType
       ID: 30
       Name: '[]*runtime.bmap'
@@ -506,138 +904,445 @@ Types:
           Offset: 16
           Type: 8 BaseType int
       Data: 208 GoSliceDataType []*runtime.bmap.array
-    - __kind: PointerType
-      ID: 31
-      Name: '**runtime.bmap'
-      ByteSize: 8
-      Pointee: 32 PointerType *runtime.bmap
-    - __kind: PointerType
-      ID: 32
-      Name: '*runtime.bmap'
-      ByteSize: 8
-      GoRuntimeType: 1.137024e+06
-      GoKind: 22
-      Pointee: 33 StructureType runtime.bmap
-    - __kind: StructureType
-      ID: 33
-      Name: runtime.bmap
-      ByteSize: 8
-      GoRuntimeType: 1.136896e+06
-      GoKind: 25
+    - __kind: GoSliceDataType
+      ID: 208
+      Name: '[]*runtime.bmap.array'
+      ByteSize: 2048
+      Element: 32 PointerType *runtime.bmap
+    - __kind: GoSliceHeaderType
+      ID: 105
+      Name: '[][]*crypto/x509.Certificate'
+      ByteSize: 24
+      GoRuntimeType: 473888
+      GoKind: 23
+      RawFields:
+        - Name: array
+          Offset: 0
+          Type: 106 PointerType *[]*crypto/x509.Certificate
+        - Name: len
+          Offset: 8
+          Type: 8 BaseType int
+        - Name: cap
+          Offset: 16
+          Type: 8 BaseType int
+      Data: 245 GoSliceDataType [][]*crypto/x509.Certificate.array
+    - __kind: GoSliceDataType
+      ID: 245
+      Name: '[][]*crypto/x509.Certificate.array'
+      ByteSize: 2048
+      Element: 55 GoSliceHeaderType []*crypto/x509.Certificate
+    - __kind: GoSliceHeaderType
+      ID: 107
+      Name: '[][]uint8'
+      ByteSize: 24
+      GoRuntimeType: 457024
+      GoKind: 23
+      RawFields:
+        - Name: array
+          Offset: 0
+          Type: 108 PointerType *[]uint8
+        - Name: len
+          Offset: 8
+          Type: 8 BaseType int
+        - Name: cap
+          Offset: 16
+          Type: 8 BaseType int
+      Data: 247 GoSliceDataType [][]uint8.array
+    - __kind: GoSliceDataType
+      ID: 247
+      Name: '[][]uint8.array'
+      ByteSize: 2048
+      Element: 52 GoSliceHeaderType []uint8
+    - __kind: GoSliceDataType
+      ID: 258
+      Name: '[]bucket<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>.array'
+      ByteSize: 2048
+      Element: 156 GoHMapBucketType bucket<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
+    - __kind: GoSliceDataType
+      ID: 210
+      Name: '[]bucket<string,[]*mime/multipart.FileHeader>.array'
+      ByteSize: 2048
+      Element: 45 GoHMapBucketType bucket<string,[]*mime/multipart.FileHeader>
+    - __kind: GoSliceDataType
+      ID: 205
+      Name: '[]bucket<string,[]string>.array'
+      ByteSize: 2048
+      Element: 20 GoHMapBucketType bucket<string,[]string>
+    - __kind: GoSliceDataType
+      ID: 253
+      Name: '[]bucket<string,float64>.array'
+      ByteSize: 2048
+      Element: 143 GoHMapBucketType bucket<string,float64>
+    - __kind: GoSliceDataType
+      ID: 252
+      Name: '[]bucket<string,interface {}>.array'
+      ByteSize: 2048
+      Element: 137 GoHMapBucketType bucket<string,interface {}>
+    - __kind: GoSliceDataType
+      ID: 251
+      Name: '[]bucket<string,string>.array'
+      ByteSize: 2048
+      Element: 124 GoHMapBucketType bucket<string,string>
+    - __kind: GoSliceHeaderType
+      ID: 89
+      Name: '[]crypto/x509.ExtKeyUsage'
+      ByteSize: 24
+      GoRuntimeType: 475040
+      GoKind: 23
+      RawFields:
+        - Name: array
+          Offset: 0
+          Type: 90 PointerType *crypto/x509.ExtKeyUsage
+        - Name: len
+          Offset: 8
+          Type: 8 BaseType int
+        - Name: cap
+          Offset: 16
+          Type: 8 BaseType int
+      Data: 231 GoSliceDataType []crypto/x509.ExtKeyUsage.array
+    - __kind: GoSliceDataType
+      ID: 231
+      Name: '[]crypto/x509.ExtKeyUsage.array'
+      ByteSize: 2048
+      Element: 91 BaseType crypto/x509.ExtKeyUsage
+    - __kind: GoSliceHeaderType
+      ID: 102
+      Name: '[]crypto/x509.OID'
+      ByteSize: 24
+      GoRuntimeType: 486880
+      GoKind: 23
+      RawFields:
+        - Name: array
+          Offset: 0
+          Type: 103 PointerType *crypto/x509.OID
+        - Name: len
+          Offset: 8
+          Type: 8 BaseType int
+        - Name: cap
+          Offset: 16
+          Type: 8 BaseType int
+      Data: 243 GoSliceDataType []crypto/x509.OID.array
+    - __kind: GoSliceDataType
+      ID: 243
+      Name: '[]crypto/x509.OID.array'
+      ByteSize: 2048
+      Element: 104 StructureType crypto/x509.OID
+    - __kind: GoSliceHeaderType
+      ID: 68
+      Name: '[]crypto/x509/pkix.AttributeTypeAndValue'
+      ByteSize: 24
+      GoRuntimeType: 487136
+      GoKind: 23
+      RawFields:
+        - Name: array
+          Offset: 0
+          Type: 69 PointerType *crypto/x509/pkix.AttributeTypeAndValue
+        - Name: len
+          Offset: 8
+          Type: 8 BaseType int
+        - Name: cap
+          Offset: 16
+          Type: 8 BaseType int
+      Data: 219 GoSliceDataType []crypto/x509/pkix.AttributeTypeAndValue.array
+    - __kind: GoSliceDataType
+      ID: 219
+      Name: '[]crypto/x509/pkix.AttributeTypeAndValue.array'
+      ByteSize: 2048
+      Element: 70 StructureType crypto/x509/pkix.AttributeTypeAndValue
+    - __kind: GoSliceHeaderType
+      ID: 84
+      Name: '[]crypto/x509/pkix.Extension'
+      ByteSize: 24
+      GoRuntimeType: 486624
+      GoKind: 23
+      RawFields:
+        - Name: array
+          Offset: 0
+          Type: 85 PointerType *crypto/x509/pkix.Extension
+        - Name: len
+          Offset: 8
+          Type: 8 BaseType int
+        - Name: cap
+          Offset: 16
+          Type: 8 BaseType int
+      Data: 227 GoSliceDataType []crypto/x509/pkix.Extension.array
+    - __kind: GoSliceDataType
+      ID: 227
+      Name: '[]crypto/x509/pkix.Extension.array'
+      ByteSize: 2048
+      Element: 86 StructureType crypto/x509/pkix.Extension
+    - __kind: GoSliceHeaderType
+      ID: 87
+      Name: '[]encoding/asn1.ObjectIdentifier'
+      ByteSize: 24
+      GoRuntimeType: 486688
+      GoKind: 23
+      RawFields:
+        - Name: array
+          Offset: 0
+          Type: 88 PointerType *encoding/asn1.ObjectIdentifier
+        - Name: len
+          Offset: 8
+          Type: 8 BaseType int
+        - Name: cap
+          Offset: 16
+          Type: 8 BaseType int
+      Data: 229 GoSliceDataType []encoding/asn1.ObjectIdentifier.array
+    - __kind: GoSliceDataType
+      ID: 229
+      Name: '[]encoding/asn1.ObjectIdentifier.array'
+      ByteSize: 2048
+      Element: 71 GoSliceHeaderType encoding/asn1.ObjectIdentifier
+    - __kind: GoSliceHeaderType
+      ID: 146
+      Name: '[]github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink'
+      ByteSize: 24
+      GoRuntimeType: 463424
+      GoKind: 23
+      RawFields:
+        - Name: array
+          Offset: 0
+          Type: 147 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink
+        - Name: len
+          Offset: 8
+          Type: 8 BaseType int
+        - Name: cap
+          Offset: 16
+          Type: 8 BaseType int
+      Data: 254 GoSliceDataType []github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink.array
+    - __kind: GoSliceDataType
+      ID: 254
+      Name: '[]github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink.array'
+      ByteSize: 2048
+      Element: 148 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink
+    - __kind: GoSliceHeaderType
+      ID: 149
+      Name: '[]github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent'
+      ByteSize: 24
+      GoRuntimeType: 463616
+      GoKind: 23
+      RawFields:
+        - Name: array
+          Offset: 0
+          Type: 150 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent
+        - Name: len
+          Offset: 8
+          Type: 8 BaseType int
+        - Name: cap
+          Offset: 16
+          Type: 8 BaseType int
+      Data: 256 GoSliceDataType []github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent.array
+    - __kind: GoSliceDataType
+      ID: 256
+      Name: '[]github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent.array'
+      ByteSize: 2048
+      Element: 151 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent
+    - __kind: ArrayType
+      ID: 22
+      Name: '[]key<string>'
+      ByteSize: 128
+      Count: 8
+      HasCount: true
+      Element: 5 GoStringHeaderType string
+    - __kind: GoSliceHeaderType
+      ID: 92
+      Name: '[]net.IP'
+      ByteSize: 24
+      GoRuntimeType: 458240
+      GoKind: 23
+      RawFields:
+        - Name: array
+          Offset: 0
+          Type: 93 PointerType *net.IP
+        - Name: len
+          Offset: 8
+          Type: 8 BaseType int
+        - Name: cap
+          Offset: 16
+          Type: 8 BaseType int
+      Data: 233 GoSliceDataType []net.IP.array
+    - __kind: GoSliceDataType
+      ID: 233
+      Name: '[]net.IP.array'
+      ByteSize: 2048
+      Element: 94 GoSliceHeaderType net.IP
+    - __kind: GoSliceHeaderType
+      ID: 117
+      Name: '[]net/http.segment'
+      ByteSize: 24
+      GoRuntimeType: 459008
+      GoKind: 23
+      RawFields:
+        - Name: array
+          Offset: 0
+          Type: 118 PointerType *net/http.segment
+        - Name: len
+          Offset: 8
+          Type: 8 BaseType int
+        - Name: cap
+          Offset: 16
+          Type: 8 BaseType int
+      Data: 249 GoSliceDataType []net/http.segment.array
+    - __kind: GoSliceDataType
+      ID: 249
+      Name: '[]net/http.segment.array'
+      ByteSize: 2048
+      Element: 119 StructureType net/http.segment
+    - __kind: GoSliceHeaderType
+      ID: 24
+      Name: '[]string'
+      ByteSize: 24
+      GoRuntimeType: 468992
+      GoKind: 23
+      RawFields:
+        - Name: array
+          Offset: 0
+          Type: 25 PointerType *string
+        - Name: len
+          Offset: 8
+          Type: 8 BaseType int
+        - Name: cap
+          Offset: 16
+          Type: 8 BaseType int
+      Data: 206 GoSliceDataType []string.array
+    - __kind: GoSliceDataType
+      ID: 206
+      Name: '[]string.array'
+      ByteSize: 2048
+      Element: 5 GoStringHeaderType string
+    - __kind: GoSliceHeaderType
+      ID: 77
+      Name: '[]time.zone'
+      ByteSize: 24
+      GoRuntimeType: 463104
+      GoKind: 23
+      RawFields:
+        - Name: array
+          Offset: 0
+          Type: 78 PointerType *time.zone
+        - Name: len
+          Offset: 8
+          Type: 8 BaseType int
+        - Name: cap
+          Offset: 16
+          Type: 8 BaseType int
+      Data: 223 GoSliceDataType []time.zone.array
+    - __kind: GoSliceDataType
+      ID: 223
+      Name: '[]time.zone.array'
+      ByteSize: 2048
+      Element: 79 StructureType time.zone
+    - __kind: GoSliceHeaderType
+      ID: 80
+      Name: '[]time.zoneTrans'
+      ByteSize: 24
+      GoRuntimeType: 463168
+      GoKind: 23
+      RawFields:
+        - Name: array
+          Offset: 0
+          Type: 81 PointerType *time.zoneTrans
+        - Name: len
+          Offset: 8
+          Type: 8 BaseType int
+        - Name: cap
+          Offset: 16
+          Type: 8 BaseType int
+      Data: 225 GoSliceDataType []time.zoneTrans.array
+    - __kind: GoSliceDataType
+      ID: 225
+      Name: '[]time.zoneTrans.array'
+      ByteSize: 2048
+      Element: 82 StructureType time.zoneTrans
+    - __kind: GoSliceHeaderType
+      ID: 52
+      Name: '[]uint8'
+      ByteSize: 24
+      GoRuntimeType: 467840
+      GoKind: 23
+      RawFields:
+        - Name: array
+          Offset: 0
+          Type: 6 PointerType *uint8
+        - Name: len
+          Offset: 8
+          Type: 8 BaseType int
+        - Name: cap
+          Offset: 16
+          Type: 8 BaseType int
+      Data: 213 GoSliceDataType []uint8.array
+    - __kind: GoSliceDataType
+      ID: 213
+      Name: '[]uint8.array'
+      ByteSize: 2048
+      Element: 7 BaseType uint8
+    - __kind: ArrayType
+      ID: 157
+      Name: '[]val<*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>'
+      ByteSize: 64
+      Count: 8
+      HasCount: true
+      Element: 158 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
+    - __kind: ArrayType
+      ID: 46
+      Name: '[]val<[]*mime/multipart.FileHeader>'
+      ByteSize: 192
+      Count: 8
+      HasCount: true
+      Element: 47 GoSliceHeaderType []*mime/multipart.FileHeader
+    - __kind: ArrayType
+      ID: 23
+      Name: '[]val<[]string>'
+      ByteSize: 192
+      Count: 8
+      HasCount: true
+      Element: 24 GoSliceHeaderType []string
+    - __kind: ArrayType
+      ID: 144
+      Name: '[]val<float64>'
+      ByteSize: 64
+      Count: 8
+      HasCount: true
+      Element: 145 BaseType float64
+    - __kind: ArrayType
+      ID: 138
+      Name: '[]val<interface {}>'
+      ByteSize: 128
+      Count: 8
+      HasCount: true
+      Element: 61 GoEmptyInterfaceType interface {}
+    - __kind: ArrayType
+      ID: 125
+      Name: '[]val<string>'
+      ByteSize: 128
+      Count: 8
+      HasCount: true
+      Element: 5 GoStringHeaderType string
+    - __kind: BaseType
+      ID: 13
+      Name: bool
+      ByteSize: 1
+      GoRuntimeType: 543328
+      GoKind: 1
+    - __kind: GoHMapBucketType
+      ID: 156
+      Name: bucket<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
+      ByteSize: 208
       RawFields:
         - Name: tophash
           Offset: 0
           Type: 21 ArrayType [8]uint8
-    - __kind: GoInterfaceType
-      ID: 34
-      Name: io.ReadCloser
-      ByteSize: 16
-      GoRuntimeType: 1.092864e+06
-      GoKind: 20
-      RawFields:
-        - Name: tab
-          Offset: 0
-          Type: 2 VoidPointerType unsafe.Pointer
-        - Name: data
+        - Name: keys
           Offset: 8
-          Type: 2 VoidPointerType unsafe.Pointer
-    - __kind: GoSubroutineType
-      ID: 35
-      Name: func() (io.ReadCloser, error)
-      ByteSize: 8
-      GoRuntimeType: 645280
-      GoKind: 19
-    - __kind: BaseType
-      ID: 36
-      Name: int64
-      ByteSize: 8
-      GoRuntimeType: 542752
-      GoKind: 6
-    - __kind: GoMapType
-      ID: 37
-      Name: net/url.Values
-      ByteSize: 8
-      GoRuntimeType: 1.71184e+06
-      GoKind: 21
-      HeaderType: 16 GoHMapHeaderType hash<string,[]string>
-    - __kind: PointerType
-      ID: 38
-      Name: '*mime/multipart.Form'
-      ByteSize: 8
-      GoRuntimeType: 853728
-      GoKind: 22
-      Pointee: 39 StructureType mime/multipart.Form
-    - __kind: StructureType
-      ID: 39
-      Name: mime/multipart.Form
-      ByteSize: 16
-      GoRuntimeType: 1.325824e+06
-      GoKind: 25
-      RawFields:
-        - Name: Value
-          Offset: 0
-          Type: 40 GoMapType map[string][]string
-        - Name: File
-          Offset: 8
-          Type: 41 GoMapType map[string][]*mime/multipart.FileHeader
-    - __kind: GoMapType
-      ID: 40
-      Name: map[string][]string
-      ByteSize: 8
-      GoRuntimeType: 899232
-      GoKind: 21
-      HeaderType: 16 GoHMapHeaderType hash<string,[]string>
-    - __kind: GoMapType
-      ID: 41
-      Name: map[string][]*mime/multipart.FileHeader
-      ByteSize: 8
-      GoRuntimeType: 904032
-      GoKind: 21
-      HeaderType: 43 GoHMapHeaderType hash<string,[]*mime/multipart.FileHeader>
-    - __kind: PointerType
-      ID: 42
-      Name: '*hash<string,[]*mime/multipart.FileHeader>'
-      ByteSize: 8
-      Pointee: 43 GoHMapHeaderType hash<string,[]*mime/multipart.FileHeader>
-    - __kind: GoHMapHeaderType
-      ID: 43
-      Name: hash<string,[]*mime/multipart.FileHeader>
-      ByteSize: 48
-      RawFields:
-        - Name: count
-          Offset: 0
-          Type: 8 BaseType int
-        - Name: flags
-          Offset: 8
-          Type: 7 BaseType uint8
-        - Name: B
-          Offset: 9
-          Type: 7 BaseType uint8
-        - Name: noverflow
-          Offset: 10
-          Type: 17 BaseType uint16
-        - Name: hash0
-          Offset: 12
-          Type: 18 BaseType uint32
-        - Name: buckets
-          Offset: 16
-          Type: 44 PointerType *bucket<string,[]*mime/multipart.FileHeader>
-        - Name: oldbuckets
-          Offset: 24
-          Type: 44 PointerType *bucket<string,[]*mime/multipart.FileHeader>
-        - Name: nevacuate
-          Offset: 32
-          Type: 26 BaseType uintptr
-        - Name: extra
-          Offset: 40
-          Type: 27 PointerType *runtime.mapextra
-      BucketType: 45 GoHMapBucketType bucket<string,[]*mime/multipart.FileHeader>
-      BucketsType: 210 GoSliceDataType []bucket<string,[]*mime/multipart.FileHeader>.array
-    - __kind: PointerType
-      ID: 44
-      Name: '*bucket<string,[]*mime/multipart.FileHeader>'
-      ByteSize: 8
-      Pointee: 45 GoHMapBucketType bucket<string,[]*mime/multipart.FileHeader>
+          Type: 22 ArrayType []key<string>
+        - Name: values
+          Offset: 136
+          Type: 157 ArrayType []val<*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
+        - Name: overflow
+          Offset: 200
+          Type: 155 PointerType *bucket<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
+      KeyType: 5 GoStringHeaderType string
+      ValueType: 158 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
     - __kind: GoHMapBucketType
       ID: 45
       Name: bucket<string,[]*mime/multipart.FileHeader>
@@ -657,102 +1362,144 @@ Types:
           Type: 44 PointerType *bucket<string,[]*mime/multipart.FileHeader>
       KeyType: 5 GoStringHeaderType string
       ValueType: 47 GoSliceHeaderType []*mime/multipart.FileHeader
-    - __kind: ArrayType
-      ID: 46
-      Name: '[]val<[]*mime/multipart.FileHeader>'
-      ByteSize: 192
-      Count: 8
-      HasCount: true
-      Element: 47 GoSliceHeaderType []*mime/multipart.FileHeader
-    - __kind: GoSliceHeaderType
-      ID: 47
-      Name: '[]*mime/multipart.FileHeader'
-      ByteSize: 24
-      GoRuntimeType: 461504
-      GoKind: 23
+    - __kind: GoHMapBucketType
+      ID: 20
+      Name: bucket<string,[]string>
+      ByteSize: 336
       RawFields:
-        - Name: array
+        - Name: tophash
           Offset: 0
-          Type: 48 PointerType **mime/multipart.FileHeader
-        - Name: len
+          Type: 21 ArrayType [8]uint8
+        - Name: keys
           Offset: 8
-          Type: 8 BaseType int
-        - Name: cap
-          Offset: 16
-          Type: 8 BaseType int
-      Data: 211 GoSliceDataType []*mime/multipart.FileHeader.array
-    - __kind: PointerType
-      ID: 48
-      Name: '**mime/multipart.FileHeader'
-      ByteSize: 8
-      GoKind: 22
-      Pointee: 49 PointerType *mime/multipart.FileHeader
-    - __kind: PointerType
-      ID: 49
-      Name: '*mime/multipart.FileHeader'
-      ByteSize: 8
-      GoRuntimeType: 853632
-      GoKind: 22
-      Pointee: 50 StructureType mime/multipart.FileHeader
+          Type: 22 ArrayType []key<string>
+        - Name: values
+          Offset: 136
+          Type: 23 ArrayType []val<[]string>
+        - Name: overflow
+          Offset: 328
+          Type: 19 PointerType *bucket<string,[]string>
+      KeyType: 5 GoStringHeaderType string
+      ValueType: 24 GoSliceHeaderType []string
+    - __kind: GoHMapBucketType
+      ID: 143
+      Name: bucket<string,float64>
+      ByteSize: 208
+      RawFields:
+        - Name: tophash
+          Offset: 0
+          Type: 21 ArrayType [8]uint8
+        - Name: keys
+          Offset: 8
+          Type: 22 ArrayType []key<string>
+        - Name: values
+          Offset: 136
+          Type: 144 ArrayType []val<float64>
+        - Name: overflow
+          Offset: 200
+          Type: 142 PointerType *bucket<string,float64>
+      KeyType: 5 GoStringHeaderType string
+      ValueType: 145 BaseType float64
+    - __kind: GoHMapBucketType
+      ID: 137
+      Name: bucket<string,interface {}>
+      ByteSize: 272
+      RawFields:
+        - Name: tophash
+          Offset: 0
+          Type: 21 ArrayType [8]uint8
+        - Name: keys
+          Offset: 8
+          Type: 22 ArrayType []key<string>
+        - Name: values
+          Offset: 136
+          Type: 138 ArrayType []val<interface {}>
+        - Name: overflow
+          Offset: 264
+          Type: 136 PointerType *bucket<string,interface {}>
+      KeyType: 5 GoStringHeaderType string
+      ValueType: 61 GoEmptyInterfaceType interface {}
+    - __kind: GoHMapBucketType
+      ID: 124
+      Name: bucket<string,string>
+      ByteSize: 272
+      RawFields:
+        - Name: tophash
+          Offset: 0
+          Type: 21 ArrayType [8]uint8
+        - Name: keys
+          Offset: 8
+          Type: 22 ArrayType []key<string>
+        - Name: values
+          Offset: 136
+          Type: 125 ArrayType []val<string>
+        - Name: overflow
+          Offset: 264
+          Type: 123 PointerType *bucket<string,string>
+      KeyType: 5 GoStringHeaderType string
+      ValueType: 5 GoStringHeaderType string
     - __kind: StructureType
-      ID: 50
-      Name: mime/multipart.FileHeader
-      ByteSize: 88
-      GoRuntimeType: 1.88112e+06
+      ID: 180
+      Name: bytes.Buffer
+      ByteSize: 40
+      GoRuntimeType: 1.450816e+06
       GoKind: 25
       RawFields:
-        - Name: Filename
+        - Name: buf
           Offset: 0
-          Type: 5 GoStringHeaderType string
-        - Name: Header
-          Offset: 16
-          Type: 51 GoMapType net/textproto.MIMEHeader
-        - Name: Size
-          Offset: 24
-          Type: 36 BaseType int64
-        - Name: content
-          Offset: 32
           Type: 52 GoSliceHeaderType []uint8
-        - Name: tmpfile
-          Offset: 56
-          Type: 5 GoStringHeaderType string
-        - Name: tmpoff
-          Offset: 72
-          Type: 36 BaseType int64
-        - Name: tmpshared
-          Offset: 80
-          Type: 13 BaseType bool
-    - __kind: GoMapType
-      ID: 51
-      Name: net/textproto.MIMEHeader
+        - Name: off
+          Offset: 24
+          Type: 8 BaseType int
+        - Name: lastRead
+          Offset: 32
+          Type: 181 BaseType bytes.readOp
+    - __kind: BaseType
+      ID: 181
+      Name: bytes.readOp
+      ByteSize: 1
+      GoRuntimeType: 541536
+      GoKind: 3
+    - __kind: BaseType
+      ID: 193
+      Name: complex128
+      ByteSize: 16
+      GoRuntimeType: 543136
+      GoKind: 16
+    - __kind: BaseType
+      ID: 192
+      Name: complex64
       ByteSize: 8
-      GoRuntimeType: 1.637344e+06
-      GoKind: 21
-      HeaderType: 16 GoHMapHeaderType hash<string,[]string>
-    - __kind: GoSliceHeaderType
-      ID: 52
-      Name: '[]uint8'
-      ByteSize: 24
-      GoRuntimeType: 467840
-      GoKind: 23
+      GoRuntimeType: 543072
+      GoKind: 15
+    - __kind: GoInterfaceType
+      ID: 114
+      Name: context.Context
+      ByteSize: 16
+      GoRuntimeType: 1.215552e+06
+      GoKind: 20
       RawFields:
-        - Name: array
+        - Name: tab
           Offset: 0
-          Type: 6 PointerType *uint8
-        - Name: len
+          Type: 2 VoidPointerType unsafe.Pointer
+        - Name: data
           Offset: 8
-          Type: 8 BaseType int
-        - Name: cap
-          Offset: 16
-          Type: 8 BaseType int
-      Data: 213 GoSliceDataType []uint8.array
-    - __kind: PointerType
-      ID: 53
-      Name: '*crypto/tls.ConnectionState'
-      ByteSize: 8
-      GoRuntimeType: 852192
-      GoKind: 22
-      Pointee: 54 StructureType crypto/tls.ConnectionState
+          Type: 2 VoidPointerType unsafe.Pointer
+    - __kind: StructureType
+      ID: 182
+      Name: context.backgroundCtx
+      GoRuntimeType: 1.708256e+06
+      GoKind: 25
+      RawFields:
+        - Name: emptyCtx
+          Offset: 0
+          Type: 183 StructureType context.emptyCtx
+    - __kind: StructureType
+      ID: 183
+      Name: context.emptyCtx
+      GoRuntimeType: 1.43472e+06
+      GoKind: 25
+      RawFields: []
     - __kind: StructureType
       ID: 54
       Name: crypto/tls.ConnectionState
@@ -808,35 +1555,12 @@ Types:
         - Name: testingOnlyCurveID
           Offset: 186
           Type: 110 BaseType crypto/tls.CurveID
-    - __kind: GoSliceHeaderType
-      ID: 55
-      Name: '[]*crypto/x509.Certificate'
-      ByteSize: 24
-      GoRuntimeType: 473760
-      GoKind: 23
-      RawFields:
-        - Name: array
-          Offset: 0
-          Type: 56 PointerType **crypto/x509.Certificate
-        - Name: len
-          Offset: 8
-          Type: 8 BaseType int
-        - Name: cap
-          Offset: 16
-          Type: 8 BaseType int
-      Data: 215 GoSliceDataType []*crypto/x509.Certificate.array
-    - __kind: PointerType
-      ID: 56
-      Name: '**crypto/x509.Certificate'
-      ByteSize: 8
-      Pointee: 57 PointerType *crypto/x509.Certificate
-    - __kind: PointerType
-      ID: 57
-      Name: '*crypto/x509.Certificate'
-      ByteSize: 8
-      GoRuntimeType: 1.952864e+06
-      GoKind: 22
-      Pointee: 58 StructureType crypto/x509.Certificate
+    - __kind: BaseType
+      ID: 110
+      Name: crypto/tls.CurveID
+      ByteSize: 2
+      GoRuntimeType: 778464
+      GoKind: 9
     - __kind: StructureType
       ID: 58
       Name: crypto/x509.Certificate
@@ -980,80 +1704,68 @@ Types:
           Offset: 1328
           Type: 102 GoSliceHeaderType []crypto/x509.OID
     - __kind: BaseType
-      ID: 59
-      Name: crypto/x509.SignatureAlgorithm
+      ID: 91
+      Name: crypto/x509.ExtKeyUsage
       ByteSize: 8
-      GoRuntimeType: 1.097216e+06
+      GoRuntimeType: 546400
       GoKind: 2
+    - __kind: BaseType
+      ID: 83
+      Name: crypto/x509.KeyUsage
+      ByteSize: 8
+      GoRuntimeType: 546336
+      GoKind: 2
+    - __kind: StructureType
+      ID: 104
+      Name: crypto/x509.OID
+      ByteSize: 24
+      GoRuntimeType: 1.762016e+06
+      GoKind: 25
+      RawFields:
+        - Name: der
+          Offset: 0
+          Type: 52 GoSliceHeaderType []uint8
     - __kind: BaseType
       ID: 60
       Name: crypto/x509.PublicKeyAlgorithm
       ByteSize: 8
       GoRuntimeType: 780768
       GoKind: 2
-    - __kind: GoEmptyInterfaceType
-      ID: 61
-      Name: interface {}
-      ByteSize: 16
-      GoRuntimeType: 797888
-      GoKind: 20
-      RawFields:
-        - Name: _type
-          Offset: 0
-          Type: 2 VoidPointerType unsafe.Pointer
-        - Name: data
-          Offset: 8
-          Type: 2 VoidPointerType unsafe.Pointer
-    - __kind: PointerType
-      ID: 62
-      Name: '*math/big.Int'
+    - __kind: BaseType
+      ID: 59
+      Name: crypto/x509.SignatureAlgorithm
       ByteSize: 8
-      GoRuntimeType: 2.296864e+06
-      GoKind: 22
-      Pointee: 63 StructureType math/big.Int
+      GoRuntimeType: 1.097216e+06
+      GoKind: 2
     - __kind: StructureType
-      ID: 63
-      Name: math/big.Int
-      ByteSize: 32
-      GoRuntimeType: 1.340544e+06
+      ID: 70
+      Name: crypto/x509/pkix.AttributeTypeAndValue
+      ByteSize: 40
+      GoRuntimeType: 1.349024e+06
       GoKind: 25
       RawFields:
-        - Name: neg
+        - Name: Type
           Offset: 0
-          Type: 13 BaseType bool
-        - Name: abs
-          Offset: 8
-          Type: 64 GoSliceHeaderType math/big.nat
-    - __kind: GoSliceHeaderType
-      ID: 64
-      Name: math/big.nat
-      ByteSize: 24
-      GoRuntimeType: 2.279968e+06
-      GoKind: 23
+          Type: 71 GoSliceHeaderType encoding/asn1.ObjectIdentifier
+        - Name: Value
+          Offset: 24
+          Type: 61 GoEmptyInterfaceType interface {}
+    - __kind: StructureType
+      ID: 86
+      Name: crypto/x509/pkix.Extension
+      ByteSize: 56
+      GoRuntimeType: 1.494592e+06
+      GoKind: 25
       RawFields:
-        - Name: array
+        - Name: Id
           Offset: 0
-          Type: 65 PointerType *math/big.Word
-        - Name: len
-          Offset: 8
-          Type: 8 BaseType int
-        - Name: cap
-          Offset: 16
-          Type: 8 BaseType int
-      Data: 217 GoSliceDataType math/big.nat.array
-    - __kind: PointerType
-      ID: 65
-      Name: '*math/big.Word'
-      ByteSize: 8
-      GoRuntimeType: 403456
-      GoKind: 22
-      Pointee: 66 BaseType math/big.Word
-    - __kind: BaseType
-      ID: 66
-      Name: math/big.Word
-      ByteSize: 8
-      GoRuntimeType: 546656
-      GoKind: 7
+          Type: 71 GoSliceHeaderType encoding/asn1.ObjectIdentifier
+        - Name: Critical
+          Offset: 24
+          Type: 13 BaseType bool
+        - Name: Value
+          Offset: 32
+          Type: 52 GoSliceHeaderType []uint8
     - __kind: StructureType
       ID: 67
       Name: crypto/x509/pkix.Name
@@ -1095,43 +1807,6 @@ Types:
           Offset: 224
           Type: 68 GoSliceHeaderType []crypto/x509/pkix.AttributeTypeAndValue
     - __kind: GoSliceHeaderType
-      ID: 68
-      Name: '[]crypto/x509/pkix.AttributeTypeAndValue'
-      ByteSize: 24
-      GoRuntimeType: 487136
-      GoKind: 23
-      RawFields:
-        - Name: array
-          Offset: 0
-          Type: 69 PointerType *crypto/x509/pkix.AttributeTypeAndValue
-        - Name: len
-          Offset: 8
-          Type: 8 BaseType int
-        - Name: cap
-          Offset: 16
-          Type: 8 BaseType int
-      Data: 219 GoSliceDataType []crypto/x509/pkix.AttributeTypeAndValue.array
-    - __kind: PointerType
-      ID: 69
-      Name: '*crypto/x509/pkix.AttributeTypeAndValue'
-      ByteSize: 8
-      GoRuntimeType: 417344
-      GoKind: 22
-      Pointee: 70 StructureType crypto/x509/pkix.AttributeTypeAndValue
-    - __kind: StructureType
-      ID: 70
-      Name: crypto/x509/pkix.AttributeTypeAndValue
-      ByteSize: 40
-      GoRuntimeType: 1.349024e+06
-      GoKind: 25
-      RawFields:
-        - Name: Type
-          Offset: 0
-          Type: 71 GoSliceHeaderType encoding/asn1.ObjectIdentifier
-        - Name: Value
-          Offset: 24
-          Type: 61 GoEmptyInterfaceType interface {}
-    - __kind: GoSliceHeaderType
       ID: 71
       Name: encoding/asn1.ObjectIdentifier
       ByteSize: 24
@@ -1148,536 +1823,16 @@ Types:
           Offset: 16
           Type: 8 BaseType int
       Data: 221 GoSliceDataType encoding/asn1.ObjectIdentifier.array
-    - __kind: PointerType
-      ID: 72
-      Name: '*int'
-      ByteSize: 8
-      GoRuntimeType: 376576
-      GoKind: 22
-      Pointee: 8 BaseType int
-    - __kind: StructureType
-      ID: 73
-      Name: time.Time
-      ByteSize: 24
-      GoRuntimeType: 2.280896e+06
-      GoKind: 25
-      RawFields:
-        - Name: wall
-          Offset: 0
-          Type: 74 BaseType uint64
-        - Name: ext
-          Offset: 8
-          Type: 36 BaseType int64
-        - Name: loc
-          Offset: 16
-          Type: 75 PointerType *time.Location
-    - __kind: BaseType
-      ID: 74
-      Name: uint64
-      ByteSize: 8
-      GoRuntimeType: 542816
-      GoKind: 11
-    - __kind: PointerType
-      ID: 75
-      Name: '*time.Location'
-      ByteSize: 8
-      GoRuntimeType: 1.458112e+06
-      GoKind: 22
-      Pointee: 76 StructureType time.Location
-    - __kind: StructureType
-      ID: 76
-      Name: time.Location
-      ByteSize: 104
-      GoRuntimeType: 1.877376e+06
-      GoKind: 25
-      RawFields:
-        - Name: name
-          Offset: 0
-          Type: 5 GoStringHeaderType string
-        - Name: zone
-          Offset: 16
-          Type: 77 GoSliceHeaderType []time.zone
-        - Name: tx
-          Offset: 40
-          Type: 80 GoSliceHeaderType []time.zoneTrans
-        - Name: extend
-          Offset: 64
-          Type: 5 GoStringHeaderType string
-        - Name: cacheStart
-          Offset: 80
-          Type: 36 BaseType int64
-        - Name: cacheEnd
-          Offset: 88
-          Type: 36 BaseType int64
-        - Name: cacheZone
-          Offset: 96
-          Type: 78 PointerType *time.zone
-    - __kind: GoSliceHeaderType
-      ID: 77
-      Name: '[]time.zone'
-      ByteSize: 24
-      GoRuntimeType: 463104
-      GoKind: 23
-      RawFields:
-        - Name: array
-          Offset: 0
-          Type: 78 PointerType *time.zone
-        - Name: len
-          Offset: 8
-          Type: 8 BaseType int
-        - Name: cap
-          Offset: 16
-          Type: 8 BaseType int
-      Data: 223 GoSliceDataType []time.zone.array
-    - __kind: PointerType
-      ID: 78
-      Name: '*time.zone'
-      ByteSize: 8
-      GoRuntimeType: 370880
-      GoKind: 22
-      Pointee: 79 StructureType time.zone
-    - __kind: StructureType
-      ID: 79
-      Name: time.zone
-      ByteSize: 32
-      GoRuntimeType: 1.45792e+06
-      GoKind: 25
-      RawFields:
-        - Name: name
-          Offset: 0
-          Type: 5 GoStringHeaderType string
-        - Name: offset
-          Offset: 16
-          Type: 8 BaseType int
-        - Name: isDST
-          Offset: 24
-          Type: 13 BaseType bool
-    - __kind: GoSliceHeaderType
-      ID: 80
-      Name: '[]time.zoneTrans'
-      ByteSize: 24
-      GoRuntimeType: 463168
-      GoKind: 23
-      RawFields:
-        - Name: array
-          Offset: 0
-          Type: 81 PointerType *time.zoneTrans
-        - Name: len
-          Offset: 8
-          Type: 8 BaseType int
-        - Name: cap
-          Offset: 16
-          Type: 8 BaseType int
-      Data: 225 GoSliceDataType []time.zoneTrans.array
-    - __kind: PointerType
-      ID: 81
-      Name: '*time.zoneTrans'
-      ByteSize: 8
-      GoRuntimeType: 370944
-      GoKind: 22
-      Pointee: 82 StructureType time.zoneTrans
-    - __kind: StructureType
-      ID: 82
-      Name: time.zoneTrans
-      ByteSize: 16
-      GoRuntimeType: 1.663616e+06
-      GoKind: 25
-      RawFields:
-        - Name: when
-          Offset: 0
-          Type: 36 BaseType int64
-        - Name: index
-          Offset: 8
-          Type: 7 BaseType uint8
-        - Name: isstd
-          Offset: 9
-          Type: 13 BaseType bool
-        - Name: isutc
-          Offset: 10
-          Type: 13 BaseType bool
-    - __kind: BaseType
-      ID: 83
-      Name: crypto/x509.KeyUsage
-      ByteSize: 8
-      GoRuntimeType: 546336
-      GoKind: 2
-    - __kind: GoSliceHeaderType
-      ID: 84
-      Name: '[]crypto/x509/pkix.Extension'
-      ByteSize: 24
-      GoRuntimeType: 486624
-      GoKind: 23
-      RawFields:
-        - Name: array
-          Offset: 0
-          Type: 85 PointerType *crypto/x509/pkix.Extension
-        - Name: len
-          Offset: 8
-          Type: 8 BaseType int
-        - Name: cap
-          Offset: 16
-          Type: 8 BaseType int
-      Data: 227 GoSliceDataType []crypto/x509/pkix.Extension.array
-    - __kind: PointerType
-      ID: 85
-      Name: '*crypto/x509/pkix.Extension'
-      ByteSize: 8
-      GoRuntimeType: 417536
-      GoKind: 22
-      Pointee: 86 StructureType crypto/x509/pkix.Extension
-    - __kind: StructureType
-      ID: 86
-      Name: crypto/x509/pkix.Extension
-      ByteSize: 56
-      GoRuntimeType: 1.494592e+06
-      GoKind: 25
-      RawFields:
-        - Name: Id
-          Offset: 0
-          Type: 71 GoSliceHeaderType encoding/asn1.ObjectIdentifier
-        - Name: Critical
-          Offset: 24
-          Type: 13 BaseType bool
-        - Name: Value
-          Offset: 32
-          Type: 52 GoSliceHeaderType []uint8
-    - __kind: GoSliceHeaderType
-      ID: 87
-      Name: '[]encoding/asn1.ObjectIdentifier'
-      ByteSize: 24
-      GoRuntimeType: 486688
-      GoKind: 23
-      RawFields:
-        - Name: array
-          Offset: 0
-          Type: 88 PointerType *encoding/asn1.ObjectIdentifier
-        - Name: len
-          Offset: 8
-          Type: 8 BaseType int
-        - Name: cap
-          Offset: 16
-          Type: 8 BaseType int
-      Data: 229 GoSliceDataType []encoding/asn1.ObjectIdentifier.array
-    - __kind: PointerType
-      ID: 88
-      Name: '*encoding/asn1.ObjectIdentifier'
-      ByteSize: 8
-      GoRuntimeType: 1.037248e+06
-      GoKind: 22
-      Pointee: 71 GoSliceHeaderType encoding/asn1.ObjectIdentifier
-    - __kind: GoSliceHeaderType
-      ID: 89
-      Name: '[]crypto/x509.ExtKeyUsage'
-      ByteSize: 24
-      GoRuntimeType: 475040
-      GoKind: 23
-      RawFields:
-        - Name: array
-          Offset: 0
-          Type: 90 PointerType *crypto/x509.ExtKeyUsage
-        - Name: len
-          Offset: 8
-          Type: 8 BaseType int
-        - Name: cap
-          Offset: 16
-          Type: 8 BaseType int
-      Data: 231 GoSliceDataType []crypto/x509.ExtKeyUsage.array
-    - __kind: PointerType
-      ID: 90
-      Name: '*crypto/x509.ExtKeyUsage'
-      ByteSize: 8
-      GoRuntimeType: 400640
-      GoKind: 22
-      Pointee: 91 BaseType crypto/x509.ExtKeyUsage
-    - __kind: BaseType
-      ID: 91
-      Name: crypto/x509.ExtKeyUsage
-      ByteSize: 8
-      GoRuntimeType: 546400
-      GoKind: 2
-    - __kind: GoSliceHeaderType
-      ID: 92
-      Name: '[]net.IP'
-      ByteSize: 24
-      GoRuntimeType: 458240
-      GoKind: 23
-      RawFields:
-        - Name: array
-          Offset: 0
-          Type: 93 PointerType *net.IP
-        - Name: len
-          Offset: 8
-          Type: 8 BaseType int
-        - Name: cap
-          Offset: 16
-          Type: 8 BaseType int
-      Data: 233 GoSliceDataType []net.IP.array
-    - __kind: PointerType
-      ID: 93
-      Name: '*net.IP'
-      ByteSize: 8
-      GoRuntimeType: 2.028544e+06
-      GoKind: 22
-      Pointee: 94 GoSliceHeaderType net.IP
-    - __kind: GoSliceHeaderType
-      ID: 94
-      Name: net.IP
-      ByteSize: 24
-      GoRuntimeType: 2.000864e+06
-      GoKind: 23
-      RawFields:
-        - Name: array
-          Offset: 0
-          Type: 6 PointerType *uint8
-        - Name: len
-          Offset: 8
-          Type: 8 BaseType int
-        - Name: cap
-          Offset: 16
-          Type: 8 BaseType int
-      Data: 235 GoSliceDataType net.IP.array
-    - __kind: GoSliceHeaderType
-      ID: 95
-      Name: '[]*net/url.URL'
-      ByteSize: 24
-      GoRuntimeType: 486752
-      GoKind: 23
-      RawFields:
-        - Name: array
-          Offset: 0
-          Type: 96 PointerType **net/url.URL
-        - Name: len
-          Offset: 8
-          Type: 8 BaseType int
-        - Name: cap
-          Offset: 16
-          Type: 8 BaseType int
-      Data: 237 GoSliceDataType []*net/url.URL.array
-    - __kind: PointerType
-      ID: 96
-      Name: '**net/url.URL'
-      ByteSize: 8
-      GoKind: 22
-      Pointee: 9 PointerType *net/url.URL
-    - __kind: GoSliceHeaderType
-      ID: 97
-      Name: '[]*net.IPNet'
-      ByteSize: 24
-      GoRuntimeType: 486816
-      GoKind: 23
-      RawFields:
-        - Name: array
-          Offset: 0
-          Type: 98 PointerType **net.IPNet
-        - Name: len
-          Offset: 8
-          Type: 8 BaseType int
-        - Name: cap
-          Offset: 16
-          Type: 8 BaseType int
-      Data: 239 GoSliceDataType []*net.IPNet.array
-    - __kind: PointerType
-      ID: 98
-      Name: '**net.IPNet'
-      ByteSize: 8
-      GoKind: 22
-      Pointee: 99 PointerType *net.IPNet
-    - __kind: PointerType
-      ID: 99
-      Name: '*net.IPNet'
-      ByteSize: 8
-      GoRuntimeType: 1.122688e+06
-      GoKind: 22
-      Pointee: 100 StructureType net.IPNet
-    - __kind: StructureType
-      ID: 100
-      Name: net.IPNet
-      ByteSize: 48
-      GoRuntimeType: 1.306944e+06
-      GoKind: 25
-      RawFields:
-        - Name: IP
-          Offset: 0
-          Type: 94 GoSliceHeaderType net.IP
-        - Name: Mask
-          Offset: 24
-          Type: 101 GoSliceHeaderType net.IPMask
-    - __kind: GoSliceHeaderType
-      ID: 101
-      Name: net.IPMask
-      ByteSize: 24
-      GoRuntimeType: 999232
-      GoKind: 23
-      RawFields:
-        - Name: array
-          Offset: 0
-          Type: 6 PointerType *uint8
-        - Name: len
-          Offset: 8
-          Type: 8 BaseType int
-        - Name: cap
-          Offset: 16
-          Type: 8 BaseType int
-      Data: 241 GoSliceDataType net.IPMask.array
-    - __kind: GoSliceHeaderType
-      ID: 102
-      Name: '[]crypto/x509.OID'
-      ByteSize: 24
-      GoRuntimeType: 486880
-      GoKind: 23
-      RawFields:
-        - Name: array
-          Offset: 0
-          Type: 103 PointerType *crypto/x509.OID
-        - Name: len
-          Offset: 8
-          Type: 8 BaseType int
-        - Name: cap
-          Offset: 16
-          Type: 8 BaseType int
-      Data: 243 GoSliceDataType []crypto/x509.OID.array
-    - __kind: PointerType
-      ID: 103
-      Name: '*crypto/x509.OID'
-      ByteSize: 8
-      GoRuntimeType: 1.761792e+06
-      GoKind: 22
-      Pointee: 104 StructureType crypto/x509.OID
-    - __kind: StructureType
-      ID: 104
-      Name: crypto/x509.OID
-      ByteSize: 24
-      GoRuntimeType: 1.762016e+06
-      GoKind: 25
-      RawFields:
-        - Name: der
-          Offset: 0
-          Type: 52 GoSliceHeaderType []uint8
-    - __kind: GoSliceHeaderType
-      ID: 105
-      Name: '[][]*crypto/x509.Certificate'
-      ByteSize: 24
-      GoRuntimeType: 473888
-      GoKind: 23
-      RawFields:
-        - Name: array
-          Offset: 0
-          Type: 106 PointerType *[]*crypto/x509.Certificate
-        - Name: len
-          Offset: 8
-          Type: 8 BaseType int
-        - Name: cap
-          Offset: 16
-          Type: 8 BaseType int
-      Data: 245 GoSliceDataType [][]*crypto/x509.Certificate.array
-    - __kind: PointerType
-      ID: 106
-      Name: '*[]*crypto/x509.Certificate'
-      ByteSize: 8
-      GoKind: 22
-      Pointee: 55 GoSliceHeaderType []*crypto/x509.Certificate
-    - __kind: GoSliceHeaderType
-      ID: 107
-      Name: '[][]uint8'
-      ByteSize: 24
-      GoRuntimeType: 457024
-      GoKind: 23
-      RawFields:
-        - Name: array
-          Offset: 0
-          Type: 108 PointerType *[]uint8
-        - Name: len
-          Offset: 8
-          Type: 8 BaseType int
-        - Name: cap
-          Offset: 16
-          Type: 8 BaseType int
-      Data: 247 GoSliceDataType [][]uint8.array
-    - __kind: PointerType
-      ID: 108
-      Name: '*[]uint8'
-      ByteSize: 8
-      GoRuntimeType: 456768
-      GoKind: 22
-      Pointee: 52 GoSliceHeaderType []uint8
-    - __kind: GoSubroutineType
-      ID: 109
-      Name: func(string, []uint8, int) ([]uint8, error)
-      ByteSize: 8
-      GoRuntimeType: 982976
-      GoKind: 19
-    - __kind: BaseType
-      ID: 110
-      Name: crypto/tls.CurveID
-      ByteSize: 2
-      GoRuntimeType: 778464
-      GoKind: 9
-    - __kind: GoChannelType
-      ID: 111
-      Name: <-chan struct {}
-      GoRuntimeType: 555296
-      GoKind: 18
-    - __kind: PointerType
-      ID: 112
-      Name: '*net/http.Response'
-      ByteSize: 8
-      GoRuntimeType: 1.63216e+06
-      GoKind: 22
-      Pointee: 113 StructureType net/http.Response
-    - __kind: StructureType
-      ID: 113
-      Name: net/http.Response
-      ByteSize: 144
-      GoRuntimeType: 2.123456e+06
-      GoKind: 25
-      RawFields:
-        - Name: Status
-          Offset: 0
-          Type: 5 GoStringHeaderType string
-        - Name: StatusCode
-          Offset: 16
-          Type: 8 BaseType int
-        - Name: Proto
-          Offset: 24
-          Type: 5 GoStringHeaderType string
-        - Name: ProtoMajor
-          Offset: 40
-          Type: 8 BaseType int
-        - Name: ProtoMinor
-          Offset: 48
-          Type: 8 BaseType int
-        - Name: Header
-          Offset: 56
-          Type: 14 GoMapType net/http.Header
-        - Name: Body
-          Offset: 64
-          Type: 34 GoInterfaceType io.ReadCloser
-        - Name: ContentLength
-          Offset: 80
-          Type: 36 BaseType int64
-        - Name: TransferEncoding
-          Offset: 88
-          Type: 24 GoSliceHeaderType []string
-        - Name: Close
-          Offset: 112
-          Type: 13 BaseType bool
-        - Name: Uncompressed
-          Offset: 113
-          Type: 13 BaseType bool
-        - Name: Trailer
-          Offset: 120
-          Type: 14 GoMapType net/http.Header
-        - Name: Request
-          Offset: 128
-          Type: 3 PointerType *net/http.Request
-        - Name: TLS
-          Offset: 136
-          Type: 53 PointerType *crypto/tls.ConnectionState
+    - __kind: GoSliceDataType
+      ID: 221
+      Name: encoding/asn1.ObjectIdentifier.array
+      ByteSize: 2048
+      Element: 8 BaseType int
     - __kind: GoInterfaceType
-      ID: 114
-      Name: context.Context
+      ID: 189
+      Name: error
       ByteSize: 16
-      GoRuntimeType: 1.215552e+06
+      GoRuntimeType: 1.01088e+06
       GoKind: 20
       RawFields:
         - Name: tab
@@ -1686,159 +1841,36 @@ Types:
         - Name: data
           Offset: 8
           Type: 2 VoidPointerType unsafe.Pointer
-    - __kind: PointerType
-      ID: 115
-      Name: '*net/http.pattern'
+    - __kind: BaseType
+      ID: 188
+      Name: float32
+      ByteSize: 4
+      GoRuntimeType: 543200
+      GoKind: 13
+    - __kind: BaseType
+      ID: 145
+      Name: float64
       ByteSize: 8
-      GoRuntimeType: 1.45312e+06
-      GoKind: 22
-      Pointee: 116 StructureType net/http.pattern
-    - __kind: StructureType
-      ID: 116
-      Name: net/http.pattern
-      ByteSize: 88
-      GoRuntimeType: 1.744992e+06
-      GoKind: 25
-      RawFields:
-        - Name: str
-          Offset: 0
-          Type: 5 GoStringHeaderType string
-        - Name: method
-          Offset: 16
-          Type: 5 GoStringHeaderType string
-        - Name: host
-          Offset: 32
-          Type: 5 GoStringHeaderType string
-        - Name: segments
-          Offset: 48
-          Type: 117 GoSliceHeaderType []net/http.segment
-        - Name: loc
-          Offset: 72
-          Type: 5 GoStringHeaderType string
-    - __kind: GoSliceHeaderType
-      ID: 117
-      Name: '[]net/http.segment'
-      ByteSize: 24
-      GoRuntimeType: 459008
-      GoKind: 23
-      RawFields:
-        - Name: array
-          Offset: 0
-          Type: 118 PointerType *net/http.segment
-        - Name: len
-          Offset: 8
-          Type: 8 BaseType int
-        - Name: cap
-          Offset: 16
-          Type: 8 BaseType int
-      Data: 249 GoSliceDataType []net/http.segment.array
-    - __kind: PointerType
-      ID: 118
-      Name: '*net/http.segment'
+      GoRuntimeType: 543264
+      GoKind: 14
+    - __kind: GoSubroutineType
+      ID: 178
+      Name: func()
       ByteSize: 8
-      GoRuntimeType: 367808
-      GoKind: 22
-      Pointee: 119 StructureType net/http.segment
-    - __kind: StructureType
-      ID: 119
-      Name: net/http.segment
-      ByteSize: 24
-      GoRuntimeType: 1.452928e+06
-      GoKind: 25
-      RawFields:
-        - Name: s
-          Offset: 0
-          Type: 5 GoStringHeaderType string
-        - Name: wild
-          Offset: 16
-          Type: 13 BaseType bool
-        - Name: multi
-          Offset: 17
-          Type: 13 BaseType bool
-    - __kind: GoMapType
-      ID: 120
-      Name: map[string]string
+      GoRuntimeType: 455360
+      GoKind: 19
+    - __kind: GoSubroutineType
+      ID: 35
+      Name: func() (io.ReadCloser, error)
       ByteSize: 8
-      GoRuntimeType: 900864
-      GoKind: 21
-      HeaderType: 122 GoHMapHeaderType hash<string,string>
-    - __kind: PointerType
-      ID: 121
-      Name: '*hash<string,string>'
+      GoRuntimeType: 645280
+      GoKind: 19
+    - __kind: GoSubroutineType
+      ID: 109
+      Name: func(string, []uint8, int) ([]uint8, error)
       ByteSize: 8
-      Pointee: 122 GoHMapHeaderType hash<string,string>
-    - __kind: GoHMapHeaderType
-      ID: 122
-      Name: hash<string,string>
-      ByteSize: 48
-      RawFields:
-        - Name: count
-          Offset: 0
-          Type: 8 BaseType int
-        - Name: flags
-          Offset: 8
-          Type: 7 BaseType uint8
-        - Name: B
-          Offset: 9
-          Type: 7 BaseType uint8
-        - Name: noverflow
-          Offset: 10
-          Type: 17 BaseType uint16
-        - Name: hash0
-          Offset: 12
-          Type: 18 BaseType uint32
-        - Name: buckets
-          Offset: 16
-          Type: 123 PointerType *bucket<string,string>
-        - Name: oldbuckets
-          Offset: 24
-          Type: 123 PointerType *bucket<string,string>
-        - Name: nevacuate
-          Offset: 32
-          Type: 26 BaseType uintptr
-        - Name: extra
-          Offset: 40
-          Type: 27 PointerType *runtime.mapextra
-      BucketType: 124 GoHMapBucketType bucket<string,string>
-      BucketsType: 251 GoSliceDataType []bucket<string,string>.array
-    - __kind: PointerType
-      ID: 123
-      Name: '*bucket<string,string>'
-      ByteSize: 8
-      Pointee: 124 GoHMapBucketType bucket<string,string>
-    - __kind: GoHMapBucketType
-      ID: 124
-      Name: bucket<string,string>
-      ByteSize: 272
-      RawFields:
-        - Name: tophash
-          Offset: 0
-          Type: 21 ArrayType [8]uint8
-        - Name: keys
-          Offset: 8
-          Type: 22 ArrayType []key<string>
-        - Name: values
-          Offset: 136
-          Type: 125 ArrayType []val<string>
-        - Name: overflow
-          Offset: 264
-          Type: 123 PointerType *bucket<string,string>
-      KeyType: 5 GoStringHeaderType string
-      ValueType: 5 GoStringHeaderType string
-    - __kind: ArrayType
-      ID: 125
-      Name: '[]val<string>'
-      ByteSize: 128
-      Count: 8
-      HasCount: true
-      Element: 5 GoStringHeaderType string
-    - __kind: PointerType
-      ID: 126
-      Name: '*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span'
-      ByteSize: 8
-      GoRuntimeType: 2.187104e+06
-      GoKind: 22
-      Pointee: 127 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span
+      GoRuntimeType: 982976
+      GoKind: 19
     - __kind: StructureType
       ID: 127
       Name: github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span
@@ -1922,522 +1954,6 @@ Types:
           Offset: 280
           Type: 178 GoSubroutineType func()
     - __kind: StructureType
-      ID: 128
-      Name: sync.RWMutex
-      ByteSize: 24
-      GoRuntimeType: 1.750592e+06
-      GoKind: 25
-      RawFields:
-        - Name: w
-          Offset: 0
-          Type: 129 StructureType sync.Mutex
-        - Name: writerSem
-          Offset: 8
-          Type: 18 BaseType uint32
-        - Name: readerSem
-          Offset: 12
-          Type: 18 BaseType uint32
-        - Name: readerCount
-          Offset: 16
-          Type: 131 StructureType sync/atomic.Int32
-        - Name: readerWait
-          Offset: 20
-          Type: 131 StructureType sync/atomic.Int32
-    - __kind: StructureType
-      ID: 129
-      Name: sync.Mutex
-      ByteSize: 8
-      GoRuntimeType: 1.313984e+06
-      GoKind: 25
-      RawFields:
-        - Name: state
-          Offset: 0
-          Type: 130 BaseType int32
-        - Name: sema
-          Offset: 4
-          Type: 18 BaseType uint32
-    - __kind: BaseType
-      ID: 130
-      Name: int32
-      ByteSize: 4
-      GoRuntimeType: 542624
-      GoKind: 5
-    - __kind: StructureType
-      ID: 131
-      Name: sync/atomic.Int32
-      ByteSize: 4
-      GoRuntimeType: 1.315424e+06
-      GoKind: 25
-      RawFields:
-        - Name: _
-          Offset: 0
-          Type: 132 StructureType sync/atomic.noCopy
-        - Name: v
-          Offset: 0
-          Type: 130 BaseType int32
-    - __kind: StructureType
-      ID: 132
-      Name: sync/atomic.noCopy
-      GoRuntimeType: 965792
-      GoKind: 25
-      RawFields: []
-    - __kind: GoMapType
-      ID: 133
-      Name: github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.metaStructMap
-      ByteSize: 8
-      GoRuntimeType: 1.007296e+06
-      GoKind: 21
-      HeaderType: 135 GoHMapHeaderType hash<string,interface {}>
-    - __kind: PointerType
-      ID: 134
-      Name: '*hash<string,interface {}>'
-      ByteSize: 8
-      Pointee: 135 GoHMapHeaderType hash<string,interface {}>
-    - __kind: GoHMapHeaderType
-      ID: 135
-      Name: hash<string,interface {}>
-      ByteSize: 48
-      RawFields:
-        - Name: count
-          Offset: 0
-          Type: 8 BaseType int
-        - Name: flags
-          Offset: 8
-          Type: 7 BaseType uint8
-        - Name: B
-          Offset: 9
-          Type: 7 BaseType uint8
-        - Name: noverflow
-          Offset: 10
-          Type: 17 BaseType uint16
-        - Name: hash0
-          Offset: 12
-          Type: 18 BaseType uint32
-        - Name: buckets
-          Offset: 16
-          Type: 136 PointerType *bucket<string,interface {}>
-        - Name: oldbuckets
-          Offset: 24
-          Type: 136 PointerType *bucket<string,interface {}>
-        - Name: nevacuate
-          Offset: 32
-          Type: 26 BaseType uintptr
-        - Name: extra
-          Offset: 40
-          Type: 27 PointerType *runtime.mapextra
-      BucketType: 137 GoHMapBucketType bucket<string,interface {}>
-      BucketsType: 252 GoSliceDataType []bucket<string,interface {}>.array
-    - __kind: PointerType
-      ID: 136
-      Name: '*bucket<string,interface {}>'
-      ByteSize: 8
-      Pointee: 137 GoHMapBucketType bucket<string,interface {}>
-    - __kind: GoHMapBucketType
-      ID: 137
-      Name: bucket<string,interface {}>
-      ByteSize: 272
-      RawFields:
-        - Name: tophash
-          Offset: 0
-          Type: 21 ArrayType [8]uint8
-        - Name: keys
-          Offset: 8
-          Type: 22 ArrayType []key<string>
-        - Name: values
-          Offset: 136
-          Type: 138 ArrayType []val<interface {}>
-        - Name: overflow
-          Offset: 264
-          Type: 136 PointerType *bucket<string,interface {}>
-      KeyType: 5 GoStringHeaderType string
-      ValueType: 61 GoEmptyInterfaceType interface {}
-    - __kind: ArrayType
-      ID: 138
-      Name: '[]val<interface {}>'
-      ByteSize: 128
-      Count: 8
-      HasCount: true
-      Element: 61 GoEmptyInterfaceType interface {}
-    - __kind: GoMapType
-      ID: 139
-      Name: map[string]float64
-      ByteSize: 8
-      GoRuntimeType: 904896
-      GoKind: 21
-      HeaderType: 141 GoHMapHeaderType hash<string,float64>
-    - __kind: PointerType
-      ID: 140
-      Name: '*hash<string,float64>'
-      ByteSize: 8
-      Pointee: 141 GoHMapHeaderType hash<string,float64>
-    - __kind: GoHMapHeaderType
-      ID: 141
-      Name: hash<string,float64>
-      ByteSize: 48
-      RawFields:
-        - Name: count
-          Offset: 0
-          Type: 8 BaseType int
-        - Name: flags
-          Offset: 8
-          Type: 7 BaseType uint8
-        - Name: B
-          Offset: 9
-          Type: 7 BaseType uint8
-        - Name: noverflow
-          Offset: 10
-          Type: 17 BaseType uint16
-        - Name: hash0
-          Offset: 12
-          Type: 18 BaseType uint32
-        - Name: buckets
-          Offset: 16
-          Type: 142 PointerType *bucket<string,float64>
-        - Name: oldbuckets
-          Offset: 24
-          Type: 142 PointerType *bucket<string,float64>
-        - Name: nevacuate
-          Offset: 32
-          Type: 26 BaseType uintptr
-        - Name: extra
-          Offset: 40
-          Type: 27 PointerType *runtime.mapextra
-      BucketType: 143 GoHMapBucketType bucket<string,float64>
-      BucketsType: 253 GoSliceDataType []bucket<string,float64>.array
-    - __kind: PointerType
-      ID: 142
-      Name: '*bucket<string,float64>'
-      ByteSize: 8
-      Pointee: 143 GoHMapBucketType bucket<string,float64>
-    - __kind: GoHMapBucketType
-      ID: 143
-      Name: bucket<string,float64>
-      ByteSize: 208
-      RawFields:
-        - Name: tophash
-          Offset: 0
-          Type: 21 ArrayType [8]uint8
-        - Name: keys
-          Offset: 8
-          Type: 22 ArrayType []key<string>
-        - Name: values
-          Offset: 136
-          Type: 144 ArrayType []val<float64>
-        - Name: overflow
-          Offset: 200
-          Type: 142 PointerType *bucket<string,float64>
-      KeyType: 5 GoStringHeaderType string
-      ValueType: 145 BaseType float64
-    - __kind: ArrayType
-      ID: 144
-      Name: '[]val<float64>'
-      ByteSize: 64
-      Count: 8
-      HasCount: true
-      Element: 145 BaseType float64
-    - __kind: BaseType
-      ID: 145
-      Name: float64
-      ByteSize: 8
-      GoRuntimeType: 543264
-      GoKind: 14
-    - __kind: GoSliceHeaderType
-      ID: 146
-      Name: '[]github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink'
-      ByteSize: 24
-      GoRuntimeType: 463424
-      GoKind: 23
-      RawFields:
-        - Name: array
-          Offset: 0
-          Type: 147 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink
-        - Name: len
-          Offset: 8
-          Type: 8 BaseType int
-        - Name: cap
-          Offset: 16
-          Type: 8 BaseType int
-      Data: 254 GoSliceDataType []github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink.array
-    - __kind: PointerType
-      ID: 147
-      Name: '*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink'
-      ByteSize: 8
-      GoRuntimeType: 1.129216e+06
-      GoKind: 22
-      Pointee: 148 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink
-    - __kind: StructureType
-      ID: 148
-      Name: github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink
-      ByteSize: 56
-      GoRuntimeType: 1.822016e+06
-      GoKind: 25
-      RawFields:
-        - Name: TraceID
-          Offset: 0
-          Type: 74 BaseType uint64
-        - Name: TraceIDHigh
-          Offset: 8
-          Type: 74 BaseType uint64
-        - Name: SpanID
-          Offset: 16
-          Type: 74 BaseType uint64
-        - Name: Attributes
-          Offset: 24
-          Type: 120 GoMapType map[string]string
-        - Name: Tracestate
-          Offset: 32
-          Type: 5 GoStringHeaderType string
-        - Name: Flags
-          Offset: 48
-          Type: 18 BaseType uint32
-    - __kind: GoSliceHeaderType
-      ID: 149
-      Name: '[]github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent'
-      ByteSize: 24
-      GoRuntimeType: 463616
-      GoKind: 23
-      RawFields:
-        - Name: array
-          Offset: 0
-          Type: 150 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent
-        - Name: len
-          Offset: 8
-          Type: 8 BaseType int
-        - Name: cap
-          Offset: 16
-          Type: 8 BaseType int
-      Data: 256 GoSliceDataType []github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent.array
-    - __kind: PointerType
-      ID: 150
-      Name: '*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent'
-      ByteSize: 8
-      GoRuntimeType: 1.129344e+06
-      GoKind: 22
-      Pointee: 151 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent
-    - __kind: StructureType
-      ID: 151
-      Name: github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent
-      ByteSize: 40
-      GoRuntimeType: 1.663808e+06
-      GoKind: 25
-      RawFields:
-        - Name: Name
-          Offset: 0
-          Type: 5 GoStringHeaderType string
-        - Name: TimeUnixNano
-          Offset: 16
-          Type: 74 BaseType uint64
-        - Name: Attributes
-          Offset: 24
-          Type: 152 GoMapType map[string]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
-        - Name: RawAttributes
-          Offset: 32
-          Type: 168 GoMapType map[string]interface {}
-    - __kind: GoMapType
-      ID: 152
-      Name: map[string]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
-      ByteSize: 8
-      GoRuntimeType: 904992
-      GoKind: 21
-      HeaderType: 154 GoHMapHeaderType hash<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
-    - __kind: PointerType
-      ID: 153
-      Name: '*hash<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>'
-      ByteSize: 8
-      Pointee: 154 GoHMapHeaderType hash<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
-    - __kind: GoHMapHeaderType
-      ID: 154
-      Name: hash<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
-      ByteSize: 48
-      RawFields:
-        - Name: count
-          Offset: 0
-          Type: 8 BaseType int
-        - Name: flags
-          Offset: 8
-          Type: 7 BaseType uint8
-        - Name: B
-          Offset: 9
-          Type: 7 BaseType uint8
-        - Name: noverflow
-          Offset: 10
-          Type: 17 BaseType uint16
-        - Name: hash0
-          Offset: 12
-          Type: 18 BaseType uint32
-        - Name: buckets
-          Offset: 16
-          Type: 155 PointerType *bucket<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
-        - Name: oldbuckets
-          Offset: 24
-          Type: 155 PointerType *bucket<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
-        - Name: nevacuate
-          Offset: 32
-          Type: 26 BaseType uintptr
-        - Name: extra
-          Offset: 40
-          Type: 27 PointerType *runtime.mapextra
-      BucketType: 156 GoHMapBucketType bucket<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
-      BucketsType: 258 GoSliceDataType []bucket<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>.array
-    - __kind: PointerType
-      ID: 155
-      Name: '*bucket<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>'
-      ByteSize: 8
-      Pointee: 156 GoHMapBucketType bucket<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
-    - __kind: GoHMapBucketType
-      ID: 156
-      Name: bucket<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
-      ByteSize: 208
-      RawFields:
-        - Name: tophash
-          Offset: 0
-          Type: 21 ArrayType [8]uint8
-        - Name: keys
-          Offset: 8
-          Type: 22 ArrayType []key<string>
-        - Name: values
-          Offset: 136
-          Type: 157 ArrayType []val<*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
-        - Name: overflow
-          Offset: 200
-          Type: 155 PointerType *bucket<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
-      KeyType: 5 GoStringHeaderType string
-      ValueType: 158 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
-    - __kind: ArrayType
-      ID: 157
-      Name: '[]val<*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>'
-      ByteSize: 64
-      Count: 8
-      HasCount: true
-      Element: 158 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
-    - __kind: PointerType
-      ID: 158
-      Name: '*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute'
-      ByteSize: 8
-      GoRuntimeType: 1.130112e+06
-      GoKind: 22
-      Pointee: 159 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
-    - __kind: StructureType
-      ID: 159
-      Name: github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
-      ByteSize: 56
-      GoRuntimeType: 1.822272e+06
-      GoKind: 25
-      RawFields:
-        - Name: Type
-          Offset: 0
-          Type: 160 BaseType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttributeType
-        - Name: StringValue
-          Offset: 8
-          Type: 5 GoStringHeaderType string
-        - Name: BoolValue
-          Offset: 24
-          Type: 13 BaseType bool
-        - Name: IntValue
-          Offset: 32
-          Type: 36 BaseType int64
-        - Name: DoubleValue
-          Offset: 40
-          Type: 145 BaseType float64
-        - Name: ArrayValue
-          Offset: 48
-          Type: 161 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttribute
-    - __kind: BaseType
-      ID: 160
-      Name: github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttributeType
-      ByteSize: 4
-      GoRuntimeType: 965024
-      GoKind: 5
-    - __kind: PointerType
-      ID: 161
-      Name: '*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttribute'
-      ByteSize: 8
-      GoRuntimeType: 1.129984e+06
-      GoKind: 22
-      Pointee: 162 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttribute
-    - __kind: StructureType
-      ID: 162
-      Name: github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttribute
-      ByteSize: 24
-      GoRuntimeType: 1.129856e+06
-      GoKind: 25
-      RawFields:
-        - Name: Values
-          Offset: 0
-          Type: 163 GoSliceHeaderType []*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttributeValue
-    - __kind: GoSliceHeaderType
-      ID: 163
-      Name: '[]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttributeValue'
-      ByteSize: 24
-      GoRuntimeType: 463488
-      GoKind: 23
-      RawFields:
-        - Name: array
-          Offset: 0
-          Type: 164 PointerType **github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttributeValue
-        - Name: len
-          Offset: 8
-          Type: 8 BaseType int
-        - Name: cap
-          Offset: 16
-          Type: 8 BaseType int
-      Data: 259 GoSliceDataType []*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttributeValue.array
-    - __kind: PointerType
-      ID: 164
-      Name: '**github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttributeValue'
-      ByteSize: 8
-      GoKind: 22
-      Pointee: 165 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttributeValue
-    - __kind: PointerType
-      ID: 165
-      Name: '*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttributeValue'
-      ByteSize: 8
-      GoRuntimeType: 1.129728e+06
-      GoKind: 22
-      Pointee: 166 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttributeValue
-    - __kind: StructureType
-      ID: 166
-      Name: github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttributeValue
-      ByteSize: 48
-      GoRuntimeType: 1.747904e+06
-      GoKind: 25
-      RawFields:
-        - Name: Type
-          Offset: 0
-          Type: 167 BaseType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttributeValueType
-        - Name: StringValue
-          Offset: 8
-          Type: 5 GoStringHeaderType string
-        - Name: BoolValue
-          Offset: 24
-          Type: 13 BaseType bool
-        - Name: IntValue
-          Offset: 32
-          Type: 36 BaseType int64
-        - Name: DoubleValue
-          Offset: 40
-          Type: 145 BaseType float64
-    - __kind: BaseType
-      ID: 167
-      Name: github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttributeValueType
-      ByteSize: 4
-      GoRuntimeType: 965120
-      GoKind: 5
-    - __kind: GoMapType
-      ID: 168
-      Name: map[string]interface {}
-      ByteSize: 8
-      GoRuntimeType: 896352
-      GoKind: 21
-      HeaderType: 135 GoHMapHeaderType hash<string,interface {}>
-    - __kind: PointerType
-      ID: 169
-      Name: '*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanContext'
-      ByteSize: 8
-      GoRuntimeType: 1.916704e+06
-      GoKind: 22
-      Pointee: 170 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanContext
-    - __kind: StructureType
       ID: 170
       Name: github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanContext
       ByteSize: 168
@@ -2486,13 +2002,132 @@ Types:
         - Name: baggageOnly
           Offset: 160
           Type: 13 BaseType bool
-    - __kind: PointerType
-      ID: 171
-      Name: '*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.trace'
+    - __kind: StructureType
+      ID: 148
+      Name: github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink
+      ByteSize: 56
+      GoRuntimeType: 1.822016e+06
+      GoKind: 25
+      RawFields:
+        - Name: TraceID
+          Offset: 0
+          Type: 74 BaseType uint64
+        - Name: TraceIDHigh
+          Offset: 8
+          Type: 74 BaseType uint64
+        - Name: SpanID
+          Offset: 16
+          Type: 74 BaseType uint64
+        - Name: Attributes
+          Offset: 24
+          Type: 120 GoMapType map[string]string
+        - Name: Tracestate
+          Offset: 32
+          Type: 5 GoStringHeaderType string
+        - Name: Flags
+          Offset: 48
+          Type: 18 BaseType uint32
+    - __kind: GoMapType
+      ID: 133
+      Name: github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.metaStructMap
       ByteSize: 8
-      GoRuntimeType: 2.131968e+06
-      GoKind: 22
-      Pointee: 172 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.trace
+      GoRuntimeType: 1.007296e+06
+      GoKind: 21
+      HeaderType: 135 GoHMapHeaderType hash<string,interface {}>
+    - __kind: BaseType
+      ID: 176
+      Name: github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.samplingDecision
+      ByteSize: 4
+      GoRuntimeType: 542112
+      GoKind: 10
+    - __kind: StructureType
+      ID: 151
+      Name: github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent
+      ByteSize: 40
+      GoRuntimeType: 1.663808e+06
+      GoKind: 25
+      RawFields:
+        - Name: Name
+          Offset: 0
+          Type: 5 GoStringHeaderType string
+        - Name: TimeUnixNano
+          Offset: 16
+          Type: 74 BaseType uint64
+        - Name: Attributes
+          Offset: 24
+          Type: 152 GoMapType map[string]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
+        - Name: RawAttributes
+          Offset: 32
+          Type: 168 GoMapType map[string]interface {}
+    - __kind: StructureType
+      ID: 162
+      Name: github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttribute
+      ByteSize: 24
+      GoRuntimeType: 1.129856e+06
+      GoKind: 25
+      RawFields:
+        - Name: Values
+          Offset: 0
+          Type: 163 GoSliceHeaderType []*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttributeValue
+    - __kind: StructureType
+      ID: 166
+      Name: github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttributeValue
+      ByteSize: 48
+      GoRuntimeType: 1.747904e+06
+      GoKind: 25
+      RawFields:
+        - Name: Type
+          Offset: 0
+          Type: 167 BaseType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttributeValueType
+        - Name: StringValue
+          Offset: 8
+          Type: 5 GoStringHeaderType string
+        - Name: BoolValue
+          Offset: 24
+          Type: 13 BaseType bool
+        - Name: IntValue
+          Offset: 32
+          Type: 36 BaseType int64
+        - Name: DoubleValue
+          Offset: 40
+          Type: 145 BaseType float64
+    - __kind: BaseType
+      ID: 167
+      Name: github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttributeValueType
+      ByteSize: 4
+      GoRuntimeType: 965120
+      GoKind: 5
+    - __kind: StructureType
+      ID: 159
+      Name: github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
+      ByteSize: 56
+      GoRuntimeType: 1.822272e+06
+      GoKind: 25
+      RawFields:
+        - Name: Type
+          Offset: 0
+          Type: 160 BaseType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttributeType
+        - Name: StringValue
+          Offset: 8
+          Type: 5 GoStringHeaderType string
+        - Name: BoolValue
+          Offset: 24
+          Type: 13 BaseType bool
+        - Name: IntValue
+          Offset: 32
+          Type: 36 BaseType int64
+        - Name: DoubleValue
+          Offset: 40
+          Type: 145 BaseType float64
+        - Name: ArrayValue
+          Offset: 48
+          Type: 161 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttribute
+    - __kind: BaseType
+      ID: 160
+      Name: github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttributeType
+      ByteSize: 4
+      GoRuntimeType: 965024
+      GoKind: 5
     - __kind: StructureType
       ID: 172
       Name: github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.trace
@@ -2530,42 +2165,6 @@ Types:
         - Name: root
           Offset: 96
           Type: 126 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span
-    - __kind: GoSliceHeaderType
-      ID: 173
-      Name: '[]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span'
-      ByteSize: 24
-      GoRuntimeType: 463872
-      GoKind: 23
-      RawFields:
-        - Name: array
-          Offset: 0
-          Type: 174 PointerType **github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span
-        - Name: len
-          Offset: 8
-          Type: 8 BaseType int
-        - Name: cap
-          Offset: 16
-          Type: 8 BaseType int
-      Data: 261 GoSliceDataType []*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span.array
-    - __kind: PointerType
-      ID: 174
-      Name: '**github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span'
-      ByteSize: 8
-      GoKind: 22
-      Pointee: 126 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span
-    - __kind: PointerType
-      ID: 175
-      Name: '*float64'
-      ByteSize: 8
-      GoRuntimeType: 376960
-      GoKind: 22
-      Pointee: 145 BaseType float64
-    - __kind: BaseType
-      ID: 176
-      Name: github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.samplingDecision
-      ByteSize: 4
-      GoRuntimeType: 542112
-      GoKind: 10
     - __kind: ArrayType
       ID: 177
       Name: github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.traceID
@@ -2575,93 +2174,258 @@ Types:
       Count: 16
       HasCount: true
       Element: 7 BaseType uint8
-    - __kind: GoSubroutineType
-      ID: 178
-      Name: func()
-      ByteSize: 8
-      GoRuntimeType: 455360
-      GoKind: 19
-    - __kind: PointerType
-      ID: 179
-      Name: '*bytes.Buffer'
-      ByteSize: 8
-      GoRuntimeType: 2.17632e+06
-      GoKind: 22
-      Pointee: 180 StructureType bytes.Buffer
-    - __kind: StructureType
-      ID: 180
-      Name: bytes.Buffer
-      ByteSize: 40
-      GoRuntimeType: 1.450816e+06
-      GoKind: 25
+    - __kind: GoHMapHeaderType
+      ID: 154
+      Name: hash<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
+      ByteSize: 48
       RawFields:
-        - Name: buf
+        - Name: count
           Offset: 0
-          Type: 52 GoSliceHeaderType []uint8
-        - Name: off
-          Offset: 24
           Type: 8 BaseType int
-        - Name: lastRead
+        - Name: flags
+          Offset: 8
+          Type: 7 BaseType uint8
+        - Name: B
+          Offset: 9
+          Type: 7 BaseType uint8
+        - Name: noverflow
+          Offset: 10
+          Type: 17 BaseType uint16
+        - Name: hash0
+          Offset: 12
+          Type: 18 BaseType uint32
+        - Name: buckets
+          Offset: 16
+          Type: 155 PointerType *bucket<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
+        - Name: oldbuckets
+          Offset: 24
+          Type: 155 PointerType *bucket<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
+        - Name: nevacuate
           Offset: 32
-          Type: 181 BaseType bytes.readOp
-    - __kind: BaseType
-      ID: 181
-      Name: bytes.readOp
-      ByteSize: 1
-      GoRuntimeType: 541536
-      GoKind: 3
-    - __kind: StructureType
-      ID: 182
-      Name: context.backgroundCtx
-      GoRuntimeType: 1.708256e+06
-      GoKind: 25
+          Type: 26 BaseType uintptr
+        - Name: extra
+          Offset: 40
+          Type: 27 PointerType *runtime.mapextra
+      BucketType: 156 GoHMapBucketType bucket<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
+      BucketsType: 258 GoSliceDataType []bucket<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>.array
+    - __kind: GoHMapHeaderType
+      ID: 43
+      Name: hash<string,[]*mime/multipart.FileHeader>
+      ByteSize: 48
       RawFields:
-        - Name: emptyCtx
+        - Name: count
           Offset: 0
-          Type: 183 StructureType context.emptyCtx
-    - __kind: StructureType
-      ID: 183
-      Name: context.emptyCtx
-      GoRuntimeType: 1.43472e+06
-      GoKind: 25
-      RawFields: []
-    - __kind: PointerType
-      ID: 184
-      Name: '*bool'
+          Type: 8 BaseType int
+        - Name: flags
+          Offset: 8
+          Type: 7 BaseType uint8
+        - Name: B
+          Offset: 9
+          Type: 7 BaseType uint8
+        - Name: noverflow
+          Offset: 10
+          Type: 17 BaseType uint16
+        - Name: hash0
+          Offset: 12
+          Type: 18 BaseType uint32
+        - Name: buckets
+          Offset: 16
+          Type: 44 PointerType *bucket<string,[]*mime/multipart.FileHeader>
+        - Name: oldbuckets
+          Offset: 24
+          Type: 44 PointerType *bucket<string,[]*mime/multipart.FileHeader>
+        - Name: nevacuate
+          Offset: 32
+          Type: 26 BaseType uintptr
+        - Name: extra
+          Offset: 40
+          Type: 27 PointerType *runtime.mapextra
+      BucketType: 45 GoHMapBucketType bucket<string,[]*mime/multipart.FileHeader>
+      BucketsType: 210 GoSliceDataType []bucket<string,[]*mime/multipart.FileHeader>.array
+    - __kind: GoHMapHeaderType
+      ID: 16
+      Name: hash<string,[]string>
+      ByteSize: 48
+      RawFields:
+        - Name: count
+          Offset: 0
+          Type: 8 BaseType int
+        - Name: flags
+          Offset: 8
+          Type: 7 BaseType uint8
+        - Name: B
+          Offset: 9
+          Type: 7 BaseType uint8
+        - Name: noverflow
+          Offset: 10
+          Type: 17 BaseType uint16
+        - Name: hash0
+          Offset: 12
+          Type: 18 BaseType uint32
+        - Name: buckets
+          Offset: 16
+          Type: 19 PointerType *bucket<string,[]string>
+        - Name: oldbuckets
+          Offset: 24
+          Type: 19 PointerType *bucket<string,[]string>
+        - Name: nevacuate
+          Offset: 32
+          Type: 26 BaseType uintptr
+        - Name: extra
+          Offset: 40
+          Type: 27 PointerType *runtime.mapextra
+      BucketType: 20 GoHMapBucketType bucket<string,[]string>
+      BucketsType: 205 GoSliceDataType []bucket<string,[]string>.array
+    - __kind: GoHMapHeaderType
+      ID: 141
+      Name: hash<string,float64>
+      ByteSize: 48
+      RawFields:
+        - Name: count
+          Offset: 0
+          Type: 8 BaseType int
+        - Name: flags
+          Offset: 8
+          Type: 7 BaseType uint8
+        - Name: B
+          Offset: 9
+          Type: 7 BaseType uint8
+        - Name: noverflow
+          Offset: 10
+          Type: 17 BaseType uint16
+        - Name: hash0
+          Offset: 12
+          Type: 18 BaseType uint32
+        - Name: buckets
+          Offset: 16
+          Type: 142 PointerType *bucket<string,float64>
+        - Name: oldbuckets
+          Offset: 24
+          Type: 142 PointerType *bucket<string,float64>
+        - Name: nevacuate
+          Offset: 32
+          Type: 26 BaseType uintptr
+        - Name: extra
+          Offset: 40
+          Type: 27 PointerType *runtime.mapextra
+      BucketType: 143 GoHMapBucketType bucket<string,float64>
+      BucketsType: 253 GoSliceDataType []bucket<string,float64>.array
+    - __kind: GoHMapHeaderType
+      ID: 135
+      Name: hash<string,interface {}>
+      ByteSize: 48
+      RawFields:
+        - Name: count
+          Offset: 0
+          Type: 8 BaseType int
+        - Name: flags
+          Offset: 8
+          Type: 7 BaseType uint8
+        - Name: B
+          Offset: 9
+          Type: 7 BaseType uint8
+        - Name: noverflow
+          Offset: 10
+          Type: 17 BaseType uint16
+        - Name: hash0
+          Offset: 12
+          Type: 18 BaseType uint32
+        - Name: buckets
+          Offset: 16
+          Type: 136 PointerType *bucket<string,interface {}>
+        - Name: oldbuckets
+          Offset: 24
+          Type: 136 PointerType *bucket<string,interface {}>
+        - Name: nevacuate
+          Offset: 32
+          Type: 26 BaseType uintptr
+        - Name: extra
+          Offset: 40
+          Type: 27 PointerType *runtime.mapextra
+      BucketType: 137 GoHMapBucketType bucket<string,interface {}>
+      BucketsType: 252 GoSliceDataType []bucket<string,interface {}>.array
+    - __kind: GoHMapHeaderType
+      ID: 122
+      Name: hash<string,string>
+      ByteSize: 48
+      RawFields:
+        - Name: count
+          Offset: 0
+          Type: 8 BaseType int
+        - Name: flags
+          Offset: 8
+          Type: 7 BaseType uint8
+        - Name: B
+          Offset: 9
+          Type: 7 BaseType uint8
+        - Name: noverflow
+          Offset: 10
+          Type: 17 BaseType uint16
+        - Name: hash0
+          Offset: 12
+          Type: 18 BaseType uint32
+        - Name: buckets
+          Offset: 16
+          Type: 123 PointerType *bucket<string,string>
+        - Name: oldbuckets
+          Offset: 24
+          Type: 123 PointerType *bucket<string,string>
+        - Name: nevacuate
+          Offset: 32
+          Type: 26 BaseType uintptr
+        - Name: extra
+          Offset: 40
+          Type: 27 PointerType *runtime.mapextra
+      BucketType: 124 GoHMapBucketType bucket<string,string>
+      BucketsType: 251 GoSliceDataType []bucket<string,string>.array
+    - __kind: BaseType
+      ID: 8
+      Name: int
       ByteSize: 8
-      GoRuntimeType: 377024
-      GoKind: 22
-      Pointee: 13 BaseType bool
-    - __kind: PointerType
-      ID: 185
-      Name: '*uintptr'
+      GoRuntimeType: 542880
+      GoKind: 2
+    - __kind: BaseType
+      ID: 198
+      Name: int16
+      ByteSize: 2
+      GoRuntimeType: 542496
+      GoKind: 4
+    - __kind: BaseType
+      ID: 130
+      Name: int32
+      ByteSize: 4
+      GoRuntimeType: 542624
+      GoKind: 5
+    - __kind: BaseType
+      ID: 36
+      Name: int64
       ByteSize: 8
-      GoRuntimeType: 376704
-      GoKind: 22
-      Pointee: 26 BaseType uintptr
+      GoRuntimeType: 542752
+      GoKind: 6
     - __kind: BaseType
       ID: 186
       Name: int8
       ByteSize: 1
       GoRuntimeType: 542368
       GoKind: 3
-    - __kind: BaseType
-      ID: 187
-      Name: uint
-      ByteSize: 8
-      GoRuntimeType: 542944
-      GoKind: 7
-    - __kind: BaseType
-      ID: 188
-      Name: float32
-      ByteSize: 4
-      GoRuntimeType: 543200
-      GoKind: 13
-    - __kind: GoInterfaceType
-      ID: 189
-      Name: error
+    - __kind: GoEmptyInterfaceType
+      ID: 61
+      Name: interface {}
       ByteSize: 16
-      GoRuntimeType: 1.01088e+06
+      GoRuntimeType: 797888
+      GoKind: 20
+      RawFields:
+        - Name: _type
+          Offset: 0
+          Type: 2 VoidPointerType unsafe.Pointer
+        - Name: data
+          Offset: 8
+          Type: 2 VoidPointerType unsafe.Pointer
+    - __kind: GoInterfaceType
+      ID: 34
+      Name: io.ReadCloser
+      ByteSize: 16
+      GoRuntimeType: 1.092864e+06
       GoKind: 20
       RawFields:
         - Name: tab
@@ -2670,432 +2434,668 @@ Types:
         - Name: data
           Offset: 8
           Type: 2 VoidPointerType unsafe.Pointer
-    - __kind: PointerType
-      ID: 190
-      Name: '*int32'
+    - __kind: GoMapType
+      ID: 152
+      Name: map[string]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
       ByteSize: 8
-      GoRuntimeType: 376320
-      GoKind: 22
-      Pointee: 130 BaseType int32
-    - __kind: PointerType
-      ID: 191
-      Name: '*uint32'
+      GoRuntimeType: 904992
+      GoKind: 21
+      HeaderType: 154 GoHMapHeaderType hash<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
+    - __kind: GoMapType
+      ID: 41
+      Name: map[string][]*mime/multipart.FileHeader
       ByteSize: 8
-      GoRuntimeType: 376384
-      GoKind: 22
-      Pointee: 18 BaseType uint32
+      GoRuntimeType: 904032
+      GoKind: 21
+      HeaderType: 43 GoHMapHeaderType hash<string,[]*mime/multipart.FileHeader>
+    - __kind: GoMapType
+      ID: 40
+      Name: map[string][]string
+      ByteSize: 8
+      GoRuntimeType: 899232
+      GoKind: 21
+      HeaderType: 16 GoHMapHeaderType hash<string,[]string>
+    - __kind: GoMapType
+      ID: 139
+      Name: map[string]float64
+      ByteSize: 8
+      GoRuntimeType: 904896
+      GoKind: 21
+      HeaderType: 141 GoHMapHeaderType hash<string,float64>
+    - __kind: GoMapType
+      ID: 168
+      Name: map[string]interface {}
+      ByteSize: 8
+      GoRuntimeType: 896352
+      GoKind: 21
+      HeaderType: 135 GoHMapHeaderType hash<string,interface {}>
+    - __kind: GoMapType
+      ID: 120
+      Name: map[string]string
+      ByteSize: 8
+      GoRuntimeType: 900864
+      GoKind: 21
+      HeaderType: 122 GoHMapHeaderType hash<string,string>
+    - __kind: StructureType
+      ID: 63
+      Name: math/big.Int
+      ByteSize: 32
+      GoRuntimeType: 1.340544e+06
+      GoKind: 25
+      RawFields:
+        - Name: neg
+          Offset: 0
+          Type: 13 BaseType bool
+        - Name: abs
+          Offset: 8
+          Type: 64 GoSliceHeaderType math/big.nat
     - __kind: BaseType
-      ID: 192
-      Name: complex64
+      ID: 66
+      Name: math/big.Word
       ByteSize: 8
-      GoRuntimeType: 543072
-      GoKind: 15
-    - __kind: BaseType
-      ID: 193
-      Name: complex128
-      ByteSize: 16
-      GoRuntimeType: 543136
-      GoKind: 16
-    - __kind: PointerType
-      ID: 194
-      Name: '*int64'
-      ByteSize: 8
-      GoRuntimeType: 376448
-      GoKind: 22
-      Pointee: 36 BaseType int64
-    - __kind: PointerType
-      ID: 195
-      Name: '*uint64'
-      ByteSize: 8
-      GoRuntimeType: 376512
-      GoKind: 22
-      Pointee: 74 BaseType uint64
-    - __kind: PointerType
-      ID: 196
-      Name: '*uint16'
-      ByteSize: 8
-      GoRuntimeType: 376256
-      GoKind: 22
-      Pointee: 17 BaseType uint16
-    - __kind: PointerType
-      ID: 197
-      Name: '*int16'
-      ByteSize: 8
-      GoRuntimeType: 376192
-      GoKind: 22
-      Pointee: 198 BaseType int16
-    - __kind: BaseType
-      ID: 198
-      Name: int16
-      ByteSize: 2
-      GoRuntimeType: 542496
-      GoKind: 4
-    - __kind: PointerType
-      ID: 199
-      Name: '*int8'
-      ByteSize: 8
-      GoRuntimeType: 376064
-      GoKind: 22
-      Pointee: 186 BaseType int8
-    - __kind: PointerType
-      ID: 200
-      Name: '*error'
-      ByteSize: 8
-      GoRuntimeType: 375936
-      GoKind: 22
-      Pointee: 189 GoInterfaceType error
-    - __kind: PointerType
-      ID: 201
-      Name: '*uint'
-      ByteSize: 8
-      GoRuntimeType: 376640
-      GoKind: 22
-      Pointee: 187 BaseType uint
-    - __kind: PointerType
-      ID: 202
-      Name: '*float32'
-      ByteSize: 8
-      GoRuntimeType: 376896
-      GoKind: 22
-      Pointee: 188 BaseType float32
-    - __kind: GoStringDataType
-      ID: 203
-      Name: string.str
-      ByteSize: 2048
-    - __kind: PointerType
-      ID: 204
-      Name: '*string.str'
-      ByteSize: 8
-      Pointee: 203 GoStringDataType string.str
-    - __kind: GoSliceDataType
-      ID: 205
-      Name: '[]bucket<string,[]string>.array'
-      ByteSize: 2048
-      Element: 20 GoHMapBucketType bucket<string,[]string>
-    - __kind: GoSliceDataType
-      ID: 206
-      Name: '[]string.array'
-      ByteSize: 2048
-      Element: 5 GoStringHeaderType string
-    - __kind: PointerType
-      ID: 207
-      Name: '*[]string.array'
-      ByteSize: 8
-      Pointee: 206 GoSliceDataType []string.array
-    - __kind: GoSliceDataType
-      ID: 208
-      Name: '[]*runtime.bmap.array'
-      ByteSize: 2048
-      Element: 32 PointerType *runtime.bmap
-    - __kind: PointerType
-      ID: 209
-      Name: '*[]*runtime.bmap.array'
-      ByteSize: 8
-      Pointee: 208 GoSliceDataType []*runtime.bmap.array
-    - __kind: GoSliceDataType
-      ID: 210
-      Name: '[]bucket<string,[]*mime/multipart.FileHeader>.array'
-      ByteSize: 2048
-      Element: 45 GoHMapBucketType bucket<string,[]*mime/multipart.FileHeader>
-    - __kind: GoSliceDataType
-      ID: 211
-      Name: '[]*mime/multipart.FileHeader.array'
-      ByteSize: 2048
-      Element: 49 PointerType *mime/multipart.FileHeader
-    - __kind: PointerType
-      ID: 212
-      Name: '*[]*mime/multipart.FileHeader.array'
-      ByteSize: 8
-      Pointee: 211 GoSliceDataType []*mime/multipart.FileHeader.array
-    - __kind: GoSliceDataType
-      ID: 213
-      Name: '[]uint8.array'
-      ByteSize: 2048
-      Element: 7 BaseType uint8
-    - __kind: PointerType
-      ID: 214
-      Name: '*[]uint8.array'
-      ByteSize: 8
-      Pointee: 213 GoSliceDataType []uint8.array
-    - __kind: GoSliceDataType
-      ID: 215
-      Name: '[]*crypto/x509.Certificate.array'
-      ByteSize: 2048
-      Element: 57 PointerType *crypto/x509.Certificate
-    - __kind: PointerType
-      ID: 216
-      Name: '*[]*crypto/x509.Certificate.array'
-      ByteSize: 8
-      Pointee: 215 GoSliceDataType []*crypto/x509.Certificate.array
+      GoRuntimeType: 546656
+      GoKind: 7
+    - __kind: GoSliceHeaderType
+      ID: 64
+      Name: math/big.nat
+      ByteSize: 24
+      GoRuntimeType: 2.279968e+06
+      GoKind: 23
+      RawFields:
+        - Name: array
+          Offset: 0
+          Type: 65 PointerType *math/big.Word
+        - Name: len
+          Offset: 8
+          Type: 8 BaseType int
+        - Name: cap
+          Offset: 16
+          Type: 8 BaseType int
+      Data: 217 GoSliceDataType math/big.nat.array
     - __kind: GoSliceDataType
       ID: 217
       Name: math/big.nat.array
       ByteSize: 2048
       Element: 66 BaseType math/big.Word
-    - __kind: PointerType
-      ID: 218
-      Name: '*math/big.nat.array'
-      ByteSize: 8
-      Pointee: 217 GoSliceDataType math/big.nat.array
-    - __kind: GoSliceDataType
-      ID: 219
-      Name: '[]crypto/x509/pkix.AttributeTypeAndValue.array'
-      ByteSize: 2048
-      Element: 70 StructureType crypto/x509/pkix.AttributeTypeAndValue
-    - __kind: PointerType
-      ID: 220
-      Name: '*[]crypto/x509/pkix.AttributeTypeAndValue.array'
-      ByteSize: 8
-      Pointee: 219 GoSliceDataType []crypto/x509/pkix.AttributeTypeAndValue.array
-    - __kind: GoSliceDataType
-      ID: 221
-      Name: encoding/asn1.ObjectIdentifier.array
-      ByteSize: 2048
-      Element: 8 BaseType int
-    - __kind: PointerType
-      ID: 222
-      Name: '*encoding/asn1.ObjectIdentifier.array'
-      ByteSize: 8
-      Pointee: 221 GoSliceDataType encoding/asn1.ObjectIdentifier.array
-    - __kind: GoSliceDataType
-      ID: 223
-      Name: '[]time.zone.array'
-      ByteSize: 2048
-      Element: 79 StructureType time.zone
-    - __kind: PointerType
-      ID: 224
-      Name: '*[]time.zone.array'
-      ByteSize: 8
-      Pointee: 223 GoSliceDataType []time.zone.array
-    - __kind: GoSliceDataType
-      ID: 225
-      Name: '[]time.zoneTrans.array'
-      ByteSize: 2048
-      Element: 82 StructureType time.zoneTrans
-    - __kind: PointerType
-      ID: 226
-      Name: '*[]time.zoneTrans.array'
-      ByteSize: 8
-      Pointee: 225 GoSliceDataType []time.zoneTrans.array
-    - __kind: GoSliceDataType
-      ID: 227
-      Name: '[]crypto/x509/pkix.Extension.array'
-      ByteSize: 2048
-      Element: 86 StructureType crypto/x509/pkix.Extension
-    - __kind: PointerType
-      ID: 228
-      Name: '*[]crypto/x509/pkix.Extension.array'
-      ByteSize: 8
-      Pointee: 227 GoSliceDataType []crypto/x509/pkix.Extension.array
-    - __kind: GoSliceDataType
-      ID: 229
-      Name: '[]encoding/asn1.ObjectIdentifier.array'
-      ByteSize: 2048
-      Element: 71 GoSliceHeaderType encoding/asn1.ObjectIdentifier
-    - __kind: PointerType
-      ID: 230
-      Name: '*[]encoding/asn1.ObjectIdentifier.array'
-      ByteSize: 8
-      Pointee: 229 GoSliceDataType []encoding/asn1.ObjectIdentifier.array
-    - __kind: GoSliceDataType
-      ID: 231
-      Name: '[]crypto/x509.ExtKeyUsage.array'
-      ByteSize: 2048
-      Element: 91 BaseType crypto/x509.ExtKeyUsage
-    - __kind: PointerType
-      ID: 232
-      Name: '*[]crypto/x509.ExtKeyUsage.array'
-      ByteSize: 8
-      Pointee: 231 GoSliceDataType []crypto/x509.ExtKeyUsage.array
-    - __kind: GoSliceDataType
-      ID: 233
-      Name: '[]net.IP.array'
-      ByteSize: 2048
-      Element: 94 GoSliceHeaderType net.IP
-    - __kind: PointerType
-      ID: 234
-      Name: '*[]net.IP.array'
-      ByteSize: 8
-      Pointee: 233 GoSliceDataType []net.IP.array
+    - __kind: StructureType
+      ID: 50
+      Name: mime/multipart.FileHeader
+      ByteSize: 88
+      GoRuntimeType: 1.88112e+06
+      GoKind: 25
+      RawFields:
+        - Name: Filename
+          Offset: 0
+          Type: 5 GoStringHeaderType string
+        - Name: Header
+          Offset: 16
+          Type: 51 GoMapType net/textproto.MIMEHeader
+        - Name: Size
+          Offset: 24
+          Type: 36 BaseType int64
+        - Name: content
+          Offset: 32
+          Type: 52 GoSliceHeaderType []uint8
+        - Name: tmpfile
+          Offset: 56
+          Type: 5 GoStringHeaderType string
+        - Name: tmpoff
+          Offset: 72
+          Type: 36 BaseType int64
+        - Name: tmpshared
+          Offset: 80
+          Type: 13 BaseType bool
+    - __kind: StructureType
+      ID: 39
+      Name: mime/multipart.Form
+      ByteSize: 16
+      GoRuntimeType: 1.325824e+06
+      GoKind: 25
+      RawFields:
+        - Name: Value
+          Offset: 0
+          Type: 40 GoMapType map[string][]string
+        - Name: File
+          Offset: 8
+          Type: 41 GoMapType map[string][]*mime/multipart.FileHeader
+    - __kind: GoSliceHeaderType
+      ID: 94
+      Name: net.IP
+      ByteSize: 24
+      GoRuntimeType: 2.000864e+06
+      GoKind: 23
+      RawFields:
+        - Name: array
+          Offset: 0
+          Type: 6 PointerType *uint8
+        - Name: len
+          Offset: 8
+          Type: 8 BaseType int
+        - Name: cap
+          Offset: 16
+          Type: 8 BaseType int
+      Data: 235 GoSliceDataType net.IP.array
     - __kind: GoSliceDataType
       ID: 235
       Name: net.IP.array
       ByteSize: 2048
       Element: 7 BaseType uint8
-    - __kind: PointerType
-      ID: 236
-      Name: '*net.IP.array'
-      ByteSize: 8
-      Pointee: 235 GoSliceDataType net.IP.array
-    - __kind: GoSliceDataType
-      ID: 237
-      Name: '[]*net/url.URL.array'
-      ByteSize: 2048
-      Element: 9 PointerType *net/url.URL
-    - __kind: PointerType
-      ID: 238
-      Name: '*[]*net/url.URL.array'
-      ByteSize: 8
-      Pointee: 237 GoSliceDataType []*net/url.URL.array
-    - __kind: GoSliceDataType
-      ID: 239
-      Name: '[]*net.IPNet.array'
-      ByteSize: 2048
-      Element: 99 PointerType *net.IPNet
-    - __kind: PointerType
-      ID: 240
-      Name: '*[]*net.IPNet.array'
-      ByteSize: 8
-      Pointee: 239 GoSliceDataType []*net.IPNet.array
+    - __kind: GoSliceHeaderType
+      ID: 101
+      Name: net.IPMask
+      ByteSize: 24
+      GoRuntimeType: 999232
+      GoKind: 23
+      RawFields:
+        - Name: array
+          Offset: 0
+          Type: 6 PointerType *uint8
+        - Name: len
+          Offset: 8
+          Type: 8 BaseType int
+        - Name: cap
+          Offset: 16
+          Type: 8 BaseType int
+      Data: 241 GoSliceDataType net.IPMask.array
     - __kind: GoSliceDataType
       ID: 241
       Name: net.IPMask.array
       ByteSize: 2048
       Element: 7 BaseType uint8
-    - __kind: PointerType
-      ID: 242
-      Name: '*net.IPMask.array'
+    - __kind: StructureType
+      ID: 100
+      Name: net.IPNet
+      ByteSize: 48
+      GoRuntimeType: 1.306944e+06
+      GoKind: 25
+      RawFields:
+        - Name: IP
+          Offset: 0
+          Type: 94 GoSliceHeaderType net.IP
+        - Name: Mask
+          Offset: 24
+          Type: 101 GoSliceHeaderType net.IPMask
+    - __kind: GoMapType
+      ID: 14
+      Name: net/http.Header
       ByteSize: 8
-      Pointee: 241 GoSliceDataType net.IPMask.array
-    - __kind: GoSliceDataType
-      ID: 243
-      Name: '[]crypto/x509.OID.array'
-      ByteSize: 2048
-      Element: 104 StructureType crypto/x509.OID
-    - __kind: PointerType
-      ID: 244
-      Name: '*[]crypto/x509.OID.array'
-      ByteSize: 8
-      Pointee: 243 GoSliceDataType []crypto/x509.OID.array
-    - __kind: GoSliceDataType
-      ID: 245
-      Name: '[][]*crypto/x509.Certificate.array'
-      ByteSize: 2048
-      Element: 55 GoSliceHeaderType []*crypto/x509.Certificate
-    - __kind: PointerType
-      ID: 246
-      Name: '*[][]*crypto/x509.Certificate.array'
-      ByteSize: 8
-      Pointee: 245 GoSliceDataType [][]*crypto/x509.Certificate.array
-    - __kind: GoSliceDataType
-      ID: 247
-      Name: '[][]uint8.array'
-      ByteSize: 2048
-      Element: 52 GoSliceHeaderType []uint8
-    - __kind: PointerType
-      ID: 248
-      Name: '*[][]uint8.array'
-      ByteSize: 8
-      Pointee: 247 GoSliceDataType [][]uint8.array
-    - __kind: GoSliceDataType
-      ID: 249
-      Name: '[]net/http.segment.array'
-      ByteSize: 2048
-      Element: 119 StructureType net/http.segment
-    - __kind: PointerType
-      ID: 250
-      Name: '*[]net/http.segment.array'
-      ByteSize: 8
-      Pointee: 249 GoSliceDataType []net/http.segment.array
-    - __kind: GoSliceDataType
-      ID: 251
-      Name: '[]bucket<string,string>.array'
-      ByteSize: 2048
-      Element: 124 GoHMapBucketType bucket<string,string>
-    - __kind: GoSliceDataType
-      ID: 252
-      Name: '[]bucket<string,interface {}>.array'
-      ByteSize: 2048
-      Element: 137 GoHMapBucketType bucket<string,interface {}>
-    - __kind: GoSliceDataType
-      ID: 253
-      Name: '[]bucket<string,float64>.array'
-      ByteSize: 2048
-      Element: 143 GoHMapBucketType bucket<string,float64>
-    - __kind: GoSliceDataType
-      ID: 254
-      Name: '[]github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink.array'
-      ByteSize: 2048
-      Element: 148 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink
-    - __kind: PointerType
-      ID: 255
-      Name: '*[]github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink.array'
-      ByteSize: 8
-      Pointee: 254 GoSliceDataType []github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink.array
-    - __kind: GoSliceDataType
-      ID: 256
-      Name: '[]github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent.array'
-      ByteSize: 2048
-      Element: 151 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent
-    - __kind: PointerType
-      ID: 257
-      Name: '*[]github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent.array'
-      ByteSize: 8
-      Pointee: 256 GoSliceDataType []github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent.array
-    - __kind: GoSliceDataType
-      ID: 258
-      Name: '[]bucket<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>.array'
-      ByteSize: 2048
-      Element: 156 GoHMapBucketType bucket<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
-    - __kind: GoSliceDataType
-      ID: 259
-      Name: '[]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttributeValue.array'
-      ByteSize: 2048
-      Element: 165 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttributeValue
-    - __kind: PointerType
-      ID: 260
-      Name: '*[]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttributeValue.array'
-      ByteSize: 8
-      Pointee: 259 GoSliceDataType []*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttributeValue.array
-    - __kind: GoSliceDataType
-      ID: 261
-      Name: '[]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span.array'
-      ByteSize: 2048
-      Element: 126 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span
-    - __kind: PointerType
-      ID: 262
-      Name: '*[]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span.array'
-      ByteSize: 8
-      Pointee: 261 GoSliceDataType []*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span.array
-    - __kind: EventRootType
-      ID: 263
-      Name: Probe[main.HandleHTTP]
-      ByteSize: 25
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: w
-          Offset: 1
-          Expression:
-            Type: 1 GoInterfaceType net/http.ResponseWriter
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 1, index: 0, name: w}
-                  Offset: 0
-                  ByteSize: 16
-        - Name: r
+      GoRuntimeType: 1.963712e+06
+      GoKind: 21
+      HeaderType: 16 GoHMapHeaderType hash<string,[]string>
+    - __kind: StructureType
+      ID: 4
+      Name: net/http.Request
+      ByteSize: 304
+      GoRuntimeType: 2.255712e+06
+      GoKind: 25
+      RawFields:
+        - Name: Method
+          Offset: 0
+          Type: 5 GoStringHeaderType string
+        - Name: URL
+          Offset: 16
+          Type: 9 PointerType *net/url.URL
+        - Name: Proto
+          Offset: 24
+          Type: 5 GoStringHeaderType string
+        - Name: ProtoMajor
+          Offset: 40
+          Type: 8 BaseType int
+        - Name: ProtoMinor
+          Offset: 48
+          Type: 8 BaseType int
+        - Name: Header
+          Offset: 56
+          Type: 14 GoMapType net/http.Header
+        - Name: Body
+          Offset: 64
+          Type: 34 GoInterfaceType io.ReadCloser
+        - Name: GetBody
+          Offset: 80
+          Type: 35 GoSubroutineType func() (io.ReadCloser, error)
+        - Name: ContentLength
+          Offset: 88
+          Type: 36 BaseType int64
+        - Name: TransferEncoding
+          Offset: 96
+          Type: 24 GoSliceHeaderType []string
+        - Name: Close
+          Offset: 120
+          Type: 13 BaseType bool
+        - Name: Host
+          Offset: 128
+          Type: 5 GoStringHeaderType string
+        - Name: Form
+          Offset: 144
+          Type: 37 GoMapType net/url.Values
+        - Name: PostForm
+          Offset: 152
+          Type: 37 GoMapType net/url.Values
+        - Name: MultipartForm
+          Offset: 160
+          Type: 38 PointerType *mime/multipart.Form
+        - Name: Trailer
+          Offset: 168
+          Type: 14 GoMapType net/http.Header
+        - Name: RemoteAddr
+          Offset: 176
+          Type: 5 GoStringHeaderType string
+        - Name: RequestURI
+          Offset: 192
+          Type: 5 GoStringHeaderType string
+        - Name: TLS
+          Offset: 208
+          Type: 53 PointerType *crypto/tls.ConnectionState
+        - Name: Cancel
+          Offset: 216
+          Type: 111 GoChannelType <-chan struct {}
+        - Name: Response
+          Offset: 224
+          Type: 112 PointerType *net/http.Response
+        - Name: Pattern
+          Offset: 232
+          Type: 5 GoStringHeaderType string
+        - Name: ctx
+          Offset: 248
+          Type: 114 GoInterfaceType context.Context
+        - Name: pat
+          Offset: 264
+          Type: 115 PointerType *net/http.pattern
+        - Name: matches
+          Offset: 272
+          Type: 24 GoSliceHeaderType []string
+        - Name: otherValues
+          Offset: 296
+          Type: 120 GoMapType map[string]string
+    - __kind: StructureType
+      ID: 113
+      Name: net/http.Response
+      ByteSize: 144
+      GoRuntimeType: 2.123456e+06
+      GoKind: 25
+      RawFields:
+        - Name: Status
+          Offset: 0
+          Type: 5 GoStringHeaderType string
+        - Name: StatusCode
+          Offset: 16
+          Type: 8 BaseType int
+        - Name: Proto
+          Offset: 24
+          Type: 5 GoStringHeaderType string
+        - Name: ProtoMajor
+          Offset: 40
+          Type: 8 BaseType int
+        - Name: ProtoMinor
+          Offset: 48
+          Type: 8 BaseType int
+        - Name: Header
+          Offset: 56
+          Type: 14 GoMapType net/http.Header
+        - Name: Body
+          Offset: 64
+          Type: 34 GoInterfaceType io.ReadCloser
+        - Name: ContentLength
+          Offset: 80
+          Type: 36 BaseType int64
+        - Name: TransferEncoding
+          Offset: 88
+          Type: 24 GoSliceHeaderType []string
+        - Name: Close
+          Offset: 112
+          Type: 13 BaseType bool
+        - Name: Uncompressed
+          Offset: 113
+          Type: 13 BaseType bool
+        - Name: Trailer
+          Offset: 120
+          Type: 14 GoMapType net/http.Header
+        - Name: Request
+          Offset: 128
+          Type: 3 PointerType *net/http.Request
+        - Name: TLS
+          Offset: 136
+          Type: 53 PointerType *crypto/tls.ConnectionState
+    - __kind: GoInterfaceType
+      ID: 1
+      Name: net/http.ResponseWriter
+      ByteSize: 16
+      GoRuntimeType: 1.125248e+06
+      GoKind: 20
+      RawFields:
+        - Name: tab
+          Offset: 0
+          Type: 2 VoidPointerType unsafe.Pointer
+        - Name: data
+          Offset: 8
+          Type: 2 VoidPointerType unsafe.Pointer
+    - __kind: StructureType
+      ID: 116
+      Name: net/http.pattern
+      ByteSize: 88
+      GoRuntimeType: 1.744992e+06
+      GoKind: 25
+      RawFields:
+        - Name: str
+          Offset: 0
+          Type: 5 GoStringHeaderType string
+        - Name: method
+          Offset: 16
+          Type: 5 GoStringHeaderType string
+        - Name: host
+          Offset: 32
+          Type: 5 GoStringHeaderType string
+        - Name: segments
+          Offset: 48
+          Type: 117 GoSliceHeaderType []net/http.segment
+        - Name: loc
+          Offset: 72
+          Type: 5 GoStringHeaderType string
+    - __kind: StructureType
+      ID: 119
+      Name: net/http.segment
+      ByteSize: 24
+      GoRuntimeType: 1.452928e+06
+      GoKind: 25
+      RawFields:
+        - Name: s
+          Offset: 0
+          Type: 5 GoStringHeaderType string
+        - Name: wild
+          Offset: 16
+          Type: 13 BaseType bool
+        - Name: multi
           Offset: 17
-          Expression:
-            Type: 3 PointerType *net/http.Request
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 1, index: 1, name: r}
-                  Offset: 0
-                  ByteSize: 8
-    - __kind: EventRootType
-      ID: 264
-      Name: Probe[main.LookAtTheRequest]
-      ByteSize: 17
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: path
-          Offset: 1
-          Expression:
-            Type: 5 GoStringHeaderType string
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 2, index: 0, name: path}
-                  Offset: 0
-                  ByteSize: 16
+          Type: 13 BaseType bool
+    - __kind: GoMapType
+      ID: 51
+      Name: net/textproto.MIMEHeader
+      ByteSize: 8
+      GoRuntimeType: 1.637344e+06
+      GoKind: 21
+      HeaderType: 16 GoHMapHeaderType hash<string,[]string>
+    - __kind: StructureType
+      ID: 10
+      Name: net/url.URL
+      ByteSize: 144
+      GoRuntimeType: 2.040992e+06
+      GoKind: 25
+      RawFields:
+        - Name: Scheme
+          Offset: 0
+          Type: 5 GoStringHeaderType string
+        - Name: Opaque
+          Offset: 16
+          Type: 5 GoStringHeaderType string
+        - Name: User
+          Offset: 32
+          Type: 11 PointerType *net/url.Userinfo
+        - Name: Host
+          Offset: 40
+          Type: 5 GoStringHeaderType string
+        - Name: Path
+          Offset: 56
+          Type: 5 GoStringHeaderType string
+        - Name: RawPath
+          Offset: 72
+          Type: 5 GoStringHeaderType string
+        - Name: OmitHost
+          Offset: 88
+          Type: 13 BaseType bool
+        - Name: ForceQuery
+          Offset: 89
+          Type: 13 BaseType bool
+        - Name: RawQuery
+          Offset: 96
+          Type: 5 GoStringHeaderType string
+        - Name: Fragment
+          Offset: 112
+          Type: 5 GoStringHeaderType string
+        - Name: RawFragment
+          Offset: 128
+          Type: 5 GoStringHeaderType string
+    - __kind: StructureType
+      ID: 12
+      Name: net/url.Userinfo
+      ByteSize: 40
+      GoRuntimeType: 1.469248e+06
+      GoKind: 25
+      RawFields:
+        - Name: username
+          Offset: 0
+          Type: 5 GoStringHeaderType string
+        - Name: password
+          Offset: 16
+          Type: 5 GoStringHeaderType string
+        - Name: passwordSet
+          Offset: 32
+          Type: 13 BaseType bool
+    - __kind: GoMapType
+      ID: 37
+      Name: net/url.Values
+      ByteSize: 8
+      GoRuntimeType: 1.71184e+06
+      GoKind: 21
+      HeaderType: 16 GoHMapHeaderType hash<string,[]string>
+    - __kind: StructureType
+      ID: 33
+      Name: runtime.bmap
+      ByteSize: 8
+      GoRuntimeType: 1.136896e+06
+      GoKind: 25
+      RawFields:
+        - Name: tophash
+          Offset: 0
+          Type: 21 ArrayType [8]uint8
+    - __kind: StructureType
+      ID: 28
+      Name: runtime.mapextra
+      ByteSize: 24
+      GoRuntimeType: 1.465216e+06
+      GoKind: 25
+      RawFields:
+        - Name: overflow
+          Offset: 0
+          Type: 29 PointerType *[]*runtime.bmap
+        - Name: oldoverflow
+          Offset: 8
+          Type: 29 PointerType *[]*runtime.bmap
+        - Name: nextOverflow
+          Offset: 16
+          Type: 32 PointerType *runtime.bmap
+    - __kind: GoStringHeaderType
+      ID: 5
+      Name: string
+      ByteSize: 16
+      GoRuntimeType: 542304
+      GoKind: 24
+      RawFields:
+        - Name: str
+          Offset: 0
+          Type: 204 PointerType *string.str
+        - Name: len
+          Offset: 8
+          Type: 8 BaseType int
+      Data: 203 GoStringDataType string.str
+    - __kind: GoStringDataType
+      ID: 203
+      Name: string.str
+      ByteSize: 2048
+    - __kind: StructureType
+      ID: 129
+      Name: sync.Mutex
+      ByteSize: 8
+      GoRuntimeType: 1.313984e+06
+      GoKind: 25
+      RawFields:
+        - Name: state
+          Offset: 0
+          Type: 130 BaseType int32
+        - Name: sema
+          Offset: 4
+          Type: 18 BaseType uint32
+    - __kind: StructureType
+      ID: 128
+      Name: sync.RWMutex
+      ByteSize: 24
+      GoRuntimeType: 1.750592e+06
+      GoKind: 25
+      RawFields:
+        - Name: w
+          Offset: 0
+          Type: 129 StructureType sync.Mutex
+        - Name: writerSem
+          Offset: 8
+          Type: 18 BaseType uint32
+        - Name: readerSem
+          Offset: 12
+          Type: 18 BaseType uint32
+        - Name: readerCount
+          Offset: 16
+          Type: 131 StructureType sync/atomic.Int32
+        - Name: readerWait
+          Offset: 20
+          Type: 131 StructureType sync/atomic.Int32
+    - __kind: StructureType
+      ID: 131
+      Name: sync/atomic.Int32
+      ByteSize: 4
+      GoRuntimeType: 1.315424e+06
+      GoKind: 25
+      RawFields:
+        - Name: _
+          Offset: 0
+          Type: 132 StructureType sync/atomic.noCopy
+        - Name: v
+          Offset: 0
+          Type: 130 BaseType int32
+    - __kind: StructureType
+      ID: 132
+      Name: sync/atomic.noCopy
+      GoRuntimeType: 965792
+      GoKind: 25
+      RawFields: []
+    - __kind: StructureType
+      ID: 76
+      Name: time.Location
+      ByteSize: 104
+      GoRuntimeType: 1.877376e+06
+      GoKind: 25
+      RawFields:
+        - Name: name
+          Offset: 0
+          Type: 5 GoStringHeaderType string
+        - Name: zone
+          Offset: 16
+          Type: 77 GoSliceHeaderType []time.zone
+        - Name: tx
+          Offset: 40
+          Type: 80 GoSliceHeaderType []time.zoneTrans
+        - Name: extend
+          Offset: 64
+          Type: 5 GoStringHeaderType string
+        - Name: cacheStart
+          Offset: 80
+          Type: 36 BaseType int64
+        - Name: cacheEnd
+          Offset: 88
+          Type: 36 BaseType int64
+        - Name: cacheZone
+          Offset: 96
+          Type: 78 PointerType *time.zone
+    - __kind: StructureType
+      ID: 73
+      Name: time.Time
+      ByteSize: 24
+      GoRuntimeType: 2.280896e+06
+      GoKind: 25
+      RawFields:
+        - Name: wall
+          Offset: 0
+          Type: 74 BaseType uint64
+        - Name: ext
+          Offset: 8
+          Type: 36 BaseType int64
+        - Name: loc
+          Offset: 16
+          Type: 75 PointerType *time.Location
+    - __kind: StructureType
+      ID: 79
+      Name: time.zone
+      ByteSize: 32
+      GoRuntimeType: 1.45792e+06
+      GoKind: 25
+      RawFields:
+        - Name: name
+          Offset: 0
+          Type: 5 GoStringHeaderType string
+        - Name: offset
+          Offset: 16
+          Type: 8 BaseType int
+        - Name: isDST
+          Offset: 24
+          Type: 13 BaseType bool
+    - __kind: StructureType
+      ID: 82
+      Name: time.zoneTrans
+      ByteSize: 16
+      GoRuntimeType: 1.663616e+06
+      GoKind: 25
+      RawFields:
+        - Name: when
+          Offset: 0
+          Type: 36 BaseType int64
+        - Name: index
+          Offset: 8
+          Type: 7 BaseType uint8
+        - Name: isstd
+          Offset: 9
+          Type: 13 BaseType bool
+        - Name: isutc
+          Offset: 10
+          Type: 13 BaseType bool
+    - __kind: BaseType
+      ID: 187
+      Name: uint
+      ByteSize: 8
+      GoRuntimeType: 542944
+      GoKind: 7
+    - __kind: BaseType
+      ID: 17
+      Name: uint16
+      ByteSize: 2
+      GoRuntimeType: 542560
+      GoKind: 9
+    - __kind: BaseType
+      ID: 18
+      Name: uint32
+      ByteSize: 4
+      GoRuntimeType: 542688
+      GoKind: 10
+    - __kind: BaseType
+      ID: 74
+      Name: uint64
+      ByteSize: 8
+      GoRuntimeType: 542816
+      GoKind: 11
+    - __kind: BaseType
+      ID: 7
+      Name: uint8
+      ByteSize: 1
+      GoRuntimeType: 542432
+      GoKind: 8
+    - __kind: BaseType
+      ID: 26
+      Name: uintptr
+      ByteSize: 8
+      GoRuntimeType: 543008
+      GoKind: 12
+    - __kind: VoidPointerType
+      ID: 2
+      Name: unsafe.Pointer
+      ByteSize: 8
+      GoRuntimeType: 543392
+      GoKind: 26
 MaxTypeID: 264
 Issues: []
 GoModuledataInfo: {FirstModuledataAddr: "0x1804ac0", TypesOffset: 296}

--- a/pkg/dyninst/irgen/testdata/snapshot/rc_tester.arch=amd64,toolchain=go1.23.11.yaml
+++ b/pkg/dyninst/irgen/testdata/snapshot/rc_tester.arch=amd64,toolchain=go1.23.11.yaml
@@ -10,7 +10,7 @@ Probes:
       subprogram: {subprogram: 1}
       events:
         - ID: 1
-          Type: 267 EventRootType Probe[main.HandleHTTP]
+          Type: 263 EventRootType Probe[main.HandleHTTP]
           InjectionPoints: [{PC: "0xd597d3", Frameless: false}]
           Condition: null
     - id: look_at_the_request
@@ -23,7 +23,7 @@ Probes:
       subprogram: {subprogram: 2}
       events:
         - ID: 2
-          Type: 268 EventRootType Probe[main.LookAtTheRequest]
+          Type: 264 EventRootType Probe[main.LookAtTheRequest]
           InjectionPoints: [{PC: "0xd59b2e", Frameless: false}]
           Condition: null
 Subprograms:
@@ -369,7 +369,7 @@ Types:
           Offset: 40
           Type: 27 PointerType *runtime.mapextra
       BucketType: 20 GoHMapBucketType bucket<string,[]string>
-      BucketsType: 215 GoSliceDataType []bucket<string,[]string>.array
+      BucketsType: 205 GoSliceDataType []bucket<string,[]string>.array
     - __kind: BaseType
       ID: 17
       Name: uint16
@@ -632,7 +632,7 @@ Types:
           Offset: 40
           Type: 27 PointerType *runtime.mapextra
       BucketType: 45 GoHMapBucketType bucket<string,[]*mime/multipart.FileHeader>
-      BucketsType: 212 GoSliceDataType []bucket<string,[]*mime/multipart.FileHeader>.array
+      BucketsType: 210 GoSliceDataType []bucket<string,[]*mime/multipart.FileHeader>.array
     - __kind: PointerType
       ID: 44
       Name: '*bucket<string,[]*mime/multipart.FileHeader>'
@@ -680,7 +680,7 @@ Types:
         - Name: cap
           Offset: 16
           Type: 8 BaseType int
-      Data: 213 GoSliceDataType []*mime/multipart.FileHeader.array
+      Data: 211 GoSliceDataType []*mime/multipart.FileHeader.array
     - __kind: PointerType
       ID: 48
       Name: '**mime/multipart.FileHeader'
@@ -745,7 +745,7 @@ Types:
         - Name: cap
           Offset: 16
           Type: 8 BaseType int
-      Data: 216 GoSliceDataType []uint8.array
+      Data: 213 GoSliceDataType []uint8.array
     - __kind: PointerType
       ID: 53
       Name: '*crypto/tls.ConnectionState'
@@ -824,7 +824,7 @@ Types:
         - Name: cap
           Offset: 16
           Type: 8 BaseType int
-      Data: 218 GoSliceDataType []*crypto/x509.Certificate.array
+      Data: 215 GoSliceDataType []*crypto/x509.Certificate.array
     - __kind: PointerType
       ID: 56
       Name: '**crypto/x509.Certificate'
@@ -1040,7 +1040,7 @@ Types:
         - Name: cap
           Offset: 16
           Type: 8 BaseType int
-      Data: 220 GoSliceDataType math/big.nat.array
+      Data: 217 GoSliceDataType math/big.nat.array
     - __kind: PointerType
       ID: 65
       Name: '*math/big.Word'
@@ -1110,7 +1110,7 @@ Types:
         - Name: cap
           Offset: 16
           Type: 8 BaseType int
-      Data: 222 GoSliceDataType []crypto/x509/pkix.AttributeTypeAndValue.array
+      Data: 219 GoSliceDataType []crypto/x509/pkix.AttributeTypeAndValue.array
     - __kind: PointerType
       ID: 69
       Name: '*crypto/x509/pkix.AttributeTypeAndValue'
@@ -1147,7 +1147,7 @@ Types:
         - Name: cap
           Offset: 16
           Type: 8 BaseType int
-      Data: 224 GoSliceDataType encoding/asn1.ObjectIdentifier.array
+      Data: 221 GoSliceDataType encoding/asn1.ObjectIdentifier.array
     - __kind: PointerType
       ID: 72
       Name: '*int'
@@ -1228,7 +1228,7 @@ Types:
         - Name: cap
           Offset: 16
           Type: 8 BaseType int
-      Data: 226 GoSliceDataType []time.zone.array
+      Data: 223 GoSliceDataType []time.zone.array
     - __kind: PointerType
       ID: 78
       Name: '*time.zone'
@@ -1268,7 +1268,7 @@ Types:
         - Name: cap
           Offset: 16
           Type: 8 BaseType int
-      Data: 228 GoSliceDataType []time.zoneTrans.array
+      Data: 225 GoSliceDataType []time.zoneTrans.array
     - __kind: PointerType
       ID: 81
       Name: '*time.zoneTrans'
@@ -1317,7 +1317,7 @@ Types:
         - Name: cap
           Offset: 16
           Type: 8 BaseType int
-      Data: 230 GoSliceDataType []crypto/x509/pkix.Extension.array
+      Data: 227 GoSliceDataType []crypto/x509/pkix.Extension.array
     - __kind: PointerType
       ID: 85
       Name: '*crypto/x509/pkix.Extension'
@@ -1357,7 +1357,7 @@ Types:
         - Name: cap
           Offset: 16
           Type: 8 BaseType int
-      Data: 232 GoSliceDataType []encoding/asn1.ObjectIdentifier.array
+      Data: 229 GoSliceDataType []encoding/asn1.ObjectIdentifier.array
     - __kind: PointerType
       ID: 88
       Name: '*encoding/asn1.ObjectIdentifier'
@@ -1381,7 +1381,7 @@ Types:
         - Name: cap
           Offset: 16
           Type: 8 BaseType int
-      Data: 234 GoSliceDataType []crypto/x509.ExtKeyUsage.array
+      Data: 231 GoSliceDataType []crypto/x509.ExtKeyUsage.array
     - __kind: PointerType
       ID: 90
       Name: '*crypto/x509.ExtKeyUsage'
@@ -1411,7 +1411,7 @@ Types:
         - Name: cap
           Offset: 16
           Type: 8 BaseType int
-      Data: 236 GoSliceDataType []net.IP.array
+      Data: 233 GoSliceDataType []net.IP.array
     - __kind: PointerType
       ID: 93
       Name: '*net.IP'
@@ -1435,7 +1435,7 @@ Types:
         - Name: cap
           Offset: 16
           Type: 8 BaseType int
-      Data: 238 GoSliceDataType net.IP.array
+      Data: 235 GoSliceDataType net.IP.array
     - __kind: GoSliceHeaderType
       ID: 95
       Name: '[]*net/url.URL'
@@ -1452,7 +1452,7 @@ Types:
         - Name: cap
           Offset: 16
           Type: 8 BaseType int
-      Data: 240 GoSliceDataType []*net/url.URL.array
+      Data: 237 GoSliceDataType []*net/url.URL.array
     - __kind: PointerType
       ID: 96
       Name: '**net/url.URL'
@@ -1475,7 +1475,7 @@ Types:
         - Name: cap
           Offset: 16
           Type: 8 BaseType int
-      Data: 242 GoSliceDataType []*net.IPNet.array
+      Data: 239 GoSliceDataType []*net.IPNet.array
     - __kind: PointerType
       ID: 98
       Name: '**net.IPNet'
@@ -1518,7 +1518,7 @@ Types:
         - Name: cap
           Offset: 16
           Type: 8 BaseType int
-      Data: 244 GoSliceDataType net.IPMask.array
+      Data: 241 GoSliceDataType net.IPMask.array
     - __kind: GoSliceHeaderType
       ID: 102
       Name: '[]crypto/x509.OID'
@@ -1535,7 +1535,7 @@ Types:
         - Name: cap
           Offset: 16
           Type: 8 BaseType int
-      Data: 246 GoSliceDataType []crypto/x509.OID.array
+      Data: 243 GoSliceDataType []crypto/x509.OID.array
     - __kind: PointerType
       ID: 103
       Name: '*crypto/x509.OID'
@@ -1569,7 +1569,7 @@ Types:
         - Name: cap
           Offset: 16
           Type: 8 BaseType int
-      Data: 248 GoSliceDataType [][]*crypto/x509.Certificate.array
+      Data: 245 GoSliceDataType [][]*crypto/x509.Certificate.array
     - __kind: PointerType
       ID: 106
       Name: '*[]*crypto/x509.Certificate'
@@ -1592,7 +1592,7 @@ Types:
         - Name: cap
           Offset: 16
           Type: 8 BaseType int
-      Data: 250 GoSliceDataType [][]uint8.array
+      Data: 247 GoSliceDataType [][]uint8.array
     - __kind: PointerType
       ID: 108
       Name: '*[]uint8'
@@ -1731,7 +1731,7 @@ Types:
         - Name: cap
           Offset: 16
           Type: 8 BaseType int
-      Data: 252 GoSliceDataType []net/http.segment.array
+      Data: 249 GoSliceDataType []net/http.segment.array
     - __kind: PointerType
       ID: 118
       Name: '*net/http.segment'
@@ -1800,7 +1800,7 @@ Types:
           Offset: 40
           Type: 27 PointerType *runtime.mapextra
       BucketType: 124 GoHMapBucketType bucket<string,string>
-      BucketsType: 254 GoSliceDataType []bucket<string,string>.array
+      BucketsType: 251 GoSliceDataType []bucket<string,string>.array
     - __kind: PointerType
       ID: 123
       Name: '*bucket<string,string>'
@@ -2026,7 +2026,7 @@ Types:
           Offset: 40
           Type: 27 PointerType *runtime.mapextra
       BucketType: 137 GoHMapBucketType bucket<string,interface {}>
-      BucketsType: 264 GoSliceDataType []bucket<string,interface {}>.array
+      BucketsType: 252 GoSliceDataType []bucket<string,interface {}>.array
     - __kind: PointerType
       ID: 136
       Name: '*bucket<string,interface {}>'
@@ -2103,7 +2103,7 @@ Types:
           Offset: 40
           Type: 27 PointerType *runtime.mapextra
       BucketType: 143 GoHMapBucketType bucket<string,float64>
-      BucketsType: 256 GoSliceDataType []bucket<string,float64>.array
+      BucketsType: 253 GoSliceDataType []bucket<string,float64>.array
     - __kind: PointerType
       ID: 142
       Name: '*bucket<string,float64>'
@@ -2157,7 +2157,7 @@ Types:
         - Name: cap
           Offset: 16
           Type: 8 BaseType int
-      Data: 257 GoSliceDataType []github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink.array
+      Data: 254 GoSliceDataType []github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink.array
     - __kind: PointerType
       ID: 147
       Name: '*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink'
@@ -2206,7 +2206,7 @@ Types:
         - Name: cap
           Offset: 16
           Type: 8 BaseType int
-      Data: 259 GoSliceDataType []github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent.array
+      Data: 256 GoSliceDataType []github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent.array
     - __kind: PointerType
       ID: 150
       Name: '*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent'
@@ -2278,7 +2278,7 @@ Types:
           Offset: 40
           Type: 27 PointerType *runtime.mapextra
       BucketType: 156 GoHMapBucketType bucket<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
-      BucketsType: 261 GoSliceDataType []bucket<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>.array
+      BucketsType: 258 GoSliceDataType []bucket<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>.array
     - __kind: PointerType
       ID: 155
       Name: '*bucket<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>'
@@ -2381,7 +2381,7 @@ Types:
         - Name: cap
           Offset: 16
           Type: 8 BaseType int
-      Data: 262 GoSliceDataType []*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttributeValue.array
+      Data: 259 GoSliceDataType []*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttributeValue.array
     - __kind: PointerType
       ID: 164
       Name: '**github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttributeValue'
@@ -2546,7 +2546,7 @@ Types:
         - Name: cap
           Offset: 16
           Type: 8 BaseType int
-      Data: 265 GoSliceDataType []*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span.array
+      Data: 261 GoSliceDataType []*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span.array
     - __kind: PointerType
       ID: 174
       Name: '**github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span'
@@ -2794,291 +2794,271 @@ Types:
       Pointee: 208 GoSliceDataType []*runtime.bmap.array
     - __kind: GoSliceDataType
       ID: 210
-      Name: '[]bucket<string,[]string>.array'
-      ByteSize: 2048
-      Element: 20 GoHMapBucketType bucket<string,[]string>
-    - __kind: GoSliceDataType
-      ID: 211
-      Name: '[]bucket<string,[]string>.array'
-      ByteSize: 2048
-      Element: 20 GoHMapBucketType bucket<string,[]string>
-    - __kind: GoSliceDataType
-      ID: 212
       Name: '[]bucket<string,[]*mime/multipart.FileHeader>.array'
       ByteSize: 2048
       Element: 45 GoHMapBucketType bucket<string,[]*mime/multipart.FileHeader>
     - __kind: GoSliceDataType
-      ID: 213
+      ID: 211
       Name: '[]*mime/multipart.FileHeader.array'
       ByteSize: 2048
       Element: 49 PointerType *mime/multipart.FileHeader
     - __kind: PointerType
-      ID: 214
+      ID: 212
       Name: '*[]*mime/multipart.FileHeader.array'
       ByteSize: 8
-      Pointee: 213 GoSliceDataType []*mime/multipart.FileHeader.array
+      Pointee: 211 GoSliceDataType []*mime/multipart.FileHeader.array
     - __kind: GoSliceDataType
-      ID: 215
-      Name: '[]bucket<string,[]string>.array'
-      ByteSize: 2048
-      Element: 20 GoHMapBucketType bucket<string,[]string>
-    - __kind: GoSliceDataType
-      ID: 216
+      ID: 213
       Name: '[]uint8.array'
       ByteSize: 2048
       Element: 7 BaseType uint8
     - __kind: PointerType
-      ID: 217
+      ID: 214
       Name: '*[]uint8.array'
       ByteSize: 8
-      Pointee: 216 GoSliceDataType []uint8.array
+      Pointee: 213 GoSliceDataType []uint8.array
     - __kind: GoSliceDataType
-      ID: 218
+      ID: 215
       Name: '[]*crypto/x509.Certificate.array'
       ByteSize: 2048
       Element: 57 PointerType *crypto/x509.Certificate
     - __kind: PointerType
-      ID: 219
+      ID: 216
       Name: '*[]*crypto/x509.Certificate.array'
       ByteSize: 8
-      Pointee: 218 GoSliceDataType []*crypto/x509.Certificate.array
+      Pointee: 215 GoSliceDataType []*crypto/x509.Certificate.array
     - __kind: GoSliceDataType
-      ID: 220
+      ID: 217
       Name: math/big.nat.array
       ByteSize: 2048
       Element: 66 BaseType math/big.Word
     - __kind: PointerType
-      ID: 221
+      ID: 218
       Name: '*math/big.nat.array'
       ByteSize: 8
-      Pointee: 220 GoSliceDataType math/big.nat.array
+      Pointee: 217 GoSliceDataType math/big.nat.array
     - __kind: GoSliceDataType
-      ID: 222
+      ID: 219
       Name: '[]crypto/x509/pkix.AttributeTypeAndValue.array'
       ByteSize: 2048
       Element: 70 StructureType crypto/x509/pkix.AttributeTypeAndValue
     - __kind: PointerType
-      ID: 223
+      ID: 220
       Name: '*[]crypto/x509/pkix.AttributeTypeAndValue.array'
       ByteSize: 8
-      Pointee: 222 GoSliceDataType []crypto/x509/pkix.AttributeTypeAndValue.array
+      Pointee: 219 GoSliceDataType []crypto/x509/pkix.AttributeTypeAndValue.array
     - __kind: GoSliceDataType
-      ID: 224
+      ID: 221
       Name: encoding/asn1.ObjectIdentifier.array
       ByteSize: 2048
       Element: 8 BaseType int
     - __kind: PointerType
-      ID: 225
+      ID: 222
       Name: '*encoding/asn1.ObjectIdentifier.array'
       ByteSize: 8
-      Pointee: 224 GoSliceDataType encoding/asn1.ObjectIdentifier.array
+      Pointee: 221 GoSliceDataType encoding/asn1.ObjectIdentifier.array
     - __kind: GoSliceDataType
-      ID: 226
+      ID: 223
       Name: '[]time.zone.array'
       ByteSize: 2048
       Element: 79 StructureType time.zone
     - __kind: PointerType
-      ID: 227
+      ID: 224
       Name: '*[]time.zone.array'
       ByteSize: 8
-      Pointee: 226 GoSliceDataType []time.zone.array
+      Pointee: 223 GoSliceDataType []time.zone.array
     - __kind: GoSliceDataType
-      ID: 228
+      ID: 225
       Name: '[]time.zoneTrans.array'
       ByteSize: 2048
       Element: 82 StructureType time.zoneTrans
     - __kind: PointerType
-      ID: 229
+      ID: 226
       Name: '*[]time.zoneTrans.array'
       ByteSize: 8
-      Pointee: 228 GoSliceDataType []time.zoneTrans.array
+      Pointee: 225 GoSliceDataType []time.zoneTrans.array
     - __kind: GoSliceDataType
-      ID: 230
+      ID: 227
       Name: '[]crypto/x509/pkix.Extension.array'
       ByteSize: 2048
       Element: 86 StructureType crypto/x509/pkix.Extension
     - __kind: PointerType
-      ID: 231
+      ID: 228
       Name: '*[]crypto/x509/pkix.Extension.array'
       ByteSize: 8
-      Pointee: 230 GoSliceDataType []crypto/x509/pkix.Extension.array
+      Pointee: 227 GoSliceDataType []crypto/x509/pkix.Extension.array
     - __kind: GoSliceDataType
-      ID: 232
+      ID: 229
       Name: '[]encoding/asn1.ObjectIdentifier.array'
       ByteSize: 2048
       Element: 71 GoSliceHeaderType encoding/asn1.ObjectIdentifier
     - __kind: PointerType
-      ID: 233
+      ID: 230
       Name: '*[]encoding/asn1.ObjectIdentifier.array'
       ByteSize: 8
-      Pointee: 232 GoSliceDataType []encoding/asn1.ObjectIdentifier.array
+      Pointee: 229 GoSliceDataType []encoding/asn1.ObjectIdentifier.array
     - __kind: GoSliceDataType
-      ID: 234
+      ID: 231
       Name: '[]crypto/x509.ExtKeyUsage.array'
       ByteSize: 2048
       Element: 91 BaseType crypto/x509.ExtKeyUsage
     - __kind: PointerType
-      ID: 235
+      ID: 232
       Name: '*[]crypto/x509.ExtKeyUsage.array'
       ByteSize: 8
-      Pointee: 234 GoSliceDataType []crypto/x509.ExtKeyUsage.array
+      Pointee: 231 GoSliceDataType []crypto/x509.ExtKeyUsage.array
     - __kind: GoSliceDataType
-      ID: 236
+      ID: 233
       Name: '[]net.IP.array'
       ByteSize: 2048
       Element: 94 GoSliceHeaderType net.IP
     - __kind: PointerType
-      ID: 237
+      ID: 234
       Name: '*[]net.IP.array'
       ByteSize: 8
-      Pointee: 236 GoSliceDataType []net.IP.array
+      Pointee: 233 GoSliceDataType []net.IP.array
     - __kind: GoSliceDataType
-      ID: 238
+      ID: 235
       Name: net.IP.array
       ByteSize: 2048
       Element: 7 BaseType uint8
     - __kind: PointerType
-      ID: 239
+      ID: 236
       Name: '*net.IP.array'
       ByteSize: 8
-      Pointee: 238 GoSliceDataType net.IP.array
+      Pointee: 235 GoSliceDataType net.IP.array
     - __kind: GoSliceDataType
-      ID: 240
+      ID: 237
       Name: '[]*net/url.URL.array'
       ByteSize: 2048
       Element: 9 PointerType *net/url.URL
     - __kind: PointerType
-      ID: 241
+      ID: 238
       Name: '*[]*net/url.URL.array'
       ByteSize: 8
-      Pointee: 240 GoSliceDataType []*net/url.URL.array
+      Pointee: 237 GoSliceDataType []*net/url.URL.array
     - __kind: GoSliceDataType
-      ID: 242
+      ID: 239
       Name: '[]*net.IPNet.array'
       ByteSize: 2048
       Element: 99 PointerType *net.IPNet
     - __kind: PointerType
-      ID: 243
+      ID: 240
       Name: '*[]*net.IPNet.array'
       ByteSize: 8
-      Pointee: 242 GoSliceDataType []*net.IPNet.array
+      Pointee: 239 GoSliceDataType []*net.IPNet.array
     - __kind: GoSliceDataType
-      ID: 244
+      ID: 241
       Name: net.IPMask.array
       ByteSize: 2048
       Element: 7 BaseType uint8
     - __kind: PointerType
-      ID: 245
+      ID: 242
       Name: '*net.IPMask.array'
       ByteSize: 8
-      Pointee: 244 GoSliceDataType net.IPMask.array
+      Pointee: 241 GoSliceDataType net.IPMask.array
     - __kind: GoSliceDataType
-      ID: 246
+      ID: 243
       Name: '[]crypto/x509.OID.array'
       ByteSize: 2048
       Element: 104 StructureType crypto/x509.OID
     - __kind: PointerType
-      ID: 247
+      ID: 244
       Name: '*[]crypto/x509.OID.array'
       ByteSize: 8
-      Pointee: 246 GoSliceDataType []crypto/x509.OID.array
+      Pointee: 243 GoSliceDataType []crypto/x509.OID.array
     - __kind: GoSliceDataType
-      ID: 248
+      ID: 245
       Name: '[][]*crypto/x509.Certificate.array'
       ByteSize: 2048
       Element: 55 GoSliceHeaderType []*crypto/x509.Certificate
     - __kind: PointerType
-      ID: 249
+      ID: 246
       Name: '*[][]*crypto/x509.Certificate.array'
       ByteSize: 8
-      Pointee: 248 GoSliceDataType [][]*crypto/x509.Certificate.array
+      Pointee: 245 GoSliceDataType [][]*crypto/x509.Certificate.array
     - __kind: GoSliceDataType
-      ID: 250
+      ID: 247
       Name: '[][]uint8.array'
       ByteSize: 2048
       Element: 52 GoSliceHeaderType []uint8
     - __kind: PointerType
-      ID: 251
+      ID: 248
       Name: '*[][]uint8.array'
       ByteSize: 8
-      Pointee: 250 GoSliceDataType [][]uint8.array
+      Pointee: 247 GoSliceDataType [][]uint8.array
     - __kind: GoSliceDataType
-      ID: 252
+      ID: 249
       Name: '[]net/http.segment.array'
       ByteSize: 2048
       Element: 119 StructureType net/http.segment
     - __kind: PointerType
-      ID: 253
+      ID: 250
       Name: '*[]net/http.segment.array'
       ByteSize: 8
-      Pointee: 252 GoSliceDataType []net/http.segment.array
+      Pointee: 249 GoSliceDataType []net/http.segment.array
     - __kind: GoSliceDataType
-      ID: 254
+      ID: 251
       Name: '[]bucket<string,string>.array'
       ByteSize: 2048
       Element: 124 GoHMapBucketType bucket<string,string>
     - __kind: GoSliceDataType
-      ID: 255
+      ID: 252
       Name: '[]bucket<string,interface {}>.array'
       ByteSize: 2048
       Element: 137 GoHMapBucketType bucket<string,interface {}>
     - __kind: GoSliceDataType
-      ID: 256
+      ID: 253
       Name: '[]bucket<string,float64>.array'
       ByteSize: 2048
       Element: 143 GoHMapBucketType bucket<string,float64>
     - __kind: GoSliceDataType
-      ID: 257
+      ID: 254
       Name: '[]github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink.array'
       ByteSize: 2048
       Element: 148 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink
     - __kind: PointerType
-      ID: 258
+      ID: 255
       Name: '*[]github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink.array'
       ByteSize: 8
-      Pointee: 257 GoSliceDataType []github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink.array
+      Pointee: 254 GoSliceDataType []github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink.array
     - __kind: GoSliceDataType
-      ID: 259
+      ID: 256
       Name: '[]github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent.array'
       ByteSize: 2048
       Element: 151 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent
     - __kind: PointerType
-      ID: 260
+      ID: 257
       Name: '*[]github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent.array'
       ByteSize: 8
-      Pointee: 259 GoSliceDataType []github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent.array
+      Pointee: 256 GoSliceDataType []github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent.array
     - __kind: GoSliceDataType
-      ID: 261
+      ID: 258
       Name: '[]bucket<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>.array'
       ByteSize: 2048
       Element: 156 GoHMapBucketType bucket<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
     - __kind: GoSliceDataType
-      ID: 262
+      ID: 259
       Name: '[]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttributeValue.array'
       ByteSize: 2048
       Element: 165 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttributeValue
     - __kind: PointerType
-      ID: 263
+      ID: 260
       Name: '*[]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttributeValue.array'
       ByteSize: 8
-      Pointee: 262 GoSliceDataType []*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttributeValue.array
+      Pointee: 259 GoSliceDataType []*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttributeValue.array
     - __kind: GoSliceDataType
-      ID: 264
-      Name: '[]bucket<string,interface {}>.array'
-      ByteSize: 2048
-      Element: 137 GoHMapBucketType bucket<string,interface {}>
-    - __kind: GoSliceDataType
-      ID: 265
+      ID: 261
       Name: '[]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span.array'
       ByteSize: 2048
       Element: 126 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span
     - __kind: PointerType
-      ID: 266
+      ID: 262
       Name: '*[]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span.array'
       ByteSize: 8
-      Pointee: 265 GoSliceDataType []*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span.array
+      Pointee: 261 GoSliceDataType []*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span.array
     - __kind: EventRootType
-      ID: 267
+      ID: 263
       Name: Probe[main.HandleHTTP]
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -3102,7 +3082,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 268
+      ID: 264
       Name: Probe[main.LookAtTheRequest]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -3116,6 +3096,6 @@ Types:
                   Variable: {subprogram: 2, index: 0, name: path}
                   Offset: 0
                   ByteSize: 16
-MaxTypeID: 268
+MaxTypeID: 264
 Issues: []
 GoModuledataInfo: {FirstModuledataAddr: "0x1804ac0", TypesOffset: 296}

--- a/pkg/dyninst/irgen/testdata/snapshot/rc_tester.arch=amd64,toolchain=go1.23.11.yaml
+++ b/pkg/dyninst/irgen/testdata/snapshot/rc_tester.arch=amd64,toolchain=go1.23.11.yaml
@@ -65,14 +65,14 @@ Subprograms:
           IsParameter: true
           IsReturn: false
         - Name: span
-          Type: 148 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span
+          Type: 39 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span
           Locations:
             - Range: 0xd59848..0xd59881
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: false
           IsReturn: false
         - Name: '&buf'
-          Type: 198 PointerType *bytes.Buffer
+          Type: 41 PointerType *bytes.Buffer
           Locations:
             - Range: 0xd59958..0xd5997a
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
@@ -81,7 +81,7 @@ Subprograms:
           IsParameter: false
           IsReturn: false
         - Name: .autotmp_14
-          Type: 201 StructureType context.backgroundCtx
+          Type: 43 StructureType context.backgroundCtx
           Locations:
             - Range: 0xd597c0..0xd59a5c
               Pieces: [{Size: 0, Op: {CfaOffset: 0}}]
@@ -105,175 +105,175 @@ Subprograms:
           IsReturn: false
 Types:
     - __kind: PointerType
-      ID: 80
+      ID: 114
       Name: '**crypto/x509.Certificate'
       ByteSize: 8
-      Pointee: 81 PointerType *crypto/x509.Certificate
+      Pointee: 115 PointerType *crypto/x509.Certificate
     - __kind: PointerType
-      ID: 194
+      ID: 148
       Name: '**github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span'
       ByteSize: 8
       GoKind: 22
-      Pointee: 148 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span
+      Pointee: 39 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span
     - __kind: PointerType
-      ID: 184
+      ID: 198
       Name: '**github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttributeValue'
       ByteSize: 8
       GoKind: 22
-      Pointee: 185 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttributeValue
+      Pointee: 199 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttributeValue
     - __kind: PointerType
-      ID: 72
+      ID: 141
       Name: '**mime/multipart.FileHeader'
       ByteSize: 8
       GoKind: 22
-      Pointee: 73 PointerType *mime/multipart.FileHeader
+      Pointee: 142 PointerType *mime/multipart.FileHeader
     - __kind: PointerType
-      ID: 120
+      ID: 178
       Name: '**net.IPNet'
       ByteSize: 8
       GoKind: 22
-      Pointee: 121 PointerType *net.IPNet
+      Pointee: 179 PointerType *net.IPNet
     - __kind: PointerType
-      ID: 118
+      ID: 176
       Name: '**net/url.URL'
       ByteSize: 8
       GoKind: 22
-      Pointee: 39 PointerType *net/url.URL
+      Pointee: 45 PointerType *net/url.URL
     - __kind: PointerType
-      ID: 56
+      ID: 138
       Name: '**runtime.bmap'
       ByteSize: 8
-      Pointee: 57 PointerType *runtime.bmap
+      Pointee: 105 PointerType *runtime.bmap
     - __kind: PointerType
-      ID: 128
+      ID: 117
       Name: '*[]*crypto/x509.Certificate'
       ByteSize: 8
       GoKind: 22
-      Pointee: 79 GoSliceHeaderType []*crypto/x509.Certificate
+      Pointee: 113 GoSliceHeaderType []*crypto/x509.Certificate
     - __kind: PointerType
-      ID: 216
+      ID: 221
       Name: '*[]*crypto/x509.Certificate.array'
       ByteSize: 8
-      Pointee: 215 GoSliceDataType []*crypto/x509.Certificate.array
+      Pointee: 220 GoSliceDataType []*crypto/x509.Certificate.array
     - __kind: PointerType
-      ID: 262
+      ID: 232
       Name: '*[]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span.array'
       ByteSize: 8
-      Pointee: 261 GoSliceDataType []*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span.array
+      Pointee: 231 GoSliceDataType []*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span.array
     - __kind: PointerType
       ID: 260
       Name: '*[]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttributeValue.array'
       ByteSize: 8
       Pointee: 259 GoSliceDataType []*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttributeValue.array
     - __kind: PointerType
-      ID: 212
+      ID: 230
       Name: '*[]*mime/multipart.FileHeader.array'
       ByteSize: 8
-      Pointee: 211 GoSliceDataType []*mime/multipart.FileHeader.array
+      Pointee: 229 GoSliceDataType []*mime/multipart.FileHeader.array
     - __kind: PointerType
-      ID: 240
+      ID: 250
       Name: '*[]*net.IPNet.array'
       ByteSize: 8
-      Pointee: 239 GoSliceDataType []*net.IPNet.array
+      Pointee: 249 GoSliceDataType []*net.IPNet.array
     - __kind: PointerType
-      ID: 238
+      ID: 248
       Name: '*[]*net/url.URL.array'
       ByteSize: 8
-      Pointee: 237 GoSliceDataType []*net/url.URL.array
+      Pointee: 247 GoSliceDataType []*net/url.URL.array
     - __kind: PointerType
-      ID: 54
+      ID: 103
       Name: '*[]*runtime.bmap'
       ByteSize: 8
       GoRuntimeType: 470656
       GoKind: 22
-      Pointee: 55 GoSliceHeaderType []*runtime.bmap
+      Pointee: 104 GoSliceHeaderType []*runtime.bmap
     - __kind: PointerType
-      ID: 209
+      ID: 218
       Name: '*[]*runtime.bmap.array'
       ByteSize: 8
-      Pointee: 208 GoSliceDataType []*runtime.bmap.array
+      Pointee: 217 GoSliceDataType []*runtime.bmap.array
     - __kind: PointerType
-      ID: 246
+      ID: 223
       Name: '*[][]*crypto/x509.Certificate.array'
       ByteSize: 8
-      Pointee: 245 GoSliceDataType [][]*crypto/x509.Certificate.array
+      Pointee: 222 GoSliceDataType [][]*crypto/x509.Certificate.array
     - __kind: PointerType
-      ID: 248
+      ID: 225
       Name: '*[][]uint8.array'
       ByteSize: 8
-      Pointee: 247 GoSliceDataType [][]uint8.array
+      Pointee: 224 GoSliceDataType [][]uint8.array
     - __kind: PointerType
-      ID: 232
+      ID: 242
       Name: '*[]crypto/x509.ExtKeyUsage.array'
       ByteSize: 8
-      Pointee: 231 GoSliceDataType []crypto/x509.ExtKeyUsage.array
+      Pointee: 241 GoSliceDataType []crypto/x509.ExtKeyUsage.array
     - __kind: PointerType
-      ID: 244
+      ID: 252
       Name: '*[]crypto/x509.OID.array'
       ByteSize: 8
-      Pointee: 243 GoSliceDataType []crypto/x509.OID.array
-    - __kind: PointerType
-      ID: 220
-      Name: '*[]crypto/x509/pkix.AttributeTypeAndValue.array'
-      ByteSize: 8
-      Pointee: 219 GoSliceDataType []crypto/x509/pkix.AttributeTypeAndValue.array
-    - __kind: PointerType
-      ID: 228
-      Name: '*[]crypto/x509/pkix.Extension.array'
-      ByteSize: 8
-      Pointee: 227 GoSliceDataType []crypto/x509/pkix.Extension.array
-    - __kind: PointerType
-      ID: 230
-      Name: '*[]encoding/asn1.ObjectIdentifier.array'
-      ByteSize: 8
-      Pointee: 229 GoSliceDataType []encoding/asn1.ObjectIdentifier.array
-    - __kind: PointerType
-      ID: 255
-      Name: '*[]github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink.array'
-      ByteSize: 8
-      Pointee: 254 GoSliceDataType []github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink.array
-    - __kind: PointerType
-      ID: 257
-      Name: '*[]github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent.array'
-      ByteSize: 8
-      Pointee: 256 GoSliceDataType []github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent.array
+      Pointee: 251 GoSliceDataType []crypto/x509.OID.array
     - __kind: PointerType
       ID: 234
+      Name: '*[]crypto/x509/pkix.AttributeTypeAndValue.array'
+      ByteSize: 8
+      Pointee: 233 GoSliceDataType []crypto/x509/pkix.AttributeTypeAndValue.array
+    - __kind: PointerType
+      ID: 236
+      Name: '*[]crypto/x509/pkix.Extension.array'
+      ByteSize: 8
+      Pointee: 235 GoSliceDataType []crypto/x509/pkix.Extension.array
+    - __kind: PointerType
+      ID: 238
+      Name: '*[]encoding/asn1.ObjectIdentifier.array'
+      ByteSize: 8
+      Pointee: 237 GoSliceDataType []encoding/asn1.ObjectIdentifier.array
+    - __kind: PointerType
+      ID: 212
+      Name: '*[]github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink.array'
+      ByteSize: 8
+      Pointee: 211 GoSliceDataType []github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink.array
+    - __kind: PointerType
+      ID: 214
+      Name: '*[]github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent.array'
+      ByteSize: 8
+      Pointee: 213 GoSliceDataType []github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent.array
+    - __kind: PointerType
+      ID: 244
       Name: '*[]net.IP.array'
       ByteSize: 8
-      Pointee: 233 GoSliceDataType []net.IP.array
+      Pointee: 243 GoSliceDataType []net.IP.array
     - __kind: PointerType
-      ID: 250
+      ID: 227
       Name: '*[]net/http.segment.array'
       ByteSize: 8
-      Pointee: 249 GoSliceDataType []net/http.segment.array
+      Pointee: 226 GoSliceDataType []net/http.segment.array
     - __kind: PointerType
       ID: 207
       Name: '*[]string.array'
       ByteSize: 8
       Pointee: 206 GoSliceDataType []string.array
     - __kind: PointerType
-      ID: 224
+      ID: 256
       Name: '*[]time.zone.array'
       ByteSize: 8
-      Pointee: 223 GoSliceDataType []time.zone.array
+      Pointee: 255 GoSliceDataType []time.zone.array
     - __kind: PointerType
-      ID: 226
+      ID: 258
       Name: '*[]time.zoneTrans.array'
       ByteSize: 8
-      Pointee: 225 GoSliceDataType []time.zoneTrans.array
+      Pointee: 257 GoSliceDataType []time.zoneTrans.array
     - __kind: PointerType
-      ID: 130
+      ID: 119
       Name: '*[]uint8'
       ByteSize: 8
       GoRuntimeType: 456768
       GoKind: 22
-      Pointee: 76 GoSliceHeaderType []uint8
+      Pointee: 96 GoSliceHeaderType []uint8
     - __kind: PointerType
-      ID: 214
+      ID: 216
       Name: '*[]uint8.array'
       ByteSize: 8
-      Pointee: 213 GoSliceDataType []uint8.array
+      Pointee: 215 GoSliceDataType []uint8.array
     - __kind: PointerType
       ID: 5
       Name: '*bool'
@@ -282,96 +282,96 @@ Types:
       GoKind: 22
       Pointee: 4 BaseType bool
     - __kind: PointerType
-      ID: 175
+      ID: 132
       Name: '*bucket<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>'
       ByteSize: 8
-      Pointee: 176 GoHMapBucketType bucket<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
+      Pointee: 133 GoHMapBucketType bucket<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
     - __kind: PointerType
-      ID: 68
+      ID: 111
       Name: '*bucket<string,[]*mime/multipart.FileHeader>'
       ByteSize: 8
-      Pointee: 69 GoHMapBucketType bucket<string,[]*mime/multipart.FileHeader>
+      Pointee: 112 GoHMapBucketType bucket<string,[]*mime/multipart.FileHeader>
     - __kind: PointerType
-      ID: 46
+      ID: 50
       Name: '*bucket<string,[]string>'
       ByteSize: 8
-      Pointee: 47 GoHMapBucketType bucket<string,[]string>
+      Pointee: 51 GoHMapBucketType bucket<string,[]string>
     - __kind: PointerType
-      ID: 163
+      ID: 85
       Name: '*bucket<string,float64>'
       ByteSize: 8
-      Pointee: 164 GoHMapBucketType bucket<string,float64>
+      Pointee: 86 GoHMapBucketType bucket<string,float64>
     - __kind: PointerType
-      ID: 157
+      ID: 80
       Name: '*bucket<string,interface {}>'
       ByteSize: 8
-      Pointee: 158 GoHMapBucketType bucket<string,interface {}>
+      Pointee: 81 GoHMapBucketType bucket<string,interface {}>
     - __kind: PointerType
-      ID: 145
+      ID: 71
       Name: '*bucket<string,string>'
       ByteSize: 8
-      Pointee: 146 GoHMapBucketType bucket<string,string>
+      Pointee: 72 GoHMapBucketType bucket<string,string>
     - __kind: PointerType
-      ID: 198
+      ID: 41
       Name: '*bytes.Buffer'
       ByteSize: 8
       GoRuntimeType: 2.17632e+06
       GoKind: 22
-      Pointee: 199 StructureType bytes.Buffer
+      Pointee: 42 StructureType bytes.Buffer
     - __kind: PointerType
-      ID: 77
+      ID: 60
       Name: '*crypto/tls.ConnectionState'
       ByteSize: 8
       GoRuntimeType: 852192
       GoKind: 22
-      Pointee: 78 StructureType crypto/tls.ConnectionState
+      Pointee: 61 StructureType crypto/tls.ConnectionState
     - __kind: PointerType
-      ID: 81
+      ID: 115
       Name: '*crypto/x509.Certificate'
       ByteSize: 8
       GoRuntimeType: 1.952864e+06
       GoKind: 22
-      Pointee: 82 StructureType crypto/x509.Certificate
+      Pointee: 143 StructureType crypto/x509.Certificate
     - __kind: PointerType
-      ID: 112
+      ID: 170
       Name: '*crypto/x509.ExtKeyUsage'
       ByteSize: 8
       GoRuntimeType: 400640
       GoKind: 22
-      Pointee: 113 BaseType crypto/x509.ExtKeyUsage
+      Pointee: 171 BaseType crypto/x509.ExtKeyUsage
     - __kind: PointerType
-      ID: 125
+      ID: 181
       Name: '*crypto/x509.OID'
       ByteSize: 8
       GoRuntimeType: 1.761792e+06
       GoKind: 22
-      Pointee: 126 StructureType crypto/x509.OID
+      Pointee: 182 StructureType crypto/x509.OID
     - __kind: PointerType
-      ID: 93
+      ID: 157
       Name: '*crypto/x509/pkix.AttributeTypeAndValue'
       ByteSize: 8
       GoRuntimeType: 417344
       GoKind: 22
-      Pointee: 94 StructureType crypto/x509/pkix.AttributeTypeAndValue
+      Pointee: 158 StructureType crypto/x509/pkix.AttributeTypeAndValue
     - __kind: PointerType
-      ID: 107
+      ID: 164
       Name: '*crypto/x509/pkix.Extension'
       ByteSize: 8
       GoRuntimeType: 417536
       GoKind: 22
-      Pointee: 108 StructureType crypto/x509/pkix.Extension
+      Pointee: 165 StructureType crypto/x509/pkix.Extension
     - __kind: PointerType
-      ID: 110
+      ID: 167
       Name: '*encoding/asn1.ObjectIdentifier'
       ByteSize: 8
       GoRuntimeType: 1.037248e+06
       GoKind: 22
-      Pointee: 95 GoSliceHeaderType encoding/asn1.ObjectIdentifier
+      Pointee: 168 GoSliceHeaderType encoding/asn1.ObjectIdentifier
     - __kind: PointerType
-      ID: 222
+      ID: 240
       Name: '*encoding/asn1.ObjectIdentifier.array'
       ByteSize: 8
-      Pointee: 221 GoSliceDataType encoding/asn1.ObjectIdentifier.array
+      Pointee: 239 GoSliceDataType encoding/asn1.ObjectIdentifier.array
     - __kind: PointerType
       ID: 33
       Name: '*error'
@@ -394,91 +394,91 @@ Types:
       GoKind: 22
       Pointee: 17 BaseType float64
     - __kind: PointerType
-      ID: 148
+      ID: 39
       Name: '*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span'
       ByteSize: 8
       GoRuntimeType: 2.187104e+06
       GoKind: 22
-      Pointee: 149 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span
+      Pointee: 40 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span
     - __kind: PointerType
-      ID: 189
+      ID: 93
       Name: '*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanContext'
       ByteSize: 8
       GoRuntimeType: 1.916704e+06
       GoKind: 22
-      Pointee: 190 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanContext
+      Pointee: 94 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanContext
     - __kind: PointerType
-      ID: 167
+      ID: 88
       Name: '*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink'
       ByteSize: 8
       GoRuntimeType: 1.129216e+06
       GoKind: 22
-      Pointee: 168 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink
+      Pointee: 89 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink
     - __kind: PointerType
-      ID: 170
+      ID: 91
       Name: '*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent'
       ByteSize: 8
       GoRuntimeType: 1.129344e+06
       GoKind: 22
-      Pointee: 171 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent
+      Pointee: 92 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent
     - __kind: PointerType
-      ID: 181
+      ID: 184
       Name: '*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttribute'
       ByteSize: 8
       GoRuntimeType: 1.129984e+06
       GoKind: 22
-      Pointee: 182 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttribute
+      Pointee: 185 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttribute
     - __kind: PointerType
-      ID: 185
+      ID: 199
       Name: '*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttributeValue'
       ByteSize: 8
       GoRuntimeType: 1.129728e+06
       GoKind: 22
-      Pointee: 186 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttributeValue
+      Pointee: 201 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttributeValue
     - __kind: PointerType
-      ID: 178
+      ID: 145
       Name: '*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute'
       ByteSize: 8
       GoRuntimeType: 1.130112e+06
       GoKind: 22
-      Pointee: 179 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
+      Pointee: 146 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
     - __kind: PointerType
-      ID: 191
+      ID: 135
       Name: '*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.trace'
       ByteSize: 8
       GoRuntimeType: 2.131968e+06
       GoKind: 22
-      Pointee: 192 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.trace
+      Pointee: 136 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.trace
     - __kind: PointerType
-      ID: 173
+      ID: 130
       Name: '*hash<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>'
       ByteSize: 8
-      Pointee: 174 GoHMapHeaderType hash<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
+      Pointee: 131 GoHMapHeaderType hash<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
     - __kind: PointerType
-      ID: 66
+      ID: 109
       Name: '*hash<string,[]*mime/multipart.FileHeader>'
       ByteSize: 8
-      Pointee: 67 GoHMapHeaderType hash<string,[]*mime/multipart.FileHeader>
+      Pointee: 110 GoHMapHeaderType hash<string,[]*mime/multipart.FileHeader>
     - __kind: PointerType
-      ID: 44
+      ID: 48
       Name: '*hash<string,[]string>'
       ByteSize: 8
-      Pointee: 45 GoHMapHeaderType hash<string,[]string>
+      Pointee: 49 GoHMapHeaderType hash<string,[]string>
     - __kind: PointerType
-      ID: 161
+      ID: 83
       Name: '*hash<string,float64>'
       ByteSize: 8
-      Pointee: 162 GoHMapHeaderType hash<string,float64>
+      Pointee: 84 GoHMapHeaderType hash<string,float64>
     - __kind: PointerType
-      ID: 155
+      ID: 78
       Name: '*hash<string,interface {}>'
       ByteSize: 8
-      Pointee: 156 GoHMapHeaderType hash<string,interface {}>
+      Pointee: 79 GoHMapHeaderType hash<string,interface {}>
     - __kind: PointerType
-      ID: 143
+      ID: 69
       Name: '*hash<string,string>'
       ByteSize: 8
-      Pointee: 144 GoHMapHeaderType hash<string,string>
+      Pointee: 70 GoHMapHeaderType hash<string,string>
     - __kind: PointerType
       ID: 27
       Name: '*int'
@@ -515,62 +515,62 @@ Types:
       GoKind: 22
       Pointee: 14 BaseType int8
     - __kind: PointerType
-      ID: 86
+      ID: 153
       Name: '*math/big.Int'
       ByteSize: 8
       GoRuntimeType: 2.296864e+06
       GoKind: 22
-      Pointee: 87 StructureType math/big.Int
+      Pointee: 154 StructureType math/big.Int
     - __kind: PointerType
-      ID: 89
+      ID: 188
       Name: '*math/big.Word'
       ByteSize: 8
       GoRuntimeType: 403456
       GoKind: 22
-      Pointee: 90 BaseType math/big.Word
+      Pointee: 189 BaseType math/big.Word
     - __kind: PointerType
-      ID: 218
+      ID: 254
       Name: '*math/big.nat.array'
       ByteSize: 8
-      Pointee: 217 GoSliceDataType math/big.nat.array
+      Pointee: 253 GoSliceDataType math/big.nat.array
     - __kind: PointerType
-      ID: 73
+      ID: 142
       Name: '*mime/multipart.FileHeader'
       ByteSize: 8
       GoRuntimeType: 853632
       GoKind: 22
-      Pointee: 74 StructureType mime/multipart.FileHeader
+      Pointee: 150 StructureType mime/multipart.FileHeader
     - __kind: PointerType
-      ID: 62
+      ID: 58
       Name: '*mime/multipart.Form'
       ByteSize: 8
       GoRuntimeType: 853728
       GoKind: 22
-      Pointee: 63 StructureType mime/multipart.Form
+      Pointee: 59 StructureType mime/multipart.Form
     - __kind: PointerType
-      ID: 115
+      ID: 173
       Name: '*net.IP'
       ByteSize: 8
       GoRuntimeType: 2.028544e+06
       GoKind: 22
-      Pointee: 116 GoSliceHeaderType net.IP
+      Pointee: 174 GoSliceHeaderType net.IP
     - __kind: PointerType
-      ID: 236
+      ID: 246
       Name: '*net.IP.array'
       ByteSize: 8
-      Pointee: 235 GoSliceDataType net.IP.array
+      Pointee: 245 GoSliceDataType net.IP.array
     - __kind: PointerType
-      ID: 242
+      ID: 262
       Name: '*net.IPMask.array'
       ByteSize: 8
-      Pointee: 241 GoSliceDataType net.IPMask.array
+      Pointee: 261 GoSliceDataType net.IPMask.array
     - __kind: PointerType
-      ID: 121
+      ID: 179
       Name: '*net.IPNet'
       ByteSize: 8
       GoRuntimeType: 1.122688e+06
       GoKind: 22
-      Pointee: 122 StructureType net.IPNet
+      Pointee: 196 StructureType net.IPNet
     - __kind: PointerType
       ID: 37
       Name: '*net/http.Request'
@@ -579,47 +579,47 @@ Types:
       GoKind: 22
       Pointee: 38 StructureType net/http.Request
     - __kind: PointerType
-      ID: 134
+      ID: 63
       Name: '*net/http.Response'
       ByteSize: 8
       GoRuntimeType: 1.63216e+06
       GoKind: 22
-      Pointee: 135 StructureType net/http.Response
+      Pointee: 64 StructureType net/http.Response
     - __kind: PointerType
-      ID: 137
+      ID: 66
       Name: '*net/http.pattern'
       ByteSize: 8
       GoRuntimeType: 1.45312e+06
       GoKind: 22
-      Pointee: 138 StructureType net/http.pattern
+      Pointee: 67 StructureType net/http.pattern
     - __kind: PointerType
-      ID: 140
+      ID: 123
       Name: '*net/http.segment'
       ByteSize: 8
       GoRuntimeType: 367808
       GoKind: 22
-      Pointee: 141 StructureType net/http.segment
+      Pointee: 124 StructureType net/http.segment
     - __kind: PointerType
-      ID: 39
+      ID: 45
       Name: '*net/url.URL'
       ByteSize: 8
       GoRuntimeType: 2.00192e+06
       GoKind: 22
-      Pointee: 40 StructureType net/url.URL
+      Pointee: 46 StructureType net/url.URL
     - __kind: PointerType
-      ID: 41
+      ID: 98
       Name: '*net/url.Userinfo'
       ByteSize: 8
       GoRuntimeType: 1.141376e+06
       GoKind: 22
-      Pointee: 42 StructureType net/url.Userinfo
+      Pointee: 99 StructureType net/url.Userinfo
     - __kind: PointerType
-      ID: 57
+      ID: 105
       Name: '*runtime.bmap'
       ByteSize: 8
       GoRuntimeType: 1.137024e+06
       GoKind: 22
-      Pointee: 58 StructureType runtime.bmap
+      Pointee: 106 StructureType runtime.bmap
     - __kind: PointerType
       ID: 52
       Name: '*runtime.mapextra'
@@ -640,26 +640,26 @@ Types:
       ByteSize: 8
       Pointee: 203 GoStringDataType string.str
     - __kind: PointerType
-      ID: 97
+      ID: 160
       Name: '*time.Location'
       ByteSize: 8
       GoRuntimeType: 1.458112e+06
       GoKind: 22
-      Pointee: 98 StructureType time.Location
+      Pointee: 161 StructureType time.Location
     - __kind: PointerType
-      ID: 100
+      ID: 191
       Name: '*time.zone'
       ByteSize: 8
       GoRuntimeType: 370880
       GoKind: 22
-      Pointee: 101 StructureType time.zone
+      Pointee: 192 StructureType time.zone
     - __kind: PointerType
-      ID: 103
+      ID: 194
       Name: '*time.zoneTrans'
       ByteSize: 8
       GoRuntimeType: 370944
       GoKind: 22
-      Pointee: 104 StructureType time.zoneTrans
+      Pointee: 195 StructureType time.zoneTrans
     - __kind: PointerType
       ID: 34
       Name: '*uint'
@@ -703,7 +703,7 @@ Types:
       GoKind: 22
       Pointee: 1 BaseType uintptr
     - __kind: GoChannelType
-      ID: 133
+      ID: 62
       Name: <-chan struct {}
       GoRuntimeType: 555296
       GoKind: 18
@@ -747,7 +747,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: ArrayType
-      ID: 48
+      ID: 100
       Name: '[8]uint8'
       ByteSize: 8
       GoRuntimeType: 632608
@@ -756,7 +756,7 @@ Types:
       HasCount: true
       Element: 3 BaseType uint8
     - __kind: GoSliceHeaderType
-      ID: 79
+      ID: 113
       Name: '[]*crypto/x509.Certificate'
       ByteSize: 24
       GoRuntimeType: 473760
@@ -764,21 +764,21 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 80 PointerType **crypto/x509.Certificate
+          Type: 114 PointerType **crypto/x509.Certificate
         - Name: len
           Offset: 8
           Type: 9 BaseType int
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 215 GoSliceDataType []*crypto/x509.Certificate.array
+      Data: 220 GoSliceDataType []*crypto/x509.Certificate.array
     - __kind: GoSliceDataType
-      ID: 215
+      ID: 220
       Name: '[]*crypto/x509.Certificate.array'
       ByteSize: 2048
-      Element: 81 PointerType *crypto/x509.Certificate
+      Element: 115 PointerType *crypto/x509.Certificate
     - __kind: GoSliceHeaderType
-      ID: 193
+      ID: 147
       Name: '[]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span'
       ByteSize: 24
       GoRuntimeType: 463872
@@ -786,21 +786,21 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 194 PointerType **github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span
+          Type: 148 PointerType **github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span
         - Name: len
           Offset: 8
           Type: 9 BaseType int
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 261 GoSliceDataType []*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span.array
+      Data: 231 GoSliceDataType []*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span.array
     - __kind: GoSliceDataType
-      ID: 261
+      ID: 231
       Name: '[]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span.array'
       ByteSize: 2048
-      Element: 148 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span
+      Element: 39 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span
     - __kind: GoSliceHeaderType
-      ID: 183
+      ID: 197
       Name: '[]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttributeValue'
       ByteSize: 24
       GoRuntimeType: 463488
@@ -808,7 +808,7 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 184 PointerType **github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttributeValue
+          Type: 198 PointerType **github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttributeValue
         - Name: len
           Offset: 8
           Type: 9 BaseType int
@@ -820,9 +820,9 @@ Types:
       ID: 259
       Name: '[]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttributeValue.array'
       ByteSize: 2048
-      Element: 185 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttributeValue
+      Element: 199 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttributeValue
     - __kind: GoSliceHeaderType
-      ID: 71
+      ID: 140
       Name: '[]*mime/multipart.FileHeader'
       ByteSize: 24
       GoRuntimeType: 461504
@@ -830,21 +830,21 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 72 PointerType **mime/multipart.FileHeader
+          Type: 141 PointerType **mime/multipart.FileHeader
         - Name: len
           Offset: 8
           Type: 9 BaseType int
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 211 GoSliceDataType []*mime/multipart.FileHeader.array
+      Data: 229 GoSliceDataType []*mime/multipart.FileHeader.array
     - __kind: GoSliceDataType
-      ID: 211
+      ID: 229
       Name: '[]*mime/multipart.FileHeader.array'
       ByteSize: 2048
-      Element: 73 PointerType *mime/multipart.FileHeader
+      Element: 142 PointerType *mime/multipart.FileHeader
     - __kind: GoSliceHeaderType
-      ID: 119
+      ID: 177
       Name: '[]*net.IPNet'
       ByteSize: 24
       GoRuntimeType: 486816
@@ -852,21 +852,21 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 120 PointerType **net.IPNet
+          Type: 178 PointerType **net.IPNet
         - Name: len
           Offset: 8
           Type: 9 BaseType int
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 239 GoSliceDataType []*net.IPNet.array
+      Data: 249 GoSliceDataType []*net.IPNet.array
     - __kind: GoSliceDataType
-      ID: 239
+      ID: 249
       Name: '[]*net.IPNet.array'
       ByteSize: 2048
-      Element: 121 PointerType *net.IPNet
+      Element: 179 PointerType *net.IPNet
     - __kind: GoSliceHeaderType
-      ID: 117
+      ID: 175
       Name: '[]*net/url.URL'
       ByteSize: 24
       GoRuntimeType: 486752
@@ -874,21 +874,21 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 118 PointerType **net/url.URL
+          Type: 176 PointerType **net/url.URL
         - Name: len
           Offset: 8
           Type: 9 BaseType int
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 237 GoSliceDataType []*net/url.URL.array
+      Data: 247 GoSliceDataType []*net/url.URL.array
     - __kind: GoSliceDataType
-      ID: 237
+      ID: 247
       Name: '[]*net/url.URL.array'
       ByteSize: 2048
-      Element: 39 PointerType *net/url.URL
+      Element: 45 PointerType *net/url.URL
     - __kind: GoSliceHeaderType
-      ID: 55
+      ID: 104
       Name: '[]*runtime.bmap'
       ByteSize: 24
       GoRuntimeType: 470592
@@ -896,21 +896,21 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 56 PointerType **runtime.bmap
+          Type: 138 PointerType **runtime.bmap
         - Name: len
           Offset: 8
           Type: 9 BaseType int
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 208 GoSliceDataType []*runtime.bmap.array
+      Data: 217 GoSliceDataType []*runtime.bmap.array
     - __kind: GoSliceDataType
-      ID: 208
+      ID: 217
       Name: '[]*runtime.bmap.array'
       ByteSize: 2048
-      Element: 57 PointerType *runtime.bmap
+      Element: 105 PointerType *runtime.bmap
     - __kind: GoSliceHeaderType
-      ID: 127
+      ID: 116
       Name: '[][]*crypto/x509.Certificate'
       ByteSize: 24
       GoRuntimeType: 473888
@@ -918,21 +918,21 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 128 PointerType *[]*crypto/x509.Certificate
+          Type: 117 PointerType *[]*crypto/x509.Certificate
         - Name: len
           Offset: 8
           Type: 9 BaseType int
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 245 GoSliceDataType [][]*crypto/x509.Certificate.array
+      Data: 222 GoSliceDataType [][]*crypto/x509.Certificate.array
     - __kind: GoSliceDataType
-      ID: 245
+      ID: 222
       Name: '[][]*crypto/x509.Certificate.array'
       ByteSize: 2048
-      Element: 79 GoSliceHeaderType []*crypto/x509.Certificate
+      Element: 113 GoSliceHeaderType []*crypto/x509.Certificate
     - __kind: GoSliceHeaderType
-      ID: 129
+      ID: 118
       Name: '[][]uint8'
       ByteSize: 24
       GoRuntimeType: 457024
@@ -940,51 +940,51 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 130 PointerType *[]uint8
+          Type: 119 PointerType *[]uint8
         - Name: len
           Offset: 8
           Type: 9 BaseType int
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 247 GoSliceDataType [][]uint8.array
+      Data: 224 GoSliceDataType [][]uint8.array
     - __kind: GoSliceDataType
-      ID: 247
+      ID: 224
       Name: '[][]uint8.array'
       ByteSize: 2048
-      Element: 76 GoSliceHeaderType []uint8
+      Element: 96 GoSliceHeaderType []uint8
     - __kind: GoSliceDataType
-      ID: 258
+      ID: 228
       Name: '[]bucket<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>.array'
       ByteSize: 2048
-      Element: 176 GoHMapBucketType bucket<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
+      Element: 133 GoHMapBucketType bucket<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
     - __kind: GoSliceDataType
-      ID: 210
+      ID: 219
       Name: '[]bucket<string,[]*mime/multipart.FileHeader>.array'
       ByteSize: 2048
-      Element: 69 GoHMapBucketType bucket<string,[]*mime/multipart.FileHeader>
+      Element: 112 GoHMapBucketType bucket<string,[]*mime/multipart.FileHeader>
     - __kind: GoSliceDataType
       ID: 205
       Name: '[]bucket<string,[]string>.array'
       ByteSize: 2048
-      Element: 47 GoHMapBucketType bucket<string,[]string>
+      Element: 51 GoHMapBucketType bucket<string,[]string>
     - __kind: GoSliceDataType
-      ID: 253
+      ID: 210
       Name: '[]bucket<string,float64>.array'
       ByteSize: 2048
-      Element: 164 GoHMapBucketType bucket<string,float64>
+      Element: 86 GoHMapBucketType bucket<string,float64>
     - __kind: GoSliceDataType
-      ID: 252
+      ID: 209
       Name: '[]bucket<string,interface {}>.array'
       ByteSize: 2048
-      Element: 158 GoHMapBucketType bucket<string,interface {}>
+      Element: 81 GoHMapBucketType bucket<string,interface {}>
     - __kind: GoSliceDataType
-      ID: 251
+      ID: 208
       Name: '[]bucket<string,string>.array'
       ByteSize: 2048
-      Element: 146 GoHMapBucketType bucket<string,string>
+      Element: 72 GoHMapBucketType bucket<string,string>
     - __kind: GoSliceHeaderType
-      ID: 111
+      ID: 169
       Name: '[]crypto/x509.ExtKeyUsage'
       ByteSize: 24
       GoRuntimeType: 475040
@@ -992,21 +992,21 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 112 PointerType *crypto/x509.ExtKeyUsage
+          Type: 170 PointerType *crypto/x509.ExtKeyUsage
         - Name: len
           Offset: 8
           Type: 9 BaseType int
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 231 GoSliceDataType []crypto/x509.ExtKeyUsage.array
+      Data: 241 GoSliceDataType []crypto/x509.ExtKeyUsage.array
     - __kind: GoSliceDataType
-      ID: 231
+      ID: 241
       Name: '[]crypto/x509.ExtKeyUsage.array'
       ByteSize: 2048
-      Element: 113 BaseType crypto/x509.ExtKeyUsage
+      Element: 171 BaseType crypto/x509.ExtKeyUsage
     - __kind: GoSliceHeaderType
-      ID: 124
+      ID: 180
       Name: '[]crypto/x509.OID'
       ByteSize: 24
       GoRuntimeType: 486880
@@ -1014,21 +1014,21 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 125 PointerType *crypto/x509.OID
+          Type: 181 PointerType *crypto/x509.OID
         - Name: len
           Offset: 8
           Type: 9 BaseType int
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 243 GoSliceDataType []crypto/x509.OID.array
+      Data: 251 GoSliceDataType []crypto/x509.OID.array
     - __kind: GoSliceDataType
-      ID: 243
+      ID: 251
       Name: '[]crypto/x509.OID.array'
       ByteSize: 2048
-      Element: 126 StructureType crypto/x509.OID
+      Element: 182 StructureType crypto/x509.OID
     - __kind: GoSliceHeaderType
-      ID: 92
+      ID: 156
       Name: '[]crypto/x509/pkix.AttributeTypeAndValue'
       ByteSize: 24
       GoRuntimeType: 487136
@@ -1036,21 +1036,21 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 93 PointerType *crypto/x509/pkix.AttributeTypeAndValue
+          Type: 157 PointerType *crypto/x509/pkix.AttributeTypeAndValue
         - Name: len
           Offset: 8
           Type: 9 BaseType int
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 219 GoSliceDataType []crypto/x509/pkix.AttributeTypeAndValue.array
+      Data: 233 GoSliceDataType []crypto/x509/pkix.AttributeTypeAndValue.array
     - __kind: GoSliceDataType
-      ID: 219
+      ID: 233
       Name: '[]crypto/x509/pkix.AttributeTypeAndValue.array'
       ByteSize: 2048
-      Element: 94 StructureType crypto/x509/pkix.AttributeTypeAndValue
+      Element: 158 StructureType crypto/x509/pkix.AttributeTypeAndValue
     - __kind: GoSliceHeaderType
-      ID: 106
+      ID: 163
       Name: '[]crypto/x509/pkix.Extension'
       ByteSize: 24
       GoRuntimeType: 486624
@@ -1058,21 +1058,21 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 107 PointerType *crypto/x509/pkix.Extension
+          Type: 164 PointerType *crypto/x509/pkix.Extension
         - Name: len
           Offset: 8
           Type: 9 BaseType int
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 227 GoSliceDataType []crypto/x509/pkix.Extension.array
+      Data: 235 GoSliceDataType []crypto/x509/pkix.Extension.array
     - __kind: GoSliceDataType
-      ID: 227
+      ID: 235
       Name: '[]crypto/x509/pkix.Extension.array'
       ByteSize: 2048
-      Element: 108 StructureType crypto/x509/pkix.Extension
+      Element: 165 StructureType crypto/x509/pkix.Extension
     - __kind: GoSliceHeaderType
-      ID: 109
+      ID: 166
       Name: '[]encoding/asn1.ObjectIdentifier'
       ByteSize: 24
       GoRuntimeType: 486688
@@ -1080,21 +1080,21 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 110 PointerType *encoding/asn1.ObjectIdentifier
+          Type: 167 PointerType *encoding/asn1.ObjectIdentifier
         - Name: len
           Offset: 8
           Type: 9 BaseType int
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 229 GoSliceDataType []encoding/asn1.ObjectIdentifier.array
+      Data: 237 GoSliceDataType []encoding/asn1.ObjectIdentifier.array
     - __kind: GoSliceDataType
-      ID: 229
+      ID: 237
       Name: '[]encoding/asn1.ObjectIdentifier.array'
       ByteSize: 2048
-      Element: 95 GoSliceHeaderType encoding/asn1.ObjectIdentifier
+      Element: 168 GoSliceHeaderType encoding/asn1.ObjectIdentifier
     - __kind: GoSliceHeaderType
-      ID: 166
+      ID: 87
       Name: '[]github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink'
       ByteSize: 24
       GoRuntimeType: 463424
@@ -1102,21 +1102,21 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 167 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink
+          Type: 88 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink
         - Name: len
           Offset: 8
           Type: 9 BaseType int
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 254 GoSliceDataType []github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink.array
+      Data: 211 GoSliceDataType []github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink.array
     - __kind: GoSliceDataType
-      ID: 254
+      ID: 211
       Name: '[]github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink.array'
       ByteSize: 2048
-      Element: 168 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink
+      Element: 89 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink
     - __kind: GoSliceHeaderType
-      ID: 169
+      ID: 90
       Name: '[]github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent'
       ByteSize: 24
       GoRuntimeType: 463616
@@ -1124,28 +1124,28 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 170 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent
+          Type: 91 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent
         - Name: len
           Offset: 8
           Type: 9 BaseType int
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 256 GoSliceDataType []github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent.array
+      Data: 213 GoSliceDataType []github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent.array
     - __kind: GoSliceDataType
-      ID: 256
+      ID: 213
       Name: '[]github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent.array'
       ByteSize: 2048
-      Element: 171 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent
+      Element: 92 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent
     - __kind: ArrayType
-      ID: 49
+      ID: 101
       Name: '[]key<string>'
       ByteSize: 128
       Count: 8
       HasCount: true
       Element: 11 GoStringHeaderType string
     - __kind: GoSliceHeaderType
-      ID: 114
+      ID: 172
       Name: '[]net.IP'
       ByteSize: 24
       GoRuntimeType: 458240
@@ -1153,21 +1153,21 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 115 PointerType *net.IP
+          Type: 173 PointerType *net.IP
         - Name: len
           Offset: 8
           Type: 9 BaseType int
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 233 GoSliceDataType []net.IP.array
+      Data: 243 GoSliceDataType []net.IP.array
     - __kind: GoSliceDataType
-      ID: 233
+      ID: 243
       Name: '[]net.IP.array'
       ByteSize: 2048
-      Element: 116 GoSliceHeaderType net.IP
+      Element: 174 GoSliceHeaderType net.IP
     - __kind: GoSliceHeaderType
-      ID: 139
+      ID: 122
       Name: '[]net/http.segment'
       ByteSize: 24
       GoRuntimeType: 459008
@@ -1175,21 +1175,21 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 140 PointerType *net/http.segment
+          Type: 123 PointerType *net/http.segment
         - Name: len
           Offset: 8
           Type: 9 BaseType int
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 249 GoSliceDataType []net/http.segment.array
+      Data: 226 GoSliceDataType []net/http.segment.array
     - __kind: GoSliceDataType
-      ID: 249
+      ID: 226
       Name: '[]net/http.segment.array'
       ByteSize: 2048
-      Element: 141 StructureType net/http.segment
+      Element: 124 StructureType net/http.segment
     - __kind: GoSliceHeaderType
-      ID: 51
+      ID: 56
       Name: '[]string'
       ByteSize: 24
       GoRuntimeType: 468992
@@ -1211,7 +1211,7 @@ Types:
       ByteSize: 2048
       Element: 11 GoStringHeaderType string
     - __kind: GoSliceHeaderType
-      ID: 99
+      ID: 190
       Name: '[]time.zone'
       ByteSize: 24
       GoRuntimeType: 463104
@@ -1219,21 +1219,21 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 100 PointerType *time.zone
+          Type: 191 PointerType *time.zone
         - Name: len
           Offset: 8
           Type: 9 BaseType int
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 223 GoSliceDataType []time.zone.array
+      Data: 255 GoSliceDataType []time.zone.array
     - __kind: GoSliceDataType
-      ID: 223
+      ID: 255
       Name: '[]time.zone.array'
       ByteSize: 2048
-      Element: 101 StructureType time.zone
+      Element: 192 StructureType time.zone
     - __kind: GoSliceHeaderType
-      ID: 102
+      ID: 193
       Name: '[]time.zoneTrans'
       ByteSize: 24
       GoRuntimeType: 463168
@@ -1241,21 +1241,21 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 103 PointerType *time.zoneTrans
+          Type: 194 PointerType *time.zoneTrans
         - Name: len
           Offset: 8
           Type: 9 BaseType int
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 225 GoSliceDataType []time.zoneTrans.array
+      Data: 257 GoSliceDataType []time.zoneTrans.array
     - __kind: GoSliceDataType
-      ID: 225
+      ID: 257
       Name: '[]time.zoneTrans.array'
       ByteSize: 2048
-      Element: 104 StructureType time.zoneTrans
+      Element: 195 StructureType time.zoneTrans
     - __kind: GoSliceHeaderType
-      ID: 76
+      ID: 96
       Name: '[]uint8'
       ByteSize: 24
       GoRuntimeType: 467840
@@ -1270,49 +1270,49 @@ Types:
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 213 GoSliceDataType []uint8.array
+      Data: 215 GoSliceDataType []uint8.array
     - __kind: GoSliceDataType
-      ID: 213
+      ID: 215
       Name: '[]uint8.array'
       ByteSize: 2048
       Element: 3 BaseType uint8
     - __kind: ArrayType
-      ID: 177
+      ID: 144
       Name: '[]val<*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>'
       ByteSize: 64
       Count: 8
       HasCount: true
-      Element: 178 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
+      Element: 145 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
     - __kind: ArrayType
-      ID: 70
+      ID: 139
       Name: '[]val<[]*mime/multipart.FileHeader>'
       ByteSize: 192
       Count: 8
       HasCount: true
-      Element: 71 GoSliceHeaderType []*mime/multipart.FileHeader
+      Element: 140 GoSliceHeaderType []*mime/multipart.FileHeader
     - __kind: ArrayType
-      ID: 50
+      ID: 102
       Name: '[]val<[]string>'
       ByteSize: 192
       Count: 8
       HasCount: true
-      Element: 51 GoSliceHeaderType []string
+      Element: 56 GoSliceHeaderType []string
     - __kind: ArrayType
-      ID: 165
+      ID: 128
       Name: '[]val<float64>'
       ByteSize: 64
       Count: 8
       HasCount: true
       Element: 17 BaseType float64
     - __kind: ArrayType
-      ID: 159
+      ID: 126
       Name: '[]val<interface {}>'
       ByteSize: 128
       Count: 8
       HasCount: true
-      Element: 85 GoEmptyInterfaceType interface {}
+      Element: 127 GoEmptyInterfaceType interface {}
     - __kind: ArrayType
-      ID: 147
+      ID: 125
       Name: '[]val<string>'
       ByteSize: 128
       Count: 8
@@ -1325,121 +1325,121 @@ Types:
       GoRuntimeType: 543328
       GoKind: 1
     - __kind: GoHMapBucketType
-      ID: 176
+      ID: 133
       Name: bucket<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
       ByteSize: 208
       RawFields:
         - Name: tophash
           Offset: 0
-          Type: 48 ArrayType [8]uint8
+          Type: 100 ArrayType [8]uint8
         - Name: keys
           Offset: 8
-          Type: 49 ArrayType []key<string>
+          Type: 101 ArrayType []key<string>
         - Name: values
           Offset: 136
-          Type: 177 ArrayType []val<*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
+          Type: 144 ArrayType []val<*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
         - Name: overflow
           Offset: 200
-          Type: 175 PointerType *bucket<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
+          Type: 132 PointerType *bucket<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
       KeyType: 11 GoStringHeaderType string
-      ValueType: 178 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
+      ValueType: 145 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
     - __kind: GoHMapBucketType
-      ID: 69
+      ID: 112
       Name: bucket<string,[]*mime/multipart.FileHeader>
       ByteSize: 336
       RawFields:
         - Name: tophash
           Offset: 0
-          Type: 48 ArrayType [8]uint8
+          Type: 100 ArrayType [8]uint8
         - Name: keys
           Offset: 8
-          Type: 49 ArrayType []key<string>
+          Type: 101 ArrayType []key<string>
         - Name: values
           Offset: 136
-          Type: 70 ArrayType []val<[]*mime/multipart.FileHeader>
+          Type: 139 ArrayType []val<[]*mime/multipart.FileHeader>
         - Name: overflow
           Offset: 328
-          Type: 68 PointerType *bucket<string,[]*mime/multipart.FileHeader>
+          Type: 111 PointerType *bucket<string,[]*mime/multipart.FileHeader>
       KeyType: 11 GoStringHeaderType string
-      ValueType: 71 GoSliceHeaderType []*mime/multipart.FileHeader
+      ValueType: 140 GoSliceHeaderType []*mime/multipart.FileHeader
     - __kind: GoHMapBucketType
-      ID: 47
+      ID: 51
       Name: bucket<string,[]string>
       ByteSize: 336
       RawFields:
         - Name: tophash
           Offset: 0
-          Type: 48 ArrayType [8]uint8
+          Type: 100 ArrayType [8]uint8
         - Name: keys
           Offset: 8
-          Type: 49 ArrayType []key<string>
+          Type: 101 ArrayType []key<string>
         - Name: values
           Offset: 136
-          Type: 50 ArrayType []val<[]string>
+          Type: 102 ArrayType []val<[]string>
         - Name: overflow
           Offset: 328
-          Type: 46 PointerType *bucket<string,[]string>
+          Type: 50 PointerType *bucket<string,[]string>
       KeyType: 11 GoStringHeaderType string
-      ValueType: 51 GoSliceHeaderType []string
+      ValueType: 56 GoSliceHeaderType []string
     - __kind: GoHMapBucketType
-      ID: 164
+      ID: 86
       Name: bucket<string,float64>
       ByteSize: 208
       RawFields:
         - Name: tophash
           Offset: 0
-          Type: 48 ArrayType [8]uint8
+          Type: 100 ArrayType [8]uint8
         - Name: keys
           Offset: 8
-          Type: 49 ArrayType []key<string>
+          Type: 101 ArrayType []key<string>
         - Name: values
           Offset: 136
-          Type: 165 ArrayType []val<float64>
+          Type: 128 ArrayType []val<float64>
         - Name: overflow
           Offset: 200
-          Type: 163 PointerType *bucket<string,float64>
+          Type: 85 PointerType *bucket<string,float64>
       KeyType: 11 GoStringHeaderType string
       ValueType: 17 BaseType float64
     - __kind: GoHMapBucketType
-      ID: 158
+      ID: 81
       Name: bucket<string,interface {}>
       ByteSize: 272
       RawFields:
         - Name: tophash
           Offset: 0
-          Type: 48 ArrayType [8]uint8
+          Type: 100 ArrayType [8]uint8
         - Name: keys
           Offset: 8
-          Type: 49 ArrayType []key<string>
+          Type: 101 ArrayType []key<string>
         - Name: values
           Offset: 136
-          Type: 159 ArrayType []val<interface {}>
+          Type: 126 ArrayType []val<interface {}>
         - Name: overflow
           Offset: 264
-          Type: 157 PointerType *bucket<string,interface {}>
+          Type: 80 PointerType *bucket<string,interface {}>
       KeyType: 11 GoStringHeaderType string
-      ValueType: 85 GoEmptyInterfaceType interface {}
+      ValueType: 127 GoEmptyInterfaceType interface {}
     - __kind: GoHMapBucketType
-      ID: 146
+      ID: 72
       Name: bucket<string,string>
       ByteSize: 272
       RawFields:
         - Name: tophash
           Offset: 0
-          Type: 48 ArrayType [8]uint8
+          Type: 100 ArrayType [8]uint8
         - Name: keys
           Offset: 8
-          Type: 49 ArrayType []key<string>
+          Type: 101 ArrayType []key<string>
         - Name: values
           Offset: 136
-          Type: 147 ArrayType []val<string>
+          Type: 125 ArrayType []val<string>
         - Name: overflow
           Offset: 264
-          Type: 145 PointerType *bucket<string,string>
+          Type: 71 PointerType *bucket<string,string>
       KeyType: 11 GoStringHeaderType string
       ValueType: 11 GoStringHeaderType string
     - __kind: StructureType
-      ID: 199
+      ID: 42
       Name: bytes.Buffer
       ByteSize: 40
       GoRuntimeType: 1.450816e+06
@@ -1447,15 +1447,15 @@ Types:
       RawFields:
         - Name: buf
           Offset: 0
-          Type: 76 GoSliceHeaderType []uint8
+          Type: 96 GoSliceHeaderType []uint8
         - Name: off
           Offset: 24
           Type: 9 BaseType int
         - Name: lastRead
           Offset: 32
-          Type: 200 BaseType bytes.readOp
+          Type: 97 BaseType bytes.readOp
     - __kind: BaseType
-      ID: 200
+      ID: 97
       Name: bytes.readOp
       ByteSize: 1
       GoRuntimeType: 541536
@@ -1473,7 +1473,7 @@ Types:
       GoRuntimeType: 543072
       GoKind: 15
     - __kind: GoInterfaceType
-      ID: 136
+      ID: 65
       Name: context.Context
       ByteSize: 16
       GoRuntimeType: 1.215552e+06
@@ -1486,22 +1486,22 @@ Types:
           Offset: 8
           Type: 19 VoidPointerType unsafe.Pointer
     - __kind: StructureType
-      ID: 201
+      ID: 43
       Name: context.backgroundCtx
       GoRuntimeType: 1.708256e+06
       GoKind: 25
       RawFields:
         - Name: emptyCtx
           Offset: 0
-          Type: 202 StructureType context.emptyCtx
+          Type: 44 StructureType context.emptyCtx
     - __kind: StructureType
-      ID: 202
+      ID: 44
       Name: context.emptyCtx
       GoRuntimeType: 1.43472e+06
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 78
+      ID: 61
       Name: crypto/tls.ConnectionState
       ByteSize: 192
       GoRuntimeType: 2.160384e+06
@@ -1530,39 +1530,39 @@ Types:
           Type: 11 GoStringHeaderType string
         - Name: PeerCertificates
           Offset: 48
-          Type: 79 GoSliceHeaderType []*crypto/x509.Certificate
+          Type: 113 GoSliceHeaderType []*crypto/x509.Certificate
         - Name: VerifiedChains
           Offset: 72
-          Type: 127 GoSliceHeaderType [][]*crypto/x509.Certificate
+          Type: 116 GoSliceHeaderType [][]*crypto/x509.Certificate
         - Name: SignedCertificateTimestamps
           Offset: 96
-          Type: 129 GoSliceHeaderType [][]uint8
+          Type: 118 GoSliceHeaderType [][]uint8
         - Name: OCSPResponse
           Offset: 120
-          Type: 76 GoSliceHeaderType []uint8
+          Type: 96 GoSliceHeaderType []uint8
         - Name: TLSUnique
           Offset: 144
-          Type: 76 GoSliceHeaderType []uint8
+          Type: 96 GoSliceHeaderType []uint8
         - Name: ECHAccepted
           Offset: 168
           Type: 4 BaseType bool
         - Name: ekm
           Offset: 176
-          Type: 131 GoSubroutineType func(string, []uint8, int) ([]uint8, error)
+          Type: 120 GoSubroutineType func(string, []uint8, int) ([]uint8, error)
         - Name: testingOnlyDidHRR
           Offset: 184
           Type: 4 BaseType bool
         - Name: testingOnlyCurveID
           Offset: 186
-          Type: 132 BaseType crypto/tls.CurveID
+          Type: 121 BaseType crypto/tls.CurveID
     - __kind: BaseType
-      ID: 132
+      ID: 121
       Name: crypto/tls.CurveID
       ByteSize: 2
       GoRuntimeType: 778464
       GoKind: 9
     - __kind: StructureType
-      ID: 82
+      ID: 143
       Name: crypto/x509.Certificate
       ByteSize: 1352
       GoRuntimeType: 2.300416e+06
@@ -1570,67 +1570,67 @@ Types:
       RawFields:
         - Name: Raw
           Offset: 0
-          Type: 76 GoSliceHeaderType []uint8
+          Type: 96 GoSliceHeaderType []uint8
         - Name: RawTBSCertificate
           Offset: 24
-          Type: 76 GoSliceHeaderType []uint8
+          Type: 96 GoSliceHeaderType []uint8
         - Name: RawSubjectPublicKeyInfo
           Offset: 48
-          Type: 76 GoSliceHeaderType []uint8
+          Type: 96 GoSliceHeaderType []uint8
         - Name: RawSubject
           Offset: 72
-          Type: 76 GoSliceHeaderType []uint8
+          Type: 96 GoSliceHeaderType []uint8
         - Name: RawIssuer
           Offset: 96
-          Type: 76 GoSliceHeaderType []uint8
+          Type: 96 GoSliceHeaderType []uint8
         - Name: Signature
           Offset: 120
-          Type: 76 GoSliceHeaderType []uint8
+          Type: 96 GoSliceHeaderType []uint8
         - Name: SignatureAlgorithm
           Offset: 144
-          Type: 83 BaseType crypto/x509.SignatureAlgorithm
+          Type: 151 BaseType crypto/x509.SignatureAlgorithm
         - Name: PublicKeyAlgorithm
           Offset: 152
-          Type: 84 BaseType crypto/x509.PublicKeyAlgorithm
+          Type: 152 BaseType crypto/x509.PublicKeyAlgorithm
         - Name: PublicKey
           Offset: 160
-          Type: 85 GoEmptyInterfaceType interface {}
+          Type: 127 GoEmptyInterfaceType interface {}
         - Name: Version
           Offset: 176
           Type: 9 BaseType int
         - Name: SerialNumber
           Offset: 184
-          Type: 86 PointerType *math/big.Int
+          Type: 153 PointerType *math/big.Int
         - Name: Issuer
           Offset: 192
-          Type: 91 StructureType crypto/x509/pkix.Name
+          Type: 155 StructureType crypto/x509/pkix.Name
         - Name: Subject
           Offset: 440
-          Type: 91 StructureType crypto/x509/pkix.Name
+          Type: 155 StructureType crypto/x509/pkix.Name
         - Name: NotBefore
           Offset: 688
-          Type: 96 StructureType time.Time
+          Type: 159 StructureType time.Time
         - Name: NotAfter
           Offset: 712
-          Type: 96 StructureType time.Time
+          Type: 159 StructureType time.Time
         - Name: KeyUsage
           Offset: 736
-          Type: 105 BaseType crypto/x509.KeyUsage
+          Type: 162 BaseType crypto/x509.KeyUsage
         - Name: Extensions
           Offset: 744
-          Type: 106 GoSliceHeaderType []crypto/x509/pkix.Extension
+          Type: 163 GoSliceHeaderType []crypto/x509/pkix.Extension
         - Name: ExtraExtensions
           Offset: 768
-          Type: 106 GoSliceHeaderType []crypto/x509/pkix.Extension
+          Type: 163 GoSliceHeaderType []crypto/x509/pkix.Extension
         - Name: UnhandledCriticalExtensions
           Offset: 792
-          Type: 109 GoSliceHeaderType []encoding/asn1.ObjectIdentifier
+          Type: 166 GoSliceHeaderType []encoding/asn1.ObjectIdentifier
         - Name: ExtKeyUsage
           Offset: 816
-          Type: 111 GoSliceHeaderType []crypto/x509.ExtKeyUsage
+          Type: 169 GoSliceHeaderType []crypto/x509.ExtKeyUsage
         - Name: UnknownExtKeyUsage
           Offset: 840
-          Type: 109 GoSliceHeaderType []encoding/asn1.ObjectIdentifier
+          Type: 166 GoSliceHeaderType []encoding/asn1.ObjectIdentifier
         - Name: BasicConstraintsValid
           Offset: 864
           Type: 4 BaseType bool
@@ -1645,78 +1645,78 @@ Types:
           Type: 4 BaseType bool
         - Name: SubjectKeyId
           Offset: 888
-          Type: 76 GoSliceHeaderType []uint8
+          Type: 96 GoSliceHeaderType []uint8
         - Name: AuthorityKeyId
           Offset: 912
-          Type: 76 GoSliceHeaderType []uint8
+          Type: 96 GoSliceHeaderType []uint8
         - Name: OCSPServer
           Offset: 936
-          Type: 51 GoSliceHeaderType []string
+          Type: 56 GoSliceHeaderType []string
         - Name: IssuingCertificateURL
           Offset: 960
-          Type: 51 GoSliceHeaderType []string
+          Type: 56 GoSliceHeaderType []string
         - Name: DNSNames
           Offset: 984
-          Type: 51 GoSliceHeaderType []string
+          Type: 56 GoSliceHeaderType []string
         - Name: EmailAddresses
           Offset: 1008
-          Type: 51 GoSliceHeaderType []string
+          Type: 56 GoSliceHeaderType []string
         - Name: IPAddresses
           Offset: 1032
-          Type: 114 GoSliceHeaderType []net.IP
+          Type: 172 GoSliceHeaderType []net.IP
         - Name: URIs
           Offset: 1056
-          Type: 117 GoSliceHeaderType []*net/url.URL
+          Type: 175 GoSliceHeaderType []*net/url.URL
         - Name: PermittedDNSDomainsCritical
           Offset: 1080
           Type: 4 BaseType bool
         - Name: PermittedDNSDomains
           Offset: 1088
-          Type: 51 GoSliceHeaderType []string
+          Type: 56 GoSliceHeaderType []string
         - Name: ExcludedDNSDomains
           Offset: 1112
-          Type: 51 GoSliceHeaderType []string
+          Type: 56 GoSliceHeaderType []string
         - Name: PermittedIPRanges
           Offset: 1136
-          Type: 119 GoSliceHeaderType []*net.IPNet
+          Type: 177 GoSliceHeaderType []*net.IPNet
         - Name: ExcludedIPRanges
           Offset: 1160
-          Type: 119 GoSliceHeaderType []*net.IPNet
+          Type: 177 GoSliceHeaderType []*net.IPNet
         - Name: PermittedEmailAddresses
           Offset: 1184
-          Type: 51 GoSliceHeaderType []string
+          Type: 56 GoSliceHeaderType []string
         - Name: ExcludedEmailAddresses
           Offset: 1208
-          Type: 51 GoSliceHeaderType []string
+          Type: 56 GoSliceHeaderType []string
         - Name: PermittedURIDomains
           Offset: 1232
-          Type: 51 GoSliceHeaderType []string
+          Type: 56 GoSliceHeaderType []string
         - Name: ExcludedURIDomains
           Offset: 1256
-          Type: 51 GoSliceHeaderType []string
+          Type: 56 GoSliceHeaderType []string
         - Name: CRLDistributionPoints
           Offset: 1280
-          Type: 51 GoSliceHeaderType []string
+          Type: 56 GoSliceHeaderType []string
         - Name: PolicyIdentifiers
           Offset: 1304
-          Type: 109 GoSliceHeaderType []encoding/asn1.ObjectIdentifier
+          Type: 166 GoSliceHeaderType []encoding/asn1.ObjectIdentifier
         - Name: Policies
           Offset: 1328
-          Type: 124 GoSliceHeaderType []crypto/x509.OID
+          Type: 180 GoSliceHeaderType []crypto/x509.OID
     - __kind: BaseType
-      ID: 113
+      ID: 171
       Name: crypto/x509.ExtKeyUsage
       ByteSize: 8
       GoRuntimeType: 546400
       GoKind: 2
     - __kind: BaseType
-      ID: 105
+      ID: 162
       Name: crypto/x509.KeyUsage
       ByteSize: 8
       GoRuntimeType: 546336
       GoKind: 2
     - __kind: StructureType
-      ID: 126
+      ID: 182
       Name: crypto/x509.OID
       ByteSize: 24
       GoRuntimeType: 1.762016e+06
@@ -1724,21 +1724,21 @@ Types:
       RawFields:
         - Name: der
           Offset: 0
-          Type: 76 GoSliceHeaderType []uint8
+          Type: 96 GoSliceHeaderType []uint8
     - __kind: BaseType
-      ID: 84
+      ID: 152
       Name: crypto/x509.PublicKeyAlgorithm
       ByteSize: 8
       GoRuntimeType: 780768
       GoKind: 2
     - __kind: BaseType
-      ID: 83
+      ID: 151
       Name: crypto/x509.SignatureAlgorithm
       ByteSize: 8
       GoRuntimeType: 1.097216e+06
       GoKind: 2
     - __kind: StructureType
-      ID: 94
+      ID: 158
       Name: crypto/x509/pkix.AttributeTypeAndValue
       ByteSize: 40
       GoRuntimeType: 1.349024e+06
@@ -1746,12 +1746,12 @@ Types:
       RawFields:
         - Name: Type
           Offset: 0
-          Type: 95 GoSliceHeaderType encoding/asn1.ObjectIdentifier
+          Type: 168 GoSliceHeaderType encoding/asn1.ObjectIdentifier
         - Name: Value
           Offset: 24
-          Type: 85 GoEmptyInterfaceType interface {}
+          Type: 127 GoEmptyInterfaceType interface {}
     - __kind: StructureType
-      ID: 108
+      ID: 165
       Name: crypto/x509/pkix.Extension
       ByteSize: 56
       GoRuntimeType: 1.494592e+06
@@ -1759,15 +1759,15 @@ Types:
       RawFields:
         - Name: Id
           Offset: 0
-          Type: 95 GoSliceHeaderType encoding/asn1.ObjectIdentifier
+          Type: 168 GoSliceHeaderType encoding/asn1.ObjectIdentifier
         - Name: Critical
           Offset: 24
           Type: 4 BaseType bool
         - Name: Value
           Offset: 32
-          Type: 76 GoSliceHeaderType []uint8
+          Type: 96 GoSliceHeaderType []uint8
     - __kind: StructureType
-      ID: 91
+      ID: 155
       Name: crypto/x509/pkix.Name
       ByteSize: 248
       GoRuntimeType: 2.10512e+06
@@ -1775,25 +1775,25 @@ Types:
       RawFields:
         - Name: Country
           Offset: 0
-          Type: 51 GoSliceHeaderType []string
+          Type: 56 GoSliceHeaderType []string
         - Name: Organization
           Offset: 24
-          Type: 51 GoSliceHeaderType []string
+          Type: 56 GoSliceHeaderType []string
         - Name: OrganizationalUnit
           Offset: 48
-          Type: 51 GoSliceHeaderType []string
+          Type: 56 GoSliceHeaderType []string
         - Name: Locality
           Offset: 72
-          Type: 51 GoSliceHeaderType []string
+          Type: 56 GoSliceHeaderType []string
         - Name: Province
           Offset: 96
-          Type: 51 GoSliceHeaderType []string
+          Type: 56 GoSliceHeaderType []string
         - Name: StreetAddress
           Offset: 120
-          Type: 51 GoSliceHeaderType []string
+          Type: 56 GoSliceHeaderType []string
         - Name: PostalCode
           Offset: 144
-          Type: 51 GoSliceHeaderType []string
+          Type: 56 GoSliceHeaderType []string
         - Name: SerialNumber
           Offset: 168
           Type: 11 GoStringHeaderType string
@@ -1802,12 +1802,12 @@ Types:
           Type: 11 GoStringHeaderType string
         - Name: Names
           Offset: 200
-          Type: 92 GoSliceHeaderType []crypto/x509/pkix.AttributeTypeAndValue
+          Type: 156 GoSliceHeaderType []crypto/x509/pkix.AttributeTypeAndValue
         - Name: ExtraNames
           Offset: 224
-          Type: 92 GoSliceHeaderType []crypto/x509/pkix.AttributeTypeAndValue
+          Type: 156 GoSliceHeaderType []crypto/x509/pkix.AttributeTypeAndValue
     - __kind: GoSliceHeaderType
-      ID: 95
+      ID: 168
       Name: encoding/asn1.ObjectIdentifier
       ByteSize: 24
       GoRuntimeType: 1.037376e+06
@@ -1822,9 +1822,9 @@ Types:
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 221 GoSliceDataType encoding/asn1.ObjectIdentifier.array
+      Data: 239 GoSliceDataType encoding/asn1.ObjectIdentifier.array
     - __kind: GoSliceDataType
-      ID: 221
+      ID: 239
       Name: encoding/asn1.ObjectIdentifier.array
       ByteSize: 2048
       Element: 9 BaseType int
@@ -1854,25 +1854,25 @@ Types:
       GoRuntimeType: 543264
       GoKind: 14
     - __kind: GoSubroutineType
-      ID: 197
+      ID: 95
       Name: func()
       ByteSize: 8
       GoRuntimeType: 455360
       GoKind: 19
     - __kind: GoSubroutineType
-      ID: 60
+      ID: 55
       Name: func() (io.ReadCloser, error)
       ByteSize: 8
       GoRuntimeType: 645280
       GoKind: 19
     - __kind: GoSubroutineType
-      ID: 131
+      ID: 120
       Name: func(string, []uint8, int) ([]uint8, error)
       ByteSize: 8
       GoRuntimeType: 982976
       GoKind: 19
     - __kind: StructureType
-      ID: 149
+      ID: 40
       Name: github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span
       ByteSize: 288
       GoRuntimeType: 2.251424e+06
@@ -1880,7 +1880,7 @@ Types:
       RawFields:
         - Name: mu
           Offset: 0
-          Type: 150 StructureType sync.RWMutex
+          Type: 73 StructureType sync.RWMutex
         - Name: name
           Offset: 24
           Type: 11 GoStringHeaderType string
@@ -1901,13 +1901,13 @@ Types:
           Type: 13 BaseType int64
         - Name: meta
           Offset: 104
-          Type: 142 GoMapType map[string]string
+          Type: 68 GoMapType map[string]string
         - Name: metaStruct
           Offset: 112
-          Type: 154 GoMapType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.metaStructMap
+          Type: 77 GoMapType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.metaStructMap
         - Name: metrics
           Offset: 120
-          Type: 160 GoMapType map[string]float64
+          Type: 82 GoMapType map[string]float64
         - Name: spanID
           Offset: 128
           Type: 10 BaseType uint64
@@ -1922,10 +1922,10 @@ Types:
           Type: 12 BaseType int32
         - Name: spanLinks
           Offset: 160
-          Type: 166 GoSliceHeaderType []github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink
+          Type: 87 GoSliceHeaderType []github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink
         - Name: spanEvents
           Offset: 184
-          Type: 169 GoSliceHeaderType []github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent
+          Type: 90 GoSliceHeaderType []github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent
         - Name: goExecTraced
           Offset: 208
           Type: 4 BaseType bool
@@ -1937,7 +1937,7 @@ Types:
           Type: 4 BaseType bool
         - Name: context
           Offset: 216
-          Type: 189 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanContext
+          Type: 93 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanContext
         - Name: integration
           Offset: 224
           Type: 11 GoStringHeaderType string
@@ -1946,15 +1946,15 @@ Types:
           Type: 4 BaseType bool
         - Name: pprofCtxActive
           Offset: 248
-          Type: 136 GoInterfaceType context.Context
+          Type: 65 GoInterfaceType context.Context
         - Name: pprofCtxRestore
           Offset: 264
-          Type: 136 GoInterfaceType context.Context
+          Type: 65 GoInterfaceType context.Context
         - Name: taskEnd
           Offset: 280
-          Type: 197 GoSubroutineType func()
+          Type: 95 GoSubroutineType func()
     - __kind: StructureType
-      ID: 190
+      ID: 94
       Name: github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanContext
       ByteSize: 168
       GoRuntimeType: 2.1248e+06
@@ -1965,13 +1965,13 @@ Types:
           Type: 4 BaseType bool
         - Name: trace
           Offset: 8
-          Type: 191 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.trace
+          Type: 135 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.trace
         - Name: span
           Offset: 16
-          Type: 148 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span
+          Type: 39 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span
         - Name: errors
           Offset: 24
-          Type: 152 StructureType sync/atomic.Int32
+          Type: 75 StructureType sync/atomic.Int32
         - Name: reparentID
           Offset: 32
           Type: 11 GoStringHeaderType string
@@ -1980,16 +1980,16 @@ Types:
           Type: 4 BaseType bool
         - Name: traceID
           Offset: 49
-          Type: 196 ArrayType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.traceID
+          Type: 137 ArrayType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.traceID
         - Name: spanID
           Offset: 72
           Type: 10 BaseType uint64
         - Name: mu
           Offset: 80
-          Type: 150 StructureType sync.RWMutex
+          Type: 73 StructureType sync.RWMutex
         - Name: baggage
           Offset: 104
-          Type: 142 GoMapType map[string]string
+          Type: 68 GoMapType map[string]string
         - Name: hasBaggage
           Offset: 112
           Type: 2 BaseType uint32
@@ -1998,12 +1998,12 @@ Types:
           Type: 11 GoStringHeaderType string
         - Name: spanLinks
           Offset: 136
-          Type: 166 GoSliceHeaderType []github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink
+          Type: 87 GoSliceHeaderType []github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink
         - Name: baggageOnly
           Offset: 160
           Type: 4 BaseType bool
     - __kind: StructureType
-      ID: 168
+      ID: 89
       Name: github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink
       ByteSize: 56
       GoRuntimeType: 1.822016e+06
@@ -2020,7 +2020,7 @@ Types:
           Type: 10 BaseType uint64
         - Name: Attributes
           Offset: 24
-          Type: 142 GoMapType map[string]string
+          Type: 68 GoMapType map[string]string
         - Name: Tracestate
           Offset: 32
           Type: 11 GoStringHeaderType string
@@ -2028,20 +2028,20 @@ Types:
           Offset: 48
           Type: 2 BaseType uint32
     - __kind: GoMapType
-      ID: 154
+      ID: 77
       Name: github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.metaStructMap
       ByteSize: 8
       GoRuntimeType: 1.007296e+06
       GoKind: 21
-      HeaderType: 156 GoHMapHeaderType hash<string,interface {}>
+      HeaderType: 79 GoHMapHeaderType hash<string,interface {}>
     - __kind: BaseType
-      ID: 195
+      ID: 149
       Name: github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.samplingDecision
       ByteSize: 4
       GoRuntimeType: 542112
       GoKind: 10
     - __kind: StructureType
-      ID: 171
+      ID: 92
       Name: github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent
       ByteSize: 40
       GoRuntimeType: 1.663808e+06
@@ -2055,12 +2055,12 @@ Types:
           Type: 10 BaseType uint64
         - Name: Attributes
           Offset: 24
-          Type: 172 GoMapType map[string]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
+          Type: 129 GoMapType map[string]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
         - Name: RawAttributes
           Offset: 32
-          Type: 188 GoMapType map[string]interface {}
+          Type: 134 GoMapType map[string]interface {}
     - __kind: StructureType
-      ID: 182
+      ID: 185
       Name: github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttribute
       ByteSize: 24
       GoRuntimeType: 1.129856e+06
@@ -2068,9 +2068,9 @@ Types:
       RawFields:
         - Name: Values
           Offset: 0
-          Type: 183 GoSliceHeaderType []*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttributeValue
+          Type: 197 GoSliceHeaderType []*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttributeValue
     - __kind: StructureType
-      ID: 186
+      ID: 201
       Name: github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttributeValue
       ByteSize: 48
       GoRuntimeType: 1.747904e+06
@@ -2078,7 +2078,7 @@ Types:
       RawFields:
         - Name: Type
           Offset: 0
-          Type: 187 BaseType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttributeValueType
+          Type: 202 BaseType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttributeValueType
         - Name: StringValue
           Offset: 8
           Type: 11 GoStringHeaderType string
@@ -2092,13 +2092,13 @@ Types:
           Offset: 40
           Type: 17 BaseType float64
     - __kind: BaseType
-      ID: 187
+      ID: 202
       Name: github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttributeValueType
       ByteSize: 4
       GoRuntimeType: 965120
       GoKind: 5
     - __kind: StructureType
-      ID: 179
+      ID: 146
       Name: github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
       ByteSize: 56
       GoRuntimeType: 1.822272e+06
@@ -2106,7 +2106,7 @@ Types:
       RawFields:
         - Name: Type
           Offset: 0
-          Type: 180 BaseType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttributeType
+          Type: 183 BaseType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttributeType
         - Name: StringValue
           Offset: 8
           Type: 11 GoStringHeaderType string
@@ -2121,15 +2121,15 @@ Types:
           Type: 17 BaseType float64
         - Name: ArrayValue
           Offset: 48
-          Type: 181 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttribute
+          Type: 184 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttribute
     - __kind: BaseType
-      ID: 180
+      ID: 183
       Name: github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttributeType
       ByteSize: 4
       GoRuntimeType: 965024
       GoKind: 5
     - __kind: StructureType
-      ID: 192
+      ID: 136
       Name: github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.trace
       ByteSize: 104
       GoRuntimeType: 2.01696e+06
@@ -2137,16 +2137,16 @@ Types:
       RawFields:
         - Name: mu
           Offset: 0
-          Type: 150 StructureType sync.RWMutex
+          Type: 73 StructureType sync.RWMutex
         - Name: spans
           Offset: 24
-          Type: 193 GoSliceHeaderType []*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span
+          Type: 147 GoSliceHeaderType []*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span
         - Name: tags
           Offset: 48
-          Type: 142 GoMapType map[string]string
+          Type: 68 GoMapType map[string]string
         - Name: propagatingTags
           Offset: 56
-          Type: 142 GoMapType map[string]string
+          Type: 68 GoMapType map[string]string
         - Name: finished
           Offset: 64
           Type: 9 BaseType int
@@ -2161,12 +2161,12 @@ Types:
           Type: 4 BaseType bool
         - Name: samplingDecision
           Offset: 92
-          Type: 195 BaseType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.samplingDecision
+          Type: 149 BaseType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.samplingDecision
         - Name: root
           Offset: 96
-          Type: 148 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span
+          Type: 39 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span
     - __kind: ArrayType
-      ID: 196
+      ID: 137
       Name: github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.traceID
       ByteSize: 16
       GoRuntimeType: 847584
@@ -2175,7 +2175,7 @@ Types:
       HasCount: true
       Element: 3 BaseType uint8
     - __kind: GoHMapHeaderType
-      ID: 174
+      ID: 131
       Name: hash<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
       ByteSize: 48
       RawFields:
@@ -2196,20 +2196,20 @@ Types:
           Type: 2 BaseType uint32
         - Name: buckets
           Offset: 16
-          Type: 175 PointerType *bucket<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
+          Type: 132 PointerType *bucket<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
         - Name: oldbuckets
           Offset: 24
-          Type: 175 PointerType *bucket<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
+          Type: 132 PointerType *bucket<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
         - Name: nevacuate
           Offset: 32
           Type: 1 BaseType uintptr
         - Name: extra
           Offset: 40
           Type: 52 PointerType *runtime.mapextra
-      BucketType: 176 GoHMapBucketType bucket<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
-      BucketsType: 258 GoSliceDataType []bucket<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>.array
+      BucketType: 133 GoHMapBucketType bucket<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
+      BucketsType: 228 GoSliceDataType []bucket<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>.array
     - __kind: GoHMapHeaderType
-      ID: 67
+      ID: 110
       Name: hash<string,[]*mime/multipart.FileHeader>
       ByteSize: 48
       RawFields:
@@ -2230,20 +2230,20 @@ Types:
           Type: 2 BaseType uint32
         - Name: buckets
           Offset: 16
-          Type: 68 PointerType *bucket<string,[]*mime/multipart.FileHeader>
+          Type: 111 PointerType *bucket<string,[]*mime/multipart.FileHeader>
         - Name: oldbuckets
           Offset: 24
-          Type: 68 PointerType *bucket<string,[]*mime/multipart.FileHeader>
+          Type: 111 PointerType *bucket<string,[]*mime/multipart.FileHeader>
         - Name: nevacuate
           Offset: 32
           Type: 1 BaseType uintptr
         - Name: extra
           Offset: 40
           Type: 52 PointerType *runtime.mapextra
-      BucketType: 69 GoHMapBucketType bucket<string,[]*mime/multipart.FileHeader>
-      BucketsType: 210 GoSliceDataType []bucket<string,[]*mime/multipart.FileHeader>.array
+      BucketType: 112 GoHMapBucketType bucket<string,[]*mime/multipart.FileHeader>
+      BucketsType: 219 GoSliceDataType []bucket<string,[]*mime/multipart.FileHeader>.array
     - __kind: GoHMapHeaderType
-      ID: 45
+      ID: 49
       Name: hash<string,[]string>
       ByteSize: 48
       RawFields:
@@ -2264,20 +2264,20 @@ Types:
           Type: 2 BaseType uint32
         - Name: buckets
           Offset: 16
-          Type: 46 PointerType *bucket<string,[]string>
+          Type: 50 PointerType *bucket<string,[]string>
         - Name: oldbuckets
           Offset: 24
-          Type: 46 PointerType *bucket<string,[]string>
+          Type: 50 PointerType *bucket<string,[]string>
         - Name: nevacuate
           Offset: 32
           Type: 1 BaseType uintptr
         - Name: extra
           Offset: 40
           Type: 52 PointerType *runtime.mapextra
-      BucketType: 47 GoHMapBucketType bucket<string,[]string>
+      BucketType: 51 GoHMapBucketType bucket<string,[]string>
       BucketsType: 205 GoSliceDataType []bucket<string,[]string>.array
     - __kind: GoHMapHeaderType
-      ID: 162
+      ID: 84
       Name: hash<string,float64>
       ByteSize: 48
       RawFields:
@@ -2298,20 +2298,20 @@ Types:
           Type: 2 BaseType uint32
         - Name: buckets
           Offset: 16
-          Type: 163 PointerType *bucket<string,float64>
+          Type: 85 PointerType *bucket<string,float64>
         - Name: oldbuckets
           Offset: 24
-          Type: 163 PointerType *bucket<string,float64>
+          Type: 85 PointerType *bucket<string,float64>
         - Name: nevacuate
           Offset: 32
           Type: 1 BaseType uintptr
         - Name: extra
           Offset: 40
           Type: 52 PointerType *runtime.mapextra
-      BucketType: 164 GoHMapBucketType bucket<string,float64>
-      BucketsType: 253 GoSliceDataType []bucket<string,float64>.array
+      BucketType: 86 GoHMapBucketType bucket<string,float64>
+      BucketsType: 210 GoSliceDataType []bucket<string,float64>.array
     - __kind: GoHMapHeaderType
-      ID: 156
+      ID: 79
       Name: hash<string,interface {}>
       ByteSize: 48
       RawFields:
@@ -2332,20 +2332,20 @@ Types:
           Type: 2 BaseType uint32
         - Name: buckets
           Offset: 16
-          Type: 157 PointerType *bucket<string,interface {}>
+          Type: 80 PointerType *bucket<string,interface {}>
         - Name: oldbuckets
           Offset: 24
-          Type: 157 PointerType *bucket<string,interface {}>
+          Type: 80 PointerType *bucket<string,interface {}>
         - Name: nevacuate
           Offset: 32
           Type: 1 BaseType uintptr
         - Name: extra
           Offset: 40
           Type: 52 PointerType *runtime.mapextra
-      BucketType: 158 GoHMapBucketType bucket<string,interface {}>
-      BucketsType: 252 GoSliceDataType []bucket<string,interface {}>.array
+      BucketType: 81 GoHMapBucketType bucket<string,interface {}>
+      BucketsType: 209 GoSliceDataType []bucket<string,interface {}>.array
     - __kind: GoHMapHeaderType
-      ID: 144
+      ID: 70
       Name: hash<string,string>
       ByteSize: 48
       RawFields:
@@ -2366,18 +2366,18 @@ Types:
           Type: 2 BaseType uint32
         - Name: buckets
           Offset: 16
-          Type: 145 PointerType *bucket<string,string>
+          Type: 71 PointerType *bucket<string,string>
         - Name: oldbuckets
           Offset: 24
-          Type: 145 PointerType *bucket<string,string>
+          Type: 71 PointerType *bucket<string,string>
         - Name: nevacuate
           Offset: 32
           Type: 1 BaseType uintptr
         - Name: extra
           Offset: 40
           Type: 52 PointerType *runtime.mapextra
-      BucketType: 146 GoHMapBucketType bucket<string,string>
-      BucketsType: 251 GoSliceDataType []bucket<string,string>.array
+      BucketType: 72 GoHMapBucketType bucket<string,string>
+      BucketsType: 208 GoSliceDataType []bucket<string,string>.array
     - __kind: BaseType
       ID: 9
       Name: int
@@ -2409,7 +2409,7 @@ Types:
       GoRuntimeType: 542368
       GoKind: 3
     - __kind: GoEmptyInterfaceType
-      ID: 85
+      ID: 127
       Name: interface {}
       ByteSize: 16
       GoRuntimeType: 797888
@@ -2422,7 +2422,7 @@ Types:
           Offset: 8
           Type: 19 VoidPointerType unsafe.Pointer
     - __kind: GoInterfaceType
-      ID: 59
+      ID: 54
       Name: io.ReadCloser
       ByteSize: 16
       GoRuntimeType: 1.092864e+06
@@ -2435,49 +2435,49 @@ Types:
           Offset: 8
           Type: 19 VoidPointerType unsafe.Pointer
     - __kind: GoMapType
-      ID: 172
+      ID: 129
       Name: map[string]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
       ByteSize: 8
       GoRuntimeType: 904992
       GoKind: 21
-      HeaderType: 174 GoHMapHeaderType hash<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
+      HeaderType: 131 GoHMapHeaderType hash<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
     - __kind: GoMapType
-      ID: 65
+      ID: 108
       Name: map[string][]*mime/multipart.FileHeader
       ByteSize: 8
       GoRuntimeType: 904032
       GoKind: 21
-      HeaderType: 67 GoHMapHeaderType hash<string,[]*mime/multipart.FileHeader>
+      HeaderType: 110 GoHMapHeaderType hash<string,[]*mime/multipart.FileHeader>
     - __kind: GoMapType
-      ID: 64
+      ID: 107
       Name: map[string][]string
       ByteSize: 8
       GoRuntimeType: 899232
       GoKind: 21
-      HeaderType: 45 GoHMapHeaderType hash<string,[]string>
+      HeaderType: 49 GoHMapHeaderType hash<string,[]string>
     - __kind: GoMapType
-      ID: 160
+      ID: 82
       Name: map[string]float64
       ByteSize: 8
       GoRuntimeType: 904896
       GoKind: 21
-      HeaderType: 162 GoHMapHeaderType hash<string,float64>
+      HeaderType: 84 GoHMapHeaderType hash<string,float64>
     - __kind: GoMapType
-      ID: 188
+      ID: 134
       Name: map[string]interface {}
       ByteSize: 8
       GoRuntimeType: 896352
       GoKind: 21
-      HeaderType: 156 GoHMapHeaderType hash<string,interface {}>
+      HeaderType: 79 GoHMapHeaderType hash<string,interface {}>
     - __kind: GoMapType
-      ID: 142
+      ID: 68
       Name: map[string]string
       ByteSize: 8
       GoRuntimeType: 900864
       GoKind: 21
-      HeaderType: 144 GoHMapHeaderType hash<string,string>
+      HeaderType: 70 GoHMapHeaderType hash<string,string>
     - __kind: StructureType
-      ID: 87
+      ID: 154
       Name: math/big.Int
       ByteSize: 32
       GoRuntimeType: 1.340544e+06
@@ -2488,15 +2488,15 @@ Types:
           Type: 4 BaseType bool
         - Name: abs
           Offset: 8
-          Type: 88 GoSliceHeaderType math/big.nat
+          Type: 187 GoSliceHeaderType math/big.nat
     - __kind: BaseType
-      ID: 90
+      ID: 189
       Name: math/big.Word
       ByteSize: 8
       GoRuntimeType: 546656
       GoKind: 7
     - __kind: GoSliceHeaderType
-      ID: 88
+      ID: 187
       Name: math/big.nat
       ByteSize: 24
       GoRuntimeType: 2.279968e+06
@@ -2504,21 +2504,21 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 89 PointerType *math/big.Word
+          Type: 188 PointerType *math/big.Word
         - Name: len
           Offset: 8
           Type: 9 BaseType int
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 217 GoSliceDataType math/big.nat.array
+      Data: 253 GoSliceDataType math/big.nat.array
     - __kind: GoSliceDataType
-      ID: 217
+      ID: 253
       Name: math/big.nat.array
       ByteSize: 2048
-      Element: 90 BaseType math/big.Word
+      Element: 189 BaseType math/big.Word
     - __kind: StructureType
-      ID: 74
+      ID: 150
       Name: mime/multipart.FileHeader
       ByteSize: 88
       GoRuntimeType: 1.88112e+06
@@ -2529,13 +2529,13 @@ Types:
           Type: 11 GoStringHeaderType string
         - Name: Header
           Offset: 16
-          Type: 75 GoMapType net/textproto.MIMEHeader
+          Type: 186 GoMapType net/textproto.MIMEHeader
         - Name: Size
           Offset: 24
           Type: 13 BaseType int64
         - Name: content
           Offset: 32
-          Type: 76 GoSliceHeaderType []uint8
+          Type: 96 GoSliceHeaderType []uint8
         - Name: tmpfile
           Offset: 56
           Type: 11 GoStringHeaderType string
@@ -2546,7 +2546,7 @@ Types:
           Offset: 80
           Type: 4 BaseType bool
     - __kind: StructureType
-      ID: 63
+      ID: 59
       Name: mime/multipart.Form
       ByteSize: 16
       GoRuntimeType: 1.325824e+06
@@ -2554,12 +2554,12 @@ Types:
       RawFields:
         - Name: Value
           Offset: 0
-          Type: 64 GoMapType map[string][]string
+          Type: 107 GoMapType map[string][]string
         - Name: File
           Offset: 8
-          Type: 65 GoMapType map[string][]*mime/multipart.FileHeader
+          Type: 108 GoMapType map[string][]*mime/multipart.FileHeader
     - __kind: GoSliceHeaderType
-      ID: 116
+      ID: 174
       Name: net.IP
       ByteSize: 24
       GoRuntimeType: 2.000864e+06
@@ -2574,14 +2574,14 @@ Types:
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 235 GoSliceDataType net.IP.array
+      Data: 245 GoSliceDataType net.IP.array
     - __kind: GoSliceDataType
-      ID: 235
+      ID: 245
       Name: net.IP.array
       ByteSize: 2048
       Element: 3 BaseType uint8
     - __kind: GoSliceHeaderType
-      ID: 123
+      ID: 200
       Name: net.IPMask
       ByteSize: 24
       GoRuntimeType: 999232
@@ -2596,14 +2596,14 @@ Types:
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 241 GoSliceDataType net.IPMask.array
+      Data: 261 GoSliceDataType net.IPMask.array
     - __kind: GoSliceDataType
-      ID: 241
+      ID: 261
       Name: net.IPMask.array
       ByteSize: 2048
       Element: 3 BaseType uint8
     - __kind: StructureType
-      ID: 122
+      ID: 196
       Name: net.IPNet
       ByteSize: 48
       GoRuntimeType: 1.306944e+06
@@ -2611,17 +2611,17 @@ Types:
       RawFields:
         - Name: IP
           Offset: 0
-          Type: 116 GoSliceHeaderType net.IP
+          Type: 174 GoSliceHeaderType net.IP
         - Name: Mask
           Offset: 24
-          Type: 123 GoSliceHeaderType net.IPMask
+          Type: 200 GoSliceHeaderType net.IPMask
     - __kind: GoMapType
-      ID: 43
+      ID: 47
       Name: net/http.Header
       ByteSize: 8
       GoRuntimeType: 1.963712e+06
       GoKind: 21
-      HeaderType: 45 GoHMapHeaderType hash<string,[]string>
+      HeaderType: 49 GoHMapHeaderType hash<string,[]string>
     - __kind: StructureType
       ID: 38
       Name: net/http.Request
@@ -2634,7 +2634,7 @@ Types:
           Type: 11 GoStringHeaderType string
         - Name: URL
           Offset: 16
-          Type: 39 PointerType *net/url.URL
+          Type: 45 PointerType *net/url.URL
         - Name: Proto
           Offset: 24
           Type: 11 GoStringHeaderType string
@@ -2646,19 +2646,19 @@ Types:
           Type: 9 BaseType int
         - Name: Header
           Offset: 56
-          Type: 43 GoMapType net/http.Header
+          Type: 47 GoMapType net/http.Header
         - Name: Body
           Offset: 64
-          Type: 59 GoInterfaceType io.ReadCloser
+          Type: 54 GoInterfaceType io.ReadCloser
         - Name: GetBody
           Offset: 80
-          Type: 60 GoSubroutineType func() (io.ReadCloser, error)
+          Type: 55 GoSubroutineType func() (io.ReadCloser, error)
         - Name: ContentLength
           Offset: 88
           Type: 13 BaseType int64
         - Name: TransferEncoding
           Offset: 96
-          Type: 51 GoSliceHeaderType []string
+          Type: 56 GoSliceHeaderType []string
         - Name: Close
           Offset: 120
           Type: 4 BaseType bool
@@ -2667,16 +2667,16 @@ Types:
           Type: 11 GoStringHeaderType string
         - Name: Form
           Offset: 144
-          Type: 61 GoMapType net/url.Values
+          Type: 57 GoMapType net/url.Values
         - Name: PostForm
           Offset: 152
-          Type: 61 GoMapType net/url.Values
+          Type: 57 GoMapType net/url.Values
         - Name: MultipartForm
           Offset: 160
-          Type: 62 PointerType *mime/multipart.Form
+          Type: 58 PointerType *mime/multipart.Form
         - Name: Trailer
           Offset: 168
-          Type: 43 GoMapType net/http.Header
+          Type: 47 GoMapType net/http.Header
         - Name: RemoteAddr
           Offset: 176
           Type: 11 GoStringHeaderType string
@@ -2685,30 +2685,30 @@ Types:
           Type: 11 GoStringHeaderType string
         - Name: TLS
           Offset: 208
-          Type: 77 PointerType *crypto/tls.ConnectionState
+          Type: 60 PointerType *crypto/tls.ConnectionState
         - Name: Cancel
           Offset: 216
-          Type: 133 GoChannelType <-chan struct {}
+          Type: 62 GoChannelType <-chan struct {}
         - Name: Response
           Offset: 224
-          Type: 134 PointerType *net/http.Response
+          Type: 63 PointerType *net/http.Response
         - Name: Pattern
           Offset: 232
           Type: 11 GoStringHeaderType string
         - Name: ctx
           Offset: 248
-          Type: 136 GoInterfaceType context.Context
+          Type: 65 GoInterfaceType context.Context
         - Name: pat
           Offset: 264
-          Type: 137 PointerType *net/http.pattern
+          Type: 66 PointerType *net/http.pattern
         - Name: matches
           Offset: 272
-          Type: 51 GoSliceHeaderType []string
+          Type: 56 GoSliceHeaderType []string
         - Name: otherValues
           Offset: 296
-          Type: 142 GoMapType map[string]string
+          Type: 68 GoMapType map[string]string
     - __kind: StructureType
-      ID: 135
+      ID: 64
       Name: net/http.Response
       ByteSize: 144
       GoRuntimeType: 2.123456e+06
@@ -2731,16 +2731,16 @@ Types:
           Type: 9 BaseType int
         - Name: Header
           Offset: 56
-          Type: 43 GoMapType net/http.Header
+          Type: 47 GoMapType net/http.Header
         - Name: Body
           Offset: 64
-          Type: 59 GoInterfaceType io.ReadCloser
+          Type: 54 GoInterfaceType io.ReadCloser
         - Name: ContentLength
           Offset: 80
           Type: 13 BaseType int64
         - Name: TransferEncoding
           Offset: 88
-          Type: 51 GoSliceHeaderType []string
+          Type: 56 GoSliceHeaderType []string
         - Name: Close
           Offset: 112
           Type: 4 BaseType bool
@@ -2749,13 +2749,13 @@ Types:
           Type: 4 BaseType bool
         - Name: Trailer
           Offset: 120
-          Type: 43 GoMapType net/http.Header
+          Type: 47 GoMapType net/http.Header
         - Name: Request
           Offset: 128
           Type: 37 PointerType *net/http.Request
         - Name: TLS
           Offset: 136
-          Type: 77 PointerType *crypto/tls.ConnectionState
+          Type: 60 PointerType *crypto/tls.ConnectionState
     - __kind: GoInterfaceType
       ID: 36
       Name: net/http.ResponseWriter
@@ -2770,7 +2770,7 @@ Types:
           Offset: 8
           Type: 19 VoidPointerType unsafe.Pointer
     - __kind: StructureType
-      ID: 138
+      ID: 67
       Name: net/http.pattern
       ByteSize: 88
       GoRuntimeType: 1.744992e+06
@@ -2787,12 +2787,12 @@ Types:
           Type: 11 GoStringHeaderType string
         - Name: segments
           Offset: 48
-          Type: 139 GoSliceHeaderType []net/http.segment
+          Type: 122 GoSliceHeaderType []net/http.segment
         - Name: loc
           Offset: 72
           Type: 11 GoStringHeaderType string
     - __kind: StructureType
-      ID: 141
+      ID: 124
       Name: net/http.segment
       ByteSize: 24
       GoRuntimeType: 1.452928e+06
@@ -2808,14 +2808,14 @@ Types:
           Offset: 17
           Type: 4 BaseType bool
     - __kind: GoMapType
-      ID: 75
+      ID: 186
       Name: net/textproto.MIMEHeader
       ByteSize: 8
       GoRuntimeType: 1.637344e+06
       GoKind: 21
-      HeaderType: 45 GoHMapHeaderType hash<string,[]string>
+      HeaderType: 49 GoHMapHeaderType hash<string,[]string>
     - __kind: StructureType
-      ID: 40
+      ID: 46
       Name: net/url.URL
       ByteSize: 144
       GoRuntimeType: 2.040992e+06
@@ -2829,7 +2829,7 @@ Types:
           Type: 11 GoStringHeaderType string
         - Name: User
           Offset: 32
-          Type: 41 PointerType *net/url.Userinfo
+          Type: 98 PointerType *net/url.Userinfo
         - Name: Host
           Offset: 40
           Type: 11 GoStringHeaderType string
@@ -2855,7 +2855,7 @@ Types:
           Offset: 128
           Type: 11 GoStringHeaderType string
     - __kind: StructureType
-      ID: 42
+      ID: 99
       Name: net/url.Userinfo
       ByteSize: 40
       GoRuntimeType: 1.469248e+06
@@ -2871,14 +2871,14 @@ Types:
           Offset: 32
           Type: 4 BaseType bool
     - __kind: GoMapType
-      ID: 61
+      ID: 57
       Name: net/url.Values
       ByteSize: 8
       GoRuntimeType: 1.71184e+06
       GoKind: 21
-      HeaderType: 45 GoHMapHeaderType hash<string,[]string>
+      HeaderType: 49 GoHMapHeaderType hash<string,[]string>
     - __kind: StructureType
-      ID: 58
+      ID: 106
       Name: runtime.bmap
       ByteSize: 8
       GoRuntimeType: 1.136896e+06
@@ -2886,7 +2886,7 @@ Types:
       RawFields:
         - Name: tophash
           Offset: 0
-          Type: 48 ArrayType [8]uint8
+          Type: 100 ArrayType [8]uint8
     - __kind: StructureType
       ID: 53
       Name: runtime.mapextra
@@ -2896,13 +2896,13 @@ Types:
       RawFields:
         - Name: overflow
           Offset: 0
-          Type: 54 PointerType *[]*runtime.bmap
+          Type: 103 PointerType *[]*runtime.bmap
         - Name: oldoverflow
           Offset: 8
-          Type: 54 PointerType *[]*runtime.bmap
+          Type: 103 PointerType *[]*runtime.bmap
         - Name: nextOverflow
           Offset: 16
-          Type: 57 PointerType *runtime.bmap
+          Type: 105 PointerType *runtime.bmap
     - __kind: GoStringHeaderType
       ID: 11
       Name: string
@@ -2922,7 +2922,7 @@ Types:
       Name: string.str
       ByteSize: 2048
     - __kind: StructureType
-      ID: 151
+      ID: 74
       Name: sync.Mutex
       ByteSize: 8
       GoRuntimeType: 1.313984e+06
@@ -2935,7 +2935,7 @@ Types:
           Offset: 4
           Type: 2 BaseType uint32
     - __kind: StructureType
-      ID: 150
+      ID: 73
       Name: sync.RWMutex
       ByteSize: 24
       GoRuntimeType: 1.750592e+06
@@ -2943,7 +2943,7 @@ Types:
       RawFields:
         - Name: w
           Offset: 0
-          Type: 151 StructureType sync.Mutex
+          Type: 74 StructureType sync.Mutex
         - Name: writerSem
           Offset: 8
           Type: 2 BaseType uint32
@@ -2952,12 +2952,12 @@ Types:
           Type: 2 BaseType uint32
         - Name: readerCount
           Offset: 16
-          Type: 152 StructureType sync/atomic.Int32
+          Type: 75 StructureType sync/atomic.Int32
         - Name: readerWait
           Offset: 20
-          Type: 152 StructureType sync/atomic.Int32
+          Type: 75 StructureType sync/atomic.Int32
     - __kind: StructureType
-      ID: 152
+      ID: 75
       Name: sync/atomic.Int32
       ByteSize: 4
       GoRuntimeType: 1.315424e+06
@@ -2965,18 +2965,18 @@ Types:
       RawFields:
         - Name: _
           Offset: 0
-          Type: 153 StructureType sync/atomic.noCopy
+          Type: 76 StructureType sync/atomic.noCopy
         - Name: v
           Offset: 0
           Type: 12 BaseType int32
     - __kind: StructureType
-      ID: 153
+      ID: 76
       Name: sync/atomic.noCopy
       GoRuntimeType: 965792
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 98
+      ID: 161
       Name: time.Location
       ByteSize: 104
       GoRuntimeType: 1.877376e+06
@@ -2987,10 +2987,10 @@ Types:
           Type: 11 GoStringHeaderType string
         - Name: zone
           Offset: 16
-          Type: 99 GoSliceHeaderType []time.zone
+          Type: 190 GoSliceHeaderType []time.zone
         - Name: tx
           Offset: 40
-          Type: 102 GoSliceHeaderType []time.zoneTrans
+          Type: 193 GoSliceHeaderType []time.zoneTrans
         - Name: extend
           Offset: 64
           Type: 11 GoStringHeaderType string
@@ -3002,9 +3002,9 @@ Types:
           Type: 13 BaseType int64
         - Name: cacheZone
           Offset: 96
-          Type: 100 PointerType *time.zone
+          Type: 191 PointerType *time.zone
     - __kind: StructureType
-      ID: 96
+      ID: 159
       Name: time.Time
       ByteSize: 24
       GoRuntimeType: 2.280896e+06
@@ -3018,9 +3018,9 @@ Types:
           Type: 13 BaseType int64
         - Name: loc
           Offset: 16
-          Type: 97 PointerType *time.Location
+          Type: 160 PointerType *time.Location
     - __kind: StructureType
-      ID: 101
+      ID: 192
       Name: time.zone
       ByteSize: 32
       GoRuntimeType: 1.45792e+06
@@ -3036,7 +3036,7 @@ Types:
           Offset: 24
           Type: 4 BaseType bool
     - __kind: StructureType
-      ID: 104
+      ID: 195
       Name: time.zoneTrans
       ByteSize: 16
       GoRuntimeType: 1.663616e+06

--- a/pkg/dyninst/irgen/testdata/snapshot/rc_tester.arch=amd64,toolchain=go1.23.11.yaml
+++ b/pkg/dyninst/irgen/testdata/snapshot/rc_tester.arch=amd64,toolchain=go1.23.11.yaml
@@ -105,175 +105,175 @@ Subprograms:
           IsReturn: false
 Types:
     - __kind: PointerType
-      ID: 114
+      ID: 116
       Name: '**crypto/x509.Certificate'
       ByteSize: 8
-      Pointee: 115 PointerType *crypto/x509.Certificate
+      Pointee: 117 PointerType *crypto/x509.Certificate
     - __kind: PointerType
-      ID: 148
+      ID: 162
       Name: '**github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span'
       ByteSize: 8
       GoKind: 22
       Pointee: 39 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span
     - __kind: PointerType
-      ID: 198
+      ID: 228
       Name: '**github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttributeValue'
       ByteSize: 8
       GoKind: 22
-      Pointee: 199 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttributeValue
+      Pointee: 229 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttributeValue
     - __kind: PointerType
-      ID: 141
+      ID: 155
       Name: '**mime/multipart.FileHeader'
       ByteSize: 8
       GoKind: 22
-      Pointee: 142 PointerType *mime/multipart.FileHeader
+      Pointee: 156 PointerType *mime/multipart.FileHeader
     - __kind: PointerType
-      ID: 178
+      ID: 204
       Name: '**net.IPNet'
       ByteSize: 8
       GoKind: 22
-      Pointee: 179 PointerType *net.IPNet
+      Pointee: 205 PointerType *net.IPNet
     - __kind: PointerType
-      ID: 176
+      ID: 202
       Name: '**net/url.URL'
       ByteSize: 8
       GoKind: 22
       Pointee: 45 PointerType *net/url.URL
     - __kind: PointerType
-      ID: 138
+      ID: 152
       Name: '**runtime.bmap'
       ByteSize: 8
-      Pointee: 105 PointerType *runtime.bmap
+      Pointee: 107 PointerType *runtime.bmap
     - __kind: PointerType
-      ID: 117
+      ID: 119
       Name: '*[]*crypto/x509.Certificate'
       ByteSize: 8
       GoKind: 22
-      Pointee: 113 GoSliceHeaderType []*crypto/x509.Certificate
+      Pointee: 115 GoSliceHeaderType []*crypto/x509.Certificate
     - __kind: PointerType
-      ID: 221
+      ID: 168
       Name: '*[]*crypto/x509.Certificate.array'
       ByteSize: 8
-      Pointee: 220 GoSliceDataType []*crypto/x509.Certificate.array
+      Pointee: 167 GoSliceDataType []*crypto/x509.Certificate.array
     - __kind: PointerType
-      ID: 232
+      ID: 215
       Name: '*[]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span.array'
       ByteSize: 8
-      Pointee: 231 GoSliceDataType []*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span.array
+      Pointee: 214 GoSliceDataType []*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span.array
     - __kind: PointerType
-      ID: 260
+      ID: 259
       Name: '*[]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttributeValue.array'
       ByteSize: 8
-      Pointee: 259 GoSliceDataType []*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttributeValue.array
+      Pointee: 258 GoSliceDataType []*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttributeValue.array
     - __kind: PointerType
-      ID: 230
+      ID: 213
       Name: '*[]*mime/multipart.FileHeader.array'
       ByteSize: 8
-      Pointee: 229 GoSliceDataType []*mime/multipart.FileHeader.array
+      Pointee: 212 GoSliceDataType []*mime/multipart.FileHeader.array
     - __kind: PointerType
-      ID: 250
+      ID: 247
       Name: '*[]*net.IPNet.array'
       ByteSize: 8
-      Pointee: 249 GoSliceDataType []*net.IPNet.array
+      Pointee: 246 GoSliceDataType []*net.IPNet.array
     - __kind: PointerType
-      ID: 248
+      ID: 245
       Name: '*[]*net/url.URL.array'
       ByteSize: 8
-      Pointee: 247 GoSliceDataType []*net/url.URL.array
+      Pointee: 244 GoSliceDataType []*net/url.URL.array
     - __kind: PointerType
-      ID: 103
+      ID: 105
       Name: '*[]*runtime.bmap'
       ByteSize: 8
       GoRuntimeType: 470656
       GoKind: 22
-      Pointee: 104 GoSliceHeaderType []*runtime.bmap
+      Pointee: 106 GoSliceHeaderType []*runtime.bmap
     - __kind: PointerType
-      ID: 218
+      ID: 165
       Name: '*[]*runtime.bmap.array'
       ByteSize: 8
-      Pointee: 217 GoSliceDataType []*runtime.bmap.array
+      Pointee: 164 GoSliceDataType []*runtime.bmap.array
     - __kind: PointerType
-      ID: 223
+      ID: 170
       Name: '*[][]*crypto/x509.Certificate.array'
       ByteSize: 8
-      Pointee: 222 GoSliceDataType [][]*crypto/x509.Certificate.array
+      Pointee: 169 GoSliceDataType [][]*crypto/x509.Certificate.array
     - __kind: PointerType
-      ID: 225
+      ID: 172
       Name: '*[][]uint8.array'
       ByteSize: 8
-      Pointee: 224 GoSliceDataType [][]uint8.array
+      Pointee: 171 GoSliceDataType [][]uint8.array
     - __kind: PointerType
-      ID: 242
+      ID: 239
       Name: '*[]crypto/x509.ExtKeyUsage.array'
       ByteSize: 8
-      Pointee: 241 GoSliceDataType []crypto/x509.ExtKeyUsage.array
+      Pointee: 238 GoSliceDataType []crypto/x509.ExtKeyUsage.array
     - __kind: PointerType
-      ID: 252
+      ID: 249
       Name: '*[]crypto/x509.OID.array'
       ByteSize: 8
-      Pointee: 251 GoSliceDataType []crypto/x509.OID.array
+      Pointee: 248 GoSliceDataType []crypto/x509.OID.array
     - __kind: PointerType
-      ID: 234
+      ID: 231
       Name: '*[]crypto/x509/pkix.AttributeTypeAndValue.array'
       ByteSize: 8
-      Pointee: 233 GoSliceDataType []crypto/x509/pkix.AttributeTypeAndValue.array
+      Pointee: 230 GoSliceDataType []crypto/x509/pkix.AttributeTypeAndValue.array
     - __kind: PointerType
-      ID: 236
+      ID: 233
       Name: '*[]crypto/x509/pkix.Extension.array'
       ByteSize: 8
-      Pointee: 235 GoSliceDataType []crypto/x509/pkix.Extension.array
+      Pointee: 232 GoSliceDataType []crypto/x509/pkix.Extension.array
     - __kind: PointerType
-      ID: 238
+      ID: 235
       Name: '*[]encoding/asn1.ObjectIdentifier.array'
       ByteSize: 8
-      Pointee: 237 GoSliceDataType []encoding/asn1.ObjectIdentifier.array
+      Pointee: 234 GoSliceDataType []encoding/asn1.ObjectIdentifier.array
     - __kind: PointerType
-      ID: 212
+      ID: 147
       Name: '*[]github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink.array'
       ByteSize: 8
-      Pointee: 211 GoSliceDataType []github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink.array
+      Pointee: 146 GoSliceDataType []github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink.array
     - __kind: PointerType
-      ID: 214
+      ID: 149
       Name: '*[]github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent.array'
       ByteSize: 8
-      Pointee: 213 GoSliceDataType []github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent.array
+      Pointee: 148 GoSliceDataType []github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent.array
     - __kind: PointerType
-      ID: 244
+      ID: 241
       Name: '*[]net.IP.array'
       ByteSize: 8
-      Pointee: 243 GoSliceDataType []net.IP.array
+      Pointee: 240 GoSliceDataType []net.IP.array
     - __kind: PointerType
-      ID: 227
+      ID: 174
       Name: '*[]net/http.segment.array'
       ByteSize: 8
-      Pointee: 226 GoSliceDataType []net/http.segment.array
+      Pointee: 173 GoSliceDataType []net/http.segment.array
     - __kind: PointerType
-      ID: 207
+      ID: 142
       Name: '*[]string.array'
       ByteSize: 8
-      Pointee: 206 GoSliceDataType []string.array
+      Pointee: 141 GoSliceDataType []string.array
     - __kind: PointerType
-      ID: 256
+      ID: 255
       Name: '*[]time.zone.array'
       ByteSize: 8
-      Pointee: 255 GoSliceDataType []time.zone.array
+      Pointee: 254 GoSliceDataType []time.zone.array
     - __kind: PointerType
-      ID: 258
+      ID: 257
       Name: '*[]time.zoneTrans.array'
       ByteSize: 8
-      Pointee: 257 GoSliceDataType []time.zoneTrans.array
+      Pointee: 256 GoSliceDataType []time.zoneTrans.array
     - __kind: PointerType
-      ID: 119
+      ID: 121
       Name: '*[]uint8'
       ByteSize: 8
       GoRuntimeType: 456768
       GoKind: 22
       Pointee: 96 GoSliceHeaderType []uint8
     - __kind: PointerType
-      ID: 216
+      ID: 151
       Name: '*[]uint8.array'
       ByteSize: 8
-      Pointee: 215 GoSliceDataType []uint8.array
+      Pointee: 150 GoSliceDataType []uint8.array
     - __kind: PointerType
       ID: 5
       Name: '*bool'
@@ -282,15 +282,15 @@ Types:
       GoKind: 22
       Pointee: 4 BaseType bool
     - __kind: PointerType
-      ID: 132
+      ID: 134
       Name: '*bucket<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>'
       ByteSize: 8
-      Pointee: 133 GoHMapBucketType bucket<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
+      Pointee: 135 GoHMapBucketType bucket<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
     - __kind: PointerType
-      ID: 111
+      ID: 113
       Name: '*bucket<string,[]*mime/multipart.FileHeader>'
       ByteSize: 8
-      Pointee: 112 GoHMapBucketType bucket<string,[]*mime/multipart.FileHeader>
+      Pointee: 114 GoHMapBucketType bucket<string,[]*mime/multipart.FileHeader>
     - __kind: PointerType
       ID: 50
       Name: '*bucket<string,[]string>'
@@ -326,52 +326,52 @@ Types:
       GoKind: 22
       Pointee: 61 StructureType crypto/tls.ConnectionState
     - __kind: PointerType
-      ID: 115
+      ID: 117
       Name: '*crypto/x509.Certificate'
       ByteSize: 8
       GoRuntimeType: 1.952864e+06
       GoKind: 22
-      Pointee: 143 StructureType crypto/x509.Certificate
+      Pointee: 157 StructureType crypto/x509.Certificate
     - __kind: PointerType
-      ID: 170
+      ID: 196
       Name: '*crypto/x509.ExtKeyUsage'
       ByteSize: 8
       GoRuntimeType: 400640
       GoKind: 22
-      Pointee: 171 BaseType crypto/x509.ExtKeyUsage
+      Pointee: 197 BaseType crypto/x509.ExtKeyUsage
     - __kind: PointerType
-      ID: 181
+      ID: 207
       Name: '*crypto/x509.OID'
       ByteSize: 8
       GoRuntimeType: 1.761792e+06
       GoKind: 22
-      Pointee: 182 StructureType crypto/x509.OID
+      Pointee: 208 StructureType crypto/x509.OID
     - __kind: PointerType
-      ID: 157
+      ID: 183
       Name: '*crypto/x509/pkix.AttributeTypeAndValue'
       ByteSize: 8
       GoRuntimeType: 417344
       GoKind: 22
-      Pointee: 158 StructureType crypto/x509/pkix.AttributeTypeAndValue
+      Pointee: 184 StructureType crypto/x509/pkix.AttributeTypeAndValue
     - __kind: PointerType
-      ID: 164
+      ID: 190
       Name: '*crypto/x509/pkix.Extension'
       ByteSize: 8
       GoRuntimeType: 417536
       GoKind: 22
-      Pointee: 165 StructureType crypto/x509/pkix.Extension
+      Pointee: 191 StructureType crypto/x509/pkix.Extension
     - __kind: PointerType
-      ID: 167
+      ID: 193
       Name: '*encoding/asn1.ObjectIdentifier'
       ByteSize: 8
       GoRuntimeType: 1.037248e+06
       GoKind: 22
-      Pointee: 168 GoSliceHeaderType encoding/asn1.ObjectIdentifier
+      Pointee: 194 GoSliceHeaderType encoding/asn1.ObjectIdentifier
     - __kind: PointerType
-      ID: 240
+      ID: 237
       Name: '*encoding/asn1.ObjectIdentifier.array'
       ByteSize: 8
-      Pointee: 239 GoSliceDataType encoding/asn1.ObjectIdentifier.array
+      Pointee: 236 GoSliceDataType encoding/asn1.ObjectIdentifier.array
     - __kind: PointerType
       ID: 33
       Name: '*error'
@@ -422,43 +422,43 @@ Types:
       GoKind: 22
       Pointee: 92 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent
     - __kind: PointerType
-      ID: 184
+      ID: 210
       Name: '*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttribute'
       ByteSize: 8
       GoRuntimeType: 1.129984e+06
       GoKind: 22
-      Pointee: 185 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttribute
+      Pointee: 211 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttribute
     - __kind: PointerType
-      ID: 199
+      ID: 229
       Name: '*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttributeValue'
       ByteSize: 8
       GoRuntimeType: 1.129728e+06
       GoKind: 22
-      Pointee: 201 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttributeValue
+      Pointee: 251 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttributeValue
     - __kind: PointerType
-      ID: 145
+      ID: 159
       Name: '*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute'
       ByteSize: 8
       GoRuntimeType: 1.130112e+06
       GoKind: 22
-      Pointee: 146 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
+      Pointee: 160 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
     - __kind: PointerType
-      ID: 135
+      ID: 137
       Name: '*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.trace'
       ByteSize: 8
       GoRuntimeType: 2.131968e+06
       GoKind: 22
-      Pointee: 136 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.trace
+      Pointee: 138 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.trace
     - __kind: PointerType
-      ID: 130
+      ID: 132
       Name: '*hash<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>'
       ByteSize: 8
-      Pointee: 131 GoHMapHeaderType hash<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
+      Pointee: 133 GoHMapHeaderType hash<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
     - __kind: PointerType
-      ID: 109
+      ID: 111
       Name: '*hash<string,[]*mime/multipart.FileHeader>'
       ByteSize: 8
-      Pointee: 110 GoHMapHeaderType hash<string,[]*mime/multipart.FileHeader>
+      Pointee: 112 GoHMapHeaderType hash<string,[]*mime/multipart.FileHeader>
     - __kind: PointerType
       ID: 48
       Name: '*hash<string,[]string>'
@@ -515,31 +515,31 @@ Types:
       GoKind: 22
       Pointee: 14 BaseType int8
     - __kind: PointerType
-      ID: 153
+      ID: 179
       Name: '*math/big.Int'
       ByteSize: 8
       GoRuntimeType: 2.296864e+06
       GoKind: 22
-      Pointee: 154 StructureType math/big.Int
+      Pointee: 180 StructureType math/big.Int
     - __kind: PointerType
-      ID: 188
+      ID: 218
       Name: '*math/big.Word'
       ByteSize: 8
       GoRuntimeType: 403456
       GoKind: 22
-      Pointee: 189 BaseType math/big.Word
+      Pointee: 219 BaseType math/big.Word
     - __kind: PointerType
-      ID: 254
+      ID: 253
       Name: '*math/big.nat.array'
       ByteSize: 8
-      Pointee: 253 GoSliceDataType math/big.nat.array
+      Pointee: 252 GoSliceDataType math/big.nat.array
     - __kind: PointerType
-      ID: 142
+      ID: 156
       Name: '*mime/multipart.FileHeader'
       ByteSize: 8
       GoRuntimeType: 853632
       GoKind: 22
-      Pointee: 150 StructureType mime/multipart.FileHeader
+      Pointee: 176 StructureType mime/multipart.FileHeader
     - __kind: PointerType
       ID: 58
       Name: '*mime/multipart.Form'
@@ -548,29 +548,29 @@ Types:
       GoKind: 22
       Pointee: 59 StructureType mime/multipart.Form
     - __kind: PointerType
-      ID: 173
+      ID: 199
       Name: '*net.IP'
       ByteSize: 8
       GoRuntimeType: 2.028544e+06
       GoKind: 22
-      Pointee: 174 GoSliceHeaderType net.IP
+      Pointee: 200 GoSliceHeaderType net.IP
     - __kind: PointerType
-      ID: 246
+      ID: 243
       Name: '*net.IP.array'
       ByteSize: 8
-      Pointee: 245 GoSliceDataType net.IP.array
+      Pointee: 242 GoSliceDataType net.IP.array
     - __kind: PointerType
       ID: 262
       Name: '*net.IPMask.array'
       ByteSize: 8
       Pointee: 261 GoSliceDataType net.IPMask.array
     - __kind: PointerType
-      ID: 179
+      ID: 205
       Name: '*net.IPNet'
       ByteSize: 8
       GoRuntimeType: 1.122688e+06
       GoKind: 22
-      Pointee: 196 StructureType net.IPNet
+      Pointee: 226 StructureType net.IPNet
     - __kind: PointerType
       ID: 37
       Name: '*net/http.Request'
@@ -593,12 +593,12 @@ Types:
       GoKind: 22
       Pointee: 67 StructureType net/http.pattern
     - __kind: PointerType
-      ID: 123
+      ID: 125
       Name: '*net/http.segment'
       ByteSize: 8
       GoRuntimeType: 367808
       GoKind: 22
-      Pointee: 124 StructureType net/http.segment
+      Pointee: 126 StructureType net/http.segment
     - __kind: PointerType
       ID: 45
       Name: '*net/url.URL'
@@ -607,19 +607,19 @@ Types:
       GoKind: 22
       Pointee: 46 StructureType net/url.URL
     - __kind: PointerType
-      ID: 98
+      ID: 100
       Name: '*net/url.Userinfo'
       ByteSize: 8
       GoRuntimeType: 1.141376e+06
       GoKind: 22
-      Pointee: 99 StructureType net/url.Userinfo
+      Pointee: 101 StructureType net/url.Userinfo
     - __kind: PointerType
-      ID: 105
+      ID: 107
       Name: '*runtime.bmap'
       ByteSize: 8
       GoRuntimeType: 1.137024e+06
       GoKind: 22
-      Pointee: 106 StructureType runtime.bmap
+      Pointee: 108 StructureType runtime.bmap
     - __kind: PointerType
       ID: 52
       Name: '*runtime.mapextra'
@@ -635,31 +635,31 @@ Types:
       GoKind: 22
       Pointee: 11 GoStringHeaderType string
     - __kind: PointerType
-      ID: 204
+      ID: 99
       Name: '*string.str'
       ByteSize: 8
-      Pointee: 203 GoStringDataType string.str
+      Pointee: 98 GoStringDataType string.str
     - __kind: PointerType
-      ID: 160
+      ID: 186
       Name: '*time.Location'
       ByteSize: 8
       GoRuntimeType: 1.458112e+06
       GoKind: 22
-      Pointee: 161 StructureType time.Location
+      Pointee: 187 StructureType time.Location
     - __kind: PointerType
-      ID: 191
+      ID: 221
       Name: '*time.zone'
       ByteSize: 8
       GoRuntimeType: 370880
       GoKind: 22
-      Pointee: 192 StructureType time.zone
+      Pointee: 222 StructureType time.zone
     - __kind: PointerType
-      ID: 194
+      ID: 224
       Name: '*time.zoneTrans'
       ByteSize: 8
       GoRuntimeType: 370944
       GoKind: 22
-      Pointee: 195 StructureType time.zoneTrans
+      Pointee: 225 StructureType time.zoneTrans
     - __kind: PointerType
       ID: 34
       Name: '*uint'
@@ -747,7 +747,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: ArrayType
-      ID: 100
+      ID: 102
       Name: '[8]uint8'
       ByteSize: 8
       GoRuntimeType: 632608
@@ -756,7 +756,7 @@ Types:
       HasCount: true
       Element: 3 BaseType uint8
     - __kind: GoSliceHeaderType
-      ID: 113
+      ID: 115
       Name: '[]*crypto/x509.Certificate'
       ByteSize: 24
       GoRuntimeType: 473760
@@ -764,21 +764,21 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 114 PointerType **crypto/x509.Certificate
+          Type: 116 PointerType **crypto/x509.Certificate
         - Name: len
           Offset: 8
           Type: 9 BaseType int
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 220 GoSliceDataType []*crypto/x509.Certificate.array
+      Data: 167 GoSliceDataType []*crypto/x509.Certificate.array
     - __kind: GoSliceDataType
-      ID: 220
+      ID: 167
       Name: '[]*crypto/x509.Certificate.array'
       ByteSize: 2048
-      Element: 115 PointerType *crypto/x509.Certificate
+      Element: 117 PointerType *crypto/x509.Certificate
     - __kind: GoSliceHeaderType
-      ID: 147
+      ID: 161
       Name: '[]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span'
       ByteSize: 24
       GoRuntimeType: 463872
@@ -786,21 +786,21 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 148 PointerType **github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span
+          Type: 162 PointerType **github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span
         - Name: len
           Offset: 8
           Type: 9 BaseType int
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 231 GoSliceDataType []*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span.array
+      Data: 214 GoSliceDataType []*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span.array
     - __kind: GoSliceDataType
-      ID: 231
+      ID: 214
       Name: '[]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span.array'
       ByteSize: 2048
       Element: 39 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span
     - __kind: GoSliceHeaderType
-      ID: 197
+      ID: 227
       Name: '[]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttributeValue'
       ByteSize: 24
       GoRuntimeType: 463488
@@ -808,21 +808,21 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 198 PointerType **github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttributeValue
+          Type: 228 PointerType **github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttributeValue
         - Name: len
           Offset: 8
           Type: 9 BaseType int
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 259 GoSliceDataType []*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttributeValue.array
+      Data: 258 GoSliceDataType []*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttributeValue.array
     - __kind: GoSliceDataType
-      ID: 259
+      ID: 258
       Name: '[]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttributeValue.array'
       ByteSize: 2048
-      Element: 199 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttributeValue
+      Element: 229 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttributeValue
     - __kind: GoSliceHeaderType
-      ID: 140
+      ID: 154
       Name: '[]*mime/multipart.FileHeader'
       ByteSize: 24
       GoRuntimeType: 461504
@@ -830,21 +830,21 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 141 PointerType **mime/multipart.FileHeader
+          Type: 155 PointerType **mime/multipart.FileHeader
         - Name: len
           Offset: 8
           Type: 9 BaseType int
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 229 GoSliceDataType []*mime/multipart.FileHeader.array
+      Data: 212 GoSliceDataType []*mime/multipart.FileHeader.array
     - __kind: GoSliceDataType
-      ID: 229
+      ID: 212
       Name: '[]*mime/multipart.FileHeader.array'
       ByteSize: 2048
-      Element: 142 PointerType *mime/multipart.FileHeader
+      Element: 156 PointerType *mime/multipart.FileHeader
     - __kind: GoSliceHeaderType
-      ID: 177
+      ID: 203
       Name: '[]*net.IPNet'
       ByteSize: 24
       GoRuntimeType: 486816
@@ -852,21 +852,21 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 178 PointerType **net.IPNet
+          Type: 204 PointerType **net.IPNet
         - Name: len
           Offset: 8
           Type: 9 BaseType int
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 249 GoSliceDataType []*net.IPNet.array
+      Data: 246 GoSliceDataType []*net.IPNet.array
     - __kind: GoSliceDataType
-      ID: 249
+      ID: 246
       Name: '[]*net.IPNet.array'
       ByteSize: 2048
-      Element: 179 PointerType *net.IPNet
+      Element: 205 PointerType *net.IPNet
     - __kind: GoSliceHeaderType
-      ID: 175
+      ID: 201
       Name: '[]*net/url.URL'
       ByteSize: 24
       GoRuntimeType: 486752
@@ -874,21 +874,21 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 176 PointerType **net/url.URL
+          Type: 202 PointerType **net/url.URL
         - Name: len
           Offset: 8
           Type: 9 BaseType int
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 247 GoSliceDataType []*net/url.URL.array
+      Data: 244 GoSliceDataType []*net/url.URL.array
     - __kind: GoSliceDataType
-      ID: 247
+      ID: 244
       Name: '[]*net/url.URL.array'
       ByteSize: 2048
       Element: 45 PointerType *net/url.URL
     - __kind: GoSliceHeaderType
-      ID: 104
+      ID: 106
       Name: '[]*runtime.bmap'
       ByteSize: 24
       GoRuntimeType: 470592
@@ -896,21 +896,21 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 138 PointerType **runtime.bmap
+          Type: 152 PointerType **runtime.bmap
         - Name: len
           Offset: 8
           Type: 9 BaseType int
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 217 GoSliceDataType []*runtime.bmap.array
+      Data: 164 GoSliceDataType []*runtime.bmap.array
     - __kind: GoSliceDataType
-      ID: 217
+      ID: 164
       Name: '[]*runtime.bmap.array'
       ByteSize: 2048
-      Element: 105 PointerType *runtime.bmap
+      Element: 107 PointerType *runtime.bmap
     - __kind: GoSliceHeaderType
-      ID: 116
+      ID: 118
       Name: '[][]*crypto/x509.Certificate'
       ByteSize: 24
       GoRuntimeType: 473888
@@ -918,21 +918,21 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 117 PointerType *[]*crypto/x509.Certificate
+          Type: 119 PointerType *[]*crypto/x509.Certificate
         - Name: len
           Offset: 8
           Type: 9 BaseType int
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 222 GoSliceDataType [][]*crypto/x509.Certificate.array
+      Data: 169 GoSliceDataType [][]*crypto/x509.Certificate.array
     - __kind: GoSliceDataType
-      ID: 222
+      ID: 169
       Name: '[][]*crypto/x509.Certificate.array'
       ByteSize: 2048
-      Element: 113 GoSliceHeaderType []*crypto/x509.Certificate
+      Element: 115 GoSliceHeaderType []*crypto/x509.Certificate
     - __kind: GoSliceHeaderType
-      ID: 118
+      ID: 120
       Name: '[][]uint8'
       ByteSize: 24
       GoRuntimeType: 457024
@@ -940,51 +940,51 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 119 PointerType *[]uint8
+          Type: 121 PointerType *[]uint8
         - Name: len
           Offset: 8
           Type: 9 BaseType int
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 224 GoSliceDataType [][]uint8.array
+      Data: 171 GoSliceDataType [][]uint8.array
     - __kind: GoSliceDataType
-      ID: 224
+      ID: 171
       Name: '[][]uint8.array'
       ByteSize: 2048
       Element: 96 GoSliceHeaderType []uint8
     - __kind: GoSliceDataType
-      ID: 228
+      ID: 175
       Name: '[]bucket<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>.array'
       ByteSize: 2048
-      Element: 133 GoHMapBucketType bucket<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
+      Element: 135 GoHMapBucketType bucket<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
     - __kind: GoSliceDataType
-      ID: 219
+      ID: 166
       Name: '[]bucket<string,[]*mime/multipart.FileHeader>.array'
       ByteSize: 2048
-      Element: 112 GoHMapBucketType bucket<string,[]*mime/multipart.FileHeader>
+      Element: 114 GoHMapBucketType bucket<string,[]*mime/multipart.FileHeader>
     - __kind: GoSliceDataType
-      ID: 205
+      ID: 140
       Name: '[]bucket<string,[]string>.array'
       ByteSize: 2048
       Element: 51 GoHMapBucketType bucket<string,[]string>
     - __kind: GoSliceDataType
-      ID: 210
+      ID: 145
       Name: '[]bucket<string,float64>.array'
       ByteSize: 2048
       Element: 86 GoHMapBucketType bucket<string,float64>
     - __kind: GoSliceDataType
-      ID: 209
+      ID: 144
       Name: '[]bucket<string,interface {}>.array'
       ByteSize: 2048
       Element: 81 GoHMapBucketType bucket<string,interface {}>
     - __kind: GoSliceDataType
-      ID: 208
+      ID: 143
       Name: '[]bucket<string,string>.array'
       ByteSize: 2048
       Element: 72 GoHMapBucketType bucket<string,string>
     - __kind: GoSliceHeaderType
-      ID: 169
+      ID: 195
       Name: '[]crypto/x509.ExtKeyUsage'
       ByteSize: 24
       GoRuntimeType: 475040
@@ -992,21 +992,21 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 170 PointerType *crypto/x509.ExtKeyUsage
+          Type: 196 PointerType *crypto/x509.ExtKeyUsage
         - Name: len
           Offset: 8
           Type: 9 BaseType int
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 241 GoSliceDataType []crypto/x509.ExtKeyUsage.array
+      Data: 238 GoSliceDataType []crypto/x509.ExtKeyUsage.array
     - __kind: GoSliceDataType
-      ID: 241
+      ID: 238
       Name: '[]crypto/x509.ExtKeyUsage.array'
       ByteSize: 2048
-      Element: 171 BaseType crypto/x509.ExtKeyUsage
+      Element: 197 BaseType crypto/x509.ExtKeyUsage
     - __kind: GoSliceHeaderType
-      ID: 180
+      ID: 206
       Name: '[]crypto/x509.OID'
       ByteSize: 24
       GoRuntimeType: 486880
@@ -1014,21 +1014,21 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 181 PointerType *crypto/x509.OID
+          Type: 207 PointerType *crypto/x509.OID
         - Name: len
           Offset: 8
           Type: 9 BaseType int
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 251 GoSliceDataType []crypto/x509.OID.array
+      Data: 248 GoSliceDataType []crypto/x509.OID.array
     - __kind: GoSliceDataType
-      ID: 251
+      ID: 248
       Name: '[]crypto/x509.OID.array'
       ByteSize: 2048
-      Element: 182 StructureType crypto/x509.OID
+      Element: 208 StructureType crypto/x509.OID
     - __kind: GoSliceHeaderType
-      ID: 156
+      ID: 182
       Name: '[]crypto/x509/pkix.AttributeTypeAndValue'
       ByteSize: 24
       GoRuntimeType: 487136
@@ -1036,21 +1036,21 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 157 PointerType *crypto/x509/pkix.AttributeTypeAndValue
+          Type: 183 PointerType *crypto/x509/pkix.AttributeTypeAndValue
         - Name: len
           Offset: 8
           Type: 9 BaseType int
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 233 GoSliceDataType []crypto/x509/pkix.AttributeTypeAndValue.array
+      Data: 230 GoSliceDataType []crypto/x509/pkix.AttributeTypeAndValue.array
     - __kind: GoSliceDataType
-      ID: 233
+      ID: 230
       Name: '[]crypto/x509/pkix.AttributeTypeAndValue.array'
       ByteSize: 2048
-      Element: 158 StructureType crypto/x509/pkix.AttributeTypeAndValue
+      Element: 184 StructureType crypto/x509/pkix.AttributeTypeAndValue
     - __kind: GoSliceHeaderType
-      ID: 163
+      ID: 189
       Name: '[]crypto/x509/pkix.Extension'
       ByteSize: 24
       GoRuntimeType: 486624
@@ -1058,21 +1058,21 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 164 PointerType *crypto/x509/pkix.Extension
+          Type: 190 PointerType *crypto/x509/pkix.Extension
         - Name: len
           Offset: 8
           Type: 9 BaseType int
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 235 GoSliceDataType []crypto/x509/pkix.Extension.array
+      Data: 232 GoSliceDataType []crypto/x509/pkix.Extension.array
     - __kind: GoSliceDataType
-      ID: 235
+      ID: 232
       Name: '[]crypto/x509/pkix.Extension.array'
       ByteSize: 2048
-      Element: 165 StructureType crypto/x509/pkix.Extension
+      Element: 191 StructureType crypto/x509/pkix.Extension
     - __kind: GoSliceHeaderType
-      ID: 166
+      ID: 192
       Name: '[]encoding/asn1.ObjectIdentifier'
       ByteSize: 24
       GoRuntimeType: 486688
@@ -1080,19 +1080,19 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 167 PointerType *encoding/asn1.ObjectIdentifier
+          Type: 193 PointerType *encoding/asn1.ObjectIdentifier
         - Name: len
           Offset: 8
           Type: 9 BaseType int
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 237 GoSliceDataType []encoding/asn1.ObjectIdentifier.array
+      Data: 234 GoSliceDataType []encoding/asn1.ObjectIdentifier.array
     - __kind: GoSliceDataType
-      ID: 237
+      ID: 234
       Name: '[]encoding/asn1.ObjectIdentifier.array'
       ByteSize: 2048
-      Element: 168 GoSliceHeaderType encoding/asn1.ObjectIdentifier
+      Element: 194 GoSliceHeaderType encoding/asn1.ObjectIdentifier
     - __kind: GoSliceHeaderType
       ID: 87
       Name: '[]github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink'
@@ -1109,9 +1109,9 @@ Types:
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 211 GoSliceDataType []github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink.array
+      Data: 146 GoSliceDataType []github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink.array
     - __kind: GoSliceDataType
-      ID: 211
+      ID: 146
       Name: '[]github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink.array'
       ByteSize: 2048
       Element: 89 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink
@@ -1131,21 +1131,21 @@ Types:
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 213 GoSliceDataType []github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent.array
+      Data: 148 GoSliceDataType []github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent.array
     - __kind: GoSliceDataType
-      ID: 213
+      ID: 148
       Name: '[]github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent.array'
       ByteSize: 2048
       Element: 92 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent
     - __kind: ArrayType
-      ID: 101
+      ID: 103
       Name: '[]key<string>'
       ByteSize: 128
       Count: 8
       HasCount: true
       Element: 11 GoStringHeaderType string
     - __kind: GoSliceHeaderType
-      ID: 172
+      ID: 198
       Name: '[]net.IP'
       ByteSize: 24
       GoRuntimeType: 458240
@@ -1153,21 +1153,21 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 173 PointerType *net.IP
+          Type: 199 PointerType *net.IP
         - Name: len
           Offset: 8
           Type: 9 BaseType int
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 243 GoSliceDataType []net.IP.array
+      Data: 240 GoSliceDataType []net.IP.array
     - __kind: GoSliceDataType
-      ID: 243
+      ID: 240
       Name: '[]net.IP.array'
       ByteSize: 2048
-      Element: 174 GoSliceHeaderType net.IP
+      Element: 200 GoSliceHeaderType net.IP
     - __kind: GoSliceHeaderType
-      ID: 122
+      ID: 124
       Name: '[]net/http.segment'
       ByteSize: 24
       GoRuntimeType: 459008
@@ -1175,19 +1175,19 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 123 PointerType *net/http.segment
+          Type: 125 PointerType *net/http.segment
         - Name: len
           Offset: 8
           Type: 9 BaseType int
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 226 GoSliceDataType []net/http.segment.array
+      Data: 173 GoSliceDataType []net/http.segment.array
     - __kind: GoSliceDataType
-      ID: 226
+      ID: 173
       Name: '[]net/http.segment.array'
       ByteSize: 2048
-      Element: 124 StructureType net/http.segment
+      Element: 126 StructureType net/http.segment
     - __kind: GoSliceHeaderType
       ID: 56
       Name: '[]string'
@@ -1204,14 +1204,14 @@ Types:
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 206 GoSliceDataType []string.array
+      Data: 141 GoSliceDataType []string.array
     - __kind: GoSliceDataType
-      ID: 206
+      ID: 141
       Name: '[]string.array'
       ByteSize: 2048
       Element: 11 GoStringHeaderType string
     - __kind: GoSliceHeaderType
-      ID: 190
+      ID: 220
       Name: '[]time.zone'
       ByteSize: 24
       GoRuntimeType: 463104
@@ -1219,21 +1219,21 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 191 PointerType *time.zone
+          Type: 221 PointerType *time.zone
         - Name: len
           Offset: 8
           Type: 9 BaseType int
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 255 GoSliceDataType []time.zone.array
+      Data: 254 GoSliceDataType []time.zone.array
     - __kind: GoSliceDataType
-      ID: 255
+      ID: 254
       Name: '[]time.zone.array'
       ByteSize: 2048
-      Element: 192 StructureType time.zone
+      Element: 222 StructureType time.zone
     - __kind: GoSliceHeaderType
-      ID: 193
+      ID: 223
       Name: '[]time.zoneTrans'
       ByteSize: 24
       GoRuntimeType: 463168
@@ -1241,19 +1241,19 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 194 PointerType *time.zoneTrans
+          Type: 224 PointerType *time.zoneTrans
         - Name: len
           Offset: 8
           Type: 9 BaseType int
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 257 GoSliceDataType []time.zoneTrans.array
+      Data: 256 GoSliceDataType []time.zoneTrans.array
     - __kind: GoSliceDataType
-      ID: 257
+      ID: 256
       Name: '[]time.zoneTrans.array'
       ByteSize: 2048
-      Element: 195 StructureType time.zoneTrans
+      Element: 225 StructureType time.zoneTrans
     - __kind: GoSliceHeaderType
       ID: 96
       Name: '[]uint8'
@@ -1270,49 +1270,49 @@ Types:
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 215 GoSliceDataType []uint8.array
+      Data: 150 GoSliceDataType []uint8.array
     - __kind: GoSliceDataType
-      ID: 215
+      ID: 150
       Name: '[]uint8.array'
       ByteSize: 2048
       Element: 3 BaseType uint8
     - __kind: ArrayType
-      ID: 144
+      ID: 158
       Name: '[]val<*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>'
       ByteSize: 64
       Count: 8
       HasCount: true
-      Element: 145 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
+      Element: 159 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
     - __kind: ArrayType
-      ID: 139
+      ID: 153
       Name: '[]val<[]*mime/multipart.FileHeader>'
       ByteSize: 192
       Count: 8
       HasCount: true
-      Element: 140 GoSliceHeaderType []*mime/multipart.FileHeader
+      Element: 154 GoSliceHeaderType []*mime/multipart.FileHeader
     - __kind: ArrayType
-      ID: 102
+      ID: 104
       Name: '[]val<[]string>'
       ByteSize: 192
       Count: 8
       HasCount: true
       Element: 56 GoSliceHeaderType []string
     - __kind: ArrayType
-      ID: 128
+      ID: 130
       Name: '[]val<float64>'
       ByteSize: 64
       Count: 8
       HasCount: true
       Element: 17 BaseType float64
     - __kind: ArrayType
-      ID: 126
+      ID: 128
       Name: '[]val<interface {}>'
       ByteSize: 128
       Count: 8
       HasCount: true
-      Element: 127 GoEmptyInterfaceType interface {}
+      Element: 129 GoEmptyInterfaceType interface {}
     - __kind: ArrayType
-      ID: 125
+      ID: 127
       Name: '[]val<string>'
       ByteSize: 128
       Count: 8
@@ -1325,43 +1325,43 @@ Types:
       GoRuntimeType: 543328
       GoKind: 1
     - __kind: GoHMapBucketType
-      ID: 133
+      ID: 135
       Name: bucket<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
       ByteSize: 208
       RawFields:
         - Name: tophash
           Offset: 0
-          Type: 100 ArrayType [8]uint8
+          Type: 102 ArrayType [8]uint8
         - Name: keys
           Offset: 8
-          Type: 101 ArrayType []key<string>
+          Type: 103 ArrayType []key<string>
         - Name: values
           Offset: 136
-          Type: 144 ArrayType []val<*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
+          Type: 158 ArrayType []val<*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
         - Name: overflow
           Offset: 200
-          Type: 132 PointerType *bucket<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
+          Type: 134 PointerType *bucket<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
       KeyType: 11 GoStringHeaderType string
-      ValueType: 145 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
+      ValueType: 159 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
     - __kind: GoHMapBucketType
-      ID: 112
+      ID: 114
       Name: bucket<string,[]*mime/multipart.FileHeader>
       ByteSize: 336
       RawFields:
         - Name: tophash
           Offset: 0
-          Type: 100 ArrayType [8]uint8
+          Type: 102 ArrayType [8]uint8
         - Name: keys
           Offset: 8
-          Type: 101 ArrayType []key<string>
+          Type: 103 ArrayType []key<string>
         - Name: values
           Offset: 136
-          Type: 139 ArrayType []val<[]*mime/multipart.FileHeader>
+          Type: 153 ArrayType []val<[]*mime/multipart.FileHeader>
         - Name: overflow
           Offset: 328
-          Type: 111 PointerType *bucket<string,[]*mime/multipart.FileHeader>
+          Type: 113 PointerType *bucket<string,[]*mime/multipart.FileHeader>
       KeyType: 11 GoStringHeaderType string
-      ValueType: 140 GoSliceHeaderType []*mime/multipart.FileHeader
+      ValueType: 154 GoSliceHeaderType []*mime/multipart.FileHeader
     - __kind: GoHMapBucketType
       ID: 51
       Name: bucket<string,[]string>
@@ -1369,13 +1369,13 @@ Types:
       RawFields:
         - Name: tophash
           Offset: 0
-          Type: 100 ArrayType [8]uint8
+          Type: 102 ArrayType [8]uint8
         - Name: keys
           Offset: 8
-          Type: 101 ArrayType []key<string>
+          Type: 103 ArrayType []key<string>
         - Name: values
           Offset: 136
-          Type: 102 ArrayType []val<[]string>
+          Type: 104 ArrayType []val<[]string>
         - Name: overflow
           Offset: 328
           Type: 50 PointerType *bucket<string,[]string>
@@ -1388,13 +1388,13 @@ Types:
       RawFields:
         - Name: tophash
           Offset: 0
-          Type: 100 ArrayType [8]uint8
+          Type: 102 ArrayType [8]uint8
         - Name: keys
           Offset: 8
-          Type: 101 ArrayType []key<string>
+          Type: 103 ArrayType []key<string>
         - Name: values
           Offset: 136
-          Type: 128 ArrayType []val<float64>
+          Type: 130 ArrayType []val<float64>
         - Name: overflow
           Offset: 200
           Type: 85 PointerType *bucket<string,float64>
@@ -1407,18 +1407,18 @@ Types:
       RawFields:
         - Name: tophash
           Offset: 0
-          Type: 100 ArrayType [8]uint8
+          Type: 102 ArrayType [8]uint8
         - Name: keys
           Offset: 8
-          Type: 101 ArrayType []key<string>
+          Type: 103 ArrayType []key<string>
         - Name: values
           Offset: 136
-          Type: 126 ArrayType []val<interface {}>
+          Type: 128 ArrayType []val<interface {}>
         - Name: overflow
           Offset: 264
           Type: 80 PointerType *bucket<string,interface {}>
       KeyType: 11 GoStringHeaderType string
-      ValueType: 127 GoEmptyInterfaceType interface {}
+      ValueType: 129 GoEmptyInterfaceType interface {}
     - __kind: GoHMapBucketType
       ID: 72
       Name: bucket<string,string>
@@ -1426,13 +1426,13 @@ Types:
       RawFields:
         - Name: tophash
           Offset: 0
-          Type: 100 ArrayType [8]uint8
+          Type: 102 ArrayType [8]uint8
         - Name: keys
           Offset: 8
-          Type: 101 ArrayType []key<string>
+          Type: 103 ArrayType []key<string>
         - Name: values
           Offset: 136
-          Type: 125 ArrayType []val<string>
+          Type: 127 ArrayType []val<string>
         - Name: overflow
           Offset: 264
           Type: 71 PointerType *bucket<string,string>
@@ -1530,13 +1530,13 @@ Types:
           Type: 11 GoStringHeaderType string
         - Name: PeerCertificates
           Offset: 48
-          Type: 113 GoSliceHeaderType []*crypto/x509.Certificate
+          Type: 115 GoSliceHeaderType []*crypto/x509.Certificate
         - Name: VerifiedChains
           Offset: 72
-          Type: 116 GoSliceHeaderType [][]*crypto/x509.Certificate
+          Type: 118 GoSliceHeaderType [][]*crypto/x509.Certificate
         - Name: SignedCertificateTimestamps
           Offset: 96
-          Type: 118 GoSliceHeaderType [][]uint8
+          Type: 120 GoSliceHeaderType [][]uint8
         - Name: OCSPResponse
           Offset: 120
           Type: 96 GoSliceHeaderType []uint8
@@ -1548,21 +1548,21 @@ Types:
           Type: 4 BaseType bool
         - Name: ekm
           Offset: 176
-          Type: 120 GoSubroutineType func(string, []uint8, int) ([]uint8, error)
+          Type: 122 GoSubroutineType func(string, []uint8, int) ([]uint8, error)
         - Name: testingOnlyDidHRR
           Offset: 184
           Type: 4 BaseType bool
         - Name: testingOnlyCurveID
           Offset: 186
-          Type: 121 BaseType crypto/tls.CurveID
+          Type: 123 BaseType crypto/tls.CurveID
     - __kind: BaseType
-      ID: 121
+      ID: 123
       Name: crypto/tls.CurveID
       ByteSize: 2
       GoRuntimeType: 778464
       GoKind: 9
     - __kind: StructureType
-      ID: 143
+      ID: 157
       Name: crypto/x509.Certificate
       ByteSize: 1352
       GoRuntimeType: 2.300416e+06
@@ -1588,49 +1588,49 @@ Types:
           Type: 96 GoSliceHeaderType []uint8
         - Name: SignatureAlgorithm
           Offset: 144
-          Type: 151 BaseType crypto/x509.SignatureAlgorithm
+          Type: 177 BaseType crypto/x509.SignatureAlgorithm
         - Name: PublicKeyAlgorithm
           Offset: 152
-          Type: 152 BaseType crypto/x509.PublicKeyAlgorithm
+          Type: 178 BaseType crypto/x509.PublicKeyAlgorithm
         - Name: PublicKey
           Offset: 160
-          Type: 127 GoEmptyInterfaceType interface {}
+          Type: 129 GoEmptyInterfaceType interface {}
         - Name: Version
           Offset: 176
           Type: 9 BaseType int
         - Name: SerialNumber
           Offset: 184
-          Type: 153 PointerType *math/big.Int
+          Type: 179 PointerType *math/big.Int
         - Name: Issuer
           Offset: 192
-          Type: 155 StructureType crypto/x509/pkix.Name
+          Type: 181 StructureType crypto/x509/pkix.Name
         - Name: Subject
           Offset: 440
-          Type: 155 StructureType crypto/x509/pkix.Name
+          Type: 181 StructureType crypto/x509/pkix.Name
         - Name: NotBefore
           Offset: 688
-          Type: 159 StructureType time.Time
+          Type: 185 StructureType time.Time
         - Name: NotAfter
           Offset: 712
-          Type: 159 StructureType time.Time
+          Type: 185 StructureType time.Time
         - Name: KeyUsage
           Offset: 736
-          Type: 162 BaseType crypto/x509.KeyUsage
+          Type: 188 BaseType crypto/x509.KeyUsage
         - Name: Extensions
           Offset: 744
-          Type: 163 GoSliceHeaderType []crypto/x509/pkix.Extension
+          Type: 189 GoSliceHeaderType []crypto/x509/pkix.Extension
         - Name: ExtraExtensions
           Offset: 768
-          Type: 163 GoSliceHeaderType []crypto/x509/pkix.Extension
+          Type: 189 GoSliceHeaderType []crypto/x509/pkix.Extension
         - Name: UnhandledCriticalExtensions
           Offset: 792
-          Type: 166 GoSliceHeaderType []encoding/asn1.ObjectIdentifier
+          Type: 192 GoSliceHeaderType []encoding/asn1.ObjectIdentifier
         - Name: ExtKeyUsage
           Offset: 816
-          Type: 169 GoSliceHeaderType []crypto/x509.ExtKeyUsage
+          Type: 195 GoSliceHeaderType []crypto/x509.ExtKeyUsage
         - Name: UnknownExtKeyUsage
           Offset: 840
-          Type: 166 GoSliceHeaderType []encoding/asn1.ObjectIdentifier
+          Type: 192 GoSliceHeaderType []encoding/asn1.ObjectIdentifier
         - Name: BasicConstraintsValid
           Offset: 864
           Type: 4 BaseType bool
@@ -1663,10 +1663,10 @@ Types:
           Type: 56 GoSliceHeaderType []string
         - Name: IPAddresses
           Offset: 1032
-          Type: 172 GoSliceHeaderType []net.IP
+          Type: 198 GoSliceHeaderType []net.IP
         - Name: URIs
           Offset: 1056
-          Type: 175 GoSliceHeaderType []*net/url.URL
+          Type: 201 GoSliceHeaderType []*net/url.URL
         - Name: PermittedDNSDomainsCritical
           Offset: 1080
           Type: 4 BaseType bool
@@ -1678,10 +1678,10 @@ Types:
           Type: 56 GoSliceHeaderType []string
         - Name: PermittedIPRanges
           Offset: 1136
-          Type: 177 GoSliceHeaderType []*net.IPNet
+          Type: 203 GoSliceHeaderType []*net.IPNet
         - Name: ExcludedIPRanges
           Offset: 1160
-          Type: 177 GoSliceHeaderType []*net.IPNet
+          Type: 203 GoSliceHeaderType []*net.IPNet
         - Name: PermittedEmailAddresses
           Offset: 1184
           Type: 56 GoSliceHeaderType []string
@@ -1699,24 +1699,24 @@ Types:
           Type: 56 GoSliceHeaderType []string
         - Name: PolicyIdentifiers
           Offset: 1304
-          Type: 166 GoSliceHeaderType []encoding/asn1.ObjectIdentifier
+          Type: 192 GoSliceHeaderType []encoding/asn1.ObjectIdentifier
         - Name: Policies
           Offset: 1328
-          Type: 180 GoSliceHeaderType []crypto/x509.OID
+          Type: 206 GoSliceHeaderType []crypto/x509.OID
     - __kind: BaseType
-      ID: 171
+      ID: 197
       Name: crypto/x509.ExtKeyUsage
       ByteSize: 8
       GoRuntimeType: 546400
       GoKind: 2
     - __kind: BaseType
-      ID: 162
+      ID: 188
       Name: crypto/x509.KeyUsage
       ByteSize: 8
       GoRuntimeType: 546336
       GoKind: 2
     - __kind: StructureType
-      ID: 182
+      ID: 208
       Name: crypto/x509.OID
       ByteSize: 24
       GoRuntimeType: 1.762016e+06
@@ -1726,19 +1726,19 @@ Types:
           Offset: 0
           Type: 96 GoSliceHeaderType []uint8
     - __kind: BaseType
-      ID: 152
+      ID: 178
       Name: crypto/x509.PublicKeyAlgorithm
       ByteSize: 8
       GoRuntimeType: 780768
       GoKind: 2
     - __kind: BaseType
-      ID: 151
+      ID: 177
       Name: crypto/x509.SignatureAlgorithm
       ByteSize: 8
       GoRuntimeType: 1.097216e+06
       GoKind: 2
     - __kind: StructureType
-      ID: 158
+      ID: 184
       Name: crypto/x509/pkix.AttributeTypeAndValue
       ByteSize: 40
       GoRuntimeType: 1.349024e+06
@@ -1746,12 +1746,12 @@ Types:
       RawFields:
         - Name: Type
           Offset: 0
-          Type: 168 GoSliceHeaderType encoding/asn1.ObjectIdentifier
+          Type: 194 GoSliceHeaderType encoding/asn1.ObjectIdentifier
         - Name: Value
           Offset: 24
-          Type: 127 GoEmptyInterfaceType interface {}
+          Type: 129 GoEmptyInterfaceType interface {}
     - __kind: StructureType
-      ID: 165
+      ID: 191
       Name: crypto/x509/pkix.Extension
       ByteSize: 56
       GoRuntimeType: 1.494592e+06
@@ -1759,7 +1759,7 @@ Types:
       RawFields:
         - Name: Id
           Offset: 0
-          Type: 168 GoSliceHeaderType encoding/asn1.ObjectIdentifier
+          Type: 194 GoSliceHeaderType encoding/asn1.ObjectIdentifier
         - Name: Critical
           Offset: 24
           Type: 4 BaseType bool
@@ -1767,7 +1767,7 @@ Types:
           Offset: 32
           Type: 96 GoSliceHeaderType []uint8
     - __kind: StructureType
-      ID: 155
+      ID: 181
       Name: crypto/x509/pkix.Name
       ByteSize: 248
       GoRuntimeType: 2.10512e+06
@@ -1802,12 +1802,12 @@ Types:
           Type: 11 GoStringHeaderType string
         - Name: Names
           Offset: 200
-          Type: 156 GoSliceHeaderType []crypto/x509/pkix.AttributeTypeAndValue
+          Type: 182 GoSliceHeaderType []crypto/x509/pkix.AttributeTypeAndValue
         - Name: ExtraNames
           Offset: 224
-          Type: 156 GoSliceHeaderType []crypto/x509/pkix.AttributeTypeAndValue
+          Type: 182 GoSliceHeaderType []crypto/x509/pkix.AttributeTypeAndValue
     - __kind: GoSliceHeaderType
-      ID: 168
+      ID: 194
       Name: encoding/asn1.ObjectIdentifier
       ByteSize: 24
       GoRuntimeType: 1.037376e+06
@@ -1822,9 +1822,9 @@ Types:
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 239 GoSliceDataType encoding/asn1.ObjectIdentifier.array
+      Data: 236 GoSliceDataType encoding/asn1.ObjectIdentifier.array
     - __kind: GoSliceDataType
-      ID: 239
+      ID: 236
       Name: encoding/asn1.ObjectIdentifier.array
       ByteSize: 2048
       Element: 9 BaseType int
@@ -1866,7 +1866,7 @@ Types:
       GoRuntimeType: 645280
       GoKind: 19
     - __kind: GoSubroutineType
-      ID: 120
+      ID: 122
       Name: func(string, []uint8, int) ([]uint8, error)
       ByteSize: 8
       GoRuntimeType: 982976
@@ -1965,7 +1965,7 @@ Types:
           Type: 4 BaseType bool
         - Name: trace
           Offset: 8
-          Type: 135 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.trace
+          Type: 137 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.trace
         - Name: span
           Offset: 16
           Type: 39 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span
@@ -1980,7 +1980,7 @@ Types:
           Type: 4 BaseType bool
         - Name: traceID
           Offset: 49
-          Type: 137 ArrayType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.traceID
+          Type: 139 ArrayType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.traceID
         - Name: spanID
           Offset: 72
           Type: 10 BaseType uint64
@@ -2035,7 +2035,7 @@ Types:
       GoKind: 21
       HeaderType: 79 GoHMapHeaderType hash<string,interface {}>
     - __kind: BaseType
-      ID: 149
+      ID: 163
       Name: github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.samplingDecision
       ByteSize: 4
       GoRuntimeType: 542112
@@ -2055,12 +2055,12 @@ Types:
           Type: 10 BaseType uint64
         - Name: Attributes
           Offset: 24
-          Type: 129 GoMapType map[string]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
+          Type: 131 GoMapType map[string]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
         - Name: RawAttributes
           Offset: 32
-          Type: 134 GoMapType map[string]interface {}
+          Type: 136 GoMapType map[string]interface {}
     - __kind: StructureType
-      ID: 185
+      ID: 211
       Name: github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttribute
       ByteSize: 24
       GoRuntimeType: 1.129856e+06
@@ -2068,9 +2068,9 @@ Types:
       RawFields:
         - Name: Values
           Offset: 0
-          Type: 197 GoSliceHeaderType []*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttributeValue
+          Type: 227 GoSliceHeaderType []*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttributeValue
     - __kind: StructureType
-      ID: 201
+      ID: 251
       Name: github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttributeValue
       ByteSize: 48
       GoRuntimeType: 1.747904e+06
@@ -2078,7 +2078,7 @@ Types:
       RawFields:
         - Name: Type
           Offset: 0
-          Type: 202 BaseType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttributeValueType
+          Type: 260 BaseType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttributeValueType
         - Name: StringValue
           Offset: 8
           Type: 11 GoStringHeaderType string
@@ -2092,13 +2092,13 @@ Types:
           Offset: 40
           Type: 17 BaseType float64
     - __kind: BaseType
-      ID: 202
+      ID: 260
       Name: github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttributeValueType
       ByteSize: 4
       GoRuntimeType: 965120
       GoKind: 5
     - __kind: StructureType
-      ID: 146
+      ID: 160
       Name: github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
       ByteSize: 56
       GoRuntimeType: 1.822272e+06
@@ -2106,7 +2106,7 @@ Types:
       RawFields:
         - Name: Type
           Offset: 0
-          Type: 183 BaseType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttributeType
+          Type: 209 BaseType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttributeType
         - Name: StringValue
           Offset: 8
           Type: 11 GoStringHeaderType string
@@ -2121,15 +2121,15 @@ Types:
           Type: 17 BaseType float64
         - Name: ArrayValue
           Offset: 48
-          Type: 184 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttribute
+          Type: 210 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttribute
     - __kind: BaseType
-      ID: 183
+      ID: 209
       Name: github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttributeType
       ByteSize: 4
       GoRuntimeType: 965024
       GoKind: 5
     - __kind: StructureType
-      ID: 136
+      ID: 138
       Name: github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.trace
       ByteSize: 104
       GoRuntimeType: 2.01696e+06
@@ -2140,7 +2140,7 @@ Types:
           Type: 73 StructureType sync.RWMutex
         - Name: spans
           Offset: 24
-          Type: 147 GoSliceHeaderType []*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span
+          Type: 161 GoSliceHeaderType []*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span
         - Name: tags
           Offset: 48
           Type: 68 GoMapType map[string]string
@@ -2161,12 +2161,12 @@ Types:
           Type: 4 BaseType bool
         - Name: samplingDecision
           Offset: 92
-          Type: 149 BaseType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.samplingDecision
+          Type: 163 BaseType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.samplingDecision
         - Name: root
           Offset: 96
           Type: 39 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span
     - __kind: ArrayType
-      ID: 137
+      ID: 139
       Name: github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.traceID
       ByteSize: 16
       GoRuntimeType: 847584
@@ -2175,7 +2175,7 @@ Types:
       HasCount: true
       Element: 3 BaseType uint8
     - __kind: GoHMapHeaderType
-      ID: 131
+      ID: 133
       Name: hash<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
       ByteSize: 48
       RawFields:
@@ -2196,20 +2196,20 @@ Types:
           Type: 2 BaseType uint32
         - Name: buckets
           Offset: 16
-          Type: 132 PointerType *bucket<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
+          Type: 134 PointerType *bucket<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
         - Name: oldbuckets
           Offset: 24
-          Type: 132 PointerType *bucket<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
+          Type: 134 PointerType *bucket<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
         - Name: nevacuate
           Offset: 32
           Type: 1 BaseType uintptr
         - Name: extra
           Offset: 40
           Type: 52 PointerType *runtime.mapextra
-      BucketType: 133 GoHMapBucketType bucket<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
-      BucketsType: 228 GoSliceDataType []bucket<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>.array
+      BucketType: 135 GoHMapBucketType bucket<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
+      BucketsType: 175 GoSliceDataType []bucket<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>.array
     - __kind: GoHMapHeaderType
-      ID: 110
+      ID: 112
       Name: hash<string,[]*mime/multipart.FileHeader>
       ByteSize: 48
       RawFields:
@@ -2230,18 +2230,18 @@ Types:
           Type: 2 BaseType uint32
         - Name: buckets
           Offset: 16
-          Type: 111 PointerType *bucket<string,[]*mime/multipart.FileHeader>
+          Type: 113 PointerType *bucket<string,[]*mime/multipart.FileHeader>
         - Name: oldbuckets
           Offset: 24
-          Type: 111 PointerType *bucket<string,[]*mime/multipart.FileHeader>
+          Type: 113 PointerType *bucket<string,[]*mime/multipart.FileHeader>
         - Name: nevacuate
           Offset: 32
           Type: 1 BaseType uintptr
         - Name: extra
           Offset: 40
           Type: 52 PointerType *runtime.mapextra
-      BucketType: 112 GoHMapBucketType bucket<string,[]*mime/multipart.FileHeader>
-      BucketsType: 219 GoSliceDataType []bucket<string,[]*mime/multipart.FileHeader>.array
+      BucketType: 114 GoHMapBucketType bucket<string,[]*mime/multipart.FileHeader>
+      BucketsType: 166 GoSliceDataType []bucket<string,[]*mime/multipart.FileHeader>.array
     - __kind: GoHMapHeaderType
       ID: 49
       Name: hash<string,[]string>
@@ -2275,7 +2275,7 @@ Types:
           Offset: 40
           Type: 52 PointerType *runtime.mapextra
       BucketType: 51 GoHMapBucketType bucket<string,[]string>
-      BucketsType: 205 GoSliceDataType []bucket<string,[]string>.array
+      BucketsType: 140 GoSliceDataType []bucket<string,[]string>.array
     - __kind: GoHMapHeaderType
       ID: 84
       Name: hash<string,float64>
@@ -2309,7 +2309,7 @@ Types:
           Offset: 40
           Type: 52 PointerType *runtime.mapextra
       BucketType: 86 GoHMapBucketType bucket<string,float64>
-      BucketsType: 210 GoSliceDataType []bucket<string,float64>.array
+      BucketsType: 145 GoSliceDataType []bucket<string,float64>.array
     - __kind: GoHMapHeaderType
       ID: 79
       Name: hash<string,interface {}>
@@ -2343,7 +2343,7 @@ Types:
           Offset: 40
           Type: 52 PointerType *runtime.mapextra
       BucketType: 81 GoHMapBucketType bucket<string,interface {}>
-      BucketsType: 209 GoSliceDataType []bucket<string,interface {}>.array
+      BucketsType: 144 GoSliceDataType []bucket<string,interface {}>.array
     - __kind: GoHMapHeaderType
       ID: 70
       Name: hash<string,string>
@@ -2377,7 +2377,7 @@ Types:
           Offset: 40
           Type: 52 PointerType *runtime.mapextra
       BucketType: 72 GoHMapBucketType bucket<string,string>
-      BucketsType: 208 GoSliceDataType []bucket<string,string>.array
+      BucketsType: 143 GoSliceDataType []bucket<string,string>.array
     - __kind: BaseType
       ID: 9
       Name: int
@@ -2409,7 +2409,7 @@ Types:
       GoRuntimeType: 542368
       GoKind: 3
     - __kind: GoEmptyInterfaceType
-      ID: 127
+      ID: 129
       Name: interface {}
       ByteSize: 16
       GoRuntimeType: 797888
@@ -2435,21 +2435,21 @@ Types:
           Offset: 8
           Type: 19 VoidPointerType unsafe.Pointer
     - __kind: GoMapType
-      ID: 129
+      ID: 131
       Name: map[string]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
       ByteSize: 8
       GoRuntimeType: 904992
       GoKind: 21
-      HeaderType: 131 GoHMapHeaderType hash<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
+      HeaderType: 133 GoHMapHeaderType hash<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
     - __kind: GoMapType
-      ID: 108
+      ID: 110
       Name: map[string][]*mime/multipart.FileHeader
       ByteSize: 8
       GoRuntimeType: 904032
       GoKind: 21
-      HeaderType: 110 GoHMapHeaderType hash<string,[]*mime/multipart.FileHeader>
+      HeaderType: 112 GoHMapHeaderType hash<string,[]*mime/multipart.FileHeader>
     - __kind: GoMapType
-      ID: 107
+      ID: 109
       Name: map[string][]string
       ByteSize: 8
       GoRuntimeType: 899232
@@ -2463,7 +2463,7 @@ Types:
       GoKind: 21
       HeaderType: 84 GoHMapHeaderType hash<string,float64>
     - __kind: GoMapType
-      ID: 134
+      ID: 136
       Name: map[string]interface {}
       ByteSize: 8
       GoRuntimeType: 896352
@@ -2477,7 +2477,7 @@ Types:
       GoKind: 21
       HeaderType: 70 GoHMapHeaderType hash<string,string>
     - __kind: StructureType
-      ID: 154
+      ID: 180
       Name: math/big.Int
       ByteSize: 32
       GoRuntimeType: 1.340544e+06
@@ -2488,15 +2488,15 @@ Types:
           Type: 4 BaseType bool
         - Name: abs
           Offset: 8
-          Type: 187 GoSliceHeaderType math/big.nat
+          Type: 217 GoSliceHeaderType math/big.nat
     - __kind: BaseType
-      ID: 189
+      ID: 219
       Name: math/big.Word
       ByteSize: 8
       GoRuntimeType: 546656
       GoKind: 7
     - __kind: GoSliceHeaderType
-      ID: 187
+      ID: 217
       Name: math/big.nat
       ByteSize: 24
       GoRuntimeType: 2.279968e+06
@@ -2504,21 +2504,21 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 188 PointerType *math/big.Word
+          Type: 218 PointerType *math/big.Word
         - Name: len
           Offset: 8
           Type: 9 BaseType int
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 253 GoSliceDataType math/big.nat.array
+      Data: 252 GoSliceDataType math/big.nat.array
     - __kind: GoSliceDataType
-      ID: 253
+      ID: 252
       Name: math/big.nat.array
       ByteSize: 2048
-      Element: 189 BaseType math/big.Word
+      Element: 219 BaseType math/big.Word
     - __kind: StructureType
-      ID: 150
+      ID: 176
       Name: mime/multipart.FileHeader
       ByteSize: 88
       GoRuntimeType: 1.88112e+06
@@ -2529,7 +2529,7 @@ Types:
           Type: 11 GoStringHeaderType string
         - Name: Header
           Offset: 16
-          Type: 186 GoMapType net/textproto.MIMEHeader
+          Type: 216 GoMapType net/textproto.MIMEHeader
         - Name: Size
           Offset: 24
           Type: 13 BaseType int64
@@ -2554,12 +2554,12 @@ Types:
       RawFields:
         - Name: Value
           Offset: 0
-          Type: 107 GoMapType map[string][]string
+          Type: 109 GoMapType map[string][]string
         - Name: File
           Offset: 8
-          Type: 108 GoMapType map[string][]*mime/multipart.FileHeader
+          Type: 110 GoMapType map[string][]*mime/multipart.FileHeader
     - __kind: GoSliceHeaderType
-      ID: 174
+      ID: 200
       Name: net.IP
       ByteSize: 24
       GoRuntimeType: 2.000864e+06
@@ -2574,14 +2574,14 @@ Types:
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 245 GoSliceDataType net.IP.array
+      Data: 242 GoSliceDataType net.IP.array
     - __kind: GoSliceDataType
-      ID: 245
+      ID: 242
       Name: net.IP.array
       ByteSize: 2048
       Element: 3 BaseType uint8
     - __kind: GoSliceHeaderType
-      ID: 200
+      ID: 250
       Name: net.IPMask
       ByteSize: 24
       GoRuntimeType: 999232
@@ -2603,7 +2603,7 @@ Types:
       ByteSize: 2048
       Element: 3 BaseType uint8
     - __kind: StructureType
-      ID: 196
+      ID: 226
       Name: net.IPNet
       ByteSize: 48
       GoRuntimeType: 1.306944e+06
@@ -2611,10 +2611,10 @@ Types:
       RawFields:
         - Name: IP
           Offset: 0
-          Type: 174 GoSliceHeaderType net.IP
+          Type: 200 GoSliceHeaderType net.IP
         - Name: Mask
           Offset: 24
-          Type: 200 GoSliceHeaderType net.IPMask
+          Type: 250 GoSliceHeaderType net.IPMask
     - __kind: GoMapType
       ID: 47
       Name: net/http.Header
@@ -2787,12 +2787,12 @@ Types:
           Type: 11 GoStringHeaderType string
         - Name: segments
           Offset: 48
-          Type: 122 GoSliceHeaderType []net/http.segment
+          Type: 124 GoSliceHeaderType []net/http.segment
         - Name: loc
           Offset: 72
           Type: 11 GoStringHeaderType string
     - __kind: StructureType
-      ID: 124
+      ID: 126
       Name: net/http.segment
       ByteSize: 24
       GoRuntimeType: 1.452928e+06
@@ -2808,7 +2808,7 @@ Types:
           Offset: 17
           Type: 4 BaseType bool
     - __kind: GoMapType
-      ID: 186
+      ID: 216
       Name: net/textproto.MIMEHeader
       ByteSize: 8
       GoRuntimeType: 1.637344e+06
@@ -2829,7 +2829,7 @@ Types:
           Type: 11 GoStringHeaderType string
         - Name: User
           Offset: 32
-          Type: 98 PointerType *net/url.Userinfo
+          Type: 100 PointerType *net/url.Userinfo
         - Name: Host
           Offset: 40
           Type: 11 GoStringHeaderType string
@@ -2855,7 +2855,7 @@ Types:
           Offset: 128
           Type: 11 GoStringHeaderType string
     - __kind: StructureType
-      ID: 99
+      ID: 101
       Name: net/url.Userinfo
       ByteSize: 40
       GoRuntimeType: 1.469248e+06
@@ -2878,7 +2878,7 @@ Types:
       GoKind: 21
       HeaderType: 49 GoHMapHeaderType hash<string,[]string>
     - __kind: StructureType
-      ID: 106
+      ID: 108
       Name: runtime.bmap
       ByteSize: 8
       GoRuntimeType: 1.136896e+06
@@ -2886,7 +2886,7 @@ Types:
       RawFields:
         - Name: tophash
           Offset: 0
-          Type: 100 ArrayType [8]uint8
+          Type: 102 ArrayType [8]uint8
     - __kind: StructureType
       ID: 53
       Name: runtime.mapextra
@@ -2896,13 +2896,13 @@ Types:
       RawFields:
         - Name: overflow
           Offset: 0
-          Type: 103 PointerType *[]*runtime.bmap
+          Type: 105 PointerType *[]*runtime.bmap
         - Name: oldoverflow
           Offset: 8
-          Type: 103 PointerType *[]*runtime.bmap
+          Type: 105 PointerType *[]*runtime.bmap
         - Name: nextOverflow
           Offset: 16
-          Type: 105 PointerType *runtime.bmap
+          Type: 107 PointerType *runtime.bmap
     - __kind: GoStringHeaderType
       ID: 11
       Name: string
@@ -2912,13 +2912,13 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 204 PointerType *string.str
+          Type: 99 PointerType *string.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 203 GoStringDataType string.str
+      Data: 98 GoStringDataType string.str
     - __kind: GoStringDataType
-      ID: 203
+      ID: 98
       Name: string.str
       ByteSize: 2048
     - __kind: StructureType
@@ -2976,7 +2976,7 @@ Types:
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 161
+      ID: 187
       Name: time.Location
       ByteSize: 104
       GoRuntimeType: 1.877376e+06
@@ -2987,10 +2987,10 @@ Types:
           Type: 11 GoStringHeaderType string
         - Name: zone
           Offset: 16
-          Type: 190 GoSliceHeaderType []time.zone
+          Type: 220 GoSliceHeaderType []time.zone
         - Name: tx
           Offset: 40
-          Type: 193 GoSliceHeaderType []time.zoneTrans
+          Type: 223 GoSliceHeaderType []time.zoneTrans
         - Name: extend
           Offset: 64
           Type: 11 GoStringHeaderType string
@@ -3002,9 +3002,9 @@ Types:
           Type: 13 BaseType int64
         - Name: cacheZone
           Offset: 96
-          Type: 191 PointerType *time.zone
+          Type: 221 PointerType *time.zone
     - __kind: StructureType
-      ID: 159
+      ID: 185
       Name: time.Time
       ByteSize: 24
       GoRuntimeType: 2.280896e+06
@@ -3018,9 +3018,9 @@ Types:
           Type: 13 BaseType int64
         - Name: loc
           Offset: 16
-          Type: 160 PointerType *time.Location
+          Type: 186 PointerType *time.Location
     - __kind: StructureType
-      ID: 192
+      ID: 222
       Name: time.zone
       ByteSize: 32
       GoRuntimeType: 1.45792e+06
@@ -3036,7 +3036,7 @@ Types:
           Offset: 24
           Type: 4 BaseType bool
     - __kind: StructureType
-      ID: 195
+      ID: 225
       Name: time.zoneTrans
       ByteSize: 16
       GoRuntimeType: 1.663616e+06

--- a/pkg/dyninst/irgen/testdata/snapshot/rc_tester.arch=amd64,toolchain=go1.23.11.yaml
+++ b/pkg/dyninst/irgen/testdata/snapshot/rc_tester.arch=amd64,toolchain=go1.23.11.yaml
@@ -33,7 +33,7 @@ Subprograms:
       InlinePCRanges: []
       Variables:
         - Name: w
-          Type: 1 GoInterfaceType net/http.ResponseWriter
+          Type: 36 GoInterfaceType net/http.ResponseWriter
           Locations:
             - Range: 0xd597c0..0xd5982c
               Pieces:
@@ -56,7 +56,7 @@ Subprograms:
           IsParameter: true
           IsReturn: false
         - Name: r
-          Type: 3 PointerType *net/http.Request
+          Type: 37 PointerType *net/http.Request
           Locations:
             - Range: 0xd597c0..0xd59836
               Pieces: [{Size: 8, Op: {RegNo: 2, Shift: 0}}]
@@ -65,14 +65,14 @@ Subprograms:
           IsParameter: true
           IsReturn: false
         - Name: span
-          Type: 126 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span
+          Type: 148 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span
           Locations:
             - Range: 0xd59848..0xd59881
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: false
           IsReturn: false
         - Name: '&buf'
-          Type: 179 PointerType *bytes.Buffer
+          Type: 198 PointerType *bytes.Buffer
           Locations:
             - Range: 0xd59958..0xd5997a
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
@@ -81,7 +81,7 @@ Subprograms:
           IsParameter: false
           IsReturn: false
         - Name: .autotmp_14
-          Type: 182 StructureType context.backgroundCtx
+          Type: 201 StructureType context.backgroundCtx
           Locations:
             - Range: 0xd597c0..0xd59a5c
               Pieces: [{Size: 0, Op: {CfaOffset: 0}}]
@@ -93,7 +93,7 @@ Subprograms:
       InlinePCRanges: []
       Variables:
         - Name: path
-          Type: 5 GoStringHeaderType string
+          Type: 11 GoStringHeaderType string
           Locations:
             - Range: 0xd59b20..0xd59b45
               Pieces:
@@ -105,51 +105,51 @@ Subprograms:
           IsReturn: false
 Types:
     - __kind: PointerType
-      ID: 56
+      ID: 80
       Name: '**crypto/x509.Certificate'
       ByteSize: 8
-      Pointee: 57 PointerType *crypto/x509.Certificate
+      Pointee: 81 PointerType *crypto/x509.Certificate
     - __kind: PointerType
-      ID: 174
+      ID: 194
       Name: '**github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span'
       ByteSize: 8
       GoKind: 22
-      Pointee: 126 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span
+      Pointee: 148 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span
     - __kind: PointerType
-      ID: 164
+      ID: 184
       Name: '**github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttributeValue'
       ByteSize: 8
       GoKind: 22
-      Pointee: 165 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttributeValue
+      Pointee: 185 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttributeValue
     - __kind: PointerType
-      ID: 48
+      ID: 72
       Name: '**mime/multipart.FileHeader'
       ByteSize: 8
       GoKind: 22
-      Pointee: 49 PointerType *mime/multipart.FileHeader
+      Pointee: 73 PointerType *mime/multipart.FileHeader
     - __kind: PointerType
-      ID: 98
+      ID: 120
       Name: '**net.IPNet'
       ByteSize: 8
       GoKind: 22
-      Pointee: 99 PointerType *net.IPNet
+      Pointee: 121 PointerType *net.IPNet
     - __kind: PointerType
-      ID: 96
+      ID: 118
       Name: '**net/url.URL'
       ByteSize: 8
       GoKind: 22
-      Pointee: 9 PointerType *net/url.URL
+      Pointee: 39 PointerType *net/url.URL
     - __kind: PointerType
-      ID: 31
+      ID: 56
       Name: '**runtime.bmap'
       ByteSize: 8
-      Pointee: 32 PointerType *runtime.bmap
+      Pointee: 57 PointerType *runtime.bmap
     - __kind: PointerType
-      ID: 106
+      ID: 128
       Name: '*[]*crypto/x509.Certificate'
       ByteSize: 8
       GoKind: 22
-      Pointee: 55 GoSliceHeaderType []*crypto/x509.Certificate
+      Pointee: 79 GoSliceHeaderType []*crypto/x509.Certificate
     - __kind: PointerType
       ID: 216
       Name: '*[]*crypto/x509.Certificate.array'
@@ -181,12 +181,12 @@ Types:
       ByteSize: 8
       Pointee: 237 GoSliceDataType []*net/url.URL.array
     - __kind: PointerType
-      ID: 29
+      ID: 54
       Name: '*[]*runtime.bmap'
       ByteSize: 8
       GoRuntimeType: 470656
       GoKind: 22
-      Pointee: 30 GoSliceHeaderType []*runtime.bmap
+      Pointee: 55 GoSliceHeaderType []*runtime.bmap
     - __kind: PointerType
       ID: 209
       Name: '*[]*runtime.bmap.array'
@@ -263,297 +263,297 @@ Types:
       ByteSize: 8
       Pointee: 225 GoSliceDataType []time.zoneTrans.array
     - __kind: PointerType
-      ID: 108
+      ID: 130
       Name: '*[]uint8'
       ByteSize: 8
       GoRuntimeType: 456768
       GoKind: 22
-      Pointee: 52 GoSliceHeaderType []uint8
+      Pointee: 76 GoSliceHeaderType []uint8
     - __kind: PointerType
       ID: 214
       Name: '*[]uint8.array'
       ByteSize: 8
       Pointee: 213 GoSliceDataType []uint8.array
     - __kind: PointerType
-      ID: 184
+      ID: 5
       Name: '*bool'
       ByteSize: 8
       GoRuntimeType: 377024
       GoKind: 22
-      Pointee: 13 BaseType bool
+      Pointee: 4 BaseType bool
     - __kind: PointerType
-      ID: 155
+      ID: 175
       Name: '*bucket<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>'
       ByteSize: 8
-      Pointee: 156 GoHMapBucketType bucket<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
+      Pointee: 176 GoHMapBucketType bucket<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
     - __kind: PointerType
-      ID: 44
+      ID: 68
       Name: '*bucket<string,[]*mime/multipart.FileHeader>'
       ByteSize: 8
-      Pointee: 45 GoHMapBucketType bucket<string,[]*mime/multipart.FileHeader>
+      Pointee: 69 GoHMapBucketType bucket<string,[]*mime/multipart.FileHeader>
     - __kind: PointerType
-      ID: 19
+      ID: 46
       Name: '*bucket<string,[]string>'
       ByteSize: 8
-      Pointee: 20 GoHMapBucketType bucket<string,[]string>
+      Pointee: 47 GoHMapBucketType bucket<string,[]string>
     - __kind: PointerType
-      ID: 142
+      ID: 163
       Name: '*bucket<string,float64>'
       ByteSize: 8
-      Pointee: 143 GoHMapBucketType bucket<string,float64>
+      Pointee: 164 GoHMapBucketType bucket<string,float64>
     - __kind: PointerType
-      ID: 136
+      ID: 157
       Name: '*bucket<string,interface {}>'
       ByteSize: 8
-      Pointee: 137 GoHMapBucketType bucket<string,interface {}>
+      Pointee: 158 GoHMapBucketType bucket<string,interface {}>
     - __kind: PointerType
-      ID: 123
+      ID: 145
       Name: '*bucket<string,string>'
       ByteSize: 8
-      Pointee: 124 GoHMapBucketType bucket<string,string>
+      Pointee: 146 GoHMapBucketType bucket<string,string>
     - __kind: PointerType
-      ID: 179
+      ID: 198
       Name: '*bytes.Buffer'
       ByteSize: 8
       GoRuntimeType: 2.17632e+06
       GoKind: 22
-      Pointee: 180 StructureType bytes.Buffer
+      Pointee: 199 StructureType bytes.Buffer
     - __kind: PointerType
-      ID: 53
+      ID: 77
       Name: '*crypto/tls.ConnectionState'
       ByteSize: 8
       GoRuntimeType: 852192
       GoKind: 22
-      Pointee: 54 StructureType crypto/tls.ConnectionState
+      Pointee: 78 StructureType crypto/tls.ConnectionState
     - __kind: PointerType
-      ID: 57
+      ID: 81
       Name: '*crypto/x509.Certificate'
       ByteSize: 8
       GoRuntimeType: 1.952864e+06
       GoKind: 22
-      Pointee: 58 StructureType crypto/x509.Certificate
+      Pointee: 82 StructureType crypto/x509.Certificate
     - __kind: PointerType
-      ID: 90
+      ID: 112
       Name: '*crypto/x509.ExtKeyUsage'
       ByteSize: 8
       GoRuntimeType: 400640
       GoKind: 22
-      Pointee: 91 BaseType crypto/x509.ExtKeyUsage
+      Pointee: 113 BaseType crypto/x509.ExtKeyUsage
     - __kind: PointerType
-      ID: 103
+      ID: 125
       Name: '*crypto/x509.OID'
       ByteSize: 8
       GoRuntimeType: 1.761792e+06
       GoKind: 22
-      Pointee: 104 StructureType crypto/x509.OID
+      Pointee: 126 StructureType crypto/x509.OID
     - __kind: PointerType
-      ID: 69
+      ID: 93
       Name: '*crypto/x509/pkix.AttributeTypeAndValue'
       ByteSize: 8
       GoRuntimeType: 417344
       GoKind: 22
-      Pointee: 70 StructureType crypto/x509/pkix.AttributeTypeAndValue
+      Pointee: 94 StructureType crypto/x509/pkix.AttributeTypeAndValue
     - __kind: PointerType
-      ID: 85
+      ID: 107
       Name: '*crypto/x509/pkix.Extension'
       ByteSize: 8
       GoRuntimeType: 417536
       GoKind: 22
-      Pointee: 86 StructureType crypto/x509/pkix.Extension
+      Pointee: 108 StructureType crypto/x509/pkix.Extension
     - __kind: PointerType
-      ID: 88
+      ID: 110
       Name: '*encoding/asn1.ObjectIdentifier'
       ByteSize: 8
       GoRuntimeType: 1.037248e+06
       GoKind: 22
-      Pointee: 71 GoSliceHeaderType encoding/asn1.ObjectIdentifier
+      Pointee: 95 GoSliceHeaderType encoding/asn1.ObjectIdentifier
     - __kind: PointerType
       ID: 222
       Name: '*encoding/asn1.ObjectIdentifier.array'
       ByteSize: 8
       Pointee: 221 GoSliceDataType encoding/asn1.ObjectIdentifier.array
     - __kind: PointerType
-      ID: 200
+      ID: 33
       Name: '*error'
       ByteSize: 8
       GoRuntimeType: 375936
       GoKind: 22
-      Pointee: 189 GoInterfaceType error
+      Pointee: 18 GoInterfaceType error
     - __kind: PointerType
-      ID: 202
+      ID: 35
       Name: '*float32'
       ByteSize: 8
       GoRuntimeType: 376896
       GoKind: 22
-      Pointee: 188 BaseType float32
+      Pointee: 16 BaseType float32
     - __kind: PointerType
-      ID: 175
+      ID: 25
       Name: '*float64'
       ByteSize: 8
       GoRuntimeType: 376960
       GoKind: 22
-      Pointee: 145 BaseType float64
+      Pointee: 17 BaseType float64
     - __kind: PointerType
-      ID: 126
+      ID: 148
       Name: '*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span'
       ByteSize: 8
       GoRuntimeType: 2.187104e+06
       GoKind: 22
-      Pointee: 127 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span
+      Pointee: 149 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span
     - __kind: PointerType
-      ID: 169
+      ID: 189
       Name: '*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanContext'
       ByteSize: 8
       GoRuntimeType: 1.916704e+06
       GoKind: 22
-      Pointee: 170 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanContext
+      Pointee: 190 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanContext
     - __kind: PointerType
-      ID: 147
+      ID: 167
       Name: '*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink'
       ByteSize: 8
       GoRuntimeType: 1.129216e+06
       GoKind: 22
-      Pointee: 148 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink
+      Pointee: 168 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink
     - __kind: PointerType
-      ID: 150
+      ID: 170
       Name: '*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent'
       ByteSize: 8
       GoRuntimeType: 1.129344e+06
       GoKind: 22
-      Pointee: 151 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent
+      Pointee: 171 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent
     - __kind: PointerType
-      ID: 161
+      ID: 181
       Name: '*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttribute'
       ByteSize: 8
       GoRuntimeType: 1.129984e+06
       GoKind: 22
-      Pointee: 162 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttribute
+      Pointee: 182 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttribute
     - __kind: PointerType
-      ID: 165
+      ID: 185
       Name: '*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttributeValue'
       ByteSize: 8
       GoRuntimeType: 1.129728e+06
       GoKind: 22
-      Pointee: 166 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttributeValue
+      Pointee: 186 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttributeValue
     - __kind: PointerType
-      ID: 158
+      ID: 178
       Name: '*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute'
       ByteSize: 8
       GoRuntimeType: 1.130112e+06
       GoKind: 22
-      Pointee: 159 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
+      Pointee: 179 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
     - __kind: PointerType
-      ID: 171
+      ID: 191
       Name: '*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.trace'
       ByteSize: 8
       GoRuntimeType: 2.131968e+06
       GoKind: 22
-      Pointee: 172 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.trace
+      Pointee: 192 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.trace
     - __kind: PointerType
-      ID: 153
+      ID: 173
       Name: '*hash<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>'
       ByteSize: 8
-      Pointee: 154 GoHMapHeaderType hash<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
+      Pointee: 174 GoHMapHeaderType hash<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
     - __kind: PointerType
-      ID: 42
+      ID: 66
       Name: '*hash<string,[]*mime/multipart.FileHeader>'
       ByteSize: 8
-      Pointee: 43 GoHMapHeaderType hash<string,[]*mime/multipart.FileHeader>
+      Pointee: 67 GoHMapHeaderType hash<string,[]*mime/multipart.FileHeader>
     - __kind: PointerType
-      ID: 15
+      ID: 44
       Name: '*hash<string,[]string>'
       ByteSize: 8
-      Pointee: 16 GoHMapHeaderType hash<string,[]string>
+      Pointee: 45 GoHMapHeaderType hash<string,[]string>
     - __kind: PointerType
-      ID: 140
+      ID: 161
       Name: '*hash<string,float64>'
       ByteSize: 8
-      Pointee: 141 GoHMapHeaderType hash<string,float64>
+      Pointee: 162 GoHMapHeaderType hash<string,float64>
     - __kind: PointerType
-      ID: 134
+      ID: 155
       Name: '*hash<string,interface {}>'
       ByteSize: 8
-      Pointee: 135 GoHMapHeaderType hash<string,interface {}>
+      Pointee: 156 GoHMapHeaderType hash<string,interface {}>
     - __kind: PointerType
-      ID: 121
+      ID: 143
       Name: '*hash<string,string>'
       ByteSize: 8
-      Pointee: 122 GoHMapHeaderType hash<string,string>
+      Pointee: 144 GoHMapHeaderType hash<string,string>
     - __kind: PointerType
-      ID: 72
+      ID: 27
       Name: '*int'
       ByteSize: 8
       GoRuntimeType: 376576
       GoKind: 22
-      Pointee: 8 BaseType int
+      Pointee: 9 BaseType int
     - __kind: PointerType
-      ID: 197
+      ID: 30
       Name: '*int16'
       ByteSize: 8
       GoRuntimeType: 376192
       GoKind: 22
-      Pointee: 198 BaseType int16
+      Pointee: 31 BaseType int16
     - __kind: PointerType
-      ID: 190
+      ID: 20
       Name: '*int32'
       ByteSize: 8
       GoRuntimeType: 376320
       GoKind: 22
-      Pointee: 130 BaseType int32
+      Pointee: 12 BaseType int32
     - __kind: PointerType
-      ID: 194
+      ID: 26
       Name: '*int64'
       ByteSize: 8
       GoRuntimeType: 376448
       GoKind: 22
-      Pointee: 36 BaseType int64
+      Pointee: 13 BaseType int64
     - __kind: PointerType
-      ID: 199
+      ID: 32
       Name: '*int8'
       ByteSize: 8
       GoRuntimeType: 376064
       GoKind: 22
-      Pointee: 186 BaseType int8
+      Pointee: 14 BaseType int8
     - __kind: PointerType
-      ID: 62
+      ID: 86
       Name: '*math/big.Int'
       ByteSize: 8
       GoRuntimeType: 2.296864e+06
       GoKind: 22
-      Pointee: 63 StructureType math/big.Int
+      Pointee: 87 StructureType math/big.Int
     - __kind: PointerType
-      ID: 65
+      ID: 89
       Name: '*math/big.Word'
       ByteSize: 8
       GoRuntimeType: 403456
       GoKind: 22
-      Pointee: 66 BaseType math/big.Word
+      Pointee: 90 BaseType math/big.Word
     - __kind: PointerType
       ID: 218
       Name: '*math/big.nat.array'
       ByteSize: 8
       Pointee: 217 GoSliceDataType math/big.nat.array
     - __kind: PointerType
-      ID: 49
+      ID: 73
       Name: '*mime/multipart.FileHeader'
       ByteSize: 8
       GoRuntimeType: 853632
       GoKind: 22
-      Pointee: 50 StructureType mime/multipart.FileHeader
+      Pointee: 74 StructureType mime/multipart.FileHeader
     - __kind: PointerType
-      ID: 38
+      ID: 62
       Name: '*mime/multipart.Form'
       ByteSize: 8
       GoRuntimeType: 853728
       GoKind: 22
-      Pointee: 39 StructureType mime/multipart.Form
+      Pointee: 63 StructureType mime/multipart.Form
     - __kind: PointerType
-      ID: 93
+      ID: 115
       Name: '*net.IP'
       ByteSize: 8
       GoRuntimeType: 2.028544e+06
       GoKind: 22
-      Pointee: 94 GoSliceHeaderType net.IP
+      Pointee: 116 GoSliceHeaderType net.IP
     - __kind: PointerType
       ID: 236
       Name: '*net.IP.array'
@@ -565,145 +565,145 @@ Types:
       ByteSize: 8
       Pointee: 241 GoSliceDataType net.IPMask.array
     - __kind: PointerType
-      ID: 99
+      ID: 121
       Name: '*net.IPNet'
       ByteSize: 8
       GoRuntimeType: 1.122688e+06
       GoKind: 22
-      Pointee: 100 StructureType net.IPNet
+      Pointee: 122 StructureType net.IPNet
     - __kind: PointerType
-      ID: 3
+      ID: 37
       Name: '*net/http.Request'
       ByteSize: 8
       GoRuntimeType: 2.219392e+06
       GoKind: 22
-      Pointee: 4 StructureType net/http.Request
+      Pointee: 38 StructureType net/http.Request
     - __kind: PointerType
-      ID: 112
+      ID: 134
       Name: '*net/http.Response'
       ByteSize: 8
       GoRuntimeType: 1.63216e+06
       GoKind: 22
-      Pointee: 113 StructureType net/http.Response
+      Pointee: 135 StructureType net/http.Response
     - __kind: PointerType
-      ID: 115
+      ID: 137
       Name: '*net/http.pattern'
       ByteSize: 8
       GoRuntimeType: 1.45312e+06
       GoKind: 22
-      Pointee: 116 StructureType net/http.pattern
+      Pointee: 138 StructureType net/http.pattern
     - __kind: PointerType
-      ID: 118
+      ID: 140
       Name: '*net/http.segment'
       ByteSize: 8
       GoRuntimeType: 367808
       GoKind: 22
-      Pointee: 119 StructureType net/http.segment
+      Pointee: 141 StructureType net/http.segment
     - __kind: PointerType
-      ID: 9
+      ID: 39
       Name: '*net/url.URL'
       ByteSize: 8
       GoRuntimeType: 2.00192e+06
       GoKind: 22
-      Pointee: 10 StructureType net/url.URL
+      Pointee: 40 StructureType net/url.URL
     - __kind: PointerType
-      ID: 11
+      ID: 41
       Name: '*net/url.Userinfo'
       ByteSize: 8
       GoRuntimeType: 1.141376e+06
       GoKind: 22
-      Pointee: 12 StructureType net/url.Userinfo
+      Pointee: 42 StructureType net/url.Userinfo
     - __kind: PointerType
-      ID: 32
+      ID: 57
       Name: '*runtime.bmap'
       ByteSize: 8
       GoRuntimeType: 1.137024e+06
       GoKind: 22
-      Pointee: 33 StructureType runtime.bmap
+      Pointee: 58 StructureType runtime.bmap
     - __kind: PointerType
-      ID: 27
+      ID: 52
       Name: '*runtime.mapextra'
       ByteSize: 8
       GoRuntimeType: 379904
       GoKind: 22
-      Pointee: 28 StructureType runtime.mapextra
+      Pointee: 53 StructureType runtime.mapextra
     - __kind: PointerType
-      ID: 25
+      ID: 22
       Name: '*string'
       ByteSize: 8
       GoRuntimeType: 376000
       GoKind: 22
-      Pointee: 5 GoStringHeaderType string
+      Pointee: 11 GoStringHeaderType string
     - __kind: PointerType
       ID: 204
       Name: '*string.str'
       ByteSize: 8
       Pointee: 203 GoStringDataType string.str
     - __kind: PointerType
-      ID: 75
+      ID: 97
       Name: '*time.Location'
       ByteSize: 8
       GoRuntimeType: 1.458112e+06
       GoKind: 22
-      Pointee: 76 StructureType time.Location
+      Pointee: 98 StructureType time.Location
     - __kind: PointerType
-      ID: 78
+      ID: 100
       Name: '*time.zone'
       ByteSize: 8
       GoRuntimeType: 370880
       GoKind: 22
-      Pointee: 79 StructureType time.zone
+      Pointee: 101 StructureType time.zone
     - __kind: PointerType
-      ID: 81
+      ID: 103
       Name: '*time.zoneTrans'
       ByteSize: 8
       GoRuntimeType: 370944
       GoKind: 22
-      Pointee: 82 StructureType time.zoneTrans
+      Pointee: 104 StructureType time.zoneTrans
     - __kind: PointerType
-      ID: 201
+      ID: 34
       Name: '*uint'
       ByteSize: 8
       GoRuntimeType: 376640
       GoKind: 22
-      Pointee: 187 BaseType uint
+      Pointee: 15 BaseType uint
     - __kind: PointerType
-      ID: 196
+      ID: 29
       Name: '*uint16'
       ByteSize: 8
       GoRuntimeType: 376256
       GoKind: 22
-      Pointee: 17 BaseType uint16
+      Pointee: 7 BaseType uint16
     - __kind: PointerType
-      ID: 191
+      ID: 21
       Name: '*uint32'
       ByteSize: 8
       GoRuntimeType: 376384
       GoKind: 22
-      Pointee: 18 BaseType uint32
+      Pointee: 2 BaseType uint32
     - __kind: PointerType
-      ID: 195
+      ID: 28
       Name: '*uint64'
       ByteSize: 8
       GoRuntimeType: 376512
       GoKind: 22
-      Pointee: 74 BaseType uint64
+      Pointee: 10 BaseType uint64
     - __kind: PointerType
       ID: 6
       Name: '*uint8'
       ByteSize: 8
       GoRuntimeType: 376128
       GoKind: 22
-      Pointee: 7 BaseType uint8
+      Pointee: 3 BaseType uint8
     - __kind: PointerType
-      ID: 185
+      ID: 8
       Name: '*uintptr'
       ByteSize: 8
       GoRuntimeType: 376704
       GoKind: 22
-      Pointee: 26 BaseType uintptr
+      Pointee: 1 BaseType uintptr
     - __kind: GoChannelType
-      ID: 111
+      ID: 133
       Name: <-chan struct {}
       GoRuntimeType: 555296
       GoKind: 18
@@ -716,7 +716,7 @@ Types:
         - Name: w
           Offset: 1
           Expression:
-            Type: 1 GoInterfaceType net/http.ResponseWriter
+            Type: 36 GoInterfaceType net/http.ResponseWriter
             Operations:
                 - __kind: LocationOp
                   Variable: {subprogram: 1, index: 0, name: w}
@@ -725,7 +725,7 @@ Types:
         - Name: r
           Offset: 17
           Expression:
-            Type: 3 PointerType *net/http.Request
+            Type: 37 PointerType *net/http.Request
             Operations:
                 - __kind: LocationOp
                   Variable: {subprogram: 1, index: 1, name: r}
@@ -740,23 +740,23 @@ Types:
         - Name: path
           Offset: 1
           Expression:
-            Type: 5 GoStringHeaderType string
+            Type: 11 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
                   Variable: {subprogram: 2, index: 0, name: path}
                   Offset: 0
                   ByteSize: 16
     - __kind: ArrayType
-      ID: 21
+      ID: 48
       Name: '[8]uint8'
       ByteSize: 8
       GoRuntimeType: 632608
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 7 BaseType uint8
+      Element: 3 BaseType uint8
     - __kind: GoSliceHeaderType
-      ID: 55
+      ID: 79
       Name: '[]*crypto/x509.Certificate'
       ByteSize: 24
       GoRuntimeType: 473760
@@ -764,21 +764,21 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 56 PointerType **crypto/x509.Certificate
+          Type: 80 PointerType **crypto/x509.Certificate
         - Name: len
           Offset: 8
-          Type: 8 BaseType int
+          Type: 9 BaseType int
         - Name: cap
           Offset: 16
-          Type: 8 BaseType int
+          Type: 9 BaseType int
       Data: 215 GoSliceDataType []*crypto/x509.Certificate.array
     - __kind: GoSliceDataType
       ID: 215
       Name: '[]*crypto/x509.Certificate.array'
       ByteSize: 2048
-      Element: 57 PointerType *crypto/x509.Certificate
+      Element: 81 PointerType *crypto/x509.Certificate
     - __kind: GoSliceHeaderType
-      ID: 173
+      ID: 193
       Name: '[]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span'
       ByteSize: 24
       GoRuntimeType: 463872
@@ -786,21 +786,21 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 174 PointerType **github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span
+          Type: 194 PointerType **github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span
         - Name: len
           Offset: 8
-          Type: 8 BaseType int
+          Type: 9 BaseType int
         - Name: cap
           Offset: 16
-          Type: 8 BaseType int
+          Type: 9 BaseType int
       Data: 261 GoSliceDataType []*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span.array
     - __kind: GoSliceDataType
       ID: 261
       Name: '[]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span.array'
       ByteSize: 2048
-      Element: 126 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span
+      Element: 148 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span
     - __kind: GoSliceHeaderType
-      ID: 163
+      ID: 183
       Name: '[]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttributeValue'
       ByteSize: 24
       GoRuntimeType: 463488
@@ -808,21 +808,21 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 164 PointerType **github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttributeValue
+          Type: 184 PointerType **github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttributeValue
         - Name: len
           Offset: 8
-          Type: 8 BaseType int
+          Type: 9 BaseType int
         - Name: cap
           Offset: 16
-          Type: 8 BaseType int
+          Type: 9 BaseType int
       Data: 259 GoSliceDataType []*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttributeValue.array
     - __kind: GoSliceDataType
       ID: 259
       Name: '[]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttributeValue.array'
       ByteSize: 2048
-      Element: 165 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttributeValue
+      Element: 185 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttributeValue
     - __kind: GoSliceHeaderType
-      ID: 47
+      ID: 71
       Name: '[]*mime/multipart.FileHeader'
       ByteSize: 24
       GoRuntimeType: 461504
@@ -830,21 +830,21 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 48 PointerType **mime/multipart.FileHeader
+          Type: 72 PointerType **mime/multipart.FileHeader
         - Name: len
           Offset: 8
-          Type: 8 BaseType int
+          Type: 9 BaseType int
         - Name: cap
           Offset: 16
-          Type: 8 BaseType int
+          Type: 9 BaseType int
       Data: 211 GoSliceDataType []*mime/multipart.FileHeader.array
     - __kind: GoSliceDataType
       ID: 211
       Name: '[]*mime/multipart.FileHeader.array'
       ByteSize: 2048
-      Element: 49 PointerType *mime/multipart.FileHeader
+      Element: 73 PointerType *mime/multipart.FileHeader
     - __kind: GoSliceHeaderType
-      ID: 97
+      ID: 119
       Name: '[]*net.IPNet'
       ByteSize: 24
       GoRuntimeType: 486816
@@ -852,21 +852,21 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 98 PointerType **net.IPNet
+          Type: 120 PointerType **net.IPNet
         - Name: len
           Offset: 8
-          Type: 8 BaseType int
+          Type: 9 BaseType int
         - Name: cap
           Offset: 16
-          Type: 8 BaseType int
+          Type: 9 BaseType int
       Data: 239 GoSliceDataType []*net.IPNet.array
     - __kind: GoSliceDataType
       ID: 239
       Name: '[]*net.IPNet.array'
       ByteSize: 2048
-      Element: 99 PointerType *net.IPNet
+      Element: 121 PointerType *net.IPNet
     - __kind: GoSliceHeaderType
-      ID: 95
+      ID: 117
       Name: '[]*net/url.URL'
       ByteSize: 24
       GoRuntimeType: 486752
@@ -874,21 +874,21 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 96 PointerType **net/url.URL
+          Type: 118 PointerType **net/url.URL
         - Name: len
           Offset: 8
-          Type: 8 BaseType int
+          Type: 9 BaseType int
         - Name: cap
           Offset: 16
-          Type: 8 BaseType int
+          Type: 9 BaseType int
       Data: 237 GoSliceDataType []*net/url.URL.array
     - __kind: GoSliceDataType
       ID: 237
       Name: '[]*net/url.URL.array'
       ByteSize: 2048
-      Element: 9 PointerType *net/url.URL
+      Element: 39 PointerType *net/url.URL
     - __kind: GoSliceHeaderType
-      ID: 30
+      ID: 55
       Name: '[]*runtime.bmap'
       ByteSize: 24
       GoRuntimeType: 470592
@@ -896,21 +896,21 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 31 PointerType **runtime.bmap
+          Type: 56 PointerType **runtime.bmap
         - Name: len
           Offset: 8
-          Type: 8 BaseType int
+          Type: 9 BaseType int
         - Name: cap
           Offset: 16
-          Type: 8 BaseType int
+          Type: 9 BaseType int
       Data: 208 GoSliceDataType []*runtime.bmap.array
     - __kind: GoSliceDataType
       ID: 208
       Name: '[]*runtime.bmap.array'
       ByteSize: 2048
-      Element: 32 PointerType *runtime.bmap
+      Element: 57 PointerType *runtime.bmap
     - __kind: GoSliceHeaderType
-      ID: 105
+      ID: 127
       Name: '[][]*crypto/x509.Certificate'
       ByteSize: 24
       GoRuntimeType: 473888
@@ -918,21 +918,21 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 106 PointerType *[]*crypto/x509.Certificate
+          Type: 128 PointerType *[]*crypto/x509.Certificate
         - Name: len
           Offset: 8
-          Type: 8 BaseType int
+          Type: 9 BaseType int
         - Name: cap
           Offset: 16
-          Type: 8 BaseType int
+          Type: 9 BaseType int
       Data: 245 GoSliceDataType [][]*crypto/x509.Certificate.array
     - __kind: GoSliceDataType
       ID: 245
       Name: '[][]*crypto/x509.Certificate.array'
       ByteSize: 2048
-      Element: 55 GoSliceHeaderType []*crypto/x509.Certificate
+      Element: 79 GoSliceHeaderType []*crypto/x509.Certificate
     - __kind: GoSliceHeaderType
-      ID: 107
+      ID: 129
       Name: '[][]uint8'
       ByteSize: 24
       GoRuntimeType: 457024
@@ -940,51 +940,51 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 108 PointerType *[]uint8
+          Type: 130 PointerType *[]uint8
         - Name: len
           Offset: 8
-          Type: 8 BaseType int
+          Type: 9 BaseType int
         - Name: cap
           Offset: 16
-          Type: 8 BaseType int
+          Type: 9 BaseType int
       Data: 247 GoSliceDataType [][]uint8.array
     - __kind: GoSliceDataType
       ID: 247
       Name: '[][]uint8.array'
       ByteSize: 2048
-      Element: 52 GoSliceHeaderType []uint8
+      Element: 76 GoSliceHeaderType []uint8
     - __kind: GoSliceDataType
       ID: 258
       Name: '[]bucket<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>.array'
       ByteSize: 2048
-      Element: 156 GoHMapBucketType bucket<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
+      Element: 176 GoHMapBucketType bucket<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
     - __kind: GoSliceDataType
       ID: 210
       Name: '[]bucket<string,[]*mime/multipart.FileHeader>.array'
       ByteSize: 2048
-      Element: 45 GoHMapBucketType bucket<string,[]*mime/multipart.FileHeader>
+      Element: 69 GoHMapBucketType bucket<string,[]*mime/multipart.FileHeader>
     - __kind: GoSliceDataType
       ID: 205
       Name: '[]bucket<string,[]string>.array'
       ByteSize: 2048
-      Element: 20 GoHMapBucketType bucket<string,[]string>
+      Element: 47 GoHMapBucketType bucket<string,[]string>
     - __kind: GoSliceDataType
       ID: 253
       Name: '[]bucket<string,float64>.array'
       ByteSize: 2048
-      Element: 143 GoHMapBucketType bucket<string,float64>
+      Element: 164 GoHMapBucketType bucket<string,float64>
     - __kind: GoSliceDataType
       ID: 252
       Name: '[]bucket<string,interface {}>.array'
       ByteSize: 2048
-      Element: 137 GoHMapBucketType bucket<string,interface {}>
+      Element: 158 GoHMapBucketType bucket<string,interface {}>
     - __kind: GoSliceDataType
       ID: 251
       Name: '[]bucket<string,string>.array'
       ByteSize: 2048
-      Element: 124 GoHMapBucketType bucket<string,string>
+      Element: 146 GoHMapBucketType bucket<string,string>
     - __kind: GoSliceHeaderType
-      ID: 89
+      ID: 111
       Name: '[]crypto/x509.ExtKeyUsage'
       ByteSize: 24
       GoRuntimeType: 475040
@@ -992,21 +992,21 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 90 PointerType *crypto/x509.ExtKeyUsage
+          Type: 112 PointerType *crypto/x509.ExtKeyUsage
         - Name: len
           Offset: 8
-          Type: 8 BaseType int
+          Type: 9 BaseType int
         - Name: cap
           Offset: 16
-          Type: 8 BaseType int
+          Type: 9 BaseType int
       Data: 231 GoSliceDataType []crypto/x509.ExtKeyUsage.array
     - __kind: GoSliceDataType
       ID: 231
       Name: '[]crypto/x509.ExtKeyUsage.array'
       ByteSize: 2048
-      Element: 91 BaseType crypto/x509.ExtKeyUsage
+      Element: 113 BaseType crypto/x509.ExtKeyUsage
     - __kind: GoSliceHeaderType
-      ID: 102
+      ID: 124
       Name: '[]crypto/x509.OID'
       ByteSize: 24
       GoRuntimeType: 486880
@@ -1014,21 +1014,21 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 103 PointerType *crypto/x509.OID
+          Type: 125 PointerType *crypto/x509.OID
         - Name: len
           Offset: 8
-          Type: 8 BaseType int
+          Type: 9 BaseType int
         - Name: cap
           Offset: 16
-          Type: 8 BaseType int
+          Type: 9 BaseType int
       Data: 243 GoSliceDataType []crypto/x509.OID.array
     - __kind: GoSliceDataType
       ID: 243
       Name: '[]crypto/x509.OID.array'
       ByteSize: 2048
-      Element: 104 StructureType crypto/x509.OID
+      Element: 126 StructureType crypto/x509.OID
     - __kind: GoSliceHeaderType
-      ID: 68
+      ID: 92
       Name: '[]crypto/x509/pkix.AttributeTypeAndValue'
       ByteSize: 24
       GoRuntimeType: 487136
@@ -1036,21 +1036,21 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 69 PointerType *crypto/x509/pkix.AttributeTypeAndValue
+          Type: 93 PointerType *crypto/x509/pkix.AttributeTypeAndValue
         - Name: len
           Offset: 8
-          Type: 8 BaseType int
+          Type: 9 BaseType int
         - Name: cap
           Offset: 16
-          Type: 8 BaseType int
+          Type: 9 BaseType int
       Data: 219 GoSliceDataType []crypto/x509/pkix.AttributeTypeAndValue.array
     - __kind: GoSliceDataType
       ID: 219
       Name: '[]crypto/x509/pkix.AttributeTypeAndValue.array'
       ByteSize: 2048
-      Element: 70 StructureType crypto/x509/pkix.AttributeTypeAndValue
+      Element: 94 StructureType crypto/x509/pkix.AttributeTypeAndValue
     - __kind: GoSliceHeaderType
-      ID: 84
+      ID: 106
       Name: '[]crypto/x509/pkix.Extension'
       ByteSize: 24
       GoRuntimeType: 486624
@@ -1058,21 +1058,21 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 85 PointerType *crypto/x509/pkix.Extension
+          Type: 107 PointerType *crypto/x509/pkix.Extension
         - Name: len
           Offset: 8
-          Type: 8 BaseType int
+          Type: 9 BaseType int
         - Name: cap
           Offset: 16
-          Type: 8 BaseType int
+          Type: 9 BaseType int
       Data: 227 GoSliceDataType []crypto/x509/pkix.Extension.array
     - __kind: GoSliceDataType
       ID: 227
       Name: '[]crypto/x509/pkix.Extension.array'
       ByteSize: 2048
-      Element: 86 StructureType crypto/x509/pkix.Extension
+      Element: 108 StructureType crypto/x509/pkix.Extension
     - __kind: GoSliceHeaderType
-      ID: 87
+      ID: 109
       Name: '[]encoding/asn1.ObjectIdentifier'
       ByteSize: 24
       GoRuntimeType: 486688
@@ -1080,21 +1080,21 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 88 PointerType *encoding/asn1.ObjectIdentifier
+          Type: 110 PointerType *encoding/asn1.ObjectIdentifier
         - Name: len
           Offset: 8
-          Type: 8 BaseType int
+          Type: 9 BaseType int
         - Name: cap
           Offset: 16
-          Type: 8 BaseType int
+          Type: 9 BaseType int
       Data: 229 GoSliceDataType []encoding/asn1.ObjectIdentifier.array
     - __kind: GoSliceDataType
       ID: 229
       Name: '[]encoding/asn1.ObjectIdentifier.array'
       ByteSize: 2048
-      Element: 71 GoSliceHeaderType encoding/asn1.ObjectIdentifier
+      Element: 95 GoSliceHeaderType encoding/asn1.ObjectIdentifier
     - __kind: GoSliceHeaderType
-      ID: 146
+      ID: 166
       Name: '[]github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink'
       ByteSize: 24
       GoRuntimeType: 463424
@@ -1102,21 +1102,21 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 147 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink
+          Type: 167 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink
         - Name: len
           Offset: 8
-          Type: 8 BaseType int
+          Type: 9 BaseType int
         - Name: cap
           Offset: 16
-          Type: 8 BaseType int
+          Type: 9 BaseType int
       Data: 254 GoSliceDataType []github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink.array
     - __kind: GoSliceDataType
       ID: 254
       Name: '[]github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink.array'
       ByteSize: 2048
-      Element: 148 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink
+      Element: 168 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink
     - __kind: GoSliceHeaderType
-      ID: 149
+      ID: 169
       Name: '[]github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent'
       ByteSize: 24
       GoRuntimeType: 463616
@@ -1124,28 +1124,28 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 150 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent
+          Type: 170 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent
         - Name: len
           Offset: 8
-          Type: 8 BaseType int
+          Type: 9 BaseType int
         - Name: cap
           Offset: 16
-          Type: 8 BaseType int
+          Type: 9 BaseType int
       Data: 256 GoSliceDataType []github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent.array
     - __kind: GoSliceDataType
       ID: 256
       Name: '[]github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent.array'
       ByteSize: 2048
-      Element: 151 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent
+      Element: 171 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent
     - __kind: ArrayType
-      ID: 22
+      ID: 49
       Name: '[]key<string>'
       ByteSize: 128
       Count: 8
       HasCount: true
-      Element: 5 GoStringHeaderType string
+      Element: 11 GoStringHeaderType string
     - __kind: GoSliceHeaderType
-      ID: 92
+      ID: 114
       Name: '[]net.IP'
       ByteSize: 24
       GoRuntimeType: 458240
@@ -1153,21 +1153,21 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 93 PointerType *net.IP
+          Type: 115 PointerType *net.IP
         - Name: len
           Offset: 8
-          Type: 8 BaseType int
+          Type: 9 BaseType int
         - Name: cap
           Offset: 16
-          Type: 8 BaseType int
+          Type: 9 BaseType int
       Data: 233 GoSliceDataType []net.IP.array
     - __kind: GoSliceDataType
       ID: 233
       Name: '[]net.IP.array'
       ByteSize: 2048
-      Element: 94 GoSliceHeaderType net.IP
+      Element: 116 GoSliceHeaderType net.IP
     - __kind: GoSliceHeaderType
-      ID: 117
+      ID: 139
       Name: '[]net/http.segment'
       ByteSize: 24
       GoRuntimeType: 459008
@@ -1175,21 +1175,21 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 118 PointerType *net/http.segment
+          Type: 140 PointerType *net/http.segment
         - Name: len
           Offset: 8
-          Type: 8 BaseType int
+          Type: 9 BaseType int
         - Name: cap
           Offset: 16
-          Type: 8 BaseType int
+          Type: 9 BaseType int
       Data: 249 GoSliceDataType []net/http.segment.array
     - __kind: GoSliceDataType
       ID: 249
       Name: '[]net/http.segment.array'
       ByteSize: 2048
-      Element: 119 StructureType net/http.segment
+      Element: 141 StructureType net/http.segment
     - __kind: GoSliceHeaderType
-      ID: 24
+      ID: 51
       Name: '[]string'
       ByteSize: 24
       GoRuntimeType: 468992
@@ -1197,21 +1197,21 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 25 PointerType *string
+          Type: 22 PointerType *string
         - Name: len
           Offset: 8
-          Type: 8 BaseType int
+          Type: 9 BaseType int
         - Name: cap
           Offset: 16
-          Type: 8 BaseType int
+          Type: 9 BaseType int
       Data: 206 GoSliceDataType []string.array
     - __kind: GoSliceDataType
       ID: 206
       Name: '[]string.array'
       ByteSize: 2048
-      Element: 5 GoStringHeaderType string
+      Element: 11 GoStringHeaderType string
     - __kind: GoSliceHeaderType
-      ID: 77
+      ID: 99
       Name: '[]time.zone'
       ByteSize: 24
       GoRuntimeType: 463104
@@ -1219,21 +1219,21 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 78 PointerType *time.zone
+          Type: 100 PointerType *time.zone
         - Name: len
           Offset: 8
-          Type: 8 BaseType int
+          Type: 9 BaseType int
         - Name: cap
           Offset: 16
-          Type: 8 BaseType int
+          Type: 9 BaseType int
       Data: 223 GoSliceDataType []time.zone.array
     - __kind: GoSliceDataType
       ID: 223
       Name: '[]time.zone.array'
       ByteSize: 2048
-      Element: 79 StructureType time.zone
+      Element: 101 StructureType time.zone
     - __kind: GoSliceHeaderType
-      ID: 80
+      ID: 102
       Name: '[]time.zoneTrans'
       ByteSize: 24
       GoRuntimeType: 463168
@@ -1241,21 +1241,21 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 81 PointerType *time.zoneTrans
+          Type: 103 PointerType *time.zoneTrans
         - Name: len
           Offset: 8
-          Type: 8 BaseType int
+          Type: 9 BaseType int
         - Name: cap
           Offset: 16
-          Type: 8 BaseType int
+          Type: 9 BaseType int
       Data: 225 GoSliceDataType []time.zoneTrans.array
     - __kind: GoSliceDataType
       ID: 225
       Name: '[]time.zoneTrans.array'
       ByteSize: 2048
-      Element: 82 StructureType time.zoneTrans
+      Element: 104 StructureType time.zoneTrans
     - __kind: GoSliceHeaderType
-      ID: 52
+      ID: 76
       Name: '[]uint8'
       ByteSize: 24
       GoRuntimeType: 467840
@@ -1266,180 +1266,180 @@ Types:
           Type: 6 PointerType *uint8
         - Name: len
           Offset: 8
-          Type: 8 BaseType int
+          Type: 9 BaseType int
         - Name: cap
           Offset: 16
-          Type: 8 BaseType int
+          Type: 9 BaseType int
       Data: 213 GoSliceDataType []uint8.array
     - __kind: GoSliceDataType
       ID: 213
       Name: '[]uint8.array'
       ByteSize: 2048
-      Element: 7 BaseType uint8
+      Element: 3 BaseType uint8
     - __kind: ArrayType
-      ID: 157
+      ID: 177
       Name: '[]val<*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>'
       ByteSize: 64
       Count: 8
       HasCount: true
-      Element: 158 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
+      Element: 178 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
     - __kind: ArrayType
-      ID: 46
+      ID: 70
       Name: '[]val<[]*mime/multipart.FileHeader>'
       ByteSize: 192
       Count: 8
       HasCount: true
-      Element: 47 GoSliceHeaderType []*mime/multipart.FileHeader
+      Element: 71 GoSliceHeaderType []*mime/multipart.FileHeader
     - __kind: ArrayType
-      ID: 23
+      ID: 50
       Name: '[]val<[]string>'
       ByteSize: 192
       Count: 8
       HasCount: true
-      Element: 24 GoSliceHeaderType []string
+      Element: 51 GoSliceHeaderType []string
     - __kind: ArrayType
-      ID: 144
+      ID: 165
       Name: '[]val<float64>'
       ByteSize: 64
       Count: 8
       HasCount: true
-      Element: 145 BaseType float64
+      Element: 17 BaseType float64
     - __kind: ArrayType
-      ID: 138
+      ID: 159
       Name: '[]val<interface {}>'
       ByteSize: 128
       Count: 8
       HasCount: true
-      Element: 61 GoEmptyInterfaceType interface {}
+      Element: 85 GoEmptyInterfaceType interface {}
     - __kind: ArrayType
-      ID: 125
+      ID: 147
       Name: '[]val<string>'
       ByteSize: 128
       Count: 8
       HasCount: true
-      Element: 5 GoStringHeaderType string
+      Element: 11 GoStringHeaderType string
     - __kind: BaseType
-      ID: 13
+      ID: 4
       Name: bool
       ByteSize: 1
       GoRuntimeType: 543328
       GoKind: 1
     - __kind: GoHMapBucketType
-      ID: 156
+      ID: 176
       Name: bucket<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
       ByteSize: 208
       RawFields:
         - Name: tophash
           Offset: 0
-          Type: 21 ArrayType [8]uint8
+          Type: 48 ArrayType [8]uint8
         - Name: keys
           Offset: 8
-          Type: 22 ArrayType []key<string>
+          Type: 49 ArrayType []key<string>
         - Name: values
           Offset: 136
-          Type: 157 ArrayType []val<*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
+          Type: 177 ArrayType []val<*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
         - Name: overflow
           Offset: 200
-          Type: 155 PointerType *bucket<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
-      KeyType: 5 GoStringHeaderType string
-      ValueType: 158 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
+          Type: 175 PointerType *bucket<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
+      KeyType: 11 GoStringHeaderType string
+      ValueType: 178 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
     - __kind: GoHMapBucketType
-      ID: 45
+      ID: 69
       Name: bucket<string,[]*mime/multipart.FileHeader>
       ByteSize: 336
       RawFields:
         - Name: tophash
           Offset: 0
-          Type: 21 ArrayType [8]uint8
+          Type: 48 ArrayType [8]uint8
         - Name: keys
           Offset: 8
-          Type: 22 ArrayType []key<string>
+          Type: 49 ArrayType []key<string>
         - Name: values
           Offset: 136
-          Type: 46 ArrayType []val<[]*mime/multipart.FileHeader>
+          Type: 70 ArrayType []val<[]*mime/multipart.FileHeader>
         - Name: overflow
           Offset: 328
-          Type: 44 PointerType *bucket<string,[]*mime/multipart.FileHeader>
-      KeyType: 5 GoStringHeaderType string
-      ValueType: 47 GoSliceHeaderType []*mime/multipart.FileHeader
+          Type: 68 PointerType *bucket<string,[]*mime/multipart.FileHeader>
+      KeyType: 11 GoStringHeaderType string
+      ValueType: 71 GoSliceHeaderType []*mime/multipart.FileHeader
     - __kind: GoHMapBucketType
-      ID: 20
+      ID: 47
       Name: bucket<string,[]string>
       ByteSize: 336
       RawFields:
         - Name: tophash
           Offset: 0
-          Type: 21 ArrayType [8]uint8
+          Type: 48 ArrayType [8]uint8
         - Name: keys
           Offset: 8
-          Type: 22 ArrayType []key<string>
+          Type: 49 ArrayType []key<string>
         - Name: values
           Offset: 136
-          Type: 23 ArrayType []val<[]string>
+          Type: 50 ArrayType []val<[]string>
         - Name: overflow
           Offset: 328
-          Type: 19 PointerType *bucket<string,[]string>
-      KeyType: 5 GoStringHeaderType string
-      ValueType: 24 GoSliceHeaderType []string
+          Type: 46 PointerType *bucket<string,[]string>
+      KeyType: 11 GoStringHeaderType string
+      ValueType: 51 GoSliceHeaderType []string
     - __kind: GoHMapBucketType
-      ID: 143
+      ID: 164
       Name: bucket<string,float64>
       ByteSize: 208
       RawFields:
         - Name: tophash
           Offset: 0
-          Type: 21 ArrayType [8]uint8
+          Type: 48 ArrayType [8]uint8
         - Name: keys
           Offset: 8
-          Type: 22 ArrayType []key<string>
+          Type: 49 ArrayType []key<string>
         - Name: values
           Offset: 136
-          Type: 144 ArrayType []val<float64>
+          Type: 165 ArrayType []val<float64>
         - Name: overflow
           Offset: 200
-          Type: 142 PointerType *bucket<string,float64>
-      KeyType: 5 GoStringHeaderType string
-      ValueType: 145 BaseType float64
+          Type: 163 PointerType *bucket<string,float64>
+      KeyType: 11 GoStringHeaderType string
+      ValueType: 17 BaseType float64
     - __kind: GoHMapBucketType
-      ID: 137
+      ID: 158
       Name: bucket<string,interface {}>
       ByteSize: 272
       RawFields:
         - Name: tophash
           Offset: 0
-          Type: 21 ArrayType [8]uint8
+          Type: 48 ArrayType [8]uint8
         - Name: keys
           Offset: 8
-          Type: 22 ArrayType []key<string>
+          Type: 49 ArrayType []key<string>
         - Name: values
           Offset: 136
-          Type: 138 ArrayType []val<interface {}>
+          Type: 159 ArrayType []val<interface {}>
         - Name: overflow
           Offset: 264
-          Type: 136 PointerType *bucket<string,interface {}>
-      KeyType: 5 GoStringHeaderType string
-      ValueType: 61 GoEmptyInterfaceType interface {}
+          Type: 157 PointerType *bucket<string,interface {}>
+      KeyType: 11 GoStringHeaderType string
+      ValueType: 85 GoEmptyInterfaceType interface {}
     - __kind: GoHMapBucketType
-      ID: 124
+      ID: 146
       Name: bucket<string,string>
       ByteSize: 272
       RawFields:
         - Name: tophash
           Offset: 0
-          Type: 21 ArrayType [8]uint8
+          Type: 48 ArrayType [8]uint8
         - Name: keys
           Offset: 8
-          Type: 22 ArrayType []key<string>
+          Type: 49 ArrayType []key<string>
         - Name: values
           Offset: 136
-          Type: 125 ArrayType []val<string>
+          Type: 147 ArrayType []val<string>
         - Name: overflow
           Offset: 264
-          Type: 123 PointerType *bucket<string,string>
-      KeyType: 5 GoStringHeaderType string
-      ValueType: 5 GoStringHeaderType string
+          Type: 145 PointerType *bucket<string,string>
+      KeyType: 11 GoStringHeaderType string
+      ValueType: 11 GoStringHeaderType string
     - __kind: StructureType
-      ID: 180
+      ID: 199
       Name: bytes.Buffer
       ByteSize: 40
       GoRuntimeType: 1.450816e+06
@@ -1447,33 +1447,33 @@ Types:
       RawFields:
         - Name: buf
           Offset: 0
-          Type: 52 GoSliceHeaderType []uint8
+          Type: 76 GoSliceHeaderType []uint8
         - Name: off
           Offset: 24
-          Type: 8 BaseType int
+          Type: 9 BaseType int
         - Name: lastRead
           Offset: 32
-          Type: 181 BaseType bytes.readOp
+          Type: 200 BaseType bytes.readOp
     - __kind: BaseType
-      ID: 181
+      ID: 200
       Name: bytes.readOp
       ByteSize: 1
       GoRuntimeType: 541536
       GoKind: 3
     - __kind: BaseType
-      ID: 193
+      ID: 24
       Name: complex128
       ByteSize: 16
       GoRuntimeType: 543136
       GoKind: 16
     - __kind: BaseType
-      ID: 192
+      ID: 23
       Name: complex64
       ByteSize: 8
       GoRuntimeType: 543072
       GoKind: 15
     - __kind: GoInterfaceType
-      ID: 114
+      ID: 136
       Name: context.Context
       ByteSize: 16
       GoRuntimeType: 1.215552e+06
@@ -1481,27 +1481,27 @@ Types:
       RawFields:
         - Name: tab
           Offset: 0
-          Type: 2 VoidPointerType unsafe.Pointer
+          Type: 19 VoidPointerType unsafe.Pointer
         - Name: data
           Offset: 8
-          Type: 2 VoidPointerType unsafe.Pointer
+          Type: 19 VoidPointerType unsafe.Pointer
     - __kind: StructureType
-      ID: 182
+      ID: 201
       Name: context.backgroundCtx
       GoRuntimeType: 1.708256e+06
       GoKind: 25
       RawFields:
         - Name: emptyCtx
           Offset: 0
-          Type: 183 StructureType context.emptyCtx
+          Type: 202 StructureType context.emptyCtx
     - __kind: StructureType
-      ID: 183
+      ID: 202
       Name: context.emptyCtx
       GoRuntimeType: 1.43472e+06
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 54
+      ID: 78
       Name: crypto/tls.ConnectionState
       ByteSize: 192
       GoRuntimeType: 2.160384e+06
@@ -1509,60 +1509,60 @@ Types:
       RawFields:
         - Name: Version
           Offset: 0
-          Type: 17 BaseType uint16
+          Type: 7 BaseType uint16
         - Name: HandshakeComplete
           Offset: 2
-          Type: 13 BaseType bool
+          Type: 4 BaseType bool
         - Name: DidResume
           Offset: 3
-          Type: 13 BaseType bool
+          Type: 4 BaseType bool
         - Name: CipherSuite
           Offset: 4
-          Type: 17 BaseType uint16
+          Type: 7 BaseType uint16
         - Name: NegotiatedProtocol
           Offset: 8
-          Type: 5 GoStringHeaderType string
+          Type: 11 GoStringHeaderType string
         - Name: NegotiatedProtocolIsMutual
           Offset: 24
-          Type: 13 BaseType bool
+          Type: 4 BaseType bool
         - Name: ServerName
           Offset: 32
-          Type: 5 GoStringHeaderType string
+          Type: 11 GoStringHeaderType string
         - Name: PeerCertificates
           Offset: 48
-          Type: 55 GoSliceHeaderType []*crypto/x509.Certificate
+          Type: 79 GoSliceHeaderType []*crypto/x509.Certificate
         - Name: VerifiedChains
           Offset: 72
-          Type: 105 GoSliceHeaderType [][]*crypto/x509.Certificate
+          Type: 127 GoSliceHeaderType [][]*crypto/x509.Certificate
         - Name: SignedCertificateTimestamps
           Offset: 96
-          Type: 107 GoSliceHeaderType [][]uint8
+          Type: 129 GoSliceHeaderType [][]uint8
         - Name: OCSPResponse
           Offset: 120
-          Type: 52 GoSliceHeaderType []uint8
+          Type: 76 GoSliceHeaderType []uint8
         - Name: TLSUnique
           Offset: 144
-          Type: 52 GoSliceHeaderType []uint8
+          Type: 76 GoSliceHeaderType []uint8
         - Name: ECHAccepted
           Offset: 168
-          Type: 13 BaseType bool
+          Type: 4 BaseType bool
         - Name: ekm
           Offset: 176
-          Type: 109 GoSubroutineType func(string, []uint8, int) ([]uint8, error)
+          Type: 131 GoSubroutineType func(string, []uint8, int) ([]uint8, error)
         - Name: testingOnlyDidHRR
           Offset: 184
-          Type: 13 BaseType bool
+          Type: 4 BaseType bool
         - Name: testingOnlyCurveID
           Offset: 186
-          Type: 110 BaseType crypto/tls.CurveID
+          Type: 132 BaseType crypto/tls.CurveID
     - __kind: BaseType
-      ID: 110
+      ID: 132
       Name: crypto/tls.CurveID
       ByteSize: 2
       GoRuntimeType: 778464
       GoKind: 9
     - __kind: StructureType
-      ID: 58
+      ID: 82
       Name: crypto/x509.Certificate
       ByteSize: 1352
       GoRuntimeType: 2.300416e+06
@@ -1570,153 +1570,153 @@ Types:
       RawFields:
         - Name: Raw
           Offset: 0
-          Type: 52 GoSliceHeaderType []uint8
+          Type: 76 GoSliceHeaderType []uint8
         - Name: RawTBSCertificate
           Offset: 24
-          Type: 52 GoSliceHeaderType []uint8
+          Type: 76 GoSliceHeaderType []uint8
         - Name: RawSubjectPublicKeyInfo
           Offset: 48
-          Type: 52 GoSliceHeaderType []uint8
+          Type: 76 GoSliceHeaderType []uint8
         - Name: RawSubject
           Offset: 72
-          Type: 52 GoSliceHeaderType []uint8
+          Type: 76 GoSliceHeaderType []uint8
         - Name: RawIssuer
           Offset: 96
-          Type: 52 GoSliceHeaderType []uint8
+          Type: 76 GoSliceHeaderType []uint8
         - Name: Signature
           Offset: 120
-          Type: 52 GoSliceHeaderType []uint8
+          Type: 76 GoSliceHeaderType []uint8
         - Name: SignatureAlgorithm
           Offset: 144
-          Type: 59 BaseType crypto/x509.SignatureAlgorithm
+          Type: 83 BaseType crypto/x509.SignatureAlgorithm
         - Name: PublicKeyAlgorithm
           Offset: 152
-          Type: 60 BaseType crypto/x509.PublicKeyAlgorithm
+          Type: 84 BaseType crypto/x509.PublicKeyAlgorithm
         - Name: PublicKey
           Offset: 160
-          Type: 61 GoEmptyInterfaceType interface {}
+          Type: 85 GoEmptyInterfaceType interface {}
         - Name: Version
           Offset: 176
-          Type: 8 BaseType int
+          Type: 9 BaseType int
         - Name: SerialNumber
           Offset: 184
-          Type: 62 PointerType *math/big.Int
+          Type: 86 PointerType *math/big.Int
         - Name: Issuer
           Offset: 192
-          Type: 67 StructureType crypto/x509/pkix.Name
+          Type: 91 StructureType crypto/x509/pkix.Name
         - Name: Subject
           Offset: 440
-          Type: 67 StructureType crypto/x509/pkix.Name
+          Type: 91 StructureType crypto/x509/pkix.Name
         - Name: NotBefore
           Offset: 688
-          Type: 73 StructureType time.Time
+          Type: 96 StructureType time.Time
         - Name: NotAfter
           Offset: 712
-          Type: 73 StructureType time.Time
+          Type: 96 StructureType time.Time
         - Name: KeyUsage
           Offset: 736
-          Type: 83 BaseType crypto/x509.KeyUsage
+          Type: 105 BaseType crypto/x509.KeyUsage
         - Name: Extensions
           Offset: 744
-          Type: 84 GoSliceHeaderType []crypto/x509/pkix.Extension
+          Type: 106 GoSliceHeaderType []crypto/x509/pkix.Extension
         - Name: ExtraExtensions
           Offset: 768
-          Type: 84 GoSliceHeaderType []crypto/x509/pkix.Extension
+          Type: 106 GoSliceHeaderType []crypto/x509/pkix.Extension
         - Name: UnhandledCriticalExtensions
           Offset: 792
-          Type: 87 GoSliceHeaderType []encoding/asn1.ObjectIdentifier
+          Type: 109 GoSliceHeaderType []encoding/asn1.ObjectIdentifier
         - Name: ExtKeyUsage
           Offset: 816
-          Type: 89 GoSliceHeaderType []crypto/x509.ExtKeyUsage
+          Type: 111 GoSliceHeaderType []crypto/x509.ExtKeyUsage
         - Name: UnknownExtKeyUsage
           Offset: 840
-          Type: 87 GoSliceHeaderType []encoding/asn1.ObjectIdentifier
+          Type: 109 GoSliceHeaderType []encoding/asn1.ObjectIdentifier
         - Name: BasicConstraintsValid
           Offset: 864
-          Type: 13 BaseType bool
+          Type: 4 BaseType bool
         - Name: IsCA
           Offset: 865
-          Type: 13 BaseType bool
+          Type: 4 BaseType bool
         - Name: MaxPathLen
           Offset: 872
-          Type: 8 BaseType int
+          Type: 9 BaseType int
         - Name: MaxPathLenZero
           Offset: 880
-          Type: 13 BaseType bool
+          Type: 4 BaseType bool
         - Name: SubjectKeyId
           Offset: 888
-          Type: 52 GoSliceHeaderType []uint8
+          Type: 76 GoSliceHeaderType []uint8
         - Name: AuthorityKeyId
           Offset: 912
-          Type: 52 GoSliceHeaderType []uint8
+          Type: 76 GoSliceHeaderType []uint8
         - Name: OCSPServer
           Offset: 936
-          Type: 24 GoSliceHeaderType []string
+          Type: 51 GoSliceHeaderType []string
         - Name: IssuingCertificateURL
           Offset: 960
-          Type: 24 GoSliceHeaderType []string
+          Type: 51 GoSliceHeaderType []string
         - Name: DNSNames
           Offset: 984
-          Type: 24 GoSliceHeaderType []string
+          Type: 51 GoSliceHeaderType []string
         - Name: EmailAddresses
           Offset: 1008
-          Type: 24 GoSliceHeaderType []string
+          Type: 51 GoSliceHeaderType []string
         - Name: IPAddresses
           Offset: 1032
-          Type: 92 GoSliceHeaderType []net.IP
+          Type: 114 GoSliceHeaderType []net.IP
         - Name: URIs
           Offset: 1056
-          Type: 95 GoSliceHeaderType []*net/url.URL
+          Type: 117 GoSliceHeaderType []*net/url.URL
         - Name: PermittedDNSDomainsCritical
           Offset: 1080
-          Type: 13 BaseType bool
+          Type: 4 BaseType bool
         - Name: PermittedDNSDomains
           Offset: 1088
-          Type: 24 GoSliceHeaderType []string
+          Type: 51 GoSliceHeaderType []string
         - Name: ExcludedDNSDomains
           Offset: 1112
-          Type: 24 GoSliceHeaderType []string
+          Type: 51 GoSliceHeaderType []string
         - Name: PermittedIPRanges
           Offset: 1136
-          Type: 97 GoSliceHeaderType []*net.IPNet
+          Type: 119 GoSliceHeaderType []*net.IPNet
         - Name: ExcludedIPRanges
           Offset: 1160
-          Type: 97 GoSliceHeaderType []*net.IPNet
+          Type: 119 GoSliceHeaderType []*net.IPNet
         - Name: PermittedEmailAddresses
           Offset: 1184
-          Type: 24 GoSliceHeaderType []string
+          Type: 51 GoSliceHeaderType []string
         - Name: ExcludedEmailAddresses
           Offset: 1208
-          Type: 24 GoSliceHeaderType []string
+          Type: 51 GoSliceHeaderType []string
         - Name: PermittedURIDomains
           Offset: 1232
-          Type: 24 GoSliceHeaderType []string
+          Type: 51 GoSliceHeaderType []string
         - Name: ExcludedURIDomains
           Offset: 1256
-          Type: 24 GoSliceHeaderType []string
+          Type: 51 GoSliceHeaderType []string
         - Name: CRLDistributionPoints
           Offset: 1280
-          Type: 24 GoSliceHeaderType []string
+          Type: 51 GoSliceHeaderType []string
         - Name: PolicyIdentifiers
           Offset: 1304
-          Type: 87 GoSliceHeaderType []encoding/asn1.ObjectIdentifier
+          Type: 109 GoSliceHeaderType []encoding/asn1.ObjectIdentifier
         - Name: Policies
           Offset: 1328
-          Type: 102 GoSliceHeaderType []crypto/x509.OID
+          Type: 124 GoSliceHeaderType []crypto/x509.OID
     - __kind: BaseType
-      ID: 91
+      ID: 113
       Name: crypto/x509.ExtKeyUsage
       ByteSize: 8
       GoRuntimeType: 546400
       GoKind: 2
     - __kind: BaseType
-      ID: 83
+      ID: 105
       Name: crypto/x509.KeyUsage
       ByteSize: 8
       GoRuntimeType: 546336
       GoKind: 2
     - __kind: StructureType
-      ID: 104
+      ID: 126
       Name: crypto/x509.OID
       ByteSize: 24
       GoRuntimeType: 1.762016e+06
@@ -1724,21 +1724,21 @@ Types:
       RawFields:
         - Name: der
           Offset: 0
-          Type: 52 GoSliceHeaderType []uint8
+          Type: 76 GoSliceHeaderType []uint8
     - __kind: BaseType
-      ID: 60
+      ID: 84
       Name: crypto/x509.PublicKeyAlgorithm
       ByteSize: 8
       GoRuntimeType: 780768
       GoKind: 2
     - __kind: BaseType
-      ID: 59
+      ID: 83
       Name: crypto/x509.SignatureAlgorithm
       ByteSize: 8
       GoRuntimeType: 1.097216e+06
       GoKind: 2
     - __kind: StructureType
-      ID: 70
+      ID: 94
       Name: crypto/x509/pkix.AttributeTypeAndValue
       ByteSize: 40
       GoRuntimeType: 1.349024e+06
@@ -1746,12 +1746,12 @@ Types:
       RawFields:
         - Name: Type
           Offset: 0
-          Type: 71 GoSliceHeaderType encoding/asn1.ObjectIdentifier
+          Type: 95 GoSliceHeaderType encoding/asn1.ObjectIdentifier
         - Name: Value
           Offset: 24
-          Type: 61 GoEmptyInterfaceType interface {}
+          Type: 85 GoEmptyInterfaceType interface {}
     - __kind: StructureType
-      ID: 86
+      ID: 108
       Name: crypto/x509/pkix.Extension
       ByteSize: 56
       GoRuntimeType: 1.494592e+06
@@ -1759,15 +1759,15 @@ Types:
       RawFields:
         - Name: Id
           Offset: 0
-          Type: 71 GoSliceHeaderType encoding/asn1.ObjectIdentifier
+          Type: 95 GoSliceHeaderType encoding/asn1.ObjectIdentifier
         - Name: Critical
           Offset: 24
-          Type: 13 BaseType bool
+          Type: 4 BaseType bool
         - Name: Value
           Offset: 32
-          Type: 52 GoSliceHeaderType []uint8
+          Type: 76 GoSliceHeaderType []uint8
     - __kind: StructureType
-      ID: 67
+      ID: 91
       Name: crypto/x509/pkix.Name
       ByteSize: 248
       GoRuntimeType: 2.10512e+06
@@ -1775,39 +1775,39 @@ Types:
       RawFields:
         - Name: Country
           Offset: 0
-          Type: 24 GoSliceHeaderType []string
+          Type: 51 GoSliceHeaderType []string
         - Name: Organization
           Offset: 24
-          Type: 24 GoSliceHeaderType []string
+          Type: 51 GoSliceHeaderType []string
         - Name: OrganizationalUnit
           Offset: 48
-          Type: 24 GoSliceHeaderType []string
+          Type: 51 GoSliceHeaderType []string
         - Name: Locality
           Offset: 72
-          Type: 24 GoSliceHeaderType []string
+          Type: 51 GoSliceHeaderType []string
         - Name: Province
           Offset: 96
-          Type: 24 GoSliceHeaderType []string
+          Type: 51 GoSliceHeaderType []string
         - Name: StreetAddress
           Offset: 120
-          Type: 24 GoSliceHeaderType []string
+          Type: 51 GoSliceHeaderType []string
         - Name: PostalCode
           Offset: 144
-          Type: 24 GoSliceHeaderType []string
+          Type: 51 GoSliceHeaderType []string
         - Name: SerialNumber
           Offset: 168
-          Type: 5 GoStringHeaderType string
+          Type: 11 GoStringHeaderType string
         - Name: CommonName
           Offset: 184
-          Type: 5 GoStringHeaderType string
+          Type: 11 GoStringHeaderType string
         - Name: Names
           Offset: 200
-          Type: 68 GoSliceHeaderType []crypto/x509/pkix.AttributeTypeAndValue
+          Type: 92 GoSliceHeaderType []crypto/x509/pkix.AttributeTypeAndValue
         - Name: ExtraNames
           Offset: 224
-          Type: 68 GoSliceHeaderType []crypto/x509/pkix.AttributeTypeAndValue
+          Type: 92 GoSliceHeaderType []crypto/x509/pkix.AttributeTypeAndValue
     - __kind: GoSliceHeaderType
-      ID: 71
+      ID: 95
       Name: encoding/asn1.ObjectIdentifier
       ByteSize: 24
       GoRuntimeType: 1.037376e+06
@@ -1815,21 +1815,21 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 72 PointerType *int
+          Type: 27 PointerType *int
         - Name: len
           Offset: 8
-          Type: 8 BaseType int
+          Type: 9 BaseType int
         - Name: cap
           Offset: 16
-          Type: 8 BaseType int
+          Type: 9 BaseType int
       Data: 221 GoSliceDataType encoding/asn1.ObjectIdentifier.array
     - __kind: GoSliceDataType
       ID: 221
       Name: encoding/asn1.ObjectIdentifier.array
       ByteSize: 2048
-      Element: 8 BaseType int
+      Element: 9 BaseType int
     - __kind: GoInterfaceType
-      ID: 189
+      ID: 18
       Name: error
       ByteSize: 16
       GoRuntimeType: 1.01088e+06
@@ -1837,42 +1837,42 @@ Types:
       RawFields:
         - Name: tab
           Offset: 0
-          Type: 2 VoidPointerType unsafe.Pointer
+          Type: 19 VoidPointerType unsafe.Pointer
         - Name: data
           Offset: 8
-          Type: 2 VoidPointerType unsafe.Pointer
+          Type: 19 VoidPointerType unsafe.Pointer
     - __kind: BaseType
-      ID: 188
+      ID: 16
       Name: float32
       ByteSize: 4
       GoRuntimeType: 543200
       GoKind: 13
     - __kind: BaseType
-      ID: 145
+      ID: 17
       Name: float64
       ByteSize: 8
       GoRuntimeType: 543264
       GoKind: 14
     - __kind: GoSubroutineType
-      ID: 178
+      ID: 197
       Name: func()
       ByteSize: 8
       GoRuntimeType: 455360
       GoKind: 19
     - __kind: GoSubroutineType
-      ID: 35
+      ID: 60
       Name: func() (io.ReadCloser, error)
       ByteSize: 8
       GoRuntimeType: 645280
       GoKind: 19
     - __kind: GoSubroutineType
-      ID: 109
+      ID: 131
       Name: func(string, []uint8, int) ([]uint8, error)
       ByteSize: 8
       GoRuntimeType: 982976
       GoKind: 19
     - __kind: StructureType
-      ID: 127
+      ID: 149
       Name: github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span
       ByteSize: 288
       GoRuntimeType: 2.251424e+06
@@ -1880,81 +1880,81 @@ Types:
       RawFields:
         - Name: mu
           Offset: 0
-          Type: 128 StructureType sync.RWMutex
+          Type: 150 StructureType sync.RWMutex
         - Name: name
           Offset: 24
-          Type: 5 GoStringHeaderType string
+          Type: 11 GoStringHeaderType string
         - Name: service
           Offset: 40
-          Type: 5 GoStringHeaderType string
+          Type: 11 GoStringHeaderType string
         - Name: resource
           Offset: 56
-          Type: 5 GoStringHeaderType string
+          Type: 11 GoStringHeaderType string
         - Name: spanType
           Offset: 72
-          Type: 5 GoStringHeaderType string
+          Type: 11 GoStringHeaderType string
         - Name: start
           Offset: 88
-          Type: 36 BaseType int64
+          Type: 13 BaseType int64
         - Name: duration
           Offset: 96
-          Type: 36 BaseType int64
+          Type: 13 BaseType int64
         - Name: meta
           Offset: 104
-          Type: 120 GoMapType map[string]string
+          Type: 142 GoMapType map[string]string
         - Name: metaStruct
           Offset: 112
-          Type: 133 GoMapType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.metaStructMap
+          Type: 154 GoMapType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.metaStructMap
         - Name: metrics
           Offset: 120
-          Type: 139 GoMapType map[string]float64
+          Type: 160 GoMapType map[string]float64
         - Name: spanID
           Offset: 128
-          Type: 74 BaseType uint64
+          Type: 10 BaseType uint64
         - Name: traceID
           Offset: 136
-          Type: 74 BaseType uint64
+          Type: 10 BaseType uint64
         - Name: parentID
           Offset: 144
-          Type: 74 BaseType uint64
+          Type: 10 BaseType uint64
         - Name: error
           Offset: 152
-          Type: 130 BaseType int32
+          Type: 12 BaseType int32
         - Name: spanLinks
           Offset: 160
-          Type: 146 GoSliceHeaderType []github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink
+          Type: 166 GoSliceHeaderType []github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink
         - Name: spanEvents
           Offset: 184
-          Type: 149 GoSliceHeaderType []github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent
+          Type: 169 GoSliceHeaderType []github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent
         - Name: goExecTraced
           Offset: 208
-          Type: 13 BaseType bool
+          Type: 4 BaseType bool
         - Name: noDebugStack
           Offset: 209
-          Type: 13 BaseType bool
+          Type: 4 BaseType bool
         - Name: finished
           Offset: 210
-          Type: 13 BaseType bool
+          Type: 4 BaseType bool
         - Name: context
           Offset: 216
-          Type: 169 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanContext
+          Type: 189 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanContext
         - Name: integration
           Offset: 224
-          Type: 5 GoStringHeaderType string
+          Type: 11 GoStringHeaderType string
         - Name: supportsEvents
           Offset: 240
-          Type: 13 BaseType bool
+          Type: 4 BaseType bool
         - Name: pprofCtxActive
           Offset: 248
-          Type: 114 GoInterfaceType context.Context
+          Type: 136 GoInterfaceType context.Context
         - Name: pprofCtxRestore
           Offset: 264
-          Type: 114 GoInterfaceType context.Context
+          Type: 136 GoInterfaceType context.Context
         - Name: taskEnd
           Offset: 280
-          Type: 178 GoSubroutineType func()
+          Type: 197 GoSubroutineType func()
     - __kind: StructureType
-      ID: 170
+      ID: 190
       Name: github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanContext
       ByteSize: 168
       GoRuntimeType: 2.1248e+06
@@ -1962,48 +1962,48 @@ Types:
       RawFields:
         - Name: updated
           Offset: 0
-          Type: 13 BaseType bool
+          Type: 4 BaseType bool
         - Name: trace
           Offset: 8
-          Type: 171 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.trace
+          Type: 191 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.trace
         - Name: span
           Offset: 16
-          Type: 126 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span
+          Type: 148 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span
         - Name: errors
           Offset: 24
-          Type: 131 StructureType sync/atomic.Int32
+          Type: 152 StructureType sync/atomic.Int32
         - Name: reparentID
           Offset: 32
-          Type: 5 GoStringHeaderType string
+          Type: 11 GoStringHeaderType string
         - Name: isRemote
           Offset: 48
-          Type: 13 BaseType bool
+          Type: 4 BaseType bool
         - Name: traceID
           Offset: 49
-          Type: 177 ArrayType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.traceID
+          Type: 196 ArrayType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.traceID
         - Name: spanID
           Offset: 72
-          Type: 74 BaseType uint64
+          Type: 10 BaseType uint64
         - Name: mu
           Offset: 80
-          Type: 128 StructureType sync.RWMutex
+          Type: 150 StructureType sync.RWMutex
         - Name: baggage
           Offset: 104
-          Type: 120 GoMapType map[string]string
+          Type: 142 GoMapType map[string]string
         - Name: hasBaggage
           Offset: 112
-          Type: 18 BaseType uint32
+          Type: 2 BaseType uint32
         - Name: origin
           Offset: 120
-          Type: 5 GoStringHeaderType string
+          Type: 11 GoStringHeaderType string
         - Name: spanLinks
           Offset: 136
-          Type: 146 GoSliceHeaderType []github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink
+          Type: 166 GoSliceHeaderType []github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink
         - Name: baggageOnly
           Offset: 160
-          Type: 13 BaseType bool
+          Type: 4 BaseType bool
     - __kind: StructureType
-      ID: 148
+      ID: 168
       Name: github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink
       ByteSize: 56
       GoRuntimeType: 1.822016e+06
@@ -2011,37 +2011,37 @@ Types:
       RawFields:
         - Name: TraceID
           Offset: 0
-          Type: 74 BaseType uint64
+          Type: 10 BaseType uint64
         - Name: TraceIDHigh
           Offset: 8
-          Type: 74 BaseType uint64
+          Type: 10 BaseType uint64
         - Name: SpanID
           Offset: 16
-          Type: 74 BaseType uint64
+          Type: 10 BaseType uint64
         - Name: Attributes
           Offset: 24
-          Type: 120 GoMapType map[string]string
+          Type: 142 GoMapType map[string]string
         - Name: Tracestate
           Offset: 32
-          Type: 5 GoStringHeaderType string
+          Type: 11 GoStringHeaderType string
         - Name: Flags
           Offset: 48
-          Type: 18 BaseType uint32
+          Type: 2 BaseType uint32
     - __kind: GoMapType
-      ID: 133
+      ID: 154
       Name: github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.metaStructMap
       ByteSize: 8
       GoRuntimeType: 1.007296e+06
       GoKind: 21
-      HeaderType: 135 GoHMapHeaderType hash<string,interface {}>
+      HeaderType: 156 GoHMapHeaderType hash<string,interface {}>
     - __kind: BaseType
-      ID: 176
+      ID: 195
       Name: github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.samplingDecision
       ByteSize: 4
       GoRuntimeType: 542112
       GoKind: 10
     - __kind: StructureType
-      ID: 151
+      ID: 171
       Name: github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent
       ByteSize: 40
       GoRuntimeType: 1.663808e+06
@@ -2049,18 +2049,18 @@ Types:
       RawFields:
         - Name: Name
           Offset: 0
-          Type: 5 GoStringHeaderType string
+          Type: 11 GoStringHeaderType string
         - Name: TimeUnixNano
           Offset: 16
-          Type: 74 BaseType uint64
+          Type: 10 BaseType uint64
         - Name: Attributes
           Offset: 24
-          Type: 152 GoMapType map[string]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
+          Type: 172 GoMapType map[string]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
         - Name: RawAttributes
           Offset: 32
-          Type: 168 GoMapType map[string]interface {}
+          Type: 188 GoMapType map[string]interface {}
     - __kind: StructureType
-      ID: 162
+      ID: 182
       Name: github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttribute
       ByteSize: 24
       GoRuntimeType: 1.129856e+06
@@ -2068,9 +2068,9 @@ Types:
       RawFields:
         - Name: Values
           Offset: 0
-          Type: 163 GoSliceHeaderType []*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttributeValue
+          Type: 183 GoSliceHeaderType []*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttributeValue
     - __kind: StructureType
-      ID: 166
+      ID: 186
       Name: github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttributeValue
       ByteSize: 48
       GoRuntimeType: 1.747904e+06
@@ -2078,27 +2078,27 @@ Types:
       RawFields:
         - Name: Type
           Offset: 0
-          Type: 167 BaseType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttributeValueType
+          Type: 187 BaseType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttributeValueType
         - Name: StringValue
           Offset: 8
-          Type: 5 GoStringHeaderType string
+          Type: 11 GoStringHeaderType string
         - Name: BoolValue
           Offset: 24
-          Type: 13 BaseType bool
+          Type: 4 BaseType bool
         - Name: IntValue
           Offset: 32
-          Type: 36 BaseType int64
+          Type: 13 BaseType int64
         - Name: DoubleValue
           Offset: 40
-          Type: 145 BaseType float64
+          Type: 17 BaseType float64
     - __kind: BaseType
-      ID: 167
+      ID: 187
       Name: github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttributeValueType
       ByteSize: 4
       GoRuntimeType: 965120
       GoKind: 5
     - __kind: StructureType
-      ID: 159
+      ID: 179
       Name: github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
       ByteSize: 56
       GoRuntimeType: 1.822272e+06
@@ -2106,30 +2106,30 @@ Types:
       RawFields:
         - Name: Type
           Offset: 0
-          Type: 160 BaseType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttributeType
+          Type: 180 BaseType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttributeType
         - Name: StringValue
           Offset: 8
-          Type: 5 GoStringHeaderType string
+          Type: 11 GoStringHeaderType string
         - Name: BoolValue
           Offset: 24
-          Type: 13 BaseType bool
+          Type: 4 BaseType bool
         - Name: IntValue
           Offset: 32
-          Type: 36 BaseType int64
+          Type: 13 BaseType int64
         - Name: DoubleValue
           Offset: 40
-          Type: 145 BaseType float64
+          Type: 17 BaseType float64
         - Name: ArrayValue
           Offset: 48
-          Type: 161 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttribute
+          Type: 181 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttribute
     - __kind: BaseType
-      ID: 160
+      ID: 180
       Name: github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttributeType
       ByteSize: 4
       GoRuntimeType: 965024
       GoKind: 5
     - __kind: StructureType
-      ID: 172
+      ID: 192
       Name: github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.trace
       ByteSize: 104
       GoRuntimeType: 2.01696e+06
@@ -2137,279 +2137,279 @@ Types:
       RawFields:
         - Name: mu
           Offset: 0
-          Type: 128 StructureType sync.RWMutex
+          Type: 150 StructureType sync.RWMutex
         - Name: spans
           Offset: 24
-          Type: 173 GoSliceHeaderType []*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span
+          Type: 193 GoSliceHeaderType []*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span
         - Name: tags
           Offset: 48
-          Type: 120 GoMapType map[string]string
+          Type: 142 GoMapType map[string]string
         - Name: propagatingTags
           Offset: 56
-          Type: 120 GoMapType map[string]string
+          Type: 142 GoMapType map[string]string
         - Name: finished
           Offset: 64
-          Type: 8 BaseType int
+          Type: 9 BaseType int
         - Name: full
           Offset: 72
-          Type: 13 BaseType bool
+          Type: 4 BaseType bool
         - Name: priority
           Offset: 80
-          Type: 175 PointerType *float64
+          Type: 25 PointerType *float64
         - Name: locked
           Offset: 88
-          Type: 13 BaseType bool
+          Type: 4 BaseType bool
         - Name: samplingDecision
           Offset: 92
-          Type: 176 BaseType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.samplingDecision
+          Type: 195 BaseType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.samplingDecision
         - Name: root
           Offset: 96
-          Type: 126 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span
+          Type: 148 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span
     - __kind: ArrayType
-      ID: 177
+      ID: 196
       Name: github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.traceID
       ByteSize: 16
       GoRuntimeType: 847584
       GoKind: 17
       Count: 16
       HasCount: true
-      Element: 7 BaseType uint8
+      Element: 3 BaseType uint8
     - __kind: GoHMapHeaderType
-      ID: 154
+      ID: 174
       Name: hash<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
       ByteSize: 48
       RawFields:
         - Name: count
           Offset: 0
-          Type: 8 BaseType int
+          Type: 9 BaseType int
         - Name: flags
           Offset: 8
-          Type: 7 BaseType uint8
+          Type: 3 BaseType uint8
         - Name: B
           Offset: 9
-          Type: 7 BaseType uint8
+          Type: 3 BaseType uint8
         - Name: noverflow
           Offset: 10
-          Type: 17 BaseType uint16
+          Type: 7 BaseType uint16
         - Name: hash0
           Offset: 12
-          Type: 18 BaseType uint32
+          Type: 2 BaseType uint32
         - Name: buckets
           Offset: 16
-          Type: 155 PointerType *bucket<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
+          Type: 175 PointerType *bucket<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
         - Name: oldbuckets
           Offset: 24
-          Type: 155 PointerType *bucket<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
+          Type: 175 PointerType *bucket<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
         - Name: nevacuate
           Offset: 32
-          Type: 26 BaseType uintptr
+          Type: 1 BaseType uintptr
         - Name: extra
           Offset: 40
-          Type: 27 PointerType *runtime.mapextra
-      BucketType: 156 GoHMapBucketType bucket<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
+          Type: 52 PointerType *runtime.mapextra
+      BucketType: 176 GoHMapBucketType bucket<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
       BucketsType: 258 GoSliceDataType []bucket<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>.array
     - __kind: GoHMapHeaderType
-      ID: 43
+      ID: 67
       Name: hash<string,[]*mime/multipart.FileHeader>
       ByteSize: 48
       RawFields:
         - Name: count
           Offset: 0
-          Type: 8 BaseType int
+          Type: 9 BaseType int
         - Name: flags
           Offset: 8
-          Type: 7 BaseType uint8
+          Type: 3 BaseType uint8
         - Name: B
           Offset: 9
-          Type: 7 BaseType uint8
+          Type: 3 BaseType uint8
         - Name: noverflow
           Offset: 10
-          Type: 17 BaseType uint16
+          Type: 7 BaseType uint16
         - Name: hash0
           Offset: 12
-          Type: 18 BaseType uint32
+          Type: 2 BaseType uint32
         - Name: buckets
           Offset: 16
-          Type: 44 PointerType *bucket<string,[]*mime/multipart.FileHeader>
+          Type: 68 PointerType *bucket<string,[]*mime/multipart.FileHeader>
         - Name: oldbuckets
           Offset: 24
-          Type: 44 PointerType *bucket<string,[]*mime/multipart.FileHeader>
+          Type: 68 PointerType *bucket<string,[]*mime/multipart.FileHeader>
         - Name: nevacuate
           Offset: 32
-          Type: 26 BaseType uintptr
+          Type: 1 BaseType uintptr
         - Name: extra
           Offset: 40
-          Type: 27 PointerType *runtime.mapextra
-      BucketType: 45 GoHMapBucketType bucket<string,[]*mime/multipart.FileHeader>
+          Type: 52 PointerType *runtime.mapextra
+      BucketType: 69 GoHMapBucketType bucket<string,[]*mime/multipart.FileHeader>
       BucketsType: 210 GoSliceDataType []bucket<string,[]*mime/multipart.FileHeader>.array
     - __kind: GoHMapHeaderType
-      ID: 16
+      ID: 45
       Name: hash<string,[]string>
       ByteSize: 48
       RawFields:
         - Name: count
           Offset: 0
-          Type: 8 BaseType int
+          Type: 9 BaseType int
         - Name: flags
           Offset: 8
-          Type: 7 BaseType uint8
+          Type: 3 BaseType uint8
         - Name: B
           Offset: 9
-          Type: 7 BaseType uint8
+          Type: 3 BaseType uint8
         - Name: noverflow
           Offset: 10
-          Type: 17 BaseType uint16
+          Type: 7 BaseType uint16
         - Name: hash0
           Offset: 12
-          Type: 18 BaseType uint32
+          Type: 2 BaseType uint32
         - Name: buckets
           Offset: 16
-          Type: 19 PointerType *bucket<string,[]string>
+          Type: 46 PointerType *bucket<string,[]string>
         - Name: oldbuckets
           Offset: 24
-          Type: 19 PointerType *bucket<string,[]string>
+          Type: 46 PointerType *bucket<string,[]string>
         - Name: nevacuate
           Offset: 32
-          Type: 26 BaseType uintptr
+          Type: 1 BaseType uintptr
         - Name: extra
           Offset: 40
-          Type: 27 PointerType *runtime.mapextra
-      BucketType: 20 GoHMapBucketType bucket<string,[]string>
+          Type: 52 PointerType *runtime.mapextra
+      BucketType: 47 GoHMapBucketType bucket<string,[]string>
       BucketsType: 205 GoSliceDataType []bucket<string,[]string>.array
     - __kind: GoHMapHeaderType
-      ID: 141
+      ID: 162
       Name: hash<string,float64>
       ByteSize: 48
       RawFields:
         - Name: count
           Offset: 0
-          Type: 8 BaseType int
+          Type: 9 BaseType int
         - Name: flags
           Offset: 8
-          Type: 7 BaseType uint8
+          Type: 3 BaseType uint8
         - Name: B
           Offset: 9
-          Type: 7 BaseType uint8
+          Type: 3 BaseType uint8
         - Name: noverflow
           Offset: 10
-          Type: 17 BaseType uint16
+          Type: 7 BaseType uint16
         - Name: hash0
           Offset: 12
-          Type: 18 BaseType uint32
+          Type: 2 BaseType uint32
         - Name: buckets
           Offset: 16
-          Type: 142 PointerType *bucket<string,float64>
+          Type: 163 PointerType *bucket<string,float64>
         - Name: oldbuckets
           Offset: 24
-          Type: 142 PointerType *bucket<string,float64>
+          Type: 163 PointerType *bucket<string,float64>
         - Name: nevacuate
           Offset: 32
-          Type: 26 BaseType uintptr
+          Type: 1 BaseType uintptr
         - Name: extra
           Offset: 40
-          Type: 27 PointerType *runtime.mapextra
-      BucketType: 143 GoHMapBucketType bucket<string,float64>
+          Type: 52 PointerType *runtime.mapextra
+      BucketType: 164 GoHMapBucketType bucket<string,float64>
       BucketsType: 253 GoSliceDataType []bucket<string,float64>.array
     - __kind: GoHMapHeaderType
-      ID: 135
+      ID: 156
       Name: hash<string,interface {}>
       ByteSize: 48
       RawFields:
         - Name: count
           Offset: 0
-          Type: 8 BaseType int
+          Type: 9 BaseType int
         - Name: flags
           Offset: 8
-          Type: 7 BaseType uint8
+          Type: 3 BaseType uint8
         - Name: B
           Offset: 9
-          Type: 7 BaseType uint8
+          Type: 3 BaseType uint8
         - Name: noverflow
           Offset: 10
-          Type: 17 BaseType uint16
+          Type: 7 BaseType uint16
         - Name: hash0
           Offset: 12
-          Type: 18 BaseType uint32
+          Type: 2 BaseType uint32
         - Name: buckets
           Offset: 16
-          Type: 136 PointerType *bucket<string,interface {}>
+          Type: 157 PointerType *bucket<string,interface {}>
         - Name: oldbuckets
           Offset: 24
-          Type: 136 PointerType *bucket<string,interface {}>
+          Type: 157 PointerType *bucket<string,interface {}>
         - Name: nevacuate
           Offset: 32
-          Type: 26 BaseType uintptr
+          Type: 1 BaseType uintptr
         - Name: extra
           Offset: 40
-          Type: 27 PointerType *runtime.mapextra
-      BucketType: 137 GoHMapBucketType bucket<string,interface {}>
+          Type: 52 PointerType *runtime.mapextra
+      BucketType: 158 GoHMapBucketType bucket<string,interface {}>
       BucketsType: 252 GoSliceDataType []bucket<string,interface {}>.array
     - __kind: GoHMapHeaderType
-      ID: 122
+      ID: 144
       Name: hash<string,string>
       ByteSize: 48
       RawFields:
         - Name: count
           Offset: 0
-          Type: 8 BaseType int
+          Type: 9 BaseType int
         - Name: flags
           Offset: 8
-          Type: 7 BaseType uint8
+          Type: 3 BaseType uint8
         - Name: B
           Offset: 9
-          Type: 7 BaseType uint8
+          Type: 3 BaseType uint8
         - Name: noverflow
           Offset: 10
-          Type: 17 BaseType uint16
+          Type: 7 BaseType uint16
         - Name: hash0
           Offset: 12
-          Type: 18 BaseType uint32
+          Type: 2 BaseType uint32
         - Name: buckets
           Offset: 16
-          Type: 123 PointerType *bucket<string,string>
+          Type: 145 PointerType *bucket<string,string>
         - Name: oldbuckets
           Offset: 24
-          Type: 123 PointerType *bucket<string,string>
+          Type: 145 PointerType *bucket<string,string>
         - Name: nevacuate
           Offset: 32
-          Type: 26 BaseType uintptr
+          Type: 1 BaseType uintptr
         - Name: extra
           Offset: 40
-          Type: 27 PointerType *runtime.mapextra
-      BucketType: 124 GoHMapBucketType bucket<string,string>
+          Type: 52 PointerType *runtime.mapextra
+      BucketType: 146 GoHMapBucketType bucket<string,string>
       BucketsType: 251 GoSliceDataType []bucket<string,string>.array
     - __kind: BaseType
-      ID: 8
+      ID: 9
       Name: int
       ByteSize: 8
       GoRuntimeType: 542880
       GoKind: 2
     - __kind: BaseType
-      ID: 198
+      ID: 31
       Name: int16
       ByteSize: 2
       GoRuntimeType: 542496
       GoKind: 4
     - __kind: BaseType
-      ID: 130
+      ID: 12
       Name: int32
       ByteSize: 4
       GoRuntimeType: 542624
       GoKind: 5
     - __kind: BaseType
-      ID: 36
+      ID: 13
       Name: int64
       ByteSize: 8
       GoRuntimeType: 542752
       GoKind: 6
     - __kind: BaseType
-      ID: 186
+      ID: 14
       Name: int8
       ByteSize: 1
       GoRuntimeType: 542368
       GoKind: 3
     - __kind: GoEmptyInterfaceType
-      ID: 61
+      ID: 85
       Name: interface {}
       ByteSize: 16
       GoRuntimeType: 797888
@@ -2417,12 +2417,12 @@ Types:
       RawFields:
         - Name: _type
           Offset: 0
-          Type: 2 VoidPointerType unsafe.Pointer
+          Type: 19 VoidPointerType unsafe.Pointer
         - Name: data
           Offset: 8
-          Type: 2 VoidPointerType unsafe.Pointer
+          Type: 19 VoidPointerType unsafe.Pointer
     - __kind: GoInterfaceType
-      ID: 34
+      ID: 59
       Name: io.ReadCloser
       ByteSize: 16
       GoRuntimeType: 1.092864e+06
@@ -2430,54 +2430,54 @@ Types:
       RawFields:
         - Name: tab
           Offset: 0
-          Type: 2 VoidPointerType unsafe.Pointer
+          Type: 19 VoidPointerType unsafe.Pointer
         - Name: data
           Offset: 8
-          Type: 2 VoidPointerType unsafe.Pointer
+          Type: 19 VoidPointerType unsafe.Pointer
     - __kind: GoMapType
-      ID: 152
+      ID: 172
       Name: map[string]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
       ByteSize: 8
       GoRuntimeType: 904992
       GoKind: 21
-      HeaderType: 154 GoHMapHeaderType hash<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
+      HeaderType: 174 GoHMapHeaderType hash<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
     - __kind: GoMapType
-      ID: 41
+      ID: 65
       Name: map[string][]*mime/multipart.FileHeader
       ByteSize: 8
       GoRuntimeType: 904032
       GoKind: 21
-      HeaderType: 43 GoHMapHeaderType hash<string,[]*mime/multipart.FileHeader>
+      HeaderType: 67 GoHMapHeaderType hash<string,[]*mime/multipart.FileHeader>
     - __kind: GoMapType
-      ID: 40
+      ID: 64
       Name: map[string][]string
       ByteSize: 8
       GoRuntimeType: 899232
       GoKind: 21
-      HeaderType: 16 GoHMapHeaderType hash<string,[]string>
+      HeaderType: 45 GoHMapHeaderType hash<string,[]string>
     - __kind: GoMapType
-      ID: 139
+      ID: 160
       Name: map[string]float64
       ByteSize: 8
       GoRuntimeType: 904896
       GoKind: 21
-      HeaderType: 141 GoHMapHeaderType hash<string,float64>
+      HeaderType: 162 GoHMapHeaderType hash<string,float64>
     - __kind: GoMapType
-      ID: 168
+      ID: 188
       Name: map[string]interface {}
       ByteSize: 8
       GoRuntimeType: 896352
       GoKind: 21
-      HeaderType: 135 GoHMapHeaderType hash<string,interface {}>
+      HeaderType: 156 GoHMapHeaderType hash<string,interface {}>
     - __kind: GoMapType
-      ID: 120
+      ID: 142
       Name: map[string]string
       ByteSize: 8
       GoRuntimeType: 900864
       GoKind: 21
-      HeaderType: 122 GoHMapHeaderType hash<string,string>
+      HeaderType: 144 GoHMapHeaderType hash<string,string>
     - __kind: StructureType
-      ID: 63
+      ID: 87
       Name: math/big.Int
       ByteSize: 32
       GoRuntimeType: 1.340544e+06
@@ -2485,18 +2485,18 @@ Types:
       RawFields:
         - Name: neg
           Offset: 0
-          Type: 13 BaseType bool
+          Type: 4 BaseType bool
         - Name: abs
           Offset: 8
-          Type: 64 GoSliceHeaderType math/big.nat
+          Type: 88 GoSliceHeaderType math/big.nat
     - __kind: BaseType
-      ID: 66
+      ID: 90
       Name: math/big.Word
       ByteSize: 8
       GoRuntimeType: 546656
       GoKind: 7
     - __kind: GoSliceHeaderType
-      ID: 64
+      ID: 88
       Name: math/big.nat
       ByteSize: 24
       GoRuntimeType: 2.279968e+06
@@ -2504,21 +2504,21 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 65 PointerType *math/big.Word
+          Type: 89 PointerType *math/big.Word
         - Name: len
           Offset: 8
-          Type: 8 BaseType int
+          Type: 9 BaseType int
         - Name: cap
           Offset: 16
-          Type: 8 BaseType int
+          Type: 9 BaseType int
       Data: 217 GoSliceDataType math/big.nat.array
     - __kind: GoSliceDataType
       ID: 217
       Name: math/big.nat.array
       ByteSize: 2048
-      Element: 66 BaseType math/big.Word
+      Element: 90 BaseType math/big.Word
     - __kind: StructureType
-      ID: 50
+      ID: 74
       Name: mime/multipart.FileHeader
       ByteSize: 88
       GoRuntimeType: 1.88112e+06
@@ -2526,27 +2526,27 @@ Types:
       RawFields:
         - Name: Filename
           Offset: 0
-          Type: 5 GoStringHeaderType string
+          Type: 11 GoStringHeaderType string
         - Name: Header
           Offset: 16
-          Type: 51 GoMapType net/textproto.MIMEHeader
+          Type: 75 GoMapType net/textproto.MIMEHeader
         - Name: Size
           Offset: 24
-          Type: 36 BaseType int64
+          Type: 13 BaseType int64
         - Name: content
           Offset: 32
-          Type: 52 GoSliceHeaderType []uint8
+          Type: 76 GoSliceHeaderType []uint8
         - Name: tmpfile
           Offset: 56
-          Type: 5 GoStringHeaderType string
+          Type: 11 GoStringHeaderType string
         - Name: tmpoff
           Offset: 72
-          Type: 36 BaseType int64
+          Type: 13 BaseType int64
         - Name: tmpshared
           Offset: 80
-          Type: 13 BaseType bool
+          Type: 4 BaseType bool
     - __kind: StructureType
-      ID: 39
+      ID: 63
       Name: mime/multipart.Form
       ByteSize: 16
       GoRuntimeType: 1.325824e+06
@@ -2554,12 +2554,12 @@ Types:
       RawFields:
         - Name: Value
           Offset: 0
-          Type: 40 GoMapType map[string][]string
+          Type: 64 GoMapType map[string][]string
         - Name: File
           Offset: 8
-          Type: 41 GoMapType map[string][]*mime/multipart.FileHeader
+          Type: 65 GoMapType map[string][]*mime/multipart.FileHeader
     - __kind: GoSliceHeaderType
-      ID: 94
+      ID: 116
       Name: net.IP
       ByteSize: 24
       GoRuntimeType: 2.000864e+06
@@ -2570,18 +2570,18 @@ Types:
           Type: 6 PointerType *uint8
         - Name: len
           Offset: 8
-          Type: 8 BaseType int
+          Type: 9 BaseType int
         - Name: cap
           Offset: 16
-          Type: 8 BaseType int
+          Type: 9 BaseType int
       Data: 235 GoSliceDataType net.IP.array
     - __kind: GoSliceDataType
       ID: 235
       Name: net.IP.array
       ByteSize: 2048
-      Element: 7 BaseType uint8
+      Element: 3 BaseType uint8
     - __kind: GoSliceHeaderType
-      ID: 101
+      ID: 123
       Name: net.IPMask
       ByteSize: 24
       GoRuntimeType: 999232
@@ -2592,18 +2592,18 @@ Types:
           Type: 6 PointerType *uint8
         - Name: len
           Offset: 8
-          Type: 8 BaseType int
+          Type: 9 BaseType int
         - Name: cap
           Offset: 16
-          Type: 8 BaseType int
+          Type: 9 BaseType int
       Data: 241 GoSliceDataType net.IPMask.array
     - __kind: GoSliceDataType
       ID: 241
       Name: net.IPMask.array
       ByteSize: 2048
-      Element: 7 BaseType uint8
+      Element: 3 BaseType uint8
     - __kind: StructureType
-      ID: 100
+      ID: 122
       Name: net.IPNet
       ByteSize: 48
       GoRuntimeType: 1.306944e+06
@@ -2611,19 +2611,19 @@ Types:
       RawFields:
         - Name: IP
           Offset: 0
-          Type: 94 GoSliceHeaderType net.IP
+          Type: 116 GoSliceHeaderType net.IP
         - Name: Mask
           Offset: 24
-          Type: 101 GoSliceHeaderType net.IPMask
+          Type: 123 GoSliceHeaderType net.IPMask
     - __kind: GoMapType
-      ID: 14
+      ID: 43
       Name: net/http.Header
       ByteSize: 8
       GoRuntimeType: 1.963712e+06
       GoKind: 21
-      HeaderType: 16 GoHMapHeaderType hash<string,[]string>
+      HeaderType: 45 GoHMapHeaderType hash<string,[]string>
     - __kind: StructureType
-      ID: 4
+      ID: 38
       Name: net/http.Request
       ByteSize: 304
       GoRuntimeType: 2.255712e+06
@@ -2631,84 +2631,84 @@ Types:
       RawFields:
         - Name: Method
           Offset: 0
-          Type: 5 GoStringHeaderType string
+          Type: 11 GoStringHeaderType string
         - Name: URL
           Offset: 16
-          Type: 9 PointerType *net/url.URL
+          Type: 39 PointerType *net/url.URL
         - Name: Proto
           Offset: 24
-          Type: 5 GoStringHeaderType string
+          Type: 11 GoStringHeaderType string
         - Name: ProtoMajor
           Offset: 40
-          Type: 8 BaseType int
+          Type: 9 BaseType int
         - Name: ProtoMinor
           Offset: 48
-          Type: 8 BaseType int
+          Type: 9 BaseType int
         - Name: Header
           Offset: 56
-          Type: 14 GoMapType net/http.Header
+          Type: 43 GoMapType net/http.Header
         - Name: Body
           Offset: 64
-          Type: 34 GoInterfaceType io.ReadCloser
+          Type: 59 GoInterfaceType io.ReadCloser
         - Name: GetBody
           Offset: 80
-          Type: 35 GoSubroutineType func() (io.ReadCloser, error)
+          Type: 60 GoSubroutineType func() (io.ReadCloser, error)
         - Name: ContentLength
           Offset: 88
-          Type: 36 BaseType int64
+          Type: 13 BaseType int64
         - Name: TransferEncoding
           Offset: 96
-          Type: 24 GoSliceHeaderType []string
+          Type: 51 GoSliceHeaderType []string
         - Name: Close
           Offset: 120
-          Type: 13 BaseType bool
+          Type: 4 BaseType bool
         - Name: Host
           Offset: 128
-          Type: 5 GoStringHeaderType string
+          Type: 11 GoStringHeaderType string
         - Name: Form
           Offset: 144
-          Type: 37 GoMapType net/url.Values
+          Type: 61 GoMapType net/url.Values
         - Name: PostForm
           Offset: 152
-          Type: 37 GoMapType net/url.Values
+          Type: 61 GoMapType net/url.Values
         - Name: MultipartForm
           Offset: 160
-          Type: 38 PointerType *mime/multipart.Form
+          Type: 62 PointerType *mime/multipart.Form
         - Name: Trailer
           Offset: 168
-          Type: 14 GoMapType net/http.Header
+          Type: 43 GoMapType net/http.Header
         - Name: RemoteAddr
           Offset: 176
-          Type: 5 GoStringHeaderType string
+          Type: 11 GoStringHeaderType string
         - Name: RequestURI
           Offset: 192
-          Type: 5 GoStringHeaderType string
+          Type: 11 GoStringHeaderType string
         - Name: TLS
           Offset: 208
-          Type: 53 PointerType *crypto/tls.ConnectionState
+          Type: 77 PointerType *crypto/tls.ConnectionState
         - Name: Cancel
           Offset: 216
-          Type: 111 GoChannelType <-chan struct {}
+          Type: 133 GoChannelType <-chan struct {}
         - Name: Response
           Offset: 224
-          Type: 112 PointerType *net/http.Response
+          Type: 134 PointerType *net/http.Response
         - Name: Pattern
           Offset: 232
-          Type: 5 GoStringHeaderType string
+          Type: 11 GoStringHeaderType string
         - Name: ctx
           Offset: 248
-          Type: 114 GoInterfaceType context.Context
+          Type: 136 GoInterfaceType context.Context
         - Name: pat
           Offset: 264
-          Type: 115 PointerType *net/http.pattern
+          Type: 137 PointerType *net/http.pattern
         - Name: matches
           Offset: 272
-          Type: 24 GoSliceHeaderType []string
+          Type: 51 GoSliceHeaderType []string
         - Name: otherValues
           Offset: 296
-          Type: 120 GoMapType map[string]string
+          Type: 142 GoMapType map[string]string
     - __kind: StructureType
-      ID: 113
+      ID: 135
       Name: net/http.Response
       ByteSize: 144
       GoRuntimeType: 2.123456e+06
@@ -2716,48 +2716,48 @@ Types:
       RawFields:
         - Name: Status
           Offset: 0
-          Type: 5 GoStringHeaderType string
+          Type: 11 GoStringHeaderType string
         - Name: StatusCode
           Offset: 16
-          Type: 8 BaseType int
+          Type: 9 BaseType int
         - Name: Proto
           Offset: 24
-          Type: 5 GoStringHeaderType string
+          Type: 11 GoStringHeaderType string
         - Name: ProtoMajor
           Offset: 40
-          Type: 8 BaseType int
+          Type: 9 BaseType int
         - Name: ProtoMinor
           Offset: 48
-          Type: 8 BaseType int
+          Type: 9 BaseType int
         - Name: Header
           Offset: 56
-          Type: 14 GoMapType net/http.Header
+          Type: 43 GoMapType net/http.Header
         - Name: Body
           Offset: 64
-          Type: 34 GoInterfaceType io.ReadCloser
+          Type: 59 GoInterfaceType io.ReadCloser
         - Name: ContentLength
           Offset: 80
-          Type: 36 BaseType int64
+          Type: 13 BaseType int64
         - Name: TransferEncoding
           Offset: 88
-          Type: 24 GoSliceHeaderType []string
+          Type: 51 GoSliceHeaderType []string
         - Name: Close
           Offset: 112
-          Type: 13 BaseType bool
+          Type: 4 BaseType bool
         - Name: Uncompressed
           Offset: 113
-          Type: 13 BaseType bool
+          Type: 4 BaseType bool
         - Name: Trailer
           Offset: 120
-          Type: 14 GoMapType net/http.Header
+          Type: 43 GoMapType net/http.Header
         - Name: Request
           Offset: 128
-          Type: 3 PointerType *net/http.Request
+          Type: 37 PointerType *net/http.Request
         - Name: TLS
           Offset: 136
-          Type: 53 PointerType *crypto/tls.ConnectionState
+          Type: 77 PointerType *crypto/tls.ConnectionState
     - __kind: GoInterfaceType
-      ID: 1
+      ID: 36
       Name: net/http.ResponseWriter
       ByteSize: 16
       GoRuntimeType: 1.125248e+06
@@ -2765,12 +2765,12 @@ Types:
       RawFields:
         - Name: tab
           Offset: 0
-          Type: 2 VoidPointerType unsafe.Pointer
+          Type: 19 VoidPointerType unsafe.Pointer
         - Name: data
           Offset: 8
-          Type: 2 VoidPointerType unsafe.Pointer
+          Type: 19 VoidPointerType unsafe.Pointer
     - __kind: StructureType
-      ID: 116
+      ID: 138
       Name: net/http.pattern
       ByteSize: 88
       GoRuntimeType: 1.744992e+06
@@ -2778,21 +2778,21 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 5 GoStringHeaderType string
+          Type: 11 GoStringHeaderType string
         - Name: method
           Offset: 16
-          Type: 5 GoStringHeaderType string
+          Type: 11 GoStringHeaderType string
         - Name: host
           Offset: 32
-          Type: 5 GoStringHeaderType string
+          Type: 11 GoStringHeaderType string
         - Name: segments
           Offset: 48
-          Type: 117 GoSliceHeaderType []net/http.segment
+          Type: 139 GoSliceHeaderType []net/http.segment
         - Name: loc
           Offset: 72
-          Type: 5 GoStringHeaderType string
+          Type: 11 GoStringHeaderType string
     - __kind: StructureType
-      ID: 119
+      ID: 141
       Name: net/http.segment
       ByteSize: 24
       GoRuntimeType: 1.452928e+06
@@ -2800,22 +2800,22 @@ Types:
       RawFields:
         - Name: s
           Offset: 0
-          Type: 5 GoStringHeaderType string
+          Type: 11 GoStringHeaderType string
         - Name: wild
           Offset: 16
-          Type: 13 BaseType bool
+          Type: 4 BaseType bool
         - Name: multi
           Offset: 17
-          Type: 13 BaseType bool
+          Type: 4 BaseType bool
     - __kind: GoMapType
-      ID: 51
+      ID: 75
       Name: net/textproto.MIMEHeader
       ByteSize: 8
       GoRuntimeType: 1.637344e+06
       GoKind: 21
-      HeaderType: 16 GoHMapHeaderType hash<string,[]string>
+      HeaderType: 45 GoHMapHeaderType hash<string,[]string>
     - __kind: StructureType
-      ID: 10
+      ID: 40
       Name: net/url.URL
       ByteSize: 144
       GoRuntimeType: 2.040992e+06
@@ -2823,39 +2823,39 @@ Types:
       RawFields:
         - Name: Scheme
           Offset: 0
-          Type: 5 GoStringHeaderType string
+          Type: 11 GoStringHeaderType string
         - Name: Opaque
           Offset: 16
-          Type: 5 GoStringHeaderType string
+          Type: 11 GoStringHeaderType string
         - Name: User
           Offset: 32
-          Type: 11 PointerType *net/url.Userinfo
+          Type: 41 PointerType *net/url.Userinfo
         - Name: Host
           Offset: 40
-          Type: 5 GoStringHeaderType string
+          Type: 11 GoStringHeaderType string
         - Name: Path
           Offset: 56
-          Type: 5 GoStringHeaderType string
+          Type: 11 GoStringHeaderType string
         - Name: RawPath
           Offset: 72
-          Type: 5 GoStringHeaderType string
+          Type: 11 GoStringHeaderType string
         - Name: OmitHost
           Offset: 88
-          Type: 13 BaseType bool
+          Type: 4 BaseType bool
         - Name: ForceQuery
           Offset: 89
-          Type: 13 BaseType bool
+          Type: 4 BaseType bool
         - Name: RawQuery
           Offset: 96
-          Type: 5 GoStringHeaderType string
+          Type: 11 GoStringHeaderType string
         - Name: Fragment
           Offset: 112
-          Type: 5 GoStringHeaderType string
+          Type: 11 GoStringHeaderType string
         - Name: RawFragment
           Offset: 128
-          Type: 5 GoStringHeaderType string
+          Type: 11 GoStringHeaderType string
     - __kind: StructureType
-      ID: 12
+      ID: 42
       Name: net/url.Userinfo
       ByteSize: 40
       GoRuntimeType: 1.469248e+06
@@ -2863,22 +2863,22 @@ Types:
       RawFields:
         - Name: username
           Offset: 0
-          Type: 5 GoStringHeaderType string
+          Type: 11 GoStringHeaderType string
         - Name: password
           Offset: 16
-          Type: 5 GoStringHeaderType string
+          Type: 11 GoStringHeaderType string
         - Name: passwordSet
           Offset: 32
-          Type: 13 BaseType bool
+          Type: 4 BaseType bool
     - __kind: GoMapType
-      ID: 37
+      ID: 61
       Name: net/url.Values
       ByteSize: 8
       GoRuntimeType: 1.71184e+06
       GoKind: 21
-      HeaderType: 16 GoHMapHeaderType hash<string,[]string>
+      HeaderType: 45 GoHMapHeaderType hash<string,[]string>
     - __kind: StructureType
-      ID: 33
+      ID: 58
       Name: runtime.bmap
       ByteSize: 8
       GoRuntimeType: 1.136896e+06
@@ -2886,9 +2886,9 @@ Types:
       RawFields:
         - Name: tophash
           Offset: 0
-          Type: 21 ArrayType [8]uint8
+          Type: 48 ArrayType [8]uint8
     - __kind: StructureType
-      ID: 28
+      ID: 53
       Name: runtime.mapextra
       ByteSize: 24
       GoRuntimeType: 1.465216e+06
@@ -2896,15 +2896,15 @@ Types:
       RawFields:
         - Name: overflow
           Offset: 0
-          Type: 29 PointerType *[]*runtime.bmap
+          Type: 54 PointerType *[]*runtime.bmap
         - Name: oldoverflow
           Offset: 8
-          Type: 29 PointerType *[]*runtime.bmap
+          Type: 54 PointerType *[]*runtime.bmap
         - Name: nextOverflow
           Offset: 16
-          Type: 32 PointerType *runtime.bmap
+          Type: 57 PointerType *runtime.bmap
     - __kind: GoStringHeaderType
-      ID: 5
+      ID: 11
       Name: string
       ByteSize: 16
       GoRuntimeType: 542304
@@ -2915,14 +2915,14 @@ Types:
           Type: 204 PointerType *string.str
         - Name: len
           Offset: 8
-          Type: 8 BaseType int
+          Type: 9 BaseType int
       Data: 203 GoStringDataType string.str
     - __kind: GoStringDataType
       ID: 203
       Name: string.str
       ByteSize: 2048
     - __kind: StructureType
-      ID: 129
+      ID: 151
       Name: sync.Mutex
       ByteSize: 8
       GoRuntimeType: 1.313984e+06
@@ -2930,12 +2930,12 @@ Types:
       RawFields:
         - Name: state
           Offset: 0
-          Type: 130 BaseType int32
+          Type: 12 BaseType int32
         - Name: sema
           Offset: 4
-          Type: 18 BaseType uint32
+          Type: 2 BaseType uint32
     - __kind: StructureType
-      ID: 128
+      ID: 150
       Name: sync.RWMutex
       ByteSize: 24
       GoRuntimeType: 1.750592e+06
@@ -2943,21 +2943,21 @@ Types:
       RawFields:
         - Name: w
           Offset: 0
-          Type: 129 StructureType sync.Mutex
+          Type: 151 StructureType sync.Mutex
         - Name: writerSem
           Offset: 8
-          Type: 18 BaseType uint32
+          Type: 2 BaseType uint32
         - Name: readerSem
           Offset: 12
-          Type: 18 BaseType uint32
+          Type: 2 BaseType uint32
         - Name: readerCount
           Offset: 16
-          Type: 131 StructureType sync/atomic.Int32
+          Type: 152 StructureType sync/atomic.Int32
         - Name: readerWait
           Offset: 20
-          Type: 131 StructureType sync/atomic.Int32
+          Type: 152 StructureType sync/atomic.Int32
     - __kind: StructureType
-      ID: 131
+      ID: 152
       Name: sync/atomic.Int32
       ByteSize: 4
       GoRuntimeType: 1.315424e+06
@@ -2965,18 +2965,18 @@ Types:
       RawFields:
         - Name: _
           Offset: 0
-          Type: 132 StructureType sync/atomic.noCopy
+          Type: 153 StructureType sync/atomic.noCopy
         - Name: v
           Offset: 0
-          Type: 130 BaseType int32
+          Type: 12 BaseType int32
     - __kind: StructureType
-      ID: 132
+      ID: 153
       Name: sync/atomic.noCopy
       GoRuntimeType: 965792
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 76
+      ID: 98
       Name: time.Location
       ByteSize: 104
       GoRuntimeType: 1.877376e+06
@@ -2984,27 +2984,27 @@ Types:
       RawFields:
         - Name: name
           Offset: 0
-          Type: 5 GoStringHeaderType string
+          Type: 11 GoStringHeaderType string
         - Name: zone
           Offset: 16
-          Type: 77 GoSliceHeaderType []time.zone
+          Type: 99 GoSliceHeaderType []time.zone
         - Name: tx
           Offset: 40
-          Type: 80 GoSliceHeaderType []time.zoneTrans
+          Type: 102 GoSliceHeaderType []time.zoneTrans
         - Name: extend
           Offset: 64
-          Type: 5 GoStringHeaderType string
+          Type: 11 GoStringHeaderType string
         - Name: cacheStart
           Offset: 80
-          Type: 36 BaseType int64
+          Type: 13 BaseType int64
         - Name: cacheEnd
           Offset: 88
-          Type: 36 BaseType int64
+          Type: 13 BaseType int64
         - Name: cacheZone
           Offset: 96
-          Type: 78 PointerType *time.zone
+          Type: 100 PointerType *time.zone
     - __kind: StructureType
-      ID: 73
+      ID: 96
       Name: time.Time
       ByteSize: 24
       GoRuntimeType: 2.280896e+06
@@ -3012,15 +3012,15 @@ Types:
       RawFields:
         - Name: wall
           Offset: 0
-          Type: 74 BaseType uint64
+          Type: 10 BaseType uint64
         - Name: ext
           Offset: 8
-          Type: 36 BaseType int64
+          Type: 13 BaseType int64
         - Name: loc
           Offset: 16
-          Type: 75 PointerType *time.Location
+          Type: 97 PointerType *time.Location
     - __kind: StructureType
-      ID: 79
+      ID: 101
       Name: time.zone
       ByteSize: 32
       GoRuntimeType: 1.45792e+06
@@ -3028,15 +3028,15 @@ Types:
       RawFields:
         - Name: name
           Offset: 0
-          Type: 5 GoStringHeaderType string
+          Type: 11 GoStringHeaderType string
         - Name: offset
           Offset: 16
-          Type: 8 BaseType int
+          Type: 9 BaseType int
         - Name: isDST
           Offset: 24
-          Type: 13 BaseType bool
+          Type: 4 BaseType bool
     - __kind: StructureType
-      ID: 82
+      ID: 104
       Name: time.zoneTrans
       ByteSize: 16
       GoRuntimeType: 1.663616e+06
@@ -3044,54 +3044,54 @@ Types:
       RawFields:
         - Name: when
           Offset: 0
-          Type: 36 BaseType int64
+          Type: 13 BaseType int64
         - Name: index
           Offset: 8
-          Type: 7 BaseType uint8
+          Type: 3 BaseType uint8
         - Name: isstd
           Offset: 9
-          Type: 13 BaseType bool
+          Type: 4 BaseType bool
         - Name: isutc
           Offset: 10
-          Type: 13 BaseType bool
+          Type: 4 BaseType bool
     - __kind: BaseType
-      ID: 187
+      ID: 15
       Name: uint
       ByteSize: 8
       GoRuntimeType: 542944
       GoKind: 7
     - __kind: BaseType
-      ID: 17
+      ID: 7
       Name: uint16
       ByteSize: 2
       GoRuntimeType: 542560
       GoKind: 9
     - __kind: BaseType
-      ID: 18
+      ID: 2
       Name: uint32
       ByteSize: 4
       GoRuntimeType: 542688
       GoKind: 10
     - __kind: BaseType
-      ID: 74
+      ID: 10
       Name: uint64
       ByteSize: 8
       GoRuntimeType: 542816
       GoKind: 11
     - __kind: BaseType
-      ID: 7
+      ID: 3
       Name: uint8
       ByteSize: 1
       GoRuntimeType: 542432
       GoKind: 8
     - __kind: BaseType
-      ID: 26
+      ID: 1
       Name: uintptr
       ByteSize: 8
       GoRuntimeType: 543008
       GoKind: 12
     - __kind: VoidPointerType
-      ID: 2
+      ID: 19
       Name: unsafe.Pointer
       ByteSize: 8
       GoRuntimeType: 543392

--- a/pkg/dyninst/irgen/testdata/snapshot/rc_tester.arch=amd64,toolchain=go1.23.11.yaml
+++ b/pkg/dyninst/irgen/testdata/snapshot/rc_tester.arch=amd64,toolchain=go1.23.11.yaml
@@ -10,7 +10,7 @@ Probes:
       subprogram: {subprogram: 1}
       events:
         - ID: 1
-          Type: 263 EventRootType Probe[main.HandleHTTP]
+          Type: 196 EventRootType Probe[main.HandleHTTP]
           InjectionPoints: [{PC: "0xd597d3", Frameless: false}]
           Condition: null
     - id: look_at_the_request
@@ -23,7 +23,7 @@ Probes:
       subprogram: {subprogram: 2}
       events:
         - ID: 2
-          Type: 264 EventRootType Probe[main.LookAtTheRequest]
+          Type: 197 EventRootType Probe[main.LookAtTheRequest]
           InjectionPoints: [{PC: "0xd59b2e", Frameless: false}]
           Condition: null
 Subprograms:
@@ -105,175 +105,126 @@ Subprograms:
           IsReturn: false
 Types:
     - __kind: PointerType
-      ID: 116
+      ID: 102
       Name: '**crypto/x509.Certificate'
       ByteSize: 8
-      Pointee: 117 PointerType *crypto/x509.Certificate
+      Pointee: 103 PointerType *crypto/x509.Certificate
     - __kind: PointerType
-      ID: 162
-      Name: '**github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span'
-      ByteSize: 8
-      GoKind: 22
-      Pointee: 39 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span
-    - __kind: PointerType
-      ID: 228
-      Name: '**github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttributeValue'
-      ByteSize: 8
-      GoKind: 22
-      Pointee: 229 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttributeValue
-    - __kind: PointerType
-      ID: 155
+      ID: 91
       Name: '**mime/multipart.FileHeader'
       ByteSize: 8
       GoKind: 22
-      Pointee: 156 PointerType *mime/multipart.FileHeader
+      Pointee: 92 PointerType *mime/multipart.FileHeader
     - __kind: PointerType
-      ID: 204
+      ID: 145
       Name: '**net.IPNet'
       ByteSize: 8
       GoKind: 22
-      Pointee: 205 PointerType *net.IPNet
+      Pointee: 146 PointerType *net.IPNet
     - __kind: PointerType
-      ID: 202
+      ID: 143
       Name: '**net/url.URL'
       ByteSize: 8
       GoKind: 22
-      Pointee: 45 PointerType *net/url.URL
+      Pointee: 47 PointerType *net/url.URL
     - __kind: PointerType
-      ID: 152
-      Name: '**runtime.bmap'
-      ByteSize: 8
-      Pointee: 107 PointerType *runtime.bmap
-    - __kind: PointerType
-      ID: 119
+      ID: 105
       Name: '*[]*crypto/x509.Certificate'
       ByteSize: 8
       GoKind: 22
-      Pointee: 115 GoSliceHeaderType []*crypto/x509.Certificate
+      Pointee: 101 GoSliceHeaderType []*crypto/x509.Certificate
     - __kind: PointerType
-      ID: 168
+      ID: 112
       Name: '*[]*crypto/x509.Certificate.array'
       ByteSize: 8
-      Pointee: 167 GoSliceDataType []*crypto/x509.Certificate.array
+      Pointee: 111 GoSliceDataType []*crypto/x509.Certificate.array
     - __kind: PointerType
-      ID: 215
-      Name: '*[]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span.array'
-      ByteSize: 8
-      Pointee: 214 GoSliceDataType []*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span.array
-    - __kind: PointerType
-      ID: 259
-      Name: '*[]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttributeValue.array'
-      ByteSize: 8
-      Pointee: 258 GoSliceDataType []*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttributeValue.array
-    - __kind: PointerType
-      ID: 213
+      ID: 96
       Name: '*[]*mime/multipart.FileHeader.array'
       ByteSize: 8
-      Pointee: 212 GoSliceDataType []*mime/multipart.FileHeader.array
+      Pointee: 95 GoSliceDataType []*mime/multipart.FileHeader.array
     - __kind: PointerType
-      ID: 247
+      ID: 179
       Name: '*[]*net.IPNet.array'
       ByteSize: 8
-      Pointee: 246 GoSliceDataType []*net.IPNet.array
+      Pointee: 178 GoSliceDataType []*net.IPNet.array
     - __kind: PointerType
-      ID: 245
+      ID: 176
       Name: '*[]*net/url.URL.array'
       ByteSize: 8
-      Pointee: 244 GoSliceDataType []*net/url.URL.array
+      Pointee: 175 GoSliceDataType []*net/url.URL.array
     - __kind: PointerType
-      ID: 105
-      Name: '*[]*runtime.bmap'
-      ByteSize: 8
-      GoRuntimeType: 470656
-      GoKind: 22
-      Pointee: 106 GoSliceHeaderType []*runtime.bmap
-    - __kind: PointerType
-      ID: 165
-      Name: '*[]*runtime.bmap.array'
-      ByteSize: 8
-      Pointee: 164 GoSliceDataType []*runtime.bmap.array
-    - __kind: PointerType
-      ID: 170
+      ID: 114
       Name: '*[][]*crypto/x509.Certificate.array'
       ByteSize: 8
-      Pointee: 169 GoSliceDataType [][]*crypto/x509.Certificate.array
+      Pointee: 113 GoSliceDataType [][]*crypto/x509.Certificate.array
     - __kind: PointerType
-      ID: 172
+      ID: 116
       Name: '*[][]uint8.array'
       ByteSize: 8
-      Pointee: 171 GoSliceDataType [][]uint8.array
+      Pointee: 115 GoSliceDataType [][]uint8.array
     - __kind: PointerType
-      ID: 239
+      ID: 172
       Name: '*[]crypto/x509.ExtKeyUsage.array'
       ByteSize: 8
-      Pointee: 238 GoSliceDataType []crypto/x509.ExtKeyUsage.array
+      Pointee: 171 GoSliceDataType []crypto/x509.ExtKeyUsage.array
     - __kind: PointerType
-      ID: 249
+      ID: 181
       Name: '*[]crypto/x509.OID.array'
       ByteSize: 8
-      Pointee: 248 GoSliceDataType []crypto/x509.OID.array
+      Pointee: 180 GoSliceDataType []crypto/x509.OID.array
     - __kind: PointerType
-      ID: 231
+      ID: 156
       Name: '*[]crypto/x509/pkix.AttributeTypeAndValue.array'
       ByteSize: 8
-      Pointee: 230 GoSliceDataType []crypto/x509/pkix.AttributeTypeAndValue.array
+      Pointee: 155 GoSliceDataType []crypto/x509/pkix.AttributeTypeAndValue.array
     - __kind: PointerType
-      ID: 233
+      ID: 168
       Name: '*[]crypto/x509/pkix.Extension.array'
       ByteSize: 8
-      Pointee: 232 GoSliceDataType []crypto/x509/pkix.Extension.array
+      Pointee: 167 GoSliceDataType []crypto/x509/pkix.Extension.array
     - __kind: PointerType
-      ID: 235
+      ID: 170
       Name: '*[]encoding/asn1.ObjectIdentifier.array'
       ByteSize: 8
-      Pointee: 234 GoSliceDataType []encoding/asn1.ObjectIdentifier.array
-    - __kind: PointerType
-      ID: 147
-      Name: '*[]github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink.array'
-      ByteSize: 8
-      Pointee: 146 GoSliceDataType []github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink.array
-    - __kind: PointerType
-      ID: 149
-      Name: '*[]github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent.array'
-      ByteSize: 8
-      Pointee: 148 GoSliceDataType []github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent.array
-    - __kind: PointerType
-      ID: 241
-      Name: '*[]net.IP.array'
-      ByteSize: 8
-      Pointee: 240 GoSliceDataType []net.IP.array
+      Pointee: 169 GoSliceDataType []encoding/asn1.ObjectIdentifier.array
     - __kind: PointerType
       ID: 174
+      Name: '*[]net.IP.array'
+      ByteSize: 8
+      Pointee: 173 GoSliceDataType []net.IP.array
+    - __kind: PointerType
+      ID: 193
       Name: '*[]net/http.segment.array'
       ByteSize: 8
-      Pointee: 173 GoSliceDataType []net/http.segment.array
+      Pointee: 192 GoSliceDataType []net/http.segment.array
     - __kind: PointerType
-      ID: 142
+      ID: 82
       Name: '*[]string.array'
       ByteSize: 8
-      Pointee: 141 GoSliceDataType []string.array
+      Pointee: 81 GoSliceDataType []string.array
     - __kind: PointerType
-      ID: 255
+      ID: 164
       Name: '*[]time.zone.array'
       ByteSize: 8
-      Pointee: 254 GoSliceDataType []time.zone.array
+      Pointee: 163 GoSliceDataType []time.zone.array
     - __kind: PointerType
-      ID: 257
+      ID: 166
       Name: '*[]time.zoneTrans.array'
       ByteSize: 8
-      Pointee: 256 GoSliceDataType []time.zoneTrans.array
+      Pointee: 165 GoSliceDataType []time.zoneTrans.array
     - __kind: PointerType
-      ID: 121
+      ID: 107
       Name: '*[]uint8'
       ByteSize: 8
       GoRuntimeType: 456768
       GoKind: 22
-      Pointee: 96 GoSliceHeaderType []uint8
+      Pointee: 98 GoSliceHeaderType []uint8
     - __kind: PointerType
-      ID: 151
+      ID: 100
       Name: '*[]uint8.array'
       ByteSize: 8
-      Pointee: 150 GoSliceDataType []uint8.array
+      Pointee: 99 GoSliceDataType []uint8.array
     - __kind: PointerType
       ID: 5
       Name: '*bool'
@@ -282,96 +233,81 @@ Types:
       GoKind: 22
       Pointee: 4 BaseType bool
     - __kind: PointerType
-      ID: 134
-      Name: '*bucket<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>'
-      ByteSize: 8
-      Pointee: 135 GoHMapBucketType bucket<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
-    - __kind: PointerType
-      ID: 113
+      ID: 87
       Name: '*bucket<string,[]*mime/multipart.FileHeader>'
       ByteSize: 8
-      Pointee: 114 GoHMapBucketType bucket<string,[]*mime/multipart.FileHeader>
+      Pointee: 88 GoHMapBucketType bucket<string,[]*mime/multipart.FileHeader>
     - __kind: PointerType
-      ID: 50
+      ID: 52
       Name: '*bucket<string,[]string>'
       ByteSize: 8
-      Pointee: 51 GoHMapBucketType bucket<string,[]string>
+      Pointee: 53 GoHMapBucketType bucket<string,[]string>
     - __kind: PointerType
-      ID: 85
-      Name: '*bucket<string,float64>'
-      ByteSize: 8
-      Pointee: 86 GoHMapBucketType bucket<string,float64>
-    - __kind: PointerType
-      ID: 80
-      Name: '*bucket<string,interface {}>'
-      ByteSize: 8
-      Pointee: 81 GoHMapBucketType bucket<string,interface {}>
-    - __kind: PointerType
-      ID: 71
+      ID: 73
       Name: '*bucket<string,string>'
       ByteSize: 8
-      Pointee: 72 GoHMapBucketType bucket<string,string>
+      Pointee: 74 GoHMapBucketType bucket<string,string>
     - __kind: PointerType
       ID: 41
       Name: '*bytes.Buffer'
       ByteSize: 8
       GoRuntimeType: 2.17632e+06
       GoKind: 22
-      Pointee: 42 StructureType bytes.Buffer
+      Pointee: 42 UnresolvedPointeeType bytes.Buffer
     - __kind: PointerType
-      ID: 60
+      ID: 62
       Name: '*crypto/tls.ConnectionState'
       ByteSize: 8
       GoRuntimeType: 852192
       GoKind: 22
-      Pointee: 61 StructureType crypto/tls.ConnectionState
+      Pointee: 63 StructureType crypto/tls.ConnectionState
     - __kind: PointerType
-      ID: 117
+      ID: 103
       Name: '*crypto/x509.Certificate'
       ByteSize: 8
       GoRuntimeType: 1.952864e+06
       GoKind: 22
-      Pointee: 157 StructureType crypto/x509.Certificate
+      Pointee: 110 StructureType crypto/x509.Certificate
     - __kind: PointerType
-      ID: 196
+      ID: 137
       Name: '*crypto/x509.ExtKeyUsage'
       ByteSize: 8
       GoRuntimeType: 400640
       GoKind: 22
-      Pointee: 197 BaseType crypto/x509.ExtKeyUsage
+      Pointee: 138 BaseType crypto/x509.ExtKeyUsage
     - __kind: PointerType
-      ID: 207
+      ID: 148
       Name: '*crypto/x509.OID'
       ByteSize: 8
       GoRuntimeType: 1.761792e+06
       GoKind: 22
-      Pointee: 208 StructureType crypto/x509.OID
+      Pointee: 149 StructureType crypto/x509.OID
     - __kind: PointerType
-      ID: 183
+      ID: 124
       Name: '*crypto/x509/pkix.AttributeTypeAndValue'
       ByteSize: 8
       GoRuntimeType: 417344
       GoKind: 22
-      Pointee: 184 StructureType crypto/x509/pkix.AttributeTypeAndValue
+      Pointee: 125 StructureType crypto/x509/pkix.AttributeTypeAndValue
     - __kind: PointerType
-      ID: 190
+      ID: 131
       Name: '*crypto/x509/pkix.Extension'
       ByteSize: 8
       GoRuntimeType: 417536
       GoKind: 22
-      Pointee: 191 StructureType crypto/x509/pkix.Extension
+      Pointee: 132 StructureType crypto/x509/pkix.Extension
     - __kind: PointerType
-      ID: 193
+      ID: 134
       Name: '*encoding/asn1.ObjectIdentifier'
       ByteSize: 8
       GoRuntimeType: 1.037248e+06
       GoKind: 22
-      Pointee: 194 GoSliceHeaderType encoding/asn1.ObjectIdentifier
+      Pointee: 135 GoSliceHeaderType encoding/asn1.ObjectIdentifier
     - __kind: PointerType
-      ID: 237
+      ID: 183
       Name: '*encoding/asn1.ObjectIdentifier.array'
       ByteSize: 8
-      Pointee: 236 GoSliceDataType encoding/asn1.ObjectIdentifier.array
+      Pointee: 182 GoSliceDataType encoding/asn1.ObjectIdentifier.array
     - __kind: PointerType
       ID: 33
       Name: '*error'
@@ -399,86 +335,22 @@ Types:
       ByteSize: 8
       GoRuntimeType: 2.187104e+06
       GoKind: 22
-      Pointee: 40 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span
+      Pointee: 40 UnresolvedPointeeType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span
     - __kind: PointerType
-      ID: 93
-      Name: '*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanContext'
-      ByteSize: 8
-      GoRuntimeType: 1.916704e+06
-      GoKind: 22
-      Pointee: 94 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanContext
-    - __kind: PointerType
-      ID: 88
-      Name: '*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink'
-      ByteSize: 8
-      GoRuntimeType: 1.129216e+06
-      GoKind: 22
-      Pointee: 89 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink
-    - __kind: PointerType
-      ID: 91
-      Name: '*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent'
-      ByteSize: 8
-      GoRuntimeType: 1.129344e+06
-      GoKind: 22
-      Pointee: 92 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent
-    - __kind: PointerType
-      ID: 210
-      Name: '*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttribute'
-      ByteSize: 8
-      GoRuntimeType: 1.129984e+06
-      GoKind: 22
-      Pointee: 211 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttribute
-    - __kind: PointerType
-      ID: 229
-      Name: '*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttributeValue'
-      ByteSize: 8
-      GoRuntimeType: 1.129728e+06
-      GoKind: 22
-      Pointee: 251 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttributeValue
-    - __kind: PointerType
-      ID: 159
-      Name: '*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute'
-      ByteSize: 8
-      GoRuntimeType: 1.130112e+06
-      GoKind: 22
-      Pointee: 160 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
-    - __kind: PointerType
-      ID: 137
-      Name: '*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.trace'
-      ByteSize: 8
-      GoRuntimeType: 2.131968e+06
-      GoKind: 22
-      Pointee: 138 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.trace
-    - __kind: PointerType
-      ID: 132
-      Name: '*hash<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>'
-      ByteSize: 8
-      Pointee: 133 GoHMapHeaderType hash<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
-    - __kind: PointerType
-      ID: 111
+      ID: 85
       Name: '*hash<string,[]*mime/multipart.FileHeader>'
       ByteSize: 8
-      Pointee: 112 GoHMapHeaderType hash<string,[]*mime/multipart.FileHeader>
+      Pointee: 86 GoHMapHeaderType hash<string,[]*mime/multipart.FileHeader>
     - __kind: PointerType
-      ID: 48
+      ID: 50
       Name: '*hash<string,[]string>'
       ByteSize: 8
-      Pointee: 49 GoHMapHeaderType hash<string,[]string>
+      Pointee: 51 GoHMapHeaderType hash<string,[]string>
     - __kind: PointerType
-      ID: 83
-      Name: '*hash<string,float64>'
-      ByteSize: 8
-      Pointee: 84 GoHMapHeaderType hash<string,float64>
-    - __kind: PointerType
-      ID: 78
-      Name: '*hash<string,interface {}>'
-      ByteSize: 8
-      Pointee: 79 GoHMapHeaderType hash<string,interface {}>
-    - __kind: PointerType
-      ID: 69
+      ID: 71
       Name: '*hash<string,string>'
       ByteSize: 8
-      Pointee: 70 GoHMapHeaderType hash<string,string>
+      Pointee: 72 GoHMapHeaderType hash<string,string>
     - __kind: PointerType
       ID: 27
       Name: '*int'
@@ -515,62 +387,62 @@ Types:
       GoKind: 22
       Pointee: 14 BaseType int8
     - __kind: PointerType
-      ID: 179
+      ID: 120
       Name: '*math/big.Int'
       ByteSize: 8
       GoRuntimeType: 2.296864e+06
       GoKind: 22
-      Pointee: 180 StructureType math/big.Int
+      Pointee: 121 StructureType math/big.Int
     - __kind: PointerType
-      ID: 218
+      ID: 151
       Name: '*math/big.Word'
       ByteSize: 8
       GoRuntimeType: 403456
       GoKind: 22
-      Pointee: 219 BaseType math/big.Word
+      Pointee: 152 BaseType math/big.Word
     - __kind: PointerType
-      ID: 253
+      ID: 154
       Name: '*math/big.nat.array'
       ByteSize: 8
-      Pointee: 252 GoSliceDataType math/big.nat.array
+      Pointee: 153 GoSliceDataType math/big.nat.array
     - __kind: PointerType
-      ID: 156
+      ID: 92
       Name: '*mime/multipart.FileHeader'
       ByteSize: 8
       GoRuntimeType: 853632
       GoKind: 22
-      Pointee: 176 StructureType mime/multipart.FileHeader
+      Pointee: 94 StructureType mime/multipart.FileHeader
     - __kind: PointerType
-      ID: 58
+      ID: 60
       Name: '*mime/multipart.Form'
       ByteSize: 8
       GoRuntimeType: 853728
       GoKind: 22
-      Pointee: 59 StructureType mime/multipart.Form
+      Pointee: 61 StructureType mime/multipart.Form
     - __kind: PointerType
-      ID: 199
+      ID: 140
       Name: '*net.IP'
       ByteSize: 8
       GoRuntimeType: 2.028544e+06
       GoKind: 22
-      Pointee: 200 GoSliceHeaderType net.IP
+      Pointee: 141 GoSliceHeaderType net.IP
     - __kind: PointerType
-      ID: 243
+      ID: 185
       Name: '*net.IP.array'
       ByteSize: 8
-      Pointee: 242 GoSliceDataType net.IP.array
+      Pointee: 184 GoSliceDataType net.IP.array
     - __kind: PointerType
-      ID: 262
+      ID: 188
       Name: '*net.IPMask.array'
       ByteSize: 8
-      Pointee: 261 GoSliceDataType net.IPMask.array
+      Pointee: 187 GoSliceDataType net.IPMask.array
     - __kind: PointerType
-      ID: 205
+      ID: 146
       Name: '*net.IPNet'
       ByteSize: 8
       GoRuntimeType: 1.122688e+06
       GoKind: 22
-      Pointee: 226 StructureType net.IPNet
+      Pointee: 177 StructureType net.IPNet
     - __kind: PointerType
       ID: 37
       Name: '*net/http.Request'
@@ -579,54 +451,47 @@ Types:
       GoKind: 22
       Pointee: 38 StructureType net/http.Request
     - __kind: PointerType
-      ID: 63
+      ID: 65
       Name: '*net/http.Response'
       ByteSize: 8
       GoRuntimeType: 1.63216e+06
       GoKind: 22
-      Pointee: 64 StructureType net/http.Response
+      Pointee: 66 StructureType net/http.Response
     - __kind: PointerType
-      ID: 66
+      ID: 68
       Name: '*net/http.pattern'
       ByteSize: 8
       GoRuntimeType: 1.45312e+06
       GoKind: 22
-      Pointee: 67 StructureType net/http.pattern
+      Pointee: 69 StructureType net/http.pattern
     - __kind: PointerType
-      ID: 125
+      ID: 190
       Name: '*net/http.segment'
       ByteSize: 8
       GoRuntimeType: 367808
       GoKind: 22
-      Pointee: 126 StructureType net/http.segment
+      Pointee: 191 StructureType net/http.segment
     - __kind: PointerType
-      ID: 45
+      ID: 47
       Name: '*net/url.URL'
       ByteSize: 8
       GoRuntimeType: 2.00192e+06
       GoKind: 22
-      Pointee: 46 StructureType net/url.URL
+      Pointee: 48 StructureType net/url.URL
     - __kind: PointerType
-      ID: 100
+      ID: 75
       Name: '*net/url.Userinfo'
       ByteSize: 8
       GoRuntimeType: 1.141376e+06
       GoKind: 22
-      Pointee: 101 StructureType net/url.Userinfo
+      Pointee: 76 StructureType net/url.Userinfo
     - __kind: PointerType
-      ID: 107
-      Name: '*runtime.bmap'
-      ByteSize: 8
-      GoRuntimeType: 1.137024e+06
-      GoKind: 22
-      Pointee: 108 StructureType runtime.bmap
-    - __kind: PointerType
-      ID: 52
+      ID: 54
       Name: '*runtime.mapextra'
       ByteSize: 8
       GoRuntimeType: 379904
       GoKind: 22
-      Pointee: 53 StructureType runtime.mapextra
+      Pointee: 55 UnresolvedPointeeType runtime.mapextra
     - __kind: PointerType
       ID: 22
       Name: '*string'
@@ -635,31 +500,31 @@ Types:
       GoKind: 22
       Pointee: 11 GoStringHeaderType string
     - __kind: PointerType
-      ID: 99
+      ID: 46
       Name: '*string.str'
       ByteSize: 8
-      Pointee: 98 GoStringDataType string.str
+      Pointee: 45 GoStringDataType string.str
     - __kind: PointerType
-      ID: 186
+      ID: 127
       Name: '*time.Location'
       ByteSize: 8
       GoRuntimeType: 1.458112e+06
       GoKind: 22
-      Pointee: 187 StructureType time.Location
+      Pointee: 128 StructureType time.Location
     - __kind: PointerType
-      ID: 221
+      ID: 158
       Name: '*time.zone'
       ByteSize: 8
       GoRuntimeType: 370880
       GoKind: 22
-      Pointee: 222 StructureType time.zone
+      Pointee: 159 StructureType time.zone
     - __kind: PointerType
-      ID: 224
+      ID: 161
       Name: '*time.zoneTrans'
       ByteSize: 8
       GoRuntimeType: 370944
       GoKind: 22
-      Pointee: 225 StructureType time.zoneTrans
+      Pointee: 162 StructureType time.zoneTrans
     - __kind: PointerType
       ID: 34
       Name: '*uint'
@@ -703,12 +568,12 @@ Types:
       GoKind: 22
       Pointee: 1 BaseType uintptr
     - __kind: GoChannelType
-      ID: 62
+      ID: 64
       Name: <-chan struct {}
       GoRuntimeType: 555296
       GoKind: 18
     - __kind: EventRootType
-      ID: 263
+      ID: 196
       Name: Probe[main.HandleHTTP]
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -732,7 +597,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 264
+      ID: 197
       Name: Probe[main.LookAtTheRequest]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -747,7 +612,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: ArrayType
-      ID: 102
+      ID: 77
       Name: '[8]uint8'
       ByteSize: 8
       GoRuntimeType: 632608
@@ -756,7 +621,7 @@ Types:
       HasCount: true
       Element: 3 BaseType uint8
     - __kind: GoSliceHeaderType
-      ID: 115
+      ID: 101
       Name: '[]*crypto/x509.Certificate'
       ByteSize: 24
       GoRuntimeType: 473760
@@ -764,65 +629,21 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 116 PointerType **crypto/x509.Certificate
+          Type: 102 PointerType **crypto/x509.Certificate
         - Name: len
           Offset: 8
           Type: 9 BaseType int
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 167 GoSliceDataType []*crypto/x509.Certificate.array
+      Data: 111 GoSliceDataType []*crypto/x509.Certificate.array
     - __kind: GoSliceDataType
-      ID: 167
+      ID: 111
       Name: '[]*crypto/x509.Certificate.array'
       ByteSize: 2048
-      Element: 117 PointerType *crypto/x509.Certificate
+      Element: 103 PointerType *crypto/x509.Certificate
     - __kind: GoSliceHeaderType
-      ID: 161
-      Name: '[]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span'
-      ByteSize: 24
-      GoRuntimeType: 463872
-      GoKind: 23
-      RawFields:
-        - Name: array
-          Offset: 0
-          Type: 162 PointerType **github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span
-        - Name: len
-          Offset: 8
-          Type: 9 BaseType int
-        - Name: cap
-          Offset: 16
-          Type: 9 BaseType int
-      Data: 214 GoSliceDataType []*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span.array
-    - __kind: GoSliceDataType
-      ID: 214
-      Name: '[]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span.array'
-      ByteSize: 2048
-      Element: 39 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span
-    - __kind: GoSliceHeaderType
-      ID: 227
-      Name: '[]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttributeValue'
-      ByteSize: 24
-      GoRuntimeType: 463488
-      GoKind: 23
-      RawFields:
-        - Name: array
-          Offset: 0
-          Type: 228 PointerType **github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttributeValue
-        - Name: len
-          Offset: 8
-          Type: 9 BaseType int
-        - Name: cap
-          Offset: 16
-          Type: 9 BaseType int
-      Data: 258 GoSliceDataType []*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttributeValue.array
-    - __kind: GoSliceDataType
-      ID: 258
-      Name: '[]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttributeValue.array'
-      ByteSize: 2048
-      Element: 229 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttributeValue
-    - __kind: GoSliceHeaderType
-      ID: 154
+      ID: 90
       Name: '[]*mime/multipart.FileHeader'
       ByteSize: 24
       GoRuntimeType: 461504
@@ -830,21 +651,21 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 155 PointerType **mime/multipart.FileHeader
+          Type: 91 PointerType **mime/multipart.FileHeader
         - Name: len
           Offset: 8
           Type: 9 BaseType int
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 212 GoSliceDataType []*mime/multipart.FileHeader.array
+      Data: 95 GoSliceDataType []*mime/multipart.FileHeader.array
     - __kind: GoSliceDataType
-      ID: 212
+      ID: 95
       Name: '[]*mime/multipart.FileHeader.array'
       ByteSize: 2048
-      Element: 156 PointerType *mime/multipart.FileHeader
+      Element: 92 PointerType *mime/multipart.FileHeader
     - __kind: GoSliceHeaderType
-      ID: 203
+      ID: 144
       Name: '[]*net.IPNet'
       ByteSize: 24
       GoRuntimeType: 486816
@@ -852,21 +673,21 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 204 PointerType **net.IPNet
+          Type: 145 PointerType **net.IPNet
         - Name: len
           Offset: 8
           Type: 9 BaseType int
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 246 GoSliceDataType []*net.IPNet.array
+      Data: 178 GoSliceDataType []*net.IPNet.array
     - __kind: GoSliceDataType
-      ID: 246
+      ID: 178
       Name: '[]*net.IPNet.array'
       ByteSize: 2048
-      Element: 205 PointerType *net.IPNet
+      Element: 146 PointerType *net.IPNet
     - __kind: GoSliceHeaderType
-      ID: 201
+      ID: 142
       Name: '[]*net/url.URL'
       ByteSize: 24
       GoRuntimeType: 486752
@@ -874,43 +695,21 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 202 PointerType **net/url.URL
+          Type: 143 PointerType **net/url.URL
         - Name: len
           Offset: 8
           Type: 9 BaseType int
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 244 GoSliceDataType []*net/url.URL.array
+      Data: 175 GoSliceDataType []*net/url.URL.array
     - __kind: GoSliceDataType
-      ID: 244
+      ID: 175
       Name: '[]*net/url.URL.array'
       ByteSize: 2048
-      Element: 45 PointerType *net/url.URL
+      Element: 47 PointerType *net/url.URL
     - __kind: GoSliceHeaderType
-      ID: 106
-      Name: '[]*runtime.bmap'
-      ByteSize: 24
-      GoRuntimeType: 470592
-      GoKind: 23
-      RawFields:
-        - Name: array
-          Offset: 0
-          Type: 152 PointerType **runtime.bmap
-        - Name: len
-          Offset: 8
-          Type: 9 BaseType int
-        - Name: cap
-          Offset: 16
-          Type: 9 BaseType int
-      Data: 164 GoSliceDataType []*runtime.bmap.array
-    - __kind: GoSliceDataType
-      ID: 164
-      Name: '[]*runtime.bmap.array'
-      ByteSize: 2048
-      Element: 107 PointerType *runtime.bmap
-    - __kind: GoSliceHeaderType
-      ID: 118
+      ID: 104
       Name: '[][]*crypto/x509.Certificate'
       ByteSize: 24
       GoRuntimeType: 473888
@@ -918,21 +717,21 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 119 PointerType *[]*crypto/x509.Certificate
+          Type: 105 PointerType *[]*crypto/x509.Certificate
         - Name: len
           Offset: 8
           Type: 9 BaseType int
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 169 GoSliceDataType [][]*crypto/x509.Certificate.array
+      Data: 113 GoSliceDataType [][]*crypto/x509.Certificate.array
     - __kind: GoSliceDataType
-      ID: 169
+      ID: 113
       Name: '[][]*crypto/x509.Certificate.array'
       ByteSize: 2048
-      Element: 115 GoSliceHeaderType []*crypto/x509.Certificate
+      Element: 101 GoSliceHeaderType []*crypto/x509.Certificate
     - __kind: GoSliceHeaderType
-      ID: 120
+      ID: 106
       Name: '[][]uint8'
       ByteSize: 24
       GoRuntimeType: 457024
@@ -940,51 +739,36 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 121 PointerType *[]uint8
+          Type: 107 PointerType *[]uint8
         - Name: len
           Offset: 8
           Type: 9 BaseType int
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 171 GoSliceDataType [][]uint8.array
+      Data: 115 GoSliceDataType [][]uint8.array
     - __kind: GoSliceDataType
-      ID: 171
+      ID: 115
       Name: '[][]uint8.array'
       ByteSize: 2048
-      Element: 96 GoSliceHeaderType []uint8
+      Element: 98 GoSliceHeaderType []uint8
     - __kind: GoSliceDataType
-      ID: 175
-      Name: '[]bucket<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>.array'
-      ByteSize: 2048
-      Element: 135 GoHMapBucketType bucket<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
-    - __kind: GoSliceDataType
-      ID: 166
+      ID: 93
       Name: '[]bucket<string,[]*mime/multipart.FileHeader>.array'
       ByteSize: 2048
-      Element: 114 GoHMapBucketType bucket<string,[]*mime/multipart.FileHeader>
+      Element: 88 GoHMapBucketType bucket<string,[]*mime/multipart.FileHeader>
     - __kind: GoSliceDataType
-      ID: 140
+      ID: 80
       Name: '[]bucket<string,[]string>.array'
       ByteSize: 2048
-      Element: 51 GoHMapBucketType bucket<string,[]string>
+      Element: 53 GoHMapBucketType bucket<string,[]string>
     - __kind: GoSliceDataType
-      ID: 145
-      Name: '[]bucket<string,float64>.array'
-      ByteSize: 2048
-      Element: 86 GoHMapBucketType bucket<string,float64>
-    - __kind: GoSliceDataType
-      ID: 144
-      Name: '[]bucket<string,interface {}>.array'
-      ByteSize: 2048
-      Element: 81 GoHMapBucketType bucket<string,interface {}>
-    - __kind: GoSliceDataType
-      ID: 143
+      ID: 195
       Name: '[]bucket<string,string>.array'
       ByteSize: 2048
-      Element: 72 GoHMapBucketType bucket<string,string>
+      Element: 74 GoHMapBucketType bucket<string,string>
     - __kind: GoSliceHeaderType
-      ID: 195
+      ID: 136
       Name: '[]crypto/x509.ExtKeyUsage'
       ByteSize: 24
       GoRuntimeType: 475040
@@ -992,21 +776,21 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 196 PointerType *crypto/x509.ExtKeyUsage
+          Type: 137 PointerType *crypto/x509.ExtKeyUsage
         - Name: len
           Offset: 8
           Type: 9 BaseType int
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 238 GoSliceDataType []crypto/x509.ExtKeyUsage.array
+      Data: 171 GoSliceDataType []crypto/x509.ExtKeyUsage.array
     - __kind: GoSliceDataType
-      ID: 238
+      ID: 171
       Name: '[]crypto/x509.ExtKeyUsage.array'
       ByteSize: 2048
-      Element: 197 BaseType crypto/x509.ExtKeyUsage
+      Element: 138 BaseType crypto/x509.ExtKeyUsage
     - __kind: GoSliceHeaderType
-      ID: 206
+      ID: 147
       Name: '[]crypto/x509.OID'
       ByteSize: 24
       GoRuntimeType: 486880
@@ -1014,21 +798,21 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 207 PointerType *crypto/x509.OID
+          Type: 148 PointerType *crypto/x509.OID
         - Name: len
           Offset: 8
           Type: 9 BaseType int
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 248 GoSliceDataType []crypto/x509.OID.array
+      Data: 180 GoSliceDataType []crypto/x509.OID.array
     - __kind: GoSliceDataType
-      ID: 248
+      ID: 180
       Name: '[]crypto/x509.OID.array'
       ByteSize: 2048
-      Element: 208 StructureType crypto/x509.OID
+      Element: 149 StructureType crypto/x509.OID
     - __kind: GoSliceHeaderType
-      ID: 182
+      ID: 123
       Name: '[]crypto/x509/pkix.AttributeTypeAndValue'
       ByteSize: 24
       GoRuntimeType: 487136
@@ -1036,21 +820,21 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 183 PointerType *crypto/x509/pkix.AttributeTypeAndValue
+          Type: 124 PointerType *crypto/x509/pkix.AttributeTypeAndValue
         - Name: len
           Offset: 8
           Type: 9 BaseType int
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 230 GoSliceDataType []crypto/x509/pkix.AttributeTypeAndValue.array
+      Data: 155 GoSliceDataType []crypto/x509/pkix.AttributeTypeAndValue.array
     - __kind: GoSliceDataType
-      ID: 230
+      ID: 155
       Name: '[]crypto/x509/pkix.AttributeTypeAndValue.array'
       ByteSize: 2048
-      Element: 184 StructureType crypto/x509/pkix.AttributeTypeAndValue
+      Element: 125 StructureType crypto/x509/pkix.AttributeTypeAndValue
     - __kind: GoSliceHeaderType
-      ID: 189
+      ID: 130
       Name: '[]crypto/x509/pkix.Extension'
       ByteSize: 24
       GoRuntimeType: 486624
@@ -1058,21 +842,21 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 190 PointerType *crypto/x509/pkix.Extension
+          Type: 131 PointerType *crypto/x509/pkix.Extension
         - Name: len
           Offset: 8
           Type: 9 BaseType int
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 232 GoSliceDataType []crypto/x509/pkix.Extension.array
+      Data: 167 GoSliceDataType []crypto/x509/pkix.Extension.array
     - __kind: GoSliceDataType
-      ID: 232
+      ID: 167
       Name: '[]crypto/x509/pkix.Extension.array'
       ByteSize: 2048
-      Element: 191 StructureType crypto/x509/pkix.Extension
+      Element: 132 StructureType crypto/x509/pkix.Extension
     - __kind: GoSliceHeaderType
-      ID: 192
+      ID: 133
       Name: '[]encoding/asn1.ObjectIdentifier'
       ByteSize: 24
       GoRuntimeType: 486688
@@ -1080,72 +864,28 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 193 PointerType *encoding/asn1.ObjectIdentifier
+          Type: 134 PointerType *encoding/asn1.ObjectIdentifier
         - Name: len
           Offset: 8
           Type: 9 BaseType int
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 234 GoSliceDataType []encoding/asn1.ObjectIdentifier.array
+      Data: 169 GoSliceDataType []encoding/asn1.ObjectIdentifier.array
     - __kind: GoSliceDataType
-      ID: 234
+      ID: 169
       Name: '[]encoding/asn1.ObjectIdentifier.array'
       ByteSize: 2048
-      Element: 194 GoSliceHeaderType encoding/asn1.ObjectIdentifier
-    - __kind: GoSliceHeaderType
-      ID: 87
-      Name: '[]github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink'
-      ByteSize: 24
-      GoRuntimeType: 463424
-      GoKind: 23
-      RawFields:
-        - Name: array
-          Offset: 0
-          Type: 88 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink
-        - Name: len
-          Offset: 8
-          Type: 9 BaseType int
-        - Name: cap
-          Offset: 16
-          Type: 9 BaseType int
-      Data: 146 GoSliceDataType []github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink.array
-    - __kind: GoSliceDataType
-      ID: 146
-      Name: '[]github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink.array'
-      ByteSize: 2048
-      Element: 89 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink
-    - __kind: GoSliceHeaderType
-      ID: 90
-      Name: '[]github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent'
-      ByteSize: 24
-      GoRuntimeType: 463616
-      GoKind: 23
-      RawFields:
-        - Name: array
-          Offset: 0
-          Type: 91 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent
-        - Name: len
-          Offset: 8
-          Type: 9 BaseType int
-        - Name: cap
-          Offset: 16
-          Type: 9 BaseType int
-      Data: 148 GoSliceDataType []github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent.array
-    - __kind: GoSliceDataType
-      ID: 148
-      Name: '[]github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent.array'
-      ByteSize: 2048
-      Element: 92 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent
+      Element: 135 GoSliceHeaderType encoding/asn1.ObjectIdentifier
     - __kind: ArrayType
-      ID: 103
+      ID: 78
       Name: '[]key<string>'
       ByteSize: 128
       Count: 8
       HasCount: true
       Element: 11 GoStringHeaderType string
     - __kind: GoSliceHeaderType
-      ID: 198
+      ID: 139
       Name: '[]net.IP'
       ByteSize: 24
       GoRuntimeType: 458240
@@ -1153,21 +893,21 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 199 PointerType *net.IP
+          Type: 140 PointerType *net.IP
         - Name: len
           Offset: 8
           Type: 9 BaseType int
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 240 GoSliceDataType []net.IP.array
+      Data: 173 GoSliceDataType []net.IP.array
     - __kind: GoSliceDataType
-      ID: 240
+      ID: 173
       Name: '[]net.IP.array'
       ByteSize: 2048
-      Element: 200 GoSliceHeaderType net.IP
+      Element: 141 GoSliceHeaderType net.IP
     - __kind: GoSliceHeaderType
-      ID: 124
+      ID: 189
       Name: '[]net/http.segment'
       ByteSize: 24
       GoRuntimeType: 459008
@@ -1175,21 +915,21 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 125 PointerType *net/http.segment
+          Type: 190 PointerType *net/http.segment
         - Name: len
           Offset: 8
           Type: 9 BaseType int
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 173 GoSliceDataType []net/http.segment.array
+      Data: 192 GoSliceDataType []net/http.segment.array
     - __kind: GoSliceDataType
-      ID: 173
+      ID: 192
       Name: '[]net/http.segment.array'
       ByteSize: 2048
-      Element: 126 StructureType net/http.segment
+      Element: 191 StructureType net/http.segment
     - __kind: GoSliceHeaderType
-      ID: 56
+      ID: 58
       Name: '[]string'
       ByteSize: 24
       GoRuntimeType: 468992
@@ -1204,14 +944,14 @@ Types:
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 141 GoSliceDataType []string.array
+      Data: 81 GoSliceDataType []string.array
     - __kind: GoSliceDataType
-      ID: 141
+      ID: 81
       Name: '[]string.array'
       ByteSize: 2048
       Element: 11 GoStringHeaderType string
     - __kind: GoSliceHeaderType
-      ID: 220
+      ID: 157
       Name: '[]time.zone'
       ByteSize: 24
       GoRuntimeType: 463104
@@ -1219,21 +959,21 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 221 PointerType *time.zone
+          Type: 158 PointerType *time.zone
         - Name: len
           Offset: 8
           Type: 9 BaseType int
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 254 GoSliceDataType []time.zone.array
+      Data: 163 GoSliceDataType []time.zone.array
     - __kind: GoSliceDataType
-      ID: 254
+      ID: 163
       Name: '[]time.zone.array'
       ByteSize: 2048
-      Element: 222 StructureType time.zone
+      Element: 159 StructureType time.zone
     - __kind: GoSliceHeaderType
-      ID: 223
+      ID: 160
       Name: '[]time.zoneTrans'
       ByteSize: 24
       GoRuntimeType: 463168
@@ -1241,21 +981,21 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 224 PointerType *time.zoneTrans
+          Type: 161 PointerType *time.zoneTrans
         - Name: len
           Offset: 8
           Type: 9 BaseType int
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 256 GoSliceDataType []time.zoneTrans.array
+      Data: 165 GoSliceDataType []time.zoneTrans.array
     - __kind: GoSliceDataType
-      ID: 256
+      ID: 165
       Name: '[]time.zoneTrans.array'
       ByteSize: 2048
-      Element: 225 StructureType time.zoneTrans
+      Element: 162 StructureType time.zoneTrans
     - __kind: GoSliceHeaderType
-      ID: 96
+      ID: 98
       Name: '[]uint8'
       ByteSize: 24
       GoRuntimeType: 467840
@@ -1270,49 +1010,28 @@ Types:
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 150 GoSliceDataType []uint8.array
+      Data: 99 GoSliceDataType []uint8.array
     - __kind: GoSliceDataType
-      ID: 150
+      ID: 99
       Name: '[]uint8.array'
       ByteSize: 2048
       Element: 3 BaseType uint8
     - __kind: ArrayType
-      ID: 158
-      Name: '[]val<*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>'
-      ByteSize: 64
-      Count: 8
-      HasCount: true
-      Element: 159 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
-    - __kind: ArrayType
-      ID: 153
+      ID: 89
       Name: '[]val<[]*mime/multipart.FileHeader>'
       ByteSize: 192
       Count: 8
       HasCount: true
-      Element: 154 GoSliceHeaderType []*mime/multipart.FileHeader
+      Element: 90 GoSliceHeaderType []*mime/multipart.FileHeader
     - __kind: ArrayType
-      ID: 104
+      ID: 79
       Name: '[]val<[]string>'
       ByteSize: 192
       Count: 8
       HasCount: true
-      Element: 56 GoSliceHeaderType []string
+      Element: 58 GoSliceHeaderType []string
     - __kind: ArrayType
-      ID: 130
-      Name: '[]val<float64>'
-      ByteSize: 64
-      Count: 8
-      HasCount: true
-      Element: 17 BaseType float64
-    - __kind: ArrayType
-      ID: 128
-      Name: '[]val<interface {}>'
-      ByteSize: 128
-      Count: 8
-      HasCount: true
-      Element: 129 GoEmptyInterfaceType interface {}
-    - __kind: ArrayType
-      ID: 127
+      ID: 194
       Name: '[]val<string>'
       ByteSize: 128
       Count: 8
@@ -1325,141 +1044,66 @@ Types:
       GoRuntimeType: 543328
       GoKind: 1
     - __kind: GoHMapBucketType
-      ID: 135
-      Name: bucket<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
-      ByteSize: 208
-      RawFields:
-        - Name: tophash
-          Offset: 0
-          Type: 102 ArrayType [8]uint8
-        - Name: keys
-          Offset: 8
-          Type: 103 ArrayType []key<string>
-        - Name: values
-          Offset: 136
-          Type: 158 ArrayType []val<*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
-        - Name: overflow
-          Offset: 200
-          Type: 134 PointerType *bucket<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
-      KeyType: 11 GoStringHeaderType string
-      ValueType: 159 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
-    - __kind: GoHMapBucketType
-      ID: 114
+      ID: 88
       Name: bucket<string,[]*mime/multipart.FileHeader>
       ByteSize: 336
       RawFields:
         - Name: tophash
           Offset: 0
-          Type: 102 ArrayType [8]uint8
+          Type: 77 ArrayType [8]uint8
         - Name: keys
           Offset: 8
-          Type: 103 ArrayType []key<string>
+          Type: 78 ArrayType []key<string>
         - Name: values
           Offset: 136
-          Type: 153 ArrayType []val<[]*mime/multipart.FileHeader>
+          Type: 89 ArrayType []val<[]*mime/multipart.FileHeader>
         - Name: overflow
           Offset: 328
-          Type: 113 PointerType *bucket<string,[]*mime/multipart.FileHeader>
+          Type: 87 PointerType *bucket<string,[]*mime/multipart.FileHeader>
       KeyType: 11 GoStringHeaderType string
-      ValueType: 154 GoSliceHeaderType []*mime/multipart.FileHeader
+      ValueType: 90 GoSliceHeaderType []*mime/multipart.FileHeader
     - __kind: GoHMapBucketType
-      ID: 51
+      ID: 53
       Name: bucket<string,[]string>
       ByteSize: 336
       RawFields:
         - Name: tophash
           Offset: 0
-          Type: 102 ArrayType [8]uint8
+          Type: 77 ArrayType [8]uint8
         - Name: keys
           Offset: 8
-          Type: 103 ArrayType []key<string>
+          Type: 78 ArrayType []key<string>
         - Name: values
           Offset: 136
-          Type: 104 ArrayType []val<[]string>
+          Type: 79 ArrayType []val<[]string>
         - Name: overflow
           Offset: 328
-          Type: 50 PointerType *bucket<string,[]string>
+          Type: 52 PointerType *bucket<string,[]string>
       KeyType: 11 GoStringHeaderType string
-      ValueType: 56 GoSliceHeaderType []string
+      ValueType: 58 GoSliceHeaderType []string
     - __kind: GoHMapBucketType
-      ID: 86
-      Name: bucket<string,float64>
-      ByteSize: 208
-      RawFields:
-        - Name: tophash
-          Offset: 0
-          Type: 102 ArrayType [8]uint8
-        - Name: keys
-          Offset: 8
-          Type: 103 ArrayType []key<string>
-        - Name: values
-          Offset: 136
-          Type: 130 ArrayType []val<float64>
-        - Name: overflow
-          Offset: 200
-          Type: 85 PointerType *bucket<string,float64>
-      KeyType: 11 GoStringHeaderType string
-      ValueType: 17 BaseType float64
-    - __kind: GoHMapBucketType
-      ID: 81
-      Name: bucket<string,interface {}>
-      ByteSize: 272
-      RawFields:
-        - Name: tophash
-          Offset: 0
-          Type: 102 ArrayType [8]uint8
-        - Name: keys
-          Offset: 8
-          Type: 103 ArrayType []key<string>
-        - Name: values
-          Offset: 136
-          Type: 128 ArrayType []val<interface {}>
-        - Name: overflow
-          Offset: 264
-          Type: 80 PointerType *bucket<string,interface {}>
-      KeyType: 11 GoStringHeaderType string
-      ValueType: 129 GoEmptyInterfaceType interface {}
-    - __kind: GoHMapBucketType
-      ID: 72
+      ID: 74
       Name: bucket<string,string>
       ByteSize: 272
       RawFields:
         - Name: tophash
           Offset: 0
-          Type: 102 ArrayType [8]uint8
+          Type: 77 ArrayType [8]uint8
         - Name: keys
           Offset: 8
-          Type: 103 ArrayType []key<string>
+          Type: 78 ArrayType []key<string>
         - Name: values
           Offset: 136
-          Type: 127 ArrayType []val<string>
+          Type: 194 ArrayType []val<string>
         - Name: overflow
           Offset: 264
-          Type: 71 PointerType *bucket<string,string>
+          Type: 73 PointerType *bucket<string,string>
       KeyType: 11 GoStringHeaderType string
       ValueType: 11 GoStringHeaderType string
-    - __kind: StructureType
+    - __kind: UnresolvedPointeeType
       ID: 42
       Name: bytes.Buffer
-      ByteSize: 40
-      GoRuntimeType: 1.450816e+06
-      GoKind: 25
-      RawFields:
-        - Name: buf
-          Offset: 0
-          Type: 96 GoSliceHeaderType []uint8
-        - Name: off
-          Offset: 24
-          Type: 9 BaseType int
-        - Name: lastRead
-          Offset: 32
-          Type: 97 BaseType bytes.readOp
-    - __kind: BaseType
-      ID: 97
-      Name: bytes.readOp
-      ByteSize: 1
-      GoRuntimeType: 541536
-      GoKind: 3
+      ByteSize: 8
     - __kind: BaseType
       ID: 24
       Name: complex128
@@ -1473,7 +1117,7 @@ Types:
       GoRuntimeType: 543072
       GoKind: 15
     - __kind: GoInterfaceType
-      ID: 65
+      ID: 67
       Name: context.Context
       ByteSize: 16
       GoRuntimeType: 1.215552e+06
@@ -1501,7 +1145,7 @@ Types:
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 61
+      ID: 63
       Name: crypto/tls.ConnectionState
       ByteSize: 192
       GoRuntimeType: 2.160384e+06
@@ -1530,39 +1174,39 @@ Types:
           Type: 11 GoStringHeaderType string
         - Name: PeerCertificates
           Offset: 48
-          Type: 115 GoSliceHeaderType []*crypto/x509.Certificate
+          Type: 101 GoSliceHeaderType []*crypto/x509.Certificate
         - Name: VerifiedChains
           Offset: 72
-          Type: 118 GoSliceHeaderType [][]*crypto/x509.Certificate
+          Type: 104 GoSliceHeaderType [][]*crypto/x509.Certificate
         - Name: SignedCertificateTimestamps
           Offset: 96
-          Type: 120 GoSliceHeaderType [][]uint8
+          Type: 106 GoSliceHeaderType [][]uint8
         - Name: OCSPResponse
           Offset: 120
-          Type: 96 GoSliceHeaderType []uint8
+          Type: 98 GoSliceHeaderType []uint8
         - Name: TLSUnique
           Offset: 144
-          Type: 96 GoSliceHeaderType []uint8
+          Type: 98 GoSliceHeaderType []uint8
         - Name: ECHAccepted
           Offset: 168
           Type: 4 BaseType bool
         - Name: ekm
           Offset: 176
-          Type: 122 GoSubroutineType func(string, []uint8, int) ([]uint8, error)
+          Type: 108 GoSubroutineType func(string, []uint8, int) ([]uint8, error)
         - Name: testingOnlyDidHRR
           Offset: 184
           Type: 4 BaseType bool
         - Name: testingOnlyCurveID
           Offset: 186
-          Type: 123 BaseType crypto/tls.CurveID
+          Type: 109 BaseType crypto/tls.CurveID
     - __kind: BaseType
-      ID: 123
+      ID: 109
       Name: crypto/tls.CurveID
       ByteSize: 2
       GoRuntimeType: 778464
       GoKind: 9
     - __kind: StructureType
-      ID: 157
+      ID: 110
       Name: crypto/x509.Certificate
       ByteSize: 1352
       GoRuntimeType: 2.300416e+06
@@ -1570,67 +1214,67 @@ Types:
       RawFields:
         - Name: Raw
           Offset: 0
-          Type: 96 GoSliceHeaderType []uint8
+          Type: 98 GoSliceHeaderType []uint8
         - Name: RawTBSCertificate
           Offset: 24
-          Type: 96 GoSliceHeaderType []uint8
+          Type: 98 GoSliceHeaderType []uint8
         - Name: RawSubjectPublicKeyInfo
           Offset: 48
-          Type: 96 GoSliceHeaderType []uint8
+          Type: 98 GoSliceHeaderType []uint8
         - Name: RawSubject
           Offset: 72
-          Type: 96 GoSliceHeaderType []uint8
+          Type: 98 GoSliceHeaderType []uint8
         - Name: RawIssuer
           Offset: 96
-          Type: 96 GoSliceHeaderType []uint8
+          Type: 98 GoSliceHeaderType []uint8
         - Name: Signature
           Offset: 120
-          Type: 96 GoSliceHeaderType []uint8
+          Type: 98 GoSliceHeaderType []uint8
         - Name: SignatureAlgorithm
           Offset: 144
-          Type: 177 BaseType crypto/x509.SignatureAlgorithm
+          Type: 117 BaseType crypto/x509.SignatureAlgorithm
         - Name: PublicKeyAlgorithm
           Offset: 152
-          Type: 178 BaseType crypto/x509.PublicKeyAlgorithm
+          Type: 118 BaseType crypto/x509.PublicKeyAlgorithm
         - Name: PublicKey
           Offset: 160
-          Type: 129 GoEmptyInterfaceType interface {}
+          Type: 119 GoEmptyInterfaceType interface {}
         - Name: Version
           Offset: 176
           Type: 9 BaseType int
         - Name: SerialNumber
           Offset: 184
-          Type: 179 PointerType *math/big.Int
+          Type: 120 PointerType *math/big.Int
         - Name: Issuer
           Offset: 192
-          Type: 181 StructureType crypto/x509/pkix.Name
+          Type: 122 StructureType crypto/x509/pkix.Name
         - Name: Subject
           Offset: 440
-          Type: 181 StructureType crypto/x509/pkix.Name
+          Type: 122 StructureType crypto/x509/pkix.Name
         - Name: NotBefore
           Offset: 688
-          Type: 185 StructureType time.Time
+          Type: 126 StructureType time.Time
         - Name: NotAfter
           Offset: 712
-          Type: 185 StructureType time.Time
+          Type: 126 StructureType time.Time
         - Name: KeyUsage
           Offset: 736
-          Type: 188 BaseType crypto/x509.KeyUsage
+          Type: 129 BaseType crypto/x509.KeyUsage
         - Name: Extensions
           Offset: 744
-          Type: 189 GoSliceHeaderType []crypto/x509/pkix.Extension
+          Type: 130 GoSliceHeaderType []crypto/x509/pkix.Extension
         - Name: ExtraExtensions
           Offset: 768
-          Type: 189 GoSliceHeaderType []crypto/x509/pkix.Extension
+          Type: 130 GoSliceHeaderType []crypto/x509/pkix.Extension
         - Name: UnhandledCriticalExtensions
           Offset: 792
-          Type: 192 GoSliceHeaderType []encoding/asn1.ObjectIdentifier
+          Type: 133 GoSliceHeaderType []encoding/asn1.ObjectIdentifier
         - Name: ExtKeyUsage
           Offset: 816
-          Type: 195 GoSliceHeaderType []crypto/x509.ExtKeyUsage
+          Type: 136 GoSliceHeaderType []crypto/x509.ExtKeyUsage
         - Name: UnknownExtKeyUsage
           Offset: 840
-          Type: 192 GoSliceHeaderType []encoding/asn1.ObjectIdentifier
+          Type: 133 GoSliceHeaderType []encoding/asn1.ObjectIdentifier
         - Name: BasicConstraintsValid
           Offset: 864
           Type: 4 BaseType bool
@@ -1645,78 +1289,78 @@ Types:
           Type: 4 BaseType bool
         - Name: SubjectKeyId
           Offset: 888
-          Type: 96 GoSliceHeaderType []uint8
+          Type: 98 GoSliceHeaderType []uint8
         - Name: AuthorityKeyId
           Offset: 912
-          Type: 96 GoSliceHeaderType []uint8
+          Type: 98 GoSliceHeaderType []uint8
         - Name: OCSPServer
           Offset: 936
-          Type: 56 GoSliceHeaderType []string
+          Type: 58 GoSliceHeaderType []string
         - Name: IssuingCertificateURL
           Offset: 960
-          Type: 56 GoSliceHeaderType []string
+          Type: 58 GoSliceHeaderType []string
         - Name: DNSNames
           Offset: 984
-          Type: 56 GoSliceHeaderType []string
+          Type: 58 GoSliceHeaderType []string
         - Name: EmailAddresses
           Offset: 1008
-          Type: 56 GoSliceHeaderType []string
+          Type: 58 GoSliceHeaderType []string
         - Name: IPAddresses
           Offset: 1032
-          Type: 198 GoSliceHeaderType []net.IP
+          Type: 139 GoSliceHeaderType []net.IP
         - Name: URIs
           Offset: 1056
-          Type: 201 GoSliceHeaderType []*net/url.URL
+          Type: 142 GoSliceHeaderType []*net/url.URL
         - Name: PermittedDNSDomainsCritical
           Offset: 1080
           Type: 4 BaseType bool
         - Name: PermittedDNSDomains
           Offset: 1088
-          Type: 56 GoSliceHeaderType []string
+          Type: 58 GoSliceHeaderType []string
         - Name: ExcludedDNSDomains
           Offset: 1112
-          Type: 56 GoSliceHeaderType []string
+          Type: 58 GoSliceHeaderType []string
         - Name: PermittedIPRanges
           Offset: 1136
-          Type: 203 GoSliceHeaderType []*net.IPNet
+          Type: 144 GoSliceHeaderType []*net.IPNet
         - Name: ExcludedIPRanges
           Offset: 1160
-          Type: 203 GoSliceHeaderType []*net.IPNet
+          Type: 144 GoSliceHeaderType []*net.IPNet
         - Name: PermittedEmailAddresses
           Offset: 1184
-          Type: 56 GoSliceHeaderType []string
+          Type: 58 GoSliceHeaderType []string
         - Name: ExcludedEmailAddresses
           Offset: 1208
-          Type: 56 GoSliceHeaderType []string
+          Type: 58 GoSliceHeaderType []string
         - Name: PermittedURIDomains
           Offset: 1232
-          Type: 56 GoSliceHeaderType []string
+          Type: 58 GoSliceHeaderType []string
         - Name: ExcludedURIDomains
           Offset: 1256
-          Type: 56 GoSliceHeaderType []string
+          Type: 58 GoSliceHeaderType []string
         - Name: CRLDistributionPoints
           Offset: 1280
-          Type: 56 GoSliceHeaderType []string
+          Type: 58 GoSliceHeaderType []string
         - Name: PolicyIdentifiers
           Offset: 1304
-          Type: 192 GoSliceHeaderType []encoding/asn1.ObjectIdentifier
+          Type: 133 GoSliceHeaderType []encoding/asn1.ObjectIdentifier
         - Name: Policies
           Offset: 1328
-          Type: 206 GoSliceHeaderType []crypto/x509.OID
+          Type: 147 GoSliceHeaderType []crypto/x509.OID
     - __kind: BaseType
-      ID: 197
+      ID: 138
       Name: crypto/x509.ExtKeyUsage
       ByteSize: 8
       GoRuntimeType: 546400
       GoKind: 2
     - __kind: BaseType
-      ID: 188
+      ID: 129
       Name: crypto/x509.KeyUsage
       ByteSize: 8
       GoRuntimeType: 546336
       GoKind: 2
     - __kind: StructureType
-      ID: 208
+      ID: 149
       Name: crypto/x509.OID
       ByteSize: 24
       GoRuntimeType: 1.762016e+06
@@ -1724,21 +1368,21 @@ Types:
       RawFields:
         - Name: der
           Offset: 0
-          Type: 96 GoSliceHeaderType []uint8
+          Type: 98 GoSliceHeaderType []uint8
     - __kind: BaseType
-      ID: 178
+      ID: 118
       Name: crypto/x509.PublicKeyAlgorithm
       ByteSize: 8
       GoRuntimeType: 780768
       GoKind: 2
     - __kind: BaseType
-      ID: 177
+      ID: 117
       Name: crypto/x509.SignatureAlgorithm
       ByteSize: 8
       GoRuntimeType: 1.097216e+06
       GoKind: 2
     - __kind: StructureType
-      ID: 184
+      ID: 125
       Name: crypto/x509/pkix.AttributeTypeAndValue
       ByteSize: 40
       GoRuntimeType: 1.349024e+06
@@ -1746,12 +1390,12 @@ Types:
       RawFields:
         - Name: Type
           Offset: 0
-          Type: 194 GoSliceHeaderType encoding/asn1.ObjectIdentifier
+          Type: 135 GoSliceHeaderType encoding/asn1.ObjectIdentifier
         - Name: Value
           Offset: 24
-          Type: 129 GoEmptyInterfaceType interface {}
+          Type: 119 GoEmptyInterfaceType interface {}
     - __kind: StructureType
-      ID: 191
+      ID: 132
       Name: crypto/x509/pkix.Extension
       ByteSize: 56
       GoRuntimeType: 1.494592e+06
@@ -1759,15 +1403,15 @@ Types:
       RawFields:
         - Name: Id
           Offset: 0
-          Type: 194 GoSliceHeaderType encoding/asn1.ObjectIdentifier
+          Type: 135 GoSliceHeaderType encoding/asn1.ObjectIdentifier
         - Name: Critical
           Offset: 24
           Type: 4 BaseType bool
         - Name: Value
           Offset: 32
-          Type: 96 GoSliceHeaderType []uint8
+          Type: 98 GoSliceHeaderType []uint8
     - __kind: StructureType
-      ID: 181
+      ID: 122
       Name: crypto/x509/pkix.Name
       ByteSize: 248
       GoRuntimeType: 2.10512e+06
@@ -1775,25 +1419,25 @@ Types:
       RawFields:
         - Name: Country
           Offset: 0
-          Type: 56 GoSliceHeaderType []string
+          Type: 58 GoSliceHeaderType []string
         - Name: Organization
           Offset: 24
-          Type: 56 GoSliceHeaderType []string
+          Type: 58 GoSliceHeaderType []string
         - Name: OrganizationalUnit
           Offset: 48
-          Type: 56 GoSliceHeaderType []string
+          Type: 58 GoSliceHeaderType []string
         - Name: Locality
           Offset: 72
-          Type: 56 GoSliceHeaderType []string
+          Type: 58 GoSliceHeaderType []string
         - Name: Province
           Offset: 96
-          Type: 56 GoSliceHeaderType []string
+          Type: 58 GoSliceHeaderType []string
         - Name: StreetAddress
           Offset: 120
-          Type: 56 GoSliceHeaderType []string
+          Type: 58 GoSliceHeaderType []string
         - Name: PostalCode
           Offset: 144
-          Type: 56 GoSliceHeaderType []string
+          Type: 58 GoSliceHeaderType []string
         - Name: SerialNumber
           Offset: 168
           Type: 11 GoStringHeaderType string
@@ -1802,12 +1446,12 @@ Types:
           Type: 11 GoStringHeaderType string
         - Name: Names
           Offset: 200
-          Type: 182 GoSliceHeaderType []crypto/x509/pkix.AttributeTypeAndValue
+          Type: 123 GoSliceHeaderType []crypto/x509/pkix.AttributeTypeAndValue
         - Name: ExtraNames
           Offset: 224
-          Type: 182 GoSliceHeaderType []crypto/x509/pkix.AttributeTypeAndValue
+          Type: 123 GoSliceHeaderType []crypto/x509/pkix.AttributeTypeAndValue
     - __kind: GoSliceHeaderType
-      ID: 194
+      ID: 135
       Name: encoding/asn1.ObjectIdentifier
       ByteSize: 24
       GoRuntimeType: 1.037376e+06
@@ -1822,9 +1466,9 @@ Types:
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 236 GoSliceDataType encoding/asn1.ObjectIdentifier.array
+      Data: 182 GoSliceDataType encoding/asn1.ObjectIdentifier.array
     - __kind: GoSliceDataType
-      ID: 236
+      ID: 182
       Name: encoding/asn1.ObjectIdentifier.array
       ByteSize: 2048
       Element: 9 BaseType int
@@ -1854,362 +1498,23 @@ Types:
       GoRuntimeType: 543264
       GoKind: 14
     - __kind: GoSubroutineType
-      ID: 95
-      Name: func()
-      ByteSize: 8
-      GoRuntimeType: 455360
-      GoKind: 19
-    - __kind: GoSubroutineType
-      ID: 55
+      ID: 57
       Name: func() (io.ReadCloser, error)
       ByteSize: 8
       GoRuntimeType: 645280
       GoKind: 19
     - __kind: GoSubroutineType
-      ID: 122
+      ID: 108
       Name: func(string, []uint8, int) ([]uint8, error)
       ByteSize: 8
       GoRuntimeType: 982976
       GoKind: 19
-    - __kind: StructureType
+    - __kind: UnresolvedPointeeType
       ID: 40
       Name: github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span
-      ByteSize: 288
-      GoRuntimeType: 2.251424e+06
-      GoKind: 25
-      RawFields:
-        - Name: mu
-          Offset: 0
-          Type: 73 StructureType sync.RWMutex
-        - Name: name
-          Offset: 24
-          Type: 11 GoStringHeaderType string
-        - Name: service
-          Offset: 40
-          Type: 11 GoStringHeaderType string
-        - Name: resource
-          Offset: 56
-          Type: 11 GoStringHeaderType string
-        - Name: spanType
-          Offset: 72
-          Type: 11 GoStringHeaderType string
-        - Name: start
-          Offset: 88
-          Type: 13 BaseType int64
-        - Name: duration
-          Offset: 96
-          Type: 13 BaseType int64
-        - Name: meta
-          Offset: 104
-          Type: 68 GoMapType map[string]string
-        - Name: metaStruct
-          Offset: 112
-          Type: 77 GoMapType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.metaStructMap
-        - Name: metrics
-          Offset: 120
-          Type: 82 GoMapType map[string]float64
-        - Name: spanID
-          Offset: 128
-          Type: 10 BaseType uint64
-        - Name: traceID
-          Offset: 136
-          Type: 10 BaseType uint64
-        - Name: parentID
-          Offset: 144
-          Type: 10 BaseType uint64
-        - Name: error
-          Offset: 152
-          Type: 12 BaseType int32
-        - Name: spanLinks
-          Offset: 160
-          Type: 87 GoSliceHeaderType []github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink
-        - Name: spanEvents
-          Offset: 184
-          Type: 90 GoSliceHeaderType []github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent
-        - Name: goExecTraced
-          Offset: 208
-          Type: 4 BaseType bool
-        - Name: noDebugStack
-          Offset: 209
-          Type: 4 BaseType bool
-        - Name: finished
-          Offset: 210
-          Type: 4 BaseType bool
-        - Name: context
-          Offset: 216
-          Type: 93 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanContext
-        - Name: integration
-          Offset: 224
-          Type: 11 GoStringHeaderType string
-        - Name: supportsEvents
-          Offset: 240
-          Type: 4 BaseType bool
-        - Name: pprofCtxActive
-          Offset: 248
-          Type: 65 GoInterfaceType context.Context
-        - Name: pprofCtxRestore
-          Offset: 264
-          Type: 65 GoInterfaceType context.Context
-        - Name: taskEnd
-          Offset: 280
-          Type: 95 GoSubroutineType func()
-    - __kind: StructureType
-      ID: 94
-      Name: github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanContext
-      ByteSize: 168
-      GoRuntimeType: 2.1248e+06
-      GoKind: 25
-      RawFields:
-        - Name: updated
-          Offset: 0
-          Type: 4 BaseType bool
-        - Name: trace
-          Offset: 8
-          Type: 137 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.trace
-        - Name: span
-          Offset: 16
-          Type: 39 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span
-        - Name: errors
-          Offset: 24
-          Type: 75 StructureType sync/atomic.Int32
-        - Name: reparentID
-          Offset: 32
-          Type: 11 GoStringHeaderType string
-        - Name: isRemote
-          Offset: 48
-          Type: 4 BaseType bool
-        - Name: traceID
-          Offset: 49
-          Type: 139 ArrayType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.traceID
-        - Name: spanID
-          Offset: 72
-          Type: 10 BaseType uint64
-        - Name: mu
-          Offset: 80
-          Type: 73 StructureType sync.RWMutex
-        - Name: baggage
-          Offset: 104
-          Type: 68 GoMapType map[string]string
-        - Name: hasBaggage
-          Offset: 112
-          Type: 2 BaseType uint32
-        - Name: origin
-          Offset: 120
-          Type: 11 GoStringHeaderType string
-        - Name: spanLinks
-          Offset: 136
-          Type: 87 GoSliceHeaderType []github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink
-        - Name: baggageOnly
-          Offset: 160
-          Type: 4 BaseType bool
-    - __kind: StructureType
-      ID: 89
-      Name: github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink
-      ByteSize: 56
-      GoRuntimeType: 1.822016e+06
-      GoKind: 25
-      RawFields:
-        - Name: TraceID
-          Offset: 0
-          Type: 10 BaseType uint64
-        - Name: TraceIDHigh
-          Offset: 8
-          Type: 10 BaseType uint64
-        - Name: SpanID
-          Offset: 16
-          Type: 10 BaseType uint64
-        - Name: Attributes
-          Offset: 24
-          Type: 68 GoMapType map[string]string
-        - Name: Tracestate
-          Offset: 32
-          Type: 11 GoStringHeaderType string
-        - Name: Flags
-          Offset: 48
-          Type: 2 BaseType uint32
-    - __kind: GoMapType
-      ID: 77
-      Name: github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.metaStructMap
       ByteSize: 8
-      GoRuntimeType: 1.007296e+06
-      GoKind: 21
-      HeaderType: 79 GoHMapHeaderType hash<string,interface {}>
-    - __kind: BaseType
-      ID: 163
-      Name: github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.samplingDecision
-      ByteSize: 4
-      GoRuntimeType: 542112
-      GoKind: 10
-    - __kind: StructureType
-      ID: 92
-      Name: github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent
-      ByteSize: 40
-      GoRuntimeType: 1.663808e+06
-      GoKind: 25
-      RawFields:
-        - Name: Name
-          Offset: 0
-          Type: 11 GoStringHeaderType string
-        - Name: TimeUnixNano
-          Offset: 16
-          Type: 10 BaseType uint64
-        - Name: Attributes
-          Offset: 24
-          Type: 131 GoMapType map[string]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
-        - Name: RawAttributes
-          Offset: 32
-          Type: 136 GoMapType map[string]interface {}
-    - __kind: StructureType
-      ID: 211
-      Name: github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttribute
-      ByteSize: 24
-      GoRuntimeType: 1.129856e+06
-      GoKind: 25
-      RawFields:
-        - Name: Values
-          Offset: 0
-          Type: 227 GoSliceHeaderType []*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttributeValue
-    - __kind: StructureType
-      ID: 251
-      Name: github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttributeValue
-      ByteSize: 48
-      GoRuntimeType: 1.747904e+06
-      GoKind: 25
-      RawFields:
-        - Name: Type
-          Offset: 0
-          Type: 260 BaseType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttributeValueType
-        - Name: StringValue
-          Offset: 8
-          Type: 11 GoStringHeaderType string
-        - Name: BoolValue
-          Offset: 24
-          Type: 4 BaseType bool
-        - Name: IntValue
-          Offset: 32
-          Type: 13 BaseType int64
-        - Name: DoubleValue
-          Offset: 40
-          Type: 17 BaseType float64
-    - __kind: BaseType
-      ID: 260
-      Name: github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttributeValueType
-      ByteSize: 4
-      GoRuntimeType: 965120
-      GoKind: 5
-    - __kind: StructureType
-      ID: 160
-      Name: github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
-      ByteSize: 56
-      GoRuntimeType: 1.822272e+06
-      GoKind: 25
-      RawFields:
-        - Name: Type
-          Offset: 0
-          Type: 209 BaseType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttributeType
-        - Name: StringValue
-          Offset: 8
-          Type: 11 GoStringHeaderType string
-        - Name: BoolValue
-          Offset: 24
-          Type: 4 BaseType bool
-        - Name: IntValue
-          Offset: 32
-          Type: 13 BaseType int64
-        - Name: DoubleValue
-          Offset: 40
-          Type: 17 BaseType float64
-        - Name: ArrayValue
-          Offset: 48
-          Type: 210 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttribute
-    - __kind: BaseType
-      ID: 209
-      Name: github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttributeType
-      ByteSize: 4
-      GoRuntimeType: 965024
-      GoKind: 5
-    - __kind: StructureType
-      ID: 138
-      Name: github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.trace
-      ByteSize: 104
-      GoRuntimeType: 2.01696e+06
-      GoKind: 25
-      RawFields:
-        - Name: mu
-          Offset: 0
-          Type: 73 StructureType sync.RWMutex
-        - Name: spans
-          Offset: 24
-          Type: 161 GoSliceHeaderType []*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span
-        - Name: tags
-          Offset: 48
-          Type: 68 GoMapType map[string]string
-        - Name: propagatingTags
-          Offset: 56
-          Type: 68 GoMapType map[string]string
-        - Name: finished
-          Offset: 64
-          Type: 9 BaseType int
-        - Name: full
-          Offset: 72
-          Type: 4 BaseType bool
-        - Name: priority
-          Offset: 80
-          Type: 25 PointerType *float64
-        - Name: locked
-          Offset: 88
-          Type: 4 BaseType bool
-        - Name: samplingDecision
-          Offset: 92
-          Type: 163 BaseType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.samplingDecision
-        - Name: root
-          Offset: 96
-          Type: 39 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span
-    - __kind: ArrayType
-      ID: 139
-      Name: github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.traceID
-      ByteSize: 16
-      GoRuntimeType: 847584
-      GoKind: 17
-      Count: 16
-      HasCount: true
-      Element: 3 BaseType uint8
     - __kind: GoHMapHeaderType
-      ID: 133
-      Name: hash<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
-      ByteSize: 48
-      RawFields:
-        - Name: count
-          Offset: 0
-          Type: 9 BaseType int
-        - Name: flags
-          Offset: 8
-          Type: 3 BaseType uint8
-        - Name: B
-          Offset: 9
-          Type: 3 BaseType uint8
-        - Name: noverflow
-          Offset: 10
-          Type: 7 BaseType uint16
-        - Name: hash0
-          Offset: 12
-          Type: 2 BaseType uint32
-        - Name: buckets
-          Offset: 16
-          Type: 134 PointerType *bucket<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
-        - Name: oldbuckets
-          Offset: 24
-          Type: 134 PointerType *bucket<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
-        - Name: nevacuate
-          Offset: 32
-          Type: 1 BaseType uintptr
-        - Name: extra
-          Offset: 40
-          Type: 52 PointerType *runtime.mapextra
-      BucketType: 135 GoHMapBucketType bucket<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
-      BucketsType: 175 GoSliceDataType []bucket<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>.array
-    - __kind: GoHMapHeaderType
-      ID: 112
+      ID: 86
       Name: hash<string,[]*mime/multipart.FileHeader>
       ByteSize: 48
       RawFields:
@@ -2230,20 +1535,20 @@ Types:
           Type: 2 BaseType uint32
         - Name: buckets
           Offset: 16
-          Type: 113 PointerType *bucket<string,[]*mime/multipart.FileHeader>
+          Type: 87 PointerType *bucket<string,[]*mime/multipart.FileHeader>
         - Name: oldbuckets
           Offset: 24
-          Type: 113 PointerType *bucket<string,[]*mime/multipart.FileHeader>
+          Type: 87 PointerType *bucket<string,[]*mime/multipart.FileHeader>
         - Name: nevacuate
           Offset: 32
           Type: 1 BaseType uintptr
         - Name: extra
           Offset: 40
-          Type: 52 PointerType *runtime.mapextra
-      BucketType: 114 GoHMapBucketType bucket<string,[]*mime/multipart.FileHeader>
-      BucketsType: 166 GoSliceDataType []bucket<string,[]*mime/multipart.FileHeader>.array
+          Type: 54 PointerType *runtime.mapextra
+      BucketType: 88 GoHMapBucketType bucket<string,[]*mime/multipart.FileHeader>
+      BucketsType: 93 GoSliceDataType []bucket<string,[]*mime/multipart.FileHeader>.array
     - __kind: GoHMapHeaderType
-      ID: 49
+      ID: 51
       Name: hash<string,[]string>
       ByteSize: 48
       RawFields:
@@ -2264,88 +1569,20 @@ Types:
           Type: 2 BaseType uint32
         - Name: buckets
           Offset: 16
-          Type: 50 PointerType *bucket<string,[]string>
+          Type: 52 PointerType *bucket<string,[]string>
         - Name: oldbuckets
           Offset: 24
-          Type: 50 PointerType *bucket<string,[]string>
+          Type: 52 PointerType *bucket<string,[]string>
         - Name: nevacuate
           Offset: 32
           Type: 1 BaseType uintptr
         - Name: extra
           Offset: 40
-          Type: 52 PointerType *runtime.mapextra
-      BucketType: 51 GoHMapBucketType bucket<string,[]string>
-      BucketsType: 140 GoSliceDataType []bucket<string,[]string>.array
+          Type: 54 PointerType *runtime.mapextra
+      BucketType: 53 GoHMapBucketType bucket<string,[]string>
+      BucketsType: 80 GoSliceDataType []bucket<string,[]string>.array
     - __kind: GoHMapHeaderType
-      ID: 84
-      Name: hash<string,float64>
-      ByteSize: 48
-      RawFields:
-        - Name: count
-          Offset: 0
-          Type: 9 BaseType int
-        - Name: flags
-          Offset: 8
-          Type: 3 BaseType uint8
-        - Name: B
-          Offset: 9
-          Type: 3 BaseType uint8
-        - Name: noverflow
-          Offset: 10
-          Type: 7 BaseType uint16
-        - Name: hash0
-          Offset: 12
-          Type: 2 BaseType uint32
-        - Name: buckets
-          Offset: 16
-          Type: 85 PointerType *bucket<string,float64>
-        - Name: oldbuckets
-          Offset: 24
-          Type: 85 PointerType *bucket<string,float64>
-        - Name: nevacuate
-          Offset: 32
-          Type: 1 BaseType uintptr
-        - Name: extra
-          Offset: 40
-          Type: 52 PointerType *runtime.mapextra
-      BucketType: 86 GoHMapBucketType bucket<string,float64>
-      BucketsType: 145 GoSliceDataType []bucket<string,float64>.array
-    - __kind: GoHMapHeaderType
-      ID: 79
-      Name: hash<string,interface {}>
-      ByteSize: 48
-      RawFields:
-        - Name: count
-          Offset: 0
-          Type: 9 BaseType int
-        - Name: flags
-          Offset: 8
-          Type: 3 BaseType uint8
-        - Name: B
-          Offset: 9
-          Type: 3 BaseType uint8
-        - Name: noverflow
-          Offset: 10
-          Type: 7 BaseType uint16
-        - Name: hash0
-          Offset: 12
-          Type: 2 BaseType uint32
-        - Name: buckets
-          Offset: 16
-          Type: 80 PointerType *bucket<string,interface {}>
-        - Name: oldbuckets
-          Offset: 24
-          Type: 80 PointerType *bucket<string,interface {}>
-        - Name: nevacuate
-          Offset: 32
-          Type: 1 BaseType uintptr
-        - Name: extra
-          Offset: 40
-          Type: 52 PointerType *runtime.mapextra
-      BucketType: 81 GoHMapBucketType bucket<string,interface {}>
-      BucketsType: 144 GoSliceDataType []bucket<string,interface {}>.array
-    - __kind: GoHMapHeaderType
-      ID: 70
+      ID: 72
       Name: hash<string,string>
       ByteSize: 48
       RawFields:
@@ -2366,18 +1603,18 @@ Types:
           Type: 2 BaseType uint32
         - Name: buckets
           Offset: 16
-          Type: 71 PointerType *bucket<string,string>
+          Type: 73 PointerType *bucket<string,string>
         - Name: oldbuckets
           Offset: 24
-          Type: 71 PointerType *bucket<string,string>
+          Type: 73 PointerType *bucket<string,string>
         - Name: nevacuate
           Offset: 32
           Type: 1 BaseType uintptr
         - Name: extra
           Offset: 40
-          Type: 52 PointerType *runtime.mapextra
-      BucketType: 72 GoHMapBucketType bucket<string,string>
-      BucketsType: 143 GoSliceDataType []bucket<string,string>.array
+          Type: 54 PointerType *runtime.mapextra
+      BucketType: 74 GoHMapBucketType bucket<string,string>
+      BucketsType: 195 GoSliceDataType []bucket<string,string>.array
     - __kind: BaseType
       ID: 9
       Name: int
@@ -2409,7 +1646,7 @@ Types:
       GoRuntimeType: 542368
       GoKind: 3
     - __kind: GoEmptyInterfaceType
-      ID: 129
+      ID: 119
       Name: interface {}
       ByteSize: 16
       GoRuntimeType: 797888
@@ -2422,7 +1659,7 @@ Types:
           Offset: 8
           Type: 19 VoidPointerType unsafe.Pointer
     - __kind: GoInterfaceType
-      ID: 54
+      ID: 56
       Name: io.ReadCloser
       ByteSize: 16
       GoRuntimeType: 1.092864e+06
@@ -2435,49 +1672,28 @@ Types:
           Offset: 8
           Type: 19 VoidPointerType unsafe.Pointer
     - __kind: GoMapType
-      ID: 131
-      Name: map[string]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
-      ByteSize: 8
-      GoRuntimeType: 904992
-      GoKind: 21
-      HeaderType: 133 GoHMapHeaderType hash<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
-    - __kind: GoMapType
-      ID: 110
+      ID: 84
       Name: map[string][]*mime/multipart.FileHeader
       ByteSize: 8
       GoRuntimeType: 904032
       GoKind: 21
-      HeaderType: 112 GoHMapHeaderType hash<string,[]*mime/multipart.FileHeader>
+      HeaderType: 86 GoHMapHeaderType hash<string,[]*mime/multipart.FileHeader>
     - __kind: GoMapType
-      ID: 109
+      ID: 83
       Name: map[string][]string
       ByteSize: 8
       GoRuntimeType: 899232
       GoKind: 21
-      HeaderType: 49 GoHMapHeaderType hash<string,[]string>
+      HeaderType: 51 GoHMapHeaderType hash<string,[]string>
     - __kind: GoMapType
-      ID: 82
-      Name: map[string]float64
-      ByteSize: 8
-      GoRuntimeType: 904896
-      GoKind: 21
-      HeaderType: 84 GoHMapHeaderType hash<string,float64>
-    - __kind: GoMapType
-      ID: 136
-      Name: map[string]interface {}
-      ByteSize: 8
-      GoRuntimeType: 896352
-      GoKind: 21
-      HeaderType: 79 GoHMapHeaderType hash<string,interface {}>
-    - __kind: GoMapType
-      ID: 68
+      ID: 70
       Name: map[string]string
       ByteSize: 8
       GoRuntimeType: 900864
       GoKind: 21
-      HeaderType: 70 GoHMapHeaderType hash<string,string>
+      HeaderType: 72 GoHMapHeaderType hash<string,string>
     - __kind: StructureType
-      ID: 180
+      ID: 121
       Name: math/big.Int
       ByteSize: 32
       GoRuntimeType: 1.340544e+06
@@ -2488,15 +1704,15 @@ Types:
           Type: 4 BaseType bool
         - Name: abs
           Offset: 8
-          Type: 217 GoSliceHeaderType math/big.nat
+          Type: 150 GoSliceHeaderType math/big.nat
     - __kind: BaseType
-      ID: 219
+      ID: 152
       Name: math/big.Word
       ByteSize: 8
       GoRuntimeType: 546656
       GoKind: 7
     - __kind: GoSliceHeaderType
-      ID: 217
+      ID: 150
       Name: math/big.nat
       ByteSize: 24
       GoRuntimeType: 2.279968e+06
@@ -2504,21 +1720,21 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 218 PointerType *math/big.Word
+          Type: 151 PointerType *math/big.Word
         - Name: len
           Offset: 8
           Type: 9 BaseType int
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 252 GoSliceDataType math/big.nat.array
+      Data: 153 GoSliceDataType math/big.nat.array
     - __kind: GoSliceDataType
-      ID: 252
+      ID: 153
       Name: math/big.nat.array
       ByteSize: 2048
-      Element: 219 BaseType math/big.Word
+      Element: 152 BaseType math/big.Word
     - __kind: StructureType
-      ID: 176
+      ID: 94
       Name: mime/multipart.FileHeader
       ByteSize: 88
       GoRuntimeType: 1.88112e+06
@@ -2529,13 +1745,13 @@ Types:
           Type: 11 GoStringHeaderType string
         - Name: Header
           Offset: 16
-          Type: 216 GoMapType net/textproto.MIMEHeader
+          Type: 97 GoMapType net/textproto.MIMEHeader
         - Name: Size
           Offset: 24
           Type: 13 BaseType int64
         - Name: content
           Offset: 32
-          Type: 96 GoSliceHeaderType []uint8
+          Type: 98 GoSliceHeaderType []uint8
         - Name: tmpfile
           Offset: 56
           Type: 11 GoStringHeaderType string
@@ -2546,7 +1762,7 @@ Types:
           Offset: 80
           Type: 4 BaseType bool
     - __kind: StructureType
-      ID: 59
+      ID: 61
       Name: mime/multipart.Form
       ByteSize: 16
       GoRuntimeType: 1.325824e+06
@@ -2554,12 +1770,12 @@ Types:
       RawFields:
         - Name: Value
           Offset: 0
-          Type: 109 GoMapType map[string][]string
+          Type: 83 GoMapType map[string][]string
         - Name: File
           Offset: 8
-          Type: 110 GoMapType map[string][]*mime/multipart.FileHeader
+          Type: 84 GoMapType map[string][]*mime/multipart.FileHeader
     - __kind: GoSliceHeaderType
-      ID: 200
+      ID: 141
       Name: net.IP
       ByteSize: 24
       GoRuntimeType: 2.000864e+06
@@ -2574,14 +1790,14 @@ Types:
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 242 GoSliceDataType net.IP.array
+      Data: 184 GoSliceDataType net.IP.array
     - __kind: GoSliceDataType
-      ID: 242
+      ID: 184
       Name: net.IP.array
       ByteSize: 2048
       Element: 3 BaseType uint8
     - __kind: GoSliceHeaderType
-      ID: 250
+      ID: 186
       Name: net.IPMask
       ByteSize: 24
       GoRuntimeType: 999232
@@ -2596,14 +1812,14 @@ Types:
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 261 GoSliceDataType net.IPMask.array
+      Data: 187 GoSliceDataType net.IPMask.array
     - __kind: GoSliceDataType
-      ID: 261
+      ID: 187
       Name: net.IPMask.array
       ByteSize: 2048
       Element: 3 BaseType uint8
     - __kind: StructureType
-      ID: 226
+      ID: 177
       Name: net.IPNet
       ByteSize: 48
       GoRuntimeType: 1.306944e+06
@@ -2611,17 +1827,17 @@ Types:
       RawFields:
         - Name: IP
           Offset: 0
-          Type: 200 GoSliceHeaderType net.IP
+          Type: 141 GoSliceHeaderType net.IP
         - Name: Mask
           Offset: 24
-          Type: 250 GoSliceHeaderType net.IPMask
+          Type: 186 GoSliceHeaderType net.IPMask
     - __kind: GoMapType
-      ID: 47
+      ID: 49
       Name: net/http.Header
       ByteSize: 8
       GoRuntimeType: 1.963712e+06
       GoKind: 21
-      HeaderType: 49 GoHMapHeaderType hash<string,[]string>
+      HeaderType: 51 GoHMapHeaderType hash<string,[]string>
     - __kind: StructureType
       ID: 38
       Name: net/http.Request
@@ -2634,7 +1850,7 @@ Types:
           Type: 11 GoStringHeaderType string
         - Name: URL
           Offset: 16
-          Type: 45 PointerType *net/url.URL
+          Type: 47 PointerType *net/url.URL
         - Name: Proto
           Offset: 24
           Type: 11 GoStringHeaderType string
@@ -2646,19 +1862,19 @@ Types:
           Type: 9 BaseType int
         - Name: Header
           Offset: 56
-          Type: 47 GoMapType net/http.Header
+          Type: 49 GoMapType net/http.Header
         - Name: Body
           Offset: 64
-          Type: 54 GoInterfaceType io.ReadCloser
+          Type: 56 GoInterfaceType io.ReadCloser
         - Name: GetBody
           Offset: 80
-          Type: 55 GoSubroutineType func() (io.ReadCloser, error)
+          Type: 57 GoSubroutineType func() (io.ReadCloser, error)
         - Name: ContentLength
           Offset: 88
           Type: 13 BaseType int64
         - Name: TransferEncoding
           Offset: 96
-          Type: 56 GoSliceHeaderType []string
+          Type: 58 GoSliceHeaderType []string
         - Name: Close
           Offset: 120
           Type: 4 BaseType bool
@@ -2667,16 +1883,16 @@ Types:
           Type: 11 GoStringHeaderType string
         - Name: Form
           Offset: 144
-          Type: 57 GoMapType net/url.Values
+          Type: 59 GoMapType net/url.Values
         - Name: PostForm
           Offset: 152
-          Type: 57 GoMapType net/url.Values
+          Type: 59 GoMapType net/url.Values
         - Name: MultipartForm
           Offset: 160
-          Type: 58 PointerType *mime/multipart.Form
+          Type: 60 PointerType *mime/multipart.Form
         - Name: Trailer
           Offset: 168
-          Type: 47 GoMapType net/http.Header
+          Type: 49 GoMapType net/http.Header
         - Name: RemoteAddr
           Offset: 176
           Type: 11 GoStringHeaderType string
@@ -2685,30 +1901,30 @@ Types:
           Type: 11 GoStringHeaderType string
         - Name: TLS
           Offset: 208
-          Type: 60 PointerType *crypto/tls.ConnectionState
+          Type: 62 PointerType *crypto/tls.ConnectionState
         - Name: Cancel
           Offset: 216
-          Type: 62 GoChannelType <-chan struct {}
+          Type: 64 GoChannelType <-chan struct {}
         - Name: Response
           Offset: 224
-          Type: 63 PointerType *net/http.Response
+          Type: 65 PointerType *net/http.Response
         - Name: Pattern
           Offset: 232
           Type: 11 GoStringHeaderType string
         - Name: ctx
           Offset: 248
-          Type: 65 GoInterfaceType context.Context
+          Type: 67 GoInterfaceType context.Context
         - Name: pat
           Offset: 264
-          Type: 66 PointerType *net/http.pattern
+          Type: 68 PointerType *net/http.pattern
         - Name: matches
           Offset: 272
-          Type: 56 GoSliceHeaderType []string
+          Type: 58 GoSliceHeaderType []string
         - Name: otherValues
           Offset: 296
-          Type: 68 GoMapType map[string]string
+          Type: 70 GoMapType map[string]string
     - __kind: StructureType
-      ID: 64
+      ID: 66
       Name: net/http.Response
       ByteSize: 144
       GoRuntimeType: 2.123456e+06
@@ -2731,16 +1947,16 @@ Types:
           Type: 9 BaseType int
         - Name: Header
           Offset: 56
-          Type: 47 GoMapType net/http.Header
+          Type: 49 GoMapType net/http.Header
         - Name: Body
           Offset: 64
-          Type: 54 GoInterfaceType io.ReadCloser
+          Type: 56 GoInterfaceType io.ReadCloser
         - Name: ContentLength
           Offset: 80
           Type: 13 BaseType int64
         - Name: TransferEncoding
           Offset: 88
-          Type: 56 GoSliceHeaderType []string
+          Type: 58 GoSliceHeaderType []string
         - Name: Close
           Offset: 112
           Type: 4 BaseType bool
@@ -2749,13 +1965,13 @@ Types:
           Type: 4 BaseType bool
         - Name: Trailer
           Offset: 120
-          Type: 47 GoMapType net/http.Header
+          Type: 49 GoMapType net/http.Header
         - Name: Request
           Offset: 128
           Type: 37 PointerType *net/http.Request
         - Name: TLS
           Offset: 136
-          Type: 60 PointerType *crypto/tls.ConnectionState
+          Type: 62 PointerType *crypto/tls.ConnectionState
     - __kind: GoInterfaceType
       ID: 36
       Name: net/http.ResponseWriter
@@ -2770,7 +1986,7 @@ Types:
           Offset: 8
           Type: 19 VoidPointerType unsafe.Pointer
     - __kind: StructureType
-      ID: 67
+      ID: 69
       Name: net/http.pattern
       ByteSize: 88
       GoRuntimeType: 1.744992e+06
@@ -2787,12 +2003,12 @@ Types:
           Type: 11 GoStringHeaderType string
         - Name: segments
           Offset: 48
-          Type: 124 GoSliceHeaderType []net/http.segment
+          Type: 189 GoSliceHeaderType []net/http.segment
         - Name: loc
           Offset: 72
           Type: 11 GoStringHeaderType string
     - __kind: StructureType
-      ID: 126
+      ID: 191
       Name: net/http.segment
       ByteSize: 24
       GoRuntimeType: 1.452928e+06
@@ -2808,14 +2024,14 @@ Types:
           Offset: 17
           Type: 4 BaseType bool
     - __kind: GoMapType
-      ID: 216
+      ID: 97
       Name: net/textproto.MIMEHeader
       ByteSize: 8
       GoRuntimeType: 1.637344e+06
       GoKind: 21
-      HeaderType: 49 GoHMapHeaderType hash<string,[]string>
+      HeaderType: 51 GoHMapHeaderType hash<string,[]string>
     - __kind: StructureType
-      ID: 46
+      ID: 48
       Name: net/url.URL
       ByteSize: 144
       GoRuntimeType: 2.040992e+06
@@ -2829,7 +2045,7 @@ Types:
           Type: 11 GoStringHeaderType string
         - Name: User
           Offset: 32
-          Type: 100 PointerType *net/url.Userinfo
+          Type: 75 PointerType *net/url.Userinfo
         - Name: Host
           Offset: 40
           Type: 11 GoStringHeaderType string
@@ -2855,7 +2071,7 @@ Types:
           Offset: 128
           Type: 11 GoStringHeaderType string
     - __kind: StructureType
-      ID: 101
+      ID: 76
       Name: net/url.Userinfo
       ByteSize: 40
       GoRuntimeType: 1.469248e+06
@@ -2871,38 +2087,16 @@ Types:
           Offset: 32
           Type: 4 BaseType bool
     - __kind: GoMapType
-      ID: 57
+      ID: 59
       Name: net/url.Values
       ByteSize: 8
       GoRuntimeType: 1.71184e+06
       GoKind: 21
-      HeaderType: 49 GoHMapHeaderType hash<string,[]string>
-    - __kind: StructureType
-      ID: 108
-      Name: runtime.bmap
-      ByteSize: 8
-      GoRuntimeType: 1.136896e+06
-      GoKind: 25
-      RawFields:
-        - Name: tophash
-          Offset: 0
-          Type: 102 ArrayType [8]uint8
-    - __kind: StructureType
-      ID: 53
+      HeaderType: 51 GoHMapHeaderType hash<string,[]string>
+    - __kind: UnresolvedPointeeType
+      ID: 55
       Name: runtime.mapextra
-      ByteSize: 24
-      GoRuntimeType: 1.465216e+06
-      GoKind: 25
-      RawFields:
-        - Name: overflow
-          Offset: 0
-          Type: 105 PointerType *[]*runtime.bmap
-        - Name: oldoverflow
-          Offset: 8
-          Type: 105 PointerType *[]*runtime.bmap
-        - Name: nextOverflow
-          Offset: 16
-          Type: 107 PointerType *runtime.bmap
+      ByteSize: 8
     - __kind: GoStringHeaderType
       ID: 11
       Name: string
@@ -2912,71 +2106,17 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 99 PointerType *string.str
+          Type: 46 PointerType *string.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 98 GoStringDataType string.str
+      Data: 45 GoStringDataType string.str
     - __kind: GoStringDataType
-      ID: 98
+      ID: 45
       Name: string.str
       ByteSize: 2048
     - __kind: StructureType
-      ID: 74
-      Name: sync.Mutex
-      ByteSize: 8
-      GoRuntimeType: 1.313984e+06
-      GoKind: 25
-      RawFields:
-        - Name: state
-          Offset: 0
-          Type: 12 BaseType int32
-        - Name: sema
-          Offset: 4
-          Type: 2 BaseType uint32
-    - __kind: StructureType
-      ID: 73
-      Name: sync.RWMutex
-      ByteSize: 24
-      GoRuntimeType: 1.750592e+06
-      GoKind: 25
-      RawFields:
-        - Name: w
-          Offset: 0
-          Type: 74 StructureType sync.Mutex
-        - Name: writerSem
-          Offset: 8
-          Type: 2 BaseType uint32
-        - Name: readerSem
-          Offset: 12
-          Type: 2 BaseType uint32
-        - Name: readerCount
-          Offset: 16
-          Type: 75 StructureType sync/atomic.Int32
-        - Name: readerWait
-          Offset: 20
-          Type: 75 StructureType sync/atomic.Int32
-    - __kind: StructureType
-      ID: 75
-      Name: sync/atomic.Int32
-      ByteSize: 4
-      GoRuntimeType: 1.315424e+06
-      GoKind: 25
-      RawFields:
-        - Name: _
-          Offset: 0
-          Type: 76 StructureType sync/atomic.noCopy
-        - Name: v
-          Offset: 0
-          Type: 12 BaseType int32
-    - __kind: StructureType
-      ID: 76
-      Name: sync/atomic.noCopy
-      GoRuntimeType: 965792
-      GoKind: 25
-      RawFields: []
-    - __kind: StructureType
-      ID: 187
+      ID: 128
       Name: time.Location
       ByteSize: 104
       GoRuntimeType: 1.877376e+06
@@ -2987,10 +2127,10 @@ Types:
           Type: 11 GoStringHeaderType string
         - Name: zone
           Offset: 16
-          Type: 220 GoSliceHeaderType []time.zone
+          Type: 157 GoSliceHeaderType []time.zone
         - Name: tx
           Offset: 40
-          Type: 223 GoSliceHeaderType []time.zoneTrans
+          Type: 160 GoSliceHeaderType []time.zoneTrans
         - Name: extend
           Offset: 64
           Type: 11 GoStringHeaderType string
@@ -3002,9 +2142,9 @@ Types:
           Type: 13 BaseType int64
         - Name: cacheZone
           Offset: 96
-          Type: 221 PointerType *time.zone
+          Type: 158 PointerType *time.zone
     - __kind: StructureType
-      ID: 185
+      ID: 126
       Name: time.Time
       ByteSize: 24
       GoRuntimeType: 2.280896e+06
@@ -3018,9 +2158,9 @@ Types:
           Type: 13 BaseType int64
         - Name: loc
           Offset: 16
-          Type: 186 PointerType *time.Location
+          Type: 127 PointerType *time.Location
     - __kind: StructureType
-      ID: 222
+      ID: 159
       Name: time.zone
       ByteSize: 32
       GoRuntimeType: 1.45792e+06
@@ -3036,7 +2176,7 @@ Types:
           Offset: 24
           Type: 4 BaseType bool
     - __kind: StructureType
-      ID: 225
+      ID: 162
       Name: time.zoneTrans
       ByteSize: 16
       GoRuntimeType: 1.663616e+06
@@ -3096,6 +2236,6 @@ Types:
       ByteSize: 8
       GoRuntimeType: 543392
       GoKind: 26
-MaxTypeID: 264
+MaxTypeID: 197
 Issues: []
 GoModuledataInfo: {FirstModuledataAddr: "0x1804ac0", TypesOffset: 296}

--- a/pkg/dyninst/irgen/testdata/snapshot/rc_tester.arch=amd64,toolchain=go1.24.3.yaml
+++ b/pkg/dyninst/irgen/testdata/snapshot/rc_tester.arch=amd64,toolchain=go1.24.3.yaml
@@ -10,7 +10,7 @@ Probes:
       subprogram: {subprogram: 1}
       events:
         - ID: 1
-          Type: 303 EventRootType Probe[main.HandleHTTP]
+          Type: 295 EventRootType Probe[main.HandleHTTP]
           InjectionPoints: [{PC: "0xd31373", Frameless: false}]
           Condition: null
     - id: look_at_the_request
@@ -23,7 +23,7 @@ Probes:
       subprogram: {subprogram: 2}
       events:
         - ID: 2
-          Type: 304 EventRootType Probe[main.LookAtTheRequest]
+          Type: 296 EventRootType Probe[main.LookAtTheRequest]
           InjectionPoints: [{PC: "0xd316ce", Frameless: false}]
           Condition: null
 Subprograms:
@@ -366,7 +366,7 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 17 BaseType uint64
-      TablePtrSliceType: 243 GoSliceDataType []*table<string,[]string>.array
+      TablePtrSliceType: 231 GoSliceDataType []*table<string,[]string>.array
       GroupType: 25 StructureType noalg.map.group[string][]string
     - __kind: BaseType
       ID: 17
@@ -433,7 +433,7 @@ Types:
           Offset: 8
           Type: 17 BaseType uint64
       GroupType: 25 StructureType noalg.map.group[string][]string
-      GroupSliceType: 244 GoSliceDataType []noalg.map.group[string][]string.array
+      GroupSliceType: 232 GoSliceDataType []noalg.map.group[string][]string.array
     - __kind: PointerType
       ID: 24
       Name: '*noalg.map.group[string][]string'
@@ -599,7 +599,7 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 17 BaseType uint64
-      TablePtrSliceType: 239 GoSliceDataType []*table<string,[]*mime/multipart.FileHeader>.array
+      TablePtrSliceType: 235 GoSliceDataType []*table<string,[]*mime/multipart.FileHeader>.array
       GroupType: 45 StructureType noalg.map.group[string][]*mime/multipart.FileHeader
     - __kind: PointerType
       ID: 40
@@ -648,7 +648,7 @@ Types:
           Offset: 8
           Type: 17 BaseType uint64
       GroupType: 45 StructureType noalg.map.group[string][]*mime/multipart.FileHeader
-      GroupSliceType: 240 GoSliceDataType []noalg.map.group[string][]*mime/multipart.FileHeader.array
+      GroupSliceType: 236 GoSliceDataType []noalg.map.group[string][]*mime/multipart.FileHeader.array
     - __kind: PointerType
       ID: 44
       Name: '*noalg.map.group[string][]*mime/multipart.FileHeader'
@@ -705,7 +705,7 @@ Types:
         - Name: cap
           Offset: 16
           Type: 8 BaseType int
-      Data: 241 GoSliceDataType []*mime/multipart.FileHeader.array
+      Data: 237 GoSliceDataType []*mime/multipart.FileHeader.array
     - __kind: PointerType
       ID: 49
       Name: '**mime/multipart.FileHeader'
@@ -770,7 +770,7 @@ Types:
         - Name: cap
           Offset: 16
           Type: 8 BaseType int
-      Data: 245 GoSliceDataType []uint8.array
+      Data: 239 GoSliceDataType []uint8.array
     - __kind: PointerType
       ID: 54
       Name: '*crypto/tls.ConnectionState'
@@ -849,7 +849,7 @@ Types:
         - Name: cap
           Offset: 16
           Type: 8 BaseType int
-      Data: 247 GoSliceDataType []*crypto/x509.Certificate.array
+      Data: 241 GoSliceDataType []*crypto/x509.Certificate.array
     - __kind: PointerType
       ID: 57
       Name: '**crypto/x509.Certificate'
@@ -1087,7 +1087,7 @@ Types:
         - Name: cap
           Offset: 16
           Type: 8 BaseType int
-      Data: 249 GoSliceDataType math/big.nat.array
+      Data: 243 GoSliceDataType math/big.nat.array
     - __kind: PointerType
       ID: 66
       Name: '*math/big.Word'
@@ -1157,7 +1157,7 @@ Types:
         - Name: cap
           Offset: 16
           Type: 8 BaseType int
-      Data: 251 GoSliceDataType []crypto/x509/pkix.AttributeTypeAndValue.array
+      Data: 245 GoSliceDataType []crypto/x509/pkix.AttributeTypeAndValue.array
     - __kind: PointerType
       ID: 70
       Name: '*crypto/x509/pkix.AttributeTypeAndValue'
@@ -1194,7 +1194,7 @@ Types:
         - Name: cap
           Offset: 16
           Type: 8 BaseType int
-      Data: 253 GoSliceDataType encoding/asn1.ObjectIdentifier.array
+      Data: 247 GoSliceDataType encoding/asn1.ObjectIdentifier.array
     - __kind: PointerType
       ID: 73
       Name: '*int'
@@ -1269,7 +1269,7 @@ Types:
         - Name: cap
           Offset: 16
           Type: 8 BaseType int
-      Data: 255 GoSliceDataType []time.zone.array
+      Data: 249 GoSliceDataType []time.zone.array
     - __kind: PointerType
       ID: 78
       Name: '*time.zone'
@@ -1309,7 +1309,7 @@ Types:
         - Name: cap
           Offset: 16
           Type: 8 BaseType int
-      Data: 257 GoSliceDataType []time.zoneTrans.array
+      Data: 251 GoSliceDataType []time.zoneTrans.array
     - __kind: PointerType
       ID: 81
       Name: '*time.zoneTrans'
@@ -1358,7 +1358,7 @@ Types:
         - Name: cap
           Offset: 16
           Type: 8 BaseType int
-      Data: 259 GoSliceDataType []crypto/x509/pkix.Extension.array
+      Data: 253 GoSliceDataType []crypto/x509/pkix.Extension.array
     - __kind: PointerType
       ID: 85
       Name: '*crypto/x509/pkix.Extension'
@@ -1398,7 +1398,7 @@ Types:
         - Name: cap
           Offset: 16
           Type: 8 BaseType int
-      Data: 261 GoSliceDataType []encoding/asn1.ObjectIdentifier.array
+      Data: 255 GoSliceDataType []encoding/asn1.ObjectIdentifier.array
     - __kind: PointerType
       ID: 88
       Name: '*encoding/asn1.ObjectIdentifier'
@@ -1422,7 +1422,7 @@ Types:
         - Name: cap
           Offset: 16
           Type: 8 BaseType int
-      Data: 263 GoSliceDataType []crypto/x509.ExtKeyUsage.array
+      Data: 257 GoSliceDataType []crypto/x509.ExtKeyUsage.array
     - __kind: PointerType
       ID: 90
       Name: '*crypto/x509.ExtKeyUsage'
@@ -1452,7 +1452,7 @@ Types:
         - Name: cap
           Offset: 16
           Type: 8 BaseType int
-      Data: 265 GoSliceDataType []net.IP.array
+      Data: 259 GoSliceDataType []net.IP.array
     - __kind: PointerType
       ID: 93
       Name: '*net.IP'
@@ -1476,7 +1476,7 @@ Types:
         - Name: cap
           Offset: 16
           Type: 8 BaseType int
-      Data: 267 GoSliceDataType net.IP.array
+      Data: 261 GoSliceDataType net.IP.array
     - __kind: GoSliceHeaderType
       ID: 95
       Name: '[]*net/url.URL'
@@ -1493,7 +1493,7 @@ Types:
         - Name: cap
           Offset: 16
           Type: 8 BaseType int
-      Data: 269 GoSliceDataType []*net/url.URL.array
+      Data: 263 GoSliceDataType []*net/url.URL.array
     - __kind: PointerType
       ID: 96
       Name: '**net/url.URL'
@@ -1516,7 +1516,7 @@ Types:
         - Name: cap
           Offset: 16
           Type: 8 BaseType int
-      Data: 271 GoSliceDataType []*net.IPNet.array
+      Data: 265 GoSliceDataType []*net.IPNet.array
     - __kind: PointerType
       ID: 98
       Name: '**net.IPNet'
@@ -1559,7 +1559,7 @@ Types:
         - Name: cap
           Offset: 16
           Type: 8 BaseType int
-      Data: 273 GoSliceDataType net.IPMask.array
+      Data: 267 GoSliceDataType net.IPMask.array
     - __kind: GoSliceHeaderType
       ID: 102
       Name: '[]crypto/x509.OID'
@@ -1576,7 +1576,7 @@ Types:
         - Name: cap
           Offset: 16
           Type: 8 BaseType int
-      Data: 275 GoSliceDataType []crypto/x509.OID.array
+      Data: 269 GoSliceDataType []crypto/x509.OID.array
     - __kind: PointerType
       ID: 103
       Name: '*crypto/x509.OID'
@@ -1610,7 +1610,7 @@ Types:
         - Name: cap
           Offset: 16
           Type: 8 BaseType int
-      Data: 277 GoSliceDataType []crypto/x509.PolicyMapping.array
+      Data: 271 GoSliceDataType []crypto/x509.PolicyMapping.array
     - __kind: PointerType
       ID: 106
       Name: '*crypto/x509.PolicyMapping'
@@ -1647,7 +1647,7 @@ Types:
         - Name: cap
           Offset: 16
           Type: 8 BaseType int
-      Data: 279 GoSliceDataType [][]*crypto/x509.Certificate.array
+      Data: 273 GoSliceDataType [][]*crypto/x509.Certificate.array
     - __kind: PointerType
       ID: 109
       Name: '*[]*crypto/x509.Certificate'
@@ -1670,7 +1670,7 @@ Types:
         - Name: cap
           Offset: 16
           Type: 8 BaseType int
-      Data: 281 GoSliceDataType [][]uint8.array
+      Data: 275 GoSliceDataType [][]uint8.array
     - __kind: PointerType
       ID: 111
       Name: '*[]uint8'
@@ -1809,7 +1809,7 @@ Types:
         - Name: cap
           Offset: 16
           Type: 8 BaseType int
-      Data: 283 GoSliceDataType []net/http.segment.array
+      Data: 277 GoSliceDataType []net/http.segment.array
     - __kind: PointerType
       ID: 121
       Name: '*net/http.segment'
@@ -1875,7 +1875,7 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 17 BaseType uint64
-      TablePtrSliceType: 285 GoSliceDataType []*table<string,string>.array
+      TablePtrSliceType: 279 GoSliceDataType []*table<string,string>.array
       GroupType: 131 StructureType noalg.map.group[string]string
     - __kind: PointerType
       ID: 126
@@ -1924,7 +1924,7 @@ Types:
           Offset: 8
           Type: 17 BaseType uint64
       GroupType: 131 StructureType noalg.map.group[string]string
-      GroupSliceType: 286 GoSliceDataType []noalg.map.group[string]string.array
+      GroupSliceType: 280 GoSliceDataType []noalg.map.group[string]string.array
     - __kind: PointerType
       ID: 130
       Name: '*noalg.map.group[string]string'
@@ -2181,7 +2181,7 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 17 BaseType uint64
-      TablePtrSliceType: 299 GoSliceDataType []*table<string,interface {}>.array
+      TablePtrSliceType: 281 GoSliceDataType []*table<string,interface {}>.array
       GroupType: 152 StructureType noalg.map.group[string]interface {}
     - __kind: PointerType
       ID: 147
@@ -2230,7 +2230,7 @@ Types:
           Offset: 8
           Type: 17 BaseType uint64
       GroupType: 152 StructureType noalg.map.group[string]interface {}
-      GroupSliceType: 300 GoSliceDataType []noalg.map.group[string]interface {}.array
+      GroupSliceType: 282 GoSliceDataType []noalg.map.group[string]interface {}.array
     - __kind: PointerType
       ID: 151
       Name: '*noalg.map.group[string]interface {}'
@@ -2313,7 +2313,7 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 17 BaseType uint64
-      TablePtrSliceType: 289 GoSliceDataType []*table<string,float64>.array
+      TablePtrSliceType: 283 GoSliceDataType []*table<string,float64>.array
       GroupType: 163 StructureType noalg.map.group[string]float64
     - __kind: PointerType
       ID: 158
@@ -2362,7 +2362,7 @@ Types:
           Offset: 8
           Type: 17 BaseType uint64
       GroupType: 163 StructureType noalg.map.group[string]float64
-      GroupSliceType: 290 GoSliceDataType []noalg.map.group[string]float64.array
+      GroupSliceType: 284 GoSliceDataType []noalg.map.group[string]float64.array
     - __kind: PointerType
       ID: 162
       Name: '*noalg.map.group[string]float64'
@@ -2425,7 +2425,7 @@ Types:
         - Name: cap
           Offset: 16
           Type: 8 BaseType int
-      Data: 291 GoSliceDataType []github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink.array
+      Data: 285 GoSliceDataType []github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink.array
     - __kind: PointerType
       ID: 168
       Name: '*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink'
@@ -2474,7 +2474,7 @@ Types:
         - Name: cap
           Offset: 16
           Type: 8 BaseType int
-      Data: 293 GoSliceDataType []github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent.array
+      Data: 287 GoSliceDataType []github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent.array
     - __kind: PointerType
       ID: 171
       Name: '*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent'
@@ -2543,7 +2543,7 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 17 BaseType uint64
-      TablePtrSliceType: 295 GoSliceDataType []*table<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>.array
+      TablePtrSliceType: 289 GoSliceDataType []*table<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>.array
       GroupType: 181 StructureType noalg.map.group[string]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
     - __kind: PointerType
       ID: 176
@@ -2592,7 +2592,7 @@ Types:
           Offset: 8
           Type: 17 BaseType uint64
       GroupType: 181 StructureType noalg.map.group[string]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
-      GroupSliceType: 296 GoSliceDataType []noalg.map.group[string]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute.array
+      GroupSliceType: 290 GoSliceDataType []noalg.map.group[string]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute.array
     - __kind: PointerType
       ID: 180
       Name: '*noalg.map.group[string]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute'
@@ -2704,7 +2704,7 @@ Types:
         - Name: cap
           Offset: 16
           Type: 8 BaseType int
-      Data: 297 GoSliceDataType []*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttributeValue.array
+      Data: 291 GoSliceDataType []*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttributeValue.array
     - __kind: PointerType
       ID: 190
       Name: '**github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttributeValue'
@@ -2869,7 +2869,7 @@ Types:
         - Name: cap
           Offset: 16
           Type: 8 BaseType int
-      Data: 301 GoSliceDataType []*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span.array
+      Data: 293 GoSliceDataType []*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span.array
     - __kind: PointerType
       ID: 200
       Name: '**github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span'
@@ -3112,346 +3112,306 @@ Types:
       Pointee: 233 GoSliceDataType []string.array
     - __kind: GoSliceDataType
       ID: 235
-      Name: '[]*table<string,[]string>.array'
-      ByteSize: 8192
-      Element: 20 PointerType *table<string,[]string>
-    - __kind: GoSliceDataType
-      ID: 236
-      Name: '[]noalg.map.group[string][]string.array'
-      ByteSize: 2048
-      Element: 25 StructureType noalg.map.group[string][]string
-    - __kind: GoSliceDataType
-      ID: 237
-      Name: '[]*table<string,[]string>.array'
-      ByteSize: 8192
-      Element: 20 PointerType *table<string,[]string>
-    - __kind: GoSliceDataType
-      ID: 238
-      Name: '[]noalg.map.group[string][]string.array'
-      ByteSize: 2048
-      Element: 25 StructureType noalg.map.group[string][]string
-    - __kind: GoSliceDataType
-      ID: 239
       Name: '[]*table<string,[]*mime/multipart.FileHeader>.array'
       ByteSize: 8192
       Element: 41 PointerType *table<string,[]*mime/multipart.FileHeader>
     - __kind: GoSliceDataType
-      ID: 240
+      ID: 236
       Name: '[]noalg.map.group[string][]*mime/multipart.FileHeader.array'
       ByteSize: 2048
       Element: 45 StructureType noalg.map.group[string][]*mime/multipart.FileHeader
     - __kind: GoSliceDataType
-      ID: 241
+      ID: 237
       Name: '[]*mime/multipart.FileHeader.array'
       ByteSize: 2048
       Element: 50 PointerType *mime/multipart.FileHeader
     - __kind: PointerType
-      ID: 242
+      ID: 238
       Name: '*[]*mime/multipart.FileHeader.array'
       ByteSize: 8
-      Pointee: 241 GoSliceDataType []*mime/multipart.FileHeader.array
+      Pointee: 237 GoSliceDataType []*mime/multipart.FileHeader.array
     - __kind: GoSliceDataType
-      ID: 243
-      Name: '[]*table<string,[]string>.array'
-      ByteSize: 8192
-      Element: 20 PointerType *table<string,[]string>
-    - __kind: GoSliceDataType
-      ID: 244
-      Name: '[]noalg.map.group[string][]string.array'
-      ByteSize: 2048
-      Element: 25 StructureType noalg.map.group[string][]string
-    - __kind: GoSliceDataType
-      ID: 245
+      ID: 239
       Name: '[]uint8.array'
       ByteSize: 2048
       Element: 7 BaseType uint8
     - __kind: PointerType
-      ID: 246
+      ID: 240
       Name: '*[]uint8.array'
       ByteSize: 8
-      Pointee: 245 GoSliceDataType []uint8.array
+      Pointee: 239 GoSliceDataType []uint8.array
     - __kind: GoSliceDataType
-      ID: 247
+      ID: 241
       Name: '[]*crypto/x509.Certificate.array'
       ByteSize: 2048
       Element: 58 PointerType *crypto/x509.Certificate
     - __kind: PointerType
-      ID: 248
+      ID: 242
       Name: '*[]*crypto/x509.Certificate.array'
       ByteSize: 8
-      Pointee: 247 GoSliceDataType []*crypto/x509.Certificate.array
+      Pointee: 241 GoSliceDataType []*crypto/x509.Certificate.array
     - __kind: GoSliceDataType
-      ID: 249
+      ID: 243
       Name: math/big.nat.array
       ByteSize: 2048
       Element: 67 BaseType math/big.Word
     - __kind: PointerType
-      ID: 250
+      ID: 244
       Name: '*math/big.nat.array'
       ByteSize: 8
-      Pointee: 249 GoSliceDataType math/big.nat.array
+      Pointee: 243 GoSliceDataType math/big.nat.array
     - __kind: GoSliceDataType
-      ID: 251
+      ID: 245
       Name: '[]crypto/x509/pkix.AttributeTypeAndValue.array'
       ByteSize: 2048
       Element: 71 StructureType crypto/x509/pkix.AttributeTypeAndValue
     - __kind: PointerType
-      ID: 252
+      ID: 246
       Name: '*[]crypto/x509/pkix.AttributeTypeAndValue.array'
       ByteSize: 8
-      Pointee: 251 GoSliceDataType []crypto/x509/pkix.AttributeTypeAndValue.array
+      Pointee: 245 GoSliceDataType []crypto/x509/pkix.AttributeTypeAndValue.array
     - __kind: GoSliceDataType
-      ID: 253
+      ID: 247
       Name: encoding/asn1.ObjectIdentifier.array
       ByteSize: 2048
       Element: 8 BaseType int
     - __kind: PointerType
-      ID: 254
+      ID: 248
       Name: '*encoding/asn1.ObjectIdentifier.array'
       ByteSize: 8
-      Pointee: 253 GoSliceDataType encoding/asn1.ObjectIdentifier.array
+      Pointee: 247 GoSliceDataType encoding/asn1.ObjectIdentifier.array
     - __kind: GoSliceDataType
-      ID: 255
+      ID: 249
       Name: '[]time.zone.array'
       ByteSize: 2048
       Element: 79 StructureType time.zone
     - __kind: PointerType
-      ID: 256
+      ID: 250
       Name: '*[]time.zone.array'
       ByteSize: 8
-      Pointee: 255 GoSliceDataType []time.zone.array
+      Pointee: 249 GoSliceDataType []time.zone.array
     - __kind: GoSliceDataType
-      ID: 257
+      ID: 251
       Name: '[]time.zoneTrans.array'
       ByteSize: 2048
       Element: 82 StructureType time.zoneTrans
     - __kind: PointerType
-      ID: 258
+      ID: 252
       Name: '*[]time.zoneTrans.array'
       ByteSize: 8
-      Pointee: 257 GoSliceDataType []time.zoneTrans.array
+      Pointee: 251 GoSliceDataType []time.zoneTrans.array
     - __kind: GoSliceDataType
-      ID: 259
+      ID: 253
       Name: '[]crypto/x509/pkix.Extension.array'
       ByteSize: 2048
       Element: 86 StructureType crypto/x509/pkix.Extension
     - __kind: PointerType
-      ID: 260
+      ID: 254
       Name: '*[]crypto/x509/pkix.Extension.array'
       ByteSize: 8
-      Pointee: 259 GoSliceDataType []crypto/x509/pkix.Extension.array
+      Pointee: 253 GoSliceDataType []crypto/x509/pkix.Extension.array
     - __kind: GoSliceDataType
-      ID: 261
+      ID: 255
       Name: '[]encoding/asn1.ObjectIdentifier.array'
       ByteSize: 2048
       Element: 72 GoSliceHeaderType encoding/asn1.ObjectIdentifier
     - __kind: PointerType
-      ID: 262
+      ID: 256
       Name: '*[]encoding/asn1.ObjectIdentifier.array'
       ByteSize: 8
-      Pointee: 261 GoSliceDataType []encoding/asn1.ObjectIdentifier.array
+      Pointee: 255 GoSliceDataType []encoding/asn1.ObjectIdentifier.array
     - __kind: GoSliceDataType
-      ID: 263
+      ID: 257
       Name: '[]crypto/x509.ExtKeyUsage.array'
       ByteSize: 2048
       Element: 91 BaseType crypto/x509.ExtKeyUsage
     - __kind: PointerType
-      ID: 264
+      ID: 258
       Name: '*[]crypto/x509.ExtKeyUsage.array'
       ByteSize: 8
-      Pointee: 263 GoSliceDataType []crypto/x509.ExtKeyUsage.array
+      Pointee: 257 GoSliceDataType []crypto/x509.ExtKeyUsage.array
     - __kind: GoSliceDataType
-      ID: 265
+      ID: 259
       Name: '[]net.IP.array'
       ByteSize: 2048
       Element: 94 GoSliceHeaderType net.IP
     - __kind: PointerType
-      ID: 266
+      ID: 260
       Name: '*[]net.IP.array'
       ByteSize: 8
-      Pointee: 265 GoSliceDataType []net.IP.array
+      Pointee: 259 GoSliceDataType []net.IP.array
     - __kind: GoSliceDataType
-      ID: 267
+      ID: 261
       Name: net.IP.array
       ByteSize: 2048
       Element: 7 BaseType uint8
     - __kind: PointerType
-      ID: 268
+      ID: 262
       Name: '*net.IP.array'
       ByteSize: 8
-      Pointee: 267 GoSliceDataType net.IP.array
+      Pointee: 261 GoSliceDataType net.IP.array
     - __kind: GoSliceDataType
-      ID: 269
+      ID: 263
       Name: '[]*net/url.URL.array'
       ByteSize: 2048
       Element: 9 PointerType *net/url.URL
     - __kind: PointerType
-      ID: 270
+      ID: 264
       Name: '*[]*net/url.URL.array'
       ByteSize: 8
-      Pointee: 269 GoSliceDataType []*net/url.URL.array
+      Pointee: 263 GoSliceDataType []*net/url.URL.array
     - __kind: GoSliceDataType
-      ID: 271
+      ID: 265
       Name: '[]*net.IPNet.array'
       ByteSize: 2048
       Element: 99 PointerType *net.IPNet
     - __kind: PointerType
-      ID: 272
+      ID: 266
       Name: '*[]*net.IPNet.array'
       ByteSize: 8
-      Pointee: 271 GoSliceDataType []*net.IPNet.array
+      Pointee: 265 GoSliceDataType []*net.IPNet.array
     - __kind: GoSliceDataType
-      ID: 273
+      ID: 267
       Name: net.IPMask.array
       ByteSize: 2048
       Element: 7 BaseType uint8
     - __kind: PointerType
-      ID: 274
+      ID: 268
       Name: '*net.IPMask.array'
       ByteSize: 8
-      Pointee: 273 GoSliceDataType net.IPMask.array
+      Pointee: 267 GoSliceDataType net.IPMask.array
     - __kind: GoSliceDataType
-      ID: 275
+      ID: 269
       Name: '[]crypto/x509.OID.array'
       ByteSize: 2048
       Element: 104 StructureType crypto/x509.OID
     - __kind: PointerType
-      ID: 276
+      ID: 270
       Name: '*[]crypto/x509.OID.array'
       ByteSize: 8
-      Pointee: 275 GoSliceDataType []crypto/x509.OID.array
+      Pointee: 269 GoSliceDataType []crypto/x509.OID.array
     - __kind: GoSliceDataType
-      ID: 277
+      ID: 271
       Name: '[]crypto/x509.PolicyMapping.array'
       ByteSize: 2048
       Element: 107 StructureType crypto/x509.PolicyMapping
     - __kind: PointerType
-      ID: 278
+      ID: 272
       Name: '*[]crypto/x509.PolicyMapping.array'
       ByteSize: 8
-      Pointee: 277 GoSliceDataType []crypto/x509.PolicyMapping.array
+      Pointee: 271 GoSliceDataType []crypto/x509.PolicyMapping.array
     - __kind: GoSliceDataType
-      ID: 279
+      ID: 273
       Name: '[][]*crypto/x509.Certificate.array'
       ByteSize: 2048
       Element: 56 GoSliceHeaderType []*crypto/x509.Certificate
     - __kind: PointerType
-      ID: 280
+      ID: 274
       Name: '*[][]*crypto/x509.Certificate.array'
       ByteSize: 8
-      Pointee: 279 GoSliceDataType [][]*crypto/x509.Certificate.array
+      Pointee: 273 GoSliceDataType [][]*crypto/x509.Certificate.array
     - __kind: GoSliceDataType
-      ID: 281
+      ID: 275
       Name: '[][]uint8.array'
       ByteSize: 2048
       Element: 53 GoSliceHeaderType []uint8
     - __kind: PointerType
-      ID: 282
+      ID: 276
       Name: '*[][]uint8.array'
       ByteSize: 8
-      Pointee: 281 GoSliceDataType [][]uint8.array
+      Pointee: 275 GoSliceDataType [][]uint8.array
     - __kind: GoSliceDataType
-      ID: 283
+      ID: 277
       Name: '[]net/http.segment.array'
       ByteSize: 2048
       Element: 122 StructureType net/http.segment
     - __kind: PointerType
-      ID: 284
+      ID: 278
       Name: '*[]net/http.segment.array'
       ByteSize: 8
-      Pointee: 283 GoSliceDataType []net/http.segment.array
+      Pointee: 277 GoSliceDataType []net/http.segment.array
     - __kind: GoSliceDataType
-      ID: 285
+      ID: 279
       Name: '[]*table<string,string>.array'
       ByteSize: 8192
       Element: 127 PointerType *table<string,string>
     - __kind: GoSliceDataType
-      ID: 286
+      ID: 280
       Name: '[]noalg.map.group[string]string.array'
       ByteSize: 2048
       Element: 131 StructureType noalg.map.group[string]string
     - __kind: GoSliceDataType
-      ID: 287
+      ID: 281
       Name: '[]*table<string,interface {}>.array'
       ByteSize: 8192
       Element: 148 PointerType *table<string,interface {}>
     - __kind: GoSliceDataType
-      ID: 288
+      ID: 282
       Name: '[]noalg.map.group[string]interface {}.array'
       ByteSize: 2048
       Element: 152 StructureType noalg.map.group[string]interface {}
     - __kind: GoSliceDataType
-      ID: 289
+      ID: 283
       Name: '[]*table<string,float64>.array'
       ByteSize: 8192
       Element: 159 PointerType *table<string,float64>
     - __kind: GoSliceDataType
-      ID: 290
+      ID: 284
       Name: '[]noalg.map.group[string]float64.array'
       ByteSize: 2048
       Element: 163 StructureType noalg.map.group[string]float64
     - __kind: GoSliceDataType
-      ID: 291
+      ID: 285
       Name: '[]github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink.array'
       ByteSize: 2048
       Element: 169 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink
     - __kind: PointerType
-      ID: 292
+      ID: 286
       Name: '*[]github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink.array'
       ByteSize: 8
-      Pointee: 291 GoSliceDataType []github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink.array
+      Pointee: 285 GoSliceDataType []github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink.array
     - __kind: GoSliceDataType
-      ID: 293
+      ID: 287
       Name: '[]github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent.array'
       ByteSize: 2048
       Element: 172 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent
     - __kind: PointerType
-      ID: 294
+      ID: 288
       Name: '*[]github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent.array'
       ByteSize: 8
-      Pointee: 293 GoSliceDataType []github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent.array
+      Pointee: 287 GoSliceDataType []github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent.array
     - __kind: GoSliceDataType
-      ID: 295
+      ID: 289
       Name: '[]*table<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>.array'
       ByteSize: 8192
       Element: 177 PointerType *table<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
     - __kind: GoSliceDataType
-      ID: 296
+      ID: 290
       Name: '[]noalg.map.group[string]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute.array'
       ByteSize: 2048
       Element: 181 StructureType noalg.map.group[string]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
     - __kind: GoSliceDataType
-      ID: 297
+      ID: 291
       Name: '[]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttributeValue.array'
       ByteSize: 2048
       Element: 191 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttributeValue
     - __kind: PointerType
-      ID: 298
+      ID: 292
       Name: '*[]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttributeValue.array'
       ByteSize: 8
-      Pointee: 297 GoSliceDataType []*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttributeValue.array
+      Pointee: 291 GoSliceDataType []*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttributeValue.array
     - __kind: GoSliceDataType
-      ID: 299
-      Name: '[]*table<string,interface {}>.array'
-      ByteSize: 8192
-      Element: 148 PointerType *table<string,interface {}>
-    - __kind: GoSliceDataType
-      ID: 300
-      Name: '[]noalg.map.group[string]interface {}.array'
-      ByteSize: 2048
-      Element: 152 StructureType noalg.map.group[string]interface {}
-    - __kind: GoSliceDataType
-      ID: 301
+      ID: 293
       Name: '[]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span.array'
       ByteSize: 2048
       Element: 134 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span
     - __kind: PointerType
-      ID: 302
+      ID: 294
       Name: '*[]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span.array'
       ByteSize: 8
-      Pointee: 301 GoSliceDataType []*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span.array
+      Pointee: 293 GoSliceDataType []*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span.array
     - __kind: EventRootType
-      ID: 303
+      ID: 295
       Name: Probe[main.HandleHTTP]
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -3475,7 +3435,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 304
+      ID: 296
       Name: Probe[main.LookAtTheRequest]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -3489,6 +3449,6 @@ Types:
                   Variable: {subprogram: 2, index: 0, name: path}
                   Offset: 0
                   ByteSize: 16
-MaxTypeID: 304
+MaxTypeID: 296
 Issues: []
 GoModuledataInfo: {FirstModuledataAddr: "0x18b56e0", TypesOffset: 296}

--- a/pkg/dyninst/irgen/testdata/snapshot/rc_tester.arch=amd64,toolchain=go1.24.3.yaml
+++ b/pkg/dyninst/irgen/testdata/snapshot/rc_tester.arch=amd64,toolchain=go1.24.3.yaml
@@ -105,51 +105,51 @@ Subprograms:
           IsReturn: false
 Types:
     - __kind: PointerType
-      ID: 108
+      ID: 110
       Name: '**crypto/x509.Certificate'
       ByteSize: 8
       GoKind: 22
-      Pointee: 109 PointerType *crypto/x509.Certificate
+      Pointee: 111 PointerType *crypto/x509.Certificate
     - __kind: PointerType
-      ID: 147
+      ID: 174
       Name: '**github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span'
       ByteSize: 8
       GoKind: 22
       Pointee: 39 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span
     - __kind: PointerType
-      ID: 225
+      ID: 258
       Name: '**github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttributeValue'
       ByteSize: 8
       GoKind: 22
-      Pointee: 226 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttributeValue
+      Pointee: 259 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttributeValue
     - __kind: PointerType
-      ID: 202
+      ID: 182
       Name: '**mime/multipart.FileHeader'
       ByteSize: 8
       GoKind: 22
-      Pointee: 203 PointerType *mime/multipart.FileHeader
+      Pointee: 183 PointerType *mime/multipart.FileHeader
     - __kind: PointerType
-      ID: 182
+      ID: 230
       Name: '**net.IPNet'
       ByteSize: 8
       GoKind: 22
-      Pointee: 183 PointerType *net.IPNet
+      Pointee: 231 PointerType *net.IPNet
     - __kind: PointerType
-      ID: 180
+      ID: 228
       Name: '**net/url.URL'
       ByteSize: 8
       GoKind: 22
       Pointee: 45 PointerType *net/url.URL
     - __kind: PointerType
-      ID: 125
+      ID: 127
       Name: '**table<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>'
       ByteSize: 8
-      Pointee: 126 PointerType *table<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
+      Pointee: 128 PointerType *table<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
     - __kind: PointerType
-      ID: 105
+      ID: 107
       Name: '**table<string,[]*mime/multipart.FileHeader>'
       ByteSize: 8
-      Pointee: 106 PointerType *table<string,[]*mime/multipart.FileHeader>
+      Pointee: 108 PointerType *table<string,[]*mime/multipart.FileHeader>
     - __kind: PointerType
       ID: 50
       Name: '**table<string,[]string>'
@@ -171,128 +171,128 @@ Types:
       ByteSize: 8
       Pointee: 70 PointerType *table<string,string>
     - __kind: PointerType
-      ID: 111
+      ID: 113
       Name: '*[]*crypto/x509.Certificate'
       ByteSize: 8
       GoKind: 22
-      Pointee: 107 GoSliceHeaderType []*crypto/x509.Certificate
+      Pointee: 109 GoSliceHeaderType []*crypto/x509.Certificate
     - __kind: PointerType
-      ID: 250
+      ID: 187
       Name: '*[]*crypto/x509.Certificate.array'
       ByteSize: 8
-      Pointee: 249 GoSliceDataType []*crypto/x509.Certificate.array
+      Pointee: 186 GoSliceDataType []*crypto/x509.Certificate.array
     - __kind: PointerType
-      ID: 260
+      ID: 243
       Name: '*[]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span.array'
       ByteSize: 8
-      Pointee: 259 GoSliceDataType []*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span.array
+      Pointee: 242 GoSliceDataType []*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span.array
     - __kind: PointerType
-      ID: 294
+      ID: 291
       Name: '*[]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttributeValue.array'
       ByteSize: 8
-      Pointee: 293 GoSliceDataType []*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttributeValue.array
+      Pointee: 290 GoSliceDataType []*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttributeValue.array
     - __kind: PointerType
-      ID: 284
+      ID: 245
       Name: '*[]*mime/multipart.FileHeader.array'
       ByteSize: 8
-      Pointee: 283 GoSliceDataType []*mime/multipart.FileHeader.array
+      Pointee: 244 GoSliceDataType []*mime/multipart.FileHeader.array
     - __kind: PointerType
-      ID: 278
+      ID: 277
       Name: '*[]*net.IPNet.array'
       ByteSize: 8
-      Pointee: 277 GoSliceDataType []*net.IPNet.array
+      Pointee: 276 GoSliceDataType []*net.IPNet.array
     - __kind: PointerType
-      ID: 276
+      ID: 275
       Name: '*[]*net/url.URL.array'
       ByteSize: 8
-      Pointee: 275 GoSliceDataType []*net/url.URL.array
+      Pointee: 274 GoSliceDataType []*net/url.URL.array
     - __kind: PointerType
-      ID: 252
+      ID: 189
       Name: '*[][]*crypto/x509.Certificate.array'
       ByteSize: 8
-      Pointee: 251 GoSliceDataType [][]*crypto/x509.Certificate.array
+      Pointee: 188 GoSliceDataType [][]*crypto/x509.Certificate.array
     - __kind: PointerType
-      ID: 254
+      ID: 191
       Name: '*[][]uint8.array'
       ByteSize: 8
-      Pointee: 253 GoSliceDataType [][]uint8.array
+      Pointee: 190 GoSliceDataType [][]uint8.array
     - __kind: PointerType
-      ID: 270
+      ID: 269
       Name: '*[]crypto/x509.ExtKeyUsage.array'
       ByteSize: 8
-      Pointee: 269 GoSliceDataType []crypto/x509.ExtKeyUsage.array
+      Pointee: 268 GoSliceDataType []crypto/x509.ExtKeyUsage.array
     - __kind: PointerType
-      ID: 280
+      ID: 279
       Name: '*[]crypto/x509.OID.array'
       ByteSize: 8
-      Pointee: 279 GoSliceDataType []crypto/x509.OID.array
+      Pointee: 278 GoSliceDataType []crypto/x509.OID.array
     - __kind: PointerType
-      ID: 282
+      ID: 281
       Name: '*[]crypto/x509.PolicyMapping.array'
       ByteSize: 8
-      Pointee: 281 GoSliceDataType []crypto/x509.PolicyMapping.array
+      Pointee: 280 GoSliceDataType []crypto/x509.PolicyMapping.array
     - __kind: PointerType
-      ID: 262
+      ID: 261
       Name: '*[]crypto/x509/pkix.AttributeTypeAndValue.array'
       ByteSize: 8
-      Pointee: 261 GoSliceDataType []crypto/x509/pkix.AttributeTypeAndValue.array
+      Pointee: 260 GoSliceDataType []crypto/x509/pkix.AttributeTypeAndValue.array
     - __kind: PointerType
-      ID: 264
+      ID: 263
       Name: '*[]crypto/x509/pkix.Extension.array'
       ByteSize: 8
-      Pointee: 263 GoSliceDataType []crypto/x509/pkix.Extension.array
+      Pointee: 262 GoSliceDataType []crypto/x509/pkix.Extension.array
     - __kind: PointerType
-      ID: 266
+      ID: 265
       Name: '*[]encoding/asn1.ObjectIdentifier.array'
       ByteSize: 8
-      Pointee: 265 GoSliceDataType []encoding/asn1.ObjectIdentifier.array
+      Pointee: 264 GoSliceDataType []encoding/asn1.ObjectIdentifier.array
     - __kind: PointerType
-      ID: 242
+      ID: 165
       Name: '*[]github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink.array'
       ByteSize: 8
-      Pointee: 241 GoSliceDataType []github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink.array
+      Pointee: 164 GoSliceDataType []github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink.array
     - __kind: PointerType
-      ID: 244
+      ID: 167
       Name: '*[]github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent.array'
       ByteSize: 8
-      Pointee: 243 GoSliceDataType []github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent.array
+      Pointee: 166 GoSliceDataType []github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent.array
     - __kind: PointerType
-      ID: 272
+      ID: 271
       Name: '*[]net.IP.array'
       ByteSize: 8
-      Pointee: 271 GoSliceDataType []net.IP.array
+      Pointee: 270 GoSliceDataType []net.IP.array
     - __kind: PointerType
-      ID: 256
+      ID: 193
       Name: '*[]net/http.segment.array'
       ByteSize: 8
-      Pointee: 255 GoSliceDataType []net/http.segment.array
+      Pointee: 192 GoSliceDataType []net/http.segment.array
     - __kind: PointerType
-      ID: 234
+      ID: 141
       Name: '*[]string.array'
       ByteSize: 8
-      Pointee: 233 GoSliceDataType []string.array
+      Pointee: 140 GoSliceDataType []string.array
     - __kind: PointerType
-      ID: 288
+      ID: 287
       Name: '*[]time.zone.array'
       ByteSize: 8
-      Pointee: 287 GoSliceDataType []time.zone.array
+      Pointee: 286 GoSliceDataType []time.zone.array
     - __kind: PointerType
-      ID: 290
+      ID: 289
       Name: '*[]time.zoneTrans.array'
       ByteSize: 8
-      Pointee: 289 GoSliceDataType []time.zoneTrans.array
+      Pointee: 288 GoSliceDataType []time.zoneTrans.array
     - __kind: PointerType
-      ID: 113
+      ID: 115
       Name: '*[]uint8'
       ByteSize: 8
       GoRuntimeType: 483552
       GoKind: 22
       Pointee: 96 GoSliceHeaderType []uint8
     - __kind: PointerType
-      ID: 246
+      ID: 169
       Name: '*[]uint8.array'
       ByteSize: 8
-      Pointee: 245 GoSliceDataType []uint8.array
+      Pointee: 168 GoSliceDataType []uint8.array
     - __kind: PointerType
       ID: 11
       Name: '*bool'
@@ -315,59 +315,59 @@ Types:
       GoKind: 22
       Pointee: 59 StructureType crypto/tls.ConnectionState
     - __kind: PointerType
-      ID: 109
+      ID: 111
       Name: '*crypto/x509.Certificate'
       ByteSize: 8
       GoRuntimeType: 2.082688e+06
       GoKind: 22
-      Pointee: 135 StructureType crypto/x509.Certificate
+      Pointee: 171 StructureType crypto/x509.Certificate
     - __kind: PointerType
-      ID: 174
+      ID: 222
       Name: '*crypto/x509.ExtKeyUsage'
       ByteSize: 8
       GoRuntimeType: 426912
       GoKind: 22
-      Pointee: 175 BaseType crypto/x509.ExtKeyUsage
+      Pointee: 223 BaseType crypto/x509.ExtKeyUsage
     - __kind: PointerType
-      ID: 185
+      ID: 233
       Name: '*crypto/x509.OID'
       ByteSize: 8
       GoRuntimeType: 1.989632e+06
       GoKind: 22
-      Pointee: 186 StructureType crypto/x509.OID
+      Pointee: 234 StructureType crypto/x509.OID
     - __kind: PointerType
-      ID: 188
+      ID: 236
       Name: '*crypto/x509.PolicyMapping'
       ByteSize: 8
       GoRuntimeType: 426976
       GoKind: 22
-      Pointee: 189 StructureType crypto/x509.PolicyMapping
+      Pointee: 237 StructureType crypto/x509.PolicyMapping
     - __kind: PointerType
-      ID: 161
+      ID: 209
       Name: '*crypto/x509/pkix.AttributeTypeAndValue'
       ByteSize: 8
       GoRuntimeType: 443680
       GoKind: 22
-      Pointee: 162 StructureType crypto/x509/pkix.AttributeTypeAndValue
+      Pointee: 210 StructureType crypto/x509/pkix.AttributeTypeAndValue
     - __kind: PointerType
-      ID: 168
+      ID: 216
       Name: '*crypto/x509/pkix.Extension'
       ByteSize: 8
       GoRuntimeType: 443872
       GoKind: 22
-      Pointee: 169 StructureType crypto/x509/pkix.Extension
+      Pointee: 217 StructureType crypto/x509/pkix.Extension
     - __kind: PointerType
-      ID: 171
+      ID: 219
       Name: '*encoding/asn1.ObjectIdentifier'
       ByteSize: 8
       GoRuntimeType: 1.0752e+06
       GoKind: 22
-      Pointee: 172 GoSliceHeaderType encoding/asn1.ObjectIdentifier
+      Pointee: 220 GoSliceHeaderType encoding/asn1.ObjectIdentifier
     - __kind: PointerType
-      ID: 268
+      ID: 267
       Name: '*encoding/asn1.ObjectIdentifier.array'
       ByteSize: 8
-      Pointee: 267 GoSliceDataType encoding/asn1.ObjectIdentifier.array
+      Pointee: 266 GoSliceDataType encoding/asn1.ObjectIdentifier.array
     - __kind: PointerType
       ID: 33
       Name: '*error'
@@ -418,33 +418,33 @@ Types:
       GoKind: 22
       Pointee: 92 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent
     - __kind: PointerType
-      ID: 221
+      ID: 240
       Name: '*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttribute'
       ByteSize: 8
       GoRuntimeType: 1.211456e+06
       GoKind: 22
-      Pointee: 222 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttribute
+      Pointee: 241 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttribute
     - __kind: PointerType
-      ID: 226
+      ID: 259
       Name: '*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttributeValue'
       ByteSize: 8
       GoRuntimeType: 1.2112e+06
       GoKind: 22
-      Pointee: 227 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttributeValue
+      Pointee: 283 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttributeValue
     - __kind: PointerType
-      ID: 216
+      ID: 199
       Name: '*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute'
       ByteSize: 8
       GoRuntimeType: 1.211584e+06
       GoKind: 22
-      Pointee: 217 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
+      Pointee: 200 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
     - __kind: PointerType
-      ID: 128
+      ID: 130
       Name: '*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.trace'
       ByteSize: 8
       GoRuntimeType: 2.27024e+06
       GoKind: 22
-      Pointee: 129 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.trace
+      Pointee: 131 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.trace
     - __kind: PointerType
       ID: 27
       Name: '*int'
@@ -481,15 +481,15 @@ Types:
       GoKind: 22
       Pointee: 15 BaseType int8
     - __kind: PointerType
-      ID: 123
+      ID: 125
       Name: '*map<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>'
       ByteSize: 8
-      Pointee: 124 GoSwissMapHeaderType map<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
+      Pointee: 126 GoSwissMapHeaderType map<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
     - __kind: PointerType
-      ID: 103
+      ID: 105
       Name: '*map<string,[]*mime/multipart.FileHeader>'
       ByteSize: 8
-      Pointee: 104 GoSwissMapHeaderType map<string,[]*mime/multipart.FileHeader>
+      Pointee: 106 GoSwissMapHeaderType map<string,[]*mime/multipart.FileHeader>
     - __kind: PointerType
       ID: 48
       Name: '*map<string,[]string>'
@@ -511,31 +511,31 @@ Types:
       ByteSize: 8
       Pointee: 68 GoSwissMapHeaderType map<string,string>
     - __kind: PointerType
-      ID: 157
+      ID: 205
       Name: '*math/big.Int'
       ByteSize: 8
       GoRuntimeType: 2.440832e+06
       GoKind: 22
-      Pointee: 158 StructureType math/big.Int
+      Pointee: 206 StructureType math/big.Int
     - __kind: PointerType
-      ID: 205
+      ID: 247
       Name: '*math/big.Word'
       ByteSize: 8
       GoRuntimeType: 429856
       GoKind: 22
-      Pointee: 206 BaseType math/big.Word
+      Pointee: 248 BaseType math/big.Word
     - __kind: PointerType
-      ID: 286
+      ID: 285
       Name: '*math/big.nat.array'
       ByteSize: 8
-      Pointee: 285 GoSliceDataType math/big.nat.array
+      Pointee: 284 GoSliceDataType math/big.nat.array
     - __kind: PointerType
-      ID: 203
+      ID: 183
       Name: '*mime/multipart.FileHeader'
       ByteSize: 8
       GoRuntimeType: 920864
       GoKind: 22
-      Pointee: 218 StructureType mime/multipart.FileHeader
+      Pointee: 238 StructureType mime/multipart.FileHeader
     - __kind: PointerType
       ID: 56
       Name: '*mime/multipart.Form'
@@ -544,29 +544,29 @@ Types:
       GoKind: 22
       Pointee: 57 StructureType mime/multipart.Form
     - __kind: PointerType
-      ID: 177
+      ID: 225
       Name: '*net.IP'
       ByteSize: 8
       GoRuntimeType: 2.198272e+06
       GoKind: 22
-      Pointee: 178 GoSliceHeaderType net.IP
+      Pointee: 226 GoSliceHeaderType net.IP
     - __kind: PointerType
-      ID: 274
+      ID: 273
       Name: '*net.IP.array'
       ByteSize: 8
-      Pointee: 273 GoSliceDataType net.IP.array
+      Pointee: 272 GoSliceDataType net.IP.array
     - __kind: PointerType
-      ID: 292
+      ID: 294
       Name: '*net.IPMask.array'
       ByteSize: 8
-      Pointee: 291 GoSliceDataType net.IPMask.array
+      Pointee: 293 GoSliceDataType net.IPMask.array
     - __kind: PointerType
-      ID: 183
+      ID: 231
       Name: '*net.IPNet'
       ByteSize: 8
       GoRuntimeType: 1.204416e+06
       GoKind: 22
-      Pointee: 213 StructureType net.IPNet
+      Pointee: 255 StructureType net.IPNet
     - __kind: PointerType
       ID: 37
       Name: '*net/http.Request'
@@ -589,12 +589,12 @@ Types:
       GoKind: 22
       Pointee: 65 StructureType net/http.pattern
     - __kind: PointerType
-      ID: 117
+      ID: 119
       Name: '*net/http.segment'
       ByteSize: 8
       GoRuntimeType: 393504
       GoKind: 22
-      Pointee: 118 StructureType net/http.segment
+      Pointee: 120 StructureType net/http.segment
     - __kind: PointerType
       ID: 45
       Name: '*net/url.URL'
@@ -603,42 +603,42 @@ Types:
       GoKind: 22
       Pointee: 46 StructureType net/url.URL
     - __kind: PointerType
-      ID: 98
+      ID: 100
       Name: '*net/url.Userinfo'
       ByteSize: 8
       GoRuntimeType: 1.222208e+06
       GoKind: 22
-      Pointee: 99 StructureType net/url.Userinfo
+      Pointee: 101 StructureType net/url.Userinfo
     - __kind: PointerType
-      ID: 197
+      ID: 195
       Name: '*noalg.map.group[string]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute'
       ByteSize: 8
-      Pointee: 198 StructureType noalg.map.group[string]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
+      Pointee: 196 StructureType noalg.map.group[string]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
     - __kind: PointerType
-      ID: 152
+      ID: 177
       Name: '*noalg.map.group[string][]*mime/multipart.FileHeader'
       ByteSize: 8
-      Pointee: 153 StructureType noalg.map.group[string][]*mime/multipart.FileHeader
+      Pointee: 178 StructureType noalg.map.group[string][]*mime/multipart.FileHeader
     - __kind: PointerType
-      ID: 132
+      ID: 134
       Name: '*noalg.map.group[string][]string'
       ByteSize: 8
-      Pointee: 133 StructureType noalg.map.group[string][]string
+      Pointee: 135 StructureType noalg.map.group[string][]string
     - __kind: PointerType
-      ID: 143
+      ID: 158
       Name: '*noalg.map.group[string]float64'
       ByteSize: 8
-      Pointee: 144 StructureType noalg.map.group[string]float64
+      Pointee: 159 StructureType noalg.map.group[string]float64
     - __kind: PointerType
-      ID: 140
+      ID: 150
       Name: '*noalg.map.group[string]interface {}'
       ByteSize: 8
-      Pointee: 141 StructureType noalg.map.group[string]interface {}
+      Pointee: 151 StructureType noalg.map.group[string]interface {}
     - __kind: PointerType
-      ID: 137
+      ID: 143
       Name: '*noalg.map.group[string]string'
       ByteSize: 8
-      Pointee: 138 StructureType noalg.map.group[string]string
+      Pointee: 144 StructureType noalg.map.group[string]string
     - __kind: PointerType
       ID: 22
       Name: '*string'
@@ -647,61 +647,61 @@ Types:
       GoKind: 22
       Pointee: 9 GoStringHeaderType string
     - __kind: PointerType
-      ID: 230
+      ID: 99
       Name: '*string.str'
       ByteSize: 8
-      Pointee: 229 GoStringDataType string.str
+      Pointee: 98 GoStringDataType string.str
     - __kind: PointerType
-      ID: 126
+      ID: 128
       Name: '*table<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>'
       ByteSize: 8
-      Pointee: 145 StructureType table<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
+      Pointee: 172 StructureType table<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
     - __kind: PointerType
-      ID: 106
+      ID: 108
       Name: '*table<string,[]*mime/multipart.FileHeader>'
       ByteSize: 8
-      Pointee: 134 StructureType table<string,[]*mime/multipart.FileHeader>
+      Pointee: 170 StructureType table<string,[]*mime/multipart.FileHeader>
     - __kind: PointerType
       ID: 51
       Name: '*table<string,[]string>'
       ByteSize: 8
-      Pointee: 100 StructureType table<string,[]string>
+      Pointee: 102 StructureType table<string,[]string>
     - __kind: PointerType
       ID: 86
       Name: '*table<string,float64>'
       ByteSize: 8
-      Pointee: 121 StructureType table<string,float64>
+      Pointee: 123 StructureType table<string,float64>
     - __kind: PointerType
       ID: 81
       Name: '*table<string,interface {}>'
       ByteSize: 8
-      Pointee: 120 StructureType table<string,interface {}>
+      Pointee: 122 StructureType table<string,interface {}>
     - __kind: PointerType
       ID: 70
       Name: '*table<string,string>'
       ByteSize: 8
-      Pointee: 119 StructureType table<string,string>
+      Pointee: 121 StructureType table<string,string>
     - __kind: PointerType
-      ID: 164
+      ID: 212
       Name: '*time.Location'
       ByteSize: 8
       GoRuntimeType: 1.642784e+06
       GoKind: 22
-      Pointee: 165 StructureType time.Location
+      Pointee: 213 StructureType time.Location
     - __kind: PointerType
-      ID: 208
+      ID: 250
       Name: '*time.zone'
       ByteSize: 8
       GoRuntimeType: 396640
       GoKind: 22
-      Pointee: 209 StructureType time.zone
+      Pointee: 251 StructureType time.zone
     - __kind: PointerType
-      ID: 211
+      ID: 253
       Name: '*time.zoneTrans'
       ByteSize: 8
       GoRuntimeType: 396704
       GoKind: 22
-      Pointee: 212 StructureType time.zoneTrans
+      Pointee: 254 StructureType time.zoneTrans
     - __kind: PointerType
       ID: 34
       Name: '*uint'
@@ -789,7 +789,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: GoSliceHeaderType
-      ID: 107
+      ID: 109
       Name: '[]*crypto/x509.Certificate'
       ByteSize: 24
       GoRuntimeType: 503808
@@ -797,21 +797,21 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 108 PointerType **crypto/x509.Certificate
+          Type: 110 PointerType **crypto/x509.Certificate
         - Name: len
           Offset: 8
           Type: 7 BaseType int
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 249 GoSliceDataType []*crypto/x509.Certificate.array
+      Data: 186 GoSliceDataType []*crypto/x509.Certificate.array
     - __kind: GoSliceDataType
-      ID: 249
+      ID: 186
       Name: '[]*crypto/x509.Certificate.array'
       ByteSize: 2048
-      Element: 109 PointerType *crypto/x509.Certificate
+      Element: 111 PointerType *crypto/x509.Certificate
     - __kind: GoSliceHeaderType
-      ID: 146
+      ID: 173
       Name: '[]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span'
       ByteSize: 24
       GoRuntimeType: 491968
@@ -819,21 +819,21 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 147 PointerType **github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span
+          Type: 174 PointerType **github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span
         - Name: len
           Offset: 8
           Type: 7 BaseType int
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 259 GoSliceDataType []*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span.array
+      Data: 242 GoSliceDataType []*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span.array
     - __kind: GoSliceDataType
-      ID: 259
+      ID: 242
       Name: '[]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span.array'
       ByteSize: 2048
       Element: 39 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span
     - __kind: GoSliceHeaderType
-      ID: 224
+      ID: 257
       Name: '[]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttributeValue'
       ByteSize: 24
       GoRuntimeType: 491584
@@ -841,21 +841,21 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 225 PointerType **github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttributeValue
+          Type: 258 PointerType **github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttributeValue
         - Name: len
           Offset: 8
           Type: 7 BaseType int
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 293 GoSliceDataType []*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttributeValue.array
+      Data: 290 GoSliceDataType []*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttributeValue.array
     - __kind: GoSliceDataType
-      ID: 293
+      ID: 290
       Name: '[]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttributeValue.array'
       ByteSize: 2048
-      Element: 226 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttributeValue
+      Element: 259 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttributeValue
     - __kind: GoSliceHeaderType
-      ID: 201
+      ID: 181
       Name: '[]*mime/multipart.FileHeader'
       ByteSize: 24
       GoRuntimeType: 489088
@@ -863,21 +863,21 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 202 PointerType **mime/multipart.FileHeader
+          Type: 182 PointerType **mime/multipart.FileHeader
         - Name: len
           Offset: 8
           Type: 7 BaseType int
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 283 GoSliceDataType []*mime/multipart.FileHeader.array
+      Data: 244 GoSliceDataType []*mime/multipart.FileHeader.array
     - __kind: GoSliceDataType
-      ID: 283
+      ID: 244
       Name: '[]*mime/multipart.FileHeader.array'
       ByteSize: 2048
-      Element: 203 PointerType *mime/multipart.FileHeader
+      Element: 183 PointerType *mime/multipart.FileHeader
     - __kind: GoSliceHeaderType
-      ID: 181
+      ID: 229
       Name: '[]*net.IPNet'
       ByteSize: 24
       GoRuntimeType: 518592
@@ -885,21 +885,21 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 182 PointerType **net.IPNet
+          Type: 230 PointerType **net.IPNet
         - Name: len
           Offset: 8
           Type: 7 BaseType int
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 277 GoSliceDataType []*net.IPNet.array
+      Data: 276 GoSliceDataType []*net.IPNet.array
     - __kind: GoSliceDataType
-      ID: 277
+      ID: 276
       Name: '[]*net.IPNet.array'
       ByteSize: 2048
-      Element: 183 PointerType *net.IPNet
+      Element: 231 PointerType *net.IPNet
     - __kind: GoSliceHeaderType
-      ID: 179
+      ID: 227
       Name: '[]*net/url.URL'
       ByteSize: 24
       GoRuntimeType: 518528
@@ -907,51 +907,51 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 180 PointerType **net/url.URL
+          Type: 228 PointerType **net/url.URL
         - Name: len
           Offset: 8
           Type: 7 BaseType int
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 275 GoSliceDataType []*net/url.URL.array
+      Data: 274 GoSliceDataType []*net/url.URL.array
     - __kind: GoSliceDataType
-      ID: 275
+      ID: 274
       Name: '[]*net/url.URL.array'
       ByteSize: 2048
       Element: 45 PointerType *net/url.URL
     - __kind: GoSliceDataType
-      ID: 257
+      ID: 201
       Name: '[]*table<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>.array'
       ByteSize: 8192
-      Element: 126 PointerType *table<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
+      Element: 128 PointerType *table<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
     - __kind: GoSliceDataType
-      ID: 247
+      ID: 184
       Name: '[]*table<string,[]*mime/multipart.FileHeader>.array'
       ByteSize: 8192
-      Element: 106 PointerType *table<string,[]*mime/multipart.FileHeader>
+      Element: 108 PointerType *table<string,[]*mime/multipart.FileHeader>
     - __kind: GoSliceDataType
-      ID: 231
+      ID: 138
       Name: '[]*table<string,[]string>.array'
       ByteSize: 8192
       Element: 51 PointerType *table<string,[]string>
     - __kind: GoSliceDataType
-      ID: 239
+      ID: 162
       Name: '[]*table<string,float64>.array'
       ByteSize: 8192
       Element: 86 PointerType *table<string,float64>
     - __kind: GoSliceDataType
-      ID: 237
+      ID: 155
       Name: '[]*table<string,interface {}>.array'
       ByteSize: 8192
       Element: 81 PointerType *table<string,interface {}>
     - __kind: GoSliceDataType
-      ID: 235
+      ID: 147
       Name: '[]*table<string,string>.array'
       ByteSize: 8192
       Element: 70 PointerType *table<string,string>
     - __kind: GoSliceHeaderType
-      ID: 110
+      ID: 112
       Name: '[][]*crypto/x509.Certificate'
       ByteSize: 24
       GoRuntimeType: 503936
@@ -959,21 +959,21 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 111 PointerType *[]*crypto/x509.Certificate
+          Type: 113 PointerType *[]*crypto/x509.Certificate
         - Name: len
           Offset: 8
           Type: 7 BaseType int
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 251 GoSliceDataType [][]*crypto/x509.Certificate.array
+      Data: 188 GoSliceDataType [][]*crypto/x509.Certificate.array
     - __kind: GoSliceDataType
-      ID: 251
+      ID: 188
       Name: '[][]*crypto/x509.Certificate.array'
       ByteSize: 2048
-      Element: 107 GoSliceHeaderType []*crypto/x509.Certificate
+      Element: 109 GoSliceHeaderType []*crypto/x509.Certificate
     - __kind: GoSliceHeaderType
-      ID: 112
+      ID: 114
       Name: '[][]uint8'
       ByteSize: 24
       GoRuntimeType: 483936
@@ -981,21 +981,21 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 113 PointerType *[]uint8
+          Type: 115 PointerType *[]uint8
         - Name: len
           Offset: 8
           Type: 7 BaseType int
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 253 GoSliceDataType [][]uint8.array
+      Data: 190 GoSliceDataType [][]uint8.array
     - __kind: GoSliceDataType
-      ID: 253
+      ID: 190
       Name: '[][]uint8.array'
       ByteSize: 2048
       Element: 96 GoSliceHeaderType []uint8
     - __kind: GoSliceHeaderType
-      ID: 173
+      ID: 221
       Name: '[]crypto/x509.ExtKeyUsage'
       ByteSize: 24
       GoRuntimeType: 505280
@@ -1003,21 +1003,21 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 174 PointerType *crypto/x509.ExtKeyUsage
+          Type: 222 PointerType *crypto/x509.ExtKeyUsage
         - Name: len
           Offset: 8
           Type: 7 BaseType int
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 269 GoSliceDataType []crypto/x509.ExtKeyUsage.array
+      Data: 268 GoSliceDataType []crypto/x509.ExtKeyUsage.array
     - __kind: GoSliceDataType
-      ID: 269
+      ID: 268
       Name: '[]crypto/x509.ExtKeyUsage.array'
       ByteSize: 2048
-      Element: 175 BaseType crypto/x509.ExtKeyUsage
+      Element: 223 BaseType crypto/x509.ExtKeyUsage
     - __kind: GoSliceHeaderType
-      ID: 184
+      ID: 232
       Name: '[]crypto/x509.OID'
       ByteSize: 24
       GoRuntimeType: 518656
@@ -1025,21 +1025,21 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 185 PointerType *crypto/x509.OID
+          Type: 233 PointerType *crypto/x509.OID
         - Name: len
           Offset: 8
           Type: 7 BaseType int
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 279 GoSliceDataType []crypto/x509.OID.array
+      Data: 278 GoSliceDataType []crypto/x509.OID.array
     - __kind: GoSliceDataType
-      ID: 279
+      ID: 278
       Name: '[]crypto/x509.OID.array'
       ByteSize: 2048
-      Element: 186 StructureType crypto/x509.OID
+      Element: 234 StructureType crypto/x509.OID
     - __kind: GoSliceHeaderType
-      ID: 187
+      ID: 235
       Name: '[]crypto/x509.PolicyMapping'
       ByteSize: 24
       GoRuntimeType: 518720
@@ -1047,21 +1047,21 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 188 PointerType *crypto/x509.PolicyMapping
+          Type: 236 PointerType *crypto/x509.PolicyMapping
         - Name: len
           Offset: 8
           Type: 7 BaseType int
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 281 GoSliceDataType []crypto/x509.PolicyMapping.array
+      Data: 280 GoSliceDataType []crypto/x509.PolicyMapping.array
     - __kind: GoSliceDataType
-      ID: 281
+      ID: 280
       Name: '[]crypto/x509.PolicyMapping.array'
       ByteSize: 2048
-      Element: 189 StructureType crypto/x509.PolicyMapping
+      Element: 237 StructureType crypto/x509.PolicyMapping
     - __kind: GoSliceHeaderType
-      ID: 160
+      ID: 208
       Name: '[]crypto/x509/pkix.AttributeTypeAndValue'
       ByteSize: 24
       GoRuntimeType: 519168
@@ -1069,21 +1069,21 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 161 PointerType *crypto/x509/pkix.AttributeTypeAndValue
+          Type: 209 PointerType *crypto/x509/pkix.AttributeTypeAndValue
         - Name: len
           Offset: 8
           Type: 7 BaseType int
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 261 GoSliceDataType []crypto/x509/pkix.AttributeTypeAndValue.array
+      Data: 260 GoSliceDataType []crypto/x509/pkix.AttributeTypeAndValue.array
     - __kind: GoSliceDataType
-      ID: 261
+      ID: 260
       Name: '[]crypto/x509/pkix.AttributeTypeAndValue.array'
       ByteSize: 2048
-      Element: 162 StructureType crypto/x509/pkix.AttributeTypeAndValue
+      Element: 210 StructureType crypto/x509/pkix.AttributeTypeAndValue
     - __kind: GoSliceHeaderType
-      ID: 167
+      ID: 215
       Name: '[]crypto/x509/pkix.Extension'
       ByteSize: 24
       GoRuntimeType: 518400
@@ -1091,21 +1091,21 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 168 PointerType *crypto/x509/pkix.Extension
+          Type: 216 PointerType *crypto/x509/pkix.Extension
         - Name: len
           Offset: 8
           Type: 7 BaseType int
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 263 GoSliceDataType []crypto/x509/pkix.Extension.array
+      Data: 262 GoSliceDataType []crypto/x509/pkix.Extension.array
     - __kind: GoSliceDataType
-      ID: 263
+      ID: 262
       Name: '[]crypto/x509/pkix.Extension.array'
       ByteSize: 2048
-      Element: 169 StructureType crypto/x509/pkix.Extension
+      Element: 217 StructureType crypto/x509/pkix.Extension
     - __kind: GoSliceHeaderType
-      ID: 170
+      ID: 218
       Name: '[]encoding/asn1.ObjectIdentifier'
       ByteSize: 24
       GoRuntimeType: 518464
@@ -1113,19 +1113,19 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 171 PointerType *encoding/asn1.ObjectIdentifier
+          Type: 219 PointerType *encoding/asn1.ObjectIdentifier
         - Name: len
           Offset: 8
           Type: 7 BaseType int
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 265 GoSliceDataType []encoding/asn1.ObjectIdentifier.array
+      Data: 264 GoSliceDataType []encoding/asn1.ObjectIdentifier.array
     - __kind: GoSliceDataType
-      ID: 265
+      ID: 264
       Name: '[]encoding/asn1.ObjectIdentifier.array'
       ByteSize: 2048
-      Element: 172 GoSliceHeaderType encoding/asn1.ObjectIdentifier
+      Element: 220 GoSliceHeaderType encoding/asn1.ObjectIdentifier
     - __kind: GoSliceHeaderType
       ID: 87
       Name: '[]github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink'
@@ -1142,9 +1142,9 @@ Types:
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 241 GoSliceDataType []github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink.array
+      Data: 164 GoSliceDataType []github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink.array
     - __kind: GoSliceDataType
-      ID: 241
+      ID: 164
       Name: '[]github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink.array'
       ByteSize: 2048
       Element: 89 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink
@@ -1164,14 +1164,14 @@ Types:
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 243 GoSliceDataType []github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent.array
+      Data: 166 GoSliceDataType []github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent.array
     - __kind: GoSliceDataType
-      ID: 243
+      ID: 166
       Name: '[]github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent.array'
       ByteSize: 2048
       Element: 92 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent
     - __kind: GoSliceHeaderType
-      ID: 176
+      ID: 224
       Name: '[]net.IP'
       ByteSize: 24
       GoRuntimeType: 484896
@@ -1179,21 +1179,21 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 177 PointerType *net.IP
+          Type: 225 PointerType *net.IP
         - Name: len
           Offset: 8
           Type: 7 BaseType int
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 271 GoSliceDataType []net.IP.array
+      Data: 270 GoSliceDataType []net.IP.array
     - __kind: GoSliceDataType
-      ID: 271
+      ID: 270
       Name: '[]net.IP.array'
       ByteSize: 2048
-      Element: 178 GoSliceHeaderType net.IP
+      Element: 226 GoSliceHeaderType net.IP
     - __kind: GoSliceHeaderType
-      ID: 116
+      ID: 118
       Name: '[]net/http.segment'
       ByteSize: 24
       GoRuntimeType: 486528
@@ -1201,49 +1201,49 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 117 PointerType *net/http.segment
+          Type: 119 PointerType *net/http.segment
         - Name: len
           Offset: 8
           Type: 7 BaseType int
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 255 GoSliceDataType []net/http.segment.array
+      Data: 192 GoSliceDataType []net/http.segment.array
     - __kind: GoSliceDataType
-      ID: 255
+      ID: 192
       Name: '[]net/http.segment.array'
       ByteSize: 2048
-      Element: 118 StructureType net/http.segment
+      Element: 120 StructureType net/http.segment
     - __kind: GoSliceDataType
-      ID: 258
+      ID: 202
       Name: '[]noalg.map.group[string]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute.array'
       ByteSize: 2048
-      Element: 198 StructureType noalg.map.group[string]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
+      Element: 196 StructureType noalg.map.group[string]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
     - __kind: GoSliceDataType
-      ID: 248
+      ID: 185
       Name: '[]noalg.map.group[string][]*mime/multipart.FileHeader.array'
       ByteSize: 2048
-      Element: 153 StructureType noalg.map.group[string][]*mime/multipart.FileHeader
+      Element: 178 StructureType noalg.map.group[string][]*mime/multipart.FileHeader
     - __kind: GoSliceDataType
-      ID: 232
+      ID: 139
       Name: '[]noalg.map.group[string][]string.array'
       ByteSize: 2048
-      Element: 133 StructureType noalg.map.group[string][]string
+      Element: 135 StructureType noalg.map.group[string][]string
     - __kind: GoSliceDataType
-      ID: 240
+      ID: 163
       Name: '[]noalg.map.group[string]float64.array'
       ByteSize: 2048
-      Element: 144 StructureType noalg.map.group[string]float64
+      Element: 159 StructureType noalg.map.group[string]float64
     - __kind: GoSliceDataType
-      ID: 238
+      ID: 156
       Name: '[]noalg.map.group[string]interface {}.array'
       ByteSize: 2048
-      Element: 141 StructureType noalg.map.group[string]interface {}
+      Element: 151 StructureType noalg.map.group[string]interface {}
     - __kind: GoSliceDataType
-      ID: 236
+      ID: 148
       Name: '[]noalg.map.group[string]string.array'
       ByteSize: 2048
-      Element: 138 StructureType noalg.map.group[string]string
+      Element: 144 StructureType noalg.map.group[string]string
     - __kind: GoSliceHeaderType
       ID: 54
       Name: '[]string'
@@ -1260,14 +1260,14 @@ Types:
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 233 GoSliceDataType []string.array
+      Data: 140 GoSliceDataType []string.array
     - __kind: GoSliceDataType
-      ID: 233
+      ID: 140
       Name: '[]string.array'
       ByteSize: 2048
       Element: 9 GoStringHeaderType string
     - __kind: GoSliceHeaderType
-      ID: 207
+      ID: 249
       Name: '[]time.zone'
       ByteSize: 24
       GoRuntimeType: 491072
@@ -1275,21 +1275,21 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 208 PointerType *time.zone
+          Type: 250 PointerType *time.zone
         - Name: len
           Offset: 8
           Type: 7 BaseType int
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 287 GoSliceDataType []time.zone.array
+      Data: 286 GoSliceDataType []time.zone.array
     - __kind: GoSliceDataType
-      ID: 287
+      ID: 286
       Name: '[]time.zone.array'
       ByteSize: 2048
-      Element: 209 StructureType time.zone
+      Element: 251 StructureType time.zone
     - __kind: GoSliceHeaderType
-      ID: 210
+      ID: 252
       Name: '[]time.zoneTrans'
       ByteSize: 24
       GoRuntimeType: 491136
@@ -1297,19 +1297,19 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 211 PointerType *time.zoneTrans
+          Type: 253 PointerType *time.zoneTrans
         - Name: len
           Offset: 8
           Type: 7 BaseType int
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 289 GoSliceDataType []time.zoneTrans.array
+      Data: 288 GoSliceDataType []time.zoneTrans.array
     - __kind: GoSliceDataType
-      ID: 289
+      ID: 288
       Name: '[]time.zoneTrans.array'
       ByteSize: 2048
-      Element: 212 StructureType time.zoneTrans
+      Element: 254 StructureType time.zoneTrans
     - __kind: GoSliceHeaderType
       ID: 96
       Name: '[]uint8'
@@ -1326,9 +1326,9 @@ Types:
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 245 GoSliceDataType []uint8.array
+      Data: 168 GoSliceDataType []uint8.array
     - __kind: GoSliceDataType
-      ID: 245
+      ID: 168
       Name: '[]uint8.array'
       ByteSize: 2048
       Element: 3 BaseType uint8
@@ -1430,13 +1430,13 @@ Types:
           Type: 9 GoStringHeaderType string
         - Name: PeerCertificates
           Offset: 48
-          Type: 107 GoSliceHeaderType []*crypto/x509.Certificate
+          Type: 109 GoSliceHeaderType []*crypto/x509.Certificate
         - Name: VerifiedChains
           Offset: 72
-          Type: 110 GoSliceHeaderType [][]*crypto/x509.Certificate
+          Type: 112 GoSliceHeaderType [][]*crypto/x509.Certificate
         - Name: SignedCertificateTimestamps
           Offset: 96
-          Type: 112 GoSliceHeaderType [][]uint8
+          Type: 114 GoSliceHeaderType [][]uint8
         - Name: OCSPResponse
           Offset: 120
           Type: 96 GoSliceHeaderType []uint8
@@ -1448,21 +1448,21 @@ Types:
           Type: 4 BaseType bool
         - Name: ekm
           Offset: 176
-          Type: 114 GoSubroutineType func(string, []uint8, int) ([]uint8, error)
+          Type: 116 GoSubroutineType func(string, []uint8, int) ([]uint8, error)
         - Name: testingOnlyDidHRR
           Offset: 184
           Type: 4 BaseType bool
         - Name: testingOnlyCurveID
           Offset: 186
-          Type: 115 BaseType crypto/tls.CurveID
+          Type: 117 BaseType crypto/tls.CurveID
     - __kind: BaseType
-      ID: 115
+      ID: 117
       Name: crypto/tls.CurveID
       ByteSize: 2
       GoRuntimeType: 843936
       GoKind: 9
     - __kind: StructureType
-      ID: 135
+      ID: 171
       Name: crypto/x509.Certificate
       ByteSize: 1424
       GoRuntimeType: 2.453248e+06
@@ -1488,49 +1488,49 @@ Types:
           Type: 96 GoSliceHeaderType []uint8
         - Name: SignatureAlgorithm
           Offset: 144
-          Type: 154 BaseType crypto/x509.SignatureAlgorithm
+          Type: 203 BaseType crypto/x509.SignatureAlgorithm
         - Name: PublicKeyAlgorithm
           Offset: 152
-          Type: 155 BaseType crypto/x509.PublicKeyAlgorithm
+          Type: 204 BaseType crypto/x509.PublicKeyAlgorithm
         - Name: PublicKey
           Offset: 160
-          Type: 156 GoEmptyInterfaceType interface {}
+          Type: 154 GoEmptyInterfaceType interface {}
         - Name: Version
           Offset: 176
           Type: 7 BaseType int
         - Name: SerialNumber
           Offset: 184
-          Type: 157 PointerType *math/big.Int
+          Type: 205 PointerType *math/big.Int
         - Name: Issuer
           Offset: 192
-          Type: 159 StructureType crypto/x509/pkix.Name
+          Type: 207 StructureType crypto/x509/pkix.Name
         - Name: Subject
           Offset: 440
-          Type: 159 StructureType crypto/x509/pkix.Name
+          Type: 207 StructureType crypto/x509/pkix.Name
         - Name: NotBefore
           Offset: 688
-          Type: 163 StructureType time.Time
+          Type: 211 StructureType time.Time
         - Name: NotAfter
           Offset: 712
-          Type: 163 StructureType time.Time
+          Type: 211 StructureType time.Time
         - Name: KeyUsage
           Offset: 736
-          Type: 166 BaseType crypto/x509.KeyUsage
+          Type: 214 BaseType crypto/x509.KeyUsage
         - Name: Extensions
           Offset: 744
-          Type: 167 GoSliceHeaderType []crypto/x509/pkix.Extension
+          Type: 215 GoSliceHeaderType []crypto/x509/pkix.Extension
         - Name: ExtraExtensions
           Offset: 768
-          Type: 167 GoSliceHeaderType []crypto/x509/pkix.Extension
+          Type: 215 GoSliceHeaderType []crypto/x509/pkix.Extension
         - Name: UnhandledCriticalExtensions
           Offset: 792
-          Type: 170 GoSliceHeaderType []encoding/asn1.ObjectIdentifier
+          Type: 218 GoSliceHeaderType []encoding/asn1.ObjectIdentifier
         - Name: ExtKeyUsage
           Offset: 816
-          Type: 173 GoSliceHeaderType []crypto/x509.ExtKeyUsage
+          Type: 221 GoSliceHeaderType []crypto/x509.ExtKeyUsage
         - Name: UnknownExtKeyUsage
           Offset: 840
-          Type: 170 GoSliceHeaderType []encoding/asn1.ObjectIdentifier
+          Type: 218 GoSliceHeaderType []encoding/asn1.ObjectIdentifier
         - Name: BasicConstraintsValid
           Offset: 864
           Type: 4 BaseType bool
@@ -1563,10 +1563,10 @@ Types:
           Type: 54 GoSliceHeaderType []string
         - Name: IPAddresses
           Offset: 1032
-          Type: 176 GoSliceHeaderType []net.IP
+          Type: 224 GoSliceHeaderType []net.IP
         - Name: URIs
           Offset: 1056
-          Type: 179 GoSliceHeaderType []*net/url.URL
+          Type: 227 GoSliceHeaderType []*net/url.URL
         - Name: PermittedDNSDomainsCritical
           Offset: 1080
           Type: 4 BaseType bool
@@ -1578,10 +1578,10 @@ Types:
           Type: 54 GoSliceHeaderType []string
         - Name: PermittedIPRanges
           Offset: 1136
-          Type: 181 GoSliceHeaderType []*net.IPNet
+          Type: 229 GoSliceHeaderType []*net.IPNet
         - Name: ExcludedIPRanges
           Offset: 1160
-          Type: 181 GoSliceHeaderType []*net.IPNet
+          Type: 229 GoSliceHeaderType []*net.IPNet
         - Name: PermittedEmailAddresses
           Offset: 1184
           Type: 54 GoSliceHeaderType []string
@@ -1599,10 +1599,10 @@ Types:
           Type: 54 GoSliceHeaderType []string
         - Name: PolicyIdentifiers
           Offset: 1304
-          Type: 170 GoSliceHeaderType []encoding/asn1.ObjectIdentifier
+          Type: 218 GoSliceHeaderType []encoding/asn1.ObjectIdentifier
         - Name: Policies
           Offset: 1328
-          Type: 184 GoSliceHeaderType []crypto/x509.OID
+          Type: 232 GoSliceHeaderType []crypto/x509.OID
         - Name: InhibitAnyPolicy
           Offset: 1352
           Type: 7 BaseType int
@@ -1623,21 +1623,21 @@ Types:
           Type: 4 BaseType bool
         - Name: PolicyMappings
           Offset: 1400
-          Type: 187 GoSliceHeaderType []crypto/x509.PolicyMapping
+          Type: 235 GoSliceHeaderType []crypto/x509.PolicyMapping
     - __kind: BaseType
-      ID: 175
+      ID: 223
       Name: crypto/x509.ExtKeyUsage
       ByteSize: 8
       GoRuntimeType: 594464
       GoKind: 2
     - __kind: BaseType
-      ID: 166
+      ID: 214
       Name: crypto/x509.KeyUsage
       ByteSize: 8
       GoRuntimeType: 594400
       GoKind: 2
     - __kind: StructureType
-      ID: 186
+      ID: 234
       Name: crypto/x509.OID
       ByteSize: 24
       GoRuntimeType: 1.989888e+06
@@ -1647,7 +1647,7 @@ Types:
           Offset: 0
           Type: 96 GoSliceHeaderType []uint8
     - __kind: StructureType
-      ID: 189
+      ID: 237
       Name: crypto/x509.PolicyMapping
       ByteSize: 48
       GoRuntimeType: 1.515072e+06
@@ -1655,24 +1655,24 @@ Types:
       RawFields:
         - Name: IssuerDomainPolicy
           Offset: 0
-          Type: 186 StructureType crypto/x509.OID
+          Type: 234 StructureType crypto/x509.OID
         - Name: SubjectDomainPolicy
           Offset: 24
-          Type: 186 StructureType crypto/x509.OID
+          Type: 234 StructureType crypto/x509.OID
     - __kind: BaseType
-      ID: 155
+      ID: 204
       Name: crypto/x509.PublicKeyAlgorithm
       ByteSize: 8
       GoRuntimeType: 846240
       GoKind: 2
     - __kind: BaseType
-      ID: 154
+      ID: 203
       Name: crypto/x509.SignatureAlgorithm
       ByteSize: 8
       GoRuntimeType: 1.134784e+06
       GoKind: 2
     - __kind: StructureType
-      ID: 162
+      ID: 210
       Name: crypto/x509/pkix.AttributeTypeAndValue
       ByteSize: 40
       GoRuntimeType: 1.527392e+06
@@ -1680,12 +1680,12 @@ Types:
       RawFields:
         - Name: Type
           Offset: 0
-          Type: 172 GoSliceHeaderType encoding/asn1.ObjectIdentifier
+          Type: 220 GoSliceHeaderType encoding/asn1.ObjectIdentifier
         - Name: Value
           Offset: 24
-          Type: 156 GoEmptyInterfaceType interface {}
+          Type: 154 GoEmptyInterfaceType interface {}
     - __kind: StructureType
-      ID: 169
+      ID: 217
       Name: crypto/x509/pkix.Extension
       ByteSize: 56
       GoRuntimeType: 1.678688e+06
@@ -1693,7 +1693,7 @@ Types:
       RawFields:
         - Name: Id
           Offset: 0
-          Type: 172 GoSliceHeaderType encoding/asn1.ObjectIdentifier
+          Type: 220 GoSliceHeaderType encoding/asn1.ObjectIdentifier
         - Name: Critical
           Offset: 24
           Type: 4 BaseType bool
@@ -1701,7 +1701,7 @@ Types:
           Offset: 32
           Type: 96 GoSliceHeaderType []uint8
     - __kind: StructureType
-      ID: 159
+      ID: 207
       Name: crypto/x509/pkix.Name
       ByteSize: 248
       GoRuntimeType: 2.241664e+06
@@ -1736,12 +1736,12 @@ Types:
           Type: 9 GoStringHeaderType string
         - Name: Names
           Offset: 200
-          Type: 160 GoSliceHeaderType []crypto/x509/pkix.AttributeTypeAndValue
+          Type: 208 GoSliceHeaderType []crypto/x509/pkix.AttributeTypeAndValue
         - Name: ExtraNames
           Offset: 224
-          Type: 160 GoSliceHeaderType []crypto/x509/pkix.AttributeTypeAndValue
+          Type: 208 GoSliceHeaderType []crypto/x509/pkix.AttributeTypeAndValue
     - __kind: GoSliceHeaderType
-      ID: 172
+      ID: 220
       Name: encoding/asn1.ObjectIdentifier
       ByteSize: 24
       GoRuntimeType: 1.075328e+06
@@ -1756,9 +1756,9 @@ Types:
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 267 GoSliceDataType encoding/asn1.ObjectIdentifier.array
+      Data: 266 GoSliceDataType encoding/asn1.ObjectIdentifier.array
     - __kind: GoSliceDataType
-      ID: 267
+      ID: 266
       Name: encoding/asn1.ObjectIdentifier.array
       ByteSize: 2048
       Element: 7 BaseType int
@@ -1800,7 +1800,7 @@ Types:
       GoRuntimeType: 701280
       GoKind: 19
     - __kind: GoSubroutineType
-      ID: 114
+      ID: 116
       Name: func(string, []uint8, int) ([]uint8, error)
       ByteSize: 8
       GoRuntimeType: 1.020736e+06
@@ -1899,7 +1899,7 @@ Types:
           Type: 4 BaseType bool
         - Name: trace
           Offset: 8
-          Type: 128 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.trace
+          Type: 130 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.trace
         - Name: span
           Offset: 16
           Type: 39 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span
@@ -1914,7 +1914,7 @@ Types:
           Type: 4 BaseType bool
         - Name: traceID
           Offset: 49
-          Type: 130 ArrayType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.traceID
+          Type: 132 ArrayType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.traceID
         - Name: spanID
           Offset: 72
           Type: 8 BaseType uint64
@@ -1969,7 +1969,7 @@ Types:
       GoKind: 21
       HeaderType: 79 GoSwissMapHeaderType map<string,interface {}>
     - __kind: BaseType
-      ID: 148
+      ID: 175
       Name: github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.samplingDecision
       ByteSize: 4
       GoRuntimeType: 590176
@@ -1989,12 +1989,12 @@ Types:
           Type: 8 BaseType uint64
         - Name: Attributes
           Offset: 24
-          Type: 122 GoMapType map[string]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
+          Type: 124 GoMapType map[string]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
         - Name: RawAttributes
           Offset: 32
-          Type: 127 GoMapType map[string]interface {}
+          Type: 129 GoMapType map[string]interface {}
     - __kind: StructureType
-      ID: 222
+      ID: 241
       Name: github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttribute
       ByteSize: 24
       GoRuntimeType: 1.211328e+06
@@ -2002,9 +2002,9 @@ Types:
       RawFields:
         - Name: Values
           Offset: 0
-          Type: 224 GoSliceHeaderType []*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttributeValue
+          Type: 257 GoSliceHeaderType []*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttributeValue
     - __kind: StructureType
-      ID: 227
+      ID: 283
       Name: github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttributeValue
       ByteSize: 48
       GoRuntimeType: 1.869504e+06
@@ -2012,7 +2012,7 @@ Types:
       RawFields:
         - Name: Type
           Offset: 0
-          Type: 228 BaseType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttributeValueType
+          Type: 292 BaseType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttributeValueType
         - Name: StringValue
           Offset: 8
           Type: 9 GoStringHeaderType string
@@ -2026,13 +2026,13 @@ Types:
           Offset: 40
           Type: 18 BaseType float64
     - __kind: BaseType
-      ID: 228
+      ID: 292
       Name: github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttributeValueType
       ByteSize: 4
       GoRuntimeType: 1.002496e+06
       GoKind: 5
     - __kind: StructureType
-      ID: 217
+      ID: 200
       Name: github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
       ByteSize: 56
       GoRuntimeType: 1.947392e+06
@@ -2040,7 +2040,7 @@ Types:
       RawFields:
         - Name: Type
           Offset: 0
-          Type: 220 BaseType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttributeType
+          Type: 239 BaseType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttributeType
         - Name: StringValue
           Offset: 8
           Type: 9 GoStringHeaderType string
@@ -2055,15 +2055,15 @@ Types:
           Type: 18 BaseType float64
         - Name: ArrayValue
           Offset: 48
-          Type: 221 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttribute
+          Type: 240 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttribute
     - __kind: BaseType
-      ID: 220
+      ID: 239
       Name: github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttributeType
       ByteSize: 4
       GoRuntimeType: 1.0024e+06
       GoKind: 5
     - __kind: StructureType
-      ID: 129
+      ID: 131
       Name: github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.trace
       ByteSize: 104
       GoRuntimeType: 2.148896e+06
@@ -2074,7 +2074,7 @@ Types:
           Type: 71 StructureType sync.RWMutex
         - Name: spans
           Offset: 24
-          Type: 146 GoSliceHeaderType []*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span
+          Type: 173 GoSliceHeaderType []*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span
         - Name: tags
           Offset: 48
           Type: 66 GoMapType map[string]string
@@ -2095,12 +2095,12 @@ Types:
           Type: 4 BaseType bool
         - Name: samplingDecision
           Offset: 92
-          Type: 148 BaseType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.samplingDecision
+          Type: 175 BaseType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.samplingDecision
         - Name: root
           Offset: 96
           Type: 39 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span
     - __kind: ArrayType
-      ID: 130
+      ID: 132
       Name: github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.traceID
       ByteSize: 16
       GoRuntimeType: 914912
@@ -2109,89 +2109,89 @@ Types:
       HasCount: true
       Element: 3 BaseType uint8
     - __kind: GoSwissMapGroupsType
-      ID: 196
+      ID: 194
       Name: groupReference<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 197 PointerType *noalg.map.group[string]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
+          Type: 195 PointerType *noalg.map.group[string]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
         - Name: lengthMask
           Offset: 8
           Type: 8 BaseType uint64
-      GroupType: 198 StructureType noalg.map.group[string]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
-      GroupSliceType: 258 GoSliceDataType []noalg.map.group[string]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute.array
+      GroupType: 196 StructureType noalg.map.group[string]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
+      GroupSliceType: 202 GoSliceDataType []noalg.map.group[string]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute.array
     - __kind: GoSwissMapGroupsType
-      ID: 151
+      ID: 176
       Name: groupReference<string,[]*mime/multipart.FileHeader>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 152 PointerType *noalg.map.group[string][]*mime/multipart.FileHeader
+          Type: 177 PointerType *noalg.map.group[string][]*mime/multipart.FileHeader
         - Name: lengthMask
           Offset: 8
           Type: 8 BaseType uint64
-      GroupType: 153 StructureType noalg.map.group[string][]*mime/multipart.FileHeader
-      GroupSliceType: 248 GoSliceDataType []noalg.map.group[string][]*mime/multipart.FileHeader.array
+      GroupType: 178 StructureType noalg.map.group[string][]*mime/multipart.FileHeader
+      GroupSliceType: 185 GoSliceDataType []noalg.map.group[string][]*mime/multipart.FileHeader.array
     - __kind: GoSwissMapGroupsType
-      ID: 131
+      ID: 133
       Name: groupReference<string,[]string>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 132 PointerType *noalg.map.group[string][]string
+          Type: 134 PointerType *noalg.map.group[string][]string
         - Name: lengthMask
           Offset: 8
           Type: 8 BaseType uint64
-      GroupType: 133 StructureType noalg.map.group[string][]string
-      GroupSliceType: 232 GoSliceDataType []noalg.map.group[string][]string.array
+      GroupType: 135 StructureType noalg.map.group[string][]string
+      GroupSliceType: 139 GoSliceDataType []noalg.map.group[string][]string.array
     - __kind: GoSwissMapGroupsType
-      ID: 142
+      ID: 157
       Name: groupReference<string,float64>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 143 PointerType *noalg.map.group[string]float64
+          Type: 158 PointerType *noalg.map.group[string]float64
         - Name: lengthMask
           Offset: 8
           Type: 8 BaseType uint64
-      GroupType: 144 StructureType noalg.map.group[string]float64
-      GroupSliceType: 240 GoSliceDataType []noalg.map.group[string]float64.array
+      GroupType: 159 StructureType noalg.map.group[string]float64
+      GroupSliceType: 163 GoSliceDataType []noalg.map.group[string]float64.array
     - __kind: GoSwissMapGroupsType
-      ID: 139
+      ID: 149
       Name: groupReference<string,interface {}>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 140 PointerType *noalg.map.group[string]interface {}
+          Type: 150 PointerType *noalg.map.group[string]interface {}
         - Name: lengthMask
           Offset: 8
           Type: 8 BaseType uint64
-      GroupType: 141 StructureType noalg.map.group[string]interface {}
-      GroupSliceType: 238 GoSliceDataType []noalg.map.group[string]interface {}.array
+      GroupType: 151 StructureType noalg.map.group[string]interface {}
+      GroupSliceType: 156 GoSliceDataType []noalg.map.group[string]interface {}.array
     - __kind: GoSwissMapGroupsType
-      ID: 136
+      ID: 142
       Name: groupReference<string,string>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 137 PointerType *noalg.map.group[string]string
+          Type: 143 PointerType *noalg.map.group[string]string
         - Name: lengthMask
           Offset: 8
           Type: 8 BaseType uint64
-      GroupType: 138 StructureType noalg.map.group[string]string
-      GroupSliceType: 236 GoSliceDataType []noalg.map.group[string]string.array
+      GroupType: 144 StructureType noalg.map.group[string]string
+      GroupSliceType: 148 GoSliceDataType []noalg.map.group[string]string.array
     - __kind: BaseType
       ID: 7
       Name: int
@@ -2223,7 +2223,7 @@ Types:
       GoRuntimeType: 590432
       GoKind: 3
     - __kind: GoEmptyInterfaceType
-      ID: 156
+      ID: 154
       Name: interface {}
       ByteSize: 16
       GoRuntimeType: 863648
@@ -2262,7 +2262,7 @@ Types:
           Offset: 8
           Type: 14 VoidPointerType unsafe.Pointer
     - __kind: GoSwissMapHeaderType
-      ID: 124
+      ID: 126
       Name: map<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
       ByteSize: 48
       GoKind: 25
@@ -2275,7 +2275,7 @@ Types:
           Type: 1 BaseType uintptr
         - Name: dirPtr
           Offset: 16
-          Type: 125 PointerType **table<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
+          Type: 127 PointerType **table<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
         - Name: dirLen
           Offset: 24
           Type: 7 BaseType int
@@ -2291,10 +2291,10 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 8 BaseType uint64
-      TablePtrSliceType: 257 GoSliceDataType []*table<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>.array
-      GroupType: 198 StructureType noalg.map.group[string]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
+      TablePtrSliceType: 201 GoSliceDataType []*table<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>.array
+      GroupType: 196 StructureType noalg.map.group[string]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
     - __kind: GoSwissMapHeaderType
-      ID: 104
+      ID: 106
       Name: map<string,[]*mime/multipart.FileHeader>
       ByteSize: 48
       GoKind: 25
@@ -2307,7 +2307,7 @@ Types:
           Type: 1 BaseType uintptr
         - Name: dirPtr
           Offset: 16
-          Type: 105 PointerType **table<string,[]*mime/multipart.FileHeader>
+          Type: 107 PointerType **table<string,[]*mime/multipart.FileHeader>
         - Name: dirLen
           Offset: 24
           Type: 7 BaseType int
@@ -2323,8 +2323,8 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 8 BaseType uint64
-      TablePtrSliceType: 247 GoSliceDataType []*table<string,[]*mime/multipart.FileHeader>.array
-      GroupType: 153 StructureType noalg.map.group[string][]*mime/multipart.FileHeader
+      TablePtrSliceType: 184 GoSliceDataType []*table<string,[]*mime/multipart.FileHeader>.array
+      GroupType: 178 StructureType noalg.map.group[string][]*mime/multipart.FileHeader
     - __kind: GoSwissMapHeaderType
       ID: 49
       Name: map<string,[]string>
@@ -2355,8 +2355,8 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 8 BaseType uint64
-      TablePtrSliceType: 231 GoSliceDataType []*table<string,[]string>.array
-      GroupType: 133 StructureType noalg.map.group[string][]string
+      TablePtrSliceType: 138 GoSliceDataType []*table<string,[]string>.array
+      GroupType: 135 StructureType noalg.map.group[string][]string
     - __kind: GoSwissMapHeaderType
       ID: 84
       Name: map<string,float64>
@@ -2387,8 +2387,8 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 8 BaseType uint64
-      TablePtrSliceType: 239 GoSliceDataType []*table<string,float64>.array
-      GroupType: 144 StructureType noalg.map.group[string]float64
+      TablePtrSliceType: 162 GoSliceDataType []*table<string,float64>.array
+      GroupType: 159 StructureType noalg.map.group[string]float64
     - __kind: GoSwissMapHeaderType
       ID: 79
       Name: map<string,interface {}>
@@ -2419,8 +2419,8 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 8 BaseType uint64
-      TablePtrSliceType: 237 GoSliceDataType []*table<string,interface {}>.array
-      GroupType: 141 StructureType noalg.map.group[string]interface {}
+      TablePtrSliceType: 155 GoSliceDataType []*table<string,interface {}>.array
+      GroupType: 151 StructureType noalg.map.group[string]interface {}
     - __kind: GoSwissMapHeaderType
       ID: 68
       Name: map<string,string>
@@ -2451,24 +2451,24 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 8 BaseType uint64
-      TablePtrSliceType: 235 GoSliceDataType []*table<string,string>.array
-      GroupType: 138 StructureType noalg.map.group[string]string
+      TablePtrSliceType: 147 GoSliceDataType []*table<string,string>.array
+      GroupType: 144 StructureType noalg.map.group[string]string
     - __kind: GoMapType
-      ID: 122
+      ID: 124
       Name: map[string]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
       ByteSize: 8
       GoRuntimeType: 1.153728e+06
       GoKind: 21
-      HeaderType: 124 GoSwissMapHeaderType map<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
+      HeaderType: 126 GoSwissMapHeaderType map<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
     - __kind: GoMapType
-      ID: 102
+      ID: 104
       Name: map[string][]*mime/multipart.FileHeader
       ByteSize: 8
       GoRuntimeType: 1.15296e+06
       GoKind: 21
-      HeaderType: 104 GoSwissMapHeaderType map<string,[]*mime/multipart.FileHeader>
+      HeaderType: 106 GoSwissMapHeaderType map<string,[]*mime/multipart.FileHeader>
     - __kind: GoMapType
-      ID: 101
+      ID: 103
       Name: map[string][]string
       ByteSize: 8
       GoRuntimeType: 1.148352e+06
@@ -2482,7 +2482,7 @@ Types:
       GoKind: 21
       HeaderType: 84 GoSwissMapHeaderType map<string,float64>
     - __kind: GoMapType
-      ID: 127
+      ID: 129
       Name: map[string]interface {}
       ByteSize: 8
       GoRuntimeType: 1.146944e+06
@@ -2496,7 +2496,7 @@ Types:
       GoKind: 21
       HeaderType: 68 GoSwissMapHeaderType map<string,string>
     - __kind: StructureType
-      ID: 158
+      ID: 206
       Name: math/big.Int
       ByteSize: 32
       GoRuntimeType: 1.518112e+06
@@ -2507,15 +2507,15 @@ Types:
           Type: 4 BaseType bool
         - Name: abs
           Offset: 8
-          Type: 204 GoSliceHeaderType math/big.nat
+          Type: 246 GoSliceHeaderType math/big.nat
     - __kind: BaseType
-      ID: 206
+      ID: 248
       Name: math/big.Word
       ByteSize: 8
       GoRuntimeType: 594656
       GoKind: 7
     - __kind: GoSliceHeaderType
-      ID: 204
+      ID: 246
       Name: math/big.nat
       ByteSize: 24
       GoRuntimeType: 2.4216e+06
@@ -2523,21 +2523,21 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 205 PointerType *math/big.Word
+          Type: 247 PointerType *math/big.Word
         - Name: len
           Offset: 8
           Type: 7 BaseType int
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 285 GoSliceDataType math/big.nat.array
+      Data: 284 GoSliceDataType math/big.nat.array
     - __kind: GoSliceDataType
-      ID: 285
+      ID: 284
       Name: math/big.nat.array
       ByteSize: 2048
-      Element: 206 BaseType math/big.Word
+      Element: 248 BaseType math/big.Word
     - __kind: StructureType
-      ID: 218
+      ID: 238
       Name: mime/multipart.FileHeader
       ByteSize: 88
       GoRuntimeType: 2.010048e+06
@@ -2548,7 +2548,7 @@ Types:
           Type: 9 GoStringHeaderType string
         - Name: Header
           Offset: 16
-          Type: 223 GoMapType net/textproto.MIMEHeader
+          Type: 256 GoMapType net/textproto.MIMEHeader
         - Name: Size
           Offset: 24
           Type: 12 BaseType int64
@@ -2573,12 +2573,12 @@ Types:
       RawFields:
         - Name: Value
           Offset: 0
-          Type: 101 GoMapType map[string][]string
+          Type: 103 GoMapType map[string][]string
         - Name: File
           Offset: 8
-          Type: 102 GoMapType map[string][]*mime/multipart.FileHeader
+          Type: 104 GoMapType map[string][]*mime/multipart.FileHeader
     - __kind: GoSliceHeaderType
-      ID: 178
+      ID: 226
       Name: net.IP
       ByteSize: 24
       GoRuntimeType: 2.17104e+06
@@ -2593,14 +2593,14 @@ Types:
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 273 GoSliceDataType net.IP.array
+      Data: 272 GoSliceDataType net.IP.array
     - __kind: GoSliceDataType
-      ID: 273
+      ID: 272
       Name: net.IP.array
       ByteSize: 2048
       Element: 3 BaseType uint8
     - __kind: GoSliceHeaderType
-      ID: 219
+      ID: 282
       Name: net.IPMask
       ByteSize: 24
       GoRuntimeType: 1.03808e+06
@@ -2615,14 +2615,14 @@ Types:
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 291 GoSliceDataType net.IPMask.array
+      Data: 293 GoSliceDataType net.IPMask.array
     - __kind: GoSliceDataType
-      ID: 291
+      ID: 293
       Name: net.IPMask.array
       ByteSize: 2048
       Element: 3 BaseType uint8
     - __kind: StructureType
-      ID: 213
+      ID: 255
       Name: net.IPNet
       ByteSize: 48
       GoRuntimeType: 1.482432e+06
@@ -2630,10 +2630,10 @@ Types:
       RawFields:
         - Name: IP
           Offset: 0
-          Type: 178 GoSliceHeaderType net.IP
+          Type: 226 GoSliceHeaderType net.IP
         - Name: Mask
           Offset: 24
-          Type: 219 GoSliceHeaderType net.IPMask
+          Type: 282 GoSliceHeaderType net.IPMask
     - __kind: GoMapType
       ID: 47
       Name: net/http.Header
@@ -2806,12 +2806,12 @@ Types:
           Type: 9 GoStringHeaderType string
         - Name: segments
           Offset: 48
-          Type: 116 GoSliceHeaderType []net/http.segment
+          Type: 118 GoSliceHeaderType []net/http.segment
         - Name: loc
           Offset: 72
           Type: 9 GoStringHeaderType string
     - __kind: StructureType
-      ID: 118
+      ID: 120
       Name: net/http.segment
       ByteSize: 24
       GoRuntimeType: 1.6376e+06
@@ -2827,7 +2827,7 @@ Types:
           Offset: 17
           Type: 4 BaseType bool
     - __kind: GoMapType
-      ID: 223
+      ID: 256
       Name: net/textproto.MIMEHeader
       ByteSize: 8
       GoRuntimeType: 1.85488e+06
@@ -2848,7 +2848,7 @@ Types:
           Type: 9 GoStringHeaderType string
         - Name: User
           Offset: 32
-          Type: 98 PointerType *net/url.Userinfo
+          Type: 100 PointerType *net/url.Userinfo
         - Name: Host
           Offset: 40
           Type: 9 GoStringHeaderType string
@@ -2874,7 +2874,7 @@ Types:
           Offset: 128
           Type: 9 GoStringHeaderType string
     - __kind: StructureType
-      ID: 99
+      ID: 101
       Name: net/url.Userinfo
       ByteSize: 40
       GoRuntimeType: 1.653536e+06
@@ -2897,61 +2897,61 @@ Types:
       GoKind: 21
       HeaderType: 49 GoSwissMapHeaderType map<string,[]string>
     - __kind: ArrayType
-      ID: 214
+      ID: 197
       Name: noalg.[8]struct { key string; elem *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute }
       ByteSize: 192
       GoRuntimeType: 711904
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 215 StructureType noalg.struct { key string; elem *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute }
+      Element: 198 StructureType noalg.struct { key string; elem *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute }
     - __kind: ArrayType
-      ID: 199
+      ID: 179
       Name: noalg.[8]struct { key string; elem []*mime/multipart.FileHeader }
       ByteSize: 320
       GoRuntimeType: 707328
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 200 StructureType noalg.struct { key string; elem []*mime/multipart.FileHeader }
+      Element: 180 StructureType noalg.struct { key string; elem []*mime/multipart.FileHeader }
     - __kind: ArrayType
-      ID: 149
+      ID: 136
       Name: noalg.[8]struct { key string; elem []string }
       ByteSize: 320
       GoRuntimeType: 697312
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 150 StructureType noalg.struct { key string; elem []string }
+      Element: 137 StructureType noalg.struct { key string; elem []string }
     - __kind: ArrayType
-      ID: 194
+      ID: 160
       Name: noalg.[8]struct { key string; elem float64 }
       ByteSize: 192
       GoRuntimeType: 711808
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 195 StructureType noalg.struct { key string; elem float64 }
+      Element: 161 StructureType noalg.struct { key string; elem float64 }
     - __kind: ArrayType
-      ID: 192
+      ID: 152
       Name: noalg.[8]struct { key string; elem interface {} }
       ByteSize: 256
       GoRuntimeType: 688768
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 193 StructureType noalg.struct { key string; elem interface {} }
+      Element: 153 StructureType noalg.struct { key string; elem interface {} }
     - __kind: ArrayType
-      ID: 190
+      ID: 145
       Name: noalg.[8]struct { key string; elem string }
       ByteSize: 256
       GoRuntimeType: 701472
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 191 StructureType noalg.struct { key string; elem string }
+      Element: 146 StructureType noalg.struct { key string; elem string }
     - __kind: StructureType
-      ID: 198
+      ID: 196
       Name: noalg.map.group[string]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
       ByteSize: 200
       GoRuntimeType: 1.327872e+06
@@ -2962,9 +2962,9 @@ Types:
           Type: 8 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 214 ArrayType noalg.[8]struct { key string; elem *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute }
+          Type: 197 ArrayType noalg.[8]struct { key string; elem *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute }
     - __kind: StructureType
-      ID: 153
+      ID: 178
       Name: noalg.map.group[string][]*mime/multipart.FileHeader
       ByteSize: 328
       GoRuntimeType: 1.3216e+06
@@ -2975,9 +2975,9 @@ Types:
           Type: 8 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 199 ArrayType noalg.[8]struct { key string; elem []*mime/multipart.FileHeader }
+          Type: 179 ArrayType noalg.[8]struct { key string; elem []*mime/multipart.FileHeader }
     - __kind: StructureType
-      ID: 133
+      ID: 135
       Name: noalg.map.group[string][]string
       ByteSize: 328
       GoRuntimeType: 1.312128e+06
@@ -2988,9 +2988,9 @@ Types:
           Type: 8 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 149 ArrayType noalg.[8]struct { key string; elem []string }
+          Type: 136 ArrayType noalg.[8]struct { key string; elem []string }
     - __kind: StructureType
-      ID: 144
+      ID: 159
       Name: noalg.map.group[string]float64
       ByteSize: 200
       GoRuntimeType: 1.327616e+06
@@ -3001,9 +3001,9 @@ Types:
           Type: 8 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 194 ArrayType noalg.[8]struct { key string; elem float64 }
+          Type: 160 ArrayType noalg.[8]struct { key string; elem float64 }
     - __kind: StructureType
-      ID: 141
+      ID: 151
       Name: noalg.map.group[string]interface {}
       ByteSize: 264
       GoRuntimeType: 1.309568e+06
@@ -3014,9 +3014,9 @@ Types:
           Type: 8 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 192 ArrayType noalg.[8]struct { key string; elem interface {} }
+          Type: 152 ArrayType noalg.[8]struct { key string; elem interface {} }
     - __kind: StructureType
-      ID: 138
+      ID: 144
       Name: noalg.map.group[string]string
       ByteSize: 264
       GoRuntimeType: 1.314432e+06
@@ -3027,9 +3027,9 @@ Types:
           Type: 8 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 190 ArrayType noalg.[8]struct { key string; elem string }
+          Type: 145 ArrayType noalg.[8]struct { key string; elem string }
     - __kind: StructureType
-      ID: 215
+      ID: 198
       Name: noalg.struct { key string; elem *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute }
       ByteSize: 24
       GoRuntimeType: 1.327744e+06
@@ -3040,9 +3040,9 @@ Types:
           Type: 9 GoStringHeaderType string
         - Name: elem
           Offset: 16
-          Type: 216 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
+          Type: 199 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
     - __kind: StructureType
-      ID: 200
+      ID: 180
       Name: noalg.struct { key string; elem []*mime/multipart.FileHeader }
       ByteSize: 40
       GoRuntimeType: 1.321472e+06
@@ -3053,9 +3053,9 @@ Types:
           Type: 9 GoStringHeaderType string
         - Name: elem
           Offset: 16
-          Type: 201 GoSliceHeaderType []*mime/multipart.FileHeader
+          Type: 181 GoSliceHeaderType []*mime/multipart.FileHeader
     - __kind: StructureType
-      ID: 150
+      ID: 137
       Name: noalg.struct { key string; elem []string }
       ByteSize: 40
       GoRuntimeType: 1.312e+06
@@ -3068,7 +3068,7 @@ Types:
           Offset: 16
           Type: 54 GoSliceHeaderType []string
     - __kind: StructureType
-      ID: 195
+      ID: 161
       Name: noalg.struct { key string; elem float64 }
       ByteSize: 24
       GoRuntimeType: 1.327488e+06
@@ -3081,7 +3081,7 @@ Types:
           Offset: 16
           Type: 18 BaseType float64
     - __kind: StructureType
-      ID: 193
+      ID: 153
       Name: noalg.struct { key string; elem interface {} }
       ByteSize: 32
       GoRuntimeType: 1.30944e+06
@@ -3092,9 +3092,9 @@ Types:
           Type: 9 GoStringHeaderType string
         - Name: elem
           Offset: 16
-          Type: 156 GoEmptyInterfaceType interface {}
+          Type: 154 GoEmptyInterfaceType interface {}
     - __kind: StructureType
-      ID: 191
+      ID: 146
       Name: noalg.struct { key string; elem string }
       ByteSize: 32
       GoRuntimeType: 1.314304e+06
@@ -3115,13 +3115,13 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 230 PointerType *string.str
+          Type: 99 PointerType *string.str
         - Name: len
           Offset: 8
           Type: 7 BaseType int
-      Data: 229 GoStringDataType string.str
+      Data: 98 GoStringDataType string.str
     - __kind: GoStringDataType
-      ID: 229
+      ID: 98
       Name: string.str
       ByteSize: 2048
     - __kind: StructureType
@@ -3185,7 +3185,7 @@ Types:
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 145
+      ID: 172
       Name: table<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
       ByteSize: 32
       GoKind: 25
@@ -3207,9 +3207,9 @@ Types:
           Type: 7 BaseType int
         - Name: groups
           Offset: 16
-          Type: 196 GoSwissMapGroupsType groupReference<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
+          Type: 194 GoSwissMapGroupsType groupReference<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
     - __kind: StructureType
-      ID: 134
+      ID: 170
       Name: table<string,[]*mime/multipart.FileHeader>
       ByteSize: 32
       GoKind: 25
@@ -3231,9 +3231,9 @@ Types:
           Type: 7 BaseType int
         - Name: groups
           Offset: 16
-          Type: 151 GoSwissMapGroupsType groupReference<string,[]*mime/multipart.FileHeader>
+          Type: 176 GoSwissMapGroupsType groupReference<string,[]*mime/multipart.FileHeader>
     - __kind: StructureType
-      ID: 100
+      ID: 102
       Name: table<string,[]string>
       ByteSize: 32
       GoKind: 25
@@ -3255,9 +3255,9 @@ Types:
           Type: 7 BaseType int
         - Name: groups
           Offset: 16
-          Type: 131 GoSwissMapGroupsType groupReference<string,[]string>
+          Type: 133 GoSwissMapGroupsType groupReference<string,[]string>
     - __kind: StructureType
-      ID: 121
+      ID: 123
       Name: table<string,float64>
       ByteSize: 32
       GoKind: 25
@@ -3279,9 +3279,9 @@ Types:
           Type: 7 BaseType int
         - Name: groups
           Offset: 16
-          Type: 142 GoSwissMapGroupsType groupReference<string,float64>
+          Type: 157 GoSwissMapGroupsType groupReference<string,float64>
     - __kind: StructureType
-      ID: 120
+      ID: 122
       Name: table<string,interface {}>
       ByteSize: 32
       GoKind: 25
@@ -3303,9 +3303,9 @@ Types:
           Type: 7 BaseType int
         - Name: groups
           Offset: 16
-          Type: 139 GoSwissMapGroupsType groupReference<string,interface {}>
+          Type: 149 GoSwissMapGroupsType groupReference<string,interface {}>
     - __kind: StructureType
-      ID: 119
+      ID: 121
       Name: table<string,string>
       ByteSize: 32
       GoKind: 25
@@ -3327,9 +3327,9 @@ Types:
           Type: 7 BaseType int
         - Name: groups
           Offset: 16
-          Type: 136 GoSwissMapGroupsType groupReference<string,string>
+          Type: 142 GoSwissMapGroupsType groupReference<string,string>
     - __kind: StructureType
-      ID: 165
+      ID: 213
       Name: time.Location
       ByteSize: 104
       GoRuntimeType: 2.006016e+06
@@ -3340,10 +3340,10 @@ Types:
           Type: 9 GoStringHeaderType string
         - Name: zone
           Offset: 16
-          Type: 207 GoSliceHeaderType []time.zone
+          Type: 249 GoSliceHeaderType []time.zone
         - Name: tx
           Offset: 40
-          Type: 210 GoSliceHeaderType []time.zoneTrans
+          Type: 252 GoSliceHeaderType []time.zoneTrans
         - Name: extend
           Offset: 64
           Type: 9 GoStringHeaderType string
@@ -3355,9 +3355,9 @@ Types:
           Type: 12 BaseType int64
         - Name: cacheZone
           Offset: 96
-          Type: 208 PointerType *time.zone
+          Type: 250 PointerType *time.zone
     - __kind: StructureType
-      ID: 163
+      ID: 211
       Name: time.Time
       ByteSize: 24
       GoRuntimeType: 2.424416e+06
@@ -3371,9 +3371,9 @@ Types:
           Type: 12 BaseType int64
         - Name: loc
           Offset: 16
-          Type: 164 PointerType *time.Location
+          Type: 212 PointerType *time.Location
     - __kind: StructureType
-      ID: 209
+      ID: 251
       Name: time.zone
       ByteSize: 32
       GoRuntimeType: 1.642592e+06
@@ -3389,7 +3389,7 @@ Types:
           Offset: 24
           Type: 4 BaseType bool
     - __kind: StructureType
-      ID: 212
+      ID: 254
       Name: time.zoneTrans
       ByteSize: 16
       GoRuntimeType: 1.781504e+06

--- a/pkg/dyninst/irgen/testdata/snapshot/rc_tester.arch=amd64,toolchain=go1.24.3.yaml
+++ b/pkg/dyninst/irgen/testdata/snapshot/rc_tester.arch=amd64,toolchain=go1.24.3.yaml
@@ -65,14 +65,14 @@ Subprograms:
           IsParameter: true
           IsReturn: false
         - Name: span
-          Type: 157 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span
+          Type: 39 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span
           Locations:
             - Range: 0xd313e8..0xd31421
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: false
           IsReturn: false
         - Name: '&buf'
-          Type: 224 PointerType *bytes.Buffer
+          Type: 41 PointerType *bytes.Buffer
           Locations:
             - Range: 0xd314f7..0xd31512
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
@@ -81,7 +81,7 @@ Subprograms:
           IsParameter: false
           IsReturn: false
         - Name: .autotmp_14
-          Type: 227 StructureType context.backgroundCtx
+          Type: 43 StructureType context.backgroundCtx
           Locations:
             - Range: 0xd31360..0xd315f9
               Pieces: [{Size: 0, Op: {CfaOffset: 0}}]
@@ -105,194 +105,194 @@ Subprograms:
           IsReturn: false
 Types:
     - __kind: PointerType
-      ID: 81
+      ID: 108
       Name: '**crypto/x509.Certificate'
       ByteSize: 8
       GoKind: 22
-      Pointee: 82 PointerType *crypto/x509.Certificate
+      Pointee: 109 PointerType *crypto/x509.Certificate
     - __kind: PointerType
-      ID: 220
+      ID: 147
       Name: '**github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span'
       ByteSize: 8
       GoKind: 22
-      Pointee: 157 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span
+      Pointee: 39 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span
     - __kind: PointerType
-      ID: 210
+      ID: 225
       Name: '**github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttributeValue'
       ByteSize: 8
       GoKind: 22
-      Pointee: 211 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttributeValue
+      Pointee: 226 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttributeValue
     - __kind: PointerType
-      ID: 73
+      ID: 202
       Name: '**mime/multipart.FileHeader'
       ByteSize: 8
       GoKind: 22
-      Pointee: 74 PointerType *mime/multipart.FileHeader
+      Pointee: 203 PointerType *mime/multipart.FileHeader
     - __kind: PointerType
-      ID: 121
+      ID: 182
       Name: '**net.IPNet'
       ByteSize: 8
       GoKind: 22
-      Pointee: 122 PointerType *net.IPNet
+      Pointee: 183 PointerType *net.IPNet
     - __kind: PointerType
-      ID: 119
+      ID: 180
       Name: '**net/url.URL'
       ByteSize: 8
       GoKind: 22
-      Pointee: 39 PointerType *net/url.URL
+      Pointee: 45 PointerType *net/url.URL
     - __kind: PointerType
-      ID: 196
+      ID: 125
       Name: '**table<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>'
       ByteSize: 8
-      Pointee: 197 PointerType *table<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
+      Pointee: 126 PointerType *table<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
     - __kind: PointerType
-      ID: 64
+      ID: 105
       Name: '**table<string,[]*mime/multipart.FileHeader>'
       ByteSize: 8
-      Pointee: 65 PointerType *table<string,[]*mime/multipart.FileHeader>
+      Pointee: 106 PointerType *table<string,[]*mime/multipart.FileHeader>
     - __kind: PointerType
-      ID: 46
+      ID: 50
       Name: '**table<string,[]string>'
       ByteSize: 8
-      Pointee: 47 PointerType *table<string,[]string>
+      Pointee: 51 PointerType *table<string,[]string>
     - __kind: PointerType
-      ID: 179
+      ID: 85
       Name: '**table<string,float64>'
       ByteSize: 8
-      Pointee: 180 PointerType *table<string,float64>
+      Pointee: 86 PointerType *table<string,float64>
     - __kind: PointerType
-      ID: 168
+      ID: 80
       Name: '**table<string,interface {}>'
       ByteSize: 8
-      Pointee: 169 PointerType *table<string,interface {}>
+      Pointee: 81 PointerType *table<string,interface {}>
     - __kind: PointerType
-      ID: 149
+      ID: 69
       Name: '**table<string,string>'
       ByteSize: 8
-      Pointee: 150 PointerType *table<string,string>
+      Pointee: 70 PointerType *table<string,string>
     - __kind: PointerType
-      ID: 132
+      ID: 111
       Name: '*[]*crypto/x509.Certificate'
       ByteSize: 8
       GoKind: 22
-      Pointee: 80 GoSliceHeaderType []*crypto/x509.Certificate
+      Pointee: 107 GoSliceHeaderType []*crypto/x509.Certificate
     - __kind: PointerType
-      ID: 242
+      ID: 250
       Name: '*[]*crypto/x509.Certificate.array'
       ByteSize: 8
-      Pointee: 241 GoSliceDataType []*crypto/x509.Certificate.array
-    - __kind: PointerType
-      ID: 294
-      Name: '*[]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span.array'
-      ByteSize: 8
-      Pointee: 293 GoSliceDataType []*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span.array
-    - __kind: PointerType
-      ID: 292
-      Name: '*[]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttributeValue.array'
-      ByteSize: 8
-      Pointee: 291 GoSliceDataType []*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttributeValue.array
-    - __kind: PointerType
-      ID: 238
-      Name: '*[]*mime/multipart.FileHeader.array'
-      ByteSize: 8
-      Pointee: 237 GoSliceDataType []*mime/multipart.FileHeader.array
-    - __kind: PointerType
-      ID: 266
-      Name: '*[]*net.IPNet.array'
-      ByteSize: 8
-      Pointee: 265 GoSliceDataType []*net.IPNet.array
-    - __kind: PointerType
-      ID: 264
-      Name: '*[]*net/url.URL.array'
-      ByteSize: 8
-      Pointee: 263 GoSliceDataType []*net/url.URL.array
-    - __kind: PointerType
-      ID: 274
-      Name: '*[][]*crypto/x509.Certificate.array'
-      ByteSize: 8
-      Pointee: 273 GoSliceDataType [][]*crypto/x509.Certificate.array
-    - __kind: PointerType
-      ID: 276
-      Name: '*[][]uint8.array'
-      ByteSize: 8
-      Pointee: 275 GoSliceDataType [][]uint8.array
-    - __kind: PointerType
-      ID: 258
-      Name: '*[]crypto/x509.ExtKeyUsage.array'
-      ByteSize: 8
-      Pointee: 257 GoSliceDataType []crypto/x509.ExtKeyUsage.array
-    - __kind: PointerType
-      ID: 270
-      Name: '*[]crypto/x509.OID.array'
-      ByteSize: 8
-      Pointee: 269 GoSliceDataType []crypto/x509.OID.array
-    - __kind: PointerType
-      ID: 272
-      Name: '*[]crypto/x509.PolicyMapping.array'
-      ByteSize: 8
-      Pointee: 271 GoSliceDataType []crypto/x509.PolicyMapping.array
-    - __kind: PointerType
-      ID: 246
-      Name: '*[]crypto/x509/pkix.AttributeTypeAndValue.array'
-      ByteSize: 8
-      Pointee: 245 GoSliceDataType []crypto/x509/pkix.AttributeTypeAndValue.array
-    - __kind: PointerType
-      ID: 254
-      Name: '*[]crypto/x509/pkix.Extension.array'
-      ByteSize: 8
-      Pointee: 253 GoSliceDataType []crypto/x509/pkix.Extension.array
-    - __kind: PointerType
-      ID: 256
-      Name: '*[]encoding/asn1.ObjectIdentifier.array'
-      ByteSize: 8
-      Pointee: 255 GoSliceDataType []encoding/asn1.ObjectIdentifier.array
-    - __kind: PointerType
-      ID: 286
-      Name: '*[]github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink.array'
-      ByteSize: 8
-      Pointee: 285 GoSliceDataType []github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink.array
-    - __kind: PointerType
-      ID: 288
-      Name: '*[]github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent.array'
-      ByteSize: 8
-      Pointee: 287 GoSliceDataType []github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent.array
+      Pointee: 249 GoSliceDataType []*crypto/x509.Certificate.array
     - __kind: PointerType
       ID: 260
-      Name: '*[]net.IP.array'
+      Name: '*[]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span.array'
       ByteSize: 8
-      Pointee: 259 GoSliceDataType []net.IP.array
+      Pointee: 259 GoSliceDataType []*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span.array
+    - __kind: PointerType
+      ID: 294
+      Name: '*[]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttributeValue.array'
+      ByteSize: 8
+      Pointee: 293 GoSliceDataType []*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttributeValue.array
+    - __kind: PointerType
+      ID: 284
+      Name: '*[]*mime/multipart.FileHeader.array'
+      ByteSize: 8
+      Pointee: 283 GoSliceDataType []*mime/multipart.FileHeader.array
     - __kind: PointerType
       ID: 278
+      Name: '*[]*net.IPNet.array'
+      ByteSize: 8
+      Pointee: 277 GoSliceDataType []*net.IPNet.array
+    - __kind: PointerType
+      ID: 276
+      Name: '*[]*net/url.URL.array'
+      ByteSize: 8
+      Pointee: 275 GoSliceDataType []*net/url.URL.array
+    - __kind: PointerType
+      ID: 252
+      Name: '*[][]*crypto/x509.Certificate.array'
+      ByteSize: 8
+      Pointee: 251 GoSliceDataType [][]*crypto/x509.Certificate.array
+    - __kind: PointerType
+      ID: 254
+      Name: '*[][]uint8.array'
+      ByteSize: 8
+      Pointee: 253 GoSliceDataType [][]uint8.array
+    - __kind: PointerType
+      ID: 270
+      Name: '*[]crypto/x509.ExtKeyUsage.array'
+      ByteSize: 8
+      Pointee: 269 GoSliceDataType []crypto/x509.ExtKeyUsage.array
+    - __kind: PointerType
+      ID: 280
+      Name: '*[]crypto/x509.OID.array'
+      ByteSize: 8
+      Pointee: 279 GoSliceDataType []crypto/x509.OID.array
+    - __kind: PointerType
+      ID: 282
+      Name: '*[]crypto/x509.PolicyMapping.array'
+      ByteSize: 8
+      Pointee: 281 GoSliceDataType []crypto/x509.PolicyMapping.array
+    - __kind: PointerType
+      ID: 262
+      Name: '*[]crypto/x509/pkix.AttributeTypeAndValue.array'
+      ByteSize: 8
+      Pointee: 261 GoSliceDataType []crypto/x509/pkix.AttributeTypeAndValue.array
+    - __kind: PointerType
+      ID: 264
+      Name: '*[]crypto/x509/pkix.Extension.array'
+      ByteSize: 8
+      Pointee: 263 GoSliceDataType []crypto/x509/pkix.Extension.array
+    - __kind: PointerType
+      ID: 266
+      Name: '*[]encoding/asn1.ObjectIdentifier.array'
+      ByteSize: 8
+      Pointee: 265 GoSliceDataType []encoding/asn1.ObjectIdentifier.array
+    - __kind: PointerType
+      ID: 242
+      Name: '*[]github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink.array'
+      ByteSize: 8
+      Pointee: 241 GoSliceDataType []github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink.array
+    - __kind: PointerType
+      ID: 244
+      Name: '*[]github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent.array'
+      ByteSize: 8
+      Pointee: 243 GoSliceDataType []github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent.array
+    - __kind: PointerType
+      ID: 272
+      Name: '*[]net.IP.array'
+      ByteSize: 8
+      Pointee: 271 GoSliceDataType []net.IP.array
+    - __kind: PointerType
+      ID: 256
       Name: '*[]net/http.segment.array'
       ByteSize: 8
-      Pointee: 277 GoSliceDataType []net/http.segment.array
+      Pointee: 255 GoSliceDataType []net/http.segment.array
     - __kind: PointerType
       ID: 234
       Name: '*[]string.array'
       ByteSize: 8
       Pointee: 233 GoSliceDataType []string.array
     - __kind: PointerType
-      ID: 250
+      ID: 288
       Name: '*[]time.zone.array'
       ByteSize: 8
-      Pointee: 249 GoSliceDataType []time.zone.array
+      Pointee: 287 GoSliceDataType []time.zone.array
     - __kind: PointerType
-      ID: 252
+      ID: 290
       Name: '*[]time.zoneTrans.array'
       ByteSize: 8
-      Pointee: 251 GoSliceDataType []time.zoneTrans.array
+      Pointee: 289 GoSliceDataType []time.zoneTrans.array
     - __kind: PointerType
-      ID: 134
+      ID: 113
       Name: '*[]uint8'
       ByteSize: 8
       GoRuntimeType: 483552
       GoKind: 22
-      Pointee: 77 GoSliceHeaderType []uint8
+      Pointee: 96 GoSliceHeaderType []uint8
     - __kind: PointerType
-      ID: 240
+      ID: 246
       Name: '*[]uint8.array'
       ByteSize: 8
-      Pointee: 239 GoSliceDataType []uint8.array
+      Pointee: 245 GoSliceDataType []uint8.array
     - __kind: PointerType
       ID: 11
       Name: '*bool'
@@ -301,73 +301,73 @@ Types:
       GoKind: 22
       Pointee: 4 BaseType bool
     - __kind: PointerType
-      ID: 224
+      ID: 41
       Name: '*bytes.Buffer'
       ByteSize: 8
       GoRuntimeType: 2.316768e+06
       GoKind: 22
-      Pointee: 225 StructureType bytes.Buffer
+      Pointee: 42 StructureType bytes.Buffer
     - __kind: PointerType
-      ID: 78
+      ID: 58
       Name: '*crypto/tls.ConnectionState'
       ByteSize: 8
       GoRuntimeType: 919424
       GoKind: 22
-      Pointee: 79 StructureType crypto/tls.ConnectionState
+      Pointee: 59 StructureType crypto/tls.ConnectionState
     - __kind: PointerType
-      ID: 82
+      ID: 109
       Name: '*crypto/x509.Certificate'
       ByteSize: 8
       GoRuntimeType: 2.082688e+06
       GoKind: 22
-      Pointee: 83 StructureType crypto/x509.Certificate
+      Pointee: 135 StructureType crypto/x509.Certificate
     - __kind: PointerType
-      ID: 113
+      ID: 174
       Name: '*crypto/x509.ExtKeyUsage'
       ByteSize: 8
       GoRuntimeType: 426912
       GoKind: 22
-      Pointee: 114 BaseType crypto/x509.ExtKeyUsage
+      Pointee: 175 BaseType crypto/x509.ExtKeyUsage
     - __kind: PointerType
-      ID: 126
+      ID: 185
       Name: '*crypto/x509.OID'
       ByteSize: 8
       GoRuntimeType: 1.989632e+06
       GoKind: 22
-      Pointee: 127 StructureType crypto/x509.OID
+      Pointee: 186 StructureType crypto/x509.OID
     - __kind: PointerType
-      ID: 129
+      ID: 188
       Name: '*crypto/x509.PolicyMapping'
       ByteSize: 8
       GoRuntimeType: 426976
       GoKind: 22
-      Pointee: 130 StructureType crypto/x509.PolicyMapping
+      Pointee: 189 StructureType crypto/x509.PolicyMapping
     - __kind: PointerType
-      ID: 94
+      ID: 161
       Name: '*crypto/x509/pkix.AttributeTypeAndValue'
       ByteSize: 8
       GoRuntimeType: 443680
       GoKind: 22
-      Pointee: 95 StructureType crypto/x509/pkix.AttributeTypeAndValue
+      Pointee: 162 StructureType crypto/x509/pkix.AttributeTypeAndValue
     - __kind: PointerType
-      ID: 108
+      ID: 168
       Name: '*crypto/x509/pkix.Extension'
       ByteSize: 8
       GoRuntimeType: 443872
       GoKind: 22
-      Pointee: 109 StructureType crypto/x509/pkix.Extension
+      Pointee: 169 StructureType crypto/x509/pkix.Extension
     - __kind: PointerType
-      ID: 111
+      ID: 171
       Name: '*encoding/asn1.ObjectIdentifier'
       ByteSize: 8
       GoRuntimeType: 1.0752e+06
       GoKind: 22
-      Pointee: 96 GoSliceHeaderType encoding/asn1.ObjectIdentifier
+      Pointee: 172 GoSliceHeaderType encoding/asn1.ObjectIdentifier
     - __kind: PointerType
-      ID: 248
+      ID: 268
       Name: '*encoding/asn1.ObjectIdentifier.array'
       ByteSize: 8
-      Pointee: 247 GoSliceDataType encoding/asn1.ObjectIdentifier.array
+      Pointee: 267 GoSliceDataType encoding/asn1.ObjectIdentifier.array
     - __kind: PointerType
       ID: 33
       Name: '*error'
@@ -390,61 +390,61 @@ Types:
       GoKind: 22
       Pointee: 18 BaseType float64
     - __kind: PointerType
-      ID: 157
+      ID: 39
       Name: '*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span'
       ByteSize: 8
       GoRuntimeType: 2.32752e+06
       GoKind: 22
-      Pointee: 158 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span
+      Pointee: 40 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span
     - __kind: PointerType
-      ID: 215
+      ID: 93
       Name: '*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanContext'
       ByteSize: 8
       GoRuntimeType: 2.046208e+06
       GoKind: 22
-      Pointee: 216 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanContext
+      Pointee: 94 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanContext
     - __kind: PointerType
-      ID: 188
+      ID: 88
       Name: '*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink'
       ByteSize: 8
       GoRuntimeType: 1.210688e+06
       GoKind: 22
-      Pointee: 189 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink
+      Pointee: 89 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink
     - __kind: PointerType
-      ID: 191
+      ID: 91
       Name: '*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent'
       ByteSize: 8
       GoRuntimeType: 1.210816e+06
       GoKind: 22
-      Pointee: 192 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent
+      Pointee: 92 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent
     - __kind: PointerType
-      ID: 207
+      ID: 221
       Name: '*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttribute'
       ByteSize: 8
       GoRuntimeType: 1.211456e+06
       GoKind: 22
-      Pointee: 208 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttribute
+      Pointee: 222 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttribute
     - __kind: PointerType
-      ID: 211
+      ID: 226
       Name: '*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttributeValue'
       ByteSize: 8
       GoRuntimeType: 1.2112e+06
       GoKind: 22
-      Pointee: 212 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttributeValue
+      Pointee: 227 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttributeValue
     - __kind: PointerType
-      ID: 204
+      ID: 216
       Name: '*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute'
       ByteSize: 8
       GoRuntimeType: 1.211584e+06
       GoKind: 22
-      Pointee: 205 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
+      Pointee: 217 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
     - __kind: PointerType
-      ID: 217
+      ID: 128
       Name: '*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.trace'
       ByteSize: 8
       GoRuntimeType: 2.27024e+06
       GoKind: 22
-      Pointee: 218 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.trace
+      Pointee: 129 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.trace
     - __kind: PointerType
       ID: 27
       Name: '*int'
@@ -481,92 +481,92 @@ Types:
       GoKind: 22
       Pointee: 15 BaseType int8
     - __kind: PointerType
-      ID: 194
+      ID: 123
       Name: '*map<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>'
       ByteSize: 8
-      Pointee: 195 GoSwissMapHeaderType map<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
+      Pointee: 124 GoSwissMapHeaderType map<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
     - __kind: PointerType
-      ID: 62
+      ID: 103
       Name: '*map<string,[]*mime/multipart.FileHeader>'
       ByteSize: 8
-      Pointee: 63 GoSwissMapHeaderType map<string,[]*mime/multipart.FileHeader>
+      Pointee: 104 GoSwissMapHeaderType map<string,[]*mime/multipart.FileHeader>
     - __kind: PointerType
-      ID: 44
+      ID: 48
       Name: '*map<string,[]string>'
       ByteSize: 8
-      Pointee: 45 GoSwissMapHeaderType map<string,[]string>
+      Pointee: 49 GoSwissMapHeaderType map<string,[]string>
     - __kind: PointerType
-      ID: 177
+      ID: 83
       Name: '*map<string,float64>'
       ByteSize: 8
-      Pointee: 178 GoSwissMapHeaderType map<string,float64>
+      Pointee: 84 GoSwissMapHeaderType map<string,float64>
     - __kind: PointerType
-      ID: 166
+      ID: 78
       Name: '*map<string,interface {}>'
       ByteSize: 8
-      Pointee: 167 GoSwissMapHeaderType map<string,interface {}>
+      Pointee: 79 GoSwissMapHeaderType map<string,interface {}>
     - __kind: PointerType
-      ID: 147
+      ID: 67
       Name: '*map<string,string>'
       ByteSize: 8
-      Pointee: 148 GoSwissMapHeaderType map<string,string>
+      Pointee: 68 GoSwissMapHeaderType map<string,string>
     - __kind: PointerType
-      ID: 87
+      ID: 157
       Name: '*math/big.Int'
       ByteSize: 8
       GoRuntimeType: 2.440832e+06
       GoKind: 22
-      Pointee: 88 StructureType math/big.Int
+      Pointee: 158 StructureType math/big.Int
     - __kind: PointerType
-      ID: 90
+      ID: 205
       Name: '*math/big.Word'
       ByteSize: 8
       GoRuntimeType: 429856
       GoKind: 22
-      Pointee: 91 BaseType math/big.Word
+      Pointee: 206 BaseType math/big.Word
     - __kind: PointerType
-      ID: 244
+      ID: 286
       Name: '*math/big.nat.array'
       ByteSize: 8
-      Pointee: 243 GoSliceDataType math/big.nat.array
+      Pointee: 285 GoSliceDataType math/big.nat.array
     - __kind: PointerType
-      ID: 74
+      ID: 203
       Name: '*mime/multipart.FileHeader'
       ByteSize: 8
       GoRuntimeType: 920864
       GoKind: 22
-      Pointee: 75 StructureType mime/multipart.FileHeader
+      Pointee: 218 StructureType mime/multipart.FileHeader
     - __kind: PointerType
-      ID: 58
+      ID: 56
       Name: '*mime/multipart.Form'
       ByteSize: 8
       GoRuntimeType: 920960
       GoKind: 22
-      Pointee: 59 StructureType mime/multipart.Form
+      Pointee: 57 StructureType mime/multipart.Form
     - __kind: PointerType
-      ID: 116
+      ID: 177
       Name: '*net.IP'
       ByteSize: 8
       GoRuntimeType: 2.198272e+06
       GoKind: 22
-      Pointee: 117 GoSliceHeaderType net.IP
+      Pointee: 178 GoSliceHeaderType net.IP
     - __kind: PointerType
-      ID: 262
+      ID: 274
       Name: '*net.IP.array'
       ByteSize: 8
-      Pointee: 261 GoSliceDataType net.IP.array
+      Pointee: 273 GoSliceDataType net.IP.array
     - __kind: PointerType
-      ID: 268
+      ID: 292
       Name: '*net.IPMask.array'
       ByteSize: 8
-      Pointee: 267 GoSliceDataType net.IPMask.array
+      Pointee: 291 GoSliceDataType net.IPMask.array
     - __kind: PointerType
-      ID: 122
+      ID: 183
       Name: '*net.IPNet'
       ByteSize: 8
       GoRuntimeType: 1.204416e+06
       GoKind: 22
-      Pointee: 123 StructureType net.IPNet
+      Pointee: 213 StructureType net.IPNet
     - __kind: PointerType
       ID: 37
       Name: '*net/http.Request'
@@ -575,70 +575,70 @@ Types:
       GoKind: 22
       Pointee: 38 StructureType net/http.Request
     - __kind: PointerType
-      ID: 138
+      ID: 61
       Name: '*net/http.Response'
       ByteSize: 8
       GoRuntimeType: 1.751392e+06
       GoKind: 22
-      Pointee: 139 StructureType net/http.Response
+      Pointee: 62 StructureType net/http.Response
     - __kind: PointerType
-      ID: 141
+      ID: 64
       Name: '*net/http.pattern'
       ByteSize: 8
       GoRuntimeType: 1.637792e+06
       GoKind: 22
-      Pointee: 142 StructureType net/http.pattern
+      Pointee: 65 StructureType net/http.pattern
     - __kind: PointerType
-      ID: 144
+      ID: 117
       Name: '*net/http.segment'
       ByteSize: 8
       GoRuntimeType: 393504
       GoKind: 22
-      Pointee: 145 StructureType net/http.segment
+      Pointee: 118 StructureType net/http.segment
     - __kind: PointerType
-      ID: 39
+      ID: 45
       Name: '*net/url.URL'
       ByteSize: 8
       GoRuntimeType: 2.16048e+06
       GoKind: 22
-      Pointee: 40 StructureType net/url.URL
+      Pointee: 46 StructureType net/url.URL
     - __kind: PointerType
-      ID: 41
+      ID: 98
       Name: '*net/url.Userinfo'
       ByteSize: 8
       GoRuntimeType: 1.222208e+06
       GoKind: 22
-      Pointee: 42 StructureType net/url.Userinfo
+      Pointee: 99 StructureType net/url.Userinfo
     - __kind: PointerType
-      ID: 200
+      ID: 197
       Name: '*noalg.map.group[string]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute'
       ByteSize: 8
-      Pointee: 201 StructureType noalg.map.group[string]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
+      Pointee: 198 StructureType noalg.map.group[string]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
     - __kind: PointerType
-      ID: 68
+      ID: 152
       Name: '*noalg.map.group[string][]*mime/multipart.FileHeader'
       ByteSize: 8
-      Pointee: 69 StructureType noalg.map.group[string][]*mime/multipart.FileHeader
+      Pointee: 153 StructureType noalg.map.group[string][]*mime/multipart.FileHeader
     - __kind: PointerType
-      ID: 50
+      ID: 132
       Name: '*noalg.map.group[string][]string'
       ByteSize: 8
-      Pointee: 51 StructureType noalg.map.group[string][]string
+      Pointee: 133 StructureType noalg.map.group[string][]string
     - __kind: PointerType
-      ID: 183
+      ID: 143
       Name: '*noalg.map.group[string]float64'
       ByteSize: 8
-      Pointee: 184 StructureType noalg.map.group[string]float64
+      Pointee: 144 StructureType noalg.map.group[string]float64
     - __kind: PointerType
-      ID: 172
+      ID: 140
       Name: '*noalg.map.group[string]interface {}'
       ByteSize: 8
-      Pointee: 173 StructureType noalg.map.group[string]interface {}
+      Pointee: 141 StructureType noalg.map.group[string]interface {}
     - __kind: PointerType
-      ID: 153
+      ID: 137
       Name: '*noalg.map.group[string]string'
       ByteSize: 8
-      Pointee: 154 StructureType noalg.map.group[string]string
+      Pointee: 138 StructureType noalg.map.group[string]string
     - __kind: PointerType
       ID: 22
       Name: '*string'
@@ -652,56 +652,56 @@ Types:
       ByteSize: 8
       Pointee: 229 GoStringDataType string.str
     - __kind: PointerType
-      ID: 197
+      ID: 126
       Name: '*table<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>'
       ByteSize: 8
-      Pointee: 198 StructureType table<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
+      Pointee: 145 StructureType table<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
     - __kind: PointerType
-      ID: 65
+      ID: 106
       Name: '*table<string,[]*mime/multipart.FileHeader>'
       ByteSize: 8
-      Pointee: 66 StructureType table<string,[]*mime/multipart.FileHeader>
+      Pointee: 134 StructureType table<string,[]*mime/multipart.FileHeader>
     - __kind: PointerType
-      ID: 47
+      ID: 51
       Name: '*table<string,[]string>'
       ByteSize: 8
-      Pointee: 48 StructureType table<string,[]string>
+      Pointee: 100 StructureType table<string,[]string>
     - __kind: PointerType
-      ID: 180
+      ID: 86
       Name: '*table<string,float64>'
       ByteSize: 8
-      Pointee: 181 StructureType table<string,float64>
+      Pointee: 121 StructureType table<string,float64>
     - __kind: PointerType
-      ID: 169
+      ID: 81
       Name: '*table<string,interface {}>'
       ByteSize: 8
-      Pointee: 170 StructureType table<string,interface {}>
+      Pointee: 120 StructureType table<string,interface {}>
     - __kind: PointerType
-      ID: 150
+      ID: 70
       Name: '*table<string,string>'
       ByteSize: 8
-      Pointee: 151 StructureType table<string,string>
+      Pointee: 119 StructureType table<string,string>
     - __kind: PointerType
-      ID: 98
+      ID: 164
       Name: '*time.Location'
       ByteSize: 8
       GoRuntimeType: 1.642784e+06
       GoKind: 22
-      Pointee: 99 StructureType time.Location
+      Pointee: 165 StructureType time.Location
     - __kind: PointerType
-      ID: 101
+      ID: 208
       Name: '*time.zone'
       ByteSize: 8
       GoRuntimeType: 396640
       GoKind: 22
-      Pointee: 102 StructureType time.zone
+      Pointee: 209 StructureType time.zone
     - __kind: PointerType
-      ID: 104
+      ID: 211
       Name: '*time.zoneTrans'
       ByteSize: 8
       GoRuntimeType: 396704
       GoKind: 22
-      Pointee: 105 StructureType time.zoneTrans
+      Pointee: 212 StructureType time.zoneTrans
     - __kind: PointerType
       ID: 34
       Name: '*uint'
@@ -745,7 +745,7 @@ Types:
       GoKind: 22
       Pointee: 1 BaseType uintptr
     - __kind: GoChannelType
-      ID: 137
+      ID: 60
       Name: <-chan struct {}
       GoRuntimeType: 603424
       GoKind: 18
@@ -789,7 +789,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: GoSliceHeaderType
-      ID: 80
+      ID: 107
       Name: '[]*crypto/x509.Certificate'
       ByteSize: 24
       GoRuntimeType: 503808
@@ -797,21 +797,21 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 81 PointerType **crypto/x509.Certificate
+          Type: 108 PointerType **crypto/x509.Certificate
         - Name: len
           Offset: 8
           Type: 7 BaseType int
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 241 GoSliceDataType []*crypto/x509.Certificate.array
+      Data: 249 GoSliceDataType []*crypto/x509.Certificate.array
     - __kind: GoSliceDataType
-      ID: 241
+      ID: 249
       Name: '[]*crypto/x509.Certificate.array'
       ByteSize: 2048
-      Element: 82 PointerType *crypto/x509.Certificate
+      Element: 109 PointerType *crypto/x509.Certificate
     - __kind: GoSliceHeaderType
-      ID: 219
+      ID: 146
       Name: '[]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span'
       ByteSize: 24
       GoRuntimeType: 491968
@@ -819,21 +819,21 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 220 PointerType **github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span
+          Type: 147 PointerType **github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span
         - Name: len
           Offset: 8
           Type: 7 BaseType int
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 293 GoSliceDataType []*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span.array
+      Data: 259 GoSliceDataType []*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span.array
     - __kind: GoSliceDataType
-      ID: 293
+      ID: 259
       Name: '[]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span.array'
       ByteSize: 2048
-      Element: 157 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span
+      Element: 39 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span
     - __kind: GoSliceHeaderType
-      ID: 209
+      ID: 224
       Name: '[]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttributeValue'
       ByteSize: 24
       GoRuntimeType: 491584
@@ -841,21 +841,21 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 210 PointerType **github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttributeValue
+          Type: 225 PointerType **github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttributeValue
         - Name: len
           Offset: 8
           Type: 7 BaseType int
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 291 GoSliceDataType []*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttributeValue.array
+      Data: 293 GoSliceDataType []*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttributeValue.array
     - __kind: GoSliceDataType
-      ID: 291
+      ID: 293
       Name: '[]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttributeValue.array'
       ByteSize: 2048
-      Element: 211 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttributeValue
+      Element: 226 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttributeValue
     - __kind: GoSliceHeaderType
-      ID: 72
+      ID: 201
       Name: '[]*mime/multipart.FileHeader'
       ByteSize: 24
       GoRuntimeType: 489088
@@ -863,21 +863,21 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 73 PointerType **mime/multipart.FileHeader
+          Type: 202 PointerType **mime/multipart.FileHeader
         - Name: len
           Offset: 8
           Type: 7 BaseType int
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 237 GoSliceDataType []*mime/multipart.FileHeader.array
+      Data: 283 GoSliceDataType []*mime/multipart.FileHeader.array
     - __kind: GoSliceDataType
-      ID: 237
+      ID: 283
       Name: '[]*mime/multipart.FileHeader.array'
       ByteSize: 2048
-      Element: 74 PointerType *mime/multipart.FileHeader
+      Element: 203 PointerType *mime/multipart.FileHeader
     - __kind: GoSliceHeaderType
-      ID: 120
+      ID: 181
       Name: '[]*net.IPNet'
       ByteSize: 24
       GoRuntimeType: 518592
@@ -885,21 +885,21 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 121 PointerType **net.IPNet
+          Type: 182 PointerType **net.IPNet
         - Name: len
           Offset: 8
           Type: 7 BaseType int
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 265 GoSliceDataType []*net.IPNet.array
+      Data: 277 GoSliceDataType []*net.IPNet.array
     - __kind: GoSliceDataType
-      ID: 265
+      ID: 277
       Name: '[]*net.IPNet.array'
       ByteSize: 2048
-      Element: 122 PointerType *net.IPNet
+      Element: 183 PointerType *net.IPNet
     - __kind: GoSliceHeaderType
-      ID: 118
+      ID: 179
       Name: '[]*net/url.URL'
       ByteSize: 24
       GoRuntimeType: 518528
@@ -907,51 +907,51 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 119 PointerType **net/url.URL
+          Type: 180 PointerType **net/url.URL
         - Name: len
           Offset: 8
           Type: 7 BaseType int
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 263 GoSliceDataType []*net/url.URL.array
+      Data: 275 GoSliceDataType []*net/url.URL.array
     - __kind: GoSliceDataType
-      ID: 263
+      ID: 275
       Name: '[]*net/url.URL.array'
       ByteSize: 2048
-      Element: 39 PointerType *net/url.URL
+      Element: 45 PointerType *net/url.URL
     - __kind: GoSliceDataType
-      ID: 289
+      ID: 257
       Name: '[]*table<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>.array'
       ByteSize: 8192
-      Element: 197 PointerType *table<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
+      Element: 126 PointerType *table<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
     - __kind: GoSliceDataType
-      ID: 235
+      ID: 247
       Name: '[]*table<string,[]*mime/multipart.FileHeader>.array'
       ByteSize: 8192
-      Element: 65 PointerType *table<string,[]*mime/multipart.FileHeader>
+      Element: 106 PointerType *table<string,[]*mime/multipart.FileHeader>
     - __kind: GoSliceDataType
       ID: 231
       Name: '[]*table<string,[]string>.array'
       ByteSize: 8192
-      Element: 47 PointerType *table<string,[]string>
+      Element: 51 PointerType *table<string,[]string>
     - __kind: GoSliceDataType
-      ID: 283
+      ID: 239
       Name: '[]*table<string,float64>.array'
       ByteSize: 8192
-      Element: 180 PointerType *table<string,float64>
+      Element: 86 PointerType *table<string,float64>
     - __kind: GoSliceDataType
-      ID: 281
+      ID: 237
       Name: '[]*table<string,interface {}>.array'
       ByteSize: 8192
-      Element: 169 PointerType *table<string,interface {}>
+      Element: 81 PointerType *table<string,interface {}>
     - __kind: GoSliceDataType
-      ID: 279
+      ID: 235
       Name: '[]*table<string,string>.array'
       ByteSize: 8192
-      Element: 150 PointerType *table<string,string>
+      Element: 70 PointerType *table<string,string>
     - __kind: GoSliceHeaderType
-      ID: 131
+      ID: 110
       Name: '[][]*crypto/x509.Certificate'
       ByteSize: 24
       GoRuntimeType: 503936
@@ -959,21 +959,21 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 132 PointerType *[]*crypto/x509.Certificate
+          Type: 111 PointerType *[]*crypto/x509.Certificate
         - Name: len
           Offset: 8
           Type: 7 BaseType int
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 273 GoSliceDataType [][]*crypto/x509.Certificate.array
+      Data: 251 GoSliceDataType [][]*crypto/x509.Certificate.array
     - __kind: GoSliceDataType
-      ID: 273
+      ID: 251
       Name: '[][]*crypto/x509.Certificate.array'
       ByteSize: 2048
-      Element: 80 GoSliceHeaderType []*crypto/x509.Certificate
+      Element: 107 GoSliceHeaderType []*crypto/x509.Certificate
     - __kind: GoSliceHeaderType
-      ID: 133
+      ID: 112
       Name: '[][]uint8'
       ByteSize: 24
       GoRuntimeType: 483936
@@ -981,21 +981,21 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 134 PointerType *[]uint8
+          Type: 113 PointerType *[]uint8
         - Name: len
           Offset: 8
           Type: 7 BaseType int
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 275 GoSliceDataType [][]uint8.array
+      Data: 253 GoSliceDataType [][]uint8.array
     - __kind: GoSliceDataType
-      ID: 275
+      ID: 253
       Name: '[][]uint8.array'
       ByteSize: 2048
-      Element: 77 GoSliceHeaderType []uint8
+      Element: 96 GoSliceHeaderType []uint8
     - __kind: GoSliceHeaderType
-      ID: 112
+      ID: 173
       Name: '[]crypto/x509.ExtKeyUsage'
       ByteSize: 24
       GoRuntimeType: 505280
@@ -1003,21 +1003,21 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 113 PointerType *crypto/x509.ExtKeyUsage
+          Type: 174 PointerType *crypto/x509.ExtKeyUsage
         - Name: len
           Offset: 8
           Type: 7 BaseType int
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 257 GoSliceDataType []crypto/x509.ExtKeyUsage.array
+      Data: 269 GoSliceDataType []crypto/x509.ExtKeyUsage.array
     - __kind: GoSliceDataType
-      ID: 257
+      ID: 269
       Name: '[]crypto/x509.ExtKeyUsage.array'
       ByteSize: 2048
-      Element: 114 BaseType crypto/x509.ExtKeyUsage
+      Element: 175 BaseType crypto/x509.ExtKeyUsage
     - __kind: GoSliceHeaderType
-      ID: 125
+      ID: 184
       Name: '[]crypto/x509.OID'
       ByteSize: 24
       GoRuntimeType: 518656
@@ -1025,21 +1025,21 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 126 PointerType *crypto/x509.OID
+          Type: 185 PointerType *crypto/x509.OID
         - Name: len
           Offset: 8
           Type: 7 BaseType int
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 269 GoSliceDataType []crypto/x509.OID.array
+      Data: 279 GoSliceDataType []crypto/x509.OID.array
     - __kind: GoSliceDataType
-      ID: 269
+      ID: 279
       Name: '[]crypto/x509.OID.array'
       ByteSize: 2048
-      Element: 127 StructureType crypto/x509.OID
+      Element: 186 StructureType crypto/x509.OID
     - __kind: GoSliceHeaderType
-      ID: 128
+      ID: 187
       Name: '[]crypto/x509.PolicyMapping'
       ByteSize: 24
       GoRuntimeType: 518720
@@ -1047,21 +1047,21 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 129 PointerType *crypto/x509.PolicyMapping
+          Type: 188 PointerType *crypto/x509.PolicyMapping
         - Name: len
           Offset: 8
           Type: 7 BaseType int
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 271 GoSliceDataType []crypto/x509.PolicyMapping.array
+      Data: 281 GoSliceDataType []crypto/x509.PolicyMapping.array
     - __kind: GoSliceDataType
-      ID: 271
+      ID: 281
       Name: '[]crypto/x509.PolicyMapping.array'
       ByteSize: 2048
-      Element: 130 StructureType crypto/x509.PolicyMapping
+      Element: 189 StructureType crypto/x509.PolicyMapping
     - __kind: GoSliceHeaderType
-      ID: 93
+      ID: 160
       Name: '[]crypto/x509/pkix.AttributeTypeAndValue'
       ByteSize: 24
       GoRuntimeType: 519168
@@ -1069,21 +1069,21 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 94 PointerType *crypto/x509/pkix.AttributeTypeAndValue
+          Type: 161 PointerType *crypto/x509/pkix.AttributeTypeAndValue
         - Name: len
           Offset: 8
           Type: 7 BaseType int
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 245 GoSliceDataType []crypto/x509/pkix.AttributeTypeAndValue.array
+      Data: 261 GoSliceDataType []crypto/x509/pkix.AttributeTypeAndValue.array
     - __kind: GoSliceDataType
-      ID: 245
+      ID: 261
       Name: '[]crypto/x509/pkix.AttributeTypeAndValue.array'
       ByteSize: 2048
-      Element: 95 StructureType crypto/x509/pkix.AttributeTypeAndValue
+      Element: 162 StructureType crypto/x509/pkix.AttributeTypeAndValue
     - __kind: GoSliceHeaderType
-      ID: 107
+      ID: 167
       Name: '[]crypto/x509/pkix.Extension'
       ByteSize: 24
       GoRuntimeType: 518400
@@ -1091,21 +1091,21 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 108 PointerType *crypto/x509/pkix.Extension
+          Type: 168 PointerType *crypto/x509/pkix.Extension
         - Name: len
           Offset: 8
           Type: 7 BaseType int
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 253 GoSliceDataType []crypto/x509/pkix.Extension.array
+      Data: 263 GoSliceDataType []crypto/x509/pkix.Extension.array
     - __kind: GoSliceDataType
-      ID: 253
+      ID: 263
       Name: '[]crypto/x509/pkix.Extension.array'
       ByteSize: 2048
-      Element: 109 StructureType crypto/x509/pkix.Extension
+      Element: 169 StructureType crypto/x509/pkix.Extension
     - __kind: GoSliceHeaderType
-      ID: 110
+      ID: 170
       Name: '[]encoding/asn1.ObjectIdentifier'
       ByteSize: 24
       GoRuntimeType: 518464
@@ -1113,21 +1113,21 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 111 PointerType *encoding/asn1.ObjectIdentifier
+          Type: 171 PointerType *encoding/asn1.ObjectIdentifier
         - Name: len
           Offset: 8
           Type: 7 BaseType int
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 255 GoSliceDataType []encoding/asn1.ObjectIdentifier.array
+      Data: 265 GoSliceDataType []encoding/asn1.ObjectIdentifier.array
     - __kind: GoSliceDataType
-      ID: 255
+      ID: 265
       Name: '[]encoding/asn1.ObjectIdentifier.array'
       ByteSize: 2048
-      Element: 96 GoSliceHeaderType encoding/asn1.ObjectIdentifier
+      Element: 172 GoSliceHeaderType encoding/asn1.ObjectIdentifier
     - __kind: GoSliceHeaderType
-      ID: 187
+      ID: 87
       Name: '[]github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink'
       ByteSize: 24
       GoRuntimeType: 491520
@@ -1135,21 +1135,21 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 188 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink
+          Type: 88 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink
         - Name: len
           Offset: 8
           Type: 7 BaseType int
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 285 GoSliceDataType []github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink.array
+      Data: 241 GoSliceDataType []github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink.array
     - __kind: GoSliceDataType
-      ID: 285
+      ID: 241
       Name: '[]github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink.array'
       ByteSize: 2048
-      Element: 189 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink
+      Element: 89 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink
     - __kind: GoSliceHeaderType
-      ID: 190
+      ID: 90
       Name: '[]github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent'
       ByteSize: 24
       GoRuntimeType: 491712
@@ -1157,21 +1157,21 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 191 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent
+          Type: 91 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent
         - Name: len
           Offset: 8
           Type: 7 BaseType int
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 287 GoSliceDataType []github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent.array
+      Data: 243 GoSliceDataType []github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent.array
     - __kind: GoSliceDataType
-      ID: 287
+      ID: 243
       Name: '[]github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent.array'
       ByteSize: 2048
-      Element: 192 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent
+      Element: 92 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent
     - __kind: GoSliceHeaderType
-      ID: 115
+      ID: 176
       Name: '[]net.IP'
       ByteSize: 24
       GoRuntimeType: 484896
@@ -1179,21 +1179,21 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 116 PointerType *net.IP
+          Type: 177 PointerType *net.IP
         - Name: len
           Offset: 8
           Type: 7 BaseType int
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 259 GoSliceDataType []net.IP.array
+      Data: 271 GoSliceDataType []net.IP.array
     - __kind: GoSliceDataType
-      ID: 259
+      ID: 271
       Name: '[]net.IP.array'
       ByteSize: 2048
-      Element: 117 GoSliceHeaderType net.IP
+      Element: 178 GoSliceHeaderType net.IP
     - __kind: GoSliceHeaderType
-      ID: 143
+      ID: 116
       Name: '[]net/http.segment'
       ByteSize: 24
       GoRuntimeType: 486528
@@ -1201,49 +1201,49 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 144 PointerType *net/http.segment
+          Type: 117 PointerType *net/http.segment
         - Name: len
           Offset: 8
           Type: 7 BaseType int
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 277 GoSliceDataType []net/http.segment.array
+      Data: 255 GoSliceDataType []net/http.segment.array
     - __kind: GoSliceDataType
-      ID: 277
+      ID: 255
       Name: '[]net/http.segment.array'
       ByteSize: 2048
-      Element: 145 StructureType net/http.segment
+      Element: 118 StructureType net/http.segment
     - __kind: GoSliceDataType
-      ID: 290
+      ID: 258
       Name: '[]noalg.map.group[string]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute.array'
       ByteSize: 2048
-      Element: 201 StructureType noalg.map.group[string]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
+      Element: 198 StructureType noalg.map.group[string]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
     - __kind: GoSliceDataType
-      ID: 236
+      ID: 248
       Name: '[]noalg.map.group[string][]*mime/multipart.FileHeader.array'
       ByteSize: 2048
-      Element: 69 StructureType noalg.map.group[string][]*mime/multipart.FileHeader
+      Element: 153 StructureType noalg.map.group[string][]*mime/multipart.FileHeader
     - __kind: GoSliceDataType
       ID: 232
       Name: '[]noalg.map.group[string][]string.array'
       ByteSize: 2048
-      Element: 51 StructureType noalg.map.group[string][]string
+      Element: 133 StructureType noalg.map.group[string][]string
     - __kind: GoSliceDataType
-      ID: 284
+      ID: 240
       Name: '[]noalg.map.group[string]float64.array'
       ByteSize: 2048
-      Element: 184 StructureType noalg.map.group[string]float64
+      Element: 144 StructureType noalg.map.group[string]float64
     - __kind: GoSliceDataType
-      ID: 282
+      ID: 238
       Name: '[]noalg.map.group[string]interface {}.array'
       ByteSize: 2048
-      Element: 173 StructureType noalg.map.group[string]interface {}
+      Element: 141 StructureType noalg.map.group[string]interface {}
     - __kind: GoSliceDataType
-      ID: 280
+      ID: 236
       Name: '[]noalg.map.group[string]string.array'
       ByteSize: 2048
-      Element: 154 StructureType noalg.map.group[string]string
+      Element: 138 StructureType noalg.map.group[string]string
     - __kind: GoSliceHeaderType
       ID: 54
       Name: '[]string'
@@ -1267,7 +1267,7 @@ Types:
       ByteSize: 2048
       Element: 9 GoStringHeaderType string
     - __kind: GoSliceHeaderType
-      ID: 100
+      ID: 207
       Name: '[]time.zone'
       ByteSize: 24
       GoRuntimeType: 491072
@@ -1275,21 +1275,21 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 101 PointerType *time.zone
+          Type: 208 PointerType *time.zone
         - Name: len
           Offset: 8
           Type: 7 BaseType int
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 249 GoSliceDataType []time.zone.array
+      Data: 287 GoSliceDataType []time.zone.array
     - __kind: GoSliceDataType
-      ID: 249
+      ID: 287
       Name: '[]time.zone.array'
       ByteSize: 2048
-      Element: 102 StructureType time.zone
+      Element: 209 StructureType time.zone
     - __kind: GoSliceHeaderType
-      ID: 103
+      ID: 210
       Name: '[]time.zoneTrans'
       ByteSize: 24
       GoRuntimeType: 491136
@@ -1297,21 +1297,21 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 104 PointerType *time.zoneTrans
+          Type: 211 PointerType *time.zoneTrans
         - Name: len
           Offset: 8
           Type: 7 BaseType int
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 251 GoSliceDataType []time.zoneTrans.array
+      Data: 289 GoSliceDataType []time.zoneTrans.array
     - __kind: GoSliceDataType
-      ID: 251
+      ID: 289
       Name: '[]time.zoneTrans.array'
       ByteSize: 2048
-      Element: 105 StructureType time.zoneTrans
+      Element: 212 StructureType time.zoneTrans
     - __kind: GoSliceHeaderType
-      ID: 77
+      ID: 96
       Name: '[]uint8'
       ByteSize: 24
       GoRuntimeType: 497024
@@ -1326,9 +1326,9 @@ Types:
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 239 GoSliceDataType []uint8.array
+      Data: 245 GoSliceDataType []uint8.array
     - __kind: GoSliceDataType
-      ID: 239
+      ID: 245
       Name: '[]uint8.array'
       ByteSize: 2048
       Element: 3 BaseType uint8
@@ -1339,7 +1339,7 @@ Types:
       GoRuntimeType: 591392
       GoKind: 1
     - __kind: StructureType
-      ID: 225
+      ID: 42
       Name: bytes.Buffer
       ByteSize: 40
       GoRuntimeType: 1.635488e+06
@@ -1347,15 +1347,15 @@ Types:
       RawFields:
         - Name: buf
           Offset: 0
-          Type: 77 GoSliceHeaderType []uint8
+          Type: 96 GoSliceHeaderType []uint8
         - Name: off
           Offset: 24
           Type: 7 BaseType int
         - Name: lastRead
           Offset: 32
-          Type: 226 BaseType bytes.readOp
+          Type: 97 BaseType bytes.readOp
     - __kind: BaseType
-      ID: 226
+      ID: 97
       Name: bytes.readOp
       ByteSize: 1
       GoRuntimeType: 589536
@@ -1373,7 +1373,7 @@ Types:
       GoRuntimeType: 591136
       GoKind: 15
     - __kind: GoInterfaceType
-      ID: 140
+      ID: 63
       Name: context.Context
       ByteSize: 16
       GoRuntimeType: 1.298688e+06
@@ -1386,22 +1386,22 @@ Types:
           Offset: 8
           Type: 14 VoidPointerType unsafe.Pointer
     - __kind: StructureType
-      ID: 227
+      ID: 43
       Name: context.backgroundCtx
       GoRuntimeType: 1.827296e+06
       GoKind: 25
       RawFields:
         - Name: emptyCtx
           Offset: 0
-          Type: 228 StructureType context.emptyCtx
+          Type: 44 StructureType context.emptyCtx
     - __kind: StructureType
-      ID: 228
+      ID: 44
       Name: context.emptyCtx
       GoRuntimeType: 1.618752e+06
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 79
+      ID: 59
       Name: crypto/tls.ConnectionState
       ByteSize: 192
       GoRuntimeType: 2.302368e+06
@@ -1430,39 +1430,39 @@ Types:
           Type: 9 GoStringHeaderType string
         - Name: PeerCertificates
           Offset: 48
-          Type: 80 GoSliceHeaderType []*crypto/x509.Certificate
+          Type: 107 GoSliceHeaderType []*crypto/x509.Certificate
         - Name: VerifiedChains
           Offset: 72
-          Type: 131 GoSliceHeaderType [][]*crypto/x509.Certificate
+          Type: 110 GoSliceHeaderType [][]*crypto/x509.Certificate
         - Name: SignedCertificateTimestamps
           Offset: 96
-          Type: 133 GoSliceHeaderType [][]uint8
+          Type: 112 GoSliceHeaderType [][]uint8
         - Name: OCSPResponse
           Offset: 120
-          Type: 77 GoSliceHeaderType []uint8
+          Type: 96 GoSliceHeaderType []uint8
         - Name: TLSUnique
           Offset: 144
-          Type: 77 GoSliceHeaderType []uint8
+          Type: 96 GoSliceHeaderType []uint8
         - Name: ECHAccepted
           Offset: 168
           Type: 4 BaseType bool
         - Name: ekm
           Offset: 176
-          Type: 135 GoSubroutineType func(string, []uint8, int) ([]uint8, error)
+          Type: 114 GoSubroutineType func(string, []uint8, int) ([]uint8, error)
         - Name: testingOnlyDidHRR
           Offset: 184
           Type: 4 BaseType bool
         - Name: testingOnlyCurveID
           Offset: 186
-          Type: 136 BaseType crypto/tls.CurveID
+          Type: 115 BaseType crypto/tls.CurveID
     - __kind: BaseType
-      ID: 136
+      ID: 115
       Name: crypto/tls.CurveID
       ByteSize: 2
       GoRuntimeType: 843936
       GoKind: 9
     - __kind: StructureType
-      ID: 83
+      ID: 135
       Name: crypto/x509.Certificate
       ByteSize: 1424
       GoRuntimeType: 2.453248e+06
@@ -1470,67 +1470,67 @@ Types:
       RawFields:
         - Name: Raw
           Offset: 0
-          Type: 77 GoSliceHeaderType []uint8
+          Type: 96 GoSliceHeaderType []uint8
         - Name: RawTBSCertificate
           Offset: 24
-          Type: 77 GoSliceHeaderType []uint8
+          Type: 96 GoSliceHeaderType []uint8
         - Name: RawSubjectPublicKeyInfo
           Offset: 48
-          Type: 77 GoSliceHeaderType []uint8
+          Type: 96 GoSliceHeaderType []uint8
         - Name: RawSubject
           Offset: 72
-          Type: 77 GoSliceHeaderType []uint8
+          Type: 96 GoSliceHeaderType []uint8
         - Name: RawIssuer
           Offset: 96
-          Type: 77 GoSliceHeaderType []uint8
+          Type: 96 GoSliceHeaderType []uint8
         - Name: Signature
           Offset: 120
-          Type: 77 GoSliceHeaderType []uint8
+          Type: 96 GoSliceHeaderType []uint8
         - Name: SignatureAlgorithm
           Offset: 144
-          Type: 84 BaseType crypto/x509.SignatureAlgorithm
+          Type: 154 BaseType crypto/x509.SignatureAlgorithm
         - Name: PublicKeyAlgorithm
           Offset: 152
-          Type: 85 BaseType crypto/x509.PublicKeyAlgorithm
+          Type: 155 BaseType crypto/x509.PublicKeyAlgorithm
         - Name: PublicKey
           Offset: 160
-          Type: 86 GoEmptyInterfaceType interface {}
+          Type: 156 GoEmptyInterfaceType interface {}
         - Name: Version
           Offset: 176
           Type: 7 BaseType int
         - Name: SerialNumber
           Offset: 184
-          Type: 87 PointerType *math/big.Int
+          Type: 157 PointerType *math/big.Int
         - Name: Issuer
           Offset: 192
-          Type: 92 StructureType crypto/x509/pkix.Name
+          Type: 159 StructureType crypto/x509/pkix.Name
         - Name: Subject
           Offset: 440
-          Type: 92 StructureType crypto/x509/pkix.Name
+          Type: 159 StructureType crypto/x509/pkix.Name
         - Name: NotBefore
           Offset: 688
-          Type: 97 StructureType time.Time
+          Type: 163 StructureType time.Time
         - Name: NotAfter
           Offset: 712
-          Type: 97 StructureType time.Time
+          Type: 163 StructureType time.Time
         - Name: KeyUsage
           Offset: 736
-          Type: 106 BaseType crypto/x509.KeyUsage
+          Type: 166 BaseType crypto/x509.KeyUsage
         - Name: Extensions
           Offset: 744
-          Type: 107 GoSliceHeaderType []crypto/x509/pkix.Extension
+          Type: 167 GoSliceHeaderType []crypto/x509/pkix.Extension
         - Name: ExtraExtensions
           Offset: 768
-          Type: 107 GoSliceHeaderType []crypto/x509/pkix.Extension
+          Type: 167 GoSliceHeaderType []crypto/x509/pkix.Extension
         - Name: UnhandledCriticalExtensions
           Offset: 792
-          Type: 110 GoSliceHeaderType []encoding/asn1.ObjectIdentifier
+          Type: 170 GoSliceHeaderType []encoding/asn1.ObjectIdentifier
         - Name: ExtKeyUsage
           Offset: 816
-          Type: 112 GoSliceHeaderType []crypto/x509.ExtKeyUsage
+          Type: 173 GoSliceHeaderType []crypto/x509.ExtKeyUsage
         - Name: UnknownExtKeyUsage
           Offset: 840
-          Type: 110 GoSliceHeaderType []encoding/asn1.ObjectIdentifier
+          Type: 170 GoSliceHeaderType []encoding/asn1.ObjectIdentifier
         - Name: BasicConstraintsValid
           Offset: 864
           Type: 4 BaseType bool
@@ -1545,10 +1545,10 @@ Types:
           Type: 4 BaseType bool
         - Name: SubjectKeyId
           Offset: 888
-          Type: 77 GoSliceHeaderType []uint8
+          Type: 96 GoSliceHeaderType []uint8
         - Name: AuthorityKeyId
           Offset: 912
-          Type: 77 GoSliceHeaderType []uint8
+          Type: 96 GoSliceHeaderType []uint8
         - Name: OCSPServer
           Offset: 936
           Type: 54 GoSliceHeaderType []string
@@ -1563,10 +1563,10 @@ Types:
           Type: 54 GoSliceHeaderType []string
         - Name: IPAddresses
           Offset: 1032
-          Type: 115 GoSliceHeaderType []net.IP
+          Type: 176 GoSliceHeaderType []net.IP
         - Name: URIs
           Offset: 1056
-          Type: 118 GoSliceHeaderType []*net/url.URL
+          Type: 179 GoSliceHeaderType []*net/url.URL
         - Name: PermittedDNSDomainsCritical
           Offset: 1080
           Type: 4 BaseType bool
@@ -1578,10 +1578,10 @@ Types:
           Type: 54 GoSliceHeaderType []string
         - Name: PermittedIPRanges
           Offset: 1136
-          Type: 120 GoSliceHeaderType []*net.IPNet
+          Type: 181 GoSliceHeaderType []*net.IPNet
         - Name: ExcludedIPRanges
           Offset: 1160
-          Type: 120 GoSliceHeaderType []*net.IPNet
+          Type: 181 GoSliceHeaderType []*net.IPNet
         - Name: PermittedEmailAddresses
           Offset: 1184
           Type: 54 GoSliceHeaderType []string
@@ -1599,10 +1599,10 @@ Types:
           Type: 54 GoSliceHeaderType []string
         - Name: PolicyIdentifiers
           Offset: 1304
-          Type: 110 GoSliceHeaderType []encoding/asn1.ObjectIdentifier
+          Type: 170 GoSliceHeaderType []encoding/asn1.ObjectIdentifier
         - Name: Policies
           Offset: 1328
-          Type: 125 GoSliceHeaderType []crypto/x509.OID
+          Type: 184 GoSliceHeaderType []crypto/x509.OID
         - Name: InhibitAnyPolicy
           Offset: 1352
           Type: 7 BaseType int
@@ -1623,21 +1623,21 @@ Types:
           Type: 4 BaseType bool
         - Name: PolicyMappings
           Offset: 1400
-          Type: 128 GoSliceHeaderType []crypto/x509.PolicyMapping
+          Type: 187 GoSliceHeaderType []crypto/x509.PolicyMapping
     - __kind: BaseType
-      ID: 114
+      ID: 175
       Name: crypto/x509.ExtKeyUsage
       ByteSize: 8
       GoRuntimeType: 594464
       GoKind: 2
     - __kind: BaseType
-      ID: 106
+      ID: 166
       Name: crypto/x509.KeyUsage
       ByteSize: 8
       GoRuntimeType: 594400
       GoKind: 2
     - __kind: StructureType
-      ID: 127
+      ID: 186
       Name: crypto/x509.OID
       ByteSize: 24
       GoRuntimeType: 1.989888e+06
@@ -1645,9 +1645,9 @@ Types:
       RawFields:
         - Name: der
           Offset: 0
-          Type: 77 GoSliceHeaderType []uint8
+          Type: 96 GoSliceHeaderType []uint8
     - __kind: StructureType
-      ID: 130
+      ID: 189
       Name: crypto/x509.PolicyMapping
       ByteSize: 48
       GoRuntimeType: 1.515072e+06
@@ -1655,24 +1655,24 @@ Types:
       RawFields:
         - Name: IssuerDomainPolicy
           Offset: 0
-          Type: 127 StructureType crypto/x509.OID
+          Type: 186 StructureType crypto/x509.OID
         - Name: SubjectDomainPolicy
           Offset: 24
-          Type: 127 StructureType crypto/x509.OID
+          Type: 186 StructureType crypto/x509.OID
     - __kind: BaseType
-      ID: 85
+      ID: 155
       Name: crypto/x509.PublicKeyAlgorithm
       ByteSize: 8
       GoRuntimeType: 846240
       GoKind: 2
     - __kind: BaseType
-      ID: 84
+      ID: 154
       Name: crypto/x509.SignatureAlgorithm
       ByteSize: 8
       GoRuntimeType: 1.134784e+06
       GoKind: 2
     - __kind: StructureType
-      ID: 95
+      ID: 162
       Name: crypto/x509/pkix.AttributeTypeAndValue
       ByteSize: 40
       GoRuntimeType: 1.527392e+06
@@ -1680,12 +1680,12 @@ Types:
       RawFields:
         - Name: Type
           Offset: 0
-          Type: 96 GoSliceHeaderType encoding/asn1.ObjectIdentifier
+          Type: 172 GoSliceHeaderType encoding/asn1.ObjectIdentifier
         - Name: Value
           Offset: 24
-          Type: 86 GoEmptyInterfaceType interface {}
+          Type: 156 GoEmptyInterfaceType interface {}
     - __kind: StructureType
-      ID: 109
+      ID: 169
       Name: crypto/x509/pkix.Extension
       ByteSize: 56
       GoRuntimeType: 1.678688e+06
@@ -1693,15 +1693,15 @@ Types:
       RawFields:
         - Name: Id
           Offset: 0
-          Type: 96 GoSliceHeaderType encoding/asn1.ObjectIdentifier
+          Type: 172 GoSliceHeaderType encoding/asn1.ObjectIdentifier
         - Name: Critical
           Offset: 24
           Type: 4 BaseType bool
         - Name: Value
           Offset: 32
-          Type: 77 GoSliceHeaderType []uint8
+          Type: 96 GoSliceHeaderType []uint8
     - __kind: StructureType
-      ID: 92
+      ID: 159
       Name: crypto/x509/pkix.Name
       ByteSize: 248
       GoRuntimeType: 2.241664e+06
@@ -1736,12 +1736,12 @@ Types:
           Type: 9 GoStringHeaderType string
         - Name: Names
           Offset: 200
-          Type: 93 GoSliceHeaderType []crypto/x509/pkix.AttributeTypeAndValue
+          Type: 160 GoSliceHeaderType []crypto/x509/pkix.AttributeTypeAndValue
         - Name: ExtraNames
           Offset: 224
-          Type: 93 GoSliceHeaderType []crypto/x509/pkix.AttributeTypeAndValue
+          Type: 160 GoSliceHeaderType []crypto/x509/pkix.AttributeTypeAndValue
     - __kind: GoSliceHeaderType
-      ID: 96
+      ID: 172
       Name: encoding/asn1.ObjectIdentifier
       ByteSize: 24
       GoRuntimeType: 1.075328e+06
@@ -1756,9 +1756,9 @@ Types:
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 247 GoSliceDataType encoding/asn1.ObjectIdentifier.array
+      Data: 267 GoSliceDataType encoding/asn1.ObjectIdentifier.array
     - __kind: GoSliceDataType
-      ID: 247
+      ID: 267
       Name: encoding/asn1.ObjectIdentifier.array
       ByteSize: 2048
       Element: 7 BaseType int
@@ -1788,25 +1788,25 @@ Types:
       GoRuntimeType: 591328
       GoKind: 14
     - __kind: GoSubroutineType
-      ID: 223
+      ID: 95
       Name: func()
       ByteSize: 8
       GoRuntimeType: 482080
       GoKind: 19
     - __kind: GoSubroutineType
-      ID: 56
+      ID: 53
       Name: func() (io.ReadCloser, error)
       ByteSize: 8
       GoRuntimeType: 701280
       GoKind: 19
     - __kind: GoSubroutineType
-      ID: 135
+      ID: 114
       Name: func(string, []uint8, int) ([]uint8, error)
       ByteSize: 8
       GoRuntimeType: 1.020736e+06
       GoKind: 19
     - __kind: StructureType
-      ID: 158
+      ID: 40
       Name: github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span
       ByteSize: 288
       GoRuntimeType: 2.39312e+06
@@ -1814,7 +1814,7 @@ Types:
       RawFields:
         - Name: mu
           Offset: 0
-          Type: 159 StructureType sync.RWMutex
+          Type: 71 StructureType sync.RWMutex
         - Name: name
           Offset: 24
           Type: 9 GoStringHeaderType string
@@ -1835,13 +1835,13 @@ Types:
           Type: 12 BaseType int64
         - Name: meta
           Offset: 104
-          Type: 146 GoMapType map[string]string
+          Type: 66 GoMapType map[string]string
         - Name: metaStruct
           Offset: 112
-          Type: 165 GoMapType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.metaStructMap
+          Type: 77 GoMapType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.metaStructMap
         - Name: metrics
           Offset: 120
-          Type: 176 GoMapType map[string]float64
+          Type: 82 GoMapType map[string]float64
         - Name: spanID
           Offset: 128
           Type: 8 BaseType uint64
@@ -1856,10 +1856,10 @@ Types:
           Type: 10 BaseType int32
         - Name: spanLinks
           Offset: 160
-          Type: 187 GoSliceHeaderType []github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink
+          Type: 87 GoSliceHeaderType []github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink
         - Name: spanEvents
           Offset: 184
-          Type: 190 GoSliceHeaderType []github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent
+          Type: 90 GoSliceHeaderType []github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent
         - Name: goExecTraced
           Offset: 208
           Type: 4 BaseType bool
@@ -1871,7 +1871,7 @@ Types:
           Type: 4 BaseType bool
         - Name: context
           Offset: 216
-          Type: 215 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanContext
+          Type: 93 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanContext
         - Name: integration
           Offset: 224
           Type: 9 GoStringHeaderType string
@@ -1880,15 +1880,15 @@ Types:
           Type: 4 BaseType bool
         - Name: pprofCtxActive
           Offset: 248
-          Type: 140 GoInterfaceType context.Context
+          Type: 63 GoInterfaceType context.Context
         - Name: pprofCtxRestore
           Offset: 264
-          Type: 140 GoInterfaceType context.Context
+          Type: 63 GoInterfaceType context.Context
         - Name: taskEnd
           Offset: 280
-          Type: 223 GoSubroutineType func()
+          Type: 95 GoSubroutineType func()
     - __kind: StructureType
-      ID: 216
+      ID: 94
       Name: github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanContext
       ByteSize: 168
       GoRuntimeType: 2.26176e+06
@@ -1899,13 +1899,13 @@ Types:
           Type: 4 BaseType bool
         - Name: trace
           Offset: 8
-          Type: 217 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.trace
+          Type: 128 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.trace
         - Name: span
           Offset: 16
-          Type: 157 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span
+          Type: 39 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span
         - Name: errors
           Offset: 24
-          Type: 163 StructureType sync/atomic.Int32
+          Type: 75 StructureType sync/atomic.Int32
         - Name: reparentID
           Offset: 32
           Type: 9 GoStringHeaderType string
@@ -1914,16 +1914,16 @@ Types:
           Type: 4 BaseType bool
         - Name: traceID
           Offset: 49
-          Type: 222 ArrayType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.traceID
+          Type: 130 ArrayType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.traceID
         - Name: spanID
           Offset: 72
           Type: 8 BaseType uint64
         - Name: mu
           Offset: 80
-          Type: 159 StructureType sync.RWMutex
+          Type: 71 StructureType sync.RWMutex
         - Name: baggage
           Offset: 104
-          Type: 146 GoMapType map[string]string
+          Type: 66 GoMapType map[string]string
         - Name: hasBaggage
           Offset: 112
           Type: 2 BaseType uint32
@@ -1932,12 +1932,12 @@ Types:
           Type: 9 GoStringHeaderType string
         - Name: spanLinks
           Offset: 136
-          Type: 187 GoSliceHeaderType []github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink
+          Type: 87 GoSliceHeaderType []github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink
         - Name: baggageOnly
           Offset: 160
           Type: 4 BaseType bool
     - __kind: StructureType
-      ID: 189
+      ID: 89
       Name: github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink
       ByteSize: 56
       GoRuntimeType: 1.947136e+06
@@ -1954,7 +1954,7 @@ Types:
           Type: 8 BaseType uint64
         - Name: Attributes
           Offset: 24
-          Type: 146 GoMapType map[string]string
+          Type: 66 GoMapType map[string]string
         - Name: Tracestate
           Offset: 32
           Type: 9 GoStringHeaderType string
@@ -1962,20 +1962,20 @@ Types:
           Offset: 48
           Type: 2 BaseType uint32
     - __kind: GoMapType
-      ID: 165
+      ID: 77
       Name: github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.metaStructMap
       ByteSize: 8
       GoRuntimeType: 1.299968e+06
       GoKind: 21
-      HeaderType: 167 GoSwissMapHeaderType map<string,interface {}>
+      HeaderType: 79 GoSwissMapHeaderType map<string,interface {}>
     - __kind: BaseType
-      ID: 221
+      ID: 148
       Name: github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.samplingDecision
       ByteSize: 4
       GoRuntimeType: 590176
       GoKind: 10
     - __kind: StructureType
-      ID: 192
+      ID: 92
       Name: github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent
       ByteSize: 40
       GoRuntimeType: 1.781696e+06
@@ -1989,12 +1989,12 @@ Types:
           Type: 8 BaseType uint64
         - Name: Attributes
           Offset: 24
-          Type: 193 GoMapType map[string]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
+          Type: 122 GoMapType map[string]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
         - Name: RawAttributes
           Offset: 32
-          Type: 214 GoMapType map[string]interface {}
+          Type: 127 GoMapType map[string]interface {}
     - __kind: StructureType
-      ID: 208
+      ID: 222
       Name: github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttribute
       ByteSize: 24
       GoRuntimeType: 1.211328e+06
@@ -2002,9 +2002,9 @@ Types:
       RawFields:
         - Name: Values
           Offset: 0
-          Type: 209 GoSliceHeaderType []*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttributeValue
+          Type: 224 GoSliceHeaderType []*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttributeValue
     - __kind: StructureType
-      ID: 212
+      ID: 227
       Name: github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttributeValue
       ByteSize: 48
       GoRuntimeType: 1.869504e+06
@@ -2012,7 +2012,7 @@ Types:
       RawFields:
         - Name: Type
           Offset: 0
-          Type: 213 BaseType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttributeValueType
+          Type: 228 BaseType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttributeValueType
         - Name: StringValue
           Offset: 8
           Type: 9 GoStringHeaderType string
@@ -2026,13 +2026,13 @@ Types:
           Offset: 40
           Type: 18 BaseType float64
     - __kind: BaseType
-      ID: 213
+      ID: 228
       Name: github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttributeValueType
       ByteSize: 4
       GoRuntimeType: 1.002496e+06
       GoKind: 5
     - __kind: StructureType
-      ID: 205
+      ID: 217
       Name: github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
       ByteSize: 56
       GoRuntimeType: 1.947392e+06
@@ -2040,7 +2040,7 @@ Types:
       RawFields:
         - Name: Type
           Offset: 0
-          Type: 206 BaseType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttributeType
+          Type: 220 BaseType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttributeType
         - Name: StringValue
           Offset: 8
           Type: 9 GoStringHeaderType string
@@ -2055,15 +2055,15 @@ Types:
           Type: 18 BaseType float64
         - Name: ArrayValue
           Offset: 48
-          Type: 207 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttribute
+          Type: 221 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttribute
     - __kind: BaseType
-      ID: 206
+      ID: 220
       Name: github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttributeType
       ByteSize: 4
       GoRuntimeType: 1.0024e+06
       GoKind: 5
     - __kind: StructureType
-      ID: 218
+      ID: 129
       Name: github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.trace
       ByteSize: 104
       GoRuntimeType: 2.148896e+06
@@ -2071,16 +2071,16 @@ Types:
       RawFields:
         - Name: mu
           Offset: 0
-          Type: 159 StructureType sync.RWMutex
+          Type: 71 StructureType sync.RWMutex
         - Name: spans
           Offset: 24
-          Type: 219 GoSliceHeaderType []*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span
+          Type: 146 GoSliceHeaderType []*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span
         - Name: tags
           Offset: 48
-          Type: 146 GoMapType map[string]string
+          Type: 66 GoMapType map[string]string
         - Name: propagatingTags
           Offset: 56
-          Type: 146 GoMapType map[string]string
+          Type: 66 GoMapType map[string]string
         - Name: finished
           Offset: 64
           Type: 7 BaseType int
@@ -2095,12 +2095,12 @@ Types:
           Type: 4 BaseType bool
         - Name: samplingDecision
           Offset: 92
-          Type: 221 BaseType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.samplingDecision
+          Type: 148 BaseType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.samplingDecision
         - Name: root
           Offset: 96
-          Type: 157 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span
+          Type: 39 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span
     - __kind: ArrayType
-      ID: 222
+      ID: 130
       Name: github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.traceID
       ByteSize: 16
       GoRuntimeType: 914912
@@ -2109,89 +2109,89 @@ Types:
       HasCount: true
       Element: 3 BaseType uint8
     - __kind: GoSwissMapGroupsType
-      ID: 199
+      ID: 196
       Name: groupReference<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 200 PointerType *noalg.map.group[string]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
+          Type: 197 PointerType *noalg.map.group[string]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
         - Name: lengthMask
           Offset: 8
           Type: 8 BaseType uint64
-      GroupType: 201 StructureType noalg.map.group[string]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
-      GroupSliceType: 290 GoSliceDataType []noalg.map.group[string]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute.array
+      GroupType: 198 StructureType noalg.map.group[string]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
+      GroupSliceType: 258 GoSliceDataType []noalg.map.group[string]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute.array
     - __kind: GoSwissMapGroupsType
-      ID: 67
+      ID: 151
       Name: groupReference<string,[]*mime/multipart.FileHeader>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 68 PointerType *noalg.map.group[string][]*mime/multipart.FileHeader
+          Type: 152 PointerType *noalg.map.group[string][]*mime/multipart.FileHeader
         - Name: lengthMask
           Offset: 8
           Type: 8 BaseType uint64
-      GroupType: 69 StructureType noalg.map.group[string][]*mime/multipart.FileHeader
-      GroupSliceType: 236 GoSliceDataType []noalg.map.group[string][]*mime/multipart.FileHeader.array
+      GroupType: 153 StructureType noalg.map.group[string][]*mime/multipart.FileHeader
+      GroupSliceType: 248 GoSliceDataType []noalg.map.group[string][]*mime/multipart.FileHeader.array
     - __kind: GoSwissMapGroupsType
-      ID: 49
+      ID: 131
       Name: groupReference<string,[]string>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 50 PointerType *noalg.map.group[string][]string
+          Type: 132 PointerType *noalg.map.group[string][]string
         - Name: lengthMask
           Offset: 8
           Type: 8 BaseType uint64
-      GroupType: 51 StructureType noalg.map.group[string][]string
+      GroupType: 133 StructureType noalg.map.group[string][]string
       GroupSliceType: 232 GoSliceDataType []noalg.map.group[string][]string.array
     - __kind: GoSwissMapGroupsType
-      ID: 182
+      ID: 142
       Name: groupReference<string,float64>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 183 PointerType *noalg.map.group[string]float64
+          Type: 143 PointerType *noalg.map.group[string]float64
         - Name: lengthMask
           Offset: 8
           Type: 8 BaseType uint64
-      GroupType: 184 StructureType noalg.map.group[string]float64
-      GroupSliceType: 284 GoSliceDataType []noalg.map.group[string]float64.array
+      GroupType: 144 StructureType noalg.map.group[string]float64
+      GroupSliceType: 240 GoSliceDataType []noalg.map.group[string]float64.array
     - __kind: GoSwissMapGroupsType
-      ID: 171
+      ID: 139
       Name: groupReference<string,interface {}>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 172 PointerType *noalg.map.group[string]interface {}
+          Type: 140 PointerType *noalg.map.group[string]interface {}
         - Name: lengthMask
           Offset: 8
           Type: 8 BaseType uint64
-      GroupType: 173 StructureType noalg.map.group[string]interface {}
-      GroupSliceType: 282 GoSliceDataType []noalg.map.group[string]interface {}.array
+      GroupType: 141 StructureType noalg.map.group[string]interface {}
+      GroupSliceType: 238 GoSliceDataType []noalg.map.group[string]interface {}.array
     - __kind: GoSwissMapGroupsType
-      ID: 152
+      ID: 136
       Name: groupReference<string,string>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 153 PointerType *noalg.map.group[string]string
+          Type: 137 PointerType *noalg.map.group[string]string
         - Name: lengthMask
           Offset: 8
           Type: 8 BaseType uint64
-      GroupType: 154 StructureType noalg.map.group[string]string
-      GroupSliceType: 280 GoSliceDataType []noalg.map.group[string]string.array
+      GroupType: 138 StructureType noalg.map.group[string]string
+      GroupSliceType: 236 GoSliceDataType []noalg.map.group[string]string.array
     - __kind: BaseType
       ID: 7
       Name: int
@@ -2223,7 +2223,7 @@ Types:
       GoRuntimeType: 590432
       GoKind: 3
     - __kind: GoEmptyInterfaceType
-      ID: 86
+      ID: 156
       Name: interface {}
       ByteSize: 16
       GoRuntimeType: 863648
@@ -2236,7 +2236,7 @@ Types:
           Offset: 8
           Type: 14 VoidPointerType unsafe.Pointer
     - __kind: StructureType
-      ID: 162
+      ID: 74
       Name: internal/sync.Mutex
       ByteSize: 8
       GoRuntimeType: 1.512992e+06
@@ -2249,7 +2249,7 @@ Types:
           Offset: 4
           Type: 2 BaseType uint32
     - __kind: GoInterfaceType
-      ID: 55
+      ID: 52
       Name: io.ReadCloser
       ByteSize: 16
       GoRuntimeType: 1.130304e+06
@@ -2262,7 +2262,7 @@ Types:
           Offset: 8
           Type: 14 VoidPointerType unsafe.Pointer
     - __kind: GoSwissMapHeaderType
-      ID: 195
+      ID: 124
       Name: map<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
       ByteSize: 48
       GoKind: 25
@@ -2275,7 +2275,7 @@ Types:
           Type: 1 BaseType uintptr
         - Name: dirPtr
           Offset: 16
-          Type: 196 PointerType **table<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
+          Type: 125 PointerType **table<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
         - Name: dirLen
           Offset: 24
           Type: 7 BaseType int
@@ -2291,10 +2291,10 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 8 BaseType uint64
-      TablePtrSliceType: 289 GoSliceDataType []*table<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>.array
-      GroupType: 201 StructureType noalg.map.group[string]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
+      TablePtrSliceType: 257 GoSliceDataType []*table<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>.array
+      GroupType: 198 StructureType noalg.map.group[string]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
     - __kind: GoSwissMapHeaderType
-      ID: 63
+      ID: 104
       Name: map<string,[]*mime/multipart.FileHeader>
       ByteSize: 48
       GoKind: 25
@@ -2307,7 +2307,7 @@ Types:
           Type: 1 BaseType uintptr
         - Name: dirPtr
           Offset: 16
-          Type: 64 PointerType **table<string,[]*mime/multipart.FileHeader>
+          Type: 105 PointerType **table<string,[]*mime/multipart.FileHeader>
         - Name: dirLen
           Offset: 24
           Type: 7 BaseType int
@@ -2323,10 +2323,10 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 8 BaseType uint64
-      TablePtrSliceType: 235 GoSliceDataType []*table<string,[]*mime/multipart.FileHeader>.array
-      GroupType: 69 StructureType noalg.map.group[string][]*mime/multipart.FileHeader
+      TablePtrSliceType: 247 GoSliceDataType []*table<string,[]*mime/multipart.FileHeader>.array
+      GroupType: 153 StructureType noalg.map.group[string][]*mime/multipart.FileHeader
     - __kind: GoSwissMapHeaderType
-      ID: 45
+      ID: 49
       Name: map<string,[]string>
       ByteSize: 48
       GoKind: 25
@@ -2339,7 +2339,7 @@ Types:
           Type: 1 BaseType uintptr
         - Name: dirPtr
           Offset: 16
-          Type: 46 PointerType **table<string,[]string>
+          Type: 50 PointerType **table<string,[]string>
         - Name: dirLen
           Offset: 24
           Type: 7 BaseType int
@@ -2356,9 +2356,9 @@ Types:
           Offset: 40
           Type: 8 BaseType uint64
       TablePtrSliceType: 231 GoSliceDataType []*table<string,[]string>.array
-      GroupType: 51 StructureType noalg.map.group[string][]string
+      GroupType: 133 StructureType noalg.map.group[string][]string
     - __kind: GoSwissMapHeaderType
-      ID: 178
+      ID: 84
       Name: map<string,float64>
       ByteSize: 48
       GoKind: 25
@@ -2371,7 +2371,7 @@ Types:
           Type: 1 BaseType uintptr
         - Name: dirPtr
           Offset: 16
-          Type: 179 PointerType **table<string,float64>
+          Type: 85 PointerType **table<string,float64>
         - Name: dirLen
           Offset: 24
           Type: 7 BaseType int
@@ -2387,10 +2387,10 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 8 BaseType uint64
-      TablePtrSliceType: 283 GoSliceDataType []*table<string,float64>.array
-      GroupType: 184 StructureType noalg.map.group[string]float64
+      TablePtrSliceType: 239 GoSliceDataType []*table<string,float64>.array
+      GroupType: 144 StructureType noalg.map.group[string]float64
     - __kind: GoSwissMapHeaderType
-      ID: 167
+      ID: 79
       Name: map<string,interface {}>
       ByteSize: 48
       GoKind: 25
@@ -2403,7 +2403,7 @@ Types:
           Type: 1 BaseType uintptr
         - Name: dirPtr
           Offset: 16
-          Type: 168 PointerType **table<string,interface {}>
+          Type: 80 PointerType **table<string,interface {}>
         - Name: dirLen
           Offset: 24
           Type: 7 BaseType int
@@ -2419,10 +2419,10 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 8 BaseType uint64
-      TablePtrSliceType: 281 GoSliceDataType []*table<string,interface {}>.array
-      GroupType: 173 StructureType noalg.map.group[string]interface {}
+      TablePtrSliceType: 237 GoSliceDataType []*table<string,interface {}>.array
+      GroupType: 141 StructureType noalg.map.group[string]interface {}
     - __kind: GoSwissMapHeaderType
-      ID: 148
+      ID: 68
       Name: map<string,string>
       ByteSize: 48
       GoKind: 25
@@ -2435,7 +2435,7 @@ Types:
           Type: 1 BaseType uintptr
         - Name: dirPtr
           Offset: 16
-          Type: 149 PointerType **table<string,string>
+          Type: 69 PointerType **table<string,string>
         - Name: dirLen
           Offset: 24
           Type: 7 BaseType int
@@ -2451,52 +2451,52 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 8 BaseType uint64
-      TablePtrSliceType: 279 GoSliceDataType []*table<string,string>.array
-      GroupType: 154 StructureType noalg.map.group[string]string
+      TablePtrSliceType: 235 GoSliceDataType []*table<string,string>.array
+      GroupType: 138 StructureType noalg.map.group[string]string
     - __kind: GoMapType
-      ID: 193
+      ID: 122
       Name: map[string]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
       ByteSize: 8
       GoRuntimeType: 1.153728e+06
       GoKind: 21
-      HeaderType: 195 GoSwissMapHeaderType map<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
+      HeaderType: 124 GoSwissMapHeaderType map<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
     - __kind: GoMapType
-      ID: 61
+      ID: 102
       Name: map[string][]*mime/multipart.FileHeader
       ByteSize: 8
       GoRuntimeType: 1.15296e+06
       GoKind: 21
-      HeaderType: 63 GoSwissMapHeaderType map<string,[]*mime/multipart.FileHeader>
+      HeaderType: 104 GoSwissMapHeaderType map<string,[]*mime/multipart.FileHeader>
     - __kind: GoMapType
-      ID: 60
+      ID: 101
       Name: map[string][]string
       ByteSize: 8
       GoRuntimeType: 1.148352e+06
       GoKind: 21
-      HeaderType: 45 GoSwissMapHeaderType map<string,[]string>
+      HeaderType: 49 GoSwissMapHeaderType map<string,[]string>
     - __kind: GoMapType
-      ID: 176
+      ID: 82
       Name: map[string]float64
       ByteSize: 8
       GoRuntimeType: 1.1536e+06
       GoKind: 21
-      HeaderType: 178 GoSwissMapHeaderType map<string,float64>
+      HeaderType: 84 GoSwissMapHeaderType map<string,float64>
     - __kind: GoMapType
-      ID: 214
+      ID: 127
       Name: map[string]interface {}
       ByteSize: 8
       GoRuntimeType: 1.146944e+06
       GoKind: 21
-      HeaderType: 167 GoSwissMapHeaderType map<string,interface {}>
+      HeaderType: 79 GoSwissMapHeaderType map<string,interface {}>
     - __kind: GoMapType
-      ID: 146
+      ID: 66
       Name: map[string]string
       ByteSize: 8
       GoRuntimeType: 1.149376e+06
       GoKind: 21
-      HeaderType: 148 GoSwissMapHeaderType map<string,string>
+      HeaderType: 68 GoSwissMapHeaderType map<string,string>
     - __kind: StructureType
-      ID: 88
+      ID: 158
       Name: math/big.Int
       ByteSize: 32
       GoRuntimeType: 1.518112e+06
@@ -2507,15 +2507,15 @@ Types:
           Type: 4 BaseType bool
         - Name: abs
           Offset: 8
-          Type: 89 GoSliceHeaderType math/big.nat
+          Type: 204 GoSliceHeaderType math/big.nat
     - __kind: BaseType
-      ID: 91
+      ID: 206
       Name: math/big.Word
       ByteSize: 8
       GoRuntimeType: 594656
       GoKind: 7
     - __kind: GoSliceHeaderType
-      ID: 89
+      ID: 204
       Name: math/big.nat
       ByteSize: 24
       GoRuntimeType: 2.4216e+06
@@ -2523,21 +2523,21 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 90 PointerType *math/big.Word
+          Type: 205 PointerType *math/big.Word
         - Name: len
           Offset: 8
           Type: 7 BaseType int
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 243 GoSliceDataType math/big.nat.array
+      Data: 285 GoSliceDataType math/big.nat.array
     - __kind: GoSliceDataType
-      ID: 243
+      ID: 285
       Name: math/big.nat.array
       ByteSize: 2048
-      Element: 91 BaseType math/big.Word
+      Element: 206 BaseType math/big.Word
     - __kind: StructureType
-      ID: 75
+      ID: 218
       Name: mime/multipart.FileHeader
       ByteSize: 88
       GoRuntimeType: 2.010048e+06
@@ -2548,13 +2548,13 @@ Types:
           Type: 9 GoStringHeaderType string
         - Name: Header
           Offset: 16
-          Type: 76 GoMapType net/textproto.MIMEHeader
+          Type: 223 GoMapType net/textproto.MIMEHeader
         - Name: Size
           Offset: 24
           Type: 12 BaseType int64
         - Name: content
           Offset: 32
-          Type: 77 GoSliceHeaderType []uint8
+          Type: 96 GoSliceHeaderType []uint8
         - Name: tmpfile
           Offset: 56
           Type: 9 GoStringHeaderType string
@@ -2565,7 +2565,7 @@ Types:
           Offset: 80
           Type: 4 BaseType bool
     - __kind: StructureType
-      ID: 59
+      ID: 57
       Name: mime/multipart.Form
       ByteSize: 16
       GoRuntimeType: 1.501472e+06
@@ -2573,12 +2573,12 @@ Types:
       RawFields:
         - Name: Value
           Offset: 0
-          Type: 60 GoMapType map[string][]string
+          Type: 101 GoMapType map[string][]string
         - Name: File
           Offset: 8
-          Type: 61 GoMapType map[string][]*mime/multipart.FileHeader
+          Type: 102 GoMapType map[string][]*mime/multipart.FileHeader
     - __kind: GoSliceHeaderType
-      ID: 117
+      ID: 178
       Name: net.IP
       ByteSize: 24
       GoRuntimeType: 2.17104e+06
@@ -2593,14 +2593,14 @@ Types:
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 261 GoSliceDataType net.IP.array
+      Data: 273 GoSliceDataType net.IP.array
     - __kind: GoSliceDataType
-      ID: 261
+      ID: 273
       Name: net.IP.array
       ByteSize: 2048
       Element: 3 BaseType uint8
     - __kind: GoSliceHeaderType
-      ID: 124
+      ID: 219
       Name: net.IPMask
       ByteSize: 24
       GoRuntimeType: 1.03808e+06
@@ -2615,14 +2615,14 @@ Types:
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 267 GoSliceDataType net.IPMask.array
+      Data: 291 GoSliceDataType net.IPMask.array
     - __kind: GoSliceDataType
-      ID: 267
+      ID: 291
       Name: net.IPMask.array
       ByteSize: 2048
       Element: 3 BaseType uint8
     - __kind: StructureType
-      ID: 123
+      ID: 213
       Name: net.IPNet
       ByteSize: 48
       GoRuntimeType: 1.482432e+06
@@ -2630,17 +2630,17 @@ Types:
       RawFields:
         - Name: IP
           Offset: 0
-          Type: 117 GoSliceHeaderType net.IP
+          Type: 178 GoSliceHeaderType net.IP
         - Name: Mask
           Offset: 24
-          Type: 124 GoSliceHeaderType net.IPMask
+          Type: 219 GoSliceHeaderType net.IPMask
     - __kind: GoMapType
-      ID: 43
+      ID: 47
       Name: net/http.Header
       ByteSize: 8
       GoRuntimeType: 2.148192e+06
       GoKind: 21
-      HeaderType: 45 GoSwissMapHeaderType map<string,[]string>
+      HeaderType: 49 GoSwissMapHeaderType map<string,[]string>
     - __kind: StructureType
       ID: 38
       Name: net/http.Request
@@ -2653,7 +2653,7 @@ Types:
           Type: 9 GoStringHeaderType string
         - Name: URL
           Offset: 16
-          Type: 39 PointerType *net/url.URL
+          Type: 45 PointerType *net/url.URL
         - Name: Proto
           Offset: 24
           Type: 9 GoStringHeaderType string
@@ -2665,13 +2665,13 @@ Types:
           Type: 7 BaseType int
         - Name: Header
           Offset: 56
-          Type: 43 GoMapType net/http.Header
+          Type: 47 GoMapType net/http.Header
         - Name: Body
           Offset: 64
-          Type: 55 GoInterfaceType io.ReadCloser
+          Type: 52 GoInterfaceType io.ReadCloser
         - Name: GetBody
           Offset: 80
-          Type: 56 GoSubroutineType func() (io.ReadCloser, error)
+          Type: 53 GoSubroutineType func() (io.ReadCloser, error)
         - Name: ContentLength
           Offset: 88
           Type: 12 BaseType int64
@@ -2686,16 +2686,16 @@ Types:
           Type: 9 GoStringHeaderType string
         - Name: Form
           Offset: 144
-          Type: 57 GoMapType net/url.Values
+          Type: 55 GoMapType net/url.Values
         - Name: PostForm
           Offset: 152
-          Type: 57 GoMapType net/url.Values
+          Type: 55 GoMapType net/url.Values
         - Name: MultipartForm
           Offset: 160
-          Type: 58 PointerType *mime/multipart.Form
+          Type: 56 PointerType *mime/multipart.Form
         - Name: Trailer
           Offset: 168
-          Type: 43 GoMapType net/http.Header
+          Type: 47 GoMapType net/http.Header
         - Name: RemoteAddr
           Offset: 176
           Type: 9 GoStringHeaderType string
@@ -2704,30 +2704,30 @@ Types:
           Type: 9 GoStringHeaderType string
         - Name: TLS
           Offset: 208
-          Type: 78 PointerType *crypto/tls.ConnectionState
+          Type: 58 PointerType *crypto/tls.ConnectionState
         - Name: Cancel
           Offset: 216
-          Type: 137 GoChannelType <-chan struct {}
+          Type: 60 GoChannelType <-chan struct {}
         - Name: Response
           Offset: 224
-          Type: 138 PointerType *net/http.Response
+          Type: 61 PointerType *net/http.Response
         - Name: Pattern
           Offset: 232
           Type: 9 GoStringHeaderType string
         - Name: ctx
           Offset: 248
-          Type: 140 GoInterfaceType context.Context
+          Type: 63 GoInterfaceType context.Context
         - Name: pat
           Offset: 264
-          Type: 141 PointerType *net/http.pattern
+          Type: 64 PointerType *net/http.pattern
         - Name: matches
           Offset: 272
           Type: 54 GoSliceHeaderType []string
         - Name: otherValues
           Offset: 296
-          Type: 146 GoMapType map[string]string
+          Type: 66 GoMapType map[string]string
     - __kind: StructureType
-      ID: 139
+      ID: 62
       Name: net/http.Response
       ByteSize: 144
       GoRuntimeType: 2.260416e+06
@@ -2750,10 +2750,10 @@ Types:
           Type: 7 BaseType int
         - Name: Header
           Offset: 56
-          Type: 43 GoMapType net/http.Header
+          Type: 47 GoMapType net/http.Header
         - Name: Body
           Offset: 64
-          Type: 55 GoInterfaceType io.ReadCloser
+          Type: 52 GoInterfaceType io.ReadCloser
         - Name: ContentLength
           Offset: 80
           Type: 12 BaseType int64
@@ -2768,13 +2768,13 @@ Types:
           Type: 4 BaseType bool
         - Name: Trailer
           Offset: 120
-          Type: 43 GoMapType net/http.Header
+          Type: 47 GoMapType net/http.Header
         - Name: Request
           Offset: 128
           Type: 37 PointerType *net/http.Request
         - Name: TLS
           Offset: 136
-          Type: 78 PointerType *crypto/tls.ConnectionState
+          Type: 58 PointerType *crypto/tls.ConnectionState
     - __kind: GoInterfaceType
       ID: 36
       Name: net/http.ResponseWriter
@@ -2789,7 +2789,7 @@ Types:
           Offset: 8
           Type: 14 VoidPointerType unsafe.Pointer
     - __kind: StructureType
-      ID: 142
+      ID: 65
       Name: net/http.pattern
       ByteSize: 88
       GoRuntimeType: 1.866368e+06
@@ -2806,12 +2806,12 @@ Types:
           Type: 9 GoStringHeaderType string
         - Name: segments
           Offset: 48
-          Type: 143 GoSliceHeaderType []net/http.segment
+          Type: 116 GoSliceHeaderType []net/http.segment
         - Name: loc
           Offset: 72
           Type: 9 GoStringHeaderType string
     - __kind: StructureType
-      ID: 145
+      ID: 118
       Name: net/http.segment
       ByteSize: 24
       GoRuntimeType: 1.6376e+06
@@ -2827,14 +2827,14 @@ Types:
           Offset: 17
           Type: 4 BaseType bool
     - __kind: GoMapType
-      ID: 76
+      ID: 223
       Name: net/textproto.MIMEHeader
       ByteSize: 8
       GoRuntimeType: 1.85488e+06
       GoKind: 21
-      HeaderType: 45 GoSwissMapHeaderType map<string,[]string>
+      HeaderType: 49 GoSwissMapHeaderType map<string,[]string>
     - __kind: StructureType
-      ID: 40
+      ID: 46
       Name: net/url.URL
       ByteSize: 144
       GoRuntimeType: 2.173728e+06
@@ -2848,7 +2848,7 @@ Types:
           Type: 9 GoStringHeaderType string
         - Name: User
           Offset: 32
-          Type: 41 PointerType *net/url.Userinfo
+          Type: 98 PointerType *net/url.Userinfo
         - Name: Host
           Offset: 40
           Type: 9 GoStringHeaderType string
@@ -2874,7 +2874,7 @@ Types:
           Offset: 128
           Type: 9 GoStringHeaderType string
     - __kind: StructureType
-      ID: 42
+      ID: 99
       Name: net/url.Userinfo
       ByteSize: 40
       GoRuntimeType: 1.653536e+06
@@ -2890,68 +2890,68 @@ Types:
           Offset: 32
           Type: 4 BaseType bool
     - __kind: GoMapType
-      ID: 57
+      ID: 55
       Name: net/url.Values
       ByteSize: 8
       GoRuntimeType: 1.9208e+06
       GoKind: 21
-      HeaderType: 45 GoSwissMapHeaderType map<string,[]string>
+      HeaderType: 49 GoSwissMapHeaderType map<string,[]string>
     - __kind: ArrayType
-      ID: 202
+      ID: 214
       Name: noalg.[8]struct { key string; elem *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute }
       ByteSize: 192
       GoRuntimeType: 711904
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 203 StructureType noalg.struct { key string; elem *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute }
+      Element: 215 StructureType noalg.struct { key string; elem *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute }
     - __kind: ArrayType
-      ID: 70
+      ID: 199
       Name: noalg.[8]struct { key string; elem []*mime/multipart.FileHeader }
       ByteSize: 320
       GoRuntimeType: 707328
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 71 StructureType noalg.struct { key string; elem []*mime/multipart.FileHeader }
+      Element: 200 StructureType noalg.struct { key string; elem []*mime/multipart.FileHeader }
     - __kind: ArrayType
-      ID: 52
+      ID: 149
       Name: noalg.[8]struct { key string; elem []string }
       ByteSize: 320
       GoRuntimeType: 697312
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 53 StructureType noalg.struct { key string; elem []string }
+      Element: 150 StructureType noalg.struct { key string; elem []string }
     - __kind: ArrayType
-      ID: 185
+      ID: 194
       Name: noalg.[8]struct { key string; elem float64 }
       ByteSize: 192
       GoRuntimeType: 711808
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 186 StructureType noalg.struct { key string; elem float64 }
+      Element: 195 StructureType noalg.struct { key string; elem float64 }
     - __kind: ArrayType
-      ID: 174
+      ID: 192
       Name: noalg.[8]struct { key string; elem interface {} }
       ByteSize: 256
       GoRuntimeType: 688768
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 175 StructureType noalg.struct { key string; elem interface {} }
+      Element: 193 StructureType noalg.struct { key string; elem interface {} }
     - __kind: ArrayType
-      ID: 155
+      ID: 190
       Name: noalg.[8]struct { key string; elem string }
       ByteSize: 256
       GoRuntimeType: 701472
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 156 StructureType noalg.struct { key string; elem string }
+      Element: 191 StructureType noalg.struct { key string; elem string }
     - __kind: StructureType
-      ID: 201
+      ID: 198
       Name: noalg.map.group[string]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
       ByteSize: 200
       GoRuntimeType: 1.327872e+06
@@ -2962,9 +2962,9 @@ Types:
           Type: 8 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 202 ArrayType noalg.[8]struct { key string; elem *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute }
+          Type: 214 ArrayType noalg.[8]struct { key string; elem *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute }
     - __kind: StructureType
-      ID: 69
+      ID: 153
       Name: noalg.map.group[string][]*mime/multipart.FileHeader
       ByteSize: 328
       GoRuntimeType: 1.3216e+06
@@ -2975,9 +2975,9 @@ Types:
           Type: 8 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 70 ArrayType noalg.[8]struct { key string; elem []*mime/multipart.FileHeader }
+          Type: 199 ArrayType noalg.[8]struct { key string; elem []*mime/multipart.FileHeader }
     - __kind: StructureType
-      ID: 51
+      ID: 133
       Name: noalg.map.group[string][]string
       ByteSize: 328
       GoRuntimeType: 1.312128e+06
@@ -2988,9 +2988,9 @@ Types:
           Type: 8 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 52 ArrayType noalg.[8]struct { key string; elem []string }
+          Type: 149 ArrayType noalg.[8]struct { key string; elem []string }
     - __kind: StructureType
-      ID: 184
+      ID: 144
       Name: noalg.map.group[string]float64
       ByteSize: 200
       GoRuntimeType: 1.327616e+06
@@ -3001,9 +3001,9 @@ Types:
           Type: 8 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 185 ArrayType noalg.[8]struct { key string; elem float64 }
+          Type: 194 ArrayType noalg.[8]struct { key string; elem float64 }
     - __kind: StructureType
-      ID: 173
+      ID: 141
       Name: noalg.map.group[string]interface {}
       ByteSize: 264
       GoRuntimeType: 1.309568e+06
@@ -3014,9 +3014,9 @@ Types:
           Type: 8 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 174 ArrayType noalg.[8]struct { key string; elem interface {} }
+          Type: 192 ArrayType noalg.[8]struct { key string; elem interface {} }
     - __kind: StructureType
-      ID: 154
+      ID: 138
       Name: noalg.map.group[string]string
       ByteSize: 264
       GoRuntimeType: 1.314432e+06
@@ -3027,9 +3027,9 @@ Types:
           Type: 8 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 155 ArrayType noalg.[8]struct { key string; elem string }
+          Type: 190 ArrayType noalg.[8]struct { key string; elem string }
     - __kind: StructureType
-      ID: 203
+      ID: 215
       Name: noalg.struct { key string; elem *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute }
       ByteSize: 24
       GoRuntimeType: 1.327744e+06
@@ -3040,9 +3040,9 @@ Types:
           Type: 9 GoStringHeaderType string
         - Name: elem
           Offset: 16
-          Type: 204 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
+          Type: 216 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
     - __kind: StructureType
-      ID: 71
+      ID: 200
       Name: noalg.struct { key string; elem []*mime/multipart.FileHeader }
       ByteSize: 40
       GoRuntimeType: 1.321472e+06
@@ -3053,9 +3053,9 @@ Types:
           Type: 9 GoStringHeaderType string
         - Name: elem
           Offset: 16
-          Type: 72 GoSliceHeaderType []*mime/multipart.FileHeader
+          Type: 201 GoSliceHeaderType []*mime/multipart.FileHeader
     - __kind: StructureType
-      ID: 53
+      ID: 150
       Name: noalg.struct { key string; elem []string }
       ByteSize: 40
       GoRuntimeType: 1.312e+06
@@ -3068,7 +3068,7 @@ Types:
           Offset: 16
           Type: 54 GoSliceHeaderType []string
     - __kind: StructureType
-      ID: 186
+      ID: 195
       Name: noalg.struct { key string; elem float64 }
       ByteSize: 24
       GoRuntimeType: 1.327488e+06
@@ -3081,7 +3081,7 @@ Types:
           Offset: 16
           Type: 18 BaseType float64
     - __kind: StructureType
-      ID: 175
+      ID: 193
       Name: noalg.struct { key string; elem interface {} }
       ByteSize: 32
       GoRuntimeType: 1.30944e+06
@@ -3092,9 +3092,9 @@ Types:
           Type: 9 GoStringHeaderType string
         - Name: elem
           Offset: 16
-          Type: 86 GoEmptyInterfaceType interface {}
+          Type: 156 GoEmptyInterfaceType interface {}
     - __kind: StructureType
-      ID: 156
+      ID: 191
       Name: noalg.struct { key string; elem string }
       ByteSize: 32
       GoRuntimeType: 1.314304e+06
@@ -3125,7 +3125,7 @@ Types:
       Name: string.str
       ByteSize: 2048
     - __kind: StructureType
-      ID: 160
+      ID: 72
       Name: sync.Mutex
       ByteSize: 8
       GoRuntimeType: 1.489632e+06
@@ -3133,12 +3133,12 @@ Types:
       RawFields:
         - Name: _
           Offset: 0
-          Type: 161 StructureType sync.noCopy
+          Type: 73 StructureType sync.noCopy
         - Name: mu
           Offset: 0
-          Type: 162 StructureType internal/sync.Mutex
+          Type: 74 StructureType internal/sync.Mutex
     - __kind: StructureType
-      ID: 159
+      ID: 71
       Name: sync.RWMutex
       ByteSize: 24
       GoRuntimeType: 1.872192e+06
@@ -3146,7 +3146,7 @@ Types:
       RawFields:
         - Name: w
           Offset: 0
-          Type: 160 StructureType sync.Mutex
+          Type: 72 StructureType sync.Mutex
         - Name: writerSem
           Offset: 8
           Type: 2 BaseType uint32
@@ -3155,18 +3155,18 @@ Types:
           Type: 2 BaseType uint32
         - Name: readerCount
           Offset: 16
-          Type: 163 StructureType sync/atomic.Int32
+          Type: 75 StructureType sync/atomic.Int32
         - Name: readerWait
           Offset: 20
-          Type: 163 StructureType sync/atomic.Int32
+          Type: 75 StructureType sync/atomic.Int32
     - __kind: StructureType
-      ID: 161
+      ID: 73
       Name: sync.noCopy
       GoRuntimeType: 1.003072e+06
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 163
+      ID: 75
       Name: sync/atomic.Int32
       ByteSize: 4
       GoRuntimeType: 1.490912e+06
@@ -3174,18 +3174,18 @@ Types:
       RawFields:
         - Name: _
           Offset: 0
-          Type: 164 StructureType sync/atomic.noCopy
+          Type: 76 StructureType sync/atomic.noCopy
         - Name: v
           Offset: 0
           Type: 10 BaseType int32
     - __kind: StructureType
-      ID: 164
+      ID: 76
       Name: sync/atomic.noCopy
       GoRuntimeType: 1.003168e+06
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 198
+      ID: 145
       Name: table<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
       ByteSize: 32
       GoKind: 25
@@ -3207,9 +3207,9 @@ Types:
           Type: 7 BaseType int
         - Name: groups
           Offset: 16
-          Type: 199 GoSwissMapGroupsType groupReference<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
+          Type: 196 GoSwissMapGroupsType groupReference<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
     - __kind: StructureType
-      ID: 66
+      ID: 134
       Name: table<string,[]*mime/multipart.FileHeader>
       ByteSize: 32
       GoKind: 25
@@ -3231,9 +3231,9 @@ Types:
           Type: 7 BaseType int
         - Name: groups
           Offset: 16
-          Type: 67 GoSwissMapGroupsType groupReference<string,[]*mime/multipart.FileHeader>
+          Type: 151 GoSwissMapGroupsType groupReference<string,[]*mime/multipart.FileHeader>
     - __kind: StructureType
-      ID: 48
+      ID: 100
       Name: table<string,[]string>
       ByteSize: 32
       GoKind: 25
@@ -3255,9 +3255,9 @@ Types:
           Type: 7 BaseType int
         - Name: groups
           Offset: 16
-          Type: 49 GoSwissMapGroupsType groupReference<string,[]string>
+          Type: 131 GoSwissMapGroupsType groupReference<string,[]string>
     - __kind: StructureType
-      ID: 181
+      ID: 121
       Name: table<string,float64>
       ByteSize: 32
       GoKind: 25
@@ -3279,9 +3279,9 @@ Types:
           Type: 7 BaseType int
         - Name: groups
           Offset: 16
-          Type: 182 GoSwissMapGroupsType groupReference<string,float64>
+          Type: 142 GoSwissMapGroupsType groupReference<string,float64>
     - __kind: StructureType
-      ID: 170
+      ID: 120
       Name: table<string,interface {}>
       ByteSize: 32
       GoKind: 25
@@ -3303,9 +3303,9 @@ Types:
           Type: 7 BaseType int
         - Name: groups
           Offset: 16
-          Type: 171 GoSwissMapGroupsType groupReference<string,interface {}>
+          Type: 139 GoSwissMapGroupsType groupReference<string,interface {}>
     - __kind: StructureType
-      ID: 151
+      ID: 119
       Name: table<string,string>
       ByteSize: 32
       GoKind: 25
@@ -3327,9 +3327,9 @@ Types:
           Type: 7 BaseType int
         - Name: groups
           Offset: 16
-          Type: 152 GoSwissMapGroupsType groupReference<string,string>
+          Type: 136 GoSwissMapGroupsType groupReference<string,string>
     - __kind: StructureType
-      ID: 99
+      ID: 165
       Name: time.Location
       ByteSize: 104
       GoRuntimeType: 2.006016e+06
@@ -3340,10 +3340,10 @@ Types:
           Type: 9 GoStringHeaderType string
         - Name: zone
           Offset: 16
-          Type: 100 GoSliceHeaderType []time.zone
+          Type: 207 GoSliceHeaderType []time.zone
         - Name: tx
           Offset: 40
-          Type: 103 GoSliceHeaderType []time.zoneTrans
+          Type: 210 GoSliceHeaderType []time.zoneTrans
         - Name: extend
           Offset: 64
           Type: 9 GoStringHeaderType string
@@ -3355,9 +3355,9 @@ Types:
           Type: 12 BaseType int64
         - Name: cacheZone
           Offset: 96
-          Type: 101 PointerType *time.zone
+          Type: 208 PointerType *time.zone
     - __kind: StructureType
-      ID: 97
+      ID: 163
       Name: time.Time
       ByteSize: 24
       GoRuntimeType: 2.424416e+06
@@ -3371,9 +3371,9 @@ Types:
           Type: 12 BaseType int64
         - Name: loc
           Offset: 16
-          Type: 98 PointerType *time.Location
+          Type: 164 PointerType *time.Location
     - __kind: StructureType
-      ID: 102
+      ID: 209
       Name: time.zone
       ByteSize: 32
       GoRuntimeType: 1.642592e+06
@@ -3389,7 +3389,7 @@ Types:
           Offset: 24
           Type: 4 BaseType bool
     - __kind: StructureType
-      ID: 105
+      ID: 212
       Name: time.zoneTrans
       ByteSize: 16
       GoRuntimeType: 1.781504e+06

--- a/pkg/dyninst/irgen/testdata/snapshot/rc_tester.arch=amd64,toolchain=go1.24.3.yaml
+++ b/pkg/dyninst/irgen/testdata/snapshot/rc_tester.arch=amd64,toolchain=go1.24.3.yaml
@@ -104,432 +104,438 @@ Subprograms:
           IsParameter: true
           IsReturn: false
 Types:
-    - __kind: GoInterfaceType
-      ID: 1
-      Name: net/http.ResponseWriter
-      ByteSize: 16
-      GoRuntimeType: 1.206848e+06
-      GoKind: 20
-      RawFields:
-        - Name: tab
-          Offset: 0
-          Type: 2 VoidPointerType unsafe.Pointer
-        - Name: data
-          Offset: 8
-          Type: 2 VoidPointerType unsafe.Pointer
-    - __kind: VoidPointerType
-      ID: 2
-      Name: unsafe.Pointer
-      ByteSize: 8
-      GoRuntimeType: 591456
-      GoKind: 26
     - __kind: PointerType
-      ID: 3
-      Name: '*net/http.Request'
+      ID: 57
+      Name: '**crypto/x509.Certificate'
       ByteSize: 8
-      GoRuntimeType: 2.360384e+06
       GoKind: 22
-      Pointee: 4 StructureType net/http.Request
-    - __kind: StructureType
-      ID: 4
-      Name: net/http.Request
-      ByteSize: 304
-      GoRuntimeType: 2.398144e+06
-      GoKind: 25
-      RawFields:
-        - Name: Method
-          Offset: 0
-          Type: 5 GoStringHeaderType string
-        - Name: URL
-          Offset: 16
-          Type: 9 PointerType *net/url.URL
-        - Name: Proto
-          Offset: 24
-          Type: 5 GoStringHeaderType string
-        - Name: ProtoMajor
-          Offset: 40
-          Type: 8 BaseType int
-        - Name: ProtoMinor
-          Offset: 48
-          Type: 8 BaseType int
-        - Name: Header
-          Offset: 56
-          Type: 14 GoMapType net/http.Header
-        - Name: Body
-          Offset: 64
-          Type: 30 GoInterfaceType io.ReadCloser
-        - Name: GetBody
-          Offset: 80
-          Type: 31 GoSubroutineType func() (io.ReadCloser, error)
-        - Name: ContentLength
-          Offset: 88
-          Type: 32 BaseType int64
-        - Name: TransferEncoding
-          Offset: 96
-          Type: 28 GoSliceHeaderType []string
-        - Name: Close
-          Offset: 120
-          Type: 13 BaseType bool
-        - Name: Host
-          Offset: 128
-          Type: 5 GoStringHeaderType string
-        - Name: Form
-          Offset: 144
-          Type: 33 GoMapType net/url.Values
-        - Name: PostForm
-          Offset: 152
-          Type: 33 GoMapType net/url.Values
-        - Name: MultipartForm
-          Offset: 160
-          Type: 34 PointerType *mime/multipart.Form
-        - Name: Trailer
-          Offset: 168
-          Type: 14 GoMapType net/http.Header
-        - Name: RemoteAddr
-          Offset: 176
-          Type: 5 GoStringHeaderType string
-        - Name: RequestURI
-          Offset: 192
-          Type: 5 GoStringHeaderType string
-        - Name: TLS
-          Offset: 208
-          Type: 54 PointerType *crypto/tls.ConnectionState
-        - Name: Cancel
-          Offset: 216
-          Type: 114 GoChannelType <-chan struct {}
-        - Name: Response
-          Offset: 224
-          Type: 115 PointerType *net/http.Response
-        - Name: Pattern
-          Offset: 232
-          Type: 5 GoStringHeaderType string
-        - Name: ctx
-          Offset: 248
-          Type: 117 GoInterfaceType context.Context
-        - Name: pat
-          Offset: 264
-          Type: 118 PointerType *net/http.pattern
-        - Name: matches
-          Offset: 272
-          Type: 28 GoSliceHeaderType []string
-        - Name: otherValues
-          Offset: 296
-          Type: 123 GoMapType map[string]string
-    - __kind: GoStringHeaderType
-      ID: 5
-      Name: string
-      ByteSize: 16
-      GoRuntimeType: 590368
-      GoKind: 24
-      RawFields:
-        - Name: str
-          Offset: 0
-          Type: 230 PointerType *string.str
-        - Name: len
-          Offset: 8
-          Type: 8 BaseType int
-      Data: 229 GoStringDataType string.str
+      Pointee: 58 PointerType *crypto/x509.Certificate
     - __kind: PointerType
-      ID: 6
-      Name: '*uint8'
+      ID: 200
+      Name: '**github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span'
       ByteSize: 8
-      GoRuntimeType: 401824
       GoKind: 22
-      Pointee: 7 BaseType uint8
-    - __kind: BaseType
-      ID: 7
-      Name: uint8
-      ByteSize: 1
-      GoRuntimeType: 590496
-      GoKind: 8
-    - __kind: BaseType
-      ID: 8
-      Name: int
-      ByteSize: 8
-      GoRuntimeType: 590944
-      GoKind: 2
+      Pointee: 134 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span
     - __kind: PointerType
-      ID: 9
-      Name: '*net/url.URL'
+      ID: 190
+      Name: '**github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttributeValue'
       ByteSize: 8
-      GoRuntimeType: 2.16048e+06
       GoKind: 22
-      Pointee: 10 StructureType net/url.URL
-    - __kind: StructureType
-      ID: 10
-      Name: net/url.URL
-      ByteSize: 144
-      GoRuntimeType: 2.173728e+06
-      GoKind: 25
-      RawFields:
-        - Name: Scheme
-          Offset: 0
-          Type: 5 GoStringHeaderType string
-        - Name: Opaque
-          Offset: 16
-          Type: 5 GoStringHeaderType string
-        - Name: User
-          Offset: 32
-          Type: 11 PointerType *net/url.Userinfo
-        - Name: Host
-          Offset: 40
-          Type: 5 GoStringHeaderType string
-        - Name: Path
-          Offset: 56
-          Type: 5 GoStringHeaderType string
-        - Name: RawPath
-          Offset: 72
-          Type: 5 GoStringHeaderType string
-        - Name: OmitHost
-          Offset: 88
-          Type: 13 BaseType bool
-        - Name: ForceQuery
-          Offset: 89
-          Type: 13 BaseType bool
-        - Name: RawQuery
-          Offset: 96
-          Type: 5 GoStringHeaderType string
-        - Name: Fragment
-          Offset: 112
-          Type: 5 GoStringHeaderType string
-        - Name: RawFragment
-          Offset: 128
-          Type: 5 GoStringHeaderType string
+      Pointee: 191 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttributeValue
     - __kind: PointerType
-      ID: 11
-      Name: '*net/url.Userinfo'
+      ID: 49
+      Name: '**mime/multipart.FileHeader'
       ByteSize: 8
-      GoRuntimeType: 1.222208e+06
       GoKind: 22
-      Pointee: 12 StructureType net/url.Userinfo
-    - __kind: StructureType
-      ID: 12
-      Name: net/url.Userinfo
-      ByteSize: 40
-      GoRuntimeType: 1.653536e+06
-      GoKind: 25
-      RawFields:
-        - Name: username
-          Offset: 0
-          Type: 5 GoStringHeaderType string
-        - Name: password
-          Offset: 16
-          Type: 5 GoStringHeaderType string
-        - Name: passwordSet
-          Offset: 32
-          Type: 13 BaseType bool
-    - __kind: BaseType
-      ID: 13
-      Name: bool
-      ByteSize: 1
-      GoRuntimeType: 591392
-      GoKind: 1
-    - __kind: GoMapType
-      ID: 14
-      Name: net/http.Header
-      ByteSize: 8
-      GoRuntimeType: 2.148192e+06
-      GoKind: 21
-      HeaderType: 16 GoSwissMapHeaderType map<string,[]string>
+      Pointee: 50 PointerType *mime/multipart.FileHeader
     - __kind: PointerType
-      ID: 15
-      Name: '*map<string,[]string>'
+      ID: 98
+      Name: '**net.IPNet'
       ByteSize: 8
-      Pointee: 16 GoSwissMapHeaderType map<string,[]string>
-    - __kind: GoSwissMapHeaderType
-      ID: 16
-      Name: map<string,[]string>
-      ByteSize: 48
-      GoKind: 25
-      RawFields:
-        - Name: used
-          Offset: 0
-          Type: 17 BaseType uint64
-        - Name: seed
-          Offset: 8
-          Type: 18 BaseType uintptr
-        - Name: dirPtr
-          Offset: 16
-          Type: 19 PointerType **table<string,[]string>
-        - Name: dirLen
-          Offset: 24
-          Type: 8 BaseType int
-        - Name: globalDepth
-          Offset: 32
-          Type: 7 BaseType uint8
-        - Name: globalShift
-          Offset: 33
-          Type: 7 BaseType uint8
-        - Name: writing
-          Offset: 34
-          Type: 7 BaseType uint8
-        - Name: clearSeq
-          Offset: 40
-          Type: 17 BaseType uint64
-      TablePtrSliceType: 231 GoSliceDataType []*table<string,[]string>.array
-      GroupType: 25 StructureType noalg.map.group[string][]string
-    - __kind: BaseType
-      ID: 17
-      Name: uint64
+      GoKind: 22
+      Pointee: 99 PointerType *net.IPNet
+    - __kind: PointerType
+      ID: 96
+      Name: '**net/url.URL'
       ByteSize: 8
-      GoRuntimeType: 590880
-      GoKind: 11
-    - __kind: BaseType
-      ID: 18
-      Name: uintptr
+      GoKind: 22
+      Pointee: 9 PointerType *net/url.URL
+    - __kind: PointerType
+      ID: 176
+      Name: '**table<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>'
       ByteSize: 8
-      GoRuntimeType: 591072
-      GoKind: 12
+      Pointee: 177 PointerType *table<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
+    - __kind: PointerType
+      ID: 40
+      Name: '**table<string,[]*mime/multipart.FileHeader>'
+      ByteSize: 8
+      Pointee: 41 PointerType *table<string,[]*mime/multipart.FileHeader>
     - __kind: PointerType
       ID: 19
       Name: '**table<string,[]string>'
       ByteSize: 8
       Pointee: 20 PointerType *table<string,[]string>
     - __kind: PointerType
-      ID: 20
-      Name: '*table<string,[]string>'
+      ID: 158
+      Name: '**table<string,float64>'
       ByteSize: 8
-      Pointee: 21 StructureType table<string,[]string>
-    - __kind: StructureType
-      ID: 21
-      Name: table<string,[]string>
-      ByteSize: 32
-      GoKind: 25
-      RawFields:
-        - Name: used
-          Offset: 0
-          Type: 22 BaseType uint16
-        - Name: capacity
-          Offset: 2
-          Type: 22 BaseType uint16
-        - Name: growthLeft
-          Offset: 4
-          Type: 22 BaseType uint16
-        - Name: localDepth
-          Offset: 6
-          Type: 7 BaseType uint8
-        - Name: index
-          Offset: 8
-          Type: 8 BaseType int
-        - Name: groups
-          Offset: 16
-          Type: 23 GoSwissMapGroupsType groupReference<string,[]string>
-    - __kind: BaseType
-      ID: 22
-      Name: uint16
-      ByteSize: 2
-      GoRuntimeType: 590624
-      GoKind: 9
-    - __kind: GoSwissMapGroupsType
-      ID: 23
-      Name: groupReference<string,[]string>
-      ByteSize: 16
-      GoKind: 25
-      RawFields:
-        - Name: data
-          Offset: 0
-          Type: 24 PointerType *noalg.map.group[string][]string
-        - Name: lengthMask
-          Offset: 8
-          Type: 17 BaseType uint64
-      GroupType: 25 StructureType noalg.map.group[string][]string
-      GroupSliceType: 232 GoSliceDataType []noalg.map.group[string][]string.array
+      Pointee: 159 PointerType *table<string,float64>
     - __kind: PointerType
-      ID: 24
-      Name: '*noalg.map.group[string][]string'
+      ID: 147
+      Name: '**table<string,interface {}>'
       ByteSize: 8
-      Pointee: 25 StructureType noalg.map.group[string][]string
-    - __kind: StructureType
-      ID: 25
-      Name: noalg.map.group[string][]string
-      ByteSize: 328
-      GoRuntimeType: 1.312128e+06
-      GoKind: 25
-      RawFields:
-        - Name: ctrl
-          Offset: 0
-          Type: 17 BaseType uint64
-        - Name: slots
-          Offset: 8
-          Type: 26 ArrayType noalg.[8]struct { key string; elem []string }
-    - __kind: ArrayType
-      ID: 26
-      Name: noalg.[8]struct { key string; elem []string }
-      ByteSize: 320
-      GoRuntimeType: 697312
-      GoKind: 17
-      Count: 8
-      HasCount: true
-      Element: 27 StructureType noalg.struct { key string; elem []string }
-    - __kind: StructureType
-      ID: 27
-      Name: noalg.struct { key string; elem []string }
-      ByteSize: 40
-      GoRuntimeType: 1.312e+06
-      GoKind: 25
-      RawFields:
-        - Name: key
-          Offset: 0
-          Type: 5 GoStringHeaderType string
-        - Name: elem
-          Offset: 16
-          Type: 28 GoSliceHeaderType []string
-    - __kind: GoSliceHeaderType
-      ID: 28
-      Name: '[]string'
-      ByteSize: 24
-      GoRuntimeType: 498176
-      GoKind: 23
-      RawFields:
-        - Name: array
-          Offset: 0
-          Type: 29 PointerType *string
-        - Name: len
-          Offset: 8
-          Type: 8 BaseType int
-        - Name: cap
-          Offset: 16
-          Type: 8 BaseType int
-      Data: 233 GoSliceDataType []string.array
+      Pointee: 148 PointerType *table<string,interface {}>
     - __kind: PointerType
-      ID: 29
-      Name: '*string'
+      ID: 126
+      Name: '**table<string,string>'
       ByteSize: 8
-      GoRuntimeType: 401696
+      Pointee: 127 PointerType *table<string,string>
+    - __kind: PointerType
+      ID: 109
+      Name: '*[]*crypto/x509.Certificate'
+      ByteSize: 8
       GoKind: 22
-      Pointee: 5 GoStringHeaderType string
-    - __kind: GoInterfaceType
-      ID: 30
-      Name: io.ReadCloser
-      ByteSize: 16
-      GoRuntimeType: 1.130304e+06
-      GoKind: 20
-      RawFields:
-        - Name: tab
-          Offset: 0
-          Type: 2 VoidPointerType unsafe.Pointer
-        - Name: data
-          Offset: 8
-          Type: 2 VoidPointerType unsafe.Pointer
-    - __kind: GoSubroutineType
-      ID: 31
-      Name: func() (io.ReadCloser, error)
+      Pointee: 56 GoSliceHeaderType []*crypto/x509.Certificate
+    - __kind: PointerType
+      ID: 242
+      Name: '*[]*crypto/x509.Certificate.array'
       ByteSize: 8
-      GoRuntimeType: 701280
-      GoKind: 19
-    - __kind: BaseType
-      ID: 32
-      Name: int64
+      Pointee: 241 GoSliceDataType []*crypto/x509.Certificate.array
+    - __kind: PointerType
+      ID: 294
+      Name: '*[]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span.array'
       ByteSize: 8
-      GoRuntimeType: 590816
-      GoKind: 6
-    - __kind: GoMapType
-      ID: 33
-      Name: net/url.Values
+      Pointee: 293 GoSliceDataType []*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span.array
+    - __kind: PointerType
+      ID: 292
+      Name: '*[]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttributeValue.array'
       ByteSize: 8
-      GoRuntimeType: 1.9208e+06
-      GoKind: 21
-      HeaderType: 16 GoSwissMapHeaderType map<string,[]string>
+      Pointee: 291 GoSliceDataType []*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttributeValue.array
+    - __kind: PointerType
+      ID: 238
+      Name: '*[]*mime/multipart.FileHeader.array'
+      ByteSize: 8
+      Pointee: 237 GoSliceDataType []*mime/multipart.FileHeader.array
+    - __kind: PointerType
+      ID: 266
+      Name: '*[]*net.IPNet.array'
+      ByteSize: 8
+      Pointee: 265 GoSliceDataType []*net.IPNet.array
+    - __kind: PointerType
+      ID: 264
+      Name: '*[]*net/url.URL.array'
+      ByteSize: 8
+      Pointee: 263 GoSliceDataType []*net/url.URL.array
+    - __kind: PointerType
+      ID: 274
+      Name: '*[][]*crypto/x509.Certificate.array'
+      ByteSize: 8
+      Pointee: 273 GoSliceDataType [][]*crypto/x509.Certificate.array
+    - __kind: PointerType
+      ID: 276
+      Name: '*[][]uint8.array'
+      ByteSize: 8
+      Pointee: 275 GoSliceDataType [][]uint8.array
+    - __kind: PointerType
+      ID: 258
+      Name: '*[]crypto/x509.ExtKeyUsage.array'
+      ByteSize: 8
+      Pointee: 257 GoSliceDataType []crypto/x509.ExtKeyUsage.array
+    - __kind: PointerType
+      ID: 270
+      Name: '*[]crypto/x509.OID.array'
+      ByteSize: 8
+      Pointee: 269 GoSliceDataType []crypto/x509.OID.array
+    - __kind: PointerType
+      ID: 272
+      Name: '*[]crypto/x509.PolicyMapping.array'
+      ByteSize: 8
+      Pointee: 271 GoSliceDataType []crypto/x509.PolicyMapping.array
+    - __kind: PointerType
+      ID: 246
+      Name: '*[]crypto/x509/pkix.AttributeTypeAndValue.array'
+      ByteSize: 8
+      Pointee: 245 GoSliceDataType []crypto/x509/pkix.AttributeTypeAndValue.array
+    - __kind: PointerType
+      ID: 254
+      Name: '*[]crypto/x509/pkix.Extension.array'
+      ByteSize: 8
+      Pointee: 253 GoSliceDataType []crypto/x509/pkix.Extension.array
+    - __kind: PointerType
+      ID: 256
+      Name: '*[]encoding/asn1.ObjectIdentifier.array'
+      ByteSize: 8
+      Pointee: 255 GoSliceDataType []encoding/asn1.ObjectIdentifier.array
+    - __kind: PointerType
+      ID: 286
+      Name: '*[]github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink.array'
+      ByteSize: 8
+      Pointee: 285 GoSliceDataType []github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink.array
+    - __kind: PointerType
+      ID: 288
+      Name: '*[]github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent.array'
+      ByteSize: 8
+      Pointee: 287 GoSliceDataType []github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent.array
+    - __kind: PointerType
+      ID: 260
+      Name: '*[]net.IP.array'
+      ByteSize: 8
+      Pointee: 259 GoSliceDataType []net.IP.array
+    - __kind: PointerType
+      ID: 278
+      Name: '*[]net/http.segment.array'
+      ByteSize: 8
+      Pointee: 277 GoSliceDataType []net/http.segment.array
+    - __kind: PointerType
+      ID: 234
+      Name: '*[]string.array'
+      ByteSize: 8
+      Pointee: 233 GoSliceDataType []string.array
+    - __kind: PointerType
+      ID: 250
+      Name: '*[]time.zone.array'
+      ByteSize: 8
+      Pointee: 249 GoSliceDataType []time.zone.array
+    - __kind: PointerType
+      ID: 252
+      Name: '*[]time.zoneTrans.array'
+      ByteSize: 8
+      Pointee: 251 GoSliceDataType []time.zoneTrans.array
+    - __kind: PointerType
+      ID: 111
+      Name: '*[]uint8'
+      ByteSize: 8
+      GoRuntimeType: 483552
+      GoKind: 22
+      Pointee: 53 GoSliceHeaderType []uint8
+    - __kind: PointerType
+      ID: 240
+      Name: '*[]uint8.array'
+      ByteSize: 8
+      Pointee: 239 GoSliceDataType []uint8.array
+    - __kind: PointerType
+      ID: 210
+      Name: '*bool'
+      ByteSize: 8
+      GoRuntimeType: 402720
+      GoKind: 22
+      Pointee: 13 BaseType bool
+    - __kind: PointerType
+      ID: 205
+      Name: '*bytes.Buffer'
+      ByteSize: 8
+      GoRuntimeType: 2.316768e+06
+      GoKind: 22
+      Pointee: 206 StructureType bytes.Buffer
+    - __kind: PointerType
+      ID: 54
+      Name: '*crypto/tls.ConnectionState'
+      ByteSize: 8
+      GoRuntimeType: 919424
+      GoKind: 22
+      Pointee: 55 StructureType crypto/tls.ConnectionState
+    - __kind: PointerType
+      ID: 58
+      Name: '*crypto/x509.Certificate'
+      ByteSize: 8
+      GoRuntimeType: 2.082688e+06
+      GoKind: 22
+      Pointee: 59 StructureType crypto/x509.Certificate
+    - __kind: PointerType
+      ID: 90
+      Name: '*crypto/x509.ExtKeyUsage'
+      ByteSize: 8
+      GoRuntimeType: 426912
+      GoKind: 22
+      Pointee: 91 BaseType crypto/x509.ExtKeyUsage
+    - __kind: PointerType
+      ID: 103
+      Name: '*crypto/x509.OID'
+      ByteSize: 8
+      GoRuntimeType: 1.989632e+06
+      GoKind: 22
+      Pointee: 104 StructureType crypto/x509.OID
+    - __kind: PointerType
+      ID: 106
+      Name: '*crypto/x509.PolicyMapping'
+      ByteSize: 8
+      GoRuntimeType: 426976
+      GoKind: 22
+      Pointee: 107 StructureType crypto/x509.PolicyMapping
+    - __kind: PointerType
+      ID: 70
+      Name: '*crypto/x509/pkix.AttributeTypeAndValue'
+      ByteSize: 8
+      GoRuntimeType: 443680
+      GoKind: 22
+      Pointee: 71 StructureType crypto/x509/pkix.AttributeTypeAndValue
+    - __kind: PointerType
+      ID: 85
+      Name: '*crypto/x509/pkix.Extension'
+      ByteSize: 8
+      GoRuntimeType: 443872
+      GoKind: 22
+      Pointee: 86 StructureType crypto/x509/pkix.Extension
+    - __kind: PointerType
+      ID: 88
+      Name: '*encoding/asn1.ObjectIdentifier'
+      ByteSize: 8
+      GoRuntimeType: 1.0752e+06
+      GoKind: 22
+      Pointee: 72 GoSliceHeaderType encoding/asn1.ObjectIdentifier
+    - __kind: PointerType
+      ID: 248
+      Name: '*encoding/asn1.ObjectIdentifier.array'
+      ByteSize: 8
+      Pointee: 247 GoSliceDataType encoding/asn1.ObjectIdentifier.array
+    - __kind: PointerType
+      ID: 226
+      Name: '*error'
+      ByteSize: 8
+      GoRuntimeType: 401632
+      GoKind: 22
+      Pointee: 211 GoInterfaceType error
+    - __kind: PointerType
+      ID: 228
+      Name: '*float32'
+      ByteSize: 8
+      GoRuntimeType: 402592
+      GoKind: 22
+      Pointee: 214 BaseType float32
+    - __kind: PointerType
+      ID: 201
+      Name: '*float64'
+      ByteSize: 8
+      GoRuntimeType: 402656
+      GoKind: 22
+      Pointee: 166 BaseType float64
+    - __kind: PointerType
+      ID: 134
+      Name: '*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span'
+      ByteSize: 8
+      GoRuntimeType: 2.32752e+06
+      GoKind: 22
+      Pointee: 135 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span
+    - __kind: PointerType
+      ID: 195
+      Name: '*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanContext'
+      ByteSize: 8
+      GoRuntimeType: 2.046208e+06
+      GoKind: 22
+      Pointee: 196 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanContext
+    - __kind: PointerType
+      ID: 168
+      Name: '*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink'
+      ByteSize: 8
+      GoRuntimeType: 1.210688e+06
+      GoKind: 22
+      Pointee: 169 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink
+    - __kind: PointerType
+      ID: 171
+      Name: '*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent'
+      ByteSize: 8
+      GoRuntimeType: 1.210816e+06
+      GoKind: 22
+      Pointee: 172 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent
+    - __kind: PointerType
+      ID: 187
+      Name: '*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttribute'
+      ByteSize: 8
+      GoRuntimeType: 1.211456e+06
+      GoKind: 22
+      Pointee: 188 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttribute
+    - __kind: PointerType
+      ID: 191
+      Name: '*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttributeValue'
+      ByteSize: 8
+      GoRuntimeType: 1.2112e+06
+      GoKind: 22
+      Pointee: 192 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttributeValue
+    - __kind: PointerType
+      ID: 184
+      Name: '*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute'
+      ByteSize: 8
+      GoRuntimeType: 1.211584e+06
+      GoKind: 22
+      Pointee: 185 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
+    - __kind: PointerType
+      ID: 197
+      Name: '*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.trace'
+      ByteSize: 8
+      GoRuntimeType: 2.27024e+06
+      GoKind: 22
+      Pointee: 198 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.trace
+    - __kind: PointerType
+      ID: 73
+      Name: '*int'
+      ByteSize: 8
+      GoRuntimeType: 402272
+      GoKind: 22
+      Pointee: 8 BaseType int
+    - __kind: PointerType
+      ID: 223
+      Name: '*int16'
+      ByteSize: 8
+      GoRuntimeType: 401888
+      GoKind: 22
+      Pointee: 224 BaseType int16
+    - __kind: PointerType
+      ID: 216
+      Name: '*int32'
+      ByteSize: 8
+      GoRuntimeType: 402016
+      GoKind: 22
+      Pointee: 140 BaseType int32
+    - __kind: PointerType
+      ID: 220
+      Name: '*int64'
+      ByteSize: 8
+      GoRuntimeType: 402144
+      GoKind: 22
+      Pointee: 32 BaseType int64
+    - __kind: PointerType
+      ID: 225
+      Name: '*int8'
+      ByteSize: 8
+      GoRuntimeType: 401760
+      GoKind: 22
+      Pointee: 212 BaseType int8
+    - __kind: PointerType
+      ID: 174
+      Name: '*map<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>'
+      ByteSize: 8
+      Pointee: 175 GoSwissMapHeaderType map<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
+    - __kind: PointerType
+      ID: 38
+      Name: '*map<string,[]*mime/multipart.FileHeader>'
+      ByteSize: 8
+      Pointee: 39 GoSwissMapHeaderType map<string,[]*mime/multipart.FileHeader>
+    - __kind: PointerType
+      ID: 15
+      Name: '*map<string,[]string>'
+      ByteSize: 8
+      Pointee: 16 GoSwissMapHeaderType map<string,[]string>
+    - __kind: PointerType
+      ID: 156
+      Name: '*map<string,float64>'
+      ByteSize: 8
+      Pointee: 157 GoSwissMapHeaderType map<string,float64>
+    - __kind: PointerType
+      ID: 145
+      Name: '*map<string,interface {}>'
+      ByteSize: 8
+      Pointee: 146 GoSwissMapHeaderType map<string,interface {}>
+    - __kind: PointerType
+      ID: 124
+      Name: '*map<string,string>'
+      ByteSize: 8
+      Pointee: 125 GoSwissMapHeaderType map<string,string>
+    - __kind: PointerType
+      ID: 63
+      Name: '*math/big.Int'
+      ByteSize: 8
+      GoRuntimeType: 2.440832e+06
+      GoKind: 22
+      Pointee: 64 StructureType math/big.Int
+    - __kind: PointerType
+      ID: 66
+      Name: '*math/big.Word'
+      ByteSize: 8
+      GoRuntimeType: 429856
+      GoKind: 22
+      Pointee: 67 BaseType math/big.Word
+    - __kind: PointerType
+      ID: 244
+      Name: '*math/big.nat.array'
+      ByteSize: 8
+      Pointee: 243 GoSliceDataType math/big.nat.array
+    - __kind: PointerType
+      ID: 50
+      Name: '*mime/multipart.FileHeader'
+      ByteSize: 8
+      GoRuntimeType: 920864
+      GoKind: 22
+      Pointee: 51 StructureType mime/multipart.FileHeader
     - __kind: PointerType
       ID: 34
       Name: '*mime/multipart.Form'
@@ -537,158 +543,317 @@ Types:
       GoRuntimeType: 920960
       GoKind: 22
       Pointee: 35 StructureType mime/multipart.Form
-    - __kind: StructureType
-      ID: 35
-      Name: mime/multipart.Form
-      ByteSize: 16
-      GoRuntimeType: 1.501472e+06
-      GoKind: 25
-      RawFields:
-        - Name: Value
-          Offset: 0
-          Type: 36 GoMapType map[string][]string
-        - Name: File
-          Offset: 8
-          Type: 37 GoMapType map[string][]*mime/multipart.FileHeader
-    - __kind: GoMapType
-      ID: 36
-      Name: map[string][]string
-      ByteSize: 8
-      GoRuntimeType: 1.148352e+06
-      GoKind: 21
-      HeaderType: 16 GoSwissMapHeaderType map<string,[]string>
-    - __kind: GoMapType
-      ID: 37
-      Name: map[string][]*mime/multipart.FileHeader
-      ByteSize: 8
-      GoRuntimeType: 1.15296e+06
-      GoKind: 21
-      HeaderType: 39 GoSwissMapHeaderType map<string,[]*mime/multipart.FileHeader>
     - __kind: PointerType
-      ID: 38
-      Name: '*map<string,[]*mime/multipart.FileHeader>'
+      ID: 93
+      Name: '*net.IP'
       ByteSize: 8
-      Pointee: 39 GoSwissMapHeaderType map<string,[]*mime/multipart.FileHeader>
-    - __kind: GoSwissMapHeaderType
-      ID: 39
-      Name: map<string,[]*mime/multipart.FileHeader>
-      ByteSize: 48
-      GoKind: 25
-      RawFields:
-        - Name: used
-          Offset: 0
-          Type: 17 BaseType uint64
-        - Name: seed
-          Offset: 8
-          Type: 18 BaseType uintptr
-        - Name: dirPtr
-          Offset: 16
-          Type: 40 PointerType **table<string,[]*mime/multipart.FileHeader>
-        - Name: dirLen
-          Offset: 24
-          Type: 8 BaseType int
-        - Name: globalDepth
-          Offset: 32
-          Type: 7 BaseType uint8
-        - Name: globalShift
-          Offset: 33
-          Type: 7 BaseType uint8
-        - Name: writing
-          Offset: 34
-          Type: 7 BaseType uint8
-        - Name: clearSeq
-          Offset: 40
-          Type: 17 BaseType uint64
-      TablePtrSliceType: 235 GoSliceDataType []*table<string,[]*mime/multipart.FileHeader>.array
-      GroupType: 45 StructureType noalg.map.group[string][]*mime/multipart.FileHeader
+      GoRuntimeType: 2.198272e+06
+      GoKind: 22
+      Pointee: 94 GoSliceHeaderType net.IP
     - __kind: PointerType
-      ID: 40
-      Name: '**table<string,[]*mime/multipart.FileHeader>'
+      ID: 262
+      Name: '*net.IP.array'
       ByteSize: 8
-      Pointee: 41 PointerType *table<string,[]*mime/multipart.FileHeader>
+      Pointee: 261 GoSliceDataType net.IP.array
     - __kind: PointerType
-      ID: 41
-      Name: '*table<string,[]*mime/multipart.FileHeader>'
+      ID: 268
+      Name: '*net.IPMask.array'
       ByteSize: 8
-      Pointee: 42 StructureType table<string,[]*mime/multipart.FileHeader>
-    - __kind: StructureType
-      ID: 42
-      Name: table<string,[]*mime/multipart.FileHeader>
-      ByteSize: 32
-      GoKind: 25
-      RawFields:
-        - Name: used
-          Offset: 0
-          Type: 22 BaseType uint16
-        - Name: capacity
-          Offset: 2
-          Type: 22 BaseType uint16
-        - Name: growthLeft
-          Offset: 4
-          Type: 22 BaseType uint16
-        - Name: localDepth
-          Offset: 6
-          Type: 7 BaseType uint8
-        - Name: index
-          Offset: 8
-          Type: 8 BaseType int
-        - Name: groups
-          Offset: 16
-          Type: 43 GoSwissMapGroupsType groupReference<string,[]*mime/multipart.FileHeader>
-    - __kind: GoSwissMapGroupsType
-      ID: 43
-      Name: groupReference<string,[]*mime/multipart.FileHeader>
-      ByteSize: 16
-      GoKind: 25
-      RawFields:
-        - Name: data
-          Offset: 0
-          Type: 44 PointerType *noalg.map.group[string][]*mime/multipart.FileHeader
-        - Name: lengthMask
-          Offset: 8
-          Type: 17 BaseType uint64
-      GroupType: 45 StructureType noalg.map.group[string][]*mime/multipart.FileHeader
-      GroupSliceType: 236 GoSliceDataType []noalg.map.group[string][]*mime/multipart.FileHeader.array
+      Pointee: 267 GoSliceDataType net.IPMask.array
+    - __kind: PointerType
+      ID: 99
+      Name: '*net.IPNet'
+      ByteSize: 8
+      GoRuntimeType: 1.204416e+06
+      GoKind: 22
+      Pointee: 100 StructureType net.IPNet
+    - __kind: PointerType
+      ID: 3
+      Name: '*net/http.Request'
+      ByteSize: 8
+      GoRuntimeType: 2.360384e+06
+      GoKind: 22
+      Pointee: 4 StructureType net/http.Request
+    - __kind: PointerType
+      ID: 115
+      Name: '*net/http.Response'
+      ByteSize: 8
+      GoRuntimeType: 1.751392e+06
+      GoKind: 22
+      Pointee: 116 StructureType net/http.Response
+    - __kind: PointerType
+      ID: 118
+      Name: '*net/http.pattern'
+      ByteSize: 8
+      GoRuntimeType: 1.637792e+06
+      GoKind: 22
+      Pointee: 119 StructureType net/http.pattern
+    - __kind: PointerType
+      ID: 121
+      Name: '*net/http.segment'
+      ByteSize: 8
+      GoRuntimeType: 393504
+      GoKind: 22
+      Pointee: 122 StructureType net/http.segment
+    - __kind: PointerType
+      ID: 9
+      Name: '*net/url.URL'
+      ByteSize: 8
+      GoRuntimeType: 2.16048e+06
+      GoKind: 22
+      Pointee: 10 StructureType net/url.URL
+    - __kind: PointerType
+      ID: 11
+      Name: '*net/url.Userinfo'
+      ByteSize: 8
+      GoRuntimeType: 1.222208e+06
+      GoKind: 22
+      Pointee: 12 StructureType net/url.Userinfo
+    - __kind: PointerType
+      ID: 180
+      Name: '*noalg.map.group[string]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute'
+      ByteSize: 8
+      Pointee: 181 StructureType noalg.map.group[string]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
     - __kind: PointerType
       ID: 44
       Name: '*noalg.map.group[string][]*mime/multipart.FileHeader'
       ByteSize: 8
       Pointee: 45 StructureType noalg.map.group[string][]*mime/multipart.FileHeader
-    - __kind: StructureType
-      ID: 45
-      Name: noalg.map.group[string][]*mime/multipart.FileHeader
-      ByteSize: 328
-      GoRuntimeType: 1.3216e+06
-      GoKind: 25
+    - __kind: PointerType
+      ID: 24
+      Name: '*noalg.map.group[string][]string'
+      ByteSize: 8
+      Pointee: 25 StructureType noalg.map.group[string][]string
+    - __kind: PointerType
+      ID: 162
+      Name: '*noalg.map.group[string]float64'
+      ByteSize: 8
+      Pointee: 163 StructureType noalg.map.group[string]float64
+    - __kind: PointerType
+      ID: 151
+      Name: '*noalg.map.group[string]interface {}'
+      ByteSize: 8
+      Pointee: 152 StructureType noalg.map.group[string]interface {}
+    - __kind: PointerType
+      ID: 130
+      Name: '*noalg.map.group[string]string'
+      ByteSize: 8
+      Pointee: 131 StructureType noalg.map.group[string]string
+    - __kind: PointerType
+      ID: 29
+      Name: '*string'
+      ByteSize: 8
+      GoRuntimeType: 401696
+      GoKind: 22
+      Pointee: 5 GoStringHeaderType string
+    - __kind: PointerType
+      ID: 230
+      Name: '*string.str'
+      ByteSize: 8
+      Pointee: 229 GoStringDataType string.str
+    - __kind: PointerType
+      ID: 177
+      Name: '*table<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>'
+      ByteSize: 8
+      Pointee: 178 StructureType table<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
+    - __kind: PointerType
+      ID: 41
+      Name: '*table<string,[]*mime/multipart.FileHeader>'
+      ByteSize: 8
+      Pointee: 42 StructureType table<string,[]*mime/multipart.FileHeader>
+    - __kind: PointerType
+      ID: 20
+      Name: '*table<string,[]string>'
+      ByteSize: 8
+      Pointee: 21 StructureType table<string,[]string>
+    - __kind: PointerType
+      ID: 159
+      Name: '*table<string,float64>'
+      ByteSize: 8
+      Pointee: 160 StructureType table<string,float64>
+    - __kind: PointerType
+      ID: 148
+      Name: '*table<string,interface {}>'
+      ByteSize: 8
+      Pointee: 149 StructureType table<string,interface {}>
+    - __kind: PointerType
+      ID: 127
+      Name: '*table<string,string>'
+      ByteSize: 8
+      Pointee: 128 StructureType table<string,string>
+    - __kind: PointerType
+      ID: 75
+      Name: '*time.Location'
+      ByteSize: 8
+      GoRuntimeType: 1.642784e+06
+      GoKind: 22
+      Pointee: 76 StructureType time.Location
+    - __kind: PointerType
+      ID: 78
+      Name: '*time.zone'
+      ByteSize: 8
+      GoRuntimeType: 396640
+      GoKind: 22
+      Pointee: 79 StructureType time.zone
+    - __kind: PointerType
+      ID: 81
+      Name: '*time.zoneTrans'
+      ByteSize: 8
+      GoRuntimeType: 396704
+      GoKind: 22
+      Pointee: 82 StructureType time.zoneTrans
+    - __kind: PointerType
+      ID: 227
+      Name: '*uint'
+      ByteSize: 8
+      GoRuntimeType: 402336
+      GoKind: 22
+      Pointee: 213 BaseType uint
+    - __kind: PointerType
+      ID: 222
+      Name: '*uint16'
+      ByteSize: 8
+      GoRuntimeType: 401952
+      GoKind: 22
+      Pointee: 22 BaseType uint16
+    - __kind: PointerType
+      ID: 217
+      Name: '*uint32'
+      ByteSize: 8
+      GoRuntimeType: 402080
+      GoKind: 22
+      Pointee: 141 BaseType uint32
+    - __kind: PointerType
+      ID: 221
+      Name: '*uint64'
+      ByteSize: 8
+      GoRuntimeType: 402208
+      GoKind: 22
+      Pointee: 17 BaseType uint64
+    - __kind: PointerType
+      ID: 6
+      Name: '*uint8'
+      ByteSize: 8
+      GoRuntimeType: 401824
+      GoKind: 22
+      Pointee: 7 BaseType uint8
+    - __kind: PointerType
+      ID: 215
+      Name: '*uintptr'
+      ByteSize: 8
+      GoRuntimeType: 402400
+      GoKind: 22
+      Pointee: 18 BaseType uintptr
+    - __kind: GoChannelType
+      ID: 114
+      Name: <-chan struct {}
+      GoRuntimeType: 603424
+      GoKind: 18
+    - __kind: EventRootType
+      ID: 295
+      Name: Probe[main.HandleHTTP]
+      ByteSize: 25
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: w
+          Offset: 1
+          Expression:
+            Type: 1 GoInterfaceType net/http.ResponseWriter
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 1, index: 0, name: w}
+                  Offset: 0
+                  ByteSize: 16
+        - Name: r
+          Offset: 17
+          Expression:
+            Type: 3 PointerType *net/http.Request
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 1, index: 1, name: r}
+                  Offset: 0
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 296
+      Name: Probe[main.LookAtTheRequest]
+      ByteSize: 17
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: path
+          Offset: 1
+          Expression:
+            Type: 5 GoStringHeaderType string
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 2, index: 0, name: path}
+                  Offset: 0
+                  ByteSize: 16
+    - __kind: GoSliceHeaderType
+      ID: 56
+      Name: '[]*crypto/x509.Certificate'
+      ByteSize: 24
+      GoRuntimeType: 503808
+      GoKind: 23
       RawFields:
-        - Name: ctrl
+        - Name: array
           Offset: 0
-          Type: 17 BaseType uint64
-        - Name: slots
+          Type: 57 PointerType **crypto/x509.Certificate
+        - Name: len
           Offset: 8
-          Type: 46 ArrayType noalg.[8]struct { key string; elem []*mime/multipart.FileHeader }
-    - __kind: ArrayType
-      ID: 46
-      Name: noalg.[8]struct { key string; elem []*mime/multipart.FileHeader }
-      ByteSize: 320
-      GoRuntimeType: 707328
-      GoKind: 17
-      Count: 8
-      HasCount: true
-      Element: 47 StructureType noalg.struct { key string; elem []*mime/multipart.FileHeader }
-    - __kind: StructureType
-      ID: 47
-      Name: noalg.struct { key string; elem []*mime/multipart.FileHeader }
-      ByteSize: 40
-      GoRuntimeType: 1.321472e+06
-      GoKind: 25
-      RawFields:
-        - Name: key
-          Offset: 0
-          Type: 5 GoStringHeaderType string
-        - Name: elem
+          Type: 8 BaseType int
+        - Name: cap
           Offset: 16
-          Type: 48 GoSliceHeaderType []*mime/multipart.FileHeader
+          Type: 8 BaseType int
+      Data: 241 GoSliceDataType []*crypto/x509.Certificate.array
+    - __kind: GoSliceDataType
+      ID: 241
+      Name: '[]*crypto/x509.Certificate.array'
+      ByteSize: 2048
+      Element: 58 PointerType *crypto/x509.Certificate
+    - __kind: GoSliceHeaderType
+      ID: 199
+      Name: '[]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span'
+      ByteSize: 24
+      GoRuntimeType: 491968
+      GoKind: 23
+      RawFields:
+        - Name: array
+          Offset: 0
+          Type: 200 PointerType **github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span
+        - Name: len
+          Offset: 8
+          Type: 8 BaseType int
+        - Name: cap
+          Offset: 16
+          Type: 8 BaseType int
+      Data: 293 GoSliceDataType []*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span.array
+    - __kind: GoSliceDataType
+      ID: 293
+      Name: '[]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span.array'
+      ByteSize: 2048
+      Element: 134 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span
+    - __kind: GoSliceHeaderType
+      ID: 189
+      Name: '[]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttributeValue'
+      ByteSize: 24
+      GoRuntimeType: 491584
+      GoKind: 23
+      RawFields:
+        - Name: array
+          Offset: 0
+          Type: 190 PointerType **github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttributeValue
+        - Name: len
+          Offset: 8
+          Type: 8 BaseType int
+        - Name: cap
+          Offset: 16
+          Type: 8 BaseType int
+      Data: 291 GoSliceDataType []*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttributeValue.array
+    - __kind: GoSliceDataType
+      ID: 291
+      Name: '[]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttributeValue.array'
+      ByteSize: 2048
+      Element: 191 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttributeValue
     - __kind: GoSliceHeaderType
       ID: 48
       Name: '[]*mime/multipart.FileHeader'
@@ -706,54 +871,445 @@ Types:
           Offset: 16
           Type: 8 BaseType int
       Data: 237 GoSliceDataType []*mime/multipart.FileHeader.array
-    - __kind: PointerType
-      ID: 49
-      Name: '**mime/multipart.FileHeader'
-      ByteSize: 8
-      GoKind: 22
-      Pointee: 50 PointerType *mime/multipart.FileHeader
-    - __kind: PointerType
-      ID: 50
-      Name: '*mime/multipart.FileHeader'
-      ByteSize: 8
-      GoRuntimeType: 920864
-      GoKind: 22
-      Pointee: 51 StructureType mime/multipart.FileHeader
-    - __kind: StructureType
-      ID: 51
-      Name: mime/multipart.FileHeader
-      ByteSize: 88
-      GoRuntimeType: 2.010048e+06
-      GoKind: 25
+    - __kind: GoSliceDataType
+      ID: 237
+      Name: '[]*mime/multipart.FileHeader.array'
+      ByteSize: 2048
+      Element: 50 PointerType *mime/multipart.FileHeader
+    - __kind: GoSliceHeaderType
+      ID: 97
+      Name: '[]*net.IPNet'
+      ByteSize: 24
+      GoRuntimeType: 518592
+      GoKind: 23
       RawFields:
-        - Name: Filename
+        - Name: array
           Offset: 0
-          Type: 5 GoStringHeaderType string
-        - Name: Header
+          Type: 98 PointerType **net.IPNet
+        - Name: len
+          Offset: 8
+          Type: 8 BaseType int
+        - Name: cap
           Offset: 16
-          Type: 52 GoMapType net/textproto.MIMEHeader
-        - Name: Size
-          Offset: 24
-          Type: 32 BaseType int64
-        - Name: content
-          Offset: 32
-          Type: 53 GoSliceHeaderType []uint8
-        - Name: tmpfile
-          Offset: 56
-          Type: 5 GoStringHeaderType string
-        - Name: tmpoff
-          Offset: 72
-          Type: 32 BaseType int64
-        - Name: tmpshared
-          Offset: 80
-          Type: 13 BaseType bool
-    - __kind: GoMapType
-      ID: 52
-      Name: net/textproto.MIMEHeader
-      ByteSize: 8
-      GoRuntimeType: 1.85488e+06
-      GoKind: 21
-      HeaderType: 16 GoSwissMapHeaderType map<string,[]string>
+          Type: 8 BaseType int
+      Data: 265 GoSliceDataType []*net.IPNet.array
+    - __kind: GoSliceDataType
+      ID: 265
+      Name: '[]*net.IPNet.array'
+      ByteSize: 2048
+      Element: 99 PointerType *net.IPNet
+    - __kind: GoSliceHeaderType
+      ID: 95
+      Name: '[]*net/url.URL'
+      ByteSize: 24
+      GoRuntimeType: 518528
+      GoKind: 23
+      RawFields:
+        - Name: array
+          Offset: 0
+          Type: 96 PointerType **net/url.URL
+        - Name: len
+          Offset: 8
+          Type: 8 BaseType int
+        - Name: cap
+          Offset: 16
+          Type: 8 BaseType int
+      Data: 263 GoSliceDataType []*net/url.URL.array
+    - __kind: GoSliceDataType
+      ID: 263
+      Name: '[]*net/url.URL.array'
+      ByteSize: 2048
+      Element: 9 PointerType *net/url.URL
+    - __kind: GoSliceDataType
+      ID: 289
+      Name: '[]*table<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>.array'
+      ByteSize: 8192
+      Element: 177 PointerType *table<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
+    - __kind: GoSliceDataType
+      ID: 235
+      Name: '[]*table<string,[]*mime/multipart.FileHeader>.array'
+      ByteSize: 8192
+      Element: 41 PointerType *table<string,[]*mime/multipart.FileHeader>
+    - __kind: GoSliceDataType
+      ID: 231
+      Name: '[]*table<string,[]string>.array'
+      ByteSize: 8192
+      Element: 20 PointerType *table<string,[]string>
+    - __kind: GoSliceDataType
+      ID: 283
+      Name: '[]*table<string,float64>.array'
+      ByteSize: 8192
+      Element: 159 PointerType *table<string,float64>
+    - __kind: GoSliceDataType
+      ID: 281
+      Name: '[]*table<string,interface {}>.array'
+      ByteSize: 8192
+      Element: 148 PointerType *table<string,interface {}>
+    - __kind: GoSliceDataType
+      ID: 279
+      Name: '[]*table<string,string>.array'
+      ByteSize: 8192
+      Element: 127 PointerType *table<string,string>
+    - __kind: GoSliceHeaderType
+      ID: 108
+      Name: '[][]*crypto/x509.Certificate'
+      ByteSize: 24
+      GoRuntimeType: 503936
+      GoKind: 23
+      RawFields:
+        - Name: array
+          Offset: 0
+          Type: 109 PointerType *[]*crypto/x509.Certificate
+        - Name: len
+          Offset: 8
+          Type: 8 BaseType int
+        - Name: cap
+          Offset: 16
+          Type: 8 BaseType int
+      Data: 273 GoSliceDataType [][]*crypto/x509.Certificate.array
+    - __kind: GoSliceDataType
+      ID: 273
+      Name: '[][]*crypto/x509.Certificate.array'
+      ByteSize: 2048
+      Element: 56 GoSliceHeaderType []*crypto/x509.Certificate
+    - __kind: GoSliceHeaderType
+      ID: 110
+      Name: '[][]uint8'
+      ByteSize: 24
+      GoRuntimeType: 483936
+      GoKind: 23
+      RawFields:
+        - Name: array
+          Offset: 0
+          Type: 111 PointerType *[]uint8
+        - Name: len
+          Offset: 8
+          Type: 8 BaseType int
+        - Name: cap
+          Offset: 16
+          Type: 8 BaseType int
+      Data: 275 GoSliceDataType [][]uint8.array
+    - __kind: GoSliceDataType
+      ID: 275
+      Name: '[][]uint8.array'
+      ByteSize: 2048
+      Element: 53 GoSliceHeaderType []uint8
+    - __kind: GoSliceHeaderType
+      ID: 89
+      Name: '[]crypto/x509.ExtKeyUsage'
+      ByteSize: 24
+      GoRuntimeType: 505280
+      GoKind: 23
+      RawFields:
+        - Name: array
+          Offset: 0
+          Type: 90 PointerType *crypto/x509.ExtKeyUsage
+        - Name: len
+          Offset: 8
+          Type: 8 BaseType int
+        - Name: cap
+          Offset: 16
+          Type: 8 BaseType int
+      Data: 257 GoSliceDataType []crypto/x509.ExtKeyUsage.array
+    - __kind: GoSliceDataType
+      ID: 257
+      Name: '[]crypto/x509.ExtKeyUsage.array'
+      ByteSize: 2048
+      Element: 91 BaseType crypto/x509.ExtKeyUsage
+    - __kind: GoSliceHeaderType
+      ID: 102
+      Name: '[]crypto/x509.OID'
+      ByteSize: 24
+      GoRuntimeType: 518656
+      GoKind: 23
+      RawFields:
+        - Name: array
+          Offset: 0
+          Type: 103 PointerType *crypto/x509.OID
+        - Name: len
+          Offset: 8
+          Type: 8 BaseType int
+        - Name: cap
+          Offset: 16
+          Type: 8 BaseType int
+      Data: 269 GoSliceDataType []crypto/x509.OID.array
+    - __kind: GoSliceDataType
+      ID: 269
+      Name: '[]crypto/x509.OID.array'
+      ByteSize: 2048
+      Element: 104 StructureType crypto/x509.OID
+    - __kind: GoSliceHeaderType
+      ID: 105
+      Name: '[]crypto/x509.PolicyMapping'
+      ByteSize: 24
+      GoRuntimeType: 518720
+      GoKind: 23
+      RawFields:
+        - Name: array
+          Offset: 0
+          Type: 106 PointerType *crypto/x509.PolicyMapping
+        - Name: len
+          Offset: 8
+          Type: 8 BaseType int
+        - Name: cap
+          Offset: 16
+          Type: 8 BaseType int
+      Data: 271 GoSliceDataType []crypto/x509.PolicyMapping.array
+    - __kind: GoSliceDataType
+      ID: 271
+      Name: '[]crypto/x509.PolicyMapping.array'
+      ByteSize: 2048
+      Element: 107 StructureType crypto/x509.PolicyMapping
+    - __kind: GoSliceHeaderType
+      ID: 69
+      Name: '[]crypto/x509/pkix.AttributeTypeAndValue'
+      ByteSize: 24
+      GoRuntimeType: 519168
+      GoKind: 23
+      RawFields:
+        - Name: array
+          Offset: 0
+          Type: 70 PointerType *crypto/x509/pkix.AttributeTypeAndValue
+        - Name: len
+          Offset: 8
+          Type: 8 BaseType int
+        - Name: cap
+          Offset: 16
+          Type: 8 BaseType int
+      Data: 245 GoSliceDataType []crypto/x509/pkix.AttributeTypeAndValue.array
+    - __kind: GoSliceDataType
+      ID: 245
+      Name: '[]crypto/x509/pkix.AttributeTypeAndValue.array'
+      ByteSize: 2048
+      Element: 71 StructureType crypto/x509/pkix.AttributeTypeAndValue
+    - __kind: GoSliceHeaderType
+      ID: 84
+      Name: '[]crypto/x509/pkix.Extension'
+      ByteSize: 24
+      GoRuntimeType: 518400
+      GoKind: 23
+      RawFields:
+        - Name: array
+          Offset: 0
+          Type: 85 PointerType *crypto/x509/pkix.Extension
+        - Name: len
+          Offset: 8
+          Type: 8 BaseType int
+        - Name: cap
+          Offset: 16
+          Type: 8 BaseType int
+      Data: 253 GoSliceDataType []crypto/x509/pkix.Extension.array
+    - __kind: GoSliceDataType
+      ID: 253
+      Name: '[]crypto/x509/pkix.Extension.array'
+      ByteSize: 2048
+      Element: 86 StructureType crypto/x509/pkix.Extension
+    - __kind: GoSliceHeaderType
+      ID: 87
+      Name: '[]encoding/asn1.ObjectIdentifier'
+      ByteSize: 24
+      GoRuntimeType: 518464
+      GoKind: 23
+      RawFields:
+        - Name: array
+          Offset: 0
+          Type: 88 PointerType *encoding/asn1.ObjectIdentifier
+        - Name: len
+          Offset: 8
+          Type: 8 BaseType int
+        - Name: cap
+          Offset: 16
+          Type: 8 BaseType int
+      Data: 255 GoSliceDataType []encoding/asn1.ObjectIdentifier.array
+    - __kind: GoSliceDataType
+      ID: 255
+      Name: '[]encoding/asn1.ObjectIdentifier.array'
+      ByteSize: 2048
+      Element: 72 GoSliceHeaderType encoding/asn1.ObjectIdentifier
+    - __kind: GoSliceHeaderType
+      ID: 167
+      Name: '[]github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink'
+      ByteSize: 24
+      GoRuntimeType: 491520
+      GoKind: 23
+      RawFields:
+        - Name: array
+          Offset: 0
+          Type: 168 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink
+        - Name: len
+          Offset: 8
+          Type: 8 BaseType int
+        - Name: cap
+          Offset: 16
+          Type: 8 BaseType int
+      Data: 285 GoSliceDataType []github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink.array
+    - __kind: GoSliceDataType
+      ID: 285
+      Name: '[]github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink.array'
+      ByteSize: 2048
+      Element: 169 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink
+    - __kind: GoSliceHeaderType
+      ID: 170
+      Name: '[]github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent'
+      ByteSize: 24
+      GoRuntimeType: 491712
+      GoKind: 23
+      RawFields:
+        - Name: array
+          Offset: 0
+          Type: 171 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent
+        - Name: len
+          Offset: 8
+          Type: 8 BaseType int
+        - Name: cap
+          Offset: 16
+          Type: 8 BaseType int
+      Data: 287 GoSliceDataType []github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent.array
+    - __kind: GoSliceDataType
+      ID: 287
+      Name: '[]github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent.array'
+      ByteSize: 2048
+      Element: 172 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent
+    - __kind: GoSliceHeaderType
+      ID: 92
+      Name: '[]net.IP'
+      ByteSize: 24
+      GoRuntimeType: 484896
+      GoKind: 23
+      RawFields:
+        - Name: array
+          Offset: 0
+          Type: 93 PointerType *net.IP
+        - Name: len
+          Offset: 8
+          Type: 8 BaseType int
+        - Name: cap
+          Offset: 16
+          Type: 8 BaseType int
+      Data: 259 GoSliceDataType []net.IP.array
+    - __kind: GoSliceDataType
+      ID: 259
+      Name: '[]net.IP.array'
+      ByteSize: 2048
+      Element: 94 GoSliceHeaderType net.IP
+    - __kind: GoSliceHeaderType
+      ID: 120
+      Name: '[]net/http.segment'
+      ByteSize: 24
+      GoRuntimeType: 486528
+      GoKind: 23
+      RawFields:
+        - Name: array
+          Offset: 0
+          Type: 121 PointerType *net/http.segment
+        - Name: len
+          Offset: 8
+          Type: 8 BaseType int
+        - Name: cap
+          Offset: 16
+          Type: 8 BaseType int
+      Data: 277 GoSliceDataType []net/http.segment.array
+    - __kind: GoSliceDataType
+      ID: 277
+      Name: '[]net/http.segment.array'
+      ByteSize: 2048
+      Element: 122 StructureType net/http.segment
+    - __kind: GoSliceDataType
+      ID: 290
+      Name: '[]noalg.map.group[string]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute.array'
+      ByteSize: 2048
+      Element: 181 StructureType noalg.map.group[string]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
+    - __kind: GoSliceDataType
+      ID: 236
+      Name: '[]noalg.map.group[string][]*mime/multipart.FileHeader.array'
+      ByteSize: 2048
+      Element: 45 StructureType noalg.map.group[string][]*mime/multipart.FileHeader
+    - __kind: GoSliceDataType
+      ID: 232
+      Name: '[]noalg.map.group[string][]string.array'
+      ByteSize: 2048
+      Element: 25 StructureType noalg.map.group[string][]string
+    - __kind: GoSliceDataType
+      ID: 284
+      Name: '[]noalg.map.group[string]float64.array'
+      ByteSize: 2048
+      Element: 163 StructureType noalg.map.group[string]float64
+    - __kind: GoSliceDataType
+      ID: 282
+      Name: '[]noalg.map.group[string]interface {}.array'
+      ByteSize: 2048
+      Element: 152 StructureType noalg.map.group[string]interface {}
+    - __kind: GoSliceDataType
+      ID: 280
+      Name: '[]noalg.map.group[string]string.array'
+      ByteSize: 2048
+      Element: 131 StructureType noalg.map.group[string]string
+    - __kind: GoSliceHeaderType
+      ID: 28
+      Name: '[]string'
+      ByteSize: 24
+      GoRuntimeType: 498176
+      GoKind: 23
+      RawFields:
+        - Name: array
+          Offset: 0
+          Type: 29 PointerType *string
+        - Name: len
+          Offset: 8
+          Type: 8 BaseType int
+        - Name: cap
+          Offset: 16
+          Type: 8 BaseType int
+      Data: 233 GoSliceDataType []string.array
+    - __kind: GoSliceDataType
+      ID: 233
+      Name: '[]string.array'
+      ByteSize: 2048
+      Element: 5 GoStringHeaderType string
+    - __kind: GoSliceHeaderType
+      ID: 77
+      Name: '[]time.zone'
+      ByteSize: 24
+      GoRuntimeType: 491072
+      GoKind: 23
+      RawFields:
+        - Name: array
+          Offset: 0
+          Type: 78 PointerType *time.zone
+        - Name: len
+          Offset: 8
+          Type: 8 BaseType int
+        - Name: cap
+          Offset: 16
+          Type: 8 BaseType int
+      Data: 249 GoSliceDataType []time.zone.array
+    - __kind: GoSliceDataType
+      ID: 249
+      Name: '[]time.zone.array'
+      ByteSize: 2048
+      Element: 79 StructureType time.zone
+    - __kind: GoSliceHeaderType
+      ID: 80
+      Name: '[]time.zoneTrans'
+      ByteSize: 24
+      GoRuntimeType: 491136
+      GoKind: 23
+      RawFields:
+        - Name: array
+          Offset: 0
+          Type: 81 PointerType *time.zoneTrans
+        - Name: len
+          Offset: 8
+          Type: 8 BaseType int
+        - Name: cap
+          Offset: 16
+          Type: 8 BaseType int
+      Data: 251 GoSliceDataType []time.zoneTrans.array
+    - __kind: GoSliceDataType
+      ID: 251
+      Name: '[]time.zoneTrans.array'
+      ByteSize: 2048
+      Element: 82 StructureType time.zoneTrans
     - __kind: GoSliceHeaderType
       ID: 53
       Name: '[]uint8'
@@ -771,13 +1327,79 @@ Types:
           Offset: 16
           Type: 8 BaseType int
       Data: 239 GoSliceDataType []uint8.array
-    - __kind: PointerType
-      ID: 54
-      Name: '*crypto/tls.ConnectionState'
+    - __kind: GoSliceDataType
+      ID: 239
+      Name: '[]uint8.array'
+      ByteSize: 2048
+      Element: 7 BaseType uint8
+    - __kind: BaseType
+      ID: 13
+      Name: bool
+      ByteSize: 1
+      GoRuntimeType: 591392
+      GoKind: 1
+    - __kind: StructureType
+      ID: 206
+      Name: bytes.Buffer
+      ByteSize: 40
+      GoRuntimeType: 1.635488e+06
+      GoKind: 25
+      RawFields:
+        - Name: buf
+          Offset: 0
+          Type: 53 GoSliceHeaderType []uint8
+        - Name: off
+          Offset: 24
+          Type: 8 BaseType int
+        - Name: lastRead
+          Offset: 32
+          Type: 207 BaseType bytes.readOp
+    - __kind: BaseType
+      ID: 207
+      Name: bytes.readOp
+      ByteSize: 1
+      GoRuntimeType: 589536
+      GoKind: 3
+    - __kind: BaseType
+      ID: 219
+      Name: complex128
+      ByteSize: 16
+      GoRuntimeType: 591200
+      GoKind: 16
+    - __kind: BaseType
+      ID: 218
+      Name: complex64
       ByteSize: 8
-      GoRuntimeType: 919424
-      GoKind: 22
-      Pointee: 55 StructureType crypto/tls.ConnectionState
+      GoRuntimeType: 591136
+      GoKind: 15
+    - __kind: GoInterfaceType
+      ID: 117
+      Name: context.Context
+      ByteSize: 16
+      GoRuntimeType: 1.298688e+06
+      GoKind: 20
+      RawFields:
+        - Name: tab
+          Offset: 0
+          Type: 2 VoidPointerType unsafe.Pointer
+        - Name: data
+          Offset: 8
+          Type: 2 VoidPointerType unsafe.Pointer
+    - __kind: StructureType
+      ID: 208
+      Name: context.backgroundCtx
+      GoRuntimeType: 1.827296e+06
+      GoKind: 25
+      RawFields:
+        - Name: emptyCtx
+          Offset: 0
+          Type: 209 StructureType context.emptyCtx
+    - __kind: StructureType
+      ID: 209
+      Name: context.emptyCtx
+      GoRuntimeType: 1.618752e+06
+      GoKind: 25
+      RawFields: []
     - __kind: StructureType
       ID: 55
       Name: crypto/tls.ConnectionState
@@ -833,36 +1455,12 @@ Types:
         - Name: testingOnlyCurveID
           Offset: 186
           Type: 113 BaseType crypto/tls.CurveID
-    - __kind: GoSliceHeaderType
-      ID: 56
-      Name: '[]*crypto/x509.Certificate'
-      ByteSize: 24
-      GoRuntimeType: 503808
-      GoKind: 23
-      RawFields:
-        - Name: array
-          Offset: 0
-          Type: 57 PointerType **crypto/x509.Certificate
-        - Name: len
-          Offset: 8
-          Type: 8 BaseType int
-        - Name: cap
-          Offset: 16
-          Type: 8 BaseType int
-      Data: 241 GoSliceDataType []*crypto/x509.Certificate.array
-    - __kind: PointerType
-      ID: 57
-      Name: '**crypto/x509.Certificate'
-      ByteSize: 8
-      GoKind: 22
-      Pointee: 58 PointerType *crypto/x509.Certificate
-    - __kind: PointerType
-      ID: 58
-      Name: '*crypto/x509.Certificate'
-      ByteSize: 8
-      GoRuntimeType: 2.082688e+06
-      GoKind: 22
-      Pointee: 59 StructureType crypto/x509.Certificate
+    - __kind: BaseType
+      ID: 113
+      Name: crypto/tls.CurveID
+      ByteSize: 2
+      GoRuntimeType: 843936
+      GoKind: 9
     - __kind: StructureType
       ID: 59
       Name: crypto/x509.Certificate
@@ -1027,80 +1625,81 @@ Types:
           Offset: 1400
           Type: 105 GoSliceHeaderType []crypto/x509.PolicyMapping
     - __kind: BaseType
-      ID: 60
-      Name: crypto/x509.SignatureAlgorithm
+      ID: 91
+      Name: crypto/x509.ExtKeyUsage
       ByteSize: 8
-      GoRuntimeType: 1.134784e+06
+      GoRuntimeType: 594464
       GoKind: 2
+    - __kind: BaseType
+      ID: 83
+      Name: crypto/x509.KeyUsage
+      ByteSize: 8
+      GoRuntimeType: 594400
+      GoKind: 2
+    - __kind: StructureType
+      ID: 104
+      Name: crypto/x509.OID
+      ByteSize: 24
+      GoRuntimeType: 1.989888e+06
+      GoKind: 25
+      RawFields:
+        - Name: der
+          Offset: 0
+          Type: 53 GoSliceHeaderType []uint8
+    - __kind: StructureType
+      ID: 107
+      Name: crypto/x509.PolicyMapping
+      ByteSize: 48
+      GoRuntimeType: 1.515072e+06
+      GoKind: 25
+      RawFields:
+        - Name: IssuerDomainPolicy
+          Offset: 0
+          Type: 104 StructureType crypto/x509.OID
+        - Name: SubjectDomainPolicy
+          Offset: 24
+          Type: 104 StructureType crypto/x509.OID
     - __kind: BaseType
       ID: 61
       Name: crypto/x509.PublicKeyAlgorithm
       ByteSize: 8
       GoRuntimeType: 846240
       GoKind: 2
-    - __kind: GoEmptyInterfaceType
-      ID: 62
-      Name: interface {}
-      ByteSize: 16
-      GoRuntimeType: 863648
-      GoKind: 20
-      RawFields:
-        - Name: _type
-          Offset: 0
-          Type: 2 VoidPointerType unsafe.Pointer
-        - Name: data
-          Offset: 8
-          Type: 2 VoidPointerType unsafe.Pointer
-    - __kind: PointerType
-      ID: 63
-      Name: '*math/big.Int'
+    - __kind: BaseType
+      ID: 60
+      Name: crypto/x509.SignatureAlgorithm
       ByteSize: 8
-      GoRuntimeType: 2.440832e+06
-      GoKind: 22
-      Pointee: 64 StructureType math/big.Int
+      GoRuntimeType: 1.134784e+06
+      GoKind: 2
     - __kind: StructureType
-      ID: 64
-      Name: math/big.Int
-      ByteSize: 32
-      GoRuntimeType: 1.518112e+06
+      ID: 71
+      Name: crypto/x509/pkix.AttributeTypeAndValue
+      ByteSize: 40
+      GoRuntimeType: 1.527392e+06
       GoKind: 25
       RawFields:
-        - Name: neg
+        - Name: Type
           Offset: 0
-          Type: 13 BaseType bool
-        - Name: abs
-          Offset: 8
-          Type: 65 GoSliceHeaderType math/big.nat
-    - __kind: GoSliceHeaderType
-      ID: 65
-      Name: math/big.nat
-      ByteSize: 24
-      GoRuntimeType: 2.4216e+06
-      GoKind: 23
+          Type: 72 GoSliceHeaderType encoding/asn1.ObjectIdentifier
+        - Name: Value
+          Offset: 24
+          Type: 62 GoEmptyInterfaceType interface {}
+    - __kind: StructureType
+      ID: 86
+      Name: crypto/x509/pkix.Extension
+      ByteSize: 56
+      GoRuntimeType: 1.678688e+06
+      GoKind: 25
       RawFields:
-        - Name: array
+        - Name: Id
           Offset: 0
-          Type: 66 PointerType *math/big.Word
-        - Name: len
-          Offset: 8
-          Type: 8 BaseType int
-        - Name: cap
-          Offset: 16
-          Type: 8 BaseType int
-      Data: 243 GoSliceDataType math/big.nat.array
-    - __kind: PointerType
-      ID: 66
-      Name: '*math/big.Word'
-      ByteSize: 8
-      GoRuntimeType: 429856
-      GoKind: 22
-      Pointee: 67 BaseType math/big.Word
-    - __kind: BaseType
-      ID: 67
-      Name: math/big.Word
-      ByteSize: 8
-      GoRuntimeType: 594656
-      GoKind: 7
+          Type: 72 GoSliceHeaderType encoding/asn1.ObjectIdentifier
+        - Name: Critical
+          Offset: 24
+          Type: 13 BaseType bool
+        - Name: Value
+          Offset: 32
+          Type: 53 GoSliceHeaderType []uint8
     - __kind: StructureType
       ID: 68
       Name: crypto/x509/pkix.Name
@@ -1142,43 +1741,6 @@ Types:
           Offset: 224
           Type: 69 GoSliceHeaderType []crypto/x509/pkix.AttributeTypeAndValue
     - __kind: GoSliceHeaderType
-      ID: 69
-      Name: '[]crypto/x509/pkix.AttributeTypeAndValue'
-      ByteSize: 24
-      GoRuntimeType: 519168
-      GoKind: 23
-      RawFields:
-        - Name: array
-          Offset: 0
-          Type: 70 PointerType *crypto/x509/pkix.AttributeTypeAndValue
-        - Name: len
-          Offset: 8
-          Type: 8 BaseType int
-        - Name: cap
-          Offset: 16
-          Type: 8 BaseType int
-      Data: 245 GoSliceDataType []crypto/x509/pkix.AttributeTypeAndValue.array
-    - __kind: PointerType
-      ID: 70
-      Name: '*crypto/x509/pkix.AttributeTypeAndValue'
-      ByteSize: 8
-      GoRuntimeType: 443680
-      GoKind: 22
-      Pointee: 71 StructureType crypto/x509/pkix.AttributeTypeAndValue
-    - __kind: StructureType
-      ID: 71
-      Name: crypto/x509/pkix.AttributeTypeAndValue
-      ByteSize: 40
-      GoRuntimeType: 1.527392e+06
-      GoKind: 25
-      RawFields:
-        - Name: Type
-          Offset: 0
-          Type: 72 GoSliceHeaderType encoding/asn1.ObjectIdentifier
-        - Name: Value
-          Offset: 24
-          Type: 62 GoEmptyInterfaceType interface {}
-    - __kind: GoSliceHeaderType
       ID: 72
       Name: encoding/asn1.ObjectIdentifier
       ByteSize: 24
@@ -1195,567 +1757,16 @@ Types:
           Offset: 16
           Type: 8 BaseType int
       Data: 247 GoSliceDataType encoding/asn1.ObjectIdentifier.array
-    - __kind: PointerType
-      ID: 73
-      Name: '*int'
-      ByteSize: 8
-      GoRuntimeType: 402272
-      GoKind: 22
-      Pointee: 8 BaseType int
-    - __kind: StructureType
-      ID: 74
-      Name: time.Time
-      ByteSize: 24
-      GoRuntimeType: 2.424416e+06
-      GoKind: 25
-      RawFields:
-        - Name: wall
-          Offset: 0
-          Type: 17 BaseType uint64
-        - Name: ext
-          Offset: 8
-          Type: 32 BaseType int64
-        - Name: loc
-          Offset: 16
-          Type: 75 PointerType *time.Location
-    - __kind: PointerType
-      ID: 75
-      Name: '*time.Location'
-      ByteSize: 8
-      GoRuntimeType: 1.642784e+06
-      GoKind: 22
-      Pointee: 76 StructureType time.Location
-    - __kind: StructureType
-      ID: 76
-      Name: time.Location
-      ByteSize: 104
-      GoRuntimeType: 2.006016e+06
-      GoKind: 25
-      RawFields:
-        - Name: name
-          Offset: 0
-          Type: 5 GoStringHeaderType string
-        - Name: zone
-          Offset: 16
-          Type: 77 GoSliceHeaderType []time.zone
-        - Name: tx
-          Offset: 40
-          Type: 80 GoSliceHeaderType []time.zoneTrans
-        - Name: extend
-          Offset: 64
-          Type: 5 GoStringHeaderType string
-        - Name: cacheStart
-          Offset: 80
-          Type: 32 BaseType int64
-        - Name: cacheEnd
-          Offset: 88
-          Type: 32 BaseType int64
-        - Name: cacheZone
-          Offset: 96
-          Type: 78 PointerType *time.zone
-    - __kind: GoSliceHeaderType
-      ID: 77
-      Name: '[]time.zone'
-      ByteSize: 24
-      GoRuntimeType: 491072
-      GoKind: 23
-      RawFields:
-        - Name: array
-          Offset: 0
-          Type: 78 PointerType *time.zone
-        - Name: len
-          Offset: 8
-          Type: 8 BaseType int
-        - Name: cap
-          Offset: 16
-          Type: 8 BaseType int
-      Data: 249 GoSliceDataType []time.zone.array
-    - __kind: PointerType
-      ID: 78
-      Name: '*time.zone'
-      ByteSize: 8
-      GoRuntimeType: 396640
-      GoKind: 22
-      Pointee: 79 StructureType time.zone
-    - __kind: StructureType
-      ID: 79
-      Name: time.zone
-      ByteSize: 32
-      GoRuntimeType: 1.642592e+06
-      GoKind: 25
-      RawFields:
-        - Name: name
-          Offset: 0
-          Type: 5 GoStringHeaderType string
-        - Name: offset
-          Offset: 16
-          Type: 8 BaseType int
-        - Name: isDST
-          Offset: 24
-          Type: 13 BaseType bool
-    - __kind: GoSliceHeaderType
-      ID: 80
-      Name: '[]time.zoneTrans'
-      ByteSize: 24
-      GoRuntimeType: 491136
-      GoKind: 23
-      RawFields:
-        - Name: array
-          Offset: 0
-          Type: 81 PointerType *time.zoneTrans
-        - Name: len
-          Offset: 8
-          Type: 8 BaseType int
-        - Name: cap
-          Offset: 16
-          Type: 8 BaseType int
-      Data: 251 GoSliceDataType []time.zoneTrans.array
-    - __kind: PointerType
-      ID: 81
-      Name: '*time.zoneTrans'
-      ByteSize: 8
-      GoRuntimeType: 396704
-      GoKind: 22
-      Pointee: 82 StructureType time.zoneTrans
-    - __kind: StructureType
-      ID: 82
-      Name: time.zoneTrans
-      ByteSize: 16
-      GoRuntimeType: 1.781504e+06
-      GoKind: 25
-      RawFields:
-        - Name: when
-          Offset: 0
-          Type: 32 BaseType int64
-        - Name: index
-          Offset: 8
-          Type: 7 BaseType uint8
-        - Name: isstd
-          Offset: 9
-          Type: 13 BaseType bool
-        - Name: isutc
-          Offset: 10
-          Type: 13 BaseType bool
-    - __kind: BaseType
-      ID: 83
-      Name: crypto/x509.KeyUsage
-      ByteSize: 8
-      GoRuntimeType: 594400
-      GoKind: 2
-    - __kind: GoSliceHeaderType
-      ID: 84
-      Name: '[]crypto/x509/pkix.Extension'
-      ByteSize: 24
-      GoRuntimeType: 518400
-      GoKind: 23
-      RawFields:
-        - Name: array
-          Offset: 0
-          Type: 85 PointerType *crypto/x509/pkix.Extension
-        - Name: len
-          Offset: 8
-          Type: 8 BaseType int
-        - Name: cap
-          Offset: 16
-          Type: 8 BaseType int
-      Data: 253 GoSliceDataType []crypto/x509/pkix.Extension.array
-    - __kind: PointerType
-      ID: 85
-      Name: '*crypto/x509/pkix.Extension'
-      ByteSize: 8
-      GoRuntimeType: 443872
-      GoKind: 22
-      Pointee: 86 StructureType crypto/x509/pkix.Extension
-    - __kind: StructureType
-      ID: 86
-      Name: crypto/x509/pkix.Extension
-      ByteSize: 56
-      GoRuntimeType: 1.678688e+06
-      GoKind: 25
-      RawFields:
-        - Name: Id
-          Offset: 0
-          Type: 72 GoSliceHeaderType encoding/asn1.ObjectIdentifier
-        - Name: Critical
-          Offset: 24
-          Type: 13 BaseType bool
-        - Name: Value
-          Offset: 32
-          Type: 53 GoSliceHeaderType []uint8
-    - __kind: GoSliceHeaderType
-      ID: 87
-      Name: '[]encoding/asn1.ObjectIdentifier'
-      ByteSize: 24
-      GoRuntimeType: 518464
-      GoKind: 23
-      RawFields:
-        - Name: array
-          Offset: 0
-          Type: 88 PointerType *encoding/asn1.ObjectIdentifier
-        - Name: len
-          Offset: 8
-          Type: 8 BaseType int
-        - Name: cap
-          Offset: 16
-          Type: 8 BaseType int
-      Data: 255 GoSliceDataType []encoding/asn1.ObjectIdentifier.array
-    - __kind: PointerType
-      ID: 88
-      Name: '*encoding/asn1.ObjectIdentifier'
-      ByteSize: 8
-      GoRuntimeType: 1.0752e+06
-      GoKind: 22
-      Pointee: 72 GoSliceHeaderType encoding/asn1.ObjectIdentifier
-    - __kind: GoSliceHeaderType
-      ID: 89
-      Name: '[]crypto/x509.ExtKeyUsage'
-      ByteSize: 24
-      GoRuntimeType: 505280
-      GoKind: 23
-      RawFields:
-        - Name: array
-          Offset: 0
-          Type: 90 PointerType *crypto/x509.ExtKeyUsage
-        - Name: len
-          Offset: 8
-          Type: 8 BaseType int
-        - Name: cap
-          Offset: 16
-          Type: 8 BaseType int
-      Data: 257 GoSliceDataType []crypto/x509.ExtKeyUsage.array
-    - __kind: PointerType
-      ID: 90
-      Name: '*crypto/x509.ExtKeyUsage'
-      ByteSize: 8
-      GoRuntimeType: 426912
-      GoKind: 22
-      Pointee: 91 BaseType crypto/x509.ExtKeyUsage
-    - __kind: BaseType
-      ID: 91
-      Name: crypto/x509.ExtKeyUsage
-      ByteSize: 8
-      GoRuntimeType: 594464
-      GoKind: 2
-    - __kind: GoSliceHeaderType
-      ID: 92
-      Name: '[]net.IP'
-      ByteSize: 24
-      GoRuntimeType: 484896
-      GoKind: 23
-      RawFields:
-        - Name: array
-          Offset: 0
-          Type: 93 PointerType *net.IP
-        - Name: len
-          Offset: 8
-          Type: 8 BaseType int
-        - Name: cap
-          Offset: 16
-          Type: 8 BaseType int
-      Data: 259 GoSliceDataType []net.IP.array
-    - __kind: PointerType
-      ID: 93
-      Name: '*net.IP'
-      ByteSize: 8
-      GoRuntimeType: 2.198272e+06
-      GoKind: 22
-      Pointee: 94 GoSliceHeaderType net.IP
-    - __kind: GoSliceHeaderType
-      ID: 94
-      Name: net.IP
-      ByteSize: 24
-      GoRuntimeType: 2.17104e+06
-      GoKind: 23
-      RawFields:
-        - Name: array
-          Offset: 0
-          Type: 6 PointerType *uint8
-        - Name: len
-          Offset: 8
-          Type: 8 BaseType int
-        - Name: cap
-          Offset: 16
-          Type: 8 BaseType int
-      Data: 261 GoSliceDataType net.IP.array
-    - __kind: GoSliceHeaderType
-      ID: 95
-      Name: '[]*net/url.URL'
-      ByteSize: 24
-      GoRuntimeType: 518528
-      GoKind: 23
-      RawFields:
-        - Name: array
-          Offset: 0
-          Type: 96 PointerType **net/url.URL
-        - Name: len
-          Offset: 8
-          Type: 8 BaseType int
-        - Name: cap
-          Offset: 16
-          Type: 8 BaseType int
-      Data: 263 GoSliceDataType []*net/url.URL.array
-    - __kind: PointerType
-      ID: 96
-      Name: '**net/url.URL'
-      ByteSize: 8
-      GoKind: 22
-      Pointee: 9 PointerType *net/url.URL
-    - __kind: GoSliceHeaderType
-      ID: 97
-      Name: '[]*net.IPNet'
-      ByteSize: 24
-      GoRuntimeType: 518592
-      GoKind: 23
-      RawFields:
-        - Name: array
-          Offset: 0
-          Type: 98 PointerType **net.IPNet
-        - Name: len
-          Offset: 8
-          Type: 8 BaseType int
-        - Name: cap
-          Offset: 16
-          Type: 8 BaseType int
-      Data: 265 GoSliceDataType []*net.IPNet.array
-    - __kind: PointerType
-      ID: 98
-      Name: '**net.IPNet'
-      ByteSize: 8
-      GoKind: 22
-      Pointee: 99 PointerType *net.IPNet
-    - __kind: PointerType
-      ID: 99
-      Name: '*net.IPNet'
-      ByteSize: 8
-      GoRuntimeType: 1.204416e+06
-      GoKind: 22
-      Pointee: 100 StructureType net.IPNet
-    - __kind: StructureType
-      ID: 100
-      Name: net.IPNet
-      ByteSize: 48
-      GoRuntimeType: 1.482432e+06
-      GoKind: 25
-      RawFields:
-        - Name: IP
-          Offset: 0
-          Type: 94 GoSliceHeaderType net.IP
-        - Name: Mask
-          Offset: 24
-          Type: 101 GoSliceHeaderType net.IPMask
-    - __kind: GoSliceHeaderType
-      ID: 101
-      Name: net.IPMask
-      ByteSize: 24
-      GoRuntimeType: 1.03808e+06
-      GoKind: 23
-      RawFields:
-        - Name: array
-          Offset: 0
-          Type: 6 PointerType *uint8
-        - Name: len
-          Offset: 8
-          Type: 8 BaseType int
-        - Name: cap
-          Offset: 16
-          Type: 8 BaseType int
-      Data: 267 GoSliceDataType net.IPMask.array
-    - __kind: GoSliceHeaderType
-      ID: 102
-      Name: '[]crypto/x509.OID'
-      ByteSize: 24
-      GoRuntimeType: 518656
-      GoKind: 23
-      RawFields:
-        - Name: array
-          Offset: 0
-          Type: 103 PointerType *crypto/x509.OID
-        - Name: len
-          Offset: 8
-          Type: 8 BaseType int
-        - Name: cap
-          Offset: 16
-          Type: 8 BaseType int
-      Data: 269 GoSliceDataType []crypto/x509.OID.array
-    - __kind: PointerType
-      ID: 103
-      Name: '*crypto/x509.OID'
-      ByteSize: 8
-      GoRuntimeType: 1.989632e+06
-      GoKind: 22
-      Pointee: 104 StructureType crypto/x509.OID
-    - __kind: StructureType
-      ID: 104
-      Name: crypto/x509.OID
-      ByteSize: 24
-      GoRuntimeType: 1.989888e+06
-      GoKind: 25
-      RawFields:
-        - Name: der
-          Offset: 0
-          Type: 53 GoSliceHeaderType []uint8
-    - __kind: GoSliceHeaderType
-      ID: 105
-      Name: '[]crypto/x509.PolicyMapping'
-      ByteSize: 24
-      GoRuntimeType: 518720
-      GoKind: 23
-      RawFields:
-        - Name: array
-          Offset: 0
-          Type: 106 PointerType *crypto/x509.PolicyMapping
-        - Name: len
-          Offset: 8
-          Type: 8 BaseType int
-        - Name: cap
-          Offset: 16
-          Type: 8 BaseType int
-      Data: 271 GoSliceDataType []crypto/x509.PolicyMapping.array
-    - __kind: PointerType
-      ID: 106
-      Name: '*crypto/x509.PolicyMapping'
-      ByteSize: 8
-      GoRuntimeType: 426976
-      GoKind: 22
-      Pointee: 107 StructureType crypto/x509.PolicyMapping
-    - __kind: StructureType
-      ID: 107
-      Name: crypto/x509.PolicyMapping
-      ByteSize: 48
-      GoRuntimeType: 1.515072e+06
-      GoKind: 25
-      RawFields:
-        - Name: IssuerDomainPolicy
-          Offset: 0
-          Type: 104 StructureType crypto/x509.OID
-        - Name: SubjectDomainPolicy
-          Offset: 24
-          Type: 104 StructureType crypto/x509.OID
-    - __kind: GoSliceHeaderType
-      ID: 108
-      Name: '[][]*crypto/x509.Certificate'
-      ByteSize: 24
-      GoRuntimeType: 503936
-      GoKind: 23
-      RawFields:
-        - Name: array
-          Offset: 0
-          Type: 109 PointerType *[]*crypto/x509.Certificate
-        - Name: len
-          Offset: 8
-          Type: 8 BaseType int
-        - Name: cap
-          Offset: 16
-          Type: 8 BaseType int
-      Data: 273 GoSliceDataType [][]*crypto/x509.Certificate.array
-    - __kind: PointerType
-      ID: 109
-      Name: '*[]*crypto/x509.Certificate'
-      ByteSize: 8
-      GoKind: 22
-      Pointee: 56 GoSliceHeaderType []*crypto/x509.Certificate
-    - __kind: GoSliceHeaderType
-      ID: 110
-      Name: '[][]uint8'
-      ByteSize: 24
-      GoRuntimeType: 483936
-      GoKind: 23
-      RawFields:
-        - Name: array
-          Offset: 0
-          Type: 111 PointerType *[]uint8
-        - Name: len
-          Offset: 8
-          Type: 8 BaseType int
-        - Name: cap
-          Offset: 16
-          Type: 8 BaseType int
-      Data: 275 GoSliceDataType [][]uint8.array
-    - __kind: PointerType
-      ID: 111
-      Name: '*[]uint8'
-      ByteSize: 8
-      GoRuntimeType: 483552
-      GoKind: 22
-      Pointee: 53 GoSliceHeaderType []uint8
-    - __kind: GoSubroutineType
-      ID: 112
-      Name: func(string, []uint8, int) ([]uint8, error)
-      ByteSize: 8
-      GoRuntimeType: 1.020736e+06
-      GoKind: 19
-    - __kind: BaseType
-      ID: 113
-      Name: crypto/tls.CurveID
-      ByteSize: 2
-      GoRuntimeType: 843936
-      GoKind: 9
-    - __kind: GoChannelType
-      ID: 114
-      Name: <-chan struct {}
-      GoRuntimeType: 603424
-      GoKind: 18
-    - __kind: PointerType
-      ID: 115
-      Name: '*net/http.Response'
-      ByteSize: 8
-      GoRuntimeType: 1.751392e+06
-      GoKind: 22
-      Pointee: 116 StructureType net/http.Response
-    - __kind: StructureType
-      ID: 116
-      Name: net/http.Response
-      ByteSize: 144
-      GoRuntimeType: 2.260416e+06
-      GoKind: 25
-      RawFields:
-        - Name: Status
-          Offset: 0
-          Type: 5 GoStringHeaderType string
-        - Name: StatusCode
-          Offset: 16
-          Type: 8 BaseType int
-        - Name: Proto
-          Offset: 24
-          Type: 5 GoStringHeaderType string
-        - Name: ProtoMajor
-          Offset: 40
-          Type: 8 BaseType int
-        - Name: ProtoMinor
-          Offset: 48
-          Type: 8 BaseType int
-        - Name: Header
-          Offset: 56
-          Type: 14 GoMapType net/http.Header
-        - Name: Body
-          Offset: 64
-          Type: 30 GoInterfaceType io.ReadCloser
-        - Name: ContentLength
-          Offset: 80
-          Type: 32 BaseType int64
-        - Name: TransferEncoding
-          Offset: 88
-          Type: 28 GoSliceHeaderType []string
-        - Name: Close
-          Offset: 112
-          Type: 13 BaseType bool
-        - Name: Uncompressed
-          Offset: 113
-          Type: 13 BaseType bool
-        - Name: Trailer
-          Offset: 120
-          Type: 14 GoMapType net/http.Header
-        - Name: Request
-          Offset: 128
-          Type: 3 PointerType *net/http.Request
-        - Name: TLS
-          Offset: 136
-          Type: 54 PointerType *crypto/tls.ConnectionState
+    - __kind: GoSliceDataType
+      ID: 247
+      Name: encoding/asn1.ObjectIdentifier.array
+      ByteSize: 2048
+      Element: 8 BaseType int
     - __kind: GoInterfaceType
-      ID: 117
-      Name: context.Context
+      ID: 211
+      Name: error
       ByteSize: 16
-      GoRuntimeType: 1.298688e+06
+      GoRuntimeType: 1.049984e+06
       GoKind: 20
       RawFields:
         - Name: tab
@@ -1764,214 +1775,36 @@ Types:
         - Name: data
           Offset: 8
           Type: 2 VoidPointerType unsafe.Pointer
-    - __kind: PointerType
-      ID: 118
-      Name: '*net/http.pattern'
+    - __kind: BaseType
+      ID: 214
+      Name: float32
+      ByteSize: 4
+      GoRuntimeType: 591264
+      GoKind: 13
+    - __kind: BaseType
+      ID: 166
+      Name: float64
       ByteSize: 8
-      GoRuntimeType: 1.637792e+06
-      GoKind: 22
-      Pointee: 119 StructureType net/http.pattern
-    - __kind: StructureType
-      ID: 119
-      Name: net/http.pattern
-      ByteSize: 88
-      GoRuntimeType: 1.866368e+06
-      GoKind: 25
-      RawFields:
-        - Name: str
-          Offset: 0
-          Type: 5 GoStringHeaderType string
-        - Name: method
-          Offset: 16
-          Type: 5 GoStringHeaderType string
-        - Name: host
-          Offset: 32
-          Type: 5 GoStringHeaderType string
-        - Name: segments
-          Offset: 48
-          Type: 120 GoSliceHeaderType []net/http.segment
-        - Name: loc
-          Offset: 72
-          Type: 5 GoStringHeaderType string
-    - __kind: GoSliceHeaderType
-      ID: 120
-      Name: '[]net/http.segment'
-      ByteSize: 24
-      GoRuntimeType: 486528
-      GoKind: 23
-      RawFields:
-        - Name: array
-          Offset: 0
-          Type: 121 PointerType *net/http.segment
-        - Name: len
-          Offset: 8
-          Type: 8 BaseType int
-        - Name: cap
-          Offset: 16
-          Type: 8 BaseType int
-      Data: 277 GoSliceDataType []net/http.segment.array
-    - __kind: PointerType
-      ID: 121
-      Name: '*net/http.segment'
+      GoRuntimeType: 591328
+      GoKind: 14
+    - __kind: GoSubroutineType
+      ID: 204
+      Name: func()
       ByteSize: 8
-      GoRuntimeType: 393504
-      GoKind: 22
-      Pointee: 122 StructureType net/http.segment
-    - __kind: StructureType
-      ID: 122
-      Name: net/http.segment
-      ByteSize: 24
-      GoRuntimeType: 1.6376e+06
-      GoKind: 25
-      RawFields:
-        - Name: s
-          Offset: 0
-          Type: 5 GoStringHeaderType string
-        - Name: wild
-          Offset: 16
-          Type: 13 BaseType bool
-        - Name: multi
-          Offset: 17
-          Type: 13 BaseType bool
-    - __kind: GoMapType
-      ID: 123
-      Name: map[string]string
+      GoRuntimeType: 482080
+      GoKind: 19
+    - __kind: GoSubroutineType
+      ID: 31
+      Name: func() (io.ReadCloser, error)
       ByteSize: 8
-      GoRuntimeType: 1.149376e+06
-      GoKind: 21
-      HeaderType: 125 GoSwissMapHeaderType map<string,string>
-    - __kind: PointerType
-      ID: 124
-      Name: '*map<string,string>'
+      GoRuntimeType: 701280
+      GoKind: 19
+    - __kind: GoSubroutineType
+      ID: 112
+      Name: func(string, []uint8, int) ([]uint8, error)
       ByteSize: 8
-      Pointee: 125 GoSwissMapHeaderType map<string,string>
-    - __kind: GoSwissMapHeaderType
-      ID: 125
-      Name: map<string,string>
-      ByteSize: 48
-      GoKind: 25
-      RawFields:
-        - Name: used
-          Offset: 0
-          Type: 17 BaseType uint64
-        - Name: seed
-          Offset: 8
-          Type: 18 BaseType uintptr
-        - Name: dirPtr
-          Offset: 16
-          Type: 126 PointerType **table<string,string>
-        - Name: dirLen
-          Offset: 24
-          Type: 8 BaseType int
-        - Name: globalDepth
-          Offset: 32
-          Type: 7 BaseType uint8
-        - Name: globalShift
-          Offset: 33
-          Type: 7 BaseType uint8
-        - Name: writing
-          Offset: 34
-          Type: 7 BaseType uint8
-        - Name: clearSeq
-          Offset: 40
-          Type: 17 BaseType uint64
-      TablePtrSliceType: 279 GoSliceDataType []*table<string,string>.array
-      GroupType: 131 StructureType noalg.map.group[string]string
-    - __kind: PointerType
-      ID: 126
-      Name: '**table<string,string>'
-      ByteSize: 8
-      Pointee: 127 PointerType *table<string,string>
-    - __kind: PointerType
-      ID: 127
-      Name: '*table<string,string>'
-      ByteSize: 8
-      Pointee: 128 StructureType table<string,string>
-    - __kind: StructureType
-      ID: 128
-      Name: table<string,string>
-      ByteSize: 32
-      GoKind: 25
-      RawFields:
-        - Name: used
-          Offset: 0
-          Type: 22 BaseType uint16
-        - Name: capacity
-          Offset: 2
-          Type: 22 BaseType uint16
-        - Name: growthLeft
-          Offset: 4
-          Type: 22 BaseType uint16
-        - Name: localDepth
-          Offset: 6
-          Type: 7 BaseType uint8
-        - Name: index
-          Offset: 8
-          Type: 8 BaseType int
-        - Name: groups
-          Offset: 16
-          Type: 129 GoSwissMapGroupsType groupReference<string,string>
-    - __kind: GoSwissMapGroupsType
-      ID: 129
-      Name: groupReference<string,string>
-      ByteSize: 16
-      GoKind: 25
-      RawFields:
-        - Name: data
-          Offset: 0
-          Type: 130 PointerType *noalg.map.group[string]string
-        - Name: lengthMask
-          Offset: 8
-          Type: 17 BaseType uint64
-      GroupType: 131 StructureType noalg.map.group[string]string
-      GroupSliceType: 280 GoSliceDataType []noalg.map.group[string]string.array
-    - __kind: PointerType
-      ID: 130
-      Name: '*noalg.map.group[string]string'
-      ByteSize: 8
-      Pointee: 131 StructureType noalg.map.group[string]string
-    - __kind: StructureType
-      ID: 131
-      Name: noalg.map.group[string]string
-      ByteSize: 264
-      GoRuntimeType: 1.314432e+06
-      GoKind: 25
-      RawFields:
-        - Name: ctrl
-          Offset: 0
-          Type: 17 BaseType uint64
-        - Name: slots
-          Offset: 8
-          Type: 132 ArrayType noalg.[8]struct { key string; elem string }
-    - __kind: ArrayType
-      ID: 132
-      Name: noalg.[8]struct { key string; elem string }
-      ByteSize: 256
-      GoRuntimeType: 701472
-      GoKind: 17
-      Count: 8
-      HasCount: true
-      Element: 133 StructureType noalg.struct { key string; elem string }
-    - __kind: StructureType
-      ID: 133
-      Name: noalg.struct { key string; elem string }
-      ByteSize: 32
-      GoRuntimeType: 1.314304e+06
-      GoKind: 25
-      RawFields:
-        - Name: key
-          Offset: 0
-          Type: 5 GoStringHeaderType string
-        - Name: elem
-          Offset: 16
-          Type: 5 GoStringHeaderType string
-    - __kind: PointerType
-      ID: 134
-      Name: '*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span'
-      ByteSize: 8
-      GoRuntimeType: 2.32752e+06
-      GoKind: 22
-      Pointee: 135 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span
+      GoRuntimeType: 1.020736e+06
+      GoKind: 19
     - __kind: StructureType
       ID: 135
       Name: github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span
@@ -2055,712 +1888,6 @@ Types:
           Offset: 280
           Type: 204 GoSubroutineType func()
     - __kind: StructureType
-      ID: 136
-      Name: sync.RWMutex
-      ByteSize: 24
-      GoRuntimeType: 1.872192e+06
-      GoKind: 25
-      RawFields:
-        - Name: w
-          Offset: 0
-          Type: 137 StructureType sync.Mutex
-        - Name: writerSem
-          Offset: 8
-          Type: 141 BaseType uint32
-        - Name: readerSem
-          Offset: 12
-          Type: 141 BaseType uint32
-        - Name: readerCount
-          Offset: 16
-          Type: 142 StructureType sync/atomic.Int32
-        - Name: readerWait
-          Offset: 20
-          Type: 142 StructureType sync/atomic.Int32
-    - __kind: StructureType
-      ID: 137
-      Name: sync.Mutex
-      ByteSize: 8
-      GoRuntimeType: 1.489632e+06
-      GoKind: 25
-      RawFields:
-        - Name: _
-          Offset: 0
-          Type: 138 StructureType sync.noCopy
-        - Name: mu
-          Offset: 0
-          Type: 139 StructureType internal/sync.Mutex
-    - __kind: StructureType
-      ID: 138
-      Name: sync.noCopy
-      GoRuntimeType: 1.003072e+06
-      GoKind: 25
-      RawFields: []
-    - __kind: StructureType
-      ID: 139
-      Name: internal/sync.Mutex
-      ByteSize: 8
-      GoRuntimeType: 1.512992e+06
-      GoKind: 25
-      RawFields:
-        - Name: state
-          Offset: 0
-          Type: 140 BaseType int32
-        - Name: sema
-          Offset: 4
-          Type: 141 BaseType uint32
-    - __kind: BaseType
-      ID: 140
-      Name: int32
-      ByteSize: 4
-      GoRuntimeType: 590688
-      GoKind: 5
-    - __kind: BaseType
-      ID: 141
-      Name: uint32
-      ByteSize: 4
-      GoRuntimeType: 590752
-      GoKind: 10
-    - __kind: StructureType
-      ID: 142
-      Name: sync/atomic.Int32
-      ByteSize: 4
-      GoRuntimeType: 1.490912e+06
-      GoKind: 25
-      RawFields:
-        - Name: _
-          Offset: 0
-          Type: 143 StructureType sync/atomic.noCopy
-        - Name: v
-          Offset: 0
-          Type: 140 BaseType int32
-    - __kind: StructureType
-      ID: 143
-      Name: sync/atomic.noCopy
-      GoRuntimeType: 1.003168e+06
-      GoKind: 25
-      RawFields: []
-    - __kind: GoMapType
-      ID: 144
-      Name: github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.metaStructMap
-      ByteSize: 8
-      GoRuntimeType: 1.299968e+06
-      GoKind: 21
-      HeaderType: 146 GoSwissMapHeaderType map<string,interface {}>
-    - __kind: PointerType
-      ID: 145
-      Name: '*map<string,interface {}>'
-      ByteSize: 8
-      Pointee: 146 GoSwissMapHeaderType map<string,interface {}>
-    - __kind: GoSwissMapHeaderType
-      ID: 146
-      Name: map<string,interface {}>
-      ByteSize: 48
-      GoKind: 25
-      RawFields:
-        - Name: used
-          Offset: 0
-          Type: 17 BaseType uint64
-        - Name: seed
-          Offset: 8
-          Type: 18 BaseType uintptr
-        - Name: dirPtr
-          Offset: 16
-          Type: 147 PointerType **table<string,interface {}>
-        - Name: dirLen
-          Offset: 24
-          Type: 8 BaseType int
-        - Name: globalDepth
-          Offset: 32
-          Type: 7 BaseType uint8
-        - Name: globalShift
-          Offset: 33
-          Type: 7 BaseType uint8
-        - Name: writing
-          Offset: 34
-          Type: 7 BaseType uint8
-        - Name: clearSeq
-          Offset: 40
-          Type: 17 BaseType uint64
-      TablePtrSliceType: 281 GoSliceDataType []*table<string,interface {}>.array
-      GroupType: 152 StructureType noalg.map.group[string]interface {}
-    - __kind: PointerType
-      ID: 147
-      Name: '**table<string,interface {}>'
-      ByteSize: 8
-      Pointee: 148 PointerType *table<string,interface {}>
-    - __kind: PointerType
-      ID: 148
-      Name: '*table<string,interface {}>'
-      ByteSize: 8
-      Pointee: 149 StructureType table<string,interface {}>
-    - __kind: StructureType
-      ID: 149
-      Name: table<string,interface {}>
-      ByteSize: 32
-      GoKind: 25
-      RawFields:
-        - Name: used
-          Offset: 0
-          Type: 22 BaseType uint16
-        - Name: capacity
-          Offset: 2
-          Type: 22 BaseType uint16
-        - Name: growthLeft
-          Offset: 4
-          Type: 22 BaseType uint16
-        - Name: localDepth
-          Offset: 6
-          Type: 7 BaseType uint8
-        - Name: index
-          Offset: 8
-          Type: 8 BaseType int
-        - Name: groups
-          Offset: 16
-          Type: 150 GoSwissMapGroupsType groupReference<string,interface {}>
-    - __kind: GoSwissMapGroupsType
-      ID: 150
-      Name: groupReference<string,interface {}>
-      ByteSize: 16
-      GoKind: 25
-      RawFields:
-        - Name: data
-          Offset: 0
-          Type: 151 PointerType *noalg.map.group[string]interface {}
-        - Name: lengthMask
-          Offset: 8
-          Type: 17 BaseType uint64
-      GroupType: 152 StructureType noalg.map.group[string]interface {}
-      GroupSliceType: 282 GoSliceDataType []noalg.map.group[string]interface {}.array
-    - __kind: PointerType
-      ID: 151
-      Name: '*noalg.map.group[string]interface {}'
-      ByteSize: 8
-      Pointee: 152 StructureType noalg.map.group[string]interface {}
-    - __kind: StructureType
-      ID: 152
-      Name: noalg.map.group[string]interface {}
-      ByteSize: 264
-      GoRuntimeType: 1.309568e+06
-      GoKind: 25
-      RawFields:
-        - Name: ctrl
-          Offset: 0
-          Type: 17 BaseType uint64
-        - Name: slots
-          Offset: 8
-          Type: 153 ArrayType noalg.[8]struct { key string; elem interface {} }
-    - __kind: ArrayType
-      ID: 153
-      Name: noalg.[8]struct { key string; elem interface {} }
-      ByteSize: 256
-      GoRuntimeType: 688768
-      GoKind: 17
-      Count: 8
-      HasCount: true
-      Element: 154 StructureType noalg.struct { key string; elem interface {} }
-    - __kind: StructureType
-      ID: 154
-      Name: noalg.struct { key string; elem interface {} }
-      ByteSize: 32
-      GoRuntimeType: 1.30944e+06
-      GoKind: 25
-      RawFields:
-        - Name: key
-          Offset: 0
-          Type: 5 GoStringHeaderType string
-        - Name: elem
-          Offset: 16
-          Type: 62 GoEmptyInterfaceType interface {}
-    - __kind: GoMapType
-      ID: 155
-      Name: map[string]float64
-      ByteSize: 8
-      GoRuntimeType: 1.1536e+06
-      GoKind: 21
-      HeaderType: 157 GoSwissMapHeaderType map<string,float64>
-    - __kind: PointerType
-      ID: 156
-      Name: '*map<string,float64>'
-      ByteSize: 8
-      Pointee: 157 GoSwissMapHeaderType map<string,float64>
-    - __kind: GoSwissMapHeaderType
-      ID: 157
-      Name: map<string,float64>
-      ByteSize: 48
-      GoKind: 25
-      RawFields:
-        - Name: used
-          Offset: 0
-          Type: 17 BaseType uint64
-        - Name: seed
-          Offset: 8
-          Type: 18 BaseType uintptr
-        - Name: dirPtr
-          Offset: 16
-          Type: 158 PointerType **table<string,float64>
-        - Name: dirLen
-          Offset: 24
-          Type: 8 BaseType int
-        - Name: globalDepth
-          Offset: 32
-          Type: 7 BaseType uint8
-        - Name: globalShift
-          Offset: 33
-          Type: 7 BaseType uint8
-        - Name: writing
-          Offset: 34
-          Type: 7 BaseType uint8
-        - Name: clearSeq
-          Offset: 40
-          Type: 17 BaseType uint64
-      TablePtrSliceType: 283 GoSliceDataType []*table<string,float64>.array
-      GroupType: 163 StructureType noalg.map.group[string]float64
-    - __kind: PointerType
-      ID: 158
-      Name: '**table<string,float64>'
-      ByteSize: 8
-      Pointee: 159 PointerType *table<string,float64>
-    - __kind: PointerType
-      ID: 159
-      Name: '*table<string,float64>'
-      ByteSize: 8
-      Pointee: 160 StructureType table<string,float64>
-    - __kind: StructureType
-      ID: 160
-      Name: table<string,float64>
-      ByteSize: 32
-      GoKind: 25
-      RawFields:
-        - Name: used
-          Offset: 0
-          Type: 22 BaseType uint16
-        - Name: capacity
-          Offset: 2
-          Type: 22 BaseType uint16
-        - Name: growthLeft
-          Offset: 4
-          Type: 22 BaseType uint16
-        - Name: localDepth
-          Offset: 6
-          Type: 7 BaseType uint8
-        - Name: index
-          Offset: 8
-          Type: 8 BaseType int
-        - Name: groups
-          Offset: 16
-          Type: 161 GoSwissMapGroupsType groupReference<string,float64>
-    - __kind: GoSwissMapGroupsType
-      ID: 161
-      Name: groupReference<string,float64>
-      ByteSize: 16
-      GoKind: 25
-      RawFields:
-        - Name: data
-          Offset: 0
-          Type: 162 PointerType *noalg.map.group[string]float64
-        - Name: lengthMask
-          Offset: 8
-          Type: 17 BaseType uint64
-      GroupType: 163 StructureType noalg.map.group[string]float64
-      GroupSliceType: 284 GoSliceDataType []noalg.map.group[string]float64.array
-    - __kind: PointerType
-      ID: 162
-      Name: '*noalg.map.group[string]float64'
-      ByteSize: 8
-      Pointee: 163 StructureType noalg.map.group[string]float64
-    - __kind: StructureType
-      ID: 163
-      Name: noalg.map.group[string]float64
-      ByteSize: 200
-      GoRuntimeType: 1.327616e+06
-      GoKind: 25
-      RawFields:
-        - Name: ctrl
-          Offset: 0
-          Type: 17 BaseType uint64
-        - Name: slots
-          Offset: 8
-          Type: 164 ArrayType noalg.[8]struct { key string; elem float64 }
-    - __kind: ArrayType
-      ID: 164
-      Name: noalg.[8]struct { key string; elem float64 }
-      ByteSize: 192
-      GoRuntimeType: 711808
-      GoKind: 17
-      Count: 8
-      HasCount: true
-      Element: 165 StructureType noalg.struct { key string; elem float64 }
-    - __kind: StructureType
-      ID: 165
-      Name: noalg.struct { key string; elem float64 }
-      ByteSize: 24
-      GoRuntimeType: 1.327488e+06
-      GoKind: 25
-      RawFields:
-        - Name: key
-          Offset: 0
-          Type: 5 GoStringHeaderType string
-        - Name: elem
-          Offset: 16
-          Type: 166 BaseType float64
-    - __kind: BaseType
-      ID: 166
-      Name: float64
-      ByteSize: 8
-      GoRuntimeType: 591328
-      GoKind: 14
-    - __kind: GoSliceHeaderType
-      ID: 167
-      Name: '[]github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink'
-      ByteSize: 24
-      GoRuntimeType: 491520
-      GoKind: 23
-      RawFields:
-        - Name: array
-          Offset: 0
-          Type: 168 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink
-        - Name: len
-          Offset: 8
-          Type: 8 BaseType int
-        - Name: cap
-          Offset: 16
-          Type: 8 BaseType int
-      Data: 285 GoSliceDataType []github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink.array
-    - __kind: PointerType
-      ID: 168
-      Name: '*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink'
-      ByteSize: 8
-      GoRuntimeType: 1.210688e+06
-      GoKind: 22
-      Pointee: 169 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink
-    - __kind: StructureType
-      ID: 169
-      Name: github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink
-      ByteSize: 56
-      GoRuntimeType: 1.947136e+06
-      GoKind: 25
-      RawFields:
-        - Name: TraceID
-          Offset: 0
-          Type: 17 BaseType uint64
-        - Name: TraceIDHigh
-          Offset: 8
-          Type: 17 BaseType uint64
-        - Name: SpanID
-          Offset: 16
-          Type: 17 BaseType uint64
-        - Name: Attributes
-          Offset: 24
-          Type: 123 GoMapType map[string]string
-        - Name: Tracestate
-          Offset: 32
-          Type: 5 GoStringHeaderType string
-        - Name: Flags
-          Offset: 48
-          Type: 141 BaseType uint32
-    - __kind: GoSliceHeaderType
-      ID: 170
-      Name: '[]github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent'
-      ByteSize: 24
-      GoRuntimeType: 491712
-      GoKind: 23
-      RawFields:
-        - Name: array
-          Offset: 0
-          Type: 171 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent
-        - Name: len
-          Offset: 8
-          Type: 8 BaseType int
-        - Name: cap
-          Offset: 16
-          Type: 8 BaseType int
-      Data: 287 GoSliceDataType []github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent.array
-    - __kind: PointerType
-      ID: 171
-      Name: '*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent'
-      ByteSize: 8
-      GoRuntimeType: 1.210816e+06
-      GoKind: 22
-      Pointee: 172 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent
-    - __kind: StructureType
-      ID: 172
-      Name: github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent
-      ByteSize: 40
-      GoRuntimeType: 1.781696e+06
-      GoKind: 25
-      RawFields:
-        - Name: Name
-          Offset: 0
-          Type: 5 GoStringHeaderType string
-        - Name: TimeUnixNano
-          Offset: 16
-          Type: 17 BaseType uint64
-        - Name: Attributes
-          Offset: 24
-          Type: 173 GoMapType map[string]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
-        - Name: RawAttributes
-          Offset: 32
-          Type: 194 GoMapType map[string]interface {}
-    - __kind: GoMapType
-      ID: 173
-      Name: map[string]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
-      ByteSize: 8
-      GoRuntimeType: 1.153728e+06
-      GoKind: 21
-      HeaderType: 175 GoSwissMapHeaderType map<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
-    - __kind: PointerType
-      ID: 174
-      Name: '*map<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>'
-      ByteSize: 8
-      Pointee: 175 GoSwissMapHeaderType map<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
-    - __kind: GoSwissMapHeaderType
-      ID: 175
-      Name: map<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
-      ByteSize: 48
-      GoKind: 25
-      RawFields:
-        - Name: used
-          Offset: 0
-          Type: 17 BaseType uint64
-        - Name: seed
-          Offset: 8
-          Type: 18 BaseType uintptr
-        - Name: dirPtr
-          Offset: 16
-          Type: 176 PointerType **table<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
-        - Name: dirLen
-          Offset: 24
-          Type: 8 BaseType int
-        - Name: globalDepth
-          Offset: 32
-          Type: 7 BaseType uint8
-        - Name: globalShift
-          Offset: 33
-          Type: 7 BaseType uint8
-        - Name: writing
-          Offset: 34
-          Type: 7 BaseType uint8
-        - Name: clearSeq
-          Offset: 40
-          Type: 17 BaseType uint64
-      TablePtrSliceType: 289 GoSliceDataType []*table<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>.array
-      GroupType: 181 StructureType noalg.map.group[string]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
-    - __kind: PointerType
-      ID: 176
-      Name: '**table<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>'
-      ByteSize: 8
-      Pointee: 177 PointerType *table<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
-    - __kind: PointerType
-      ID: 177
-      Name: '*table<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>'
-      ByteSize: 8
-      Pointee: 178 StructureType table<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
-    - __kind: StructureType
-      ID: 178
-      Name: table<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
-      ByteSize: 32
-      GoKind: 25
-      RawFields:
-        - Name: used
-          Offset: 0
-          Type: 22 BaseType uint16
-        - Name: capacity
-          Offset: 2
-          Type: 22 BaseType uint16
-        - Name: growthLeft
-          Offset: 4
-          Type: 22 BaseType uint16
-        - Name: localDepth
-          Offset: 6
-          Type: 7 BaseType uint8
-        - Name: index
-          Offset: 8
-          Type: 8 BaseType int
-        - Name: groups
-          Offset: 16
-          Type: 179 GoSwissMapGroupsType groupReference<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
-    - __kind: GoSwissMapGroupsType
-      ID: 179
-      Name: groupReference<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
-      ByteSize: 16
-      GoKind: 25
-      RawFields:
-        - Name: data
-          Offset: 0
-          Type: 180 PointerType *noalg.map.group[string]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
-        - Name: lengthMask
-          Offset: 8
-          Type: 17 BaseType uint64
-      GroupType: 181 StructureType noalg.map.group[string]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
-      GroupSliceType: 290 GoSliceDataType []noalg.map.group[string]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute.array
-    - __kind: PointerType
-      ID: 180
-      Name: '*noalg.map.group[string]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute'
-      ByteSize: 8
-      Pointee: 181 StructureType noalg.map.group[string]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
-    - __kind: StructureType
-      ID: 181
-      Name: noalg.map.group[string]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
-      ByteSize: 200
-      GoRuntimeType: 1.327872e+06
-      GoKind: 25
-      RawFields:
-        - Name: ctrl
-          Offset: 0
-          Type: 17 BaseType uint64
-        - Name: slots
-          Offset: 8
-          Type: 182 ArrayType noalg.[8]struct { key string; elem *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute }
-    - __kind: ArrayType
-      ID: 182
-      Name: noalg.[8]struct { key string; elem *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute }
-      ByteSize: 192
-      GoRuntimeType: 711904
-      GoKind: 17
-      Count: 8
-      HasCount: true
-      Element: 183 StructureType noalg.struct { key string; elem *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute }
-    - __kind: StructureType
-      ID: 183
-      Name: noalg.struct { key string; elem *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute }
-      ByteSize: 24
-      GoRuntimeType: 1.327744e+06
-      GoKind: 25
-      RawFields:
-        - Name: key
-          Offset: 0
-          Type: 5 GoStringHeaderType string
-        - Name: elem
-          Offset: 16
-          Type: 184 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
-    - __kind: PointerType
-      ID: 184
-      Name: '*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute'
-      ByteSize: 8
-      GoRuntimeType: 1.211584e+06
-      GoKind: 22
-      Pointee: 185 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
-    - __kind: StructureType
-      ID: 185
-      Name: github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
-      ByteSize: 56
-      GoRuntimeType: 1.947392e+06
-      GoKind: 25
-      RawFields:
-        - Name: Type
-          Offset: 0
-          Type: 186 BaseType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttributeType
-        - Name: StringValue
-          Offset: 8
-          Type: 5 GoStringHeaderType string
-        - Name: BoolValue
-          Offset: 24
-          Type: 13 BaseType bool
-        - Name: IntValue
-          Offset: 32
-          Type: 32 BaseType int64
-        - Name: DoubleValue
-          Offset: 40
-          Type: 166 BaseType float64
-        - Name: ArrayValue
-          Offset: 48
-          Type: 187 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttribute
-    - __kind: BaseType
-      ID: 186
-      Name: github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttributeType
-      ByteSize: 4
-      GoRuntimeType: 1.0024e+06
-      GoKind: 5
-    - __kind: PointerType
-      ID: 187
-      Name: '*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttribute'
-      ByteSize: 8
-      GoRuntimeType: 1.211456e+06
-      GoKind: 22
-      Pointee: 188 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttribute
-    - __kind: StructureType
-      ID: 188
-      Name: github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttribute
-      ByteSize: 24
-      GoRuntimeType: 1.211328e+06
-      GoKind: 25
-      RawFields:
-        - Name: Values
-          Offset: 0
-          Type: 189 GoSliceHeaderType []*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttributeValue
-    - __kind: GoSliceHeaderType
-      ID: 189
-      Name: '[]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttributeValue'
-      ByteSize: 24
-      GoRuntimeType: 491584
-      GoKind: 23
-      RawFields:
-        - Name: array
-          Offset: 0
-          Type: 190 PointerType **github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttributeValue
-        - Name: len
-          Offset: 8
-          Type: 8 BaseType int
-        - Name: cap
-          Offset: 16
-          Type: 8 BaseType int
-      Data: 291 GoSliceDataType []*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttributeValue.array
-    - __kind: PointerType
-      ID: 190
-      Name: '**github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttributeValue'
-      ByteSize: 8
-      GoKind: 22
-      Pointee: 191 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttributeValue
-    - __kind: PointerType
-      ID: 191
-      Name: '*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttributeValue'
-      ByteSize: 8
-      GoRuntimeType: 1.2112e+06
-      GoKind: 22
-      Pointee: 192 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttributeValue
-    - __kind: StructureType
-      ID: 192
-      Name: github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttributeValue
-      ByteSize: 48
-      GoRuntimeType: 1.869504e+06
-      GoKind: 25
-      RawFields:
-        - Name: Type
-          Offset: 0
-          Type: 193 BaseType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttributeValueType
-        - Name: StringValue
-          Offset: 8
-          Type: 5 GoStringHeaderType string
-        - Name: BoolValue
-          Offset: 24
-          Type: 13 BaseType bool
-        - Name: IntValue
-          Offset: 32
-          Type: 32 BaseType int64
-        - Name: DoubleValue
-          Offset: 40
-          Type: 166 BaseType float64
-    - __kind: BaseType
-      ID: 193
-      Name: github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttributeValueType
-      ByteSize: 4
-      GoRuntimeType: 1.002496e+06
-      GoKind: 5
-    - __kind: GoMapType
-      ID: 194
-      Name: map[string]interface {}
-      ByteSize: 8
-      GoRuntimeType: 1.146944e+06
-      GoKind: 21
-      HeaderType: 146 GoSwissMapHeaderType map<string,interface {}>
-    - __kind: PointerType
-      ID: 195
-      Name: '*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanContext'
-      ByteSize: 8
-      GoRuntimeType: 2.046208e+06
-      GoKind: 22
-      Pointee: 196 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanContext
-    - __kind: StructureType
       ID: 196
       Name: github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanContext
       ByteSize: 168
@@ -2809,13 +1936,132 @@ Types:
         - Name: baggageOnly
           Offset: 160
           Type: 13 BaseType bool
-    - __kind: PointerType
-      ID: 197
-      Name: '*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.trace'
+    - __kind: StructureType
+      ID: 169
+      Name: github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink
+      ByteSize: 56
+      GoRuntimeType: 1.947136e+06
+      GoKind: 25
+      RawFields:
+        - Name: TraceID
+          Offset: 0
+          Type: 17 BaseType uint64
+        - Name: TraceIDHigh
+          Offset: 8
+          Type: 17 BaseType uint64
+        - Name: SpanID
+          Offset: 16
+          Type: 17 BaseType uint64
+        - Name: Attributes
+          Offset: 24
+          Type: 123 GoMapType map[string]string
+        - Name: Tracestate
+          Offset: 32
+          Type: 5 GoStringHeaderType string
+        - Name: Flags
+          Offset: 48
+          Type: 141 BaseType uint32
+    - __kind: GoMapType
+      ID: 144
+      Name: github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.metaStructMap
       ByteSize: 8
-      GoRuntimeType: 2.27024e+06
-      GoKind: 22
-      Pointee: 198 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.trace
+      GoRuntimeType: 1.299968e+06
+      GoKind: 21
+      HeaderType: 146 GoSwissMapHeaderType map<string,interface {}>
+    - __kind: BaseType
+      ID: 202
+      Name: github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.samplingDecision
+      ByteSize: 4
+      GoRuntimeType: 590176
+      GoKind: 10
+    - __kind: StructureType
+      ID: 172
+      Name: github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent
+      ByteSize: 40
+      GoRuntimeType: 1.781696e+06
+      GoKind: 25
+      RawFields:
+        - Name: Name
+          Offset: 0
+          Type: 5 GoStringHeaderType string
+        - Name: TimeUnixNano
+          Offset: 16
+          Type: 17 BaseType uint64
+        - Name: Attributes
+          Offset: 24
+          Type: 173 GoMapType map[string]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
+        - Name: RawAttributes
+          Offset: 32
+          Type: 194 GoMapType map[string]interface {}
+    - __kind: StructureType
+      ID: 188
+      Name: github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttribute
+      ByteSize: 24
+      GoRuntimeType: 1.211328e+06
+      GoKind: 25
+      RawFields:
+        - Name: Values
+          Offset: 0
+          Type: 189 GoSliceHeaderType []*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttributeValue
+    - __kind: StructureType
+      ID: 192
+      Name: github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttributeValue
+      ByteSize: 48
+      GoRuntimeType: 1.869504e+06
+      GoKind: 25
+      RawFields:
+        - Name: Type
+          Offset: 0
+          Type: 193 BaseType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttributeValueType
+        - Name: StringValue
+          Offset: 8
+          Type: 5 GoStringHeaderType string
+        - Name: BoolValue
+          Offset: 24
+          Type: 13 BaseType bool
+        - Name: IntValue
+          Offset: 32
+          Type: 32 BaseType int64
+        - Name: DoubleValue
+          Offset: 40
+          Type: 166 BaseType float64
+    - __kind: BaseType
+      ID: 193
+      Name: github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttributeValueType
+      ByteSize: 4
+      GoRuntimeType: 1.002496e+06
+      GoKind: 5
+    - __kind: StructureType
+      ID: 185
+      Name: github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
+      ByteSize: 56
+      GoRuntimeType: 1.947392e+06
+      GoKind: 25
+      RawFields:
+        - Name: Type
+          Offset: 0
+          Type: 186 BaseType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttributeType
+        - Name: StringValue
+          Offset: 8
+          Type: 5 GoStringHeaderType string
+        - Name: BoolValue
+          Offset: 24
+          Type: 13 BaseType bool
+        - Name: IntValue
+          Offset: 32
+          Type: 32 BaseType int64
+        - Name: DoubleValue
+          Offset: 40
+          Type: 166 BaseType float64
+        - Name: ArrayValue
+          Offset: 48
+          Type: 187 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttribute
+    - __kind: BaseType
+      ID: 186
+      Name: github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttributeType
+      ByteSize: 4
+      GoRuntimeType: 1.0024e+06
+      GoKind: 5
     - __kind: StructureType
       ID: 198
       Name: github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.trace
@@ -2853,42 +2099,6 @@ Types:
         - Name: root
           Offset: 96
           Type: 134 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span
-    - __kind: GoSliceHeaderType
-      ID: 199
-      Name: '[]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span'
-      ByteSize: 24
-      GoRuntimeType: 491968
-      GoKind: 23
-      RawFields:
-        - Name: array
-          Offset: 0
-          Type: 200 PointerType **github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span
-        - Name: len
-          Offset: 8
-          Type: 8 BaseType int
-        - Name: cap
-          Offset: 16
-          Type: 8 BaseType int
-      Data: 293 GoSliceDataType []*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span.array
-    - __kind: PointerType
-      ID: 200
-      Name: '**github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span'
-      ByteSize: 8
-      GoKind: 22
-      Pointee: 134 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span
-    - __kind: PointerType
-      ID: 201
-      Name: '*float64'
-      ByteSize: 8
-      GoRuntimeType: 402656
-      GoKind: 22
-      Pointee: 166 BaseType float64
-    - __kind: BaseType
-      ID: 202
-      Name: github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.samplingDecision
-      ByteSize: 4
-      GoRuntimeType: 590176
-      GoKind: 10
     - __kind: ArrayType
       ID: 203
       Name: github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.traceID
@@ -2898,68 +2108,151 @@ Types:
       Count: 16
       HasCount: true
       Element: 7 BaseType uint8
-    - __kind: GoSubroutineType
-      ID: 204
-      Name: func()
-      ByteSize: 8
-      GoRuntimeType: 482080
-      GoKind: 19
-    - __kind: PointerType
-      ID: 205
-      Name: '*bytes.Buffer'
-      ByteSize: 8
-      GoRuntimeType: 2.316768e+06
-      GoKind: 22
-      Pointee: 206 StructureType bytes.Buffer
-    - __kind: StructureType
-      ID: 206
-      Name: bytes.Buffer
-      ByteSize: 40
-      GoRuntimeType: 1.635488e+06
-      GoKind: 25
-      RawFields:
-        - Name: buf
-          Offset: 0
-          Type: 53 GoSliceHeaderType []uint8
-        - Name: off
-          Offset: 24
-          Type: 8 BaseType int
-        - Name: lastRead
-          Offset: 32
-          Type: 207 BaseType bytes.readOp
-    - __kind: BaseType
-      ID: 207
-      Name: bytes.readOp
-      ByteSize: 1
-      GoRuntimeType: 589536
-      GoKind: 3
-    - __kind: StructureType
-      ID: 208
-      Name: context.backgroundCtx
-      GoRuntimeType: 1.827296e+06
-      GoKind: 25
-      RawFields:
-        - Name: emptyCtx
-          Offset: 0
-          Type: 209 StructureType context.emptyCtx
-    - __kind: StructureType
-      ID: 209
-      Name: context.emptyCtx
-      GoRuntimeType: 1.618752e+06
-      GoKind: 25
-      RawFields: []
-    - __kind: PointerType
-      ID: 210
-      Name: '*bool'
-      ByteSize: 8
-      GoRuntimeType: 402720
-      GoKind: 22
-      Pointee: 13 BaseType bool
-    - __kind: GoInterfaceType
-      ID: 211
-      Name: error
+    - __kind: GoSwissMapGroupsType
+      ID: 179
+      Name: groupReference<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
       ByteSize: 16
-      GoRuntimeType: 1.049984e+06
+      GoKind: 25
+      RawFields:
+        - Name: data
+          Offset: 0
+          Type: 180 PointerType *noalg.map.group[string]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
+        - Name: lengthMask
+          Offset: 8
+          Type: 17 BaseType uint64
+      GroupType: 181 StructureType noalg.map.group[string]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
+      GroupSliceType: 290 GoSliceDataType []noalg.map.group[string]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute.array
+    - __kind: GoSwissMapGroupsType
+      ID: 43
+      Name: groupReference<string,[]*mime/multipart.FileHeader>
+      ByteSize: 16
+      GoKind: 25
+      RawFields:
+        - Name: data
+          Offset: 0
+          Type: 44 PointerType *noalg.map.group[string][]*mime/multipart.FileHeader
+        - Name: lengthMask
+          Offset: 8
+          Type: 17 BaseType uint64
+      GroupType: 45 StructureType noalg.map.group[string][]*mime/multipart.FileHeader
+      GroupSliceType: 236 GoSliceDataType []noalg.map.group[string][]*mime/multipart.FileHeader.array
+    - __kind: GoSwissMapGroupsType
+      ID: 23
+      Name: groupReference<string,[]string>
+      ByteSize: 16
+      GoKind: 25
+      RawFields:
+        - Name: data
+          Offset: 0
+          Type: 24 PointerType *noalg.map.group[string][]string
+        - Name: lengthMask
+          Offset: 8
+          Type: 17 BaseType uint64
+      GroupType: 25 StructureType noalg.map.group[string][]string
+      GroupSliceType: 232 GoSliceDataType []noalg.map.group[string][]string.array
+    - __kind: GoSwissMapGroupsType
+      ID: 161
+      Name: groupReference<string,float64>
+      ByteSize: 16
+      GoKind: 25
+      RawFields:
+        - Name: data
+          Offset: 0
+          Type: 162 PointerType *noalg.map.group[string]float64
+        - Name: lengthMask
+          Offset: 8
+          Type: 17 BaseType uint64
+      GroupType: 163 StructureType noalg.map.group[string]float64
+      GroupSliceType: 284 GoSliceDataType []noalg.map.group[string]float64.array
+    - __kind: GoSwissMapGroupsType
+      ID: 150
+      Name: groupReference<string,interface {}>
+      ByteSize: 16
+      GoKind: 25
+      RawFields:
+        - Name: data
+          Offset: 0
+          Type: 151 PointerType *noalg.map.group[string]interface {}
+        - Name: lengthMask
+          Offset: 8
+          Type: 17 BaseType uint64
+      GroupType: 152 StructureType noalg.map.group[string]interface {}
+      GroupSliceType: 282 GoSliceDataType []noalg.map.group[string]interface {}.array
+    - __kind: GoSwissMapGroupsType
+      ID: 129
+      Name: groupReference<string,string>
+      ByteSize: 16
+      GoKind: 25
+      RawFields:
+        - Name: data
+          Offset: 0
+          Type: 130 PointerType *noalg.map.group[string]string
+        - Name: lengthMask
+          Offset: 8
+          Type: 17 BaseType uint64
+      GroupType: 131 StructureType noalg.map.group[string]string
+      GroupSliceType: 280 GoSliceDataType []noalg.map.group[string]string.array
+    - __kind: BaseType
+      ID: 8
+      Name: int
+      ByteSize: 8
+      GoRuntimeType: 590944
+      GoKind: 2
+    - __kind: BaseType
+      ID: 224
+      Name: int16
+      ByteSize: 2
+      GoRuntimeType: 590560
+      GoKind: 4
+    - __kind: BaseType
+      ID: 140
+      Name: int32
+      ByteSize: 4
+      GoRuntimeType: 590688
+      GoKind: 5
+    - __kind: BaseType
+      ID: 32
+      Name: int64
+      ByteSize: 8
+      GoRuntimeType: 590816
+      GoKind: 6
+    - __kind: BaseType
+      ID: 212
+      Name: int8
+      ByteSize: 1
+      GoRuntimeType: 590432
+      GoKind: 3
+    - __kind: GoEmptyInterfaceType
+      ID: 62
+      Name: interface {}
+      ByteSize: 16
+      GoRuntimeType: 863648
+      GoKind: 20
+      RawFields:
+        - Name: _type
+          Offset: 0
+          Type: 2 VoidPointerType unsafe.Pointer
+        - Name: data
+          Offset: 8
+          Type: 2 VoidPointerType unsafe.Pointer
+    - __kind: StructureType
+      ID: 139
+      Name: internal/sync.Mutex
+      ByteSize: 8
+      GoRuntimeType: 1.512992e+06
+      GoKind: 25
+      RawFields:
+        - Name: state
+          Offset: 0
+          Type: 140 BaseType int32
+        - Name: sema
+          Offset: 4
+          Type: 141 BaseType uint32
+    - __kind: GoInterfaceType
+      ID: 30
+      Name: io.ReadCloser
+      ByteSize: 16
+      GoRuntimeType: 1.130304e+06
       GoKind: 20
       RawFields:
         - Name: tab
@@ -2968,12 +2261,1152 @@ Types:
         - Name: data
           Offset: 8
           Type: 2 VoidPointerType unsafe.Pointer
+    - __kind: GoSwissMapHeaderType
+      ID: 175
+      Name: map<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
+      ByteSize: 48
+      GoKind: 25
+      RawFields:
+        - Name: used
+          Offset: 0
+          Type: 17 BaseType uint64
+        - Name: seed
+          Offset: 8
+          Type: 18 BaseType uintptr
+        - Name: dirPtr
+          Offset: 16
+          Type: 176 PointerType **table<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
+        - Name: dirLen
+          Offset: 24
+          Type: 8 BaseType int
+        - Name: globalDepth
+          Offset: 32
+          Type: 7 BaseType uint8
+        - Name: globalShift
+          Offset: 33
+          Type: 7 BaseType uint8
+        - Name: writing
+          Offset: 34
+          Type: 7 BaseType uint8
+        - Name: clearSeq
+          Offset: 40
+          Type: 17 BaseType uint64
+      TablePtrSliceType: 289 GoSliceDataType []*table<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>.array
+      GroupType: 181 StructureType noalg.map.group[string]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
+    - __kind: GoSwissMapHeaderType
+      ID: 39
+      Name: map<string,[]*mime/multipart.FileHeader>
+      ByteSize: 48
+      GoKind: 25
+      RawFields:
+        - Name: used
+          Offset: 0
+          Type: 17 BaseType uint64
+        - Name: seed
+          Offset: 8
+          Type: 18 BaseType uintptr
+        - Name: dirPtr
+          Offset: 16
+          Type: 40 PointerType **table<string,[]*mime/multipart.FileHeader>
+        - Name: dirLen
+          Offset: 24
+          Type: 8 BaseType int
+        - Name: globalDepth
+          Offset: 32
+          Type: 7 BaseType uint8
+        - Name: globalShift
+          Offset: 33
+          Type: 7 BaseType uint8
+        - Name: writing
+          Offset: 34
+          Type: 7 BaseType uint8
+        - Name: clearSeq
+          Offset: 40
+          Type: 17 BaseType uint64
+      TablePtrSliceType: 235 GoSliceDataType []*table<string,[]*mime/multipart.FileHeader>.array
+      GroupType: 45 StructureType noalg.map.group[string][]*mime/multipart.FileHeader
+    - __kind: GoSwissMapHeaderType
+      ID: 16
+      Name: map<string,[]string>
+      ByteSize: 48
+      GoKind: 25
+      RawFields:
+        - Name: used
+          Offset: 0
+          Type: 17 BaseType uint64
+        - Name: seed
+          Offset: 8
+          Type: 18 BaseType uintptr
+        - Name: dirPtr
+          Offset: 16
+          Type: 19 PointerType **table<string,[]string>
+        - Name: dirLen
+          Offset: 24
+          Type: 8 BaseType int
+        - Name: globalDepth
+          Offset: 32
+          Type: 7 BaseType uint8
+        - Name: globalShift
+          Offset: 33
+          Type: 7 BaseType uint8
+        - Name: writing
+          Offset: 34
+          Type: 7 BaseType uint8
+        - Name: clearSeq
+          Offset: 40
+          Type: 17 BaseType uint64
+      TablePtrSliceType: 231 GoSliceDataType []*table<string,[]string>.array
+      GroupType: 25 StructureType noalg.map.group[string][]string
+    - __kind: GoSwissMapHeaderType
+      ID: 157
+      Name: map<string,float64>
+      ByteSize: 48
+      GoKind: 25
+      RawFields:
+        - Name: used
+          Offset: 0
+          Type: 17 BaseType uint64
+        - Name: seed
+          Offset: 8
+          Type: 18 BaseType uintptr
+        - Name: dirPtr
+          Offset: 16
+          Type: 158 PointerType **table<string,float64>
+        - Name: dirLen
+          Offset: 24
+          Type: 8 BaseType int
+        - Name: globalDepth
+          Offset: 32
+          Type: 7 BaseType uint8
+        - Name: globalShift
+          Offset: 33
+          Type: 7 BaseType uint8
+        - Name: writing
+          Offset: 34
+          Type: 7 BaseType uint8
+        - Name: clearSeq
+          Offset: 40
+          Type: 17 BaseType uint64
+      TablePtrSliceType: 283 GoSliceDataType []*table<string,float64>.array
+      GroupType: 163 StructureType noalg.map.group[string]float64
+    - __kind: GoSwissMapHeaderType
+      ID: 146
+      Name: map<string,interface {}>
+      ByteSize: 48
+      GoKind: 25
+      RawFields:
+        - Name: used
+          Offset: 0
+          Type: 17 BaseType uint64
+        - Name: seed
+          Offset: 8
+          Type: 18 BaseType uintptr
+        - Name: dirPtr
+          Offset: 16
+          Type: 147 PointerType **table<string,interface {}>
+        - Name: dirLen
+          Offset: 24
+          Type: 8 BaseType int
+        - Name: globalDepth
+          Offset: 32
+          Type: 7 BaseType uint8
+        - Name: globalShift
+          Offset: 33
+          Type: 7 BaseType uint8
+        - Name: writing
+          Offset: 34
+          Type: 7 BaseType uint8
+        - Name: clearSeq
+          Offset: 40
+          Type: 17 BaseType uint64
+      TablePtrSliceType: 281 GoSliceDataType []*table<string,interface {}>.array
+      GroupType: 152 StructureType noalg.map.group[string]interface {}
+    - __kind: GoSwissMapHeaderType
+      ID: 125
+      Name: map<string,string>
+      ByteSize: 48
+      GoKind: 25
+      RawFields:
+        - Name: used
+          Offset: 0
+          Type: 17 BaseType uint64
+        - Name: seed
+          Offset: 8
+          Type: 18 BaseType uintptr
+        - Name: dirPtr
+          Offset: 16
+          Type: 126 PointerType **table<string,string>
+        - Name: dirLen
+          Offset: 24
+          Type: 8 BaseType int
+        - Name: globalDepth
+          Offset: 32
+          Type: 7 BaseType uint8
+        - Name: globalShift
+          Offset: 33
+          Type: 7 BaseType uint8
+        - Name: writing
+          Offset: 34
+          Type: 7 BaseType uint8
+        - Name: clearSeq
+          Offset: 40
+          Type: 17 BaseType uint64
+      TablePtrSliceType: 279 GoSliceDataType []*table<string,string>.array
+      GroupType: 131 StructureType noalg.map.group[string]string
+    - __kind: GoMapType
+      ID: 173
+      Name: map[string]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
+      ByteSize: 8
+      GoRuntimeType: 1.153728e+06
+      GoKind: 21
+      HeaderType: 175 GoSwissMapHeaderType map<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
+    - __kind: GoMapType
+      ID: 37
+      Name: map[string][]*mime/multipart.FileHeader
+      ByteSize: 8
+      GoRuntimeType: 1.15296e+06
+      GoKind: 21
+      HeaderType: 39 GoSwissMapHeaderType map<string,[]*mime/multipart.FileHeader>
+    - __kind: GoMapType
+      ID: 36
+      Name: map[string][]string
+      ByteSize: 8
+      GoRuntimeType: 1.148352e+06
+      GoKind: 21
+      HeaderType: 16 GoSwissMapHeaderType map<string,[]string>
+    - __kind: GoMapType
+      ID: 155
+      Name: map[string]float64
+      ByteSize: 8
+      GoRuntimeType: 1.1536e+06
+      GoKind: 21
+      HeaderType: 157 GoSwissMapHeaderType map<string,float64>
+    - __kind: GoMapType
+      ID: 194
+      Name: map[string]interface {}
+      ByteSize: 8
+      GoRuntimeType: 1.146944e+06
+      GoKind: 21
+      HeaderType: 146 GoSwissMapHeaderType map<string,interface {}>
+    - __kind: GoMapType
+      ID: 123
+      Name: map[string]string
+      ByteSize: 8
+      GoRuntimeType: 1.149376e+06
+      GoKind: 21
+      HeaderType: 125 GoSwissMapHeaderType map<string,string>
+    - __kind: StructureType
+      ID: 64
+      Name: math/big.Int
+      ByteSize: 32
+      GoRuntimeType: 1.518112e+06
+      GoKind: 25
+      RawFields:
+        - Name: neg
+          Offset: 0
+          Type: 13 BaseType bool
+        - Name: abs
+          Offset: 8
+          Type: 65 GoSliceHeaderType math/big.nat
     - __kind: BaseType
-      ID: 212
-      Name: int8
-      ByteSize: 1
-      GoRuntimeType: 590432
-      GoKind: 3
+      ID: 67
+      Name: math/big.Word
+      ByteSize: 8
+      GoRuntimeType: 594656
+      GoKind: 7
+    - __kind: GoSliceHeaderType
+      ID: 65
+      Name: math/big.nat
+      ByteSize: 24
+      GoRuntimeType: 2.4216e+06
+      GoKind: 23
+      RawFields:
+        - Name: array
+          Offset: 0
+          Type: 66 PointerType *math/big.Word
+        - Name: len
+          Offset: 8
+          Type: 8 BaseType int
+        - Name: cap
+          Offset: 16
+          Type: 8 BaseType int
+      Data: 243 GoSliceDataType math/big.nat.array
+    - __kind: GoSliceDataType
+      ID: 243
+      Name: math/big.nat.array
+      ByteSize: 2048
+      Element: 67 BaseType math/big.Word
+    - __kind: StructureType
+      ID: 51
+      Name: mime/multipart.FileHeader
+      ByteSize: 88
+      GoRuntimeType: 2.010048e+06
+      GoKind: 25
+      RawFields:
+        - Name: Filename
+          Offset: 0
+          Type: 5 GoStringHeaderType string
+        - Name: Header
+          Offset: 16
+          Type: 52 GoMapType net/textproto.MIMEHeader
+        - Name: Size
+          Offset: 24
+          Type: 32 BaseType int64
+        - Name: content
+          Offset: 32
+          Type: 53 GoSliceHeaderType []uint8
+        - Name: tmpfile
+          Offset: 56
+          Type: 5 GoStringHeaderType string
+        - Name: tmpoff
+          Offset: 72
+          Type: 32 BaseType int64
+        - Name: tmpshared
+          Offset: 80
+          Type: 13 BaseType bool
+    - __kind: StructureType
+      ID: 35
+      Name: mime/multipart.Form
+      ByteSize: 16
+      GoRuntimeType: 1.501472e+06
+      GoKind: 25
+      RawFields:
+        - Name: Value
+          Offset: 0
+          Type: 36 GoMapType map[string][]string
+        - Name: File
+          Offset: 8
+          Type: 37 GoMapType map[string][]*mime/multipart.FileHeader
+    - __kind: GoSliceHeaderType
+      ID: 94
+      Name: net.IP
+      ByteSize: 24
+      GoRuntimeType: 2.17104e+06
+      GoKind: 23
+      RawFields:
+        - Name: array
+          Offset: 0
+          Type: 6 PointerType *uint8
+        - Name: len
+          Offset: 8
+          Type: 8 BaseType int
+        - Name: cap
+          Offset: 16
+          Type: 8 BaseType int
+      Data: 261 GoSliceDataType net.IP.array
+    - __kind: GoSliceDataType
+      ID: 261
+      Name: net.IP.array
+      ByteSize: 2048
+      Element: 7 BaseType uint8
+    - __kind: GoSliceHeaderType
+      ID: 101
+      Name: net.IPMask
+      ByteSize: 24
+      GoRuntimeType: 1.03808e+06
+      GoKind: 23
+      RawFields:
+        - Name: array
+          Offset: 0
+          Type: 6 PointerType *uint8
+        - Name: len
+          Offset: 8
+          Type: 8 BaseType int
+        - Name: cap
+          Offset: 16
+          Type: 8 BaseType int
+      Data: 267 GoSliceDataType net.IPMask.array
+    - __kind: GoSliceDataType
+      ID: 267
+      Name: net.IPMask.array
+      ByteSize: 2048
+      Element: 7 BaseType uint8
+    - __kind: StructureType
+      ID: 100
+      Name: net.IPNet
+      ByteSize: 48
+      GoRuntimeType: 1.482432e+06
+      GoKind: 25
+      RawFields:
+        - Name: IP
+          Offset: 0
+          Type: 94 GoSliceHeaderType net.IP
+        - Name: Mask
+          Offset: 24
+          Type: 101 GoSliceHeaderType net.IPMask
+    - __kind: GoMapType
+      ID: 14
+      Name: net/http.Header
+      ByteSize: 8
+      GoRuntimeType: 2.148192e+06
+      GoKind: 21
+      HeaderType: 16 GoSwissMapHeaderType map<string,[]string>
+    - __kind: StructureType
+      ID: 4
+      Name: net/http.Request
+      ByteSize: 304
+      GoRuntimeType: 2.398144e+06
+      GoKind: 25
+      RawFields:
+        - Name: Method
+          Offset: 0
+          Type: 5 GoStringHeaderType string
+        - Name: URL
+          Offset: 16
+          Type: 9 PointerType *net/url.URL
+        - Name: Proto
+          Offset: 24
+          Type: 5 GoStringHeaderType string
+        - Name: ProtoMajor
+          Offset: 40
+          Type: 8 BaseType int
+        - Name: ProtoMinor
+          Offset: 48
+          Type: 8 BaseType int
+        - Name: Header
+          Offset: 56
+          Type: 14 GoMapType net/http.Header
+        - Name: Body
+          Offset: 64
+          Type: 30 GoInterfaceType io.ReadCloser
+        - Name: GetBody
+          Offset: 80
+          Type: 31 GoSubroutineType func() (io.ReadCloser, error)
+        - Name: ContentLength
+          Offset: 88
+          Type: 32 BaseType int64
+        - Name: TransferEncoding
+          Offset: 96
+          Type: 28 GoSliceHeaderType []string
+        - Name: Close
+          Offset: 120
+          Type: 13 BaseType bool
+        - Name: Host
+          Offset: 128
+          Type: 5 GoStringHeaderType string
+        - Name: Form
+          Offset: 144
+          Type: 33 GoMapType net/url.Values
+        - Name: PostForm
+          Offset: 152
+          Type: 33 GoMapType net/url.Values
+        - Name: MultipartForm
+          Offset: 160
+          Type: 34 PointerType *mime/multipart.Form
+        - Name: Trailer
+          Offset: 168
+          Type: 14 GoMapType net/http.Header
+        - Name: RemoteAddr
+          Offset: 176
+          Type: 5 GoStringHeaderType string
+        - Name: RequestURI
+          Offset: 192
+          Type: 5 GoStringHeaderType string
+        - Name: TLS
+          Offset: 208
+          Type: 54 PointerType *crypto/tls.ConnectionState
+        - Name: Cancel
+          Offset: 216
+          Type: 114 GoChannelType <-chan struct {}
+        - Name: Response
+          Offset: 224
+          Type: 115 PointerType *net/http.Response
+        - Name: Pattern
+          Offset: 232
+          Type: 5 GoStringHeaderType string
+        - Name: ctx
+          Offset: 248
+          Type: 117 GoInterfaceType context.Context
+        - Name: pat
+          Offset: 264
+          Type: 118 PointerType *net/http.pattern
+        - Name: matches
+          Offset: 272
+          Type: 28 GoSliceHeaderType []string
+        - Name: otherValues
+          Offset: 296
+          Type: 123 GoMapType map[string]string
+    - __kind: StructureType
+      ID: 116
+      Name: net/http.Response
+      ByteSize: 144
+      GoRuntimeType: 2.260416e+06
+      GoKind: 25
+      RawFields:
+        - Name: Status
+          Offset: 0
+          Type: 5 GoStringHeaderType string
+        - Name: StatusCode
+          Offset: 16
+          Type: 8 BaseType int
+        - Name: Proto
+          Offset: 24
+          Type: 5 GoStringHeaderType string
+        - Name: ProtoMajor
+          Offset: 40
+          Type: 8 BaseType int
+        - Name: ProtoMinor
+          Offset: 48
+          Type: 8 BaseType int
+        - Name: Header
+          Offset: 56
+          Type: 14 GoMapType net/http.Header
+        - Name: Body
+          Offset: 64
+          Type: 30 GoInterfaceType io.ReadCloser
+        - Name: ContentLength
+          Offset: 80
+          Type: 32 BaseType int64
+        - Name: TransferEncoding
+          Offset: 88
+          Type: 28 GoSliceHeaderType []string
+        - Name: Close
+          Offset: 112
+          Type: 13 BaseType bool
+        - Name: Uncompressed
+          Offset: 113
+          Type: 13 BaseType bool
+        - Name: Trailer
+          Offset: 120
+          Type: 14 GoMapType net/http.Header
+        - Name: Request
+          Offset: 128
+          Type: 3 PointerType *net/http.Request
+        - Name: TLS
+          Offset: 136
+          Type: 54 PointerType *crypto/tls.ConnectionState
+    - __kind: GoInterfaceType
+      ID: 1
+      Name: net/http.ResponseWriter
+      ByteSize: 16
+      GoRuntimeType: 1.206848e+06
+      GoKind: 20
+      RawFields:
+        - Name: tab
+          Offset: 0
+          Type: 2 VoidPointerType unsafe.Pointer
+        - Name: data
+          Offset: 8
+          Type: 2 VoidPointerType unsafe.Pointer
+    - __kind: StructureType
+      ID: 119
+      Name: net/http.pattern
+      ByteSize: 88
+      GoRuntimeType: 1.866368e+06
+      GoKind: 25
+      RawFields:
+        - Name: str
+          Offset: 0
+          Type: 5 GoStringHeaderType string
+        - Name: method
+          Offset: 16
+          Type: 5 GoStringHeaderType string
+        - Name: host
+          Offset: 32
+          Type: 5 GoStringHeaderType string
+        - Name: segments
+          Offset: 48
+          Type: 120 GoSliceHeaderType []net/http.segment
+        - Name: loc
+          Offset: 72
+          Type: 5 GoStringHeaderType string
+    - __kind: StructureType
+      ID: 122
+      Name: net/http.segment
+      ByteSize: 24
+      GoRuntimeType: 1.6376e+06
+      GoKind: 25
+      RawFields:
+        - Name: s
+          Offset: 0
+          Type: 5 GoStringHeaderType string
+        - Name: wild
+          Offset: 16
+          Type: 13 BaseType bool
+        - Name: multi
+          Offset: 17
+          Type: 13 BaseType bool
+    - __kind: GoMapType
+      ID: 52
+      Name: net/textproto.MIMEHeader
+      ByteSize: 8
+      GoRuntimeType: 1.85488e+06
+      GoKind: 21
+      HeaderType: 16 GoSwissMapHeaderType map<string,[]string>
+    - __kind: StructureType
+      ID: 10
+      Name: net/url.URL
+      ByteSize: 144
+      GoRuntimeType: 2.173728e+06
+      GoKind: 25
+      RawFields:
+        - Name: Scheme
+          Offset: 0
+          Type: 5 GoStringHeaderType string
+        - Name: Opaque
+          Offset: 16
+          Type: 5 GoStringHeaderType string
+        - Name: User
+          Offset: 32
+          Type: 11 PointerType *net/url.Userinfo
+        - Name: Host
+          Offset: 40
+          Type: 5 GoStringHeaderType string
+        - Name: Path
+          Offset: 56
+          Type: 5 GoStringHeaderType string
+        - Name: RawPath
+          Offset: 72
+          Type: 5 GoStringHeaderType string
+        - Name: OmitHost
+          Offset: 88
+          Type: 13 BaseType bool
+        - Name: ForceQuery
+          Offset: 89
+          Type: 13 BaseType bool
+        - Name: RawQuery
+          Offset: 96
+          Type: 5 GoStringHeaderType string
+        - Name: Fragment
+          Offset: 112
+          Type: 5 GoStringHeaderType string
+        - Name: RawFragment
+          Offset: 128
+          Type: 5 GoStringHeaderType string
+    - __kind: StructureType
+      ID: 12
+      Name: net/url.Userinfo
+      ByteSize: 40
+      GoRuntimeType: 1.653536e+06
+      GoKind: 25
+      RawFields:
+        - Name: username
+          Offset: 0
+          Type: 5 GoStringHeaderType string
+        - Name: password
+          Offset: 16
+          Type: 5 GoStringHeaderType string
+        - Name: passwordSet
+          Offset: 32
+          Type: 13 BaseType bool
+    - __kind: GoMapType
+      ID: 33
+      Name: net/url.Values
+      ByteSize: 8
+      GoRuntimeType: 1.9208e+06
+      GoKind: 21
+      HeaderType: 16 GoSwissMapHeaderType map<string,[]string>
+    - __kind: ArrayType
+      ID: 182
+      Name: noalg.[8]struct { key string; elem *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute }
+      ByteSize: 192
+      GoRuntimeType: 711904
+      GoKind: 17
+      Count: 8
+      HasCount: true
+      Element: 183 StructureType noalg.struct { key string; elem *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute }
+    - __kind: ArrayType
+      ID: 46
+      Name: noalg.[8]struct { key string; elem []*mime/multipart.FileHeader }
+      ByteSize: 320
+      GoRuntimeType: 707328
+      GoKind: 17
+      Count: 8
+      HasCount: true
+      Element: 47 StructureType noalg.struct { key string; elem []*mime/multipart.FileHeader }
+    - __kind: ArrayType
+      ID: 26
+      Name: noalg.[8]struct { key string; elem []string }
+      ByteSize: 320
+      GoRuntimeType: 697312
+      GoKind: 17
+      Count: 8
+      HasCount: true
+      Element: 27 StructureType noalg.struct { key string; elem []string }
+    - __kind: ArrayType
+      ID: 164
+      Name: noalg.[8]struct { key string; elem float64 }
+      ByteSize: 192
+      GoRuntimeType: 711808
+      GoKind: 17
+      Count: 8
+      HasCount: true
+      Element: 165 StructureType noalg.struct { key string; elem float64 }
+    - __kind: ArrayType
+      ID: 153
+      Name: noalg.[8]struct { key string; elem interface {} }
+      ByteSize: 256
+      GoRuntimeType: 688768
+      GoKind: 17
+      Count: 8
+      HasCount: true
+      Element: 154 StructureType noalg.struct { key string; elem interface {} }
+    - __kind: ArrayType
+      ID: 132
+      Name: noalg.[8]struct { key string; elem string }
+      ByteSize: 256
+      GoRuntimeType: 701472
+      GoKind: 17
+      Count: 8
+      HasCount: true
+      Element: 133 StructureType noalg.struct { key string; elem string }
+    - __kind: StructureType
+      ID: 181
+      Name: noalg.map.group[string]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
+      ByteSize: 200
+      GoRuntimeType: 1.327872e+06
+      GoKind: 25
+      RawFields:
+        - Name: ctrl
+          Offset: 0
+          Type: 17 BaseType uint64
+        - Name: slots
+          Offset: 8
+          Type: 182 ArrayType noalg.[8]struct { key string; elem *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute }
+    - __kind: StructureType
+      ID: 45
+      Name: noalg.map.group[string][]*mime/multipart.FileHeader
+      ByteSize: 328
+      GoRuntimeType: 1.3216e+06
+      GoKind: 25
+      RawFields:
+        - Name: ctrl
+          Offset: 0
+          Type: 17 BaseType uint64
+        - Name: slots
+          Offset: 8
+          Type: 46 ArrayType noalg.[8]struct { key string; elem []*mime/multipart.FileHeader }
+    - __kind: StructureType
+      ID: 25
+      Name: noalg.map.group[string][]string
+      ByteSize: 328
+      GoRuntimeType: 1.312128e+06
+      GoKind: 25
+      RawFields:
+        - Name: ctrl
+          Offset: 0
+          Type: 17 BaseType uint64
+        - Name: slots
+          Offset: 8
+          Type: 26 ArrayType noalg.[8]struct { key string; elem []string }
+    - __kind: StructureType
+      ID: 163
+      Name: noalg.map.group[string]float64
+      ByteSize: 200
+      GoRuntimeType: 1.327616e+06
+      GoKind: 25
+      RawFields:
+        - Name: ctrl
+          Offset: 0
+          Type: 17 BaseType uint64
+        - Name: slots
+          Offset: 8
+          Type: 164 ArrayType noalg.[8]struct { key string; elem float64 }
+    - __kind: StructureType
+      ID: 152
+      Name: noalg.map.group[string]interface {}
+      ByteSize: 264
+      GoRuntimeType: 1.309568e+06
+      GoKind: 25
+      RawFields:
+        - Name: ctrl
+          Offset: 0
+          Type: 17 BaseType uint64
+        - Name: slots
+          Offset: 8
+          Type: 153 ArrayType noalg.[8]struct { key string; elem interface {} }
+    - __kind: StructureType
+      ID: 131
+      Name: noalg.map.group[string]string
+      ByteSize: 264
+      GoRuntimeType: 1.314432e+06
+      GoKind: 25
+      RawFields:
+        - Name: ctrl
+          Offset: 0
+          Type: 17 BaseType uint64
+        - Name: slots
+          Offset: 8
+          Type: 132 ArrayType noalg.[8]struct { key string; elem string }
+    - __kind: StructureType
+      ID: 183
+      Name: noalg.struct { key string; elem *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute }
+      ByteSize: 24
+      GoRuntimeType: 1.327744e+06
+      GoKind: 25
+      RawFields:
+        - Name: key
+          Offset: 0
+          Type: 5 GoStringHeaderType string
+        - Name: elem
+          Offset: 16
+          Type: 184 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
+    - __kind: StructureType
+      ID: 47
+      Name: noalg.struct { key string; elem []*mime/multipart.FileHeader }
+      ByteSize: 40
+      GoRuntimeType: 1.321472e+06
+      GoKind: 25
+      RawFields:
+        - Name: key
+          Offset: 0
+          Type: 5 GoStringHeaderType string
+        - Name: elem
+          Offset: 16
+          Type: 48 GoSliceHeaderType []*mime/multipart.FileHeader
+    - __kind: StructureType
+      ID: 27
+      Name: noalg.struct { key string; elem []string }
+      ByteSize: 40
+      GoRuntimeType: 1.312e+06
+      GoKind: 25
+      RawFields:
+        - Name: key
+          Offset: 0
+          Type: 5 GoStringHeaderType string
+        - Name: elem
+          Offset: 16
+          Type: 28 GoSliceHeaderType []string
+    - __kind: StructureType
+      ID: 165
+      Name: noalg.struct { key string; elem float64 }
+      ByteSize: 24
+      GoRuntimeType: 1.327488e+06
+      GoKind: 25
+      RawFields:
+        - Name: key
+          Offset: 0
+          Type: 5 GoStringHeaderType string
+        - Name: elem
+          Offset: 16
+          Type: 166 BaseType float64
+    - __kind: StructureType
+      ID: 154
+      Name: noalg.struct { key string; elem interface {} }
+      ByteSize: 32
+      GoRuntimeType: 1.30944e+06
+      GoKind: 25
+      RawFields:
+        - Name: key
+          Offset: 0
+          Type: 5 GoStringHeaderType string
+        - Name: elem
+          Offset: 16
+          Type: 62 GoEmptyInterfaceType interface {}
+    - __kind: StructureType
+      ID: 133
+      Name: noalg.struct { key string; elem string }
+      ByteSize: 32
+      GoRuntimeType: 1.314304e+06
+      GoKind: 25
+      RawFields:
+        - Name: key
+          Offset: 0
+          Type: 5 GoStringHeaderType string
+        - Name: elem
+          Offset: 16
+          Type: 5 GoStringHeaderType string
+    - __kind: GoStringHeaderType
+      ID: 5
+      Name: string
+      ByteSize: 16
+      GoRuntimeType: 590368
+      GoKind: 24
+      RawFields:
+        - Name: str
+          Offset: 0
+          Type: 230 PointerType *string.str
+        - Name: len
+          Offset: 8
+          Type: 8 BaseType int
+      Data: 229 GoStringDataType string.str
+    - __kind: GoStringDataType
+      ID: 229
+      Name: string.str
+      ByteSize: 2048
+    - __kind: StructureType
+      ID: 137
+      Name: sync.Mutex
+      ByteSize: 8
+      GoRuntimeType: 1.489632e+06
+      GoKind: 25
+      RawFields:
+        - Name: _
+          Offset: 0
+          Type: 138 StructureType sync.noCopy
+        - Name: mu
+          Offset: 0
+          Type: 139 StructureType internal/sync.Mutex
+    - __kind: StructureType
+      ID: 136
+      Name: sync.RWMutex
+      ByteSize: 24
+      GoRuntimeType: 1.872192e+06
+      GoKind: 25
+      RawFields:
+        - Name: w
+          Offset: 0
+          Type: 137 StructureType sync.Mutex
+        - Name: writerSem
+          Offset: 8
+          Type: 141 BaseType uint32
+        - Name: readerSem
+          Offset: 12
+          Type: 141 BaseType uint32
+        - Name: readerCount
+          Offset: 16
+          Type: 142 StructureType sync/atomic.Int32
+        - Name: readerWait
+          Offset: 20
+          Type: 142 StructureType sync/atomic.Int32
+    - __kind: StructureType
+      ID: 138
+      Name: sync.noCopy
+      GoRuntimeType: 1.003072e+06
+      GoKind: 25
+      RawFields: []
+    - __kind: StructureType
+      ID: 142
+      Name: sync/atomic.Int32
+      ByteSize: 4
+      GoRuntimeType: 1.490912e+06
+      GoKind: 25
+      RawFields:
+        - Name: _
+          Offset: 0
+          Type: 143 StructureType sync/atomic.noCopy
+        - Name: v
+          Offset: 0
+          Type: 140 BaseType int32
+    - __kind: StructureType
+      ID: 143
+      Name: sync/atomic.noCopy
+      GoRuntimeType: 1.003168e+06
+      GoKind: 25
+      RawFields: []
+    - __kind: StructureType
+      ID: 178
+      Name: table<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
+      ByteSize: 32
+      GoKind: 25
+      RawFields:
+        - Name: used
+          Offset: 0
+          Type: 22 BaseType uint16
+        - Name: capacity
+          Offset: 2
+          Type: 22 BaseType uint16
+        - Name: growthLeft
+          Offset: 4
+          Type: 22 BaseType uint16
+        - Name: localDepth
+          Offset: 6
+          Type: 7 BaseType uint8
+        - Name: index
+          Offset: 8
+          Type: 8 BaseType int
+        - Name: groups
+          Offset: 16
+          Type: 179 GoSwissMapGroupsType groupReference<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
+    - __kind: StructureType
+      ID: 42
+      Name: table<string,[]*mime/multipart.FileHeader>
+      ByteSize: 32
+      GoKind: 25
+      RawFields:
+        - Name: used
+          Offset: 0
+          Type: 22 BaseType uint16
+        - Name: capacity
+          Offset: 2
+          Type: 22 BaseType uint16
+        - Name: growthLeft
+          Offset: 4
+          Type: 22 BaseType uint16
+        - Name: localDepth
+          Offset: 6
+          Type: 7 BaseType uint8
+        - Name: index
+          Offset: 8
+          Type: 8 BaseType int
+        - Name: groups
+          Offset: 16
+          Type: 43 GoSwissMapGroupsType groupReference<string,[]*mime/multipart.FileHeader>
+    - __kind: StructureType
+      ID: 21
+      Name: table<string,[]string>
+      ByteSize: 32
+      GoKind: 25
+      RawFields:
+        - Name: used
+          Offset: 0
+          Type: 22 BaseType uint16
+        - Name: capacity
+          Offset: 2
+          Type: 22 BaseType uint16
+        - Name: growthLeft
+          Offset: 4
+          Type: 22 BaseType uint16
+        - Name: localDepth
+          Offset: 6
+          Type: 7 BaseType uint8
+        - Name: index
+          Offset: 8
+          Type: 8 BaseType int
+        - Name: groups
+          Offset: 16
+          Type: 23 GoSwissMapGroupsType groupReference<string,[]string>
+    - __kind: StructureType
+      ID: 160
+      Name: table<string,float64>
+      ByteSize: 32
+      GoKind: 25
+      RawFields:
+        - Name: used
+          Offset: 0
+          Type: 22 BaseType uint16
+        - Name: capacity
+          Offset: 2
+          Type: 22 BaseType uint16
+        - Name: growthLeft
+          Offset: 4
+          Type: 22 BaseType uint16
+        - Name: localDepth
+          Offset: 6
+          Type: 7 BaseType uint8
+        - Name: index
+          Offset: 8
+          Type: 8 BaseType int
+        - Name: groups
+          Offset: 16
+          Type: 161 GoSwissMapGroupsType groupReference<string,float64>
+    - __kind: StructureType
+      ID: 149
+      Name: table<string,interface {}>
+      ByteSize: 32
+      GoKind: 25
+      RawFields:
+        - Name: used
+          Offset: 0
+          Type: 22 BaseType uint16
+        - Name: capacity
+          Offset: 2
+          Type: 22 BaseType uint16
+        - Name: growthLeft
+          Offset: 4
+          Type: 22 BaseType uint16
+        - Name: localDepth
+          Offset: 6
+          Type: 7 BaseType uint8
+        - Name: index
+          Offset: 8
+          Type: 8 BaseType int
+        - Name: groups
+          Offset: 16
+          Type: 150 GoSwissMapGroupsType groupReference<string,interface {}>
+    - __kind: StructureType
+      ID: 128
+      Name: table<string,string>
+      ByteSize: 32
+      GoKind: 25
+      RawFields:
+        - Name: used
+          Offset: 0
+          Type: 22 BaseType uint16
+        - Name: capacity
+          Offset: 2
+          Type: 22 BaseType uint16
+        - Name: growthLeft
+          Offset: 4
+          Type: 22 BaseType uint16
+        - Name: localDepth
+          Offset: 6
+          Type: 7 BaseType uint8
+        - Name: index
+          Offset: 8
+          Type: 8 BaseType int
+        - Name: groups
+          Offset: 16
+          Type: 129 GoSwissMapGroupsType groupReference<string,string>
+    - __kind: StructureType
+      ID: 76
+      Name: time.Location
+      ByteSize: 104
+      GoRuntimeType: 2.006016e+06
+      GoKind: 25
+      RawFields:
+        - Name: name
+          Offset: 0
+          Type: 5 GoStringHeaderType string
+        - Name: zone
+          Offset: 16
+          Type: 77 GoSliceHeaderType []time.zone
+        - Name: tx
+          Offset: 40
+          Type: 80 GoSliceHeaderType []time.zoneTrans
+        - Name: extend
+          Offset: 64
+          Type: 5 GoStringHeaderType string
+        - Name: cacheStart
+          Offset: 80
+          Type: 32 BaseType int64
+        - Name: cacheEnd
+          Offset: 88
+          Type: 32 BaseType int64
+        - Name: cacheZone
+          Offset: 96
+          Type: 78 PointerType *time.zone
+    - __kind: StructureType
+      ID: 74
+      Name: time.Time
+      ByteSize: 24
+      GoRuntimeType: 2.424416e+06
+      GoKind: 25
+      RawFields:
+        - Name: wall
+          Offset: 0
+          Type: 17 BaseType uint64
+        - Name: ext
+          Offset: 8
+          Type: 32 BaseType int64
+        - Name: loc
+          Offset: 16
+          Type: 75 PointerType *time.Location
+    - __kind: StructureType
+      ID: 79
+      Name: time.zone
+      ByteSize: 32
+      GoRuntimeType: 1.642592e+06
+      GoKind: 25
+      RawFields:
+        - Name: name
+          Offset: 0
+          Type: 5 GoStringHeaderType string
+        - Name: offset
+          Offset: 16
+          Type: 8 BaseType int
+        - Name: isDST
+          Offset: 24
+          Type: 13 BaseType bool
+    - __kind: StructureType
+      ID: 82
+      Name: time.zoneTrans
+      ByteSize: 16
+      GoRuntimeType: 1.781504e+06
+      GoKind: 25
+      RawFields:
+        - Name: when
+          Offset: 0
+          Type: 32 BaseType int64
+        - Name: index
+          Offset: 8
+          Type: 7 BaseType uint8
+        - Name: isstd
+          Offset: 9
+          Type: 13 BaseType bool
+        - Name: isutc
+          Offset: 10
+          Type: 13 BaseType bool
     - __kind: BaseType
       ID: 213
       Name: uint
@@ -2981,474 +3414,41 @@ Types:
       GoRuntimeType: 591008
       GoKind: 7
     - __kind: BaseType
-      ID: 214
-      Name: float32
-      ByteSize: 4
-      GoRuntimeType: 591264
-      GoKind: 13
-    - __kind: PointerType
-      ID: 215
-      Name: '*uintptr'
-      ByteSize: 8
-      GoRuntimeType: 402400
-      GoKind: 22
-      Pointee: 18 BaseType uintptr
-    - __kind: PointerType
-      ID: 216
-      Name: '*int32'
-      ByteSize: 8
-      GoRuntimeType: 402016
-      GoKind: 22
-      Pointee: 140 BaseType int32
-    - __kind: PointerType
-      ID: 217
-      Name: '*uint32'
-      ByteSize: 8
-      GoRuntimeType: 402080
-      GoKind: 22
-      Pointee: 141 BaseType uint32
-    - __kind: BaseType
-      ID: 218
-      Name: complex64
-      ByteSize: 8
-      GoRuntimeType: 591136
-      GoKind: 15
-    - __kind: BaseType
-      ID: 219
-      Name: complex128
-      ByteSize: 16
-      GoRuntimeType: 591200
-      GoKind: 16
-    - __kind: PointerType
-      ID: 220
-      Name: '*int64'
-      ByteSize: 8
-      GoRuntimeType: 402144
-      GoKind: 22
-      Pointee: 32 BaseType int64
-    - __kind: PointerType
-      ID: 221
-      Name: '*uint64'
-      ByteSize: 8
-      GoRuntimeType: 402208
-      GoKind: 22
-      Pointee: 17 BaseType uint64
-    - __kind: PointerType
-      ID: 222
-      Name: '*uint16'
-      ByteSize: 8
-      GoRuntimeType: 401952
-      GoKind: 22
-      Pointee: 22 BaseType uint16
-    - __kind: PointerType
-      ID: 223
-      Name: '*int16'
-      ByteSize: 8
-      GoRuntimeType: 401888
-      GoKind: 22
-      Pointee: 224 BaseType int16
-    - __kind: BaseType
-      ID: 224
-      Name: int16
+      ID: 22
+      Name: uint16
       ByteSize: 2
-      GoRuntimeType: 590560
-      GoKind: 4
-    - __kind: PointerType
-      ID: 225
-      Name: '*int8'
+      GoRuntimeType: 590624
+      GoKind: 9
+    - __kind: BaseType
+      ID: 141
+      Name: uint32
+      ByteSize: 4
+      GoRuntimeType: 590752
+      GoKind: 10
+    - __kind: BaseType
+      ID: 17
+      Name: uint64
       ByteSize: 8
-      GoRuntimeType: 401760
-      GoKind: 22
-      Pointee: 212 BaseType int8
-    - __kind: PointerType
-      ID: 226
-      Name: '*error'
+      GoRuntimeType: 590880
+      GoKind: 11
+    - __kind: BaseType
+      ID: 7
+      Name: uint8
+      ByteSize: 1
+      GoRuntimeType: 590496
+      GoKind: 8
+    - __kind: BaseType
+      ID: 18
+      Name: uintptr
       ByteSize: 8
-      GoRuntimeType: 401632
-      GoKind: 22
-      Pointee: 211 GoInterfaceType error
-    - __kind: PointerType
-      ID: 227
-      Name: '*uint'
+      GoRuntimeType: 591072
+      GoKind: 12
+    - __kind: VoidPointerType
+      ID: 2
+      Name: unsafe.Pointer
       ByteSize: 8
-      GoRuntimeType: 402336
-      GoKind: 22
-      Pointee: 213 BaseType uint
-    - __kind: PointerType
-      ID: 228
-      Name: '*float32'
-      ByteSize: 8
-      GoRuntimeType: 402592
-      GoKind: 22
-      Pointee: 214 BaseType float32
-    - __kind: GoStringDataType
-      ID: 229
-      Name: string.str
-      ByteSize: 2048
-    - __kind: PointerType
-      ID: 230
-      Name: '*string.str'
-      ByteSize: 8
-      Pointee: 229 GoStringDataType string.str
-    - __kind: GoSliceDataType
-      ID: 231
-      Name: '[]*table<string,[]string>.array'
-      ByteSize: 8192
-      Element: 20 PointerType *table<string,[]string>
-    - __kind: GoSliceDataType
-      ID: 232
-      Name: '[]noalg.map.group[string][]string.array'
-      ByteSize: 2048
-      Element: 25 StructureType noalg.map.group[string][]string
-    - __kind: GoSliceDataType
-      ID: 233
-      Name: '[]string.array'
-      ByteSize: 2048
-      Element: 5 GoStringHeaderType string
-    - __kind: PointerType
-      ID: 234
-      Name: '*[]string.array'
-      ByteSize: 8
-      Pointee: 233 GoSliceDataType []string.array
-    - __kind: GoSliceDataType
-      ID: 235
-      Name: '[]*table<string,[]*mime/multipart.FileHeader>.array'
-      ByteSize: 8192
-      Element: 41 PointerType *table<string,[]*mime/multipart.FileHeader>
-    - __kind: GoSliceDataType
-      ID: 236
-      Name: '[]noalg.map.group[string][]*mime/multipart.FileHeader.array'
-      ByteSize: 2048
-      Element: 45 StructureType noalg.map.group[string][]*mime/multipart.FileHeader
-    - __kind: GoSliceDataType
-      ID: 237
-      Name: '[]*mime/multipart.FileHeader.array'
-      ByteSize: 2048
-      Element: 50 PointerType *mime/multipart.FileHeader
-    - __kind: PointerType
-      ID: 238
-      Name: '*[]*mime/multipart.FileHeader.array'
-      ByteSize: 8
-      Pointee: 237 GoSliceDataType []*mime/multipart.FileHeader.array
-    - __kind: GoSliceDataType
-      ID: 239
-      Name: '[]uint8.array'
-      ByteSize: 2048
-      Element: 7 BaseType uint8
-    - __kind: PointerType
-      ID: 240
-      Name: '*[]uint8.array'
-      ByteSize: 8
-      Pointee: 239 GoSliceDataType []uint8.array
-    - __kind: GoSliceDataType
-      ID: 241
-      Name: '[]*crypto/x509.Certificate.array'
-      ByteSize: 2048
-      Element: 58 PointerType *crypto/x509.Certificate
-    - __kind: PointerType
-      ID: 242
-      Name: '*[]*crypto/x509.Certificate.array'
-      ByteSize: 8
-      Pointee: 241 GoSliceDataType []*crypto/x509.Certificate.array
-    - __kind: GoSliceDataType
-      ID: 243
-      Name: math/big.nat.array
-      ByteSize: 2048
-      Element: 67 BaseType math/big.Word
-    - __kind: PointerType
-      ID: 244
-      Name: '*math/big.nat.array'
-      ByteSize: 8
-      Pointee: 243 GoSliceDataType math/big.nat.array
-    - __kind: GoSliceDataType
-      ID: 245
-      Name: '[]crypto/x509/pkix.AttributeTypeAndValue.array'
-      ByteSize: 2048
-      Element: 71 StructureType crypto/x509/pkix.AttributeTypeAndValue
-    - __kind: PointerType
-      ID: 246
-      Name: '*[]crypto/x509/pkix.AttributeTypeAndValue.array'
-      ByteSize: 8
-      Pointee: 245 GoSliceDataType []crypto/x509/pkix.AttributeTypeAndValue.array
-    - __kind: GoSliceDataType
-      ID: 247
-      Name: encoding/asn1.ObjectIdentifier.array
-      ByteSize: 2048
-      Element: 8 BaseType int
-    - __kind: PointerType
-      ID: 248
-      Name: '*encoding/asn1.ObjectIdentifier.array'
-      ByteSize: 8
-      Pointee: 247 GoSliceDataType encoding/asn1.ObjectIdentifier.array
-    - __kind: GoSliceDataType
-      ID: 249
-      Name: '[]time.zone.array'
-      ByteSize: 2048
-      Element: 79 StructureType time.zone
-    - __kind: PointerType
-      ID: 250
-      Name: '*[]time.zone.array'
-      ByteSize: 8
-      Pointee: 249 GoSliceDataType []time.zone.array
-    - __kind: GoSliceDataType
-      ID: 251
-      Name: '[]time.zoneTrans.array'
-      ByteSize: 2048
-      Element: 82 StructureType time.zoneTrans
-    - __kind: PointerType
-      ID: 252
-      Name: '*[]time.zoneTrans.array'
-      ByteSize: 8
-      Pointee: 251 GoSliceDataType []time.zoneTrans.array
-    - __kind: GoSliceDataType
-      ID: 253
-      Name: '[]crypto/x509/pkix.Extension.array'
-      ByteSize: 2048
-      Element: 86 StructureType crypto/x509/pkix.Extension
-    - __kind: PointerType
-      ID: 254
-      Name: '*[]crypto/x509/pkix.Extension.array'
-      ByteSize: 8
-      Pointee: 253 GoSliceDataType []crypto/x509/pkix.Extension.array
-    - __kind: GoSliceDataType
-      ID: 255
-      Name: '[]encoding/asn1.ObjectIdentifier.array'
-      ByteSize: 2048
-      Element: 72 GoSliceHeaderType encoding/asn1.ObjectIdentifier
-    - __kind: PointerType
-      ID: 256
-      Name: '*[]encoding/asn1.ObjectIdentifier.array'
-      ByteSize: 8
-      Pointee: 255 GoSliceDataType []encoding/asn1.ObjectIdentifier.array
-    - __kind: GoSliceDataType
-      ID: 257
-      Name: '[]crypto/x509.ExtKeyUsage.array'
-      ByteSize: 2048
-      Element: 91 BaseType crypto/x509.ExtKeyUsage
-    - __kind: PointerType
-      ID: 258
-      Name: '*[]crypto/x509.ExtKeyUsage.array'
-      ByteSize: 8
-      Pointee: 257 GoSliceDataType []crypto/x509.ExtKeyUsage.array
-    - __kind: GoSliceDataType
-      ID: 259
-      Name: '[]net.IP.array'
-      ByteSize: 2048
-      Element: 94 GoSliceHeaderType net.IP
-    - __kind: PointerType
-      ID: 260
-      Name: '*[]net.IP.array'
-      ByteSize: 8
-      Pointee: 259 GoSliceDataType []net.IP.array
-    - __kind: GoSliceDataType
-      ID: 261
-      Name: net.IP.array
-      ByteSize: 2048
-      Element: 7 BaseType uint8
-    - __kind: PointerType
-      ID: 262
-      Name: '*net.IP.array'
-      ByteSize: 8
-      Pointee: 261 GoSliceDataType net.IP.array
-    - __kind: GoSliceDataType
-      ID: 263
-      Name: '[]*net/url.URL.array'
-      ByteSize: 2048
-      Element: 9 PointerType *net/url.URL
-    - __kind: PointerType
-      ID: 264
-      Name: '*[]*net/url.URL.array'
-      ByteSize: 8
-      Pointee: 263 GoSliceDataType []*net/url.URL.array
-    - __kind: GoSliceDataType
-      ID: 265
-      Name: '[]*net.IPNet.array'
-      ByteSize: 2048
-      Element: 99 PointerType *net.IPNet
-    - __kind: PointerType
-      ID: 266
-      Name: '*[]*net.IPNet.array'
-      ByteSize: 8
-      Pointee: 265 GoSliceDataType []*net.IPNet.array
-    - __kind: GoSliceDataType
-      ID: 267
-      Name: net.IPMask.array
-      ByteSize: 2048
-      Element: 7 BaseType uint8
-    - __kind: PointerType
-      ID: 268
-      Name: '*net.IPMask.array'
-      ByteSize: 8
-      Pointee: 267 GoSliceDataType net.IPMask.array
-    - __kind: GoSliceDataType
-      ID: 269
-      Name: '[]crypto/x509.OID.array'
-      ByteSize: 2048
-      Element: 104 StructureType crypto/x509.OID
-    - __kind: PointerType
-      ID: 270
-      Name: '*[]crypto/x509.OID.array'
-      ByteSize: 8
-      Pointee: 269 GoSliceDataType []crypto/x509.OID.array
-    - __kind: GoSliceDataType
-      ID: 271
-      Name: '[]crypto/x509.PolicyMapping.array'
-      ByteSize: 2048
-      Element: 107 StructureType crypto/x509.PolicyMapping
-    - __kind: PointerType
-      ID: 272
-      Name: '*[]crypto/x509.PolicyMapping.array'
-      ByteSize: 8
-      Pointee: 271 GoSliceDataType []crypto/x509.PolicyMapping.array
-    - __kind: GoSliceDataType
-      ID: 273
-      Name: '[][]*crypto/x509.Certificate.array'
-      ByteSize: 2048
-      Element: 56 GoSliceHeaderType []*crypto/x509.Certificate
-    - __kind: PointerType
-      ID: 274
-      Name: '*[][]*crypto/x509.Certificate.array'
-      ByteSize: 8
-      Pointee: 273 GoSliceDataType [][]*crypto/x509.Certificate.array
-    - __kind: GoSliceDataType
-      ID: 275
-      Name: '[][]uint8.array'
-      ByteSize: 2048
-      Element: 53 GoSliceHeaderType []uint8
-    - __kind: PointerType
-      ID: 276
-      Name: '*[][]uint8.array'
-      ByteSize: 8
-      Pointee: 275 GoSliceDataType [][]uint8.array
-    - __kind: GoSliceDataType
-      ID: 277
-      Name: '[]net/http.segment.array'
-      ByteSize: 2048
-      Element: 122 StructureType net/http.segment
-    - __kind: PointerType
-      ID: 278
-      Name: '*[]net/http.segment.array'
-      ByteSize: 8
-      Pointee: 277 GoSliceDataType []net/http.segment.array
-    - __kind: GoSliceDataType
-      ID: 279
-      Name: '[]*table<string,string>.array'
-      ByteSize: 8192
-      Element: 127 PointerType *table<string,string>
-    - __kind: GoSliceDataType
-      ID: 280
-      Name: '[]noalg.map.group[string]string.array'
-      ByteSize: 2048
-      Element: 131 StructureType noalg.map.group[string]string
-    - __kind: GoSliceDataType
-      ID: 281
-      Name: '[]*table<string,interface {}>.array'
-      ByteSize: 8192
-      Element: 148 PointerType *table<string,interface {}>
-    - __kind: GoSliceDataType
-      ID: 282
-      Name: '[]noalg.map.group[string]interface {}.array'
-      ByteSize: 2048
-      Element: 152 StructureType noalg.map.group[string]interface {}
-    - __kind: GoSliceDataType
-      ID: 283
-      Name: '[]*table<string,float64>.array'
-      ByteSize: 8192
-      Element: 159 PointerType *table<string,float64>
-    - __kind: GoSliceDataType
-      ID: 284
-      Name: '[]noalg.map.group[string]float64.array'
-      ByteSize: 2048
-      Element: 163 StructureType noalg.map.group[string]float64
-    - __kind: GoSliceDataType
-      ID: 285
-      Name: '[]github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink.array'
-      ByteSize: 2048
-      Element: 169 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink
-    - __kind: PointerType
-      ID: 286
-      Name: '*[]github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink.array'
-      ByteSize: 8
-      Pointee: 285 GoSliceDataType []github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink.array
-    - __kind: GoSliceDataType
-      ID: 287
-      Name: '[]github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent.array'
-      ByteSize: 2048
-      Element: 172 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent
-    - __kind: PointerType
-      ID: 288
-      Name: '*[]github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent.array'
-      ByteSize: 8
-      Pointee: 287 GoSliceDataType []github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent.array
-    - __kind: GoSliceDataType
-      ID: 289
-      Name: '[]*table<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>.array'
-      ByteSize: 8192
-      Element: 177 PointerType *table<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
-    - __kind: GoSliceDataType
-      ID: 290
-      Name: '[]noalg.map.group[string]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute.array'
-      ByteSize: 2048
-      Element: 181 StructureType noalg.map.group[string]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
-    - __kind: GoSliceDataType
-      ID: 291
-      Name: '[]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttributeValue.array'
-      ByteSize: 2048
-      Element: 191 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttributeValue
-    - __kind: PointerType
-      ID: 292
-      Name: '*[]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttributeValue.array'
-      ByteSize: 8
-      Pointee: 291 GoSliceDataType []*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttributeValue.array
-    - __kind: GoSliceDataType
-      ID: 293
-      Name: '[]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span.array'
-      ByteSize: 2048
-      Element: 134 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span
-    - __kind: PointerType
-      ID: 294
-      Name: '*[]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span.array'
-      ByteSize: 8
-      Pointee: 293 GoSliceDataType []*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span.array
-    - __kind: EventRootType
-      ID: 295
-      Name: Probe[main.HandleHTTP]
-      ByteSize: 25
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: w
-          Offset: 1
-          Expression:
-            Type: 1 GoInterfaceType net/http.ResponseWriter
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 1, index: 0, name: w}
-                  Offset: 0
-                  ByteSize: 16
-        - Name: r
-          Offset: 17
-          Expression:
-            Type: 3 PointerType *net/http.Request
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 1, index: 1, name: r}
-                  Offset: 0
-                  ByteSize: 8
-    - __kind: EventRootType
-      ID: 296
-      Name: Probe[main.LookAtTheRequest]
-      ByteSize: 17
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: path
-          Offset: 1
-          Expression:
-            Type: 5 GoStringHeaderType string
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 2, index: 0, name: path}
-                  Offset: 0
-                  ByteSize: 16
+      GoRuntimeType: 591456
+      GoKind: 26
 MaxTypeID: 296
 Issues: []
 GoModuledataInfo: {FirstModuledataAddr: "0x18b56e0", TypesOffset: 296}

--- a/pkg/dyninst/irgen/testdata/snapshot/rc_tester.arch=amd64,toolchain=go1.24.3.yaml
+++ b/pkg/dyninst/irgen/testdata/snapshot/rc_tester.arch=amd64,toolchain=go1.24.3.yaml
@@ -33,7 +33,7 @@ Subprograms:
       InlinePCRanges: []
       Variables:
         - Name: w
-          Type: 1 GoInterfaceType net/http.ResponseWriter
+          Type: 36 GoInterfaceType net/http.ResponseWriter
           Locations:
             - Range: 0xd31360..0xd313cc
               Pieces:
@@ -56,7 +56,7 @@ Subprograms:
           IsParameter: true
           IsReturn: false
         - Name: r
-          Type: 3 PointerType *net/http.Request
+          Type: 37 PointerType *net/http.Request
           Locations:
             - Range: 0xd31360..0xd313d6
               Pieces: [{Size: 8, Op: {RegNo: 2, Shift: 0}}]
@@ -65,14 +65,14 @@ Subprograms:
           IsParameter: true
           IsReturn: false
         - Name: span
-          Type: 134 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span
+          Type: 157 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span
           Locations:
             - Range: 0xd313e8..0xd31421
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: false
           IsReturn: false
         - Name: '&buf'
-          Type: 205 PointerType *bytes.Buffer
+          Type: 224 PointerType *bytes.Buffer
           Locations:
             - Range: 0xd314f7..0xd31512
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
@@ -81,7 +81,7 @@ Subprograms:
           IsParameter: false
           IsReturn: false
         - Name: .autotmp_14
-          Type: 208 StructureType context.backgroundCtx
+          Type: 227 StructureType context.backgroundCtx
           Locations:
             - Range: 0xd31360..0xd315f9
               Pieces: [{Size: 0, Op: {CfaOffset: 0}}]
@@ -93,7 +93,7 @@ Subprograms:
       InlinePCRanges: []
       Variables:
         - Name: path
-          Type: 5 GoStringHeaderType string
+          Type: 9 GoStringHeaderType string
           Locations:
             - Range: 0xd316c0..0xd316e5
               Pieces:
@@ -105,77 +105,77 @@ Subprograms:
           IsReturn: false
 Types:
     - __kind: PointerType
-      ID: 57
+      ID: 81
       Name: '**crypto/x509.Certificate'
       ByteSize: 8
       GoKind: 22
-      Pointee: 58 PointerType *crypto/x509.Certificate
+      Pointee: 82 PointerType *crypto/x509.Certificate
     - __kind: PointerType
-      ID: 200
+      ID: 220
       Name: '**github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span'
       ByteSize: 8
       GoKind: 22
-      Pointee: 134 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span
+      Pointee: 157 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span
     - __kind: PointerType
-      ID: 190
+      ID: 210
       Name: '**github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttributeValue'
       ByteSize: 8
       GoKind: 22
-      Pointee: 191 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttributeValue
+      Pointee: 211 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttributeValue
     - __kind: PointerType
-      ID: 49
+      ID: 73
       Name: '**mime/multipart.FileHeader'
       ByteSize: 8
       GoKind: 22
-      Pointee: 50 PointerType *mime/multipart.FileHeader
+      Pointee: 74 PointerType *mime/multipart.FileHeader
     - __kind: PointerType
-      ID: 98
+      ID: 121
       Name: '**net.IPNet'
       ByteSize: 8
       GoKind: 22
-      Pointee: 99 PointerType *net.IPNet
+      Pointee: 122 PointerType *net.IPNet
     - __kind: PointerType
-      ID: 96
+      ID: 119
       Name: '**net/url.URL'
       ByteSize: 8
       GoKind: 22
-      Pointee: 9 PointerType *net/url.URL
+      Pointee: 39 PointerType *net/url.URL
     - __kind: PointerType
-      ID: 176
+      ID: 196
       Name: '**table<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>'
       ByteSize: 8
-      Pointee: 177 PointerType *table<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
+      Pointee: 197 PointerType *table<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
     - __kind: PointerType
-      ID: 40
+      ID: 64
       Name: '**table<string,[]*mime/multipart.FileHeader>'
       ByteSize: 8
-      Pointee: 41 PointerType *table<string,[]*mime/multipart.FileHeader>
+      Pointee: 65 PointerType *table<string,[]*mime/multipart.FileHeader>
     - __kind: PointerType
-      ID: 19
+      ID: 46
       Name: '**table<string,[]string>'
       ByteSize: 8
-      Pointee: 20 PointerType *table<string,[]string>
+      Pointee: 47 PointerType *table<string,[]string>
     - __kind: PointerType
-      ID: 158
+      ID: 179
       Name: '**table<string,float64>'
       ByteSize: 8
-      Pointee: 159 PointerType *table<string,float64>
+      Pointee: 180 PointerType *table<string,float64>
     - __kind: PointerType
-      ID: 147
+      ID: 168
       Name: '**table<string,interface {}>'
       ByteSize: 8
-      Pointee: 148 PointerType *table<string,interface {}>
+      Pointee: 169 PointerType *table<string,interface {}>
     - __kind: PointerType
-      ID: 126
+      ID: 149
       Name: '**table<string,string>'
       ByteSize: 8
-      Pointee: 127 PointerType *table<string,string>
+      Pointee: 150 PointerType *table<string,string>
     - __kind: PointerType
-      ID: 109
+      ID: 132
       Name: '*[]*crypto/x509.Certificate'
       ByteSize: 8
       GoKind: 22
-      Pointee: 56 GoSliceHeaderType []*crypto/x509.Certificate
+      Pointee: 80 GoSliceHeaderType []*crypto/x509.Certificate
     - __kind: PointerType
       ID: 242
       Name: '*[]*crypto/x509.Certificate.array'
@@ -282,274 +282,274 @@ Types:
       ByteSize: 8
       Pointee: 251 GoSliceDataType []time.zoneTrans.array
     - __kind: PointerType
-      ID: 111
+      ID: 134
       Name: '*[]uint8'
       ByteSize: 8
       GoRuntimeType: 483552
       GoKind: 22
-      Pointee: 53 GoSliceHeaderType []uint8
+      Pointee: 77 GoSliceHeaderType []uint8
     - __kind: PointerType
       ID: 240
       Name: '*[]uint8.array'
       ByteSize: 8
       Pointee: 239 GoSliceDataType []uint8.array
     - __kind: PointerType
-      ID: 210
+      ID: 11
       Name: '*bool'
       ByteSize: 8
       GoRuntimeType: 402720
       GoKind: 22
-      Pointee: 13 BaseType bool
+      Pointee: 4 BaseType bool
     - __kind: PointerType
-      ID: 205
+      ID: 224
       Name: '*bytes.Buffer'
       ByteSize: 8
       GoRuntimeType: 2.316768e+06
       GoKind: 22
-      Pointee: 206 StructureType bytes.Buffer
+      Pointee: 225 StructureType bytes.Buffer
     - __kind: PointerType
-      ID: 54
+      ID: 78
       Name: '*crypto/tls.ConnectionState'
       ByteSize: 8
       GoRuntimeType: 919424
       GoKind: 22
-      Pointee: 55 StructureType crypto/tls.ConnectionState
+      Pointee: 79 StructureType crypto/tls.ConnectionState
     - __kind: PointerType
-      ID: 58
+      ID: 82
       Name: '*crypto/x509.Certificate'
       ByteSize: 8
       GoRuntimeType: 2.082688e+06
       GoKind: 22
-      Pointee: 59 StructureType crypto/x509.Certificate
+      Pointee: 83 StructureType crypto/x509.Certificate
     - __kind: PointerType
-      ID: 90
+      ID: 113
       Name: '*crypto/x509.ExtKeyUsage'
       ByteSize: 8
       GoRuntimeType: 426912
       GoKind: 22
-      Pointee: 91 BaseType crypto/x509.ExtKeyUsage
+      Pointee: 114 BaseType crypto/x509.ExtKeyUsage
     - __kind: PointerType
-      ID: 103
+      ID: 126
       Name: '*crypto/x509.OID'
       ByteSize: 8
       GoRuntimeType: 1.989632e+06
       GoKind: 22
-      Pointee: 104 StructureType crypto/x509.OID
+      Pointee: 127 StructureType crypto/x509.OID
     - __kind: PointerType
-      ID: 106
+      ID: 129
       Name: '*crypto/x509.PolicyMapping'
       ByteSize: 8
       GoRuntimeType: 426976
       GoKind: 22
-      Pointee: 107 StructureType crypto/x509.PolicyMapping
+      Pointee: 130 StructureType crypto/x509.PolicyMapping
     - __kind: PointerType
-      ID: 70
+      ID: 94
       Name: '*crypto/x509/pkix.AttributeTypeAndValue'
       ByteSize: 8
       GoRuntimeType: 443680
       GoKind: 22
-      Pointee: 71 StructureType crypto/x509/pkix.AttributeTypeAndValue
+      Pointee: 95 StructureType crypto/x509/pkix.AttributeTypeAndValue
     - __kind: PointerType
-      ID: 85
+      ID: 108
       Name: '*crypto/x509/pkix.Extension'
       ByteSize: 8
       GoRuntimeType: 443872
       GoKind: 22
-      Pointee: 86 StructureType crypto/x509/pkix.Extension
+      Pointee: 109 StructureType crypto/x509/pkix.Extension
     - __kind: PointerType
-      ID: 88
+      ID: 111
       Name: '*encoding/asn1.ObjectIdentifier'
       ByteSize: 8
       GoRuntimeType: 1.0752e+06
       GoKind: 22
-      Pointee: 72 GoSliceHeaderType encoding/asn1.ObjectIdentifier
+      Pointee: 96 GoSliceHeaderType encoding/asn1.ObjectIdentifier
     - __kind: PointerType
       ID: 248
       Name: '*encoding/asn1.ObjectIdentifier.array'
       ByteSize: 8
       Pointee: 247 GoSliceDataType encoding/asn1.ObjectIdentifier.array
     - __kind: PointerType
-      ID: 226
+      ID: 33
       Name: '*error'
       ByteSize: 8
       GoRuntimeType: 401632
       GoKind: 22
-      Pointee: 211 GoInterfaceType error
+      Pointee: 13 GoInterfaceType error
     - __kind: PointerType
-      ID: 228
+      ID: 35
       Name: '*float32'
       ByteSize: 8
       GoRuntimeType: 402592
       GoKind: 22
-      Pointee: 214 BaseType float32
+      Pointee: 17 BaseType float32
     - __kind: PointerType
-      ID: 201
+      ID: 25
       Name: '*float64'
       ByteSize: 8
       GoRuntimeType: 402656
       GoKind: 22
-      Pointee: 166 BaseType float64
+      Pointee: 18 BaseType float64
     - __kind: PointerType
-      ID: 134
+      ID: 157
       Name: '*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span'
       ByteSize: 8
       GoRuntimeType: 2.32752e+06
       GoKind: 22
-      Pointee: 135 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span
+      Pointee: 158 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span
     - __kind: PointerType
-      ID: 195
+      ID: 215
       Name: '*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanContext'
       ByteSize: 8
       GoRuntimeType: 2.046208e+06
       GoKind: 22
-      Pointee: 196 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanContext
+      Pointee: 216 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanContext
     - __kind: PointerType
-      ID: 168
+      ID: 188
       Name: '*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink'
       ByteSize: 8
       GoRuntimeType: 1.210688e+06
       GoKind: 22
-      Pointee: 169 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink
+      Pointee: 189 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink
     - __kind: PointerType
-      ID: 171
+      ID: 191
       Name: '*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent'
       ByteSize: 8
       GoRuntimeType: 1.210816e+06
       GoKind: 22
-      Pointee: 172 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent
+      Pointee: 192 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent
     - __kind: PointerType
-      ID: 187
+      ID: 207
       Name: '*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttribute'
       ByteSize: 8
       GoRuntimeType: 1.211456e+06
       GoKind: 22
-      Pointee: 188 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttribute
+      Pointee: 208 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttribute
     - __kind: PointerType
-      ID: 191
+      ID: 211
       Name: '*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttributeValue'
       ByteSize: 8
       GoRuntimeType: 1.2112e+06
       GoKind: 22
-      Pointee: 192 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttributeValue
+      Pointee: 212 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttributeValue
     - __kind: PointerType
-      ID: 184
+      ID: 204
       Name: '*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute'
       ByteSize: 8
       GoRuntimeType: 1.211584e+06
       GoKind: 22
-      Pointee: 185 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
+      Pointee: 205 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
     - __kind: PointerType
-      ID: 197
+      ID: 217
       Name: '*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.trace'
       ByteSize: 8
       GoRuntimeType: 2.27024e+06
       GoKind: 22
-      Pointee: 198 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.trace
+      Pointee: 218 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.trace
     - __kind: PointerType
-      ID: 73
+      ID: 27
       Name: '*int'
       ByteSize: 8
       GoRuntimeType: 402272
       GoKind: 22
-      Pointee: 8 BaseType int
+      Pointee: 7 BaseType int
     - __kind: PointerType
-      ID: 223
+      ID: 30
       Name: '*int16'
       ByteSize: 8
       GoRuntimeType: 401888
       GoKind: 22
-      Pointee: 224 BaseType int16
+      Pointee: 31 BaseType int16
     - __kind: PointerType
-      ID: 216
+      ID: 20
       Name: '*int32'
       ByteSize: 8
       GoRuntimeType: 402016
       GoKind: 22
-      Pointee: 140 BaseType int32
+      Pointee: 10 BaseType int32
     - __kind: PointerType
-      ID: 220
+      ID: 26
       Name: '*int64'
       ByteSize: 8
       GoRuntimeType: 402144
       GoKind: 22
-      Pointee: 32 BaseType int64
+      Pointee: 12 BaseType int64
     - __kind: PointerType
-      ID: 225
+      ID: 32
       Name: '*int8'
       ByteSize: 8
       GoRuntimeType: 401760
       GoKind: 22
-      Pointee: 212 BaseType int8
+      Pointee: 15 BaseType int8
     - __kind: PointerType
-      ID: 174
+      ID: 194
       Name: '*map<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>'
       ByteSize: 8
-      Pointee: 175 GoSwissMapHeaderType map<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
+      Pointee: 195 GoSwissMapHeaderType map<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
     - __kind: PointerType
-      ID: 38
+      ID: 62
       Name: '*map<string,[]*mime/multipart.FileHeader>'
       ByteSize: 8
-      Pointee: 39 GoSwissMapHeaderType map<string,[]*mime/multipart.FileHeader>
+      Pointee: 63 GoSwissMapHeaderType map<string,[]*mime/multipart.FileHeader>
     - __kind: PointerType
-      ID: 15
+      ID: 44
       Name: '*map<string,[]string>'
       ByteSize: 8
-      Pointee: 16 GoSwissMapHeaderType map<string,[]string>
+      Pointee: 45 GoSwissMapHeaderType map<string,[]string>
     - __kind: PointerType
-      ID: 156
+      ID: 177
       Name: '*map<string,float64>'
       ByteSize: 8
-      Pointee: 157 GoSwissMapHeaderType map<string,float64>
+      Pointee: 178 GoSwissMapHeaderType map<string,float64>
     - __kind: PointerType
-      ID: 145
+      ID: 166
       Name: '*map<string,interface {}>'
       ByteSize: 8
-      Pointee: 146 GoSwissMapHeaderType map<string,interface {}>
+      Pointee: 167 GoSwissMapHeaderType map<string,interface {}>
     - __kind: PointerType
-      ID: 124
+      ID: 147
       Name: '*map<string,string>'
       ByteSize: 8
-      Pointee: 125 GoSwissMapHeaderType map<string,string>
+      Pointee: 148 GoSwissMapHeaderType map<string,string>
     - __kind: PointerType
-      ID: 63
+      ID: 87
       Name: '*math/big.Int'
       ByteSize: 8
       GoRuntimeType: 2.440832e+06
       GoKind: 22
-      Pointee: 64 StructureType math/big.Int
+      Pointee: 88 StructureType math/big.Int
     - __kind: PointerType
-      ID: 66
+      ID: 90
       Name: '*math/big.Word'
       ByteSize: 8
       GoRuntimeType: 429856
       GoKind: 22
-      Pointee: 67 BaseType math/big.Word
+      Pointee: 91 BaseType math/big.Word
     - __kind: PointerType
       ID: 244
       Name: '*math/big.nat.array'
       ByteSize: 8
       Pointee: 243 GoSliceDataType math/big.nat.array
     - __kind: PointerType
-      ID: 50
+      ID: 74
       Name: '*mime/multipart.FileHeader'
       ByteSize: 8
       GoRuntimeType: 920864
       GoKind: 22
-      Pointee: 51 StructureType mime/multipart.FileHeader
+      Pointee: 75 StructureType mime/multipart.FileHeader
     - __kind: PointerType
-      ID: 34
+      ID: 58
       Name: '*mime/multipart.Form'
       ByteSize: 8
       GoRuntimeType: 920960
       GoKind: 22
-      Pointee: 35 StructureType mime/multipart.Form
+      Pointee: 59 StructureType mime/multipart.Form
     - __kind: PointerType
-      ID: 93
+      ID: 116
       Name: '*net.IP'
       ByteSize: 8
       GoRuntimeType: 2.198272e+06
       GoKind: 22
-      Pointee: 94 GoSliceHeaderType net.IP
+      Pointee: 117 GoSliceHeaderType net.IP
     - __kind: PointerType
       ID: 262
       Name: '*net.IP.array'
@@ -561,191 +561,191 @@ Types:
       ByteSize: 8
       Pointee: 267 GoSliceDataType net.IPMask.array
     - __kind: PointerType
-      ID: 99
+      ID: 122
       Name: '*net.IPNet'
       ByteSize: 8
       GoRuntimeType: 1.204416e+06
       GoKind: 22
-      Pointee: 100 StructureType net.IPNet
+      Pointee: 123 StructureType net.IPNet
     - __kind: PointerType
-      ID: 3
+      ID: 37
       Name: '*net/http.Request'
       ByteSize: 8
       GoRuntimeType: 2.360384e+06
       GoKind: 22
-      Pointee: 4 StructureType net/http.Request
+      Pointee: 38 StructureType net/http.Request
     - __kind: PointerType
-      ID: 115
+      ID: 138
       Name: '*net/http.Response'
       ByteSize: 8
       GoRuntimeType: 1.751392e+06
       GoKind: 22
-      Pointee: 116 StructureType net/http.Response
+      Pointee: 139 StructureType net/http.Response
     - __kind: PointerType
-      ID: 118
+      ID: 141
       Name: '*net/http.pattern'
       ByteSize: 8
       GoRuntimeType: 1.637792e+06
       GoKind: 22
-      Pointee: 119 StructureType net/http.pattern
+      Pointee: 142 StructureType net/http.pattern
     - __kind: PointerType
-      ID: 121
+      ID: 144
       Name: '*net/http.segment'
       ByteSize: 8
       GoRuntimeType: 393504
       GoKind: 22
-      Pointee: 122 StructureType net/http.segment
+      Pointee: 145 StructureType net/http.segment
     - __kind: PointerType
-      ID: 9
+      ID: 39
       Name: '*net/url.URL'
       ByteSize: 8
       GoRuntimeType: 2.16048e+06
       GoKind: 22
-      Pointee: 10 StructureType net/url.URL
+      Pointee: 40 StructureType net/url.URL
     - __kind: PointerType
-      ID: 11
+      ID: 41
       Name: '*net/url.Userinfo'
       ByteSize: 8
       GoRuntimeType: 1.222208e+06
       GoKind: 22
-      Pointee: 12 StructureType net/url.Userinfo
+      Pointee: 42 StructureType net/url.Userinfo
     - __kind: PointerType
-      ID: 180
+      ID: 200
       Name: '*noalg.map.group[string]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute'
       ByteSize: 8
-      Pointee: 181 StructureType noalg.map.group[string]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
+      Pointee: 201 StructureType noalg.map.group[string]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
     - __kind: PointerType
-      ID: 44
+      ID: 68
       Name: '*noalg.map.group[string][]*mime/multipart.FileHeader'
       ByteSize: 8
-      Pointee: 45 StructureType noalg.map.group[string][]*mime/multipart.FileHeader
+      Pointee: 69 StructureType noalg.map.group[string][]*mime/multipart.FileHeader
     - __kind: PointerType
-      ID: 24
+      ID: 50
       Name: '*noalg.map.group[string][]string'
       ByteSize: 8
-      Pointee: 25 StructureType noalg.map.group[string][]string
+      Pointee: 51 StructureType noalg.map.group[string][]string
     - __kind: PointerType
-      ID: 162
+      ID: 183
       Name: '*noalg.map.group[string]float64'
       ByteSize: 8
-      Pointee: 163 StructureType noalg.map.group[string]float64
+      Pointee: 184 StructureType noalg.map.group[string]float64
     - __kind: PointerType
-      ID: 151
+      ID: 172
       Name: '*noalg.map.group[string]interface {}'
       ByteSize: 8
-      Pointee: 152 StructureType noalg.map.group[string]interface {}
+      Pointee: 173 StructureType noalg.map.group[string]interface {}
     - __kind: PointerType
-      ID: 130
+      ID: 153
       Name: '*noalg.map.group[string]string'
       ByteSize: 8
-      Pointee: 131 StructureType noalg.map.group[string]string
+      Pointee: 154 StructureType noalg.map.group[string]string
     - __kind: PointerType
-      ID: 29
+      ID: 22
       Name: '*string'
       ByteSize: 8
       GoRuntimeType: 401696
       GoKind: 22
-      Pointee: 5 GoStringHeaderType string
+      Pointee: 9 GoStringHeaderType string
     - __kind: PointerType
       ID: 230
       Name: '*string.str'
       ByteSize: 8
       Pointee: 229 GoStringDataType string.str
     - __kind: PointerType
-      ID: 177
+      ID: 197
       Name: '*table<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>'
       ByteSize: 8
-      Pointee: 178 StructureType table<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
+      Pointee: 198 StructureType table<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
     - __kind: PointerType
-      ID: 41
+      ID: 65
       Name: '*table<string,[]*mime/multipart.FileHeader>'
       ByteSize: 8
-      Pointee: 42 StructureType table<string,[]*mime/multipart.FileHeader>
+      Pointee: 66 StructureType table<string,[]*mime/multipart.FileHeader>
     - __kind: PointerType
-      ID: 20
+      ID: 47
       Name: '*table<string,[]string>'
       ByteSize: 8
-      Pointee: 21 StructureType table<string,[]string>
+      Pointee: 48 StructureType table<string,[]string>
     - __kind: PointerType
-      ID: 159
+      ID: 180
       Name: '*table<string,float64>'
       ByteSize: 8
-      Pointee: 160 StructureType table<string,float64>
+      Pointee: 181 StructureType table<string,float64>
     - __kind: PointerType
-      ID: 148
+      ID: 169
       Name: '*table<string,interface {}>'
       ByteSize: 8
-      Pointee: 149 StructureType table<string,interface {}>
+      Pointee: 170 StructureType table<string,interface {}>
     - __kind: PointerType
-      ID: 127
+      ID: 150
       Name: '*table<string,string>'
       ByteSize: 8
-      Pointee: 128 StructureType table<string,string>
+      Pointee: 151 StructureType table<string,string>
     - __kind: PointerType
-      ID: 75
+      ID: 98
       Name: '*time.Location'
       ByteSize: 8
       GoRuntimeType: 1.642784e+06
       GoKind: 22
-      Pointee: 76 StructureType time.Location
+      Pointee: 99 StructureType time.Location
     - __kind: PointerType
-      ID: 78
+      ID: 101
       Name: '*time.zone'
       ByteSize: 8
       GoRuntimeType: 396640
       GoKind: 22
-      Pointee: 79 StructureType time.zone
+      Pointee: 102 StructureType time.zone
     - __kind: PointerType
-      ID: 81
+      ID: 104
       Name: '*time.zoneTrans'
       ByteSize: 8
       GoRuntimeType: 396704
       GoKind: 22
-      Pointee: 82 StructureType time.zoneTrans
+      Pointee: 105 StructureType time.zoneTrans
     - __kind: PointerType
-      ID: 227
+      ID: 34
       Name: '*uint'
       ByteSize: 8
       GoRuntimeType: 402336
       GoKind: 22
-      Pointee: 213 BaseType uint
+      Pointee: 16 BaseType uint
     - __kind: PointerType
-      ID: 222
+      ID: 29
       Name: '*uint16'
       ByteSize: 8
       GoRuntimeType: 401952
       GoKind: 22
-      Pointee: 22 BaseType uint16
+      Pointee: 6 BaseType uint16
     - __kind: PointerType
-      ID: 217
+      ID: 21
       Name: '*uint32'
       ByteSize: 8
       GoRuntimeType: 402080
       GoKind: 22
-      Pointee: 141 BaseType uint32
+      Pointee: 2 BaseType uint32
     - __kind: PointerType
-      ID: 221
+      ID: 28
       Name: '*uint64'
       ByteSize: 8
       GoRuntimeType: 402208
       GoKind: 22
-      Pointee: 17 BaseType uint64
+      Pointee: 8 BaseType uint64
     - __kind: PointerType
-      ID: 6
+      ID: 5
       Name: '*uint8'
       ByteSize: 8
       GoRuntimeType: 401824
       GoKind: 22
-      Pointee: 7 BaseType uint8
+      Pointee: 3 BaseType uint8
     - __kind: PointerType
-      ID: 215
+      ID: 19
       Name: '*uintptr'
       ByteSize: 8
       GoRuntimeType: 402400
       GoKind: 22
-      Pointee: 18 BaseType uintptr
+      Pointee: 1 BaseType uintptr
     - __kind: GoChannelType
-      ID: 114
+      ID: 137
       Name: <-chan struct {}
       GoRuntimeType: 603424
       GoKind: 18
@@ -758,7 +758,7 @@ Types:
         - Name: w
           Offset: 1
           Expression:
-            Type: 1 GoInterfaceType net/http.ResponseWriter
+            Type: 36 GoInterfaceType net/http.ResponseWriter
             Operations:
                 - __kind: LocationOp
                   Variable: {subprogram: 1, index: 0, name: w}
@@ -767,7 +767,7 @@ Types:
         - Name: r
           Offset: 17
           Expression:
-            Type: 3 PointerType *net/http.Request
+            Type: 37 PointerType *net/http.Request
             Operations:
                 - __kind: LocationOp
                   Variable: {subprogram: 1, index: 1, name: r}
@@ -782,14 +782,14 @@ Types:
         - Name: path
           Offset: 1
           Expression:
-            Type: 5 GoStringHeaderType string
+            Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
                   Variable: {subprogram: 2, index: 0, name: path}
                   Offset: 0
                   ByteSize: 16
     - __kind: GoSliceHeaderType
-      ID: 56
+      ID: 80
       Name: '[]*crypto/x509.Certificate'
       ByteSize: 24
       GoRuntimeType: 503808
@@ -797,21 +797,21 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 57 PointerType **crypto/x509.Certificate
+          Type: 81 PointerType **crypto/x509.Certificate
         - Name: len
           Offset: 8
-          Type: 8 BaseType int
+          Type: 7 BaseType int
         - Name: cap
           Offset: 16
-          Type: 8 BaseType int
+          Type: 7 BaseType int
       Data: 241 GoSliceDataType []*crypto/x509.Certificate.array
     - __kind: GoSliceDataType
       ID: 241
       Name: '[]*crypto/x509.Certificate.array'
       ByteSize: 2048
-      Element: 58 PointerType *crypto/x509.Certificate
+      Element: 82 PointerType *crypto/x509.Certificate
     - __kind: GoSliceHeaderType
-      ID: 199
+      ID: 219
       Name: '[]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span'
       ByteSize: 24
       GoRuntimeType: 491968
@@ -819,21 +819,21 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 200 PointerType **github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span
+          Type: 220 PointerType **github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span
         - Name: len
           Offset: 8
-          Type: 8 BaseType int
+          Type: 7 BaseType int
         - Name: cap
           Offset: 16
-          Type: 8 BaseType int
+          Type: 7 BaseType int
       Data: 293 GoSliceDataType []*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span.array
     - __kind: GoSliceDataType
       ID: 293
       Name: '[]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span.array'
       ByteSize: 2048
-      Element: 134 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span
+      Element: 157 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span
     - __kind: GoSliceHeaderType
-      ID: 189
+      ID: 209
       Name: '[]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttributeValue'
       ByteSize: 24
       GoRuntimeType: 491584
@@ -841,21 +841,21 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 190 PointerType **github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttributeValue
+          Type: 210 PointerType **github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttributeValue
         - Name: len
           Offset: 8
-          Type: 8 BaseType int
+          Type: 7 BaseType int
         - Name: cap
           Offset: 16
-          Type: 8 BaseType int
+          Type: 7 BaseType int
       Data: 291 GoSliceDataType []*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttributeValue.array
     - __kind: GoSliceDataType
       ID: 291
       Name: '[]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttributeValue.array'
       ByteSize: 2048
-      Element: 191 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttributeValue
+      Element: 211 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttributeValue
     - __kind: GoSliceHeaderType
-      ID: 48
+      ID: 72
       Name: '[]*mime/multipart.FileHeader'
       ByteSize: 24
       GoRuntimeType: 489088
@@ -863,21 +863,21 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 49 PointerType **mime/multipart.FileHeader
+          Type: 73 PointerType **mime/multipart.FileHeader
         - Name: len
           Offset: 8
-          Type: 8 BaseType int
+          Type: 7 BaseType int
         - Name: cap
           Offset: 16
-          Type: 8 BaseType int
+          Type: 7 BaseType int
       Data: 237 GoSliceDataType []*mime/multipart.FileHeader.array
     - __kind: GoSliceDataType
       ID: 237
       Name: '[]*mime/multipart.FileHeader.array'
       ByteSize: 2048
-      Element: 50 PointerType *mime/multipart.FileHeader
+      Element: 74 PointerType *mime/multipart.FileHeader
     - __kind: GoSliceHeaderType
-      ID: 97
+      ID: 120
       Name: '[]*net.IPNet'
       ByteSize: 24
       GoRuntimeType: 518592
@@ -885,21 +885,21 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 98 PointerType **net.IPNet
+          Type: 121 PointerType **net.IPNet
         - Name: len
           Offset: 8
-          Type: 8 BaseType int
+          Type: 7 BaseType int
         - Name: cap
           Offset: 16
-          Type: 8 BaseType int
+          Type: 7 BaseType int
       Data: 265 GoSliceDataType []*net.IPNet.array
     - __kind: GoSliceDataType
       ID: 265
       Name: '[]*net.IPNet.array'
       ByteSize: 2048
-      Element: 99 PointerType *net.IPNet
+      Element: 122 PointerType *net.IPNet
     - __kind: GoSliceHeaderType
-      ID: 95
+      ID: 118
       Name: '[]*net/url.URL'
       ByteSize: 24
       GoRuntimeType: 518528
@@ -907,51 +907,51 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 96 PointerType **net/url.URL
+          Type: 119 PointerType **net/url.URL
         - Name: len
           Offset: 8
-          Type: 8 BaseType int
+          Type: 7 BaseType int
         - Name: cap
           Offset: 16
-          Type: 8 BaseType int
+          Type: 7 BaseType int
       Data: 263 GoSliceDataType []*net/url.URL.array
     - __kind: GoSliceDataType
       ID: 263
       Name: '[]*net/url.URL.array'
       ByteSize: 2048
-      Element: 9 PointerType *net/url.URL
+      Element: 39 PointerType *net/url.URL
     - __kind: GoSliceDataType
       ID: 289
       Name: '[]*table<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>.array'
       ByteSize: 8192
-      Element: 177 PointerType *table<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
+      Element: 197 PointerType *table<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
     - __kind: GoSliceDataType
       ID: 235
       Name: '[]*table<string,[]*mime/multipart.FileHeader>.array'
       ByteSize: 8192
-      Element: 41 PointerType *table<string,[]*mime/multipart.FileHeader>
+      Element: 65 PointerType *table<string,[]*mime/multipart.FileHeader>
     - __kind: GoSliceDataType
       ID: 231
       Name: '[]*table<string,[]string>.array'
       ByteSize: 8192
-      Element: 20 PointerType *table<string,[]string>
+      Element: 47 PointerType *table<string,[]string>
     - __kind: GoSliceDataType
       ID: 283
       Name: '[]*table<string,float64>.array'
       ByteSize: 8192
-      Element: 159 PointerType *table<string,float64>
+      Element: 180 PointerType *table<string,float64>
     - __kind: GoSliceDataType
       ID: 281
       Name: '[]*table<string,interface {}>.array'
       ByteSize: 8192
-      Element: 148 PointerType *table<string,interface {}>
+      Element: 169 PointerType *table<string,interface {}>
     - __kind: GoSliceDataType
       ID: 279
       Name: '[]*table<string,string>.array'
       ByteSize: 8192
-      Element: 127 PointerType *table<string,string>
+      Element: 150 PointerType *table<string,string>
     - __kind: GoSliceHeaderType
-      ID: 108
+      ID: 131
       Name: '[][]*crypto/x509.Certificate'
       ByteSize: 24
       GoRuntimeType: 503936
@@ -959,21 +959,21 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 109 PointerType *[]*crypto/x509.Certificate
+          Type: 132 PointerType *[]*crypto/x509.Certificate
         - Name: len
           Offset: 8
-          Type: 8 BaseType int
+          Type: 7 BaseType int
         - Name: cap
           Offset: 16
-          Type: 8 BaseType int
+          Type: 7 BaseType int
       Data: 273 GoSliceDataType [][]*crypto/x509.Certificate.array
     - __kind: GoSliceDataType
       ID: 273
       Name: '[][]*crypto/x509.Certificate.array'
       ByteSize: 2048
-      Element: 56 GoSliceHeaderType []*crypto/x509.Certificate
+      Element: 80 GoSliceHeaderType []*crypto/x509.Certificate
     - __kind: GoSliceHeaderType
-      ID: 110
+      ID: 133
       Name: '[][]uint8'
       ByteSize: 24
       GoRuntimeType: 483936
@@ -981,21 +981,21 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 111 PointerType *[]uint8
+          Type: 134 PointerType *[]uint8
         - Name: len
           Offset: 8
-          Type: 8 BaseType int
+          Type: 7 BaseType int
         - Name: cap
           Offset: 16
-          Type: 8 BaseType int
+          Type: 7 BaseType int
       Data: 275 GoSliceDataType [][]uint8.array
     - __kind: GoSliceDataType
       ID: 275
       Name: '[][]uint8.array'
       ByteSize: 2048
-      Element: 53 GoSliceHeaderType []uint8
+      Element: 77 GoSliceHeaderType []uint8
     - __kind: GoSliceHeaderType
-      ID: 89
+      ID: 112
       Name: '[]crypto/x509.ExtKeyUsage'
       ByteSize: 24
       GoRuntimeType: 505280
@@ -1003,21 +1003,21 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 90 PointerType *crypto/x509.ExtKeyUsage
+          Type: 113 PointerType *crypto/x509.ExtKeyUsage
         - Name: len
           Offset: 8
-          Type: 8 BaseType int
+          Type: 7 BaseType int
         - Name: cap
           Offset: 16
-          Type: 8 BaseType int
+          Type: 7 BaseType int
       Data: 257 GoSliceDataType []crypto/x509.ExtKeyUsage.array
     - __kind: GoSliceDataType
       ID: 257
       Name: '[]crypto/x509.ExtKeyUsage.array'
       ByteSize: 2048
-      Element: 91 BaseType crypto/x509.ExtKeyUsage
+      Element: 114 BaseType crypto/x509.ExtKeyUsage
     - __kind: GoSliceHeaderType
-      ID: 102
+      ID: 125
       Name: '[]crypto/x509.OID'
       ByteSize: 24
       GoRuntimeType: 518656
@@ -1025,21 +1025,21 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 103 PointerType *crypto/x509.OID
+          Type: 126 PointerType *crypto/x509.OID
         - Name: len
           Offset: 8
-          Type: 8 BaseType int
+          Type: 7 BaseType int
         - Name: cap
           Offset: 16
-          Type: 8 BaseType int
+          Type: 7 BaseType int
       Data: 269 GoSliceDataType []crypto/x509.OID.array
     - __kind: GoSliceDataType
       ID: 269
       Name: '[]crypto/x509.OID.array'
       ByteSize: 2048
-      Element: 104 StructureType crypto/x509.OID
+      Element: 127 StructureType crypto/x509.OID
     - __kind: GoSliceHeaderType
-      ID: 105
+      ID: 128
       Name: '[]crypto/x509.PolicyMapping'
       ByteSize: 24
       GoRuntimeType: 518720
@@ -1047,21 +1047,21 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 106 PointerType *crypto/x509.PolicyMapping
+          Type: 129 PointerType *crypto/x509.PolicyMapping
         - Name: len
           Offset: 8
-          Type: 8 BaseType int
+          Type: 7 BaseType int
         - Name: cap
           Offset: 16
-          Type: 8 BaseType int
+          Type: 7 BaseType int
       Data: 271 GoSliceDataType []crypto/x509.PolicyMapping.array
     - __kind: GoSliceDataType
       ID: 271
       Name: '[]crypto/x509.PolicyMapping.array'
       ByteSize: 2048
-      Element: 107 StructureType crypto/x509.PolicyMapping
+      Element: 130 StructureType crypto/x509.PolicyMapping
     - __kind: GoSliceHeaderType
-      ID: 69
+      ID: 93
       Name: '[]crypto/x509/pkix.AttributeTypeAndValue'
       ByteSize: 24
       GoRuntimeType: 519168
@@ -1069,21 +1069,21 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 70 PointerType *crypto/x509/pkix.AttributeTypeAndValue
+          Type: 94 PointerType *crypto/x509/pkix.AttributeTypeAndValue
         - Name: len
           Offset: 8
-          Type: 8 BaseType int
+          Type: 7 BaseType int
         - Name: cap
           Offset: 16
-          Type: 8 BaseType int
+          Type: 7 BaseType int
       Data: 245 GoSliceDataType []crypto/x509/pkix.AttributeTypeAndValue.array
     - __kind: GoSliceDataType
       ID: 245
       Name: '[]crypto/x509/pkix.AttributeTypeAndValue.array'
       ByteSize: 2048
-      Element: 71 StructureType crypto/x509/pkix.AttributeTypeAndValue
+      Element: 95 StructureType crypto/x509/pkix.AttributeTypeAndValue
     - __kind: GoSliceHeaderType
-      ID: 84
+      ID: 107
       Name: '[]crypto/x509/pkix.Extension'
       ByteSize: 24
       GoRuntimeType: 518400
@@ -1091,21 +1091,21 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 85 PointerType *crypto/x509/pkix.Extension
+          Type: 108 PointerType *crypto/x509/pkix.Extension
         - Name: len
           Offset: 8
-          Type: 8 BaseType int
+          Type: 7 BaseType int
         - Name: cap
           Offset: 16
-          Type: 8 BaseType int
+          Type: 7 BaseType int
       Data: 253 GoSliceDataType []crypto/x509/pkix.Extension.array
     - __kind: GoSliceDataType
       ID: 253
       Name: '[]crypto/x509/pkix.Extension.array'
       ByteSize: 2048
-      Element: 86 StructureType crypto/x509/pkix.Extension
+      Element: 109 StructureType crypto/x509/pkix.Extension
     - __kind: GoSliceHeaderType
-      ID: 87
+      ID: 110
       Name: '[]encoding/asn1.ObjectIdentifier'
       ByteSize: 24
       GoRuntimeType: 518464
@@ -1113,21 +1113,21 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 88 PointerType *encoding/asn1.ObjectIdentifier
+          Type: 111 PointerType *encoding/asn1.ObjectIdentifier
         - Name: len
           Offset: 8
-          Type: 8 BaseType int
+          Type: 7 BaseType int
         - Name: cap
           Offset: 16
-          Type: 8 BaseType int
+          Type: 7 BaseType int
       Data: 255 GoSliceDataType []encoding/asn1.ObjectIdentifier.array
     - __kind: GoSliceDataType
       ID: 255
       Name: '[]encoding/asn1.ObjectIdentifier.array'
       ByteSize: 2048
-      Element: 72 GoSliceHeaderType encoding/asn1.ObjectIdentifier
+      Element: 96 GoSliceHeaderType encoding/asn1.ObjectIdentifier
     - __kind: GoSliceHeaderType
-      ID: 167
+      ID: 187
       Name: '[]github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink'
       ByteSize: 24
       GoRuntimeType: 491520
@@ -1135,21 +1135,21 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 168 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink
+          Type: 188 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink
         - Name: len
           Offset: 8
-          Type: 8 BaseType int
+          Type: 7 BaseType int
         - Name: cap
           Offset: 16
-          Type: 8 BaseType int
+          Type: 7 BaseType int
       Data: 285 GoSliceDataType []github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink.array
     - __kind: GoSliceDataType
       ID: 285
       Name: '[]github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink.array'
       ByteSize: 2048
-      Element: 169 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink
+      Element: 189 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink
     - __kind: GoSliceHeaderType
-      ID: 170
+      ID: 190
       Name: '[]github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent'
       ByteSize: 24
       GoRuntimeType: 491712
@@ -1157,21 +1157,21 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 171 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent
+          Type: 191 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent
         - Name: len
           Offset: 8
-          Type: 8 BaseType int
+          Type: 7 BaseType int
         - Name: cap
           Offset: 16
-          Type: 8 BaseType int
+          Type: 7 BaseType int
       Data: 287 GoSliceDataType []github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent.array
     - __kind: GoSliceDataType
       ID: 287
       Name: '[]github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent.array'
       ByteSize: 2048
-      Element: 172 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent
+      Element: 192 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent
     - __kind: GoSliceHeaderType
-      ID: 92
+      ID: 115
       Name: '[]net.IP'
       ByteSize: 24
       GoRuntimeType: 484896
@@ -1179,21 +1179,21 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 93 PointerType *net.IP
+          Type: 116 PointerType *net.IP
         - Name: len
           Offset: 8
-          Type: 8 BaseType int
+          Type: 7 BaseType int
         - Name: cap
           Offset: 16
-          Type: 8 BaseType int
+          Type: 7 BaseType int
       Data: 259 GoSliceDataType []net.IP.array
     - __kind: GoSliceDataType
       ID: 259
       Name: '[]net.IP.array'
       ByteSize: 2048
-      Element: 94 GoSliceHeaderType net.IP
+      Element: 117 GoSliceHeaderType net.IP
     - __kind: GoSliceHeaderType
-      ID: 120
+      ID: 143
       Name: '[]net/http.segment'
       ByteSize: 24
       GoRuntimeType: 486528
@@ -1201,51 +1201,51 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 121 PointerType *net/http.segment
+          Type: 144 PointerType *net/http.segment
         - Name: len
           Offset: 8
-          Type: 8 BaseType int
+          Type: 7 BaseType int
         - Name: cap
           Offset: 16
-          Type: 8 BaseType int
+          Type: 7 BaseType int
       Data: 277 GoSliceDataType []net/http.segment.array
     - __kind: GoSliceDataType
       ID: 277
       Name: '[]net/http.segment.array'
       ByteSize: 2048
-      Element: 122 StructureType net/http.segment
+      Element: 145 StructureType net/http.segment
     - __kind: GoSliceDataType
       ID: 290
       Name: '[]noalg.map.group[string]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute.array'
       ByteSize: 2048
-      Element: 181 StructureType noalg.map.group[string]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
+      Element: 201 StructureType noalg.map.group[string]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
     - __kind: GoSliceDataType
       ID: 236
       Name: '[]noalg.map.group[string][]*mime/multipart.FileHeader.array'
       ByteSize: 2048
-      Element: 45 StructureType noalg.map.group[string][]*mime/multipart.FileHeader
+      Element: 69 StructureType noalg.map.group[string][]*mime/multipart.FileHeader
     - __kind: GoSliceDataType
       ID: 232
       Name: '[]noalg.map.group[string][]string.array'
       ByteSize: 2048
-      Element: 25 StructureType noalg.map.group[string][]string
+      Element: 51 StructureType noalg.map.group[string][]string
     - __kind: GoSliceDataType
       ID: 284
       Name: '[]noalg.map.group[string]float64.array'
       ByteSize: 2048
-      Element: 163 StructureType noalg.map.group[string]float64
+      Element: 184 StructureType noalg.map.group[string]float64
     - __kind: GoSliceDataType
       ID: 282
       Name: '[]noalg.map.group[string]interface {}.array'
       ByteSize: 2048
-      Element: 152 StructureType noalg.map.group[string]interface {}
+      Element: 173 StructureType noalg.map.group[string]interface {}
     - __kind: GoSliceDataType
       ID: 280
       Name: '[]noalg.map.group[string]string.array'
       ByteSize: 2048
-      Element: 131 StructureType noalg.map.group[string]string
+      Element: 154 StructureType noalg.map.group[string]string
     - __kind: GoSliceHeaderType
-      ID: 28
+      ID: 54
       Name: '[]string'
       ByteSize: 24
       GoRuntimeType: 498176
@@ -1253,21 +1253,21 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 29 PointerType *string
+          Type: 22 PointerType *string
         - Name: len
           Offset: 8
-          Type: 8 BaseType int
+          Type: 7 BaseType int
         - Name: cap
           Offset: 16
-          Type: 8 BaseType int
+          Type: 7 BaseType int
       Data: 233 GoSliceDataType []string.array
     - __kind: GoSliceDataType
       ID: 233
       Name: '[]string.array'
       ByteSize: 2048
-      Element: 5 GoStringHeaderType string
+      Element: 9 GoStringHeaderType string
     - __kind: GoSliceHeaderType
-      ID: 77
+      ID: 100
       Name: '[]time.zone'
       ByteSize: 24
       GoRuntimeType: 491072
@@ -1275,21 +1275,21 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 78 PointerType *time.zone
+          Type: 101 PointerType *time.zone
         - Name: len
           Offset: 8
-          Type: 8 BaseType int
+          Type: 7 BaseType int
         - Name: cap
           Offset: 16
-          Type: 8 BaseType int
+          Type: 7 BaseType int
       Data: 249 GoSliceDataType []time.zone.array
     - __kind: GoSliceDataType
       ID: 249
       Name: '[]time.zone.array'
       ByteSize: 2048
-      Element: 79 StructureType time.zone
+      Element: 102 StructureType time.zone
     - __kind: GoSliceHeaderType
-      ID: 80
+      ID: 103
       Name: '[]time.zoneTrans'
       ByteSize: 24
       GoRuntimeType: 491136
@@ -1297,21 +1297,21 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 81 PointerType *time.zoneTrans
+          Type: 104 PointerType *time.zoneTrans
         - Name: len
           Offset: 8
-          Type: 8 BaseType int
+          Type: 7 BaseType int
         - Name: cap
           Offset: 16
-          Type: 8 BaseType int
+          Type: 7 BaseType int
       Data: 251 GoSliceDataType []time.zoneTrans.array
     - __kind: GoSliceDataType
       ID: 251
       Name: '[]time.zoneTrans.array'
       ByteSize: 2048
-      Element: 82 StructureType time.zoneTrans
+      Element: 105 StructureType time.zoneTrans
     - __kind: GoSliceHeaderType
-      ID: 53
+      ID: 77
       Name: '[]uint8'
       ByteSize: 24
       GoRuntimeType: 497024
@@ -1319,27 +1319,27 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 6 PointerType *uint8
+          Type: 5 PointerType *uint8
         - Name: len
           Offset: 8
-          Type: 8 BaseType int
+          Type: 7 BaseType int
         - Name: cap
           Offset: 16
-          Type: 8 BaseType int
+          Type: 7 BaseType int
       Data: 239 GoSliceDataType []uint8.array
     - __kind: GoSliceDataType
       ID: 239
       Name: '[]uint8.array'
       ByteSize: 2048
-      Element: 7 BaseType uint8
+      Element: 3 BaseType uint8
     - __kind: BaseType
-      ID: 13
+      ID: 4
       Name: bool
       ByteSize: 1
       GoRuntimeType: 591392
       GoKind: 1
     - __kind: StructureType
-      ID: 206
+      ID: 225
       Name: bytes.Buffer
       ByteSize: 40
       GoRuntimeType: 1.635488e+06
@@ -1347,33 +1347,33 @@ Types:
       RawFields:
         - Name: buf
           Offset: 0
-          Type: 53 GoSliceHeaderType []uint8
+          Type: 77 GoSliceHeaderType []uint8
         - Name: off
           Offset: 24
-          Type: 8 BaseType int
+          Type: 7 BaseType int
         - Name: lastRead
           Offset: 32
-          Type: 207 BaseType bytes.readOp
+          Type: 226 BaseType bytes.readOp
     - __kind: BaseType
-      ID: 207
+      ID: 226
       Name: bytes.readOp
       ByteSize: 1
       GoRuntimeType: 589536
       GoKind: 3
     - __kind: BaseType
-      ID: 219
+      ID: 24
       Name: complex128
       ByteSize: 16
       GoRuntimeType: 591200
       GoKind: 16
     - __kind: BaseType
-      ID: 218
+      ID: 23
       Name: complex64
       ByteSize: 8
       GoRuntimeType: 591136
       GoKind: 15
     - __kind: GoInterfaceType
-      ID: 117
+      ID: 140
       Name: context.Context
       ByteSize: 16
       GoRuntimeType: 1.298688e+06
@@ -1381,27 +1381,27 @@ Types:
       RawFields:
         - Name: tab
           Offset: 0
-          Type: 2 VoidPointerType unsafe.Pointer
+          Type: 14 VoidPointerType unsafe.Pointer
         - Name: data
           Offset: 8
-          Type: 2 VoidPointerType unsafe.Pointer
+          Type: 14 VoidPointerType unsafe.Pointer
     - __kind: StructureType
-      ID: 208
+      ID: 227
       Name: context.backgroundCtx
       GoRuntimeType: 1.827296e+06
       GoKind: 25
       RawFields:
         - Name: emptyCtx
           Offset: 0
-          Type: 209 StructureType context.emptyCtx
+          Type: 228 StructureType context.emptyCtx
     - __kind: StructureType
-      ID: 209
+      ID: 228
       Name: context.emptyCtx
       GoRuntimeType: 1.618752e+06
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 55
+      ID: 79
       Name: crypto/tls.ConnectionState
       ByteSize: 192
       GoRuntimeType: 2.302368e+06
@@ -1409,60 +1409,60 @@ Types:
       RawFields:
         - Name: Version
           Offset: 0
-          Type: 22 BaseType uint16
+          Type: 6 BaseType uint16
         - Name: HandshakeComplete
           Offset: 2
-          Type: 13 BaseType bool
+          Type: 4 BaseType bool
         - Name: DidResume
           Offset: 3
-          Type: 13 BaseType bool
+          Type: 4 BaseType bool
         - Name: CipherSuite
           Offset: 4
-          Type: 22 BaseType uint16
+          Type: 6 BaseType uint16
         - Name: NegotiatedProtocol
           Offset: 8
-          Type: 5 GoStringHeaderType string
+          Type: 9 GoStringHeaderType string
         - Name: NegotiatedProtocolIsMutual
           Offset: 24
-          Type: 13 BaseType bool
+          Type: 4 BaseType bool
         - Name: ServerName
           Offset: 32
-          Type: 5 GoStringHeaderType string
+          Type: 9 GoStringHeaderType string
         - Name: PeerCertificates
           Offset: 48
-          Type: 56 GoSliceHeaderType []*crypto/x509.Certificate
+          Type: 80 GoSliceHeaderType []*crypto/x509.Certificate
         - Name: VerifiedChains
           Offset: 72
-          Type: 108 GoSliceHeaderType [][]*crypto/x509.Certificate
+          Type: 131 GoSliceHeaderType [][]*crypto/x509.Certificate
         - Name: SignedCertificateTimestamps
           Offset: 96
-          Type: 110 GoSliceHeaderType [][]uint8
+          Type: 133 GoSliceHeaderType [][]uint8
         - Name: OCSPResponse
           Offset: 120
-          Type: 53 GoSliceHeaderType []uint8
+          Type: 77 GoSliceHeaderType []uint8
         - Name: TLSUnique
           Offset: 144
-          Type: 53 GoSliceHeaderType []uint8
+          Type: 77 GoSliceHeaderType []uint8
         - Name: ECHAccepted
           Offset: 168
-          Type: 13 BaseType bool
+          Type: 4 BaseType bool
         - Name: ekm
           Offset: 176
-          Type: 112 GoSubroutineType func(string, []uint8, int) ([]uint8, error)
+          Type: 135 GoSubroutineType func(string, []uint8, int) ([]uint8, error)
         - Name: testingOnlyDidHRR
           Offset: 184
-          Type: 13 BaseType bool
+          Type: 4 BaseType bool
         - Name: testingOnlyCurveID
           Offset: 186
-          Type: 113 BaseType crypto/tls.CurveID
+          Type: 136 BaseType crypto/tls.CurveID
     - __kind: BaseType
-      ID: 113
+      ID: 136
       Name: crypto/tls.CurveID
       ByteSize: 2
       GoRuntimeType: 843936
       GoKind: 9
     - __kind: StructureType
-      ID: 59
+      ID: 83
       Name: crypto/x509.Certificate
       ByteSize: 1424
       GoRuntimeType: 2.453248e+06
@@ -1470,174 +1470,174 @@ Types:
       RawFields:
         - Name: Raw
           Offset: 0
-          Type: 53 GoSliceHeaderType []uint8
+          Type: 77 GoSliceHeaderType []uint8
         - Name: RawTBSCertificate
           Offset: 24
-          Type: 53 GoSliceHeaderType []uint8
+          Type: 77 GoSliceHeaderType []uint8
         - Name: RawSubjectPublicKeyInfo
           Offset: 48
-          Type: 53 GoSliceHeaderType []uint8
+          Type: 77 GoSliceHeaderType []uint8
         - Name: RawSubject
           Offset: 72
-          Type: 53 GoSliceHeaderType []uint8
+          Type: 77 GoSliceHeaderType []uint8
         - Name: RawIssuer
           Offset: 96
-          Type: 53 GoSliceHeaderType []uint8
+          Type: 77 GoSliceHeaderType []uint8
         - Name: Signature
           Offset: 120
-          Type: 53 GoSliceHeaderType []uint8
+          Type: 77 GoSliceHeaderType []uint8
         - Name: SignatureAlgorithm
           Offset: 144
-          Type: 60 BaseType crypto/x509.SignatureAlgorithm
+          Type: 84 BaseType crypto/x509.SignatureAlgorithm
         - Name: PublicKeyAlgorithm
           Offset: 152
-          Type: 61 BaseType crypto/x509.PublicKeyAlgorithm
+          Type: 85 BaseType crypto/x509.PublicKeyAlgorithm
         - Name: PublicKey
           Offset: 160
-          Type: 62 GoEmptyInterfaceType interface {}
+          Type: 86 GoEmptyInterfaceType interface {}
         - Name: Version
           Offset: 176
-          Type: 8 BaseType int
+          Type: 7 BaseType int
         - Name: SerialNumber
           Offset: 184
-          Type: 63 PointerType *math/big.Int
+          Type: 87 PointerType *math/big.Int
         - Name: Issuer
           Offset: 192
-          Type: 68 StructureType crypto/x509/pkix.Name
+          Type: 92 StructureType crypto/x509/pkix.Name
         - Name: Subject
           Offset: 440
-          Type: 68 StructureType crypto/x509/pkix.Name
+          Type: 92 StructureType crypto/x509/pkix.Name
         - Name: NotBefore
           Offset: 688
-          Type: 74 StructureType time.Time
+          Type: 97 StructureType time.Time
         - Name: NotAfter
           Offset: 712
-          Type: 74 StructureType time.Time
+          Type: 97 StructureType time.Time
         - Name: KeyUsage
           Offset: 736
-          Type: 83 BaseType crypto/x509.KeyUsage
+          Type: 106 BaseType crypto/x509.KeyUsage
         - Name: Extensions
           Offset: 744
-          Type: 84 GoSliceHeaderType []crypto/x509/pkix.Extension
+          Type: 107 GoSliceHeaderType []crypto/x509/pkix.Extension
         - Name: ExtraExtensions
           Offset: 768
-          Type: 84 GoSliceHeaderType []crypto/x509/pkix.Extension
+          Type: 107 GoSliceHeaderType []crypto/x509/pkix.Extension
         - Name: UnhandledCriticalExtensions
           Offset: 792
-          Type: 87 GoSliceHeaderType []encoding/asn1.ObjectIdentifier
+          Type: 110 GoSliceHeaderType []encoding/asn1.ObjectIdentifier
         - Name: ExtKeyUsage
           Offset: 816
-          Type: 89 GoSliceHeaderType []crypto/x509.ExtKeyUsage
+          Type: 112 GoSliceHeaderType []crypto/x509.ExtKeyUsage
         - Name: UnknownExtKeyUsage
           Offset: 840
-          Type: 87 GoSliceHeaderType []encoding/asn1.ObjectIdentifier
+          Type: 110 GoSliceHeaderType []encoding/asn1.ObjectIdentifier
         - Name: BasicConstraintsValid
           Offset: 864
-          Type: 13 BaseType bool
+          Type: 4 BaseType bool
         - Name: IsCA
           Offset: 865
-          Type: 13 BaseType bool
+          Type: 4 BaseType bool
         - Name: MaxPathLen
           Offset: 872
-          Type: 8 BaseType int
+          Type: 7 BaseType int
         - Name: MaxPathLenZero
           Offset: 880
-          Type: 13 BaseType bool
+          Type: 4 BaseType bool
         - Name: SubjectKeyId
           Offset: 888
-          Type: 53 GoSliceHeaderType []uint8
+          Type: 77 GoSliceHeaderType []uint8
         - Name: AuthorityKeyId
           Offset: 912
-          Type: 53 GoSliceHeaderType []uint8
+          Type: 77 GoSliceHeaderType []uint8
         - Name: OCSPServer
           Offset: 936
-          Type: 28 GoSliceHeaderType []string
+          Type: 54 GoSliceHeaderType []string
         - Name: IssuingCertificateURL
           Offset: 960
-          Type: 28 GoSliceHeaderType []string
+          Type: 54 GoSliceHeaderType []string
         - Name: DNSNames
           Offset: 984
-          Type: 28 GoSliceHeaderType []string
+          Type: 54 GoSliceHeaderType []string
         - Name: EmailAddresses
           Offset: 1008
-          Type: 28 GoSliceHeaderType []string
+          Type: 54 GoSliceHeaderType []string
         - Name: IPAddresses
           Offset: 1032
-          Type: 92 GoSliceHeaderType []net.IP
+          Type: 115 GoSliceHeaderType []net.IP
         - Name: URIs
           Offset: 1056
-          Type: 95 GoSliceHeaderType []*net/url.URL
+          Type: 118 GoSliceHeaderType []*net/url.URL
         - Name: PermittedDNSDomainsCritical
           Offset: 1080
-          Type: 13 BaseType bool
+          Type: 4 BaseType bool
         - Name: PermittedDNSDomains
           Offset: 1088
-          Type: 28 GoSliceHeaderType []string
+          Type: 54 GoSliceHeaderType []string
         - Name: ExcludedDNSDomains
           Offset: 1112
-          Type: 28 GoSliceHeaderType []string
+          Type: 54 GoSliceHeaderType []string
         - Name: PermittedIPRanges
           Offset: 1136
-          Type: 97 GoSliceHeaderType []*net.IPNet
+          Type: 120 GoSliceHeaderType []*net.IPNet
         - Name: ExcludedIPRanges
           Offset: 1160
-          Type: 97 GoSliceHeaderType []*net.IPNet
+          Type: 120 GoSliceHeaderType []*net.IPNet
         - Name: PermittedEmailAddresses
           Offset: 1184
-          Type: 28 GoSliceHeaderType []string
+          Type: 54 GoSliceHeaderType []string
         - Name: ExcludedEmailAddresses
           Offset: 1208
-          Type: 28 GoSliceHeaderType []string
+          Type: 54 GoSliceHeaderType []string
         - Name: PermittedURIDomains
           Offset: 1232
-          Type: 28 GoSliceHeaderType []string
+          Type: 54 GoSliceHeaderType []string
         - Name: ExcludedURIDomains
           Offset: 1256
-          Type: 28 GoSliceHeaderType []string
+          Type: 54 GoSliceHeaderType []string
         - Name: CRLDistributionPoints
           Offset: 1280
-          Type: 28 GoSliceHeaderType []string
+          Type: 54 GoSliceHeaderType []string
         - Name: PolicyIdentifiers
           Offset: 1304
-          Type: 87 GoSliceHeaderType []encoding/asn1.ObjectIdentifier
+          Type: 110 GoSliceHeaderType []encoding/asn1.ObjectIdentifier
         - Name: Policies
           Offset: 1328
-          Type: 102 GoSliceHeaderType []crypto/x509.OID
+          Type: 125 GoSliceHeaderType []crypto/x509.OID
         - Name: InhibitAnyPolicy
           Offset: 1352
-          Type: 8 BaseType int
+          Type: 7 BaseType int
         - Name: InhibitAnyPolicyZero
           Offset: 1360
-          Type: 13 BaseType bool
+          Type: 4 BaseType bool
         - Name: InhibitPolicyMapping
           Offset: 1368
-          Type: 8 BaseType int
+          Type: 7 BaseType int
         - Name: InhibitPolicyMappingZero
           Offset: 1376
-          Type: 13 BaseType bool
+          Type: 4 BaseType bool
         - Name: RequireExplicitPolicy
           Offset: 1384
-          Type: 8 BaseType int
+          Type: 7 BaseType int
         - Name: RequireExplicitPolicyZero
           Offset: 1392
-          Type: 13 BaseType bool
+          Type: 4 BaseType bool
         - Name: PolicyMappings
           Offset: 1400
-          Type: 105 GoSliceHeaderType []crypto/x509.PolicyMapping
+          Type: 128 GoSliceHeaderType []crypto/x509.PolicyMapping
     - __kind: BaseType
-      ID: 91
+      ID: 114
       Name: crypto/x509.ExtKeyUsage
       ByteSize: 8
       GoRuntimeType: 594464
       GoKind: 2
     - __kind: BaseType
-      ID: 83
+      ID: 106
       Name: crypto/x509.KeyUsage
       ByteSize: 8
       GoRuntimeType: 594400
       GoKind: 2
     - __kind: StructureType
-      ID: 104
+      ID: 127
       Name: crypto/x509.OID
       ByteSize: 24
       GoRuntimeType: 1.989888e+06
@@ -1645,9 +1645,9 @@ Types:
       RawFields:
         - Name: der
           Offset: 0
-          Type: 53 GoSliceHeaderType []uint8
+          Type: 77 GoSliceHeaderType []uint8
     - __kind: StructureType
-      ID: 107
+      ID: 130
       Name: crypto/x509.PolicyMapping
       ByteSize: 48
       GoRuntimeType: 1.515072e+06
@@ -1655,24 +1655,24 @@ Types:
       RawFields:
         - Name: IssuerDomainPolicy
           Offset: 0
-          Type: 104 StructureType crypto/x509.OID
+          Type: 127 StructureType crypto/x509.OID
         - Name: SubjectDomainPolicy
           Offset: 24
-          Type: 104 StructureType crypto/x509.OID
+          Type: 127 StructureType crypto/x509.OID
     - __kind: BaseType
-      ID: 61
+      ID: 85
       Name: crypto/x509.PublicKeyAlgorithm
       ByteSize: 8
       GoRuntimeType: 846240
       GoKind: 2
     - __kind: BaseType
-      ID: 60
+      ID: 84
       Name: crypto/x509.SignatureAlgorithm
       ByteSize: 8
       GoRuntimeType: 1.134784e+06
       GoKind: 2
     - __kind: StructureType
-      ID: 71
+      ID: 95
       Name: crypto/x509/pkix.AttributeTypeAndValue
       ByteSize: 40
       GoRuntimeType: 1.527392e+06
@@ -1680,12 +1680,12 @@ Types:
       RawFields:
         - Name: Type
           Offset: 0
-          Type: 72 GoSliceHeaderType encoding/asn1.ObjectIdentifier
+          Type: 96 GoSliceHeaderType encoding/asn1.ObjectIdentifier
         - Name: Value
           Offset: 24
-          Type: 62 GoEmptyInterfaceType interface {}
+          Type: 86 GoEmptyInterfaceType interface {}
     - __kind: StructureType
-      ID: 86
+      ID: 109
       Name: crypto/x509/pkix.Extension
       ByteSize: 56
       GoRuntimeType: 1.678688e+06
@@ -1693,15 +1693,15 @@ Types:
       RawFields:
         - Name: Id
           Offset: 0
-          Type: 72 GoSliceHeaderType encoding/asn1.ObjectIdentifier
+          Type: 96 GoSliceHeaderType encoding/asn1.ObjectIdentifier
         - Name: Critical
           Offset: 24
-          Type: 13 BaseType bool
+          Type: 4 BaseType bool
         - Name: Value
           Offset: 32
-          Type: 53 GoSliceHeaderType []uint8
+          Type: 77 GoSliceHeaderType []uint8
     - __kind: StructureType
-      ID: 68
+      ID: 92
       Name: crypto/x509/pkix.Name
       ByteSize: 248
       GoRuntimeType: 2.241664e+06
@@ -1709,39 +1709,39 @@ Types:
       RawFields:
         - Name: Country
           Offset: 0
-          Type: 28 GoSliceHeaderType []string
+          Type: 54 GoSliceHeaderType []string
         - Name: Organization
           Offset: 24
-          Type: 28 GoSliceHeaderType []string
+          Type: 54 GoSliceHeaderType []string
         - Name: OrganizationalUnit
           Offset: 48
-          Type: 28 GoSliceHeaderType []string
+          Type: 54 GoSliceHeaderType []string
         - Name: Locality
           Offset: 72
-          Type: 28 GoSliceHeaderType []string
+          Type: 54 GoSliceHeaderType []string
         - Name: Province
           Offset: 96
-          Type: 28 GoSliceHeaderType []string
+          Type: 54 GoSliceHeaderType []string
         - Name: StreetAddress
           Offset: 120
-          Type: 28 GoSliceHeaderType []string
+          Type: 54 GoSliceHeaderType []string
         - Name: PostalCode
           Offset: 144
-          Type: 28 GoSliceHeaderType []string
+          Type: 54 GoSliceHeaderType []string
         - Name: SerialNumber
           Offset: 168
-          Type: 5 GoStringHeaderType string
+          Type: 9 GoStringHeaderType string
         - Name: CommonName
           Offset: 184
-          Type: 5 GoStringHeaderType string
+          Type: 9 GoStringHeaderType string
         - Name: Names
           Offset: 200
-          Type: 69 GoSliceHeaderType []crypto/x509/pkix.AttributeTypeAndValue
+          Type: 93 GoSliceHeaderType []crypto/x509/pkix.AttributeTypeAndValue
         - Name: ExtraNames
           Offset: 224
-          Type: 69 GoSliceHeaderType []crypto/x509/pkix.AttributeTypeAndValue
+          Type: 93 GoSliceHeaderType []crypto/x509/pkix.AttributeTypeAndValue
     - __kind: GoSliceHeaderType
-      ID: 72
+      ID: 96
       Name: encoding/asn1.ObjectIdentifier
       ByteSize: 24
       GoRuntimeType: 1.075328e+06
@@ -1749,21 +1749,21 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 73 PointerType *int
+          Type: 27 PointerType *int
         - Name: len
           Offset: 8
-          Type: 8 BaseType int
+          Type: 7 BaseType int
         - Name: cap
           Offset: 16
-          Type: 8 BaseType int
+          Type: 7 BaseType int
       Data: 247 GoSliceDataType encoding/asn1.ObjectIdentifier.array
     - __kind: GoSliceDataType
       ID: 247
       Name: encoding/asn1.ObjectIdentifier.array
       ByteSize: 2048
-      Element: 8 BaseType int
+      Element: 7 BaseType int
     - __kind: GoInterfaceType
-      ID: 211
+      ID: 13
       Name: error
       ByteSize: 16
       GoRuntimeType: 1.049984e+06
@@ -1771,42 +1771,42 @@ Types:
       RawFields:
         - Name: tab
           Offset: 0
-          Type: 2 VoidPointerType unsafe.Pointer
+          Type: 14 VoidPointerType unsafe.Pointer
         - Name: data
           Offset: 8
-          Type: 2 VoidPointerType unsafe.Pointer
+          Type: 14 VoidPointerType unsafe.Pointer
     - __kind: BaseType
-      ID: 214
+      ID: 17
       Name: float32
       ByteSize: 4
       GoRuntimeType: 591264
       GoKind: 13
     - __kind: BaseType
-      ID: 166
+      ID: 18
       Name: float64
       ByteSize: 8
       GoRuntimeType: 591328
       GoKind: 14
     - __kind: GoSubroutineType
-      ID: 204
+      ID: 223
       Name: func()
       ByteSize: 8
       GoRuntimeType: 482080
       GoKind: 19
     - __kind: GoSubroutineType
-      ID: 31
+      ID: 56
       Name: func() (io.ReadCloser, error)
       ByteSize: 8
       GoRuntimeType: 701280
       GoKind: 19
     - __kind: GoSubroutineType
-      ID: 112
+      ID: 135
       Name: func(string, []uint8, int) ([]uint8, error)
       ByteSize: 8
       GoRuntimeType: 1.020736e+06
       GoKind: 19
     - __kind: StructureType
-      ID: 135
+      ID: 158
       Name: github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span
       ByteSize: 288
       GoRuntimeType: 2.39312e+06
@@ -1814,81 +1814,81 @@ Types:
       RawFields:
         - Name: mu
           Offset: 0
-          Type: 136 StructureType sync.RWMutex
+          Type: 159 StructureType sync.RWMutex
         - Name: name
           Offset: 24
-          Type: 5 GoStringHeaderType string
+          Type: 9 GoStringHeaderType string
         - Name: service
           Offset: 40
-          Type: 5 GoStringHeaderType string
+          Type: 9 GoStringHeaderType string
         - Name: resource
           Offset: 56
-          Type: 5 GoStringHeaderType string
+          Type: 9 GoStringHeaderType string
         - Name: spanType
           Offset: 72
-          Type: 5 GoStringHeaderType string
+          Type: 9 GoStringHeaderType string
         - Name: start
           Offset: 88
-          Type: 32 BaseType int64
+          Type: 12 BaseType int64
         - Name: duration
           Offset: 96
-          Type: 32 BaseType int64
+          Type: 12 BaseType int64
         - Name: meta
           Offset: 104
-          Type: 123 GoMapType map[string]string
+          Type: 146 GoMapType map[string]string
         - Name: metaStruct
           Offset: 112
-          Type: 144 GoMapType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.metaStructMap
+          Type: 165 GoMapType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.metaStructMap
         - Name: metrics
           Offset: 120
-          Type: 155 GoMapType map[string]float64
+          Type: 176 GoMapType map[string]float64
         - Name: spanID
           Offset: 128
-          Type: 17 BaseType uint64
+          Type: 8 BaseType uint64
         - Name: traceID
           Offset: 136
-          Type: 17 BaseType uint64
+          Type: 8 BaseType uint64
         - Name: parentID
           Offset: 144
-          Type: 17 BaseType uint64
+          Type: 8 BaseType uint64
         - Name: error
           Offset: 152
-          Type: 140 BaseType int32
+          Type: 10 BaseType int32
         - Name: spanLinks
           Offset: 160
-          Type: 167 GoSliceHeaderType []github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink
+          Type: 187 GoSliceHeaderType []github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink
         - Name: spanEvents
           Offset: 184
-          Type: 170 GoSliceHeaderType []github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent
+          Type: 190 GoSliceHeaderType []github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent
         - Name: goExecTraced
           Offset: 208
-          Type: 13 BaseType bool
+          Type: 4 BaseType bool
         - Name: noDebugStack
           Offset: 209
-          Type: 13 BaseType bool
+          Type: 4 BaseType bool
         - Name: finished
           Offset: 210
-          Type: 13 BaseType bool
+          Type: 4 BaseType bool
         - Name: context
           Offset: 216
-          Type: 195 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanContext
+          Type: 215 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanContext
         - Name: integration
           Offset: 224
-          Type: 5 GoStringHeaderType string
+          Type: 9 GoStringHeaderType string
         - Name: supportsEvents
           Offset: 240
-          Type: 13 BaseType bool
+          Type: 4 BaseType bool
         - Name: pprofCtxActive
           Offset: 248
-          Type: 117 GoInterfaceType context.Context
+          Type: 140 GoInterfaceType context.Context
         - Name: pprofCtxRestore
           Offset: 264
-          Type: 117 GoInterfaceType context.Context
+          Type: 140 GoInterfaceType context.Context
         - Name: taskEnd
           Offset: 280
-          Type: 204 GoSubroutineType func()
+          Type: 223 GoSubroutineType func()
     - __kind: StructureType
-      ID: 196
+      ID: 216
       Name: github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanContext
       ByteSize: 168
       GoRuntimeType: 2.26176e+06
@@ -1896,48 +1896,48 @@ Types:
       RawFields:
         - Name: updated
           Offset: 0
-          Type: 13 BaseType bool
+          Type: 4 BaseType bool
         - Name: trace
           Offset: 8
-          Type: 197 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.trace
+          Type: 217 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.trace
         - Name: span
           Offset: 16
-          Type: 134 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span
+          Type: 157 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span
         - Name: errors
           Offset: 24
-          Type: 142 StructureType sync/atomic.Int32
+          Type: 163 StructureType sync/atomic.Int32
         - Name: reparentID
           Offset: 32
-          Type: 5 GoStringHeaderType string
+          Type: 9 GoStringHeaderType string
         - Name: isRemote
           Offset: 48
-          Type: 13 BaseType bool
+          Type: 4 BaseType bool
         - Name: traceID
           Offset: 49
-          Type: 203 ArrayType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.traceID
+          Type: 222 ArrayType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.traceID
         - Name: spanID
           Offset: 72
-          Type: 17 BaseType uint64
+          Type: 8 BaseType uint64
         - Name: mu
           Offset: 80
-          Type: 136 StructureType sync.RWMutex
+          Type: 159 StructureType sync.RWMutex
         - Name: baggage
           Offset: 104
-          Type: 123 GoMapType map[string]string
+          Type: 146 GoMapType map[string]string
         - Name: hasBaggage
           Offset: 112
-          Type: 141 BaseType uint32
+          Type: 2 BaseType uint32
         - Name: origin
           Offset: 120
-          Type: 5 GoStringHeaderType string
+          Type: 9 GoStringHeaderType string
         - Name: spanLinks
           Offset: 136
-          Type: 167 GoSliceHeaderType []github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink
+          Type: 187 GoSliceHeaderType []github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink
         - Name: baggageOnly
           Offset: 160
-          Type: 13 BaseType bool
+          Type: 4 BaseType bool
     - __kind: StructureType
-      ID: 169
+      ID: 189
       Name: github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink
       ByteSize: 56
       GoRuntimeType: 1.947136e+06
@@ -1945,37 +1945,37 @@ Types:
       RawFields:
         - Name: TraceID
           Offset: 0
-          Type: 17 BaseType uint64
+          Type: 8 BaseType uint64
         - Name: TraceIDHigh
           Offset: 8
-          Type: 17 BaseType uint64
+          Type: 8 BaseType uint64
         - Name: SpanID
           Offset: 16
-          Type: 17 BaseType uint64
+          Type: 8 BaseType uint64
         - Name: Attributes
           Offset: 24
-          Type: 123 GoMapType map[string]string
+          Type: 146 GoMapType map[string]string
         - Name: Tracestate
           Offset: 32
-          Type: 5 GoStringHeaderType string
+          Type: 9 GoStringHeaderType string
         - Name: Flags
           Offset: 48
-          Type: 141 BaseType uint32
+          Type: 2 BaseType uint32
     - __kind: GoMapType
-      ID: 144
+      ID: 165
       Name: github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.metaStructMap
       ByteSize: 8
       GoRuntimeType: 1.299968e+06
       GoKind: 21
-      HeaderType: 146 GoSwissMapHeaderType map<string,interface {}>
+      HeaderType: 167 GoSwissMapHeaderType map<string,interface {}>
     - __kind: BaseType
-      ID: 202
+      ID: 221
       Name: github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.samplingDecision
       ByteSize: 4
       GoRuntimeType: 590176
       GoKind: 10
     - __kind: StructureType
-      ID: 172
+      ID: 192
       Name: github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent
       ByteSize: 40
       GoRuntimeType: 1.781696e+06
@@ -1983,18 +1983,18 @@ Types:
       RawFields:
         - Name: Name
           Offset: 0
-          Type: 5 GoStringHeaderType string
+          Type: 9 GoStringHeaderType string
         - Name: TimeUnixNano
           Offset: 16
-          Type: 17 BaseType uint64
+          Type: 8 BaseType uint64
         - Name: Attributes
           Offset: 24
-          Type: 173 GoMapType map[string]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
+          Type: 193 GoMapType map[string]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
         - Name: RawAttributes
           Offset: 32
-          Type: 194 GoMapType map[string]interface {}
+          Type: 214 GoMapType map[string]interface {}
     - __kind: StructureType
-      ID: 188
+      ID: 208
       Name: github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttribute
       ByteSize: 24
       GoRuntimeType: 1.211328e+06
@@ -2002,9 +2002,9 @@ Types:
       RawFields:
         - Name: Values
           Offset: 0
-          Type: 189 GoSliceHeaderType []*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttributeValue
+          Type: 209 GoSliceHeaderType []*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttributeValue
     - __kind: StructureType
-      ID: 192
+      ID: 212
       Name: github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttributeValue
       ByteSize: 48
       GoRuntimeType: 1.869504e+06
@@ -2012,27 +2012,27 @@ Types:
       RawFields:
         - Name: Type
           Offset: 0
-          Type: 193 BaseType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttributeValueType
+          Type: 213 BaseType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttributeValueType
         - Name: StringValue
           Offset: 8
-          Type: 5 GoStringHeaderType string
+          Type: 9 GoStringHeaderType string
         - Name: BoolValue
           Offset: 24
-          Type: 13 BaseType bool
+          Type: 4 BaseType bool
         - Name: IntValue
           Offset: 32
-          Type: 32 BaseType int64
+          Type: 12 BaseType int64
         - Name: DoubleValue
           Offset: 40
-          Type: 166 BaseType float64
+          Type: 18 BaseType float64
     - __kind: BaseType
-      ID: 193
+      ID: 213
       Name: github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttributeValueType
       ByteSize: 4
       GoRuntimeType: 1.002496e+06
       GoKind: 5
     - __kind: StructureType
-      ID: 185
+      ID: 205
       Name: github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
       ByteSize: 56
       GoRuntimeType: 1.947392e+06
@@ -2040,30 +2040,30 @@ Types:
       RawFields:
         - Name: Type
           Offset: 0
-          Type: 186 BaseType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttributeType
+          Type: 206 BaseType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttributeType
         - Name: StringValue
           Offset: 8
-          Type: 5 GoStringHeaderType string
+          Type: 9 GoStringHeaderType string
         - Name: BoolValue
           Offset: 24
-          Type: 13 BaseType bool
+          Type: 4 BaseType bool
         - Name: IntValue
           Offset: 32
-          Type: 32 BaseType int64
+          Type: 12 BaseType int64
         - Name: DoubleValue
           Offset: 40
-          Type: 166 BaseType float64
+          Type: 18 BaseType float64
         - Name: ArrayValue
           Offset: 48
-          Type: 187 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttribute
+          Type: 207 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttribute
     - __kind: BaseType
-      ID: 186
+      ID: 206
       Name: github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttributeType
       ByteSize: 4
       GoRuntimeType: 1.0024e+06
       GoKind: 5
     - __kind: StructureType
-      ID: 198
+      ID: 218
       Name: github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.trace
       ByteSize: 104
       GoRuntimeType: 2.148896e+06
@@ -2071,159 +2071,159 @@ Types:
       RawFields:
         - Name: mu
           Offset: 0
-          Type: 136 StructureType sync.RWMutex
+          Type: 159 StructureType sync.RWMutex
         - Name: spans
           Offset: 24
-          Type: 199 GoSliceHeaderType []*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span
+          Type: 219 GoSliceHeaderType []*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span
         - Name: tags
           Offset: 48
-          Type: 123 GoMapType map[string]string
+          Type: 146 GoMapType map[string]string
         - Name: propagatingTags
           Offset: 56
-          Type: 123 GoMapType map[string]string
+          Type: 146 GoMapType map[string]string
         - Name: finished
           Offset: 64
-          Type: 8 BaseType int
+          Type: 7 BaseType int
         - Name: full
           Offset: 72
-          Type: 13 BaseType bool
+          Type: 4 BaseType bool
         - Name: priority
           Offset: 80
-          Type: 201 PointerType *float64
+          Type: 25 PointerType *float64
         - Name: locked
           Offset: 88
-          Type: 13 BaseType bool
+          Type: 4 BaseType bool
         - Name: samplingDecision
           Offset: 92
-          Type: 202 BaseType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.samplingDecision
+          Type: 221 BaseType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.samplingDecision
         - Name: root
           Offset: 96
-          Type: 134 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span
+          Type: 157 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span
     - __kind: ArrayType
-      ID: 203
+      ID: 222
       Name: github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.traceID
       ByteSize: 16
       GoRuntimeType: 914912
       GoKind: 17
       Count: 16
       HasCount: true
-      Element: 7 BaseType uint8
+      Element: 3 BaseType uint8
     - __kind: GoSwissMapGroupsType
-      ID: 179
+      ID: 199
       Name: groupReference<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 180 PointerType *noalg.map.group[string]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
+          Type: 200 PointerType *noalg.map.group[string]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
         - Name: lengthMask
           Offset: 8
-          Type: 17 BaseType uint64
-      GroupType: 181 StructureType noalg.map.group[string]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
+          Type: 8 BaseType uint64
+      GroupType: 201 StructureType noalg.map.group[string]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
       GroupSliceType: 290 GoSliceDataType []noalg.map.group[string]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute.array
     - __kind: GoSwissMapGroupsType
-      ID: 43
+      ID: 67
       Name: groupReference<string,[]*mime/multipart.FileHeader>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 44 PointerType *noalg.map.group[string][]*mime/multipart.FileHeader
+          Type: 68 PointerType *noalg.map.group[string][]*mime/multipart.FileHeader
         - Name: lengthMask
           Offset: 8
-          Type: 17 BaseType uint64
-      GroupType: 45 StructureType noalg.map.group[string][]*mime/multipart.FileHeader
+          Type: 8 BaseType uint64
+      GroupType: 69 StructureType noalg.map.group[string][]*mime/multipart.FileHeader
       GroupSliceType: 236 GoSliceDataType []noalg.map.group[string][]*mime/multipart.FileHeader.array
     - __kind: GoSwissMapGroupsType
-      ID: 23
+      ID: 49
       Name: groupReference<string,[]string>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 24 PointerType *noalg.map.group[string][]string
+          Type: 50 PointerType *noalg.map.group[string][]string
         - Name: lengthMask
           Offset: 8
-          Type: 17 BaseType uint64
-      GroupType: 25 StructureType noalg.map.group[string][]string
+          Type: 8 BaseType uint64
+      GroupType: 51 StructureType noalg.map.group[string][]string
       GroupSliceType: 232 GoSliceDataType []noalg.map.group[string][]string.array
     - __kind: GoSwissMapGroupsType
-      ID: 161
+      ID: 182
       Name: groupReference<string,float64>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 162 PointerType *noalg.map.group[string]float64
+          Type: 183 PointerType *noalg.map.group[string]float64
         - Name: lengthMask
           Offset: 8
-          Type: 17 BaseType uint64
-      GroupType: 163 StructureType noalg.map.group[string]float64
+          Type: 8 BaseType uint64
+      GroupType: 184 StructureType noalg.map.group[string]float64
       GroupSliceType: 284 GoSliceDataType []noalg.map.group[string]float64.array
     - __kind: GoSwissMapGroupsType
-      ID: 150
+      ID: 171
       Name: groupReference<string,interface {}>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 151 PointerType *noalg.map.group[string]interface {}
+          Type: 172 PointerType *noalg.map.group[string]interface {}
         - Name: lengthMask
           Offset: 8
-          Type: 17 BaseType uint64
-      GroupType: 152 StructureType noalg.map.group[string]interface {}
+          Type: 8 BaseType uint64
+      GroupType: 173 StructureType noalg.map.group[string]interface {}
       GroupSliceType: 282 GoSliceDataType []noalg.map.group[string]interface {}.array
     - __kind: GoSwissMapGroupsType
-      ID: 129
+      ID: 152
       Name: groupReference<string,string>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 130 PointerType *noalg.map.group[string]string
+          Type: 153 PointerType *noalg.map.group[string]string
         - Name: lengthMask
           Offset: 8
-          Type: 17 BaseType uint64
-      GroupType: 131 StructureType noalg.map.group[string]string
+          Type: 8 BaseType uint64
+      GroupType: 154 StructureType noalg.map.group[string]string
       GroupSliceType: 280 GoSliceDataType []noalg.map.group[string]string.array
     - __kind: BaseType
-      ID: 8
+      ID: 7
       Name: int
       ByteSize: 8
       GoRuntimeType: 590944
       GoKind: 2
     - __kind: BaseType
-      ID: 224
+      ID: 31
       Name: int16
       ByteSize: 2
       GoRuntimeType: 590560
       GoKind: 4
     - __kind: BaseType
-      ID: 140
+      ID: 10
       Name: int32
       ByteSize: 4
       GoRuntimeType: 590688
       GoKind: 5
     - __kind: BaseType
-      ID: 32
+      ID: 12
       Name: int64
       ByteSize: 8
       GoRuntimeType: 590816
       GoKind: 6
     - __kind: BaseType
-      ID: 212
+      ID: 15
       Name: int8
       ByteSize: 1
       GoRuntimeType: 590432
       GoKind: 3
     - __kind: GoEmptyInterfaceType
-      ID: 62
+      ID: 86
       Name: interface {}
       ByteSize: 16
       GoRuntimeType: 863648
@@ -2231,12 +2231,12 @@ Types:
       RawFields:
         - Name: _type
           Offset: 0
-          Type: 2 VoidPointerType unsafe.Pointer
+          Type: 14 VoidPointerType unsafe.Pointer
         - Name: data
           Offset: 8
-          Type: 2 VoidPointerType unsafe.Pointer
+          Type: 14 VoidPointerType unsafe.Pointer
     - __kind: StructureType
-      ID: 139
+      ID: 162
       Name: internal/sync.Mutex
       ByteSize: 8
       GoRuntimeType: 1.512992e+06
@@ -2244,12 +2244,12 @@ Types:
       RawFields:
         - Name: state
           Offset: 0
-          Type: 140 BaseType int32
+          Type: 10 BaseType int32
         - Name: sema
           Offset: 4
-          Type: 141 BaseType uint32
+          Type: 2 BaseType uint32
     - __kind: GoInterfaceType
-      ID: 30
+      ID: 55
       Name: io.ReadCloser
       ByteSize: 16
       GoRuntimeType: 1.130304e+06
@@ -2257,246 +2257,246 @@ Types:
       RawFields:
         - Name: tab
           Offset: 0
-          Type: 2 VoidPointerType unsafe.Pointer
+          Type: 14 VoidPointerType unsafe.Pointer
         - Name: data
           Offset: 8
-          Type: 2 VoidPointerType unsafe.Pointer
+          Type: 14 VoidPointerType unsafe.Pointer
     - __kind: GoSwissMapHeaderType
-      ID: 175
+      ID: 195
       Name: map<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
       ByteSize: 48
       GoKind: 25
       RawFields:
         - Name: used
           Offset: 0
-          Type: 17 BaseType uint64
+          Type: 8 BaseType uint64
         - Name: seed
           Offset: 8
-          Type: 18 BaseType uintptr
+          Type: 1 BaseType uintptr
         - Name: dirPtr
           Offset: 16
-          Type: 176 PointerType **table<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
+          Type: 196 PointerType **table<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
         - Name: dirLen
           Offset: 24
-          Type: 8 BaseType int
+          Type: 7 BaseType int
         - Name: globalDepth
           Offset: 32
-          Type: 7 BaseType uint8
+          Type: 3 BaseType uint8
         - Name: globalShift
           Offset: 33
-          Type: 7 BaseType uint8
+          Type: 3 BaseType uint8
         - Name: writing
           Offset: 34
-          Type: 7 BaseType uint8
+          Type: 3 BaseType uint8
         - Name: clearSeq
           Offset: 40
-          Type: 17 BaseType uint64
+          Type: 8 BaseType uint64
       TablePtrSliceType: 289 GoSliceDataType []*table<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>.array
-      GroupType: 181 StructureType noalg.map.group[string]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
+      GroupType: 201 StructureType noalg.map.group[string]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
     - __kind: GoSwissMapHeaderType
-      ID: 39
+      ID: 63
       Name: map<string,[]*mime/multipart.FileHeader>
       ByteSize: 48
       GoKind: 25
       RawFields:
         - Name: used
           Offset: 0
-          Type: 17 BaseType uint64
+          Type: 8 BaseType uint64
         - Name: seed
           Offset: 8
-          Type: 18 BaseType uintptr
+          Type: 1 BaseType uintptr
         - Name: dirPtr
           Offset: 16
-          Type: 40 PointerType **table<string,[]*mime/multipart.FileHeader>
+          Type: 64 PointerType **table<string,[]*mime/multipart.FileHeader>
         - Name: dirLen
           Offset: 24
-          Type: 8 BaseType int
+          Type: 7 BaseType int
         - Name: globalDepth
           Offset: 32
-          Type: 7 BaseType uint8
+          Type: 3 BaseType uint8
         - Name: globalShift
           Offset: 33
-          Type: 7 BaseType uint8
+          Type: 3 BaseType uint8
         - Name: writing
           Offset: 34
-          Type: 7 BaseType uint8
+          Type: 3 BaseType uint8
         - Name: clearSeq
           Offset: 40
-          Type: 17 BaseType uint64
+          Type: 8 BaseType uint64
       TablePtrSliceType: 235 GoSliceDataType []*table<string,[]*mime/multipart.FileHeader>.array
-      GroupType: 45 StructureType noalg.map.group[string][]*mime/multipart.FileHeader
+      GroupType: 69 StructureType noalg.map.group[string][]*mime/multipart.FileHeader
     - __kind: GoSwissMapHeaderType
-      ID: 16
+      ID: 45
       Name: map<string,[]string>
       ByteSize: 48
       GoKind: 25
       RawFields:
         - Name: used
           Offset: 0
-          Type: 17 BaseType uint64
+          Type: 8 BaseType uint64
         - Name: seed
           Offset: 8
-          Type: 18 BaseType uintptr
+          Type: 1 BaseType uintptr
         - Name: dirPtr
           Offset: 16
-          Type: 19 PointerType **table<string,[]string>
+          Type: 46 PointerType **table<string,[]string>
         - Name: dirLen
           Offset: 24
-          Type: 8 BaseType int
+          Type: 7 BaseType int
         - Name: globalDepth
           Offset: 32
-          Type: 7 BaseType uint8
+          Type: 3 BaseType uint8
         - Name: globalShift
           Offset: 33
-          Type: 7 BaseType uint8
+          Type: 3 BaseType uint8
         - Name: writing
           Offset: 34
-          Type: 7 BaseType uint8
+          Type: 3 BaseType uint8
         - Name: clearSeq
           Offset: 40
-          Type: 17 BaseType uint64
+          Type: 8 BaseType uint64
       TablePtrSliceType: 231 GoSliceDataType []*table<string,[]string>.array
-      GroupType: 25 StructureType noalg.map.group[string][]string
+      GroupType: 51 StructureType noalg.map.group[string][]string
     - __kind: GoSwissMapHeaderType
-      ID: 157
+      ID: 178
       Name: map<string,float64>
       ByteSize: 48
       GoKind: 25
       RawFields:
         - Name: used
           Offset: 0
-          Type: 17 BaseType uint64
+          Type: 8 BaseType uint64
         - Name: seed
           Offset: 8
-          Type: 18 BaseType uintptr
+          Type: 1 BaseType uintptr
         - Name: dirPtr
           Offset: 16
-          Type: 158 PointerType **table<string,float64>
+          Type: 179 PointerType **table<string,float64>
         - Name: dirLen
           Offset: 24
-          Type: 8 BaseType int
+          Type: 7 BaseType int
         - Name: globalDepth
           Offset: 32
-          Type: 7 BaseType uint8
+          Type: 3 BaseType uint8
         - Name: globalShift
           Offset: 33
-          Type: 7 BaseType uint8
+          Type: 3 BaseType uint8
         - Name: writing
           Offset: 34
-          Type: 7 BaseType uint8
+          Type: 3 BaseType uint8
         - Name: clearSeq
           Offset: 40
-          Type: 17 BaseType uint64
+          Type: 8 BaseType uint64
       TablePtrSliceType: 283 GoSliceDataType []*table<string,float64>.array
-      GroupType: 163 StructureType noalg.map.group[string]float64
+      GroupType: 184 StructureType noalg.map.group[string]float64
     - __kind: GoSwissMapHeaderType
-      ID: 146
+      ID: 167
       Name: map<string,interface {}>
       ByteSize: 48
       GoKind: 25
       RawFields:
         - Name: used
           Offset: 0
-          Type: 17 BaseType uint64
+          Type: 8 BaseType uint64
         - Name: seed
           Offset: 8
-          Type: 18 BaseType uintptr
+          Type: 1 BaseType uintptr
         - Name: dirPtr
           Offset: 16
-          Type: 147 PointerType **table<string,interface {}>
+          Type: 168 PointerType **table<string,interface {}>
         - Name: dirLen
           Offset: 24
-          Type: 8 BaseType int
+          Type: 7 BaseType int
         - Name: globalDepth
           Offset: 32
-          Type: 7 BaseType uint8
+          Type: 3 BaseType uint8
         - Name: globalShift
           Offset: 33
-          Type: 7 BaseType uint8
+          Type: 3 BaseType uint8
         - Name: writing
           Offset: 34
-          Type: 7 BaseType uint8
+          Type: 3 BaseType uint8
         - Name: clearSeq
           Offset: 40
-          Type: 17 BaseType uint64
+          Type: 8 BaseType uint64
       TablePtrSliceType: 281 GoSliceDataType []*table<string,interface {}>.array
-      GroupType: 152 StructureType noalg.map.group[string]interface {}
+      GroupType: 173 StructureType noalg.map.group[string]interface {}
     - __kind: GoSwissMapHeaderType
-      ID: 125
+      ID: 148
       Name: map<string,string>
       ByteSize: 48
       GoKind: 25
       RawFields:
         - Name: used
           Offset: 0
-          Type: 17 BaseType uint64
+          Type: 8 BaseType uint64
         - Name: seed
           Offset: 8
-          Type: 18 BaseType uintptr
+          Type: 1 BaseType uintptr
         - Name: dirPtr
           Offset: 16
-          Type: 126 PointerType **table<string,string>
+          Type: 149 PointerType **table<string,string>
         - Name: dirLen
           Offset: 24
-          Type: 8 BaseType int
+          Type: 7 BaseType int
         - Name: globalDepth
           Offset: 32
-          Type: 7 BaseType uint8
+          Type: 3 BaseType uint8
         - Name: globalShift
           Offset: 33
-          Type: 7 BaseType uint8
+          Type: 3 BaseType uint8
         - Name: writing
           Offset: 34
-          Type: 7 BaseType uint8
+          Type: 3 BaseType uint8
         - Name: clearSeq
           Offset: 40
-          Type: 17 BaseType uint64
+          Type: 8 BaseType uint64
       TablePtrSliceType: 279 GoSliceDataType []*table<string,string>.array
-      GroupType: 131 StructureType noalg.map.group[string]string
+      GroupType: 154 StructureType noalg.map.group[string]string
     - __kind: GoMapType
-      ID: 173
+      ID: 193
       Name: map[string]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
       ByteSize: 8
       GoRuntimeType: 1.153728e+06
       GoKind: 21
-      HeaderType: 175 GoSwissMapHeaderType map<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
+      HeaderType: 195 GoSwissMapHeaderType map<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
     - __kind: GoMapType
-      ID: 37
+      ID: 61
       Name: map[string][]*mime/multipart.FileHeader
       ByteSize: 8
       GoRuntimeType: 1.15296e+06
       GoKind: 21
-      HeaderType: 39 GoSwissMapHeaderType map<string,[]*mime/multipart.FileHeader>
+      HeaderType: 63 GoSwissMapHeaderType map<string,[]*mime/multipart.FileHeader>
     - __kind: GoMapType
-      ID: 36
+      ID: 60
       Name: map[string][]string
       ByteSize: 8
       GoRuntimeType: 1.148352e+06
       GoKind: 21
-      HeaderType: 16 GoSwissMapHeaderType map<string,[]string>
+      HeaderType: 45 GoSwissMapHeaderType map<string,[]string>
     - __kind: GoMapType
-      ID: 155
+      ID: 176
       Name: map[string]float64
       ByteSize: 8
       GoRuntimeType: 1.1536e+06
       GoKind: 21
-      HeaderType: 157 GoSwissMapHeaderType map<string,float64>
+      HeaderType: 178 GoSwissMapHeaderType map<string,float64>
     - __kind: GoMapType
-      ID: 194
+      ID: 214
       Name: map[string]interface {}
       ByteSize: 8
       GoRuntimeType: 1.146944e+06
       GoKind: 21
-      HeaderType: 146 GoSwissMapHeaderType map<string,interface {}>
+      HeaderType: 167 GoSwissMapHeaderType map<string,interface {}>
     - __kind: GoMapType
-      ID: 123
+      ID: 146
       Name: map[string]string
       ByteSize: 8
       GoRuntimeType: 1.149376e+06
       GoKind: 21
-      HeaderType: 125 GoSwissMapHeaderType map<string,string>
+      HeaderType: 148 GoSwissMapHeaderType map<string,string>
     - __kind: StructureType
-      ID: 64
+      ID: 88
       Name: math/big.Int
       ByteSize: 32
       GoRuntimeType: 1.518112e+06
@@ -2504,18 +2504,18 @@ Types:
       RawFields:
         - Name: neg
           Offset: 0
-          Type: 13 BaseType bool
+          Type: 4 BaseType bool
         - Name: abs
           Offset: 8
-          Type: 65 GoSliceHeaderType math/big.nat
+          Type: 89 GoSliceHeaderType math/big.nat
     - __kind: BaseType
-      ID: 67
+      ID: 91
       Name: math/big.Word
       ByteSize: 8
       GoRuntimeType: 594656
       GoKind: 7
     - __kind: GoSliceHeaderType
-      ID: 65
+      ID: 89
       Name: math/big.nat
       ByteSize: 24
       GoRuntimeType: 2.4216e+06
@@ -2523,21 +2523,21 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 66 PointerType *math/big.Word
+          Type: 90 PointerType *math/big.Word
         - Name: len
           Offset: 8
-          Type: 8 BaseType int
+          Type: 7 BaseType int
         - Name: cap
           Offset: 16
-          Type: 8 BaseType int
+          Type: 7 BaseType int
       Data: 243 GoSliceDataType math/big.nat.array
     - __kind: GoSliceDataType
       ID: 243
       Name: math/big.nat.array
       ByteSize: 2048
-      Element: 67 BaseType math/big.Word
+      Element: 91 BaseType math/big.Word
     - __kind: StructureType
-      ID: 51
+      ID: 75
       Name: mime/multipart.FileHeader
       ByteSize: 88
       GoRuntimeType: 2.010048e+06
@@ -2545,27 +2545,27 @@ Types:
       RawFields:
         - Name: Filename
           Offset: 0
-          Type: 5 GoStringHeaderType string
+          Type: 9 GoStringHeaderType string
         - Name: Header
           Offset: 16
-          Type: 52 GoMapType net/textproto.MIMEHeader
+          Type: 76 GoMapType net/textproto.MIMEHeader
         - Name: Size
           Offset: 24
-          Type: 32 BaseType int64
+          Type: 12 BaseType int64
         - Name: content
           Offset: 32
-          Type: 53 GoSliceHeaderType []uint8
+          Type: 77 GoSliceHeaderType []uint8
         - Name: tmpfile
           Offset: 56
-          Type: 5 GoStringHeaderType string
+          Type: 9 GoStringHeaderType string
         - Name: tmpoff
           Offset: 72
-          Type: 32 BaseType int64
+          Type: 12 BaseType int64
         - Name: tmpshared
           Offset: 80
-          Type: 13 BaseType bool
+          Type: 4 BaseType bool
     - __kind: StructureType
-      ID: 35
+      ID: 59
       Name: mime/multipart.Form
       ByteSize: 16
       GoRuntimeType: 1.501472e+06
@@ -2573,12 +2573,12 @@ Types:
       RawFields:
         - Name: Value
           Offset: 0
-          Type: 36 GoMapType map[string][]string
+          Type: 60 GoMapType map[string][]string
         - Name: File
           Offset: 8
-          Type: 37 GoMapType map[string][]*mime/multipart.FileHeader
+          Type: 61 GoMapType map[string][]*mime/multipart.FileHeader
     - __kind: GoSliceHeaderType
-      ID: 94
+      ID: 117
       Name: net.IP
       ByteSize: 24
       GoRuntimeType: 2.17104e+06
@@ -2586,21 +2586,21 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 6 PointerType *uint8
+          Type: 5 PointerType *uint8
         - Name: len
           Offset: 8
-          Type: 8 BaseType int
+          Type: 7 BaseType int
         - Name: cap
           Offset: 16
-          Type: 8 BaseType int
+          Type: 7 BaseType int
       Data: 261 GoSliceDataType net.IP.array
     - __kind: GoSliceDataType
       ID: 261
       Name: net.IP.array
       ByteSize: 2048
-      Element: 7 BaseType uint8
+      Element: 3 BaseType uint8
     - __kind: GoSliceHeaderType
-      ID: 101
+      ID: 124
       Name: net.IPMask
       ByteSize: 24
       GoRuntimeType: 1.03808e+06
@@ -2608,21 +2608,21 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 6 PointerType *uint8
+          Type: 5 PointerType *uint8
         - Name: len
           Offset: 8
-          Type: 8 BaseType int
+          Type: 7 BaseType int
         - Name: cap
           Offset: 16
-          Type: 8 BaseType int
+          Type: 7 BaseType int
       Data: 267 GoSliceDataType net.IPMask.array
     - __kind: GoSliceDataType
       ID: 267
       Name: net.IPMask.array
       ByteSize: 2048
-      Element: 7 BaseType uint8
+      Element: 3 BaseType uint8
     - __kind: StructureType
-      ID: 100
+      ID: 123
       Name: net.IPNet
       ByteSize: 48
       GoRuntimeType: 1.482432e+06
@@ -2630,19 +2630,19 @@ Types:
       RawFields:
         - Name: IP
           Offset: 0
-          Type: 94 GoSliceHeaderType net.IP
+          Type: 117 GoSliceHeaderType net.IP
         - Name: Mask
           Offset: 24
-          Type: 101 GoSliceHeaderType net.IPMask
+          Type: 124 GoSliceHeaderType net.IPMask
     - __kind: GoMapType
-      ID: 14
+      ID: 43
       Name: net/http.Header
       ByteSize: 8
       GoRuntimeType: 2.148192e+06
       GoKind: 21
-      HeaderType: 16 GoSwissMapHeaderType map<string,[]string>
+      HeaderType: 45 GoSwissMapHeaderType map<string,[]string>
     - __kind: StructureType
-      ID: 4
+      ID: 38
       Name: net/http.Request
       ByteSize: 304
       GoRuntimeType: 2.398144e+06
@@ -2650,84 +2650,84 @@ Types:
       RawFields:
         - Name: Method
           Offset: 0
-          Type: 5 GoStringHeaderType string
+          Type: 9 GoStringHeaderType string
         - Name: URL
           Offset: 16
-          Type: 9 PointerType *net/url.URL
+          Type: 39 PointerType *net/url.URL
         - Name: Proto
           Offset: 24
-          Type: 5 GoStringHeaderType string
+          Type: 9 GoStringHeaderType string
         - Name: ProtoMajor
           Offset: 40
-          Type: 8 BaseType int
+          Type: 7 BaseType int
         - Name: ProtoMinor
           Offset: 48
-          Type: 8 BaseType int
+          Type: 7 BaseType int
         - Name: Header
           Offset: 56
-          Type: 14 GoMapType net/http.Header
+          Type: 43 GoMapType net/http.Header
         - Name: Body
           Offset: 64
-          Type: 30 GoInterfaceType io.ReadCloser
+          Type: 55 GoInterfaceType io.ReadCloser
         - Name: GetBody
           Offset: 80
-          Type: 31 GoSubroutineType func() (io.ReadCloser, error)
+          Type: 56 GoSubroutineType func() (io.ReadCloser, error)
         - Name: ContentLength
           Offset: 88
-          Type: 32 BaseType int64
+          Type: 12 BaseType int64
         - Name: TransferEncoding
           Offset: 96
-          Type: 28 GoSliceHeaderType []string
+          Type: 54 GoSliceHeaderType []string
         - Name: Close
           Offset: 120
-          Type: 13 BaseType bool
+          Type: 4 BaseType bool
         - Name: Host
           Offset: 128
-          Type: 5 GoStringHeaderType string
+          Type: 9 GoStringHeaderType string
         - Name: Form
           Offset: 144
-          Type: 33 GoMapType net/url.Values
+          Type: 57 GoMapType net/url.Values
         - Name: PostForm
           Offset: 152
-          Type: 33 GoMapType net/url.Values
+          Type: 57 GoMapType net/url.Values
         - Name: MultipartForm
           Offset: 160
-          Type: 34 PointerType *mime/multipart.Form
+          Type: 58 PointerType *mime/multipart.Form
         - Name: Trailer
           Offset: 168
-          Type: 14 GoMapType net/http.Header
+          Type: 43 GoMapType net/http.Header
         - Name: RemoteAddr
           Offset: 176
-          Type: 5 GoStringHeaderType string
+          Type: 9 GoStringHeaderType string
         - Name: RequestURI
           Offset: 192
-          Type: 5 GoStringHeaderType string
+          Type: 9 GoStringHeaderType string
         - Name: TLS
           Offset: 208
-          Type: 54 PointerType *crypto/tls.ConnectionState
+          Type: 78 PointerType *crypto/tls.ConnectionState
         - Name: Cancel
           Offset: 216
-          Type: 114 GoChannelType <-chan struct {}
+          Type: 137 GoChannelType <-chan struct {}
         - Name: Response
           Offset: 224
-          Type: 115 PointerType *net/http.Response
+          Type: 138 PointerType *net/http.Response
         - Name: Pattern
           Offset: 232
-          Type: 5 GoStringHeaderType string
+          Type: 9 GoStringHeaderType string
         - Name: ctx
           Offset: 248
-          Type: 117 GoInterfaceType context.Context
+          Type: 140 GoInterfaceType context.Context
         - Name: pat
           Offset: 264
-          Type: 118 PointerType *net/http.pattern
+          Type: 141 PointerType *net/http.pattern
         - Name: matches
           Offset: 272
-          Type: 28 GoSliceHeaderType []string
+          Type: 54 GoSliceHeaderType []string
         - Name: otherValues
           Offset: 296
-          Type: 123 GoMapType map[string]string
+          Type: 146 GoMapType map[string]string
     - __kind: StructureType
-      ID: 116
+      ID: 139
       Name: net/http.Response
       ByteSize: 144
       GoRuntimeType: 2.260416e+06
@@ -2735,48 +2735,48 @@ Types:
       RawFields:
         - Name: Status
           Offset: 0
-          Type: 5 GoStringHeaderType string
+          Type: 9 GoStringHeaderType string
         - Name: StatusCode
           Offset: 16
-          Type: 8 BaseType int
+          Type: 7 BaseType int
         - Name: Proto
           Offset: 24
-          Type: 5 GoStringHeaderType string
+          Type: 9 GoStringHeaderType string
         - Name: ProtoMajor
           Offset: 40
-          Type: 8 BaseType int
+          Type: 7 BaseType int
         - Name: ProtoMinor
           Offset: 48
-          Type: 8 BaseType int
+          Type: 7 BaseType int
         - Name: Header
           Offset: 56
-          Type: 14 GoMapType net/http.Header
+          Type: 43 GoMapType net/http.Header
         - Name: Body
           Offset: 64
-          Type: 30 GoInterfaceType io.ReadCloser
+          Type: 55 GoInterfaceType io.ReadCloser
         - Name: ContentLength
           Offset: 80
-          Type: 32 BaseType int64
+          Type: 12 BaseType int64
         - Name: TransferEncoding
           Offset: 88
-          Type: 28 GoSliceHeaderType []string
+          Type: 54 GoSliceHeaderType []string
         - Name: Close
           Offset: 112
-          Type: 13 BaseType bool
+          Type: 4 BaseType bool
         - Name: Uncompressed
           Offset: 113
-          Type: 13 BaseType bool
+          Type: 4 BaseType bool
         - Name: Trailer
           Offset: 120
-          Type: 14 GoMapType net/http.Header
+          Type: 43 GoMapType net/http.Header
         - Name: Request
           Offset: 128
-          Type: 3 PointerType *net/http.Request
+          Type: 37 PointerType *net/http.Request
         - Name: TLS
           Offset: 136
-          Type: 54 PointerType *crypto/tls.ConnectionState
+          Type: 78 PointerType *crypto/tls.ConnectionState
     - __kind: GoInterfaceType
-      ID: 1
+      ID: 36
       Name: net/http.ResponseWriter
       ByteSize: 16
       GoRuntimeType: 1.206848e+06
@@ -2784,12 +2784,12 @@ Types:
       RawFields:
         - Name: tab
           Offset: 0
-          Type: 2 VoidPointerType unsafe.Pointer
+          Type: 14 VoidPointerType unsafe.Pointer
         - Name: data
           Offset: 8
-          Type: 2 VoidPointerType unsafe.Pointer
+          Type: 14 VoidPointerType unsafe.Pointer
     - __kind: StructureType
-      ID: 119
+      ID: 142
       Name: net/http.pattern
       ByteSize: 88
       GoRuntimeType: 1.866368e+06
@@ -2797,21 +2797,21 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 5 GoStringHeaderType string
+          Type: 9 GoStringHeaderType string
         - Name: method
           Offset: 16
-          Type: 5 GoStringHeaderType string
+          Type: 9 GoStringHeaderType string
         - Name: host
           Offset: 32
-          Type: 5 GoStringHeaderType string
+          Type: 9 GoStringHeaderType string
         - Name: segments
           Offset: 48
-          Type: 120 GoSliceHeaderType []net/http.segment
+          Type: 143 GoSliceHeaderType []net/http.segment
         - Name: loc
           Offset: 72
-          Type: 5 GoStringHeaderType string
+          Type: 9 GoStringHeaderType string
     - __kind: StructureType
-      ID: 122
+      ID: 145
       Name: net/http.segment
       ByteSize: 24
       GoRuntimeType: 1.6376e+06
@@ -2819,22 +2819,22 @@ Types:
       RawFields:
         - Name: s
           Offset: 0
-          Type: 5 GoStringHeaderType string
+          Type: 9 GoStringHeaderType string
         - Name: wild
           Offset: 16
-          Type: 13 BaseType bool
+          Type: 4 BaseType bool
         - Name: multi
           Offset: 17
-          Type: 13 BaseType bool
+          Type: 4 BaseType bool
     - __kind: GoMapType
-      ID: 52
+      ID: 76
       Name: net/textproto.MIMEHeader
       ByteSize: 8
       GoRuntimeType: 1.85488e+06
       GoKind: 21
-      HeaderType: 16 GoSwissMapHeaderType map<string,[]string>
+      HeaderType: 45 GoSwissMapHeaderType map<string,[]string>
     - __kind: StructureType
-      ID: 10
+      ID: 40
       Name: net/url.URL
       ByteSize: 144
       GoRuntimeType: 2.173728e+06
@@ -2842,39 +2842,39 @@ Types:
       RawFields:
         - Name: Scheme
           Offset: 0
-          Type: 5 GoStringHeaderType string
+          Type: 9 GoStringHeaderType string
         - Name: Opaque
           Offset: 16
-          Type: 5 GoStringHeaderType string
+          Type: 9 GoStringHeaderType string
         - Name: User
           Offset: 32
-          Type: 11 PointerType *net/url.Userinfo
+          Type: 41 PointerType *net/url.Userinfo
         - Name: Host
           Offset: 40
-          Type: 5 GoStringHeaderType string
+          Type: 9 GoStringHeaderType string
         - Name: Path
           Offset: 56
-          Type: 5 GoStringHeaderType string
+          Type: 9 GoStringHeaderType string
         - Name: RawPath
           Offset: 72
-          Type: 5 GoStringHeaderType string
+          Type: 9 GoStringHeaderType string
         - Name: OmitHost
           Offset: 88
-          Type: 13 BaseType bool
+          Type: 4 BaseType bool
         - Name: ForceQuery
           Offset: 89
-          Type: 13 BaseType bool
+          Type: 4 BaseType bool
         - Name: RawQuery
           Offset: 96
-          Type: 5 GoStringHeaderType string
+          Type: 9 GoStringHeaderType string
         - Name: Fragment
           Offset: 112
-          Type: 5 GoStringHeaderType string
+          Type: 9 GoStringHeaderType string
         - Name: RawFragment
           Offset: 128
-          Type: 5 GoStringHeaderType string
+          Type: 9 GoStringHeaderType string
     - __kind: StructureType
-      ID: 12
+      ID: 42
       Name: net/url.Userinfo
       ByteSize: 40
       GoRuntimeType: 1.653536e+06
@@ -2882,76 +2882,76 @@ Types:
       RawFields:
         - Name: username
           Offset: 0
-          Type: 5 GoStringHeaderType string
+          Type: 9 GoStringHeaderType string
         - Name: password
           Offset: 16
-          Type: 5 GoStringHeaderType string
+          Type: 9 GoStringHeaderType string
         - Name: passwordSet
           Offset: 32
-          Type: 13 BaseType bool
+          Type: 4 BaseType bool
     - __kind: GoMapType
-      ID: 33
+      ID: 57
       Name: net/url.Values
       ByteSize: 8
       GoRuntimeType: 1.9208e+06
       GoKind: 21
-      HeaderType: 16 GoSwissMapHeaderType map<string,[]string>
+      HeaderType: 45 GoSwissMapHeaderType map<string,[]string>
     - __kind: ArrayType
-      ID: 182
+      ID: 202
       Name: noalg.[8]struct { key string; elem *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute }
       ByteSize: 192
       GoRuntimeType: 711904
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 183 StructureType noalg.struct { key string; elem *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute }
+      Element: 203 StructureType noalg.struct { key string; elem *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute }
     - __kind: ArrayType
-      ID: 46
+      ID: 70
       Name: noalg.[8]struct { key string; elem []*mime/multipart.FileHeader }
       ByteSize: 320
       GoRuntimeType: 707328
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 47 StructureType noalg.struct { key string; elem []*mime/multipart.FileHeader }
+      Element: 71 StructureType noalg.struct { key string; elem []*mime/multipart.FileHeader }
     - __kind: ArrayType
-      ID: 26
+      ID: 52
       Name: noalg.[8]struct { key string; elem []string }
       ByteSize: 320
       GoRuntimeType: 697312
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 27 StructureType noalg.struct { key string; elem []string }
+      Element: 53 StructureType noalg.struct { key string; elem []string }
     - __kind: ArrayType
-      ID: 164
+      ID: 185
       Name: noalg.[8]struct { key string; elem float64 }
       ByteSize: 192
       GoRuntimeType: 711808
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 165 StructureType noalg.struct { key string; elem float64 }
+      Element: 186 StructureType noalg.struct { key string; elem float64 }
     - __kind: ArrayType
-      ID: 153
+      ID: 174
       Name: noalg.[8]struct { key string; elem interface {} }
       ByteSize: 256
       GoRuntimeType: 688768
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 154 StructureType noalg.struct { key string; elem interface {} }
+      Element: 175 StructureType noalg.struct { key string; elem interface {} }
     - __kind: ArrayType
-      ID: 132
+      ID: 155
       Name: noalg.[8]struct { key string; elem string }
       ByteSize: 256
       GoRuntimeType: 701472
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 133 StructureType noalg.struct { key string; elem string }
+      Element: 156 StructureType noalg.struct { key string; elem string }
     - __kind: StructureType
-      ID: 181
+      ID: 201
       Name: noalg.map.group[string]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
       ByteSize: 200
       GoRuntimeType: 1.327872e+06
@@ -2959,12 +2959,12 @@ Types:
       RawFields:
         - Name: ctrl
           Offset: 0
-          Type: 17 BaseType uint64
+          Type: 8 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 182 ArrayType noalg.[8]struct { key string; elem *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute }
+          Type: 202 ArrayType noalg.[8]struct { key string; elem *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute }
     - __kind: StructureType
-      ID: 45
+      ID: 69
       Name: noalg.map.group[string][]*mime/multipart.FileHeader
       ByteSize: 328
       GoRuntimeType: 1.3216e+06
@@ -2972,12 +2972,12 @@ Types:
       RawFields:
         - Name: ctrl
           Offset: 0
-          Type: 17 BaseType uint64
+          Type: 8 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 46 ArrayType noalg.[8]struct { key string; elem []*mime/multipart.FileHeader }
+          Type: 70 ArrayType noalg.[8]struct { key string; elem []*mime/multipart.FileHeader }
     - __kind: StructureType
-      ID: 25
+      ID: 51
       Name: noalg.map.group[string][]string
       ByteSize: 328
       GoRuntimeType: 1.312128e+06
@@ -2985,12 +2985,12 @@ Types:
       RawFields:
         - Name: ctrl
           Offset: 0
-          Type: 17 BaseType uint64
+          Type: 8 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 26 ArrayType noalg.[8]struct { key string; elem []string }
+          Type: 52 ArrayType noalg.[8]struct { key string; elem []string }
     - __kind: StructureType
-      ID: 163
+      ID: 184
       Name: noalg.map.group[string]float64
       ByteSize: 200
       GoRuntimeType: 1.327616e+06
@@ -2998,12 +2998,12 @@ Types:
       RawFields:
         - Name: ctrl
           Offset: 0
-          Type: 17 BaseType uint64
+          Type: 8 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 164 ArrayType noalg.[8]struct { key string; elem float64 }
+          Type: 185 ArrayType noalg.[8]struct { key string; elem float64 }
     - __kind: StructureType
-      ID: 152
+      ID: 173
       Name: noalg.map.group[string]interface {}
       ByteSize: 264
       GoRuntimeType: 1.309568e+06
@@ -3011,12 +3011,12 @@ Types:
       RawFields:
         - Name: ctrl
           Offset: 0
-          Type: 17 BaseType uint64
+          Type: 8 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 153 ArrayType noalg.[8]struct { key string; elem interface {} }
+          Type: 174 ArrayType noalg.[8]struct { key string; elem interface {} }
     - __kind: StructureType
-      ID: 131
+      ID: 154
       Name: noalg.map.group[string]string
       ByteSize: 264
       GoRuntimeType: 1.314432e+06
@@ -3024,12 +3024,12 @@ Types:
       RawFields:
         - Name: ctrl
           Offset: 0
-          Type: 17 BaseType uint64
+          Type: 8 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 132 ArrayType noalg.[8]struct { key string; elem string }
+          Type: 155 ArrayType noalg.[8]struct { key string; elem string }
     - __kind: StructureType
-      ID: 183
+      ID: 203
       Name: noalg.struct { key string; elem *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute }
       ByteSize: 24
       GoRuntimeType: 1.327744e+06
@@ -3037,12 +3037,12 @@ Types:
       RawFields:
         - Name: key
           Offset: 0
-          Type: 5 GoStringHeaderType string
+          Type: 9 GoStringHeaderType string
         - Name: elem
           Offset: 16
-          Type: 184 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
+          Type: 204 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
     - __kind: StructureType
-      ID: 47
+      ID: 71
       Name: noalg.struct { key string; elem []*mime/multipart.FileHeader }
       ByteSize: 40
       GoRuntimeType: 1.321472e+06
@@ -3050,12 +3050,12 @@ Types:
       RawFields:
         - Name: key
           Offset: 0
-          Type: 5 GoStringHeaderType string
+          Type: 9 GoStringHeaderType string
         - Name: elem
           Offset: 16
-          Type: 48 GoSliceHeaderType []*mime/multipart.FileHeader
+          Type: 72 GoSliceHeaderType []*mime/multipart.FileHeader
     - __kind: StructureType
-      ID: 27
+      ID: 53
       Name: noalg.struct { key string; elem []string }
       ByteSize: 40
       GoRuntimeType: 1.312e+06
@@ -3063,12 +3063,12 @@ Types:
       RawFields:
         - Name: key
           Offset: 0
-          Type: 5 GoStringHeaderType string
+          Type: 9 GoStringHeaderType string
         - Name: elem
           Offset: 16
-          Type: 28 GoSliceHeaderType []string
+          Type: 54 GoSliceHeaderType []string
     - __kind: StructureType
-      ID: 165
+      ID: 186
       Name: noalg.struct { key string; elem float64 }
       ByteSize: 24
       GoRuntimeType: 1.327488e+06
@@ -3076,12 +3076,12 @@ Types:
       RawFields:
         - Name: key
           Offset: 0
-          Type: 5 GoStringHeaderType string
+          Type: 9 GoStringHeaderType string
         - Name: elem
           Offset: 16
-          Type: 166 BaseType float64
+          Type: 18 BaseType float64
     - __kind: StructureType
-      ID: 154
+      ID: 175
       Name: noalg.struct { key string; elem interface {} }
       ByteSize: 32
       GoRuntimeType: 1.30944e+06
@@ -3089,12 +3089,12 @@ Types:
       RawFields:
         - Name: key
           Offset: 0
-          Type: 5 GoStringHeaderType string
+          Type: 9 GoStringHeaderType string
         - Name: elem
           Offset: 16
-          Type: 62 GoEmptyInterfaceType interface {}
+          Type: 86 GoEmptyInterfaceType interface {}
     - __kind: StructureType
-      ID: 133
+      ID: 156
       Name: noalg.struct { key string; elem string }
       ByteSize: 32
       GoRuntimeType: 1.314304e+06
@@ -3102,12 +3102,12 @@ Types:
       RawFields:
         - Name: key
           Offset: 0
-          Type: 5 GoStringHeaderType string
+          Type: 9 GoStringHeaderType string
         - Name: elem
           Offset: 16
-          Type: 5 GoStringHeaderType string
+          Type: 9 GoStringHeaderType string
     - __kind: GoStringHeaderType
-      ID: 5
+      ID: 9
       Name: string
       ByteSize: 16
       GoRuntimeType: 590368
@@ -3118,14 +3118,14 @@ Types:
           Type: 230 PointerType *string.str
         - Name: len
           Offset: 8
-          Type: 8 BaseType int
+          Type: 7 BaseType int
       Data: 229 GoStringDataType string.str
     - __kind: GoStringDataType
       ID: 229
       Name: string.str
       ByteSize: 2048
     - __kind: StructureType
-      ID: 137
+      ID: 160
       Name: sync.Mutex
       ByteSize: 8
       GoRuntimeType: 1.489632e+06
@@ -3133,12 +3133,12 @@ Types:
       RawFields:
         - Name: _
           Offset: 0
-          Type: 138 StructureType sync.noCopy
+          Type: 161 StructureType sync.noCopy
         - Name: mu
           Offset: 0
-          Type: 139 StructureType internal/sync.Mutex
+          Type: 162 StructureType internal/sync.Mutex
     - __kind: StructureType
-      ID: 136
+      ID: 159
       Name: sync.RWMutex
       ByteSize: 24
       GoRuntimeType: 1.872192e+06
@@ -3146,27 +3146,27 @@ Types:
       RawFields:
         - Name: w
           Offset: 0
-          Type: 137 StructureType sync.Mutex
+          Type: 160 StructureType sync.Mutex
         - Name: writerSem
           Offset: 8
-          Type: 141 BaseType uint32
+          Type: 2 BaseType uint32
         - Name: readerSem
           Offset: 12
-          Type: 141 BaseType uint32
+          Type: 2 BaseType uint32
         - Name: readerCount
           Offset: 16
-          Type: 142 StructureType sync/atomic.Int32
+          Type: 163 StructureType sync/atomic.Int32
         - Name: readerWait
           Offset: 20
-          Type: 142 StructureType sync/atomic.Int32
+          Type: 163 StructureType sync/atomic.Int32
     - __kind: StructureType
-      ID: 138
+      ID: 161
       Name: sync.noCopy
       GoRuntimeType: 1.003072e+06
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 142
+      ID: 163
       Name: sync/atomic.Int32
       ByteSize: 4
       GoRuntimeType: 1.490912e+06
@@ -3174,162 +3174,162 @@ Types:
       RawFields:
         - Name: _
           Offset: 0
-          Type: 143 StructureType sync/atomic.noCopy
+          Type: 164 StructureType sync/atomic.noCopy
         - Name: v
           Offset: 0
-          Type: 140 BaseType int32
+          Type: 10 BaseType int32
     - __kind: StructureType
-      ID: 143
+      ID: 164
       Name: sync/atomic.noCopy
       GoRuntimeType: 1.003168e+06
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 178
+      ID: 198
       Name: table<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
       ByteSize: 32
       GoKind: 25
       RawFields:
         - Name: used
           Offset: 0
-          Type: 22 BaseType uint16
+          Type: 6 BaseType uint16
         - Name: capacity
           Offset: 2
-          Type: 22 BaseType uint16
+          Type: 6 BaseType uint16
         - Name: growthLeft
           Offset: 4
-          Type: 22 BaseType uint16
+          Type: 6 BaseType uint16
         - Name: localDepth
           Offset: 6
-          Type: 7 BaseType uint8
+          Type: 3 BaseType uint8
         - Name: index
           Offset: 8
-          Type: 8 BaseType int
+          Type: 7 BaseType int
         - Name: groups
           Offset: 16
-          Type: 179 GoSwissMapGroupsType groupReference<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
+          Type: 199 GoSwissMapGroupsType groupReference<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
     - __kind: StructureType
-      ID: 42
+      ID: 66
       Name: table<string,[]*mime/multipart.FileHeader>
       ByteSize: 32
       GoKind: 25
       RawFields:
         - Name: used
           Offset: 0
-          Type: 22 BaseType uint16
+          Type: 6 BaseType uint16
         - Name: capacity
           Offset: 2
-          Type: 22 BaseType uint16
+          Type: 6 BaseType uint16
         - Name: growthLeft
           Offset: 4
-          Type: 22 BaseType uint16
+          Type: 6 BaseType uint16
         - Name: localDepth
           Offset: 6
-          Type: 7 BaseType uint8
+          Type: 3 BaseType uint8
         - Name: index
           Offset: 8
-          Type: 8 BaseType int
+          Type: 7 BaseType int
         - Name: groups
           Offset: 16
-          Type: 43 GoSwissMapGroupsType groupReference<string,[]*mime/multipart.FileHeader>
+          Type: 67 GoSwissMapGroupsType groupReference<string,[]*mime/multipart.FileHeader>
     - __kind: StructureType
-      ID: 21
+      ID: 48
       Name: table<string,[]string>
       ByteSize: 32
       GoKind: 25
       RawFields:
         - Name: used
           Offset: 0
-          Type: 22 BaseType uint16
+          Type: 6 BaseType uint16
         - Name: capacity
           Offset: 2
-          Type: 22 BaseType uint16
+          Type: 6 BaseType uint16
         - Name: growthLeft
           Offset: 4
-          Type: 22 BaseType uint16
+          Type: 6 BaseType uint16
         - Name: localDepth
           Offset: 6
-          Type: 7 BaseType uint8
+          Type: 3 BaseType uint8
         - Name: index
           Offset: 8
-          Type: 8 BaseType int
+          Type: 7 BaseType int
         - Name: groups
           Offset: 16
-          Type: 23 GoSwissMapGroupsType groupReference<string,[]string>
+          Type: 49 GoSwissMapGroupsType groupReference<string,[]string>
     - __kind: StructureType
-      ID: 160
+      ID: 181
       Name: table<string,float64>
       ByteSize: 32
       GoKind: 25
       RawFields:
         - Name: used
           Offset: 0
-          Type: 22 BaseType uint16
+          Type: 6 BaseType uint16
         - Name: capacity
           Offset: 2
-          Type: 22 BaseType uint16
+          Type: 6 BaseType uint16
         - Name: growthLeft
           Offset: 4
-          Type: 22 BaseType uint16
+          Type: 6 BaseType uint16
         - Name: localDepth
           Offset: 6
-          Type: 7 BaseType uint8
+          Type: 3 BaseType uint8
         - Name: index
           Offset: 8
-          Type: 8 BaseType int
+          Type: 7 BaseType int
         - Name: groups
           Offset: 16
-          Type: 161 GoSwissMapGroupsType groupReference<string,float64>
+          Type: 182 GoSwissMapGroupsType groupReference<string,float64>
     - __kind: StructureType
-      ID: 149
+      ID: 170
       Name: table<string,interface {}>
       ByteSize: 32
       GoKind: 25
       RawFields:
         - Name: used
           Offset: 0
-          Type: 22 BaseType uint16
+          Type: 6 BaseType uint16
         - Name: capacity
           Offset: 2
-          Type: 22 BaseType uint16
+          Type: 6 BaseType uint16
         - Name: growthLeft
           Offset: 4
-          Type: 22 BaseType uint16
+          Type: 6 BaseType uint16
         - Name: localDepth
           Offset: 6
-          Type: 7 BaseType uint8
+          Type: 3 BaseType uint8
         - Name: index
           Offset: 8
-          Type: 8 BaseType int
+          Type: 7 BaseType int
         - Name: groups
           Offset: 16
-          Type: 150 GoSwissMapGroupsType groupReference<string,interface {}>
+          Type: 171 GoSwissMapGroupsType groupReference<string,interface {}>
     - __kind: StructureType
-      ID: 128
+      ID: 151
       Name: table<string,string>
       ByteSize: 32
       GoKind: 25
       RawFields:
         - Name: used
           Offset: 0
-          Type: 22 BaseType uint16
+          Type: 6 BaseType uint16
         - Name: capacity
           Offset: 2
-          Type: 22 BaseType uint16
+          Type: 6 BaseType uint16
         - Name: growthLeft
           Offset: 4
-          Type: 22 BaseType uint16
+          Type: 6 BaseType uint16
         - Name: localDepth
           Offset: 6
-          Type: 7 BaseType uint8
+          Type: 3 BaseType uint8
         - Name: index
           Offset: 8
-          Type: 8 BaseType int
+          Type: 7 BaseType int
         - Name: groups
           Offset: 16
-          Type: 129 GoSwissMapGroupsType groupReference<string,string>
+          Type: 152 GoSwissMapGroupsType groupReference<string,string>
     - __kind: StructureType
-      ID: 76
+      ID: 99
       Name: time.Location
       ByteSize: 104
       GoRuntimeType: 2.006016e+06
@@ -3337,27 +3337,27 @@ Types:
       RawFields:
         - Name: name
           Offset: 0
-          Type: 5 GoStringHeaderType string
+          Type: 9 GoStringHeaderType string
         - Name: zone
           Offset: 16
-          Type: 77 GoSliceHeaderType []time.zone
+          Type: 100 GoSliceHeaderType []time.zone
         - Name: tx
           Offset: 40
-          Type: 80 GoSliceHeaderType []time.zoneTrans
+          Type: 103 GoSliceHeaderType []time.zoneTrans
         - Name: extend
           Offset: 64
-          Type: 5 GoStringHeaderType string
+          Type: 9 GoStringHeaderType string
         - Name: cacheStart
           Offset: 80
-          Type: 32 BaseType int64
+          Type: 12 BaseType int64
         - Name: cacheEnd
           Offset: 88
-          Type: 32 BaseType int64
+          Type: 12 BaseType int64
         - Name: cacheZone
           Offset: 96
-          Type: 78 PointerType *time.zone
+          Type: 101 PointerType *time.zone
     - __kind: StructureType
-      ID: 74
+      ID: 97
       Name: time.Time
       ByteSize: 24
       GoRuntimeType: 2.424416e+06
@@ -3365,15 +3365,15 @@ Types:
       RawFields:
         - Name: wall
           Offset: 0
-          Type: 17 BaseType uint64
+          Type: 8 BaseType uint64
         - Name: ext
           Offset: 8
-          Type: 32 BaseType int64
+          Type: 12 BaseType int64
         - Name: loc
           Offset: 16
-          Type: 75 PointerType *time.Location
+          Type: 98 PointerType *time.Location
     - __kind: StructureType
-      ID: 79
+      ID: 102
       Name: time.zone
       ByteSize: 32
       GoRuntimeType: 1.642592e+06
@@ -3381,15 +3381,15 @@ Types:
       RawFields:
         - Name: name
           Offset: 0
-          Type: 5 GoStringHeaderType string
+          Type: 9 GoStringHeaderType string
         - Name: offset
           Offset: 16
-          Type: 8 BaseType int
+          Type: 7 BaseType int
         - Name: isDST
           Offset: 24
-          Type: 13 BaseType bool
+          Type: 4 BaseType bool
     - __kind: StructureType
-      ID: 82
+      ID: 105
       Name: time.zoneTrans
       ByteSize: 16
       GoRuntimeType: 1.781504e+06
@@ -3397,54 +3397,54 @@ Types:
       RawFields:
         - Name: when
           Offset: 0
-          Type: 32 BaseType int64
+          Type: 12 BaseType int64
         - Name: index
           Offset: 8
-          Type: 7 BaseType uint8
+          Type: 3 BaseType uint8
         - Name: isstd
           Offset: 9
-          Type: 13 BaseType bool
+          Type: 4 BaseType bool
         - Name: isutc
           Offset: 10
-          Type: 13 BaseType bool
+          Type: 4 BaseType bool
     - __kind: BaseType
-      ID: 213
+      ID: 16
       Name: uint
       ByteSize: 8
       GoRuntimeType: 591008
       GoKind: 7
     - __kind: BaseType
-      ID: 22
+      ID: 6
       Name: uint16
       ByteSize: 2
       GoRuntimeType: 590624
       GoKind: 9
     - __kind: BaseType
-      ID: 141
+      ID: 2
       Name: uint32
       ByteSize: 4
       GoRuntimeType: 590752
       GoKind: 10
     - __kind: BaseType
-      ID: 17
+      ID: 8
       Name: uint64
       ByteSize: 8
       GoRuntimeType: 590880
       GoKind: 11
     - __kind: BaseType
-      ID: 7
+      ID: 3
       Name: uint8
       ByteSize: 1
       GoRuntimeType: 590496
       GoKind: 8
     - __kind: BaseType
-      ID: 18
+      ID: 1
       Name: uintptr
       ByteSize: 8
       GoRuntimeType: 591072
       GoKind: 12
     - __kind: VoidPointerType
-      ID: 2
+      ID: 14
       Name: unsafe.Pointer
       ByteSize: 8
       GoRuntimeType: 591456

--- a/pkg/dyninst/irgen/testdata/snapshot/rc_tester.arch=amd64,toolchain=go1.24.3.yaml
+++ b/pkg/dyninst/irgen/testdata/snapshot/rc_tester.arch=amd64,toolchain=go1.24.3.yaml
@@ -10,7 +10,7 @@ Probes:
       subprogram: {subprogram: 1}
       events:
         - ID: 1
-          Type: 295 EventRootType Probe[main.HandleHTTP]
+          Type: 215 EventRootType Probe[main.HandleHTTP]
           InjectionPoints: [{PC: "0xd31373", Frameless: false}]
           Condition: null
     - id: look_at_the_request
@@ -23,7 +23,7 @@ Probes:
       subprogram: {subprogram: 2}
       events:
         - ID: 2
-          Type: 296 EventRootType Probe[main.LookAtTheRequest]
+          Type: 216 EventRootType Probe[main.LookAtTheRequest]
           InjectionPoints: [{PC: "0xd316ce", Frameless: false}]
           Condition: null
 Subprograms:
@@ -111,65 +111,38 @@ Types:
       GoKind: 22
       Pointee: 111 PointerType *crypto/x509.Certificate
     - __kind: PointerType
-      ID: 174
-      Name: '**github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span'
-      ByteSize: 8
-      GoKind: 22
-      Pointee: 39 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span
-    - __kind: PointerType
-      ID: 258
-      Name: '**github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttributeValue'
-      ByteSize: 8
-      GoKind: 22
-      Pointee: 259 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttributeValue
-    - __kind: PointerType
-      ID: 182
+      ID: 98
       Name: '**mime/multipart.FileHeader'
       ByteSize: 8
       GoKind: 22
-      Pointee: 183 PointerType *mime/multipart.FileHeader
+      Pointee: 99 PointerType *mime/multipart.FileHeader
     - __kind: PointerType
-      ID: 230
+      ID: 153
       Name: '**net.IPNet'
       ByteSize: 8
       GoKind: 22
-      Pointee: 231 PointerType *net.IPNet
+      Pointee: 154 PointerType *net.IPNet
     - __kind: PointerType
-      ID: 228
+      ID: 151
       Name: '**net/url.URL'
       ByteSize: 8
       GoKind: 22
-      Pointee: 45 PointerType *net/url.URL
+      Pointee: 47 PointerType *net/url.URL
     - __kind: PointerType
-      ID: 127
-      Name: '**table<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>'
-      ByteSize: 8
-      Pointee: 128 PointerType *table<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
-    - __kind: PointerType
-      ID: 107
+      ID: 89
       Name: '**table<string,[]*mime/multipart.FileHeader>'
       ByteSize: 8
-      Pointee: 108 PointerType *table<string,[]*mime/multipart.FileHeader>
+      Pointee: 90 PointerType *table<string,[]*mime/multipart.FileHeader>
     - __kind: PointerType
-      ID: 50
+      ID: 52
       Name: '**table<string,[]string>'
       ByteSize: 8
-      Pointee: 51 PointerType *table<string,[]string>
+      Pointee: 53 PointerType *table<string,[]string>
     - __kind: PointerType
-      ID: 85
-      Name: '**table<string,float64>'
-      ByteSize: 8
-      Pointee: 86 PointerType *table<string,float64>
-    - __kind: PointerType
-      ID: 80
-      Name: '**table<string,interface {}>'
-      ByteSize: 8
-      Pointee: 81 PointerType *table<string,interface {}>
-    - __kind: PointerType
-      ID: 69
+      ID: 71
       Name: '**table<string,string>'
       ByteSize: 8
-      Pointee: 70 PointerType *table<string,string>
+      Pointee: 72 PointerType *table<string,string>
     - __kind: PointerType
       ID: 113
       Name: '*[]*crypto/x509.Certificate'
@@ -177,122 +150,102 @@ Types:
       GoKind: 22
       Pointee: 109 GoSliceHeaderType []*crypto/x509.Certificate
     - __kind: PointerType
-      ID: 187
+      ID: 120
       Name: '*[]*crypto/x509.Certificate.array'
       ByteSize: 8
-      Pointee: 186 GoSliceDataType []*crypto/x509.Certificate.array
+      Pointee: 119 GoSliceDataType []*crypto/x509.Certificate.array
     - __kind: PointerType
-      ID: 243
-      Name: '*[]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span.array'
-      ByteSize: 8
-      Pointee: 242 GoSliceDataType []*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span.array
-    - __kind: PointerType
-      ID: 291
-      Name: '*[]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttributeValue.array'
-      ByteSize: 8
-      Pointee: 290 GoSliceDataType []*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttributeValue.array
-    - __kind: PointerType
-      ID: 245
+      ID: 104
       Name: '*[]*mime/multipart.FileHeader.array'
       ByteSize: 8
-      Pointee: 244 GoSliceDataType []*mime/multipart.FileHeader.array
+      Pointee: 103 GoSliceDataType []*mime/multipart.FileHeader.array
     - __kind: PointerType
-      ID: 277
+      ID: 190
       Name: '*[]*net.IPNet.array'
       ByteSize: 8
-      Pointee: 276 GoSliceDataType []*net.IPNet.array
+      Pointee: 189 GoSliceDataType []*net.IPNet.array
     - __kind: PointerType
-      ID: 275
+      ID: 187
       Name: '*[]*net/url.URL.array'
       ByteSize: 8
-      Pointee: 274 GoSliceDataType []*net/url.URL.array
+      Pointee: 186 GoSliceDataType []*net/url.URL.array
     - __kind: PointerType
-      ID: 189
+      ID: 122
       Name: '*[][]*crypto/x509.Certificate.array'
       ByteSize: 8
-      Pointee: 188 GoSliceDataType [][]*crypto/x509.Certificate.array
+      Pointee: 121 GoSliceDataType [][]*crypto/x509.Certificate.array
     - __kind: PointerType
-      ID: 191
+      ID: 124
       Name: '*[][]uint8.array'
       ByteSize: 8
-      Pointee: 190 GoSliceDataType [][]uint8.array
+      Pointee: 123 GoSliceDataType [][]uint8.array
     - __kind: PointerType
-      ID: 269
+      ID: 183
       Name: '*[]crypto/x509.ExtKeyUsage.array'
       ByteSize: 8
-      Pointee: 268 GoSliceDataType []crypto/x509.ExtKeyUsage.array
+      Pointee: 182 GoSliceDataType []crypto/x509.ExtKeyUsage.array
     - __kind: PointerType
-      ID: 279
+      ID: 192
       Name: '*[]crypto/x509.OID.array'
       ByteSize: 8
-      Pointee: 278 GoSliceDataType []crypto/x509.OID.array
+      Pointee: 191 GoSliceDataType []crypto/x509.OID.array
     - __kind: PointerType
-      ID: 281
+      ID: 194
       Name: '*[]crypto/x509.PolicyMapping.array'
       ByteSize: 8
-      Pointee: 280 GoSliceDataType []crypto/x509.PolicyMapping.array
-    - __kind: PointerType
-      ID: 261
-      Name: '*[]crypto/x509/pkix.AttributeTypeAndValue.array'
-      ByteSize: 8
-      Pointee: 260 GoSliceDataType []crypto/x509/pkix.AttributeTypeAndValue.array
-    - __kind: PointerType
-      ID: 263
-      Name: '*[]crypto/x509/pkix.Extension.array'
-      ByteSize: 8
-      Pointee: 262 GoSliceDataType []crypto/x509/pkix.Extension.array
-    - __kind: PointerType
-      ID: 265
-      Name: '*[]encoding/asn1.ObjectIdentifier.array'
-      ByteSize: 8
-      Pointee: 264 GoSliceDataType []encoding/asn1.ObjectIdentifier.array
-    - __kind: PointerType
-      ID: 165
-      Name: '*[]github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink.array'
-      ByteSize: 8
-      Pointee: 164 GoSliceDataType []github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink.array
+      Pointee: 193 GoSliceDataType []crypto/x509.PolicyMapping.array
     - __kind: PointerType
       ID: 167
-      Name: '*[]github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent.array'
+      Name: '*[]crypto/x509/pkix.AttributeTypeAndValue.array'
       ByteSize: 8
-      Pointee: 166 GoSliceDataType []github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent.array
+      Pointee: 166 GoSliceDataType []crypto/x509/pkix.AttributeTypeAndValue.array
     - __kind: PointerType
-      ID: 271
+      ID: 179
+      Name: '*[]crypto/x509/pkix.Extension.array'
+      ByteSize: 8
+      Pointee: 178 GoSliceDataType []crypto/x509/pkix.Extension.array
+    - __kind: PointerType
+      ID: 181
+      Name: '*[]encoding/asn1.ObjectIdentifier.array'
+      ByteSize: 8
+      Pointee: 180 GoSliceDataType []encoding/asn1.ObjectIdentifier.array
+    - __kind: PointerType
+      ID: 185
       Name: '*[]net.IP.array'
       ByteSize: 8
-      Pointee: 270 GoSliceDataType []net.IP.array
+      Pointee: 184 GoSliceDataType []net.IP.array
     - __kind: PointerType
-      ID: 193
+      ID: 206
       Name: '*[]net/http.segment.array'
       ByteSize: 8
-      Pointee: 192 GoSliceDataType []net/http.segment.array
+      Pointee: 205 GoSliceDataType []net/http.segment.array
     - __kind: PointerType
-      ID: 141
+      ID: 84
       Name: '*[]string.array'
       ByteSize: 8
-      Pointee: 140 GoSliceDataType []string.array
+      Pointee: 83 GoSliceDataType []string.array
     - __kind: PointerType
-      ID: 287
+      ID: 175
       Name: '*[]time.zone.array'
       ByteSize: 8
-      Pointee: 286 GoSliceDataType []time.zone.array
+      Pointee: 174 GoSliceDataType []time.zone.array
     - __kind: PointerType
-      ID: 289
+      ID: 177
       Name: '*[]time.zoneTrans.array'
       ByteSize: 8
-      Pointee: 288 GoSliceDataType []time.zoneTrans.array
+      Pointee: 176 GoSliceDataType []time.zoneTrans.array
     - __kind: PointerType
       ID: 115
       Name: '*[]uint8'
       ByteSize: 8
       GoRuntimeType: 483552
       GoKind: 22
-      Pointee: 96 GoSliceHeaderType []uint8
+      Pointee: 106 GoSliceHeaderType []uint8
     - __kind: PointerType
-      ID: 169
+      ID: 108
       Name: '*[]uint8.array'
       ByteSize: 8
-      Pointee: 168 GoSliceDataType []uint8.array
+      Pointee: 107 GoSliceDataType []uint8.array
     - __kind: PointerType
       ID: 11
       Name: '*bool'
@@ -306,68 +259,68 @@ Types:
       ByteSize: 8
       GoRuntimeType: 2.316768e+06
       GoKind: 22
-      Pointee: 42 StructureType bytes.Buffer
+      Pointee: 42 UnresolvedPointeeType bytes.Buffer
     - __kind: PointerType
-      ID: 58
+      ID: 60
       Name: '*crypto/tls.ConnectionState'
       ByteSize: 8
       GoRuntimeType: 919424
       GoKind: 22
-      Pointee: 59 StructureType crypto/tls.ConnectionState
+      Pointee: 61 StructureType crypto/tls.ConnectionState
     - __kind: PointerType
       ID: 111
       Name: '*crypto/x509.Certificate'
       ByteSize: 8
       GoRuntimeType: 2.082688e+06
       GoKind: 22
-      Pointee: 171 StructureType crypto/x509.Certificate
+      Pointee: 118 StructureType crypto/x509.Certificate
     - __kind: PointerType
-      ID: 222
+      ID: 145
       Name: '*crypto/x509.ExtKeyUsage'
       ByteSize: 8
       GoRuntimeType: 426912
       GoKind: 22
-      Pointee: 223 BaseType crypto/x509.ExtKeyUsage
+      Pointee: 146 BaseType crypto/x509.ExtKeyUsage
     - __kind: PointerType
-      ID: 233
+      ID: 156
       Name: '*crypto/x509.OID'
       ByteSize: 8
       GoRuntimeType: 1.989632e+06
       GoKind: 22
-      Pointee: 234 StructureType crypto/x509.OID
+      Pointee: 157 StructureType crypto/x509.OID
     - __kind: PointerType
-      ID: 236
+      ID: 159
       Name: '*crypto/x509.PolicyMapping'
       ByteSize: 8
       GoRuntimeType: 426976
       GoKind: 22
-      Pointee: 237 StructureType crypto/x509.PolicyMapping
+      Pointee: 160 StructureType crypto/x509.PolicyMapping
     - __kind: PointerType
-      ID: 209
+      ID: 132
       Name: '*crypto/x509/pkix.AttributeTypeAndValue'
       ByteSize: 8
       GoRuntimeType: 443680
       GoKind: 22
-      Pointee: 210 StructureType crypto/x509/pkix.AttributeTypeAndValue
+      Pointee: 133 StructureType crypto/x509/pkix.AttributeTypeAndValue
     - __kind: PointerType
-      ID: 216
+      ID: 139
       Name: '*crypto/x509/pkix.Extension'
       ByteSize: 8
       GoRuntimeType: 443872
       GoKind: 22
-      Pointee: 217 StructureType crypto/x509/pkix.Extension
+      Pointee: 140 StructureType crypto/x509/pkix.Extension
     - __kind: PointerType
-      ID: 219
+      ID: 142
       Name: '*encoding/asn1.ObjectIdentifier'
       ByteSize: 8
       GoRuntimeType: 1.0752e+06
       GoKind: 22
-      Pointee: 220 GoSliceHeaderType encoding/asn1.ObjectIdentifier
+      Pointee: 143 GoSliceHeaderType encoding/asn1.ObjectIdentifier
     - __kind: PointerType
-      ID: 267
+      ID: 196
       Name: '*encoding/asn1.ObjectIdentifier.array'
       ByteSize: 8
-      Pointee: 266 GoSliceDataType encoding/asn1.ObjectIdentifier.array
+      Pointee: 195 GoSliceDataType encoding/asn1.ObjectIdentifier.array
     - __kind: PointerType
       ID: 33
       Name: '*error'
@@ -395,56 +348,7 @@ Types:
       ByteSize: 8
       GoRuntimeType: 2.32752e+06
       GoKind: 22
-      Pointee: 40 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span
-    - __kind: PointerType
-      ID: 93
-      Name: '*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanContext'
-      ByteSize: 8
-      GoRuntimeType: 2.046208e+06
-      GoKind: 22
-      Pointee: 94 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanContext
-    - __kind: PointerType
-      ID: 88
-      Name: '*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink'
-      ByteSize: 8
-      GoRuntimeType: 1.210688e+06
-      GoKind: 22
-      Pointee: 89 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink
-    - __kind: PointerType
-      ID: 91
-      Name: '*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent'
-      ByteSize: 8
-      GoRuntimeType: 1.210816e+06
-      GoKind: 22
-      Pointee: 92 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent
-    - __kind: PointerType
-      ID: 240
-      Name: '*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttribute'
-      ByteSize: 8
-      GoRuntimeType: 1.211456e+06
-      GoKind: 22
-      Pointee: 241 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttribute
-    - __kind: PointerType
-      ID: 259
-      Name: '*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttributeValue'
-      ByteSize: 8
-      GoRuntimeType: 1.2112e+06
-      GoKind: 22
-      Pointee: 283 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttributeValue
-    - __kind: PointerType
-      ID: 199
-      Name: '*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute'
-      ByteSize: 8
-      GoRuntimeType: 1.211584e+06
-      GoKind: 22
-      Pointee: 200 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
-    - __kind: PointerType
-      ID: 130
-      Name: '*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.trace'
-      ByteSize: 8
-      GoRuntimeType: 2.27024e+06
-      GoKind: 22
-      Pointee: 131 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.trace
+      Pointee: 40 UnresolvedPointeeType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span
     - __kind: PointerType
       ID: 27
       Name: '*int'
@@ -481,92 +385,77 @@ Types:
       GoKind: 22
       Pointee: 15 BaseType int8
     - __kind: PointerType
-      ID: 125
-      Name: '*map<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>'
-      ByteSize: 8
-      Pointee: 126 GoSwissMapHeaderType map<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
-    - __kind: PointerType
-      ID: 105
+      ID: 87
       Name: '*map<string,[]*mime/multipart.FileHeader>'
       ByteSize: 8
-      Pointee: 106 GoSwissMapHeaderType map<string,[]*mime/multipart.FileHeader>
+      Pointee: 88 GoSwissMapHeaderType map<string,[]*mime/multipart.FileHeader>
     - __kind: PointerType
-      ID: 48
+      ID: 50
       Name: '*map<string,[]string>'
       ByteSize: 8
-      Pointee: 49 GoSwissMapHeaderType map<string,[]string>
+      Pointee: 51 GoSwissMapHeaderType map<string,[]string>
     - __kind: PointerType
-      ID: 83
-      Name: '*map<string,float64>'
-      ByteSize: 8
-      Pointee: 84 GoSwissMapHeaderType map<string,float64>
-    - __kind: PointerType
-      ID: 78
-      Name: '*map<string,interface {}>'
-      ByteSize: 8
-      Pointee: 79 GoSwissMapHeaderType map<string,interface {}>
-    - __kind: PointerType
-      ID: 67
+      ID: 69
       Name: '*map<string,string>'
       ByteSize: 8
-      Pointee: 68 GoSwissMapHeaderType map<string,string>
+      Pointee: 70 GoSwissMapHeaderType map<string,string>
     - __kind: PointerType
-      ID: 205
+      ID: 128
       Name: '*math/big.Int'
       ByteSize: 8
       GoRuntimeType: 2.440832e+06
       GoKind: 22
-      Pointee: 206 StructureType math/big.Int
+      Pointee: 129 StructureType math/big.Int
     - __kind: PointerType
-      ID: 247
+      ID: 162
       Name: '*math/big.Word'
       ByteSize: 8
       GoRuntimeType: 429856
       GoKind: 22
-      Pointee: 248 BaseType math/big.Word
+      Pointee: 163 BaseType math/big.Word
     - __kind: PointerType
-      ID: 285
+      ID: 165
       Name: '*math/big.nat.array'
       ByteSize: 8
-      Pointee: 284 GoSliceDataType math/big.nat.array
+      Pointee: 164 GoSliceDataType math/big.nat.array
     - __kind: PointerType
-      ID: 183
+      ID: 99
       Name: '*mime/multipart.FileHeader'
       ByteSize: 8
       GoRuntimeType: 920864
       GoKind: 22
-      Pointee: 238 StructureType mime/multipart.FileHeader
+      Pointee: 102 StructureType mime/multipart.FileHeader
     - __kind: PointerType
-      ID: 56
+      ID: 58
       Name: '*mime/multipart.Form'
       ByteSize: 8
       GoRuntimeType: 920960
       GoKind: 22
-      Pointee: 57 StructureType mime/multipart.Form
+      Pointee: 59 StructureType mime/multipart.Form
     - __kind: PointerType
-      ID: 225
+      ID: 148
       Name: '*net.IP'
       ByteSize: 8
       GoRuntimeType: 2.198272e+06
       GoKind: 22
-      Pointee: 226 GoSliceHeaderType net.IP
+      Pointee: 149 GoSliceHeaderType net.IP
     - __kind: PointerType
-      ID: 273
+      ID: 198
       Name: '*net.IP.array'
       ByteSize: 8
-      Pointee: 272 GoSliceDataType net.IP.array
+      Pointee: 197 GoSliceDataType net.IP.array
     - __kind: PointerType
-      ID: 294
+      ID: 201
       Name: '*net.IPMask.array'
       ByteSize: 8
-      Pointee: 293 GoSliceDataType net.IPMask.array
+      Pointee: 200 GoSliceDataType net.IPMask.array
     - __kind: PointerType
-      ID: 231
+      ID: 154
       Name: '*net.IPNet'
       ByteSize: 8
       GoRuntimeType: 1.204416e+06
       GoKind: 22
-      Pointee: 255 StructureType net.IPNet
+      Pointee: 188 StructureType net.IPNet
     - __kind: PointerType
       ID: 37
       Name: '*net/http.Request'
@@ -575,70 +464,55 @@ Types:
       GoKind: 22
       Pointee: 38 StructureType net/http.Request
     - __kind: PointerType
-      ID: 61
+      ID: 63
       Name: '*net/http.Response'
       ByteSize: 8
       GoRuntimeType: 1.751392e+06
       GoKind: 22
-      Pointee: 62 StructureType net/http.Response
+      Pointee: 64 StructureType net/http.Response
     - __kind: PointerType
-      ID: 64
+      ID: 66
       Name: '*net/http.pattern'
       ByteSize: 8
       GoRuntimeType: 1.637792e+06
       GoKind: 22
-      Pointee: 65 StructureType net/http.pattern
+      Pointee: 67 StructureType net/http.pattern
     - __kind: PointerType
-      ID: 119
+      ID: 203
       Name: '*net/http.segment'
       ByteSize: 8
       GoRuntimeType: 393504
       GoKind: 22
-      Pointee: 120 StructureType net/http.segment
+      Pointee: 204 StructureType net/http.segment
     - __kind: PointerType
-      ID: 45
+      ID: 47
       Name: '*net/url.URL'
       ByteSize: 8
       GoRuntimeType: 2.16048e+06
       GoKind: 22
-      Pointee: 46 StructureType net/url.URL
+      Pointee: 48 StructureType net/url.URL
     - __kind: PointerType
-      ID: 100
+      ID: 73
       Name: '*net/url.Userinfo'
       ByteSize: 8
       GoRuntimeType: 1.222208e+06
       GoKind: 22
-      Pointee: 101 StructureType net/url.Userinfo
+      Pointee: 74 StructureType net/url.Userinfo
     - __kind: PointerType
-      ID: 195
-      Name: '*noalg.map.group[string]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute'
-      ByteSize: 8
-      Pointee: 196 StructureType noalg.map.group[string]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
-    - __kind: PointerType
-      ID: 177
+      ID: 93
       Name: '*noalg.map.group[string][]*mime/multipart.FileHeader'
       ByteSize: 8
-      Pointee: 178 StructureType noalg.map.group[string][]*mime/multipart.FileHeader
+      Pointee: 94 StructureType noalg.map.group[string][]*mime/multipart.FileHeader
     - __kind: PointerType
-      ID: 134
+      ID: 77
       Name: '*noalg.map.group[string][]string'
       ByteSize: 8
-      Pointee: 135 StructureType noalg.map.group[string][]string
+      Pointee: 78 StructureType noalg.map.group[string][]string
     - __kind: PointerType
-      ID: 158
-      Name: '*noalg.map.group[string]float64'
-      ByteSize: 8
-      Pointee: 159 StructureType noalg.map.group[string]float64
-    - __kind: PointerType
-      ID: 150
-      Name: '*noalg.map.group[string]interface {}'
-      ByteSize: 8
-      Pointee: 151 StructureType noalg.map.group[string]interface {}
-    - __kind: PointerType
-      ID: 143
+      ID: 209
       Name: '*noalg.map.group[string]string'
       ByteSize: 8
-      Pointee: 144 StructureType noalg.map.group[string]string
+      Pointee: 210 StructureType noalg.map.group[string]string
     - __kind: PointerType
       ID: 22
       Name: '*string'
@@ -647,61 +521,46 @@ Types:
       GoKind: 22
       Pointee: 9 GoStringHeaderType string
     - __kind: PointerType
-      ID: 99
+      ID: 46
       Name: '*string.str'
       ByteSize: 8
-      Pointee: 98 GoStringDataType string.str
+      Pointee: 45 GoStringDataType string.str
     - __kind: PointerType
-      ID: 128
-      Name: '*table<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>'
-      ByteSize: 8
-      Pointee: 172 StructureType table<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
-    - __kind: PointerType
-      ID: 108
+      ID: 90
       Name: '*table<string,[]*mime/multipart.FileHeader>'
       ByteSize: 8
-      Pointee: 170 StructureType table<string,[]*mime/multipart.FileHeader>
+      Pointee: 91 StructureType table<string,[]*mime/multipart.FileHeader>
     - __kind: PointerType
-      ID: 51
+      ID: 53
       Name: '*table<string,[]string>'
       ByteSize: 8
-      Pointee: 102 StructureType table<string,[]string>
+      Pointee: 75 StructureType table<string,[]string>
     - __kind: PointerType
-      ID: 86
-      Name: '*table<string,float64>'
-      ByteSize: 8
-      Pointee: 123 StructureType table<string,float64>
-    - __kind: PointerType
-      ID: 81
-      Name: '*table<string,interface {}>'
-      ByteSize: 8
-      Pointee: 122 StructureType table<string,interface {}>
-    - __kind: PointerType
-      ID: 70
+      ID: 72
       Name: '*table<string,string>'
       ByteSize: 8
-      Pointee: 121 StructureType table<string,string>
+      Pointee: 207 StructureType table<string,string>
     - __kind: PointerType
-      ID: 212
+      ID: 135
       Name: '*time.Location'
       ByteSize: 8
       GoRuntimeType: 1.642784e+06
       GoKind: 22
-      Pointee: 213 StructureType time.Location
+      Pointee: 136 StructureType time.Location
     - __kind: PointerType
-      ID: 250
+      ID: 169
       Name: '*time.zone'
       ByteSize: 8
       GoRuntimeType: 396640
       GoKind: 22
-      Pointee: 251 StructureType time.zone
+      Pointee: 170 StructureType time.zone
     - __kind: PointerType
-      ID: 253
+      ID: 172
       Name: '*time.zoneTrans'
       ByteSize: 8
       GoRuntimeType: 396704
       GoKind: 22
-      Pointee: 254 StructureType time.zoneTrans
+      Pointee: 173 StructureType time.zoneTrans
     - __kind: PointerType
       ID: 34
       Name: '*uint'
@@ -745,12 +604,12 @@ Types:
       GoKind: 22
       Pointee: 1 BaseType uintptr
     - __kind: GoChannelType
-      ID: 60
+      ID: 62
       Name: <-chan struct {}
       GoRuntimeType: 603424
       GoKind: 18
     - __kind: EventRootType
-      ID: 295
+      ID: 215
       Name: Probe[main.HandleHTTP]
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -774,7 +633,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 296
+      ID: 216
       Name: Probe[main.LookAtTheRequest]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -804,58 +663,14 @@ Types:
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 186 GoSliceDataType []*crypto/x509.Certificate.array
+      Data: 119 GoSliceDataType []*crypto/x509.Certificate.array
     - __kind: GoSliceDataType
-      ID: 186
+      ID: 119
       Name: '[]*crypto/x509.Certificate.array'
       ByteSize: 2048
       Element: 111 PointerType *crypto/x509.Certificate
     - __kind: GoSliceHeaderType
-      ID: 173
-      Name: '[]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span'
-      ByteSize: 24
-      GoRuntimeType: 491968
-      GoKind: 23
-      RawFields:
-        - Name: array
-          Offset: 0
-          Type: 174 PointerType **github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span
-        - Name: len
-          Offset: 8
-          Type: 7 BaseType int
-        - Name: cap
-          Offset: 16
-          Type: 7 BaseType int
-      Data: 242 GoSliceDataType []*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span.array
-    - __kind: GoSliceDataType
-      ID: 242
-      Name: '[]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span.array'
-      ByteSize: 2048
-      Element: 39 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span
-    - __kind: GoSliceHeaderType
-      ID: 257
-      Name: '[]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttributeValue'
-      ByteSize: 24
-      GoRuntimeType: 491584
-      GoKind: 23
-      RawFields:
-        - Name: array
-          Offset: 0
-          Type: 258 PointerType **github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttributeValue
-        - Name: len
-          Offset: 8
-          Type: 7 BaseType int
-        - Name: cap
-          Offset: 16
-          Type: 7 BaseType int
-      Data: 290 GoSliceDataType []*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttributeValue.array
-    - __kind: GoSliceDataType
-      ID: 290
-      Name: '[]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttributeValue.array'
-      ByteSize: 2048
-      Element: 259 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttributeValue
-    - __kind: GoSliceHeaderType
-      ID: 181
+      ID: 97
       Name: '[]*mime/multipart.FileHeader'
       ByteSize: 24
       GoRuntimeType: 489088
@@ -863,21 +678,21 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 182 PointerType **mime/multipart.FileHeader
+          Type: 98 PointerType **mime/multipart.FileHeader
         - Name: len
           Offset: 8
           Type: 7 BaseType int
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 244 GoSliceDataType []*mime/multipart.FileHeader.array
+      Data: 103 GoSliceDataType []*mime/multipart.FileHeader.array
     - __kind: GoSliceDataType
-      ID: 244
+      ID: 103
       Name: '[]*mime/multipart.FileHeader.array'
       ByteSize: 2048
-      Element: 183 PointerType *mime/multipart.FileHeader
+      Element: 99 PointerType *mime/multipart.FileHeader
     - __kind: GoSliceHeaderType
-      ID: 229
+      ID: 152
       Name: '[]*net.IPNet'
       ByteSize: 24
       GoRuntimeType: 518592
@@ -885,21 +700,21 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 230 PointerType **net.IPNet
+          Type: 153 PointerType **net.IPNet
         - Name: len
           Offset: 8
           Type: 7 BaseType int
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 276 GoSliceDataType []*net.IPNet.array
+      Data: 189 GoSliceDataType []*net.IPNet.array
     - __kind: GoSliceDataType
-      ID: 276
+      ID: 189
       Name: '[]*net.IPNet.array'
       ByteSize: 2048
-      Element: 231 PointerType *net.IPNet
+      Element: 154 PointerType *net.IPNet
     - __kind: GoSliceHeaderType
-      ID: 227
+      ID: 150
       Name: '[]*net/url.URL'
       ByteSize: 24
       GoRuntimeType: 518528
@@ -907,49 +722,34 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 228 PointerType **net/url.URL
+          Type: 151 PointerType **net/url.URL
         - Name: len
           Offset: 8
           Type: 7 BaseType int
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 274 GoSliceDataType []*net/url.URL.array
+      Data: 186 GoSliceDataType []*net/url.URL.array
     - __kind: GoSliceDataType
-      ID: 274
+      ID: 186
       Name: '[]*net/url.URL.array'
       ByteSize: 2048
-      Element: 45 PointerType *net/url.URL
+      Element: 47 PointerType *net/url.URL
     - __kind: GoSliceDataType
-      ID: 201
-      Name: '[]*table<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>.array'
-      ByteSize: 8192
-      Element: 128 PointerType *table<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
-    - __kind: GoSliceDataType
-      ID: 184
+      ID: 100
       Name: '[]*table<string,[]*mime/multipart.FileHeader>.array'
       ByteSize: 8192
-      Element: 108 PointerType *table<string,[]*mime/multipart.FileHeader>
+      Element: 90 PointerType *table<string,[]*mime/multipart.FileHeader>
     - __kind: GoSliceDataType
-      ID: 138
+      ID: 81
       Name: '[]*table<string,[]string>.array'
       ByteSize: 8192
-      Element: 51 PointerType *table<string,[]string>
+      Element: 53 PointerType *table<string,[]string>
     - __kind: GoSliceDataType
-      ID: 162
-      Name: '[]*table<string,float64>.array'
-      ByteSize: 8192
-      Element: 86 PointerType *table<string,float64>
-    - __kind: GoSliceDataType
-      ID: 155
-      Name: '[]*table<string,interface {}>.array'
-      ByteSize: 8192
-      Element: 81 PointerType *table<string,interface {}>
-    - __kind: GoSliceDataType
-      ID: 147
+      ID: 213
       Name: '[]*table<string,string>.array'
       ByteSize: 8192
-      Element: 70 PointerType *table<string,string>
+      Element: 72 PointerType *table<string,string>
     - __kind: GoSliceHeaderType
       ID: 112
       Name: '[][]*crypto/x509.Certificate'
@@ -966,9 +766,9 @@ Types:
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 188 GoSliceDataType [][]*crypto/x509.Certificate.array
+      Data: 121 GoSliceDataType [][]*crypto/x509.Certificate.array
     - __kind: GoSliceDataType
-      ID: 188
+      ID: 121
       Name: '[][]*crypto/x509.Certificate.array'
       ByteSize: 2048
       Element: 109 GoSliceHeaderType []*crypto/x509.Certificate
@@ -988,14 +788,14 @@ Types:
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 190 GoSliceDataType [][]uint8.array
+      Data: 123 GoSliceDataType [][]uint8.array
     - __kind: GoSliceDataType
-      ID: 190
+      ID: 123
       Name: '[][]uint8.array'
       ByteSize: 2048
-      Element: 96 GoSliceHeaderType []uint8
+      Element: 106 GoSliceHeaderType []uint8
     - __kind: GoSliceHeaderType
-      ID: 221
+      ID: 144
       Name: '[]crypto/x509.ExtKeyUsage'
       ByteSize: 24
       GoRuntimeType: 505280
@@ -1003,21 +803,21 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 222 PointerType *crypto/x509.ExtKeyUsage
+          Type: 145 PointerType *crypto/x509.ExtKeyUsage
         - Name: len
           Offset: 8
           Type: 7 BaseType int
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 268 GoSliceDataType []crypto/x509.ExtKeyUsage.array
+      Data: 182 GoSliceDataType []crypto/x509.ExtKeyUsage.array
     - __kind: GoSliceDataType
-      ID: 268
+      ID: 182
       Name: '[]crypto/x509.ExtKeyUsage.array'
       ByteSize: 2048
-      Element: 223 BaseType crypto/x509.ExtKeyUsage
+      Element: 146 BaseType crypto/x509.ExtKeyUsage
     - __kind: GoSliceHeaderType
-      ID: 232
+      ID: 155
       Name: '[]crypto/x509.OID'
       ByteSize: 24
       GoRuntimeType: 518656
@@ -1025,21 +825,21 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 233 PointerType *crypto/x509.OID
+          Type: 156 PointerType *crypto/x509.OID
         - Name: len
           Offset: 8
           Type: 7 BaseType int
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 278 GoSliceDataType []crypto/x509.OID.array
+      Data: 191 GoSliceDataType []crypto/x509.OID.array
     - __kind: GoSliceDataType
-      ID: 278
+      ID: 191
       Name: '[]crypto/x509.OID.array'
       ByteSize: 2048
-      Element: 234 StructureType crypto/x509.OID
+      Element: 157 StructureType crypto/x509.OID
     - __kind: GoSliceHeaderType
-      ID: 235
+      ID: 158
       Name: '[]crypto/x509.PolicyMapping'
       ByteSize: 24
       GoRuntimeType: 518720
@@ -1047,21 +847,21 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 236 PointerType *crypto/x509.PolicyMapping
+          Type: 159 PointerType *crypto/x509.PolicyMapping
         - Name: len
           Offset: 8
           Type: 7 BaseType int
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 280 GoSliceDataType []crypto/x509.PolicyMapping.array
+      Data: 193 GoSliceDataType []crypto/x509.PolicyMapping.array
     - __kind: GoSliceDataType
-      ID: 280
+      ID: 193
       Name: '[]crypto/x509.PolicyMapping.array'
       ByteSize: 2048
-      Element: 237 StructureType crypto/x509.PolicyMapping
+      Element: 160 StructureType crypto/x509.PolicyMapping
     - __kind: GoSliceHeaderType
-      ID: 208
+      ID: 131
       Name: '[]crypto/x509/pkix.AttributeTypeAndValue'
       ByteSize: 24
       GoRuntimeType: 519168
@@ -1069,21 +869,21 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 209 PointerType *crypto/x509/pkix.AttributeTypeAndValue
+          Type: 132 PointerType *crypto/x509/pkix.AttributeTypeAndValue
         - Name: len
           Offset: 8
           Type: 7 BaseType int
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 260 GoSliceDataType []crypto/x509/pkix.AttributeTypeAndValue.array
+      Data: 166 GoSliceDataType []crypto/x509/pkix.AttributeTypeAndValue.array
     - __kind: GoSliceDataType
-      ID: 260
+      ID: 166
       Name: '[]crypto/x509/pkix.AttributeTypeAndValue.array'
       ByteSize: 2048
-      Element: 210 StructureType crypto/x509/pkix.AttributeTypeAndValue
+      Element: 133 StructureType crypto/x509/pkix.AttributeTypeAndValue
     - __kind: GoSliceHeaderType
-      ID: 215
+      ID: 138
       Name: '[]crypto/x509/pkix.Extension'
       ByteSize: 24
       GoRuntimeType: 518400
@@ -1091,21 +891,21 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 216 PointerType *crypto/x509/pkix.Extension
+          Type: 139 PointerType *crypto/x509/pkix.Extension
         - Name: len
           Offset: 8
           Type: 7 BaseType int
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 262 GoSliceDataType []crypto/x509/pkix.Extension.array
+      Data: 178 GoSliceDataType []crypto/x509/pkix.Extension.array
     - __kind: GoSliceDataType
-      ID: 262
+      ID: 178
       Name: '[]crypto/x509/pkix.Extension.array'
       ByteSize: 2048
-      Element: 217 StructureType crypto/x509/pkix.Extension
+      Element: 140 StructureType crypto/x509/pkix.Extension
     - __kind: GoSliceHeaderType
-      ID: 218
+      ID: 141
       Name: '[]encoding/asn1.ObjectIdentifier'
       ByteSize: 24
       GoRuntimeType: 518464
@@ -1113,65 +913,21 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 219 PointerType *encoding/asn1.ObjectIdentifier
+          Type: 142 PointerType *encoding/asn1.ObjectIdentifier
         - Name: len
           Offset: 8
           Type: 7 BaseType int
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 264 GoSliceDataType []encoding/asn1.ObjectIdentifier.array
+      Data: 180 GoSliceDataType []encoding/asn1.ObjectIdentifier.array
     - __kind: GoSliceDataType
-      ID: 264
+      ID: 180
       Name: '[]encoding/asn1.ObjectIdentifier.array'
       ByteSize: 2048
-      Element: 220 GoSliceHeaderType encoding/asn1.ObjectIdentifier
+      Element: 143 GoSliceHeaderType encoding/asn1.ObjectIdentifier
     - __kind: GoSliceHeaderType
-      ID: 87
-      Name: '[]github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink'
-      ByteSize: 24
-      GoRuntimeType: 491520
-      GoKind: 23
-      RawFields:
-        - Name: array
-          Offset: 0
-          Type: 88 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink
-        - Name: len
-          Offset: 8
-          Type: 7 BaseType int
-        - Name: cap
-          Offset: 16
-          Type: 7 BaseType int
-      Data: 164 GoSliceDataType []github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink.array
-    - __kind: GoSliceDataType
-      ID: 164
-      Name: '[]github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink.array'
-      ByteSize: 2048
-      Element: 89 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink
-    - __kind: GoSliceHeaderType
-      ID: 90
-      Name: '[]github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent'
-      ByteSize: 24
-      GoRuntimeType: 491712
-      GoKind: 23
-      RawFields:
-        - Name: array
-          Offset: 0
-          Type: 91 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent
-        - Name: len
-          Offset: 8
-          Type: 7 BaseType int
-        - Name: cap
-          Offset: 16
-          Type: 7 BaseType int
-      Data: 166 GoSliceDataType []github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent.array
-    - __kind: GoSliceDataType
-      ID: 166
-      Name: '[]github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent.array'
-      ByteSize: 2048
-      Element: 92 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent
-    - __kind: GoSliceHeaderType
-      ID: 224
+      ID: 147
       Name: '[]net.IP'
       ByteSize: 24
       GoRuntimeType: 484896
@@ -1179,21 +935,21 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 225 PointerType *net.IP
+          Type: 148 PointerType *net.IP
         - Name: len
           Offset: 8
           Type: 7 BaseType int
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 270 GoSliceDataType []net.IP.array
+      Data: 184 GoSliceDataType []net.IP.array
     - __kind: GoSliceDataType
-      ID: 270
+      ID: 184
       Name: '[]net.IP.array'
       ByteSize: 2048
-      Element: 226 GoSliceHeaderType net.IP
+      Element: 149 GoSliceHeaderType net.IP
     - __kind: GoSliceHeaderType
-      ID: 118
+      ID: 202
       Name: '[]net/http.segment'
       ByteSize: 24
       GoRuntimeType: 486528
@@ -1201,51 +957,36 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 119 PointerType *net/http.segment
+          Type: 203 PointerType *net/http.segment
         - Name: len
           Offset: 8
           Type: 7 BaseType int
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 192 GoSliceDataType []net/http.segment.array
+      Data: 205 GoSliceDataType []net/http.segment.array
     - __kind: GoSliceDataType
-      ID: 192
+      ID: 205
       Name: '[]net/http.segment.array'
       ByteSize: 2048
-      Element: 120 StructureType net/http.segment
+      Element: 204 StructureType net/http.segment
     - __kind: GoSliceDataType
-      ID: 202
-      Name: '[]noalg.map.group[string]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute.array'
-      ByteSize: 2048
-      Element: 196 StructureType noalg.map.group[string]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
-    - __kind: GoSliceDataType
-      ID: 185
+      ID: 101
       Name: '[]noalg.map.group[string][]*mime/multipart.FileHeader.array'
       ByteSize: 2048
-      Element: 178 StructureType noalg.map.group[string][]*mime/multipart.FileHeader
+      Element: 94 StructureType noalg.map.group[string][]*mime/multipart.FileHeader
     - __kind: GoSliceDataType
-      ID: 139
+      ID: 82
       Name: '[]noalg.map.group[string][]string.array'
       ByteSize: 2048
-      Element: 135 StructureType noalg.map.group[string][]string
+      Element: 78 StructureType noalg.map.group[string][]string
     - __kind: GoSliceDataType
-      ID: 163
-      Name: '[]noalg.map.group[string]float64.array'
-      ByteSize: 2048
-      Element: 159 StructureType noalg.map.group[string]float64
-    - __kind: GoSliceDataType
-      ID: 156
-      Name: '[]noalg.map.group[string]interface {}.array'
-      ByteSize: 2048
-      Element: 151 StructureType noalg.map.group[string]interface {}
-    - __kind: GoSliceDataType
-      ID: 148
+      ID: 214
       Name: '[]noalg.map.group[string]string.array'
       ByteSize: 2048
-      Element: 144 StructureType noalg.map.group[string]string
+      Element: 210 StructureType noalg.map.group[string]string
     - __kind: GoSliceHeaderType
-      ID: 54
+      ID: 56
       Name: '[]string'
       ByteSize: 24
       GoRuntimeType: 498176
@@ -1260,14 +1001,14 @@ Types:
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 140 GoSliceDataType []string.array
+      Data: 83 GoSliceDataType []string.array
     - __kind: GoSliceDataType
-      ID: 140
+      ID: 83
       Name: '[]string.array'
       ByteSize: 2048
       Element: 9 GoStringHeaderType string
     - __kind: GoSliceHeaderType
-      ID: 249
+      ID: 168
       Name: '[]time.zone'
       ByteSize: 24
       GoRuntimeType: 491072
@@ -1275,21 +1016,21 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 250 PointerType *time.zone
+          Type: 169 PointerType *time.zone
         - Name: len
           Offset: 8
           Type: 7 BaseType int
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 286 GoSliceDataType []time.zone.array
+      Data: 174 GoSliceDataType []time.zone.array
     - __kind: GoSliceDataType
-      ID: 286
+      ID: 174
       Name: '[]time.zone.array'
       ByteSize: 2048
-      Element: 251 StructureType time.zone
+      Element: 170 StructureType time.zone
     - __kind: GoSliceHeaderType
-      ID: 252
+      ID: 171
       Name: '[]time.zoneTrans'
       ByteSize: 24
       GoRuntimeType: 491136
@@ -1297,21 +1038,21 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 253 PointerType *time.zoneTrans
+          Type: 172 PointerType *time.zoneTrans
         - Name: len
           Offset: 8
           Type: 7 BaseType int
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 288 GoSliceDataType []time.zoneTrans.array
+      Data: 176 GoSliceDataType []time.zoneTrans.array
     - __kind: GoSliceDataType
-      ID: 288
+      ID: 176
       Name: '[]time.zoneTrans.array'
       ByteSize: 2048
-      Element: 254 StructureType time.zoneTrans
+      Element: 173 StructureType time.zoneTrans
     - __kind: GoSliceHeaderType
-      ID: 96
+      ID: 106
       Name: '[]uint8'
       ByteSize: 24
       GoRuntimeType: 497024
@@ -1326,9 +1067,9 @@ Types:
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 168 GoSliceDataType []uint8.array
+      Data: 107 GoSliceDataType []uint8.array
     - __kind: GoSliceDataType
-      ID: 168
+      ID: 107
       Name: '[]uint8.array'
       ByteSize: 2048
       Element: 3 BaseType uint8
@@ -1338,28 +1079,10 @@ Types:
       ByteSize: 1
       GoRuntimeType: 591392
       GoKind: 1
-    - __kind: StructureType
+    - __kind: UnresolvedPointeeType
       ID: 42
       Name: bytes.Buffer
-      ByteSize: 40
-      GoRuntimeType: 1.635488e+06
-      GoKind: 25
-      RawFields:
-        - Name: buf
-          Offset: 0
-          Type: 96 GoSliceHeaderType []uint8
-        - Name: off
-          Offset: 24
-          Type: 7 BaseType int
-        - Name: lastRead
-          Offset: 32
-          Type: 97 BaseType bytes.readOp
-    - __kind: BaseType
-      ID: 97
-      Name: bytes.readOp
-      ByteSize: 1
-      GoRuntimeType: 589536
-      GoKind: 3
+      ByteSize: 8
     - __kind: BaseType
       ID: 24
       Name: complex128
@@ -1373,7 +1096,7 @@ Types:
       GoRuntimeType: 591136
       GoKind: 15
     - __kind: GoInterfaceType
-      ID: 63
+      ID: 65
       Name: context.Context
       ByteSize: 16
       GoRuntimeType: 1.298688e+06
@@ -1401,7 +1124,7 @@ Types:
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 59
+      ID: 61
       Name: crypto/tls.ConnectionState
       ByteSize: 192
       GoRuntimeType: 2.302368e+06
@@ -1439,10 +1162,10 @@ Types:
           Type: 114 GoSliceHeaderType [][]uint8
         - Name: OCSPResponse
           Offset: 120
-          Type: 96 GoSliceHeaderType []uint8
+          Type: 106 GoSliceHeaderType []uint8
         - Name: TLSUnique
           Offset: 144
-          Type: 96 GoSliceHeaderType []uint8
+          Type: 106 GoSliceHeaderType []uint8
         - Name: ECHAccepted
           Offset: 168
           Type: 4 BaseType bool
@@ -1462,7 +1185,7 @@ Types:
       GoRuntimeType: 843936
       GoKind: 9
     - __kind: StructureType
-      ID: 171
+      ID: 118
       Name: crypto/x509.Certificate
       ByteSize: 1424
       GoRuntimeType: 2.453248e+06
@@ -1470,67 +1193,67 @@ Types:
       RawFields:
         - Name: Raw
           Offset: 0
-          Type: 96 GoSliceHeaderType []uint8
+          Type: 106 GoSliceHeaderType []uint8
         - Name: RawTBSCertificate
           Offset: 24
-          Type: 96 GoSliceHeaderType []uint8
+          Type: 106 GoSliceHeaderType []uint8
         - Name: RawSubjectPublicKeyInfo
           Offset: 48
-          Type: 96 GoSliceHeaderType []uint8
+          Type: 106 GoSliceHeaderType []uint8
         - Name: RawSubject
           Offset: 72
-          Type: 96 GoSliceHeaderType []uint8
+          Type: 106 GoSliceHeaderType []uint8
         - Name: RawIssuer
           Offset: 96
-          Type: 96 GoSliceHeaderType []uint8
+          Type: 106 GoSliceHeaderType []uint8
         - Name: Signature
           Offset: 120
-          Type: 96 GoSliceHeaderType []uint8
+          Type: 106 GoSliceHeaderType []uint8
         - Name: SignatureAlgorithm
           Offset: 144
-          Type: 203 BaseType crypto/x509.SignatureAlgorithm
+          Type: 125 BaseType crypto/x509.SignatureAlgorithm
         - Name: PublicKeyAlgorithm
           Offset: 152
-          Type: 204 BaseType crypto/x509.PublicKeyAlgorithm
+          Type: 126 BaseType crypto/x509.PublicKeyAlgorithm
         - Name: PublicKey
           Offset: 160
-          Type: 154 GoEmptyInterfaceType interface {}
+          Type: 127 GoEmptyInterfaceType interface {}
         - Name: Version
           Offset: 176
           Type: 7 BaseType int
         - Name: SerialNumber
           Offset: 184
-          Type: 205 PointerType *math/big.Int
+          Type: 128 PointerType *math/big.Int
         - Name: Issuer
           Offset: 192
-          Type: 207 StructureType crypto/x509/pkix.Name
+          Type: 130 StructureType crypto/x509/pkix.Name
         - Name: Subject
           Offset: 440
-          Type: 207 StructureType crypto/x509/pkix.Name
+          Type: 130 StructureType crypto/x509/pkix.Name
         - Name: NotBefore
           Offset: 688
-          Type: 211 StructureType time.Time
+          Type: 134 StructureType time.Time
         - Name: NotAfter
           Offset: 712
-          Type: 211 StructureType time.Time
+          Type: 134 StructureType time.Time
         - Name: KeyUsage
           Offset: 736
-          Type: 214 BaseType crypto/x509.KeyUsage
+          Type: 137 BaseType crypto/x509.KeyUsage
         - Name: Extensions
           Offset: 744
-          Type: 215 GoSliceHeaderType []crypto/x509/pkix.Extension
+          Type: 138 GoSliceHeaderType []crypto/x509/pkix.Extension
         - Name: ExtraExtensions
           Offset: 768
-          Type: 215 GoSliceHeaderType []crypto/x509/pkix.Extension
+          Type: 138 GoSliceHeaderType []crypto/x509/pkix.Extension
         - Name: UnhandledCriticalExtensions
           Offset: 792
-          Type: 218 GoSliceHeaderType []encoding/asn1.ObjectIdentifier
+          Type: 141 GoSliceHeaderType []encoding/asn1.ObjectIdentifier
         - Name: ExtKeyUsage
           Offset: 816
-          Type: 221 GoSliceHeaderType []crypto/x509.ExtKeyUsage
+          Type: 144 GoSliceHeaderType []crypto/x509.ExtKeyUsage
         - Name: UnknownExtKeyUsage
           Offset: 840
-          Type: 218 GoSliceHeaderType []encoding/asn1.ObjectIdentifier
+          Type: 141 GoSliceHeaderType []encoding/asn1.ObjectIdentifier
         - Name: BasicConstraintsValid
           Offset: 864
           Type: 4 BaseType bool
@@ -1545,64 +1268,64 @@ Types:
           Type: 4 BaseType bool
         - Name: SubjectKeyId
           Offset: 888
-          Type: 96 GoSliceHeaderType []uint8
+          Type: 106 GoSliceHeaderType []uint8
         - Name: AuthorityKeyId
           Offset: 912
-          Type: 96 GoSliceHeaderType []uint8
+          Type: 106 GoSliceHeaderType []uint8
         - Name: OCSPServer
           Offset: 936
-          Type: 54 GoSliceHeaderType []string
+          Type: 56 GoSliceHeaderType []string
         - Name: IssuingCertificateURL
           Offset: 960
-          Type: 54 GoSliceHeaderType []string
+          Type: 56 GoSliceHeaderType []string
         - Name: DNSNames
           Offset: 984
-          Type: 54 GoSliceHeaderType []string
+          Type: 56 GoSliceHeaderType []string
         - Name: EmailAddresses
           Offset: 1008
-          Type: 54 GoSliceHeaderType []string
+          Type: 56 GoSliceHeaderType []string
         - Name: IPAddresses
           Offset: 1032
-          Type: 224 GoSliceHeaderType []net.IP
+          Type: 147 GoSliceHeaderType []net.IP
         - Name: URIs
           Offset: 1056
-          Type: 227 GoSliceHeaderType []*net/url.URL
+          Type: 150 GoSliceHeaderType []*net/url.URL
         - Name: PermittedDNSDomainsCritical
           Offset: 1080
           Type: 4 BaseType bool
         - Name: PermittedDNSDomains
           Offset: 1088
-          Type: 54 GoSliceHeaderType []string
+          Type: 56 GoSliceHeaderType []string
         - Name: ExcludedDNSDomains
           Offset: 1112
-          Type: 54 GoSliceHeaderType []string
+          Type: 56 GoSliceHeaderType []string
         - Name: PermittedIPRanges
           Offset: 1136
-          Type: 229 GoSliceHeaderType []*net.IPNet
+          Type: 152 GoSliceHeaderType []*net.IPNet
         - Name: ExcludedIPRanges
           Offset: 1160
-          Type: 229 GoSliceHeaderType []*net.IPNet
+          Type: 152 GoSliceHeaderType []*net.IPNet
         - Name: PermittedEmailAddresses
           Offset: 1184
-          Type: 54 GoSliceHeaderType []string
+          Type: 56 GoSliceHeaderType []string
         - Name: ExcludedEmailAddresses
           Offset: 1208
-          Type: 54 GoSliceHeaderType []string
+          Type: 56 GoSliceHeaderType []string
         - Name: PermittedURIDomains
           Offset: 1232
-          Type: 54 GoSliceHeaderType []string
+          Type: 56 GoSliceHeaderType []string
         - Name: ExcludedURIDomains
           Offset: 1256
-          Type: 54 GoSliceHeaderType []string
+          Type: 56 GoSliceHeaderType []string
         - Name: CRLDistributionPoints
           Offset: 1280
-          Type: 54 GoSliceHeaderType []string
+          Type: 56 GoSliceHeaderType []string
         - Name: PolicyIdentifiers
           Offset: 1304
-          Type: 218 GoSliceHeaderType []encoding/asn1.ObjectIdentifier
+          Type: 141 GoSliceHeaderType []encoding/asn1.ObjectIdentifier
         - Name: Policies
           Offset: 1328
-          Type: 232 GoSliceHeaderType []crypto/x509.OID
+          Type: 155 GoSliceHeaderType []crypto/x509.OID
         - Name: InhibitAnyPolicy
           Offset: 1352
           Type: 7 BaseType int
@@ -1623,21 +1346,21 @@ Types:
           Type: 4 BaseType bool
         - Name: PolicyMappings
           Offset: 1400
-          Type: 235 GoSliceHeaderType []crypto/x509.PolicyMapping
+          Type: 158 GoSliceHeaderType []crypto/x509.PolicyMapping
     - __kind: BaseType
-      ID: 223
+      ID: 146
       Name: crypto/x509.ExtKeyUsage
       ByteSize: 8
       GoRuntimeType: 594464
       GoKind: 2
     - __kind: BaseType
-      ID: 214
+      ID: 137
       Name: crypto/x509.KeyUsage
       ByteSize: 8
       GoRuntimeType: 594400
       GoKind: 2
     - __kind: StructureType
-      ID: 234
+      ID: 157
       Name: crypto/x509.OID
       ByteSize: 24
       GoRuntimeType: 1.989888e+06
@@ -1645,9 +1368,9 @@ Types:
       RawFields:
         - Name: der
           Offset: 0
-          Type: 96 GoSliceHeaderType []uint8
+          Type: 106 GoSliceHeaderType []uint8
     - __kind: StructureType
-      ID: 237
+      ID: 160
       Name: crypto/x509.PolicyMapping
       ByteSize: 48
       GoRuntimeType: 1.515072e+06
@@ -1655,24 +1378,24 @@ Types:
       RawFields:
         - Name: IssuerDomainPolicy
           Offset: 0
-          Type: 234 StructureType crypto/x509.OID
+          Type: 157 StructureType crypto/x509.OID
         - Name: SubjectDomainPolicy
           Offset: 24
-          Type: 234 StructureType crypto/x509.OID
+          Type: 157 StructureType crypto/x509.OID
     - __kind: BaseType
-      ID: 204
+      ID: 126
       Name: crypto/x509.PublicKeyAlgorithm
       ByteSize: 8
       GoRuntimeType: 846240
       GoKind: 2
     - __kind: BaseType
-      ID: 203
+      ID: 125
       Name: crypto/x509.SignatureAlgorithm
       ByteSize: 8
       GoRuntimeType: 1.134784e+06
       GoKind: 2
     - __kind: StructureType
-      ID: 210
+      ID: 133
       Name: crypto/x509/pkix.AttributeTypeAndValue
       ByteSize: 40
       GoRuntimeType: 1.527392e+06
@@ -1680,12 +1403,12 @@ Types:
       RawFields:
         - Name: Type
           Offset: 0
-          Type: 220 GoSliceHeaderType encoding/asn1.ObjectIdentifier
+          Type: 143 GoSliceHeaderType encoding/asn1.ObjectIdentifier
         - Name: Value
           Offset: 24
-          Type: 154 GoEmptyInterfaceType interface {}
+          Type: 127 GoEmptyInterfaceType interface {}
     - __kind: StructureType
-      ID: 217
+      ID: 140
       Name: crypto/x509/pkix.Extension
       ByteSize: 56
       GoRuntimeType: 1.678688e+06
@@ -1693,15 +1416,15 @@ Types:
       RawFields:
         - Name: Id
           Offset: 0
-          Type: 220 GoSliceHeaderType encoding/asn1.ObjectIdentifier
+          Type: 143 GoSliceHeaderType encoding/asn1.ObjectIdentifier
         - Name: Critical
           Offset: 24
           Type: 4 BaseType bool
         - Name: Value
           Offset: 32
-          Type: 96 GoSliceHeaderType []uint8
+          Type: 106 GoSliceHeaderType []uint8
     - __kind: StructureType
-      ID: 207
+      ID: 130
       Name: crypto/x509/pkix.Name
       ByteSize: 248
       GoRuntimeType: 2.241664e+06
@@ -1709,25 +1432,25 @@ Types:
       RawFields:
         - Name: Country
           Offset: 0
-          Type: 54 GoSliceHeaderType []string
+          Type: 56 GoSliceHeaderType []string
         - Name: Organization
           Offset: 24
-          Type: 54 GoSliceHeaderType []string
+          Type: 56 GoSliceHeaderType []string
         - Name: OrganizationalUnit
           Offset: 48
-          Type: 54 GoSliceHeaderType []string
+          Type: 56 GoSliceHeaderType []string
         - Name: Locality
           Offset: 72
-          Type: 54 GoSliceHeaderType []string
+          Type: 56 GoSliceHeaderType []string
         - Name: Province
           Offset: 96
-          Type: 54 GoSliceHeaderType []string
+          Type: 56 GoSliceHeaderType []string
         - Name: StreetAddress
           Offset: 120
-          Type: 54 GoSliceHeaderType []string
+          Type: 56 GoSliceHeaderType []string
         - Name: PostalCode
           Offset: 144
-          Type: 54 GoSliceHeaderType []string
+          Type: 56 GoSliceHeaderType []string
         - Name: SerialNumber
           Offset: 168
           Type: 9 GoStringHeaderType string
@@ -1736,12 +1459,12 @@ Types:
           Type: 9 GoStringHeaderType string
         - Name: Names
           Offset: 200
-          Type: 208 GoSliceHeaderType []crypto/x509/pkix.AttributeTypeAndValue
+          Type: 131 GoSliceHeaderType []crypto/x509/pkix.AttributeTypeAndValue
         - Name: ExtraNames
           Offset: 224
-          Type: 208 GoSliceHeaderType []crypto/x509/pkix.AttributeTypeAndValue
+          Type: 131 GoSliceHeaderType []crypto/x509/pkix.AttributeTypeAndValue
     - __kind: GoSliceHeaderType
-      ID: 220
+      ID: 143
       Name: encoding/asn1.ObjectIdentifier
       ByteSize: 24
       GoRuntimeType: 1.075328e+06
@@ -1756,9 +1479,9 @@ Types:
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 266 GoSliceDataType encoding/asn1.ObjectIdentifier.array
+      Data: 195 GoSliceDataType encoding/asn1.ObjectIdentifier.array
     - __kind: GoSliceDataType
-      ID: 266
+      ID: 195
       Name: encoding/asn1.ObjectIdentifier.array
       ByteSize: 2048
       Element: 7 BaseType int
@@ -1788,13 +1511,7 @@ Types:
       GoRuntimeType: 591328
       GoKind: 14
     - __kind: GoSubroutineType
-      ID: 95
-      Name: func()
-      ByteSize: 8
-      GoRuntimeType: 482080
-      GoKind: 19
-    - __kind: GoSubroutineType
-      ID: 53
+      ID: 55
       Name: func() (io.ReadCloser, error)
       ByteSize: 8
       GoRuntimeType: 701280
@@ -1805,393 +1522,52 @@ Types:
       ByteSize: 8
       GoRuntimeType: 1.020736e+06
       GoKind: 19
-    - __kind: StructureType
+    - __kind: UnresolvedPointeeType
       ID: 40
       Name: github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span
-      ByteSize: 288
-      GoRuntimeType: 2.39312e+06
-      GoKind: 25
-      RawFields:
-        - Name: mu
-          Offset: 0
-          Type: 71 StructureType sync.RWMutex
-        - Name: name
-          Offset: 24
-          Type: 9 GoStringHeaderType string
-        - Name: service
-          Offset: 40
-          Type: 9 GoStringHeaderType string
-        - Name: resource
-          Offset: 56
-          Type: 9 GoStringHeaderType string
-        - Name: spanType
-          Offset: 72
-          Type: 9 GoStringHeaderType string
-        - Name: start
-          Offset: 88
-          Type: 12 BaseType int64
-        - Name: duration
-          Offset: 96
-          Type: 12 BaseType int64
-        - Name: meta
-          Offset: 104
-          Type: 66 GoMapType map[string]string
-        - Name: metaStruct
-          Offset: 112
-          Type: 77 GoMapType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.metaStructMap
-        - Name: metrics
-          Offset: 120
-          Type: 82 GoMapType map[string]float64
-        - Name: spanID
-          Offset: 128
-          Type: 8 BaseType uint64
-        - Name: traceID
-          Offset: 136
-          Type: 8 BaseType uint64
-        - Name: parentID
-          Offset: 144
-          Type: 8 BaseType uint64
-        - Name: error
-          Offset: 152
-          Type: 10 BaseType int32
-        - Name: spanLinks
-          Offset: 160
-          Type: 87 GoSliceHeaderType []github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink
-        - Name: spanEvents
-          Offset: 184
-          Type: 90 GoSliceHeaderType []github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent
-        - Name: goExecTraced
-          Offset: 208
-          Type: 4 BaseType bool
-        - Name: noDebugStack
-          Offset: 209
-          Type: 4 BaseType bool
-        - Name: finished
-          Offset: 210
-          Type: 4 BaseType bool
-        - Name: context
-          Offset: 216
-          Type: 93 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanContext
-        - Name: integration
-          Offset: 224
-          Type: 9 GoStringHeaderType string
-        - Name: supportsEvents
-          Offset: 240
-          Type: 4 BaseType bool
-        - Name: pprofCtxActive
-          Offset: 248
-          Type: 63 GoInterfaceType context.Context
-        - Name: pprofCtxRestore
-          Offset: 264
-          Type: 63 GoInterfaceType context.Context
-        - Name: taskEnd
-          Offset: 280
-          Type: 95 GoSubroutineType func()
-    - __kind: StructureType
-      ID: 94
-      Name: github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanContext
-      ByteSize: 168
-      GoRuntimeType: 2.26176e+06
-      GoKind: 25
-      RawFields:
-        - Name: updated
-          Offset: 0
-          Type: 4 BaseType bool
-        - Name: trace
-          Offset: 8
-          Type: 130 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.trace
-        - Name: span
-          Offset: 16
-          Type: 39 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span
-        - Name: errors
-          Offset: 24
-          Type: 75 StructureType sync/atomic.Int32
-        - Name: reparentID
-          Offset: 32
-          Type: 9 GoStringHeaderType string
-        - Name: isRemote
-          Offset: 48
-          Type: 4 BaseType bool
-        - Name: traceID
-          Offset: 49
-          Type: 132 ArrayType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.traceID
-        - Name: spanID
-          Offset: 72
-          Type: 8 BaseType uint64
-        - Name: mu
-          Offset: 80
-          Type: 71 StructureType sync.RWMutex
-        - Name: baggage
-          Offset: 104
-          Type: 66 GoMapType map[string]string
-        - Name: hasBaggage
-          Offset: 112
-          Type: 2 BaseType uint32
-        - Name: origin
-          Offset: 120
-          Type: 9 GoStringHeaderType string
-        - Name: spanLinks
-          Offset: 136
-          Type: 87 GoSliceHeaderType []github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink
-        - Name: baggageOnly
-          Offset: 160
-          Type: 4 BaseType bool
-    - __kind: StructureType
-      ID: 89
-      Name: github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink
-      ByteSize: 56
-      GoRuntimeType: 1.947136e+06
-      GoKind: 25
-      RawFields:
-        - Name: TraceID
-          Offset: 0
-          Type: 8 BaseType uint64
-        - Name: TraceIDHigh
-          Offset: 8
-          Type: 8 BaseType uint64
-        - Name: SpanID
-          Offset: 16
-          Type: 8 BaseType uint64
-        - Name: Attributes
-          Offset: 24
-          Type: 66 GoMapType map[string]string
-        - Name: Tracestate
-          Offset: 32
-          Type: 9 GoStringHeaderType string
-        - Name: Flags
-          Offset: 48
-          Type: 2 BaseType uint32
-    - __kind: GoMapType
-      ID: 77
-      Name: github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.metaStructMap
       ByteSize: 8
-      GoRuntimeType: 1.299968e+06
-      GoKind: 21
-      HeaderType: 79 GoSwissMapHeaderType map<string,interface {}>
-    - __kind: BaseType
-      ID: 175
-      Name: github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.samplingDecision
-      ByteSize: 4
-      GoRuntimeType: 590176
-      GoKind: 10
-    - __kind: StructureType
+    - __kind: GoSwissMapGroupsType
       ID: 92
-      Name: github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent
-      ByteSize: 40
-      GoRuntimeType: 1.781696e+06
-      GoKind: 25
-      RawFields:
-        - Name: Name
-          Offset: 0
-          Type: 9 GoStringHeaderType string
-        - Name: TimeUnixNano
-          Offset: 16
-          Type: 8 BaseType uint64
-        - Name: Attributes
-          Offset: 24
-          Type: 124 GoMapType map[string]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
-        - Name: RawAttributes
-          Offset: 32
-          Type: 129 GoMapType map[string]interface {}
-    - __kind: StructureType
-      ID: 241
-      Name: github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttribute
-      ByteSize: 24
-      GoRuntimeType: 1.211328e+06
-      GoKind: 25
-      RawFields:
-        - Name: Values
-          Offset: 0
-          Type: 257 GoSliceHeaderType []*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttributeValue
-    - __kind: StructureType
-      ID: 283
-      Name: github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttributeValue
-      ByteSize: 48
-      GoRuntimeType: 1.869504e+06
-      GoKind: 25
-      RawFields:
-        - Name: Type
-          Offset: 0
-          Type: 292 BaseType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttributeValueType
-        - Name: StringValue
-          Offset: 8
-          Type: 9 GoStringHeaderType string
-        - Name: BoolValue
-          Offset: 24
-          Type: 4 BaseType bool
-        - Name: IntValue
-          Offset: 32
-          Type: 12 BaseType int64
-        - Name: DoubleValue
-          Offset: 40
-          Type: 18 BaseType float64
-    - __kind: BaseType
-      ID: 292
-      Name: github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttributeValueType
-      ByteSize: 4
-      GoRuntimeType: 1.002496e+06
-      GoKind: 5
-    - __kind: StructureType
-      ID: 200
-      Name: github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
-      ByteSize: 56
-      GoRuntimeType: 1.947392e+06
-      GoKind: 25
-      RawFields:
-        - Name: Type
-          Offset: 0
-          Type: 239 BaseType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttributeType
-        - Name: StringValue
-          Offset: 8
-          Type: 9 GoStringHeaderType string
-        - Name: BoolValue
-          Offset: 24
-          Type: 4 BaseType bool
-        - Name: IntValue
-          Offset: 32
-          Type: 12 BaseType int64
-        - Name: DoubleValue
-          Offset: 40
-          Type: 18 BaseType float64
-        - Name: ArrayValue
-          Offset: 48
-          Type: 240 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttribute
-    - __kind: BaseType
-      ID: 239
-      Name: github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttributeType
-      ByteSize: 4
-      GoRuntimeType: 1.0024e+06
-      GoKind: 5
-    - __kind: StructureType
-      ID: 131
-      Name: github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.trace
-      ByteSize: 104
-      GoRuntimeType: 2.148896e+06
-      GoKind: 25
-      RawFields:
-        - Name: mu
-          Offset: 0
-          Type: 71 StructureType sync.RWMutex
-        - Name: spans
-          Offset: 24
-          Type: 173 GoSliceHeaderType []*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span
-        - Name: tags
-          Offset: 48
-          Type: 66 GoMapType map[string]string
-        - Name: propagatingTags
-          Offset: 56
-          Type: 66 GoMapType map[string]string
-        - Name: finished
-          Offset: 64
-          Type: 7 BaseType int
-        - Name: full
-          Offset: 72
-          Type: 4 BaseType bool
-        - Name: priority
-          Offset: 80
-          Type: 25 PointerType *float64
-        - Name: locked
-          Offset: 88
-          Type: 4 BaseType bool
-        - Name: samplingDecision
-          Offset: 92
-          Type: 175 BaseType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.samplingDecision
-        - Name: root
-          Offset: 96
-          Type: 39 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span
-    - __kind: ArrayType
-      ID: 132
-      Name: github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.traceID
-      ByteSize: 16
-      GoRuntimeType: 914912
-      GoKind: 17
-      Count: 16
-      HasCount: true
-      Element: 3 BaseType uint8
-    - __kind: GoSwissMapGroupsType
-      ID: 194
-      Name: groupReference<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
-      ByteSize: 16
-      GoKind: 25
-      RawFields:
-        - Name: data
-          Offset: 0
-          Type: 195 PointerType *noalg.map.group[string]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
-        - Name: lengthMask
-          Offset: 8
-          Type: 8 BaseType uint64
-      GroupType: 196 StructureType noalg.map.group[string]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
-      GroupSliceType: 202 GoSliceDataType []noalg.map.group[string]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute.array
-    - __kind: GoSwissMapGroupsType
-      ID: 176
       Name: groupReference<string,[]*mime/multipart.FileHeader>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 177 PointerType *noalg.map.group[string][]*mime/multipart.FileHeader
+          Type: 93 PointerType *noalg.map.group[string][]*mime/multipart.FileHeader
         - Name: lengthMask
           Offset: 8
           Type: 8 BaseType uint64
-      GroupType: 178 StructureType noalg.map.group[string][]*mime/multipart.FileHeader
-      GroupSliceType: 185 GoSliceDataType []noalg.map.group[string][]*mime/multipart.FileHeader.array
+      GroupType: 94 StructureType noalg.map.group[string][]*mime/multipart.FileHeader
+      GroupSliceType: 101 GoSliceDataType []noalg.map.group[string][]*mime/multipart.FileHeader.array
     - __kind: GoSwissMapGroupsType
-      ID: 133
+      ID: 76
       Name: groupReference<string,[]string>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 134 PointerType *noalg.map.group[string][]string
+          Type: 77 PointerType *noalg.map.group[string][]string
         - Name: lengthMask
           Offset: 8
           Type: 8 BaseType uint64
-      GroupType: 135 StructureType noalg.map.group[string][]string
-      GroupSliceType: 139 GoSliceDataType []noalg.map.group[string][]string.array
+      GroupType: 78 StructureType noalg.map.group[string][]string
+      GroupSliceType: 82 GoSliceDataType []noalg.map.group[string][]string.array
     - __kind: GoSwissMapGroupsType
-      ID: 157
-      Name: groupReference<string,float64>
-      ByteSize: 16
-      GoKind: 25
-      RawFields:
-        - Name: data
-          Offset: 0
-          Type: 158 PointerType *noalg.map.group[string]float64
-        - Name: lengthMask
-          Offset: 8
-          Type: 8 BaseType uint64
-      GroupType: 159 StructureType noalg.map.group[string]float64
-      GroupSliceType: 163 GoSliceDataType []noalg.map.group[string]float64.array
-    - __kind: GoSwissMapGroupsType
-      ID: 149
-      Name: groupReference<string,interface {}>
-      ByteSize: 16
-      GoKind: 25
-      RawFields:
-        - Name: data
-          Offset: 0
-          Type: 150 PointerType *noalg.map.group[string]interface {}
-        - Name: lengthMask
-          Offset: 8
-          Type: 8 BaseType uint64
-      GroupType: 151 StructureType noalg.map.group[string]interface {}
-      GroupSliceType: 156 GoSliceDataType []noalg.map.group[string]interface {}.array
-    - __kind: GoSwissMapGroupsType
-      ID: 142
+      ID: 208
       Name: groupReference<string,string>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 143 PointerType *noalg.map.group[string]string
+          Type: 209 PointerType *noalg.map.group[string]string
         - Name: lengthMask
           Offset: 8
           Type: 8 BaseType uint64
-      GroupType: 144 StructureType noalg.map.group[string]string
-      GroupSliceType: 148 GoSliceDataType []noalg.map.group[string]string.array
+      GroupType: 210 StructureType noalg.map.group[string]string
+      GroupSliceType: 214 GoSliceDataType []noalg.map.group[string]string.array
     - __kind: BaseType
       ID: 7
       Name: int
@@ -2223,7 +1599,7 @@ Types:
       GoRuntimeType: 590432
       GoKind: 3
     - __kind: GoEmptyInterfaceType
-      ID: 154
+      ID: 127
       Name: interface {}
       ByteSize: 16
       GoRuntimeType: 863648
@@ -2235,21 +1611,8 @@ Types:
         - Name: data
           Offset: 8
           Type: 14 VoidPointerType unsafe.Pointer
-    - __kind: StructureType
-      ID: 74
-      Name: internal/sync.Mutex
-      ByteSize: 8
-      GoRuntimeType: 1.512992e+06
-      GoKind: 25
-      RawFields:
-        - Name: state
-          Offset: 0
-          Type: 10 BaseType int32
-        - Name: sema
-          Offset: 4
-          Type: 2 BaseType uint32
     - __kind: GoInterfaceType
-      ID: 52
+      ID: 54
       Name: io.ReadCloser
       ByteSize: 16
       GoRuntimeType: 1.130304e+06
@@ -2262,39 +1625,7 @@ Types:
           Offset: 8
           Type: 14 VoidPointerType unsafe.Pointer
     - __kind: GoSwissMapHeaderType
-      ID: 126
-      Name: map<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
-      ByteSize: 48
-      GoKind: 25
-      RawFields:
-        - Name: used
-          Offset: 0
-          Type: 8 BaseType uint64
-        - Name: seed
-          Offset: 8
-          Type: 1 BaseType uintptr
-        - Name: dirPtr
-          Offset: 16
-          Type: 127 PointerType **table<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
-        - Name: dirLen
-          Offset: 24
-          Type: 7 BaseType int
-        - Name: globalDepth
-          Offset: 32
-          Type: 3 BaseType uint8
-        - Name: globalShift
-          Offset: 33
-          Type: 3 BaseType uint8
-        - Name: writing
-          Offset: 34
-          Type: 3 BaseType uint8
-        - Name: clearSeq
-          Offset: 40
-          Type: 8 BaseType uint64
-      TablePtrSliceType: 201 GoSliceDataType []*table<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>.array
-      GroupType: 196 StructureType noalg.map.group[string]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
-    - __kind: GoSwissMapHeaderType
-      ID: 106
+      ID: 88
       Name: map<string,[]*mime/multipart.FileHeader>
       ByteSize: 48
       GoKind: 25
@@ -2307,7 +1638,7 @@ Types:
           Type: 1 BaseType uintptr
         - Name: dirPtr
           Offset: 16
-          Type: 107 PointerType **table<string,[]*mime/multipart.FileHeader>
+          Type: 89 PointerType **table<string,[]*mime/multipart.FileHeader>
         - Name: dirLen
           Offset: 24
           Type: 7 BaseType int
@@ -2323,10 +1654,10 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 8 BaseType uint64
-      TablePtrSliceType: 184 GoSliceDataType []*table<string,[]*mime/multipart.FileHeader>.array
-      GroupType: 178 StructureType noalg.map.group[string][]*mime/multipart.FileHeader
+      TablePtrSliceType: 100 GoSliceDataType []*table<string,[]*mime/multipart.FileHeader>.array
+      GroupType: 94 StructureType noalg.map.group[string][]*mime/multipart.FileHeader
     - __kind: GoSwissMapHeaderType
-      ID: 49
+      ID: 51
       Name: map<string,[]string>
       ByteSize: 48
       GoKind: 25
@@ -2339,7 +1670,7 @@ Types:
           Type: 1 BaseType uintptr
         - Name: dirPtr
           Offset: 16
-          Type: 50 PointerType **table<string,[]string>
+          Type: 52 PointerType **table<string,[]string>
         - Name: dirLen
           Offset: 24
           Type: 7 BaseType int
@@ -2355,74 +1686,10 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 8 BaseType uint64
-      TablePtrSliceType: 138 GoSliceDataType []*table<string,[]string>.array
-      GroupType: 135 StructureType noalg.map.group[string][]string
+      TablePtrSliceType: 81 GoSliceDataType []*table<string,[]string>.array
+      GroupType: 78 StructureType noalg.map.group[string][]string
     - __kind: GoSwissMapHeaderType
-      ID: 84
-      Name: map<string,float64>
-      ByteSize: 48
-      GoKind: 25
-      RawFields:
-        - Name: used
-          Offset: 0
-          Type: 8 BaseType uint64
-        - Name: seed
-          Offset: 8
-          Type: 1 BaseType uintptr
-        - Name: dirPtr
-          Offset: 16
-          Type: 85 PointerType **table<string,float64>
-        - Name: dirLen
-          Offset: 24
-          Type: 7 BaseType int
-        - Name: globalDepth
-          Offset: 32
-          Type: 3 BaseType uint8
-        - Name: globalShift
-          Offset: 33
-          Type: 3 BaseType uint8
-        - Name: writing
-          Offset: 34
-          Type: 3 BaseType uint8
-        - Name: clearSeq
-          Offset: 40
-          Type: 8 BaseType uint64
-      TablePtrSliceType: 162 GoSliceDataType []*table<string,float64>.array
-      GroupType: 159 StructureType noalg.map.group[string]float64
-    - __kind: GoSwissMapHeaderType
-      ID: 79
-      Name: map<string,interface {}>
-      ByteSize: 48
-      GoKind: 25
-      RawFields:
-        - Name: used
-          Offset: 0
-          Type: 8 BaseType uint64
-        - Name: seed
-          Offset: 8
-          Type: 1 BaseType uintptr
-        - Name: dirPtr
-          Offset: 16
-          Type: 80 PointerType **table<string,interface {}>
-        - Name: dirLen
-          Offset: 24
-          Type: 7 BaseType int
-        - Name: globalDepth
-          Offset: 32
-          Type: 3 BaseType uint8
-        - Name: globalShift
-          Offset: 33
-          Type: 3 BaseType uint8
-        - Name: writing
-          Offset: 34
-          Type: 3 BaseType uint8
-        - Name: clearSeq
-          Offset: 40
-          Type: 8 BaseType uint64
-      TablePtrSliceType: 155 GoSliceDataType []*table<string,interface {}>.array
-      GroupType: 151 StructureType noalg.map.group[string]interface {}
-    - __kind: GoSwissMapHeaderType
-      ID: 68
+      ID: 70
       Name: map<string,string>
       ByteSize: 48
       GoKind: 25
@@ -2435,7 +1702,7 @@ Types:
           Type: 1 BaseType uintptr
         - Name: dirPtr
           Offset: 16
-          Type: 69 PointerType **table<string,string>
+          Type: 71 PointerType **table<string,string>
         - Name: dirLen
           Offset: 24
           Type: 7 BaseType int
@@ -2451,52 +1718,31 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 8 BaseType uint64
-      TablePtrSliceType: 147 GoSliceDataType []*table<string,string>.array
-      GroupType: 144 StructureType noalg.map.group[string]string
+      TablePtrSliceType: 213 GoSliceDataType []*table<string,string>.array
+      GroupType: 210 StructureType noalg.map.group[string]string
     - __kind: GoMapType
-      ID: 124
-      Name: map[string]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
-      ByteSize: 8
-      GoRuntimeType: 1.153728e+06
-      GoKind: 21
-      HeaderType: 126 GoSwissMapHeaderType map<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
-    - __kind: GoMapType
-      ID: 104
+      ID: 86
       Name: map[string][]*mime/multipart.FileHeader
       ByteSize: 8
       GoRuntimeType: 1.15296e+06
       GoKind: 21
-      HeaderType: 106 GoSwissMapHeaderType map<string,[]*mime/multipart.FileHeader>
+      HeaderType: 88 GoSwissMapHeaderType map<string,[]*mime/multipart.FileHeader>
     - __kind: GoMapType
-      ID: 103
+      ID: 85
       Name: map[string][]string
       ByteSize: 8
       GoRuntimeType: 1.148352e+06
       GoKind: 21
-      HeaderType: 49 GoSwissMapHeaderType map<string,[]string>
+      HeaderType: 51 GoSwissMapHeaderType map<string,[]string>
     - __kind: GoMapType
-      ID: 82
-      Name: map[string]float64
-      ByteSize: 8
-      GoRuntimeType: 1.1536e+06
-      GoKind: 21
-      HeaderType: 84 GoSwissMapHeaderType map<string,float64>
-    - __kind: GoMapType
-      ID: 129
-      Name: map[string]interface {}
-      ByteSize: 8
-      GoRuntimeType: 1.146944e+06
-      GoKind: 21
-      HeaderType: 79 GoSwissMapHeaderType map<string,interface {}>
-    - __kind: GoMapType
-      ID: 66
+      ID: 68
       Name: map[string]string
       ByteSize: 8
       GoRuntimeType: 1.149376e+06
       GoKind: 21
-      HeaderType: 68 GoSwissMapHeaderType map<string,string>
+      HeaderType: 70 GoSwissMapHeaderType map<string,string>
     - __kind: StructureType
-      ID: 206
+      ID: 129
       Name: math/big.Int
       ByteSize: 32
       GoRuntimeType: 1.518112e+06
@@ -2507,15 +1753,15 @@ Types:
           Type: 4 BaseType bool
         - Name: abs
           Offset: 8
-          Type: 246 GoSliceHeaderType math/big.nat
+          Type: 161 GoSliceHeaderType math/big.nat
     - __kind: BaseType
-      ID: 248
+      ID: 163
       Name: math/big.Word
       ByteSize: 8
       GoRuntimeType: 594656
       GoKind: 7
     - __kind: GoSliceHeaderType
-      ID: 246
+      ID: 161
       Name: math/big.nat
       ByteSize: 24
       GoRuntimeType: 2.4216e+06
@@ -2523,21 +1769,21 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 247 PointerType *math/big.Word
+          Type: 162 PointerType *math/big.Word
         - Name: len
           Offset: 8
           Type: 7 BaseType int
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 284 GoSliceDataType math/big.nat.array
+      Data: 164 GoSliceDataType math/big.nat.array
     - __kind: GoSliceDataType
-      ID: 284
+      ID: 164
       Name: math/big.nat.array
       ByteSize: 2048
-      Element: 248 BaseType math/big.Word
+      Element: 163 BaseType math/big.Word
     - __kind: StructureType
-      ID: 238
+      ID: 102
       Name: mime/multipart.FileHeader
       ByteSize: 88
       GoRuntimeType: 2.010048e+06
@@ -2548,13 +1794,13 @@ Types:
           Type: 9 GoStringHeaderType string
         - Name: Header
           Offset: 16
-          Type: 256 GoMapType net/textproto.MIMEHeader
+          Type: 105 GoMapType net/textproto.MIMEHeader
         - Name: Size
           Offset: 24
           Type: 12 BaseType int64
         - Name: content
           Offset: 32
-          Type: 96 GoSliceHeaderType []uint8
+          Type: 106 GoSliceHeaderType []uint8
         - Name: tmpfile
           Offset: 56
           Type: 9 GoStringHeaderType string
@@ -2565,7 +1811,7 @@ Types:
           Offset: 80
           Type: 4 BaseType bool
     - __kind: StructureType
-      ID: 57
+      ID: 59
       Name: mime/multipart.Form
       ByteSize: 16
       GoRuntimeType: 1.501472e+06
@@ -2573,12 +1819,12 @@ Types:
       RawFields:
         - Name: Value
           Offset: 0
-          Type: 103 GoMapType map[string][]string
+          Type: 85 GoMapType map[string][]string
         - Name: File
           Offset: 8
-          Type: 104 GoMapType map[string][]*mime/multipart.FileHeader
+          Type: 86 GoMapType map[string][]*mime/multipart.FileHeader
     - __kind: GoSliceHeaderType
-      ID: 226
+      ID: 149
       Name: net.IP
       ByteSize: 24
       GoRuntimeType: 2.17104e+06
@@ -2593,14 +1839,14 @@ Types:
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 272 GoSliceDataType net.IP.array
+      Data: 197 GoSliceDataType net.IP.array
     - __kind: GoSliceDataType
-      ID: 272
+      ID: 197
       Name: net.IP.array
       ByteSize: 2048
       Element: 3 BaseType uint8
     - __kind: GoSliceHeaderType
-      ID: 282
+      ID: 199
       Name: net.IPMask
       ByteSize: 24
       GoRuntimeType: 1.03808e+06
@@ -2615,14 +1861,14 @@ Types:
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 293 GoSliceDataType net.IPMask.array
+      Data: 200 GoSliceDataType net.IPMask.array
     - __kind: GoSliceDataType
-      ID: 293
+      ID: 200
       Name: net.IPMask.array
       ByteSize: 2048
       Element: 3 BaseType uint8
     - __kind: StructureType
-      ID: 255
+      ID: 188
       Name: net.IPNet
       ByteSize: 48
       GoRuntimeType: 1.482432e+06
@@ -2630,17 +1876,17 @@ Types:
       RawFields:
         - Name: IP
           Offset: 0
-          Type: 226 GoSliceHeaderType net.IP
+          Type: 149 GoSliceHeaderType net.IP
         - Name: Mask
           Offset: 24
-          Type: 282 GoSliceHeaderType net.IPMask
+          Type: 199 GoSliceHeaderType net.IPMask
     - __kind: GoMapType
-      ID: 47
+      ID: 49
       Name: net/http.Header
       ByteSize: 8
       GoRuntimeType: 2.148192e+06
       GoKind: 21
-      HeaderType: 49 GoSwissMapHeaderType map<string,[]string>
+      HeaderType: 51 GoSwissMapHeaderType map<string,[]string>
     - __kind: StructureType
       ID: 38
       Name: net/http.Request
@@ -2653,7 +1899,7 @@ Types:
           Type: 9 GoStringHeaderType string
         - Name: URL
           Offset: 16
-          Type: 45 PointerType *net/url.URL
+          Type: 47 PointerType *net/url.URL
         - Name: Proto
           Offset: 24
           Type: 9 GoStringHeaderType string
@@ -2665,19 +1911,19 @@ Types:
           Type: 7 BaseType int
         - Name: Header
           Offset: 56
-          Type: 47 GoMapType net/http.Header
+          Type: 49 GoMapType net/http.Header
         - Name: Body
           Offset: 64
-          Type: 52 GoInterfaceType io.ReadCloser
+          Type: 54 GoInterfaceType io.ReadCloser
         - Name: GetBody
           Offset: 80
-          Type: 53 GoSubroutineType func() (io.ReadCloser, error)
+          Type: 55 GoSubroutineType func() (io.ReadCloser, error)
         - Name: ContentLength
           Offset: 88
           Type: 12 BaseType int64
         - Name: TransferEncoding
           Offset: 96
-          Type: 54 GoSliceHeaderType []string
+          Type: 56 GoSliceHeaderType []string
         - Name: Close
           Offset: 120
           Type: 4 BaseType bool
@@ -2686,16 +1932,16 @@ Types:
           Type: 9 GoStringHeaderType string
         - Name: Form
           Offset: 144
-          Type: 55 GoMapType net/url.Values
+          Type: 57 GoMapType net/url.Values
         - Name: PostForm
           Offset: 152
-          Type: 55 GoMapType net/url.Values
+          Type: 57 GoMapType net/url.Values
         - Name: MultipartForm
           Offset: 160
-          Type: 56 PointerType *mime/multipart.Form
+          Type: 58 PointerType *mime/multipart.Form
         - Name: Trailer
           Offset: 168
-          Type: 47 GoMapType net/http.Header
+          Type: 49 GoMapType net/http.Header
         - Name: RemoteAddr
           Offset: 176
           Type: 9 GoStringHeaderType string
@@ -2704,30 +1950,30 @@ Types:
           Type: 9 GoStringHeaderType string
         - Name: TLS
           Offset: 208
-          Type: 58 PointerType *crypto/tls.ConnectionState
+          Type: 60 PointerType *crypto/tls.ConnectionState
         - Name: Cancel
           Offset: 216
-          Type: 60 GoChannelType <-chan struct {}
+          Type: 62 GoChannelType <-chan struct {}
         - Name: Response
           Offset: 224
-          Type: 61 PointerType *net/http.Response
+          Type: 63 PointerType *net/http.Response
         - Name: Pattern
           Offset: 232
           Type: 9 GoStringHeaderType string
         - Name: ctx
           Offset: 248
-          Type: 63 GoInterfaceType context.Context
+          Type: 65 GoInterfaceType context.Context
         - Name: pat
           Offset: 264
-          Type: 64 PointerType *net/http.pattern
+          Type: 66 PointerType *net/http.pattern
         - Name: matches
           Offset: 272
-          Type: 54 GoSliceHeaderType []string
+          Type: 56 GoSliceHeaderType []string
         - Name: otherValues
           Offset: 296
-          Type: 66 GoMapType map[string]string
+          Type: 68 GoMapType map[string]string
     - __kind: StructureType
-      ID: 62
+      ID: 64
       Name: net/http.Response
       ByteSize: 144
       GoRuntimeType: 2.260416e+06
@@ -2750,16 +1996,16 @@ Types:
           Type: 7 BaseType int
         - Name: Header
           Offset: 56
-          Type: 47 GoMapType net/http.Header
+          Type: 49 GoMapType net/http.Header
         - Name: Body
           Offset: 64
-          Type: 52 GoInterfaceType io.ReadCloser
+          Type: 54 GoInterfaceType io.ReadCloser
         - Name: ContentLength
           Offset: 80
           Type: 12 BaseType int64
         - Name: TransferEncoding
           Offset: 88
-          Type: 54 GoSliceHeaderType []string
+          Type: 56 GoSliceHeaderType []string
         - Name: Close
           Offset: 112
           Type: 4 BaseType bool
@@ -2768,13 +2014,13 @@ Types:
           Type: 4 BaseType bool
         - Name: Trailer
           Offset: 120
-          Type: 47 GoMapType net/http.Header
+          Type: 49 GoMapType net/http.Header
         - Name: Request
           Offset: 128
           Type: 37 PointerType *net/http.Request
         - Name: TLS
           Offset: 136
-          Type: 58 PointerType *crypto/tls.ConnectionState
+          Type: 60 PointerType *crypto/tls.ConnectionState
     - __kind: GoInterfaceType
       ID: 36
       Name: net/http.ResponseWriter
@@ -2789,7 +2035,7 @@ Types:
           Offset: 8
           Type: 14 VoidPointerType unsafe.Pointer
     - __kind: StructureType
-      ID: 65
+      ID: 67
       Name: net/http.pattern
       ByteSize: 88
       GoRuntimeType: 1.866368e+06
@@ -2806,12 +2052,12 @@ Types:
           Type: 9 GoStringHeaderType string
         - Name: segments
           Offset: 48
-          Type: 118 GoSliceHeaderType []net/http.segment
+          Type: 202 GoSliceHeaderType []net/http.segment
         - Name: loc
           Offset: 72
           Type: 9 GoStringHeaderType string
     - __kind: StructureType
-      ID: 120
+      ID: 204
       Name: net/http.segment
       ByteSize: 24
       GoRuntimeType: 1.6376e+06
@@ -2827,14 +2073,14 @@ Types:
           Offset: 17
           Type: 4 BaseType bool
     - __kind: GoMapType
-      ID: 256
+      ID: 105
       Name: net/textproto.MIMEHeader
       ByteSize: 8
       GoRuntimeType: 1.85488e+06
       GoKind: 21
-      HeaderType: 49 GoSwissMapHeaderType map<string,[]string>
+      HeaderType: 51 GoSwissMapHeaderType map<string,[]string>
     - __kind: StructureType
-      ID: 46
+      ID: 48
       Name: net/url.URL
       ByteSize: 144
       GoRuntimeType: 2.173728e+06
@@ -2848,7 +2094,7 @@ Types:
           Type: 9 GoStringHeaderType string
         - Name: User
           Offset: 32
-          Type: 100 PointerType *net/url.Userinfo
+          Type: 73 PointerType *net/url.Userinfo
         - Name: Host
           Offset: 40
           Type: 9 GoStringHeaderType string
@@ -2874,7 +2120,7 @@ Types:
           Offset: 128
           Type: 9 GoStringHeaderType string
     - __kind: StructureType
-      ID: 101
+      ID: 74
       Name: net/url.Userinfo
       ByteSize: 40
       GoRuntimeType: 1.653536e+06
@@ -2890,81 +2136,41 @@ Types:
           Offset: 32
           Type: 4 BaseType bool
     - __kind: GoMapType
-      ID: 55
+      ID: 57
       Name: net/url.Values
       ByteSize: 8
       GoRuntimeType: 1.9208e+06
       GoKind: 21
-      HeaderType: 49 GoSwissMapHeaderType map<string,[]string>
+      HeaderType: 51 GoSwissMapHeaderType map<string,[]string>
     - __kind: ArrayType
-      ID: 197
-      Name: noalg.[8]struct { key string; elem *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute }
-      ByteSize: 192
-      GoRuntimeType: 711904
-      GoKind: 17
-      Count: 8
-      HasCount: true
-      Element: 198 StructureType noalg.struct { key string; elem *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute }
-    - __kind: ArrayType
-      ID: 179
+      ID: 95
       Name: noalg.[8]struct { key string; elem []*mime/multipart.FileHeader }
       ByteSize: 320
       GoRuntimeType: 707328
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 180 StructureType noalg.struct { key string; elem []*mime/multipart.FileHeader }
+      Element: 96 StructureType noalg.struct { key string; elem []*mime/multipart.FileHeader }
     - __kind: ArrayType
-      ID: 136
+      ID: 79
       Name: noalg.[8]struct { key string; elem []string }
       ByteSize: 320
       GoRuntimeType: 697312
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 137 StructureType noalg.struct { key string; elem []string }
+      Element: 80 StructureType noalg.struct { key string; elem []string }
     - __kind: ArrayType
-      ID: 160
-      Name: noalg.[8]struct { key string; elem float64 }
-      ByteSize: 192
-      GoRuntimeType: 711808
-      GoKind: 17
-      Count: 8
-      HasCount: true
-      Element: 161 StructureType noalg.struct { key string; elem float64 }
-    - __kind: ArrayType
-      ID: 152
-      Name: noalg.[8]struct { key string; elem interface {} }
-      ByteSize: 256
-      GoRuntimeType: 688768
-      GoKind: 17
-      Count: 8
-      HasCount: true
-      Element: 153 StructureType noalg.struct { key string; elem interface {} }
-    - __kind: ArrayType
-      ID: 145
+      ID: 211
       Name: noalg.[8]struct { key string; elem string }
       ByteSize: 256
       GoRuntimeType: 701472
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 146 StructureType noalg.struct { key string; elem string }
+      Element: 212 StructureType noalg.struct { key string; elem string }
     - __kind: StructureType
-      ID: 196
-      Name: noalg.map.group[string]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
-      ByteSize: 200
-      GoRuntimeType: 1.327872e+06
-      GoKind: 25
-      RawFields:
-        - Name: ctrl
-          Offset: 0
-          Type: 8 BaseType uint64
-        - Name: slots
-          Offset: 8
-          Type: 197 ArrayType noalg.[8]struct { key string; elem *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute }
-    - __kind: StructureType
-      ID: 178
+      ID: 94
       Name: noalg.map.group[string][]*mime/multipart.FileHeader
       ByteSize: 328
       GoRuntimeType: 1.3216e+06
@@ -2975,9 +2181,9 @@ Types:
           Type: 8 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 179 ArrayType noalg.[8]struct { key string; elem []*mime/multipart.FileHeader }
+          Type: 95 ArrayType noalg.[8]struct { key string; elem []*mime/multipart.FileHeader }
     - __kind: StructureType
-      ID: 135
+      ID: 78
       Name: noalg.map.group[string][]string
       ByteSize: 328
       GoRuntimeType: 1.312128e+06
@@ -2988,35 +2194,9 @@ Types:
           Type: 8 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 136 ArrayType noalg.[8]struct { key string; elem []string }
+          Type: 79 ArrayType noalg.[8]struct { key string; elem []string }
     - __kind: StructureType
-      ID: 159
-      Name: noalg.map.group[string]float64
-      ByteSize: 200
-      GoRuntimeType: 1.327616e+06
-      GoKind: 25
-      RawFields:
-        - Name: ctrl
-          Offset: 0
-          Type: 8 BaseType uint64
-        - Name: slots
-          Offset: 8
-          Type: 160 ArrayType noalg.[8]struct { key string; elem float64 }
-    - __kind: StructureType
-      ID: 151
-      Name: noalg.map.group[string]interface {}
-      ByteSize: 264
-      GoRuntimeType: 1.309568e+06
-      GoKind: 25
-      RawFields:
-        - Name: ctrl
-          Offset: 0
-          Type: 8 BaseType uint64
-        - Name: slots
-          Offset: 8
-          Type: 152 ArrayType noalg.[8]struct { key string; elem interface {} }
-    - __kind: StructureType
-      ID: 144
+      ID: 210
       Name: noalg.map.group[string]string
       ByteSize: 264
       GoRuntimeType: 1.314432e+06
@@ -3027,22 +2207,9 @@ Types:
           Type: 8 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 145 ArrayType noalg.[8]struct { key string; elem string }
+          Type: 211 ArrayType noalg.[8]struct { key string; elem string }
     - __kind: StructureType
-      ID: 198
-      Name: noalg.struct { key string; elem *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute }
-      ByteSize: 24
-      GoRuntimeType: 1.327744e+06
-      GoKind: 25
-      RawFields:
-        - Name: key
-          Offset: 0
-          Type: 9 GoStringHeaderType string
-        - Name: elem
-          Offset: 16
-          Type: 199 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
-    - __kind: StructureType
-      ID: 180
+      ID: 96
       Name: noalg.struct { key string; elem []*mime/multipart.FileHeader }
       ByteSize: 40
       GoRuntimeType: 1.321472e+06
@@ -3053,9 +2220,9 @@ Types:
           Type: 9 GoStringHeaderType string
         - Name: elem
           Offset: 16
-          Type: 181 GoSliceHeaderType []*mime/multipart.FileHeader
+          Type: 97 GoSliceHeaderType []*mime/multipart.FileHeader
     - __kind: StructureType
-      ID: 137
+      ID: 80
       Name: noalg.struct { key string; elem []string }
       ByteSize: 40
       GoRuntimeType: 1.312e+06
@@ -3066,35 +2233,9 @@ Types:
           Type: 9 GoStringHeaderType string
         - Name: elem
           Offset: 16
-          Type: 54 GoSliceHeaderType []string
+          Type: 56 GoSliceHeaderType []string
     - __kind: StructureType
-      ID: 161
-      Name: noalg.struct { key string; elem float64 }
-      ByteSize: 24
-      GoRuntimeType: 1.327488e+06
-      GoKind: 25
-      RawFields:
-        - Name: key
-          Offset: 0
-          Type: 9 GoStringHeaderType string
-        - Name: elem
-          Offset: 16
-          Type: 18 BaseType float64
-    - __kind: StructureType
-      ID: 153
-      Name: noalg.struct { key string; elem interface {} }
-      ByteSize: 32
-      GoRuntimeType: 1.30944e+06
-      GoKind: 25
-      RawFields:
-        - Name: key
-          Offset: 0
-          Type: 9 GoStringHeaderType string
-        - Name: elem
-          Offset: 16
-          Type: 154 GoEmptyInterfaceType interface {}
-    - __kind: StructureType
-      ID: 146
+      ID: 212
       Name: noalg.struct { key string; elem string }
       ByteSize: 32
       GoRuntimeType: 1.314304e+06
@@ -3115,101 +2256,17 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 99 PointerType *string.str
+          Type: 46 PointerType *string.str
         - Name: len
           Offset: 8
           Type: 7 BaseType int
-      Data: 98 GoStringDataType string.str
+      Data: 45 GoStringDataType string.str
     - __kind: GoStringDataType
-      ID: 98
+      ID: 45
       Name: string.str
       ByteSize: 2048
     - __kind: StructureType
-      ID: 72
-      Name: sync.Mutex
-      ByteSize: 8
-      GoRuntimeType: 1.489632e+06
-      GoKind: 25
-      RawFields:
-        - Name: _
-          Offset: 0
-          Type: 73 StructureType sync.noCopy
-        - Name: mu
-          Offset: 0
-          Type: 74 StructureType internal/sync.Mutex
-    - __kind: StructureType
-      ID: 71
-      Name: sync.RWMutex
-      ByteSize: 24
-      GoRuntimeType: 1.872192e+06
-      GoKind: 25
-      RawFields:
-        - Name: w
-          Offset: 0
-          Type: 72 StructureType sync.Mutex
-        - Name: writerSem
-          Offset: 8
-          Type: 2 BaseType uint32
-        - Name: readerSem
-          Offset: 12
-          Type: 2 BaseType uint32
-        - Name: readerCount
-          Offset: 16
-          Type: 75 StructureType sync/atomic.Int32
-        - Name: readerWait
-          Offset: 20
-          Type: 75 StructureType sync/atomic.Int32
-    - __kind: StructureType
-      ID: 73
-      Name: sync.noCopy
-      GoRuntimeType: 1.003072e+06
-      GoKind: 25
-      RawFields: []
-    - __kind: StructureType
-      ID: 75
-      Name: sync/atomic.Int32
-      ByteSize: 4
-      GoRuntimeType: 1.490912e+06
-      GoKind: 25
-      RawFields:
-        - Name: _
-          Offset: 0
-          Type: 76 StructureType sync/atomic.noCopy
-        - Name: v
-          Offset: 0
-          Type: 10 BaseType int32
-    - __kind: StructureType
-      ID: 76
-      Name: sync/atomic.noCopy
-      GoRuntimeType: 1.003168e+06
-      GoKind: 25
-      RawFields: []
-    - __kind: StructureType
-      ID: 172
-      Name: table<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
-      ByteSize: 32
-      GoKind: 25
-      RawFields:
-        - Name: used
-          Offset: 0
-          Type: 6 BaseType uint16
-        - Name: capacity
-          Offset: 2
-          Type: 6 BaseType uint16
-        - Name: growthLeft
-          Offset: 4
-          Type: 6 BaseType uint16
-        - Name: localDepth
-          Offset: 6
-          Type: 3 BaseType uint8
-        - Name: index
-          Offset: 8
-          Type: 7 BaseType int
-        - Name: groups
-          Offset: 16
-          Type: 194 GoSwissMapGroupsType groupReference<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
-    - __kind: StructureType
-      ID: 170
+      ID: 91
       Name: table<string,[]*mime/multipart.FileHeader>
       ByteSize: 32
       GoKind: 25
@@ -3231,9 +2288,9 @@ Types:
           Type: 7 BaseType int
         - Name: groups
           Offset: 16
-          Type: 176 GoSwissMapGroupsType groupReference<string,[]*mime/multipart.FileHeader>
+          Type: 92 GoSwissMapGroupsType groupReference<string,[]*mime/multipart.FileHeader>
     - __kind: StructureType
-      ID: 102
+      ID: 75
       Name: table<string,[]string>
       ByteSize: 32
       GoKind: 25
@@ -3255,57 +2312,9 @@ Types:
           Type: 7 BaseType int
         - Name: groups
           Offset: 16
-          Type: 133 GoSwissMapGroupsType groupReference<string,[]string>
+          Type: 76 GoSwissMapGroupsType groupReference<string,[]string>
     - __kind: StructureType
-      ID: 123
-      Name: table<string,float64>
-      ByteSize: 32
-      GoKind: 25
-      RawFields:
-        - Name: used
-          Offset: 0
-          Type: 6 BaseType uint16
-        - Name: capacity
-          Offset: 2
-          Type: 6 BaseType uint16
-        - Name: growthLeft
-          Offset: 4
-          Type: 6 BaseType uint16
-        - Name: localDepth
-          Offset: 6
-          Type: 3 BaseType uint8
-        - Name: index
-          Offset: 8
-          Type: 7 BaseType int
-        - Name: groups
-          Offset: 16
-          Type: 157 GoSwissMapGroupsType groupReference<string,float64>
-    - __kind: StructureType
-      ID: 122
-      Name: table<string,interface {}>
-      ByteSize: 32
-      GoKind: 25
-      RawFields:
-        - Name: used
-          Offset: 0
-          Type: 6 BaseType uint16
-        - Name: capacity
-          Offset: 2
-          Type: 6 BaseType uint16
-        - Name: growthLeft
-          Offset: 4
-          Type: 6 BaseType uint16
-        - Name: localDepth
-          Offset: 6
-          Type: 3 BaseType uint8
-        - Name: index
-          Offset: 8
-          Type: 7 BaseType int
-        - Name: groups
-          Offset: 16
-          Type: 149 GoSwissMapGroupsType groupReference<string,interface {}>
-    - __kind: StructureType
-      ID: 121
+      ID: 207
       Name: table<string,string>
       ByteSize: 32
       GoKind: 25
@@ -3327,9 +2336,9 @@ Types:
           Type: 7 BaseType int
         - Name: groups
           Offset: 16
-          Type: 142 GoSwissMapGroupsType groupReference<string,string>
+          Type: 208 GoSwissMapGroupsType groupReference<string,string>
     - __kind: StructureType
-      ID: 213
+      ID: 136
       Name: time.Location
       ByteSize: 104
       GoRuntimeType: 2.006016e+06
@@ -3340,10 +2349,10 @@ Types:
           Type: 9 GoStringHeaderType string
         - Name: zone
           Offset: 16
-          Type: 249 GoSliceHeaderType []time.zone
+          Type: 168 GoSliceHeaderType []time.zone
         - Name: tx
           Offset: 40
-          Type: 252 GoSliceHeaderType []time.zoneTrans
+          Type: 171 GoSliceHeaderType []time.zoneTrans
         - Name: extend
           Offset: 64
           Type: 9 GoStringHeaderType string
@@ -3355,9 +2364,9 @@ Types:
           Type: 12 BaseType int64
         - Name: cacheZone
           Offset: 96
-          Type: 250 PointerType *time.zone
+          Type: 169 PointerType *time.zone
     - __kind: StructureType
-      ID: 211
+      ID: 134
       Name: time.Time
       ByteSize: 24
       GoRuntimeType: 2.424416e+06
@@ -3371,9 +2380,9 @@ Types:
           Type: 12 BaseType int64
         - Name: loc
           Offset: 16
-          Type: 212 PointerType *time.Location
+          Type: 135 PointerType *time.Location
     - __kind: StructureType
-      ID: 251
+      ID: 170
       Name: time.zone
       ByteSize: 32
       GoRuntimeType: 1.642592e+06
@@ -3389,7 +2398,7 @@ Types:
           Offset: 24
           Type: 4 BaseType bool
     - __kind: StructureType
-      ID: 254
+      ID: 173
       Name: time.zoneTrans
       ByteSize: 16
       GoRuntimeType: 1.781504e+06
@@ -3449,6 +2458,6 @@ Types:
       ByteSize: 8
       GoRuntimeType: 591456
       GoKind: 26
-MaxTypeID: 296
+MaxTypeID: 216
 Issues: []
 GoModuledataInfo: {FirstModuledataAddr: "0x18b56e0", TypesOffset: 296}

--- a/pkg/dyninst/irgen/testdata/snapshot/rc_tester.arch=amd64,toolchain=go1.25.0.yaml
+++ b/pkg/dyninst/irgen/testdata/snapshot/rc_tester.arch=amd64,toolchain=go1.25.0.yaml
@@ -65,14 +65,14 @@ Subprograms:
           IsParameter: true
           IsReturn: false
         - Name: span
-          Type: 158 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span
+          Type: 39 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span
           Locations:
             - Range: 0xd363c8..0xd36401
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: false
           IsReturn: false
         - Name: '&buf'
-          Type: 225 PointerType *bytes.Buffer
+          Type: 41 PointerType *bytes.Buffer
           Locations:
             - Range: 0xd364d7..0xd364f2
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
@@ -98,194 +98,194 @@ Subprograms:
           IsReturn: false
 Types:
     - __kind: PointerType
-      ID: 82
+      ID: 107
       Name: '**crypto/x509.Certificate'
       ByteSize: 8
       GoKind: 22
-      Pointee: 83 PointerType *crypto/x509.Certificate
+      Pointee: 108 PointerType *crypto/x509.Certificate
     - __kind: PointerType
-      ID: 221
+      ID: 146
       Name: '**github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span'
       ByteSize: 8
       GoKind: 22
-      Pointee: 158 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span
+      Pointee: 39 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span
     - __kind: PointerType
-      ID: 211
+      ID: 224
       Name: '**github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttributeValue'
       ByteSize: 8
       GoKind: 22
-      Pointee: 212 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttributeValue
+      Pointee: 225 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttributeValue
     - __kind: PointerType
-      ID: 73
+      ID: 201
       Name: '**mime/multipart.FileHeader'
       ByteSize: 8
       GoKind: 22
-      Pointee: 74 PointerType *mime/multipart.FileHeader
+      Pointee: 202 PointerType *mime/multipart.FileHeader
     - __kind: PointerType
-      ID: 122
+      ID: 181
       Name: '**net.IPNet'
       ByteSize: 8
       GoKind: 22
-      Pointee: 123 PointerType *net.IPNet
+      Pointee: 182 PointerType *net.IPNet
     - __kind: PointerType
-      ID: 120
+      ID: 179
       Name: '**net/url.URL'
       ByteSize: 8
       GoKind: 22
-      Pointee: 39 PointerType *net/url.URL
+      Pointee: 43 PointerType *net/url.URL
     - __kind: PointerType
-      ID: 197
+      ID: 124
       Name: '**table<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>'
       ByteSize: 8
-      Pointee: 198 PointerType *table<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
+      Pointee: 125 PointerType *table<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
     - __kind: PointerType
-      ID: 64
+      ID: 103
       Name: '**table<string,[]*mime/multipart.FileHeader>'
       ByteSize: 8
-      Pointee: 65 PointerType *table<string,[]*mime/multipart.FileHeader>
+      Pointee: 104 PointerType *table<string,[]*mime/multipart.FileHeader>
     - __kind: PointerType
-      ID: 46
+      ID: 48
       Name: '**table<string,[]string>'
       ByteSize: 8
-      Pointee: 47 PointerType *table<string,[]string>
+      Pointee: 49 PointerType *table<string,[]string>
     - __kind: PointerType
-      ID: 180
+      ID: 83
       Name: '**table<string,float64>'
       ByteSize: 8
-      Pointee: 181 PointerType *table<string,float64>
+      Pointee: 84 PointerType *table<string,float64>
     - __kind: PointerType
-      ID: 169
+      ID: 78
       Name: '**table<string,interface {}>'
       ByteSize: 8
-      Pointee: 170 PointerType *table<string,interface {}>
+      Pointee: 79 PointerType *table<string,interface {}>
     - __kind: PointerType
-      ID: 150
+      ID: 67
       Name: '**table<string,string>'
       ByteSize: 8
-      Pointee: 151 PointerType *table<string,string>
+      Pointee: 68 PointerType *table<string,string>
     - __kind: PointerType
-      ID: 133
+      ID: 110
       Name: '*[]*crypto/x509.Certificate'
       ByteSize: 8
       GoKind: 22
-      Pointee: 81 GoSliceHeaderType []*crypto/x509.Certificate
+      Pointee: 106 GoSliceHeaderType []*crypto/x509.Certificate
     - __kind: PointerType
-      ID: 241
+      ID: 249
       Name: '*[]*crypto/x509.Certificate.array'
       ByteSize: 8
-      Pointee: 240 GoSliceDataType []*crypto/x509.Certificate.array
-    - __kind: PointerType
-      ID: 293
-      Name: '*[]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span.array'
-      ByteSize: 8
-      Pointee: 292 GoSliceDataType []*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span.array
-    - __kind: PointerType
-      ID: 291
-      Name: '*[]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttributeValue.array'
-      ByteSize: 8
-      Pointee: 290 GoSliceDataType []*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttributeValue.array
-    - __kind: PointerType
-      ID: 237
-      Name: '*[]*mime/multipart.FileHeader.array'
-      ByteSize: 8
-      Pointee: 236 GoSliceDataType []*mime/multipart.FileHeader.array
-    - __kind: PointerType
-      ID: 265
-      Name: '*[]*net.IPNet.array'
-      ByteSize: 8
-      Pointee: 264 GoSliceDataType []*net.IPNet.array
-    - __kind: PointerType
-      ID: 263
-      Name: '*[]*net/url.URL.array'
-      ByteSize: 8
-      Pointee: 262 GoSliceDataType []*net/url.URL.array
-    - __kind: PointerType
-      ID: 273
-      Name: '*[][]*crypto/x509.Certificate.array'
-      ByteSize: 8
-      Pointee: 272 GoSliceDataType [][]*crypto/x509.Certificate.array
-    - __kind: PointerType
-      ID: 275
-      Name: '*[][]uint8.array'
-      ByteSize: 8
-      Pointee: 274 GoSliceDataType [][]uint8.array
-    - __kind: PointerType
-      ID: 257
-      Name: '*[]crypto/x509.ExtKeyUsage.array'
-      ByteSize: 8
-      Pointee: 256 GoSliceDataType []crypto/x509.ExtKeyUsage.array
-    - __kind: PointerType
-      ID: 269
-      Name: '*[]crypto/x509.OID.array'
-      ByteSize: 8
-      Pointee: 268 GoSliceDataType []crypto/x509.OID.array
-    - __kind: PointerType
-      ID: 271
-      Name: '*[]crypto/x509.PolicyMapping.array'
-      ByteSize: 8
-      Pointee: 270 GoSliceDataType []crypto/x509.PolicyMapping.array
-    - __kind: PointerType
-      ID: 245
-      Name: '*[]crypto/x509/pkix.AttributeTypeAndValue.array'
-      ByteSize: 8
-      Pointee: 244 GoSliceDataType []crypto/x509/pkix.AttributeTypeAndValue.array
-    - __kind: PointerType
-      ID: 253
-      Name: '*[]crypto/x509/pkix.Extension.array'
-      ByteSize: 8
-      Pointee: 252 GoSliceDataType []crypto/x509/pkix.Extension.array
-    - __kind: PointerType
-      ID: 255
-      Name: '*[]encoding/asn1.ObjectIdentifier.array'
-      ByteSize: 8
-      Pointee: 254 GoSliceDataType []encoding/asn1.ObjectIdentifier.array
-    - __kind: PointerType
-      ID: 285
-      Name: '*[]github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink.array'
-      ByteSize: 8
-      Pointee: 284 GoSliceDataType []github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink.array
-    - __kind: PointerType
-      ID: 287
-      Name: '*[]github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent.array'
-      ByteSize: 8
-      Pointee: 286 GoSliceDataType []github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent.array
+      Pointee: 248 GoSliceDataType []*crypto/x509.Certificate.array
     - __kind: PointerType
       ID: 259
-      Name: '*[]net.IP.array'
+      Name: '*[]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span.array'
       ByteSize: 8
-      Pointee: 258 GoSliceDataType []net.IP.array
+      Pointee: 258 GoSliceDataType []*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span.array
+    - __kind: PointerType
+      ID: 293
+      Name: '*[]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttributeValue.array'
+      ByteSize: 8
+      Pointee: 292 GoSliceDataType []*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttributeValue.array
+    - __kind: PointerType
+      ID: 283
+      Name: '*[]*mime/multipart.FileHeader.array'
+      ByteSize: 8
+      Pointee: 282 GoSliceDataType []*mime/multipart.FileHeader.array
     - __kind: PointerType
       ID: 277
+      Name: '*[]*net.IPNet.array'
+      ByteSize: 8
+      Pointee: 276 GoSliceDataType []*net.IPNet.array
+    - __kind: PointerType
+      ID: 275
+      Name: '*[]*net/url.URL.array'
+      ByteSize: 8
+      Pointee: 274 GoSliceDataType []*net/url.URL.array
+    - __kind: PointerType
+      ID: 251
+      Name: '*[][]*crypto/x509.Certificate.array'
+      ByteSize: 8
+      Pointee: 250 GoSliceDataType [][]*crypto/x509.Certificate.array
+    - __kind: PointerType
+      ID: 253
+      Name: '*[][]uint8.array'
+      ByteSize: 8
+      Pointee: 252 GoSliceDataType [][]uint8.array
+    - __kind: PointerType
+      ID: 269
+      Name: '*[]crypto/x509.ExtKeyUsage.array'
+      ByteSize: 8
+      Pointee: 268 GoSliceDataType []crypto/x509.ExtKeyUsage.array
+    - __kind: PointerType
+      ID: 279
+      Name: '*[]crypto/x509.OID.array'
+      ByteSize: 8
+      Pointee: 278 GoSliceDataType []crypto/x509.OID.array
+    - __kind: PointerType
+      ID: 281
+      Name: '*[]crypto/x509.PolicyMapping.array'
+      ByteSize: 8
+      Pointee: 280 GoSliceDataType []crypto/x509.PolicyMapping.array
+    - __kind: PointerType
+      ID: 261
+      Name: '*[]crypto/x509/pkix.AttributeTypeAndValue.array'
+      ByteSize: 8
+      Pointee: 260 GoSliceDataType []crypto/x509/pkix.AttributeTypeAndValue.array
+    - __kind: PointerType
+      ID: 263
+      Name: '*[]crypto/x509/pkix.Extension.array'
+      ByteSize: 8
+      Pointee: 262 GoSliceDataType []crypto/x509/pkix.Extension.array
+    - __kind: PointerType
+      ID: 265
+      Name: '*[]encoding/asn1.ObjectIdentifier.array'
+      ByteSize: 8
+      Pointee: 264 GoSliceDataType []encoding/asn1.ObjectIdentifier.array
+    - __kind: PointerType
+      ID: 241
+      Name: '*[]github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink.array'
+      ByteSize: 8
+      Pointee: 240 GoSliceDataType []github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink.array
+    - __kind: PointerType
+      ID: 243
+      Name: '*[]github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent.array'
+      ByteSize: 8
+      Pointee: 242 GoSliceDataType []github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent.array
+    - __kind: PointerType
+      ID: 271
+      Name: '*[]net.IP.array'
+      ByteSize: 8
+      Pointee: 270 GoSliceDataType []net.IP.array
+    - __kind: PointerType
+      ID: 255
       Name: '*[]net/http.segment.array'
       ByteSize: 8
-      Pointee: 276 GoSliceDataType []net/http.segment.array
+      Pointee: 254 GoSliceDataType []net/http.segment.array
     - __kind: PointerType
       ID: 233
       Name: '*[]string.array'
       ByteSize: 8
       Pointee: 232 GoSliceDataType []string.array
     - __kind: PointerType
-      ID: 249
+      ID: 287
       Name: '*[]time.zone.array'
       ByteSize: 8
-      Pointee: 248 GoSliceDataType []time.zone.array
+      Pointee: 286 GoSliceDataType []time.zone.array
     - __kind: PointerType
-      ID: 251
+      ID: 289
       Name: '*[]time.zoneTrans.array'
       ByteSize: 8
-      Pointee: 250 GoSliceDataType []time.zoneTrans.array
+      Pointee: 288 GoSliceDataType []time.zoneTrans.array
     - __kind: PointerType
-      ID: 135
+      ID: 112
       Name: '*[]uint8'
       ByteSize: 8
       GoRuntimeType: 486560
       GoKind: 22
-      Pointee: 77 GoSliceHeaderType []uint8
+      Pointee: 94 GoSliceHeaderType []uint8
     - __kind: PointerType
-      ID: 239
+      ID: 245
       Name: '*[]uint8.array'
       ByteSize: 8
-      Pointee: 238 GoSliceDataType []uint8.array
+      Pointee: 244 GoSliceDataType []uint8.array
     - __kind: PointerType
       ID: 11
       Name: '*bool'
@@ -294,73 +294,73 @@ Types:
       GoKind: 22
       Pointee: 4 BaseType bool
     - __kind: PointerType
-      ID: 225
+      ID: 41
       Name: '*bytes.Buffer'
       ByteSize: 8
       GoRuntimeType: 2.321376e+06
       GoKind: 22
-      Pointee: 226 StructureType bytes.Buffer
+      Pointee: 42 StructureType bytes.Buffer
     - __kind: PointerType
-      ID: 78
+      ID: 56
       Name: '*crypto/tls.ConnectionState'
       ByteSize: 8
       GoRuntimeType: 924032
       GoKind: 22
-      Pointee: 79 StructureType crypto/tls.ConnectionState
+      Pointee: 57 StructureType crypto/tls.ConnectionState
     - __kind: PointerType
-      ID: 83
+      ID: 108
       Name: '*crypto/x509.Certificate'
       ByteSize: 8
       GoRuntimeType: 2.089664e+06
       GoKind: 22
-      Pointee: 84 StructureType crypto/x509.Certificate
+      Pointee: 134 StructureType crypto/x509.Certificate
     - __kind: PointerType
-      ID: 114
+      ID: 173
       Name: '*crypto/x509.ExtKeyUsage'
       ByteSize: 8
       GoRuntimeType: 429920
       GoKind: 22
-      Pointee: 115 BaseType crypto/x509.ExtKeyUsage
+      Pointee: 174 BaseType crypto/x509.ExtKeyUsage
     - __kind: PointerType
-      ID: 127
+      ID: 184
       Name: '*crypto/x509.OID'
       ByteSize: 8
       GoRuntimeType: 1.998112e+06
       GoKind: 22
-      Pointee: 128 StructureType crypto/x509.OID
+      Pointee: 185 StructureType crypto/x509.OID
     - __kind: PointerType
-      ID: 130
+      ID: 187
       Name: '*crypto/x509.PolicyMapping'
       ByteSize: 8
       GoRuntimeType: 429984
       GoKind: 22
-      Pointee: 131 StructureType crypto/x509.PolicyMapping
+      Pointee: 188 StructureType crypto/x509.PolicyMapping
     - __kind: PointerType
-      ID: 95
+      ID: 160
       Name: '*crypto/x509/pkix.AttributeTypeAndValue'
       ByteSize: 8
       GoRuntimeType: 446624
       GoKind: 22
-      Pointee: 96 StructureType crypto/x509/pkix.AttributeTypeAndValue
+      Pointee: 161 StructureType crypto/x509/pkix.AttributeTypeAndValue
     - __kind: PointerType
-      ID: 109
+      ID: 167
       Name: '*crypto/x509/pkix.Extension'
       ByteSize: 8
       GoRuntimeType: 446816
       GoKind: 22
-      Pointee: 110 StructureType crypto/x509/pkix.Extension
+      Pointee: 168 StructureType crypto/x509/pkix.Extension
     - __kind: PointerType
-      ID: 112
+      ID: 170
       Name: '*encoding/asn1.ObjectIdentifier'
       ByteSize: 8
       GoRuntimeType: 1.079776e+06
       GoKind: 22
-      Pointee: 97 GoSliceHeaderType encoding/asn1.ObjectIdentifier
+      Pointee: 171 GoSliceHeaderType encoding/asn1.ObjectIdentifier
     - __kind: PointerType
-      ID: 247
+      ID: 267
       Name: '*encoding/asn1.ObjectIdentifier.array'
       ByteSize: 8
-      Pointee: 246 GoSliceDataType encoding/asn1.ObjectIdentifier.array
+      Pointee: 266 GoSliceDataType encoding/asn1.ObjectIdentifier.array
     - __kind: PointerType
       ID: 33
       Name: '*error'
@@ -383,61 +383,61 @@ Types:
       GoKind: 22
       Pointee: 15 BaseType float64
     - __kind: PointerType
-      ID: 158
+      ID: 39
       Name: '*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span'
       ByteSize: 8
       GoRuntimeType: 2.33264e+06
       GoKind: 22
-      Pointee: 159 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span
+      Pointee: 40 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span
     - __kind: PointerType
-      ID: 216
+      ID: 91
       Name: '*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanContext'
       ByteSize: 8
       GoRuntimeType: 2.054336e+06
       GoKind: 22
-      Pointee: 217 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanContext
+      Pointee: 92 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanContext
     - __kind: PointerType
-      ID: 189
+      ID: 86
       Name: '*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink'
       ByteSize: 8
       GoRuntimeType: 1.21456e+06
       GoKind: 22
-      Pointee: 190 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink
+      Pointee: 87 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink
     - __kind: PointerType
-      ID: 192
+      ID: 89
       Name: '*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent'
       ByteSize: 8
       GoRuntimeType: 1.214688e+06
       GoKind: 22
-      Pointee: 193 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent
+      Pointee: 90 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent
     - __kind: PointerType
-      ID: 208
+      ID: 220
       Name: '*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttribute'
       ByteSize: 8
       GoRuntimeType: 1.215328e+06
       GoKind: 22
-      Pointee: 209 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttribute
+      Pointee: 221 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttribute
     - __kind: PointerType
-      ID: 212
+      ID: 225
       Name: '*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttributeValue'
       ByteSize: 8
       GoRuntimeType: 1.215072e+06
       GoKind: 22
-      Pointee: 213 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttributeValue
+      Pointee: 226 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttributeValue
     - __kind: PointerType
-      ID: 205
+      ID: 215
       Name: '*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute'
       ByteSize: 8
       GoRuntimeType: 1.215456e+06
       GoKind: 22
-      Pointee: 206 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
+      Pointee: 216 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
     - __kind: PointerType
-      ID: 218
+      ID: 127
       Name: '*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.trace'
       ByteSize: 8
       GoRuntimeType: 2.277568e+06
       GoKind: 22
-      Pointee: 219 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.trace
+      Pointee: 128 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.trace
     - __kind: PointerType
       ID: 26
       Name: '*int'
@@ -474,92 +474,92 @@ Types:
       GoKind: 22
       Pointee: 16 BaseType int8
     - __kind: PointerType
-      ID: 195
+      ID: 122
       Name: '*map<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>'
       ByteSize: 8
-      Pointee: 196 GoSwissMapHeaderType map<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
+      Pointee: 123 GoSwissMapHeaderType map<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
     - __kind: PointerType
-      ID: 62
+      ID: 101
       Name: '*map<string,[]*mime/multipart.FileHeader>'
       ByteSize: 8
-      Pointee: 63 GoSwissMapHeaderType map<string,[]*mime/multipart.FileHeader>
+      Pointee: 102 GoSwissMapHeaderType map<string,[]*mime/multipart.FileHeader>
     - __kind: PointerType
-      ID: 44
+      ID: 46
       Name: '*map<string,[]string>'
       ByteSize: 8
-      Pointee: 45 GoSwissMapHeaderType map<string,[]string>
+      Pointee: 47 GoSwissMapHeaderType map<string,[]string>
     - __kind: PointerType
-      ID: 178
+      ID: 81
       Name: '*map<string,float64>'
       ByteSize: 8
-      Pointee: 179 GoSwissMapHeaderType map<string,float64>
+      Pointee: 82 GoSwissMapHeaderType map<string,float64>
     - __kind: PointerType
-      ID: 167
+      ID: 76
       Name: '*map<string,interface {}>'
       ByteSize: 8
-      Pointee: 168 GoSwissMapHeaderType map<string,interface {}>
+      Pointee: 77 GoSwissMapHeaderType map<string,interface {}>
     - __kind: PointerType
-      ID: 148
+      ID: 65
       Name: '*map<string,string>'
       ByteSize: 8
-      Pointee: 149 GoSwissMapHeaderType map<string,string>
+      Pointee: 66 GoSwissMapHeaderType map<string,string>
     - __kind: PointerType
-      ID: 88
+      ID: 156
       Name: '*math/big.Int'
       ByteSize: 8
       GoRuntimeType: 2.447424e+06
       GoKind: 22
-      Pointee: 89 StructureType math/big.Int
+      Pointee: 157 StructureType math/big.Int
     - __kind: PointerType
-      ID: 91
+      ID: 204
       Name: '*math/big.Word'
       ByteSize: 8
       GoRuntimeType: 432800
       GoKind: 22
-      Pointee: 92 BaseType math/big.Word
+      Pointee: 205 BaseType math/big.Word
     - __kind: PointerType
-      ID: 243
+      ID: 285
       Name: '*math/big.nat.array'
       ByteSize: 8
-      Pointee: 242 GoSliceDataType math/big.nat.array
+      Pointee: 284 GoSliceDataType math/big.nat.array
     - __kind: PointerType
-      ID: 74
+      ID: 202
       Name: '*mime/multipart.FileHeader'
       ByteSize: 8
       GoRuntimeType: 925568
       GoKind: 22
-      Pointee: 75 StructureType mime/multipart.FileHeader
+      Pointee: 217 StructureType mime/multipart.FileHeader
     - __kind: PointerType
-      ID: 58
+      ID: 54
       Name: '*mime/multipart.Form'
       ByteSize: 8
       GoRuntimeType: 925664
       GoKind: 22
-      Pointee: 59 StructureType mime/multipart.Form
+      Pointee: 55 StructureType mime/multipart.Form
     - __kind: PointerType
-      ID: 117
+      ID: 176
       Name: '*net.IP'
       ByteSize: 8
       GoRuntimeType: 2.206912e+06
       GoKind: 22
-      Pointee: 118 GoSliceHeaderType net.IP
+      Pointee: 177 GoSliceHeaderType net.IP
     - __kind: PointerType
-      ID: 261
+      ID: 273
       Name: '*net.IP.array'
       ByteSize: 8
-      Pointee: 260 GoSliceDataType net.IP.array
+      Pointee: 272 GoSliceDataType net.IP.array
     - __kind: PointerType
-      ID: 267
+      ID: 291
       Name: '*net.IPMask.array'
       ByteSize: 8
-      Pointee: 266 GoSliceDataType net.IPMask.array
+      Pointee: 290 GoSliceDataType net.IPMask.array
     - __kind: PointerType
-      ID: 123
+      ID: 182
       Name: '*net.IPNet'
       ByteSize: 8
       GoRuntimeType: 1.208416e+06
       GoKind: 22
-      Pointee: 124 StructureType net.IPNet
+      Pointee: 212 StructureType net.IPNet
     - __kind: PointerType
       ID: 37
       Name: '*net/http.Request'
@@ -568,70 +568,70 @@ Types:
       GoKind: 22
       Pointee: 38 StructureType net/http.Request
     - __kind: PointerType
-      ID: 139
+      ID: 59
       Name: '*net/http.Response'
       ByteSize: 8
       GoRuntimeType: 1.7584e+06
       GoKind: 22
-      Pointee: 140 StructureType net/http.Response
+      Pointee: 60 StructureType net/http.Response
     - __kind: PointerType
-      ID: 142
+      ID: 62
       Name: '*net/http.pattern'
       ByteSize: 8
       GoRuntimeType: 1.642688e+06
       GoKind: 22
-      Pointee: 143 StructureType net/http.pattern
+      Pointee: 63 StructureType net/http.pattern
     - __kind: PointerType
-      ID: 145
+      ID: 116
       Name: '*net/http.segment'
       ByteSize: 8
       GoRuntimeType: 396384
       GoKind: 22
-      Pointee: 146 StructureType net/http.segment
+      Pointee: 117 StructureType net/http.segment
     - __kind: PointerType
-      ID: 39
+      ID: 43
       Name: '*net/url.URL'
       ByteSize: 8
       GoRuntimeType: 2.167328e+06
       GoKind: 22
-      Pointee: 40 StructureType net/url.URL
+      Pointee: 44 StructureType net/url.URL
     - __kind: PointerType
-      ID: 41
+      ID: 96
       Name: '*net/url.Userinfo'
       ByteSize: 8
       GoRuntimeType: 1.22608e+06
       GoKind: 22
-      Pointee: 42 StructureType net/url.Userinfo
+      Pointee: 97 StructureType net/url.Userinfo
     - __kind: PointerType
-      ID: 201
+      ID: 196
       Name: '*noalg.map.group[string]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute'
       ByteSize: 8
-      Pointee: 202 StructureType noalg.map.group[string]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
+      Pointee: 197 StructureType noalg.map.group[string]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
     - __kind: PointerType
-      ID: 68
+      ID: 151
       Name: '*noalg.map.group[string][]*mime/multipart.FileHeader'
       ByteSize: 8
-      Pointee: 69 StructureType noalg.map.group[string][]*mime/multipart.FileHeader
+      Pointee: 152 StructureType noalg.map.group[string][]*mime/multipart.FileHeader
     - __kind: PointerType
-      ID: 50
+      ID: 131
       Name: '*noalg.map.group[string][]string'
       ByteSize: 8
-      Pointee: 51 StructureType noalg.map.group[string][]string
+      Pointee: 132 StructureType noalg.map.group[string][]string
     - __kind: PointerType
-      ID: 184
+      ID: 142
       Name: '*noalg.map.group[string]float64'
       ByteSize: 8
-      Pointee: 185 StructureType noalg.map.group[string]float64
+      Pointee: 143 StructureType noalg.map.group[string]float64
     - __kind: PointerType
-      ID: 173
+      ID: 139
       Name: '*noalg.map.group[string]interface {}'
       ByteSize: 8
-      Pointee: 174 StructureType noalg.map.group[string]interface {}
+      Pointee: 140 StructureType noalg.map.group[string]interface {}
     - __kind: PointerType
-      ID: 154
+      ID: 136
       Name: '*noalg.map.group[string]string'
       ByteSize: 8
-      Pointee: 155 StructureType noalg.map.group[string]string
+      Pointee: 137 StructureType noalg.map.group[string]string
     - __kind: PointerType
       ID: 22
       Name: '*string'
@@ -645,56 +645,56 @@ Types:
       ByteSize: 8
       Pointee: 228 GoStringDataType string.str
     - __kind: PointerType
-      ID: 198
+      ID: 125
       Name: '*table<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>'
       ByteSize: 8
-      Pointee: 199 StructureType table<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
+      Pointee: 144 StructureType table<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
     - __kind: PointerType
-      ID: 65
+      ID: 104
       Name: '*table<string,[]*mime/multipart.FileHeader>'
       ByteSize: 8
-      Pointee: 66 StructureType table<string,[]*mime/multipart.FileHeader>
+      Pointee: 133 StructureType table<string,[]*mime/multipart.FileHeader>
     - __kind: PointerType
-      ID: 47
+      ID: 49
       Name: '*table<string,[]string>'
       ByteSize: 8
-      Pointee: 48 StructureType table<string,[]string>
+      Pointee: 98 StructureType table<string,[]string>
     - __kind: PointerType
-      ID: 181
+      ID: 84
       Name: '*table<string,float64>'
       ByteSize: 8
-      Pointee: 182 StructureType table<string,float64>
+      Pointee: 120 StructureType table<string,float64>
     - __kind: PointerType
-      ID: 170
+      ID: 79
       Name: '*table<string,interface {}>'
       ByteSize: 8
-      Pointee: 171 StructureType table<string,interface {}>
+      Pointee: 119 StructureType table<string,interface {}>
     - __kind: PointerType
-      ID: 151
+      ID: 68
       Name: '*table<string,string>'
       ByteSize: 8
-      Pointee: 152 StructureType table<string,string>
+      Pointee: 118 StructureType table<string,string>
     - __kind: PointerType
-      ID: 99
+      ID: 163
       Name: '*time.Location'
       ByteSize: 8
       GoRuntimeType: 1.64768e+06
       GoKind: 22
-      Pointee: 100 StructureType time.Location
+      Pointee: 164 StructureType time.Location
     - __kind: PointerType
-      ID: 102
+      ID: 207
       Name: '*time.zone'
       ByteSize: 8
       GoRuntimeType: 399456
       GoKind: 22
-      Pointee: 103 StructureType time.zone
+      Pointee: 208 StructureType time.zone
     - __kind: PointerType
-      ID: 105
+      ID: 210
       Name: '*time.zoneTrans'
       ByteSize: 8
       GoRuntimeType: 399520
       GoKind: 22
-      Pointee: 106 StructureType time.zoneTrans
+      Pointee: 211 StructureType time.zoneTrans
     - __kind: PointerType
       ID: 34
       Name: '*uint'
@@ -738,7 +738,7 @@ Types:
       GoKind: 22
       Pointee: 1 BaseType uintptr
     - __kind: GoChannelType
-      ID: 138
+      ID: 58
       Name: <-chan struct {}
       GoRuntimeType: 607264
       GoKind: 18
@@ -782,7 +782,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: GoSliceHeaderType
-      ID: 81
+      ID: 106
       Name: '[]*crypto/x509.Certificate'
       ByteSize: 24
       GoRuntimeType: 507488
@@ -790,21 +790,21 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 82 PointerType **crypto/x509.Certificate
+          Type: 107 PointerType **crypto/x509.Certificate
         - Name: len
           Offset: 8
           Type: 7 BaseType int
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 240 GoSliceDataType []*crypto/x509.Certificate.array
+      Data: 248 GoSliceDataType []*crypto/x509.Certificate.array
     - __kind: GoSliceDataType
-      ID: 240
+      ID: 248
       Name: '[]*crypto/x509.Certificate.array'
       ByteSize: 2048
-      Element: 83 PointerType *crypto/x509.Certificate
+      Element: 108 PointerType *crypto/x509.Certificate
     - __kind: GoSliceHeaderType
-      ID: 220
+      ID: 145
       Name: '[]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span'
       ByteSize: 24
       GoRuntimeType: 495232
@@ -812,21 +812,21 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 221 PointerType **github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span
+          Type: 146 PointerType **github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span
         - Name: len
           Offset: 8
           Type: 7 BaseType int
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 292 GoSliceDataType []*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span.array
+      Data: 258 GoSliceDataType []*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span.array
     - __kind: GoSliceDataType
-      ID: 292
+      ID: 258
       Name: '[]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span.array'
       ByteSize: 2048
-      Element: 158 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span
+      Element: 39 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span
     - __kind: GoSliceHeaderType
-      ID: 210
+      ID: 223
       Name: '[]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttributeValue'
       ByteSize: 24
       GoRuntimeType: 494848
@@ -834,21 +834,21 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 211 PointerType **github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttributeValue
+          Type: 224 PointerType **github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttributeValue
         - Name: len
           Offset: 8
           Type: 7 BaseType int
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 290 GoSliceDataType []*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttributeValue.array
+      Data: 292 GoSliceDataType []*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttributeValue.array
     - __kind: GoSliceDataType
-      ID: 290
+      ID: 292
       Name: '[]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttributeValue.array'
       ByteSize: 2048
-      Element: 212 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttributeValue
+      Element: 225 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttributeValue
     - __kind: GoSliceHeaderType
-      ID: 72
+      ID: 200
       Name: '[]*mime/multipart.FileHeader'
       ByteSize: 24
       GoRuntimeType: 492224
@@ -856,21 +856,21 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 73 PointerType **mime/multipart.FileHeader
+          Type: 201 PointerType **mime/multipart.FileHeader
         - Name: len
           Offset: 8
           Type: 7 BaseType int
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 236 GoSliceDataType []*mime/multipart.FileHeader.array
+      Data: 282 GoSliceDataType []*mime/multipart.FileHeader.array
     - __kind: GoSliceDataType
-      ID: 236
+      ID: 282
       Name: '[]*mime/multipart.FileHeader.array'
       ByteSize: 2048
-      Element: 74 PointerType *mime/multipart.FileHeader
+      Element: 202 PointerType *mime/multipart.FileHeader
     - __kind: GoSliceHeaderType
-      ID: 121
+      ID: 180
       Name: '[]*net.IPNet'
       ByteSize: 24
       GoRuntimeType: 509088
@@ -878,21 +878,21 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 122 PointerType **net.IPNet
+          Type: 181 PointerType **net.IPNet
         - Name: len
           Offset: 8
           Type: 7 BaseType int
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 264 GoSliceDataType []*net.IPNet.array
+      Data: 276 GoSliceDataType []*net.IPNet.array
     - __kind: GoSliceDataType
-      ID: 264
+      ID: 276
       Name: '[]*net.IPNet.array'
       ByteSize: 2048
-      Element: 123 PointerType *net.IPNet
+      Element: 182 PointerType *net.IPNet
     - __kind: GoSliceHeaderType
-      ID: 119
+      ID: 178
       Name: '[]*net/url.URL'
       ByteSize: 24
       GoRuntimeType: 509024
@@ -900,51 +900,51 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 120 PointerType **net/url.URL
+          Type: 179 PointerType **net/url.URL
         - Name: len
           Offset: 8
           Type: 7 BaseType int
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 262 GoSliceDataType []*net/url.URL.array
+      Data: 274 GoSliceDataType []*net/url.URL.array
     - __kind: GoSliceDataType
-      ID: 262
+      ID: 274
       Name: '[]*net/url.URL.array'
       ByteSize: 2048
-      Element: 39 PointerType *net/url.URL
+      Element: 43 PointerType *net/url.URL
     - __kind: GoSliceDataType
-      ID: 288
+      ID: 256
       Name: '[]*table<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>.array'
       ByteSize: 8192
-      Element: 198 PointerType *table<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
+      Element: 125 PointerType *table<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
     - __kind: GoSliceDataType
-      ID: 234
+      ID: 246
       Name: '[]*table<string,[]*mime/multipart.FileHeader>.array'
       ByteSize: 8192
-      Element: 65 PointerType *table<string,[]*mime/multipart.FileHeader>
+      Element: 104 PointerType *table<string,[]*mime/multipart.FileHeader>
     - __kind: GoSliceDataType
       ID: 230
       Name: '[]*table<string,[]string>.array'
       ByteSize: 8192
-      Element: 47 PointerType *table<string,[]string>
+      Element: 49 PointerType *table<string,[]string>
     - __kind: GoSliceDataType
-      ID: 282
+      ID: 238
       Name: '[]*table<string,float64>.array'
       ByteSize: 8192
-      Element: 181 PointerType *table<string,float64>
+      Element: 84 PointerType *table<string,float64>
     - __kind: GoSliceDataType
-      ID: 280
+      ID: 236
       Name: '[]*table<string,interface {}>.array'
       ByteSize: 8192
-      Element: 170 PointerType *table<string,interface {}>
+      Element: 79 PointerType *table<string,interface {}>
     - __kind: GoSliceDataType
-      ID: 278
+      ID: 234
       Name: '[]*table<string,string>.array'
       ByteSize: 8192
-      Element: 151 PointerType *table<string,string>
+      Element: 68 PointerType *table<string,string>
     - __kind: GoSliceHeaderType
-      ID: 132
+      ID: 109
       Name: '[][]*crypto/x509.Certificate'
       ByteSize: 24
       GoRuntimeType: 507552
@@ -952,21 +952,21 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 133 PointerType *[]*crypto/x509.Certificate
+          Type: 110 PointerType *[]*crypto/x509.Certificate
         - Name: len
           Offset: 8
           Type: 7 BaseType int
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 272 GoSliceDataType [][]*crypto/x509.Certificate.array
+      Data: 250 GoSliceDataType [][]*crypto/x509.Certificate.array
     - __kind: GoSliceDataType
-      ID: 272
+      ID: 250
       Name: '[][]*crypto/x509.Certificate.array'
       ByteSize: 2048
-      Element: 81 GoSliceHeaderType []*crypto/x509.Certificate
+      Element: 106 GoSliceHeaderType []*crypto/x509.Certificate
     - __kind: GoSliceHeaderType
-      ID: 134
+      ID: 111
       Name: '[][]uint8'
       ByteSize: 24
       GoRuntimeType: 486880
@@ -974,21 +974,21 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 135 PointerType *[]uint8
+          Type: 112 PointerType *[]uint8
         - Name: len
           Offset: 8
           Type: 7 BaseType int
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 274 GoSliceDataType [][]uint8.array
+      Data: 252 GoSliceDataType [][]uint8.array
     - __kind: GoSliceDataType
-      ID: 274
+      ID: 252
       Name: '[][]uint8.array'
       ByteSize: 2048
-      Element: 77 GoSliceHeaderType []uint8
+      Element: 94 GoSliceHeaderType []uint8
     - __kind: GoSliceHeaderType
-      ID: 113
+      ID: 172
       Name: '[]crypto/x509.ExtKeyUsage'
       ByteSize: 24
       GoRuntimeType: 508960
@@ -996,21 +996,21 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 114 PointerType *crypto/x509.ExtKeyUsage
+          Type: 173 PointerType *crypto/x509.ExtKeyUsage
         - Name: len
           Offset: 8
           Type: 7 BaseType int
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 256 GoSliceDataType []crypto/x509.ExtKeyUsage.array
+      Data: 268 GoSliceDataType []crypto/x509.ExtKeyUsage.array
     - __kind: GoSliceDataType
-      ID: 256
+      ID: 268
       Name: '[]crypto/x509.ExtKeyUsage.array'
       ByteSize: 2048
-      Element: 115 BaseType crypto/x509.ExtKeyUsage
+      Element: 174 BaseType crypto/x509.ExtKeyUsage
     - __kind: GoSliceHeaderType
-      ID: 126
+      ID: 183
       Name: '[]crypto/x509.OID'
       ByteSize: 24
       GoRuntimeType: 509152
@@ -1018,21 +1018,21 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 127 PointerType *crypto/x509.OID
+          Type: 184 PointerType *crypto/x509.OID
         - Name: len
           Offset: 8
           Type: 7 BaseType int
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 268 GoSliceDataType []crypto/x509.OID.array
+      Data: 278 GoSliceDataType []crypto/x509.OID.array
     - __kind: GoSliceDataType
-      ID: 268
+      ID: 278
       Name: '[]crypto/x509.OID.array'
       ByteSize: 2048
-      Element: 128 StructureType crypto/x509.OID
+      Element: 185 StructureType crypto/x509.OID
     - __kind: GoSliceHeaderType
-      ID: 129
+      ID: 186
       Name: '[]crypto/x509.PolicyMapping'
       ByteSize: 24
       GoRuntimeType: 509216
@@ -1040,21 +1040,21 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 130 PointerType *crypto/x509.PolicyMapping
+          Type: 187 PointerType *crypto/x509.PolicyMapping
         - Name: len
           Offset: 8
           Type: 7 BaseType int
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 270 GoSliceDataType []crypto/x509.PolicyMapping.array
+      Data: 280 GoSliceDataType []crypto/x509.PolicyMapping.array
     - __kind: GoSliceDataType
-      ID: 270
+      ID: 280
       Name: '[]crypto/x509.PolicyMapping.array'
       ByteSize: 2048
-      Element: 131 StructureType crypto/x509.PolicyMapping
+      Element: 188 StructureType crypto/x509.PolicyMapping
     - __kind: GoSliceHeaderType
-      ID: 94
+      ID: 159
       Name: '[]crypto/x509/pkix.AttributeTypeAndValue'
       ByteSize: 24
       GoRuntimeType: 523680
@@ -1062,21 +1062,21 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 95 PointerType *crypto/x509/pkix.AttributeTypeAndValue
+          Type: 160 PointerType *crypto/x509/pkix.AttributeTypeAndValue
         - Name: len
           Offset: 8
           Type: 7 BaseType int
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 244 GoSliceDataType []crypto/x509/pkix.AttributeTypeAndValue.array
+      Data: 260 GoSliceDataType []crypto/x509/pkix.AttributeTypeAndValue.array
     - __kind: GoSliceDataType
-      ID: 244
+      ID: 260
       Name: '[]crypto/x509/pkix.AttributeTypeAndValue.array'
       ByteSize: 2048
-      Element: 96 StructureType crypto/x509/pkix.AttributeTypeAndValue
+      Element: 161 StructureType crypto/x509/pkix.AttributeTypeAndValue
     - __kind: GoSliceHeaderType
-      ID: 108
+      ID: 166
       Name: '[]crypto/x509/pkix.Extension'
       ByteSize: 24
       GoRuntimeType: 508832
@@ -1084,21 +1084,21 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 109 PointerType *crypto/x509/pkix.Extension
+          Type: 167 PointerType *crypto/x509/pkix.Extension
         - Name: len
           Offset: 8
           Type: 7 BaseType int
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 252 GoSliceDataType []crypto/x509/pkix.Extension.array
+      Data: 262 GoSliceDataType []crypto/x509/pkix.Extension.array
     - __kind: GoSliceDataType
-      ID: 252
+      ID: 262
       Name: '[]crypto/x509/pkix.Extension.array'
       ByteSize: 2048
-      Element: 110 StructureType crypto/x509/pkix.Extension
+      Element: 168 StructureType crypto/x509/pkix.Extension
     - __kind: GoSliceHeaderType
-      ID: 111
+      ID: 169
       Name: '[]encoding/asn1.ObjectIdentifier'
       ByteSize: 24
       GoRuntimeType: 508896
@@ -1106,21 +1106,21 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 112 PointerType *encoding/asn1.ObjectIdentifier
+          Type: 170 PointerType *encoding/asn1.ObjectIdentifier
         - Name: len
           Offset: 8
           Type: 7 BaseType int
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 254 GoSliceDataType []encoding/asn1.ObjectIdentifier.array
+      Data: 264 GoSliceDataType []encoding/asn1.ObjectIdentifier.array
     - __kind: GoSliceDataType
-      ID: 254
+      ID: 264
       Name: '[]encoding/asn1.ObjectIdentifier.array'
       ByteSize: 2048
-      Element: 97 GoSliceHeaderType encoding/asn1.ObjectIdentifier
+      Element: 171 GoSliceHeaderType encoding/asn1.ObjectIdentifier
     - __kind: GoSliceHeaderType
-      ID: 188
+      ID: 85
       Name: '[]github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink'
       ByteSize: 24
       GoRuntimeType: 494784
@@ -1128,21 +1128,21 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 189 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink
+          Type: 86 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink
         - Name: len
           Offset: 8
           Type: 7 BaseType int
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 284 GoSliceDataType []github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink.array
+      Data: 240 GoSliceDataType []github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink.array
     - __kind: GoSliceDataType
-      ID: 284
+      ID: 240
       Name: '[]github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink.array'
       ByteSize: 2048
-      Element: 190 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink
+      Element: 87 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink
     - __kind: GoSliceHeaderType
-      ID: 191
+      ID: 88
       Name: '[]github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent'
       ByteSize: 24
       GoRuntimeType: 494976
@@ -1150,21 +1150,21 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 192 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent
+          Type: 89 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent
         - Name: len
           Offset: 8
           Type: 7 BaseType int
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 286 GoSliceDataType []github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent.array
+      Data: 242 GoSliceDataType []github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent.array
     - __kind: GoSliceDataType
-      ID: 286
+      ID: 242
       Name: '[]github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent.array'
       ByteSize: 2048
-      Element: 193 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent
+      Element: 90 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent
     - __kind: GoSliceHeaderType
-      ID: 116
+      ID: 175
       Name: '[]net.IP'
       ByteSize: 24
       GoRuntimeType: 487904
@@ -1172,21 +1172,21 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 117 PointerType *net.IP
+          Type: 176 PointerType *net.IP
         - Name: len
           Offset: 8
           Type: 7 BaseType int
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 258 GoSliceDataType []net.IP.array
+      Data: 270 GoSliceDataType []net.IP.array
     - __kind: GoSliceDataType
-      ID: 258
+      ID: 270
       Name: '[]net.IP.array'
       ByteSize: 2048
-      Element: 118 GoSliceHeaderType net.IP
+      Element: 177 GoSliceHeaderType net.IP
     - __kind: GoSliceHeaderType
-      ID: 144
+      ID: 115
       Name: '[]net/http.segment'
       ByteSize: 24
       GoRuntimeType: 489600
@@ -1194,51 +1194,51 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 145 PointerType *net/http.segment
+          Type: 116 PointerType *net/http.segment
         - Name: len
           Offset: 8
           Type: 7 BaseType int
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 276 GoSliceDataType []net/http.segment.array
+      Data: 254 GoSliceDataType []net/http.segment.array
     - __kind: GoSliceDataType
-      ID: 276
+      ID: 254
       Name: '[]net/http.segment.array'
       ByteSize: 2048
-      Element: 146 StructureType net/http.segment
+      Element: 117 StructureType net/http.segment
     - __kind: GoSliceDataType
-      ID: 289
+      ID: 257
       Name: '[]noalg.map.group[string]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute.array'
       ByteSize: 2048
-      Element: 202 StructureType noalg.map.group[string]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
+      Element: 197 StructureType noalg.map.group[string]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
     - __kind: GoSliceDataType
-      ID: 235
+      ID: 247
       Name: '[]noalg.map.group[string][]*mime/multipart.FileHeader.array'
       ByteSize: 2048
-      Element: 69 StructureType noalg.map.group[string][]*mime/multipart.FileHeader
+      Element: 152 StructureType noalg.map.group[string][]*mime/multipart.FileHeader
     - __kind: GoSliceDataType
       ID: 231
       Name: '[]noalg.map.group[string][]string.array'
       ByteSize: 2048
-      Element: 51 StructureType noalg.map.group[string][]string
+      Element: 132 StructureType noalg.map.group[string][]string
     - __kind: GoSliceDataType
-      ID: 283
+      ID: 239
       Name: '[]noalg.map.group[string]float64.array'
       ByteSize: 2048
-      Element: 185 StructureType noalg.map.group[string]float64
+      Element: 143 StructureType noalg.map.group[string]float64
     - __kind: GoSliceDataType
-      ID: 281
+      ID: 237
       Name: '[]noalg.map.group[string]interface {}.array'
       ByteSize: 2048
-      Element: 174 StructureType noalg.map.group[string]interface {}
+      Element: 140 StructureType noalg.map.group[string]interface {}
     - __kind: GoSliceDataType
-      ID: 279
+      ID: 235
       Name: '[]noalg.map.group[string]string.array'
       ByteSize: 2048
-      Element: 155 StructureType noalg.map.group[string]string
+      Element: 137 StructureType noalg.map.group[string]string
     - __kind: GoSliceHeaderType
-      ID: 54
+      ID: 52
       Name: '[]string'
       ByteSize: 24
       GoRuntimeType: 501440
@@ -1260,7 +1260,7 @@ Types:
       ByteSize: 2048
       Element: 9 GoStringHeaderType string
     - __kind: GoSliceHeaderType
-      ID: 101
+      ID: 206
       Name: '[]time.zone'
       ByteSize: 24
       GoRuntimeType: 494336
@@ -1268,21 +1268,21 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 102 PointerType *time.zone
+          Type: 207 PointerType *time.zone
         - Name: len
           Offset: 8
           Type: 7 BaseType int
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 248 GoSliceDataType []time.zone.array
+      Data: 286 GoSliceDataType []time.zone.array
     - __kind: GoSliceDataType
-      ID: 248
+      ID: 286
       Name: '[]time.zone.array'
       ByteSize: 2048
-      Element: 103 StructureType time.zone
+      Element: 208 StructureType time.zone
     - __kind: GoSliceHeaderType
-      ID: 104
+      ID: 209
       Name: '[]time.zoneTrans'
       ByteSize: 24
       GoRuntimeType: 494400
@@ -1290,21 +1290,21 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 105 PointerType *time.zoneTrans
+          Type: 210 PointerType *time.zoneTrans
         - Name: len
           Offset: 8
           Type: 7 BaseType int
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 250 GoSliceDataType []time.zoneTrans.array
+      Data: 288 GoSliceDataType []time.zoneTrans.array
     - __kind: GoSliceDataType
-      ID: 250
+      ID: 288
       Name: '[]time.zoneTrans.array'
       ByteSize: 2048
-      Element: 106 StructureType time.zoneTrans
+      Element: 211 StructureType time.zoneTrans
     - __kind: GoSliceHeaderType
-      ID: 77
+      ID: 94
       Name: '[]uint8'
       ByteSize: 24
       GoRuntimeType: 500288
@@ -1319,9 +1319,9 @@ Types:
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 238 GoSliceDataType []uint8.array
+      Data: 244 GoSliceDataType []uint8.array
     - __kind: GoSliceDataType
-      ID: 238
+      ID: 244
       Name: '[]uint8.array'
       ByteSize: 2048
       Element: 3 BaseType uint8
@@ -1332,7 +1332,7 @@ Types:
       GoRuntimeType: 595232
       GoKind: 1
     - __kind: StructureType
-      ID: 226
+      ID: 42
       Name: bytes.Buffer
       ByteSize: 40
       GoRuntimeType: 1.640384e+06
@@ -1340,15 +1340,15 @@ Types:
       RawFields:
         - Name: buf
           Offset: 0
-          Type: 77 GoSliceHeaderType []uint8
+          Type: 94 GoSliceHeaderType []uint8
         - Name: off
           Offset: 24
           Type: 7 BaseType int
         - Name: lastRead
           Offset: 32
-          Type: 227 BaseType bytes.readOp
+          Type: 95 BaseType bytes.readOp
     - __kind: BaseType
-      ID: 227
+      ID: 95
       Name: bytes.readOp
       ByteSize: 1
       GoRuntimeType: 593440
@@ -1366,7 +1366,7 @@ Types:
       GoRuntimeType: 594976
       GoKind: 15
     - __kind: GoInterfaceType
-      ID: 141
+      ID: 61
       Name: context.Context
       ByteSize: 16
       GoRuntimeType: 1.3032e+06
@@ -1379,7 +1379,7 @@ Types:
           Offset: 8
           Type: 14 VoidPointerType unsafe.Pointer
     - __kind: StructureType
-      ID: 79
+      ID: 57
       Name: crypto/tls.ConnectionState
       ByteSize: 192
       GoRuntimeType: 2.323424e+06
@@ -1399,7 +1399,7 @@ Types:
           Type: 6 BaseType uint16
         - Name: CurveID
           Offset: 6
-          Type: 80 BaseType crypto/tls.CurveID
+          Type: 105 BaseType crypto/tls.CurveID
         - Name: NegotiatedProtocol
           Offset: 8
           Type: 9 GoStringHeaderType string
@@ -1411,45 +1411,45 @@ Types:
           Type: 9 GoStringHeaderType string
         - Name: PeerCertificates
           Offset: 48
-          Type: 81 GoSliceHeaderType []*crypto/x509.Certificate
+          Type: 106 GoSliceHeaderType []*crypto/x509.Certificate
         - Name: VerifiedChains
           Offset: 72
-          Type: 132 GoSliceHeaderType [][]*crypto/x509.Certificate
+          Type: 109 GoSliceHeaderType [][]*crypto/x509.Certificate
         - Name: SignedCertificateTimestamps
           Offset: 96
-          Type: 134 GoSliceHeaderType [][]uint8
+          Type: 111 GoSliceHeaderType [][]uint8
         - Name: OCSPResponse
           Offset: 120
-          Type: 77 GoSliceHeaderType []uint8
+          Type: 94 GoSliceHeaderType []uint8
         - Name: TLSUnique
           Offset: 144
-          Type: 77 GoSliceHeaderType []uint8
+          Type: 94 GoSliceHeaderType []uint8
         - Name: ECHAccepted
           Offset: 168
           Type: 4 BaseType bool
         - Name: ekm
           Offset: 176
-          Type: 136 GoSubroutineType func(string, []uint8, int) ([]uint8, error)
+          Type: 113 GoSubroutineType func(string, []uint8, int) ([]uint8, error)
         - Name: testingOnlyDidHRR
           Offset: 184
           Type: 4 BaseType bool
         - Name: testingOnlyPeerSignatureAlgorithm
           Offset: 186
-          Type: 137 BaseType crypto/tls.SignatureScheme
+          Type: 114 BaseType crypto/tls.SignatureScheme
     - __kind: BaseType
-      ID: 80
+      ID: 105
       Name: crypto/tls.CurveID
       ByteSize: 2
       GoRuntimeType: 847200
       GoKind: 9
     - __kind: BaseType
-      ID: 137
+      ID: 114
       Name: crypto/tls.SignatureScheme
       ByteSize: 2
       GoRuntimeType: 847296
       GoKind: 9
     - __kind: StructureType
-      ID: 84
+      ID: 134
       Name: crypto/x509.Certificate
       ByteSize: 1424
       GoRuntimeType: 2.458688e+06
@@ -1457,67 +1457,67 @@ Types:
       RawFields:
         - Name: Raw
           Offset: 0
-          Type: 77 GoSliceHeaderType []uint8
+          Type: 94 GoSliceHeaderType []uint8
         - Name: RawTBSCertificate
           Offset: 24
-          Type: 77 GoSliceHeaderType []uint8
+          Type: 94 GoSliceHeaderType []uint8
         - Name: RawSubjectPublicKeyInfo
           Offset: 48
-          Type: 77 GoSliceHeaderType []uint8
+          Type: 94 GoSliceHeaderType []uint8
         - Name: RawSubject
           Offset: 72
-          Type: 77 GoSliceHeaderType []uint8
+          Type: 94 GoSliceHeaderType []uint8
         - Name: RawIssuer
           Offset: 96
-          Type: 77 GoSliceHeaderType []uint8
+          Type: 94 GoSliceHeaderType []uint8
         - Name: Signature
           Offset: 120
-          Type: 77 GoSliceHeaderType []uint8
+          Type: 94 GoSliceHeaderType []uint8
         - Name: SignatureAlgorithm
           Offset: 144
-          Type: 85 BaseType crypto/x509.SignatureAlgorithm
+          Type: 153 BaseType crypto/x509.SignatureAlgorithm
         - Name: PublicKeyAlgorithm
           Offset: 152
-          Type: 86 BaseType crypto/x509.PublicKeyAlgorithm
+          Type: 154 BaseType crypto/x509.PublicKeyAlgorithm
         - Name: PublicKey
           Offset: 160
-          Type: 87 GoEmptyInterfaceType interface {}
+          Type: 155 GoEmptyInterfaceType interface {}
         - Name: Version
           Offset: 176
           Type: 7 BaseType int
         - Name: SerialNumber
           Offset: 184
-          Type: 88 PointerType *math/big.Int
+          Type: 156 PointerType *math/big.Int
         - Name: Issuer
           Offset: 192
-          Type: 93 StructureType crypto/x509/pkix.Name
+          Type: 158 StructureType crypto/x509/pkix.Name
         - Name: Subject
           Offset: 440
-          Type: 93 StructureType crypto/x509/pkix.Name
+          Type: 158 StructureType crypto/x509/pkix.Name
         - Name: NotBefore
           Offset: 688
-          Type: 98 StructureType time.Time
+          Type: 162 StructureType time.Time
         - Name: NotAfter
           Offset: 712
-          Type: 98 StructureType time.Time
+          Type: 162 StructureType time.Time
         - Name: KeyUsage
           Offset: 736
-          Type: 107 BaseType crypto/x509.KeyUsage
+          Type: 165 BaseType crypto/x509.KeyUsage
         - Name: Extensions
           Offset: 744
-          Type: 108 GoSliceHeaderType []crypto/x509/pkix.Extension
+          Type: 166 GoSliceHeaderType []crypto/x509/pkix.Extension
         - Name: ExtraExtensions
           Offset: 768
-          Type: 108 GoSliceHeaderType []crypto/x509/pkix.Extension
+          Type: 166 GoSliceHeaderType []crypto/x509/pkix.Extension
         - Name: UnhandledCriticalExtensions
           Offset: 792
-          Type: 111 GoSliceHeaderType []encoding/asn1.ObjectIdentifier
+          Type: 169 GoSliceHeaderType []encoding/asn1.ObjectIdentifier
         - Name: ExtKeyUsage
           Offset: 816
-          Type: 113 GoSliceHeaderType []crypto/x509.ExtKeyUsage
+          Type: 172 GoSliceHeaderType []crypto/x509.ExtKeyUsage
         - Name: UnknownExtKeyUsage
           Offset: 840
-          Type: 111 GoSliceHeaderType []encoding/asn1.ObjectIdentifier
+          Type: 169 GoSliceHeaderType []encoding/asn1.ObjectIdentifier
         - Name: BasicConstraintsValid
           Offset: 864
           Type: 4 BaseType bool
@@ -1532,64 +1532,64 @@ Types:
           Type: 4 BaseType bool
         - Name: SubjectKeyId
           Offset: 888
-          Type: 77 GoSliceHeaderType []uint8
+          Type: 94 GoSliceHeaderType []uint8
         - Name: AuthorityKeyId
           Offset: 912
-          Type: 77 GoSliceHeaderType []uint8
+          Type: 94 GoSliceHeaderType []uint8
         - Name: OCSPServer
           Offset: 936
-          Type: 54 GoSliceHeaderType []string
+          Type: 52 GoSliceHeaderType []string
         - Name: IssuingCertificateURL
           Offset: 960
-          Type: 54 GoSliceHeaderType []string
+          Type: 52 GoSliceHeaderType []string
         - Name: DNSNames
           Offset: 984
-          Type: 54 GoSliceHeaderType []string
+          Type: 52 GoSliceHeaderType []string
         - Name: EmailAddresses
           Offset: 1008
-          Type: 54 GoSliceHeaderType []string
+          Type: 52 GoSliceHeaderType []string
         - Name: IPAddresses
           Offset: 1032
-          Type: 116 GoSliceHeaderType []net.IP
+          Type: 175 GoSliceHeaderType []net.IP
         - Name: URIs
           Offset: 1056
-          Type: 119 GoSliceHeaderType []*net/url.URL
+          Type: 178 GoSliceHeaderType []*net/url.URL
         - Name: PermittedDNSDomainsCritical
           Offset: 1080
           Type: 4 BaseType bool
         - Name: PermittedDNSDomains
           Offset: 1088
-          Type: 54 GoSliceHeaderType []string
+          Type: 52 GoSliceHeaderType []string
         - Name: ExcludedDNSDomains
           Offset: 1112
-          Type: 54 GoSliceHeaderType []string
+          Type: 52 GoSliceHeaderType []string
         - Name: PermittedIPRanges
           Offset: 1136
-          Type: 121 GoSliceHeaderType []*net.IPNet
+          Type: 180 GoSliceHeaderType []*net.IPNet
         - Name: ExcludedIPRanges
           Offset: 1160
-          Type: 121 GoSliceHeaderType []*net.IPNet
+          Type: 180 GoSliceHeaderType []*net.IPNet
         - Name: PermittedEmailAddresses
           Offset: 1184
-          Type: 54 GoSliceHeaderType []string
+          Type: 52 GoSliceHeaderType []string
         - Name: ExcludedEmailAddresses
           Offset: 1208
-          Type: 54 GoSliceHeaderType []string
+          Type: 52 GoSliceHeaderType []string
         - Name: PermittedURIDomains
           Offset: 1232
-          Type: 54 GoSliceHeaderType []string
+          Type: 52 GoSliceHeaderType []string
         - Name: ExcludedURIDomains
           Offset: 1256
-          Type: 54 GoSliceHeaderType []string
+          Type: 52 GoSliceHeaderType []string
         - Name: CRLDistributionPoints
           Offset: 1280
-          Type: 54 GoSliceHeaderType []string
+          Type: 52 GoSliceHeaderType []string
         - Name: PolicyIdentifiers
           Offset: 1304
-          Type: 111 GoSliceHeaderType []encoding/asn1.ObjectIdentifier
+          Type: 169 GoSliceHeaderType []encoding/asn1.ObjectIdentifier
         - Name: Policies
           Offset: 1328
-          Type: 126 GoSliceHeaderType []crypto/x509.OID
+          Type: 183 GoSliceHeaderType []crypto/x509.OID
         - Name: InhibitAnyPolicy
           Offset: 1352
           Type: 7 BaseType int
@@ -1610,21 +1610,21 @@ Types:
           Type: 4 BaseType bool
         - Name: PolicyMappings
           Offset: 1400
-          Type: 129 GoSliceHeaderType []crypto/x509.PolicyMapping
+          Type: 186 GoSliceHeaderType []crypto/x509.PolicyMapping
     - __kind: BaseType
-      ID: 115
+      ID: 174
       Name: crypto/x509.ExtKeyUsage
       ByteSize: 8
       GoRuntimeType: 598304
       GoKind: 2
     - __kind: BaseType
-      ID: 107
+      ID: 165
       Name: crypto/x509.KeyUsage
       ByteSize: 8
       GoRuntimeType: 598240
       GoKind: 2
     - __kind: StructureType
-      ID: 128
+      ID: 185
       Name: crypto/x509.OID
       ByteSize: 24
       GoRuntimeType: 1.998368e+06
@@ -1632,9 +1632,9 @@ Types:
       RawFields:
         - Name: der
           Offset: 0
-          Type: 77 GoSliceHeaderType []uint8
+          Type: 94 GoSliceHeaderType []uint8
     - __kind: StructureType
-      ID: 131
+      ID: 188
       Name: crypto/x509.PolicyMapping
       ByteSize: 48
       GoRuntimeType: 1.520416e+06
@@ -1642,24 +1642,24 @@ Types:
       RawFields:
         - Name: IssuerDomainPolicy
           Offset: 0
-          Type: 128 StructureType crypto/x509.OID
+          Type: 185 StructureType crypto/x509.OID
         - Name: SubjectDomainPolicy
           Offset: 24
-          Type: 128 StructureType crypto/x509.OID
+          Type: 185 StructureType crypto/x509.OID
     - __kind: BaseType
-      ID: 86
+      ID: 154
       Name: crypto/x509.PublicKeyAlgorithm
       ByteSize: 8
       GoRuntimeType: 849696
       GoKind: 2
     - __kind: BaseType
-      ID: 85
+      ID: 153
       Name: crypto/x509.SignatureAlgorithm
       ByteSize: 8
       GoRuntimeType: 1.139648e+06
       GoKind: 2
     - __kind: StructureType
-      ID: 96
+      ID: 161
       Name: crypto/x509/pkix.AttributeTypeAndValue
       ByteSize: 40
       GoRuntimeType: 1.532736e+06
@@ -1667,12 +1667,12 @@ Types:
       RawFields:
         - Name: Type
           Offset: 0
-          Type: 97 GoSliceHeaderType encoding/asn1.ObjectIdentifier
+          Type: 171 GoSliceHeaderType encoding/asn1.ObjectIdentifier
         - Name: Value
           Offset: 24
-          Type: 87 GoEmptyInterfaceType interface {}
+          Type: 155 GoEmptyInterfaceType interface {}
     - __kind: StructureType
-      ID: 110
+      ID: 168
       Name: crypto/x509/pkix.Extension
       ByteSize: 56
       GoRuntimeType: 1.683776e+06
@@ -1680,15 +1680,15 @@ Types:
       RawFields:
         - Name: Id
           Offset: 0
-          Type: 97 GoSliceHeaderType encoding/asn1.ObjectIdentifier
+          Type: 171 GoSliceHeaderType encoding/asn1.ObjectIdentifier
         - Name: Critical
           Offset: 24
           Type: 4 BaseType bool
         - Name: Value
           Offset: 32
-          Type: 77 GoSliceHeaderType []uint8
+          Type: 94 GoSliceHeaderType []uint8
     - __kind: StructureType
-      ID: 93
+      ID: 158
       Name: crypto/x509/pkix.Name
       ByteSize: 248
       GoRuntimeType: 2.250272e+06
@@ -1696,25 +1696,25 @@ Types:
       RawFields:
         - Name: Country
           Offset: 0
-          Type: 54 GoSliceHeaderType []string
+          Type: 52 GoSliceHeaderType []string
         - Name: Organization
           Offset: 24
-          Type: 54 GoSliceHeaderType []string
+          Type: 52 GoSliceHeaderType []string
         - Name: OrganizationalUnit
           Offset: 48
-          Type: 54 GoSliceHeaderType []string
+          Type: 52 GoSliceHeaderType []string
         - Name: Locality
           Offset: 72
-          Type: 54 GoSliceHeaderType []string
+          Type: 52 GoSliceHeaderType []string
         - Name: Province
           Offset: 96
-          Type: 54 GoSliceHeaderType []string
+          Type: 52 GoSliceHeaderType []string
         - Name: StreetAddress
           Offset: 120
-          Type: 54 GoSliceHeaderType []string
+          Type: 52 GoSliceHeaderType []string
         - Name: PostalCode
           Offset: 144
-          Type: 54 GoSliceHeaderType []string
+          Type: 52 GoSliceHeaderType []string
         - Name: SerialNumber
           Offset: 168
           Type: 9 GoStringHeaderType string
@@ -1723,12 +1723,12 @@ Types:
           Type: 9 GoStringHeaderType string
         - Name: Names
           Offset: 200
-          Type: 94 GoSliceHeaderType []crypto/x509/pkix.AttributeTypeAndValue
+          Type: 159 GoSliceHeaderType []crypto/x509/pkix.AttributeTypeAndValue
         - Name: ExtraNames
           Offset: 224
-          Type: 94 GoSliceHeaderType []crypto/x509/pkix.AttributeTypeAndValue
+          Type: 159 GoSliceHeaderType []crypto/x509/pkix.AttributeTypeAndValue
     - __kind: GoSliceHeaderType
-      ID: 97
+      ID: 171
       Name: encoding/asn1.ObjectIdentifier
       ByteSize: 24
       GoRuntimeType: 1.079904e+06
@@ -1743,9 +1743,9 @@ Types:
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 246 GoSliceDataType encoding/asn1.ObjectIdentifier.array
+      Data: 266 GoSliceDataType encoding/asn1.ObjectIdentifier.array
     - __kind: GoSliceDataType
-      ID: 246
+      ID: 266
       Name: encoding/asn1.ObjectIdentifier.array
       ByteSize: 2048
       Element: 7 BaseType int
@@ -1775,25 +1775,25 @@ Types:
       GoRuntimeType: 595168
       GoKind: 14
     - __kind: GoSubroutineType
-      ID: 224
+      ID: 93
       Name: func()
       ByteSize: 8
       GoRuntimeType: 484960
       GoKind: 19
     - __kind: GoSubroutineType
-      ID: 56
+      ID: 51
       Name: func() (io.ReadCloser, error)
       ByteSize: 8
       GoRuntimeType: 705088
       GoKind: 19
     - __kind: GoSubroutineType
-      ID: 136
+      ID: 113
       Name: func(string, []uint8, int) ([]uint8, error)
       ByteSize: 8
       GoRuntimeType: 1.025152e+06
       GoKind: 19
     - __kind: StructureType
-      ID: 159
+      ID: 40
       Name: github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span
       ByteSize: 288
       GoRuntimeType: 2.3976e+06
@@ -1801,7 +1801,7 @@ Types:
       RawFields:
         - Name: mu
           Offset: 0
-          Type: 160 StructureType sync.RWMutex
+          Type: 69 StructureType sync.RWMutex
         - Name: name
           Offset: 24
           Type: 9 GoStringHeaderType string
@@ -1822,13 +1822,13 @@ Types:
           Type: 12 BaseType int64
         - Name: meta
           Offset: 104
-          Type: 147 GoMapType map[string]string
+          Type: 64 GoMapType map[string]string
         - Name: metaStruct
           Offset: 112
-          Type: 166 GoMapType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.metaStructMap
+          Type: 75 GoMapType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.metaStructMap
         - Name: metrics
           Offset: 120
-          Type: 177 GoMapType map[string]float64
+          Type: 80 GoMapType map[string]float64
         - Name: spanID
           Offset: 128
           Type: 8 BaseType uint64
@@ -1843,10 +1843,10 @@ Types:
           Type: 10 BaseType int32
         - Name: spanLinks
           Offset: 160
-          Type: 188 GoSliceHeaderType []github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink
+          Type: 85 GoSliceHeaderType []github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink
         - Name: spanEvents
           Offset: 184
-          Type: 191 GoSliceHeaderType []github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent
+          Type: 88 GoSliceHeaderType []github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent
         - Name: goExecTraced
           Offset: 208
           Type: 4 BaseType bool
@@ -1858,7 +1858,7 @@ Types:
           Type: 4 BaseType bool
         - Name: context
           Offset: 216
-          Type: 216 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanContext
+          Type: 91 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanContext
         - Name: integration
           Offset: 224
           Type: 9 GoStringHeaderType string
@@ -1867,15 +1867,15 @@ Types:
           Type: 4 BaseType bool
         - Name: pprofCtxActive
           Offset: 248
-          Type: 141 GoInterfaceType context.Context
+          Type: 61 GoInterfaceType context.Context
         - Name: pprofCtxRestore
           Offset: 264
-          Type: 141 GoInterfaceType context.Context
+          Type: 61 GoInterfaceType context.Context
         - Name: taskEnd
           Offset: 280
-          Type: 224 GoSubroutineType func()
+          Type: 93 GoSubroutineType func()
     - __kind: StructureType
-      ID: 217
+      ID: 92
       Name: github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanContext
       ByteSize: 168
       GoRuntimeType: 2.269952e+06
@@ -1886,13 +1886,13 @@ Types:
           Type: 4 BaseType bool
         - Name: trace
           Offset: 8
-          Type: 218 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.trace
+          Type: 127 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.trace
         - Name: span
           Offset: 16
-          Type: 158 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span
+          Type: 39 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span
         - Name: errors
           Offset: 24
-          Type: 164 StructureType sync/atomic.Int32
+          Type: 73 StructureType sync/atomic.Int32
         - Name: reparentID
           Offset: 32
           Type: 9 GoStringHeaderType string
@@ -1901,16 +1901,16 @@ Types:
           Type: 4 BaseType bool
         - Name: traceID
           Offset: 49
-          Type: 223 ArrayType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.traceID
+          Type: 129 ArrayType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.traceID
         - Name: spanID
           Offset: 72
           Type: 8 BaseType uint64
         - Name: mu
           Offset: 80
-          Type: 160 StructureType sync.RWMutex
+          Type: 69 StructureType sync.RWMutex
         - Name: baggage
           Offset: 104
-          Type: 147 GoMapType map[string]string
+          Type: 64 GoMapType map[string]string
         - Name: hasBaggage
           Offset: 112
           Type: 2 BaseType uint32
@@ -1919,12 +1919,12 @@ Types:
           Type: 9 GoStringHeaderType string
         - Name: spanLinks
           Offset: 136
-          Type: 188 GoSliceHeaderType []github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink
+          Type: 85 GoSliceHeaderType []github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink
         - Name: baggageOnly
           Offset: 160
           Type: 4 BaseType bool
     - __kind: StructureType
-      ID: 190
+      ID: 87
       Name: github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink
       ByteSize: 56
       GoRuntimeType: 1.955616e+06
@@ -1941,7 +1941,7 @@ Types:
           Type: 8 BaseType uint64
         - Name: Attributes
           Offset: 24
-          Type: 147 GoMapType map[string]string
+          Type: 64 GoMapType map[string]string
         - Name: Tracestate
           Offset: 32
           Type: 9 GoStringHeaderType string
@@ -1949,20 +1949,20 @@ Types:
           Offset: 48
           Type: 2 BaseType uint32
     - __kind: GoMapType
-      ID: 166
+      ID: 75
       Name: github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.metaStructMap
       ByteSize: 8
       GoRuntimeType: 1.30448e+06
       GoKind: 21
-      HeaderType: 168 GoSwissMapHeaderType map<string,interface {}>
+      HeaderType: 77 GoSwissMapHeaderType map<string,interface {}>
     - __kind: BaseType
-      ID: 222
+      ID: 147
       Name: github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.samplingDecision
       ByteSize: 4
       GoRuntimeType: 594016
       GoKind: 10
     - __kind: StructureType
-      ID: 193
+      ID: 90
       Name: github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent
       ByteSize: 40
       GoRuntimeType: 1.789664e+06
@@ -1976,12 +1976,12 @@ Types:
           Type: 8 BaseType uint64
         - Name: Attributes
           Offset: 24
-          Type: 194 GoMapType map[string]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
+          Type: 121 GoMapType map[string]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
         - Name: RawAttributes
           Offset: 32
-          Type: 215 GoMapType map[string]interface {}
+          Type: 126 GoMapType map[string]interface {}
     - __kind: StructureType
-      ID: 209
+      ID: 221
       Name: github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttribute
       ByteSize: 24
       GoRuntimeType: 1.2152e+06
@@ -1989,9 +1989,9 @@ Types:
       RawFields:
         - Name: Values
           Offset: 0
-          Type: 210 GoSliceHeaderType []*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttributeValue
+          Type: 223 GoSliceHeaderType []*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttributeValue
     - __kind: StructureType
-      ID: 213
+      ID: 226
       Name: github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttributeValue
       ByteSize: 48
       GoRuntimeType: 1.878752e+06
@@ -1999,7 +1999,7 @@ Types:
       RawFields:
         - Name: Type
           Offset: 0
-          Type: 214 BaseType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttributeValueType
+          Type: 227 BaseType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttributeValueType
         - Name: StringValue
           Offset: 8
           Type: 9 GoStringHeaderType string
@@ -2013,13 +2013,13 @@ Types:
           Offset: 40
           Type: 15 BaseType float64
     - __kind: BaseType
-      ID: 214
+      ID: 227
       Name: github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttributeValueType
       ByteSize: 4
       GoRuntimeType: 1.006816e+06
       GoKind: 5
     - __kind: StructureType
-      ID: 206
+      ID: 216
       Name: github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
       ByteSize: 56
       GoRuntimeType: 1.955872e+06
@@ -2027,7 +2027,7 @@ Types:
       RawFields:
         - Name: Type
           Offset: 0
-          Type: 207 BaseType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttributeType
+          Type: 219 BaseType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttributeType
         - Name: StringValue
           Offset: 8
           Type: 9 GoStringHeaderType string
@@ -2042,15 +2042,15 @@ Types:
           Type: 15 BaseType float64
         - Name: ArrayValue
           Offset: 48
-          Type: 208 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttribute
+          Type: 220 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttribute
     - __kind: BaseType
-      ID: 207
+      ID: 219
       Name: github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttributeType
       ByteSize: 4
       GoRuntimeType: 1.00672e+06
       GoKind: 5
     - __kind: StructureType
-      ID: 219
+      ID: 128
       Name: github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.trace
       ByteSize: 104
       GoRuntimeType: 2.155744e+06
@@ -2058,16 +2058,16 @@ Types:
       RawFields:
         - Name: mu
           Offset: 0
-          Type: 160 StructureType sync.RWMutex
+          Type: 69 StructureType sync.RWMutex
         - Name: spans
           Offset: 24
-          Type: 220 GoSliceHeaderType []*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span
+          Type: 145 GoSliceHeaderType []*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span
         - Name: tags
           Offset: 48
-          Type: 147 GoMapType map[string]string
+          Type: 64 GoMapType map[string]string
         - Name: propagatingTags
           Offset: 56
-          Type: 147 GoMapType map[string]string
+          Type: 64 GoMapType map[string]string
         - Name: finished
           Offset: 64
           Type: 7 BaseType int
@@ -2082,12 +2082,12 @@ Types:
           Type: 4 BaseType bool
         - Name: samplingDecision
           Offset: 92
-          Type: 222 BaseType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.samplingDecision
+          Type: 147 BaseType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.samplingDecision
         - Name: root
           Offset: 96
-          Type: 158 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span
+          Type: 39 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span
     - __kind: ArrayType
-      ID: 223
+      ID: 129
       Name: github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.traceID
       ByteSize: 16
       GoRuntimeType: 919232
@@ -2096,89 +2096,89 @@ Types:
       HasCount: true
       Element: 3 BaseType uint8
     - __kind: GoSwissMapGroupsType
-      ID: 200
+      ID: 195
       Name: groupReference<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 201 PointerType *noalg.map.group[string]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
+          Type: 196 PointerType *noalg.map.group[string]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
         - Name: lengthMask
           Offset: 8
           Type: 8 BaseType uint64
-      GroupType: 202 StructureType noalg.map.group[string]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
-      GroupSliceType: 289 GoSliceDataType []noalg.map.group[string]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute.array
+      GroupType: 197 StructureType noalg.map.group[string]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
+      GroupSliceType: 257 GoSliceDataType []noalg.map.group[string]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute.array
     - __kind: GoSwissMapGroupsType
-      ID: 67
+      ID: 150
       Name: groupReference<string,[]*mime/multipart.FileHeader>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 68 PointerType *noalg.map.group[string][]*mime/multipart.FileHeader
+          Type: 151 PointerType *noalg.map.group[string][]*mime/multipart.FileHeader
         - Name: lengthMask
           Offset: 8
           Type: 8 BaseType uint64
-      GroupType: 69 StructureType noalg.map.group[string][]*mime/multipart.FileHeader
-      GroupSliceType: 235 GoSliceDataType []noalg.map.group[string][]*mime/multipart.FileHeader.array
+      GroupType: 152 StructureType noalg.map.group[string][]*mime/multipart.FileHeader
+      GroupSliceType: 247 GoSliceDataType []noalg.map.group[string][]*mime/multipart.FileHeader.array
     - __kind: GoSwissMapGroupsType
-      ID: 49
+      ID: 130
       Name: groupReference<string,[]string>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 50 PointerType *noalg.map.group[string][]string
+          Type: 131 PointerType *noalg.map.group[string][]string
         - Name: lengthMask
           Offset: 8
           Type: 8 BaseType uint64
-      GroupType: 51 StructureType noalg.map.group[string][]string
+      GroupType: 132 StructureType noalg.map.group[string][]string
       GroupSliceType: 231 GoSliceDataType []noalg.map.group[string][]string.array
     - __kind: GoSwissMapGroupsType
-      ID: 183
+      ID: 141
       Name: groupReference<string,float64>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 184 PointerType *noalg.map.group[string]float64
+          Type: 142 PointerType *noalg.map.group[string]float64
         - Name: lengthMask
           Offset: 8
           Type: 8 BaseType uint64
-      GroupType: 185 StructureType noalg.map.group[string]float64
-      GroupSliceType: 283 GoSliceDataType []noalg.map.group[string]float64.array
+      GroupType: 143 StructureType noalg.map.group[string]float64
+      GroupSliceType: 239 GoSliceDataType []noalg.map.group[string]float64.array
     - __kind: GoSwissMapGroupsType
-      ID: 172
+      ID: 138
       Name: groupReference<string,interface {}>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 173 PointerType *noalg.map.group[string]interface {}
+          Type: 139 PointerType *noalg.map.group[string]interface {}
         - Name: lengthMask
           Offset: 8
           Type: 8 BaseType uint64
-      GroupType: 174 StructureType noalg.map.group[string]interface {}
-      GroupSliceType: 281 GoSliceDataType []noalg.map.group[string]interface {}.array
+      GroupType: 140 StructureType noalg.map.group[string]interface {}
+      GroupSliceType: 237 GoSliceDataType []noalg.map.group[string]interface {}.array
     - __kind: GoSwissMapGroupsType
-      ID: 153
+      ID: 135
       Name: groupReference<string,string>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 154 PointerType *noalg.map.group[string]string
+          Type: 136 PointerType *noalg.map.group[string]string
         - Name: lengthMask
           Offset: 8
           Type: 8 BaseType uint64
-      GroupType: 155 StructureType noalg.map.group[string]string
-      GroupSliceType: 279 GoSliceDataType []noalg.map.group[string]string.array
+      GroupType: 137 StructureType noalg.map.group[string]string
+      GroupSliceType: 235 GoSliceDataType []noalg.map.group[string]string.array
     - __kind: BaseType
       ID: 7
       Name: int
@@ -2210,7 +2210,7 @@ Types:
       GoRuntimeType: 594272
       GoKind: 3
     - __kind: GoEmptyInterfaceType
-      ID: 87
+      ID: 155
       Name: interface {}
       ByteSize: 16
       GoRuntimeType: 867104
@@ -2223,7 +2223,7 @@ Types:
           Offset: 8
           Type: 14 VoidPointerType unsafe.Pointer
     - __kind: StructureType
-      ID: 163
+      ID: 72
       Name: internal/sync.Mutex
       ByteSize: 8
       GoRuntimeType: 1.518176e+06
@@ -2236,7 +2236,7 @@ Types:
           Offset: 4
           Type: 2 BaseType uint32
     - __kind: GoInterfaceType
-      ID: 55
+      ID: 50
       Name: io.ReadCloser
       ByteSize: 16
       GoRuntimeType: 1.135168e+06
@@ -2249,7 +2249,7 @@ Types:
           Offset: 8
           Type: 14 VoidPointerType unsafe.Pointer
     - __kind: GoSwissMapHeaderType
-      ID: 196
+      ID: 123
       Name: map<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
       ByteSize: 48
       GoKind: 25
@@ -2262,7 +2262,7 @@ Types:
           Type: 1 BaseType uintptr
         - Name: dirPtr
           Offset: 16
-          Type: 197 PointerType **table<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
+          Type: 124 PointerType **table<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
         - Name: dirLen
           Offset: 24
           Type: 7 BaseType int
@@ -2281,10 +2281,10 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 8 BaseType uint64
-      TablePtrSliceType: 288 GoSliceDataType []*table<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>.array
-      GroupType: 202 StructureType noalg.map.group[string]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
+      TablePtrSliceType: 256 GoSliceDataType []*table<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>.array
+      GroupType: 197 StructureType noalg.map.group[string]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
     - __kind: GoSwissMapHeaderType
-      ID: 63
+      ID: 102
       Name: map<string,[]*mime/multipart.FileHeader>
       ByteSize: 48
       GoKind: 25
@@ -2297,7 +2297,7 @@ Types:
           Type: 1 BaseType uintptr
         - Name: dirPtr
           Offset: 16
-          Type: 64 PointerType **table<string,[]*mime/multipart.FileHeader>
+          Type: 103 PointerType **table<string,[]*mime/multipart.FileHeader>
         - Name: dirLen
           Offset: 24
           Type: 7 BaseType int
@@ -2316,10 +2316,10 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 8 BaseType uint64
-      TablePtrSliceType: 234 GoSliceDataType []*table<string,[]*mime/multipart.FileHeader>.array
-      GroupType: 69 StructureType noalg.map.group[string][]*mime/multipart.FileHeader
+      TablePtrSliceType: 246 GoSliceDataType []*table<string,[]*mime/multipart.FileHeader>.array
+      GroupType: 152 StructureType noalg.map.group[string][]*mime/multipart.FileHeader
     - __kind: GoSwissMapHeaderType
-      ID: 45
+      ID: 47
       Name: map<string,[]string>
       ByteSize: 48
       GoKind: 25
@@ -2332,7 +2332,7 @@ Types:
           Type: 1 BaseType uintptr
         - Name: dirPtr
           Offset: 16
-          Type: 46 PointerType **table<string,[]string>
+          Type: 48 PointerType **table<string,[]string>
         - Name: dirLen
           Offset: 24
           Type: 7 BaseType int
@@ -2352,9 +2352,9 @@ Types:
           Offset: 40
           Type: 8 BaseType uint64
       TablePtrSliceType: 230 GoSliceDataType []*table<string,[]string>.array
-      GroupType: 51 StructureType noalg.map.group[string][]string
+      GroupType: 132 StructureType noalg.map.group[string][]string
     - __kind: GoSwissMapHeaderType
-      ID: 179
+      ID: 82
       Name: map<string,float64>
       ByteSize: 48
       GoKind: 25
@@ -2367,7 +2367,7 @@ Types:
           Type: 1 BaseType uintptr
         - Name: dirPtr
           Offset: 16
-          Type: 180 PointerType **table<string,float64>
+          Type: 83 PointerType **table<string,float64>
         - Name: dirLen
           Offset: 24
           Type: 7 BaseType int
@@ -2386,10 +2386,10 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 8 BaseType uint64
-      TablePtrSliceType: 282 GoSliceDataType []*table<string,float64>.array
-      GroupType: 185 StructureType noalg.map.group[string]float64
+      TablePtrSliceType: 238 GoSliceDataType []*table<string,float64>.array
+      GroupType: 143 StructureType noalg.map.group[string]float64
     - __kind: GoSwissMapHeaderType
-      ID: 168
+      ID: 77
       Name: map<string,interface {}>
       ByteSize: 48
       GoKind: 25
@@ -2402,7 +2402,7 @@ Types:
           Type: 1 BaseType uintptr
         - Name: dirPtr
           Offset: 16
-          Type: 169 PointerType **table<string,interface {}>
+          Type: 78 PointerType **table<string,interface {}>
         - Name: dirLen
           Offset: 24
           Type: 7 BaseType int
@@ -2421,10 +2421,10 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 8 BaseType uint64
-      TablePtrSliceType: 280 GoSliceDataType []*table<string,interface {}>.array
-      GroupType: 174 StructureType noalg.map.group[string]interface {}
+      TablePtrSliceType: 236 GoSliceDataType []*table<string,interface {}>.array
+      GroupType: 140 StructureType noalg.map.group[string]interface {}
     - __kind: GoSwissMapHeaderType
-      ID: 149
+      ID: 66
       Name: map<string,string>
       ByteSize: 48
       GoKind: 25
@@ -2437,7 +2437,7 @@ Types:
           Type: 1 BaseType uintptr
         - Name: dirPtr
           Offset: 16
-          Type: 150 PointerType **table<string,string>
+          Type: 67 PointerType **table<string,string>
         - Name: dirLen
           Offset: 24
           Type: 7 BaseType int
@@ -2456,52 +2456,52 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 8 BaseType uint64
-      TablePtrSliceType: 278 GoSliceDataType []*table<string,string>.array
-      GroupType: 155 StructureType noalg.map.group[string]string
+      TablePtrSliceType: 234 GoSliceDataType []*table<string,string>.array
+      GroupType: 137 StructureType noalg.map.group[string]string
     - __kind: GoMapType
-      ID: 194
+      ID: 121
       Name: map[string]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
       ByteSize: 8
       GoRuntimeType: 1.158336e+06
       GoKind: 21
-      HeaderType: 196 GoSwissMapHeaderType map<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
+      HeaderType: 123 GoSwissMapHeaderType map<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
     - __kind: GoMapType
-      ID: 61
+      ID: 100
       Name: map[string][]*mime/multipart.FileHeader
       ByteSize: 8
       GoRuntimeType: 1.157568e+06
       GoKind: 21
-      HeaderType: 63 GoSwissMapHeaderType map<string,[]*mime/multipart.FileHeader>
+      HeaderType: 102 GoSwissMapHeaderType map<string,[]*mime/multipart.FileHeader>
     - __kind: GoMapType
-      ID: 60
+      ID: 99
       Name: map[string][]string
       ByteSize: 8
       GoRuntimeType: 1.153216e+06
       GoKind: 21
-      HeaderType: 45 GoSwissMapHeaderType map<string,[]string>
+      HeaderType: 47 GoSwissMapHeaderType map<string,[]string>
     - __kind: GoMapType
-      ID: 177
+      ID: 80
       Name: map[string]float64
       ByteSize: 8
       GoRuntimeType: 1.158208e+06
       GoKind: 21
-      HeaderType: 179 GoSwissMapHeaderType map<string,float64>
+      HeaderType: 82 GoSwissMapHeaderType map<string,float64>
     - __kind: GoMapType
-      ID: 215
+      ID: 126
       Name: map[string]interface {}
       ByteSize: 8
       GoRuntimeType: 1.151808e+06
       GoKind: 21
-      HeaderType: 168 GoSwissMapHeaderType map<string,interface {}>
+      HeaderType: 77 GoSwissMapHeaderType map<string,interface {}>
     - __kind: GoMapType
-      ID: 147
+      ID: 64
       Name: map[string]string
       ByteSize: 8
       GoRuntimeType: 1.15424e+06
       GoKind: 21
-      HeaderType: 149 GoSwissMapHeaderType map<string,string>
+      HeaderType: 66 GoSwissMapHeaderType map<string,string>
     - __kind: StructureType
-      ID: 89
+      ID: 157
       Name: math/big.Int
       ByteSize: 32
       GoRuntimeType: 1.523456e+06
@@ -2512,15 +2512,15 @@ Types:
           Type: 4 BaseType bool
         - Name: abs
           Offset: 8
-          Type: 90 GoSliceHeaderType math/big.nat
+          Type: 203 GoSliceHeaderType math/big.nat
     - __kind: BaseType
-      ID: 92
+      ID: 205
       Name: math/big.Word
       ByteSize: 8
       GoRuntimeType: 598496
       GoKind: 7
     - __kind: GoSliceHeaderType
-      ID: 90
+      ID: 203
       Name: math/big.nat
       ByteSize: 24
       GoRuntimeType: 2.426912e+06
@@ -2528,21 +2528,21 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 91 PointerType *math/big.Word
+          Type: 204 PointerType *math/big.Word
         - Name: len
           Offset: 8
           Type: 7 BaseType int
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 242 GoSliceDataType math/big.nat.array
+      Data: 284 GoSliceDataType math/big.nat.array
     - __kind: GoSliceDataType
-      ID: 242
+      ID: 284
       Name: math/big.nat.array
       ByteSize: 2048
-      Element: 92 BaseType math/big.Word
+      Element: 205 BaseType math/big.Word
     - __kind: StructureType
-      ID: 75
+      ID: 217
       Name: mime/multipart.FileHeader
       ByteSize: 88
       GoRuntimeType: 2.018784e+06
@@ -2553,13 +2553,13 @@ Types:
           Type: 9 GoStringHeaderType string
         - Name: Header
           Offset: 16
-          Type: 76 GoMapType net/textproto.MIMEHeader
+          Type: 222 GoMapType net/textproto.MIMEHeader
         - Name: Size
           Offset: 24
           Type: 12 BaseType int64
         - Name: content
           Offset: 32
-          Type: 77 GoSliceHeaderType []uint8
+          Type: 94 GoSliceHeaderType []uint8
         - Name: tmpfile
           Offset: 56
           Type: 9 GoStringHeaderType string
@@ -2570,7 +2570,7 @@ Types:
           Offset: 80
           Type: 4 BaseType bool
     - __kind: StructureType
-      ID: 59
+      ID: 55
       Name: mime/multipart.Form
       ByteSize: 16
       GoRuntimeType: 1.506656e+06
@@ -2578,12 +2578,12 @@ Types:
       RawFields:
         - Name: Value
           Offset: 0
-          Type: 60 GoMapType map[string][]string
+          Type: 99 GoMapType map[string][]string
         - Name: File
           Offset: 8
-          Type: 61 GoMapType map[string][]*mime/multipart.FileHeader
+          Type: 100 GoMapType map[string][]*mime/multipart.FileHeader
     - __kind: GoSliceHeaderType
-      ID: 118
+      ID: 177
       Name: net.IP
       ByteSize: 24
       GoRuntimeType: 2.178944e+06
@@ -2598,14 +2598,14 @@ Types:
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 260 GoSliceDataType net.IP.array
+      Data: 272 GoSliceDataType net.IP.array
     - __kind: GoSliceDataType
-      ID: 260
+      ID: 272
       Name: net.IP.array
       ByteSize: 2048
       Element: 3 BaseType uint8
     - __kind: GoSliceHeaderType
-      ID: 125
+      ID: 218
       Name: net.IPMask
       ByteSize: 24
       GoRuntimeType: 1.042272e+06
@@ -2620,14 +2620,14 @@ Types:
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 266 GoSliceDataType net.IPMask.array
+      Data: 290 GoSliceDataType net.IPMask.array
     - __kind: GoSliceDataType
-      ID: 266
+      ID: 290
       Name: net.IPMask.array
       ByteSize: 2048
       Element: 3 BaseType uint8
     - __kind: StructureType
-      ID: 124
+      ID: 212
       Name: net.IPNet
       ByteSize: 48
       GoRuntimeType: 1.486976e+06
@@ -2635,17 +2635,17 @@ Types:
       RawFields:
         - Name: IP
           Offset: 0
-          Type: 118 GoSliceHeaderType net.IP
+          Type: 177 GoSliceHeaderType net.IP
         - Name: Mask
           Offset: 24
-          Type: 125 GoSliceHeaderType net.IPMask
+          Type: 218 GoSliceHeaderType net.IPMask
     - __kind: GoMapType
-      ID: 43
+      ID: 45
       Name: net/http.Header
       ByteSize: 8
       GoRuntimeType: 2.15504e+06
       GoKind: 21
-      HeaderType: 45 GoSwissMapHeaderType map<string,[]string>
+      HeaderType: 47 GoSwissMapHeaderType map<string,[]string>
     - __kind: StructureType
       ID: 38
       Name: net/http.Request
@@ -2658,7 +2658,7 @@ Types:
           Type: 9 GoStringHeaderType string
         - Name: URL
           Offset: 16
-          Type: 39 PointerType *net/url.URL
+          Type: 43 PointerType *net/url.URL
         - Name: Proto
           Offset: 24
           Type: 9 GoStringHeaderType string
@@ -2670,19 +2670,19 @@ Types:
           Type: 7 BaseType int
         - Name: Header
           Offset: 56
-          Type: 43 GoMapType net/http.Header
+          Type: 45 GoMapType net/http.Header
         - Name: Body
           Offset: 64
-          Type: 55 GoInterfaceType io.ReadCloser
+          Type: 50 GoInterfaceType io.ReadCloser
         - Name: GetBody
           Offset: 80
-          Type: 56 GoSubroutineType func() (io.ReadCloser, error)
+          Type: 51 GoSubroutineType func() (io.ReadCloser, error)
         - Name: ContentLength
           Offset: 88
           Type: 12 BaseType int64
         - Name: TransferEncoding
           Offset: 96
-          Type: 54 GoSliceHeaderType []string
+          Type: 52 GoSliceHeaderType []string
         - Name: Close
           Offset: 120
           Type: 4 BaseType bool
@@ -2691,16 +2691,16 @@ Types:
           Type: 9 GoStringHeaderType string
         - Name: Form
           Offset: 144
-          Type: 57 GoMapType net/url.Values
+          Type: 53 GoMapType net/url.Values
         - Name: PostForm
           Offset: 152
-          Type: 57 GoMapType net/url.Values
+          Type: 53 GoMapType net/url.Values
         - Name: MultipartForm
           Offset: 160
-          Type: 58 PointerType *mime/multipart.Form
+          Type: 54 PointerType *mime/multipart.Form
         - Name: Trailer
           Offset: 168
-          Type: 43 GoMapType net/http.Header
+          Type: 45 GoMapType net/http.Header
         - Name: RemoteAddr
           Offset: 176
           Type: 9 GoStringHeaderType string
@@ -2709,30 +2709,30 @@ Types:
           Type: 9 GoStringHeaderType string
         - Name: TLS
           Offset: 208
-          Type: 78 PointerType *crypto/tls.ConnectionState
+          Type: 56 PointerType *crypto/tls.ConnectionState
         - Name: Cancel
           Offset: 216
-          Type: 138 GoChannelType <-chan struct {}
+          Type: 58 GoChannelType <-chan struct {}
         - Name: Response
           Offset: 224
-          Type: 139 PointerType *net/http.Response
+          Type: 59 PointerType *net/http.Response
         - Name: Pattern
           Offset: 232
           Type: 9 GoStringHeaderType string
         - Name: ctx
           Offset: 248
-          Type: 141 GoInterfaceType context.Context
+          Type: 61 GoInterfaceType context.Context
         - Name: pat
           Offset: 264
-          Type: 142 PointerType *net/http.pattern
+          Type: 62 PointerType *net/http.pattern
         - Name: matches
           Offset: 272
-          Type: 54 GoSliceHeaderType []string
+          Type: 52 GoSliceHeaderType []string
         - Name: otherValues
           Offset: 296
-          Type: 147 GoMapType map[string]string
+          Type: 64 GoMapType map[string]string
     - __kind: StructureType
-      ID: 140
+      ID: 60
       Name: net/http.Response
       ByteSize: 144
       GoRuntimeType: 2.268608e+06
@@ -2755,16 +2755,16 @@ Types:
           Type: 7 BaseType int
         - Name: Header
           Offset: 56
-          Type: 43 GoMapType net/http.Header
+          Type: 45 GoMapType net/http.Header
         - Name: Body
           Offset: 64
-          Type: 55 GoInterfaceType io.ReadCloser
+          Type: 50 GoInterfaceType io.ReadCloser
         - Name: ContentLength
           Offset: 80
           Type: 12 BaseType int64
         - Name: TransferEncoding
           Offset: 88
-          Type: 54 GoSliceHeaderType []string
+          Type: 52 GoSliceHeaderType []string
         - Name: Close
           Offset: 112
           Type: 4 BaseType bool
@@ -2773,13 +2773,13 @@ Types:
           Type: 4 BaseType bool
         - Name: Trailer
           Offset: 120
-          Type: 43 GoMapType net/http.Header
+          Type: 45 GoMapType net/http.Header
         - Name: Request
           Offset: 128
           Type: 37 PointerType *net/http.Request
         - Name: TLS
           Offset: 136
-          Type: 78 PointerType *crypto/tls.ConnectionState
+          Type: 56 PointerType *crypto/tls.ConnectionState
     - __kind: GoInterfaceType
       ID: 36
       Name: net/http.ResponseWriter
@@ -2794,7 +2794,7 @@ Types:
           Offset: 8
           Type: 14 VoidPointerType unsafe.Pointer
     - __kind: StructureType
-      ID: 143
+      ID: 63
       Name: net/http.pattern
       ByteSize: 88
       GoRuntimeType: 1.875616e+06
@@ -2811,12 +2811,12 @@ Types:
           Type: 9 GoStringHeaderType string
         - Name: segments
           Offset: 48
-          Type: 144 GoSliceHeaderType []net/http.segment
+          Type: 115 GoSliceHeaderType []net/http.segment
         - Name: loc
           Offset: 72
           Type: 9 GoStringHeaderType string
     - __kind: StructureType
-      ID: 146
+      ID: 117
       Name: net/http.segment
       ByteSize: 24
       GoRuntimeType: 1.642496e+06
@@ -2832,14 +2832,14 @@ Types:
           Offset: 17
           Type: 4 BaseType bool
     - __kind: GoMapType
-      ID: 76
+      ID: 222
       Name: net/textproto.MIMEHeader
       ByteSize: 8
       GoRuntimeType: 1.86368e+06
       GoKind: 21
-      HeaderType: 45 GoSwissMapHeaderType map<string,[]string>
+      HeaderType: 47 GoSwissMapHeaderType map<string,[]string>
     - __kind: StructureType
-      ID: 40
+      ID: 44
       Name: net/url.URL
       ByteSize: 144
       GoRuntimeType: 2.181632e+06
@@ -2853,7 +2853,7 @@ Types:
           Type: 9 GoStringHeaderType string
         - Name: User
           Offset: 32
-          Type: 41 PointerType *net/url.Userinfo
+          Type: 96 PointerType *net/url.Userinfo
         - Name: Host
           Offset: 40
           Type: 9 GoStringHeaderType string
@@ -2879,7 +2879,7 @@ Types:
           Offset: 128
           Type: 9 GoStringHeaderType string
     - __kind: StructureType
-      ID: 42
+      ID: 97
       Name: net/url.Userinfo
       ByteSize: 40
       GoRuntimeType: 1.658624e+06
@@ -2895,68 +2895,68 @@ Types:
           Offset: 32
           Type: 4 BaseType bool
     - __kind: GoMapType
-      ID: 57
+      ID: 53
       Name: net/url.Values
       ByteSize: 8
       GoRuntimeType: 1.92848e+06
       GoKind: 21
-      HeaderType: 45 GoSwissMapHeaderType map<string,[]string>
+      HeaderType: 47 GoSwissMapHeaderType map<string,[]string>
     - __kind: ArrayType
-      ID: 203
+      ID: 213
       Name: noalg.[8]struct { key string; elem *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute }
       ByteSize: 192
       GoRuntimeType: 715328
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 204 StructureType noalg.struct { key string; elem *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute }
+      Element: 214 StructureType noalg.struct { key string; elem *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute }
     - __kind: ArrayType
-      ID: 70
+      ID: 198
       Name: noalg.[8]struct { key string; elem []*mime/multipart.FileHeader }
       ByteSize: 320
       GoRuntimeType: 710944
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 71 StructureType noalg.struct { key string; elem []*mime/multipart.FileHeader }
+      Element: 199 StructureType noalg.struct { key string; elem []*mime/multipart.FileHeader }
     - __kind: ArrayType
-      ID: 52
+      ID: 148
       Name: noalg.[8]struct { key string; elem []string }
       ByteSize: 320
       GoRuntimeType: 701120
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 53 StructureType noalg.struct { key string; elem []string }
+      Element: 149 StructureType noalg.struct { key string; elem []string }
     - __kind: ArrayType
-      ID: 186
+      ID: 193
       Name: noalg.[8]struct { key string; elem float64 }
       ByteSize: 192
       GoRuntimeType: 715232
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 187 StructureType noalg.struct { key string; elem float64 }
+      Element: 194 StructureType noalg.struct { key string; elem float64 }
     - __kind: ArrayType
-      ID: 175
+      ID: 191
       Name: noalg.[8]struct { key string; elem interface {} }
       ByteSize: 256
       GoRuntimeType: 692576
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 176 StructureType noalg.struct { key string; elem interface {} }
+      Element: 192 StructureType noalg.struct { key string; elem interface {} }
     - __kind: ArrayType
-      ID: 156
+      ID: 189
       Name: noalg.[8]struct { key string; elem string }
       ByteSize: 256
       GoRuntimeType: 705280
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 157 StructureType noalg.struct { key string; elem string }
+      Element: 190 StructureType noalg.struct { key string; elem string }
     - __kind: StructureType
-      ID: 202
+      ID: 197
       Name: noalg.map.group[string]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
       ByteSize: 200
       GoRuntimeType: 1.332e+06
@@ -2967,9 +2967,9 @@ Types:
           Type: 8 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 203 ArrayType noalg.[8]struct { key string; elem *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute }
+          Type: 213 ArrayType noalg.[8]struct { key string; elem *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute }
     - __kind: StructureType
-      ID: 69
+      ID: 152
       Name: noalg.map.group[string][]*mime/multipart.FileHeader
       ByteSize: 328
       GoRuntimeType: 1.325728e+06
@@ -2980,9 +2980,9 @@ Types:
           Type: 8 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 70 ArrayType noalg.[8]struct { key string; elem []*mime/multipart.FileHeader }
+          Type: 198 ArrayType noalg.[8]struct { key string; elem []*mime/multipart.FileHeader }
     - __kind: StructureType
-      ID: 51
+      ID: 132
       Name: noalg.map.group[string][]string
       ByteSize: 328
       GoRuntimeType: 1.31664e+06
@@ -2993,9 +2993,9 @@ Types:
           Type: 8 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 52 ArrayType noalg.[8]struct { key string; elem []string }
+          Type: 148 ArrayType noalg.[8]struct { key string; elem []string }
     - __kind: StructureType
-      ID: 185
+      ID: 143
       Name: noalg.map.group[string]float64
       ByteSize: 200
       GoRuntimeType: 1.331744e+06
@@ -3006,9 +3006,9 @@ Types:
           Type: 8 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 186 ArrayType noalg.[8]struct { key string; elem float64 }
+          Type: 193 ArrayType noalg.[8]struct { key string; elem float64 }
     - __kind: StructureType
-      ID: 174
+      ID: 140
       Name: noalg.map.group[string]interface {}
       ByteSize: 264
       GoRuntimeType: 1.31408e+06
@@ -3019,9 +3019,9 @@ Types:
           Type: 8 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 175 ArrayType noalg.[8]struct { key string; elem interface {} }
+          Type: 191 ArrayType noalg.[8]struct { key string; elem interface {} }
     - __kind: StructureType
-      ID: 155
+      ID: 137
       Name: noalg.map.group[string]string
       ByteSize: 264
       GoRuntimeType: 1.319072e+06
@@ -3032,9 +3032,9 @@ Types:
           Type: 8 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 156 ArrayType noalg.[8]struct { key string; elem string }
+          Type: 189 ArrayType noalg.[8]struct { key string; elem string }
     - __kind: StructureType
-      ID: 204
+      ID: 214
       Name: noalg.struct { key string; elem *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute }
       ByteSize: 24
       GoRuntimeType: 1.331872e+06
@@ -3045,9 +3045,9 @@ Types:
           Type: 9 GoStringHeaderType string
         - Name: elem
           Offset: 16
-          Type: 205 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
+          Type: 215 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
     - __kind: StructureType
-      ID: 71
+      ID: 199
       Name: noalg.struct { key string; elem []*mime/multipart.FileHeader }
       ByteSize: 40
       GoRuntimeType: 1.3256e+06
@@ -3058,9 +3058,9 @@ Types:
           Type: 9 GoStringHeaderType string
         - Name: elem
           Offset: 16
-          Type: 72 GoSliceHeaderType []*mime/multipart.FileHeader
+          Type: 200 GoSliceHeaderType []*mime/multipart.FileHeader
     - __kind: StructureType
-      ID: 53
+      ID: 149
       Name: noalg.struct { key string; elem []string }
       ByteSize: 40
       GoRuntimeType: 1.316512e+06
@@ -3071,9 +3071,9 @@ Types:
           Type: 9 GoStringHeaderType string
         - Name: elem
           Offset: 16
-          Type: 54 GoSliceHeaderType []string
+          Type: 52 GoSliceHeaderType []string
     - __kind: StructureType
-      ID: 187
+      ID: 194
       Name: noalg.struct { key string; elem float64 }
       ByteSize: 24
       GoRuntimeType: 1.331616e+06
@@ -3086,7 +3086,7 @@ Types:
           Offset: 16
           Type: 15 BaseType float64
     - __kind: StructureType
-      ID: 176
+      ID: 192
       Name: noalg.struct { key string; elem interface {} }
       ByteSize: 32
       GoRuntimeType: 1.313952e+06
@@ -3097,9 +3097,9 @@ Types:
           Type: 9 GoStringHeaderType string
         - Name: elem
           Offset: 16
-          Type: 87 GoEmptyInterfaceType interface {}
+          Type: 155 GoEmptyInterfaceType interface {}
     - __kind: StructureType
-      ID: 157
+      ID: 190
       Name: noalg.struct { key string; elem string }
       ByteSize: 32
       GoRuntimeType: 1.318944e+06
@@ -3130,7 +3130,7 @@ Types:
       Name: string.str
       ByteSize: 2048
     - __kind: StructureType
-      ID: 161
+      ID: 70
       Name: sync.Mutex
       ByteSize: 8
       GoRuntimeType: 1.494336e+06
@@ -3138,12 +3138,12 @@ Types:
       RawFields:
         - Name: _
           Offset: 0
-          Type: 162 StructureType sync.noCopy
+          Type: 71 StructureType sync.noCopy
         - Name: mu
           Offset: 0
-          Type: 163 StructureType internal/sync.Mutex
+          Type: 72 StructureType internal/sync.Mutex
     - __kind: StructureType
-      ID: 160
+      ID: 69
       Name: sync.RWMutex
       ByteSize: 24
       GoRuntimeType: 1.88144e+06
@@ -3151,7 +3151,7 @@ Types:
       RawFields:
         - Name: w
           Offset: 0
-          Type: 161 StructureType sync.Mutex
+          Type: 70 StructureType sync.Mutex
         - Name: writerSem
           Offset: 8
           Type: 2 BaseType uint32
@@ -3160,18 +3160,18 @@ Types:
           Type: 2 BaseType uint32
         - Name: readerCount
           Offset: 16
-          Type: 164 StructureType sync/atomic.Int32
+          Type: 73 StructureType sync/atomic.Int32
         - Name: readerWait
           Offset: 20
-          Type: 164 StructureType sync/atomic.Int32
+          Type: 73 StructureType sync/atomic.Int32
     - __kind: StructureType
-      ID: 162
+      ID: 71
       Name: sync.noCopy
       GoRuntimeType: 1.007392e+06
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 164
+      ID: 73
       Name: sync/atomic.Int32
       ByteSize: 4
       GoRuntimeType: 1.495616e+06
@@ -3179,18 +3179,18 @@ Types:
       RawFields:
         - Name: _
           Offset: 0
-          Type: 165 StructureType sync/atomic.noCopy
+          Type: 74 StructureType sync/atomic.noCopy
         - Name: v
           Offset: 0
           Type: 10 BaseType int32
     - __kind: StructureType
-      ID: 165
+      ID: 74
       Name: sync/atomic.noCopy
       GoRuntimeType: 1.007488e+06
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 199
+      ID: 144
       Name: table<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
       ByteSize: 32
       GoKind: 25
@@ -3212,9 +3212,9 @@ Types:
           Type: 7 BaseType int
         - Name: groups
           Offset: 16
-          Type: 200 GoSwissMapGroupsType groupReference<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
+          Type: 195 GoSwissMapGroupsType groupReference<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
     - __kind: StructureType
-      ID: 66
+      ID: 133
       Name: table<string,[]*mime/multipart.FileHeader>
       ByteSize: 32
       GoKind: 25
@@ -3236,9 +3236,9 @@ Types:
           Type: 7 BaseType int
         - Name: groups
           Offset: 16
-          Type: 67 GoSwissMapGroupsType groupReference<string,[]*mime/multipart.FileHeader>
+          Type: 150 GoSwissMapGroupsType groupReference<string,[]*mime/multipart.FileHeader>
     - __kind: StructureType
-      ID: 48
+      ID: 98
       Name: table<string,[]string>
       ByteSize: 32
       GoKind: 25
@@ -3260,9 +3260,9 @@ Types:
           Type: 7 BaseType int
         - Name: groups
           Offset: 16
-          Type: 49 GoSwissMapGroupsType groupReference<string,[]string>
+          Type: 130 GoSwissMapGroupsType groupReference<string,[]string>
     - __kind: StructureType
-      ID: 182
+      ID: 120
       Name: table<string,float64>
       ByteSize: 32
       GoKind: 25
@@ -3284,9 +3284,9 @@ Types:
           Type: 7 BaseType int
         - Name: groups
           Offset: 16
-          Type: 183 GoSwissMapGroupsType groupReference<string,float64>
+          Type: 141 GoSwissMapGroupsType groupReference<string,float64>
     - __kind: StructureType
-      ID: 171
+      ID: 119
       Name: table<string,interface {}>
       ByteSize: 32
       GoKind: 25
@@ -3308,9 +3308,9 @@ Types:
           Type: 7 BaseType int
         - Name: groups
           Offset: 16
-          Type: 172 GoSwissMapGroupsType groupReference<string,interface {}>
+          Type: 138 GoSwissMapGroupsType groupReference<string,interface {}>
     - __kind: StructureType
-      ID: 152
+      ID: 118
       Name: table<string,string>
       ByteSize: 32
       GoKind: 25
@@ -3332,9 +3332,9 @@ Types:
           Type: 7 BaseType int
         - Name: groups
           Offset: 16
-          Type: 153 GoSwissMapGroupsType groupReference<string,string>
+          Type: 135 GoSwissMapGroupsType groupReference<string,string>
     - __kind: StructureType
-      ID: 100
+      ID: 164
       Name: time.Location
       ByteSize: 104
       GoRuntimeType: 2.014752e+06
@@ -3345,10 +3345,10 @@ Types:
           Type: 9 GoStringHeaderType string
         - Name: zone
           Offset: 16
-          Type: 101 GoSliceHeaderType []time.zone
+          Type: 206 GoSliceHeaderType []time.zone
         - Name: tx
           Offset: 40
-          Type: 104 GoSliceHeaderType []time.zoneTrans
+          Type: 209 GoSliceHeaderType []time.zoneTrans
         - Name: extend
           Offset: 64
           Type: 9 GoStringHeaderType string
@@ -3360,9 +3360,9 @@ Types:
           Type: 12 BaseType int64
         - Name: cacheZone
           Offset: 96
-          Type: 102 PointerType *time.zone
+          Type: 207 PointerType *time.zone
     - __kind: StructureType
-      ID: 98
+      ID: 162
       Name: time.Time
       ByteSize: 24
       GoRuntimeType: 2.42976e+06
@@ -3376,9 +3376,9 @@ Types:
           Type: 12 BaseType int64
         - Name: loc
           Offset: 16
-          Type: 99 PointerType *time.Location
+          Type: 163 PointerType *time.Location
     - __kind: StructureType
-      ID: 103
+      ID: 208
       Name: time.zone
       ByteSize: 32
       GoRuntimeType: 1.647488e+06
@@ -3394,7 +3394,7 @@ Types:
           Offset: 24
           Type: 4 BaseType bool
     - __kind: StructureType
-      ID: 106
+      ID: 211
       Name: time.zoneTrans
       ByteSize: 16
       GoRuntimeType: 1.789472e+06

--- a/pkg/dyninst/irgen/testdata/snapshot/rc_tester.arch=amd64,toolchain=go1.25.0.yaml
+++ b/pkg/dyninst/irgen/testdata/snapshot/rc_tester.arch=amd64,toolchain=go1.25.0.yaml
@@ -97,435 +97,438 @@ Subprograms:
           IsParameter: true
           IsReturn: false
 Types:
-    - __kind: GoInterfaceType
-      ID: 1
-      Name: net/http.ResponseWriter
-      ByteSize: 16
-      GoRuntimeType: 1.210848e+06
-      GoKind: 20
-      RawFields:
-        - Name: tab
-          Offset: 0
-          Type: 2 VoidPointerType unsafe.Pointer
-        - Name: data
-          Offset: 8
-          Type: 2 VoidPointerType unsafe.Pointer
-    - __kind: VoidPointerType
-      ID: 2
-      Name: unsafe.Pointer
-      ByteSize: 8
-      GoRuntimeType: 595296
-      GoKind: 26
     - __kind: PointerType
-      ID: 3
-      Name: '*net/http.Request'
+      ID: 58
+      Name: '**crypto/x509.Certificate'
       ByteSize: 8
-      GoRuntimeType: 2.365504e+06
       GoKind: 22
-      Pointee: 4 StructureType net/http.Request
-    - __kind: StructureType
-      ID: 4
-      Name: net/http.Request
-      ByteSize: 304
-      GoRuntimeType: 2.401888e+06
-      GoKind: 25
-      RawFields:
-        - Name: Method
-          Offset: 0
-          Type: 5 GoStringHeaderType string
-        - Name: URL
-          Offset: 16
-          Type: 9 PointerType *net/url.URL
-        - Name: Proto
-          Offset: 24
-          Type: 5 GoStringHeaderType string
-        - Name: ProtoMajor
-          Offset: 40
-          Type: 8 BaseType int
-        - Name: ProtoMinor
-          Offset: 48
-          Type: 8 BaseType int
-        - Name: Header
-          Offset: 56
-          Type: 14 GoMapType net/http.Header
-        - Name: Body
-          Offset: 64
-          Type: 30 GoInterfaceType io.ReadCloser
-        - Name: GetBody
-          Offset: 80
-          Type: 31 GoSubroutineType func() (io.ReadCloser, error)
-        - Name: ContentLength
-          Offset: 88
-          Type: 32 BaseType int64
-        - Name: TransferEncoding
-          Offset: 96
-          Type: 28 GoSliceHeaderType []string
-        - Name: Close
-          Offset: 120
-          Type: 13 BaseType bool
-        - Name: Host
-          Offset: 128
-          Type: 5 GoStringHeaderType string
-        - Name: Form
-          Offset: 144
-          Type: 33 GoMapType net/url.Values
-        - Name: PostForm
-          Offset: 152
-          Type: 33 GoMapType net/url.Values
-        - Name: MultipartForm
-          Offset: 160
-          Type: 34 PointerType *mime/multipart.Form
-        - Name: Trailer
-          Offset: 168
-          Type: 14 GoMapType net/http.Header
-        - Name: RemoteAddr
-          Offset: 176
-          Type: 5 GoStringHeaderType string
-        - Name: RequestURI
-          Offset: 192
-          Type: 5 GoStringHeaderType string
-        - Name: TLS
-          Offset: 208
-          Type: 54 PointerType *crypto/tls.ConnectionState
-        - Name: Cancel
-          Offset: 216
-          Type: 115 GoChannelType <-chan struct {}
-        - Name: Response
-          Offset: 224
-          Type: 116 PointerType *net/http.Response
-        - Name: Pattern
-          Offset: 232
-          Type: 5 GoStringHeaderType string
-        - Name: ctx
-          Offset: 248
-          Type: 118 GoInterfaceType context.Context
-        - Name: pat
-          Offset: 264
-          Type: 119 PointerType *net/http.pattern
-        - Name: matches
-          Offset: 272
-          Type: 28 GoSliceHeaderType []string
-        - Name: otherValues
-          Offset: 296
-          Type: 124 GoMapType map[string]string
-    - __kind: GoStringHeaderType
-      ID: 5
-      Name: string
-      ByteSize: 16
-      GoRuntimeType: 594208
-      GoKind: 24
-      RawFields:
-        - Name: str
-          Offset: 0
-          Type: 229 PointerType *string.str
-        - Name: len
-          Offset: 8
-          Type: 8 BaseType int
-      Data: 228 GoStringDataType string.str
+      Pointee: 59 PointerType *crypto/x509.Certificate
     - __kind: PointerType
-      ID: 6
-      Name: '*uint8'
+      ID: 201
+      Name: '**github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span'
       ByteSize: 8
-      GoRuntimeType: 404576
       GoKind: 22
-      Pointee: 7 BaseType uint8
-    - __kind: BaseType
-      ID: 7
-      Name: uint8
-      ByteSize: 1
-      GoRuntimeType: 594336
-      GoKind: 8
-    - __kind: BaseType
-      ID: 8
-      Name: int
-      ByteSize: 8
-      GoRuntimeType: 594784
-      GoKind: 2
+      Pointee: 135 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span
     - __kind: PointerType
-      ID: 9
-      Name: '*net/url.URL'
+      ID: 191
+      Name: '**github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttributeValue'
       ByteSize: 8
-      GoRuntimeType: 2.167328e+06
       GoKind: 22
-      Pointee: 10 StructureType net/url.URL
-    - __kind: StructureType
-      ID: 10
-      Name: net/url.URL
-      ByteSize: 144
-      GoRuntimeType: 2.181632e+06
-      GoKind: 25
-      RawFields:
-        - Name: Scheme
-          Offset: 0
-          Type: 5 GoStringHeaderType string
-        - Name: Opaque
-          Offset: 16
-          Type: 5 GoStringHeaderType string
-        - Name: User
-          Offset: 32
-          Type: 11 PointerType *net/url.Userinfo
-        - Name: Host
-          Offset: 40
-          Type: 5 GoStringHeaderType string
-        - Name: Path
-          Offset: 56
-          Type: 5 GoStringHeaderType string
-        - Name: RawPath
-          Offset: 72
-          Type: 5 GoStringHeaderType string
-        - Name: OmitHost
-          Offset: 88
-          Type: 13 BaseType bool
-        - Name: ForceQuery
-          Offset: 89
-          Type: 13 BaseType bool
-        - Name: RawQuery
-          Offset: 96
-          Type: 5 GoStringHeaderType string
-        - Name: Fragment
-          Offset: 112
-          Type: 5 GoStringHeaderType string
-        - Name: RawFragment
-          Offset: 128
-          Type: 5 GoStringHeaderType string
+      Pointee: 192 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttributeValue
     - __kind: PointerType
-      ID: 11
-      Name: '*net/url.Userinfo'
+      ID: 49
+      Name: '**mime/multipart.FileHeader'
       ByteSize: 8
-      GoRuntimeType: 1.22608e+06
       GoKind: 22
-      Pointee: 12 StructureType net/url.Userinfo
-    - __kind: StructureType
-      ID: 12
-      Name: net/url.Userinfo
-      ByteSize: 40
-      GoRuntimeType: 1.658624e+06
-      GoKind: 25
-      RawFields:
-        - Name: username
-          Offset: 0
-          Type: 5 GoStringHeaderType string
-        - Name: password
-          Offset: 16
-          Type: 5 GoStringHeaderType string
-        - Name: passwordSet
-          Offset: 32
-          Type: 13 BaseType bool
-    - __kind: BaseType
-      ID: 13
-      Name: bool
-      ByteSize: 1
-      GoRuntimeType: 595232
-      GoKind: 1
-    - __kind: GoMapType
-      ID: 14
-      Name: net/http.Header
-      ByteSize: 8
-      GoRuntimeType: 2.15504e+06
-      GoKind: 21
-      HeaderType: 16 GoSwissMapHeaderType map<string,[]string>
+      Pointee: 50 PointerType *mime/multipart.FileHeader
     - __kind: PointerType
-      ID: 15
-      Name: '*map<string,[]string>'
+      ID: 99
+      Name: '**net.IPNet'
       ByteSize: 8
-      Pointee: 16 GoSwissMapHeaderType map<string,[]string>
-    - __kind: GoSwissMapHeaderType
-      ID: 16
-      Name: map<string,[]string>
-      ByteSize: 48
-      GoKind: 25
-      RawFields:
-        - Name: used
-          Offset: 0
-          Type: 17 BaseType uint64
-        - Name: seed
-          Offset: 8
-          Type: 18 BaseType uintptr
-        - Name: dirPtr
-          Offset: 16
-          Type: 19 PointerType **table<string,[]string>
-        - Name: dirLen
-          Offset: 24
-          Type: 8 BaseType int
-        - Name: globalDepth
-          Offset: 32
-          Type: 7 BaseType uint8
-        - Name: globalShift
-          Offset: 33
-          Type: 7 BaseType uint8
-        - Name: writing
-          Offset: 34
-          Type: 7 BaseType uint8
-        - Name: tombstonePossible
-          Offset: 35
-          Type: 13 BaseType bool
-        - Name: clearSeq
-          Offset: 40
-          Type: 17 BaseType uint64
-      TablePtrSliceType: 230 GoSliceDataType []*table<string,[]string>.array
-      GroupType: 25 StructureType noalg.map.group[string][]string
-    - __kind: BaseType
-      ID: 17
-      Name: uint64
+      GoKind: 22
+      Pointee: 100 PointerType *net.IPNet
+    - __kind: PointerType
+      ID: 97
+      Name: '**net/url.URL'
       ByteSize: 8
-      GoRuntimeType: 594720
-      GoKind: 11
-    - __kind: BaseType
-      ID: 18
-      Name: uintptr
+      GoKind: 22
+      Pointee: 9 PointerType *net/url.URL
+    - __kind: PointerType
+      ID: 177
+      Name: '**table<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>'
       ByteSize: 8
-      GoRuntimeType: 594912
-      GoKind: 12
+      Pointee: 178 PointerType *table<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
+    - __kind: PointerType
+      ID: 40
+      Name: '**table<string,[]*mime/multipart.FileHeader>'
+      ByteSize: 8
+      Pointee: 41 PointerType *table<string,[]*mime/multipart.FileHeader>
     - __kind: PointerType
       ID: 19
       Name: '**table<string,[]string>'
       ByteSize: 8
       Pointee: 20 PointerType *table<string,[]string>
     - __kind: PointerType
-      ID: 20
-      Name: '*table<string,[]string>'
+      ID: 159
+      Name: '**table<string,float64>'
       ByteSize: 8
-      Pointee: 21 StructureType table<string,[]string>
-    - __kind: StructureType
-      ID: 21
-      Name: table<string,[]string>
-      ByteSize: 32
-      GoKind: 25
-      RawFields:
-        - Name: used
-          Offset: 0
-          Type: 22 BaseType uint16
-        - Name: capacity
-          Offset: 2
-          Type: 22 BaseType uint16
-        - Name: growthLeft
-          Offset: 4
-          Type: 22 BaseType uint16
-        - Name: localDepth
-          Offset: 6
-          Type: 7 BaseType uint8
-        - Name: index
-          Offset: 8
-          Type: 8 BaseType int
-        - Name: groups
-          Offset: 16
-          Type: 23 GoSwissMapGroupsType groupReference<string,[]string>
-    - __kind: BaseType
-      ID: 22
-      Name: uint16
-      ByteSize: 2
-      GoRuntimeType: 594464
-      GoKind: 9
-    - __kind: GoSwissMapGroupsType
-      ID: 23
-      Name: groupReference<string,[]string>
-      ByteSize: 16
-      GoKind: 25
-      RawFields:
-        - Name: data
-          Offset: 0
-          Type: 24 PointerType *noalg.map.group[string][]string
-        - Name: lengthMask
-          Offset: 8
-          Type: 17 BaseType uint64
-      GroupType: 25 StructureType noalg.map.group[string][]string
-      GroupSliceType: 231 GoSliceDataType []noalg.map.group[string][]string.array
+      Pointee: 160 PointerType *table<string,float64>
     - __kind: PointerType
-      ID: 24
-      Name: '*noalg.map.group[string][]string'
+      ID: 148
+      Name: '**table<string,interface {}>'
       ByteSize: 8
-      Pointee: 25 StructureType noalg.map.group[string][]string
-    - __kind: StructureType
-      ID: 25
-      Name: noalg.map.group[string][]string
-      ByteSize: 328
-      GoRuntimeType: 1.31664e+06
-      GoKind: 25
-      RawFields:
-        - Name: ctrl
-          Offset: 0
-          Type: 17 BaseType uint64
-        - Name: slots
-          Offset: 8
-          Type: 26 ArrayType noalg.[8]struct { key string; elem []string }
-    - __kind: ArrayType
-      ID: 26
-      Name: noalg.[8]struct { key string; elem []string }
-      ByteSize: 320
-      GoRuntimeType: 701120
-      GoKind: 17
-      Count: 8
-      HasCount: true
-      Element: 27 StructureType noalg.struct { key string; elem []string }
-    - __kind: StructureType
-      ID: 27
-      Name: noalg.struct { key string; elem []string }
-      ByteSize: 40
-      GoRuntimeType: 1.316512e+06
-      GoKind: 25
-      RawFields:
-        - Name: key
-          Offset: 0
-          Type: 5 GoStringHeaderType string
-        - Name: elem
-          Offset: 16
-          Type: 28 GoSliceHeaderType []string
-    - __kind: GoSliceHeaderType
-      ID: 28
-      Name: '[]string'
-      ByteSize: 24
-      GoRuntimeType: 501440
-      GoKind: 23
-      RawFields:
-        - Name: array
-          Offset: 0
-          Type: 29 PointerType *string
-        - Name: len
-          Offset: 8
-          Type: 8 BaseType int
-        - Name: cap
-          Offset: 16
-          Type: 8 BaseType int
-      Data: 232 GoSliceDataType []string.array
+      Pointee: 149 PointerType *table<string,interface {}>
     - __kind: PointerType
-      ID: 29
-      Name: '*string'
+      ID: 127
+      Name: '**table<string,string>'
       ByteSize: 8
-      GoRuntimeType: 404448
+      Pointee: 128 PointerType *table<string,string>
+    - __kind: PointerType
+      ID: 110
+      Name: '*[]*crypto/x509.Certificate'
+      ByteSize: 8
       GoKind: 22
-      Pointee: 5 GoStringHeaderType string
-    - __kind: GoInterfaceType
-      ID: 30
-      Name: io.ReadCloser
-      ByteSize: 16
-      GoRuntimeType: 1.135168e+06
-      GoKind: 20
-      RawFields:
-        - Name: tab
-          Offset: 0
-          Type: 2 VoidPointerType unsafe.Pointer
-        - Name: data
-          Offset: 8
-          Type: 2 VoidPointerType unsafe.Pointer
-    - __kind: GoSubroutineType
-      ID: 31
-      Name: func() (io.ReadCloser, error)
+      Pointee: 57 GoSliceHeaderType []*crypto/x509.Certificate
+    - __kind: PointerType
+      ID: 241
+      Name: '*[]*crypto/x509.Certificate.array'
       ByteSize: 8
-      GoRuntimeType: 705088
-      GoKind: 19
-    - __kind: BaseType
-      ID: 32
-      Name: int64
+      Pointee: 240 GoSliceDataType []*crypto/x509.Certificate.array
+    - __kind: PointerType
+      ID: 293
+      Name: '*[]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span.array'
       ByteSize: 8
-      GoRuntimeType: 594656
-      GoKind: 6
-    - __kind: GoMapType
-      ID: 33
-      Name: net/url.Values
+      Pointee: 292 GoSliceDataType []*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span.array
+    - __kind: PointerType
+      ID: 291
+      Name: '*[]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttributeValue.array'
       ByteSize: 8
-      GoRuntimeType: 1.92848e+06
-      GoKind: 21
-      HeaderType: 16 GoSwissMapHeaderType map<string,[]string>
+      Pointee: 290 GoSliceDataType []*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttributeValue.array
+    - __kind: PointerType
+      ID: 237
+      Name: '*[]*mime/multipart.FileHeader.array'
+      ByteSize: 8
+      Pointee: 236 GoSliceDataType []*mime/multipart.FileHeader.array
+    - __kind: PointerType
+      ID: 265
+      Name: '*[]*net.IPNet.array'
+      ByteSize: 8
+      Pointee: 264 GoSliceDataType []*net.IPNet.array
+    - __kind: PointerType
+      ID: 263
+      Name: '*[]*net/url.URL.array'
+      ByteSize: 8
+      Pointee: 262 GoSliceDataType []*net/url.URL.array
+    - __kind: PointerType
+      ID: 273
+      Name: '*[][]*crypto/x509.Certificate.array'
+      ByteSize: 8
+      Pointee: 272 GoSliceDataType [][]*crypto/x509.Certificate.array
+    - __kind: PointerType
+      ID: 275
+      Name: '*[][]uint8.array'
+      ByteSize: 8
+      Pointee: 274 GoSliceDataType [][]uint8.array
+    - __kind: PointerType
+      ID: 257
+      Name: '*[]crypto/x509.ExtKeyUsage.array'
+      ByteSize: 8
+      Pointee: 256 GoSliceDataType []crypto/x509.ExtKeyUsage.array
+    - __kind: PointerType
+      ID: 269
+      Name: '*[]crypto/x509.OID.array'
+      ByteSize: 8
+      Pointee: 268 GoSliceDataType []crypto/x509.OID.array
+    - __kind: PointerType
+      ID: 271
+      Name: '*[]crypto/x509.PolicyMapping.array'
+      ByteSize: 8
+      Pointee: 270 GoSliceDataType []crypto/x509.PolicyMapping.array
+    - __kind: PointerType
+      ID: 245
+      Name: '*[]crypto/x509/pkix.AttributeTypeAndValue.array'
+      ByteSize: 8
+      Pointee: 244 GoSliceDataType []crypto/x509/pkix.AttributeTypeAndValue.array
+    - __kind: PointerType
+      ID: 253
+      Name: '*[]crypto/x509/pkix.Extension.array'
+      ByteSize: 8
+      Pointee: 252 GoSliceDataType []crypto/x509/pkix.Extension.array
+    - __kind: PointerType
+      ID: 255
+      Name: '*[]encoding/asn1.ObjectIdentifier.array'
+      ByteSize: 8
+      Pointee: 254 GoSliceDataType []encoding/asn1.ObjectIdentifier.array
+    - __kind: PointerType
+      ID: 285
+      Name: '*[]github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink.array'
+      ByteSize: 8
+      Pointee: 284 GoSliceDataType []github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink.array
+    - __kind: PointerType
+      ID: 287
+      Name: '*[]github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent.array'
+      ByteSize: 8
+      Pointee: 286 GoSliceDataType []github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent.array
+    - __kind: PointerType
+      ID: 259
+      Name: '*[]net.IP.array'
+      ByteSize: 8
+      Pointee: 258 GoSliceDataType []net.IP.array
+    - __kind: PointerType
+      ID: 277
+      Name: '*[]net/http.segment.array'
+      ByteSize: 8
+      Pointee: 276 GoSliceDataType []net/http.segment.array
+    - __kind: PointerType
+      ID: 233
+      Name: '*[]string.array'
+      ByteSize: 8
+      Pointee: 232 GoSliceDataType []string.array
+    - __kind: PointerType
+      ID: 249
+      Name: '*[]time.zone.array'
+      ByteSize: 8
+      Pointee: 248 GoSliceDataType []time.zone.array
+    - __kind: PointerType
+      ID: 251
+      Name: '*[]time.zoneTrans.array'
+      ByteSize: 8
+      Pointee: 250 GoSliceDataType []time.zoneTrans.array
+    - __kind: PointerType
+      ID: 112
+      Name: '*[]uint8'
+      ByteSize: 8
+      GoRuntimeType: 486560
+      GoKind: 22
+      Pointee: 53 GoSliceHeaderType []uint8
+    - __kind: PointerType
+      ID: 239
+      Name: '*[]uint8.array'
+      ByteSize: 8
+      Pointee: 238 GoSliceDataType []uint8.array
+    - __kind: PointerType
+      ID: 209
+      Name: '*bool'
+      ByteSize: 8
+      GoRuntimeType: 405472
+      GoKind: 22
+      Pointee: 13 BaseType bool
+    - __kind: PointerType
+      ID: 206
+      Name: '*bytes.Buffer'
+      ByteSize: 8
+      GoRuntimeType: 2.321376e+06
+      GoKind: 22
+      Pointee: 207 StructureType bytes.Buffer
+    - __kind: PointerType
+      ID: 54
+      Name: '*crypto/tls.ConnectionState'
+      ByteSize: 8
+      GoRuntimeType: 924032
+      GoKind: 22
+      Pointee: 55 StructureType crypto/tls.ConnectionState
+    - __kind: PointerType
+      ID: 59
+      Name: '*crypto/x509.Certificate'
+      ByteSize: 8
+      GoRuntimeType: 2.089664e+06
+      GoKind: 22
+      Pointee: 60 StructureType crypto/x509.Certificate
+    - __kind: PointerType
+      ID: 91
+      Name: '*crypto/x509.ExtKeyUsage'
+      ByteSize: 8
+      GoRuntimeType: 429920
+      GoKind: 22
+      Pointee: 92 BaseType crypto/x509.ExtKeyUsage
+    - __kind: PointerType
+      ID: 104
+      Name: '*crypto/x509.OID'
+      ByteSize: 8
+      GoRuntimeType: 1.998112e+06
+      GoKind: 22
+      Pointee: 105 StructureType crypto/x509.OID
+    - __kind: PointerType
+      ID: 107
+      Name: '*crypto/x509.PolicyMapping'
+      ByteSize: 8
+      GoRuntimeType: 429984
+      GoKind: 22
+      Pointee: 108 StructureType crypto/x509.PolicyMapping
+    - __kind: PointerType
+      ID: 71
+      Name: '*crypto/x509/pkix.AttributeTypeAndValue'
+      ByteSize: 8
+      GoRuntimeType: 446624
+      GoKind: 22
+      Pointee: 72 StructureType crypto/x509/pkix.AttributeTypeAndValue
+    - __kind: PointerType
+      ID: 86
+      Name: '*crypto/x509/pkix.Extension'
+      ByteSize: 8
+      GoRuntimeType: 446816
+      GoKind: 22
+      Pointee: 87 StructureType crypto/x509/pkix.Extension
+    - __kind: PointerType
+      ID: 89
+      Name: '*encoding/asn1.ObjectIdentifier'
+      ByteSize: 8
+      GoRuntimeType: 1.079776e+06
+      GoKind: 22
+      Pointee: 73 GoSliceHeaderType encoding/asn1.ObjectIdentifier
+    - __kind: PointerType
+      ID: 247
+      Name: '*encoding/asn1.ObjectIdentifier.array'
+      ByteSize: 8
+      Pointee: 246 GoSliceDataType encoding/asn1.ObjectIdentifier.array
+    - __kind: PointerType
+      ID: 225
+      Name: '*error'
+      ByteSize: 8
+      GoRuntimeType: 404384
+      GoKind: 22
+      Pointee: 210 GoInterfaceType error
+    - __kind: PointerType
+      ID: 227
+      Name: '*float32'
+      ByteSize: 8
+      GoRuntimeType: 405344
+      GoKind: 22
+      Pointee: 213 BaseType float32
+    - __kind: PointerType
+      ID: 202
+      Name: '*float64'
+      ByteSize: 8
+      GoRuntimeType: 405408
+      GoKind: 22
+      Pointee: 167 BaseType float64
+    - __kind: PointerType
+      ID: 135
+      Name: '*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span'
+      ByteSize: 8
+      GoRuntimeType: 2.33264e+06
+      GoKind: 22
+      Pointee: 136 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span
+    - __kind: PointerType
+      ID: 196
+      Name: '*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanContext'
+      ByteSize: 8
+      GoRuntimeType: 2.054336e+06
+      GoKind: 22
+      Pointee: 197 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanContext
+    - __kind: PointerType
+      ID: 169
+      Name: '*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink'
+      ByteSize: 8
+      GoRuntimeType: 1.21456e+06
+      GoKind: 22
+      Pointee: 170 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink
+    - __kind: PointerType
+      ID: 172
+      Name: '*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent'
+      ByteSize: 8
+      GoRuntimeType: 1.214688e+06
+      GoKind: 22
+      Pointee: 173 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent
+    - __kind: PointerType
+      ID: 188
+      Name: '*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttribute'
+      ByteSize: 8
+      GoRuntimeType: 1.215328e+06
+      GoKind: 22
+      Pointee: 189 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttribute
+    - __kind: PointerType
+      ID: 192
+      Name: '*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttributeValue'
+      ByteSize: 8
+      GoRuntimeType: 1.215072e+06
+      GoKind: 22
+      Pointee: 193 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttributeValue
+    - __kind: PointerType
+      ID: 185
+      Name: '*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute'
+      ByteSize: 8
+      GoRuntimeType: 1.215456e+06
+      GoKind: 22
+      Pointee: 186 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
+    - __kind: PointerType
+      ID: 198
+      Name: '*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.trace'
+      ByteSize: 8
+      GoRuntimeType: 2.277568e+06
+      GoKind: 22
+      Pointee: 199 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.trace
+    - __kind: PointerType
+      ID: 74
+      Name: '*int'
+      ByteSize: 8
+      GoRuntimeType: 405024
+      GoKind: 22
+      Pointee: 8 BaseType int
+    - __kind: PointerType
+      ID: 222
+      Name: '*int16'
+      ByteSize: 8
+      GoRuntimeType: 404640
+      GoKind: 22
+      Pointee: 223 BaseType int16
+    - __kind: PointerType
+      ID: 215
+      Name: '*int32'
+      ByteSize: 8
+      GoRuntimeType: 404768
+      GoKind: 22
+      Pointee: 141 BaseType int32
+    - __kind: PointerType
+      ID: 219
+      Name: '*int64'
+      ByteSize: 8
+      GoRuntimeType: 404896
+      GoKind: 22
+      Pointee: 32 BaseType int64
+    - __kind: PointerType
+      ID: 224
+      Name: '*int8'
+      ByteSize: 8
+      GoRuntimeType: 404512
+      GoKind: 22
+      Pointee: 211 BaseType int8
+    - __kind: PointerType
+      ID: 175
+      Name: '*map<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>'
+      ByteSize: 8
+      Pointee: 176 GoSwissMapHeaderType map<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
+    - __kind: PointerType
+      ID: 38
+      Name: '*map<string,[]*mime/multipart.FileHeader>'
+      ByteSize: 8
+      Pointee: 39 GoSwissMapHeaderType map<string,[]*mime/multipart.FileHeader>
+    - __kind: PointerType
+      ID: 15
+      Name: '*map<string,[]string>'
+      ByteSize: 8
+      Pointee: 16 GoSwissMapHeaderType map<string,[]string>
+    - __kind: PointerType
+      ID: 157
+      Name: '*map<string,float64>'
+      ByteSize: 8
+      Pointee: 158 GoSwissMapHeaderType map<string,float64>
+    - __kind: PointerType
+      ID: 146
+      Name: '*map<string,interface {}>'
+      ByteSize: 8
+      Pointee: 147 GoSwissMapHeaderType map<string,interface {}>
+    - __kind: PointerType
+      ID: 125
+      Name: '*map<string,string>'
+      ByteSize: 8
+      Pointee: 126 GoSwissMapHeaderType map<string,string>
+    - __kind: PointerType
+      ID: 64
+      Name: '*math/big.Int'
+      ByteSize: 8
+      GoRuntimeType: 2.447424e+06
+      GoKind: 22
+      Pointee: 65 StructureType math/big.Int
+    - __kind: PointerType
+      ID: 67
+      Name: '*math/big.Word'
+      ByteSize: 8
+      GoRuntimeType: 432800
+      GoKind: 22
+      Pointee: 68 BaseType math/big.Word
+    - __kind: PointerType
+      ID: 243
+      Name: '*math/big.nat.array'
+      ByteSize: 8
+      Pointee: 242 GoSliceDataType math/big.nat.array
+    - __kind: PointerType
+      ID: 50
+      Name: '*mime/multipart.FileHeader'
+      ByteSize: 8
+      GoRuntimeType: 925568
+      GoKind: 22
+      Pointee: 51 StructureType mime/multipart.FileHeader
     - __kind: PointerType
       ID: 34
       Name: '*mime/multipart.Form'
@@ -533,161 +536,317 @@ Types:
       GoRuntimeType: 925664
       GoKind: 22
       Pointee: 35 StructureType mime/multipart.Form
-    - __kind: StructureType
-      ID: 35
-      Name: mime/multipart.Form
-      ByteSize: 16
-      GoRuntimeType: 1.506656e+06
-      GoKind: 25
-      RawFields:
-        - Name: Value
-          Offset: 0
-          Type: 36 GoMapType map[string][]string
-        - Name: File
-          Offset: 8
-          Type: 37 GoMapType map[string][]*mime/multipart.FileHeader
-    - __kind: GoMapType
-      ID: 36
-      Name: map[string][]string
-      ByteSize: 8
-      GoRuntimeType: 1.153216e+06
-      GoKind: 21
-      HeaderType: 16 GoSwissMapHeaderType map<string,[]string>
-    - __kind: GoMapType
-      ID: 37
-      Name: map[string][]*mime/multipart.FileHeader
-      ByteSize: 8
-      GoRuntimeType: 1.157568e+06
-      GoKind: 21
-      HeaderType: 39 GoSwissMapHeaderType map<string,[]*mime/multipart.FileHeader>
     - __kind: PointerType
-      ID: 38
-      Name: '*map<string,[]*mime/multipart.FileHeader>'
+      ID: 94
+      Name: '*net.IP'
       ByteSize: 8
-      Pointee: 39 GoSwissMapHeaderType map<string,[]*mime/multipart.FileHeader>
-    - __kind: GoSwissMapHeaderType
-      ID: 39
-      Name: map<string,[]*mime/multipart.FileHeader>
-      ByteSize: 48
-      GoKind: 25
-      RawFields:
-        - Name: used
-          Offset: 0
-          Type: 17 BaseType uint64
-        - Name: seed
-          Offset: 8
-          Type: 18 BaseType uintptr
-        - Name: dirPtr
-          Offset: 16
-          Type: 40 PointerType **table<string,[]*mime/multipart.FileHeader>
-        - Name: dirLen
-          Offset: 24
-          Type: 8 BaseType int
-        - Name: globalDepth
-          Offset: 32
-          Type: 7 BaseType uint8
-        - Name: globalShift
-          Offset: 33
-          Type: 7 BaseType uint8
-        - Name: writing
-          Offset: 34
-          Type: 7 BaseType uint8
-        - Name: tombstonePossible
-          Offset: 35
-          Type: 13 BaseType bool
-        - Name: clearSeq
-          Offset: 40
-          Type: 17 BaseType uint64
-      TablePtrSliceType: 234 GoSliceDataType []*table<string,[]*mime/multipart.FileHeader>.array
-      GroupType: 45 StructureType noalg.map.group[string][]*mime/multipart.FileHeader
+      GoRuntimeType: 2.206912e+06
+      GoKind: 22
+      Pointee: 95 GoSliceHeaderType net.IP
     - __kind: PointerType
-      ID: 40
-      Name: '**table<string,[]*mime/multipart.FileHeader>'
+      ID: 261
+      Name: '*net.IP.array'
       ByteSize: 8
-      Pointee: 41 PointerType *table<string,[]*mime/multipart.FileHeader>
+      Pointee: 260 GoSliceDataType net.IP.array
     - __kind: PointerType
-      ID: 41
-      Name: '*table<string,[]*mime/multipart.FileHeader>'
+      ID: 267
+      Name: '*net.IPMask.array'
       ByteSize: 8
-      Pointee: 42 StructureType table<string,[]*mime/multipart.FileHeader>
-    - __kind: StructureType
-      ID: 42
-      Name: table<string,[]*mime/multipart.FileHeader>
-      ByteSize: 32
-      GoKind: 25
-      RawFields:
-        - Name: used
-          Offset: 0
-          Type: 22 BaseType uint16
-        - Name: capacity
-          Offset: 2
-          Type: 22 BaseType uint16
-        - Name: growthLeft
-          Offset: 4
-          Type: 22 BaseType uint16
-        - Name: localDepth
-          Offset: 6
-          Type: 7 BaseType uint8
-        - Name: index
-          Offset: 8
-          Type: 8 BaseType int
-        - Name: groups
-          Offset: 16
-          Type: 43 GoSwissMapGroupsType groupReference<string,[]*mime/multipart.FileHeader>
-    - __kind: GoSwissMapGroupsType
-      ID: 43
-      Name: groupReference<string,[]*mime/multipart.FileHeader>
-      ByteSize: 16
-      GoKind: 25
-      RawFields:
-        - Name: data
-          Offset: 0
-          Type: 44 PointerType *noalg.map.group[string][]*mime/multipart.FileHeader
-        - Name: lengthMask
-          Offset: 8
-          Type: 17 BaseType uint64
-      GroupType: 45 StructureType noalg.map.group[string][]*mime/multipart.FileHeader
-      GroupSliceType: 235 GoSliceDataType []noalg.map.group[string][]*mime/multipart.FileHeader.array
+      Pointee: 266 GoSliceDataType net.IPMask.array
+    - __kind: PointerType
+      ID: 100
+      Name: '*net.IPNet'
+      ByteSize: 8
+      GoRuntimeType: 1.208416e+06
+      GoKind: 22
+      Pointee: 101 StructureType net.IPNet
+    - __kind: PointerType
+      ID: 3
+      Name: '*net/http.Request'
+      ByteSize: 8
+      GoRuntimeType: 2.365504e+06
+      GoKind: 22
+      Pointee: 4 StructureType net/http.Request
+    - __kind: PointerType
+      ID: 116
+      Name: '*net/http.Response'
+      ByteSize: 8
+      GoRuntimeType: 1.7584e+06
+      GoKind: 22
+      Pointee: 117 StructureType net/http.Response
+    - __kind: PointerType
+      ID: 119
+      Name: '*net/http.pattern'
+      ByteSize: 8
+      GoRuntimeType: 1.642688e+06
+      GoKind: 22
+      Pointee: 120 StructureType net/http.pattern
+    - __kind: PointerType
+      ID: 122
+      Name: '*net/http.segment'
+      ByteSize: 8
+      GoRuntimeType: 396384
+      GoKind: 22
+      Pointee: 123 StructureType net/http.segment
+    - __kind: PointerType
+      ID: 9
+      Name: '*net/url.URL'
+      ByteSize: 8
+      GoRuntimeType: 2.167328e+06
+      GoKind: 22
+      Pointee: 10 StructureType net/url.URL
+    - __kind: PointerType
+      ID: 11
+      Name: '*net/url.Userinfo'
+      ByteSize: 8
+      GoRuntimeType: 1.22608e+06
+      GoKind: 22
+      Pointee: 12 StructureType net/url.Userinfo
+    - __kind: PointerType
+      ID: 181
+      Name: '*noalg.map.group[string]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute'
+      ByteSize: 8
+      Pointee: 182 StructureType noalg.map.group[string]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
     - __kind: PointerType
       ID: 44
       Name: '*noalg.map.group[string][]*mime/multipart.FileHeader'
       ByteSize: 8
       Pointee: 45 StructureType noalg.map.group[string][]*mime/multipart.FileHeader
-    - __kind: StructureType
-      ID: 45
-      Name: noalg.map.group[string][]*mime/multipart.FileHeader
-      ByteSize: 328
-      GoRuntimeType: 1.325728e+06
-      GoKind: 25
+    - __kind: PointerType
+      ID: 24
+      Name: '*noalg.map.group[string][]string'
+      ByteSize: 8
+      Pointee: 25 StructureType noalg.map.group[string][]string
+    - __kind: PointerType
+      ID: 163
+      Name: '*noalg.map.group[string]float64'
+      ByteSize: 8
+      Pointee: 164 StructureType noalg.map.group[string]float64
+    - __kind: PointerType
+      ID: 152
+      Name: '*noalg.map.group[string]interface {}'
+      ByteSize: 8
+      Pointee: 153 StructureType noalg.map.group[string]interface {}
+    - __kind: PointerType
+      ID: 131
+      Name: '*noalg.map.group[string]string'
+      ByteSize: 8
+      Pointee: 132 StructureType noalg.map.group[string]string
+    - __kind: PointerType
+      ID: 29
+      Name: '*string'
+      ByteSize: 8
+      GoRuntimeType: 404448
+      GoKind: 22
+      Pointee: 5 GoStringHeaderType string
+    - __kind: PointerType
+      ID: 229
+      Name: '*string.str'
+      ByteSize: 8
+      Pointee: 228 GoStringDataType string.str
+    - __kind: PointerType
+      ID: 178
+      Name: '*table<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>'
+      ByteSize: 8
+      Pointee: 179 StructureType table<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
+    - __kind: PointerType
+      ID: 41
+      Name: '*table<string,[]*mime/multipart.FileHeader>'
+      ByteSize: 8
+      Pointee: 42 StructureType table<string,[]*mime/multipart.FileHeader>
+    - __kind: PointerType
+      ID: 20
+      Name: '*table<string,[]string>'
+      ByteSize: 8
+      Pointee: 21 StructureType table<string,[]string>
+    - __kind: PointerType
+      ID: 160
+      Name: '*table<string,float64>'
+      ByteSize: 8
+      Pointee: 161 StructureType table<string,float64>
+    - __kind: PointerType
+      ID: 149
+      Name: '*table<string,interface {}>'
+      ByteSize: 8
+      Pointee: 150 StructureType table<string,interface {}>
+    - __kind: PointerType
+      ID: 128
+      Name: '*table<string,string>'
+      ByteSize: 8
+      Pointee: 129 StructureType table<string,string>
+    - __kind: PointerType
+      ID: 76
+      Name: '*time.Location'
+      ByteSize: 8
+      GoRuntimeType: 1.64768e+06
+      GoKind: 22
+      Pointee: 77 StructureType time.Location
+    - __kind: PointerType
+      ID: 79
+      Name: '*time.zone'
+      ByteSize: 8
+      GoRuntimeType: 399456
+      GoKind: 22
+      Pointee: 80 StructureType time.zone
+    - __kind: PointerType
+      ID: 82
+      Name: '*time.zoneTrans'
+      ByteSize: 8
+      GoRuntimeType: 399520
+      GoKind: 22
+      Pointee: 83 StructureType time.zoneTrans
+    - __kind: PointerType
+      ID: 226
+      Name: '*uint'
+      ByteSize: 8
+      GoRuntimeType: 405088
+      GoKind: 22
+      Pointee: 212 BaseType uint
+    - __kind: PointerType
+      ID: 221
+      Name: '*uint16'
+      ByteSize: 8
+      GoRuntimeType: 404704
+      GoKind: 22
+      Pointee: 22 BaseType uint16
+    - __kind: PointerType
+      ID: 216
+      Name: '*uint32'
+      ByteSize: 8
+      GoRuntimeType: 404832
+      GoKind: 22
+      Pointee: 142 BaseType uint32
+    - __kind: PointerType
+      ID: 220
+      Name: '*uint64'
+      ByteSize: 8
+      GoRuntimeType: 404960
+      GoKind: 22
+      Pointee: 17 BaseType uint64
+    - __kind: PointerType
+      ID: 6
+      Name: '*uint8'
+      ByteSize: 8
+      GoRuntimeType: 404576
+      GoKind: 22
+      Pointee: 7 BaseType uint8
+    - __kind: PointerType
+      ID: 214
+      Name: '*uintptr'
+      ByteSize: 8
+      GoRuntimeType: 405152
+      GoKind: 22
+      Pointee: 18 BaseType uintptr
+    - __kind: GoChannelType
+      ID: 115
+      Name: <-chan struct {}
+      GoRuntimeType: 607264
+      GoKind: 18
+    - __kind: EventRootType
+      ID: 294
+      Name: Probe[main.HandleHTTP]
+      ByteSize: 25
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: w
+          Offset: 1
+          Expression:
+            Type: 1 GoInterfaceType net/http.ResponseWriter
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 1, index: 0, name: w}
+                  Offset: 0
+                  ByteSize: 16
+        - Name: r
+          Offset: 17
+          Expression:
+            Type: 3 PointerType *net/http.Request
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 1, index: 1, name: r}
+                  Offset: 0
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 295
+      Name: Probe[main.LookAtTheRequest]
+      ByteSize: 17
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: path
+          Offset: 1
+          Expression:
+            Type: 5 GoStringHeaderType string
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 2, index: 0, name: path}
+                  Offset: 0
+                  ByteSize: 16
+    - __kind: GoSliceHeaderType
+      ID: 57
+      Name: '[]*crypto/x509.Certificate'
+      ByteSize: 24
+      GoRuntimeType: 507488
+      GoKind: 23
       RawFields:
-        - Name: ctrl
+        - Name: array
           Offset: 0
-          Type: 17 BaseType uint64
-        - Name: slots
+          Type: 58 PointerType **crypto/x509.Certificate
+        - Name: len
           Offset: 8
-          Type: 46 ArrayType noalg.[8]struct { key string; elem []*mime/multipart.FileHeader }
-    - __kind: ArrayType
-      ID: 46
-      Name: noalg.[8]struct { key string; elem []*mime/multipart.FileHeader }
-      ByteSize: 320
-      GoRuntimeType: 710944
-      GoKind: 17
-      Count: 8
-      HasCount: true
-      Element: 47 StructureType noalg.struct { key string; elem []*mime/multipart.FileHeader }
-    - __kind: StructureType
-      ID: 47
-      Name: noalg.struct { key string; elem []*mime/multipart.FileHeader }
-      ByteSize: 40
-      GoRuntimeType: 1.3256e+06
-      GoKind: 25
-      RawFields:
-        - Name: key
-          Offset: 0
-          Type: 5 GoStringHeaderType string
-        - Name: elem
+          Type: 8 BaseType int
+        - Name: cap
           Offset: 16
-          Type: 48 GoSliceHeaderType []*mime/multipart.FileHeader
+          Type: 8 BaseType int
+      Data: 240 GoSliceDataType []*crypto/x509.Certificate.array
+    - __kind: GoSliceDataType
+      ID: 240
+      Name: '[]*crypto/x509.Certificate.array'
+      ByteSize: 2048
+      Element: 59 PointerType *crypto/x509.Certificate
+    - __kind: GoSliceHeaderType
+      ID: 200
+      Name: '[]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span'
+      ByteSize: 24
+      GoRuntimeType: 495232
+      GoKind: 23
+      RawFields:
+        - Name: array
+          Offset: 0
+          Type: 201 PointerType **github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span
+        - Name: len
+          Offset: 8
+          Type: 8 BaseType int
+        - Name: cap
+          Offset: 16
+          Type: 8 BaseType int
+      Data: 292 GoSliceDataType []*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span.array
+    - __kind: GoSliceDataType
+      ID: 292
+      Name: '[]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span.array'
+      ByteSize: 2048
+      Element: 135 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span
+    - __kind: GoSliceHeaderType
+      ID: 190
+      Name: '[]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttributeValue'
+      ByteSize: 24
+      GoRuntimeType: 494848
+      GoKind: 23
+      RawFields:
+        - Name: array
+          Offset: 0
+          Type: 191 PointerType **github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttributeValue
+        - Name: len
+          Offset: 8
+          Type: 8 BaseType int
+        - Name: cap
+          Offset: 16
+          Type: 8 BaseType int
+      Data: 290 GoSliceDataType []*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttributeValue.array
+    - __kind: GoSliceDataType
+      ID: 290
+      Name: '[]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttributeValue.array'
+      ByteSize: 2048
+      Element: 192 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttributeValue
     - __kind: GoSliceHeaderType
       ID: 48
       Name: '[]*mime/multipart.FileHeader'
@@ -705,54 +864,445 @@ Types:
           Offset: 16
           Type: 8 BaseType int
       Data: 236 GoSliceDataType []*mime/multipart.FileHeader.array
-    - __kind: PointerType
-      ID: 49
-      Name: '**mime/multipart.FileHeader'
-      ByteSize: 8
-      GoKind: 22
-      Pointee: 50 PointerType *mime/multipart.FileHeader
-    - __kind: PointerType
-      ID: 50
-      Name: '*mime/multipart.FileHeader'
-      ByteSize: 8
-      GoRuntimeType: 925568
-      GoKind: 22
-      Pointee: 51 StructureType mime/multipart.FileHeader
-    - __kind: StructureType
-      ID: 51
-      Name: mime/multipart.FileHeader
-      ByteSize: 88
-      GoRuntimeType: 2.018784e+06
-      GoKind: 25
+    - __kind: GoSliceDataType
+      ID: 236
+      Name: '[]*mime/multipart.FileHeader.array'
+      ByteSize: 2048
+      Element: 50 PointerType *mime/multipart.FileHeader
+    - __kind: GoSliceHeaderType
+      ID: 98
+      Name: '[]*net.IPNet'
+      ByteSize: 24
+      GoRuntimeType: 509088
+      GoKind: 23
       RawFields:
-        - Name: Filename
+        - Name: array
           Offset: 0
-          Type: 5 GoStringHeaderType string
-        - Name: Header
+          Type: 99 PointerType **net.IPNet
+        - Name: len
+          Offset: 8
+          Type: 8 BaseType int
+        - Name: cap
           Offset: 16
-          Type: 52 GoMapType net/textproto.MIMEHeader
-        - Name: Size
-          Offset: 24
-          Type: 32 BaseType int64
-        - Name: content
-          Offset: 32
-          Type: 53 GoSliceHeaderType []uint8
-        - Name: tmpfile
-          Offset: 56
-          Type: 5 GoStringHeaderType string
-        - Name: tmpoff
-          Offset: 72
-          Type: 32 BaseType int64
-        - Name: tmpshared
-          Offset: 80
-          Type: 13 BaseType bool
-    - __kind: GoMapType
-      ID: 52
-      Name: net/textproto.MIMEHeader
-      ByteSize: 8
-      GoRuntimeType: 1.86368e+06
-      GoKind: 21
-      HeaderType: 16 GoSwissMapHeaderType map<string,[]string>
+          Type: 8 BaseType int
+      Data: 264 GoSliceDataType []*net.IPNet.array
+    - __kind: GoSliceDataType
+      ID: 264
+      Name: '[]*net.IPNet.array'
+      ByteSize: 2048
+      Element: 100 PointerType *net.IPNet
+    - __kind: GoSliceHeaderType
+      ID: 96
+      Name: '[]*net/url.URL'
+      ByteSize: 24
+      GoRuntimeType: 509024
+      GoKind: 23
+      RawFields:
+        - Name: array
+          Offset: 0
+          Type: 97 PointerType **net/url.URL
+        - Name: len
+          Offset: 8
+          Type: 8 BaseType int
+        - Name: cap
+          Offset: 16
+          Type: 8 BaseType int
+      Data: 262 GoSliceDataType []*net/url.URL.array
+    - __kind: GoSliceDataType
+      ID: 262
+      Name: '[]*net/url.URL.array'
+      ByteSize: 2048
+      Element: 9 PointerType *net/url.URL
+    - __kind: GoSliceDataType
+      ID: 288
+      Name: '[]*table<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>.array'
+      ByteSize: 8192
+      Element: 178 PointerType *table<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
+    - __kind: GoSliceDataType
+      ID: 234
+      Name: '[]*table<string,[]*mime/multipart.FileHeader>.array'
+      ByteSize: 8192
+      Element: 41 PointerType *table<string,[]*mime/multipart.FileHeader>
+    - __kind: GoSliceDataType
+      ID: 230
+      Name: '[]*table<string,[]string>.array'
+      ByteSize: 8192
+      Element: 20 PointerType *table<string,[]string>
+    - __kind: GoSliceDataType
+      ID: 282
+      Name: '[]*table<string,float64>.array'
+      ByteSize: 8192
+      Element: 160 PointerType *table<string,float64>
+    - __kind: GoSliceDataType
+      ID: 280
+      Name: '[]*table<string,interface {}>.array'
+      ByteSize: 8192
+      Element: 149 PointerType *table<string,interface {}>
+    - __kind: GoSliceDataType
+      ID: 278
+      Name: '[]*table<string,string>.array'
+      ByteSize: 8192
+      Element: 128 PointerType *table<string,string>
+    - __kind: GoSliceHeaderType
+      ID: 109
+      Name: '[][]*crypto/x509.Certificate'
+      ByteSize: 24
+      GoRuntimeType: 507552
+      GoKind: 23
+      RawFields:
+        - Name: array
+          Offset: 0
+          Type: 110 PointerType *[]*crypto/x509.Certificate
+        - Name: len
+          Offset: 8
+          Type: 8 BaseType int
+        - Name: cap
+          Offset: 16
+          Type: 8 BaseType int
+      Data: 272 GoSliceDataType [][]*crypto/x509.Certificate.array
+    - __kind: GoSliceDataType
+      ID: 272
+      Name: '[][]*crypto/x509.Certificate.array'
+      ByteSize: 2048
+      Element: 57 GoSliceHeaderType []*crypto/x509.Certificate
+    - __kind: GoSliceHeaderType
+      ID: 111
+      Name: '[][]uint8'
+      ByteSize: 24
+      GoRuntimeType: 486880
+      GoKind: 23
+      RawFields:
+        - Name: array
+          Offset: 0
+          Type: 112 PointerType *[]uint8
+        - Name: len
+          Offset: 8
+          Type: 8 BaseType int
+        - Name: cap
+          Offset: 16
+          Type: 8 BaseType int
+      Data: 274 GoSliceDataType [][]uint8.array
+    - __kind: GoSliceDataType
+      ID: 274
+      Name: '[][]uint8.array'
+      ByteSize: 2048
+      Element: 53 GoSliceHeaderType []uint8
+    - __kind: GoSliceHeaderType
+      ID: 90
+      Name: '[]crypto/x509.ExtKeyUsage'
+      ByteSize: 24
+      GoRuntimeType: 508960
+      GoKind: 23
+      RawFields:
+        - Name: array
+          Offset: 0
+          Type: 91 PointerType *crypto/x509.ExtKeyUsage
+        - Name: len
+          Offset: 8
+          Type: 8 BaseType int
+        - Name: cap
+          Offset: 16
+          Type: 8 BaseType int
+      Data: 256 GoSliceDataType []crypto/x509.ExtKeyUsage.array
+    - __kind: GoSliceDataType
+      ID: 256
+      Name: '[]crypto/x509.ExtKeyUsage.array'
+      ByteSize: 2048
+      Element: 92 BaseType crypto/x509.ExtKeyUsage
+    - __kind: GoSliceHeaderType
+      ID: 103
+      Name: '[]crypto/x509.OID'
+      ByteSize: 24
+      GoRuntimeType: 509152
+      GoKind: 23
+      RawFields:
+        - Name: array
+          Offset: 0
+          Type: 104 PointerType *crypto/x509.OID
+        - Name: len
+          Offset: 8
+          Type: 8 BaseType int
+        - Name: cap
+          Offset: 16
+          Type: 8 BaseType int
+      Data: 268 GoSliceDataType []crypto/x509.OID.array
+    - __kind: GoSliceDataType
+      ID: 268
+      Name: '[]crypto/x509.OID.array'
+      ByteSize: 2048
+      Element: 105 StructureType crypto/x509.OID
+    - __kind: GoSliceHeaderType
+      ID: 106
+      Name: '[]crypto/x509.PolicyMapping'
+      ByteSize: 24
+      GoRuntimeType: 509216
+      GoKind: 23
+      RawFields:
+        - Name: array
+          Offset: 0
+          Type: 107 PointerType *crypto/x509.PolicyMapping
+        - Name: len
+          Offset: 8
+          Type: 8 BaseType int
+        - Name: cap
+          Offset: 16
+          Type: 8 BaseType int
+      Data: 270 GoSliceDataType []crypto/x509.PolicyMapping.array
+    - __kind: GoSliceDataType
+      ID: 270
+      Name: '[]crypto/x509.PolicyMapping.array'
+      ByteSize: 2048
+      Element: 108 StructureType crypto/x509.PolicyMapping
+    - __kind: GoSliceHeaderType
+      ID: 70
+      Name: '[]crypto/x509/pkix.AttributeTypeAndValue'
+      ByteSize: 24
+      GoRuntimeType: 523680
+      GoKind: 23
+      RawFields:
+        - Name: array
+          Offset: 0
+          Type: 71 PointerType *crypto/x509/pkix.AttributeTypeAndValue
+        - Name: len
+          Offset: 8
+          Type: 8 BaseType int
+        - Name: cap
+          Offset: 16
+          Type: 8 BaseType int
+      Data: 244 GoSliceDataType []crypto/x509/pkix.AttributeTypeAndValue.array
+    - __kind: GoSliceDataType
+      ID: 244
+      Name: '[]crypto/x509/pkix.AttributeTypeAndValue.array'
+      ByteSize: 2048
+      Element: 72 StructureType crypto/x509/pkix.AttributeTypeAndValue
+    - __kind: GoSliceHeaderType
+      ID: 85
+      Name: '[]crypto/x509/pkix.Extension'
+      ByteSize: 24
+      GoRuntimeType: 508832
+      GoKind: 23
+      RawFields:
+        - Name: array
+          Offset: 0
+          Type: 86 PointerType *crypto/x509/pkix.Extension
+        - Name: len
+          Offset: 8
+          Type: 8 BaseType int
+        - Name: cap
+          Offset: 16
+          Type: 8 BaseType int
+      Data: 252 GoSliceDataType []crypto/x509/pkix.Extension.array
+    - __kind: GoSliceDataType
+      ID: 252
+      Name: '[]crypto/x509/pkix.Extension.array'
+      ByteSize: 2048
+      Element: 87 StructureType crypto/x509/pkix.Extension
+    - __kind: GoSliceHeaderType
+      ID: 88
+      Name: '[]encoding/asn1.ObjectIdentifier'
+      ByteSize: 24
+      GoRuntimeType: 508896
+      GoKind: 23
+      RawFields:
+        - Name: array
+          Offset: 0
+          Type: 89 PointerType *encoding/asn1.ObjectIdentifier
+        - Name: len
+          Offset: 8
+          Type: 8 BaseType int
+        - Name: cap
+          Offset: 16
+          Type: 8 BaseType int
+      Data: 254 GoSliceDataType []encoding/asn1.ObjectIdentifier.array
+    - __kind: GoSliceDataType
+      ID: 254
+      Name: '[]encoding/asn1.ObjectIdentifier.array'
+      ByteSize: 2048
+      Element: 73 GoSliceHeaderType encoding/asn1.ObjectIdentifier
+    - __kind: GoSliceHeaderType
+      ID: 168
+      Name: '[]github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink'
+      ByteSize: 24
+      GoRuntimeType: 494784
+      GoKind: 23
+      RawFields:
+        - Name: array
+          Offset: 0
+          Type: 169 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink
+        - Name: len
+          Offset: 8
+          Type: 8 BaseType int
+        - Name: cap
+          Offset: 16
+          Type: 8 BaseType int
+      Data: 284 GoSliceDataType []github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink.array
+    - __kind: GoSliceDataType
+      ID: 284
+      Name: '[]github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink.array'
+      ByteSize: 2048
+      Element: 170 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink
+    - __kind: GoSliceHeaderType
+      ID: 171
+      Name: '[]github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent'
+      ByteSize: 24
+      GoRuntimeType: 494976
+      GoKind: 23
+      RawFields:
+        - Name: array
+          Offset: 0
+          Type: 172 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent
+        - Name: len
+          Offset: 8
+          Type: 8 BaseType int
+        - Name: cap
+          Offset: 16
+          Type: 8 BaseType int
+      Data: 286 GoSliceDataType []github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent.array
+    - __kind: GoSliceDataType
+      ID: 286
+      Name: '[]github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent.array'
+      ByteSize: 2048
+      Element: 173 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent
+    - __kind: GoSliceHeaderType
+      ID: 93
+      Name: '[]net.IP'
+      ByteSize: 24
+      GoRuntimeType: 487904
+      GoKind: 23
+      RawFields:
+        - Name: array
+          Offset: 0
+          Type: 94 PointerType *net.IP
+        - Name: len
+          Offset: 8
+          Type: 8 BaseType int
+        - Name: cap
+          Offset: 16
+          Type: 8 BaseType int
+      Data: 258 GoSliceDataType []net.IP.array
+    - __kind: GoSliceDataType
+      ID: 258
+      Name: '[]net.IP.array'
+      ByteSize: 2048
+      Element: 95 GoSliceHeaderType net.IP
+    - __kind: GoSliceHeaderType
+      ID: 121
+      Name: '[]net/http.segment'
+      ByteSize: 24
+      GoRuntimeType: 489600
+      GoKind: 23
+      RawFields:
+        - Name: array
+          Offset: 0
+          Type: 122 PointerType *net/http.segment
+        - Name: len
+          Offset: 8
+          Type: 8 BaseType int
+        - Name: cap
+          Offset: 16
+          Type: 8 BaseType int
+      Data: 276 GoSliceDataType []net/http.segment.array
+    - __kind: GoSliceDataType
+      ID: 276
+      Name: '[]net/http.segment.array'
+      ByteSize: 2048
+      Element: 123 StructureType net/http.segment
+    - __kind: GoSliceDataType
+      ID: 289
+      Name: '[]noalg.map.group[string]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute.array'
+      ByteSize: 2048
+      Element: 182 StructureType noalg.map.group[string]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
+    - __kind: GoSliceDataType
+      ID: 235
+      Name: '[]noalg.map.group[string][]*mime/multipart.FileHeader.array'
+      ByteSize: 2048
+      Element: 45 StructureType noalg.map.group[string][]*mime/multipart.FileHeader
+    - __kind: GoSliceDataType
+      ID: 231
+      Name: '[]noalg.map.group[string][]string.array'
+      ByteSize: 2048
+      Element: 25 StructureType noalg.map.group[string][]string
+    - __kind: GoSliceDataType
+      ID: 283
+      Name: '[]noalg.map.group[string]float64.array'
+      ByteSize: 2048
+      Element: 164 StructureType noalg.map.group[string]float64
+    - __kind: GoSliceDataType
+      ID: 281
+      Name: '[]noalg.map.group[string]interface {}.array'
+      ByteSize: 2048
+      Element: 153 StructureType noalg.map.group[string]interface {}
+    - __kind: GoSliceDataType
+      ID: 279
+      Name: '[]noalg.map.group[string]string.array'
+      ByteSize: 2048
+      Element: 132 StructureType noalg.map.group[string]string
+    - __kind: GoSliceHeaderType
+      ID: 28
+      Name: '[]string'
+      ByteSize: 24
+      GoRuntimeType: 501440
+      GoKind: 23
+      RawFields:
+        - Name: array
+          Offset: 0
+          Type: 29 PointerType *string
+        - Name: len
+          Offset: 8
+          Type: 8 BaseType int
+        - Name: cap
+          Offset: 16
+          Type: 8 BaseType int
+      Data: 232 GoSliceDataType []string.array
+    - __kind: GoSliceDataType
+      ID: 232
+      Name: '[]string.array'
+      ByteSize: 2048
+      Element: 5 GoStringHeaderType string
+    - __kind: GoSliceHeaderType
+      ID: 78
+      Name: '[]time.zone'
+      ByteSize: 24
+      GoRuntimeType: 494336
+      GoKind: 23
+      RawFields:
+        - Name: array
+          Offset: 0
+          Type: 79 PointerType *time.zone
+        - Name: len
+          Offset: 8
+          Type: 8 BaseType int
+        - Name: cap
+          Offset: 16
+          Type: 8 BaseType int
+      Data: 248 GoSliceDataType []time.zone.array
+    - __kind: GoSliceDataType
+      ID: 248
+      Name: '[]time.zone.array'
+      ByteSize: 2048
+      Element: 80 StructureType time.zone
+    - __kind: GoSliceHeaderType
+      ID: 81
+      Name: '[]time.zoneTrans'
+      ByteSize: 24
+      GoRuntimeType: 494400
+      GoKind: 23
+      RawFields:
+        - Name: array
+          Offset: 0
+          Type: 82 PointerType *time.zoneTrans
+        - Name: len
+          Offset: 8
+          Type: 8 BaseType int
+        - Name: cap
+          Offset: 16
+          Type: 8 BaseType int
+      Data: 250 GoSliceDataType []time.zoneTrans.array
+    - __kind: GoSliceDataType
+      ID: 250
+      Name: '[]time.zoneTrans.array'
+      ByteSize: 2048
+      Element: 83 StructureType time.zoneTrans
     - __kind: GoSliceHeaderType
       ID: 53
       Name: '[]uint8'
@@ -770,13 +1320,64 @@ Types:
           Offset: 16
           Type: 8 BaseType int
       Data: 238 GoSliceDataType []uint8.array
-    - __kind: PointerType
-      ID: 54
-      Name: '*crypto/tls.ConnectionState'
+    - __kind: GoSliceDataType
+      ID: 238
+      Name: '[]uint8.array'
+      ByteSize: 2048
+      Element: 7 BaseType uint8
+    - __kind: BaseType
+      ID: 13
+      Name: bool
+      ByteSize: 1
+      GoRuntimeType: 595232
+      GoKind: 1
+    - __kind: StructureType
+      ID: 207
+      Name: bytes.Buffer
+      ByteSize: 40
+      GoRuntimeType: 1.640384e+06
+      GoKind: 25
+      RawFields:
+        - Name: buf
+          Offset: 0
+          Type: 53 GoSliceHeaderType []uint8
+        - Name: off
+          Offset: 24
+          Type: 8 BaseType int
+        - Name: lastRead
+          Offset: 32
+          Type: 208 BaseType bytes.readOp
+    - __kind: BaseType
+      ID: 208
+      Name: bytes.readOp
+      ByteSize: 1
+      GoRuntimeType: 593440
+      GoKind: 3
+    - __kind: BaseType
+      ID: 218
+      Name: complex128
+      ByteSize: 16
+      GoRuntimeType: 595040
+      GoKind: 16
+    - __kind: BaseType
+      ID: 217
+      Name: complex64
       ByteSize: 8
-      GoRuntimeType: 924032
-      GoKind: 22
-      Pointee: 55 StructureType crypto/tls.ConnectionState
+      GoRuntimeType: 594976
+      GoKind: 15
+    - __kind: GoInterfaceType
+      ID: 118
+      Name: context.Context
+      ByteSize: 16
+      GoRuntimeType: 1.3032e+06
+      GoKind: 20
+      RawFields:
+        - Name: tab
+          Offset: 0
+          Type: 2 VoidPointerType unsafe.Pointer
+        - Name: data
+          Offset: 8
+          Type: 2 VoidPointerType unsafe.Pointer
     - __kind: StructureType
       ID: 55
       Name: crypto/tls.ConnectionState
@@ -841,36 +1442,12 @@ Types:
       ByteSize: 2
       GoRuntimeType: 847200
       GoKind: 9
-    - __kind: GoSliceHeaderType
-      ID: 57
-      Name: '[]*crypto/x509.Certificate'
-      ByteSize: 24
-      GoRuntimeType: 507488
-      GoKind: 23
-      RawFields:
-        - Name: array
-          Offset: 0
-          Type: 58 PointerType **crypto/x509.Certificate
-        - Name: len
-          Offset: 8
-          Type: 8 BaseType int
-        - Name: cap
-          Offset: 16
-          Type: 8 BaseType int
-      Data: 240 GoSliceDataType []*crypto/x509.Certificate.array
-    - __kind: PointerType
-      ID: 58
-      Name: '**crypto/x509.Certificate'
-      ByteSize: 8
-      GoKind: 22
-      Pointee: 59 PointerType *crypto/x509.Certificate
-    - __kind: PointerType
-      ID: 59
-      Name: '*crypto/x509.Certificate'
-      ByteSize: 8
-      GoRuntimeType: 2.089664e+06
-      GoKind: 22
-      Pointee: 60 StructureType crypto/x509.Certificate
+    - __kind: BaseType
+      ID: 114
+      Name: crypto/tls.SignatureScheme
+      ByteSize: 2
+      GoRuntimeType: 847296
+      GoKind: 9
     - __kind: StructureType
       ID: 60
       Name: crypto/x509.Certificate
@@ -1035,80 +1612,81 @@ Types:
           Offset: 1400
           Type: 106 GoSliceHeaderType []crypto/x509.PolicyMapping
     - __kind: BaseType
-      ID: 61
-      Name: crypto/x509.SignatureAlgorithm
+      ID: 92
+      Name: crypto/x509.ExtKeyUsage
       ByteSize: 8
-      GoRuntimeType: 1.139648e+06
+      GoRuntimeType: 598304
       GoKind: 2
+    - __kind: BaseType
+      ID: 84
+      Name: crypto/x509.KeyUsage
+      ByteSize: 8
+      GoRuntimeType: 598240
+      GoKind: 2
+    - __kind: StructureType
+      ID: 105
+      Name: crypto/x509.OID
+      ByteSize: 24
+      GoRuntimeType: 1.998368e+06
+      GoKind: 25
+      RawFields:
+        - Name: der
+          Offset: 0
+          Type: 53 GoSliceHeaderType []uint8
+    - __kind: StructureType
+      ID: 108
+      Name: crypto/x509.PolicyMapping
+      ByteSize: 48
+      GoRuntimeType: 1.520416e+06
+      GoKind: 25
+      RawFields:
+        - Name: IssuerDomainPolicy
+          Offset: 0
+          Type: 105 StructureType crypto/x509.OID
+        - Name: SubjectDomainPolicy
+          Offset: 24
+          Type: 105 StructureType crypto/x509.OID
     - __kind: BaseType
       ID: 62
       Name: crypto/x509.PublicKeyAlgorithm
       ByteSize: 8
       GoRuntimeType: 849696
       GoKind: 2
-    - __kind: GoEmptyInterfaceType
-      ID: 63
-      Name: interface {}
-      ByteSize: 16
-      GoRuntimeType: 867104
-      GoKind: 20
-      RawFields:
-        - Name: _type
-          Offset: 0
-          Type: 2 VoidPointerType unsafe.Pointer
-        - Name: data
-          Offset: 8
-          Type: 2 VoidPointerType unsafe.Pointer
-    - __kind: PointerType
-      ID: 64
-      Name: '*math/big.Int'
+    - __kind: BaseType
+      ID: 61
+      Name: crypto/x509.SignatureAlgorithm
       ByteSize: 8
-      GoRuntimeType: 2.447424e+06
-      GoKind: 22
-      Pointee: 65 StructureType math/big.Int
+      GoRuntimeType: 1.139648e+06
+      GoKind: 2
     - __kind: StructureType
-      ID: 65
-      Name: math/big.Int
-      ByteSize: 32
-      GoRuntimeType: 1.523456e+06
+      ID: 72
+      Name: crypto/x509/pkix.AttributeTypeAndValue
+      ByteSize: 40
+      GoRuntimeType: 1.532736e+06
       GoKind: 25
       RawFields:
-        - Name: neg
+        - Name: Type
           Offset: 0
-          Type: 13 BaseType bool
-        - Name: abs
-          Offset: 8
-          Type: 66 GoSliceHeaderType math/big.nat
-    - __kind: GoSliceHeaderType
-      ID: 66
-      Name: math/big.nat
-      ByteSize: 24
-      GoRuntimeType: 2.426912e+06
-      GoKind: 23
+          Type: 73 GoSliceHeaderType encoding/asn1.ObjectIdentifier
+        - Name: Value
+          Offset: 24
+          Type: 63 GoEmptyInterfaceType interface {}
+    - __kind: StructureType
+      ID: 87
+      Name: crypto/x509/pkix.Extension
+      ByteSize: 56
+      GoRuntimeType: 1.683776e+06
+      GoKind: 25
       RawFields:
-        - Name: array
+        - Name: Id
           Offset: 0
-          Type: 67 PointerType *math/big.Word
-        - Name: len
-          Offset: 8
-          Type: 8 BaseType int
-        - Name: cap
-          Offset: 16
-          Type: 8 BaseType int
-      Data: 242 GoSliceDataType math/big.nat.array
-    - __kind: PointerType
-      ID: 67
-      Name: '*math/big.Word'
-      ByteSize: 8
-      GoRuntimeType: 432800
-      GoKind: 22
-      Pointee: 68 BaseType math/big.Word
-    - __kind: BaseType
-      ID: 68
-      Name: math/big.Word
-      ByteSize: 8
-      GoRuntimeType: 598496
-      GoKind: 7
+          Type: 73 GoSliceHeaderType encoding/asn1.ObjectIdentifier
+        - Name: Critical
+          Offset: 24
+          Type: 13 BaseType bool
+        - Name: Value
+          Offset: 32
+          Type: 53 GoSliceHeaderType []uint8
     - __kind: StructureType
       ID: 69
       Name: crypto/x509/pkix.Name
@@ -1150,43 +1728,6 @@ Types:
           Offset: 224
           Type: 70 GoSliceHeaderType []crypto/x509/pkix.AttributeTypeAndValue
     - __kind: GoSliceHeaderType
-      ID: 70
-      Name: '[]crypto/x509/pkix.AttributeTypeAndValue'
-      ByteSize: 24
-      GoRuntimeType: 523680
-      GoKind: 23
-      RawFields:
-        - Name: array
-          Offset: 0
-          Type: 71 PointerType *crypto/x509/pkix.AttributeTypeAndValue
-        - Name: len
-          Offset: 8
-          Type: 8 BaseType int
-        - Name: cap
-          Offset: 16
-          Type: 8 BaseType int
-      Data: 244 GoSliceDataType []crypto/x509/pkix.AttributeTypeAndValue.array
-    - __kind: PointerType
-      ID: 71
-      Name: '*crypto/x509/pkix.AttributeTypeAndValue'
-      ByteSize: 8
-      GoRuntimeType: 446624
-      GoKind: 22
-      Pointee: 72 StructureType crypto/x509/pkix.AttributeTypeAndValue
-    - __kind: StructureType
-      ID: 72
-      Name: crypto/x509/pkix.AttributeTypeAndValue
-      ByteSize: 40
-      GoRuntimeType: 1.532736e+06
-      GoKind: 25
-      RawFields:
-        - Name: Type
-          Offset: 0
-          Type: 73 GoSliceHeaderType encoding/asn1.ObjectIdentifier
-        - Name: Value
-          Offset: 24
-          Type: 63 GoEmptyInterfaceType interface {}
-    - __kind: GoSliceHeaderType
       ID: 73
       Name: encoding/asn1.ObjectIdentifier
       ByteSize: 24
@@ -1203,567 +1744,16 @@ Types:
           Offset: 16
           Type: 8 BaseType int
       Data: 246 GoSliceDataType encoding/asn1.ObjectIdentifier.array
-    - __kind: PointerType
-      ID: 74
-      Name: '*int'
-      ByteSize: 8
-      GoRuntimeType: 405024
-      GoKind: 22
-      Pointee: 8 BaseType int
-    - __kind: StructureType
-      ID: 75
-      Name: time.Time
-      ByteSize: 24
-      GoRuntimeType: 2.42976e+06
-      GoKind: 25
-      RawFields:
-        - Name: wall
-          Offset: 0
-          Type: 17 BaseType uint64
-        - Name: ext
-          Offset: 8
-          Type: 32 BaseType int64
-        - Name: loc
-          Offset: 16
-          Type: 76 PointerType *time.Location
-    - __kind: PointerType
-      ID: 76
-      Name: '*time.Location'
-      ByteSize: 8
-      GoRuntimeType: 1.64768e+06
-      GoKind: 22
-      Pointee: 77 StructureType time.Location
-    - __kind: StructureType
-      ID: 77
-      Name: time.Location
-      ByteSize: 104
-      GoRuntimeType: 2.014752e+06
-      GoKind: 25
-      RawFields:
-        - Name: name
-          Offset: 0
-          Type: 5 GoStringHeaderType string
-        - Name: zone
-          Offset: 16
-          Type: 78 GoSliceHeaderType []time.zone
-        - Name: tx
-          Offset: 40
-          Type: 81 GoSliceHeaderType []time.zoneTrans
-        - Name: extend
-          Offset: 64
-          Type: 5 GoStringHeaderType string
-        - Name: cacheStart
-          Offset: 80
-          Type: 32 BaseType int64
-        - Name: cacheEnd
-          Offset: 88
-          Type: 32 BaseType int64
-        - Name: cacheZone
-          Offset: 96
-          Type: 79 PointerType *time.zone
-    - __kind: GoSliceHeaderType
-      ID: 78
-      Name: '[]time.zone'
-      ByteSize: 24
-      GoRuntimeType: 494336
-      GoKind: 23
-      RawFields:
-        - Name: array
-          Offset: 0
-          Type: 79 PointerType *time.zone
-        - Name: len
-          Offset: 8
-          Type: 8 BaseType int
-        - Name: cap
-          Offset: 16
-          Type: 8 BaseType int
-      Data: 248 GoSliceDataType []time.zone.array
-    - __kind: PointerType
-      ID: 79
-      Name: '*time.zone'
-      ByteSize: 8
-      GoRuntimeType: 399456
-      GoKind: 22
-      Pointee: 80 StructureType time.zone
-    - __kind: StructureType
-      ID: 80
-      Name: time.zone
-      ByteSize: 32
-      GoRuntimeType: 1.647488e+06
-      GoKind: 25
-      RawFields:
-        - Name: name
-          Offset: 0
-          Type: 5 GoStringHeaderType string
-        - Name: offset
-          Offset: 16
-          Type: 8 BaseType int
-        - Name: isDST
-          Offset: 24
-          Type: 13 BaseType bool
-    - __kind: GoSliceHeaderType
-      ID: 81
-      Name: '[]time.zoneTrans'
-      ByteSize: 24
-      GoRuntimeType: 494400
-      GoKind: 23
-      RawFields:
-        - Name: array
-          Offset: 0
-          Type: 82 PointerType *time.zoneTrans
-        - Name: len
-          Offset: 8
-          Type: 8 BaseType int
-        - Name: cap
-          Offset: 16
-          Type: 8 BaseType int
-      Data: 250 GoSliceDataType []time.zoneTrans.array
-    - __kind: PointerType
-      ID: 82
-      Name: '*time.zoneTrans'
-      ByteSize: 8
-      GoRuntimeType: 399520
-      GoKind: 22
-      Pointee: 83 StructureType time.zoneTrans
-    - __kind: StructureType
-      ID: 83
-      Name: time.zoneTrans
-      ByteSize: 16
-      GoRuntimeType: 1.789472e+06
-      GoKind: 25
-      RawFields:
-        - Name: when
-          Offset: 0
-          Type: 32 BaseType int64
-        - Name: index
-          Offset: 8
-          Type: 7 BaseType uint8
-        - Name: isstd
-          Offset: 9
-          Type: 13 BaseType bool
-        - Name: isutc
-          Offset: 10
-          Type: 13 BaseType bool
-    - __kind: BaseType
-      ID: 84
-      Name: crypto/x509.KeyUsage
-      ByteSize: 8
-      GoRuntimeType: 598240
-      GoKind: 2
-    - __kind: GoSliceHeaderType
-      ID: 85
-      Name: '[]crypto/x509/pkix.Extension'
-      ByteSize: 24
-      GoRuntimeType: 508832
-      GoKind: 23
-      RawFields:
-        - Name: array
-          Offset: 0
-          Type: 86 PointerType *crypto/x509/pkix.Extension
-        - Name: len
-          Offset: 8
-          Type: 8 BaseType int
-        - Name: cap
-          Offset: 16
-          Type: 8 BaseType int
-      Data: 252 GoSliceDataType []crypto/x509/pkix.Extension.array
-    - __kind: PointerType
-      ID: 86
-      Name: '*crypto/x509/pkix.Extension'
-      ByteSize: 8
-      GoRuntimeType: 446816
-      GoKind: 22
-      Pointee: 87 StructureType crypto/x509/pkix.Extension
-    - __kind: StructureType
-      ID: 87
-      Name: crypto/x509/pkix.Extension
-      ByteSize: 56
-      GoRuntimeType: 1.683776e+06
-      GoKind: 25
-      RawFields:
-        - Name: Id
-          Offset: 0
-          Type: 73 GoSliceHeaderType encoding/asn1.ObjectIdentifier
-        - Name: Critical
-          Offset: 24
-          Type: 13 BaseType bool
-        - Name: Value
-          Offset: 32
-          Type: 53 GoSliceHeaderType []uint8
-    - __kind: GoSliceHeaderType
-      ID: 88
-      Name: '[]encoding/asn1.ObjectIdentifier'
-      ByteSize: 24
-      GoRuntimeType: 508896
-      GoKind: 23
-      RawFields:
-        - Name: array
-          Offset: 0
-          Type: 89 PointerType *encoding/asn1.ObjectIdentifier
-        - Name: len
-          Offset: 8
-          Type: 8 BaseType int
-        - Name: cap
-          Offset: 16
-          Type: 8 BaseType int
-      Data: 254 GoSliceDataType []encoding/asn1.ObjectIdentifier.array
-    - __kind: PointerType
-      ID: 89
-      Name: '*encoding/asn1.ObjectIdentifier'
-      ByteSize: 8
-      GoRuntimeType: 1.079776e+06
-      GoKind: 22
-      Pointee: 73 GoSliceHeaderType encoding/asn1.ObjectIdentifier
-    - __kind: GoSliceHeaderType
-      ID: 90
-      Name: '[]crypto/x509.ExtKeyUsage'
-      ByteSize: 24
-      GoRuntimeType: 508960
-      GoKind: 23
-      RawFields:
-        - Name: array
-          Offset: 0
-          Type: 91 PointerType *crypto/x509.ExtKeyUsage
-        - Name: len
-          Offset: 8
-          Type: 8 BaseType int
-        - Name: cap
-          Offset: 16
-          Type: 8 BaseType int
-      Data: 256 GoSliceDataType []crypto/x509.ExtKeyUsage.array
-    - __kind: PointerType
-      ID: 91
-      Name: '*crypto/x509.ExtKeyUsage'
-      ByteSize: 8
-      GoRuntimeType: 429920
-      GoKind: 22
-      Pointee: 92 BaseType crypto/x509.ExtKeyUsage
-    - __kind: BaseType
-      ID: 92
-      Name: crypto/x509.ExtKeyUsage
-      ByteSize: 8
-      GoRuntimeType: 598304
-      GoKind: 2
-    - __kind: GoSliceHeaderType
-      ID: 93
-      Name: '[]net.IP'
-      ByteSize: 24
-      GoRuntimeType: 487904
-      GoKind: 23
-      RawFields:
-        - Name: array
-          Offset: 0
-          Type: 94 PointerType *net.IP
-        - Name: len
-          Offset: 8
-          Type: 8 BaseType int
-        - Name: cap
-          Offset: 16
-          Type: 8 BaseType int
-      Data: 258 GoSliceDataType []net.IP.array
-    - __kind: PointerType
-      ID: 94
-      Name: '*net.IP'
-      ByteSize: 8
-      GoRuntimeType: 2.206912e+06
-      GoKind: 22
-      Pointee: 95 GoSliceHeaderType net.IP
-    - __kind: GoSliceHeaderType
-      ID: 95
-      Name: net.IP
-      ByteSize: 24
-      GoRuntimeType: 2.178944e+06
-      GoKind: 23
-      RawFields:
-        - Name: array
-          Offset: 0
-          Type: 6 PointerType *uint8
-        - Name: len
-          Offset: 8
-          Type: 8 BaseType int
-        - Name: cap
-          Offset: 16
-          Type: 8 BaseType int
-      Data: 260 GoSliceDataType net.IP.array
-    - __kind: GoSliceHeaderType
-      ID: 96
-      Name: '[]*net/url.URL'
-      ByteSize: 24
-      GoRuntimeType: 509024
-      GoKind: 23
-      RawFields:
-        - Name: array
-          Offset: 0
-          Type: 97 PointerType **net/url.URL
-        - Name: len
-          Offset: 8
-          Type: 8 BaseType int
-        - Name: cap
-          Offset: 16
-          Type: 8 BaseType int
-      Data: 262 GoSliceDataType []*net/url.URL.array
-    - __kind: PointerType
-      ID: 97
-      Name: '**net/url.URL'
-      ByteSize: 8
-      GoKind: 22
-      Pointee: 9 PointerType *net/url.URL
-    - __kind: GoSliceHeaderType
-      ID: 98
-      Name: '[]*net.IPNet'
-      ByteSize: 24
-      GoRuntimeType: 509088
-      GoKind: 23
-      RawFields:
-        - Name: array
-          Offset: 0
-          Type: 99 PointerType **net.IPNet
-        - Name: len
-          Offset: 8
-          Type: 8 BaseType int
-        - Name: cap
-          Offset: 16
-          Type: 8 BaseType int
-      Data: 264 GoSliceDataType []*net.IPNet.array
-    - __kind: PointerType
-      ID: 99
-      Name: '**net.IPNet'
-      ByteSize: 8
-      GoKind: 22
-      Pointee: 100 PointerType *net.IPNet
-    - __kind: PointerType
-      ID: 100
-      Name: '*net.IPNet'
-      ByteSize: 8
-      GoRuntimeType: 1.208416e+06
-      GoKind: 22
-      Pointee: 101 StructureType net.IPNet
-    - __kind: StructureType
-      ID: 101
-      Name: net.IPNet
-      ByteSize: 48
-      GoRuntimeType: 1.486976e+06
-      GoKind: 25
-      RawFields:
-        - Name: IP
-          Offset: 0
-          Type: 95 GoSliceHeaderType net.IP
-        - Name: Mask
-          Offset: 24
-          Type: 102 GoSliceHeaderType net.IPMask
-    - __kind: GoSliceHeaderType
-      ID: 102
-      Name: net.IPMask
-      ByteSize: 24
-      GoRuntimeType: 1.042272e+06
-      GoKind: 23
-      RawFields:
-        - Name: array
-          Offset: 0
-          Type: 6 PointerType *uint8
-        - Name: len
-          Offset: 8
-          Type: 8 BaseType int
-        - Name: cap
-          Offset: 16
-          Type: 8 BaseType int
-      Data: 266 GoSliceDataType net.IPMask.array
-    - __kind: GoSliceHeaderType
-      ID: 103
-      Name: '[]crypto/x509.OID'
-      ByteSize: 24
-      GoRuntimeType: 509152
-      GoKind: 23
-      RawFields:
-        - Name: array
-          Offset: 0
-          Type: 104 PointerType *crypto/x509.OID
-        - Name: len
-          Offset: 8
-          Type: 8 BaseType int
-        - Name: cap
-          Offset: 16
-          Type: 8 BaseType int
-      Data: 268 GoSliceDataType []crypto/x509.OID.array
-    - __kind: PointerType
-      ID: 104
-      Name: '*crypto/x509.OID'
-      ByteSize: 8
-      GoRuntimeType: 1.998112e+06
-      GoKind: 22
-      Pointee: 105 StructureType crypto/x509.OID
-    - __kind: StructureType
-      ID: 105
-      Name: crypto/x509.OID
-      ByteSize: 24
-      GoRuntimeType: 1.998368e+06
-      GoKind: 25
-      RawFields:
-        - Name: der
-          Offset: 0
-          Type: 53 GoSliceHeaderType []uint8
-    - __kind: GoSliceHeaderType
-      ID: 106
-      Name: '[]crypto/x509.PolicyMapping'
-      ByteSize: 24
-      GoRuntimeType: 509216
-      GoKind: 23
-      RawFields:
-        - Name: array
-          Offset: 0
-          Type: 107 PointerType *crypto/x509.PolicyMapping
-        - Name: len
-          Offset: 8
-          Type: 8 BaseType int
-        - Name: cap
-          Offset: 16
-          Type: 8 BaseType int
-      Data: 270 GoSliceDataType []crypto/x509.PolicyMapping.array
-    - __kind: PointerType
-      ID: 107
-      Name: '*crypto/x509.PolicyMapping'
-      ByteSize: 8
-      GoRuntimeType: 429984
-      GoKind: 22
-      Pointee: 108 StructureType crypto/x509.PolicyMapping
-    - __kind: StructureType
-      ID: 108
-      Name: crypto/x509.PolicyMapping
-      ByteSize: 48
-      GoRuntimeType: 1.520416e+06
-      GoKind: 25
-      RawFields:
-        - Name: IssuerDomainPolicy
-          Offset: 0
-          Type: 105 StructureType crypto/x509.OID
-        - Name: SubjectDomainPolicy
-          Offset: 24
-          Type: 105 StructureType crypto/x509.OID
-    - __kind: GoSliceHeaderType
-      ID: 109
-      Name: '[][]*crypto/x509.Certificate'
-      ByteSize: 24
-      GoRuntimeType: 507552
-      GoKind: 23
-      RawFields:
-        - Name: array
-          Offset: 0
-          Type: 110 PointerType *[]*crypto/x509.Certificate
-        - Name: len
-          Offset: 8
-          Type: 8 BaseType int
-        - Name: cap
-          Offset: 16
-          Type: 8 BaseType int
-      Data: 272 GoSliceDataType [][]*crypto/x509.Certificate.array
-    - __kind: PointerType
-      ID: 110
-      Name: '*[]*crypto/x509.Certificate'
-      ByteSize: 8
-      GoKind: 22
-      Pointee: 57 GoSliceHeaderType []*crypto/x509.Certificate
-    - __kind: GoSliceHeaderType
-      ID: 111
-      Name: '[][]uint8'
-      ByteSize: 24
-      GoRuntimeType: 486880
-      GoKind: 23
-      RawFields:
-        - Name: array
-          Offset: 0
-          Type: 112 PointerType *[]uint8
-        - Name: len
-          Offset: 8
-          Type: 8 BaseType int
-        - Name: cap
-          Offset: 16
-          Type: 8 BaseType int
-      Data: 274 GoSliceDataType [][]uint8.array
-    - __kind: PointerType
-      ID: 112
-      Name: '*[]uint8'
-      ByteSize: 8
-      GoRuntimeType: 486560
-      GoKind: 22
-      Pointee: 53 GoSliceHeaderType []uint8
-    - __kind: GoSubroutineType
-      ID: 113
-      Name: func(string, []uint8, int) ([]uint8, error)
-      ByteSize: 8
-      GoRuntimeType: 1.025152e+06
-      GoKind: 19
-    - __kind: BaseType
-      ID: 114
-      Name: crypto/tls.SignatureScheme
-      ByteSize: 2
-      GoRuntimeType: 847296
-      GoKind: 9
-    - __kind: GoChannelType
-      ID: 115
-      Name: <-chan struct {}
-      GoRuntimeType: 607264
-      GoKind: 18
-    - __kind: PointerType
-      ID: 116
-      Name: '*net/http.Response'
-      ByteSize: 8
-      GoRuntimeType: 1.7584e+06
-      GoKind: 22
-      Pointee: 117 StructureType net/http.Response
-    - __kind: StructureType
-      ID: 117
-      Name: net/http.Response
-      ByteSize: 144
-      GoRuntimeType: 2.268608e+06
-      GoKind: 25
-      RawFields:
-        - Name: Status
-          Offset: 0
-          Type: 5 GoStringHeaderType string
-        - Name: StatusCode
-          Offset: 16
-          Type: 8 BaseType int
-        - Name: Proto
-          Offset: 24
-          Type: 5 GoStringHeaderType string
-        - Name: ProtoMajor
-          Offset: 40
-          Type: 8 BaseType int
-        - Name: ProtoMinor
-          Offset: 48
-          Type: 8 BaseType int
-        - Name: Header
-          Offset: 56
-          Type: 14 GoMapType net/http.Header
-        - Name: Body
-          Offset: 64
-          Type: 30 GoInterfaceType io.ReadCloser
-        - Name: ContentLength
-          Offset: 80
-          Type: 32 BaseType int64
-        - Name: TransferEncoding
-          Offset: 88
-          Type: 28 GoSliceHeaderType []string
-        - Name: Close
-          Offset: 112
-          Type: 13 BaseType bool
-        - Name: Uncompressed
-          Offset: 113
-          Type: 13 BaseType bool
-        - Name: Trailer
-          Offset: 120
-          Type: 14 GoMapType net/http.Header
-        - Name: Request
-          Offset: 128
-          Type: 3 PointerType *net/http.Request
-        - Name: TLS
-          Offset: 136
-          Type: 54 PointerType *crypto/tls.ConnectionState
+    - __kind: GoSliceDataType
+      ID: 246
+      Name: encoding/asn1.ObjectIdentifier.array
+      ByteSize: 2048
+      Element: 8 BaseType int
     - __kind: GoInterfaceType
-      ID: 118
-      Name: context.Context
+      ID: 210
+      Name: error
       ByteSize: 16
-      GoRuntimeType: 1.3032e+06
+      GoRuntimeType: 1.054304e+06
       GoKind: 20
       RawFields:
         - Name: tab
@@ -1772,217 +1762,36 @@ Types:
         - Name: data
           Offset: 8
           Type: 2 VoidPointerType unsafe.Pointer
-    - __kind: PointerType
-      ID: 119
-      Name: '*net/http.pattern'
+    - __kind: BaseType
+      ID: 213
+      Name: float32
+      ByteSize: 4
+      GoRuntimeType: 595104
+      GoKind: 13
+    - __kind: BaseType
+      ID: 167
+      Name: float64
       ByteSize: 8
-      GoRuntimeType: 1.642688e+06
-      GoKind: 22
-      Pointee: 120 StructureType net/http.pattern
-    - __kind: StructureType
-      ID: 120
-      Name: net/http.pattern
-      ByteSize: 88
-      GoRuntimeType: 1.875616e+06
-      GoKind: 25
-      RawFields:
-        - Name: str
-          Offset: 0
-          Type: 5 GoStringHeaderType string
-        - Name: method
-          Offset: 16
-          Type: 5 GoStringHeaderType string
-        - Name: host
-          Offset: 32
-          Type: 5 GoStringHeaderType string
-        - Name: segments
-          Offset: 48
-          Type: 121 GoSliceHeaderType []net/http.segment
-        - Name: loc
-          Offset: 72
-          Type: 5 GoStringHeaderType string
-    - __kind: GoSliceHeaderType
-      ID: 121
-      Name: '[]net/http.segment'
-      ByteSize: 24
-      GoRuntimeType: 489600
-      GoKind: 23
-      RawFields:
-        - Name: array
-          Offset: 0
-          Type: 122 PointerType *net/http.segment
-        - Name: len
-          Offset: 8
-          Type: 8 BaseType int
-        - Name: cap
-          Offset: 16
-          Type: 8 BaseType int
-      Data: 276 GoSliceDataType []net/http.segment.array
-    - __kind: PointerType
-      ID: 122
-      Name: '*net/http.segment'
+      GoRuntimeType: 595168
+      GoKind: 14
+    - __kind: GoSubroutineType
+      ID: 205
+      Name: func()
       ByteSize: 8
-      GoRuntimeType: 396384
-      GoKind: 22
-      Pointee: 123 StructureType net/http.segment
-    - __kind: StructureType
-      ID: 123
-      Name: net/http.segment
-      ByteSize: 24
-      GoRuntimeType: 1.642496e+06
-      GoKind: 25
-      RawFields:
-        - Name: s
-          Offset: 0
-          Type: 5 GoStringHeaderType string
-        - Name: wild
-          Offset: 16
-          Type: 13 BaseType bool
-        - Name: multi
-          Offset: 17
-          Type: 13 BaseType bool
-    - __kind: GoMapType
-      ID: 124
-      Name: map[string]string
+      GoRuntimeType: 484960
+      GoKind: 19
+    - __kind: GoSubroutineType
+      ID: 31
+      Name: func() (io.ReadCloser, error)
       ByteSize: 8
-      GoRuntimeType: 1.15424e+06
-      GoKind: 21
-      HeaderType: 126 GoSwissMapHeaderType map<string,string>
-    - __kind: PointerType
-      ID: 125
-      Name: '*map<string,string>'
+      GoRuntimeType: 705088
+      GoKind: 19
+    - __kind: GoSubroutineType
+      ID: 113
+      Name: func(string, []uint8, int) ([]uint8, error)
       ByteSize: 8
-      Pointee: 126 GoSwissMapHeaderType map<string,string>
-    - __kind: GoSwissMapHeaderType
-      ID: 126
-      Name: map<string,string>
-      ByteSize: 48
-      GoKind: 25
-      RawFields:
-        - Name: used
-          Offset: 0
-          Type: 17 BaseType uint64
-        - Name: seed
-          Offset: 8
-          Type: 18 BaseType uintptr
-        - Name: dirPtr
-          Offset: 16
-          Type: 127 PointerType **table<string,string>
-        - Name: dirLen
-          Offset: 24
-          Type: 8 BaseType int
-        - Name: globalDepth
-          Offset: 32
-          Type: 7 BaseType uint8
-        - Name: globalShift
-          Offset: 33
-          Type: 7 BaseType uint8
-        - Name: writing
-          Offset: 34
-          Type: 7 BaseType uint8
-        - Name: tombstonePossible
-          Offset: 35
-          Type: 13 BaseType bool
-        - Name: clearSeq
-          Offset: 40
-          Type: 17 BaseType uint64
-      TablePtrSliceType: 278 GoSliceDataType []*table<string,string>.array
-      GroupType: 132 StructureType noalg.map.group[string]string
-    - __kind: PointerType
-      ID: 127
-      Name: '**table<string,string>'
-      ByteSize: 8
-      Pointee: 128 PointerType *table<string,string>
-    - __kind: PointerType
-      ID: 128
-      Name: '*table<string,string>'
-      ByteSize: 8
-      Pointee: 129 StructureType table<string,string>
-    - __kind: StructureType
-      ID: 129
-      Name: table<string,string>
-      ByteSize: 32
-      GoKind: 25
-      RawFields:
-        - Name: used
-          Offset: 0
-          Type: 22 BaseType uint16
-        - Name: capacity
-          Offset: 2
-          Type: 22 BaseType uint16
-        - Name: growthLeft
-          Offset: 4
-          Type: 22 BaseType uint16
-        - Name: localDepth
-          Offset: 6
-          Type: 7 BaseType uint8
-        - Name: index
-          Offset: 8
-          Type: 8 BaseType int
-        - Name: groups
-          Offset: 16
-          Type: 130 GoSwissMapGroupsType groupReference<string,string>
-    - __kind: GoSwissMapGroupsType
-      ID: 130
-      Name: groupReference<string,string>
-      ByteSize: 16
-      GoKind: 25
-      RawFields:
-        - Name: data
-          Offset: 0
-          Type: 131 PointerType *noalg.map.group[string]string
-        - Name: lengthMask
-          Offset: 8
-          Type: 17 BaseType uint64
-      GroupType: 132 StructureType noalg.map.group[string]string
-      GroupSliceType: 279 GoSliceDataType []noalg.map.group[string]string.array
-    - __kind: PointerType
-      ID: 131
-      Name: '*noalg.map.group[string]string'
-      ByteSize: 8
-      Pointee: 132 StructureType noalg.map.group[string]string
-    - __kind: StructureType
-      ID: 132
-      Name: noalg.map.group[string]string
-      ByteSize: 264
-      GoRuntimeType: 1.319072e+06
-      GoKind: 25
-      RawFields:
-        - Name: ctrl
-          Offset: 0
-          Type: 17 BaseType uint64
-        - Name: slots
-          Offset: 8
-          Type: 133 ArrayType noalg.[8]struct { key string; elem string }
-    - __kind: ArrayType
-      ID: 133
-      Name: noalg.[8]struct { key string; elem string }
-      ByteSize: 256
-      GoRuntimeType: 705280
-      GoKind: 17
-      Count: 8
-      HasCount: true
-      Element: 134 StructureType noalg.struct { key string; elem string }
-    - __kind: StructureType
-      ID: 134
-      Name: noalg.struct { key string; elem string }
-      ByteSize: 32
-      GoRuntimeType: 1.318944e+06
-      GoKind: 25
-      RawFields:
-        - Name: key
-          Offset: 0
-          Type: 5 GoStringHeaderType string
-        - Name: elem
-          Offset: 16
-          Type: 5 GoStringHeaderType string
-    - __kind: PointerType
-      ID: 135
-      Name: '*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span'
-      ByteSize: 8
-      GoRuntimeType: 2.33264e+06
-      GoKind: 22
-      Pointee: 136 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span
+      GoRuntimeType: 1.025152e+06
+      GoKind: 19
     - __kind: StructureType
       ID: 136
       Name: github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span
@@ -2066,721 +1875,6 @@ Types:
           Offset: 280
           Type: 205 GoSubroutineType func()
     - __kind: StructureType
-      ID: 137
-      Name: sync.RWMutex
-      ByteSize: 24
-      GoRuntimeType: 1.88144e+06
-      GoKind: 25
-      RawFields:
-        - Name: w
-          Offset: 0
-          Type: 138 StructureType sync.Mutex
-        - Name: writerSem
-          Offset: 8
-          Type: 142 BaseType uint32
-        - Name: readerSem
-          Offset: 12
-          Type: 142 BaseType uint32
-        - Name: readerCount
-          Offset: 16
-          Type: 143 StructureType sync/atomic.Int32
-        - Name: readerWait
-          Offset: 20
-          Type: 143 StructureType sync/atomic.Int32
-    - __kind: StructureType
-      ID: 138
-      Name: sync.Mutex
-      ByteSize: 8
-      GoRuntimeType: 1.494336e+06
-      GoKind: 25
-      RawFields:
-        - Name: _
-          Offset: 0
-          Type: 139 StructureType sync.noCopy
-        - Name: mu
-          Offset: 0
-          Type: 140 StructureType internal/sync.Mutex
-    - __kind: StructureType
-      ID: 139
-      Name: sync.noCopy
-      GoRuntimeType: 1.007392e+06
-      GoKind: 25
-      RawFields: []
-    - __kind: StructureType
-      ID: 140
-      Name: internal/sync.Mutex
-      ByteSize: 8
-      GoRuntimeType: 1.518176e+06
-      GoKind: 25
-      RawFields:
-        - Name: state
-          Offset: 0
-          Type: 141 BaseType int32
-        - Name: sema
-          Offset: 4
-          Type: 142 BaseType uint32
-    - __kind: BaseType
-      ID: 141
-      Name: int32
-      ByteSize: 4
-      GoRuntimeType: 594528
-      GoKind: 5
-    - __kind: BaseType
-      ID: 142
-      Name: uint32
-      ByteSize: 4
-      GoRuntimeType: 594592
-      GoKind: 10
-    - __kind: StructureType
-      ID: 143
-      Name: sync/atomic.Int32
-      ByteSize: 4
-      GoRuntimeType: 1.495616e+06
-      GoKind: 25
-      RawFields:
-        - Name: _
-          Offset: 0
-          Type: 144 StructureType sync/atomic.noCopy
-        - Name: v
-          Offset: 0
-          Type: 141 BaseType int32
-    - __kind: StructureType
-      ID: 144
-      Name: sync/atomic.noCopy
-      GoRuntimeType: 1.007488e+06
-      GoKind: 25
-      RawFields: []
-    - __kind: GoMapType
-      ID: 145
-      Name: github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.metaStructMap
-      ByteSize: 8
-      GoRuntimeType: 1.30448e+06
-      GoKind: 21
-      HeaderType: 147 GoSwissMapHeaderType map<string,interface {}>
-    - __kind: PointerType
-      ID: 146
-      Name: '*map<string,interface {}>'
-      ByteSize: 8
-      Pointee: 147 GoSwissMapHeaderType map<string,interface {}>
-    - __kind: GoSwissMapHeaderType
-      ID: 147
-      Name: map<string,interface {}>
-      ByteSize: 48
-      GoKind: 25
-      RawFields:
-        - Name: used
-          Offset: 0
-          Type: 17 BaseType uint64
-        - Name: seed
-          Offset: 8
-          Type: 18 BaseType uintptr
-        - Name: dirPtr
-          Offset: 16
-          Type: 148 PointerType **table<string,interface {}>
-        - Name: dirLen
-          Offset: 24
-          Type: 8 BaseType int
-        - Name: globalDepth
-          Offset: 32
-          Type: 7 BaseType uint8
-        - Name: globalShift
-          Offset: 33
-          Type: 7 BaseType uint8
-        - Name: writing
-          Offset: 34
-          Type: 7 BaseType uint8
-        - Name: tombstonePossible
-          Offset: 35
-          Type: 13 BaseType bool
-        - Name: clearSeq
-          Offset: 40
-          Type: 17 BaseType uint64
-      TablePtrSliceType: 280 GoSliceDataType []*table<string,interface {}>.array
-      GroupType: 153 StructureType noalg.map.group[string]interface {}
-    - __kind: PointerType
-      ID: 148
-      Name: '**table<string,interface {}>'
-      ByteSize: 8
-      Pointee: 149 PointerType *table<string,interface {}>
-    - __kind: PointerType
-      ID: 149
-      Name: '*table<string,interface {}>'
-      ByteSize: 8
-      Pointee: 150 StructureType table<string,interface {}>
-    - __kind: StructureType
-      ID: 150
-      Name: table<string,interface {}>
-      ByteSize: 32
-      GoKind: 25
-      RawFields:
-        - Name: used
-          Offset: 0
-          Type: 22 BaseType uint16
-        - Name: capacity
-          Offset: 2
-          Type: 22 BaseType uint16
-        - Name: growthLeft
-          Offset: 4
-          Type: 22 BaseType uint16
-        - Name: localDepth
-          Offset: 6
-          Type: 7 BaseType uint8
-        - Name: index
-          Offset: 8
-          Type: 8 BaseType int
-        - Name: groups
-          Offset: 16
-          Type: 151 GoSwissMapGroupsType groupReference<string,interface {}>
-    - __kind: GoSwissMapGroupsType
-      ID: 151
-      Name: groupReference<string,interface {}>
-      ByteSize: 16
-      GoKind: 25
-      RawFields:
-        - Name: data
-          Offset: 0
-          Type: 152 PointerType *noalg.map.group[string]interface {}
-        - Name: lengthMask
-          Offset: 8
-          Type: 17 BaseType uint64
-      GroupType: 153 StructureType noalg.map.group[string]interface {}
-      GroupSliceType: 281 GoSliceDataType []noalg.map.group[string]interface {}.array
-    - __kind: PointerType
-      ID: 152
-      Name: '*noalg.map.group[string]interface {}'
-      ByteSize: 8
-      Pointee: 153 StructureType noalg.map.group[string]interface {}
-    - __kind: StructureType
-      ID: 153
-      Name: noalg.map.group[string]interface {}
-      ByteSize: 264
-      GoRuntimeType: 1.31408e+06
-      GoKind: 25
-      RawFields:
-        - Name: ctrl
-          Offset: 0
-          Type: 17 BaseType uint64
-        - Name: slots
-          Offset: 8
-          Type: 154 ArrayType noalg.[8]struct { key string; elem interface {} }
-    - __kind: ArrayType
-      ID: 154
-      Name: noalg.[8]struct { key string; elem interface {} }
-      ByteSize: 256
-      GoRuntimeType: 692576
-      GoKind: 17
-      Count: 8
-      HasCount: true
-      Element: 155 StructureType noalg.struct { key string; elem interface {} }
-    - __kind: StructureType
-      ID: 155
-      Name: noalg.struct { key string; elem interface {} }
-      ByteSize: 32
-      GoRuntimeType: 1.313952e+06
-      GoKind: 25
-      RawFields:
-        - Name: key
-          Offset: 0
-          Type: 5 GoStringHeaderType string
-        - Name: elem
-          Offset: 16
-          Type: 63 GoEmptyInterfaceType interface {}
-    - __kind: GoMapType
-      ID: 156
-      Name: map[string]float64
-      ByteSize: 8
-      GoRuntimeType: 1.158208e+06
-      GoKind: 21
-      HeaderType: 158 GoSwissMapHeaderType map<string,float64>
-    - __kind: PointerType
-      ID: 157
-      Name: '*map<string,float64>'
-      ByteSize: 8
-      Pointee: 158 GoSwissMapHeaderType map<string,float64>
-    - __kind: GoSwissMapHeaderType
-      ID: 158
-      Name: map<string,float64>
-      ByteSize: 48
-      GoKind: 25
-      RawFields:
-        - Name: used
-          Offset: 0
-          Type: 17 BaseType uint64
-        - Name: seed
-          Offset: 8
-          Type: 18 BaseType uintptr
-        - Name: dirPtr
-          Offset: 16
-          Type: 159 PointerType **table<string,float64>
-        - Name: dirLen
-          Offset: 24
-          Type: 8 BaseType int
-        - Name: globalDepth
-          Offset: 32
-          Type: 7 BaseType uint8
-        - Name: globalShift
-          Offset: 33
-          Type: 7 BaseType uint8
-        - Name: writing
-          Offset: 34
-          Type: 7 BaseType uint8
-        - Name: tombstonePossible
-          Offset: 35
-          Type: 13 BaseType bool
-        - Name: clearSeq
-          Offset: 40
-          Type: 17 BaseType uint64
-      TablePtrSliceType: 282 GoSliceDataType []*table<string,float64>.array
-      GroupType: 164 StructureType noalg.map.group[string]float64
-    - __kind: PointerType
-      ID: 159
-      Name: '**table<string,float64>'
-      ByteSize: 8
-      Pointee: 160 PointerType *table<string,float64>
-    - __kind: PointerType
-      ID: 160
-      Name: '*table<string,float64>'
-      ByteSize: 8
-      Pointee: 161 StructureType table<string,float64>
-    - __kind: StructureType
-      ID: 161
-      Name: table<string,float64>
-      ByteSize: 32
-      GoKind: 25
-      RawFields:
-        - Name: used
-          Offset: 0
-          Type: 22 BaseType uint16
-        - Name: capacity
-          Offset: 2
-          Type: 22 BaseType uint16
-        - Name: growthLeft
-          Offset: 4
-          Type: 22 BaseType uint16
-        - Name: localDepth
-          Offset: 6
-          Type: 7 BaseType uint8
-        - Name: index
-          Offset: 8
-          Type: 8 BaseType int
-        - Name: groups
-          Offset: 16
-          Type: 162 GoSwissMapGroupsType groupReference<string,float64>
-    - __kind: GoSwissMapGroupsType
-      ID: 162
-      Name: groupReference<string,float64>
-      ByteSize: 16
-      GoKind: 25
-      RawFields:
-        - Name: data
-          Offset: 0
-          Type: 163 PointerType *noalg.map.group[string]float64
-        - Name: lengthMask
-          Offset: 8
-          Type: 17 BaseType uint64
-      GroupType: 164 StructureType noalg.map.group[string]float64
-      GroupSliceType: 283 GoSliceDataType []noalg.map.group[string]float64.array
-    - __kind: PointerType
-      ID: 163
-      Name: '*noalg.map.group[string]float64'
-      ByteSize: 8
-      Pointee: 164 StructureType noalg.map.group[string]float64
-    - __kind: StructureType
-      ID: 164
-      Name: noalg.map.group[string]float64
-      ByteSize: 200
-      GoRuntimeType: 1.331744e+06
-      GoKind: 25
-      RawFields:
-        - Name: ctrl
-          Offset: 0
-          Type: 17 BaseType uint64
-        - Name: slots
-          Offset: 8
-          Type: 165 ArrayType noalg.[8]struct { key string; elem float64 }
-    - __kind: ArrayType
-      ID: 165
-      Name: noalg.[8]struct { key string; elem float64 }
-      ByteSize: 192
-      GoRuntimeType: 715232
-      GoKind: 17
-      Count: 8
-      HasCount: true
-      Element: 166 StructureType noalg.struct { key string; elem float64 }
-    - __kind: StructureType
-      ID: 166
-      Name: noalg.struct { key string; elem float64 }
-      ByteSize: 24
-      GoRuntimeType: 1.331616e+06
-      GoKind: 25
-      RawFields:
-        - Name: key
-          Offset: 0
-          Type: 5 GoStringHeaderType string
-        - Name: elem
-          Offset: 16
-          Type: 167 BaseType float64
-    - __kind: BaseType
-      ID: 167
-      Name: float64
-      ByteSize: 8
-      GoRuntimeType: 595168
-      GoKind: 14
-    - __kind: GoSliceHeaderType
-      ID: 168
-      Name: '[]github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink'
-      ByteSize: 24
-      GoRuntimeType: 494784
-      GoKind: 23
-      RawFields:
-        - Name: array
-          Offset: 0
-          Type: 169 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink
-        - Name: len
-          Offset: 8
-          Type: 8 BaseType int
-        - Name: cap
-          Offset: 16
-          Type: 8 BaseType int
-      Data: 284 GoSliceDataType []github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink.array
-    - __kind: PointerType
-      ID: 169
-      Name: '*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink'
-      ByteSize: 8
-      GoRuntimeType: 1.21456e+06
-      GoKind: 22
-      Pointee: 170 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink
-    - __kind: StructureType
-      ID: 170
-      Name: github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink
-      ByteSize: 56
-      GoRuntimeType: 1.955616e+06
-      GoKind: 25
-      RawFields:
-        - Name: TraceID
-          Offset: 0
-          Type: 17 BaseType uint64
-        - Name: TraceIDHigh
-          Offset: 8
-          Type: 17 BaseType uint64
-        - Name: SpanID
-          Offset: 16
-          Type: 17 BaseType uint64
-        - Name: Attributes
-          Offset: 24
-          Type: 124 GoMapType map[string]string
-        - Name: Tracestate
-          Offset: 32
-          Type: 5 GoStringHeaderType string
-        - Name: Flags
-          Offset: 48
-          Type: 142 BaseType uint32
-    - __kind: GoSliceHeaderType
-      ID: 171
-      Name: '[]github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent'
-      ByteSize: 24
-      GoRuntimeType: 494976
-      GoKind: 23
-      RawFields:
-        - Name: array
-          Offset: 0
-          Type: 172 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent
-        - Name: len
-          Offset: 8
-          Type: 8 BaseType int
-        - Name: cap
-          Offset: 16
-          Type: 8 BaseType int
-      Data: 286 GoSliceDataType []github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent.array
-    - __kind: PointerType
-      ID: 172
-      Name: '*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent'
-      ByteSize: 8
-      GoRuntimeType: 1.214688e+06
-      GoKind: 22
-      Pointee: 173 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent
-    - __kind: StructureType
-      ID: 173
-      Name: github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent
-      ByteSize: 40
-      GoRuntimeType: 1.789664e+06
-      GoKind: 25
-      RawFields:
-        - Name: Name
-          Offset: 0
-          Type: 5 GoStringHeaderType string
-        - Name: TimeUnixNano
-          Offset: 16
-          Type: 17 BaseType uint64
-        - Name: Attributes
-          Offset: 24
-          Type: 174 GoMapType map[string]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
-        - Name: RawAttributes
-          Offset: 32
-          Type: 195 GoMapType map[string]interface {}
-    - __kind: GoMapType
-      ID: 174
-      Name: map[string]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
-      ByteSize: 8
-      GoRuntimeType: 1.158336e+06
-      GoKind: 21
-      HeaderType: 176 GoSwissMapHeaderType map<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
-    - __kind: PointerType
-      ID: 175
-      Name: '*map<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>'
-      ByteSize: 8
-      Pointee: 176 GoSwissMapHeaderType map<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
-    - __kind: GoSwissMapHeaderType
-      ID: 176
-      Name: map<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
-      ByteSize: 48
-      GoKind: 25
-      RawFields:
-        - Name: used
-          Offset: 0
-          Type: 17 BaseType uint64
-        - Name: seed
-          Offset: 8
-          Type: 18 BaseType uintptr
-        - Name: dirPtr
-          Offset: 16
-          Type: 177 PointerType **table<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
-        - Name: dirLen
-          Offset: 24
-          Type: 8 BaseType int
-        - Name: globalDepth
-          Offset: 32
-          Type: 7 BaseType uint8
-        - Name: globalShift
-          Offset: 33
-          Type: 7 BaseType uint8
-        - Name: writing
-          Offset: 34
-          Type: 7 BaseType uint8
-        - Name: tombstonePossible
-          Offset: 35
-          Type: 13 BaseType bool
-        - Name: clearSeq
-          Offset: 40
-          Type: 17 BaseType uint64
-      TablePtrSliceType: 288 GoSliceDataType []*table<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>.array
-      GroupType: 182 StructureType noalg.map.group[string]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
-    - __kind: PointerType
-      ID: 177
-      Name: '**table<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>'
-      ByteSize: 8
-      Pointee: 178 PointerType *table<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
-    - __kind: PointerType
-      ID: 178
-      Name: '*table<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>'
-      ByteSize: 8
-      Pointee: 179 StructureType table<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
-    - __kind: StructureType
-      ID: 179
-      Name: table<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
-      ByteSize: 32
-      GoKind: 25
-      RawFields:
-        - Name: used
-          Offset: 0
-          Type: 22 BaseType uint16
-        - Name: capacity
-          Offset: 2
-          Type: 22 BaseType uint16
-        - Name: growthLeft
-          Offset: 4
-          Type: 22 BaseType uint16
-        - Name: localDepth
-          Offset: 6
-          Type: 7 BaseType uint8
-        - Name: index
-          Offset: 8
-          Type: 8 BaseType int
-        - Name: groups
-          Offset: 16
-          Type: 180 GoSwissMapGroupsType groupReference<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
-    - __kind: GoSwissMapGroupsType
-      ID: 180
-      Name: groupReference<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
-      ByteSize: 16
-      GoKind: 25
-      RawFields:
-        - Name: data
-          Offset: 0
-          Type: 181 PointerType *noalg.map.group[string]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
-        - Name: lengthMask
-          Offset: 8
-          Type: 17 BaseType uint64
-      GroupType: 182 StructureType noalg.map.group[string]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
-      GroupSliceType: 289 GoSliceDataType []noalg.map.group[string]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute.array
-    - __kind: PointerType
-      ID: 181
-      Name: '*noalg.map.group[string]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute'
-      ByteSize: 8
-      Pointee: 182 StructureType noalg.map.group[string]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
-    - __kind: StructureType
-      ID: 182
-      Name: noalg.map.group[string]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
-      ByteSize: 200
-      GoRuntimeType: 1.332e+06
-      GoKind: 25
-      RawFields:
-        - Name: ctrl
-          Offset: 0
-          Type: 17 BaseType uint64
-        - Name: slots
-          Offset: 8
-          Type: 183 ArrayType noalg.[8]struct { key string; elem *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute }
-    - __kind: ArrayType
-      ID: 183
-      Name: noalg.[8]struct { key string; elem *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute }
-      ByteSize: 192
-      GoRuntimeType: 715328
-      GoKind: 17
-      Count: 8
-      HasCount: true
-      Element: 184 StructureType noalg.struct { key string; elem *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute }
-    - __kind: StructureType
-      ID: 184
-      Name: noalg.struct { key string; elem *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute }
-      ByteSize: 24
-      GoRuntimeType: 1.331872e+06
-      GoKind: 25
-      RawFields:
-        - Name: key
-          Offset: 0
-          Type: 5 GoStringHeaderType string
-        - Name: elem
-          Offset: 16
-          Type: 185 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
-    - __kind: PointerType
-      ID: 185
-      Name: '*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute'
-      ByteSize: 8
-      GoRuntimeType: 1.215456e+06
-      GoKind: 22
-      Pointee: 186 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
-    - __kind: StructureType
-      ID: 186
-      Name: github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
-      ByteSize: 56
-      GoRuntimeType: 1.955872e+06
-      GoKind: 25
-      RawFields:
-        - Name: Type
-          Offset: 0
-          Type: 187 BaseType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttributeType
-        - Name: StringValue
-          Offset: 8
-          Type: 5 GoStringHeaderType string
-        - Name: BoolValue
-          Offset: 24
-          Type: 13 BaseType bool
-        - Name: IntValue
-          Offset: 32
-          Type: 32 BaseType int64
-        - Name: DoubleValue
-          Offset: 40
-          Type: 167 BaseType float64
-        - Name: ArrayValue
-          Offset: 48
-          Type: 188 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttribute
-    - __kind: BaseType
-      ID: 187
-      Name: github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttributeType
-      ByteSize: 4
-      GoRuntimeType: 1.00672e+06
-      GoKind: 5
-    - __kind: PointerType
-      ID: 188
-      Name: '*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttribute'
-      ByteSize: 8
-      GoRuntimeType: 1.215328e+06
-      GoKind: 22
-      Pointee: 189 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttribute
-    - __kind: StructureType
-      ID: 189
-      Name: github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttribute
-      ByteSize: 24
-      GoRuntimeType: 1.2152e+06
-      GoKind: 25
-      RawFields:
-        - Name: Values
-          Offset: 0
-          Type: 190 GoSliceHeaderType []*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttributeValue
-    - __kind: GoSliceHeaderType
-      ID: 190
-      Name: '[]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttributeValue'
-      ByteSize: 24
-      GoRuntimeType: 494848
-      GoKind: 23
-      RawFields:
-        - Name: array
-          Offset: 0
-          Type: 191 PointerType **github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttributeValue
-        - Name: len
-          Offset: 8
-          Type: 8 BaseType int
-        - Name: cap
-          Offset: 16
-          Type: 8 BaseType int
-      Data: 290 GoSliceDataType []*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttributeValue.array
-    - __kind: PointerType
-      ID: 191
-      Name: '**github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttributeValue'
-      ByteSize: 8
-      GoKind: 22
-      Pointee: 192 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttributeValue
-    - __kind: PointerType
-      ID: 192
-      Name: '*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttributeValue'
-      ByteSize: 8
-      GoRuntimeType: 1.215072e+06
-      GoKind: 22
-      Pointee: 193 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttributeValue
-    - __kind: StructureType
-      ID: 193
-      Name: github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttributeValue
-      ByteSize: 48
-      GoRuntimeType: 1.878752e+06
-      GoKind: 25
-      RawFields:
-        - Name: Type
-          Offset: 0
-          Type: 194 BaseType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttributeValueType
-        - Name: StringValue
-          Offset: 8
-          Type: 5 GoStringHeaderType string
-        - Name: BoolValue
-          Offset: 24
-          Type: 13 BaseType bool
-        - Name: IntValue
-          Offset: 32
-          Type: 32 BaseType int64
-        - Name: DoubleValue
-          Offset: 40
-          Type: 167 BaseType float64
-    - __kind: BaseType
-      ID: 194
-      Name: github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttributeValueType
-      ByteSize: 4
-      GoRuntimeType: 1.006816e+06
-      GoKind: 5
-    - __kind: GoMapType
-      ID: 195
-      Name: map[string]interface {}
-      ByteSize: 8
-      GoRuntimeType: 1.151808e+06
-      GoKind: 21
-      HeaderType: 147 GoSwissMapHeaderType map<string,interface {}>
-    - __kind: PointerType
-      ID: 196
-      Name: '*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanContext'
-      ByteSize: 8
-      GoRuntimeType: 2.054336e+06
-      GoKind: 22
-      Pointee: 197 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanContext
-    - __kind: StructureType
       ID: 197
       Name: github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanContext
       ByteSize: 168
@@ -2829,13 +1923,132 @@ Types:
         - Name: baggageOnly
           Offset: 160
           Type: 13 BaseType bool
-    - __kind: PointerType
-      ID: 198
-      Name: '*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.trace'
+    - __kind: StructureType
+      ID: 170
+      Name: github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink
+      ByteSize: 56
+      GoRuntimeType: 1.955616e+06
+      GoKind: 25
+      RawFields:
+        - Name: TraceID
+          Offset: 0
+          Type: 17 BaseType uint64
+        - Name: TraceIDHigh
+          Offset: 8
+          Type: 17 BaseType uint64
+        - Name: SpanID
+          Offset: 16
+          Type: 17 BaseType uint64
+        - Name: Attributes
+          Offset: 24
+          Type: 124 GoMapType map[string]string
+        - Name: Tracestate
+          Offset: 32
+          Type: 5 GoStringHeaderType string
+        - Name: Flags
+          Offset: 48
+          Type: 142 BaseType uint32
+    - __kind: GoMapType
+      ID: 145
+      Name: github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.metaStructMap
       ByteSize: 8
-      GoRuntimeType: 2.277568e+06
-      GoKind: 22
-      Pointee: 199 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.trace
+      GoRuntimeType: 1.30448e+06
+      GoKind: 21
+      HeaderType: 147 GoSwissMapHeaderType map<string,interface {}>
+    - __kind: BaseType
+      ID: 203
+      Name: github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.samplingDecision
+      ByteSize: 4
+      GoRuntimeType: 594016
+      GoKind: 10
+    - __kind: StructureType
+      ID: 173
+      Name: github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent
+      ByteSize: 40
+      GoRuntimeType: 1.789664e+06
+      GoKind: 25
+      RawFields:
+        - Name: Name
+          Offset: 0
+          Type: 5 GoStringHeaderType string
+        - Name: TimeUnixNano
+          Offset: 16
+          Type: 17 BaseType uint64
+        - Name: Attributes
+          Offset: 24
+          Type: 174 GoMapType map[string]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
+        - Name: RawAttributes
+          Offset: 32
+          Type: 195 GoMapType map[string]interface {}
+    - __kind: StructureType
+      ID: 189
+      Name: github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttribute
+      ByteSize: 24
+      GoRuntimeType: 1.2152e+06
+      GoKind: 25
+      RawFields:
+        - Name: Values
+          Offset: 0
+          Type: 190 GoSliceHeaderType []*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttributeValue
+    - __kind: StructureType
+      ID: 193
+      Name: github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttributeValue
+      ByteSize: 48
+      GoRuntimeType: 1.878752e+06
+      GoKind: 25
+      RawFields:
+        - Name: Type
+          Offset: 0
+          Type: 194 BaseType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttributeValueType
+        - Name: StringValue
+          Offset: 8
+          Type: 5 GoStringHeaderType string
+        - Name: BoolValue
+          Offset: 24
+          Type: 13 BaseType bool
+        - Name: IntValue
+          Offset: 32
+          Type: 32 BaseType int64
+        - Name: DoubleValue
+          Offset: 40
+          Type: 167 BaseType float64
+    - __kind: BaseType
+      ID: 194
+      Name: github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttributeValueType
+      ByteSize: 4
+      GoRuntimeType: 1.006816e+06
+      GoKind: 5
+    - __kind: StructureType
+      ID: 186
+      Name: github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
+      ByteSize: 56
+      GoRuntimeType: 1.955872e+06
+      GoKind: 25
+      RawFields:
+        - Name: Type
+          Offset: 0
+          Type: 187 BaseType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttributeType
+        - Name: StringValue
+          Offset: 8
+          Type: 5 GoStringHeaderType string
+        - Name: BoolValue
+          Offset: 24
+          Type: 13 BaseType bool
+        - Name: IntValue
+          Offset: 32
+          Type: 32 BaseType int64
+        - Name: DoubleValue
+          Offset: 40
+          Type: 167 BaseType float64
+        - Name: ArrayValue
+          Offset: 48
+          Type: 188 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttribute
+    - __kind: BaseType
+      ID: 187
+      Name: github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttributeType
+      ByteSize: 4
+      GoRuntimeType: 1.00672e+06
+      GoKind: 5
     - __kind: StructureType
       ID: 199
       Name: github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.trace
@@ -2873,42 +2086,6 @@ Types:
         - Name: root
           Offset: 96
           Type: 135 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span
-    - __kind: GoSliceHeaderType
-      ID: 200
-      Name: '[]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span'
-      ByteSize: 24
-      GoRuntimeType: 495232
-      GoKind: 23
-      RawFields:
-        - Name: array
-          Offset: 0
-          Type: 201 PointerType **github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span
-        - Name: len
-          Offset: 8
-          Type: 8 BaseType int
-        - Name: cap
-          Offset: 16
-          Type: 8 BaseType int
-      Data: 292 GoSliceDataType []*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span.array
-    - __kind: PointerType
-      ID: 201
-      Name: '**github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span'
-      ByteSize: 8
-      GoKind: 22
-      Pointee: 135 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span
-    - __kind: PointerType
-      ID: 202
-      Name: '*float64'
-      ByteSize: 8
-      GoRuntimeType: 405408
-      GoKind: 22
-      Pointee: 167 BaseType float64
-    - __kind: BaseType
-      ID: 203
-      Name: github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.samplingDecision
-      ByteSize: 4
-      GoRuntimeType: 594016
-      GoKind: 10
     - __kind: ArrayType
       ID: 204
       Name: github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.traceID
@@ -2918,53 +2095,151 @@ Types:
       Count: 16
       HasCount: true
       Element: 7 BaseType uint8
-    - __kind: GoSubroutineType
-      ID: 205
-      Name: func()
-      ByteSize: 8
-      GoRuntimeType: 484960
-      GoKind: 19
-    - __kind: PointerType
-      ID: 206
-      Name: '*bytes.Buffer'
-      ByteSize: 8
-      GoRuntimeType: 2.321376e+06
-      GoKind: 22
-      Pointee: 207 StructureType bytes.Buffer
-    - __kind: StructureType
-      ID: 207
-      Name: bytes.Buffer
-      ByteSize: 40
-      GoRuntimeType: 1.640384e+06
+    - __kind: GoSwissMapGroupsType
+      ID: 180
+      Name: groupReference<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
+      ByteSize: 16
       GoKind: 25
       RawFields:
-        - Name: buf
+        - Name: data
           Offset: 0
-          Type: 53 GoSliceHeaderType []uint8
-        - Name: off
-          Offset: 24
-          Type: 8 BaseType int
-        - Name: lastRead
-          Offset: 32
-          Type: 208 BaseType bytes.readOp
-    - __kind: BaseType
-      ID: 208
-      Name: bytes.readOp
-      ByteSize: 1
-      GoRuntimeType: 593440
-      GoKind: 3
-    - __kind: PointerType
-      ID: 209
-      Name: '*bool'
-      ByteSize: 8
-      GoRuntimeType: 405472
-      GoKind: 22
-      Pointee: 13 BaseType bool
-    - __kind: GoInterfaceType
-      ID: 210
-      Name: error
+          Type: 181 PointerType *noalg.map.group[string]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
+        - Name: lengthMask
+          Offset: 8
+          Type: 17 BaseType uint64
+      GroupType: 182 StructureType noalg.map.group[string]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
+      GroupSliceType: 289 GoSliceDataType []noalg.map.group[string]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute.array
+    - __kind: GoSwissMapGroupsType
+      ID: 43
+      Name: groupReference<string,[]*mime/multipart.FileHeader>
       ByteSize: 16
-      GoRuntimeType: 1.054304e+06
+      GoKind: 25
+      RawFields:
+        - Name: data
+          Offset: 0
+          Type: 44 PointerType *noalg.map.group[string][]*mime/multipart.FileHeader
+        - Name: lengthMask
+          Offset: 8
+          Type: 17 BaseType uint64
+      GroupType: 45 StructureType noalg.map.group[string][]*mime/multipart.FileHeader
+      GroupSliceType: 235 GoSliceDataType []noalg.map.group[string][]*mime/multipart.FileHeader.array
+    - __kind: GoSwissMapGroupsType
+      ID: 23
+      Name: groupReference<string,[]string>
+      ByteSize: 16
+      GoKind: 25
+      RawFields:
+        - Name: data
+          Offset: 0
+          Type: 24 PointerType *noalg.map.group[string][]string
+        - Name: lengthMask
+          Offset: 8
+          Type: 17 BaseType uint64
+      GroupType: 25 StructureType noalg.map.group[string][]string
+      GroupSliceType: 231 GoSliceDataType []noalg.map.group[string][]string.array
+    - __kind: GoSwissMapGroupsType
+      ID: 162
+      Name: groupReference<string,float64>
+      ByteSize: 16
+      GoKind: 25
+      RawFields:
+        - Name: data
+          Offset: 0
+          Type: 163 PointerType *noalg.map.group[string]float64
+        - Name: lengthMask
+          Offset: 8
+          Type: 17 BaseType uint64
+      GroupType: 164 StructureType noalg.map.group[string]float64
+      GroupSliceType: 283 GoSliceDataType []noalg.map.group[string]float64.array
+    - __kind: GoSwissMapGroupsType
+      ID: 151
+      Name: groupReference<string,interface {}>
+      ByteSize: 16
+      GoKind: 25
+      RawFields:
+        - Name: data
+          Offset: 0
+          Type: 152 PointerType *noalg.map.group[string]interface {}
+        - Name: lengthMask
+          Offset: 8
+          Type: 17 BaseType uint64
+      GroupType: 153 StructureType noalg.map.group[string]interface {}
+      GroupSliceType: 281 GoSliceDataType []noalg.map.group[string]interface {}.array
+    - __kind: GoSwissMapGroupsType
+      ID: 130
+      Name: groupReference<string,string>
+      ByteSize: 16
+      GoKind: 25
+      RawFields:
+        - Name: data
+          Offset: 0
+          Type: 131 PointerType *noalg.map.group[string]string
+        - Name: lengthMask
+          Offset: 8
+          Type: 17 BaseType uint64
+      GroupType: 132 StructureType noalg.map.group[string]string
+      GroupSliceType: 279 GoSliceDataType []noalg.map.group[string]string.array
+    - __kind: BaseType
+      ID: 8
+      Name: int
+      ByteSize: 8
+      GoRuntimeType: 594784
+      GoKind: 2
+    - __kind: BaseType
+      ID: 223
+      Name: int16
+      ByteSize: 2
+      GoRuntimeType: 594400
+      GoKind: 4
+    - __kind: BaseType
+      ID: 141
+      Name: int32
+      ByteSize: 4
+      GoRuntimeType: 594528
+      GoKind: 5
+    - __kind: BaseType
+      ID: 32
+      Name: int64
+      ByteSize: 8
+      GoRuntimeType: 594656
+      GoKind: 6
+    - __kind: BaseType
+      ID: 211
+      Name: int8
+      ByteSize: 1
+      GoRuntimeType: 594272
+      GoKind: 3
+    - __kind: GoEmptyInterfaceType
+      ID: 63
+      Name: interface {}
+      ByteSize: 16
+      GoRuntimeType: 867104
+      GoKind: 20
+      RawFields:
+        - Name: _type
+          Offset: 0
+          Type: 2 VoidPointerType unsafe.Pointer
+        - Name: data
+          Offset: 8
+          Type: 2 VoidPointerType unsafe.Pointer
+    - __kind: StructureType
+      ID: 140
+      Name: internal/sync.Mutex
+      ByteSize: 8
+      GoRuntimeType: 1.518176e+06
+      GoKind: 25
+      RawFields:
+        - Name: state
+          Offset: 0
+          Type: 141 BaseType int32
+        - Name: sema
+          Offset: 4
+          Type: 142 BaseType uint32
+    - __kind: GoInterfaceType
+      ID: 30
+      Name: io.ReadCloser
+      ByteSize: 16
+      GoRuntimeType: 1.135168e+06
       GoKind: 20
       RawFields:
         - Name: tab
@@ -2973,12 +2248,1170 @@ Types:
         - Name: data
           Offset: 8
           Type: 2 VoidPointerType unsafe.Pointer
+    - __kind: GoSwissMapHeaderType
+      ID: 176
+      Name: map<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
+      ByteSize: 48
+      GoKind: 25
+      RawFields:
+        - Name: used
+          Offset: 0
+          Type: 17 BaseType uint64
+        - Name: seed
+          Offset: 8
+          Type: 18 BaseType uintptr
+        - Name: dirPtr
+          Offset: 16
+          Type: 177 PointerType **table<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
+        - Name: dirLen
+          Offset: 24
+          Type: 8 BaseType int
+        - Name: globalDepth
+          Offset: 32
+          Type: 7 BaseType uint8
+        - Name: globalShift
+          Offset: 33
+          Type: 7 BaseType uint8
+        - Name: writing
+          Offset: 34
+          Type: 7 BaseType uint8
+        - Name: tombstonePossible
+          Offset: 35
+          Type: 13 BaseType bool
+        - Name: clearSeq
+          Offset: 40
+          Type: 17 BaseType uint64
+      TablePtrSliceType: 288 GoSliceDataType []*table<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>.array
+      GroupType: 182 StructureType noalg.map.group[string]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
+    - __kind: GoSwissMapHeaderType
+      ID: 39
+      Name: map<string,[]*mime/multipart.FileHeader>
+      ByteSize: 48
+      GoKind: 25
+      RawFields:
+        - Name: used
+          Offset: 0
+          Type: 17 BaseType uint64
+        - Name: seed
+          Offset: 8
+          Type: 18 BaseType uintptr
+        - Name: dirPtr
+          Offset: 16
+          Type: 40 PointerType **table<string,[]*mime/multipart.FileHeader>
+        - Name: dirLen
+          Offset: 24
+          Type: 8 BaseType int
+        - Name: globalDepth
+          Offset: 32
+          Type: 7 BaseType uint8
+        - Name: globalShift
+          Offset: 33
+          Type: 7 BaseType uint8
+        - Name: writing
+          Offset: 34
+          Type: 7 BaseType uint8
+        - Name: tombstonePossible
+          Offset: 35
+          Type: 13 BaseType bool
+        - Name: clearSeq
+          Offset: 40
+          Type: 17 BaseType uint64
+      TablePtrSliceType: 234 GoSliceDataType []*table<string,[]*mime/multipart.FileHeader>.array
+      GroupType: 45 StructureType noalg.map.group[string][]*mime/multipart.FileHeader
+    - __kind: GoSwissMapHeaderType
+      ID: 16
+      Name: map<string,[]string>
+      ByteSize: 48
+      GoKind: 25
+      RawFields:
+        - Name: used
+          Offset: 0
+          Type: 17 BaseType uint64
+        - Name: seed
+          Offset: 8
+          Type: 18 BaseType uintptr
+        - Name: dirPtr
+          Offset: 16
+          Type: 19 PointerType **table<string,[]string>
+        - Name: dirLen
+          Offset: 24
+          Type: 8 BaseType int
+        - Name: globalDepth
+          Offset: 32
+          Type: 7 BaseType uint8
+        - Name: globalShift
+          Offset: 33
+          Type: 7 BaseType uint8
+        - Name: writing
+          Offset: 34
+          Type: 7 BaseType uint8
+        - Name: tombstonePossible
+          Offset: 35
+          Type: 13 BaseType bool
+        - Name: clearSeq
+          Offset: 40
+          Type: 17 BaseType uint64
+      TablePtrSliceType: 230 GoSliceDataType []*table<string,[]string>.array
+      GroupType: 25 StructureType noalg.map.group[string][]string
+    - __kind: GoSwissMapHeaderType
+      ID: 158
+      Name: map<string,float64>
+      ByteSize: 48
+      GoKind: 25
+      RawFields:
+        - Name: used
+          Offset: 0
+          Type: 17 BaseType uint64
+        - Name: seed
+          Offset: 8
+          Type: 18 BaseType uintptr
+        - Name: dirPtr
+          Offset: 16
+          Type: 159 PointerType **table<string,float64>
+        - Name: dirLen
+          Offset: 24
+          Type: 8 BaseType int
+        - Name: globalDepth
+          Offset: 32
+          Type: 7 BaseType uint8
+        - Name: globalShift
+          Offset: 33
+          Type: 7 BaseType uint8
+        - Name: writing
+          Offset: 34
+          Type: 7 BaseType uint8
+        - Name: tombstonePossible
+          Offset: 35
+          Type: 13 BaseType bool
+        - Name: clearSeq
+          Offset: 40
+          Type: 17 BaseType uint64
+      TablePtrSliceType: 282 GoSliceDataType []*table<string,float64>.array
+      GroupType: 164 StructureType noalg.map.group[string]float64
+    - __kind: GoSwissMapHeaderType
+      ID: 147
+      Name: map<string,interface {}>
+      ByteSize: 48
+      GoKind: 25
+      RawFields:
+        - Name: used
+          Offset: 0
+          Type: 17 BaseType uint64
+        - Name: seed
+          Offset: 8
+          Type: 18 BaseType uintptr
+        - Name: dirPtr
+          Offset: 16
+          Type: 148 PointerType **table<string,interface {}>
+        - Name: dirLen
+          Offset: 24
+          Type: 8 BaseType int
+        - Name: globalDepth
+          Offset: 32
+          Type: 7 BaseType uint8
+        - Name: globalShift
+          Offset: 33
+          Type: 7 BaseType uint8
+        - Name: writing
+          Offset: 34
+          Type: 7 BaseType uint8
+        - Name: tombstonePossible
+          Offset: 35
+          Type: 13 BaseType bool
+        - Name: clearSeq
+          Offset: 40
+          Type: 17 BaseType uint64
+      TablePtrSliceType: 280 GoSliceDataType []*table<string,interface {}>.array
+      GroupType: 153 StructureType noalg.map.group[string]interface {}
+    - __kind: GoSwissMapHeaderType
+      ID: 126
+      Name: map<string,string>
+      ByteSize: 48
+      GoKind: 25
+      RawFields:
+        - Name: used
+          Offset: 0
+          Type: 17 BaseType uint64
+        - Name: seed
+          Offset: 8
+          Type: 18 BaseType uintptr
+        - Name: dirPtr
+          Offset: 16
+          Type: 127 PointerType **table<string,string>
+        - Name: dirLen
+          Offset: 24
+          Type: 8 BaseType int
+        - Name: globalDepth
+          Offset: 32
+          Type: 7 BaseType uint8
+        - Name: globalShift
+          Offset: 33
+          Type: 7 BaseType uint8
+        - Name: writing
+          Offset: 34
+          Type: 7 BaseType uint8
+        - Name: tombstonePossible
+          Offset: 35
+          Type: 13 BaseType bool
+        - Name: clearSeq
+          Offset: 40
+          Type: 17 BaseType uint64
+      TablePtrSliceType: 278 GoSliceDataType []*table<string,string>.array
+      GroupType: 132 StructureType noalg.map.group[string]string
+    - __kind: GoMapType
+      ID: 174
+      Name: map[string]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
+      ByteSize: 8
+      GoRuntimeType: 1.158336e+06
+      GoKind: 21
+      HeaderType: 176 GoSwissMapHeaderType map<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
+    - __kind: GoMapType
+      ID: 37
+      Name: map[string][]*mime/multipart.FileHeader
+      ByteSize: 8
+      GoRuntimeType: 1.157568e+06
+      GoKind: 21
+      HeaderType: 39 GoSwissMapHeaderType map<string,[]*mime/multipart.FileHeader>
+    - __kind: GoMapType
+      ID: 36
+      Name: map[string][]string
+      ByteSize: 8
+      GoRuntimeType: 1.153216e+06
+      GoKind: 21
+      HeaderType: 16 GoSwissMapHeaderType map<string,[]string>
+    - __kind: GoMapType
+      ID: 156
+      Name: map[string]float64
+      ByteSize: 8
+      GoRuntimeType: 1.158208e+06
+      GoKind: 21
+      HeaderType: 158 GoSwissMapHeaderType map<string,float64>
+    - __kind: GoMapType
+      ID: 195
+      Name: map[string]interface {}
+      ByteSize: 8
+      GoRuntimeType: 1.151808e+06
+      GoKind: 21
+      HeaderType: 147 GoSwissMapHeaderType map<string,interface {}>
+    - __kind: GoMapType
+      ID: 124
+      Name: map[string]string
+      ByteSize: 8
+      GoRuntimeType: 1.15424e+06
+      GoKind: 21
+      HeaderType: 126 GoSwissMapHeaderType map<string,string>
+    - __kind: StructureType
+      ID: 65
+      Name: math/big.Int
+      ByteSize: 32
+      GoRuntimeType: 1.523456e+06
+      GoKind: 25
+      RawFields:
+        - Name: neg
+          Offset: 0
+          Type: 13 BaseType bool
+        - Name: abs
+          Offset: 8
+          Type: 66 GoSliceHeaderType math/big.nat
     - __kind: BaseType
-      ID: 211
-      Name: int8
-      ByteSize: 1
-      GoRuntimeType: 594272
-      GoKind: 3
+      ID: 68
+      Name: math/big.Word
+      ByteSize: 8
+      GoRuntimeType: 598496
+      GoKind: 7
+    - __kind: GoSliceHeaderType
+      ID: 66
+      Name: math/big.nat
+      ByteSize: 24
+      GoRuntimeType: 2.426912e+06
+      GoKind: 23
+      RawFields:
+        - Name: array
+          Offset: 0
+          Type: 67 PointerType *math/big.Word
+        - Name: len
+          Offset: 8
+          Type: 8 BaseType int
+        - Name: cap
+          Offset: 16
+          Type: 8 BaseType int
+      Data: 242 GoSliceDataType math/big.nat.array
+    - __kind: GoSliceDataType
+      ID: 242
+      Name: math/big.nat.array
+      ByteSize: 2048
+      Element: 68 BaseType math/big.Word
+    - __kind: StructureType
+      ID: 51
+      Name: mime/multipart.FileHeader
+      ByteSize: 88
+      GoRuntimeType: 2.018784e+06
+      GoKind: 25
+      RawFields:
+        - Name: Filename
+          Offset: 0
+          Type: 5 GoStringHeaderType string
+        - Name: Header
+          Offset: 16
+          Type: 52 GoMapType net/textproto.MIMEHeader
+        - Name: Size
+          Offset: 24
+          Type: 32 BaseType int64
+        - Name: content
+          Offset: 32
+          Type: 53 GoSliceHeaderType []uint8
+        - Name: tmpfile
+          Offset: 56
+          Type: 5 GoStringHeaderType string
+        - Name: tmpoff
+          Offset: 72
+          Type: 32 BaseType int64
+        - Name: tmpshared
+          Offset: 80
+          Type: 13 BaseType bool
+    - __kind: StructureType
+      ID: 35
+      Name: mime/multipart.Form
+      ByteSize: 16
+      GoRuntimeType: 1.506656e+06
+      GoKind: 25
+      RawFields:
+        - Name: Value
+          Offset: 0
+          Type: 36 GoMapType map[string][]string
+        - Name: File
+          Offset: 8
+          Type: 37 GoMapType map[string][]*mime/multipart.FileHeader
+    - __kind: GoSliceHeaderType
+      ID: 95
+      Name: net.IP
+      ByteSize: 24
+      GoRuntimeType: 2.178944e+06
+      GoKind: 23
+      RawFields:
+        - Name: array
+          Offset: 0
+          Type: 6 PointerType *uint8
+        - Name: len
+          Offset: 8
+          Type: 8 BaseType int
+        - Name: cap
+          Offset: 16
+          Type: 8 BaseType int
+      Data: 260 GoSliceDataType net.IP.array
+    - __kind: GoSliceDataType
+      ID: 260
+      Name: net.IP.array
+      ByteSize: 2048
+      Element: 7 BaseType uint8
+    - __kind: GoSliceHeaderType
+      ID: 102
+      Name: net.IPMask
+      ByteSize: 24
+      GoRuntimeType: 1.042272e+06
+      GoKind: 23
+      RawFields:
+        - Name: array
+          Offset: 0
+          Type: 6 PointerType *uint8
+        - Name: len
+          Offset: 8
+          Type: 8 BaseType int
+        - Name: cap
+          Offset: 16
+          Type: 8 BaseType int
+      Data: 266 GoSliceDataType net.IPMask.array
+    - __kind: GoSliceDataType
+      ID: 266
+      Name: net.IPMask.array
+      ByteSize: 2048
+      Element: 7 BaseType uint8
+    - __kind: StructureType
+      ID: 101
+      Name: net.IPNet
+      ByteSize: 48
+      GoRuntimeType: 1.486976e+06
+      GoKind: 25
+      RawFields:
+        - Name: IP
+          Offset: 0
+          Type: 95 GoSliceHeaderType net.IP
+        - Name: Mask
+          Offset: 24
+          Type: 102 GoSliceHeaderType net.IPMask
+    - __kind: GoMapType
+      ID: 14
+      Name: net/http.Header
+      ByteSize: 8
+      GoRuntimeType: 2.15504e+06
+      GoKind: 21
+      HeaderType: 16 GoSwissMapHeaderType map<string,[]string>
+    - __kind: StructureType
+      ID: 4
+      Name: net/http.Request
+      ByteSize: 304
+      GoRuntimeType: 2.401888e+06
+      GoKind: 25
+      RawFields:
+        - Name: Method
+          Offset: 0
+          Type: 5 GoStringHeaderType string
+        - Name: URL
+          Offset: 16
+          Type: 9 PointerType *net/url.URL
+        - Name: Proto
+          Offset: 24
+          Type: 5 GoStringHeaderType string
+        - Name: ProtoMajor
+          Offset: 40
+          Type: 8 BaseType int
+        - Name: ProtoMinor
+          Offset: 48
+          Type: 8 BaseType int
+        - Name: Header
+          Offset: 56
+          Type: 14 GoMapType net/http.Header
+        - Name: Body
+          Offset: 64
+          Type: 30 GoInterfaceType io.ReadCloser
+        - Name: GetBody
+          Offset: 80
+          Type: 31 GoSubroutineType func() (io.ReadCloser, error)
+        - Name: ContentLength
+          Offset: 88
+          Type: 32 BaseType int64
+        - Name: TransferEncoding
+          Offset: 96
+          Type: 28 GoSliceHeaderType []string
+        - Name: Close
+          Offset: 120
+          Type: 13 BaseType bool
+        - Name: Host
+          Offset: 128
+          Type: 5 GoStringHeaderType string
+        - Name: Form
+          Offset: 144
+          Type: 33 GoMapType net/url.Values
+        - Name: PostForm
+          Offset: 152
+          Type: 33 GoMapType net/url.Values
+        - Name: MultipartForm
+          Offset: 160
+          Type: 34 PointerType *mime/multipart.Form
+        - Name: Trailer
+          Offset: 168
+          Type: 14 GoMapType net/http.Header
+        - Name: RemoteAddr
+          Offset: 176
+          Type: 5 GoStringHeaderType string
+        - Name: RequestURI
+          Offset: 192
+          Type: 5 GoStringHeaderType string
+        - Name: TLS
+          Offset: 208
+          Type: 54 PointerType *crypto/tls.ConnectionState
+        - Name: Cancel
+          Offset: 216
+          Type: 115 GoChannelType <-chan struct {}
+        - Name: Response
+          Offset: 224
+          Type: 116 PointerType *net/http.Response
+        - Name: Pattern
+          Offset: 232
+          Type: 5 GoStringHeaderType string
+        - Name: ctx
+          Offset: 248
+          Type: 118 GoInterfaceType context.Context
+        - Name: pat
+          Offset: 264
+          Type: 119 PointerType *net/http.pattern
+        - Name: matches
+          Offset: 272
+          Type: 28 GoSliceHeaderType []string
+        - Name: otherValues
+          Offset: 296
+          Type: 124 GoMapType map[string]string
+    - __kind: StructureType
+      ID: 117
+      Name: net/http.Response
+      ByteSize: 144
+      GoRuntimeType: 2.268608e+06
+      GoKind: 25
+      RawFields:
+        - Name: Status
+          Offset: 0
+          Type: 5 GoStringHeaderType string
+        - Name: StatusCode
+          Offset: 16
+          Type: 8 BaseType int
+        - Name: Proto
+          Offset: 24
+          Type: 5 GoStringHeaderType string
+        - Name: ProtoMajor
+          Offset: 40
+          Type: 8 BaseType int
+        - Name: ProtoMinor
+          Offset: 48
+          Type: 8 BaseType int
+        - Name: Header
+          Offset: 56
+          Type: 14 GoMapType net/http.Header
+        - Name: Body
+          Offset: 64
+          Type: 30 GoInterfaceType io.ReadCloser
+        - Name: ContentLength
+          Offset: 80
+          Type: 32 BaseType int64
+        - Name: TransferEncoding
+          Offset: 88
+          Type: 28 GoSliceHeaderType []string
+        - Name: Close
+          Offset: 112
+          Type: 13 BaseType bool
+        - Name: Uncompressed
+          Offset: 113
+          Type: 13 BaseType bool
+        - Name: Trailer
+          Offset: 120
+          Type: 14 GoMapType net/http.Header
+        - Name: Request
+          Offset: 128
+          Type: 3 PointerType *net/http.Request
+        - Name: TLS
+          Offset: 136
+          Type: 54 PointerType *crypto/tls.ConnectionState
+    - __kind: GoInterfaceType
+      ID: 1
+      Name: net/http.ResponseWriter
+      ByteSize: 16
+      GoRuntimeType: 1.210848e+06
+      GoKind: 20
+      RawFields:
+        - Name: tab
+          Offset: 0
+          Type: 2 VoidPointerType unsafe.Pointer
+        - Name: data
+          Offset: 8
+          Type: 2 VoidPointerType unsafe.Pointer
+    - __kind: StructureType
+      ID: 120
+      Name: net/http.pattern
+      ByteSize: 88
+      GoRuntimeType: 1.875616e+06
+      GoKind: 25
+      RawFields:
+        - Name: str
+          Offset: 0
+          Type: 5 GoStringHeaderType string
+        - Name: method
+          Offset: 16
+          Type: 5 GoStringHeaderType string
+        - Name: host
+          Offset: 32
+          Type: 5 GoStringHeaderType string
+        - Name: segments
+          Offset: 48
+          Type: 121 GoSliceHeaderType []net/http.segment
+        - Name: loc
+          Offset: 72
+          Type: 5 GoStringHeaderType string
+    - __kind: StructureType
+      ID: 123
+      Name: net/http.segment
+      ByteSize: 24
+      GoRuntimeType: 1.642496e+06
+      GoKind: 25
+      RawFields:
+        - Name: s
+          Offset: 0
+          Type: 5 GoStringHeaderType string
+        - Name: wild
+          Offset: 16
+          Type: 13 BaseType bool
+        - Name: multi
+          Offset: 17
+          Type: 13 BaseType bool
+    - __kind: GoMapType
+      ID: 52
+      Name: net/textproto.MIMEHeader
+      ByteSize: 8
+      GoRuntimeType: 1.86368e+06
+      GoKind: 21
+      HeaderType: 16 GoSwissMapHeaderType map<string,[]string>
+    - __kind: StructureType
+      ID: 10
+      Name: net/url.URL
+      ByteSize: 144
+      GoRuntimeType: 2.181632e+06
+      GoKind: 25
+      RawFields:
+        - Name: Scheme
+          Offset: 0
+          Type: 5 GoStringHeaderType string
+        - Name: Opaque
+          Offset: 16
+          Type: 5 GoStringHeaderType string
+        - Name: User
+          Offset: 32
+          Type: 11 PointerType *net/url.Userinfo
+        - Name: Host
+          Offset: 40
+          Type: 5 GoStringHeaderType string
+        - Name: Path
+          Offset: 56
+          Type: 5 GoStringHeaderType string
+        - Name: RawPath
+          Offset: 72
+          Type: 5 GoStringHeaderType string
+        - Name: OmitHost
+          Offset: 88
+          Type: 13 BaseType bool
+        - Name: ForceQuery
+          Offset: 89
+          Type: 13 BaseType bool
+        - Name: RawQuery
+          Offset: 96
+          Type: 5 GoStringHeaderType string
+        - Name: Fragment
+          Offset: 112
+          Type: 5 GoStringHeaderType string
+        - Name: RawFragment
+          Offset: 128
+          Type: 5 GoStringHeaderType string
+    - __kind: StructureType
+      ID: 12
+      Name: net/url.Userinfo
+      ByteSize: 40
+      GoRuntimeType: 1.658624e+06
+      GoKind: 25
+      RawFields:
+        - Name: username
+          Offset: 0
+          Type: 5 GoStringHeaderType string
+        - Name: password
+          Offset: 16
+          Type: 5 GoStringHeaderType string
+        - Name: passwordSet
+          Offset: 32
+          Type: 13 BaseType bool
+    - __kind: GoMapType
+      ID: 33
+      Name: net/url.Values
+      ByteSize: 8
+      GoRuntimeType: 1.92848e+06
+      GoKind: 21
+      HeaderType: 16 GoSwissMapHeaderType map<string,[]string>
+    - __kind: ArrayType
+      ID: 183
+      Name: noalg.[8]struct { key string; elem *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute }
+      ByteSize: 192
+      GoRuntimeType: 715328
+      GoKind: 17
+      Count: 8
+      HasCount: true
+      Element: 184 StructureType noalg.struct { key string; elem *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute }
+    - __kind: ArrayType
+      ID: 46
+      Name: noalg.[8]struct { key string; elem []*mime/multipart.FileHeader }
+      ByteSize: 320
+      GoRuntimeType: 710944
+      GoKind: 17
+      Count: 8
+      HasCount: true
+      Element: 47 StructureType noalg.struct { key string; elem []*mime/multipart.FileHeader }
+    - __kind: ArrayType
+      ID: 26
+      Name: noalg.[8]struct { key string; elem []string }
+      ByteSize: 320
+      GoRuntimeType: 701120
+      GoKind: 17
+      Count: 8
+      HasCount: true
+      Element: 27 StructureType noalg.struct { key string; elem []string }
+    - __kind: ArrayType
+      ID: 165
+      Name: noalg.[8]struct { key string; elem float64 }
+      ByteSize: 192
+      GoRuntimeType: 715232
+      GoKind: 17
+      Count: 8
+      HasCount: true
+      Element: 166 StructureType noalg.struct { key string; elem float64 }
+    - __kind: ArrayType
+      ID: 154
+      Name: noalg.[8]struct { key string; elem interface {} }
+      ByteSize: 256
+      GoRuntimeType: 692576
+      GoKind: 17
+      Count: 8
+      HasCount: true
+      Element: 155 StructureType noalg.struct { key string; elem interface {} }
+    - __kind: ArrayType
+      ID: 133
+      Name: noalg.[8]struct { key string; elem string }
+      ByteSize: 256
+      GoRuntimeType: 705280
+      GoKind: 17
+      Count: 8
+      HasCount: true
+      Element: 134 StructureType noalg.struct { key string; elem string }
+    - __kind: StructureType
+      ID: 182
+      Name: noalg.map.group[string]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
+      ByteSize: 200
+      GoRuntimeType: 1.332e+06
+      GoKind: 25
+      RawFields:
+        - Name: ctrl
+          Offset: 0
+          Type: 17 BaseType uint64
+        - Name: slots
+          Offset: 8
+          Type: 183 ArrayType noalg.[8]struct { key string; elem *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute }
+    - __kind: StructureType
+      ID: 45
+      Name: noalg.map.group[string][]*mime/multipart.FileHeader
+      ByteSize: 328
+      GoRuntimeType: 1.325728e+06
+      GoKind: 25
+      RawFields:
+        - Name: ctrl
+          Offset: 0
+          Type: 17 BaseType uint64
+        - Name: slots
+          Offset: 8
+          Type: 46 ArrayType noalg.[8]struct { key string; elem []*mime/multipart.FileHeader }
+    - __kind: StructureType
+      ID: 25
+      Name: noalg.map.group[string][]string
+      ByteSize: 328
+      GoRuntimeType: 1.31664e+06
+      GoKind: 25
+      RawFields:
+        - Name: ctrl
+          Offset: 0
+          Type: 17 BaseType uint64
+        - Name: slots
+          Offset: 8
+          Type: 26 ArrayType noalg.[8]struct { key string; elem []string }
+    - __kind: StructureType
+      ID: 164
+      Name: noalg.map.group[string]float64
+      ByteSize: 200
+      GoRuntimeType: 1.331744e+06
+      GoKind: 25
+      RawFields:
+        - Name: ctrl
+          Offset: 0
+          Type: 17 BaseType uint64
+        - Name: slots
+          Offset: 8
+          Type: 165 ArrayType noalg.[8]struct { key string; elem float64 }
+    - __kind: StructureType
+      ID: 153
+      Name: noalg.map.group[string]interface {}
+      ByteSize: 264
+      GoRuntimeType: 1.31408e+06
+      GoKind: 25
+      RawFields:
+        - Name: ctrl
+          Offset: 0
+          Type: 17 BaseType uint64
+        - Name: slots
+          Offset: 8
+          Type: 154 ArrayType noalg.[8]struct { key string; elem interface {} }
+    - __kind: StructureType
+      ID: 132
+      Name: noalg.map.group[string]string
+      ByteSize: 264
+      GoRuntimeType: 1.319072e+06
+      GoKind: 25
+      RawFields:
+        - Name: ctrl
+          Offset: 0
+          Type: 17 BaseType uint64
+        - Name: slots
+          Offset: 8
+          Type: 133 ArrayType noalg.[8]struct { key string; elem string }
+    - __kind: StructureType
+      ID: 184
+      Name: noalg.struct { key string; elem *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute }
+      ByteSize: 24
+      GoRuntimeType: 1.331872e+06
+      GoKind: 25
+      RawFields:
+        - Name: key
+          Offset: 0
+          Type: 5 GoStringHeaderType string
+        - Name: elem
+          Offset: 16
+          Type: 185 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
+    - __kind: StructureType
+      ID: 47
+      Name: noalg.struct { key string; elem []*mime/multipart.FileHeader }
+      ByteSize: 40
+      GoRuntimeType: 1.3256e+06
+      GoKind: 25
+      RawFields:
+        - Name: key
+          Offset: 0
+          Type: 5 GoStringHeaderType string
+        - Name: elem
+          Offset: 16
+          Type: 48 GoSliceHeaderType []*mime/multipart.FileHeader
+    - __kind: StructureType
+      ID: 27
+      Name: noalg.struct { key string; elem []string }
+      ByteSize: 40
+      GoRuntimeType: 1.316512e+06
+      GoKind: 25
+      RawFields:
+        - Name: key
+          Offset: 0
+          Type: 5 GoStringHeaderType string
+        - Name: elem
+          Offset: 16
+          Type: 28 GoSliceHeaderType []string
+    - __kind: StructureType
+      ID: 166
+      Name: noalg.struct { key string; elem float64 }
+      ByteSize: 24
+      GoRuntimeType: 1.331616e+06
+      GoKind: 25
+      RawFields:
+        - Name: key
+          Offset: 0
+          Type: 5 GoStringHeaderType string
+        - Name: elem
+          Offset: 16
+          Type: 167 BaseType float64
+    - __kind: StructureType
+      ID: 155
+      Name: noalg.struct { key string; elem interface {} }
+      ByteSize: 32
+      GoRuntimeType: 1.313952e+06
+      GoKind: 25
+      RawFields:
+        - Name: key
+          Offset: 0
+          Type: 5 GoStringHeaderType string
+        - Name: elem
+          Offset: 16
+          Type: 63 GoEmptyInterfaceType interface {}
+    - __kind: StructureType
+      ID: 134
+      Name: noalg.struct { key string; elem string }
+      ByteSize: 32
+      GoRuntimeType: 1.318944e+06
+      GoKind: 25
+      RawFields:
+        - Name: key
+          Offset: 0
+          Type: 5 GoStringHeaderType string
+        - Name: elem
+          Offset: 16
+          Type: 5 GoStringHeaderType string
+    - __kind: GoStringHeaderType
+      ID: 5
+      Name: string
+      ByteSize: 16
+      GoRuntimeType: 594208
+      GoKind: 24
+      RawFields:
+        - Name: str
+          Offset: 0
+          Type: 229 PointerType *string.str
+        - Name: len
+          Offset: 8
+          Type: 8 BaseType int
+      Data: 228 GoStringDataType string.str
+    - __kind: GoStringDataType
+      ID: 228
+      Name: string.str
+      ByteSize: 2048
+    - __kind: StructureType
+      ID: 138
+      Name: sync.Mutex
+      ByteSize: 8
+      GoRuntimeType: 1.494336e+06
+      GoKind: 25
+      RawFields:
+        - Name: _
+          Offset: 0
+          Type: 139 StructureType sync.noCopy
+        - Name: mu
+          Offset: 0
+          Type: 140 StructureType internal/sync.Mutex
+    - __kind: StructureType
+      ID: 137
+      Name: sync.RWMutex
+      ByteSize: 24
+      GoRuntimeType: 1.88144e+06
+      GoKind: 25
+      RawFields:
+        - Name: w
+          Offset: 0
+          Type: 138 StructureType sync.Mutex
+        - Name: writerSem
+          Offset: 8
+          Type: 142 BaseType uint32
+        - Name: readerSem
+          Offset: 12
+          Type: 142 BaseType uint32
+        - Name: readerCount
+          Offset: 16
+          Type: 143 StructureType sync/atomic.Int32
+        - Name: readerWait
+          Offset: 20
+          Type: 143 StructureType sync/atomic.Int32
+    - __kind: StructureType
+      ID: 139
+      Name: sync.noCopy
+      GoRuntimeType: 1.007392e+06
+      GoKind: 25
+      RawFields: []
+    - __kind: StructureType
+      ID: 143
+      Name: sync/atomic.Int32
+      ByteSize: 4
+      GoRuntimeType: 1.495616e+06
+      GoKind: 25
+      RawFields:
+        - Name: _
+          Offset: 0
+          Type: 144 StructureType sync/atomic.noCopy
+        - Name: v
+          Offset: 0
+          Type: 141 BaseType int32
+    - __kind: StructureType
+      ID: 144
+      Name: sync/atomic.noCopy
+      GoRuntimeType: 1.007488e+06
+      GoKind: 25
+      RawFields: []
+    - __kind: StructureType
+      ID: 179
+      Name: table<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
+      ByteSize: 32
+      GoKind: 25
+      RawFields:
+        - Name: used
+          Offset: 0
+          Type: 22 BaseType uint16
+        - Name: capacity
+          Offset: 2
+          Type: 22 BaseType uint16
+        - Name: growthLeft
+          Offset: 4
+          Type: 22 BaseType uint16
+        - Name: localDepth
+          Offset: 6
+          Type: 7 BaseType uint8
+        - Name: index
+          Offset: 8
+          Type: 8 BaseType int
+        - Name: groups
+          Offset: 16
+          Type: 180 GoSwissMapGroupsType groupReference<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
+    - __kind: StructureType
+      ID: 42
+      Name: table<string,[]*mime/multipart.FileHeader>
+      ByteSize: 32
+      GoKind: 25
+      RawFields:
+        - Name: used
+          Offset: 0
+          Type: 22 BaseType uint16
+        - Name: capacity
+          Offset: 2
+          Type: 22 BaseType uint16
+        - Name: growthLeft
+          Offset: 4
+          Type: 22 BaseType uint16
+        - Name: localDepth
+          Offset: 6
+          Type: 7 BaseType uint8
+        - Name: index
+          Offset: 8
+          Type: 8 BaseType int
+        - Name: groups
+          Offset: 16
+          Type: 43 GoSwissMapGroupsType groupReference<string,[]*mime/multipart.FileHeader>
+    - __kind: StructureType
+      ID: 21
+      Name: table<string,[]string>
+      ByteSize: 32
+      GoKind: 25
+      RawFields:
+        - Name: used
+          Offset: 0
+          Type: 22 BaseType uint16
+        - Name: capacity
+          Offset: 2
+          Type: 22 BaseType uint16
+        - Name: growthLeft
+          Offset: 4
+          Type: 22 BaseType uint16
+        - Name: localDepth
+          Offset: 6
+          Type: 7 BaseType uint8
+        - Name: index
+          Offset: 8
+          Type: 8 BaseType int
+        - Name: groups
+          Offset: 16
+          Type: 23 GoSwissMapGroupsType groupReference<string,[]string>
+    - __kind: StructureType
+      ID: 161
+      Name: table<string,float64>
+      ByteSize: 32
+      GoKind: 25
+      RawFields:
+        - Name: used
+          Offset: 0
+          Type: 22 BaseType uint16
+        - Name: capacity
+          Offset: 2
+          Type: 22 BaseType uint16
+        - Name: growthLeft
+          Offset: 4
+          Type: 22 BaseType uint16
+        - Name: localDepth
+          Offset: 6
+          Type: 7 BaseType uint8
+        - Name: index
+          Offset: 8
+          Type: 8 BaseType int
+        - Name: groups
+          Offset: 16
+          Type: 162 GoSwissMapGroupsType groupReference<string,float64>
+    - __kind: StructureType
+      ID: 150
+      Name: table<string,interface {}>
+      ByteSize: 32
+      GoKind: 25
+      RawFields:
+        - Name: used
+          Offset: 0
+          Type: 22 BaseType uint16
+        - Name: capacity
+          Offset: 2
+          Type: 22 BaseType uint16
+        - Name: growthLeft
+          Offset: 4
+          Type: 22 BaseType uint16
+        - Name: localDepth
+          Offset: 6
+          Type: 7 BaseType uint8
+        - Name: index
+          Offset: 8
+          Type: 8 BaseType int
+        - Name: groups
+          Offset: 16
+          Type: 151 GoSwissMapGroupsType groupReference<string,interface {}>
+    - __kind: StructureType
+      ID: 129
+      Name: table<string,string>
+      ByteSize: 32
+      GoKind: 25
+      RawFields:
+        - Name: used
+          Offset: 0
+          Type: 22 BaseType uint16
+        - Name: capacity
+          Offset: 2
+          Type: 22 BaseType uint16
+        - Name: growthLeft
+          Offset: 4
+          Type: 22 BaseType uint16
+        - Name: localDepth
+          Offset: 6
+          Type: 7 BaseType uint8
+        - Name: index
+          Offset: 8
+          Type: 8 BaseType int
+        - Name: groups
+          Offset: 16
+          Type: 130 GoSwissMapGroupsType groupReference<string,string>
+    - __kind: StructureType
+      ID: 77
+      Name: time.Location
+      ByteSize: 104
+      GoRuntimeType: 2.014752e+06
+      GoKind: 25
+      RawFields:
+        - Name: name
+          Offset: 0
+          Type: 5 GoStringHeaderType string
+        - Name: zone
+          Offset: 16
+          Type: 78 GoSliceHeaderType []time.zone
+        - Name: tx
+          Offset: 40
+          Type: 81 GoSliceHeaderType []time.zoneTrans
+        - Name: extend
+          Offset: 64
+          Type: 5 GoStringHeaderType string
+        - Name: cacheStart
+          Offset: 80
+          Type: 32 BaseType int64
+        - Name: cacheEnd
+          Offset: 88
+          Type: 32 BaseType int64
+        - Name: cacheZone
+          Offset: 96
+          Type: 79 PointerType *time.zone
+    - __kind: StructureType
+      ID: 75
+      Name: time.Time
+      ByteSize: 24
+      GoRuntimeType: 2.42976e+06
+      GoKind: 25
+      RawFields:
+        - Name: wall
+          Offset: 0
+          Type: 17 BaseType uint64
+        - Name: ext
+          Offset: 8
+          Type: 32 BaseType int64
+        - Name: loc
+          Offset: 16
+          Type: 76 PointerType *time.Location
+    - __kind: StructureType
+      ID: 80
+      Name: time.zone
+      ByteSize: 32
+      GoRuntimeType: 1.647488e+06
+      GoKind: 25
+      RawFields:
+        - Name: name
+          Offset: 0
+          Type: 5 GoStringHeaderType string
+        - Name: offset
+          Offset: 16
+          Type: 8 BaseType int
+        - Name: isDST
+          Offset: 24
+          Type: 13 BaseType bool
+    - __kind: StructureType
+      ID: 83
+      Name: time.zoneTrans
+      ByteSize: 16
+      GoRuntimeType: 1.789472e+06
+      GoKind: 25
+      RawFields:
+        - Name: when
+          Offset: 0
+          Type: 32 BaseType int64
+        - Name: index
+          Offset: 8
+          Type: 7 BaseType uint8
+        - Name: isstd
+          Offset: 9
+          Type: 13 BaseType bool
+        - Name: isutc
+          Offset: 10
+          Type: 13 BaseType bool
     - __kind: BaseType
       ID: 212
       Name: uint
@@ -2986,474 +3419,41 @@ Types:
       GoRuntimeType: 594848
       GoKind: 7
     - __kind: BaseType
-      ID: 213
-      Name: float32
-      ByteSize: 4
-      GoRuntimeType: 595104
-      GoKind: 13
-    - __kind: PointerType
-      ID: 214
-      Name: '*uintptr'
-      ByteSize: 8
-      GoRuntimeType: 405152
-      GoKind: 22
-      Pointee: 18 BaseType uintptr
-    - __kind: PointerType
-      ID: 215
-      Name: '*int32'
-      ByteSize: 8
-      GoRuntimeType: 404768
-      GoKind: 22
-      Pointee: 141 BaseType int32
-    - __kind: PointerType
-      ID: 216
-      Name: '*uint32'
-      ByteSize: 8
-      GoRuntimeType: 404832
-      GoKind: 22
-      Pointee: 142 BaseType uint32
-    - __kind: BaseType
-      ID: 217
-      Name: complex64
-      ByteSize: 8
-      GoRuntimeType: 594976
-      GoKind: 15
-    - __kind: BaseType
-      ID: 218
-      Name: complex128
-      ByteSize: 16
-      GoRuntimeType: 595040
-      GoKind: 16
-    - __kind: PointerType
-      ID: 219
-      Name: '*int64'
-      ByteSize: 8
-      GoRuntimeType: 404896
-      GoKind: 22
-      Pointee: 32 BaseType int64
-    - __kind: PointerType
-      ID: 220
-      Name: '*uint64'
-      ByteSize: 8
-      GoRuntimeType: 404960
-      GoKind: 22
-      Pointee: 17 BaseType uint64
-    - __kind: PointerType
-      ID: 221
-      Name: '*uint16'
-      ByteSize: 8
-      GoRuntimeType: 404704
-      GoKind: 22
-      Pointee: 22 BaseType uint16
-    - __kind: PointerType
-      ID: 222
-      Name: '*int16'
-      ByteSize: 8
-      GoRuntimeType: 404640
-      GoKind: 22
-      Pointee: 223 BaseType int16
-    - __kind: BaseType
-      ID: 223
-      Name: int16
+      ID: 22
+      Name: uint16
       ByteSize: 2
-      GoRuntimeType: 594400
-      GoKind: 4
-    - __kind: PointerType
-      ID: 224
-      Name: '*int8'
+      GoRuntimeType: 594464
+      GoKind: 9
+    - __kind: BaseType
+      ID: 142
+      Name: uint32
+      ByteSize: 4
+      GoRuntimeType: 594592
+      GoKind: 10
+    - __kind: BaseType
+      ID: 17
+      Name: uint64
       ByteSize: 8
-      GoRuntimeType: 404512
-      GoKind: 22
-      Pointee: 211 BaseType int8
-    - __kind: PointerType
-      ID: 225
-      Name: '*error'
+      GoRuntimeType: 594720
+      GoKind: 11
+    - __kind: BaseType
+      ID: 7
+      Name: uint8
+      ByteSize: 1
+      GoRuntimeType: 594336
+      GoKind: 8
+    - __kind: BaseType
+      ID: 18
+      Name: uintptr
       ByteSize: 8
-      GoRuntimeType: 404384
-      GoKind: 22
-      Pointee: 210 GoInterfaceType error
-    - __kind: PointerType
-      ID: 226
-      Name: '*uint'
+      GoRuntimeType: 594912
+      GoKind: 12
+    - __kind: VoidPointerType
+      ID: 2
+      Name: unsafe.Pointer
       ByteSize: 8
-      GoRuntimeType: 405088
-      GoKind: 22
-      Pointee: 212 BaseType uint
-    - __kind: PointerType
-      ID: 227
-      Name: '*float32'
-      ByteSize: 8
-      GoRuntimeType: 405344
-      GoKind: 22
-      Pointee: 213 BaseType float32
-    - __kind: GoStringDataType
-      ID: 228
-      Name: string.str
-      ByteSize: 2048
-    - __kind: PointerType
-      ID: 229
-      Name: '*string.str'
-      ByteSize: 8
-      Pointee: 228 GoStringDataType string.str
-    - __kind: GoSliceDataType
-      ID: 230
-      Name: '[]*table<string,[]string>.array'
-      ByteSize: 8192
-      Element: 20 PointerType *table<string,[]string>
-    - __kind: GoSliceDataType
-      ID: 231
-      Name: '[]noalg.map.group[string][]string.array'
-      ByteSize: 2048
-      Element: 25 StructureType noalg.map.group[string][]string
-    - __kind: GoSliceDataType
-      ID: 232
-      Name: '[]string.array'
-      ByteSize: 2048
-      Element: 5 GoStringHeaderType string
-    - __kind: PointerType
-      ID: 233
-      Name: '*[]string.array'
-      ByteSize: 8
-      Pointee: 232 GoSliceDataType []string.array
-    - __kind: GoSliceDataType
-      ID: 234
-      Name: '[]*table<string,[]*mime/multipart.FileHeader>.array'
-      ByteSize: 8192
-      Element: 41 PointerType *table<string,[]*mime/multipart.FileHeader>
-    - __kind: GoSliceDataType
-      ID: 235
-      Name: '[]noalg.map.group[string][]*mime/multipart.FileHeader.array'
-      ByteSize: 2048
-      Element: 45 StructureType noalg.map.group[string][]*mime/multipart.FileHeader
-    - __kind: GoSliceDataType
-      ID: 236
-      Name: '[]*mime/multipart.FileHeader.array'
-      ByteSize: 2048
-      Element: 50 PointerType *mime/multipart.FileHeader
-    - __kind: PointerType
-      ID: 237
-      Name: '*[]*mime/multipart.FileHeader.array'
-      ByteSize: 8
-      Pointee: 236 GoSliceDataType []*mime/multipart.FileHeader.array
-    - __kind: GoSliceDataType
-      ID: 238
-      Name: '[]uint8.array'
-      ByteSize: 2048
-      Element: 7 BaseType uint8
-    - __kind: PointerType
-      ID: 239
-      Name: '*[]uint8.array'
-      ByteSize: 8
-      Pointee: 238 GoSliceDataType []uint8.array
-    - __kind: GoSliceDataType
-      ID: 240
-      Name: '[]*crypto/x509.Certificate.array'
-      ByteSize: 2048
-      Element: 59 PointerType *crypto/x509.Certificate
-    - __kind: PointerType
-      ID: 241
-      Name: '*[]*crypto/x509.Certificate.array'
-      ByteSize: 8
-      Pointee: 240 GoSliceDataType []*crypto/x509.Certificate.array
-    - __kind: GoSliceDataType
-      ID: 242
-      Name: math/big.nat.array
-      ByteSize: 2048
-      Element: 68 BaseType math/big.Word
-    - __kind: PointerType
-      ID: 243
-      Name: '*math/big.nat.array'
-      ByteSize: 8
-      Pointee: 242 GoSliceDataType math/big.nat.array
-    - __kind: GoSliceDataType
-      ID: 244
-      Name: '[]crypto/x509/pkix.AttributeTypeAndValue.array'
-      ByteSize: 2048
-      Element: 72 StructureType crypto/x509/pkix.AttributeTypeAndValue
-    - __kind: PointerType
-      ID: 245
-      Name: '*[]crypto/x509/pkix.AttributeTypeAndValue.array'
-      ByteSize: 8
-      Pointee: 244 GoSliceDataType []crypto/x509/pkix.AttributeTypeAndValue.array
-    - __kind: GoSliceDataType
-      ID: 246
-      Name: encoding/asn1.ObjectIdentifier.array
-      ByteSize: 2048
-      Element: 8 BaseType int
-    - __kind: PointerType
-      ID: 247
-      Name: '*encoding/asn1.ObjectIdentifier.array'
-      ByteSize: 8
-      Pointee: 246 GoSliceDataType encoding/asn1.ObjectIdentifier.array
-    - __kind: GoSliceDataType
-      ID: 248
-      Name: '[]time.zone.array'
-      ByteSize: 2048
-      Element: 80 StructureType time.zone
-    - __kind: PointerType
-      ID: 249
-      Name: '*[]time.zone.array'
-      ByteSize: 8
-      Pointee: 248 GoSliceDataType []time.zone.array
-    - __kind: GoSliceDataType
-      ID: 250
-      Name: '[]time.zoneTrans.array'
-      ByteSize: 2048
-      Element: 83 StructureType time.zoneTrans
-    - __kind: PointerType
-      ID: 251
-      Name: '*[]time.zoneTrans.array'
-      ByteSize: 8
-      Pointee: 250 GoSliceDataType []time.zoneTrans.array
-    - __kind: GoSliceDataType
-      ID: 252
-      Name: '[]crypto/x509/pkix.Extension.array'
-      ByteSize: 2048
-      Element: 87 StructureType crypto/x509/pkix.Extension
-    - __kind: PointerType
-      ID: 253
-      Name: '*[]crypto/x509/pkix.Extension.array'
-      ByteSize: 8
-      Pointee: 252 GoSliceDataType []crypto/x509/pkix.Extension.array
-    - __kind: GoSliceDataType
-      ID: 254
-      Name: '[]encoding/asn1.ObjectIdentifier.array'
-      ByteSize: 2048
-      Element: 73 GoSliceHeaderType encoding/asn1.ObjectIdentifier
-    - __kind: PointerType
-      ID: 255
-      Name: '*[]encoding/asn1.ObjectIdentifier.array'
-      ByteSize: 8
-      Pointee: 254 GoSliceDataType []encoding/asn1.ObjectIdentifier.array
-    - __kind: GoSliceDataType
-      ID: 256
-      Name: '[]crypto/x509.ExtKeyUsage.array'
-      ByteSize: 2048
-      Element: 92 BaseType crypto/x509.ExtKeyUsage
-    - __kind: PointerType
-      ID: 257
-      Name: '*[]crypto/x509.ExtKeyUsage.array'
-      ByteSize: 8
-      Pointee: 256 GoSliceDataType []crypto/x509.ExtKeyUsage.array
-    - __kind: GoSliceDataType
-      ID: 258
-      Name: '[]net.IP.array'
-      ByteSize: 2048
-      Element: 95 GoSliceHeaderType net.IP
-    - __kind: PointerType
-      ID: 259
-      Name: '*[]net.IP.array'
-      ByteSize: 8
-      Pointee: 258 GoSliceDataType []net.IP.array
-    - __kind: GoSliceDataType
-      ID: 260
-      Name: net.IP.array
-      ByteSize: 2048
-      Element: 7 BaseType uint8
-    - __kind: PointerType
-      ID: 261
-      Name: '*net.IP.array'
-      ByteSize: 8
-      Pointee: 260 GoSliceDataType net.IP.array
-    - __kind: GoSliceDataType
-      ID: 262
-      Name: '[]*net/url.URL.array'
-      ByteSize: 2048
-      Element: 9 PointerType *net/url.URL
-    - __kind: PointerType
-      ID: 263
-      Name: '*[]*net/url.URL.array'
-      ByteSize: 8
-      Pointee: 262 GoSliceDataType []*net/url.URL.array
-    - __kind: GoSliceDataType
-      ID: 264
-      Name: '[]*net.IPNet.array'
-      ByteSize: 2048
-      Element: 100 PointerType *net.IPNet
-    - __kind: PointerType
-      ID: 265
-      Name: '*[]*net.IPNet.array'
-      ByteSize: 8
-      Pointee: 264 GoSliceDataType []*net.IPNet.array
-    - __kind: GoSliceDataType
-      ID: 266
-      Name: net.IPMask.array
-      ByteSize: 2048
-      Element: 7 BaseType uint8
-    - __kind: PointerType
-      ID: 267
-      Name: '*net.IPMask.array'
-      ByteSize: 8
-      Pointee: 266 GoSliceDataType net.IPMask.array
-    - __kind: GoSliceDataType
-      ID: 268
-      Name: '[]crypto/x509.OID.array'
-      ByteSize: 2048
-      Element: 105 StructureType crypto/x509.OID
-    - __kind: PointerType
-      ID: 269
-      Name: '*[]crypto/x509.OID.array'
-      ByteSize: 8
-      Pointee: 268 GoSliceDataType []crypto/x509.OID.array
-    - __kind: GoSliceDataType
-      ID: 270
-      Name: '[]crypto/x509.PolicyMapping.array'
-      ByteSize: 2048
-      Element: 108 StructureType crypto/x509.PolicyMapping
-    - __kind: PointerType
-      ID: 271
-      Name: '*[]crypto/x509.PolicyMapping.array'
-      ByteSize: 8
-      Pointee: 270 GoSliceDataType []crypto/x509.PolicyMapping.array
-    - __kind: GoSliceDataType
-      ID: 272
-      Name: '[][]*crypto/x509.Certificate.array'
-      ByteSize: 2048
-      Element: 57 GoSliceHeaderType []*crypto/x509.Certificate
-    - __kind: PointerType
-      ID: 273
-      Name: '*[][]*crypto/x509.Certificate.array'
-      ByteSize: 8
-      Pointee: 272 GoSliceDataType [][]*crypto/x509.Certificate.array
-    - __kind: GoSliceDataType
-      ID: 274
-      Name: '[][]uint8.array'
-      ByteSize: 2048
-      Element: 53 GoSliceHeaderType []uint8
-    - __kind: PointerType
-      ID: 275
-      Name: '*[][]uint8.array'
-      ByteSize: 8
-      Pointee: 274 GoSliceDataType [][]uint8.array
-    - __kind: GoSliceDataType
-      ID: 276
-      Name: '[]net/http.segment.array'
-      ByteSize: 2048
-      Element: 123 StructureType net/http.segment
-    - __kind: PointerType
-      ID: 277
-      Name: '*[]net/http.segment.array'
-      ByteSize: 8
-      Pointee: 276 GoSliceDataType []net/http.segment.array
-    - __kind: GoSliceDataType
-      ID: 278
-      Name: '[]*table<string,string>.array'
-      ByteSize: 8192
-      Element: 128 PointerType *table<string,string>
-    - __kind: GoSliceDataType
-      ID: 279
-      Name: '[]noalg.map.group[string]string.array'
-      ByteSize: 2048
-      Element: 132 StructureType noalg.map.group[string]string
-    - __kind: GoSliceDataType
-      ID: 280
-      Name: '[]*table<string,interface {}>.array'
-      ByteSize: 8192
-      Element: 149 PointerType *table<string,interface {}>
-    - __kind: GoSliceDataType
-      ID: 281
-      Name: '[]noalg.map.group[string]interface {}.array'
-      ByteSize: 2048
-      Element: 153 StructureType noalg.map.group[string]interface {}
-    - __kind: GoSliceDataType
-      ID: 282
-      Name: '[]*table<string,float64>.array'
-      ByteSize: 8192
-      Element: 160 PointerType *table<string,float64>
-    - __kind: GoSliceDataType
-      ID: 283
-      Name: '[]noalg.map.group[string]float64.array'
-      ByteSize: 2048
-      Element: 164 StructureType noalg.map.group[string]float64
-    - __kind: GoSliceDataType
-      ID: 284
-      Name: '[]github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink.array'
-      ByteSize: 2048
-      Element: 170 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink
-    - __kind: PointerType
-      ID: 285
-      Name: '*[]github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink.array'
-      ByteSize: 8
-      Pointee: 284 GoSliceDataType []github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink.array
-    - __kind: GoSliceDataType
-      ID: 286
-      Name: '[]github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent.array'
-      ByteSize: 2048
-      Element: 173 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent
-    - __kind: PointerType
-      ID: 287
-      Name: '*[]github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent.array'
-      ByteSize: 8
-      Pointee: 286 GoSliceDataType []github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent.array
-    - __kind: GoSliceDataType
-      ID: 288
-      Name: '[]*table<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>.array'
-      ByteSize: 8192
-      Element: 178 PointerType *table<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
-    - __kind: GoSliceDataType
-      ID: 289
-      Name: '[]noalg.map.group[string]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute.array'
-      ByteSize: 2048
-      Element: 182 StructureType noalg.map.group[string]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
-    - __kind: GoSliceDataType
-      ID: 290
-      Name: '[]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttributeValue.array'
-      ByteSize: 2048
-      Element: 192 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttributeValue
-    - __kind: PointerType
-      ID: 291
-      Name: '*[]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttributeValue.array'
-      ByteSize: 8
-      Pointee: 290 GoSliceDataType []*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttributeValue.array
-    - __kind: GoSliceDataType
-      ID: 292
-      Name: '[]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span.array'
-      ByteSize: 2048
-      Element: 135 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span
-    - __kind: PointerType
-      ID: 293
-      Name: '*[]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span.array'
-      ByteSize: 8
-      Pointee: 292 GoSliceDataType []*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span.array
-    - __kind: EventRootType
-      ID: 294
-      Name: Probe[main.HandleHTTP]
-      ByteSize: 25
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: w
-          Offset: 1
-          Expression:
-            Type: 1 GoInterfaceType net/http.ResponseWriter
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 1, index: 0, name: w}
-                  Offset: 0
-                  ByteSize: 16
-        - Name: r
-          Offset: 17
-          Expression:
-            Type: 3 PointerType *net/http.Request
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 1, index: 1, name: r}
-                  Offset: 0
-                  ByteSize: 8
-    - __kind: EventRootType
-      ID: 295
-      Name: Probe[main.LookAtTheRequest]
-      ByteSize: 17
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: path
-          Offset: 1
-          Expression:
-            Type: 5 GoStringHeaderType string
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 2, index: 0, name: path}
-                  Offset: 0
-                  ByteSize: 16
+      GoRuntimeType: 595296
+      GoKind: 26
 MaxTypeID: 295
 Issues: []
 GoModuledataInfo: {FirstModuledataAddr: "0x18bb880", TypesOffset: 296}

--- a/pkg/dyninst/irgen/testdata/snapshot/rc_tester.arch=amd64,toolchain=go1.25.0.yaml
+++ b/pkg/dyninst/irgen/testdata/snapshot/rc_tester.arch=amd64,toolchain=go1.25.0.yaml
@@ -10,7 +10,7 @@ Probes:
       subprogram: {subprogram: 1}
       events:
         - ID: 1
-          Type: 302 EventRootType Probe[main.HandleHTTP]
+          Type: 294 EventRootType Probe[main.HandleHTTP]
           InjectionPoints: [{PC: "0xd36353", Frameless: false}]
           Condition: null
     - id: look_at_the_request
@@ -23,7 +23,7 @@ Probes:
       subprogram: {subprogram: 2}
       events:
         - ID: 2
-          Type: 303 EventRootType Probe[main.LookAtTheRequest]
+          Type: 295 EventRootType Probe[main.LookAtTheRequest]
           InjectionPoints: [{PC: "0xd366ae", Frameless: false}]
           Condition: null
 Subprograms:
@@ -362,7 +362,7 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 17 BaseType uint64
-      TablePtrSliceType: 242 GoSliceDataType []*table<string,[]string>.array
+      TablePtrSliceType: 230 GoSliceDataType []*table<string,[]string>.array
       GroupType: 25 StructureType noalg.map.group[string][]string
     - __kind: BaseType
       ID: 17
@@ -429,7 +429,7 @@ Types:
           Offset: 8
           Type: 17 BaseType uint64
       GroupType: 25 StructureType noalg.map.group[string][]string
-      GroupSliceType: 243 GoSliceDataType []noalg.map.group[string][]string.array
+      GroupSliceType: 231 GoSliceDataType []noalg.map.group[string][]string.array
     - __kind: PointerType
       ID: 24
       Name: '*noalg.map.group[string][]string'
@@ -598,7 +598,7 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 17 BaseType uint64
-      TablePtrSliceType: 238 GoSliceDataType []*table<string,[]*mime/multipart.FileHeader>.array
+      TablePtrSliceType: 234 GoSliceDataType []*table<string,[]*mime/multipart.FileHeader>.array
       GroupType: 45 StructureType noalg.map.group[string][]*mime/multipart.FileHeader
     - __kind: PointerType
       ID: 40
@@ -647,7 +647,7 @@ Types:
           Offset: 8
           Type: 17 BaseType uint64
       GroupType: 45 StructureType noalg.map.group[string][]*mime/multipart.FileHeader
-      GroupSliceType: 239 GoSliceDataType []noalg.map.group[string][]*mime/multipart.FileHeader.array
+      GroupSliceType: 235 GoSliceDataType []noalg.map.group[string][]*mime/multipart.FileHeader.array
     - __kind: PointerType
       ID: 44
       Name: '*noalg.map.group[string][]*mime/multipart.FileHeader'
@@ -704,7 +704,7 @@ Types:
         - Name: cap
           Offset: 16
           Type: 8 BaseType int
-      Data: 240 GoSliceDataType []*mime/multipart.FileHeader.array
+      Data: 236 GoSliceDataType []*mime/multipart.FileHeader.array
     - __kind: PointerType
       ID: 49
       Name: '**mime/multipart.FileHeader'
@@ -769,7 +769,7 @@ Types:
         - Name: cap
           Offset: 16
           Type: 8 BaseType int
-      Data: 244 GoSliceDataType []uint8.array
+      Data: 238 GoSliceDataType []uint8.array
     - __kind: PointerType
       ID: 54
       Name: '*crypto/tls.ConnectionState'
@@ -857,7 +857,7 @@ Types:
         - Name: cap
           Offset: 16
           Type: 8 BaseType int
-      Data: 246 GoSliceDataType []*crypto/x509.Certificate.array
+      Data: 240 GoSliceDataType []*crypto/x509.Certificate.array
     - __kind: PointerType
       ID: 58
       Name: '**crypto/x509.Certificate'
@@ -1095,7 +1095,7 @@ Types:
         - Name: cap
           Offset: 16
           Type: 8 BaseType int
-      Data: 248 GoSliceDataType math/big.nat.array
+      Data: 242 GoSliceDataType math/big.nat.array
     - __kind: PointerType
       ID: 67
       Name: '*math/big.Word'
@@ -1165,7 +1165,7 @@ Types:
         - Name: cap
           Offset: 16
           Type: 8 BaseType int
-      Data: 250 GoSliceDataType []crypto/x509/pkix.AttributeTypeAndValue.array
+      Data: 244 GoSliceDataType []crypto/x509/pkix.AttributeTypeAndValue.array
     - __kind: PointerType
       ID: 71
       Name: '*crypto/x509/pkix.AttributeTypeAndValue'
@@ -1202,7 +1202,7 @@ Types:
         - Name: cap
           Offset: 16
           Type: 8 BaseType int
-      Data: 252 GoSliceDataType encoding/asn1.ObjectIdentifier.array
+      Data: 246 GoSliceDataType encoding/asn1.ObjectIdentifier.array
     - __kind: PointerType
       ID: 74
       Name: '*int'
@@ -1277,7 +1277,7 @@ Types:
         - Name: cap
           Offset: 16
           Type: 8 BaseType int
-      Data: 254 GoSliceDataType []time.zone.array
+      Data: 248 GoSliceDataType []time.zone.array
     - __kind: PointerType
       ID: 79
       Name: '*time.zone'
@@ -1317,7 +1317,7 @@ Types:
         - Name: cap
           Offset: 16
           Type: 8 BaseType int
-      Data: 256 GoSliceDataType []time.zoneTrans.array
+      Data: 250 GoSliceDataType []time.zoneTrans.array
     - __kind: PointerType
       ID: 82
       Name: '*time.zoneTrans'
@@ -1366,7 +1366,7 @@ Types:
         - Name: cap
           Offset: 16
           Type: 8 BaseType int
-      Data: 258 GoSliceDataType []crypto/x509/pkix.Extension.array
+      Data: 252 GoSliceDataType []crypto/x509/pkix.Extension.array
     - __kind: PointerType
       ID: 86
       Name: '*crypto/x509/pkix.Extension'
@@ -1406,7 +1406,7 @@ Types:
         - Name: cap
           Offset: 16
           Type: 8 BaseType int
-      Data: 260 GoSliceDataType []encoding/asn1.ObjectIdentifier.array
+      Data: 254 GoSliceDataType []encoding/asn1.ObjectIdentifier.array
     - __kind: PointerType
       ID: 89
       Name: '*encoding/asn1.ObjectIdentifier'
@@ -1430,7 +1430,7 @@ Types:
         - Name: cap
           Offset: 16
           Type: 8 BaseType int
-      Data: 262 GoSliceDataType []crypto/x509.ExtKeyUsage.array
+      Data: 256 GoSliceDataType []crypto/x509.ExtKeyUsage.array
     - __kind: PointerType
       ID: 91
       Name: '*crypto/x509.ExtKeyUsage'
@@ -1460,7 +1460,7 @@ Types:
         - Name: cap
           Offset: 16
           Type: 8 BaseType int
-      Data: 264 GoSliceDataType []net.IP.array
+      Data: 258 GoSliceDataType []net.IP.array
     - __kind: PointerType
       ID: 94
       Name: '*net.IP'
@@ -1484,7 +1484,7 @@ Types:
         - Name: cap
           Offset: 16
           Type: 8 BaseType int
-      Data: 266 GoSliceDataType net.IP.array
+      Data: 260 GoSliceDataType net.IP.array
     - __kind: GoSliceHeaderType
       ID: 96
       Name: '[]*net/url.URL'
@@ -1501,7 +1501,7 @@ Types:
         - Name: cap
           Offset: 16
           Type: 8 BaseType int
-      Data: 268 GoSliceDataType []*net/url.URL.array
+      Data: 262 GoSliceDataType []*net/url.URL.array
     - __kind: PointerType
       ID: 97
       Name: '**net/url.URL'
@@ -1524,7 +1524,7 @@ Types:
         - Name: cap
           Offset: 16
           Type: 8 BaseType int
-      Data: 270 GoSliceDataType []*net.IPNet.array
+      Data: 264 GoSliceDataType []*net.IPNet.array
     - __kind: PointerType
       ID: 99
       Name: '**net.IPNet'
@@ -1567,7 +1567,7 @@ Types:
         - Name: cap
           Offset: 16
           Type: 8 BaseType int
-      Data: 272 GoSliceDataType net.IPMask.array
+      Data: 266 GoSliceDataType net.IPMask.array
     - __kind: GoSliceHeaderType
       ID: 103
       Name: '[]crypto/x509.OID'
@@ -1584,7 +1584,7 @@ Types:
         - Name: cap
           Offset: 16
           Type: 8 BaseType int
-      Data: 274 GoSliceDataType []crypto/x509.OID.array
+      Data: 268 GoSliceDataType []crypto/x509.OID.array
     - __kind: PointerType
       ID: 104
       Name: '*crypto/x509.OID'
@@ -1618,7 +1618,7 @@ Types:
         - Name: cap
           Offset: 16
           Type: 8 BaseType int
-      Data: 276 GoSliceDataType []crypto/x509.PolicyMapping.array
+      Data: 270 GoSliceDataType []crypto/x509.PolicyMapping.array
     - __kind: PointerType
       ID: 107
       Name: '*crypto/x509.PolicyMapping'
@@ -1655,7 +1655,7 @@ Types:
         - Name: cap
           Offset: 16
           Type: 8 BaseType int
-      Data: 278 GoSliceDataType [][]*crypto/x509.Certificate.array
+      Data: 272 GoSliceDataType [][]*crypto/x509.Certificate.array
     - __kind: PointerType
       ID: 110
       Name: '*[]*crypto/x509.Certificate'
@@ -1678,7 +1678,7 @@ Types:
         - Name: cap
           Offset: 16
           Type: 8 BaseType int
-      Data: 280 GoSliceDataType [][]uint8.array
+      Data: 274 GoSliceDataType [][]uint8.array
     - __kind: PointerType
       ID: 112
       Name: '*[]uint8'
@@ -1817,7 +1817,7 @@ Types:
         - Name: cap
           Offset: 16
           Type: 8 BaseType int
-      Data: 282 GoSliceDataType []net/http.segment.array
+      Data: 276 GoSliceDataType []net/http.segment.array
     - __kind: PointerType
       ID: 122
       Name: '*net/http.segment'
@@ -1886,7 +1886,7 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 17 BaseType uint64
-      TablePtrSliceType: 284 GoSliceDataType []*table<string,string>.array
+      TablePtrSliceType: 278 GoSliceDataType []*table<string,string>.array
       GroupType: 132 StructureType noalg.map.group[string]string
     - __kind: PointerType
       ID: 127
@@ -1935,7 +1935,7 @@ Types:
           Offset: 8
           Type: 17 BaseType uint64
       GroupType: 132 StructureType noalg.map.group[string]string
-      GroupSliceType: 285 GoSliceDataType []noalg.map.group[string]string.array
+      GroupSliceType: 279 GoSliceDataType []noalg.map.group[string]string.array
     - __kind: PointerType
       ID: 131
       Name: '*noalg.map.group[string]string'
@@ -2195,7 +2195,7 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 17 BaseType uint64
-      TablePtrSliceType: 298 GoSliceDataType []*table<string,interface {}>.array
+      TablePtrSliceType: 280 GoSliceDataType []*table<string,interface {}>.array
       GroupType: 153 StructureType noalg.map.group[string]interface {}
     - __kind: PointerType
       ID: 148
@@ -2244,7 +2244,7 @@ Types:
           Offset: 8
           Type: 17 BaseType uint64
       GroupType: 153 StructureType noalg.map.group[string]interface {}
-      GroupSliceType: 299 GoSliceDataType []noalg.map.group[string]interface {}.array
+      GroupSliceType: 281 GoSliceDataType []noalg.map.group[string]interface {}.array
     - __kind: PointerType
       ID: 152
       Name: '*noalg.map.group[string]interface {}'
@@ -2330,7 +2330,7 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 17 BaseType uint64
-      TablePtrSliceType: 288 GoSliceDataType []*table<string,float64>.array
+      TablePtrSliceType: 282 GoSliceDataType []*table<string,float64>.array
       GroupType: 164 StructureType noalg.map.group[string]float64
     - __kind: PointerType
       ID: 159
@@ -2379,7 +2379,7 @@ Types:
           Offset: 8
           Type: 17 BaseType uint64
       GroupType: 164 StructureType noalg.map.group[string]float64
-      GroupSliceType: 289 GoSliceDataType []noalg.map.group[string]float64.array
+      GroupSliceType: 283 GoSliceDataType []noalg.map.group[string]float64.array
     - __kind: PointerType
       ID: 163
       Name: '*noalg.map.group[string]float64'
@@ -2442,7 +2442,7 @@ Types:
         - Name: cap
           Offset: 16
           Type: 8 BaseType int
-      Data: 290 GoSliceDataType []github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink.array
+      Data: 284 GoSliceDataType []github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink.array
     - __kind: PointerType
       ID: 169
       Name: '*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink'
@@ -2491,7 +2491,7 @@ Types:
         - Name: cap
           Offset: 16
           Type: 8 BaseType int
-      Data: 292 GoSliceDataType []github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent.array
+      Data: 286 GoSliceDataType []github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent.array
     - __kind: PointerType
       ID: 172
       Name: '*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent'
@@ -2563,7 +2563,7 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 17 BaseType uint64
-      TablePtrSliceType: 294 GoSliceDataType []*table<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>.array
+      TablePtrSliceType: 288 GoSliceDataType []*table<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>.array
       GroupType: 182 StructureType noalg.map.group[string]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
     - __kind: PointerType
       ID: 177
@@ -2612,7 +2612,7 @@ Types:
           Offset: 8
           Type: 17 BaseType uint64
       GroupType: 182 StructureType noalg.map.group[string]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
-      GroupSliceType: 295 GoSliceDataType []noalg.map.group[string]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute.array
+      GroupSliceType: 289 GoSliceDataType []noalg.map.group[string]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute.array
     - __kind: PointerType
       ID: 181
       Name: '*noalg.map.group[string]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute'
@@ -2724,7 +2724,7 @@ Types:
         - Name: cap
           Offset: 16
           Type: 8 BaseType int
-      Data: 296 GoSliceDataType []*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttributeValue.array
+      Data: 290 GoSliceDataType []*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttributeValue.array
     - __kind: PointerType
       ID: 191
       Name: '**github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttributeValue'
@@ -2889,7 +2889,7 @@ Types:
         - Name: cap
           Offset: 16
           Type: 8 BaseType int
-      Data: 300 GoSliceDataType []*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span.array
+      Data: 292 GoSliceDataType []*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span.array
     - __kind: PointerType
       ID: 201
       Name: '**github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span'
@@ -3117,346 +3117,306 @@ Types:
       Pointee: 232 GoSliceDataType []string.array
     - __kind: GoSliceDataType
       ID: 234
-      Name: '[]*table<string,[]string>.array'
-      ByteSize: 8192
-      Element: 20 PointerType *table<string,[]string>
-    - __kind: GoSliceDataType
-      ID: 235
-      Name: '[]noalg.map.group[string][]string.array'
-      ByteSize: 2048
-      Element: 25 StructureType noalg.map.group[string][]string
-    - __kind: GoSliceDataType
-      ID: 236
-      Name: '[]*table<string,[]string>.array'
-      ByteSize: 8192
-      Element: 20 PointerType *table<string,[]string>
-    - __kind: GoSliceDataType
-      ID: 237
-      Name: '[]noalg.map.group[string][]string.array'
-      ByteSize: 2048
-      Element: 25 StructureType noalg.map.group[string][]string
-    - __kind: GoSliceDataType
-      ID: 238
       Name: '[]*table<string,[]*mime/multipart.FileHeader>.array'
       ByteSize: 8192
       Element: 41 PointerType *table<string,[]*mime/multipart.FileHeader>
     - __kind: GoSliceDataType
-      ID: 239
+      ID: 235
       Name: '[]noalg.map.group[string][]*mime/multipart.FileHeader.array'
       ByteSize: 2048
       Element: 45 StructureType noalg.map.group[string][]*mime/multipart.FileHeader
     - __kind: GoSliceDataType
-      ID: 240
+      ID: 236
       Name: '[]*mime/multipart.FileHeader.array'
       ByteSize: 2048
       Element: 50 PointerType *mime/multipart.FileHeader
     - __kind: PointerType
-      ID: 241
+      ID: 237
       Name: '*[]*mime/multipart.FileHeader.array'
       ByteSize: 8
-      Pointee: 240 GoSliceDataType []*mime/multipart.FileHeader.array
+      Pointee: 236 GoSliceDataType []*mime/multipart.FileHeader.array
     - __kind: GoSliceDataType
-      ID: 242
-      Name: '[]*table<string,[]string>.array'
-      ByteSize: 8192
-      Element: 20 PointerType *table<string,[]string>
-    - __kind: GoSliceDataType
-      ID: 243
-      Name: '[]noalg.map.group[string][]string.array'
-      ByteSize: 2048
-      Element: 25 StructureType noalg.map.group[string][]string
-    - __kind: GoSliceDataType
-      ID: 244
+      ID: 238
       Name: '[]uint8.array'
       ByteSize: 2048
       Element: 7 BaseType uint8
     - __kind: PointerType
-      ID: 245
+      ID: 239
       Name: '*[]uint8.array'
       ByteSize: 8
-      Pointee: 244 GoSliceDataType []uint8.array
+      Pointee: 238 GoSliceDataType []uint8.array
     - __kind: GoSliceDataType
-      ID: 246
+      ID: 240
       Name: '[]*crypto/x509.Certificate.array'
       ByteSize: 2048
       Element: 59 PointerType *crypto/x509.Certificate
     - __kind: PointerType
-      ID: 247
+      ID: 241
       Name: '*[]*crypto/x509.Certificate.array'
       ByteSize: 8
-      Pointee: 246 GoSliceDataType []*crypto/x509.Certificate.array
+      Pointee: 240 GoSliceDataType []*crypto/x509.Certificate.array
     - __kind: GoSliceDataType
-      ID: 248
+      ID: 242
       Name: math/big.nat.array
       ByteSize: 2048
       Element: 68 BaseType math/big.Word
     - __kind: PointerType
-      ID: 249
+      ID: 243
       Name: '*math/big.nat.array'
       ByteSize: 8
-      Pointee: 248 GoSliceDataType math/big.nat.array
+      Pointee: 242 GoSliceDataType math/big.nat.array
     - __kind: GoSliceDataType
-      ID: 250
+      ID: 244
       Name: '[]crypto/x509/pkix.AttributeTypeAndValue.array'
       ByteSize: 2048
       Element: 72 StructureType crypto/x509/pkix.AttributeTypeAndValue
     - __kind: PointerType
-      ID: 251
+      ID: 245
       Name: '*[]crypto/x509/pkix.AttributeTypeAndValue.array'
       ByteSize: 8
-      Pointee: 250 GoSliceDataType []crypto/x509/pkix.AttributeTypeAndValue.array
+      Pointee: 244 GoSliceDataType []crypto/x509/pkix.AttributeTypeAndValue.array
     - __kind: GoSliceDataType
-      ID: 252
+      ID: 246
       Name: encoding/asn1.ObjectIdentifier.array
       ByteSize: 2048
       Element: 8 BaseType int
     - __kind: PointerType
-      ID: 253
+      ID: 247
       Name: '*encoding/asn1.ObjectIdentifier.array'
       ByteSize: 8
-      Pointee: 252 GoSliceDataType encoding/asn1.ObjectIdentifier.array
+      Pointee: 246 GoSliceDataType encoding/asn1.ObjectIdentifier.array
     - __kind: GoSliceDataType
-      ID: 254
+      ID: 248
       Name: '[]time.zone.array'
       ByteSize: 2048
       Element: 80 StructureType time.zone
     - __kind: PointerType
-      ID: 255
+      ID: 249
       Name: '*[]time.zone.array'
       ByteSize: 8
-      Pointee: 254 GoSliceDataType []time.zone.array
+      Pointee: 248 GoSliceDataType []time.zone.array
     - __kind: GoSliceDataType
-      ID: 256
+      ID: 250
       Name: '[]time.zoneTrans.array'
       ByteSize: 2048
       Element: 83 StructureType time.zoneTrans
     - __kind: PointerType
-      ID: 257
+      ID: 251
       Name: '*[]time.zoneTrans.array'
       ByteSize: 8
-      Pointee: 256 GoSliceDataType []time.zoneTrans.array
+      Pointee: 250 GoSliceDataType []time.zoneTrans.array
     - __kind: GoSliceDataType
-      ID: 258
+      ID: 252
       Name: '[]crypto/x509/pkix.Extension.array'
       ByteSize: 2048
       Element: 87 StructureType crypto/x509/pkix.Extension
     - __kind: PointerType
-      ID: 259
+      ID: 253
       Name: '*[]crypto/x509/pkix.Extension.array'
       ByteSize: 8
-      Pointee: 258 GoSliceDataType []crypto/x509/pkix.Extension.array
+      Pointee: 252 GoSliceDataType []crypto/x509/pkix.Extension.array
     - __kind: GoSliceDataType
-      ID: 260
+      ID: 254
       Name: '[]encoding/asn1.ObjectIdentifier.array'
       ByteSize: 2048
       Element: 73 GoSliceHeaderType encoding/asn1.ObjectIdentifier
     - __kind: PointerType
-      ID: 261
+      ID: 255
       Name: '*[]encoding/asn1.ObjectIdentifier.array'
       ByteSize: 8
-      Pointee: 260 GoSliceDataType []encoding/asn1.ObjectIdentifier.array
+      Pointee: 254 GoSliceDataType []encoding/asn1.ObjectIdentifier.array
     - __kind: GoSliceDataType
-      ID: 262
+      ID: 256
       Name: '[]crypto/x509.ExtKeyUsage.array'
       ByteSize: 2048
       Element: 92 BaseType crypto/x509.ExtKeyUsage
     - __kind: PointerType
-      ID: 263
+      ID: 257
       Name: '*[]crypto/x509.ExtKeyUsage.array'
       ByteSize: 8
-      Pointee: 262 GoSliceDataType []crypto/x509.ExtKeyUsage.array
+      Pointee: 256 GoSliceDataType []crypto/x509.ExtKeyUsage.array
     - __kind: GoSliceDataType
-      ID: 264
+      ID: 258
       Name: '[]net.IP.array'
       ByteSize: 2048
       Element: 95 GoSliceHeaderType net.IP
     - __kind: PointerType
-      ID: 265
+      ID: 259
       Name: '*[]net.IP.array'
       ByteSize: 8
-      Pointee: 264 GoSliceDataType []net.IP.array
+      Pointee: 258 GoSliceDataType []net.IP.array
     - __kind: GoSliceDataType
-      ID: 266
+      ID: 260
       Name: net.IP.array
       ByteSize: 2048
       Element: 7 BaseType uint8
     - __kind: PointerType
-      ID: 267
+      ID: 261
       Name: '*net.IP.array'
       ByteSize: 8
-      Pointee: 266 GoSliceDataType net.IP.array
+      Pointee: 260 GoSliceDataType net.IP.array
     - __kind: GoSliceDataType
-      ID: 268
+      ID: 262
       Name: '[]*net/url.URL.array'
       ByteSize: 2048
       Element: 9 PointerType *net/url.URL
     - __kind: PointerType
-      ID: 269
+      ID: 263
       Name: '*[]*net/url.URL.array'
       ByteSize: 8
-      Pointee: 268 GoSliceDataType []*net/url.URL.array
+      Pointee: 262 GoSliceDataType []*net/url.URL.array
     - __kind: GoSliceDataType
-      ID: 270
+      ID: 264
       Name: '[]*net.IPNet.array'
       ByteSize: 2048
       Element: 100 PointerType *net.IPNet
     - __kind: PointerType
-      ID: 271
+      ID: 265
       Name: '*[]*net.IPNet.array'
       ByteSize: 8
-      Pointee: 270 GoSliceDataType []*net.IPNet.array
+      Pointee: 264 GoSliceDataType []*net.IPNet.array
     - __kind: GoSliceDataType
-      ID: 272
+      ID: 266
       Name: net.IPMask.array
       ByteSize: 2048
       Element: 7 BaseType uint8
     - __kind: PointerType
-      ID: 273
+      ID: 267
       Name: '*net.IPMask.array'
       ByteSize: 8
-      Pointee: 272 GoSliceDataType net.IPMask.array
+      Pointee: 266 GoSliceDataType net.IPMask.array
     - __kind: GoSliceDataType
-      ID: 274
+      ID: 268
       Name: '[]crypto/x509.OID.array'
       ByteSize: 2048
       Element: 105 StructureType crypto/x509.OID
     - __kind: PointerType
-      ID: 275
+      ID: 269
       Name: '*[]crypto/x509.OID.array'
       ByteSize: 8
-      Pointee: 274 GoSliceDataType []crypto/x509.OID.array
+      Pointee: 268 GoSliceDataType []crypto/x509.OID.array
     - __kind: GoSliceDataType
-      ID: 276
+      ID: 270
       Name: '[]crypto/x509.PolicyMapping.array'
       ByteSize: 2048
       Element: 108 StructureType crypto/x509.PolicyMapping
     - __kind: PointerType
-      ID: 277
+      ID: 271
       Name: '*[]crypto/x509.PolicyMapping.array'
       ByteSize: 8
-      Pointee: 276 GoSliceDataType []crypto/x509.PolicyMapping.array
+      Pointee: 270 GoSliceDataType []crypto/x509.PolicyMapping.array
     - __kind: GoSliceDataType
-      ID: 278
+      ID: 272
       Name: '[][]*crypto/x509.Certificate.array'
       ByteSize: 2048
       Element: 57 GoSliceHeaderType []*crypto/x509.Certificate
     - __kind: PointerType
-      ID: 279
+      ID: 273
       Name: '*[][]*crypto/x509.Certificate.array'
       ByteSize: 8
-      Pointee: 278 GoSliceDataType [][]*crypto/x509.Certificate.array
+      Pointee: 272 GoSliceDataType [][]*crypto/x509.Certificate.array
     - __kind: GoSliceDataType
-      ID: 280
+      ID: 274
       Name: '[][]uint8.array'
       ByteSize: 2048
       Element: 53 GoSliceHeaderType []uint8
     - __kind: PointerType
-      ID: 281
+      ID: 275
       Name: '*[][]uint8.array'
       ByteSize: 8
-      Pointee: 280 GoSliceDataType [][]uint8.array
+      Pointee: 274 GoSliceDataType [][]uint8.array
     - __kind: GoSliceDataType
-      ID: 282
+      ID: 276
       Name: '[]net/http.segment.array'
       ByteSize: 2048
       Element: 123 StructureType net/http.segment
     - __kind: PointerType
-      ID: 283
+      ID: 277
       Name: '*[]net/http.segment.array'
       ByteSize: 8
-      Pointee: 282 GoSliceDataType []net/http.segment.array
+      Pointee: 276 GoSliceDataType []net/http.segment.array
     - __kind: GoSliceDataType
-      ID: 284
+      ID: 278
       Name: '[]*table<string,string>.array'
       ByteSize: 8192
       Element: 128 PointerType *table<string,string>
     - __kind: GoSliceDataType
-      ID: 285
+      ID: 279
       Name: '[]noalg.map.group[string]string.array'
       ByteSize: 2048
       Element: 132 StructureType noalg.map.group[string]string
     - __kind: GoSliceDataType
-      ID: 286
+      ID: 280
       Name: '[]*table<string,interface {}>.array'
       ByteSize: 8192
       Element: 149 PointerType *table<string,interface {}>
     - __kind: GoSliceDataType
-      ID: 287
+      ID: 281
       Name: '[]noalg.map.group[string]interface {}.array'
       ByteSize: 2048
       Element: 153 StructureType noalg.map.group[string]interface {}
     - __kind: GoSliceDataType
-      ID: 288
+      ID: 282
       Name: '[]*table<string,float64>.array'
       ByteSize: 8192
       Element: 160 PointerType *table<string,float64>
     - __kind: GoSliceDataType
-      ID: 289
+      ID: 283
       Name: '[]noalg.map.group[string]float64.array'
       ByteSize: 2048
       Element: 164 StructureType noalg.map.group[string]float64
     - __kind: GoSliceDataType
-      ID: 290
+      ID: 284
       Name: '[]github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink.array'
       ByteSize: 2048
       Element: 170 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink
     - __kind: PointerType
-      ID: 291
+      ID: 285
       Name: '*[]github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink.array'
       ByteSize: 8
-      Pointee: 290 GoSliceDataType []github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink.array
+      Pointee: 284 GoSliceDataType []github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink.array
     - __kind: GoSliceDataType
-      ID: 292
+      ID: 286
       Name: '[]github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent.array'
       ByteSize: 2048
       Element: 173 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent
     - __kind: PointerType
-      ID: 293
+      ID: 287
       Name: '*[]github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent.array'
       ByteSize: 8
-      Pointee: 292 GoSliceDataType []github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent.array
+      Pointee: 286 GoSliceDataType []github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent.array
     - __kind: GoSliceDataType
-      ID: 294
+      ID: 288
       Name: '[]*table<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>.array'
       ByteSize: 8192
       Element: 178 PointerType *table<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
     - __kind: GoSliceDataType
-      ID: 295
+      ID: 289
       Name: '[]noalg.map.group[string]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute.array'
       ByteSize: 2048
       Element: 182 StructureType noalg.map.group[string]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
     - __kind: GoSliceDataType
-      ID: 296
+      ID: 290
       Name: '[]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttributeValue.array'
       ByteSize: 2048
       Element: 192 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttributeValue
     - __kind: PointerType
-      ID: 297
+      ID: 291
       Name: '*[]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttributeValue.array'
       ByteSize: 8
-      Pointee: 296 GoSliceDataType []*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttributeValue.array
+      Pointee: 290 GoSliceDataType []*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttributeValue.array
     - __kind: GoSliceDataType
-      ID: 298
-      Name: '[]*table<string,interface {}>.array'
-      ByteSize: 8192
-      Element: 149 PointerType *table<string,interface {}>
-    - __kind: GoSliceDataType
-      ID: 299
-      Name: '[]noalg.map.group[string]interface {}.array'
-      ByteSize: 2048
-      Element: 153 StructureType noalg.map.group[string]interface {}
-    - __kind: GoSliceDataType
-      ID: 300
+      ID: 292
       Name: '[]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span.array'
       ByteSize: 2048
       Element: 135 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span
     - __kind: PointerType
-      ID: 301
+      ID: 293
       Name: '*[]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span.array'
       ByteSize: 8
-      Pointee: 300 GoSliceDataType []*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span.array
+      Pointee: 292 GoSliceDataType []*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span.array
     - __kind: EventRootType
-      ID: 302
+      ID: 294
       Name: Probe[main.HandleHTTP]
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -3480,7 +3440,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 303
+      ID: 295
       Name: Probe[main.LookAtTheRequest]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -3494,6 +3454,6 @@ Types:
                   Variable: {subprogram: 2, index: 0, name: path}
                   Offset: 0
                   ByteSize: 16
-MaxTypeID: 303
+MaxTypeID: 295
 Issues: []
 GoModuledataInfo: {FirstModuledataAddr: "0x18bb880", TypesOffset: 296}

--- a/pkg/dyninst/irgen/testdata/snapshot/rc_tester.arch=amd64,toolchain=go1.25.0.yaml
+++ b/pkg/dyninst/irgen/testdata/snapshot/rc_tester.arch=amd64,toolchain=go1.25.0.yaml
@@ -10,7 +10,7 @@ Probes:
       subprogram: {subprogram: 1}
       events:
         - ID: 1
-          Type: 294 EventRootType Probe[main.HandleHTTP]
+          Type: 214 EventRootType Probe[main.HandleHTTP]
           InjectionPoints: [{PC: "0xd36353", Frameless: false}]
           Condition: null
     - id: look_at_the_request
@@ -23,7 +23,7 @@ Probes:
       subprogram: {subprogram: 2}
       events:
         - ID: 2
-          Type: 295 EventRootType Probe[main.LookAtTheRequest]
+          Type: 215 EventRootType Probe[main.LookAtTheRequest]
           InjectionPoints: [{PC: "0xd366ae", Frameless: false}]
           Condition: null
 Subprograms:
@@ -104,65 +104,38 @@ Types:
       GoKind: 22
       Pointee: 110 PointerType *crypto/x509.Certificate
     - __kind: PointerType
-      ID: 173
-      Name: '**github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span'
-      ByteSize: 8
-      GoKind: 22
-      Pointee: 39 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span
-    - __kind: PointerType
-      ID: 257
-      Name: '**github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttributeValue'
-      ByteSize: 8
-      GoKind: 22
-      Pointee: 258 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttributeValue
-    - __kind: PointerType
-      ID: 181
+      ID: 96
       Name: '**mime/multipart.FileHeader'
       ByteSize: 8
       GoKind: 22
-      Pointee: 182 PointerType *mime/multipart.FileHeader
+      Pointee: 97 PointerType *mime/multipart.FileHeader
     - __kind: PointerType
-      ID: 229
+      ID: 152
       Name: '**net.IPNet'
       ByteSize: 8
       GoKind: 22
-      Pointee: 230 PointerType *net.IPNet
+      Pointee: 153 PointerType *net.IPNet
     - __kind: PointerType
-      ID: 227
+      ID: 150
       Name: '**net/url.URL'
       ByteSize: 8
       GoKind: 22
-      Pointee: 43 PointerType *net/url.URL
+      Pointee: 45 PointerType *net/url.URL
     - __kind: PointerType
-      ID: 126
-      Name: '**table<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>'
-      ByteSize: 8
-      Pointee: 127 PointerType *table<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
-    - __kind: PointerType
-      ID: 105
+      ID: 87
       Name: '**table<string,[]*mime/multipart.FileHeader>'
       ByteSize: 8
-      Pointee: 106 PointerType *table<string,[]*mime/multipart.FileHeader>
+      Pointee: 88 PointerType *table<string,[]*mime/multipart.FileHeader>
     - __kind: PointerType
-      ID: 48
+      ID: 50
       Name: '**table<string,[]string>'
       ByteSize: 8
-      Pointee: 49 PointerType *table<string,[]string>
+      Pointee: 51 PointerType *table<string,[]string>
     - __kind: PointerType
-      ID: 83
-      Name: '**table<string,float64>'
-      ByteSize: 8
-      Pointee: 84 PointerType *table<string,float64>
-    - __kind: PointerType
-      ID: 78
-      Name: '**table<string,interface {}>'
-      ByteSize: 8
-      Pointee: 79 PointerType *table<string,interface {}>
-    - __kind: PointerType
-      ID: 67
+      ID: 69
       Name: '**table<string,string>'
       ByteSize: 8
-      Pointee: 68 PointerType *table<string,string>
+      Pointee: 70 PointerType *table<string,string>
     - __kind: PointerType
       ID: 112
       Name: '*[]*crypto/x509.Certificate'
@@ -170,122 +143,102 @@ Types:
       GoKind: 22
       Pointee: 108 GoSliceHeaderType []*crypto/x509.Certificate
     - __kind: PointerType
-      ID: 186
+      ID: 119
       Name: '*[]*crypto/x509.Certificate.array'
       ByteSize: 8
-      Pointee: 185 GoSliceDataType []*crypto/x509.Certificate.array
+      Pointee: 118 GoSliceDataType []*crypto/x509.Certificate.array
     - __kind: PointerType
-      ID: 242
-      Name: '*[]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span.array'
-      ByteSize: 8
-      Pointee: 241 GoSliceDataType []*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span.array
-    - __kind: PointerType
-      ID: 290
-      Name: '*[]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttributeValue.array'
-      ByteSize: 8
-      Pointee: 289 GoSliceDataType []*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttributeValue.array
-    - __kind: PointerType
-      ID: 244
+      ID: 102
       Name: '*[]*mime/multipart.FileHeader.array'
       ByteSize: 8
-      Pointee: 243 GoSliceDataType []*mime/multipart.FileHeader.array
+      Pointee: 101 GoSliceDataType []*mime/multipart.FileHeader.array
     - __kind: PointerType
-      ID: 276
+      ID: 189
       Name: '*[]*net.IPNet.array'
       ByteSize: 8
-      Pointee: 275 GoSliceDataType []*net.IPNet.array
+      Pointee: 188 GoSliceDataType []*net.IPNet.array
     - __kind: PointerType
-      ID: 274
+      ID: 186
       Name: '*[]*net/url.URL.array'
       ByteSize: 8
-      Pointee: 273 GoSliceDataType []*net/url.URL.array
+      Pointee: 185 GoSliceDataType []*net/url.URL.array
     - __kind: PointerType
-      ID: 188
+      ID: 121
       Name: '*[][]*crypto/x509.Certificate.array'
       ByteSize: 8
-      Pointee: 187 GoSliceDataType [][]*crypto/x509.Certificate.array
+      Pointee: 120 GoSliceDataType [][]*crypto/x509.Certificate.array
     - __kind: PointerType
-      ID: 190
+      ID: 123
       Name: '*[][]uint8.array'
       ByteSize: 8
-      Pointee: 189 GoSliceDataType [][]uint8.array
+      Pointee: 122 GoSliceDataType [][]uint8.array
     - __kind: PointerType
-      ID: 268
+      ID: 182
       Name: '*[]crypto/x509.ExtKeyUsage.array'
       ByteSize: 8
-      Pointee: 267 GoSliceDataType []crypto/x509.ExtKeyUsage.array
+      Pointee: 181 GoSliceDataType []crypto/x509.ExtKeyUsage.array
     - __kind: PointerType
-      ID: 278
+      ID: 191
       Name: '*[]crypto/x509.OID.array'
       ByteSize: 8
-      Pointee: 277 GoSliceDataType []crypto/x509.OID.array
+      Pointee: 190 GoSliceDataType []crypto/x509.OID.array
     - __kind: PointerType
-      ID: 280
+      ID: 193
       Name: '*[]crypto/x509.PolicyMapping.array'
       ByteSize: 8
-      Pointee: 279 GoSliceDataType []crypto/x509.PolicyMapping.array
-    - __kind: PointerType
-      ID: 260
-      Name: '*[]crypto/x509/pkix.AttributeTypeAndValue.array'
-      ByteSize: 8
-      Pointee: 259 GoSliceDataType []crypto/x509/pkix.AttributeTypeAndValue.array
-    - __kind: PointerType
-      ID: 262
-      Name: '*[]crypto/x509/pkix.Extension.array'
-      ByteSize: 8
-      Pointee: 261 GoSliceDataType []crypto/x509/pkix.Extension.array
-    - __kind: PointerType
-      ID: 264
-      Name: '*[]encoding/asn1.ObjectIdentifier.array'
-      ByteSize: 8
-      Pointee: 263 GoSliceDataType []encoding/asn1.ObjectIdentifier.array
-    - __kind: PointerType
-      ID: 164
-      Name: '*[]github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink.array'
-      ByteSize: 8
-      Pointee: 163 GoSliceDataType []github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink.array
+      Pointee: 192 GoSliceDataType []crypto/x509.PolicyMapping.array
     - __kind: PointerType
       ID: 166
-      Name: '*[]github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent.array'
+      Name: '*[]crypto/x509/pkix.AttributeTypeAndValue.array'
       ByteSize: 8
-      Pointee: 165 GoSliceDataType []github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent.array
+      Pointee: 165 GoSliceDataType []crypto/x509/pkix.AttributeTypeAndValue.array
     - __kind: PointerType
-      ID: 270
+      ID: 178
+      Name: '*[]crypto/x509/pkix.Extension.array'
+      ByteSize: 8
+      Pointee: 177 GoSliceDataType []crypto/x509/pkix.Extension.array
+    - __kind: PointerType
+      ID: 180
+      Name: '*[]encoding/asn1.ObjectIdentifier.array'
+      ByteSize: 8
+      Pointee: 179 GoSliceDataType []encoding/asn1.ObjectIdentifier.array
+    - __kind: PointerType
+      ID: 184
       Name: '*[]net.IP.array'
       ByteSize: 8
-      Pointee: 269 GoSliceDataType []net.IP.array
+      Pointee: 183 GoSliceDataType []net.IP.array
     - __kind: PointerType
-      ID: 192
+      ID: 205
       Name: '*[]net/http.segment.array'
       ByteSize: 8
-      Pointee: 191 GoSliceDataType []net/http.segment.array
+      Pointee: 204 GoSliceDataType []net/http.segment.array
     - __kind: PointerType
-      ID: 140
+      ID: 82
       Name: '*[]string.array'
       ByteSize: 8
-      Pointee: 139 GoSliceDataType []string.array
+      Pointee: 81 GoSliceDataType []string.array
     - __kind: PointerType
-      ID: 286
+      ID: 174
       Name: '*[]time.zone.array'
       ByteSize: 8
-      Pointee: 285 GoSliceDataType []time.zone.array
+      Pointee: 173 GoSliceDataType []time.zone.array
     - __kind: PointerType
-      ID: 288
+      ID: 176
       Name: '*[]time.zoneTrans.array'
       ByteSize: 8
-      Pointee: 287 GoSliceDataType []time.zoneTrans.array
+      Pointee: 175 GoSliceDataType []time.zoneTrans.array
     - __kind: PointerType
       ID: 114
       Name: '*[]uint8'
       ByteSize: 8
       GoRuntimeType: 486560
       GoKind: 22
-      Pointee: 94 GoSliceHeaderType []uint8
+      Pointee: 104 GoSliceHeaderType []uint8
     - __kind: PointerType
-      ID: 168
+      ID: 106
       Name: '*[]uint8.array'
       ByteSize: 8
-      Pointee: 167 GoSliceDataType []uint8.array
+      Pointee: 105 GoSliceDataType []uint8.array
     - __kind: PointerType
       ID: 11
       Name: '*bool'
@@ -299,68 +252,68 @@ Types:
       ByteSize: 8
       GoRuntimeType: 2.321376e+06
       GoKind: 22
-      Pointee: 42 StructureType bytes.Buffer
+      Pointee: 42 UnresolvedPointeeType bytes.Buffer
     - __kind: PointerType
-      ID: 56
+      ID: 58
       Name: '*crypto/tls.ConnectionState'
       ByteSize: 8
       GoRuntimeType: 924032
       GoKind: 22
-      Pointee: 57 StructureType crypto/tls.ConnectionState
+      Pointee: 59 StructureType crypto/tls.ConnectionState
     - __kind: PointerType
       ID: 110
       Name: '*crypto/x509.Certificate'
       ByteSize: 8
       GoRuntimeType: 2.089664e+06
       GoKind: 22
-      Pointee: 170 StructureType crypto/x509.Certificate
+      Pointee: 117 StructureType crypto/x509.Certificate
     - __kind: PointerType
-      ID: 221
+      ID: 144
       Name: '*crypto/x509.ExtKeyUsage'
       ByteSize: 8
       GoRuntimeType: 429920
       GoKind: 22
-      Pointee: 222 BaseType crypto/x509.ExtKeyUsage
+      Pointee: 145 BaseType crypto/x509.ExtKeyUsage
     - __kind: PointerType
-      ID: 232
+      ID: 155
       Name: '*crypto/x509.OID'
       ByteSize: 8
       GoRuntimeType: 1.998112e+06
       GoKind: 22
-      Pointee: 233 StructureType crypto/x509.OID
+      Pointee: 156 StructureType crypto/x509.OID
     - __kind: PointerType
-      ID: 235
+      ID: 158
       Name: '*crypto/x509.PolicyMapping'
       ByteSize: 8
       GoRuntimeType: 429984
       GoKind: 22
-      Pointee: 236 StructureType crypto/x509.PolicyMapping
+      Pointee: 159 StructureType crypto/x509.PolicyMapping
     - __kind: PointerType
-      ID: 208
+      ID: 131
       Name: '*crypto/x509/pkix.AttributeTypeAndValue'
       ByteSize: 8
       GoRuntimeType: 446624
       GoKind: 22
-      Pointee: 209 StructureType crypto/x509/pkix.AttributeTypeAndValue
+      Pointee: 132 StructureType crypto/x509/pkix.AttributeTypeAndValue
     - __kind: PointerType
-      ID: 215
+      ID: 138
       Name: '*crypto/x509/pkix.Extension'
       ByteSize: 8
       GoRuntimeType: 446816
       GoKind: 22
-      Pointee: 216 StructureType crypto/x509/pkix.Extension
+      Pointee: 139 StructureType crypto/x509/pkix.Extension
     - __kind: PointerType
-      ID: 218
+      ID: 141
       Name: '*encoding/asn1.ObjectIdentifier'
       ByteSize: 8
       GoRuntimeType: 1.079776e+06
       GoKind: 22
-      Pointee: 219 GoSliceHeaderType encoding/asn1.ObjectIdentifier
+      Pointee: 142 GoSliceHeaderType encoding/asn1.ObjectIdentifier
     - __kind: PointerType
-      ID: 266
+      ID: 195
       Name: '*encoding/asn1.ObjectIdentifier.array'
       ByteSize: 8
-      Pointee: 265 GoSliceDataType encoding/asn1.ObjectIdentifier.array
+      Pointee: 194 GoSliceDataType encoding/asn1.ObjectIdentifier.array
     - __kind: PointerType
       ID: 33
       Name: '*error'
@@ -388,56 +341,7 @@ Types:
       ByteSize: 8
       GoRuntimeType: 2.33264e+06
       GoKind: 22
-      Pointee: 40 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span
-    - __kind: PointerType
-      ID: 91
-      Name: '*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanContext'
-      ByteSize: 8
-      GoRuntimeType: 2.054336e+06
-      GoKind: 22
-      Pointee: 92 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanContext
-    - __kind: PointerType
-      ID: 86
-      Name: '*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink'
-      ByteSize: 8
-      GoRuntimeType: 1.21456e+06
-      GoKind: 22
-      Pointee: 87 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink
-    - __kind: PointerType
-      ID: 89
-      Name: '*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent'
-      ByteSize: 8
-      GoRuntimeType: 1.214688e+06
-      GoKind: 22
-      Pointee: 90 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent
-    - __kind: PointerType
-      ID: 239
-      Name: '*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttribute'
-      ByteSize: 8
-      GoRuntimeType: 1.215328e+06
-      GoKind: 22
-      Pointee: 240 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttribute
-    - __kind: PointerType
-      ID: 258
-      Name: '*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttributeValue'
-      ByteSize: 8
-      GoRuntimeType: 1.215072e+06
-      GoKind: 22
-      Pointee: 282 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttributeValue
-    - __kind: PointerType
-      ID: 198
-      Name: '*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute'
-      ByteSize: 8
-      GoRuntimeType: 1.215456e+06
-      GoKind: 22
-      Pointee: 199 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
-    - __kind: PointerType
-      ID: 129
-      Name: '*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.trace'
-      ByteSize: 8
-      GoRuntimeType: 2.277568e+06
-      GoKind: 22
-      Pointee: 130 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.trace
+      Pointee: 40 UnresolvedPointeeType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span
     - __kind: PointerType
       ID: 26
       Name: '*int'
@@ -474,92 +378,77 @@ Types:
       GoKind: 22
       Pointee: 16 BaseType int8
     - __kind: PointerType
-      ID: 124
-      Name: '*map<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>'
-      ByteSize: 8
-      Pointee: 125 GoSwissMapHeaderType map<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
-    - __kind: PointerType
-      ID: 103
+      ID: 85
       Name: '*map<string,[]*mime/multipart.FileHeader>'
       ByteSize: 8
-      Pointee: 104 GoSwissMapHeaderType map<string,[]*mime/multipart.FileHeader>
+      Pointee: 86 GoSwissMapHeaderType map<string,[]*mime/multipart.FileHeader>
     - __kind: PointerType
-      ID: 46
+      ID: 48
       Name: '*map<string,[]string>'
       ByteSize: 8
-      Pointee: 47 GoSwissMapHeaderType map<string,[]string>
+      Pointee: 49 GoSwissMapHeaderType map<string,[]string>
     - __kind: PointerType
-      ID: 81
-      Name: '*map<string,float64>'
-      ByteSize: 8
-      Pointee: 82 GoSwissMapHeaderType map<string,float64>
-    - __kind: PointerType
-      ID: 76
-      Name: '*map<string,interface {}>'
-      ByteSize: 8
-      Pointee: 77 GoSwissMapHeaderType map<string,interface {}>
-    - __kind: PointerType
-      ID: 65
+      ID: 67
       Name: '*map<string,string>'
       ByteSize: 8
-      Pointee: 66 GoSwissMapHeaderType map<string,string>
+      Pointee: 68 GoSwissMapHeaderType map<string,string>
     - __kind: PointerType
-      ID: 204
+      ID: 127
       Name: '*math/big.Int'
       ByteSize: 8
       GoRuntimeType: 2.447424e+06
       GoKind: 22
-      Pointee: 205 StructureType math/big.Int
+      Pointee: 128 StructureType math/big.Int
     - __kind: PointerType
-      ID: 246
+      ID: 161
       Name: '*math/big.Word'
       ByteSize: 8
       GoRuntimeType: 432800
       GoKind: 22
-      Pointee: 247 BaseType math/big.Word
+      Pointee: 162 BaseType math/big.Word
     - __kind: PointerType
-      ID: 284
+      ID: 164
       Name: '*math/big.nat.array'
       ByteSize: 8
-      Pointee: 283 GoSliceDataType math/big.nat.array
+      Pointee: 163 GoSliceDataType math/big.nat.array
     - __kind: PointerType
-      ID: 182
+      ID: 97
       Name: '*mime/multipart.FileHeader'
       ByteSize: 8
       GoRuntimeType: 925568
       GoKind: 22
-      Pointee: 237 StructureType mime/multipart.FileHeader
+      Pointee: 100 StructureType mime/multipart.FileHeader
     - __kind: PointerType
-      ID: 54
+      ID: 56
       Name: '*mime/multipart.Form'
       ByteSize: 8
       GoRuntimeType: 925664
       GoKind: 22
-      Pointee: 55 StructureType mime/multipart.Form
+      Pointee: 57 StructureType mime/multipart.Form
     - __kind: PointerType
-      ID: 224
+      ID: 147
       Name: '*net.IP'
       ByteSize: 8
       GoRuntimeType: 2.206912e+06
       GoKind: 22
-      Pointee: 225 GoSliceHeaderType net.IP
+      Pointee: 148 GoSliceHeaderType net.IP
     - __kind: PointerType
-      ID: 272
+      ID: 197
       Name: '*net.IP.array'
       ByteSize: 8
-      Pointee: 271 GoSliceDataType net.IP.array
+      Pointee: 196 GoSliceDataType net.IP.array
     - __kind: PointerType
-      ID: 293
+      ID: 200
       Name: '*net.IPMask.array'
       ByteSize: 8
-      Pointee: 292 GoSliceDataType net.IPMask.array
+      Pointee: 199 GoSliceDataType net.IPMask.array
     - __kind: PointerType
-      ID: 230
+      ID: 153
       Name: '*net.IPNet'
       ByteSize: 8
       GoRuntimeType: 1.208416e+06
       GoKind: 22
-      Pointee: 254 StructureType net.IPNet
+      Pointee: 187 StructureType net.IPNet
     - __kind: PointerType
       ID: 37
       Name: '*net/http.Request'
@@ -568,70 +457,55 @@ Types:
       GoKind: 22
       Pointee: 38 StructureType net/http.Request
     - __kind: PointerType
-      ID: 59
+      ID: 61
       Name: '*net/http.Response'
       ByteSize: 8
       GoRuntimeType: 1.7584e+06
       GoKind: 22
-      Pointee: 60 StructureType net/http.Response
+      Pointee: 62 StructureType net/http.Response
     - __kind: PointerType
-      ID: 62
+      ID: 64
       Name: '*net/http.pattern'
       ByteSize: 8
       GoRuntimeType: 1.642688e+06
       GoKind: 22
-      Pointee: 63 StructureType net/http.pattern
+      Pointee: 65 StructureType net/http.pattern
     - __kind: PointerType
-      ID: 118
+      ID: 202
       Name: '*net/http.segment'
       ByteSize: 8
       GoRuntimeType: 396384
       GoKind: 22
-      Pointee: 119 StructureType net/http.segment
+      Pointee: 203 StructureType net/http.segment
     - __kind: PointerType
-      ID: 43
+      ID: 45
       Name: '*net/url.URL'
       ByteSize: 8
       GoRuntimeType: 2.167328e+06
       GoKind: 22
-      Pointee: 44 StructureType net/url.URL
+      Pointee: 46 StructureType net/url.URL
     - __kind: PointerType
-      ID: 98
+      ID: 71
       Name: '*net/url.Userinfo'
       ByteSize: 8
       GoRuntimeType: 1.22608e+06
       GoKind: 22
-      Pointee: 99 StructureType net/url.Userinfo
+      Pointee: 72 StructureType net/url.Userinfo
     - __kind: PointerType
-      ID: 194
-      Name: '*noalg.map.group[string]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute'
-      ByteSize: 8
-      Pointee: 195 StructureType noalg.map.group[string]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
-    - __kind: PointerType
-      ID: 176
+      ID: 91
       Name: '*noalg.map.group[string][]*mime/multipart.FileHeader'
       ByteSize: 8
-      Pointee: 177 StructureType noalg.map.group[string][]*mime/multipart.FileHeader
+      Pointee: 92 StructureType noalg.map.group[string][]*mime/multipart.FileHeader
     - __kind: PointerType
-      ID: 133
+      ID: 75
       Name: '*noalg.map.group[string][]string'
       ByteSize: 8
-      Pointee: 134 StructureType noalg.map.group[string][]string
+      Pointee: 76 StructureType noalg.map.group[string][]string
     - __kind: PointerType
-      ID: 157
-      Name: '*noalg.map.group[string]float64'
-      ByteSize: 8
-      Pointee: 158 StructureType noalg.map.group[string]float64
-    - __kind: PointerType
-      ID: 149
-      Name: '*noalg.map.group[string]interface {}'
-      ByteSize: 8
-      Pointee: 150 StructureType noalg.map.group[string]interface {}
-    - __kind: PointerType
-      ID: 142
+      ID: 208
       Name: '*noalg.map.group[string]string'
       ByteSize: 8
-      Pointee: 143 StructureType noalg.map.group[string]string
+      Pointee: 209 StructureType noalg.map.group[string]string
     - __kind: PointerType
       ID: 22
       Name: '*string'
@@ -640,61 +514,46 @@ Types:
       GoKind: 22
       Pointee: 9 GoStringHeaderType string
     - __kind: PointerType
-      ID: 97
+      ID: 44
       Name: '*string.str'
       ByteSize: 8
-      Pointee: 96 GoStringDataType string.str
+      Pointee: 43 GoStringDataType string.str
     - __kind: PointerType
-      ID: 127
-      Name: '*table<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>'
-      ByteSize: 8
-      Pointee: 171 StructureType table<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
-    - __kind: PointerType
-      ID: 106
+      ID: 88
       Name: '*table<string,[]*mime/multipart.FileHeader>'
       ByteSize: 8
-      Pointee: 169 StructureType table<string,[]*mime/multipart.FileHeader>
+      Pointee: 89 StructureType table<string,[]*mime/multipart.FileHeader>
     - __kind: PointerType
-      ID: 49
+      ID: 51
       Name: '*table<string,[]string>'
       ByteSize: 8
-      Pointee: 100 StructureType table<string,[]string>
+      Pointee: 73 StructureType table<string,[]string>
     - __kind: PointerType
-      ID: 84
-      Name: '*table<string,float64>'
-      ByteSize: 8
-      Pointee: 122 StructureType table<string,float64>
-    - __kind: PointerType
-      ID: 79
-      Name: '*table<string,interface {}>'
-      ByteSize: 8
-      Pointee: 121 StructureType table<string,interface {}>
-    - __kind: PointerType
-      ID: 68
+      ID: 70
       Name: '*table<string,string>'
       ByteSize: 8
-      Pointee: 120 StructureType table<string,string>
+      Pointee: 206 StructureType table<string,string>
     - __kind: PointerType
-      ID: 211
+      ID: 134
       Name: '*time.Location'
       ByteSize: 8
       GoRuntimeType: 1.64768e+06
       GoKind: 22
-      Pointee: 212 StructureType time.Location
+      Pointee: 135 StructureType time.Location
     - __kind: PointerType
-      ID: 249
+      ID: 168
       Name: '*time.zone'
       ByteSize: 8
       GoRuntimeType: 399456
       GoKind: 22
-      Pointee: 250 StructureType time.zone
+      Pointee: 169 StructureType time.zone
     - __kind: PointerType
-      ID: 252
+      ID: 171
       Name: '*time.zoneTrans'
       ByteSize: 8
       GoRuntimeType: 399520
       GoKind: 22
-      Pointee: 253 StructureType time.zoneTrans
+      Pointee: 172 StructureType time.zoneTrans
     - __kind: PointerType
       ID: 34
       Name: '*uint'
@@ -738,12 +597,12 @@ Types:
       GoKind: 22
       Pointee: 1 BaseType uintptr
     - __kind: GoChannelType
-      ID: 58
+      ID: 60
       Name: <-chan struct {}
       GoRuntimeType: 607264
       GoKind: 18
     - __kind: EventRootType
-      ID: 294
+      ID: 214
       Name: Probe[main.HandleHTTP]
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -767,7 +626,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 295
+      ID: 215
       Name: Probe[main.LookAtTheRequest]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -797,58 +656,14 @@ Types:
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 185 GoSliceDataType []*crypto/x509.Certificate.array
+      Data: 118 GoSliceDataType []*crypto/x509.Certificate.array
     - __kind: GoSliceDataType
-      ID: 185
+      ID: 118
       Name: '[]*crypto/x509.Certificate.array'
       ByteSize: 2048
       Element: 110 PointerType *crypto/x509.Certificate
     - __kind: GoSliceHeaderType
-      ID: 172
-      Name: '[]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span'
-      ByteSize: 24
-      GoRuntimeType: 495232
-      GoKind: 23
-      RawFields:
-        - Name: array
-          Offset: 0
-          Type: 173 PointerType **github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span
-        - Name: len
-          Offset: 8
-          Type: 7 BaseType int
-        - Name: cap
-          Offset: 16
-          Type: 7 BaseType int
-      Data: 241 GoSliceDataType []*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span.array
-    - __kind: GoSliceDataType
-      ID: 241
-      Name: '[]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span.array'
-      ByteSize: 2048
-      Element: 39 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span
-    - __kind: GoSliceHeaderType
-      ID: 256
-      Name: '[]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttributeValue'
-      ByteSize: 24
-      GoRuntimeType: 494848
-      GoKind: 23
-      RawFields:
-        - Name: array
-          Offset: 0
-          Type: 257 PointerType **github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttributeValue
-        - Name: len
-          Offset: 8
-          Type: 7 BaseType int
-        - Name: cap
-          Offset: 16
-          Type: 7 BaseType int
-      Data: 289 GoSliceDataType []*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttributeValue.array
-    - __kind: GoSliceDataType
-      ID: 289
-      Name: '[]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttributeValue.array'
-      ByteSize: 2048
-      Element: 258 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttributeValue
-    - __kind: GoSliceHeaderType
-      ID: 180
+      ID: 95
       Name: '[]*mime/multipart.FileHeader'
       ByteSize: 24
       GoRuntimeType: 492224
@@ -856,21 +671,21 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 181 PointerType **mime/multipart.FileHeader
+          Type: 96 PointerType **mime/multipart.FileHeader
         - Name: len
           Offset: 8
           Type: 7 BaseType int
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 243 GoSliceDataType []*mime/multipart.FileHeader.array
+      Data: 101 GoSliceDataType []*mime/multipart.FileHeader.array
     - __kind: GoSliceDataType
-      ID: 243
+      ID: 101
       Name: '[]*mime/multipart.FileHeader.array'
       ByteSize: 2048
-      Element: 182 PointerType *mime/multipart.FileHeader
+      Element: 97 PointerType *mime/multipart.FileHeader
     - __kind: GoSliceHeaderType
-      ID: 228
+      ID: 151
       Name: '[]*net.IPNet'
       ByteSize: 24
       GoRuntimeType: 509088
@@ -878,21 +693,21 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 229 PointerType **net.IPNet
+          Type: 152 PointerType **net.IPNet
         - Name: len
           Offset: 8
           Type: 7 BaseType int
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 275 GoSliceDataType []*net.IPNet.array
+      Data: 188 GoSliceDataType []*net.IPNet.array
     - __kind: GoSliceDataType
-      ID: 275
+      ID: 188
       Name: '[]*net.IPNet.array'
       ByteSize: 2048
-      Element: 230 PointerType *net.IPNet
+      Element: 153 PointerType *net.IPNet
     - __kind: GoSliceHeaderType
-      ID: 226
+      ID: 149
       Name: '[]*net/url.URL'
       ByteSize: 24
       GoRuntimeType: 509024
@@ -900,49 +715,34 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 227 PointerType **net/url.URL
+          Type: 150 PointerType **net/url.URL
         - Name: len
           Offset: 8
           Type: 7 BaseType int
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 273 GoSliceDataType []*net/url.URL.array
+      Data: 185 GoSliceDataType []*net/url.URL.array
     - __kind: GoSliceDataType
-      ID: 273
+      ID: 185
       Name: '[]*net/url.URL.array'
       ByteSize: 2048
-      Element: 43 PointerType *net/url.URL
+      Element: 45 PointerType *net/url.URL
     - __kind: GoSliceDataType
-      ID: 200
-      Name: '[]*table<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>.array'
-      ByteSize: 8192
-      Element: 127 PointerType *table<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
-    - __kind: GoSliceDataType
-      ID: 183
+      ID: 98
       Name: '[]*table<string,[]*mime/multipart.FileHeader>.array'
       ByteSize: 8192
-      Element: 106 PointerType *table<string,[]*mime/multipart.FileHeader>
+      Element: 88 PointerType *table<string,[]*mime/multipart.FileHeader>
     - __kind: GoSliceDataType
-      ID: 137
+      ID: 79
       Name: '[]*table<string,[]string>.array'
       ByteSize: 8192
-      Element: 49 PointerType *table<string,[]string>
+      Element: 51 PointerType *table<string,[]string>
     - __kind: GoSliceDataType
-      ID: 161
-      Name: '[]*table<string,float64>.array'
-      ByteSize: 8192
-      Element: 84 PointerType *table<string,float64>
-    - __kind: GoSliceDataType
-      ID: 154
-      Name: '[]*table<string,interface {}>.array'
-      ByteSize: 8192
-      Element: 79 PointerType *table<string,interface {}>
-    - __kind: GoSliceDataType
-      ID: 146
+      ID: 212
       Name: '[]*table<string,string>.array'
       ByteSize: 8192
-      Element: 68 PointerType *table<string,string>
+      Element: 70 PointerType *table<string,string>
     - __kind: GoSliceHeaderType
       ID: 111
       Name: '[][]*crypto/x509.Certificate'
@@ -959,9 +759,9 @@ Types:
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 187 GoSliceDataType [][]*crypto/x509.Certificate.array
+      Data: 120 GoSliceDataType [][]*crypto/x509.Certificate.array
     - __kind: GoSliceDataType
-      ID: 187
+      ID: 120
       Name: '[][]*crypto/x509.Certificate.array'
       ByteSize: 2048
       Element: 108 GoSliceHeaderType []*crypto/x509.Certificate
@@ -981,14 +781,14 @@ Types:
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 189 GoSliceDataType [][]uint8.array
+      Data: 122 GoSliceDataType [][]uint8.array
     - __kind: GoSliceDataType
-      ID: 189
+      ID: 122
       Name: '[][]uint8.array'
       ByteSize: 2048
-      Element: 94 GoSliceHeaderType []uint8
+      Element: 104 GoSliceHeaderType []uint8
     - __kind: GoSliceHeaderType
-      ID: 220
+      ID: 143
       Name: '[]crypto/x509.ExtKeyUsage'
       ByteSize: 24
       GoRuntimeType: 508960
@@ -996,21 +796,21 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 221 PointerType *crypto/x509.ExtKeyUsage
+          Type: 144 PointerType *crypto/x509.ExtKeyUsage
         - Name: len
           Offset: 8
           Type: 7 BaseType int
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 267 GoSliceDataType []crypto/x509.ExtKeyUsage.array
+      Data: 181 GoSliceDataType []crypto/x509.ExtKeyUsage.array
     - __kind: GoSliceDataType
-      ID: 267
+      ID: 181
       Name: '[]crypto/x509.ExtKeyUsage.array'
       ByteSize: 2048
-      Element: 222 BaseType crypto/x509.ExtKeyUsage
+      Element: 145 BaseType crypto/x509.ExtKeyUsage
     - __kind: GoSliceHeaderType
-      ID: 231
+      ID: 154
       Name: '[]crypto/x509.OID'
       ByteSize: 24
       GoRuntimeType: 509152
@@ -1018,21 +818,21 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 232 PointerType *crypto/x509.OID
+          Type: 155 PointerType *crypto/x509.OID
         - Name: len
           Offset: 8
           Type: 7 BaseType int
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 277 GoSliceDataType []crypto/x509.OID.array
+      Data: 190 GoSliceDataType []crypto/x509.OID.array
     - __kind: GoSliceDataType
-      ID: 277
+      ID: 190
       Name: '[]crypto/x509.OID.array'
       ByteSize: 2048
-      Element: 233 StructureType crypto/x509.OID
+      Element: 156 StructureType crypto/x509.OID
     - __kind: GoSliceHeaderType
-      ID: 234
+      ID: 157
       Name: '[]crypto/x509.PolicyMapping'
       ByteSize: 24
       GoRuntimeType: 509216
@@ -1040,21 +840,21 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 235 PointerType *crypto/x509.PolicyMapping
+          Type: 158 PointerType *crypto/x509.PolicyMapping
         - Name: len
           Offset: 8
           Type: 7 BaseType int
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 279 GoSliceDataType []crypto/x509.PolicyMapping.array
+      Data: 192 GoSliceDataType []crypto/x509.PolicyMapping.array
     - __kind: GoSliceDataType
-      ID: 279
+      ID: 192
       Name: '[]crypto/x509.PolicyMapping.array'
       ByteSize: 2048
-      Element: 236 StructureType crypto/x509.PolicyMapping
+      Element: 159 StructureType crypto/x509.PolicyMapping
     - __kind: GoSliceHeaderType
-      ID: 207
+      ID: 130
       Name: '[]crypto/x509/pkix.AttributeTypeAndValue'
       ByteSize: 24
       GoRuntimeType: 523680
@@ -1062,21 +862,21 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 208 PointerType *crypto/x509/pkix.AttributeTypeAndValue
+          Type: 131 PointerType *crypto/x509/pkix.AttributeTypeAndValue
         - Name: len
           Offset: 8
           Type: 7 BaseType int
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 259 GoSliceDataType []crypto/x509/pkix.AttributeTypeAndValue.array
+      Data: 165 GoSliceDataType []crypto/x509/pkix.AttributeTypeAndValue.array
     - __kind: GoSliceDataType
-      ID: 259
+      ID: 165
       Name: '[]crypto/x509/pkix.AttributeTypeAndValue.array'
       ByteSize: 2048
-      Element: 209 StructureType crypto/x509/pkix.AttributeTypeAndValue
+      Element: 132 StructureType crypto/x509/pkix.AttributeTypeAndValue
     - __kind: GoSliceHeaderType
-      ID: 214
+      ID: 137
       Name: '[]crypto/x509/pkix.Extension'
       ByteSize: 24
       GoRuntimeType: 508832
@@ -1084,21 +884,21 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 215 PointerType *crypto/x509/pkix.Extension
+          Type: 138 PointerType *crypto/x509/pkix.Extension
         - Name: len
           Offset: 8
           Type: 7 BaseType int
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 261 GoSliceDataType []crypto/x509/pkix.Extension.array
+      Data: 177 GoSliceDataType []crypto/x509/pkix.Extension.array
     - __kind: GoSliceDataType
-      ID: 261
+      ID: 177
       Name: '[]crypto/x509/pkix.Extension.array'
       ByteSize: 2048
-      Element: 216 StructureType crypto/x509/pkix.Extension
+      Element: 139 StructureType crypto/x509/pkix.Extension
     - __kind: GoSliceHeaderType
-      ID: 217
+      ID: 140
       Name: '[]encoding/asn1.ObjectIdentifier'
       ByteSize: 24
       GoRuntimeType: 508896
@@ -1106,65 +906,21 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 218 PointerType *encoding/asn1.ObjectIdentifier
+          Type: 141 PointerType *encoding/asn1.ObjectIdentifier
         - Name: len
           Offset: 8
           Type: 7 BaseType int
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 263 GoSliceDataType []encoding/asn1.ObjectIdentifier.array
+      Data: 179 GoSliceDataType []encoding/asn1.ObjectIdentifier.array
     - __kind: GoSliceDataType
-      ID: 263
+      ID: 179
       Name: '[]encoding/asn1.ObjectIdentifier.array'
       ByteSize: 2048
-      Element: 219 GoSliceHeaderType encoding/asn1.ObjectIdentifier
+      Element: 142 GoSliceHeaderType encoding/asn1.ObjectIdentifier
     - __kind: GoSliceHeaderType
-      ID: 85
-      Name: '[]github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink'
-      ByteSize: 24
-      GoRuntimeType: 494784
-      GoKind: 23
-      RawFields:
-        - Name: array
-          Offset: 0
-          Type: 86 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink
-        - Name: len
-          Offset: 8
-          Type: 7 BaseType int
-        - Name: cap
-          Offset: 16
-          Type: 7 BaseType int
-      Data: 163 GoSliceDataType []github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink.array
-    - __kind: GoSliceDataType
-      ID: 163
-      Name: '[]github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink.array'
-      ByteSize: 2048
-      Element: 87 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink
-    - __kind: GoSliceHeaderType
-      ID: 88
-      Name: '[]github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent'
-      ByteSize: 24
-      GoRuntimeType: 494976
-      GoKind: 23
-      RawFields:
-        - Name: array
-          Offset: 0
-          Type: 89 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent
-        - Name: len
-          Offset: 8
-          Type: 7 BaseType int
-        - Name: cap
-          Offset: 16
-          Type: 7 BaseType int
-      Data: 165 GoSliceDataType []github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent.array
-    - __kind: GoSliceDataType
-      ID: 165
-      Name: '[]github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent.array'
-      ByteSize: 2048
-      Element: 90 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent
-    - __kind: GoSliceHeaderType
-      ID: 223
+      ID: 146
       Name: '[]net.IP'
       ByteSize: 24
       GoRuntimeType: 487904
@@ -1172,21 +928,21 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 224 PointerType *net.IP
+          Type: 147 PointerType *net.IP
         - Name: len
           Offset: 8
           Type: 7 BaseType int
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 269 GoSliceDataType []net.IP.array
+      Data: 183 GoSliceDataType []net.IP.array
     - __kind: GoSliceDataType
-      ID: 269
+      ID: 183
       Name: '[]net.IP.array'
       ByteSize: 2048
-      Element: 225 GoSliceHeaderType net.IP
+      Element: 148 GoSliceHeaderType net.IP
     - __kind: GoSliceHeaderType
-      ID: 117
+      ID: 201
       Name: '[]net/http.segment'
       ByteSize: 24
       GoRuntimeType: 489600
@@ -1194,51 +950,36 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 118 PointerType *net/http.segment
+          Type: 202 PointerType *net/http.segment
         - Name: len
           Offset: 8
           Type: 7 BaseType int
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 191 GoSliceDataType []net/http.segment.array
+      Data: 204 GoSliceDataType []net/http.segment.array
     - __kind: GoSliceDataType
-      ID: 191
+      ID: 204
       Name: '[]net/http.segment.array'
       ByteSize: 2048
-      Element: 119 StructureType net/http.segment
+      Element: 203 StructureType net/http.segment
     - __kind: GoSliceDataType
-      ID: 201
-      Name: '[]noalg.map.group[string]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute.array'
-      ByteSize: 2048
-      Element: 195 StructureType noalg.map.group[string]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
-    - __kind: GoSliceDataType
-      ID: 184
+      ID: 99
       Name: '[]noalg.map.group[string][]*mime/multipart.FileHeader.array'
       ByteSize: 2048
-      Element: 177 StructureType noalg.map.group[string][]*mime/multipart.FileHeader
+      Element: 92 StructureType noalg.map.group[string][]*mime/multipart.FileHeader
     - __kind: GoSliceDataType
-      ID: 138
+      ID: 80
       Name: '[]noalg.map.group[string][]string.array'
       ByteSize: 2048
-      Element: 134 StructureType noalg.map.group[string][]string
+      Element: 76 StructureType noalg.map.group[string][]string
     - __kind: GoSliceDataType
-      ID: 162
-      Name: '[]noalg.map.group[string]float64.array'
-      ByteSize: 2048
-      Element: 158 StructureType noalg.map.group[string]float64
-    - __kind: GoSliceDataType
-      ID: 155
-      Name: '[]noalg.map.group[string]interface {}.array'
-      ByteSize: 2048
-      Element: 150 StructureType noalg.map.group[string]interface {}
-    - __kind: GoSliceDataType
-      ID: 147
+      ID: 213
       Name: '[]noalg.map.group[string]string.array'
       ByteSize: 2048
-      Element: 143 StructureType noalg.map.group[string]string
+      Element: 209 StructureType noalg.map.group[string]string
     - __kind: GoSliceHeaderType
-      ID: 52
+      ID: 54
       Name: '[]string'
       ByteSize: 24
       GoRuntimeType: 501440
@@ -1253,14 +994,14 @@ Types:
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 139 GoSliceDataType []string.array
+      Data: 81 GoSliceDataType []string.array
     - __kind: GoSliceDataType
-      ID: 139
+      ID: 81
       Name: '[]string.array'
       ByteSize: 2048
       Element: 9 GoStringHeaderType string
     - __kind: GoSliceHeaderType
-      ID: 248
+      ID: 167
       Name: '[]time.zone'
       ByteSize: 24
       GoRuntimeType: 494336
@@ -1268,21 +1009,21 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 249 PointerType *time.zone
+          Type: 168 PointerType *time.zone
         - Name: len
           Offset: 8
           Type: 7 BaseType int
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 285 GoSliceDataType []time.zone.array
+      Data: 173 GoSliceDataType []time.zone.array
     - __kind: GoSliceDataType
-      ID: 285
+      ID: 173
       Name: '[]time.zone.array'
       ByteSize: 2048
-      Element: 250 StructureType time.zone
+      Element: 169 StructureType time.zone
     - __kind: GoSliceHeaderType
-      ID: 251
+      ID: 170
       Name: '[]time.zoneTrans'
       ByteSize: 24
       GoRuntimeType: 494400
@@ -1290,21 +1031,21 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 252 PointerType *time.zoneTrans
+          Type: 171 PointerType *time.zoneTrans
         - Name: len
           Offset: 8
           Type: 7 BaseType int
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 287 GoSliceDataType []time.zoneTrans.array
+      Data: 175 GoSliceDataType []time.zoneTrans.array
     - __kind: GoSliceDataType
-      ID: 287
+      ID: 175
       Name: '[]time.zoneTrans.array'
       ByteSize: 2048
-      Element: 253 StructureType time.zoneTrans
+      Element: 172 StructureType time.zoneTrans
     - __kind: GoSliceHeaderType
-      ID: 94
+      ID: 104
       Name: '[]uint8'
       ByteSize: 24
       GoRuntimeType: 500288
@@ -1319,9 +1060,9 @@ Types:
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 167 GoSliceDataType []uint8.array
+      Data: 105 GoSliceDataType []uint8.array
     - __kind: GoSliceDataType
-      ID: 167
+      ID: 105
       Name: '[]uint8.array'
       ByteSize: 2048
       Element: 3 BaseType uint8
@@ -1331,28 +1072,10 @@ Types:
       ByteSize: 1
       GoRuntimeType: 595232
       GoKind: 1
-    - __kind: StructureType
+    - __kind: UnresolvedPointeeType
       ID: 42
       Name: bytes.Buffer
-      ByteSize: 40
-      GoRuntimeType: 1.640384e+06
-      GoKind: 25
-      RawFields:
-        - Name: buf
-          Offset: 0
-          Type: 94 GoSliceHeaderType []uint8
-        - Name: off
-          Offset: 24
-          Type: 7 BaseType int
-        - Name: lastRead
-          Offset: 32
-          Type: 95 BaseType bytes.readOp
-    - __kind: BaseType
-      ID: 95
-      Name: bytes.readOp
-      ByteSize: 1
-      GoRuntimeType: 593440
-      GoKind: 3
+      ByteSize: 8
     - __kind: BaseType
       ID: 24
       Name: complex128
@@ -1366,7 +1089,7 @@ Types:
       GoRuntimeType: 594976
       GoKind: 15
     - __kind: GoInterfaceType
-      ID: 61
+      ID: 63
       Name: context.Context
       ByteSize: 16
       GoRuntimeType: 1.3032e+06
@@ -1379,7 +1102,7 @@ Types:
           Offset: 8
           Type: 14 VoidPointerType unsafe.Pointer
     - __kind: StructureType
-      ID: 57
+      ID: 59
       Name: crypto/tls.ConnectionState
       ByteSize: 192
       GoRuntimeType: 2.323424e+06
@@ -1420,10 +1143,10 @@ Types:
           Type: 113 GoSliceHeaderType [][]uint8
         - Name: OCSPResponse
           Offset: 120
-          Type: 94 GoSliceHeaderType []uint8
+          Type: 104 GoSliceHeaderType []uint8
         - Name: TLSUnique
           Offset: 144
-          Type: 94 GoSliceHeaderType []uint8
+          Type: 104 GoSliceHeaderType []uint8
         - Name: ECHAccepted
           Offset: 168
           Type: 4 BaseType bool
@@ -1449,7 +1172,7 @@ Types:
       GoRuntimeType: 847296
       GoKind: 9
     - __kind: StructureType
-      ID: 170
+      ID: 117
       Name: crypto/x509.Certificate
       ByteSize: 1424
       GoRuntimeType: 2.458688e+06
@@ -1457,67 +1180,67 @@ Types:
       RawFields:
         - Name: Raw
           Offset: 0
-          Type: 94 GoSliceHeaderType []uint8
+          Type: 104 GoSliceHeaderType []uint8
         - Name: RawTBSCertificate
           Offset: 24
-          Type: 94 GoSliceHeaderType []uint8
+          Type: 104 GoSliceHeaderType []uint8
         - Name: RawSubjectPublicKeyInfo
           Offset: 48
-          Type: 94 GoSliceHeaderType []uint8
+          Type: 104 GoSliceHeaderType []uint8
         - Name: RawSubject
           Offset: 72
-          Type: 94 GoSliceHeaderType []uint8
+          Type: 104 GoSliceHeaderType []uint8
         - Name: RawIssuer
           Offset: 96
-          Type: 94 GoSliceHeaderType []uint8
+          Type: 104 GoSliceHeaderType []uint8
         - Name: Signature
           Offset: 120
-          Type: 94 GoSliceHeaderType []uint8
+          Type: 104 GoSliceHeaderType []uint8
         - Name: SignatureAlgorithm
           Offset: 144
-          Type: 202 BaseType crypto/x509.SignatureAlgorithm
+          Type: 124 BaseType crypto/x509.SignatureAlgorithm
         - Name: PublicKeyAlgorithm
           Offset: 152
-          Type: 203 BaseType crypto/x509.PublicKeyAlgorithm
+          Type: 125 BaseType crypto/x509.PublicKeyAlgorithm
         - Name: PublicKey
           Offset: 160
-          Type: 153 GoEmptyInterfaceType interface {}
+          Type: 126 GoEmptyInterfaceType interface {}
         - Name: Version
           Offset: 176
           Type: 7 BaseType int
         - Name: SerialNumber
           Offset: 184
-          Type: 204 PointerType *math/big.Int
+          Type: 127 PointerType *math/big.Int
         - Name: Issuer
           Offset: 192
-          Type: 206 StructureType crypto/x509/pkix.Name
+          Type: 129 StructureType crypto/x509/pkix.Name
         - Name: Subject
           Offset: 440
-          Type: 206 StructureType crypto/x509/pkix.Name
+          Type: 129 StructureType crypto/x509/pkix.Name
         - Name: NotBefore
           Offset: 688
-          Type: 210 StructureType time.Time
+          Type: 133 StructureType time.Time
         - Name: NotAfter
           Offset: 712
-          Type: 210 StructureType time.Time
+          Type: 133 StructureType time.Time
         - Name: KeyUsage
           Offset: 736
-          Type: 213 BaseType crypto/x509.KeyUsage
+          Type: 136 BaseType crypto/x509.KeyUsage
         - Name: Extensions
           Offset: 744
-          Type: 214 GoSliceHeaderType []crypto/x509/pkix.Extension
+          Type: 137 GoSliceHeaderType []crypto/x509/pkix.Extension
         - Name: ExtraExtensions
           Offset: 768
-          Type: 214 GoSliceHeaderType []crypto/x509/pkix.Extension
+          Type: 137 GoSliceHeaderType []crypto/x509/pkix.Extension
         - Name: UnhandledCriticalExtensions
           Offset: 792
-          Type: 217 GoSliceHeaderType []encoding/asn1.ObjectIdentifier
+          Type: 140 GoSliceHeaderType []encoding/asn1.ObjectIdentifier
         - Name: ExtKeyUsage
           Offset: 816
-          Type: 220 GoSliceHeaderType []crypto/x509.ExtKeyUsage
+          Type: 143 GoSliceHeaderType []crypto/x509.ExtKeyUsage
         - Name: UnknownExtKeyUsage
           Offset: 840
-          Type: 217 GoSliceHeaderType []encoding/asn1.ObjectIdentifier
+          Type: 140 GoSliceHeaderType []encoding/asn1.ObjectIdentifier
         - Name: BasicConstraintsValid
           Offset: 864
           Type: 4 BaseType bool
@@ -1532,64 +1255,64 @@ Types:
           Type: 4 BaseType bool
         - Name: SubjectKeyId
           Offset: 888
-          Type: 94 GoSliceHeaderType []uint8
+          Type: 104 GoSliceHeaderType []uint8
         - Name: AuthorityKeyId
           Offset: 912
-          Type: 94 GoSliceHeaderType []uint8
+          Type: 104 GoSliceHeaderType []uint8
         - Name: OCSPServer
           Offset: 936
-          Type: 52 GoSliceHeaderType []string
+          Type: 54 GoSliceHeaderType []string
         - Name: IssuingCertificateURL
           Offset: 960
-          Type: 52 GoSliceHeaderType []string
+          Type: 54 GoSliceHeaderType []string
         - Name: DNSNames
           Offset: 984
-          Type: 52 GoSliceHeaderType []string
+          Type: 54 GoSliceHeaderType []string
         - Name: EmailAddresses
           Offset: 1008
-          Type: 52 GoSliceHeaderType []string
+          Type: 54 GoSliceHeaderType []string
         - Name: IPAddresses
           Offset: 1032
-          Type: 223 GoSliceHeaderType []net.IP
+          Type: 146 GoSliceHeaderType []net.IP
         - Name: URIs
           Offset: 1056
-          Type: 226 GoSliceHeaderType []*net/url.URL
+          Type: 149 GoSliceHeaderType []*net/url.URL
         - Name: PermittedDNSDomainsCritical
           Offset: 1080
           Type: 4 BaseType bool
         - Name: PermittedDNSDomains
           Offset: 1088
-          Type: 52 GoSliceHeaderType []string
+          Type: 54 GoSliceHeaderType []string
         - Name: ExcludedDNSDomains
           Offset: 1112
-          Type: 52 GoSliceHeaderType []string
+          Type: 54 GoSliceHeaderType []string
         - Name: PermittedIPRanges
           Offset: 1136
-          Type: 228 GoSliceHeaderType []*net.IPNet
+          Type: 151 GoSliceHeaderType []*net.IPNet
         - Name: ExcludedIPRanges
           Offset: 1160
-          Type: 228 GoSliceHeaderType []*net.IPNet
+          Type: 151 GoSliceHeaderType []*net.IPNet
         - Name: PermittedEmailAddresses
           Offset: 1184
-          Type: 52 GoSliceHeaderType []string
+          Type: 54 GoSliceHeaderType []string
         - Name: ExcludedEmailAddresses
           Offset: 1208
-          Type: 52 GoSliceHeaderType []string
+          Type: 54 GoSliceHeaderType []string
         - Name: PermittedURIDomains
           Offset: 1232
-          Type: 52 GoSliceHeaderType []string
+          Type: 54 GoSliceHeaderType []string
         - Name: ExcludedURIDomains
           Offset: 1256
-          Type: 52 GoSliceHeaderType []string
+          Type: 54 GoSliceHeaderType []string
         - Name: CRLDistributionPoints
           Offset: 1280
-          Type: 52 GoSliceHeaderType []string
+          Type: 54 GoSliceHeaderType []string
         - Name: PolicyIdentifiers
           Offset: 1304
-          Type: 217 GoSliceHeaderType []encoding/asn1.ObjectIdentifier
+          Type: 140 GoSliceHeaderType []encoding/asn1.ObjectIdentifier
         - Name: Policies
           Offset: 1328
-          Type: 231 GoSliceHeaderType []crypto/x509.OID
+          Type: 154 GoSliceHeaderType []crypto/x509.OID
         - Name: InhibitAnyPolicy
           Offset: 1352
           Type: 7 BaseType int
@@ -1610,21 +1333,21 @@ Types:
           Type: 4 BaseType bool
         - Name: PolicyMappings
           Offset: 1400
-          Type: 234 GoSliceHeaderType []crypto/x509.PolicyMapping
+          Type: 157 GoSliceHeaderType []crypto/x509.PolicyMapping
     - __kind: BaseType
-      ID: 222
+      ID: 145
       Name: crypto/x509.ExtKeyUsage
       ByteSize: 8
       GoRuntimeType: 598304
       GoKind: 2
     - __kind: BaseType
-      ID: 213
+      ID: 136
       Name: crypto/x509.KeyUsage
       ByteSize: 8
       GoRuntimeType: 598240
       GoKind: 2
     - __kind: StructureType
-      ID: 233
+      ID: 156
       Name: crypto/x509.OID
       ByteSize: 24
       GoRuntimeType: 1.998368e+06
@@ -1632,9 +1355,9 @@ Types:
       RawFields:
         - Name: der
           Offset: 0
-          Type: 94 GoSliceHeaderType []uint8
+          Type: 104 GoSliceHeaderType []uint8
     - __kind: StructureType
-      ID: 236
+      ID: 159
       Name: crypto/x509.PolicyMapping
       ByteSize: 48
       GoRuntimeType: 1.520416e+06
@@ -1642,24 +1365,24 @@ Types:
       RawFields:
         - Name: IssuerDomainPolicy
           Offset: 0
-          Type: 233 StructureType crypto/x509.OID
+          Type: 156 StructureType crypto/x509.OID
         - Name: SubjectDomainPolicy
           Offset: 24
-          Type: 233 StructureType crypto/x509.OID
+          Type: 156 StructureType crypto/x509.OID
     - __kind: BaseType
-      ID: 203
+      ID: 125
       Name: crypto/x509.PublicKeyAlgorithm
       ByteSize: 8
       GoRuntimeType: 849696
       GoKind: 2
     - __kind: BaseType
-      ID: 202
+      ID: 124
       Name: crypto/x509.SignatureAlgorithm
       ByteSize: 8
       GoRuntimeType: 1.139648e+06
       GoKind: 2
     - __kind: StructureType
-      ID: 209
+      ID: 132
       Name: crypto/x509/pkix.AttributeTypeAndValue
       ByteSize: 40
       GoRuntimeType: 1.532736e+06
@@ -1667,12 +1390,12 @@ Types:
       RawFields:
         - Name: Type
           Offset: 0
-          Type: 219 GoSliceHeaderType encoding/asn1.ObjectIdentifier
+          Type: 142 GoSliceHeaderType encoding/asn1.ObjectIdentifier
         - Name: Value
           Offset: 24
-          Type: 153 GoEmptyInterfaceType interface {}
+          Type: 126 GoEmptyInterfaceType interface {}
     - __kind: StructureType
-      ID: 216
+      ID: 139
       Name: crypto/x509/pkix.Extension
       ByteSize: 56
       GoRuntimeType: 1.683776e+06
@@ -1680,15 +1403,15 @@ Types:
       RawFields:
         - Name: Id
           Offset: 0
-          Type: 219 GoSliceHeaderType encoding/asn1.ObjectIdentifier
+          Type: 142 GoSliceHeaderType encoding/asn1.ObjectIdentifier
         - Name: Critical
           Offset: 24
           Type: 4 BaseType bool
         - Name: Value
           Offset: 32
-          Type: 94 GoSliceHeaderType []uint8
+          Type: 104 GoSliceHeaderType []uint8
     - __kind: StructureType
-      ID: 206
+      ID: 129
       Name: crypto/x509/pkix.Name
       ByteSize: 248
       GoRuntimeType: 2.250272e+06
@@ -1696,25 +1419,25 @@ Types:
       RawFields:
         - Name: Country
           Offset: 0
-          Type: 52 GoSliceHeaderType []string
+          Type: 54 GoSliceHeaderType []string
         - Name: Organization
           Offset: 24
-          Type: 52 GoSliceHeaderType []string
+          Type: 54 GoSliceHeaderType []string
         - Name: OrganizationalUnit
           Offset: 48
-          Type: 52 GoSliceHeaderType []string
+          Type: 54 GoSliceHeaderType []string
         - Name: Locality
           Offset: 72
-          Type: 52 GoSliceHeaderType []string
+          Type: 54 GoSliceHeaderType []string
         - Name: Province
           Offset: 96
-          Type: 52 GoSliceHeaderType []string
+          Type: 54 GoSliceHeaderType []string
         - Name: StreetAddress
           Offset: 120
-          Type: 52 GoSliceHeaderType []string
+          Type: 54 GoSliceHeaderType []string
         - Name: PostalCode
           Offset: 144
-          Type: 52 GoSliceHeaderType []string
+          Type: 54 GoSliceHeaderType []string
         - Name: SerialNumber
           Offset: 168
           Type: 9 GoStringHeaderType string
@@ -1723,12 +1446,12 @@ Types:
           Type: 9 GoStringHeaderType string
         - Name: Names
           Offset: 200
-          Type: 207 GoSliceHeaderType []crypto/x509/pkix.AttributeTypeAndValue
+          Type: 130 GoSliceHeaderType []crypto/x509/pkix.AttributeTypeAndValue
         - Name: ExtraNames
           Offset: 224
-          Type: 207 GoSliceHeaderType []crypto/x509/pkix.AttributeTypeAndValue
+          Type: 130 GoSliceHeaderType []crypto/x509/pkix.AttributeTypeAndValue
     - __kind: GoSliceHeaderType
-      ID: 219
+      ID: 142
       Name: encoding/asn1.ObjectIdentifier
       ByteSize: 24
       GoRuntimeType: 1.079904e+06
@@ -1743,9 +1466,9 @@ Types:
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 265 GoSliceDataType encoding/asn1.ObjectIdentifier.array
+      Data: 194 GoSliceDataType encoding/asn1.ObjectIdentifier.array
     - __kind: GoSliceDataType
-      ID: 265
+      ID: 194
       Name: encoding/asn1.ObjectIdentifier.array
       ByteSize: 2048
       Element: 7 BaseType int
@@ -1775,13 +1498,7 @@ Types:
       GoRuntimeType: 595168
       GoKind: 14
     - __kind: GoSubroutineType
-      ID: 93
-      Name: func()
-      ByteSize: 8
-      GoRuntimeType: 484960
-      GoKind: 19
-    - __kind: GoSubroutineType
-      ID: 51
+      ID: 53
       Name: func() (io.ReadCloser, error)
       ByteSize: 8
       GoRuntimeType: 705088
@@ -1792,393 +1509,52 @@ Types:
       ByteSize: 8
       GoRuntimeType: 1.025152e+06
       GoKind: 19
-    - __kind: StructureType
+    - __kind: UnresolvedPointeeType
       ID: 40
       Name: github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span
-      ByteSize: 288
-      GoRuntimeType: 2.3976e+06
-      GoKind: 25
-      RawFields:
-        - Name: mu
-          Offset: 0
-          Type: 69 StructureType sync.RWMutex
-        - Name: name
-          Offset: 24
-          Type: 9 GoStringHeaderType string
-        - Name: service
-          Offset: 40
-          Type: 9 GoStringHeaderType string
-        - Name: resource
-          Offset: 56
-          Type: 9 GoStringHeaderType string
-        - Name: spanType
-          Offset: 72
-          Type: 9 GoStringHeaderType string
-        - Name: start
-          Offset: 88
-          Type: 12 BaseType int64
-        - Name: duration
-          Offset: 96
-          Type: 12 BaseType int64
-        - Name: meta
-          Offset: 104
-          Type: 64 GoMapType map[string]string
-        - Name: metaStruct
-          Offset: 112
-          Type: 75 GoMapType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.metaStructMap
-        - Name: metrics
-          Offset: 120
-          Type: 80 GoMapType map[string]float64
-        - Name: spanID
-          Offset: 128
-          Type: 8 BaseType uint64
-        - Name: traceID
-          Offset: 136
-          Type: 8 BaseType uint64
-        - Name: parentID
-          Offset: 144
-          Type: 8 BaseType uint64
-        - Name: error
-          Offset: 152
-          Type: 10 BaseType int32
-        - Name: spanLinks
-          Offset: 160
-          Type: 85 GoSliceHeaderType []github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink
-        - Name: spanEvents
-          Offset: 184
-          Type: 88 GoSliceHeaderType []github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent
-        - Name: goExecTraced
-          Offset: 208
-          Type: 4 BaseType bool
-        - Name: noDebugStack
-          Offset: 209
-          Type: 4 BaseType bool
-        - Name: finished
-          Offset: 210
-          Type: 4 BaseType bool
-        - Name: context
-          Offset: 216
-          Type: 91 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanContext
-        - Name: integration
-          Offset: 224
-          Type: 9 GoStringHeaderType string
-        - Name: supportsEvents
-          Offset: 240
-          Type: 4 BaseType bool
-        - Name: pprofCtxActive
-          Offset: 248
-          Type: 61 GoInterfaceType context.Context
-        - Name: pprofCtxRestore
-          Offset: 264
-          Type: 61 GoInterfaceType context.Context
-        - Name: taskEnd
-          Offset: 280
-          Type: 93 GoSubroutineType func()
-    - __kind: StructureType
-      ID: 92
-      Name: github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanContext
-      ByteSize: 168
-      GoRuntimeType: 2.269952e+06
-      GoKind: 25
-      RawFields:
-        - Name: updated
-          Offset: 0
-          Type: 4 BaseType bool
-        - Name: trace
-          Offset: 8
-          Type: 129 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.trace
-        - Name: span
-          Offset: 16
-          Type: 39 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span
-        - Name: errors
-          Offset: 24
-          Type: 73 StructureType sync/atomic.Int32
-        - Name: reparentID
-          Offset: 32
-          Type: 9 GoStringHeaderType string
-        - Name: isRemote
-          Offset: 48
-          Type: 4 BaseType bool
-        - Name: traceID
-          Offset: 49
-          Type: 131 ArrayType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.traceID
-        - Name: spanID
-          Offset: 72
-          Type: 8 BaseType uint64
-        - Name: mu
-          Offset: 80
-          Type: 69 StructureType sync.RWMutex
-        - Name: baggage
-          Offset: 104
-          Type: 64 GoMapType map[string]string
-        - Name: hasBaggage
-          Offset: 112
-          Type: 2 BaseType uint32
-        - Name: origin
-          Offset: 120
-          Type: 9 GoStringHeaderType string
-        - Name: spanLinks
-          Offset: 136
-          Type: 85 GoSliceHeaderType []github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink
-        - Name: baggageOnly
-          Offset: 160
-          Type: 4 BaseType bool
-    - __kind: StructureType
-      ID: 87
-      Name: github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink
-      ByteSize: 56
-      GoRuntimeType: 1.955616e+06
-      GoKind: 25
-      RawFields:
-        - Name: TraceID
-          Offset: 0
-          Type: 8 BaseType uint64
-        - Name: TraceIDHigh
-          Offset: 8
-          Type: 8 BaseType uint64
-        - Name: SpanID
-          Offset: 16
-          Type: 8 BaseType uint64
-        - Name: Attributes
-          Offset: 24
-          Type: 64 GoMapType map[string]string
-        - Name: Tracestate
-          Offset: 32
-          Type: 9 GoStringHeaderType string
-        - Name: Flags
-          Offset: 48
-          Type: 2 BaseType uint32
-    - __kind: GoMapType
-      ID: 75
-      Name: github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.metaStructMap
       ByteSize: 8
-      GoRuntimeType: 1.30448e+06
-      GoKind: 21
-      HeaderType: 77 GoSwissMapHeaderType map<string,interface {}>
-    - __kind: BaseType
-      ID: 174
-      Name: github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.samplingDecision
-      ByteSize: 4
-      GoRuntimeType: 594016
-      GoKind: 10
-    - __kind: StructureType
+    - __kind: GoSwissMapGroupsType
       ID: 90
-      Name: github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent
-      ByteSize: 40
-      GoRuntimeType: 1.789664e+06
-      GoKind: 25
-      RawFields:
-        - Name: Name
-          Offset: 0
-          Type: 9 GoStringHeaderType string
-        - Name: TimeUnixNano
-          Offset: 16
-          Type: 8 BaseType uint64
-        - Name: Attributes
-          Offset: 24
-          Type: 123 GoMapType map[string]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
-        - Name: RawAttributes
-          Offset: 32
-          Type: 128 GoMapType map[string]interface {}
-    - __kind: StructureType
-      ID: 240
-      Name: github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttribute
-      ByteSize: 24
-      GoRuntimeType: 1.2152e+06
-      GoKind: 25
-      RawFields:
-        - Name: Values
-          Offset: 0
-          Type: 256 GoSliceHeaderType []*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttributeValue
-    - __kind: StructureType
-      ID: 282
-      Name: github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttributeValue
-      ByteSize: 48
-      GoRuntimeType: 1.878752e+06
-      GoKind: 25
-      RawFields:
-        - Name: Type
-          Offset: 0
-          Type: 291 BaseType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttributeValueType
-        - Name: StringValue
-          Offset: 8
-          Type: 9 GoStringHeaderType string
-        - Name: BoolValue
-          Offset: 24
-          Type: 4 BaseType bool
-        - Name: IntValue
-          Offset: 32
-          Type: 12 BaseType int64
-        - Name: DoubleValue
-          Offset: 40
-          Type: 15 BaseType float64
-    - __kind: BaseType
-      ID: 291
-      Name: github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttributeValueType
-      ByteSize: 4
-      GoRuntimeType: 1.006816e+06
-      GoKind: 5
-    - __kind: StructureType
-      ID: 199
-      Name: github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
-      ByteSize: 56
-      GoRuntimeType: 1.955872e+06
-      GoKind: 25
-      RawFields:
-        - Name: Type
-          Offset: 0
-          Type: 238 BaseType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttributeType
-        - Name: StringValue
-          Offset: 8
-          Type: 9 GoStringHeaderType string
-        - Name: BoolValue
-          Offset: 24
-          Type: 4 BaseType bool
-        - Name: IntValue
-          Offset: 32
-          Type: 12 BaseType int64
-        - Name: DoubleValue
-          Offset: 40
-          Type: 15 BaseType float64
-        - Name: ArrayValue
-          Offset: 48
-          Type: 239 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttribute
-    - __kind: BaseType
-      ID: 238
-      Name: github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttributeType
-      ByteSize: 4
-      GoRuntimeType: 1.00672e+06
-      GoKind: 5
-    - __kind: StructureType
-      ID: 130
-      Name: github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.trace
-      ByteSize: 104
-      GoRuntimeType: 2.155744e+06
-      GoKind: 25
-      RawFields:
-        - Name: mu
-          Offset: 0
-          Type: 69 StructureType sync.RWMutex
-        - Name: spans
-          Offset: 24
-          Type: 172 GoSliceHeaderType []*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span
-        - Name: tags
-          Offset: 48
-          Type: 64 GoMapType map[string]string
-        - Name: propagatingTags
-          Offset: 56
-          Type: 64 GoMapType map[string]string
-        - Name: finished
-          Offset: 64
-          Type: 7 BaseType int
-        - Name: full
-          Offset: 72
-          Type: 4 BaseType bool
-        - Name: priority
-          Offset: 80
-          Type: 25 PointerType *float64
-        - Name: locked
-          Offset: 88
-          Type: 4 BaseType bool
-        - Name: samplingDecision
-          Offset: 92
-          Type: 174 BaseType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.samplingDecision
-        - Name: root
-          Offset: 96
-          Type: 39 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span
-    - __kind: ArrayType
-      ID: 131
-      Name: github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.traceID
-      ByteSize: 16
-      GoRuntimeType: 919232
-      GoKind: 17
-      Count: 16
-      HasCount: true
-      Element: 3 BaseType uint8
-    - __kind: GoSwissMapGroupsType
-      ID: 193
-      Name: groupReference<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
-      ByteSize: 16
-      GoKind: 25
-      RawFields:
-        - Name: data
-          Offset: 0
-          Type: 194 PointerType *noalg.map.group[string]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
-        - Name: lengthMask
-          Offset: 8
-          Type: 8 BaseType uint64
-      GroupType: 195 StructureType noalg.map.group[string]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
-      GroupSliceType: 201 GoSliceDataType []noalg.map.group[string]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute.array
-    - __kind: GoSwissMapGroupsType
-      ID: 175
       Name: groupReference<string,[]*mime/multipart.FileHeader>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 176 PointerType *noalg.map.group[string][]*mime/multipart.FileHeader
+          Type: 91 PointerType *noalg.map.group[string][]*mime/multipart.FileHeader
         - Name: lengthMask
           Offset: 8
           Type: 8 BaseType uint64
-      GroupType: 177 StructureType noalg.map.group[string][]*mime/multipart.FileHeader
-      GroupSliceType: 184 GoSliceDataType []noalg.map.group[string][]*mime/multipart.FileHeader.array
+      GroupType: 92 StructureType noalg.map.group[string][]*mime/multipart.FileHeader
+      GroupSliceType: 99 GoSliceDataType []noalg.map.group[string][]*mime/multipart.FileHeader.array
     - __kind: GoSwissMapGroupsType
-      ID: 132
+      ID: 74
       Name: groupReference<string,[]string>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 133 PointerType *noalg.map.group[string][]string
+          Type: 75 PointerType *noalg.map.group[string][]string
         - Name: lengthMask
           Offset: 8
           Type: 8 BaseType uint64
-      GroupType: 134 StructureType noalg.map.group[string][]string
-      GroupSliceType: 138 GoSliceDataType []noalg.map.group[string][]string.array
+      GroupType: 76 StructureType noalg.map.group[string][]string
+      GroupSliceType: 80 GoSliceDataType []noalg.map.group[string][]string.array
     - __kind: GoSwissMapGroupsType
-      ID: 156
-      Name: groupReference<string,float64>
-      ByteSize: 16
-      GoKind: 25
-      RawFields:
-        - Name: data
-          Offset: 0
-          Type: 157 PointerType *noalg.map.group[string]float64
-        - Name: lengthMask
-          Offset: 8
-          Type: 8 BaseType uint64
-      GroupType: 158 StructureType noalg.map.group[string]float64
-      GroupSliceType: 162 GoSliceDataType []noalg.map.group[string]float64.array
-    - __kind: GoSwissMapGroupsType
-      ID: 148
-      Name: groupReference<string,interface {}>
-      ByteSize: 16
-      GoKind: 25
-      RawFields:
-        - Name: data
-          Offset: 0
-          Type: 149 PointerType *noalg.map.group[string]interface {}
-        - Name: lengthMask
-          Offset: 8
-          Type: 8 BaseType uint64
-      GroupType: 150 StructureType noalg.map.group[string]interface {}
-      GroupSliceType: 155 GoSliceDataType []noalg.map.group[string]interface {}.array
-    - __kind: GoSwissMapGroupsType
-      ID: 141
+      ID: 207
       Name: groupReference<string,string>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 142 PointerType *noalg.map.group[string]string
+          Type: 208 PointerType *noalg.map.group[string]string
         - Name: lengthMask
           Offset: 8
           Type: 8 BaseType uint64
-      GroupType: 143 StructureType noalg.map.group[string]string
-      GroupSliceType: 147 GoSliceDataType []noalg.map.group[string]string.array
+      GroupType: 209 StructureType noalg.map.group[string]string
+      GroupSliceType: 213 GoSliceDataType []noalg.map.group[string]string.array
     - __kind: BaseType
       ID: 7
       Name: int
@@ -2210,7 +1586,7 @@ Types:
       GoRuntimeType: 594272
       GoKind: 3
     - __kind: GoEmptyInterfaceType
-      ID: 153
+      ID: 126
       Name: interface {}
       ByteSize: 16
       GoRuntimeType: 867104
@@ -2222,21 +1598,8 @@ Types:
         - Name: data
           Offset: 8
           Type: 14 VoidPointerType unsafe.Pointer
-    - __kind: StructureType
-      ID: 72
-      Name: internal/sync.Mutex
-      ByteSize: 8
-      GoRuntimeType: 1.518176e+06
-      GoKind: 25
-      RawFields:
-        - Name: state
-          Offset: 0
-          Type: 10 BaseType int32
-        - Name: sema
-          Offset: 4
-          Type: 2 BaseType uint32
     - __kind: GoInterfaceType
-      ID: 50
+      ID: 52
       Name: io.ReadCloser
       ByteSize: 16
       GoRuntimeType: 1.135168e+06
@@ -2249,42 +1612,7 @@ Types:
           Offset: 8
           Type: 14 VoidPointerType unsafe.Pointer
     - __kind: GoSwissMapHeaderType
-      ID: 125
-      Name: map<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
-      ByteSize: 48
-      GoKind: 25
-      RawFields:
-        - Name: used
-          Offset: 0
-          Type: 8 BaseType uint64
-        - Name: seed
-          Offset: 8
-          Type: 1 BaseType uintptr
-        - Name: dirPtr
-          Offset: 16
-          Type: 126 PointerType **table<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
-        - Name: dirLen
-          Offset: 24
-          Type: 7 BaseType int
-        - Name: globalDepth
-          Offset: 32
-          Type: 3 BaseType uint8
-        - Name: globalShift
-          Offset: 33
-          Type: 3 BaseType uint8
-        - Name: writing
-          Offset: 34
-          Type: 3 BaseType uint8
-        - Name: tombstonePossible
-          Offset: 35
-          Type: 4 BaseType bool
-        - Name: clearSeq
-          Offset: 40
-          Type: 8 BaseType uint64
-      TablePtrSliceType: 200 GoSliceDataType []*table<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>.array
-      GroupType: 195 StructureType noalg.map.group[string]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
-    - __kind: GoSwissMapHeaderType
-      ID: 104
+      ID: 86
       Name: map<string,[]*mime/multipart.FileHeader>
       ByteSize: 48
       GoKind: 25
@@ -2297,7 +1625,7 @@ Types:
           Type: 1 BaseType uintptr
         - Name: dirPtr
           Offset: 16
-          Type: 105 PointerType **table<string,[]*mime/multipart.FileHeader>
+          Type: 87 PointerType **table<string,[]*mime/multipart.FileHeader>
         - Name: dirLen
           Offset: 24
           Type: 7 BaseType int
@@ -2316,10 +1644,10 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 8 BaseType uint64
-      TablePtrSliceType: 183 GoSliceDataType []*table<string,[]*mime/multipart.FileHeader>.array
-      GroupType: 177 StructureType noalg.map.group[string][]*mime/multipart.FileHeader
+      TablePtrSliceType: 98 GoSliceDataType []*table<string,[]*mime/multipart.FileHeader>.array
+      GroupType: 92 StructureType noalg.map.group[string][]*mime/multipart.FileHeader
     - __kind: GoSwissMapHeaderType
-      ID: 47
+      ID: 49
       Name: map<string,[]string>
       ByteSize: 48
       GoKind: 25
@@ -2332,7 +1660,7 @@ Types:
           Type: 1 BaseType uintptr
         - Name: dirPtr
           Offset: 16
-          Type: 48 PointerType **table<string,[]string>
+          Type: 50 PointerType **table<string,[]string>
         - Name: dirLen
           Offset: 24
           Type: 7 BaseType int
@@ -2351,80 +1679,10 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 8 BaseType uint64
-      TablePtrSliceType: 137 GoSliceDataType []*table<string,[]string>.array
-      GroupType: 134 StructureType noalg.map.group[string][]string
+      TablePtrSliceType: 79 GoSliceDataType []*table<string,[]string>.array
+      GroupType: 76 StructureType noalg.map.group[string][]string
     - __kind: GoSwissMapHeaderType
-      ID: 82
-      Name: map<string,float64>
-      ByteSize: 48
-      GoKind: 25
-      RawFields:
-        - Name: used
-          Offset: 0
-          Type: 8 BaseType uint64
-        - Name: seed
-          Offset: 8
-          Type: 1 BaseType uintptr
-        - Name: dirPtr
-          Offset: 16
-          Type: 83 PointerType **table<string,float64>
-        - Name: dirLen
-          Offset: 24
-          Type: 7 BaseType int
-        - Name: globalDepth
-          Offset: 32
-          Type: 3 BaseType uint8
-        - Name: globalShift
-          Offset: 33
-          Type: 3 BaseType uint8
-        - Name: writing
-          Offset: 34
-          Type: 3 BaseType uint8
-        - Name: tombstonePossible
-          Offset: 35
-          Type: 4 BaseType bool
-        - Name: clearSeq
-          Offset: 40
-          Type: 8 BaseType uint64
-      TablePtrSliceType: 161 GoSliceDataType []*table<string,float64>.array
-      GroupType: 158 StructureType noalg.map.group[string]float64
-    - __kind: GoSwissMapHeaderType
-      ID: 77
-      Name: map<string,interface {}>
-      ByteSize: 48
-      GoKind: 25
-      RawFields:
-        - Name: used
-          Offset: 0
-          Type: 8 BaseType uint64
-        - Name: seed
-          Offset: 8
-          Type: 1 BaseType uintptr
-        - Name: dirPtr
-          Offset: 16
-          Type: 78 PointerType **table<string,interface {}>
-        - Name: dirLen
-          Offset: 24
-          Type: 7 BaseType int
-        - Name: globalDepth
-          Offset: 32
-          Type: 3 BaseType uint8
-        - Name: globalShift
-          Offset: 33
-          Type: 3 BaseType uint8
-        - Name: writing
-          Offset: 34
-          Type: 3 BaseType uint8
-        - Name: tombstonePossible
-          Offset: 35
-          Type: 4 BaseType bool
-        - Name: clearSeq
-          Offset: 40
-          Type: 8 BaseType uint64
-      TablePtrSliceType: 154 GoSliceDataType []*table<string,interface {}>.array
-      GroupType: 150 StructureType noalg.map.group[string]interface {}
-    - __kind: GoSwissMapHeaderType
-      ID: 66
+      ID: 68
       Name: map<string,string>
       ByteSize: 48
       GoKind: 25
@@ -2437,7 +1695,7 @@ Types:
           Type: 1 BaseType uintptr
         - Name: dirPtr
           Offset: 16
-          Type: 67 PointerType **table<string,string>
+          Type: 69 PointerType **table<string,string>
         - Name: dirLen
           Offset: 24
           Type: 7 BaseType int
@@ -2456,52 +1714,31 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 8 BaseType uint64
-      TablePtrSliceType: 146 GoSliceDataType []*table<string,string>.array
-      GroupType: 143 StructureType noalg.map.group[string]string
+      TablePtrSliceType: 212 GoSliceDataType []*table<string,string>.array
+      GroupType: 209 StructureType noalg.map.group[string]string
     - __kind: GoMapType
-      ID: 123
-      Name: map[string]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
-      ByteSize: 8
-      GoRuntimeType: 1.158336e+06
-      GoKind: 21
-      HeaderType: 125 GoSwissMapHeaderType map<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
-    - __kind: GoMapType
-      ID: 102
+      ID: 84
       Name: map[string][]*mime/multipart.FileHeader
       ByteSize: 8
       GoRuntimeType: 1.157568e+06
       GoKind: 21
-      HeaderType: 104 GoSwissMapHeaderType map<string,[]*mime/multipart.FileHeader>
+      HeaderType: 86 GoSwissMapHeaderType map<string,[]*mime/multipart.FileHeader>
     - __kind: GoMapType
-      ID: 101
+      ID: 83
       Name: map[string][]string
       ByteSize: 8
       GoRuntimeType: 1.153216e+06
       GoKind: 21
-      HeaderType: 47 GoSwissMapHeaderType map<string,[]string>
+      HeaderType: 49 GoSwissMapHeaderType map<string,[]string>
     - __kind: GoMapType
-      ID: 80
-      Name: map[string]float64
-      ByteSize: 8
-      GoRuntimeType: 1.158208e+06
-      GoKind: 21
-      HeaderType: 82 GoSwissMapHeaderType map<string,float64>
-    - __kind: GoMapType
-      ID: 128
-      Name: map[string]interface {}
-      ByteSize: 8
-      GoRuntimeType: 1.151808e+06
-      GoKind: 21
-      HeaderType: 77 GoSwissMapHeaderType map<string,interface {}>
-    - __kind: GoMapType
-      ID: 64
+      ID: 66
       Name: map[string]string
       ByteSize: 8
       GoRuntimeType: 1.15424e+06
       GoKind: 21
-      HeaderType: 66 GoSwissMapHeaderType map<string,string>
+      HeaderType: 68 GoSwissMapHeaderType map<string,string>
     - __kind: StructureType
-      ID: 205
+      ID: 128
       Name: math/big.Int
       ByteSize: 32
       GoRuntimeType: 1.523456e+06
@@ -2512,15 +1749,15 @@ Types:
           Type: 4 BaseType bool
         - Name: abs
           Offset: 8
-          Type: 245 GoSliceHeaderType math/big.nat
+          Type: 160 GoSliceHeaderType math/big.nat
     - __kind: BaseType
-      ID: 247
+      ID: 162
       Name: math/big.Word
       ByteSize: 8
       GoRuntimeType: 598496
       GoKind: 7
     - __kind: GoSliceHeaderType
-      ID: 245
+      ID: 160
       Name: math/big.nat
       ByteSize: 24
       GoRuntimeType: 2.426912e+06
@@ -2528,21 +1765,21 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 246 PointerType *math/big.Word
+          Type: 161 PointerType *math/big.Word
         - Name: len
           Offset: 8
           Type: 7 BaseType int
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 283 GoSliceDataType math/big.nat.array
+      Data: 163 GoSliceDataType math/big.nat.array
     - __kind: GoSliceDataType
-      ID: 283
+      ID: 163
       Name: math/big.nat.array
       ByteSize: 2048
-      Element: 247 BaseType math/big.Word
+      Element: 162 BaseType math/big.Word
     - __kind: StructureType
-      ID: 237
+      ID: 100
       Name: mime/multipart.FileHeader
       ByteSize: 88
       GoRuntimeType: 2.018784e+06
@@ -2553,13 +1790,13 @@ Types:
           Type: 9 GoStringHeaderType string
         - Name: Header
           Offset: 16
-          Type: 255 GoMapType net/textproto.MIMEHeader
+          Type: 103 GoMapType net/textproto.MIMEHeader
         - Name: Size
           Offset: 24
           Type: 12 BaseType int64
         - Name: content
           Offset: 32
-          Type: 94 GoSliceHeaderType []uint8
+          Type: 104 GoSliceHeaderType []uint8
         - Name: tmpfile
           Offset: 56
           Type: 9 GoStringHeaderType string
@@ -2570,7 +1807,7 @@ Types:
           Offset: 80
           Type: 4 BaseType bool
     - __kind: StructureType
-      ID: 55
+      ID: 57
       Name: mime/multipart.Form
       ByteSize: 16
       GoRuntimeType: 1.506656e+06
@@ -2578,12 +1815,12 @@ Types:
       RawFields:
         - Name: Value
           Offset: 0
-          Type: 101 GoMapType map[string][]string
+          Type: 83 GoMapType map[string][]string
         - Name: File
           Offset: 8
-          Type: 102 GoMapType map[string][]*mime/multipart.FileHeader
+          Type: 84 GoMapType map[string][]*mime/multipart.FileHeader
     - __kind: GoSliceHeaderType
-      ID: 225
+      ID: 148
       Name: net.IP
       ByteSize: 24
       GoRuntimeType: 2.178944e+06
@@ -2598,14 +1835,14 @@ Types:
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 271 GoSliceDataType net.IP.array
+      Data: 196 GoSliceDataType net.IP.array
     - __kind: GoSliceDataType
-      ID: 271
+      ID: 196
       Name: net.IP.array
       ByteSize: 2048
       Element: 3 BaseType uint8
     - __kind: GoSliceHeaderType
-      ID: 281
+      ID: 198
       Name: net.IPMask
       ByteSize: 24
       GoRuntimeType: 1.042272e+06
@@ -2620,14 +1857,14 @@ Types:
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 292 GoSliceDataType net.IPMask.array
+      Data: 199 GoSliceDataType net.IPMask.array
     - __kind: GoSliceDataType
-      ID: 292
+      ID: 199
       Name: net.IPMask.array
       ByteSize: 2048
       Element: 3 BaseType uint8
     - __kind: StructureType
-      ID: 254
+      ID: 187
       Name: net.IPNet
       ByteSize: 48
       GoRuntimeType: 1.486976e+06
@@ -2635,17 +1872,17 @@ Types:
       RawFields:
         - Name: IP
           Offset: 0
-          Type: 225 GoSliceHeaderType net.IP
+          Type: 148 GoSliceHeaderType net.IP
         - Name: Mask
           Offset: 24
-          Type: 281 GoSliceHeaderType net.IPMask
+          Type: 198 GoSliceHeaderType net.IPMask
     - __kind: GoMapType
-      ID: 45
+      ID: 47
       Name: net/http.Header
       ByteSize: 8
       GoRuntimeType: 2.15504e+06
       GoKind: 21
-      HeaderType: 47 GoSwissMapHeaderType map<string,[]string>
+      HeaderType: 49 GoSwissMapHeaderType map<string,[]string>
     - __kind: StructureType
       ID: 38
       Name: net/http.Request
@@ -2658,7 +1895,7 @@ Types:
           Type: 9 GoStringHeaderType string
         - Name: URL
           Offset: 16
-          Type: 43 PointerType *net/url.URL
+          Type: 45 PointerType *net/url.URL
         - Name: Proto
           Offset: 24
           Type: 9 GoStringHeaderType string
@@ -2670,19 +1907,19 @@ Types:
           Type: 7 BaseType int
         - Name: Header
           Offset: 56
-          Type: 45 GoMapType net/http.Header
+          Type: 47 GoMapType net/http.Header
         - Name: Body
           Offset: 64
-          Type: 50 GoInterfaceType io.ReadCloser
+          Type: 52 GoInterfaceType io.ReadCloser
         - Name: GetBody
           Offset: 80
-          Type: 51 GoSubroutineType func() (io.ReadCloser, error)
+          Type: 53 GoSubroutineType func() (io.ReadCloser, error)
         - Name: ContentLength
           Offset: 88
           Type: 12 BaseType int64
         - Name: TransferEncoding
           Offset: 96
-          Type: 52 GoSliceHeaderType []string
+          Type: 54 GoSliceHeaderType []string
         - Name: Close
           Offset: 120
           Type: 4 BaseType bool
@@ -2691,16 +1928,16 @@ Types:
           Type: 9 GoStringHeaderType string
         - Name: Form
           Offset: 144
-          Type: 53 GoMapType net/url.Values
+          Type: 55 GoMapType net/url.Values
         - Name: PostForm
           Offset: 152
-          Type: 53 GoMapType net/url.Values
+          Type: 55 GoMapType net/url.Values
         - Name: MultipartForm
           Offset: 160
-          Type: 54 PointerType *mime/multipart.Form
+          Type: 56 PointerType *mime/multipart.Form
         - Name: Trailer
           Offset: 168
-          Type: 45 GoMapType net/http.Header
+          Type: 47 GoMapType net/http.Header
         - Name: RemoteAddr
           Offset: 176
           Type: 9 GoStringHeaderType string
@@ -2709,30 +1946,30 @@ Types:
           Type: 9 GoStringHeaderType string
         - Name: TLS
           Offset: 208
-          Type: 56 PointerType *crypto/tls.ConnectionState
+          Type: 58 PointerType *crypto/tls.ConnectionState
         - Name: Cancel
           Offset: 216
-          Type: 58 GoChannelType <-chan struct {}
+          Type: 60 GoChannelType <-chan struct {}
         - Name: Response
           Offset: 224
-          Type: 59 PointerType *net/http.Response
+          Type: 61 PointerType *net/http.Response
         - Name: Pattern
           Offset: 232
           Type: 9 GoStringHeaderType string
         - Name: ctx
           Offset: 248
-          Type: 61 GoInterfaceType context.Context
+          Type: 63 GoInterfaceType context.Context
         - Name: pat
           Offset: 264
-          Type: 62 PointerType *net/http.pattern
+          Type: 64 PointerType *net/http.pattern
         - Name: matches
           Offset: 272
-          Type: 52 GoSliceHeaderType []string
+          Type: 54 GoSliceHeaderType []string
         - Name: otherValues
           Offset: 296
-          Type: 64 GoMapType map[string]string
+          Type: 66 GoMapType map[string]string
     - __kind: StructureType
-      ID: 60
+      ID: 62
       Name: net/http.Response
       ByteSize: 144
       GoRuntimeType: 2.268608e+06
@@ -2755,16 +1992,16 @@ Types:
           Type: 7 BaseType int
         - Name: Header
           Offset: 56
-          Type: 45 GoMapType net/http.Header
+          Type: 47 GoMapType net/http.Header
         - Name: Body
           Offset: 64
-          Type: 50 GoInterfaceType io.ReadCloser
+          Type: 52 GoInterfaceType io.ReadCloser
         - Name: ContentLength
           Offset: 80
           Type: 12 BaseType int64
         - Name: TransferEncoding
           Offset: 88
-          Type: 52 GoSliceHeaderType []string
+          Type: 54 GoSliceHeaderType []string
         - Name: Close
           Offset: 112
           Type: 4 BaseType bool
@@ -2773,13 +2010,13 @@ Types:
           Type: 4 BaseType bool
         - Name: Trailer
           Offset: 120
-          Type: 45 GoMapType net/http.Header
+          Type: 47 GoMapType net/http.Header
         - Name: Request
           Offset: 128
           Type: 37 PointerType *net/http.Request
         - Name: TLS
           Offset: 136
-          Type: 56 PointerType *crypto/tls.ConnectionState
+          Type: 58 PointerType *crypto/tls.ConnectionState
     - __kind: GoInterfaceType
       ID: 36
       Name: net/http.ResponseWriter
@@ -2794,7 +2031,7 @@ Types:
           Offset: 8
           Type: 14 VoidPointerType unsafe.Pointer
     - __kind: StructureType
-      ID: 63
+      ID: 65
       Name: net/http.pattern
       ByteSize: 88
       GoRuntimeType: 1.875616e+06
@@ -2811,12 +2048,12 @@ Types:
           Type: 9 GoStringHeaderType string
         - Name: segments
           Offset: 48
-          Type: 117 GoSliceHeaderType []net/http.segment
+          Type: 201 GoSliceHeaderType []net/http.segment
         - Name: loc
           Offset: 72
           Type: 9 GoStringHeaderType string
     - __kind: StructureType
-      ID: 119
+      ID: 203
       Name: net/http.segment
       ByteSize: 24
       GoRuntimeType: 1.642496e+06
@@ -2832,14 +2069,14 @@ Types:
           Offset: 17
           Type: 4 BaseType bool
     - __kind: GoMapType
-      ID: 255
+      ID: 103
       Name: net/textproto.MIMEHeader
       ByteSize: 8
       GoRuntimeType: 1.86368e+06
       GoKind: 21
-      HeaderType: 47 GoSwissMapHeaderType map<string,[]string>
+      HeaderType: 49 GoSwissMapHeaderType map<string,[]string>
     - __kind: StructureType
-      ID: 44
+      ID: 46
       Name: net/url.URL
       ByteSize: 144
       GoRuntimeType: 2.181632e+06
@@ -2853,7 +2090,7 @@ Types:
           Type: 9 GoStringHeaderType string
         - Name: User
           Offset: 32
-          Type: 98 PointerType *net/url.Userinfo
+          Type: 71 PointerType *net/url.Userinfo
         - Name: Host
           Offset: 40
           Type: 9 GoStringHeaderType string
@@ -2879,7 +2116,7 @@ Types:
           Offset: 128
           Type: 9 GoStringHeaderType string
     - __kind: StructureType
-      ID: 99
+      ID: 72
       Name: net/url.Userinfo
       ByteSize: 40
       GoRuntimeType: 1.658624e+06
@@ -2895,81 +2132,41 @@ Types:
           Offset: 32
           Type: 4 BaseType bool
     - __kind: GoMapType
-      ID: 53
+      ID: 55
       Name: net/url.Values
       ByteSize: 8
       GoRuntimeType: 1.92848e+06
       GoKind: 21
-      HeaderType: 47 GoSwissMapHeaderType map<string,[]string>
+      HeaderType: 49 GoSwissMapHeaderType map<string,[]string>
     - __kind: ArrayType
-      ID: 196
-      Name: noalg.[8]struct { key string; elem *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute }
-      ByteSize: 192
-      GoRuntimeType: 715328
-      GoKind: 17
-      Count: 8
-      HasCount: true
-      Element: 197 StructureType noalg.struct { key string; elem *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute }
-    - __kind: ArrayType
-      ID: 178
+      ID: 93
       Name: noalg.[8]struct { key string; elem []*mime/multipart.FileHeader }
       ByteSize: 320
       GoRuntimeType: 710944
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 179 StructureType noalg.struct { key string; elem []*mime/multipart.FileHeader }
+      Element: 94 StructureType noalg.struct { key string; elem []*mime/multipart.FileHeader }
     - __kind: ArrayType
-      ID: 135
+      ID: 77
       Name: noalg.[8]struct { key string; elem []string }
       ByteSize: 320
       GoRuntimeType: 701120
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 136 StructureType noalg.struct { key string; elem []string }
+      Element: 78 StructureType noalg.struct { key string; elem []string }
     - __kind: ArrayType
-      ID: 159
-      Name: noalg.[8]struct { key string; elem float64 }
-      ByteSize: 192
-      GoRuntimeType: 715232
-      GoKind: 17
-      Count: 8
-      HasCount: true
-      Element: 160 StructureType noalg.struct { key string; elem float64 }
-    - __kind: ArrayType
-      ID: 151
-      Name: noalg.[8]struct { key string; elem interface {} }
-      ByteSize: 256
-      GoRuntimeType: 692576
-      GoKind: 17
-      Count: 8
-      HasCount: true
-      Element: 152 StructureType noalg.struct { key string; elem interface {} }
-    - __kind: ArrayType
-      ID: 144
+      ID: 210
       Name: noalg.[8]struct { key string; elem string }
       ByteSize: 256
       GoRuntimeType: 705280
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 145 StructureType noalg.struct { key string; elem string }
+      Element: 211 StructureType noalg.struct { key string; elem string }
     - __kind: StructureType
-      ID: 195
-      Name: noalg.map.group[string]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
-      ByteSize: 200
-      GoRuntimeType: 1.332e+06
-      GoKind: 25
-      RawFields:
-        - Name: ctrl
-          Offset: 0
-          Type: 8 BaseType uint64
-        - Name: slots
-          Offset: 8
-          Type: 196 ArrayType noalg.[8]struct { key string; elem *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute }
-    - __kind: StructureType
-      ID: 177
+      ID: 92
       Name: noalg.map.group[string][]*mime/multipart.FileHeader
       ByteSize: 328
       GoRuntimeType: 1.325728e+06
@@ -2980,9 +2177,9 @@ Types:
           Type: 8 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 178 ArrayType noalg.[8]struct { key string; elem []*mime/multipart.FileHeader }
+          Type: 93 ArrayType noalg.[8]struct { key string; elem []*mime/multipart.FileHeader }
     - __kind: StructureType
-      ID: 134
+      ID: 76
       Name: noalg.map.group[string][]string
       ByteSize: 328
       GoRuntimeType: 1.31664e+06
@@ -2993,35 +2190,9 @@ Types:
           Type: 8 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 135 ArrayType noalg.[8]struct { key string; elem []string }
+          Type: 77 ArrayType noalg.[8]struct { key string; elem []string }
     - __kind: StructureType
-      ID: 158
-      Name: noalg.map.group[string]float64
-      ByteSize: 200
-      GoRuntimeType: 1.331744e+06
-      GoKind: 25
-      RawFields:
-        - Name: ctrl
-          Offset: 0
-          Type: 8 BaseType uint64
-        - Name: slots
-          Offset: 8
-          Type: 159 ArrayType noalg.[8]struct { key string; elem float64 }
-    - __kind: StructureType
-      ID: 150
-      Name: noalg.map.group[string]interface {}
-      ByteSize: 264
-      GoRuntimeType: 1.31408e+06
-      GoKind: 25
-      RawFields:
-        - Name: ctrl
-          Offset: 0
-          Type: 8 BaseType uint64
-        - Name: slots
-          Offset: 8
-          Type: 151 ArrayType noalg.[8]struct { key string; elem interface {} }
-    - __kind: StructureType
-      ID: 143
+      ID: 209
       Name: noalg.map.group[string]string
       ByteSize: 264
       GoRuntimeType: 1.319072e+06
@@ -3032,22 +2203,9 @@ Types:
           Type: 8 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 144 ArrayType noalg.[8]struct { key string; elem string }
+          Type: 210 ArrayType noalg.[8]struct { key string; elem string }
     - __kind: StructureType
-      ID: 197
-      Name: noalg.struct { key string; elem *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute }
-      ByteSize: 24
-      GoRuntimeType: 1.331872e+06
-      GoKind: 25
-      RawFields:
-        - Name: key
-          Offset: 0
-          Type: 9 GoStringHeaderType string
-        - Name: elem
-          Offset: 16
-          Type: 198 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
-    - __kind: StructureType
-      ID: 179
+      ID: 94
       Name: noalg.struct { key string; elem []*mime/multipart.FileHeader }
       ByteSize: 40
       GoRuntimeType: 1.3256e+06
@@ -3058,9 +2216,9 @@ Types:
           Type: 9 GoStringHeaderType string
         - Name: elem
           Offset: 16
-          Type: 180 GoSliceHeaderType []*mime/multipart.FileHeader
+          Type: 95 GoSliceHeaderType []*mime/multipart.FileHeader
     - __kind: StructureType
-      ID: 136
+      ID: 78
       Name: noalg.struct { key string; elem []string }
       ByteSize: 40
       GoRuntimeType: 1.316512e+06
@@ -3071,35 +2229,9 @@ Types:
           Type: 9 GoStringHeaderType string
         - Name: elem
           Offset: 16
-          Type: 52 GoSliceHeaderType []string
+          Type: 54 GoSliceHeaderType []string
     - __kind: StructureType
-      ID: 160
-      Name: noalg.struct { key string; elem float64 }
-      ByteSize: 24
-      GoRuntimeType: 1.331616e+06
-      GoKind: 25
-      RawFields:
-        - Name: key
-          Offset: 0
-          Type: 9 GoStringHeaderType string
-        - Name: elem
-          Offset: 16
-          Type: 15 BaseType float64
-    - __kind: StructureType
-      ID: 152
-      Name: noalg.struct { key string; elem interface {} }
-      ByteSize: 32
-      GoRuntimeType: 1.313952e+06
-      GoKind: 25
-      RawFields:
-        - Name: key
-          Offset: 0
-          Type: 9 GoStringHeaderType string
-        - Name: elem
-          Offset: 16
-          Type: 153 GoEmptyInterfaceType interface {}
-    - __kind: StructureType
-      ID: 145
+      ID: 211
       Name: noalg.struct { key string; elem string }
       ByteSize: 32
       GoRuntimeType: 1.318944e+06
@@ -3120,101 +2252,17 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 97 PointerType *string.str
+          Type: 44 PointerType *string.str
         - Name: len
           Offset: 8
           Type: 7 BaseType int
-      Data: 96 GoStringDataType string.str
+      Data: 43 GoStringDataType string.str
     - __kind: GoStringDataType
-      ID: 96
+      ID: 43
       Name: string.str
       ByteSize: 2048
     - __kind: StructureType
-      ID: 70
-      Name: sync.Mutex
-      ByteSize: 8
-      GoRuntimeType: 1.494336e+06
-      GoKind: 25
-      RawFields:
-        - Name: _
-          Offset: 0
-          Type: 71 StructureType sync.noCopy
-        - Name: mu
-          Offset: 0
-          Type: 72 StructureType internal/sync.Mutex
-    - __kind: StructureType
-      ID: 69
-      Name: sync.RWMutex
-      ByteSize: 24
-      GoRuntimeType: 1.88144e+06
-      GoKind: 25
-      RawFields:
-        - Name: w
-          Offset: 0
-          Type: 70 StructureType sync.Mutex
-        - Name: writerSem
-          Offset: 8
-          Type: 2 BaseType uint32
-        - Name: readerSem
-          Offset: 12
-          Type: 2 BaseType uint32
-        - Name: readerCount
-          Offset: 16
-          Type: 73 StructureType sync/atomic.Int32
-        - Name: readerWait
-          Offset: 20
-          Type: 73 StructureType sync/atomic.Int32
-    - __kind: StructureType
-      ID: 71
-      Name: sync.noCopy
-      GoRuntimeType: 1.007392e+06
-      GoKind: 25
-      RawFields: []
-    - __kind: StructureType
-      ID: 73
-      Name: sync/atomic.Int32
-      ByteSize: 4
-      GoRuntimeType: 1.495616e+06
-      GoKind: 25
-      RawFields:
-        - Name: _
-          Offset: 0
-          Type: 74 StructureType sync/atomic.noCopy
-        - Name: v
-          Offset: 0
-          Type: 10 BaseType int32
-    - __kind: StructureType
-      ID: 74
-      Name: sync/atomic.noCopy
-      GoRuntimeType: 1.007488e+06
-      GoKind: 25
-      RawFields: []
-    - __kind: StructureType
-      ID: 171
-      Name: table<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
-      ByteSize: 32
-      GoKind: 25
-      RawFields:
-        - Name: used
-          Offset: 0
-          Type: 6 BaseType uint16
-        - Name: capacity
-          Offset: 2
-          Type: 6 BaseType uint16
-        - Name: growthLeft
-          Offset: 4
-          Type: 6 BaseType uint16
-        - Name: localDepth
-          Offset: 6
-          Type: 3 BaseType uint8
-        - Name: index
-          Offset: 8
-          Type: 7 BaseType int
-        - Name: groups
-          Offset: 16
-          Type: 193 GoSwissMapGroupsType groupReference<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
-    - __kind: StructureType
-      ID: 169
+      ID: 89
       Name: table<string,[]*mime/multipart.FileHeader>
       ByteSize: 32
       GoKind: 25
@@ -3236,9 +2284,9 @@ Types:
           Type: 7 BaseType int
         - Name: groups
           Offset: 16
-          Type: 175 GoSwissMapGroupsType groupReference<string,[]*mime/multipart.FileHeader>
+          Type: 90 GoSwissMapGroupsType groupReference<string,[]*mime/multipart.FileHeader>
     - __kind: StructureType
-      ID: 100
+      ID: 73
       Name: table<string,[]string>
       ByteSize: 32
       GoKind: 25
@@ -3260,57 +2308,9 @@ Types:
           Type: 7 BaseType int
         - Name: groups
           Offset: 16
-          Type: 132 GoSwissMapGroupsType groupReference<string,[]string>
+          Type: 74 GoSwissMapGroupsType groupReference<string,[]string>
     - __kind: StructureType
-      ID: 122
-      Name: table<string,float64>
-      ByteSize: 32
-      GoKind: 25
-      RawFields:
-        - Name: used
-          Offset: 0
-          Type: 6 BaseType uint16
-        - Name: capacity
-          Offset: 2
-          Type: 6 BaseType uint16
-        - Name: growthLeft
-          Offset: 4
-          Type: 6 BaseType uint16
-        - Name: localDepth
-          Offset: 6
-          Type: 3 BaseType uint8
-        - Name: index
-          Offset: 8
-          Type: 7 BaseType int
-        - Name: groups
-          Offset: 16
-          Type: 156 GoSwissMapGroupsType groupReference<string,float64>
-    - __kind: StructureType
-      ID: 121
-      Name: table<string,interface {}>
-      ByteSize: 32
-      GoKind: 25
-      RawFields:
-        - Name: used
-          Offset: 0
-          Type: 6 BaseType uint16
-        - Name: capacity
-          Offset: 2
-          Type: 6 BaseType uint16
-        - Name: growthLeft
-          Offset: 4
-          Type: 6 BaseType uint16
-        - Name: localDepth
-          Offset: 6
-          Type: 3 BaseType uint8
-        - Name: index
-          Offset: 8
-          Type: 7 BaseType int
-        - Name: groups
-          Offset: 16
-          Type: 148 GoSwissMapGroupsType groupReference<string,interface {}>
-    - __kind: StructureType
-      ID: 120
+      ID: 206
       Name: table<string,string>
       ByteSize: 32
       GoKind: 25
@@ -3332,9 +2332,9 @@ Types:
           Type: 7 BaseType int
         - Name: groups
           Offset: 16
-          Type: 141 GoSwissMapGroupsType groupReference<string,string>
+          Type: 207 GoSwissMapGroupsType groupReference<string,string>
     - __kind: StructureType
-      ID: 212
+      ID: 135
       Name: time.Location
       ByteSize: 104
       GoRuntimeType: 2.014752e+06
@@ -3345,10 +2345,10 @@ Types:
           Type: 9 GoStringHeaderType string
         - Name: zone
           Offset: 16
-          Type: 248 GoSliceHeaderType []time.zone
+          Type: 167 GoSliceHeaderType []time.zone
         - Name: tx
           Offset: 40
-          Type: 251 GoSliceHeaderType []time.zoneTrans
+          Type: 170 GoSliceHeaderType []time.zoneTrans
         - Name: extend
           Offset: 64
           Type: 9 GoStringHeaderType string
@@ -3360,9 +2360,9 @@ Types:
           Type: 12 BaseType int64
         - Name: cacheZone
           Offset: 96
-          Type: 249 PointerType *time.zone
+          Type: 168 PointerType *time.zone
     - __kind: StructureType
-      ID: 210
+      ID: 133
       Name: time.Time
       ByteSize: 24
       GoRuntimeType: 2.42976e+06
@@ -3376,9 +2376,9 @@ Types:
           Type: 12 BaseType int64
         - Name: loc
           Offset: 16
-          Type: 211 PointerType *time.Location
+          Type: 134 PointerType *time.Location
     - __kind: StructureType
-      ID: 250
+      ID: 169
       Name: time.zone
       ByteSize: 32
       GoRuntimeType: 1.647488e+06
@@ -3394,7 +2394,7 @@ Types:
           Offset: 24
           Type: 4 BaseType bool
     - __kind: StructureType
-      ID: 253
+      ID: 172
       Name: time.zoneTrans
       ByteSize: 16
       GoRuntimeType: 1.789472e+06
@@ -3454,6 +2454,6 @@ Types:
       ByteSize: 8
       GoRuntimeType: 595296
       GoKind: 26
-MaxTypeID: 295
+MaxTypeID: 215
 Issues: []
 GoModuledataInfo: {FirstModuledataAddr: "0x18bb880", TypesOffset: 296}

--- a/pkg/dyninst/irgen/testdata/snapshot/rc_tester.arch=amd64,toolchain=go1.25.0.yaml
+++ b/pkg/dyninst/irgen/testdata/snapshot/rc_tester.arch=amd64,toolchain=go1.25.0.yaml
@@ -33,7 +33,7 @@ Subprograms:
       InlinePCRanges: []
       Variables:
         - Name: w
-          Type: 1 GoInterfaceType net/http.ResponseWriter
+          Type: 36 GoInterfaceType net/http.ResponseWriter
           Locations:
             - Range: 0xd36340..0xd363ac
               Pieces:
@@ -56,7 +56,7 @@ Subprograms:
           IsParameter: true
           IsReturn: false
         - Name: r
-          Type: 3 PointerType *net/http.Request
+          Type: 37 PointerType *net/http.Request
           Locations:
             - Range: 0xd36340..0xd363b6
               Pieces: [{Size: 8, Op: {RegNo: 2, Shift: 0}}]
@@ -65,14 +65,14 @@ Subprograms:
           IsParameter: true
           IsReturn: false
         - Name: span
-          Type: 135 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span
+          Type: 158 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span
           Locations:
             - Range: 0xd363c8..0xd36401
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: false
           IsReturn: false
         - Name: '&buf'
-          Type: 206 PointerType *bytes.Buffer
+          Type: 225 PointerType *bytes.Buffer
           Locations:
             - Range: 0xd364d7..0xd364f2
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
@@ -86,7 +86,7 @@ Subprograms:
       InlinePCRanges: []
       Variables:
         - Name: path
-          Type: 5 GoStringHeaderType string
+          Type: 9 GoStringHeaderType string
           Locations:
             - Range: 0xd366a0..0xd366c5
               Pieces:
@@ -98,77 +98,77 @@ Subprograms:
           IsReturn: false
 Types:
     - __kind: PointerType
-      ID: 58
+      ID: 82
       Name: '**crypto/x509.Certificate'
       ByteSize: 8
       GoKind: 22
-      Pointee: 59 PointerType *crypto/x509.Certificate
+      Pointee: 83 PointerType *crypto/x509.Certificate
     - __kind: PointerType
-      ID: 201
+      ID: 221
       Name: '**github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span'
       ByteSize: 8
       GoKind: 22
-      Pointee: 135 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span
+      Pointee: 158 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span
     - __kind: PointerType
-      ID: 191
+      ID: 211
       Name: '**github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttributeValue'
       ByteSize: 8
       GoKind: 22
-      Pointee: 192 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttributeValue
+      Pointee: 212 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttributeValue
     - __kind: PointerType
-      ID: 49
+      ID: 73
       Name: '**mime/multipart.FileHeader'
       ByteSize: 8
       GoKind: 22
-      Pointee: 50 PointerType *mime/multipart.FileHeader
+      Pointee: 74 PointerType *mime/multipart.FileHeader
     - __kind: PointerType
-      ID: 99
+      ID: 122
       Name: '**net.IPNet'
       ByteSize: 8
       GoKind: 22
-      Pointee: 100 PointerType *net.IPNet
+      Pointee: 123 PointerType *net.IPNet
     - __kind: PointerType
-      ID: 97
+      ID: 120
       Name: '**net/url.URL'
       ByteSize: 8
       GoKind: 22
-      Pointee: 9 PointerType *net/url.URL
+      Pointee: 39 PointerType *net/url.URL
     - __kind: PointerType
-      ID: 177
+      ID: 197
       Name: '**table<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>'
       ByteSize: 8
-      Pointee: 178 PointerType *table<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
+      Pointee: 198 PointerType *table<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
     - __kind: PointerType
-      ID: 40
+      ID: 64
       Name: '**table<string,[]*mime/multipart.FileHeader>'
       ByteSize: 8
-      Pointee: 41 PointerType *table<string,[]*mime/multipart.FileHeader>
+      Pointee: 65 PointerType *table<string,[]*mime/multipart.FileHeader>
     - __kind: PointerType
-      ID: 19
+      ID: 46
       Name: '**table<string,[]string>'
       ByteSize: 8
-      Pointee: 20 PointerType *table<string,[]string>
+      Pointee: 47 PointerType *table<string,[]string>
     - __kind: PointerType
-      ID: 159
+      ID: 180
       Name: '**table<string,float64>'
       ByteSize: 8
-      Pointee: 160 PointerType *table<string,float64>
+      Pointee: 181 PointerType *table<string,float64>
     - __kind: PointerType
-      ID: 148
+      ID: 169
       Name: '**table<string,interface {}>'
       ByteSize: 8
-      Pointee: 149 PointerType *table<string,interface {}>
+      Pointee: 170 PointerType *table<string,interface {}>
     - __kind: PointerType
-      ID: 127
+      ID: 150
       Name: '**table<string,string>'
       ByteSize: 8
-      Pointee: 128 PointerType *table<string,string>
+      Pointee: 151 PointerType *table<string,string>
     - __kind: PointerType
-      ID: 110
+      ID: 133
       Name: '*[]*crypto/x509.Certificate'
       ByteSize: 8
       GoKind: 22
-      Pointee: 57 GoSliceHeaderType []*crypto/x509.Certificate
+      Pointee: 81 GoSliceHeaderType []*crypto/x509.Certificate
     - __kind: PointerType
       ID: 241
       Name: '*[]*crypto/x509.Certificate.array'
@@ -275,274 +275,274 @@ Types:
       ByteSize: 8
       Pointee: 250 GoSliceDataType []time.zoneTrans.array
     - __kind: PointerType
-      ID: 112
+      ID: 135
       Name: '*[]uint8'
       ByteSize: 8
       GoRuntimeType: 486560
       GoKind: 22
-      Pointee: 53 GoSliceHeaderType []uint8
+      Pointee: 77 GoSliceHeaderType []uint8
     - __kind: PointerType
       ID: 239
       Name: '*[]uint8.array'
       ByteSize: 8
       Pointee: 238 GoSliceDataType []uint8.array
     - __kind: PointerType
-      ID: 209
+      ID: 11
       Name: '*bool'
       ByteSize: 8
       GoRuntimeType: 405472
       GoKind: 22
-      Pointee: 13 BaseType bool
+      Pointee: 4 BaseType bool
     - __kind: PointerType
-      ID: 206
+      ID: 225
       Name: '*bytes.Buffer'
       ByteSize: 8
       GoRuntimeType: 2.321376e+06
       GoKind: 22
-      Pointee: 207 StructureType bytes.Buffer
+      Pointee: 226 StructureType bytes.Buffer
     - __kind: PointerType
-      ID: 54
+      ID: 78
       Name: '*crypto/tls.ConnectionState'
       ByteSize: 8
       GoRuntimeType: 924032
       GoKind: 22
-      Pointee: 55 StructureType crypto/tls.ConnectionState
+      Pointee: 79 StructureType crypto/tls.ConnectionState
     - __kind: PointerType
-      ID: 59
+      ID: 83
       Name: '*crypto/x509.Certificate'
       ByteSize: 8
       GoRuntimeType: 2.089664e+06
       GoKind: 22
-      Pointee: 60 StructureType crypto/x509.Certificate
+      Pointee: 84 StructureType crypto/x509.Certificate
     - __kind: PointerType
-      ID: 91
+      ID: 114
       Name: '*crypto/x509.ExtKeyUsage'
       ByteSize: 8
       GoRuntimeType: 429920
       GoKind: 22
-      Pointee: 92 BaseType crypto/x509.ExtKeyUsage
+      Pointee: 115 BaseType crypto/x509.ExtKeyUsage
     - __kind: PointerType
-      ID: 104
+      ID: 127
       Name: '*crypto/x509.OID'
       ByteSize: 8
       GoRuntimeType: 1.998112e+06
       GoKind: 22
-      Pointee: 105 StructureType crypto/x509.OID
+      Pointee: 128 StructureType crypto/x509.OID
     - __kind: PointerType
-      ID: 107
+      ID: 130
       Name: '*crypto/x509.PolicyMapping'
       ByteSize: 8
       GoRuntimeType: 429984
       GoKind: 22
-      Pointee: 108 StructureType crypto/x509.PolicyMapping
+      Pointee: 131 StructureType crypto/x509.PolicyMapping
     - __kind: PointerType
-      ID: 71
+      ID: 95
       Name: '*crypto/x509/pkix.AttributeTypeAndValue'
       ByteSize: 8
       GoRuntimeType: 446624
       GoKind: 22
-      Pointee: 72 StructureType crypto/x509/pkix.AttributeTypeAndValue
+      Pointee: 96 StructureType crypto/x509/pkix.AttributeTypeAndValue
     - __kind: PointerType
-      ID: 86
+      ID: 109
       Name: '*crypto/x509/pkix.Extension'
       ByteSize: 8
       GoRuntimeType: 446816
       GoKind: 22
-      Pointee: 87 StructureType crypto/x509/pkix.Extension
+      Pointee: 110 StructureType crypto/x509/pkix.Extension
     - __kind: PointerType
-      ID: 89
+      ID: 112
       Name: '*encoding/asn1.ObjectIdentifier'
       ByteSize: 8
       GoRuntimeType: 1.079776e+06
       GoKind: 22
-      Pointee: 73 GoSliceHeaderType encoding/asn1.ObjectIdentifier
+      Pointee: 97 GoSliceHeaderType encoding/asn1.ObjectIdentifier
     - __kind: PointerType
       ID: 247
       Name: '*encoding/asn1.ObjectIdentifier.array'
       ByteSize: 8
       Pointee: 246 GoSliceDataType encoding/asn1.ObjectIdentifier.array
     - __kind: PointerType
-      ID: 225
+      ID: 33
       Name: '*error'
       ByteSize: 8
       GoRuntimeType: 404384
       GoKind: 22
-      Pointee: 210 GoInterfaceType error
+      Pointee: 13 GoInterfaceType error
     - __kind: PointerType
-      ID: 227
+      ID: 35
       Name: '*float32'
       ByteSize: 8
       GoRuntimeType: 405344
       GoKind: 22
-      Pointee: 213 BaseType float32
+      Pointee: 18 BaseType float32
     - __kind: PointerType
-      ID: 202
+      ID: 25
       Name: '*float64'
       ByteSize: 8
       GoRuntimeType: 405408
       GoKind: 22
-      Pointee: 167 BaseType float64
+      Pointee: 15 BaseType float64
     - __kind: PointerType
-      ID: 135
+      ID: 158
       Name: '*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span'
       ByteSize: 8
       GoRuntimeType: 2.33264e+06
       GoKind: 22
-      Pointee: 136 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span
+      Pointee: 159 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span
     - __kind: PointerType
-      ID: 196
+      ID: 216
       Name: '*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanContext'
       ByteSize: 8
       GoRuntimeType: 2.054336e+06
       GoKind: 22
-      Pointee: 197 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanContext
+      Pointee: 217 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanContext
     - __kind: PointerType
-      ID: 169
+      ID: 189
       Name: '*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink'
       ByteSize: 8
       GoRuntimeType: 1.21456e+06
       GoKind: 22
-      Pointee: 170 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink
+      Pointee: 190 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink
     - __kind: PointerType
-      ID: 172
+      ID: 192
       Name: '*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent'
       ByteSize: 8
       GoRuntimeType: 1.214688e+06
       GoKind: 22
-      Pointee: 173 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent
+      Pointee: 193 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent
     - __kind: PointerType
-      ID: 188
+      ID: 208
       Name: '*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttribute'
       ByteSize: 8
       GoRuntimeType: 1.215328e+06
       GoKind: 22
-      Pointee: 189 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttribute
+      Pointee: 209 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttribute
     - __kind: PointerType
-      ID: 192
+      ID: 212
       Name: '*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttributeValue'
       ByteSize: 8
       GoRuntimeType: 1.215072e+06
       GoKind: 22
-      Pointee: 193 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttributeValue
+      Pointee: 213 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttributeValue
     - __kind: PointerType
-      ID: 185
+      ID: 205
       Name: '*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute'
       ByteSize: 8
       GoRuntimeType: 1.215456e+06
       GoKind: 22
-      Pointee: 186 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
+      Pointee: 206 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
     - __kind: PointerType
-      ID: 198
+      ID: 218
       Name: '*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.trace'
       ByteSize: 8
       GoRuntimeType: 2.277568e+06
       GoKind: 22
-      Pointee: 199 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.trace
+      Pointee: 219 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.trace
     - __kind: PointerType
-      ID: 74
+      ID: 26
       Name: '*int'
       ByteSize: 8
       GoRuntimeType: 405024
       GoKind: 22
-      Pointee: 8 BaseType int
+      Pointee: 7 BaseType int
     - __kind: PointerType
-      ID: 222
+      ID: 30
       Name: '*int16'
       ByteSize: 8
       GoRuntimeType: 404640
       GoKind: 22
-      Pointee: 223 BaseType int16
+      Pointee: 31 BaseType int16
     - __kind: PointerType
-      ID: 215
+      ID: 20
       Name: '*int32'
       ByteSize: 8
       GoRuntimeType: 404768
       GoKind: 22
-      Pointee: 141 BaseType int32
+      Pointee: 10 BaseType int32
     - __kind: PointerType
-      ID: 219
+      ID: 27
       Name: '*int64'
       ByteSize: 8
       GoRuntimeType: 404896
       GoKind: 22
-      Pointee: 32 BaseType int64
+      Pointee: 12 BaseType int64
     - __kind: PointerType
-      ID: 224
+      ID: 32
       Name: '*int8'
       ByteSize: 8
       GoRuntimeType: 404512
       GoKind: 22
-      Pointee: 211 BaseType int8
+      Pointee: 16 BaseType int8
     - __kind: PointerType
-      ID: 175
+      ID: 195
       Name: '*map<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>'
       ByteSize: 8
-      Pointee: 176 GoSwissMapHeaderType map<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
+      Pointee: 196 GoSwissMapHeaderType map<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
     - __kind: PointerType
-      ID: 38
+      ID: 62
       Name: '*map<string,[]*mime/multipart.FileHeader>'
       ByteSize: 8
-      Pointee: 39 GoSwissMapHeaderType map<string,[]*mime/multipart.FileHeader>
+      Pointee: 63 GoSwissMapHeaderType map<string,[]*mime/multipart.FileHeader>
     - __kind: PointerType
-      ID: 15
+      ID: 44
       Name: '*map<string,[]string>'
       ByteSize: 8
-      Pointee: 16 GoSwissMapHeaderType map<string,[]string>
+      Pointee: 45 GoSwissMapHeaderType map<string,[]string>
     - __kind: PointerType
-      ID: 157
+      ID: 178
       Name: '*map<string,float64>'
       ByteSize: 8
-      Pointee: 158 GoSwissMapHeaderType map<string,float64>
+      Pointee: 179 GoSwissMapHeaderType map<string,float64>
     - __kind: PointerType
-      ID: 146
+      ID: 167
       Name: '*map<string,interface {}>'
       ByteSize: 8
-      Pointee: 147 GoSwissMapHeaderType map<string,interface {}>
+      Pointee: 168 GoSwissMapHeaderType map<string,interface {}>
     - __kind: PointerType
-      ID: 125
+      ID: 148
       Name: '*map<string,string>'
       ByteSize: 8
-      Pointee: 126 GoSwissMapHeaderType map<string,string>
+      Pointee: 149 GoSwissMapHeaderType map<string,string>
     - __kind: PointerType
-      ID: 64
+      ID: 88
       Name: '*math/big.Int'
       ByteSize: 8
       GoRuntimeType: 2.447424e+06
       GoKind: 22
-      Pointee: 65 StructureType math/big.Int
+      Pointee: 89 StructureType math/big.Int
     - __kind: PointerType
-      ID: 67
+      ID: 91
       Name: '*math/big.Word'
       ByteSize: 8
       GoRuntimeType: 432800
       GoKind: 22
-      Pointee: 68 BaseType math/big.Word
+      Pointee: 92 BaseType math/big.Word
     - __kind: PointerType
       ID: 243
       Name: '*math/big.nat.array'
       ByteSize: 8
       Pointee: 242 GoSliceDataType math/big.nat.array
     - __kind: PointerType
-      ID: 50
+      ID: 74
       Name: '*mime/multipart.FileHeader'
       ByteSize: 8
       GoRuntimeType: 925568
       GoKind: 22
-      Pointee: 51 StructureType mime/multipart.FileHeader
+      Pointee: 75 StructureType mime/multipart.FileHeader
     - __kind: PointerType
-      ID: 34
+      ID: 58
       Name: '*mime/multipart.Form'
       ByteSize: 8
       GoRuntimeType: 925664
       GoKind: 22
-      Pointee: 35 StructureType mime/multipart.Form
+      Pointee: 59 StructureType mime/multipart.Form
     - __kind: PointerType
-      ID: 94
+      ID: 117
       Name: '*net.IP'
       ByteSize: 8
       GoRuntimeType: 2.206912e+06
       GoKind: 22
-      Pointee: 95 GoSliceHeaderType net.IP
+      Pointee: 118 GoSliceHeaderType net.IP
     - __kind: PointerType
       ID: 261
       Name: '*net.IP.array'
@@ -554,191 +554,191 @@ Types:
       ByteSize: 8
       Pointee: 266 GoSliceDataType net.IPMask.array
     - __kind: PointerType
-      ID: 100
+      ID: 123
       Name: '*net.IPNet'
       ByteSize: 8
       GoRuntimeType: 1.208416e+06
       GoKind: 22
-      Pointee: 101 StructureType net.IPNet
+      Pointee: 124 StructureType net.IPNet
     - __kind: PointerType
-      ID: 3
+      ID: 37
       Name: '*net/http.Request'
       ByteSize: 8
       GoRuntimeType: 2.365504e+06
       GoKind: 22
-      Pointee: 4 StructureType net/http.Request
+      Pointee: 38 StructureType net/http.Request
     - __kind: PointerType
-      ID: 116
+      ID: 139
       Name: '*net/http.Response'
       ByteSize: 8
       GoRuntimeType: 1.7584e+06
       GoKind: 22
-      Pointee: 117 StructureType net/http.Response
+      Pointee: 140 StructureType net/http.Response
     - __kind: PointerType
-      ID: 119
+      ID: 142
       Name: '*net/http.pattern'
       ByteSize: 8
       GoRuntimeType: 1.642688e+06
       GoKind: 22
-      Pointee: 120 StructureType net/http.pattern
+      Pointee: 143 StructureType net/http.pattern
     - __kind: PointerType
-      ID: 122
+      ID: 145
       Name: '*net/http.segment'
       ByteSize: 8
       GoRuntimeType: 396384
       GoKind: 22
-      Pointee: 123 StructureType net/http.segment
+      Pointee: 146 StructureType net/http.segment
     - __kind: PointerType
-      ID: 9
+      ID: 39
       Name: '*net/url.URL'
       ByteSize: 8
       GoRuntimeType: 2.167328e+06
       GoKind: 22
-      Pointee: 10 StructureType net/url.URL
+      Pointee: 40 StructureType net/url.URL
     - __kind: PointerType
-      ID: 11
+      ID: 41
       Name: '*net/url.Userinfo'
       ByteSize: 8
       GoRuntimeType: 1.22608e+06
       GoKind: 22
-      Pointee: 12 StructureType net/url.Userinfo
+      Pointee: 42 StructureType net/url.Userinfo
     - __kind: PointerType
-      ID: 181
+      ID: 201
       Name: '*noalg.map.group[string]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute'
       ByteSize: 8
-      Pointee: 182 StructureType noalg.map.group[string]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
+      Pointee: 202 StructureType noalg.map.group[string]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
     - __kind: PointerType
-      ID: 44
+      ID: 68
       Name: '*noalg.map.group[string][]*mime/multipart.FileHeader'
       ByteSize: 8
-      Pointee: 45 StructureType noalg.map.group[string][]*mime/multipart.FileHeader
+      Pointee: 69 StructureType noalg.map.group[string][]*mime/multipart.FileHeader
     - __kind: PointerType
-      ID: 24
+      ID: 50
       Name: '*noalg.map.group[string][]string'
       ByteSize: 8
-      Pointee: 25 StructureType noalg.map.group[string][]string
+      Pointee: 51 StructureType noalg.map.group[string][]string
     - __kind: PointerType
-      ID: 163
+      ID: 184
       Name: '*noalg.map.group[string]float64'
       ByteSize: 8
-      Pointee: 164 StructureType noalg.map.group[string]float64
+      Pointee: 185 StructureType noalg.map.group[string]float64
     - __kind: PointerType
-      ID: 152
+      ID: 173
       Name: '*noalg.map.group[string]interface {}'
       ByteSize: 8
-      Pointee: 153 StructureType noalg.map.group[string]interface {}
+      Pointee: 174 StructureType noalg.map.group[string]interface {}
     - __kind: PointerType
-      ID: 131
+      ID: 154
       Name: '*noalg.map.group[string]string'
       ByteSize: 8
-      Pointee: 132 StructureType noalg.map.group[string]string
+      Pointee: 155 StructureType noalg.map.group[string]string
     - __kind: PointerType
-      ID: 29
+      ID: 22
       Name: '*string'
       ByteSize: 8
       GoRuntimeType: 404448
       GoKind: 22
-      Pointee: 5 GoStringHeaderType string
+      Pointee: 9 GoStringHeaderType string
     - __kind: PointerType
       ID: 229
       Name: '*string.str'
       ByteSize: 8
       Pointee: 228 GoStringDataType string.str
     - __kind: PointerType
-      ID: 178
+      ID: 198
       Name: '*table<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>'
       ByteSize: 8
-      Pointee: 179 StructureType table<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
+      Pointee: 199 StructureType table<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
     - __kind: PointerType
-      ID: 41
+      ID: 65
       Name: '*table<string,[]*mime/multipart.FileHeader>'
       ByteSize: 8
-      Pointee: 42 StructureType table<string,[]*mime/multipart.FileHeader>
+      Pointee: 66 StructureType table<string,[]*mime/multipart.FileHeader>
     - __kind: PointerType
-      ID: 20
+      ID: 47
       Name: '*table<string,[]string>'
       ByteSize: 8
-      Pointee: 21 StructureType table<string,[]string>
+      Pointee: 48 StructureType table<string,[]string>
     - __kind: PointerType
-      ID: 160
+      ID: 181
       Name: '*table<string,float64>'
       ByteSize: 8
-      Pointee: 161 StructureType table<string,float64>
+      Pointee: 182 StructureType table<string,float64>
     - __kind: PointerType
-      ID: 149
+      ID: 170
       Name: '*table<string,interface {}>'
       ByteSize: 8
-      Pointee: 150 StructureType table<string,interface {}>
+      Pointee: 171 StructureType table<string,interface {}>
     - __kind: PointerType
-      ID: 128
+      ID: 151
       Name: '*table<string,string>'
       ByteSize: 8
-      Pointee: 129 StructureType table<string,string>
+      Pointee: 152 StructureType table<string,string>
     - __kind: PointerType
-      ID: 76
+      ID: 99
       Name: '*time.Location'
       ByteSize: 8
       GoRuntimeType: 1.64768e+06
       GoKind: 22
-      Pointee: 77 StructureType time.Location
+      Pointee: 100 StructureType time.Location
     - __kind: PointerType
-      ID: 79
+      ID: 102
       Name: '*time.zone'
       ByteSize: 8
       GoRuntimeType: 399456
       GoKind: 22
-      Pointee: 80 StructureType time.zone
+      Pointee: 103 StructureType time.zone
     - __kind: PointerType
-      ID: 82
+      ID: 105
       Name: '*time.zoneTrans'
       ByteSize: 8
       GoRuntimeType: 399520
       GoKind: 22
-      Pointee: 83 StructureType time.zoneTrans
+      Pointee: 106 StructureType time.zoneTrans
     - __kind: PointerType
-      ID: 226
+      ID: 34
       Name: '*uint'
       ByteSize: 8
       GoRuntimeType: 405088
       GoKind: 22
-      Pointee: 212 BaseType uint
+      Pointee: 17 BaseType uint
     - __kind: PointerType
-      ID: 221
+      ID: 29
       Name: '*uint16'
       ByteSize: 8
       GoRuntimeType: 404704
       GoKind: 22
-      Pointee: 22 BaseType uint16
+      Pointee: 6 BaseType uint16
     - __kind: PointerType
-      ID: 216
+      ID: 21
       Name: '*uint32'
       ByteSize: 8
       GoRuntimeType: 404832
       GoKind: 22
-      Pointee: 142 BaseType uint32
+      Pointee: 2 BaseType uint32
     - __kind: PointerType
-      ID: 220
+      ID: 28
       Name: '*uint64'
       ByteSize: 8
       GoRuntimeType: 404960
       GoKind: 22
-      Pointee: 17 BaseType uint64
+      Pointee: 8 BaseType uint64
     - __kind: PointerType
-      ID: 6
+      ID: 5
       Name: '*uint8'
       ByteSize: 8
       GoRuntimeType: 404576
       GoKind: 22
-      Pointee: 7 BaseType uint8
+      Pointee: 3 BaseType uint8
     - __kind: PointerType
-      ID: 214
+      ID: 19
       Name: '*uintptr'
       ByteSize: 8
       GoRuntimeType: 405152
       GoKind: 22
-      Pointee: 18 BaseType uintptr
+      Pointee: 1 BaseType uintptr
     - __kind: GoChannelType
-      ID: 115
+      ID: 138
       Name: <-chan struct {}
       GoRuntimeType: 607264
       GoKind: 18
@@ -751,7 +751,7 @@ Types:
         - Name: w
           Offset: 1
           Expression:
-            Type: 1 GoInterfaceType net/http.ResponseWriter
+            Type: 36 GoInterfaceType net/http.ResponseWriter
             Operations:
                 - __kind: LocationOp
                   Variable: {subprogram: 1, index: 0, name: w}
@@ -760,7 +760,7 @@ Types:
         - Name: r
           Offset: 17
           Expression:
-            Type: 3 PointerType *net/http.Request
+            Type: 37 PointerType *net/http.Request
             Operations:
                 - __kind: LocationOp
                   Variable: {subprogram: 1, index: 1, name: r}
@@ -775,14 +775,14 @@ Types:
         - Name: path
           Offset: 1
           Expression:
-            Type: 5 GoStringHeaderType string
+            Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
                   Variable: {subprogram: 2, index: 0, name: path}
                   Offset: 0
                   ByteSize: 16
     - __kind: GoSliceHeaderType
-      ID: 57
+      ID: 81
       Name: '[]*crypto/x509.Certificate'
       ByteSize: 24
       GoRuntimeType: 507488
@@ -790,21 +790,21 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 58 PointerType **crypto/x509.Certificate
+          Type: 82 PointerType **crypto/x509.Certificate
         - Name: len
           Offset: 8
-          Type: 8 BaseType int
+          Type: 7 BaseType int
         - Name: cap
           Offset: 16
-          Type: 8 BaseType int
+          Type: 7 BaseType int
       Data: 240 GoSliceDataType []*crypto/x509.Certificate.array
     - __kind: GoSliceDataType
       ID: 240
       Name: '[]*crypto/x509.Certificate.array'
       ByteSize: 2048
-      Element: 59 PointerType *crypto/x509.Certificate
+      Element: 83 PointerType *crypto/x509.Certificate
     - __kind: GoSliceHeaderType
-      ID: 200
+      ID: 220
       Name: '[]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span'
       ByteSize: 24
       GoRuntimeType: 495232
@@ -812,21 +812,21 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 201 PointerType **github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span
+          Type: 221 PointerType **github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span
         - Name: len
           Offset: 8
-          Type: 8 BaseType int
+          Type: 7 BaseType int
         - Name: cap
           Offset: 16
-          Type: 8 BaseType int
+          Type: 7 BaseType int
       Data: 292 GoSliceDataType []*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span.array
     - __kind: GoSliceDataType
       ID: 292
       Name: '[]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span.array'
       ByteSize: 2048
-      Element: 135 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span
+      Element: 158 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span
     - __kind: GoSliceHeaderType
-      ID: 190
+      ID: 210
       Name: '[]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttributeValue'
       ByteSize: 24
       GoRuntimeType: 494848
@@ -834,21 +834,21 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 191 PointerType **github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttributeValue
+          Type: 211 PointerType **github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttributeValue
         - Name: len
           Offset: 8
-          Type: 8 BaseType int
+          Type: 7 BaseType int
         - Name: cap
           Offset: 16
-          Type: 8 BaseType int
+          Type: 7 BaseType int
       Data: 290 GoSliceDataType []*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttributeValue.array
     - __kind: GoSliceDataType
       ID: 290
       Name: '[]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttributeValue.array'
       ByteSize: 2048
-      Element: 192 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttributeValue
+      Element: 212 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttributeValue
     - __kind: GoSliceHeaderType
-      ID: 48
+      ID: 72
       Name: '[]*mime/multipart.FileHeader'
       ByteSize: 24
       GoRuntimeType: 492224
@@ -856,21 +856,21 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 49 PointerType **mime/multipart.FileHeader
+          Type: 73 PointerType **mime/multipart.FileHeader
         - Name: len
           Offset: 8
-          Type: 8 BaseType int
+          Type: 7 BaseType int
         - Name: cap
           Offset: 16
-          Type: 8 BaseType int
+          Type: 7 BaseType int
       Data: 236 GoSliceDataType []*mime/multipart.FileHeader.array
     - __kind: GoSliceDataType
       ID: 236
       Name: '[]*mime/multipart.FileHeader.array'
       ByteSize: 2048
-      Element: 50 PointerType *mime/multipart.FileHeader
+      Element: 74 PointerType *mime/multipart.FileHeader
     - __kind: GoSliceHeaderType
-      ID: 98
+      ID: 121
       Name: '[]*net.IPNet'
       ByteSize: 24
       GoRuntimeType: 509088
@@ -878,21 +878,21 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 99 PointerType **net.IPNet
+          Type: 122 PointerType **net.IPNet
         - Name: len
           Offset: 8
-          Type: 8 BaseType int
+          Type: 7 BaseType int
         - Name: cap
           Offset: 16
-          Type: 8 BaseType int
+          Type: 7 BaseType int
       Data: 264 GoSliceDataType []*net.IPNet.array
     - __kind: GoSliceDataType
       ID: 264
       Name: '[]*net.IPNet.array'
       ByteSize: 2048
-      Element: 100 PointerType *net.IPNet
+      Element: 123 PointerType *net.IPNet
     - __kind: GoSliceHeaderType
-      ID: 96
+      ID: 119
       Name: '[]*net/url.URL'
       ByteSize: 24
       GoRuntimeType: 509024
@@ -900,51 +900,51 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 97 PointerType **net/url.URL
+          Type: 120 PointerType **net/url.URL
         - Name: len
           Offset: 8
-          Type: 8 BaseType int
+          Type: 7 BaseType int
         - Name: cap
           Offset: 16
-          Type: 8 BaseType int
+          Type: 7 BaseType int
       Data: 262 GoSliceDataType []*net/url.URL.array
     - __kind: GoSliceDataType
       ID: 262
       Name: '[]*net/url.URL.array'
       ByteSize: 2048
-      Element: 9 PointerType *net/url.URL
+      Element: 39 PointerType *net/url.URL
     - __kind: GoSliceDataType
       ID: 288
       Name: '[]*table<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>.array'
       ByteSize: 8192
-      Element: 178 PointerType *table<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
+      Element: 198 PointerType *table<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
     - __kind: GoSliceDataType
       ID: 234
       Name: '[]*table<string,[]*mime/multipart.FileHeader>.array'
       ByteSize: 8192
-      Element: 41 PointerType *table<string,[]*mime/multipart.FileHeader>
+      Element: 65 PointerType *table<string,[]*mime/multipart.FileHeader>
     - __kind: GoSliceDataType
       ID: 230
       Name: '[]*table<string,[]string>.array'
       ByteSize: 8192
-      Element: 20 PointerType *table<string,[]string>
+      Element: 47 PointerType *table<string,[]string>
     - __kind: GoSliceDataType
       ID: 282
       Name: '[]*table<string,float64>.array'
       ByteSize: 8192
-      Element: 160 PointerType *table<string,float64>
+      Element: 181 PointerType *table<string,float64>
     - __kind: GoSliceDataType
       ID: 280
       Name: '[]*table<string,interface {}>.array'
       ByteSize: 8192
-      Element: 149 PointerType *table<string,interface {}>
+      Element: 170 PointerType *table<string,interface {}>
     - __kind: GoSliceDataType
       ID: 278
       Name: '[]*table<string,string>.array'
       ByteSize: 8192
-      Element: 128 PointerType *table<string,string>
+      Element: 151 PointerType *table<string,string>
     - __kind: GoSliceHeaderType
-      ID: 109
+      ID: 132
       Name: '[][]*crypto/x509.Certificate'
       ByteSize: 24
       GoRuntimeType: 507552
@@ -952,21 +952,21 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 110 PointerType *[]*crypto/x509.Certificate
+          Type: 133 PointerType *[]*crypto/x509.Certificate
         - Name: len
           Offset: 8
-          Type: 8 BaseType int
+          Type: 7 BaseType int
         - Name: cap
           Offset: 16
-          Type: 8 BaseType int
+          Type: 7 BaseType int
       Data: 272 GoSliceDataType [][]*crypto/x509.Certificate.array
     - __kind: GoSliceDataType
       ID: 272
       Name: '[][]*crypto/x509.Certificate.array'
       ByteSize: 2048
-      Element: 57 GoSliceHeaderType []*crypto/x509.Certificate
+      Element: 81 GoSliceHeaderType []*crypto/x509.Certificate
     - __kind: GoSliceHeaderType
-      ID: 111
+      ID: 134
       Name: '[][]uint8'
       ByteSize: 24
       GoRuntimeType: 486880
@@ -974,21 +974,21 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 112 PointerType *[]uint8
+          Type: 135 PointerType *[]uint8
         - Name: len
           Offset: 8
-          Type: 8 BaseType int
+          Type: 7 BaseType int
         - Name: cap
           Offset: 16
-          Type: 8 BaseType int
+          Type: 7 BaseType int
       Data: 274 GoSliceDataType [][]uint8.array
     - __kind: GoSliceDataType
       ID: 274
       Name: '[][]uint8.array'
       ByteSize: 2048
-      Element: 53 GoSliceHeaderType []uint8
+      Element: 77 GoSliceHeaderType []uint8
     - __kind: GoSliceHeaderType
-      ID: 90
+      ID: 113
       Name: '[]crypto/x509.ExtKeyUsage'
       ByteSize: 24
       GoRuntimeType: 508960
@@ -996,21 +996,21 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 91 PointerType *crypto/x509.ExtKeyUsage
+          Type: 114 PointerType *crypto/x509.ExtKeyUsage
         - Name: len
           Offset: 8
-          Type: 8 BaseType int
+          Type: 7 BaseType int
         - Name: cap
           Offset: 16
-          Type: 8 BaseType int
+          Type: 7 BaseType int
       Data: 256 GoSliceDataType []crypto/x509.ExtKeyUsage.array
     - __kind: GoSliceDataType
       ID: 256
       Name: '[]crypto/x509.ExtKeyUsage.array'
       ByteSize: 2048
-      Element: 92 BaseType crypto/x509.ExtKeyUsage
+      Element: 115 BaseType crypto/x509.ExtKeyUsage
     - __kind: GoSliceHeaderType
-      ID: 103
+      ID: 126
       Name: '[]crypto/x509.OID'
       ByteSize: 24
       GoRuntimeType: 509152
@@ -1018,21 +1018,21 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 104 PointerType *crypto/x509.OID
+          Type: 127 PointerType *crypto/x509.OID
         - Name: len
           Offset: 8
-          Type: 8 BaseType int
+          Type: 7 BaseType int
         - Name: cap
           Offset: 16
-          Type: 8 BaseType int
+          Type: 7 BaseType int
       Data: 268 GoSliceDataType []crypto/x509.OID.array
     - __kind: GoSliceDataType
       ID: 268
       Name: '[]crypto/x509.OID.array'
       ByteSize: 2048
-      Element: 105 StructureType crypto/x509.OID
+      Element: 128 StructureType crypto/x509.OID
     - __kind: GoSliceHeaderType
-      ID: 106
+      ID: 129
       Name: '[]crypto/x509.PolicyMapping'
       ByteSize: 24
       GoRuntimeType: 509216
@@ -1040,21 +1040,21 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 107 PointerType *crypto/x509.PolicyMapping
+          Type: 130 PointerType *crypto/x509.PolicyMapping
         - Name: len
           Offset: 8
-          Type: 8 BaseType int
+          Type: 7 BaseType int
         - Name: cap
           Offset: 16
-          Type: 8 BaseType int
+          Type: 7 BaseType int
       Data: 270 GoSliceDataType []crypto/x509.PolicyMapping.array
     - __kind: GoSliceDataType
       ID: 270
       Name: '[]crypto/x509.PolicyMapping.array'
       ByteSize: 2048
-      Element: 108 StructureType crypto/x509.PolicyMapping
+      Element: 131 StructureType crypto/x509.PolicyMapping
     - __kind: GoSliceHeaderType
-      ID: 70
+      ID: 94
       Name: '[]crypto/x509/pkix.AttributeTypeAndValue'
       ByteSize: 24
       GoRuntimeType: 523680
@@ -1062,21 +1062,21 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 71 PointerType *crypto/x509/pkix.AttributeTypeAndValue
+          Type: 95 PointerType *crypto/x509/pkix.AttributeTypeAndValue
         - Name: len
           Offset: 8
-          Type: 8 BaseType int
+          Type: 7 BaseType int
         - Name: cap
           Offset: 16
-          Type: 8 BaseType int
+          Type: 7 BaseType int
       Data: 244 GoSliceDataType []crypto/x509/pkix.AttributeTypeAndValue.array
     - __kind: GoSliceDataType
       ID: 244
       Name: '[]crypto/x509/pkix.AttributeTypeAndValue.array'
       ByteSize: 2048
-      Element: 72 StructureType crypto/x509/pkix.AttributeTypeAndValue
+      Element: 96 StructureType crypto/x509/pkix.AttributeTypeAndValue
     - __kind: GoSliceHeaderType
-      ID: 85
+      ID: 108
       Name: '[]crypto/x509/pkix.Extension'
       ByteSize: 24
       GoRuntimeType: 508832
@@ -1084,21 +1084,21 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 86 PointerType *crypto/x509/pkix.Extension
+          Type: 109 PointerType *crypto/x509/pkix.Extension
         - Name: len
           Offset: 8
-          Type: 8 BaseType int
+          Type: 7 BaseType int
         - Name: cap
           Offset: 16
-          Type: 8 BaseType int
+          Type: 7 BaseType int
       Data: 252 GoSliceDataType []crypto/x509/pkix.Extension.array
     - __kind: GoSliceDataType
       ID: 252
       Name: '[]crypto/x509/pkix.Extension.array'
       ByteSize: 2048
-      Element: 87 StructureType crypto/x509/pkix.Extension
+      Element: 110 StructureType crypto/x509/pkix.Extension
     - __kind: GoSliceHeaderType
-      ID: 88
+      ID: 111
       Name: '[]encoding/asn1.ObjectIdentifier'
       ByteSize: 24
       GoRuntimeType: 508896
@@ -1106,21 +1106,21 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 89 PointerType *encoding/asn1.ObjectIdentifier
+          Type: 112 PointerType *encoding/asn1.ObjectIdentifier
         - Name: len
           Offset: 8
-          Type: 8 BaseType int
+          Type: 7 BaseType int
         - Name: cap
           Offset: 16
-          Type: 8 BaseType int
+          Type: 7 BaseType int
       Data: 254 GoSliceDataType []encoding/asn1.ObjectIdentifier.array
     - __kind: GoSliceDataType
       ID: 254
       Name: '[]encoding/asn1.ObjectIdentifier.array'
       ByteSize: 2048
-      Element: 73 GoSliceHeaderType encoding/asn1.ObjectIdentifier
+      Element: 97 GoSliceHeaderType encoding/asn1.ObjectIdentifier
     - __kind: GoSliceHeaderType
-      ID: 168
+      ID: 188
       Name: '[]github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink'
       ByteSize: 24
       GoRuntimeType: 494784
@@ -1128,21 +1128,21 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 169 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink
+          Type: 189 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink
         - Name: len
           Offset: 8
-          Type: 8 BaseType int
+          Type: 7 BaseType int
         - Name: cap
           Offset: 16
-          Type: 8 BaseType int
+          Type: 7 BaseType int
       Data: 284 GoSliceDataType []github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink.array
     - __kind: GoSliceDataType
       ID: 284
       Name: '[]github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink.array'
       ByteSize: 2048
-      Element: 170 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink
+      Element: 190 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink
     - __kind: GoSliceHeaderType
-      ID: 171
+      ID: 191
       Name: '[]github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent'
       ByteSize: 24
       GoRuntimeType: 494976
@@ -1150,21 +1150,21 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 172 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent
+          Type: 192 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent
         - Name: len
           Offset: 8
-          Type: 8 BaseType int
+          Type: 7 BaseType int
         - Name: cap
           Offset: 16
-          Type: 8 BaseType int
+          Type: 7 BaseType int
       Data: 286 GoSliceDataType []github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent.array
     - __kind: GoSliceDataType
       ID: 286
       Name: '[]github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent.array'
       ByteSize: 2048
-      Element: 173 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent
+      Element: 193 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent
     - __kind: GoSliceHeaderType
-      ID: 93
+      ID: 116
       Name: '[]net.IP'
       ByteSize: 24
       GoRuntimeType: 487904
@@ -1172,21 +1172,21 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 94 PointerType *net.IP
+          Type: 117 PointerType *net.IP
         - Name: len
           Offset: 8
-          Type: 8 BaseType int
+          Type: 7 BaseType int
         - Name: cap
           Offset: 16
-          Type: 8 BaseType int
+          Type: 7 BaseType int
       Data: 258 GoSliceDataType []net.IP.array
     - __kind: GoSliceDataType
       ID: 258
       Name: '[]net.IP.array'
       ByteSize: 2048
-      Element: 95 GoSliceHeaderType net.IP
+      Element: 118 GoSliceHeaderType net.IP
     - __kind: GoSliceHeaderType
-      ID: 121
+      ID: 144
       Name: '[]net/http.segment'
       ByteSize: 24
       GoRuntimeType: 489600
@@ -1194,51 +1194,51 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 122 PointerType *net/http.segment
+          Type: 145 PointerType *net/http.segment
         - Name: len
           Offset: 8
-          Type: 8 BaseType int
+          Type: 7 BaseType int
         - Name: cap
           Offset: 16
-          Type: 8 BaseType int
+          Type: 7 BaseType int
       Data: 276 GoSliceDataType []net/http.segment.array
     - __kind: GoSliceDataType
       ID: 276
       Name: '[]net/http.segment.array'
       ByteSize: 2048
-      Element: 123 StructureType net/http.segment
+      Element: 146 StructureType net/http.segment
     - __kind: GoSliceDataType
       ID: 289
       Name: '[]noalg.map.group[string]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute.array'
       ByteSize: 2048
-      Element: 182 StructureType noalg.map.group[string]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
+      Element: 202 StructureType noalg.map.group[string]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
     - __kind: GoSliceDataType
       ID: 235
       Name: '[]noalg.map.group[string][]*mime/multipart.FileHeader.array'
       ByteSize: 2048
-      Element: 45 StructureType noalg.map.group[string][]*mime/multipart.FileHeader
+      Element: 69 StructureType noalg.map.group[string][]*mime/multipart.FileHeader
     - __kind: GoSliceDataType
       ID: 231
       Name: '[]noalg.map.group[string][]string.array'
       ByteSize: 2048
-      Element: 25 StructureType noalg.map.group[string][]string
+      Element: 51 StructureType noalg.map.group[string][]string
     - __kind: GoSliceDataType
       ID: 283
       Name: '[]noalg.map.group[string]float64.array'
       ByteSize: 2048
-      Element: 164 StructureType noalg.map.group[string]float64
+      Element: 185 StructureType noalg.map.group[string]float64
     - __kind: GoSliceDataType
       ID: 281
       Name: '[]noalg.map.group[string]interface {}.array'
       ByteSize: 2048
-      Element: 153 StructureType noalg.map.group[string]interface {}
+      Element: 174 StructureType noalg.map.group[string]interface {}
     - __kind: GoSliceDataType
       ID: 279
       Name: '[]noalg.map.group[string]string.array'
       ByteSize: 2048
-      Element: 132 StructureType noalg.map.group[string]string
+      Element: 155 StructureType noalg.map.group[string]string
     - __kind: GoSliceHeaderType
-      ID: 28
+      ID: 54
       Name: '[]string'
       ByteSize: 24
       GoRuntimeType: 501440
@@ -1246,21 +1246,21 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 29 PointerType *string
+          Type: 22 PointerType *string
         - Name: len
           Offset: 8
-          Type: 8 BaseType int
+          Type: 7 BaseType int
         - Name: cap
           Offset: 16
-          Type: 8 BaseType int
+          Type: 7 BaseType int
       Data: 232 GoSliceDataType []string.array
     - __kind: GoSliceDataType
       ID: 232
       Name: '[]string.array'
       ByteSize: 2048
-      Element: 5 GoStringHeaderType string
+      Element: 9 GoStringHeaderType string
     - __kind: GoSliceHeaderType
-      ID: 78
+      ID: 101
       Name: '[]time.zone'
       ByteSize: 24
       GoRuntimeType: 494336
@@ -1268,21 +1268,21 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 79 PointerType *time.zone
+          Type: 102 PointerType *time.zone
         - Name: len
           Offset: 8
-          Type: 8 BaseType int
+          Type: 7 BaseType int
         - Name: cap
           Offset: 16
-          Type: 8 BaseType int
+          Type: 7 BaseType int
       Data: 248 GoSliceDataType []time.zone.array
     - __kind: GoSliceDataType
       ID: 248
       Name: '[]time.zone.array'
       ByteSize: 2048
-      Element: 80 StructureType time.zone
+      Element: 103 StructureType time.zone
     - __kind: GoSliceHeaderType
-      ID: 81
+      ID: 104
       Name: '[]time.zoneTrans'
       ByteSize: 24
       GoRuntimeType: 494400
@@ -1290,21 +1290,21 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 82 PointerType *time.zoneTrans
+          Type: 105 PointerType *time.zoneTrans
         - Name: len
           Offset: 8
-          Type: 8 BaseType int
+          Type: 7 BaseType int
         - Name: cap
           Offset: 16
-          Type: 8 BaseType int
+          Type: 7 BaseType int
       Data: 250 GoSliceDataType []time.zoneTrans.array
     - __kind: GoSliceDataType
       ID: 250
       Name: '[]time.zoneTrans.array'
       ByteSize: 2048
-      Element: 83 StructureType time.zoneTrans
+      Element: 106 StructureType time.zoneTrans
     - __kind: GoSliceHeaderType
-      ID: 53
+      ID: 77
       Name: '[]uint8'
       ByteSize: 24
       GoRuntimeType: 500288
@@ -1312,27 +1312,27 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 6 PointerType *uint8
+          Type: 5 PointerType *uint8
         - Name: len
           Offset: 8
-          Type: 8 BaseType int
+          Type: 7 BaseType int
         - Name: cap
           Offset: 16
-          Type: 8 BaseType int
+          Type: 7 BaseType int
       Data: 238 GoSliceDataType []uint8.array
     - __kind: GoSliceDataType
       ID: 238
       Name: '[]uint8.array'
       ByteSize: 2048
-      Element: 7 BaseType uint8
+      Element: 3 BaseType uint8
     - __kind: BaseType
-      ID: 13
+      ID: 4
       Name: bool
       ByteSize: 1
       GoRuntimeType: 595232
       GoKind: 1
     - __kind: StructureType
-      ID: 207
+      ID: 226
       Name: bytes.Buffer
       ByteSize: 40
       GoRuntimeType: 1.640384e+06
@@ -1340,33 +1340,33 @@ Types:
       RawFields:
         - Name: buf
           Offset: 0
-          Type: 53 GoSliceHeaderType []uint8
+          Type: 77 GoSliceHeaderType []uint8
         - Name: off
           Offset: 24
-          Type: 8 BaseType int
+          Type: 7 BaseType int
         - Name: lastRead
           Offset: 32
-          Type: 208 BaseType bytes.readOp
+          Type: 227 BaseType bytes.readOp
     - __kind: BaseType
-      ID: 208
+      ID: 227
       Name: bytes.readOp
       ByteSize: 1
       GoRuntimeType: 593440
       GoKind: 3
     - __kind: BaseType
-      ID: 218
+      ID: 24
       Name: complex128
       ByteSize: 16
       GoRuntimeType: 595040
       GoKind: 16
     - __kind: BaseType
-      ID: 217
+      ID: 23
       Name: complex64
       ByteSize: 8
       GoRuntimeType: 594976
       GoKind: 15
     - __kind: GoInterfaceType
-      ID: 118
+      ID: 141
       Name: context.Context
       ByteSize: 16
       GoRuntimeType: 1.3032e+06
@@ -1374,12 +1374,12 @@ Types:
       RawFields:
         - Name: tab
           Offset: 0
-          Type: 2 VoidPointerType unsafe.Pointer
+          Type: 14 VoidPointerType unsafe.Pointer
         - Name: data
           Offset: 8
-          Type: 2 VoidPointerType unsafe.Pointer
+          Type: 14 VoidPointerType unsafe.Pointer
     - __kind: StructureType
-      ID: 55
+      ID: 79
       Name: crypto/tls.ConnectionState
       ByteSize: 192
       GoRuntimeType: 2.323424e+06
@@ -1387,69 +1387,69 @@ Types:
       RawFields:
         - Name: Version
           Offset: 0
-          Type: 22 BaseType uint16
+          Type: 6 BaseType uint16
         - Name: HandshakeComplete
           Offset: 2
-          Type: 13 BaseType bool
+          Type: 4 BaseType bool
         - Name: DidResume
           Offset: 3
-          Type: 13 BaseType bool
+          Type: 4 BaseType bool
         - Name: CipherSuite
           Offset: 4
-          Type: 22 BaseType uint16
+          Type: 6 BaseType uint16
         - Name: CurveID
           Offset: 6
-          Type: 56 BaseType crypto/tls.CurveID
+          Type: 80 BaseType crypto/tls.CurveID
         - Name: NegotiatedProtocol
           Offset: 8
-          Type: 5 GoStringHeaderType string
+          Type: 9 GoStringHeaderType string
         - Name: NegotiatedProtocolIsMutual
           Offset: 24
-          Type: 13 BaseType bool
+          Type: 4 BaseType bool
         - Name: ServerName
           Offset: 32
-          Type: 5 GoStringHeaderType string
+          Type: 9 GoStringHeaderType string
         - Name: PeerCertificates
           Offset: 48
-          Type: 57 GoSliceHeaderType []*crypto/x509.Certificate
+          Type: 81 GoSliceHeaderType []*crypto/x509.Certificate
         - Name: VerifiedChains
           Offset: 72
-          Type: 109 GoSliceHeaderType [][]*crypto/x509.Certificate
+          Type: 132 GoSliceHeaderType [][]*crypto/x509.Certificate
         - Name: SignedCertificateTimestamps
           Offset: 96
-          Type: 111 GoSliceHeaderType [][]uint8
+          Type: 134 GoSliceHeaderType [][]uint8
         - Name: OCSPResponse
           Offset: 120
-          Type: 53 GoSliceHeaderType []uint8
+          Type: 77 GoSliceHeaderType []uint8
         - Name: TLSUnique
           Offset: 144
-          Type: 53 GoSliceHeaderType []uint8
+          Type: 77 GoSliceHeaderType []uint8
         - Name: ECHAccepted
           Offset: 168
-          Type: 13 BaseType bool
+          Type: 4 BaseType bool
         - Name: ekm
           Offset: 176
-          Type: 113 GoSubroutineType func(string, []uint8, int) ([]uint8, error)
+          Type: 136 GoSubroutineType func(string, []uint8, int) ([]uint8, error)
         - Name: testingOnlyDidHRR
           Offset: 184
-          Type: 13 BaseType bool
+          Type: 4 BaseType bool
         - Name: testingOnlyPeerSignatureAlgorithm
           Offset: 186
-          Type: 114 BaseType crypto/tls.SignatureScheme
+          Type: 137 BaseType crypto/tls.SignatureScheme
     - __kind: BaseType
-      ID: 56
+      ID: 80
       Name: crypto/tls.CurveID
       ByteSize: 2
       GoRuntimeType: 847200
       GoKind: 9
     - __kind: BaseType
-      ID: 114
+      ID: 137
       Name: crypto/tls.SignatureScheme
       ByteSize: 2
       GoRuntimeType: 847296
       GoKind: 9
     - __kind: StructureType
-      ID: 60
+      ID: 84
       Name: crypto/x509.Certificate
       ByteSize: 1424
       GoRuntimeType: 2.458688e+06
@@ -1457,174 +1457,174 @@ Types:
       RawFields:
         - Name: Raw
           Offset: 0
-          Type: 53 GoSliceHeaderType []uint8
+          Type: 77 GoSliceHeaderType []uint8
         - Name: RawTBSCertificate
           Offset: 24
-          Type: 53 GoSliceHeaderType []uint8
+          Type: 77 GoSliceHeaderType []uint8
         - Name: RawSubjectPublicKeyInfo
           Offset: 48
-          Type: 53 GoSliceHeaderType []uint8
+          Type: 77 GoSliceHeaderType []uint8
         - Name: RawSubject
           Offset: 72
-          Type: 53 GoSliceHeaderType []uint8
+          Type: 77 GoSliceHeaderType []uint8
         - Name: RawIssuer
           Offset: 96
-          Type: 53 GoSliceHeaderType []uint8
+          Type: 77 GoSliceHeaderType []uint8
         - Name: Signature
           Offset: 120
-          Type: 53 GoSliceHeaderType []uint8
+          Type: 77 GoSliceHeaderType []uint8
         - Name: SignatureAlgorithm
           Offset: 144
-          Type: 61 BaseType crypto/x509.SignatureAlgorithm
+          Type: 85 BaseType crypto/x509.SignatureAlgorithm
         - Name: PublicKeyAlgorithm
           Offset: 152
-          Type: 62 BaseType crypto/x509.PublicKeyAlgorithm
+          Type: 86 BaseType crypto/x509.PublicKeyAlgorithm
         - Name: PublicKey
           Offset: 160
-          Type: 63 GoEmptyInterfaceType interface {}
+          Type: 87 GoEmptyInterfaceType interface {}
         - Name: Version
           Offset: 176
-          Type: 8 BaseType int
+          Type: 7 BaseType int
         - Name: SerialNumber
           Offset: 184
-          Type: 64 PointerType *math/big.Int
+          Type: 88 PointerType *math/big.Int
         - Name: Issuer
           Offset: 192
-          Type: 69 StructureType crypto/x509/pkix.Name
+          Type: 93 StructureType crypto/x509/pkix.Name
         - Name: Subject
           Offset: 440
-          Type: 69 StructureType crypto/x509/pkix.Name
+          Type: 93 StructureType crypto/x509/pkix.Name
         - Name: NotBefore
           Offset: 688
-          Type: 75 StructureType time.Time
+          Type: 98 StructureType time.Time
         - Name: NotAfter
           Offset: 712
-          Type: 75 StructureType time.Time
+          Type: 98 StructureType time.Time
         - Name: KeyUsage
           Offset: 736
-          Type: 84 BaseType crypto/x509.KeyUsage
+          Type: 107 BaseType crypto/x509.KeyUsage
         - Name: Extensions
           Offset: 744
-          Type: 85 GoSliceHeaderType []crypto/x509/pkix.Extension
+          Type: 108 GoSliceHeaderType []crypto/x509/pkix.Extension
         - Name: ExtraExtensions
           Offset: 768
-          Type: 85 GoSliceHeaderType []crypto/x509/pkix.Extension
+          Type: 108 GoSliceHeaderType []crypto/x509/pkix.Extension
         - Name: UnhandledCriticalExtensions
           Offset: 792
-          Type: 88 GoSliceHeaderType []encoding/asn1.ObjectIdentifier
+          Type: 111 GoSliceHeaderType []encoding/asn1.ObjectIdentifier
         - Name: ExtKeyUsage
           Offset: 816
-          Type: 90 GoSliceHeaderType []crypto/x509.ExtKeyUsage
+          Type: 113 GoSliceHeaderType []crypto/x509.ExtKeyUsage
         - Name: UnknownExtKeyUsage
           Offset: 840
-          Type: 88 GoSliceHeaderType []encoding/asn1.ObjectIdentifier
+          Type: 111 GoSliceHeaderType []encoding/asn1.ObjectIdentifier
         - Name: BasicConstraintsValid
           Offset: 864
-          Type: 13 BaseType bool
+          Type: 4 BaseType bool
         - Name: IsCA
           Offset: 865
-          Type: 13 BaseType bool
+          Type: 4 BaseType bool
         - Name: MaxPathLen
           Offset: 872
-          Type: 8 BaseType int
+          Type: 7 BaseType int
         - Name: MaxPathLenZero
           Offset: 880
-          Type: 13 BaseType bool
+          Type: 4 BaseType bool
         - Name: SubjectKeyId
           Offset: 888
-          Type: 53 GoSliceHeaderType []uint8
+          Type: 77 GoSliceHeaderType []uint8
         - Name: AuthorityKeyId
           Offset: 912
-          Type: 53 GoSliceHeaderType []uint8
+          Type: 77 GoSliceHeaderType []uint8
         - Name: OCSPServer
           Offset: 936
-          Type: 28 GoSliceHeaderType []string
+          Type: 54 GoSliceHeaderType []string
         - Name: IssuingCertificateURL
           Offset: 960
-          Type: 28 GoSliceHeaderType []string
+          Type: 54 GoSliceHeaderType []string
         - Name: DNSNames
           Offset: 984
-          Type: 28 GoSliceHeaderType []string
+          Type: 54 GoSliceHeaderType []string
         - Name: EmailAddresses
           Offset: 1008
-          Type: 28 GoSliceHeaderType []string
+          Type: 54 GoSliceHeaderType []string
         - Name: IPAddresses
           Offset: 1032
-          Type: 93 GoSliceHeaderType []net.IP
+          Type: 116 GoSliceHeaderType []net.IP
         - Name: URIs
           Offset: 1056
-          Type: 96 GoSliceHeaderType []*net/url.URL
+          Type: 119 GoSliceHeaderType []*net/url.URL
         - Name: PermittedDNSDomainsCritical
           Offset: 1080
-          Type: 13 BaseType bool
+          Type: 4 BaseType bool
         - Name: PermittedDNSDomains
           Offset: 1088
-          Type: 28 GoSliceHeaderType []string
+          Type: 54 GoSliceHeaderType []string
         - Name: ExcludedDNSDomains
           Offset: 1112
-          Type: 28 GoSliceHeaderType []string
+          Type: 54 GoSliceHeaderType []string
         - Name: PermittedIPRanges
           Offset: 1136
-          Type: 98 GoSliceHeaderType []*net.IPNet
+          Type: 121 GoSliceHeaderType []*net.IPNet
         - Name: ExcludedIPRanges
           Offset: 1160
-          Type: 98 GoSliceHeaderType []*net.IPNet
+          Type: 121 GoSliceHeaderType []*net.IPNet
         - Name: PermittedEmailAddresses
           Offset: 1184
-          Type: 28 GoSliceHeaderType []string
+          Type: 54 GoSliceHeaderType []string
         - Name: ExcludedEmailAddresses
           Offset: 1208
-          Type: 28 GoSliceHeaderType []string
+          Type: 54 GoSliceHeaderType []string
         - Name: PermittedURIDomains
           Offset: 1232
-          Type: 28 GoSliceHeaderType []string
+          Type: 54 GoSliceHeaderType []string
         - Name: ExcludedURIDomains
           Offset: 1256
-          Type: 28 GoSliceHeaderType []string
+          Type: 54 GoSliceHeaderType []string
         - Name: CRLDistributionPoints
           Offset: 1280
-          Type: 28 GoSliceHeaderType []string
+          Type: 54 GoSliceHeaderType []string
         - Name: PolicyIdentifiers
           Offset: 1304
-          Type: 88 GoSliceHeaderType []encoding/asn1.ObjectIdentifier
+          Type: 111 GoSliceHeaderType []encoding/asn1.ObjectIdentifier
         - Name: Policies
           Offset: 1328
-          Type: 103 GoSliceHeaderType []crypto/x509.OID
+          Type: 126 GoSliceHeaderType []crypto/x509.OID
         - Name: InhibitAnyPolicy
           Offset: 1352
-          Type: 8 BaseType int
+          Type: 7 BaseType int
         - Name: InhibitAnyPolicyZero
           Offset: 1360
-          Type: 13 BaseType bool
+          Type: 4 BaseType bool
         - Name: InhibitPolicyMapping
           Offset: 1368
-          Type: 8 BaseType int
+          Type: 7 BaseType int
         - Name: InhibitPolicyMappingZero
           Offset: 1376
-          Type: 13 BaseType bool
+          Type: 4 BaseType bool
         - Name: RequireExplicitPolicy
           Offset: 1384
-          Type: 8 BaseType int
+          Type: 7 BaseType int
         - Name: RequireExplicitPolicyZero
           Offset: 1392
-          Type: 13 BaseType bool
+          Type: 4 BaseType bool
         - Name: PolicyMappings
           Offset: 1400
-          Type: 106 GoSliceHeaderType []crypto/x509.PolicyMapping
+          Type: 129 GoSliceHeaderType []crypto/x509.PolicyMapping
     - __kind: BaseType
-      ID: 92
+      ID: 115
       Name: crypto/x509.ExtKeyUsage
       ByteSize: 8
       GoRuntimeType: 598304
       GoKind: 2
     - __kind: BaseType
-      ID: 84
+      ID: 107
       Name: crypto/x509.KeyUsage
       ByteSize: 8
       GoRuntimeType: 598240
       GoKind: 2
     - __kind: StructureType
-      ID: 105
+      ID: 128
       Name: crypto/x509.OID
       ByteSize: 24
       GoRuntimeType: 1.998368e+06
@@ -1632,9 +1632,9 @@ Types:
       RawFields:
         - Name: der
           Offset: 0
-          Type: 53 GoSliceHeaderType []uint8
+          Type: 77 GoSliceHeaderType []uint8
     - __kind: StructureType
-      ID: 108
+      ID: 131
       Name: crypto/x509.PolicyMapping
       ByteSize: 48
       GoRuntimeType: 1.520416e+06
@@ -1642,24 +1642,24 @@ Types:
       RawFields:
         - Name: IssuerDomainPolicy
           Offset: 0
-          Type: 105 StructureType crypto/x509.OID
+          Type: 128 StructureType crypto/x509.OID
         - Name: SubjectDomainPolicy
           Offset: 24
-          Type: 105 StructureType crypto/x509.OID
+          Type: 128 StructureType crypto/x509.OID
     - __kind: BaseType
-      ID: 62
+      ID: 86
       Name: crypto/x509.PublicKeyAlgorithm
       ByteSize: 8
       GoRuntimeType: 849696
       GoKind: 2
     - __kind: BaseType
-      ID: 61
+      ID: 85
       Name: crypto/x509.SignatureAlgorithm
       ByteSize: 8
       GoRuntimeType: 1.139648e+06
       GoKind: 2
     - __kind: StructureType
-      ID: 72
+      ID: 96
       Name: crypto/x509/pkix.AttributeTypeAndValue
       ByteSize: 40
       GoRuntimeType: 1.532736e+06
@@ -1667,12 +1667,12 @@ Types:
       RawFields:
         - Name: Type
           Offset: 0
-          Type: 73 GoSliceHeaderType encoding/asn1.ObjectIdentifier
+          Type: 97 GoSliceHeaderType encoding/asn1.ObjectIdentifier
         - Name: Value
           Offset: 24
-          Type: 63 GoEmptyInterfaceType interface {}
+          Type: 87 GoEmptyInterfaceType interface {}
     - __kind: StructureType
-      ID: 87
+      ID: 110
       Name: crypto/x509/pkix.Extension
       ByteSize: 56
       GoRuntimeType: 1.683776e+06
@@ -1680,15 +1680,15 @@ Types:
       RawFields:
         - Name: Id
           Offset: 0
-          Type: 73 GoSliceHeaderType encoding/asn1.ObjectIdentifier
+          Type: 97 GoSliceHeaderType encoding/asn1.ObjectIdentifier
         - Name: Critical
           Offset: 24
-          Type: 13 BaseType bool
+          Type: 4 BaseType bool
         - Name: Value
           Offset: 32
-          Type: 53 GoSliceHeaderType []uint8
+          Type: 77 GoSliceHeaderType []uint8
     - __kind: StructureType
-      ID: 69
+      ID: 93
       Name: crypto/x509/pkix.Name
       ByteSize: 248
       GoRuntimeType: 2.250272e+06
@@ -1696,39 +1696,39 @@ Types:
       RawFields:
         - Name: Country
           Offset: 0
-          Type: 28 GoSliceHeaderType []string
+          Type: 54 GoSliceHeaderType []string
         - Name: Organization
           Offset: 24
-          Type: 28 GoSliceHeaderType []string
+          Type: 54 GoSliceHeaderType []string
         - Name: OrganizationalUnit
           Offset: 48
-          Type: 28 GoSliceHeaderType []string
+          Type: 54 GoSliceHeaderType []string
         - Name: Locality
           Offset: 72
-          Type: 28 GoSliceHeaderType []string
+          Type: 54 GoSliceHeaderType []string
         - Name: Province
           Offset: 96
-          Type: 28 GoSliceHeaderType []string
+          Type: 54 GoSliceHeaderType []string
         - Name: StreetAddress
           Offset: 120
-          Type: 28 GoSliceHeaderType []string
+          Type: 54 GoSliceHeaderType []string
         - Name: PostalCode
           Offset: 144
-          Type: 28 GoSliceHeaderType []string
+          Type: 54 GoSliceHeaderType []string
         - Name: SerialNumber
           Offset: 168
-          Type: 5 GoStringHeaderType string
+          Type: 9 GoStringHeaderType string
         - Name: CommonName
           Offset: 184
-          Type: 5 GoStringHeaderType string
+          Type: 9 GoStringHeaderType string
         - Name: Names
           Offset: 200
-          Type: 70 GoSliceHeaderType []crypto/x509/pkix.AttributeTypeAndValue
+          Type: 94 GoSliceHeaderType []crypto/x509/pkix.AttributeTypeAndValue
         - Name: ExtraNames
           Offset: 224
-          Type: 70 GoSliceHeaderType []crypto/x509/pkix.AttributeTypeAndValue
+          Type: 94 GoSliceHeaderType []crypto/x509/pkix.AttributeTypeAndValue
     - __kind: GoSliceHeaderType
-      ID: 73
+      ID: 97
       Name: encoding/asn1.ObjectIdentifier
       ByteSize: 24
       GoRuntimeType: 1.079904e+06
@@ -1736,21 +1736,21 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 74 PointerType *int
+          Type: 26 PointerType *int
         - Name: len
           Offset: 8
-          Type: 8 BaseType int
+          Type: 7 BaseType int
         - Name: cap
           Offset: 16
-          Type: 8 BaseType int
+          Type: 7 BaseType int
       Data: 246 GoSliceDataType encoding/asn1.ObjectIdentifier.array
     - __kind: GoSliceDataType
       ID: 246
       Name: encoding/asn1.ObjectIdentifier.array
       ByteSize: 2048
-      Element: 8 BaseType int
+      Element: 7 BaseType int
     - __kind: GoInterfaceType
-      ID: 210
+      ID: 13
       Name: error
       ByteSize: 16
       GoRuntimeType: 1.054304e+06
@@ -1758,42 +1758,42 @@ Types:
       RawFields:
         - Name: tab
           Offset: 0
-          Type: 2 VoidPointerType unsafe.Pointer
+          Type: 14 VoidPointerType unsafe.Pointer
         - Name: data
           Offset: 8
-          Type: 2 VoidPointerType unsafe.Pointer
+          Type: 14 VoidPointerType unsafe.Pointer
     - __kind: BaseType
-      ID: 213
+      ID: 18
       Name: float32
       ByteSize: 4
       GoRuntimeType: 595104
       GoKind: 13
     - __kind: BaseType
-      ID: 167
+      ID: 15
       Name: float64
       ByteSize: 8
       GoRuntimeType: 595168
       GoKind: 14
     - __kind: GoSubroutineType
-      ID: 205
+      ID: 224
       Name: func()
       ByteSize: 8
       GoRuntimeType: 484960
       GoKind: 19
     - __kind: GoSubroutineType
-      ID: 31
+      ID: 56
       Name: func() (io.ReadCloser, error)
       ByteSize: 8
       GoRuntimeType: 705088
       GoKind: 19
     - __kind: GoSubroutineType
-      ID: 113
+      ID: 136
       Name: func(string, []uint8, int) ([]uint8, error)
       ByteSize: 8
       GoRuntimeType: 1.025152e+06
       GoKind: 19
     - __kind: StructureType
-      ID: 136
+      ID: 159
       Name: github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span
       ByteSize: 288
       GoRuntimeType: 2.3976e+06
@@ -1801,81 +1801,81 @@ Types:
       RawFields:
         - Name: mu
           Offset: 0
-          Type: 137 StructureType sync.RWMutex
+          Type: 160 StructureType sync.RWMutex
         - Name: name
           Offset: 24
-          Type: 5 GoStringHeaderType string
+          Type: 9 GoStringHeaderType string
         - Name: service
           Offset: 40
-          Type: 5 GoStringHeaderType string
+          Type: 9 GoStringHeaderType string
         - Name: resource
           Offset: 56
-          Type: 5 GoStringHeaderType string
+          Type: 9 GoStringHeaderType string
         - Name: spanType
           Offset: 72
-          Type: 5 GoStringHeaderType string
+          Type: 9 GoStringHeaderType string
         - Name: start
           Offset: 88
-          Type: 32 BaseType int64
+          Type: 12 BaseType int64
         - Name: duration
           Offset: 96
-          Type: 32 BaseType int64
+          Type: 12 BaseType int64
         - Name: meta
           Offset: 104
-          Type: 124 GoMapType map[string]string
+          Type: 147 GoMapType map[string]string
         - Name: metaStruct
           Offset: 112
-          Type: 145 GoMapType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.metaStructMap
+          Type: 166 GoMapType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.metaStructMap
         - Name: metrics
           Offset: 120
-          Type: 156 GoMapType map[string]float64
+          Type: 177 GoMapType map[string]float64
         - Name: spanID
           Offset: 128
-          Type: 17 BaseType uint64
+          Type: 8 BaseType uint64
         - Name: traceID
           Offset: 136
-          Type: 17 BaseType uint64
+          Type: 8 BaseType uint64
         - Name: parentID
           Offset: 144
-          Type: 17 BaseType uint64
+          Type: 8 BaseType uint64
         - Name: error
           Offset: 152
-          Type: 141 BaseType int32
+          Type: 10 BaseType int32
         - Name: spanLinks
           Offset: 160
-          Type: 168 GoSliceHeaderType []github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink
+          Type: 188 GoSliceHeaderType []github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink
         - Name: spanEvents
           Offset: 184
-          Type: 171 GoSliceHeaderType []github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent
+          Type: 191 GoSliceHeaderType []github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent
         - Name: goExecTraced
           Offset: 208
-          Type: 13 BaseType bool
+          Type: 4 BaseType bool
         - Name: noDebugStack
           Offset: 209
-          Type: 13 BaseType bool
+          Type: 4 BaseType bool
         - Name: finished
           Offset: 210
-          Type: 13 BaseType bool
+          Type: 4 BaseType bool
         - Name: context
           Offset: 216
-          Type: 196 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanContext
+          Type: 216 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanContext
         - Name: integration
           Offset: 224
-          Type: 5 GoStringHeaderType string
+          Type: 9 GoStringHeaderType string
         - Name: supportsEvents
           Offset: 240
-          Type: 13 BaseType bool
+          Type: 4 BaseType bool
         - Name: pprofCtxActive
           Offset: 248
-          Type: 118 GoInterfaceType context.Context
+          Type: 141 GoInterfaceType context.Context
         - Name: pprofCtxRestore
           Offset: 264
-          Type: 118 GoInterfaceType context.Context
+          Type: 141 GoInterfaceType context.Context
         - Name: taskEnd
           Offset: 280
-          Type: 205 GoSubroutineType func()
+          Type: 224 GoSubroutineType func()
     - __kind: StructureType
-      ID: 197
+      ID: 217
       Name: github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanContext
       ByteSize: 168
       GoRuntimeType: 2.269952e+06
@@ -1883,48 +1883,48 @@ Types:
       RawFields:
         - Name: updated
           Offset: 0
-          Type: 13 BaseType bool
+          Type: 4 BaseType bool
         - Name: trace
           Offset: 8
-          Type: 198 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.trace
+          Type: 218 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.trace
         - Name: span
           Offset: 16
-          Type: 135 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span
+          Type: 158 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span
         - Name: errors
           Offset: 24
-          Type: 143 StructureType sync/atomic.Int32
+          Type: 164 StructureType sync/atomic.Int32
         - Name: reparentID
           Offset: 32
-          Type: 5 GoStringHeaderType string
+          Type: 9 GoStringHeaderType string
         - Name: isRemote
           Offset: 48
-          Type: 13 BaseType bool
+          Type: 4 BaseType bool
         - Name: traceID
           Offset: 49
-          Type: 204 ArrayType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.traceID
+          Type: 223 ArrayType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.traceID
         - Name: spanID
           Offset: 72
-          Type: 17 BaseType uint64
+          Type: 8 BaseType uint64
         - Name: mu
           Offset: 80
-          Type: 137 StructureType sync.RWMutex
+          Type: 160 StructureType sync.RWMutex
         - Name: baggage
           Offset: 104
-          Type: 124 GoMapType map[string]string
+          Type: 147 GoMapType map[string]string
         - Name: hasBaggage
           Offset: 112
-          Type: 142 BaseType uint32
+          Type: 2 BaseType uint32
         - Name: origin
           Offset: 120
-          Type: 5 GoStringHeaderType string
+          Type: 9 GoStringHeaderType string
         - Name: spanLinks
           Offset: 136
-          Type: 168 GoSliceHeaderType []github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink
+          Type: 188 GoSliceHeaderType []github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink
         - Name: baggageOnly
           Offset: 160
-          Type: 13 BaseType bool
+          Type: 4 BaseType bool
     - __kind: StructureType
-      ID: 170
+      ID: 190
       Name: github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink
       ByteSize: 56
       GoRuntimeType: 1.955616e+06
@@ -1932,37 +1932,37 @@ Types:
       RawFields:
         - Name: TraceID
           Offset: 0
-          Type: 17 BaseType uint64
+          Type: 8 BaseType uint64
         - Name: TraceIDHigh
           Offset: 8
-          Type: 17 BaseType uint64
+          Type: 8 BaseType uint64
         - Name: SpanID
           Offset: 16
-          Type: 17 BaseType uint64
+          Type: 8 BaseType uint64
         - Name: Attributes
           Offset: 24
-          Type: 124 GoMapType map[string]string
+          Type: 147 GoMapType map[string]string
         - Name: Tracestate
           Offset: 32
-          Type: 5 GoStringHeaderType string
+          Type: 9 GoStringHeaderType string
         - Name: Flags
           Offset: 48
-          Type: 142 BaseType uint32
+          Type: 2 BaseType uint32
     - __kind: GoMapType
-      ID: 145
+      ID: 166
       Name: github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.metaStructMap
       ByteSize: 8
       GoRuntimeType: 1.30448e+06
       GoKind: 21
-      HeaderType: 147 GoSwissMapHeaderType map<string,interface {}>
+      HeaderType: 168 GoSwissMapHeaderType map<string,interface {}>
     - __kind: BaseType
-      ID: 203
+      ID: 222
       Name: github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.samplingDecision
       ByteSize: 4
       GoRuntimeType: 594016
       GoKind: 10
     - __kind: StructureType
-      ID: 173
+      ID: 193
       Name: github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent
       ByteSize: 40
       GoRuntimeType: 1.789664e+06
@@ -1970,18 +1970,18 @@ Types:
       RawFields:
         - Name: Name
           Offset: 0
-          Type: 5 GoStringHeaderType string
+          Type: 9 GoStringHeaderType string
         - Name: TimeUnixNano
           Offset: 16
-          Type: 17 BaseType uint64
+          Type: 8 BaseType uint64
         - Name: Attributes
           Offset: 24
-          Type: 174 GoMapType map[string]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
+          Type: 194 GoMapType map[string]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
         - Name: RawAttributes
           Offset: 32
-          Type: 195 GoMapType map[string]interface {}
+          Type: 215 GoMapType map[string]interface {}
     - __kind: StructureType
-      ID: 189
+      ID: 209
       Name: github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttribute
       ByteSize: 24
       GoRuntimeType: 1.2152e+06
@@ -1989,9 +1989,9 @@ Types:
       RawFields:
         - Name: Values
           Offset: 0
-          Type: 190 GoSliceHeaderType []*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttributeValue
+          Type: 210 GoSliceHeaderType []*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttributeValue
     - __kind: StructureType
-      ID: 193
+      ID: 213
       Name: github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttributeValue
       ByteSize: 48
       GoRuntimeType: 1.878752e+06
@@ -1999,27 +1999,27 @@ Types:
       RawFields:
         - Name: Type
           Offset: 0
-          Type: 194 BaseType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttributeValueType
+          Type: 214 BaseType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttributeValueType
         - Name: StringValue
           Offset: 8
-          Type: 5 GoStringHeaderType string
+          Type: 9 GoStringHeaderType string
         - Name: BoolValue
           Offset: 24
-          Type: 13 BaseType bool
+          Type: 4 BaseType bool
         - Name: IntValue
           Offset: 32
-          Type: 32 BaseType int64
+          Type: 12 BaseType int64
         - Name: DoubleValue
           Offset: 40
-          Type: 167 BaseType float64
+          Type: 15 BaseType float64
     - __kind: BaseType
-      ID: 194
+      ID: 214
       Name: github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttributeValueType
       ByteSize: 4
       GoRuntimeType: 1.006816e+06
       GoKind: 5
     - __kind: StructureType
-      ID: 186
+      ID: 206
       Name: github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
       ByteSize: 56
       GoRuntimeType: 1.955872e+06
@@ -2027,30 +2027,30 @@ Types:
       RawFields:
         - Name: Type
           Offset: 0
-          Type: 187 BaseType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttributeType
+          Type: 207 BaseType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttributeType
         - Name: StringValue
           Offset: 8
-          Type: 5 GoStringHeaderType string
+          Type: 9 GoStringHeaderType string
         - Name: BoolValue
           Offset: 24
-          Type: 13 BaseType bool
+          Type: 4 BaseType bool
         - Name: IntValue
           Offset: 32
-          Type: 32 BaseType int64
+          Type: 12 BaseType int64
         - Name: DoubleValue
           Offset: 40
-          Type: 167 BaseType float64
+          Type: 15 BaseType float64
         - Name: ArrayValue
           Offset: 48
-          Type: 188 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttribute
+          Type: 208 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttribute
     - __kind: BaseType
-      ID: 187
+      ID: 207
       Name: github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttributeType
       ByteSize: 4
       GoRuntimeType: 1.00672e+06
       GoKind: 5
     - __kind: StructureType
-      ID: 199
+      ID: 219
       Name: github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.trace
       ByteSize: 104
       GoRuntimeType: 2.155744e+06
@@ -2058,159 +2058,159 @@ Types:
       RawFields:
         - Name: mu
           Offset: 0
-          Type: 137 StructureType sync.RWMutex
+          Type: 160 StructureType sync.RWMutex
         - Name: spans
           Offset: 24
-          Type: 200 GoSliceHeaderType []*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span
+          Type: 220 GoSliceHeaderType []*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span
         - Name: tags
           Offset: 48
-          Type: 124 GoMapType map[string]string
+          Type: 147 GoMapType map[string]string
         - Name: propagatingTags
           Offset: 56
-          Type: 124 GoMapType map[string]string
+          Type: 147 GoMapType map[string]string
         - Name: finished
           Offset: 64
-          Type: 8 BaseType int
+          Type: 7 BaseType int
         - Name: full
           Offset: 72
-          Type: 13 BaseType bool
+          Type: 4 BaseType bool
         - Name: priority
           Offset: 80
-          Type: 202 PointerType *float64
+          Type: 25 PointerType *float64
         - Name: locked
           Offset: 88
-          Type: 13 BaseType bool
+          Type: 4 BaseType bool
         - Name: samplingDecision
           Offset: 92
-          Type: 203 BaseType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.samplingDecision
+          Type: 222 BaseType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.samplingDecision
         - Name: root
           Offset: 96
-          Type: 135 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span
+          Type: 158 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span
     - __kind: ArrayType
-      ID: 204
+      ID: 223
       Name: github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.traceID
       ByteSize: 16
       GoRuntimeType: 919232
       GoKind: 17
       Count: 16
       HasCount: true
-      Element: 7 BaseType uint8
+      Element: 3 BaseType uint8
     - __kind: GoSwissMapGroupsType
-      ID: 180
+      ID: 200
       Name: groupReference<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 181 PointerType *noalg.map.group[string]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
+          Type: 201 PointerType *noalg.map.group[string]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
         - Name: lengthMask
           Offset: 8
-          Type: 17 BaseType uint64
-      GroupType: 182 StructureType noalg.map.group[string]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
+          Type: 8 BaseType uint64
+      GroupType: 202 StructureType noalg.map.group[string]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
       GroupSliceType: 289 GoSliceDataType []noalg.map.group[string]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute.array
     - __kind: GoSwissMapGroupsType
-      ID: 43
+      ID: 67
       Name: groupReference<string,[]*mime/multipart.FileHeader>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 44 PointerType *noalg.map.group[string][]*mime/multipart.FileHeader
+          Type: 68 PointerType *noalg.map.group[string][]*mime/multipart.FileHeader
         - Name: lengthMask
           Offset: 8
-          Type: 17 BaseType uint64
-      GroupType: 45 StructureType noalg.map.group[string][]*mime/multipart.FileHeader
+          Type: 8 BaseType uint64
+      GroupType: 69 StructureType noalg.map.group[string][]*mime/multipart.FileHeader
       GroupSliceType: 235 GoSliceDataType []noalg.map.group[string][]*mime/multipart.FileHeader.array
     - __kind: GoSwissMapGroupsType
-      ID: 23
+      ID: 49
       Name: groupReference<string,[]string>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 24 PointerType *noalg.map.group[string][]string
+          Type: 50 PointerType *noalg.map.group[string][]string
         - Name: lengthMask
           Offset: 8
-          Type: 17 BaseType uint64
-      GroupType: 25 StructureType noalg.map.group[string][]string
+          Type: 8 BaseType uint64
+      GroupType: 51 StructureType noalg.map.group[string][]string
       GroupSliceType: 231 GoSliceDataType []noalg.map.group[string][]string.array
     - __kind: GoSwissMapGroupsType
-      ID: 162
+      ID: 183
       Name: groupReference<string,float64>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 163 PointerType *noalg.map.group[string]float64
+          Type: 184 PointerType *noalg.map.group[string]float64
         - Name: lengthMask
           Offset: 8
-          Type: 17 BaseType uint64
-      GroupType: 164 StructureType noalg.map.group[string]float64
+          Type: 8 BaseType uint64
+      GroupType: 185 StructureType noalg.map.group[string]float64
       GroupSliceType: 283 GoSliceDataType []noalg.map.group[string]float64.array
     - __kind: GoSwissMapGroupsType
-      ID: 151
+      ID: 172
       Name: groupReference<string,interface {}>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 152 PointerType *noalg.map.group[string]interface {}
+          Type: 173 PointerType *noalg.map.group[string]interface {}
         - Name: lengthMask
           Offset: 8
-          Type: 17 BaseType uint64
-      GroupType: 153 StructureType noalg.map.group[string]interface {}
+          Type: 8 BaseType uint64
+      GroupType: 174 StructureType noalg.map.group[string]interface {}
       GroupSliceType: 281 GoSliceDataType []noalg.map.group[string]interface {}.array
     - __kind: GoSwissMapGroupsType
-      ID: 130
+      ID: 153
       Name: groupReference<string,string>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 131 PointerType *noalg.map.group[string]string
+          Type: 154 PointerType *noalg.map.group[string]string
         - Name: lengthMask
           Offset: 8
-          Type: 17 BaseType uint64
-      GroupType: 132 StructureType noalg.map.group[string]string
+          Type: 8 BaseType uint64
+      GroupType: 155 StructureType noalg.map.group[string]string
       GroupSliceType: 279 GoSliceDataType []noalg.map.group[string]string.array
     - __kind: BaseType
-      ID: 8
+      ID: 7
       Name: int
       ByteSize: 8
       GoRuntimeType: 594784
       GoKind: 2
     - __kind: BaseType
-      ID: 223
+      ID: 31
       Name: int16
       ByteSize: 2
       GoRuntimeType: 594400
       GoKind: 4
     - __kind: BaseType
-      ID: 141
+      ID: 10
       Name: int32
       ByteSize: 4
       GoRuntimeType: 594528
       GoKind: 5
     - __kind: BaseType
-      ID: 32
+      ID: 12
       Name: int64
       ByteSize: 8
       GoRuntimeType: 594656
       GoKind: 6
     - __kind: BaseType
-      ID: 211
+      ID: 16
       Name: int8
       ByteSize: 1
       GoRuntimeType: 594272
       GoKind: 3
     - __kind: GoEmptyInterfaceType
-      ID: 63
+      ID: 87
       Name: interface {}
       ByteSize: 16
       GoRuntimeType: 867104
@@ -2218,12 +2218,12 @@ Types:
       RawFields:
         - Name: _type
           Offset: 0
-          Type: 2 VoidPointerType unsafe.Pointer
+          Type: 14 VoidPointerType unsafe.Pointer
         - Name: data
           Offset: 8
-          Type: 2 VoidPointerType unsafe.Pointer
+          Type: 14 VoidPointerType unsafe.Pointer
     - __kind: StructureType
-      ID: 140
+      ID: 163
       Name: internal/sync.Mutex
       ByteSize: 8
       GoRuntimeType: 1.518176e+06
@@ -2231,12 +2231,12 @@ Types:
       RawFields:
         - Name: state
           Offset: 0
-          Type: 141 BaseType int32
+          Type: 10 BaseType int32
         - Name: sema
           Offset: 4
-          Type: 142 BaseType uint32
+          Type: 2 BaseType uint32
     - __kind: GoInterfaceType
-      ID: 30
+      ID: 55
       Name: io.ReadCloser
       ByteSize: 16
       GoRuntimeType: 1.135168e+06
@@ -2244,264 +2244,264 @@ Types:
       RawFields:
         - Name: tab
           Offset: 0
-          Type: 2 VoidPointerType unsafe.Pointer
+          Type: 14 VoidPointerType unsafe.Pointer
         - Name: data
           Offset: 8
-          Type: 2 VoidPointerType unsafe.Pointer
+          Type: 14 VoidPointerType unsafe.Pointer
     - __kind: GoSwissMapHeaderType
-      ID: 176
+      ID: 196
       Name: map<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
       ByteSize: 48
       GoKind: 25
       RawFields:
         - Name: used
           Offset: 0
-          Type: 17 BaseType uint64
+          Type: 8 BaseType uint64
         - Name: seed
           Offset: 8
-          Type: 18 BaseType uintptr
+          Type: 1 BaseType uintptr
         - Name: dirPtr
           Offset: 16
-          Type: 177 PointerType **table<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
+          Type: 197 PointerType **table<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
         - Name: dirLen
           Offset: 24
-          Type: 8 BaseType int
+          Type: 7 BaseType int
         - Name: globalDepth
           Offset: 32
-          Type: 7 BaseType uint8
+          Type: 3 BaseType uint8
         - Name: globalShift
           Offset: 33
-          Type: 7 BaseType uint8
+          Type: 3 BaseType uint8
         - Name: writing
           Offset: 34
-          Type: 7 BaseType uint8
+          Type: 3 BaseType uint8
         - Name: tombstonePossible
           Offset: 35
-          Type: 13 BaseType bool
+          Type: 4 BaseType bool
         - Name: clearSeq
           Offset: 40
-          Type: 17 BaseType uint64
+          Type: 8 BaseType uint64
       TablePtrSliceType: 288 GoSliceDataType []*table<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>.array
-      GroupType: 182 StructureType noalg.map.group[string]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
+      GroupType: 202 StructureType noalg.map.group[string]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
     - __kind: GoSwissMapHeaderType
-      ID: 39
+      ID: 63
       Name: map<string,[]*mime/multipart.FileHeader>
       ByteSize: 48
       GoKind: 25
       RawFields:
         - Name: used
           Offset: 0
-          Type: 17 BaseType uint64
+          Type: 8 BaseType uint64
         - Name: seed
           Offset: 8
-          Type: 18 BaseType uintptr
+          Type: 1 BaseType uintptr
         - Name: dirPtr
           Offset: 16
-          Type: 40 PointerType **table<string,[]*mime/multipart.FileHeader>
+          Type: 64 PointerType **table<string,[]*mime/multipart.FileHeader>
         - Name: dirLen
           Offset: 24
-          Type: 8 BaseType int
+          Type: 7 BaseType int
         - Name: globalDepth
           Offset: 32
-          Type: 7 BaseType uint8
+          Type: 3 BaseType uint8
         - Name: globalShift
           Offset: 33
-          Type: 7 BaseType uint8
+          Type: 3 BaseType uint8
         - Name: writing
           Offset: 34
-          Type: 7 BaseType uint8
+          Type: 3 BaseType uint8
         - Name: tombstonePossible
           Offset: 35
-          Type: 13 BaseType bool
+          Type: 4 BaseType bool
         - Name: clearSeq
           Offset: 40
-          Type: 17 BaseType uint64
+          Type: 8 BaseType uint64
       TablePtrSliceType: 234 GoSliceDataType []*table<string,[]*mime/multipart.FileHeader>.array
-      GroupType: 45 StructureType noalg.map.group[string][]*mime/multipart.FileHeader
+      GroupType: 69 StructureType noalg.map.group[string][]*mime/multipart.FileHeader
     - __kind: GoSwissMapHeaderType
-      ID: 16
+      ID: 45
       Name: map<string,[]string>
       ByteSize: 48
       GoKind: 25
       RawFields:
         - Name: used
           Offset: 0
-          Type: 17 BaseType uint64
+          Type: 8 BaseType uint64
         - Name: seed
           Offset: 8
-          Type: 18 BaseType uintptr
+          Type: 1 BaseType uintptr
         - Name: dirPtr
           Offset: 16
-          Type: 19 PointerType **table<string,[]string>
+          Type: 46 PointerType **table<string,[]string>
         - Name: dirLen
           Offset: 24
-          Type: 8 BaseType int
+          Type: 7 BaseType int
         - Name: globalDepth
           Offset: 32
-          Type: 7 BaseType uint8
+          Type: 3 BaseType uint8
         - Name: globalShift
           Offset: 33
-          Type: 7 BaseType uint8
+          Type: 3 BaseType uint8
         - Name: writing
           Offset: 34
-          Type: 7 BaseType uint8
+          Type: 3 BaseType uint8
         - Name: tombstonePossible
           Offset: 35
-          Type: 13 BaseType bool
+          Type: 4 BaseType bool
         - Name: clearSeq
           Offset: 40
-          Type: 17 BaseType uint64
+          Type: 8 BaseType uint64
       TablePtrSliceType: 230 GoSliceDataType []*table<string,[]string>.array
-      GroupType: 25 StructureType noalg.map.group[string][]string
+      GroupType: 51 StructureType noalg.map.group[string][]string
     - __kind: GoSwissMapHeaderType
-      ID: 158
+      ID: 179
       Name: map<string,float64>
       ByteSize: 48
       GoKind: 25
       RawFields:
         - Name: used
           Offset: 0
-          Type: 17 BaseType uint64
+          Type: 8 BaseType uint64
         - Name: seed
           Offset: 8
-          Type: 18 BaseType uintptr
+          Type: 1 BaseType uintptr
         - Name: dirPtr
           Offset: 16
-          Type: 159 PointerType **table<string,float64>
+          Type: 180 PointerType **table<string,float64>
         - Name: dirLen
           Offset: 24
-          Type: 8 BaseType int
+          Type: 7 BaseType int
         - Name: globalDepth
           Offset: 32
-          Type: 7 BaseType uint8
+          Type: 3 BaseType uint8
         - Name: globalShift
           Offset: 33
-          Type: 7 BaseType uint8
+          Type: 3 BaseType uint8
         - Name: writing
           Offset: 34
-          Type: 7 BaseType uint8
+          Type: 3 BaseType uint8
         - Name: tombstonePossible
           Offset: 35
-          Type: 13 BaseType bool
+          Type: 4 BaseType bool
         - Name: clearSeq
           Offset: 40
-          Type: 17 BaseType uint64
+          Type: 8 BaseType uint64
       TablePtrSliceType: 282 GoSliceDataType []*table<string,float64>.array
-      GroupType: 164 StructureType noalg.map.group[string]float64
+      GroupType: 185 StructureType noalg.map.group[string]float64
     - __kind: GoSwissMapHeaderType
-      ID: 147
+      ID: 168
       Name: map<string,interface {}>
       ByteSize: 48
       GoKind: 25
       RawFields:
         - Name: used
           Offset: 0
-          Type: 17 BaseType uint64
+          Type: 8 BaseType uint64
         - Name: seed
           Offset: 8
-          Type: 18 BaseType uintptr
+          Type: 1 BaseType uintptr
         - Name: dirPtr
           Offset: 16
-          Type: 148 PointerType **table<string,interface {}>
+          Type: 169 PointerType **table<string,interface {}>
         - Name: dirLen
           Offset: 24
-          Type: 8 BaseType int
+          Type: 7 BaseType int
         - Name: globalDepth
           Offset: 32
-          Type: 7 BaseType uint8
+          Type: 3 BaseType uint8
         - Name: globalShift
           Offset: 33
-          Type: 7 BaseType uint8
+          Type: 3 BaseType uint8
         - Name: writing
           Offset: 34
-          Type: 7 BaseType uint8
+          Type: 3 BaseType uint8
         - Name: tombstonePossible
           Offset: 35
-          Type: 13 BaseType bool
+          Type: 4 BaseType bool
         - Name: clearSeq
           Offset: 40
-          Type: 17 BaseType uint64
+          Type: 8 BaseType uint64
       TablePtrSliceType: 280 GoSliceDataType []*table<string,interface {}>.array
-      GroupType: 153 StructureType noalg.map.group[string]interface {}
+      GroupType: 174 StructureType noalg.map.group[string]interface {}
     - __kind: GoSwissMapHeaderType
-      ID: 126
+      ID: 149
       Name: map<string,string>
       ByteSize: 48
       GoKind: 25
       RawFields:
         - Name: used
           Offset: 0
-          Type: 17 BaseType uint64
+          Type: 8 BaseType uint64
         - Name: seed
           Offset: 8
-          Type: 18 BaseType uintptr
+          Type: 1 BaseType uintptr
         - Name: dirPtr
           Offset: 16
-          Type: 127 PointerType **table<string,string>
+          Type: 150 PointerType **table<string,string>
         - Name: dirLen
           Offset: 24
-          Type: 8 BaseType int
+          Type: 7 BaseType int
         - Name: globalDepth
           Offset: 32
-          Type: 7 BaseType uint8
+          Type: 3 BaseType uint8
         - Name: globalShift
           Offset: 33
-          Type: 7 BaseType uint8
+          Type: 3 BaseType uint8
         - Name: writing
           Offset: 34
-          Type: 7 BaseType uint8
+          Type: 3 BaseType uint8
         - Name: tombstonePossible
           Offset: 35
-          Type: 13 BaseType bool
+          Type: 4 BaseType bool
         - Name: clearSeq
           Offset: 40
-          Type: 17 BaseType uint64
+          Type: 8 BaseType uint64
       TablePtrSliceType: 278 GoSliceDataType []*table<string,string>.array
-      GroupType: 132 StructureType noalg.map.group[string]string
+      GroupType: 155 StructureType noalg.map.group[string]string
     - __kind: GoMapType
-      ID: 174
+      ID: 194
       Name: map[string]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
       ByteSize: 8
       GoRuntimeType: 1.158336e+06
       GoKind: 21
-      HeaderType: 176 GoSwissMapHeaderType map<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
+      HeaderType: 196 GoSwissMapHeaderType map<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
     - __kind: GoMapType
-      ID: 37
+      ID: 61
       Name: map[string][]*mime/multipart.FileHeader
       ByteSize: 8
       GoRuntimeType: 1.157568e+06
       GoKind: 21
-      HeaderType: 39 GoSwissMapHeaderType map<string,[]*mime/multipart.FileHeader>
+      HeaderType: 63 GoSwissMapHeaderType map<string,[]*mime/multipart.FileHeader>
     - __kind: GoMapType
-      ID: 36
+      ID: 60
       Name: map[string][]string
       ByteSize: 8
       GoRuntimeType: 1.153216e+06
       GoKind: 21
-      HeaderType: 16 GoSwissMapHeaderType map<string,[]string>
+      HeaderType: 45 GoSwissMapHeaderType map<string,[]string>
     - __kind: GoMapType
-      ID: 156
+      ID: 177
       Name: map[string]float64
       ByteSize: 8
       GoRuntimeType: 1.158208e+06
       GoKind: 21
-      HeaderType: 158 GoSwissMapHeaderType map<string,float64>
+      HeaderType: 179 GoSwissMapHeaderType map<string,float64>
     - __kind: GoMapType
-      ID: 195
+      ID: 215
       Name: map[string]interface {}
       ByteSize: 8
       GoRuntimeType: 1.151808e+06
       GoKind: 21
-      HeaderType: 147 GoSwissMapHeaderType map<string,interface {}>
+      HeaderType: 168 GoSwissMapHeaderType map<string,interface {}>
     - __kind: GoMapType
-      ID: 124
+      ID: 147
       Name: map[string]string
       ByteSize: 8
       GoRuntimeType: 1.15424e+06
       GoKind: 21
-      HeaderType: 126 GoSwissMapHeaderType map<string,string>
+      HeaderType: 149 GoSwissMapHeaderType map<string,string>
     - __kind: StructureType
-      ID: 65
+      ID: 89
       Name: math/big.Int
       ByteSize: 32
       GoRuntimeType: 1.523456e+06
@@ -2509,18 +2509,18 @@ Types:
       RawFields:
         - Name: neg
           Offset: 0
-          Type: 13 BaseType bool
+          Type: 4 BaseType bool
         - Name: abs
           Offset: 8
-          Type: 66 GoSliceHeaderType math/big.nat
+          Type: 90 GoSliceHeaderType math/big.nat
     - __kind: BaseType
-      ID: 68
+      ID: 92
       Name: math/big.Word
       ByteSize: 8
       GoRuntimeType: 598496
       GoKind: 7
     - __kind: GoSliceHeaderType
-      ID: 66
+      ID: 90
       Name: math/big.nat
       ByteSize: 24
       GoRuntimeType: 2.426912e+06
@@ -2528,21 +2528,21 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 67 PointerType *math/big.Word
+          Type: 91 PointerType *math/big.Word
         - Name: len
           Offset: 8
-          Type: 8 BaseType int
+          Type: 7 BaseType int
         - Name: cap
           Offset: 16
-          Type: 8 BaseType int
+          Type: 7 BaseType int
       Data: 242 GoSliceDataType math/big.nat.array
     - __kind: GoSliceDataType
       ID: 242
       Name: math/big.nat.array
       ByteSize: 2048
-      Element: 68 BaseType math/big.Word
+      Element: 92 BaseType math/big.Word
     - __kind: StructureType
-      ID: 51
+      ID: 75
       Name: mime/multipart.FileHeader
       ByteSize: 88
       GoRuntimeType: 2.018784e+06
@@ -2550,27 +2550,27 @@ Types:
       RawFields:
         - Name: Filename
           Offset: 0
-          Type: 5 GoStringHeaderType string
+          Type: 9 GoStringHeaderType string
         - Name: Header
           Offset: 16
-          Type: 52 GoMapType net/textproto.MIMEHeader
+          Type: 76 GoMapType net/textproto.MIMEHeader
         - Name: Size
           Offset: 24
-          Type: 32 BaseType int64
+          Type: 12 BaseType int64
         - Name: content
           Offset: 32
-          Type: 53 GoSliceHeaderType []uint8
+          Type: 77 GoSliceHeaderType []uint8
         - Name: tmpfile
           Offset: 56
-          Type: 5 GoStringHeaderType string
+          Type: 9 GoStringHeaderType string
         - Name: tmpoff
           Offset: 72
-          Type: 32 BaseType int64
+          Type: 12 BaseType int64
         - Name: tmpshared
           Offset: 80
-          Type: 13 BaseType bool
+          Type: 4 BaseType bool
     - __kind: StructureType
-      ID: 35
+      ID: 59
       Name: mime/multipart.Form
       ByteSize: 16
       GoRuntimeType: 1.506656e+06
@@ -2578,12 +2578,12 @@ Types:
       RawFields:
         - Name: Value
           Offset: 0
-          Type: 36 GoMapType map[string][]string
+          Type: 60 GoMapType map[string][]string
         - Name: File
           Offset: 8
-          Type: 37 GoMapType map[string][]*mime/multipart.FileHeader
+          Type: 61 GoMapType map[string][]*mime/multipart.FileHeader
     - __kind: GoSliceHeaderType
-      ID: 95
+      ID: 118
       Name: net.IP
       ByteSize: 24
       GoRuntimeType: 2.178944e+06
@@ -2591,21 +2591,21 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 6 PointerType *uint8
+          Type: 5 PointerType *uint8
         - Name: len
           Offset: 8
-          Type: 8 BaseType int
+          Type: 7 BaseType int
         - Name: cap
           Offset: 16
-          Type: 8 BaseType int
+          Type: 7 BaseType int
       Data: 260 GoSliceDataType net.IP.array
     - __kind: GoSliceDataType
       ID: 260
       Name: net.IP.array
       ByteSize: 2048
-      Element: 7 BaseType uint8
+      Element: 3 BaseType uint8
     - __kind: GoSliceHeaderType
-      ID: 102
+      ID: 125
       Name: net.IPMask
       ByteSize: 24
       GoRuntimeType: 1.042272e+06
@@ -2613,21 +2613,21 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 6 PointerType *uint8
+          Type: 5 PointerType *uint8
         - Name: len
           Offset: 8
-          Type: 8 BaseType int
+          Type: 7 BaseType int
         - Name: cap
           Offset: 16
-          Type: 8 BaseType int
+          Type: 7 BaseType int
       Data: 266 GoSliceDataType net.IPMask.array
     - __kind: GoSliceDataType
       ID: 266
       Name: net.IPMask.array
       ByteSize: 2048
-      Element: 7 BaseType uint8
+      Element: 3 BaseType uint8
     - __kind: StructureType
-      ID: 101
+      ID: 124
       Name: net.IPNet
       ByteSize: 48
       GoRuntimeType: 1.486976e+06
@@ -2635,19 +2635,19 @@ Types:
       RawFields:
         - Name: IP
           Offset: 0
-          Type: 95 GoSliceHeaderType net.IP
+          Type: 118 GoSliceHeaderType net.IP
         - Name: Mask
           Offset: 24
-          Type: 102 GoSliceHeaderType net.IPMask
+          Type: 125 GoSliceHeaderType net.IPMask
     - __kind: GoMapType
-      ID: 14
+      ID: 43
       Name: net/http.Header
       ByteSize: 8
       GoRuntimeType: 2.15504e+06
       GoKind: 21
-      HeaderType: 16 GoSwissMapHeaderType map<string,[]string>
+      HeaderType: 45 GoSwissMapHeaderType map<string,[]string>
     - __kind: StructureType
-      ID: 4
+      ID: 38
       Name: net/http.Request
       ByteSize: 304
       GoRuntimeType: 2.401888e+06
@@ -2655,84 +2655,84 @@ Types:
       RawFields:
         - Name: Method
           Offset: 0
-          Type: 5 GoStringHeaderType string
+          Type: 9 GoStringHeaderType string
         - Name: URL
           Offset: 16
-          Type: 9 PointerType *net/url.URL
+          Type: 39 PointerType *net/url.URL
         - Name: Proto
           Offset: 24
-          Type: 5 GoStringHeaderType string
+          Type: 9 GoStringHeaderType string
         - Name: ProtoMajor
           Offset: 40
-          Type: 8 BaseType int
+          Type: 7 BaseType int
         - Name: ProtoMinor
           Offset: 48
-          Type: 8 BaseType int
+          Type: 7 BaseType int
         - Name: Header
           Offset: 56
-          Type: 14 GoMapType net/http.Header
+          Type: 43 GoMapType net/http.Header
         - Name: Body
           Offset: 64
-          Type: 30 GoInterfaceType io.ReadCloser
+          Type: 55 GoInterfaceType io.ReadCloser
         - Name: GetBody
           Offset: 80
-          Type: 31 GoSubroutineType func() (io.ReadCloser, error)
+          Type: 56 GoSubroutineType func() (io.ReadCloser, error)
         - Name: ContentLength
           Offset: 88
-          Type: 32 BaseType int64
+          Type: 12 BaseType int64
         - Name: TransferEncoding
           Offset: 96
-          Type: 28 GoSliceHeaderType []string
+          Type: 54 GoSliceHeaderType []string
         - Name: Close
           Offset: 120
-          Type: 13 BaseType bool
+          Type: 4 BaseType bool
         - Name: Host
           Offset: 128
-          Type: 5 GoStringHeaderType string
+          Type: 9 GoStringHeaderType string
         - Name: Form
           Offset: 144
-          Type: 33 GoMapType net/url.Values
+          Type: 57 GoMapType net/url.Values
         - Name: PostForm
           Offset: 152
-          Type: 33 GoMapType net/url.Values
+          Type: 57 GoMapType net/url.Values
         - Name: MultipartForm
           Offset: 160
-          Type: 34 PointerType *mime/multipart.Form
+          Type: 58 PointerType *mime/multipart.Form
         - Name: Trailer
           Offset: 168
-          Type: 14 GoMapType net/http.Header
+          Type: 43 GoMapType net/http.Header
         - Name: RemoteAddr
           Offset: 176
-          Type: 5 GoStringHeaderType string
+          Type: 9 GoStringHeaderType string
         - Name: RequestURI
           Offset: 192
-          Type: 5 GoStringHeaderType string
+          Type: 9 GoStringHeaderType string
         - Name: TLS
           Offset: 208
-          Type: 54 PointerType *crypto/tls.ConnectionState
+          Type: 78 PointerType *crypto/tls.ConnectionState
         - Name: Cancel
           Offset: 216
-          Type: 115 GoChannelType <-chan struct {}
+          Type: 138 GoChannelType <-chan struct {}
         - Name: Response
           Offset: 224
-          Type: 116 PointerType *net/http.Response
+          Type: 139 PointerType *net/http.Response
         - Name: Pattern
           Offset: 232
-          Type: 5 GoStringHeaderType string
+          Type: 9 GoStringHeaderType string
         - Name: ctx
           Offset: 248
-          Type: 118 GoInterfaceType context.Context
+          Type: 141 GoInterfaceType context.Context
         - Name: pat
           Offset: 264
-          Type: 119 PointerType *net/http.pattern
+          Type: 142 PointerType *net/http.pattern
         - Name: matches
           Offset: 272
-          Type: 28 GoSliceHeaderType []string
+          Type: 54 GoSliceHeaderType []string
         - Name: otherValues
           Offset: 296
-          Type: 124 GoMapType map[string]string
+          Type: 147 GoMapType map[string]string
     - __kind: StructureType
-      ID: 117
+      ID: 140
       Name: net/http.Response
       ByteSize: 144
       GoRuntimeType: 2.268608e+06
@@ -2740,48 +2740,48 @@ Types:
       RawFields:
         - Name: Status
           Offset: 0
-          Type: 5 GoStringHeaderType string
+          Type: 9 GoStringHeaderType string
         - Name: StatusCode
           Offset: 16
-          Type: 8 BaseType int
+          Type: 7 BaseType int
         - Name: Proto
           Offset: 24
-          Type: 5 GoStringHeaderType string
+          Type: 9 GoStringHeaderType string
         - Name: ProtoMajor
           Offset: 40
-          Type: 8 BaseType int
+          Type: 7 BaseType int
         - Name: ProtoMinor
           Offset: 48
-          Type: 8 BaseType int
+          Type: 7 BaseType int
         - Name: Header
           Offset: 56
-          Type: 14 GoMapType net/http.Header
+          Type: 43 GoMapType net/http.Header
         - Name: Body
           Offset: 64
-          Type: 30 GoInterfaceType io.ReadCloser
+          Type: 55 GoInterfaceType io.ReadCloser
         - Name: ContentLength
           Offset: 80
-          Type: 32 BaseType int64
+          Type: 12 BaseType int64
         - Name: TransferEncoding
           Offset: 88
-          Type: 28 GoSliceHeaderType []string
+          Type: 54 GoSliceHeaderType []string
         - Name: Close
           Offset: 112
-          Type: 13 BaseType bool
+          Type: 4 BaseType bool
         - Name: Uncompressed
           Offset: 113
-          Type: 13 BaseType bool
+          Type: 4 BaseType bool
         - Name: Trailer
           Offset: 120
-          Type: 14 GoMapType net/http.Header
+          Type: 43 GoMapType net/http.Header
         - Name: Request
           Offset: 128
-          Type: 3 PointerType *net/http.Request
+          Type: 37 PointerType *net/http.Request
         - Name: TLS
           Offset: 136
-          Type: 54 PointerType *crypto/tls.ConnectionState
+          Type: 78 PointerType *crypto/tls.ConnectionState
     - __kind: GoInterfaceType
-      ID: 1
+      ID: 36
       Name: net/http.ResponseWriter
       ByteSize: 16
       GoRuntimeType: 1.210848e+06
@@ -2789,12 +2789,12 @@ Types:
       RawFields:
         - Name: tab
           Offset: 0
-          Type: 2 VoidPointerType unsafe.Pointer
+          Type: 14 VoidPointerType unsafe.Pointer
         - Name: data
           Offset: 8
-          Type: 2 VoidPointerType unsafe.Pointer
+          Type: 14 VoidPointerType unsafe.Pointer
     - __kind: StructureType
-      ID: 120
+      ID: 143
       Name: net/http.pattern
       ByteSize: 88
       GoRuntimeType: 1.875616e+06
@@ -2802,21 +2802,21 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 5 GoStringHeaderType string
+          Type: 9 GoStringHeaderType string
         - Name: method
           Offset: 16
-          Type: 5 GoStringHeaderType string
+          Type: 9 GoStringHeaderType string
         - Name: host
           Offset: 32
-          Type: 5 GoStringHeaderType string
+          Type: 9 GoStringHeaderType string
         - Name: segments
           Offset: 48
-          Type: 121 GoSliceHeaderType []net/http.segment
+          Type: 144 GoSliceHeaderType []net/http.segment
         - Name: loc
           Offset: 72
-          Type: 5 GoStringHeaderType string
+          Type: 9 GoStringHeaderType string
     - __kind: StructureType
-      ID: 123
+      ID: 146
       Name: net/http.segment
       ByteSize: 24
       GoRuntimeType: 1.642496e+06
@@ -2824,22 +2824,22 @@ Types:
       RawFields:
         - Name: s
           Offset: 0
-          Type: 5 GoStringHeaderType string
+          Type: 9 GoStringHeaderType string
         - Name: wild
           Offset: 16
-          Type: 13 BaseType bool
+          Type: 4 BaseType bool
         - Name: multi
           Offset: 17
-          Type: 13 BaseType bool
+          Type: 4 BaseType bool
     - __kind: GoMapType
-      ID: 52
+      ID: 76
       Name: net/textproto.MIMEHeader
       ByteSize: 8
       GoRuntimeType: 1.86368e+06
       GoKind: 21
-      HeaderType: 16 GoSwissMapHeaderType map<string,[]string>
+      HeaderType: 45 GoSwissMapHeaderType map<string,[]string>
     - __kind: StructureType
-      ID: 10
+      ID: 40
       Name: net/url.URL
       ByteSize: 144
       GoRuntimeType: 2.181632e+06
@@ -2847,39 +2847,39 @@ Types:
       RawFields:
         - Name: Scheme
           Offset: 0
-          Type: 5 GoStringHeaderType string
+          Type: 9 GoStringHeaderType string
         - Name: Opaque
           Offset: 16
-          Type: 5 GoStringHeaderType string
+          Type: 9 GoStringHeaderType string
         - Name: User
           Offset: 32
-          Type: 11 PointerType *net/url.Userinfo
+          Type: 41 PointerType *net/url.Userinfo
         - Name: Host
           Offset: 40
-          Type: 5 GoStringHeaderType string
+          Type: 9 GoStringHeaderType string
         - Name: Path
           Offset: 56
-          Type: 5 GoStringHeaderType string
+          Type: 9 GoStringHeaderType string
         - Name: RawPath
           Offset: 72
-          Type: 5 GoStringHeaderType string
+          Type: 9 GoStringHeaderType string
         - Name: OmitHost
           Offset: 88
-          Type: 13 BaseType bool
+          Type: 4 BaseType bool
         - Name: ForceQuery
           Offset: 89
-          Type: 13 BaseType bool
+          Type: 4 BaseType bool
         - Name: RawQuery
           Offset: 96
-          Type: 5 GoStringHeaderType string
+          Type: 9 GoStringHeaderType string
         - Name: Fragment
           Offset: 112
-          Type: 5 GoStringHeaderType string
+          Type: 9 GoStringHeaderType string
         - Name: RawFragment
           Offset: 128
-          Type: 5 GoStringHeaderType string
+          Type: 9 GoStringHeaderType string
     - __kind: StructureType
-      ID: 12
+      ID: 42
       Name: net/url.Userinfo
       ByteSize: 40
       GoRuntimeType: 1.658624e+06
@@ -2887,76 +2887,76 @@ Types:
       RawFields:
         - Name: username
           Offset: 0
-          Type: 5 GoStringHeaderType string
+          Type: 9 GoStringHeaderType string
         - Name: password
           Offset: 16
-          Type: 5 GoStringHeaderType string
+          Type: 9 GoStringHeaderType string
         - Name: passwordSet
           Offset: 32
-          Type: 13 BaseType bool
+          Type: 4 BaseType bool
     - __kind: GoMapType
-      ID: 33
+      ID: 57
       Name: net/url.Values
       ByteSize: 8
       GoRuntimeType: 1.92848e+06
       GoKind: 21
-      HeaderType: 16 GoSwissMapHeaderType map<string,[]string>
+      HeaderType: 45 GoSwissMapHeaderType map<string,[]string>
     - __kind: ArrayType
-      ID: 183
+      ID: 203
       Name: noalg.[8]struct { key string; elem *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute }
       ByteSize: 192
       GoRuntimeType: 715328
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 184 StructureType noalg.struct { key string; elem *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute }
+      Element: 204 StructureType noalg.struct { key string; elem *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute }
     - __kind: ArrayType
-      ID: 46
+      ID: 70
       Name: noalg.[8]struct { key string; elem []*mime/multipart.FileHeader }
       ByteSize: 320
       GoRuntimeType: 710944
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 47 StructureType noalg.struct { key string; elem []*mime/multipart.FileHeader }
+      Element: 71 StructureType noalg.struct { key string; elem []*mime/multipart.FileHeader }
     - __kind: ArrayType
-      ID: 26
+      ID: 52
       Name: noalg.[8]struct { key string; elem []string }
       ByteSize: 320
       GoRuntimeType: 701120
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 27 StructureType noalg.struct { key string; elem []string }
+      Element: 53 StructureType noalg.struct { key string; elem []string }
     - __kind: ArrayType
-      ID: 165
+      ID: 186
       Name: noalg.[8]struct { key string; elem float64 }
       ByteSize: 192
       GoRuntimeType: 715232
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 166 StructureType noalg.struct { key string; elem float64 }
+      Element: 187 StructureType noalg.struct { key string; elem float64 }
     - __kind: ArrayType
-      ID: 154
+      ID: 175
       Name: noalg.[8]struct { key string; elem interface {} }
       ByteSize: 256
       GoRuntimeType: 692576
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 155 StructureType noalg.struct { key string; elem interface {} }
+      Element: 176 StructureType noalg.struct { key string; elem interface {} }
     - __kind: ArrayType
-      ID: 133
+      ID: 156
       Name: noalg.[8]struct { key string; elem string }
       ByteSize: 256
       GoRuntimeType: 705280
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 134 StructureType noalg.struct { key string; elem string }
+      Element: 157 StructureType noalg.struct { key string; elem string }
     - __kind: StructureType
-      ID: 182
+      ID: 202
       Name: noalg.map.group[string]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
       ByteSize: 200
       GoRuntimeType: 1.332e+06
@@ -2964,12 +2964,12 @@ Types:
       RawFields:
         - Name: ctrl
           Offset: 0
-          Type: 17 BaseType uint64
+          Type: 8 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 183 ArrayType noalg.[8]struct { key string; elem *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute }
+          Type: 203 ArrayType noalg.[8]struct { key string; elem *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute }
     - __kind: StructureType
-      ID: 45
+      ID: 69
       Name: noalg.map.group[string][]*mime/multipart.FileHeader
       ByteSize: 328
       GoRuntimeType: 1.325728e+06
@@ -2977,12 +2977,12 @@ Types:
       RawFields:
         - Name: ctrl
           Offset: 0
-          Type: 17 BaseType uint64
+          Type: 8 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 46 ArrayType noalg.[8]struct { key string; elem []*mime/multipart.FileHeader }
+          Type: 70 ArrayType noalg.[8]struct { key string; elem []*mime/multipart.FileHeader }
     - __kind: StructureType
-      ID: 25
+      ID: 51
       Name: noalg.map.group[string][]string
       ByteSize: 328
       GoRuntimeType: 1.31664e+06
@@ -2990,12 +2990,12 @@ Types:
       RawFields:
         - Name: ctrl
           Offset: 0
-          Type: 17 BaseType uint64
+          Type: 8 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 26 ArrayType noalg.[8]struct { key string; elem []string }
+          Type: 52 ArrayType noalg.[8]struct { key string; elem []string }
     - __kind: StructureType
-      ID: 164
+      ID: 185
       Name: noalg.map.group[string]float64
       ByteSize: 200
       GoRuntimeType: 1.331744e+06
@@ -3003,12 +3003,12 @@ Types:
       RawFields:
         - Name: ctrl
           Offset: 0
-          Type: 17 BaseType uint64
+          Type: 8 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 165 ArrayType noalg.[8]struct { key string; elem float64 }
+          Type: 186 ArrayType noalg.[8]struct { key string; elem float64 }
     - __kind: StructureType
-      ID: 153
+      ID: 174
       Name: noalg.map.group[string]interface {}
       ByteSize: 264
       GoRuntimeType: 1.31408e+06
@@ -3016,12 +3016,12 @@ Types:
       RawFields:
         - Name: ctrl
           Offset: 0
-          Type: 17 BaseType uint64
+          Type: 8 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 154 ArrayType noalg.[8]struct { key string; elem interface {} }
+          Type: 175 ArrayType noalg.[8]struct { key string; elem interface {} }
     - __kind: StructureType
-      ID: 132
+      ID: 155
       Name: noalg.map.group[string]string
       ByteSize: 264
       GoRuntimeType: 1.319072e+06
@@ -3029,12 +3029,12 @@ Types:
       RawFields:
         - Name: ctrl
           Offset: 0
-          Type: 17 BaseType uint64
+          Type: 8 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 133 ArrayType noalg.[8]struct { key string; elem string }
+          Type: 156 ArrayType noalg.[8]struct { key string; elem string }
     - __kind: StructureType
-      ID: 184
+      ID: 204
       Name: noalg.struct { key string; elem *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute }
       ByteSize: 24
       GoRuntimeType: 1.331872e+06
@@ -3042,12 +3042,12 @@ Types:
       RawFields:
         - Name: key
           Offset: 0
-          Type: 5 GoStringHeaderType string
+          Type: 9 GoStringHeaderType string
         - Name: elem
           Offset: 16
-          Type: 185 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
+          Type: 205 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
     - __kind: StructureType
-      ID: 47
+      ID: 71
       Name: noalg.struct { key string; elem []*mime/multipart.FileHeader }
       ByteSize: 40
       GoRuntimeType: 1.3256e+06
@@ -3055,12 +3055,12 @@ Types:
       RawFields:
         - Name: key
           Offset: 0
-          Type: 5 GoStringHeaderType string
+          Type: 9 GoStringHeaderType string
         - Name: elem
           Offset: 16
-          Type: 48 GoSliceHeaderType []*mime/multipart.FileHeader
+          Type: 72 GoSliceHeaderType []*mime/multipart.FileHeader
     - __kind: StructureType
-      ID: 27
+      ID: 53
       Name: noalg.struct { key string; elem []string }
       ByteSize: 40
       GoRuntimeType: 1.316512e+06
@@ -3068,12 +3068,12 @@ Types:
       RawFields:
         - Name: key
           Offset: 0
-          Type: 5 GoStringHeaderType string
+          Type: 9 GoStringHeaderType string
         - Name: elem
           Offset: 16
-          Type: 28 GoSliceHeaderType []string
+          Type: 54 GoSliceHeaderType []string
     - __kind: StructureType
-      ID: 166
+      ID: 187
       Name: noalg.struct { key string; elem float64 }
       ByteSize: 24
       GoRuntimeType: 1.331616e+06
@@ -3081,12 +3081,12 @@ Types:
       RawFields:
         - Name: key
           Offset: 0
-          Type: 5 GoStringHeaderType string
+          Type: 9 GoStringHeaderType string
         - Name: elem
           Offset: 16
-          Type: 167 BaseType float64
+          Type: 15 BaseType float64
     - __kind: StructureType
-      ID: 155
+      ID: 176
       Name: noalg.struct { key string; elem interface {} }
       ByteSize: 32
       GoRuntimeType: 1.313952e+06
@@ -3094,12 +3094,12 @@ Types:
       RawFields:
         - Name: key
           Offset: 0
-          Type: 5 GoStringHeaderType string
+          Type: 9 GoStringHeaderType string
         - Name: elem
           Offset: 16
-          Type: 63 GoEmptyInterfaceType interface {}
+          Type: 87 GoEmptyInterfaceType interface {}
     - __kind: StructureType
-      ID: 134
+      ID: 157
       Name: noalg.struct { key string; elem string }
       ByteSize: 32
       GoRuntimeType: 1.318944e+06
@@ -3107,12 +3107,12 @@ Types:
       RawFields:
         - Name: key
           Offset: 0
-          Type: 5 GoStringHeaderType string
+          Type: 9 GoStringHeaderType string
         - Name: elem
           Offset: 16
-          Type: 5 GoStringHeaderType string
+          Type: 9 GoStringHeaderType string
     - __kind: GoStringHeaderType
-      ID: 5
+      ID: 9
       Name: string
       ByteSize: 16
       GoRuntimeType: 594208
@@ -3123,14 +3123,14 @@ Types:
           Type: 229 PointerType *string.str
         - Name: len
           Offset: 8
-          Type: 8 BaseType int
+          Type: 7 BaseType int
       Data: 228 GoStringDataType string.str
     - __kind: GoStringDataType
       ID: 228
       Name: string.str
       ByteSize: 2048
     - __kind: StructureType
-      ID: 138
+      ID: 161
       Name: sync.Mutex
       ByteSize: 8
       GoRuntimeType: 1.494336e+06
@@ -3138,12 +3138,12 @@ Types:
       RawFields:
         - Name: _
           Offset: 0
-          Type: 139 StructureType sync.noCopy
+          Type: 162 StructureType sync.noCopy
         - Name: mu
           Offset: 0
-          Type: 140 StructureType internal/sync.Mutex
+          Type: 163 StructureType internal/sync.Mutex
     - __kind: StructureType
-      ID: 137
+      ID: 160
       Name: sync.RWMutex
       ByteSize: 24
       GoRuntimeType: 1.88144e+06
@@ -3151,27 +3151,27 @@ Types:
       RawFields:
         - Name: w
           Offset: 0
-          Type: 138 StructureType sync.Mutex
+          Type: 161 StructureType sync.Mutex
         - Name: writerSem
           Offset: 8
-          Type: 142 BaseType uint32
+          Type: 2 BaseType uint32
         - Name: readerSem
           Offset: 12
-          Type: 142 BaseType uint32
+          Type: 2 BaseType uint32
         - Name: readerCount
           Offset: 16
-          Type: 143 StructureType sync/atomic.Int32
+          Type: 164 StructureType sync/atomic.Int32
         - Name: readerWait
           Offset: 20
-          Type: 143 StructureType sync/atomic.Int32
+          Type: 164 StructureType sync/atomic.Int32
     - __kind: StructureType
-      ID: 139
+      ID: 162
       Name: sync.noCopy
       GoRuntimeType: 1.007392e+06
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 143
+      ID: 164
       Name: sync/atomic.Int32
       ByteSize: 4
       GoRuntimeType: 1.495616e+06
@@ -3179,162 +3179,162 @@ Types:
       RawFields:
         - Name: _
           Offset: 0
-          Type: 144 StructureType sync/atomic.noCopy
+          Type: 165 StructureType sync/atomic.noCopy
         - Name: v
           Offset: 0
-          Type: 141 BaseType int32
+          Type: 10 BaseType int32
     - __kind: StructureType
-      ID: 144
+      ID: 165
       Name: sync/atomic.noCopy
       GoRuntimeType: 1.007488e+06
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 179
+      ID: 199
       Name: table<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
       ByteSize: 32
       GoKind: 25
       RawFields:
         - Name: used
           Offset: 0
-          Type: 22 BaseType uint16
+          Type: 6 BaseType uint16
         - Name: capacity
           Offset: 2
-          Type: 22 BaseType uint16
+          Type: 6 BaseType uint16
         - Name: growthLeft
           Offset: 4
-          Type: 22 BaseType uint16
+          Type: 6 BaseType uint16
         - Name: localDepth
           Offset: 6
-          Type: 7 BaseType uint8
+          Type: 3 BaseType uint8
         - Name: index
           Offset: 8
-          Type: 8 BaseType int
+          Type: 7 BaseType int
         - Name: groups
           Offset: 16
-          Type: 180 GoSwissMapGroupsType groupReference<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
+          Type: 200 GoSwissMapGroupsType groupReference<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
     - __kind: StructureType
-      ID: 42
+      ID: 66
       Name: table<string,[]*mime/multipart.FileHeader>
       ByteSize: 32
       GoKind: 25
       RawFields:
         - Name: used
           Offset: 0
-          Type: 22 BaseType uint16
+          Type: 6 BaseType uint16
         - Name: capacity
           Offset: 2
-          Type: 22 BaseType uint16
+          Type: 6 BaseType uint16
         - Name: growthLeft
           Offset: 4
-          Type: 22 BaseType uint16
+          Type: 6 BaseType uint16
         - Name: localDepth
           Offset: 6
-          Type: 7 BaseType uint8
+          Type: 3 BaseType uint8
         - Name: index
           Offset: 8
-          Type: 8 BaseType int
+          Type: 7 BaseType int
         - Name: groups
           Offset: 16
-          Type: 43 GoSwissMapGroupsType groupReference<string,[]*mime/multipart.FileHeader>
+          Type: 67 GoSwissMapGroupsType groupReference<string,[]*mime/multipart.FileHeader>
     - __kind: StructureType
-      ID: 21
+      ID: 48
       Name: table<string,[]string>
       ByteSize: 32
       GoKind: 25
       RawFields:
         - Name: used
           Offset: 0
-          Type: 22 BaseType uint16
+          Type: 6 BaseType uint16
         - Name: capacity
           Offset: 2
-          Type: 22 BaseType uint16
+          Type: 6 BaseType uint16
         - Name: growthLeft
           Offset: 4
-          Type: 22 BaseType uint16
+          Type: 6 BaseType uint16
         - Name: localDepth
           Offset: 6
-          Type: 7 BaseType uint8
+          Type: 3 BaseType uint8
         - Name: index
           Offset: 8
-          Type: 8 BaseType int
+          Type: 7 BaseType int
         - Name: groups
           Offset: 16
-          Type: 23 GoSwissMapGroupsType groupReference<string,[]string>
+          Type: 49 GoSwissMapGroupsType groupReference<string,[]string>
     - __kind: StructureType
-      ID: 161
+      ID: 182
       Name: table<string,float64>
       ByteSize: 32
       GoKind: 25
       RawFields:
         - Name: used
           Offset: 0
-          Type: 22 BaseType uint16
+          Type: 6 BaseType uint16
         - Name: capacity
           Offset: 2
-          Type: 22 BaseType uint16
+          Type: 6 BaseType uint16
         - Name: growthLeft
           Offset: 4
-          Type: 22 BaseType uint16
+          Type: 6 BaseType uint16
         - Name: localDepth
           Offset: 6
-          Type: 7 BaseType uint8
+          Type: 3 BaseType uint8
         - Name: index
           Offset: 8
-          Type: 8 BaseType int
+          Type: 7 BaseType int
         - Name: groups
           Offset: 16
-          Type: 162 GoSwissMapGroupsType groupReference<string,float64>
+          Type: 183 GoSwissMapGroupsType groupReference<string,float64>
     - __kind: StructureType
-      ID: 150
+      ID: 171
       Name: table<string,interface {}>
       ByteSize: 32
       GoKind: 25
       RawFields:
         - Name: used
           Offset: 0
-          Type: 22 BaseType uint16
+          Type: 6 BaseType uint16
         - Name: capacity
           Offset: 2
-          Type: 22 BaseType uint16
+          Type: 6 BaseType uint16
         - Name: growthLeft
           Offset: 4
-          Type: 22 BaseType uint16
+          Type: 6 BaseType uint16
         - Name: localDepth
           Offset: 6
-          Type: 7 BaseType uint8
+          Type: 3 BaseType uint8
         - Name: index
           Offset: 8
-          Type: 8 BaseType int
+          Type: 7 BaseType int
         - Name: groups
           Offset: 16
-          Type: 151 GoSwissMapGroupsType groupReference<string,interface {}>
+          Type: 172 GoSwissMapGroupsType groupReference<string,interface {}>
     - __kind: StructureType
-      ID: 129
+      ID: 152
       Name: table<string,string>
       ByteSize: 32
       GoKind: 25
       RawFields:
         - Name: used
           Offset: 0
-          Type: 22 BaseType uint16
+          Type: 6 BaseType uint16
         - Name: capacity
           Offset: 2
-          Type: 22 BaseType uint16
+          Type: 6 BaseType uint16
         - Name: growthLeft
           Offset: 4
-          Type: 22 BaseType uint16
+          Type: 6 BaseType uint16
         - Name: localDepth
           Offset: 6
-          Type: 7 BaseType uint8
+          Type: 3 BaseType uint8
         - Name: index
           Offset: 8
-          Type: 8 BaseType int
+          Type: 7 BaseType int
         - Name: groups
           Offset: 16
-          Type: 130 GoSwissMapGroupsType groupReference<string,string>
+          Type: 153 GoSwissMapGroupsType groupReference<string,string>
     - __kind: StructureType
-      ID: 77
+      ID: 100
       Name: time.Location
       ByteSize: 104
       GoRuntimeType: 2.014752e+06
@@ -3342,27 +3342,27 @@ Types:
       RawFields:
         - Name: name
           Offset: 0
-          Type: 5 GoStringHeaderType string
+          Type: 9 GoStringHeaderType string
         - Name: zone
           Offset: 16
-          Type: 78 GoSliceHeaderType []time.zone
+          Type: 101 GoSliceHeaderType []time.zone
         - Name: tx
           Offset: 40
-          Type: 81 GoSliceHeaderType []time.zoneTrans
+          Type: 104 GoSliceHeaderType []time.zoneTrans
         - Name: extend
           Offset: 64
-          Type: 5 GoStringHeaderType string
+          Type: 9 GoStringHeaderType string
         - Name: cacheStart
           Offset: 80
-          Type: 32 BaseType int64
+          Type: 12 BaseType int64
         - Name: cacheEnd
           Offset: 88
-          Type: 32 BaseType int64
+          Type: 12 BaseType int64
         - Name: cacheZone
           Offset: 96
-          Type: 79 PointerType *time.zone
+          Type: 102 PointerType *time.zone
     - __kind: StructureType
-      ID: 75
+      ID: 98
       Name: time.Time
       ByteSize: 24
       GoRuntimeType: 2.42976e+06
@@ -3370,15 +3370,15 @@ Types:
       RawFields:
         - Name: wall
           Offset: 0
-          Type: 17 BaseType uint64
+          Type: 8 BaseType uint64
         - Name: ext
           Offset: 8
-          Type: 32 BaseType int64
+          Type: 12 BaseType int64
         - Name: loc
           Offset: 16
-          Type: 76 PointerType *time.Location
+          Type: 99 PointerType *time.Location
     - __kind: StructureType
-      ID: 80
+      ID: 103
       Name: time.zone
       ByteSize: 32
       GoRuntimeType: 1.647488e+06
@@ -3386,15 +3386,15 @@ Types:
       RawFields:
         - Name: name
           Offset: 0
-          Type: 5 GoStringHeaderType string
+          Type: 9 GoStringHeaderType string
         - Name: offset
           Offset: 16
-          Type: 8 BaseType int
+          Type: 7 BaseType int
         - Name: isDST
           Offset: 24
-          Type: 13 BaseType bool
+          Type: 4 BaseType bool
     - __kind: StructureType
-      ID: 83
+      ID: 106
       Name: time.zoneTrans
       ByteSize: 16
       GoRuntimeType: 1.789472e+06
@@ -3402,54 +3402,54 @@ Types:
       RawFields:
         - Name: when
           Offset: 0
-          Type: 32 BaseType int64
+          Type: 12 BaseType int64
         - Name: index
           Offset: 8
-          Type: 7 BaseType uint8
+          Type: 3 BaseType uint8
         - Name: isstd
           Offset: 9
-          Type: 13 BaseType bool
+          Type: 4 BaseType bool
         - Name: isutc
           Offset: 10
-          Type: 13 BaseType bool
+          Type: 4 BaseType bool
     - __kind: BaseType
-      ID: 212
+      ID: 17
       Name: uint
       ByteSize: 8
       GoRuntimeType: 594848
       GoKind: 7
     - __kind: BaseType
-      ID: 22
+      ID: 6
       Name: uint16
       ByteSize: 2
       GoRuntimeType: 594464
       GoKind: 9
     - __kind: BaseType
-      ID: 142
+      ID: 2
       Name: uint32
       ByteSize: 4
       GoRuntimeType: 594592
       GoKind: 10
     - __kind: BaseType
-      ID: 17
+      ID: 8
       Name: uint64
       ByteSize: 8
       GoRuntimeType: 594720
       GoKind: 11
     - __kind: BaseType
-      ID: 7
+      ID: 3
       Name: uint8
       ByteSize: 1
       GoRuntimeType: 594336
       GoKind: 8
     - __kind: BaseType
-      ID: 18
+      ID: 1
       Name: uintptr
       ByteSize: 8
       GoRuntimeType: 594912
       GoKind: 12
     - __kind: VoidPointerType
-      ID: 2
+      ID: 14
       Name: unsafe.Pointer
       ByteSize: 8
       GoRuntimeType: 595296

--- a/pkg/dyninst/irgen/testdata/snapshot/rc_tester.arch=amd64,toolchain=go1.25.0.yaml
+++ b/pkg/dyninst/irgen/testdata/snapshot/rc_tester.arch=amd64,toolchain=go1.25.0.yaml
@@ -98,51 +98,51 @@ Subprograms:
           IsReturn: false
 Types:
     - __kind: PointerType
-      ID: 107
+      ID: 109
       Name: '**crypto/x509.Certificate'
       ByteSize: 8
       GoKind: 22
-      Pointee: 108 PointerType *crypto/x509.Certificate
+      Pointee: 110 PointerType *crypto/x509.Certificate
     - __kind: PointerType
-      ID: 146
+      ID: 173
       Name: '**github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span'
       ByteSize: 8
       GoKind: 22
       Pointee: 39 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span
     - __kind: PointerType
-      ID: 224
+      ID: 257
       Name: '**github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttributeValue'
       ByteSize: 8
       GoKind: 22
-      Pointee: 225 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttributeValue
+      Pointee: 258 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttributeValue
     - __kind: PointerType
-      ID: 201
+      ID: 181
       Name: '**mime/multipart.FileHeader'
       ByteSize: 8
       GoKind: 22
-      Pointee: 202 PointerType *mime/multipart.FileHeader
+      Pointee: 182 PointerType *mime/multipart.FileHeader
     - __kind: PointerType
-      ID: 181
+      ID: 229
       Name: '**net.IPNet'
       ByteSize: 8
       GoKind: 22
-      Pointee: 182 PointerType *net.IPNet
+      Pointee: 230 PointerType *net.IPNet
     - __kind: PointerType
-      ID: 179
+      ID: 227
       Name: '**net/url.URL'
       ByteSize: 8
       GoKind: 22
       Pointee: 43 PointerType *net/url.URL
     - __kind: PointerType
-      ID: 124
+      ID: 126
       Name: '**table<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>'
       ByteSize: 8
-      Pointee: 125 PointerType *table<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
+      Pointee: 127 PointerType *table<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
     - __kind: PointerType
-      ID: 103
+      ID: 105
       Name: '**table<string,[]*mime/multipart.FileHeader>'
       ByteSize: 8
-      Pointee: 104 PointerType *table<string,[]*mime/multipart.FileHeader>
+      Pointee: 106 PointerType *table<string,[]*mime/multipart.FileHeader>
     - __kind: PointerType
       ID: 48
       Name: '**table<string,[]string>'
@@ -164,128 +164,128 @@ Types:
       ByteSize: 8
       Pointee: 68 PointerType *table<string,string>
     - __kind: PointerType
-      ID: 110
+      ID: 112
       Name: '*[]*crypto/x509.Certificate'
       ByteSize: 8
       GoKind: 22
-      Pointee: 106 GoSliceHeaderType []*crypto/x509.Certificate
+      Pointee: 108 GoSliceHeaderType []*crypto/x509.Certificate
     - __kind: PointerType
-      ID: 249
+      ID: 186
       Name: '*[]*crypto/x509.Certificate.array'
       ByteSize: 8
-      Pointee: 248 GoSliceDataType []*crypto/x509.Certificate.array
+      Pointee: 185 GoSliceDataType []*crypto/x509.Certificate.array
     - __kind: PointerType
-      ID: 259
+      ID: 242
       Name: '*[]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span.array'
       ByteSize: 8
-      Pointee: 258 GoSliceDataType []*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span.array
+      Pointee: 241 GoSliceDataType []*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span.array
     - __kind: PointerType
-      ID: 293
+      ID: 290
       Name: '*[]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttributeValue.array'
       ByteSize: 8
-      Pointee: 292 GoSliceDataType []*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttributeValue.array
+      Pointee: 289 GoSliceDataType []*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttributeValue.array
     - __kind: PointerType
-      ID: 283
+      ID: 244
       Name: '*[]*mime/multipart.FileHeader.array'
       ByteSize: 8
-      Pointee: 282 GoSliceDataType []*mime/multipart.FileHeader.array
+      Pointee: 243 GoSliceDataType []*mime/multipart.FileHeader.array
     - __kind: PointerType
-      ID: 277
+      ID: 276
       Name: '*[]*net.IPNet.array'
       ByteSize: 8
-      Pointee: 276 GoSliceDataType []*net.IPNet.array
+      Pointee: 275 GoSliceDataType []*net.IPNet.array
     - __kind: PointerType
-      ID: 275
+      ID: 274
       Name: '*[]*net/url.URL.array'
       ByteSize: 8
-      Pointee: 274 GoSliceDataType []*net/url.URL.array
+      Pointee: 273 GoSliceDataType []*net/url.URL.array
     - __kind: PointerType
-      ID: 251
+      ID: 188
       Name: '*[][]*crypto/x509.Certificate.array'
       ByteSize: 8
-      Pointee: 250 GoSliceDataType [][]*crypto/x509.Certificate.array
+      Pointee: 187 GoSliceDataType [][]*crypto/x509.Certificate.array
     - __kind: PointerType
-      ID: 253
+      ID: 190
       Name: '*[][]uint8.array'
       ByteSize: 8
-      Pointee: 252 GoSliceDataType [][]uint8.array
+      Pointee: 189 GoSliceDataType [][]uint8.array
     - __kind: PointerType
-      ID: 269
+      ID: 268
       Name: '*[]crypto/x509.ExtKeyUsage.array'
       ByteSize: 8
-      Pointee: 268 GoSliceDataType []crypto/x509.ExtKeyUsage.array
+      Pointee: 267 GoSliceDataType []crypto/x509.ExtKeyUsage.array
     - __kind: PointerType
-      ID: 279
+      ID: 278
       Name: '*[]crypto/x509.OID.array'
       ByteSize: 8
-      Pointee: 278 GoSliceDataType []crypto/x509.OID.array
+      Pointee: 277 GoSliceDataType []crypto/x509.OID.array
     - __kind: PointerType
-      ID: 281
+      ID: 280
       Name: '*[]crypto/x509.PolicyMapping.array'
       ByteSize: 8
-      Pointee: 280 GoSliceDataType []crypto/x509.PolicyMapping.array
+      Pointee: 279 GoSliceDataType []crypto/x509.PolicyMapping.array
     - __kind: PointerType
-      ID: 261
+      ID: 260
       Name: '*[]crypto/x509/pkix.AttributeTypeAndValue.array'
       ByteSize: 8
-      Pointee: 260 GoSliceDataType []crypto/x509/pkix.AttributeTypeAndValue.array
+      Pointee: 259 GoSliceDataType []crypto/x509/pkix.AttributeTypeAndValue.array
     - __kind: PointerType
-      ID: 263
+      ID: 262
       Name: '*[]crypto/x509/pkix.Extension.array'
       ByteSize: 8
-      Pointee: 262 GoSliceDataType []crypto/x509/pkix.Extension.array
+      Pointee: 261 GoSliceDataType []crypto/x509/pkix.Extension.array
     - __kind: PointerType
-      ID: 265
+      ID: 264
       Name: '*[]encoding/asn1.ObjectIdentifier.array'
       ByteSize: 8
-      Pointee: 264 GoSliceDataType []encoding/asn1.ObjectIdentifier.array
+      Pointee: 263 GoSliceDataType []encoding/asn1.ObjectIdentifier.array
     - __kind: PointerType
-      ID: 241
+      ID: 164
       Name: '*[]github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink.array'
       ByteSize: 8
-      Pointee: 240 GoSliceDataType []github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink.array
+      Pointee: 163 GoSliceDataType []github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink.array
     - __kind: PointerType
-      ID: 243
+      ID: 166
       Name: '*[]github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent.array'
       ByteSize: 8
-      Pointee: 242 GoSliceDataType []github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent.array
+      Pointee: 165 GoSliceDataType []github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent.array
     - __kind: PointerType
-      ID: 271
+      ID: 270
       Name: '*[]net.IP.array'
       ByteSize: 8
-      Pointee: 270 GoSliceDataType []net.IP.array
+      Pointee: 269 GoSliceDataType []net.IP.array
     - __kind: PointerType
-      ID: 255
+      ID: 192
       Name: '*[]net/http.segment.array'
       ByteSize: 8
-      Pointee: 254 GoSliceDataType []net/http.segment.array
+      Pointee: 191 GoSliceDataType []net/http.segment.array
     - __kind: PointerType
-      ID: 233
+      ID: 140
       Name: '*[]string.array'
       ByteSize: 8
-      Pointee: 232 GoSliceDataType []string.array
+      Pointee: 139 GoSliceDataType []string.array
     - __kind: PointerType
-      ID: 287
+      ID: 286
       Name: '*[]time.zone.array'
       ByteSize: 8
-      Pointee: 286 GoSliceDataType []time.zone.array
+      Pointee: 285 GoSliceDataType []time.zone.array
     - __kind: PointerType
-      ID: 289
+      ID: 288
       Name: '*[]time.zoneTrans.array'
       ByteSize: 8
-      Pointee: 288 GoSliceDataType []time.zoneTrans.array
+      Pointee: 287 GoSliceDataType []time.zoneTrans.array
     - __kind: PointerType
-      ID: 112
+      ID: 114
       Name: '*[]uint8'
       ByteSize: 8
       GoRuntimeType: 486560
       GoKind: 22
       Pointee: 94 GoSliceHeaderType []uint8
     - __kind: PointerType
-      ID: 245
+      ID: 168
       Name: '*[]uint8.array'
       ByteSize: 8
-      Pointee: 244 GoSliceDataType []uint8.array
+      Pointee: 167 GoSliceDataType []uint8.array
     - __kind: PointerType
       ID: 11
       Name: '*bool'
@@ -308,59 +308,59 @@ Types:
       GoKind: 22
       Pointee: 57 StructureType crypto/tls.ConnectionState
     - __kind: PointerType
-      ID: 108
+      ID: 110
       Name: '*crypto/x509.Certificate'
       ByteSize: 8
       GoRuntimeType: 2.089664e+06
       GoKind: 22
-      Pointee: 134 StructureType crypto/x509.Certificate
+      Pointee: 170 StructureType crypto/x509.Certificate
     - __kind: PointerType
-      ID: 173
+      ID: 221
       Name: '*crypto/x509.ExtKeyUsage'
       ByteSize: 8
       GoRuntimeType: 429920
       GoKind: 22
-      Pointee: 174 BaseType crypto/x509.ExtKeyUsage
+      Pointee: 222 BaseType crypto/x509.ExtKeyUsage
     - __kind: PointerType
-      ID: 184
+      ID: 232
       Name: '*crypto/x509.OID'
       ByteSize: 8
       GoRuntimeType: 1.998112e+06
       GoKind: 22
-      Pointee: 185 StructureType crypto/x509.OID
+      Pointee: 233 StructureType crypto/x509.OID
     - __kind: PointerType
-      ID: 187
+      ID: 235
       Name: '*crypto/x509.PolicyMapping'
       ByteSize: 8
       GoRuntimeType: 429984
       GoKind: 22
-      Pointee: 188 StructureType crypto/x509.PolicyMapping
+      Pointee: 236 StructureType crypto/x509.PolicyMapping
     - __kind: PointerType
-      ID: 160
+      ID: 208
       Name: '*crypto/x509/pkix.AttributeTypeAndValue'
       ByteSize: 8
       GoRuntimeType: 446624
       GoKind: 22
-      Pointee: 161 StructureType crypto/x509/pkix.AttributeTypeAndValue
+      Pointee: 209 StructureType crypto/x509/pkix.AttributeTypeAndValue
     - __kind: PointerType
-      ID: 167
+      ID: 215
       Name: '*crypto/x509/pkix.Extension'
       ByteSize: 8
       GoRuntimeType: 446816
       GoKind: 22
-      Pointee: 168 StructureType crypto/x509/pkix.Extension
+      Pointee: 216 StructureType crypto/x509/pkix.Extension
     - __kind: PointerType
-      ID: 170
+      ID: 218
       Name: '*encoding/asn1.ObjectIdentifier'
       ByteSize: 8
       GoRuntimeType: 1.079776e+06
       GoKind: 22
-      Pointee: 171 GoSliceHeaderType encoding/asn1.ObjectIdentifier
+      Pointee: 219 GoSliceHeaderType encoding/asn1.ObjectIdentifier
     - __kind: PointerType
-      ID: 267
+      ID: 266
       Name: '*encoding/asn1.ObjectIdentifier.array'
       ByteSize: 8
-      Pointee: 266 GoSliceDataType encoding/asn1.ObjectIdentifier.array
+      Pointee: 265 GoSliceDataType encoding/asn1.ObjectIdentifier.array
     - __kind: PointerType
       ID: 33
       Name: '*error'
@@ -411,33 +411,33 @@ Types:
       GoKind: 22
       Pointee: 90 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent
     - __kind: PointerType
-      ID: 220
+      ID: 239
       Name: '*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttribute'
       ByteSize: 8
       GoRuntimeType: 1.215328e+06
       GoKind: 22
-      Pointee: 221 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttribute
+      Pointee: 240 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttribute
     - __kind: PointerType
-      ID: 225
+      ID: 258
       Name: '*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttributeValue'
       ByteSize: 8
       GoRuntimeType: 1.215072e+06
       GoKind: 22
-      Pointee: 226 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttributeValue
+      Pointee: 282 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttributeValue
     - __kind: PointerType
-      ID: 215
+      ID: 198
       Name: '*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute'
       ByteSize: 8
       GoRuntimeType: 1.215456e+06
       GoKind: 22
-      Pointee: 216 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
+      Pointee: 199 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
     - __kind: PointerType
-      ID: 127
+      ID: 129
       Name: '*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.trace'
       ByteSize: 8
       GoRuntimeType: 2.277568e+06
       GoKind: 22
-      Pointee: 128 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.trace
+      Pointee: 130 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.trace
     - __kind: PointerType
       ID: 26
       Name: '*int'
@@ -474,15 +474,15 @@ Types:
       GoKind: 22
       Pointee: 16 BaseType int8
     - __kind: PointerType
-      ID: 122
+      ID: 124
       Name: '*map<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>'
       ByteSize: 8
-      Pointee: 123 GoSwissMapHeaderType map<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
+      Pointee: 125 GoSwissMapHeaderType map<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
     - __kind: PointerType
-      ID: 101
+      ID: 103
       Name: '*map<string,[]*mime/multipart.FileHeader>'
       ByteSize: 8
-      Pointee: 102 GoSwissMapHeaderType map<string,[]*mime/multipart.FileHeader>
+      Pointee: 104 GoSwissMapHeaderType map<string,[]*mime/multipart.FileHeader>
     - __kind: PointerType
       ID: 46
       Name: '*map<string,[]string>'
@@ -504,31 +504,31 @@ Types:
       ByteSize: 8
       Pointee: 66 GoSwissMapHeaderType map<string,string>
     - __kind: PointerType
-      ID: 156
+      ID: 204
       Name: '*math/big.Int'
       ByteSize: 8
       GoRuntimeType: 2.447424e+06
       GoKind: 22
-      Pointee: 157 StructureType math/big.Int
+      Pointee: 205 StructureType math/big.Int
     - __kind: PointerType
-      ID: 204
+      ID: 246
       Name: '*math/big.Word'
       ByteSize: 8
       GoRuntimeType: 432800
       GoKind: 22
-      Pointee: 205 BaseType math/big.Word
+      Pointee: 247 BaseType math/big.Word
     - __kind: PointerType
-      ID: 285
+      ID: 284
       Name: '*math/big.nat.array'
       ByteSize: 8
-      Pointee: 284 GoSliceDataType math/big.nat.array
+      Pointee: 283 GoSliceDataType math/big.nat.array
     - __kind: PointerType
-      ID: 202
+      ID: 182
       Name: '*mime/multipart.FileHeader'
       ByteSize: 8
       GoRuntimeType: 925568
       GoKind: 22
-      Pointee: 217 StructureType mime/multipart.FileHeader
+      Pointee: 237 StructureType mime/multipart.FileHeader
     - __kind: PointerType
       ID: 54
       Name: '*mime/multipart.Form'
@@ -537,29 +537,29 @@ Types:
       GoKind: 22
       Pointee: 55 StructureType mime/multipart.Form
     - __kind: PointerType
-      ID: 176
+      ID: 224
       Name: '*net.IP'
       ByteSize: 8
       GoRuntimeType: 2.206912e+06
       GoKind: 22
-      Pointee: 177 GoSliceHeaderType net.IP
+      Pointee: 225 GoSliceHeaderType net.IP
     - __kind: PointerType
-      ID: 273
+      ID: 272
       Name: '*net.IP.array'
       ByteSize: 8
-      Pointee: 272 GoSliceDataType net.IP.array
+      Pointee: 271 GoSliceDataType net.IP.array
     - __kind: PointerType
-      ID: 291
+      ID: 293
       Name: '*net.IPMask.array'
       ByteSize: 8
-      Pointee: 290 GoSliceDataType net.IPMask.array
+      Pointee: 292 GoSliceDataType net.IPMask.array
     - __kind: PointerType
-      ID: 182
+      ID: 230
       Name: '*net.IPNet'
       ByteSize: 8
       GoRuntimeType: 1.208416e+06
       GoKind: 22
-      Pointee: 212 StructureType net.IPNet
+      Pointee: 254 StructureType net.IPNet
     - __kind: PointerType
       ID: 37
       Name: '*net/http.Request'
@@ -582,12 +582,12 @@ Types:
       GoKind: 22
       Pointee: 63 StructureType net/http.pattern
     - __kind: PointerType
-      ID: 116
+      ID: 118
       Name: '*net/http.segment'
       ByteSize: 8
       GoRuntimeType: 396384
       GoKind: 22
-      Pointee: 117 StructureType net/http.segment
+      Pointee: 119 StructureType net/http.segment
     - __kind: PointerType
       ID: 43
       Name: '*net/url.URL'
@@ -596,42 +596,42 @@ Types:
       GoKind: 22
       Pointee: 44 StructureType net/url.URL
     - __kind: PointerType
-      ID: 96
+      ID: 98
       Name: '*net/url.Userinfo'
       ByteSize: 8
       GoRuntimeType: 1.22608e+06
       GoKind: 22
-      Pointee: 97 StructureType net/url.Userinfo
+      Pointee: 99 StructureType net/url.Userinfo
     - __kind: PointerType
-      ID: 196
+      ID: 194
       Name: '*noalg.map.group[string]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute'
       ByteSize: 8
-      Pointee: 197 StructureType noalg.map.group[string]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
+      Pointee: 195 StructureType noalg.map.group[string]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
     - __kind: PointerType
-      ID: 151
+      ID: 176
       Name: '*noalg.map.group[string][]*mime/multipart.FileHeader'
       ByteSize: 8
-      Pointee: 152 StructureType noalg.map.group[string][]*mime/multipart.FileHeader
+      Pointee: 177 StructureType noalg.map.group[string][]*mime/multipart.FileHeader
     - __kind: PointerType
-      ID: 131
+      ID: 133
       Name: '*noalg.map.group[string][]string'
       ByteSize: 8
-      Pointee: 132 StructureType noalg.map.group[string][]string
+      Pointee: 134 StructureType noalg.map.group[string][]string
     - __kind: PointerType
-      ID: 142
+      ID: 157
       Name: '*noalg.map.group[string]float64'
       ByteSize: 8
-      Pointee: 143 StructureType noalg.map.group[string]float64
+      Pointee: 158 StructureType noalg.map.group[string]float64
     - __kind: PointerType
-      ID: 139
+      ID: 149
       Name: '*noalg.map.group[string]interface {}'
       ByteSize: 8
-      Pointee: 140 StructureType noalg.map.group[string]interface {}
+      Pointee: 150 StructureType noalg.map.group[string]interface {}
     - __kind: PointerType
-      ID: 136
+      ID: 142
       Name: '*noalg.map.group[string]string'
       ByteSize: 8
-      Pointee: 137 StructureType noalg.map.group[string]string
+      Pointee: 143 StructureType noalg.map.group[string]string
     - __kind: PointerType
       ID: 22
       Name: '*string'
@@ -640,61 +640,61 @@ Types:
       GoKind: 22
       Pointee: 9 GoStringHeaderType string
     - __kind: PointerType
-      ID: 229
+      ID: 97
       Name: '*string.str'
       ByteSize: 8
-      Pointee: 228 GoStringDataType string.str
+      Pointee: 96 GoStringDataType string.str
     - __kind: PointerType
-      ID: 125
+      ID: 127
       Name: '*table<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>'
       ByteSize: 8
-      Pointee: 144 StructureType table<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
+      Pointee: 171 StructureType table<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
     - __kind: PointerType
-      ID: 104
+      ID: 106
       Name: '*table<string,[]*mime/multipart.FileHeader>'
       ByteSize: 8
-      Pointee: 133 StructureType table<string,[]*mime/multipart.FileHeader>
+      Pointee: 169 StructureType table<string,[]*mime/multipart.FileHeader>
     - __kind: PointerType
       ID: 49
       Name: '*table<string,[]string>'
       ByteSize: 8
-      Pointee: 98 StructureType table<string,[]string>
+      Pointee: 100 StructureType table<string,[]string>
     - __kind: PointerType
       ID: 84
       Name: '*table<string,float64>'
       ByteSize: 8
-      Pointee: 120 StructureType table<string,float64>
+      Pointee: 122 StructureType table<string,float64>
     - __kind: PointerType
       ID: 79
       Name: '*table<string,interface {}>'
       ByteSize: 8
-      Pointee: 119 StructureType table<string,interface {}>
+      Pointee: 121 StructureType table<string,interface {}>
     - __kind: PointerType
       ID: 68
       Name: '*table<string,string>'
       ByteSize: 8
-      Pointee: 118 StructureType table<string,string>
+      Pointee: 120 StructureType table<string,string>
     - __kind: PointerType
-      ID: 163
+      ID: 211
       Name: '*time.Location'
       ByteSize: 8
       GoRuntimeType: 1.64768e+06
       GoKind: 22
-      Pointee: 164 StructureType time.Location
+      Pointee: 212 StructureType time.Location
     - __kind: PointerType
-      ID: 207
+      ID: 249
       Name: '*time.zone'
       ByteSize: 8
       GoRuntimeType: 399456
       GoKind: 22
-      Pointee: 208 StructureType time.zone
+      Pointee: 250 StructureType time.zone
     - __kind: PointerType
-      ID: 210
+      ID: 252
       Name: '*time.zoneTrans'
       ByteSize: 8
       GoRuntimeType: 399520
       GoKind: 22
-      Pointee: 211 StructureType time.zoneTrans
+      Pointee: 253 StructureType time.zoneTrans
     - __kind: PointerType
       ID: 34
       Name: '*uint'
@@ -782,7 +782,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: GoSliceHeaderType
-      ID: 106
+      ID: 108
       Name: '[]*crypto/x509.Certificate'
       ByteSize: 24
       GoRuntimeType: 507488
@@ -790,21 +790,21 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 107 PointerType **crypto/x509.Certificate
+          Type: 109 PointerType **crypto/x509.Certificate
         - Name: len
           Offset: 8
           Type: 7 BaseType int
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 248 GoSliceDataType []*crypto/x509.Certificate.array
+      Data: 185 GoSliceDataType []*crypto/x509.Certificate.array
     - __kind: GoSliceDataType
-      ID: 248
+      ID: 185
       Name: '[]*crypto/x509.Certificate.array'
       ByteSize: 2048
-      Element: 108 PointerType *crypto/x509.Certificate
+      Element: 110 PointerType *crypto/x509.Certificate
     - __kind: GoSliceHeaderType
-      ID: 145
+      ID: 172
       Name: '[]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span'
       ByteSize: 24
       GoRuntimeType: 495232
@@ -812,21 +812,21 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 146 PointerType **github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span
+          Type: 173 PointerType **github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span
         - Name: len
           Offset: 8
           Type: 7 BaseType int
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 258 GoSliceDataType []*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span.array
+      Data: 241 GoSliceDataType []*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span.array
     - __kind: GoSliceDataType
-      ID: 258
+      ID: 241
       Name: '[]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span.array'
       ByteSize: 2048
       Element: 39 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span
     - __kind: GoSliceHeaderType
-      ID: 223
+      ID: 256
       Name: '[]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttributeValue'
       ByteSize: 24
       GoRuntimeType: 494848
@@ -834,21 +834,21 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 224 PointerType **github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttributeValue
+          Type: 257 PointerType **github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttributeValue
         - Name: len
           Offset: 8
           Type: 7 BaseType int
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 292 GoSliceDataType []*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttributeValue.array
+      Data: 289 GoSliceDataType []*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttributeValue.array
     - __kind: GoSliceDataType
-      ID: 292
+      ID: 289
       Name: '[]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttributeValue.array'
       ByteSize: 2048
-      Element: 225 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttributeValue
+      Element: 258 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttributeValue
     - __kind: GoSliceHeaderType
-      ID: 200
+      ID: 180
       Name: '[]*mime/multipart.FileHeader'
       ByteSize: 24
       GoRuntimeType: 492224
@@ -856,21 +856,21 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 201 PointerType **mime/multipart.FileHeader
+          Type: 181 PointerType **mime/multipart.FileHeader
         - Name: len
           Offset: 8
           Type: 7 BaseType int
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 282 GoSliceDataType []*mime/multipart.FileHeader.array
+      Data: 243 GoSliceDataType []*mime/multipart.FileHeader.array
     - __kind: GoSliceDataType
-      ID: 282
+      ID: 243
       Name: '[]*mime/multipart.FileHeader.array'
       ByteSize: 2048
-      Element: 202 PointerType *mime/multipart.FileHeader
+      Element: 182 PointerType *mime/multipart.FileHeader
     - __kind: GoSliceHeaderType
-      ID: 180
+      ID: 228
       Name: '[]*net.IPNet'
       ByteSize: 24
       GoRuntimeType: 509088
@@ -878,21 +878,21 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 181 PointerType **net.IPNet
+          Type: 229 PointerType **net.IPNet
         - Name: len
           Offset: 8
           Type: 7 BaseType int
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 276 GoSliceDataType []*net.IPNet.array
+      Data: 275 GoSliceDataType []*net.IPNet.array
     - __kind: GoSliceDataType
-      ID: 276
+      ID: 275
       Name: '[]*net.IPNet.array'
       ByteSize: 2048
-      Element: 182 PointerType *net.IPNet
+      Element: 230 PointerType *net.IPNet
     - __kind: GoSliceHeaderType
-      ID: 178
+      ID: 226
       Name: '[]*net/url.URL'
       ByteSize: 24
       GoRuntimeType: 509024
@@ -900,51 +900,51 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 179 PointerType **net/url.URL
+          Type: 227 PointerType **net/url.URL
         - Name: len
           Offset: 8
           Type: 7 BaseType int
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 274 GoSliceDataType []*net/url.URL.array
+      Data: 273 GoSliceDataType []*net/url.URL.array
     - __kind: GoSliceDataType
-      ID: 274
+      ID: 273
       Name: '[]*net/url.URL.array'
       ByteSize: 2048
       Element: 43 PointerType *net/url.URL
     - __kind: GoSliceDataType
-      ID: 256
+      ID: 200
       Name: '[]*table<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>.array'
       ByteSize: 8192
-      Element: 125 PointerType *table<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
+      Element: 127 PointerType *table<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
     - __kind: GoSliceDataType
-      ID: 246
+      ID: 183
       Name: '[]*table<string,[]*mime/multipart.FileHeader>.array'
       ByteSize: 8192
-      Element: 104 PointerType *table<string,[]*mime/multipart.FileHeader>
+      Element: 106 PointerType *table<string,[]*mime/multipart.FileHeader>
     - __kind: GoSliceDataType
-      ID: 230
+      ID: 137
       Name: '[]*table<string,[]string>.array'
       ByteSize: 8192
       Element: 49 PointerType *table<string,[]string>
     - __kind: GoSliceDataType
-      ID: 238
+      ID: 161
       Name: '[]*table<string,float64>.array'
       ByteSize: 8192
       Element: 84 PointerType *table<string,float64>
     - __kind: GoSliceDataType
-      ID: 236
+      ID: 154
       Name: '[]*table<string,interface {}>.array'
       ByteSize: 8192
       Element: 79 PointerType *table<string,interface {}>
     - __kind: GoSliceDataType
-      ID: 234
+      ID: 146
       Name: '[]*table<string,string>.array'
       ByteSize: 8192
       Element: 68 PointerType *table<string,string>
     - __kind: GoSliceHeaderType
-      ID: 109
+      ID: 111
       Name: '[][]*crypto/x509.Certificate'
       ByteSize: 24
       GoRuntimeType: 507552
@@ -952,21 +952,21 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 110 PointerType *[]*crypto/x509.Certificate
+          Type: 112 PointerType *[]*crypto/x509.Certificate
         - Name: len
           Offset: 8
           Type: 7 BaseType int
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 250 GoSliceDataType [][]*crypto/x509.Certificate.array
+      Data: 187 GoSliceDataType [][]*crypto/x509.Certificate.array
     - __kind: GoSliceDataType
-      ID: 250
+      ID: 187
       Name: '[][]*crypto/x509.Certificate.array'
       ByteSize: 2048
-      Element: 106 GoSliceHeaderType []*crypto/x509.Certificate
+      Element: 108 GoSliceHeaderType []*crypto/x509.Certificate
     - __kind: GoSliceHeaderType
-      ID: 111
+      ID: 113
       Name: '[][]uint8'
       ByteSize: 24
       GoRuntimeType: 486880
@@ -974,21 +974,21 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 112 PointerType *[]uint8
+          Type: 114 PointerType *[]uint8
         - Name: len
           Offset: 8
           Type: 7 BaseType int
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 252 GoSliceDataType [][]uint8.array
+      Data: 189 GoSliceDataType [][]uint8.array
     - __kind: GoSliceDataType
-      ID: 252
+      ID: 189
       Name: '[][]uint8.array'
       ByteSize: 2048
       Element: 94 GoSliceHeaderType []uint8
     - __kind: GoSliceHeaderType
-      ID: 172
+      ID: 220
       Name: '[]crypto/x509.ExtKeyUsage'
       ByteSize: 24
       GoRuntimeType: 508960
@@ -996,21 +996,21 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 173 PointerType *crypto/x509.ExtKeyUsage
+          Type: 221 PointerType *crypto/x509.ExtKeyUsage
         - Name: len
           Offset: 8
           Type: 7 BaseType int
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 268 GoSliceDataType []crypto/x509.ExtKeyUsage.array
+      Data: 267 GoSliceDataType []crypto/x509.ExtKeyUsage.array
     - __kind: GoSliceDataType
-      ID: 268
+      ID: 267
       Name: '[]crypto/x509.ExtKeyUsage.array'
       ByteSize: 2048
-      Element: 174 BaseType crypto/x509.ExtKeyUsage
+      Element: 222 BaseType crypto/x509.ExtKeyUsage
     - __kind: GoSliceHeaderType
-      ID: 183
+      ID: 231
       Name: '[]crypto/x509.OID'
       ByteSize: 24
       GoRuntimeType: 509152
@@ -1018,21 +1018,21 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 184 PointerType *crypto/x509.OID
+          Type: 232 PointerType *crypto/x509.OID
         - Name: len
           Offset: 8
           Type: 7 BaseType int
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 278 GoSliceDataType []crypto/x509.OID.array
+      Data: 277 GoSliceDataType []crypto/x509.OID.array
     - __kind: GoSliceDataType
-      ID: 278
+      ID: 277
       Name: '[]crypto/x509.OID.array'
       ByteSize: 2048
-      Element: 185 StructureType crypto/x509.OID
+      Element: 233 StructureType crypto/x509.OID
     - __kind: GoSliceHeaderType
-      ID: 186
+      ID: 234
       Name: '[]crypto/x509.PolicyMapping'
       ByteSize: 24
       GoRuntimeType: 509216
@@ -1040,21 +1040,21 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 187 PointerType *crypto/x509.PolicyMapping
+          Type: 235 PointerType *crypto/x509.PolicyMapping
         - Name: len
           Offset: 8
           Type: 7 BaseType int
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 280 GoSliceDataType []crypto/x509.PolicyMapping.array
+      Data: 279 GoSliceDataType []crypto/x509.PolicyMapping.array
     - __kind: GoSliceDataType
-      ID: 280
+      ID: 279
       Name: '[]crypto/x509.PolicyMapping.array'
       ByteSize: 2048
-      Element: 188 StructureType crypto/x509.PolicyMapping
+      Element: 236 StructureType crypto/x509.PolicyMapping
     - __kind: GoSliceHeaderType
-      ID: 159
+      ID: 207
       Name: '[]crypto/x509/pkix.AttributeTypeAndValue'
       ByteSize: 24
       GoRuntimeType: 523680
@@ -1062,21 +1062,21 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 160 PointerType *crypto/x509/pkix.AttributeTypeAndValue
+          Type: 208 PointerType *crypto/x509/pkix.AttributeTypeAndValue
         - Name: len
           Offset: 8
           Type: 7 BaseType int
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 260 GoSliceDataType []crypto/x509/pkix.AttributeTypeAndValue.array
+      Data: 259 GoSliceDataType []crypto/x509/pkix.AttributeTypeAndValue.array
     - __kind: GoSliceDataType
-      ID: 260
+      ID: 259
       Name: '[]crypto/x509/pkix.AttributeTypeAndValue.array'
       ByteSize: 2048
-      Element: 161 StructureType crypto/x509/pkix.AttributeTypeAndValue
+      Element: 209 StructureType crypto/x509/pkix.AttributeTypeAndValue
     - __kind: GoSliceHeaderType
-      ID: 166
+      ID: 214
       Name: '[]crypto/x509/pkix.Extension'
       ByteSize: 24
       GoRuntimeType: 508832
@@ -1084,21 +1084,21 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 167 PointerType *crypto/x509/pkix.Extension
+          Type: 215 PointerType *crypto/x509/pkix.Extension
         - Name: len
           Offset: 8
           Type: 7 BaseType int
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 262 GoSliceDataType []crypto/x509/pkix.Extension.array
+      Data: 261 GoSliceDataType []crypto/x509/pkix.Extension.array
     - __kind: GoSliceDataType
-      ID: 262
+      ID: 261
       Name: '[]crypto/x509/pkix.Extension.array'
       ByteSize: 2048
-      Element: 168 StructureType crypto/x509/pkix.Extension
+      Element: 216 StructureType crypto/x509/pkix.Extension
     - __kind: GoSliceHeaderType
-      ID: 169
+      ID: 217
       Name: '[]encoding/asn1.ObjectIdentifier'
       ByteSize: 24
       GoRuntimeType: 508896
@@ -1106,19 +1106,19 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 170 PointerType *encoding/asn1.ObjectIdentifier
+          Type: 218 PointerType *encoding/asn1.ObjectIdentifier
         - Name: len
           Offset: 8
           Type: 7 BaseType int
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 264 GoSliceDataType []encoding/asn1.ObjectIdentifier.array
+      Data: 263 GoSliceDataType []encoding/asn1.ObjectIdentifier.array
     - __kind: GoSliceDataType
-      ID: 264
+      ID: 263
       Name: '[]encoding/asn1.ObjectIdentifier.array'
       ByteSize: 2048
-      Element: 171 GoSliceHeaderType encoding/asn1.ObjectIdentifier
+      Element: 219 GoSliceHeaderType encoding/asn1.ObjectIdentifier
     - __kind: GoSliceHeaderType
       ID: 85
       Name: '[]github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink'
@@ -1135,9 +1135,9 @@ Types:
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 240 GoSliceDataType []github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink.array
+      Data: 163 GoSliceDataType []github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink.array
     - __kind: GoSliceDataType
-      ID: 240
+      ID: 163
       Name: '[]github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink.array'
       ByteSize: 2048
       Element: 87 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink
@@ -1157,14 +1157,14 @@ Types:
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 242 GoSliceDataType []github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent.array
+      Data: 165 GoSliceDataType []github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent.array
     - __kind: GoSliceDataType
-      ID: 242
+      ID: 165
       Name: '[]github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent.array'
       ByteSize: 2048
       Element: 90 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent
     - __kind: GoSliceHeaderType
-      ID: 175
+      ID: 223
       Name: '[]net.IP'
       ByteSize: 24
       GoRuntimeType: 487904
@@ -1172,21 +1172,21 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 176 PointerType *net.IP
+          Type: 224 PointerType *net.IP
         - Name: len
           Offset: 8
           Type: 7 BaseType int
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 270 GoSliceDataType []net.IP.array
+      Data: 269 GoSliceDataType []net.IP.array
     - __kind: GoSliceDataType
-      ID: 270
+      ID: 269
       Name: '[]net.IP.array'
       ByteSize: 2048
-      Element: 177 GoSliceHeaderType net.IP
+      Element: 225 GoSliceHeaderType net.IP
     - __kind: GoSliceHeaderType
-      ID: 115
+      ID: 117
       Name: '[]net/http.segment'
       ByteSize: 24
       GoRuntimeType: 489600
@@ -1194,49 +1194,49 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 116 PointerType *net/http.segment
+          Type: 118 PointerType *net/http.segment
         - Name: len
           Offset: 8
           Type: 7 BaseType int
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 254 GoSliceDataType []net/http.segment.array
+      Data: 191 GoSliceDataType []net/http.segment.array
     - __kind: GoSliceDataType
-      ID: 254
+      ID: 191
       Name: '[]net/http.segment.array'
       ByteSize: 2048
-      Element: 117 StructureType net/http.segment
+      Element: 119 StructureType net/http.segment
     - __kind: GoSliceDataType
-      ID: 257
+      ID: 201
       Name: '[]noalg.map.group[string]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute.array'
       ByteSize: 2048
-      Element: 197 StructureType noalg.map.group[string]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
+      Element: 195 StructureType noalg.map.group[string]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
     - __kind: GoSliceDataType
-      ID: 247
+      ID: 184
       Name: '[]noalg.map.group[string][]*mime/multipart.FileHeader.array'
       ByteSize: 2048
-      Element: 152 StructureType noalg.map.group[string][]*mime/multipart.FileHeader
+      Element: 177 StructureType noalg.map.group[string][]*mime/multipart.FileHeader
     - __kind: GoSliceDataType
-      ID: 231
+      ID: 138
       Name: '[]noalg.map.group[string][]string.array'
       ByteSize: 2048
-      Element: 132 StructureType noalg.map.group[string][]string
+      Element: 134 StructureType noalg.map.group[string][]string
     - __kind: GoSliceDataType
-      ID: 239
+      ID: 162
       Name: '[]noalg.map.group[string]float64.array'
       ByteSize: 2048
-      Element: 143 StructureType noalg.map.group[string]float64
+      Element: 158 StructureType noalg.map.group[string]float64
     - __kind: GoSliceDataType
-      ID: 237
+      ID: 155
       Name: '[]noalg.map.group[string]interface {}.array'
       ByteSize: 2048
-      Element: 140 StructureType noalg.map.group[string]interface {}
+      Element: 150 StructureType noalg.map.group[string]interface {}
     - __kind: GoSliceDataType
-      ID: 235
+      ID: 147
       Name: '[]noalg.map.group[string]string.array'
       ByteSize: 2048
-      Element: 137 StructureType noalg.map.group[string]string
+      Element: 143 StructureType noalg.map.group[string]string
     - __kind: GoSliceHeaderType
       ID: 52
       Name: '[]string'
@@ -1253,14 +1253,14 @@ Types:
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 232 GoSliceDataType []string.array
+      Data: 139 GoSliceDataType []string.array
     - __kind: GoSliceDataType
-      ID: 232
+      ID: 139
       Name: '[]string.array'
       ByteSize: 2048
       Element: 9 GoStringHeaderType string
     - __kind: GoSliceHeaderType
-      ID: 206
+      ID: 248
       Name: '[]time.zone'
       ByteSize: 24
       GoRuntimeType: 494336
@@ -1268,21 +1268,21 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 207 PointerType *time.zone
+          Type: 249 PointerType *time.zone
         - Name: len
           Offset: 8
           Type: 7 BaseType int
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 286 GoSliceDataType []time.zone.array
+      Data: 285 GoSliceDataType []time.zone.array
     - __kind: GoSliceDataType
-      ID: 286
+      ID: 285
       Name: '[]time.zone.array'
       ByteSize: 2048
-      Element: 208 StructureType time.zone
+      Element: 250 StructureType time.zone
     - __kind: GoSliceHeaderType
-      ID: 209
+      ID: 251
       Name: '[]time.zoneTrans'
       ByteSize: 24
       GoRuntimeType: 494400
@@ -1290,19 +1290,19 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 210 PointerType *time.zoneTrans
+          Type: 252 PointerType *time.zoneTrans
         - Name: len
           Offset: 8
           Type: 7 BaseType int
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 288 GoSliceDataType []time.zoneTrans.array
+      Data: 287 GoSliceDataType []time.zoneTrans.array
     - __kind: GoSliceDataType
-      ID: 288
+      ID: 287
       Name: '[]time.zoneTrans.array'
       ByteSize: 2048
-      Element: 211 StructureType time.zoneTrans
+      Element: 253 StructureType time.zoneTrans
     - __kind: GoSliceHeaderType
       ID: 94
       Name: '[]uint8'
@@ -1319,9 +1319,9 @@ Types:
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 244 GoSliceDataType []uint8.array
+      Data: 167 GoSliceDataType []uint8.array
     - __kind: GoSliceDataType
-      ID: 244
+      ID: 167
       Name: '[]uint8.array'
       ByteSize: 2048
       Element: 3 BaseType uint8
@@ -1399,7 +1399,7 @@ Types:
           Type: 6 BaseType uint16
         - Name: CurveID
           Offset: 6
-          Type: 105 BaseType crypto/tls.CurveID
+          Type: 107 BaseType crypto/tls.CurveID
         - Name: NegotiatedProtocol
           Offset: 8
           Type: 9 GoStringHeaderType string
@@ -1411,13 +1411,13 @@ Types:
           Type: 9 GoStringHeaderType string
         - Name: PeerCertificates
           Offset: 48
-          Type: 106 GoSliceHeaderType []*crypto/x509.Certificate
+          Type: 108 GoSliceHeaderType []*crypto/x509.Certificate
         - Name: VerifiedChains
           Offset: 72
-          Type: 109 GoSliceHeaderType [][]*crypto/x509.Certificate
+          Type: 111 GoSliceHeaderType [][]*crypto/x509.Certificate
         - Name: SignedCertificateTimestamps
           Offset: 96
-          Type: 111 GoSliceHeaderType [][]uint8
+          Type: 113 GoSliceHeaderType [][]uint8
         - Name: OCSPResponse
           Offset: 120
           Type: 94 GoSliceHeaderType []uint8
@@ -1429,27 +1429,27 @@ Types:
           Type: 4 BaseType bool
         - Name: ekm
           Offset: 176
-          Type: 113 GoSubroutineType func(string, []uint8, int) ([]uint8, error)
+          Type: 115 GoSubroutineType func(string, []uint8, int) ([]uint8, error)
         - Name: testingOnlyDidHRR
           Offset: 184
           Type: 4 BaseType bool
         - Name: testingOnlyPeerSignatureAlgorithm
           Offset: 186
-          Type: 114 BaseType crypto/tls.SignatureScheme
+          Type: 116 BaseType crypto/tls.SignatureScheme
     - __kind: BaseType
-      ID: 105
+      ID: 107
       Name: crypto/tls.CurveID
       ByteSize: 2
       GoRuntimeType: 847200
       GoKind: 9
     - __kind: BaseType
-      ID: 114
+      ID: 116
       Name: crypto/tls.SignatureScheme
       ByteSize: 2
       GoRuntimeType: 847296
       GoKind: 9
     - __kind: StructureType
-      ID: 134
+      ID: 170
       Name: crypto/x509.Certificate
       ByteSize: 1424
       GoRuntimeType: 2.458688e+06
@@ -1475,49 +1475,49 @@ Types:
           Type: 94 GoSliceHeaderType []uint8
         - Name: SignatureAlgorithm
           Offset: 144
-          Type: 153 BaseType crypto/x509.SignatureAlgorithm
+          Type: 202 BaseType crypto/x509.SignatureAlgorithm
         - Name: PublicKeyAlgorithm
           Offset: 152
-          Type: 154 BaseType crypto/x509.PublicKeyAlgorithm
+          Type: 203 BaseType crypto/x509.PublicKeyAlgorithm
         - Name: PublicKey
           Offset: 160
-          Type: 155 GoEmptyInterfaceType interface {}
+          Type: 153 GoEmptyInterfaceType interface {}
         - Name: Version
           Offset: 176
           Type: 7 BaseType int
         - Name: SerialNumber
           Offset: 184
-          Type: 156 PointerType *math/big.Int
+          Type: 204 PointerType *math/big.Int
         - Name: Issuer
           Offset: 192
-          Type: 158 StructureType crypto/x509/pkix.Name
+          Type: 206 StructureType crypto/x509/pkix.Name
         - Name: Subject
           Offset: 440
-          Type: 158 StructureType crypto/x509/pkix.Name
+          Type: 206 StructureType crypto/x509/pkix.Name
         - Name: NotBefore
           Offset: 688
-          Type: 162 StructureType time.Time
+          Type: 210 StructureType time.Time
         - Name: NotAfter
           Offset: 712
-          Type: 162 StructureType time.Time
+          Type: 210 StructureType time.Time
         - Name: KeyUsage
           Offset: 736
-          Type: 165 BaseType crypto/x509.KeyUsage
+          Type: 213 BaseType crypto/x509.KeyUsage
         - Name: Extensions
           Offset: 744
-          Type: 166 GoSliceHeaderType []crypto/x509/pkix.Extension
+          Type: 214 GoSliceHeaderType []crypto/x509/pkix.Extension
         - Name: ExtraExtensions
           Offset: 768
-          Type: 166 GoSliceHeaderType []crypto/x509/pkix.Extension
+          Type: 214 GoSliceHeaderType []crypto/x509/pkix.Extension
         - Name: UnhandledCriticalExtensions
           Offset: 792
-          Type: 169 GoSliceHeaderType []encoding/asn1.ObjectIdentifier
+          Type: 217 GoSliceHeaderType []encoding/asn1.ObjectIdentifier
         - Name: ExtKeyUsage
           Offset: 816
-          Type: 172 GoSliceHeaderType []crypto/x509.ExtKeyUsage
+          Type: 220 GoSliceHeaderType []crypto/x509.ExtKeyUsage
         - Name: UnknownExtKeyUsage
           Offset: 840
-          Type: 169 GoSliceHeaderType []encoding/asn1.ObjectIdentifier
+          Type: 217 GoSliceHeaderType []encoding/asn1.ObjectIdentifier
         - Name: BasicConstraintsValid
           Offset: 864
           Type: 4 BaseType bool
@@ -1550,10 +1550,10 @@ Types:
           Type: 52 GoSliceHeaderType []string
         - Name: IPAddresses
           Offset: 1032
-          Type: 175 GoSliceHeaderType []net.IP
+          Type: 223 GoSliceHeaderType []net.IP
         - Name: URIs
           Offset: 1056
-          Type: 178 GoSliceHeaderType []*net/url.URL
+          Type: 226 GoSliceHeaderType []*net/url.URL
         - Name: PermittedDNSDomainsCritical
           Offset: 1080
           Type: 4 BaseType bool
@@ -1565,10 +1565,10 @@ Types:
           Type: 52 GoSliceHeaderType []string
         - Name: PermittedIPRanges
           Offset: 1136
-          Type: 180 GoSliceHeaderType []*net.IPNet
+          Type: 228 GoSliceHeaderType []*net.IPNet
         - Name: ExcludedIPRanges
           Offset: 1160
-          Type: 180 GoSliceHeaderType []*net.IPNet
+          Type: 228 GoSliceHeaderType []*net.IPNet
         - Name: PermittedEmailAddresses
           Offset: 1184
           Type: 52 GoSliceHeaderType []string
@@ -1586,10 +1586,10 @@ Types:
           Type: 52 GoSliceHeaderType []string
         - Name: PolicyIdentifiers
           Offset: 1304
-          Type: 169 GoSliceHeaderType []encoding/asn1.ObjectIdentifier
+          Type: 217 GoSliceHeaderType []encoding/asn1.ObjectIdentifier
         - Name: Policies
           Offset: 1328
-          Type: 183 GoSliceHeaderType []crypto/x509.OID
+          Type: 231 GoSliceHeaderType []crypto/x509.OID
         - Name: InhibitAnyPolicy
           Offset: 1352
           Type: 7 BaseType int
@@ -1610,21 +1610,21 @@ Types:
           Type: 4 BaseType bool
         - Name: PolicyMappings
           Offset: 1400
-          Type: 186 GoSliceHeaderType []crypto/x509.PolicyMapping
+          Type: 234 GoSliceHeaderType []crypto/x509.PolicyMapping
     - __kind: BaseType
-      ID: 174
+      ID: 222
       Name: crypto/x509.ExtKeyUsage
       ByteSize: 8
       GoRuntimeType: 598304
       GoKind: 2
     - __kind: BaseType
-      ID: 165
+      ID: 213
       Name: crypto/x509.KeyUsage
       ByteSize: 8
       GoRuntimeType: 598240
       GoKind: 2
     - __kind: StructureType
-      ID: 185
+      ID: 233
       Name: crypto/x509.OID
       ByteSize: 24
       GoRuntimeType: 1.998368e+06
@@ -1634,7 +1634,7 @@ Types:
           Offset: 0
           Type: 94 GoSliceHeaderType []uint8
     - __kind: StructureType
-      ID: 188
+      ID: 236
       Name: crypto/x509.PolicyMapping
       ByteSize: 48
       GoRuntimeType: 1.520416e+06
@@ -1642,24 +1642,24 @@ Types:
       RawFields:
         - Name: IssuerDomainPolicy
           Offset: 0
-          Type: 185 StructureType crypto/x509.OID
+          Type: 233 StructureType crypto/x509.OID
         - Name: SubjectDomainPolicy
           Offset: 24
-          Type: 185 StructureType crypto/x509.OID
+          Type: 233 StructureType crypto/x509.OID
     - __kind: BaseType
-      ID: 154
+      ID: 203
       Name: crypto/x509.PublicKeyAlgorithm
       ByteSize: 8
       GoRuntimeType: 849696
       GoKind: 2
     - __kind: BaseType
-      ID: 153
+      ID: 202
       Name: crypto/x509.SignatureAlgorithm
       ByteSize: 8
       GoRuntimeType: 1.139648e+06
       GoKind: 2
     - __kind: StructureType
-      ID: 161
+      ID: 209
       Name: crypto/x509/pkix.AttributeTypeAndValue
       ByteSize: 40
       GoRuntimeType: 1.532736e+06
@@ -1667,12 +1667,12 @@ Types:
       RawFields:
         - Name: Type
           Offset: 0
-          Type: 171 GoSliceHeaderType encoding/asn1.ObjectIdentifier
+          Type: 219 GoSliceHeaderType encoding/asn1.ObjectIdentifier
         - Name: Value
           Offset: 24
-          Type: 155 GoEmptyInterfaceType interface {}
+          Type: 153 GoEmptyInterfaceType interface {}
     - __kind: StructureType
-      ID: 168
+      ID: 216
       Name: crypto/x509/pkix.Extension
       ByteSize: 56
       GoRuntimeType: 1.683776e+06
@@ -1680,7 +1680,7 @@ Types:
       RawFields:
         - Name: Id
           Offset: 0
-          Type: 171 GoSliceHeaderType encoding/asn1.ObjectIdentifier
+          Type: 219 GoSliceHeaderType encoding/asn1.ObjectIdentifier
         - Name: Critical
           Offset: 24
           Type: 4 BaseType bool
@@ -1688,7 +1688,7 @@ Types:
           Offset: 32
           Type: 94 GoSliceHeaderType []uint8
     - __kind: StructureType
-      ID: 158
+      ID: 206
       Name: crypto/x509/pkix.Name
       ByteSize: 248
       GoRuntimeType: 2.250272e+06
@@ -1723,12 +1723,12 @@ Types:
           Type: 9 GoStringHeaderType string
         - Name: Names
           Offset: 200
-          Type: 159 GoSliceHeaderType []crypto/x509/pkix.AttributeTypeAndValue
+          Type: 207 GoSliceHeaderType []crypto/x509/pkix.AttributeTypeAndValue
         - Name: ExtraNames
           Offset: 224
-          Type: 159 GoSliceHeaderType []crypto/x509/pkix.AttributeTypeAndValue
+          Type: 207 GoSliceHeaderType []crypto/x509/pkix.AttributeTypeAndValue
     - __kind: GoSliceHeaderType
-      ID: 171
+      ID: 219
       Name: encoding/asn1.ObjectIdentifier
       ByteSize: 24
       GoRuntimeType: 1.079904e+06
@@ -1743,9 +1743,9 @@ Types:
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 266 GoSliceDataType encoding/asn1.ObjectIdentifier.array
+      Data: 265 GoSliceDataType encoding/asn1.ObjectIdentifier.array
     - __kind: GoSliceDataType
-      ID: 266
+      ID: 265
       Name: encoding/asn1.ObjectIdentifier.array
       ByteSize: 2048
       Element: 7 BaseType int
@@ -1787,7 +1787,7 @@ Types:
       GoRuntimeType: 705088
       GoKind: 19
     - __kind: GoSubroutineType
-      ID: 113
+      ID: 115
       Name: func(string, []uint8, int) ([]uint8, error)
       ByteSize: 8
       GoRuntimeType: 1.025152e+06
@@ -1886,7 +1886,7 @@ Types:
           Type: 4 BaseType bool
         - Name: trace
           Offset: 8
-          Type: 127 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.trace
+          Type: 129 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.trace
         - Name: span
           Offset: 16
           Type: 39 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span
@@ -1901,7 +1901,7 @@ Types:
           Type: 4 BaseType bool
         - Name: traceID
           Offset: 49
-          Type: 129 ArrayType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.traceID
+          Type: 131 ArrayType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.traceID
         - Name: spanID
           Offset: 72
           Type: 8 BaseType uint64
@@ -1956,7 +1956,7 @@ Types:
       GoKind: 21
       HeaderType: 77 GoSwissMapHeaderType map<string,interface {}>
     - __kind: BaseType
-      ID: 147
+      ID: 174
       Name: github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.samplingDecision
       ByteSize: 4
       GoRuntimeType: 594016
@@ -1976,12 +1976,12 @@ Types:
           Type: 8 BaseType uint64
         - Name: Attributes
           Offset: 24
-          Type: 121 GoMapType map[string]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
+          Type: 123 GoMapType map[string]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
         - Name: RawAttributes
           Offset: 32
-          Type: 126 GoMapType map[string]interface {}
+          Type: 128 GoMapType map[string]interface {}
     - __kind: StructureType
-      ID: 221
+      ID: 240
       Name: github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttribute
       ByteSize: 24
       GoRuntimeType: 1.2152e+06
@@ -1989,9 +1989,9 @@ Types:
       RawFields:
         - Name: Values
           Offset: 0
-          Type: 223 GoSliceHeaderType []*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttributeValue
+          Type: 256 GoSliceHeaderType []*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttributeValue
     - __kind: StructureType
-      ID: 226
+      ID: 282
       Name: github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttributeValue
       ByteSize: 48
       GoRuntimeType: 1.878752e+06
@@ -1999,7 +1999,7 @@ Types:
       RawFields:
         - Name: Type
           Offset: 0
-          Type: 227 BaseType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttributeValueType
+          Type: 291 BaseType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttributeValueType
         - Name: StringValue
           Offset: 8
           Type: 9 GoStringHeaderType string
@@ -2013,13 +2013,13 @@ Types:
           Offset: 40
           Type: 15 BaseType float64
     - __kind: BaseType
-      ID: 227
+      ID: 291
       Name: github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttributeValueType
       ByteSize: 4
       GoRuntimeType: 1.006816e+06
       GoKind: 5
     - __kind: StructureType
-      ID: 216
+      ID: 199
       Name: github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
       ByteSize: 56
       GoRuntimeType: 1.955872e+06
@@ -2027,7 +2027,7 @@ Types:
       RawFields:
         - Name: Type
           Offset: 0
-          Type: 219 BaseType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttributeType
+          Type: 238 BaseType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttributeType
         - Name: StringValue
           Offset: 8
           Type: 9 GoStringHeaderType string
@@ -2042,15 +2042,15 @@ Types:
           Type: 15 BaseType float64
         - Name: ArrayValue
           Offset: 48
-          Type: 220 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttribute
+          Type: 239 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttribute
     - __kind: BaseType
-      ID: 219
+      ID: 238
       Name: github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttributeType
       ByteSize: 4
       GoRuntimeType: 1.00672e+06
       GoKind: 5
     - __kind: StructureType
-      ID: 128
+      ID: 130
       Name: github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.trace
       ByteSize: 104
       GoRuntimeType: 2.155744e+06
@@ -2061,7 +2061,7 @@ Types:
           Type: 69 StructureType sync.RWMutex
         - Name: spans
           Offset: 24
-          Type: 145 GoSliceHeaderType []*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span
+          Type: 172 GoSliceHeaderType []*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span
         - Name: tags
           Offset: 48
           Type: 64 GoMapType map[string]string
@@ -2082,12 +2082,12 @@ Types:
           Type: 4 BaseType bool
         - Name: samplingDecision
           Offset: 92
-          Type: 147 BaseType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.samplingDecision
+          Type: 174 BaseType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.samplingDecision
         - Name: root
           Offset: 96
           Type: 39 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span
     - __kind: ArrayType
-      ID: 129
+      ID: 131
       Name: github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.traceID
       ByteSize: 16
       GoRuntimeType: 919232
@@ -2096,89 +2096,89 @@ Types:
       HasCount: true
       Element: 3 BaseType uint8
     - __kind: GoSwissMapGroupsType
-      ID: 195
+      ID: 193
       Name: groupReference<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 196 PointerType *noalg.map.group[string]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
+          Type: 194 PointerType *noalg.map.group[string]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
         - Name: lengthMask
           Offset: 8
           Type: 8 BaseType uint64
-      GroupType: 197 StructureType noalg.map.group[string]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
-      GroupSliceType: 257 GoSliceDataType []noalg.map.group[string]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute.array
+      GroupType: 195 StructureType noalg.map.group[string]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
+      GroupSliceType: 201 GoSliceDataType []noalg.map.group[string]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute.array
     - __kind: GoSwissMapGroupsType
-      ID: 150
+      ID: 175
       Name: groupReference<string,[]*mime/multipart.FileHeader>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 151 PointerType *noalg.map.group[string][]*mime/multipart.FileHeader
+          Type: 176 PointerType *noalg.map.group[string][]*mime/multipart.FileHeader
         - Name: lengthMask
           Offset: 8
           Type: 8 BaseType uint64
-      GroupType: 152 StructureType noalg.map.group[string][]*mime/multipart.FileHeader
-      GroupSliceType: 247 GoSliceDataType []noalg.map.group[string][]*mime/multipart.FileHeader.array
+      GroupType: 177 StructureType noalg.map.group[string][]*mime/multipart.FileHeader
+      GroupSliceType: 184 GoSliceDataType []noalg.map.group[string][]*mime/multipart.FileHeader.array
     - __kind: GoSwissMapGroupsType
-      ID: 130
+      ID: 132
       Name: groupReference<string,[]string>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 131 PointerType *noalg.map.group[string][]string
+          Type: 133 PointerType *noalg.map.group[string][]string
         - Name: lengthMask
           Offset: 8
           Type: 8 BaseType uint64
-      GroupType: 132 StructureType noalg.map.group[string][]string
-      GroupSliceType: 231 GoSliceDataType []noalg.map.group[string][]string.array
+      GroupType: 134 StructureType noalg.map.group[string][]string
+      GroupSliceType: 138 GoSliceDataType []noalg.map.group[string][]string.array
     - __kind: GoSwissMapGroupsType
-      ID: 141
+      ID: 156
       Name: groupReference<string,float64>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 142 PointerType *noalg.map.group[string]float64
+          Type: 157 PointerType *noalg.map.group[string]float64
         - Name: lengthMask
           Offset: 8
           Type: 8 BaseType uint64
-      GroupType: 143 StructureType noalg.map.group[string]float64
-      GroupSliceType: 239 GoSliceDataType []noalg.map.group[string]float64.array
+      GroupType: 158 StructureType noalg.map.group[string]float64
+      GroupSliceType: 162 GoSliceDataType []noalg.map.group[string]float64.array
     - __kind: GoSwissMapGroupsType
-      ID: 138
+      ID: 148
       Name: groupReference<string,interface {}>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 139 PointerType *noalg.map.group[string]interface {}
+          Type: 149 PointerType *noalg.map.group[string]interface {}
         - Name: lengthMask
           Offset: 8
           Type: 8 BaseType uint64
-      GroupType: 140 StructureType noalg.map.group[string]interface {}
-      GroupSliceType: 237 GoSliceDataType []noalg.map.group[string]interface {}.array
+      GroupType: 150 StructureType noalg.map.group[string]interface {}
+      GroupSliceType: 155 GoSliceDataType []noalg.map.group[string]interface {}.array
     - __kind: GoSwissMapGroupsType
-      ID: 135
+      ID: 141
       Name: groupReference<string,string>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 136 PointerType *noalg.map.group[string]string
+          Type: 142 PointerType *noalg.map.group[string]string
         - Name: lengthMask
           Offset: 8
           Type: 8 BaseType uint64
-      GroupType: 137 StructureType noalg.map.group[string]string
-      GroupSliceType: 235 GoSliceDataType []noalg.map.group[string]string.array
+      GroupType: 143 StructureType noalg.map.group[string]string
+      GroupSliceType: 147 GoSliceDataType []noalg.map.group[string]string.array
     - __kind: BaseType
       ID: 7
       Name: int
@@ -2210,7 +2210,7 @@ Types:
       GoRuntimeType: 594272
       GoKind: 3
     - __kind: GoEmptyInterfaceType
-      ID: 155
+      ID: 153
       Name: interface {}
       ByteSize: 16
       GoRuntimeType: 867104
@@ -2249,7 +2249,7 @@ Types:
           Offset: 8
           Type: 14 VoidPointerType unsafe.Pointer
     - __kind: GoSwissMapHeaderType
-      ID: 123
+      ID: 125
       Name: map<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
       ByteSize: 48
       GoKind: 25
@@ -2262,7 +2262,7 @@ Types:
           Type: 1 BaseType uintptr
         - Name: dirPtr
           Offset: 16
-          Type: 124 PointerType **table<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
+          Type: 126 PointerType **table<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
         - Name: dirLen
           Offset: 24
           Type: 7 BaseType int
@@ -2281,10 +2281,10 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 8 BaseType uint64
-      TablePtrSliceType: 256 GoSliceDataType []*table<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>.array
-      GroupType: 197 StructureType noalg.map.group[string]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
+      TablePtrSliceType: 200 GoSliceDataType []*table<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>.array
+      GroupType: 195 StructureType noalg.map.group[string]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
     - __kind: GoSwissMapHeaderType
-      ID: 102
+      ID: 104
       Name: map<string,[]*mime/multipart.FileHeader>
       ByteSize: 48
       GoKind: 25
@@ -2297,7 +2297,7 @@ Types:
           Type: 1 BaseType uintptr
         - Name: dirPtr
           Offset: 16
-          Type: 103 PointerType **table<string,[]*mime/multipart.FileHeader>
+          Type: 105 PointerType **table<string,[]*mime/multipart.FileHeader>
         - Name: dirLen
           Offset: 24
           Type: 7 BaseType int
@@ -2316,8 +2316,8 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 8 BaseType uint64
-      TablePtrSliceType: 246 GoSliceDataType []*table<string,[]*mime/multipart.FileHeader>.array
-      GroupType: 152 StructureType noalg.map.group[string][]*mime/multipart.FileHeader
+      TablePtrSliceType: 183 GoSliceDataType []*table<string,[]*mime/multipart.FileHeader>.array
+      GroupType: 177 StructureType noalg.map.group[string][]*mime/multipart.FileHeader
     - __kind: GoSwissMapHeaderType
       ID: 47
       Name: map<string,[]string>
@@ -2351,8 +2351,8 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 8 BaseType uint64
-      TablePtrSliceType: 230 GoSliceDataType []*table<string,[]string>.array
-      GroupType: 132 StructureType noalg.map.group[string][]string
+      TablePtrSliceType: 137 GoSliceDataType []*table<string,[]string>.array
+      GroupType: 134 StructureType noalg.map.group[string][]string
     - __kind: GoSwissMapHeaderType
       ID: 82
       Name: map<string,float64>
@@ -2386,8 +2386,8 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 8 BaseType uint64
-      TablePtrSliceType: 238 GoSliceDataType []*table<string,float64>.array
-      GroupType: 143 StructureType noalg.map.group[string]float64
+      TablePtrSliceType: 161 GoSliceDataType []*table<string,float64>.array
+      GroupType: 158 StructureType noalg.map.group[string]float64
     - __kind: GoSwissMapHeaderType
       ID: 77
       Name: map<string,interface {}>
@@ -2421,8 +2421,8 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 8 BaseType uint64
-      TablePtrSliceType: 236 GoSliceDataType []*table<string,interface {}>.array
-      GroupType: 140 StructureType noalg.map.group[string]interface {}
+      TablePtrSliceType: 154 GoSliceDataType []*table<string,interface {}>.array
+      GroupType: 150 StructureType noalg.map.group[string]interface {}
     - __kind: GoSwissMapHeaderType
       ID: 66
       Name: map<string,string>
@@ -2456,24 +2456,24 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 8 BaseType uint64
-      TablePtrSliceType: 234 GoSliceDataType []*table<string,string>.array
-      GroupType: 137 StructureType noalg.map.group[string]string
+      TablePtrSliceType: 146 GoSliceDataType []*table<string,string>.array
+      GroupType: 143 StructureType noalg.map.group[string]string
     - __kind: GoMapType
-      ID: 121
+      ID: 123
       Name: map[string]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
       ByteSize: 8
       GoRuntimeType: 1.158336e+06
       GoKind: 21
-      HeaderType: 123 GoSwissMapHeaderType map<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
+      HeaderType: 125 GoSwissMapHeaderType map<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
     - __kind: GoMapType
-      ID: 100
+      ID: 102
       Name: map[string][]*mime/multipart.FileHeader
       ByteSize: 8
       GoRuntimeType: 1.157568e+06
       GoKind: 21
-      HeaderType: 102 GoSwissMapHeaderType map<string,[]*mime/multipart.FileHeader>
+      HeaderType: 104 GoSwissMapHeaderType map<string,[]*mime/multipart.FileHeader>
     - __kind: GoMapType
-      ID: 99
+      ID: 101
       Name: map[string][]string
       ByteSize: 8
       GoRuntimeType: 1.153216e+06
@@ -2487,7 +2487,7 @@ Types:
       GoKind: 21
       HeaderType: 82 GoSwissMapHeaderType map<string,float64>
     - __kind: GoMapType
-      ID: 126
+      ID: 128
       Name: map[string]interface {}
       ByteSize: 8
       GoRuntimeType: 1.151808e+06
@@ -2501,7 +2501,7 @@ Types:
       GoKind: 21
       HeaderType: 66 GoSwissMapHeaderType map<string,string>
     - __kind: StructureType
-      ID: 157
+      ID: 205
       Name: math/big.Int
       ByteSize: 32
       GoRuntimeType: 1.523456e+06
@@ -2512,15 +2512,15 @@ Types:
           Type: 4 BaseType bool
         - Name: abs
           Offset: 8
-          Type: 203 GoSliceHeaderType math/big.nat
+          Type: 245 GoSliceHeaderType math/big.nat
     - __kind: BaseType
-      ID: 205
+      ID: 247
       Name: math/big.Word
       ByteSize: 8
       GoRuntimeType: 598496
       GoKind: 7
     - __kind: GoSliceHeaderType
-      ID: 203
+      ID: 245
       Name: math/big.nat
       ByteSize: 24
       GoRuntimeType: 2.426912e+06
@@ -2528,21 +2528,21 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 204 PointerType *math/big.Word
+          Type: 246 PointerType *math/big.Word
         - Name: len
           Offset: 8
           Type: 7 BaseType int
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 284 GoSliceDataType math/big.nat.array
+      Data: 283 GoSliceDataType math/big.nat.array
     - __kind: GoSliceDataType
-      ID: 284
+      ID: 283
       Name: math/big.nat.array
       ByteSize: 2048
-      Element: 205 BaseType math/big.Word
+      Element: 247 BaseType math/big.Word
     - __kind: StructureType
-      ID: 217
+      ID: 237
       Name: mime/multipart.FileHeader
       ByteSize: 88
       GoRuntimeType: 2.018784e+06
@@ -2553,7 +2553,7 @@ Types:
           Type: 9 GoStringHeaderType string
         - Name: Header
           Offset: 16
-          Type: 222 GoMapType net/textproto.MIMEHeader
+          Type: 255 GoMapType net/textproto.MIMEHeader
         - Name: Size
           Offset: 24
           Type: 12 BaseType int64
@@ -2578,12 +2578,12 @@ Types:
       RawFields:
         - Name: Value
           Offset: 0
-          Type: 99 GoMapType map[string][]string
+          Type: 101 GoMapType map[string][]string
         - Name: File
           Offset: 8
-          Type: 100 GoMapType map[string][]*mime/multipart.FileHeader
+          Type: 102 GoMapType map[string][]*mime/multipart.FileHeader
     - __kind: GoSliceHeaderType
-      ID: 177
+      ID: 225
       Name: net.IP
       ByteSize: 24
       GoRuntimeType: 2.178944e+06
@@ -2598,14 +2598,14 @@ Types:
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 272 GoSliceDataType net.IP.array
+      Data: 271 GoSliceDataType net.IP.array
     - __kind: GoSliceDataType
-      ID: 272
+      ID: 271
       Name: net.IP.array
       ByteSize: 2048
       Element: 3 BaseType uint8
     - __kind: GoSliceHeaderType
-      ID: 218
+      ID: 281
       Name: net.IPMask
       ByteSize: 24
       GoRuntimeType: 1.042272e+06
@@ -2620,14 +2620,14 @@ Types:
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 290 GoSliceDataType net.IPMask.array
+      Data: 292 GoSliceDataType net.IPMask.array
     - __kind: GoSliceDataType
-      ID: 290
+      ID: 292
       Name: net.IPMask.array
       ByteSize: 2048
       Element: 3 BaseType uint8
     - __kind: StructureType
-      ID: 212
+      ID: 254
       Name: net.IPNet
       ByteSize: 48
       GoRuntimeType: 1.486976e+06
@@ -2635,10 +2635,10 @@ Types:
       RawFields:
         - Name: IP
           Offset: 0
-          Type: 177 GoSliceHeaderType net.IP
+          Type: 225 GoSliceHeaderType net.IP
         - Name: Mask
           Offset: 24
-          Type: 218 GoSliceHeaderType net.IPMask
+          Type: 281 GoSliceHeaderType net.IPMask
     - __kind: GoMapType
       ID: 45
       Name: net/http.Header
@@ -2811,12 +2811,12 @@ Types:
           Type: 9 GoStringHeaderType string
         - Name: segments
           Offset: 48
-          Type: 115 GoSliceHeaderType []net/http.segment
+          Type: 117 GoSliceHeaderType []net/http.segment
         - Name: loc
           Offset: 72
           Type: 9 GoStringHeaderType string
     - __kind: StructureType
-      ID: 117
+      ID: 119
       Name: net/http.segment
       ByteSize: 24
       GoRuntimeType: 1.642496e+06
@@ -2832,7 +2832,7 @@ Types:
           Offset: 17
           Type: 4 BaseType bool
     - __kind: GoMapType
-      ID: 222
+      ID: 255
       Name: net/textproto.MIMEHeader
       ByteSize: 8
       GoRuntimeType: 1.86368e+06
@@ -2853,7 +2853,7 @@ Types:
           Type: 9 GoStringHeaderType string
         - Name: User
           Offset: 32
-          Type: 96 PointerType *net/url.Userinfo
+          Type: 98 PointerType *net/url.Userinfo
         - Name: Host
           Offset: 40
           Type: 9 GoStringHeaderType string
@@ -2879,7 +2879,7 @@ Types:
           Offset: 128
           Type: 9 GoStringHeaderType string
     - __kind: StructureType
-      ID: 97
+      ID: 99
       Name: net/url.Userinfo
       ByteSize: 40
       GoRuntimeType: 1.658624e+06
@@ -2902,61 +2902,61 @@ Types:
       GoKind: 21
       HeaderType: 47 GoSwissMapHeaderType map<string,[]string>
     - __kind: ArrayType
-      ID: 213
+      ID: 196
       Name: noalg.[8]struct { key string; elem *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute }
       ByteSize: 192
       GoRuntimeType: 715328
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 214 StructureType noalg.struct { key string; elem *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute }
+      Element: 197 StructureType noalg.struct { key string; elem *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute }
     - __kind: ArrayType
-      ID: 198
+      ID: 178
       Name: noalg.[8]struct { key string; elem []*mime/multipart.FileHeader }
       ByteSize: 320
       GoRuntimeType: 710944
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 199 StructureType noalg.struct { key string; elem []*mime/multipart.FileHeader }
+      Element: 179 StructureType noalg.struct { key string; elem []*mime/multipart.FileHeader }
     - __kind: ArrayType
-      ID: 148
+      ID: 135
       Name: noalg.[8]struct { key string; elem []string }
       ByteSize: 320
       GoRuntimeType: 701120
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 149 StructureType noalg.struct { key string; elem []string }
+      Element: 136 StructureType noalg.struct { key string; elem []string }
     - __kind: ArrayType
-      ID: 193
+      ID: 159
       Name: noalg.[8]struct { key string; elem float64 }
       ByteSize: 192
       GoRuntimeType: 715232
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 194 StructureType noalg.struct { key string; elem float64 }
+      Element: 160 StructureType noalg.struct { key string; elem float64 }
     - __kind: ArrayType
-      ID: 191
+      ID: 151
       Name: noalg.[8]struct { key string; elem interface {} }
       ByteSize: 256
       GoRuntimeType: 692576
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 192 StructureType noalg.struct { key string; elem interface {} }
+      Element: 152 StructureType noalg.struct { key string; elem interface {} }
     - __kind: ArrayType
-      ID: 189
+      ID: 144
       Name: noalg.[8]struct { key string; elem string }
       ByteSize: 256
       GoRuntimeType: 705280
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 190 StructureType noalg.struct { key string; elem string }
+      Element: 145 StructureType noalg.struct { key string; elem string }
     - __kind: StructureType
-      ID: 197
+      ID: 195
       Name: noalg.map.group[string]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
       ByteSize: 200
       GoRuntimeType: 1.332e+06
@@ -2967,9 +2967,9 @@ Types:
           Type: 8 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 213 ArrayType noalg.[8]struct { key string; elem *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute }
+          Type: 196 ArrayType noalg.[8]struct { key string; elem *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute }
     - __kind: StructureType
-      ID: 152
+      ID: 177
       Name: noalg.map.group[string][]*mime/multipart.FileHeader
       ByteSize: 328
       GoRuntimeType: 1.325728e+06
@@ -2980,9 +2980,9 @@ Types:
           Type: 8 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 198 ArrayType noalg.[8]struct { key string; elem []*mime/multipart.FileHeader }
+          Type: 178 ArrayType noalg.[8]struct { key string; elem []*mime/multipart.FileHeader }
     - __kind: StructureType
-      ID: 132
+      ID: 134
       Name: noalg.map.group[string][]string
       ByteSize: 328
       GoRuntimeType: 1.31664e+06
@@ -2993,9 +2993,9 @@ Types:
           Type: 8 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 148 ArrayType noalg.[8]struct { key string; elem []string }
+          Type: 135 ArrayType noalg.[8]struct { key string; elem []string }
     - __kind: StructureType
-      ID: 143
+      ID: 158
       Name: noalg.map.group[string]float64
       ByteSize: 200
       GoRuntimeType: 1.331744e+06
@@ -3006,9 +3006,9 @@ Types:
           Type: 8 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 193 ArrayType noalg.[8]struct { key string; elem float64 }
+          Type: 159 ArrayType noalg.[8]struct { key string; elem float64 }
     - __kind: StructureType
-      ID: 140
+      ID: 150
       Name: noalg.map.group[string]interface {}
       ByteSize: 264
       GoRuntimeType: 1.31408e+06
@@ -3019,9 +3019,9 @@ Types:
           Type: 8 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 191 ArrayType noalg.[8]struct { key string; elem interface {} }
+          Type: 151 ArrayType noalg.[8]struct { key string; elem interface {} }
     - __kind: StructureType
-      ID: 137
+      ID: 143
       Name: noalg.map.group[string]string
       ByteSize: 264
       GoRuntimeType: 1.319072e+06
@@ -3032,9 +3032,9 @@ Types:
           Type: 8 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 189 ArrayType noalg.[8]struct { key string; elem string }
+          Type: 144 ArrayType noalg.[8]struct { key string; elem string }
     - __kind: StructureType
-      ID: 214
+      ID: 197
       Name: noalg.struct { key string; elem *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute }
       ByteSize: 24
       GoRuntimeType: 1.331872e+06
@@ -3045,9 +3045,9 @@ Types:
           Type: 9 GoStringHeaderType string
         - Name: elem
           Offset: 16
-          Type: 215 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
+          Type: 198 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
     - __kind: StructureType
-      ID: 199
+      ID: 179
       Name: noalg.struct { key string; elem []*mime/multipart.FileHeader }
       ByteSize: 40
       GoRuntimeType: 1.3256e+06
@@ -3058,9 +3058,9 @@ Types:
           Type: 9 GoStringHeaderType string
         - Name: elem
           Offset: 16
-          Type: 200 GoSliceHeaderType []*mime/multipart.FileHeader
+          Type: 180 GoSliceHeaderType []*mime/multipart.FileHeader
     - __kind: StructureType
-      ID: 149
+      ID: 136
       Name: noalg.struct { key string; elem []string }
       ByteSize: 40
       GoRuntimeType: 1.316512e+06
@@ -3073,7 +3073,7 @@ Types:
           Offset: 16
           Type: 52 GoSliceHeaderType []string
     - __kind: StructureType
-      ID: 194
+      ID: 160
       Name: noalg.struct { key string; elem float64 }
       ByteSize: 24
       GoRuntimeType: 1.331616e+06
@@ -3086,7 +3086,7 @@ Types:
           Offset: 16
           Type: 15 BaseType float64
     - __kind: StructureType
-      ID: 192
+      ID: 152
       Name: noalg.struct { key string; elem interface {} }
       ByteSize: 32
       GoRuntimeType: 1.313952e+06
@@ -3097,9 +3097,9 @@ Types:
           Type: 9 GoStringHeaderType string
         - Name: elem
           Offset: 16
-          Type: 155 GoEmptyInterfaceType interface {}
+          Type: 153 GoEmptyInterfaceType interface {}
     - __kind: StructureType
-      ID: 190
+      ID: 145
       Name: noalg.struct { key string; elem string }
       ByteSize: 32
       GoRuntimeType: 1.318944e+06
@@ -3120,13 +3120,13 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 229 PointerType *string.str
+          Type: 97 PointerType *string.str
         - Name: len
           Offset: 8
           Type: 7 BaseType int
-      Data: 228 GoStringDataType string.str
+      Data: 96 GoStringDataType string.str
     - __kind: GoStringDataType
-      ID: 228
+      ID: 96
       Name: string.str
       ByteSize: 2048
     - __kind: StructureType
@@ -3190,7 +3190,7 @@ Types:
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 144
+      ID: 171
       Name: table<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
       ByteSize: 32
       GoKind: 25
@@ -3212,9 +3212,9 @@ Types:
           Type: 7 BaseType int
         - Name: groups
           Offset: 16
-          Type: 195 GoSwissMapGroupsType groupReference<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
+          Type: 193 GoSwissMapGroupsType groupReference<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
     - __kind: StructureType
-      ID: 133
+      ID: 169
       Name: table<string,[]*mime/multipart.FileHeader>
       ByteSize: 32
       GoKind: 25
@@ -3236,9 +3236,9 @@ Types:
           Type: 7 BaseType int
         - Name: groups
           Offset: 16
-          Type: 150 GoSwissMapGroupsType groupReference<string,[]*mime/multipart.FileHeader>
+          Type: 175 GoSwissMapGroupsType groupReference<string,[]*mime/multipart.FileHeader>
     - __kind: StructureType
-      ID: 98
+      ID: 100
       Name: table<string,[]string>
       ByteSize: 32
       GoKind: 25
@@ -3260,9 +3260,9 @@ Types:
           Type: 7 BaseType int
         - Name: groups
           Offset: 16
-          Type: 130 GoSwissMapGroupsType groupReference<string,[]string>
+          Type: 132 GoSwissMapGroupsType groupReference<string,[]string>
     - __kind: StructureType
-      ID: 120
+      ID: 122
       Name: table<string,float64>
       ByteSize: 32
       GoKind: 25
@@ -3284,9 +3284,9 @@ Types:
           Type: 7 BaseType int
         - Name: groups
           Offset: 16
-          Type: 141 GoSwissMapGroupsType groupReference<string,float64>
+          Type: 156 GoSwissMapGroupsType groupReference<string,float64>
     - __kind: StructureType
-      ID: 119
+      ID: 121
       Name: table<string,interface {}>
       ByteSize: 32
       GoKind: 25
@@ -3308,9 +3308,9 @@ Types:
           Type: 7 BaseType int
         - Name: groups
           Offset: 16
-          Type: 138 GoSwissMapGroupsType groupReference<string,interface {}>
+          Type: 148 GoSwissMapGroupsType groupReference<string,interface {}>
     - __kind: StructureType
-      ID: 118
+      ID: 120
       Name: table<string,string>
       ByteSize: 32
       GoKind: 25
@@ -3332,9 +3332,9 @@ Types:
           Type: 7 BaseType int
         - Name: groups
           Offset: 16
-          Type: 135 GoSwissMapGroupsType groupReference<string,string>
+          Type: 141 GoSwissMapGroupsType groupReference<string,string>
     - __kind: StructureType
-      ID: 164
+      ID: 212
       Name: time.Location
       ByteSize: 104
       GoRuntimeType: 2.014752e+06
@@ -3345,10 +3345,10 @@ Types:
           Type: 9 GoStringHeaderType string
         - Name: zone
           Offset: 16
-          Type: 206 GoSliceHeaderType []time.zone
+          Type: 248 GoSliceHeaderType []time.zone
         - Name: tx
           Offset: 40
-          Type: 209 GoSliceHeaderType []time.zoneTrans
+          Type: 251 GoSliceHeaderType []time.zoneTrans
         - Name: extend
           Offset: 64
           Type: 9 GoStringHeaderType string
@@ -3360,9 +3360,9 @@ Types:
           Type: 12 BaseType int64
         - Name: cacheZone
           Offset: 96
-          Type: 207 PointerType *time.zone
+          Type: 249 PointerType *time.zone
     - __kind: StructureType
-      ID: 162
+      ID: 210
       Name: time.Time
       ByteSize: 24
       GoRuntimeType: 2.42976e+06
@@ -3376,9 +3376,9 @@ Types:
           Type: 12 BaseType int64
         - Name: loc
           Offset: 16
-          Type: 163 PointerType *time.Location
+          Type: 211 PointerType *time.Location
     - __kind: StructureType
-      ID: 208
+      ID: 250
       Name: time.zone
       ByteSize: 32
       GoRuntimeType: 1.647488e+06
@@ -3394,7 +3394,7 @@ Types:
           Offset: 24
           Type: 4 BaseType bool
     - __kind: StructureType
-      ID: 211
+      ID: 253
       Name: time.zoneTrans
       ByteSize: 16
       GoRuntimeType: 1.789472e+06

--- a/pkg/dyninst/irgen/testdata/snapshot/rc_tester.arch=arm64,toolchain=go1.23.11.yaml
+++ b/pkg/dyninst/irgen/testdata/snapshot/rc_tester.arch=arm64,toolchain=go1.23.11.yaml
@@ -65,14 +65,14 @@ Subprograms:
           IsParameter: true
           IsReturn: false
         - Name: span
-          Type: 148 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span
+          Type: 39 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span
           Locations:
             - Range: 0x8dffa8..0x8dffd8
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: false
           IsReturn: false
         - Name: '&buf'
-          Type: 198 PointerType *bytes.Buffer
+          Type: 41 PointerType *bytes.Buffer
           Locations:
             - Range: 0x8e007c..0x8e0098
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
@@ -81,7 +81,7 @@ Subprograms:
           IsParameter: false
           IsReturn: false
         - Name: .autotmp_14
-          Type: 201 StructureType context.backgroundCtx
+          Type: 43 StructureType context.backgroundCtx
           Locations:
             - Range: 0x8dff30..0x8e0170
               Pieces: [{Size: 0, Op: {CfaOffset: 0}}]
@@ -105,174 +105,174 @@ Subprograms:
           IsReturn: false
 Types:
     - __kind: PointerType
-      ID: 80
+      ID: 114
       Name: '**crypto/x509.Certificate'
       ByteSize: 8
-      Pointee: 81 PointerType *crypto/x509.Certificate
+      Pointee: 115 PointerType *crypto/x509.Certificate
     - __kind: PointerType
-      ID: 194
+      ID: 148
       Name: '**github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span'
       ByteSize: 8
       GoKind: 22
-      Pointee: 148 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span
+      Pointee: 39 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span
     - __kind: PointerType
-      ID: 184
+      ID: 198
       Name: '**github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttributeValue'
       ByteSize: 8
       GoKind: 22
-      Pointee: 185 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttributeValue
+      Pointee: 199 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttributeValue
     - __kind: PointerType
-      ID: 72
+      ID: 141
       Name: '**mime/multipart.FileHeader'
       ByteSize: 8
       GoKind: 22
-      Pointee: 73 PointerType *mime/multipart.FileHeader
+      Pointee: 142 PointerType *mime/multipart.FileHeader
     - __kind: PointerType
-      ID: 120
+      ID: 178
       Name: '**net.IPNet'
       ByteSize: 8
       GoKind: 22
-      Pointee: 121 PointerType *net.IPNet
+      Pointee: 179 PointerType *net.IPNet
     - __kind: PointerType
-      ID: 118
+      ID: 176
       Name: '**net/url.URL'
       ByteSize: 8
-      Pointee: 39 PointerType *net/url.URL
+      Pointee: 45 PointerType *net/url.URL
     - __kind: PointerType
-      ID: 56
+      ID: 138
       Name: '**runtime.bmap'
       ByteSize: 8
-      Pointee: 57 PointerType *runtime.bmap
+      Pointee: 105 PointerType *runtime.bmap
     - __kind: PointerType
-      ID: 128
+      ID: 117
       Name: '*[]*crypto/x509.Certificate'
       ByteSize: 8
       GoKind: 22
-      Pointee: 79 GoSliceHeaderType []*crypto/x509.Certificate
+      Pointee: 113 GoSliceHeaderType []*crypto/x509.Certificate
     - __kind: PointerType
-      ID: 216
+      ID: 221
       Name: '*[]*crypto/x509.Certificate.array'
       ByteSize: 8
-      Pointee: 215 GoSliceDataType []*crypto/x509.Certificate.array
+      Pointee: 220 GoSliceDataType []*crypto/x509.Certificate.array
     - __kind: PointerType
-      ID: 262
+      ID: 232
       Name: '*[]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span.array'
       ByteSize: 8
-      Pointee: 261 GoSliceDataType []*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span.array
+      Pointee: 231 GoSliceDataType []*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span.array
     - __kind: PointerType
       ID: 260
       Name: '*[]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttributeValue.array'
       ByteSize: 8
       Pointee: 259 GoSliceDataType []*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttributeValue.array
     - __kind: PointerType
-      ID: 212
+      ID: 230
       Name: '*[]*mime/multipart.FileHeader.array'
       ByteSize: 8
-      Pointee: 211 GoSliceDataType []*mime/multipart.FileHeader.array
+      Pointee: 229 GoSliceDataType []*mime/multipart.FileHeader.array
     - __kind: PointerType
-      ID: 240
+      ID: 250
       Name: '*[]*net.IPNet.array'
       ByteSize: 8
-      Pointee: 239 GoSliceDataType []*net.IPNet.array
+      Pointee: 249 GoSliceDataType []*net.IPNet.array
     - __kind: PointerType
-      ID: 238
+      ID: 248
       Name: '*[]*net/url.URL.array'
       ByteSize: 8
-      Pointee: 237 GoSliceDataType []*net/url.URL.array
+      Pointee: 247 GoSliceDataType []*net/url.URL.array
     - __kind: PointerType
-      ID: 54
+      ID: 103
       Name: '*[]*runtime.bmap'
       ByteSize: 8
       GoRuntimeType: 470816
       GoKind: 22
-      Pointee: 55 GoSliceHeaderType []*runtime.bmap
+      Pointee: 104 GoSliceHeaderType []*runtime.bmap
     - __kind: PointerType
-      ID: 209
+      ID: 218
       Name: '*[]*runtime.bmap.array'
       ByteSize: 8
-      Pointee: 208 GoSliceDataType []*runtime.bmap.array
+      Pointee: 217 GoSliceDataType []*runtime.bmap.array
     - __kind: PointerType
-      ID: 246
+      ID: 223
       Name: '*[][]*crypto/x509.Certificate.array'
       ByteSize: 8
-      Pointee: 245 GoSliceDataType [][]*crypto/x509.Certificate.array
+      Pointee: 222 GoSliceDataType [][]*crypto/x509.Certificate.array
     - __kind: PointerType
-      ID: 248
+      ID: 225
       Name: '*[][]uint8.array'
       ByteSize: 8
-      Pointee: 247 GoSliceDataType [][]uint8.array
+      Pointee: 224 GoSliceDataType [][]uint8.array
     - __kind: PointerType
-      ID: 232
+      ID: 242
       Name: '*[]crypto/x509.ExtKeyUsage.array'
       ByteSize: 8
-      Pointee: 231 GoSliceDataType []crypto/x509.ExtKeyUsage.array
+      Pointee: 241 GoSliceDataType []crypto/x509.ExtKeyUsage.array
     - __kind: PointerType
-      ID: 244
+      ID: 252
       Name: '*[]crypto/x509.OID.array'
       ByteSize: 8
-      Pointee: 243 GoSliceDataType []crypto/x509.OID.array
-    - __kind: PointerType
-      ID: 220
-      Name: '*[]crypto/x509/pkix.AttributeTypeAndValue.array'
-      ByteSize: 8
-      Pointee: 219 GoSliceDataType []crypto/x509/pkix.AttributeTypeAndValue.array
-    - __kind: PointerType
-      ID: 228
-      Name: '*[]crypto/x509/pkix.Extension.array'
-      ByteSize: 8
-      Pointee: 227 GoSliceDataType []crypto/x509/pkix.Extension.array
-    - __kind: PointerType
-      ID: 230
-      Name: '*[]encoding/asn1.ObjectIdentifier.array'
-      ByteSize: 8
-      Pointee: 229 GoSliceDataType []encoding/asn1.ObjectIdentifier.array
-    - __kind: PointerType
-      ID: 255
-      Name: '*[]github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink.array'
-      ByteSize: 8
-      Pointee: 254 GoSliceDataType []github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink.array
-    - __kind: PointerType
-      ID: 257
-      Name: '*[]github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent.array'
-      ByteSize: 8
-      Pointee: 256 GoSliceDataType []github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent.array
+      Pointee: 251 GoSliceDataType []crypto/x509.OID.array
     - __kind: PointerType
       ID: 234
+      Name: '*[]crypto/x509/pkix.AttributeTypeAndValue.array'
+      ByteSize: 8
+      Pointee: 233 GoSliceDataType []crypto/x509/pkix.AttributeTypeAndValue.array
+    - __kind: PointerType
+      ID: 236
+      Name: '*[]crypto/x509/pkix.Extension.array'
+      ByteSize: 8
+      Pointee: 235 GoSliceDataType []crypto/x509/pkix.Extension.array
+    - __kind: PointerType
+      ID: 238
+      Name: '*[]encoding/asn1.ObjectIdentifier.array'
+      ByteSize: 8
+      Pointee: 237 GoSliceDataType []encoding/asn1.ObjectIdentifier.array
+    - __kind: PointerType
+      ID: 212
+      Name: '*[]github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink.array'
+      ByteSize: 8
+      Pointee: 211 GoSliceDataType []github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink.array
+    - __kind: PointerType
+      ID: 214
+      Name: '*[]github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent.array'
+      ByteSize: 8
+      Pointee: 213 GoSliceDataType []github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent.array
+    - __kind: PointerType
+      ID: 244
       Name: '*[]net.IP.array'
       ByteSize: 8
-      Pointee: 233 GoSliceDataType []net.IP.array
+      Pointee: 243 GoSliceDataType []net.IP.array
     - __kind: PointerType
-      ID: 250
+      ID: 227
       Name: '*[]net/http.segment.array'
       ByteSize: 8
-      Pointee: 249 GoSliceDataType []net/http.segment.array
+      Pointee: 226 GoSliceDataType []net/http.segment.array
     - __kind: PointerType
       ID: 207
       Name: '*[]string.array'
       ByteSize: 8
       Pointee: 206 GoSliceDataType []string.array
     - __kind: PointerType
-      ID: 224
+      ID: 256
       Name: '*[]time.zone.array'
       ByteSize: 8
-      Pointee: 223 GoSliceDataType []time.zone.array
+      Pointee: 255 GoSliceDataType []time.zone.array
     - __kind: PointerType
-      ID: 226
+      ID: 258
       Name: '*[]time.zoneTrans.array'
       ByteSize: 8
-      Pointee: 225 GoSliceDataType []time.zoneTrans.array
+      Pointee: 257 GoSliceDataType []time.zoneTrans.array
     - __kind: PointerType
-      ID: 130
+      ID: 119
       Name: '*[]uint8'
       ByteSize: 8
       GoRuntimeType: 456928
       GoKind: 22
-      Pointee: 76 GoSliceHeaderType []uint8
+      Pointee: 96 GoSliceHeaderType []uint8
     - __kind: PointerType
-      ID: 214
+      ID: 216
       Name: '*[]uint8.array'
       ByteSize: 8
-      Pointee: 213 GoSliceDataType []uint8.array
+      Pointee: 215 GoSliceDataType []uint8.array
     - __kind: PointerType
       ID: 5
       Name: '*bool'
@@ -281,96 +281,96 @@ Types:
       GoKind: 22
       Pointee: 4 BaseType bool
     - __kind: PointerType
-      ID: 175
+      ID: 132
       Name: '*bucket<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>'
       ByteSize: 8
-      Pointee: 176 GoHMapBucketType bucket<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
+      Pointee: 133 GoHMapBucketType bucket<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
     - __kind: PointerType
-      ID: 68
+      ID: 111
       Name: '*bucket<string,[]*mime/multipart.FileHeader>'
       ByteSize: 8
-      Pointee: 69 GoHMapBucketType bucket<string,[]*mime/multipart.FileHeader>
+      Pointee: 112 GoHMapBucketType bucket<string,[]*mime/multipart.FileHeader>
     - __kind: PointerType
-      ID: 46
+      ID: 50
       Name: '*bucket<string,[]string>'
       ByteSize: 8
-      Pointee: 47 GoHMapBucketType bucket<string,[]string>
+      Pointee: 51 GoHMapBucketType bucket<string,[]string>
     - __kind: PointerType
-      ID: 163
+      ID: 85
       Name: '*bucket<string,float64>'
       ByteSize: 8
-      Pointee: 164 GoHMapBucketType bucket<string,float64>
+      Pointee: 86 GoHMapBucketType bucket<string,float64>
     - __kind: PointerType
-      ID: 157
+      ID: 80
       Name: '*bucket<string,interface {}>'
       ByteSize: 8
-      Pointee: 158 GoHMapBucketType bucket<string,interface {}>
+      Pointee: 81 GoHMapBucketType bucket<string,interface {}>
     - __kind: PointerType
-      ID: 145
+      ID: 71
       Name: '*bucket<string,string>'
       ByteSize: 8
-      Pointee: 146 GoHMapBucketType bucket<string,string>
+      Pointee: 72 GoHMapBucketType bucket<string,string>
     - __kind: PointerType
-      ID: 198
+      ID: 41
       Name: '*bytes.Buffer'
       ByteSize: 8
       GoRuntimeType: 2.176896e+06
       GoKind: 22
-      Pointee: 199 StructureType bytes.Buffer
+      Pointee: 42 StructureType bytes.Buffer
     - __kind: PointerType
-      ID: 77
+      ID: 60
       Name: '*crypto/tls.ConnectionState'
       ByteSize: 8
       GoRuntimeType: 852320
       GoKind: 22
-      Pointee: 78 StructureType crypto/tls.ConnectionState
+      Pointee: 61 StructureType crypto/tls.ConnectionState
     - __kind: PointerType
-      ID: 81
+      ID: 115
       Name: '*crypto/x509.Certificate'
       ByteSize: 8
       GoRuntimeType: 1.95344e+06
       GoKind: 22
-      Pointee: 82 StructureType crypto/x509.Certificate
+      Pointee: 143 StructureType crypto/x509.Certificate
     - __kind: PointerType
-      ID: 112
+      ID: 170
       Name: '*crypto/x509.ExtKeyUsage'
       ByteSize: 8
       GoRuntimeType: 400736
       GoKind: 22
-      Pointee: 113 BaseType crypto/x509.ExtKeyUsage
+      Pointee: 171 BaseType crypto/x509.ExtKeyUsage
     - __kind: PointerType
-      ID: 125
+      ID: 181
       Name: '*crypto/x509.OID'
       ByteSize: 8
       GoRuntimeType: 1.762368e+06
       GoKind: 22
-      Pointee: 126 StructureType crypto/x509.OID
+      Pointee: 182 StructureType crypto/x509.OID
     - __kind: PointerType
-      ID: 93
+      ID: 157
       Name: '*crypto/x509/pkix.AttributeTypeAndValue'
       ByteSize: 8
       GoRuntimeType: 417504
       GoKind: 22
-      Pointee: 94 StructureType crypto/x509/pkix.AttributeTypeAndValue
+      Pointee: 158 StructureType crypto/x509/pkix.AttributeTypeAndValue
     - __kind: PointerType
-      ID: 107
+      ID: 164
       Name: '*crypto/x509/pkix.Extension'
       ByteSize: 8
       GoRuntimeType: 417696
       GoKind: 22
-      Pointee: 108 StructureType crypto/x509/pkix.Extension
+      Pointee: 165 StructureType crypto/x509/pkix.Extension
     - __kind: PointerType
-      ID: 110
+      ID: 167
       Name: '*encoding/asn1.ObjectIdentifier'
       ByteSize: 8
       GoRuntimeType: 1.037472e+06
       GoKind: 22
-      Pointee: 95 GoSliceHeaderType encoding/asn1.ObjectIdentifier
+      Pointee: 168 GoSliceHeaderType encoding/asn1.ObjectIdentifier
     - __kind: PointerType
-      ID: 222
+      ID: 240
       Name: '*encoding/asn1.ObjectIdentifier.array'
       ByteSize: 8
-      Pointee: 221 GoSliceDataType encoding/asn1.ObjectIdentifier.array
+      Pointee: 239 GoSliceDataType encoding/asn1.ObjectIdentifier.array
     - __kind: PointerType
       ID: 33
       Name: '*error'
@@ -393,91 +393,91 @@ Types:
       GoKind: 22
       Pointee: 17 BaseType float64
     - __kind: PointerType
-      ID: 148
+      ID: 39
       Name: '*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span'
       ByteSize: 8
       GoRuntimeType: 2.18768e+06
       GoKind: 22
-      Pointee: 149 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span
+      Pointee: 40 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span
     - __kind: PointerType
-      ID: 189
+      ID: 93
       Name: '*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanContext'
       ByteSize: 8
       GoRuntimeType: 1.91728e+06
       GoKind: 22
-      Pointee: 190 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanContext
+      Pointee: 94 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanContext
     - __kind: PointerType
-      ID: 167
+      ID: 88
       Name: '*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink'
       ByteSize: 8
       GoRuntimeType: 1.12944e+06
       GoKind: 22
-      Pointee: 168 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink
+      Pointee: 89 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink
     - __kind: PointerType
-      ID: 170
+      ID: 91
       Name: '*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent'
       ByteSize: 8
       GoRuntimeType: 1.129568e+06
       GoKind: 22
-      Pointee: 171 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent
+      Pointee: 92 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent
     - __kind: PointerType
-      ID: 181
+      ID: 184
       Name: '*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttribute'
       ByteSize: 8
       GoRuntimeType: 1.130208e+06
       GoKind: 22
-      Pointee: 182 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttribute
+      Pointee: 185 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttribute
     - __kind: PointerType
-      ID: 185
+      ID: 199
       Name: '*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttributeValue'
       ByteSize: 8
       GoRuntimeType: 1.129952e+06
       GoKind: 22
-      Pointee: 186 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttributeValue
+      Pointee: 201 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttributeValue
     - __kind: PointerType
-      ID: 178
+      ID: 145
       Name: '*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute'
       ByteSize: 8
       GoRuntimeType: 1.130336e+06
       GoKind: 22
-      Pointee: 179 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
+      Pointee: 146 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
     - __kind: PointerType
-      ID: 191
+      ID: 135
       Name: '*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.trace'
       ByteSize: 8
       GoRuntimeType: 2.132544e+06
       GoKind: 22
-      Pointee: 192 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.trace
+      Pointee: 136 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.trace
     - __kind: PointerType
-      ID: 173
+      ID: 130
       Name: '*hash<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>'
       ByteSize: 8
-      Pointee: 174 GoHMapHeaderType hash<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
+      Pointee: 131 GoHMapHeaderType hash<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
     - __kind: PointerType
-      ID: 66
+      ID: 109
       Name: '*hash<string,[]*mime/multipart.FileHeader>'
       ByteSize: 8
-      Pointee: 67 GoHMapHeaderType hash<string,[]*mime/multipart.FileHeader>
+      Pointee: 110 GoHMapHeaderType hash<string,[]*mime/multipart.FileHeader>
     - __kind: PointerType
-      ID: 44
+      ID: 48
       Name: '*hash<string,[]string>'
       ByteSize: 8
-      Pointee: 45 GoHMapHeaderType hash<string,[]string>
+      Pointee: 49 GoHMapHeaderType hash<string,[]string>
     - __kind: PointerType
-      ID: 161
+      ID: 83
       Name: '*hash<string,float64>'
       ByteSize: 8
-      Pointee: 162 GoHMapHeaderType hash<string,float64>
+      Pointee: 84 GoHMapHeaderType hash<string,float64>
     - __kind: PointerType
-      ID: 155
+      ID: 78
       Name: '*hash<string,interface {}>'
       ByteSize: 8
-      Pointee: 156 GoHMapHeaderType hash<string,interface {}>
+      Pointee: 79 GoHMapHeaderType hash<string,interface {}>
     - __kind: PointerType
-      ID: 143
+      ID: 69
       Name: '*hash<string,string>'
       ByteSize: 8
-      Pointee: 144 GoHMapHeaderType hash<string,string>
+      Pointee: 70 GoHMapHeaderType hash<string,string>
     - __kind: PointerType
       ID: 28
       Name: '*int'
@@ -514,62 +514,62 @@ Types:
       GoKind: 22
       Pointee: 15 BaseType int8
     - __kind: PointerType
-      ID: 86
+      ID: 153
       Name: '*math/big.Int'
       ByteSize: 8
       GoRuntimeType: 2.29744e+06
       GoKind: 22
-      Pointee: 87 StructureType math/big.Int
+      Pointee: 154 StructureType math/big.Int
     - __kind: PointerType
-      ID: 89
+      ID: 188
       Name: '*math/big.Word'
       ByteSize: 8
       GoRuntimeType: 403552
       GoKind: 22
-      Pointee: 90 BaseType math/big.Word
+      Pointee: 189 BaseType math/big.Word
     - __kind: PointerType
-      ID: 218
+      ID: 254
       Name: '*math/big.nat.array'
       ByteSize: 8
-      Pointee: 217 GoSliceDataType math/big.nat.array
+      Pointee: 253 GoSliceDataType math/big.nat.array
     - __kind: PointerType
-      ID: 73
+      ID: 142
       Name: '*mime/multipart.FileHeader'
       ByteSize: 8
       GoRuntimeType: 853760
       GoKind: 22
-      Pointee: 74 StructureType mime/multipart.FileHeader
+      Pointee: 150 StructureType mime/multipart.FileHeader
     - __kind: PointerType
-      ID: 62
+      ID: 58
       Name: '*mime/multipart.Form'
       ByteSize: 8
       GoRuntimeType: 853856
       GoKind: 22
-      Pointee: 63 StructureType mime/multipart.Form
+      Pointee: 59 StructureType mime/multipart.Form
     - __kind: PointerType
-      ID: 115
+      ID: 173
       Name: '*net.IP'
       ByteSize: 8
       GoRuntimeType: 2.02912e+06
       GoKind: 22
-      Pointee: 116 GoSliceHeaderType net.IP
+      Pointee: 174 GoSliceHeaderType net.IP
     - __kind: PointerType
-      ID: 236
+      ID: 246
       Name: '*net.IP.array'
       ByteSize: 8
-      Pointee: 235 GoSliceDataType net.IP.array
+      Pointee: 245 GoSliceDataType net.IP.array
     - __kind: PointerType
-      ID: 242
+      ID: 262
       Name: '*net.IPMask.array'
       ByteSize: 8
-      Pointee: 241 GoSliceDataType net.IPMask.array
+      Pointee: 261 GoSliceDataType net.IPMask.array
     - __kind: PointerType
-      ID: 121
+      ID: 179
       Name: '*net.IPNet'
       ByteSize: 8
       GoRuntimeType: 1.122912e+06
       GoKind: 22
-      Pointee: 122 StructureType net.IPNet
+      Pointee: 196 StructureType net.IPNet
     - __kind: PointerType
       ID: 37
       Name: '*net/http.Request'
@@ -578,47 +578,47 @@ Types:
       GoKind: 22
       Pointee: 38 StructureType net/http.Request
     - __kind: PointerType
-      ID: 134
+      ID: 63
       Name: '*net/http.Response'
       ByteSize: 8
       GoRuntimeType: 1.632736e+06
       GoKind: 22
-      Pointee: 135 StructureType net/http.Response
+      Pointee: 64 StructureType net/http.Response
     - __kind: PointerType
-      ID: 137
+      ID: 66
       Name: '*net/http.pattern'
       ByteSize: 8
       GoRuntimeType: 1.453504e+06
       GoKind: 22
-      Pointee: 138 StructureType net/http.pattern
+      Pointee: 67 StructureType net/http.pattern
     - __kind: PointerType
-      ID: 140
+      ID: 123
       Name: '*net/http.segment'
       ByteSize: 8
       GoRuntimeType: 367904
       GoKind: 22
-      Pointee: 141 StructureType net/http.segment
+      Pointee: 124 StructureType net/http.segment
     - __kind: PointerType
-      ID: 39
+      ID: 45
       Name: '*net/url.URL'
       ByteSize: 8
       GoRuntimeType: 2.002496e+06
       GoKind: 22
-      Pointee: 40 StructureType net/url.URL
+      Pointee: 46 StructureType net/url.URL
     - __kind: PointerType
-      ID: 41
+      ID: 98
       Name: '*net/url.Userinfo'
       ByteSize: 8
       GoRuntimeType: 1.1416e+06
       GoKind: 22
-      Pointee: 42 StructureType net/url.Userinfo
+      Pointee: 99 StructureType net/url.Userinfo
     - __kind: PointerType
-      ID: 57
+      ID: 105
       Name: '*runtime.bmap'
       ByteSize: 8
       GoRuntimeType: 1.137248e+06
       GoKind: 22
-      Pointee: 58 StructureType runtime.bmap
+      Pointee: 106 StructureType runtime.bmap
     - __kind: PointerType
       ID: 52
       Name: '*runtime.mapextra'
@@ -639,26 +639,26 @@ Types:
       ByteSize: 8
       Pointee: 203 GoStringDataType string.str
     - __kind: PointerType
-      ID: 97
+      ID: 160
       Name: '*time.Location'
       ByteSize: 8
       GoRuntimeType: 1.458496e+06
       GoKind: 22
-      Pointee: 98 StructureType time.Location
+      Pointee: 161 StructureType time.Location
     - __kind: PointerType
-      ID: 100
+      ID: 191
       Name: '*time.zone'
       ByteSize: 8
       GoRuntimeType: 370976
       GoKind: 22
-      Pointee: 101 StructureType time.zone
+      Pointee: 192 StructureType time.zone
     - __kind: PointerType
-      ID: 103
+      ID: 194
       Name: '*time.zoneTrans'
       ByteSize: 8
       GoRuntimeType: 371040
       GoKind: 22
-      Pointee: 104 StructureType time.zoneTrans
+      Pointee: 195 StructureType time.zoneTrans
     - __kind: PointerType
       ID: 34
       Name: '*uint'
@@ -702,7 +702,7 @@ Types:
       GoKind: 22
       Pointee: 1 BaseType uintptr
     - __kind: GoChannelType
-      ID: 133
+      ID: 62
       Name: <-chan struct {}
       GoRuntimeType: 555520
       GoKind: 18
@@ -746,7 +746,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: ArrayType
-      ID: 48
+      ID: 100
       Name: '[8]uint8'
       ByteSize: 8
       GoRuntimeType: 632832
@@ -755,7 +755,7 @@ Types:
       HasCount: true
       Element: 3 BaseType uint8
     - __kind: GoSliceHeaderType
-      ID: 79
+      ID: 113
       Name: '[]*crypto/x509.Certificate'
       ByteSize: 24
       GoRuntimeType: 473920
@@ -763,21 +763,21 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 80 PointerType **crypto/x509.Certificate
+          Type: 114 PointerType **crypto/x509.Certificate
         - Name: len
           Offset: 8
           Type: 9 BaseType int
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 215 GoSliceDataType []*crypto/x509.Certificate.array
+      Data: 220 GoSliceDataType []*crypto/x509.Certificate.array
     - __kind: GoSliceDataType
-      ID: 215
+      ID: 220
       Name: '[]*crypto/x509.Certificate.array'
       ByteSize: 2048
-      Element: 81 PointerType *crypto/x509.Certificate
+      Element: 115 PointerType *crypto/x509.Certificate
     - __kind: GoSliceHeaderType
-      ID: 193
+      ID: 147
       Name: '[]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span'
       ByteSize: 24
       GoRuntimeType: 464032
@@ -785,21 +785,21 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 194 PointerType **github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span
+          Type: 148 PointerType **github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span
         - Name: len
           Offset: 8
           Type: 9 BaseType int
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 261 GoSliceDataType []*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span.array
+      Data: 231 GoSliceDataType []*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span.array
     - __kind: GoSliceDataType
-      ID: 261
+      ID: 231
       Name: '[]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span.array'
       ByteSize: 2048
-      Element: 148 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span
+      Element: 39 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span
     - __kind: GoSliceHeaderType
-      ID: 183
+      ID: 197
       Name: '[]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttributeValue'
       ByteSize: 24
       GoRuntimeType: 463648
@@ -807,7 +807,7 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 184 PointerType **github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttributeValue
+          Type: 198 PointerType **github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttributeValue
         - Name: len
           Offset: 8
           Type: 9 BaseType int
@@ -819,9 +819,9 @@ Types:
       ID: 259
       Name: '[]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttributeValue.array'
       ByteSize: 2048
-      Element: 185 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttributeValue
+      Element: 199 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttributeValue
     - __kind: GoSliceHeaderType
-      ID: 71
+      ID: 140
       Name: '[]*mime/multipart.FileHeader'
       ByteSize: 24
       GoRuntimeType: 461664
@@ -829,21 +829,21 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 72 PointerType **mime/multipart.FileHeader
+          Type: 141 PointerType **mime/multipart.FileHeader
         - Name: len
           Offset: 8
           Type: 9 BaseType int
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 211 GoSliceDataType []*mime/multipart.FileHeader.array
+      Data: 229 GoSliceDataType []*mime/multipart.FileHeader.array
     - __kind: GoSliceDataType
-      ID: 211
+      ID: 229
       Name: '[]*mime/multipart.FileHeader.array'
       ByteSize: 2048
-      Element: 73 PointerType *mime/multipart.FileHeader
+      Element: 142 PointerType *mime/multipart.FileHeader
     - __kind: GoSliceHeaderType
-      ID: 119
+      ID: 177
       Name: '[]*net.IPNet'
       ByteSize: 24
       GoRuntimeType: 486976
@@ -851,21 +851,21 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 120 PointerType **net.IPNet
+          Type: 178 PointerType **net.IPNet
         - Name: len
           Offset: 8
           Type: 9 BaseType int
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 239 GoSliceDataType []*net.IPNet.array
+      Data: 249 GoSliceDataType []*net.IPNet.array
     - __kind: GoSliceDataType
-      ID: 239
+      ID: 249
       Name: '[]*net.IPNet.array'
       ByteSize: 2048
-      Element: 121 PointerType *net.IPNet
+      Element: 179 PointerType *net.IPNet
     - __kind: GoSliceHeaderType
-      ID: 117
+      ID: 175
       Name: '[]*net/url.URL'
       ByteSize: 24
       GoRuntimeType: 486912
@@ -873,21 +873,21 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 118 PointerType **net/url.URL
+          Type: 176 PointerType **net/url.URL
         - Name: len
           Offset: 8
           Type: 9 BaseType int
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 237 GoSliceDataType []*net/url.URL.array
+      Data: 247 GoSliceDataType []*net/url.URL.array
     - __kind: GoSliceDataType
-      ID: 237
+      ID: 247
       Name: '[]*net/url.URL.array'
       ByteSize: 2048
-      Element: 39 PointerType *net/url.URL
+      Element: 45 PointerType *net/url.URL
     - __kind: GoSliceHeaderType
-      ID: 55
+      ID: 104
       Name: '[]*runtime.bmap'
       ByteSize: 24
       GoRuntimeType: 470752
@@ -895,21 +895,21 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 56 PointerType **runtime.bmap
+          Type: 138 PointerType **runtime.bmap
         - Name: len
           Offset: 8
           Type: 9 BaseType int
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 208 GoSliceDataType []*runtime.bmap.array
+      Data: 217 GoSliceDataType []*runtime.bmap.array
     - __kind: GoSliceDataType
-      ID: 208
+      ID: 217
       Name: '[]*runtime.bmap.array'
       ByteSize: 2048
-      Element: 57 PointerType *runtime.bmap
+      Element: 105 PointerType *runtime.bmap
     - __kind: GoSliceHeaderType
-      ID: 127
+      ID: 116
       Name: '[][]*crypto/x509.Certificate'
       ByteSize: 24
       GoRuntimeType: 474048
@@ -917,21 +917,21 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 128 PointerType *[]*crypto/x509.Certificate
+          Type: 117 PointerType *[]*crypto/x509.Certificate
         - Name: len
           Offset: 8
           Type: 9 BaseType int
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 245 GoSliceDataType [][]*crypto/x509.Certificate.array
+      Data: 222 GoSliceDataType [][]*crypto/x509.Certificate.array
     - __kind: GoSliceDataType
-      ID: 245
+      ID: 222
       Name: '[][]*crypto/x509.Certificate.array'
       ByteSize: 2048
-      Element: 79 GoSliceHeaderType []*crypto/x509.Certificate
+      Element: 113 GoSliceHeaderType []*crypto/x509.Certificate
     - __kind: GoSliceHeaderType
-      ID: 129
+      ID: 118
       Name: '[][]uint8'
       ByteSize: 24
       GoRuntimeType: 457184
@@ -939,51 +939,51 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 130 PointerType *[]uint8
+          Type: 119 PointerType *[]uint8
         - Name: len
           Offset: 8
           Type: 9 BaseType int
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 247 GoSliceDataType [][]uint8.array
+      Data: 224 GoSliceDataType [][]uint8.array
     - __kind: GoSliceDataType
-      ID: 247
+      ID: 224
       Name: '[][]uint8.array'
       ByteSize: 2048
-      Element: 76 GoSliceHeaderType []uint8
+      Element: 96 GoSliceHeaderType []uint8
     - __kind: GoSliceDataType
-      ID: 258
+      ID: 228
       Name: '[]bucket<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>.array'
       ByteSize: 2048
-      Element: 176 GoHMapBucketType bucket<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
+      Element: 133 GoHMapBucketType bucket<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
     - __kind: GoSliceDataType
-      ID: 210
+      ID: 219
       Name: '[]bucket<string,[]*mime/multipart.FileHeader>.array'
       ByteSize: 2048
-      Element: 69 GoHMapBucketType bucket<string,[]*mime/multipart.FileHeader>
+      Element: 112 GoHMapBucketType bucket<string,[]*mime/multipart.FileHeader>
     - __kind: GoSliceDataType
       ID: 205
       Name: '[]bucket<string,[]string>.array'
       ByteSize: 2048
-      Element: 47 GoHMapBucketType bucket<string,[]string>
+      Element: 51 GoHMapBucketType bucket<string,[]string>
     - __kind: GoSliceDataType
-      ID: 253
+      ID: 210
       Name: '[]bucket<string,float64>.array'
       ByteSize: 2048
-      Element: 164 GoHMapBucketType bucket<string,float64>
+      Element: 86 GoHMapBucketType bucket<string,float64>
     - __kind: GoSliceDataType
-      ID: 252
+      ID: 209
       Name: '[]bucket<string,interface {}>.array'
       ByteSize: 2048
-      Element: 158 GoHMapBucketType bucket<string,interface {}>
+      Element: 81 GoHMapBucketType bucket<string,interface {}>
     - __kind: GoSliceDataType
-      ID: 251
+      ID: 208
       Name: '[]bucket<string,string>.array'
       ByteSize: 2048
-      Element: 146 GoHMapBucketType bucket<string,string>
+      Element: 72 GoHMapBucketType bucket<string,string>
     - __kind: GoSliceHeaderType
-      ID: 111
+      ID: 169
       Name: '[]crypto/x509.ExtKeyUsage'
       ByteSize: 24
       GoRuntimeType: 475200
@@ -991,21 +991,21 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 112 PointerType *crypto/x509.ExtKeyUsage
+          Type: 170 PointerType *crypto/x509.ExtKeyUsage
         - Name: len
           Offset: 8
           Type: 9 BaseType int
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 231 GoSliceDataType []crypto/x509.ExtKeyUsage.array
+      Data: 241 GoSliceDataType []crypto/x509.ExtKeyUsage.array
     - __kind: GoSliceDataType
-      ID: 231
+      ID: 241
       Name: '[]crypto/x509.ExtKeyUsage.array'
       ByteSize: 2048
-      Element: 113 BaseType crypto/x509.ExtKeyUsage
+      Element: 171 BaseType crypto/x509.ExtKeyUsage
     - __kind: GoSliceHeaderType
-      ID: 124
+      ID: 180
       Name: '[]crypto/x509.OID'
       ByteSize: 24
       GoRuntimeType: 487040
@@ -1013,21 +1013,21 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 125 PointerType *crypto/x509.OID
+          Type: 181 PointerType *crypto/x509.OID
         - Name: len
           Offset: 8
           Type: 9 BaseType int
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 243 GoSliceDataType []crypto/x509.OID.array
+      Data: 251 GoSliceDataType []crypto/x509.OID.array
     - __kind: GoSliceDataType
-      ID: 243
+      ID: 251
       Name: '[]crypto/x509.OID.array'
       ByteSize: 2048
-      Element: 126 StructureType crypto/x509.OID
+      Element: 182 StructureType crypto/x509.OID
     - __kind: GoSliceHeaderType
-      ID: 92
+      ID: 156
       Name: '[]crypto/x509/pkix.AttributeTypeAndValue'
       ByteSize: 24
       GoRuntimeType: 487296
@@ -1035,21 +1035,21 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 93 PointerType *crypto/x509/pkix.AttributeTypeAndValue
+          Type: 157 PointerType *crypto/x509/pkix.AttributeTypeAndValue
         - Name: len
           Offset: 8
           Type: 9 BaseType int
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 219 GoSliceDataType []crypto/x509/pkix.AttributeTypeAndValue.array
+      Data: 233 GoSliceDataType []crypto/x509/pkix.AttributeTypeAndValue.array
     - __kind: GoSliceDataType
-      ID: 219
+      ID: 233
       Name: '[]crypto/x509/pkix.AttributeTypeAndValue.array'
       ByteSize: 2048
-      Element: 94 StructureType crypto/x509/pkix.AttributeTypeAndValue
+      Element: 158 StructureType crypto/x509/pkix.AttributeTypeAndValue
     - __kind: GoSliceHeaderType
-      ID: 106
+      ID: 163
       Name: '[]crypto/x509/pkix.Extension'
       ByteSize: 24
       GoRuntimeType: 486784
@@ -1057,21 +1057,21 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 107 PointerType *crypto/x509/pkix.Extension
+          Type: 164 PointerType *crypto/x509/pkix.Extension
         - Name: len
           Offset: 8
           Type: 9 BaseType int
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 227 GoSliceDataType []crypto/x509/pkix.Extension.array
+      Data: 235 GoSliceDataType []crypto/x509/pkix.Extension.array
     - __kind: GoSliceDataType
-      ID: 227
+      ID: 235
       Name: '[]crypto/x509/pkix.Extension.array'
       ByteSize: 2048
-      Element: 108 StructureType crypto/x509/pkix.Extension
+      Element: 165 StructureType crypto/x509/pkix.Extension
     - __kind: GoSliceHeaderType
-      ID: 109
+      ID: 166
       Name: '[]encoding/asn1.ObjectIdentifier'
       ByteSize: 24
       GoRuntimeType: 486848
@@ -1079,21 +1079,21 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 110 PointerType *encoding/asn1.ObjectIdentifier
+          Type: 167 PointerType *encoding/asn1.ObjectIdentifier
         - Name: len
           Offset: 8
           Type: 9 BaseType int
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 229 GoSliceDataType []encoding/asn1.ObjectIdentifier.array
+      Data: 237 GoSliceDataType []encoding/asn1.ObjectIdentifier.array
     - __kind: GoSliceDataType
-      ID: 229
+      ID: 237
       Name: '[]encoding/asn1.ObjectIdentifier.array'
       ByteSize: 2048
-      Element: 95 GoSliceHeaderType encoding/asn1.ObjectIdentifier
+      Element: 168 GoSliceHeaderType encoding/asn1.ObjectIdentifier
     - __kind: GoSliceHeaderType
-      ID: 166
+      ID: 87
       Name: '[]github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink'
       ByteSize: 24
       GoRuntimeType: 463584
@@ -1101,21 +1101,21 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 167 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink
+          Type: 88 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink
         - Name: len
           Offset: 8
           Type: 9 BaseType int
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 254 GoSliceDataType []github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink.array
+      Data: 211 GoSliceDataType []github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink.array
     - __kind: GoSliceDataType
-      ID: 254
+      ID: 211
       Name: '[]github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink.array'
       ByteSize: 2048
-      Element: 168 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink
+      Element: 89 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink
     - __kind: GoSliceHeaderType
-      ID: 169
+      ID: 90
       Name: '[]github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent'
       ByteSize: 24
       GoRuntimeType: 463776
@@ -1123,28 +1123,28 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 170 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent
+          Type: 91 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent
         - Name: len
           Offset: 8
           Type: 9 BaseType int
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 256 GoSliceDataType []github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent.array
+      Data: 213 GoSliceDataType []github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent.array
     - __kind: GoSliceDataType
-      ID: 256
+      ID: 213
       Name: '[]github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent.array'
       ByteSize: 2048
-      Element: 171 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent
+      Element: 92 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent
     - __kind: ArrayType
-      ID: 49
+      ID: 101
       Name: '[]key<string>'
       ByteSize: 128
       Count: 8
       HasCount: true
       Element: 11 GoStringHeaderType string
     - __kind: GoSliceHeaderType
-      ID: 114
+      ID: 172
       Name: '[]net.IP'
       ByteSize: 24
       GoRuntimeType: 458400
@@ -1152,21 +1152,21 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 115 PointerType *net.IP
+          Type: 173 PointerType *net.IP
         - Name: len
           Offset: 8
           Type: 9 BaseType int
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 233 GoSliceDataType []net.IP.array
+      Data: 243 GoSliceDataType []net.IP.array
     - __kind: GoSliceDataType
-      ID: 233
+      ID: 243
       Name: '[]net.IP.array'
       ByteSize: 2048
-      Element: 116 GoSliceHeaderType net.IP
+      Element: 174 GoSliceHeaderType net.IP
     - __kind: GoSliceHeaderType
-      ID: 139
+      ID: 122
       Name: '[]net/http.segment'
       ByteSize: 24
       GoRuntimeType: 459168
@@ -1174,21 +1174,21 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 140 PointerType *net/http.segment
+          Type: 123 PointerType *net/http.segment
         - Name: len
           Offset: 8
           Type: 9 BaseType int
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 249 GoSliceDataType []net/http.segment.array
+      Data: 226 GoSliceDataType []net/http.segment.array
     - __kind: GoSliceDataType
-      ID: 249
+      ID: 226
       Name: '[]net/http.segment.array'
       ByteSize: 2048
-      Element: 141 StructureType net/http.segment
+      Element: 124 StructureType net/http.segment
     - __kind: GoSliceHeaderType
-      ID: 51
+      ID: 56
       Name: '[]string'
       ByteSize: 24
       GoRuntimeType: 469152
@@ -1210,7 +1210,7 @@ Types:
       ByteSize: 2048
       Element: 11 GoStringHeaderType string
     - __kind: GoSliceHeaderType
-      ID: 99
+      ID: 190
       Name: '[]time.zone'
       ByteSize: 24
       GoRuntimeType: 463264
@@ -1218,21 +1218,21 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 100 PointerType *time.zone
+          Type: 191 PointerType *time.zone
         - Name: len
           Offset: 8
           Type: 9 BaseType int
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 223 GoSliceDataType []time.zone.array
+      Data: 255 GoSliceDataType []time.zone.array
     - __kind: GoSliceDataType
-      ID: 223
+      ID: 255
       Name: '[]time.zone.array'
       ByteSize: 2048
-      Element: 101 StructureType time.zone
+      Element: 192 StructureType time.zone
     - __kind: GoSliceHeaderType
-      ID: 102
+      ID: 193
       Name: '[]time.zoneTrans'
       ByteSize: 24
       GoRuntimeType: 463328
@@ -1240,21 +1240,21 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 103 PointerType *time.zoneTrans
+          Type: 194 PointerType *time.zoneTrans
         - Name: len
           Offset: 8
           Type: 9 BaseType int
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 225 GoSliceDataType []time.zoneTrans.array
+      Data: 257 GoSliceDataType []time.zoneTrans.array
     - __kind: GoSliceDataType
-      ID: 225
+      ID: 257
       Name: '[]time.zoneTrans.array'
       ByteSize: 2048
-      Element: 104 StructureType time.zoneTrans
+      Element: 195 StructureType time.zoneTrans
     - __kind: GoSliceHeaderType
-      ID: 76
+      ID: 96
       Name: '[]uint8'
       ByteSize: 24
       GoRuntimeType: 468000
@@ -1269,49 +1269,49 @@ Types:
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 213 GoSliceDataType []uint8.array
+      Data: 215 GoSliceDataType []uint8.array
     - __kind: GoSliceDataType
-      ID: 213
+      ID: 215
       Name: '[]uint8.array'
       ByteSize: 2048
       Element: 3 BaseType uint8
     - __kind: ArrayType
-      ID: 177
+      ID: 144
       Name: '[]val<*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>'
       ByteSize: 64
       Count: 8
       HasCount: true
-      Element: 178 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
+      Element: 145 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
     - __kind: ArrayType
-      ID: 70
+      ID: 139
       Name: '[]val<[]*mime/multipart.FileHeader>'
       ByteSize: 192
       Count: 8
       HasCount: true
-      Element: 71 GoSliceHeaderType []*mime/multipart.FileHeader
+      Element: 140 GoSliceHeaderType []*mime/multipart.FileHeader
     - __kind: ArrayType
-      ID: 50
+      ID: 102
       Name: '[]val<[]string>'
       ByteSize: 192
       Count: 8
       HasCount: true
-      Element: 51 GoSliceHeaderType []string
+      Element: 56 GoSliceHeaderType []string
     - __kind: ArrayType
-      ID: 165
+      ID: 128
       Name: '[]val<float64>'
       ByteSize: 64
       Count: 8
       HasCount: true
       Element: 17 BaseType float64
     - __kind: ArrayType
-      ID: 159
+      ID: 126
       Name: '[]val<interface {}>'
       ByteSize: 128
       Count: 8
       HasCount: true
-      Element: 85 GoEmptyInterfaceType interface {}
+      Element: 127 GoEmptyInterfaceType interface {}
     - __kind: ArrayType
-      ID: 147
+      ID: 125
       Name: '[]val<string>'
       ByteSize: 128
       Count: 8
@@ -1324,121 +1324,121 @@ Types:
       GoRuntimeType: 543552
       GoKind: 1
     - __kind: GoHMapBucketType
-      ID: 176
+      ID: 133
       Name: bucket<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
       ByteSize: 208
       RawFields:
         - Name: tophash
           Offset: 0
-          Type: 48 ArrayType [8]uint8
+          Type: 100 ArrayType [8]uint8
         - Name: keys
           Offset: 8
-          Type: 49 ArrayType []key<string>
+          Type: 101 ArrayType []key<string>
         - Name: values
           Offset: 136
-          Type: 177 ArrayType []val<*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
+          Type: 144 ArrayType []val<*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
         - Name: overflow
           Offset: 200
-          Type: 175 PointerType *bucket<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
+          Type: 132 PointerType *bucket<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
       KeyType: 11 GoStringHeaderType string
-      ValueType: 178 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
+      ValueType: 145 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
     - __kind: GoHMapBucketType
-      ID: 69
+      ID: 112
       Name: bucket<string,[]*mime/multipart.FileHeader>
       ByteSize: 336
       RawFields:
         - Name: tophash
           Offset: 0
-          Type: 48 ArrayType [8]uint8
+          Type: 100 ArrayType [8]uint8
         - Name: keys
           Offset: 8
-          Type: 49 ArrayType []key<string>
+          Type: 101 ArrayType []key<string>
         - Name: values
           Offset: 136
-          Type: 70 ArrayType []val<[]*mime/multipart.FileHeader>
+          Type: 139 ArrayType []val<[]*mime/multipart.FileHeader>
         - Name: overflow
           Offset: 328
-          Type: 68 PointerType *bucket<string,[]*mime/multipart.FileHeader>
+          Type: 111 PointerType *bucket<string,[]*mime/multipart.FileHeader>
       KeyType: 11 GoStringHeaderType string
-      ValueType: 71 GoSliceHeaderType []*mime/multipart.FileHeader
+      ValueType: 140 GoSliceHeaderType []*mime/multipart.FileHeader
     - __kind: GoHMapBucketType
-      ID: 47
+      ID: 51
       Name: bucket<string,[]string>
       ByteSize: 336
       RawFields:
         - Name: tophash
           Offset: 0
-          Type: 48 ArrayType [8]uint8
+          Type: 100 ArrayType [8]uint8
         - Name: keys
           Offset: 8
-          Type: 49 ArrayType []key<string>
+          Type: 101 ArrayType []key<string>
         - Name: values
           Offset: 136
-          Type: 50 ArrayType []val<[]string>
+          Type: 102 ArrayType []val<[]string>
         - Name: overflow
           Offset: 328
-          Type: 46 PointerType *bucket<string,[]string>
+          Type: 50 PointerType *bucket<string,[]string>
       KeyType: 11 GoStringHeaderType string
-      ValueType: 51 GoSliceHeaderType []string
+      ValueType: 56 GoSliceHeaderType []string
     - __kind: GoHMapBucketType
-      ID: 164
+      ID: 86
       Name: bucket<string,float64>
       ByteSize: 208
       RawFields:
         - Name: tophash
           Offset: 0
-          Type: 48 ArrayType [8]uint8
+          Type: 100 ArrayType [8]uint8
         - Name: keys
           Offset: 8
-          Type: 49 ArrayType []key<string>
+          Type: 101 ArrayType []key<string>
         - Name: values
           Offset: 136
-          Type: 165 ArrayType []val<float64>
+          Type: 128 ArrayType []val<float64>
         - Name: overflow
           Offset: 200
-          Type: 163 PointerType *bucket<string,float64>
+          Type: 85 PointerType *bucket<string,float64>
       KeyType: 11 GoStringHeaderType string
       ValueType: 17 BaseType float64
     - __kind: GoHMapBucketType
-      ID: 158
+      ID: 81
       Name: bucket<string,interface {}>
       ByteSize: 272
       RawFields:
         - Name: tophash
           Offset: 0
-          Type: 48 ArrayType [8]uint8
+          Type: 100 ArrayType [8]uint8
         - Name: keys
           Offset: 8
-          Type: 49 ArrayType []key<string>
+          Type: 101 ArrayType []key<string>
         - Name: values
           Offset: 136
-          Type: 159 ArrayType []val<interface {}>
+          Type: 126 ArrayType []val<interface {}>
         - Name: overflow
           Offset: 264
-          Type: 157 PointerType *bucket<string,interface {}>
+          Type: 80 PointerType *bucket<string,interface {}>
       KeyType: 11 GoStringHeaderType string
-      ValueType: 85 GoEmptyInterfaceType interface {}
+      ValueType: 127 GoEmptyInterfaceType interface {}
     - __kind: GoHMapBucketType
-      ID: 146
+      ID: 72
       Name: bucket<string,string>
       ByteSize: 272
       RawFields:
         - Name: tophash
           Offset: 0
-          Type: 48 ArrayType [8]uint8
+          Type: 100 ArrayType [8]uint8
         - Name: keys
           Offset: 8
-          Type: 49 ArrayType []key<string>
+          Type: 101 ArrayType []key<string>
         - Name: values
           Offset: 136
-          Type: 147 ArrayType []val<string>
+          Type: 125 ArrayType []val<string>
         - Name: overflow
           Offset: 264
-          Type: 145 PointerType *bucket<string,string>
+          Type: 71 PointerType *bucket<string,string>
       KeyType: 11 GoStringHeaderType string
       ValueType: 11 GoStringHeaderType string
     - __kind: StructureType
-      ID: 199
+      ID: 42
       Name: bytes.Buffer
       ByteSize: 40
       GoRuntimeType: 1.4512e+06
@@ -1446,15 +1446,15 @@ Types:
       RawFields:
         - Name: buf
           Offset: 0
-          Type: 76 GoSliceHeaderType []uint8
+          Type: 96 GoSliceHeaderType []uint8
         - Name: off
           Offset: 24
           Type: 9 BaseType int
         - Name: lastRead
           Offset: 32
-          Type: 200 BaseType bytes.readOp
+          Type: 97 BaseType bytes.readOp
     - __kind: BaseType
-      ID: 200
+      ID: 97
       Name: bytes.readOp
       ByteSize: 1
       GoRuntimeType: 541760
@@ -1472,7 +1472,7 @@ Types:
       GoRuntimeType: 543296
       GoKind: 15
     - __kind: GoInterfaceType
-      ID: 136
+      ID: 65
       Name: context.Context
       ByteSize: 16
       GoRuntimeType: 1.215776e+06
@@ -1485,22 +1485,22 @@ Types:
           Offset: 8
           Type: 19 VoidPointerType unsafe.Pointer
     - __kind: StructureType
-      ID: 201
+      ID: 43
       Name: context.backgroundCtx
       GoRuntimeType: 1.708832e+06
       GoKind: 25
       RawFields:
         - Name: emptyCtx
           Offset: 0
-          Type: 202 StructureType context.emptyCtx
+          Type: 44 StructureType context.emptyCtx
     - __kind: StructureType
-      ID: 202
+      ID: 44
       Name: context.emptyCtx
       GoRuntimeType: 1.435104e+06
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 78
+      ID: 61
       Name: crypto/tls.ConnectionState
       ByteSize: 192
       GoRuntimeType: 2.16096e+06
@@ -1529,39 +1529,39 @@ Types:
           Type: 11 GoStringHeaderType string
         - Name: PeerCertificates
           Offset: 48
-          Type: 79 GoSliceHeaderType []*crypto/x509.Certificate
+          Type: 113 GoSliceHeaderType []*crypto/x509.Certificate
         - Name: VerifiedChains
           Offset: 72
-          Type: 127 GoSliceHeaderType [][]*crypto/x509.Certificate
+          Type: 116 GoSliceHeaderType [][]*crypto/x509.Certificate
         - Name: SignedCertificateTimestamps
           Offset: 96
-          Type: 129 GoSliceHeaderType [][]uint8
+          Type: 118 GoSliceHeaderType [][]uint8
         - Name: OCSPResponse
           Offset: 120
-          Type: 76 GoSliceHeaderType []uint8
+          Type: 96 GoSliceHeaderType []uint8
         - Name: TLSUnique
           Offset: 144
-          Type: 76 GoSliceHeaderType []uint8
+          Type: 96 GoSliceHeaderType []uint8
         - Name: ECHAccepted
           Offset: 168
           Type: 4 BaseType bool
         - Name: ekm
           Offset: 176
-          Type: 131 GoSubroutineType func(string, []uint8, int) ([]uint8, error)
+          Type: 120 GoSubroutineType func(string, []uint8, int) ([]uint8, error)
         - Name: testingOnlyDidHRR
           Offset: 184
           Type: 4 BaseType bool
         - Name: testingOnlyCurveID
           Offset: 186
-          Type: 132 BaseType crypto/tls.CurveID
+          Type: 121 BaseType crypto/tls.CurveID
     - __kind: BaseType
-      ID: 132
+      ID: 121
       Name: crypto/tls.CurveID
       ByteSize: 2
       GoRuntimeType: 778592
       GoKind: 9
     - __kind: StructureType
-      ID: 82
+      ID: 143
       Name: crypto/x509.Certificate
       ByteSize: 1352
       GoRuntimeType: 2.300992e+06
@@ -1569,67 +1569,67 @@ Types:
       RawFields:
         - Name: Raw
           Offset: 0
-          Type: 76 GoSliceHeaderType []uint8
+          Type: 96 GoSliceHeaderType []uint8
         - Name: RawTBSCertificate
           Offset: 24
-          Type: 76 GoSliceHeaderType []uint8
+          Type: 96 GoSliceHeaderType []uint8
         - Name: RawSubjectPublicKeyInfo
           Offset: 48
-          Type: 76 GoSliceHeaderType []uint8
+          Type: 96 GoSliceHeaderType []uint8
         - Name: RawSubject
           Offset: 72
-          Type: 76 GoSliceHeaderType []uint8
+          Type: 96 GoSliceHeaderType []uint8
         - Name: RawIssuer
           Offset: 96
-          Type: 76 GoSliceHeaderType []uint8
+          Type: 96 GoSliceHeaderType []uint8
         - Name: Signature
           Offset: 120
-          Type: 76 GoSliceHeaderType []uint8
+          Type: 96 GoSliceHeaderType []uint8
         - Name: SignatureAlgorithm
           Offset: 144
-          Type: 83 BaseType crypto/x509.SignatureAlgorithm
+          Type: 151 BaseType crypto/x509.SignatureAlgorithm
         - Name: PublicKeyAlgorithm
           Offset: 152
-          Type: 84 BaseType crypto/x509.PublicKeyAlgorithm
+          Type: 152 BaseType crypto/x509.PublicKeyAlgorithm
         - Name: PublicKey
           Offset: 160
-          Type: 85 GoEmptyInterfaceType interface {}
+          Type: 127 GoEmptyInterfaceType interface {}
         - Name: Version
           Offset: 176
           Type: 9 BaseType int
         - Name: SerialNumber
           Offset: 184
-          Type: 86 PointerType *math/big.Int
+          Type: 153 PointerType *math/big.Int
         - Name: Issuer
           Offset: 192
-          Type: 91 StructureType crypto/x509/pkix.Name
+          Type: 155 StructureType crypto/x509/pkix.Name
         - Name: Subject
           Offset: 440
-          Type: 91 StructureType crypto/x509/pkix.Name
+          Type: 155 StructureType crypto/x509/pkix.Name
         - Name: NotBefore
           Offset: 688
-          Type: 96 StructureType time.Time
+          Type: 159 StructureType time.Time
         - Name: NotAfter
           Offset: 712
-          Type: 96 StructureType time.Time
+          Type: 159 StructureType time.Time
         - Name: KeyUsage
           Offset: 736
-          Type: 105 BaseType crypto/x509.KeyUsage
+          Type: 162 BaseType crypto/x509.KeyUsage
         - Name: Extensions
           Offset: 744
-          Type: 106 GoSliceHeaderType []crypto/x509/pkix.Extension
+          Type: 163 GoSliceHeaderType []crypto/x509/pkix.Extension
         - Name: ExtraExtensions
           Offset: 768
-          Type: 106 GoSliceHeaderType []crypto/x509/pkix.Extension
+          Type: 163 GoSliceHeaderType []crypto/x509/pkix.Extension
         - Name: UnhandledCriticalExtensions
           Offset: 792
-          Type: 109 GoSliceHeaderType []encoding/asn1.ObjectIdentifier
+          Type: 166 GoSliceHeaderType []encoding/asn1.ObjectIdentifier
         - Name: ExtKeyUsage
           Offset: 816
-          Type: 111 GoSliceHeaderType []crypto/x509.ExtKeyUsage
+          Type: 169 GoSliceHeaderType []crypto/x509.ExtKeyUsage
         - Name: UnknownExtKeyUsage
           Offset: 840
-          Type: 109 GoSliceHeaderType []encoding/asn1.ObjectIdentifier
+          Type: 166 GoSliceHeaderType []encoding/asn1.ObjectIdentifier
         - Name: BasicConstraintsValid
           Offset: 864
           Type: 4 BaseType bool
@@ -1644,78 +1644,78 @@ Types:
           Type: 4 BaseType bool
         - Name: SubjectKeyId
           Offset: 888
-          Type: 76 GoSliceHeaderType []uint8
+          Type: 96 GoSliceHeaderType []uint8
         - Name: AuthorityKeyId
           Offset: 912
-          Type: 76 GoSliceHeaderType []uint8
+          Type: 96 GoSliceHeaderType []uint8
         - Name: OCSPServer
           Offset: 936
-          Type: 51 GoSliceHeaderType []string
+          Type: 56 GoSliceHeaderType []string
         - Name: IssuingCertificateURL
           Offset: 960
-          Type: 51 GoSliceHeaderType []string
+          Type: 56 GoSliceHeaderType []string
         - Name: DNSNames
           Offset: 984
-          Type: 51 GoSliceHeaderType []string
+          Type: 56 GoSliceHeaderType []string
         - Name: EmailAddresses
           Offset: 1008
-          Type: 51 GoSliceHeaderType []string
+          Type: 56 GoSliceHeaderType []string
         - Name: IPAddresses
           Offset: 1032
-          Type: 114 GoSliceHeaderType []net.IP
+          Type: 172 GoSliceHeaderType []net.IP
         - Name: URIs
           Offset: 1056
-          Type: 117 GoSliceHeaderType []*net/url.URL
+          Type: 175 GoSliceHeaderType []*net/url.URL
         - Name: PermittedDNSDomainsCritical
           Offset: 1080
           Type: 4 BaseType bool
         - Name: PermittedDNSDomains
           Offset: 1088
-          Type: 51 GoSliceHeaderType []string
+          Type: 56 GoSliceHeaderType []string
         - Name: ExcludedDNSDomains
           Offset: 1112
-          Type: 51 GoSliceHeaderType []string
+          Type: 56 GoSliceHeaderType []string
         - Name: PermittedIPRanges
           Offset: 1136
-          Type: 119 GoSliceHeaderType []*net.IPNet
+          Type: 177 GoSliceHeaderType []*net.IPNet
         - Name: ExcludedIPRanges
           Offset: 1160
-          Type: 119 GoSliceHeaderType []*net.IPNet
+          Type: 177 GoSliceHeaderType []*net.IPNet
         - Name: PermittedEmailAddresses
           Offset: 1184
-          Type: 51 GoSliceHeaderType []string
+          Type: 56 GoSliceHeaderType []string
         - Name: ExcludedEmailAddresses
           Offset: 1208
-          Type: 51 GoSliceHeaderType []string
+          Type: 56 GoSliceHeaderType []string
         - Name: PermittedURIDomains
           Offset: 1232
-          Type: 51 GoSliceHeaderType []string
+          Type: 56 GoSliceHeaderType []string
         - Name: ExcludedURIDomains
           Offset: 1256
-          Type: 51 GoSliceHeaderType []string
+          Type: 56 GoSliceHeaderType []string
         - Name: CRLDistributionPoints
           Offset: 1280
-          Type: 51 GoSliceHeaderType []string
+          Type: 56 GoSliceHeaderType []string
         - Name: PolicyIdentifiers
           Offset: 1304
-          Type: 109 GoSliceHeaderType []encoding/asn1.ObjectIdentifier
+          Type: 166 GoSliceHeaderType []encoding/asn1.ObjectIdentifier
         - Name: Policies
           Offset: 1328
-          Type: 124 GoSliceHeaderType []crypto/x509.OID
+          Type: 180 GoSliceHeaderType []crypto/x509.OID
     - __kind: BaseType
-      ID: 113
+      ID: 171
       Name: crypto/x509.ExtKeyUsage
       ByteSize: 8
       GoRuntimeType: 546624
       GoKind: 2
     - __kind: BaseType
-      ID: 105
+      ID: 162
       Name: crypto/x509.KeyUsage
       ByteSize: 8
       GoRuntimeType: 546560
       GoKind: 2
     - __kind: StructureType
-      ID: 126
+      ID: 182
       Name: crypto/x509.OID
       ByteSize: 24
       GoRuntimeType: 1.762592e+06
@@ -1723,21 +1723,21 @@ Types:
       RawFields:
         - Name: der
           Offset: 0
-          Type: 76 GoSliceHeaderType []uint8
+          Type: 96 GoSliceHeaderType []uint8
     - __kind: BaseType
-      ID: 84
+      ID: 152
       Name: crypto/x509.PublicKeyAlgorithm
       ByteSize: 8
       GoRuntimeType: 780896
       GoKind: 2
     - __kind: BaseType
-      ID: 83
+      ID: 151
       Name: crypto/x509.SignatureAlgorithm
       ByteSize: 8
       GoRuntimeType: 1.09744e+06
       GoKind: 2
     - __kind: StructureType
-      ID: 94
+      ID: 158
       Name: crypto/x509/pkix.AttributeTypeAndValue
       ByteSize: 40
       GoRuntimeType: 1.349408e+06
@@ -1745,12 +1745,12 @@ Types:
       RawFields:
         - Name: Type
           Offset: 0
-          Type: 95 GoSliceHeaderType encoding/asn1.ObjectIdentifier
+          Type: 168 GoSliceHeaderType encoding/asn1.ObjectIdentifier
         - Name: Value
           Offset: 24
-          Type: 85 GoEmptyInterfaceType interface {}
+          Type: 127 GoEmptyInterfaceType interface {}
     - __kind: StructureType
-      ID: 108
+      ID: 165
       Name: crypto/x509/pkix.Extension
       ByteSize: 56
       GoRuntimeType: 1.494976e+06
@@ -1758,15 +1758,15 @@ Types:
       RawFields:
         - Name: Id
           Offset: 0
-          Type: 95 GoSliceHeaderType encoding/asn1.ObjectIdentifier
+          Type: 168 GoSliceHeaderType encoding/asn1.ObjectIdentifier
         - Name: Critical
           Offset: 24
           Type: 4 BaseType bool
         - Name: Value
           Offset: 32
-          Type: 76 GoSliceHeaderType []uint8
+          Type: 96 GoSliceHeaderType []uint8
     - __kind: StructureType
-      ID: 91
+      ID: 155
       Name: crypto/x509/pkix.Name
       ByteSize: 248
       GoRuntimeType: 2.105696e+06
@@ -1774,25 +1774,25 @@ Types:
       RawFields:
         - Name: Country
           Offset: 0
-          Type: 51 GoSliceHeaderType []string
+          Type: 56 GoSliceHeaderType []string
         - Name: Organization
           Offset: 24
-          Type: 51 GoSliceHeaderType []string
+          Type: 56 GoSliceHeaderType []string
         - Name: OrganizationalUnit
           Offset: 48
-          Type: 51 GoSliceHeaderType []string
+          Type: 56 GoSliceHeaderType []string
         - Name: Locality
           Offset: 72
-          Type: 51 GoSliceHeaderType []string
+          Type: 56 GoSliceHeaderType []string
         - Name: Province
           Offset: 96
-          Type: 51 GoSliceHeaderType []string
+          Type: 56 GoSliceHeaderType []string
         - Name: StreetAddress
           Offset: 120
-          Type: 51 GoSliceHeaderType []string
+          Type: 56 GoSliceHeaderType []string
         - Name: PostalCode
           Offset: 144
-          Type: 51 GoSliceHeaderType []string
+          Type: 56 GoSliceHeaderType []string
         - Name: SerialNumber
           Offset: 168
           Type: 11 GoStringHeaderType string
@@ -1801,12 +1801,12 @@ Types:
           Type: 11 GoStringHeaderType string
         - Name: Names
           Offset: 200
-          Type: 92 GoSliceHeaderType []crypto/x509/pkix.AttributeTypeAndValue
+          Type: 156 GoSliceHeaderType []crypto/x509/pkix.AttributeTypeAndValue
         - Name: ExtraNames
           Offset: 224
-          Type: 92 GoSliceHeaderType []crypto/x509/pkix.AttributeTypeAndValue
+          Type: 156 GoSliceHeaderType []crypto/x509/pkix.AttributeTypeAndValue
     - __kind: GoSliceHeaderType
-      ID: 95
+      ID: 168
       Name: encoding/asn1.ObjectIdentifier
       ByteSize: 24
       GoRuntimeType: 1.0376e+06
@@ -1821,9 +1821,9 @@ Types:
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 221 GoSliceDataType encoding/asn1.ObjectIdentifier.array
+      Data: 239 GoSliceDataType encoding/asn1.ObjectIdentifier.array
     - __kind: GoSliceDataType
-      ID: 221
+      ID: 239
       Name: encoding/asn1.ObjectIdentifier.array
       ByteSize: 2048
       Element: 9 BaseType int
@@ -1853,25 +1853,25 @@ Types:
       GoRuntimeType: 543488
       GoKind: 14
     - __kind: GoSubroutineType
-      ID: 197
+      ID: 95
       Name: func()
       ByteSize: 8
       GoRuntimeType: 455520
       GoKind: 19
     - __kind: GoSubroutineType
-      ID: 60
+      ID: 55
       Name: func() (io.ReadCloser, error)
       ByteSize: 8
       GoRuntimeType: 645600
       GoKind: 19
     - __kind: GoSubroutineType
-      ID: 131
+      ID: 120
       Name: func(string, []uint8, int) ([]uint8, error)
       ByteSize: 8
       GoRuntimeType: 983200
       GoKind: 19
     - __kind: StructureType
-      ID: 149
+      ID: 40
       Name: github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span
       ByteSize: 288
       GoRuntimeType: 2.252e+06
@@ -1879,7 +1879,7 @@ Types:
       RawFields:
         - Name: mu
           Offset: 0
-          Type: 150 StructureType sync.RWMutex
+          Type: 73 StructureType sync.RWMutex
         - Name: name
           Offset: 24
           Type: 11 GoStringHeaderType string
@@ -1900,13 +1900,13 @@ Types:
           Type: 14 BaseType int64
         - Name: meta
           Offset: 104
-          Type: 142 GoMapType map[string]string
+          Type: 68 GoMapType map[string]string
         - Name: metaStruct
           Offset: 112
-          Type: 154 GoMapType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.metaStructMap
+          Type: 77 GoMapType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.metaStructMap
         - Name: metrics
           Offset: 120
-          Type: 160 GoMapType map[string]float64
+          Type: 82 GoMapType map[string]float64
         - Name: spanID
           Offset: 128
           Type: 10 BaseType uint64
@@ -1921,10 +1921,10 @@ Types:
           Type: 13 BaseType int32
         - Name: spanLinks
           Offset: 160
-          Type: 166 GoSliceHeaderType []github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink
+          Type: 87 GoSliceHeaderType []github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink
         - Name: spanEvents
           Offset: 184
-          Type: 169 GoSliceHeaderType []github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent
+          Type: 90 GoSliceHeaderType []github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent
         - Name: goExecTraced
           Offset: 208
           Type: 4 BaseType bool
@@ -1936,7 +1936,7 @@ Types:
           Type: 4 BaseType bool
         - Name: context
           Offset: 216
-          Type: 189 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanContext
+          Type: 93 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanContext
         - Name: integration
           Offset: 224
           Type: 11 GoStringHeaderType string
@@ -1945,15 +1945,15 @@ Types:
           Type: 4 BaseType bool
         - Name: pprofCtxActive
           Offset: 248
-          Type: 136 GoInterfaceType context.Context
+          Type: 65 GoInterfaceType context.Context
         - Name: pprofCtxRestore
           Offset: 264
-          Type: 136 GoInterfaceType context.Context
+          Type: 65 GoInterfaceType context.Context
         - Name: taskEnd
           Offset: 280
-          Type: 197 GoSubroutineType func()
+          Type: 95 GoSubroutineType func()
     - __kind: StructureType
-      ID: 190
+      ID: 94
       Name: github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanContext
       ByteSize: 168
       GoRuntimeType: 2.125376e+06
@@ -1964,13 +1964,13 @@ Types:
           Type: 4 BaseType bool
         - Name: trace
           Offset: 8
-          Type: 191 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.trace
+          Type: 135 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.trace
         - Name: span
           Offset: 16
-          Type: 148 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span
+          Type: 39 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span
         - Name: errors
           Offset: 24
-          Type: 152 StructureType sync/atomic.Int32
+          Type: 75 StructureType sync/atomic.Int32
         - Name: reparentID
           Offset: 32
           Type: 11 GoStringHeaderType string
@@ -1979,16 +1979,16 @@ Types:
           Type: 4 BaseType bool
         - Name: traceID
           Offset: 49
-          Type: 196 ArrayType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.traceID
+          Type: 137 ArrayType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.traceID
         - Name: spanID
           Offset: 72
           Type: 10 BaseType uint64
         - Name: mu
           Offset: 80
-          Type: 150 StructureType sync.RWMutex
+          Type: 73 StructureType sync.RWMutex
         - Name: baggage
           Offset: 104
-          Type: 142 GoMapType map[string]string
+          Type: 68 GoMapType map[string]string
         - Name: hasBaggage
           Offset: 112
           Type: 2 BaseType uint32
@@ -1997,12 +1997,12 @@ Types:
           Type: 11 GoStringHeaderType string
         - Name: spanLinks
           Offset: 136
-          Type: 166 GoSliceHeaderType []github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink
+          Type: 87 GoSliceHeaderType []github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink
         - Name: baggageOnly
           Offset: 160
           Type: 4 BaseType bool
     - __kind: StructureType
-      ID: 168
+      ID: 89
       Name: github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink
       ByteSize: 56
       GoRuntimeType: 1.822592e+06
@@ -2019,7 +2019,7 @@ Types:
           Type: 10 BaseType uint64
         - Name: Attributes
           Offset: 24
-          Type: 142 GoMapType map[string]string
+          Type: 68 GoMapType map[string]string
         - Name: Tracestate
           Offset: 32
           Type: 11 GoStringHeaderType string
@@ -2027,20 +2027,20 @@ Types:
           Offset: 48
           Type: 2 BaseType uint32
     - __kind: GoMapType
-      ID: 154
+      ID: 77
       Name: github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.metaStructMap
       ByteSize: 8
       GoRuntimeType: 1.00752e+06
       GoKind: 21
-      HeaderType: 156 GoHMapHeaderType hash<string,interface {}>
+      HeaderType: 79 GoHMapHeaderType hash<string,interface {}>
     - __kind: BaseType
-      ID: 195
+      ID: 149
       Name: github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.samplingDecision
       ByteSize: 4
       GoRuntimeType: 542336
       GoKind: 10
     - __kind: StructureType
-      ID: 171
+      ID: 92
       Name: github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent
       ByteSize: 40
       GoRuntimeType: 1.664384e+06
@@ -2054,12 +2054,12 @@ Types:
           Type: 10 BaseType uint64
         - Name: Attributes
           Offset: 24
-          Type: 172 GoMapType map[string]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
+          Type: 129 GoMapType map[string]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
         - Name: RawAttributes
           Offset: 32
-          Type: 188 GoMapType map[string]interface {}
+          Type: 134 GoMapType map[string]interface {}
     - __kind: StructureType
-      ID: 182
+      ID: 185
       Name: github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttribute
       ByteSize: 24
       GoRuntimeType: 1.13008e+06
@@ -2067,9 +2067,9 @@ Types:
       RawFields:
         - Name: Values
           Offset: 0
-          Type: 183 GoSliceHeaderType []*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttributeValue
+          Type: 197 GoSliceHeaderType []*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttributeValue
     - __kind: StructureType
-      ID: 186
+      ID: 201
       Name: github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttributeValue
       ByteSize: 48
       GoRuntimeType: 1.74848e+06
@@ -2077,7 +2077,7 @@ Types:
       RawFields:
         - Name: Type
           Offset: 0
-          Type: 187 BaseType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttributeValueType
+          Type: 202 BaseType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttributeValueType
         - Name: StringValue
           Offset: 8
           Type: 11 GoStringHeaderType string
@@ -2091,13 +2091,13 @@ Types:
           Offset: 40
           Type: 17 BaseType float64
     - __kind: BaseType
-      ID: 187
+      ID: 202
       Name: github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttributeValueType
       ByteSize: 4
       GoRuntimeType: 965344
       GoKind: 5
     - __kind: StructureType
-      ID: 179
+      ID: 146
       Name: github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
       ByteSize: 56
       GoRuntimeType: 1.822848e+06
@@ -2105,7 +2105,7 @@ Types:
       RawFields:
         - Name: Type
           Offset: 0
-          Type: 180 BaseType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttributeType
+          Type: 183 BaseType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttributeType
         - Name: StringValue
           Offset: 8
           Type: 11 GoStringHeaderType string
@@ -2120,15 +2120,15 @@ Types:
           Type: 17 BaseType float64
         - Name: ArrayValue
           Offset: 48
-          Type: 181 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttribute
+          Type: 184 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttribute
     - __kind: BaseType
-      ID: 180
+      ID: 183
       Name: github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttributeType
       ByteSize: 4
       GoRuntimeType: 965248
       GoKind: 5
     - __kind: StructureType
-      ID: 192
+      ID: 136
       Name: github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.trace
       ByteSize: 104
       GoRuntimeType: 2.017536e+06
@@ -2136,16 +2136,16 @@ Types:
       RawFields:
         - Name: mu
           Offset: 0
-          Type: 150 StructureType sync.RWMutex
+          Type: 73 StructureType sync.RWMutex
         - Name: spans
           Offset: 24
-          Type: 193 GoSliceHeaderType []*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span
+          Type: 147 GoSliceHeaderType []*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span
         - Name: tags
           Offset: 48
-          Type: 142 GoMapType map[string]string
+          Type: 68 GoMapType map[string]string
         - Name: propagatingTags
           Offset: 56
-          Type: 142 GoMapType map[string]string
+          Type: 68 GoMapType map[string]string
         - Name: finished
           Offset: 64
           Type: 9 BaseType int
@@ -2160,12 +2160,12 @@ Types:
           Type: 4 BaseType bool
         - Name: samplingDecision
           Offset: 92
-          Type: 195 BaseType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.samplingDecision
+          Type: 149 BaseType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.samplingDecision
         - Name: root
           Offset: 96
-          Type: 148 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span
+          Type: 39 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span
     - __kind: ArrayType
-      ID: 196
+      ID: 137
       Name: github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.traceID
       ByteSize: 16
       GoRuntimeType: 847712
@@ -2174,7 +2174,7 @@ Types:
       HasCount: true
       Element: 3 BaseType uint8
     - __kind: GoHMapHeaderType
-      ID: 174
+      ID: 131
       Name: hash<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
       ByteSize: 48
       RawFields:
@@ -2195,20 +2195,20 @@ Types:
           Type: 2 BaseType uint32
         - Name: buckets
           Offset: 16
-          Type: 175 PointerType *bucket<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
+          Type: 132 PointerType *bucket<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
         - Name: oldbuckets
           Offset: 24
-          Type: 175 PointerType *bucket<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
+          Type: 132 PointerType *bucket<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
         - Name: nevacuate
           Offset: 32
           Type: 1 BaseType uintptr
         - Name: extra
           Offset: 40
           Type: 52 PointerType *runtime.mapextra
-      BucketType: 176 GoHMapBucketType bucket<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
-      BucketsType: 258 GoSliceDataType []bucket<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>.array
+      BucketType: 133 GoHMapBucketType bucket<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
+      BucketsType: 228 GoSliceDataType []bucket<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>.array
     - __kind: GoHMapHeaderType
-      ID: 67
+      ID: 110
       Name: hash<string,[]*mime/multipart.FileHeader>
       ByteSize: 48
       RawFields:
@@ -2229,20 +2229,20 @@ Types:
           Type: 2 BaseType uint32
         - Name: buckets
           Offset: 16
-          Type: 68 PointerType *bucket<string,[]*mime/multipart.FileHeader>
+          Type: 111 PointerType *bucket<string,[]*mime/multipart.FileHeader>
         - Name: oldbuckets
           Offset: 24
-          Type: 68 PointerType *bucket<string,[]*mime/multipart.FileHeader>
+          Type: 111 PointerType *bucket<string,[]*mime/multipart.FileHeader>
         - Name: nevacuate
           Offset: 32
           Type: 1 BaseType uintptr
         - Name: extra
           Offset: 40
           Type: 52 PointerType *runtime.mapextra
-      BucketType: 69 GoHMapBucketType bucket<string,[]*mime/multipart.FileHeader>
-      BucketsType: 210 GoSliceDataType []bucket<string,[]*mime/multipart.FileHeader>.array
+      BucketType: 112 GoHMapBucketType bucket<string,[]*mime/multipart.FileHeader>
+      BucketsType: 219 GoSliceDataType []bucket<string,[]*mime/multipart.FileHeader>.array
     - __kind: GoHMapHeaderType
-      ID: 45
+      ID: 49
       Name: hash<string,[]string>
       ByteSize: 48
       RawFields:
@@ -2263,20 +2263,20 @@ Types:
           Type: 2 BaseType uint32
         - Name: buckets
           Offset: 16
-          Type: 46 PointerType *bucket<string,[]string>
+          Type: 50 PointerType *bucket<string,[]string>
         - Name: oldbuckets
           Offset: 24
-          Type: 46 PointerType *bucket<string,[]string>
+          Type: 50 PointerType *bucket<string,[]string>
         - Name: nevacuate
           Offset: 32
           Type: 1 BaseType uintptr
         - Name: extra
           Offset: 40
           Type: 52 PointerType *runtime.mapextra
-      BucketType: 47 GoHMapBucketType bucket<string,[]string>
+      BucketType: 51 GoHMapBucketType bucket<string,[]string>
       BucketsType: 205 GoSliceDataType []bucket<string,[]string>.array
     - __kind: GoHMapHeaderType
-      ID: 162
+      ID: 84
       Name: hash<string,float64>
       ByteSize: 48
       RawFields:
@@ -2297,20 +2297,20 @@ Types:
           Type: 2 BaseType uint32
         - Name: buckets
           Offset: 16
-          Type: 163 PointerType *bucket<string,float64>
+          Type: 85 PointerType *bucket<string,float64>
         - Name: oldbuckets
           Offset: 24
-          Type: 163 PointerType *bucket<string,float64>
+          Type: 85 PointerType *bucket<string,float64>
         - Name: nevacuate
           Offset: 32
           Type: 1 BaseType uintptr
         - Name: extra
           Offset: 40
           Type: 52 PointerType *runtime.mapextra
-      BucketType: 164 GoHMapBucketType bucket<string,float64>
-      BucketsType: 253 GoSliceDataType []bucket<string,float64>.array
+      BucketType: 86 GoHMapBucketType bucket<string,float64>
+      BucketsType: 210 GoSliceDataType []bucket<string,float64>.array
     - __kind: GoHMapHeaderType
-      ID: 156
+      ID: 79
       Name: hash<string,interface {}>
       ByteSize: 48
       RawFields:
@@ -2331,20 +2331,20 @@ Types:
           Type: 2 BaseType uint32
         - Name: buckets
           Offset: 16
-          Type: 157 PointerType *bucket<string,interface {}>
+          Type: 80 PointerType *bucket<string,interface {}>
         - Name: oldbuckets
           Offset: 24
-          Type: 157 PointerType *bucket<string,interface {}>
+          Type: 80 PointerType *bucket<string,interface {}>
         - Name: nevacuate
           Offset: 32
           Type: 1 BaseType uintptr
         - Name: extra
           Offset: 40
           Type: 52 PointerType *runtime.mapextra
-      BucketType: 158 GoHMapBucketType bucket<string,interface {}>
-      BucketsType: 252 GoSliceDataType []bucket<string,interface {}>.array
+      BucketType: 81 GoHMapBucketType bucket<string,interface {}>
+      BucketsType: 209 GoSliceDataType []bucket<string,interface {}>.array
     - __kind: GoHMapHeaderType
-      ID: 144
+      ID: 70
       Name: hash<string,string>
       ByteSize: 48
       RawFields:
@@ -2365,18 +2365,18 @@ Types:
           Type: 2 BaseType uint32
         - Name: buckets
           Offset: 16
-          Type: 145 PointerType *bucket<string,string>
+          Type: 71 PointerType *bucket<string,string>
         - Name: oldbuckets
           Offset: 24
-          Type: 145 PointerType *bucket<string,string>
+          Type: 71 PointerType *bucket<string,string>
         - Name: nevacuate
           Offset: 32
           Type: 1 BaseType uintptr
         - Name: extra
           Offset: 40
           Type: 52 PointerType *runtime.mapextra
-      BucketType: 146 GoHMapBucketType bucket<string,string>
-      BucketsType: 251 GoSliceDataType []bucket<string,string>.array
+      BucketType: 72 GoHMapBucketType bucket<string,string>
+      BucketsType: 208 GoSliceDataType []bucket<string,string>.array
     - __kind: BaseType
       ID: 9
       Name: int
@@ -2408,7 +2408,7 @@ Types:
       GoRuntimeType: 542592
       GoKind: 3
     - __kind: GoEmptyInterfaceType
-      ID: 85
+      ID: 127
       Name: interface {}
       ByteSize: 16
       GoRuntimeType: 798016
@@ -2421,7 +2421,7 @@ Types:
           Offset: 8
           Type: 19 VoidPointerType unsafe.Pointer
     - __kind: GoInterfaceType
-      ID: 59
+      ID: 54
       Name: io.ReadCloser
       ByteSize: 16
       GoRuntimeType: 1.093088e+06
@@ -2434,49 +2434,49 @@ Types:
           Offset: 8
           Type: 19 VoidPointerType unsafe.Pointer
     - __kind: GoMapType
-      ID: 172
+      ID: 129
       Name: map[string]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
       ByteSize: 8
       GoRuntimeType: 905120
       GoKind: 21
-      HeaderType: 174 GoHMapHeaderType hash<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
+      HeaderType: 131 GoHMapHeaderType hash<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
     - __kind: GoMapType
-      ID: 65
+      ID: 108
       Name: map[string][]*mime/multipart.FileHeader
       ByteSize: 8
       GoRuntimeType: 904160
       GoKind: 21
-      HeaderType: 67 GoHMapHeaderType hash<string,[]*mime/multipart.FileHeader>
+      HeaderType: 110 GoHMapHeaderType hash<string,[]*mime/multipart.FileHeader>
     - __kind: GoMapType
-      ID: 64
+      ID: 107
       Name: map[string][]string
       ByteSize: 8
       GoRuntimeType: 899360
       GoKind: 21
-      HeaderType: 45 GoHMapHeaderType hash<string,[]string>
+      HeaderType: 49 GoHMapHeaderType hash<string,[]string>
     - __kind: GoMapType
-      ID: 160
+      ID: 82
       Name: map[string]float64
       ByteSize: 8
       GoRuntimeType: 905024
       GoKind: 21
-      HeaderType: 162 GoHMapHeaderType hash<string,float64>
+      HeaderType: 84 GoHMapHeaderType hash<string,float64>
     - __kind: GoMapType
-      ID: 188
+      ID: 134
       Name: map[string]interface {}
       ByteSize: 8
       GoRuntimeType: 896480
       GoKind: 21
-      HeaderType: 156 GoHMapHeaderType hash<string,interface {}>
+      HeaderType: 79 GoHMapHeaderType hash<string,interface {}>
     - __kind: GoMapType
-      ID: 142
+      ID: 68
       Name: map[string]string
       ByteSize: 8
       GoRuntimeType: 900992
       GoKind: 21
-      HeaderType: 144 GoHMapHeaderType hash<string,string>
+      HeaderType: 70 GoHMapHeaderType hash<string,string>
     - __kind: StructureType
-      ID: 87
+      ID: 154
       Name: math/big.Int
       ByteSize: 32
       GoRuntimeType: 1.340768e+06
@@ -2487,15 +2487,15 @@ Types:
           Type: 4 BaseType bool
         - Name: abs
           Offset: 8
-          Type: 88 GoSliceHeaderType math/big.nat
+          Type: 187 GoSliceHeaderType math/big.nat
     - __kind: BaseType
-      ID: 90
+      ID: 189
       Name: math/big.Word
       ByteSize: 8
       GoRuntimeType: 546880
       GoKind: 7
     - __kind: GoSliceHeaderType
-      ID: 88
+      ID: 187
       Name: math/big.nat
       ByteSize: 24
       GoRuntimeType: 2.280544e+06
@@ -2503,21 +2503,21 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 89 PointerType *math/big.Word
+          Type: 188 PointerType *math/big.Word
         - Name: len
           Offset: 8
           Type: 9 BaseType int
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 217 GoSliceDataType math/big.nat.array
+      Data: 253 GoSliceDataType math/big.nat.array
     - __kind: GoSliceDataType
-      ID: 217
+      ID: 253
       Name: math/big.nat.array
       ByteSize: 2048
-      Element: 90 BaseType math/big.Word
+      Element: 189 BaseType math/big.Word
     - __kind: StructureType
-      ID: 74
+      ID: 150
       Name: mime/multipart.FileHeader
       ByteSize: 88
       GoRuntimeType: 1.881696e+06
@@ -2528,13 +2528,13 @@ Types:
           Type: 11 GoStringHeaderType string
         - Name: Header
           Offset: 16
-          Type: 75 GoMapType net/textproto.MIMEHeader
+          Type: 186 GoMapType net/textproto.MIMEHeader
         - Name: Size
           Offset: 24
           Type: 14 BaseType int64
         - Name: content
           Offset: 32
-          Type: 76 GoSliceHeaderType []uint8
+          Type: 96 GoSliceHeaderType []uint8
         - Name: tmpfile
           Offset: 56
           Type: 11 GoStringHeaderType string
@@ -2545,7 +2545,7 @@ Types:
           Offset: 80
           Type: 4 BaseType bool
     - __kind: StructureType
-      ID: 63
+      ID: 59
       Name: mime/multipart.Form
       ByteSize: 16
       GoRuntimeType: 1.326048e+06
@@ -2553,12 +2553,12 @@ Types:
       RawFields:
         - Name: Value
           Offset: 0
-          Type: 64 GoMapType map[string][]string
+          Type: 107 GoMapType map[string][]string
         - Name: File
           Offset: 8
-          Type: 65 GoMapType map[string][]*mime/multipart.FileHeader
+          Type: 108 GoMapType map[string][]*mime/multipart.FileHeader
     - __kind: GoSliceHeaderType
-      ID: 116
+      ID: 174
       Name: net.IP
       ByteSize: 24
       GoRuntimeType: 2.00144e+06
@@ -2573,14 +2573,14 @@ Types:
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 235 GoSliceDataType net.IP.array
+      Data: 245 GoSliceDataType net.IP.array
     - __kind: GoSliceDataType
-      ID: 235
+      ID: 245
       Name: net.IP.array
       ByteSize: 2048
       Element: 3 BaseType uint8
     - __kind: GoSliceHeaderType
-      ID: 123
+      ID: 200
       Name: net.IPMask
       ByteSize: 24
       GoRuntimeType: 999456
@@ -2595,14 +2595,14 @@ Types:
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 241 GoSliceDataType net.IPMask.array
+      Data: 261 GoSliceDataType net.IPMask.array
     - __kind: GoSliceDataType
-      ID: 241
+      ID: 261
       Name: net.IPMask.array
       ByteSize: 2048
       Element: 3 BaseType uint8
     - __kind: StructureType
-      ID: 122
+      ID: 196
       Name: net.IPNet
       ByteSize: 48
       GoRuntimeType: 1.307168e+06
@@ -2610,17 +2610,17 @@ Types:
       RawFields:
         - Name: IP
           Offset: 0
-          Type: 116 GoSliceHeaderType net.IP
+          Type: 174 GoSliceHeaderType net.IP
         - Name: Mask
           Offset: 24
-          Type: 123 GoSliceHeaderType net.IPMask
+          Type: 200 GoSliceHeaderType net.IPMask
     - __kind: GoMapType
-      ID: 43
+      ID: 47
       Name: net/http.Header
       ByteSize: 8
       GoRuntimeType: 1.964288e+06
       GoKind: 21
-      HeaderType: 45 GoHMapHeaderType hash<string,[]string>
+      HeaderType: 49 GoHMapHeaderType hash<string,[]string>
     - __kind: StructureType
       ID: 38
       Name: net/http.Request
@@ -2633,7 +2633,7 @@ Types:
           Type: 11 GoStringHeaderType string
         - Name: URL
           Offset: 16
-          Type: 39 PointerType *net/url.URL
+          Type: 45 PointerType *net/url.URL
         - Name: Proto
           Offset: 24
           Type: 11 GoStringHeaderType string
@@ -2645,19 +2645,19 @@ Types:
           Type: 9 BaseType int
         - Name: Header
           Offset: 56
-          Type: 43 GoMapType net/http.Header
+          Type: 47 GoMapType net/http.Header
         - Name: Body
           Offset: 64
-          Type: 59 GoInterfaceType io.ReadCloser
+          Type: 54 GoInterfaceType io.ReadCloser
         - Name: GetBody
           Offset: 80
-          Type: 60 GoSubroutineType func() (io.ReadCloser, error)
+          Type: 55 GoSubroutineType func() (io.ReadCloser, error)
         - Name: ContentLength
           Offset: 88
           Type: 14 BaseType int64
         - Name: TransferEncoding
           Offset: 96
-          Type: 51 GoSliceHeaderType []string
+          Type: 56 GoSliceHeaderType []string
         - Name: Close
           Offset: 120
           Type: 4 BaseType bool
@@ -2666,16 +2666,16 @@ Types:
           Type: 11 GoStringHeaderType string
         - Name: Form
           Offset: 144
-          Type: 61 GoMapType net/url.Values
+          Type: 57 GoMapType net/url.Values
         - Name: PostForm
           Offset: 152
-          Type: 61 GoMapType net/url.Values
+          Type: 57 GoMapType net/url.Values
         - Name: MultipartForm
           Offset: 160
-          Type: 62 PointerType *mime/multipart.Form
+          Type: 58 PointerType *mime/multipart.Form
         - Name: Trailer
           Offset: 168
-          Type: 43 GoMapType net/http.Header
+          Type: 47 GoMapType net/http.Header
         - Name: RemoteAddr
           Offset: 176
           Type: 11 GoStringHeaderType string
@@ -2684,30 +2684,30 @@ Types:
           Type: 11 GoStringHeaderType string
         - Name: TLS
           Offset: 208
-          Type: 77 PointerType *crypto/tls.ConnectionState
+          Type: 60 PointerType *crypto/tls.ConnectionState
         - Name: Cancel
           Offset: 216
-          Type: 133 GoChannelType <-chan struct {}
+          Type: 62 GoChannelType <-chan struct {}
         - Name: Response
           Offset: 224
-          Type: 134 PointerType *net/http.Response
+          Type: 63 PointerType *net/http.Response
         - Name: Pattern
           Offset: 232
           Type: 11 GoStringHeaderType string
         - Name: ctx
           Offset: 248
-          Type: 136 GoInterfaceType context.Context
+          Type: 65 GoInterfaceType context.Context
         - Name: pat
           Offset: 264
-          Type: 137 PointerType *net/http.pattern
+          Type: 66 PointerType *net/http.pattern
         - Name: matches
           Offset: 272
-          Type: 51 GoSliceHeaderType []string
+          Type: 56 GoSliceHeaderType []string
         - Name: otherValues
           Offset: 296
-          Type: 142 GoMapType map[string]string
+          Type: 68 GoMapType map[string]string
     - __kind: StructureType
-      ID: 135
+      ID: 64
       Name: net/http.Response
       ByteSize: 144
       GoRuntimeType: 2.124032e+06
@@ -2730,16 +2730,16 @@ Types:
           Type: 9 BaseType int
         - Name: Header
           Offset: 56
-          Type: 43 GoMapType net/http.Header
+          Type: 47 GoMapType net/http.Header
         - Name: Body
           Offset: 64
-          Type: 59 GoInterfaceType io.ReadCloser
+          Type: 54 GoInterfaceType io.ReadCloser
         - Name: ContentLength
           Offset: 80
           Type: 14 BaseType int64
         - Name: TransferEncoding
           Offset: 88
-          Type: 51 GoSliceHeaderType []string
+          Type: 56 GoSliceHeaderType []string
         - Name: Close
           Offset: 112
           Type: 4 BaseType bool
@@ -2748,13 +2748,13 @@ Types:
           Type: 4 BaseType bool
         - Name: Trailer
           Offset: 120
-          Type: 43 GoMapType net/http.Header
+          Type: 47 GoMapType net/http.Header
         - Name: Request
           Offset: 128
           Type: 37 PointerType *net/http.Request
         - Name: TLS
           Offset: 136
-          Type: 77 PointerType *crypto/tls.ConnectionState
+          Type: 60 PointerType *crypto/tls.ConnectionState
     - __kind: GoInterfaceType
       ID: 36
       Name: net/http.ResponseWriter
@@ -2769,7 +2769,7 @@ Types:
           Offset: 8
           Type: 19 VoidPointerType unsafe.Pointer
     - __kind: StructureType
-      ID: 138
+      ID: 67
       Name: net/http.pattern
       ByteSize: 88
       GoRuntimeType: 1.745568e+06
@@ -2786,12 +2786,12 @@ Types:
           Type: 11 GoStringHeaderType string
         - Name: segments
           Offset: 48
-          Type: 139 GoSliceHeaderType []net/http.segment
+          Type: 122 GoSliceHeaderType []net/http.segment
         - Name: loc
           Offset: 72
           Type: 11 GoStringHeaderType string
     - __kind: StructureType
-      ID: 141
+      ID: 124
       Name: net/http.segment
       ByteSize: 24
       GoRuntimeType: 1.453312e+06
@@ -2807,14 +2807,14 @@ Types:
           Offset: 17
           Type: 4 BaseType bool
     - __kind: GoMapType
-      ID: 75
+      ID: 186
       Name: net/textproto.MIMEHeader
       ByteSize: 8
       GoRuntimeType: 1.63792e+06
       GoKind: 21
-      HeaderType: 45 GoHMapHeaderType hash<string,[]string>
+      HeaderType: 49 GoHMapHeaderType hash<string,[]string>
     - __kind: StructureType
-      ID: 40
+      ID: 46
       Name: net/url.URL
       ByteSize: 144
       GoRuntimeType: 2.041568e+06
@@ -2828,7 +2828,7 @@ Types:
           Type: 11 GoStringHeaderType string
         - Name: User
           Offset: 32
-          Type: 41 PointerType *net/url.Userinfo
+          Type: 98 PointerType *net/url.Userinfo
         - Name: Host
           Offset: 40
           Type: 11 GoStringHeaderType string
@@ -2854,7 +2854,7 @@ Types:
           Offset: 128
           Type: 11 GoStringHeaderType string
     - __kind: StructureType
-      ID: 42
+      ID: 99
       Name: net/url.Userinfo
       ByteSize: 40
       GoRuntimeType: 1.469632e+06
@@ -2870,14 +2870,14 @@ Types:
           Offset: 32
           Type: 4 BaseType bool
     - __kind: GoMapType
-      ID: 61
+      ID: 57
       Name: net/url.Values
       ByteSize: 8
       GoRuntimeType: 1.712416e+06
       GoKind: 21
-      HeaderType: 45 GoHMapHeaderType hash<string,[]string>
+      HeaderType: 49 GoHMapHeaderType hash<string,[]string>
     - __kind: StructureType
-      ID: 58
+      ID: 106
       Name: runtime.bmap
       ByteSize: 8
       GoRuntimeType: 1.13712e+06
@@ -2885,7 +2885,7 @@ Types:
       RawFields:
         - Name: tophash
           Offset: 0
-          Type: 48 ArrayType [8]uint8
+          Type: 100 ArrayType [8]uint8
     - __kind: StructureType
       ID: 53
       Name: runtime.mapextra
@@ -2895,13 +2895,13 @@ Types:
       RawFields:
         - Name: overflow
           Offset: 0
-          Type: 54 PointerType *[]*runtime.bmap
+          Type: 103 PointerType *[]*runtime.bmap
         - Name: oldoverflow
           Offset: 8
-          Type: 54 PointerType *[]*runtime.bmap
+          Type: 103 PointerType *[]*runtime.bmap
         - Name: nextOverflow
           Offset: 16
-          Type: 57 PointerType *runtime.bmap
+          Type: 105 PointerType *runtime.bmap
     - __kind: GoStringHeaderType
       ID: 11
       Name: string
@@ -2921,7 +2921,7 @@ Types:
       Name: string.str
       ByteSize: 2048
     - __kind: StructureType
-      ID: 151
+      ID: 74
       Name: sync.Mutex
       ByteSize: 8
       GoRuntimeType: 1.314208e+06
@@ -2934,7 +2934,7 @@ Types:
           Offset: 4
           Type: 2 BaseType uint32
     - __kind: StructureType
-      ID: 150
+      ID: 73
       Name: sync.RWMutex
       ByteSize: 24
       GoRuntimeType: 1.751168e+06
@@ -2942,7 +2942,7 @@ Types:
       RawFields:
         - Name: w
           Offset: 0
-          Type: 151 StructureType sync.Mutex
+          Type: 74 StructureType sync.Mutex
         - Name: writerSem
           Offset: 8
           Type: 2 BaseType uint32
@@ -2951,12 +2951,12 @@ Types:
           Type: 2 BaseType uint32
         - Name: readerCount
           Offset: 16
-          Type: 152 StructureType sync/atomic.Int32
+          Type: 75 StructureType sync/atomic.Int32
         - Name: readerWait
           Offset: 20
-          Type: 152 StructureType sync/atomic.Int32
+          Type: 75 StructureType sync/atomic.Int32
     - __kind: StructureType
-      ID: 152
+      ID: 75
       Name: sync/atomic.Int32
       ByteSize: 4
       GoRuntimeType: 1.315648e+06
@@ -2964,18 +2964,18 @@ Types:
       RawFields:
         - Name: _
           Offset: 0
-          Type: 153 StructureType sync/atomic.noCopy
+          Type: 76 StructureType sync/atomic.noCopy
         - Name: v
           Offset: 0
           Type: 13 BaseType int32
     - __kind: StructureType
-      ID: 153
+      ID: 76
       Name: sync/atomic.noCopy
       GoRuntimeType: 966016
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 98
+      ID: 161
       Name: time.Location
       ByteSize: 104
       GoRuntimeType: 1.877952e+06
@@ -2986,10 +2986,10 @@ Types:
           Type: 11 GoStringHeaderType string
         - Name: zone
           Offset: 16
-          Type: 99 GoSliceHeaderType []time.zone
+          Type: 190 GoSliceHeaderType []time.zone
         - Name: tx
           Offset: 40
-          Type: 102 GoSliceHeaderType []time.zoneTrans
+          Type: 193 GoSliceHeaderType []time.zoneTrans
         - Name: extend
           Offset: 64
           Type: 11 GoStringHeaderType string
@@ -3001,9 +3001,9 @@ Types:
           Type: 14 BaseType int64
         - Name: cacheZone
           Offset: 96
-          Type: 100 PointerType *time.zone
+          Type: 191 PointerType *time.zone
     - __kind: StructureType
-      ID: 96
+      ID: 159
       Name: time.Time
       ByteSize: 24
       GoRuntimeType: 2.281472e+06
@@ -3017,9 +3017,9 @@ Types:
           Type: 14 BaseType int64
         - Name: loc
           Offset: 16
-          Type: 97 PointerType *time.Location
+          Type: 160 PointerType *time.Location
     - __kind: StructureType
-      ID: 101
+      ID: 192
       Name: time.zone
       ByteSize: 32
       GoRuntimeType: 1.458304e+06
@@ -3035,7 +3035,7 @@ Types:
           Offset: 24
           Type: 4 BaseType bool
     - __kind: StructureType
-      ID: 104
+      ID: 195
       Name: time.zoneTrans
       ByteSize: 16
       GoRuntimeType: 1.664192e+06

--- a/pkg/dyninst/irgen/testdata/snapshot/rc_tester.arch=arm64,toolchain=go1.23.11.yaml
+++ b/pkg/dyninst/irgen/testdata/snapshot/rc_tester.arch=arm64,toolchain=go1.23.11.yaml
@@ -33,7 +33,7 @@ Subprograms:
       InlinePCRanges: []
       Variables:
         - Name: w
-          Type: 1 GoInterfaceType net/http.ResponseWriter
+          Type: 36 GoInterfaceType net/http.ResponseWriter
           Locations:
             - Range: 0x8dff30..0x8dff88
               Pieces:
@@ -56,7 +56,7 @@ Subprograms:
           IsParameter: true
           IsReturn: false
         - Name: r
-          Type: 3 PointerType *net/http.Request
+          Type: 37 PointerType *net/http.Request
           Locations:
             - Range: 0x8dff30..0x8dff94
               Pieces: [{Size: 8, Op: {RegNo: 2, Shift: 0}}]
@@ -65,14 +65,14 @@ Subprograms:
           IsParameter: true
           IsReturn: false
         - Name: span
-          Type: 126 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span
+          Type: 148 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span
           Locations:
             - Range: 0x8dffa8..0x8dffd8
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: false
           IsReturn: false
         - Name: '&buf'
-          Type: 179 PointerType *bytes.Buffer
+          Type: 198 PointerType *bytes.Buffer
           Locations:
             - Range: 0x8e007c..0x8e0098
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
@@ -81,7 +81,7 @@ Subprograms:
           IsParameter: false
           IsReturn: false
         - Name: .autotmp_14
-          Type: 182 StructureType context.backgroundCtx
+          Type: 201 StructureType context.backgroundCtx
           Locations:
             - Range: 0x8dff30..0x8e0170
               Pieces: [{Size: 0, Op: {CfaOffset: 0}}]
@@ -93,7 +93,7 @@ Subprograms:
       InlinePCRanges: []
       Variables:
         - Name: path
-          Type: 5 GoStringHeaderType string
+          Type: 11 GoStringHeaderType string
           Locations:
             - Range: 0x8e0250..0x8e0274
               Pieces:
@@ -105,50 +105,50 @@ Subprograms:
           IsReturn: false
 Types:
     - __kind: PointerType
-      ID: 56
+      ID: 80
       Name: '**crypto/x509.Certificate'
       ByteSize: 8
-      Pointee: 57 PointerType *crypto/x509.Certificate
+      Pointee: 81 PointerType *crypto/x509.Certificate
     - __kind: PointerType
-      ID: 174
+      ID: 194
       Name: '**github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span'
       ByteSize: 8
       GoKind: 22
-      Pointee: 126 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span
+      Pointee: 148 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span
     - __kind: PointerType
-      ID: 164
+      ID: 184
       Name: '**github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttributeValue'
       ByteSize: 8
       GoKind: 22
-      Pointee: 165 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttributeValue
+      Pointee: 185 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttributeValue
     - __kind: PointerType
-      ID: 48
+      ID: 72
       Name: '**mime/multipart.FileHeader'
       ByteSize: 8
       GoKind: 22
-      Pointee: 49 PointerType *mime/multipart.FileHeader
+      Pointee: 73 PointerType *mime/multipart.FileHeader
     - __kind: PointerType
-      ID: 98
+      ID: 120
       Name: '**net.IPNet'
       ByteSize: 8
       GoKind: 22
-      Pointee: 99 PointerType *net.IPNet
+      Pointee: 121 PointerType *net.IPNet
     - __kind: PointerType
-      ID: 96
+      ID: 118
       Name: '**net/url.URL'
       ByteSize: 8
-      Pointee: 9 PointerType *net/url.URL
+      Pointee: 39 PointerType *net/url.URL
     - __kind: PointerType
-      ID: 31
+      ID: 56
       Name: '**runtime.bmap'
       ByteSize: 8
-      Pointee: 32 PointerType *runtime.bmap
+      Pointee: 57 PointerType *runtime.bmap
     - __kind: PointerType
-      ID: 106
+      ID: 128
       Name: '*[]*crypto/x509.Certificate'
       ByteSize: 8
       GoKind: 22
-      Pointee: 55 GoSliceHeaderType []*crypto/x509.Certificate
+      Pointee: 79 GoSliceHeaderType []*crypto/x509.Certificate
     - __kind: PointerType
       ID: 216
       Name: '*[]*crypto/x509.Certificate.array'
@@ -180,12 +180,12 @@ Types:
       ByteSize: 8
       Pointee: 237 GoSliceDataType []*net/url.URL.array
     - __kind: PointerType
-      ID: 29
+      ID: 54
       Name: '*[]*runtime.bmap'
       ByteSize: 8
       GoRuntimeType: 470816
       GoKind: 22
-      Pointee: 30 GoSliceHeaderType []*runtime.bmap
+      Pointee: 55 GoSliceHeaderType []*runtime.bmap
     - __kind: PointerType
       ID: 209
       Name: '*[]*runtime.bmap.array'
@@ -262,297 +262,297 @@ Types:
       ByteSize: 8
       Pointee: 225 GoSliceDataType []time.zoneTrans.array
     - __kind: PointerType
-      ID: 108
+      ID: 130
       Name: '*[]uint8'
       ByteSize: 8
       GoRuntimeType: 456928
       GoKind: 22
-      Pointee: 52 GoSliceHeaderType []uint8
+      Pointee: 76 GoSliceHeaderType []uint8
     - __kind: PointerType
       ID: 214
       Name: '*[]uint8.array'
       ByteSize: 8
       Pointee: 213 GoSliceDataType []uint8.array
     - __kind: PointerType
-      ID: 184
+      ID: 5
       Name: '*bool'
       ByteSize: 8
       GoRuntimeType: 377120
       GoKind: 22
-      Pointee: 13 BaseType bool
+      Pointee: 4 BaseType bool
     - __kind: PointerType
-      ID: 155
+      ID: 175
       Name: '*bucket<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>'
       ByteSize: 8
-      Pointee: 156 GoHMapBucketType bucket<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
+      Pointee: 176 GoHMapBucketType bucket<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
     - __kind: PointerType
-      ID: 44
+      ID: 68
       Name: '*bucket<string,[]*mime/multipart.FileHeader>'
       ByteSize: 8
-      Pointee: 45 GoHMapBucketType bucket<string,[]*mime/multipart.FileHeader>
+      Pointee: 69 GoHMapBucketType bucket<string,[]*mime/multipart.FileHeader>
     - __kind: PointerType
-      ID: 19
+      ID: 46
       Name: '*bucket<string,[]string>'
       ByteSize: 8
-      Pointee: 20 GoHMapBucketType bucket<string,[]string>
+      Pointee: 47 GoHMapBucketType bucket<string,[]string>
     - __kind: PointerType
-      ID: 142
+      ID: 163
       Name: '*bucket<string,float64>'
       ByteSize: 8
-      Pointee: 143 GoHMapBucketType bucket<string,float64>
+      Pointee: 164 GoHMapBucketType bucket<string,float64>
     - __kind: PointerType
-      ID: 136
+      ID: 157
       Name: '*bucket<string,interface {}>'
       ByteSize: 8
-      Pointee: 137 GoHMapBucketType bucket<string,interface {}>
+      Pointee: 158 GoHMapBucketType bucket<string,interface {}>
     - __kind: PointerType
-      ID: 123
+      ID: 145
       Name: '*bucket<string,string>'
       ByteSize: 8
-      Pointee: 124 GoHMapBucketType bucket<string,string>
+      Pointee: 146 GoHMapBucketType bucket<string,string>
     - __kind: PointerType
-      ID: 179
+      ID: 198
       Name: '*bytes.Buffer'
       ByteSize: 8
       GoRuntimeType: 2.176896e+06
       GoKind: 22
-      Pointee: 180 StructureType bytes.Buffer
+      Pointee: 199 StructureType bytes.Buffer
     - __kind: PointerType
-      ID: 53
+      ID: 77
       Name: '*crypto/tls.ConnectionState'
       ByteSize: 8
       GoRuntimeType: 852320
       GoKind: 22
-      Pointee: 54 StructureType crypto/tls.ConnectionState
+      Pointee: 78 StructureType crypto/tls.ConnectionState
     - __kind: PointerType
-      ID: 57
+      ID: 81
       Name: '*crypto/x509.Certificate'
       ByteSize: 8
       GoRuntimeType: 1.95344e+06
       GoKind: 22
-      Pointee: 58 StructureType crypto/x509.Certificate
+      Pointee: 82 StructureType crypto/x509.Certificate
     - __kind: PointerType
-      ID: 90
+      ID: 112
       Name: '*crypto/x509.ExtKeyUsage'
       ByteSize: 8
       GoRuntimeType: 400736
       GoKind: 22
-      Pointee: 91 BaseType crypto/x509.ExtKeyUsage
+      Pointee: 113 BaseType crypto/x509.ExtKeyUsage
     - __kind: PointerType
-      ID: 103
+      ID: 125
       Name: '*crypto/x509.OID'
       ByteSize: 8
       GoRuntimeType: 1.762368e+06
       GoKind: 22
-      Pointee: 104 StructureType crypto/x509.OID
+      Pointee: 126 StructureType crypto/x509.OID
     - __kind: PointerType
-      ID: 69
+      ID: 93
       Name: '*crypto/x509/pkix.AttributeTypeAndValue'
       ByteSize: 8
       GoRuntimeType: 417504
       GoKind: 22
-      Pointee: 70 StructureType crypto/x509/pkix.AttributeTypeAndValue
+      Pointee: 94 StructureType crypto/x509/pkix.AttributeTypeAndValue
     - __kind: PointerType
-      ID: 85
+      ID: 107
       Name: '*crypto/x509/pkix.Extension'
       ByteSize: 8
       GoRuntimeType: 417696
       GoKind: 22
-      Pointee: 86 StructureType crypto/x509/pkix.Extension
+      Pointee: 108 StructureType crypto/x509/pkix.Extension
     - __kind: PointerType
-      ID: 88
+      ID: 110
       Name: '*encoding/asn1.ObjectIdentifier'
       ByteSize: 8
       GoRuntimeType: 1.037472e+06
       GoKind: 22
-      Pointee: 71 GoSliceHeaderType encoding/asn1.ObjectIdentifier
+      Pointee: 95 GoSliceHeaderType encoding/asn1.ObjectIdentifier
     - __kind: PointerType
       ID: 222
       Name: '*encoding/asn1.ObjectIdentifier.array'
       ByteSize: 8
       Pointee: 221 GoSliceDataType encoding/asn1.ObjectIdentifier.array
     - __kind: PointerType
-      ID: 200
+      ID: 33
       Name: '*error'
       ByteSize: 8
       GoRuntimeType: 376032
       GoKind: 22
-      Pointee: 189 GoInterfaceType error
+      Pointee: 18 GoInterfaceType error
     - __kind: PointerType
-      ID: 202
+      ID: 35
       Name: '*float32'
       ByteSize: 8
       GoRuntimeType: 376992
       GoKind: 22
-      Pointee: 188 BaseType float32
+      Pointee: 16 BaseType float32
     - __kind: PointerType
-      ID: 175
+      ID: 26
       Name: '*float64'
       ByteSize: 8
       GoRuntimeType: 377056
       GoKind: 22
-      Pointee: 145 BaseType float64
+      Pointee: 17 BaseType float64
     - __kind: PointerType
-      ID: 126
+      ID: 148
       Name: '*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span'
       ByteSize: 8
       GoRuntimeType: 2.18768e+06
       GoKind: 22
-      Pointee: 127 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span
+      Pointee: 149 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span
     - __kind: PointerType
-      ID: 169
+      ID: 189
       Name: '*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanContext'
       ByteSize: 8
       GoRuntimeType: 1.91728e+06
       GoKind: 22
-      Pointee: 170 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanContext
+      Pointee: 190 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanContext
     - __kind: PointerType
-      ID: 147
+      ID: 167
       Name: '*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink'
       ByteSize: 8
       GoRuntimeType: 1.12944e+06
       GoKind: 22
-      Pointee: 148 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink
+      Pointee: 168 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink
     - __kind: PointerType
-      ID: 150
+      ID: 170
       Name: '*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent'
       ByteSize: 8
       GoRuntimeType: 1.129568e+06
       GoKind: 22
-      Pointee: 151 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent
+      Pointee: 171 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent
     - __kind: PointerType
-      ID: 161
+      ID: 181
       Name: '*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttribute'
       ByteSize: 8
       GoRuntimeType: 1.130208e+06
       GoKind: 22
-      Pointee: 162 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttribute
+      Pointee: 182 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttribute
     - __kind: PointerType
-      ID: 165
+      ID: 185
       Name: '*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttributeValue'
       ByteSize: 8
       GoRuntimeType: 1.129952e+06
       GoKind: 22
-      Pointee: 166 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttributeValue
+      Pointee: 186 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttributeValue
     - __kind: PointerType
-      ID: 158
+      ID: 178
       Name: '*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute'
       ByteSize: 8
       GoRuntimeType: 1.130336e+06
       GoKind: 22
-      Pointee: 159 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
+      Pointee: 179 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
     - __kind: PointerType
-      ID: 171
+      ID: 191
       Name: '*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.trace'
       ByteSize: 8
       GoRuntimeType: 2.132544e+06
       GoKind: 22
-      Pointee: 172 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.trace
+      Pointee: 192 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.trace
     - __kind: PointerType
-      ID: 153
+      ID: 173
       Name: '*hash<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>'
       ByteSize: 8
-      Pointee: 154 GoHMapHeaderType hash<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
+      Pointee: 174 GoHMapHeaderType hash<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
     - __kind: PointerType
-      ID: 42
+      ID: 66
       Name: '*hash<string,[]*mime/multipart.FileHeader>'
       ByteSize: 8
-      Pointee: 43 GoHMapHeaderType hash<string,[]*mime/multipart.FileHeader>
+      Pointee: 67 GoHMapHeaderType hash<string,[]*mime/multipart.FileHeader>
     - __kind: PointerType
-      ID: 15
+      ID: 44
       Name: '*hash<string,[]string>'
       ByteSize: 8
-      Pointee: 16 GoHMapHeaderType hash<string,[]string>
+      Pointee: 45 GoHMapHeaderType hash<string,[]string>
     - __kind: PointerType
-      ID: 140
+      ID: 161
       Name: '*hash<string,float64>'
       ByteSize: 8
-      Pointee: 141 GoHMapHeaderType hash<string,float64>
+      Pointee: 162 GoHMapHeaderType hash<string,float64>
     - __kind: PointerType
-      ID: 134
+      ID: 155
       Name: '*hash<string,interface {}>'
       ByteSize: 8
-      Pointee: 135 GoHMapHeaderType hash<string,interface {}>
+      Pointee: 156 GoHMapHeaderType hash<string,interface {}>
     - __kind: PointerType
-      ID: 121
+      ID: 143
       Name: '*hash<string,string>'
       ByteSize: 8
-      Pointee: 122 GoHMapHeaderType hash<string,string>
+      Pointee: 144 GoHMapHeaderType hash<string,string>
     - __kind: PointerType
-      ID: 72
+      ID: 28
       Name: '*int'
       ByteSize: 8
       GoRuntimeType: 376672
       GoKind: 22
-      Pointee: 8 BaseType int
+      Pointee: 9 BaseType int
     - __kind: PointerType
-      ID: 198
+      ID: 31
       Name: '*int16'
       ByteSize: 8
       GoRuntimeType: 376288
       GoKind: 22
-      Pointee: 192 BaseType int16
+      Pointee: 23 BaseType int16
     - __kind: PointerType
-      ID: 190
+      ID: 20
       Name: '*int32'
       ByteSize: 8
       GoRuntimeType: 376416
       GoKind: 22
-      Pointee: 130 BaseType int32
+      Pointee: 13 BaseType int32
     - __kind: PointerType
-      ID: 195
+      ID: 27
       Name: '*int64'
       ByteSize: 8
       GoRuntimeType: 376544
       GoKind: 22
-      Pointee: 36 BaseType int64
+      Pointee: 14 BaseType int64
     - __kind: PointerType
-      ID: 199
+      ID: 32
       Name: '*int8'
       ByteSize: 8
       GoRuntimeType: 376160
       GoKind: 22
-      Pointee: 187 BaseType int8
+      Pointee: 15 BaseType int8
     - __kind: PointerType
-      ID: 62
+      ID: 86
       Name: '*math/big.Int'
       ByteSize: 8
       GoRuntimeType: 2.29744e+06
       GoKind: 22
-      Pointee: 63 StructureType math/big.Int
+      Pointee: 87 StructureType math/big.Int
     - __kind: PointerType
-      ID: 65
+      ID: 89
       Name: '*math/big.Word'
       ByteSize: 8
       GoRuntimeType: 403552
       GoKind: 22
-      Pointee: 66 BaseType math/big.Word
+      Pointee: 90 BaseType math/big.Word
     - __kind: PointerType
       ID: 218
       Name: '*math/big.nat.array'
       ByteSize: 8
       Pointee: 217 GoSliceDataType math/big.nat.array
     - __kind: PointerType
-      ID: 49
+      ID: 73
       Name: '*mime/multipart.FileHeader'
       ByteSize: 8
       GoRuntimeType: 853760
       GoKind: 22
-      Pointee: 50 StructureType mime/multipart.FileHeader
+      Pointee: 74 StructureType mime/multipart.FileHeader
     - __kind: PointerType
-      ID: 38
+      ID: 62
       Name: '*mime/multipart.Form'
       ByteSize: 8
       GoRuntimeType: 853856
       GoKind: 22
-      Pointee: 39 StructureType mime/multipart.Form
+      Pointee: 63 StructureType mime/multipart.Form
     - __kind: PointerType
-      ID: 93
+      ID: 115
       Name: '*net.IP'
       ByteSize: 8
       GoRuntimeType: 2.02912e+06
       GoKind: 22
-      Pointee: 94 GoSliceHeaderType net.IP
+      Pointee: 116 GoSliceHeaderType net.IP
     - __kind: PointerType
       ID: 236
       Name: '*net.IP.array'
@@ -564,145 +564,145 @@ Types:
       ByteSize: 8
       Pointee: 241 GoSliceDataType net.IPMask.array
     - __kind: PointerType
-      ID: 99
+      ID: 121
       Name: '*net.IPNet'
       ByteSize: 8
       GoRuntimeType: 1.122912e+06
       GoKind: 22
-      Pointee: 100 StructureType net.IPNet
+      Pointee: 122 StructureType net.IPNet
     - __kind: PointerType
-      ID: 3
+      ID: 37
       Name: '*net/http.Request'
       ByteSize: 8
       GoRuntimeType: 2.219968e+06
       GoKind: 22
-      Pointee: 4 StructureType net/http.Request
+      Pointee: 38 StructureType net/http.Request
     - __kind: PointerType
-      ID: 112
+      ID: 134
       Name: '*net/http.Response'
       ByteSize: 8
       GoRuntimeType: 1.632736e+06
       GoKind: 22
-      Pointee: 113 StructureType net/http.Response
+      Pointee: 135 StructureType net/http.Response
     - __kind: PointerType
-      ID: 115
+      ID: 137
       Name: '*net/http.pattern'
       ByteSize: 8
       GoRuntimeType: 1.453504e+06
       GoKind: 22
-      Pointee: 116 StructureType net/http.pattern
+      Pointee: 138 StructureType net/http.pattern
     - __kind: PointerType
-      ID: 118
+      ID: 140
       Name: '*net/http.segment'
       ByteSize: 8
       GoRuntimeType: 367904
       GoKind: 22
-      Pointee: 119 StructureType net/http.segment
+      Pointee: 141 StructureType net/http.segment
     - __kind: PointerType
-      ID: 9
+      ID: 39
       Name: '*net/url.URL'
       ByteSize: 8
       GoRuntimeType: 2.002496e+06
       GoKind: 22
-      Pointee: 10 StructureType net/url.URL
+      Pointee: 40 StructureType net/url.URL
     - __kind: PointerType
-      ID: 11
+      ID: 41
       Name: '*net/url.Userinfo'
       ByteSize: 8
       GoRuntimeType: 1.1416e+06
       GoKind: 22
-      Pointee: 12 StructureType net/url.Userinfo
+      Pointee: 42 StructureType net/url.Userinfo
     - __kind: PointerType
-      ID: 32
+      ID: 57
       Name: '*runtime.bmap'
       ByteSize: 8
       GoRuntimeType: 1.137248e+06
       GoKind: 22
-      Pointee: 33 StructureType runtime.bmap
+      Pointee: 58 StructureType runtime.bmap
     - __kind: PointerType
-      ID: 27
+      ID: 52
       Name: '*runtime.mapextra'
       ByteSize: 8
       GoRuntimeType: 380000
       GoKind: 22
-      Pointee: 28 StructureType runtime.mapextra
+      Pointee: 53 StructureType runtime.mapextra
     - __kind: PointerType
-      ID: 25
+      ID: 22
       Name: '*string'
       ByteSize: 8
       GoRuntimeType: 376096
       GoKind: 22
-      Pointee: 5 GoStringHeaderType string
+      Pointee: 11 GoStringHeaderType string
     - __kind: PointerType
       ID: 204
       Name: '*string.str'
       ByteSize: 8
       Pointee: 203 GoStringDataType string.str
     - __kind: PointerType
-      ID: 75
+      ID: 97
       Name: '*time.Location'
       ByteSize: 8
       GoRuntimeType: 1.458496e+06
       GoKind: 22
-      Pointee: 76 StructureType time.Location
+      Pointee: 98 StructureType time.Location
     - __kind: PointerType
-      ID: 78
+      ID: 100
       Name: '*time.zone'
       ByteSize: 8
       GoRuntimeType: 370976
       GoKind: 22
-      Pointee: 79 StructureType time.zone
+      Pointee: 101 StructureType time.zone
     - __kind: PointerType
-      ID: 81
+      ID: 103
       Name: '*time.zoneTrans'
       ByteSize: 8
       GoRuntimeType: 371040
       GoKind: 22
-      Pointee: 82 StructureType time.zoneTrans
+      Pointee: 104 StructureType time.zoneTrans
     - __kind: PointerType
-      ID: 201
+      ID: 34
       Name: '*uint'
       ByteSize: 8
       GoRuntimeType: 376736
       GoKind: 22
-      Pointee: 186 BaseType uint
+      Pointee: 12 BaseType uint
     - __kind: PointerType
-      ID: 197
+      ID: 30
       Name: '*uint16'
       ByteSize: 8
       GoRuntimeType: 376352
       GoKind: 22
-      Pointee: 17 BaseType uint16
+      Pointee: 7 BaseType uint16
     - __kind: PointerType
-      ID: 191
+      ID: 21
       Name: '*uint32'
       ByteSize: 8
       GoRuntimeType: 376480
       GoKind: 22
-      Pointee: 18 BaseType uint32
+      Pointee: 2 BaseType uint32
     - __kind: PointerType
-      ID: 196
+      ID: 29
       Name: '*uint64'
       ByteSize: 8
       GoRuntimeType: 376608
       GoKind: 22
-      Pointee: 74 BaseType uint64
+      Pointee: 10 BaseType uint64
     - __kind: PointerType
       ID: 6
       Name: '*uint8'
       ByteSize: 8
       GoRuntimeType: 376224
       GoKind: 22
-      Pointee: 7 BaseType uint8
+      Pointee: 3 BaseType uint8
     - __kind: PointerType
-      ID: 185
+      ID: 8
       Name: '*uintptr'
       ByteSize: 8
       GoRuntimeType: 376800
       GoKind: 22
-      Pointee: 26 BaseType uintptr
+      Pointee: 1 BaseType uintptr
     - __kind: GoChannelType
-      ID: 111
+      ID: 133
       Name: <-chan struct {}
       GoRuntimeType: 555520
       GoKind: 18
@@ -715,7 +715,7 @@ Types:
         - Name: w
           Offset: 1
           Expression:
-            Type: 1 GoInterfaceType net/http.ResponseWriter
+            Type: 36 GoInterfaceType net/http.ResponseWriter
             Operations:
                 - __kind: LocationOp
                   Variable: {subprogram: 1, index: 0, name: w}
@@ -724,7 +724,7 @@ Types:
         - Name: r
           Offset: 17
           Expression:
-            Type: 3 PointerType *net/http.Request
+            Type: 37 PointerType *net/http.Request
             Operations:
                 - __kind: LocationOp
                   Variable: {subprogram: 1, index: 1, name: r}
@@ -739,23 +739,23 @@ Types:
         - Name: path
           Offset: 1
           Expression:
-            Type: 5 GoStringHeaderType string
+            Type: 11 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
                   Variable: {subprogram: 2, index: 0, name: path}
                   Offset: 0
                   ByteSize: 16
     - __kind: ArrayType
-      ID: 21
+      ID: 48
       Name: '[8]uint8'
       ByteSize: 8
       GoRuntimeType: 632832
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 7 BaseType uint8
+      Element: 3 BaseType uint8
     - __kind: GoSliceHeaderType
-      ID: 55
+      ID: 79
       Name: '[]*crypto/x509.Certificate'
       ByteSize: 24
       GoRuntimeType: 473920
@@ -763,21 +763,21 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 56 PointerType **crypto/x509.Certificate
+          Type: 80 PointerType **crypto/x509.Certificate
         - Name: len
           Offset: 8
-          Type: 8 BaseType int
+          Type: 9 BaseType int
         - Name: cap
           Offset: 16
-          Type: 8 BaseType int
+          Type: 9 BaseType int
       Data: 215 GoSliceDataType []*crypto/x509.Certificate.array
     - __kind: GoSliceDataType
       ID: 215
       Name: '[]*crypto/x509.Certificate.array'
       ByteSize: 2048
-      Element: 57 PointerType *crypto/x509.Certificate
+      Element: 81 PointerType *crypto/x509.Certificate
     - __kind: GoSliceHeaderType
-      ID: 173
+      ID: 193
       Name: '[]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span'
       ByteSize: 24
       GoRuntimeType: 464032
@@ -785,21 +785,21 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 174 PointerType **github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span
+          Type: 194 PointerType **github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span
         - Name: len
           Offset: 8
-          Type: 8 BaseType int
+          Type: 9 BaseType int
         - Name: cap
           Offset: 16
-          Type: 8 BaseType int
+          Type: 9 BaseType int
       Data: 261 GoSliceDataType []*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span.array
     - __kind: GoSliceDataType
       ID: 261
       Name: '[]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span.array'
       ByteSize: 2048
-      Element: 126 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span
+      Element: 148 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span
     - __kind: GoSliceHeaderType
-      ID: 163
+      ID: 183
       Name: '[]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttributeValue'
       ByteSize: 24
       GoRuntimeType: 463648
@@ -807,21 +807,21 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 164 PointerType **github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttributeValue
+          Type: 184 PointerType **github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttributeValue
         - Name: len
           Offset: 8
-          Type: 8 BaseType int
+          Type: 9 BaseType int
         - Name: cap
           Offset: 16
-          Type: 8 BaseType int
+          Type: 9 BaseType int
       Data: 259 GoSliceDataType []*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttributeValue.array
     - __kind: GoSliceDataType
       ID: 259
       Name: '[]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttributeValue.array'
       ByteSize: 2048
-      Element: 165 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttributeValue
+      Element: 185 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttributeValue
     - __kind: GoSliceHeaderType
-      ID: 47
+      ID: 71
       Name: '[]*mime/multipart.FileHeader'
       ByteSize: 24
       GoRuntimeType: 461664
@@ -829,21 +829,21 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 48 PointerType **mime/multipart.FileHeader
+          Type: 72 PointerType **mime/multipart.FileHeader
         - Name: len
           Offset: 8
-          Type: 8 BaseType int
+          Type: 9 BaseType int
         - Name: cap
           Offset: 16
-          Type: 8 BaseType int
+          Type: 9 BaseType int
       Data: 211 GoSliceDataType []*mime/multipart.FileHeader.array
     - __kind: GoSliceDataType
       ID: 211
       Name: '[]*mime/multipart.FileHeader.array'
       ByteSize: 2048
-      Element: 49 PointerType *mime/multipart.FileHeader
+      Element: 73 PointerType *mime/multipart.FileHeader
     - __kind: GoSliceHeaderType
-      ID: 97
+      ID: 119
       Name: '[]*net.IPNet'
       ByteSize: 24
       GoRuntimeType: 486976
@@ -851,21 +851,21 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 98 PointerType **net.IPNet
+          Type: 120 PointerType **net.IPNet
         - Name: len
           Offset: 8
-          Type: 8 BaseType int
+          Type: 9 BaseType int
         - Name: cap
           Offset: 16
-          Type: 8 BaseType int
+          Type: 9 BaseType int
       Data: 239 GoSliceDataType []*net.IPNet.array
     - __kind: GoSliceDataType
       ID: 239
       Name: '[]*net.IPNet.array'
       ByteSize: 2048
-      Element: 99 PointerType *net.IPNet
+      Element: 121 PointerType *net.IPNet
     - __kind: GoSliceHeaderType
-      ID: 95
+      ID: 117
       Name: '[]*net/url.URL'
       ByteSize: 24
       GoRuntimeType: 486912
@@ -873,21 +873,21 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 96 PointerType **net/url.URL
+          Type: 118 PointerType **net/url.URL
         - Name: len
           Offset: 8
-          Type: 8 BaseType int
+          Type: 9 BaseType int
         - Name: cap
           Offset: 16
-          Type: 8 BaseType int
+          Type: 9 BaseType int
       Data: 237 GoSliceDataType []*net/url.URL.array
     - __kind: GoSliceDataType
       ID: 237
       Name: '[]*net/url.URL.array'
       ByteSize: 2048
-      Element: 9 PointerType *net/url.URL
+      Element: 39 PointerType *net/url.URL
     - __kind: GoSliceHeaderType
-      ID: 30
+      ID: 55
       Name: '[]*runtime.bmap'
       ByteSize: 24
       GoRuntimeType: 470752
@@ -895,21 +895,21 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 31 PointerType **runtime.bmap
+          Type: 56 PointerType **runtime.bmap
         - Name: len
           Offset: 8
-          Type: 8 BaseType int
+          Type: 9 BaseType int
         - Name: cap
           Offset: 16
-          Type: 8 BaseType int
+          Type: 9 BaseType int
       Data: 208 GoSliceDataType []*runtime.bmap.array
     - __kind: GoSliceDataType
       ID: 208
       Name: '[]*runtime.bmap.array'
       ByteSize: 2048
-      Element: 32 PointerType *runtime.bmap
+      Element: 57 PointerType *runtime.bmap
     - __kind: GoSliceHeaderType
-      ID: 105
+      ID: 127
       Name: '[][]*crypto/x509.Certificate'
       ByteSize: 24
       GoRuntimeType: 474048
@@ -917,21 +917,21 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 106 PointerType *[]*crypto/x509.Certificate
+          Type: 128 PointerType *[]*crypto/x509.Certificate
         - Name: len
           Offset: 8
-          Type: 8 BaseType int
+          Type: 9 BaseType int
         - Name: cap
           Offset: 16
-          Type: 8 BaseType int
+          Type: 9 BaseType int
       Data: 245 GoSliceDataType [][]*crypto/x509.Certificate.array
     - __kind: GoSliceDataType
       ID: 245
       Name: '[][]*crypto/x509.Certificate.array'
       ByteSize: 2048
-      Element: 55 GoSliceHeaderType []*crypto/x509.Certificate
+      Element: 79 GoSliceHeaderType []*crypto/x509.Certificate
     - __kind: GoSliceHeaderType
-      ID: 107
+      ID: 129
       Name: '[][]uint8'
       ByteSize: 24
       GoRuntimeType: 457184
@@ -939,51 +939,51 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 108 PointerType *[]uint8
+          Type: 130 PointerType *[]uint8
         - Name: len
           Offset: 8
-          Type: 8 BaseType int
+          Type: 9 BaseType int
         - Name: cap
           Offset: 16
-          Type: 8 BaseType int
+          Type: 9 BaseType int
       Data: 247 GoSliceDataType [][]uint8.array
     - __kind: GoSliceDataType
       ID: 247
       Name: '[][]uint8.array'
       ByteSize: 2048
-      Element: 52 GoSliceHeaderType []uint8
+      Element: 76 GoSliceHeaderType []uint8
     - __kind: GoSliceDataType
       ID: 258
       Name: '[]bucket<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>.array'
       ByteSize: 2048
-      Element: 156 GoHMapBucketType bucket<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
+      Element: 176 GoHMapBucketType bucket<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
     - __kind: GoSliceDataType
       ID: 210
       Name: '[]bucket<string,[]*mime/multipart.FileHeader>.array'
       ByteSize: 2048
-      Element: 45 GoHMapBucketType bucket<string,[]*mime/multipart.FileHeader>
+      Element: 69 GoHMapBucketType bucket<string,[]*mime/multipart.FileHeader>
     - __kind: GoSliceDataType
       ID: 205
       Name: '[]bucket<string,[]string>.array'
       ByteSize: 2048
-      Element: 20 GoHMapBucketType bucket<string,[]string>
+      Element: 47 GoHMapBucketType bucket<string,[]string>
     - __kind: GoSliceDataType
       ID: 253
       Name: '[]bucket<string,float64>.array'
       ByteSize: 2048
-      Element: 143 GoHMapBucketType bucket<string,float64>
+      Element: 164 GoHMapBucketType bucket<string,float64>
     - __kind: GoSliceDataType
       ID: 252
       Name: '[]bucket<string,interface {}>.array'
       ByteSize: 2048
-      Element: 137 GoHMapBucketType bucket<string,interface {}>
+      Element: 158 GoHMapBucketType bucket<string,interface {}>
     - __kind: GoSliceDataType
       ID: 251
       Name: '[]bucket<string,string>.array'
       ByteSize: 2048
-      Element: 124 GoHMapBucketType bucket<string,string>
+      Element: 146 GoHMapBucketType bucket<string,string>
     - __kind: GoSliceHeaderType
-      ID: 89
+      ID: 111
       Name: '[]crypto/x509.ExtKeyUsage'
       ByteSize: 24
       GoRuntimeType: 475200
@@ -991,21 +991,21 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 90 PointerType *crypto/x509.ExtKeyUsage
+          Type: 112 PointerType *crypto/x509.ExtKeyUsage
         - Name: len
           Offset: 8
-          Type: 8 BaseType int
+          Type: 9 BaseType int
         - Name: cap
           Offset: 16
-          Type: 8 BaseType int
+          Type: 9 BaseType int
       Data: 231 GoSliceDataType []crypto/x509.ExtKeyUsage.array
     - __kind: GoSliceDataType
       ID: 231
       Name: '[]crypto/x509.ExtKeyUsage.array'
       ByteSize: 2048
-      Element: 91 BaseType crypto/x509.ExtKeyUsage
+      Element: 113 BaseType crypto/x509.ExtKeyUsage
     - __kind: GoSliceHeaderType
-      ID: 102
+      ID: 124
       Name: '[]crypto/x509.OID'
       ByteSize: 24
       GoRuntimeType: 487040
@@ -1013,21 +1013,21 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 103 PointerType *crypto/x509.OID
+          Type: 125 PointerType *crypto/x509.OID
         - Name: len
           Offset: 8
-          Type: 8 BaseType int
+          Type: 9 BaseType int
         - Name: cap
           Offset: 16
-          Type: 8 BaseType int
+          Type: 9 BaseType int
       Data: 243 GoSliceDataType []crypto/x509.OID.array
     - __kind: GoSliceDataType
       ID: 243
       Name: '[]crypto/x509.OID.array'
       ByteSize: 2048
-      Element: 104 StructureType crypto/x509.OID
+      Element: 126 StructureType crypto/x509.OID
     - __kind: GoSliceHeaderType
-      ID: 68
+      ID: 92
       Name: '[]crypto/x509/pkix.AttributeTypeAndValue'
       ByteSize: 24
       GoRuntimeType: 487296
@@ -1035,21 +1035,21 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 69 PointerType *crypto/x509/pkix.AttributeTypeAndValue
+          Type: 93 PointerType *crypto/x509/pkix.AttributeTypeAndValue
         - Name: len
           Offset: 8
-          Type: 8 BaseType int
+          Type: 9 BaseType int
         - Name: cap
           Offset: 16
-          Type: 8 BaseType int
+          Type: 9 BaseType int
       Data: 219 GoSliceDataType []crypto/x509/pkix.AttributeTypeAndValue.array
     - __kind: GoSliceDataType
       ID: 219
       Name: '[]crypto/x509/pkix.AttributeTypeAndValue.array'
       ByteSize: 2048
-      Element: 70 StructureType crypto/x509/pkix.AttributeTypeAndValue
+      Element: 94 StructureType crypto/x509/pkix.AttributeTypeAndValue
     - __kind: GoSliceHeaderType
-      ID: 84
+      ID: 106
       Name: '[]crypto/x509/pkix.Extension'
       ByteSize: 24
       GoRuntimeType: 486784
@@ -1057,21 +1057,21 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 85 PointerType *crypto/x509/pkix.Extension
+          Type: 107 PointerType *crypto/x509/pkix.Extension
         - Name: len
           Offset: 8
-          Type: 8 BaseType int
+          Type: 9 BaseType int
         - Name: cap
           Offset: 16
-          Type: 8 BaseType int
+          Type: 9 BaseType int
       Data: 227 GoSliceDataType []crypto/x509/pkix.Extension.array
     - __kind: GoSliceDataType
       ID: 227
       Name: '[]crypto/x509/pkix.Extension.array'
       ByteSize: 2048
-      Element: 86 StructureType crypto/x509/pkix.Extension
+      Element: 108 StructureType crypto/x509/pkix.Extension
     - __kind: GoSliceHeaderType
-      ID: 87
+      ID: 109
       Name: '[]encoding/asn1.ObjectIdentifier'
       ByteSize: 24
       GoRuntimeType: 486848
@@ -1079,21 +1079,21 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 88 PointerType *encoding/asn1.ObjectIdentifier
+          Type: 110 PointerType *encoding/asn1.ObjectIdentifier
         - Name: len
           Offset: 8
-          Type: 8 BaseType int
+          Type: 9 BaseType int
         - Name: cap
           Offset: 16
-          Type: 8 BaseType int
+          Type: 9 BaseType int
       Data: 229 GoSliceDataType []encoding/asn1.ObjectIdentifier.array
     - __kind: GoSliceDataType
       ID: 229
       Name: '[]encoding/asn1.ObjectIdentifier.array'
       ByteSize: 2048
-      Element: 71 GoSliceHeaderType encoding/asn1.ObjectIdentifier
+      Element: 95 GoSliceHeaderType encoding/asn1.ObjectIdentifier
     - __kind: GoSliceHeaderType
-      ID: 146
+      ID: 166
       Name: '[]github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink'
       ByteSize: 24
       GoRuntimeType: 463584
@@ -1101,21 +1101,21 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 147 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink
+          Type: 167 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink
         - Name: len
           Offset: 8
-          Type: 8 BaseType int
+          Type: 9 BaseType int
         - Name: cap
           Offset: 16
-          Type: 8 BaseType int
+          Type: 9 BaseType int
       Data: 254 GoSliceDataType []github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink.array
     - __kind: GoSliceDataType
       ID: 254
       Name: '[]github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink.array'
       ByteSize: 2048
-      Element: 148 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink
+      Element: 168 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink
     - __kind: GoSliceHeaderType
-      ID: 149
+      ID: 169
       Name: '[]github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent'
       ByteSize: 24
       GoRuntimeType: 463776
@@ -1123,28 +1123,28 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 150 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent
+          Type: 170 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent
         - Name: len
           Offset: 8
-          Type: 8 BaseType int
+          Type: 9 BaseType int
         - Name: cap
           Offset: 16
-          Type: 8 BaseType int
+          Type: 9 BaseType int
       Data: 256 GoSliceDataType []github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent.array
     - __kind: GoSliceDataType
       ID: 256
       Name: '[]github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent.array'
       ByteSize: 2048
-      Element: 151 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent
+      Element: 171 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent
     - __kind: ArrayType
-      ID: 22
+      ID: 49
       Name: '[]key<string>'
       ByteSize: 128
       Count: 8
       HasCount: true
-      Element: 5 GoStringHeaderType string
+      Element: 11 GoStringHeaderType string
     - __kind: GoSliceHeaderType
-      ID: 92
+      ID: 114
       Name: '[]net.IP'
       ByteSize: 24
       GoRuntimeType: 458400
@@ -1152,21 +1152,21 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 93 PointerType *net.IP
+          Type: 115 PointerType *net.IP
         - Name: len
           Offset: 8
-          Type: 8 BaseType int
+          Type: 9 BaseType int
         - Name: cap
           Offset: 16
-          Type: 8 BaseType int
+          Type: 9 BaseType int
       Data: 233 GoSliceDataType []net.IP.array
     - __kind: GoSliceDataType
       ID: 233
       Name: '[]net.IP.array'
       ByteSize: 2048
-      Element: 94 GoSliceHeaderType net.IP
+      Element: 116 GoSliceHeaderType net.IP
     - __kind: GoSliceHeaderType
-      ID: 117
+      ID: 139
       Name: '[]net/http.segment'
       ByteSize: 24
       GoRuntimeType: 459168
@@ -1174,21 +1174,21 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 118 PointerType *net/http.segment
+          Type: 140 PointerType *net/http.segment
         - Name: len
           Offset: 8
-          Type: 8 BaseType int
+          Type: 9 BaseType int
         - Name: cap
           Offset: 16
-          Type: 8 BaseType int
+          Type: 9 BaseType int
       Data: 249 GoSliceDataType []net/http.segment.array
     - __kind: GoSliceDataType
       ID: 249
       Name: '[]net/http.segment.array'
       ByteSize: 2048
-      Element: 119 StructureType net/http.segment
+      Element: 141 StructureType net/http.segment
     - __kind: GoSliceHeaderType
-      ID: 24
+      ID: 51
       Name: '[]string'
       ByteSize: 24
       GoRuntimeType: 469152
@@ -1196,21 +1196,21 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 25 PointerType *string
+          Type: 22 PointerType *string
         - Name: len
           Offset: 8
-          Type: 8 BaseType int
+          Type: 9 BaseType int
         - Name: cap
           Offset: 16
-          Type: 8 BaseType int
+          Type: 9 BaseType int
       Data: 206 GoSliceDataType []string.array
     - __kind: GoSliceDataType
       ID: 206
       Name: '[]string.array'
       ByteSize: 2048
-      Element: 5 GoStringHeaderType string
+      Element: 11 GoStringHeaderType string
     - __kind: GoSliceHeaderType
-      ID: 77
+      ID: 99
       Name: '[]time.zone'
       ByteSize: 24
       GoRuntimeType: 463264
@@ -1218,21 +1218,21 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 78 PointerType *time.zone
+          Type: 100 PointerType *time.zone
         - Name: len
           Offset: 8
-          Type: 8 BaseType int
+          Type: 9 BaseType int
         - Name: cap
           Offset: 16
-          Type: 8 BaseType int
+          Type: 9 BaseType int
       Data: 223 GoSliceDataType []time.zone.array
     - __kind: GoSliceDataType
       ID: 223
       Name: '[]time.zone.array'
       ByteSize: 2048
-      Element: 79 StructureType time.zone
+      Element: 101 StructureType time.zone
     - __kind: GoSliceHeaderType
-      ID: 80
+      ID: 102
       Name: '[]time.zoneTrans'
       ByteSize: 24
       GoRuntimeType: 463328
@@ -1240,21 +1240,21 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 81 PointerType *time.zoneTrans
+          Type: 103 PointerType *time.zoneTrans
         - Name: len
           Offset: 8
-          Type: 8 BaseType int
+          Type: 9 BaseType int
         - Name: cap
           Offset: 16
-          Type: 8 BaseType int
+          Type: 9 BaseType int
       Data: 225 GoSliceDataType []time.zoneTrans.array
     - __kind: GoSliceDataType
       ID: 225
       Name: '[]time.zoneTrans.array'
       ByteSize: 2048
-      Element: 82 StructureType time.zoneTrans
+      Element: 104 StructureType time.zoneTrans
     - __kind: GoSliceHeaderType
-      ID: 52
+      ID: 76
       Name: '[]uint8'
       ByteSize: 24
       GoRuntimeType: 468000
@@ -1265,180 +1265,180 @@ Types:
           Type: 6 PointerType *uint8
         - Name: len
           Offset: 8
-          Type: 8 BaseType int
+          Type: 9 BaseType int
         - Name: cap
           Offset: 16
-          Type: 8 BaseType int
+          Type: 9 BaseType int
       Data: 213 GoSliceDataType []uint8.array
     - __kind: GoSliceDataType
       ID: 213
       Name: '[]uint8.array'
       ByteSize: 2048
-      Element: 7 BaseType uint8
+      Element: 3 BaseType uint8
     - __kind: ArrayType
-      ID: 157
+      ID: 177
       Name: '[]val<*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>'
       ByteSize: 64
       Count: 8
       HasCount: true
-      Element: 158 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
+      Element: 178 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
     - __kind: ArrayType
-      ID: 46
+      ID: 70
       Name: '[]val<[]*mime/multipart.FileHeader>'
       ByteSize: 192
       Count: 8
       HasCount: true
-      Element: 47 GoSliceHeaderType []*mime/multipart.FileHeader
+      Element: 71 GoSliceHeaderType []*mime/multipart.FileHeader
     - __kind: ArrayType
-      ID: 23
+      ID: 50
       Name: '[]val<[]string>'
       ByteSize: 192
       Count: 8
       HasCount: true
-      Element: 24 GoSliceHeaderType []string
+      Element: 51 GoSliceHeaderType []string
     - __kind: ArrayType
-      ID: 144
+      ID: 165
       Name: '[]val<float64>'
       ByteSize: 64
       Count: 8
       HasCount: true
-      Element: 145 BaseType float64
+      Element: 17 BaseType float64
     - __kind: ArrayType
-      ID: 138
+      ID: 159
       Name: '[]val<interface {}>'
       ByteSize: 128
       Count: 8
       HasCount: true
-      Element: 61 GoEmptyInterfaceType interface {}
+      Element: 85 GoEmptyInterfaceType interface {}
     - __kind: ArrayType
-      ID: 125
+      ID: 147
       Name: '[]val<string>'
       ByteSize: 128
       Count: 8
       HasCount: true
-      Element: 5 GoStringHeaderType string
+      Element: 11 GoStringHeaderType string
     - __kind: BaseType
-      ID: 13
+      ID: 4
       Name: bool
       ByteSize: 1
       GoRuntimeType: 543552
       GoKind: 1
     - __kind: GoHMapBucketType
-      ID: 156
+      ID: 176
       Name: bucket<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
       ByteSize: 208
       RawFields:
         - Name: tophash
           Offset: 0
-          Type: 21 ArrayType [8]uint8
+          Type: 48 ArrayType [8]uint8
         - Name: keys
           Offset: 8
-          Type: 22 ArrayType []key<string>
+          Type: 49 ArrayType []key<string>
         - Name: values
           Offset: 136
-          Type: 157 ArrayType []val<*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
+          Type: 177 ArrayType []val<*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
         - Name: overflow
           Offset: 200
-          Type: 155 PointerType *bucket<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
-      KeyType: 5 GoStringHeaderType string
-      ValueType: 158 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
+          Type: 175 PointerType *bucket<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
+      KeyType: 11 GoStringHeaderType string
+      ValueType: 178 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
     - __kind: GoHMapBucketType
-      ID: 45
+      ID: 69
       Name: bucket<string,[]*mime/multipart.FileHeader>
       ByteSize: 336
       RawFields:
         - Name: tophash
           Offset: 0
-          Type: 21 ArrayType [8]uint8
+          Type: 48 ArrayType [8]uint8
         - Name: keys
           Offset: 8
-          Type: 22 ArrayType []key<string>
+          Type: 49 ArrayType []key<string>
         - Name: values
           Offset: 136
-          Type: 46 ArrayType []val<[]*mime/multipart.FileHeader>
+          Type: 70 ArrayType []val<[]*mime/multipart.FileHeader>
         - Name: overflow
           Offset: 328
-          Type: 44 PointerType *bucket<string,[]*mime/multipart.FileHeader>
-      KeyType: 5 GoStringHeaderType string
-      ValueType: 47 GoSliceHeaderType []*mime/multipart.FileHeader
+          Type: 68 PointerType *bucket<string,[]*mime/multipart.FileHeader>
+      KeyType: 11 GoStringHeaderType string
+      ValueType: 71 GoSliceHeaderType []*mime/multipart.FileHeader
     - __kind: GoHMapBucketType
-      ID: 20
+      ID: 47
       Name: bucket<string,[]string>
       ByteSize: 336
       RawFields:
         - Name: tophash
           Offset: 0
-          Type: 21 ArrayType [8]uint8
+          Type: 48 ArrayType [8]uint8
         - Name: keys
           Offset: 8
-          Type: 22 ArrayType []key<string>
+          Type: 49 ArrayType []key<string>
         - Name: values
           Offset: 136
-          Type: 23 ArrayType []val<[]string>
+          Type: 50 ArrayType []val<[]string>
         - Name: overflow
           Offset: 328
-          Type: 19 PointerType *bucket<string,[]string>
-      KeyType: 5 GoStringHeaderType string
-      ValueType: 24 GoSliceHeaderType []string
+          Type: 46 PointerType *bucket<string,[]string>
+      KeyType: 11 GoStringHeaderType string
+      ValueType: 51 GoSliceHeaderType []string
     - __kind: GoHMapBucketType
-      ID: 143
+      ID: 164
       Name: bucket<string,float64>
       ByteSize: 208
       RawFields:
         - Name: tophash
           Offset: 0
-          Type: 21 ArrayType [8]uint8
+          Type: 48 ArrayType [8]uint8
         - Name: keys
           Offset: 8
-          Type: 22 ArrayType []key<string>
+          Type: 49 ArrayType []key<string>
         - Name: values
           Offset: 136
-          Type: 144 ArrayType []val<float64>
+          Type: 165 ArrayType []val<float64>
         - Name: overflow
           Offset: 200
-          Type: 142 PointerType *bucket<string,float64>
-      KeyType: 5 GoStringHeaderType string
-      ValueType: 145 BaseType float64
+          Type: 163 PointerType *bucket<string,float64>
+      KeyType: 11 GoStringHeaderType string
+      ValueType: 17 BaseType float64
     - __kind: GoHMapBucketType
-      ID: 137
+      ID: 158
       Name: bucket<string,interface {}>
       ByteSize: 272
       RawFields:
         - Name: tophash
           Offset: 0
-          Type: 21 ArrayType [8]uint8
+          Type: 48 ArrayType [8]uint8
         - Name: keys
           Offset: 8
-          Type: 22 ArrayType []key<string>
+          Type: 49 ArrayType []key<string>
         - Name: values
           Offset: 136
-          Type: 138 ArrayType []val<interface {}>
+          Type: 159 ArrayType []val<interface {}>
         - Name: overflow
           Offset: 264
-          Type: 136 PointerType *bucket<string,interface {}>
-      KeyType: 5 GoStringHeaderType string
-      ValueType: 61 GoEmptyInterfaceType interface {}
+          Type: 157 PointerType *bucket<string,interface {}>
+      KeyType: 11 GoStringHeaderType string
+      ValueType: 85 GoEmptyInterfaceType interface {}
     - __kind: GoHMapBucketType
-      ID: 124
+      ID: 146
       Name: bucket<string,string>
       ByteSize: 272
       RawFields:
         - Name: tophash
           Offset: 0
-          Type: 21 ArrayType [8]uint8
+          Type: 48 ArrayType [8]uint8
         - Name: keys
           Offset: 8
-          Type: 22 ArrayType []key<string>
+          Type: 49 ArrayType []key<string>
         - Name: values
           Offset: 136
-          Type: 125 ArrayType []val<string>
+          Type: 147 ArrayType []val<string>
         - Name: overflow
           Offset: 264
-          Type: 123 PointerType *bucket<string,string>
-      KeyType: 5 GoStringHeaderType string
-      ValueType: 5 GoStringHeaderType string
+          Type: 145 PointerType *bucket<string,string>
+      KeyType: 11 GoStringHeaderType string
+      ValueType: 11 GoStringHeaderType string
     - __kind: StructureType
-      ID: 180
+      ID: 199
       Name: bytes.Buffer
       ByteSize: 40
       GoRuntimeType: 1.4512e+06
@@ -1446,33 +1446,33 @@ Types:
       RawFields:
         - Name: buf
           Offset: 0
-          Type: 52 GoSliceHeaderType []uint8
+          Type: 76 GoSliceHeaderType []uint8
         - Name: off
           Offset: 24
-          Type: 8 BaseType int
+          Type: 9 BaseType int
         - Name: lastRead
           Offset: 32
-          Type: 181 BaseType bytes.readOp
+          Type: 200 BaseType bytes.readOp
     - __kind: BaseType
-      ID: 181
+      ID: 200
       Name: bytes.readOp
       ByteSize: 1
       GoRuntimeType: 541760
       GoKind: 3
     - __kind: BaseType
-      ID: 194
+      ID: 25
       Name: complex128
       ByteSize: 16
       GoRuntimeType: 543360
       GoKind: 16
     - __kind: BaseType
-      ID: 193
+      ID: 24
       Name: complex64
       ByteSize: 8
       GoRuntimeType: 543296
       GoKind: 15
     - __kind: GoInterfaceType
-      ID: 114
+      ID: 136
       Name: context.Context
       ByteSize: 16
       GoRuntimeType: 1.215776e+06
@@ -1480,27 +1480,27 @@ Types:
       RawFields:
         - Name: tab
           Offset: 0
-          Type: 2 VoidPointerType unsafe.Pointer
+          Type: 19 VoidPointerType unsafe.Pointer
         - Name: data
           Offset: 8
-          Type: 2 VoidPointerType unsafe.Pointer
+          Type: 19 VoidPointerType unsafe.Pointer
     - __kind: StructureType
-      ID: 182
+      ID: 201
       Name: context.backgroundCtx
       GoRuntimeType: 1.708832e+06
       GoKind: 25
       RawFields:
         - Name: emptyCtx
           Offset: 0
-          Type: 183 StructureType context.emptyCtx
+          Type: 202 StructureType context.emptyCtx
     - __kind: StructureType
-      ID: 183
+      ID: 202
       Name: context.emptyCtx
       GoRuntimeType: 1.435104e+06
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 54
+      ID: 78
       Name: crypto/tls.ConnectionState
       ByteSize: 192
       GoRuntimeType: 2.16096e+06
@@ -1508,60 +1508,60 @@ Types:
       RawFields:
         - Name: Version
           Offset: 0
-          Type: 17 BaseType uint16
+          Type: 7 BaseType uint16
         - Name: HandshakeComplete
           Offset: 2
-          Type: 13 BaseType bool
+          Type: 4 BaseType bool
         - Name: DidResume
           Offset: 3
-          Type: 13 BaseType bool
+          Type: 4 BaseType bool
         - Name: CipherSuite
           Offset: 4
-          Type: 17 BaseType uint16
+          Type: 7 BaseType uint16
         - Name: NegotiatedProtocol
           Offset: 8
-          Type: 5 GoStringHeaderType string
+          Type: 11 GoStringHeaderType string
         - Name: NegotiatedProtocolIsMutual
           Offset: 24
-          Type: 13 BaseType bool
+          Type: 4 BaseType bool
         - Name: ServerName
           Offset: 32
-          Type: 5 GoStringHeaderType string
+          Type: 11 GoStringHeaderType string
         - Name: PeerCertificates
           Offset: 48
-          Type: 55 GoSliceHeaderType []*crypto/x509.Certificate
+          Type: 79 GoSliceHeaderType []*crypto/x509.Certificate
         - Name: VerifiedChains
           Offset: 72
-          Type: 105 GoSliceHeaderType [][]*crypto/x509.Certificate
+          Type: 127 GoSliceHeaderType [][]*crypto/x509.Certificate
         - Name: SignedCertificateTimestamps
           Offset: 96
-          Type: 107 GoSliceHeaderType [][]uint8
+          Type: 129 GoSliceHeaderType [][]uint8
         - Name: OCSPResponse
           Offset: 120
-          Type: 52 GoSliceHeaderType []uint8
+          Type: 76 GoSliceHeaderType []uint8
         - Name: TLSUnique
           Offset: 144
-          Type: 52 GoSliceHeaderType []uint8
+          Type: 76 GoSliceHeaderType []uint8
         - Name: ECHAccepted
           Offset: 168
-          Type: 13 BaseType bool
+          Type: 4 BaseType bool
         - Name: ekm
           Offset: 176
-          Type: 109 GoSubroutineType func(string, []uint8, int) ([]uint8, error)
+          Type: 131 GoSubroutineType func(string, []uint8, int) ([]uint8, error)
         - Name: testingOnlyDidHRR
           Offset: 184
-          Type: 13 BaseType bool
+          Type: 4 BaseType bool
         - Name: testingOnlyCurveID
           Offset: 186
-          Type: 110 BaseType crypto/tls.CurveID
+          Type: 132 BaseType crypto/tls.CurveID
     - __kind: BaseType
-      ID: 110
+      ID: 132
       Name: crypto/tls.CurveID
       ByteSize: 2
       GoRuntimeType: 778592
       GoKind: 9
     - __kind: StructureType
-      ID: 58
+      ID: 82
       Name: crypto/x509.Certificate
       ByteSize: 1352
       GoRuntimeType: 2.300992e+06
@@ -1569,153 +1569,153 @@ Types:
       RawFields:
         - Name: Raw
           Offset: 0
-          Type: 52 GoSliceHeaderType []uint8
+          Type: 76 GoSliceHeaderType []uint8
         - Name: RawTBSCertificate
           Offset: 24
-          Type: 52 GoSliceHeaderType []uint8
+          Type: 76 GoSliceHeaderType []uint8
         - Name: RawSubjectPublicKeyInfo
           Offset: 48
-          Type: 52 GoSliceHeaderType []uint8
+          Type: 76 GoSliceHeaderType []uint8
         - Name: RawSubject
           Offset: 72
-          Type: 52 GoSliceHeaderType []uint8
+          Type: 76 GoSliceHeaderType []uint8
         - Name: RawIssuer
           Offset: 96
-          Type: 52 GoSliceHeaderType []uint8
+          Type: 76 GoSliceHeaderType []uint8
         - Name: Signature
           Offset: 120
-          Type: 52 GoSliceHeaderType []uint8
+          Type: 76 GoSliceHeaderType []uint8
         - Name: SignatureAlgorithm
           Offset: 144
-          Type: 59 BaseType crypto/x509.SignatureAlgorithm
+          Type: 83 BaseType crypto/x509.SignatureAlgorithm
         - Name: PublicKeyAlgorithm
           Offset: 152
-          Type: 60 BaseType crypto/x509.PublicKeyAlgorithm
+          Type: 84 BaseType crypto/x509.PublicKeyAlgorithm
         - Name: PublicKey
           Offset: 160
-          Type: 61 GoEmptyInterfaceType interface {}
+          Type: 85 GoEmptyInterfaceType interface {}
         - Name: Version
           Offset: 176
-          Type: 8 BaseType int
+          Type: 9 BaseType int
         - Name: SerialNumber
           Offset: 184
-          Type: 62 PointerType *math/big.Int
+          Type: 86 PointerType *math/big.Int
         - Name: Issuer
           Offset: 192
-          Type: 67 StructureType crypto/x509/pkix.Name
+          Type: 91 StructureType crypto/x509/pkix.Name
         - Name: Subject
           Offset: 440
-          Type: 67 StructureType crypto/x509/pkix.Name
+          Type: 91 StructureType crypto/x509/pkix.Name
         - Name: NotBefore
           Offset: 688
-          Type: 73 StructureType time.Time
+          Type: 96 StructureType time.Time
         - Name: NotAfter
           Offset: 712
-          Type: 73 StructureType time.Time
+          Type: 96 StructureType time.Time
         - Name: KeyUsage
           Offset: 736
-          Type: 83 BaseType crypto/x509.KeyUsage
+          Type: 105 BaseType crypto/x509.KeyUsage
         - Name: Extensions
           Offset: 744
-          Type: 84 GoSliceHeaderType []crypto/x509/pkix.Extension
+          Type: 106 GoSliceHeaderType []crypto/x509/pkix.Extension
         - Name: ExtraExtensions
           Offset: 768
-          Type: 84 GoSliceHeaderType []crypto/x509/pkix.Extension
+          Type: 106 GoSliceHeaderType []crypto/x509/pkix.Extension
         - Name: UnhandledCriticalExtensions
           Offset: 792
-          Type: 87 GoSliceHeaderType []encoding/asn1.ObjectIdentifier
+          Type: 109 GoSliceHeaderType []encoding/asn1.ObjectIdentifier
         - Name: ExtKeyUsage
           Offset: 816
-          Type: 89 GoSliceHeaderType []crypto/x509.ExtKeyUsage
+          Type: 111 GoSliceHeaderType []crypto/x509.ExtKeyUsage
         - Name: UnknownExtKeyUsage
           Offset: 840
-          Type: 87 GoSliceHeaderType []encoding/asn1.ObjectIdentifier
+          Type: 109 GoSliceHeaderType []encoding/asn1.ObjectIdentifier
         - Name: BasicConstraintsValid
           Offset: 864
-          Type: 13 BaseType bool
+          Type: 4 BaseType bool
         - Name: IsCA
           Offset: 865
-          Type: 13 BaseType bool
+          Type: 4 BaseType bool
         - Name: MaxPathLen
           Offset: 872
-          Type: 8 BaseType int
+          Type: 9 BaseType int
         - Name: MaxPathLenZero
           Offset: 880
-          Type: 13 BaseType bool
+          Type: 4 BaseType bool
         - Name: SubjectKeyId
           Offset: 888
-          Type: 52 GoSliceHeaderType []uint8
+          Type: 76 GoSliceHeaderType []uint8
         - Name: AuthorityKeyId
           Offset: 912
-          Type: 52 GoSliceHeaderType []uint8
+          Type: 76 GoSliceHeaderType []uint8
         - Name: OCSPServer
           Offset: 936
-          Type: 24 GoSliceHeaderType []string
+          Type: 51 GoSliceHeaderType []string
         - Name: IssuingCertificateURL
           Offset: 960
-          Type: 24 GoSliceHeaderType []string
+          Type: 51 GoSliceHeaderType []string
         - Name: DNSNames
           Offset: 984
-          Type: 24 GoSliceHeaderType []string
+          Type: 51 GoSliceHeaderType []string
         - Name: EmailAddresses
           Offset: 1008
-          Type: 24 GoSliceHeaderType []string
+          Type: 51 GoSliceHeaderType []string
         - Name: IPAddresses
           Offset: 1032
-          Type: 92 GoSliceHeaderType []net.IP
+          Type: 114 GoSliceHeaderType []net.IP
         - Name: URIs
           Offset: 1056
-          Type: 95 GoSliceHeaderType []*net/url.URL
+          Type: 117 GoSliceHeaderType []*net/url.URL
         - Name: PermittedDNSDomainsCritical
           Offset: 1080
-          Type: 13 BaseType bool
+          Type: 4 BaseType bool
         - Name: PermittedDNSDomains
           Offset: 1088
-          Type: 24 GoSliceHeaderType []string
+          Type: 51 GoSliceHeaderType []string
         - Name: ExcludedDNSDomains
           Offset: 1112
-          Type: 24 GoSliceHeaderType []string
+          Type: 51 GoSliceHeaderType []string
         - Name: PermittedIPRanges
           Offset: 1136
-          Type: 97 GoSliceHeaderType []*net.IPNet
+          Type: 119 GoSliceHeaderType []*net.IPNet
         - Name: ExcludedIPRanges
           Offset: 1160
-          Type: 97 GoSliceHeaderType []*net.IPNet
+          Type: 119 GoSliceHeaderType []*net.IPNet
         - Name: PermittedEmailAddresses
           Offset: 1184
-          Type: 24 GoSliceHeaderType []string
+          Type: 51 GoSliceHeaderType []string
         - Name: ExcludedEmailAddresses
           Offset: 1208
-          Type: 24 GoSliceHeaderType []string
+          Type: 51 GoSliceHeaderType []string
         - Name: PermittedURIDomains
           Offset: 1232
-          Type: 24 GoSliceHeaderType []string
+          Type: 51 GoSliceHeaderType []string
         - Name: ExcludedURIDomains
           Offset: 1256
-          Type: 24 GoSliceHeaderType []string
+          Type: 51 GoSliceHeaderType []string
         - Name: CRLDistributionPoints
           Offset: 1280
-          Type: 24 GoSliceHeaderType []string
+          Type: 51 GoSliceHeaderType []string
         - Name: PolicyIdentifiers
           Offset: 1304
-          Type: 87 GoSliceHeaderType []encoding/asn1.ObjectIdentifier
+          Type: 109 GoSliceHeaderType []encoding/asn1.ObjectIdentifier
         - Name: Policies
           Offset: 1328
-          Type: 102 GoSliceHeaderType []crypto/x509.OID
+          Type: 124 GoSliceHeaderType []crypto/x509.OID
     - __kind: BaseType
-      ID: 91
+      ID: 113
       Name: crypto/x509.ExtKeyUsage
       ByteSize: 8
       GoRuntimeType: 546624
       GoKind: 2
     - __kind: BaseType
-      ID: 83
+      ID: 105
       Name: crypto/x509.KeyUsage
       ByteSize: 8
       GoRuntimeType: 546560
       GoKind: 2
     - __kind: StructureType
-      ID: 104
+      ID: 126
       Name: crypto/x509.OID
       ByteSize: 24
       GoRuntimeType: 1.762592e+06
@@ -1723,21 +1723,21 @@ Types:
       RawFields:
         - Name: der
           Offset: 0
-          Type: 52 GoSliceHeaderType []uint8
+          Type: 76 GoSliceHeaderType []uint8
     - __kind: BaseType
-      ID: 60
+      ID: 84
       Name: crypto/x509.PublicKeyAlgorithm
       ByteSize: 8
       GoRuntimeType: 780896
       GoKind: 2
     - __kind: BaseType
-      ID: 59
+      ID: 83
       Name: crypto/x509.SignatureAlgorithm
       ByteSize: 8
       GoRuntimeType: 1.09744e+06
       GoKind: 2
     - __kind: StructureType
-      ID: 70
+      ID: 94
       Name: crypto/x509/pkix.AttributeTypeAndValue
       ByteSize: 40
       GoRuntimeType: 1.349408e+06
@@ -1745,12 +1745,12 @@ Types:
       RawFields:
         - Name: Type
           Offset: 0
-          Type: 71 GoSliceHeaderType encoding/asn1.ObjectIdentifier
+          Type: 95 GoSliceHeaderType encoding/asn1.ObjectIdentifier
         - Name: Value
           Offset: 24
-          Type: 61 GoEmptyInterfaceType interface {}
+          Type: 85 GoEmptyInterfaceType interface {}
     - __kind: StructureType
-      ID: 86
+      ID: 108
       Name: crypto/x509/pkix.Extension
       ByteSize: 56
       GoRuntimeType: 1.494976e+06
@@ -1758,15 +1758,15 @@ Types:
       RawFields:
         - Name: Id
           Offset: 0
-          Type: 71 GoSliceHeaderType encoding/asn1.ObjectIdentifier
+          Type: 95 GoSliceHeaderType encoding/asn1.ObjectIdentifier
         - Name: Critical
           Offset: 24
-          Type: 13 BaseType bool
+          Type: 4 BaseType bool
         - Name: Value
           Offset: 32
-          Type: 52 GoSliceHeaderType []uint8
+          Type: 76 GoSliceHeaderType []uint8
     - __kind: StructureType
-      ID: 67
+      ID: 91
       Name: crypto/x509/pkix.Name
       ByteSize: 248
       GoRuntimeType: 2.105696e+06
@@ -1774,39 +1774,39 @@ Types:
       RawFields:
         - Name: Country
           Offset: 0
-          Type: 24 GoSliceHeaderType []string
+          Type: 51 GoSliceHeaderType []string
         - Name: Organization
           Offset: 24
-          Type: 24 GoSliceHeaderType []string
+          Type: 51 GoSliceHeaderType []string
         - Name: OrganizationalUnit
           Offset: 48
-          Type: 24 GoSliceHeaderType []string
+          Type: 51 GoSliceHeaderType []string
         - Name: Locality
           Offset: 72
-          Type: 24 GoSliceHeaderType []string
+          Type: 51 GoSliceHeaderType []string
         - Name: Province
           Offset: 96
-          Type: 24 GoSliceHeaderType []string
+          Type: 51 GoSliceHeaderType []string
         - Name: StreetAddress
           Offset: 120
-          Type: 24 GoSliceHeaderType []string
+          Type: 51 GoSliceHeaderType []string
         - Name: PostalCode
           Offset: 144
-          Type: 24 GoSliceHeaderType []string
+          Type: 51 GoSliceHeaderType []string
         - Name: SerialNumber
           Offset: 168
-          Type: 5 GoStringHeaderType string
+          Type: 11 GoStringHeaderType string
         - Name: CommonName
           Offset: 184
-          Type: 5 GoStringHeaderType string
+          Type: 11 GoStringHeaderType string
         - Name: Names
           Offset: 200
-          Type: 68 GoSliceHeaderType []crypto/x509/pkix.AttributeTypeAndValue
+          Type: 92 GoSliceHeaderType []crypto/x509/pkix.AttributeTypeAndValue
         - Name: ExtraNames
           Offset: 224
-          Type: 68 GoSliceHeaderType []crypto/x509/pkix.AttributeTypeAndValue
+          Type: 92 GoSliceHeaderType []crypto/x509/pkix.AttributeTypeAndValue
     - __kind: GoSliceHeaderType
-      ID: 71
+      ID: 95
       Name: encoding/asn1.ObjectIdentifier
       ByteSize: 24
       GoRuntimeType: 1.0376e+06
@@ -1814,21 +1814,21 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 72 PointerType *int
+          Type: 28 PointerType *int
         - Name: len
           Offset: 8
-          Type: 8 BaseType int
+          Type: 9 BaseType int
         - Name: cap
           Offset: 16
-          Type: 8 BaseType int
+          Type: 9 BaseType int
       Data: 221 GoSliceDataType encoding/asn1.ObjectIdentifier.array
     - __kind: GoSliceDataType
       ID: 221
       Name: encoding/asn1.ObjectIdentifier.array
       ByteSize: 2048
-      Element: 8 BaseType int
+      Element: 9 BaseType int
     - __kind: GoInterfaceType
-      ID: 189
+      ID: 18
       Name: error
       ByteSize: 16
       GoRuntimeType: 1.011104e+06
@@ -1836,42 +1836,42 @@ Types:
       RawFields:
         - Name: tab
           Offset: 0
-          Type: 2 VoidPointerType unsafe.Pointer
+          Type: 19 VoidPointerType unsafe.Pointer
         - Name: data
           Offset: 8
-          Type: 2 VoidPointerType unsafe.Pointer
+          Type: 19 VoidPointerType unsafe.Pointer
     - __kind: BaseType
-      ID: 188
+      ID: 16
       Name: float32
       ByteSize: 4
       GoRuntimeType: 543424
       GoKind: 13
     - __kind: BaseType
-      ID: 145
+      ID: 17
       Name: float64
       ByteSize: 8
       GoRuntimeType: 543488
       GoKind: 14
     - __kind: GoSubroutineType
-      ID: 178
+      ID: 197
       Name: func()
       ByteSize: 8
       GoRuntimeType: 455520
       GoKind: 19
     - __kind: GoSubroutineType
-      ID: 35
+      ID: 60
       Name: func() (io.ReadCloser, error)
       ByteSize: 8
       GoRuntimeType: 645600
       GoKind: 19
     - __kind: GoSubroutineType
-      ID: 109
+      ID: 131
       Name: func(string, []uint8, int) ([]uint8, error)
       ByteSize: 8
       GoRuntimeType: 983200
       GoKind: 19
     - __kind: StructureType
-      ID: 127
+      ID: 149
       Name: github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span
       ByteSize: 288
       GoRuntimeType: 2.252e+06
@@ -1879,81 +1879,81 @@ Types:
       RawFields:
         - Name: mu
           Offset: 0
-          Type: 128 StructureType sync.RWMutex
+          Type: 150 StructureType sync.RWMutex
         - Name: name
           Offset: 24
-          Type: 5 GoStringHeaderType string
+          Type: 11 GoStringHeaderType string
         - Name: service
           Offset: 40
-          Type: 5 GoStringHeaderType string
+          Type: 11 GoStringHeaderType string
         - Name: resource
           Offset: 56
-          Type: 5 GoStringHeaderType string
+          Type: 11 GoStringHeaderType string
         - Name: spanType
           Offset: 72
-          Type: 5 GoStringHeaderType string
+          Type: 11 GoStringHeaderType string
         - Name: start
           Offset: 88
-          Type: 36 BaseType int64
+          Type: 14 BaseType int64
         - Name: duration
           Offset: 96
-          Type: 36 BaseType int64
+          Type: 14 BaseType int64
         - Name: meta
           Offset: 104
-          Type: 120 GoMapType map[string]string
+          Type: 142 GoMapType map[string]string
         - Name: metaStruct
           Offset: 112
-          Type: 133 GoMapType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.metaStructMap
+          Type: 154 GoMapType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.metaStructMap
         - Name: metrics
           Offset: 120
-          Type: 139 GoMapType map[string]float64
+          Type: 160 GoMapType map[string]float64
         - Name: spanID
           Offset: 128
-          Type: 74 BaseType uint64
+          Type: 10 BaseType uint64
         - Name: traceID
           Offset: 136
-          Type: 74 BaseType uint64
+          Type: 10 BaseType uint64
         - Name: parentID
           Offset: 144
-          Type: 74 BaseType uint64
+          Type: 10 BaseType uint64
         - Name: error
           Offset: 152
-          Type: 130 BaseType int32
+          Type: 13 BaseType int32
         - Name: spanLinks
           Offset: 160
-          Type: 146 GoSliceHeaderType []github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink
+          Type: 166 GoSliceHeaderType []github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink
         - Name: spanEvents
           Offset: 184
-          Type: 149 GoSliceHeaderType []github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent
+          Type: 169 GoSliceHeaderType []github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent
         - Name: goExecTraced
           Offset: 208
-          Type: 13 BaseType bool
+          Type: 4 BaseType bool
         - Name: noDebugStack
           Offset: 209
-          Type: 13 BaseType bool
+          Type: 4 BaseType bool
         - Name: finished
           Offset: 210
-          Type: 13 BaseType bool
+          Type: 4 BaseType bool
         - Name: context
           Offset: 216
-          Type: 169 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanContext
+          Type: 189 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanContext
         - Name: integration
           Offset: 224
-          Type: 5 GoStringHeaderType string
+          Type: 11 GoStringHeaderType string
         - Name: supportsEvents
           Offset: 240
-          Type: 13 BaseType bool
+          Type: 4 BaseType bool
         - Name: pprofCtxActive
           Offset: 248
-          Type: 114 GoInterfaceType context.Context
+          Type: 136 GoInterfaceType context.Context
         - Name: pprofCtxRestore
           Offset: 264
-          Type: 114 GoInterfaceType context.Context
+          Type: 136 GoInterfaceType context.Context
         - Name: taskEnd
           Offset: 280
-          Type: 178 GoSubroutineType func()
+          Type: 197 GoSubroutineType func()
     - __kind: StructureType
-      ID: 170
+      ID: 190
       Name: github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanContext
       ByteSize: 168
       GoRuntimeType: 2.125376e+06
@@ -1961,48 +1961,48 @@ Types:
       RawFields:
         - Name: updated
           Offset: 0
-          Type: 13 BaseType bool
+          Type: 4 BaseType bool
         - Name: trace
           Offset: 8
-          Type: 171 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.trace
+          Type: 191 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.trace
         - Name: span
           Offset: 16
-          Type: 126 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span
+          Type: 148 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span
         - Name: errors
           Offset: 24
-          Type: 131 StructureType sync/atomic.Int32
+          Type: 152 StructureType sync/atomic.Int32
         - Name: reparentID
           Offset: 32
-          Type: 5 GoStringHeaderType string
+          Type: 11 GoStringHeaderType string
         - Name: isRemote
           Offset: 48
-          Type: 13 BaseType bool
+          Type: 4 BaseType bool
         - Name: traceID
           Offset: 49
-          Type: 177 ArrayType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.traceID
+          Type: 196 ArrayType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.traceID
         - Name: spanID
           Offset: 72
-          Type: 74 BaseType uint64
+          Type: 10 BaseType uint64
         - Name: mu
           Offset: 80
-          Type: 128 StructureType sync.RWMutex
+          Type: 150 StructureType sync.RWMutex
         - Name: baggage
           Offset: 104
-          Type: 120 GoMapType map[string]string
+          Type: 142 GoMapType map[string]string
         - Name: hasBaggage
           Offset: 112
-          Type: 18 BaseType uint32
+          Type: 2 BaseType uint32
         - Name: origin
           Offset: 120
-          Type: 5 GoStringHeaderType string
+          Type: 11 GoStringHeaderType string
         - Name: spanLinks
           Offset: 136
-          Type: 146 GoSliceHeaderType []github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink
+          Type: 166 GoSliceHeaderType []github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink
         - Name: baggageOnly
           Offset: 160
-          Type: 13 BaseType bool
+          Type: 4 BaseType bool
     - __kind: StructureType
-      ID: 148
+      ID: 168
       Name: github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink
       ByteSize: 56
       GoRuntimeType: 1.822592e+06
@@ -2010,37 +2010,37 @@ Types:
       RawFields:
         - Name: TraceID
           Offset: 0
-          Type: 74 BaseType uint64
+          Type: 10 BaseType uint64
         - Name: TraceIDHigh
           Offset: 8
-          Type: 74 BaseType uint64
+          Type: 10 BaseType uint64
         - Name: SpanID
           Offset: 16
-          Type: 74 BaseType uint64
+          Type: 10 BaseType uint64
         - Name: Attributes
           Offset: 24
-          Type: 120 GoMapType map[string]string
+          Type: 142 GoMapType map[string]string
         - Name: Tracestate
           Offset: 32
-          Type: 5 GoStringHeaderType string
+          Type: 11 GoStringHeaderType string
         - Name: Flags
           Offset: 48
-          Type: 18 BaseType uint32
+          Type: 2 BaseType uint32
     - __kind: GoMapType
-      ID: 133
+      ID: 154
       Name: github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.metaStructMap
       ByteSize: 8
       GoRuntimeType: 1.00752e+06
       GoKind: 21
-      HeaderType: 135 GoHMapHeaderType hash<string,interface {}>
+      HeaderType: 156 GoHMapHeaderType hash<string,interface {}>
     - __kind: BaseType
-      ID: 176
+      ID: 195
       Name: github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.samplingDecision
       ByteSize: 4
       GoRuntimeType: 542336
       GoKind: 10
     - __kind: StructureType
-      ID: 151
+      ID: 171
       Name: github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent
       ByteSize: 40
       GoRuntimeType: 1.664384e+06
@@ -2048,18 +2048,18 @@ Types:
       RawFields:
         - Name: Name
           Offset: 0
-          Type: 5 GoStringHeaderType string
+          Type: 11 GoStringHeaderType string
         - Name: TimeUnixNano
           Offset: 16
-          Type: 74 BaseType uint64
+          Type: 10 BaseType uint64
         - Name: Attributes
           Offset: 24
-          Type: 152 GoMapType map[string]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
+          Type: 172 GoMapType map[string]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
         - Name: RawAttributes
           Offset: 32
-          Type: 168 GoMapType map[string]interface {}
+          Type: 188 GoMapType map[string]interface {}
     - __kind: StructureType
-      ID: 162
+      ID: 182
       Name: github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttribute
       ByteSize: 24
       GoRuntimeType: 1.13008e+06
@@ -2067,9 +2067,9 @@ Types:
       RawFields:
         - Name: Values
           Offset: 0
-          Type: 163 GoSliceHeaderType []*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttributeValue
+          Type: 183 GoSliceHeaderType []*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttributeValue
     - __kind: StructureType
-      ID: 166
+      ID: 186
       Name: github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttributeValue
       ByteSize: 48
       GoRuntimeType: 1.74848e+06
@@ -2077,27 +2077,27 @@ Types:
       RawFields:
         - Name: Type
           Offset: 0
-          Type: 167 BaseType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttributeValueType
+          Type: 187 BaseType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttributeValueType
         - Name: StringValue
           Offset: 8
-          Type: 5 GoStringHeaderType string
+          Type: 11 GoStringHeaderType string
         - Name: BoolValue
           Offset: 24
-          Type: 13 BaseType bool
+          Type: 4 BaseType bool
         - Name: IntValue
           Offset: 32
-          Type: 36 BaseType int64
+          Type: 14 BaseType int64
         - Name: DoubleValue
           Offset: 40
-          Type: 145 BaseType float64
+          Type: 17 BaseType float64
     - __kind: BaseType
-      ID: 167
+      ID: 187
       Name: github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttributeValueType
       ByteSize: 4
       GoRuntimeType: 965344
       GoKind: 5
     - __kind: StructureType
-      ID: 159
+      ID: 179
       Name: github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
       ByteSize: 56
       GoRuntimeType: 1.822848e+06
@@ -2105,30 +2105,30 @@ Types:
       RawFields:
         - Name: Type
           Offset: 0
-          Type: 160 BaseType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttributeType
+          Type: 180 BaseType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttributeType
         - Name: StringValue
           Offset: 8
-          Type: 5 GoStringHeaderType string
+          Type: 11 GoStringHeaderType string
         - Name: BoolValue
           Offset: 24
-          Type: 13 BaseType bool
+          Type: 4 BaseType bool
         - Name: IntValue
           Offset: 32
-          Type: 36 BaseType int64
+          Type: 14 BaseType int64
         - Name: DoubleValue
           Offset: 40
-          Type: 145 BaseType float64
+          Type: 17 BaseType float64
         - Name: ArrayValue
           Offset: 48
-          Type: 161 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttribute
+          Type: 181 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttribute
     - __kind: BaseType
-      ID: 160
+      ID: 180
       Name: github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttributeType
       ByteSize: 4
       GoRuntimeType: 965248
       GoKind: 5
     - __kind: StructureType
-      ID: 172
+      ID: 192
       Name: github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.trace
       ByteSize: 104
       GoRuntimeType: 2.017536e+06
@@ -2136,279 +2136,279 @@ Types:
       RawFields:
         - Name: mu
           Offset: 0
-          Type: 128 StructureType sync.RWMutex
+          Type: 150 StructureType sync.RWMutex
         - Name: spans
           Offset: 24
-          Type: 173 GoSliceHeaderType []*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span
+          Type: 193 GoSliceHeaderType []*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span
         - Name: tags
           Offset: 48
-          Type: 120 GoMapType map[string]string
+          Type: 142 GoMapType map[string]string
         - Name: propagatingTags
           Offset: 56
-          Type: 120 GoMapType map[string]string
+          Type: 142 GoMapType map[string]string
         - Name: finished
           Offset: 64
-          Type: 8 BaseType int
+          Type: 9 BaseType int
         - Name: full
           Offset: 72
-          Type: 13 BaseType bool
+          Type: 4 BaseType bool
         - Name: priority
           Offset: 80
-          Type: 175 PointerType *float64
+          Type: 26 PointerType *float64
         - Name: locked
           Offset: 88
-          Type: 13 BaseType bool
+          Type: 4 BaseType bool
         - Name: samplingDecision
           Offset: 92
-          Type: 176 BaseType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.samplingDecision
+          Type: 195 BaseType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.samplingDecision
         - Name: root
           Offset: 96
-          Type: 126 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span
+          Type: 148 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span
     - __kind: ArrayType
-      ID: 177
+      ID: 196
       Name: github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.traceID
       ByteSize: 16
       GoRuntimeType: 847712
       GoKind: 17
       Count: 16
       HasCount: true
-      Element: 7 BaseType uint8
+      Element: 3 BaseType uint8
     - __kind: GoHMapHeaderType
-      ID: 154
+      ID: 174
       Name: hash<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
       ByteSize: 48
       RawFields:
         - Name: count
           Offset: 0
-          Type: 8 BaseType int
+          Type: 9 BaseType int
         - Name: flags
           Offset: 8
-          Type: 7 BaseType uint8
+          Type: 3 BaseType uint8
         - Name: B
           Offset: 9
-          Type: 7 BaseType uint8
+          Type: 3 BaseType uint8
         - Name: noverflow
           Offset: 10
-          Type: 17 BaseType uint16
+          Type: 7 BaseType uint16
         - Name: hash0
           Offset: 12
-          Type: 18 BaseType uint32
+          Type: 2 BaseType uint32
         - Name: buckets
           Offset: 16
-          Type: 155 PointerType *bucket<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
+          Type: 175 PointerType *bucket<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
         - Name: oldbuckets
           Offset: 24
-          Type: 155 PointerType *bucket<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
+          Type: 175 PointerType *bucket<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
         - Name: nevacuate
           Offset: 32
-          Type: 26 BaseType uintptr
+          Type: 1 BaseType uintptr
         - Name: extra
           Offset: 40
-          Type: 27 PointerType *runtime.mapextra
-      BucketType: 156 GoHMapBucketType bucket<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
+          Type: 52 PointerType *runtime.mapextra
+      BucketType: 176 GoHMapBucketType bucket<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
       BucketsType: 258 GoSliceDataType []bucket<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>.array
     - __kind: GoHMapHeaderType
-      ID: 43
+      ID: 67
       Name: hash<string,[]*mime/multipart.FileHeader>
       ByteSize: 48
       RawFields:
         - Name: count
           Offset: 0
-          Type: 8 BaseType int
+          Type: 9 BaseType int
         - Name: flags
           Offset: 8
-          Type: 7 BaseType uint8
+          Type: 3 BaseType uint8
         - Name: B
           Offset: 9
-          Type: 7 BaseType uint8
+          Type: 3 BaseType uint8
         - Name: noverflow
           Offset: 10
-          Type: 17 BaseType uint16
+          Type: 7 BaseType uint16
         - Name: hash0
           Offset: 12
-          Type: 18 BaseType uint32
+          Type: 2 BaseType uint32
         - Name: buckets
           Offset: 16
-          Type: 44 PointerType *bucket<string,[]*mime/multipart.FileHeader>
+          Type: 68 PointerType *bucket<string,[]*mime/multipart.FileHeader>
         - Name: oldbuckets
           Offset: 24
-          Type: 44 PointerType *bucket<string,[]*mime/multipart.FileHeader>
+          Type: 68 PointerType *bucket<string,[]*mime/multipart.FileHeader>
         - Name: nevacuate
           Offset: 32
-          Type: 26 BaseType uintptr
+          Type: 1 BaseType uintptr
         - Name: extra
           Offset: 40
-          Type: 27 PointerType *runtime.mapextra
-      BucketType: 45 GoHMapBucketType bucket<string,[]*mime/multipart.FileHeader>
+          Type: 52 PointerType *runtime.mapextra
+      BucketType: 69 GoHMapBucketType bucket<string,[]*mime/multipart.FileHeader>
       BucketsType: 210 GoSliceDataType []bucket<string,[]*mime/multipart.FileHeader>.array
     - __kind: GoHMapHeaderType
-      ID: 16
+      ID: 45
       Name: hash<string,[]string>
       ByteSize: 48
       RawFields:
         - Name: count
           Offset: 0
-          Type: 8 BaseType int
+          Type: 9 BaseType int
         - Name: flags
           Offset: 8
-          Type: 7 BaseType uint8
+          Type: 3 BaseType uint8
         - Name: B
           Offset: 9
-          Type: 7 BaseType uint8
+          Type: 3 BaseType uint8
         - Name: noverflow
           Offset: 10
-          Type: 17 BaseType uint16
+          Type: 7 BaseType uint16
         - Name: hash0
           Offset: 12
-          Type: 18 BaseType uint32
+          Type: 2 BaseType uint32
         - Name: buckets
           Offset: 16
-          Type: 19 PointerType *bucket<string,[]string>
+          Type: 46 PointerType *bucket<string,[]string>
         - Name: oldbuckets
           Offset: 24
-          Type: 19 PointerType *bucket<string,[]string>
+          Type: 46 PointerType *bucket<string,[]string>
         - Name: nevacuate
           Offset: 32
-          Type: 26 BaseType uintptr
+          Type: 1 BaseType uintptr
         - Name: extra
           Offset: 40
-          Type: 27 PointerType *runtime.mapextra
-      BucketType: 20 GoHMapBucketType bucket<string,[]string>
+          Type: 52 PointerType *runtime.mapextra
+      BucketType: 47 GoHMapBucketType bucket<string,[]string>
       BucketsType: 205 GoSliceDataType []bucket<string,[]string>.array
     - __kind: GoHMapHeaderType
-      ID: 141
+      ID: 162
       Name: hash<string,float64>
       ByteSize: 48
       RawFields:
         - Name: count
           Offset: 0
-          Type: 8 BaseType int
+          Type: 9 BaseType int
         - Name: flags
           Offset: 8
-          Type: 7 BaseType uint8
+          Type: 3 BaseType uint8
         - Name: B
           Offset: 9
-          Type: 7 BaseType uint8
+          Type: 3 BaseType uint8
         - Name: noverflow
           Offset: 10
-          Type: 17 BaseType uint16
+          Type: 7 BaseType uint16
         - Name: hash0
           Offset: 12
-          Type: 18 BaseType uint32
+          Type: 2 BaseType uint32
         - Name: buckets
           Offset: 16
-          Type: 142 PointerType *bucket<string,float64>
+          Type: 163 PointerType *bucket<string,float64>
         - Name: oldbuckets
           Offset: 24
-          Type: 142 PointerType *bucket<string,float64>
+          Type: 163 PointerType *bucket<string,float64>
         - Name: nevacuate
           Offset: 32
-          Type: 26 BaseType uintptr
+          Type: 1 BaseType uintptr
         - Name: extra
           Offset: 40
-          Type: 27 PointerType *runtime.mapextra
-      BucketType: 143 GoHMapBucketType bucket<string,float64>
+          Type: 52 PointerType *runtime.mapextra
+      BucketType: 164 GoHMapBucketType bucket<string,float64>
       BucketsType: 253 GoSliceDataType []bucket<string,float64>.array
     - __kind: GoHMapHeaderType
-      ID: 135
+      ID: 156
       Name: hash<string,interface {}>
       ByteSize: 48
       RawFields:
         - Name: count
           Offset: 0
-          Type: 8 BaseType int
+          Type: 9 BaseType int
         - Name: flags
           Offset: 8
-          Type: 7 BaseType uint8
+          Type: 3 BaseType uint8
         - Name: B
           Offset: 9
-          Type: 7 BaseType uint8
+          Type: 3 BaseType uint8
         - Name: noverflow
           Offset: 10
-          Type: 17 BaseType uint16
+          Type: 7 BaseType uint16
         - Name: hash0
           Offset: 12
-          Type: 18 BaseType uint32
+          Type: 2 BaseType uint32
         - Name: buckets
           Offset: 16
-          Type: 136 PointerType *bucket<string,interface {}>
+          Type: 157 PointerType *bucket<string,interface {}>
         - Name: oldbuckets
           Offset: 24
-          Type: 136 PointerType *bucket<string,interface {}>
+          Type: 157 PointerType *bucket<string,interface {}>
         - Name: nevacuate
           Offset: 32
-          Type: 26 BaseType uintptr
+          Type: 1 BaseType uintptr
         - Name: extra
           Offset: 40
-          Type: 27 PointerType *runtime.mapextra
-      BucketType: 137 GoHMapBucketType bucket<string,interface {}>
+          Type: 52 PointerType *runtime.mapextra
+      BucketType: 158 GoHMapBucketType bucket<string,interface {}>
       BucketsType: 252 GoSliceDataType []bucket<string,interface {}>.array
     - __kind: GoHMapHeaderType
-      ID: 122
+      ID: 144
       Name: hash<string,string>
       ByteSize: 48
       RawFields:
         - Name: count
           Offset: 0
-          Type: 8 BaseType int
+          Type: 9 BaseType int
         - Name: flags
           Offset: 8
-          Type: 7 BaseType uint8
+          Type: 3 BaseType uint8
         - Name: B
           Offset: 9
-          Type: 7 BaseType uint8
+          Type: 3 BaseType uint8
         - Name: noverflow
           Offset: 10
-          Type: 17 BaseType uint16
+          Type: 7 BaseType uint16
         - Name: hash0
           Offset: 12
-          Type: 18 BaseType uint32
+          Type: 2 BaseType uint32
         - Name: buckets
           Offset: 16
-          Type: 123 PointerType *bucket<string,string>
+          Type: 145 PointerType *bucket<string,string>
         - Name: oldbuckets
           Offset: 24
-          Type: 123 PointerType *bucket<string,string>
+          Type: 145 PointerType *bucket<string,string>
         - Name: nevacuate
           Offset: 32
-          Type: 26 BaseType uintptr
+          Type: 1 BaseType uintptr
         - Name: extra
           Offset: 40
-          Type: 27 PointerType *runtime.mapextra
-      BucketType: 124 GoHMapBucketType bucket<string,string>
+          Type: 52 PointerType *runtime.mapextra
+      BucketType: 146 GoHMapBucketType bucket<string,string>
       BucketsType: 251 GoSliceDataType []bucket<string,string>.array
     - __kind: BaseType
-      ID: 8
+      ID: 9
       Name: int
       ByteSize: 8
       GoRuntimeType: 543104
       GoKind: 2
     - __kind: BaseType
-      ID: 192
+      ID: 23
       Name: int16
       ByteSize: 2
       GoRuntimeType: 542720
       GoKind: 4
     - __kind: BaseType
-      ID: 130
+      ID: 13
       Name: int32
       ByteSize: 4
       GoRuntimeType: 542848
       GoKind: 5
     - __kind: BaseType
-      ID: 36
+      ID: 14
       Name: int64
       ByteSize: 8
       GoRuntimeType: 542976
       GoKind: 6
     - __kind: BaseType
-      ID: 187
+      ID: 15
       Name: int8
       ByteSize: 1
       GoRuntimeType: 542592
       GoKind: 3
     - __kind: GoEmptyInterfaceType
-      ID: 61
+      ID: 85
       Name: interface {}
       ByteSize: 16
       GoRuntimeType: 798016
@@ -2416,12 +2416,12 @@ Types:
       RawFields:
         - Name: _type
           Offset: 0
-          Type: 2 VoidPointerType unsafe.Pointer
+          Type: 19 VoidPointerType unsafe.Pointer
         - Name: data
           Offset: 8
-          Type: 2 VoidPointerType unsafe.Pointer
+          Type: 19 VoidPointerType unsafe.Pointer
     - __kind: GoInterfaceType
-      ID: 34
+      ID: 59
       Name: io.ReadCloser
       ByteSize: 16
       GoRuntimeType: 1.093088e+06
@@ -2429,54 +2429,54 @@ Types:
       RawFields:
         - Name: tab
           Offset: 0
-          Type: 2 VoidPointerType unsafe.Pointer
+          Type: 19 VoidPointerType unsafe.Pointer
         - Name: data
           Offset: 8
-          Type: 2 VoidPointerType unsafe.Pointer
+          Type: 19 VoidPointerType unsafe.Pointer
     - __kind: GoMapType
-      ID: 152
+      ID: 172
       Name: map[string]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
       ByteSize: 8
       GoRuntimeType: 905120
       GoKind: 21
-      HeaderType: 154 GoHMapHeaderType hash<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
+      HeaderType: 174 GoHMapHeaderType hash<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
     - __kind: GoMapType
-      ID: 41
+      ID: 65
       Name: map[string][]*mime/multipart.FileHeader
       ByteSize: 8
       GoRuntimeType: 904160
       GoKind: 21
-      HeaderType: 43 GoHMapHeaderType hash<string,[]*mime/multipart.FileHeader>
+      HeaderType: 67 GoHMapHeaderType hash<string,[]*mime/multipart.FileHeader>
     - __kind: GoMapType
-      ID: 40
+      ID: 64
       Name: map[string][]string
       ByteSize: 8
       GoRuntimeType: 899360
       GoKind: 21
-      HeaderType: 16 GoHMapHeaderType hash<string,[]string>
+      HeaderType: 45 GoHMapHeaderType hash<string,[]string>
     - __kind: GoMapType
-      ID: 139
+      ID: 160
       Name: map[string]float64
       ByteSize: 8
       GoRuntimeType: 905024
       GoKind: 21
-      HeaderType: 141 GoHMapHeaderType hash<string,float64>
+      HeaderType: 162 GoHMapHeaderType hash<string,float64>
     - __kind: GoMapType
-      ID: 168
+      ID: 188
       Name: map[string]interface {}
       ByteSize: 8
       GoRuntimeType: 896480
       GoKind: 21
-      HeaderType: 135 GoHMapHeaderType hash<string,interface {}>
+      HeaderType: 156 GoHMapHeaderType hash<string,interface {}>
     - __kind: GoMapType
-      ID: 120
+      ID: 142
       Name: map[string]string
       ByteSize: 8
       GoRuntimeType: 900992
       GoKind: 21
-      HeaderType: 122 GoHMapHeaderType hash<string,string>
+      HeaderType: 144 GoHMapHeaderType hash<string,string>
     - __kind: StructureType
-      ID: 63
+      ID: 87
       Name: math/big.Int
       ByteSize: 32
       GoRuntimeType: 1.340768e+06
@@ -2484,18 +2484,18 @@ Types:
       RawFields:
         - Name: neg
           Offset: 0
-          Type: 13 BaseType bool
+          Type: 4 BaseType bool
         - Name: abs
           Offset: 8
-          Type: 64 GoSliceHeaderType math/big.nat
+          Type: 88 GoSliceHeaderType math/big.nat
     - __kind: BaseType
-      ID: 66
+      ID: 90
       Name: math/big.Word
       ByteSize: 8
       GoRuntimeType: 546880
       GoKind: 7
     - __kind: GoSliceHeaderType
-      ID: 64
+      ID: 88
       Name: math/big.nat
       ByteSize: 24
       GoRuntimeType: 2.280544e+06
@@ -2503,21 +2503,21 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 65 PointerType *math/big.Word
+          Type: 89 PointerType *math/big.Word
         - Name: len
           Offset: 8
-          Type: 8 BaseType int
+          Type: 9 BaseType int
         - Name: cap
           Offset: 16
-          Type: 8 BaseType int
+          Type: 9 BaseType int
       Data: 217 GoSliceDataType math/big.nat.array
     - __kind: GoSliceDataType
       ID: 217
       Name: math/big.nat.array
       ByteSize: 2048
-      Element: 66 BaseType math/big.Word
+      Element: 90 BaseType math/big.Word
     - __kind: StructureType
-      ID: 50
+      ID: 74
       Name: mime/multipart.FileHeader
       ByteSize: 88
       GoRuntimeType: 1.881696e+06
@@ -2525,27 +2525,27 @@ Types:
       RawFields:
         - Name: Filename
           Offset: 0
-          Type: 5 GoStringHeaderType string
+          Type: 11 GoStringHeaderType string
         - Name: Header
           Offset: 16
-          Type: 51 GoMapType net/textproto.MIMEHeader
+          Type: 75 GoMapType net/textproto.MIMEHeader
         - Name: Size
           Offset: 24
-          Type: 36 BaseType int64
+          Type: 14 BaseType int64
         - Name: content
           Offset: 32
-          Type: 52 GoSliceHeaderType []uint8
+          Type: 76 GoSliceHeaderType []uint8
         - Name: tmpfile
           Offset: 56
-          Type: 5 GoStringHeaderType string
+          Type: 11 GoStringHeaderType string
         - Name: tmpoff
           Offset: 72
-          Type: 36 BaseType int64
+          Type: 14 BaseType int64
         - Name: tmpshared
           Offset: 80
-          Type: 13 BaseType bool
+          Type: 4 BaseType bool
     - __kind: StructureType
-      ID: 39
+      ID: 63
       Name: mime/multipart.Form
       ByteSize: 16
       GoRuntimeType: 1.326048e+06
@@ -2553,12 +2553,12 @@ Types:
       RawFields:
         - Name: Value
           Offset: 0
-          Type: 40 GoMapType map[string][]string
+          Type: 64 GoMapType map[string][]string
         - Name: File
           Offset: 8
-          Type: 41 GoMapType map[string][]*mime/multipart.FileHeader
+          Type: 65 GoMapType map[string][]*mime/multipart.FileHeader
     - __kind: GoSliceHeaderType
-      ID: 94
+      ID: 116
       Name: net.IP
       ByteSize: 24
       GoRuntimeType: 2.00144e+06
@@ -2569,18 +2569,18 @@ Types:
           Type: 6 PointerType *uint8
         - Name: len
           Offset: 8
-          Type: 8 BaseType int
+          Type: 9 BaseType int
         - Name: cap
           Offset: 16
-          Type: 8 BaseType int
+          Type: 9 BaseType int
       Data: 235 GoSliceDataType net.IP.array
     - __kind: GoSliceDataType
       ID: 235
       Name: net.IP.array
       ByteSize: 2048
-      Element: 7 BaseType uint8
+      Element: 3 BaseType uint8
     - __kind: GoSliceHeaderType
-      ID: 101
+      ID: 123
       Name: net.IPMask
       ByteSize: 24
       GoRuntimeType: 999456
@@ -2591,18 +2591,18 @@ Types:
           Type: 6 PointerType *uint8
         - Name: len
           Offset: 8
-          Type: 8 BaseType int
+          Type: 9 BaseType int
         - Name: cap
           Offset: 16
-          Type: 8 BaseType int
+          Type: 9 BaseType int
       Data: 241 GoSliceDataType net.IPMask.array
     - __kind: GoSliceDataType
       ID: 241
       Name: net.IPMask.array
       ByteSize: 2048
-      Element: 7 BaseType uint8
+      Element: 3 BaseType uint8
     - __kind: StructureType
-      ID: 100
+      ID: 122
       Name: net.IPNet
       ByteSize: 48
       GoRuntimeType: 1.307168e+06
@@ -2610,19 +2610,19 @@ Types:
       RawFields:
         - Name: IP
           Offset: 0
-          Type: 94 GoSliceHeaderType net.IP
+          Type: 116 GoSliceHeaderType net.IP
         - Name: Mask
           Offset: 24
-          Type: 101 GoSliceHeaderType net.IPMask
+          Type: 123 GoSliceHeaderType net.IPMask
     - __kind: GoMapType
-      ID: 14
+      ID: 43
       Name: net/http.Header
       ByteSize: 8
       GoRuntimeType: 1.964288e+06
       GoKind: 21
-      HeaderType: 16 GoHMapHeaderType hash<string,[]string>
+      HeaderType: 45 GoHMapHeaderType hash<string,[]string>
     - __kind: StructureType
-      ID: 4
+      ID: 38
       Name: net/http.Request
       ByteSize: 304
       GoRuntimeType: 2.256288e+06
@@ -2630,84 +2630,84 @@ Types:
       RawFields:
         - Name: Method
           Offset: 0
-          Type: 5 GoStringHeaderType string
+          Type: 11 GoStringHeaderType string
         - Name: URL
           Offset: 16
-          Type: 9 PointerType *net/url.URL
+          Type: 39 PointerType *net/url.URL
         - Name: Proto
           Offset: 24
-          Type: 5 GoStringHeaderType string
+          Type: 11 GoStringHeaderType string
         - Name: ProtoMajor
           Offset: 40
-          Type: 8 BaseType int
+          Type: 9 BaseType int
         - Name: ProtoMinor
           Offset: 48
-          Type: 8 BaseType int
+          Type: 9 BaseType int
         - Name: Header
           Offset: 56
-          Type: 14 GoMapType net/http.Header
+          Type: 43 GoMapType net/http.Header
         - Name: Body
           Offset: 64
-          Type: 34 GoInterfaceType io.ReadCloser
+          Type: 59 GoInterfaceType io.ReadCloser
         - Name: GetBody
           Offset: 80
-          Type: 35 GoSubroutineType func() (io.ReadCloser, error)
+          Type: 60 GoSubroutineType func() (io.ReadCloser, error)
         - Name: ContentLength
           Offset: 88
-          Type: 36 BaseType int64
+          Type: 14 BaseType int64
         - Name: TransferEncoding
           Offset: 96
-          Type: 24 GoSliceHeaderType []string
+          Type: 51 GoSliceHeaderType []string
         - Name: Close
           Offset: 120
-          Type: 13 BaseType bool
+          Type: 4 BaseType bool
         - Name: Host
           Offset: 128
-          Type: 5 GoStringHeaderType string
+          Type: 11 GoStringHeaderType string
         - Name: Form
           Offset: 144
-          Type: 37 GoMapType net/url.Values
+          Type: 61 GoMapType net/url.Values
         - Name: PostForm
           Offset: 152
-          Type: 37 GoMapType net/url.Values
+          Type: 61 GoMapType net/url.Values
         - Name: MultipartForm
           Offset: 160
-          Type: 38 PointerType *mime/multipart.Form
+          Type: 62 PointerType *mime/multipart.Form
         - Name: Trailer
           Offset: 168
-          Type: 14 GoMapType net/http.Header
+          Type: 43 GoMapType net/http.Header
         - Name: RemoteAddr
           Offset: 176
-          Type: 5 GoStringHeaderType string
+          Type: 11 GoStringHeaderType string
         - Name: RequestURI
           Offset: 192
-          Type: 5 GoStringHeaderType string
+          Type: 11 GoStringHeaderType string
         - Name: TLS
           Offset: 208
-          Type: 53 PointerType *crypto/tls.ConnectionState
+          Type: 77 PointerType *crypto/tls.ConnectionState
         - Name: Cancel
           Offset: 216
-          Type: 111 GoChannelType <-chan struct {}
+          Type: 133 GoChannelType <-chan struct {}
         - Name: Response
           Offset: 224
-          Type: 112 PointerType *net/http.Response
+          Type: 134 PointerType *net/http.Response
         - Name: Pattern
           Offset: 232
-          Type: 5 GoStringHeaderType string
+          Type: 11 GoStringHeaderType string
         - Name: ctx
           Offset: 248
-          Type: 114 GoInterfaceType context.Context
+          Type: 136 GoInterfaceType context.Context
         - Name: pat
           Offset: 264
-          Type: 115 PointerType *net/http.pattern
+          Type: 137 PointerType *net/http.pattern
         - Name: matches
           Offset: 272
-          Type: 24 GoSliceHeaderType []string
+          Type: 51 GoSliceHeaderType []string
         - Name: otherValues
           Offset: 296
-          Type: 120 GoMapType map[string]string
+          Type: 142 GoMapType map[string]string
     - __kind: StructureType
-      ID: 113
+      ID: 135
       Name: net/http.Response
       ByteSize: 144
       GoRuntimeType: 2.124032e+06
@@ -2715,48 +2715,48 @@ Types:
       RawFields:
         - Name: Status
           Offset: 0
-          Type: 5 GoStringHeaderType string
+          Type: 11 GoStringHeaderType string
         - Name: StatusCode
           Offset: 16
-          Type: 8 BaseType int
+          Type: 9 BaseType int
         - Name: Proto
           Offset: 24
-          Type: 5 GoStringHeaderType string
+          Type: 11 GoStringHeaderType string
         - Name: ProtoMajor
           Offset: 40
-          Type: 8 BaseType int
+          Type: 9 BaseType int
         - Name: ProtoMinor
           Offset: 48
-          Type: 8 BaseType int
+          Type: 9 BaseType int
         - Name: Header
           Offset: 56
-          Type: 14 GoMapType net/http.Header
+          Type: 43 GoMapType net/http.Header
         - Name: Body
           Offset: 64
-          Type: 34 GoInterfaceType io.ReadCloser
+          Type: 59 GoInterfaceType io.ReadCloser
         - Name: ContentLength
           Offset: 80
-          Type: 36 BaseType int64
+          Type: 14 BaseType int64
         - Name: TransferEncoding
           Offset: 88
-          Type: 24 GoSliceHeaderType []string
+          Type: 51 GoSliceHeaderType []string
         - Name: Close
           Offset: 112
-          Type: 13 BaseType bool
+          Type: 4 BaseType bool
         - Name: Uncompressed
           Offset: 113
-          Type: 13 BaseType bool
+          Type: 4 BaseType bool
         - Name: Trailer
           Offset: 120
-          Type: 14 GoMapType net/http.Header
+          Type: 43 GoMapType net/http.Header
         - Name: Request
           Offset: 128
-          Type: 3 PointerType *net/http.Request
+          Type: 37 PointerType *net/http.Request
         - Name: TLS
           Offset: 136
-          Type: 53 PointerType *crypto/tls.ConnectionState
+          Type: 77 PointerType *crypto/tls.ConnectionState
     - __kind: GoInterfaceType
-      ID: 1
+      ID: 36
       Name: net/http.ResponseWriter
       ByteSize: 16
       GoRuntimeType: 1.125472e+06
@@ -2764,12 +2764,12 @@ Types:
       RawFields:
         - Name: tab
           Offset: 0
-          Type: 2 VoidPointerType unsafe.Pointer
+          Type: 19 VoidPointerType unsafe.Pointer
         - Name: data
           Offset: 8
-          Type: 2 VoidPointerType unsafe.Pointer
+          Type: 19 VoidPointerType unsafe.Pointer
     - __kind: StructureType
-      ID: 116
+      ID: 138
       Name: net/http.pattern
       ByteSize: 88
       GoRuntimeType: 1.745568e+06
@@ -2777,21 +2777,21 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 5 GoStringHeaderType string
+          Type: 11 GoStringHeaderType string
         - Name: method
           Offset: 16
-          Type: 5 GoStringHeaderType string
+          Type: 11 GoStringHeaderType string
         - Name: host
           Offset: 32
-          Type: 5 GoStringHeaderType string
+          Type: 11 GoStringHeaderType string
         - Name: segments
           Offset: 48
-          Type: 117 GoSliceHeaderType []net/http.segment
+          Type: 139 GoSliceHeaderType []net/http.segment
         - Name: loc
           Offset: 72
-          Type: 5 GoStringHeaderType string
+          Type: 11 GoStringHeaderType string
     - __kind: StructureType
-      ID: 119
+      ID: 141
       Name: net/http.segment
       ByteSize: 24
       GoRuntimeType: 1.453312e+06
@@ -2799,22 +2799,22 @@ Types:
       RawFields:
         - Name: s
           Offset: 0
-          Type: 5 GoStringHeaderType string
+          Type: 11 GoStringHeaderType string
         - Name: wild
           Offset: 16
-          Type: 13 BaseType bool
+          Type: 4 BaseType bool
         - Name: multi
           Offset: 17
-          Type: 13 BaseType bool
+          Type: 4 BaseType bool
     - __kind: GoMapType
-      ID: 51
+      ID: 75
       Name: net/textproto.MIMEHeader
       ByteSize: 8
       GoRuntimeType: 1.63792e+06
       GoKind: 21
-      HeaderType: 16 GoHMapHeaderType hash<string,[]string>
+      HeaderType: 45 GoHMapHeaderType hash<string,[]string>
     - __kind: StructureType
-      ID: 10
+      ID: 40
       Name: net/url.URL
       ByteSize: 144
       GoRuntimeType: 2.041568e+06
@@ -2822,39 +2822,39 @@ Types:
       RawFields:
         - Name: Scheme
           Offset: 0
-          Type: 5 GoStringHeaderType string
+          Type: 11 GoStringHeaderType string
         - Name: Opaque
           Offset: 16
-          Type: 5 GoStringHeaderType string
+          Type: 11 GoStringHeaderType string
         - Name: User
           Offset: 32
-          Type: 11 PointerType *net/url.Userinfo
+          Type: 41 PointerType *net/url.Userinfo
         - Name: Host
           Offset: 40
-          Type: 5 GoStringHeaderType string
+          Type: 11 GoStringHeaderType string
         - Name: Path
           Offset: 56
-          Type: 5 GoStringHeaderType string
+          Type: 11 GoStringHeaderType string
         - Name: RawPath
           Offset: 72
-          Type: 5 GoStringHeaderType string
+          Type: 11 GoStringHeaderType string
         - Name: OmitHost
           Offset: 88
-          Type: 13 BaseType bool
+          Type: 4 BaseType bool
         - Name: ForceQuery
           Offset: 89
-          Type: 13 BaseType bool
+          Type: 4 BaseType bool
         - Name: RawQuery
           Offset: 96
-          Type: 5 GoStringHeaderType string
+          Type: 11 GoStringHeaderType string
         - Name: Fragment
           Offset: 112
-          Type: 5 GoStringHeaderType string
+          Type: 11 GoStringHeaderType string
         - Name: RawFragment
           Offset: 128
-          Type: 5 GoStringHeaderType string
+          Type: 11 GoStringHeaderType string
     - __kind: StructureType
-      ID: 12
+      ID: 42
       Name: net/url.Userinfo
       ByteSize: 40
       GoRuntimeType: 1.469632e+06
@@ -2862,22 +2862,22 @@ Types:
       RawFields:
         - Name: username
           Offset: 0
-          Type: 5 GoStringHeaderType string
+          Type: 11 GoStringHeaderType string
         - Name: password
           Offset: 16
-          Type: 5 GoStringHeaderType string
+          Type: 11 GoStringHeaderType string
         - Name: passwordSet
           Offset: 32
-          Type: 13 BaseType bool
+          Type: 4 BaseType bool
     - __kind: GoMapType
-      ID: 37
+      ID: 61
       Name: net/url.Values
       ByteSize: 8
       GoRuntimeType: 1.712416e+06
       GoKind: 21
-      HeaderType: 16 GoHMapHeaderType hash<string,[]string>
+      HeaderType: 45 GoHMapHeaderType hash<string,[]string>
     - __kind: StructureType
-      ID: 33
+      ID: 58
       Name: runtime.bmap
       ByteSize: 8
       GoRuntimeType: 1.13712e+06
@@ -2885,9 +2885,9 @@ Types:
       RawFields:
         - Name: tophash
           Offset: 0
-          Type: 21 ArrayType [8]uint8
+          Type: 48 ArrayType [8]uint8
     - __kind: StructureType
-      ID: 28
+      ID: 53
       Name: runtime.mapextra
       ByteSize: 24
       GoRuntimeType: 1.4656e+06
@@ -2895,15 +2895,15 @@ Types:
       RawFields:
         - Name: overflow
           Offset: 0
-          Type: 29 PointerType *[]*runtime.bmap
+          Type: 54 PointerType *[]*runtime.bmap
         - Name: oldoverflow
           Offset: 8
-          Type: 29 PointerType *[]*runtime.bmap
+          Type: 54 PointerType *[]*runtime.bmap
         - Name: nextOverflow
           Offset: 16
-          Type: 32 PointerType *runtime.bmap
+          Type: 57 PointerType *runtime.bmap
     - __kind: GoStringHeaderType
-      ID: 5
+      ID: 11
       Name: string
       ByteSize: 16
       GoRuntimeType: 542528
@@ -2914,14 +2914,14 @@ Types:
           Type: 204 PointerType *string.str
         - Name: len
           Offset: 8
-          Type: 8 BaseType int
+          Type: 9 BaseType int
       Data: 203 GoStringDataType string.str
     - __kind: GoStringDataType
       ID: 203
       Name: string.str
       ByteSize: 2048
     - __kind: StructureType
-      ID: 129
+      ID: 151
       Name: sync.Mutex
       ByteSize: 8
       GoRuntimeType: 1.314208e+06
@@ -2929,12 +2929,12 @@ Types:
       RawFields:
         - Name: state
           Offset: 0
-          Type: 130 BaseType int32
+          Type: 13 BaseType int32
         - Name: sema
           Offset: 4
-          Type: 18 BaseType uint32
+          Type: 2 BaseType uint32
     - __kind: StructureType
-      ID: 128
+      ID: 150
       Name: sync.RWMutex
       ByteSize: 24
       GoRuntimeType: 1.751168e+06
@@ -2942,21 +2942,21 @@ Types:
       RawFields:
         - Name: w
           Offset: 0
-          Type: 129 StructureType sync.Mutex
+          Type: 151 StructureType sync.Mutex
         - Name: writerSem
           Offset: 8
-          Type: 18 BaseType uint32
+          Type: 2 BaseType uint32
         - Name: readerSem
           Offset: 12
-          Type: 18 BaseType uint32
+          Type: 2 BaseType uint32
         - Name: readerCount
           Offset: 16
-          Type: 131 StructureType sync/atomic.Int32
+          Type: 152 StructureType sync/atomic.Int32
         - Name: readerWait
           Offset: 20
-          Type: 131 StructureType sync/atomic.Int32
+          Type: 152 StructureType sync/atomic.Int32
     - __kind: StructureType
-      ID: 131
+      ID: 152
       Name: sync/atomic.Int32
       ByteSize: 4
       GoRuntimeType: 1.315648e+06
@@ -2964,18 +2964,18 @@ Types:
       RawFields:
         - Name: _
           Offset: 0
-          Type: 132 StructureType sync/atomic.noCopy
+          Type: 153 StructureType sync/atomic.noCopy
         - Name: v
           Offset: 0
-          Type: 130 BaseType int32
+          Type: 13 BaseType int32
     - __kind: StructureType
-      ID: 132
+      ID: 153
       Name: sync/atomic.noCopy
       GoRuntimeType: 966016
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 76
+      ID: 98
       Name: time.Location
       ByteSize: 104
       GoRuntimeType: 1.877952e+06
@@ -2983,27 +2983,27 @@ Types:
       RawFields:
         - Name: name
           Offset: 0
-          Type: 5 GoStringHeaderType string
+          Type: 11 GoStringHeaderType string
         - Name: zone
           Offset: 16
-          Type: 77 GoSliceHeaderType []time.zone
+          Type: 99 GoSliceHeaderType []time.zone
         - Name: tx
           Offset: 40
-          Type: 80 GoSliceHeaderType []time.zoneTrans
+          Type: 102 GoSliceHeaderType []time.zoneTrans
         - Name: extend
           Offset: 64
-          Type: 5 GoStringHeaderType string
+          Type: 11 GoStringHeaderType string
         - Name: cacheStart
           Offset: 80
-          Type: 36 BaseType int64
+          Type: 14 BaseType int64
         - Name: cacheEnd
           Offset: 88
-          Type: 36 BaseType int64
+          Type: 14 BaseType int64
         - Name: cacheZone
           Offset: 96
-          Type: 78 PointerType *time.zone
+          Type: 100 PointerType *time.zone
     - __kind: StructureType
-      ID: 73
+      ID: 96
       Name: time.Time
       ByteSize: 24
       GoRuntimeType: 2.281472e+06
@@ -3011,15 +3011,15 @@ Types:
       RawFields:
         - Name: wall
           Offset: 0
-          Type: 74 BaseType uint64
+          Type: 10 BaseType uint64
         - Name: ext
           Offset: 8
-          Type: 36 BaseType int64
+          Type: 14 BaseType int64
         - Name: loc
           Offset: 16
-          Type: 75 PointerType *time.Location
+          Type: 97 PointerType *time.Location
     - __kind: StructureType
-      ID: 79
+      ID: 101
       Name: time.zone
       ByteSize: 32
       GoRuntimeType: 1.458304e+06
@@ -3027,15 +3027,15 @@ Types:
       RawFields:
         - Name: name
           Offset: 0
-          Type: 5 GoStringHeaderType string
+          Type: 11 GoStringHeaderType string
         - Name: offset
           Offset: 16
-          Type: 8 BaseType int
+          Type: 9 BaseType int
         - Name: isDST
           Offset: 24
-          Type: 13 BaseType bool
+          Type: 4 BaseType bool
     - __kind: StructureType
-      ID: 82
+      ID: 104
       Name: time.zoneTrans
       ByteSize: 16
       GoRuntimeType: 1.664192e+06
@@ -3043,54 +3043,54 @@ Types:
       RawFields:
         - Name: when
           Offset: 0
-          Type: 36 BaseType int64
+          Type: 14 BaseType int64
         - Name: index
           Offset: 8
-          Type: 7 BaseType uint8
+          Type: 3 BaseType uint8
         - Name: isstd
           Offset: 9
-          Type: 13 BaseType bool
+          Type: 4 BaseType bool
         - Name: isutc
           Offset: 10
-          Type: 13 BaseType bool
+          Type: 4 BaseType bool
     - __kind: BaseType
-      ID: 186
+      ID: 12
       Name: uint
       ByteSize: 8
       GoRuntimeType: 543168
       GoKind: 7
     - __kind: BaseType
-      ID: 17
+      ID: 7
       Name: uint16
       ByteSize: 2
       GoRuntimeType: 542784
       GoKind: 9
     - __kind: BaseType
-      ID: 18
+      ID: 2
       Name: uint32
       ByteSize: 4
       GoRuntimeType: 542912
       GoKind: 10
     - __kind: BaseType
-      ID: 74
+      ID: 10
       Name: uint64
       ByteSize: 8
       GoRuntimeType: 543040
       GoKind: 11
     - __kind: BaseType
-      ID: 7
+      ID: 3
       Name: uint8
       ByteSize: 1
       GoRuntimeType: 542656
       GoKind: 8
     - __kind: BaseType
-      ID: 26
+      ID: 1
       Name: uintptr
       ByteSize: 8
       GoRuntimeType: 543232
       GoKind: 12
     - __kind: VoidPointerType
-      ID: 2
+      ID: 19
       Name: unsafe.Pointer
       ByteSize: 8
       GoRuntimeType: 543616

--- a/pkg/dyninst/irgen/testdata/snapshot/rc_tester.arch=arm64,toolchain=go1.23.11.yaml
+++ b/pkg/dyninst/irgen/testdata/snapshot/rc_tester.arch=arm64,toolchain=go1.23.11.yaml
@@ -10,7 +10,7 @@ Probes:
       subprogram: {subprogram: 1}
       events:
         - ID: 1
-          Type: 267 EventRootType Probe[main.HandleHTTP]
+          Type: 263 EventRootType Probe[main.HandleHTTP]
           InjectionPoints: [{PC: "0x8dff40", Frameless: true}]
           Condition: null
     - id: look_at_the_request
@@ -23,7 +23,7 @@ Probes:
       subprogram: {subprogram: 2}
       events:
         - ID: 2
-          Type: 268 EventRootType Probe[main.LookAtTheRequest]
+          Type: 264 EventRootType Probe[main.LookAtTheRequest]
           InjectionPoints: [{PC: "0x8e025c", Frameless: true}]
           Condition: null
 Subprograms:
@@ -369,7 +369,7 @@ Types:
           Offset: 40
           Type: 27 PointerType *runtime.mapextra
       BucketType: 20 GoHMapBucketType bucket<string,[]string>
-      BucketsType: 215 GoSliceDataType []bucket<string,[]string>.array
+      BucketsType: 205 GoSliceDataType []bucket<string,[]string>.array
     - __kind: BaseType
       ID: 17
       Name: uint16
@@ -632,7 +632,7 @@ Types:
           Offset: 40
           Type: 27 PointerType *runtime.mapextra
       BucketType: 45 GoHMapBucketType bucket<string,[]*mime/multipart.FileHeader>
-      BucketsType: 212 GoSliceDataType []bucket<string,[]*mime/multipart.FileHeader>.array
+      BucketsType: 210 GoSliceDataType []bucket<string,[]*mime/multipart.FileHeader>.array
     - __kind: PointerType
       ID: 44
       Name: '*bucket<string,[]*mime/multipart.FileHeader>'
@@ -680,7 +680,7 @@ Types:
         - Name: cap
           Offset: 16
           Type: 8 BaseType int
-      Data: 213 GoSliceDataType []*mime/multipart.FileHeader.array
+      Data: 211 GoSliceDataType []*mime/multipart.FileHeader.array
     - __kind: PointerType
       ID: 48
       Name: '**mime/multipart.FileHeader'
@@ -745,7 +745,7 @@ Types:
         - Name: cap
           Offset: 16
           Type: 8 BaseType int
-      Data: 216 GoSliceDataType []uint8.array
+      Data: 213 GoSliceDataType []uint8.array
     - __kind: PointerType
       ID: 53
       Name: '*crypto/tls.ConnectionState'
@@ -824,7 +824,7 @@ Types:
         - Name: cap
           Offset: 16
           Type: 8 BaseType int
-      Data: 218 GoSliceDataType []*crypto/x509.Certificate.array
+      Data: 215 GoSliceDataType []*crypto/x509.Certificate.array
     - __kind: PointerType
       ID: 56
       Name: '**crypto/x509.Certificate'
@@ -1040,7 +1040,7 @@ Types:
         - Name: cap
           Offset: 16
           Type: 8 BaseType int
-      Data: 220 GoSliceDataType math/big.nat.array
+      Data: 217 GoSliceDataType math/big.nat.array
     - __kind: PointerType
       ID: 65
       Name: '*math/big.Word'
@@ -1110,7 +1110,7 @@ Types:
         - Name: cap
           Offset: 16
           Type: 8 BaseType int
-      Data: 222 GoSliceDataType []crypto/x509/pkix.AttributeTypeAndValue.array
+      Data: 219 GoSliceDataType []crypto/x509/pkix.AttributeTypeAndValue.array
     - __kind: PointerType
       ID: 69
       Name: '*crypto/x509/pkix.AttributeTypeAndValue'
@@ -1147,7 +1147,7 @@ Types:
         - Name: cap
           Offset: 16
           Type: 8 BaseType int
-      Data: 224 GoSliceDataType encoding/asn1.ObjectIdentifier.array
+      Data: 221 GoSliceDataType encoding/asn1.ObjectIdentifier.array
     - __kind: PointerType
       ID: 72
       Name: '*int'
@@ -1228,7 +1228,7 @@ Types:
         - Name: cap
           Offset: 16
           Type: 8 BaseType int
-      Data: 226 GoSliceDataType []time.zone.array
+      Data: 223 GoSliceDataType []time.zone.array
     - __kind: PointerType
       ID: 78
       Name: '*time.zone'
@@ -1268,7 +1268,7 @@ Types:
         - Name: cap
           Offset: 16
           Type: 8 BaseType int
-      Data: 228 GoSliceDataType []time.zoneTrans.array
+      Data: 225 GoSliceDataType []time.zoneTrans.array
     - __kind: PointerType
       ID: 81
       Name: '*time.zoneTrans'
@@ -1317,7 +1317,7 @@ Types:
         - Name: cap
           Offset: 16
           Type: 8 BaseType int
-      Data: 230 GoSliceDataType []crypto/x509/pkix.Extension.array
+      Data: 227 GoSliceDataType []crypto/x509/pkix.Extension.array
     - __kind: PointerType
       ID: 85
       Name: '*crypto/x509/pkix.Extension'
@@ -1357,7 +1357,7 @@ Types:
         - Name: cap
           Offset: 16
           Type: 8 BaseType int
-      Data: 232 GoSliceDataType []encoding/asn1.ObjectIdentifier.array
+      Data: 229 GoSliceDataType []encoding/asn1.ObjectIdentifier.array
     - __kind: PointerType
       ID: 88
       Name: '*encoding/asn1.ObjectIdentifier'
@@ -1381,7 +1381,7 @@ Types:
         - Name: cap
           Offset: 16
           Type: 8 BaseType int
-      Data: 234 GoSliceDataType []crypto/x509.ExtKeyUsage.array
+      Data: 231 GoSliceDataType []crypto/x509.ExtKeyUsage.array
     - __kind: PointerType
       ID: 90
       Name: '*crypto/x509.ExtKeyUsage'
@@ -1411,7 +1411,7 @@ Types:
         - Name: cap
           Offset: 16
           Type: 8 BaseType int
-      Data: 236 GoSliceDataType []net.IP.array
+      Data: 233 GoSliceDataType []net.IP.array
     - __kind: PointerType
       ID: 93
       Name: '*net.IP'
@@ -1435,7 +1435,7 @@ Types:
         - Name: cap
           Offset: 16
           Type: 8 BaseType int
-      Data: 238 GoSliceDataType net.IP.array
+      Data: 235 GoSliceDataType net.IP.array
     - __kind: GoSliceHeaderType
       ID: 95
       Name: '[]*net/url.URL'
@@ -1452,7 +1452,7 @@ Types:
         - Name: cap
           Offset: 16
           Type: 8 BaseType int
-      Data: 240 GoSliceDataType []*net/url.URL.array
+      Data: 237 GoSliceDataType []*net/url.URL.array
     - __kind: PointerType
       ID: 96
       Name: '**net/url.URL'
@@ -1474,7 +1474,7 @@ Types:
         - Name: cap
           Offset: 16
           Type: 8 BaseType int
-      Data: 242 GoSliceDataType []*net.IPNet.array
+      Data: 239 GoSliceDataType []*net.IPNet.array
     - __kind: PointerType
       ID: 98
       Name: '**net.IPNet'
@@ -1517,7 +1517,7 @@ Types:
         - Name: cap
           Offset: 16
           Type: 8 BaseType int
-      Data: 244 GoSliceDataType net.IPMask.array
+      Data: 241 GoSliceDataType net.IPMask.array
     - __kind: GoSliceHeaderType
       ID: 102
       Name: '[]crypto/x509.OID'
@@ -1534,7 +1534,7 @@ Types:
         - Name: cap
           Offset: 16
           Type: 8 BaseType int
-      Data: 246 GoSliceDataType []crypto/x509.OID.array
+      Data: 243 GoSliceDataType []crypto/x509.OID.array
     - __kind: PointerType
       ID: 103
       Name: '*crypto/x509.OID'
@@ -1568,7 +1568,7 @@ Types:
         - Name: cap
           Offset: 16
           Type: 8 BaseType int
-      Data: 248 GoSliceDataType [][]*crypto/x509.Certificate.array
+      Data: 245 GoSliceDataType [][]*crypto/x509.Certificate.array
     - __kind: PointerType
       ID: 106
       Name: '*[]*crypto/x509.Certificate'
@@ -1591,7 +1591,7 @@ Types:
         - Name: cap
           Offset: 16
           Type: 8 BaseType int
-      Data: 250 GoSliceDataType [][]uint8.array
+      Data: 247 GoSliceDataType [][]uint8.array
     - __kind: PointerType
       ID: 108
       Name: '*[]uint8'
@@ -1730,7 +1730,7 @@ Types:
         - Name: cap
           Offset: 16
           Type: 8 BaseType int
-      Data: 252 GoSliceDataType []net/http.segment.array
+      Data: 249 GoSliceDataType []net/http.segment.array
     - __kind: PointerType
       ID: 118
       Name: '*net/http.segment'
@@ -1799,7 +1799,7 @@ Types:
           Offset: 40
           Type: 27 PointerType *runtime.mapextra
       BucketType: 124 GoHMapBucketType bucket<string,string>
-      BucketsType: 254 GoSliceDataType []bucket<string,string>.array
+      BucketsType: 251 GoSliceDataType []bucket<string,string>.array
     - __kind: PointerType
       ID: 123
       Name: '*bucket<string,string>'
@@ -2025,7 +2025,7 @@ Types:
           Offset: 40
           Type: 27 PointerType *runtime.mapextra
       BucketType: 137 GoHMapBucketType bucket<string,interface {}>
-      BucketsType: 264 GoSliceDataType []bucket<string,interface {}>.array
+      BucketsType: 252 GoSliceDataType []bucket<string,interface {}>.array
     - __kind: PointerType
       ID: 136
       Name: '*bucket<string,interface {}>'
@@ -2102,7 +2102,7 @@ Types:
           Offset: 40
           Type: 27 PointerType *runtime.mapextra
       BucketType: 143 GoHMapBucketType bucket<string,float64>
-      BucketsType: 256 GoSliceDataType []bucket<string,float64>.array
+      BucketsType: 253 GoSliceDataType []bucket<string,float64>.array
     - __kind: PointerType
       ID: 142
       Name: '*bucket<string,float64>'
@@ -2156,7 +2156,7 @@ Types:
         - Name: cap
           Offset: 16
           Type: 8 BaseType int
-      Data: 257 GoSliceDataType []github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink.array
+      Data: 254 GoSliceDataType []github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink.array
     - __kind: PointerType
       ID: 147
       Name: '*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink'
@@ -2205,7 +2205,7 @@ Types:
         - Name: cap
           Offset: 16
           Type: 8 BaseType int
-      Data: 259 GoSliceDataType []github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent.array
+      Data: 256 GoSliceDataType []github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent.array
     - __kind: PointerType
       ID: 150
       Name: '*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent'
@@ -2277,7 +2277,7 @@ Types:
           Offset: 40
           Type: 27 PointerType *runtime.mapextra
       BucketType: 156 GoHMapBucketType bucket<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
-      BucketsType: 261 GoSliceDataType []bucket<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>.array
+      BucketsType: 258 GoSliceDataType []bucket<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>.array
     - __kind: PointerType
       ID: 155
       Name: '*bucket<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>'
@@ -2380,7 +2380,7 @@ Types:
         - Name: cap
           Offset: 16
           Type: 8 BaseType int
-      Data: 262 GoSliceDataType []*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttributeValue.array
+      Data: 259 GoSliceDataType []*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttributeValue.array
     - __kind: PointerType
       ID: 164
       Name: '**github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttributeValue'
@@ -2545,7 +2545,7 @@ Types:
         - Name: cap
           Offset: 16
           Type: 8 BaseType int
-      Data: 265 GoSliceDataType []*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span.array
+      Data: 261 GoSliceDataType []*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span.array
     - __kind: PointerType
       ID: 174
       Name: '**github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span'
@@ -2793,291 +2793,271 @@ Types:
       Pointee: 208 GoSliceDataType []*runtime.bmap.array
     - __kind: GoSliceDataType
       ID: 210
-      Name: '[]bucket<string,[]string>.array'
-      ByteSize: 2048
-      Element: 20 GoHMapBucketType bucket<string,[]string>
-    - __kind: GoSliceDataType
-      ID: 211
-      Name: '[]bucket<string,[]string>.array'
-      ByteSize: 2048
-      Element: 20 GoHMapBucketType bucket<string,[]string>
-    - __kind: GoSliceDataType
-      ID: 212
       Name: '[]bucket<string,[]*mime/multipart.FileHeader>.array'
       ByteSize: 2048
       Element: 45 GoHMapBucketType bucket<string,[]*mime/multipart.FileHeader>
     - __kind: GoSliceDataType
-      ID: 213
+      ID: 211
       Name: '[]*mime/multipart.FileHeader.array'
       ByteSize: 2048
       Element: 49 PointerType *mime/multipart.FileHeader
     - __kind: PointerType
-      ID: 214
+      ID: 212
       Name: '*[]*mime/multipart.FileHeader.array'
       ByteSize: 8
-      Pointee: 213 GoSliceDataType []*mime/multipart.FileHeader.array
+      Pointee: 211 GoSliceDataType []*mime/multipart.FileHeader.array
     - __kind: GoSliceDataType
-      ID: 215
-      Name: '[]bucket<string,[]string>.array'
-      ByteSize: 2048
-      Element: 20 GoHMapBucketType bucket<string,[]string>
-    - __kind: GoSliceDataType
-      ID: 216
+      ID: 213
       Name: '[]uint8.array'
       ByteSize: 2048
       Element: 7 BaseType uint8
     - __kind: PointerType
-      ID: 217
+      ID: 214
       Name: '*[]uint8.array'
       ByteSize: 8
-      Pointee: 216 GoSliceDataType []uint8.array
+      Pointee: 213 GoSliceDataType []uint8.array
     - __kind: GoSliceDataType
-      ID: 218
+      ID: 215
       Name: '[]*crypto/x509.Certificate.array'
       ByteSize: 2048
       Element: 57 PointerType *crypto/x509.Certificate
     - __kind: PointerType
-      ID: 219
+      ID: 216
       Name: '*[]*crypto/x509.Certificate.array'
       ByteSize: 8
-      Pointee: 218 GoSliceDataType []*crypto/x509.Certificate.array
+      Pointee: 215 GoSliceDataType []*crypto/x509.Certificate.array
     - __kind: GoSliceDataType
-      ID: 220
+      ID: 217
       Name: math/big.nat.array
       ByteSize: 2048
       Element: 66 BaseType math/big.Word
     - __kind: PointerType
-      ID: 221
+      ID: 218
       Name: '*math/big.nat.array'
       ByteSize: 8
-      Pointee: 220 GoSliceDataType math/big.nat.array
+      Pointee: 217 GoSliceDataType math/big.nat.array
     - __kind: GoSliceDataType
-      ID: 222
+      ID: 219
       Name: '[]crypto/x509/pkix.AttributeTypeAndValue.array'
       ByteSize: 2048
       Element: 70 StructureType crypto/x509/pkix.AttributeTypeAndValue
     - __kind: PointerType
-      ID: 223
+      ID: 220
       Name: '*[]crypto/x509/pkix.AttributeTypeAndValue.array'
       ByteSize: 8
-      Pointee: 222 GoSliceDataType []crypto/x509/pkix.AttributeTypeAndValue.array
+      Pointee: 219 GoSliceDataType []crypto/x509/pkix.AttributeTypeAndValue.array
     - __kind: GoSliceDataType
-      ID: 224
+      ID: 221
       Name: encoding/asn1.ObjectIdentifier.array
       ByteSize: 2048
       Element: 8 BaseType int
     - __kind: PointerType
-      ID: 225
+      ID: 222
       Name: '*encoding/asn1.ObjectIdentifier.array'
       ByteSize: 8
-      Pointee: 224 GoSliceDataType encoding/asn1.ObjectIdentifier.array
+      Pointee: 221 GoSliceDataType encoding/asn1.ObjectIdentifier.array
     - __kind: GoSliceDataType
-      ID: 226
+      ID: 223
       Name: '[]time.zone.array'
       ByteSize: 2048
       Element: 79 StructureType time.zone
     - __kind: PointerType
-      ID: 227
+      ID: 224
       Name: '*[]time.zone.array'
       ByteSize: 8
-      Pointee: 226 GoSliceDataType []time.zone.array
+      Pointee: 223 GoSliceDataType []time.zone.array
     - __kind: GoSliceDataType
-      ID: 228
+      ID: 225
       Name: '[]time.zoneTrans.array'
       ByteSize: 2048
       Element: 82 StructureType time.zoneTrans
     - __kind: PointerType
-      ID: 229
+      ID: 226
       Name: '*[]time.zoneTrans.array'
       ByteSize: 8
-      Pointee: 228 GoSliceDataType []time.zoneTrans.array
+      Pointee: 225 GoSliceDataType []time.zoneTrans.array
     - __kind: GoSliceDataType
-      ID: 230
+      ID: 227
       Name: '[]crypto/x509/pkix.Extension.array'
       ByteSize: 2048
       Element: 86 StructureType crypto/x509/pkix.Extension
     - __kind: PointerType
-      ID: 231
+      ID: 228
       Name: '*[]crypto/x509/pkix.Extension.array'
       ByteSize: 8
-      Pointee: 230 GoSliceDataType []crypto/x509/pkix.Extension.array
+      Pointee: 227 GoSliceDataType []crypto/x509/pkix.Extension.array
     - __kind: GoSliceDataType
-      ID: 232
+      ID: 229
       Name: '[]encoding/asn1.ObjectIdentifier.array'
       ByteSize: 2048
       Element: 71 GoSliceHeaderType encoding/asn1.ObjectIdentifier
     - __kind: PointerType
-      ID: 233
+      ID: 230
       Name: '*[]encoding/asn1.ObjectIdentifier.array'
       ByteSize: 8
-      Pointee: 232 GoSliceDataType []encoding/asn1.ObjectIdentifier.array
+      Pointee: 229 GoSliceDataType []encoding/asn1.ObjectIdentifier.array
     - __kind: GoSliceDataType
-      ID: 234
+      ID: 231
       Name: '[]crypto/x509.ExtKeyUsage.array'
       ByteSize: 2048
       Element: 91 BaseType crypto/x509.ExtKeyUsage
     - __kind: PointerType
-      ID: 235
+      ID: 232
       Name: '*[]crypto/x509.ExtKeyUsage.array'
       ByteSize: 8
-      Pointee: 234 GoSliceDataType []crypto/x509.ExtKeyUsage.array
+      Pointee: 231 GoSliceDataType []crypto/x509.ExtKeyUsage.array
     - __kind: GoSliceDataType
-      ID: 236
+      ID: 233
       Name: '[]net.IP.array'
       ByteSize: 2048
       Element: 94 GoSliceHeaderType net.IP
     - __kind: PointerType
-      ID: 237
+      ID: 234
       Name: '*[]net.IP.array'
       ByteSize: 8
-      Pointee: 236 GoSliceDataType []net.IP.array
+      Pointee: 233 GoSliceDataType []net.IP.array
     - __kind: GoSliceDataType
-      ID: 238
+      ID: 235
       Name: net.IP.array
       ByteSize: 2048
       Element: 7 BaseType uint8
     - __kind: PointerType
-      ID: 239
+      ID: 236
       Name: '*net.IP.array'
       ByteSize: 8
-      Pointee: 238 GoSliceDataType net.IP.array
+      Pointee: 235 GoSliceDataType net.IP.array
     - __kind: GoSliceDataType
-      ID: 240
+      ID: 237
       Name: '[]*net/url.URL.array'
       ByteSize: 2048
       Element: 9 PointerType *net/url.URL
     - __kind: PointerType
-      ID: 241
+      ID: 238
       Name: '*[]*net/url.URL.array'
       ByteSize: 8
-      Pointee: 240 GoSliceDataType []*net/url.URL.array
+      Pointee: 237 GoSliceDataType []*net/url.URL.array
     - __kind: GoSliceDataType
-      ID: 242
+      ID: 239
       Name: '[]*net.IPNet.array'
       ByteSize: 2048
       Element: 99 PointerType *net.IPNet
     - __kind: PointerType
-      ID: 243
+      ID: 240
       Name: '*[]*net.IPNet.array'
       ByteSize: 8
-      Pointee: 242 GoSliceDataType []*net.IPNet.array
+      Pointee: 239 GoSliceDataType []*net.IPNet.array
     - __kind: GoSliceDataType
-      ID: 244
+      ID: 241
       Name: net.IPMask.array
       ByteSize: 2048
       Element: 7 BaseType uint8
     - __kind: PointerType
-      ID: 245
+      ID: 242
       Name: '*net.IPMask.array'
       ByteSize: 8
-      Pointee: 244 GoSliceDataType net.IPMask.array
+      Pointee: 241 GoSliceDataType net.IPMask.array
     - __kind: GoSliceDataType
-      ID: 246
+      ID: 243
       Name: '[]crypto/x509.OID.array'
       ByteSize: 2048
       Element: 104 StructureType crypto/x509.OID
     - __kind: PointerType
-      ID: 247
+      ID: 244
       Name: '*[]crypto/x509.OID.array'
       ByteSize: 8
-      Pointee: 246 GoSliceDataType []crypto/x509.OID.array
+      Pointee: 243 GoSliceDataType []crypto/x509.OID.array
     - __kind: GoSliceDataType
-      ID: 248
+      ID: 245
       Name: '[][]*crypto/x509.Certificate.array'
       ByteSize: 2048
       Element: 55 GoSliceHeaderType []*crypto/x509.Certificate
     - __kind: PointerType
-      ID: 249
+      ID: 246
       Name: '*[][]*crypto/x509.Certificate.array'
       ByteSize: 8
-      Pointee: 248 GoSliceDataType [][]*crypto/x509.Certificate.array
+      Pointee: 245 GoSliceDataType [][]*crypto/x509.Certificate.array
     - __kind: GoSliceDataType
-      ID: 250
+      ID: 247
       Name: '[][]uint8.array'
       ByteSize: 2048
       Element: 52 GoSliceHeaderType []uint8
     - __kind: PointerType
-      ID: 251
+      ID: 248
       Name: '*[][]uint8.array'
       ByteSize: 8
-      Pointee: 250 GoSliceDataType [][]uint8.array
+      Pointee: 247 GoSliceDataType [][]uint8.array
     - __kind: GoSliceDataType
-      ID: 252
+      ID: 249
       Name: '[]net/http.segment.array'
       ByteSize: 2048
       Element: 119 StructureType net/http.segment
     - __kind: PointerType
-      ID: 253
+      ID: 250
       Name: '*[]net/http.segment.array'
       ByteSize: 8
-      Pointee: 252 GoSliceDataType []net/http.segment.array
+      Pointee: 249 GoSliceDataType []net/http.segment.array
     - __kind: GoSliceDataType
-      ID: 254
+      ID: 251
       Name: '[]bucket<string,string>.array'
       ByteSize: 2048
       Element: 124 GoHMapBucketType bucket<string,string>
     - __kind: GoSliceDataType
-      ID: 255
+      ID: 252
       Name: '[]bucket<string,interface {}>.array'
       ByteSize: 2048
       Element: 137 GoHMapBucketType bucket<string,interface {}>
     - __kind: GoSliceDataType
-      ID: 256
+      ID: 253
       Name: '[]bucket<string,float64>.array'
       ByteSize: 2048
       Element: 143 GoHMapBucketType bucket<string,float64>
     - __kind: GoSliceDataType
-      ID: 257
+      ID: 254
       Name: '[]github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink.array'
       ByteSize: 2048
       Element: 148 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink
     - __kind: PointerType
-      ID: 258
+      ID: 255
       Name: '*[]github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink.array'
       ByteSize: 8
-      Pointee: 257 GoSliceDataType []github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink.array
+      Pointee: 254 GoSliceDataType []github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink.array
     - __kind: GoSliceDataType
-      ID: 259
+      ID: 256
       Name: '[]github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent.array'
       ByteSize: 2048
       Element: 151 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent
     - __kind: PointerType
-      ID: 260
+      ID: 257
       Name: '*[]github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent.array'
       ByteSize: 8
-      Pointee: 259 GoSliceDataType []github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent.array
+      Pointee: 256 GoSliceDataType []github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent.array
     - __kind: GoSliceDataType
-      ID: 261
+      ID: 258
       Name: '[]bucket<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>.array'
       ByteSize: 2048
       Element: 156 GoHMapBucketType bucket<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
     - __kind: GoSliceDataType
-      ID: 262
+      ID: 259
       Name: '[]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttributeValue.array'
       ByteSize: 2048
       Element: 165 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttributeValue
     - __kind: PointerType
-      ID: 263
+      ID: 260
       Name: '*[]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttributeValue.array'
       ByteSize: 8
-      Pointee: 262 GoSliceDataType []*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttributeValue.array
+      Pointee: 259 GoSliceDataType []*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttributeValue.array
     - __kind: GoSliceDataType
-      ID: 264
-      Name: '[]bucket<string,interface {}>.array'
-      ByteSize: 2048
-      Element: 137 GoHMapBucketType bucket<string,interface {}>
-    - __kind: GoSliceDataType
-      ID: 265
+      ID: 261
       Name: '[]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span.array'
       ByteSize: 2048
       Element: 126 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span
     - __kind: PointerType
-      ID: 266
+      ID: 262
       Name: '*[]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span.array'
       ByteSize: 8
-      Pointee: 265 GoSliceDataType []*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span.array
+      Pointee: 261 GoSliceDataType []*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span.array
     - __kind: EventRootType
-      ID: 267
+      ID: 263
       Name: Probe[main.HandleHTTP]
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -3101,7 +3081,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 268
+      ID: 264
       Name: Probe[main.LookAtTheRequest]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -3115,6 +3095,6 @@ Types:
                   Variable: {subprogram: 2, index: 0, name: path}
                   Offset: 0
                   ByteSize: 16
-MaxTypeID: 268
+MaxTypeID: 264
 Issues: []
 GoModuledataInfo: {FirstModuledataAddr: "0x137dc20", TypesOffset: 296}

--- a/pkg/dyninst/irgen/testdata/snapshot/rc_tester.arch=arm64,toolchain=go1.23.11.yaml
+++ b/pkg/dyninst/irgen/testdata/snapshot/rc_tester.arch=arm64,toolchain=go1.23.11.yaml
@@ -105,174 +105,174 @@ Subprograms:
           IsReturn: false
 Types:
     - __kind: PointerType
-      ID: 114
+      ID: 116
       Name: '**crypto/x509.Certificate'
       ByteSize: 8
-      Pointee: 115 PointerType *crypto/x509.Certificate
+      Pointee: 117 PointerType *crypto/x509.Certificate
     - __kind: PointerType
-      ID: 148
+      ID: 162
       Name: '**github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span'
       ByteSize: 8
       GoKind: 22
       Pointee: 39 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span
     - __kind: PointerType
-      ID: 198
+      ID: 228
       Name: '**github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttributeValue'
       ByteSize: 8
       GoKind: 22
-      Pointee: 199 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttributeValue
+      Pointee: 229 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttributeValue
     - __kind: PointerType
-      ID: 141
+      ID: 155
       Name: '**mime/multipart.FileHeader'
       ByteSize: 8
       GoKind: 22
-      Pointee: 142 PointerType *mime/multipart.FileHeader
+      Pointee: 156 PointerType *mime/multipart.FileHeader
     - __kind: PointerType
-      ID: 178
+      ID: 204
       Name: '**net.IPNet'
       ByteSize: 8
       GoKind: 22
-      Pointee: 179 PointerType *net.IPNet
+      Pointee: 205 PointerType *net.IPNet
     - __kind: PointerType
-      ID: 176
+      ID: 202
       Name: '**net/url.URL'
       ByteSize: 8
       Pointee: 45 PointerType *net/url.URL
     - __kind: PointerType
-      ID: 138
+      ID: 152
       Name: '**runtime.bmap'
       ByteSize: 8
-      Pointee: 105 PointerType *runtime.bmap
+      Pointee: 107 PointerType *runtime.bmap
     - __kind: PointerType
-      ID: 117
+      ID: 119
       Name: '*[]*crypto/x509.Certificate'
       ByteSize: 8
       GoKind: 22
-      Pointee: 113 GoSliceHeaderType []*crypto/x509.Certificate
+      Pointee: 115 GoSliceHeaderType []*crypto/x509.Certificate
     - __kind: PointerType
-      ID: 221
+      ID: 168
       Name: '*[]*crypto/x509.Certificate.array'
       ByteSize: 8
-      Pointee: 220 GoSliceDataType []*crypto/x509.Certificate.array
+      Pointee: 167 GoSliceDataType []*crypto/x509.Certificate.array
     - __kind: PointerType
-      ID: 232
+      ID: 215
       Name: '*[]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span.array'
       ByteSize: 8
-      Pointee: 231 GoSliceDataType []*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span.array
+      Pointee: 214 GoSliceDataType []*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span.array
     - __kind: PointerType
-      ID: 260
+      ID: 259
       Name: '*[]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttributeValue.array'
       ByteSize: 8
-      Pointee: 259 GoSliceDataType []*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttributeValue.array
+      Pointee: 258 GoSliceDataType []*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttributeValue.array
     - __kind: PointerType
-      ID: 230
+      ID: 213
       Name: '*[]*mime/multipart.FileHeader.array'
       ByteSize: 8
-      Pointee: 229 GoSliceDataType []*mime/multipart.FileHeader.array
+      Pointee: 212 GoSliceDataType []*mime/multipart.FileHeader.array
     - __kind: PointerType
-      ID: 250
+      ID: 247
       Name: '*[]*net.IPNet.array'
       ByteSize: 8
-      Pointee: 249 GoSliceDataType []*net.IPNet.array
+      Pointee: 246 GoSliceDataType []*net.IPNet.array
     - __kind: PointerType
-      ID: 248
+      ID: 245
       Name: '*[]*net/url.URL.array'
       ByteSize: 8
-      Pointee: 247 GoSliceDataType []*net/url.URL.array
+      Pointee: 244 GoSliceDataType []*net/url.URL.array
     - __kind: PointerType
-      ID: 103
+      ID: 105
       Name: '*[]*runtime.bmap'
       ByteSize: 8
       GoRuntimeType: 470816
       GoKind: 22
-      Pointee: 104 GoSliceHeaderType []*runtime.bmap
+      Pointee: 106 GoSliceHeaderType []*runtime.bmap
     - __kind: PointerType
-      ID: 218
+      ID: 165
       Name: '*[]*runtime.bmap.array'
       ByteSize: 8
-      Pointee: 217 GoSliceDataType []*runtime.bmap.array
+      Pointee: 164 GoSliceDataType []*runtime.bmap.array
     - __kind: PointerType
-      ID: 223
+      ID: 170
       Name: '*[][]*crypto/x509.Certificate.array'
       ByteSize: 8
-      Pointee: 222 GoSliceDataType [][]*crypto/x509.Certificate.array
+      Pointee: 169 GoSliceDataType [][]*crypto/x509.Certificate.array
     - __kind: PointerType
-      ID: 225
+      ID: 172
       Name: '*[][]uint8.array'
       ByteSize: 8
-      Pointee: 224 GoSliceDataType [][]uint8.array
+      Pointee: 171 GoSliceDataType [][]uint8.array
     - __kind: PointerType
-      ID: 242
+      ID: 239
       Name: '*[]crypto/x509.ExtKeyUsage.array'
       ByteSize: 8
-      Pointee: 241 GoSliceDataType []crypto/x509.ExtKeyUsage.array
+      Pointee: 238 GoSliceDataType []crypto/x509.ExtKeyUsage.array
     - __kind: PointerType
-      ID: 252
+      ID: 249
       Name: '*[]crypto/x509.OID.array'
       ByteSize: 8
-      Pointee: 251 GoSliceDataType []crypto/x509.OID.array
+      Pointee: 248 GoSliceDataType []crypto/x509.OID.array
     - __kind: PointerType
-      ID: 234
+      ID: 231
       Name: '*[]crypto/x509/pkix.AttributeTypeAndValue.array'
       ByteSize: 8
-      Pointee: 233 GoSliceDataType []crypto/x509/pkix.AttributeTypeAndValue.array
+      Pointee: 230 GoSliceDataType []crypto/x509/pkix.AttributeTypeAndValue.array
     - __kind: PointerType
-      ID: 236
+      ID: 233
       Name: '*[]crypto/x509/pkix.Extension.array'
       ByteSize: 8
-      Pointee: 235 GoSliceDataType []crypto/x509/pkix.Extension.array
+      Pointee: 232 GoSliceDataType []crypto/x509/pkix.Extension.array
     - __kind: PointerType
-      ID: 238
+      ID: 235
       Name: '*[]encoding/asn1.ObjectIdentifier.array'
       ByteSize: 8
-      Pointee: 237 GoSliceDataType []encoding/asn1.ObjectIdentifier.array
+      Pointee: 234 GoSliceDataType []encoding/asn1.ObjectIdentifier.array
     - __kind: PointerType
-      ID: 212
+      ID: 147
       Name: '*[]github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink.array'
       ByteSize: 8
-      Pointee: 211 GoSliceDataType []github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink.array
+      Pointee: 146 GoSliceDataType []github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink.array
     - __kind: PointerType
-      ID: 214
+      ID: 149
       Name: '*[]github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent.array'
       ByteSize: 8
-      Pointee: 213 GoSliceDataType []github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent.array
+      Pointee: 148 GoSliceDataType []github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent.array
     - __kind: PointerType
-      ID: 244
+      ID: 241
       Name: '*[]net.IP.array'
       ByteSize: 8
-      Pointee: 243 GoSliceDataType []net.IP.array
+      Pointee: 240 GoSliceDataType []net.IP.array
     - __kind: PointerType
-      ID: 227
+      ID: 174
       Name: '*[]net/http.segment.array'
       ByteSize: 8
-      Pointee: 226 GoSliceDataType []net/http.segment.array
+      Pointee: 173 GoSliceDataType []net/http.segment.array
     - __kind: PointerType
-      ID: 207
+      ID: 142
       Name: '*[]string.array'
       ByteSize: 8
-      Pointee: 206 GoSliceDataType []string.array
+      Pointee: 141 GoSliceDataType []string.array
     - __kind: PointerType
-      ID: 256
+      ID: 255
       Name: '*[]time.zone.array'
       ByteSize: 8
-      Pointee: 255 GoSliceDataType []time.zone.array
+      Pointee: 254 GoSliceDataType []time.zone.array
     - __kind: PointerType
-      ID: 258
+      ID: 257
       Name: '*[]time.zoneTrans.array'
       ByteSize: 8
-      Pointee: 257 GoSliceDataType []time.zoneTrans.array
+      Pointee: 256 GoSliceDataType []time.zoneTrans.array
     - __kind: PointerType
-      ID: 119
+      ID: 121
       Name: '*[]uint8'
       ByteSize: 8
       GoRuntimeType: 456928
       GoKind: 22
       Pointee: 96 GoSliceHeaderType []uint8
     - __kind: PointerType
-      ID: 216
+      ID: 151
       Name: '*[]uint8.array'
       ByteSize: 8
-      Pointee: 215 GoSliceDataType []uint8.array
+      Pointee: 150 GoSliceDataType []uint8.array
     - __kind: PointerType
       ID: 5
       Name: '*bool'
@@ -281,15 +281,15 @@ Types:
       GoKind: 22
       Pointee: 4 BaseType bool
     - __kind: PointerType
-      ID: 132
+      ID: 134
       Name: '*bucket<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>'
       ByteSize: 8
-      Pointee: 133 GoHMapBucketType bucket<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
+      Pointee: 135 GoHMapBucketType bucket<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
     - __kind: PointerType
-      ID: 111
+      ID: 113
       Name: '*bucket<string,[]*mime/multipart.FileHeader>'
       ByteSize: 8
-      Pointee: 112 GoHMapBucketType bucket<string,[]*mime/multipart.FileHeader>
+      Pointee: 114 GoHMapBucketType bucket<string,[]*mime/multipart.FileHeader>
     - __kind: PointerType
       ID: 50
       Name: '*bucket<string,[]string>'
@@ -325,52 +325,52 @@ Types:
       GoKind: 22
       Pointee: 61 StructureType crypto/tls.ConnectionState
     - __kind: PointerType
-      ID: 115
+      ID: 117
       Name: '*crypto/x509.Certificate'
       ByteSize: 8
       GoRuntimeType: 1.95344e+06
       GoKind: 22
-      Pointee: 143 StructureType crypto/x509.Certificate
+      Pointee: 157 StructureType crypto/x509.Certificate
     - __kind: PointerType
-      ID: 170
+      ID: 196
       Name: '*crypto/x509.ExtKeyUsage'
       ByteSize: 8
       GoRuntimeType: 400736
       GoKind: 22
-      Pointee: 171 BaseType crypto/x509.ExtKeyUsage
+      Pointee: 197 BaseType crypto/x509.ExtKeyUsage
     - __kind: PointerType
-      ID: 181
+      ID: 207
       Name: '*crypto/x509.OID'
       ByteSize: 8
       GoRuntimeType: 1.762368e+06
       GoKind: 22
-      Pointee: 182 StructureType crypto/x509.OID
+      Pointee: 208 StructureType crypto/x509.OID
     - __kind: PointerType
-      ID: 157
+      ID: 183
       Name: '*crypto/x509/pkix.AttributeTypeAndValue'
       ByteSize: 8
       GoRuntimeType: 417504
       GoKind: 22
-      Pointee: 158 StructureType crypto/x509/pkix.AttributeTypeAndValue
+      Pointee: 184 StructureType crypto/x509/pkix.AttributeTypeAndValue
     - __kind: PointerType
-      ID: 164
+      ID: 190
       Name: '*crypto/x509/pkix.Extension'
       ByteSize: 8
       GoRuntimeType: 417696
       GoKind: 22
-      Pointee: 165 StructureType crypto/x509/pkix.Extension
+      Pointee: 191 StructureType crypto/x509/pkix.Extension
     - __kind: PointerType
-      ID: 167
+      ID: 193
       Name: '*encoding/asn1.ObjectIdentifier'
       ByteSize: 8
       GoRuntimeType: 1.037472e+06
       GoKind: 22
-      Pointee: 168 GoSliceHeaderType encoding/asn1.ObjectIdentifier
+      Pointee: 194 GoSliceHeaderType encoding/asn1.ObjectIdentifier
     - __kind: PointerType
-      ID: 240
+      ID: 237
       Name: '*encoding/asn1.ObjectIdentifier.array'
       ByteSize: 8
-      Pointee: 239 GoSliceDataType encoding/asn1.ObjectIdentifier.array
+      Pointee: 236 GoSliceDataType encoding/asn1.ObjectIdentifier.array
     - __kind: PointerType
       ID: 33
       Name: '*error'
@@ -421,43 +421,43 @@ Types:
       GoKind: 22
       Pointee: 92 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent
     - __kind: PointerType
-      ID: 184
+      ID: 210
       Name: '*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttribute'
       ByteSize: 8
       GoRuntimeType: 1.130208e+06
       GoKind: 22
-      Pointee: 185 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttribute
+      Pointee: 211 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttribute
     - __kind: PointerType
-      ID: 199
+      ID: 229
       Name: '*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttributeValue'
       ByteSize: 8
       GoRuntimeType: 1.129952e+06
       GoKind: 22
-      Pointee: 201 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttributeValue
+      Pointee: 251 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttributeValue
     - __kind: PointerType
-      ID: 145
+      ID: 159
       Name: '*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute'
       ByteSize: 8
       GoRuntimeType: 1.130336e+06
       GoKind: 22
-      Pointee: 146 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
+      Pointee: 160 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
     - __kind: PointerType
-      ID: 135
+      ID: 137
       Name: '*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.trace'
       ByteSize: 8
       GoRuntimeType: 2.132544e+06
       GoKind: 22
-      Pointee: 136 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.trace
+      Pointee: 138 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.trace
     - __kind: PointerType
-      ID: 130
+      ID: 132
       Name: '*hash<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>'
       ByteSize: 8
-      Pointee: 131 GoHMapHeaderType hash<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
+      Pointee: 133 GoHMapHeaderType hash<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
     - __kind: PointerType
-      ID: 109
+      ID: 111
       Name: '*hash<string,[]*mime/multipart.FileHeader>'
       ByteSize: 8
-      Pointee: 110 GoHMapHeaderType hash<string,[]*mime/multipart.FileHeader>
+      Pointee: 112 GoHMapHeaderType hash<string,[]*mime/multipart.FileHeader>
     - __kind: PointerType
       ID: 48
       Name: '*hash<string,[]string>'
@@ -514,31 +514,31 @@ Types:
       GoKind: 22
       Pointee: 15 BaseType int8
     - __kind: PointerType
-      ID: 153
+      ID: 179
       Name: '*math/big.Int'
       ByteSize: 8
       GoRuntimeType: 2.29744e+06
       GoKind: 22
-      Pointee: 154 StructureType math/big.Int
+      Pointee: 180 StructureType math/big.Int
     - __kind: PointerType
-      ID: 188
+      ID: 218
       Name: '*math/big.Word'
       ByteSize: 8
       GoRuntimeType: 403552
       GoKind: 22
-      Pointee: 189 BaseType math/big.Word
+      Pointee: 219 BaseType math/big.Word
     - __kind: PointerType
-      ID: 254
+      ID: 253
       Name: '*math/big.nat.array'
       ByteSize: 8
-      Pointee: 253 GoSliceDataType math/big.nat.array
+      Pointee: 252 GoSliceDataType math/big.nat.array
     - __kind: PointerType
-      ID: 142
+      ID: 156
       Name: '*mime/multipart.FileHeader'
       ByteSize: 8
       GoRuntimeType: 853760
       GoKind: 22
-      Pointee: 150 StructureType mime/multipart.FileHeader
+      Pointee: 176 StructureType mime/multipart.FileHeader
     - __kind: PointerType
       ID: 58
       Name: '*mime/multipart.Form'
@@ -547,29 +547,29 @@ Types:
       GoKind: 22
       Pointee: 59 StructureType mime/multipart.Form
     - __kind: PointerType
-      ID: 173
+      ID: 199
       Name: '*net.IP'
       ByteSize: 8
       GoRuntimeType: 2.02912e+06
       GoKind: 22
-      Pointee: 174 GoSliceHeaderType net.IP
+      Pointee: 200 GoSliceHeaderType net.IP
     - __kind: PointerType
-      ID: 246
+      ID: 243
       Name: '*net.IP.array'
       ByteSize: 8
-      Pointee: 245 GoSliceDataType net.IP.array
+      Pointee: 242 GoSliceDataType net.IP.array
     - __kind: PointerType
       ID: 262
       Name: '*net.IPMask.array'
       ByteSize: 8
       Pointee: 261 GoSliceDataType net.IPMask.array
     - __kind: PointerType
-      ID: 179
+      ID: 205
       Name: '*net.IPNet'
       ByteSize: 8
       GoRuntimeType: 1.122912e+06
       GoKind: 22
-      Pointee: 196 StructureType net.IPNet
+      Pointee: 226 StructureType net.IPNet
     - __kind: PointerType
       ID: 37
       Name: '*net/http.Request'
@@ -592,12 +592,12 @@ Types:
       GoKind: 22
       Pointee: 67 StructureType net/http.pattern
     - __kind: PointerType
-      ID: 123
+      ID: 125
       Name: '*net/http.segment'
       ByteSize: 8
       GoRuntimeType: 367904
       GoKind: 22
-      Pointee: 124 StructureType net/http.segment
+      Pointee: 126 StructureType net/http.segment
     - __kind: PointerType
       ID: 45
       Name: '*net/url.URL'
@@ -606,19 +606,19 @@ Types:
       GoKind: 22
       Pointee: 46 StructureType net/url.URL
     - __kind: PointerType
-      ID: 98
+      ID: 100
       Name: '*net/url.Userinfo'
       ByteSize: 8
       GoRuntimeType: 1.1416e+06
       GoKind: 22
-      Pointee: 99 StructureType net/url.Userinfo
+      Pointee: 101 StructureType net/url.Userinfo
     - __kind: PointerType
-      ID: 105
+      ID: 107
       Name: '*runtime.bmap'
       ByteSize: 8
       GoRuntimeType: 1.137248e+06
       GoKind: 22
-      Pointee: 106 StructureType runtime.bmap
+      Pointee: 108 StructureType runtime.bmap
     - __kind: PointerType
       ID: 52
       Name: '*runtime.mapextra'
@@ -634,31 +634,31 @@ Types:
       GoKind: 22
       Pointee: 11 GoStringHeaderType string
     - __kind: PointerType
-      ID: 204
+      ID: 99
       Name: '*string.str'
       ByteSize: 8
-      Pointee: 203 GoStringDataType string.str
+      Pointee: 98 GoStringDataType string.str
     - __kind: PointerType
-      ID: 160
+      ID: 186
       Name: '*time.Location'
       ByteSize: 8
       GoRuntimeType: 1.458496e+06
       GoKind: 22
-      Pointee: 161 StructureType time.Location
+      Pointee: 187 StructureType time.Location
     - __kind: PointerType
-      ID: 191
+      ID: 221
       Name: '*time.zone'
       ByteSize: 8
       GoRuntimeType: 370976
       GoKind: 22
-      Pointee: 192 StructureType time.zone
+      Pointee: 222 StructureType time.zone
     - __kind: PointerType
-      ID: 194
+      ID: 224
       Name: '*time.zoneTrans'
       ByteSize: 8
       GoRuntimeType: 371040
       GoKind: 22
-      Pointee: 195 StructureType time.zoneTrans
+      Pointee: 225 StructureType time.zoneTrans
     - __kind: PointerType
       ID: 34
       Name: '*uint'
@@ -746,7 +746,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: ArrayType
-      ID: 100
+      ID: 102
       Name: '[8]uint8'
       ByteSize: 8
       GoRuntimeType: 632832
@@ -755,7 +755,7 @@ Types:
       HasCount: true
       Element: 3 BaseType uint8
     - __kind: GoSliceHeaderType
-      ID: 113
+      ID: 115
       Name: '[]*crypto/x509.Certificate'
       ByteSize: 24
       GoRuntimeType: 473920
@@ -763,21 +763,21 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 114 PointerType **crypto/x509.Certificate
+          Type: 116 PointerType **crypto/x509.Certificate
         - Name: len
           Offset: 8
           Type: 9 BaseType int
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 220 GoSliceDataType []*crypto/x509.Certificate.array
+      Data: 167 GoSliceDataType []*crypto/x509.Certificate.array
     - __kind: GoSliceDataType
-      ID: 220
+      ID: 167
       Name: '[]*crypto/x509.Certificate.array'
       ByteSize: 2048
-      Element: 115 PointerType *crypto/x509.Certificate
+      Element: 117 PointerType *crypto/x509.Certificate
     - __kind: GoSliceHeaderType
-      ID: 147
+      ID: 161
       Name: '[]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span'
       ByteSize: 24
       GoRuntimeType: 464032
@@ -785,21 +785,21 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 148 PointerType **github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span
+          Type: 162 PointerType **github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span
         - Name: len
           Offset: 8
           Type: 9 BaseType int
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 231 GoSliceDataType []*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span.array
+      Data: 214 GoSliceDataType []*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span.array
     - __kind: GoSliceDataType
-      ID: 231
+      ID: 214
       Name: '[]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span.array'
       ByteSize: 2048
       Element: 39 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span
     - __kind: GoSliceHeaderType
-      ID: 197
+      ID: 227
       Name: '[]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttributeValue'
       ByteSize: 24
       GoRuntimeType: 463648
@@ -807,21 +807,21 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 198 PointerType **github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttributeValue
+          Type: 228 PointerType **github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttributeValue
         - Name: len
           Offset: 8
           Type: 9 BaseType int
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 259 GoSliceDataType []*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttributeValue.array
+      Data: 258 GoSliceDataType []*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttributeValue.array
     - __kind: GoSliceDataType
-      ID: 259
+      ID: 258
       Name: '[]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttributeValue.array'
       ByteSize: 2048
-      Element: 199 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttributeValue
+      Element: 229 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttributeValue
     - __kind: GoSliceHeaderType
-      ID: 140
+      ID: 154
       Name: '[]*mime/multipart.FileHeader'
       ByteSize: 24
       GoRuntimeType: 461664
@@ -829,21 +829,21 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 141 PointerType **mime/multipart.FileHeader
+          Type: 155 PointerType **mime/multipart.FileHeader
         - Name: len
           Offset: 8
           Type: 9 BaseType int
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 229 GoSliceDataType []*mime/multipart.FileHeader.array
+      Data: 212 GoSliceDataType []*mime/multipart.FileHeader.array
     - __kind: GoSliceDataType
-      ID: 229
+      ID: 212
       Name: '[]*mime/multipart.FileHeader.array'
       ByteSize: 2048
-      Element: 142 PointerType *mime/multipart.FileHeader
+      Element: 156 PointerType *mime/multipart.FileHeader
     - __kind: GoSliceHeaderType
-      ID: 177
+      ID: 203
       Name: '[]*net.IPNet'
       ByteSize: 24
       GoRuntimeType: 486976
@@ -851,21 +851,21 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 178 PointerType **net.IPNet
+          Type: 204 PointerType **net.IPNet
         - Name: len
           Offset: 8
           Type: 9 BaseType int
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 249 GoSliceDataType []*net.IPNet.array
+      Data: 246 GoSliceDataType []*net.IPNet.array
     - __kind: GoSliceDataType
-      ID: 249
+      ID: 246
       Name: '[]*net.IPNet.array'
       ByteSize: 2048
-      Element: 179 PointerType *net.IPNet
+      Element: 205 PointerType *net.IPNet
     - __kind: GoSliceHeaderType
-      ID: 175
+      ID: 201
       Name: '[]*net/url.URL'
       ByteSize: 24
       GoRuntimeType: 486912
@@ -873,21 +873,21 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 176 PointerType **net/url.URL
+          Type: 202 PointerType **net/url.URL
         - Name: len
           Offset: 8
           Type: 9 BaseType int
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 247 GoSliceDataType []*net/url.URL.array
+      Data: 244 GoSliceDataType []*net/url.URL.array
     - __kind: GoSliceDataType
-      ID: 247
+      ID: 244
       Name: '[]*net/url.URL.array'
       ByteSize: 2048
       Element: 45 PointerType *net/url.URL
     - __kind: GoSliceHeaderType
-      ID: 104
+      ID: 106
       Name: '[]*runtime.bmap'
       ByteSize: 24
       GoRuntimeType: 470752
@@ -895,21 +895,21 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 138 PointerType **runtime.bmap
+          Type: 152 PointerType **runtime.bmap
         - Name: len
           Offset: 8
           Type: 9 BaseType int
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 217 GoSliceDataType []*runtime.bmap.array
+      Data: 164 GoSliceDataType []*runtime.bmap.array
     - __kind: GoSliceDataType
-      ID: 217
+      ID: 164
       Name: '[]*runtime.bmap.array'
       ByteSize: 2048
-      Element: 105 PointerType *runtime.bmap
+      Element: 107 PointerType *runtime.bmap
     - __kind: GoSliceHeaderType
-      ID: 116
+      ID: 118
       Name: '[][]*crypto/x509.Certificate'
       ByteSize: 24
       GoRuntimeType: 474048
@@ -917,21 +917,21 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 117 PointerType *[]*crypto/x509.Certificate
+          Type: 119 PointerType *[]*crypto/x509.Certificate
         - Name: len
           Offset: 8
           Type: 9 BaseType int
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 222 GoSliceDataType [][]*crypto/x509.Certificate.array
+      Data: 169 GoSliceDataType [][]*crypto/x509.Certificate.array
     - __kind: GoSliceDataType
-      ID: 222
+      ID: 169
       Name: '[][]*crypto/x509.Certificate.array'
       ByteSize: 2048
-      Element: 113 GoSliceHeaderType []*crypto/x509.Certificate
+      Element: 115 GoSliceHeaderType []*crypto/x509.Certificate
     - __kind: GoSliceHeaderType
-      ID: 118
+      ID: 120
       Name: '[][]uint8'
       ByteSize: 24
       GoRuntimeType: 457184
@@ -939,51 +939,51 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 119 PointerType *[]uint8
+          Type: 121 PointerType *[]uint8
         - Name: len
           Offset: 8
           Type: 9 BaseType int
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 224 GoSliceDataType [][]uint8.array
+      Data: 171 GoSliceDataType [][]uint8.array
     - __kind: GoSliceDataType
-      ID: 224
+      ID: 171
       Name: '[][]uint8.array'
       ByteSize: 2048
       Element: 96 GoSliceHeaderType []uint8
     - __kind: GoSliceDataType
-      ID: 228
+      ID: 175
       Name: '[]bucket<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>.array'
       ByteSize: 2048
-      Element: 133 GoHMapBucketType bucket<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
+      Element: 135 GoHMapBucketType bucket<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
     - __kind: GoSliceDataType
-      ID: 219
+      ID: 166
       Name: '[]bucket<string,[]*mime/multipart.FileHeader>.array'
       ByteSize: 2048
-      Element: 112 GoHMapBucketType bucket<string,[]*mime/multipart.FileHeader>
+      Element: 114 GoHMapBucketType bucket<string,[]*mime/multipart.FileHeader>
     - __kind: GoSliceDataType
-      ID: 205
+      ID: 140
       Name: '[]bucket<string,[]string>.array'
       ByteSize: 2048
       Element: 51 GoHMapBucketType bucket<string,[]string>
     - __kind: GoSliceDataType
-      ID: 210
+      ID: 145
       Name: '[]bucket<string,float64>.array'
       ByteSize: 2048
       Element: 86 GoHMapBucketType bucket<string,float64>
     - __kind: GoSliceDataType
-      ID: 209
+      ID: 144
       Name: '[]bucket<string,interface {}>.array'
       ByteSize: 2048
       Element: 81 GoHMapBucketType bucket<string,interface {}>
     - __kind: GoSliceDataType
-      ID: 208
+      ID: 143
       Name: '[]bucket<string,string>.array'
       ByteSize: 2048
       Element: 72 GoHMapBucketType bucket<string,string>
     - __kind: GoSliceHeaderType
-      ID: 169
+      ID: 195
       Name: '[]crypto/x509.ExtKeyUsage'
       ByteSize: 24
       GoRuntimeType: 475200
@@ -991,21 +991,21 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 170 PointerType *crypto/x509.ExtKeyUsage
+          Type: 196 PointerType *crypto/x509.ExtKeyUsage
         - Name: len
           Offset: 8
           Type: 9 BaseType int
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 241 GoSliceDataType []crypto/x509.ExtKeyUsage.array
+      Data: 238 GoSliceDataType []crypto/x509.ExtKeyUsage.array
     - __kind: GoSliceDataType
-      ID: 241
+      ID: 238
       Name: '[]crypto/x509.ExtKeyUsage.array'
       ByteSize: 2048
-      Element: 171 BaseType crypto/x509.ExtKeyUsage
+      Element: 197 BaseType crypto/x509.ExtKeyUsage
     - __kind: GoSliceHeaderType
-      ID: 180
+      ID: 206
       Name: '[]crypto/x509.OID'
       ByteSize: 24
       GoRuntimeType: 487040
@@ -1013,21 +1013,21 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 181 PointerType *crypto/x509.OID
+          Type: 207 PointerType *crypto/x509.OID
         - Name: len
           Offset: 8
           Type: 9 BaseType int
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 251 GoSliceDataType []crypto/x509.OID.array
+      Data: 248 GoSliceDataType []crypto/x509.OID.array
     - __kind: GoSliceDataType
-      ID: 251
+      ID: 248
       Name: '[]crypto/x509.OID.array'
       ByteSize: 2048
-      Element: 182 StructureType crypto/x509.OID
+      Element: 208 StructureType crypto/x509.OID
     - __kind: GoSliceHeaderType
-      ID: 156
+      ID: 182
       Name: '[]crypto/x509/pkix.AttributeTypeAndValue'
       ByteSize: 24
       GoRuntimeType: 487296
@@ -1035,21 +1035,21 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 157 PointerType *crypto/x509/pkix.AttributeTypeAndValue
+          Type: 183 PointerType *crypto/x509/pkix.AttributeTypeAndValue
         - Name: len
           Offset: 8
           Type: 9 BaseType int
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 233 GoSliceDataType []crypto/x509/pkix.AttributeTypeAndValue.array
+      Data: 230 GoSliceDataType []crypto/x509/pkix.AttributeTypeAndValue.array
     - __kind: GoSliceDataType
-      ID: 233
+      ID: 230
       Name: '[]crypto/x509/pkix.AttributeTypeAndValue.array'
       ByteSize: 2048
-      Element: 158 StructureType crypto/x509/pkix.AttributeTypeAndValue
+      Element: 184 StructureType crypto/x509/pkix.AttributeTypeAndValue
     - __kind: GoSliceHeaderType
-      ID: 163
+      ID: 189
       Name: '[]crypto/x509/pkix.Extension'
       ByteSize: 24
       GoRuntimeType: 486784
@@ -1057,21 +1057,21 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 164 PointerType *crypto/x509/pkix.Extension
+          Type: 190 PointerType *crypto/x509/pkix.Extension
         - Name: len
           Offset: 8
           Type: 9 BaseType int
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 235 GoSliceDataType []crypto/x509/pkix.Extension.array
+      Data: 232 GoSliceDataType []crypto/x509/pkix.Extension.array
     - __kind: GoSliceDataType
-      ID: 235
+      ID: 232
       Name: '[]crypto/x509/pkix.Extension.array'
       ByteSize: 2048
-      Element: 165 StructureType crypto/x509/pkix.Extension
+      Element: 191 StructureType crypto/x509/pkix.Extension
     - __kind: GoSliceHeaderType
-      ID: 166
+      ID: 192
       Name: '[]encoding/asn1.ObjectIdentifier'
       ByteSize: 24
       GoRuntimeType: 486848
@@ -1079,19 +1079,19 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 167 PointerType *encoding/asn1.ObjectIdentifier
+          Type: 193 PointerType *encoding/asn1.ObjectIdentifier
         - Name: len
           Offset: 8
           Type: 9 BaseType int
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 237 GoSliceDataType []encoding/asn1.ObjectIdentifier.array
+      Data: 234 GoSliceDataType []encoding/asn1.ObjectIdentifier.array
     - __kind: GoSliceDataType
-      ID: 237
+      ID: 234
       Name: '[]encoding/asn1.ObjectIdentifier.array'
       ByteSize: 2048
-      Element: 168 GoSliceHeaderType encoding/asn1.ObjectIdentifier
+      Element: 194 GoSliceHeaderType encoding/asn1.ObjectIdentifier
     - __kind: GoSliceHeaderType
       ID: 87
       Name: '[]github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink'
@@ -1108,9 +1108,9 @@ Types:
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 211 GoSliceDataType []github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink.array
+      Data: 146 GoSliceDataType []github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink.array
     - __kind: GoSliceDataType
-      ID: 211
+      ID: 146
       Name: '[]github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink.array'
       ByteSize: 2048
       Element: 89 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink
@@ -1130,21 +1130,21 @@ Types:
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 213 GoSliceDataType []github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent.array
+      Data: 148 GoSliceDataType []github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent.array
     - __kind: GoSliceDataType
-      ID: 213
+      ID: 148
       Name: '[]github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent.array'
       ByteSize: 2048
       Element: 92 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent
     - __kind: ArrayType
-      ID: 101
+      ID: 103
       Name: '[]key<string>'
       ByteSize: 128
       Count: 8
       HasCount: true
       Element: 11 GoStringHeaderType string
     - __kind: GoSliceHeaderType
-      ID: 172
+      ID: 198
       Name: '[]net.IP'
       ByteSize: 24
       GoRuntimeType: 458400
@@ -1152,21 +1152,21 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 173 PointerType *net.IP
+          Type: 199 PointerType *net.IP
         - Name: len
           Offset: 8
           Type: 9 BaseType int
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 243 GoSliceDataType []net.IP.array
+      Data: 240 GoSliceDataType []net.IP.array
     - __kind: GoSliceDataType
-      ID: 243
+      ID: 240
       Name: '[]net.IP.array'
       ByteSize: 2048
-      Element: 174 GoSliceHeaderType net.IP
+      Element: 200 GoSliceHeaderType net.IP
     - __kind: GoSliceHeaderType
-      ID: 122
+      ID: 124
       Name: '[]net/http.segment'
       ByteSize: 24
       GoRuntimeType: 459168
@@ -1174,19 +1174,19 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 123 PointerType *net/http.segment
+          Type: 125 PointerType *net/http.segment
         - Name: len
           Offset: 8
           Type: 9 BaseType int
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 226 GoSliceDataType []net/http.segment.array
+      Data: 173 GoSliceDataType []net/http.segment.array
     - __kind: GoSliceDataType
-      ID: 226
+      ID: 173
       Name: '[]net/http.segment.array'
       ByteSize: 2048
-      Element: 124 StructureType net/http.segment
+      Element: 126 StructureType net/http.segment
     - __kind: GoSliceHeaderType
       ID: 56
       Name: '[]string'
@@ -1203,14 +1203,14 @@ Types:
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 206 GoSliceDataType []string.array
+      Data: 141 GoSliceDataType []string.array
     - __kind: GoSliceDataType
-      ID: 206
+      ID: 141
       Name: '[]string.array'
       ByteSize: 2048
       Element: 11 GoStringHeaderType string
     - __kind: GoSliceHeaderType
-      ID: 190
+      ID: 220
       Name: '[]time.zone'
       ByteSize: 24
       GoRuntimeType: 463264
@@ -1218,21 +1218,21 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 191 PointerType *time.zone
+          Type: 221 PointerType *time.zone
         - Name: len
           Offset: 8
           Type: 9 BaseType int
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 255 GoSliceDataType []time.zone.array
+      Data: 254 GoSliceDataType []time.zone.array
     - __kind: GoSliceDataType
-      ID: 255
+      ID: 254
       Name: '[]time.zone.array'
       ByteSize: 2048
-      Element: 192 StructureType time.zone
+      Element: 222 StructureType time.zone
     - __kind: GoSliceHeaderType
-      ID: 193
+      ID: 223
       Name: '[]time.zoneTrans'
       ByteSize: 24
       GoRuntimeType: 463328
@@ -1240,19 +1240,19 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 194 PointerType *time.zoneTrans
+          Type: 224 PointerType *time.zoneTrans
         - Name: len
           Offset: 8
           Type: 9 BaseType int
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 257 GoSliceDataType []time.zoneTrans.array
+      Data: 256 GoSliceDataType []time.zoneTrans.array
     - __kind: GoSliceDataType
-      ID: 257
+      ID: 256
       Name: '[]time.zoneTrans.array'
       ByteSize: 2048
-      Element: 195 StructureType time.zoneTrans
+      Element: 225 StructureType time.zoneTrans
     - __kind: GoSliceHeaderType
       ID: 96
       Name: '[]uint8'
@@ -1269,49 +1269,49 @@ Types:
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 215 GoSliceDataType []uint8.array
+      Data: 150 GoSliceDataType []uint8.array
     - __kind: GoSliceDataType
-      ID: 215
+      ID: 150
       Name: '[]uint8.array'
       ByteSize: 2048
       Element: 3 BaseType uint8
     - __kind: ArrayType
-      ID: 144
+      ID: 158
       Name: '[]val<*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>'
       ByteSize: 64
       Count: 8
       HasCount: true
-      Element: 145 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
+      Element: 159 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
     - __kind: ArrayType
-      ID: 139
+      ID: 153
       Name: '[]val<[]*mime/multipart.FileHeader>'
       ByteSize: 192
       Count: 8
       HasCount: true
-      Element: 140 GoSliceHeaderType []*mime/multipart.FileHeader
+      Element: 154 GoSliceHeaderType []*mime/multipart.FileHeader
     - __kind: ArrayType
-      ID: 102
+      ID: 104
       Name: '[]val<[]string>'
       ByteSize: 192
       Count: 8
       HasCount: true
       Element: 56 GoSliceHeaderType []string
     - __kind: ArrayType
-      ID: 128
+      ID: 130
       Name: '[]val<float64>'
       ByteSize: 64
       Count: 8
       HasCount: true
       Element: 17 BaseType float64
     - __kind: ArrayType
-      ID: 126
+      ID: 128
       Name: '[]val<interface {}>'
       ByteSize: 128
       Count: 8
       HasCount: true
-      Element: 127 GoEmptyInterfaceType interface {}
+      Element: 129 GoEmptyInterfaceType interface {}
     - __kind: ArrayType
-      ID: 125
+      ID: 127
       Name: '[]val<string>'
       ByteSize: 128
       Count: 8
@@ -1324,43 +1324,43 @@ Types:
       GoRuntimeType: 543552
       GoKind: 1
     - __kind: GoHMapBucketType
-      ID: 133
+      ID: 135
       Name: bucket<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
       ByteSize: 208
       RawFields:
         - Name: tophash
           Offset: 0
-          Type: 100 ArrayType [8]uint8
+          Type: 102 ArrayType [8]uint8
         - Name: keys
           Offset: 8
-          Type: 101 ArrayType []key<string>
+          Type: 103 ArrayType []key<string>
         - Name: values
           Offset: 136
-          Type: 144 ArrayType []val<*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
+          Type: 158 ArrayType []val<*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
         - Name: overflow
           Offset: 200
-          Type: 132 PointerType *bucket<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
+          Type: 134 PointerType *bucket<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
       KeyType: 11 GoStringHeaderType string
-      ValueType: 145 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
+      ValueType: 159 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
     - __kind: GoHMapBucketType
-      ID: 112
+      ID: 114
       Name: bucket<string,[]*mime/multipart.FileHeader>
       ByteSize: 336
       RawFields:
         - Name: tophash
           Offset: 0
-          Type: 100 ArrayType [8]uint8
+          Type: 102 ArrayType [8]uint8
         - Name: keys
           Offset: 8
-          Type: 101 ArrayType []key<string>
+          Type: 103 ArrayType []key<string>
         - Name: values
           Offset: 136
-          Type: 139 ArrayType []val<[]*mime/multipart.FileHeader>
+          Type: 153 ArrayType []val<[]*mime/multipart.FileHeader>
         - Name: overflow
           Offset: 328
-          Type: 111 PointerType *bucket<string,[]*mime/multipart.FileHeader>
+          Type: 113 PointerType *bucket<string,[]*mime/multipart.FileHeader>
       KeyType: 11 GoStringHeaderType string
-      ValueType: 140 GoSliceHeaderType []*mime/multipart.FileHeader
+      ValueType: 154 GoSliceHeaderType []*mime/multipart.FileHeader
     - __kind: GoHMapBucketType
       ID: 51
       Name: bucket<string,[]string>
@@ -1368,13 +1368,13 @@ Types:
       RawFields:
         - Name: tophash
           Offset: 0
-          Type: 100 ArrayType [8]uint8
+          Type: 102 ArrayType [8]uint8
         - Name: keys
           Offset: 8
-          Type: 101 ArrayType []key<string>
+          Type: 103 ArrayType []key<string>
         - Name: values
           Offset: 136
-          Type: 102 ArrayType []val<[]string>
+          Type: 104 ArrayType []val<[]string>
         - Name: overflow
           Offset: 328
           Type: 50 PointerType *bucket<string,[]string>
@@ -1387,13 +1387,13 @@ Types:
       RawFields:
         - Name: tophash
           Offset: 0
-          Type: 100 ArrayType [8]uint8
+          Type: 102 ArrayType [8]uint8
         - Name: keys
           Offset: 8
-          Type: 101 ArrayType []key<string>
+          Type: 103 ArrayType []key<string>
         - Name: values
           Offset: 136
-          Type: 128 ArrayType []val<float64>
+          Type: 130 ArrayType []val<float64>
         - Name: overflow
           Offset: 200
           Type: 85 PointerType *bucket<string,float64>
@@ -1406,18 +1406,18 @@ Types:
       RawFields:
         - Name: tophash
           Offset: 0
-          Type: 100 ArrayType [8]uint8
+          Type: 102 ArrayType [8]uint8
         - Name: keys
           Offset: 8
-          Type: 101 ArrayType []key<string>
+          Type: 103 ArrayType []key<string>
         - Name: values
           Offset: 136
-          Type: 126 ArrayType []val<interface {}>
+          Type: 128 ArrayType []val<interface {}>
         - Name: overflow
           Offset: 264
           Type: 80 PointerType *bucket<string,interface {}>
       KeyType: 11 GoStringHeaderType string
-      ValueType: 127 GoEmptyInterfaceType interface {}
+      ValueType: 129 GoEmptyInterfaceType interface {}
     - __kind: GoHMapBucketType
       ID: 72
       Name: bucket<string,string>
@@ -1425,13 +1425,13 @@ Types:
       RawFields:
         - Name: tophash
           Offset: 0
-          Type: 100 ArrayType [8]uint8
+          Type: 102 ArrayType [8]uint8
         - Name: keys
           Offset: 8
-          Type: 101 ArrayType []key<string>
+          Type: 103 ArrayType []key<string>
         - Name: values
           Offset: 136
-          Type: 125 ArrayType []val<string>
+          Type: 127 ArrayType []val<string>
         - Name: overflow
           Offset: 264
           Type: 71 PointerType *bucket<string,string>
@@ -1529,13 +1529,13 @@ Types:
           Type: 11 GoStringHeaderType string
         - Name: PeerCertificates
           Offset: 48
-          Type: 113 GoSliceHeaderType []*crypto/x509.Certificate
+          Type: 115 GoSliceHeaderType []*crypto/x509.Certificate
         - Name: VerifiedChains
           Offset: 72
-          Type: 116 GoSliceHeaderType [][]*crypto/x509.Certificate
+          Type: 118 GoSliceHeaderType [][]*crypto/x509.Certificate
         - Name: SignedCertificateTimestamps
           Offset: 96
-          Type: 118 GoSliceHeaderType [][]uint8
+          Type: 120 GoSliceHeaderType [][]uint8
         - Name: OCSPResponse
           Offset: 120
           Type: 96 GoSliceHeaderType []uint8
@@ -1547,21 +1547,21 @@ Types:
           Type: 4 BaseType bool
         - Name: ekm
           Offset: 176
-          Type: 120 GoSubroutineType func(string, []uint8, int) ([]uint8, error)
+          Type: 122 GoSubroutineType func(string, []uint8, int) ([]uint8, error)
         - Name: testingOnlyDidHRR
           Offset: 184
           Type: 4 BaseType bool
         - Name: testingOnlyCurveID
           Offset: 186
-          Type: 121 BaseType crypto/tls.CurveID
+          Type: 123 BaseType crypto/tls.CurveID
     - __kind: BaseType
-      ID: 121
+      ID: 123
       Name: crypto/tls.CurveID
       ByteSize: 2
       GoRuntimeType: 778592
       GoKind: 9
     - __kind: StructureType
-      ID: 143
+      ID: 157
       Name: crypto/x509.Certificate
       ByteSize: 1352
       GoRuntimeType: 2.300992e+06
@@ -1587,49 +1587,49 @@ Types:
           Type: 96 GoSliceHeaderType []uint8
         - Name: SignatureAlgorithm
           Offset: 144
-          Type: 151 BaseType crypto/x509.SignatureAlgorithm
+          Type: 177 BaseType crypto/x509.SignatureAlgorithm
         - Name: PublicKeyAlgorithm
           Offset: 152
-          Type: 152 BaseType crypto/x509.PublicKeyAlgorithm
+          Type: 178 BaseType crypto/x509.PublicKeyAlgorithm
         - Name: PublicKey
           Offset: 160
-          Type: 127 GoEmptyInterfaceType interface {}
+          Type: 129 GoEmptyInterfaceType interface {}
         - Name: Version
           Offset: 176
           Type: 9 BaseType int
         - Name: SerialNumber
           Offset: 184
-          Type: 153 PointerType *math/big.Int
+          Type: 179 PointerType *math/big.Int
         - Name: Issuer
           Offset: 192
-          Type: 155 StructureType crypto/x509/pkix.Name
+          Type: 181 StructureType crypto/x509/pkix.Name
         - Name: Subject
           Offset: 440
-          Type: 155 StructureType crypto/x509/pkix.Name
+          Type: 181 StructureType crypto/x509/pkix.Name
         - Name: NotBefore
           Offset: 688
-          Type: 159 StructureType time.Time
+          Type: 185 StructureType time.Time
         - Name: NotAfter
           Offset: 712
-          Type: 159 StructureType time.Time
+          Type: 185 StructureType time.Time
         - Name: KeyUsage
           Offset: 736
-          Type: 162 BaseType crypto/x509.KeyUsage
+          Type: 188 BaseType crypto/x509.KeyUsage
         - Name: Extensions
           Offset: 744
-          Type: 163 GoSliceHeaderType []crypto/x509/pkix.Extension
+          Type: 189 GoSliceHeaderType []crypto/x509/pkix.Extension
         - Name: ExtraExtensions
           Offset: 768
-          Type: 163 GoSliceHeaderType []crypto/x509/pkix.Extension
+          Type: 189 GoSliceHeaderType []crypto/x509/pkix.Extension
         - Name: UnhandledCriticalExtensions
           Offset: 792
-          Type: 166 GoSliceHeaderType []encoding/asn1.ObjectIdentifier
+          Type: 192 GoSliceHeaderType []encoding/asn1.ObjectIdentifier
         - Name: ExtKeyUsage
           Offset: 816
-          Type: 169 GoSliceHeaderType []crypto/x509.ExtKeyUsage
+          Type: 195 GoSliceHeaderType []crypto/x509.ExtKeyUsage
         - Name: UnknownExtKeyUsage
           Offset: 840
-          Type: 166 GoSliceHeaderType []encoding/asn1.ObjectIdentifier
+          Type: 192 GoSliceHeaderType []encoding/asn1.ObjectIdentifier
         - Name: BasicConstraintsValid
           Offset: 864
           Type: 4 BaseType bool
@@ -1662,10 +1662,10 @@ Types:
           Type: 56 GoSliceHeaderType []string
         - Name: IPAddresses
           Offset: 1032
-          Type: 172 GoSliceHeaderType []net.IP
+          Type: 198 GoSliceHeaderType []net.IP
         - Name: URIs
           Offset: 1056
-          Type: 175 GoSliceHeaderType []*net/url.URL
+          Type: 201 GoSliceHeaderType []*net/url.URL
         - Name: PermittedDNSDomainsCritical
           Offset: 1080
           Type: 4 BaseType bool
@@ -1677,10 +1677,10 @@ Types:
           Type: 56 GoSliceHeaderType []string
         - Name: PermittedIPRanges
           Offset: 1136
-          Type: 177 GoSliceHeaderType []*net.IPNet
+          Type: 203 GoSliceHeaderType []*net.IPNet
         - Name: ExcludedIPRanges
           Offset: 1160
-          Type: 177 GoSliceHeaderType []*net.IPNet
+          Type: 203 GoSliceHeaderType []*net.IPNet
         - Name: PermittedEmailAddresses
           Offset: 1184
           Type: 56 GoSliceHeaderType []string
@@ -1698,24 +1698,24 @@ Types:
           Type: 56 GoSliceHeaderType []string
         - Name: PolicyIdentifiers
           Offset: 1304
-          Type: 166 GoSliceHeaderType []encoding/asn1.ObjectIdentifier
+          Type: 192 GoSliceHeaderType []encoding/asn1.ObjectIdentifier
         - Name: Policies
           Offset: 1328
-          Type: 180 GoSliceHeaderType []crypto/x509.OID
+          Type: 206 GoSliceHeaderType []crypto/x509.OID
     - __kind: BaseType
-      ID: 171
+      ID: 197
       Name: crypto/x509.ExtKeyUsage
       ByteSize: 8
       GoRuntimeType: 546624
       GoKind: 2
     - __kind: BaseType
-      ID: 162
+      ID: 188
       Name: crypto/x509.KeyUsage
       ByteSize: 8
       GoRuntimeType: 546560
       GoKind: 2
     - __kind: StructureType
-      ID: 182
+      ID: 208
       Name: crypto/x509.OID
       ByteSize: 24
       GoRuntimeType: 1.762592e+06
@@ -1725,19 +1725,19 @@ Types:
           Offset: 0
           Type: 96 GoSliceHeaderType []uint8
     - __kind: BaseType
-      ID: 152
+      ID: 178
       Name: crypto/x509.PublicKeyAlgorithm
       ByteSize: 8
       GoRuntimeType: 780896
       GoKind: 2
     - __kind: BaseType
-      ID: 151
+      ID: 177
       Name: crypto/x509.SignatureAlgorithm
       ByteSize: 8
       GoRuntimeType: 1.09744e+06
       GoKind: 2
     - __kind: StructureType
-      ID: 158
+      ID: 184
       Name: crypto/x509/pkix.AttributeTypeAndValue
       ByteSize: 40
       GoRuntimeType: 1.349408e+06
@@ -1745,12 +1745,12 @@ Types:
       RawFields:
         - Name: Type
           Offset: 0
-          Type: 168 GoSliceHeaderType encoding/asn1.ObjectIdentifier
+          Type: 194 GoSliceHeaderType encoding/asn1.ObjectIdentifier
         - Name: Value
           Offset: 24
-          Type: 127 GoEmptyInterfaceType interface {}
+          Type: 129 GoEmptyInterfaceType interface {}
     - __kind: StructureType
-      ID: 165
+      ID: 191
       Name: crypto/x509/pkix.Extension
       ByteSize: 56
       GoRuntimeType: 1.494976e+06
@@ -1758,7 +1758,7 @@ Types:
       RawFields:
         - Name: Id
           Offset: 0
-          Type: 168 GoSliceHeaderType encoding/asn1.ObjectIdentifier
+          Type: 194 GoSliceHeaderType encoding/asn1.ObjectIdentifier
         - Name: Critical
           Offset: 24
           Type: 4 BaseType bool
@@ -1766,7 +1766,7 @@ Types:
           Offset: 32
           Type: 96 GoSliceHeaderType []uint8
     - __kind: StructureType
-      ID: 155
+      ID: 181
       Name: crypto/x509/pkix.Name
       ByteSize: 248
       GoRuntimeType: 2.105696e+06
@@ -1801,12 +1801,12 @@ Types:
           Type: 11 GoStringHeaderType string
         - Name: Names
           Offset: 200
-          Type: 156 GoSliceHeaderType []crypto/x509/pkix.AttributeTypeAndValue
+          Type: 182 GoSliceHeaderType []crypto/x509/pkix.AttributeTypeAndValue
         - Name: ExtraNames
           Offset: 224
-          Type: 156 GoSliceHeaderType []crypto/x509/pkix.AttributeTypeAndValue
+          Type: 182 GoSliceHeaderType []crypto/x509/pkix.AttributeTypeAndValue
     - __kind: GoSliceHeaderType
-      ID: 168
+      ID: 194
       Name: encoding/asn1.ObjectIdentifier
       ByteSize: 24
       GoRuntimeType: 1.0376e+06
@@ -1821,9 +1821,9 @@ Types:
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 239 GoSliceDataType encoding/asn1.ObjectIdentifier.array
+      Data: 236 GoSliceDataType encoding/asn1.ObjectIdentifier.array
     - __kind: GoSliceDataType
-      ID: 239
+      ID: 236
       Name: encoding/asn1.ObjectIdentifier.array
       ByteSize: 2048
       Element: 9 BaseType int
@@ -1865,7 +1865,7 @@ Types:
       GoRuntimeType: 645600
       GoKind: 19
     - __kind: GoSubroutineType
-      ID: 120
+      ID: 122
       Name: func(string, []uint8, int) ([]uint8, error)
       ByteSize: 8
       GoRuntimeType: 983200
@@ -1964,7 +1964,7 @@ Types:
           Type: 4 BaseType bool
         - Name: trace
           Offset: 8
-          Type: 135 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.trace
+          Type: 137 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.trace
         - Name: span
           Offset: 16
           Type: 39 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span
@@ -1979,7 +1979,7 @@ Types:
           Type: 4 BaseType bool
         - Name: traceID
           Offset: 49
-          Type: 137 ArrayType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.traceID
+          Type: 139 ArrayType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.traceID
         - Name: spanID
           Offset: 72
           Type: 10 BaseType uint64
@@ -2034,7 +2034,7 @@ Types:
       GoKind: 21
       HeaderType: 79 GoHMapHeaderType hash<string,interface {}>
     - __kind: BaseType
-      ID: 149
+      ID: 163
       Name: github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.samplingDecision
       ByteSize: 4
       GoRuntimeType: 542336
@@ -2054,12 +2054,12 @@ Types:
           Type: 10 BaseType uint64
         - Name: Attributes
           Offset: 24
-          Type: 129 GoMapType map[string]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
+          Type: 131 GoMapType map[string]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
         - Name: RawAttributes
           Offset: 32
-          Type: 134 GoMapType map[string]interface {}
+          Type: 136 GoMapType map[string]interface {}
     - __kind: StructureType
-      ID: 185
+      ID: 211
       Name: github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttribute
       ByteSize: 24
       GoRuntimeType: 1.13008e+06
@@ -2067,9 +2067,9 @@ Types:
       RawFields:
         - Name: Values
           Offset: 0
-          Type: 197 GoSliceHeaderType []*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttributeValue
+          Type: 227 GoSliceHeaderType []*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttributeValue
     - __kind: StructureType
-      ID: 201
+      ID: 251
       Name: github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttributeValue
       ByteSize: 48
       GoRuntimeType: 1.74848e+06
@@ -2077,7 +2077,7 @@ Types:
       RawFields:
         - Name: Type
           Offset: 0
-          Type: 202 BaseType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttributeValueType
+          Type: 260 BaseType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttributeValueType
         - Name: StringValue
           Offset: 8
           Type: 11 GoStringHeaderType string
@@ -2091,13 +2091,13 @@ Types:
           Offset: 40
           Type: 17 BaseType float64
     - __kind: BaseType
-      ID: 202
+      ID: 260
       Name: github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttributeValueType
       ByteSize: 4
       GoRuntimeType: 965344
       GoKind: 5
     - __kind: StructureType
-      ID: 146
+      ID: 160
       Name: github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
       ByteSize: 56
       GoRuntimeType: 1.822848e+06
@@ -2105,7 +2105,7 @@ Types:
       RawFields:
         - Name: Type
           Offset: 0
-          Type: 183 BaseType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttributeType
+          Type: 209 BaseType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttributeType
         - Name: StringValue
           Offset: 8
           Type: 11 GoStringHeaderType string
@@ -2120,15 +2120,15 @@ Types:
           Type: 17 BaseType float64
         - Name: ArrayValue
           Offset: 48
-          Type: 184 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttribute
+          Type: 210 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttribute
     - __kind: BaseType
-      ID: 183
+      ID: 209
       Name: github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttributeType
       ByteSize: 4
       GoRuntimeType: 965248
       GoKind: 5
     - __kind: StructureType
-      ID: 136
+      ID: 138
       Name: github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.trace
       ByteSize: 104
       GoRuntimeType: 2.017536e+06
@@ -2139,7 +2139,7 @@ Types:
           Type: 73 StructureType sync.RWMutex
         - Name: spans
           Offset: 24
-          Type: 147 GoSliceHeaderType []*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span
+          Type: 161 GoSliceHeaderType []*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span
         - Name: tags
           Offset: 48
           Type: 68 GoMapType map[string]string
@@ -2160,12 +2160,12 @@ Types:
           Type: 4 BaseType bool
         - Name: samplingDecision
           Offset: 92
-          Type: 149 BaseType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.samplingDecision
+          Type: 163 BaseType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.samplingDecision
         - Name: root
           Offset: 96
           Type: 39 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span
     - __kind: ArrayType
-      ID: 137
+      ID: 139
       Name: github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.traceID
       ByteSize: 16
       GoRuntimeType: 847712
@@ -2174,7 +2174,7 @@ Types:
       HasCount: true
       Element: 3 BaseType uint8
     - __kind: GoHMapHeaderType
-      ID: 131
+      ID: 133
       Name: hash<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
       ByteSize: 48
       RawFields:
@@ -2195,20 +2195,20 @@ Types:
           Type: 2 BaseType uint32
         - Name: buckets
           Offset: 16
-          Type: 132 PointerType *bucket<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
+          Type: 134 PointerType *bucket<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
         - Name: oldbuckets
           Offset: 24
-          Type: 132 PointerType *bucket<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
+          Type: 134 PointerType *bucket<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
         - Name: nevacuate
           Offset: 32
           Type: 1 BaseType uintptr
         - Name: extra
           Offset: 40
           Type: 52 PointerType *runtime.mapextra
-      BucketType: 133 GoHMapBucketType bucket<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
-      BucketsType: 228 GoSliceDataType []bucket<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>.array
+      BucketType: 135 GoHMapBucketType bucket<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
+      BucketsType: 175 GoSliceDataType []bucket<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>.array
     - __kind: GoHMapHeaderType
-      ID: 110
+      ID: 112
       Name: hash<string,[]*mime/multipart.FileHeader>
       ByteSize: 48
       RawFields:
@@ -2229,18 +2229,18 @@ Types:
           Type: 2 BaseType uint32
         - Name: buckets
           Offset: 16
-          Type: 111 PointerType *bucket<string,[]*mime/multipart.FileHeader>
+          Type: 113 PointerType *bucket<string,[]*mime/multipart.FileHeader>
         - Name: oldbuckets
           Offset: 24
-          Type: 111 PointerType *bucket<string,[]*mime/multipart.FileHeader>
+          Type: 113 PointerType *bucket<string,[]*mime/multipart.FileHeader>
         - Name: nevacuate
           Offset: 32
           Type: 1 BaseType uintptr
         - Name: extra
           Offset: 40
           Type: 52 PointerType *runtime.mapextra
-      BucketType: 112 GoHMapBucketType bucket<string,[]*mime/multipart.FileHeader>
-      BucketsType: 219 GoSliceDataType []bucket<string,[]*mime/multipart.FileHeader>.array
+      BucketType: 114 GoHMapBucketType bucket<string,[]*mime/multipart.FileHeader>
+      BucketsType: 166 GoSliceDataType []bucket<string,[]*mime/multipart.FileHeader>.array
     - __kind: GoHMapHeaderType
       ID: 49
       Name: hash<string,[]string>
@@ -2274,7 +2274,7 @@ Types:
           Offset: 40
           Type: 52 PointerType *runtime.mapextra
       BucketType: 51 GoHMapBucketType bucket<string,[]string>
-      BucketsType: 205 GoSliceDataType []bucket<string,[]string>.array
+      BucketsType: 140 GoSliceDataType []bucket<string,[]string>.array
     - __kind: GoHMapHeaderType
       ID: 84
       Name: hash<string,float64>
@@ -2308,7 +2308,7 @@ Types:
           Offset: 40
           Type: 52 PointerType *runtime.mapextra
       BucketType: 86 GoHMapBucketType bucket<string,float64>
-      BucketsType: 210 GoSliceDataType []bucket<string,float64>.array
+      BucketsType: 145 GoSliceDataType []bucket<string,float64>.array
     - __kind: GoHMapHeaderType
       ID: 79
       Name: hash<string,interface {}>
@@ -2342,7 +2342,7 @@ Types:
           Offset: 40
           Type: 52 PointerType *runtime.mapextra
       BucketType: 81 GoHMapBucketType bucket<string,interface {}>
-      BucketsType: 209 GoSliceDataType []bucket<string,interface {}>.array
+      BucketsType: 144 GoSliceDataType []bucket<string,interface {}>.array
     - __kind: GoHMapHeaderType
       ID: 70
       Name: hash<string,string>
@@ -2376,7 +2376,7 @@ Types:
           Offset: 40
           Type: 52 PointerType *runtime.mapextra
       BucketType: 72 GoHMapBucketType bucket<string,string>
-      BucketsType: 208 GoSliceDataType []bucket<string,string>.array
+      BucketsType: 143 GoSliceDataType []bucket<string,string>.array
     - __kind: BaseType
       ID: 9
       Name: int
@@ -2408,7 +2408,7 @@ Types:
       GoRuntimeType: 542592
       GoKind: 3
     - __kind: GoEmptyInterfaceType
-      ID: 127
+      ID: 129
       Name: interface {}
       ByteSize: 16
       GoRuntimeType: 798016
@@ -2434,21 +2434,21 @@ Types:
           Offset: 8
           Type: 19 VoidPointerType unsafe.Pointer
     - __kind: GoMapType
-      ID: 129
+      ID: 131
       Name: map[string]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
       ByteSize: 8
       GoRuntimeType: 905120
       GoKind: 21
-      HeaderType: 131 GoHMapHeaderType hash<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
+      HeaderType: 133 GoHMapHeaderType hash<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
     - __kind: GoMapType
-      ID: 108
+      ID: 110
       Name: map[string][]*mime/multipart.FileHeader
       ByteSize: 8
       GoRuntimeType: 904160
       GoKind: 21
-      HeaderType: 110 GoHMapHeaderType hash<string,[]*mime/multipart.FileHeader>
+      HeaderType: 112 GoHMapHeaderType hash<string,[]*mime/multipart.FileHeader>
     - __kind: GoMapType
-      ID: 107
+      ID: 109
       Name: map[string][]string
       ByteSize: 8
       GoRuntimeType: 899360
@@ -2462,7 +2462,7 @@ Types:
       GoKind: 21
       HeaderType: 84 GoHMapHeaderType hash<string,float64>
     - __kind: GoMapType
-      ID: 134
+      ID: 136
       Name: map[string]interface {}
       ByteSize: 8
       GoRuntimeType: 896480
@@ -2476,7 +2476,7 @@ Types:
       GoKind: 21
       HeaderType: 70 GoHMapHeaderType hash<string,string>
     - __kind: StructureType
-      ID: 154
+      ID: 180
       Name: math/big.Int
       ByteSize: 32
       GoRuntimeType: 1.340768e+06
@@ -2487,15 +2487,15 @@ Types:
           Type: 4 BaseType bool
         - Name: abs
           Offset: 8
-          Type: 187 GoSliceHeaderType math/big.nat
+          Type: 217 GoSliceHeaderType math/big.nat
     - __kind: BaseType
-      ID: 189
+      ID: 219
       Name: math/big.Word
       ByteSize: 8
       GoRuntimeType: 546880
       GoKind: 7
     - __kind: GoSliceHeaderType
-      ID: 187
+      ID: 217
       Name: math/big.nat
       ByteSize: 24
       GoRuntimeType: 2.280544e+06
@@ -2503,21 +2503,21 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 188 PointerType *math/big.Word
+          Type: 218 PointerType *math/big.Word
         - Name: len
           Offset: 8
           Type: 9 BaseType int
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 253 GoSliceDataType math/big.nat.array
+      Data: 252 GoSliceDataType math/big.nat.array
     - __kind: GoSliceDataType
-      ID: 253
+      ID: 252
       Name: math/big.nat.array
       ByteSize: 2048
-      Element: 189 BaseType math/big.Word
+      Element: 219 BaseType math/big.Word
     - __kind: StructureType
-      ID: 150
+      ID: 176
       Name: mime/multipart.FileHeader
       ByteSize: 88
       GoRuntimeType: 1.881696e+06
@@ -2528,7 +2528,7 @@ Types:
           Type: 11 GoStringHeaderType string
         - Name: Header
           Offset: 16
-          Type: 186 GoMapType net/textproto.MIMEHeader
+          Type: 216 GoMapType net/textproto.MIMEHeader
         - Name: Size
           Offset: 24
           Type: 14 BaseType int64
@@ -2553,12 +2553,12 @@ Types:
       RawFields:
         - Name: Value
           Offset: 0
-          Type: 107 GoMapType map[string][]string
+          Type: 109 GoMapType map[string][]string
         - Name: File
           Offset: 8
-          Type: 108 GoMapType map[string][]*mime/multipart.FileHeader
+          Type: 110 GoMapType map[string][]*mime/multipart.FileHeader
     - __kind: GoSliceHeaderType
-      ID: 174
+      ID: 200
       Name: net.IP
       ByteSize: 24
       GoRuntimeType: 2.00144e+06
@@ -2573,14 +2573,14 @@ Types:
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 245 GoSliceDataType net.IP.array
+      Data: 242 GoSliceDataType net.IP.array
     - __kind: GoSliceDataType
-      ID: 245
+      ID: 242
       Name: net.IP.array
       ByteSize: 2048
       Element: 3 BaseType uint8
     - __kind: GoSliceHeaderType
-      ID: 200
+      ID: 250
       Name: net.IPMask
       ByteSize: 24
       GoRuntimeType: 999456
@@ -2602,7 +2602,7 @@ Types:
       ByteSize: 2048
       Element: 3 BaseType uint8
     - __kind: StructureType
-      ID: 196
+      ID: 226
       Name: net.IPNet
       ByteSize: 48
       GoRuntimeType: 1.307168e+06
@@ -2610,10 +2610,10 @@ Types:
       RawFields:
         - Name: IP
           Offset: 0
-          Type: 174 GoSliceHeaderType net.IP
+          Type: 200 GoSliceHeaderType net.IP
         - Name: Mask
           Offset: 24
-          Type: 200 GoSliceHeaderType net.IPMask
+          Type: 250 GoSliceHeaderType net.IPMask
     - __kind: GoMapType
       ID: 47
       Name: net/http.Header
@@ -2786,12 +2786,12 @@ Types:
           Type: 11 GoStringHeaderType string
         - Name: segments
           Offset: 48
-          Type: 122 GoSliceHeaderType []net/http.segment
+          Type: 124 GoSliceHeaderType []net/http.segment
         - Name: loc
           Offset: 72
           Type: 11 GoStringHeaderType string
     - __kind: StructureType
-      ID: 124
+      ID: 126
       Name: net/http.segment
       ByteSize: 24
       GoRuntimeType: 1.453312e+06
@@ -2807,7 +2807,7 @@ Types:
           Offset: 17
           Type: 4 BaseType bool
     - __kind: GoMapType
-      ID: 186
+      ID: 216
       Name: net/textproto.MIMEHeader
       ByteSize: 8
       GoRuntimeType: 1.63792e+06
@@ -2828,7 +2828,7 @@ Types:
           Type: 11 GoStringHeaderType string
         - Name: User
           Offset: 32
-          Type: 98 PointerType *net/url.Userinfo
+          Type: 100 PointerType *net/url.Userinfo
         - Name: Host
           Offset: 40
           Type: 11 GoStringHeaderType string
@@ -2854,7 +2854,7 @@ Types:
           Offset: 128
           Type: 11 GoStringHeaderType string
     - __kind: StructureType
-      ID: 99
+      ID: 101
       Name: net/url.Userinfo
       ByteSize: 40
       GoRuntimeType: 1.469632e+06
@@ -2877,7 +2877,7 @@ Types:
       GoKind: 21
       HeaderType: 49 GoHMapHeaderType hash<string,[]string>
     - __kind: StructureType
-      ID: 106
+      ID: 108
       Name: runtime.bmap
       ByteSize: 8
       GoRuntimeType: 1.13712e+06
@@ -2885,7 +2885,7 @@ Types:
       RawFields:
         - Name: tophash
           Offset: 0
-          Type: 100 ArrayType [8]uint8
+          Type: 102 ArrayType [8]uint8
     - __kind: StructureType
       ID: 53
       Name: runtime.mapextra
@@ -2895,13 +2895,13 @@ Types:
       RawFields:
         - Name: overflow
           Offset: 0
-          Type: 103 PointerType *[]*runtime.bmap
+          Type: 105 PointerType *[]*runtime.bmap
         - Name: oldoverflow
           Offset: 8
-          Type: 103 PointerType *[]*runtime.bmap
+          Type: 105 PointerType *[]*runtime.bmap
         - Name: nextOverflow
           Offset: 16
-          Type: 105 PointerType *runtime.bmap
+          Type: 107 PointerType *runtime.bmap
     - __kind: GoStringHeaderType
       ID: 11
       Name: string
@@ -2911,13 +2911,13 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 204 PointerType *string.str
+          Type: 99 PointerType *string.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 203 GoStringDataType string.str
+      Data: 98 GoStringDataType string.str
     - __kind: GoStringDataType
-      ID: 203
+      ID: 98
       Name: string.str
       ByteSize: 2048
     - __kind: StructureType
@@ -2975,7 +2975,7 @@ Types:
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 161
+      ID: 187
       Name: time.Location
       ByteSize: 104
       GoRuntimeType: 1.877952e+06
@@ -2986,10 +2986,10 @@ Types:
           Type: 11 GoStringHeaderType string
         - Name: zone
           Offset: 16
-          Type: 190 GoSliceHeaderType []time.zone
+          Type: 220 GoSliceHeaderType []time.zone
         - Name: tx
           Offset: 40
-          Type: 193 GoSliceHeaderType []time.zoneTrans
+          Type: 223 GoSliceHeaderType []time.zoneTrans
         - Name: extend
           Offset: 64
           Type: 11 GoStringHeaderType string
@@ -3001,9 +3001,9 @@ Types:
           Type: 14 BaseType int64
         - Name: cacheZone
           Offset: 96
-          Type: 191 PointerType *time.zone
+          Type: 221 PointerType *time.zone
     - __kind: StructureType
-      ID: 159
+      ID: 185
       Name: time.Time
       ByteSize: 24
       GoRuntimeType: 2.281472e+06
@@ -3017,9 +3017,9 @@ Types:
           Type: 14 BaseType int64
         - Name: loc
           Offset: 16
-          Type: 160 PointerType *time.Location
+          Type: 186 PointerType *time.Location
     - __kind: StructureType
-      ID: 192
+      ID: 222
       Name: time.zone
       ByteSize: 32
       GoRuntimeType: 1.458304e+06
@@ -3035,7 +3035,7 @@ Types:
           Offset: 24
           Type: 4 BaseType bool
     - __kind: StructureType
-      ID: 195
+      ID: 225
       Name: time.zoneTrans
       ByteSize: 16
       GoRuntimeType: 1.664192e+06

--- a/pkg/dyninst/irgen/testdata/snapshot/rc_tester.arch=arm64,toolchain=go1.23.11.yaml
+++ b/pkg/dyninst/irgen/testdata/snapshot/rc_tester.arch=arm64,toolchain=go1.23.11.yaml
@@ -104,25 +104,472 @@ Subprograms:
           IsParameter: true
           IsReturn: false
 Types:
-    - __kind: GoInterfaceType
-      ID: 1
-      Name: net/http.ResponseWriter
-      ByteSize: 16
-      GoRuntimeType: 1.125472e+06
-      GoKind: 20
-      RawFields:
-        - Name: tab
-          Offset: 0
-          Type: 2 VoidPointerType unsafe.Pointer
-        - Name: data
-          Offset: 8
-          Type: 2 VoidPointerType unsafe.Pointer
-    - __kind: VoidPointerType
-      ID: 2
-      Name: unsafe.Pointer
+    - __kind: PointerType
+      ID: 56
+      Name: '**crypto/x509.Certificate'
       ByteSize: 8
-      GoRuntimeType: 543616
-      GoKind: 26
+      Pointee: 57 PointerType *crypto/x509.Certificate
+    - __kind: PointerType
+      ID: 174
+      Name: '**github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span'
+      ByteSize: 8
+      GoKind: 22
+      Pointee: 126 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span
+    - __kind: PointerType
+      ID: 164
+      Name: '**github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttributeValue'
+      ByteSize: 8
+      GoKind: 22
+      Pointee: 165 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttributeValue
+    - __kind: PointerType
+      ID: 48
+      Name: '**mime/multipart.FileHeader'
+      ByteSize: 8
+      GoKind: 22
+      Pointee: 49 PointerType *mime/multipart.FileHeader
+    - __kind: PointerType
+      ID: 98
+      Name: '**net.IPNet'
+      ByteSize: 8
+      GoKind: 22
+      Pointee: 99 PointerType *net.IPNet
+    - __kind: PointerType
+      ID: 96
+      Name: '**net/url.URL'
+      ByteSize: 8
+      Pointee: 9 PointerType *net/url.URL
+    - __kind: PointerType
+      ID: 31
+      Name: '**runtime.bmap'
+      ByteSize: 8
+      Pointee: 32 PointerType *runtime.bmap
+    - __kind: PointerType
+      ID: 106
+      Name: '*[]*crypto/x509.Certificate'
+      ByteSize: 8
+      GoKind: 22
+      Pointee: 55 GoSliceHeaderType []*crypto/x509.Certificate
+    - __kind: PointerType
+      ID: 216
+      Name: '*[]*crypto/x509.Certificate.array'
+      ByteSize: 8
+      Pointee: 215 GoSliceDataType []*crypto/x509.Certificate.array
+    - __kind: PointerType
+      ID: 262
+      Name: '*[]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span.array'
+      ByteSize: 8
+      Pointee: 261 GoSliceDataType []*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span.array
+    - __kind: PointerType
+      ID: 260
+      Name: '*[]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttributeValue.array'
+      ByteSize: 8
+      Pointee: 259 GoSliceDataType []*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttributeValue.array
+    - __kind: PointerType
+      ID: 212
+      Name: '*[]*mime/multipart.FileHeader.array'
+      ByteSize: 8
+      Pointee: 211 GoSliceDataType []*mime/multipart.FileHeader.array
+    - __kind: PointerType
+      ID: 240
+      Name: '*[]*net.IPNet.array'
+      ByteSize: 8
+      Pointee: 239 GoSliceDataType []*net.IPNet.array
+    - __kind: PointerType
+      ID: 238
+      Name: '*[]*net/url.URL.array'
+      ByteSize: 8
+      Pointee: 237 GoSliceDataType []*net/url.URL.array
+    - __kind: PointerType
+      ID: 29
+      Name: '*[]*runtime.bmap'
+      ByteSize: 8
+      GoRuntimeType: 470816
+      GoKind: 22
+      Pointee: 30 GoSliceHeaderType []*runtime.bmap
+    - __kind: PointerType
+      ID: 209
+      Name: '*[]*runtime.bmap.array'
+      ByteSize: 8
+      Pointee: 208 GoSliceDataType []*runtime.bmap.array
+    - __kind: PointerType
+      ID: 246
+      Name: '*[][]*crypto/x509.Certificate.array'
+      ByteSize: 8
+      Pointee: 245 GoSliceDataType [][]*crypto/x509.Certificate.array
+    - __kind: PointerType
+      ID: 248
+      Name: '*[][]uint8.array'
+      ByteSize: 8
+      Pointee: 247 GoSliceDataType [][]uint8.array
+    - __kind: PointerType
+      ID: 232
+      Name: '*[]crypto/x509.ExtKeyUsage.array'
+      ByteSize: 8
+      Pointee: 231 GoSliceDataType []crypto/x509.ExtKeyUsage.array
+    - __kind: PointerType
+      ID: 244
+      Name: '*[]crypto/x509.OID.array'
+      ByteSize: 8
+      Pointee: 243 GoSliceDataType []crypto/x509.OID.array
+    - __kind: PointerType
+      ID: 220
+      Name: '*[]crypto/x509/pkix.AttributeTypeAndValue.array'
+      ByteSize: 8
+      Pointee: 219 GoSliceDataType []crypto/x509/pkix.AttributeTypeAndValue.array
+    - __kind: PointerType
+      ID: 228
+      Name: '*[]crypto/x509/pkix.Extension.array'
+      ByteSize: 8
+      Pointee: 227 GoSliceDataType []crypto/x509/pkix.Extension.array
+    - __kind: PointerType
+      ID: 230
+      Name: '*[]encoding/asn1.ObjectIdentifier.array'
+      ByteSize: 8
+      Pointee: 229 GoSliceDataType []encoding/asn1.ObjectIdentifier.array
+    - __kind: PointerType
+      ID: 255
+      Name: '*[]github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink.array'
+      ByteSize: 8
+      Pointee: 254 GoSliceDataType []github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink.array
+    - __kind: PointerType
+      ID: 257
+      Name: '*[]github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent.array'
+      ByteSize: 8
+      Pointee: 256 GoSliceDataType []github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent.array
+    - __kind: PointerType
+      ID: 234
+      Name: '*[]net.IP.array'
+      ByteSize: 8
+      Pointee: 233 GoSliceDataType []net.IP.array
+    - __kind: PointerType
+      ID: 250
+      Name: '*[]net/http.segment.array'
+      ByteSize: 8
+      Pointee: 249 GoSliceDataType []net/http.segment.array
+    - __kind: PointerType
+      ID: 207
+      Name: '*[]string.array'
+      ByteSize: 8
+      Pointee: 206 GoSliceDataType []string.array
+    - __kind: PointerType
+      ID: 224
+      Name: '*[]time.zone.array'
+      ByteSize: 8
+      Pointee: 223 GoSliceDataType []time.zone.array
+    - __kind: PointerType
+      ID: 226
+      Name: '*[]time.zoneTrans.array'
+      ByteSize: 8
+      Pointee: 225 GoSliceDataType []time.zoneTrans.array
+    - __kind: PointerType
+      ID: 108
+      Name: '*[]uint8'
+      ByteSize: 8
+      GoRuntimeType: 456928
+      GoKind: 22
+      Pointee: 52 GoSliceHeaderType []uint8
+    - __kind: PointerType
+      ID: 214
+      Name: '*[]uint8.array'
+      ByteSize: 8
+      Pointee: 213 GoSliceDataType []uint8.array
+    - __kind: PointerType
+      ID: 184
+      Name: '*bool'
+      ByteSize: 8
+      GoRuntimeType: 377120
+      GoKind: 22
+      Pointee: 13 BaseType bool
+    - __kind: PointerType
+      ID: 155
+      Name: '*bucket<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>'
+      ByteSize: 8
+      Pointee: 156 GoHMapBucketType bucket<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
+    - __kind: PointerType
+      ID: 44
+      Name: '*bucket<string,[]*mime/multipart.FileHeader>'
+      ByteSize: 8
+      Pointee: 45 GoHMapBucketType bucket<string,[]*mime/multipart.FileHeader>
+    - __kind: PointerType
+      ID: 19
+      Name: '*bucket<string,[]string>'
+      ByteSize: 8
+      Pointee: 20 GoHMapBucketType bucket<string,[]string>
+    - __kind: PointerType
+      ID: 142
+      Name: '*bucket<string,float64>'
+      ByteSize: 8
+      Pointee: 143 GoHMapBucketType bucket<string,float64>
+    - __kind: PointerType
+      ID: 136
+      Name: '*bucket<string,interface {}>'
+      ByteSize: 8
+      Pointee: 137 GoHMapBucketType bucket<string,interface {}>
+    - __kind: PointerType
+      ID: 123
+      Name: '*bucket<string,string>'
+      ByteSize: 8
+      Pointee: 124 GoHMapBucketType bucket<string,string>
+    - __kind: PointerType
+      ID: 179
+      Name: '*bytes.Buffer'
+      ByteSize: 8
+      GoRuntimeType: 2.176896e+06
+      GoKind: 22
+      Pointee: 180 StructureType bytes.Buffer
+    - __kind: PointerType
+      ID: 53
+      Name: '*crypto/tls.ConnectionState'
+      ByteSize: 8
+      GoRuntimeType: 852320
+      GoKind: 22
+      Pointee: 54 StructureType crypto/tls.ConnectionState
+    - __kind: PointerType
+      ID: 57
+      Name: '*crypto/x509.Certificate'
+      ByteSize: 8
+      GoRuntimeType: 1.95344e+06
+      GoKind: 22
+      Pointee: 58 StructureType crypto/x509.Certificate
+    - __kind: PointerType
+      ID: 90
+      Name: '*crypto/x509.ExtKeyUsage'
+      ByteSize: 8
+      GoRuntimeType: 400736
+      GoKind: 22
+      Pointee: 91 BaseType crypto/x509.ExtKeyUsage
+    - __kind: PointerType
+      ID: 103
+      Name: '*crypto/x509.OID'
+      ByteSize: 8
+      GoRuntimeType: 1.762368e+06
+      GoKind: 22
+      Pointee: 104 StructureType crypto/x509.OID
+    - __kind: PointerType
+      ID: 69
+      Name: '*crypto/x509/pkix.AttributeTypeAndValue'
+      ByteSize: 8
+      GoRuntimeType: 417504
+      GoKind: 22
+      Pointee: 70 StructureType crypto/x509/pkix.AttributeTypeAndValue
+    - __kind: PointerType
+      ID: 85
+      Name: '*crypto/x509/pkix.Extension'
+      ByteSize: 8
+      GoRuntimeType: 417696
+      GoKind: 22
+      Pointee: 86 StructureType crypto/x509/pkix.Extension
+    - __kind: PointerType
+      ID: 88
+      Name: '*encoding/asn1.ObjectIdentifier'
+      ByteSize: 8
+      GoRuntimeType: 1.037472e+06
+      GoKind: 22
+      Pointee: 71 GoSliceHeaderType encoding/asn1.ObjectIdentifier
+    - __kind: PointerType
+      ID: 222
+      Name: '*encoding/asn1.ObjectIdentifier.array'
+      ByteSize: 8
+      Pointee: 221 GoSliceDataType encoding/asn1.ObjectIdentifier.array
+    - __kind: PointerType
+      ID: 200
+      Name: '*error'
+      ByteSize: 8
+      GoRuntimeType: 376032
+      GoKind: 22
+      Pointee: 189 GoInterfaceType error
+    - __kind: PointerType
+      ID: 202
+      Name: '*float32'
+      ByteSize: 8
+      GoRuntimeType: 376992
+      GoKind: 22
+      Pointee: 188 BaseType float32
+    - __kind: PointerType
+      ID: 175
+      Name: '*float64'
+      ByteSize: 8
+      GoRuntimeType: 377056
+      GoKind: 22
+      Pointee: 145 BaseType float64
+    - __kind: PointerType
+      ID: 126
+      Name: '*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span'
+      ByteSize: 8
+      GoRuntimeType: 2.18768e+06
+      GoKind: 22
+      Pointee: 127 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span
+    - __kind: PointerType
+      ID: 169
+      Name: '*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanContext'
+      ByteSize: 8
+      GoRuntimeType: 1.91728e+06
+      GoKind: 22
+      Pointee: 170 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanContext
+    - __kind: PointerType
+      ID: 147
+      Name: '*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink'
+      ByteSize: 8
+      GoRuntimeType: 1.12944e+06
+      GoKind: 22
+      Pointee: 148 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink
+    - __kind: PointerType
+      ID: 150
+      Name: '*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent'
+      ByteSize: 8
+      GoRuntimeType: 1.129568e+06
+      GoKind: 22
+      Pointee: 151 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent
+    - __kind: PointerType
+      ID: 161
+      Name: '*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttribute'
+      ByteSize: 8
+      GoRuntimeType: 1.130208e+06
+      GoKind: 22
+      Pointee: 162 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttribute
+    - __kind: PointerType
+      ID: 165
+      Name: '*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttributeValue'
+      ByteSize: 8
+      GoRuntimeType: 1.129952e+06
+      GoKind: 22
+      Pointee: 166 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttributeValue
+    - __kind: PointerType
+      ID: 158
+      Name: '*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute'
+      ByteSize: 8
+      GoRuntimeType: 1.130336e+06
+      GoKind: 22
+      Pointee: 159 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
+    - __kind: PointerType
+      ID: 171
+      Name: '*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.trace'
+      ByteSize: 8
+      GoRuntimeType: 2.132544e+06
+      GoKind: 22
+      Pointee: 172 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.trace
+    - __kind: PointerType
+      ID: 153
+      Name: '*hash<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>'
+      ByteSize: 8
+      Pointee: 154 GoHMapHeaderType hash<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
+    - __kind: PointerType
+      ID: 42
+      Name: '*hash<string,[]*mime/multipart.FileHeader>'
+      ByteSize: 8
+      Pointee: 43 GoHMapHeaderType hash<string,[]*mime/multipart.FileHeader>
+    - __kind: PointerType
+      ID: 15
+      Name: '*hash<string,[]string>'
+      ByteSize: 8
+      Pointee: 16 GoHMapHeaderType hash<string,[]string>
+    - __kind: PointerType
+      ID: 140
+      Name: '*hash<string,float64>'
+      ByteSize: 8
+      Pointee: 141 GoHMapHeaderType hash<string,float64>
+    - __kind: PointerType
+      ID: 134
+      Name: '*hash<string,interface {}>'
+      ByteSize: 8
+      Pointee: 135 GoHMapHeaderType hash<string,interface {}>
+    - __kind: PointerType
+      ID: 121
+      Name: '*hash<string,string>'
+      ByteSize: 8
+      Pointee: 122 GoHMapHeaderType hash<string,string>
+    - __kind: PointerType
+      ID: 72
+      Name: '*int'
+      ByteSize: 8
+      GoRuntimeType: 376672
+      GoKind: 22
+      Pointee: 8 BaseType int
+    - __kind: PointerType
+      ID: 198
+      Name: '*int16'
+      ByteSize: 8
+      GoRuntimeType: 376288
+      GoKind: 22
+      Pointee: 192 BaseType int16
+    - __kind: PointerType
+      ID: 190
+      Name: '*int32'
+      ByteSize: 8
+      GoRuntimeType: 376416
+      GoKind: 22
+      Pointee: 130 BaseType int32
+    - __kind: PointerType
+      ID: 195
+      Name: '*int64'
+      ByteSize: 8
+      GoRuntimeType: 376544
+      GoKind: 22
+      Pointee: 36 BaseType int64
+    - __kind: PointerType
+      ID: 199
+      Name: '*int8'
+      ByteSize: 8
+      GoRuntimeType: 376160
+      GoKind: 22
+      Pointee: 187 BaseType int8
+    - __kind: PointerType
+      ID: 62
+      Name: '*math/big.Int'
+      ByteSize: 8
+      GoRuntimeType: 2.29744e+06
+      GoKind: 22
+      Pointee: 63 StructureType math/big.Int
+    - __kind: PointerType
+      ID: 65
+      Name: '*math/big.Word'
+      ByteSize: 8
+      GoRuntimeType: 403552
+      GoKind: 22
+      Pointee: 66 BaseType math/big.Word
+    - __kind: PointerType
+      ID: 218
+      Name: '*math/big.nat.array'
+      ByteSize: 8
+      Pointee: 217 GoSliceDataType math/big.nat.array
+    - __kind: PointerType
+      ID: 49
+      Name: '*mime/multipart.FileHeader'
+      ByteSize: 8
+      GoRuntimeType: 853760
+      GoKind: 22
+      Pointee: 50 StructureType mime/multipart.FileHeader
+    - __kind: PointerType
+      ID: 38
+      Name: '*mime/multipart.Form'
+      ByteSize: 8
+      GoRuntimeType: 853856
+      GoKind: 22
+      Pointee: 39 StructureType mime/multipart.Form
+    - __kind: PointerType
+      ID: 93
+      Name: '*net.IP'
+      ByteSize: 8
+      GoRuntimeType: 2.02912e+06
+      GoKind: 22
+      Pointee: 94 GoSliceHeaderType net.IP
+    - __kind: PointerType
+      ID: 236
+      Name: '*net.IP.array'
+      ByteSize: 8
+      Pointee: 235 GoSliceDataType net.IP.array
+    - __kind: PointerType
+      ID: 242
+      Name: '*net.IPMask.array'
+      ByteSize: 8
+      Pointee: 241 GoSliceDataType net.IPMask.array
+    - __kind: PointerType
+      ID: 99
+      Name: '*net.IPNet'
+      ByteSize: 8
+      GoRuntimeType: 1.122912e+06
+      GoKind: 22
+      Pointee: 100 StructureType net.IPNet
     - __kind: PointerType
       ID: 3
       Name: '*net/http.Request'
@@ -130,124 +577,27 @@ Types:
       GoRuntimeType: 2.219968e+06
       GoKind: 22
       Pointee: 4 StructureType net/http.Request
-    - __kind: StructureType
-      ID: 4
-      Name: net/http.Request
-      ByteSize: 304
-      GoRuntimeType: 2.256288e+06
-      GoKind: 25
-      RawFields:
-        - Name: Method
-          Offset: 0
-          Type: 5 GoStringHeaderType string
-        - Name: URL
-          Offset: 16
-          Type: 9 PointerType *net/url.URL
-        - Name: Proto
-          Offset: 24
-          Type: 5 GoStringHeaderType string
-        - Name: ProtoMajor
-          Offset: 40
-          Type: 8 BaseType int
-        - Name: ProtoMinor
-          Offset: 48
-          Type: 8 BaseType int
-        - Name: Header
-          Offset: 56
-          Type: 14 GoMapType net/http.Header
-        - Name: Body
-          Offset: 64
-          Type: 34 GoInterfaceType io.ReadCloser
-        - Name: GetBody
-          Offset: 80
-          Type: 35 GoSubroutineType func() (io.ReadCloser, error)
-        - Name: ContentLength
-          Offset: 88
-          Type: 36 BaseType int64
-        - Name: TransferEncoding
-          Offset: 96
-          Type: 24 GoSliceHeaderType []string
-        - Name: Close
-          Offset: 120
-          Type: 13 BaseType bool
-        - Name: Host
-          Offset: 128
-          Type: 5 GoStringHeaderType string
-        - Name: Form
-          Offset: 144
-          Type: 37 GoMapType net/url.Values
-        - Name: PostForm
-          Offset: 152
-          Type: 37 GoMapType net/url.Values
-        - Name: MultipartForm
-          Offset: 160
-          Type: 38 PointerType *mime/multipart.Form
-        - Name: Trailer
-          Offset: 168
-          Type: 14 GoMapType net/http.Header
-        - Name: RemoteAddr
-          Offset: 176
-          Type: 5 GoStringHeaderType string
-        - Name: RequestURI
-          Offset: 192
-          Type: 5 GoStringHeaderType string
-        - Name: TLS
-          Offset: 208
-          Type: 53 PointerType *crypto/tls.ConnectionState
-        - Name: Cancel
-          Offset: 216
-          Type: 111 GoChannelType <-chan struct {}
-        - Name: Response
-          Offset: 224
-          Type: 112 PointerType *net/http.Response
-        - Name: Pattern
-          Offset: 232
-          Type: 5 GoStringHeaderType string
-        - Name: ctx
-          Offset: 248
-          Type: 114 GoInterfaceType context.Context
-        - Name: pat
-          Offset: 264
-          Type: 115 PointerType *net/http.pattern
-        - Name: matches
-          Offset: 272
-          Type: 24 GoSliceHeaderType []string
-        - Name: otherValues
-          Offset: 296
-          Type: 120 GoMapType map[string]string
-    - __kind: GoStringHeaderType
-      ID: 5
-      Name: string
-      ByteSize: 16
-      GoRuntimeType: 542528
-      GoKind: 24
-      RawFields:
-        - Name: str
-          Offset: 0
-          Type: 204 PointerType *string.str
-        - Name: len
-          Offset: 8
-          Type: 8 BaseType int
-      Data: 203 GoStringDataType string.str
     - __kind: PointerType
-      ID: 6
-      Name: '*uint8'
+      ID: 112
+      Name: '*net/http.Response'
       ByteSize: 8
-      GoRuntimeType: 376224
+      GoRuntimeType: 1.632736e+06
       GoKind: 22
-      Pointee: 7 BaseType uint8
-    - __kind: BaseType
-      ID: 7
-      Name: uint8
-      ByteSize: 1
-      GoRuntimeType: 542656
-      GoKind: 8
-    - __kind: BaseType
-      ID: 8
-      Name: int
+      Pointee: 113 StructureType net/http.Response
+    - __kind: PointerType
+      ID: 115
+      Name: '*net/http.pattern'
       ByteSize: 8
-      GoRuntimeType: 543104
-      GoKind: 2
+      GoRuntimeType: 1.453504e+06
+      GoKind: 22
+      Pointee: 116 StructureType net/http.pattern
+    - __kind: PointerType
+      ID: 118
+      Name: '*net/http.segment'
+      ByteSize: 8
+      GoRuntimeType: 367904
+      GoKind: 22
+      Pointee: 119 StructureType net/http.segment
     - __kind: PointerType
       ID: 9
       Name: '*net/url.URL'
@@ -255,46 +605,6 @@ Types:
       GoRuntimeType: 2.002496e+06
       GoKind: 22
       Pointee: 10 StructureType net/url.URL
-    - __kind: StructureType
-      ID: 10
-      Name: net/url.URL
-      ByteSize: 144
-      GoRuntimeType: 2.041568e+06
-      GoKind: 25
-      RawFields:
-        - Name: Scheme
-          Offset: 0
-          Type: 5 GoStringHeaderType string
-        - Name: Opaque
-          Offset: 16
-          Type: 5 GoStringHeaderType string
-        - Name: User
-          Offset: 32
-          Type: 11 PointerType *net/url.Userinfo
-        - Name: Host
-          Offset: 40
-          Type: 5 GoStringHeaderType string
-        - Name: Path
-          Offset: 56
-          Type: 5 GoStringHeaderType string
-        - Name: RawPath
-          Offset: 72
-          Type: 5 GoStringHeaderType string
-        - Name: OmitHost
-          Offset: 88
-          Type: 13 BaseType bool
-        - Name: ForceQuery
-          Offset: 89
-          Type: 13 BaseType bool
-        - Name: RawQuery
-          Offset: 96
-          Type: 5 GoStringHeaderType string
-        - Name: Fragment
-          Offset: 112
-          Type: 5 GoStringHeaderType string
-        - Name: RawFragment
-          Offset: 128
-          Type: 5 GoStringHeaderType string
     - __kind: PointerType
       ID: 11
       Name: '*net/url.Userinfo'
@@ -302,110 +612,139 @@ Types:
       GoRuntimeType: 1.1416e+06
       GoKind: 22
       Pointee: 12 StructureType net/url.Userinfo
-    - __kind: StructureType
-      ID: 12
-      Name: net/url.Userinfo
-      ByteSize: 40
-      GoRuntimeType: 1.469632e+06
-      GoKind: 25
-      RawFields:
-        - Name: username
-          Offset: 0
-          Type: 5 GoStringHeaderType string
-        - Name: password
-          Offset: 16
-          Type: 5 GoStringHeaderType string
-        - Name: passwordSet
-          Offset: 32
-          Type: 13 BaseType bool
-    - __kind: BaseType
-      ID: 13
-      Name: bool
-      ByteSize: 1
-      GoRuntimeType: 543552
-      GoKind: 1
-    - __kind: GoMapType
-      ID: 14
-      Name: net/http.Header
-      ByteSize: 8
-      GoRuntimeType: 1.964288e+06
-      GoKind: 21
-      HeaderType: 16 GoHMapHeaderType hash<string,[]string>
     - __kind: PointerType
-      ID: 15
-      Name: '*hash<string,[]string>'
+      ID: 32
+      Name: '*runtime.bmap'
       ByteSize: 8
-      Pointee: 16 GoHMapHeaderType hash<string,[]string>
-    - __kind: GoHMapHeaderType
-      ID: 16
-      Name: hash<string,[]string>
-      ByteSize: 48
-      RawFields:
-        - Name: count
-          Offset: 0
-          Type: 8 BaseType int
-        - Name: flags
-          Offset: 8
-          Type: 7 BaseType uint8
-        - Name: B
-          Offset: 9
-          Type: 7 BaseType uint8
-        - Name: noverflow
-          Offset: 10
-          Type: 17 BaseType uint16
-        - Name: hash0
-          Offset: 12
-          Type: 18 BaseType uint32
-        - Name: buckets
-          Offset: 16
-          Type: 19 PointerType *bucket<string,[]string>
-        - Name: oldbuckets
-          Offset: 24
-          Type: 19 PointerType *bucket<string,[]string>
-        - Name: nevacuate
-          Offset: 32
-          Type: 26 BaseType uintptr
-        - Name: extra
-          Offset: 40
-          Type: 27 PointerType *runtime.mapextra
-      BucketType: 20 GoHMapBucketType bucket<string,[]string>
-      BucketsType: 205 GoSliceDataType []bucket<string,[]string>.array
-    - __kind: BaseType
-      ID: 17
-      Name: uint16
-      ByteSize: 2
-      GoRuntimeType: 542784
-      GoKind: 9
-    - __kind: BaseType
-      ID: 18
-      Name: uint32
-      ByteSize: 4
-      GoRuntimeType: 542912
-      GoKind: 10
+      GoRuntimeType: 1.137248e+06
+      GoKind: 22
+      Pointee: 33 StructureType runtime.bmap
     - __kind: PointerType
-      ID: 19
-      Name: '*bucket<string,[]string>'
+      ID: 27
+      Name: '*runtime.mapextra'
       ByteSize: 8
-      Pointee: 20 GoHMapBucketType bucket<string,[]string>
-    - __kind: GoHMapBucketType
-      ID: 20
-      Name: bucket<string,[]string>
-      ByteSize: 336
-      RawFields:
-        - Name: tophash
-          Offset: 0
-          Type: 21 ArrayType [8]uint8
-        - Name: keys
-          Offset: 8
-          Type: 22 ArrayType []key<string>
-        - Name: values
-          Offset: 136
-          Type: 23 ArrayType []val<[]string>
-        - Name: overflow
-          Offset: 328
-          Type: 19 PointerType *bucket<string,[]string>
-      KeyType: 5 GoStringHeaderType string
-      ValueType: 24 GoSliceHeaderType []string
+      GoRuntimeType: 380000
+      GoKind: 22
+      Pointee: 28 StructureType runtime.mapextra
+    - __kind: PointerType
+      ID: 25
+      Name: '*string'
+      ByteSize: 8
+      GoRuntimeType: 376096
+      GoKind: 22
+      Pointee: 5 GoStringHeaderType string
+    - __kind: PointerType
+      ID: 204
+      Name: '*string.str'
+      ByteSize: 8
+      Pointee: 203 GoStringDataType string.str
+    - __kind: PointerType
+      ID: 75
+      Name: '*time.Location'
+      ByteSize: 8
+      GoRuntimeType: 1.458496e+06
+      GoKind: 22
+      Pointee: 76 StructureType time.Location
+    - __kind: PointerType
+      ID: 78
+      Name: '*time.zone'
+      ByteSize: 8
+      GoRuntimeType: 370976
+      GoKind: 22
+      Pointee: 79 StructureType time.zone
+    - __kind: PointerType
+      ID: 81
+      Name: '*time.zoneTrans'
+      ByteSize: 8
+      GoRuntimeType: 371040
+      GoKind: 22
+      Pointee: 82 StructureType time.zoneTrans
+    - __kind: PointerType
+      ID: 201
+      Name: '*uint'
+      ByteSize: 8
+      GoRuntimeType: 376736
+      GoKind: 22
+      Pointee: 186 BaseType uint
+    - __kind: PointerType
+      ID: 197
+      Name: '*uint16'
+      ByteSize: 8
+      GoRuntimeType: 376352
+      GoKind: 22
+      Pointee: 17 BaseType uint16
+    - __kind: PointerType
+      ID: 191
+      Name: '*uint32'
+      ByteSize: 8
+      GoRuntimeType: 376480
+      GoKind: 22
+      Pointee: 18 BaseType uint32
+    - __kind: PointerType
+      ID: 196
+      Name: '*uint64'
+      ByteSize: 8
+      GoRuntimeType: 376608
+      GoKind: 22
+      Pointee: 74 BaseType uint64
+    - __kind: PointerType
+      ID: 6
+      Name: '*uint8'
+      ByteSize: 8
+      GoRuntimeType: 376224
+      GoKind: 22
+      Pointee: 7 BaseType uint8
+    - __kind: PointerType
+      ID: 185
+      Name: '*uintptr'
+      ByteSize: 8
+      GoRuntimeType: 376800
+      GoKind: 22
+      Pointee: 26 BaseType uintptr
+    - __kind: GoChannelType
+      ID: 111
+      Name: <-chan struct {}
+      GoRuntimeType: 555520
+      GoKind: 18
+    - __kind: EventRootType
+      ID: 263
+      Name: Probe[main.HandleHTTP]
+      ByteSize: 25
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: w
+          Offset: 1
+          Expression:
+            Type: 1 GoInterfaceType net/http.ResponseWriter
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 1, index: 0, name: w}
+                  Offset: 0
+                  ByteSize: 16
+        - Name: r
+          Offset: 17
+          Expression:
+            Type: 3 PointerType *net/http.Request
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 1, index: 1, name: r}
+                  Offset: 0
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 264
+      Name: Probe[main.LookAtTheRequest]
+      ByteSize: 17
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: path
+          Offset: 1
+          Expression:
+            Type: 5 GoStringHeaderType string
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 2, index: 0, name: path}
+                  Offset: 0
+                  ByteSize: 16
     - __kind: ArrayType
       ID: 21
       Name: '[8]uint8'
@@ -415,80 +754,138 @@ Types:
       Count: 8
       HasCount: true
       Element: 7 BaseType uint8
-    - __kind: ArrayType
-      ID: 22
-      Name: '[]key<string>'
-      ByteSize: 128
-      Count: 8
-      HasCount: true
-      Element: 5 GoStringHeaderType string
-    - __kind: ArrayType
-      ID: 23
-      Name: '[]val<[]string>'
-      ByteSize: 192
-      Count: 8
-      HasCount: true
-      Element: 24 GoSliceHeaderType []string
     - __kind: GoSliceHeaderType
-      ID: 24
-      Name: '[]string'
+      ID: 55
+      Name: '[]*crypto/x509.Certificate'
       ByteSize: 24
-      GoRuntimeType: 469152
+      GoRuntimeType: 473920
       GoKind: 23
       RawFields:
         - Name: array
           Offset: 0
-          Type: 25 PointerType *string
+          Type: 56 PointerType **crypto/x509.Certificate
         - Name: len
           Offset: 8
           Type: 8 BaseType int
         - Name: cap
           Offset: 16
           Type: 8 BaseType int
-      Data: 206 GoSliceDataType []string.array
-    - __kind: PointerType
-      ID: 25
-      Name: '*string'
-      ByteSize: 8
-      GoRuntimeType: 376096
-      GoKind: 22
-      Pointee: 5 GoStringHeaderType string
-    - __kind: BaseType
-      ID: 26
-      Name: uintptr
-      ByteSize: 8
-      GoRuntimeType: 543232
-      GoKind: 12
-    - __kind: PointerType
-      ID: 27
-      Name: '*runtime.mapextra'
-      ByteSize: 8
-      GoRuntimeType: 380000
-      GoKind: 22
-      Pointee: 28 StructureType runtime.mapextra
-    - __kind: StructureType
-      ID: 28
-      Name: runtime.mapextra
+      Data: 215 GoSliceDataType []*crypto/x509.Certificate.array
+    - __kind: GoSliceDataType
+      ID: 215
+      Name: '[]*crypto/x509.Certificate.array'
+      ByteSize: 2048
+      Element: 57 PointerType *crypto/x509.Certificate
+    - __kind: GoSliceHeaderType
+      ID: 173
+      Name: '[]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span'
       ByteSize: 24
-      GoRuntimeType: 1.4656e+06
-      GoKind: 25
+      GoRuntimeType: 464032
+      GoKind: 23
       RawFields:
-        - Name: overflow
+        - Name: array
           Offset: 0
-          Type: 29 PointerType *[]*runtime.bmap
-        - Name: oldoverflow
+          Type: 174 PointerType **github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span
+        - Name: len
           Offset: 8
-          Type: 29 PointerType *[]*runtime.bmap
-        - Name: nextOverflow
+          Type: 8 BaseType int
+        - Name: cap
           Offset: 16
-          Type: 32 PointerType *runtime.bmap
-    - __kind: PointerType
-      ID: 29
-      Name: '*[]*runtime.bmap'
-      ByteSize: 8
-      GoRuntimeType: 470816
-      GoKind: 22
-      Pointee: 30 GoSliceHeaderType []*runtime.bmap
+          Type: 8 BaseType int
+      Data: 261 GoSliceDataType []*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span.array
+    - __kind: GoSliceDataType
+      ID: 261
+      Name: '[]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span.array'
+      ByteSize: 2048
+      Element: 126 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span
+    - __kind: GoSliceHeaderType
+      ID: 163
+      Name: '[]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttributeValue'
+      ByteSize: 24
+      GoRuntimeType: 463648
+      GoKind: 23
+      RawFields:
+        - Name: array
+          Offset: 0
+          Type: 164 PointerType **github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttributeValue
+        - Name: len
+          Offset: 8
+          Type: 8 BaseType int
+        - Name: cap
+          Offset: 16
+          Type: 8 BaseType int
+      Data: 259 GoSliceDataType []*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttributeValue.array
+    - __kind: GoSliceDataType
+      ID: 259
+      Name: '[]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttributeValue.array'
+      ByteSize: 2048
+      Element: 165 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttributeValue
+    - __kind: GoSliceHeaderType
+      ID: 47
+      Name: '[]*mime/multipart.FileHeader'
+      ByteSize: 24
+      GoRuntimeType: 461664
+      GoKind: 23
+      RawFields:
+        - Name: array
+          Offset: 0
+          Type: 48 PointerType **mime/multipart.FileHeader
+        - Name: len
+          Offset: 8
+          Type: 8 BaseType int
+        - Name: cap
+          Offset: 16
+          Type: 8 BaseType int
+      Data: 211 GoSliceDataType []*mime/multipart.FileHeader.array
+    - __kind: GoSliceDataType
+      ID: 211
+      Name: '[]*mime/multipart.FileHeader.array'
+      ByteSize: 2048
+      Element: 49 PointerType *mime/multipart.FileHeader
+    - __kind: GoSliceHeaderType
+      ID: 97
+      Name: '[]*net.IPNet'
+      ByteSize: 24
+      GoRuntimeType: 486976
+      GoKind: 23
+      RawFields:
+        - Name: array
+          Offset: 0
+          Type: 98 PointerType **net.IPNet
+        - Name: len
+          Offset: 8
+          Type: 8 BaseType int
+        - Name: cap
+          Offset: 16
+          Type: 8 BaseType int
+      Data: 239 GoSliceDataType []*net.IPNet.array
+    - __kind: GoSliceDataType
+      ID: 239
+      Name: '[]*net.IPNet.array'
+      ByteSize: 2048
+      Element: 99 PointerType *net.IPNet
+    - __kind: GoSliceHeaderType
+      ID: 95
+      Name: '[]*net/url.URL'
+      ByteSize: 24
+      GoRuntimeType: 486912
+      GoKind: 23
+      RawFields:
+        - Name: array
+          Offset: 0
+          Type: 96 PointerType **net/url.URL
+        - Name: len
+          Offset: 8
+          Type: 8 BaseType int
+        - Name: cap
+          Offset: 16
+          Type: 8 BaseType int
+      Data: 237 GoSliceDataType []*net/url.URL.array
+    - __kind: GoSliceDataType
+      ID: 237
+      Name: '[]*net/url.URL.array'
+      ByteSize: 2048
+      Element: 9 PointerType *net/url.URL
     - __kind: GoSliceHeaderType
       ID: 30
       Name: '[]*runtime.bmap'
@@ -506,138 +903,445 @@ Types:
           Offset: 16
           Type: 8 BaseType int
       Data: 208 GoSliceDataType []*runtime.bmap.array
-    - __kind: PointerType
-      ID: 31
-      Name: '**runtime.bmap'
-      ByteSize: 8
-      Pointee: 32 PointerType *runtime.bmap
-    - __kind: PointerType
-      ID: 32
-      Name: '*runtime.bmap'
-      ByteSize: 8
-      GoRuntimeType: 1.137248e+06
-      GoKind: 22
-      Pointee: 33 StructureType runtime.bmap
-    - __kind: StructureType
-      ID: 33
-      Name: runtime.bmap
-      ByteSize: 8
-      GoRuntimeType: 1.13712e+06
-      GoKind: 25
+    - __kind: GoSliceDataType
+      ID: 208
+      Name: '[]*runtime.bmap.array'
+      ByteSize: 2048
+      Element: 32 PointerType *runtime.bmap
+    - __kind: GoSliceHeaderType
+      ID: 105
+      Name: '[][]*crypto/x509.Certificate'
+      ByteSize: 24
+      GoRuntimeType: 474048
+      GoKind: 23
+      RawFields:
+        - Name: array
+          Offset: 0
+          Type: 106 PointerType *[]*crypto/x509.Certificate
+        - Name: len
+          Offset: 8
+          Type: 8 BaseType int
+        - Name: cap
+          Offset: 16
+          Type: 8 BaseType int
+      Data: 245 GoSliceDataType [][]*crypto/x509.Certificate.array
+    - __kind: GoSliceDataType
+      ID: 245
+      Name: '[][]*crypto/x509.Certificate.array'
+      ByteSize: 2048
+      Element: 55 GoSliceHeaderType []*crypto/x509.Certificate
+    - __kind: GoSliceHeaderType
+      ID: 107
+      Name: '[][]uint8'
+      ByteSize: 24
+      GoRuntimeType: 457184
+      GoKind: 23
+      RawFields:
+        - Name: array
+          Offset: 0
+          Type: 108 PointerType *[]uint8
+        - Name: len
+          Offset: 8
+          Type: 8 BaseType int
+        - Name: cap
+          Offset: 16
+          Type: 8 BaseType int
+      Data: 247 GoSliceDataType [][]uint8.array
+    - __kind: GoSliceDataType
+      ID: 247
+      Name: '[][]uint8.array'
+      ByteSize: 2048
+      Element: 52 GoSliceHeaderType []uint8
+    - __kind: GoSliceDataType
+      ID: 258
+      Name: '[]bucket<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>.array'
+      ByteSize: 2048
+      Element: 156 GoHMapBucketType bucket<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
+    - __kind: GoSliceDataType
+      ID: 210
+      Name: '[]bucket<string,[]*mime/multipart.FileHeader>.array'
+      ByteSize: 2048
+      Element: 45 GoHMapBucketType bucket<string,[]*mime/multipart.FileHeader>
+    - __kind: GoSliceDataType
+      ID: 205
+      Name: '[]bucket<string,[]string>.array'
+      ByteSize: 2048
+      Element: 20 GoHMapBucketType bucket<string,[]string>
+    - __kind: GoSliceDataType
+      ID: 253
+      Name: '[]bucket<string,float64>.array'
+      ByteSize: 2048
+      Element: 143 GoHMapBucketType bucket<string,float64>
+    - __kind: GoSliceDataType
+      ID: 252
+      Name: '[]bucket<string,interface {}>.array'
+      ByteSize: 2048
+      Element: 137 GoHMapBucketType bucket<string,interface {}>
+    - __kind: GoSliceDataType
+      ID: 251
+      Name: '[]bucket<string,string>.array'
+      ByteSize: 2048
+      Element: 124 GoHMapBucketType bucket<string,string>
+    - __kind: GoSliceHeaderType
+      ID: 89
+      Name: '[]crypto/x509.ExtKeyUsage'
+      ByteSize: 24
+      GoRuntimeType: 475200
+      GoKind: 23
+      RawFields:
+        - Name: array
+          Offset: 0
+          Type: 90 PointerType *crypto/x509.ExtKeyUsage
+        - Name: len
+          Offset: 8
+          Type: 8 BaseType int
+        - Name: cap
+          Offset: 16
+          Type: 8 BaseType int
+      Data: 231 GoSliceDataType []crypto/x509.ExtKeyUsage.array
+    - __kind: GoSliceDataType
+      ID: 231
+      Name: '[]crypto/x509.ExtKeyUsage.array'
+      ByteSize: 2048
+      Element: 91 BaseType crypto/x509.ExtKeyUsage
+    - __kind: GoSliceHeaderType
+      ID: 102
+      Name: '[]crypto/x509.OID'
+      ByteSize: 24
+      GoRuntimeType: 487040
+      GoKind: 23
+      RawFields:
+        - Name: array
+          Offset: 0
+          Type: 103 PointerType *crypto/x509.OID
+        - Name: len
+          Offset: 8
+          Type: 8 BaseType int
+        - Name: cap
+          Offset: 16
+          Type: 8 BaseType int
+      Data: 243 GoSliceDataType []crypto/x509.OID.array
+    - __kind: GoSliceDataType
+      ID: 243
+      Name: '[]crypto/x509.OID.array'
+      ByteSize: 2048
+      Element: 104 StructureType crypto/x509.OID
+    - __kind: GoSliceHeaderType
+      ID: 68
+      Name: '[]crypto/x509/pkix.AttributeTypeAndValue'
+      ByteSize: 24
+      GoRuntimeType: 487296
+      GoKind: 23
+      RawFields:
+        - Name: array
+          Offset: 0
+          Type: 69 PointerType *crypto/x509/pkix.AttributeTypeAndValue
+        - Name: len
+          Offset: 8
+          Type: 8 BaseType int
+        - Name: cap
+          Offset: 16
+          Type: 8 BaseType int
+      Data: 219 GoSliceDataType []crypto/x509/pkix.AttributeTypeAndValue.array
+    - __kind: GoSliceDataType
+      ID: 219
+      Name: '[]crypto/x509/pkix.AttributeTypeAndValue.array'
+      ByteSize: 2048
+      Element: 70 StructureType crypto/x509/pkix.AttributeTypeAndValue
+    - __kind: GoSliceHeaderType
+      ID: 84
+      Name: '[]crypto/x509/pkix.Extension'
+      ByteSize: 24
+      GoRuntimeType: 486784
+      GoKind: 23
+      RawFields:
+        - Name: array
+          Offset: 0
+          Type: 85 PointerType *crypto/x509/pkix.Extension
+        - Name: len
+          Offset: 8
+          Type: 8 BaseType int
+        - Name: cap
+          Offset: 16
+          Type: 8 BaseType int
+      Data: 227 GoSliceDataType []crypto/x509/pkix.Extension.array
+    - __kind: GoSliceDataType
+      ID: 227
+      Name: '[]crypto/x509/pkix.Extension.array'
+      ByteSize: 2048
+      Element: 86 StructureType crypto/x509/pkix.Extension
+    - __kind: GoSliceHeaderType
+      ID: 87
+      Name: '[]encoding/asn1.ObjectIdentifier'
+      ByteSize: 24
+      GoRuntimeType: 486848
+      GoKind: 23
+      RawFields:
+        - Name: array
+          Offset: 0
+          Type: 88 PointerType *encoding/asn1.ObjectIdentifier
+        - Name: len
+          Offset: 8
+          Type: 8 BaseType int
+        - Name: cap
+          Offset: 16
+          Type: 8 BaseType int
+      Data: 229 GoSliceDataType []encoding/asn1.ObjectIdentifier.array
+    - __kind: GoSliceDataType
+      ID: 229
+      Name: '[]encoding/asn1.ObjectIdentifier.array'
+      ByteSize: 2048
+      Element: 71 GoSliceHeaderType encoding/asn1.ObjectIdentifier
+    - __kind: GoSliceHeaderType
+      ID: 146
+      Name: '[]github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink'
+      ByteSize: 24
+      GoRuntimeType: 463584
+      GoKind: 23
+      RawFields:
+        - Name: array
+          Offset: 0
+          Type: 147 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink
+        - Name: len
+          Offset: 8
+          Type: 8 BaseType int
+        - Name: cap
+          Offset: 16
+          Type: 8 BaseType int
+      Data: 254 GoSliceDataType []github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink.array
+    - __kind: GoSliceDataType
+      ID: 254
+      Name: '[]github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink.array'
+      ByteSize: 2048
+      Element: 148 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink
+    - __kind: GoSliceHeaderType
+      ID: 149
+      Name: '[]github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent'
+      ByteSize: 24
+      GoRuntimeType: 463776
+      GoKind: 23
+      RawFields:
+        - Name: array
+          Offset: 0
+          Type: 150 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent
+        - Name: len
+          Offset: 8
+          Type: 8 BaseType int
+        - Name: cap
+          Offset: 16
+          Type: 8 BaseType int
+      Data: 256 GoSliceDataType []github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent.array
+    - __kind: GoSliceDataType
+      ID: 256
+      Name: '[]github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent.array'
+      ByteSize: 2048
+      Element: 151 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent
+    - __kind: ArrayType
+      ID: 22
+      Name: '[]key<string>'
+      ByteSize: 128
+      Count: 8
+      HasCount: true
+      Element: 5 GoStringHeaderType string
+    - __kind: GoSliceHeaderType
+      ID: 92
+      Name: '[]net.IP'
+      ByteSize: 24
+      GoRuntimeType: 458400
+      GoKind: 23
+      RawFields:
+        - Name: array
+          Offset: 0
+          Type: 93 PointerType *net.IP
+        - Name: len
+          Offset: 8
+          Type: 8 BaseType int
+        - Name: cap
+          Offset: 16
+          Type: 8 BaseType int
+      Data: 233 GoSliceDataType []net.IP.array
+    - __kind: GoSliceDataType
+      ID: 233
+      Name: '[]net.IP.array'
+      ByteSize: 2048
+      Element: 94 GoSliceHeaderType net.IP
+    - __kind: GoSliceHeaderType
+      ID: 117
+      Name: '[]net/http.segment'
+      ByteSize: 24
+      GoRuntimeType: 459168
+      GoKind: 23
+      RawFields:
+        - Name: array
+          Offset: 0
+          Type: 118 PointerType *net/http.segment
+        - Name: len
+          Offset: 8
+          Type: 8 BaseType int
+        - Name: cap
+          Offset: 16
+          Type: 8 BaseType int
+      Data: 249 GoSliceDataType []net/http.segment.array
+    - __kind: GoSliceDataType
+      ID: 249
+      Name: '[]net/http.segment.array'
+      ByteSize: 2048
+      Element: 119 StructureType net/http.segment
+    - __kind: GoSliceHeaderType
+      ID: 24
+      Name: '[]string'
+      ByteSize: 24
+      GoRuntimeType: 469152
+      GoKind: 23
+      RawFields:
+        - Name: array
+          Offset: 0
+          Type: 25 PointerType *string
+        - Name: len
+          Offset: 8
+          Type: 8 BaseType int
+        - Name: cap
+          Offset: 16
+          Type: 8 BaseType int
+      Data: 206 GoSliceDataType []string.array
+    - __kind: GoSliceDataType
+      ID: 206
+      Name: '[]string.array'
+      ByteSize: 2048
+      Element: 5 GoStringHeaderType string
+    - __kind: GoSliceHeaderType
+      ID: 77
+      Name: '[]time.zone'
+      ByteSize: 24
+      GoRuntimeType: 463264
+      GoKind: 23
+      RawFields:
+        - Name: array
+          Offset: 0
+          Type: 78 PointerType *time.zone
+        - Name: len
+          Offset: 8
+          Type: 8 BaseType int
+        - Name: cap
+          Offset: 16
+          Type: 8 BaseType int
+      Data: 223 GoSliceDataType []time.zone.array
+    - __kind: GoSliceDataType
+      ID: 223
+      Name: '[]time.zone.array'
+      ByteSize: 2048
+      Element: 79 StructureType time.zone
+    - __kind: GoSliceHeaderType
+      ID: 80
+      Name: '[]time.zoneTrans'
+      ByteSize: 24
+      GoRuntimeType: 463328
+      GoKind: 23
+      RawFields:
+        - Name: array
+          Offset: 0
+          Type: 81 PointerType *time.zoneTrans
+        - Name: len
+          Offset: 8
+          Type: 8 BaseType int
+        - Name: cap
+          Offset: 16
+          Type: 8 BaseType int
+      Data: 225 GoSliceDataType []time.zoneTrans.array
+    - __kind: GoSliceDataType
+      ID: 225
+      Name: '[]time.zoneTrans.array'
+      ByteSize: 2048
+      Element: 82 StructureType time.zoneTrans
+    - __kind: GoSliceHeaderType
+      ID: 52
+      Name: '[]uint8'
+      ByteSize: 24
+      GoRuntimeType: 468000
+      GoKind: 23
+      RawFields:
+        - Name: array
+          Offset: 0
+          Type: 6 PointerType *uint8
+        - Name: len
+          Offset: 8
+          Type: 8 BaseType int
+        - Name: cap
+          Offset: 16
+          Type: 8 BaseType int
+      Data: 213 GoSliceDataType []uint8.array
+    - __kind: GoSliceDataType
+      ID: 213
+      Name: '[]uint8.array'
+      ByteSize: 2048
+      Element: 7 BaseType uint8
+    - __kind: ArrayType
+      ID: 157
+      Name: '[]val<*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>'
+      ByteSize: 64
+      Count: 8
+      HasCount: true
+      Element: 158 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
+    - __kind: ArrayType
+      ID: 46
+      Name: '[]val<[]*mime/multipart.FileHeader>'
+      ByteSize: 192
+      Count: 8
+      HasCount: true
+      Element: 47 GoSliceHeaderType []*mime/multipart.FileHeader
+    - __kind: ArrayType
+      ID: 23
+      Name: '[]val<[]string>'
+      ByteSize: 192
+      Count: 8
+      HasCount: true
+      Element: 24 GoSliceHeaderType []string
+    - __kind: ArrayType
+      ID: 144
+      Name: '[]val<float64>'
+      ByteSize: 64
+      Count: 8
+      HasCount: true
+      Element: 145 BaseType float64
+    - __kind: ArrayType
+      ID: 138
+      Name: '[]val<interface {}>'
+      ByteSize: 128
+      Count: 8
+      HasCount: true
+      Element: 61 GoEmptyInterfaceType interface {}
+    - __kind: ArrayType
+      ID: 125
+      Name: '[]val<string>'
+      ByteSize: 128
+      Count: 8
+      HasCount: true
+      Element: 5 GoStringHeaderType string
+    - __kind: BaseType
+      ID: 13
+      Name: bool
+      ByteSize: 1
+      GoRuntimeType: 543552
+      GoKind: 1
+    - __kind: GoHMapBucketType
+      ID: 156
+      Name: bucket<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
+      ByteSize: 208
       RawFields:
         - Name: tophash
           Offset: 0
           Type: 21 ArrayType [8]uint8
-    - __kind: GoInterfaceType
-      ID: 34
-      Name: io.ReadCloser
-      ByteSize: 16
-      GoRuntimeType: 1.093088e+06
-      GoKind: 20
-      RawFields:
-        - Name: tab
-          Offset: 0
-          Type: 2 VoidPointerType unsafe.Pointer
-        - Name: data
+        - Name: keys
           Offset: 8
-          Type: 2 VoidPointerType unsafe.Pointer
-    - __kind: GoSubroutineType
-      ID: 35
-      Name: func() (io.ReadCloser, error)
-      ByteSize: 8
-      GoRuntimeType: 645600
-      GoKind: 19
-    - __kind: BaseType
-      ID: 36
-      Name: int64
-      ByteSize: 8
-      GoRuntimeType: 542976
-      GoKind: 6
-    - __kind: GoMapType
-      ID: 37
-      Name: net/url.Values
-      ByteSize: 8
-      GoRuntimeType: 1.712416e+06
-      GoKind: 21
-      HeaderType: 16 GoHMapHeaderType hash<string,[]string>
-    - __kind: PointerType
-      ID: 38
-      Name: '*mime/multipart.Form'
-      ByteSize: 8
-      GoRuntimeType: 853856
-      GoKind: 22
-      Pointee: 39 StructureType mime/multipart.Form
-    - __kind: StructureType
-      ID: 39
-      Name: mime/multipart.Form
-      ByteSize: 16
-      GoRuntimeType: 1.326048e+06
-      GoKind: 25
-      RawFields:
-        - Name: Value
-          Offset: 0
-          Type: 40 GoMapType map[string][]string
-        - Name: File
-          Offset: 8
-          Type: 41 GoMapType map[string][]*mime/multipart.FileHeader
-    - __kind: GoMapType
-      ID: 40
-      Name: map[string][]string
-      ByteSize: 8
-      GoRuntimeType: 899360
-      GoKind: 21
-      HeaderType: 16 GoHMapHeaderType hash<string,[]string>
-    - __kind: GoMapType
-      ID: 41
-      Name: map[string][]*mime/multipart.FileHeader
-      ByteSize: 8
-      GoRuntimeType: 904160
-      GoKind: 21
-      HeaderType: 43 GoHMapHeaderType hash<string,[]*mime/multipart.FileHeader>
-    - __kind: PointerType
-      ID: 42
-      Name: '*hash<string,[]*mime/multipart.FileHeader>'
-      ByteSize: 8
-      Pointee: 43 GoHMapHeaderType hash<string,[]*mime/multipart.FileHeader>
-    - __kind: GoHMapHeaderType
-      ID: 43
-      Name: hash<string,[]*mime/multipart.FileHeader>
-      ByteSize: 48
-      RawFields:
-        - Name: count
-          Offset: 0
-          Type: 8 BaseType int
-        - Name: flags
-          Offset: 8
-          Type: 7 BaseType uint8
-        - Name: B
-          Offset: 9
-          Type: 7 BaseType uint8
-        - Name: noverflow
-          Offset: 10
-          Type: 17 BaseType uint16
-        - Name: hash0
-          Offset: 12
-          Type: 18 BaseType uint32
-        - Name: buckets
-          Offset: 16
-          Type: 44 PointerType *bucket<string,[]*mime/multipart.FileHeader>
-        - Name: oldbuckets
-          Offset: 24
-          Type: 44 PointerType *bucket<string,[]*mime/multipart.FileHeader>
-        - Name: nevacuate
-          Offset: 32
-          Type: 26 BaseType uintptr
-        - Name: extra
-          Offset: 40
-          Type: 27 PointerType *runtime.mapextra
-      BucketType: 45 GoHMapBucketType bucket<string,[]*mime/multipart.FileHeader>
-      BucketsType: 210 GoSliceDataType []bucket<string,[]*mime/multipart.FileHeader>.array
-    - __kind: PointerType
-      ID: 44
-      Name: '*bucket<string,[]*mime/multipart.FileHeader>'
-      ByteSize: 8
-      Pointee: 45 GoHMapBucketType bucket<string,[]*mime/multipart.FileHeader>
+          Type: 22 ArrayType []key<string>
+        - Name: values
+          Offset: 136
+          Type: 157 ArrayType []val<*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
+        - Name: overflow
+          Offset: 200
+          Type: 155 PointerType *bucket<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
+      KeyType: 5 GoStringHeaderType string
+      ValueType: 158 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
     - __kind: GoHMapBucketType
       ID: 45
       Name: bucket<string,[]*mime/multipart.FileHeader>
@@ -657,102 +1361,144 @@ Types:
           Type: 44 PointerType *bucket<string,[]*mime/multipart.FileHeader>
       KeyType: 5 GoStringHeaderType string
       ValueType: 47 GoSliceHeaderType []*mime/multipart.FileHeader
-    - __kind: ArrayType
-      ID: 46
-      Name: '[]val<[]*mime/multipart.FileHeader>'
-      ByteSize: 192
-      Count: 8
-      HasCount: true
-      Element: 47 GoSliceHeaderType []*mime/multipart.FileHeader
-    - __kind: GoSliceHeaderType
-      ID: 47
-      Name: '[]*mime/multipart.FileHeader'
-      ByteSize: 24
-      GoRuntimeType: 461664
-      GoKind: 23
+    - __kind: GoHMapBucketType
+      ID: 20
+      Name: bucket<string,[]string>
+      ByteSize: 336
       RawFields:
-        - Name: array
+        - Name: tophash
           Offset: 0
-          Type: 48 PointerType **mime/multipart.FileHeader
-        - Name: len
+          Type: 21 ArrayType [8]uint8
+        - Name: keys
           Offset: 8
-          Type: 8 BaseType int
-        - Name: cap
-          Offset: 16
-          Type: 8 BaseType int
-      Data: 211 GoSliceDataType []*mime/multipart.FileHeader.array
-    - __kind: PointerType
-      ID: 48
-      Name: '**mime/multipart.FileHeader'
-      ByteSize: 8
-      GoKind: 22
-      Pointee: 49 PointerType *mime/multipart.FileHeader
-    - __kind: PointerType
-      ID: 49
-      Name: '*mime/multipart.FileHeader'
-      ByteSize: 8
-      GoRuntimeType: 853760
-      GoKind: 22
-      Pointee: 50 StructureType mime/multipart.FileHeader
+          Type: 22 ArrayType []key<string>
+        - Name: values
+          Offset: 136
+          Type: 23 ArrayType []val<[]string>
+        - Name: overflow
+          Offset: 328
+          Type: 19 PointerType *bucket<string,[]string>
+      KeyType: 5 GoStringHeaderType string
+      ValueType: 24 GoSliceHeaderType []string
+    - __kind: GoHMapBucketType
+      ID: 143
+      Name: bucket<string,float64>
+      ByteSize: 208
+      RawFields:
+        - Name: tophash
+          Offset: 0
+          Type: 21 ArrayType [8]uint8
+        - Name: keys
+          Offset: 8
+          Type: 22 ArrayType []key<string>
+        - Name: values
+          Offset: 136
+          Type: 144 ArrayType []val<float64>
+        - Name: overflow
+          Offset: 200
+          Type: 142 PointerType *bucket<string,float64>
+      KeyType: 5 GoStringHeaderType string
+      ValueType: 145 BaseType float64
+    - __kind: GoHMapBucketType
+      ID: 137
+      Name: bucket<string,interface {}>
+      ByteSize: 272
+      RawFields:
+        - Name: tophash
+          Offset: 0
+          Type: 21 ArrayType [8]uint8
+        - Name: keys
+          Offset: 8
+          Type: 22 ArrayType []key<string>
+        - Name: values
+          Offset: 136
+          Type: 138 ArrayType []val<interface {}>
+        - Name: overflow
+          Offset: 264
+          Type: 136 PointerType *bucket<string,interface {}>
+      KeyType: 5 GoStringHeaderType string
+      ValueType: 61 GoEmptyInterfaceType interface {}
+    - __kind: GoHMapBucketType
+      ID: 124
+      Name: bucket<string,string>
+      ByteSize: 272
+      RawFields:
+        - Name: tophash
+          Offset: 0
+          Type: 21 ArrayType [8]uint8
+        - Name: keys
+          Offset: 8
+          Type: 22 ArrayType []key<string>
+        - Name: values
+          Offset: 136
+          Type: 125 ArrayType []val<string>
+        - Name: overflow
+          Offset: 264
+          Type: 123 PointerType *bucket<string,string>
+      KeyType: 5 GoStringHeaderType string
+      ValueType: 5 GoStringHeaderType string
     - __kind: StructureType
-      ID: 50
-      Name: mime/multipart.FileHeader
-      ByteSize: 88
-      GoRuntimeType: 1.881696e+06
+      ID: 180
+      Name: bytes.Buffer
+      ByteSize: 40
+      GoRuntimeType: 1.4512e+06
       GoKind: 25
       RawFields:
-        - Name: Filename
+        - Name: buf
           Offset: 0
-          Type: 5 GoStringHeaderType string
-        - Name: Header
-          Offset: 16
-          Type: 51 GoMapType net/textproto.MIMEHeader
-        - Name: Size
-          Offset: 24
-          Type: 36 BaseType int64
-        - Name: content
-          Offset: 32
           Type: 52 GoSliceHeaderType []uint8
-        - Name: tmpfile
-          Offset: 56
-          Type: 5 GoStringHeaderType string
-        - Name: tmpoff
-          Offset: 72
-          Type: 36 BaseType int64
-        - Name: tmpshared
-          Offset: 80
-          Type: 13 BaseType bool
-    - __kind: GoMapType
-      ID: 51
-      Name: net/textproto.MIMEHeader
+        - Name: off
+          Offset: 24
+          Type: 8 BaseType int
+        - Name: lastRead
+          Offset: 32
+          Type: 181 BaseType bytes.readOp
+    - __kind: BaseType
+      ID: 181
+      Name: bytes.readOp
+      ByteSize: 1
+      GoRuntimeType: 541760
+      GoKind: 3
+    - __kind: BaseType
+      ID: 194
+      Name: complex128
+      ByteSize: 16
+      GoRuntimeType: 543360
+      GoKind: 16
+    - __kind: BaseType
+      ID: 193
+      Name: complex64
       ByteSize: 8
-      GoRuntimeType: 1.63792e+06
-      GoKind: 21
-      HeaderType: 16 GoHMapHeaderType hash<string,[]string>
-    - __kind: GoSliceHeaderType
-      ID: 52
-      Name: '[]uint8'
-      ByteSize: 24
-      GoRuntimeType: 468000
-      GoKind: 23
+      GoRuntimeType: 543296
+      GoKind: 15
+    - __kind: GoInterfaceType
+      ID: 114
+      Name: context.Context
+      ByteSize: 16
+      GoRuntimeType: 1.215776e+06
+      GoKind: 20
       RawFields:
-        - Name: array
+        - Name: tab
           Offset: 0
-          Type: 6 PointerType *uint8
-        - Name: len
+          Type: 2 VoidPointerType unsafe.Pointer
+        - Name: data
           Offset: 8
-          Type: 8 BaseType int
-        - Name: cap
-          Offset: 16
-          Type: 8 BaseType int
-      Data: 213 GoSliceDataType []uint8.array
-    - __kind: PointerType
-      ID: 53
-      Name: '*crypto/tls.ConnectionState'
-      ByteSize: 8
-      GoRuntimeType: 852320
-      GoKind: 22
-      Pointee: 54 StructureType crypto/tls.ConnectionState
+          Type: 2 VoidPointerType unsafe.Pointer
+    - __kind: StructureType
+      ID: 182
+      Name: context.backgroundCtx
+      GoRuntimeType: 1.708832e+06
+      GoKind: 25
+      RawFields:
+        - Name: emptyCtx
+          Offset: 0
+          Type: 183 StructureType context.emptyCtx
+    - __kind: StructureType
+      ID: 183
+      Name: context.emptyCtx
+      GoRuntimeType: 1.435104e+06
+      GoKind: 25
+      RawFields: []
     - __kind: StructureType
       ID: 54
       Name: crypto/tls.ConnectionState
@@ -808,35 +1554,12 @@ Types:
         - Name: testingOnlyCurveID
           Offset: 186
           Type: 110 BaseType crypto/tls.CurveID
-    - __kind: GoSliceHeaderType
-      ID: 55
-      Name: '[]*crypto/x509.Certificate'
-      ByteSize: 24
-      GoRuntimeType: 473920
-      GoKind: 23
-      RawFields:
-        - Name: array
-          Offset: 0
-          Type: 56 PointerType **crypto/x509.Certificate
-        - Name: len
-          Offset: 8
-          Type: 8 BaseType int
-        - Name: cap
-          Offset: 16
-          Type: 8 BaseType int
-      Data: 215 GoSliceDataType []*crypto/x509.Certificate.array
-    - __kind: PointerType
-      ID: 56
-      Name: '**crypto/x509.Certificate'
-      ByteSize: 8
-      Pointee: 57 PointerType *crypto/x509.Certificate
-    - __kind: PointerType
-      ID: 57
-      Name: '*crypto/x509.Certificate'
-      ByteSize: 8
-      GoRuntimeType: 1.95344e+06
-      GoKind: 22
-      Pointee: 58 StructureType crypto/x509.Certificate
+    - __kind: BaseType
+      ID: 110
+      Name: crypto/tls.CurveID
+      ByteSize: 2
+      GoRuntimeType: 778592
+      GoKind: 9
     - __kind: StructureType
       ID: 58
       Name: crypto/x509.Certificate
@@ -980,80 +1703,68 @@ Types:
           Offset: 1328
           Type: 102 GoSliceHeaderType []crypto/x509.OID
     - __kind: BaseType
-      ID: 59
-      Name: crypto/x509.SignatureAlgorithm
+      ID: 91
+      Name: crypto/x509.ExtKeyUsage
       ByteSize: 8
-      GoRuntimeType: 1.09744e+06
+      GoRuntimeType: 546624
       GoKind: 2
+    - __kind: BaseType
+      ID: 83
+      Name: crypto/x509.KeyUsage
+      ByteSize: 8
+      GoRuntimeType: 546560
+      GoKind: 2
+    - __kind: StructureType
+      ID: 104
+      Name: crypto/x509.OID
+      ByteSize: 24
+      GoRuntimeType: 1.762592e+06
+      GoKind: 25
+      RawFields:
+        - Name: der
+          Offset: 0
+          Type: 52 GoSliceHeaderType []uint8
     - __kind: BaseType
       ID: 60
       Name: crypto/x509.PublicKeyAlgorithm
       ByteSize: 8
       GoRuntimeType: 780896
       GoKind: 2
-    - __kind: GoEmptyInterfaceType
-      ID: 61
-      Name: interface {}
-      ByteSize: 16
-      GoRuntimeType: 798016
-      GoKind: 20
-      RawFields:
-        - Name: _type
-          Offset: 0
-          Type: 2 VoidPointerType unsafe.Pointer
-        - Name: data
-          Offset: 8
-          Type: 2 VoidPointerType unsafe.Pointer
-    - __kind: PointerType
-      ID: 62
-      Name: '*math/big.Int'
+    - __kind: BaseType
+      ID: 59
+      Name: crypto/x509.SignatureAlgorithm
       ByteSize: 8
-      GoRuntimeType: 2.29744e+06
-      GoKind: 22
-      Pointee: 63 StructureType math/big.Int
+      GoRuntimeType: 1.09744e+06
+      GoKind: 2
     - __kind: StructureType
-      ID: 63
-      Name: math/big.Int
-      ByteSize: 32
-      GoRuntimeType: 1.340768e+06
+      ID: 70
+      Name: crypto/x509/pkix.AttributeTypeAndValue
+      ByteSize: 40
+      GoRuntimeType: 1.349408e+06
       GoKind: 25
       RawFields:
-        - Name: neg
+        - Name: Type
           Offset: 0
-          Type: 13 BaseType bool
-        - Name: abs
-          Offset: 8
-          Type: 64 GoSliceHeaderType math/big.nat
-    - __kind: GoSliceHeaderType
-      ID: 64
-      Name: math/big.nat
-      ByteSize: 24
-      GoRuntimeType: 2.280544e+06
-      GoKind: 23
+          Type: 71 GoSliceHeaderType encoding/asn1.ObjectIdentifier
+        - Name: Value
+          Offset: 24
+          Type: 61 GoEmptyInterfaceType interface {}
+    - __kind: StructureType
+      ID: 86
+      Name: crypto/x509/pkix.Extension
+      ByteSize: 56
+      GoRuntimeType: 1.494976e+06
+      GoKind: 25
       RawFields:
-        - Name: array
+        - Name: Id
           Offset: 0
-          Type: 65 PointerType *math/big.Word
-        - Name: len
-          Offset: 8
-          Type: 8 BaseType int
-        - Name: cap
-          Offset: 16
-          Type: 8 BaseType int
-      Data: 217 GoSliceDataType math/big.nat.array
-    - __kind: PointerType
-      ID: 65
-      Name: '*math/big.Word'
-      ByteSize: 8
-      GoRuntimeType: 403552
-      GoKind: 22
-      Pointee: 66 BaseType math/big.Word
-    - __kind: BaseType
-      ID: 66
-      Name: math/big.Word
-      ByteSize: 8
-      GoRuntimeType: 546880
-      GoKind: 7
+          Type: 71 GoSliceHeaderType encoding/asn1.ObjectIdentifier
+        - Name: Critical
+          Offset: 24
+          Type: 13 BaseType bool
+        - Name: Value
+          Offset: 32
+          Type: 52 GoSliceHeaderType []uint8
     - __kind: StructureType
       ID: 67
       Name: crypto/x509/pkix.Name
@@ -1095,43 +1806,6 @@ Types:
           Offset: 224
           Type: 68 GoSliceHeaderType []crypto/x509/pkix.AttributeTypeAndValue
     - __kind: GoSliceHeaderType
-      ID: 68
-      Name: '[]crypto/x509/pkix.AttributeTypeAndValue'
-      ByteSize: 24
-      GoRuntimeType: 487296
-      GoKind: 23
-      RawFields:
-        - Name: array
-          Offset: 0
-          Type: 69 PointerType *crypto/x509/pkix.AttributeTypeAndValue
-        - Name: len
-          Offset: 8
-          Type: 8 BaseType int
-        - Name: cap
-          Offset: 16
-          Type: 8 BaseType int
-      Data: 219 GoSliceDataType []crypto/x509/pkix.AttributeTypeAndValue.array
-    - __kind: PointerType
-      ID: 69
-      Name: '*crypto/x509/pkix.AttributeTypeAndValue'
-      ByteSize: 8
-      GoRuntimeType: 417504
-      GoKind: 22
-      Pointee: 70 StructureType crypto/x509/pkix.AttributeTypeAndValue
-    - __kind: StructureType
-      ID: 70
-      Name: crypto/x509/pkix.AttributeTypeAndValue
-      ByteSize: 40
-      GoRuntimeType: 1.349408e+06
-      GoKind: 25
-      RawFields:
-        - Name: Type
-          Offset: 0
-          Type: 71 GoSliceHeaderType encoding/asn1.ObjectIdentifier
-        - Name: Value
-          Offset: 24
-          Type: 61 GoEmptyInterfaceType interface {}
-    - __kind: GoSliceHeaderType
       ID: 71
       Name: encoding/asn1.ObjectIdentifier
       ByteSize: 24
@@ -1148,535 +1822,16 @@ Types:
           Offset: 16
           Type: 8 BaseType int
       Data: 221 GoSliceDataType encoding/asn1.ObjectIdentifier.array
-    - __kind: PointerType
-      ID: 72
-      Name: '*int'
-      ByteSize: 8
-      GoRuntimeType: 376672
-      GoKind: 22
-      Pointee: 8 BaseType int
-    - __kind: StructureType
-      ID: 73
-      Name: time.Time
-      ByteSize: 24
-      GoRuntimeType: 2.281472e+06
-      GoKind: 25
-      RawFields:
-        - Name: wall
-          Offset: 0
-          Type: 74 BaseType uint64
-        - Name: ext
-          Offset: 8
-          Type: 36 BaseType int64
-        - Name: loc
-          Offset: 16
-          Type: 75 PointerType *time.Location
-    - __kind: BaseType
-      ID: 74
-      Name: uint64
-      ByteSize: 8
-      GoRuntimeType: 543040
-      GoKind: 11
-    - __kind: PointerType
-      ID: 75
-      Name: '*time.Location'
-      ByteSize: 8
-      GoRuntimeType: 1.458496e+06
-      GoKind: 22
-      Pointee: 76 StructureType time.Location
-    - __kind: StructureType
-      ID: 76
-      Name: time.Location
-      ByteSize: 104
-      GoRuntimeType: 1.877952e+06
-      GoKind: 25
-      RawFields:
-        - Name: name
-          Offset: 0
-          Type: 5 GoStringHeaderType string
-        - Name: zone
-          Offset: 16
-          Type: 77 GoSliceHeaderType []time.zone
-        - Name: tx
-          Offset: 40
-          Type: 80 GoSliceHeaderType []time.zoneTrans
-        - Name: extend
-          Offset: 64
-          Type: 5 GoStringHeaderType string
-        - Name: cacheStart
-          Offset: 80
-          Type: 36 BaseType int64
-        - Name: cacheEnd
-          Offset: 88
-          Type: 36 BaseType int64
-        - Name: cacheZone
-          Offset: 96
-          Type: 78 PointerType *time.zone
-    - __kind: GoSliceHeaderType
-      ID: 77
-      Name: '[]time.zone'
-      ByteSize: 24
-      GoRuntimeType: 463264
-      GoKind: 23
-      RawFields:
-        - Name: array
-          Offset: 0
-          Type: 78 PointerType *time.zone
-        - Name: len
-          Offset: 8
-          Type: 8 BaseType int
-        - Name: cap
-          Offset: 16
-          Type: 8 BaseType int
-      Data: 223 GoSliceDataType []time.zone.array
-    - __kind: PointerType
-      ID: 78
-      Name: '*time.zone'
-      ByteSize: 8
-      GoRuntimeType: 370976
-      GoKind: 22
-      Pointee: 79 StructureType time.zone
-    - __kind: StructureType
-      ID: 79
-      Name: time.zone
-      ByteSize: 32
-      GoRuntimeType: 1.458304e+06
-      GoKind: 25
-      RawFields:
-        - Name: name
-          Offset: 0
-          Type: 5 GoStringHeaderType string
-        - Name: offset
-          Offset: 16
-          Type: 8 BaseType int
-        - Name: isDST
-          Offset: 24
-          Type: 13 BaseType bool
-    - __kind: GoSliceHeaderType
-      ID: 80
-      Name: '[]time.zoneTrans'
-      ByteSize: 24
-      GoRuntimeType: 463328
-      GoKind: 23
-      RawFields:
-        - Name: array
-          Offset: 0
-          Type: 81 PointerType *time.zoneTrans
-        - Name: len
-          Offset: 8
-          Type: 8 BaseType int
-        - Name: cap
-          Offset: 16
-          Type: 8 BaseType int
-      Data: 225 GoSliceDataType []time.zoneTrans.array
-    - __kind: PointerType
-      ID: 81
-      Name: '*time.zoneTrans'
-      ByteSize: 8
-      GoRuntimeType: 371040
-      GoKind: 22
-      Pointee: 82 StructureType time.zoneTrans
-    - __kind: StructureType
-      ID: 82
-      Name: time.zoneTrans
-      ByteSize: 16
-      GoRuntimeType: 1.664192e+06
-      GoKind: 25
-      RawFields:
-        - Name: when
-          Offset: 0
-          Type: 36 BaseType int64
-        - Name: index
-          Offset: 8
-          Type: 7 BaseType uint8
-        - Name: isstd
-          Offset: 9
-          Type: 13 BaseType bool
-        - Name: isutc
-          Offset: 10
-          Type: 13 BaseType bool
-    - __kind: BaseType
-      ID: 83
-      Name: crypto/x509.KeyUsage
-      ByteSize: 8
-      GoRuntimeType: 546560
-      GoKind: 2
-    - __kind: GoSliceHeaderType
-      ID: 84
-      Name: '[]crypto/x509/pkix.Extension'
-      ByteSize: 24
-      GoRuntimeType: 486784
-      GoKind: 23
-      RawFields:
-        - Name: array
-          Offset: 0
-          Type: 85 PointerType *crypto/x509/pkix.Extension
-        - Name: len
-          Offset: 8
-          Type: 8 BaseType int
-        - Name: cap
-          Offset: 16
-          Type: 8 BaseType int
-      Data: 227 GoSliceDataType []crypto/x509/pkix.Extension.array
-    - __kind: PointerType
-      ID: 85
-      Name: '*crypto/x509/pkix.Extension'
-      ByteSize: 8
-      GoRuntimeType: 417696
-      GoKind: 22
-      Pointee: 86 StructureType crypto/x509/pkix.Extension
-    - __kind: StructureType
-      ID: 86
-      Name: crypto/x509/pkix.Extension
-      ByteSize: 56
-      GoRuntimeType: 1.494976e+06
-      GoKind: 25
-      RawFields:
-        - Name: Id
-          Offset: 0
-          Type: 71 GoSliceHeaderType encoding/asn1.ObjectIdentifier
-        - Name: Critical
-          Offset: 24
-          Type: 13 BaseType bool
-        - Name: Value
-          Offset: 32
-          Type: 52 GoSliceHeaderType []uint8
-    - __kind: GoSliceHeaderType
-      ID: 87
-      Name: '[]encoding/asn1.ObjectIdentifier'
-      ByteSize: 24
-      GoRuntimeType: 486848
-      GoKind: 23
-      RawFields:
-        - Name: array
-          Offset: 0
-          Type: 88 PointerType *encoding/asn1.ObjectIdentifier
-        - Name: len
-          Offset: 8
-          Type: 8 BaseType int
-        - Name: cap
-          Offset: 16
-          Type: 8 BaseType int
-      Data: 229 GoSliceDataType []encoding/asn1.ObjectIdentifier.array
-    - __kind: PointerType
-      ID: 88
-      Name: '*encoding/asn1.ObjectIdentifier'
-      ByteSize: 8
-      GoRuntimeType: 1.037472e+06
-      GoKind: 22
-      Pointee: 71 GoSliceHeaderType encoding/asn1.ObjectIdentifier
-    - __kind: GoSliceHeaderType
-      ID: 89
-      Name: '[]crypto/x509.ExtKeyUsage'
-      ByteSize: 24
-      GoRuntimeType: 475200
-      GoKind: 23
-      RawFields:
-        - Name: array
-          Offset: 0
-          Type: 90 PointerType *crypto/x509.ExtKeyUsage
-        - Name: len
-          Offset: 8
-          Type: 8 BaseType int
-        - Name: cap
-          Offset: 16
-          Type: 8 BaseType int
-      Data: 231 GoSliceDataType []crypto/x509.ExtKeyUsage.array
-    - __kind: PointerType
-      ID: 90
-      Name: '*crypto/x509.ExtKeyUsage'
-      ByteSize: 8
-      GoRuntimeType: 400736
-      GoKind: 22
-      Pointee: 91 BaseType crypto/x509.ExtKeyUsage
-    - __kind: BaseType
-      ID: 91
-      Name: crypto/x509.ExtKeyUsage
-      ByteSize: 8
-      GoRuntimeType: 546624
-      GoKind: 2
-    - __kind: GoSliceHeaderType
-      ID: 92
-      Name: '[]net.IP'
-      ByteSize: 24
-      GoRuntimeType: 458400
-      GoKind: 23
-      RawFields:
-        - Name: array
-          Offset: 0
-          Type: 93 PointerType *net.IP
-        - Name: len
-          Offset: 8
-          Type: 8 BaseType int
-        - Name: cap
-          Offset: 16
-          Type: 8 BaseType int
-      Data: 233 GoSliceDataType []net.IP.array
-    - __kind: PointerType
-      ID: 93
-      Name: '*net.IP'
-      ByteSize: 8
-      GoRuntimeType: 2.02912e+06
-      GoKind: 22
-      Pointee: 94 GoSliceHeaderType net.IP
-    - __kind: GoSliceHeaderType
-      ID: 94
-      Name: net.IP
-      ByteSize: 24
-      GoRuntimeType: 2.00144e+06
-      GoKind: 23
-      RawFields:
-        - Name: array
-          Offset: 0
-          Type: 6 PointerType *uint8
-        - Name: len
-          Offset: 8
-          Type: 8 BaseType int
-        - Name: cap
-          Offset: 16
-          Type: 8 BaseType int
-      Data: 235 GoSliceDataType net.IP.array
-    - __kind: GoSliceHeaderType
-      ID: 95
-      Name: '[]*net/url.URL'
-      ByteSize: 24
-      GoRuntimeType: 486912
-      GoKind: 23
-      RawFields:
-        - Name: array
-          Offset: 0
-          Type: 96 PointerType **net/url.URL
-        - Name: len
-          Offset: 8
-          Type: 8 BaseType int
-        - Name: cap
-          Offset: 16
-          Type: 8 BaseType int
-      Data: 237 GoSliceDataType []*net/url.URL.array
-    - __kind: PointerType
-      ID: 96
-      Name: '**net/url.URL'
-      ByteSize: 8
-      Pointee: 9 PointerType *net/url.URL
-    - __kind: GoSliceHeaderType
-      ID: 97
-      Name: '[]*net.IPNet'
-      ByteSize: 24
-      GoRuntimeType: 486976
-      GoKind: 23
-      RawFields:
-        - Name: array
-          Offset: 0
-          Type: 98 PointerType **net.IPNet
-        - Name: len
-          Offset: 8
-          Type: 8 BaseType int
-        - Name: cap
-          Offset: 16
-          Type: 8 BaseType int
-      Data: 239 GoSliceDataType []*net.IPNet.array
-    - __kind: PointerType
-      ID: 98
-      Name: '**net.IPNet'
-      ByteSize: 8
-      GoKind: 22
-      Pointee: 99 PointerType *net.IPNet
-    - __kind: PointerType
-      ID: 99
-      Name: '*net.IPNet'
-      ByteSize: 8
-      GoRuntimeType: 1.122912e+06
-      GoKind: 22
-      Pointee: 100 StructureType net.IPNet
-    - __kind: StructureType
-      ID: 100
-      Name: net.IPNet
-      ByteSize: 48
-      GoRuntimeType: 1.307168e+06
-      GoKind: 25
-      RawFields:
-        - Name: IP
-          Offset: 0
-          Type: 94 GoSliceHeaderType net.IP
-        - Name: Mask
-          Offset: 24
-          Type: 101 GoSliceHeaderType net.IPMask
-    - __kind: GoSliceHeaderType
-      ID: 101
-      Name: net.IPMask
-      ByteSize: 24
-      GoRuntimeType: 999456
-      GoKind: 23
-      RawFields:
-        - Name: array
-          Offset: 0
-          Type: 6 PointerType *uint8
-        - Name: len
-          Offset: 8
-          Type: 8 BaseType int
-        - Name: cap
-          Offset: 16
-          Type: 8 BaseType int
-      Data: 241 GoSliceDataType net.IPMask.array
-    - __kind: GoSliceHeaderType
-      ID: 102
-      Name: '[]crypto/x509.OID'
-      ByteSize: 24
-      GoRuntimeType: 487040
-      GoKind: 23
-      RawFields:
-        - Name: array
-          Offset: 0
-          Type: 103 PointerType *crypto/x509.OID
-        - Name: len
-          Offset: 8
-          Type: 8 BaseType int
-        - Name: cap
-          Offset: 16
-          Type: 8 BaseType int
-      Data: 243 GoSliceDataType []crypto/x509.OID.array
-    - __kind: PointerType
-      ID: 103
-      Name: '*crypto/x509.OID'
-      ByteSize: 8
-      GoRuntimeType: 1.762368e+06
-      GoKind: 22
-      Pointee: 104 StructureType crypto/x509.OID
-    - __kind: StructureType
-      ID: 104
-      Name: crypto/x509.OID
-      ByteSize: 24
-      GoRuntimeType: 1.762592e+06
-      GoKind: 25
-      RawFields:
-        - Name: der
-          Offset: 0
-          Type: 52 GoSliceHeaderType []uint8
-    - __kind: GoSliceHeaderType
-      ID: 105
-      Name: '[][]*crypto/x509.Certificate'
-      ByteSize: 24
-      GoRuntimeType: 474048
-      GoKind: 23
-      RawFields:
-        - Name: array
-          Offset: 0
-          Type: 106 PointerType *[]*crypto/x509.Certificate
-        - Name: len
-          Offset: 8
-          Type: 8 BaseType int
-        - Name: cap
-          Offset: 16
-          Type: 8 BaseType int
-      Data: 245 GoSliceDataType [][]*crypto/x509.Certificate.array
-    - __kind: PointerType
-      ID: 106
-      Name: '*[]*crypto/x509.Certificate'
-      ByteSize: 8
-      GoKind: 22
-      Pointee: 55 GoSliceHeaderType []*crypto/x509.Certificate
-    - __kind: GoSliceHeaderType
-      ID: 107
-      Name: '[][]uint8'
-      ByteSize: 24
-      GoRuntimeType: 457184
-      GoKind: 23
-      RawFields:
-        - Name: array
-          Offset: 0
-          Type: 108 PointerType *[]uint8
-        - Name: len
-          Offset: 8
-          Type: 8 BaseType int
-        - Name: cap
-          Offset: 16
-          Type: 8 BaseType int
-      Data: 247 GoSliceDataType [][]uint8.array
-    - __kind: PointerType
-      ID: 108
-      Name: '*[]uint8'
-      ByteSize: 8
-      GoRuntimeType: 456928
-      GoKind: 22
-      Pointee: 52 GoSliceHeaderType []uint8
-    - __kind: GoSubroutineType
-      ID: 109
-      Name: func(string, []uint8, int) ([]uint8, error)
-      ByteSize: 8
-      GoRuntimeType: 983200
-      GoKind: 19
-    - __kind: BaseType
-      ID: 110
-      Name: crypto/tls.CurveID
-      ByteSize: 2
-      GoRuntimeType: 778592
-      GoKind: 9
-    - __kind: GoChannelType
-      ID: 111
-      Name: <-chan struct {}
-      GoRuntimeType: 555520
-      GoKind: 18
-    - __kind: PointerType
-      ID: 112
-      Name: '*net/http.Response'
-      ByteSize: 8
-      GoRuntimeType: 1.632736e+06
-      GoKind: 22
-      Pointee: 113 StructureType net/http.Response
-    - __kind: StructureType
-      ID: 113
-      Name: net/http.Response
-      ByteSize: 144
-      GoRuntimeType: 2.124032e+06
-      GoKind: 25
-      RawFields:
-        - Name: Status
-          Offset: 0
-          Type: 5 GoStringHeaderType string
-        - Name: StatusCode
-          Offset: 16
-          Type: 8 BaseType int
-        - Name: Proto
-          Offset: 24
-          Type: 5 GoStringHeaderType string
-        - Name: ProtoMajor
-          Offset: 40
-          Type: 8 BaseType int
-        - Name: ProtoMinor
-          Offset: 48
-          Type: 8 BaseType int
-        - Name: Header
-          Offset: 56
-          Type: 14 GoMapType net/http.Header
-        - Name: Body
-          Offset: 64
-          Type: 34 GoInterfaceType io.ReadCloser
-        - Name: ContentLength
-          Offset: 80
-          Type: 36 BaseType int64
-        - Name: TransferEncoding
-          Offset: 88
-          Type: 24 GoSliceHeaderType []string
-        - Name: Close
-          Offset: 112
-          Type: 13 BaseType bool
-        - Name: Uncompressed
-          Offset: 113
-          Type: 13 BaseType bool
-        - Name: Trailer
-          Offset: 120
-          Type: 14 GoMapType net/http.Header
-        - Name: Request
-          Offset: 128
-          Type: 3 PointerType *net/http.Request
-        - Name: TLS
-          Offset: 136
-          Type: 53 PointerType *crypto/tls.ConnectionState
+    - __kind: GoSliceDataType
+      ID: 221
+      Name: encoding/asn1.ObjectIdentifier.array
+      ByteSize: 2048
+      Element: 8 BaseType int
     - __kind: GoInterfaceType
-      ID: 114
-      Name: context.Context
+      ID: 189
+      Name: error
       ByteSize: 16
-      GoRuntimeType: 1.215776e+06
+      GoRuntimeType: 1.011104e+06
       GoKind: 20
       RawFields:
         - Name: tab
@@ -1685,159 +1840,36 @@ Types:
         - Name: data
           Offset: 8
           Type: 2 VoidPointerType unsafe.Pointer
-    - __kind: PointerType
-      ID: 115
-      Name: '*net/http.pattern'
+    - __kind: BaseType
+      ID: 188
+      Name: float32
+      ByteSize: 4
+      GoRuntimeType: 543424
+      GoKind: 13
+    - __kind: BaseType
+      ID: 145
+      Name: float64
       ByteSize: 8
-      GoRuntimeType: 1.453504e+06
-      GoKind: 22
-      Pointee: 116 StructureType net/http.pattern
-    - __kind: StructureType
-      ID: 116
-      Name: net/http.pattern
-      ByteSize: 88
-      GoRuntimeType: 1.745568e+06
-      GoKind: 25
-      RawFields:
-        - Name: str
-          Offset: 0
-          Type: 5 GoStringHeaderType string
-        - Name: method
-          Offset: 16
-          Type: 5 GoStringHeaderType string
-        - Name: host
-          Offset: 32
-          Type: 5 GoStringHeaderType string
-        - Name: segments
-          Offset: 48
-          Type: 117 GoSliceHeaderType []net/http.segment
-        - Name: loc
-          Offset: 72
-          Type: 5 GoStringHeaderType string
-    - __kind: GoSliceHeaderType
-      ID: 117
-      Name: '[]net/http.segment'
-      ByteSize: 24
-      GoRuntimeType: 459168
-      GoKind: 23
-      RawFields:
-        - Name: array
-          Offset: 0
-          Type: 118 PointerType *net/http.segment
-        - Name: len
-          Offset: 8
-          Type: 8 BaseType int
-        - Name: cap
-          Offset: 16
-          Type: 8 BaseType int
-      Data: 249 GoSliceDataType []net/http.segment.array
-    - __kind: PointerType
-      ID: 118
-      Name: '*net/http.segment'
+      GoRuntimeType: 543488
+      GoKind: 14
+    - __kind: GoSubroutineType
+      ID: 178
+      Name: func()
       ByteSize: 8
-      GoRuntimeType: 367904
-      GoKind: 22
-      Pointee: 119 StructureType net/http.segment
-    - __kind: StructureType
-      ID: 119
-      Name: net/http.segment
-      ByteSize: 24
-      GoRuntimeType: 1.453312e+06
-      GoKind: 25
-      RawFields:
-        - Name: s
-          Offset: 0
-          Type: 5 GoStringHeaderType string
-        - Name: wild
-          Offset: 16
-          Type: 13 BaseType bool
-        - Name: multi
-          Offset: 17
-          Type: 13 BaseType bool
-    - __kind: GoMapType
-      ID: 120
-      Name: map[string]string
+      GoRuntimeType: 455520
+      GoKind: 19
+    - __kind: GoSubroutineType
+      ID: 35
+      Name: func() (io.ReadCloser, error)
       ByteSize: 8
-      GoRuntimeType: 900992
-      GoKind: 21
-      HeaderType: 122 GoHMapHeaderType hash<string,string>
-    - __kind: PointerType
-      ID: 121
-      Name: '*hash<string,string>'
+      GoRuntimeType: 645600
+      GoKind: 19
+    - __kind: GoSubroutineType
+      ID: 109
+      Name: func(string, []uint8, int) ([]uint8, error)
       ByteSize: 8
-      Pointee: 122 GoHMapHeaderType hash<string,string>
-    - __kind: GoHMapHeaderType
-      ID: 122
-      Name: hash<string,string>
-      ByteSize: 48
-      RawFields:
-        - Name: count
-          Offset: 0
-          Type: 8 BaseType int
-        - Name: flags
-          Offset: 8
-          Type: 7 BaseType uint8
-        - Name: B
-          Offset: 9
-          Type: 7 BaseType uint8
-        - Name: noverflow
-          Offset: 10
-          Type: 17 BaseType uint16
-        - Name: hash0
-          Offset: 12
-          Type: 18 BaseType uint32
-        - Name: buckets
-          Offset: 16
-          Type: 123 PointerType *bucket<string,string>
-        - Name: oldbuckets
-          Offset: 24
-          Type: 123 PointerType *bucket<string,string>
-        - Name: nevacuate
-          Offset: 32
-          Type: 26 BaseType uintptr
-        - Name: extra
-          Offset: 40
-          Type: 27 PointerType *runtime.mapextra
-      BucketType: 124 GoHMapBucketType bucket<string,string>
-      BucketsType: 251 GoSliceDataType []bucket<string,string>.array
-    - __kind: PointerType
-      ID: 123
-      Name: '*bucket<string,string>'
-      ByteSize: 8
-      Pointee: 124 GoHMapBucketType bucket<string,string>
-    - __kind: GoHMapBucketType
-      ID: 124
-      Name: bucket<string,string>
-      ByteSize: 272
-      RawFields:
-        - Name: tophash
-          Offset: 0
-          Type: 21 ArrayType [8]uint8
-        - Name: keys
-          Offset: 8
-          Type: 22 ArrayType []key<string>
-        - Name: values
-          Offset: 136
-          Type: 125 ArrayType []val<string>
-        - Name: overflow
-          Offset: 264
-          Type: 123 PointerType *bucket<string,string>
-      KeyType: 5 GoStringHeaderType string
-      ValueType: 5 GoStringHeaderType string
-    - __kind: ArrayType
-      ID: 125
-      Name: '[]val<string>'
-      ByteSize: 128
-      Count: 8
-      HasCount: true
-      Element: 5 GoStringHeaderType string
-    - __kind: PointerType
-      ID: 126
-      Name: '*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span'
-      ByteSize: 8
-      GoRuntimeType: 2.18768e+06
-      GoKind: 22
-      Pointee: 127 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span
+      GoRuntimeType: 983200
+      GoKind: 19
     - __kind: StructureType
       ID: 127
       Name: github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span
@@ -1921,522 +1953,6 @@ Types:
           Offset: 280
           Type: 178 GoSubroutineType func()
     - __kind: StructureType
-      ID: 128
-      Name: sync.RWMutex
-      ByteSize: 24
-      GoRuntimeType: 1.751168e+06
-      GoKind: 25
-      RawFields:
-        - Name: w
-          Offset: 0
-          Type: 129 StructureType sync.Mutex
-        - Name: writerSem
-          Offset: 8
-          Type: 18 BaseType uint32
-        - Name: readerSem
-          Offset: 12
-          Type: 18 BaseType uint32
-        - Name: readerCount
-          Offset: 16
-          Type: 131 StructureType sync/atomic.Int32
-        - Name: readerWait
-          Offset: 20
-          Type: 131 StructureType sync/atomic.Int32
-    - __kind: StructureType
-      ID: 129
-      Name: sync.Mutex
-      ByteSize: 8
-      GoRuntimeType: 1.314208e+06
-      GoKind: 25
-      RawFields:
-        - Name: state
-          Offset: 0
-          Type: 130 BaseType int32
-        - Name: sema
-          Offset: 4
-          Type: 18 BaseType uint32
-    - __kind: BaseType
-      ID: 130
-      Name: int32
-      ByteSize: 4
-      GoRuntimeType: 542848
-      GoKind: 5
-    - __kind: StructureType
-      ID: 131
-      Name: sync/atomic.Int32
-      ByteSize: 4
-      GoRuntimeType: 1.315648e+06
-      GoKind: 25
-      RawFields:
-        - Name: _
-          Offset: 0
-          Type: 132 StructureType sync/atomic.noCopy
-        - Name: v
-          Offset: 0
-          Type: 130 BaseType int32
-    - __kind: StructureType
-      ID: 132
-      Name: sync/atomic.noCopy
-      GoRuntimeType: 966016
-      GoKind: 25
-      RawFields: []
-    - __kind: GoMapType
-      ID: 133
-      Name: github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.metaStructMap
-      ByteSize: 8
-      GoRuntimeType: 1.00752e+06
-      GoKind: 21
-      HeaderType: 135 GoHMapHeaderType hash<string,interface {}>
-    - __kind: PointerType
-      ID: 134
-      Name: '*hash<string,interface {}>'
-      ByteSize: 8
-      Pointee: 135 GoHMapHeaderType hash<string,interface {}>
-    - __kind: GoHMapHeaderType
-      ID: 135
-      Name: hash<string,interface {}>
-      ByteSize: 48
-      RawFields:
-        - Name: count
-          Offset: 0
-          Type: 8 BaseType int
-        - Name: flags
-          Offset: 8
-          Type: 7 BaseType uint8
-        - Name: B
-          Offset: 9
-          Type: 7 BaseType uint8
-        - Name: noverflow
-          Offset: 10
-          Type: 17 BaseType uint16
-        - Name: hash0
-          Offset: 12
-          Type: 18 BaseType uint32
-        - Name: buckets
-          Offset: 16
-          Type: 136 PointerType *bucket<string,interface {}>
-        - Name: oldbuckets
-          Offset: 24
-          Type: 136 PointerType *bucket<string,interface {}>
-        - Name: nevacuate
-          Offset: 32
-          Type: 26 BaseType uintptr
-        - Name: extra
-          Offset: 40
-          Type: 27 PointerType *runtime.mapextra
-      BucketType: 137 GoHMapBucketType bucket<string,interface {}>
-      BucketsType: 252 GoSliceDataType []bucket<string,interface {}>.array
-    - __kind: PointerType
-      ID: 136
-      Name: '*bucket<string,interface {}>'
-      ByteSize: 8
-      Pointee: 137 GoHMapBucketType bucket<string,interface {}>
-    - __kind: GoHMapBucketType
-      ID: 137
-      Name: bucket<string,interface {}>
-      ByteSize: 272
-      RawFields:
-        - Name: tophash
-          Offset: 0
-          Type: 21 ArrayType [8]uint8
-        - Name: keys
-          Offset: 8
-          Type: 22 ArrayType []key<string>
-        - Name: values
-          Offset: 136
-          Type: 138 ArrayType []val<interface {}>
-        - Name: overflow
-          Offset: 264
-          Type: 136 PointerType *bucket<string,interface {}>
-      KeyType: 5 GoStringHeaderType string
-      ValueType: 61 GoEmptyInterfaceType interface {}
-    - __kind: ArrayType
-      ID: 138
-      Name: '[]val<interface {}>'
-      ByteSize: 128
-      Count: 8
-      HasCount: true
-      Element: 61 GoEmptyInterfaceType interface {}
-    - __kind: GoMapType
-      ID: 139
-      Name: map[string]float64
-      ByteSize: 8
-      GoRuntimeType: 905024
-      GoKind: 21
-      HeaderType: 141 GoHMapHeaderType hash<string,float64>
-    - __kind: PointerType
-      ID: 140
-      Name: '*hash<string,float64>'
-      ByteSize: 8
-      Pointee: 141 GoHMapHeaderType hash<string,float64>
-    - __kind: GoHMapHeaderType
-      ID: 141
-      Name: hash<string,float64>
-      ByteSize: 48
-      RawFields:
-        - Name: count
-          Offset: 0
-          Type: 8 BaseType int
-        - Name: flags
-          Offset: 8
-          Type: 7 BaseType uint8
-        - Name: B
-          Offset: 9
-          Type: 7 BaseType uint8
-        - Name: noverflow
-          Offset: 10
-          Type: 17 BaseType uint16
-        - Name: hash0
-          Offset: 12
-          Type: 18 BaseType uint32
-        - Name: buckets
-          Offset: 16
-          Type: 142 PointerType *bucket<string,float64>
-        - Name: oldbuckets
-          Offset: 24
-          Type: 142 PointerType *bucket<string,float64>
-        - Name: nevacuate
-          Offset: 32
-          Type: 26 BaseType uintptr
-        - Name: extra
-          Offset: 40
-          Type: 27 PointerType *runtime.mapextra
-      BucketType: 143 GoHMapBucketType bucket<string,float64>
-      BucketsType: 253 GoSliceDataType []bucket<string,float64>.array
-    - __kind: PointerType
-      ID: 142
-      Name: '*bucket<string,float64>'
-      ByteSize: 8
-      Pointee: 143 GoHMapBucketType bucket<string,float64>
-    - __kind: GoHMapBucketType
-      ID: 143
-      Name: bucket<string,float64>
-      ByteSize: 208
-      RawFields:
-        - Name: tophash
-          Offset: 0
-          Type: 21 ArrayType [8]uint8
-        - Name: keys
-          Offset: 8
-          Type: 22 ArrayType []key<string>
-        - Name: values
-          Offset: 136
-          Type: 144 ArrayType []val<float64>
-        - Name: overflow
-          Offset: 200
-          Type: 142 PointerType *bucket<string,float64>
-      KeyType: 5 GoStringHeaderType string
-      ValueType: 145 BaseType float64
-    - __kind: ArrayType
-      ID: 144
-      Name: '[]val<float64>'
-      ByteSize: 64
-      Count: 8
-      HasCount: true
-      Element: 145 BaseType float64
-    - __kind: BaseType
-      ID: 145
-      Name: float64
-      ByteSize: 8
-      GoRuntimeType: 543488
-      GoKind: 14
-    - __kind: GoSliceHeaderType
-      ID: 146
-      Name: '[]github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink'
-      ByteSize: 24
-      GoRuntimeType: 463584
-      GoKind: 23
-      RawFields:
-        - Name: array
-          Offset: 0
-          Type: 147 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink
-        - Name: len
-          Offset: 8
-          Type: 8 BaseType int
-        - Name: cap
-          Offset: 16
-          Type: 8 BaseType int
-      Data: 254 GoSliceDataType []github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink.array
-    - __kind: PointerType
-      ID: 147
-      Name: '*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink'
-      ByteSize: 8
-      GoRuntimeType: 1.12944e+06
-      GoKind: 22
-      Pointee: 148 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink
-    - __kind: StructureType
-      ID: 148
-      Name: github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink
-      ByteSize: 56
-      GoRuntimeType: 1.822592e+06
-      GoKind: 25
-      RawFields:
-        - Name: TraceID
-          Offset: 0
-          Type: 74 BaseType uint64
-        - Name: TraceIDHigh
-          Offset: 8
-          Type: 74 BaseType uint64
-        - Name: SpanID
-          Offset: 16
-          Type: 74 BaseType uint64
-        - Name: Attributes
-          Offset: 24
-          Type: 120 GoMapType map[string]string
-        - Name: Tracestate
-          Offset: 32
-          Type: 5 GoStringHeaderType string
-        - Name: Flags
-          Offset: 48
-          Type: 18 BaseType uint32
-    - __kind: GoSliceHeaderType
-      ID: 149
-      Name: '[]github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent'
-      ByteSize: 24
-      GoRuntimeType: 463776
-      GoKind: 23
-      RawFields:
-        - Name: array
-          Offset: 0
-          Type: 150 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent
-        - Name: len
-          Offset: 8
-          Type: 8 BaseType int
-        - Name: cap
-          Offset: 16
-          Type: 8 BaseType int
-      Data: 256 GoSliceDataType []github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent.array
-    - __kind: PointerType
-      ID: 150
-      Name: '*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent'
-      ByteSize: 8
-      GoRuntimeType: 1.129568e+06
-      GoKind: 22
-      Pointee: 151 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent
-    - __kind: StructureType
-      ID: 151
-      Name: github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent
-      ByteSize: 40
-      GoRuntimeType: 1.664384e+06
-      GoKind: 25
-      RawFields:
-        - Name: Name
-          Offset: 0
-          Type: 5 GoStringHeaderType string
-        - Name: TimeUnixNano
-          Offset: 16
-          Type: 74 BaseType uint64
-        - Name: Attributes
-          Offset: 24
-          Type: 152 GoMapType map[string]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
-        - Name: RawAttributes
-          Offset: 32
-          Type: 168 GoMapType map[string]interface {}
-    - __kind: GoMapType
-      ID: 152
-      Name: map[string]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
-      ByteSize: 8
-      GoRuntimeType: 905120
-      GoKind: 21
-      HeaderType: 154 GoHMapHeaderType hash<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
-    - __kind: PointerType
-      ID: 153
-      Name: '*hash<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>'
-      ByteSize: 8
-      Pointee: 154 GoHMapHeaderType hash<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
-    - __kind: GoHMapHeaderType
-      ID: 154
-      Name: hash<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
-      ByteSize: 48
-      RawFields:
-        - Name: count
-          Offset: 0
-          Type: 8 BaseType int
-        - Name: flags
-          Offset: 8
-          Type: 7 BaseType uint8
-        - Name: B
-          Offset: 9
-          Type: 7 BaseType uint8
-        - Name: noverflow
-          Offset: 10
-          Type: 17 BaseType uint16
-        - Name: hash0
-          Offset: 12
-          Type: 18 BaseType uint32
-        - Name: buckets
-          Offset: 16
-          Type: 155 PointerType *bucket<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
-        - Name: oldbuckets
-          Offset: 24
-          Type: 155 PointerType *bucket<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
-        - Name: nevacuate
-          Offset: 32
-          Type: 26 BaseType uintptr
-        - Name: extra
-          Offset: 40
-          Type: 27 PointerType *runtime.mapextra
-      BucketType: 156 GoHMapBucketType bucket<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
-      BucketsType: 258 GoSliceDataType []bucket<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>.array
-    - __kind: PointerType
-      ID: 155
-      Name: '*bucket<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>'
-      ByteSize: 8
-      Pointee: 156 GoHMapBucketType bucket<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
-    - __kind: GoHMapBucketType
-      ID: 156
-      Name: bucket<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
-      ByteSize: 208
-      RawFields:
-        - Name: tophash
-          Offset: 0
-          Type: 21 ArrayType [8]uint8
-        - Name: keys
-          Offset: 8
-          Type: 22 ArrayType []key<string>
-        - Name: values
-          Offset: 136
-          Type: 157 ArrayType []val<*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
-        - Name: overflow
-          Offset: 200
-          Type: 155 PointerType *bucket<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
-      KeyType: 5 GoStringHeaderType string
-      ValueType: 158 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
-    - __kind: ArrayType
-      ID: 157
-      Name: '[]val<*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>'
-      ByteSize: 64
-      Count: 8
-      HasCount: true
-      Element: 158 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
-    - __kind: PointerType
-      ID: 158
-      Name: '*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute'
-      ByteSize: 8
-      GoRuntimeType: 1.130336e+06
-      GoKind: 22
-      Pointee: 159 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
-    - __kind: StructureType
-      ID: 159
-      Name: github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
-      ByteSize: 56
-      GoRuntimeType: 1.822848e+06
-      GoKind: 25
-      RawFields:
-        - Name: Type
-          Offset: 0
-          Type: 160 BaseType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttributeType
-        - Name: StringValue
-          Offset: 8
-          Type: 5 GoStringHeaderType string
-        - Name: BoolValue
-          Offset: 24
-          Type: 13 BaseType bool
-        - Name: IntValue
-          Offset: 32
-          Type: 36 BaseType int64
-        - Name: DoubleValue
-          Offset: 40
-          Type: 145 BaseType float64
-        - Name: ArrayValue
-          Offset: 48
-          Type: 161 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttribute
-    - __kind: BaseType
-      ID: 160
-      Name: github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttributeType
-      ByteSize: 4
-      GoRuntimeType: 965248
-      GoKind: 5
-    - __kind: PointerType
-      ID: 161
-      Name: '*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttribute'
-      ByteSize: 8
-      GoRuntimeType: 1.130208e+06
-      GoKind: 22
-      Pointee: 162 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttribute
-    - __kind: StructureType
-      ID: 162
-      Name: github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttribute
-      ByteSize: 24
-      GoRuntimeType: 1.13008e+06
-      GoKind: 25
-      RawFields:
-        - Name: Values
-          Offset: 0
-          Type: 163 GoSliceHeaderType []*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttributeValue
-    - __kind: GoSliceHeaderType
-      ID: 163
-      Name: '[]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttributeValue'
-      ByteSize: 24
-      GoRuntimeType: 463648
-      GoKind: 23
-      RawFields:
-        - Name: array
-          Offset: 0
-          Type: 164 PointerType **github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttributeValue
-        - Name: len
-          Offset: 8
-          Type: 8 BaseType int
-        - Name: cap
-          Offset: 16
-          Type: 8 BaseType int
-      Data: 259 GoSliceDataType []*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttributeValue.array
-    - __kind: PointerType
-      ID: 164
-      Name: '**github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttributeValue'
-      ByteSize: 8
-      GoKind: 22
-      Pointee: 165 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttributeValue
-    - __kind: PointerType
-      ID: 165
-      Name: '*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttributeValue'
-      ByteSize: 8
-      GoRuntimeType: 1.129952e+06
-      GoKind: 22
-      Pointee: 166 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttributeValue
-    - __kind: StructureType
-      ID: 166
-      Name: github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttributeValue
-      ByteSize: 48
-      GoRuntimeType: 1.74848e+06
-      GoKind: 25
-      RawFields:
-        - Name: Type
-          Offset: 0
-          Type: 167 BaseType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttributeValueType
-        - Name: StringValue
-          Offset: 8
-          Type: 5 GoStringHeaderType string
-        - Name: BoolValue
-          Offset: 24
-          Type: 13 BaseType bool
-        - Name: IntValue
-          Offset: 32
-          Type: 36 BaseType int64
-        - Name: DoubleValue
-          Offset: 40
-          Type: 145 BaseType float64
-    - __kind: BaseType
-      ID: 167
-      Name: github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttributeValueType
-      ByteSize: 4
-      GoRuntimeType: 965344
-      GoKind: 5
-    - __kind: GoMapType
-      ID: 168
-      Name: map[string]interface {}
-      ByteSize: 8
-      GoRuntimeType: 896480
-      GoKind: 21
-      HeaderType: 135 GoHMapHeaderType hash<string,interface {}>
-    - __kind: PointerType
-      ID: 169
-      Name: '*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanContext'
-      ByteSize: 8
-      GoRuntimeType: 1.91728e+06
-      GoKind: 22
-      Pointee: 170 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanContext
-    - __kind: StructureType
       ID: 170
       Name: github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanContext
       ByteSize: 168
@@ -2485,13 +2001,132 @@ Types:
         - Name: baggageOnly
           Offset: 160
           Type: 13 BaseType bool
-    - __kind: PointerType
-      ID: 171
-      Name: '*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.trace'
+    - __kind: StructureType
+      ID: 148
+      Name: github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink
+      ByteSize: 56
+      GoRuntimeType: 1.822592e+06
+      GoKind: 25
+      RawFields:
+        - Name: TraceID
+          Offset: 0
+          Type: 74 BaseType uint64
+        - Name: TraceIDHigh
+          Offset: 8
+          Type: 74 BaseType uint64
+        - Name: SpanID
+          Offset: 16
+          Type: 74 BaseType uint64
+        - Name: Attributes
+          Offset: 24
+          Type: 120 GoMapType map[string]string
+        - Name: Tracestate
+          Offset: 32
+          Type: 5 GoStringHeaderType string
+        - Name: Flags
+          Offset: 48
+          Type: 18 BaseType uint32
+    - __kind: GoMapType
+      ID: 133
+      Name: github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.metaStructMap
       ByteSize: 8
-      GoRuntimeType: 2.132544e+06
-      GoKind: 22
-      Pointee: 172 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.trace
+      GoRuntimeType: 1.00752e+06
+      GoKind: 21
+      HeaderType: 135 GoHMapHeaderType hash<string,interface {}>
+    - __kind: BaseType
+      ID: 176
+      Name: github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.samplingDecision
+      ByteSize: 4
+      GoRuntimeType: 542336
+      GoKind: 10
+    - __kind: StructureType
+      ID: 151
+      Name: github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent
+      ByteSize: 40
+      GoRuntimeType: 1.664384e+06
+      GoKind: 25
+      RawFields:
+        - Name: Name
+          Offset: 0
+          Type: 5 GoStringHeaderType string
+        - Name: TimeUnixNano
+          Offset: 16
+          Type: 74 BaseType uint64
+        - Name: Attributes
+          Offset: 24
+          Type: 152 GoMapType map[string]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
+        - Name: RawAttributes
+          Offset: 32
+          Type: 168 GoMapType map[string]interface {}
+    - __kind: StructureType
+      ID: 162
+      Name: github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttribute
+      ByteSize: 24
+      GoRuntimeType: 1.13008e+06
+      GoKind: 25
+      RawFields:
+        - Name: Values
+          Offset: 0
+          Type: 163 GoSliceHeaderType []*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttributeValue
+    - __kind: StructureType
+      ID: 166
+      Name: github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttributeValue
+      ByteSize: 48
+      GoRuntimeType: 1.74848e+06
+      GoKind: 25
+      RawFields:
+        - Name: Type
+          Offset: 0
+          Type: 167 BaseType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttributeValueType
+        - Name: StringValue
+          Offset: 8
+          Type: 5 GoStringHeaderType string
+        - Name: BoolValue
+          Offset: 24
+          Type: 13 BaseType bool
+        - Name: IntValue
+          Offset: 32
+          Type: 36 BaseType int64
+        - Name: DoubleValue
+          Offset: 40
+          Type: 145 BaseType float64
+    - __kind: BaseType
+      ID: 167
+      Name: github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttributeValueType
+      ByteSize: 4
+      GoRuntimeType: 965344
+      GoKind: 5
+    - __kind: StructureType
+      ID: 159
+      Name: github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
+      ByteSize: 56
+      GoRuntimeType: 1.822848e+06
+      GoKind: 25
+      RawFields:
+        - Name: Type
+          Offset: 0
+          Type: 160 BaseType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttributeType
+        - Name: StringValue
+          Offset: 8
+          Type: 5 GoStringHeaderType string
+        - Name: BoolValue
+          Offset: 24
+          Type: 13 BaseType bool
+        - Name: IntValue
+          Offset: 32
+          Type: 36 BaseType int64
+        - Name: DoubleValue
+          Offset: 40
+          Type: 145 BaseType float64
+        - Name: ArrayValue
+          Offset: 48
+          Type: 161 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttribute
+    - __kind: BaseType
+      ID: 160
+      Name: github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttributeType
+      ByteSize: 4
+      GoRuntimeType: 965248
+      GoKind: 5
     - __kind: StructureType
       ID: 172
       Name: github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.trace
@@ -2529,42 +2164,6 @@ Types:
         - Name: root
           Offset: 96
           Type: 126 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span
-    - __kind: GoSliceHeaderType
-      ID: 173
-      Name: '[]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span'
-      ByteSize: 24
-      GoRuntimeType: 464032
-      GoKind: 23
-      RawFields:
-        - Name: array
-          Offset: 0
-          Type: 174 PointerType **github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span
-        - Name: len
-          Offset: 8
-          Type: 8 BaseType int
-        - Name: cap
-          Offset: 16
-          Type: 8 BaseType int
-      Data: 261 GoSliceDataType []*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span.array
-    - __kind: PointerType
-      ID: 174
-      Name: '**github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span'
-      ByteSize: 8
-      GoKind: 22
-      Pointee: 126 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span
-    - __kind: PointerType
-      ID: 175
-      Name: '*float64'
-      ByteSize: 8
-      GoRuntimeType: 377056
-      GoKind: 22
-      Pointee: 145 BaseType float64
-    - __kind: BaseType
-      ID: 176
-      Name: github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.samplingDecision
-      ByteSize: 4
-      GoRuntimeType: 542336
-      GoKind: 10
     - __kind: ArrayType
       ID: 177
       Name: github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.traceID
@@ -2574,93 +2173,258 @@ Types:
       Count: 16
       HasCount: true
       Element: 7 BaseType uint8
-    - __kind: GoSubroutineType
-      ID: 178
-      Name: func()
-      ByteSize: 8
-      GoRuntimeType: 455520
-      GoKind: 19
-    - __kind: PointerType
-      ID: 179
-      Name: '*bytes.Buffer'
-      ByteSize: 8
-      GoRuntimeType: 2.176896e+06
-      GoKind: 22
-      Pointee: 180 StructureType bytes.Buffer
-    - __kind: StructureType
-      ID: 180
-      Name: bytes.Buffer
-      ByteSize: 40
-      GoRuntimeType: 1.4512e+06
-      GoKind: 25
+    - __kind: GoHMapHeaderType
+      ID: 154
+      Name: hash<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
+      ByteSize: 48
       RawFields:
-        - Name: buf
+        - Name: count
           Offset: 0
-          Type: 52 GoSliceHeaderType []uint8
-        - Name: off
-          Offset: 24
           Type: 8 BaseType int
-        - Name: lastRead
+        - Name: flags
+          Offset: 8
+          Type: 7 BaseType uint8
+        - Name: B
+          Offset: 9
+          Type: 7 BaseType uint8
+        - Name: noverflow
+          Offset: 10
+          Type: 17 BaseType uint16
+        - Name: hash0
+          Offset: 12
+          Type: 18 BaseType uint32
+        - Name: buckets
+          Offset: 16
+          Type: 155 PointerType *bucket<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
+        - Name: oldbuckets
+          Offset: 24
+          Type: 155 PointerType *bucket<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
+        - Name: nevacuate
           Offset: 32
-          Type: 181 BaseType bytes.readOp
-    - __kind: BaseType
-      ID: 181
-      Name: bytes.readOp
-      ByteSize: 1
-      GoRuntimeType: 541760
-      GoKind: 3
-    - __kind: StructureType
-      ID: 182
-      Name: context.backgroundCtx
-      GoRuntimeType: 1.708832e+06
-      GoKind: 25
+          Type: 26 BaseType uintptr
+        - Name: extra
+          Offset: 40
+          Type: 27 PointerType *runtime.mapextra
+      BucketType: 156 GoHMapBucketType bucket<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
+      BucketsType: 258 GoSliceDataType []bucket<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>.array
+    - __kind: GoHMapHeaderType
+      ID: 43
+      Name: hash<string,[]*mime/multipart.FileHeader>
+      ByteSize: 48
       RawFields:
-        - Name: emptyCtx
+        - Name: count
           Offset: 0
-          Type: 183 StructureType context.emptyCtx
-    - __kind: StructureType
-      ID: 183
-      Name: context.emptyCtx
-      GoRuntimeType: 1.435104e+06
-      GoKind: 25
-      RawFields: []
-    - __kind: PointerType
-      ID: 184
-      Name: '*bool'
-      ByteSize: 8
-      GoRuntimeType: 377120
-      GoKind: 22
-      Pointee: 13 BaseType bool
-    - __kind: PointerType
-      ID: 185
-      Name: '*uintptr'
-      ByteSize: 8
-      GoRuntimeType: 376800
-      GoKind: 22
-      Pointee: 26 BaseType uintptr
+          Type: 8 BaseType int
+        - Name: flags
+          Offset: 8
+          Type: 7 BaseType uint8
+        - Name: B
+          Offset: 9
+          Type: 7 BaseType uint8
+        - Name: noverflow
+          Offset: 10
+          Type: 17 BaseType uint16
+        - Name: hash0
+          Offset: 12
+          Type: 18 BaseType uint32
+        - Name: buckets
+          Offset: 16
+          Type: 44 PointerType *bucket<string,[]*mime/multipart.FileHeader>
+        - Name: oldbuckets
+          Offset: 24
+          Type: 44 PointerType *bucket<string,[]*mime/multipart.FileHeader>
+        - Name: nevacuate
+          Offset: 32
+          Type: 26 BaseType uintptr
+        - Name: extra
+          Offset: 40
+          Type: 27 PointerType *runtime.mapextra
+      BucketType: 45 GoHMapBucketType bucket<string,[]*mime/multipart.FileHeader>
+      BucketsType: 210 GoSliceDataType []bucket<string,[]*mime/multipart.FileHeader>.array
+    - __kind: GoHMapHeaderType
+      ID: 16
+      Name: hash<string,[]string>
+      ByteSize: 48
+      RawFields:
+        - Name: count
+          Offset: 0
+          Type: 8 BaseType int
+        - Name: flags
+          Offset: 8
+          Type: 7 BaseType uint8
+        - Name: B
+          Offset: 9
+          Type: 7 BaseType uint8
+        - Name: noverflow
+          Offset: 10
+          Type: 17 BaseType uint16
+        - Name: hash0
+          Offset: 12
+          Type: 18 BaseType uint32
+        - Name: buckets
+          Offset: 16
+          Type: 19 PointerType *bucket<string,[]string>
+        - Name: oldbuckets
+          Offset: 24
+          Type: 19 PointerType *bucket<string,[]string>
+        - Name: nevacuate
+          Offset: 32
+          Type: 26 BaseType uintptr
+        - Name: extra
+          Offset: 40
+          Type: 27 PointerType *runtime.mapextra
+      BucketType: 20 GoHMapBucketType bucket<string,[]string>
+      BucketsType: 205 GoSliceDataType []bucket<string,[]string>.array
+    - __kind: GoHMapHeaderType
+      ID: 141
+      Name: hash<string,float64>
+      ByteSize: 48
+      RawFields:
+        - Name: count
+          Offset: 0
+          Type: 8 BaseType int
+        - Name: flags
+          Offset: 8
+          Type: 7 BaseType uint8
+        - Name: B
+          Offset: 9
+          Type: 7 BaseType uint8
+        - Name: noverflow
+          Offset: 10
+          Type: 17 BaseType uint16
+        - Name: hash0
+          Offset: 12
+          Type: 18 BaseType uint32
+        - Name: buckets
+          Offset: 16
+          Type: 142 PointerType *bucket<string,float64>
+        - Name: oldbuckets
+          Offset: 24
+          Type: 142 PointerType *bucket<string,float64>
+        - Name: nevacuate
+          Offset: 32
+          Type: 26 BaseType uintptr
+        - Name: extra
+          Offset: 40
+          Type: 27 PointerType *runtime.mapextra
+      BucketType: 143 GoHMapBucketType bucket<string,float64>
+      BucketsType: 253 GoSliceDataType []bucket<string,float64>.array
+    - __kind: GoHMapHeaderType
+      ID: 135
+      Name: hash<string,interface {}>
+      ByteSize: 48
+      RawFields:
+        - Name: count
+          Offset: 0
+          Type: 8 BaseType int
+        - Name: flags
+          Offset: 8
+          Type: 7 BaseType uint8
+        - Name: B
+          Offset: 9
+          Type: 7 BaseType uint8
+        - Name: noverflow
+          Offset: 10
+          Type: 17 BaseType uint16
+        - Name: hash0
+          Offset: 12
+          Type: 18 BaseType uint32
+        - Name: buckets
+          Offset: 16
+          Type: 136 PointerType *bucket<string,interface {}>
+        - Name: oldbuckets
+          Offset: 24
+          Type: 136 PointerType *bucket<string,interface {}>
+        - Name: nevacuate
+          Offset: 32
+          Type: 26 BaseType uintptr
+        - Name: extra
+          Offset: 40
+          Type: 27 PointerType *runtime.mapextra
+      BucketType: 137 GoHMapBucketType bucket<string,interface {}>
+      BucketsType: 252 GoSliceDataType []bucket<string,interface {}>.array
+    - __kind: GoHMapHeaderType
+      ID: 122
+      Name: hash<string,string>
+      ByteSize: 48
+      RawFields:
+        - Name: count
+          Offset: 0
+          Type: 8 BaseType int
+        - Name: flags
+          Offset: 8
+          Type: 7 BaseType uint8
+        - Name: B
+          Offset: 9
+          Type: 7 BaseType uint8
+        - Name: noverflow
+          Offset: 10
+          Type: 17 BaseType uint16
+        - Name: hash0
+          Offset: 12
+          Type: 18 BaseType uint32
+        - Name: buckets
+          Offset: 16
+          Type: 123 PointerType *bucket<string,string>
+        - Name: oldbuckets
+          Offset: 24
+          Type: 123 PointerType *bucket<string,string>
+        - Name: nevacuate
+          Offset: 32
+          Type: 26 BaseType uintptr
+        - Name: extra
+          Offset: 40
+          Type: 27 PointerType *runtime.mapextra
+      BucketType: 124 GoHMapBucketType bucket<string,string>
+      BucketsType: 251 GoSliceDataType []bucket<string,string>.array
     - __kind: BaseType
-      ID: 186
-      Name: uint
+      ID: 8
+      Name: int
       ByteSize: 8
-      GoRuntimeType: 543168
-      GoKind: 7
+      GoRuntimeType: 543104
+      GoKind: 2
+    - __kind: BaseType
+      ID: 192
+      Name: int16
+      ByteSize: 2
+      GoRuntimeType: 542720
+      GoKind: 4
+    - __kind: BaseType
+      ID: 130
+      Name: int32
+      ByteSize: 4
+      GoRuntimeType: 542848
+      GoKind: 5
+    - __kind: BaseType
+      ID: 36
+      Name: int64
+      ByteSize: 8
+      GoRuntimeType: 542976
+      GoKind: 6
     - __kind: BaseType
       ID: 187
       Name: int8
       ByteSize: 1
       GoRuntimeType: 542592
       GoKind: 3
-    - __kind: BaseType
-      ID: 188
-      Name: float32
-      ByteSize: 4
-      GoRuntimeType: 543424
-      GoKind: 13
-    - __kind: GoInterfaceType
-      ID: 189
-      Name: error
+    - __kind: GoEmptyInterfaceType
+      ID: 61
+      Name: interface {}
       ByteSize: 16
-      GoRuntimeType: 1.011104e+06
+      GoRuntimeType: 798016
+      GoKind: 20
+      RawFields:
+        - Name: _type
+          Offset: 0
+          Type: 2 VoidPointerType unsafe.Pointer
+        - Name: data
+          Offset: 8
+          Type: 2 VoidPointerType unsafe.Pointer
+    - __kind: GoInterfaceType
+      ID: 34
+      Name: io.ReadCloser
+      ByteSize: 16
+      GoRuntimeType: 1.093088e+06
       GoKind: 20
       RawFields:
         - Name: tab
@@ -2669,432 +2433,668 @@ Types:
         - Name: data
           Offset: 8
           Type: 2 VoidPointerType unsafe.Pointer
-    - __kind: PointerType
-      ID: 190
-      Name: '*int32'
+    - __kind: GoMapType
+      ID: 152
+      Name: map[string]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
       ByteSize: 8
-      GoRuntimeType: 376416
-      GoKind: 22
-      Pointee: 130 BaseType int32
-    - __kind: PointerType
-      ID: 191
-      Name: '*uint32'
+      GoRuntimeType: 905120
+      GoKind: 21
+      HeaderType: 154 GoHMapHeaderType hash<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
+    - __kind: GoMapType
+      ID: 41
+      Name: map[string][]*mime/multipart.FileHeader
       ByteSize: 8
-      GoRuntimeType: 376480
-      GoKind: 22
-      Pointee: 18 BaseType uint32
+      GoRuntimeType: 904160
+      GoKind: 21
+      HeaderType: 43 GoHMapHeaderType hash<string,[]*mime/multipart.FileHeader>
+    - __kind: GoMapType
+      ID: 40
+      Name: map[string][]string
+      ByteSize: 8
+      GoRuntimeType: 899360
+      GoKind: 21
+      HeaderType: 16 GoHMapHeaderType hash<string,[]string>
+    - __kind: GoMapType
+      ID: 139
+      Name: map[string]float64
+      ByteSize: 8
+      GoRuntimeType: 905024
+      GoKind: 21
+      HeaderType: 141 GoHMapHeaderType hash<string,float64>
+    - __kind: GoMapType
+      ID: 168
+      Name: map[string]interface {}
+      ByteSize: 8
+      GoRuntimeType: 896480
+      GoKind: 21
+      HeaderType: 135 GoHMapHeaderType hash<string,interface {}>
+    - __kind: GoMapType
+      ID: 120
+      Name: map[string]string
+      ByteSize: 8
+      GoRuntimeType: 900992
+      GoKind: 21
+      HeaderType: 122 GoHMapHeaderType hash<string,string>
+    - __kind: StructureType
+      ID: 63
+      Name: math/big.Int
+      ByteSize: 32
+      GoRuntimeType: 1.340768e+06
+      GoKind: 25
+      RawFields:
+        - Name: neg
+          Offset: 0
+          Type: 13 BaseType bool
+        - Name: abs
+          Offset: 8
+          Type: 64 GoSliceHeaderType math/big.nat
     - __kind: BaseType
-      ID: 192
-      Name: int16
-      ByteSize: 2
-      GoRuntimeType: 542720
-      GoKind: 4
-    - __kind: BaseType
-      ID: 193
-      Name: complex64
+      ID: 66
+      Name: math/big.Word
       ByteSize: 8
-      GoRuntimeType: 543296
-      GoKind: 15
-    - __kind: BaseType
-      ID: 194
-      Name: complex128
-      ByteSize: 16
-      GoRuntimeType: 543360
-      GoKind: 16
-    - __kind: PointerType
-      ID: 195
-      Name: '*int64'
-      ByteSize: 8
-      GoRuntimeType: 376544
-      GoKind: 22
-      Pointee: 36 BaseType int64
-    - __kind: PointerType
-      ID: 196
-      Name: '*uint64'
-      ByteSize: 8
-      GoRuntimeType: 376608
-      GoKind: 22
-      Pointee: 74 BaseType uint64
-    - __kind: PointerType
-      ID: 197
-      Name: '*uint16'
-      ByteSize: 8
-      GoRuntimeType: 376352
-      GoKind: 22
-      Pointee: 17 BaseType uint16
-    - __kind: PointerType
-      ID: 198
-      Name: '*int16'
-      ByteSize: 8
-      GoRuntimeType: 376288
-      GoKind: 22
-      Pointee: 192 BaseType int16
-    - __kind: PointerType
-      ID: 199
-      Name: '*int8'
-      ByteSize: 8
-      GoRuntimeType: 376160
-      GoKind: 22
-      Pointee: 187 BaseType int8
-    - __kind: PointerType
-      ID: 200
-      Name: '*error'
-      ByteSize: 8
-      GoRuntimeType: 376032
-      GoKind: 22
-      Pointee: 189 GoInterfaceType error
-    - __kind: PointerType
-      ID: 201
-      Name: '*uint'
-      ByteSize: 8
-      GoRuntimeType: 376736
-      GoKind: 22
-      Pointee: 186 BaseType uint
-    - __kind: PointerType
-      ID: 202
-      Name: '*float32'
-      ByteSize: 8
-      GoRuntimeType: 376992
-      GoKind: 22
-      Pointee: 188 BaseType float32
-    - __kind: GoStringDataType
-      ID: 203
-      Name: string.str
-      ByteSize: 2048
-    - __kind: PointerType
-      ID: 204
-      Name: '*string.str'
-      ByteSize: 8
-      Pointee: 203 GoStringDataType string.str
-    - __kind: GoSliceDataType
-      ID: 205
-      Name: '[]bucket<string,[]string>.array'
-      ByteSize: 2048
-      Element: 20 GoHMapBucketType bucket<string,[]string>
-    - __kind: GoSliceDataType
-      ID: 206
-      Name: '[]string.array'
-      ByteSize: 2048
-      Element: 5 GoStringHeaderType string
-    - __kind: PointerType
-      ID: 207
-      Name: '*[]string.array'
-      ByteSize: 8
-      Pointee: 206 GoSliceDataType []string.array
-    - __kind: GoSliceDataType
-      ID: 208
-      Name: '[]*runtime.bmap.array'
-      ByteSize: 2048
-      Element: 32 PointerType *runtime.bmap
-    - __kind: PointerType
-      ID: 209
-      Name: '*[]*runtime.bmap.array'
-      ByteSize: 8
-      Pointee: 208 GoSliceDataType []*runtime.bmap.array
-    - __kind: GoSliceDataType
-      ID: 210
-      Name: '[]bucket<string,[]*mime/multipart.FileHeader>.array'
-      ByteSize: 2048
-      Element: 45 GoHMapBucketType bucket<string,[]*mime/multipart.FileHeader>
-    - __kind: GoSliceDataType
-      ID: 211
-      Name: '[]*mime/multipart.FileHeader.array'
-      ByteSize: 2048
-      Element: 49 PointerType *mime/multipart.FileHeader
-    - __kind: PointerType
-      ID: 212
-      Name: '*[]*mime/multipart.FileHeader.array'
-      ByteSize: 8
-      Pointee: 211 GoSliceDataType []*mime/multipart.FileHeader.array
-    - __kind: GoSliceDataType
-      ID: 213
-      Name: '[]uint8.array'
-      ByteSize: 2048
-      Element: 7 BaseType uint8
-    - __kind: PointerType
-      ID: 214
-      Name: '*[]uint8.array'
-      ByteSize: 8
-      Pointee: 213 GoSliceDataType []uint8.array
-    - __kind: GoSliceDataType
-      ID: 215
-      Name: '[]*crypto/x509.Certificate.array'
-      ByteSize: 2048
-      Element: 57 PointerType *crypto/x509.Certificate
-    - __kind: PointerType
-      ID: 216
-      Name: '*[]*crypto/x509.Certificate.array'
-      ByteSize: 8
-      Pointee: 215 GoSliceDataType []*crypto/x509.Certificate.array
+      GoRuntimeType: 546880
+      GoKind: 7
+    - __kind: GoSliceHeaderType
+      ID: 64
+      Name: math/big.nat
+      ByteSize: 24
+      GoRuntimeType: 2.280544e+06
+      GoKind: 23
+      RawFields:
+        - Name: array
+          Offset: 0
+          Type: 65 PointerType *math/big.Word
+        - Name: len
+          Offset: 8
+          Type: 8 BaseType int
+        - Name: cap
+          Offset: 16
+          Type: 8 BaseType int
+      Data: 217 GoSliceDataType math/big.nat.array
     - __kind: GoSliceDataType
       ID: 217
       Name: math/big.nat.array
       ByteSize: 2048
       Element: 66 BaseType math/big.Word
-    - __kind: PointerType
-      ID: 218
-      Name: '*math/big.nat.array'
-      ByteSize: 8
-      Pointee: 217 GoSliceDataType math/big.nat.array
-    - __kind: GoSliceDataType
-      ID: 219
-      Name: '[]crypto/x509/pkix.AttributeTypeAndValue.array'
-      ByteSize: 2048
-      Element: 70 StructureType crypto/x509/pkix.AttributeTypeAndValue
-    - __kind: PointerType
-      ID: 220
-      Name: '*[]crypto/x509/pkix.AttributeTypeAndValue.array'
-      ByteSize: 8
-      Pointee: 219 GoSliceDataType []crypto/x509/pkix.AttributeTypeAndValue.array
-    - __kind: GoSliceDataType
-      ID: 221
-      Name: encoding/asn1.ObjectIdentifier.array
-      ByteSize: 2048
-      Element: 8 BaseType int
-    - __kind: PointerType
-      ID: 222
-      Name: '*encoding/asn1.ObjectIdentifier.array'
-      ByteSize: 8
-      Pointee: 221 GoSliceDataType encoding/asn1.ObjectIdentifier.array
-    - __kind: GoSliceDataType
-      ID: 223
-      Name: '[]time.zone.array'
-      ByteSize: 2048
-      Element: 79 StructureType time.zone
-    - __kind: PointerType
-      ID: 224
-      Name: '*[]time.zone.array'
-      ByteSize: 8
-      Pointee: 223 GoSliceDataType []time.zone.array
-    - __kind: GoSliceDataType
-      ID: 225
-      Name: '[]time.zoneTrans.array'
-      ByteSize: 2048
-      Element: 82 StructureType time.zoneTrans
-    - __kind: PointerType
-      ID: 226
-      Name: '*[]time.zoneTrans.array'
-      ByteSize: 8
-      Pointee: 225 GoSliceDataType []time.zoneTrans.array
-    - __kind: GoSliceDataType
-      ID: 227
-      Name: '[]crypto/x509/pkix.Extension.array'
-      ByteSize: 2048
-      Element: 86 StructureType crypto/x509/pkix.Extension
-    - __kind: PointerType
-      ID: 228
-      Name: '*[]crypto/x509/pkix.Extension.array'
-      ByteSize: 8
-      Pointee: 227 GoSliceDataType []crypto/x509/pkix.Extension.array
-    - __kind: GoSliceDataType
-      ID: 229
-      Name: '[]encoding/asn1.ObjectIdentifier.array'
-      ByteSize: 2048
-      Element: 71 GoSliceHeaderType encoding/asn1.ObjectIdentifier
-    - __kind: PointerType
-      ID: 230
-      Name: '*[]encoding/asn1.ObjectIdentifier.array'
-      ByteSize: 8
-      Pointee: 229 GoSliceDataType []encoding/asn1.ObjectIdentifier.array
-    - __kind: GoSliceDataType
-      ID: 231
-      Name: '[]crypto/x509.ExtKeyUsage.array'
-      ByteSize: 2048
-      Element: 91 BaseType crypto/x509.ExtKeyUsage
-    - __kind: PointerType
-      ID: 232
-      Name: '*[]crypto/x509.ExtKeyUsage.array'
-      ByteSize: 8
-      Pointee: 231 GoSliceDataType []crypto/x509.ExtKeyUsage.array
-    - __kind: GoSliceDataType
-      ID: 233
-      Name: '[]net.IP.array'
-      ByteSize: 2048
-      Element: 94 GoSliceHeaderType net.IP
-    - __kind: PointerType
-      ID: 234
-      Name: '*[]net.IP.array'
-      ByteSize: 8
-      Pointee: 233 GoSliceDataType []net.IP.array
+    - __kind: StructureType
+      ID: 50
+      Name: mime/multipart.FileHeader
+      ByteSize: 88
+      GoRuntimeType: 1.881696e+06
+      GoKind: 25
+      RawFields:
+        - Name: Filename
+          Offset: 0
+          Type: 5 GoStringHeaderType string
+        - Name: Header
+          Offset: 16
+          Type: 51 GoMapType net/textproto.MIMEHeader
+        - Name: Size
+          Offset: 24
+          Type: 36 BaseType int64
+        - Name: content
+          Offset: 32
+          Type: 52 GoSliceHeaderType []uint8
+        - Name: tmpfile
+          Offset: 56
+          Type: 5 GoStringHeaderType string
+        - Name: tmpoff
+          Offset: 72
+          Type: 36 BaseType int64
+        - Name: tmpshared
+          Offset: 80
+          Type: 13 BaseType bool
+    - __kind: StructureType
+      ID: 39
+      Name: mime/multipart.Form
+      ByteSize: 16
+      GoRuntimeType: 1.326048e+06
+      GoKind: 25
+      RawFields:
+        - Name: Value
+          Offset: 0
+          Type: 40 GoMapType map[string][]string
+        - Name: File
+          Offset: 8
+          Type: 41 GoMapType map[string][]*mime/multipart.FileHeader
+    - __kind: GoSliceHeaderType
+      ID: 94
+      Name: net.IP
+      ByteSize: 24
+      GoRuntimeType: 2.00144e+06
+      GoKind: 23
+      RawFields:
+        - Name: array
+          Offset: 0
+          Type: 6 PointerType *uint8
+        - Name: len
+          Offset: 8
+          Type: 8 BaseType int
+        - Name: cap
+          Offset: 16
+          Type: 8 BaseType int
+      Data: 235 GoSliceDataType net.IP.array
     - __kind: GoSliceDataType
       ID: 235
       Name: net.IP.array
       ByteSize: 2048
       Element: 7 BaseType uint8
-    - __kind: PointerType
-      ID: 236
-      Name: '*net.IP.array'
-      ByteSize: 8
-      Pointee: 235 GoSliceDataType net.IP.array
-    - __kind: GoSliceDataType
-      ID: 237
-      Name: '[]*net/url.URL.array'
-      ByteSize: 2048
-      Element: 9 PointerType *net/url.URL
-    - __kind: PointerType
-      ID: 238
-      Name: '*[]*net/url.URL.array'
-      ByteSize: 8
-      Pointee: 237 GoSliceDataType []*net/url.URL.array
-    - __kind: GoSliceDataType
-      ID: 239
-      Name: '[]*net.IPNet.array'
-      ByteSize: 2048
-      Element: 99 PointerType *net.IPNet
-    - __kind: PointerType
-      ID: 240
-      Name: '*[]*net.IPNet.array'
-      ByteSize: 8
-      Pointee: 239 GoSliceDataType []*net.IPNet.array
+    - __kind: GoSliceHeaderType
+      ID: 101
+      Name: net.IPMask
+      ByteSize: 24
+      GoRuntimeType: 999456
+      GoKind: 23
+      RawFields:
+        - Name: array
+          Offset: 0
+          Type: 6 PointerType *uint8
+        - Name: len
+          Offset: 8
+          Type: 8 BaseType int
+        - Name: cap
+          Offset: 16
+          Type: 8 BaseType int
+      Data: 241 GoSliceDataType net.IPMask.array
     - __kind: GoSliceDataType
       ID: 241
       Name: net.IPMask.array
       ByteSize: 2048
       Element: 7 BaseType uint8
-    - __kind: PointerType
-      ID: 242
-      Name: '*net.IPMask.array'
+    - __kind: StructureType
+      ID: 100
+      Name: net.IPNet
+      ByteSize: 48
+      GoRuntimeType: 1.307168e+06
+      GoKind: 25
+      RawFields:
+        - Name: IP
+          Offset: 0
+          Type: 94 GoSliceHeaderType net.IP
+        - Name: Mask
+          Offset: 24
+          Type: 101 GoSliceHeaderType net.IPMask
+    - __kind: GoMapType
+      ID: 14
+      Name: net/http.Header
       ByteSize: 8
-      Pointee: 241 GoSliceDataType net.IPMask.array
-    - __kind: GoSliceDataType
-      ID: 243
-      Name: '[]crypto/x509.OID.array'
-      ByteSize: 2048
-      Element: 104 StructureType crypto/x509.OID
-    - __kind: PointerType
-      ID: 244
-      Name: '*[]crypto/x509.OID.array'
-      ByteSize: 8
-      Pointee: 243 GoSliceDataType []crypto/x509.OID.array
-    - __kind: GoSliceDataType
-      ID: 245
-      Name: '[][]*crypto/x509.Certificate.array'
-      ByteSize: 2048
-      Element: 55 GoSliceHeaderType []*crypto/x509.Certificate
-    - __kind: PointerType
-      ID: 246
-      Name: '*[][]*crypto/x509.Certificate.array'
-      ByteSize: 8
-      Pointee: 245 GoSliceDataType [][]*crypto/x509.Certificate.array
-    - __kind: GoSliceDataType
-      ID: 247
-      Name: '[][]uint8.array'
-      ByteSize: 2048
-      Element: 52 GoSliceHeaderType []uint8
-    - __kind: PointerType
-      ID: 248
-      Name: '*[][]uint8.array'
-      ByteSize: 8
-      Pointee: 247 GoSliceDataType [][]uint8.array
-    - __kind: GoSliceDataType
-      ID: 249
-      Name: '[]net/http.segment.array'
-      ByteSize: 2048
-      Element: 119 StructureType net/http.segment
-    - __kind: PointerType
-      ID: 250
-      Name: '*[]net/http.segment.array'
-      ByteSize: 8
-      Pointee: 249 GoSliceDataType []net/http.segment.array
-    - __kind: GoSliceDataType
-      ID: 251
-      Name: '[]bucket<string,string>.array'
-      ByteSize: 2048
-      Element: 124 GoHMapBucketType bucket<string,string>
-    - __kind: GoSliceDataType
-      ID: 252
-      Name: '[]bucket<string,interface {}>.array'
-      ByteSize: 2048
-      Element: 137 GoHMapBucketType bucket<string,interface {}>
-    - __kind: GoSliceDataType
-      ID: 253
-      Name: '[]bucket<string,float64>.array'
-      ByteSize: 2048
-      Element: 143 GoHMapBucketType bucket<string,float64>
-    - __kind: GoSliceDataType
-      ID: 254
-      Name: '[]github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink.array'
-      ByteSize: 2048
-      Element: 148 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink
-    - __kind: PointerType
-      ID: 255
-      Name: '*[]github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink.array'
-      ByteSize: 8
-      Pointee: 254 GoSliceDataType []github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink.array
-    - __kind: GoSliceDataType
-      ID: 256
-      Name: '[]github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent.array'
-      ByteSize: 2048
-      Element: 151 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent
-    - __kind: PointerType
-      ID: 257
-      Name: '*[]github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent.array'
-      ByteSize: 8
-      Pointee: 256 GoSliceDataType []github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent.array
-    - __kind: GoSliceDataType
-      ID: 258
-      Name: '[]bucket<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>.array'
-      ByteSize: 2048
-      Element: 156 GoHMapBucketType bucket<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
-    - __kind: GoSliceDataType
-      ID: 259
-      Name: '[]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttributeValue.array'
-      ByteSize: 2048
-      Element: 165 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttributeValue
-    - __kind: PointerType
-      ID: 260
-      Name: '*[]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttributeValue.array'
-      ByteSize: 8
-      Pointee: 259 GoSliceDataType []*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttributeValue.array
-    - __kind: GoSliceDataType
-      ID: 261
-      Name: '[]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span.array'
-      ByteSize: 2048
-      Element: 126 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span
-    - __kind: PointerType
-      ID: 262
-      Name: '*[]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span.array'
-      ByteSize: 8
-      Pointee: 261 GoSliceDataType []*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span.array
-    - __kind: EventRootType
-      ID: 263
-      Name: Probe[main.HandleHTTP]
-      ByteSize: 25
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: w
-          Offset: 1
-          Expression:
-            Type: 1 GoInterfaceType net/http.ResponseWriter
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 1, index: 0, name: w}
-                  Offset: 0
-                  ByteSize: 16
-        - Name: r
+      GoRuntimeType: 1.964288e+06
+      GoKind: 21
+      HeaderType: 16 GoHMapHeaderType hash<string,[]string>
+    - __kind: StructureType
+      ID: 4
+      Name: net/http.Request
+      ByteSize: 304
+      GoRuntimeType: 2.256288e+06
+      GoKind: 25
+      RawFields:
+        - Name: Method
+          Offset: 0
+          Type: 5 GoStringHeaderType string
+        - Name: URL
+          Offset: 16
+          Type: 9 PointerType *net/url.URL
+        - Name: Proto
+          Offset: 24
+          Type: 5 GoStringHeaderType string
+        - Name: ProtoMajor
+          Offset: 40
+          Type: 8 BaseType int
+        - Name: ProtoMinor
+          Offset: 48
+          Type: 8 BaseType int
+        - Name: Header
+          Offset: 56
+          Type: 14 GoMapType net/http.Header
+        - Name: Body
+          Offset: 64
+          Type: 34 GoInterfaceType io.ReadCloser
+        - Name: GetBody
+          Offset: 80
+          Type: 35 GoSubroutineType func() (io.ReadCloser, error)
+        - Name: ContentLength
+          Offset: 88
+          Type: 36 BaseType int64
+        - Name: TransferEncoding
+          Offset: 96
+          Type: 24 GoSliceHeaderType []string
+        - Name: Close
+          Offset: 120
+          Type: 13 BaseType bool
+        - Name: Host
+          Offset: 128
+          Type: 5 GoStringHeaderType string
+        - Name: Form
+          Offset: 144
+          Type: 37 GoMapType net/url.Values
+        - Name: PostForm
+          Offset: 152
+          Type: 37 GoMapType net/url.Values
+        - Name: MultipartForm
+          Offset: 160
+          Type: 38 PointerType *mime/multipart.Form
+        - Name: Trailer
+          Offset: 168
+          Type: 14 GoMapType net/http.Header
+        - Name: RemoteAddr
+          Offset: 176
+          Type: 5 GoStringHeaderType string
+        - Name: RequestURI
+          Offset: 192
+          Type: 5 GoStringHeaderType string
+        - Name: TLS
+          Offset: 208
+          Type: 53 PointerType *crypto/tls.ConnectionState
+        - Name: Cancel
+          Offset: 216
+          Type: 111 GoChannelType <-chan struct {}
+        - Name: Response
+          Offset: 224
+          Type: 112 PointerType *net/http.Response
+        - Name: Pattern
+          Offset: 232
+          Type: 5 GoStringHeaderType string
+        - Name: ctx
+          Offset: 248
+          Type: 114 GoInterfaceType context.Context
+        - Name: pat
+          Offset: 264
+          Type: 115 PointerType *net/http.pattern
+        - Name: matches
+          Offset: 272
+          Type: 24 GoSliceHeaderType []string
+        - Name: otherValues
+          Offset: 296
+          Type: 120 GoMapType map[string]string
+    - __kind: StructureType
+      ID: 113
+      Name: net/http.Response
+      ByteSize: 144
+      GoRuntimeType: 2.124032e+06
+      GoKind: 25
+      RawFields:
+        - Name: Status
+          Offset: 0
+          Type: 5 GoStringHeaderType string
+        - Name: StatusCode
+          Offset: 16
+          Type: 8 BaseType int
+        - Name: Proto
+          Offset: 24
+          Type: 5 GoStringHeaderType string
+        - Name: ProtoMajor
+          Offset: 40
+          Type: 8 BaseType int
+        - Name: ProtoMinor
+          Offset: 48
+          Type: 8 BaseType int
+        - Name: Header
+          Offset: 56
+          Type: 14 GoMapType net/http.Header
+        - Name: Body
+          Offset: 64
+          Type: 34 GoInterfaceType io.ReadCloser
+        - Name: ContentLength
+          Offset: 80
+          Type: 36 BaseType int64
+        - Name: TransferEncoding
+          Offset: 88
+          Type: 24 GoSliceHeaderType []string
+        - Name: Close
+          Offset: 112
+          Type: 13 BaseType bool
+        - Name: Uncompressed
+          Offset: 113
+          Type: 13 BaseType bool
+        - Name: Trailer
+          Offset: 120
+          Type: 14 GoMapType net/http.Header
+        - Name: Request
+          Offset: 128
+          Type: 3 PointerType *net/http.Request
+        - Name: TLS
+          Offset: 136
+          Type: 53 PointerType *crypto/tls.ConnectionState
+    - __kind: GoInterfaceType
+      ID: 1
+      Name: net/http.ResponseWriter
+      ByteSize: 16
+      GoRuntimeType: 1.125472e+06
+      GoKind: 20
+      RawFields:
+        - Name: tab
+          Offset: 0
+          Type: 2 VoidPointerType unsafe.Pointer
+        - Name: data
+          Offset: 8
+          Type: 2 VoidPointerType unsafe.Pointer
+    - __kind: StructureType
+      ID: 116
+      Name: net/http.pattern
+      ByteSize: 88
+      GoRuntimeType: 1.745568e+06
+      GoKind: 25
+      RawFields:
+        - Name: str
+          Offset: 0
+          Type: 5 GoStringHeaderType string
+        - Name: method
+          Offset: 16
+          Type: 5 GoStringHeaderType string
+        - Name: host
+          Offset: 32
+          Type: 5 GoStringHeaderType string
+        - Name: segments
+          Offset: 48
+          Type: 117 GoSliceHeaderType []net/http.segment
+        - Name: loc
+          Offset: 72
+          Type: 5 GoStringHeaderType string
+    - __kind: StructureType
+      ID: 119
+      Name: net/http.segment
+      ByteSize: 24
+      GoRuntimeType: 1.453312e+06
+      GoKind: 25
+      RawFields:
+        - Name: s
+          Offset: 0
+          Type: 5 GoStringHeaderType string
+        - Name: wild
+          Offset: 16
+          Type: 13 BaseType bool
+        - Name: multi
           Offset: 17
-          Expression:
-            Type: 3 PointerType *net/http.Request
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 1, index: 1, name: r}
-                  Offset: 0
-                  ByteSize: 8
-    - __kind: EventRootType
-      ID: 264
-      Name: Probe[main.LookAtTheRequest]
-      ByteSize: 17
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: path
-          Offset: 1
-          Expression:
-            Type: 5 GoStringHeaderType string
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 2, index: 0, name: path}
-                  Offset: 0
-                  ByteSize: 16
+          Type: 13 BaseType bool
+    - __kind: GoMapType
+      ID: 51
+      Name: net/textproto.MIMEHeader
+      ByteSize: 8
+      GoRuntimeType: 1.63792e+06
+      GoKind: 21
+      HeaderType: 16 GoHMapHeaderType hash<string,[]string>
+    - __kind: StructureType
+      ID: 10
+      Name: net/url.URL
+      ByteSize: 144
+      GoRuntimeType: 2.041568e+06
+      GoKind: 25
+      RawFields:
+        - Name: Scheme
+          Offset: 0
+          Type: 5 GoStringHeaderType string
+        - Name: Opaque
+          Offset: 16
+          Type: 5 GoStringHeaderType string
+        - Name: User
+          Offset: 32
+          Type: 11 PointerType *net/url.Userinfo
+        - Name: Host
+          Offset: 40
+          Type: 5 GoStringHeaderType string
+        - Name: Path
+          Offset: 56
+          Type: 5 GoStringHeaderType string
+        - Name: RawPath
+          Offset: 72
+          Type: 5 GoStringHeaderType string
+        - Name: OmitHost
+          Offset: 88
+          Type: 13 BaseType bool
+        - Name: ForceQuery
+          Offset: 89
+          Type: 13 BaseType bool
+        - Name: RawQuery
+          Offset: 96
+          Type: 5 GoStringHeaderType string
+        - Name: Fragment
+          Offset: 112
+          Type: 5 GoStringHeaderType string
+        - Name: RawFragment
+          Offset: 128
+          Type: 5 GoStringHeaderType string
+    - __kind: StructureType
+      ID: 12
+      Name: net/url.Userinfo
+      ByteSize: 40
+      GoRuntimeType: 1.469632e+06
+      GoKind: 25
+      RawFields:
+        - Name: username
+          Offset: 0
+          Type: 5 GoStringHeaderType string
+        - Name: password
+          Offset: 16
+          Type: 5 GoStringHeaderType string
+        - Name: passwordSet
+          Offset: 32
+          Type: 13 BaseType bool
+    - __kind: GoMapType
+      ID: 37
+      Name: net/url.Values
+      ByteSize: 8
+      GoRuntimeType: 1.712416e+06
+      GoKind: 21
+      HeaderType: 16 GoHMapHeaderType hash<string,[]string>
+    - __kind: StructureType
+      ID: 33
+      Name: runtime.bmap
+      ByteSize: 8
+      GoRuntimeType: 1.13712e+06
+      GoKind: 25
+      RawFields:
+        - Name: tophash
+          Offset: 0
+          Type: 21 ArrayType [8]uint8
+    - __kind: StructureType
+      ID: 28
+      Name: runtime.mapextra
+      ByteSize: 24
+      GoRuntimeType: 1.4656e+06
+      GoKind: 25
+      RawFields:
+        - Name: overflow
+          Offset: 0
+          Type: 29 PointerType *[]*runtime.bmap
+        - Name: oldoverflow
+          Offset: 8
+          Type: 29 PointerType *[]*runtime.bmap
+        - Name: nextOverflow
+          Offset: 16
+          Type: 32 PointerType *runtime.bmap
+    - __kind: GoStringHeaderType
+      ID: 5
+      Name: string
+      ByteSize: 16
+      GoRuntimeType: 542528
+      GoKind: 24
+      RawFields:
+        - Name: str
+          Offset: 0
+          Type: 204 PointerType *string.str
+        - Name: len
+          Offset: 8
+          Type: 8 BaseType int
+      Data: 203 GoStringDataType string.str
+    - __kind: GoStringDataType
+      ID: 203
+      Name: string.str
+      ByteSize: 2048
+    - __kind: StructureType
+      ID: 129
+      Name: sync.Mutex
+      ByteSize: 8
+      GoRuntimeType: 1.314208e+06
+      GoKind: 25
+      RawFields:
+        - Name: state
+          Offset: 0
+          Type: 130 BaseType int32
+        - Name: sema
+          Offset: 4
+          Type: 18 BaseType uint32
+    - __kind: StructureType
+      ID: 128
+      Name: sync.RWMutex
+      ByteSize: 24
+      GoRuntimeType: 1.751168e+06
+      GoKind: 25
+      RawFields:
+        - Name: w
+          Offset: 0
+          Type: 129 StructureType sync.Mutex
+        - Name: writerSem
+          Offset: 8
+          Type: 18 BaseType uint32
+        - Name: readerSem
+          Offset: 12
+          Type: 18 BaseType uint32
+        - Name: readerCount
+          Offset: 16
+          Type: 131 StructureType sync/atomic.Int32
+        - Name: readerWait
+          Offset: 20
+          Type: 131 StructureType sync/atomic.Int32
+    - __kind: StructureType
+      ID: 131
+      Name: sync/atomic.Int32
+      ByteSize: 4
+      GoRuntimeType: 1.315648e+06
+      GoKind: 25
+      RawFields:
+        - Name: _
+          Offset: 0
+          Type: 132 StructureType sync/atomic.noCopy
+        - Name: v
+          Offset: 0
+          Type: 130 BaseType int32
+    - __kind: StructureType
+      ID: 132
+      Name: sync/atomic.noCopy
+      GoRuntimeType: 966016
+      GoKind: 25
+      RawFields: []
+    - __kind: StructureType
+      ID: 76
+      Name: time.Location
+      ByteSize: 104
+      GoRuntimeType: 1.877952e+06
+      GoKind: 25
+      RawFields:
+        - Name: name
+          Offset: 0
+          Type: 5 GoStringHeaderType string
+        - Name: zone
+          Offset: 16
+          Type: 77 GoSliceHeaderType []time.zone
+        - Name: tx
+          Offset: 40
+          Type: 80 GoSliceHeaderType []time.zoneTrans
+        - Name: extend
+          Offset: 64
+          Type: 5 GoStringHeaderType string
+        - Name: cacheStart
+          Offset: 80
+          Type: 36 BaseType int64
+        - Name: cacheEnd
+          Offset: 88
+          Type: 36 BaseType int64
+        - Name: cacheZone
+          Offset: 96
+          Type: 78 PointerType *time.zone
+    - __kind: StructureType
+      ID: 73
+      Name: time.Time
+      ByteSize: 24
+      GoRuntimeType: 2.281472e+06
+      GoKind: 25
+      RawFields:
+        - Name: wall
+          Offset: 0
+          Type: 74 BaseType uint64
+        - Name: ext
+          Offset: 8
+          Type: 36 BaseType int64
+        - Name: loc
+          Offset: 16
+          Type: 75 PointerType *time.Location
+    - __kind: StructureType
+      ID: 79
+      Name: time.zone
+      ByteSize: 32
+      GoRuntimeType: 1.458304e+06
+      GoKind: 25
+      RawFields:
+        - Name: name
+          Offset: 0
+          Type: 5 GoStringHeaderType string
+        - Name: offset
+          Offset: 16
+          Type: 8 BaseType int
+        - Name: isDST
+          Offset: 24
+          Type: 13 BaseType bool
+    - __kind: StructureType
+      ID: 82
+      Name: time.zoneTrans
+      ByteSize: 16
+      GoRuntimeType: 1.664192e+06
+      GoKind: 25
+      RawFields:
+        - Name: when
+          Offset: 0
+          Type: 36 BaseType int64
+        - Name: index
+          Offset: 8
+          Type: 7 BaseType uint8
+        - Name: isstd
+          Offset: 9
+          Type: 13 BaseType bool
+        - Name: isutc
+          Offset: 10
+          Type: 13 BaseType bool
+    - __kind: BaseType
+      ID: 186
+      Name: uint
+      ByteSize: 8
+      GoRuntimeType: 543168
+      GoKind: 7
+    - __kind: BaseType
+      ID: 17
+      Name: uint16
+      ByteSize: 2
+      GoRuntimeType: 542784
+      GoKind: 9
+    - __kind: BaseType
+      ID: 18
+      Name: uint32
+      ByteSize: 4
+      GoRuntimeType: 542912
+      GoKind: 10
+    - __kind: BaseType
+      ID: 74
+      Name: uint64
+      ByteSize: 8
+      GoRuntimeType: 543040
+      GoKind: 11
+    - __kind: BaseType
+      ID: 7
+      Name: uint8
+      ByteSize: 1
+      GoRuntimeType: 542656
+      GoKind: 8
+    - __kind: BaseType
+      ID: 26
+      Name: uintptr
+      ByteSize: 8
+      GoRuntimeType: 543232
+      GoKind: 12
+    - __kind: VoidPointerType
+      ID: 2
+      Name: unsafe.Pointer
+      ByteSize: 8
+      GoRuntimeType: 543616
+      GoKind: 26
 MaxTypeID: 264
 Issues: []
 GoModuledataInfo: {FirstModuledataAddr: "0x137dc20", TypesOffset: 296}

--- a/pkg/dyninst/irgen/testdata/snapshot/rc_tester.arch=arm64,toolchain=go1.23.11.yaml
+++ b/pkg/dyninst/irgen/testdata/snapshot/rc_tester.arch=arm64,toolchain=go1.23.11.yaml
@@ -10,7 +10,7 @@ Probes:
       subprogram: {subprogram: 1}
       events:
         - ID: 1
-          Type: 263 EventRootType Probe[main.HandleHTTP]
+          Type: 196 EventRootType Probe[main.HandleHTTP]
           InjectionPoints: [{PC: "0x8dff40", Frameless: true}]
           Condition: null
     - id: look_at_the_request
@@ -23,7 +23,7 @@ Probes:
       subprogram: {subprogram: 2}
       events:
         - ID: 2
-          Type: 264 EventRootType Probe[main.LookAtTheRequest]
+          Type: 197 EventRootType Probe[main.LookAtTheRequest]
           InjectionPoints: [{PC: "0x8e025c", Frameless: true}]
           Condition: null
 Subprograms:
@@ -105,174 +105,125 @@ Subprograms:
           IsReturn: false
 Types:
     - __kind: PointerType
-      ID: 116
+      ID: 102
       Name: '**crypto/x509.Certificate'
       ByteSize: 8
-      Pointee: 117 PointerType *crypto/x509.Certificate
+      Pointee: 103 PointerType *crypto/x509.Certificate
     - __kind: PointerType
-      ID: 162
-      Name: '**github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span'
-      ByteSize: 8
-      GoKind: 22
-      Pointee: 39 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span
-    - __kind: PointerType
-      ID: 228
-      Name: '**github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttributeValue'
-      ByteSize: 8
-      GoKind: 22
-      Pointee: 229 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttributeValue
-    - __kind: PointerType
-      ID: 155
+      ID: 91
       Name: '**mime/multipart.FileHeader'
       ByteSize: 8
       GoKind: 22
-      Pointee: 156 PointerType *mime/multipart.FileHeader
+      Pointee: 92 PointerType *mime/multipart.FileHeader
     - __kind: PointerType
-      ID: 204
+      ID: 145
       Name: '**net.IPNet'
       ByteSize: 8
       GoKind: 22
-      Pointee: 205 PointerType *net.IPNet
+      Pointee: 146 PointerType *net.IPNet
     - __kind: PointerType
-      ID: 202
+      ID: 143
       Name: '**net/url.URL'
       ByteSize: 8
-      Pointee: 45 PointerType *net/url.URL
+      Pointee: 47 PointerType *net/url.URL
     - __kind: PointerType
-      ID: 152
-      Name: '**runtime.bmap'
-      ByteSize: 8
-      Pointee: 107 PointerType *runtime.bmap
-    - __kind: PointerType
-      ID: 119
+      ID: 105
       Name: '*[]*crypto/x509.Certificate'
       ByteSize: 8
       GoKind: 22
-      Pointee: 115 GoSliceHeaderType []*crypto/x509.Certificate
+      Pointee: 101 GoSliceHeaderType []*crypto/x509.Certificate
     - __kind: PointerType
-      ID: 168
+      ID: 112
       Name: '*[]*crypto/x509.Certificate.array'
       ByteSize: 8
-      Pointee: 167 GoSliceDataType []*crypto/x509.Certificate.array
+      Pointee: 111 GoSliceDataType []*crypto/x509.Certificate.array
     - __kind: PointerType
-      ID: 215
-      Name: '*[]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span.array'
-      ByteSize: 8
-      Pointee: 214 GoSliceDataType []*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span.array
-    - __kind: PointerType
-      ID: 259
-      Name: '*[]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttributeValue.array'
-      ByteSize: 8
-      Pointee: 258 GoSliceDataType []*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttributeValue.array
-    - __kind: PointerType
-      ID: 213
+      ID: 96
       Name: '*[]*mime/multipart.FileHeader.array'
       ByteSize: 8
-      Pointee: 212 GoSliceDataType []*mime/multipart.FileHeader.array
+      Pointee: 95 GoSliceDataType []*mime/multipart.FileHeader.array
     - __kind: PointerType
-      ID: 247
+      ID: 179
       Name: '*[]*net.IPNet.array'
       ByteSize: 8
-      Pointee: 246 GoSliceDataType []*net.IPNet.array
+      Pointee: 178 GoSliceDataType []*net.IPNet.array
     - __kind: PointerType
-      ID: 245
+      ID: 176
       Name: '*[]*net/url.URL.array'
       ByteSize: 8
-      Pointee: 244 GoSliceDataType []*net/url.URL.array
+      Pointee: 175 GoSliceDataType []*net/url.URL.array
     - __kind: PointerType
-      ID: 105
-      Name: '*[]*runtime.bmap'
-      ByteSize: 8
-      GoRuntimeType: 470816
-      GoKind: 22
-      Pointee: 106 GoSliceHeaderType []*runtime.bmap
-    - __kind: PointerType
-      ID: 165
-      Name: '*[]*runtime.bmap.array'
-      ByteSize: 8
-      Pointee: 164 GoSliceDataType []*runtime.bmap.array
-    - __kind: PointerType
-      ID: 170
+      ID: 114
       Name: '*[][]*crypto/x509.Certificate.array'
       ByteSize: 8
-      Pointee: 169 GoSliceDataType [][]*crypto/x509.Certificate.array
+      Pointee: 113 GoSliceDataType [][]*crypto/x509.Certificate.array
     - __kind: PointerType
-      ID: 172
+      ID: 116
       Name: '*[][]uint8.array'
       ByteSize: 8
-      Pointee: 171 GoSliceDataType [][]uint8.array
+      Pointee: 115 GoSliceDataType [][]uint8.array
     - __kind: PointerType
-      ID: 239
+      ID: 172
       Name: '*[]crypto/x509.ExtKeyUsage.array'
       ByteSize: 8
-      Pointee: 238 GoSliceDataType []crypto/x509.ExtKeyUsage.array
+      Pointee: 171 GoSliceDataType []crypto/x509.ExtKeyUsage.array
     - __kind: PointerType
-      ID: 249
+      ID: 181
       Name: '*[]crypto/x509.OID.array'
       ByteSize: 8
-      Pointee: 248 GoSliceDataType []crypto/x509.OID.array
+      Pointee: 180 GoSliceDataType []crypto/x509.OID.array
     - __kind: PointerType
-      ID: 231
+      ID: 156
       Name: '*[]crypto/x509/pkix.AttributeTypeAndValue.array'
       ByteSize: 8
-      Pointee: 230 GoSliceDataType []crypto/x509/pkix.AttributeTypeAndValue.array
+      Pointee: 155 GoSliceDataType []crypto/x509/pkix.AttributeTypeAndValue.array
     - __kind: PointerType
-      ID: 233
+      ID: 168
       Name: '*[]crypto/x509/pkix.Extension.array'
       ByteSize: 8
-      Pointee: 232 GoSliceDataType []crypto/x509/pkix.Extension.array
+      Pointee: 167 GoSliceDataType []crypto/x509/pkix.Extension.array
     - __kind: PointerType
-      ID: 235
+      ID: 170
       Name: '*[]encoding/asn1.ObjectIdentifier.array'
       ByteSize: 8
-      Pointee: 234 GoSliceDataType []encoding/asn1.ObjectIdentifier.array
-    - __kind: PointerType
-      ID: 147
-      Name: '*[]github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink.array'
-      ByteSize: 8
-      Pointee: 146 GoSliceDataType []github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink.array
-    - __kind: PointerType
-      ID: 149
-      Name: '*[]github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent.array'
-      ByteSize: 8
-      Pointee: 148 GoSliceDataType []github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent.array
-    - __kind: PointerType
-      ID: 241
-      Name: '*[]net.IP.array'
-      ByteSize: 8
-      Pointee: 240 GoSliceDataType []net.IP.array
+      Pointee: 169 GoSliceDataType []encoding/asn1.ObjectIdentifier.array
     - __kind: PointerType
       ID: 174
+      Name: '*[]net.IP.array'
+      ByteSize: 8
+      Pointee: 173 GoSliceDataType []net.IP.array
+    - __kind: PointerType
+      ID: 193
       Name: '*[]net/http.segment.array'
       ByteSize: 8
-      Pointee: 173 GoSliceDataType []net/http.segment.array
+      Pointee: 192 GoSliceDataType []net/http.segment.array
     - __kind: PointerType
-      ID: 142
+      ID: 82
       Name: '*[]string.array'
       ByteSize: 8
-      Pointee: 141 GoSliceDataType []string.array
+      Pointee: 81 GoSliceDataType []string.array
     - __kind: PointerType
-      ID: 255
+      ID: 164
       Name: '*[]time.zone.array'
       ByteSize: 8
-      Pointee: 254 GoSliceDataType []time.zone.array
+      Pointee: 163 GoSliceDataType []time.zone.array
     - __kind: PointerType
-      ID: 257
+      ID: 166
       Name: '*[]time.zoneTrans.array'
       ByteSize: 8
-      Pointee: 256 GoSliceDataType []time.zoneTrans.array
+      Pointee: 165 GoSliceDataType []time.zoneTrans.array
     - __kind: PointerType
-      ID: 121
+      ID: 107
       Name: '*[]uint8'
       ByteSize: 8
       GoRuntimeType: 456928
       GoKind: 22
-      Pointee: 96 GoSliceHeaderType []uint8
+      Pointee: 98 GoSliceHeaderType []uint8
     - __kind: PointerType
-      ID: 151
+      ID: 100
       Name: '*[]uint8.array'
       ByteSize: 8
-      Pointee: 150 GoSliceDataType []uint8.array
+      Pointee: 99 GoSliceDataType []uint8.array
     - __kind: PointerType
       ID: 5
       Name: '*bool'
@@ -281,96 +232,81 @@ Types:
       GoKind: 22
       Pointee: 4 BaseType bool
     - __kind: PointerType
-      ID: 134
-      Name: '*bucket<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>'
-      ByteSize: 8
-      Pointee: 135 GoHMapBucketType bucket<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
-    - __kind: PointerType
-      ID: 113
+      ID: 87
       Name: '*bucket<string,[]*mime/multipart.FileHeader>'
       ByteSize: 8
-      Pointee: 114 GoHMapBucketType bucket<string,[]*mime/multipart.FileHeader>
+      Pointee: 88 GoHMapBucketType bucket<string,[]*mime/multipart.FileHeader>
     - __kind: PointerType
-      ID: 50
+      ID: 52
       Name: '*bucket<string,[]string>'
       ByteSize: 8
-      Pointee: 51 GoHMapBucketType bucket<string,[]string>
+      Pointee: 53 GoHMapBucketType bucket<string,[]string>
     - __kind: PointerType
-      ID: 85
-      Name: '*bucket<string,float64>'
-      ByteSize: 8
-      Pointee: 86 GoHMapBucketType bucket<string,float64>
-    - __kind: PointerType
-      ID: 80
-      Name: '*bucket<string,interface {}>'
-      ByteSize: 8
-      Pointee: 81 GoHMapBucketType bucket<string,interface {}>
-    - __kind: PointerType
-      ID: 71
+      ID: 73
       Name: '*bucket<string,string>'
       ByteSize: 8
-      Pointee: 72 GoHMapBucketType bucket<string,string>
+      Pointee: 74 GoHMapBucketType bucket<string,string>
     - __kind: PointerType
       ID: 41
       Name: '*bytes.Buffer'
       ByteSize: 8
       GoRuntimeType: 2.176896e+06
       GoKind: 22
-      Pointee: 42 StructureType bytes.Buffer
+      Pointee: 42 UnresolvedPointeeType bytes.Buffer
     - __kind: PointerType
-      ID: 60
+      ID: 62
       Name: '*crypto/tls.ConnectionState'
       ByteSize: 8
       GoRuntimeType: 852320
       GoKind: 22
-      Pointee: 61 StructureType crypto/tls.ConnectionState
+      Pointee: 63 StructureType crypto/tls.ConnectionState
     - __kind: PointerType
-      ID: 117
+      ID: 103
       Name: '*crypto/x509.Certificate'
       ByteSize: 8
       GoRuntimeType: 1.95344e+06
       GoKind: 22
-      Pointee: 157 StructureType crypto/x509.Certificate
+      Pointee: 110 StructureType crypto/x509.Certificate
     - __kind: PointerType
-      ID: 196
+      ID: 137
       Name: '*crypto/x509.ExtKeyUsage'
       ByteSize: 8
       GoRuntimeType: 400736
       GoKind: 22
-      Pointee: 197 BaseType crypto/x509.ExtKeyUsage
+      Pointee: 138 BaseType crypto/x509.ExtKeyUsage
     - __kind: PointerType
-      ID: 207
+      ID: 148
       Name: '*crypto/x509.OID'
       ByteSize: 8
       GoRuntimeType: 1.762368e+06
       GoKind: 22
-      Pointee: 208 StructureType crypto/x509.OID
+      Pointee: 149 StructureType crypto/x509.OID
     - __kind: PointerType
-      ID: 183
+      ID: 124
       Name: '*crypto/x509/pkix.AttributeTypeAndValue'
       ByteSize: 8
       GoRuntimeType: 417504
       GoKind: 22
-      Pointee: 184 StructureType crypto/x509/pkix.AttributeTypeAndValue
+      Pointee: 125 StructureType crypto/x509/pkix.AttributeTypeAndValue
     - __kind: PointerType
-      ID: 190
+      ID: 131
       Name: '*crypto/x509/pkix.Extension'
       ByteSize: 8
       GoRuntimeType: 417696
       GoKind: 22
-      Pointee: 191 StructureType crypto/x509/pkix.Extension
+      Pointee: 132 StructureType crypto/x509/pkix.Extension
     - __kind: PointerType
-      ID: 193
+      ID: 134
       Name: '*encoding/asn1.ObjectIdentifier'
       ByteSize: 8
       GoRuntimeType: 1.037472e+06
       GoKind: 22
-      Pointee: 194 GoSliceHeaderType encoding/asn1.ObjectIdentifier
+      Pointee: 135 GoSliceHeaderType encoding/asn1.ObjectIdentifier
     - __kind: PointerType
-      ID: 237
+      ID: 183
       Name: '*encoding/asn1.ObjectIdentifier.array'
       ByteSize: 8
-      Pointee: 236 GoSliceDataType encoding/asn1.ObjectIdentifier.array
+      Pointee: 182 GoSliceDataType encoding/asn1.ObjectIdentifier.array
     - __kind: PointerType
       ID: 33
       Name: '*error'
@@ -398,86 +334,22 @@ Types:
       ByteSize: 8
       GoRuntimeType: 2.18768e+06
       GoKind: 22
-      Pointee: 40 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span
+      Pointee: 40 UnresolvedPointeeType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span
     - __kind: PointerType
-      ID: 93
-      Name: '*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanContext'
-      ByteSize: 8
-      GoRuntimeType: 1.91728e+06
-      GoKind: 22
-      Pointee: 94 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanContext
-    - __kind: PointerType
-      ID: 88
-      Name: '*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink'
-      ByteSize: 8
-      GoRuntimeType: 1.12944e+06
-      GoKind: 22
-      Pointee: 89 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink
-    - __kind: PointerType
-      ID: 91
-      Name: '*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent'
-      ByteSize: 8
-      GoRuntimeType: 1.129568e+06
-      GoKind: 22
-      Pointee: 92 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent
-    - __kind: PointerType
-      ID: 210
-      Name: '*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttribute'
-      ByteSize: 8
-      GoRuntimeType: 1.130208e+06
-      GoKind: 22
-      Pointee: 211 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttribute
-    - __kind: PointerType
-      ID: 229
-      Name: '*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttributeValue'
-      ByteSize: 8
-      GoRuntimeType: 1.129952e+06
-      GoKind: 22
-      Pointee: 251 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttributeValue
-    - __kind: PointerType
-      ID: 159
-      Name: '*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute'
-      ByteSize: 8
-      GoRuntimeType: 1.130336e+06
-      GoKind: 22
-      Pointee: 160 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
-    - __kind: PointerType
-      ID: 137
-      Name: '*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.trace'
-      ByteSize: 8
-      GoRuntimeType: 2.132544e+06
-      GoKind: 22
-      Pointee: 138 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.trace
-    - __kind: PointerType
-      ID: 132
-      Name: '*hash<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>'
-      ByteSize: 8
-      Pointee: 133 GoHMapHeaderType hash<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
-    - __kind: PointerType
-      ID: 111
+      ID: 85
       Name: '*hash<string,[]*mime/multipart.FileHeader>'
       ByteSize: 8
-      Pointee: 112 GoHMapHeaderType hash<string,[]*mime/multipart.FileHeader>
+      Pointee: 86 GoHMapHeaderType hash<string,[]*mime/multipart.FileHeader>
     - __kind: PointerType
-      ID: 48
+      ID: 50
       Name: '*hash<string,[]string>'
       ByteSize: 8
-      Pointee: 49 GoHMapHeaderType hash<string,[]string>
+      Pointee: 51 GoHMapHeaderType hash<string,[]string>
     - __kind: PointerType
-      ID: 83
-      Name: '*hash<string,float64>'
-      ByteSize: 8
-      Pointee: 84 GoHMapHeaderType hash<string,float64>
-    - __kind: PointerType
-      ID: 78
-      Name: '*hash<string,interface {}>'
-      ByteSize: 8
-      Pointee: 79 GoHMapHeaderType hash<string,interface {}>
-    - __kind: PointerType
-      ID: 69
+      ID: 71
       Name: '*hash<string,string>'
       ByteSize: 8
-      Pointee: 70 GoHMapHeaderType hash<string,string>
+      Pointee: 72 GoHMapHeaderType hash<string,string>
     - __kind: PointerType
       ID: 28
       Name: '*int'
@@ -514,62 +386,62 @@ Types:
       GoKind: 22
       Pointee: 15 BaseType int8
     - __kind: PointerType
-      ID: 179
+      ID: 120
       Name: '*math/big.Int'
       ByteSize: 8
       GoRuntimeType: 2.29744e+06
       GoKind: 22
-      Pointee: 180 StructureType math/big.Int
+      Pointee: 121 StructureType math/big.Int
     - __kind: PointerType
-      ID: 218
+      ID: 151
       Name: '*math/big.Word'
       ByteSize: 8
       GoRuntimeType: 403552
       GoKind: 22
-      Pointee: 219 BaseType math/big.Word
+      Pointee: 152 BaseType math/big.Word
     - __kind: PointerType
-      ID: 253
+      ID: 154
       Name: '*math/big.nat.array'
       ByteSize: 8
-      Pointee: 252 GoSliceDataType math/big.nat.array
+      Pointee: 153 GoSliceDataType math/big.nat.array
     - __kind: PointerType
-      ID: 156
+      ID: 92
       Name: '*mime/multipart.FileHeader'
       ByteSize: 8
       GoRuntimeType: 853760
       GoKind: 22
-      Pointee: 176 StructureType mime/multipart.FileHeader
+      Pointee: 94 StructureType mime/multipart.FileHeader
     - __kind: PointerType
-      ID: 58
+      ID: 60
       Name: '*mime/multipart.Form'
       ByteSize: 8
       GoRuntimeType: 853856
       GoKind: 22
-      Pointee: 59 StructureType mime/multipart.Form
+      Pointee: 61 StructureType mime/multipart.Form
     - __kind: PointerType
-      ID: 199
+      ID: 140
       Name: '*net.IP'
       ByteSize: 8
       GoRuntimeType: 2.02912e+06
       GoKind: 22
-      Pointee: 200 GoSliceHeaderType net.IP
+      Pointee: 141 GoSliceHeaderType net.IP
     - __kind: PointerType
-      ID: 243
+      ID: 185
       Name: '*net.IP.array'
       ByteSize: 8
-      Pointee: 242 GoSliceDataType net.IP.array
+      Pointee: 184 GoSliceDataType net.IP.array
     - __kind: PointerType
-      ID: 262
+      ID: 188
       Name: '*net.IPMask.array'
       ByteSize: 8
-      Pointee: 261 GoSliceDataType net.IPMask.array
+      Pointee: 187 GoSliceDataType net.IPMask.array
     - __kind: PointerType
-      ID: 205
+      ID: 146
       Name: '*net.IPNet'
       ByteSize: 8
       GoRuntimeType: 1.122912e+06
       GoKind: 22
-      Pointee: 226 StructureType net.IPNet
+      Pointee: 177 StructureType net.IPNet
     - __kind: PointerType
       ID: 37
       Name: '*net/http.Request'
@@ -578,54 +450,47 @@ Types:
       GoKind: 22
       Pointee: 38 StructureType net/http.Request
     - __kind: PointerType
-      ID: 63
+      ID: 65
       Name: '*net/http.Response'
       ByteSize: 8
       GoRuntimeType: 1.632736e+06
       GoKind: 22
-      Pointee: 64 StructureType net/http.Response
+      Pointee: 66 StructureType net/http.Response
     - __kind: PointerType
-      ID: 66
+      ID: 68
       Name: '*net/http.pattern'
       ByteSize: 8
       GoRuntimeType: 1.453504e+06
       GoKind: 22
-      Pointee: 67 StructureType net/http.pattern
+      Pointee: 69 StructureType net/http.pattern
     - __kind: PointerType
-      ID: 125
+      ID: 190
       Name: '*net/http.segment'
       ByteSize: 8
       GoRuntimeType: 367904
       GoKind: 22
-      Pointee: 126 StructureType net/http.segment
+      Pointee: 191 StructureType net/http.segment
     - __kind: PointerType
-      ID: 45
+      ID: 47
       Name: '*net/url.URL'
       ByteSize: 8
       GoRuntimeType: 2.002496e+06
       GoKind: 22
-      Pointee: 46 StructureType net/url.URL
+      Pointee: 48 StructureType net/url.URL
     - __kind: PointerType
-      ID: 100
+      ID: 75
       Name: '*net/url.Userinfo'
       ByteSize: 8
       GoRuntimeType: 1.1416e+06
       GoKind: 22
-      Pointee: 101 StructureType net/url.Userinfo
+      Pointee: 76 StructureType net/url.Userinfo
     - __kind: PointerType
-      ID: 107
-      Name: '*runtime.bmap'
-      ByteSize: 8
-      GoRuntimeType: 1.137248e+06
-      GoKind: 22
-      Pointee: 108 StructureType runtime.bmap
-    - __kind: PointerType
-      ID: 52
+      ID: 54
       Name: '*runtime.mapextra'
       ByteSize: 8
       GoRuntimeType: 380000
       GoKind: 22
-      Pointee: 53 StructureType runtime.mapextra
+      Pointee: 55 UnresolvedPointeeType runtime.mapextra
     - __kind: PointerType
       ID: 22
       Name: '*string'
@@ -634,31 +499,31 @@ Types:
       GoKind: 22
       Pointee: 11 GoStringHeaderType string
     - __kind: PointerType
-      ID: 99
+      ID: 46
       Name: '*string.str'
       ByteSize: 8
-      Pointee: 98 GoStringDataType string.str
+      Pointee: 45 GoStringDataType string.str
     - __kind: PointerType
-      ID: 186
+      ID: 127
       Name: '*time.Location'
       ByteSize: 8
       GoRuntimeType: 1.458496e+06
       GoKind: 22
-      Pointee: 187 StructureType time.Location
+      Pointee: 128 StructureType time.Location
     - __kind: PointerType
-      ID: 221
+      ID: 158
       Name: '*time.zone'
       ByteSize: 8
       GoRuntimeType: 370976
       GoKind: 22
-      Pointee: 222 StructureType time.zone
+      Pointee: 159 StructureType time.zone
     - __kind: PointerType
-      ID: 224
+      ID: 161
       Name: '*time.zoneTrans'
       ByteSize: 8
       GoRuntimeType: 371040
       GoKind: 22
-      Pointee: 225 StructureType time.zoneTrans
+      Pointee: 162 StructureType time.zoneTrans
     - __kind: PointerType
       ID: 34
       Name: '*uint'
@@ -702,12 +567,12 @@ Types:
       GoKind: 22
       Pointee: 1 BaseType uintptr
     - __kind: GoChannelType
-      ID: 62
+      ID: 64
       Name: <-chan struct {}
       GoRuntimeType: 555520
       GoKind: 18
     - __kind: EventRootType
-      ID: 263
+      ID: 196
       Name: Probe[main.HandleHTTP]
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -731,7 +596,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 264
+      ID: 197
       Name: Probe[main.LookAtTheRequest]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -746,7 +611,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: ArrayType
-      ID: 102
+      ID: 77
       Name: '[8]uint8'
       ByteSize: 8
       GoRuntimeType: 632832
@@ -755,7 +620,7 @@ Types:
       HasCount: true
       Element: 3 BaseType uint8
     - __kind: GoSliceHeaderType
-      ID: 115
+      ID: 101
       Name: '[]*crypto/x509.Certificate'
       ByteSize: 24
       GoRuntimeType: 473920
@@ -763,65 +628,21 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 116 PointerType **crypto/x509.Certificate
+          Type: 102 PointerType **crypto/x509.Certificate
         - Name: len
           Offset: 8
           Type: 9 BaseType int
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 167 GoSliceDataType []*crypto/x509.Certificate.array
+      Data: 111 GoSliceDataType []*crypto/x509.Certificate.array
     - __kind: GoSliceDataType
-      ID: 167
+      ID: 111
       Name: '[]*crypto/x509.Certificate.array'
       ByteSize: 2048
-      Element: 117 PointerType *crypto/x509.Certificate
+      Element: 103 PointerType *crypto/x509.Certificate
     - __kind: GoSliceHeaderType
-      ID: 161
-      Name: '[]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span'
-      ByteSize: 24
-      GoRuntimeType: 464032
-      GoKind: 23
-      RawFields:
-        - Name: array
-          Offset: 0
-          Type: 162 PointerType **github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span
-        - Name: len
-          Offset: 8
-          Type: 9 BaseType int
-        - Name: cap
-          Offset: 16
-          Type: 9 BaseType int
-      Data: 214 GoSliceDataType []*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span.array
-    - __kind: GoSliceDataType
-      ID: 214
-      Name: '[]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span.array'
-      ByteSize: 2048
-      Element: 39 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span
-    - __kind: GoSliceHeaderType
-      ID: 227
-      Name: '[]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttributeValue'
-      ByteSize: 24
-      GoRuntimeType: 463648
-      GoKind: 23
-      RawFields:
-        - Name: array
-          Offset: 0
-          Type: 228 PointerType **github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttributeValue
-        - Name: len
-          Offset: 8
-          Type: 9 BaseType int
-        - Name: cap
-          Offset: 16
-          Type: 9 BaseType int
-      Data: 258 GoSliceDataType []*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttributeValue.array
-    - __kind: GoSliceDataType
-      ID: 258
-      Name: '[]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttributeValue.array'
-      ByteSize: 2048
-      Element: 229 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttributeValue
-    - __kind: GoSliceHeaderType
-      ID: 154
+      ID: 90
       Name: '[]*mime/multipart.FileHeader'
       ByteSize: 24
       GoRuntimeType: 461664
@@ -829,21 +650,21 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 155 PointerType **mime/multipart.FileHeader
+          Type: 91 PointerType **mime/multipart.FileHeader
         - Name: len
           Offset: 8
           Type: 9 BaseType int
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 212 GoSliceDataType []*mime/multipart.FileHeader.array
+      Data: 95 GoSliceDataType []*mime/multipart.FileHeader.array
     - __kind: GoSliceDataType
-      ID: 212
+      ID: 95
       Name: '[]*mime/multipart.FileHeader.array'
       ByteSize: 2048
-      Element: 156 PointerType *mime/multipart.FileHeader
+      Element: 92 PointerType *mime/multipart.FileHeader
     - __kind: GoSliceHeaderType
-      ID: 203
+      ID: 144
       Name: '[]*net.IPNet'
       ByteSize: 24
       GoRuntimeType: 486976
@@ -851,21 +672,21 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 204 PointerType **net.IPNet
+          Type: 145 PointerType **net.IPNet
         - Name: len
           Offset: 8
           Type: 9 BaseType int
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 246 GoSliceDataType []*net.IPNet.array
+      Data: 178 GoSliceDataType []*net.IPNet.array
     - __kind: GoSliceDataType
-      ID: 246
+      ID: 178
       Name: '[]*net.IPNet.array'
       ByteSize: 2048
-      Element: 205 PointerType *net.IPNet
+      Element: 146 PointerType *net.IPNet
     - __kind: GoSliceHeaderType
-      ID: 201
+      ID: 142
       Name: '[]*net/url.URL'
       ByteSize: 24
       GoRuntimeType: 486912
@@ -873,43 +694,21 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 202 PointerType **net/url.URL
+          Type: 143 PointerType **net/url.URL
         - Name: len
           Offset: 8
           Type: 9 BaseType int
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 244 GoSliceDataType []*net/url.URL.array
+      Data: 175 GoSliceDataType []*net/url.URL.array
     - __kind: GoSliceDataType
-      ID: 244
+      ID: 175
       Name: '[]*net/url.URL.array'
       ByteSize: 2048
-      Element: 45 PointerType *net/url.URL
+      Element: 47 PointerType *net/url.URL
     - __kind: GoSliceHeaderType
-      ID: 106
-      Name: '[]*runtime.bmap'
-      ByteSize: 24
-      GoRuntimeType: 470752
-      GoKind: 23
-      RawFields:
-        - Name: array
-          Offset: 0
-          Type: 152 PointerType **runtime.bmap
-        - Name: len
-          Offset: 8
-          Type: 9 BaseType int
-        - Name: cap
-          Offset: 16
-          Type: 9 BaseType int
-      Data: 164 GoSliceDataType []*runtime.bmap.array
-    - __kind: GoSliceDataType
-      ID: 164
-      Name: '[]*runtime.bmap.array'
-      ByteSize: 2048
-      Element: 107 PointerType *runtime.bmap
-    - __kind: GoSliceHeaderType
-      ID: 118
+      ID: 104
       Name: '[][]*crypto/x509.Certificate'
       ByteSize: 24
       GoRuntimeType: 474048
@@ -917,21 +716,21 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 119 PointerType *[]*crypto/x509.Certificate
+          Type: 105 PointerType *[]*crypto/x509.Certificate
         - Name: len
           Offset: 8
           Type: 9 BaseType int
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 169 GoSliceDataType [][]*crypto/x509.Certificate.array
+      Data: 113 GoSliceDataType [][]*crypto/x509.Certificate.array
     - __kind: GoSliceDataType
-      ID: 169
+      ID: 113
       Name: '[][]*crypto/x509.Certificate.array'
       ByteSize: 2048
-      Element: 115 GoSliceHeaderType []*crypto/x509.Certificate
+      Element: 101 GoSliceHeaderType []*crypto/x509.Certificate
     - __kind: GoSliceHeaderType
-      ID: 120
+      ID: 106
       Name: '[][]uint8'
       ByteSize: 24
       GoRuntimeType: 457184
@@ -939,51 +738,36 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 121 PointerType *[]uint8
+          Type: 107 PointerType *[]uint8
         - Name: len
           Offset: 8
           Type: 9 BaseType int
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 171 GoSliceDataType [][]uint8.array
+      Data: 115 GoSliceDataType [][]uint8.array
     - __kind: GoSliceDataType
-      ID: 171
+      ID: 115
       Name: '[][]uint8.array'
       ByteSize: 2048
-      Element: 96 GoSliceHeaderType []uint8
+      Element: 98 GoSliceHeaderType []uint8
     - __kind: GoSliceDataType
-      ID: 175
-      Name: '[]bucket<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>.array'
-      ByteSize: 2048
-      Element: 135 GoHMapBucketType bucket<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
-    - __kind: GoSliceDataType
-      ID: 166
+      ID: 93
       Name: '[]bucket<string,[]*mime/multipart.FileHeader>.array'
       ByteSize: 2048
-      Element: 114 GoHMapBucketType bucket<string,[]*mime/multipart.FileHeader>
+      Element: 88 GoHMapBucketType bucket<string,[]*mime/multipart.FileHeader>
     - __kind: GoSliceDataType
-      ID: 140
+      ID: 80
       Name: '[]bucket<string,[]string>.array'
       ByteSize: 2048
-      Element: 51 GoHMapBucketType bucket<string,[]string>
+      Element: 53 GoHMapBucketType bucket<string,[]string>
     - __kind: GoSliceDataType
-      ID: 145
-      Name: '[]bucket<string,float64>.array'
-      ByteSize: 2048
-      Element: 86 GoHMapBucketType bucket<string,float64>
-    - __kind: GoSliceDataType
-      ID: 144
-      Name: '[]bucket<string,interface {}>.array'
-      ByteSize: 2048
-      Element: 81 GoHMapBucketType bucket<string,interface {}>
-    - __kind: GoSliceDataType
-      ID: 143
+      ID: 195
       Name: '[]bucket<string,string>.array'
       ByteSize: 2048
-      Element: 72 GoHMapBucketType bucket<string,string>
+      Element: 74 GoHMapBucketType bucket<string,string>
     - __kind: GoSliceHeaderType
-      ID: 195
+      ID: 136
       Name: '[]crypto/x509.ExtKeyUsage'
       ByteSize: 24
       GoRuntimeType: 475200
@@ -991,21 +775,21 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 196 PointerType *crypto/x509.ExtKeyUsage
+          Type: 137 PointerType *crypto/x509.ExtKeyUsage
         - Name: len
           Offset: 8
           Type: 9 BaseType int
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 238 GoSliceDataType []crypto/x509.ExtKeyUsage.array
+      Data: 171 GoSliceDataType []crypto/x509.ExtKeyUsage.array
     - __kind: GoSliceDataType
-      ID: 238
+      ID: 171
       Name: '[]crypto/x509.ExtKeyUsage.array'
       ByteSize: 2048
-      Element: 197 BaseType crypto/x509.ExtKeyUsage
+      Element: 138 BaseType crypto/x509.ExtKeyUsage
     - __kind: GoSliceHeaderType
-      ID: 206
+      ID: 147
       Name: '[]crypto/x509.OID'
       ByteSize: 24
       GoRuntimeType: 487040
@@ -1013,21 +797,21 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 207 PointerType *crypto/x509.OID
+          Type: 148 PointerType *crypto/x509.OID
         - Name: len
           Offset: 8
           Type: 9 BaseType int
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 248 GoSliceDataType []crypto/x509.OID.array
+      Data: 180 GoSliceDataType []crypto/x509.OID.array
     - __kind: GoSliceDataType
-      ID: 248
+      ID: 180
       Name: '[]crypto/x509.OID.array'
       ByteSize: 2048
-      Element: 208 StructureType crypto/x509.OID
+      Element: 149 StructureType crypto/x509.OID
     - __kind: GoSliceHeaderType
-      ID: 182
+      ID: 123
       Name: '[]crypto/x509/pkix.AttributeTypeAndValue'
       ByteSize: 24
       GoRuntimeType: 487296
@@ -1035,21 +819,21 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 183 PointerType *crypto/x509/pkix.AttributeTypeAndValue
+          Type: 124 PointerType *crypto/x509/pkix.AttributeTypeAndValue
         - Name: len
           Offset: 8
           Type: 9 BaseType int
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 230 GoSliceDataType []crypto/x509/pkix.AttributeTypeAndValue.array
+      Data: 155 GoSliceDataType []crypto/x509/pkix.AttributeTypeAndValue.array
     - __kind: GoSliceDataType
-      ID: 230
+      ID: 155
       Name: '[]crypto/x509/pkix.AttributeTypeAndValue.array'
       ByteSize: 2048
-      Element: 184 StructureType crypto/x509/pkix.AttributeTypeAndValue
+      Element: 125 StructureType crypto/x509/pkix.AttributeTypeAndValue
     - __kind: GoSliceHeaderType
-      ID: 189
+      ID: 130
       Name: '[]crypto/x509/pkix.Extension'
       ByteSize: 24
       GoRuntimeType: 486784
@@ -1057,21 +841,21 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 190 PointerType *crypto/x509/pkix.Extension
+          Type: 131 PointerType *crypto/x509/pkix.Extension
         - Name: len
           Offset: 8
           Type: 9 BaseType int
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 232 GoSliceDataType []crypto/x509/pkix.Extension.array
+      Data: 167 GoSliceDataType []crypto/x509/pkix.Extension.array
     - __kind: GoSliceDataType
-      ID: 232
+      ID: 167
       Name: '[]crypto/x509/pkix.Extension.array'
       ByteSize: 2048
-      Element: 191 StructureType crypto/x509/pkix.Extension
+      Element: 132 StructureType crypto/x509/pkix.Extension
     - __kind: GoSliceHeaderType
-      ID: 192
+      ID: 133
       Name: '[]encoding/asn1.ObjectIdentifier'
       ByteSize: 24
       GoRuntimeType: 486848
@@ -1079,72 +863,28 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 193 PointerType *encoding/asn1.ObjectIdentifier
+          Type: 134 PointerType *encoding/asn1.ObjectIdentifier
         - Name: len
           Offset: 8
           Type: 9 BaseType int
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 234 GoSliceDataType []encoding/asn1.ObjectIdentifier.array
+      Data: 169 GoSliceDataType []encoding/asn1.ObjectIdentifier.array
     - __kind: GoSliceDataType
-      ID: 234
+      ID: 169
       Name: '[]encoding/asn1.ObjectIdentifier.array'
       ByteSize: 2048
-      Element: 194 GoSliceHeaderType encoding/asn1.ObjectIdentifier
-    - __kind: GoSliceHeaderType
-      ID: 87
-      Name: '[]github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink'
-      ByteSize: 24
-      GoRuntimeType: 463584
-      GoKind: 23
-      RawFields:
-        - Name: array
-          Offset: 0
-          Type: 88 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink
-        - Name: len
-          Offset: 8
-          Type: 9 BaseType int
-        - Name: cap
-          Offset: 16
-          Type: 9 BaseType int
-      Data: 146 GoSliceDataType []github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink.array
-    - __kind: GoSliceDataType
-      ID: 146
-      Name: '[]github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink.array'
-      ByteSize: 2048
-      Element: 89 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink
-    - __kind: GoSliceHeaderType
-      ID: 90
-      Name: '[]github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent'
-      ByteSize: 24
-      GoRuntimeType: 463776
-      GoKind: 23
-      RawFields:
-        - Name: array
-          Offset: 0
-          Type: 91 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent
-        - Name: len
-          Offset: 8
-          Type: 9 BaseType int
-        - Name: cap
-          Offset: 16
-          Type: 9 BaseType int
-      Data: 148 GoSliceDataType []github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent.array
-    - __kind: GoSliceDataType
-      ID: 148
-      Name: '[]github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent.array'
-      ByteSize: 2048
-      Element: 92 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent
+      Element: 135 GoSliceHeaderType encoding/asn1.ObjectIdentifier
     - __kind: ArrayType
-      ID: 103
+      ID: 78
       Name: '[]key<string>'
       ByteSize: 128
       Count: 8
       HasCount: true
       Element: 11 GoStringHeaderType string
     - __kind: GoSliceHeaderType
-      ID: 198
+      ID: 139
       Name: '[]net.IP'
       ByteSize: 24
       GoRuntimeType: 458400
@@ -1152,21 +892,21 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 199 PointerType *net.IP
+          Type: 140 PointerType *net.IP
         - Name: len
           Offset: 8
           Type: 9 BaseType int
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 240 GoSliceDataType []net.IP.array
+      Data: 173 GoSliceDataType []net.IP.array
     - __kind: GoSliceDataType
-      ID: 240
+      ID: 173
       Name: '[]net.IP.array'
       ByteSize: 2048
-      Element: 200 GoSliceHeaderType net.IP
+      Element: 141 GoSliceHeaderType net.IP
     - __kind: GoSliceHeaderType
-      ID: 124
+      ID: 189
       Name: '[]net/http.segment'
       ByteSize: 24
       GoRuntimeType: 459168
@@ -1174,21 +914,21 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 125 PointerType *net/http.segment
+          Type: 190 PointerType *net/http.segment
         - Name: len
           Offset: 8
           Type: 9 BaseType int
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 173 GoSliceDataType []net/http.segment.array
+      Data: 192 GoSliceDataType []net/http.segment.array
     - __kind: GoSliceDataType
-      ID: 173
+      ID: 192
       Name: '[]net/http.segment.array'
       ByteSize: 2048
-      Element: 126 StructureType net/http.segment
+      Element: 191 StructureType net/http.segment
     - __kind: GoSliceHeaderType
-      ID: 56
+      ID: 58
       Name: '[]string'
       ByteSize: 24
       GoRuntimeType: 469152
@@ -1203,14 +943,14 @@ Types:
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 141 GoSliceDataType []string.array
+      Data: 81 GoSliceDataType []string.array
     - __kind: GoSliceDataType
-      ID: 141
+      ID: 81
       Name: '[]string.array'
       ByteSize: 2048
       Element: 11 GoStringHeaderType string
     - __kind: GoSliceHeaderType
-      ID: 220
+      ID: 157
       Name: '[]time.zone'
       ByteSize: 24
       GoRuntimeType: 463264
@@ -1218,21 +958,21 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 221 PointerType *time.zone
+          Type: 158 PointerType *time.zone
         - Name: len
           Offset: 8
           Type: 9 BaseType int
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 254 GoSliceDataType []time.zone.array
+      Data: 163 GoSliceDataType []time.zone.array
     - __kind: GoSliceDataType
-      ID: 254
+      ID: 163
       Name: '[]time.zone.array'
       ByteSize: 2048
-      Element: 222 StructureType time.zone
+      Element: 159 StructureType time.zone
     - __kind: GoSliceHeaderType
-      ID: 223
+      ID: 160
       Name: '[]time.zoneTrans'
       ByteSize: 24
       GoRuntimeType: 463328
@@ -1240,21 +980,21 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 224 PointerType *time.zoneTrans
+          Type: 161 PointerType *time.zoneTrans
         - Name: len
           Offset: 8
           Type: 9 BaseType int
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 256 GoSliceDataType []time.zoneTrans.array
+      Data: 165 GoSliceDataType []time.zoneTrans.array
     - __kind: GoSliceDataType
-      ID: 256
+      ID: 165
       Name: '[]time.zoneTrans.array'
       ByteSize: 2048
-      Element: 225 StructureType time.zoneTrans
+      Element: 162 StructureType time.zoneTrans
     - __kind: GoSliceHeaderType
-      ID: 96
+      ID: 98
       Name: '[]uint8'
       ByteSize: 24
       GoRuntimeType: 468000
@@ -1269,49 +1009,28 @@ Types:
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 150 GoSliceDataType []uint8.array
+      Data: 99 GoSliceDataType []uint8.array
     - __kind: GoSliceDataType
-      ID: 150
+      ID: 99
       Name: '[]uint8.array'
       ByteSize: 2048
       Element: 3 BaseType uint8
     - __kind: ArrayType
-      ID: 158
-      Name: '[]val<*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>'
-      ByteSize: 64
-      Count: 8
-      HasCount: true
-      Element: 159 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
-    - __kind: ArrayType
-      ID: 153
+      ID: 89
       Name: '[]val<[]*mime/multipart.FileHeader>'
       ByteSize: 192
       Count: 8
       HasCount: true
-      Element: 154 GoSliceHeaderType []*mime/multipart.FileHeader
+      Element: 90 GoSliceHeaderType []*mime/multipart.FileHeader
     - __kind: ArrayType
-      ID: 104
+      ID: 79
       Name: '[]val<[]string>'
       ByteSize: 192
       Count: 8
       HasCount: true
-      Element: 56 GoSliceHeaderType []string
+      Element: 58 GoSliceHeaderType []string
     - __kind: ArrayType
-      ID: 130
-      Name: '[]val<float64>'
-      ByteSize: 64
-      Count: 8
-      HasCount: true
-      Element: 17 BaseType float64
-    - __kind: ArrayType
-      ID: 128
-      Name: '[]val<interface {}>'
-      ByteSize: 128
-      Count: 8
-      HasCount: true
-      Element: 129 GoEmptyInterfaceType interface {}
-    - __kind: ArrayType
-      ID: 127
+      ID: 194
       Name: '[]val<string>'
       ByteSize: 128
       Count: 8
@@ -1324,141 +1043,66 @@ Types:
       GoRuntimeType: 543552
       GoKind: 1
     - __kind: GoHMapBucketType
-      ID: 135
-      Name: bucket<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
-      ByteSize: 208
-      RawFields:
-        - Name: tophash
-          Offset: 0
-          Type: 102 ArrayType [8]uint8
-        - Name: keys
-          Offset: 8
-          Type: 103 ArrayType []key<string>
-        - Name: values
-          Offset: 136
-          Type: 158 ArrayType []val<*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
-        - Name: overflow
-          Offset: 200
-          Type: 134 PointerType *bucket<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
-      KeyType: 11 GoStringHeaderType string
-      ValueType: 159 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
-    - __kind: GoHMapBucketType
-      ID: 114
+      ID: 88
       Name: bucket<string,[]*mime/multipart.FileHeader>
       ByteSize: 336
       RawFields:
         - Name: tophash
           Offset: 0
-          Type: 102 ArrayType [8]uint8
+          Type: 77 ArrayType [8]uint8
         - Name: keys
           Offset: 8
-          Type: 103 ArrayType []key<string>
+          Type: 78 ArrayType []key<string>
         - Name: values
           Offset: 136
-          Type: 153 ArrayType []val<[]*mime/multipart.FileHeader>
+          Type: 89 ArrayType []val<[]*mime/multipart.FileHeader>
         - Name: overflow
           Offset: 328
-          Type: 113 PointerType *bucket<string,[]*mime/multipart.FileHeader>
+          Type: 87 PointerType *bucket<string,[]*mime/multipart.FileHeader>
       KeyType: 11 GoStringHeaderType string
-      ValueType: 154 GoSliceHeaderType []*mime/multipart.FileHeader
+      ValueType: 90 GoSliceHeaderType []*mime/multipart.FileHeader
     - __kind: GoHMapBucketType
-      ID: 51
+      ID: 53
       Name: bucket<string,[]string>
       ByteSize: 336
       RawFields:
         - Name: tophash
           Offset: 0
-          Type: 102 ArrayType [8]uint8
+          Type: 77 ArrayType [8]uint8
         - Name: keys
           Offset: 8
-          Type: 103 ArrayType []key<string>
+          Type: 78 ArrayType []key<string>
         - Name: values
           Offset: 136
-          Type: 104 ArrayType []val<[]string>
+          Type: 79 ArrayType []val<[]string>
         - Name: overflow
           Offset: 328
-          Type: 50 PointerType *bucket<string,[]string>
+          Type: 52 PointerType *bucket<string,[]string>
       KeyType: 11 GoStringHeaderType string
-      ValueType: 56 GoSliceHeaderType []string
+      ValueType: 58 GoSliceHeaderType []string
     - __kind: GoHMapBucketType
-      ID: 86
-      Name: bucket<string,float64>
-      ByteSize: 208
-      RawFields:
-        - Name: tophash
-          Offset: 0
-          Type: 102 ArrayType [8]uint8
-        - Name: keys
-          Offset: 8
-          Type: 103 ArrayType []key<string>
-        - Name: values
-          Offset: 136
-          Type: 130 ArrayType []val<float64>
-        - Name: overflow
-          Offset: 200
-          Type: 85 PointerType *bucket<string,float64>
-      KeyType: 11 GoStringHeaderType string
-      ValueType: 17 BaseType float64
-    - __kind: GoHMapBucketType
-      ID: 81
-      Name: bucket<string,interface {}>
-      ByteSize: 272
-      RawFields:
-        - Name: tophash
-          Offset: 0
-          Type: 102 ArrayType [8]uint8
-        - Name: keys
-          Offset: 8
-          Type: 103 ArrayType []key<string>
-        - Name: values
-          Offset: 136
-          Type: 128 ArrayType []val<interface {}>
-        - Name: overflow
-          Offset: 264
-          Type: 80 PointerType *bucket<string,interface {}>
-      KeyType: 11 GoStringHeaderType string
-      ValueType: 129 GoEmptyInterfaceType interface {}
-    - __kind: GoHMapBucketType
-      ID: 72
+      ID: 74
       Name: bucket<string,string>
       ByteSize: 272
       RawFields:
         - Name: tophash
           Offset: 0
-          Type: 102 ArrayType [8]uint8
+          Type: 77 ArrayType [8]uint8
         - Name: keys
           Offset: 8
-          Type: 103 ArrayType []key<string>
+          Type: 78 ArrayType []key<string>
         - Name: values
           Offset: 136
-          Type: 127 ArrayType []val<string>
+          Type: 194 ArrayType []val<string>
         - Name: overflow
           Offset: 264
-          Type: 71 PointerType *bucket<string,string>
+          Type: 73 PointerType *bucket<string,string>
       KeyType: 11 GoStringHeaderType string
       ValueType: 11 GoStringHeaderType string
-    - __kind: StructureType
+    - __kind: UnresolvedPointeeType
       ID: 42
       Name: bytes.Buffer
-      ByteSize: 40
-      GoRuntimeType: 1.4512e+06
-      GoKind: 25
-      RawFields:
-        - Name: buf
-          Offset: 0
-          Type: 96 GoSliceHeaderType []uint8
-        - Name: off
-          Offset: 24
-          Type: 9 BaseType int
-        - Name: lastRead
-          Offset: 32
-          Type: 97 BaseType bytes.readOp
-    - __kind: BaseType
-      ID: 97
-      Name: bytes.readOp
-      ByteSize: 1
-      GoRuntimeType: 541760
-      GoKind: 3
+      ByteSize: 8
     - __kind: BaseType
       ID: 25
       Name: complex128
@@ -1472,7 +1116,7 @@ Types:
       GoRuntimeType: 543296
       GoKind: 15
     - __kind: GoInterfaceType
-      ID: 65
+      ID: 67
       Name: context.Context
       ByteSize: 16
       GoRuntimeType: 1.215776e+06
@@ -1500,7 +1144,7 @@ Types:
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 61
+      ID: 63
       Name: crypto/tls.ConnectionState
       ByteSize: 192
       GoRuntimeType: 2.16096e+06
@@ -1529,39 +1173,39 @@ Types:
           Type: 11 GoStringHeaderType string
         - Name: PeerCertificates
           Offset: 48
-          Type: 115 GoSliceHeaderType []*crypto/x509.Certificate
+          Type: 101 GoSliceHeaderType []*crypto/x509.Certificate
         - Name: VerifiedChains
           Offset: 72
-          Type: 118 GoSliceHeaderType [][]*crypto/x509.Certificate
+          Type: 104 GoSliceHeaderType [][]*crypto/x509.Certificate
         - Name: SignedCertificateTimestamps
           Offset: 96
-          Type: 120 GoSliceHeaderType [][]uint8
+          Type: 106 GoSliceHeaderType [][]uint8
         - Name: OCSPResponse
           Offset: 120
-          Type: 96 GoSliceHeaderType []uint8
+          Type: 98 GoSliceHeaderType []uint8
         - Name: TLSUnique
           Offset: 144
-          Type: 96 GoSliceHeaderType []uint8
+          Type: 98 GoSliceHeaderType []uint8
         - Name: ECHAccepted
           Offset: 168
           Type: 4 BaseType bool
         - Name: ekm
           Offset: 176
-          Type: 122 GoSubroutineType func(string, []uint8, int) ([]uint8, error)
+          Type: 108 GoSubroutineType func(string, []uint8, int) ([]uint8, error)
         - Name: testingOnlyDidHRR
           Offset: 184
           Type: 4 BaseType bool
         - Name: testingOnlyCurveID
           Offset: 186
-          Type: 123 BaseType crypto/tls.CurveID
+          Type: 109 BaseType crypto/tls.CurveID
     - __kind: BaseType
-      ID: 123
+      ID: 109
       Name: crypto/tls.CurveID
       ByteSize: 2
       GoRuntimeType: 778592
       GoKind: 9
     - __kind: StructureType
-      ID: 157
+      ID: 110
       Name: crypto/x509.Certificate
       ByteSize: 1352
       GoRuntimeType: 2.300992e+06
@@ -1569,67 +1213,67 @@ Types:
       RawFields:
         - Name: Raw
           Offset: 0
-          Type: 96 GoSliceHeaderType []uint8
+          Type: 98 GoSliceHeaderType []uint8
         - Name: RawTBSCertificate
           Offset: 24
-          Type: 96 GoSliceHeaderType []uint8
+          Type: 98 GoSliceHeaderType []uint8
         - Name: RawSubjectPublicKeyInfo
           Offset: 48
-          Type: 96 GoSliceHeaderType []uint8
+          Type: 98 GoSliceHeaderType []uint8
         - Name: RawSubject
           Offset: 72
-          Type: 96 GoSliceHeaderType []uint8
+          Type: 98 GoSliceHeaderType []uint8
         - Name: RawIssuer
           Offset: 96
-          Type: 96 GoSliceHeaderType []uint8
+          Type: 98 GoSliceHeaderType []uint8
         - Name: Signature
           Offset: 120
-          Type: 96 GoSliceHeaderType []uint8
+          Type: 98 GoSliceHeaderType []uint8
         - Name: SignatureAlgorithm
           Offset: 144
-          Type: 177 BaseType crypto/x509.SignatureAlgorithm
+          Type: 117 BaseType crypto/x509.SignatureAlgorithm
         - Name: PublicKeyAlgorithm
           Offset: 152
-          Type: 178 BaseType crypto/x509.PublicKeyAlgorithm
+          Type: 118 BaseType crypto/x509.PublicKeyAlgorithm
         - Name: PublicKey
           Offset: 160
-          Type: 129 GoEmptyInterfaceType interface {}
+          Type: 119 GoEmptyInterfaceType interface {}
         - Name: Version
           Offset: 176
           Type: 9 BaseType int
         - Name: SerialNumber
           Offset: 184
-          Type: 179 PointerType *math/big.Int
+          Type: 120 PointerType *math/big.Int
         - Name: Issuer
           Offset: 192
-          Type: 181 StructureType crypto/x509/pkix.Name
+          Type: 122 StructureType crypto/x509/pkix.Name
         - Name: Subject
           Offset: 440
-          Type: 181 StructureType crypto/x509/pkix.Name
+          Type: 122 StructureType crypto/x509/pkix.Name
         - Name: NotBefore
           Offset: 688
-          Type: 185 StructureType time.Time
+          Type: 126 StructureType time.Time
         - Name: NotAfter
           Offset: 712
-          Type: 185 StructureType time.Time
+          Type: 126 StructureType time.Time
         - Name: KeyUsage
           Offset: 736
-          Type: 188 BaseType crypto/x509.KeyUsage
+          Type: 129 BaseType crypto/x509.KeyUsage
         - Name: Extensions
           Offset: 744
-          Type: 189 GoSliceHeaderType []crypto/x509/pkix.Extension
+          Type: 130 GoSliceHeaderType []crypto/x509/pkix.Extension
         - Name: ExtraExtensions
           Offset: 768
-          Type: 189 GoSliceHeaderType []crypto/x509/pkix.Extension
+          Type: 130 GoSliceHeaderType []crypto/x509/pkix.Extension
         - Name: UnhandledCriticalExtensions
           Offset: 792
-          Type: 192 GoSliceHeaderType []encoding/asn1.ObjectIdentifier
+          Type: 133 GoSliceHeaderType []encoding/asn1.ObjectIdentifier
         - Name: ExtKeyUsage
           Offset: 816
-          Type: 195 GoSliceHeaderType []crypto/x509.ExtKeyUsage
+          Type: 136 GoSliceHeaderType []crypto/x509.ExtKeyUsage
         - Name: UnknownExtKeyUsage
           Offset: 840
-          Type: 192 GoSliceHeaderType []encoding/asn1.ObjectIdentifier
+          Type: 133 GoSliceHeaderType []encoding/asn1.ObjectIdentifier
         - Name: BasicConstraintsValid
           Offset: 864
           Type: 4 BaseType bool
@@ -1644,78 +1288,78 @@ Types:
           Type: 4 BaseType bool
         - Name: SubjectKeyId
           Offset: 888
-          Type: 96 GoSliceHeaderType []uint8
+          Type: 98 GoSliceHeaderType []uint8
         - Name: AuthorityKeyId
           Offset: 912
-          Type: 96 GoSliceHeaderType []uint8
+          Type: 98 GoSliceHeaderType []uint8
         - Name: OCSPServer
           Offset: 936
-          Type: 56 GoSliceHeaderType []string
+          Type: 58 GoSliceHeaderType []string
         - Name: IssuingCertificateURL
           Offset: 960
-          Type: 56 GoSliceHeaderType []string
+          Type: 58 GoSliceHeaderType []string
         - Name: DNSNames
           Offset: 984
-          Type: 56 GoSliceHeaderType []string
+          Type: 58 GoSliceHeaderType []string
         - Name: EmailAddresses
           Offset: 1008
-          Type: 56 GoSliceHeaderType []string
+          Type: 58 GoSliceHeaderType []string
         - Name: IPAddresses
           Offset: 1032
-          Type: 198 GoSliceHeaderType []net.IP
+          Type: 139 GoSliceHeaderType []net.IP
         - Name: URIs
           Offset: 1056
-          Type: 201 GoSliceHeaderType []*net/url.URL
+          Type: 142 GoSliceHeaderType []*net/url.URL
         - Name: PermittedDNSDomainsCritical
           Offset: 1080
           Type: 4 BaseType bool
         - Name: PermittedDNSDomains
           Offset: 1088
-          Type: 56 GoSliceHeaderType []string
+          Type: 58 GoSliceHeaderType []string
         - Name: ExcludedDNSDomains
           Offset: 1112
-          Type: 56 GoSliceHeaderType []string
+          Type: 58 GoSliceHeaderType []string
         - Name: PermittedIPRanges
           Offset: 1136
-          Type: 203 GoSliceHeaderType []*net.IPNet
+          Type: 144 GoSliceHeaderType []*net.IPNet
         - Name: ExcludedIPRanges
           Offset: 1160
-          Type: 203 GoSliceHeaderType []*net.IPNet
+          Type: 144 GoSliceHeaderType []*net.IPNet
         - Name: PermittedEmailAddresses
           Offset: 1184
-          Type: 56 GoSliceHeaderType []string
+          Type: 58 GoSliceHeaderType []string
         - Name: ExcludedEmailAddresses
           Offset: 1208
-          Type: 56 GoSliceHeaderType []string
+          Type: 58 GoSliceHeaderType []string
         - Name: PermittedURIDomains
           Offset: 1232
-          Type: 56 GoSliceHeaderType []string
+          Type: 58 GoSliceHeaderType []string
         - Name: ExcludedURIDomains
           Offset: 1256
-          Type: 56 GoSliceHeaderType []string
+          Type: 58 GoSliceHeaderType []string
         - Name: CRLDistributionPoints
           Offset: 1280
-          Type: 56 GoSliceHeaderType []string
+          Type: 58 GoSliceHeaderType []string
         - Name: PolicyIdentifiers
           Offset: 1304
-          Type: 192 GoSliceHeaderType []encoding/asn1.ObjectIdentifier
+          Type: 133 GoSliceHeaderType []encoding/asn1.ObjectIdentifier
         - Name: Policies
           Offset: 1328
-          Type: 206 GoSliceHeaderType []crypto/x509.OID
+          Type: 147 GoSliceHeaderType []crypto/x509.OID
     - __kind: BaseType
-      ID: 197
+      ID: 138
       Name: crypto/x509.ExtKeyUsage
       ByteSize: 8
       GoRuntimeType: 546624
       GoKind: 2
     - __kind: BaseType
-      ID: 188
+      ID: 129
       Name: crypto/x509.KeyUsage
       ByteSize: 8
       GoRuntimeType: 546560
       GoKind: 2
     - __kind: StructureType
-      ID: 208
+      ID: 149
       Name: crypto/x509.OID
       ByteSize: 24
       GoRuntimeType: 1.762592e+06
@@ -1723,21 +1367,21 @@ Types:
       RawFields:
         - Name: der
           Offset: 0
-          Type: 96 GoSliceHeaderType []uint8
+          Type: 98 GoSliceHeaderType []uint8
     - __kind: BaseType
-      ID: 178
+      ID: 118
       Name: crypto/x509.PublicKeyAlgorithm
       ByteSize: 8
       GoRuntimeType: 780896
       GoKind: 2
     - __kind: BaseType
-      ID: 177
+      ID: 117
       Name: crypto/x509.SignatureAlgorithm
       ByteSize: 8
       GoRuntimeType: 1.09744e+06
       GoKind: 2
     - __kind: StructureType
-      ID: 184
+      ID: 125
       Name: crypto/x509/pkix.AttributeTypeAndValue
       ByteSize: 40
       GoRuntimeType: 1.349408e+06
@@ -1745,12 +1389,12 @@ Types:
       RawFields:
         - Name: Type
           Offset: 0
-          Type: 194 GoSliceHeaderType encoding/asn1.ObjectIdentifier
+          Type: 135 GoSliceHeaderType encoding/asn1.ObjectIdentifier
         - Name: Value
           Offset: 24
-          Type: 129 GoEmptyInterfaceType interface {}
+          Type: 119 GoEmptyInterfaceType interface {}
     - __kind: StructureType
-      ID: 191
+      ID: 132
       Name: crypto/x509/pkix.Extension
       ByteSize: 56
       GoRuntimeType: 1.494976e+06
@@ -1758,15 +1402,15 @@ Types:
       RawFields:
         - Name: Id
           Offset: 0
-          Type: 194 GoSliceHeaderType encoding/asn1.ObjectIdentifier
+          Type: 135 GoSliceHeaderType encoding/asn1.ObjectIdentifier
         - Name: Critical
           Offset: 24
           Type: 4 BaseType bool
         - Name: Value
           Offset: 32
-          Type: 96 GoSliceHeaderType []uint8
+          Type: 98 GoSliceHeaderType []uint8
     - __kind: StructureType
-      ID: 181
+      ID: 122
       Name: crypto/x509/pkix.Name
       ByteSize: 248
       GoRuntimeType: 2.105696e+06
@@ -1774,25 +1418,25 @@ Types:
       RawFields:
         - Name: Country
           Offset: 0
-          Type: 56 GoSliceHeaderType []string
+          Type: 58 GoSliceHeaderType []string
         - Name: Organization
           Offset: 24
-          Type: 56 GoSliceHeaderType []string
+          Type: 58 GoSliceHeaderType []string
         - Name: OrganizationalUnit
           Offset: 48
-          Type: 56 GoSliceHeaderType []string
+          Type: 58 GoSliceHeaderType []string
         - Name: Locality
           Offset: 72
-          Type: 56 GoSliceHeaderType []string
+          Type: 58 GoSliceHeaderType []string
         - Name: Province
           Offset: 96
-          Type: 56 GoSliceHeaderType []string
+          Type: 58 GoSliceHeaderType []string
         - Name: StreetAddress
           Offset: 120
-          Type: 56 GoSliceHeaderType []string
+          Type: 58 GoSliceHeaderType []string
         - Name: PostalCode
           Offset: 144
-          Type: 56 GoSliceHeaderType []string
+          Type: 58 GoSliceHeaderType []string
         - Name: SerialNumber
           Offset: 168
           Type: 11 GoStringHeaderType string
@@ -1801,12 +1445,12 @@ Types:
           Type: 11 GoStringHeaderType string
         - Name: Names
           Offset: 200
-          Type: 182 GoSliceHeaderType []crypto/x509/pkix.AttributeTypeAndValue
+          Type: 123 GoSliceHeaderType []crypto/x509/pkix.AttributeTypeAndValue
         - Name: ExtraNames
           Offset: 224
-          Type: 182 GoSliceHeaderType []crypto/x509/pkix.AttributeTypeAndValue
+          Type: 123 GoSliceHeaderType []crypto/x509/pkix.AttributeTypeAndValue
     - __kind: GoSliceHeaderType
-      ID: 194
+      ID: 135
       Name: encoding/asn1.ObjectIdentifier
       ByteSize: 24
       GoRuntimeType: 1.0376e+06
@@ -1821,9 +1465,9 @@ Types:
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 236 GoSliceDataType encoding/asn1.ObjectIdentifier.array
+      Data: 182 GoSliceDataType encoding/asn1.ObjectIdentifier.array
     - __kind: GoSliceDataType
-      ID: 236
+      ID: 182
       Name: encoding/asn1.ObjectIdentifier.array
       ByteSize: 2048
       Element: 9 BaseType int
@@ -1853,362 +1497,23 @@ Types:
       GoRuntimeType: 543488
       GoKind: 14
     - __kind: GoSubroutineType
-      ID: 95
-      Name: func()
-      ByteSize: 8
-      GoRuntimeType: 455520
-      GoKind: 19
-    - __kind: GoSubroutineType
-      ID: 55
+      ID: 57
       Name: func() (io.ReadCloser, error)
       ByteSize: 8
       GoRuntimeType: 645600
       GoKind: 19
     - __kind: GoSubroutineType
-      ID: 122
+      ID: 108
       Name: func(string, []uint8, int) ([]uint8, error)
       ByteSize: 8
       GoRuntimeType: 983200
       GoKind: 19
-    - __kind: StructureType
+    - __kind: UnresolvedPointeeType
       ID: 40
       Name: github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span
-      ByteSize: 288
-      GoRuntimeType: 2.252e+06
-      GoKind: 25
-      RawFields:
-        - Name: mu
-          Offset: 0
-          Type: 73 StructureType sync.RWMutex
-        - Name: name
-          Offset: 24
-          Type: 11 GoStringHeaderType string
-        - Name: service
-          Offset: 40
-          Type: 11 GoStringHeaderType string
-        - Name: resource
-          Offset: 56
-          Type: 11 GoStringHeaderType string
-        - Name: spanType
-          Offset: 72
-          Type: 11 GoStringHeaderType string
-        - Name: start
-          Offset: 88
-          Type: 14 BaseType int64
-        - Name: duration
-          Offset: 96
-          Type: 14 BaseType int64
-        - Name: meta
-          Offset: 104
-          Type: 68 GoMapType map[string]string
-        - Name: metaStruct
-          Offset: 112
-          Type: 77 GoMapType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.metaStructMap
-        - Name: metrics
-          Offset: 120
-          Type: 82 GoMapType map[string]float64
-        - Name: spanID
-          Offset: 128
-          Type: 10 BaseType uint64
-        - Name: traceID
-          Offset: 136
-          Type: 10 BaseType uint64
-        - Name: parentID
-          Offset: 144
-          Type: 10 BaseType uint64
-        - Name: error
-          Offset: 152
-          Type: 13 BaseType int32
-        - Name: spanLinks
-          Offset: 160
-          Type: 87 GoSliceHeaderType []github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink
-        - Name: spanEvents
-          Offset: 184
-          Type: 90 GoSliceHeaderType []github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent
-        - Name: goExecTraced
-          Offset: 208
-          Type: 4 BaseType bool
-        - Name: noDebugStack
-          Offset: 209
-          Type: 4 BaseType bool
-        - Name: finished
-          Offset: 210
-          Type: 4 BaseType bool
-        - Name: context
-          Offset: 216
-          Type: 93 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanContext
-        - Name: integration
-          Offset: 224
-          Type: 11 GoStringHeaderType string
-        - Name: supportsEvents
-          Offset: 240
-          Type: 4 BaseType bool
-        - Name: pprofCtxActive
-          Offset: 248
-          Type: 65 GoInterfaceType context.Context
-        - Name: pprofCtxRestore
-          Offset: 264
-          Type: 65 GoInterfaceType context.Context
-        - Name: taskEnd
-          Offset: 280
-          Type: 95 GoSubroutineType func()
-    - __kind: StructureType
-      ID: 94
-      Name: github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanContext
-      ByteSize: 168
-      GoRuntimeType: 2.125376e+06
-      GoKind: 25
-      RawFields:
-        - Name: updated
-          Offset: 0
-          Type: 4 BaseType bool
-        - Name: trace
-          Offset: 8
-          Type: 137 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.trace
-        - Name: span
-          Offset: 16
-          Type: 39 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span
-        - Name: errors
-          Offset: 24
-          Type: 75 StructureType sync/atomic.Int32
-        - Name: reparentID
-          Offset: 32
-          Type: 11 GoStringHeaderType string
-        - Name: isRemote
-          Offset: 48
-          Type: 4 BaseType bool
-        - Name: traceID
-          Offset: 49
-          Type: 139 ArrayType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.traceID
-        - Name: spanID
-          Offset: 72
-          Type: 10 BaseType uint64
-        - Name: mu
-          Offset: 80
-          Type: 73 StructureType sync.RWMutex
-        - Name: baggage
-          Offset: 104
-          Type: 68 GoMapType map[string]string
-        - Name: hasBaggage
-          Offset: 112
-          Type: 2 BaseType uint32
-        - Name: origin
-          Offset: 120
-          Type: 11 GoStringHeaderType string
-        - Name: spanLinks
-          Offset: 136
-          Type: 87 GoSliceHeaderType []github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink
-        - Name: baggageOnly
-          Offset: 160
-          Type: 4 BaseType bool
-    - __kind: StructureType
-      ID: 89
-      Name: github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink
-      ByteSize: 56
-      GoRuntimeType: 1.822592e+06
-      GoKind: 25
-      RawFields:
-        - Name: TraceID
-          Offset: 0
-          Type: 10 BaseType uint64
-        - Name: TraceIDHigh
-          Offset: 8
-          Type: 10 BaseType uint64
-        - Name: SpanID
-          Offset: 16
-          Type: 10 BaseType uint64
-        - Name: Attributes
-          Offset: 24
-          Type: 68 GoMapType map[string]string
-        - Name: Tracestate
-          Offset: 32
-          Type: 11 GoStringHeaderType string
-        - Name: Flags
-          Offset: 48
-          Type: 2 BaseType uint32
-    - __kind: GoMapType
-      ID: 77
-      Name: github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.metaStructMap
       ByteSize: 8
-      GoRuntimeType: 1.00752e+06
-      GoKind: 21
-      HeaderType: 79 GoHMapHeaderType hash<string,interface {}>
-    - __kind: BaseType
-      ID: 163
-      Name: github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.samplingDecision
-      ByteSize: 4
-      GoRuntimeType: 542336
-      GoKind: 10
-    - __kind: StructureType
-      ID: 92
-      Name: github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent
-      ByteSize: 40
-      GoRuntimeType: 1.664384e+06
-      GoKind: 25
-      RawFields:
-        - Name: Name
-          Offset: 0
-          Type: 11 GoStringHeaderType string
-        - Name: TimeUnixNano
-          Offset: 16
-          Type: 10 BaseType uint64
-        - Name: Attributes
-          Offset: 24
-          Type: 131 GoMapType map[string]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
-        - Name: RawAttributes
-          Offset: 32
-          Type: 136 GoMapType map[string]interface {}
-    - __kind: StructureType
-      ID: 211
-      Name: github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttribute
-      ByteSize: 24
-      GoRuntimeType: 1.13008e+06
-      GoKind: 25
-      RawFields:
-        - Name: Values
-          Offset: 0
-          Type: 227 GoSliceHeaderType []*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttributeValue
-    - __kind: StructureType
-      ID: 251
-      Name: github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttributeValue
-      ByteSize: 48
-      GoRuntimeType: 1.74848e+06
-      GoKind: 25
-      RawFields:
-        - Name: Type
-          Offset: 0
-          Type: 260 BaseType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttributeValueType
-        - Name: StringValue
-          Offset: 8
-          Type: 11 GoStringHeaderType string
-        - Name: BoolValue
-          Offset: 24
-          Type: 4 BaseType bool
-        - Name: IntValue
-          Offset: 32
-          Type: 14 BaseType int64
-        - Name: DoubleValue
-          Offset: 40
-          Type: 17 BaseType float64
-    - __kind: BaseType
-      ID: 260
-      Name: github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttributeValueType
-      ByteSize: 4
-      GoRuntimeType: 965344
-      GoKind: 5
-    - __kind: StructureType
-      ID: 160
-      Name: github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
-      ByteSize: 56
-      GoRuntimeType: 1.822848e+06
-      GoKind: 25
-      RawFields:
-        - Name: Type
-          Offset: 0
-          Type: 209 BaseType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttributeType
-        - Name: StringValue
-          Offset: 8
-          Type: 11 GoStringHeaderType string
-        - Name: BoolValue
-          Offset: 24
-          Type: 4 BaseType bool
-        - Name: IntValue
-          Offset: 32
-          Type: 14 BaseType int64
-        - Name: DoubleValue
-          Offset: 40
-          Type: 17 BaseType float64
-        - Name: ArrayValue
-          Offset: 48
-          Type: 210 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttribute
-    - __kind: BaseType
-      ID: 209
-      Name: github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttributeType
-      ByteSize: 4
-      GoRuntimeType: 965248
-      GoKind: 5
-    - __kind: StructureType
-      ID: 138
-      Name: github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.trace
-      ByteSize: 104
-      GoRuntimeType: 2.017536e+06
-      GoKind: 25
-      RawFields:
-        - Name: mu
-          Offset: 0
-          Type: 73 StructureType sync.RWMutex
-        - Name: spans
-          Offset: 24
-          Type: 161 GoSliceHeaderType []*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span
-        - Name: tags
-          Offset: 48
-          Type: 68 GoMapType map[string]string
-        - Name: propagatingTags
-          Offset: 56
-          Type: 68 GoMapType map[string]string
-        - Name: finished
-          Offset: 64
-          Type: 9 BaseType int
-        - Name: full
-          Offset: 72
-          Type: 4 BaseType bool
-        - Name: priority
-          Offset: 80
-          Type: 26 PointerType *float64
-        - Name: locked
-          Offset: 88
-          Type: 4 BaseType bool
-        - Name: samplingDecision
-          Offset: 92
-          Type: 163 BaseType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.samplingDecision
-        - Name: root
-          Offset: 96
-          Type: 39 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span
-    - __kind: ArrayType
-      ID: 139
-      Name: github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.traceID
-      ByteSize: 16
-      GoRuntimeType: 847712
-      GoKind: 17
-      Count: 16
-      HasCount: true
-      Element: 3 BaseType uint8
     - __kind: GoHMapHeaderType
-      ID: 133
-      Name: hash<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
-      ByteSize: 48
-      RawFields:
-        - Name: count
-          Offset: 0
-          Type: 9 BaseType int
-        - Name: flags
-          Offset: 8
-          Type: 3 BaseType uint8
-        - Name: B
-          Offset: 9
-          Type: 3 BaseType uint8
-        - Name: noverflow
-          Offset: 10
-          Type: 7 BaseType uint16
-        - Name: hash0
-          Offset: 12
-          Type: 2 BaseType uint32
-        - Name: buckets
-          Offset: 16
-          Type: 134 PointerType *bucket<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
-        - Name: oldbuckets
-          Offset: 24
-          Type: 134 PointerType *bucket<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
-        - Name: nevacuate
-          Offset: 32
-          Type: 1 BaseType uintptr
-        - Name: extra
-          Offset: 40
-          Type: 52 PointerType *runtime.mapextra
-      BucketType: 135 GoHMapBucketType bucket<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
-      BucketsType: 175 GoSliceDataType []bucket<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>.array
-    - __kind: GoHMapHeaderType
-      ID: 112
+      ID: 86
       Name: hash<string,[]*mime/multipart.FileHeader>
       ByteSize: 48
       RawFields:
@@ -2229,20 +1534,20 @@ Types:
           Type: 2 BaseType uint32
         - Name: buckets
           Offset: 16
-          Type: 113 PointerType *bucket<string,[]*mime/multipart.FileHeader>
+          Type: 87 PointerType *bucket<string,[]*mime/multipart.FileHeader>
         - Name: oldbuckets
           Offset: 24
-          Type: 113 PointerType *bucket<string,[]*mime/multipart.FileHeader>
+          Type: 87 PointerType *bucket<string,[]*mime/multipart.FileHeader>
         - Name: nevacuate
           Offset: 32
           Type: 1 BaseType uintptr
         - Name: extra
           Offset: 40
-          Type: 52 PointerType *runtime.mapextra
-      BucketType: 114 GoHMapBucketType bucket<string,[]*mime/multipart.FileHeader>
-      BucketsType: 166 GoSliceDataType []bucket<string,[]*mime/multipart.FileHeader>.array
+          Type: 54 PointerType *runtime.mapextra
+      BucketType: 88 GoHMapBucketType bucket<string,[]*mime/multipart.FileHeader>
+      BucketsType: 93 GoSliceDataType []bucket<string,[]*mime/multipart.FileHeader>.array
     - __kind: GoHMapHeaderType
-      ID: 49
+      ID: 51
       Name: hash<string,[]string>
       ByteSize: 48
       RawFields:
@@ -2263,88 +1568,20 @@ Types:
           Type: 2 BaseType uint32
         - Name: buckets
           Offset: 16
-          Type: 50 PointerType *bucket<string,[]string>
+          Type: 52 PointerType *bucket<string,[]string>
         - Name: oldbuckets
           Offset: 24
-          Type: 50 PointerType *bucket<string,[]string>
+          Type: 52 PointerType *bucket<string,[]string>
         - Name: nevacuate
           Offset: 32
           Type: 1 BaseType uintptr
         - Name: extra
           Offset: 40
-          Type: 52 PointerType *runtime.mapextra
-      BucketType: 51 GoHMapBucketType bucket<string,[]string>
-      BucketsType: 140 GoSliceDataType []bucket<string,[]string>.array
+          Type: 54 PointerType *runtime.mapextra
+      BucketType: 53 GoHMapBucketType bucket<string,[]string>
+      BucketsType: 80 GoSliceDataType []bucket<string,[]string>.array
     - __kind: GoHMapHeaderType
-      ID: 84
-      Name: hash<string,float64>
-      ByteSize: 48
-      RawFields:
-        - Name: count
-          Offset: 0
-          Type: 9 BaseType int
-        - Name: flags
-          Offset: 8
-          Type: 3 BaseType uint8
-        - Name: B
-          Offset: 9
-          Type: 3 BaseType uint8
-        - Name: noverflow
-          Offset: 10
-          Type: 7 BaseType uint16
-        - Name: hash0
-          Offset: 12
-          Type: 2 BaseType uint32
-        - Name: buckets
-          Offset: 16
-          Type: 85 PointerType *bucket<string,float64>
-        - Name: oldbuckets
-          Offset: 24
-          Type: 85 PointerType *bucket<string,float64>
-        - Name: nevacuate
-          Offset: 32
-          Type: 1 BaseType uintptr
-        - Name: extra
-          Offset: 40
-          Type: 52 PointerType *runtime.mapextra
-      BucketType: 86 GoHMapBucketType bucket<string,float64>
-      BucketsType: 145 GoSliceDataType []bucket<string,float64>.array
-    - __kind: GoHMapHeaderType
-      ID: 79
-      Name: hash<string,interface {}>
-      ByteSize: 48
-      RawFields:
-        - Name: count
-          Offset: 0
-          Type: 9 BaseType int
-        - Name: flags
-          Offset: 8
-          Type: 3 BaseType uint8
-        - Name: B
-          Offset: 9
-          Type: 3 BaseType uint8
-        - Name: noverflow
-          Offset: 10
-          Type: 7 BaseType uint16
-        - Name: hash0
-          Offset: 12
-          Type: 2 BaseType uint32
-        - Name: buckets
-          Offset: 16
-          Type: 80 PointerType *bucket<string,interface {}>
-        - Name: oldbuckets
-          Offset: 24
-          Type: 80 PointerType *bucket<string,interface {}>
-        - Name: nevacuate
-          Offset: 32
-          Type: 1 BaseType uintptr
-        - Name: extra
-          Offset: 40
-          Type: 52 PointerType *runtime.mapextra
-      BucketType: 81 GoHMapBucketType bucket<string,interface {}>
-      BucketsType: 144 GoSliceDataType []bucket<string,interface {}>.array
-    - __kind: GoHMapHeaderType
-      ID: 70
+      ID: 72
       Name: hash<string,string>
       ByteSize: 48
       RawFields:
@@ -2365,18 +1602,18 @@ Types:
           Type: 2 BaseType uint32
         - Name: buckets
           Offset: 16
-          Type: 71 PointerType *bucket<string,string>
+          Type: 73 PointerType *bucket<string,string>
         - Name: oldbuckets
           Offset: 24
-          Type: 71 PointerType *bucket<string,string>
+          Type: 73 PointerType *bucket<string,string>
         - Name: nevacuate
           Offset: 32
           Type: 1 BaseType uintptr
         - Name: extra
           Offset: 40
-          Type: 52 PointerType *runtime.mapextra
-      BucketType: 72 GoHMapBucketType bucket<string,string>
-      BucketsType: 143 GoSliceDataType []bucket<string,string>.array
+          Type: 54 PointerType *runtime.mapextra
+      BucketType: 74 GoHMapBucketType bucket<string,string>
+      BucketsType: 195 GoSliceDataType []bucket<string,string>.array
     - __kind: BaseType
       ID: 9
       Name: int
@@ -2408,7 +1645,7 @@ Types:
       GoRuntimeType: 542592
       GoKind: 3
     - __kind: GoEmptyInterfaceType
-      ID: 129
+      ID: 119
       Name: interface {}
       ByteSize: 16
       GoRuntimeType: 798016
@@ -2421,7 +1658,7 @@ Types:
           Offset: 8
           Type: 19 VoidPointerType unsafe.Pointer
     - __kind: GoInterfaceType
-      ID: 54
+      ID: 56
       Name: io.ReadCloser
       ByteSize: 16
       GoRuntimeType: 1.093088e+06
@@ -2434,49 +1671,28 @@ Types:
           Offset: 8
           Type: 19 VoidPointerType unsafe.Pointer
     - __kind: GoMapType
-      ID: 131
-      Name: map[string]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
-      ByteSize: 8
-      GoRuntimeType: 905120
-      GoKind: 21
-      HeaderType: 133 GoHMapHeaderType hash<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
-    - __kind: GoMapType
-      ID: 110
+      ID: 84
       Name: map[string][]*mime/multipart.FileHeader
       ByteSize: 8
       GoRuntimeType: 904160
       GoKind: 21
-      HeaderType: 112 GoHMapHeaderType hash<string,[]*mime/multipart.FileHeader>
+      HeaderType: 86 GoHMapHeaderType hash<string,[]*mime/multipart.FileHeader>
     - __kind: GoMapType
-      ID: 109
+      ID: 83
       Name: map[string][]string
       ByteSize: 8
       GoRuntimeType: 899360
       GoKind: 21
-      HeaderType: 49 GoHMapHeaderType hash<string,[]string>
+      HeaderType: 51 GoHMapHeaderType hash<string,[]string>
     - __kind: GoMapType
-      ID: 82
-      Name: map[string]float64
-      ByteSize: 8
-      GoRuntimeType: 905024
-      GoKind: 21
-      HeaderType: 84 GoHMapHeaderType hash<string,float64>
-    - __kind: GoMapType
-      ID: 136
-      Name: map[string]interface {}
-      ByteSize: 8
-      GoRuntimeType: 896480
-      GoKind: 21
-      HeaderType: 79 GoHMapHeaderType hash<string,interface {}>
-    - __kind: GoMapType
-      ID: 68
+      ID: 70
       Name: map[string]string
       ByteSize: 8
       GoRuntimeType: 900992
       GoKind: 21
-      HeaderType: 70 GoHMapHeaderType hash<string,string>
+      HeaderType: 72 GoHMapHeaderType hash<string,string>
     - __kind: StructureType
-      ID: 180
+      ID: 121
       Name: math/big.Int
       ByteSize: 32
       GoRuntimeType: 1.340768e+06
@@ -2487,15 +1703,15 @@ Types:
           Type: 4 BaseType bool
         - Name: abs
           Offset: 8
-          Type: 217 GoSliceHeaderType math/big.nat
+          Type: 150 GoSliceHeaderType math/big.nat
     - __kind: BaseType
-      ID: 219
+      ID: 152
       Name: math/big.Word
       ByteSize: 8
       GoRuntimeType: 546880
       GoKind: 7
     - __kind: GoSliceHeaderType
-      ID: 217
+      ID: 150
       Name: math/big.nat
       ByteSize: 24
       GoRuntimeType: 2.280544e+06
@@ -2503,21 +1719,21 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 218 PointerType *math/big.Word
+          Type: 151 PointerType *math/big.Word
         - Name: len
           Offset: 8
           Type: 9 BaseType int
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 252 GoSliceDataType math/big.nat.array
+      Data: 153 GoSliceDataType math/big.nat.array
     - __kind: GoSliceDataType
-      ID: 252
+      ID: 153
       Name: math/big.nat.array
       ByteSize: 2048
-      Element: 219 BaseType math/big.Word
+      Element: 152 BaseType math/big.Word
     - __kind: StructureType
-      ID: 176
+      ID: 94
       Name: mime/multipart.FileHeader
       ByteSize: 88
       GoRuntimeType: 1.881696e+06
@@ -2528,13 +1744,13 @@ Types:
           Type: 11 GoStringHeaderType string
         - Name: Header
           Offset: 16
-          Type: 216 GoMapType net/textproto.MIMEHeader
+          Type: 97 GoMapType net/textproto.MIMEHeader
         - Name: Size
           Offset: 24
           Type: 14 BaseType int64
         - Name: content
           Offset: 32
-          Type: 96 GoSliceHeaderType []uint8
+          Type: 98 GoSliceHeaderType []uint8
         - Name: tmpfile
           Offset: 56
           Type: 11 GoStringHeaderType string
@@ -2545,7 +1761,7 @@ Types:
           Offset: 80
           Type: 4 BaseType bool
     - __kind: StructureType
-      ID: 59
+      ID: 61
       Name: mime/multipart.Form
       ByteSize: 16
       GoRuntimeType: 1.326048e+06
@@ -2553,12 +1769,12 @@ Types:
       RawFields:
         - Name: Value
           Offset: 0
-          Type: 109 GoMapType map[string][]string
+          Type: 83 GoMapType map[string][]string
         - Name: File
           Offset: 8
-          Type: 110 GoMapType map[string][]*mime/multipart.FileHeader
+          Type: 84 GoMapType map[string][]*mime/multipart.FileHeader
     - __kind: GoSliceHeaderType
-      ID: 200
+      ID: 141
       Name: net.IP
       ByteSize: 24
       GoRuntimeType: 2.00144e+06
@@ -2573,14 +1789,14 @@ Types:
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 242 GoSliceDataType net.IP.array
+      Data: 184 GoSliceDataType net.IP.array
     - __kind: GoSliceDataType
-      ID: 242
+      ID: 184
       Name: net.IP.array
       ByteSize: 2048
       Element: 3 BaseType uint8
     - __kind: GoSliceHeaderType
-      ID: 250
+      ID: 186
       Name: net.IPMask
       ByteSize: 24
       GoRuntimeType: 999456
@@ -2595,14 +1811,14 @@ Types:
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 261 GoSliceDataType net.IPMask.array
+      Data: 187 GoSliceDataType net.IPMask.array
     - __kind: GoSliceDataType
-      ID: 261
+      ID: 187
       Name: net.IPMask.array
       ByteSize: 2048
       Element: 3 BaseType uint8
     - __kind: StructureType
-      ID: 226
+      ID: 177
       Name: net.IPNet
       ByteSize: 48
       GoRuntimeType: 1.307168e+06
@@ -2610,17 +1826,17 @@ Types:
       RawFields:
         - Name: IP
           Offset: 0
-          Type: 200 GoSliceHeaderType net.IP
+          Type: 141 GoSliceHeaderType net.IP
         - Name: Mask
           Offset: 24
-          Type: 250 GoSliceHeaderType net.IPMask
+          Type: 186 GoSliceHeaderType net.IPMask
     - __kind: GoMapType
-      ID: 47
+      ID: 49
       Name: net/http.Header
       ByteSize: 8
       GoRuntimeType: 1.964288e+06
       GoKind: 21
-      HeaderType: 49 GoHMapHeaderType hash<string,[]string>
+      HeaderType: 51 GoHMapHeaderType hash<string,[]string>
     - __kind: StructureType
       ID: 38
       Name: net/http.Request
@@ -2633,7 +1849,7 @@ Types:
           Type: 11 GoStringHeaderType string
         - Name: URL
           Offset: 16
-          Type: 45 PointerType *net/url.URL
+          Type: 47 PointerType *net/url.URL
         - Name: Proto
           Offset: 24
           Type: 11 GoStringHeaderType string
@@ -2645,19 +1861,19 @@ Types:
           Type: 9 BaseType int
         - Name: Header
           Offset: 56
-          Type: 47 GoMapType net/http.Header
+          Type: 49 GoMapType net/http.Header
         - Name: Body
           Offset: 64
-          Type: 54 GoInterfaceType io.ReadCloser
+          Type: 56 GoInterfaceType io.ReadCloser
         - Name: GetBody
           Offset: 80
-          Type: 55 GoSubroutineType func() (io.ReadCloser, error)
+          Type: 57 GoSubroutineType func() (io.ReadCloser, error)
         - Name: ContentLength
           Offset: 88
           Type: 14 BaseType int64
         - Name: TransferEncoding
           Offset: 96
-          Type: 56 GoSliceHeaderType []string
+          Type: 58 GoSliceHeaderType []string
         - Name: Close
           Offset: 120
           Type: 4 BaseType bool
@@ -2666,16 +1882,16 @@ Types:
           Type: 11 GoStringHeaderType string
         - Name: Form
           Offset: 144
-          Type: 57 GoMapType net/url.Values
+          Type: 59 GoMapType net/url.Values
         - Name: PostForm
           Offset: 152
-          Type: 57 GoMapType net/url.Values
+          Type: 59 GoMapType net/url.Values
         - Name: MultipartForm
           Offset: 160
-          Type: 58 PointerType *mime/multipart.Form
+          Type: 60 PointerType *mime/multipart.Form
         - Name: Trailer
           Offset: 168
-          Type: 47 GoMapType net/http.Header
+          Type: 49 GoMapType net/http.Header
         - Name: RemoteAddr
           Offset: 176
           Type: 11 GoStringHeaderType string
@@ -2684,30 +1900,30 @@ Types:
           Type: 11 GoStringHeaderType string
         - Name: TLS
           Offset: 208
-          Type: 60 PointerType *crypto/tls.ConnectionState
+          Type: 62 PointerType *crypto/tls.ConnectionState
         - Name: Cancel
           Offset: 216
-          Type: 62 GoChannelType <-chan struct {}
+          Type: 64 GoChannelType <-chan struct {}
         - Name: Response
           Offset: 224
-          Type: 63 PointerType *net/http.Response
+          Type: 65 PointerType *net/http.Response
         - Name: Pattern
           Offset: 232
           Type: 11 GoStringHeaderType string
         - Name: ctx
           Offset: 248
-          Type: 65 GoInterfaceType context.Context
+          Type: 67 GoInterfaceType context.Context
         - Name: pat
           Offset: 264
-          Type: 66 PointerType *net/http.pattern
+          Type: 68 PointerType *net/http.pattern
         - Name: matches
           Offset: 272
-          Type: 56 GoSliceHeaderType []string
+          Type: 58 GoSliceHeaderType []string
         - Name: otherValues
           Offset: 296
-          Type: 68 GoMapType map[string]string
+          Type: 70 GoMapType map[string]string
     - __kind: StructureType
-      ID: 64
+      ID: 66
       Name: net/http.Response
       ByteSize: 144
       GoRuntimeType: 2.124032e+06
@@ -2730,16 +1946,16 @@ Types:
           Type: 9 BaseType int
         - Name: Header
           Offset: 56
-          Type: 47 GoMapType net/http.Header
+          Type: 49 GoMapType net/http.Header
         - Name: Body
           Offset: 64
-          Type: 54 GoInterfaceType io.ReadCloser
+          Type: 56 GoInterfaceType io.ReadCloser
         - Name: ContentLength
           Offset: 80
           Type: 14 BaseType int64
         - Name: TransferEncoding
           Offset: 88
-          Type: 56 GoSliceHeaderType []string
+          Type: 58 GoSliceHeaderType []string
         - Name: Close
           Offset: 112
           Type: 4 BaseType bool
@@ -2748,13 +1964,13 @@ Types:
           Type: 4 BaseType bool
         - Name: Trailer
           Offset: 120
-          Type: 47 GoMapType net/http.Header
+          Type: 49 GoMapType net/http.Header
         - Name: Request
           Offset: 128
           Type: 37 PointerType *net/http.Request
         - Name: TLS
           Offset: 136
-          Type: 60 PointerType *crypto/tls.ConnectionState
+          Type: 62 PointerType *crypto/tls.ConnectionState
     - __kind: GoInterfaceType
       ID: 36
       Name: net/http.ResponseWriter
@@ -2769,7 +1985,7 @@ Types:
           Offset: 8
           Type: 19 VoidPointerType unsafe.Pointer
     - __kind: StructureType
-      ID: 67
+      ID: 69
       Name: net/http.pattern
       ByteSize: 88
       GoRuntimeType: 1.745568e+06
@@ -2786,12 +2002,12 @@ Types:
           Type: 11 GoStringHeaderType string
         - Name: segments
           Offset: 48
-          Type: 124 GoSliceHeaderType []net/http.segment
+          Type: 189 GoSliceHeaderType []net/http.segment
         - Name: loc
           Offset: 72
           Type: 11 GoStringHeaderType string
     - __kind: StructureType
-      ID: 126
+      ID: 191
       Name: net/http.segment
       ByteSize: 24
       GoRuntimeType: 1.453312e+06
@@ -2807,14 +2023,14 @@ Types:
           Offset: 17
           Type: 4 BaseType bool
     - __kind: GoMapType
-      ID: 216
+      ID: 97
       Name: net/textproto.MIMEHeader
       ByteSize: 8
       GoRuntimeType: 1.63792e+06
       GoKind: 21
-      HeaderType: 49 GoHMapHeaderType hash<string,[]string>
+      HeaderType: 51 GoHMapHeaderType hash<string,[]string>
     - __kind: StructureType
-      ID: 46
+      ID: 48
       Name: net/url.URL
       ByteSize: 144
       GoRuntimeType: 2.041568e+06
@@ -2828,7 +2044,7 @@ Types:
           Type: 11 GoStringHeaderType string
         - Name: User
           Offset: 32
-          Type: 100 PointerType *net/url.Userinfo
+          Type: 75 PointerType *net/url.Userinfo
         - Name: Host
           Offset: 40
           Type: 11 GoStringHeaderType string
@@ -2854,7 +2070,7 @@ Types:
           Offset: 128
           Type: 11 GoStringHeaderType string
     - __kind: StructureType
-      ID: 101
+      ID: 76
       Name: net/url.Userinfo
       ByteSize: 40
       GoRuntimeType: 1.469632e+06
@@ -2870,38 +2086,16 @@ Types:
           Offset: 32
           Type: 4 BaseType bool
     - __kind: GoMapType
-      ID: 57
+      ID: 59
       Name: net/url.Values
       ByteSize: 8
       GoRuntimeType: 1.712416e+06
       GoKind: 21
-      HeaderType: 49 GoHMapHeaderType hash<string,[]string>
-    - __kind: StructureType
-      ID: 108
-      Name: runtime.bmap
-      ByteSize: 8
-      GoRuntimeType: 1.13712e+06
-      GoKind: 25
-      RawFields:
-        - Name: tophash
-          Offset: 0
-          Type: 102 ArrayType [8]uint8
-    - __kind: StructureType
-      ID: 53
+      HeaderType: 51 GoHMapHeaderType hash<string,[]string>
+    - __kind: UnresolvedPointeeType
+      ID: 55
       Name: runtime.mapextra
-      ByteSize: 24
-      GoRuntimeType: 1.4656e+06
-      GoKind: 25
-      RawFields:
-        - Name: overflow
-          Offset: 0
-          Type: 105 PointerType *[]*runtime.bmap
-        - Name: oldoverflow
-          Offset: 8
-          Type: 105 PointerType *[]*runtime.bmap
-        - Name: nextOverflow
-          Offset: 16
-          Type: 107 PointerType *runtime.bmap
+      ByteSize: 8
     - __kind: GoStringHeaderType
       ID: 11
       Name: string
@@ -2911,71 +2105,17 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 99 PointerType *string.str
+          Type: 46 PointerType *string.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 98 GoStringDataType string.str
+      Data: 45 GoStringDataType string.str
     - __kind: GoStringDataType
-      ID: 98
+      ID: 45
       Name: string.str
       ByteSize: 2048
     - __kind: StructureType
-      ID: 74
-      Name: sync.Mutex
-      ByteSize: 8
-      GoRuntimeType: 1.314208e+06
-      GoKind: 25
-      RawFields:
-        - Name: state
-          Offset: 0
-          Type: 13 BaseType int32
-        - Name: sema
-          Offset: 4
-          Type: 2 BaseType uint32
-    - __kind: StructureType
-      ID: 73
-      Name: sync.RWMutex
-      ByteSize: 24
-      GoRuntimeType: 1.751168e+06
-      GoKind: 25
-      RawFields:
-        - Name: w
-          Offset: 0
-          Type: 74 StructureType sync.Mutex
-        - Name: writerSem
-          Offset: 8
-          Type: 2 BaseType uint32
-        - Name: readerSem
-          Offset: 12
-          Type: 2 BaseType uint32
-        - Name: readerCount
-          Offset: 16
-          Type: 75 StructureType sync/atomic.Int32
-        - Name: readerWait
-          Offset: 20
-          Type: 75 StructureType sync/atomic.Int32
-    - __kind: StructureType
-      ID: 75
-      Name: sync/atomic.Int32
-      ByteSize: 4
-      GoRuntimeType: 1.315648e+06
-      GoKind: 25
-      RawFields:
-        - Name: _
-          Offset: 0
-          Type: 76 StructureType sync/atomic.noCopy
-        - Name: v
-          Offset: 0
-          Type: 13 BaseType int32
-    - __kind: StructureType
-      ID: 76
-      Name: sync/atomic.noCopy
-      GoRuntimeType: 966016
-      GoKind: 25
-      RawFields: []
-    - __kind: StructureType
-      ID: 187
+      ID: 128
       Name: time.Location
       ByteSize: 104
       GoRuntimeType: 1.877952e+06
@@ -2986,10 +2126,10 @@ Types:
           Type: 11 GoStringHeaderType string
         - Name: zone
           Offset: 16
-          Type: 220 GoSliceHeaderType []time.zone
+          Type: 157 GoSliceHeaderType []time.zone
         - Name: tx
           Offset: 40
-          Type: 223 GoSliceHeaderType []time.zoneTrans
+          Type: 160 GoSliceHeaderType []time.zoneTrans
         - Name: extend
           Offset: 64
           Type: 11 GoStringHeaderType string
@@ -3001,9 +2141,9 @@ Types:
           Type: 14 BaseType int64
         - Name: cacheZone
           Offset: 96
-          Type: 221 PointerType *time.zone
+          Type: 158 PointerType *time.zone
     - __kind: StructureType
-      ID: 185
+      ID: 126
       Name: time.Time
       ByteSize: 24
       GoRuntimeType: 2.281472e+06
@@ -3017,9 +2157,9 @@ Types:
           Type: 14 BaseType int64
         - Name: loc
           Offset: 16
-          Type: 186 PointerType *time.Location
+          Type: 127 PointerType *time.Location
     - __kind: StructureType
-      ID: 222
+      ID: 159
       Name: time.zone
       ByteSize: 32
       GoRuntimeType: 1.458304e+06
@@ -3035,7 +2175,7 @@ Types:
           Offset: 24
           Type: 4 BaseType bool
     - __kind: StructureType
-      ID: 225
+      ID: 162
       Name: time.zoneTrans
       ByteSize: 16
       GoRuntimeType: 1.664192e+06
@@ -3095,6 +2235,6 @@ Types:
       ByteSize: 8
       GoRuntimeType: 543616
       GoKind: 26
-MaxTypeID: 264
+MaxTypeID: 197
 Issues: []
 GoModuledataInfo: {FirstModuledataAddr: "0x137dc20", TypesOffset: 296}

--- a/pkg/dyninst/irgen/testdata/snapshot/rc_tester.arch=arm64,toolchain=go1.24.3.yaml
+++ b/pkg/dyninst/irgen/testdata/snapshot/rc_tester.arch=arm64,toolchain=go1.24.3.yaml
@@ -104,432 +104,437 @@ Subprograms:
           IsParameter: true
           IsReturn: false
 Types:
-    - __kind: GoInterfaceType
-      ID: 1
-      Name: net/http.ResponseWriter
-      ByteSize: 16
-      GoRuntimeType: 1.206176e+06
-      GoKind: 20
-      RawFields:
-        - Name: tab
-          Offset: 0
-          Type: 2 VoidPointerType unsafe.Pointer
-        - Name: data
-          Offset: 8
-          Type: 2 VoidPointerType unsafe.Pointer
-    - __kind: VoidPointerType
-      ID: 2
-      Name: unsafe.Pointer
-      ByteSize: 8
-      GoRuntimeType: 591264
-      GoKind: 26
     - __kind: PointerType
-      ID: 3
-      Name: '*net/http.Request'
+      ID: 57
+      Name: '**crypto/x509.Certificate'
       ByteSize: 8
-      GoRuntimeType: 2.359648e+06
       GoKind: 22
-      Pointee: 4 StructureType net/http.Request
-    - __kind: StructureType
-      ID: 4
-      Name: net/http.Request
-      ByteSize: 304
-      GoRuntimeType: 2.397408e+06
-      GoKind: 25
-      RawFields:
-        - Name: Method
-          Offset: 0
-          Type: 5 GoStringHeaderType string
-        - Name: URL
-          Offset: 16
-          Type: 9 PointerType *net/url.URL
-        - Name: Proto
-          Offset: 24
-          Type: 5 GoStringHeaderType string
-        - Name: ProtoMajor
-          Offset: 40
-          Type: 8 BaseType int
-        - Name: ProtoMinor
-          Offset: 48
-          Type: 8 BaseType int
-        - Name: Header
-          Offset: 56
-          Type: 14 GoMapType net/http.Header
-        - Name: Body
-          Offset: 64
-          Type: 30 GoInterfaceType io.ReadCloser
-        - Name: GetBody
-          Offset: 80
-          Type: 31 GoSubroutineType func() (io.ReadCloser, error)
-        - Name: ContentLength
-          Offset: 88
-          Type: 32 BaseType int64
-        - Name: TransferEncoding
-          Offset: 96
-          Type: 28 GoSliceHeaderType []string
-        - Name: Close
-          Offset: 120
-          Type: 13 BaseType bool
-        - Name: Host
-          Offset: 128
-          Type: 5 GoStringHeaderType string
-        - Name: Form
-          Offset: 144
-          Type: 33 GoMapType net/url.Values
-        - Name: PostForm
-          Offset: 152
-          Type: 33 GoMapType net/url.Values
-        - Name: MultipartForm
-          Offset: 160
-          Type: 34 PointerType *mime/multipart.Form
-        - Name: Trailer
-          Offset: 168
-          Type: 14 GoMapType net/http.Header
-        - Name: RemoteAddr
-          Offset: 176
-          Type: 5 GoStringHeaderType string
-        - Name: RequestURI
-          Offset: 192
-          Type: 5 GoStringHeaderType string
-        - Name: TLS
-          Offset: 208
-          Type: 54 PointerType *crypto/tls.ConnectionState
-        - Name: Cancel
-          Offset: 216
-          Type: 114 GoChannelType <-chan struct {}
-        - Name: Response
-          Offset: 224
-          Type: 115 PointerType *net/http.Response
-        - Name: Pattern
-          Offset: 232
-          Type: 5 GoStringHeaderType string
-        - Name: ctx
-          Offset: 248
-          Type: 117 GoInterfaceType context.Context
-        - Name: pat
-          Offset: 264
-          Type: 118 PointerType *net/http.pattern
-        - Name: matches
-          Offset: 272
-          Type: 28 GoSliceHeaderType []string
-        - Name: otherValues
-          Offset: 296
-          Type: 123 GoMapType map[string]string
-    - __kind: GoStringHeaderType
-      ID: 5
-      Name: string
-      ByteSize: 16
-      GoRuntimeType: 590176
-      GoKind: 24
-      RawFields:
-        - Name: str
-          Offset: 0
-          Type: 230 PointerType *string.str
-        - Name: len
-          Offset: 8
-          Type: 8 BaseType int
-      Data: 229 GoStringDataType string.str
+      Pointee: 58 PointerType *crypto/x509.Certificate
     - __kind: PointerType
-      ID: 6
-      Name: '*uint8'
+      ID: 200
+      Name: '**github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span'
       ByteSize: 8
-      GoRuntimeType: 401760
       GoKind: 22
-      Pointee: 7 BaseType uint8
-    - __kind: BaseType
-      ID: 7
-      Name: uint8
-      ByteSize: 1
-      GoRuntimeType: 590304
-      GoKind: 8
-    - __kind: BaseType
-      ID: 8
-      Name: int
-      ByteSize: 8
-      GoRuntimeType: 590752
-      GoKind: 2
+      Pointee: 134 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span
     - __kind: PointerType
-      ID: 9
-      Name: '*net/url.URL'
+      ID: 190
+      Name: '**github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttributeValue'
       ByteSize: 8
-      GoRuntimeType: 2.159744e+06
       GoKind: 22
-      Pointee: 10 StructureType net/url.URL
-    - __kind: StructureType
-      ID: 10
-      Name: net/url.URL
-      ByteSize: 144
-      GoRuntimeType: 2.172992e+06
-      GoKind: 25
-      RawFields:
-        - Name: Scheme
-          Offset: 0
-          Type: 5 GoStringHeaderType string
-        - Name: Opaque
-          Offset: 16
-          Type: 5 GoStringHeaderType string
-        - Name: User
-          Offset: 32
-          Type: 11 PointerType *net/url.Userinfo
-        - Name: Host
-          Offset: 40
-          Type: 5 GoStringHeaderType string
-        - Name: Path
-          Offset: 56
-          Type: 5 GoStringHeaderType string
-        - Name: RawPath
-          Offset: 72
-          Type: 5 GoStringHeaderType string
-        - Name: OmitHost
-          Offset: 88
-          Type: 13 BaseType bool
-        - Name: ForceQuery
-          Offset: 89
-          Type: 13 BaseType bool
-        - Name: RawQuery
-          Offset: 96
-          Type: 5 GoStringHeaderType string
-        - Name: Fragment
-          Offset: 112
-          Type: 5 GoStringHeaderType string
-        - Name: RawFragment
-          Offset: 128
-          Type: 5 GoStringHeaderType string
+      Pointee: 191 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttributeValue
     - __kind: PointerType
-      ID: 11
-      Name: '*net/url.Userinfo'
+      ID: 49
+      Name: '**mime/multipart.FileHeader'
       ByteSize: 8
-      GoRuntimeType: 1.221536e+06
       GoKind: 22
-      Pointee: 12 StructureType net/url.Userinfo
-    - __kind: StructureType
-      ID: 12
-      Name: net/url.Userinfo
-      ByteSize: 40
-      GoRuntimeType: 1.653024e+06
-      GoKind: 25
-      RawFields:
-        - Name: username
-          Offset: 0
-          Type: 5 GoStringHeaderType string
-        - Name: password
-          Offset: 16
-          Type: 5 GoStringHeaderType string
-        - Name: passwordSet
-          Offset: 32
-          Type: 13 BaseType bool
-    - __kind: BaseType
-      ID: 13
-      Name: bool
-      ByteSize: 1
-      GoRuntimeType: 591200
-      GoKind: 1
-    - __kind: GoMapType
-      ID: 14
-      Name: net/http.Header
-      ByteSize: 8
-      GoRuntimeType: 2.147456e+06
-      GoKind: 21
-      HeaderType: 16 GoSwissMapHeaderType map<string,[]string>
+      Pointee: 50 PointerType *mime/multipart.FileHeader
     - __kind: PointerType
-      ID: 15
-      Name: '*map<string,[]string>'
+      ID: 98
+      Name: '**net.IPNet'
       ByteSize: 8
-      Pointee: 16 GoSwissMapHeaderType map<string,[]string>
-    - __kind: GoSwissMapHeaderType
-      ID: 16
-      Name: map<string,[]string>
-      ByteSize: 48
-      GoKind: 25
-      RawFields:
-        - Name: used
-          Offset: 0
-          Type: 17 BaseType uint64
-        - Name: seed
-          Offset: 8
-          Type: 18 BaseType uintptr
-        - Name: dirPtr
-          Offset: 16
-          Type: 19 PointerType **table<string,[]string>
-        - Name: dirLen
-          Offset: 24
-          Type: 8 BaseType int
-        - Name: globalDepth
-          Offset: 32
-          Type: 7 BaseType uint8
-        - Name: globalShift
-          Offset: 33
-          Type: 7 BaseType uint8
-        - Name: writing
-          Offset: 34
-          Type: 7 BaseType uint8
-        - Name: clearSeq
-          Offset: 40
-          Type: 17 BaseType uint64
-      TablePtrSliceType: 231 GoSliceDataType []*table<string,[]string>.array
-      GroupType: 25 StructureType noalg.map.group[string][]string
-    - __kind: BaseType
-      ID: 17
-      Name: uint64
+      GoKind: 22
+      Pointee: 99 PointerType *net.IPNet
+    - __kind: PointerType
+      ID: 96
+      Name: '**net/url.URL'
       ByteSize: 8
-      GoRuntimeType: 590688
-      GoKind: 11
-    - __kind: BaseType
-      ID: 18
-      Name: uintptr
+      Pointee: 9 PointerType *net/url.URL
+    - __kind: PointerType
+      ID: 176
+      Name: '**table<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>'
       ByteSize: 8
-      GoRuntimeType: 590880
-      GoKind: 12
+      Pointee: 177 PointerType *table<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
+    - __kind: PointerType
+      ID: 40
+      Name: '**table<string,[]*mime/multipart.FileHeader>'
+      ByteSize: 8
+      Pointee: 41 PointerType *table<string,[]*mime/multipart.FileHeader>
     - __kind: PointerType
       ID: 19
       Name: '**table<string,[]string>'
       ByteSize: 8
       Pointee: 20 PointerType *table<string,[]string>
     - __kind: PointerType
-      ID: 20
-      Name: '*table<string,[]string>'
+      ID: 158
+      Name: '**table<string,float64>'
       ByteSize: 8
-      Pointee: 21 StructureType table<string,[]string>
-    - __kind: StructureType
-      ID: 21
-      Name: table<string,[]string>
-      ByteSize: 32
-      GoKind: 25
-      RawFields:
-        - Name: used
-          Offset: 0
-          Type: 22 BaseType uint16
-        - Name: capacity
-          Offset: 2
-          Type: 22 BaseType uint16
-        - Name: growthLeft
-          Offset: 4
-          Type: 22 BaseType uint16
-        - Name: localDepth
-          Offset: 6
-          Type: 7 BaseType uint8
-        - Name: index
-          Offset: 8
-          Type: 8 BaseType int
-        - Name: groups
-          Offset: 16
-          Type: 23 GoSwissMapGroupsType groupReference<string,[]string>
-    - __kind: BaseType
-      ID: 22
-      Name: uint16
-      ByteSize: 2
-      GoRuntimeType: 590432
-      GoKind: 9
-    - __kind: GoSwissMapGroupsType
-      ID: 23
-      Name: groupReference<string,[]string>
-      ByteSize: 16
-      GoKind: 25
-      RawFields:
-        - Name: data
-          Offset: 0
-          Type: 24 PointerType *noalg.map.group[string][]string
-        - Name: lengthMask
-          Offset: 8
-          Type: 17 BaseType uint64
-      GroupType: 25 StructureType noalg.map.group[string][]string
-      GroupSliceType: 232 GoSliceDataType []noalg.map.group[string][]string.array
+      Pointee: 159 PointerType *table<string,float64>
     - __kind: PointerType
-      ID: 24
-      Name: '*noalg.map.group[string][]string'
+      ID: 147
+      Name: '**table<string,interface {}>'
       ByteSize: 8
-      Pointee: 25 StructureType noalg.map.group[string][]string
-    - __kind: StructureType
-      ID: 25
-      Name: noalg.map.group[string][]string
-      ByteSize: 328
-      GoRuntimeType: 1.311456e+06
-      GoKind: 25
-      RawFields:
-        - Name: ctrl
-          Offset: 0
-          Type: 17 BaseType uint64
-        - Name: slots
-          Offset: 8
-          Type: 26 ArrayType noalg.[8]struct { key string; elem []string }
-    - __kind: ArrayType
-      ID: 26
-      Name: noalg.[8]struct { key string; elem []string }
-      ByteSize: 320
-      GoRuntimeType: 697120
-      GoKind: 17
-      Count: 8
-      HasCount: true
-      Element: 27 StructureType noalg.struct { key string; elem []string }
-    - __kind: StructureType
-      ID: 27
-      Name: noalg.struct { key string; elem []string }
-      ByteSize: 40
-      GoRuntimeType: 1.311328e+06
-      GoKind: 25
-      RawFields:
-        - Name: key
-          Offset: 0
-          Type: 5 GoStringHeaderType string
-        - Name: elem
-          Offset: 16
-          Type: 28 GoSliceHeaderType []string
-    - __kind: GoSliceHeaderType
-      ID: 28
-      Name: '[]string'
-      ByteSize: 24
-      GoRuntimeType: 498048
-      GoKind: 23
-      RawFields:
-        - Name: array
-          Offset: 0
-          Type: 29 PointerType *string
-        - Name: len
-          Offset: 8
-          Type: 8 BaseType int
-        - Name: cap
-          Offset: 16
-          Type: 8 BaseType int
-      Data: 233 GoSliceDataType []string.array
+      Pointee: 148 PointerType *table<string,interface {}>
     - __kind: PointerType
-      ID: 29
-      Name: '*string'
+      ID: 126
+      Name: '**table<string,string>'
       ByteSize: 8
-      GoRuntimeType: 401632
+      Pointee: 127 PointerType *table<string,string>
+    - __kind: PointerType
+      ID: 109
+      Name: '*[]*crypto/x509.Certificate'
+      ByteSize: 8
       GoKind: 22
-      Pointee: 5 GoStringHeaderType string
-    - __kind: GoInterfaceType
-      ID: 30
-      Name: io.ReadCloser
-      ByteSize: 16
-      GoRuntimeType: 1.129632e+06
-      GoKind: 20
-      RawFields:
-        - Name: tab
-          Offset: 0
-          Type: 2 VoidPointerType unsafe.Pointer
-        - Name: data
-          Offset: 8
-          Type: 2 VoidPointerType unsafe.Pointer
-    - __kind: GoSubroutineType
-      ID: 31
-      Name: func() (io.ReadCloser, error)
+      Pointee: 56 GoSliceHeaderType []*crypto/x509.Certificate
+    - __kind: PointerType
+      ID: 242
+      Name: '*[]*crypto/x509.Certificate.array'
       ByteSize: 8
-      GoRuntimeType: 701088
-      GoKind: 19
-    - __kind: BaseType
-      ID: 32
-      Name: int64
+      Pointee: 241 GoSliceDataType []*crypto/x509.Certificate.array
+    - __kind: PointerType
+      ID: 294
+      Name: '*[]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span.array'
       ByteSize: 8
-      GoRuntimeType: 590624
-      GoKind: 6
-    - __kind: GoMapType
-      ID: 33
-      Name: net/url.Values
+      Pointee: 293 GoSliceDataType []*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span.array
+    - __kind: PointerType
+      ID: 292
+      Name: '*[]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttributeValue.array'
       ByteSize: 8
-      GoRuntimeType: 1.920064e+06
-      GoKind: 21
-      HeaderType: 16 GoSwissMapHeaderType map<string,[]string>
+      Pointee: 291 GoSliceDataType []*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttributeValue.array
+    - __kind: PointerType
+      ID: 238
+      Name: '*[]*mime/multipart.FileHeader.array'
+      ByteSize: 8
+      Pointee: 237 GoSliceDataType []*mime/multipart.FileHeader.array
+    - __kind: PointerType
+      ID: 266
+      Name: '*[]*net.IPNet.array'
+      ByteSize: 8
+      Pointee: 265 GoSliceDataType []*net.IPNet.array
+    - __kind: PointerType
+      ID: 264
+      Name: '*[]*net/url.URL.array'
+      ByteSize: 8
+      Pointee: 263 GoSliceDataType []*net/url.URL.array
+    - __kind: PointerType
+      ID: 274
+      Name: '*[][]*crypto/x509.Certificate.array'
+      ByteSize: 8
+      Pointee: 273 GoSliceDataType [][]*crypto/x509.Certificate.array
+    - __kind: PointerType
+      ID: 276
+      Name: '*[][]uint8.array'
+      ByteSize: 8
+      Pointee: 275 GoSliceDataType [][]uint8.array
+    - __kind: PointerType
+      ID: 258
+      Name: '*[]crypto/x509.ExtKeyUsage.array'
+      ByteSize: 8
+      Pointee: 257 GoSliceDataType []crypto/x509.ExtKeyUsage.array
+    - __kind: PointerType
+      ID: 270
+      Name: '*[]crypto/x509.OID.array'
+      ByteSize: 8
+      Pointee: 269 GoSliceDataType []crypto/x509.OID.array
+    - __kind: PointerType
+      ID: 272
+      Name: '*[]crypto/x509.PolicyMapping.array'
+      ByteSize: 8
+      Pointee: 271 GoSliceDataType []crypto/x509.PolicyMapping.array
+    - __kind: PointerType
+      ID: 246
+      Name: '*[]crypto/x509/pkix.AttributeTypeAndValue.array'
+      ByteSize: 8
+      Pointee: 245 GoSliceDataType []crypto/x509/pkix.AttributeTypeAndValue.array
+    - __kind: PointerType
+      ID: 254
+      Name: '*[]crypto/x509/pkix.Extension.array'
+      ByteSize: 8
+      Pointee: 253 GoSliceDataType []crypto/x509/pkix.Extension.array
+    - __kind: PointerType
+      ID: 256
+      Name: '*[]encoding/asn1.ObjectIdentifier.array'
+      ByteSize: 8
+      Pointee: 255 GoSliceDataType []encoding/asn1.ObjectIdentifier.array
+    - __kind: PointerType
+      ID: 286
+      Name: '*[]github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink.array'
+      ByteSize: 8
+      Pointee: 285 GoSliceDataType []github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink.array
+    - __kind: PointerType
+      ID: 288
+      Name: '*[]github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent.array'
+      ByteSize: 8
+      Pointee: 287 GoSliceDataType []github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent.array
+    - __kind: PointerType
+      ID: 260
+      Name: '*[]net.IP.array'
+      ByteSize: 8
+      Pointee: 259 GoSliceDataType []net.IP.array
+    - __kind: PointerType
+      ID: 278
+      Name: '*[]net/http.segment.array'
+      ByteSize: 8
+      Pointee: 277 GoSliceDataType []net/http.segment.array
+    - __kind: PointerType
+      ID: 234
+      Name: '*[]string.array'
+      ByteSize: 8
+      Pointee: 233 GoSliceDataType []string.array
+    - __kind: PointerType
+      ID: 250
+      Name: '*[]time.zone.array'
+      ByteSize: 8
+      Pointee: 249 GoSliceDataType []time.zone.array
+    - __kind: PointerType
+      ID: 252
+      Name: '*[]time.zoneTrans.array'
+      ByteSize: 8
+      Pointee: 251 GoSliceDataType []time.zoneTrans.array
+    - __kind: PointerType
+      ID: 111
+      Name: '*[]uint8'
+      ByteSize: 8
+      GoRuntimeType: 483424
+      GoKind: 22
+      Pointee: 53 GoSliceHeaderType []uint8
+    - __kind: PointerType
+      ID: 240
+      Name: '*[]uint8.array'
+      ByteSize: 8
+      Pointee: 239 GoSliceDataType []uint8.array
+    - __kind: PointerType
+      ID: 211
+      Name: '*bool'
+      ByteSize: 8
+      GoRuntimeType: 402656
+      GoKind: 22
+      Pointee: 13 BaseType bool
+    - __kind: PointerType
+      ID: 205
+      Name: '*bytes.Buffer'
+      ByteSize: 8
+      GoRuntimeType: 2.316032e+06
+      GoKind: 22
+      Pointee: 206 StructureType bytes.Buffer
+    - __kind: PointerType
+      ID: 54
+      Name: '*crypto/tls.ConnectionState'
+      ByteSize: 8
+      GoRuntimeType: 918848
+      GoKind: 22
+      Pointee: 55 StructureType crypto/tls.ConnectionState
+    - __kind: PointerType
+      ID: 58
+      Name: '*crypto/x509.Certificate'
+      ByteSize: 8
+      GoRuntimeType: 2.081952e+06
+      GoKind: 22
+      Pointee: 59 StructureType crypto/x509.Certificate
+    - __kind: PointerType
+      ID: 90
+      Name: '*crypto/x509.ExtKeyUsage'
+      ByteSize: 8
+      GoRuntimeType: 426848
+      GoKind: 22
+      Pointee: 91 BaseType crypto/x509.ExtKeyUsage
+    - __kind: PointerType
+      ID: 103
+      Name: '*crypto/x509.OID'
+      ByteSize: 8
+      GoRuntimeType: 1.988896e+06
+      GoKind: 22
+      Pointee: 104 StructureType crypto/x509.OID
+    - __kind: PointerType
+      ID: 106
+      Name: '*crypto/x509.PolicyMapping'
+      ByteSize: 8
+      GoRuntimeType: 426912
+      GoKind: 22
+      Pointee: 107 StructureType crypto/x509.PolicyMapping
+    - __kind: PointerType
+      ID: 70
+      Name: '*crypto/x509/pkix.AttributeTypeAndValue'
+      ByteSize: 8
+      GoRuntimeType: 443616
+      GoKind: 22
+      Pointee: 71 StructureType crypto/x509/pkix.AttributeTypeAndValue
+    - __kind: PointerType
+      ID: 85
+      Name: '*crypto/x509/pkix.Extension'
+      ByteSize: 8
+      GoRuntimeType: 443808
+      GoKind: 22
+      Pointee: 86 StructureType crypto/x509/pkix.Extension
+    - __kind: PointerType
+      ID: 88
+      Name: '*encoding/asn1.ObjectIdentifier'
+      ByteSize: 8
+      GoRuntimeType: 1.074528e+06
+      GoKind: 22
+      Pointee: 72 GoSliceHeaderType encoding/asn1.ObjectIdentifier
+    - __kind: PointerType
+      ID: 248
+      Name: '*encoding/asn1.ObjectIdentifier.array'
+      ByteSize: 8
+      Pointee: 247 GoSliceDataType encoding/asn1.ObjectIdentifier.array
+    - __kind: PointerType
+      ID: 226
+      Name: '*error'
+      ByteSize: 8
+      GoRuntimeType: 401568
+      GoKind: 22
+      Pointee: 212 GoInterfaceType error
+    - __kind: PointerType
+      ID: 228
+      Name: '*float32'
+      ByteSize: 8
+      GoRuntimeType: 402528
+      GoKind: 22
+      Pointee: 214 BaseType float32
+    - __kind: PointerType
+      ID: 201
+      Name: '*float64'
+      ByteSize: 8
+      GoRuntimeType: 402592
+      GoKind: 22
+      Pointee: 166 BaseType float64
+    - __kind: PointerType
+      ID: 134
+      Name: '*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span'
+      ByteSize: 8
+      GoRuntimeType: 2.326784e+06
+      GoKind: 22
+      Pointee: 135 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span
+    - __kind: PointerType
+      ID: 195
+      Name: '*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanContext'
+      ByteSize: 8
+      GoRuntimeType: 2.045472e+06
+      GoKind: 22
+      Pointee: 196 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanContext
+    - __kind: PointerType
+      ID: 168
+      Name: '*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink'
+      ByteSize: 8
+      GoRuntimeType: 1.210016e+06
+      GoKind: 22
+      Pointee: 169 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink
+    - __kind: PointerType
+      ID: 171
+      Name: '*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent'
+      ByteSize: 8
+      GoRuntimeType: 1.210144e+06
+      GoKind: 22
+      Pointee: 172 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent
+    - __kind: PointerType
+      ID: 187
+      Name: '*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttribute'
+      ByteSize: 8
+      GoRuntimeType: 1.210784e+06
+      GoKind: 22
+      Pointee: 188 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttribute
+    - __kind: PointerType
+      ID: 191
+      Name: '*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttributeValue'
+      ByteSize: 8
+      GoRuntimeType: 1.210528e+06
+      GoKind: 22
+      Pointee: 192 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttributeValue
+    - __kind: PointerType
+      ID: 184
+      Name: '*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute'
+      ByteSize: 8
+      GoRuntimeType: 1.210912e+06
+      GoKind: 22
+      Pointee: 185 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
+    - __kind: PointerType
+      ID: 197
+      Name: '*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.trace'
+      ByteSize: 8
+      GoRuntimeType: 2.269504e+06
+      GoKind: 22
+      Pointee: 198 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.trace
+    - __kind: PointerType
+      ID: 73
+      Name: '*int'
+      ByteSize: 8
+      GoRuntimeType: 402208
+      GoKind: 22
+      Pointee: 8 BaseType int
+    - __kind: PointerType
+      ID: 224
+      Name: '*int16'
+      ByteSize: 8
+      GoRuntimeType: 401824
+      GoKind: 22
+      Pointee: 218 BaseType int16
+    - __kind: PointerType
+      ID: 216
+      Name: '*int32'
+      ByteSize: 8
+      GoRuntimeType: 401952
+      GoKind: 22
+      Pointee: 140 BaseType int32
+    - __kind: PointerType
+      ID: 221
+      Name: '*int64'
+      ByteSize: 8
+      GoRuntimeType: 402080
+      GoKind: 22
+      Pointee: 32 BaseType int64
+    - __kind: PointerType
+      ID: 225
+      Name: '*int8'
+      ByteSize: 8
+      GoRuntimeType: 401696
+      GoKind: 22
+      Pointee: 213 BaseType int8
+    - __kind: PointerType
+      ID: 174
+      Name: '*map<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>'
+      ByteSize: 8
+      Pointee: 175 GoSwissMapHeaderType map<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
+    - __kind: PointerType
+      ID: 38
+      Name: '*map<string,[]*mime/multipart.FileHeader>'
+      ByteSize: 8
+      Pointee: 39 GoSwissMapHeaderType map<string,[]*mime/multipart.FileHeader>
+    - __kind: PointerType
+      ID: 15
+      Name: '*map<string,[]string>'
+      ByteSize: 8
+      Pointee: 16 GoSwissMapHeaderType map<string,[]string>
+    - __kind: PointerType
+      ID: 156
+      Name: '*map<string,float64>'
+      ByteSize: 8
+      Pointee: 157 GoSwissMapHeaderType map<string,float64>
+    - __kind: PointerType
+      ID: 145
+      Name: '*map<string,interface {}>'
+      ByteSize: 8
+      Pointee: 146 GoSwissMapHeaderType map<string,interface {}>
+    - __kind: PointerType
+      ID: 124
+      Name: '*map<string,string>'
+      ByteSize: 8
+      Pointee: 125 GoSwissMapHeaderType map<string,string>
+    - __kind: PointerType
+      ID: 63
+      Name: '*math/big.Int'
+      ByteSize: 8
+      GoRuntimeType: 2.440096e+06
+      GoKind: 22
+      Pointee: 64 StructureType math/big.Int
+    - __kind: PointerType
+      ID: 66
+      Name: '*math/big.Word'
+      ByteSize: 8
+      GoRuntimeType: 429728
+      GoKind: 22
+      Pointee: 67 BaseType math/big.Word
+    - __kind: PointerType
+      ID: 244
+      Name: '*math/big.nat.array'
+      ByteSize: 8
+      Pointee: 243 GoSliceDataType math/big.nat.array
+    - __kind: PointerType
+      ID: 50
+      Name: '*mime/multipart.FileHeader'
+      ByteSize: 8
+      GoRuntimeType: 920288
+      GoKind: 22
+      Pointee: 51 StructureType mime/multipart.FileHeader
     - __kind: PointerType
       ID: 34
       Name: '*mime/multipart.Form'
@@ -537,158 +542,317 @@ Types:
       GoRuntimeType: 920384
       GoKind: 22
       Pointee: 35 StructureType mime/multipart.Form
-    - __kind: StructureType
-      ID: 35
-      Name: mime/multipart.Form
-      ByteSize: 16
-      GoRuntimeType: 1.5008e+06
-      GoKind: 25
-      RawFields:
-        - Name: Value
-          Offset: 0
-          Type: 36 GoMapType map[string][]string
-        - Name: File
-          Offset: 8
-          Type: 37 GoMapType map[string][]*mime/multipart.FileHeader
-    - __kind: GoMapType
-      ID: 36
-      Name: map[string][]string
-      ByteSize: 8
-      GoRuntimeType: 1.14768e+06
-      GoKind: 21
-      HeaderType: 16 GoSwissMapHeaderType map<string,[]string>
-    - __kind: GoMapType
-      ID: 37
-      Name: map[string][]*mime/multipart.FileHeader
-      ByteSize: 8
-      GoRuntimeType: 1.152288e+06
-      GoKind: 21
-      HeaderType: 39 GoSwissMapHeaderType map<string,[]*mime/multipart.FileHeader>
     - __kind: PointerType
-      ID: 38
-      Name: '*map<string,[]*mime/multipart.FileHeader>'
+      ID: 93
+      Name: '*net.IP'
       ByteSize: 8
-      Pointee: 39 GoSwissMapHeaderType map<string,[]*mime/multipart.FileHeader>
-    - __kind: GoSwissMapHeaderType
-      ID: 39
-      Name: map<string,[]*mime/multipart.FileHeader>
-      ByteSize: 48
-      GoKind: 25
-      RawFields:
-        - Name: used
-          Offset: 0
-          Type: 17 BaseType uint64
-        - Name: seed
-          Offset: 8
-          Type: 18 BaseType uintptr
-        - Name: dirPtr
-          Offset: 16
-          Type: 40 PointerType **table<string,[]*mime/multipart.FileHeader>
-        - Name: dirLen
-          Offset: 24
-          Type: 8 BaseType int
-        - Name: globalDepth
-          Offset: 32
-          Type: 7 BaseType uint8
-        - Name: globalShift
-          Offset: 33
-          Type: 7 BaseType uint8
-        - Name: writing
-          Offset: 34
-          Type: 7 BaseType uint8
-        - Name: clearSeq
-          Offset: 40
-          Type: 17 BaseType uint64
-      TablePtrSliceType: 235 GoSliceDataType []*table<string,[]*mime/multipart.FileHeader>.array
-      GroupType: 45 StructureType noalg.map.group[string][]*mime/multipart.FileHeader
+      GoRuntimeType: 2.197536e+06
+      GoKind: 22
+      Pointee: 94 GoSliceHeaderType net.IP
     - __kind: PointerType
-      ID: 40
-      Name: '**table<string,[]*mime/multipart.FileHeader>'
+      ID: 262
+      Name: '*net.IP.array'
       ByteSize: 8
-      Pointee: 41 PointerType *table<string,[]*mime/multipart.FileHeader>
+      Pointee: 261 GoSliceDataType net.IP.array
     - __kind: PointerType
-      ID: 41
-      Name: '*table<string,[]*mime/multipart.FileHeader>'
+      ID: 268
+      Name: '*net.IPMask.array'
       ByteSize: 8
-      Pointee: 42 StructureType table<string,[]*mime/multipart.FileHeader>
-    - __kind: StructureType
-      ID: 42
-      Name: table<string,[]*mime/multipart.FileHeader>
-      ByteSize: 32
-      GoKind: 25
-      RawFields:
-        - Name: used
-          Offset: 0
-          Type: 22 BaseType uint16
-        - Name: capacity
-          Offset: 2
-          Type: 22 BaseType uint16
-        - Name: growthLeft
-          Offset: 4
-          Type: 22 BaseType uint16
-        - Name: localDepth
-          Offset: 6
-          Type: 7 BaseType uint8
-        - Name: index
-          Offset: 8
-          Type: 8 BaseType int
-        - Name: groups
-          Offset: 16
-          Type: 43 GoSwissMapGroupsType groupReference<string,[]*mime/multipart.FileHeader>
-    - __kind: GoSwissMapGroupsType
-      ID: 43
-      Name: groupReference<string,[]*mime/multipart.FileHeader>
-      ByteSize: 16
-      GoKind: 25
-      RawFields:
-        - Name: data
-          Offset: 0
-          Type: 44 PointerType *noalg.map.group[string][]*mime/multipart.FileHeader
-        - Name: lengthMask
-          Offset: 8
-          Type: 17 BaseType uint64
-      GroupType: 45 StructureType noalg.map.group[string][]*mime/multipart.FileHeader
-      GroupSliceType: 236 GoSliceDataType []noalg.map.group[string][]*mime/multipart.FileHeader.array
+      Pointee: 267 GoSliceDataType net.IPMask.array
+    - __kind: PointerType
+      ID: 99
+      Name: '*net.IPNet'
+      ByteSize: 8
+      GoRuntimeType: 1.203744e+06
+      GoKind: 22
+      Pointee: 100 StructureType net.IPNet
+    - __kind: PointerType
+      ID: 3
+      Name: '*net/http.Request'
+      ByteSize: 8
+      GoRuntimeType: 2.359648e+06
+      GoKind: 22
+      Pointee: 4 StructureType net/http.Request
+    - __kind: PointerType
+      ID: 115
+      Name: '*net/http.Response'
+      ByteSize: 8
+      GoRuntimeType: 1.75088e+06
+      GoKind: 22
+      Pointee: 116 StructureType net/http.Response
+    - __kind: PointerType
+      ID: 118
+      Name: '*net/http.pattern'
+      ByteSize: 8
+      GoRuntimeType: 1.63728e+06
+      GoKind: 22
+      Pointee: 119 StructureType net/http.pattern
+    - __kind: PointerType
+      ID: 121
+      Name: '*net/http.segment'
+      ByteSize: 8
+      GoRuntimeType: 393440
+      GoKind: 22
+      Pointee: 122 StructureType net/http.segment
+    - __kind: PointerType
+      ID: 9
+      Name: '*net/url.URL'
+      ByteSize: 8
+      GoRuntimeType: 2.159744e+06
+      GoKind: 22
+      Pointee: 10 StructureType net/url.URL
+    - __kind: PointerType
+      ID: 11
+      Name: '*net/url.Userinfo'
+      ByteSize: 8
+      GoRuntimeType: 1.221536e+06
+      GoKind: 22
+      Pointee: 12 StructureType net/url.Userinfo
+    - __kind: PointerType
+      ID: 180
+      Name: '*noalg.map.group[string]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute'
+      ByteSize: 8
+      Pointee: 181 StructureType noalg.map.group[string]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
     - __kind: PointerType
       ID: 44
       Name: '*noalg.map.group[string][]*mime/multipart.FileHeader'
       ByteSize: 8
       Pointee: 45 StructureType noalg.map.group[string][]*mime/multipart.FileHeader
-    - __kind: StructureType
-      ID: 45
-      Name: noalg.map.group[string][]*mime/multipart.FileHeader
-      ByteSize: 328
-      GoRuntimeType: 1.320928e+06
-      GoKind: 25
+    - __kind: PointerType
+      ID: 24
+      Name: '*noalg.map.group[string][]string'
+      ByteSize: 8
+      Pointee: 25 StructureType noalg.map.group[string][]string
+    - __kind: PointerType
+      ID: 162
+      Name: '*noalg.map.group[string]float64'
+      ByteSize: 8
+      Pointee: 163 StructureType noalg.map.group[string]float64
+    - __kind: PointerType
+      ID: 151
+      Name: '*noalg.map.group[string]interface {}'
+      ByteSize: 8
+      Pointee: 152 StructureType noalg.map.group[string]interface {}
+    - __kind: PointerType
+      ID: 130
+      Name: '*noalg.map.group[string]string'
+      ByteSize: 8
+      Pointee: 131 StructureType noalg.map.group[string]string
+    - __kind: PointerType
+      ID: 29
+      Name: '*string'
+      ByteSize: 8
+      GoRuntimeType: 401632
+      GoKind: 22
+      Pointee: 5 GoStringHeaderType string
+    - __kind: PointerType
+      ID: 230
+      Name: '*string.str'
+      ByteSize: 8
+      Pointee: 229 GoStringDataType string.str
+    - __kind: PointerType
+      ID: 177
+      Name: '*table<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>'
+      ByteSize: 8
+      Pointee: 178 StructureType table<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
+    - __kind: PointerType
+      ID: 41
+      Name: '*table<string,[]*mime/multipart.FileHeader>'
+      ByteSize: 8
+      Pointee: 42 StructureType table<string,[]*mime/multipart.FileHeader>
+    - __kind: PointerType
+      ID: 20
+      Name: '*table<string,[]string>'
+      ByteSize: 8
+      Pointee: 21 StructureType table<string,[]string>
+    - __kind: PointerType
+      ID: 159
+      Name: '*table<string,float64>'
+      ByteSize: 8
+      Pointee: 160 StructureType table<string,float64>
+    - __kind: PointerType
+      ID: 148
+      Name: '*table<string,interface {}>'
+      ByteSize: 8
+      Pointee: 149 StructureType table<string,interface {}>
+    - __kind: PointerType
+      ID: 127
+      Name: '*table<string,string>'
+      ByteSize: 8
+      Pointee: 128 StructureType table<string,string>
+    - __kind: PointerType
+      ID: 75
+      Name: '*time.Location'
+      ByteSize: 8
+      GoRuntimeType: 1.642272e+06
+      GoKind: 22
+      Pointee: 76 StructureType time.Location
+    - __kind: PointerType
+      ID: 78
+      Name: '*time.zone'
+      ByteSize: 8
+      GoRuntimeType: 396576
+      GoKind: 22
+      Pointee: 79 StructureType time.zone
+    - __kind: PointerType
+      ID: 81
+      Name: '*time.zoneTrans'
+      ByteSize: 8
+      GoRuntimeType: 396640
+      GoKind: 22
+      Pointee: 82 StructureType time.zoneTrans
+    - __kind: PointerType
+      ID: 227
+      Name: '*uint'
+      ByteSize: 8
+      GoRuntimeType: 402272
+      GoKind: 22
+      Pointee: 210 BaseType uint
+    - __kind: PointerType
+      ID: 223
+      Name: '*uint16'
+      ByteSize: 8
+      GoRuntimeType: 401888
+      GoKind: 22
+      Pointee: 22 BaseType uint16
+    - __kind: PointerType
+      ID: 217
+      Name: '*uint32'
+      ByteSize: 8
+      GoRuntimeType: 402016
+      GoKind: 22
+      Pointee: 141 BaseType uint32
+    - __kind: PointerType
+      ID: 222
+      Name: '*uint64'
+      ByteSize: 8
+      GoRuntimeType: 402144
+      GoKind: 22
+      Pointee: 17 BaseType uint64
+    - __kind: PointerType
+      ID: 6
+      Name: '*uint8'
+      ByteSize: 8
+      GoRuntimeType: 401760
+      GoKind: 22
+      Pointee: 7 BaseType uint8
+    - __kind: PointerType
+      ID: 215
+      Name: '*uintptr'
+      ByteSize: 8
+      GoRuntimeType: 402336
+      GoKind: 22
+      Pointee: 18 BaseType uintptr
+    - __kind: GoChannelType
+      ID: 114
+      Name: <-chan struct {}
+      GoRuntimeType: 603232
+      GoKind: 18
+    - __kind: EventRootType
+      ID: 295
+      Name: Probe[main.HandleHTTP]
+      ByteSize: 25
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: w
+          Offset: 1
+          Expression:
+            Type: 1 GoInterfaceType net/http.ResponseWriter
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 1, index: 0, name: w}
+                  Offset: 0
+                  ByteSize: 16
+        - Name: r
+          Offset: 17
+          Expression:
+            Type: 3 PointerType *net/http.Request
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 1, index: 1, name: r}
+                  Offset: 0
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 296
+      Name: Probe[main.LookAtTheRequest]
+      ByteSize: 17
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: path
+          Offset: 1
+          Expression:
+            Type: 5 GoStringHeaderType string
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 2, index: 0, name: path}
+                  Offset: 0
+                  ByteSize: 16
+    - __kind: GoSliceHeaderType
+      ID: 56
+      Name: '[]*crypto/x509.Certificate'
+      ByteSize: 24
+      GoRuntimeType: 503680
+      GoKind: 23
       RawFields:
-        - Name: ctrl
+        - Name: array
           Offset: 0
-          Type: 17 BaseType uint64
-        - Name: slots
+          Type: 57 PointerType **crypto/x509.Certificate
+        - Name: len
           Offset: 8
-          Type: 46 ArrayType noalg.[8]struct { key string; elem []*mime/multipart.FileHeader }
-    - __kind: ArrayType
-      ID: 46
-      Name: noalg.[8]struct { key string; elem []*mime/multipart.FileHeader }
-      ByteSize: 320
-      GoRuntimeType: 707136
-      GoKind: 17
-      Count: 8
-      HasCount: true
-      Element: 47 StructureType noalg.struct { key string; elem []*mime/multipart.FileHeader }
-    - __kind: StructureType
-      ID: 47
-      Name: noalg.struct { key string; elem []*mime/multipart.FileHeader }
-      ByteSize: 40
-      GoRuntimeType: 1.3208e+06
-      GoKind: 25
-      RawFields:
-        - Name: key
-          Offset: 0
-          Type: 5 GoStringHeaderType string
-        - Name: elem
+          Type: 8 BaseType int
+        - Name: cap
           Offset: 16
-          Type: 48 GoSliceHeaderType []*mime/multipart.FileHeader
+          Type: 8 BaseType int
+      Data: 241 GoSliceDataType []*crypto/x509.Certificate.array
+    - __kind: GoSliceDataType
+      ID: 241
+      Name: '[]*crypto/x509.Certificate.array'
+      ByteSize: 2048
+      Element: 58 PointerType *crypto/x509.Certificate
+    - __kind: GoSliceHeaderType
+      ID: 199
+      Name: '[]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span'
+      ByteSize: 24
+      GoRuntimeType: 491840
+      GoKind: 23
+      RawFields:
+        - Name: array
+          Offset: 0
+          Type: 200 PointerType **github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span
+        - Name: len
+          Offset: 8
+          Type: 8 BaseType int
+        - Name: cap
+          Offset: 16
+          Type: 8 BaseType int
+      Data: 293 GoSliceDataType []*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span.array
+    - __kind: GoSliceDataType
+      ID: 293
+      Name: '[]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span.array'
+      ByteSize: 2048
+      Element: 134 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span
+    - __kind: GoSliceHeaderType
+      ID: 189
+      Name: '[]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttributeValue'
+      ByteSize: 24
+      GoRuntimeType: 491456
+      GoKind: 23
+      RawFields:
+        - Name: array
+          Offset: 0
+          Type: 190 PointerType **github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttributeValue
+        - Name: len
+          Offset: 8
+          Type: 8 BaseType int
+        - Name: cap
+          Offset: 16
+          Type: 8 BaseType int
+      Data: 291 GoSliceDataType []*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttributeValue.array
+    - __kind: GoSliceDataType
+      ID: 291
+      Name: '[]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttributeValue.array'
+      ByteSize: 2048
+      Element: 191 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttributeValue
     - __kind: GoSliceHeaderType
       ID: 48
       Name: '[]*mime/multipart.FileHeader'
@@ -706,54 +870,445 @@ Types:
           Offset: 16
           Type: 8 BaseType int
       Data: 237 GoSliceDataType []*mime/multipart.FileHeader.array
-    - __kind: PointerType
-      ID: 49
-      Name: '**mime/multipart.FileHeader'
-      ByteSize: 8
-      GoKind: 22
-      Pointee: 50 PointerType *mime/multipart.FileHeader
-    - __kind: PointerType
-      ID: 50
-      Name: '*mime/multipart.FileHeader'
-      ByteSize: 8
-      GoRuntimeType: 920288
-      GoKind: 22
-      Pointee: 51 StructureType mime/multipart.FileHeader
-    - __kind: StructureType
-      ID: 51
-      Name: mime/multipart.FileHeader
-      ByteSize: 88
-      GoRuntimeType: 2.009312e+06
-      GoKind: 25
+    - __kind: GoSliceDataType
+      ID: 237
+      Name: '[]*mime/multipart.FileHeader.array'
+      ByteSize: 2048
+      Element: 50 PointerType *mime/multipart.FileHeader
+    - __kind: GoSliceHeaderType
+      ID: 97
+      Name: '[]*net.IPNet'
+      ByteSize: 24
+      GoRuntimeType: 518464
+      GoKind: 23
       RawFields:
-        - Name: Filename
+        - Name: array
           Offset: 0
-          Type: 5 GoStringHeaderType string
-        - Name: Header
+          Type: 98 PointerType **net.IPNet
+        - Name: len
+          Offset: 8
+          Type: 8 BaseType int
+        - Name: cap
           Offset: 16
-          Type: 52 GoMapType net/textproto.MIMEHeader
-        - Name: Size
-          Offset: 24
-          Type: 32 BaseType int64
-        - Name: content
-          Offset: 32
-          Type: 53 GoSliceHeaderType []uint8
-        - Name: tmpfile
-          Offset: 56
-          Type: 5 GoStringHeaderType string
-        - Name: tmpoff
-          Offset: 72
-          Type: 32 BaseType int64
-        - Name: tmpshared
-          Offset: 80
-          Type: 13 BaseType bool
-    - __kind: GoMapType
-      ID: 52
-      Name: net/textproto.MIMEHeader
-      ByteSize: 8
-      GoRuntimeType: 1.854368e+06
-      GoKind: 21
-      HeaderType: 16 GoSwissMapHeaderType map<string,[]string>
+          Type: 8 BaseType int
+      Data: 265 GoSliceDataType []*net.IPNet.array
+    - __kind: GoSliceDataType
+      ID: 265
+      Name: '[]*net.IPNet.array'
+      ByteSize: 2048
+      Element: 99 PointerType *net.IPNet
+    - __kind: GoSliceHeaderType
+      ID: 95
+      Name: '[]*net/url.URL'
+      ByteSize: 24
+      GoRuntimeType: 518400
+      GoKind: 23
+      RawFields:
+        - Name: array
+          Offset: 0
+          Type: 96 PointerType **net/url.URL
+        - Name: len
+          Offset: 8
+          Type: 8 BaseType int
+        - Name: cap
+          Offset: 16
+          Type: 8 BaseType int
+      Data: 263 GoSliceDataType []*net/url.URL.array
+    - __kind: GoSliceDataType
+      ID: 263
+      Name: '[]*net/url.URL.array'
+      ByteSize: 2048
+      Element: 9 PointerType *net/url.URL
+    - __kind: GoSliceDataType
+      ID: 289
+      Name: '[]*table<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>.array'
+      ByteSize: 8192
+      Element: 177 PointerType *table<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
+    - __kind: GoSliceDataType
+      ID: 235
+      Name: '[]*table<string,[]*mime/multipart.FileHeader>.array'
+      ByteSize: 8192
+      Element: 41 PointerType *table<string,[]*mime/multipart.FileHeader>
+    - __kind: GoSliceDataType
+      ID: 231
+      Name: '[]*table<string,[]string>.array'
+      ByteSize: 8192
+      Element: 20 PointerType *table<string,[]string>
+    - __kind: GoSliceDataType
+      ID: 283
+      Name: '[]*table<string,float64>.array'
+      ByteSize: 8192
+      Element: 159 PointerType *table<string,float64>
+    - __kind: GoSliceDataType
+      ID: 281
+      Name: '[]*table<string,interface {}>.array'
+      ByteSize: 8192
+      Element: 148 PointerType *table<string,interface {}>
+    - __kind: GoSliceDataType
+      ID: 279
+      Name: '[]*table<string,string>.array'
+      ByteSize: 8192
+      Element: 127 PointerType *table<string,string>
+    - __kind: GoSliceHeaderType
+      ID: 108
+      Name: '[][]*crypto/x509.Certificate'
+      ByteSize: 24
+      GoRuntimeType: 503808
+      GoKind: 23
+      RawFields:
+        - Name: array
+          Offset: 0
+          Type: 109 PointerType *[]*crypto/x509.Certificate
+        - Name: len
+          Offset: 8
+          Type: 8 BaseType int
+        - Name: cap
+          Offset: 16
+          Type: 8 BaseType int
+      Data: 273 GoSliceDataType [][]*crypto/x509.Certificate.array
+    - __kind: GoSliceDataType
+      ID: 273
+      Name: '[][]*crypto/x509.Certificate.array'
+      ByteSize: 2048
+      Element: 56 GoSliceHeaderType []*crypto/x509.Certificate
+    - __kind: GoSliceHeaderType
+      ID: 110
+      Name: '[][]uint8'
+      ByteSize: 24
+      GoRuntimeType: 483808
+      GoKind: 23
+      RawFields:
+        - Name: array
+          Offset: 0
+          Type: 111 PointerType *[]uint8
+        - Name: len
+          Offset: 8
+          Type: 8 BaseType int
+        - Name: cap
+          Offset: 16
+          Type: 8 BaseType int
+      Data: 275 GoSliceDataType [][]uint8.array
+    - __kind: GoSliceDataType
+      ID: 275
+      Name: '[][]uint8.array'
+      ByteSize: 2048
+      Element: 53 GoSliceHeaderType []uint8
+    - __kind: GoSliceHeaderType
+      ID: 89
+      Name: '[]crypto/x509.ExtKeyUsage'
+      ByteSize: 24
+      GoRuntimeType: 505152
+      GoKind: 23
+      RawFields:
+        - Name: array
+          Offset: 0
+          Type: 90 PointerType *crypto/x509.ExtKeyUsage
+        - Name: len
+          Offset: 8
+          Type: 8 BaseType int
+        - Name: cap
+          Offset: 16
+          Type: 8 BaseType int
+      Data: 257 GoSliceDataType []crypto/x509.ExtKeyUsage.array
+    - __kind: GoSliceDataType
+      ID: 257
+      Name: '[]crypto/x509.ExtKeyUsage.array'
+      ByteSize: 2048
+      Element: 91 BaseType crypto/x509.ExtKeyUsage
+    - __kind: GoSliceHeaderType
+      ID: 102
+      Name: '[]crypto/x509.OID'
+      ByteSize: 24
+      GoRuntimeType: 518528
+      GoKind: 23
+      RawFields:
+        - Name: array
+          Offset: 0
+          Type: 103 PointerType *crypto/x509.OID
+        - Name: len
+          Offset: 8
+          Type: 8 BaseType int
+        - Name: cap
+          Offset: 16
+          Type: 8 BaseType int
+      Data: 269 GoSliceDataType []crypto/x509.OID.array
+    - __kind: GoSliceDataType
+      ID: 269
+      Name: '[]crypto/x509.OID.array'
+      ByteSize: 2048
+      Element: 104 StructureType crypto/x509.OID
+    - __kind: GoSliceHeaderType
+      ID: 105
+      Name: '[]crypto/x509.PolicyMapping'
+      ByteSize: 24
+      GoRuntimeType: 518592
+      GoKind: 23
+      RawFields:
+        - Name: array
+          Offset: 0
+          Type: 106 PointerType *crypto/x509.PolicyMapping
+        - Name: len
+          Offset: 8
+          Type: 8 BaseType int
+        - Name: cap
+          Offset: 16
+          Type: 8 BaseType int
+      Data: 271 GoSliceDataType []crypto/x509.PolicyMapping.array
+    - __kind: GoSliceDataType
+      ID: 271
+      Name: '[]crypto/x509.PolicyMapping.array'
+      ByteSize: 2048
+      Element: 107 StructureType crypto/x509.PolicyMapping
+    - __kind: GoSliceHeaderType
+      ID: 69
+      Name: '[]crypto/x509/pkix.AttributeTypeAndValue'
+      ByteSize: 24
+      GoRuntimeType: 519040
+      GoKind: 23
+      RawFields:
+        - Name: array
+          Offset: 0
+          Type: 70 PointerType *crypto/x509/pkix.AttributeTypeAndValue
+        - Name: len
+          Offset: 8
+          Type: 8 BaseType int
+        - Name: cap
+          Offset: 16
+          Type: 8 BaseType int
+      Data: 245 GoSliceDataType []crypto/x509/pkix.AttributeTypeAndValue.array
+    - __kind: GoSliceDataType
+      ID: 245
+      Name: '[]crypto/x509/pkix.AttributeTypeAndValue.array'
+      ByteSize: 2048
+      Element: 71 StructureType crypto/x509/pkix.AttributeTypeAndValue
+    - __kind: GoSliceHeaderType
+      ID: 84
+      Name: '[]crypto/x509/pkix.Extension'
+      ByteSize: 24
+      GoRuntimeType: 518272
+      GoKind: 23
+      RawFields:
+        - Name: array
+          Offset: 0
+          Type: 85 PointerType *crypto/x509/pkix.Extension
+        - Name: len
+          Offset: 8
+          Type: 8 BaseType int
+        - Name: cap
+          Offset: 16
+          Type: 8 BaseType int
+      Data: 253 GoSliceDataType []crypto/x509/pkix.Extension.array
+    - __kind: GoSliceDataType
+      ID: 253
+      Name: '[]crypto/x509/pkix.Extension.array'
+      ByteSize: 2048
+      Element: 86 StructureType crypto/x509/pkix.Extension
+    - __kind: GoSliceHeaderType
+      ID: 87
+      Name: '[]encoding/asn1.ObjectIdentifier'
+      ByteSize: 24
+      GoRuntimeType: 518336
+      GoKind: 23
+      RawFields:
+        - Name: array
+          Offset: 0
+          Type: 88 PointerType *encoding/asn1.ObjectIdentifier
+        - Name: len
+          Offset: 8
+          Type: 8 BaseType int
+        - Name: cap
+          Offset: 16
+          Type: 8 BaseType int
+      Data: 255 GoSliceDataType []encoding/asn1.ObjectIdentifier.array
+    - __kind: GoSliceDataType
+      ID: 255
+      Name: '[]encoding/asn1.ObjectIdentifier.array'
+      ByteSize: 2048
+      Element: 72 GoSliceHeaderType encoding/asn1.ObjectIdentifier
+    - __kind: GoSliceHeaderType
+      ID: 167
+      Name: '[]github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink'
+      ByteSize: 24
+      GoRuntimeType: 491392
+      GoKind: 23
+      RawFields:
+        - Name: array
+          Offset: 0
+          Type: 168 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink
+        - Name: len
+          Offset: 8
+          Type: 8 BaseType int
+        - Name: cap
+          Offset: 16
+          Type: 8 BaseType int
+      Data: 285 GoSliceDataType []github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink.array
+    - __kind: GoSliceDataType
+      ID: 285
+      Name: '[]github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink.array'
+      ByteSize: 2048
+      Element: 169 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink
+    - __kind: GoSliceHeaderType
+      ID: 170
+      Name: '[]github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent'
+      ByteSize: 24
+      GoRuntimeType: 491584
+      GoKind: 23
+      RawFields:
+        - Name: array
+          Offset: 0
+          Type: 171 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent
+        - Name: len
+          Offset: 8
+          Type: 8 BaseType int
+        - Name: cap
+          Offset: 16
+          Type: 8 BaseType int
+      Data: 287 GoSliceDataType []github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent.array
+    - __kind: GoSliceDataType
+      ID: 287
+      Name: '[]github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent.array'
+      ByteSize: 2048
+      Element: 172 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent
+    - __kind: GoSliceHeaderType
+      ID: 92
+      Name: '[]net.IP'
+      ByteSize: 24
+      GoRuntimeType: 484768
+      GoKind: 23
+      RawFields:
+        - Name: array
+          Offset: 0
+          Type: 93 PointerType *net.IP
+        - Name: len
+          Offset: 8
+          Type: 8 BaseType int
+        - Name: cap
+          Offset: 16
+          Type: 8 BaseType int
+      Data: 259 GoSliceDataType []net.IP.array
+    - __kind: GoSliceDataType
+      ID: 259
+      Name: '[]net.IP.array'
+      ByteSize: 2048
+      Element: 94 GoSliceHeaderType net.IP
+    - __kind: GoSliceHeaderType
+      ID: 120
+      Name: '[]net/http.segment'
+      ByteSize: 24
+      GoRuntimeType: 486400
+      GoKind: 23
+      RawFields:
+        - Name: array
+          Offset: 0
+          Type: 121 PointerType *net/http.segment
+        - Name: len
+          Offset: 8
+          Type: 8 BaseType int
+        - Name: cap
+          Offset: 16
+          Type: 8 BaseType int
+      Data: 277 GoSliceDataType []net/http.segment.array
+    - __kind: GoSliceDataType
+      ID: 277
+      Name: '[]net/http.segment.array'
+      ByteSize: 2048
+      Element: 122 StructureType net/http.segment
+    - __kind: GoSliceDataType
+      ID: 290
+      Name: '[]noalg.map.group[string]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute.array'
+      ByteSize: 2048
+      Element: 181 StructureType noalg.map.group[string]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
+    - __kind: GoSliceDataType
+      ID: 236
+      Name: '[]noalg.map.group[string][]*mime/multipart.FileHeader.array'
+      ByteSize: 2048
+      Element: 45 StructureType noalg.map.group[string][]*mime/multipart.FileHeader
+    - __kind: GoSliceDataType
+      ID: 232
+      Name: '[]noalg.map.group[string][]string.array'
+      ByteSize: 2048
+      Element: 25 StructureType noalg.map.group[string][]string
+    - __kind: GoSliceDataType
+      ID: 284
+      Name: '[]noalg.map.group[string]float64.array'
+      ByteSize: 2048
+      Element: 163 StructureType noalg.map.group[string]float64
+    - __kind: GoSliceDataType
+      ID: 282
+      Name: '[]noalg.map.group[string]interface {}.array'
+      ByteSize: 2048
+      Element: 152 StructureType noalg.map.group[string]interface {}
+    - __kind: GoSliceDataType
+      ID: 280
+      Name: '[]noalg.map.group[string]string.array'
+      ByteSize: 2048
+      Element: 131 StructureType noalg.map.group[string]string
+    - __kind: GoSliceHeaderType
+      ID: 28
+      Name: '[]string'
+      ByteSize: 24
+      GoRuntimeType: 498048
+      GoKind: 23
+      RawFields:
+        - Name: array
+          Offset: 0
+          Type: 29 PointerType *string
+        - Name: len
+          Offset: 8
+          Type: 8 BaseType int
+        - Name: cap
+          Offset: 16
+          Type: 8 BaseType int
+      Data: 233 GoSliceDataType []string.array
+    - __kind: GoSliceDataType
+      ID: 233
+      Name: '[]string.array'
+      ByteSize: 2048
+      Element: 5 GoStringHeaderType string
+    - __kind: GoSliceHeaderType
+      ID: 77
+      Name: '[]time.zone'
+      ByteSize: 24
+      GoRuntimeType: 490944
+      GoKind: 23
+      RawFields:
+        - Name: array
+          Offset: 0
+          Type: 78 PointerType *time.zone
+        - Name: len
+          Offset: 8
+          Type: 8 BaseType int
+        - Name: cap
+          Offset: 16
+          Type: 8 BaseType int
+      Data: 249 GoSliceDataType []time.zone.array
+    - __kind: GoSliceDataType
+      ID: 249
+      Name: '[]time.zone.array'
+      ByteSize: 2048
+      Element: 79 StructureType time.zone
+    - __kind: GoSliceHeaderType
+      ID: 80
+      Name: '[]time.zoneTrans'
+      ByteSize: 24
+      GoRuntimeType: 491008
+      GoKind: 23
+      RawFields:
+        - Name: array
+          Offset: 0
+          Type: 81 PointerType *time.zoneTrans
+        - Name: len
+          Offset: 8
+          Type: 8 BaseType int
+        - Name: cap
+          Offset: 16
+          Type: 8 BaseType int
+      Data: 251 GoSliceDataType []time.zoneTrans.array
+    - __kind: GoSliceDataType
+      ID: 251
+      Name: '[]time.zoneTrans.array'
+      ByteSize: 2048
+      Element: 82 StructureType time.zoneTrans
     - __kind: GoSliceHeaderType
       ID: 53
       Name: '[]uint8'
@@ -771,13 +1326,79 @@ Types:
           Offset: 16
           Type: 8 BaseType int
       Data: 239 GoSliceDataType []uint8.array
-    - __kind: PointerType
-      ID: 54
-      Name: '*crypto/tls.ConnectionState'
+    - __kind: GoSliceDataType
+      ID: 239
+      Name: '[]uint8.array'
+      ByteSize: 2048
+      Element: 7 BaseType uint8
+    - __kind: BaseType
+      ID: 13
+      Name: bool
+      ByteSize: 1
+      GoRuntimeType: 591200
+      GoKind: 1
+    - __kind: StructureType
+      ID: 206
+      Name: bytes.Buffer
+      ByteSize: 40
+      GoRuntimeType: 1.634976e+06
+      GoKind: 25
+      RawFields:
+        - Name: buf
+          Offset: 0
+          Type: 53 GoSliceHeaderType []uint8
+        - Name: off
+          Offset: 24
+          Type: 8 BaseType int
+        - Name: lastRead
+          Offset: 32
+          Type: 207 BaseType bytes.readOp
+    - __kind: BaseType
+      ID: 207
+      Name: bytes.readOp
+      ByteSize: 1
+      GoRuntimeType: 589344
+      GoKind: 3
+    - __kind: BaseType
+      ID: 220
+      Name: complex128
+      ByteSize: 16
+      GoRuntimeType: 591008
+      GoKind: 16
+    - __kind: BaseType
+      ID: 219
+      Name: complex64
       ByteSize: 8
-      GoRuntimeType: 918848
-      GoKind: 22
-      Pointee: 55 StructureType crypto/tls.ConnectionState
+      GoRuntimeType: 590944
+      GoKind: 15
+    - __kind: GoInterfaceType
+      ID: 117
+      Name: context.Context
+      ByteSize: 16
+      GoRuntimeType: 1.298016e+06
+      GoKind: 20
+      RawFields:
+        - Name: tab
+          Offset: 0
+          Type: 2 VoidPointerType unsafe.Pointer
+        - Name: data
+          Offset: 8
+          Type: 2 VoidPointerType unsafe.Pointer
+    - __kind: StructureType
+      ID: 208
+      Name: context.backgroundCtx
+      GoRuntimeType: 1.826784e+06
+      GoKind: 25
+      RawFields:
+        - Name: emptyCtx
+          Offset: 0
+          Type: 209 StructureType context.emptyCtx
+    - __kind: StructureType
+      ID: 209
+      Name: context.emptyCtx
+      GoRuntimeType: 1.61824e+06
+      GoKind: 25
+      RawFields: []
     - __kind: StructureType
       ID: 55
       Name: crypto/tls.ConnectionState
@@ -833,36 +1454,12 @@ Types:
         - Name: testingOnlyCurveID
           Offset: 186
           Type: 113 BaseType crypto/tls.CurveID
-    - __kind: GoSliceHeaderType
-      ID: 56
-      Name: '[]*crypto/x509.Certificate'
-      ByteSize: 24
-      GoRuntimeType: 503680
-      GoKind: 23
-      RawFields:
-        - Name: array
-          Offset: 0
-          Type: 57 PointerType **crypto/x509.Certificate
-        - Name: len
-          Offset: 8
-          Type: 8 BaseType int
-        - Name: cap
-          Offset: 16
-          Type: 8 BaseType int
-      Data: 241 GoSliceDataType []*crypto/x509.Certificate.array
-    - __kind: PointerType
-      ID: 57
-      Name: '**crypto/x509.Certificate'
-      ByteSize: 8
-      GoKind: 22
-      Pointee: 58 PointerType *crypto/x509.Certificate
-    - __kind: PointerType
-      ID: 58
-      Name: '*crypto/x509.Certificate'
-      ByteSize: 8
-      GoRuntimeType: 2.081952e+06
-      GoKind: 22
-      Pointee: 59 StructureType crypto/x509.Certificate
+    - __kind: BaseType
+      ID: 113
+      Name: crypto/tls.CurveID
+      ByteSize: 2
+      GoRuntimeType: 843360
+      GoKind: 9
     - __kind: StructureType
       ID: 59
       Name: crypto/x509.Certificate
@@ -1027,80 +1624,81 @@ Types:
           Offset: 1400
           Type: 105 GoSliceHeaderType []crypto/x509.PolicyMapping
     - __kind: BaseType
-      ID: 60
-      Name: crypto/x509.SignatureAlgorithm
+      ID: 91
+      Name: crypto/x509.ExtKeyUsage
       ByteSize: 8
-      GoRuntimeType: 1.134112e+06
+      GoRuntimeType: 594272
       GoKind: 2
+    - __kind: BaseType
+      ID: 83
+      Name: crypto/x509.KeyUsage
+      ByteSize: 8
+      GoRuntimeType: 594208
+      GoKind: 2
+    - __kind: StructureType
+      ID: 104
+      Name: crypto/x509.OID
+      ByteSize: 24
+      GoRuntimeType: 1.989152e+06
+      GoKind: 25
+      RawFields:
+        - Name: der
+          Offset: 0
+          Type: 53 GoSliceHeaderType []uint8
+    - __kind: StructureType
+      ID: 107
+      Name: crypto/x509.PolicyMapping
+      ByteSize: 48
+      GoRuntimeType: 1.5144e+06
+      GoKind: 25
+      RawFields:
+        - Name: IssuerDomainPolicy
+          Offset: 0
+          Type: 104 StructureType crypto/x509.OID
+        - Name: SubjectDomainPolicy
+          Offset: 24
+          Type: 104 StructureType crypto/x509.OID
     - __kind: BaseType
       ID: 61
       Name: crypto/x509.PublicKeyAlgorithm
       ByteSize: 8
       GoRuntimeType: 845664
       GoKind: 2
-    - __kind: GoEmptyInterfaceType
-      ID: 62
-      Name: interface {}
-      ByteSize: 16
-      GoRuntimeType: 863072
-      GoKind: 20
-      RawFields:
-        - Name: _type
-          Offset: 0
-          Type: 2 VoidPointerType unsafe.Pointer
-        - Name: data
-          Offset: 8
-          Type: 2 VoidPointerType unsafe.Pointer
-    - __kind: PointerType
-      ID: 63
-      Name: '*math/big.Int'
+    - __kind: BaseType
+      ID: 60
+      Name: crypto/x509.SignatureAlgorithm
       ByteSize: 8
-      GoRuntimeType: 2.440096e+06
-      GoKind: 22
-      Pointee: 64 StructureType math/big.Int
+      GoRuntimeType: 1.134112e+06
+      GoKind: 2
     - __kind: StructureType
-      ID: 64
-      Name: math/big.Int
-      ByteSize: 32
-      GoRuntimeType: 1.51744e+06
+      ID: 71
+      Name: crypto/x509/pkix.AttributeTypeAndValue
+      ByteSize: 40
+      GoRuntimeType: 1.52688e+06
       GoKind: 25
       RawFields:
-        - Name: neg
+        - Name: Type
           Offset: 0
-          Type: 13 BaseType bool
-        - Name: abs
-          Offset: 8
-          Type: 65 GoSliceHeaderType math/big.nat
-    - __kind: GoSliceHeaderType
-      ID: 65
-      Name: math/big.nat
-      ByteSize: 24
-      GoRuntimeType: 2.420864e+06
-      GoKind: 23
+          Type: 72 GoSliceHeaderType encoding/asn1.ObjectIdentifier
+        - Name: Value
+          Offset: 24
+          Type: 62 GoEmptyInterfaceType interface {}
+    - __kind: StructureType
+      ID: 86
+      Name: crypto/x509/pkix.Extension
+      ByteSize: 56
+      GoRuntimeType: 1.678176e+06
+      GoKind: 25
       RawFields:
-        - Name: array
+        - Name: Id
           Offset: 0
-          Type: 66 PointerType *math/big.Word
-        - Name: len
-          Offset: 8
-          Type: 8 BaseType int
-        - Name: cap
-          Offset: 16
-          Type: 8 BaseType int
-      Data: 243 GoSliceDataType math/big.nat.array
-    - __kind: PointerType
-      ID: 66
-      Name: '*math/big.Word'
-      ByteSize: 8
-      GoRuntimeType: 429728
-      GoKind: 22
-      Pointee: 67 BaseType math/big.Word
-    - __kind: BaseType
-      ID: 67
-      Name: math/big.Word
-      ByteSize: 8
-      GoRuntimeType: 594464
-      GoKind: 7
+          Type: 72 GoSliceHeaderType encoding/asn1.ObjectIdentifier
+        - Name: Critical
+          Offset: 24
+          Type: 13 BaseType bool
+        - Name: Value
+          Offset: 32
+          Type: 53 GoSliceHeaderType []uint8
     - __kind: StructureType
       ID: 68
       Name: crypto/x509/pkix.Name
@@ -1142,43 +1740,6 @@ Types:
           Offset: 224
           Type: 69 GoSliceHeaderType []crypto/x509/pkix.AttributeTypeAndValue
     - __kind: GoSliceHeaderType
-      ID: 69
-      Name: '[]crypto/x509/pkix.AttributeTypeAndValue'
-      ByteSize: 24
-      GoRuntimeType: 519040
-      GoKind: 23
-      RawFields:
-        - Name: array
-          Offset: 0
-          Type: 70 PointerType *crypto/x509/pkix.AttributeTypeAndValue
-        - Name: len
-          Offset: 8
-          Type: 8 BaseType int
-        - Name: cap
-          Offset: 16
-          Type: 8 BaseType int
-      Data: 245 GoSliceDataType []crypto/x509/pkix.AttributeTypeAndValue.array
-    - __kind: PointerType
-      ID: 70
-      Name: '*crypto/x509/pkix.AttributeTypeAndValue'
-      ByteSize: 8
-      GoRuntimeType: 443616
-      GoKind: 22
-      Pointee: 71 StructureType crypto/x509/pkix.AttributeTypeAndValue
-    - __kind: StructureType
-      ID: 71
-      Name: crypto/x509/pkix.AttributeTypeAndValue
-      ByteSize: 40
-      GoRuntimeType: 1.52688e+06
-      GoKind: 25
-      RawFields:
-        - Name: Type
-          Offset: 0
-          Type: 72 GoSliceHeaderType encoding/asn1.ObjectIdentifier
-        - Name: Value
-          Offset: 24
-          Type: 62 GoEmptyInterfaceType interface {}
-    - __kind: GoSliceHeaderType
       ID: 72
       Name: encoding/asn1.ObjectIdentifier
       ByteSize: 24
@@ -1195,566 +1756,16 @@ Types:
           Offset: 16
           Type: 8 BaseType int
       Data: 247 GoSliceDataType encoding/asn1.ObjectIdentifier.array
-    - __kind: PointerType
-      ID: 73
-      Name: '*int'
-      ByteSize: 8
-      GoRuntimeType: 402208
-      GoKind: 22
-      Pointee: 8 BaseType int
-    - __kind: StructureType
-      ID: 74
-      Name: time.Time
-      ByteSize: 24
-      GoRuntimeType: 2.42368e+06
-      GoKind: 25
-      RawFields:
-        - Name: wall
-          Offset: 0
-          Type: 17 BaseType uint64
-        - Name: ext
-          Offset: 8
-          Type: 32 BaseType int64
-        - Name: loc
-          Offset: 16
-          Type: 75 PointerType *time.Location
-    - __kind: PointerType
-      ID: 75
-      Name: '*time.Location'
-      ByteSize: 8
-      GoRuntimeType: 1.642272e+06
-      GoKind: 22
-      Pointee: 76 StructureType time.Location
-    - __kind: StructureType
-      ID: 76
-      Name: time.Location
-      ByteSize: 104
-      GoRuntimeType: 2.00528e+06
-      GoKind: 25
-      RawFields:
-        - Name: name
-          Offset: 0
-          Type: 5 GoStringHeaderType string
-        - Name: zone
-          Offset: 16
-          Type: 77 GoSliceHeaderType []time.zone
-        - Name: tx
-          Offset: 40
-          Type: 80 GoSliceHeaderType []time.zoneTrans
-        - Name: extend
-          Offset: 64
-          Type: 5 GoStringHeaderType string
-        - Name: cacheStart
-          Offset: 80
-          Type: 32 BaseType int64
-        - Name: cacheEnd
-          Offset: 88
-          Type: 32 BaseType int64
-        - Name: cacheZone
-          Offset: 96
-          Type: 78 PointerType *time.zone
-    - __kind: GoSliceHeaderType
-      ID: 77
-      Name: '[]time.zone'
-      ByteSize: 24
-      GoRuntimeType: 490944
-      GoKind: 23
-      RawFields:
-        - Name: array
-          Offset: 0
-          Type: 78 PointerType *time.zone
-        - Name: len
-          Offset: 8
-          Type: 8 BaseType int
-        - Name: cap
-          Offset: 16
-          Type: 8 BaseType int
-      Data: 249 GoSliceDataType []time.zone.array
-    - __kind: PointerType
-      ID: 78
-      Name: '*time.zone'
-      ByteSize: 8
-      GoRuntimeType: 396576
-      GoKind: 22
-      Pointee: 79 StructureType time.zone
-    - __kind: StructureType
-      ID: 79
-      Name: time.zone
-      ByteSize: 32
-      GoRuntimeType: 1.64208e+06
-      GoKind: 25
-      RawFields:
-        - Name: name
-          Offset: 0
-          Type: 5 GoStringHeaderType string
-        - Name: offset
-          Offset: 16
-          Type: 8 BaseType int
-        - Name: isDST
-          Offset: 24
-          Type: 13 BaseType bool
-    - __kind: GoSliceHeaderType
-      ID: 80
-      Name: '[]time.zoneTrans'
-      ByteSize: 24
-      GoRuntimeType: 491008
-      GoKind: 23
-      RawFields:
-        - Name: array
-          Offset: 0
-          Type: 81 PointerType *time.zoneTrans
-        - Name: len
-          Offset: 8
-          Type: 8 BaseType int
-        - Name: cap
-          Offset: 16
-          Type: 8 BaseType int
-      Data: 251 GoSliceDataType []time.zoneTrans.array
-    - __kind: PointerType
-      ID: 81
-      Name: '*time.zoneTrans'
-      ByteSize: 8
-      GoRuntimeType: 396640
-      GoKind: 22
-      Pointee: 82 StructureType time.zoneTrans
-    - __kind: StructureType
-      ID: 82
-      Name: time.zoneTrans
-      ByteSize: 16
-      GoRuntimeType: 1.780992e+06
-      GoKind: 25
-      RawFields:
-        - Name: when
-          Offset: 0
-          Type: 32 BaseType int64
-        - Name: index
-          Offset: 8
-          Type: 7 BaseType uint8
-        - Name: isstd
-          Offset: 9
-          Type: 13 BaseType bool
-        - Name: isutc
-          Offset: 10
-          Type: 13 BaseType bool
-    - __kind: BaseType
-      ID: 83
-      Name: crypto/x509.KeyUsage
-      ByteSize: 8
-      GoRuntimeType: 594208
-      GoKind: 2
-    - __kind: GoSliceHeaderType
-      ID: 84
-      Name: '[]crypto/x509/pkix.Extension'
-      ByteSize: 24
-      GoRuntimeType: 518272
-      GoKind: 23
-      RawFields:
-        - Name: array
-          Offset: 0
-          Type: 85 PointerType *crypto/x509/pkix.Extension
-        - Name: len
-          Offset: 8
-          Type: 8 BaseType int
-        - Name: cap
-          Offset: 16
-          Type: 8 BaseType int
-      Data: 253 GoSliceDataType []crypto/x509/pkix.Extension.array
-    - __kind: PointerType
-      ID: 85
-      Name: '*crypto/x509/pkix.Extension'
-      ByteSize: 8
-      GoRuntimeType: 443808
-      GoKind: 22
-      Pointee: 86 StructureType crypto/x509/pkix.Extension
-    - __kind: StructureType
-      ID: 86
-      Name: crypto/x509/pkix.Extension
-      ByteSize: 56
-      GoRuntimeType: 1.678176e+06
-      GoKind: 25
-      RawFields:
-        - Name: Id
-          Offset: 0
-          Type: 72 GoSliceHeaderType encoding/asn1.ObjectIdentifier
-        - Name: Critical
-          Offset: 24
-          Type: 13 BaseType bool
-        - Name: Value
-          Offset: 32
-          Type: 53 GoSliceHeaderType []uint8
-    - __kind: GoSliceHeaderType
-      ID: 87
-      Name: '[]encoding/asn1.ObjectIdentifier'
-      ByteSize: 24
-      GoRuntimeType: 518336
-      GoKind: 23
-      RawFields:
-        - Name: array
-          Offset: 0
-          Type: 88 PointerType *encoding/asn1.ObjectIdentifier
-        - Name: len
-          Offset: 8
-          Type: 8 BaseType int
-        - Name: cap
-          Offset: 16
-          Type: 8 BaseType int
-      Data: 255 GoSliceDataType []encoding/asn1.ObjectIdentifier.array
-    - __kind: PointerType
-      ID: 88
-      Name: '*encoding/asn1.ObjectIdentifier'
-      ByteSize: 8
-      GoRuntimeType: 1.074528e+06
-      GoKind: 22
-      Pointee: 72 GoSliceHeaderType encoding/asn1.ObjectIdentifier
-    - __kind: GoSliceHeaderType
-      ID: 89
-      Name: '[]crypto/x509.ExtKeyUsage'
-      ByteSize: 24
-      GoRuntimeType: 505152
-      GoKind: 23
-      RawFields:
-        - Name: array
-          Offset: 0
-          Type: 90 PointerType *crypto/x509.ExtKeyUsage
-        - Name: len
-          Offset: 8
-          Type: 8 BaseType int
-        - Name: cap
-          Offset: 16
-          Type: 8 BaseType int
-      Data: 257 GoSliceDataType []crypto/x509.ExtKeyUsage.array
-    - __kind: PointerType
-      ID: 90
-      Name: '*crypto/x509.ExtKeyUsage'
-      ByteSize: 8
-      GoRuntimeType: 426848
-      GoKind: 22
-      Pointee: 91 BaseType crypto/x509.ExtKeyUsage
-    - __kind: BaseType
-      ID: 91
-      Name: crypto/x509.ExtKeyUsage
-      ByteSize: 8
-      GoRuntimeType: 594272
-      GoKind: 2
-    - __kind: GoSliceHeaderType
-      ID: 92
-      Name: '[]net.IP'
-      ByteSize: 24
-      GoRuntimeType: 484768
-      GoKind: 23
-      RawFields:
-        - Name: array
-          Offset: 0
-          Type: 93 PointerType *net.IP
-        - Name: len
-          Offset: 8
-          Type: 8 BaseType int
-        - Name: cap
-          Offset: 16
-          Type: 8 BaseType int
-      Data: 259 GoSliceDataType []net.IP.array
-    - __kind: PointerType
-      ID: 93
-      Name: '*net.IP'
-      ByteSize: 8
-      GoRuntimeType: 2.197536e+06
-      GoKind: 22
-      Pointee: 94 GoSliceHeaderType net.IP
-    - __kind: GoSliceHeaderType
-      ID: 94
-      Name: net.IP
-      ByteSize: 24
-      GoRuntimeType: 2.170304e+06
-      GoKind: 23
-      RawFields:
-        - Name: array
-          Offset: 0
-          Type: 6 PointerType *uint8
-        - Name: len
-          Offset: 8
-          Type: 8 BaseType int
-        - Name: cap
-          Offset: 16
-          Type: 8 BaseType int
-      Data: 261 GoSliceDataType net.IP.array
-    - __kind: GoSliceHeaderType
-      ID: 95
-      Name: '[]*net/url.URL'
-      ByteSize: 24
-      GoRuntimeType: 518400
-      GoKind: 23
-      RawFields:
-        - Name: array
-          Offset: 0
-          Type: 96 PointerType **net/url.URL
-        - Name: len
-          Offset: 8
-          Type: 8 BaseType int
-        - Name: cap
-          Offset: 16
-          Type: 8 BaseType int
-      Data: 263 GoSliceDataType []*net/url.URL.array
-    - __kind: PointerType
-      ID: 96
-      Name: '**net/url.URL'
-      ByteSize: 8
-      Pointee: 9 PointerType *net/url.URL
-    - __kind: GoSliceHeaderType
-      ID: 97
-      Name: '[]*net.IPNet'
-      ByteSize: 24
-      GoRuntimeType: 518464
-      GoKind: 23
-      RawFields:
-        - Name: array
-          Offset: 0
-          Type: 98 PointerType **net.IPNet
-        - Name: len
-          Offset: 8
-          Type: 8 BaseType int
-        - Name: cap
-          Offset: 16
-          Type: 8 BaseType int
-      Data: 265 GoSliceDataType []*net.IPNet.array
-    - __kind: PointerType
-      ID: 98
-      Name: '**net.IPNet'
-      ByteSize: 8
-      GoKind: 22
-      Pointee: 99 PointerType *net.IPNet
-    - __kind: PointerType
-      ID: 99
-      Name: '*net.IPNet'
-      ByteSize: 8
-      GoRuntimeType: 1.203744e+06
-      GoKind: 22
-      Pointee: 100 StructureType net.IPNet
-    - __kind: StructureType
-      ID: 100
-      Name: net.IPNet
-      ByteSize: 48
-      GoRuntimeType: 1.48176e+06
-      GoKind: 25
-      RawFields:
-        - Name: IP
-          Offset: 0
-          Type: 94 GoSliceHeaderType net.IP
-        - Name: Mask
-          Offset: 24
-          Type: 101 GoSliceHeaderType net.IPMask
-    - __kind: GoSliceHeaderType
-      ID: 101
-      Name: net.IPMask
-      ByteSize: 24
-      GoRuntimeType: 1.037408e+06
-      GoKind: 23
-      RawFields:
-        - Name: array
-          Offset: 0
-          Type: 6 PointerType *uint8
-        - Name: len
-          Offset: 8
-          Type: 8 BaseType int
-        - Name: cap
-          Offset: 16
-          Type: 8 BaseType int
-      Data: 267 GoSliceDataType net.IPMask.array
-    - __kind: GoSliceHeaderType
-      ID: 102
-      Name: '[]crypto/x509.OID'
-      ByteSize: 24
-      GoRuntimeType: 518528
-      GoKind: 23
-      RawFields:
-        - Name: array
-          Offset: 0
-          Type: 103 PointerType *crypto/x509.OID
-        - Name: len
-          Offset: 8
-          Type: 8 BaseType int
-        - Name: cap
-          Offset: 16
-          Type: 8 BaseType int
-      Data: 269 GoSliceDataType []crypto/x509.OID.array
-    - __kind: PointerType
-      ID: 103
-      Name: '*crypto/x509.OID'
-      ByteSize: 8
-      GoRuntimeType: 1.988896e+06
-      GoKind: 22
-      Pointee: 104 StructureType crypto/x509.OID
-    - __kind: StructureType
-      ID: 104
-      Name: crypto/x509.OID
-      ByteSize: 24
-      GoRuntimeType: 1.989152e+06
-      GoKind: 25
-      RawFields:
-        - Name: der
-          Offset: 0
-          Type: 53 GoSliceHeaderType []uint8
-    - __kind: GoSliceHeaderType
-      ID: 105
-      Name: '[]crypto/x509.PolicyMapping'
-      ByteSize: 24
-      GoRuntimeType: 518592
-      GoKind: 23
-      RawFields:
-        - Name: array
-          Offset: 0
-          Type: 106 PointerType *crypto/x509.PolicyMapping
-        - Name: len
-          Offset: 8
-          Type: 8 BaseType int
-        - Name: cap
-          Offset: 16
-          Type: 8 BaseType int
-      Data: 271 GoSliceDataType []crypto/x509.PolicyMapping.array
-    - __kind: PointerType
-      ID: 106
-      Name: '*crypto/x509.PolicyMapping'
-      ByteSize: 8
-      GoRuntimeType: 426912
-      GoKind: 22
-      Pointee: 107 StructureType crypto/x509.PolicyMapping
-    - __kind: StructureType
-      ID: 107
-      Name: crypto/x509.PolicyMapping
-      ByteSize: 48
-      GoRuntimeType: 1.5144e+06
-      GoKind: 25
-      RawFields:
-        - Name: IssuerDomainPolicy
-          Offset: 0
-          Type: 104 StructureType crypto/x509.OID
-        - Name: SubjectDomainPolicy
-          Offset: 24
-          Type: 104 StructureType crypto/x509.OID
-    - __kind: GoSliceHeaderType
-      ID: 108
-      Name: '[][]*crypto/x509.Certificate'
-      ByteSize: 24
-      GoRuntimeType: 503808
-      GoKind: 23
-      RawFields:
-        - Name: array
-          Offset: 0
-          Type: 109 PointerType *[]*crypto/x509.Certificate
-        - Name: len
-          Offset: 8
-          Type: 8 BaseType int
-        - Name: cap
-          Offset: 16
-          Type: 8 BaseType int
-      Data: 273 GoSliceDataType [][]*crypto/x509.Certificate.array
-    - __kind: PointerType
-      ID: 109
-      Name: '*[]*crypto/x509.Certificate'
-      ByteSize: 8
-      GoKind: 22
-      Pointee: 56 GoSliceHeaderType []*crypto/x509.Certificate
-    - __kind: GoSliceHeaderType
-      ID: 110
-      Name: '[][]uint8'
-      ByteSize: 24
-      GoRuntimeType: 483808
-      GoKind: 23
-      RawFields:
-        - Name: array
-          Offset: 0
-          Type: 111 PointerType *[]uint8
-        - Name: len
-          Offset: 8
-          Type: 8 BaseType int
-        - Name: cap
-          Offset: 16
-          Type: 8 BaseType int
-      Data: 275 GoSliceDataType [][]uint8.array
-    - __kind: PointerType
-      ID: 111
-      Name: '*[]uint8'
-      ByteSize: 8
-      GoRuntimeType: 483424
-      GoKind: 22
-      Pointee: 53 GoSliceHeaderType []uint8
-    - __kind: GoSubroutineType
-      ID: 112
-      Name: func(string, []uint8, int) ([]uint8, error)
-      ByteSize: 8
-      GoRuntimeType: 1.020064e+06
-      GoKind: 19
-    - __kind: BaseType
-      ID: 113
-      Name: crypto/tls.CurveID
-      ByteSize: 2
-      GoRuntimeType: 843360
-      GoKind: 9
-    - __kind: GoChannelType
-      ID: 114
-      Name: <-chan struct {}
-      GoRuntimeType: 603232
-      GoKind: 18
-    - __kind: PointerType
-      ID: 115
-      Name: '*net/http.Response'
-      ByteSize: 8
-      GoRuntimeType: 1.75088e+06
-      GoKind: 22
-      Pointee: 116 StructureType net/http.Response
-    - __kind: StructureType
-      ID: 116
-      Name: net/http.Response
-      ByteSize: 144
-      GoRuntimeType: 2.25968e+06
-      GoKind: 25
-      RawFields:
-        - Name: Status
-          Offset: 0
-          Type: 5 GoStringHeaderType string
-        - Name: StatusCode
-          Offset: 16
-          Type: 8 BaseType int
-        - Name: Proto
-          Offset: 24
-          Type: 5 GoStringHeaderType string
-        - Name: ProtoMajor
-          Offset: 40
-          Type: 8 BaseType int
-        - Name: ProtoMinor
-          Offset: 48
-          Type: 8 BaseType int
-        - Name: Header
-          Offset: 56
-          Type: 14 GoMapType net/http.Header
-        - Name: Body
-          Offset: 64
-          Type: 30 GoInterfaceType io.ReadCloser
-        - Name: ContentLength
-          Offset: 80
-          Type: 32 BaseType int64
-        - Name: TransferEncoding
-          Offset: 88
-          Type: 28 GoSliceHeaderType []string
-        - Name: Close
-          Offset: 112
-          Type: 13 BaseType bool
-        - Name: Uncompressed
-          Offset: 113
-          Type: 13 BaseType bool
-        - Name: Trailer
-          Offset: 120
-          Type: 14 GoMapType net/http.Header
-        - Name: Request
-          Offset: 128
-          Type: 3 PointerType *net/http.Request
-        - Name: TLS
-          Offset: 136
-          Type: 54 PointerType *crypto/tls.ConnectionState
+    - __kind: GoSliceDataType
+      ID: 247
+      Name: encoding/asn1.ObjectIdentifier.array
+      ByteSize: 2048
+      Element: 8 BaseType int
     - __kind: GoInterfaceType
-      ID: 117
-      Name: context.Context
+      ID: 212
+      Name: error
       ByteSize: 16
-      GoRuntimeType: 1.298016e+06
+      GoRuntimeType: 1.049312e+06
       GoKind: 20
       RawFields:
         - Name: tab
@@ -1763,214 +1774,36 @@ Types:
         - Name: data
           Offset: 8
           Type: 2 VoidPointerType unsafe.Pointer
-    - __kind: PointerType
-      ID: 118
-      Name: '*net/http.pattern'
+    - __kind: BaseType
+      ID: 214
+      Name: float32
+      ByteSize: 4
+      GoRuntimeType: 591072
+      GoKind: 13
+    - __kind: BaseType
+      ID: 166
+      Name: float64
       ByteSize: 8
-      GoRuntimeType: 1.63728e+06
-      GoKind: 22
-      Pointee: 119 StructureType net/http.pattern
-    - __kind: StructureType
-      ID: 119
-      Name: net/http.pattern
-      ByteSize: 88
-      GoRuntimeType: 1.865856e+06
-      GoKind: 25
-      RawFields:
-        - Name: str
-          Offset: 0
-          Type: 5 GoStringHeaderType string
-        - Name: method
-          Offset: 16
-          Type: 5 GoStringHeaderType string
-        - Name: host
-          Offset: 32
-          Type: 5 GoStringHeaderType string
-        - Name: segments
-          Offset: 48
-          Type: 120 GoSliceHeaderType []net/http.segment
-        - Name: loc
-          Offset: 72
-          Type: 5 GoStringHeaderType string
-    - __kind: GoSliceHeaderType
-      ID: 120
-      Name: '[]net/http.segment'
-      ByteSize: 24
-      GoRuntimeType: 486400
-      GoKind: 23
-      RawFields:
-        - Name: array
-          Offset: 0
-          Type: 121 PointerType *net/http.segment
-        - Name: len
-          Offset: 8
-          Type: 8 BaseType int
-        - Name: cap
-          Offset: 16
-          Type: 8 BaseType int
-      Data: 277 GoSliceDataType []net/http.segment.array
-    - __kind: PointerType
-      ID: 121
-      Name: '*net/http.segment'
+      GoRuntimeType: 591136
+      GoKind: 14
+    - __kind: GoSubroutineType
+      ID: 204
+      Name: func()
       ByteSize: 8
-      GoRuntimeType: 393440
-      GoKind: 22
-      Pointee: 122 StructureType net/http.segment
-    - __kind: StructureType
-      ID: 122
-      Name: net/http.segment
-      ByteSize: 24
-      GoRuntimeType: 1.637088e+06
-      GoKind: 25
-      RawFields:
-        - Name: s
-          Offset: 0
-          Type: 5 GoStringHeaderType string
-        - Name: wild
-          Offset: 16
-          Type: 13 BaseType bool
-        - Name: multi
-          Offset: 17
-          Type: 13 BaseType bool
-    - __kind: GoMapType
-      ID: 123
-      Name: map[string]string
+      GoRuntimeType: 481952
+      GoKind: 19
+    - __kind: GoSubroutineType
+      ID: 31
+      Name: func() (io.ReadCloser, error)
       ByteSize: 8
-      GoRuntimeType: 1.148704e+06
-      GoKind: 21
-      HeaderType: 125 GoSwissMapHeaderType map<string,string>
-    - __kind: PointerType
-      ID: 124
-      Name: '*map<string,string>'
+      GoRuntimeType: 701088
+      GoKind: 19
+    - __kind: GoSubroutineType
+      ID: 112
+      Name: func(string, []uint8, int) ([]uint8, error)
       ByteSize: 8
-      Pointee: 125 GoSwissMapHeaderType map<string,string>
-    - __kind: GoSwissMapHeaderType
-      ID: 125
-      Name: map<string,string>
-      ByteSize: 48
-      GoKind: 25
-      RawFields:
-        - Name: used
-          Offset: 0
-          Type: 17 BaseType uint64
-        - Name: seed
-          Offset: 8
-          Type: 18 BaseType uintptr
-        - Name: dirPtr
-          Offset: 16
-          Type: 126 PointerType **table<string,string>
-        - Name: dirLen
-          Offset: 24
-          Type: 8 BaseType int
-        - Name: globalDepth
-          Offset: 32
-          Type: 7 BaseType uint8
-        - Name: globalShift
-          Offset: 33
-          Type: 7 BaseType uint8
-        - Name: writing
-          Offset: 34
-          Type: 7 BaseType uint8
-        - Name: clearSeq
-          Offset: 40
-          Type: 17 BaseType uint64
-      TablePtrSliceType: 279 GoSliceDataType []*table<string,string>.array
-      GroupType: 131 StructureType noalg.map.group[string]string
-    - __kind: PointerType
-      ID: 126
-      Name: '**table<string,string>'
-      ByteSize: 8
-      Pointee: 127 PointerType *table<string,string>
-    - __kind: PointerType
-      ID: 127
-      Name: '*table<string,string>'
-      ByteSize: 8
-      Pointee: 128 StructureType table<string,string>
-    - __kind: StructureType
-      ID: 128
-      Name: table<string,string>
-      ByteSize: 32
-      GoKind: 25
-      RawFields:
-        - Name: used
-          Offset: 0
-          Type: 22 BaseType uint16
-        - Name: capacity
-          Offset: 2
-          Type: 22 BaseType uint16
-        - Name: growthLeft
-          Offset: 4
-          Type: 22 BaseType uint16
-        - Name: localDepth
-          Offset: 6
-          Type: 7 BaseType uint8
-        - Name: index
-          Offset: 8
-          Type: 8 BaseType int
-        - Name: groups
-          Offset: 16
-          Type: 129 GoSwissMapGroupsType groupReference<string,string>
-    - __kind: GoSwissMapGroupsType
-      ID: 129
-      Name: groupReference<string,string>
-      ByteSize: 16
-      GoKind: 25
-      RawFields:
-        - Name: data
-          Offset: 0
-          Type: 130 PointerType *noalg.map.group[string]string
-        - Name: lengthMask
-          Offset: 8
-          Type: 17 BaseType uint64
-      GroupType: 131 StructureType noalg.map.group[string]string
-      GroupSliceType: 280 GoSliceDataType []noalg.map.group[string]string.array
-    - __kind: PointerType
-      ID: 130
-      Name: '*noalg.map.group[string]string'
-      ByteSize: 8
-      Pointee: 131 StructureType noalg.map.group[string]string
-    - __kind: StructureType
-      ID: 131
-      Name: noalg.map.group[string]string
-      ByteSize: 264
-      GoRuntimeType: 1.31376e+06
-      GoKind: 25
-      RawFields:
-        - Name: ctrl
-          Offset: 0
-          Type: 17 BaseType uint64
-        - Name: slots
-          Offset: 8
-          Type: 132 ArrayType noalg.[8]struct { key string; elem string }
-    - __kind: ArrayType
-      ID: 132
-      Name: noalg.[8]struct { key string; elem string }
-      ByteSize: 256
-      GoRuntimeType: 701280
-      GoKind: 17
-      Count: 8
-      HasCount: true
-      Element: 133 StructureType noalg.struct { key string; elem string }
-    - __kind: StructureType
-      ID: 133
-      Name: noalg.struct { key string; elem string }
-      ByteSize: 32
-      GoRuntimeType: 1.313632e+06
-      GoKind: 25
-      RawFields:
-        - Name: key
-          Offset: 0
-          Type: 5 GoStringHeaderType string
-        - Name: elem
-          Offset: 16
-          Type: 5 GoStringHeaderType string
-    - __kind: PointerType
-      ID: 134
-      Name: '*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span'
-      ByteSize: 8
-      GoRuntimeType: 2.326784e+06
-      GoKind: 22
-      Pointee: 135 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span
+      GoRuntimeType: 1.020064e+06
+      GoKind: 19
     - __kind: StructureType
       ID: 135
       Name: github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span
@@ -2054,712 +1887,6 @@ Types:
           Offset: 280
           Type: 204 GoSubroutineType func()
     - __kind: StructureType
-      ID: 136
-      Name: sync.RWMutex
-      ByteSize: 24
-      GoRuntimeType: 1.87168e+06
-      GoKind: 25
-      RawFields:
-        - Name: w
-          Offset: 0
-          Type: 137 StructureType sync.Mutex
-        - Name: writerSem
-          Offset: 8
-          Type: 141 BaseType uint32
-        - Name: readerSem
-          Offset: 12
-          Type: 141 BaseType uint32
-        - Name: readerCount
-          Offset: 16
-          Type: 142 StructureType sync/atomic.Int32
-        - Name: readerWait
-          Offset: 20
-          Type: 142 StructureType sync/atomic.Int32
-    - __kind: StructureType
-      ID: 137
-      Name: sync.Mutex
-      ByteSize: 8
-      GoRuntimeType: 1.48896e+06
-      GoKind: 25
-      RawFields:
-        - Name: _
-          Offset: 0
-          Type: 138 StructureType sync.noCopy
-        - Name: mu
-          Offset: 0
-          Type: 139 StructureType internal/sync.Mutex
-    - __kind: StructureType
-      ID: 138
-      Name: sync.noCopy
-      GoRuntimeType: 1.0024e+06
-      GoKind: 25
-      RawFields: []
-    - __kind: StructureType
-      ID: 139
-      Name: internal/sync.Mutex
-      ByteSize: 8
-      GoRuntimeType: 1.51232e+06
-      GoKind: 25
-      RawFields:
-        - Name: state
-          Offset: 0
-          Type: 140 BaseType int32
-        - Name: sema
-          Offset: 4
-          Type: 141 BaseType uint32
-    - __kind: BaseType
-      ID: 140
-      Name: int32
-      ByteSize: 4
-      GoRuntimeType: 590496
-      GoKind: 5
-    - __kind: BaseType
-      ID: 141
-      Name: uint32
-      ByteSize: 4
-      GoRuntimeType: 590560
-      GoKind: 10
-    - __kind: StructureType
-      ID: 142
-      Name: sync/atomic.Int32
-      ByteSize: 4
-      GoRuntimeType: 1.49024e+06
-      GoKind: 25
-      RawFields:
-        - Name: _
-          Offset: 0
-          Type: 143 StructureType sync/atomic.noCopy
-        - Name: v
-          Offset: 0
-          Type: 140 BaseType int32
-    - __kind: StructureType
-      ID: 143
-      Name: sync/atomic.noCopy
-      GoRuntimeType: 1.002496e+06
-      GoKind: 25
-      RawFields: []
-    - __kind: GoMapType
-      ID: 144
-      Name: github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.metaStructMap
-      ByteSize: 8
-      GoRuntimeType: 1.299296e+06
-      GoKind: 21
-      HeaderType: 146 GoSwissMapHeaderType map<string,interface {}>
-    - __kind: PointerType
-      ID: 145
-      Name: '*map<string,interface {}>'
-      ByteSize: 8
-      Pointee: 146 GoSwissMapHeaderType map<string,interface {}>
-    - __kind: GoSwissMapHeaderType
-      ID: 146
-      Name: map<string,interface {}>
-      ByteSize: 48
-      GoKind: 25
-      RawFields:
-        - Name: used
-          Offset: 0
-          Type: 17 BaseType uint64
-        - Name: seed
-          Offset: 8
-          Type: 18 BaseType uintptr
-        - Name: dirPtr
-          Offset: 16
-          Type: 147 PointerType **table<string,interface {}>
-        - Name: dirLen
-          Offset: 24
-          Type: 8 BaseType int
-        - Name: globalDepth
-          Offset: 32
-          Type: 7 BaseType uint8
-        - Name: globalShift
-          Offset: 33
-          Type: 7 BaseType uint8
-        - Name: writing
-          Offset: 34
-          Type: 7 BaseType uint8
-        - Name: clearSeq
-          Offset: 40
-          Type: 17 BaseType uint64
-      TablePtrSliceType: 281 GoSliceDataType []*table<string,interface {}>.array
-      GroupType: 152 StructureType noalg.map.group[string]interface {}
-    - __kind: PointerType
-      ID: 147
-      Name: '**table<string,interface {}>'
-      ByteSize: 8
-      Pointee: 148 PointerType *table<string,interface {}>
-    - __kind: PointerType
-      ID: 148
-      Name: '*table<string,interface {}>'
-      ByteSize: 8
-      Pointee: 149 StructureType table<string,interface {}>
-    - __kind: StructureType
-      ID: 149
-      Name: table<string,interface {}>
-      ByteSize: 32
-      GoKind: 25
-      RawFields:
-        - Name: used
-          Offset: 0
-          Type: 22 BaseType uint16
-        - Name: capacity
-          Offset: 2
-          Type: 22 BaseType uint16
-        - Name: growthLeft
-          Offset: 4
-          Type: 22 BaseType uint16
-        - Name: localDepth
-          Offset: 6
-          Type: 7 BaseType uint8
-        - Name: index
-          Offset: 8
-          Type: 8 BaseType int
-        - Name: groups
-          Offset: 16
-          Type: 150 GoSwissMapGroupsType groupReference<string,interface {}>
-    - __kind: GoSwissMapGroupsType
-      ID: 150
-      Name: groupReference<string,interface {}>
-      ByteSize: 16
-      GoKind: 25
-      RawFields:
-        - Name: data
-          Offset: 0
-          Type: 151 PointerType *noalg.map.group[string]interface {}
-        - Name: lengthMask
-          Offset: 8
-          Type: 17 BaseType uint64
-      GroupType: 152 StructureType noalg.map.group[string]interface {}
-      GroupSliceType: 282 GoSliceDataType []noalg.map.group[string]interface {}.array
-    - __kind: PointerType
-      ID: 151
-      Name: '*noalg.map.group[string]interface {}'
-      ByteSize: 8
-      Pointee: 152 StructureType noalg.map.group[string]interface {}
-    - __kind: StructureType
-      ID: 152
-      Name: noalg.map.group[string]interface {}
-      ByteSize: 264
-      GoRuntimeType: 1.308896e+06
-      GoKind: 25
-      RawFields:
-        - Name: ctrl
-          Offset: 0
-          Type: 17 BaseType uint64
-        - Name: slots
-          Offset: 8
-          Type: 153 ArrayType noalg.[8]struct { key string; elem interface {} }
-    - __kind: ArrayType
-      ID: 153
-      Name: noalg.[8]struct { key string; elem interface {} }
-      ByteSize: 256
-      GoRuntimeType: 688576
-      GoKind: 17
-      Count: 8
-      HasCount: true
-      Element: 154 StructureType noalg.struct { key string; elem interface {} }
-    - __kind: StructureType
-      ID: 154
-      Name: noalg.struct { key string; elem interface {} }
-      ByteSize: 32
-      GoRuntimeType: 1.308768e+06
-      GoKind: 25
-      RawFields:
-        - Name: key
-          Offset: 0
-          Type: 5 GoStringHeaderType string
-        - Name: elem
-          Offset: 16
-          Type: 62 GoEmptyInterfaceType interface {}
-    - __kind: GoMapType
-      ID: 155
-      Name: map[string]float64
-      ByteSize: 8
-      GoRuntimeType: 1.152928e+06
-      GoKind: 21
-      HeaderType: 157 GoSwissMapHeaderType map<string,float64>
-    - __kind: PointerType
-      ID: 156
-      Name: '*map<string,float64>'
-      ByteSize: 8
-      Pointee: 157 GoSwissMapHeaderType map<string,float64>
-    - __kind: GoSwissMapHeaderType
-      ID: 157
-      Name: map<string,float64>
-      ByteSize: 48
-      GoKind: 25
-      RawFields:
-        - Name: used
-          Offset: 0
-          Type: 17 BaseType uint64
-        - Name: seed
-          Offset: 8
-          Type: 18 BaseType uintptr
-        - Name: dirPtr
-          Offset: 16
-          Type: 158 PointerType **table<string,float64>
-        - Name: dirLen
-          Offset: 24
-          Type: 8 BaseType int
-        - Name: globalDepth
-          Offset: 32
-          Type: 7 BaseType uint8
-        - Name: globalShift
-          Offset: 33
-          Type: 7 BaseType uint8
-        - Name: writing
-          Offset: 34
-          Type: 7 BaseType uint8
-        - Name: clearSeq
-          Offset: 40
-          Type: 17 BaseType uint64
-      TablePtrSliceType: 283 GoSliceDataType []*table<string,float64>.array
-      GroupType: 163 StructureType noalg.map.group[string]float64
-    - __kind: PointerType
-      ID: 158
-      Name: '**table<string,float64>'
-      ByteSize: 8
-      Pointee: 159 PointerType *table<string,float64>
-    - __kind: PointerType
-      ID: 159
-      Name: '*table<string,float64>'
-      ByteSize: 8
-      Pointee: 160 StructureType table<string,float64>
-    - __kind: StructureType
-      ID: 160
-      Name: table<string,float64>
-      ByteSize: 32
-      GoKind: 25
-      RawFields:
-        - Name: used
-          Offset: 0
-          Type: 22 BaseType uint16
-        - Name: capacity
-          Offset: 2
-          Type: 22 BaseType uint16
-        - Name: growthLeft
-          Offset: 4
-          Type: 22 BaseType uint16
-        - Name: localDepth
-          Offset: 6
-          Type: 7 BaseType uint8
-        - Name: index
-          Offset: 8
-          Type: 8 BaseType int
-        - Name: groups
-          Offset: 16
-          Type: 161 GoSwissMapGroupsType groupReference<string,float64>
-    - __kind: GoSwissMapGroupsType
-      ID: 161
-      Name: groupReference<string,float64>
-      ByteSize: 16
-      GoKind: 25
-      RawFields:
-        - Name: data
-          Offset: 0
-          Type: 162 PointerType *noalg.map.group[string]float64
-        - Name: lengthMask
-          Offset: 8
-          Type: 17 BaseType uint64
-      GroupType: 163 StructureType noalg.map.group[string]float64
-      GroupSliceType: 284 GoSliceDataType []noalg.map.group[string]float64.array
-    - __kind: PointerType
-      ID: 162
-      Name: '*noalg.map.group[string]float64'
-      ByteSize: 8
-      Pointee: 163 StructureType noalg.map.group[string]float64
-    - __kind: StructureType
-      ID: 163
-      Name: noalg.map.group[string]float64
-      ByteSize: 200
-      GoRuntimeType: 1.326944e+06
-      GoKind: 25
-      RawFields:
-        - Name: ctrl
-          Offset: 0
-          Type: 17 BaseType uint64
-        - Name: slots
-          Offset: 8
-          Type: 164 ArrayType noalg.[8]struct { key string; elem float64 }
-    - __kind: ArrayType
-      ID: 164
-      Name: noalg.[8]struct { key string; elem float64 }
-      ByteSize: 192
-      GoRuntimeType: 711616
-      GoKind: 17
-      Count: 8
-      HasCount: true
-      Element: 165 StructureType noalg.struct { key string; elem float64 }
-    - __kind: StructureType
-      ID: 165
-      Name: noalg.struct { key string; elem float64 }
-      ByteSize: 24
-      GoRuntimeType: 1.326816e+06
-      GoKind: 25
-      RawFields:
-        - Name: key
-          Offset: 0
-          Type: 5 GoStringHeaderType string
-        - Name: elem
-          Offset: 16
-          Type: 166 BaseType float64
-    - __kind: BaseType
-      ID: 166
-      Name: float64
-      ByteSize: 8
-      GoRuntimeType: 591136
-      GoKind: 14
-    - __kind: GoSliceHeaderType
-      ID: 167
-      Name: '[]github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink'
-      ByteSize: 24
-      GoRuntimeType: 491392
-      GoKind: 23
-      RawFields:
-        - Name: array
-          Offset: 0
-          Type: 168 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink
-        - Name: len
-          Offset: 8
-          Type: 8 BaseType int
-        - Name: cap
-          Offset: 16
-          Type: 8 BaseType int
-      Data: 285 GoSliceDataType []github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink.array
-    - __kind: PointerType
-      ID: 168
-      Name: '*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink'
-      ByteSize: 8
-      GoRuntimeType: 1.210016e+06
-      GoKind: 22
-      Pointee: 169 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink
-    - __kind: StructureType
-      ID: 169
-      Name: github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink
-      ByteSize: 56
-      GoRuntimeType: 1.9464e+06
-      GoKind: 25
-      RawFields:
-        - Name: TraceID
-          Offset: 0
-          Type: 17 BaseType uint64
-        - Name: TraceIDHigh
-          Offset: 8
-          Type: 17 BaseType uint64
-        - Name: SpanID
-          Offset: 16
-          Type: 17 BaseType uint64
-        - Name: Attributes
-          Offset: 24
-          Type: 123 GoMapType map[string]string
-        - Name: Tracestate
-          Offset: 32
-          Type: 5 GoStringHeaderType string
-        - Name: Flags
-          Offset: 48
-          Type: 141 BaseType uint32
-    - __kind: GoSliceHeaderType
-      ID: 170
-      Name: '[]github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent'
-      ByteSize: 24
-      GoRuntimeType: 491584
-      GoKind: 23
-      RawFields:
-        - Name: array
-          Offset: 0
-          Type: 171 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent
-        - Name: len
-          Offset: 8
-          Type: 8 BaseType int
-        - Name: cap
-          Offset: 16
-          Type: 8 BaseType int
-      Data: 287 GoSliceDataType []github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent.array
-    - __kind: PointerType
-      ID: 171
-      Name: '*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent'
-      ByteSize: 8
-      GoRuntimeType: 1.210144e+06
-      GoKind: 22
-      Pointee: 172 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent
-    - __kind: StructureType
-      ID: 172
-      Name: github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent
-      ByteSize: 40
-      GoRuntimeType: 1.781184e+06
-      GoKind: 25
-      RawFields:
-        - Name: Name
-          Offset: 0
-          Type: 5 GoStringHeaderType string
-        - Name: TimeUnixNano
-          Offset: 16
-          Type: 17 BaseType uint64
-        - Name: Attributes
-          Offset: 24
-          Type: 173 GoMapType map[string]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
-        - Name: RawAttributes
-          Offset: 32
-          Type: 194 GoMapType map[string]interface {}
-    - __kind: GoMapType
-      ID: 173
-      Name: map[string]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
-      ByteSize: 8
-      GoRuntimeType: 1.153056e+06
-      GoKind: 21
-      HeaderType: 175 GoSwissMapHeaderType map<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
-    - __kind: PointerType
-      ID: 174
-      Name: '*map<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>'
-      ByteSize: 8
-      Pointee: 175 GoSwissMapHeaderType map<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
-    - __kind: GoSwissMapHeaderType
-      ID: 175
-      Name: map<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
-      ByteSize: 48
-      GoKind: 25
-      RawFields:
-        - Name: used
-          Offset: 0
-          Type: 17 BaseType uint64
-        - Name: seed
-          Offset: 8
-          Type: 18 BaseType uintptr
-        - Name: dirPtr
-          Offset: 16
-          Type: 176 PointerType **table<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
-        - Name: dirLen
-          Offset: 24
-          Type: 8 BaseType int
-        - Name: globalDepth
-          Offset: 32
-          Type: 7 BaseType uint8
-        - Name: globalShift
-          Offset: 33
-          Type: 7 BaseType uint8
-        - Name: writing
-          Offset: 34
-          Type: 7 BaseType uint8
-        - Name: clearSeq
-          Offset: 40
-          Type: 17 BaseType uint64
-      TablePtrSliceType: 289 GoSliceDataType []*table<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>.array
-      GroupType: 181 StructureType noalg.map.group[string]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
-    - __kind: PointerType
-      ID: 176
-      Name: '**table<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>'
-      ByteSize: 8
-      Pointee: 177 PointerType *table<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
-    - __kind: PointerType
-      ID: 177
-      Name: '*table<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>'
-      ByteSize: 8
-      Pointee: 178 StructureType table<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
-    - __kind: StructureType
-      ID: 178
-      Name: table<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
-      ByteSize: 32
-      GoKind: 25
-      RawFields:
-        - Name: used
-          Offset: 0
-          Type: 22 BaseType uint16
-        - Name: capacity
-          Offset: 2
-          Type: 22 BaseType uint16
-        - Name: growthLeft
-          Offset: 4
-          Type: 22 BaseType uint16
-        - Name: localDepth
-          Offset: 6
-          Type: 7 BaseType uint8
-        - Name: index
-          Offset: 8
-          Type: 8 BaseType int
-        - Name: groups
-          Offset: 16
-          Type: 179 GoSwissMapGroupsType groupReference<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
-    - __kind: GoSwissMapGroupsType
-      ID: 179
-      Name: groupReference<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
-      ByteSize: 16
-      GoKind: 25
-      RawFields:
-        - Name: data
-          Offset: 0
-          Type: 180 PointerType *noalg.map.group[string]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
-        - Name: lengthMask
-          Offset: 8
-          Type: 17 BaseType uint64
-      GroupType: 181 StructureType noalg.map.group[string]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
-      GroupSliceType: 290 GoSliceDataType []noalg.map.group[string]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute.array
-    - __kind: PointerType
-      ID: 180
-      Name: '*noalg.map.group[string]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute'
-      ByteSize: 8
-      Pointee: 181 StructureType noalg.map.group[string]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
-    - __kind: StructureType
-      ID: 181
-      Name: noalg.map.group[string]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
-      ByteSize: 200
-      GoRuntimeType: 1.3272e+06
-      GoKind: 25
-      RawFields:
-        - Name: ctrl
-          Offset: 0
-          Type: 17 BaseType uint64
-        - Name: slots
-          Offset: 8
-          Type: 182 ArrayType noalg.[8]struct { key string; elem *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute }
-    - __kind: ArrayType
-      ID: 182
-      Name: noalg.[8]struct { key string; elem *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute }
-      ByteSize: 192
-      GoRuntimeType: 711712
-      GoKind: 17
-      Count: 8
-      HasCount: true
-      Element: 183 StructureType noalg.struct { key string; elem *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute }
-    - __kind: StructureType
-      ID: 183
-      Name: noalg.struct { key string; elem *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute }
-      ByteSize: 24
-      GoRuntimeType: 1.327072e+06
-      GoKind: 25
-      RawFields:
-        - Name: key
-          Offset: 0
-          Type: 5 GoStringHeaderType string
-        - Name: elem
-          Offset: 16
-          Type: 184 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
-    - __kind: PointerType
-      ID: 184
-      Name: '*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute'
-      ByteSize: 8
-      GoRuntimeType: 1.210912e+06
-      GoKind: 22
-      Pointee: 185 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
-    - __kind: StructureType
-      ID: 185
-      Name: github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
-      ByteSize: 56
-      GoRuntimeType: 1.946656e+06
-      GoKind: 25
-      RawFields:
-        - Name: Type
-          Offset: 0
-          Type: 186 BaseType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttributeType
-        - Name: StringValue
-          Offset: 8
-          Type: 5 GoStringHeaderType string
-        - Name: BoolValue
-          Offset: 24
-          Type: 13 BaseType bool
-        - Name: IntValue
-          Offset: 32
-          Type: 32 BaseType int64
-        - Name: DoubleValue
-          Offset: 40
-          Type: 166 BaseType float64
-        - Name: ArrayValue
-          Offset: 48
-          Type: 187 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttribute
-    - __kind: BaseType
-      ID: 186
-      Name: github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttributeType
-      ByteSize: 4
-      GoRuntimeType: 1.001728e+06
-      GoKind: 5
-    - __kind: PointerType
-      ID: 187
-      Name: '*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttribute'
-      ByteSize: 8
-      GoRuntimeType: 1.210784e+06
-      GoKind: 22
-      Pointee: 188 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttribute
-    - __kind: StructureType
-      ID: 188
-      Name: github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttribute
-      ByteSize: 24
-      GoRuntimeType: 1.210656e+06
-      GoKind: 25
-      RawFields:
-        - Name: Values
-          Offset: 0
-          Type: 189 GoSliceHeaderType []*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttributeValue
-    - __kind: GoSliceHeaderType
-      ID: 189
-      Name: '[]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttributeValue'
-      ByteSize: 24
-      GoRuntimeType: 491456
-      GoKind: 23
-      RawFields:
-        - Name: array
-          Offset: 0
-          Type: 190 PointerType **github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttributeValue
-        - Name: len
-          Offset: 8
-          Type: 8 BaseType int
-        - Name: cap
-          Offset: 16
-          Type: 8 BaseType int
-      Data: 291 GoSliceDataType []*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttributeValue.array
-    - __kind: PointerType
-      ID: 190
-      Name: '**github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttributeValue'
-      ByteSize: 8
-      GoKind: 22
-      Pointee: 191 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttributeValue
-    - __kind: PointerType
-      ID: 191
-      Name: '*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttributeValue'
-      ByteSize: 8
-      GoRuntimeType: 1.210528e+06
-      GoKind: 22
-      Pointee: 192 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttributeValue
-    - __kind: StructureType
-      ID: 192
-      Name: github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttributeValue
-      ByteSize: 48
-      GoRuntimeType: 1.868992e+06
-      GoKind: 25
-      RawFields:
-        - Name: Type
-          Offset: 0
-          Type: 193 BaseType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttributeValueType
-        - Name: StringValue
-          Offset: 8
-          Type: 5 GoStringHeaderType string
-        - Name: BoolValue
-          Offset: 24
-          Type: 13 BaseType bool
-        - Name: IntValue
-          Offset: 32
-          Type: 32 BaseType int64
-        - Name: DoubleValue
-          Offset: 40
-          Type: 166 BaseType float64
-    - __kind: BaseType
-      ID: 193
-      Name: github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttributeValueType
-      ByteSize: 4
-      GoRuntimeType: 1.001824e+06
-      GoKind: 5
-    - __kind: GoMapType
-      ID: 194
-      Name: map[string]interface {}
-      ByteSize: 8
-      GoRuntimeType: 1.146272e+06
-      GoKind: 21
-      HeaderType: 146 GoSwissMapHeaderType map<string,interface {}>
-    - __kind: PointerType
-      ID: 195
-      Name: '*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanContext'
-      ByteSize: 8
-      GoRuntimeType: 2.045472e+06
-      GoKind: 22
-      Pointee: 196 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanContext
-    - __kind: StructureType
       ID: 196
       Name: github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanContext
       ByteSize: 168
@@ -2808,13 +1935,132 @@ Types:
         - Name: baggageOnly
           Offset: 160
           Type: 13 BaseType bool
-    - __kind: PointerType
-      ID: 197
-      Name: '*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.trace'
+    - __kind: StructureType
+      ID: 169
+      Name: github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink
+      ByteSize: 56
+      GoRuntimeType: 1.9464e+06
+      GoKind: 25
+      RawFields:
+        - Name: TraceID
+          Offset: 0
+          Type: 17 BaseType uint64
+        - Name: TraceIDHigh
+          Offset: 8
+          Type: 17 BaseType uint64
+        - Name: SpanID
+          Offset: 16
+          Type: 17 BaseType uint64
+        - Name: Attributes
+          Offset: 24
+          Type: 123 GoMapType map[string]string
+        - Name: Tracestate
+          Offset: 32
+          Type: 5 GoStringHeaderType string
+        - Name: Flags
+          Offset: 48
+          Type: 141 BaseType uint32
+    - __kind: GoMapType
+      ID: 144
+      Name: github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.metaStructMap
       ByteSize: 8
-      GoRuntimeType: 2.269504e+06
-      GoKind: 22
-      Pointee: 198 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.trace
+      GoRuntimeType: 1.299296e+06
+      GoKind: 21
+      HeaderType: 146 GoSwissMapHeaderType map<string,interface {}>
+    - __kind: BaseType
+      ID: 202
+      Name: github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.samplingDecision
+      ByteSize: 4
+      GoRuntimeType: 589984
+      GoKind: 10
+    - __kind: StructureType
+      ID: 172
+      Name: github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent
+      ByteSize: 40
+      GoRuntimeType: 1.781184e+06
+      GoKind: 25
+      RawFields:
+        - Name: Name
+          Offset: 0
+          Type: 5 GoStringHeaderType string
+        - Name: TimeUnixNano
+          Offset: 16
+          Type: 17 BaseType uint64
+        - Name: Attributes
+          Offset: 24
+          Type: 173 GoMapType map[string]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
+        - Name: RawAttributes
+          Offset: 32
+          Type: 194 GoMapType map[string]interface {}
+    - __kind: StructureType
+      ID: 188
+      Name: github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttribute
+      ByteSize: 24
+      GoRuntimeType: 1.210656e+06
+      GoKind: 25
+      RawFields:
+        - Name: Values
+          Offset: 0
+          Type: 189 GoSliceHeaderType []*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttributeValue
+    - __kind: StructureType
+      ID: 192
+      Name: github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttributeValue
+      ByteSize: 48
+      GoRuntimeType: 1.868992e+06
+      GoKind: 25
+      RawFields:
+        - Name: Type
+          Offset: 0
+          Type: 193 BaseType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttributeValueType
+        - Name: StringValue
+          Offset: 8
+          Type: 5 GoStringHeaderType string
+        - Name: BoolValue
+          Offset: 24
+          Type: 13 BaseType bool
+        - Name: IntValue
+          Offset: 32
+          Type: 32 BaseType int64
+        - Name: DoubleValue
+          Offset: 40
+          Type: 166 BaseType float64
+    - __kind: BaseType
+      ID: 193
+      Name: github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttributeValueType
+      ByteSize: 4
+      GoRuntimeType: 1.001824e+06
+      GoKind: 5
+    - __kind: StructureType
+      ID: 185
+      Name: github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
+      ByteSize: 56
+      GoRuntimeType: 1.946656e+06
+      GoKind: 25
+      RawFields:
+        - Name: Type
+          Offset: 0
+          Type: 186 BaseType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttributeType
+        - Name: StringValue
+          Offset: 8
+          Type: 5 GoStringHeaderType string
+        - Name: BoolValue
+          Offset: 24
+          Type: 13 BaseType bool
+        - Name: IntValue
+          Offset: 32
+          Type: 32 BaseType int64
+        - Name: DoubleValue
+          Offset: 40
+          Type: 166 BaseType float64
+        - Name: ArrayValue
+          Offset: 48
+          Type: 187 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttribute
+    - __kind: BaseType
+      ID: 186
+      Name: github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttributeType
+      ByteSize: 4
+      GoRuntimeType: 1.001728e+06
+      GoKind: 5
     - __kind: StructureType
       ID: 198
       Name: github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.trace
@@ -2852,42 +2098,6 @@ Types:
         - Name: root
           Offset: 96
           Type: 134 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span
-    - __kind: GoSliceHeaderType
-      ID: 199
-      Name: '[]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span'
-      ByteSize: 24
-      GoRuntimeType: 491840
-      GoKind: 23
-      RawFields:
-        - Name: array
-          Offset: 0
-          Type: 200 PointerType **github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span
-        - Name: len
-          Offset: 8
-          Type: 8 BaseType int
-        - Name: cap
-          Offset: 16
-          Type: 8 BaseType int
-      Data: 293 GoSliceDataType []*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span.array
-    - __kind: PointerType
-      ID: 200
-      Name: '**github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span'
-      ByteSize: 8
-      GoKind: 22
-      Pointee: 134 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span
-    - __kind: PointerType
-      ID: 201
-      Name: '*float64'
-      ByteSize: 8
-      GoRuntimeType: 402592
-      GoKind: 22
-      Pointee: 166 BaseType float64
-    - __kind: BaseType
-      ID: 202
-      Name: github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.samplingDecision
-      ByteSize: 4
-      GoRuntimeType: 589984
-      GoKind: 10
     - __kind: ArrayType
       ID: 203
       Name: github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.traceID
@@ -2897,74 +2107,151 @@ Types:
       Count: 16
       HasCount: true
       Element: 7 BaseType uint8
-    - __kind: GoSubroutineType
-      ID: 204
-      Name: func()
-      ByteSize: 8
-      GoRuntimeType: 481952
-      GoKind: 19
-    - __kind: PointerType
-      ID: 205
-      Name: '*bytes.Buffer'
-      ByteSize: 8
-      GoRuntimeType: 2.316032e+06
-      GoKind: 22
-      Pointee: 206 StructureType bytes.Buffer
-    - __kind: StructureType
-      ID: 206
-      Name: bytes.Buffer
-      ByteSize: 40
-      GoRuntimeType: 1.634976e+06
-      GoKind: 25
-      RawFields:
-        - Name: buf
-          Offset: 0
-          Type: 53 GoSliceHeaderType []uint8
-        - Name: off
-          Offset: 24
-          Type: 8 BaseType int
-        - Name: lastRead
-          Offset: 32
-          Type: 207 BaseType bytes.readOp
-    - __kind: BaseType
-      ID: 207
-      Name: bytes.readOp
-      ByteSize: 1
-      GoRuntimeType: 589344
-      GoKind: 3
-    - __kind: StructureType
-      ID: 208
-      Name: context.backgroundCtx
-      GoRuntimeType: 1.826784e+06
-      GoKind: 25
-      RawFields:
-        - Name: emptyCtx
-          Offset: 0
-          Type: 209 StructureType context.emptyCtx
-    - __kind: StructureType
-      ID: 209
-      Name: context.emptyCtx
-      GoRuntimeType: 1.61824e+06
-      GoKind: 25
-      RawFields: []
-    - __kind: BaseType
-      ID: 210
-      Name: uint
-      ByteSize: 8
-      GoRuntimeType: 590816
-      GoKind: 7
-    - __kind: PointerType
-      ID: 211
-      Name: '*bool'
-      ByteSize: 8
-      GoRuntimeType: 402656
-      GoKind: 22
-      Pointee: 13 BaseType bool
-    - __kind: GoInterfaceType
-      ID: 212
-      Name: error
+    - __kind: GoSwissMapGroupsType
+      ID: 179
+      Name: groupReference<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
       ByteSize: 16
-      GoRuntimeType: 1.049312e+06
+      GoKind: 25
+      RawFields:
+        - Name: data
+          Offset: 0
+          Type: 180 PointerType *noalg.map.group[string]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
+        - Name: lengthMask
+          Offset: 8
+          Type: 17 BaseType uint64
+      GroupType: 181 StructureType noalg.map.group[string]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
+      GroupSliceType: 290 GoSliceDataType []noalg.map.group[string]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute.array
+    - __kind: GoSwissMapGroupsType
+      ID: 43
+      Name: groupReference<string,[]*mime/multipart.FileHeader>
+      ByteSize: 16
+      GoKind: 25
+      RawFields:
+        - Name: data
+          Offset: 0
+          Type: 44 PointerType *noalg.map.group[string][]*mime/multipart.FileHeader
+        - Name: lengthMask
+          Offset: 8
+          Type: 17 BaseType uint64
+      GroupType: 45 StructureType noalg.map.group[string][]*mime/multipart.FileHeader
+      GroupSliceType: 236 GoSliceDataType []noalg.map.group[string][]*mime/multipart.FileHeader.array
+    - __kind: GoSwissMapGroupsType
+      ID: 23
+      Name: groupReference<string,[]string>
+      ByteSize: 16
+      GoKind: 25
+      RawFields:
+        - Name: data
+          Offset: 0
+          Type: 24 PointerType *noalg.map.group[string][]string
+        - Name: lengthMask
+          Offset: 8
+          Type: 17 BaseType uint64
+      GroupType: 25 StructureType noalg.map.group[string][]string
+      GroupSliceType: 232 GoSliceDataType []noalg.map.group[string][]string.array
+    - __kind: GoSwissMapGroupsType
+      ID: 161
+      Name: groupReference<string,float64>
+      ByteSize: 16
+      GoKind: 25
+      RawFields:
+        - Name: data
+          Offset: 0
+          Type: 162 PointerType *noalg.map.group[string]float64
+        - Name: lengthMask
+          Offset: 8
+          Type: 17 BaseType uint64
+      GroupType: 163 StructureType noalg.map.group[string]float64
+      GroupSliceType: 284 GoSliceDataType []noalg.map.group[string]float64.array
+    - __kind: GoSwissMapGroupsType
+      ID: 150
+      Name: groupReference<string,interface {}>
+      ByteSize: 16
+      GoKind: 25
+      RawFields:
+        - Name: data
+          Offset: 0
+          Type: 151 PointerType *noalg.map.group[string]interface {}
+        - Name: lengthMask
+          Offset: 8
+          Type: 17 BaseType uint64
+      GroupType: 152 StructureType noalg.map.group[string]interface {}
+      GroupSliceType: 282 GoSliceDataType []noalg.map.group[string]interface {}.array
+    - __kind: GoSwissMapGroupsType
+      ID: 129
+      Name: groupReference<string,string>
+      ByteSize: 16
+      GoKind: 25
+      RawFields:
+        - Name: data
+          Offset: 0
+          Type: 130 PointerType *noalg.map.group[string]string
+        - Name: lengthMask
+          Offset: 8
+          Type: 17 BaseType uint64
+      GroupType: 131 StructureType noalg.map.group[string]string
+      GroupSliceType: 280 GoSliceDataType []noalg.map.group[string]string.array
+    - __kind: BaseType
+      ID: 8
+      Name: int
+      ByteSize: 8
+      GoRuntimeType: 590752
+      GoKind: 2
+    - __kind: BaseType
+      ID: 218
+      Name: int16
+      ByteSize: 2
+      GoRuntimeType: 590368
+      GoKind: 4
+    - __kind: BaseType
+      ID: 140
+      Name: int32
+      ByteSize: 4
+      GoRuntimeType: 590496
+      GoKind: 5
+    - __kind: BaseType
+      ID: 32
+      Name: int64
+      ByteSize: 8
+      GoRuntimeType: 590624
+      GoKind: 6
+    - __kind: BaseType
+      ID: 213
+      Name: int8
+      ByteSize: 1
+      GoRuntimeType: 590240
+      GoKind: 3
+    - __kind: GoEmptyInterfaceType
+      ID: 62
+      Name: interface {}
+      ByteSize: 16
+      GoRuntimeType: 863072
+      GoKind: 20
+      RawFields:
+        - Name: _type
+          Offset: 0
+          Type: 2 VoidPointerType unsafe.Pointer
+        - Name: data
+          Offset: 8
+          Type: 2 VoidPointerType unsafe.Pointer
+    - __kind: StructureType
+      ID: 139
+      Name: internal/sync.Mutex
+      ByteSize: 8
+      GoRuntimeType: 1.51232e+06
+      GoKind: 25
+      RawFields:
+        - Name: state
+          Offset: 0
+          Type: 140 BaseType int32
+        - Name: sema
+          Offset: 4
+          Type: 141 BaseType uint32
+    - __kind: GoInterfaceType
+      ID: 30
+      Name: io.ReadCloser
+      ByteSize: 16
+      GoRuntimeType: 1.129632e+06
       GoKind: 20
       RawFields:
         - Name: tab
@@ -2973,481 +2260,1194 @@ Types:
         - Name: data
           Offset: 8
           Type: 2 VoidPointerType unsafe.Pointer
+    - __kind: GoSwissMapHeaderType
+      ID: 175
+      Name: map<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
+      ByteSize: 48
+      GoKind: 25
+      RawFields:
+        - Name: used
+          Offset: 0
+          Type: 17 BaseType uint64
+        - Name: seed
+          Offset: 8
+          Type: 18 BaseType uintptr
+        - Name: dirPtr
+          Offset: 16
+          Type: 176 PointerType **table<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
+        - Name: dirLen
+          Offset: 24
+          Type: 8 BaseType int
+        - Name: globalDepth
+          Offset: 32
+          Type: 7 BaseType uint8
+        - Name: globalShift
+          Offset: 33
+          Type: 7 BaseType uint8
+        - Name: writing
+          Offset: 34
+          Type: 7 BaseType uint8
+        - Name: clearSeq
+          Offset: 40
+          Type: 17 BaseType uint64
+      TablePtrSliceType: 289 GoSliceDataType []*table<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>.array
+      GroupType: 181 StructureType noalg.map.group[string]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
+    - __kind: GoSwissMapHeaderType
+      ID: 39
+      Name: map<string,[]*mime/multipart.FileHeader>
+      ByteSize: 48
+      GoKind: 25
+      RawFields:
+        - Name: used
+          Offset: 0
+          Type: 17 BaseType uint64
+        - Name: seed
+          Offset: 8
+          Type: 18 BaseType uintptr
+        - Name: dirPtr
+          Offset: 16
+          Type: 40 PointerType **table<string,[]*mime/multipart.FileHeader>
+        - Name: dirLen
+          Offset: 24
+          Type: 8 BaseType int
+        - Name: globalDepth
+          Offset: 32
+          Type: 7 BaseType uint8
+        - Name: globalShift
+          Offset: 33
+          Type: 7 BaseType uint8
+        - Name: writing
+          Offset: 34
+          Type: 7 BaseType uint8
+        - Name: clearSeq
+          Offset: 40
+          Type: 17 BaseType uint64
+      TablePtrSliceType: 235 GoSliceDataType []*table<string,[]*mime/multipart.FileHeader>.array
+      GroupType: 45 StructureType noalg.map.group[string][]*mime/multipart.FileHeader
+    - __kind: GoSwissMapHeaderType
+      ID: 16
+      Name: map<string,[]string>
+      ByteSize: 48
+      GoKind: 25
+      RawFields:
+        - Name: used
+          Offset: 0
+          Type: 17 BaseType uint64
+        - Name: seed
+          Offset: 8
+          Type: 18 BaseType uintptr
+        - Name: dirPtr
+          Offset: 16
+          Type: 19 PointerType **table<string,[]string>
+        - Name: dirLen
+          Offset: 24
+          Type: 8 BaseType int
+        - Name: globalDepth
+          Offset: 32
+          Type: 7 BaseType uint8
+        - Name: globalShift
+          Offset: 33
+          Type: 7 BaseType uint8
+        - Name: writing
+          Offset: 34
+          Type: 7 BaseType uint8
+        - Name: clearSeq
+          Offset: 40
+          Type: 17 BaseType uint64
+      TablePtrSliceType: 231 GoSliceDataType []*table<string,[]string>.array
+      GroupType: 25 StructureType noalg.map.group[string][]string
+    - __kind: GoSwissMapHeaderType
+      ID: 157
+      Name: map<string,float64>
+      ByteSize: 48
+      GoKind: 25
+      RawFields:
+        - Name: used
+          Offset: 0
+          Type: 17 BaseType uint64
+        - Name: seed
+          Offset: 8
+          Type: 18 BaseType uintptr
+        - Name: dirPtr
+          Offset: 16
+          Type: 158 PointerType **table<string,float64>
+        - Name: dirLen
+          Offset: 24
+          Type: 8 BaseType int
+        - Name: globalDepth
+          Offset: 32
+          Type: 7 BaseType uint8
+        - Name: globalShift
+          Offset: 33
+          Type: 7 BaseType uint8
+        - Name: writing
+          Offset: 34
+          Type: 7 BaseType uint8
+        - Name: clearSeq
+          Offset: 40
+          Type: 17 BaseType uint64
+      TablePtrSliceType: 283 GoSliceDataType []*table<string,float64>.array
+      GroupType: 163 StructureType noalg.map.group[string]float64
+    - __kind: GoSwissMapHeaderType
+      ID: 146
+      Name: map<string,interface {}>
+      ByteSize: 48
+      GoKind: 25
+      RawFields:
+        - Name: used
+          Offset: 0
+          Type: 17 BaseType uint64
+        - Name: seed
+          Offset: 8
+          Type: 18 BaseType uintptr
+        - Name: dirPtr
+          Offset: 16
+          Type: 147 PointerType **table<string,interface {}>
+        - Name: dirLen
+          Offset: 24
+          Type: 8 BaseType int
+        - Name: globalDepth
+          Offset: 32
+          Type: 7 BaseType uint8
+        - Name: globalShift
+          Offset: 33
+          Type: 7 BaseType uint8
+        - Name: writing
+          Offset: 34
+          Type: 7 BaseType uint8
+        - Name: clearSeq
+          Offset: 40
+          Type: 17 BaseType uint64
+      TablePtrSliceType: 281 GoSliceDataType []*table<string,interface {}>.array
+      GroupType: 152 StructureType noalg.map.group[string]interface {}
+    - __kind: GoSwissMapHeaderType
+      ID: 125
+      Name: map<string,string>
+      ByteSize: 48
+      GoKind: 25
+      RawFields:
+        - Name: used
+          Offset: 0
+          Type: 17 BaseType uint64
+        - Name: seed
+          Offset: 8
+          Type: 18 BaseType uintptr
+        - Name: dirPtr
+          Offset: 16
+          Type: 126 PointerType **table<string,string>
+        - Name: dirLen
+          Offset: 24
+          Type: 8 BaseType int
+        - Name: globalDepth
+          Offset: 32
+          Type: 7 BaseType uint8
+        - Name: globalShift
+          Offset: 33
+          Type: 7 BaseType uint8
+        - Name: writing
+          Offset: 34
+          Type: 7 BaseType uint8
+        - Name: clearSeq
+          Offset: 40
+          Type: 17 BaseType uint64
+      TablePtrSliceType: 279 GoSliceDataType []*table<string,string>.array
+      GroupType: 131 StructureType noalg.map.group[string]string
+    - __kind: GoMapType
+      ID: 173
+      Name: map[string]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
+      ByteSize: 8
+      GoRuntimeType: 1.153056e+06
+      GoKind: 21
+      HeaderType: 175 GoSwissMapHeaderType map<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
+    - __kind: GoMapType
+      ID: 37
+      Name: map[string][]*mime/multipart.FileHeader
+      ByteSize: 8
+      GoRuntimeType: 1.152288e+06
+      GoKind: 21
+      HeaderType: 39 GoSwissMapHeaderType map<string,[]*mime/multipart.FileHeader>
+    - __kind: GoMapType
+      ID: 36
+      Name: map[string][]string
+      ByteSize: 8
+      GoRuntimeType: 1.14768e+06
+      GoKind: 21
+      HeaderType: 16 GoSwissMapHeaderType map<string,[]string>
+    - __kind: GoMapType
+      ID: 155
+      Name: map[string]float64
+      ByteSize: 8
+      GoRuntimeType: 1.152928e+06
+      GoKind: 21
+      HeaderType: 157 GoSwissMapHeaderType map<string,float64>
+    - __kind: GoMapType
+      ID: 194
+      Name: map[string]interface {}
+      ByteSize: 8
+      GoRuntimeType: 1.146272e+06
+      GoKind: 21
+      HeaderType: 146 GoSwissMapHeaderType map<string,interface {}>
+    - __kind: GoMapType
+      ID: 123
+      Name: map[string]string
+      ByteSize: 8
+      GoRuntimeType: 1.148704e+06
+      GoKind: 21
+      HeaderType: 125 GoSwissMapHeaderType map<string,string>
+    - __kind: StructureType
+      ID: 64
+      Name: math/big.Int
+      ByteSize: 32
+      GoRuntimeType: 1.51744e+06
+      GoKind: 25
+      RawFields:
+        - Name: neg
+          Offset: 0
+          Type: 13 BaseType bool
+        - Name: abs
+          Offset: 8
+          Type: 65 GoSliceHeaderType math/big.nat
     - __kind: BaseType
-      ID: 213
-      Name: int8
-      ByteSize: 1
-      GoRuntimeType: 590240
-      GoKind: 3
-    - __kind: BaseType
-      ID: 214
-      Name: float32
-      ByteSize: 4
-      GoRuntimeType: 591072
-      GoKind: 13
-    - __kind: PointerType
-      ID: 215
-      Name: '*uintptr'
+      ID: 67
+      Name: math/big.Word
       ByteSize: 8
-      GoRuntimeType: 402336
-      GoKind: 22
-      Pointee: 18 BaseType uintptr
-    - __kind: PointerType
-      ID: 216
-      Name: '*int32'
-      ByteSize: 8
-      GoRuntimeType: 401952
-      GoKind: 22
-      Pointee: 140 BaseType int32
-    - __kind: PointerType
-      ID: 217
-      Name: '*uint32'
-      ByteSize: 8
-      GoRuntimeType: 402016
-      GoKind: 22
-      Pointee: 141 BaseType uint32
-    - __kind: BaseType
-      ID: 218
-      Name: int16
-      ByteSize: 2
-      GoRuntimeType: 590368
-      GoKind: 4
-    - __kind: BaseType
-      ID: 219
-      Name: complex64
-      ByteSize: 8
-      GoRuntimeType: 590944
-      GoKind: 15
-    - __kind: BaseType
-      ID: 220
-      Name: complex128
-      ByteSize: 16
-      GoRuntimeType: 591008
-      GoKind: 16
-    - __kind: PointerType
-      ID: 221
-      Name: '*int64'
-      ByteSize: 8
-      GoRuntimeType: 402080
-      GoKind: 22
-      Pointee: 32 BaseType int64
-    - __kind: PointerType
-      ID: 222
-      Name: '*uint64'
-      ByteSize: 8
-      GoRuntimeType: 402144
-      GoKind: 22
-      Pointee: 17 BaseType uint64
-    - __kind: PointerType
-      ID: 223
-      Name: '*uint16'
-      ByteSize: 8
-      GoRuntimeType: 401888
-      GoKind: 22
-      Pointee: 22 BaseType uint16
-    - __kind: PointerType
-      ID: 224
-      Name: '*int16'
-      ByteSize: 8
-      GoRuntimeType: 401824
-      GoKind: 22
-      Pointee: 218 BaseType int16
-    - __kind: PointerType
-      ID: 225
-      Name: '*int8'
-      ByteSize: 8
-      GoRuntimeType: 401696
-      GoKind: 22
-      Pointee: 213 BaseType int8
-    - __kind: PointerType
-      ID: 226
-      Name: '*error'
-      ByteSize: 8
-      GoRuntimeType: 401568
-      GoKind: 22
-      Pointee: 212 GoInterfaceType error
-    - __kind: PointerType
-      ID: 227
-      Name: '*uint'
-      ByteSize: 8
-      GoRuntimeType: 402272
-      GoKind: 22
-      Pointee: 210 BaseType uint
-    - __kind: PointerType
-      ID: 228
-      Name: '*float32'
-      ByteSize: 8
-      GoRuntimeType: 402528
-      GoKind: 22
-      Pointee: 214 BaseType float32
-    - __kind: GoStringDataType
-      ID: 229
-      Name: string.str
-      ByteSize: 2048
-    - __kind: PointerType
-      ID: 230
-      Name: '*string.str'
-      ByteSize: 8
-      Pointee: 229 GoStringDataType string.str
-    - __kind: GoSliceDataType
-      ID: 231
-      Name: '[]*table<string,[]string>.array'
-      ByteSize: 8192
-      Element: 20 PointerType *table<string,[]string>
-    - __kind: GoSliceDataType
-      ID: 232
-      Name: '[]noalg.map.group[string][]string.array'
-      ByteSize: 2048
-      Element: 25 StructureType noalg.map.group[string][]string
-    - __kind: GoSliceDataType
-      ID: 233
-      Name: '[]string.array'
-      ByteSize: 2048
-      Element: 5 GoStringHeaderType string
-    - __kind: PointerType
-      ID: 234
-      Name: '*[]string.array'
-      ByteSize: 8
-      Pointee: 233 GoSliceDataType []string.array
-    - __kind: GoSliceDataType
-      ID: 235
-      Name: '[]*table<string,[]*mime/multipart.FileHeader>.array'
-      ByteSize: 8192
-      Element: 41 PointerType *table<string,[]*mime/multipart.FileHeader>
-    - __kind: GoSliceDataType
-      ID: 236
-      Name: '[]noalg.map.group[string][]*mime/multipart.FileHeader.array'
-      ByteSize: 2048
-      Element: 45 StructureType noalg.map.group[string][]*mime/multipart.FileHeader
-    - __kind: GoSliceDataType
-      ID: 237
-      Name: '[]*mime/multipart.FileHeader.array'
-      ByteSize: 2048
-      Element: 50 PointerType *mime/multipart.FileHeader
-    - __kind: PointerType
-      ID: 238
-      Name: '*[]*mime/multipart.FileHeader.array'
-      ByteSize: 8
-      Pointee: 237 GoSliceDataType []*mime/multipart.FileHeader.array
-    - __kind: GoSliceDataType
-      ID: 239
-      Name: '[]uint8.array'
-      ByteSize: 2048
-      Element: 7 BaseType uint8
-    - __kind: PointerType
-      ID: 240
-      Name: '*[]uint8.array'
-      ByteSize: 8
-      Pointee: 239 GoSliceDataType []uint8.array
-    - __kind: GoSliceDataType
-      ID: 241
-      Name: '[]*crypto/x509.Certificate.array'
-      ByteSize: 2048
-      Element: 58 PointerType *crypto/x509.Certificate
-    - __kind: PointerType
-      ID: 242
-      Name: '*[]*crypto/x509.Certificate.array'
-      ByteSize: 8
-      Pointee: 241 GoSliceDataType []*crypto/x509.Certificate.array
+      GoRuntimeType: 594464
+      GoKind: 7
+    - __kind: GoSliceHeaderType
+      ID: 65
+      Name: math/big.nat
+      ByteSize: 24
+      GoRuntimeType: 2.420864e+06
+      GoKind: 23
+      RawFields:
+        - Name: array
+          Offset: 0
+          Type: 66 PointerType *math/big.Word
+        - Name: len
+          Offset: 8
+          Type: 8 BaseType int
+        - Name: cap
+          Offset: 16
+          Type: 8 BaseType int
+      Data: 243 GoSliceDataType math/big.nat.array
     - __kind: GoSliceDataType
       ID: 243
       Name: math/big.nat.array
       ByteSize: 2048
       Element: 67 BaseType math/big.Word
-    - __kind: PointerType
-      ID: 244
-      Name: '*math/big.nat.array'
-      ByteSize: 8
-      Pointee: 243 GoSliceDataType math/big.nat.array
-    - __kind: GoSliceDataType
-      ID: 245
-      Name: '[]crypto/x509/pkix.AttributeTypeAndValue.array'
-      ByteSize: 2048
-      Element: 71 StructureType crypto/x509/pkix.AttributeTypeAndValue
-    - __kind: PointerType
-      ID: 246
-      Name: '*[]crypto/x509/pkix.AttributeTypeAndValue.array'
-      ByteSize: 8
-      Pointee: 245 GoSliceDataType []crypto/x509/pkix.AttributeTypeAndValue.array
-    - __kind: GoSliceDataType
-      ID: 247
-      Name: encoding/asn1.ObjectIdentifier.array
-      ByteSize: 2048
-      Element: 8 BaseType int
-    - __kind: PointerType
-      ID: 248
-      Name: '*encoding/asn1.ObjectIdentifier.array'
-      ByteSize: 8
-      Pointee: 247 GoSliceDataType encoding/asn1.ObjectIdentifier.array
-    - __kind: GoSliceDataType
-      ID: 249
-      Name: '[]time.zone.array'
-      ByteSize: 2048
-      Element: 79 StructureType time.zone
-    - __kind: PointerType
-      ID: 250
-      Name: '*[]time.zone.array'
-      ByteSize: 8
-      Pointee: 249 GoSliceDataType []time.zone.array
-    - __kind: GoSliceDataType
-      ID: 251
-      Name: '[]time.zoneTrans.array'
-      ByteSize: 2048
-      Element: 82 StructureType time.zoneTrans
-    - __kind: PointerType
-      ID: 252
-      Name: '*[]time.zoneTrans.array'
-      ByteSize: 8
-      Pointee: 251 GoSliceDataType []time.zoneTrans.array
-    - __kind: GoSliceDataType
-      ID: 253
-      Name: '[]crypto/x509/pkix.Extension.array'
-      ByteSize: 2048
-      Element: 86 StructureType crypto/x509/pkix.Extension
-    - __kind: PointerType
-      ID: 254
-      Name: '*[]crypto/x509/pkix.Extension.array'
-      ByteSize: 8
-      Pointee: 253 GoSliceDataType []crypto/x509/pkix.Extension.array
-    - __kind: GoSliceDataType
-      ID: 255
-      Name: '[]encoding/asn1.ObjectIdentifier.array'
-      ByteSize: 2048
-      Element: 72 GoSliceHeaderType encoding/asn1.ObjectIdentifier
-    - __kind: PointerType
-      ID: 256
-      Name: '*[]encoding/asn1.ObjectIdentifier.array'
-      ByteSize: 8
-      Pointee: 255 GoSliceDataType []encoding/asn1.ObjectIdentifier.array
-    - __kind: GoSliceDataType
-      ID: 257
-      Name: '[]crypto/x509.ExtKeyUsage.array'
-      ByteSize: 2048
-      Element: 91 BaseType crypto/x509.ExtKeyUsage
-    - __kind: PointerType
-      ID: 258
-      Name: '*[]crypto/x509.ExtKeyUsage.array'
-      ByteSize: 8
-      Pointee: 257 GoSliceDataType []crypto/x509.ExtKeyUsage.array
-    - __kind: GoSliceDataType
-      ID: 259
-      Name: '[]net.IP.array'
-      ByteSize: 2048
-      Element: 94 GoSliceHeaderType net.IP
-    - __kind: PointerType
-      ID: 260
-      Name: '*[]net.IP.array'
-      ByteSize: 8
-      Pointee: 259 GoSliceDataType []net.IP.array
+    - __kind: StructureType
+      ID: 51
+      Name: mime/multipart.FileHeader
+      ByteSize: 88
+      GoRuntimeType: 2.009312e+06
+      GoKind: 25
+      RawFields:
+        - Name: Filename
+          Offset: 0
+          Type: 5 GoStringHeaderType string
+        - Name: Header
+          Offset: 16
+          Type: 52 GoMapType net/textproto.MIMEHeader
+        - Name: Size
+          Offset: 24
+          Type: 32 BaseType int64
+        - Name: content
+          Offset: 32
+          Type: 53 GoSliceHeaderType []uint8
+        - Name: tmpfile
+          Offset: 56
+          Type: 5 GoStringHeaderType string
+        - Name: tmpoff
+          Offset: 72
+          Type: 32 BaseType int64
+        - Name: tmpshared
+          Offset: 80
+          Type: 13 BaseType bool
+    - __kind: StructureType
+      ID: 35
+      Name: mime/multipart.Form
+      ByteSize: 16
+      GoRuntimeType: 1.5008e+06
+      GoKind: 25
+      RawFields:
+        - Name: Value
+          Offset: 0
+          Type: 36 GoMapType map[string][]string
+        - Name: File
+          Offset: 8
+          Type: 37 GoMapType map[string][]*mime/multipart.FileHeader
+    - __kind: GoSliceHeaderType
+      ID: 94
+      Name: net.IP
+      ByteSize: 24
+      GoRuntimeType: 2.170304e+06
+      GoKind: 23
+      RawFields:
+        - Name: array
+          Offset: 0
+          Type: 6 PointerType *uint8
+        - Name: len
+          Offset: 8
+          Type: 8 BaseType int
+        - Name: cap
+          Offset: 16
+          Type: 8 BaseType int
+      Data: 261 GoSliceDataType net.IP.array
     - __kind: GoSliceDataType
       ID: 261
       Name: net.IP.array
       ByteSize: 2048
       Element: 7 BaseType uint8
-    - __kind: PointerType
-      ID: 262
-      Name: '*net.IP.array'
-      ByteSize: 8
-      Pointee: 261 GoSliceDataType net.IP.array
-    - __kind: GoSliceDataType
-      ID: 263
-      Name: '[]*net/url.URL.array'
-      ByteSize: 2048
-      Element: 9 PointerType *net/url.URL
-    - __kind: PointerType
-      ID: 264
-      Name: '*[]*net/url.URL.array'
-      ByteSize: 8
-      Pointee: 263 GoSliceDataType []*net/url.URL.array
-    - __kind: GoSliceDataType
-      ID: 265
-      Name: '[]*net.IPNet.array'
-      ByteSize: 2048
-      Element: 99 PointerType *net.IPNet
-    - __kind: PointerType
-      ID: 266
-      Name: '*[]*net.IPNet.array'
-      ByteSize: 8
-      Pointee: 265 GoSliceDataType []*net.IPNet.array
+    - __kind: GoSliceHeaderType
+      ID: 101
+      Name: net.IPMask
+      ByteSize: 24
+      GoRuntimeType: 1.037408e+06
+      GoKind: 23
+      RawFields:
+        - Name: array
+          Offset: 0
+          Type: 6 PointerType *uint8
+        - Name: len
+          Offset: 8
+          Type: 8 BaseType int
+        - Name: cap
+          Offset: 16
+          Type: 8 BaseType int
+      Data: 267 GoSliceDataType net.IPMask.array
     - __kind: GoSliceDataType
       ID: 267
       Name: net.IPMask.array
       ByteSize: 2048
       Element: 7 BaseType uint8
-    - __kind: PointerType
-      ID: 268
-      Name: '*net.IPMask.array'
+    - __kind: StructureType
+      ID: 100
+      Name: net.IPNet
+      ByteSize: 48
+      GoRuntimeType: 1.48176e+06
+      GoKind: 25
+      RawFields:
+        - Name: IP
+          Offset: 0
+          Type: 94 GoSliceHeaderType net.IP
+        - Name: Mask
+          Offset: 24
+          Type: 101 GoSliceHeaderType net.IPMask
+    - __kind: GoMapType
+      ID: 14
+      Name: net/http.Header
       ByteSize: 8
-      Pointee: 267 GoSliceDataType net.IPMask.array
-    - __kind: GoSliceDataType
-      ID: 269
-      Name: '[]crypto/x509.OID.array'
-      ByteSize: 2048
-      Element: 104 StructureType crypto/x509.OID
-    - __kind: PointerType
-      ID: 270
-      Name: '*[]crypto/x509.OID.array'
-      ByteSize: 8
-      Pointee: 269 GoSliceDataType []crypto/x509.OID.array
-    - __kind: GoSliceDataType
-      ID: 271
-      Name: '[]crypto/x509.PolicyMapping.array'
-      ByteSize: 2048
-      Element: 107 StructureType crypto/x509.PolicyMapping
-    - __kind: PointerType
-      ID: 272
-      Name: '*[]crypto/x509.PolicyMapping.array'
-      ByteSize: 8
-      Pointee: 271 GoSliceDataType []crypto/x509.PolicyMapping.array
-    - __kind: GoSliceDataType
-      ID: 273
-      Name: '[][]*crypto/x509.Certificate.array'
-      ByteSize: 2048
-      Element: 56 GoSliceHeaderType []*crypto/x509.Certificate
-    - __kind: PointerType
-      ID: 274
-      Name: '*[][]*crypto/x509.Certificate.array'
-      ByteSize: 8
-      Pointee: 273 GoSliceDataType [][]*crypto/x509.Certificate.array
-    - __kind: GoSliceDataType
-      ID: 275
-      Name: '[][]uint8.array'
-      ByteSize: 2048
-      Element: 53 GoSliceHeaderType []uint8
-    - __kind: PointerType
-      ID: 276
-      Name: '*[][]uint8.array'
-      ByteSize: 8
-      Pointee: 275 GoSliceDataType [][]uint8.array
-    - __kind: GoSliceDataType
-      ID: 277
-      Name: '[]net/http.segment.array'
-      ByteSize: 2048
-      Element: 122 StructureType net/http.segment
-    - __kind: PointerType
-      ID: 278
-      Name: '*[]net/http.segment.array'
-      ByteSize: 8
-      Pointee: 277 GoSliceDataType []net/http.segment.array
-    - __kind: GoSliceDataType
-      ID: 279
-      Name: '[]*table<string,string>.array'
-      ByteSize: 8192
-      Element: 127 PointerType *table<string,string>
-    - __kind: GoSliceDataType
-      ID: 280
-      Name: '[]noalg.map.group[string]string.array'
-      ByteSize: 2048
-      Element: 131 StructureType noalg.map.group[string]string
-    - __kind: GoSliceDataType
-      ID: 281
-      Name: '[]*table<string,interface {}>.array'
-      ByteSize: 8192
-      Element: 148 PointerType *table<string,interface {}>
-    - __kind: GoSliceDataType
-      ID: 282
-      Name: '[]noalg.map.group[string]interface {}.array'
-      ByteSize: 2048
-      Element: 152 StructureType noalg.map.group[string]interface {}
-    - __kind: GoSliceDataType
-      ID: 283
-      Name: '[]*table<string,float64>.array'
-      ByteSize: 8192
-      Element: 159 PointerType *table<string,float64>
-    - __kind: GoSliceDataType
-      ID: 284
-      Name: '[]noalg.map.group[string]float64.array'
-      ByteSize: 2048
-      Element: 163 StructureType noalg.map.group[string]float64
-    - __kind: GoSliceDataType
-      ID: 285
-      Name: '[]github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink.array'
-      ByteSize: 2048
-      Element: 169 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink
-    - __kind: PointerType
-      ID: 286
-      Name: '*[]github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink.array'
-      ByteSize: 8
-      Pointee: 285 GoSliceDataType []github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink.array
-    - __kind: GoSliceDataType
-      ID: 287
-      Name: '[]github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent.array'
-      ByteSize: 2048
-      Element: 172 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent
-    - __kind: PointerType
-      ID: 288
-      Name: '*[]github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent.array'
-      ByteSize: 8
-      Pointee: 287 GoSliceDataType []github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent.array
-    - __kind: GoSliceDataType
-      ID: 289
-      Name: '[]*table<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>.array'
-      ByteSize: 8192
-      Element: 177 PointerType *table<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
-    - __kind: GoSliceDataType
-      ID: 290
-      Name: '[]noalg.map.group[string]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute.array'
-      ByteSize: 2048
-      Element: 181 StructureType noalg.map.group[string]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
-    - __kind: GoSliceDataType
-      ID: 291
-      Name: '[]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttributeValue.array'
-      ByteSize: 2048
-      Element: 191 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttributeValue
-    - __kind: PointerType
-      ID: 292
-      Name: '*[]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttributeValue.array'
-      ByteSize: 8
-      Pointee: 291 GoSliceDataType []*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttributeValue.array
-    - __kind: GoSliceDataType
-      ID: 293
-      Name: '[]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span.array'
-      ByteSize: 2048
-      Element: 134 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span
-    - __kind: PointerType
-      ID: 294
-      Name: '*[]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span.array'
-      ByteSize: 8
-      Pointee: 293 GoSliceDataType []*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span.array
-    - __kind: EventRootType
-      ID: 295
-      Name: Probe[main.HandleHTTP]
-      ByteSize: 25
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: w
-          Offset: 1
-          Expression:
-            Type: 1 GoInterfaceType net/http.ResponseWriter
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 1, index: 0, name: w}
-                  Offset: 0
-                  ByteSize: 16
-        - Name: r
+      GoRuntimeType: 2.147456e+06
+      GoKind: 21
+      HeaderType: 16 GoSwissMapHeaderType map<string,[]string>
+    - __kind: StructureType
+      ID: 4
+      Name: net/http.Request
+      ByteSize: 304
+      GoRuntimeType: 2.397408e+06
+      GoKind: 25
+      RawFields:
+        - Name: Method
+          Offset: 0
+          Type: 5 GoStringHeaderType string
+        - Name: URL
+          Offset: 16
+          Type: 9 PointerType *net/url.URL
+        - Name: Proto
+          Offset: 24
+          Type: 5 GoStringHeaderType string
+        - Name: ProtoMajor
+          Offset: 40
+          Type: 8 BaseType int
+        - Name: ProtoMinor
+          Offset: 48
+          Type: 8 BaseType int
+        - Name: Header
+          Offset: 56
+          Type: 14 GoMapType net/http.Header
+        - Name: Body
+          Offset: 64
+          Type: 30 GoInterfaceType io.ReadCloser
+        - Name: GetBody
+          Offset: 80
+          Type: 31 GoSubroutineType func() (io.ReadCloser, error)
+        - Name: ContentLength
+          Offset: 88
+          Type: 32 BaseType int64
+        - Name: TransferEncoding
+          Offset: 96
+          Type: 28 GoSliceHeaderType []string
+        - Name: Close
+          Offset: 120
+          Type: 13 BaseType bool
+        - Name: Host
+          Offset: 128
+          Type: 5 GoStringHeaderType string
+        - Name: Form
+          Offset: 144
+          Type: 33 GoMapType net/url.Values
+        - Name: PostForm
+          Offset: 152
+          Type: 33 GoMapType net/url.Values
+        - Name: MultipartForm
+          Offset: 160
+          Type: 34 PointerType *mime/multipart.Form
+        - Name: Trailer
+          Offset: 168
+          Type: 14 GoMapType net/http.Header
+        - Name: RemoteAddr
+          Offset: 176
+          Type: 5 GoStringHeaderType string
+        - Name: RequestURI
+          Offset: 192
+          Type: 5 GoStringHeaderType string
+        - Name: TLS
+          Offset: 208
+          Type: 54 PointerType *crypto/tls.ConnectionState
+        - Name: Cancel
+          Offset: 216
+          Type: 114 GoChannelType <-chan struct {}
+        - Name: Response
+          Offset: 224
+          Type: 115 PointerType *net/http.Response
+        - Name: Pattern
+          Offset: 232
+          Type: 5 GoStringHeaderType string
+        - Name: ctx
+          Offset: 248
+          Type: 117 GoInterfaceType context.Context
+        - Name: pat
+          Offset: 264
+          Type: 118 PointerType *net/http.pattern
+        - Name: matches
+          Offset: 272
+          Type: 28 GoSliceHeaderType []string
+        - Name: otherValues
+          Offset: 296
+          Type: 123 GoMapType map[string]string
+    - __kind: StructureType
+      ID: 116
+      Name: net/http.Response
+      ByteSize: 144
+      GoRuntimeType: 2.25968e+06
+      GoKind: 25
+      RawFields:
+        - Name: Status
+          Offset: 0
+          Type: 5 GoStringHeaderType string
+        - Name: StatusCode
+          Offset: 16
+          Type: 8 BaseType int
+        - Name: Proto
+          Offset: 24
+          Type: 5 GoStringHeaderType string
+        - Name: ProtoMajor
+          Offset: 40
+          Type: 8 BaseType int
+        - Name: ProtoMinor
+          Offset: 48
+          Type: 8 BaseType int
+        - Name: Header
+          Offset: 56
+          Type: 14 GoMapType net/http.Header
+        - Name: Body
+          Offset: 64
+          Type: 30 GoInterfaceType io.ReadCloser
+        - Name: ContentLength
+          Offset: 80
+          Type: 32 BaseType int64
+        - Name: TransferEncoding
+          Offset: 88
+          Type: 28 GoSliceHeaderType []string
+        - Name: Close
+          Offset: 112
+          Type: 13 BaseType bool
+        - Name: Uncompressed
+          Offset: 113
+          Type: 13 BaseType bool
+        - Name: Trailer
+          Offset: 120
+          Type: 14 GoMapType net/http.Header
+        - Name: Request
+          Offset: 128
+          Type: 3 PointerType *net/http.Request
+        - Name: TLS
+          Offset: 136
+          Type: 54 PointerType *crypto/tls.ConnectionState
+    - __kind: GoInterfaceType
+      ID: 1
+      Name: net/http.ResponseWriter
+      ByteSize: 16
+      GoRuntimeType: 1.206176e+06
+      GoKind: 20
+      RawFields:
+        - Name: tab
+          Offset: 0
+          Type: 2 VoidPointerType unsafe.Pointer
+        - Name: data
+          Offset: 8
+          Type: 2 VoidPointerType unsafe.Pointer
+    - __kind: StructureType
+      ID: 119
+      Name: net/http.pattern
+      ByteSize: 88
+      GoRuntimeType: 1.865856e+06
+      GoKind: 25
+      RawFields:
+        - Name: str
+          Offset: 0
+          Type: 5 GoStringHeaderType string
+        - Name: method
+          Offset: 16
+          Type: 5 GoStringHeaderType string
+        - Name: host
+          Offset: 32
+          Type: 5 GoStringHeaderType string
+        - Name: segments
+          Offset: 48
+          Type: 120 GoSliceHeaderType []net/http.segment
+        - Name: loc
+          Offset: 72
+          Type: 5 GoStringHeaderType string
+    - __kind: StructureType
+      ID: 122
+      Name: net/http.segment
+      ByteSize: 24
+      GoRuntimeType: 1.637088e+06
+      GoKind: 25
+      RawFields:
+        - Name: s
+          Offset: 0
+          Type: 5 GoStringHeaderType string
+        - Name: wild
+          Offset: 16
+          Type: 13 BaseType bool
+        - Name: multi
           Offset: 17
-          Expression:
-            Type: 3 PointerType *net/http.Request
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 1, index: 1, name: r}
-                  Offset: 0
-                  ByteSize: 8
-    - __kind: EventRootType
-      ID: 296
-      Name: Probe[main.LookAtTheRequest]
-      ByteSize: 17
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: path
-          Offset: 1
-          Expression:
-            Type: 5 GoStringHeaderType string
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 2, index: 0, name: path}
-                  Offset: 0
-                  ByteSize: 16
+          Type: 13 BaseType bool
+    - __kind: GoMapType
+      ID: 52
+      Name: net/textproto.MIMEHeader
+      ByteSize: 8
+      GoRuntimeType: 1.854368e+06
+      GoKind: 21
+      HeaderType: 16 GoSwissMapHeaderType map<string,[]string>
+    - __kind: StructureType
+      ID: 10
+      Name: net/url.URL
+      ByteSize: 144
+      GoRuntimeType: 2.172992e+06
+      GoKind: 25
+      RawFields:
+        - Name: Scheme
+          Offset: 0
+          Type: 5 GoStringHeaderType string
+        - Name: Opaque
+          Offset: 16
+          Type: 5 GoStringHeaderType string
+        - Name: User
+          Offset: 32
+          Type: 11 PointerType *net/url.Userinfo
+        - Name: Host
+          Offset: 40
+          Type: 5 GoStringHeaderType string
+        - Name: Path
+          Offset: 56
+          Type: 5 GoStringHeaderType string
+        - Name: RawPath
+          Offset: 72
+          Type: 5 GoStringHeaderType string
+        - Name: OmitHost
+          Offset: 88
+          Type: 13 BaseType bool
+        - Name: ForceQuery
+          Offset: 89
+          Type: 13 BaseType bool
+        - Name: RawQuery
+          Offset: 96
+          Type: 5 GoStringHeaderType string
+        - Name: Fragment
+          Offset: 112
+          Type: 5 GoStringHeaderType string
+        - Name: RawFragment
+          Offset: 128
+          Type: 5 GoStringHeaderType string
+    - __kind: StructureType
+      ID: 12
+      Name: net/url.Userinfo
+      ByteSize: 40
+      GoRuntimeType: 1.653024e+06
+      GoKind: 25
+      RawFields:
+        - Name: username
+          Offset: 0
+          Type: 5 GoStringHeaderType string
+        - Name: password
+          Offset: 16
+          Type: 5 GoStringHeaderType string
+        - Name: passwordSet
+          Offset: 32
+          Type: 13 BaseType bool
+    - __kind: GoMapType
+      ID: 33
+      Name: net/url.Values
+      ByteSize: 8
+      GoRuntimeType: 1.920064e+06
+      GoKind: 21
+      HeaderType: 16 GoSwissMapHeaderType map<string,[]string>
+    - __kind: ArrayType
+      ID: 182
+      Name: noalg.[8]struct { key string; elem *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute }
+      ByteSize: 192
+      GoRuntimeType: 711712
+      GoKind: 17
+      Count: 8
+      HasCount: true
+      Element: 183 StructureType noalg.struct { key string; elem *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute }
+    - __kind: ArrayType
+      ID: 46
+      Name: noalg.[8]struct { key string; elem []*mime/multipart.FileHeader }
+      ByteSize: 320
+      GoRuntimeType: 707136
+      GoKind: 17
+      Count: 8
+      HasCount: true
+      Element: 47 StructureType noalg.struct { key string; elem []*mime/multipart.FileHeader }
+    - __kind: ArrayType
+      ID: 26
+      Name: noalg.[8]struct { key string; elem []string }
+      ByteSize: 320
+      GoRuntimeType: 697120
+      GoKind: 17
+      Count: 8
+      HasCount: true
+      Element: 27 StructureType noalg.struct { key string; elem []string }
+    - __kind: ArrayType
+      ID: 164
+      Name: noalg.[8]struct { key string; elem float64 }
+      ByteSize: 192
+      GoRuntimeType: 711616
+      GoKind: 17
+      Count: 8
+      HasCount: true
+      Element: 165 StructureType noalg.struct { key string; elem float64 }
+    - __kind: ArrayType
+      ID: 153
+      Name: noalg.[8]struct { key string; elem interface {} }
+      ByteSize: 256
+      GoRuntimeType: 688576
+      GoKind: 17
+      Count: 8
+      HasCount: true
+      Element: 154 StructureType noalg.struct { key string; elem interface {} }
+    - __kind: ArrayType
+      ID: 132
+      Name: noalg.[8]struct { key string; elem string }
+      ByteSize: 256
+      GoRuntimeType: 701280
+      GoKind: 17
+      Count: 8
+      HasCount: true
+      Element: 133 StructureType noalg.struct { key string; elem string }
+    - __kind: StructureType
+      ID: 181
+      Name: noalg.map.group[string]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
+      ByteSize: 200
+      GoRuntimeType: 1.3272e+06
+      GoKind: 25
+      RawFields:
+        - Name: ctrl
+          Offset: 0
+          Type: 17 BaseType uint64
+        - Name: slots
+          Offset: 8
+          Type: 182 ArrayType noalg.[8]struct { key string; elem *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute }
+    - __kind: StructureType
+      ID: 45
+      Name: noalg.map.group[string][]*mime/multipart.FileHeader
+      ByteSize: 328
+      GoRuntimeType: 1.320928e+06
+      GoKind: 25
+      RawFields:
+        - Name: ctrl
+          Offset: 0
+          Type: 17 BaseType uint64
+        - Name: slots
+          Offset: 8
+          Type: 46 ArrayType noalg.[8]struct { key string; elem []*mime/multipart.FileHeader }
+    - __kind: StructureType
+      ID: 25
+      Name: noalg.map.group[string][]string
+      ByteSize: 328
+      GoRuntimeType: 1.311456e+06
+      GoKind: 25
+      RawFields:
+        - Name: ctrl
+          Offset: 0
+          Type: 17 BaseType uint64
+        - Name: slots
+          Offset: 8
+          Type: 26 ArrayType noalg.[8]struct { key string; elem []string }
+    - __kind: StructureType
+      ID: 163
+      Name: noalg.map.group[string]float64
+      ByteSize: 200
+      GoRuntimeType: 1.326944e+06
+      GoKind: 25
+      RawFields:
+        - Name: ctrl
+          Offset: 0
+          Type: 17 BaseType uint64
+        - Name: slots
+          Offset: 8
+          Type: 164 ArrayType noalg.[8]struct { key string; elem float64 }
+    - __kind: StructureType
+      ID: 152
+      Name: noalg.map.group[string]interface {}
+      ByteSize: 264
+      GoRuntimeType: 1.308896e+06
+      GoKind: 25
+      RawFields:
+        - Name: ctrl
+          Offset: 0
+          Type: 17 BaseType uint64
+        - Name: slots
+          Offset: 8
+          Type: 153 ArrayType noalg.[8]struct { key string; elem interface {} }
+    - __kind: StructureType
+      ID: 131
+      Name: noalg.map.group[string]string
+      ByteSize: 264
+      GoRuntimeType: 1.31376e+06
+      GoKind: 25
+      RawFields:
+        - Name: ctrl
+          Offset: 0
+          Type: 17 BaseType uint64
+        - Name: slots
+          Offset: 8
+          Type: 132 ArrayType noalg.[8]struct { key string; elem string }
+    - __kind: StructureType
+      ID: 183
+      Name: noalg.struct { key string; elem *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute }
+      ByteSize: 24
+      GoRuntimeType: 1.327072e+06
+      GoKind: 25
+      RawFields:
+        - Name: key
+          Offset: 0
+          Type: 5 GoStringHeaderType string
+        - Name: elem
+          Offset: 16
+          Type: 184 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
+    - __kind: StructureType
+      ID: 47
+      Name: noalg.struct { key string; elem []*mime/multipart.FileHeader }
+      ByteSize: 40
+      GoRuntimeType: 1.3208e+06
+      GoKind: 25
+      RawFields:
+        - Name: key
+          Offset: 0
+          Type: 5 GoStringHeaderType string
+        - Name: elem
+          Offset: 16
+          Type: 48 GoSliceHeaderType []*mime/multipart.FileHeader
+    - __kind: StructureType
+      ID: 27
+      Name: noalg.struct { key string; elem []string }
+      ByteSize: 40
+      GoRuntimeType: 1.311328e+06
+      GoKind: 25
+      RawFields:
+        - Name: key
+          Offset: 0
+          Type: 5 GoStringHeaderType string
+        - Name: elem
+          Offset: 16
+          Type: 28 GoSliceHeaderType []string
+    - __kind: StructureType
+      ID: 165
+      Name: noalg.struct { key string; elem float64 }
+      ByteSize: 24
+      GoRuntimeType: 1.326816e+06
+      GoKind: 25
+      RawFields:
+        - Name: key
+          Offset: 0
+          Type: 5 GoStringHeaderType string
+        - Name: elem
+          Offset: 16
+          Type: 166 BaseType float64
+    - __kind: StructureType
+      ID: 154
+      Name: noalg.struct { key string; elem interface {} }
+      ByteSize: 32
+      GoRuntimeType: 1.308768e+06
+      GoKind: 25
+      RawFields:
+        - Name: key
+          Offset: 0
+          Type: 5 GoStringHeaderType string
+        - Name: elem
+          Offset: 16
+          Type: 62 GoEmptyInterfaceType interface {}
+    - __kind: StructureType
+      ID: 133
+      Name: noalg.struct { key string; elem string }
+      ByteSize: 32
+      GoRuntimeType: 1.313632e+06
+      GoKind: 25
+      RawFields:
+        - Name: key
+          Offset: 0
+          Type: 5 GoStringHeaderType string
+        - Name: elem
+          Offset: 16
+          Type: 5 GoStringHeaderType string
+    - __kind: GoStringHeaderType
+      ID: 5
+      Name: string
+      ByteSize: 16
+      GoRuntimeType: 590176
+      GoKind: 24
+      RawFields:
+        - Name: str
+          Offset: 0
+          Type: 230 PointerType *string.str
+        - Name: len
+          Offset: 8
+          Type: 8 BaseType int
+      Data: 229 GoStringDataType string.str
+    - __kind: GoStringDataType
+      ID: 229
+      Name: string.str
+      ByteSize: 2048
+    - __kind: StructureType
+      ID: 137
+      Name: sync.Mutex
+      ByteSize: 8
+      GoRuntimeType: 1.48896e+06
+      GoKind: 25
+      RawFields:
+        - Name: _
+          Offset: 0
+          Type: 138 StructureType sync.noCopy
+        - Name: mu
+          Offset: 0
+          Type: 139 StructureType internal/sync.Mutex
+    - __kind: StructureType
+      ID: 136
+      Name: sync.RWMutex
+      ByteSize: 24
+      GoRuntimeType: 1.87168e+06
+      GoKind: 25
+      RawFields:
+        - Name: w
+          Offset: 0
+          Type: 137 StructureType sync.Mutex
+        - Name: writerSem
+          Offset: 8
+          Type: 141 BaseType uint32
+        - Name: readerSem
+          Offset: 12
+          Type: 141 BaseType uint32
+        - Name: readerCount
+          Offset: 16
+          Type: 142 StructureType sync/atomic.Int32
+        - Name: readerWait
+          Offset: 20
+          Type: 142 StructureType sync/atomic.Int32
+    - __kind: StructureType
+      ID: 138
+      Name: sync.noCopy
+      GoRuntimeType: 1.0024e+06
+      GoKind: 25
+      RawFields: []
+    - __kind: StructureType
+      ID: 142
+      Name: sync/atomic.Int32
+      ByteSize: 4
+      GoRuntimeType: 1.49024e+06
+      GoKind: 25
+      RawFields:
+        - Name: _
+          Offset: 0
+          Type: 143 StructureType sync/atomic.noCopy
+        - Name: v
+          Offset: 0
+          Type: 140 BaseType int32
+    - __kind: StructureType
+      ID: 143
+      Name: sync/atomic.noCopy
+      GoRuntimeType: 1.002496e+06
+      GoKind: 25
+      RawFields: []
+    - __kind: StructureType
+      ID: 178
+      Name: table<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
+      ByteSize: 32
+      GoKind: 25
+      RawFields:
+        - Name: used
+          Offset: 0
+          Type: 22 BaseType uint16
+        - Name: capacity
+          Offset: 2
+          Type: 22 BaseType uint16
+        - Name: growthLeft
+          Offset: 4
+          Type: 22 BaseType uint16
+        - Name: localDepth
+          Offset: 6
+          Type: 7 BaseType uint8
+        - Name: index
+          Offset: 8
+          Type: 8 BaseType int
+        - Name: groups
+          Offset: 16
+          Type: 179 GoSwissMapGroupsType groupReference<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
+    - __kind: StructureType
+      ID: 42
+      Name: table<string,[]*mime/multipart.FileHeader>
+      ByteSize: 32
+      GoKind: 25
+      RawFields:
+        - Name: used
+          Offset: 0
+          Type: 22 BaseType uint16
+        - Name: capacity
+          Offset: 2
+          Type: 22 BaseType uint16
+        - Name: growthLeft
+          Offset: 4
+          Type: 22 BaseType uint16
+        - Name: localDepth
+          Offset: 6
+          Type: 7 BaseType uint8
+        - Name: index
+          Offset: 8
+          Type: 8 BaseType int
+        - Name: groups
+          Offset: 16
+          Type: 43 GoSwissMapGroupsType groupReference<string,[]*mime/multipart.FileHeader>
+    - __kind: StructureType
+      ID: 21
+      Name: table<string,[]string>
+      ByteSize: 32
+      GoKind: 25
+      RawFields:
+        - Name: used
+          Offset: 0
+          Type: 22 BaseType uint16
+        - Name: capacity
+          Offset: 2
+          Type: 22 BaseType uint16
+        - Name: growthLeft
+          Offset: 4
+          Type: 22 BaseType uint16
+        - Name: localDepth
+          Offset: 6
+          Type: 7 BaseType uint8
+        - Name: index
+          Offset: 8
+          Type: 8 BaseType int
+        - Name: groups
+          Offset: 16
+          Type: 23 GoSwissMapGroupsType groupReference<string,[]string>
+    - __kind: StructureType
+      ID: 160
+      Name: table<string,float64>
+      ByteSize: 32
+      GoKind: 25
+      RawFields:
+        - Name: used
+          Offset: 0
+          Type: 22 BaseType uint16
+        - Name: capacity
+          Offset: 2
+          Type: 22 BaseType uint16
+        - Name: growthLeft
+          Offset: 4
+          Type: 22 BaseType uint16
+        - Name: localDepth
+          Offset: 6
+          Type: 7 BaseType uint8
+        - Name: index
+          Offset: 8
+          Type: 8 BaseType int
+        - Name: groups
+          Offset: 16
+          Type: 161 GoSwissMapGroupsType groupReference<string,float64>
+    - __kind: StructureType
+      ID: 149
+      Name: table<string,interface {}>
+      ByteSize: 32
+      GoKind: 25
+      RawFields:
+        - Name: used
+          Offset: 0
+          Type: 22 BaseType uint16
+        - Name: capacity
+          Offset: 2
+          Type: 22 BaseType uint16
+        - Name: growthLeft
+          Offset: 4
+          Type: 22 BaseType uint16
+        - Name: localDepth
+          Offset: 6
+          Type: 7 BaseType uint8
+        - Name: index
+          Offset: 8
+          Type: 8 BaseType int
+        - Name: groups
+          Offset: 16
+          Type: 150 GoSwissMapGroupsType groupReference<string,interface {}>
+    - __kind: StructureType
+      ID: 128
+      Name: table<string,string>
+      ByteSize: 32
+      GoKind: 25
+      RawFields:
+        - Name: used
+          Offset: 0
+          Type: 22 BaseType uint16
+        - Name: capacity
+          Offset: 2
+          Type: 22 BaseType uint16
+        - Name: growthLeft
+          Offset: 4
+          Type: 22 BaseType uint16
+        - Name: localDepth
+          Offset: 6
+          Type: 7 BaseType uint8
+        - Name: index
+          Offset: 8
+          Type: 8 BaseType int
+        - Name: groups
+          Offset: 16
+          Type: 129 GoSwissMapGroupsType groupReference<string,string>
+    - __kind: StructureType
+      ID: 76
+      Name: time.Location
+      ByteSize: 104
+      GoRuntimeType: 2.00528e+06
+      GoKind: 25
+      RawFields:
+        - Name: name
+          Offset: 0
+          Type: 5 GoStringHeaderType string
+        - Name: zone
+          Offset: 16
+          Type: 77 GoSliceHeaderType []time.zone
+        - Name: tx
+          Offset: 40
+          Type: 80 GoSliceHeaderType []time.zoneTrans
+        - Name: extend
+          Offset: 64
+          Type: 5 GoStringHeaderType string
+        - Name: cacheStart
+          Offset: 80
+          Type: 32 BaseType int64
+        - Name: cacheEnd
+          Offset: 88
+          Type: 32 BaseType int64
+        - Name: cacheZone
+          Offset: 96
+          Type: 78 PointerType *time.zone
+    - __kind: StructureType
+      ID: 74
+      Name: time.Time
+      ByteSize: 24
+      GoRuntimeType: 2.42368e+06
+      GoKind: 25
+      RawFields:
+        - Name: wall
+          Offset: 0
+          Type: 17 BaseType uint64
+        - Name: ext
+          Offset: 8
+          Type: 32 BaseType int64
+        - Name: loc
+          Offset: 16
+          Type: 75 PointerType *time.Location
+    - __kind: StructureType
+      ID: 79
+      Name: time.zone
+      ByteSize: 32
+      GoRuntimeType: 1.64208e+06
+      GoKind: 25
+      RawFields:
+        - Name: name
+          Offset: 0
+          Type: 5 GoStringHeaderType string
+        - Name: offset
+          Offset: 16
+          Type: 8 BaseType int
+        - Name: isDST
+          Offset: 24
+          Type: 13 BaseType bool
+    - __kind: StructureType
+      ID: 82
+      Name: time.zoneTrans
+      ByteSize: 16
+      GoRuntimeType: 1.780992e+06
+      GoKind: 25
+      RawFields:
+        - Name: when
+          Offset: 0
+          Type: 32 BaseType int64
+        - Name: index
+          Offset: 8
+          Type: 7 BaseType uint8
+        - Name: isstd
+          Offset: 9
+          Type: 13 BaseType bool
+        - Name: isutc
+          Offset: 10
+          Type: 13 BaseType bool
+    - __kind: BaseType
+      ID: 210
+      Name: uint
+      ByteSize: 8
+      GoRuntimeType: 590816
+      GoKind: 7
+    - __kind: BaseType
+      ID: 22
+      Name: uint16
+      ByteSize: 2
+      GoRuntimeType: 590432
+      GoKind: 9
+    - __kind: BaseType
+      ID: 141
+      Name: uint32
+      ByteSize: 4
+      GoRuntimeType: 590560
+      GoKind: 10
+    - __kind: BaseType
+      ID: 17
+      Name: uint64
+      ByteSize: 8
+      GoRuntimeType: 590688
+      GoKind: 11
+    - __kind: BaseType
+      ID: 7
+      Name: uint8
+      ByteSize: 1
+      GoRuntimeType: 590304
+      GoKind: 8
+    - __kind: BaseType
+      ID: 18
+      Name: uintptr
+      ByteSize: 8
+      GoRuntimeType: 590880
+      GoKind: 12
+    - __kind: VoidPointerType
+      ID: 2
+      Name: unsafe.Pointer
+      ByteSize: 8
+      GoRuntimeType: 591264
+      GoKind: 26
 MaxTypeID: 296
 Issues: []
 GoModuledataInfo: {FirstModuledataAddr: "0x13dd6a0", TypesOffset: 296}

--- a/pkg/dyninst/irgen/testdata/snapshot/rc_tester.arch=arm64,toolchain=go1.24.3.yaml
+++ b/pkg/dyninst/irgen/testdata/snapshot/rc_tester.arch=arm64,toolchain=go1.24.3.yaml
@@ -10,7 +10,7 @@ Probes:
       subprogram: {subprogram: 1}
       events:
         - ID: 1
-          Type: 295 EventRootType Probe[main.HandleHTTP]
+          Type: 215 EventRootType Probe[main.HandleHTTP]
           InjectionPoints: [{PC: "0x8a0ca0", Frameless: true}]
           Condition: null
     - id: look_at_the_request
@@ -23,7 +23,7 @@ Probes:
       subprogram: {subprogram: 2}
       events:
         - ID: 2
-          Type: 296 EventRootType Probe[main.LookAtTheRequest]
+          Type: 216 EventRootType Probe[main.LookAtTheRequest]
           InjectionPoints: [{PC: "0x8a0f9c", Frameless: true}]
           Condition: null
 Subprograms:
@@ -111,64 +111,37 @@ Types:
       GoKind: 22
       Pointee: 111 PointerType *crypto/x509.Certificate
     - __kind: PointerType
-      ID: 174
-      Name: '**github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span'
-      ByteSize: 8
-      GoKind: 22
-      Pointee: 39 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span
-    - __kind: PointerType
-      ID: 258
-      Name: '**github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttributeValue'
-      ByteSize: 8
-      GoKind: 22
-      Pointee: 259 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttributeValue
-    - __kind: PointerType
-      ID: 182
+      ID: 98
       Name: '**mime/multipart.FileHeader'
       ByteSize: 8
       GoKind: 22
-      Pointee: 183 PointerType *mime/multipart.FileHeader
+      Pointee: 99 PointerType *mime/multipart.FileHeader
     - __kind: PointerType
-      ID: 230
+      ID: 153
       Name: '**net.IPNet'
       ByteSize: 8
       GoKind: 22
-      Pointee: 231 PointerType *net.IPNet
+      Pointee: 154 PointerType *net.IPNet
     - __kind: PointerType
-      ID: 228
+      ID: 151
       Name: '**net/url.URL'
       ByteSize: 8
-      Pointee: 45 PointerType *net/url.URL
+      Pointee: 47 PointerType *net/url.URL
     - __kind: PointerType
-      ID: 127
-      Name: '**table<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>'
-      ByteSize: 8
-      Pointee: 128 PointerType *table<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
-    - __kind: PointerType
-      ID: 107
+      ID: 89
       Name: '**table<string,[]*mime/multipart.FileHeader>'
       ByteSize: 8
-      Pointee: 108 PointerType *table<string,[]*mime/multipart.FileHeader>
+      Pointee: 90 PointerType *table<string,[]*mime/multipart.FileHeader>
     - __kind: PointerType
-      ID: 50
+      ID: 52
       Name: '**table<string,[]string>'
       ByteSize: 8
-      Pointee: 51 PointerType *table<string,[]string>
+      Pointee: 53 PointerType *table<string,[]string>
     - __kind: PointerType
-      ID: 85
-      Name: '**table<string,float64>'
-      ByteSize: 8
-      Pointee: 86 PointerType *table<string,float64>
-    - __kind: PointerType
-      ID: 80
-      Name: '**table<string,interface {}>'
-      ByteSize: 8
-      Pointee: 81 PointerType *table<string,interface {}>
-    - __kind: PointerType
-      ID: 69
+      ID: 71
       Name: '**table<string,string>'
       ByteSize: 8
-      Pointee: 70 PointerType *table<string,string>
+      Pointee: 72 PointerType *table<string,string>
     - __kind: PointerType
       ID: 113
       Name: '*[]*crypto/x509.Certificate'
@@ -176,122 +149,102 @@ Types:
       GoKind: 22
       Pointee: 109 GoSliceHeaderType []*crypto/x509.Certificate
     - __kind: PointerType
-      ID: 187
+      ID: 120
       Name: '*[]*crypto/x509.Certificate.array'
       ByteSize: 8
-      Pointee: 186 GoSliceDataType []*crypto/x509.Certificate.array
+      Pointee: 119 GoSliceDataType []*crypto/x509.Certificate.array
     - __kind: PointerType
-      ID: 243
-      Name: '*[]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span.array'
-      ByteSize: 8
-      Pointee: 242 GoSliceDataType []*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span.array
-    - __kind: PointerType
-      ID: 291
-      Name: '*[]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttributeValue.array'
-      ByteSize: 8
-      Pointee: 290 GoSliceDataType []*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttributeValue.array
-    - __kind: PointerType
-      ID: 245
+      ID: 104
       Name: '*[]*mime/multipart.FileHeader.array'
       ByteSize: 8
-      Pointee: 244 GoSliceDataType []*mime/multipart.FileHeader.array
+      Pointee: 103 GoSliceDataType []*mime/multipart.FileHeader.array
     - __kind: PointerType
-      ID: 277
+      ID: 190
       Name: '*[]*net.IPNet.array'
       ByteSize: 8
-      Pointee: 276 GoSliceDataType []*net.IPNet.array
+      Pointee: 189 GoSliceDataType []*net.IPNet.array
     - __kind: PointerType
-      ID: 275
+      ID: 187
       Name: '*[]*net/url.URL.array'
       ByteSize: 8
-      Pointee: 274 GoSliceDataType []*net/url.URL.array
+      Pointee: 186 GoSliceDataType []*net/url.URL.array
     - __kind: PointerType
-      ID: 189
+      ID: 122
       Name: '*[][]*crypto/x509.Certificate.array'
       ByteSize: 8
-      Pointee: 188 GoSliceDataType [][]*crypto/x509.Certificate.array
+      Pointee: 121 GoSliceDataType [][]*crypto/x509.Certificate.array
     - __kind: PointerType
-      ID: 191
+      ID: 124
       Name: '*[][]uint8.array'
       ByteSize: 8
-      Pointee: 190 GoSliceDataType [][]uint8.array
+      Pointee: 123 GoSliceDataType [][]uint8.array
     - __kind: PointerType
-      ID: 269
+      ID: 183
       Name: '*[]crypto/x509.ExtKeyUsage.array'
       ByteSize: 8
-      Pointee: 268 GoSliceDataType []crypto/x509.ExtKeyUsage.array
+      Pointee: 182 GoSliceDataType []crypto/x509.ExtKeyUsage.array
     - __kind: PointerType
-      ID: 279
+      ID: 192
       Name: '*[]crypto/x509.OID.array'
       ByteSize: 8
-      Pointee: 278 GoSliceDataType []crypto/x509.OID.array
+      Pointee: 191 GoSliceDataType []crypto/x509.OID.array
     - __kind: PointerType
-      ID: 281
+      ID: 194
       Name: '*[]crypto/x509.PolicyMapping.array'
       ByteSize: 8
-      Pointee: 280 GoSliceDataType []crypto/x509.PolicyMapping.array
-    - __kind: PointerType
-      ID: 261
-      Name: '*[]crypto/x509/pkix.AttributeTypeAndValue.array'
-      ByteSize: 8
-      Pointee: 260 GoSliceDataType []crypto/x509/pkix.AttributeTypeAndValue.array
-    - __kind: PointerType
-      ID: 263
-      Name: '*[]crypto/x509/pkix.Extension.array'
-      ByteSize: 8
-      Pointee: 262 GoSliceDataType []crypto/x509/pkix.Extension.array
-    - __kind: PointerType
-      ID: 265
-      Name: '*[]encoding/asn1.ObjectIdentifier.array'
-      ByteSize: 8
-      Pointee: 264 GoSliceDataType []encoding/asn1.ObjectIdentifier.array
-    - __kind: PointerType
-      ID: 165
-      Name: '*[]github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink.array'
-      ByteSize: 8
-      Pointee: 164 GoSliceDataType []github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink.array
+      Pointee: 193 GoSliceDataType []crypto/x509.PolicyMapping.array
     - __kind: PointerType
       ID: 167
-      Name: '*[]github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent.array'
+      Name: '*[]crypto/x509/pkix.AttributeTypeAndValue.array'
       ByteSize: 8
-      Pointee: 166 GoSliceDataType []github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent.array
+      Pointee: 166 GoSliceDataType []crypto/x509/pkix.AttributeTypeAndValue.array
     - __kind: PointerType
-      ID: 271
+      ID: 179
+      Name: '*[]crypto/x509/pkix.Extension.array'
+      ByteSize: 8
+      Pointee: 178 GoSliceDataType []crypto/x509/pkix.Extension.array
+    - __kind: PointerType
+      ID: 181
+      Name: '*[]encoding/asn1.ObjectIdentifier.array'
+      ByteSize: 8
+      Pointee: 180 GoSliceDataType []encoding/asn1.ObjectIdentifier.array
+    - __kind: PointerType
+      ID: 185
       Name: '*[]net.IP.array'
       ByteSize: 8
-      Pointee: 270 GoSliceDataType []net.IP.array
+      Pointee: 184 GoSliceDataType []net.IP.array
     - __kind: PointerType
-      ID: 193
+      ID: 206
       Name: '*[]net/http.segment.array'
       ByteSize: 8
-      Pointee: 192 GoSliceDataType []net/http.segment.array
+      Pointee: 205 GoSliceDataType []net/http.segment.array
     - __kind: PointerType
-      ID: 141
+      ID: 84
       Name: '*[]string.array'
       ByteSize: 8
-      Pointee: 140 GoSliceDataType []string.array
+      Pointee: 83 GoSliceDataType []string.array
     - __kind: PointerType
-      ID: 287
+      ID: 175
       Name: '*[]time.zone.array'
       ByteSize: 8
-      Pointee: 286 GoSliceDataType []time.zone.array
+      Pointee: 174 GoSliceDataType []time.zone.array
     - __kind: PointerType
-      ID: 289
+      ID: 177
       Name: '*[]time.zoneTrans.array'
       ByteSize: 8
-      Pointee: 288 GoSliceDataType []time.zoneTrans.array
+      Pointee: 176 GoSliceDataType []time.zoneTrans.array
     - __kind: PointerType
       ID: 115
       Name: '*[]uint8'
       ByteSize: 8
       GoRuntimeType: 483424
       GoKind: 22
-      Pointee: 96 GoSliceHeaderType []uint8
+      Pointee: 106 GoSliceHeaderType []uint8
     - __kind: PointerType
-      ID: 169
+      ID: 108
       Name: '*[]uint8.array'
       ByteSize: 8
-      Pointee: 168 GoSliceDataType []uint8.array
+      Pointee: 107 GoSliceDataType []uint8.array
     - __kind: PointerType
       ID: 11
       Name: '*bool'
@@ -305,68 +258,68 @@ Types:
       ByteSize: 8
       GoRuntimeType: 2.316032e+06
       GoKind: 22
-      Pointee: 42 StructureType bytes.Buffer
+      Pointee: 42 UnresolvedPointeeType bytes.Buffer
     - __kind: PointerType
-      ID: 58
+      ID: 60
       Name: '*crypto/tls.ConnectionState'
       ByteSize: 8
       GoRuntimeType: 918848
       GoKind: 22
-      Pointee: 59 StructureType crypto/tls.ConnectionState
+      Pointee: 61 StructureType crypto/tls.ConnectionState
     - __kind: PointerType
       ID: 111
       Name: '*crypto/x509.Certificate'
       ByteSize: 8
       GoRuntimeType: 2.081952e+06
       GoKind: 22
-      Pointee: 171 StructureType crypto/x509.Certificate
+      Pointee: 118 StructureType crypto/x509.Certificate
     - __kind: PointerType
-      ID: 222
+      ID: 145
       Name: '*crypto/x509.ExtKeyUsage'
       ByteSize: 8
       GoRuntimeType: 426848
       GoKind: 22
-      Pointee: 223 BaseType crypto/x509.ExtKeyUsage
+      Pointee: 146 BaseType crypto/x509.ExtKeyUsage
     - __kind: PointerType
-      ID: 233
+      ID: 156
       Name: '*crypto/x509.OID'
       ByteSize: 8
       GoRuntimeType: 1.988896e+06
       GoKind: 22
-      Pointee: 234 StructureType crypto/x509.OID
+      Pointee: 157 StructureType crypto/x509.OID
     - __kind: PointerType
-      ID: 236
+      ID: 159
       Name: '*crypto/x509.PolicyMapping'
       ByteSize: 8
       GoRuntimeType: 426912
       GoKind: 22
-      Pointee: 237 StructureType crypto/x509.PolicyMapping
+      Pointee: 160 StructureType crypto/x509.PolicyMapping
     - __kind: PointerType
-      ID: 209
+      ID: 132
       Name: '*crypto/x509/pkix.AttributeTypeAndValue'
       ByteSize: 8
       GoRuntimeType: 443616
       GoKind: 22
-      Pointee: 210 StructureType crypto/x509/pkix.AttributeTypeAndValue
+      Pointee: 133 StructureType crypto/x509/pkix.AttributeTypeAndValue
     - __kind: PointerType
-      ID: 216
+      ID: 139
       Name: '*crypto/x509/pkix.Extension'
       ByteSize: 8
       GoRuntimeType: 443808
       GoKind: 22
-      Pointee: 217 StructureType crypto/x509/pkix.Extension
+      Pointee: 140 StructureType crypto/x509/pkix.Extension
     - __kind: PointerType
-      ID: 219
+      ID: 142
       Name: '*encoding/asn1.ObjectIdentifier'
       ByteSize: 8
       GoRuntimeType: 1.074528e+06
       GoKind: 22
-      Pointee: 220 GoSliceHeaderType encoding/asn1.ObjectIdentifier
+      Pointee: 143 GoSliceHeaderType encoding/asn1.ObjectIdentifier
     - __kind: PointerType
-      ID: 267
+      ID: 196
       Name: '*encoding/asn1.ObjectIdentifier.array'
       ByteSize: 8
-      Pointee: 266 GoSliceDataType encoding/asn1.ObjectIdentifier.array
+      Pointee: 195 GoSliceDataType encoding/asn1.ObjectIdentifier.array
     - __kind: PointerType
       ID: 33
       Name: '*error'
@@ -394,56 +347,7 @@ Types:
       ByteSize: 8
       GoRuntimeType: 2.326784e+06
       GoKind: 22
-      Pointee: 40 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span
-    - __kind: PointerType
-      ID: 93
-      Name: '*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanContext'
-      ByteSize: 8
-      GoRuntimeType: 2.045472e+06
-      GoKind: 22
-      Pointee: 94 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanContext
-    - __kind: PointerType
-      ID: 88
-      Name: '*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink'
-      ByteSize: 8
-      GoRuntimeType: 1.210016e+06
-      GoKind: 22
-      Pointee: 89 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink
-    - __kind: PointerType
-      ID: 91
-      Name: '*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent'
-      ByteSize: 8
-      GoRuntimeType: 1.210144e+06
-      GoKind: 22
-      Pointee: 92 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent
-    - __kind: PointerType
-      ID: 240
-      Name: '*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttribute'
-      ByteSize: 8
-      GoRuntimeType: 1.210784e+06
-      GoKind: 22
-      Pointee: 241 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttribute
-    - __kind: PointerType
-      ID: 259
-      Name: '*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttributeValue'
-      ByteSize: 8
-      GoRuntimeType: 1.210528e+06
-      GoKind: 22
-      Pointee: 283 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttributeValue
-    - __kind: PointerType
-      ID: 199
-      Name: '*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute'
-      ByteSize: 8
-      GoRuntimeType: 1.210912e+06
-      GoKind: 22
-      Pointee: 200 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
-    - __kind: PointerType
-      ID: 130
-      Name: '*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.trace'
-      ByteSize: 8
-      GoRuntimeType: 2.269504e+06
-      GoKind: 22
-      Pointee: 131 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.trace
+      Pointee: 40 UnresolvedPointeeType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span
     - __kind: PointerType
       ID: 28
       Name: '*int'
@@ -480,92 +384,77 @@ Types:
       GoKind: 22
       Pointee: 16 BaseType int8
     - __kind: PointerType
-      ID: 125
-      Name: '*map<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>'
-      ByteSize: 8
-      Pointee: 126 GoSwissMapHeaderType map<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
-    - __kind: PointerType
-      ID: 105
+      ID: 87
       Name: '*map<string,[]*mime/multipart.FileHeader>'
       ByteSize: 8
-      Pointee: 106 GoSwissMapHeaderType map<string,[]*mime/multipart.FileHeader>
+      Pointee: 88 GoSwissMapHeaderType map<string,[]*mime/multipart.FileHeader>
     - __kind: PointerType
-      ID: 48
+      ID: 50
       Name: '*map<string,[]string>'
       ByteSize: 8
-      Pointee: 49 GoSwissMapHeaderType map<string,[]string>
+      Pointee: 51 GoSwissMapHeaderType map<string,[]string>
     - __kind: PointerType
-      ID: 83
-      Name: '*map<string,float64>'
-      ByteSize: 8
-      Pointee: 84 GoSwissMapHeaderType map<string,float64>
-    - __kind: PointerType
-      ID: 78
-      Name: '*map<string,interface {}>'
-      ByteSize: 8
-      Pointee: 79 GoSwissMapHeaderType map<string,interface {}>
-    - __kind: PointerType
-      ID: 67
+      ID: 69
       Name: '*map<string,string>'
       ByteSize: 8
-      Pointee: 68 GoSwissMapHeaderType map<string,string>
+      Pointee: 70 GoSwissMapHeaderType map<string,string>
     - __kind: PointerType
-      ID: 205
+      ID: 128
       Name: '*math/big.Int'
       ByteSize: 8
       GoRuntimeType: 2.440096e+06
       GoKind: 22
-      Pointee: 206 StructureType math/big.Int
+      Pointee: 129 StructureType math/big.Int
     - __kind: PointerType
-      ID: 247
+      ID: 162
       Name: '*math/big.Word'
       ByteSize: 8
       GoRuntimeType: 429728
       GoKind: 22
-      Pointee: 248 BaseType math/big.Word
+      Pointee: 163 BaseType math/big.Word
     - __kind: PointerType
-      ID: 285
+      ID: 165
       Name: '*math/big.nat.array'
       ByteSize: 8
-      Pointee: 284 GoSliceDataType math/big.nat.array
+      Pointee: 164 GoSliceDataType math/big.nat.array
     - __kind: PointerType
-      ID: 183
+      ID: 99
       Name: '*mime/multipart.FileHeader'
       ByteSize: 8
       GoRuntimeType: 920288
       GoKind: 22
-      Pointee: 238 StructureType mime/multipart.FileHeader
+      Pointee: 102 StructureType mime/multipart.FileHeader
     - __kind: PointerType
-      ID: 56
+      ID: 58
       Name: '*mime/multipart.Form'
       ByteSize: 8
       GoRuntimeType: 920384
       GoKind: 22
-      Pointee: 57 StructureType mime/multipart.Form
+      Pointee: 59 StructureType mime/multipart.Form
     - __kind: PointerType
-      ID: 225
+      ID: 148
       Name: '*net.IP'
       ByteSize: 8
       GoRuntimeType: 2.197536e+06
       GoKind: 22
-      Pointee: 226 GoSliceHeaderType net.IP
+      Pointee: 149 GoSliceHeaderType net.IP
     - __kind: PointerType
-      ID: 273
+      ID: 198
       Name: '*net.IP.array'
       ByteSize: 8
-      Pointee: 272 GoSliceDataType net.IP.array
+      Pointee: 197 GoSliceDataType net.IP.array
     - __kind: PointerType
-      ID: 294
+      ID: 201
       Name: '*net.IPMask.array'
       ByteSize: 8
-      Pointee: 293 GoSliceDataType net.IPMask.array
+      Pointee: 200 GoSliceDataType net.IPMask.array
     - __kind: PointerType
-      ID: 231
+      ID: 154
       Name: '*net.IPNet'
       ByteSize: 8
       GoRuntimeType: 1.203744e+06
       GoKind: 22
-      Pointee: 255 StructureType net.IPNet
+      Pointee: 188 StructureType net.IPNet
     - __kind: PointerType
       ID: 37
       Name: '*net/http.Request'
@@ -574,70 +463,55 @@ Types:
       GoKind: 22
       Pointee: 38 StructureType net/http.Request
     - __kind: PointerType
-      ID: 61
+      ID: 63
       Name: '*net/http.Response'
       ByteSize: 8
       GoRuntimeType: 1.75088e+06
       GoKind: 22
-      Pointee: 62 StructureType net/http.Response
+      Pointee: 64 StructureType net/http.Response
     - __kind: PointerType
-      ID: 64
+      ID: 66
       Name: '*net/http.pattern'
       ByteSize: 8
       GoRuntimeType: 1.63728e+06
       GoKind: 22
-      Pointee: 65 StructureType net/http.pattern
+      Pointee: 67 StructureType net/http.pattern
     - __kind: PointerType
-      ID: 119
+      ID: 203
       Name: '*net/http.segment'
       ByteSize: 8
       GoRuntimeType: 393440
       GoKind: 22
-      Pointee: 120 StructureType net/http.segment
+      Pointee: 204 StructureType net/http.segment
     - __kind: PointerType
-      ID: 45
+      ID: 47
       Name: '*net/url.URL'
       ByteSize: 8
       GoRuntimeType: 2.159744e+06
       GoKind: 22
-      Pointee: 46 StructureType net/url.URL
+      Pointee: 48 StructureType net/url.URL
     - __kind: PointerType
-      ID: 100
+      ID: 73
       Name: '*net/url.Userinfo'
       ByteSize: 8
       GoRuntimeType: 1.221536e+06
       GoKind: 22
-      Pointee: 101 StructureType net/url.Userinfo
+      Pointee: 74 StructureType net/url.Userinfo
     - __kind: PointerType
-      ID: 195
-      Name: '*noalg.map.group[string]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute'
-      ByteSize: 8
-      Pointee: 196 StructureType noalg.map.group[string]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
-    - __kind: PointerType
-      ID: 177
+      ID: 93
       Name: '*noalg.map.group[string][]*mime/multipart.FileHeader'
       ByteSize: 8
-      Pointee: 178 StructureType noalg.map.group[string][]*mime/multipart.FileHeader
+      Pointee: 94 StructureType noalg.map.group[string][]*mime/multipart.FileHeader
     - __kind: PointerType
-      ID: 134
+      ID: 77
       Name: '*noalg.map.group[string][]string'
       ByteSize: 8
-      Pointee: 135 StructureType noalg.map.group[string][]string
+      Pointee: 78 StructureType noalg.map.group[string][]string
     - __kind: PointerType
-      ID: 158
-      Name: '*noalg.map.group[string]float64'
-      ByteSize: 8
-      Pointee: 159 StructureType noalg.map.group[string]float64
-    - __kind: PointerType
-      ID: 150
-      Name: '*noalg.map.group[string]interface {}'
-      ByteSize: 8
-      Pointee: 151 StructureType noalg.map.group[string]interface {}
-    - __kind: PointerType
-      ID: 143
+      ID: 209
       Name: '*noalg.map.group[string]string'
       ByteSize: 8
-      Pointee: 144 StructureType noalg.map.group[string]string
+      Pointee: 210 StructureType noalg.map.group[string]string
     - __kind: PointerType
       ID: 22
       Name: '*string'
@@ -646,61 +520,46 @@ Types:
       GoKind: 22
       Pointee: 9 GoStringHeaderType string
     - __kind: PointerType
-      ID: 99
+      ID: 46
       Name: '*string.str'
       ByteSize: 8
-      Pointee: 98 GoStringDataType string.str
+      Pointee: 45 GoStringDataType string.str
     - __kind: PointerType
-      ID: 128
-      Name: '*table<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>'
-      ByteSize: 8
-      Pointee: 172 StructureType table<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
-    - __kind: PointerType
-      ID: 108
+      ID: 90
       Name: '*table<string,[]*mime/multipart.FileHeader>'
       ByteSize: 8
-      Pointee: 170 StructureType table<string,[]*mime/multipart.FileHeader>
+      Pointee: 91 StructureType table<string,[]*mime/multipart.FileHeader>
     - __kind: PointerType
-      ID: 51
+      ID: 53
       Name: '*table<string,[]string>'
       ByteSize: 8
-      Pointee: 102 StructureType table<string,[]string>
+      Pointee: 75 StructureType table<string,[]string>
     - __kind: PointerType
-      ID: 86
-      Name: '*table<string,float64>'
-      ByteSize: 8
-      Pointee: 123 StructureType table<string,float64>
-    - __kind: PointerType
-      ID: 81
-      Name: '*table<string,interface {}>'
-      ByteSize: 8
-      Pointee: 122 StructureType table<string,interface {}>
-    - __kind: PointerType
-      ID: 70
+      ID: 72
       Name: '*table<string,string>'
       ByteSize: 8
-      Pointee: 121 StructureType table<string,string>
+      Pointee: 207 StructureType table<string,string>
     - __kind: PointerType
-      ID: 212
+      ID: 135
       Name: '*time.Location'
       ByteSize: 8
       GoRuntimeType: 1.642272e+06
       GoKind: 22
-      Pointee: 213 StructureType time.Location
+      Pointee: 136 StructureType time.Location
     - __kind: PointerType
-      ID: 250
+      ID: 169
       Name: '*time.zone'
       ByteSize: 8
       GoRuntimeType: 396576
       GoKind: 22
-      Pointee: 251 StructureType time.zone
+      Pointee: 170 StructureType time.zone
     - __kind: PointerType
-      ID: 253
+      ID: 172
       Name: '*time.zoneTrans'
       ByteSize: 8
       GoRuntimeType: 396640
       GoKind: 22
-      Pointee: 254 StructureType time.zoneTrans
+      Pointee: 173 StructureType time.zoneTrans
     - __kind: PointerType
       ID: 34
       Name: '*uint'
@@ -744,12 +603,12 @@ Types:
       GoKind: 22
       Pointee: 1 BaseType uintptr
     - __kind: GoChannelType
-      ID: 60
+      ID: 62
       Name: <-chan struct {}
       GoRuntimeType: 603232
       GoKind: 18
     - __kind: EventRootType
-      ID: 295
+      ID: 215
       Name: Probe[main.HandleHTTP]
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -773,7 +632,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 296
+      ID: 216
       Name: Probe[main.LookAtTheRequest]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -803,58 +662,14 @@ Types:
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 186 GoSliceDataType []*crypto/x509.Certificate.array
+      Data: 119 GoSliceDataType []*crypto/x509.Certificate.array
     - __kind: GoSliceDataType
-      ID: 186
+      ID: 119
       Name: '[]*crypto/x509.Certificate.array'
       ByteSize: 2048
       Element: 111 PointerType *crypto/x509.Certificate
     - __kind: GoSliceHeaderType
-      ID: 173
-      Name: '[]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span'
-      ByteSize: 24
-      GoRuntimeType: 491840
-      GoKind: 23
-      RawFields:
-        - Name: array
-          Offset: 0
-          Type: 174 PointerType **github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span
-        - Name: len
-          Offset: 8
-          Type: 7 BaseType int
-        - Name: cap
-          Offset: 16
-          Type: 7 BaseType int
-      Data: 242 GoSliceDataType []*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span.array
-    - __kind: GoSliceDataType
-      ID: 242
-      Name: '[]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span.array'
-      ByteSize: 2048
-      Element: 39 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span
-    - __kind: GoSliceHeaderType
-      ID: 257
-      Name: '[]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttributeValue'
-      ByteSize: 24
-      GoRuntimeType: 491456
-      GoKind: 23
-      RawFields:
-        - Name: array
-          Offset: 0
-          Type: 258 PointerType **github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttributeValue
-        - Name: len
-          Offset: 8
-          Type: 7 BaseType int
-        - Name: cap
-          Offset: 16
-          Type: 7 BaseType int
-      Data: 290 GoSliceDataType []*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttributeValue.array
-    - __kind: GoSliceDataType
-      ID: 290
-      Name: '[]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttributeValue.array'
-      ByteSize: 2048
-      Element: 259 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttributeValue
-    - __kind: GoSliceHeaderType
-      ID: 181
+      ID: 97
       Name: '[]*mime/multipart.FileHeader'
       ByteSize: 24
       GoRuntimeType: 488960
@@ -862,21 +677,21 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 182 PointerType **mime/multipart.FileHeader
+          Type: 98 PointerType **mime/multipart.FileHeader
         - Name: len
           Offset: 8
           Type: 7 BaseType int
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 244 GoSliceDataType []*mime/multipart.FileHeader.array
+      Data: 103 GoSliceDataType []*mime/multipart.FileHeader.array
     - __kind: GoSliceDataType
-      ID: 244
+      ID: 103
       Name: '[]*mime/multipart.FileHeader.array'
       ByteSize: 2048
-      Element: 183 PointerType *mime/multipart.FileHeader
+      Element: 99 PointerType *mime/multipart.FileHeader
     - __kind: GoSliceHeaderType
-      ID: 229
+      ID: 152
       Name: '[]*net.IPNet'
       ByteSize: 24
       GoRuntimeType: 518464
@@ -884,21 +699,21 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 230 PointerType **net.IPNet
+          Type: 153 PointerType **net.IPNet
         - Name: len
           Offset: 8
           Type: 7 BaseType int
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 276 GoSliceDataType []*net.IPNet.array
+      Data: 189 GoSliceDataType []*net.IPNet.array
     - __kind: GoSliceDataType
-      ID: 276
+      ID: 189
       Name: '[]*net.IPNet.array'
       ByteSize: 2048
-      Element: 231 PointerType *net.IPNet
+      Element: 154 PointerType *net.IPNet
     - __kind: GoSliceHeaderType
-      ID: 227
+      ID: 150
       Name: '[]*net/url.URL'
       ByteSize: 24
       GoRuntimeType: 518400
@@ -906,49 +721,34 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 228 PointerType **net/url.URL
+          Type: 151 PointerType **net/url.URL
         - Name: len
           Offset: 8
           Type: 7 BaseType int
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 274 GoSliceDataType []*net/url.URL.array
+      Data: 186 GoSliceDataType []*net/url.URL.array
     - __kind: GoSliceDataType
-      ID: 274
+      ID: 186
       Name: '[]*net/url.URL.array'
       ByteSize: 2048
-      Element: 45 PointerType *net/url.URL
+      Element: 47 PointerType *net/url.URL
     - __kind: GoSliceDataType
-      ID: 201
-      Name: '[]*table<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>.array'
-      ByteSize: 8192
-      Element: 128 PointerType *table<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
-    - __kind: GoSliceDataType
-      ID: 184
+      ID: 100
       Name: '[]*table<string,[]*mime/multipart.FileHeader>.array'
       ByteSize: 8192
-      Element: 108 PointerType *table<string,[]*mime/multipart.FileHeader>
+      Element: 90 PointerType *table<string,[]*mime/multipart.FileHeader>
     - __kind: GoSliceDataType
-      ID: 138
+      ID: 81
       Name: '[]*table<string,[]string>.array'
       ByteSize: 8192
-      Element: 51 PointerType *table<string,[]string>
+      Element: 53 PointerType *table<string,[]string>
     - __kind: GoSliceDataType
-      ID: 162
-      Name: '[]*table<string,float64>.array'
-      ByteSize: 8192
-      Element: 86 PointerType *table<string,float64>
-    - __kind: GoSliceDataType
-      ID: 155
-      Name: '[]*table<string,interface {}>.array'
-      ByteSize: 8192
-      Element: 81 PointerType *table<string,interface {}>
-    - __kind: GoSliceDataType
-      ID: 147
+      ID: 213
       Name: '[]*table<string,string>.array'
       ByteSize: 8192
-      Element: 70 PointerType *table<string,string>
+      Element: 72 PointerType *table<string,string>
     - __kind: GoSliceHeaderType
       ID: 112
       Name: '[][]*crypto/x509.Certificate'
@@ -965,9 +765,9 @@ Types:
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 188 GoSliceDataType [][]*crypto/x509.Certificate.array
+      Data: 121 GoSliceDataType [][]*crypto/x509.Certificate.array
     - __kind: GoSliceDataType
-      ID: 188
+      ID: 121
       Name: '[][]*crypto/x509.Certificate.array'
       ByteSize: 2048
       Element: 109 GoSliceHeaderType []*crypto/x509.Certificate
@@ -987,14 +787,14 @@ Types:
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 190 GoSliceDataType [][]uint8.array
+      Data: 123 GoSliceDataType [][]uint8.array
     - __kind: GoSliceDataType
-      ID: 190
+      ID: 123
       Name: '[][]uint8.array'
       ByteSize: 2048
-      Element: 96 GoSliceHeaderType []uint8
+      Element: 106 GoSliceHeaderType []uint8
     - __kind: GoSliceHeaderType
-      ID: 221
+      ID: 144
       Name: '[]crypto/x509.ExtKeyUsage'
       ByteSize: 24
       GoRuntimeType: 505152
@@ -1002,21 +802,21 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 222 PointerType *crypto/x509.ExtKeyUsage
+          Type: 145 PointerType *crypto/x509.ExtKeyUsage
         - Name: len
           Offset: 8
           Type: 7 BaseType int
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 268 GoSliceDataType []crypto/x509.ExtKeyUsage.array
+      Data: 182 GoSliceDataType []crypto/x509.ExtKeyUsage.array
     - __kind: GoSliceDataType
-      ID: 268
+      ID: 182
       Name: '[]crypto/x509.ExtKeyUsage.array'
       ByteSize: 2048
-      Element: 223 BaseType crypto/x509.ExtKeyUsage
+      Element: 146 BaseType crypto/x509.ExtKeyUsage
     - __kind: GoSliceHeaderType
-      ID: 232
+      ID: 155
       Name: '[]crypto/x509.OID'
       ByteSize: 24
       GoRuntimeType: 518528
@@ -1024,21 +824,21 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 233 PointerType *crypto/x509.OID
+          Type: 156 PointerType *crypto/x509.OID
         - Name: len
           Offset: 8
           Type: 7 BaseType int
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 278 GoSliceDataType []crypto/x509.OID.array
+      Data: 191 GoSliceDataType []crypto/x509.OID.array
     - __kind: GoSliceDataType
-      ID: 278
+      ID: 191
       Name: '[]crypto/x509.OID.array'
       ByteSize: 2048
-      Element: 234 StructureType crypto/x509.OID
+      Element: 157 StructureType crypto/x509.OID
     - __kind: GoSliceHeaderType
-      ID: 235
+      ID: 158
       Name: '[]crypto/x509.PolicyMapping'
       ByteSize: 24
       GoRuntimeType: 518592
@@ -1046,21 +846,21 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 236 PointerType *crypto/x509.PolicyMapping
+          Type: 159 PointerType *crypto/x509.PolicyMapping
         - Name: len
           Offset: 8
           Type: 7 BaseType int
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 280 GoSliceDataType []crypto/x509.PolicyMapping.array
+      Data: 193 GoSliceDataType []crypto/x509.PolicyMapping.array
     - __kind: GoSliceDataType
-      ID: 280
+      ID: 193
       Name: '[]crypto/x509.PolicyMapping.array'
       ByteSize: 2048
-      Element: 237 StructureType crypto/x509.PolicyMapping
+      Element: 160 StructureType crypto/x509.PolicyMapping
     - __kind: GoSliceHeaderType
-      ID: 208
+      ID: 131
       Name: '[]crypto/x509/pkix.AttributeTypeAndValue'
       ByteSize: 24
       GoRuntimeType: 519040
@@ -1068,21 +868,21 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 209 PointerType *crypto/x509/pkix.AttributeTypeAndValue
+          Type: 132 PointerType *crypto/x509/pkix.AttributeTypeAndValue
         - Name: len
           Offset: 8
           Type: 7 BaseType int
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 260 GoSliceDataType []crypto/x509/pkix.AttributeTypeAndValue.array
+      Data: 166 GoSliceDataType []crypto/x509/pkix.AttributeTypeAndValue.array
     - __kind: GoSliceDataType
-      ID: 260
+      ID: 166
       Name: '[]crypto/x509/pkix.AttributeTypeAndValue.array'
       ByteSize: 2048
-      Element: 210 StructureType crypto/x509/pkix.AttributeTypeAndValue
+      Element: 133 StructureType crypto/x509/pkix.AttributeTypeAndValue
     - __kind: GoSliceHeaderType
-      ID: 215
+      ID: 138
       Name: '[]crypto/x509/pkix.Extension'
       ByteSize: 24
       GoRuntimeType: 518272
@@ -1090,21 +890,21 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 216 PointerType *crypto/x509/pkix.Extension
+          Type: 139 PointerType *crypto/x509/pkix.Extension
         - Name: len
           Offset: 8
           Type: 7 BaseType int
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 262 GoSliceDataType []crypto/x509/pkix.Extension.array
+      Data: 178 GoSliceDataType []crypto/x509/pkix.Extension.array
     - __kind: GoSliceDataType
-      ID: 262
+      ID: 178
       Name: '[]crypto/x509/pkix.Extension.array'
       ByteSize: 2048
-      Element: 217 StructureType crypto/x509/pkix.Extension
+      Element: 140 StructureType crypto/x509/pkix.Extension
     - __kind: GoSliceHeaderType
-      ID: 218
+      ID: 141
       Name: '[]encoding/asn1.ObjectIdentifier'
       ByteSize: 24
       GoRuntimeType: 518336
@@ -1112,65 +912,21 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 219 PointerType *encoding/asn1.ObjectIdentifier
+          Type: 142 PointerType *encoding/asn1.ObjectIdentifier
         - Name: len
           Offset: 8
           Type: 7 BaseType int
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 264 GoSliceDataType []encoding/asn1.ObjectIdentifier.array
+      Data: 180 GoSliceDataType []encoding/asn1.ObjectIdentifier.array
     - __kind: GoSliceDataType
-      ID: 264
+      ID: 180
       Name: '[]encoding/asn1.ObjectIdentifier.array'
       ByteSize: 2048
-      Element: 220 GoSliceHeaderType encoding/asn1.ObjectIdentifier
+      Element: 143 GoSliceHeaderType encoding/asn1.ObjectIdentifier
     - __kind: GoSliceHeaderType
-      ID: 87
-      Name: '[]github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink'
-      ByteSize: 24
-      GoRuntimeType: 491392
-      GoKind: 23
-      RawFields:
-        - Name: array
-          Offset: 0
-          Type: 88 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink
-        - Name: len
-          Offset: 8
-          Type: 7 BaseType int
-        - Name: cap
-          Offset: 16
-          Type: 7 BaseType int
-      Data: 164 GoSliceDataType []github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink.array
-    - __kind: GoSliceDataType
-      ID: 164
-      Name: '[]github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink.array'
-      ByteSize: 2048
-      Element: 89 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink
-    - __kind: GoSliceHeaderType
-      ID: 90
-      Name: '[]github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent'
-      ByteSize: 24
-      GoRuntimeType: 491584
-      GoKind: 23
-      RawFields:
-        - Name: array
-          Offset: 0
-          Type: 91 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent
-        - Name: len
-          Offset: 8
-          Type: 7 BaseType int
-        - Name: cap
-          Offset: 16
-          Type: 7 BaseType int
-      Data: 166 GoSliceDataType []github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent.array
-    - __kind: GoSliceDataType
-      ID: 166
-      Name: '[]github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent.array'
-      ByteSize: 2048
-      Element: 92 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent
-    - __kind: GoSliceHeaderType
-      ID: 224
+      ID: 147
       Name: '[]net.IP'
       ByteSize: 24
       GoRuntimeType: 484768
@@ -1178,21 +934,21 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 225 PointerType *net.IP
+          Type: 148 PointerType *net.IP
         - Name: len
           Offset: 8
           Type: 7 BaseType int
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 270 GoSliceDataType []net.IP.array
+      Data: 184 GoSliceDataType []net.IP.array
     - __kind: GoSliceDataType
-      ID: 270
+      ID: 184
       Name: '[]net.IP.array'
       ByteSize: 2048
-      Element: 226 GoSliceHeaderType net.IP
+      Element: 149 GoSliceHeaderType net.IP
     - __kind: GoSliceHeaderType
-      ID: 118
+      ID: 202
       Name: '[]net/http.segment'
       ByteSize: 24
       GoRuntimeType: 486400
@@ -1200,51 +956,36 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 119 PointerType *net/http.segment
+          Type: 203 PointerType *net/http.segment
         - Name: len
           Offset: 8
           Type: 7 BaseType int
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 192 GoSliceDataType []net/http.segment.array
+      Data: 205 GoSliceDataType []net/http.segment.array
     - __kind: GoSliceDataType
-      ID: 192
+      ID: 205
       Name: '[]net/http.segment.array'
       ByteSize: 2048
-      Element: 120 StructureType net/http.segment
+      Element: 204 StructureType net/http.segment
     - __kind: GoSliceDataType
-      ID: 202
-      Name: '[]noalg.map.group[string]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute.array'
-      ByteSize: 2048
-      Element: 196 StructureType noalg.map.group[string]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
-    - __kind: GoSliceDataType
-      ID: 185
+      ID: 101
       Name: '[]noalg.map.group[string][]*mime/multipart.FileHeader.array'
       ByteSize: 2048
-      Element: 178 StructureType noalg.map.group[string][]*mime/multipart.FileHeader
+      Element: 94 StructureType noalg.map.group[string][]*mime/multipart.FileHeader
     - __kind: GoSliceDataType
-      ID: 139
+      ID: 82
       Name: '[]noalg.map.group[string][]string.array'
       ByteSize: 2048
-      Element: 135 StructureType noalg.map.group[string][]string
+      Element: 78 StructureType noalg.map.group[string][]string
     - __kind: GoSliceDataType
-      ID: 163
-      Name: '[]noalg.map.group[string]float64.array'
-      ByteSize: 2048
-      Element: 159 StructureType noalg.map.group[string]float64
-    - __kind: GoSliceDataType
-      ID: 156
-      Name: '[]noalg.map.group[string]interface {}.array'
-      ByteSize: 2048
-      Element: 151 StructureType noalg.map.group[string]interface {}
-    - __kind: GoSliceDataType
-      ID: 148
+      ID: 214
       Name: '[]noalg.map.group[string]string.array'
       ByteSize: 2048
-      Element: 144 StructureType noalg.map.group[string]string
+      Element: 210 StructureType noalg.map.group[string]string
     - __kind: GoSliceHeaderType
-      ID: 54
+      ID: 56
       Name: '[]string'
       ByteSize: 24
       GoRuntimeType: 498048
@@ -1259,14 +1000,14 @@ Types:
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 140 GoSliceDataType []string.array
+      Data: 83 GoSliceDataType []string.array
     - __kind: GoSliceDataType
-      ID: 140
+      ID: 83
       Name: '[]string.array'
       ByteSize: 2048
       Element: 9 GoStringHeaderType string
     - __kind: GoSliceHeaderType
-      ID: 249
+      ID: 168
       Name: '[]time.zone'
       ByteSize: 24
       GoRuntimeType: 490944
@@ -1274,21 +1015,21 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 250 PointerType *time.zone
+          Type: 169 PointerType *time.zone
         - Name: len
           Offset: 8
           Type: 7 BaseType int
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 286 GoSliceDataType []time.zone.array
+      Data: 174 GoSliceDataType []time.zone.array
     - __kind: GoSliceDataType
-      ID: 286
+      ID: 174
       Name: '[]time.zone.array'
       ByteSize: 2048
-      Element: 251 StructureType time.zone
+      Element: 170 StructureType time.zone
     - __kind: GoSliceHeaderType
-      ID: 252
+      ID: 171
       Name: '[]time.zoneTrans'
       ByteSize: 24
       GoRuntimeType: 491008
@@ -1296,21 +1037,21 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 253 PointerType *time.zoneTrans
+          Type: 172 PointerType *time.zoneTrans
         - Name: len
           Offset: 8
           Type: 7 BaseType int
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 288 GoSliceDataType []time.zoneTrans.array
+      Data: 176 GoSliceDataType []time.zoneTrans.array
     - __kind: GoSliceDataType
-      ID: 288
+      ID: 176
       Name: '[]time.zoneTrans.array'
       ByteSize: 2048
-      Element: 254 StructureType time.zoneTrans
+      Element: 173 StructureType time.zoneTrans
     - __kind: GoSliceHeaderType
-      ID: 96
+      ID: 106
       Name: '[]uint8'
       ByteSize: 24
       GoRuntimeType: 496896
@@ -1325,9 +1066,9 @@ Types:
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 168 GoSliceDataType []uint8.array
+      Data: 107 GoSliceDataType []uint8.array
     - __kind: GoSliceDataType
-      ID: 168
+      ID: 107
       Name: '[]uint8.array'
       ByteSize: 2048
       Element: 3 BaseType uint8
@@ -1337,28 +1078,10 @@ Types:
       ByteSize: 1
       GoRuntimeType: 591200
       GoKind: 1
-    - __kind: StructureType
+    - __kind: UnresolvedPointeeType
       ID: 42
       Name: bytes.Buffer
-      ByteSize: 40
-      GoRuntimeType: 1.634976e+06
-      GoKind: 25
-      RawFields:
-        - Name: buf
-          Offset: 0
-          Type: 96 GoSliceHeaderType []uint8
-        - Name: off
-          Offset: 24
-          Type: 7 BaseType int
-        - Name: lastRead
-          Offset: 32
-          Type: 97 BaseType bytes.readOp
-    - __kind: BaseType
-      ID: 97
-      Name: bytes.readOp
-      ByteSize: 1
-      GoRuntimeType: 589344
-      GoKind: 3
+      ByteSize: 8
     - __kind: BaseType
       ID: 25
       Name: complex128
@@ -1372,7 +1095,7 @@ Types:
       GoRuntimeType: 590944
       GoKind: 15
     - __kind: GoInterfaceType
-      ID: 63
+      ID: 65
       Name: context.Context
       ByteSize: 16
       GoRuntimeType: 1.298016e+06
@@ -1400,7 +1123,7 @@ Types:
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 59
+      ID: 61
       Name: crypto/tls.ConnectionState
       ByteSize: 192
       GoRuntimeType: 2.301632e+06
@@ -1438,10 +1161,10 @@ Types:
           Type: 114 GoSliceHeaderType [][]uint8
         - Name: OCSPResponse
           Offset: 120
-          Type: 96 GoSliceHeaderType []uint8
+          Type: 106 GoSliceHeaderType []uint8
         - Name: TLSUnique
           Offset: 144
-          Type: 96 GoSliceHeaderType []uint8
+          Type: 106 GoSliceHeaderType []uint8
         - Name: ECHAccepted
           Offset: 168
           Type: 4 BaseType bool
@@ -1461,7 +1184,7 @@ Types:
       GoRuntimeType: 843360
       GoKind: 9
     - __kind: StructureType
-      ID: 171
+      ID: 118
       Name: crypto/x509.Certificate
       ByteSize: 1424
       GoRuntimeType: 2.452512e+06
@@ -1469,67 +1192,67 @@ Types:
       RawFields:
         - Name: Raw
           Offset: 0
-          Type: 96 GoSliceHeaderType []uint8
+          Type: 106 GoSliceHeaderType []uint8
         - Name: RawTBSCertificate
           Offset: 24
-          Type: 96 GoSliceHeaderType []uint8
+          Type: 106 GoSliceHeaderType []uint8
         - Name: RawSubjectPublicKeyInfo
           Offset: 48
-          Type: 96 GoSliceHeaderType []uint8
+          Type: 106 GoSliceHeaderType []uint8
         - Name: RawSubject
           Offset: 72
-          Type: 96 GoSliceHeaderType []uint8
+          Type: 106 GoSliceHeaderType []uint8
         - Name: RawIssuer
           Offset: 96
-          Type: 96 GoSliceHeaderType []uint8
+          Type: 106 GoSliceHeaderType []uint8
         - Name: Signature
           Offset: 120
-          Type: 96 GoSliceHeaderType []uint8
+          Type: 106 GoSliceHeaderType []uint8
         - Name: SignatureAlgorithm
           Offset: 144
-          Type: 203 BaseType crypto/x509.SignatureAlgorithm
+          Type: 125 BaseType crypto/x509.SignatureAlgorithm
         - Name: PublicKeyAlgorithm
           Offset: 152
-          Type: 204 BaseType crypto/x509.PublicKeyAlgorithm
+          Type: 126 BaseType crypto/x509.PublicKeyAlgorithm
         - Name: PublicKey
           Offset: 160
-          Type: 154 GoEmptyInterfaceType interface {}
+          Type: 127 GoEmptyInterfaceType interface {}
         - Name: Version
           Offset: 176
           Type: 7 BaseType int
         - Name: SerialNumber
           Offset: 184
-          Type: 205 PointerType *math/big.Int
+          Type: 128 PointerType *math/big.Int
         - Name: Issuer
           Offset: 192
-          Type: 207 StructureType crypto/x509/pkix.Name
+          Type: 130 StructureType crypto/x509/pkix.Name
         - Name: Subject
           Offset: 440
-          Type: 207 StructureType crypto/x509/pkix.Name
+          Type: 130 StructureType crypto/x509/pkix.Name
         - Name: NotBefore
           Offset: 688
-          Type: 211 StructureType time.Time
+          Type: 134 StructureType time.Time
         - Name: NotAfter
           Offset: 712
-          Type: 211 StructureType time.Time
+          Type: 134 StructureType time.Time
         - Name: KeyUsage
           Offset: 736
-          Type: 214 BaseType crypto/x509.KeyUsage
+          Type: 137 BaseType crypto/x509.KeyUsage
         - Name: Extensions
           Offset: 744
-          Type: 215 GoSliceHeaderType []crypto/x509/pkix.Extension
+          Type: 138 GoSliceHeaderType []crypto/x509/pkix.Extension
         - Name: ExtraExtensions
           Offset: 768
-          Type: 215 GoSliceHeaderType []crypto/x509/pkix.Extension
+          Type: 138 GoSliceHeaderType []crypto/x509/pkix.Extension
         - Name: UnhandledCriticalExtensions
           Offset: 792
-          Type: 218 GoSliceHeaderType []encoding/asn1.ObjectIdentifier
+          Type: 141 GoSliceHeaderType []encoding/asn1.ObjectIdentifier
         - Name: ExtKeyUsage
           Offset: 816
-          Type: 221 GoSliceHeaderType []crypto/x509.ExtKeyUsage
+          Type: 144 GoSliceHeaderType []crypto/x509.ExtKeyUsage
         - Name: UnknownExtKeyUsage
           Offset: 840
-          Type: 218 GoSliceHeaderType []encoding/asn1.ObjectIdentifier
+          Type: 141 GoSliceHeaderType []encoding/asn1.ObjectIdentifier
         - Name: BasicConstraintsValid
           Offset: 864
           Type: 4 BaseType bool
@@ -1544,64 +1267,64 @@ Types:
           Type: 4 BaseType bool
         - Name: SubjectKeyId
           Offset: 888
-          Type: 96 GoSliceHeaderType []uint8
+          Type: 106 GoSliceHeaderType []uint8
         - Name: AuthorityKeyId
           Offset: 912
-          Type: 96 GoSliceHeaderType []uint8
+          Type: 106 GoSliceHeaderType []uint8
         - Name: OCSPServer
           Offset: 936
-          Type: 54 GoSliceHeaderType []string
+          Type: 56 GoSliceHeaderType []string
         - Name: IssuingCertificateURL
           Offset: 960
-          Type: 54 GoSliceHeaderType []string
+          Type: 56 GoSliceHeaderType []string
         - Name: DNSNames
           Offset: 984
-          Type: 54 GoSliceHeaderType []string
+          Type: 56 GoSliceHeaderType []string
         - Name: EmailAddresses
           Offset: 1008
-          Type: 54 GoSliceHeaderType []string
+          Type: 56 GoSliceHeaderType []string
         - Name: IPAddresses
           Offset: 1032
-          Type: 224 GoSliceHeaderType []net.IP
+          Type: 147 GoSliceHeaderType []net.IP
         - Name: URIs
           Offset: 1056
-          Type: 227 GoSliceHeaderType []*net/url.URL
+          Type: 150 GoSliceHeaderType []*net/url.URL
         - Name: PermittedDNSDomainsCritical
           Offset: 1080
           Type: 4 BaseType bool
         - Name: PermittedDNSDomains
           Offset: 1088
-          Type: 54 GoSliceHeaderType []string
+          Type: 56 GoSliceHeaderType []string
         - Name: ExcludedDNSDomains
           Offset: 1112
-          Type: 54 GoSliceHeaderType []string
+          Type: 56 GoSliceHeaderType []string
         - Name: PermittedIPRanges
           Offset: 1136
-          Type: 229 GoSliceHeaderType []*net.IPNet
+          Type: 152 GoSliceHeaderType []*net.IPNet
         - Name: ExcludedIPRanges
           Offset: 1160
-          Type: 229 GoSliceHeaderType []*net.IPNet
+          Type: 152 GoSliceHeaderType []*net.IPNet
         - Name: PermittedEmailAddresses
           Offset: 1184
-          Type: 54 GoSliceHeaderType []string
+          Type: 56 GoSliceHeaderType []string
         - Name: ExcludedEmailAddresses
           Offset: 1208
-          Type: 54 GoSliceHeaderType []string
+          Type: 56 GoSliceHeaderType []string
         - Name: PermittedURIDomains
           Offset: 1232
-          Type: 54 GoSliceHeaderType []string
+          Type: 56 GoSliceHeaderType []string
         - Name: ExcludedURIDomains
           Offset: 1256
-          Type: 54 GoSliceHeaderType []string
+          Type: 56 GoSliceHeaderType []string
         - Name: CRLDistributionPoints
           Offset: 1280
-          Type: 54 GoSliceHeaderType []string
+          Type: 56 GoSliceHeaderType []string
         - Name: PolicyIdentifiers
           Offset: 1304
-          Type: 218 GoSliceHeaderType []encoding/asn1.ObjectIdentifier
+          Type: 141 GoSliceHeaderType []encoding/asn1.ObjectIdentifier
         - Name: Policies
           Offset: 1328
-          Type: 232 GoSliceHeaderType []crypto/x509.OID
+          Type: 155 GoSliceHeaderType []crypto/x509.OID
         - Name: InhibitAnyPolicy
           Offset: 1352
           Type: 7 BaseType int
@@ -1622,21 +1345,21 @@ Types:
           Type: 4 BaseType bool
         - Name: PolicyMappings
           Offset: 1400
-          Type: 235 GoSliceHeaderType []crypto/x509.PolicyMapping
+          Type: 158 GoSliceHeaderType []crypto/x509.PolicyMapping
     - __kind: BaseType
-      ID: 223
+      ID: 146
       Name: crypto/x509.ExtKeyUsage
       ByteSize: 8
       GoRuntimeType: 594272
       GoKind: 2
     - __kind: BaseType
-      ID: 214
+      ID: 137
       Name: crypto/x509.KeyUsage
       ByteSize: 8
       GoRuntimeType: 594208
       GoKind: 2
     - __kind: StructureType
-      ID: 234
+      ID: 157
       Name: crypto/x509.OID
       ByteSize: 24
       GoRuntimeType: 1.989152e+06
@@ -1644,9 +1367,9 @@ Types:
       RawFields:
         - Name: der
           Offset: 0
-          Type: 96 GoSliceHeaderType []uint8
+          Type: 106 GoSliceHeaderType []uint8
     - __kind: StructureType
-      ID: 237
+      ID: 160
       Name: crypto/x509.PolicyMapping
       ByteSize: 48
       GoRuntimeType: 1.5144e+06
@@ -1654,24 +1377,24 @@ Types:
       RawFields:
         - Name: IssuerDomainPolicy
           Offset: 0
-          Type: 234 StructureType crypto/x509.OID
+          Type: 157 StructureType crypto/x509.OID
         - Name: SubjectDomainPolicy
           Offset: 24
-          Type: 234 StructureType crypto/x509.OID
+          Type: 157 StructureType crypto/x509.OID
     - __kind: BaseType
-      ID: 204
+      ID: 126
       Name: crypto/x509.PublicKeyAlgorithm
       ByteSize: 8
       GoRuntimeType: 845664
       GoKind: 2
     - __kind: BaseType
-      ID: 203
+      ID: 125
       Name: crypto/x509.SignatureAlgorithm
       ByteSize: 8
       GoRuntimeType: 1.134112e+06
       GoKind: 2
     - __kind: StructureType
-      ID: 210
+      ID: 133
       Name: crypto/x509/pkix.AttributeTypeAndValue
       ByteSize: 40
       GoRuntimeType: 1.52688e+06
@@ -1679,12 +1402,12 @@ Types:
       RawFields:
         - Name: Type
           Offset: 0
-          Type: 220 GoSliceHeaderType encoding/asn1.ObjectIdentifier
+          Type: 143 GoSliceHeaderType encoding/asn1.ObjectIdentifier
         - Name: Value
           Offset: 24
-          Type: 154 GoEmptyInterfaceType interface {}
+          Type: 127 GoEmptyInterfaceType interface {}
     - __kind: StructureType
-      ID: 217
+      ID: 140
       Name: crypto/x509/pkix.Extension
       ByteSize: 56
       GoRuntimeType: 1.678176e+06
@@ -1692,15 +1415,15 @@ Types:
       RawFields:
         - Name: Id
           Offset: 0
-          Type: 220 GoSliceHeaderType encoding/asn1.ObjectIdentifier
+          Type: 143 GoSliceHeaderType encoding/asn1.ObjectIdentifier
         - Name: Critical
           Offset: 24
           Type: 4 BaseType bool
         - Name: Value
           Offset: 32
-          Type: 96 GoSliceHeaderType []uint8
+          Type: 106 GoSliceHeaderType []uint8
     - __kind: StructureType
-      ID: 207
+      ID: 130
       Name: crypto/x509/pkix.Name
       ByteSize: 248
       GoRuntimeType: 2.240928e+06
@@ -1708,25 +1431,25 @@ Types:
       RawFields:
         - Name: Country
           Offset: 0
-          Type: 54 GoSliceHeaderType []string
+          Type: 56 GoSliceHeaderType []string
         - Name: Organization
           Offset: 24
-          Type: 54 GoSliceHeaderType []string
+          Type: 56 GoSliceHeaderType []string
         - Name: OrganizationalUnit
           Offset: 48
-          Type: 54 GoSliceHeaderType []string
+          Type: 56 GoSliceHeaderType []string
         - Name: Locality
           Offset: 72
-          Type: 54 GoSliceHeaderType []string
+          Type: 56 GoSliceHeaderType []string
         - Name: Province
           Offset: 96
-          Type: 54 GoSliceHeaderType []string
+          Type: 56 GoSliceHeaderType []string
         - Name: StreetAddress
           Offset: 120
-          Type: 54 GoSliceHeaderType []string
+          Type: 56 GoSliceHeaderType []string
         - Name: PostalCode
           Offset: 144
-          Type: 54 GoSliceHeaderType []string
+          Type: 56 GoSliceHeaderType []string
         - Name: SerialNumber
           Offset: 168
           Type: 9 GoStringHeaderType string
@@ -1735,12 +1458,12 @@ Types:
           Type: 9 GoStringHeaderType string
         - Name: Names
           Offset: 200
-          Type: 208 GoSliceHeaderType []crypto/x509/pkix.AttributeTypeAndValue
+          Type: 131 GoSliceHeaderType []crypto/x509/pkix.AttributeTypeAndValue
         - Name: ExtraNames
           Offset: 224
-          Type: 208 GoSliceHeaderType []crypto/x509/pkix.AttributeTypeAndValue
+          Type: 131 GoSliceHeaderType []crypto/x509/pkix.AttributeTypeAndValue
     - __kind: GoSliceHeaderType
-      ID: 220
+      ID: 143
       Name: encoding/asn1.ObjectIdentifier
       ByteSize: 24
       GoRuntimeType: 1.074656e+06
@@ -1755,9 +1478,9 @@ Types:
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 266 GoSliceDataType encoding/asn1.ObjectIdentifier.array
+      Data: 195 GoSliceDataType encoding/asn1.ObjectIdentifier.array
     - __kind: GoSliceDataType
-      ID: 266
+      ID: 195
       Name: encoding/asn1.ObjectIdentifier.array
       ByteSize: 2048
       Element: 7 BaseType int
@@ -1787,13 +1510,7 @@ Types:
       GoRuntimeType: 591136
       GoKind: 14
     - __kind: GoSubroutineType
-      ID: 95
-      Name: func()
-      ByteSize: 8
-      GoRuntimeType: 481952
-      GoKind: 19
-    - __kind: GoSubroutineType
-      ID: 53
+      ID: 55
       Name: func() (io.ReadCloser, error)
       ByteSize: 8
       GoRuntimeType: 701088
@@ -1804,393 +1521,52 @@ Types:
       ByteSize: 8
       GoRuntimeType: 1.020064e+06
       GoKind: 19
-    - __kind: StructureType
+    - __kind: UnresolvedPointeeType
       ID: 40
       Name: github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span
-      ByteSize: 288
-      GoRuntimeType: 2.392384e+06
-      GoKind: 25
-      RawFields:
-        - Name: mu
-          Offset: 0
-          Type: 71 StructureType sync.RWMutex
-        - Name: name
-          Offset: 24
-          Type: 9 GoStringHeaderType string
-        - Name: service
-          Offset: 40
-          Type: 9 GoStringHeaderType string
-        - Name: resource
-          Offset: 56
-          Type: 9 GoStringHeaderType string
-        - Name: spanType
-          Offset: 72
-          Type: 9 GoStringHeaderType string
-        - Name: start
-          Offset: 88
-          Type: 13 BaseType int64
-        - Name: duration
-          Offset: 96
-          Type: 13 BaseType int64
-        - Name: meta
-          Offset: 104
-          Type: 66 GoMapType map[string]string
-        - Name: metaStruct
-          Offset: 112
-          Type: 77 GoMapType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.metaStructMap
-        - Name: metrics
-          Offset: 120
-          Type: 82 GoMapType map[string]float64
-        - Name: spanID
-          Offset: 128
-          Type: 8 BaseType uint64
-        - Name: traceID
-          Offset: 136
-          Type: 8 BaseType uint64
-        - Name: parentID
-          Offset: 144
-          Type: 8 BaseType uint64
-        - Name: error
-          Offset: 152
-          Type: 12 BaseType int32
-        - Name: spanLinks
-          Offset: 160
-          Type: 87 GoSliceHeaderType []github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink
-        - Name: spanEvents
-          Offset: 184
-          Type: 90 GoSliceHeaderType []github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent
-        - Name: goExecTraced
-          Offset: 208
-          Type: 4 BaseType bool
-        - Name: noDebugStack
-          Offset: 209
-          Type: 4 BaseType bool
-        - Name: finished
-          Offset: 210
-          Type: 4 BaseType bool
-        - Name: context
-          Offset: 216
-          Type: 93 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanContext
-        - Name: integration
-          Offset: 224
-          Type: 9 GoStringHeaderType string
-        - Name: supportsEvents
-          Offset: 240
-          Type: 4 BaseType bool
-        - Name: pprofCtxActive
-          Offset: 248
-          Type: 63 GoInterfaceType context.Context
-        - Name: pprofCtxRestore
-          Offset: 264
-          Type: 63 GoInterfaceType context.Context
-        - Name: taskEnd
-          Offset: 280
-          Type: 95 GoSubroutineType func()
-    - __kind: StructureType
-      ID: 94
-      Name: github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanContext
-      ByteSize: 168
-      GoRuntimeType: 2.261024e+06
-      GoKind: 25
-      RawFields:
-        - Name: updated
-          Offset: 0
-          Type: 4 BaseType bool
-        - Name: trace
-          Offset: 8
-          Type: 130 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.trace
-        - Name: span
-          Offset: 16
-          Type: 39 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span
-        - Name: errors
-          Offset: 24
-          Type: 75 StructureType sync/atomic.Int32
-        - Name: reparentID
-          Offset: 32
-          Type: 9 GoStringHeaderType string
-        - Name: isRemote
-          Offset: 48
-          Type: 4 BaseType bool
-        - Name: traceID
-          Offset: 49
-          Type: 132 ArrayType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.traceID
-        - Name: spanID
-          Offset: 72
-          Type: 8 BaseType uint64
-        - Name: mu
-          Offset: 80
-          Type: 71 StructureType sync.RWMutex
-        - Name: baggage
-          Offset: 104
-          Type: 66 GoMapType map[string]string
-        - Name: hasBaggage
-          Offset: 112
-          Type: 2 BaseType uint32
-        - Name: origin
-          Offset: 120
-          Type: 9 GoStringHeaderType string
-        - Name: spanLinks
-          Offset: 136
-          Type: 87 GoSliceHeaderType []github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink
-        - Name: baggageOnly
-          Offset: 160
-          Type: 4 BaseType bool
-    - __kind: StructureType
-      ID: 89
-      Name: github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink
-      ByteSize: 56
-      GoRuntimeType: 1.9464e+06
-      GoKind: 25
-      RawFields:
-        - Name: TraceID
-          Offset: 0
-          Type: 8 BaseType uint64
-        - Name: TraceIDHigh
-          Offset: 8
-          Type: 8 BaseType uint64
-        - Name: SpanID
-          Offset: 16
-          Type: 8 BaseType uint64
-        - Name: Attributes
-          Offset: 24
-          Type: 66 GoMapType map[string]string
-        - Name: Tracestate
-          Offset: 32
-          Type: 9 GoStringHeaderType string
-        - Name: Flags
-          Offset: 48
-          Type: 2 BaseType uint32
-    - __kind: GoMapType
-      ID: 77
-      Name: github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.metaStructMap
       ByteSize: 8
-      GoRuntimeType: 1.299296e+06
-      GoKind: 21
-      HeaderType: 79 GoSwissMapHeaderType map<string,interface {}>
-    - __kind: BaseType
-      ID: 175
-      Name: github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.samplingDecision
-      ByteSize: 4
-      GoRuntimeType: 589984
-      GoKind: 10
-    - __kind: StructureType
+    - __kind: GoSwissMapGroupsType
       ID: 92
-      Name: github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent
-      ByteSize: 40
-      GoRuntimeType: 1.781184e+06
-      GoKind: 25
-      RawFields:
-        - Name: Name
-          Offset: 0
-          Type: 9 GoStringHeaderType string
-        - Name: TimeUnixNano
-          Offset: 16
-          Type: 8 BaseType uint64
-        - Name: Attributes
-          Offset: 24
-          Type: 124 GoMapType map[string]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
-        - Name: RawAttributes
-          Offset: 32
-          Type: 129 GoMapType map[string]interface {}
-    - __kind: StructureType
-      ID: 241
-      Name: github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttribute
-      ByteSize: 24
-      GoRuntimeType: 1.210656e+06
-      GoKind: 25
-      RawFields:
-        - Name: Values
-          Offset: 0
-          Type: 257 GoSliceHeaderType []*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttributeValue
-    - __kind: StructureType
-      ID: 283
-      Name: github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttributeValue
-      ByteSize: 48
-      GoRuntimeType: 1.868992e+06
-      GoKind: 25
-      RawFields:
-        - Name: Type
-          Offset: 0
-          Type: 292 BaseType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttributeValueType
-        - Name: StringValue
-          Offset: 8
-          Type: 9 GoStringHeaderType string
-        - Name: BoolValue
-          Offset: 24
-          Type: 4 BaseType bool
-        - Name: IntValue
-          Offset: 32
-          Type: 13 BaseType int64
-        - Name: DoubleValue
-          Offset: 40
-          Type: 18 BaseType float64
-    - __kind: BaseType
-      ID: 292
-      Name: github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttributeValueType
-      ByteSize: 4
-      GoRuntimeType: 1.001824e+06
-      GoKind: 5
-    - __kind: StructureType
-      ID: 200
-      Name: github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
-      ByteSize: 56
-      GoRuntimeType: 1.946656e+06
-      GoKind: 25
-      RawFields:
-        - Name: Type
-          Offset: 0
-          Type: 239 BaseType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttributeType
-        - Name: StringValue
-          Offset: 8
-          Type: 9 GoStringHeaderType string
-        - Name: BoolValue
-          Offset: 24
-          Type: 4 BaseType bool
-        - Name: IntValue
-          Offset: 32
-          Type: 13 BaseType int64
-        - Name: DoubleValue
-          Offset: 40
-          Type: 18 BaseType float64
-        - Name: ArrayValue
-          Offset: 48
-          Type: 240 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttribute
-    - __kind: BaseType
-      ID: 239
-      Name: github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttributeType
-      ByteSize: 4
-      GoRuntimeType: 1.001728e+06
-      GoKind: 5
-    - __kind: StructureType
-      ID: 131
-      Name: github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.trace
-      ByteSize: 104
-      GoRuntimeType: 2.14816e+06
-      GoKind: 25
-      RawFields:
-        - Name: mu
-          Offset: 0
-          Type: 71 StructureType sync.RWMutex
-        - Name: spans
-          Offset: 24
-          Type: 173 GoSliceHeaderType []*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span
-        - Name: tags
-          Offset: 48
-          Type: 66 GoMapType map[string]string
-        - Name: propagatingTags
-          Offset: 56
-          Type: 66 GoMapType map[string]string
-        - Name: finished
-          Offset: 64
-          Type: 7 BaseType int
-        - Name: full
-          Offset: 72
-          Type: 4 BaseType bool
-        - Name: priority
-          Offset: 80
-          Type: 26 PointerType *float64
-        - Name: locked
-          Offset: 88
-          Type: 4 BaseType bool
-        - Name: samplingDecision
-          Offset: 92
-          Type: 175 BaseType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.samplingDecision
-        - Name: root
-          Offset: 96
-          Type: 39 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span
-    - __kind: ArrayType
-      ID: 132
-      Name: github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.traceID
-      ByteSize: 16
-      GoRuntimeType: 914336
-      GoKind: 17
-      Count: 16
-      HasCount: true
-      Element: 3 BaseType uint8
-    - __kind: GoSwissMapGroupsType
-      ID: 194
-      Name: groupReference<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
-      ByteSize: 16
-      GoKind: 25
-      RawFields:
-        - Name: data
-          Offset: 0
-          Type: 195 PointerType *noalg.map.group[string]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
-        - Name: lengthMask
-          Offset: 8
-          Type: 8 BaseType uint64
-      GroupType: 196 StructureType noalg.map.group[string]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
-      GroupSliceType: 202 GoSliceDataType []noalg.map.group[string]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute.array
-    - __kind: GoSwissMapGroupsType
-      ID: 176
       Name: groupReference<string,[]*mime/multipart.FileHeader>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 177 PointerType *noalg.map.group[string][]*mime/multipart.FileHeader
+          Type: 93 PointerType *noalg.map.group[string][]*mime/multipart.FileHeader
         - Name: lengthMask
           Offset: 8
           Type: 8 BaseType uint64
-      GroupType: 178 StructureType noalg.map.group[string][]*mime/multipart.FileHeader
-      GroupSliceType: 185 GoSliceDataType []noalg.map.group[string][]*mime/multipart.FileHeader.array
+      GroupType: 94 StructureType noalg.map.group[string][]*mime/multipart.FileHeader
+      GroupSliceType: 101 GoSliceDataType []noalg.map.group[string][]*mime/multipart.FileHeader.array
     - __kind: GoSwissMapGroupsType
-      ID: 133
+      ID: 76
       Name: groupReference<string,[]string>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 134 PointerType *noalg.map.group[string][]string
+          Type: 77 PointerType *noalg.map.group[string][]string
         - Name: lengthMask
           Offset: 8
           Type: 8 BaseType uint64
-      GroupType: 135 StructureType noalg.map.group[string][]string
-      GroupSliceType: 139 GoSliceDataType []noalg.map.group[string][]string.array
+      GroupType: 78 StructureType noalg.map.group[string][]string
+      GroupSliceType: 82 GoSliceDataType []noalg.map.group[string][]string.array
     - __kind: GoSwissMapGroupsType
-      ID: 157
-      Name: groupReference<string,float64>
-      ByteSize: 16
-      GoKind: 25
-      RawFields:
-        - Name: data
-          Offset: 0
-          Type: 158 PointerType *noalg.map.group[string]float64
-        - Name: lengthMask
-          Offset: 8
-          Type: 8 BaseType uint64
-      GroupType: 159 StructureType noalg.map.group[string]float64
-      GroupSliceType: 163 GoSliceDataType []noalg.map.group[string]float64.array
-    - __kind: GoSwissMapGroupsType
-      ID: 149
-      Name: groupReference<string,interface {}>
-      ByteSize: 16
-      GoKind: 25
-      RawFields:
-        - Name: data
-          Offset: 0
-          Type: 150 PointerType *noalg.map.group[string]interface {}
-        - Name: lengthMask
-          Offset: 8
-          Type: 8 BaseType uint64
-      GroupType: 151 StructureType noalg.map.group[string]interface {}
-      GroupSliceType: 156 GoSliceDataType []noalg.map.group[string]interface {}.array
-    - __kind: GoSwissMapGroupsType
-      ID: 142
+      ID: 208
       Name: groupReference<string,string>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 143 PointerType *noalg.map.group[string]string
+          Type: 209 PointerType *noalg.map.group[string]string
         - Name: lengthMask
           Offset: 8
           Type: 8 BaseType uint64
-      GroupType: 144 StructureType noalg.map.group[string]string
-      GroupSliceType: 148 GoSliceDataType []noalg.map.group[string]string.array
+      GroupType: 210 StructureType noalg.map.group[string]string
+      GroupSliceType: 214 GoSliceDataType []noalg.map.group[string]string.array
     - __kind: BaseType
       ID: 7
       Name: int
@@ -2222,7 +1598,7 @@ Types:
       GoRuntimeType: 590240
       GoKind: 3
     - __kind: GoEmptyInterfaceType
-      ID: 154
+      ID: 127
       Name: interface {}
       ByteSize: 16
       GoRuntimeType: 863072
@@ -2234,21 +1610,8 @@ Types:
         - Name: data
           Offset: 8
           Type: 15 VoidPointerType unsafe.Pointer
-    - __kind: StructureType
-      ID: 74
-      Name: internal/sync.Mutex
-      ByteSize: 8
-      GoRuntimeType: 1.51232e+06
-      GoKind: 25
-      RawFields:
-        - Name: state
-          Offset: 0
-          Type: 12 BaseType int32
-        - Name: sema
-          Offset: 4
-          Type: 2 BaseType uint32
     - __kind: GoInterfaceType
-      ID: 52
+      ID: 54
       Name: io.ReadCloser
       ByteSize: 16
       GoRuntimeType: 1.129632e+06
@@ -2261,39 +1624,7 @@ Types:
           Offset: 8
           Type: 15 VoidPointerType unsafe.Pointer
     - __kind: GoSwissMapHeaderType
-      ID: 126
-      Name: map<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
-      ByteSize: 48
-      GoKind: 25
-      RawFields:
-        - Name: used
-          Offset: 0
-          Type: 8 BaseType uint64
-        - Name: seed
-          Offset: 8
-          Type: 1 BaseType uintptr
-        - Name: dirPtr
-          Offset: 16
-          Type: 127 PointerType **table<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
-        - Name: dirLen
-          Offset: 24
-          Type: 7 BaseType int
-        - Name: globalDepth
-          Offset: 32
-          Type: 3 BaseType uint8
-        - Name: globalShift
-          Offset: 33
-          Type: 3 BaseType uint8
-        - Name: writing
-          Offset: 34
-          Type: 3 BaseType uint8
-        - Name: clearSeq
-          Offset: 40
-          Type: 8 BaseType uint64
-      TablePtrSliceType: 201 GoSliceDataType []*table<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>.array
-      GroupType: 196 StructureType noalg.map.group[string]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
-    - __kind: GoSwissMapHeaderType
-      ID: 106
+      ID: 88
       Name: map<string,[]*mime/multipart.FileHeader>
       ByteSize: 48
       GoKind: 25
@@ -2306,7 +1637,7 @@ Types:
           Type: 1 BaseType uintptr
         - Name: dirPtr
           Offset: 16
-          Type: 107 PointerType **table<string,[]*mime/multipart.FileHeader>
+          Type: 89 PointerType **table<string,[]*mime/multipart.FileHeader>
         - Name: dirLen
           Offset: 24
           Type: 7 BaseType int
@@ -2322,10 +1653,10 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 8 BaseType uint64
-      TablePtrSliceType: 184 GoSliceDataType []*table<string,[]*mime/multipart.FileHeader>.array
-      GroupType: 178 StructureType noalg.map.group[string][]*mime/multipart.FileHeader
+      TablePtrSliceType: 100 GoSliceDataType []*table<string,[]*mime/multipart.FileHeader>.array
+      GroupType: 94 StructureType noalg.map.group[string][]*mime/multipart.FileHeader
     - __kind: GoSwissMapHeaderType
-      ID: 49
+      ID: 51
       Name: map<string,[]string>
       ByteSize: 48
       GoKind: 25
@@ -2338,7 +1669,7 @@ Types:
           Type: 1 BaseType uintptr
         - Name: dirPtr
           Offset: 16
-          Type: 50 PointerType **table<string,[]string>
+          Type: 52 PointerType **table<string,[]string>
         - Name: dirLen
           Offset: 24
           Type: 7 BaseType int
@@ -2354,74 +1685,10 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 8 BaseType uint64
-      TablePtrSliceType: 138 GoSliceDataType []*table<string,[]string>.array
-      GroupType: 135 StructureType noalg.map.group[string][]string
+      TablePtrSliceType: 81 GoSliceDataType []*table<string,[]string>.array
+      GroupType: 78 StructureType noalg.map.group[string][]string
     - __kind: GoSwissMapHeaderType
-      ID: 84
-      Name: map<string,float64>
-      ByteSize: 48
-      GoKind: 25
-      RawFields:
-        - Name: used
-          Offset: 0
-          Type: 8 BaseType uint64
-        - Name: seed
-          Offset: 8
-          Type: 1 BaseType uintptr
-        - Name: dirPtr
-          Offset: 16
-          Type: 85 PointerType **table<string,float64>
-        - Name: dirLen
-          Offset: 24
-          Type: 7 BaseType int
-        - Name: globalDepth
-          Offset: 32
-          Type: 3 BaseType uint8
-        - Name: globalShift
-          Offset: 33
-          Type: 3 BaseType uint8
-        - Name: writing
-          Offset: 34
-          Type: 3 BaseType uint8
-        - Name: clearSeq
-          Offset: 40
-          Type: 8 BaseType uint64
-      TablePtrSliceType: 162 GoSliceDataType []*table<string,float64>.array
-      GroupType: 159 StructureType noalg.map.group[string]float64
-    - __kind: GoSwissMapHeaderType
-      ID: 79
-      Name: map<string,interface {}>
-      ByteSize: 48
-      GoKind: 25
-      RawFields:
-        - Name: used
-          Offset: 0
-          Type: 8 BaseType uint64
-        - Name: seed
-          Offset: 8
-          Type: 1 BaseType uintptr
-        - Name: dirPtr
-          Offset: 16
-          Type: 80 PointerType **table<string,interface {}>
-        - Name: dirLen
-          Offset: 24
-          Type: 7 BaseType int
-        - Name: globalDepth
-          Offset: 32
-          Type: 3 BaseType uint8
-        - Name: globalShift
-          Offset: 33
-          Type: 3 BaseType uint8
-        - Name: writing
-          Offset: 34
-          Type: 3 BaseType uint8
-        - Name: clearSeq
-          Offset: 40
-          Type: 8 BaseType uint64
-      TablePtrSliceType: 155 GoSliceDataType []*table<string,interface {}>.array
-      GroupType: 151 StructureType noalg.map.group[string]interface {}
-    - __kind: GoSwissMapHeaderType
-      ID: 68
+      ID: 70
       Name: map<string,string>
       ByteSize: 48
       GoKind: 25
@@ -2434,7 +1701,7 @@ Types:
           Type: 1 BaseType uintptr
         - Name: dirPtr
           Offset: 16
-          Type: 69 PointerType **table<string,string>
+          Type: 71 PointerType **table<string,string>
         - Name: dirLen
           Offset: 24
           Type: 7 BaseType int
@@ -2450,52 +1717,31 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 8 BaseType uint64
-      TablePtrSliceType: 147 GoSliceDataType []*table<string,string>.array
-      GroupType: 144 StructureType noalg.map.group[string]string
+      TablePtrSliceType: 213 GoSliceDataType []*table<string,string>.array
+      GroupType: 210 StructureType noalg.map.group[string]string
     - __kind: GoMapType
-      ID: 124
-      Name: map[string]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
-      ByteSize: 8
-      GoRuntimeType: 1.153056e+06
-      GoKind: 21
-      HeaderType: 126 GoSwissMapHeaderType map<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
-    - __kind: GoMapType
-      ID: 104
+      ID: 86
       Name: map[string][]*mime/multipart.FileHeader
       ByteSize: 8
       GoRuntimeType: 1.152288e+06
       GoKind: 21
-      HeaderType: 106 GoSwissMapHeaderType map<string,[]*mime/multipart.FileHeader>
+      HeaderType: 88 GoSwissMapHeaderType map<string,[]*mime/multipart.FileHeader>
     - __kind: GoMapType
-      ID: 103
+      ID: 85
       Name: map[string][]string
       ByteSize: 8
       GoRuntimeType: 1.14768e+06
       GoKind: 21
-      HeaderType: 49 GoSwissMapHeaderType map<string,[]string>
+      HeaderType: 51 GoSwissMapHeaderType map<string,[]string>
     - __kind: GoMapType
-      ID: 82
-      Name: map[string]float64
-      ByteSize: 8
-      GoRuntimeType: 1.152928e+06
-      GoKind: 21
-      HeaderType: 84 GoSwissMapHeaderType map<string,float64>
-    - __kind: GoMapType
-      ID: 129
-      Name: map[string]interface {}
-      ByteSize: 8
-      GoRuntimeType: 1.146272e+06
-      GoKind: 21
-      HeaderType: 79 GoSwissMapHeaderType map<string,interface {}>
-    - __kind: GoMapType
-      ID: 66
+      ID: 68
       Name: map[string]string
       ByteSize: 8
       GoRuntimeType: 1.148704e+06
       GoKind: 21
-      HeaderType: 68 GoSwissMapHeaderType map<string,string>
+      HeaderType: 70 GoSwissMapHeaderType map<string,string>
     - __kind: StructureType
-      ID: 206
+      ID: 129
       Name: math/big.Int
       ByteSize: 32
       GoRuntimeType: 1.51744e+06
@@ -2506,15 +1752,15 @@ Types:
           Type: 4 BaseType bool
         - Name: abs
           Offset: 8
-          Type: 246 GoSliceHeaderType math/big.nat
+          Type: 161 GoSliceHeaderType math/big.nat
     - __kind: BaseType
-      ID: 248
+      ID: 163
       Name: math/big.Word
       ByteSize: 8
       GoRuntimeType: 594464
       GoKind: 7
     - __kind: GoSliceHeaderType
-      ID: 246
+      ID: 161
       Name: math/big.nat
       ByteSize: 24
       GoRuntimeType: 2.420864e+06
@@ -2522,21 +1768,21 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 247 PointerType *math/big.Word
+          Type: 162 PointerType *math/big.Word
         - Name: len
           Offset: 8
           Type: 7 BaseType int
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 284 GoSliceDataType math/big.nat.array
+      Data: 164 GoSliceDataType math/big.nat.array
     - __kind: GoSliceDataType
-      ID: 284
+      ID: 164
       Name: math/big.nat.array
       ByteSize: 2048
-      Element: 248 BaseType math/big.Word
+      Element: 163 BaseType math/big.Word
     - __kind: StructureType
-      ID: 238
+      ID: 102
       Name: mime/multipart.FileHeader
       ByteSize: 88
       GoRuntimeType: 2.009312e+06
@@ -2547,13 +1793,13 @@ Types:
           Type: 9 GoStringHeaderType string
         - Name: Header
           Offset: 16
-          Type: 256 GoMapType net/textproto.MIMEHeader
+          Type: 105 GoMapType net/textproto.MIMEHeader
         - Name: Size
           Offset: 24
           Type: 13 BaseType int64
         - Name: content
           Offset: 32
-          Type: 96 GoSliceHeaderType []uint8
+          Type: 106 GoSliceHeaderType []uint8
         - Name: tmpfile
           Offset: 56
           Type: 9 GoStringHeaderType string
@@ -2564,7 +1810,7 @@ Types:
           Offset: 80
           Type: 4 BaseType bool
     - __kind: StructureType
-      ID: 57
+      ID: 59
       Name: mime/multipart.Form
       ByteSize: 16
       GoRuntimeType: 1.5008e+06
@@ -2572,12 +1818,12 @@ Types:
       RawFields:
         - Name: Value
           Offset: 0
-          Type: 103 GoMapType map[string][]string
+          Type: 85 GoMapType map[string][]string
         - Name: File
           Offset: 8
-          Type: 104 GoMapType map[string][]*mime/multipart.FileHeader
+          Type: 86 GoMapType map[string][]*mime/multipart.FileHeader
     - __kind: GoSliceHeaderType
-      ID: 226
+      ID: 149
       Name: net.IP
       ByteSize: 24
       GoRuntimeType: 2.170304e+06
@@ -2592,14 +1838,14 @@ Types:
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 272 GoSliceDataType net.IP.array
+      Data: 197 GoSliceDataType net.IP.array
     - __kind: GoSliceDataType
-      ID: 272
+      ID: 197
       Name: net.IP.array
       ByteSize: 2048
       Element: 3 BaseType uint8
     - __kind: GoSliceHeaderType
-      ID: 282
+      ID: 199
       Name: net.IPMask
       ByteSize: 24
       GoRuntimeType: 1.037408e+06
@@ -2614,14 +1860,14 @@ Types:
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 293 GoSliceDataType net.IPMask.array
+      Data: 200 GoSliceDataType net.IPMask.array
     - __kind: GoSliceDataType
-      ID: 293
+      ID: 200
       Name: net.IPMask.array
       ByteSize: 2048
       Element: 3 BaseType uint8
     - __kind: StructureType
-      ID: 255
+      ID: 188
       Name: net.IPNet
       ByteSize: 48
       GoRuntimeType: 1.48176e+06
@@ -2629,17 +1875,17 @@ Types:
       RawFields:
         - Name: IP
           Offset: 0
-          Type: 226 GoSliceHeaderType net.IP
+          Type: 149 GoSliceHeaderType net.IP
         - Name: Mask
           Offset: 24
-          Type: 282 GoSliceHeaderType net.IPMask
+          Type: 199 GoSliceHeaderType net.IPMask
     - __kind: GoMapType
-      ID: 47
+      ID: 49
       Name: net/http.Header
       ByteSize: 8
       GoRuntimeType: 2.147456e+06
       GoKind: 21
-      HeaderType: 49 GoSwissMapHeaderType map<string,[]string>
+      HeaderType: 51 GoSwissMapHeaderType map<string,[]string>
     - __kind: StructureType
       ID: 38
       Name: net/http.Request
@@ -2652,7 +1898,7 @@ Types:
           Type: 9 GoStringHeaderType string
         - Name: URL
           Offset: 16
-          Type: 45 PointerType *net/url.URL
+          Type: 47 PointerType *net/url.URL
         - Name: Proto
           Offset: 24
           Type: 9 GoStringHeaderType string
@@ -2664,19 +1910,19 @@ Types:
           Type: 7 BaseType int
         - Name: Header
           Offset: 56
-          Type: 47 GoMapType net/http.Header
+          Type: 49 GoMapType net/http.Header
         - Name: Body
           Offset: 64
-          Type: 52 GoInterfaceType io.ReadCloser
+          Type: 54 GoInterfaceType io.ReadCloser
         - Name: GetBody
           Offset: 80
-          Type: 53 GoSubroutineType func() (io.ReadCloser, error)
+          Type: 55 GoSubroutineType func() (io.ReadCloser, error)
         - Name: ContentLength
           Offset: 88
           Type: 13 BaseType int64
         - Name: TransferEncoding
           Offset: 96
-          Type: 54 GoSliceHeaderType []string
+          Type: 56 GoSliceHeaderType []string
         - Name: Close
           Offset: 120
           Type: 4 BaseType bool
@@ -2685,16 +1931,16 @@ Types:
           Type: 9 GoStringHeaderType string
         - Name: Form
           Offset: 144
-          Type: 55 GoMapType net/url.Values
+          Type: 57 GoMapType net/url.Values
         - Name: PostForm
           Offset: 152
-          Type: 55 GoMapType net/url.Values
+          Type: 57 GoMapType net/url.Values
         - Name: MultipartForm
           Offset: 160
-          Type: 56 PointerType *mime/multipart.Form
+          Type: 58 PointerType *mime/multipart.Form
         - Name: Trailer
           Offset: 168
-          Type: 47 GoMapType net/http.Header
+          Type: 49 GoMapType net/http.Header
         - Name: RemoteAddr
           Offset: 176
           Type: 9 GoStringHeaderType string
@@ -2703,30 +1949,30 @@ Types:
           Type: 9 GoStringHeaderType string
         - Name: TLS
           Offset: 208
-          Type: 58 PointerType *crypto/tls.ConnectionState
+          Type: 60 PointerType *crypto/tls.ConnectionState
         - Name: Cancel
           Offset: 216
-          Type: 60 GoChannelType <-chan struct {}
+          Type: 62 GoChannelType <-chan struct {}
         - Name: Response
           Offset: 224
-          Type: 61 PointerType *net/http.Response
+          Type: 63 PointerType *net/http.Response
         - Name: Pattern
           Offset: 232
           Type: 9 GoStringHeaderType string
         - Name: ctx
           Offset: 248
-          Type: 63 GoInterfaceType context.Context
+          Type: 65 GoInterfaceType context.Context
         - Name: pat
           Offset: 264
-          Type: 64 PointerType *net/http.pattern
+          Type: 66 PointerType *net/http.pattern
         - Name: matches
           Offset: 272
-          Type: 54 GoSliceHeaderType []string
+          Type: 56 GoSliceHeaderType []string
         - Name: otherValues
           Offset: 296
-          Type: 66 GoMapType map[string]string
+          Type: 68 GoMapType map[string]string
     - __kind: StructureType
-      ID: 62
+      ID: 64
       Name: net/http.Response
       ByteSize: 144
       GoRuntimeType: 2.25968e+06
@@ -2749,16 +1995,16 @@ Types:
           Type: 7 BaseType int
         - Name: Header
           Offset: 56
-          Type: 47 GoMapType net/http.Header
+          Type: 49 GoMapType net/http.Header
         - Name: Body
           Offset: 64
-          Type: 52 GoInterfaceType io.ReadCloser
+          Type: 54 GoInterfaceType io.ReadCloser
         - Name: ContentLength
           Offset: 80
           Type: 13 BaseType int64
         - Name: TransferEncoding
           Offset: 88
-          Type: 54 GoSliceHeaderType []string
+          Type: 56 GoSliceHeaderType []string
         - Name: Close
           Offset: 112
           Type: 4 BaseType bool
@@ -2767,13 +2013,13 @@ Types:
           Type: 4 BaseType bool
         - Name: Trailer
           Offset: 120
-          Type: 47 GoMapType net/http.Header
+          Type: 49 GoMapType net/http.Header
         - Name: Request
           Offset: 128
           Type: 37 PointerType *net/http.Request
         - Name: TLS
           Offset: 136
-          Type: 58 PointerType *crypto/tls.ConnectionState
+          Type: 60 PointerType *crypto/tls.ConnectionState
     - __kind: GoInterfaceType
       ID: 36
       Name: net/http.ResponseWriter
@@ -2788,7 +2034,7 @@ Types:
           Offset: 8
           Type: 15 VoidPointerType unsafe.Pointer
     - __kind: StructureType
-      ID: 65
+      ID: 67
       Name: net/http.pattern
       ByteSize: 88
       GoRuntimeType: 1.865856e+06
@@ -2805,12 +2051,12 @@ Types:
           Type: 9 GoStringHeaderType string
         - Name: segments
           Offset: 48
-          Type: 118 GoSliceHeaderType []net/http.segment
+          Type: 202 GoSliceHeaderType []net/http.segment
         - Name: loc
           Offset: 72
           Type: 9 GoStringHeaderType string
     - __kind: StructureType
-      ID: 120
+      ID: 204
       Name: net/http.segment
       ByteSize: 24
       GoRuntimeType: 1.637088e+06
@@ -2826,14 +2072,14 @@ Types:
           Offset: 17
           Type: 4 BaseType bool
     - __kind: GoMapType
-      ID: 256
+      ID: 105
       Name: net/textproto.MIMEHeader
       ByteSize: 8
       GoRuntimeType: 1.854368e+06
       GoKind: 21
-      HeaderType: 49 GoSwissMapHeaderType map<string,[]string>
+      HeaderType: 51 GoSwissMapHeaderType map<string,[]string>
     - __kind: StructureType
-      ID: 46
+      ID: 48
       Name: net/url.URL
       ByteSize: 144
       GoRuntimeType: 2.172992e+06
@@ -2847,7 +2093,7 @@ Types:
           Type: 9 GoStringHeaderType string
         - Name: User
           Offset: 32
-          Type: 100 PointerType *net/url.Userinfo
+          Type: 73 PointerType *net/url.Userinfo
         - Name: Host
           Offset: 40
           Type: 9 GoStringHeaderType string
@@ -2873,7 +2119,7 @@ Types:
           Offset: 128
           Type: 9 GoStringHeaderType string
     - __kind: StructureType
-      ID: 101
+      ID: 74
       Name: net/url.Userinfo
       ByteSize: 40
       GoRuntimeType: 1.653024e+06
@@ -2889,81 +2135,41 @@ Types:
           Offset: 32
           Type: 4 BaseType bool
     - __kind: GoMapType
-      ID: 55
+      ID: 57
       Name: net/url.Values
       ByteSize: 8
       GoRuntimeType: 1.920064e+06
       GoKind: 21
-      HeaderType: 49 GoSwissMapHeaderType map<string,[]string>
+      HeaderType: 51 GoSwissMapHeaderType map<string,[]string>
     - __kind: ArrayType
-      ID: 197
-      Name: noalg.[8]struct { key string; elem *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute }
-      ByteSize: 192
-      GoRuntimeType: 711712
-      GoKind: 17
-      Count: 8
-      HasCount: true
-      Element: 198 StructureType noalg.struct { key string; elem *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute }
-    - __kind: ArrayType
-      ID: 179
+      ID: 95
       Name: noalg.[8]struct { key string; elem []*mime/multipart.FileHeader }
       ByteSize: 320
       GoRuntimeType: 707136
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 180 StructureType noalg.struct { key string; elem []*mime/multipart.FileHeader }
+      Element: 96 StructureType noalg.struct { key string; elem []*mime/multipart.FileHeader }
     - __kind: ArrayType
-      ID: 136
+      ID: 79
       Name: noalg.[8]struct { key string; elem []string }
       ByteSize: 320
       GoRuntimeType: 697120
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 137 StructureType noalg.struct { key string; elem []string }
+      Element: 80 StructureType noalg.struct { key string; elem []string }
     - __kind: ArrayType
-      ID: 160
-      Name: noalg.[8]struct { key string; elem float64 }
-      ByteSize: 192
-      GoRuntimeType: 711616
-      GoKind: 17
-      Count: 8
-      HasCount: true
-      Element: 161 StructureType noalg.struct { key string; elem float64 }
-    - __kind: ArrayType
-      ID: 152
-      Name: noalg.[8]struct { key string; elem interface {} }
-      ByteSize: 256
-      GoRuntimeType: 688576
-      GoKind: 17
-      Count: 8
-      HasCount: true
-      Element: 153 StructureType noalg.struct { key string; elem interface {} }
-    - __kind: ArrayType
-      ID: 145
+      ID: 211
       Name: noalg.[8]struct { key string; elem string }
       ByteSize: 256
       GoRuntimeType: 701280
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 146 StructureType noalg.struct { key string; elem string }
+      Element: 212 StructureType noalg.struct { key string; elem string }
     - __kind: StructureType
-      ID: 196
-      Name: noalg.map.group[string]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
-      ByteSize: 200
-      GoRuntimeType: 1.3272e+06
-      GoKind: 25
-      RawFields:
-        - Name: ctrl
-          Offset: 0
-          Type: 8 BaseType uint64
-        - Name: slots
-          Offset: 8
-          Type: 197 ArrayType noalg.[8]struct { key string; elem *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute }
-    - __kind: StructureType
-      ID: 178
+      ID: 94
       Name: noalg.map.group[string][]*mime/multipart.FileHeader
       ByteSize: 328
       GoRuntimeType: 1.320928e+06
@@ -2974,9 +2180,9 @@ Types:
           Type: 8 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 179 ArrayType noalg.[8]struct { key string; elem []*mime/multipart.FileHeader }
+          Type: 95 ArrayType noalg.[8]struct { key string; elem []*mime/multipart.FileHeader }
     - __kind: StructureType
-      ID: 135
+      ID: 78
       Name: noalg.map.group[string][]string
       ByteSize: 328
       GoRuntimeType: 1.311456e+06
@@ -2987,35 +2193,9 @@ Types:
           Type: 8 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 136 ArrayType noalg.[8]struct { key string; elem []string }
+          Type: 79 ArrayType noalg.[8]struct { key string; elem []string }
     - __kind: StructureType
-      ID: 159
-      Name: noalg.map.group[string]float64
-      ByteSize: 200
-      GoRuntimeType: 1.326944e+06
-      GoKind: 25
-      RawFields:
-        - Name: ctrl
-          Offset: 0
-          Type: 8 BaseType uint64
-        - Name: slots
-          Offset: 8
-          Type: 160 ArrayType noalg.[8]struct { key string; elem float64 }
-    - __kind: StructureType
-      ID: 151
-      Name: noalg.map.group[string]interface {}
-      ByteSize: 264
-      GoRuntimeType: 1.308896e+06
-      GoKind: 25
-      RawFields:
-        - Name: ctrl
-          Offset: 0
-          Type: 8 BaseType uint64
-        - Name: slots
-          Offset: 8
-          Type: 152 ArrayType noalg.[8]struct { key string; elem interface {} }
-    - __kind: StructureType
-      ID: 144
+      ID: 210
       Name: noalg.map.group[string]string
       ByteSize: 264
       GoRuntimeType: 1.31376e+06
@@ -3026,22 +2206,9 @@ Types:
           Type: 8 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 145 ArrayType noalg.[8]struct { key string; elem string }
+          Type: 211 ArrayType noalg.[8]struct { key string; elem string }
     - __kind: StructureType
-      ID: 198
-      Name: noalg.struct { key string; elem *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute }
-      ByteSize: 24
-      GoRuntimeType: 1.327072e+06
-      GoKind: 25
-      RawFields:
-        - Name: key
-          Offset: 0
-          Type: 9 GoStringHeaderType string
-        - Name: elem
-          Offset: 16
-          Type: 199 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
-    - __kind: StructureType
-      ID: 180
+      ID: 96
       Name: noalg.struct { key string; elem []*mime/multipart.FileHeader }
       ByteSize: 40
       GoRuntimeType: 1.3208e+06
@@ -3052,9 +2219,9 @@ Types:
           Type: 9 GoStringHeaderType string
         - Name: elem
           Offset: 16
-          Type: 181 GoSliceHeaderType []*mime/multipart.FileHeader
+          Type: 97 GoSliceHeaderType []*mime/multipart.FileHeader
     - __kind: StructureType
-      ID: 137
+      ID: 80
       Name: noalg.struct { key string; elem []string }
       ByteSize: 40
       GoRuntimeType: 1.311328e+06
@@ -3065,35 +2232,9 @@ Types:
           Type: 9 GoStringHeaderType string
         - Name: elem
           Offset: 16
-          Type: 54 GoSliceHeaderType []string
+          Type: 56 GoSliceHeaderType []string
     - __kind: StructureType
-      ID: 161
-      Name: noalg.struct { key string; elem float64 }
-      ByteSize: 24
-      GoRuntimeType: 1.326816e+06
-      GoKind: 25
-      RawFields:
-        - Name: key
-          Offset: 0
-          Type: 9 GoStringHeaderType string
-        - Name: elem
-          Offset: 16
-          Type: 18 BaseType float64
-    - __kind: StructureType
-      ID: 153
-      Name: noalg.struct { key string; elem interface {} }
-      ByteSize: 32
-      GoRuntimeType: 1.308768e+06
-      GoKind: 25
-      RawFields:
-        - Name: key
-          Offset: 0
-          Type: 9 GoStringHeaderType string
-        - Name: elem
-          Offset: 16
-          Type: 154 GoEmptyInterfaceType interface {}
-    - __kind: StructureType
-      ID: 146
+      ID: 212
       Name: noalg.struct { key string; elem string }
       ByteSize: 32
       GoRuntimeType: 1.313632e+06
@@ -3114,101 +2255,17 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 99 PointerType *string.str
+          Type: 46 PointerType *string.str
         - Name: len
           Offset: 8
           Type: 7 BaseType int
-      Data: 98 GoStringDataType string.str
+      Data: 45 GoStringDataType string.str
     - __kind: GoStringDataType
-      ID: 98
+      ID: 45
       Name: string.str
       ByteSize: 2048
     - __kind: StructureType
-      ID: 72
-      Name: sync.Mutex
-      ByteSize: 8
-      GoRuntimeType: 1.48896e+06
-      GoKind: 25
-      RawFields:
-        - Name: _
-          Offset: 0
-          Type: 73 StructureType sync.noCopy
-        - Name: mu
-          Offset: 0
-          Type: 74 StructureType internal/sync.Mutex
-    - __kind: StructureType
-      ID: 71
-      Name: sync.RWMutex
-      ByteSize: 24
-      GoRuntimeType: 1.87168e+06
-      GoKind: 25
-      RawFields:
-        - Name: w
-          Offset: 0
-          Type: 72 StructureType sync.Mutex
-        - Name: writerSem
-          Offset: 8
-          Type: 2 BaseType uint32
-        - Name: readerSem
-          Offset: 12
-          Type: 2 BaseType uint32
-        - Name: readerCount
-          Offset: 16
-          Type: 75 StructureType sync/atomic.Int32
-        - Name: readerWait
-          Offset: 20
-          Type: 75 StructureType sync/atomic.Int32
-    - __kind: StructureType
-      ID: 73
-      Name: sync.noCopy
-      GoRuntimeType: 1.0024e+06
-      GoKind: 25
-      RawFields: []
-    - __kind: StructureType
-      ID: 75
-      Name: sync/atomic.Int32
-      ByteSize: 4
-      GoRuntimeType: 1.49024e+06
-      GoKind: 25
-      RawFields:
-        - Name: _
-          Offset: 0
-          Type: 76 StructureType sync/atomic.noCopy
-        - Name: v
-          Offset: 0
-          Type: 12 BaseType int32
-    - __kind: StructureType
-      ID: 76
-      Name: sync/atomic.noCopy
-      GoRuntimeType: 1.002496e+06
-      GoKind: 25
-      RawFields: []
-    - __kind: StructureType
-      ID: 172
-      Name: table<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
-      ByteSize: 32
-      GoKind: 25
-      RawFields:
-        - Name: used
-          Offset: 0
-          Type: 6 BaseType uint16
-        - Name: capacity
-          Offset: 2
-          Type: 6 BaseType uint16
-        - Name: growthLeft
-          Offset: 4
-          Type: 6 BaseType uint16
-        - Name: localDepth
-          Offset: 6
-          Type: 3 BaseType uint8
-        - Name: index
-          Offset: 8
-          Type: 7 BaseType int
-        - Name: groups
-          Offset: 16
-          Type: 194 GoSwissMapGroupsType groupReference<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
-    - __kind: StructureType
-      ID: 170
+      ID: 91
       Name: table<string,[]*mime/multipart.FileHeader>
       ByteSize: 32
       GoKind: 25
@@ -3230,9 +2287,9 @@ Types:
           Type: 7 BaseType int
         - Name: groups
           Offset: 16
-          Type: 176 GoSwissMapGroupsType groupReference<string,[]*mime/multipart.FileHeader>
+          Type: 92 GoSwissMapGroupsType groupReference<string,[]*mime/multipart.FileHeader>
     - __kind: StructureType
-      ID: 102
+      ID: 75
       Name: table<string,[]string>
       ByteSize: 32
       GoKind: 25
@@ -3254,57 +2311,9 @@ Types:
           Type: 7 BaseType int
         - Name: groups
           Offset: 16
-          Type: 133 GoSwissMapGroupsType groupReference<string,[]string>
+          Type: 76 GoSwissMapGroupsType groupReference<string,[]string>
     - __kind: StructureType
-      ID: 123
-      Name: table<string,float64>
-      ByteSize: 32
-      GoKind: 25
-      RawFields:
-        - Name: used
-          Offset: 0
-          Type: 6 BaseType uint16
-        - Name: capacity
-          Offset: 2
-          Type: 6 BaseType uint16
-        - Name: growthLeft
-          Offset: 4
-          Type: 6 BaseType uint16
-        - Name: localDepth
-          Offset: 6
-          Type: 3 BaseType uint8
-        - Name: index
-          Offset: 8
-          Type: 7 BaseType int
-        - Name: groups
-          Offset: 16
-          Type: 157 GoSwissMapGroupsType groupReference<string,float64>
-    - __kind: StructureType
-      ID: 122
-      Name: table<string,interface {}>
-      ByteSize: 32
-      GoKind: 25
-      RawFields:
-        - Name: used
-          Offset: 0
-          Type: 6 BaseType uint16
-        - Name: capacity
-          Offset: 2
-          Type: 6 BaseType uint16
-        - Name: growthLeft
-          Offset: 4
-          Type: 6 BaseType uint16
-        - Name: localDepth
-          Offset: 6
-          Type: 3 BaseType uint8
-        - Name: index
-          Offset: 8
-          Type: 7 BaseType int
-        - Name: groups
-          Offset: 16
-          Type: 149 GoSwissMapGroupsType groupReference<string,interface {}>
-    - __kind: StructureType
-      ID: 121
+      ID: 207
       Name: table<string,string>
       ByteSize: 32
       GoKind: 25
@@ -3326,9 +2335,9 @@ Types:
           Type: 7 BaseType int
         - Name: groups
           Offset: 16
-          Type: 142 GoSwissMapGroupsType groupReference<string,string>
+          Type: 208 GoSwissMapGroupsType groupReference<string,string>
     - __kind: StructureType
-      ID: 213
+      ID: 136
       Name: time.Location
       ByteSize: 104
       GoRuntimeType: 2.00528e+06
@@ -3339,10 +2348,10 @@ Types:
           Type: 9 GoStringHeaderType string
         - Name: zone
           Offset: 16
-          Type: 249 GoSliceHeaderType []time.zone
+          Type: 168 GoSliceHeaderType []time.zone
         - Name: tx
           Offset: 40
-          Type: 252 GoSliceHeaderType []time.zoneTrans
+          Type: 171 GoSliceHeaderType []time.zoneTrans
         - Name: extend
           Offset: 64
           Type: 9 GoStringHeaderType string
@@ -3354,9 +2363,9 @@ Types:
           Type: 13 BaseType int64
         - Name: cacheZone
           Offset: 96
-          Type: 250 PointerType *time.zone
+          Type: 169 PointerType *time.zone
     - __kind: StructureType
-      ID: 211
+      ID: 134
       Name: time.Time
       ByteSize: 24
       GoRuntimeType: 2.42368e+06
@@ -3370,9 +2379,9 @@ Types:
           Type: 13 BaseType int64
         - Name: loc
           Offset: 16
-          Type: 212 PointerType *time.Location
+          Type: 135 PointerType *time.Location
     - __kind: StructureType
-      ID: 251
+      ID: 170
       Name: time.zone
       ByteSize: 32
       GoRuntimeType: 1.64208e+06
@@ -3388,7 +2397,7 @@ Types:
           Offset: 24
           Type: 4 BaseType bool
     - __kind: StructureType
-      ID: 254
+      ID: 173
       Name: time.zoneTrans
       ByteSize: 16
       GoRuntimeType: 1.780992e+06
@@ -3448,6 +2457,6 @@ Types:
       ByteSize: 8
       GoRuntimeType: 591264
       GoKind: 26
-MaxTypeID: 296
+MaxTypeID: 216
 Issues: []
 GoModuledataInfo: {FirstModuledataAddr: "0x13dd6a0", TypesOffset: 296}

--- a/pkg/dyninst/irgen/testdata/snapshot/rc_tester.arch=arm64,toolchain=go1.24.3.yaml
+++ b/pkg/dyninst/irgen/testdata/snapshot/rc_tester.arch=arm64,toolchain=go1.24.3.yaml
@@ -65,14 +65,14 @@ Subprograms:
           IsParameter: true
           IsReturn: false
         - Name: span
-          Type: 157 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span
+          Type: 39 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span
           Locations:
             - Range: 0x8a0d08..0x8a0d38
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: false
           IsReturn: false
         - Name: '&buf'
-          Type: 224 PointerType *bytes.Buffer
+          Type: 41 PointerType *bytes.Buffer
           Locations:
             - Range: 0x8a0ddc..0x8a0df0
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
@@ -81,7 +81,7 @@ Subprograms:
           IsParameter: false
           IsReturn: false
         - Name: .autotmp_14
-          Type: 227 StructureType context.backgroundCtx
+          Type: 43 StructureType context.backgroundCtx
           Locations:
             - Range: 0x8a0c90..0x8a0ec0
               Pieces: [{Size: 0, Op: {CfaOffset: 0}}]
@@ -105,193 +105,193 @@ Subprograms:
           IsReturn: false
 Types:
     - __kind: PointerType
-      ID: 81
+      ID: 108
       Name: '**crypto/x509.Certificate'
       ByteSize: 8
       GoKind: 22
-      Pointee: 82 PointerType *crypto/x509.Certificate
+      Pointee: 109 PointerType *crypto/x509.Certificate
     - __kind: PointerType
-      ID: 220
+      ID: 147
       Name: '**github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span'
       ByteSize: 8
       GoKind: 22
-      Pointee: 157 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span
+      Pointee: 39 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span
     - __kind: PointerType
-      ID: 210
+      ID: 225
       Name: '**github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttributeValue'
       ByteSize: 8
       GoKind: 22
-      Pointee: 211 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttributeValue
+      Pointee: 226 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttributeValue
     - __kind: PointerType
-      ID: 73
+      ID: 202
       Name: '**mime/multipart.FileHeader'
       ByteSize: 8
       GoKind: 22
-      Pointee: 74 PointerType *mime/multipart.FileHeader
+      Pointee: 203 PointerType *mime/multipart.FileHeader
     - __kind: PointerType
-      ID: 121
+      ID: 182
       Name: '**net.IPNet'
       ByteSize: 8
       GoKind: 22
-      Pointee: 122 PointerType *net.IPNet
+      Pointee: 183 PointerType *net.IPNet
     - __kind: PointerType
-      ID: 119
+      ID: 180
       Name: '**net/url.URL'
       ByteSize: 8
-      Pointee: 39 PointerType *net/url.URL
+      Pointee: 45 PointerType *net/url.URL
     - __kind: PointerType
-      ID: 196
+      ID: 125
       Name: '**table<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>'
       ByteSize: 8
-      Pointee: 197 PointerType *table<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
+      Pointee: 126 PointerType *table<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
     - __kind: PointerType
-      ID: 64
+      ID: 105
       Name: '**table<string,[]*mime/multipart.FileHeader>'
       ByteSize: 8
-      Pointee: 65 PointerType *table<string,[]*mime/multipart.FileHeader>
+      Pointee: 106 PointerType *table<string,[]*mime/multipart.FileHeader>
     - __kind: PointerType
-      ID: 46
+      ID: 50
       Name: '**table<string,[]string>'
       ByteSize: 8
-      Pointee: 47 PointerType *table<string,[]string>
+      Pointee: 51 PointerType *table<string,[]string>
     - __kind: PointerType
-      ID: 179
+      ID: 85
       Name: '**table<string,float64>'
       ByteSize: 8
-      Pointee: 180 PointerType *table<string,float64>
+      Pointee: 86 PointerType *table<string,float64>
     - __kind: PointerType
-      ID: 168
+      ID: 80
       Name: '**table<string,interface {}>'
       ByteSize: 8
-      Pointee: 169 PointerType *table<string,interface {}>
+      Pointee: 81 PointerType *table<string,interface {}>
     - __kind: PointerType
-      ID: 149
+      ID: 69
       Name: '**table<string,string>'
       ByteSize: 8
-      Pointee: 150 PointerType *table<string,string>
+      Pointee: 70 PointerType *table<string,string>
     - __kind: PointerType
-      ID: 132
+      ID: 111
       Name: '*[]*crypto/x509.Certificate'
       ByteSize: 8
       GoKind: 22
-      Pointee: 80 GoSliceHeaderType []*crypto/x509.Certificate
+      Pointee: 107 GoSliceHeaderType []*crypto/x509.Certificate
     - __kind: PointerType
-      ID: 242
+      ID: 250
       Name: '*[]*crypto/x509.Certificate.array'
       ByteSize: 8
-      Pointee: 241 GoSliceDataType []*crypto/x509.Certificate.array
-    - __kind: PointerType
-      ID: 294
-      Name: '*[]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span.array'
-      ByteSize: 8
-      Pointee: 293 GoSliceDataType []*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span.array
-    - __kind: PointerType
-      ID: 292
-      Name: '*[]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttributeValue.array'
-      ByteSize: 8
-      Pointee: 291 GoSliceDataType []*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttributeValue.array
-    - __kind: PointerType
-      ID: 238
-      Name: '*[]*mime/multipart.FileHeader.array'
-      ByteSize: 8
-      Pointee: 237 GoSliceDataType []*mime/multipart.FileHeader.array
-    - __kind: PointerType
-      ID: 266
-      Name: '*[]*net.IPNet.array'
-      ByteSize: 8
-      Pointee: 265 GoSliceDataType []*net.IPNet.array
-    - __kind: PointerType
-      ID: 264
-      Name: '*[]*net/url.URL.array'
-      ByteSize: 8
-      Pointee: 263 GoSliceDataType []*net/url.URL.array
-    - __kind: PointerType
-      ID: 274
-      Name: '*[][]*crypto/x509.Certificate.array'
-      ByteSize: 8
-      Pointee: 273 GoSliceDataType [][]*crypto/x509.Certificate.array
-    - __kind: PointerType
-      ID: 276
-      Name: '*[][]uint8.array'
-      ByteSize: 8
-      Pointee: 275 GoSliceDataType [][]uint8.array
-    - __kind: PointerType
-      ID: 258
-      Name: '*[]crypto/x509.ExtKeyUsage.array'
-      ByteSize: 8
-      Pointee: 257 GoSliceDataType []crypto/x509.ExtKeyUsage.array
-    - __kind: PointerType
-      ID: 270
-      Name: '*[]crypto/x509.OID.array'
-      ByteSize: 8
-      Pointee: 269 GoSliceDataType []crypto/x509.OID.array
-    - __kind: PointerType
-      ID: 272
-      Name: '*[]crypto/x509.PolicyMapping.array'
-      ByteSize: 8
-      Pointee: 271 GoSliceDataType []crypto/x509.PolicyMapping.array
-    - __kind: PointerType
-      ID: 246
-      Name: '*[]crypto/x509/pkix.AttributeTypeAndValue.array'
-      ByteSize: 8
-      Pointee: 245 GoSliceDataType []crypto/x509/pkix.AttributeTypeAndValue.array
-    - __kind: PointerType
-      ID: 254
-      Name: '*[]crypto/x509/pkix.Extension.array'
-      ByteSize: 8
-      Pointee: 253 GoSliceDataType []crypto/x509/pkix.Extension.array
-    - __kind: PointerType
-      ID: 256
-      Name: '*[]encoding/asn1.ObjectIdentifier.array'
-      ByteSize: 8
-      Pointee: 255 GoSliceDataType []encoding/asn1.ObjectIdentifier.array
-    - __kind: PointerType
-      ID: 286
-      Name: '*[]github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink.array'
-      ByteSize: 8
-      Pointee: 285 GoSliceDataType []github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink.array
-    - __kind: PointerType
-      ID: 288
-      Name: '*[]github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent.array'
-      ByteSize: 8
-      Pointee: 287 GoSliceDataType []github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent.array
+      Pointee: 249 GoSliceDataType []*crypto/x509.Certificate.array
     - __kind: PointerType
       ID: 260
-      Name: '*[]net.IP.array'
+      Name: '*[]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span.array'
       ByteSize: 8
-      Pointee: 259 GoSliceDataType []net.IP.array
+      Pointee: 259 GoSliceDataType []*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span.array
+    - __kind: PointerType
+      ID: 294
+      Name: '*[]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttributeValue.array'
+      ByteSize: 8
+      Pointee: 293 GoSliceDataType []*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttributeValue.array
+    - __kind: PointerType
+      ID: 284
+      Name: '*[]*mime/multipart.FileHeader.array'
+      ByteSize: 8
+      Pointee: 283 GoSliceDataType []*mime/multipart.FileHeader.array
     - __kind: PointerType
       ID: 278
+      Name: '*[]*net.IPNet.array'
+      ByteSize: 8
+      Pointee: 277 GoSliceDataType []*net.IPNet.array
+    - __kind: PointerType
+      ID: 276
+      Name: '*[]*net/url.URL.array'
+      ByteSize: 8
+      Pointee: 275 GoSliceDataType []*net/url.URL.array
+    - __kind: PointerType
+      ID: 252
+      Name: '*[][]*crypto/x509.Certificate.array'
+      ByteSize: 8
+      Pointee: 251 GoSliceDataType [][]*crypto/x509.Certificate.array
+    - __kind: PointerType
+      ID: 254
+      Name: '*[][]uint8.array'
+      ByteSize: 8
+      Pointee: 253 GoSliceDataType [][]uint8.array
+    - __kind: PointerType
+      ID: 270
+      Name: '*[]crypto/x509.ExtKeyUsage.array'
+      ByteSize: 8
+      Pointee: 269 GoSliceDataType []crypto/x509.ExtKeyUsage.array
+    - __kind: PointerType
+      ID: 280
+      Name: '*[]crypto/x509.OID.array'
+      ByteSize: 8
+      Pointee: 279 GoSliceDataType []crypto/x509.OID.array
+    - __kind: PointerType
+      ID: 282
+      Name: '*[]crypto/x509.PolicyMapping.array'
+      ByteSize: 8
+      Pointee: 281 GoSliceDataType []crypto/x509.PolicyMapping.array
+    - __kind: PointerType
+      ID: 262
+      Name: '*[]crypto/x509/pkix.AttributeTypeAndValue.array'
+      ByteSize: 8
+      Pointee: 261 GoSliceDataType []crypto/x509/pkix.AttributeTypeAndValue.array
+    - __kind: PointerType
+      ID: 264
+      Name: '*[]crypto/x509/pkix.Extension.array'
+      ByteSize: 8
+      Pointee: 263 GoSliceDataType []crypto/x509/pkix.Extension.array
+    - __kind: PointerType
+      ID: 266
+      Name: '*[]encoding/asn1.ObjectIdentifier.array'
+      ByteSize: 8
+      Pointee: 265 GoSliceDataType []encoding/asn1.ObjectIdentifier.array
+    - __kind: PointerType
+      ID: 242
+      Name: '*[]github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink.array'
+      ByteSize: 8
+      Pointee: 241 GoSliceDataType []github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink.array
+    - __kind: PointerType
+      ID: 244
+      Name: '*[]github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent.array'
+      ByteSize: 8
+      Pointee: 243 GoSliceDataType []github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent.array
+    - __kind: PointerType
+      ID: 272
+      Name: '*[]net.IP.array'
+      ByteSize: 8
+      Pointee: 271 GoSliceDataType []net.IP.array
+    - __kind: PointerType
+      ID: 256
       Name: '*[]net/http.segment.array'
       ByteSize: 8
-      Pointee: 277 GoSliceDataType []net/http.segment.array
+      Pointee: 255 GoSliceDataType []net/http.segment.array
     - __kind: PointerType
       ID: 234
       Name: '*[]string.array'
       ByteSize: 8
       Pointee: 233 GoSliceDataType []string.array
     - __kind: PointerType
-      ID: 250
+      ID: 288
       Name: '*[]time.zone.array'
       ByteSize: 8
-      Pointee: 249 GoSliceDataType []time.zone.array
+      Pointee: 287 GoSliceDataType []time.zone.array
     - __kind: PointerType
-      ID: 252
+      ID: 290
       Name: '*[]time.zoneTrans.array'
       ByteSize: 8
-      Pointee: 251 GoSliceDataType []time.zoneTrans.array
+      Pointee: 289 GoSliceDataType []time.zoneTrans.array
     - __kind: PointerType
-      ID: 134
+      ID: 113
       Name: '*[]uint8'
       ByteSize: 8
       GoRuntimeType: 483424
       GoKind: 22
-      Pointee: 77 GoSliceHeaderType []uint8
+      Pointee: 96 GoSliceHeaderType []uint8
     - __kind: PointerType
-      ID: 240
+      ID: 246
       Name: '*[]uint8.array'
       ByteSize: 8
-      Pointee: 239 GoSliceDataType []uint8.array
+      Pointee: 245 GoSliceDataType []uint8.array
     - __kind: PointerType
       ID: 11
       Name: '*bool'
@@ -300,73 +300,73 @@ Types:
       GoKind: 22
       Pointee: 4 BaseType bool
     - __kind: PointerType
-      ID: 224
+      ID: 41
       Name: '*bytes.Buffer'
       ByteSize: 8
       GoRuntimeType: 2.316032e+06
       GoKind: 22
-      Pointee: 225 StructureType bytes.Buffer
+      Pointee: 42 StructureType bytes.Buffer
     - __kind: PointerType
-      ID: 78
+      ID: 58
       Name: '*crypto/tls.ConnectionState'
       ByteSize: 8
       GoRuntimeType: 918848
       GoKind: 22
-      Pointee: 79 StructureType crypto/tls.ConnectionState
+      Pointee: 59 StructureType crypto/tls.ConnectionState
     - __kind: PointerType
-      ID: 82
+      ID: 109
       Name: '*crypto/x509.Certificate'
       ByteSize: 8
       GoRuntimeType: 2.081952e+06
       GoKind: 22
-      Pointee: 83 StructureType crypto/x509.Certificate
+      Pointee: 135 StructureType crypto/x509.Certificate
     - __kind: PointerType
-      ID: 113
+      ID: 174
       Name: '*crypto/x509.ExtKeyUsage'
       ByteSize: 8
       GoRuntimeType: 426848
       GoKind: 22
-      Pointee: 114 BaseType crypto/x509.ExtKeyUsage
+      Pointee: 175 BaseType crypto/x509.ExtKeyUsage
     - __kind: PointerType
-      ID: 126
+      ID: 185
       Name: '*crypto/x509.OID'
       ByteSize: 8
       GoRuntimeType: 1.988896e+06
       GoKind: 22
-      Pointee: 127 StructureType crypto/x509.OID
+      Pointee: 186 StructureType crypto/x509.OID
     - __kind: PointerType
-      ID: 129
+      ID: 188
       Name: '*crypto/x509.PolicyMapping'
       ByteSize: 8
       GoRuntimeType: 426912
       GoKind: 22
-      Pointee: 130 StructureType crypto/x509.PolicyMapping
+      Pointee: 189 StructureType crypto/x509.PolicyMapping
     - __kind: PointerType
-      ID: 94
+      ID: 161
       Name: '*crypto/x509/pkix.AttributeTypeAndValue'
       ByteSize: 8
       GoRuntimeType: 443616
       GoKind: 22
-      Pointee: 95 StructureType crypto/x509/pkix.AttributeTypeAndValue
+      Pointee: 162 StructureType crypto/x509/pkix.AttributeTypeAndValue
     - __kind: PointerType
-      ID: 108
+      ID: 168
       Name: '*crypto/x509/pkix.Extension'
       ByteSize: 8
       GoRuntimeType: 443808
       GoKind: 22
-      Pointee: 109 StructureType crypto/x509/pkix.Extension
+      Pointee: 169 StructureType crypto/x509/pkix.Extension
     - __kind: PointerType
-      ID: 111
+      ID: 171
       Name: '*encoding/asn1.ObjectIdentifier'
       ByteSize: 8
       GoRuntimeType: 1.074528e+06
       GoKind: 22
-      Pointee: 96 GoSliceHeaderType encoding/asn1.ObjectIdentifier
+      Pointee: 172 GoSliceHeaderType encoding/asn1.ObjectIdentifier
     - __kind: PointerType
-      ID: 248
+      ID: 268
       Name: '*encoding/asn1.ObjectIdentifier.array'
       ByteSize: 8
-      Pointee: 247 GoSliceDataType encoding/asn1.ObjectIdentifier.array
+      Pointee: 267 GoSliceDataType encoding/asn1.ObjectIdentifier.array
     - __kind: PointerType
       ID: 33
       Name: '*error'
@@ -389,61 +389,61 @@ Types:
       GoKind: 22
       Pointee: 18 BaseType float64
     - __kind: PointerType
-      ID: 157
+      ID: 39
       Name: '*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span'
       ByteSize: 8
       GoRuntimeType: 2.326784e+06
       GoKind: 22
-      Pointee: 158 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span
+      Pointee: 40 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span
     - __kind: PointerType
-      ID: 215
+      ID: 93
       Name: '*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanContext'
       ByteSize: 8
       GoRuntimeType: 2.045472e+06
       GoKind: 22
-      Pointee: 216 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanContext
+      Pointee: 94 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanContext
     - __kind: PointerType
-      ID: 188
+      ID: 88
       Name: '*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink'
       ByteSize: 8
       GoRuntimeType: 1.210016e+06
       GoKind: 22
-      Pointee: 189 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink
+      Pointee: 89 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink
     - __kind: PointerType
-      ID: 191
+      ID: 91
       Name: '*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent'
       ByteSize: 8
       GoRuntimeType: 1.210144e+06
       GoKind: 22
-      Pointee: 192 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent
+      Pointee: 92 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent
     - __kind: PointerType
-      ID: 207
+      ID: 221
       Name: '*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttribute'
       ByteSize: 8
       GoRuntimeType: 1.210784e+06
       GoKind: 22
-      Pointee: 208 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttribute
+      Pointee: 222 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttribute
     - __kind: PointerType
-      ID: 211
+      ID: 226
       Name: '*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttributeValue'
       ByteSize: 8
       GoRuntimeType: 1.210528e+06
       GoKind: 22
-      Pointee: 212 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttributeValue
+      Pointee: 227 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttributeValue
     - __kind: PointerType
-      ID: 204
+      ID: 216
       Name: '*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute'
       ByteSize: 8
       GoRuntimeType: 1.210912e+06
       GoKind: 22
-      Pointee: 205 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
+      Pointee: 217 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
     - __kind: PointerType
-      ID: 217
+      ID: 128
       Name: '*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.trace'
       ByteSize: 8
       GoRuntimeType: 2.269504e+06
       GoKind: 22
-      Pointee: 218 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.trace
+      Pointee: 129 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.trace
     - __kind: PointerType
       ID: 28
       Name: '*int'
@@ -480,92 +480,92 @@ Types:
       GoKind: 22
       Pointee: 16 BaseType int8
     - __kind: PointerType
-      ID: 194
+      ID: 123
       Name: '*map<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>'
       ByteSize: 8
-      Pointee: 195 GoSwissMapHeaderType map<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
+      Pointee: 124 GoSwissMapHeaderType map<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
     - __kind: PointerType
-      ID: 62
+      ID: 103
       Name: '*map<string,[]*mime/multipart.FileHeader>'
       ByteSize: 8
-      Pointee: 63 GoSwissMapHeaderType map<string,[]*mime/multipart.FileHeader>
+      Pointee: 104 GoSwissMapHeaderType map<string,[]*mime/multipart.FileHeader>
     - __kind: PointerType
-      ID: 44
+      ID: 48
       Name: '*map<string,[]string>'
       ByteSize: 8
-      Pointee: 45 GoSwissMapHeaderType map<string,[]string>
+      Pointee: 49 GoSwissMapHeaderType map<string,[]string>
     - __kind: PointerType
-      ID: 177
+      ID: 83
       Name: '*map<string,float64>'
       ByteSize: 8
-      Pointee: 178 GoSwissMapHeaderType map<string,float64>
+      Pointee: 84 GoSwissMapHeaderType map<string,float64>
     - __kind: PointerType
-      ID: 166
+      ID: 78
       Name: '*map<string,interface {}>'
       ByteSize: 8
-      Pointee: 167 GoSwissMapHeaderType map<string,interface {}>
+      Pointee: 79 GoSwissMapHeaderType map<string,interface {}>
     - __kind: PointerType
-      ID: 147
+      ID: 67
       Name: '*map<string,string>'
       ByteSize: 8
-      Pointee: 148 GoSwissMapHeaderType map<string,string>
+      Pointee: 68 GoSwissMapHeaderType map<string,string>
     - __kind: PointerType
-      ID: 87
+      ID: 157
       Name: '*math/big.Int'
       ByteSize: 8
       GoRuntimeType: 2.440096e+06
       GoKind: 22
-      Pointee: 88 StructureType math/big.Int
+      Pointee: 158 StructureType math/big.Int
     - __kind: PointerType
-      ID: 90
+      ID: 205
       Name: '*math/big.Word'
       ByteSize: 8
       GoRuntimeType: 429728
       GoKind: 22
-      Pointee: 91 BaseType math/big.Word
+      Pointee: 206 BaseType math/big.Word
     - __kind: PointerType
-      ID: 244
+      ID: 286
       Name: '*math/big.nat.array'
       ByteSize: 8
-      Pointee: 243 GoSliceDataType math/big.nat.array
+      Pointee: 285 GoSliceDataType math/big.nat.array
     - __kind: PointerType
-      ID: 74
+      ID: 203
       Name: '*mime/multipart.FileHeader'
       ByteSize: 8
       GoRuntimeType: 920288
       GoKind: 22
-      Pointee: 75 StructureType mime/multipart.FileHeader
+      Pointee: 218 StructureType mime/multipart.FileHeader
     - __kind: PointerType
-      ID: 58
+      ID: 56
       Name: '*mime/multipart.Form'
       ByteSize: 8
       GoRuntimeType: 920384
       GoKind: 22
-      Pointee: 59 StructureType mime/multipart.Form
+      Pointee: 57 StructureType mime/multipart.Form
     - __kind: PointerType
-      ID: 116
+      ID: 177
       Name: '*net.IP'
       ByteSize: 8
       GoRuntimeType: 2.197536e+06
       GoKind: 22
-      Pointee: 117 GoSliceHeaderType net.IP
+      Pointee: 178 GoSliceHeaderType net.IP
     - __kind: PointerType
-      ID: 262
+      ID: 274
       Name: '*net.IP.array'
       ByteSize: 8
-      Pointee: 261 GoSliceDataType net.IP.array
+      Pointee: 273 GoSliceDataType net.IP.array
     - __kind: PointerType
-      ID: 268
+      ID: 292
       Name: '*net.IPMask.array'
       ByteSize: 8
-      Pointee: 267 GoSliceDataType net.IPMask.array
+      Pointee: 291 GoSliceDataType net.IPMask.array
     - __kind: PointerType
-      ID: 122
+      ID: 183
       Name: '*net.IPNet'
       ByteSize: 8
       GoRuntimeType: 1.203744e+06
       GoKind: 22
-      Pointee: 123 StructureType net.IPNet
+      Pointee: 213 StructureType net.IPNet
     - __kind: PointerType
       ID: 37
       Name: '*net/http.Request'
@@ -574,70 +574,70 @@ Types:
       GoKind: 22
       Pointee: 38 StructureType net/http.Request
     - __kind: PointerType
-      ID: 138
+      ID: 61
       Name: '*net/http.Response'
       ByteSize: 8
       GoRuntimeType: 1.75088e+06
       GoKind: 22
-      Pointee: 139 StructureType net/http.Response
+      Pointee: 62 StructureType net/http.Response
     - __kind: PointerType
-      ID: 141
+      ID: 64
       Name: '*net/http.pattern'
       ByteSize: 8
       GoRuntimeType: 1.63728e+06
       GoKind: 22
-      Pointee: 142 StructureType net/http.pattern
+      Pointee: 65 StructureType net/http.pattern
     - __kind: PointerType
-      ID: 144
+      ID: 117
       Name: '*net/http.segment'
       ByteSize: 8
       GoRuntimeType: 393440
       GoKind: 22
-      Pointee: 145 StructureType net/http.segment
+      Pointee: 118 StructureType net/http.segment
     - __kind: PointerType
-      ID: 39
+      ID: 45
       Name: '*net/url.URL'
       ByteSize: 8
       GoRuntimeType: 2.159744e+06
       GoKind: 22
-      Pointee: 40 StructureType net/url.URL
+      Pointee: 46 StructureType net/url.URL
     - __kind: PointerType
-      ID: 41
+      ID: 98
       Name: '*net/url.Userinfo'
       ByteSize: 8
       GoRuntimeType: 1.221536e+06
       GoKind: 22
-      Pointee: 42 StructureType net/url.Userinfo
+      Pointee: 99 StructureType net/url.Userinfo
     - __kind: PointerType
-      ID: 200
+      ID: 197
       Name: '*noalg.map.group[string]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute'
       ByteSize: 8
-      Pointee: 201 StructureType noalg.map.group[string]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
+      Pointee: 198 StructureType noalg.map.group[string]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
     - __kind: PointerType
-      ID: 68
+      ID: 152
       Name: '*noalg.map.group[string][]*mime/multipart.FileHeader'
       ByteSize: 8
-      Pointee: 69 StructureType noalg.map.group[string][]*mime/multipart.FileHeader
+      Pointee: 153 StructureType noalg.map.group[string][]*mime/multipart.FileHeader
     - __kind: PointerType
-      ID: 50
+      ID: 132
       Name: '*noalg.map.group[string][]string'
       ByteSize: 8
-      Pointee: 51 StructureType noalg.map.group[string][]string
+      Pointee: 133 StructureType noalg.map.group[string][]string
     - __kind: PointerType
-      ID: 183
+      ID: 143
       Name: '*noalg.map.group[string]float64'
       ByteSize: 8
-      Pointee: 184 StructureType noalg.map.group[string]float64
+      Pointee: 144 StructureType noalg.map.group[string]float64
     - __kind: PointerType
-      ID: 172
+      ID: 140
       Name: '*noalg.map.group[string]interface {}'
       ByteSize: 8
-      Pointee: 173 StructureType noalg.map.group[string]interface {}
+      Pointee: 141 StructureType noalg.map.group[string]interface {}
     - __kind: PointerType
-      ID: 153
+      ID: 137
       Name: '*noalg.map.group[string]string'
       ByteSize: 8
-      Pointee: 154 StructureType noalg.map.group[string]string
+      Pointee: 138 StructureType noalg.map.group[string]string
     - __kind: PointerType
       ID: 22
       Name: '*string'
@@ -651,56 +651,56 @@ Types:
       ByteSize: 8
       Pointee: 229 GoStringDataType string.str
     - __kind: PointerType
-      ID: 197
+      ID: 126
       Name: '*table<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>'
       ByteSize: 8
-      Pointee: 198 StructureType table<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
+      Pointee: 145 StructureType table<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
     - __kind: PointerType
-      ID: 65
+      ID: 106
       Name: '*table<string,[]*mime/multipart.FileHeader>'
       ByteSize: 8
-      Pointee: 66 StructureType table<string,[]*mime/multipart.FileHeader>
+      Pointee: 134 StructureType table<string,[]*mime/multipart.FileHeader>
     - __kind: PointerType
-      ID: 47
+      ID: 51
       Name: '*table<string,[]string>'
       ByteSize: 8
-      Pointee: 48 StructureType table<string,[]string>
+      Pointee: 100 StructureType table<string,[]string>
     - __kind: PointerType
-      ID: 180
+      ID: 86
       Name: '*table<string,float64>'
       ByteSize: 8
-      Pointee: 181 StructureType table<string,float64>
+      Pointee: 121 StructureType table<string,float64>
     - __kind: PointerType
-      ID: 169
+      ID: 81
       Name: '*table<string,interface {}>'
       ByteSize: 8
-      Pointee: 170 StructureType table<string,interface {}>
+      Pointee: 120 StructureType table<string,interface {}>
     - __kind: PointerType
-      ID: 150
+      ID: 70
       Name: '*table<string,string>'
       ByteSize: 8
-      Pointee: 151 StructureType table<string,string>
+      Pointee: 119 StructureType table<string,string>
     - __kind: PointerType
-      ID: 98
+      ID: 164
       Name: '*time.Location'
       ByteSize: 8
       GoRuntimeType: 1.642272e+06
       GoKind: 22
-      Pointee: 99 StructureType time.Location
+      Pointee: 165 StructureType time.Location
     - __kind: PointerType
-      ID: 101
+      ID: 208
       Name: '*time.zone'
       ByteSize: 8
       GoRuntimeType: 396576
       GoKind: 22
-      Pointee: 102 StructureType time.zone
+      Pointee: 209 StructureType time.zone
     - __kind: PointerType
-      ID: 104
+      ID: 211
       Name: '*time.zoneTrans'
       ByteSize: 8
       GoRuntimeType: 396640
       GoKind: 22
-      Pointee: 105 StructureType time.zoneTrans
+      Pointee: 212 StructureType time.zoneTrans
     - __kind: PointerType
       ID: 34
       Name: '*uint'
@@ -744,7 +744,7 @@ Types:
       GoKind: 22
       Pointee: 1 BaseType uintptr
     - __kind: GoChannelType
-      ID: 137
+      ID: 60
       Name: <-chan struct {}
       GoRuntimeType: 603232
       GoKind: 18
@@ -788,7 +788,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: GoSliceHeaderType
-      ID: 80
+      ID: 107
       Name: '[]*crypto/x509.Certificate'
       ByteSize: 24
       GoRuntimeType: 503680
@@ -796,21 +796,21 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 81 PointerType **crypto/x509.Certificate
+          Type: 108 PointerType **crypto/x509.Certificate
         - Name: len
           Offset: 8
           Type: 7 BaseType int
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 241 GoSliceDataType []*crypto/x509.Certificate.array
+      Data: 249 GoSliceDataType []*crypto/x509.Certificate.array
     - __kind: GoSliceDataType
-      ID: 241
+      ID: 249
       Name: '[]*crypto/x509.Certificate.array'
       ByteSize: 2048
-      Element: 82 PointerType *crypto/x509.Certificate
+      Element: 109 PointerType *crypto/x509.Certificate
     - __kind: GoSliceHeaderType
-      ID: 219
+      ID: 146
       Name: '[]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span'
       ByteSize: 24
       GoRuntimeType: 491840
@@ -818,21 +818,21 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 220 PointerType **github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span
+          Type: 147 PointerType **github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span
         - Name: len
           Offset: 8
           Type: 7 BaseType int
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 293 GoSliceDataType []*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span.array
+      Data: 259 GoSliceDataType []*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span.array
     - __kind: GoSliceDataType
-      ID: 293
+      ID: 259
       Name: '[]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span.array'
       ByteSize: 2048
-      Element: 157 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span
+      Element: 39 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span
     - __kind: GoSliceHeaderType
-      ID: 209
+      ID: 224
       Name: '[]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttributeValue'
       ByteSize: 24
       GoRuntimeType: 491456
@@ -840,21 +840,21 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 210 PointerType **github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttributeValue
+          Type: 225 PointerType **github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttributeValue
         - Name: len
           Offset: 8
           Type: 7 BaseType int
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 291 GoSliceDataType []*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttributeValue.array
+      Data: 293 GoSliceDataType []*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttributeValue.array
     - __kind: GoSliceDataType
-      ID: 291
+      ID: 293
       Name: '[]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttributeValue.array'
       ByteSize: 2048
-      Element: 211 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttributeValue
+      Element: 226 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttributeValue
     - __kind: GoSliceHeaderType
-      ID: 72
+      ID: 201
       Name: '[]*mime/multipart.FileHeader'
       ByteSize: 24
       GoRuntimeType: 488960
@@ -862,21 +862,21 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 73 PointerType **mime/multipart.FileHeader
+          Type: 202 PointerType **mime/multipart.FileHeader
         - Name: len
           Offset: 8
           Type: 7 BaseType int
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 237 GoSliceDataType []*mime/multipart.FileHeader.array
+      Data: 283 GoSliceDataType []*mime/multipart.FileHeader.array
     - __kind: GoSliceDataType
-      ID: 237
+      ID: 283
       Name: '[]*mime/multipart.FileHeader.array'
       ByteSize: 2048
-      Element: 74 PointerType *mime/multipart.FileHeader
+      Element: 203 PointerType *mime/multipart.FileHeader
     - __kind: GoSliceHeaderType
-      ID: 120
+      ID: 181
       Name: '[]*net.IPNet'
       ByteSize: 24
       GoRuntimeType: 518464
@@ -884,21 +884,21 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 121 PointerType **net.IPNet
+          Type: 182 PointerType **net.IPNet
         - Name: len
           Offset: 8
           Type: 7 BaseType int
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 265 GoSliceDataType []*net.IPNet.array
+      Data: 277 GoSliceDataType []*net.IPNet.array
     - __kind: GoSliceDataType
-      ID: 265
+      ID: 277
       Name: '[]*net.IPNet.array'
       ByteSize: 2048
-      Element: 122 PointerType *net.IPNet
+      Element: 183 PointerType *net.IPNet
     - __kind: GoSliceHeaderType
-      ID: 118
+      ID: 179
       Name: '[]*net/url.URL'
       ByteSize: 24
       GoRuntimeType: 518400
@@ -906,51 +906,51 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 119 PointerType **net/url.URL
+          Type: 180 PointerType **net/url.URL
         - Name: len
           Offset: 8
           Type: 7 BaseType int
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 263 GoSliceDataType []*net/url.URL.array
+      Data: 275 GoSliceDataType []*net/url.URL.array
     - __kind: GoSliceDataType
-      ID: 263
+      ID: 275
       Name: '[]*net/url.URL.array'
       ByteSize: 2048
-      Element: 39 PointerType *net/url.URL
+      Element: 45 PointerType *net/url.URL
     - __kind: GoSliceDataType
-      ID: 289
+      ID: 257
       Name: '[]*table<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>.array'
       ByteSize: 8192
-      Element: 197 PointerType *table<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
+      Element: 126 PointerType *table<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
     - __kind: GoSliceDataType
-      ID: 235
+      ID: 247
       Name: '[]*table<string,[]*mime/multipart.FileHeader>.array'
       ByteSize: 8192
-      Element: 65 PointerType *table<string,[]*mime/multipart.FileHeader>
+      Element: 106 PointerType *table<string,[]*mime/multipart.FileHeader>
     - __kind: GoSliceDataType
       ID: 231
       Name: '[]*table<string,[]string>.array'
       ByteSize: 8192
-      Element: 47 PointerType *table<string,[]string>
+      Element: 51 PointerType *table<string,[]string>
     - __kind: GoSliceDataType
-      ID: 283
+      ID: 239
       Name: '[]*table<string,float64>.array'
       ByteSize: 8192
-      Element: 180 PointerType *table<string,float64>
+      Element: 86 PointerType *table<string,float64>
     - __kind: GoSliceDataType
-      ID: 281
+      ID: 237
       Name: '[]*table<string,interface {}>.array'
       ByteSize: 8192
-      Element: 169 PointerType *table<string,interface {}>
+      Element: 81 PointerType *table<string,interface {}>
     - __kind: GoSliceDataType
-      ID: 279
+      ID: 235
       Name: '[]*table<string,string>.array'
       ByteSize: 8192
-      Element: 150 PointerType *table<string,string>
+      Element: 70 PointerType *table<string,string>
     - __kind: GoSliceHeaderType
-      ID: 131
+      ID: 110
       Name: '[][]*crypto/x509.Certificate'
       ByteSize: 24
       GoRuntimeType: 503808
@@ -958,21 +958,21 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 132 PointerType *[]*crypto/x509.Certificate
+          Type: 111 PointerType *[]*crypto/x509.Certificate
         - Name: len
           Offset: 8
           Type: 7 BaseType int
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 273 GoSliceDataType [][]*crypto/x509.Certificate.array
+      Data: 251 GoSliceDataType [][]*crypto/x509.Certificate.array
     - __kind: GoSliceDataType
-      ID: 273
+      ID: 251
       Name: '[][]*crypto/x509.Certificate.array'
       ByteSize: 2048
-      Element: 80 GoSliceHeaderType []*crypto/x509.Certificate
+      Element: 107 GoSliceHeaderType []*crypto/x509.Certificate
     - __kind: GoSliceHeaderType
-      ID: 133
+      ID: 112
       Name: '[][]uint8'
       ByteSize: 24
       GoRuntimeType: 483808
@@ -980,21 +980,21 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 134 PointerType *[]uint8
+          Type: 113 PointerType *[]uint8
         - Name: len
           Offset: 8
           Type: 7 BaseType int
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 275 GoSliceDataType [][]uint8.array
+      Data: 253 GoSliceDataType [][]uint8.array
     - __kind: GoSliceDataType
-      ID: 275
+      ID: 253
       Name: '[][]uint8.array'
       ByteSize: 2048
-      Element: 77 GoSliceHeaderType []uint8
+      Element: 96 GoSliceHeaderType []uint8
     - __kind: GoSliceHeaderType
-      ID: 112
+      ID: 173
       Name: '[]crypto/x509.ExtKeyUsage'
       ByteSize: 24
       GoRuntimeType: 505152
@@ -1002,21 +1002,21 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 113 PointerType *crypto/x509.ExtKeyUsage
+          Type: 174 PointerType *crypto/x509.ExtKeyUsage
         - Name: len
           Offset: 8
           Type: 7 BaseType int
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 257 GoSliceDataType []crypto/x509.ExtKeyUsage.array
+      Data: 269 GoSliceDataType []crypto/x509.ExtKeyUsage.array
     - __kind: GoSliceDataType
-      ID: 257
+      ID: 269
       Name: '[]crypto/x509.ExtKeyUsage.array'
       ByteSize: 2048
-      Element: 114 BaseType crypto/x509.ExtKeyUsage
+      Element: 175 BaseType crypto/x509.ExtKeyUsage
     - __kind: GoSliceHeaderType
-      ID: 125
+      ID: 184
       Name: '[]crypto/x509.OID'
       ByteSize: 24
       GoRuntimeType: 518528
@@ -1024,21 +1024,21 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 126 PointerType *crypto/x509.OID
+          Type: 185 PointerType *crypto/x509.OID
         - Name: len
           Offset: 8
           Type: 7 BaseType int
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 269 GoSliceDataType []crypto/x509.OID.array
+      Data: 279 GoSliceDataType []crypto/x509.OID.array
     - __kind: GoSliceDataType
-      ID: 269
+      ID: 279
       Name: '[]crypto/x509.OID.array'
       ByteSize: 2048
-      Element: 127 StructureType crypto/x509.OID
+      Element: 186 StructureType crypto/x509.OID
     - __kind: GoSliceHeaderType
-      ID: 128
+      ID: 187
       Name: '[]crypto/x509.PolicyMapping'
       ByteSize: 24
       GoRuntimeType: 518592
@@ -1046,21 +1046,21 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 129 PointerType *crypto/x509.PolicyMapping
+          Type: 188 PointerType *crypto/x509.PolicyMapping
         - Name: len
           Offset: 8
           Type: 7 BaseType int
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 271 GoSliceDataType []crypto/x509.PolicyMapping.array
+      Data: 281 GoSliceDataType []crypto/x509.PolicyMapping.array
     - __kind: GoSliceDataType
-      ID: 271
+      ID: 281
       Name: '[]crypto/x509.PolicyMapping.array'
       ByteSize: 2048
-      Element: 130 StructureType crypto/x509.PolicyMapping
+      Element: 189 StructureType crypto/x509.PolicyMapping
     - __kind: GoSliceHeaderType
-      ID: 93
+      ID: 160
       Name: '[]crypto/x509/pkix.AttributeTypeAndValue'
       ByteSize: 24
       GoRuntimeType: 519040
@@ -1068,21 +1068,21 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 94 PointerType *crypto/x509/pkix.AttributeTypeAndValue
+          Type: 161 PointerType *crypto/x509/pkix.AttributeTypeAndValue
         - Name: len
           Offset: 8
           Type: 7 BaseType int
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 245 GoSliceDataType []crypto/x509/pkix.AttributeTypeAndValue.array
+      Data: 261 GoSliceDataType []crypto/x509/pkix.AttributeTypeAndValue.array
     - __kind: GoSliceDataType
-      ID: 245
+      ID: 261
       Name: '[]crypto/x509/pkix.AttributeTypeAndValue.array'
       ByteSize: 2048
-      Element: 95 StructureType crypto/x509/pkix.AttributeTypeAndValue
+      Element: 162 StructureType crypto/x509/pkix.AttributeTypeAndValue
     - __kind: GoSliceHeaderType
-      ID: 107
+      ID: 167
       Name: '[]crypto/x509/pkix.Extension'
       ByteSize: 24
       GoRuntimeType: 518272
@@ -1090,21 +1090,21 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 108 PointerType *crypto/x509/pkix.Extension
+          Type: 168 PointerType *crypto/x509/pkix.Extension
         - Name: len
           Offset: 8
           Type: 7 BaseType int
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 253 GoSliceDataType []crypto/x509/pkix.Extension.array
+      Data: 263 GoSliceDataType []crypto/x509/pkix.Extension.array
     - __kind: GoSliceDataType
-      ID: 253
+      ID: 263
       Name: '[]crypto/x509/pkix.Extension.array'
       ByteSize: 2048
-      Element: 109 StructureType crypto/x509/pkix.Extension
+      Element: 169 StructureType crypto/x509/pkix.Extension
     - __kind: GoSliceHeaderType
-      ID: 110
+      ID: 170
       Name: '[]encoding/asn1.ObjectIdentifier'
       ByteSize: 24
       GoRuntimeType: 518336
@@ -1112,21 +1112,21 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 111 PointerType *encoding/asn1.ObjectIdentifier
+          Type: 171 PointerType *encoding/asn1.ObjectIdentifier
         - Name: len
           Offset: 8
           Type: 7 BaseType int
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 255 GoSliceDataType []encoding/asn1.ObjectIdentifier.array
+      Data: 265 GoSliceDataType []encoding/asn1.ObjectIdentifier.array
     - __kind: GoSliceDataType
-      ID: 255
+      ID: 265
       Name: '[]encoding/asn1.ObjectIdentifier.array'
       ByteSize: 2048
-      Element: 96 GoSliceHeaderType encoding/asn1.ObjectIdentifier
+      Element: 172 GoSliceHeaderType encoding/asn1.ObjectIdentifier
     - __kind: GoSliceHeaderType
-      ID: 187
+      ID: 87
       Name: '[]github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink'
       ByteSize: 24
       GoRuntimeType: 491392
@@ -1134,21 +1134,21 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 188 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink
+          Type: 88 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink
         - Name: len
           Offset: 8
           Type: 7 BaseType int
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 285 GoSliceDataType []github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink.array
+      Data: 241 GoSliceDataType []github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink.array
     - __kind: GoSliceDataType
-      ID: 285
+      ID: 241
       Name: '[]github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink.array'
       ByteSize: 2048
-      Element: 189 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink
+      Element: 89 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink
     - __kind: GoSliceHeaderType
-      ID: 190
+      ID: 90
       Name: '[]github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent'
       ByteSize: 24
       GoRuntimeType: 491584
@@ -1156,21 +1156,21 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 191 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent
+          Type: 91 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent
         - Name: len
           Offset: 8
           Type: 7 BaseType int
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 287 GoSliceDataType []github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent.array
+      Data: 243 GoSliceDataType []github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent.array
     - __kind: GoSliceDataType
-      ID: 287
+      ID: 243
       Name: '[]github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent.array'
       ByteSize: 2048
-      Element: 192 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent
+      Element: 92 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent
     - __kind: GoSliceHeaderType
-      ID: 115
+      ID: 176
       Name: '[]net.IP'
       ByteSize: 24
       GoRuntimeType: 484768
@@ -1178,21 +1178,21 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 116 PointerType *net.IP
+          Type: 177 PointerType *net.IP
         - Name: len
           Offset: 8
           Type: 7 BaseType int
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 259 GoSliceDataType []net.IP.array
+      Data: 271 GoSliceDataType []net.IP.array
     - __kind: GoSliceDataType
-      ID: 259
+      ID: 271
       Name: '[]net.IP.array'
       ByteSize: 2048
-      Element: 117 GoSliceHeaderType net.IP
+      Element: 178 GoSliceHeaderType net.IP
     - __kind: GoSliceHeaderType
-      ID: 143
+      ID: 116
       Name: '[]net/http.segment'
       ByteSize: 24
       GoRuntimeType: 486400
@@ -1200,49 +1200,49 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 144 PointerType *net/http.segment
+          Type: 117 PointerType *net/http.segment
         - Name: len
           Offset: 8
           Type: 7 BaseType int
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 277 GoSliceDataType []net/http.segment.array
+      Data: 255 GoSliceDataType []net/http.segment.array
     - __kind: GoSliceDataType
-      ID: 277
+      ID: 255
       Name: '[]net/http.segment.array'
       ByteSize: 2048
-      Element: 145 StructureType net/http.segment
+      Element: 118 StructureType net/http.segment
     - __kind: GoSliceDataType
-      ID: 290
+      ID: 258
       Name: '[]noalg.map.group[string]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute.array'
       ByteSize: 2048
-      Element: 201 StructureType noalg.map.group[string]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
+      Element: 198 StructureType noalg.map.group[string]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
     - __kind: GoSliceDataType
-      ID: 236
+      ID: 248
       Name: '[]noalg.map.group[string][]*mime/multipart.FileHeader.array'
       ByteSize: 2048
-      Element: 69 StructureType noalg.map.group[string][]*mime/multipart.FileHeader
+      Element: 153 StructureType noalg.map.group[string][]*mime/multipart.FileHeader
     - __kind: GoSliceDataType
       ID: 232
       Name: '[]noalg.map.group[string][]string.array'
       ByteSize: 2048
-      Element: 51 StructureType noalg.map.group[string][]string
+      Element: 133 StructureType noalg.map.group[string][]string
     - __kind: GoSliceDataType
-      ID: 284
+      ID: 240
       Name: '[]noalg.map.group[string]float64.array'
       ByteSize: 2048
-      Element: 184 StructureType noalg.map.group[string]float64
+      Element: 144 StructureType noalg.map.group[string]float64
     - __kind: GoSliceDataType
-      ID: 282
+      ID: 238
       Name: '[]noalg.map.group[string]interface {}.array'
       ByteSize: 2048
-      Element: 173 StructureType noalg.map.group[string]interface {}
+      Element: 141 StructureType noalg.map.group[string]interface {}
     - __kind: GoSliceDataType
-      ID: 280
+      ID: 236
       Name: '[]noalg.map.group[string]string.array'
       ByteSize: 2048
-      Element: 154 StructureType noalg.map.group[string]string
+      Element: 138 StructureType noalg.map.group[string]string
     - __kind: GoSliceHeaderType
       ID: 54
       Name: '[]string'
@@ -1266,7 +1266,7 @@ Types:
       ByteSize: 2048
       Element: 9 GoStringHeaderType string
     - __kind: GoSliceHeaderType
-      ID: 100
+      ID: 207
       Name: '[]time.zone'
       ByteSize: 24
       GoRuntimeType: 490944
@@ -1274,21 +1274,21 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 101 PointerType *time.zone
+          Type: 208 PointerType *time.zone
         - Name: len
           Offset: 8
           Type: 7 BaseType int
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 249 GoSliceDataType []time.zone.array
+      Data: 287 GoSliceDataType []time.zone.array
     - __kind: GoSliceDataType
-      ID: 249
+      ID: 287
       Name: '[]time.zone.array'
       ByteSize: 2048
-      Element: 102 StructureType time.zone
+      Element: 209 StructureType time.zone
     - __kind: GoSliceHeaderType
-      ID: 103
+      ID: 210
       Name: '[]time.zoneTrans'
       ByteSize: 24
       GoRuntimeType: 491008
@@ -1296,21 +1296,21 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 104 PointerType *time.zoneTrans
+          Type: 211 PointerType *time.zoneTrans
         - Name: len
           Offset: 8
           Type: 7 BaseType int
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 251 GoSliceDataType []time.zoneTrans.array
+      Data: 289 GoSliceDataType []time.zoneTrans.array
     - __kind: GoSliceDataType
-      ID: 251
+      ID: 289
       Name: '[]time.zoneTrans.array'
       ByteSize: 2048
-      Element: 105 StructureType time.zoneTrans
+      Element: 212 StructureType time.zoneTrans
     - __kind: GoSliceHeaderType
-      ID: 77
+      ID: 96
       Name: '[]uint8'
       ByteSize: 24
       GoRuntimeType: 496896
@@ -1325,9 +1325,9 @@ Types:
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 239 GoSliceDataType []uint8.array
+      Data: 245 GoSliceDataType []uint8.array
     - __kind: GoSliceDataType
-      ID: 239
+      ID: 245
       Name: '[]uint8.array'
       ByteSize: 2048
       Element: 3 BaseType uint8
@@ -1338,7 +1338,7 @@ Types:
       GoRuntimeType: 591200
       GoKind: 1
     - __kind: StructureType
-      ID: 225
+      ID: 42
       Name: bytes.Buffer
       ByteSize: 40
       GoRuntimeType: 1.634976e+06
@@ -1346,15 +1346,15 @@ Types:
       RawFields:
         - Name: buf
           Offset: 0
-          Type: 77 GoSliceHeaderType []uint8
+          Type: 96 GoSliceHeaderType []uint8
         - Name: off
           Offset: 24
           Type: 7 BaseType int
         - Name: lastRead
           Offset: 32
-          Type: 226 BaseType bytes.readOp
+          Type: 97 BaseType bytes.readOp
     - __kind: BaseType
-      ID: 226
+      ID: 97
       Name: bytes.readOp
       ByteSize: 1
       GoRuntimeType: 589344
@@ -1372,7 +1372,7 @@ Types:
       GoRuntimeType: 590944
       GoKind: 15
     - __kind: GoInterfaceType
-      ID: 140
+      ID: 63
       Name: context.Context
       ByteSize: 16
       GoRuntimeType: 1.298016e+06
@@ -1385,22 +1385,22 @@ Types:
           Offset: 8
           Type: 15 VoidPointerType unsafe.Pointer
     - __kind: StructureType
-      ID: 227
+      ID: 43
       Name: context.backgroundCtx
       GoRuntimeType: 1.826784e+06
       GoKind: 25
       RawFields:
         - Name: emptyCtx
           Offset: 0
-          Type: 228 StructureType context.emptyCtx
+          Type: 44 StructureType context.emptyCtx
     - __kind: StructureType
-      ID: 228
+      ID: 44
       Name: context.emptyCtx
       GoRuntimeType: 1.61824e+06
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 79
+      ID: 59
       Name: crypto/tls.ConnectionState
       ByteSize: 192
       GoRuntimeType: 2.301632e+06
@@ -1429,39 +1429,39 @@ Types:
           Type: 9 GoStringHeaderType string
         - Name: PeerCertificates
           Offset: 48
-          Type: 80 GoSliceHeaderType []*crypto/x509.Certificate
+          Type: 107 GoSliceHeaderType []*crypto/x509.Certificate
         - Name: VerifiedChains
           Offset: 72
-          Type: 131 GoSliceHeaderType [][]*crypto/x509.Certificate
+          Type: 110 GoSliceHeaderType [][]*crypto/x509.Certificate
         - Name: SignedCertificateTimestamps
           Offset: 96
-          Type: 133 GoSliceHeaderType [][]uint8
+          Type: 112 GoSliceHeaderType [][]uint8
         - Name: OCSPResponse
           Offset: 120
-          Type: 77 GoSliceHeaderType []uint8
+          Type: 96 GoSliceHeaderType []uint8
         - Name: TLSUnique
           Offset: 144
-          Type: 77 GoSliceHeaderType []uint8
+          Type: 96 GoSliceHeaderType []uint8
         - Name: ECHAccepted
           Offset: 168
           Type: 4 BaseType bool
         - Name: ekm
           Offset: 176
-          Type: 135 GoSubroutineType func(string, []uint8, int) ([]uint8, error)
+          Type: 114 GoSubroutineType func(string, []uint8, int) ([]uint8, error)
         - Name: testingOnlyDidHRR
           Offset: 184
           Type: 4 BaseType bool
         - Name: testingOnlyCurveID
           Offset: 186
-          Type: 136 BaseType crypto/tls.CurveID
+          Type: 115 BaseType crypto/tls.CurveID
     - __kind: BaseType
-      ID: 136
+      ID: 115
       Name: crypto/tls.CurveID
       ByteSize: 2
       GoRuntimeType: 843360
       GoKind: 9
     - __kind: StructureType
-      ID: 83
+      ID: 135
       Name: crypto/x509.Certificate
       ByteSize: 1424
       GoRuntimeType: 2.452512e+06
@@ -1469,67 +1469,67 @@ Types:
       RawFields:
         - Name: Raw
           Offset: 0
-          Type: 77 GoSliceHeaderType []uint8
+          Type: 96 GoSliceHeaderType []uint8
         - Name: RawTBSCertificate
           Offset: 24
-          Type: 77 GoSliceHeaderType []uint8
+          Type: 96 GoSliceHeaderType []uint8
         - Name: RawSubjectPublicKeyInfo
           Offset: 48
-          Type: 77 GoSliceHeaderType []uint8
+          Type: 96 GoSliceHeaderType []uint8
         - Name: RawSubject
           Offset: 72
-          Type: 77 GoSliceHeaderType []uint8
+          Type: 96 GoSliceHeaderType []uint8
         - Name: RawIssuer
           Offset: 96
-          Type: 77 GoSliceHeaderType []uint8
+          Type: 96 GoSliceHeaderType []uint8
         - Name: Signature
           Offset: 120
-          Type: 77 GoSliceHeaderType []uint8
+          Type: 96 GoSliceHeaderType []uint8
         - Name: SignatureAlgorithm
           Offset: 144
-          Type: 84 BaseType crypto/x509.SignatureAlgorithm
+          Type: 154 BaseType crypto/x509.SignatureAlgorithm
         - Name: PublicKeyAlgorithm
           Offset: 152
-          Type: 85 BaseType crypto/x509.PublicKeyAlgorithm
+          Type: 155 BaseType crypto/x509.PublicKeyAlgorithm
         - Name: PublicKey
           Offset: 160
-          Type: 86 GoEmptyInterfaceType interface {}
+          Type: 156 GoEmptyInterfaceType interface {}
         - Name: Version
           Offset: 176
           Type: 7 BaseType int
         - Name: SerialNumber
           Offset: 184
-          Type: 87 PointerType *math/big.Int
+          Type: 157 PointerType *math/big.Int
         - Name: Issuer
           Offset: 192
-          Type: 92 StructureType crypto/x509/pkix.Name
+          Type: 159 StructureType crypto/x509/pkix.Name
         - Name: Subject
           Offset: 440
-          Type: 92 StructureType crypto/x509/pkix.Name
+          Type: 159 StructureType crypto/x509/pkix.Name
         - Name: NotBefore
           Offset: 688
-          Type: 97 StructureType time.Time
+          Type: 163 StructureType time.Time
         - Name: NotAfter
           Offset: 712
-          Type: 97 StructureType time.Time
+          Type: 163 StructureType time.Time
         - Name: KeyUsage
           Offset: 736
-          Type: 106 BaseType crypto/x509.KeyUsage
+          Type: 166 BaseType crypto/x509.KeyUsage
         - Name: Extensions
           Offset: 744
-          Type: 107 GoSliceHeaderType []crypto/x509/pkix.Extension
+          Type: 167 GoSliceHeaderType []crypto/x509/pkix.Extension
         - Name: ExtraExtensions
           Offset: 768
-          Type: 107 GoSliceHeaderType []crypto/x509/pkix.Extension
+          Type: 167 GoSliceHeaderType []crypto/x509/pkix.Extension
         - Name: UnhandledCriticalExtensions
           Offset: 792
-          Type: 110 GoSliceHeaderType []encoding/asn1.ObjectIdentifier
+          Type: 170 GoSliceHeaderType []encoding/asn1.ObjectIdentifier
         - Name: ExtKeyUsage
           Offset: 816
-          Type: 112 GoSliceHeaderType []crypto/x509.ExtKeyUsage
+          Type: 173 GoSliceHeaderType []crypto/x509.ExtKeyUsage
         - Name: UnknownExtKeyUsage
           Offset: 840
-          Type: 110 GoSliceHeaderType []encoding/asn1.ObjectIdentifier
+          Type: 170 GoSliceHeaderType []encoding/asn1.ObjectIdentifier
         - Name: BasicConstraintsValid
           Offset: 864
           Type: 4 BaseType bool
@@ -1544,10 +1544,10 @@ Types:
           Type: 4 BaseType bool
         - Name: SubjectKeyId
           Offset: 888
-          Type: 77 GoSliceHeaderType []uint8
+          Type: 96 GoSliceHeaderType []uint8
         - Name: AuthorityKeyId
           Offset: 912
-          Type: 77 GoSliceHeaderType []uint8
+          Type: 96 GoSliceHeaderType []uint8
         - Name: OCSPServer
           Offset: 936
           Type: 54 GoSliceHeaderType []string
@@ -1562,10 +1562,10 @@ Types:
           Type: 54 GoSliceHeaderType []string
         - Name: IPAddresses
           Offset: 1032
-          Type: 115 GoSliceHeaderType []net.IP
+          Type: 176 GoSliceHeaderType []net.IP
         - Name: URIs
           Offset: 1056
-          Type: 118 GoSliceHeaderType []*net/url.URL
+          Type: 179 GoSliceHeaderType []*net/url.URL
         - Name: PermittedDNSDomainsCritical
           Offset: 1080
           Type: 4 BaseType bool
@@ -1577,10 +1577,10 @@ Types:
           Type: 54 GoSliceHeaderType []string
         - Name: PermittedIPRanges
           Offset: 1136
-          Type: 120 GoSliceHeaderType []*net.IPNet
+          Type: 181 GoSliceHeaderType []*net.IPNet
         - Name: ExcludedIPRanges
           Offset: 1160
-          Type: 120 GoSliceHeaderType []*net.IPNet
+          Type: 181 GoSliceHeaderType []*net.IPNet
         - Name: PermittedEmailAddresses
           Offset: 1184
           Type: 54 GoSliceHeaderType []string
@@ -1598,10 +1598,10 @@ Types:
           Type: 54 GoSliceHeaderType []string
         - Name: PolicyIdentifiers
           Offset: 1304
-          Type: 110 GoSliceHeaderType []encoding/asn1.ObjectIdentifier
+          Type: 170 GoSliceHeaderType []encoding/asn1.ObjectIdentifier
         - Name: Policies
           Offset: 1328
-          Type: 125 GoSliceHeaderType []crypto/x509.OID
+          Type: 184 GoSliceHeaderType []crypto/x509.OID
         - Name: InhibitAnyPolicy
           Offset: 1352
           Type: 7 BaseType int
@@ -1622,21 +1622,21 @@ Types:
           Type: 4 BaseType bool
         - Name: PolicyMappings
           Offset: 1400
-          Type: 128 GoSliceHeaderType []crypto/x509.PolicyMapping
+          Type: 187 GoSliceHeaderType []crypto/x509.PolicyMapping
     - __kind: BaseType
-      ID: 114
+      ID: 175
       Name: crypto/x509.ExtKeyUsage
       ByteSize: 8
       GoRuntimeType: 594272
       GoKind: 2
     - __kind: BaseType
-      ID: 106
+      ID: 166
       Name: crypto/x509.KeyUsage
       ByteSize: 8
       GoRuntimeType: 594208
       GoKind: 2
     - __kind: StructureType
-      ID: 127
+      ID: 186
       Name: crypto/x509.OID
       ByteSize: 24
       GoRuntimeType: 1.989152e+06
@@ -1644,9 +1644,9 @@ Types:
       RawFields:
         - Name: der
           Offset: 0
-          Type: 77 GoSliceHeaderType []uint8
+          Type: 96 GoSliceHeaderType []uint8
     - __kind: StructureType
-      ID: 130
+      ID: 189
       Name: crypto/x509.PolicyMapping
       ByteSize: 48
       GoRuntimeType: 1.5144e+06
@@ -1654,24 +1654,24 @@ Types:
       RawFields:
         - Name: IssuerDomainPolicy
           Offset: 0
-          Type: 127 StructureType crypto/x509.OID
+          Type: 186 StructureType crypto/x509.OID
         - Name: SubjectDomainPolicy
           Offset: 24
-          Type: 127 StructureType crypto/x509.OID
+          Type: 186 StructureType crypto/x509.OID
     - __kind: BaseType
-      ID: 85
+      ID: 155
       Name: crypto/x509.PublicKeyAlgorithm
       ByteSize: 8
       GoRuntimeType: 845664
       GoKind: 2
     - __kind: BaseType
-      ID: 84
+      ID: 154
       Name: crypto/x509.SignatureAlgorithm
       ByteSize: 8
       GoRuntimeType: 1.134112e+06
       GoKind: 2
     - __kind: StructureType
-      ID: 95
+      ID: 162
       Name: crypto/x509/pkix.AttributeTypeAndValue
       ByteSize: 40
       GoRuntimeType: 1.52688e+06
@@ -1679,12 +1679,12 @@ Types:
       RawFields:
         - Name: Type
           Offset: 0
-          Type: 96 GoSliceHeaderType encoding/asn1.ObjectIdentifier
+          Type: 172 GoSliceHeaderType encoding/asn1.ObjectIdentifier
         - Name: Value
           Offset: 24
-          Type: 86 GoEmptyInterfaceType interface {}
+          Type: 156 GoEmptyInterfaceType interface {}
     - __kind: StructureType
-      ID: 109
+      ID: 169
       Name: crypto/x509/pkix.Extension
       ByteSize: 56
       GoRuntimeType: 1.678176e+06
@@ -1692,15 +1692,15 @@ Types:
       RawFields:
         - Name: Id
           Offset: 0
-          Type: 96 GoSliceHeaderType encoding/asn1.ObjectIdentifier
+          Type: 172 GoSliceHeaderType encoding/asn1.ObjectIdentifier
         - Name: Critical
           Offset: 24
           Type: 4 BaseType bool
         - Name: Value
           Offset: 32
-          Type: 77 GoSliceHeaderType []uint8
+          Type: 96 GoSliceHeaderType []uint8
     - __kind: StructureType
-      ID: 92
+      ID: 159
       Name: crypto/x509/pkix.Name
       ByteSize: 248
       GoRuntimeType: 2.240928e+06
@@ -1735,12 +1735,12 @@ Types:
           Type: 9 GoStringHeaderType string
         - Name: Names
           Offset: 200
-          Type: 93 GoSliceHeaderType []crypto/x509/pkix.AttributeTypeAndValue
+          Type: 160 GoSliceHeaderType []crypto/x509/pkix.AttributeTypeAndValue
         - Name: ExtraNames
           Offset: 224
-          Type: 93 GoSliceHeaderType []crypto/x509/pkix.AttributeTypeAndValue
+          Type: 160 GoSliceHeaderType []crypto/x509/pkix.AttributeTypeAndValue
     - __kind: GoSliceHeaderType
-      ID: 96
+      ID: 172
       Name: encoding/asn1.ObjectIdentifier
       ByteSize: 24
       GoRuntimeType: 1.074656e+06
@@ -1755,9 +1755,9 @@ Types:
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 247 GoSliceDataType encoding/asn1.ObjectIdentifier.array
+      Data: 267 GoSliceDataType encoding/asn1.ObjectIdentifier.array
     - __kind: GoSliceDataType
-      ID: 247
+      ID: 267
       Name: encoding/asn1.ObjectIdentifier.array
       ByteSize: 2048
       Element: 7 BaseType int
@@ -1787,25 +1787,25 @@ Types:
       GoRuntimeType: 591136
       GoKind: 14
     - __kind: GoSubroutineType
-      ID: 223
+      ID: 95
       Name: func()
       ByteSize: 8
       GoRuntimeType: 481952
       GoKind: 19
     - __kind: GoSubroutineType
-      ID: 56
+      ID: 53
       Name: func() (io.ReadCloser, error)
       ByteSize: 8
       GoRuntimeType: 701088
       GoKind: 19
     - __kind: GoSubroutineType
-      ID: 135
+      ID: 114
       Name: func(string, []uint8, int) ([]uint8, error)
       ByteSize: 8
       GoRuntimeType: 1.020064e+06
       GoKind: 19
     - __kind: StructureType
-      ID: 158
+      ID: 40
       Name: github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span
       ByteSize: 288
       GoRuntimeType: 2.392384e+06
@@ -1813,7 +1813,7 @@ Types:
       RawFields:
         - Name: mu
           Offset: 0
-          Type: 159 StructureType sync.RWMutex
+          Type: 71 StructureType sync.RWMutex
         - Name: name
           Offset: 24
           Type: 9 GoStringHeaderType string
@@ -1834,13 +1834,13 @@ Types:
           Type: 13 BaseType int64
         - Name: meta
           Offset: 104
-          Type: 146 GoMapType map[string]string
+          Type: 66 GoMapType map[string]string
         - Name: metaStruct
           Offset: 112
-          Type: 165 GoMapType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.metaStructMap
+          Type: 77 GoMapType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.metaStructMap
         - Name: metrics
           Offset: 120
-          Type: 176 GoMapType map[string]float64
+          Type: 82 GoMapType map[string]float64
         - Name: spanID
           Offset: 128
           Type: 8 BaseType uint64
@@ -1855,10 +1855,10 @@ Types:
           Type: 12 BaseType int32
         - Name: spanLinks
           Offset: 160
-          Type: 187 GoSliceHeaderType []github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink
+          Type: 87 GoSliceHeaderType []github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink
         - Name: spanEvents
           Offset: 184
-          Type: 190 GoSliceHeaderType []github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent
+          Type: 90 GoSliceHeaderType []github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent
         - Name: goExecTraced
           Offset: 208
           Type: 4 BaseType bool
@@ -1870,7 +1870,7 @@ Types:
           Type: 4 BaseType bool
         - Name: context
           Offset: 216
-          Type: 215 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanContext
+          Type: 93 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanContext
         - Name: integration
           Offset: 224
           Type: 9 GoStringHeaderType string
@@ -1879,15 +1879,15 @@ Types:
           Type: 4 BaseType bool
         - Name: pprofCtxActive
           Offset: 248
-          Type: 140 GoInterfaceType context.Context
+          Type: 63 GoInterfaceType context.Context
         - Name: pprofCtxRestore
           Offset: 264
-          Type: 140 GoInterfaceType context.Context
+          Type: 63 GoInterfaceType context.Context
         - Name: taskEnd
           Offset: 280
-          Type: 223 GoSubroutineType func()
+          Type: 95 GoSubroutineType func()
     - __kind: StructureType
-      ID: 216
+      ID: 94
       Name: github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanContext
       ByteSize: 168
       GoRuntimeType: 2.261024e+06
@@ -1898,13 +1898,13 @@ Types:
           Type: 4 BaseType bool
         - Name: trace
           Offset: 8
-          Type: 217 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.trace
+          Type: 128 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.trace
         - Name: span
           Offset: 16
-          Type: 157 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span
+          Type: 39 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span
         - Name: errors
           Offset: 24
-          Type: 163 StructureType sync/atomic.Int32
+          Type: 75 StructureType sync/atomic.Int32
         - Name: reparentID
           Offset: 32
           Type: 9 GoStringHeaderType string
@@ -1913,16 +1913,16 @@ Types:
           Type: 4 BaseType bool
         - Name: traceID
           Offset: 49
-          Type: 222 ArrayType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.traceID
+          Type: 130 ArrayType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.traceID
         - Name: spanID
           Offset: 72
           Type: 8 BaseType uint64
         - Name: mu
           Offset: 80
-          Type: 159 StructureType sync.RWMutex
+          Type: 71 StructureType sync.RWMutex
         - Name: baggage
           Offset: 104
-          Type: 146 GoMapType map[string]string
+          Type: 66 GoMapType map[string]string
         - Name: hasBaggage
           Offset: 112
           Type: 2 BaseType uint32
@@ -1931,12 +1931,12 @@ Types:
           Type: 9 GoStringHeaderType string
         - Name: spanLinks
           Offset: 136
-          Type: 187 GoSliceHeaderType []github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink
+          Type: 87 GoSliceHeaderType []github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink
         - Name: baggageOnly
           Offset: 160
           Type: 4 BaseType bool
     - __kind: StructureType
-      ID: 189
+      ID: 89
       Name: github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink
       ByteSize: 56
       GoRuntimeType: 1.9464e+06
@@ -1953,7 +1953,7 @@ Types:
           Type: 8 BaseType uint64
         - Name: Attributes
           Offset: 24
-          Type: 146 GoMapType map[string]string
+          Type: 66 GoMapType map[string]string
         - Name: Tracestate
           Offset: 32
           Type: 9 GoStringHeaderType string
@@ -1961,20 +1961,20 @@ Types:
           Offset: 48
           Type: 2 BaseType uint32
     - __kind: GoMapType
-      ID: 165
+      ID: 77
       Name: github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.metaStructMap
       ByteSize: 8
       GoRuntimeType: 1.299296e+06
       GoKind: 21
-      HeaderType: 167 GoSwissMapHeaderType map<string,interface {}>
+      HeaderType: 79 GoSwissMapHeaderType map<string,interface {}>
     - __kind: BaseType
-      ID: 221
+      ID: 148
       Name: github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.samplingDecision
       ByteSize: 4
       GoRuntimeType: 589984
       GoKind: 10
     - __kind: StructureType
-      ID: 192
+      ID: 92
       Name: github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent
       ByteSize: 40
       GoRuntimeType: 1.781184e+06
@@ -1988,12 +1988,12 @@ Types:
           Type: 8 BaseType uint64
         - Name: Attributes
           Offset: 24
-          Type: 193 GoMapType map[string]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
+          Type: 122 GoMapType map[string]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
         - Name: RawAttributes
           Offset: 32
-          Type: 214 GoMapType map[string]interface {}
+          Type: 127 GoMapType map[string]interface {}
     - __kind: StructureType
-      ID: 208
+      ID: 222
       Name: github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttribute
       ByteSize: 24
       GoRuntimeType: 1.210656e+06
@@ -2001,9 +2001,9 @@ Types:
       RawFields:
         - Name: Values
           Offset: 0
-          Type: 209 GoSliceHeaderType []*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttributeValue
+          Type: 224 GoSliceHeaderType []*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttributeValue
     - __kind: StructureType
-      ID: 212
+      ID: 227
       Name: github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttributeValue
       ByteSize: 48
       GoRuntimeType: 1.868992e+06
@@ -2011,7 +2011,7 @@ Types:
       RawFields:
         - Name: Type
           Offset: 0
-          Type: 213 BaseType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttributeValueType
+          Type: 228 BaseType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttributeValueType
         - Name: StringValue
           Offset: 8
           Type: 9 GoStringHeaderType string
@@ -2025,13 +2025,13 @@ Types:
           Offset: 40
           Type: 18 BaseType float64
     - __kind: BaseType
-      ID: 213
+      ID: 228
       Name: github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttributeValueType
       ByteSize: 4
       GoRuntimeType: 1.001824e+06
       GoKind: 5
     - __kind: StructureType
-      ID: 205
+      ID: 217
       Name: github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
       ByteSize: 56
       GoRuntimeType: 1.946656e+06
@@ -2039,7 +2039,7 @@ Types:
       RawFields:
         - Name: Type
           Offset: 0
-          Type: 206 BaseType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttributeType
+          Type: 220 BaseType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttributeType
         - Name: StringValue
           Offset: 8
           Type: 9 GoStringHeaderType string
@@ -2054,15 +2054,15 @@ Types:
           Type: 18 BaseType float64
         - Name: ArrayValue
           Offset: 48
-          Type: 207 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttribute
+          Type: 221 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttribute
     - __kind: BaseType
-      ID: 206
+      ID: 220
       Name: github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttributeType
       ByteSize: 4
       GoRuntimeType: 1.001728e+06
       GoKind: 5
     - __kind: StructureType
-      ID: 218
+      ID: 129
       Name: github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.trace
       ByteSize: 104
       GoRuntimeType: 2.14816e+06
@@ -2070,16 +2070,16 @@ Types:
       RawFields:
         - Name: mu
           Offset: 0
-          Type: 159 StructureType sync.RWMutex
+          Type: 71 StructureType sync.RWMutex
         - Name: spans
           Offset: 24
-          Type: 219 GoSliceHeaderType []*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span
+          Type: 146 GoSliceHeaderType []*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span
         - Name: tags
           Offset: 48
-          Type: 146 GoMapType map[string]string
+          Type: 66 GoMapType map[string]string
         - Name: propagatingTags
           Offset: 56
-          Type: 146 GoMapType map[string]string
+          Type: 66 GoMapType map[string]string
         - Name: finished
           Offset: 64
           Type: 7 BaseType int
@@ -2094,12 +2094,12 @@ Types:
           Type: 4 BaseType bool
         - Name: samplingDecision
           Offset: 92
-          Type: 221 BaseType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.samplingDecision
+          Type: 148 BaseType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.samplingDecision
         - Name: root
           Offset: 96
-          Type: 157 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span
+          Type: 39 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span
     - __kind: ArrayType
-      ID: 222
+      ID: 130
       Name: github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.traceID
       ByteSize: 16
       GoRuntimeType: 914336
@@ -2108,89 +2108,89 @@ Types:
       HasCount: true
       Element: 3 BaseType uint8
     - __kind: GoSwissMapGroupsType
-      ID: 199
+      ID: 196
       Name: groupReference<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 200 PointerType *noalg.map.group[string]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
+          Type: 197 PointerType *noalg.map.group[string]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
         - Name: lengthMask
           Offset: 8
           Type: 8 BaseType uint64
-      GroupType: 201 StructureType noalg.map.group[string]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
-      GroupSliceType: 290 GoSliceDataType []noalg.map.group[string]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute.array
+      GroupType: 198 StructureType noalg.map.group[string]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
+      GroupSliceType: 258 GoSliceDataType []noalg.map.group[string]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute.array
     - __kind: GoSwissMapGroupsType
-      ID: 67
+      ID: 151
       Name: groupReference<string,[]*mime/multipart.FileHeader>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 68 PointerType *noalg.map.group[string][]*mime/multipart.FileHeader
+          Type: 152 PointerType *noalg.map.group[string][]*mime/multipart.FileHeader
         - Name: lengthMask
           Offset: 8
           Type: 8 BaseType uint64
-      GroupType: 69 StructureType noalg.map.group[string][]*mime/multipart.FileHeader
-      GroupSliceType: 236 GoSliceDataType []noalg.map.group[string][]*mime/multipart.FileHeader.array
+      GroupType: 153 StructureType noalg.map.group[string][]*mime/multipart.FileHeader
+      GroupSliceType: 248 GoSliceDataType []noalg.map.group[string][]*mime/multipart.FileHeader.array
     - __kind: GoSwissMapGroupsType
-      ID: 49
+      ID: 131
       Name: groupReference<string,[]string>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 50 PointerType *noalg.map.group[string][]string
+          Type: 132 PointerType *noalg.map.group[string][]string
         - Name: lengthMask
           Offset: 8
           Type: 8 BaseType uint64
-      GroupType: 51 StructureType noalg.map.group[string][]string
+      GroupType: 133 StructureType noalg.map.group[string][]string
       GroupSliceType: 232 GoSliceDataType []noalg.map.group[string][]string.array
     - __kind: GoSwissMapGroupsType
-      ID: 182
+      ID: 142
       Name: groupReference<string,float64>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 183 PointerType *noalg.map.group[string]float64
+          Type: 143 PointerType *noalg.map.group[string]float64
         - Name: lengthMask
           Offset: 8
           Type: 8 BaseType uint64
-      GroupType: 184 StructureType noalg.map.group[string]float64
-      GroupSliceType: 284 GoSliceDataType []noalg.map.group[string]float64.array
+      GroupType: 144 StructureType noalg.map.group[string]float64
+      GroupSliceType: 240 GoSliceDataType []noalg.map.group[string]float64.array
     - __kind: GoSwissMapGroupsType
-      ID: 171
+      ID: 139
       Name: groupReference<string,interface {}>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 172 PointerType *noalg.map.group[string]interface {}
+          Type: 140 PointerType *noalg.map.group[string]interface {}
         - Name: lengthMask
           Offset: 8
           Type: 8 BaseType uint64
-      GroupType: 173 StructureType noalg.map.group[string]interface {}
-      GroupSliceType: 282 GoSliceDataType []noalg.map.group[string]interface {}.array
+      GroupType: 141 StructureType noalg.map.group[string]interface {}
+      GroupSliceType: 238 GoSliceDataType []noalg.map.group[string]interface {}.array
     - __kind: GoSwissMapGroupsType
-      ID: 152
+      ID: 136
       Name: groupReference<string,string>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 153 PointerType *noalg.map.group[string]string
+          Type: 137 PointerType *noalg.map.group[string]string
         - Name: lengthMask
           Offset: 8
           Type: 8 BaseType uint64
-      GroupType: 154 StructureType noalg.map.group[string]string
-      GroupSliceType: 280 GoSliceDataType []noalg.map.group[string]string.array
+      GroupType: 138 StructureType noalg.map.group[string]string
+      GroupSliceType: 236 GoSliceDataType []noalg.map.group[string]string.array
     - __kind: BaseType
       ID: 7
       Name: int
@@ -2222,7 +2222,7 @@ Types:
       GoRuntimeType: 590240
       GoKind: 3
     - __kind: GoEmptyInterfaceType
-      ID: 86
+      ID: 156
       Name: interface {}
       ByteSize: 16
       GoRuntimeType: 863072
@@ -2235,7 +2235,7 @@ Types:
           Offset: 8
           Type: 15 VoidPointerType unsafe.Pointer
     - __kind: StructureType
-      ID: 162
+      ID: 74
       Name: internal/sync.Mutex
       ByteSize: 8
       GoRuntimeType: 1.51232e+06
@@ -2248,7 +2248,7 @@ Types:
           Offset: 4
           Type: 2 BaseType uint32
     - __kind: GoInterfaceType
-      ID: 55
+      ID: 52
       Name: io.ReadCloser
       ByteSize: 16
       GoRuntimeType: 1.129632e+06
@@ -2261,7 +2261,7 @@ Types:
           Offset: 8
           Type: 15 VoidPointerType unsafe.Pointer
     - __kind: GoSwissMapHeaderType
-      ID: 195
+      ID: 124
       Name: map<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
       ByteSize: 48
       GoKind: 25
@@ -2274,7 +2274,7 @@ Types:
           Type: 1 BaseType uintptr
         - Name: dirPtr
           Offset: 16
-          Type: 196 PointerType **table<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
+          Type: 125 PointerType **table<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
         - Name: dirLen
           Offset: 24
           Type: 7 BaseType int
@@ -2290,10 +2290,10 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 8 BaseType uint64
-      TablePtrSliceType: 289 GoSliceDataType []*table<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>.array
-      GroupType: 201 StructureType noalg.map.group[string]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
+      TablePtrSliceType: 257 GoSliceDataType []*table<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>.array
+      GroupType: 198 StructureType noalg.map.group[string]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
     - __kind: GoSwissMapHeaderType
-      ID: 63
+      ID: 104
       Name: map<string,[]*mime/multipart.FileHeader>
       ByteSize: 48
       GoKind: 25
@@ -2306,7 +2306,7 @@ Types:
           Type: 1 BaseType uintptr
         - Name: dirPtr
           Offset: 16
-          Type: 64 PointerType **table<string,[]*mime/multipart.FileHeader>
+          Type: 105 PointerType **table<string,[]*mime/multipart.FileHeader>
         - Name: dirLen
           Offset: 24
           Type: 7 BaseType int
@@ -2322,10 +2322,10 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 8 BaseType uint64
-      TablePtrSliceType: 235 GoSliceDataType []*table<string,[]*mime/multipart.FileHeader>.array
-      GroupType: 69 StructureType noalg.map.group[string][]*mime/multipart.FileHeader
+      TablePtrSliceType: 247 GoSliceDataType []*table<string,[]*mime/multipart.FileHeader>.array
+      GroupType: 153 StructureType noalg.map.group[string][]*mime/multipart.FileHeader
     - __kind: GoSwissMapHeaderType
-      ID: 45
+      ID: 49
       Name: map<string,[]string>
       ByteSize: 48
       GoKind: 25
@@ -2338,7 +2338,7 @@ Types:
           Type: 1 BaseType uintptr
         - Name: dirPtr
           Offset: 16
-          Type: 46 PointerType **table<string,[]string>
+          Type: 50 PointerType **table<string,[]string>
         - Name: dirLen
           Offset: 24
           Type: 7 BaseType int
@@ -2355,9 +2355,9 @@ Types:
           Offset: 40
           Type: 8 BaseType uint64
       TablePtrSliceType: 231 GoSliceDataType []*table<string,[]string>.array
-      GroupType: 51 StructureType noalg.map.group[string][]string
+      GroupType: 133 StructureType noalg.map.group[string][]string
     - __kind: GoSwissMapHeaderType
-      ID: 178
+      ID: 84
       Name: map<string,float64>
       ByteSize: 48
       GoKind: 25
@@ -2370,7 +2370,7 @@ Types:
           Type: 1 BaseType uintptr
         - Name: dirPtr
           Offset: 16
-          Type: 179 PointerType **table<string,float64>
+          Type: 85 PointerType **table<string,float64>
         - Name: dirLen
           Offset: 24
           Type: 7 BaseType int
@@ -2386,10 +2386,10 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 8 BaseType uint64
-      TablePtrSliceType: 283 GoSliceDataType []*table<string,float64>.array
-      GroupType: 184 StructureType noalg.map.group[string]float64
+      TablePtrSliceType: 239 GoSliceDataType []*table<string,float64>.array
+      GroupType: 144 StructureType noalg.map.group[string]float64
     - __kind: GoSwissMapHeaderType
-      ID: 167
+      ID: 79
       Name: map<string,interface {}>
       ByteSize: 48
       GoKind: 25
@@ -2402,7 +2402,7 @@ Types:
           Type: 1 BaseType uintptr
         - Name: dirPtr
           Offset: 16
-          Type: 168 PointerType **table<string,interface {}>
+          Type: 80 PointerType **table<string,interface {}>
         - Name: dirLen
           Offset: 24
           Type: 7 BaseType int
@@ -2418,10 +2418,10 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 8 BaseType uint64
-      TablePtrSliceType: 281 GoSliceDataType []*table<string,interface {}>.array
-      GroupType: 173 StructureType noalg.map.group[string]interface {}
+      TablePtrSliceType: 237 GoSliceDataType []*table<string,interface {}>.array
+      GroupType: 141 StructureType noalg.map.group[string]interface {}
     - __kind: GoSwissMapHeaderType
-      ID: 148
+      ID: 68
       Name: map<string,string>
       ByteSize: 48
       GoKind: 25
@@ -2434,7 +2434,7 @@ Types:
           Type: 1 BaseType uintptr
         - Name: dirPtr
           Offset: 16
-          Type: 149 PointerType **table<string,string>
+          Type: 69 PointerType **table<string,string>
         - Name: dirLen
           Offset: 24
           Type: 7 BaseType int
@@ -2450,52 +2450,52 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 8 BaseType uint64
-      TablePtrSliceType: 279 GoSliceDataType []*table<string,string>.array
-      GroupType: 154 StructureType noalg.map.group[string]string
+      TablePtrSliceType: 235 GoSliceDataType []*table<string,string>.array
+      GroupType: 138 StructureType noalg.map.group[string]string
     - __kind: GoMapType
-      ID: 193
+      ID: 122
       Name: map[string]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
       ByteSize: 8
       GoRuntimeType: 1.153056e+06
       GoKind: 21
-      HeaderType: 195 GoSwissMapHeaderType map<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
+      HeaderType: 124 GoSwissMapHeaderType map<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
     - __kind: GoMapType
-      ID: 61
+      ID: 102
       Name: map[string][]*mime/multipart.FileHeader
       ByteSize: 8
       GoRuntimeType: 1.152288e+06
       GoKind: 21
-      HeaderType: 63 GoSwissMapHeaderType map<string,[]*mime/multipart.FileHeader>
+      HeaderType: 104 GoSwissMapHeaderType map<string,[]*mime/multipart.FileHeader>
     - __kind: GoMapType
-      ID: 60
+      ID: 101
       Name: map[string][]string
       ByteSize: 8
       GoRuntimeType: 1.14768e+06
       GoKind: 21
-      HeaderType: 45 GoSwissMapHeaderType map<string,[]string>
+      HeaderType: 49 GoSwissMapHeaderType map<string,[]string>
     - __kind: GoMapType
-      ID: 176
+      ID: 82
       Name: map[string]float64
       ByteSize: 8
       GoRuntimeType: 1.152928e+06
       GoKind: 21
-      HeaderType: 178 GoSwissMapHeaderType map<string,float64>
+      HeaderType: 84 GoSwissMapHeaderType map<string,float64>
     - __kind: GoMapType
-      ID: 214
+      ID: 127
       Name: map[string]interface {}
       ByteSize: 8
       GoRuntimeType: 1.146272e+06
       GoKind: 21
-      HeaderType: 167 GoSwissMapHeaderType map<string,interface {}>
+      HeaderType: 79 GoSwissMapHeaderType map<string,interface {}>
     - __kind: GoMapType
-      ID: 146
+      ID: 66
       Name: map[string]string
       ByteSize: 8
       GoRuntimeType: 1.148704e+06
       GoKind: 21
-      HeaderType: 148 GoSwissMapHeaderType map<string,string>
+      HeaderType: 68 GoSwissMapHeaderType map<string,string>
     - __kind: StructureType
-      ID: 88
+      ID: 158
       Name: math/big.Int
       ByteSize: 32
       GoRuntimeType: 1.51744e+06
@@ -2506,15 +2506,15 @@ Types:
           Type: 4 BaseType bool
         - Name: abs
           Offset: 8
-          Type: 89 GoSliceHeaderType math/big.nat
+          Type: 204 GoSliceHeaderType math/big.nat
     - __kind: BaseType
-      ID: 91
+      ID: 206
       Name: math/big.Word
       ByteSize: 8
       GoRuntimeType: 594464
       GoKind: 7
     - __kind: GoSliceHeaderType
-      ID: 89
+      ID: 204
       Name: math/big.nat
       ByteSize: 24
       GoRuntimeType: 2.420864e+06
@@ -2522,21 +2522,21 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 90 PointerType *math/big.Word
+          Type: 205 PointerType *math/big.Word
         - Name: len
           Offset: 8
           Type: 7 BaseType int
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 243 GoSliceDataType math/big.nat.array
+      Data: 285 GoSliceDataType math/big.nat.array
     - __kind: GoSliceDataType
-      ID: 243
+      ID: 285
       Name: math/big.nat.array
       ByteSize: 2048
-      Element: 91 BaseType math/big.Word
+      Element: 206 BaseType math/big.Word
     - __kind: StructureType
-      ID: 75
+      ID: 218
       Name: mime/multipart.FileHeader
       ByteSize: 88
       GoRuntimeType: 2.009312e+06
@@ -2547,13 +2547,13 @@ Types:
           Type: 9 GoStringHeaderType string
         - Name: Header
           Offset: 16
-          Type: 76 GoMapType net/textproto.MIMEHeader
+          Type: 223 GoMapType net/textproto.MIMEHeader
         - Name: Size
           Offset: 24
           Type: 13 BaseType int64
         - Name: content
           Offset: 32
-          Type: 77 GoSliceHeaderType []uint8
+          Type: 96 GoSliceHeaderType []uint8
         - Name: tmpfile
           Offset: 56
           Type: 9 GoStringHeaderType string
@@ -2564,7 +2564,7 @@ Types:
           Offset: 80
           Type: 4 BaseType bool
     - __kind: StructureType
-      ID: 59
+      ID: 57
       Name: mime/multipart.Form
       ByteSize: 16
       GoRuntimeType: 1.5008e+06
@@ -2572,12 +2572,12 @@ Types:
       RawFields:
         - Name: Value
           Offset: 0
-          Type: 60 GoMapType map[string][]string
+          Type: 101 GoMapType map[string][]string
         - Name: File
           Offset: 8
-          Type: 61 GoMapType map[string][]*mime/multipart.FileHeader
+          Type: 102 GoMapType map[string][]*mime/multipart.FileHeader
     - __kind: GoSliceHeaderType
-      ID: 117
+      ID: 178
       Name: net.IP
       ByteSize: 24
       GoRuntimeType: 2.170304e+06
@@ -2592,14 +2592,14 @@ Types:
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 261 GoSliceDataType net.IP.array
+      Data: 273 GoSliceDataType net.IP.array
     - __kind: GoSliceDataType
-      ID: 261
+      ID: 273
       Name: net.IP.array
       ByteSize: 2048
       Element: 3 BaseType uint8
     - __kind: GoSliceHeaderType
-      ID: 124
+      ID: 219
       Name: net.IPMask
       ByteSize: 24
       GoRuntimeType: 1.037408e+06
@@ -2614,14 +2614,14 @@ Types:
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 267 GoSliceDataType net.IPMask.array
+      Data: 291 GoSliceDataType net.IPMask.array
     - __kind: GoSliceDataType
-      ID: 267
+      ID: 291
       Name: net.IPMask.array
       ByteSize: 2048
       Element: 3 BaseType uint8
     - __kind: StructureType
-      ID: 123
+      ID: 213
       Name: net.IPNet
       ByteSize: 48
       GoRuntimeType: 1.48176e+06
@@ -2629,17 +2629,17 @@ Types:
       RawFields:
         - Name: IP
           Offset: 0
-          Type: 117 GoSliceHeaderType net.IP
+          Type: 178 GoSliceHeaderType net.IP
         - Name: Mask
           Offset: 24
-          Type: 124 GoSliceHeaderType net.IPMask
+          Type: 219 GoSliceHeaderType net.IPMask
     - __kind: GoMapType
-      ID: 43
+      ID: 47
       Name: net/http.Header
       ByteSize: 8
       GoRuntimeType: 2.147456e+06
       GoKind: 21
-      HeaderType: 45 GoSwissMapHeaderType map<string,[]string>
+      HeaderType: 49 GoSwissMapHeaderType map<string,[]string>
     - __kind: StructureType
       ID: 38
       Name: net/http.Request
@@ -2652,7 +2652,7 @@ Types:
           Type: 9 GoStringHeaderType string
         - Name: URL
           Offset: 16
-          Type: 39 PointerType *net/url.URL
+          Type: 45 PointerType *net/url.URL
         - Name: Proto
           Offset: 24
           Type: 9 GoStringHeaderType string
@@ -2664,13 +2664,13 @@ Types:
           Type: 7 BaseType int
         - Name: Header
           Offset: 56
-          Type: 43 GoMapType net/http.Header
+          Type: 47 GoMapType net/http.Header
         - Name: Body
           Offset: 64
-          Type: 55 GoInterfaceType io.ReadCloser
+          Type: 52 GoInterfaceType io.ReadCloser
         - Name: GetBody
           Offset: 80
-          Type: 56 GoSubroutineType func() (io.ReadCloser, error)
+          Type: 53 GoSubroutineType func() (io.ReadCloser, error)
         - Name: ContentLength
           Offset: 88
           Type: 13 BaseType int64
@@ -2685,16 +2685,16 @@ Types:
           Type: 9 GoStringHeaderType string
         - Name: Form
           Offset: 144
-          Type: 57 GoMapType net/url.Values
+          Type: 55 GoMapType net/url.Values
         - Name: PostForm
           Offset: 152
-          Type: 57 GoMapType net/url.Values
+          Type: 55 GoMapType net/url.Values
         - Name: MultipartForm
           Offset: 160
-          Type: 58 PointerType *mime/multipart.Form
+          Type: 56 PointerType *mime/multipart.Form
         - Name: Trailer
           Offset: 168
-          Type: 43 GoMapType net/http.Header
+          Type: 47 GoMapType net/http.Header
         - Name: RemoteAddr
           Offset: 176
           Type: 9 GoStringHeaderType string
@@ -2703,30 +2703,30 @@ Types:
           Type: 9 GoStringHeaderType string
         - Name: TLS
           Offset: 208
-          Type: 78 PointerType *crypto/tls.ConnectionState
+          Type: 58 PointerType *crypto/tls.ConnectionState
         - Name: Cancel
           Offset: 216
-          Type: 137 GoChannelType <-chan struct {}
+          Type: 60 GoChannelType <-chan struct {}
         - Name: Response
           Offset: 224
-          Type: 138 PointerType *net/http.Response
+          Type: 61 PointerType *net/http.Response
         - Name: Pattern
           Offset: 232
           Type: 9 GoStringHeaderType string
         - Name: ctx
           Offset: 248
-          Type: 140 GoInterfaceType context.Context
+          Type: 63 GoInterfaceType context.Context
         - Name: pat
           Offset: 264
-          Type: 141 PointerType *net/http.pattern
+          Type: 64 PointerType *net/http.pattern
         - Name: matches
           Offset: 272
           Type: 54 GoSliceHeaderType []string
         - Name: otherValues
           Offset: 296
-          Type: 146 GoMapType map[string]string
+          Type: 66 GoMapType map[string]string
     - __kind: StructureType
-      ID: 139
+      ID: 62
       Name: net/http.Response
       ByteSize: 144
       GoRuntimeType: 2.25968e+06
@@ -2749,10 +2749,10 @@ Types:
           Type: 7 BaseType int
         - Name: Header
           Offset: 56
-          Type: 43 GoMapType net/http.Header
+          Type: 47 GoMapType net/http.Header
         - Name: Body
           Offset: 64
-          Type: 55 GoInterfaceType io.ReadCloser
+          Type: 52 GoInterfaceType io.ReadCloser
         - Name: ContentLength
           Offset: 80
           Type: 13 BaseType int64
@@ -2767,13 +2767,13 @@ Types:
           Type: 4 BaseType bool
         - Name: Trailer
           Offset: 120
-          Type: 43 GoMapType net/http.Header
+          Type: 47 GoMapType net/http.Header
         - Name: Request
           Offset: 128
           Type: 37 PointerType *net/http.Request
         - Name: TLS
           Offset: 136
-          Type: 78 PointerType *crypto/tls.ConnectionState
+          Type: 58 PointerType *crypto/tls.ConnectionState
     - __kind: GoInterfaceType
       ID: 36
       Name: net/http.ResponseWriter
@@ -2788,7 +2788,7 @@ Types:
           Offset: 8
           Type: 15 VoidPointerType unsafe.Pointer
     - __kind: StructureType
-      ID: 142
+      ID: 65
       Name: net/http.pattern
       ByteSize: 88
       GoRuntimeType: 1.865856e+06
@@ -2805,12 +2805,12 @@ Types:
           Type: 9 GoStringHeaderType string
         - Name: segments
           Offset: 48
-          Type: 143 GoSliceHeaderType []net/http.segment
+          Type: 116 GoSliceHeaderType []net/http.segment
         - Name: loc
           Offset: 72
           Type: 9 GoStringHeaderType string
     - __kind: StructureType
-      ID: 145
+      ID: 118
       Name: net/http.segment
       ByteSize: 24
       GoRuntimeType: 1.637088e+06
@@ -2826,14 +2826,14 @@ Types:
           Offset: 17
           Type: 4 BaseType bool
     - __kind: GoMapType
-      ID: 76
+      ID: 223
       Name: net/textproto.MIMEHeader
       ByteSize: 8
       GoRuntimeType: 1.854368e+06
       GoKind: 21
-      HeaderType: 45 GoSwissMapHeaderType map<string,[]string>
+      HeaderType: 49 GoSwissMapHeaderType map<string,[]string>
     - __kind: StructureType
-      ID: 40
+      ID: 46
       Name: net/url.URL
       ByteSize: 144
       GoRuntimeType: 2.172992e+06
@@ -2847,7 +2847,7 @@ Types:
           Type: 9 GoStringHeaderType string
         - Name: User
           Offset: 32
-          Type: 41 PointerType *net/url.Userinfo
+          Type: 98 PointerType *net/url.Userinfo
         - Name: Host
           Offset: 40
           Type: 9 GoStringHeaderType string
@@ -2873,7 +2873,7 @@ Types:
           Offset: 128
           Type: 9 GoStringHeaderType string
     - __kind: StructureType
-      ID: 42
+      ID: 99
       Name: net/url.Userinfo
       ByteSize: 40
       GoRuntimeType: 1.653024e+06
@@ -2889,68 +2889,68 @@ Types:
           Offset: 32
           Type: 4 BaseType bool
     - __kind: GoMapType
-      ID: 57
+      ID: 55
       Name: net/url.Values
       ByteSize: 8
       GoRuntimeType: 1.920064e+06
       GoKind: 21
-      HeaderType: 45 GoSwissMapHeaderType map<string,[]string>
+      HeaderType: 49 GoSwissMapHeaderType map<string,[]string>
     - __kind: ArrayType
-      ID: 202
+      ID: 214
       Name: noalg.[8]struct { key string; elem *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute }
       ByteSize: 192
       GoRuntimeType: 711712
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 203 StructureType noalg.struct { key string; elem *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute }
+      Element: 215 StructureType noalg.struct { key string; elem *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute }
     - __kind: ArrayType
-      ID: 70
+      ID: 199
       Name: noalg.[8]struct { key string; elem []*mime/multipart.FileHeader }
       ByteSize: 320
       GoRuntimeType: 707136
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 71 StructureType noalg.struct { key string; elem []*mime/multipart.FileHeader }
+      Element: 200 StructureType noalg.struct { key string; elem []*mime/multipart.FileHeader }
     - __kind: ArrayType
-      ID: 52
+      ID: 149
       Name: noalg.[8]struct { key string; elem []string }
       ByteSize: 320
       GoRuntimeType: 697120
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 53 StructureType noalg.struct { key string; elem []string }
+      Element: 150 StructureType noalg.struct { key string; elem []string }
     - __kind: ArrayType
-      ID: 185
+      ID: 194
       Name: noalg.[8]struct { key string; elem float64 }
       ByteSize: 192
       GoRuntimeType: 711616
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 186 StructureType noalg.struct { key string; elem float64 }
+      Element: 195 StructureType noalg.struct { key string; elem float64 }
     - __kind: ArrayType
-      ID: 174
+      ID: 192
       Name: noalg.[8]struct { key string; elem interface {} }
       ByteSize: 256
       GoRuntimeType: 688576
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 175 StructureType noalg.struct { key string; elem interface {} }
+      Element: 193 StructureType noalg.struct { key string; elem interface {} }
     - __kind: ArrayType
-      ID: 155
+      ID: 190
       Name: noalg.[8]struct { key string; elem string }
       ByteSize: 256
       GoRuntimeType: 701280
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 156 StructureType noalg.struct { key string; elem string }
+      Element: 191 StructureType noalg.struct { key string; elem string }
     - __kind: StructureType
-      ID: 201
+      ID: 198
       Name: noalg.map.group[string]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
       ByteSize: 200
       GoRuntimeType: 1.3272e+06
@@ -2961,9 +2961,9 @@ Types:
           Type: 8 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 202 ArrayType noalg.[8]struct { key string; elem *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute }
+          Type: 214 ArrayType noalg.[8]struct { key string; elem *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute }
     - __kind: StructureType
-      ID: 69
+      ID: 153
       Name: noalg.map.group[string][]*mime/multipart.FileHeader
       ByteSize: 328
       GoRuntimeType: 1.320928e+06
@@ -2974,9 +2974,9 @@ Types:
           Type: 8 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 70 ArrayType noalg.[8]struct { key string; elem []*mime/multipart.FileHeader }
+          Type: 199 ArrayType noalg.[8]struct { key string; elem []*mime/multipart.FileHeader }
     - __kind: StructureType
-      ID: 51
+      ID: 133
       Name: noalg.map.group[string][]string
       ByteSize: 328
       GoRuntimeType: 1.311456e+06
@@ -2987,9 +2987,9 @@ Types:
           Type: 8 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 52 ArrayType noalg.[8]struct { key string; elem []string }
+          Type: 149 ArrayType noalg.[8]struct { key string; elem []string }
     - __kind: StructureType
-      ID: 184
+      ID: 144
       Name: noalg.map.group[string]float64
       ByteSize: 200
       GoRuntimeType: 1.326944e+06
@@ -3000,9 +3000,9 @@ Types:
           Type: 8 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 185 ArrayType noalg.[8]struct { key string; elem float64 }
+          Type: 194 ArrayType noalg.[8]struct { key string; elem float64 }
     - __kind: StructureType
-      ID: 173
+      ID: 141
       Name: noalg.map.group[string]interface {}
       ByteSize: 264
       GoRuntimeType: 1.308896e+06
@@ -3013,9 +3013,9 @@ Types:
           Type: 8 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 174 ArrayType noalg.[8]struct { key string; elem interface {} }
+          Type: 192 ArrayType noalg.[8]struct { key string; elem interface {} }
     - __kind: StructureType
-      ID: 154
+      ID: 138
       Name: noalg.map.group[string]string
       ByteSize: 264
       GoRuntimeType: 1.31376e+06
@@ -3026,9 +3026,9 @@ Types:
           Type: 8 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 155 ArrayType noalg.[8]struct { key string; elem string }
+          Type: 190 ArrayType noalg.[8]struct { key string; elem string }
     - __kind: StructureType
-      ID: 203
+      ID: 215
       Name: noalg.struct { key string; elem *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute }
       ByteSize: 24
       GoRuntimeType: 1.327072e+06
@@ -3039,9 +3039,9 @@ Types:
           Type: 9 GoStringHeaderType string
         - Name: elem
           Offset: 16
-          Type: 204 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
+          Type: 216 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
     - __kind: StructureType
-      ID: 71
+      ID: 200
       Name: noalg.struct { key string; elem []*mime/multipart.FileHeader }
       ByteSize: 40
       GoRuntimeType: 1.3208e+06
@@ -3052,9 +3052,9 @@ Types:
           Type: 9 GoStringHeaderType string
         - Name: elem
           Offset: 16
-          Type: 72 GoSliceHeaderType []*mime/multipart.FileHeader
+          Type: 201 GoSliceHeaderType []*mime/multipart.FileHeader
     - __kind: StructureType
-      ID: 53
+      ID: 150
       Name: noalg.struct { key string; elem []string }
       ByteSize: 40
       GoRuntimeType: 1.311328e+06
@@ -3067,7 +3067,7 @@ Types:
           Offset: 16
           Type: 54 GoSliceHeaderType []string
     - __kind: StructureType
-      ID: 186
+      ID: 195
       Name: noalg.struct { key string; elem float64 }
       ByteSize: 24
       GoRuntimeType: 1.326816e+06
@@ -3080,7 +3080,7 @@ Types:
           Offset: 16
           Type: 18 BaseType float64
     - __kind: StructureType
-      ID: 175
+      ID: 193
       Name: noalg.struct { key string; elem interface {} }
       ByteSize: 32
       GoRuntimeType: 1.308768e+06
@@ -3091,9 +3091,9 @@ Types:
           Type: 9 GoStringHeaderType string
         - Name: elem
           Offset: 16
-          Type: 86 GoEmptyInterfaceType interface {}
+          Type: 156 GoEmptyInterfaceType interface {}
     - __kind: StructureType
-      ID: 156
+      ID: 191
       Name: noalg.struct { key string; elem string }
       ByteSize: 32
       GoRuntimeType: 1.313632e+06
@@ -3124,7 +3124,7 @@ Types:
       Name: string.str
       ByteSize: 2048
     - __kind: StructureType
-      ID: 160
+      ID: 72
       Name: sync.Mutex
       ByteSize: 8
       GoRuntimeType: 1.48896e+06
@@ -3132,12 +3132,12 @@ Types:
       RawFields:
         - Name: _
           Offset: 0
-          Type: 161 StructureType sync.noCopy
+          Type: 73 StructureType sync.noCopy
         - Name: mu
           Offset: 0
-          Type: 162 StructureType internal/sync.Mutex
+          Type: 74 StructureType internal/sync.Mutex
     - __kind: StructureType
-      ID: 159
+      ID: 71
       Name: sync.RWMutex
       ByteSize: 24
       GoRuntimeType: 1.87168e+06
@@ -3145,7 +3145,7 @@ Types:
       RawFields:
         - Name: w
           Offset: 0
-          Type: 160 StructureType sync.Mutex
+          Type: 72 StructureType sync.Mutex
         - Name: writerSem
           Offset: 8
           Type: 2 BaseType uint32
@@ -3154,18 +3154,18 @@ Types:
           Type: 2 BaseType uint32
         - Name: readerCount
           Offset: 16
-          Type: 163 StructureType sync/atomic.Int32
+          Type: 75 StructureType sync/atomic.Int32
         - Name: readerWait
           Offset: 20
-          Type: 163 StructureType sync/atomic.Int32
+          Type: 75 StructureType sync/atomic.Int32
     - __kind: StructureType
-      ID: 161
+      ID: 73
       Name: sync.noCopy
       GoRuntimeType: 1.0024e+06
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 163
+      ID: 75
       Name: sync/atomic.Int32
       ByteSize: 4
       GoRuntimeType: 1.49024e+06
@@ -3173,18 +3173,18 @@ Types:
       RawFields:
         - Name: _
           Offset: 0
-          Type: 164 StructureType sync/atomic.noCopy
+          Type: 76 StructureType sync/atomic.noCopy
         - Name: v
           Offset: 0
           Type: 12 BaseType int32
     - __kind: StructureType
-      ID: 164
+      ID: 76
       Name: sync/atomic.noCopy
       GoRuntimeType: 1.002496e+06
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 198
+      ID: 145
       Name: table<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
       ByteSize: 32
       GoKind: 25
@@ -3206,9 +3206,9 @@ Types:
           Type: 7 BaseType int
         - Name: groups
           Offset: 16
-          Type: 199 GoSwissMapGroupsType groupReference<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
+          Type: 196 GoSwissMapGroupsType groupReference<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
     - __kind: StructureType
-      ID: 66
+      ID: 134
       Name: table<string,[]*mime/multipart.FileHeader>
       ByteSize: 32
       GoKind: 25
@@ -3230,9 +3230,9 @@ Types:
           Type: 7 BaseType int
         - Name: groups
           Offset: 16
-          Type: 67 GoSwissMapGroupsType groupReference<string,[]*mime/multipart.FileHeader>
+          Type: 151 GoSwissMapGroupsType groupReference<string,[]*mime/multipart.FileHeader>
     - __kind: StructureType
-      ID: 48
+      ID: 100
       Name: table<string,[]string>
       ByteSize: 32
       GoKind: 25
@@ -3254,9 +3254,9 @@ Types:
           Type: 7 BaseType int
         - Name: groups
           Offset: 16
-          Type: 49 GoSwissMapGroupsType groupReference<string,[]string>
+          Type: 131 GoSwissMapGroupsType groupReference<string,[]string>
     - __kind: StructureType
-      ID: 181
+      ID: 121
       Name: table<string,float64>
       ByteSize: 32
       GoKind: 25
@@ -3278,9 +3278,9 @@ Types:
           Type: 7 BaseType int
         - Name: groups
           Offset: 16
-          Type: 182 GoSwissMapGroupsType groupReference<string,float64>
+          Type: 142 GoSwissMapGroupsType groupReference<string,float64>
     - __kind: StructureType
-      ID: 170
+      ID: 120
       Name: table<string,interface {}>
       ByteSize: 32
       GoKind: 25
@@ -3302,9 +3302,9 @@ Types:
           Type: 7 BaseType int
         - Name: groups
           Offset: 16
-          Type: 171 GoSwissMapGroupsType groupReference<string,interface {}>
+          Type: 139 GoSwissMapGroupsType groupReference<string,interface {}>
     - __kind: StructureType
-      ID: 151
+      ID: 119
       Name: table<string,string>
       ByteSize: 32
       GoKind: 25
@@ -3326,9 +3326,9 @@ Types:
           Type: 7 BaseType int
         - Name: groups
           Offset: 16
-          Type: 152 GoSwissMapGroupsType groupReference<string,string>
+          Type: 136 GoSwissMapGroupsType groupReference<string,string>
     - __kind: StructureType
-      ID: 99
+      ID: 165
       Name: time.Location
       ByteSize: 104
       GoRuntimeType: 2.00528e+06
@@ -3339,10 +3339,10 @@ Types:
           Type: 9 GoStringHeaderType string
         - Name: zone
           Offset: 16
-          Type: 100 GoSliceHeaderType []time.zone
+          Type: 207 GoSliceHeaderType []time.zone
         - Name: tx
           Offset: 40
-          Type: 103 GoSliceHeaderType []time.zoneTrans
+          Type: 210 GoSliceHeaderType []time.zoneTrans
         - Name: extend
           Offset: 64
           Type: 9 GoStringHeaderType string
@@ -3354,9 +3354,9 @@ Types:
           Type: 13 BaseType int64
         - Name: cacheZone
           Offset: 96
-          Type: 101 PointerType *time.zone
+          Type: 208 PointerType *time.zone
     - __kind: StructureType
-      ID: 97
+      ID: 163
       Name: time.Time
       ByteSize: 24
       GoRuntimeType: 2.42368e+06
@@ -3370,9 +3370,9 @@ Types:
           Type: 13 BaseType int64
         - Name: loc
           Offset: 16
-          Type: 98 PointerType *time.Location
+          Type: 164 PointerType *time.Location
     - __kind: StructureType
-      ID: 102
+      ID: 209
       Name: time.zone
       ByteSize: 32
       GoRuntimeType: 1.64208e+06
@@ -3388,7 +3388,7 @@ Types:
           Offset: 24
           Type: 4 BaseType bool
     - __kind: StructureType
-      ID: 105
+      ID: 212
       Name: time.zoneTrans
       ByteSize: 16
       GoRuntimeType: 1.780992e+06

--- a/pkg/dyninst/irgen/testdata/snapshot/rc_tester.arch=arm64,toolchain=go1.24.3.yaml
+++ b/pkg/dyninst/irgen/testdata/snapshot/rc_tester.arch=arm64,toolchain=go1.24.3.yaml
@@ -105,50 +105,50 @@ Subprograms:
           IsReturn: false
 Types:
     - __kind: PointerType
-      ID: 108
+      ID: 110
       Name: '**crypto/x509.Certificate'
       ByteSize: 8
       GoKind: 22
-      Pointee: 109 PointerType *crypto/x509.Certificate
+      Pointee: 111 PointerType *crypto/x509.Certificate
     - __kind: PointerType
-      ID: 147
+      ID: 174
       Name: '**github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span'
       ByteSize: 8
       GoKind: 22
       Pointee: 39 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span
     - __kind: PointerType
-      ID: 225
+      ID: 258
       Name: '**github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttributeValue'
       ByteSize: 8
       GoKind: 22
-      Pointee: 226 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttributeValue
+      Pointee: 259 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttributeValue
     - __kind: PointerType
-      ID: 202
+      ID: 182
       Name: '**mime/multipart.FileHeader'
       ByteSize: 8
       GoKind: 22
-      Pointee: 203 PointerType *mime/multipart.FileHeader
+      Pointee: 183 PointerType *mime/multipart.FileHeader
     - __kind: PointerType
-      ID: 182
+      ID: 230
       Name: '**net.IPNet'
       ByteSize: 8
       GoKind: 22
-      Pointee: 183 PointerType *net.IPNet
+      Pointee: 231 PointerType *net.IPNet
     - __kind: PointerType
-      ID: 180
+      ID: 228
       Name: '**net/url.URL'
       ByteSize: 8
       Pointee: 45 PointerType *net/url.URL
     - __kind: PointerType
-      ID: 125
+      ID: 127
       Name: '**table<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>'
       ByteSize: 8
-      Pointee: 126 PointerType *table<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
+      Pointee: 128 PointerType *table<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
     - __kind: PointerType
-      ID: 105
+      ID: 107
       Name: '**table<string,[]*mime/multipart.FileHeader>'
       ByteSize: 8
-      Pointee: 106 PointerType *table<string,[]*mime/multipart.FileHeader>
+      Pointee: 108 PointerType *table<string,[]*mime/multipart.FileHeader>
     - __kind: PointerType
       ID: 50
       Name: '**table<string,[]string>'
@@ -170,128 +170,128 @@ Types:
       ByteSize: 8
       Pointee: 70 PointerType *table<string,string>
     - __kind: PointerType
-      ID: 111
+      ID: 113
       Name: '*[]*crypto/x509.Certificate'
       ByteSize: 8
       GoKind: 22
-      Pointee: 107 GoSliceHeaderType []*crypto/x509.Certificate
+      Pointee: 109 GoSliceHeaderType []*crypto/x509.Certificate
     - __kind: PointerType
-      ID: 250
+      ID: 187
       Name: '*[]*crypto/x509.Certificate.array'
       ByteSize: 8
-      Pointee: 249 GoSliceDataType []*crypto/x509.Certificate.array
+      Pointee: 186 GoSliceDataType []*crypto/x509.Certificate.array
     - __kind: PointerType
-      ID: 260
+      ID: 243
       Name: '*[]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span.array'
       ByteSize: 8
-      Pointee: 259 GoSliceDataType []*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span.array
+      Pointee: 242 GoSliceDataType []*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span.array
     - __kind: PointerType
-      ID: 294
+      ID: 291
       Name: '*[]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttributeValue.array'
       ByteSize: 8
-      Pointee: 293 GoSliceDataType []*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttributeValue.array
+      Pointee: 290 GoSliceDataType []*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttributeValue.array
     - __kind: PointerType
-      ID: 284
+      ID: 245
       Name: '*[]*mime/multipart.FileHeader.array'
       ByteSize: 8
-      Pointee: 283 GoSliceDataType []*mime/multipart.FileHeader.array
+      Pointee: 244 GoSliceDataType []*mime/multipart.FileHeader.array
     - __kind: PointerType
-      ID: 278
+      ID: 277
       Name: '*[]*net.IPNet.array'
       ByteSize: 8
-      Pointee: 277 GoSliceDataType []*net.IPNet.array
+      Pointee: 276 GoSliceDataType []*net.IPNet.array
     - __kind: PointerType
-      ID: 276
+      ID: 275
       Name: '*[]*net/url.URL.array'
       ByteSize: 8
-      Pointee: 275 GoSliceDataType []*net/url.URL.array
+      Pointee: 274 GoSliceDataType []*net/url.URL.array
     - __kind: PointerType
-      ID: 252
+      ID: 189
       Name: '*[][]*crypto/x509.Certificate.array'
       ByteSize: 8
-      Pointee: 251 GoSliceDataType [][]*crypto/x509.Certificate.array
+      Pointee: 188 GoSliceDataType [][]*crypto/x509.Certificate.array
     - __kind: PointerType
-      ID: 254
+      ID: 191
       Name: '*[][]uint8.array'
       ByteSize: 8
-      Pointee: 253 GoSliceDataType [][]uint8.array
+      Pointee: 190 GoSliceDataType [][]uint8.array
     - __kind: PointerType
-      ID: 270
+      ID: 269
       Name: '*[]crypto/x509.ExtKeyUsage.array'
       ByteSize: 8
-      Pointee: 269 GoSliceDataType []crypto/x509.ExtKeyUsage.array
+      Pointee: 268 GoSliceDataType []crypto/x509.ExtKeyUsage.array
     - __kind: PointerType
-      ID: 280
+      ID: 279
       Name: '*[]crypto/x509.OID.array'
       ByteSize: 8
-      Pointee: 279 GoSliceDataType []crypto/x509.OID.array
+      Pointee: 278 GoSliceDataType []crypto/x509.OID.array
     - __kind: PointerType
-      ID: 282
+      ID: 281
       Name: '*[]crypto/x509.PolicyMapping.array'
       ByteSize: 8
-      Pointee: 281 GoSliceDataType []crypto/x509.PolicyMapping.array
+      Pointee: 280 GoSliceDataType []crypto/x509.PolicyMapping.array
     - __kind: PointerType
-      ID: 262
+      ID: 261
       Name: '*[]crypto/x509/pkix.AttributeTypeAndValue.array'
       ByteSize: 8
-      Pointee: 261 GoSliceDataType []crypto/x509/pkix.AttributeTypeAndValue.array
+      Pointee: 260 GoSliceDataType []crypto/x509/pkix.AttributeTypeAndValue.array
     - __kind: PointerType
-      ID: 264
+      ID: 263
       Name: '*[]crypto/x509/pkix.Extension.array'
       ByteSize: 8
-      Pointee: 263 GoSliceDataType []crypto/x509/pkix.Extension.array
+      Pointee: 262 GoSliceDataType []crypto/x509/pkix.Extension.array
     - __kind: PointerType
-      ID: 266
+      ID: 265
       Name: '*[]encoding/asn1.ObjectIdentifier.array'
       ByteSize: 8
-      Pointee: 265 GoSliceDataType []encoding/asn1.ObjectIdentifier.array
+      Pointee: 264 GoSliceDataType []encoding/asn1.ObjectIdentifier.array
     - __kind: PointerType
-      ID: 242
+      ID: 165
       Name: '*[]github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink.array'
       ByteSize: 8
-      Pointee: 241 GoSliceDataType []github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink.array
+      Pointee: 164 GoSliceDataType []github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink.array
     - __kind: PointerType
-      ID: 244
+      ID: 167
       Name: '*[]github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent.array'
       ByteSize: 8
-      Pointee: 243 GoSliceDataType []github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent.array
+      Pointee: 166 GoSliceDataType []github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent.array
     - __kind: PointerType
-      ID: 272
+      ID: 271
       Name: '*[]net.IP.array'
       ByteSize: 8
-      Pointee: 271 GoSliceDataType []net.IP.array
+      Pointee: 270 GoSliceDataType []net.IP.array
     - __kind: PointerType
-      ID: 256
+      ID: 193
       Name: '*[]net/http.segment.array'
       ByteSize: 8
-      Pointee: 255 GoSliceDataType []net/http.segment.array
+      Pointee: 192 GoSliceDataType []net/http.segment.array
     - __kind: PointerType
-      ID: 234
+      ID: 141
       Name: '*[]string.array'
       ByteSize: 8
-      Pointee: 233 GoSliceDataType []string.array
+      Pointee: 140 GoSliceDataType []string.array
     - __kind: PointerType
-      ID: 288
+      ID: 287
       Name: '*[]time.zone.array'
       ByteSize: 8
-      Pointee: 287 GoSliceDataType []time.zone.array
+      Pointee: 286 GoSliceDataType []time.zone.array
     - __kind: PointerType
-      ID: 290
+      ID: 289
       Name: '*[]time.zoneTrans.array'
       ByteSize: 8
-      Pointee: 289 GoSliceDataType []time.zoneTrans.array
+      Pointee: 288 GoSliceDataType []time.zoneTrans.array
     - __kind: PointerType
-      ID: 113
+      ID: 115
       Name: '*[]uint8'
       ByteSize: 8
       GoRuntimeType: 483424
       GoKind: 22
       Pointee: 96 GoSliceHeaderType []uint8
     - __kind: PointerType
-      ID: 246
+      ID: 169
       Name: '*[]uint8.array'
       ByteSize: 8
-      Pointee: 245 GoSliceDataType []uint8.array
+      Pointee: 168 GoSliceDataType []uint8.array
     - __kind: PointerType
       ID: 11
       Name: '*bool'
@@ -314,59 +314,59 @@ Types:
       GoKind: 22
       Pointee: 59 StructureType crypto/tls.ConnectionState
     - __kind: PointerType
-      ID: 109
+      ID: 111
       Name: '*crypto/x509.Certificate'
       ByteSize: 8
       GoRuntimeType: 2.081952e+06
       GoKind: 22
-      Pointee: 135 StructureType crypto/x509.Certificate
+      Pointee: 171 StructureType crypto/x509.Certificate
     - __kind: PointerType
-      ID: 174
+      ID: 222
       Name: '*crypto/x509.ExtKeyUsage'
       ByteSize: 8
       GoRuntimeType: 426848
       GoKind: 22
-      Pointee: 175 BaseType crypto/x509.ExtKeyUsage
+      Pointee: 223 BaseType crypto/x509.ExtKeyUsage
     - __kind: PointerType
-      ID: 185
+      ID: 233
       Name: '*crypto/x509.OID'
       ByteSize: 8
       GoRuntimeType: 1.988896e+06
       GoKind: 22
-      Pointee: 186 StructureType crypto/x509.OID
+      Pointee: 234 StructureType crypto/x509.OID
     - __kind: PointerType
-      ID: 188
+      ID: 236
       Name: '*crypto/x509.PolicyMapping'
       ByteSize: 8
       GoRuntimeType: 426912
       GoKind: 22
-      Pointee: 189 StructureType crypto/x509.PolicyMapping
+      Pointee: 237 StructureType crypto/x509.PolicyMapping
     - __kind: PointerType
-      ID: 161
+      ID: 209
       Name: '*crypto/x509/pkix.AttributeTypeAndValue'
       ByteSize: 8
       GoRuntimeType: 443616
       GoKind: 22
-      Pointee: 162 StructureType crypto/x509/pkix.AttributeTypeAndValue
+      Pointee: 210 StructureType crypto/x509/pkix.AttributeTypeAndValue
     - __kind: PointerType
-      ID: 168
+      ID: 216
       Name: '*crypto/x509/pkix.Extension'
       ByteSize: 8
       GoRuntimeType: 443808
       GoKind: 22
-      Pointee: 169 StructureType crypto/x509/pkix.Extension
+      Pointee: 217 StructureType crypto/x509/pkix.Extension
     - __kind: PointerType
-      ID: 171
+      ID: 219
       Name: '*encoding/asn1.ObjectIdentifier'
       ByteSize: 8
       GoRuntimeType: 1.074528e+06
       GoKind: 22
-      Pointee: 172 GoSliceHeaderType encoding/asn1.ObjectIdentifier
+      Pointee: 220 GoSliceHeaderType encoding/asn1.ObjectIdentifier
     - __kind: PointerType
-      ID: 268
+      ID: 267
       Name: '*encoding/asn1.ObjectIdentifier.array'
       ByteSize: 8
-      Pointee: 267 GoSliceDataType encoding/asn1.ObjectIdentifier.array
+      Pointee: 266 GoSliceDataType encoding/asn1.ObjectIdentifier.array
     - __kind: PointerType
       ID: 33
       Name: '*error'
@@ -417,33 +417,33 @@ Types:
       GoKind: 22
       Pointee: 92 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent
     - __kind: PointerType
-      ID: 221
+      ID: 240
       Name: '*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttribute'
       ByteSize: 8
       GoRuntimeType: 1.210784e+06
       GoKind: 22
-      Pointee: 222 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttribute
+      Pointee: 241 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttribute
     - __kind: PointerType
-      ID: 226
+      ID: 259
       Name: '*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttributeValue'
       ByteSize: 8
       GoRuntimeType: 1.210528e+06
       GoKind: 22
-      Pointee: 227 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttributeValue
+      Pointee: 283 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttributeValue
     - __kind: PointerType
-      ID: 216
+      ID: 199
       Name: '*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute'
       ByteSize: 8
       GoRuntimeType: 1.210912e+06
       GoKind: 22
-      Pointee: 217 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
+      Pointee: 200 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
     - __kind: PointerType
-      ID: 128
+      ID: 130
       Name: '*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.trace'
       ByteSize: 8
       GoRuntimeType: 2.269504e+06
       GoKind: 22
-      Pointee: 129 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.trace
+      Pointee: 131 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.trace
     - __kind: PointerType
       ID: 28
       Name: '*int'
@@ -480,15 +480,15 @@ Types:
       GoKind: 22
       Pointee: 16 BaseType int8
     - __kind: PointerType
-      ID: 123
+      ID: 125
       Name: '*map<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>'
       ByteSize: 8
-      Pointee: 124 GoSwissMapHeaderType map<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
+      Pointee: 126 GoSwissMapHeaderType map<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
     - __kind: PointerType
-      ID: 103
+      ID: 105
       Name: '*map<string,[]*mime/multipart.FileHeader>'
       ByteSize: 8
-      Pointee: 104 GoSwissMapHeaderType map<string,[]*mime/multipart.FileHeader>
+      Pointee: 106 GoSwissMapHeaderType map<string,[]*mime/multipart.FileHeader>
     - __kind: PointerType
       ID: 48
       Name: '*map<string,[]string>'
@@ -510,31 +510,31 @@ Types:
       ByteSize: 8
       Pointee: 68 GoSwissMapHeaderType map<string,string>
     - __kind: PointerType
-      ID: 157
+      ID: 205
       Name: '*math/big.Int'
       ByteSize: 8
       GoRuntimeType: 2.440096e+06
       GoKind: 22
-      Pointee: 158 StructureType math/big.Int
+      Pointee: 206 StructureType math/big.Int
     - __kind: PointerType
-      ID: 205
+      ID: 247
       Name: '*math/big.Word'
       ByteSize: 8
       GoRuntimeType: 429728
       GoKind: 22
-      Pointee: 206 BaseType math/big.Word
+      Pointee: 248 BaseType math/big.Word
     - __kind: PointerType
-      ID: 286
+      ID: 285
       Name: '*math/big.nat.array'
       ByteSize: 8
-      Pointee: 285 GoSliceDataType math/big.nat.array
+      Pointee: 284 GoSliceDataType math/big.nat.array
     - __kind: PointerType
-      ID: 203
+      ID: 183
       Name: '*mime/multipart.FileHeader'
       ByteSize: 8
       GoRuntimeType: 920288
       GoKind: 22
-      Pointee: 218 StructureType mime/multipart.FileHeader
+      Pointee: 238 StructureType mime/multipart.FileHeader
     - __kind: PointerType
       ID: 56
       Name: '*mime/multipart.Form'
@@ -543,29 +543,29 @@ Types:
       GoKind: 22
       Pointee: 57 StructureType mime/multipart.Form
     - __kind: PointerType
-      ID: 177
+      ID: 225
       Name: '*net.IP'
       ByteSize: 8
       GoRuntimeType: 2.197536e+06
       GoKind: 22
-      Pointee: 178 GoSliceHeaderType net.IP
+      Pointee: 226 GoSliceHeaderType net.IP
     - __kind: PointerType
-      ID: 274
+      ID: 273
       Name: '*net.IP.array'
       ByteSize: 8
-      Pointee: 273 GoSliceDataType net.IP.array
+      Pointee: 272 GoSliceDataType net.IP.array
     - __kind: PointerType
-      ID: 292
+      ID: 294
       Name: '*net.IPMask.array'
       ByteSize: 8
-      Pointee: 291 GoSliceDataType net.IPMask.array
+      Pointee: 293 GoSliceDataType net.IPMask.array
     - __kind: PointerType
-      ID: 183
+      ID: 231
       Name: '*net.IPNet'
       ByteSize: 8
       GoRuntimeType: 1.203744e+06
       GoKind: 22
-      Pointee: 213 StructureType net.IPNet
+      Pointee: 255 StructureType net.IPNet
     - __kind: PointerType
       ID: 37
       Name: '*net/http.Request'
@@ -588,12 +588,12 @@ Types:
       GoKind: 22
       Pointee: 65 StructureType net/http.pattern
     - __kind: PointerType
-      ID: 117
+      ID: 119
       Name: '*net/http.segment'
       ByteSize: 8
       GoRuntimeType: 393440
       GoKind: 22
-      Pointee: 118 StructureType net/http.segment
+      Pointee: 120 StructureType net/http.segment
     - __kind: PointerType
       ID: 45
       Name: '*net/url.URL'
@@ -602,42 +602,42 @@ Types:
       GoKind: 22
       Pointee: 46 StructureType net/url.URL
     - __kind: PointerType
-      ID: 98
+      ID: 100
       Name: '*net/url.Userinfo'
       ByteSize: 8
       GoRuntimeType: 1.221536e+06
       GoKind: 22
-      Pointee: 99 StructureType net/url.Userinfo
+      Pointee: 101 StructureType net/url.Userinfo
     - __kind: PointerType
-      ID: 197
+      ID: 195
       Name: '*noalg.map.group[string]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute'
       ByteSize: 8
-      Pointee: 198 StructureType noalg.map.group[string]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
+      Pointee: 196 StructureType noalg.map.group[string]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
     - __kind: PointerType
-      ID: 152
+      ID: 177
       Name: '*noalg.map.group[string][]*mime/multipart.FileHeader'
       ByteSize: 8
-      Pointee: 153 StructureType noalg.map.group[string][]*mime/multipart.FileHeader
+      Pointee: 178 StructureType noalg.map.group[string][]*mime/multipart.FileHeader
     - __kind: PointerType
-      ID: 132
+      ID: 134
       Name: '*noalg.map.group[string][]string'
       ByteSize: 8
-      Pointee: 133 StructureType noalg.map.group[string][]string
+      Pointee: 135 StructureType noalg.map.group[string][]string
     - __kind: PointerType
-      ID: 143
+      ID: 158
       Name: '*noalg.map.group[string]float64'
       ByteSize: 8
-      Pointee: 144 StructureType noalg.map.group[string]float64
+      Pointee: 159 StructureType noalg.map.group[string]float64
     - __kind: PointerType
-      ID: 140
+      ID: 150
       Name: '*noalg.map.group[string]interface {}'
       ByteSize: 8
-      Pointee: 141 StructureType noalg.map.group[string]interface {}
+      Pointee: 151 StructureType noalg.map.group[string]interface {}
     - __kind: PointerType
-      ID: 137
+      ID: 143
       Name: '*noalg.map.group[string]string'
       ByteSize: 8
-      Pointee: 138 StructureType noalg.map.group[string]string
+      Pointee: 144 StructureType noalg.map.group[string]string
     - __kind: PointerType
       ID: 22
       Name: '*string'
@@ -646,61 +646,61 @@ Types:
       GoKind: 22
       Pointee: 9 GoStringHeaderType string
     - __kind: PointerType
-      ID: 230
+      ID: 99
       Name: '*string.str'
       ByteSize: 8
-      Pointee: 229 GoStringDataType string.str
+      Pointee: 98 GoStringDataType string.str
     - __kind: PointerType
-      ID: 126
+      ID: 128
       Name: '*table<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>'
       ByteSize: 8
-      Pointee: 145 StructureType table<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
+      Pointee: 172 StructureType table<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
     - __kind: PointerType
-      ID: 106
+      ID: 108
       Name: '*table<string,[]*mime/multipart.FileHeader>'
       ByteSize: 8
-      Pointee: 134 StructureType table<string,[]*mime/multipart.FileHeader>
+      Pointee: 170 StructureType table<string,[]*mime/multipart.FileHeader>
     - __kind: PointerType
       ID: 51
       Name: '*table<string,[]string>'
       ByteSize: 8
-      Pointee: 100 StructureType table<string,[]string>
+      Pointee: 102 StructureType table<string,[]string>
     - __kind: PointerType
       ID: 86
       Name: '*table<string,float64>'
       ByteSize: 8
-      Pointee: 121 StructureType table<string,float64>
+      Pointee: 123 StructureType table<string,float64>
     - __kind: PointerType
       ID: 81
       Name: '*table<string,interface {}>'
       ByteSize: 8
-      Pointee: 120 StructureType table<string,interface {}>
+      Pointee: 122 StructureType table<string,interface {}>
     - __kind: PointerType
       ID: 70
       Name: '*table<string,string>'
       ByteSize: 8
-      Pointee: 119 StructureType table<string,string>
+      Pointee: 121 StructureType table<string,string>
     - __kind: PointerType
-      ID: 164
+      ID: 212
       Name: '*time.Location'
       ByteSize: 8
       GoRuntimeType: 1.642272e+06
       GoKind: 22
-      Pointee: 165 StructureType time.Location
+      Pointee: 213 StructureType time.Location
     - __kind: PointerType
-      ID: 208
+      ID: 250
       Name: '*time.zone'
       ByteSize: 8
       GoRuntimeType: 396576
       GoKind: 22
-      Pointee: 209 StructureType time.zone
+      Pointee: 251 StructureType time.zone
     - __kind: PointerType
-      ID: 211
+      ID: 253
       Name: '*time.zoneTrans'
       ByteSize: 8
       GoRuntimeType: 396640
       GoKind: 22
-      Pointee: 212 StructureType time.zoneTrans
+      Pointee: 254 StructureType time.zoneTrans
     - __kind: PointerType
       ID: 34
       Name: '*uint'
@@ -788,7 +788,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: GoSliceHeaderType
-      ID: 107
+      ID: 109
       Name: '[]*crypto/x509.Certificate'
       ByteSize: 24
       GoRuntimeType: 503680
@@ -796,21 +796,21 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 108 PointerType **crypto/x509.Certificate
+          Type: 110 PointerType **crypto/x509.Certificate
         - Name: len
           Offset: 8
           Type: 7 BaseType int
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 249 GoSliceDataType []*crypto/x509.Certificate.array
+      Data: 186 GoSliceDataType []*crypto/x509.Certificate.array
     - __kind: GoSliceDataType
-      ID: 249
+      ID: 186
       Name: '[]*crypto/x509.Certificate.array'
       ByteSize: 2048
-      Element: 109 PointerType *crypto/x509.Certificate
+      Element: 111 PointerType *crypto/x509.Certificate
     - __kind: GoSliceHeaderType
-      ID: 146
+      ID: 173
       Name: '[]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span'
       ByteSize: 24
       GoRuntimeType: 491840
@@ -818,21 +818,21 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 147 PointerType **github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span
+          Type: 174 PointerType **github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span
         - Name: len
           Offset: 8
           Type: 7 BaseType int
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 259 GoSliceDataType []*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span.array
+      Data: 242 GoSliceDataType []*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span.array
     - __kind: GoSliceDataType
-      ID: 259
+      ID: 242
       Name: '[]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span.array'
       ByteSize: 2048
       Element: 39 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span
     - __kind: GoSliceHeaderType
-      ID: 224
+      ID: 257
       Name: '[]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttributeValue'
       ByteSize: 24
       GoRuntimeType: 491456
@@ -840,21 +840,21 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 225 PointerType **github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttributeValue
+          Type: 258 PointerType **github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttributeValue
         - Name: len
           Offset: 8
           Type: 7 BaseType int
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 293 GoSliceDataType []*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttributeValue.array
+      Data: 290 GoSliceDataType []*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttributeValue.array
     - __kind: GoSliceDataType
-      ID: 293
+      ID: 290
       Name: '[]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttributeValue.array'
       ByteSize: 2048
-      Element: 226 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttributeValue
+      Element: 259 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttributeValue
     - __kind: GoSliceHeaderType
-      ID: 201
+      ID: 181
       Name: '[]*mime/multipart.FileHeader'
       ByteSize: 24
       GoRuntimeType: 488960
@@ -862,21 +862,21 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 202 PointerType **mime/multipart.FileHeader
+          Type: 182 PointerType **mime/multipart.FileHeader
         - Name: len
           Offset: 8
           Type: 7 BaseType int
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 283 GoSliceDataType []*mime/multipart.FileHeader.array
+      Data: 244 GoSliceDataType []*mime/multipart.FileHeader.array
     - __kind: GoSliceDataType
-      ID: 283
+      ID: 244
       Name: '[]*mime/multipart.FileHeader.array'
       ByteSize: 2048
-      Element: 203 PointerType *mime/multipart.FileHeader
+      Element: 183 PointerType *mime/multipart.FileHeader
     - __kind: GoSliceHeaderType
-      ID: 181
+      ID: 229
       Name: '[]*net.IPNet'
       ByteSize: 24
       GoRuntimeType: 518464
@@ -884,21 +884,21 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 182 PointerType **net.IPNet
+          Type: 230 PointerType **net.IPNet
         - Name: len
           Offset: 8
           Type: 7 BaseType int
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 277 GoSliceDataType []*net.IPNet.array
+      Data: 276 GoSliceDataType []*net.IPNet.array
     - __kind: GoSliceDataType
-      ID: 277
+      ID: 276
       Name: '[]*net.IPNet.array'
       ByteSize: 2048
-      Element: 183 PointerType *net.IPNet
+      Element: 231 PointerType *net.IPNet
     - __kind: GoSliceHeaderType
-      ID: 179
+      ID: 227
       Name: '[]*net/url.URL'
       ByteSize: 24
       GoRuntimeType: 518400
@@ -906,51 +906,51 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 180 PointerType **net/url.URL
+          Type: 228 PointerType **net/url.URL
         - Name: len
           Offset: 8
           Type: 7 BaseType int
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 275 GoSliceDataType []*net/url.URL.array
+      Data: 274 GoSliceDataType []*net/url.URL.array
     - __kind: GoSliceDataType
-      ID: 275
+      ID: 274
       Name: '[]*net/url.URL.array'
       ByteSize: 2048
       Element: 45 PointerType *net/url.URL
     - __kind: GoSliceDataType
-      ID: 257
+      ID: 201
       Name: '[]*table<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>.array'
       ByteSize: 8192
-      Element: 126 PointerType *table<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
+      Element: 128 PointerType *table<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
     - __kind: GoSliceDataType
-      ID: 247
+      ID: 184
       Name: '[]*table<string,[]*mime/multipart.FileHeader>.array'
       ByteSize: 8192
-      Element: 106 PointerType *table<string,[]*mime/multipart.FileHeader>
+      Element: 108 PointerType *table<string,[]*mime/multipart.FileHeader>
     - __kind: GoSliceDataType
-      ID: 231
+      ID: 138
       Name: '[]*table<string,[]string>.array'
       ByteSize: 8192
       Element: 51 PointerType *table<string,[]string>
     - __kind: GoSliceDataType
-      ID: 239
+      ID: 162
       Name: '[]*table<string,float64>.array'
       ByteSize: 8192
       Element: 86 PointerType *table<string,float64>
     - __kind: GoSliceDataType
-      ID: 237
+      ID: 155
       Name: '[]*table<string,interface {}>.array'
       ByteSize: 8192
       Element: 81 PointerType *table<string,interface {}>
     - __kind: GoSliceDataType
-      ID: 235
+      ID: 147
       Name: '[]*table<string,string>.array'
       ByteSize: 8192
       Element: 70 PointerType *table<string,string>
     - __kind: GoSliceHeaderType
-      ID: 110
+      ID: 112
       Name: '[][]*crypto/x509.Certificate'
       ByteSize: 24
       GoRuntimeType: 503808
@@ -958,21 +958,21 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 111 PointerType *[]*crypto/x509.Certificate
+          Type: 113 PointerType *[]*crypto/x509.Certificate
         - Name: len
           Offset: 8
           Type: 7 BaseType int
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 251 GoSliceDataType [][]*crypto/x509.Certificate.array
+      Data: 188 GoSliceDataType [][]*crypto/x509.Certificate.array
     - __kind: GoSliceDataType
-      ID: 251
+      ID: 188
       Name: '[][]*crypto/x509.Certificate.array'
       ByteSize: 2048
-      Element: 107 GoSliceHeaderType []*crypto/x509.Certificate
+      Element: 109 GoSliceHeaderType []*crypto/x509.Certificate
     - __kind: GoSliceHeaderType
-      ID: 112
+      ID: 114
       Name: '[][]uint8'
       ByteSize: 24
       GoRuntimeType: 483808
@@ -980,21 +980,21 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 113 PointerType *[]uint8
+          Type: 115 PointerType *[]uint8
         - Name: len
           Offset: 8
           Type: 7 BaseType int
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 253 GoSliceDataType [][]uint8.array
+      Data: 190 GoSliceDataType [][]uint8.array
     - __kind: GoSliceDataType
-      ID: 253
+      ID: 190
       Name: '[][]uint8.array'
       ByteSize: 2048
       Element: 96 GoSliceHeaderType []uint8
     - __kind: GoSliceHeaderType
-      ID: 173
+      ID: 221
       Name: '[]crypto/x509.ExtKeyUsage'
       ByteSize: 24
       GoRuntimeType: 505152
@@ -1002,21 +1002,21 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 174 PointerType *crypto/x509.ExtKeyUsage
+          Type: 222 PointerType *crypto/x509.ExtKeyUsage
         - Name: len
           Offset: 8
           Type: 7 BaseType int
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 269 GoSliceDataType []crypto/x509.ExtKeyUsage.array
+      Data: 268 GoSliceDataType []crypto/x509.ExtKeyUsage.array
     - __kind: GoSliceDataType
-      ID: 269
+      ID: 268
       Name: '[]crypto/x509.ExtKeyUsage.array'
       ByteSize: 2048
-      Element: 175 BaseType crypto/x509.ExtKeyUsage
+      Element: 223 BaseType crypto/x509.ExtKeyUsage
     - __kind: GoSliceHeaderType
-      ID: 184
+      ID: 232
       Name: '[]crypto/x509.OID'
       ByteSize: 24
       GoRuntimeType: 518528
@@ -1024,21 +1024,21 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 185 PointerType *crypto/x509.OID
+          Type: 233 PointerType *crypto/x509.OID
         - Name: len
           Offset: 8
           Type: 7 BaseType int
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 279 GoSliceDataType []crypto/x509.OID.array
+      Data: 278 GoSliceDataType []crypto/x509.OID.array
     - __kind: GoSliceDataType
-      ID: 279
+      ID: 278
       Name: '[]crypto/x509.OID.array'
       ByteSize: 2048
-      Element: 186 StructureType crypto/x509.OID
+      Element: 234 StructureType crypto/x509.OID
     - __kind: GoSliceHeaderType
-      ID: 187
+      ID: 235
       Name: '[]crypto/x509.PolicyMapping'
       ByteSize: 24
       GoRuntimeType: 518592
@@ -1046,21 +1046,21 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 188 PointerType *crypto/x509.PolicyMapping
+          Type: 236 PointerType *crypto/x509.PolicyMapping
         - Name: len
           Offset: 8
           Type: 7 BaseType int
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 281 GoSliceDataType []crypto/x509.PolicyMapping.array
+      Data: 280 GoSliceDataType []crypto/x509.PolicyMapping.array
     - __kind: GoSliceDataType
-      ID: 281
+      ID: 280
       Name: '[]crypto/x509.PolicyMapping.array'
       ByteSize: 2048
-      Element: 189 StructureType crypto/x509.PolicyMapping
+      Element: 237 StructureType crypto/x509.PolicyMapping
     - __kind: GoSliceHeaderType
-      ID: 160
+      ID: 208
       Name: '[]crypto/x509/pkix.AttributeTypeAndValue'
       ByteSize: 24
       GoRuntimeType: 519040
@@ -1068,21 +1068,21 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 161 PointerType *crypto/x509/pkix.AttributeTypeAndValue
+          Type: 209 PointerType *crypto/x509/pkix.AttributeTypeAndValue
         - Name: len
           Offset: 8
           Type: 7 BaseType int
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 261 GoSliceDataType []crypto/x509/pkix.AttributeTypeAndValue.array
+      Data: 260 GoSliceDataType []crypto/x509/pkix.AttributeTypeAndValue.array
     - __kind: GoSliceDataType
-      ID: 261
+      ID: 260
       Name: '[]crypto/x509/pkix.AttributeTypeAndValue.array'
       ByteSize: 2048
-      Element: 162 StructureType crypto/x509/pkix.AttributeTypeAndValue
+      Element: 210 StructureType crypto/x509/pkix.AttributeTypeAndValue
     - __kind: GoSliceHeaderType
-      ID: 167
+      ID: 215
       Name: '[]crypto/x509/pkix.Extension'
       ByteSize: 24
       GoRuntimeType: 518272
@@ -1090,21 +1090,21 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 168 PointerType *crypto/x509/pkix.Extension
+          Type: 216 PointerType *crypto/x509/pkix.Extension
         - Name: len
           Offset: 8
           Type: 7 BaseType int
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 263 GoSliceDataType []crypto/x509/pkix.Extension.array
+      Data: 262 GoSliceDataType []crypto/x509/pkix.Extension.array
     - __kind: GoSliceDataType
-      ID: 263
+      ID: 262
       Name: '[]crypto/x509/pkix.Extension.array'
       ByteSize: 2048
-      Element: 169 StructureType crypto/x509/pkix.Extension
+      Element: 217 StructureType crypto/x509/pkix.Extension
     - __kind: GoSliceHeaderType
-      ID: 170
+      ID: 218
       Name: '[]encoding/asn1.ObjectIdentifier'
       ByteSize: 24
       GoRuntimeType: 518336
@@ -1112,19 +1112,19 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 171 PointerType *encoding/asn1.ObjectIdentifier
+          Type: 219 PointerType *encoding/asn1.ObjectIdentifier
         - Name: len
           Offset: 8
           Type: 7 BaseType int
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 265 GoSliceDataType []encoding/asn1.ObjectIdentifier.array
+      Data: 264 GoSliceDataType []encoding/asn1.ObjectIdentifier.array
     - __kind: GoSliceDataType
-      ID: 265
+      ID: 264
       Name: '[]encoding/asn1.ObjectIdentifier.array'
       ByteSize: 2048
-      Element: 172 GoSliceHeaderType encoding/asn1.ObjectIdentifier
+      Element: 220 GoSliceHeaderType encoding/asn1.ObjectIdentifier
     - __kind: GoSliceHeaderType
       ID: 87
       Name: '[]github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink'
@@ -1141,9 +1141,9 @@ Types:
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 241 GoSliceDataType []github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink.array
+      Data: 164 GoSliceDataType []github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink.array
     - __kind: GoSliceDataType
-      ID: 241
+      ID: 164
       Name: '[]github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink.array'
       ByteSize: 2048
       Element: 89 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink
@@ -1163,14 +1163,14 @@ Types:
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 243 GoSliceDataType []github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent.array
+      Data: 166 GoSliceDataType []github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent.array
     - __kind: GoSliceDataType
-      ID: 243
+      ID: 166
       Name: '[]github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent.array'
       ByteSize: 2048
       Element: 92 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent
     - __kind: GoSliceHeaderType
-      ID: 176
+      ID: 224
       Name: '[]net.IP'
       ByteSize: 24
       GoRuntimeType: 484768
@@ -1178,21 +1178,21 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 177 PointerType *net.IP
+          Type: 225 PointerType *net.IP
         - Name: len
           Offset: 8
           Type: 7 BaseType int
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 271 GoSliceDataType []net.IP.array
+      Data: 270 GoSliceDataType []net.IP.array
     - __kind: GoSliceDataType
-      ID: 271
+      ID: 270
       Name: '[]net.IP.array'
       ByteSize: 2048
-      Element: 178 GoSliceHeaderType net.IP
+      Element: 226 GoSliceHeaderType net.IP
     - __kind: GoSliceHeaderType
-      ID: 116
+      ID: 118
       Name: '[]net/http.segment'
       ByteSize: 24
       GoRuntimeType: 486400
@@ -1200,49 +1200,49 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 117 PointerType *net/http.segment
+          Type: 119 PointerType *net/http.segment
         - Name: len
           Offset: 8
           Type: 7 BaseType int
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 255 GoSliceDataType []net/http.segment.array
+      Data: 192 GoSliceDataType []net/http.segment.array
     - __kind: GoSliceDataType
-      ID: 255
+      ID: 192
       Name: '[]net/http.segment.array'
       ByteSize: 2048
-      Element: 118 StructureType net/http.segment
+      Element: 120 StructureType net/http.segment
     - __kind: GoSliceDataType
-      ID: 258
+      ID: 202
       Name: '[]noalg.map.group[string]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute.array'
       ByteSize: 2048
-      Element: 198 StructureType noalg.map.group[string]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
+      Element: 196 StructureType noalg.map.group[string]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
     - __kind: GoSliceDataType
-      ID: 248
+      ID: 185
       Name: '[]noalg.map.group[string][]*mime/multipart.FileHeader.array'
       ByteSize: 2048
-      Element: 153 StructureType noalg.map.group[string][]*mime/multipart.FileHeader
+      Element: 178 StructureType noalg.map.group[string][]*mime/multipart.FileHeader
     - __kind: GoSliceDataType
-      ID: 232
+      ID: 139
       Name: '[]noalg.map.group[string][]string.array'
       ByteSize: 2048
-      Element: 133 StructureType noalg.map.group[string][]string
+      Element: 135 StructureType noalg.map.group[string][]string
     - __kind: GoSliceDataType
-      ID: 240
+      ID: 163
       Name: '[]noalg.map.group[string]float64.array'
       ByteSize: 2048
-      Element: 144 StructureType noalg.map.group[string]float64
+      Element: 159 StructureType noalg.map.group[string]float64
     - __kind: GoSliceDataType
-      ID: 238
+      ID: 156
       Name: '[]noalg.map.group[string]interface {}.array'
       ByteSize: 2048
-      Element: 141 StructureType noalg.map.group[string]interface {}
+      Element: 151 StructureType noalg.map.group[string]interface {}
     - __kind: GoSliceDataType
-      ID: 236
+      ID: 148
       Name: '[]noalg.map.group[string]string.array'
       ByteSize: 2048
-      Element: 138 StructureType noalg.map.group[string]string
+      Element: 144 StructureType noalg.map.group[string]string
     - __kind: GoSliceHeaderType
       ID: 54
       Name: '[]string'
@@ -1259,14 +1259,14 @@ Types:
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 233 GoSliceDataType []string.array
+      Data: 140 GoSliceDataType []string.array
     - __kind: GoSliceDataType
-      ID: 233
+      ID: 140
       Name: '[]string.array'
       ByteSize: 2048
       Element: 9 GoStringHeaderType string
     - __kind: GoSliceHeaderType
-      ID: 207
+      ID: 249
       Name: '[]time.zone'
       ByteSize: 24
       GoRuntimeType: 490944
@@ -1274,21 +1274,21 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 208 PointerType *time.zone
+          Type: 250 PointerType *time.zone
         - Name: len
           Offset: 8
           Type: 7 BaseType int
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 287 GoSliceDataType []time.zone.array
+      Data: 286 GoSliceDataType []time.zone.array
     - __kind: GoSliceDataType
-      ID: 287
+      ID: 286
       Name: '[]time.zone.array'
       ByteSize: 2048
-      Element: 209 StructureType time.zone
+      Element: 251 StructureType time.zone
     - __kind: GoSliceHeaderType
-      ID: 210
+      ID: 252
       Name: '[]time.zoneTrans'
       ByteSize: 24
       GoRuntimeType: 491008
@@ -1296,19 +1296,19 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 211 PointerType *time.zoneTrans
+          Type: 253 PointerType *time.zoneTrans
         - Name: len
           Offset: 8
           Type: 7 BaseType int
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 289 GoSliceDataType []time.zoneTrans.array
+      Data: 288 GoSliceDataType []time.zoneTrans.array
     - __kind: GoSliceDataType
-      ID: 289
+      ID: 288
       Name: '[]time.zoneTrans.array'
       ByteSize: 2048
-      Element: 212 StructureType time.zoneTrans
+      Element: 254 StructureType time.zoneTrans
     - __kind: GoSliceHeaderType
       ID: 96
       Name: '[]uint8'
@@ -1325,9 +1325,9 @@ Types:
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 245 GoSliceDataType []uint8.array
+      Data: 168 GoSliceDataType []uint8.array
     - __kind: GoSliceDataType
-      ID: 245
+      ID: 168
       Name: '[]uint8.array'
       ByteSize: 2048
       Element: 3 BaseType uint8
@@ -1429,13 +1429,13 @@ Types:
           Type: 9 GoStringHeaderType string
         - Name: PeerCertificates
           Offset: 48
-          Type: 107 GoSliceHeaderType []*crypto/x509.Certificate
+          Type: 109 GoSliceHeaderType []*crypto/x509.Certificate
         - Name: VerifiedChains
           Offset: 72
-          Type: 110 GoSliceHeaderType [][]*crypto/x509.Certificate
+          Type: 112 GoSliceHeaderType [][]*crypto/x509.Certificate
         - Name: SignedCertificateTimestamps
           Offset: 96
-          Type: 112 GoSliceHeaderType [][]uint8
+          Type: 114 GoSliceHeaderType [][]uint8
         - Name: OCSPResponse
           Offset: 120
           Type: 96 GoSliceHeaderType []uint8
@@ -1447,21 +1447,21 @@ Types:
           Type: 4 BaseType bool
         - Name: ekm
           Offset: 176
-          Type: 114 GoSubroutineType func(string, []uint8, int) ([]uint8, error)
+          Type: 116 GoSubroutineType func(string, []uint8, int) ([]uint8, error)
         - Name: testingOnlyDidHRR
           Offset: 184
           Type: 4 BaseType bool
         - Name: testingOnlyCurveID
           Offset: 186
-          Type: 115 BaseType crypto/tls.CurveID
+          Type: 117 BaseType crypto/tls.CurveID
     - __kind: BaseType
-      ID: 115
+      ID: 117
       Name: crypto/tls.CurveID
       ByteSize: 2
       GoRuntimeType: 843360
       GoKind: 9
     - __kind: StructureType
-      ID: 135
+      ID: 171
       Name: crypto/x509.Certificate
       ByteSize: 1424
       GoRuntimeType: 2.452512e+06
@@ -1487,49 +1487,49 @@ Types:
           Type: 96 GoSliceHeaderType []uint8
         - Name: SignatureAlgorithm
           Offset: 144
-          Type: 154 BaseType crypto/x509.SignatureAlgorithm
+          Type: 203 BaseType crypto/x509.SignatureAlgorithm
         - Name: PublicKeyAlgorithm
           Offset: 152
-          Type: 155 BaseType crypto/x509.PublicKeyAlgorithm
+          Type: 204 BaseType crypto/x509.PublicKeyAlgorithm
         - Name: PublicKey
           Offset: 160
-          Type: 156 GoEmptyInterfaceType interface {}
+          Type: 154 GoEmptyInterfaceType interface {}
         - Name: Version
           Offset: 176
           Type: 7 BaseType int
         - Name: SerialNumber
           Offset: 184
-          Type: 157 PointerType *math/big.Int
+          Type: 205 PointerType *math/big.Int
         - Name: Issuer
           Offset: 192
-          Type: 159 StructureType crypto/x509/pkix.Name
+          Type: 207 StructureType crypto/x509/pkix.Name
         - Name: Subject
           Offset: 440
-          Type: 159 StructureType crypto/x509/pkix.Name
+          Type: 207 StructureType crypto/x509/pkix.Name
         - Name: NotBefore
           Offset: 688
-          Type: 163 StructureType time.Time
+          Type: 211 StructureType time.Time
         - Name: NotAfter
           Offset: 712
-          Type: 163 StructureType time.Time
+          Type: 211 StructureType time.Time
         - Name: KeyUsage
           Offset: 736
-          Type: 166 BaseType crypto/x509.KeyUsage
+          Type: 214 BaseType crypto/x509.KeyUsage
         - Name: Extensions
           Offset: 744
-          Type: 167 GoSliceHeaderType []crypto/x509/pkix.Extension
+          Type: 215 GoSliceHeaderType []crypto/x509/pkix.Extension
         - Name: ExtraExtensions
           Offset: 768
-          Type: 167 GoSliceHeaderType []crypto/x509/pkix.Extension
+          Type: 215 GoSliceHeaderType []crypto/x509/pkix.Extension
         - Name: UnhandledCriticalExtensions
           Offset: 792
-          Type: 170 GoSliceHeaderType []encoding/asn1.ObjectIdentifier
+          Type: 218 GoSliceHeaderType []encoding/asn1.ObjectIdentifier
         - Name: ExtKeyUsage
           Offset: 816
-          Type: 173 GoSliceHeaderType []crypto/x509.ExtKeyUsage
+          Type: 221 GoSliceHeaderType []crypto/x509.ExtKeyUsage
         - Name: UnknownExtKeyUsage
           Offset: 840
-          Type: 170 GoSliceHeaderType []encoding/asn1.ObjectIdentifier
+          Type: 218 GoSliceHeaderType []encoding/asn1.ObjectIdentifier
         - Name: BasicConstraintsValid
           Offset: 864
           Type: 4 BaseType bool
@@ -1562,10 +1562,10 @@ Types:
           Type: 54 GoSliceHeaderType []string
         - Name: IPAddresses
           Offset: 1032
-          Type: 176 GoSliceHeaderType []net.IP
+          Type: 224 GoSliceHeaderType []net.IP
         - Name: URIs
           Offset: 1056
-          Type: 179 GoSliceHeaderType []*net/url.URL
+          Type: 227 GoSliceHeaderType []*net/url.URL
         - Name: PermittedDNSDomainsCritical
           Offset: 1080
           Type: 4 BaseType bool
@@ -1577,10 +1577,10 @@ Types:
           Type: 54 GoSliceHeaderType []string
         - Name: PermittedIPRanges
           Offset: 1136
-          Type: 181 GoSliceHeaderType []*net.IPNet
+          Type: 229 GoSliceHeaderType []*net.IPNet
         - Name: ExcludedIPRanges
           Offset: 1160
-          Type: 181 GoSliceHeaderType []*net.IPNet
+          Type: 229 GoSliceHeaderType []*net.IPNet
         - Name: PermittedEmailAddresses
           Offset: 1184
           Type: 54 GoSliceHeaderType []string
@@ -1598,10 +1598,10 @@ Types:
           Type: 54 GoSliceHeaderType []string
         - Name: PolicyIdentifiers
           Offset: 1304
-          Type: 170 GoSliceHeaderType []encoding/asn1.ObjectIdentifier
+          Type: 218 GoSliceHeaderType []encoding/asn1.ObjectIdentifier
         - Name: Policies
           Offset: 1328
-          Type: 184 GoSliceHeaderType []crypto/x509.OID
+          Type: 232 GoSliceHeaderType []crypto/x509.OID
         - Name: InhibitAnyPolicy
           Offset: 1352
           Type: 7 BaseType int
@@ -1622,21 +1622,21 @@ Types:
           Type: 4 BaseType bool
         - Name: PolicyMappings
           Offset: 1400
-          Type: 187 GoSliceHeaderType []crypto/x509.PolicyMapping
+          Type: 235 GoSliceHeaderType []crypto/x509.PolicyMapping
     - __kind: BaseType
-      ID: 175
+      ID: 223
       Name: crypto/x509.ExtKeyUsage
       ByteSize: 8
       GoRuntimeType: 594272
       GoKind: 2
     - __kind: BaseType
-      ID: 166
+      ID: 214
       Name: crypto/x509.KeyUsage
       ByteSize: 8
       GoRuntimeType: 594208
       GoKind: 2
     - __kind: StructureType
-      ID: 186
+      ID: 234
       Name: crypto/x509.OID
       ByteSize: 24
       GoRuntimeType: 1.989152e+06
@@ -1646,7 +1646,7 @@ Types:
           Offset: 0
           Type: 96 GoSliceHeaderType []uint8
     - __kind: StructureType
-      ID: 189
+      ID: 237
       Name: crypto/x509.PolicyMapping
       ByteSize: 48
       GoRuntimeType: 1.5144e+06
@@ -1654,24 +1654,24 @@ Types:
       RawFields:
         - Name: IssuerDomainPolicy
           Offset: 0
-          Type: 186 StructureType crypto/x509.OID
+          Type: 234 StructureType crypto/x509.OID
         - Name: SubjectDomainPolicy
           Offset: 24
-          Type: 186 StructureType crypto/x509.OID
+          Type: 234 StructureType crypto/x509.OID
     - __kind: BaseType
-      ID: 155
+      ID: 204
       Name: crypto/x509.PublicKeyAlgorithm
       ByteSize: 8
       GoRuntimeType: 845664
       GoKind: 2
     - __kind: BaseType
-      ID: 154
+      ID: 203
       Name: crypto/x509.SignatureAlgorithm
       ByteSize: 8
       GoRuntimeType: 1.134112e+06
       GoKind: 2
     - __kind: StructureType
-      ID: 162
+      ID: 210
       Name: crypto/x509/pkix.AttributeTypeAndValue
       ByteSize: 40
       GoRuntimeType: 1.52688e+06
@@ -1679,12 +1679,12 @@ Types:
       RawFields:
         - Name: Type
           Offset: 0
-          Type: 172 GoSliceHeaderType encoding/asn1.ObjectIdentifier
+          Type: 220 GoSliceHeaderType encoding/asn1.ObjectIdentifier
         - Name: Value
           Offset: 24
-          Type: 156 GoEmptyInterfaceType interface {}
+          Type: 154 GoEmptyInterfaceType interface {}
     - __kind: StructureType
-      ID: 169
+      ID: 217
       Name: crypto/x509/pkix.Extension
       ByteSize: 56
       GoRuntimeType: 1.678176e+06
@@ -1692,7 +1692,7 @@ Types:
       RawFields:
         - Name: Id
           Offset: 0
-          Type: 172 GoSliceHeaderType encoding/asn1.ObjectIdentifier
+          Type: 220 GoSliceHeaderType encoding/asn1.ObjectIdentifier
         - Name: Critical
           Offset: 24
           Type: 4 BaseType bool
@@ -1700,7 +1700,7 @@ Types:
           Offset: 32
           Type: 96 GoSliceHeaderType []uint8
     - __kind: StructureType
-      ID: 159
+      ID: 207
       Name: crypto/x509/pkix.Name
       ByteSize: 248
       GoRuntimeType: 2.240928e+06
@@ -1735,12 +1735,12 @@ Types:
           Type: 9 GoStringHeaderType string
         - Name: Names
           Offset: 200
-          Type: 160 GoSliceHeaderType []crypto/x509/pkix.AttributeTypeAndValue
+          Type: 208 GoSliceHeaderType []crypto/x509/pkix.AttributeTypeAndValue
         - Name: ExtraNames
           Offset: 224
-          Type: 160 GoSliceHeaderType []crypto/x509/pkix.AttributeTypeAndValue
+          Type: 208 GoSliceHeaderType []crypto/x509/pkix.AttributeTypeAndValue
     - __kind: GoSliceHeaderType
-      ID: 172
+      ID: 220
       Name: encoding/asn1.ObjectIdentifier
       ByteSize: 24
       GoRuntimeType: 1.074656e+06
@@ -1755,9 +1755,9 @@ Types:
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 267 GoSliceDataType encoding/asn1.ObjectIdentifier.array
+      Data: 266 GoSliceDataType encoding/asn1.ObjectIdentifier.array
     - __kind: GoSliceDataType
-      ID: 267
+      ID: 266
       Name: encoding/asn1.ObjectIdentifier.array
       ByteSize: 2048
       Element: 7 BaseType int
@@ -1799,7 +1799,7 @@ Types:
       GoRuntimeType: 701088
       GoKind: 19
     - __kind: GoSubroutineType
-      ID: 114
+      ID: 116
       Name: func(string, []uint8, int) ([]uint8, error)
       ByteSize: 8
       GoRuntimeType: 1.020064e+06
@@ -1898,7 +1898,7 @@ Types:
           Type: 4 BaseType bool
         - Name: trace
           Offset: 8
-          Type: 128 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.trace
+          Type: 130 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.trace
         - Name: span
           Offset: 16
           Type: 39 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span
@@ -1913,7 +1913,7 @@ Types:
           Type: 4 BaseType bool
         - Name: traceID
           Offset: 49
-          Type: 130 ArrayType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.traceID
+          Type: 132 ArrayType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.traceID
         - Name: spanID
           Offset: 72
           Type: 8 BaseType uint64
@@ -1968,7 +1968,7 @@ Types:
       GoKind: 21
       HeaderType: 79 GoSwissMapHeaderType map<string,interface {}>
     - __kind: BaseType
-      ID: 148
+      ID: 175
       Name: github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.samplingDecision
       ByteSize: 4
       GoRuntimeType: 589984
@@ -1988,12 +1988,12 @@ Types:
           Type: 8 BaseType uint64
         - Name: Attributes
           Offset: 24
-          Type: 122 GoMapType map[string]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
+          Type: 124 GoMapType map[string]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
         - Name: RawAttributes
           Offset: 32
-          Type: 127 GoMapType map[string]interface {}
+          Type: 129 GoMapType map[string]interface {}
     - __kind: StructureType
-      ID: 222
+      ID: 241
       Name: github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttribute
       ByteSize: 24
       GoRuntimeType: 1.210656e+06
@@ -2001,9 +2001,9 @@ Types:
       RawFields:
         - Name: Values
           Offset: 0
-          Type: 224 GoSliceHeaderType []*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttributeValue
+          Type: 257 GoSliceHeaderType []*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttributeValue
     - __kind: StructureType
-      ID: 227
+      ID: 283
       Name: github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttributeValue
       ByteSize: 48
       GoRuntimeType: 1.868992e+06
@@ -2011,7 +2011,7 @@ Types:
       RawFields:
         - Name: Type
           Offset: 0
-          Type: 228 BaseType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttributeValueType
+          Type: 292 BaseType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttributeValueType
         - Name: StringValue
           Offset: 8
           Type: 9 GoStringHeaderType string
@@ -2025,13 +2025,13 @@ Types:
           Offset: 40
           Type: 18 BaseType float64
     - __kind: BaseType
-      ID: 228
+      ID: 292
       Name: github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttributeValueType
       ByteSize: 4
       GoRuntimeType: 1.001824e+06
       GoKind: 5
     - __kind: StructureType
-      ID: 217
+      ID: 200
       Name: github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
       ByteSize: 56
       GoRuntimeType: 1.946656e+06
@@ -2039,7 +2039,7 @@ Types:
       RawFields:
         - Name: Type
           Offset: 0
-          Type: 220 BaseType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttributeType
+          Type: 239 BaseType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttributeType
         - Name: StringValue
           Offset: 8
           Type: 9 GoStringHeaderType string
@@ -2054,15 +2054,15 @@ Types:
           Type: 18 BaseType float64
         - Name: ArrayValue
           Offset: 48
-          Type: 221 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttribute
+          Type: 240 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttribute
     - __kind: BaseType
-      ID: 220
+      ID: 239
       Name: github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttributeType
       ByteSize: 4
       GoRuntimeType: 1.001728e+06
       GoKind: 5
     - __kind: StructureType
-      ID: 129
+      ID: 131
       Name: github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.trace
       ByteSize: 104
       GoRuntimeType: 2.14816e+06
@@ -2073,7 +2073,7 @@ Types:
           Type: 71 StructureType sync.RWMutex
         - Name: spans
           Offset: 24
-          Type: 146 GoSliceHeaderType []*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span
+          Type: 173 GoSliceHeaderType []*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span
         - Name: tags
           Offset: 48
           Type: 66 GoMapType map[string]string
@@ -2094,12 +2094,12 @@ Types:
           Type: 4 BaseType bool
         - Name: samplingDecision
           Offset: 92
-          Type: 148 BaseType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.samplingDecision
+          Type: 175 BaseType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.samplingDecision
         - Name: root
           Offset: 96
           Type: 39 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span
     - __kind: ArrayType
-      ID: 130
+      ID: 132
       Name: github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.traceID
       ByteSize: 16
       GoRuntimeType: 914336
@@ -2108,89 +2108,89 @@ Types:
       HasCount: true
       Element: 3 BaseType uint8
     - __kind: GoSwissMapGroupsType
-      ID: 196
+      ID: 194
       Name: groupReference<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 197 PointerType *noalg.map.group[string]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
+          Type: 195 PointerType *noalg.map.group[string]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
         - Name: lengthMask
           Offset: 8
           Type: 8 BaseType uint64
-      GroupType: 198 StructureType noalg.map.group[string]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
-      GroupSliceType: 258 GoSliceDataType []noalg.map.group[string]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute.array
+      GroupType: 196 StructureType noalg.map.group[string]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
+      GroupSliceType: 202 GoSliceDataType []noalg.map.group[string]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute.array
     - __kind: GoSwissMapGroupsType
-      ID: 151
+      ID: 176
       Name: groupReference<string,[]*mime/multipart.FileHeader>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 152 PointerType *noalg.map.group[string][]*mime/multipart.FileHeader
+          Type: 177 PointerType *noalg.map.group[string][]*mime/multipart.FileHeader
         - Name: lengthMask
           Offset: 8
           Type: 8 BaseType uint64
-      GroupType: 153 StructureType noalg.map.group[string][]*mime/multipart.FileHeader
-      GroupSliceType: 248 GoSliceDataType []noalg.map.group[string][]*mime/multipart.FileHeader.array
+      GroupType: 178 StructureType noalg.map.group[string][]*mime/multipart.FileHeader
+      GroupSliceType: 185 GoSliceDataType []noalg.map.group[string][]*mime/multipart.FileHeader.array
     - __kind: GoSwissMapGroupsType
-      ID: 131
+      ID: 133
       Name: groupReference<string,[]string>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 132 PointerType *noalg.map.group[string][]string
+          Type: 134 PointerType *noalg.map.group[string][]string
         - Name: lengthMask
           Offset: 8
           Type: 8 BaseType uint64
-      GroupType: 133 StructureType noalg.map.group[string][]string
-      GroupSliceType: 232 GoSliceDataType []noalg.map.group[string][]string.array
+      GroupType: 135 StructureType noalg.map.group[string][]string
+      GroupSliceType: 139 GoSliceDataType []noalg.map.group[string][]string.array
     - __kind: GoSwissMapGroupsType
-      ID: 142
+      ID: 157
       Name: groupReference<string,float64>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 143 PointerType *noalg.map.group[string]float64
+          Type: 158 PointerType *noalg.map.group[string]float64
         - Name: lengthMask
           Offset: 8
           Type: 8 BaseType uint64
-      GroupType: 144 StructureType noalg.map.group[string]float64
-      GroupSliceType: 240 GoSliceDataType []noalg.map.group[string]float64.array
+      GroupType: 159 StructureType noalg.map.group[string]float64
+      GroupSliceType: 163 GoSliceDataType []noalg.map.group[string]float64.array
     - __kind: GoSwissMapGroupsType
-      ID: 139
+      ID: 149
       Name: groupReference<string,interface {}>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 140 PointerType *noalg.map.group[string]interface {}
+          Type: 150 PointerType *noalg.map.group[string]interface {}
         - Name: lengthMask
           Offset: 8
           Type: 8 BaseType uint64
-      GroupType: 141 StructureType noalg.map.group[string]interface {}
-      GroupSliceType: 238 GoSliceDataType []noalg.map.group[string]interface {}.array
+      GroupType: 151 StructureType noalg.map.group[string]interface {}
+      GroupSliceType: 156 GoSliceDataType []noalg.map.group[string]interface {}.array
     - __kind: GoSwissMapGroupsType
-      ID: 136
+      ID: 142
       Name: groupReference<string,string>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 137 PointerType *noalg.map.group[string]string
+          Type: 143 PointerType *noalg.map.group[string]string
         - Name: lengthMask
           Offset: 8
           Type: 8 BaseType uint64
-      GroupType: 138 StructureType noalg.map.group[string]string
-      GroupSliceType: 236 GoSliceDataType []noalg.map.group[string]string.array
+      GroupType: 144 StructureType noalg.map.group[string]string
+      GroupSliceType: 148 GoSliceDataType []noalg.map.group[string]string.array
     - __kind: BaseType
       ID: 7
       Name: int
@@ -2222,7 +2222,7 @@ Types:
       GoRuntimeType: 590240
       GoKind: 3
     - __kind: GoEmptyInterfaceType
-      ID: 156
+      ID: 154
       Name: interface {}
       ByteSize: 16
       GoRuntimeType: 863072
@@ -2261,7 +2261,7 @@ Types:
           Offset: 8
           Type: 15 VoidPointerType unsafe.Pointer
     - __kind: GoSwissMapHeaderType
-      ID: 124
+      ID: 126
       Name: map<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
       ByteSize: 48
       GoKind: 25
@@ -2274,7 +2274,7 @@ Types:
           Type: 1 BaseType uintptr
         - Name: dirPtr
           Offset: 16
-          Type: 125 PointerType **table<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
+          Type: 127 PointerType **table<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
         - Name: dirLen
           Offset: 24
           Type: 7 BaseType int
@@ -2290,10 +2290,10 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 8 BaseType uint64
-      TablePtrSliceType: 257 GoSliceDataType []*table<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>.array
-      GroupType: 198 StructureType noalg.map.group[string]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
+      TablePtrSliceType: 201 GoSliceDataType []*table<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>.array
+      GroupType: 196 StructureType noalg.map.group[string]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
     - __kind: GoSwissMapHeaderType
-      ID: 104
+      ID: 106
       Name: map<string,[]*mime/multipart.FileHeader>
       ByteSize: 48
       GoKind: 25
@@ -2306,7 +2306,7 @@ Types:
           Type: 1 BaseType uintptr
         - Name: dirPtr
           Offset: 16
-          Type: 105 PointerType **table<string,[]*mime/multipart.FileHeader>
+          Type: 107 PointerType **table<string,[]*mime/multipart.FileHeader>
         - Name: dirLen
           Offset: 24
           Type: 7 BaseType int
@@ -2322,8 +2322,8 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 8 BaseType uint64
-      TablePtrSliceType: 247 GoSliceDataType []*table<string,[]*mime/multipart.FileHeader>.array
-      GroupType: 153 StructureType noalg.map.group[string][]*mime/multipart.FileHeader
+      TablePtrSliceType: 184 GoSliceDataType []*table<string,[]*mime/multipart.FileHeader>.array
+      GroupType: 178 StructureType noalg.map.group[string][]*mime/multipart.FileHeader
     - __kind: GoSwissMapHeaderType
       ID: 49
       Name: map<string,[]string>
@@ -2354,8 +2354,8 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 8 BaseType uint64
-      TablePtrSliceType: 231 GoSliceDataType []*table<string,[]string>.array
-      GroupType: 133 StructureType noalg.map.group[string][]string
+      TablePtrSliceType: 138 GoSliceDataType []*table<string,[]string>.array
+      GroupType: 135 StructureType noalg.map.group[string][]string
     - __kind: GoSwissMapHeaderType
       ID: 84
       Name: map<string,float64>
@@ -2386,8 +2386,8 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 8 BaseType uint64
-      TablePtrSliceType: 239 GoSliceDataType []*table<string,float64>.array
-      GroupType: 144 StructureType noalg.map.group[string]float64
+      TablePtrSliceType: 162 GoSliceDataType []*table<string,float64>.array
+      GroupType: 159 StructureType noalg.map.group[string]float64
     - __kind: GoSwissMapHeaderType
       ID: 79
       Name: map<string,interface {}>
@@ -2418,8 +2418,8 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 8 BaseType uint64
-      TablePtrSliceType: 237 GoSliceDataType []*table<string,interface {}>.array
-      GroupType: 141 StructureType noalg.map.group[string]interface {}
+      TablePtrSliceType: 155 GoSliceDataType []*table<string,interface {}>.array
+      GroupType: 151 StructureType noalg.map.group[string]interface {}
     - __kind: GoSwissMapHeaderType
       ID: 68
       Name: map<string,string>
@@ -2450,24 +2450,24 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 8 BaseType uint64
-      TablePtrSliceType: 235 GoSliceDataType []*table<string,string>.array
-      GroupType: 138 StructureType noalg.map.group[string]string
+      TablePtrSliceType: 147 GoSliceDataType []*table<string,string>.array
+      GroupType: 144 StructureType noalg.map.group[string]string
     - __kind: GoMapType
-      ID: 122
+      ID: 124
       Name: map[string]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
       ByteSize: 8
       GoRuntimeType: 1.153056e+06
       GoKind: 21
-      HeaderType: 124 GoSwissMapHeaderType map<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
+      HeaderType: 126 GoSwissMapHeaderType map<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
     - __kind: GoMapType
-      ID: 102
+      ID: 104
       Name: map[string][]*mime/multipart.FileHeader
       ByteSize: 8
       GoRuntimeType: 1.152288e+06
       GoKind: 21
-      HeaderType: 104 GoSwissMapHeaderType map<string,[]*mime/multipart.FileHeader>
+      HeaderType: 106 GoSwissMapHeaderType map<string,[]*mime/multipart.FileHeader>
     - __kind: GoMapType
-      ID: 101
+      ID: 103
       Name: map[string][]string
       ByteSize: 8
       GoRuntimeType: 1.14768e+06
@@ -2481,7 +2481,7 @@ Types:
       GoKind: 21
       HeaderType: 84 GoSwissMapHeaderType map<string,float64>
     - __kind: GoMapType
-      ID: 127
+      ID: 129
       Name: map[string]interface {}
       ByteSize: 8
       GoRuntimeType: 1.146272e+06
@@ -2495,7 +2495,7 @@ Types:
       GoKind: 21
       HeaderType: 68 GoSwissMapHeaderType map<string,string>
     - __kind: StructureType
-      ID: 158
+      ID: 206
       Name: math/big.Int
       ByteSize: 32
       GoRuntimeType: 1.51744e+06
@@ -2506,15 +2506,15 @@ Types:
           Type: 4 BaseType bool
         - Name: abs
           Offset: 8
-          Type: 204 GoSliceHeaderType math/big.nat
+          Type: 246 GoSliceHeaderType math/big.nat
     - __kind: BaseType
-      ID: 206
+      ID: 248
       Name: math/big.Word
       ByteSize: 8
       GoRuntimeType: 594464
       GoKind: 7
     - __kind: GoSliceHeaderType
-      ID: 204
+      ID: 246
       Name: math/big.nat
       ByteSize: 24
       GoRuntimeType: 2.420864e+06
@@ -2522,21 +2522,21 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 205 PointerType *math/big.Word
+          Type: 247 PointerType *math/big.Word
         - Name: len
           Offset: 8
           Type: 7 BaseType int
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 285 GoSliceDataType math/big.nat.array
+      Data: 284 GoSliceDataType math/big.nat.array
     - __kind: GoSliceDataType
-      ID: 285
+      ID: 284
       Name: math/big.nat.array
       ByteSize: 2048
-      Element: 206 BaseType math/big.Word
+      Element: 248 BaseType math/big.Word
     - __kind: StructureType
-      ID: 218
+      ID: 238
       Name: mime/multipart.FileHeader
       ByteSize: 88
       GoRuntimeType: 2.009312e+06
@@ -2547,7 +2547,7 @@ Types:
           Type: 9 GoStringHeaderType string
         - Name: Header
           Offset: 16
-          Type: 223 GoMapType net/textproto.MIMEHeader
+          Type: 256 GoMapType net/textproto.MIMEHeader
         - Name: Size
           Offset: 24
           Type: 13 BaseType int64
@@ -2572,12 +2572,12 @@ Types:
       RawFields:
         - Name: Value
           Offset: 0
-          Type: 101 GoMapType map[string][]string
+          Type: 103 GoMapType map[string][]string
         - Name: File
           Offset: 8
-          Type: 102 GoMapType map[string][]*mime/multipart.FileHeader
+          Type: 104 GoMapType map[string][]*mime/multipart.FileHeader
     - __kind: GoSliceHeaderType
-      ID: 178
+      ID: 226
       Name: net.IP
       ByteSize: 24
       GoRuntimeType: 2.170304e+06
@@ -2592,14 +2592,14 @@ Types:
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 273 GoSliceDataType net.IP.array
+      Data: 272 GoSliceDataType net.IP.array
     - __kind: GoSliceDataType
-      ID: 273
+      ID: 272
       Name: net.IP.array
       ByteSize: 2048
       Element: 3 BaseType uint8
     - __kind: GoSliceHeaderType
-      ID: 219
+      ID: 282
       Name: net.IPMask
       ByteSize: 24
       GoRuntimeType: 1.037408e+06
@@ -2614,14 +2614,14 @@ Types:
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 291 GoSliceDataType net.IPMask.array
+      Data: 293 GoSliceDataType net.IPMask.array
     - __kind: GoSliceDataType
-      ID: 291
+      ID: 293
       Name: net.IPMask.array
       ByteSize: 2048
       Element: 3 BaseType uint8
     - __kind: StructureType
-      ID: 213
+      ID: 255
       Name: net.IPNet
       ByteSize: 48
       GoRuntimeType: 1.48176e+06
@@ -2629,10 +2629,10 @@ Types:
       RawFields:
         - Name: IP
           Offset: 0
-          Type: 178 GoSliceHeaderType net.IP
+          Type: 226 GoSliceHeaderType net.IP
         - Name: Mask
           Offset: 24
-          Type: 219 GoSliceHeaderType net.IPMask
+          Type: 282 GoSliceHeaderType net.IPMask
     - __kind: GoMapType
       ID: 47
       Name: net/http.Header
@@ -2805,12 +2805,12 @@ Types:
           Type: 9 GoStringHeaderType string
         - Name: segments
           Offset: 48
-          Type: 116 GoSliceHeaderType []net/http.segment
+          Type: 118 GoSliceHeaderType []net/http.segment
         - Name: loc
           Offset: 72
           Type: 9 GoStringHeaderType string
     - __kind: StructureType
-      ID: 118
+      ID: 120
       Name: net/http.segment
       ByteSize: 24
       GoRuntimeType: 1.637088e+06
@@ -2826,7 +2826,7 @@ Types:
           Offset: 17
           Type: 4 BaseType bool
     - __kind: GoMapType
-      ID: 223
+      ID: 256
       Name: net/textproto.MIMEHeader
       ByteSize: 8
       GoRuntimeType: 1.854368e+06
@@ -2847,7 +2847,7 @@ Types:
           Type: 9 GoStringHeaderType string
         - Name: User
           Offset: 32
-          Type: 98 PointerType *net/url.Userinfo
+          Type: 100 PointerType *net/url.Userinfo
         - Name: Host
           Offset: 40
           Type: 9 GoStringHeaderType string
@@ -2873,7 +2873,7 @@ Types:
           Offset: 128
           Type: 9 GoStringHeaderType string
     - __kind: StructureType
-      ID: 99
+      ID: 101
       Name: net/url.Userinfo
       ByteSize: 40
       GoRuntimeType: 1.653024e+06
@@ -2896,61 +2896,61 @@ Types:
       GoKind: 21
       HeaderType: 49 GoSwissMapHeaderType map<string,[]string>
     - __kind: ArrayType
-      ID: 214
+      ID: 197
       Name: noalg.[8]struct { key string; elem *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute }
       ByteSize: 192
       GoRuntimeType: 711712
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 215 StructureType noalg.struct { key string; elem *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute }
+      Element: 198 StructureType noalg.struct { key string; elem *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute }
     - __kind: ArrayType
-      ID: 199
+      ID: 179
       Name: noalg.[8]struct { key string; elem []*mime/multipart.FileHeader }
       ByteSize: 320
       GoRuntimeType: 707136
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 200 StructureType noalg.struct { key string; elem []*mime/multipart.FileHeader }
+      Element: 180 StructureType noalg.struct { key string; elem []*mime/multipart.FileHeader }
     - __kind: ArrayType
-      ID: 149
+      ID: 136
       Name: noalg.[8]struct { key string; elem []string }
       ByteSize: 320
       GoRuntimeType: 697120
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 150 StructureType noalg.struct { key string; elem []string }
+      Element: 137 StructureType noalg.struct { key string; elem []string }
     - __kind: ArrayType
-      ID: 194
+      ID: 160
       Name: noalg.[8]struct { key string; elem float64 }
       ByteSize: 192
       GoRuntimeType: 711616
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 195 StructureType noalg.struct { key string; elem float64 }
+      Element: 161 StructureType noalg.struct { key string; elem float64 }
     - __kind: ArrayType
-      ID: 192
+      ID: 152
       Name: noalg.[8]struct { key string; elem interface {} }
       ByteSize: 256
       GoRuntimeType: 688576
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 193 StructureType noalg.struct { key string; elem interface {} }
+      Element: 153 StructureType noalg.struct { key string; elem interface {} }
     - __kind: ArrayType
-      ID: 190
+      ID: 145
       Name: noalg.[8]struct { key string; elem string }
       ByteSize: 256
       GoRuntimeType: 701280
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 191 StructureType noalg.struct { key string; elem string }
+      Element: 146 StructureType noalg.struct { key string; elem string }
     - __kind: StructureType
-      ID: 198
+      ID: 196
       Name: noalg.map.group[string]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
       ByteSize: 200
       GoRuntimeType: 1.3272e+06
@@ -2961,9 +2961,9 @@ Types:
           Type: 8 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 214 ArrayType noalg.[8]struct { key string; elem *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute }
+          Type: 197 ArrayType noalg.[8]struct { key string; elem *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute }
     - __kind: StructureType
-      ID: 153
+      ID: 178
       Name: noalg.map.group[string][]*mime/multipart.FileHeader
       ByteSize: 328
       GoRuntimeType: 1.320928e+06
@@ -2974,9 +2974,9 @@ Types:
           Type: 8 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 199 ArrayType noalg.[8]struct { key string; elem []*mime/multipart.FileHeader }
+          Type: 179 ArrayType noalg.[8]struct { key string; elem []*mime/multipart.FileHeader }
     - __kind: StructureType
-      ID: 133
+      ID: 135
       Name: noalg.map.group[string][]string
       ByteSize: 328
       GoRuntimeType: 1.311456e+06
@@ -2987,9 +2987,9 @@ Types:
           Type: 8 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 149 ArrayType noalg.[8]struct { key string; elem []string }
+          Type: 136 ArrayType noalg.[8]struct { key string; elem []string }
     - __kind: StructureType
-      ID: 144
+      ID: 159
       Name: noalg.map.group[string]float64
       ByteSize: 200
       GoRuntimeType: 1.326944e+06
@@ -3000,9 +3000,9 @@ Types:
           Type: 8 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 194 ArrayType noalg.[8]struct { key string; elem float64 }
+          Type: 160 ArrayType noalg.[8]struct { key string; elem float64 }
     - __kind: StructureType
-      ID: 141
+      ID: 151
       Name: noalg.map.group[string]interface {}
       ByteSize: 264
       GoRuntimeType: 1.308896e+06
@@ -3013,9 +3013,9 @@ Types:
           Type: 8 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 192 ArrayType noalg.[8]struct { key string; elem interface {} }
+          Type: 152 ArrayType noalg.[8]struct { key string; elem interface {} }
     - __kind: StructureType
-      ID: 138
+      ID: 144
       Name: noalg.map.group[string]string
       ByteSize: 264
       GoRuntimeType: 1.31376e+06
@@ -3026,9 +3026,9 @@ Types:
           Type: 8 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 190 ArrayType noalg.[8]struct { key string; elem string }
+          Type: 145 ArrayType noalg.[8]struct { key string; elem string }
     - __kind: StructureType
-      ID: 215
+      ID: 198
       Name: noalg.struct { key string; elem *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute }
       ByteSize: 24
       GoRuntimeType: 1.327072e+06
@@ -3039,9 +3039,9 @@ Types:
           Type: 9 GoStringHeaderType string
         - Name: elem
           Offset: 16
-          Type: 216 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
+          Type: 199 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
     - __kind: StructureType
-      ID: 200
+      ID: 180
       Name: noalg.struct { key string; elem []*mime/multipart.FileHeader }
       ByteSize: 40
       GoRuntimeType: 1.3208e+06
@@ -3052,9 +3052,9 @@ Types:
           Type: 9 GoStringHeaderType string
         - Name: elem
           Offset: 16
-          Type: 201 GoSliceHeaderType []*mime/multipart.FileHeader
+          Type: 181 GoSliceHeaderType []*mime/multipart.FileHeader
     - __kind: StructureType
-      ID: 150
+      ID: 137
       Name: noalg.struct { key string; elem []string }
       ByteSize: 40
       GoRuntimeType: 1.311328e+06
@@ -3067,7 +3067,7 @@ Types:
           Offset: 16
           Type: 54 GoSliceHeaderType []string
     - __kind: StructureType
-      ID: 195
+      ID: 161
       Name: noalg.struct { key string; elem float64 }
       ByteSize: 24
       GoRuntimeType: 1.326816e+06
@@ -3080,7 +3080,7 @@ Types:
           Offset: 16
           Type: 18 BaseType float64
     - __kind: StructureType
-      ID: 193
+      ID: 153
       Name: noalg.struct { key string; elem interface {} }
       ByteSize: 32
       GoRuntimeType: 1.308768e+06
@@ -3091,9 +3091,9 @@ Types:
           Type: 9 GoStringHeaderType string
         - Name: elem
           Offset: 16
-          Type: 156 GoEmptyInterfaceType interface {}
+          Type: 154 GoEmptyInterfaceType interface {}
     - __kind: StructureType
-      ID: 191
+      ID: 146
       Name: noalg.struct { key string; elem string }
       ByteSize: 32
       GoRuntimeType: 1.313632e+06
@@ -3114,13 +3114,13 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 230 PointerType *string.str
+          Type: 99 PointerType *string.str
         - Name: len
           Offset: 8
           Type: 7 BaseType int
-      Data: 229 GoStringDataType string.str
+      Data: 98 GoStringDataType string.str
     - __kind: GoStringDataType
-      ID: 229
+      ID: 98
       Name: string.str
       ByteSize: 2048
     - __kind: StructureType
@@ -3184,7 +3184,7 @@ Types:
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 145
+      ID: 172
       Name: table<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
       ByteSize: 32
       GoKind: 25
@@ -3206,9 +3206,9 @@ Types:
           Type: 7 BaseType int
         - Name: groups
           Offset: 16
-          Type: 196 GoSwissMapGroupsType groupReference<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
+          Type: 194 GoSwissMapGroupsType groupReference<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
     - __kind: StructureType
-      ID: 134
+      ID: 170
       Name: table<string,[]*mime/multipart.FileHeader>
       ByteSize: 32
       GoKind: 25
@@ -3230,9 +3230,9 @@ Types:
           Type: 7 BaseType int
         - Name: groups
           Offset: 16
-          Type: 151 GoSwissMapGroupsType groupReference<string,[]*mime/multipart.FileHeader>
+          Type: 176 GoSwissMapGroupsType groupReference<string,[]*mime/multipart.FileHeader>
     - __kind: StructureType
-      ID: 100
+      ID: 102
       Name: table<string,[]string>
       ByteSize: 32
       GoKind: 25
@@ -3254,9 +3254,9 @@ Types:
           Type: 7 BaseType int
         - Name: groups
           Offset: 16
-          Type: 131 GoSwissMapGroupsType groupReference<string,[]string>
+          Type: 133 GoSwissMapGroupsType groupReference<string,[]string>
     - __kind: StructureType
-      ID: 121
+      ID: 123
       Name: table<string,float64>
       ByteSize: 32
       GoKind: 25
@@ -3278,9 +3278,9 @@ Types:
           Type: 7 BaseType int
         - Name: groups
           Offset: 16
-          Type: 142 GoSwissMapGroupsType groupReference<string,float64>
+          Type: 157 GoSwissMapGroupsType groupReference<string,float64>
     - __kind: StructureType
-      ID: 120
+      ID: 122
       Name: table<string,interface {}>
       ByteSize: 32
       GoKind: 25
@@ -3302,9 +3302,9 @@ Types:
           Type: 7 BaseType int
         - Name: groups
           Offset: 16
-          Type: 139 GoSwissMapGroupsType groupReference<string,interface {}>
+          Type: 149 GoSwissMapGroupsType groupReference<string,interface {}>
     - __kind: StructureType
-      ID: 119
+      ID: 121
       Name: table<string,string>
       ByteSize: 32
       GoKind: 25
@@ -3326,9 +3326,9 @@ Types:
           Type: 7 BaseType int
         - Name: groups
           Offset: 16
-          Type: 136 GoSwissMapGroupsType groupReference<string,string>
+          Type: 142 GoSwissMapGroupsType groupReference<string,string>
     - __kind: StructureType
-      ID: 165
+      ID: 213
       Name: time.Location
       ByteSize: 104
       GoRuntimeType: 2.00528e+06
@@ -3339,10 +3339,10 @@ Types:
           Type: 9 GoStringHeaderType string
         - Name: zone
           Offset: 16
-          Type: 207 GoSliceHeaderType []time.zone
+          Type: 249 GoSliceHeaderType []time.zone
         - Name: tx
           Offset: 40
-          Type: 210 GoSliceHeaderType []time.zoneTrans
+          Type: 252 GoSliceHeaderType []time.zoneTrans
         - Name: extend
           Offset: 64
           Type: 9 GoStringHeaderType string
@@ -3354,9 +3354,9 @@ Types:
           Type: 13 BaseType int64
         - Name: cacheZone
           Offset: 96
-          Type: 208 PointerType *time.zone
+          Type: 250 PointerType *time.zone
     - __kind: StructureType
-      ID: 163
+      ID: 211
       Name: time.Time
       ByteSize: 24
       GoRuntimeType: 2.42368e+06
@@ -3370,9 +3370,9 @@ Types:
           Type: 13 BaseType int64
         - Name: loc
           Offset: 16
-          Type: 164 PointerType *time.Location
+          Type: 212 PointerType *time.Location
     - __kind: StructureType
-      ID: 209
+      ID: 251
       Name: time.zone
       ByteSize: 32
       GoRuntimeType: 1.64208e+06
@@ -3388,7 +3388,7 @@ Types:
           Offset: 24
           Type: 4 BaseType bool
     - __kind: StructureType
-      ID: 212
+      ID: 254
       Name: time.zoneTrans
       ByteSize: 16
       GoRuntimeType: 1.780992e+06

--- a/pkg/dyninst/irgen/testdata/snapshot/rc_tester.arch=arm64,toolchain=go1.24.3.yaml
+++ b/pkg/dyninst/irgen/testdata/snapshot/rc_tester.arch=arm64,toolchain=go1.24.3.yaml
@@ -33,7 +33,7 @@ Subprograms:
       InlinePCRanges: []
       Variables:
         - Name: w
-          Type: 1 GoInterfaceType net/http.ResponseWriter
+          Type: 36 GoInterfaceType net/http.ResponseWriter
           Locations:
             - Range: 0x8a0c90..0x8a0ce8
               Pieces:
@@ -56,7 +56,7 @@ Subprograms:
           IsParameter: true
           IsReturn: false
         - Name: r
-          Type: 3 PointerType *net/http.Request
+          Type: 37 PointerType *net/http.Request
           Locations:
             - Range: 0x8a0c90..0x8a0cf4
               Pieces: [{Size: 8, Op: {RegNo: 2, Shift: 0}}]
@@ -65,14 +65,14 @@ Subprograms:
           IsParameter: true
           IsReturn: false
         - Name: span
-          Type: 134 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span
+          Type: 157 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span
           Locations:
             - Range: 0x8a0d08..0x8a0d38
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: false
           IsReturn: false
         - Name: '&buf'
-          Type: 205 PointerType *bytes.Buffer
+          Type: 224 PointerType *bytes.Buffer
           Locations:
             - Range: 0x8a0ddc..0x8a0df0
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
@@ -81,7 +81,7 @@ Subprograms:
           IsParameter: false
           IsReturn: false
         - Name: .autotmp_14
-          Type: 208 StructureType context.backgroundCtx
+          Type: 227 StructureType context.backgroundCtx
           Locations:
             - Range: 0x8a0c90..0x8a0ec0
               Pieces: [{Size: 0, Op: {CfaOffset: 0}}]
@@ -93,7 +93,7 @@ Subprograms:
       InlinePCRanges: []
       Variables:
         - Name: path
-          Type: 5 GoStringHeaderType string
+          Type: 9 GoStringHeaderType string
           Locations:
             - Range: 0x8a0f90..0x8a0fb4
               Pieces:
@@ -105,76 +105,76 @@ Subprograms:
           IsReturn: false
 Types:
     - __kind: PointerType
-      ID: 57
+      ID: 81
       Name: '**crypto/x509.Certificate'
       ByteSize: 8
       GoKind: 22
-      Pointee: 58 PointerType *crypto/x509.Certificate
+      Pointee: 82 PointerType *crypto/x509.Certificate
     - __kind: PointerType
-      ID: 200
+      ID: 220
       Name: '**github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span'
       ByteSize: 8
       GoKind: 22
-      Pointee: 134 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span
+      Pointee: 157 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span
     - __kind: PointerType
-      ID: 190
+      ID: 210
       Name: '**github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttributeValue'
       ByteSize: 8
       GoKind: 22
-      Pointee: 191 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttributeValue
+      Pointee: 211 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttributeValue
     - __kind: PointerType
-      ID: 49
+      ID: 73
       Name: '**mime/multipart.FileHeader'
       ByteSize: 8
       GoKind: 22
-      Pointee: 50 PointerType *mime/multipart.FileHeader
+      Pointee: 74 PointerType *mime/multipart.FileHeader
     - __kind: PointerType
-      ID: 98
+      ID: 121
       Name: '**net.IPNet'
       ByteSize: 8
       GoKind: 22
-      Pointee: 99 PointerType *net.IPNet
+      Pointee: 122 PointerType *net.IPNet
     - __kind: PointerType
-      ID: 96
+      ID: 119
       Name: '**net/url.URL'
       ByteSize: 8
-      Pointee: 9 PointerType *net/url.URL
+      Pointee: 39 PointerType *net/url.URL
     - __kind: PointerType
-      ID: 176
+      ID: 196
       Name: '**table<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>'
       ByteSize: 8
-      Pointee: 177 PointerType *table<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
+      Pointee: 197 PointerType *table<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
     - __kind: PointerType
-      ID: 40
+      ID: 64
       Name: '**table<string,[]*mime/multipart.FileHeader>'
       ByteSize: 8
-      Pointee: 41 PointerType *table<string,[]*mime/multipart.FileHeader>
+      Pointee: 65 PointerType *table<string,[]*mime/multipart.FileHeader>
     - __kind: PointerType
-      ID: 19
+      ID: 46
       Name: '**table<string,[]string>'
       ByteSize: 8
-      Pointee: 20 PointerType *table<string,[]string>
+      Pointee: 47 PointerType *table<string,[]string>
     - __kind: PointerType
-      ID: 158
+      ID: 179
       Name: '**table<string,float64>'
       ByteSize: 8
-      Pointee: 159 PointerType *table<string,float64>
+      Pointee: 180 PointerType *table<string,float64>
     - __kind: PointerType
-      ID: 147
+      ID: 168
       Name: '**table<string,interface {}>'
       ByteSize: 8
-      Pointee: 148 PointerType *table<string,interface {}>
+      Pointee: 169 PointerType *table<string,interface {}>
     - __kind: PointerType
-      ID: 126
+      ID: 149
       Name: '**table<string,string>'
       ByteSize: 8
-      Pointee: 127 PointerType *table<string,string>
+      Pointee: 150 PointerType *table<string,string>
     - __kind: PointerType
-      ID: 109
+      ID: 132
       Name: '*[]*crypto/x509.Certificate'
       ByteSize: 8
       GoKind: 22
-      Pointee: 56 GoSliceHeaderType []*crypto/x509.Certificate
+      Pointee: 80 GoSliceHeaderType []*crypto/x509.Certificate
     - __kind: PointerType
       ID: 242
       Name: '*[]*crypto/x509.Certificate.array'
@@ -281,274 +281,274 @@ Types:
       ByteSize: 8
       Pointee: 251 GoSliceDataType []time.zoneTrans.array
     - __kind: PointerType
-      ID: 111
+      ID: 134
       Name: '*[]uint8'
       ByteSize: 8
       GoRuntimeType: 483424
       GoKind: 22
-      Pointee: 53 GoSliceHeaderType []uint8
+      Pointee: 77 GoSliceHeaderType []uint8
     - __kind: PointerType
       ID: 240
       Name: '*[]uint8.array'
       ByteSize: 8
       Pointee: 239 GoSliceDataType []uint8.array
     - __kind: PointerType
-      ID: 211
+      ID: 11
       Name: '*bool'
       ByteSize: 8
       GoRuntimeType: 402656
       GoKind: 22
-      Pointee: 13 BaseType bool
+      Pointee: 4 BaseType bool
     - __kind: PointerType
-      ID: 205
+      ID: 224
       Name: '*bytes.Buffer'
       ByteSize: 8
       GoRuntimeType: 2.316032e+06
       GoKind: 22
-      Pointee: 206 StructureType bytes.Buffer
+      Pointee: 225 StructureType bytes.Buffer
     - __kind: PointerType
-      ID: 54
+      ID: 78
       Name: '*crypto/tls.ConnectionState'
       ByteSize: 8
       GoRuntimeType: 918848
       GoKind: 22
-      Pointee: 55 StructureType crypto/tls.ConnectionState
+      Pointee: 79 StructureType crypto/tls.ConnectionState
     - __kind: PointerType
-      ID: 58
+      ID: 82
       Name: '*crypto/x509.Certificate'
       ByteSize: 8
       GoRuntimeType: 2.081952e+06
       GoKind: 22
-      Pointee: 59 StructureType crypto/x509.Certificate
+      Pointee: 83 StructureType crypto/x509.Certificate
     - __kind: PointerType
-      ID: 90
+      ID: 113
       Name: '*crypto/x509.ExtKeyUsage'
       ByteSize: 8
       GoRuntimeType: 426848
       GoKind: 22
-      Pointee: 91 BaseType crypto/x509.ExtKeyUsage
+      Pointee: 114 BaseType crypto/x509.ExtKeyUsage
     - __kind: PointerType
-      ID: 103
+      ID: 126
       Name: '*crypto/x509.OID'
       ByteSize: 8
       GoRuntimeType: 1.988896e+06
       GoKind: 22
-      Pointee: 104 StructureType crypto/x509.OID
+      Pointee: 127 StructureType crypto/x509.OID
     - __kind: PointerType
-      ID: 106
+      ID: 129
       Name: '*crypto/x509.PolicyMapping'
       ByteSize: 8
       GoRuntimeType: 426912
       GoKind: 22
-      Pointee: 107 StructureType crypto/x509.PolicyMapping
+      Pointee: 130 StructureType crypto/x509.PolicyMapping
     - __kind: PointerType
-      ID: 70
+      ID: 94
       Name: '*crypto/x509/pkix.AttributeTypeAndValue'
       ByteSize: 8
       GoRuntimeType: 443616
       GoKind: 22
-      Pointee: 71 StructureType crypto/x509/pkix.AttributeTypeAndValue
+      Pointee: 95 StructureType crypto/x509/pkix.AttributeTypeAndValue
     - __kind: PointerType
-      ID: 85
+      ID: 108
       Name: '*crypto/x509/pkix.Extension'
       ByteSize: 8
       GoRuntimeType: 443808
       GoKind: 22
-      Pointee: 86 StructureType crypto/x509/pkix.Extension
+      Pointee: 109 StructureType crypto/x509/pkix.Extension
     - __kind: PointerType
-      ID: 88
+      ID: 111
       Name: '*encoding/asn1.ObjectIdentifier'
       ByteSize: 8
       GoRuntimeType: 1.074528e+06
       GoKind: 22
-      Pointee: 72 GoSliceHeaderType encoding/asn1.ObjectIdentifier
+      Pointee: 96 GoSliceHeaderType encoding/asn1.ObjectIdentifier
     - __kind: PointerType
       ID: 248
       Name: '*encoding/asn1.ObjectIdentifier.array'
       ByteSize: 8
       Pointee: 247 GoSliceDataType encoding/asn1.ObjectIdentifier.array
     - __kind: PointerType
-      ID: 226
+      ID: 33
       Name: '*error'
       ByteSize: 8
       GoRuntimeType: 401568
       GoKind: 22
-      Pointee: 212 GoInterfaceType error
+      Pointee: 14 GoInterfaceType error
     - __kind: PointerType
-      ID: 228
+      ID: 35
       Name: '*float32'
       ByteSize: 8
       GoRuntimeType: 402528
       GoKind: 22
-      Pointee: 214 BaseType float32
+      Pointee: 17 BaseType float32
     - __kind: PointerType
-      ID: 201
+      ID: 26
       Name: '*float64'
       ByteSize: 8
       GoRuntimeType: 402592
       GoKind: 22
-      Pointee: 166 BaseType float64
+      Pointee: 18 BaseType float64
     - __kind: PointerType
-      ID: 134
+      ID: 157
       Name: '*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span'
       ByteSize: 8
       GoRuntimeType: 2.326784e+06
       GoKind: 22
-      Pointee: 135 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span
+      Pointee: 158 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span
     - __kind: PointerType
-      ID: 195
+      ID: 215
       Name: '*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanContext'
       ByteSize: 8
       GoRuntimeType: 2.045472e+06
       GoKind: 22
-      Pointee: 196 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanContext
+      Pointee: 216 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanContext
     - __kind: PointerType
-      ID: 168
+      ID: 188
       Name: '*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink'
       ByteSize: 8
       GoRuntimeType: 1.210016e+06
       GoKind: 22
-      Pointee: 169 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink
+      Pointee: 189 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink
     - __kind: PointerType
-      ID: 171
+      ID: 191
       Name: '*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent'
       ByteSize: 8
       GoRuntimeType: 1.210144e+06
       GoKind: 22
-      Pointee: 172 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent
+      Pointee: 192 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent
     - __kind: PointerType
-      ID: 187
+      ID: 207
       Name: '*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttribute'
       ByteSize: 8
       GoRuntimeType: 1.210784e+06
       GoKind: 22
-      Pointee: 188 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttribute
+      Pointee: 208 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttribute
     - __kind: PointerType
-      ID: 191
+      ID: 211
       Name: '*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttributeValue'
       ByteSize: 8
       GoRuntimeType: 1.210528e+06
       GoKind: 22
-      Pointee: 192 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttributeValue
+      Pointee: 212 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttributeValue
     - __kind: PointerType
-      ID: 184
+      ID: 204
       Name: '*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute'
       ByteSize: 8
       GoRuntimeType: 1.210912e+06
       GoKind: 22
-      Pointee: 185 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
+      Pointee: 205 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
     - __kind: PointerType
-      ID: 197
+      ID: 217
       Name: '*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.trace'
       ByteSize: 8
       GoRuntimeType: 2.269504e+06
       GoKind: 22
-      Pointee: 198 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.trace
+      Pointee: 218 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.trace
     - __kind: PointerType
-      ID: 73
+      ID: 28
       Name: '*int'
       ByteSize: 8
       GoRuntimeType: 402208
       GoKind: 22
-      Pointee: 8 BaseType int
+      Pointee: 7 BaseType int
     - __kind: PointerType
-      ID: 224
+      ID: 31
       Name: '*int16'
       ByteSize: 8
       GoRuntimeType: 401824
       GoKind: 22
-      Pointee: 218 BaseType int16
+      Pointee: 23 BaseType int16
     - __kind: PointerType
-      ID: 216
+      ID: 20
       Name: '*int32'
       ByteSize: 8
       GoRuntimeType: 401952
       GoKind: 22
-      Pointee: 140 BaseType int32
+      Pointee: 12 BaseType int32
     - __kind: PointerType
-      ID: 221
+      ID: 27
       Name: '*int64'
       ByteSize: 8
       GoRuntimeType: 402080
       GoKind: 22
-      Pointee: 32 BaseType int64
+      Pointee: 13 BaseType int64
     - __kind: PointerType
-      ID: 225
+      ID: 32
       Name: '*int8'
       ByteSize: 8
       GoRuntimeType: 401696
       GoKind: 22
-      Pointee: 213 BaseType int8
+      Pointee: 16 BaseType int8
     - __kind: PointerType
-      ID: 174
+      ID: 194
       Name: '*map<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>'
       ByteSize: 8
-      Pointee: 175 GoSwissMapHeaderType map<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
+      Pointee: 195 GoSwissMapHeaderType map<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
     - __kind: PointerType
-      ID: 38
+      ID: 62
       Name: '*map<string,[]*mime/multipart.FileHeader>'
       ByteSize: 8
-      Pointee: 39 GoSwissMapHeaderType map<string,[]*mime/multipart.FileHeader>
+      Pointee: 63 GoSwissMapHeaderType map<string,[]*mime/multipart.FileHeader>
     - __kind: PointerType
-      ID: 15
+      ID: 44
       Name: '*map<string,[]string>'
       ByteSize: 8
-      Pointee: 16 GoSwissMapHeaderType map<string,[]string>
+      Pointee: 45 GoSwissMapHeaderType map<string,[]string>
     - __kind: PointerType
-      ID: 156
+      ID: 177
       Name: '*map<string,float64>'
       ByteSize: 8
-      Pointee: 157 GoSwissMapHeaderType map<string,float64>
+      Pointee: 178 GoSwissMapHeaderType map<string,float64>
     - __kind: PointerType
-      ID: 145
+      ID: 166
       Name: '*map<string,interface {}>'
       ByteSize: 8
-      Pointee: 146 GoSwissMapHeaderType map<string,interface {}>
+      Pointee: 167 GoSwissMapHeaderType map<string,interface {}>
     - __kind: PointerType
-      ID: 124
+      ID: 147
       Name: '*map<string,string>'
       ByteSize: 8
-      Pointee: 125 GoSwissMapHeaderType map<string,string>
+      Pointee: 148 GoSwissMapHeaderType map<string,string>
     - __kind: PointerType
-      ID: 63
+      ID: 87
       Name: '*math/big.Int'
       ByteSize: 8
       GoRuntimeType: 2.440096e+06
       GoKind: 22
-      Pointee: 64 StructureType math/big.Int
+      Pointee: 88 StructureType math/big.Int
     - __kind: PointerType
-      ID: 66
+      ID: 90
       Name: '*math/big.Word'
       ByteSize: 8
       GoRuntimeType: 429728
       GoKind: 22
-      Pointee: 67 BaseType math/big.Word
+      Pointee: 91 BaseType math/big.Word
     - __kind: PointerType
       ID: 244
       Name: '*math/big.nat.array'
       ByteSize: 8
       Pointee: 243 GoSliceDataType math/big.nat.array
     - __kind: PointerType
-      ID: 50
+      ID: 74
       Name: '*mime/multipart.FileHeader'
       ByteSize: 8
       GoRuntimeType: 920288
       GoKind: 22
-      Pointee: 51 StructureType mime/multipart.FileHeader
+      Pointee: 75 StructureType mime/multipart.FileHeader
     - __kind: PointerType
-      ID: 34
+      ID: 58
       Name: '*mime/multipart.Form'
       ByteSize: 8
       GoRuntimeType: 920384
       GoKind: 22
-      Pointee: 35 StructureType mime/multipart.Form
+      Pointee: 59 StructureType mime/multipart.Form
     - __kind: PointerType
-      ID: 93
+      ID: 116
       Name: '*net.IP'
       ByteSize: 8
       GoRuntimeType: 2.197536e+06
       GoKind: 22
-      Pointee: 94 GoSliceHeaderType net.IP
+      Pointee: 117 GoSliceHeaderType net.IP
     - __kind: PointerType
       ID: 262
       Name: '*net.IP.array'
@@ -560,191 +560,191 @@ Types:
       ByteSize: 8
       Pointee: 267 GoSliceDataType net.IPMask.array
     - __kind: PointerType
-      ID: 99
+      ID: 122
       Name: '*net.IPNet'
       ByteSize: 8
       GoRuntimeType: 1.203744e+06
       GoKind: 22
-      Pointee: 100 StructureType net.IPNet
+      Pointee: 123 StructureType net.IPNet
     - __kind: PointerType
-      ID: 3
+      ID: 37
       Name: '*net/http.Request'
       ByteSize: 8
       GoRuntimeType: 2.359648e+06
       GoKind: 22
-      Pointee: 4 StructureType net/http.Request
+      Pointee: 38 StructureType net/http.Request
     - __kind: PointerType
-      ID: 115
+      ID: 138
       Name: '*net/http.Response'
       ByteSize: 8
       GoRuntimeType: 1.75088e+06
       GoKind: 22
-      Pointee: 116 StructureType net/http.Response
+      Pointee: 139 StructureType net/http.Response
     - __kind: PointerType
-      ID: 118
+      ID: 141
       Name: '*net/http.pattern'
       ByteSize: 8
       GoRuntimeType: 1.63728e+06
       GoKind: 22
-      Pointee: 119 StructureType net/http.pattern
+      Pointee: 142 StructureType net/http.pattern
     - __kind: PointerType
-      ID: 121
+      ID: 144
       Name: '*net/http.segment'
       ByteSize: 8
       GoRuntimeType: 393440
       GoKind: 22
-      Pointee: 122 StructureType net/http.segment
+      Pointee: 145 StructureType net/http.segment
     - __kind: PointerType
-      ID: 9
+      ID: 39
       Name: '*net/url.URL'
       ByteSize: 8
       GoRuntimeType: 2.159744e+06
       GoKind: 22
-      Pointee: 10 StructureType net/url.URL
+      Pointee: 40 StructureType net/url.URL
     - __kind: PointerType
-      ID: 11
+      ID: 41
       Name: '*net/url.Userinfo'
       ByteSize: 8
       GoRuntimeType: 1.221536e+06
       GoKind: 22
-      Pointee: 12 StructureType net/url.Userinfo
+      Pointee: 42 StructureType net/url.Userinfo
     - __kind: PointerType
-      ID: 180
+      ID: 200
       Name: '*noalg.map.group[string]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute'
       ByteSize: 8
-      Pointee: 181 StructureType noalg.map.group[string]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
+      Pointee: 201 StructureType noalg.map.group[string]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
     - __kind: PointerType
-      ID: 44
+      ID: 68
       Name: '*noalg.map.group[string][]*mime/multipart.FileHeader'
       ByteSize: 8
-      Pointee: 45 StructureType noalg.map.group[string][]*mime/multipart.FileHeader
+      Pointee: 69 StructureType noalg.map.group[string][]*mime/multipart.FileHeader
     - __kind: PointerType
-      ID: 24
+      ID: 50
       Name: '*noalg.map.group[string][]string'
       ByteSize: 8
-      Pointee: 25 StructureType noalg.map.group[string][]string
+      Pointee: 51 StructureType noalg.map.group[string][]string
     - __kind: PointerType
-      ID: 162
+      ID: 183
       Name: '*noalg.map.group[string]float64'
       ByteSize: 8
-      Pointee: 163 StructureType noalg.map.group[string]float64
+      Pointee: 184 StructureType noalg.map.group[string]float64
     - __kind: PointerType
-      ID: 151
+      ID: 172
       Name: '*noalg.map.group[string]interface {}'
       ByteSize: 8
-      Pointee: 152 StructureType noalg.map.group[string]interface {}
+      Pointee: 173 StructureType noalg.map.group[string]interface {}
     - __kind: PointerType
-      ID: 130
+      ID: 153
       Name: '*noalg.map.group[string]string'
       ByteSize: 8
-      Pointee: 131 StructureType noalg.map.group[string]string
+      Pointee: 154 StructureType noalg.map.group[string]string
     - __kind: PointerType
-      ID: 29
+      ID: 22
       Name: '*string'
       ByteSize: 8
       GoRuntimeType: 401632
       GoKind: 22
-      Pointee: 5 GoStringHeaderType string
+      Pointee: 9 GoStringHeaderType string
     - __kind: PointerType
       ID: 230
       Name: '*string.str'
       ByteSize: 8
       Pointee: 229 GoStringDataType string.str
     - __kind: PointerType
-      ID: 177
+      ID: 197
       Name: '*table<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>'
       ByteSize: 8
-      Pointee: 178 StructureType table<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
+      Pointee: 198 StructureType table<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
     - __kind: PointerType
-      ID: 41
+      ID: 65
       Name: '*table<string,[]*mime/multipart.FileHeader>'
       ByteSize: 8
-      Pointee: 42 StructureType table<string,[]*mime/multipart.FileHeader>
+      Pointee: 66 StructureType table<string,[]*mime/multipart.FileHeader>
     - __kind: PointerType
-      ID: 20
+      ID: 47
       Name: '*table<string,[]string>'
       ByteSize: 8
-      Pointee: 21 StructureType table<string,[]string>
+      Pointee: 48 StructureType table<string,[]string>
     - __kind: PointerType
-      ID: 159
+      ID: 180
       Name: '*table<string,float64>'
       ByteSize: 8
-      Pointee: 160 StructureType table<string,float64>
+      Pointee: 181 StructureType table<string,float64>
     - __kind: PointerType
-      ID: 148
+      ID: 169
       Name: '*table<string,interface {}>'
       ByteSize: 8
-      Pointee: 149 StructureType table<string,interface {}>
+      Pointee: 170 StructureType table<string,interface {}>
     - __kind: PointerType
-      ID: 127
+      ID: 150
       Name: '*table<string,string>'
       ByteSize: 8
-      Pointee: 128 StructureType table<string,string>
+      Pointee: 151 StructureType table<string,string>
     - __kind: PointerType
-      ID: 75
+      ID: 98
       Name: '*time.Location'
       ByteSize: 8
       GoRuntimeType: 1.642272e+06
       GoKind: 22
-      Pointee: 76 StructureType time.Location
+      Pointee: 99 StructureType time.Location
     - __kind: PointerType
-      ID: 78
+      ID: 101
       Name: '*time.zone'
       ByteSize: 8
       GoRuntimeType: 396576
       GoKind: 22
-      Pointee: 79 StructureType time.zone
+      Pointee: 102 StructureType time.zone
     - __kind: PointerType
-      ID: 81
+      ID: 104
       Name: '*time.zoneTrans'
       ByteSize: 8
       GoRuntimeType: 396640
       GoKind: 22
-      Pointee: 82 StructureType time.zoneTrans
+      Pointee: 105 StructureType time.zoneTrans
     - __kind: PointerType
-      ID: 227
+      ID: 34
       Name: '*uint'
       ByteSize: 8
       GoRuntimeType: 402272
       GoKind: 22
-      Pointee: 210 BaseType uint
+      Pointee: 10 BaseType uint
     - __kind: PointerType
-      ID: 223
+      ID: 30
       Name: '*uint16'
       ByteSize: 8
       GoRuntimeType: 401888
       GoKind: 22
-      Pointee: 22 BaseType uint16
+      Pointee: 6 BaseType uint16
     - __kind: PointerType
-      ID: 217
+      ID: 21
       Name: '*uint32'
       ByteSize: 8
       GoRuntimeType: 402016
       GoKind: 22
-      Pointee: 141 BaseType uint32
+      Pointee: 2 BaseType uint32
     - __kind: PointerType
-      ID: 222
+      ID: 29
       Name: '*uint64'
       ByteSize: 8
       GoRuntimeType: 402144
       GoKind: 22
-      Pointee: 17 BaseType uint64
+      Pointee: 8 BaseType uint64
     - __kind: PointerType
-      ID: 6
+      ID: 5
       Name: '*uint8'
       ByteSize: 8
       GoRuntimeType: 401760
       GoKind: 22
-      Pointee: 7 BaseType uint8
+      Pointee: 3 BaseType uint8
     - __kind: PointerType
-      ID: 215
+      ID: 19
       Name: '*uintptr'
       ByteSize: 8
       GoRuntimeType: 402336
       GoKind: 22
-      Pointee: 18 BaseType uintptr
+      Pointee: 1 BaseType uintptr
     - __kind: GoChannelType
-      ID: 114
+      ID: 137
       Name: <-chan struct {}
       GoRuntimeType: 603232
       GoKind: 18
@@ -757,7 +757,7 @@ Types:
         - Name: w
           Offset: 1
           Expression:
-            Type: 1 GoInterfaceType net/http.ResponseWriter
+            Type: 36 GoInterfaceType net/http.ResponseWriter
             Operations:
                 - __kind: LocationOp
                   Variable: {subprogram: 1, index: 0, name: w}
@@ -766,7 +766,7 @@ Types:
         - Name: r
           Offset: 17
           Expression:
-            Type: 3 PointerType *net/http.Request
+            Type: 37 PointerType *net/http.Request
             Operations:
                 - __kind: LocationOp
                   Variable: {subprogram: 1, index: 1, name: r}
@@ -781,14 +781,14 @@ Types:
         - Name: path
           Offset: 1
           Expression:
-            Type: 5 GoStringHeaderType string
+            Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
                   Variable: {subprogram: 2, index: 0, name: path}
                   Offset: 0
                   ByteSize: 16
     - __kind: GoSliceHeaderType
-      ID: 56
+      ID: 80
       Name: '[]*crypto/x509.Certificate'
       ByteSize: 24
       GoRuntimeType: 503680
@@ -796,21 +796,21 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 57 PointerType **crypto/x509.Certificate
+          Type: 81 PointerType **crypto/x509.Certificate
         - Name: len
           Offset: 8
-          Type: 8 BaseType int
+          Type: 7 BaseType int
         - Name: cap
           Offset: 16
-          Type: 8 BaseType int
+          Type: 7 BaseType int
       Data: 241 GoSliceDataType []*crypto/x509.Certificate.array
     - __kind: GoSliceDataType
       ID: 241
       Name: '[]*crypto/x509.Certificate.array'
       ByteSize: 2048
-      Element: 58 PointerType *crypto/x509.Certificate
+      Element: 82 PointerType *crypto/x509.Certificate
     - __kind: GoSliceHeaderType
-      ID: 199
+      ID: 219
       Name: '[]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span'
       ByteSize: 24
       GoRuntimeType: 491840
@@ -818,21 +818,21 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 200 PointerType **github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span
+          Type: 220 PointerType **github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span
         - Name: len
           Offset: 8
-          Type: 8 BaseType int
+          Type: 7 BaseType int
         - Name: cap
           Offset: 16
-          Type: 8 BaseType int
+          Type: 7 BaseType int
       Data: 293 GoSliceDataType []*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span.array
     - __kind: GoSliceDataType
       ID: 293
       Name: '[]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span.array'
       ByteSize: 2048
-      Element: 134 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span
+      Element: 157 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span
     - __kind: GoSliceHeaderType
-      ID: 189
+      ID: 209
       Name: '[]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttributeValue'
       ByteSize: 24
       GoRuntimeType: 491456
@@ -840,21 +840,21 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 190 PointerType **github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttributeValue
+          Type: 210 PointerType **github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttributeValue
         - Name: len
           Offset: 8
-          Type: 8 BaseType int
+          Type: 7 BaseType int
         - Name: cap
           Offset: 16
-          Type: 8 BaseType int
+          Type: 7 BaseType int
       Data: 291 GoSliceDataType []*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttributeValue.array
     - __kind: GoSliceDataType
       ID: 291
       Name: '[]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttributeValue.array'
       ByteSize: 2048
-      Element: 191 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttributeValue
+      Element: 211 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttributeValue
     - __kind: GoSliceHeaderType
-      ID: 48
+      ID: 72
       Name: '[]*mime/multipart.FileHeader'
       ByteSize: 24
       GoRuntimeType: 488960
@@ -862,21 +862,21 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 49 PointerType **mime/multipart.FileHeader
+          Type: 73 PointerType **mime/multipart.FileHeader
         - Name: len
           Offset: 8
-          Type: 8 BaseType int
+          Type: 7 BaseType int
         - Name: cap
           Offset: 16
-          Type: 8 BaseType int
+          Type: 7 BaseType int
       Data: 237 GoSliceDataType []*mime/multipart.FileHeader.array
     - __kind: GoSliceDataType
       ID: 237
       Name: '[]*mime/multipart.FileHeader.array'
       ByteSize: 2048
-      Element: 50 PointerType *mime/multipart.FileHeader
+      Element: 74 PointerType *mime/multipart.FileHeader
     - __kind: GoSliceHeaderType
-      ID: 97
+      ID: 120
       Name: '[]*net.IPNet'
       ByteSize: 24
       GoRuntimeType: 518464
@@ -884,21 +884,21 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 98 PointerType **net.IPNet
+          Type: 121 PointerType **net.IPNet
         - Name: len
           Offset: 8
-          Type: 8 BaseType int
+          Type: 7 BaseType int
         - Name: cap
           Offset: 16
-          Type: 8 BaseType int
+          Type: 7 BaseType int
       Data: 265 GoSliceDataType []*net.IPNet.array
     - __kind: GoSliceDataType
       ID: 265
       Name: '[]*net.IPNet.array'
       ByteSize: 2048
-      Element: 99 PointerType *net.IPNet
+      Element: 122 PointerType *net.IPNet
     - __kind: GoSliceHeaderType
-      ID: 95
+      ID: 118
       Name: '[]*net/url.URL'
       ByteSize: 24
       GoRuntimeType: 518400
@@ -906,51 +906,51 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 96 PointerType **net/url.URL
+          Type: 119 PointerType **net/url.URL
         - Name: len
           Offset: 8
-          Type: 8 BaseType int
+          Type: 7 BaseType int
         - Name: cap
           Offset: 16
-          Type: 8 BaseType int
+          Type: 7 BaseType int
       Data: 263 GoSliceDataType []*net/url.URL.array
     - __kind: GoSliceDataType
       ID: 263
       Name: '[]*net/url.URL.array'
       ByteSize: 2048
-      Element: 9 PointerType *net/url.URL
+      Element: 39 PointerType *net/url.URL
     - __kind: GoSliceDataType
       ID: 289
       Name: '[]*table<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>.array'
       ByteSize: 8192
-      Element: 177 PointerType *table<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
+      Element: 197 PointerType *table<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
     - __kind: GoSliceDataType
       ID: 235
       Name: '[]*table<string,[]*mime/multipart.FileHeader>.array'
       ByteSize: 8192
-      Element: 41 PointerType *table<string,[]*mime/multipart.FileHeader>
+      Element: 65 PointerType *table<string,[]*mime/multipart.FileHeader>
     - __kind: GoSliceDataType
       ID: 231
       Name: '[]*table<string,[]string>.array'
       ByteSize: 8192
-      Element: 20 PointerType *table<string,[]string>
+      Element: 47 PointerType *table<string,[]string>
     - __kind: GoSliceDataType
       ID: 283
       Name: '[]*table<string,float64>.array'
       ByteSize: 8192
-      Element: 159 PointerType *table<string,float64>
+      Element: 180 PointerType *table<string,float64>
     - __kind: GoSliceDataType
       ID: 281
       Name: '[]*table<string,interface {}>.array'
       ByteSize: 8192
-      Element: 148 PointerType *table<string,interface {}>
+      Element: 169 PointerType *table<string,interface {}>
     - __kind: GoSliceDataType
       ID: 279
       Name: '[]*table<string,string>.array'
       ByteSize: 8192
-      Element: 127 PointerType *table<string,string>
+      Element: 150 PointerType *table<string,string>
     - __kind: GoSliceHeaderType
-      ID: 108
+      ID: 131
       Name: '[][]*crypto/x509.Certificate'
       ByteSize: 24
       GoRuntimeType: 503808
@@ -958,21 +958,21 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 109 PointerType *[]*crypto/x509.Certificate
+          Type: 132 PointerType *[]*crypto/x509.Certificate
         - Name: len
           Offset: 8
-          Type: 8 BaseType int
+          Type: 7 BaseType int
         - Name: cap
           Offset: 16
-          Type: 8 BaseType int
+          Type: 7 BaseType int
       Data: 273 GoSliceDataType [][]*crypto/x509.Certificate.array
     - __kind: GoSliceDataType
       ID: 273
       Name: '[][]*crypto/x509.Certificate.array'
       ByteSize: 2048
-      Element: 56 GoSliceHeaderType []*crypto/x509.Certificate
+      Element: 80 GoSliceHeaderType []*crypto/x509.Certificate
     - __kind: GoSliceHeaderType
-      ID: 110
+      ID: 133
       Name: '[][]uint8'
       ByteSize: 24
       GoRuntimeType: 483808
@@ -980,21 +980,21 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 111 PointerType *[]uint8
+          Type: 134 PointerType *[]uint8
         - Name: len
           Offset: 8
-          Type: 8 BaseType int
+          Type: 7 BaseType int
         - Name: cap
           Offset: 16
-          Type: 8 BaseType int
+          Type: 7 BaseType int
       Data: 275 GoSliceDataType [][]uint8.array
     - __kind: GoSliceDataType
       ID: 275
       Name: '[][]uint8.array'
       ByteSize: 2048
-      Element: 53 GoSliceHeaderType []uint8
+      Element: 77 GoSliceHeaderType []uint8
     - __kind: GoSliceHeaderType
-      ID: 89
+      ID: 112
       Name: '[]crypto/x509.ExtKeyUsage'
       ByteSize: 24
       GoRuntimeType: 505152
@@ -1002,21 +1002,21 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 90 PointerType *crypto/x509.ExtKeyUsage
+          Type: 113 PointerType *crypto/x509.ExtKeyUsage
         - Name: len
           Offset: 8
-          Type: 8 BaseType int
+          Type: 7 BaseType int
         - Name: cap
           Offset: 16
-          Type: 8 BaseType int
+          Type: 7 BaseType int
       Data: 257 GoSliceDataType []crypto/x509.ExtKeyUsage.array
     - __kind: GoSliceDataType
       ID: 257
       Name: '[]crypto/x509.ExtKeyUsage.array'
       ByteSize: 2048
-      Element: 91 BaseType crypto/x509.ExtKeyUsage
+      Element: 114 BaseType crypto/x509.ExtKeyUsage
     - __kind: GoSliceHeaderType
-      ID: 102
+      ID: 125
       Name: '[]crypto/x509.OID'
       ByteSize: 24
       GoRuntimeType: 518528
@@ -1024,21 +1024,21 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 103 PointerType *crypto/x509.OID
+          Type: 126 PointerType *crypto/x509.OID
         - Name: len
           Offset: 8
-          Type: 8 BaseType int
+          Type: 7 BaseType int
         - Name: cap
           Offset: 16
-          Type: 8 BaseType int
+          Type: 7 BaseType int
       Data: 269 GoSliceDataType []crypto/x509.OID.array
     - __kind: GoSliceDataType
       ID: 269
       Name: '[]crypto/x509.OID.array'
       ByteSize: 2048
-      Element: 104 StructureType crypto/x509.OID
+      Element: 127 StructureType crypto/x509.OID
     - __kind: GoSliceHeaderType
-      ID: 105
+      ID: 128
       Name: '[]crypto/x509.PolicyMapping'
       ByteSize: 24
       GoRuntimeType: 518592
@@ -1046,21 +1046,21 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 106 PointerType *crypto/x509.PolicyMapping
+          Type: 129 PointerType *crypto/x509.PolicyMapping
         - Name: len
           Offset: 8
-          Type: 8 BaseType int
+          Type: 7 BaseType int
         - Name: cap
           Offset: 16
-          Type: 8 BaseType int
+          Type: 7 BaseType int
       Data: 271 GoSliceDataType []crypto/x509.PolicyMapping.array
     - __kind: GoSliceDataType
       ID: 271
       Name: '[]crypto/x509.PolicyMapping.array'
       ByteSize: 2048
-      Element: 107 StructureType crypto/x509.PolicyMapping
+      Element: 130 StructureType crypto/x509.PolicyMapping
     - __kind: GoSliceHeaderType
-      ID: 69
+      ID: 93
       Name: '[]crypto/x509/pkix.AttributeTypeAndValue'
       ByteSize: 24
       GoRuntimeType: 519040
@@ -1068,21 +1068,21 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 70 PointerType *crypto/x509/pkix.AttributeTypeAndValue
+          Type: 94 PointerType *crypto/x509/pkix.AttributeTypeAndValue
         - Name: len
           Offset: 8
-          Type: 8 BaseType int
+          Type: 7 BaseType int
         - Name: cap
           Offset: 16
-          Type: 8 BaseType int
+          Type: 7 BaseType int
       Data: 245 GoSliceDataType []crypto/x509/pkix.AttributeTypeAndValue.array
     - __kind: GoSliceDataType
       ID: 245
       Name: '[]crypto/x509/pkix.AttributeTypeAndValue.array'
       ByteSize: 2048
-      Element: 71 StructureType crypto/x509/pkix.AttributeTypeAndValue
+      Element: 95 StructureType crypto/x509/pkix.AttributeTypeAndValue
     - __kind: GoSliceHeaderType
-      ID: 84
+      ID: 107
       Name: '[]crypto/x509/pkix.Extension'
       ByteSize: 24
       GoRuntimeType: 518272
@@ -1090,21 +1090,21 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 85 PointerType *crypto/x509/pkix.Extension
+          Type: 108 PointerType *crypto/x509/pkix.Extension
         - Name: len
           Offset: 8
-          Type: 8 BaseType int
+          Type: 7 BaseType int
         - Name: cap
           Offset: 16
-          Type: 8 BaseType int
+          Type: 7 BaseType int
       Data: 253 GoSliceDataType []crypto/x509/pkix.Extension.array
     - __kind: GoSliceDataType
       ID: 253
       Name: '[]crypto/x509/pkix.Extension.array'
       ByteSize: 2048
-      Element: 86 StructureType crypto/x509/pkix.Extension
+      Element: 109 StructureType crypto/x509/pkix.Extension
     - __kind: GoSliceHeaderType
-      ID: 87
+      ID: 110
       Name: '[]encoding/asn1.ObjectIdentifier'
       ByteSize: 24
       GoRuntimeType: 518336
@@ -1112,21 +1112,21 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 88 PointerType *encoding/asn1.ObjectIdentifier
+          Type: 111 PointerType *encoding/asn1.ObjectIdentifier
         - Name: len
           Offset: 8
-          Type: 8 BaseType int
+          Type: 7 BaseType int
         - Name: cap
           Offset: 16
-          Type: 8 BaseType int
+          Type: 7 BaseType int
       Data: 255 GoSliceDataType []encoding/asn1.ObjectIdentifier.array
     - __kind: GoSliceDataType
       ID: 255
       Name: '[]encoding/asn1.ObjectIdentifier.array'
       ByteSize: 2048
-      Element: 72 GoSliceHeaderType encoding/asn1.ObjectIdentifier
+      Element: 96 GoSliceHeaderType encoding/asn1.ObjectIdentifier
     - __kind: GoSliceHeaderType
-      ID: 167
+      ID: 187
       Name: '[]github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink'
       ByteSize: 24
       GoRuntimeType: 491392
@@ -1134,21 +1134,21 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 168 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink
+          Type: 188 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink
         - Name: len
           Offset: 8
-          Type: 8 BaseType int
+          Type: 7 BaseType int
         - Name: cap
           Offset: 16
-          Type: 8 BaseType int
+          Type: 7 BaseType int
       Data: 285 GoSliceDataType []github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink.array
     - __kind: GoSliceDataType
       ID: 285
       Name: '[]github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink.array'
       ByteSize: 2048
-      Element: 169 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink
+      Element: 189 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink
     - __kind: GoSliceHeaderType
-      ID: 170
+      ID: 190
       Name: '[]github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent'
       ByteSize: 24
       GoRuntimeType: 491584
@@ -1156,21 +1156,21 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 171 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent
+          Type: 191 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent
         - Name: len
           Offset: 8
-          Type: 8 BaseType int
+          Type: 7 BaseType int
         - Name: cap
           Offset: 16
-          Type: 8 BaseType int
+          Type: 7 BaseType int
       Data: 287 GoSliceDataType []github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent.array
     - __kind: GoSliceDataType
       ID: 287
       Name: '[]github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent.array'
       ByteSize: 2048
-      Element: 172 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent
+      Element: 192 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent
     - __kind: GoSliceHeaderType
-      ID: 92
+      ID: 115
       Name: '[]net.IP'
       ByteSize: 24
       GoRuntimeType: 484768
@@ -1178,21 +1178,21 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 93 PointerType *net.IP
+          Type: 116 PointerType *net.IP
         - Name: len
           Offset: 8
-          Type: 8 BaseType int
+          Type: 7 BaseType int
         - Name: cap
           Offset: 16
-          Type: 8 BaseType int
+          Type: 7 BaseType int
       Data: 259 GoSliceDataType []net.IP.array
     - __kind: GoSliceDataType
       ID: 259
       Name: '[]net.IP.array'
       ByteSize: 2048
-      Element: 94 GoSliceHeaderType net.IP
+      Element: 117 GoSliceHeaderType net.IP
     - __kind: GoSliceHeaderType
-      ID: 120
+      ID: 143
       Name: '[]net/http.segment'
       ByteSize: 24
       GoRuntimeType: 486400
@@ -1200,51 +1200,51 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 121 PointerType *net/http.segment
+          Type: 144 PointerType *net/http.segment
         - Name: len
           Offset: 8
-          Type: 8 BaseType int
+          Type: 7 BaseType int
         - Name: cap
           Offset: 16
-          Type: 8 BaseType int
+          Type: 7 BaseType int
       Data: 277 GoSliceDataType []net/http.segment.array
     - __kind: GoSliceDataType
       ID: 277
       Name: '[]net/http.segment.array'
       ByteSize: 2048
-      Element: 122 StructureType net/http.segment
+      Element: 145 StructureType net/http.segment
     - __kind: GoSliceDataType
       ID: 290
       Name: '[]noalg.map.group[string]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute.array'
       ByteSize: 2048
-      Element: 181 StructureType noalg.map.group[string]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
+      Element: 201 StructureType noalg.map.group[string]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
     - __kind: GoSliceDataType
       ID: 236
       Name: '[]noalg.map.group[string][]*mime/multipart.FileHeader.array'
       ByteSize: 2048
-      Element: 45 StructureType noalg.map.group[string][]*mime/multipart.FileHeader
+      Element: 69 StructureType noalg.map.group[string][]*mime/multipart.FileHeader
     - __kind: GoSliceDataType
       ID: 232
       Name: '[]noalg.map.group[string][]string.array'
       ByteSize: 2048
-      Element: 25 StructureType noalg.map.group[string][]string
+      Element: 51 StructureType noalg.map.group[string][]string
     - __kind: GoSliceDataType
       ID: 284
       Name: '[]noalg.map.group[string]float64.array'
       ByteSize: 2048
-      Element: 163 StructureType noalg.map.group[string]float64
+      Element: 184 StructureType noalg.map.group[string]float64
     - __kind: GoSliceDataType
       ID: 282
       Name: '[]noalg.map.group[string]interface {}.array'
       ByteSize: 2048
-      Element: 152 StructureType noalg.map.group[string]interface {}
+      Element: 173 StructureType noalg.map.group[string]interface {}
     - __kind: GoSliceDataType
       ID: 280
       Name: '[]noalg.map.group[string]string.array'
       ByteSize: 2048
-      Element: 131 StructureType noalg.map.group[string]string
+      Element: 154 StructureType noalg.map.group[string]string
     - __kind: GoSliceHeaderType
-      ID: 28
+      ID: 54
       Name: '[]string'
       ByteSize: 24
       GoRuntimeType: 498048
@@ -1252,21 +1252,21 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 29 PointerType *string
+          Type: 22 PointerType *string
         - Name: len
           Offset: 8
-          Type: 8 BaseType int
+          Type: 7 BaseType int
         - Name: cap
           Offset: 16
-          Type: 8 BaseType int
+          Type: 7 BaseType int
       Data: 233 GoSliceDataType []string.array
     - __kind: GoSliceDataType
       ID: 233
       Name: '[]string.array'
       ByteSize: 2048
-      Element: 5 GoStringHeaderType string
+      Element: 9 GoStringHeaderType string
     - __kind: GoSliceHeaderType
-      ID: 77
+      ID: 100
       Name: '[]time.zone'
       ByteSize: 24
       GoRuntimeType: 490944
@@ -1274,21 +1274,21 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 78 PointerType *time.zone
+          Type: 101 PointerType *time.zone
         - Name: len
           Offset: 8
-          Type: 8 BaseType int
+          Type: 7 BaseType int
         - Name: cap
           Offset: 16
-          Type: 8 BaseType int
+          Type: 7 BaseType int
       Data: 249 GoSliceDataType []time.zone.array
     - __kind: GoSliceDataType
       ID: 249
       Name: '[]time.zone.array'
       ByteSize: 2048
-      Element: 79 StructureType time.zone
+      Element: 102 StructureType time.zone
     - __kind: GoSliceHeaderType
-      ID: 80
+      ID: 103
       Name: '[]time.zoneTrans'
       ByteSize: 24
       GoRuntimeType: 491008
@@ -1296,21 +1296,21 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 81 PointerType *time.zoneTrans
+          Type: 104 PointerType *time.zoneTrans
         - Name: len
           Offset: 8
-          Type: 8 BaseType int
+          Type: 7 BaseType int
         - Name: cap
           Offset: 16
-          Type: 8 BaseType int
+          Type: 7 BaseType int
       Data: 251 GoSliceDataType []time.zoneTrans.array
     - __kind: GoSliceDataType
       ID: 251
       Name: '[]time.zoneTrans.array'
       ByteSize: 2048
-      Element: 82 StructureType time.zoneTrans
+      Element: 105 StructureType time.zoneTrans
     - __kind: GoSliceHeaderType
-      ID: 53
+      ID: 77
       Name: '[]uint8'
       ByteSize: 24
       GoRuntimeType: 496896
@@ -1318,27 +1318,27 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 6 PointerType *uint8
+          Type: 5 PointerType *uint8
         - Name: len
           Offset: 8
-          Type: 8 BaseType int
+          Type: 7 BaseType int
         - Name: cap
           Offset: 16
-          Type: 8 BaseType int
+          Type: 7 BaseType int
       Data: 239 GoSliceDataType []uint8.array
     - __kind: GoSliceDataType
       ID: 239
       Name: '[]uint8.array'
       ByteSize: 2048
-      Element: 7 BaseType uint8
+      Element: 3 BaseType uint8
     - __kind: BaseType
-      ID: 13
+      ID: 4
       Name: bool
       ByteSize: 1
       GoRuntimeType: 591200
       GoKind: 1
     - __kind: StructureType
-      ID: 206
+      ID: 225
       Name: bytes.Buffer
       ByteSize: 40
       GoRuntimeType: 1.634976e+06
@@ -1346,33 +1346,33 @@ Types:
       RawFields:
         - Name: buf
           Offset: 0
-          Type: 53 GoSliceHeaderType []uint8
+          Type: 77 GoSliceHeaderType []uint8
         - Name: off
           Offset: 24
-          Type: 8 BaseType int
+          Type: 7 BaseType int
         - Name: lastRead
           Offset: 32
-          Type: 207 BaseType bytes.readOp
+          Type: 226 BaseType bytes.readOp
     - __kind: BaseType
-      ID: 207
+      ID: 226
       Name: bytes.readOp
       ByteSize: 1
       GoRuntimeType: 589344
       GoKind: 3
     - __kind: BaseType
-      ID: 220
+      ID: 25
       Name: complex128
       ByteSize: 16
       GoRuntimeType: 591008
       GoKind: 16
     - __kind: BaseType
-      ID: 219
+      ID: 24
       Name: complex64
       ByteSize: 8
       GoRuntimeType: 590944
       GoKind: 15
     - __kind: GoInterfaceType
-      ID: 117
+      ID: 140
       Name: context.Context
       ByteSize: 16
       GoRuntimeType: 1.298016e+06
@@ -1380,27 +1380,27 @@ Types:
       RawFields:
         - Name: tab
           Offset: 0
-          Type: 2 VoidPointerType unsafe.Pointer
+          Type: 15 VoidPointerType unsafe.Pointer
         - Name: data
           Offset: 8
-          Type: 2 VoidPointerType unsafe.Pointer
+          Type: 15 VoidPointerType unsafe.Pointer
     - __kind: StructureType
-      ID: 208
+      ID: 227
       Name: context.backgroundCtx
       GoRuntimeType: 1.826784e+06
       GoKind: 25
       RawFields:
         - Name: emptyCtx
           Offset: 0
-          Type: 209 StructureType context.emptyCtx
+          Type: 228 StructureType context.emptyCtx
     - __kind: StructureType
-      ID: 209
+      ID: 228
       Name: context.emptyCtx
       GoRuntimeType: 1.61824e+06
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 55
+      ID: 79
       Name: crypto/tls.ConnectionState
       ByteSize: 192
       GoRuntimeType: 2.301632e+06
@@ -1408,60 +1408,60 @@ Types:
       RawFields:
         - Name: Version
           Offset: 0
-          Type: 22 BaseType uint16
+          Type: 6 BaseType uint16
         - Name: HandshakeComplete
           Offset: 2
-          Type: 13 BaseType bool
+          Type: 4 BaseType bool
         - Name: DidResume
           Offset: 3
-          Type: 13 BaseType bool
+          Type: 4 BaseType bool
         - Name: CipherSuite
           Offset: 4
-          Type: 22 BaseType uint16
+          Type: 6 BaseType uint16
         - Name: NegotiatedProtocol
           Offset: 8
-          Type: 5 GoStringHeaderType string
+          Type: 9 GoStringHeaderType string
         - Name: NegotiatedProtocolIsMutual
           Offset: 24
-          Type: 13 BaseType bool
+          Type: 4 BaseType bool
         - Name: ServerName
           Offset: 32
-          Type: 5 GoStringHeaderType string
+          Type: 9 GoStringHeaderType string
         - Name: PeerCertificates
           Offset: 48
-          Type: 56 GoSliceHeaderType []*crypto/x509.Certificate
+          Type: 80 GoSliceHeaderType []*crypto/x509.Certificate
         - Name: VerifiedChains
           Offset: 72
-          Type: 108 GoSliceHeaderType [][]*crypto/x509.Certificate
+          Type: 131 GoSliceHeaderType [][]*crypto/x509.Certificate
         - Name: SignedCertificateTimestamps
           Offset: 96
-          Type: 110 GoSliceHeaderType [][]uint8
+          Type: 133 GoSliceHeaderType [][]uint8
         - Name: OCSPResponse
           Offset: 120
-          Type: 53 GoSliceHeaderType []uint8
+          Type: 77 GoSliceHeaderType []uint8
         - Name: TLSUnique
           Offset: 144
-          Type: 53 GoSliceHeaderType []uint8
+          Type: 77 GoSliceHeaderType []uint8
         - Name: ECHAccepted
           Offset: 168
-          Type: 13 BaseType bool
+          Type: 4 BaseType bool
         - Name: ekm
           Offset: 176
-          Type: 112 GoSubroutineType func(string, []uint8, int) ([]uint8, error)
+          Type: 135 GoSubroutineType func(string, []uint8, int) ([]uint8, error)
         - Name: testingOnlyDidHRR
           Offset: 184
-          Type: 13 BaseType bool
+          Type: 4 BaseType bool
         - Name: testingOnlyCurveID
           Offset: 186
-          Type: 113 BaseType crypto/tls.CurveID
+          Type: 136 BaseType crypto/tls.CurveID
     - __kind: BaseType
-      ID: 113
+      ID: 136
       Name: crypto/tls.CurveID
       ByteSize: 2
       GoRuntimeType: 843360
       GoKind: 9
     - __kind: StructureType
-      ID: 59
+      ID: 83
       Name: crypto/x509.Certificate
       ByteSize: 1424
       GoRuntimeType: 2.452512e+06
@@ -1469,174 +1469,174 @@ Types:
       RawFields:
         - Name: Raw
           Offset: 0
-          Type: 53 GoSliceHeaderType []uint8
+          Type: 77 GoSliceHeaderType []uint8
         - Name: RawTBSCertificate
           Offset: 24
-          Type: 53 GoSliceHeaderType []uint8
+          Type: 77 GoSliceHeaderType []uint8
         - Name: RawSubjectPublicKeyInfo
           Offset: 48
-          Type: 53 GoSliceHeaderType []uint8
+          Type: 77 GoSliceHeaderType []uint8
         - Name: RawSubject
           Offset: 72
-          Type: 53 GoSliceHeaderType []uint8
+          Type: 77 GoSliceHeaderType []uint8
         - Name: RawIssuer
           Offset: 96
-          Type: 53 GoSliceHeaderType []uint8
+          Type: 77 GoSliceHeaderType []uint8
         - Name: Signature
           Offset: 120
-          Type: 53 GoSliceHeaderType []uint8
+          Type: 77 GoSliceHeaderType []uint8
         - Name: SignatureAlgorithm
           Offset: 144
-          Type: 60 BaseType crypto/x509.SignatureAlgorithm
+          Type: 84 BaseType crypto/x509.SignatureAlgorithm
         - Name: PublicKeyAlgorithm
           Offset: 152
-          Type: 61 BaseType crypto/x509.PublicKeyAlgorithm
+          Type: 85 BaseType crypto/x509.PublicKeyAlgorithm
         - Name: PublicKey
           Offset: 160
-          Type: 62 GoEmptyInterfaceType interface {}
+          Type: 86 GoEmptyInterfaceType interface {}
         - Name: Version
           Offset: 176
-          Type: 8 BaseType int
+          Type: 7 BaseType int
         - Name: SerialNumber
           Offset: 184
-          Type: 63 PointerType *math/big.Int
+          Type: 87 PointerType *math/big.Int
         - Name: Issuer
           Offset: 192
-          Type: 68 StructureType crypto/x509/pkix.Name
+          Type: 92 StructureType crypto/x509/pkix.Name
         - Name: Subject
           Offset: 440
-          Type: 68 StructureType crypto/x509/pkix.Name
+          Type: 92 StructureType crypto/x509/pkix.Name
         - Name: NotBefore
           Offset: 688
-          Type: 74 StructureType time.Time
+          Type: 97 StructureType time.Time
         - Name: NotAfter
           Offset: 712
-          Type: 74 StructureType time.Time
+          Type: 97 StructureType time.Time
         - Name: KeyUsage
           Offset: 736
-          Type: 83 BaseType crypto/x509.KeyUsage
+          Type: 106 BaseType crypto/x509.KeyUsage
         - Name: Extensions
           Offset: 744
-          Type: 84 GoSliceHeaderType []crypto/x509/pkix.Extension
+          Type: 107 GoSliceHeaderType []crypto/x509/pkix.Extension
         - Name: ExtraExtensions
           Offset: 768
-          Type: 84 GoSliceHeaderType []crypto/x509/pkix.Extension
+          Type: 107 GoSliceHeaderType []crypto/x509/pkix.Extension
         - Name: UnhandledCriticalExtensions
           Offset: 792
-          Type: 87 GoSliceHeaderType []encoding/asn1.ObjectIdentifier
+          Type: 110 GoSliceHeaderType []encoding/asn1.ObjectIdentifier
         - Name: ExtKeyUsage
           Offset: 816
-          Type: 89 GoSliceHeaderType []crypto/x509.ExtKeyUsage
+          Type: 112 GoSliceHeaderType []crypto/x509.ExtKeyUsage
         - Name: UnknownExtKeyUsage
           Offset: 840
-          Type: 87 GoSliceHeaderType []encoding/asn1.ObjectIdentifier
+          Type: 110 GoSliceHeaderType []encoding/asn1.ObjectIdentifier
         - Name: BasicConstraintsValid
           Offset: 864
-          Type: 13 BaseType bool
+          Type: 4 BaseType bool
         - Name: IsCA
           Offset: 865
-          Type: 13 BaseType bool
+          Type: 4 BaseType bool
         - Name: MaxPathLen
           Offset: 872
-          Type: 8 BaseType int
+          Type: 7 BaseType int
         - Name: MaxPathLenZero
           Offset: 880
-          Type: 13 BaseType bool
+          Type: 4 BaseType bool
         - Name: SubjectKeyId
           Offset: 888
-          Type: 53 GoSliceHeaderType []uint8
+          Type: 77 GoSliceHeaderType []uint8
         - Name: AuthorityKeyId
           Offset: 912
-          Type: 53 GoSliceHeaderType []uint8
+          Type: 77 GoSliceHeaderType []uint8
         - Name: OCSPServer
           Offset: 936
-          Type: 28 GoSliceHeaderType []string
+          Type: 54 GoSliceHeaderType []string
         - Name: IssuingCertificateURL
           Offset: 960
-          Type: 28 GoSliceHeaderType []string
+          Type: 54 GoSliceHeaderType []string
         - Name: DNSNames
           Offset: 984
-          Type: 28 GoSliceHeaderType []string
+          Type: 54 GoSliceHeaderType []string
         - Name: EmailAddresses
           Offset: 1008
-          Type: 28 GoSliceHeaderType []string
+          Type: 54 GoSliceHeaderType []string
         - Name: IPAddresses
           Offset: 1032
-          Type: 92 GoSliceHeaderType []net.IP
+          Type: 115 GoSliceHeaderType []net.IP
         - Name: URIs
           Offset: 1056
-          Type: 95 GoSliceHeaderType []*net/url.URL
+          Type: 118 GoSliceHeaderType []*net/url.URL
         - Name: PermittedDNSDomainsCritical
           Offset: 1080
-          Type: 13 BaseType bool
+          Type: 4 BaseType bool
         - Name: PermittedDNSDomains
           Offset: 1088
-          Type: 28 GoSliceHeaderType []string
+          Type: 54 GoSliceHeaderType []string
         - Name: ExcludedDNSDomains
           Offset: 1112
-          Type: 28 GoSliceHeaderType []string
+          Type: 54 GoSliceHeaderType []string
         - Name: PermittedIPRanges
           Offset: 1136
-          Type: 97 GoSliceHeaderType []*net.IPNet
+          Type: 120 GoSliceHeaderType []*net.IPNet
         - Name: ExcludedIPRanges
           Offset: 1160
-          Type: 97 GoSliceHeaderType []*net.IPNet
+          Type: 120 GoSliceHeaderType []*net.IPNet
         - Name: PermittedEmailAddresses
           Offset: 1184
-          Type: 28 GoSliceHeaderType []string
+          Type: 54 GoSliceHeaderType []string
         - Name: ExcludedEmailAddresses
           Offset: 1208
-          Type: 28 GoSliceHeaderType []string
+          Type: 54 GoSliceHeaderType []string
         - Name: PermittedURIDomains
           Offset: 1232
-          Type: 28 GoSliceHeaderType []string
+          Type: 54 GoSliceHeaderType []string
         - Name: ExcludedURIDomains
           Offset: 1256
-          Type: 28 GoSliceHeaderType []string
+          Type: 54 GoSliceHeaderType []string
         - Name: CRLDistributionPoints
           Offset: 1280
-          Type: 28 GoSliceHeaderType []string
+          Type: 54 GoSliceHeaderType []string
         - Name: PolicyIdentifiers
           Offset: 1304
-          Type: 87 GoSliceHeaderType []encoding/asn1.ObjectIdentifier
+          Type: 110 GoSliceHeaderType []encoding/asn1.ObjectIdentifier
         - Name: Policies
           Offset: 1328
-          Type: 102 GoSliceHeaderType []crypto/x509.OID
+          Type: 125 GoSliceHeaderType []crypto/x509.OID
         - Name: InhibitAnyPolicy
           Offset: 1352
-          Type: 8 BaseType int
+          Type: 7 BaseType int
         - Name: InhibitAnyPolicyZero
           Offset: 1360
-          Type: 13 BaseType bool
+          Type: 4 BaseType bool
         - Name: InhibitPolicyMapping
           Offset: 1368
-          Type: 8 BaseType int
+          Type: 7 BaseType int
         - Name: InhibitPolicyMappingZero
           Offset: 1376
-          Type: 13 BaseType bool
+          Type: 4 BaseType bool
         - Name: RequireExplicitPolicy
           Offset: 1384
-          Type: 8 BaseType int
+          Type: 7 BaseType int
         - Name: RequireExplicitPolicyZero
           Offset: 1392
-          Type: 13 BaseType bool
+          Type: 4 BaseType bool
         - Name: PolicyMappings
           Offset: 1400
-          Type: 105 GoSliceHeaderType []crypto/x509.PolicyMapping
+          Type: 128 GoSliceHeaderType []crypto/x509.PolicyMapping
     - __kind: BaseType
-      ID: 91
+      ID: 114
       Name: crypto/x509.ExtKeyUsage
       ByteSize: 8
       GoRuntimeType: 594272
       GoKind: 2
     - __kind: BaseType
-      ID: 83
+      ID: 106
       Name: crypto/x509.KeyUsage
       ByteSize: 8
       GoRuntimeType: 594208
       GoKind: 2
     - __kind: StructureType
-      ID: 104
+      ID: 127
       Name: crypto/x509.OID
       ByteSize: 24
       GoRuntimeType: 1.989152e+06
@@ -1644,9 +1644,9 @@ Types:
       RawFields:
         - Name: der
           Offset: 0
-          Type: 53 GoSliceHeaderType []uint8
+          Type: 77 GoSliceHeaderType []uint8
     - __kind: StructureType
-      ID: 107
+      ID: 130
       Name: crypto/x509.PolicyMapping
       ByteSize: 48
       GoRuntimeType: 1.5144e+06
@@ -1654,24 +1654,24 @@ Types:
       RawFields:
         - Name: IssuerDomainPolicy
           Offset: 0
-          Type: 104 StructureType crypto/x509.OID
+          Type: 127 StructureType crypto/x509.OID
         - Name: SubjectDomainPolicy
           Offset: 24
-          Type: 104 StructureType crypto/x509.OID
+          Type: 127 StructureType crypto/x509.OID
     - __kind: BaseType
-      ID: 61
+      ID: 85
       Name: crypto/x509.PublicKeyAlgorithm
       ByteSize: 8
       GoRuntimeType: 845664
       GoKind: 2
     - __kind: BaseType
-      ID: 60
+      ID: 84
       Name: crypto/x509.SignatureAlgorithm
       ByteSize: 8
       GoRuntimeType: 1.134112e+06
       GoKind: 2
     - __kind: StructureType
-      ID: 71
+      ID: 95
       Name: crypto/x509/pkix.AttributeTypeAndValue
       ByteSize: 40
       GoRuntimeType: 1.52688e+06
@@ -1679,12 +1679,12 @@ Types:
       RawFields:
         - Name: Type
           Offset: 0
-          Type: 72 GoSliceHeaderType encoding/asn1.ObjectIdentifier
+          Type: 96 GoSliceHeaderType encoding/asn1.ObjectIdentifier
         - Name: Value
           Offset: 24
-          Type: 62 GoEmptyInterfaceType interface {}
+          Type: 86 GoEmptyInterfaceType interface {}
     - __kind: StructureType
-      ID: 86
+      ID: 109
       Name: crypto/x509/pkix.Extension
       ByteSize: 56
       GoRuntimeType: 1.678176e+06
@@ -1692,15 +1692,15 @@ Types:
       RawFields:
         - Name: Id
           Offset: 0
-          Type: 72 GoSliceHeaderType encoding/asn1.ObjectIdentifier
+          Type: 96 GoSliceHeaderType encoding/asn1.ObjectIdentifier
         - Name: Critical
           Offset: 24
-          Type: 13 BaseType bool
+          Type: 4 BaseType bool
         - Name: Value
           Offset: 32
-          Type: 53 GoSliceHeaderType []uint8
+          Type: 77 GoSliceHeaderType []uint8
     - __kind: StructureType
-      ID: 68
+      ID: 92
       Name: crypto/x509/pkix.Name
       ByteSize: 248
       GoRuntimeType: 2.240928e+06
@@ -1708,39 +1708,39 @@ Types:
       RawFields:
         - Name: Country
           Offset: 0
-          Type: 28 GoSliceHeaderType []string
+          Type: 54 GoSliceHeaderType []string
         - Name: Organization
           Offset: 24
-          Type: 28 GoSliceHeaderType []string
+          Type: 54 GoSliceHeaderType []string
         - Name: OrganizationalUnit
           Offset: 48
-          Type: 28 GoSliceHeaderType []string
+          Type: 54 GoSliceHeaderType []string
         - Name: Locality
           Offset: 72
-          Type: 28 GoSliceHeaderType []string
+          Type: 54 GoSliceHeaderType []string
         - Name: Province
           Offset: 96
-          Type: 28 GoSliceHeaderType []string
+          Type: 54 GoSliceHeaderType []string
         - Name: StreetAddress
           Offset: 120
-          Type: 28 GoSliceHeaderType []string
+          Type: 54 GoSliceHeaderType []string
         - Name: PostalCode
           Offset: 144
-          Type: 28 GoSliceHeaderType []string
+          Type: 54 GoSliceHeaderType []string
         - Name: SerialNumber
           Offset: 168
-          Type: 5 GoStringHeaderType string
+          Type: 9 GoStringHeaderType string
         - Name: CommonName
           Offset: 184
-          Type: 5 GoStringHeaderType string
+          Type: 9 GoStringHeaderType string
         - Name: Names
           Offset: 200
-          Type: 69 GoSliceHeaderType []crypto/x509/pkix.AttributeTypeAndValue
+          Type: 93 GoSliceHeaderType []crypto/x509/pkix.AttributeTypeAndValue
         - Name: ExtraNames
           Offset: 224
-          Type: 69 GoSliceHeaderType []crypto/x509/pkix.AttributeTypeAndValue
+          Type: 93 GoSliceHeaderType []crypto/x509/pkix.AttributeTypeAndValue
     - __kind: GoSliceHeaderType
-      ID: 72
+      ID: 96
       Name: encoding/asn1.ObjectIdentifier
       ByteSize: 24
       GoRuntimeType: 1.074656e+06
@@ -1748,21 +1748,21 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 73 PointerType *int
+          Type: 28 PointerType *int
         - Name: len
           Offset: 8
-          Type: 8 BaseType int
+          Type: 7 BaseType int
         - Name: cap
           Offset: 16
-          Type: 8 BaseType int
+          Type: 7 BaseType int
       Data: 247 GoSliceDataType encoding/asn1.ObjectIdentifier.array
     - __kind: GoSliceDataType
       ID: 247
       Name: encoding/asn1.ObjectIdentifier.array
       ByteSize: 2048
-      Element: 8 BaseType int
+      Element: 7 BaseType int
     - __kind: GoInterfaceType
-      ID: 212
+      ID: 14
       Name: error
       ByteSize: 16
       GoRuntimeType: 1.049312e+06
@@ -1770,42 +1770,42 @@ Types:
       RawFields:
         - Name: tab
           Offset: 0
-          Type: 2 VoidPointerType unsafe.Pointer
+          Type: 15 VoidPointerType unsafe.Pointer
         - Name: data
           Offset: 8
-          Type: 2 VoidPointerType unsafe.Pointer
+          Type: 15 VoidPointerType unsafe.Pointer
     - __kind: BaseType
-      ID: 214
+      ID: 17
       Name: float32
       ByteSize: 4
       GoRuntimeType: 591072
       GoKind: 13
     - __kind: BaseType
-      ID: 166
+      ID: 18
       Name: float64
       ByteSize: 8
       GoRuntimeType: 591136
       GoKind: 14
     - __kind: GoSubroutineType
-      ID: 204
+      ID: 223
       Name: func()
       ByteSize: 8
       GoRuntimeType: 481952
       GoKind: 19
     - __kind: GoSubroutineType
-      ID: 31
+      ID: 56
       Name: func() (io.ReadCloser, error)
       ByteSize: 8
       GoRuntimeType: 701088
       GoKind: 19
     - __kind: GoSubroutineType
-      ID: 112
+      ID: 135
       Name: func(string, []uint8, int) ([]uint8, error)
       ByteSize: 8
       GoRuntimeType: 1.020064e+06
       GoKind: 19
     - __kind: StructureType
-      ID: 135
+      ID: 158
       Name: github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span
       ByteSize: 288
       GoRuntimeType: 2.392384e+06
@@ -1813,81 +1813,81 @@ Types:
       RawFields:
         - Name: mu
           Offset: 0
-          Type: 136 StructureType sync.RWMutex
+          Type: 159 StructureType sync.RWMutex
         - Name: name
           Offset: 24
-          Type: 5 GoStringHeaderType string
+          Type: 9 GoStringHeaderType string
         - Name: service
           Offset: 40
-          Type: 5 GoStringHeaderType string
+          Type: 9 GoStringHeaderType string
         - Name: resource
           Offset: 56
-          Type: 5 GoStringHeaderType string
+          Type: 9 GoStringHeaderType string
         - Name: spanType
           Offset: 72
-          Type: 5 GoStringHeaderType string
+          Type: 9 GoStringHeaderType string
         - Name: start
           Offset: 88
-          Type: 32 BaseType int64
+          Type: 13 BaseType int64
         - Name: duration
           Offset: 96
-          Type: 32 BaseType int64
+          Type: 13 BaseType int64
         - Name: meta
           Offset: 104
-          Type: 123 GoMapType map[string]string
+          Type: 146 GoMapType map[string]string
         - Name: metaStruct
           Offset: 112
-          Type: 144 GoMapType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.metaStructMap
+          Type: 165 GoMapType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.metaStructMap
         - Name: metrics
           Offset: 120
-          Type: 155 GoMapType map[string]float64
+          Type: 176 GoMapType map[string]float64
         - Name: spanID
           Offset: 128
-          Type: 17 BaseType uint64
+          Type: 8 BaseType uint64
         - Name: traceID
           Offset: 136
-          Type: 17 BaseType uint64
+          Type: 8 BaseType uint64
         - Name: parentID
           Offset: 144
-          Type: 17 BaseType uint64
+          Type: 8 BaseType uint64
         - Name: error
           Offset: 152
-          Type: 140 BaseType int32
+          Type: 12 BaseType int32
         - Name: spanLinks
           Offset: 160
-          Type: 167 GoSliceHeaderType []github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink
+          Type: 187 GoSliceHeaderType []github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink
         - Name: spanEvents
           Offset: 184
-          Type: 170 GoSliceHeaderType []github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent
+          Type: 190 GoSliceHeaderType []github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent
         - Name: goExecTraced
           Offset: 208
-          Type: 13 BaseType bool
+          Type: 4 BaseType bool
         - Name: noDebugStack
           Offset: 209
-          Type: 13 BaseType bool
+          Type: 4 BaseType bool
         - Name: finished
           Offset: 210
-          Type: 13 BaseType bool
+          Type: 4 BaseType bool
         - Name: context
           Offset: 216
-          Type: 195 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanContext
+          Type: 215 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanContext
         - Name: integration
           Offset: 224
-          Type: 5 GoStringHeaderType string
+          Type: 9 GoStringHeaderType string
         - Name: supportsEvents
           Offset: 240
-          Type: 13 BaseType bool
+          Type: 4 BaseType bool
         - Name: pprofCtxActive
           Offset: 248
-          Type: 117 GoInterfaceType context.Context
+          Type: 140 GoInterfaceType context.Context
         - Name: pprofCtxRestore
           Offset: 264
-          Type: 117 GoInterfaceType context.Context
+          Type: 140 GoInterfaceType context.Context
         - Name: taskEnd
           Offset: 280
-          Type: 204 GoSubroutineType func()
+          Type: 223 GoSubroutineType func()
     - __kind: StructureType
-      ID: 196
+      ID: 216
       Name: github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanContext
       ByteSize: 168
       GoRuntimeType: 2.261024e+06
@@ -1895,48 +1895,48 @@ Types:
       RawFields:
         - Name: updated
           Offset: 0
-          Type: 13 BaseType bool
+          Type: 4 BaseType bool
         - Name: trace
           Offset: 8
-          Type: 197 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.trace
+          Type: 217 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.trace
         - Name: span
           Offset: 16
-          Type: 134 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span
+          Type: 157 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span
         - Name: errors
           Offset: 24
-          Type: 142 StructureType sync/atomic.Int32
+          Type: 163 StructureType sync/atomic.Int32
         - Name: reparentID
           Offset: 32
-          Type: 5 GoStringHeaderType string
+          Type: 9 GoStringHeaderType string
         - Name: isRemote
           Offset: 48
-          Type: 13 BaseType bool
+          Type: 4 BaseType bool
         - Name: traceID
           Offset: 49
-          Type: 203 ArrayType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.traceID
+          Type: 222 ArrayType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.traceID
         - Name: spanID
           Offset: 72
-          Type: 17 BaseType uint64
+          Type: 8 BaseType uint64
         - Name: mu
           Offset: 80
-          Type: 136 StructureType sync.RWMutex
+          Type: 159 StructureType sync.RWMutex
         - Name: baggage
           Offset: 104
-          Type: 123 GoMapType map[string]string
+          Type: 146 GoMapType map[string]string
         - Name: hasBaggage
           Offset: 112
-          Type: 141 BaseType uint32
+          Type: 2 BaseType uint32
         - Name: origin
           Offset: 120
-          Type: 5 GoStringHeaderType string
+          Type: 9 GoStringHeaderType string
         - Name: spanLinks
           Offset: 136
-          Type: 167 GoSliceHeaderType []github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink
+          Type: 187 GoSliceHeaderType []github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink
         - Name: baggageOnly
           Offset: 160
-          Type: 13 BaseType bool
+          Type: 4 BaseType bool
     - __kind: StructureType
-      ID: 169
+      ID: 189
       Name: github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink
       ByteSize: 56
       GoRuntimeType: 1.9464e+06
@@ -1944,37 +1944,37 @@ Types:
       RawFields:
         - Name: TraceID
           Offset: 0
-          Type: 17 BaseType uint64
+          Type: 8 BaseType uint64
         - Name: TraceIDHigh
           Offset: 8
-          Type: 17 BaseType uint64
+          Type: 8 BaseType uint64
         - Name: SpanID
           Offset: 16
-          Type: 17 BaseType uint64
+          Type: 8 BaseType uint64
         - Name: Attributes
           Offset: 24
-          Type: 123 GoMapType map[string]string
+          Type: 146 GoMapType map[string]string
         - Name: Tracestate
           Offset: 32
-          Type: 5 GoStringHeaderType string
+          Type: 9 GoStringHeaderType string
         - Name: Flags
           Offset: 48
-          Type: 141 BaseType uint32
+          Type: 2 BaseType uint32
     - __kind: GoMapType
-      ID: 144
+      ID: 165
       Name: github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.metaStructMap
       ByteSize: 8
       GoRuntimeType: 1.299296e+06
       GoKind: 21
-      HeaderType: 146 GoSwissMapHeaderType map<string,interface {}>
+      HeaderType: 167 GoSwissMapHeaderType map<string,interface {}>
     - __kind: BaseType
-      ID: 202
+      ID: 221
       Name: github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.samplingDecision
       ByteSize: 4
       GoRuntimeType: 589984
       GoKind: 10
     - __kind: StructureType
-      ID: 172
+      ID: 192
       Name: github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent
       ByteSize: 40
       GoRuntimeType: 1.781184e+06
@@ -1982,18 +1982,18 @@ Types:
       RawFields:
         - Name: Name
           Offset: 0
-          Type: 5 GoStringHeaderType string
+          Type: 9 GoStringHeaderType string
         - Name: TimeUnixNano
           Offset: 16
-          Type: 17 BaseType uint64
+          Type: 8 BaseType uint64
         - Name: Attributes
           Offset: 24
-          Type: 173 GoMapType map[string]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
+          Type: 193 GoMapType map[string]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
         - Name: RawAttributes
           Offset: 32
-          Type: 194 GoMapType map[string]interface {}
+          Type: 214 GoMapType map[string]interface {}
     - __kind: StructureType
-      ID: 188
+      ID: 208
       Name: github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttribute
       ByteSize: 24
       GoRuntimeType: 1.210656e+06
@@ -2001,9 +2001,9 @@ Types:
       RawFields:
         - Name: Values
           Offset: 0
-          Type: 189 GoSliceHeaderType []*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttributeValue
+          Type: 209 GoSliceHeaderType []*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttributeValue
     - __kind: StructureType
-      ID: 192
+      ID: 212
       Name: github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttributeValue
       ByteSize: 48
       GoRuntimeType: 1.868992e+06
@@ -2011,27 +2011,27 @@ Types:
       RawFields:
         - Name: Type
           Offset: 0
-          Type: 193 BaseType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttributeValueType
+          Type: 213 BaseType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttributeValueType
         - Name: StringValue
           Offset: 8
-          Type: 5 GoStringHeaderType string
+          Type: 9 GoStringHeaderType string
         - Name: BoolValue
           Offset: 24
-          Type: 13 BaseType bool
+          Type: 4 BaseType bool
         - Name: IntValue
           Offset: 32
-          Type: 32 BaseType int64
+          Type: 13 BaseType int64
         - Name: DoubleValue
           Offset: 40
-          Type: 166 BaseType float64
+          Type: 18 BaseType float64
     - __kind: BaseType
-      ID: 193
+      ID: 213
       Name: github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttributeValueType
       ByteSize: 4
       GoRuntimeType: 1.001824e+06
       GoKind: 5
     - __kind: StructureType
-      ID: 185
+      ID: 205
       Name: github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
       ByteSize: 56
       GoRuntimeType: 1.946656e+06
@@ -2039,30 +2039,30 @@ Types:
       RawFields:
         - Name: Type
           Offset: 0
-          Type: 186 BaseType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttributeType
+          Type: 206 BaseType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttributeType
         - Name: StringValue
           Offset: 8
-          Type: 5 GoStringHeaderType string
+          Type: 9 GoStringHeaderType string
         - Name: BoolValue
           Offset: 24
-          Type: 13 BaseType bool
+          Type: 4 BaseType bool
         - Name: IntValue
           Offset: 32
-          Type: 32 BaseType int64
+          Type: 13 BaseType int64
         - Name: DoubleValue
           Offset: 40
-          Type: 166 BaseType float64
+          Type: 18 BaseType float64
         - Name: ArrayValue
           Offset: 48
-          Type: 187 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttribute
+          Type: 207 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttribute
     - __kind: BaseType
-      ID: 186
+      ID: 206
       Name: github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttributeType
       ByteSize: 4
       GoRuntimeType: 1.001728e+06
       GoKind: 5
     - __kind: StructureType
-      ID: 198
+      ID: 218
       Name: github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.trace
       ByteSize: 104
       GoRuntimeType: 2.14816e+06
@@ -2070,159 +2070,159 @@ Types:
       RawFields:
         - Name: mu
           Offset: 0
-          Type: 136 StructureType sync.RWMutex
+          Type: 159 StructureType sync.RWMutex
         - Name: spans
           Offset: 24
-          Type: 199 GoSliceHeaderType []*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span
+          Type: 219 GoSliceHeaderType []*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span
         - Name: tags
           Offset: 48
-          Type: 123 GoMapType map[string]string
+          Type: 146 GoMapType map[string]string
         - Name: propagatingTags
           Offset: 56
-          Type: 123 GoMapType map[string]string
+          Type: 146 GoMapType map[string]string
         - Name: finished
           Offset: 64
-          Type: 8 BaseType int
+          Type: 7 BaseType int
         - Name: full
           Offset: 72
-          Type: 13 BaseType bool
+          Type: 4 BaseType bool
         - Name: priority
           Offset: 80
-          Type: 201 PointerType *float64
+          Type: 26 PointerType *float64
         - Name: locked
           Offset: 88
-          Type: 13 BaseType bool
+          Type: 4 BaseType bool
         - Name: samplingDecision
           Offset: 92
-          Type: 202 BaseType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.samplingDecision
+          Type: 221 BaseType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.samplingDecision
         - Name: root
           Offset: 96
-          Type: 134 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span
+          Type: 157 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span
     - __kind: ArrayType
-      ID: 203
+      ID: 222
       Name: github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.traceID
       ByteSize: 16
       GoRuntimeType: 914336
       GoKind: 17
       Count: 16
       HasCount: true
-      Element: 7 BaseType uint8
+      Element: 3 BaseType uint8
     - __kind: GoSwissMapGroupsType
-      ID: 179
+      ID: 199
       Name: groupReference<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 180 PointerType *noalg.map.group[string]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
+          Type: 200 PointerType *noalg.map.group[string]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
         - Name: lengthMask
           Offset: 8
-          Type: 17 BaseType uint64
-      GroupType: 181 StructureType noalg.map.group[string]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
+          Type: 8 BaseType uint64
+      GroupType: 201 StructureType noalg.map.group[string]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
       GroupSliceType: 290 GoSliceDataType []noalg.map.group[string]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute.array
     - __kind: GoSwissMapGroupsType
-      ID: 43
+      ID: 67
       Name: groupReference<string,[]*mime/multipart.FileHeader>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 44 PointerType *noalg.map.group[string][]*mime/multipart.FileHeader
+          Type: 68 PointerType *noalg.map.group[string][]*mime/multipart.FileHeader
         - Name: lengthMask
           Offset: 8
-          Type: 17 BaseType uint64
-      GroupType: 45 StructureType noalg.map.group[string][]*mime/multipart.FileHeader
+          Type: 8 BaseType uint64
+      GroupType: 69 StructureType noalg.map.group[string][]*mime/multipart.FileHeader
       GroupSliceType: 236 GoSliceDataType []noalg.map.group[string][]*mime/multipart.FileHeader.array
     - __kind: GoSwissMapGroupsType
-      ID: 23
+      ID: 49
       Name: groupReference<string,[]string>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 24 PointerType *noalg.map.group[string][]string
+          Type: 50 PointerType *noalg.map.group[string][]string
         - Name: lengthMask
           Offset: 8
-          Type: 17 BaseType uint64
-      GroupType: 25 StructureType noalg.map.group[string][]string
+          Type: 8 BaseType uint64
+      GroupType: 51 StructureType noalg.map.group[string][]string
       GroupSliceType: 232 GoSliceDataType []noalg.map.group[string][]string.array
     - __kind: GoSwissMapGroupsType
-      ID: 161
+      ID: 182
       Name: groupReference<string,float64>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 162 PointerType *noalg.map.group[string]float64
+          Type: 183 PointerType *noalg.map.group[string]float64
         - Name: lengthMask
           Offset: 8
-          Type: 17 BaseType uint64
-      GroupType: 163 StructureType noalg.map.group[string]float64
+          Type: 8 BaseType uint64
+      GroupType: 184 StructureType noalg.map.group[string]float64
       GroupSliceType: 284 GoSliceDataType []noalg.map.group[string]float64.array
     - __kind: GoSwissMapGroupsType
-      ID: 150
+      ID: 171
       Name: groupReference<string,interface {}>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 151 PointerType *noalg.map.group[string]interface {}
+          Type: 172 PointerType *noalg.map.group[string]interface {}
         - Name: lengthMask
           Offset: 8
-          Type: 17 BaseType uint64
-      GroupType: 152 StructureType noalg.map.group[string]interface {}
+          Type: 8 BaseType uint64
+      GroupType: 173 StructureType noalg.map.group[string]interface {}
       GroupSliceType: 282 GoSliceDataType []noalg.map.group[string]interface {}.array
     - __kind: GoSwissMapGroupsType
-      ID: 129
+      ID: 152
       Name: groupReference<string,string>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 130 PointerType *noalg.map.group[string]string
+          Type: 153 PointerType *noalg.map.group[string]string
         - Name: lengthMask
           Offset: 8
-          Type: 17 BaseType uint64
-      GroupType: 131 StructureType noalg.map.group[string]string
+          Type: 8 BaseType uint64
+      GroupType: 154 StructureType noalg.map.group[string]string
       GroupSliceType: 280 GoSliceDataType []noalg.map.group[string]string.array
     - __kind: BaseType
-      ID: 8
+      ID: 7
       Name: int
       ByteSize: 8
       GoRuntimeType: 590752
       GoKind: 2
     - __kind: BaseType
-      ID: 218
+      ID: 23
       Name: int16
       ByteSize: 2
       GoRuntimeType: 590368
       GoKind: 4
     - __kind: BaseType
-      ID: 140
+      ID: 12
       Name: int32
       ByteSize: 4
       GoRuntimeType: 590496
       GoKind: 5
     - __kind: BaseType
-      ID: 32
+      ID: 13
       Name: int64
       ByteSize: 8
       GoRuntimeType: 590624
       GoKind: 6
     - __kind: BaseType
-      ID: 213
+      ID: 16
       Name: int8
       ByteSize: 1
       GoRuntimeType: 590240
       GoKind: 3
     - __kind: GoEmptyInterfaceType
-      ID: 62
+      ID: 86
       Name: interface {}
       ByteSize: 16
       GoRuntimeType: 863072
@@ -2230,12 +2230,12 @@ Types:
       RawFields:
         - Name: _type
           Offset: 0
-          Type: 2 VoidPointerType unsafe.Pointer
+          Type: 15 VoidPointerType unsafe.Pointer
         - Name: data
           Offset: 8
-          Type: 2 VoidPointerType unsafe.Pointer
+          Type: 15 VoidPointerType unsafe.Pointer
     - __kind: StructureType
-      ID: 139
+      ID: 162
       Name: internal/sync.Mutex
       ByteSize: 8
       GoRuntimeType: 1.51232e+06
@@ -2243,12 +2243,12 @@ Types:
       RawFields:
         - Name: state
           Offset: 0
-          Type: 140 BaseType int32
+          Type: 12 BaseType int32
         - Name: sema
           Offset: 4
-          Type: 141 BaseType uint32
+          Type: 2 BaseType uint32
     - __kind: GoInterfaceType
-      ID: 30
+      ID: 55
       Name: io.ReadCloser
       ByteSize: 16
       GoRuntimeType: 1.129632e+06
@@ -2256,246 +2256,246 @@ Types:
       RawFields:
         - Name: tab
           Offset: 0
-          Type: 2 VoidPointerType unsafe.Pointer
+          Type: 15 VoidPointerType unsafe.Pointer
         - Name: data
           Offset: 8
-          Type: 2 VoidPointerType unsafe.Pointer
+          Type: 15 VoidPointerType unsafe.Pointer
     - __kind: GoSwissMapHeaderType
-      ID: 175
+      ID: 195
       Name: map<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
       ByteSize: 48
       GoKind: 25
       RawFields:
         - Name: used
           Offset: 0
-          Type: 17 BaseType uint64
+          Type: 8 BaseType uint64
         - Name: seed
           Offset: 8
-          Type: 18 BaseType uintptr
+          Type: 1 BaseType uintptr
         - Name: dirPtr
           Offset: 16
-          Type: 176 PointerType **table<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
+          Type: 196 PointerType **table<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
         - Name: dirLen
           Offset: 24
-          Type: 8 BaseType int
+          Type: 7 BaseType int
         - Name: globalDepth
           Offset: 32
-          Type: 7 BaseType uint8
+          Type: 3 BaseType uint8
         - Name: globalShift
           Offset: 33
-          Type: 7 BaseType uint8
+          Type: 3 BaseType uint8
         - Name: writing
           Offset: 34
-          Type: 7 BaseType uint8
+          Type: 3 BaseType uint8
         - Name: clearSeq
           Offset: 40
-          Type: 17 BaseType uint64
+          Type: 8 BaseType uint64
       TablePtrSliceType: 289 GoSliceDataType []*table<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>.array
-      GroupType: 181 StructureType noalg.map.group[string]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
+      GroupType: 201 StructureType noalg.map.group[string]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
     - __kind: GoSwissMapHeaderType
-      ID: 39
+      ID: 63
       Name: map<string,[]*mime/multipart.FileHeader>
       ByteSize: 48
       GoKind: 25
       RawFields:
         - Name: used
           Offset: 0
-          Type: 17 BaseType uint64
+          Type: 8 BaseType uint64
         - Name: seed
           Offset: 8
-          Type: 18 BaseType uintptr
+          Type: 1 BaseType uintptr
         - Name: dirPtr
           Offset: 16
-          Type: 40 PointerType **table<string,[]*mime/multipart.FileHeader>
+          Type: 64 PointerType **table<string,[]*mime/multipart.FileHeader>
         - Name: dirLen
           Offset: 24
-          Type: 8 BaseType int
+          Type: 7 BaseType int
         - Name: globalDepth
           Offset: 32
-          Type: 7 BaseType uint8
+          Type: 3 BaseType uint8
         - Name: globalShift
           Offset: 33
-          Type: 7 BaseType uint8
+          Type: 3 BaseType uint8
         - Name: writing
           Offset: 34
-          Type: 7 BaseType uint8
+          Type: 3 BaseType uint8
         - Name: clearSeq
           Offset: 40
-          Type: 17 BaseType uint64
+          Type: 8 BaseType uint64
       TablePtrSliceType: 235 GoSliceDataType []*table<string,[]*mime/multipart.FileHeader>.array
-      GroupType: 45 StructureType noalg.map.group[string][]*mime/multipart.FileHeader
+      GroupType: 69 StructureType noalg.map.group[string][]*mime/multipart.FileHeader
     - __kind: GoSwissMapHeaderType
-      ID: 16
+      ID: 45
       Name: map<string,[]string>
       ByteSize: 48
       GoKind: 25
       RawFields:
         - Name: used
           Offset: 0
-          Type: 17 BaseType uint64
+          Type: 8 BaseType uint64
         - Name: seed
           Offset: 8
-          Type: 18 BaseType uintptr
+          Type: 1 BaseType uintptr
         - Name: dirPtr
           Offset: 16
-          Type: 19 PointerType **table<string,[]string>
+          Type: 46 PointerType **table<string,[]string>
         - Name: dirLen
           Offset: 24
-          Type: 8 BaseType int
+          Type: 7 BaseType int
         - Name: globalDepth
           Offset: 32
-          Type: 7 BaseType uint8
+          Type: 3 BaseType uint8
         - Name: globalShift
           Offset: 33
-          Type: 7 BaseType uint8
+          Type: 3 BaseType uint8
         - Name: writing
           Offset: 34
-          Type: 7 BaseType uint8
+          Type: 3 BaseType uint8
         - Name: clearSeq
           Offset: 40
-          Type: 17 BaseType uint64
+          Type: 8 BaseType uint64
       TablePtrSliceType: 231 GoSliceDataType []*table<string,[]string>.array
-      GroupType: 25 StructureType noalg.map.group[string][]string
+      GroupType: 51 StructureType noalg.map.group[string][]string
     - __kind: GoSwissMapHeaderType
-      ID: 157
+      ID: 178
       Name: map<string,float64>
       ByteSize: 48
       GoKind: 25
       RawFields:
         - Name: used
           Offset: 0
-          Type: 17 BaseType uint64
+          Type: 8 BaseType uint64
         - Name: seed
           Offset: 8
-          Type: 18 BaseType uintptr
+          Type: 1 BaseType uintptr
         - Name: dirPtr
           Offset: 16
-          Type: 158 PointerType **table<string,float64>
+          Type: 179 PointerType **table<string,float64>
         - Name: dirLen
           Offset: 24
-          Type: 8 BaseType int
+          Type: 7 BaseType int
         - Name: globalDepth
           Offset: 32
-          Type: 7 BaseType uint8
+          Type: 3 BaseType uint8
         - Name: globalShift
           Offset: 33
-          Type: 7 BaseType uint8
+          Type: 3 BaseType uint8
         - Name: writing
           Offset: 34
-          Type: 7 BaseType uint8
+          Type: 3 BaseType uint8
         - Name: clearSeq
           Offset: 40
-          Type: 17 BaseType uint64
+          Type: 8 BaseType uint64
       TablePtrSliceType: 283 GoSliceDataType []*table<string,float64>.array
-      GroupType: 163 StructureType noalg.map.group[string]float64
+      GroupType: 184 StructureType noalg.map.group[string]float64
     - __kind: GoSwissMapHeaderType
-      ID: 146
+      ID: 167
       Name: map<string,interface {}>
       ByteSize: 48
       GoKind: 25
       RawFields:
         - Name: used
           Offset: 0
-          Type: 17 BaseType uint64
+          Type: 8 BaseType uint64
         - Name: seed
           Offset: 8
-          Type: 18 BaseType uintptr
+          Type: 1 BaseType uintptr
         - Name: dirPtr
           Offset: 16
-          Type: 147 PointerType **table<string,interface {}>
+          Type: 168 PointerType **table<string,interface {}>
         - Name: dirLen
           Offset: 24
-          Type: 8 BaseType int
+          Type: 7 BaseType int
         - Name: globalDepth
           Offset: 32
-          Type: 7 BaseType uint8
+          Type: 3 BaseType uint8
         - Name: globalShift
           Offset: 33
-          Type: 7 BaseType uint8
+          Type: 3 BaseType uint8
         - Name: writing
           Offset: 34
-          Type: 7 BaseType uint8
+          Type: 3 BaseType uint8
         - Name: clearSeq
           Offset: 40
-          Type: 17 BaseType uint64
+          Type: 8 BaseType uint64
       TablePtrSliceType: 281 GoSliceDataType []*table<string,interface {}>.array
-      GroupType: 152 StructureType noalg.map.group[string]interface {}
+      GroupType: 173 StructureType noalg.map.group[string]interface {}
     - __kind: GoSwissMapHeaderType
-      ID: 125
+      ID: 148
       Name: map<string,string>
       ByteSize: 48
       GoKind: 25
       RawFields:
         - Name: used
           Offset: 0
-          Type: 17 BaseType uint64
+          Type: 8 BaseType uint64
         - Name: seed
           Offset: 8
-          Type: 18 BaseType uintptr
+          Type: 1 BaseType uintptr
         - Name: dirPtr
           Offset: 16
-          Type: 126 PointerType **table<string,string>
+          Type: 149 PointerType **table<string,string>
         - Name: dirLen
           Offset: 24
-          Type: 8 BaseType int
+          Type: 7 BaseType int
         - Name: globalDepth
           Offset: 32
-          Type: 7 BaseType uint8
+          Type: 3 BaseType uint8
         - Name: globalShift
           Offset: 33
-          Type: 7 BaseType uint8
+          Type: 3 BaseType uint8
         - Name: writing
           Offset: 34
-          Type: 7 BaseType uint8
+          Type: 3 BaseType uint8
         - Name: clearSeq
           Offset: 40
-          Type: 17 BaseType uint64
+          Type: 8 BaseType uint64
       TablePtrSliceType: 279 GoSliceDataType []*table<string,string>.array
-      GroupType: 131 StructureType noalg.map.group[string]string
+      GroupType: 154 StructureType noalg.map.group[string]string
     - __kind: GoMapType
-      ID: 173
+      ID: 193
       Name: map[string]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
       ByteSize: 8
       GoRuntimeType: 1.153056e+06
       GoKind: 21
-      HeaderType: 175 GoSwissMapHeaderType map<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
+      HeaderType: 195 GoSwissMapHeaderType map<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
     - __kind: GoMapType
-      ID: 37
+      ID: 61
       Name: map[string][]*mime/multipart.FileHeader
       ByteSize: 8
       GoRuntimeType: 1.152288e+06
       GoKind: 21
-      HeaderType: 39 GoSwissMapHeaderType map<string,[]*mime/multipart.FileHeader>
+      HeaderType: 63 GoSwissMapHeaderType map<string,[]*mime/multipart.FileHeader>
     - __kind: GoMapType
-      ID: 36
+      ID: 60
       Name: map[string][]string
       ByteSize: 8
       GoRuntimeType: 1.14768e+06
       GoKind: 21
-      HeaderType: 16 GoSwissMapHeaderType map<string,[]string>
+      HeaderType: 45 GoSwissMapHeaderType map<string,[]string>
     - __kind: GoMapType
-      ID: 155
+      ID: 176
       Name: map[string]float64
       ByteSize: 8
       GoRuntimeType: 1.152928e+06
       GoKind: 21
-      HeaderType: 157 GoSwissMapHeaderType map<string,float64>
+      HeaderType: 178 GoSwissMapHeaderType map<string,float64>
     - __kind: GoMapType
-      ID: 194
+      ID: 214
       Name: map[string]interface {}
       ByteSize: 8
       GoRuntimeType: 1.146272e+06
       GoKind: 21
-      HeaderType: 146 GoSwissMapHeaderType map<string,interface {}>
+      HeaderType: 167 GoSwissMapHeaderType map<string,interface {}>
     - __kind: GoMapType
-      ID: 123
+      ID: 146
       Name: map[string]string
       ByteSize: 8
       GoRuntimeType: 1.148704e+06
       GoKind: 21
-      HeaderType: 125 GoSwissMapHeaderType map<string,string>
+      HeaderType: 148 GoSwissMapHeaderType map<string,string>
     - __kind: StructureType
-      ID: 64
+      ID: 88
       Name: math/big.Int
       ByteSize: 32
       GoRuntimeType: 1.51744e+06
@@ -2503,18 +2503,18 @@ Types:
       RawFields:
         - Name: neg
           Offset: 0
-          Type: 13 BaseType bool
+          Type: 4 BaseType bool
         - Name: abs
           Offset: 8
-          Type: 65 GoSliceHeaderType math/big.nat
+          Type: 89 GoSliceHeaderType math/big.nat
     - __kind: BaseType
-      ID: 67
+      ID: 91
       Name: math/big.Word
       ByteSize: 8
       GoRuntimeType: 594464
       GoKind: 7
     - __kind: GoSliceHeaderType
-      ID: 65
+      ID: 89
       Name: math/big.nat
       ByteSize: 24
       GoRuntimeType: 2.420864e+06
@@ -2522,21 +2522,21 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 66 PointerType *math/big.Word
+          Type: 90 PointerType *math/big.Word
         - Name: len
           Offset: 8
-          Type: 8 BaseType int
+          Type: 7 BaseType int
         - Name: cap
           Offset: 16
-          Type: 8 BaseType int
+          Type: 7 BaseType int
       Data: 243 GoSliceDataType math/big.nat.array
     - __kind: GoSliceDataType
       ID: 243
       Name: math/big.nat.array
       ByteSize: 2048
-      Element: 67 BaseType math/big.Word
+      Element: 91 BaseType math/big.Word
     - __kind: StructureType
-      ID: 51
+      ID: 75
       Name: mime/multipart.FileHeader
       ByteSize: 88
       GoRuntimeType: 2.009312e+06
@@ -2544,27 +2544,27 @@ Types:
       RawFields:
         - Name: Filename
           Offset: 0
-          Type: 5 GoStringHeaderType string
+          Type: 9 GoStringHeaderType string
         - Name: Header
           Offset: 16
-          Type: 52 GoMapType net/textproto.MIMEHeader
+          Type: 76 GoMapType net/textproto.MIMEHeader
         - Name: Size
           Offset: 24
-          Type: 32 BaseType int64
+          Type: 13 BaseType int64
         - Name: content
           Offset: 32
-          Type: 53 GoSliceHeaderType []uint8
+          Type: 77 GoSliceHeaderType []uint8
         - Name: tmpfile
           Offset: 56
-          Type: 5 GoStringHeaderType string
+          Type: 9 GoStringHeaderType string
         - Name: tmpoff
           Offset: 72
-          Type: 32 BaseType int64
+          Type: 13 BaseType int64
         - Name: tmpshared
           Offset: 80
-          Type: 13 BaseType bool
+          Type: 4 BaseType bool
     - __kind: StructureType
-      ID: 35
+      ID: 59
       Name: mime/multipart.Form
       ByteSize: 16
       GoRuntimeType: 1.5008e+06
@@ -2572,12 +2572,12 @@ Types:
       RawFields:
         - Name: Value
           Offset: 0
-          Type: 36 GoMapType map[string][]string
+          Type: 60 GoMapType map[string][]string
         - Name: File
           Offset: 8
-          Type: 37 GoMapType map[string][]*mime/multipart.FileHeader
+          Type: 61 GoMapType map[string][]*mime/multipart.FileHeader
     - __kind: GoSliceHeaderType
-      ID: 94
+      ID: 117
       Name: net.IP
       ByteSize: 24
       GoRuntimeType: 2.170304e+06
@@ -2585,21 +2585,21 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 6 PointerType *uint8
+          Type: 5 PointerType *uint8
         - Name: len
           Offset: 8
-          Type: 8 BaseType int
+          Type: 7 BaseType int
         - Name: cap
           Offset: 16
-          Type: 8 BaseType int
+          Type: 7 BaseType int
       Data: 261 GoSliceDataType net.IP.array
     - __kind: GoSliceDataType
       ID: 261
       Name: net.IP.array
       ByteSize: 2048
-      Element: 7 BaseType uint8
+      Element: 3 BaseType uint8
     - __kind: GoSliceHeaderType
-      ID: 101
+      ID: 124
       Name: net.IPMask
       ByteSize: 24
       GoRuntimeType: 1.037408e+06
@@ -2607,21 +2607,21 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 6 PointerType *uint8
+          Type: 5 PointerType *uint8
         - Name: len
           Offset: 8
-          Type: 8 BaseType int
+          Type: 7 BaseType int
         - Name: cap
           Offset: 16
-          Type: 8 BaseType int
+          Type: 7 BaseType int
       Data: 267 GoSliceDataType net.IPMask.array
     - __kind: GoSliceDataType
       ID: 267
       Name: net.IPMask.array
       ByteSize: 2048
-      Element: 7 BaseType uint8
+      Element: 3 BaseType uint8
     - __kind: StructureType
-      ID: 100
+      ID: 123
       Name: net.IPNet
       ByteSize: 48
       GoRuntimeType: 1.48176e+06
@@ -2629,19 +2629,19 @@ Types:
       RawFields:
         - Name: IP
           Offset: 0
-          Type: 94 GoSliceHeaderType net.IP
+          Type: 117 GoSliceHeaderType net.IP
         - Name: Mask
           Offset: 24
-          Type: 101 GoSliceHeaderType net.IPMask
+          Type: 124 GoSliceHeaderType net.IPMask
     - __kind: GoMapType
-      ID: 14
+      ID: 43
       Name: net/http.Header
       ByteSize: 8
       GoRuntimeType: 2.147456e+06
       GoKind: 21
-      HeaderType: 16 GoSwissMapHeaderType map<string,[]string>
+      HeaderType: 45 GoSwissMapHeaderType map<string,[]string>
     - __kind: StructureType
-      ID: 4
+      ID: 38
       Name: net/http.Request
       ByteSize: 304
       GoRuntimeType: 2.397408e+06
@@ -2649,84 +2649,84 @@ Types:
       RawFields:
         - Name: Method
           Offset: 0
-          Type: 5 GoStringHeaderType string
+          Type: 9 GoStringHeaderType string
         - Name: URL
           Offset: 16
-          Type: 9 PointerType *net/url.URL
+          Type: 39 PointerType *net/url.URL
         - Name: Proto
           Offset: 24
-          Type: 5 GoStringHeaderType string
+          Type: 9 GoStringHeaderType string
         - Name: ProtoMajor
           Offset: 40
-          Type: 8 BaseType int
+          Type: 7 BaseType int
         - Name: ProtoMinor
           Offset: 48
-          Type: 8 BaseType int
+          Type: 7 BaseType int
         - Name: Header
           Offset: 56
-          Type: 14 GoMapType net/http.Header
+          Type: 43 GoMapType net/http.Header
         - Name: Body
           Offset: 64
-          Type: 30 GoInterfaceType io.ReadCloser
+          Type: 55 GoInterfaceType io.ReadCloser
         - Name: GetBody
           Offset: 80
-          Type: 31 GoSubroutineType func() (io.ReadCloser, error)
+          Type: 56 GoSubroutineType func() (io.ReadCloser, error)
         - Name: ContentLength
           Offset: 88
-          Type: 32 BaseType int64
+          Type: 13 BaseType int64
         - Name: TransferEncoding
           Offset: 96
-          Type: 28 GoSliceHeaderType []string
+          Type: 54 GoSliceHeaderType []string
         - Name: Close
           Offset: 120
-          Type: 13 BaseType bool
+          Type: 4 BaseType bool
         - Name: Host
           Offset: 128
-          Type: 5 GoStringHeaderType string
+          Type: 9 GoStringHeaderType string
         - Name: Form
           Offset: 144
-          Type: 33 GoMapType net/url.Values
+          Type: 57 GoMapType net/url.Values
         - Name: PostForm
           Offset: 152
-          Type: 33 GoMapType net/url.Values
+          Type: 57 GoMapType net/url.Values
         - Name: MultipartForm
           Offset: 160
-          Type: 34 PointerType *mime/multipart.Form
+          Type: 58 PointerType *mime/multipart.Form
         - Name: Trailer
           Offset: 168
-          Type: 14 GoMapType net/http.Header
+          Type: 43 GoMapType net/http.Header
         - Name: RemoteAddr
           Offset: 176
-          Type: 5 GoStringHeaderType string
+          Type: 9 GoStringHeaderType string
         - Name: RequestURI
           Offset: 192
-          Type: 5 GoStringHeaderType string
+          Type: 9 GoStringHeaderType string
         - Name: TLS
           Offset: 208
-          Type: 54 PointerType *crypto/tls.ConnectionState
+          Type: 78 PointerType *crypto/tls.ConnectionState
         - Name: Cancel
           Offset: 216
-          Type: 114 GoChannelType <-chan struct {}
+          Type: 137 GoChannelType <-chan struct {}
         - Name: Response
           Offset: 224
-          Type: 115 PointerType *net/http.Response
+          Type: 138 PointerType *net/http.Response
         - Name: Pattern
           Offset: 232
-          Type: 5 GoStringHeaderType string
+          Type: 9 GoStringHeaderType string
         - Name: ctx
           Offset: 248
-          Type: 117 GoInterfaceType context.Context
+          Type: 140 GoInterfaceType context.Context
         - Name: pat
           Offset: 264
-          Type: 118 PointerType *net/http.pattern
+          Type: 141 PointerType *net/http.pattern
         - Name: matches
           Offset: 272
-          Type: 28 GoSliceHeaderType []string
+          Type: 54 GoSliceHeaderType []string
         - Name: otherValues
           Offset: 296
-          Type: 123 GoMapType map[string]string
+          Type: 146 GoMapType map[string]string
     - __kind: StructureType
-      ID: 116
+      ID: 139
       Name: net/http.Response
       ByteSize: 144
       GoRuntimeType: 2.25968e+06
@@ -2734,48 +2734,48 @@ Types:
       RawFields:
         - Name: Status
           Offset: 0
-          Type: 5 GoStringHeaderType string
+          Type: 9 GoStringHeaderType string
         - Name: StatusCode
           Offset: 16
-          Type: 8 BaseType int
+          Type: 7 BaseType int
         - Name: Proto
           Offset: 24
-          Type: 5 GoStringHeaderType string
+          Type: 9 GoStringHeaderType string
         - Name: ProtoMajor
           Offset: 40
-          Type: 8 BaseType int
+          Type: 7 BaseType int
         - Name: ProtoMinor
           Offset: 48
-          Type: 8 BaseType int
+          Type: 7 BaseType int
         - Name: Header
           Offset: 56
-          Type: 14 GoMapType net/http.Header
+          Type: 43 GoMapType net/http.Header
         - Name: Body
           Offset: 64
-          Type: 30 GoInterfaceType io.ReadCloser
+          Type: 55 GoInterfaceType io.ReadCloser
         - Name: ContentLength
           Offset: 80
-          Type: 32 BaseType int64
+          Type: 13 BaseType int64
         - Name: TransferEncoding
           Offset: 88
-          Type: 28 GoSliceHeaderType []string
+          Type: 54 GoSliceHeaderType []string
         - Name: Close
           Offset: 112
-          Type: 13 BaseType bool
+          Type: 4 BaseType bool
         - Name: Uncompressed
           Offset: 113
-          Type: 13 BaseType bool
+          Type: 4 BaseType bool
         - Name: Trailer
           Offset: 120
-          Type: 14 GoMapType net/http.Header
+          Type: 43 GoMapType net/http.Header
         - Name: Request
           Offset: 128
-          Type: 3 PointerType *net/http.Request
+          Type: 37 PointerType *net/http.Request
         - Name: TLS
           Offset: 136
-          Type: 54 PointerType *crypto/tls.ConnectionState
+          Type: 78 PointerType *crypto/tls.ConnectionState
     - __kind: GoInterfaceType
-      ID: 1
+      ID: 36
       Name: net/http.ResponseWriter
       ByteSize: 16
       GoRuntimeType: 1.206176e+06
@@ -2783,12 +2783,12 @@ Types:
       RawFields:
         - Name: tab
           Offset: 0
-          Type: 2 VoidPointerType unsafe.Pointer
+          Type: 15 VoidPointerType unsafe.Pointer
         - Name: data
           Offset: 8
-          Type: 2 VoidPointerType unsafe.Pointer
+          Type: 15 VoidPointerType unsafe.Pointer
     - __kind: StructureType
-      ID: 119
+      ID: 142
       Name: net/http.pattern
       ByteSize: 88
       GoRuntimeType: 1.865856e+06
@@ -2796,21 +2796,21 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 5 GoStringHeaderType string
+          Type: 9 GoStringHeaderType string
         - Name: method
           Offset: 16
-          Type: 5 GoStringHeaderType string
+          Type: 9 GoStringHeaderType string
         - Name: host
           Offset: 32
-          Type: 5 GoStringHeaderType string
+          Type: 9 GoStringHeaderType string
         - Name: segments
           Offset: 48
-          Type: 120 GoSliceHeaderType []net/http.segment
+          Type: 143 GoSliceHeaderType []net/http.segment
         - Name: loc
           Offset: 72
-          Type: 5 GoStringHeaderType string
+          Type: 9 GoStringHeaderType string
     - __kind: StructureType
-      ID: 122
+      ID: 145
       Name: net/http.segment
       ByteSize: 24
       GoRuntimeType: 1.637088e+06
@@ -2818,22 +2818,22 @@ Types:
       RawFields:
         - Name: s
           Offset: 0
-          Type: 5 GoStringHeaderType string
+          Type: 9 GoStringHeaderType string
         - Name: wild
           Offset: 16
-          Type: 13 BaseType bool
+          Type: 4 BaseType bool
         - Name: multi
           Offset: 17
-          Type: 13 BaseType bool
+          Type: 4 BaseType bool
     - __kind: GoMapType
-      ID: 52
+      ID: 76
       Name: net/textproto.MIMEHeader
       ByteSize: 8
       GoRuntimeType: 1.854368e+06
       GoKind: 21
-      HeaderType: 16 GoSwissMapHeaderType map<string,[]string>
+      HeaderType: 45 GoSwissMapHeaderType map<string,[]string>
     - __kind: StructureType
-      ID: 10
+      ID: 40
       Name: net/url.URL
       ByteSize: 144
       GoRuntimeType: 2.172992e+06
@@ -2841,39 +2841,39 @@ Types:
       RawFields:
         - Name: Scheme
           Offset: 0
-          Type: 5 GoStringHeaderType string
+          Type: 9 GoStringHeaderType string
         - Name: Opaque
           Offset: 16
-          Type: 5 GoStringHeaderType string
+          Type: 9 GoStringHeaderType string
         - Name: User
           Offset: 32
-          Type: 11 PointerType *net/url.Userinfo
+          Type: 41 PointerType *net/url.Userinfo
         - Name: Host
           Offset: 40
-          Type: 5 GoStringHeaderType string
+          Type: 9 GoStringHeaderType string
         - Name: Path
           Offset: 56
-          Type: 5 GoStringHeaderType string
+          Type: 9 GoStringHeaderType string
         - Name: RawPath
           Offset: 72
-          Type: 5 GoStringHeaderType string
+          Type: 9 GoStringHeaderType string
         - Name: OmitHost
           Offset: 88
-          Type: 13 BaseType bool
+          Type: 4 BaseType bool
         - Name: ForceQuery
           Offset: 89
-          Type: 13 BaseType bool
+          Type: 4 BaseType bool
         - Name: RawQuery
           Offset: 96
-          Type: 5 GoStringHeaderType string
+          Type: 9 GoStringHeaderType string
         - Name: Fragment
           Offset: 112
-          Type: 5 GoStringHeaderType string
+          Type: 9 GoStringHeaderType string
         - Name: RawFragment
           Offset: 128
-          Type: 5 GoStringHeaderType string
+          Type: 9 GoStringHeaderType string
     - __kind: StructureType
-      ID: 12
+      ID: 42
       Name: net/url.Userinfo
       ByteSize: 40
       GoRuntimeType: 1.653024e+06
@@ -2881,76 +2881,76 @@ Types:
       RawFields:
         - Name: username
           Offset: 0
-          Type: 5 GoStringHeaderType string
+          Type: 9 GoStringHeaderType string
         - Name: password
           Offset: 16
-          Type: 5 GoStringHeaderType string
+          Type: 9 GoStringHeaderType string
         - Name: passwordSet
           Offset: 32
-          Type: 13 BaseType bool
+          Type: 4 BaseType bool
     - __kind: GoMapType
-      ID: 33
+      ID: 57
       Name: net/url.Values
       ByteSize: 8
       GoRuntimeType: 1.920064e+06
       GoKind: 21
-      HeaderType: 16 GoSwissMapHeaderType map<string,[]string>
+      HeaderType: 45 GoSwissMapHeaderType map<string,[]string>
     - __kind: ArrayType
-      ID: 182
+      ID: 202
       Name: noalg.[8]struct { key string; elem *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute }
       ByteSize: 192
       GoRuntimeType: 711712
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 183 StructureType noalg.struct { key string; elem *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute }
+      Element: 203 StructureType noalg.struct { key string; elem *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute }
     - __kind: ArrayType
-      ID: 46
+      ID: 70
       Name: noalg.[8]struct { key string; elem []*mime/multipart.FileHeader }
       ByteSize: 320
       GoRuntimeType: 707136
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 47 StructureType noalg.struct { key string; elem []*mime/multipart.FileHeader }
+      Element: 71 StructureType noalg.struct { key string; elem []*mime/multipart.FileHeader }
     - __kind: ArrayType
-      ID: 26
+      ID: 52
       Name: noalg.[8]struct { key string; elem []string }
       ByteSize: 320
       GoRuntimeType: 697120
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 27 StructureType noalg.struct { key string; elem []string }
+      Element: 53 StructureType noalg.struct { key string; elem []string }
     - __kind: ArrayType
-      ID: 164
+      ID: 185
       Name: noalg.[8]struct { key string; elem float64 }
       ByteSize: 192
       GoRuntimeType: 711616
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 165 StructureType noalg.struct { key string; elem float64 }
+      Element: 186 StructureType noalg.struct { key string; elem float64 }
     - __kind: ArrayType
-      ID: 153
+      ID: 174
       Name: noalg.[8]struct { key string; elem interface {} }
       ByteSize: 256
       GoRuntimeType: 688576
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 154 StructureType noalg.struct { key string; elem interface {} }
+      Element: 175 StructureType noalg.struct { key string; elem interface {} }
     - __kind: ArrayType
-      ID: 132
+      ID: 155
       Name: noalg.[8]struct { key string; elem string }
       ByteSize: 256
       GoRuntimeType: 701280
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 133 StructureType noalg.struct { key string; elem string }
+      Element: 156 StructureType noalg.struct { key string; elem string }
     - __kind: StructureType
-      ID: 181
+      ID: 201
       Name: noalg.map.group[string]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
       ByteSize: 200
       GoRuntimeType: 1.3272e+06
@@ -2958,12 +2958,12 @@ Types:
       RawFields:
         - Name: ctrl
           Offset: 0
-          Type: 17 BaseType uint64
+          Type: 8 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 182 ArrayType noalg.[8]struct { key string; elem *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute }
+          Type: 202 ArrayType noalg.[8]struct { key string; elem *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute }
     - __kind: StructureType
-      ID: 45
+      ID: 69
       Name: noalg.map.group[string][]*mime/multipart.FileHeader
       ByteSize: 328
       GoRuntimeType: 1.320928e+06
@@ -2971,12 +2971,12 @@ Types:
       RawFields:
         - Name: ctrl
           Offset: 0
-          Type: 17 BaseType uint64
+          Type: 8 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 46 ArrayType noalg.[8]struct { key string; elem []*mime/multipart.FileHeader }
+          Type: 70 ArrayType noalg.[8]struct { key string; elem []*mime/multipart.FileHeader }
     - __kind: StructureType
-      ID: 25
+      ID: 51
       Name: noalg.map.group[string][]string
       ByteSize: 328
       GoRuntimeType: 1.311456e+06
@@ -2984,12 +2984,12 @@ Types:
       RawFields:
         - Name: ctrl
           Offset: 0
-          Type: 17 BaseType uint64
+          Type: 8 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 26 ArrayType noalg.[8]struct { key string; elem []string }
+          Type: 52 ArrayType noalg.[8]struct { key string; elem []string }
     - __kind: StructureType
-      ID: 163
+      ID: 184
       Name: noalg.map.group[string]float64
       ByteSize: 200
       GoRuntimeType: 1.326944e+06
@@ -2997,12 +2997,12 @@ Types:
       RawFields:
         - Name: ctrl
           Offset: 0
-          Type: 17 BaseType uint64
+          Type: 8 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 164 ArrayType noalg.[8]struct { key string; elem float64 }
+          Type: 185 ArrayType noalg.[8]struct { key string; elem float64 }
     - __kind: StructureType
-      ID: 152
+      ID: 173
       Name: noalg.map.group[string]interface {}
       ByteSize: 264
       GoRuntimeType: 1.308896e+06
@@ -3010,12 +3010,12 @@ Types:
       RawFields:
         - Name: ctrl
           Offset: 0
-          Type: 17 BaseType uint64
+          Type: 8 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 153 ArrayType noalg.[8]struct { key string; elem interface {} }
+          Type: 174 ArrayType noalg.[8]struct { key string; elem interface {} }
     - __kind: StructureType
-      ID: 131
+      ID: 154
       Name: noalg.map.group[string]string
       ByteSize: 264
       GoRuntimeType: 1.31376e+06
@@ -3023,12 +3023,12 @@ Types:
       RawFields:
         - Name: ctrl
           Offset: 0
-          Type: 17 BaseType uint64
+          Type: 8 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 132 ArrayType noalg.[8]struct { key string; elem string }
+          Type: 155 ArrayType noalg.[8]struct { key string; elem string }
     - __kind: StructureType
-      ID: 183
+      ID: 203
       Name: noalg.struct { key string; elem *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute }
       ByteSize: 24
       GoRuntimeType: 1.327072e+06
@@ -3036,12 +3036,12 @@ Types:
       RawFields:
         - Name: key
           Offset: 0
-          Type: 5 GoStringHeaderType string
+          Type: 9 GoStringHeaderType string
         - Name: elem
           Offset: 16
-          Type: 184 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
+          Type: 204 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
     - __kind: StructureType
-      ID: 47
+      ID: 71
       Name: noalg.struct { key string; elem []*mime/multipart.FileHeader }
       ByteSize: 40
       GoRuntimeType: 1.3208e+06
@@ -3049,12 +3049,12 @@ Types:
       RawFields:
         - Name: key
           Offset: 0
-          Type: 5 GoStringHeaderType string
+          Type: 9 GoStringHeaderType string
         - Name: elem
           Offset: 16
-          Type: 48 GoSliceHeaderType []*mime/multipart.FileHeader
+          Type: 72 GoSliceHeaderType []*mime/multipart.FileHeader
     - __kind: StructureType
-      ID: 27
+      ID: 53
       Name: noalg.struct { key string; elem []string }
       ByteSize: 40
       GoRuntimeType: 1.311328e+06
@@ -3062,12 +3062,12 @@ Types:
       RawFields:
         - Name: key
           Offset: 0
-          Type: 5 GoStringHeaderType string
+          Type: 9 GoStringHeaderType string
         - Name: elem
           Offset: 16
-          Type: 28 GoSliceHeaderType []string
+          Type: 54 GoSliceHeaderType []string
     - __kind: StructureType
-      ID: 165
+      ID: 186
       Name: noalg.struct { key string; elem float64 }
       ByteSize: 24
       GoRuntimeType: 1.326816e+06
@@ -3075,12 +3075,12 @@ Types:
       RawFields:
         - Name: key
           Offset: 0
-          Type: 5 GoStringHeaderType string
+          Type: 9 GoStringHeaderType string
         - Name: elem
           Offset: 16
-          Type: 166 BaseType float64
+          Type: 18 BaseType float64
     - __kind: StructureType
-      ID: 154
+      ID: 175
       Name: noalg.struct { key string; elem interface {} }
       ByteSize: 32
       GoRuntimeType: 1.308768e+06
@@ -3088,12 +3088,12 @@ Types:
       RawFields:
         - Name: key
           Offset: 0
-          Type: 5 GoStringHeaderType string
+          Type: 9 GoStringHeaderType string
         - Name: elem
           Offset: 16
-          Type: 62 GoEmptyInterfaceType interface {}
+          Type: 86 GoEmptyInterfaceType interface {}
     - __kind: StructureType
-      ID: 133
+      ID: 156
       Name: noalg.struct { key string; elem string }
       ByteSize: 32
       GoRuntimeType: 1.313632e+06
@@ -3101,12 +3101,12 @@ Types:
       RawFields:
         - Name: key
           Offset: 0
-          Type: 5 GoStringHeaderType string
+          Type: 9 GoStringHeaderType string
         - Name: elem
           Offset: 16
-          Type: 5 GoStringHeaderType string
+          Type: 9 GoStringHeaderType string
     - __kind: GoStringHeaderType
-      ID: 5
+      ID: 9
       Name: string
       ByteSize: 16
       GoRuntimeType: 590176
@@ -3117,14 +3117,14 @@ Types:
           Type: 230 PointerType *string.str
         - Name: len
           Offset: 8
-          Type: 8 BaseType int
+          Type: 7 BaseType int
       Data: 229 GoStringDataType string.str
     - __kind: GoStringDataType
       ID: 229
       Name: string.str
       ByteSize: 2048
     - __kind: StructureType
-      ID: 137
+      ID: 160
       Name: sync.Mutex
       ByteSize: 8
       GoRuntimeType: 1.48896e+06
@@ -3132,12 +3132,12 @@ Types:
       RawFields:
         - Name: _
           Offset: 0
-          Type: 138 StructureType sync.noCopy
+          Type: 161 StructureType sync.noCopy
         - Name: mu
           Offset: 0
-          Type: 139 StructureType internal/sync.Mutex
+          Type: 162 StructureType internal/sync.Mutex
     - __kind: StructureType
-      ID: 136
+      ID: 159
       Name: sync.RWMutex
       ByteSize: 24
       GoRuntimeType: 1.87168e+06
@@ -3145,27 +3145,27 @@ Types:
       RawFields:
         - Name: w
           Offset: 0
-          Type: 137 StructureType sync.Mutex
+          Type: 160 StructureType sync.Mutex
         - Name: writerSem
           Offset: 8
-          Type: 141 BaseType uint32
+          Type: 2 BaseType uint32
         - Name: readerSem
           Offset: 12
-          Type: 141 BaseType uint32
+          Type: 2 BaseType uint32
         - Name: readerCount
           Offset: 16
-          Type: 142 StructureType sync/atomic.Int32
+          Type: 163 StructureType sync/atomic.Int32
         - Name: readerWait
           Offset: 20
-          Type: 142 StructureType sync/atomic.Int32
+          Type: 163 StructureType sync/atomic.Int32
     - __kind: StructureType
-      ID: 138
+      ID: 161
       Name: sync.noCopy
       GoRuntimeType: 1.0024e+06
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 142
+      ID: 163
       Name: sync/atomic.Int32
       ByteSize: 4
       GoRuntimeType: 1.49024e+06
@@ -3173,162 +3173,162 @@ Types:
       RawFields:
         - Name: _
           Offset: 0
-          Type: 143 StructureType sync/atomic.noCopy
+          Type: 164 StructureType sync/atomic.noCopy
         - Name: v
           Offset: 0
-          Type: 140 BaseType int32
+          Type: 12 BaseType int32
     - __kind: StructureType
-      ID: 143
+      ID: 164
       Name: sync/atomic.noCopy
       GoRuntimeType: 1.002496e+06
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 178
+      ID: 198
       Name: table<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
       ByteSize: 32
       GoKind: 25
       RawFields:
         - Name: used
           Offset: 0
-          Type: 22 BaseType uint16
+          Type: 6 BaseType uint16
         - Name: capacity
           Offset: 2
-          Type: 22 BaseType uint16
+          Type: 6 BaseType uint16
         - Name: growthLeft
           Offset: 4
-          Type: 22 BaseType uint16
+          Type: 6 BaseType uint16
         - Name: localDepth
           Offset: 6
-          Type: 7 BaseType uint8
+          Type: 3 BaseType uint8
         - Name: index
           Offset: 8
-          Type: 8 BaseType int
+          Type: 7 BaseType int
         - Name: groups
           Offset: 16
-          Type: 179 GoSwissMapGroupsType groupReference<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
+          Type: 199 GoSwissMapGroupsType groupReference<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
     - __kind: StructureType
-      ID: 42
+      ID: 66
       Name: table<string,[]*mime/multipart.FileHeader>
       ByteSize: 32
       GoKind: 25
       RawFields:
         - Name: used
           Offset: 0
-          Type: 22 BaseType uint16
+          Type: 6 BaseType uint16
         - Name: capacity
           Offset: 2
-          Type: 22 BaseType uint16
+          Type: 6 BaseType uint16
         - Name: growthLeft
           Offset: 4
-          Type: 22 BaseType uint16
+          Type: 6 BaseType uint16
         - Name: localDepth
           Offset: 6
-          Type: 7 BaseType uint8
+          Type: 3 BaseType uint8
         - Name: index
           Offset: 8
-          Type: 8 BaseType int
+          Type: 7 BaseType int
         - Name: groups
           Offset: 16
-          Type: 43 GoSwissMapGroupsType groupReference<string,[]*mime/multipart.FileHeader>
+          Type: 67 GoSwissMapGroupsType groupReference<string,[]*mime/multipart.FileHeader>
     - __kind: StructureType
-      ID: 21
+      ID: 48
       Name: table<string,[]string>
       ByteSize: 32
       GoKind: 25
       RawFields:
         - Name: used
           Offset: 0
-          Type: 22 BaseType uint16
+          Type: 6 BaseType uint16
         - Name: capacity
           Offset: 2
-          Type: 22 BaseType uint16
+          Type: 6 BaseType uint16
         - Name: growthLeft
           Offset: 4
-          Type: 22 BaseType uint16
+          Type: 6 BaseType uint16
         - Name: localDepth
           Offset: 6
-          Type: 7 BaseType uint8
+          Type: 3 BaseType uint8
         - Name: index
           Offset: 8
-          Type: 8 BaseType int
+          Type: 7 BaseType int
         - Name: groups
           Offset: 16
-          Type: 23 GoSwissMapGroupsType groupReference<string,[]string>
+          Type: 49 GoSwissMapGroupsType groupReference<string,[]string>
     - __kind: StructureType
-      ID: 160
+      ID: 181
       Name: table<string,float64>
       ByteSize: 32
       GoKind: 25
       RawFields:
         - Name: used
           Offset: 0
-          Type: 22 BaseType uint16
+          Type: 6 BaseType uint16
         - Name: capacity
           Offset: 2
-          Type: 22 BaseType uint16
+          Type: 6 BaseType uint16
         - Name: growthLeft
           Offset: 4
-          Type: 22 BaseType uint16
+          Type: 6 BaseType uint16
         - Name: localDepth
           Offset: 6
-          Type: 7 BaseType uint8
+          Type: 3 BaseType uint8
         - Name: index
           Offset: 8
-          Type: 8 BaseType int
+          Type: 7 BaseType int
         - Name: groups
           Offset: 16
-          Type: 161 GoSwissMapGroupsType groupReference<string,float64>
+          Type: 182 GoSwissMapGroupsType groupReference<string,float64>
     - __kind: StructureType
-      ID: 149
+      ID: 170
       Name: table<string,interface {}>
       ByteSize: 32
       GoKind: 25
       RawFields:
         - Name: used
           Offset: 0
-          Type: 22 BaseType uint16
+          Type: 6 BaseType uint16
         - Name: capacity
           Offset: 2
-          Type: 22 BaseType uint16
+          Type: 6 BaseType uint16
         - Name: growthLeft
           Offset: 4
-          Type: 22 BaseType uint16
+          Type: 6 BaseType uint16
         - Name: localDepth
           Offset: 6
-          Type: 7 BaseType uint8
+          Type: 3 BaseType uint8
         - Name: index
           Offset: 8
-          Type: 8 BaseType int
+          Type: 7 BaseType int
         - Name: groups
           Offset: 16
-          Type: 150 GoSwissMapGroupsType groupReference<string,interface {}>
+          Type: 171 GoSwissMapGroupsType groupReference<string,interface {}>
     - __kind: StructureType
-      ID: 128
+      ID: 151
       Name: table<string,string>
       ByteSize: 32
       GoKind: 25
       RawFields:
         - Name: used
           Offset: 0
-          Type: 22 BaseType uint16
+          Type: 6 BaseType uint16
         - Name: capacity
           Offset: 2
-          Type: 22 BaseType uint16
+          Type: 6 BaseType uint16
         - Name: growthLeft
           Offset: 4
-          Type: 22 BaseType uint16
+          Type: 6 BaseType uint16
         - Name: localDepth
           Offset: 6
-          Type: 7 BaseType uint8
+          Type: 3 BaseType uint8
         - Name: index
           Offset: 8
-          Type: 8 BaseType int
+          Type: 7 BaseType int
         - Name: groups
           Offset: 16
-          Type: 129 GoSwissMapGroupsType groupReference<string,string>
+          Type: 152 GoSwissMapGroupsType groupReference<string,string>
     - __kind: StructureType
-      ID: 76
+      ID: 99
       Name: time.Location
       ByteSize: 104
       GoRuntimeType: 2.00528e+06
@@ -3336,27 +3336,27 @@ Types:
       RawFields:
         - Name: name
           Offset: 0
-          Type: 5 GoStringHeaderType string
+          Type: 9 GoStringHeaderType string
         - Name: zone
           Offset: 16
-          Type: 77 GoSliceHeaderType []time.zone
+          Type: 100 GoSliceHeaderType []time.zone
         - Name: tx
           Offset: 40
-          Type: 80 GoSliceHeaderType []time.zoneTrans
+          Type: 103 GoSliceHeaderType []time.zoneTrans
         - Name: extend
           Offset: 64
-          Type: 5 GoStringHeaderType string
+          Type: 9 GoStringHeaderType string
         - Name: cacheStart
           Offset: 80
-          Type: 32 BaseType int64
+          Type: 13 BaseType int64
         - Name: cacheEnd
           Offset: 88
-          Type: 32 BaseType int64
+          Type: 13 BaseType int64
         - Name: cacheZone
           Offset: 96
-          Type: 78 PointerType *time.zone
+          Type: 101 PointerType *time.zone
     - __kind: StructureType
-      ID: 74
+      ID: 97
       Name: time.Time
       ByteSize: 24
       GoRuntimeType: 2.42368e+06
@@ -3364,15 +3364,15 @@ Types:
       RawFields:
         - Name: wall
           Offset: 0
-          Type: 17 BaseType uint64
+          Type: 8 BaseType uint64
         - Name: ext
           Offset: 8
-          Type: 32 BaseType int64
+          Type: 13 BaseType int64
         - Name: loc
           Offset: 16
-          Type: 75 PointerType *time.Location
+          Type: 98 PointerType *time.Location
     - __kind: StructureType
-      ID: 79
+      ID: 102
       Name: time.zone
       ByteSize: 32
       GoRuntimeType: 1.64208e+06
@@ -3380,15 +3380,15 @@ Types:
       RawFields:
         - Name: name
           Offset: 0
-          Type: 5 GoStringHeaderType string
+          Type: 9 GoStringHeaderType string
         - Name: offset
           Offset: 16
-          Type: 8 BaseType int
+          Type: 7 BaseType int
         - Name: isDST
           Offset: 24
-          Type: 13 BaseType bool
+          Type: 4 BaseType bool
     - __kind: StructureType
-      ID: 82
+      ID: 105
       Name: time.zoneTrans
       ByteSize: 16
       GoRuntimeType: 1.780992e+06
@@ -3396,54 +3396,54 @@ Types:
       RawFields:
         - Name: when
           Offset: 0
-          Type: 32 BaseType int64
+          Type: 13 BaseType int64
         - Name: index
           Offset: 8
-          Type: 7 BaseType uint8
+          Type: 3 BaseType uint8
         - Name: isstd
           Offset: 9
-          Type: 13 BaseType bool
+          Type: 4 BaseType bool
         - Name: isutc
           Offset: 10
-          Type: 13 BaseType bool
+          Type: 4 BaseType bool
     - __kind: BaseType
-      ID: 210
+      ID: 10
       Name: uint
       ByteSize: 8
       GoRuntimeType: 590816
       GoKind: 7
     - __kind: BaseType
-      ID: 22
+      ID: 6
       Name: uint16
       ByteSize: 2
       GoRuntimeType: 590432
       GoKind: 9
     - __kind: BaseType
-      ID: 141
+      ID: 2
       Name: uint32
       ByteSize: 4
       GoRuntimeType: 590560
       GoKind: 10
     - __kind: BaseType
-      ID: 17
+      ID: 8
       Name: uint64
       ByteSize: 8
       GoRuntimeType: 590688
       GoKind: 11
     - __kind: BaseType
-      ID: 7
+      ID: 3
       Name: uint8
       ByteSize: 1
       GoRuntimeType: 590304
       GoKind: 8
     - __kind: BaseType
-      ID: 18
+      ID: 1
       Name: uintptr
       ByteSize: 8
       GoRuntimeType: 590880
       GoKind: 12
     - __kind: VoidPointerType
-      ID: 2
+      ID: 15
       Name: unsafe.Pointer
       ByteSize: 8
       GoRuntimeType: 591264

--- a/pkg/dyninst/irgen/testdata/snapshot/rc_tester.arch=arm64,toolchain=go1.24.3.yaml
+++ b/pkg/dyninst/irgen/testdata/snapshot/rc_tester.arch=arm64,toolchain=go1.24.3.yaml
@@ -10,7 +10,7 @@ Probes:
       subprogram: {subprogram: 1}
       events:
         - ID: 1
-          Type: 303 EventRootType Probe[main.HandleHTTP]
+          Type: 295 EventRootType Probe[main.HandleHTTP]
           InjectionPoints: [{PC: "0x8a0ca0", Frameless: true}]
           Condition: null
     - id: look_at_the_request
@@ -23,7 +23,7 @@ Probes:
       subprogram: {subprogram: 2}
       events:
         - ID: 2
-          Type: 304 EventRootType Probe[main.LookAtTheRequest]
+          Type: 296 EventRootType Probe[main.LookAtTheRequest]
           InjectionPoints: [{PC: "0x8a0f9c", Frameless: true}]
           Condition: null
 Subprograms:
@@ -366,7 +366,7 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 17 BaseType uint64
-      TablePtrSliceType: 243 GoSliceDataType []*table<string,[]string>.array
+      TablePtrSliceType: 231 GoSliceDataType []*table<string,[]string>.array
       GroupType: 25 StructureType noalg.map.group[string][]string
     - __kind: BaseType
       ID: 17
@@ -433,7 +433,7 @@ Types:
           Offset: 8
           Type: 17 BaseType uint64
       GroupType: 25 StructureType noalg.map.group[string][]string
-      GroupSliceType: 244 GoSliceDataType []noalg.map.group[string][]string.array
+      GroupSliceType: 232 GoSliceDataType []noalg.map.group[string][]string.array
     - __kind: PointerType
       ID: 24
       Name: '*noalg.map.group[string][]string'
@@ -599,7 +599,7 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 17 BaseType uint64
-      TablePtrSliceType: 239 GoSliceDataType []*table<string,[]*mime/multipart.FileHeader>.array
+      TablePtrSliceType: 235 GoSliceDataType []*table<string,[]*mime/multipart.FileHeader>.array
       GroupType: 45 StructureType noalg.map.group[string][]*mime/multipart.FileHeader
     - __kind: PointerType
       ID: 40
@@ -648,7 +648,7 @@ Types:
           Offset: 8
           Type: 17 BaseType uint64
       GroupType: 45 StructureType noalg.map.group[string][]*mime/multipart.FileHeader
-      GroupSliceType: 240 GoSliceDataType []noalg.map.group[string][]*mime/multipart.FileHeader.array
+      GroupSliceType: 236 GoSliceDataType []noalg.map.group[string][]*mime/multipart.FileHeader.array
     - __kind: PointerType
       ID: 44
       Name: '*noalg.map.group[string][]*mime/multipart.FileHeader'
@@ -705,7 +705,7 @@ Types:
         - Name: cap
           Offset: 16
           Type: 8 BaseType int
-      Data: 241 GoSliceDataType []*mime/multipart.FileHeader.array
+      Data: 237 GoSliceDataType []*mime/multipart.FileHeader.array
     - __kind: PointerType
       ID: 49
       Name: '**mime/multipart.FileHeader'
@@ -770,7 +770,7 @@ Types:
         - Name: cap
           Offset: 16
           Type: 8 BaseType int
-      Data: 245 GoSliceDataType []uint8.array
+      Data: 239 GoSliceDataType []uint8.array
     - __kind: PointerType
       ID: 54
       Name: '*crypto/tls.ConnectionState'
@@ -849,7 +849,7 @@ Types:
         - Name: cap
           Offset: 16
           Type: 8 BaseType int
-      Data: 247 GoSliceDataType []*crypto/x509.Certificate.array
+      Data: 241 GoSliceDataType []*crypto/x509.Certificate.array
     - __kind: PointerType
       ID: 57
       Name: '**crypto/x509.Certificate'
@@ -1087,7 +1087,7 @@ Types:
         - Name: cap
           Offset: 16
           Type: 8 BaseType int
-      Data: 249 GoSliceDataType math/big.nat.array
+      Data: 243 GoSliceDataType math/big.nat.array
     - __kind: PointerType
       ID: 66
       Name: '*math/big.Word'
@@ -1157,7 +1157,7 @@ Types:
         - Name: cap
           Offset: 16
           Type: 8 BaseType int
-      Data: 251 GoSliceDataType []crypto/x509/pkix.AttributeTypeAndValue.array
+      Data: 245 GoSliceDataType []crypto/x509/pkix.AttributeTypeAndValue.array
     - __kind: PointerType
       ID: 70
       Name: '*crypto/x509/pkix.AttributeTypeAndValue'
@@ -1194,7 +1194,7 @@ Types:
         - Name: cap
           Offset: 16
           Type: 8 BaseType int
-      Data: 253 GoSliceDataType encoding/asn1.ObjectIdentifier.array
+      Data: 247 GoSliceDataType encoding/asn1.ObjectIdentifier.array
     - __kind: PointerType
       ID: 73
       Name: '*int'
@@ -1269,7 +1269,7 @@ Types:
         - Name: cap
           Offset: 16
           Type: 8 BaseType int
-      Data: 255 GoSliceDataType []time.zone.array
+      Data: 249 GoSliceDataType []time.zone.array
     - __kind: PointerType
       ID: 78
       Name: '*time.zone'
@@ -1309,7 +1309,7 @@ Types:
         - Name: cap
           Offset: 16
           Type: 8 BaseType int
-      Data: 257 GoSliceDataType []time.zoneTrans.array
+      Data: 251 GoSliceDataType []time.zoneTrans.array
     - __kind: PointerType
       ID: 81
       Name: '*time.zoneTrans'
@@ -1358,7 +1358,7 @@ Types:
         - Name: cap
           Offset: 16
           Type: 8 BaseType int
-      Data: 259 GoSliceDataType []crypto/x509/pkix.Extension.array
+      Data: 253 GoSliceDataType []crypto/x509/pkix.Extension.array
     - __kind: PointerType
       ID: 85
       Name: '*crypto/x509/pkix.Extension'
@@ -1398,7 +1398,7 @@ Types:
         - Name: cap
           Offset: 16
           Type: 8 BaseType int
-      Data: 261 GoSliceDataType []encoding/asn1.ObjectIdentifier.array
+      Data: 255 GoSliceDataType []encoding/asn1.ObjectIdentifier.array
     - __kind: PointerType
       ID: 88
       Name: '*encoding/asn1.ObjectIdentifier'
@@ -1422,7 +1422,7 @@ Types:
         - Name: cap
           Offset: 16
           Type: 8 BaseType int
-      Data: 263 GoSliceDataType []crypto/x509.ExtKeyUsage.array
+      Data: 257 GoSliceDataType []crypto/x509.ExtKeyUsage.array
     - __kind: PointerType
       ID: 90
       Name: '*crypto/x509.ExtKeyUsage'
@@ -1452,7 +1452,7 @@ Types:
         - Name: cap
           Offset: 16
           Type: 8 BaseType int
-      Data: 265 GoSliceDataType []net.IP.array
+      Data: 259 GoSliceDataType []net.IP.array
     - __kind: PointerType
       ID: 93
       Name: '*net.IP'
@@ -1476,7 +1476,7 @@ Types:
         - Name: cap
           Offset: 16
           Type: 8 BaseType int
-      Data: 267 GoSliceDataType net.IP.array
+      Data: 261 GoSliceDataType net.IP.array
     - __kind: GoSliceHeaderType
       ID: 95
       Name: '[]*net/url.URL'
@@ -1493,7 +1493,7 @@ Types:
         - Name: cap
           Offset: 16
           Type: 8 BaseType int
-      Data: 269 GoSliceDataType []*net/url.URL.array
+      Data: 263 GoSliceDataType []*net/url.URL.array
     - __kind: PointerType
       ID: 96
       Name: '**net/url.URL'
@@ -1515,7 +1515,7 @@ Types:
         - Name: cap
           Offset: 16
           Type: 8 BaseType int
-      Data: 271 GoSliceDataType []*net.IPNet.array
+      Data: 265 GoSliceDataType []*net.IPNet.array
     - __kind: PointerType
       ID: 98
       Name: '**net.IPNet'
@@ -1558,7 +1558,7 @@ Types:
         - Name: cap
           Offset: 16
           Type: 8 BaseType int
-      Data: 273 GoSliceDataType net.IPMask.array
+      Data: 267 GoSliceDataType net.IPMask.array
     - __kind: GoSliceHeaderType
       ID: 102
       Name: '[]crypto/x509.OID'
@@ -1575,7 +1575,7 @@ Types:
         - Name: cap
           Offset: 16
           Type: 8 BaseType int
-      Data: 275 GoSliceDataType []crypto/x509.OID.array
+      Data: 269 GoSliceDataType []crypto/x509.OID.array
     - __kind: PointerType
       ID: 103
       Name: '*crypto/x509.OID'
@@ -1609,7 +1609,7 @@ Types:
         - Name: cap
           Offset: 16
           Type: 8 BaseType int
-      Data: 277 GoSliceDataType []crypto/x509.PolicyMapping.array
+      Data: 271 GoSliceDataType []crypto/x509.PolicyMapping.array
     - __kind: PointerType
       ID: 106
       Name: '*crypto/x509.PolicyMapping'
@@ -1646,7 +1646,7 @@ Types:
         - Name: cap
           Offset: 16
           Type: 8 BaseType int
-      Data: 279 GoSliceDataType [][]*crypto/x509.Certificate.array
+      Data: 273 GoSliceDataType [][]*crypto/x509.Certificate.array
     - __kind: PointerType
       ID: 109
       Name: '*[]*crypto/x509.Certificate'
@@ -1669,7 +1669,7 @@ Types:
         - Name: cap
           Offset: 16
           Type: 8 BaseType int
-      Data: 281 GoSliceDataType [][]uint8.array
+      Data: 275 GoSliceDataType [][]uint8.array
     - __kind: PointerType
       ID: 111
       Name: '*[]uint8'
@@ -1808,7 +1808,7 @@ Types:
         - Name: cap
           Offset: 16
           Type: 8 BaseType int
-      Data: 283 GoSliceDataType []net/http.segment.array
+      Data: 277 GoSliceDataType []net/http.segment.array
     - __kind: PointerType
       ID: 121
       Name: '*net/http.segment'
@@ -1874,7 +1874,7 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 17 BaseType uint64
-      TablePtrSliceType: 285 GoSliceDataType []*table<string,string>.array
+      TablePtrSliceType: 279 GoSliceDataType []*table<string,string>.array
       GroupType: 131 StructureType noalg.map.group[string]string
     - __kind: PointerType
       ID: 126
@@ -1923,7 +1923,7 @@ Types:
           Offset: 8
           Type: 17 BaseType uint64
       GroupType: 131 StructureType noalg.map.group[string]string
-      GroupSliceType: 286 GoSliceDataType []noalg.map.group[string]string.array
+      GroupSliceType: 280 GoSliceDataType []noalg.map.group[string]string.array
     - __kind: PointerType
       ID: 130
       Name: '*noalg.map.group[string]string'
@@ -2180,7 +2180,7 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 17 BaseType uint64
-      TablePtrSliceType: 299 GoSliceDataType []*table<string,interface {}>.array
+      TablePtrSliceType: 281 GoSliceDataType []*table<string,interface {}>.array
       GroupType: 152 StructureType noalg.map.group[string]interface {}
     - __kind: PointerType
       ID: 147
@@ -2229,7 +2229,7 @@ Types:
           Offset: 8
           Type: 17 BaseType uint64
       GroupType: 152 StructureType noalg.map.group[string]interface {}
-      GroupSliceType: 300 GoSliceDataType []noalg.map.group[string]interface {}.array
+      GroupSliceType: 282 GoSliceDataType []noalg.map.group[string]interface {}.array
     - __kind: PointerType
       ID: 151
       Name: '*noalg.map.group[string]interface {}'
@@ -2312,7 +2312,7 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 17 BaseType uint64
-      TablePtrSliceType: 289 GoSliceDataType []*table<string,float64>.array
+      TablePtrSliceType: 283 GoSliceDataType []*table<string,float64>.array
       GroupType: 163 StructureType noalg.map.group[string]float64
     - __kind: PointerType
       ID: 158
@@ -2361,7 +2361,7 @@ Types:
           Offset: 8
           Type: 17 BaseType uint64
       GroupType: 163 StructureType noalg.map.group[string]float64
-      GroupSliceType: 290 GoSliceDataType []noalg.map.group[string]float64.array
+      GroupSliceType: 284 GoSliceDataType []noalg.map.group[string]float64.array
     - __kind: PointerType
       ID: 162
       Name: '*noalg.map.group[string]float64'
@@ -2424,7 +2424,7 @@ Types:
         - Name: cap
           Offset: 16
           Type: 8 BaseType int
-      Data: 291 GoSliceDataType []github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink.array
+      Data: 285 GoSliceDataType []github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink.array
     - __kind: PointerType
       ID: 168
       Name: '*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink'
@@ -2473,7 +2473,7 @@ Types:
         - Name: cap
           Offset: 16
           Type: 8 BaseType int
-      Data: 293 GoSliceDataType []github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent.array
+      Data: 287 GoSliceDataType []github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent.array
     - __kind: PointerType
       ID: 171
       Name: '*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent'
@@ -2542,7 +2542,7 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 17 BaseType uint64
-      TablePtrSliceType: 295 GoSliceDataType []*table<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>.array
+      TablePtrSliceType: 289 GoSliceDataType []*table<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>.array
       GroupType: 181 StructureType noalg.map.group[string]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
     - __kind: PointerType
       ID: 176
@@ -2591,7 +2591,7 @@ Types:
           Offset: 8
           Type: 17 BaseType uint64
       GroupType: 181 StructureType noalg.map.group[string]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
-      GroupSliceType: 296 GoSliceDataType []noalg.map.group[string]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute.array
+      GroupSliceType: 290 GoSliceDataType []noalg.map.group[string]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute.array
     - __kind: PointerType
       ID: 180
       Name: '*noalg.map.group[string]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute'
@@ -2703,7 +2703,7 @@ Types:
         - Name: cap
           Offset: 16
           Type: 8 BaseType int
-      Data: 297 GoSliceDataType []*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttributeValue.array
+      Data: 291 GoSliceDataType []*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttributeValue.array
     - __kind: PointerType
       ID: 190
       Name: '**github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttributeValue'
@@ -2868,7 +2868,7 @@ Types:
         - Name: cap
           Offset: 16
           Type: 8 BaseType int
-      Data: 301 GoSliceDataType []*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span.array
+      Data: 293 GoSliceDataType []*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span.array
     - __kind: PointerType
       ID: 200
       Name: '**github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span'
@@ -3111,346 +3111,306 @@ Types:
       Pointee: 233 GoSliceDataType []string.array
     - __kind: GoSliceDataType
       ID: 235
-      Name: '[]*table<string,[]string>.array'
-      ByteSize: 8192
-      Element: 20 PointerType *table<string,[]string>
-    - __kind: GoSliceDataType
-      ID: 236
-      Name: '[]noalg.map.group[string][]string.array'
-      ByteSize: 2048
-      Element: 25 StructureType noalg.map.group[string][]string
-    - __kind: GoSliceDataType
-      ID: 237
-      Name: '[]*table<string,[]string>.array'
-      ByteSize: 8192
-      Element: 20 PointerType *table<string,[]string>
-    - __kind: GoSliceDataType
-      ID: 238
-      Name: '[]noalg.map.group[string][]string.array'
-      ByteSize: 2048
-      Element: 25 StructureType noalg.map.group[string][]string
-    - __kind: GoSliceDataType
-      ID: 239
       Name: '[]*table<string,[]*mime/multipart.FileHeader>.array'
       ByteSize: 8192
       Element: 41 PointerType *table<string,[]*mime/multipart.FileHeader>
     - __kind: GoSliceDataType
-      ID: 240
+      ID: 236
       Name: '[]noalg.map.group[string][]*mime/multipart.FileHeader.array'
       ByteSize: 2048
       Element: 45 StructureType noalg.map.group[string][]*mime/multipart.FileHeader
     - __kind: GoSliceDataType
-      ID: 241
+      ID: 237
       Name: '[]*mime/multipart.FileHeader.array'
       ByteSize: 2048
       Element: 50 PointerType *mime/multipart.FileHeader
     - __kind: PointerType
-      ID: 242
+      ID: 238
       Name: '*[]*mime/multipart.FileHeader.array'
       ByteSize: 8
-      Pointee: 241 GoSliceDataType []*mime/multipart.FileHeader.array
+      Pointee: 237 GoSliceDataType []*mime/multipart.FileHeader.array
     - __kind: GoSliceDataType
-      ID: 243
-      Name: '[]*table<string,[]string>.array'
-      ByteSize: 8192
-      Element: 20 PointerType *table<string,[]string>
-    - __kind: GoSliceDataType
-      ID: 244
-      Name: '[]noalg.map.group[string][]string.array'
-      ByteSize: 2048
-      Element: 25 StructureType noalg.map.group[string][]string
-    - __kind: GoSliceDataType
-      ID: 245
+      ID: 239
       Name: '[]uint8.array'
       ByteSize: 2048
       Element: 7 BaseType uint8
     - __kind: PointerType
-      ID: 246
+      ID: 240
       Name: '*[]uint8.array'
       ByteSize: 8
-      Pointee: 245 GoSliceDataType []uint8.array
+      Pointee: 239 GoSliceDataType []uint8.array
     - __kind: GoSliceDataType
-      ID: 247
+      ID: 241
       Name: '[]*crypto/x509.Certificate.array'
       ByteSize: 2048
       Element: 58 PointerType *crypto/x509.Certificate
     - __kind: PointerType
-      ID: 248
+      ID: 242
       Name: '*[]*crypto/x509.Certificate.array'
       ByteSize: 8
-      Pointee: 247 GoSliceDataType []*crypto/x509.Certificate.array
+      Pointee: 241 GoSliceDataType []*crypto/x509.Certificate.array
     - __kind: GoSliceDataType
-      ID: 249
+      ID: 243
       Name: math/big.nat.array
       ByteSize: 2048
       Element: 67 BaseType math/big.Word
     - __kind: PointerType
-      ID: 250
+      ID: 244
       Name: '*math/big.nat.array'
       ByteSize: 8
-      Pointee: 249 GoSliceDataType math/big.nat.array
+      Pointee: 243 GoSliceDataType math/big.nat.array
     - __kind: GoSliceDataType
-      ID: 251
+      ID: 245
       Name: '[]crypto/x509/pkix.AttributeTypeAndValue.array'
       ByteSize: 2048
       Element: 71 StructureType crypto/x509/pkix.AttributeTypeAndValue
     - __kind: PointerType
-      ID: 252
+      ID: 246
       Name: '*[]crypto/x509/pkix.AttributeTypeAndValue.array'
       ByteSize: 8
-      Pointee: 251 GoSliceDataType []crypto/x509/pkix.AttributeTypeAndValue.array
+      Pointee: 245 GoSliceDataType []crypto/x509/pkix.AttributeTypeAndValue.array
     - __kind: GoSliceDataType
-      ID: 253
+      ID: 247
       Name: encoding/asn1.ObjectIdentifier.array
       ByteSize: 2048
       Element: 8 BaseType int
     - __kind: PointerType
-      ID: 254
+      ID: 248
       Name: '*encoding/asn1.ObjectIdentifier.array'
       ByteSize: 8
-      Pointee: 253 GoSliceDataType encoding/asn1.ObjectIdentifier.array
+      Pointee: 247 GoSliceDataType encoding/asn1.ObjectIdentifier.array
     - __kind: GoSliceDataType
-      ID: 255
+      ID: 249
       Name: '[]time.zone.array'
       ByteSize: 2048
       Element: 79 StructureType time.zone
     - __kind: PointerType
-      ID: 256
+      ID: 250
       Name: '*[]time.zone.array'
       ByteSize: 8
-      Pointee: 255 GoSliceDataType []time.zone.array
+      Pointee: 249 GoSliceDataType []time.zone.array
     - __kind: GoSliceDataType
-      ID: 257
+      ID: 251
       Name: '[]time.zoneTrans.array'
       ByteSize: 2048
       Element: 82 StructureType time.zoneTrans
     - __kind: PointerType
-      ID: 258
+      ID: 252
       Name: '*[]time.zoneTrans.array'
       ByteSize: 8
-      Pointee: 257 GoSliceDataType []time.zoneTrans.array
+      Pointee: 251 GoSliceDataType []time.zoneTrans.array
     - __kind: GoSliceDataType
-      ID: 259
+      ID: 253
       Name: '[]crypto/x509/pkix.Extension.array'
       ByteSize: 2048
       Element: 86 StructureType crypto/x509/pkix.Extension
     - __kind: PointerType
-      ID: 260
+      ID: 254
       Name: '*[]crypto/x509/pkix.Extension.array'
       ByteSize: 8
-      Pointee: 259 GoSliceDataType []crypto/x509/pkix.Extension.array
+      Pointee: 253 GoSliceDataType []crypto/x509/pkix.Extension.array
     - __kind: GoSliceDataType
-      ID: 261
+      ID: 255
       Name: '[]encoding/asn1.ObjectIdentifier.array'
       ByteSize: 2048
       Element: 72 GoSliceHeaderType encoding/asn1.ObjectIdentifier
     - __kind: PointerType
-      ID: 262
+      ID: 256
       Name: '*[]encoding/asn1.ObjectIdentifier.array'
       ByteSize: 8
-      Pointee: 261 GoSliceDataType []encoding/asn1.ObjectIdentifier.array
+      Pointee: 255 GoSliceDataType []encoding/asn1.ObjectIdentifier.array
     - __kind: GoSliceDataType
-      ID: 263
+      ID: 257
       Name: '[]crypto/x509.ExtKeyUsage.array'
       ByteSize: 2048
       Element: 91 BaseType crypto/x509.ExtKeyUsage
     - __kind: PointerType
-      ID: 264
+      ID: 258
       Name: '*[]crypto/x509.ExtKeyUsage.array'
       ByteSize: 8
-      Pointee: 263 GoSliceDataType []crypto/x509.ExtKeyUsage.array
+      Pointee: 257 GoSliceDataType []crypto/x509.ExtKeyUsage.array
     - __kind: GoSliceDataType
-      ID: 265
+      ID: 259
       Name: '[]net.IP.array'
       ByteSize: 2048
       Element: 94 GoSliceHeaderType net.IP
     - __kind: PointerType
-      ID: 266
+      ID: 260
       Name: '*[]net.IP.array'
       ByteSize: 8
-      Pointee: 265 GoSliceDataType []net.IP.array
+      Pointee: 259 GoSliceDataType []net.IP.array
     - __kind: GoSliceDataType
-      ID: 267
+      ID: 261
       Name: net.IP.array
       ByteSize: 2048
       Element: 7 BaseType uint8
     - __kind: PointerType
-      ID: 268
+      ID: 262
       Name: '*net.IP.array'
       ByteSize: 8
-      Pointee: 267 GoSliceDataType net.IP.array
+      Pointee: 261 GoSliceDataType net.IP.array
     - __kind: GoSliceDataType
-      ID: 269
+      ID: 263
       Name: '[]*net/url.URL.array'
       ByteSize: 2048
       Element: 9 PointerType *net/url.URL
     - __kind: PointerType
-      ID: 270
+      ID: 264
       Name: '*[]*net/url.URL.array'
       ByteSize: 8
-      Pointee: 269 GoSliceDataType []*net/url.URL.array
+      Pointee: 263 GoSliceDataType []*net/url.URL.array
     - __kind: GoSliceDataType
-      ID: 271
+      ID: 265
       Name: '[]*net.IPNet.array'
       ByteSize: 2048
       Element: 99 PointerType *net.IPNet
     - __kind: PointerType
-      ID: 272
+      ID: 266
       Name: '*[]*net.IPNet.array'
       ByteSize: 8
-      Pointee: 271 GoSliceDataType []*net.IPNet.array
+      Pointee: 265 GoSliceDataType []*net.IPNet.array
     - __kind: GoSliceDataType
-      ID: 273
+      ID: 267
       Name: net.IPMask.array
       ByteSize: 2048
       Element: 7 BaseType uint8
     - __kind: PointerType
-      ID: 274
+      ID: 268
       Name: '*net.IPMask.array'
       ByteSize: 8
-      Pointee: 273 GoSliceDataType net.IPMask.array
+      Pointee: 267 GoSliceDataType net.IPMask.array
     - __kind: GoSliceDataType
-      ID: 275
+      ID: 269
       Name: '[]crypto/x509.OID.array'
       ByteSize: 2048
       Element: 104 StructureType crypto/x509.OID
     - __kind: PointerType
-      ID: 276
+      ID: 270
       Name: '*[]crypto/x509.OID.array'
       ByteSize: 8
-      Pointee: 275 GoSliceDataType []crypto/x509.OID.array
+      Pointee: 269 GoSliceDataType []crypto/x509.OID.array
     - __kind: GoSliceDataType
-      ID: 277
+      ID: 271
       Name: '[]crypto/x509.PolicyMapping.array'
       ByteSize: 2048
       Element: 107 StructureType crypto/x509.PolicyMapping
     - __kind: PointerType
-      ID: 278
+      ID: 272
       Name: '*[]crypto/x509.PolicyMapping.array'
       ByteSize: 8
-      Pointee: 277 GoSliceDataType []crypto/x509.PolicyMapping.array
+      Pointee: 271 GoSliceDataType []crypto/x509.PolicyMapping.array
     - __kind: GoSliceDataType
-      ID: 279
+      ID: 273
       Name: '[][]*crypto/x509.Certificate.array'
       ByteSize: 2048
       Element: 56 GoSliceHeaderType []*crypto/x509.Certificate
     - __kind: PointerType
-      ID: 280
+      ID: 274
       Name: '*[][]*crypto/x509.Certificate.array'
       ByteSize: 8
-      Pointee: 279 GoSliceDataType [][]*crypto/x509.Certificate.array
+      Pointee: 273 GoSliceDataType [][]*crypto/x509.Certificate.array
     - __kind: GoSliceDataType
-      ID: 281
+      ID: 275
       Name: '[][]uint8.array'
       ByteSize: 2048
       Element: 53 GoSliceHeaderType []uint8
     - __kind: PointerType
-      ID: 282
+      ID: 276
       Name: '*[][]uint8.array'
       ByteSize: 8
-      Pointee: 281 GoSliceDataType [][]uint8.array
+      Pointee: 275 GoSliceDataType [][]uint8.array
     - __kind: GoSliceDataType
-      ID: 283
+      ID: 277
       Name: '[]net/http.segment.array'
       ByteSize: 2048
       Element: 122 StructureType net/http.segment
     - __kind: PointerType
-      ID: 284
+      ID: 278
       Name: '*[]net/http.segment.array'
       ByteSize: 8
-      Pointee: 283 GoSliceDataType []net/http.segment.array
+      Pointee: 277 GoSliceDataType []net/http.segment.array
     - __kind: GoSliceDataType
-      ID: 285
+      ID: 279
       Name: '[]*table<string,string>.array'
       ByteSize: 8192
       Element: 127 PointerType *table<string,string>
     - __kind: GoSliceDataType
-      ID: 286
+      ID: 280
       Name: '[]noalg.map.group[string]string.array'
       ByteSize: 2048
       Element: 131 StructureType noalg.map.group[string]string
     - __kind: GoSliceDataType
-      ID: 287
+      ID: 281
       Name: '[]*table<string,interface {}>.array'
       ByteSize: 8192
       Element: 148 PointerType *table<string,interface {}>
     - __kind: GoSliceDataType
-      ID: 288
+      ID: 282
       Name: '[]noalg.map.group[string]interface {}.array'
       ByteSize: 2048
       Element: 152 StructureType noalg.map.group[string]interface {}
     - __kind: GoSliceDataType
-      ID: 289
+      ID: 283
       Name: '[]*table<string,float64>.array'
       ByteSize: 8192
       Element: 159 PointerType *table<string,float64>
     - __kind: GoSliceDataType
-      ID: 290
+      ID: 284
       Name: '[]noalg.map.group[string]float64.array'
       ByteSize: 2048
       Element: 163 StructureType noalg.map.group[string]float64
     - __kind: GoSliceDataType
-      ID: 291
+      ID: 285
       Name: '[]github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink.array'
       ByteSize: 2048
       Element: 169 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink
     - __kind: PointerType
-      ID: 292
+      ID: 286
       Name: '*[]github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink.array'
       ByteSize: 8
-      Pointee: 291 GoSliceDataType []github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink.array
+      Pointee: 285 GoSliceDataType []github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink.array
     - __kind: GoSliceDataType
-      ID: 293
+      ID: 287
       Name: '[]github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent.array'
       ByteSize: 2048
       Element: 172 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent
     - __kind: PointerType
-      ID: 294
+      ID: 288
       Name: '*[]github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent.array'
       ByteSize: 8
-      Pointee: 293 GoSliceDataType []github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent.array
+      Pointee: 287 GoSliceDataType []github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent.array
     - __kind: GoSliceDataType
-      ID: 295
+      ID: 289
       Name: '[]*table<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>.array'
       ByteSize: 8192
       Element: 177 PointerType *table<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
     - __kind: GoSliceDataType
-      ID: 296
+      ID: 290
       Name: '[]noalg.map.group[string]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute.array'
       ByteSize: 2048
       Element: 181 StructureType noalg.map.group[string]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
     - __kind: GoSliceDataType
-      ID: 297
+      ID: 291
       Name: '[]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttributeValue.array'
       ByteSize: 2048
       Element: 191 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttributeValue
     - __kind: PointerType
-      ID: 298
+      ID: 292
       Name: '*[]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttributeValue.array'
       ByteSize: 8
-      Pointee: 297 GoSliceDataType []*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttributeValue.array
+      Pointee: 291 GoSliceDataType []*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttributeValue.array
     - __kind: GoSliceDataType
-      ID: 299
-      Name: '[]*table<string,interface {}>.array'
-      ByteSize: 8192
-      Element: 148 PointerType *table<string,interface {}>
-    - __kind: GoSliceDataType
-      ID: 300
-      Name: '[]noalg.map.group[string]interface {}.array'
-      ByteSize: 2048
-      Element: 152 StructureType noalg.map.group[string]interface {}
-    - __kind: GoSliceDataType
-      ID: 301
+      ID: 293
       Name: '[]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span.array'
       ByteSize: 2048
       Element: 134 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span
     - __kind: PointerType
-      ID: 302
+      ID: 294
       Name: '*[]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span.array'
       ByteSize: 8
-      Pointee: 301 GoSliceDataType []*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span.array
+      Pointee: 293 GoSliceDataType []*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span.array
     - __kind: EventRootType
-      ID: 303
+      ID: 295
       Name: Probe[main.HandleHTTP]
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -3474,7 +3434,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 304
+      ID: 296
       Name: Probe[main.LookAtTheRequest]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -3488,6 +3448,6 @@ Types:
                   Variable: {subprogram: 2, index: 0, name: path}
                   Offset: 0
                   ByteSize: 16
-MaxTypeID: 304
+MaxTypeID: 296
 Issues: []
 GoModuledataInfo: {FirstModuledataAddr: "0x13dd6a0", TypesOffset: 296}

--- a/pkg/dyninst/irgen/testdata/snapshot/rc_tester.arch=arm64,toolchain=go1.25.0.yaml
+++ b/pkg/dyninst/irgen/testdata/snapshot/rc_tester.arch=arm64,toolchain=go1.25.0.yaml
@@ -33,7 +33,7 @@ Subprograms:
       InlinePCRanges: []
       Variables:
         - Name: w
-          Type: 1 GoInterfaceType net/http.ResponseWriter
+          Type: 36 GoInterfaceType net/http.ResponseWriter
           Locations:
             - Range: 0x859970..0x8599c4
               Pieces:
@@ -56,7 +56,7 @@ Subprograms:
           IsParameter: true
           IsReturn: false
         - Name: r
-          Type: 3 PointerType *net/http.Request
+          Type: 37 PointerType *net/http.Request
           Locations:
             - Range: 0x859970..0x8599d0
               Pieces: [{Size: 8, Op: {RegNo: 2, Shift: 0}}]
@@ -65,14 +65,14 @@ Subprograms:
           IsParameter: true
           IsReturn: false
         - Name: span
-          Type: 135 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span
+          Type: 158 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span
           Locations:
             - Range: 0x8599e4..0x859a14
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: false
           IsReturn: false
         - Name: '&buf'
-          Type: 206 PointerType *bytes.Buffer
+          Type: 225 PointerType *bytes.Buffer
           Locations:
             - Range: 0x859aa0..0x859ab8
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
@@ -86,7 +86,7 @@ Subprograms:
       InlinePCRanges: []
       Variables:
         - Name: path
-          Type: 5 GoStringHeaderType string
+          Type: 9 GoStringHeaderType string
           Locations:
             - Range: 0x859c50..0x859c74
               Pieces:
@@ -98,76 +98,76 @@ Subprograms:
           IsReturn: false
 Types:
     - __kind: PointerType
-      ID: 58
+      ID: 82
       Name: '**crypto/x509.Certificate'
       ByteSize: 8
       GoKind: 22
-      Pointee: 59 PointerType *crypto/x509.Certificate
+      Pointee: 83 PointerType *crypto/x509.Certificate
     - __kind: PointerType
-      ID: 201
+      ID: 221
       Name: '**github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span'
       ByteSize: 8
       GoKind: 22
-      Pointee: 135 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span
+      Pointee: 158 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span
     - __kind: PointerType
-      ID: 191
+      ID: 211
       Name: '**github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttributeValue'
       ByteSize: 8
       GoKind: 22
-      Pointee: 192 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttributeValue
+      Pointee: 212 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttributeValue
     - __kind: PointerType
-      ID: 49
+      ID: 73
       Name: '**mime/multipart.FileHeader'
       ByteSize: 8
       GoKind: 22
-      Pointee: 50 PointerType *mime/multipart.FileHeader
+      Pointee: 74 PointerType *mime/multipart.FileHeader
     - __kind: PointerType
-      ID: 99
+      ID: 122
       Name: '**net.IPNet'
       ByteSize: 8
       GoKind: 22
-      Pointee: 100 PointerType *net.IPNet
+      Pointee: 123 PointerType *net.IPNet
     - __kind: PointerType
-      ID: 97
+      ID: 120
       Name: '**net/url.URL'
       ByteSize: 8
-      Pointee: 9 PointerType *net/url.URL
+      Pointee: 39 PointerType *net/url.URL
     - __kind: PointerType
-      ID: 177
+      ID: 197
       Name: '**table<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>'
       ByteSize: 8
-      Pointee: 178 PointerType *table<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
+      Pointee: 198 PointerType *table<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
     - __kind: PointerType
-      ID: 40
+      ID: 64
       Name: '**table<string,[]*mime/multipart.FileHeader>'
       ByteSize: 8
-      Pointee: 41 PointerType *table<string,[]*mime/multipart.FileHeader>
+      Pointee: 65 PointerType *table<string,[]*mime/multipart.FileHeader>
     - __kind: PointerType
-      ID: 19
+      ID: 46
       Name: '**table<string,[]string>'
       ByteSize: 8
-      Pointee: 20 PointerType *table<string,[]string>
+      Pointee: 47 PointerType *table<string,[]string>
     - __kind: PointerType
-      ID: 159
+      ID: 180
       Name: '**table<string,float64>'
       ByteSize: 8
-      Pointee: 160 PointerType *table<string,float64>
+      Pointee: 181 PointerType *table<string,float64>
     - __kind: PointerType
-      ID: 148
+      ID: 169
       Name: '**table<string,interface {}>'
       ByteSize: 8
-      Pointee: 149 PointerType *table<string,interface {}>
+      Pointee: 170 PointerType *table<string,interface {}>
     - __kind: PointerType
-      ID: 127
+      ID: 150
       Name: '**table<string,string>'
       ByteSize: 8
-      Pointee: 128 PointerType *table<string,string>
+      Pointee: 151 PointerType *table<string,string>
     - __kind: PointerType
-      ID: 110
+      ID: 133
       Name: '*[]*crypto/x509.Certificate'
       ByteSize: 8
       GoKind: 22
-      Pointee: 57 GoSliceHeaderType []*crypto/x509.Certificate
+      Pointee: 81 GoSliceHeaderType []*crypto/x509.Certificate
     - __kind: PointerType
       ID: 241
       Name: '*[]*crypto/x509.Certificate.array'
@@ -274,274 +274,274 @@ Types:
       ByteSize: 8
       Pointee: 250 GoSliceDataType []time.zoneTrans.array
     - __kind: PointerType
-      ID: 112
+      ID: 135
       Name: '*[]uint8'
       ByteSize: 8
       GoRuntimeType: 486400
       GoKind: 22
-      Pointee: 53 GoSliceHeaderType []uint8
+      Pointee: 77 GoSliceHeaderType []uint8
     - __kind: PointerType
       ID: 239
       Name: '*[]uint8.array'
       ByteSize: 8
       Pointee: 238 GoSliceDataType []uint8.array
     - __kind: PointerType
-      ID: 210
+      ID: 11
       Name: '*bool'
       ByteSize: 8
       GoRuntimeType: 405376
       GoKind: 22
-      Pointee: 13 BaseType bool
+      Pointee: 4 BaseType bool
     - __kind: PointerType
-      ID: 206
+      ID: 225
       Name: '*bytes.Buffer'
       ByteSize: 8
       GoRuntimeType: 2.320608e+06
       GoKind: 22
-      Pointee: 207 StructureType bytes.Buffer
+      Pointee: 226 StructureType bytes.Buffer
     - __kind: PointerType
-      ID: 54
+      ID: 78
       Name: '*crypto/tls.ConnectionState'
       ByteSize: 8
       GoRuntimeType: 923424
       GoKind: 22
-      Pointee: 55 StructureType crypto/tls.ConnectionState
+      Pointee: 79 StructureType crypto/tls.ConnectionState
     - __kind: PointerType
-      ID: 59
+      ID: 83
       Name: '*crypto/x509.Certificate'
       ByteSize: 8
       GoRuntimeType: 2.088896e+06
       GoKind: 22
-      Pointee: 60 StructureType crypto/x509.Certificate
+      Pointee: 84 StructureType crypto/x509.Certificate
     - __kind: PointerType
-      ID: 91
+      ID: 114
       Name: '*crypto/x509.ExtKeyUsage'
       ByteSize: 8
       GoRuntimeType: 429824
       GoKind: 22
-      Pointee: 92 BaseType crypto/x509.ExtKeyUsage
+      Pointee: 115 BaseType crypto/x509.ExtKeyUsage
     - __kind: PointerType
-      ID: 104
+      ID: 127
       Name: '*crypto/x509.OID'
       ByteSize: 8
       GoRuntimeType: 1.997344e+06
       GoKind: 22
-      Pointee: 105 StructureType crypto/x509.OID
+      Pointee: 128 StructureType crypto/x509.OID
     - __kind: PointerType
-      ID: 107
+      ID: 130
       Name: '*crypto/x509.PolicyMapping'
       ByteSize: 8
       GoRuntimeType: 429888
       GoKind: 22
-      Pointee: 108 StructureType crypto/x509.PolicyMapping
+      Pointee: 131 StructureType crypto/x509.PolicyMapping
     - __kind: PointerType
-      ID: 71
+      ID: 95
       Name: '*crypto/x509/pkix.AttributeTypeAndValue'
       ByteSize: 8
       GoRuntimeType: 446528
       GoKind: 22
-      Pointee: 72 StructureType crypto/x509/pkix.AttributeTypeAndValue
+      Pointee: 96 StructureType crypto/x509/pkix.AttributeTypeAndValue
     - __kind: PointerType
-      ID: 86
+      ID: 109
       Name: '*crypto/x509/pkix.Extension'
       ByteSize: 8
       GoRuntimeType: 446720
       GoKind: 22
-      Pointee: 87 StructureType crypto/x509/pkix.Extension
+      Pointee: 110 StructureType crypto/x509/pkix.Extension
     - __kind: PointerType
-      ID: 89
+      ID: 112
       Name: '*encoding/asn1.ObjectIdentifier'
       ByteSize: 8
       GoRuntimeType: 1.079072e+06
       GoKind: 22
-      Pointee: 73 GoSliceHeaderType encoding/asn1.ObjectIdentifier
+      Pointee: 97 GoSliceHeaderType encoding/asn1.ObjectIdentifier
     - __kind: PointerType
       ID: 247
       Name: '*encoding/asn1.ObjectIdentifier.array'
       ByteSize: 8
       Pointee: 246 GoSliceDataType encoding/asn1.ObjectIdentifier.array
     - __kind: PointerType
-      ID: 225
+      ID: 33
       Name: '*error'
       ByteSize: 8
       GoRuntimeType: 404288
       GoKind: 22
-      Pointee: 211 GoInterfaceType error
+      Pointee: 14 GoInterfaceType error
     - __kind: PointerType
-      ID: 227
+      ID: 35
       Name: '*float32'
       ByteSize: 8
       GoRuntimeType: 405248
       GoKind: 22
-      Pointee: 213 BaseType float32
+      Pointee: 18 BaseType float32
     - __kind: PointerType
-      ID: 202
+      ID: 26
       Name: '*float64'
       ByteSize: 8
       GoRuntimeType: 405312
       GoKind: 22
-      Pointee: 167 BaseType float64
+      Pointee: 16 BaseType float64
     - __kind: PointerType
-      ID: 135
+      ID: 158
       Name: '*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span'
       ByteSize: 8
       GoRuntimeType: 2.331872e+06
       GoKind: 22
-      Pointee: 136 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span
+      Pointee: 159 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span
     - __kind: PointerType
-      ID: 196
+      ID: 216
       Name: '*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanContext'
       ByteSize: 8
       GoRuntimeType: 2.053568e+06
       GoKind: 22
-      Pointee: 197 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanContext
+      Pointee: 217 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanContext
     - __kind: PointerType
-      ID: 169
+      ID: 189
       Name: '*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink'
       ByteSize: 8
       GoRuntimeType: 1.213856e+06
       GoKind: 22
-      Pointee: 170 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink
+      Pointee: 190 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink
     - __kind: PointerType
-      ID: 172
+      ID: 192
       Name: '*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent'
       ByteSize: 8
       GoRuntimeType: 1.213984e+06
       GoKind: 22
-      Pointee: 173 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent
+      Pointee: 193 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent
     - __kind: PointerType
-      ID: 188
+      ID: 208
       Name: '*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttribute'
       ByteSize: 8
       GoRuntimeType: 1.214624e+06
       GoKind: 22
-      Pointee: 189 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttribute
+      Pointee: 209 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttribute
     - __kind: PointerType
-      ID: 192
+      ID: 212
       Name: '*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttributeValue'
       ByteSize: 8
       GoRuntimeType: 1.214368e+06
       GoKind: 22
-      Pointee: 193 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttributeValue
+      Pointee: 213 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttributeValue
     - __kind: PointerType
-      ID: 185
+      ID: 205
       Name: '*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute'
       ByteSize: 8
       GoRuntimeType: 1.214752e+06
       GoKind: 22
-      Pointee: 186 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
+      Pointee: 206 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
     - __kind: PointerType
-      ID: 198
+      ID: 218
       Name: '*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.trace'
       ByteSize: 8
       GoRuntimeType: 2.2768e+06
       GoKind: 22
-      Pointee: 199 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.trace
+      Pointee: 219 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.trace
     - __kind: PointerType
-      ID: 74
+      ID: 27
       Name: '*int'
       ByteSize: 8
       GoRuntimeType: 404928
       GoKind: 22
-      Pointee: 8 BaseType int
+      Pointee: 7 BaseType int
     - __kind: PointerType
-      ID: 223
+      ID: 31
       Name: '*int16'
       ByteSize: 8
       GoRuntimeType: 404544
       GoKind: 22
-      Pointee: 217 BaseType int16
+      Pointee: 23 BaseType int16
     - __kind: PointerType
-      ID: 215
+      ID: 20
       Name: '*int32'
       ByteSize: 8
       GoRuntimeType: 404672
       GoKind: 22
-      Pointee: 141 BaseType int32
+      Pointee: 12 BaseType int32
     - __kind: PointerType
-      ID: 221
+      ID: 29
       Name: '*int64'
       ByteSize: 8
       GoRuntimeType: 404800
       GoKind: 22
-      Pointee: 32 BaseType int64
+      Pointee: 13 BaseType int64
     - __kind: PointerType
-      ID: 224
+      ID: 32
       Name: '*int8'
       ByteSize: 8
       GoRuntimeType: 404416
       GoKind: 22
-      Pointee: 212 BaseType int8
+      Pointee: 17 BaseType int8
     - __kind: PointerType
-      ID: 175
+      ID: 195
       Name: '*map<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>'
       ByteSize: 8
-      Pointee: 176 GoSwissMapHeaderType map<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
+      Pointee: 196 GoSwissMapHeaderType map<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
     - __kind: PointerType
-      ID: 38
+      ID: 62
       Name: '*map<string,[]*mime/multipart.FileHeader>'
       ByteSize: 8
-      Pointee: 39 GoSwissMapHeaderType map<string,[]*mime/multipart.FileHeader>
+      Pointee: 63 GoSwissMapHeaderType map<string,[]*mime/multipart.FileHeader>
     - __kind: PointerType
-      ID: 15
+      ID: 44
       Name: '*map<string,[]string>'
       ByteSize: 8
-      Pointee: 16 GoSwissMapHeaderType map<string,[]string>
+      Pointee: 45 GoSwissMapHeaderType map<string,[]string>
     - __kind: PointerType
-      ID: 157
+      ID: 178
       Name: '*map<string,float64>'
       ByteSize: 8
-      Pointee: 158 GoSwissMapHeaderType map<string,float64>
+      Pointee: 179 GoSwissMapHeaderType map<string,float64>
     - __kind: PointerType
-      ID: 146
+      ID: 167
       Name: '*map<string,interface {}>'
       ByteSize: 8
-      Pointee: 147 GoSwissMapHeaderType map<string,interface {}>
+      Pointee: 168 GoSwissMapHeaderType map<string,interface {}>
     - __kind: PointerType
-      ID: 125
+      ID: 148
       Name: '*map<string,string>'
       ByteSize: 8
-      Pointee: 126 GoSwissMapHeaderType map<string,string>
+      Pointee: 149 GoSwissMapHeaderType map<string,string>
     - __kind: PointerType
-      ID: 64
+      ID: 88
       Name: '*math/big.Int'
       ByteSize: 8
       GoRuntimeType: 2.446656e+06
       GoKind: 22
-      Pointee: 65 StructureType math/big.Int
+      Pointee: 89 StructureType math/big.Int
     - __kind: PointerType
-      ID: 67
+      ID: 91
       Name: '*math/big.Word'
       ByteSize: 8
       GoRuntimeType: 432640
       GoKind: 22
-      Pointee: 68 BaseType math/big.Word
+      Pointee: 92 BaseType math/big.Word
     - __kind: PointerType
       ID: 243
       Name: '*math/big.nat.array'
       ByteSize: 8
       Pointee: 242 GoSliceDataType math/big.nat.array
     - __kind: PointerType
-      ID: 50
+      ID: 74
       Name: '*mime/multipart.FileHeader'
       ByteSize: 8
       GoRuntimeType: 924960
       GoKind: 22
-      Pointee: 51 StructureType mime/multipart.FileHeader
+      Pointee: 75 StructureType mime/multipart.FileHeader
     - __kind: PointerType
-      ID: 34
+      ID: 58
       Name: '*mime/multipart.Form'
       ByteSize: 8
       GoRuntimeType: 925056
       GoKind: 22
-      Pointee: 35 StructureType mime/multipart.Form
+      Pointee: 59 StructureType mime/multipart.Form
     - __kind: PointerType
-      ID: 94
+      ID: 117
       Name: '*net.IP'
       ByteSize: 8
       GoRuntimeType: 2.206144e+06
       GoKind: 22
-      Pointee: 95 GoSliceHeaderType net.IP
+      Pointee: 118 GoSliceHeaderType net.IP
     - __kind: PointerType
       ID: 261
       Name: '*net.IP.array'
@@ -553,191 +553,191 @@ Types:
       ByteSize: 8
       Pointee: 266 GoSliceDataType net.IPMask.array
     - __kind: PointerType
-      ID: 100
+      ID: 123
       Name: '*net.IPNet'
       ByteSize: 8
       GoRuntimeType: 1.207712e+06
       GoKind: 22
-      Pointee: 101 StructureType net.IPNet
+      Pointee: 124 StructureType net.IPNet
     - __kind: PointerType
-      ID: 3
+      ID: 37
       Name: '*net/http.Request'
       ByteSize: 8
       GoRuntimeType: 2.364736e+06
       GoKind: 22
-      Pointee: 4 StructureType net/http.Request
+      Pointee: 38 StructureType net/http.Request
     - __kind: PointerType
-      ID: 116
+      ID: 139
       Name: '*net/http.Response'
       ByteSize: 8
       GoRuntimeType: 1.757856e+06
       GoKind: 22
-      Pointee: 117 StructureType net/http.Response
+      Pointee: 140 StructureType net/http.Response
     - __kind: PointerType
-      ID: 119
+      ID: 142
       Name: '*net/http.pattern'
       ByteSize: 8
       GoRuntimeType: 1.642144e+06
       GoKind: 22
-      Pointee: 120 StructureType net/http.pattern
+      Pointee: 143 StructureType net/http.pattern
     - __kind: PointerType
-      ID: 122
+      ID: 145
       Name: '*net/http.segment'
       ByteSize: 8
       GoRuntimeType: 396288
       GoKind: 22
-      Pointee: 123 StructureType net/http.segment
+      Pointee: 146 StructureType net/http.segment
     - __kind: PointerType
-      ID: 9
+      ID: 39
       Name: '*net/url.URL'
       ByteSize: 8
       GoRuntimeType: 2.16656e+06
       GoKind: 22
-      Pointee: 10 StructureType net/url.URL
+      Pointee: 40 StructureType net/url.URL
     - __kind: PointerType
-      ID: 11
+      ID: 41
       Name: '*net/url.Userinfo'
       ByteSize: 8
       GoRuntimeType: 1.225376e+06
       GoKind: 22
-      Pointee: 12 StructureType net/url.Userinfo
+      Pointee: 42 StructureType net/url.Userinfo
     - __kind: PointerType
-      ID: 181
+      ID: 201
       Name: '*noalg.map.group[string]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute'
       ByteSize: 8
-      Pointee: 182 StructureType noalg.map.group[string]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
+      Pointee: 202 StructureType noalg.map.group[string]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
     - __kind: PointerType
-      ID: 44
+      ID: 68
       Name: '*noalg.map.group[string][]*mime/multipart.FileHeader'
       ByteSize: 8
-      Pointee: 45 StructureType noalg.map.group[string][]*mime/multipart.FileHeader
+      Pointee: 69 StructureType noalg.map.group[string][]*mime/multipart.FileHeader
     - __kind: PointerType
-      ID: 24
+      ID: 50
       Name: '*noalg.map.group[string][]string'
       ByteSize: 8
-      Pointee: 25 StructureType noalg.map.group[string][]string
+      Pointee: 51 StructureType noalg.map.group[string][]string
     - __kind: PointerType
-      ID: 163
+      ID: 184
       Name: '*noalg.map.group[string]float64'
       ByteSize: 8
-      Pointee: 164 StructureType noalg.map.group[string]float64
+      Pointee: 185 StructureType noalg.map.group[string]float64
     - __kind: PointerType
-      ID: 152
+      ID: 173
       Name: '*noalg.map.group[string]interface {}'
       ByteSize: 8
-      Pointee: 153 StructureType noalg.map.group[string]interface {}
+      Pointee: 174 StructureType noalg.map.group[string]interface {}
     - __kind: PointerType
-      ID: 131
+      ID: 154
       Name: '*noalg.map.group[string]string'
       ByteSize: 8
-      Pointee: 132 StructureType noalg.map.group[string]string
+      Pointee: 155 StructureType noalg.map.group[string]string
     - __kind: PointerType
-      ID: 29
+      ID: 22
       Name: '*string'
       ByteSize: 8
       GoRuntimeType: 404352
       GoKind: 22
-      Pointee: 5 GoStringHeaderType string
+      Pointee: 9 GoStringHeaderType string
     - __kind: PointerType
       ID: 229
       Name: '*string.str'
       ByteSize: 8
       Pointee: 228 GoStringDataType string.str
     - __kind: PointerType
-      ID: 178
+      ID: 198
       Name: '*table<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>'
       ByteSize: 8
-      Pointee: 179 StructureType table<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
+      Pointee: 199 StructureType table<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
     - __kind: PointerType
-      ID: 41
+      ID: 65
       Name: '*table<string,[]*mime/multipart.FileHeader>'
       ByteSize: 8
-      Pointee: 42 StructureType table<string,[]*mime/multipart.FileHeader>
+      Pointee: 66 StructureType table<string,[]*mime/multipart.FileHeader>
     - __kind: PointerType
-      ID: 20
+      ID: 47
       Name: '*table<string,[]string>'
       ByteSize: 8
-      Pointee: 21 StructureType table<string,[]string>
+      Pointee: 48 StructureType table<string,[]string>
     - __kind: PointerType
-      ID: 160
+      ID: 181
       Name: '*table<string,float64>'
       ByteSize: 8
-      Pointee: 161 StructureType table<string,float64>
+      Pointee: 182 StructureType table<string,float64>
     - __kind: PointerType
-      ID: 149
+      ID: 170
       Name: '*table<string,interface {}>'
       ByteSize: 8
-      Pointee: 150 StructureType table<string,interface {}>
+      Pointee: 171 StructureType table<string,interface {}>
     - __kind: PointerType
-      ID: 128
+      ID: 151
       Name: '*table<string,string>'
       ByteSize: 8
-      Pointee: 129 StructureType table<string,string>
+      Pointee: 152 StructureType table<string,string>
     - __kind: PointerType
-      ID: 76
+      ID: 99
       Name: '*time.Location'
       ByteSize: 8
       GoRuntimeType: 1.647136e+06
       GoKind: 22
-      Pointee: 77 StructureType time.Location
+      Pointee: 100 StructureType time.Location
     - __kind: PointerType
-      ID: 79
+      ID: 102
       Name: '*time.zone'
       ByteSize: 8
       GoRuntimeType: 399360
       GoKind: 22
-      Pointee: 80 StructureType time.zone
+      Pointee: 103 StructureType time.zone
     - __kind: PointerType
-      ID: 82
+      ID: 105
       Name: '*time.zoneTrans'
       ByteSize: 8
       GoRuntimeType: 399424
       GoKind: 22
-      Pointee: 83 StructureType time.zoneTrans
+      Pointee: 106 StructureType time.zoneTrans
     - __kind: PointerType
-      ID: 226
+      ID: 34
       Name: '*uint'
       ByteSize: 8
       GoRuntimeType: 404992
       GoKind: 22
-      Pointee: 209 BaseType uint
+      Pointee: 10 BaseType uint
     - __kind: PointerType
-      ID: 222
+      ID: 30
       Name: '*uint16'
       ByteSize: 8
       GoRuntimeType: 404608
       GoKind: 22
-      Pointee: 22 BaseType uint16
+      Pointee: 6 BaseType uint16
     - __kind: PointerType
-      ID: 216
+      ID: 21
       Name: '*uint32'
       ByteSize: 8
       GoRuntimeType: 404736
       GoKind: 22
-      Pointee: 142 BaseType uint32
+      Pointee: 2 BaseType uint32
     - __kind: PointerType
-      ID: 220
+      ID: 28
       Name: '*uint64'
       ByteSize: 8
       GoRuntimeType: 404864
       GoKind: 22
-      Pointee: 17 BaseType uint64
+      Pointee: 8 BaseType uint64
     - __kind: PointerType
-      ID: 6
+      ID: 5
       Name: '*uint8'
       ByteSize: 8
       GoRuntimeType: 404480
       GoKind: 22
-      Pointee: 7 BaseType uint8
+      Pointee: 3 BaseType uint8
     - __kind: PointerType
-      ID: 214
+      ID: 19
       Name: '*uintptr'
       ByteSize: 8
       GoRuntimeType: 405056
       GoKind: 22
-      Pointee: 18 BaseType uintptr
+      Pointee: 1 BaseType uintptr
     - __kind: GoChannelType
-      ID: 115
+      ID: 138
       Name: <-chan struct {}
       GoRuntimeType: 607040
       GoKind: 18
@@ -750,7 +750,7 @@ Types:
         - Name: w
           Offset: 1
           Expression:
-            Type: 1 GoInterfaceType net/http.ResponseWriter
+            Type: 36 GoInterfaceType net/http.ResponseWriter
             Operations:
                 - __kind: LocationOp
                   Variable: {subprogram: 1, index: 0, name: w}
@@ -759,7 +759,7 @@ Types:
         - Name: r
           Offset: 17
           Expression:
-            Type: 3 PointerType *net/http.Request
+            Type: 37 PointerType *net/http.Request
             Operations:
                 - __kind: LocationOp
                   Variable: {subprogram: 1, index: 1, name: r}
@@ -774,14 +774,14 @@ Types:
         - Name: path
           Offset: 1
           Expression:
-            Type: 5 GoStringHeaderType string
+            Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
                   Variable: {subprogram: 2, index: 0, name: path}
                   Offset: 0
                   ByteSize: 16
     - __kind: GoSliceHeaderType
-      ID: 57
+      ID: 81
       Name: '[]*crypto/x509.Certificate'
       ByteSize: 24
       GoRuntimeType: 507264
@@ -789,21 +789,21 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 58 PointerType **crypto/x509.Certificate
+          Type: 82 PointerType **crypto/x509.Certificate
         - Name: len
           Offset: 8
-          Type: 8 BaseType int
+          Type: 7 BaseType int
         - Name: cap
           Offset: 16
-          Type: 8 BaseType int
+          Type: 7 BaseType int
       Data: 240 GoSliceDataType []*crypto/x509.Certificate.array
     - __kind: GoSliceDataType
       ID: 240
       Name: '[]*crypto/x509.Certificate.array'
       ByteSize: 2048
-      Element: 59 PointerType *crypto/x509.Certificate
+      Element: 83 PointerType *crypto/x509.Certificate
     - __kind: GoSliceHeaderType
-      ID: 200
+      ID: 220
       Name: '[]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span'
       ByteSize: 24
       GoRuntimeType: 495072
@@ -811,21 +811,21 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 201 PointerType **github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span
+          Type: 221 PointerType **github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span
         - Name: len
           Offset: 8
-          Type: 8 BaseType int
+          Type: 7 BaseType int
         - Name: cap
           Offset: 16
-          Type: 8 BaseType int
+          Type: 7 BaseType int
       Data: 292 GoSliceDataType []*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span.array
     - __kind: GoSliceDataType
       ID: 292
       Name: '[]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span.array'
       ByteSize: 2048
-      Element: 135 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span
+      Element: 158 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span
     - __kind: GoSliceHeaderType
-      ID: 190
+      ID: 210
       Name: '[]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttributeValue'
       ByteSize: 24
       GoRuntimeType: 494688
@@ -833,21 +833,21 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 191 PointerType **github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttributeValue
+          Type: 211 PointerType **github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttributeValue
         - Name: len
           Offset: 8
-          Type: 8 BaseType int
+          Type: 7 BaseType int
         - Name: cap
           Offset: 16
-          Type: 8 BaseType int
+          Type: 7 BaseType int
       Data: 290 GoSliceDataType []*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttributeValue.array
     - __kind: GoSliceDataType
       ID: 290
       Name: '[]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttributeValue.array'
       ByteSize: 2048
-      Element: 192 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttributeValue
+      Element: 212 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttributeValue
     - __kind: GoSliceHeaderType
-      ID: 48
+      ID: 72
       Name: '[]*mime/multipart.FileHeader'
       ByteSize: 24
       GoRuntimeType: 492064
@@ -855,21 +855,21 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 49 PointerType **mime/multipart.FileHeader
+          Type: 73 PointerType **mime/multipart.FileHeader
         - Name: len
           Offset: 8
-          Type: 8 BaseType int
+          Type: 7 BaseType int
         - Name: cap
           Offset: 16
-          Type: 8 BaseType int
+          Type: 7 BaseType int
       Data: 236 GoSliceDataType []*mime/multipart.FileHeader.array
     - __kind: GoSliceDataType
       ID: 236
       Name: '[]*mime/multipart.FileHeader.array'
       ByteSize: 2048
-      Element: 50 PointerType *mime/multipart.FileHeader
+      Element: 74 PointerType *mime/multipart.FileHeader
     - __kind: GoSliceHeaderType
-      ID: 98
+      ID: 121
       Name: '[]*net.IPNet'
       ByteSize: 24
       GoRuntimeType: 508864
@@ -877,21 +877,21 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 99 PointerType **net.IPNet
+          Type: 122 PointerType **net.IPNet
         - Name: len
           Offset: 8
-          Type: 8 BaseType int
+          Type: 7 BaseType int
         - Name: cap
           Offset: 16
-          Type: 8 BaseType int
+          Type: 7 BaseType int
       Data: 264 GoSliceDataType []*net.IPNet.array
     - __kind: GoSliceDataType
       ID: 264
       Name: '[]*net.IPNet.array'
       ByteSize: 2048
-      Element: 100 PointerType *net.IPNet
+      Element: 123 PointerType *net.IPNet
     - __kind: GoSliceHeaderType
-      ID: 96
+      ID: 119
       Name: '[]*net/url.URL'
       ByteSize: 24
       GoRuntimeType: 508800
@@ -899,51 +899,51 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 97 PointerType **net/url.URL
+          Type: 120 PointerType **net/url.URL
         - Name: len
           Offset: 8
-          Type: 8 BaseType int
+          Type: 7 BaseType int
         - Name: cap
           Offset: 16
-          Type: 8 BaseType int
+          Type: 7 BaseType int
       Data: 262 GoSliceDataType []*net/url.URL.array
     - __kind: GoSliceDataType
       ID: 262
       Name: '[]*net/url.URL.array'
       ByteSize: 2048
-      Element: 9 PointerType *net/url.URL
+      Element: 39 PointerType *net/url.URL
     - __kind: GoSliceDataType
       ID: 288
       Name: '[]*table<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>.array'
       ByteSize: 8192
-      Element: 178 PointerType *table<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
+      Element: 198 PointerType *table<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
     - __kind: GoSliceDataType
       ID: 234
       Name: '[]*table<string,[]*mime/multipart.FileHeader>.array'
       ByteSize: 8192
-      Element: 41 PointerType *table<string,[]*mime/multipart.FileHeader>
+      Element: 65 PointerType *table<string,[]*mime/multipart.FileHeader>
     - __kind: GoSliceDataType
       ID: 230
       Name: '[]*table<string,[]string>.array'
       ByteSize: 8192
-      Element: 20 PointerType *table<string,[]string>
+      Element: 47 PointerType *table<string,[]string>
     - __kind: GoSliceDataType
       ID: 282
       Name: '[]*table<string,float64>.array'
       ByteSize: 8192
-      Element: 160 PointerType *table<string,float64>
+      Element: 181 PointerType *table<string,float64>
     - __kind: GoSliceDataType
       ID: 280
       Name: '[]*table<string,interface {}>.array'
       ByteSize: 8192
-      Element: 149 PointerType *table<string,interface {}>
+      Element: 170 PointerType *table<string,interface {}>
     - __kind: GoSliceDataType
       ID: 278
       Name: '[]*table<string,string>.array'
       ByteSize: 8192
-      Element: 128 PointerType *table<string,string>
+      Element: 151 PointerType *table<string,string>
     - __kind: GoSliceHeaderType
-      ID: 109
+      ID: 132
       Name: '[][]*crypto/x509.Certificate'
       ByteSize: 24
       GoRuntimeType: 507328
@@ -951,21 +951,21 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 110 PointerType *[]*crypto/x509.Certificate
+          Type: 133 PointerType *[]*crypto/x509.Certificate
         - Name: len
           Offset: 8
-          Type: 8 BaseType int
+          Type: 7 BaseType int
         - Name: cap
           Offset: 16
-          Type: 8 BaseType int
+          Type: 7 BaseType int
       Data: 272 GoSliceDataType [][]*crypto/x509.Certificate.array
     - __kind: GoSliceDataType
       ID: 272
       Name: '[][]*crypto/x509.Certificate.array'
       ByteSize: 2048
-      Element: 57 GoSliceHeaderType []*crypto/x509.Certificate
+      Element: 81 GoSliceHeaderType []*crypto/x509.Certificate
     - __kind: GoSliceHeaderType
-      ID: 111
+      ID: 134
       Name: '[][]uint8'
       ByteSize: 24
       GoRuntimeType: 486720
@@ -973,21 +973,21 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 112 PointerType *[]uint8
+          Type: 135 PointerType *[]uint8
         - Name: len
           Offset: 8
-          Type: 8 BaseType int
+          Type: 7 BaseType int
         - Name: cap
           Offset: 16
-          Type: 8 BaseType int
+          Type: 7 BaseType int
       Data: 274 GoSliceDataType [][]uint8.array
     - __kind: GoSliceDataType
       ID: 274
       Name: '[][]uint8.array'
       ByteSize: 2048
-      Element: 53 GoSliceHeaderType []uint8
+      Element: 77 GoSliceHeaderType []uint8
     - __kind: GoSliceHeaderType
-      ID: 90
+      ID: 113
       Name: '[]crypto/x509.ExtKeyUsage'
       ByteSize: 24
       GoRuntimeType: 508736
@@ -995,21 +995,21 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 91 PointerType *crypto/x509.ExtKeyUsage
+          Type: 114 PointerType *crypto/x509.ExtKeyUsage
         - Name: len
           Offset: 8
-          Type: 8 BaseType int
+          Type: 7 BaseType int
         - Name: cap
           Offset: 16
-          Type: 8 BaseType int
+          Type: 7 BaseType int
       Data: 256 GoSliceDataType []crypto/x509.ExtKeyUsage.array
     - __kind: GoSliceDataType
       ID: 256
       Name: '[]crypto/x509.ExtKeyUsage.array'
       ByteSize: 2048
-      Element: 92 BaseType crypto/x509.ExtKeyUsage
+      Element: 115 BaseType crypto/x509.ExtKeyUsage
     - __kind: GoSliceHeaderType
-      ID: 103
+      ID: 126
       Name: '[]crypto/x509.OID'
       ByteSize: 24
       GoRuntimeType: 508928
@@ -1017,21 +1017,21 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 104 PointerType *crypto/x509.OID
+          Type: 127 PointerType *crypto/x509.OID
         - Name: len
           Offset: 8
-          Type: 8 BaseType int
+          Type: 7 BaseType int
         - Name: cap
           Offset: 16
-          Type: 8 BaseType int
+          Type: 7 BaseType int
       Data: 268 GoSliceDataType []crypto/x509.OID.array
     - __kind: GoSliceDataType
       ID: 268
       Name: '[]crypto/x509.OID.array'
       ByteSize: 2048
-      Element: 105 StructureType crypto/x509.OID
+      Element: 128 StructureType crypto/x509.OID
     - __kind: GoSliceHeaderType
-      ID: 106
+      ID: 129
       Name: '[]crypto/x509.PolicyMapping'
       ByteSize: 24
       GoRuntimeType: 508992
@@ -1039,21 +1039,21 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 107 PointerType *crypto/x509.PolicyMapping
+          Type: 130 PointerType *crypto/x509.PolicyMapping
         - Name: len
           Offset: 8
-          Type: 8 BaseType int
+          Type: 7 BaseType int
         - Name: cap
           Offset: 16
-          Type: 8 BaseType int
+          Type: 7 BaseType int
       Data: 270 GoSliceDataType []crypto/x509.PolicyMapping.array
     - __kind: GoSliceDataType
       ID: 270
       Name: '[]crypto/x509.PolicyMapping.array'
       ByteSize: 2048
-      Element: 108 StructureType crypto/x509.PolicyMapping
+      Element: 131 StructureType crypto/x509.PolicyMapping
     - __kind: GoSliceHeaderType
-      ID: 70
+      ID: 94
       Name: '[]crypto/x509/pkix.AttributeTypeAndValue'
       ByteSize: 24
       GoRuntimeType: 523520
@@ -1061,21 +1061,21 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 71 PointerType *crypto/x509/pkix.AttributeTypeAndValue
+          Type: 95 PointerType *crypto/x509/pkix.AttributeTypeAndValue
         - Name: len
           Offset: 8
-          Type: 8 BaseType int
+          Type: 7 BaseType int
         - Name: cap
           Offset: 16
-          Type: 8 BaseType int
+          Type: 7 BaseType int
       Data: 244 GoSliceDataType []crypto/x509/pkix.AttributeTypeAndValue.array
     - __kind: GoSliceDataType
       ID: 244
       Name: '[]crypto/x509/pkix.AttributeTypeAndValue.array'
       ByteSize: 2048
-      Element: 72 StructureType crypto/x509/pkix.AttributeTypeAndValue
+      Element: 96 StructureType crypto/x509/pkix.AttributeTypeAndValue
     - __kind: GoSliceHeaderType
-      ID: 85
+      ID: 108
       Name: '[]crypto/x509/pkix.Extension'
       ByteSize: 24
       GoRuntimeType: 508608
@@ -1083,21 +1083,21 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 86 PointerType *crypto/x509/pkix.Extension
+          Type: 109 PointerType *crypto/x509/pkix.Extension
         - Name: len
           Offset: 8
-          Type: 8 BaseType int
+          Type: 7 BaseType int
         - Name: cap
           Offset: 16
-          Type: 8 BaseType int
+          Type: 7 BaseType int
       Data: 252 GoSliceDataType []crypto/x509/pkix.Extension.array
     - __kind: GoSliceDataType
       ID: 252
       Name: '[]crypto/x509/pkix.Extension.array'
       ByteSize: 2048
-      Element: 87 StructureType crypto/x509/pkix.Extension
+      Element: 110 StructureType crypto/x509/pkix.Extension
     - __kind: GoSliceHeaderType
-      ID: 88
+      ID: 111
       Name: '[]encoding/asn1.ObjectIdentifier'
       ByteSize: 24
       GoRuntimeType: 508672
@@ -1105,21 +1105,21 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 89 PointerType *encoding/asn1.ObjectIdentifier
+          Type: 112 PointerType *encoding/asn1.ObjectIdentifier
         - Name: len
           Offset: 8
-          Type: 8 BaseType int
+          Type: 7 BaseType int
         - Name: cap
           Offset: 16
-          Type: 8 BaseType int
+          Type: 7 BaseType int
       Data: 254 GoSliceDataType []encoding/asn1.ObjectIdentifier.array
     - __kind: GoSliceDataType
       ID: 254
       Name: '[]encoding/asn1.ObjectIdentifier.array'
       ByteSize: 2048
-      Element: 73 GoSliceHeaderType encoding/asn1.ObjectIdentifier
+      Element: 97 GoSliceHeaderType encoding/asn1.ObjectIdentifier
     - __kind: GoSliceHeaderType
-      ID: 168
+      ID: 188
       Name: '[]github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink'
       ByteSize: 24
       GoRuntimeType: 494624
@@ -1127,21 +1127,21 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 169 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink
+          Type: 189 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink
         - Name: len
           Offset: 8
-          Type: 8 BaseType int
+          Type: 7 BaseType int
         - Name: cap
           Offset: 16
-          Type: 8 BaseType int
+          Type: 7 BaseType int
       Data: 284 GoSliceDataType []github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink.array
     - __kind: GoSliceDataType
       ID: 284
       Name: '[]github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink.array'
       ByteSize: 2048
-      Element: 170 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink
+      Element: 190 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink
     - __kind: GoSliceHeaderType
-      ID: 171
+      ID: 191
       Name: '[]github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent'
       ByteSize: 24
       GoRuntimeType: 494816
@@ -1149,21 +1149,21 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 172 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent
+          Type: 192 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent
         - Name: len
           Offset: 8
-          Type: 8 BaseType int
+          Type: 7 BaseType int
         - Name: cap
           Offset: 16
-          Type: 8 BaseType int
+          Type: 7 BaseType int
       Data: 286 GoSliceDataType []github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent.array
     - __kind: GoSliceDataType
       ID: 286
       Name: '[]github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent.array'
       ByteSize: 2048
-      Element: 173 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent
+      Element: 193 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent
     - __kind: GoSliceHeaderType
-      ID: 93
+      ID: 116
       Name: '[]net.IP'
       ByteSize: 24
       GoRuntimeType: 487744
@@ -1171,21 +1171,21 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 94 PointerType *net.IP
+          Type: 117 PointerType *net.IP
         - Name: len
           Offset: 8
-          Type: 8 BaseType int
+          Type: 7 BaseType int
         - Name: cap
           Offset: 16
-          Type: 8 BaseType int
+          Type: 7 BaseType int
       Data: 258 GoSliceDataType []net.IP.array
     - __kind: GoSliceDataType
       ID: 258
       Name: '[]net.IP.array'
       ByteSize: 2048
-      Element: 95 GoSliceHeaderType net.IP
+      Element: 118 GoSliceHeaderType net.IP
     - __kind: GoSliceHeaderType
-      ID: 121
+      ID: 144
       Name: '[]net/http.segment'
       ByteSize: 24
       GoRuntimeType: 489440
@@ -1193,51 +1193,51 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 122 PointerType *net/http.segment
+          Type: 145 PointerType *net/http.segment
         - Name: len
           Offset: 8
-          Type: 8 BaseType int
+          Type: 7 BaseType int
         - Name: cap
           Offset: 16
-          Type: 8 BaseType int
+          Type: 7 BaseType int
       Data: 276 GoSliceDataType []net/http.segment.array
     - __kind: GoSliceDataType
       ID: 276
       Name: '[]net/http.segment.array'
       ByteSize: 2048
-      Element: 123 StructureType net/http.segment
+      Element: 146 StructureType net/http.segment
     - __kind: GoSliceDataType
       ID: 289
       Name: '[]noalg.map.group[string]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute.array'
       ByteSize: 2048
-      Element: 182 StructureType noalg.map.group[string]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
+      Element: 202 StructureType noalg.map.group[string]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
     - __kind: GoSliceDataType
       ID: 235
       Name: '[]noalg.map.group[string][]*mime/multipart.FileHeader.array'
       ByteSize: 2048
-      Element: 45 StructureType noalg.map.group[string][]*mime/multipart.FileHeader
+      Element: 69 StructureType noalg.map.group[string][]*mime/multipart.FileHeader
     - __kind: GoSliceDataType
       ID: 231
       Name: '[]noalg.map.group[string][]string.array'
       ByteSize: 2048
-      Element: 25 StructureType noalg.map.group[string][]string
+      Element: 51 StructureType noalg.map.group[string][]string
     - __kind: GoSliceDataType
       ID: 283
       Name: '[]noalg.map.group[string]float64.array'
       ByteSize: 2048
-      Element: 164 StructureType noalg.map.group[string]float64
+      Element: 185 StructureType noalg.map.group[string]float64
     - __kind: GoSliceDataType
       ID: 281
       Name: '[]noalg.map.group[string]interface {}.array'
       ByteSize: 2048
-      Element: 153 StructureType noalg.map.group[string]interface {}
+      Element: 174 StructureType noalg.map.group[string]interface {}
     - __kind: GoSliceDataType
       ID: 279
       Name: '[]noalg.map.group[string]string.array'
       ByteSize: 2048
-      Element: 132 StructureType noalg.map.group[string]string
+      Element: 155 StructureType noalg.map.group[string]string
     - __kind: GoSliceHeaderType
-      ID: 28
+      ID: 54
       Name: '[]string'
       ByteSize: 24
       GoRuntimeType: 501280
@@ -1245,21 +1245,21 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 29 PointerType *string
+          Type: 22 PointerType *string
         - Name: len
           Offset: 8
-          Type: 8 BaseType int
+          Type: 7 BaseType int
         - Name: cap
           Offset: 16
-          Type: 8 BaseType int
+          Type: 7 BaseType int
       Data: 232 GoSliceDataType []string.array
     - __kind: GoSliceDataType
       ID: 232
       Name: '[]string.array'
       ByteSize: 2048
-      Element: 5 GoStringHeaderType string
+      Element: 9 GoStringHeaderType string
     - __kind: GoSliceHeaderType
-      ID: 78
+      ID: 101
       Name: '[]time.zone'
       ByteSize: 24
       GoRuntimeType: 494176
@@ -1267,21 +1267,21 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 79 PointerType *time.zone
+          Type: 102 PointerType *time.zone
         - Name: len
           Offset: 8
-          Type: 8 BaseType int
+          Type: 7 BaseType int
         - Name: cap
           Offset: 16
-          Type: 8 BaseType int
+          Type: 7 BaseType int
       Data: 248 GoSliceDataType []time.zone.array
     - __kind: GoSliceDataType
       ID: 248
       Name: '[]time.zone.array'
       ByteSize: 2048
-      Element: 80 StructureType time.zone
+      Element: 103 StructureType time.zone
     - __kind: GoSliceHeaderType
-      ID: 81
+      ID: 104
       Name: '[]time.zoneTrans'
       ByteSize: 24
       GoRuntimeType: 494240
@@ -1289,21 +1289,21 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 82 PointerType *time.zoneTrans
+          Type: 105 PointerType *time.zoneTrans
         - Name: len
           Offset: 8
-          Type: 8 BaseType int
+          Type: 7 BaseType int
         - Name: cap
           Offset: 16
-          Type: 8 BaseType int
+          Type: 7 BaseType int
       Data: 250 GoSliceDataType []time.zoneTrans.array
     - __kind: GoSliceDataType
       ID: 250
       Name: '[]time.zoneTrans.array'
       ByteSize: 2048
-      Element: 83 StructureType time.zoneTrans
+      Element: 106 StructureType time.zoneTrans
     - __kind: GoSliceHeaderType
-      ID: 53
+      ID: 77
       Name: '[]uint8'
       ByteSize: 24
       GoRuntimeType: 500128
@@ -1311,27 +1311,27 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 6 PointerType *uint8
+          Type: 5 PointerType *uint8
         - Name: len
           Offset: 8
-          Type: 8 BaseType int
+          Type: 7 BaseType int
         - Name: cap
           Offset: 16
-          Type: 8 BaseType int
+          Type: 7 BaseType int
       Data: 238 GoSliceDataType []uint8.array
     - __kind: GoSliceDataType
       ID: 238
       Name: '[]uint8.array'
       ByteSize: 2048
-      Element: 7 BaseType uint8
+      Element: 3 BaseType uint8
     - __kind: BaseType
-      ID: 13
+      ID: 4
       Name: bool
       ByteSize: 1
       GoRuntimeType: 595008
       GoKind: 1
     - __kind: StructureType
-      ID: 207
+      ID: 226
       Name: bytes.Buffer
       ByteSize: 40
       GoRuntimeType: 1.63984e+06
@@ -1339,33 +1339,33 @@ Types:
       RawFields:
         - Name: buf
           Offset: 0
-          Type: 53 GoSliceHeaderType []uint8
+          Type: 77 GoSliceHeaderType []uint8
         - Name: off
           Offset: 24
-          Type: 8 BaseType int
+          Type: 7 BaseType int
         - Name: lastRead
           Offset: 32
-          Type: 208 BaseType bytes.readOp
+          Type: 227 BaseType bytes.readOp
     - __kind: BaseType
-      ID: 208
+      ID: 227
       Name: bytes.readOp
       ByteSize: 1
       GoRuntimeType: 593216
       GoKind: 3
     - __kind: BaseType
-      ID: 219
+      ID: 25
       Name: complex128
       ByteSize: 16
       GoRuntimeType: 594816
       GoKind: 16
     - __kind: BaseType
-      ID: 218
+      ID: 24
       Name: complex64
       ByteSize: 8
       GoRuntimeType: 594752
       GoKind: 15
     - __kind: GoInterfaceType
-      ID: 118
+      ID: 141
       Name: context.Context
       ByteSize: 16
       GoRuntimeType: 1.302496e+06
@@ -1373,12 +1373,12 @@ Types:
       RawFields:
         - Name: tab
           Offset: 0
-          Type: 2 VoidPointerType unsafe.Pointer
+          Type: 15 VoidPointerType unsafe.Pointer
         - Name: data
           Offset: 8
-          Type: 2 VoidPointerType unsafe.Pointer
+          Type: 15 VoidPointerType unsafe.Pointer
     - __kind: StructureType
-      ID: 55
+      ID: 79
       Name: crypto/tls.ConnectionState
       ByteSize: 192
       GoRuntimeType: 2.322656e+06
@@ -1386,69 +1386,69 @@ Types:
       RawFields:
         - Name: Version
           Offset: 0
-          Type: 22 BaseType uint16
+          Type: 6 BaseType uint16
         - Name: HandshakeComplete
           Offset: 2
-          Type: 13 BaseType bool
+          Type: 4 BaseType bool
         - Name: DidResume
           Offset: 3
-          Type: 13 BaseType bool
+          Type: 4 BaseType bool
         - Name: CipherSuite
           Offset: 4
-          Type: 22 BaseType uint16
+          Type: 6 BaseType uint16
         - Name: CurveID
           Offset: 6
-          Type: 56 BaseType crypto/tls.CurveID
+          Type: 80 BaseType crypto/tls.CurveID
         - Name: NegotiatedProtocol
           Offset: 8
-          Type: 5 GoStringHeaderType string
+          Type: 9 GoStringHeaderType string
         - Name: NegotiatedProtocolIsMutual
           Offset: 24
-          Type: 13 BaseType bool
+          Type: 4 BaseType bool
         - Name: ServerName
           Offset: 32
-          Type: 5 GoStringHeaderType string
+          Type: 9 GoStringHeaderType string
         - Name: PeerCertificates
           Offset: 48
-          Type: 57 GoSliceHeaderType []*crypto/x509.Certificate
+          Type: 81 GoSliceHeaderType []*crypto/x509.Certificate
         - Name: VerifiedChains
           Offset: 72
-          Type: 109 GoSliceHeaderType [][]*crypto/x509.Certificate
+          Type: 132 GoSliceHeaderType [][]*crypto/x509.Certificate
         - Name: SignedCertificateTimestamps
           Offset: 96
-          Type: 111 GoSliceHeaderType [][]uint8
+          Type: 134 GoSliceHeaderType [][]uint8
         - Name: OCSPResponse
           Offset: 120
-          Type: 53 GoSliceHeaderType []uint8
+          Type: 77 GoSliceHeaderType []uint8
         - Name: TLSUnique
           Offset: 144
-          Type: 53 GoSliceHeaderType []uint8
+          Type: 77 GoSliceHeaderType []uint8
         - Name: ECHAccepted
           Offset: 168
-          Type: 13 BaseType bool
+          Type: 4 BaseType bool
         - Name: ekm
           Offset: 176
-          Type: 113 GoSubroutineType func(string, []uint8, int) ([]uint8, error)
+          Type: 136 GoSubroutineType func(string, []uint8, int) ([]uint8, error)
         - Name: testingOnlyDidHRR
           Offset: 184
-          Type: 13 BaseType bool
+          Type: 4 BaseType bool
         - Name: testingOnlyPeerSignatureAlgorithm
           Offset: 186
-          Type: 114 BaseType crypto/tls.SignatureScheme
+          Type: 137 BaseType crypto/tls.SignatureScheme
     - __kind: BaseType
-      ID: 56
+      ID: 80
       Name: crypto/tls.CurveID
       ByteSize: 2
       GoRuntimeType: 846592
       GoKind: 9
     - __kind: BaseType
-      ID: 114
+      ID: 137
       Name: crypto/tls.SignatureScheme
       ByteSize: 2
       GoRuntimeType: 846688
       GoKind: 9
     - __kind: StructureType
-      ID: 60
+      ID: 84
       Name: crypto/x509.Certificate
       ByteSize: 1424
       GoRuntimeType: 2.45792e+06
@@ -1456,174 +1456,174 @@ Types:
       RawFields:
         - Name: Raw
           Offset: 0
-          Type: 53 GoSliceHeaderType []uint8
+          Type: 77 GoSliceHeaderType []uint8
         - Name: RawTBSCertificate
           Offset: 24
-          Type: 53 GoSliceHeaderType []uint8
+          Type: 77 GoSliceHeaderType []uint8
         - Name: RawSubjectPublicKeyInfo
           Offset: 48
-          Type: 53 GoSliceHeaderType []uint8
+          Type: 77 GoSliceHeaderType []uint8
         - Name: RawSubject
           Offset: 72
-          Type: 53 GoSliceHeaderType []uint8
+          Type: 77 GoSliceHeaderType []uint8
         - Name: RawIssuer
           Offset: 96
-          Type: 53 GoSliceHeaderType []uint8
+          Type: 77 GoSliceHeaderType []uint8
         - Name: Signature
           Offset: 120
-          Type: 53 GoSliceHeaderType []uint8
+          Type: 77 GoSliceHeaderType []uint8
         - Name: SignatureAlgorithm
           Offset: 144
-          Type: 61 BaseType crypto/x509.SignatureAlgorithm
+          Type: 85 BaseType crypto/x509.SignatureAlgorithm
         - Name: PublicKeyAlgorithm
           Offset: 152
-          Type: 62 BaseType crypto/x509.PublicKeyAlgorithm
+          Type: 86 BaseType crypto/x509.PublicKeyAlgorithm
         - Name: PublicKey
           Offset: 160
-          Type: 63 GoEmptyInterfaceType interface {}
+          Type: 87 GoEmptyInterfaceType interface {}
         - Name: Version
           Offset: 176
-          Type: 8 BaseType int
+          Type: 7 BaseType int
         - Name: SerialNumber
           Offset: 184
-          Type: 64 PointerType *math/big.Int
+          Type: 88 PointerType *math/big.Int
         - Name: Issuer
           Offset: 192
-          Type: 69 StructureType crypto/x509/pkix.Name
+          Type: 93 StructureType crypto/x509/pkix.Name
         - Name: Subject
           Offset: 440
-          Type: 69 StructureType crypto/x509/pkix.Name
+          Type: 93 StructureType crypto/x509/pkix.Name
         - Name: NotBefore
           Offset: 688
-          Type: 75 StructureType time.Time
+          Type: 98 StructureType time.Time
         - Name: NotAfter
           Offset: 712
-          Type: 75 StructureType time.Time
+          Type: 98 StructureType time.Time
         - Name: KeyUsage
           Offset: 736
-          Type: 84 BaseType crypto/x509.KeyUsage
+          Type: 107 BaseType crypto/x509.KeyUsage
         - Name: Extensions
           Offset: 744
-          Type: 85 GoSliceHeaderType []crypto/x509/pkix.Extension
+          Type: 108 GoSliceHeaderType []crypto/x509/pkix.Extension
         - Name: ExtraExtensions
           Offset: 768
-          Type: 85 GoSliceHeaderType []crypto/x509/pkix.Extension
+          Type: 108 GoSliceHeaderType []crypto/x509/pkix.Extension
         - Name: UnhandledCriticalExtensions
           Offset: 792
-          Type: 88 GoSliceHeaderType []encoding/asn1.ObjectIdentifier
+          Type: 111 GoSliceHeaderType []encoding/asn1.ObjectIdentifier
         - Name: ExtKeyUsage
           Offset: 816
-          Type: 90 GoSliceHeaderType []crypto/x509.ExtKeyUsage
+          Type: 113 GoSliceHeaderType []crypto/x509.ExtKeyUsage
         - Name: UnknownExtKeyUsage
           Offset: 840
-          Type: 88 GoSliceHeaderType []encoding/asn1.ObjectIdentifier
+          Type: 111 GoSliceHeaderType []encoding/asn1.ObjectIdentifier
         - Name: BasicConstraintsValid
           Offset: 864
-          Type: 13 BaseType bool
+          Type: 4 BaseType bool
         - Name: IsCA
           Offset: 865
-          Type: 13 BaseType bool
+          Type: 4 BaseType bool
         - Name: MaxPathLen
           Offset: 872
-          Type: 8 BaseType int
+          Type: 7 BaseType int
         - Name: MaxPathLenZero
           Offset: 880
-          Type: 13 BaseType bool
+          Type: 4 BaseType bool
         - Name: SubjectKeyId
           Offset: 888
-          Type: 53 GoSliceHeaderType []uint8
+          Type: 77 GoSliceHeaderType []uint8
         - Name: AuthorityKeyId
           Offset: 912
-          Type: 53 GoSliceHeaderType []uint8
+          Type: 77 GoSliceHeaderType []uint8
         - Name: OCSPServer
           Offset: 936
-          Type: 28 GoSliceHeaderType []string
+          Type: 54 GoSliceHeaderType []string
         - Name: IssuingCertificateURL
           Offset: 960
-          Type: 28 GoSliceHeaderType []string
+          Type: 54 GoSliceHeaderType []string
         - Name: DNSNames
           Offset: 984
-          Type: 28 GoSliceHeaderType []string
+          Type: 54 GoSliceHeaderType []string
         - Name: EmailAddresses
           Offset: 1008
-          Type: 28 GoSliceHeaderType []string
+          Type: 54 GoSliceHeaderType []string
         - Name: IPAddresses
           Offset: 1032
-          Type: 93 GoSliceHeaderType []net.IP
+          Type: 116 GoSliceHeaderType []net.IP
         - Name: URIs
           Offset: 1056
-          Type: 96 GoSliceHeaderType []*net/url.URL
+          Type: 119 GoSliceHeaderType []*net/url.URL
         - Name: PermittedDNSDomainsCritical
           Offset: 1080
-          Type: 13 BaseType bool
+          Type: 4 BaseType bool
         - Name: PermittedDNSDomains
           Offset: 1088
-          Type: 28 GoSliceHeaderType []string
+          Type: 54 GoSliceHeaderType []string
         - Name: ExcludedDNSDomains
           Offset: 1112
-          Type: 28 GoSliceHeaderType []string
+          Type: 54 GoSliceHeaderType []string
         - Name: PermittedIPRanges
           Offset: 1136
-          Type: 98 GoSliceHeaderType []*net.IPNet
+          Type: 121 GoSliceHeaderType []*net.IPNet
         - Name: ExcludedIPRanges
           Offset: 1160
-          Type: 98 GoSliceHeaderType []*net.IPNet
+          Type: 121 GoSliceHeaderType []*net.IPNet
         - Name: PermittedEmailAddresses
           Offset: 1184
-          Type: 28 GoSliceHeaderType []string
+          Type: 54 GoSliceHeaderType []string
         - Name: ExcludedEmailAddresses
           Offset: 1208
-          Type: 28 GoSliceHeaderType []string
+          Type: 54 GoSliceHeaderType []string
         - Name: PermittedURIDomains
           Offset: 1232
-          Type: 28 GoSliceHeaderType []string
+          Type: 54 GoSliceHeaderType []string
         - Name: ExcludedURIDomains
           Offset: 1256
-          Type: 28 GoSliceHeaderType []string
+          Type: 54 GoSliceHeaderType []string
         - Name: CRLDistributionPoints
           Offset: 1280
-          Type: 28 GoSliceHeaderType []string
+          Type: 54 GoSliceHeaderType []string
         - Name: PolicyIdentifiers
           Offset: 1304
-          Type: 88 GoSliceHeaderType []encoding/asn1.ObjectIdentifier
+          Type: 111 GoSliceHeaderType []encoding/asn1.ObjectIdentifier
         - Name: Policies
           Offset: 1328
-          Type: 103 GoSliceHeaderType []crypto/x509.OID
+          Type: 126 GoSliceHeaderType []crypto/x509.OID
         - Name: InhibitAnyPolicy
           Offset: 1352
-          Type: 8 BaseType int
+          Type: 7 BaseType int
         - Name: InhibitAnyPolicyZero
           Offset: 1360
-          Type: 13 BaseType bool
+          Type: 4 BaseType bool
         - Name: InhibitPolicyMapping
           Offset: 1368
-          Type: 8 BaseType int
+          Type: 7 BaseType int
         - Name: InhibitPolicyMappingZero
           Offset: 1376
-          Type: 13 BaseType bool
+          Type: 4 BaseType bool
         - Name: RequireExplicitPolicy
           Offset: 1384
-          Type: 8 BaseType int
+          Type: 7 BaseType int
         - Name: RequireExplicitPolicyZero
           Offset: 1392
-          Type: 13 BaseType bool
+          Type: 4 BaseType bool
         - Name: PolicyMappings
           Offset: 1400
-          Type: 106 GoSliceHeaderType []crypto/x509.PolicyMapping
+          Type: 129 GoSliceHeaderType []crypto/x509.PolicyMapping
     - __kind: BaseType
-      ID: 92
+      ID: 115
       Name: crypto/x509.ExtKeyUsage
       ByteSize: 8
       GoRuntimeType: 598080
       GoKind: 2
     - __kind: BaseType
-      ID: 84
+      ID: 107
       Name: crypto/x509.KeyUsage
       ByteSize: 8
       GoRuntimeType: 598016
       GoKind: 2
     - __kind: StructureType
-      ID: 105
+      ID: 128
       Name: crypto/x509.OID
       ByteSize: 24
       GoRuntimeType: 1.9976e+06
@@ -1631,9 +1631,9 @@ Types:
       RawFields:
         - Name: der
           Offset: 0
-          Type: 53 GoSliceHeaderType []uint8
+          Type: 77 GoSliceHeaderType []uint8
     - __kind: StructureType
-      ID: 108
+      ID: 131
       Name: crypto/x509.PolicyMapping
       ByteSize: 48
       GoRuntimeType: 1.519712e+06
@@ -1641,24 +1641,24 @@ Types:
       RawFields:
         - Name: IssuerDomainPolicy
           Offset: 0
-          Type: 105 StructureType crypto/x509.OID
+          Type: 128 StructureType crypto/x509.OID
         - Name: SubjectDomainPolicy
           Offset: 24
-          Type: 105 StructureType crypto/x509.OID
+          Type: 128 StructureType crypto/x509.OID
     - __kind: BaseType
-      ID: 62
+      ID: 86
       Name: crypto/x509.PublicKeyAlgorithm
       ByteSize: 8
       GoRuntimeType: 849088
       GoKind: 2
     - __kind: BaseType
-      ID: 61
+      ID: 85
       Name: crypto/x509.SignatureAlgorithm
       ByteSize: 8
       GoRuntimeType: 1.138944e+06
       GoKind: 2
     - __kind: StructureType
-      ID: 72
+      ID: 96
       Name: crypto/x509/pkix.AttributeTypeAndValue
       ByteSize: 40
       GoRuntimeType: 1.532192e+06
@@ -1666,12 +1666,12 @@ Types:
       RawFields:
         - Name: Type
           Offset: 0
-          Type: 73 GoSliceHeaderType encoding/asn1.ObjectIdentifier
+          Type: 97 GoSliceHeaderType encoding/asn1.ObjectIdentifier
         - Name: Value
           Offset: 24
-          Type: 63 GoEmptyInterfaceType interface {}
+          Type: 87 GoEmptyInterfaceType interface {}
     - __kind: StructureType
-      ID: 87
+      ID: 110
       Name: crypto/x509/pkix.Extension
       ByteSize: 56
       GoRuntimeType: 1.683232e+06
@@ -1679,15 +1679,15 @@ Types:
       RawFields:
         - Name: Id
           Offset: 0
-          Type: 73 GoSliceHeaderType encoding/asn1.ObjectIdentifier
+          Type: 97 GoSliceHeaderType encoding/asn1.ObjectIdentifier
         - Name: Critical
           Offset: 24
-          Type: 13 BaseType bool
+          Type: 4 BaseType bool
         - Name: Value
           Offset: 32
-          Type: 53 GoSliceHeaderType []uint8
+          Type: 77 GoSliceHeaderType []uint8
     - __kind: StructureType
-      ID: 69
+      ID: 93
       Name: crypto/x509/pkix.Name
       ByteSize: 248
       GoRuntimeType: 2.249504e+06
@@ -1695,39 +1695,39 @@ Types:
       RawFields:
         - Name: Country
           Offset: 0
-          Type: 28 GoSliceHeaderType []string
+          Type: 54 GoSliceHeaderType []string
         - Name: Organization
           Offset: 24
-          Type: 28 GoSliceHeaderType []string
+          Type: 54 GoSliceHeaderType []string
         - Name: OrganizationalUnit
           Offset: 48
-          Type: 28 GoSliceHeaderType []string
+          Type: 54 GoSliceHeaderType []string
         - Name: Locality
           Offset: 72
-          Type: 28 GoSliceHeaderType []string
+          Type: 54 GoSliceHeaderType []string
         - Name: Province
           Offset: 96
-          Type: 28 GoSliceHeaderType []string
+          Type: 54 GoSliceHeaderType []string
         - Name: StreetAddress
           Offset: 120
-          Type: 28 GoSliceHeaderType []string
+          Type: 54 GoSliceHeaderType []string
         - Name: PostalCode
           Offset: 144
-          Type: 28 GoSliceHeaderType []string
+          Type: 54 GoSliceHeaderType []string
         - Name: SerialNumber
           Offset: 168
-          Type: 5 GoStringHeaderType string
+          Type: 9 GoStringHeaderType string
         - Name: CommonName
           Offset: 184
-          Type: 5 GoStringHeaderType string
+          Type: 9 GoStringHeaderType string
         - Name: Names
           Offset: 200
-          Type: 70 GoSliceHeaderType []crypto/x509/pkix.AttributeTypeAndValue
+          Type: 94 GoSliceHeaderType []crypto/x509/pkix.AttributeTypeAndValue
         - Name: ExtraNames
           Offset: 224
-          Type: 70 GoSliceHeaderType []crypto/x509/pkix.AttributeTypeAndValue
+          Type: 94 GoSliceHeaderType []crypto/x509/pkix.AttributeTypeAndValue
     - __kind: GoSliceHeaderType
-      ID: 73
+      ID: 97
       Name: encoding/asn1.ObjectIdentifier
       ByteSize: 24
       GoRuntimeType: 1.0792e+06
@@ -1735,21 +1735,21 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 74 PointerType *int
+          Type: 27 PointerType *int
         - Name: len
           Offset: 8
-          Type: 8 BaseType int
+          Type: 7 BaseType int
         - Name: cap
           Offset: 16
-          Type: 8 BaseType int
+          Type: 7 BaseType int
       Data: 246 GoSliceDataType encoding/asn1.ObjectIdentifier.array
     - __kind: GoSliceDataType
       ID: 246
       Name: encoding/asn1.ObjectIdentifier.array
       ByteSize: 2048
-      Element: 8 BaseType int
+      Element: 7 BaseType int
     - __kind: GoInterfaceType
-      ID: 211
+      ID: 14
       Name: error
       ByteSize: 16
       GoRuntimeType: 1.0536e+06
@@ -1757,42 +1757,42 @@ Types:
       RawFields:
         - Name: tab
           Offset: 0
-          Type: 2 VoidPointerType unsafe.Pointer
+          Type: 15 VoidPointerType unsafe.Pointer
         - Name: data
           Offset: 8
-          Type: 2 VoidPointerType unsafe.Pointer
+          Type: 15 VoidPointerType unsafe.Pointer
     - __kind: BaseType
-      ID: 213
+      ID: 18
       Name: float32
       ByteSize: 4
       GoRuntimeType: 594880
       GoKind: 13
     - __kind: BaseType
-      ID: 167
+      ID: 16
       Name: float64
       ByteSize: 8
       GoRuntimeType: 594944
       GoKind: 14
     - __kind: GoSubroutineType
-      ID: 205
+      ID: 224
       Name: func()
       ByteSize: 8
       GoRuntimeType: 484800
       GoKind: 19
     - __kind: GoSubroutineType
-      ID: 31
+      ID: 56
       Name: func() (io.ReadCloser, error)
       ByteSize: 8
       GoRuntimeType: 704864
       GoKind: 19
     - __kind: GoSubroutineType
-      ID: 113
+      ID: 136
       Name: func(string, []uint8, int) ([]uint8, error)
       ByteSize: 8
       GoRuntimeType: 1.024448e+06
       GoKind: 19
     - __kind: StructureType
-      ID: 136
+      ID: 159
       Name: github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span
       ByteSize: 288
       GoRuntimeType: 2.396832e+06
@@ -1800,81 +1800,81 @@ Types:
       RawFields:
         - Name: mu
           Offset: 0
-          Type: 137 StructureType sync.RWMutex
+          Type: 160 StructureType sync.RWMutex
         - Name: name
           Offset: 24
-          Type: 5 GoStringHeaderType string
+          Type: 9 GoStringHeaderType string
         - Name: service
           Offset: 40
-          Type: 5 GoStringHeaderType string
+          Type: 9 GoStringHeaderType string
         - Name: resource
           Offset: 56
-          Type: 5 GoStringHeaderType string
+          Type: 9 GoStringHeaderType string
         - Name: spanType
           Offset: 72
-          Type: 5 GoStringHeaderType string
+          Type: 9 GoStringHeaderType string
         - Name: start
           Offset: 88
-          Type: 32 BaseType int64
+          Type: 13 BaseType int64
         - Name: duration
           Offset: 96
-          Type: 32 BaseType int64
+          Type: 13 BaseType int64
         - Name: meta
           Offset: 104
-          Type: 124 GoMapType map[string]string
+          Type: 147 GoMapType map[string]string
         - Name: metaStruct
           Offset: 112
-          Type: 145 GoMapType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.metaStructMap
+          Type: 166 GoMapType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.metaStructMap
         - Name: metrics
           Offset: 120
-          Type: 156 GoMapType map[string]float64
+          Type: 177 GoMapType map[string]float64
         - Name: spanID
           Offset: 128
-          Type: 17 BaseType uint64
+          Type: 8 BaseType uint64
         - Name: traceID
           Offset: 136
-          Type: 17 BaseType uint64
+          Type: 8 BaseType uint64
         - Name: parentID
           Offset: 144
-          Type: 17 BaseType uint64
+          Type: 8 BaseType uint64
         - Name: error
           Offset: 152
-          Type: 141 BaseType int32
+          Type: 12 BaseType int32
         - Name: spanLinks
           Offset: 160
-          Type: 168 GoSliceHeaderType []github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink
+          Type: 188 GoSliceHeaderType []github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink
         - Name: spanEvents
           Offset: 184
-          Type: 171 GoSliceHeaderType []github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent
+          Type: 191 GoSliceHeaderType []github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent
         - Name: goExecTraced
           Offset: 208
-          Type: 13 BaseType bool
+          Type: 4 BaseType bool
         - Name: noDebugStack
           Offset: 209
-          Type: 13 BaseType bool
+          Type: 4 BaseType bool
         - Name: finished
           Offset: 210
-          Type: 13 BaseType bool
+          Type: 4 BaseType bool
         - Name: context
           Offset: 216
-          Type: 196 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanContext
+          Type: 216 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanContext
         - Name: integration
           Offset: 224
-          Type: 5 GoStringHeaderType string
+          Type: 9 GoStringHeaderType string
         - Name: supportsEvents
           Offset: 240
-          Type: 13 BaseType bool
+          Type: 4 BaseType bool
         - Name: pprofCtxActive
           Offset: 248
-          Type: 118 GoInterfaceType context.Context
+          Type: 141 GoInterfaceType context.Context
         - Name: pprofCtxRestore
           Offset: 264
-          Type: 118 GoInterfaceType context.Context
+          Type: 141 GoInterfaceType context.Context
         - Name: taskEnd
           Offset: 280
-          Type: 205 GoSubroutineType func()
+          Type: 224 GoSubroutineType func()
     - __kind: StructureType
-      ID: 197
+      ID: 217
       Name: github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanContext
       ByteSize: 168
       GoRuntimeType: 2.269184e+06
@@ -1882,48 +1882,48 @@ Types:
       RawFields:
         - Name: updated
           Offset: 0
-          Type: 13 BaseType bool
+          Type: 4 BaseType bool
         - Name: trace
           Offset: 8
-          Type: 198 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.trace
+          Type: 218 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.trace
         - Name: span
           Offset: 16
-          Type: 135 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span
+          Type: 158 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span
         - Name: errors
           Offset: 24
-          Type: 143 StructureType sync/atomic.Int32
+          Type: 164 StructureType sync/atomic.Int32
         - Name: reparentID
           Offset: 32
-          Type: 5 GoStringHeaderType string
+          Type: 9 GoStringHeaderType string
         - Name: isRemote
           Offset: 48
-          Type: 13 BaseType bool
+          Type: 4 BaseType bool
         - Name: traceID
           Offset: 49
-          Type: 204 ArrayType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.traceID
+          Type: 223 ArrayType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.traceID
         - Name: spanID
           Offset: 72
-          Type: 17 BaseType uint64
+          Type: 8 BaseType uint64
         - Name: mu
           Offset: 80
-          Type: 137 StructureType sync.RWMutex
+          Type: 160 StructureType sync.RWMutex
         - Name: baggage
           Offset: 104
-          Type: 124 GoMapType map[string]string
+          Type: 147 GoMapType map[string]string
         - Name: hasBaggage
           Offset: 112
-          Type: 142 BaseType uint32
+          Type: 2 BaseType uint32
         - Name: origin
           Offset: 120
-          Type: 5 GoStringHeaderType string
+          Type: 9 GoStringHeaderType string
         - Name: spanLinks
           Offset: 136
-          Type: 168 GoSliceHeaderType []github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink
+          Type: 188 GoSliceHeaderType []github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink
         - Name: baggageOnly
           Offset: 160
-          Type: 13 BaseType bool
+          Type: 4 BaseType bool
     - __kind: StructureType
-      ID: 170
+      ID: 190
       Name: github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink
       ByteSize: 56
       GoRuntimeType: 1.954848e+06
@@ -1931,37 +1931,37 @@ Types:
       RawFields:
         - Name: TraceID
           Offset: 0
-          Type: 17 BaseType uint64
+          Type: 8 BaseType uint64
         - Name: TraceIDHigh
           Offset: 8
-          Type: 17 BaseType uint64
+          Type: 8 BaseType uint64
         - Name: SpanID
           Offset: 16
-          Type: 17 BaseType uint64
+          Type: 8 BaseType uint64
         - Name: Attributes
           Offset: 24
-          Type: 124 GoMapType map[string]string
+          Type: 147 GoMapType map[string]string
         - Name: Tracestate
           Offset: 32
-          Type: 5 GoStringHeaderType string
+          Type: 9 GoStringHeaderType string
         - Name: Flags
           Offset: 48
-          Type: 142 BaseType uint32
+          Type: 2 BaseType uint32
     - __kind: GoMapType
-      ID: 145
+      ID: 166
       Name: github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.metaStructMap
       ByteSize: 8
       GoRuntimeType: 1.303776e+06
       GoKind: 21
-      HeaderType: 147 GoSwissMapHeaderType map<string,interface {}>
+      HeaderType: 168 GoSwissMapHeaderType map<string,interface {}>
     - __kind: BaseType
-      ID: 203
+      ID: 222
       Name: github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.samplingDecision
       ByteSize: 4
       GoRuntimeType: 593792
       GoKind: 10
     - __kind: StructureType
-      ID: 173
+      ID: 193
       Name: github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent
       ByteSize: 40
       GoRuntimeType: 1.78912e+06
@@ -1969,18 +1969,18 @@ Types:
       RawFields:
         - Name: Name
           Offset: 0
-          Type: 5 GoStringHeaderType string
+          Type: 9 GoStringHeaderType string
         - Name: TimeUnixNano
           Offset: 16
-          Type: 17 BaseType uint64
+          Type: 8 BaseType uint64
         - Name: Attributes
           Offset: 24
-          Type: 174 GoMapType map[string]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
+          Type: 194 GoMapType map[string]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
         - Name: RawAttributes
           Offset: 32
-          Type: 195 GoMapType map[string]interface {}
+          Type: 215 GoMapType map[string]interface {}
     - __kind: StructureType
-      ID: 189
+      ID: 209
       Name: github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttribute
       ByteSize: 24
       GoRuntimeType: 1.214496e+06
@@ -1988,9 +1988,9 @@ Types:
       RawFields:
         - Name: Values
           Offset: 0
-          Type: 190 GoSliceHeaderType []*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttributeValue
+          Type: 210 GoSliceHeaderType []*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttributeValue
     - __kind: StructureType
-      ID: 193
+      ID: 213
       Name: github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttributeValue
       ByteSize: 48
       GoRuntimeType: 1.878208e+06
@@ -1998,27 +1998,27 @@ Types:
       RawFields:
         - Name: Type
           Offset: 0
-          Type: 194 BaseType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttributeValueType
+          Type: 214 BaseType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttributeValueType
         - Name: StringValue
           Offset: 8
-          Type: 5 GoStringHeaderType string
+          Type: 9 GoStringHeaderType string
         - Name: BoolValue
           Offset: 24
-          Type: 13 BaseType bool
+          Type: 4 BaseType bool
         - Name: IntValue
           Offset: 32
-          Type: 32 BaseType int64
+          Type: 13 BaseType int64
         - Name: DoubleValue
           Offset: 40
-          Type: 167 BaseType float64
+          Type: 16 BaseType float64
     - __kind: BaseType
-      ID: 194
+      ID: 214
       Name: github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttributeValueType
       ByteSize: 4
       GoRuntimeType: 1.006112e+06
       GoKind: 5
     - __kind: StructureType
-      ID: 186
+      ID: 206
       Name: github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
       ByteSize: 56
       GoRuntimeType: 1.955104e+06
@@ -2026,30 +2026,30 @@ Types:
       RawFields:
         - Name: Type
           Offset: 0
-          Type: 187 BaseType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttributeType
+          Type: 207 BaseType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttributeType
         - Name: StringValue
           Offset: 8
-          Type: 5 GoStringHeaderType string
+          Type: 9 GoStringHeaderType string
         - Name: BoolValue
           Offset: 24
-          Type: 13 BaseType bool
+          Type: 4 BaseType bool
         - Name: IntValue
           Offset: 32
-          Type: 32 BaseType int64
+          Type: 13 BaseType int64
         - Name: DoubleValue
           Offset: 40
-          Type: 167 BaseType float64
+          Type: 16 BaseType float64
         - Name: ArrayValue
           Offset: 48
-          Type: 188 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttribute
+          Type: 208 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttribute
     - __kind: BaseType
-      ID: 187
+      ID: 207
       Name: github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttributeType
       ByteSize: 4
       GoRuntimeType: 1.006016e+06
       GoKind: 5
     - __kind: StructureType
-      ID: 199
+      ID: 219
       Name: github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.trace
       ByteSize: 104
       GoRuntimeType: 2.154976e+06
@@ -2057,159 +2057,159 @@ Types:
       RawFields:
         - Name: mu
           Offset: 0
-          Type: 137 StructureType sync.RWMutex
+          Type: 160 StructureType sync.RWMutex
         - Name: spans
           Offset: 24
-          Type: 200 GoSliceHeaderType []*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span
+          Type: 220 GoSliceHeaderType []*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span
         - Name: tags
           Offset: 48
-          Type: 124 GoMapType map[string]string
+          Type: 147 GoMapType map[string]string
         - Name: propagatingTags
           Offset: 56
-          Type: 124 GoMapType map[string]string
+          Type: 147 GoMapType map[string]string
         - Name: finished
           Offset: 64
-          Type: 8 BaseType int
+          Type: 7 BaseType int
         - Name: full
           Offset: 72
-          Type: 13 BaseType bool
+          Type: 4 BaseType bool
         - Name: priority
           Offset: 80
-          Type: 202 PointerType *float64
+          Type: 26 PointerType *float64
         - Name: locked
           Offset: 88
-          Type: 13 BaseType bool
+          Type: 4 BaseType bool
         - Name: samplingDecision
           Offset: 92
-          Type: 203 BaseType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.samplingDecision
+          Type: 222 BaseType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.samplingDecision
         - Name: root
           Offset: 96
-          Type: 135 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span
+          Type: 158 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span
     - __kind: ArrayType
-      ID: 204
+      ID: 223
       Name: github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.traceID
       ByteSize: 16
       GoRuntimeType: 918624
       GoKind: 17
       Count: 16
       HasCount: true
-      Element: 7 BaseType uint8
+      Element: 3 BaseType uint8
     - __kind: GoSwissMapGroupsType
-      ID: 180
+      ID: 200
       Name: groupReference<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 181 PointerType *noalg.map.group[string]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
+          Type: 201 PointerType *noalg.map.group[string]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
         - Name: lengthMask
           Offset: 8
-          Type: 17 BaseType uint64
-      GroupType: 182 StructureType noalg.map.group[string]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
+          Type: 8 BaseType uint64
+      GroupType: 202 StructureType noalg.map.group[string]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
       GroupSliceType: 289 GoSliceDataType []noalg.map.group[string]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute.array
     - __kind: GoSwissMapGroupsType
-      ID: 43
+      ID: 67
       Name: groupReference<string,[]*mime/multipart.FileHeader>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 44 PointerType *noalg.map.group[string][]*mime/multipart.FileHeader
+          Type: 68 PointerType *noalg.map.group[string][]*mime/multipart.FileHeader
         - Name: lengthMask
           Offset: 8
-          Type: 17 BaseType uint64
-      GroupType: 45 StructureType noalg.map.group[string][]*mime/multipart.FileHeader
+          Type: 8 BaseType uint64
+      GroupType: 69 StructureType noalg.map.group[string][]*mime/multipart.FileHeader
       GroupSliceType: 235 GoSliceDataType []noalg.map.group[string][]*mime/multipart.FileHeader.array
     - __kind: GoSwissMapGroupsType
-      ID: 23
+      ID: 49
       Name: groupReference<string,[]string>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 24 PointerType *noalg.map.group[string][]string
+          Type: 50 PointerType *noalg.map.group[string][]string
         - Name: lengthMask
           Offset: 8
-          Type: 17 BaseType uint64
-      GroupType: 25 StructureType noalg.map.group[string][]string
+          Type: 8 BaseType uint64
+      GroupType: 51 StructureType noalg.map.group[string][]string
       GroupSliceType: 231 GoSliceDataType []noalg.map.group[string][]string.array
     - __kind: GoSwissMapGroupsType
-      ID: 162
+      ID: 183
       Name: groupReference<string,float64>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 163 PointerType *noalg.map.group[string]float64
+          Type: 184 PointerType *noalg.map.group[string]float64
         - Name: lengthMask
           Offset: 8
-          Type: 17 BaseType uint64
-      GroupType: 164 StructureType noalg.map.group[string]float64
+          Type: 8 BaseType uint64
+      GroupType: 185 StructureType noalg.map.group[string]float64
       GroupSliceType: 283 GoSliceDataType []noalg.map.group[string]float64.array
     - __kind: GoSwissMapGroupsType
-      ID: 151
+      ID: 172
       Name: groupReference<string,interface {}>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 152 PointerType *noalg.map.group[string]interface {}
+          Type: 173 PointerType *noalg.map.group[string]interface {}
         - Name: lengthMask
           Offset: 8
-          Type: 17 BaseType uint64
-      GroupType: 153 StructureType noalg.map.group[string]interface {}
+          Type: 8 BaseType uint64
+      GroupType: 174 StructureType noalg.map.group[string]interface {}
       GroupSliceType: 281 GoSliceDataType []noalg.map.group[string]interface {}.array
     - __kind: GoSwissMapGroupsType
-      ID: 130
+      ID: 153
       Name: groupReference<string,string>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 131 PointerType *noalg.map.group[string]string
+          Type: 154 PointerType *noalg.map.group[string]string
         - Name: lengthMask
           Offset: 8
-          Type: 17 BaseType uint64
-      GroupType: 132 StructureType noalg.map.group[string]string
+          Type: 8 BaseType uint64
+      GroupType: 155 StructureType noalg.map.group[string]string
       GroupSliceType: 279 GoSliceDataType []noalg.map.group[string]string.array
     - __kind: BaseType
-      ID: 8
+      ID: 7
       Name: int
       ByteSize: 8
       GoRuntimeType: 594560
       GoKind: 2
     - __kind: BaseType
-      ID: 217
+      ID: 23
       Name: int16
       ByteSize: 2
       GoRuntimeType: 594176
       GoKind: 4
     - __kind: BaseType
-      ID: 141
+      ID: 12
       Name: int32
       ByteSize: 4
       GoRuntimeType: 594304
       GoKind: 5
     - __kind: BaseType
-      ID: 32
+      ID: 13
       Name: int64
       ByteSize: 8
       GoRuntimeType: 594432
       GoKind: 6
     - __kind: BaseType
-      ID: 212
+      ID: 17
       Name: int8
       ByteSize: 1
       GoRuntimeType: 594048
       GoKind: 3
     - __kind: GoEmptyInterfaceType
-      ID: 63
+      ID: 87
       Name: interface {}
       ByteSize: 16
       GoRuntimeType: 866496
@@ -2217,12 +2217,12 @@ Types:
       RawFields:
         - Name: _type
           Offset: 0
-          Type: 2 VoidPointerType unsafe.Pointer
+          Type: 15 VoidPointerType unsafe.Pointer
         - Name: data
           Offset: 8
-          Type: 2 VoidPointerType unsafe.Pointer
+          Type: 15 VoidPointerType unsafe.Pointer
     - __kind: StructureType
-      ID: 140
+      ID: 163
       Name: internal/sync.Mutex
       ByteSize: 8
       GoRuntimeType: 1.517472e+06
@@ -2230,12 +2230,12 @@ Types:
       RawFields:
         - Name: state
           Offset: 0
-          Type: 141 BaseType int32
+          Type: 12 BaseType int32
         - Name: sema
           Offset: 4
-          Type: 142 BaseType uint32
+          Type: 2 BaseType uint32
     - __kind: GoInterfaceType
-      ID: 30
+      ID: 55
       Name: io.ReadCloser
       ByteSize: 16
       GoRuntimeType: 1.134464e+06
@@ -2243,264 +2243,264 @@ Types:
       RawFields:
         - Name: tab
           Offset: 0
-          Type: 2 VoidPointerType unsafe.Pointer
+          Type: 15 VoidPointerType unsafe.Pointer
         - Name: data
           Offset: 8
-          Type: 2 VoidPointerType unsafe.Pointer
+          Type: 15 VoidPointerType unsafe.Pointer
     - __kind: GoSwissMapHeaderType
-      ID: 176
+      ID: 196
       Name: map<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
       ByteSize: 48
       GoKind: 25
       RawFields:
         - Name: used
           Offset: 0
-          Type: 17 BaseType uint64
+          Type: 8 BaseType uint64
         - Name: seed
           Offset: 8
-          Type: 18 BaseType uintptr
+          Type: 1 BaseType uintptr
         - Name: dirPtr
           Offset: 16
-          Type: 177 PointerType **table<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
+          Type: 197 PointerType **table<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
         - Name: dirLen
           Offset: 24
-          Type: 8 BaseType int
+          Type: 7 BaseType int
         - Name: globalDepth
           Offset: 32
-          Type: 7 BaseType uint8
+          Type: 3 BaseType uint8
         - Name: globalShift
           Offset: 33
-          Type: 7 BaseType uint8
+          Type: 3 BaseType uint8
         - Name: writing
           Offset: 34
-          Type: 7 BaseType uint8
+          Type: 3 BaseType uint8
         - Name: tombstonePossible
           Offset: 35
-          Type: 13 BaseType bool
+          Type: 4 BaseType bool
         - Name: clearSeq
           Offset: 40
-          Type: 17 BaseType uint64
+          Type: 8 BaseType uint64
       TablePtrSliceType: 288 GoSliceDataType []*table<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>.array
-      GroupType: 182 StructureType noalg.map.group[string]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
+      GroupType: 202 StructureType noalg.map.group[string]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
     - __kind: GoSwissMapHeaderType
-      ID: 39
+      ID: 63
       Name: map<string,[]*mime/multipart.FileHeader>
       ByteSize: 48
       GoKind: 25
       RawFields:
         - Name: used
           Offset: 0
-          Type: 17 BaseType uint64
+          Type: 8 BaseType uint64
         - Name: seed
           Offset: 8
-          Type: 18 BaseType uintptr
+          Type: 1 BaseType uintptr
         - Name: dirPtr
           Offset: 16
-          Type: 40 PointerType **table<string,[]*mime/multipart.FileHeader>
+          Type: 64 PointerType **table<string,[]*mime/multipart.FileHeader>
         - Name: dirLen
           Offset: 24
-          Type: 8 BaseType int
+          Type: 7 BaseType int
         - Name: globalDepth
           Offset: 32
-          Type: 7 BaseType uint8
+          Type: 3 BaseType uint8
         - Name: globalShift
           Offset: 33
-          Type: 7 BaseType uint8
+          Type: 3 BaseType uint8
         - Name: writing
           Offset: 34
-          Type: 7 BaseType uint8
+          Type: 3 BaseType uint8
         - Name: tombstonePossible
           Offset: 35
-          Type: 13 BaseType bool
+          Type: 4 BaseType bool
         - Name: clearSeq
           Offset: 40
-          Type: 17 BaseType uint64
+          Type: 8 BaseType uint64
       TablePtrSliceType: 234 GoSliceDataType []*table<string,[]*mime/multipart.FileHeader>.array
-      GroupType: 45 StructureType noalg.map.group[string][]*mime/multipart.FileHeader
+      GroupType: 69 StructureType noalg.map.group[string][]*mime/multipart.FileHeader
     - __kind: GoSwissMapHeaderType
-      ID: 16
+      ID: 45
       Name: map<string,[]string>
       ByteSize: 48
       GoKind: 25
       RawFields:
         - Name: used
           Offset: 0
-          Type: 17 BaseType uint64
+          Type: 8 BaseType uint64
         - Name: seed
           Offset: 8
-          Type: 18 BaseType uintptr
+          Type: 1 BaseType uintptr
         - Name: dirPtr
           Offset: 16
-          Type: 19 PointerType **table<string,[]string>
+          Type: 46 PointerType **table<string,[]string>
         - Name: dirLen
           Offset: 24
-          Type: 8 BaseType int
+          Type: 7 BaseType int
         - Name: globalDepth
           Offset: 32
-          Type: 7 BaseType uint8
+          Type: 3 BaseType uint8
         - Name: globalShift
           Offset: 33
-          Type: 7 BaseType uint8
+          Type: 3 BaseType uint8
         - Name: writing
           Offset: 34
-          Type: 7 BaseType uint8
+          Type: 3 BaseType uint8
         - Name: tombstonePossible
           Offset: 35
-          Type: 13 BaseType bool
+          Type: 4 BaseType bool
         - Name: clearSeq
           Offset: 40
-          Type: 17 BaseType uint64
+          Type: 8 BaseType uint64
       TablePtrSliceType: 230 GoSliceDataType []*table<string,[]string>.array
-      GroupType: 25 StructureType noalg.map.group[string][]string
+      GroupType: 51 StructureType noalg.map.group[string][]string
     - __kind: GoSwissMapHeaderType
-      ID: 158
+      ID: 179
       Name: map<string,float64>
       ByteSize: 48
       GoKind: 25
       RawFields:
         - Name: used
           Offset: 0
-          Type: 17 BaseType uint64
+          Type: 8 BaseType uint64
         - Name: seed
           Offset: 8
-          Type: 18 BaseType uintptr
+          Type: 1 BaseType uintptr
         - Name: dirPtr
           Offset: 16
-          Type: 159 PointerType **table<string,float64>
+          Type: 180 PointerType **table<string,float64>
         - Name: dirLen
           Offset: 24
-          Type: 8 BaseType int
+          Type: 7 BaseType int
         - Name: globalDepth
           Offset: 32
-          Type: 7 BaseType uint8
+          Type: 3 BaseType uint8
         - Name: globalShift
           Offset: 33
-          Type: 7 BaseType uint8
+          Type: 3 BaseType uint8
         - Name: writing
           Offset: 34
-          Type: 7 BaseType uint8
+          Type: 3 BaseType uint8
         - Name: tombstonePossible
           Offset: 35
-          Type: 13 BaseType bool
+          Type: 4 BaseType bool
         - Name: clearSeq
           Offset: 40
-          Type: 17 BaseType uint64
+          Type: 8 BaseType uint64
       TablePtrSliceType: 282 GoSliceDataType []*table<string,float64>.array
-      GroupType: 164 StructureType noalg.map.group[string]float64
+      GroupType: 185 StructureType noalg.map.group[string]float64
     - __kind: GoSwissMapHeaderType
-      ID: 147
+      ID: 168
       Name: map<string,interface {}>
       ByteSize: 48
       GoKind: 25
       RawFields:
         - Name: used
           Offset: 0
-          Type: 17 BaseType uint64
+          Type: 8 BaseType uint64
         - Name: seed
           Offset: 8
-          Type: 18 BaseType uintptr
+          Type: 1 BaseType uintptr
         - Name: dirPtr
           Offset: 16
-          Type: 148 PointerType **table<string,interface {}>
+          Type: 169 PointerType **table<string,interface {}>
         - Name: dirLen
           Offset: 24
-          Type: 8 BaseType int
+          Type: 7 BaseType int
         - Name: globalDepth
           Offset: 32
-          Type: 7 BaseType uint8
+          Type: 3 BaseType uint8
         - Name: globalShift
           Offset: 33
-          Type: 7 BaseType uint8
+          Type: 3 BaseType uint8
         - Name: writing
           Offset: 34
-          Type: 7 BaseType uint8
+          Type: 3 BaseType uint8
         - Name: tombstonePossible
           Offset: 35
-          Type: 13 BaseType bool
+          Type: 4 BaseType bool
         - Name: clearSeq
           Offset: 40
-          Type: 17 BaseType uint64
+          Type: 8 BaseType uint64
       TablePtrSliceType: 280 GoSliceDataType []*table<string,interface {}>.array
-      GroupType: 153 StructureType noalg.map.group[string]interface {}
+      GroupType: 174 StructureType noalg.map.group[string]interface {}
     - __kind: GoSwissMapHeaderType
-      ID: 126
+      ID: 149
       Name: map<string,string>
       ByteSize: 48
       GoKind: 25
       RawFields:
         - Name: used
           Offset: 0
-          Type: 17 BaseType uint64
+          Type: 8 BaseType uint64
         - Name: seed
           Offset: 8
-          Type: 18 BaseType uintptr
+          Type: 1 BaseType uintptr
         - Name: dirPtr
           Offset: 16
-          Type: 127 PointerType **table<string,string>
+          Type: 150 PointerType **table<string,string>
         - Name: dirLen
           Offset: 24
-          Type: 8 BaseType int
+          Type: 7 BaseType int
         - Name: globalDepth
           Offset: 32
-          Type: 7 BaseType uint8
+          Type: 3 BaseType uint8
         - Name: globalShift
           Offset: 33
-          Type: 7 BaseType uint8
+          Type: 3 BaseType uint8
         - Name: writing
           Offset: 34
-          Type: 7 BaseType uint8
+          Type: 3 BaseType uint8
         - Name: tombstonePossible
           Offset: 35
-          Type: 13 BaseType bool
+          Type: 4 BaseType bool
         - Name: clearSeq
           Offset: 40
-          Type: 17 BaseType uint64
+          Type: 8 BaseType uint64
       TablePtrSliceType: 278 GoSliceDataType []*table<string,string>.array
-      GroupType: 132 StructureType noalg.map.group[string]string
+      GroupType: 155 StructureType noalg.map.group[string]string
     - __kind: GoMapType
-      ID: 174
+      ID: 194
       Name: map[string]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
       ByteSize: 8
       GoRuntimeType: 1.157632e+06
       GoKind: 21
-      HeaderType: 176 GoSwissMapHeaderType map<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
+      HeaderType: 196 GoSwissMapHeaderType map<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
     - __kind: GoMapType
-      ID: 37
+      ID: 61
       Name: map[string][]*mime/multipart.FileHeader
       ByteSize: 8
       GoRuntimeType: 1.156864e+06
       GoKind: 21
-      HeaderType: 39 GoSwissMapHeaderType map<string,[]*mime/multipart.FileHeader>
+      HeaderType: 63 GoSwissMapHeaderType map<string,[]*mime/multipart.FileHeader>
     - __kind: GoMapType
-      ID: 36
+      ID: 60
       Name: map[string][]string
       ByteSize: 8
       GoRuntimeType: 1.152512e+06
       GoKind: 21
-      HeaderType: 16 GoSwissMapHeaderType map<string,[]string>
+      HeaderType: 45 GoSwissMapHeaderType map<string,[]string>
     - __kind: GoMapType
-      ID: 156
+      ID: 177
       Name: map[string]float64
       ByteSize: 8
       GoRuntimeType: 1.157504e+06
       GoKind: 21
-      HeaderType: 158 GoSwissMapHeaderType map<string,float64>
+      HeaderType: 179 GoSwissMapHeaderType map<string,float64>
     - __kind: GoMapType
-      ID: 195
+      ID: 215
       Name: map[string]interface {}
       ByteSize: 8
       GoRuntimeType: 1.151104e+06
       GoKind: 21
-      HeaderType: 147 GoSwissMapHeaderType map<string,interface {}>
+      HeaderType: 168 GoSwissMapHeaderType map<string,interface {}>
     - __kind: GoMapType
-      ID: 124
+      ID: 147
       Name: map[string]string
       ByteSize: 8
       GoRuntimeType: 1.153536e+06
       GoKind: 21
-      HeaderType: 126 GoSwissMapHeaderType map<string,string>
+      HeaderType: 149 GoSwissMapHeaderType map<string,string>
     - __kind: StructureType
-      ID: 65
+      ID: 89
       Name: math/big.Int
       ByteSize: 32
       GoRuntimeType: 1.522752e+06
@@ -2508,18 +2508,18 @@ Types:
       RawFields:
         - Name: neg
           Offset: 0
-          Type: 13 BaseType bool
+          Type: 4 BaseType bool
         - Name: abs
           Offset: 8
-          Type: 66 GoSliceHeaderType math/big.nat
+          Type: 90 GoSliceHeaderType math/big.nat
     - __kind: BaseType
-      ID: 68
+      ID: 92
       Name: math/big.Word
       ByteSize: 8
       GoRuntimeType: 598272
       GoKind: 7
     - __kind: GoSliceHeaderType
-      ID: 66
+      ID: 90
       Name: math/big.nat
       ByteSize: 24
       GoRuntimeType: 2.426144e+06
@@ -2527,21 +2527,21 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 67 PointerType *math/big.Word
+          Type: 91 PointerType *math/big.Word
         - Name: len
           Offset: 8
-          Type: 8 BaseType int
+          Type: 7 BaseType int
         - Name: cap
           Offset: 16
-          Type: 8 BaseType int
+          Type: 7 BaseType int
       Data: 242 GoSliceDataType math/big.nat.array
     - __kind: GoSliceDataType
       ID: 242
       Name: math/big.nat.array
       ByteSize: 2048
-      Element: 68 BaseType math/big.Word
+      Element: 92 BaseType math/big.Word
     - __kind: StructureType
-      ID: 51
+      ID: 75
       Name: mime/multipart.FileHeader
       ByteSize: 88
       GoRuntimeType: 2.018016e+06
@@ -2549,27 +2549,27 @@ Types:
       RawFields:
         - Name: Filename
           Offset: 0
-          Type: 5 GoStringHeaderType string
+          Type: 9 GoStringHeaderType string
         - Name: Header
           Offset: 16
-          Type: 52 GoMapType net/textproto.MIMEHeader
+          Type: 76 GoMapType net/textproto.MIMEHeader
         - Name: Size
           Offset: 24
-          Type: 32 BaseType int64
+          Type: 13 BaseType int64
         - Name: content
           Offset: 32
-          Type: 53 GoSliceHeaderType []uint8
+          Type: 77 GoSliceHeaderType []uint8
         - Name: tmpfile
           Offset: 56
-          Type: 5 GoStringHeaderType string
+          Type: 9 GoStringHeaderType string
         - Name: tmpoff
           Offset: 72
-          Type: 32 BaseType int64
+          Type: 13 BaseType int64
         - Name: tmpshared
           Offset: 80
-          Type: 13 BaseType bool
+          Type: 4 BaseType bool
     - __kind: StructureType
-      ID: 35
+      ID: 59
       Name: mime/multipart.Form
       ByteSize: 16
       GoRuntimeType: 1.505952e+06
@@ -2577,12 +2577,12 @@ Types:
       RawFields:
         - Name: Value
           Offset: 0
-          Type: 36 GoMapType map[string][]string
+          Type: 60 GoMapType map[string][]string
         - Name: File
           Offset: 8
-          Type: 37 GoMapType map[string][]*mime/multipart.FileHeader
+          Type: 61 GoMapType map[string][]*mime/multipart.FileHeader
     - __kind: GoSliceHeaderType
-      ID: 95
+      ID: 118
       Name: net.IP
       ByteSize: 24
       GoRuntimeType: 2.178176e+06
@@ -2590,21 +2590,21 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 6 PointerType *uint8
+          Type: 5 PointerType *uint8
         - Name: len
           Offset: 8
-          Type: 8 BaseType int
+          Type: 7 BaseType int
         - Name: cap
           Offset: 16
-          Type: 8 BaseType int
+          Type: 7 BaseType int
       Data: 260 GoSliceDataType net.IP.array
     - __kind: GoSliceDataType
       ID: 260
       Name: net.IP.array
       ByteSize: 2048
-      Element: 7 BaseType uint8
+      Element: 3 BaseType uint8
     - __kind: GoSliceHeaderType
-      ID: 102
+      ID: 125
       Name: net.IPMask
       ByteSize: 24
       GoRuntimeType: 1.041568e+06
@@ -2612,21 +2612,21 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 6 PointerType *uint8
+          Type: 5 PointerType *uint8
         - Name: len
           Offset: 8
-          Type: 8 BaseType int
+          Type: 7 BaseType int
         - Name: cap
           Offset: 16
-          Type: 8 BaseType int
+          Type: 7 BaseType int
       Data: 266 GoSliceDataType net.IPMask.array
     - __kind: GoSliceDataType
       ID: 266
       Name: net.IPMask.array
       ByteSize: 2048
-      Element: 7 BaseType uint8
+      Element: 3 BaseType uint8
     - __kind: StructureType
-      ID: 101
+      ID: 124
       Name: net.IPNet
       ByteSize: 48
       GoRuntimeType: 1.486272e+06
@@ -2634,19 +2634,19 @@ Types:
       RawFields:
         - Name: IP
           Offset: 0
-          Type: 95 GoSliceHeaderType net.IP
+          Type: 118 GoSliceHeaderType net.IP
         - Name: Mask
           Offset: 24
-          Type: 102 GoSliceHeaderType net.IPMask
+          Type: 125 GoSliceHeaderType net.IPMask
     - __kind: GoMapType
-      ID: 14
+      ID: 43
       Name: net/http.Header
       ByteSize: 8
       GoRuntimeType: 2.154272e+06
       GoKind: 21
-      HeaderType: 16 GoSwissMapHeaderType map<string,[]string>
+      HeaderType: 45 GoSwissMapHeaderType map<string,[]string>
     - __kind: StructureType
-      ID: 4
+      ID: 38
       Name: net/http.Request
       ByteSize: 304
       GoRuntimeType: 2.40112e+06
@@ -2654,84 +2654,84 @@ Types:
       RawFields:
         - Name: Method
           Offset: 0
-          Type: 5 GoStringHeaderType string
+          Type: 9 GoStringHeaderType string
         - Name: URL
           Offset: 16
-          Type: 9 PointerType *net/url.URL
+          Type: 39 PointerType *net/url.URL
         - Name: Proto
           Offset: 24
-          Type: 5 GoStringHeaderType string
+          Type: 9 GoStringHeaderType string
         - Name: ProtoMajor
           Offset: 40
-          Type: 8 BaseType int
+          Type: 7 BaseType int
         - Name: ProtoMinor
           Offset: 48
-          Type: 8 BaseType int
+          Type: 7 BaseType int
         - Name: Header
           Offset: 56
-          Type: 14 GoMapType net/http.Header
+          Type: 43 GoMapType net/http.Header
         - Name: Body
           Offset: 64
-          Type: 30 GoInterfaceType io.ReadCloser
+          Type: 55 GoInterfaceType io.ReadCloser
         - Name: GetBody
           Offset: 80
-          Type: 31 GoSubroutineType func() (io.ReadCloser, error)
+          Type: 56 GoSubroutineType func() (io.ReadCloser, error)
         - Name: ContentLength
           Offset: 88
-          Type: 32 BaseType int64
+          Type: 13 BaseType int64
         - Name: TransferEncoding
           Offset: 96
-          Type: 28 GoSliceHeaderType []string
+          Type: 54 GoSliceHeaderType []string
         - Name: Close
           Offset: 120
-          Type: 13 BaseType bool
+          Type: 4 BaseType bool
         - Name: Host
           Offset: 128
-          Type: 5 GoStringHeaderType string
+          Type: 9 GoStringHeaderType string
         - Name: Form
           Offset: 144
-          Type: 33 GoMapType net/url.Values
+          Type: 57 GoMapType net/url.Values
         - Name: PostForm
           Offset: 152
-          Type: 33 GoMapType net/url.Values
+          Type: 57 GoMapType net/url.Values
         - Name: MultipartForm
           Offset: 160
-          Type: 34 PointerType *mime/multipart.Form
+          Type: 58 PointerType *mime/multipart.Form
         - Name: Trailer
           Offset: 168
-          Type: 14 GoMapType net/http.Header
+          Type: 43 GoMapType net/http.Header
         - Name: RemoteAddr
           Offset: 176
-          Type: 5 GoStringHeaderType string
+          Type: 9 GoStringHeaderType string
         - Name: RequestURI
           Offset: 192
-          Type: 5 GoStringHeaderType string
+          Type: 9 GoStringHeaderType string
         - Name: TLS
           Offset: 208
-          Type: 54 PointerType *crypto/tls.ConnectionState
+          Type: 78 PointerType *crypto/tls.ConnectionState
         - Name: Cancel
           Offset: 216
-          Type: 115 GoChannelType <-chan struct {}
+          Type: 138 GoChannelType <-chan struct {}
         - Name: Response
           Offset: 224
-          Type: 116 PointerType *net/http.Response
+          Type: 139 PointerType *net/http.Response
         - Name: Pattern
           Offset: 232
-          Type: 5 GoStringHeaderType string
+          Type: 9 GoStringHeaderType string
         - Name: ctx
           Offset: 248
-          Type: 118 GoInterfaceType context.Context
+          Type: 141 GoInterfaceType context.Context
         - Name: pat
           Offset: 264
-          Type: 119 PointerType *net/http.pattern
+          Type: 142 PointerType *net/http.pattern
         - Name: matches
           Offset: 272
-          Type: 28 GoSliceHeaderType []string
+          Type: 54 GoSliceHeaderType []string
         - Name: otherValues
           Offset: 296
-          Type: 124 GoMapType map[string]string
+          Type: 147 GoMapType map[string]string
     - __kind: StructureType
-      ID: 117
+      ID: 140
       Name: net/http.Response
       ByteSize: 144
       GoRuntimeType: 2.26784e+06
@@ -2739,48 +2739,48 @@ Types:
       RawFields:
         - Name: Status
           Offset: 0
-          Type: 5 GoStringHeaderType string
+          Type: 9 GoStringHeaderType string
         - Name: StatusCode
           Offset: 16
-          Type: 8 BaseType int
+          Type: 7 BaseType int
         - Name: Proto
           Offset: 24
-          Type: 5 GoStringHeaderType string
+          Type: 9 GoStringHeaderType string
         - Name: ProtoMajor
           Offset: 40
-          Type: 8 BaseType int
+          Type: 7 BaseType int
         - Name: ProtoMinor
           Offset: 48
-          Type: 8 BaseType int
+          Type: 7 BaseType int
         - Name: Header
           Offset: 56
-          Type: 14 GoMapType net/http.Header
+          Type: 43 GoMapType net/http.Header
         - Name: Body
           Offset: 64
-          Type: 30 GoInterfaceType io.ReadCloser
+          Type: 55 GoInterfaceType io.ReadCloser
         - Name: ContentLength
           Offset: 80
-          Type: 32 BaseType int64
+          Type: 13 BaseType int64
         - Name: TransferEncoding
           Offset: 88
-          Type: 28 GoSliceHeaderType []string
+          Type: 54 GoSliceHeaderType []string
         - Name: Close
           Offset: 112
-          Type: 13 BaseType bool
+          Type: 4 BaseType bool
         - Name: Uncompressed
           Offset: 113
-          Type: 13 BaseType bool
+          Type: 4 BaseType bool
         - Name: Trailer
           Offset: 120
-          Type: 14 GoMapType net/http.Header
+          Type: 43 GoMapType net/http.Header
         - Name: Request
           Offset: 128
-          Type: 3 PointerType *net/http.Request
+          Type: 37 PointerType *net/http.Request
         - Name: TLS
           Offset: 136
-          Type: 54 PointerType *crypto/tls.ConnectionState
+          Type: 78 PointerType *crypto/tls.ConnectionState
     - __kind: GoInterfaceType
-      ID: 1
+      ID: 36
       Name: net/http.ResponseWriter
       ByteSize: 16
       GoRuntimeType: 1.210144e+06
@@ -2788,12 +2788,12 @@ Types:
       RawFields:
         - Name: tab
           Offset: 0
-          Type: 2 VoidPointerType unsafe.Pointer
+          Type: 15 VoidPointerType unsafe.Pointer
         - Name: data
           Offset: 8
-          Type: 2 VoidPointerType unsafe.Pointer
+          Type: 15 VoidPointerType unsafe.Pointer
     - __kind: StructureType
-      ID: 120
+      ID: 143
       Name: net/http.pattern
       ByteSize: 88
       GoRuntimeType: 1.875072e+06
@@ -2801,21 +2801,21 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 5 GoStringHeaderType string
+          Type: 9 GoStringHeaderType string
         - Name: method
           Offset: 16
-          Type: 5 GoStringHeaderType string
+          Type: 9 GoStringHeaderType string
         - Name: host
           Offset: 32
-          Type: 5 GoStringHeaderType string
+          Type: 9 GoStringHeaderType string
         - Name: segments
           Offset: 48
-          Type: 121 GoSliceHeaderType []net/http.segment
+          Type: 144 GoSliceHeaderType []net/http.segment
         - Name: loc
           Offset: 72
-          Type: 5 GoStringHeaderType string
+          Type: 9 GoStringHeaderType string
     - __kind: StructureType
-      ID: 123
+      ID: 146
       Name: net/http.segment
       ByteSize: 24
       GoRuntimeType: 1.641952e+06
@@ -2823,22 +2823,22 @@ Types:
       RawFields:
         - Name: s
           Offset: 0
-          Type: 5 GoStringHeaderType string
+          Type: 9 GoStringHeaderType string
         - Name: wild
           Offset: 16
-          Type: 13 BaseType bool
+          Type: 4 BaseType bool
         - Name: multi
           Offset: 17
-          Type: 13 BaseType bool
+          Type: 4 BaseType bool
     - __kind: GoMapType
-      ID: 52
+      ID: 76
       Name: net/textproto.MIMEHeader
       ByteSize: 8
       GoRuntimeType: 1.863136e+06
       GoKind: 21
-      HeaderType: 16 GoSwissMapHeaderType map<string,[]string>
+      HeaderType: 45 GoSwissMapHeaderType map<string,[]string>
     - __kind: StructureType
-      ID: 10
+      ID: 40
       Name: net/url.URL
       ByteSize: 144
       GoRuntimeType: 2.180864e+06
@@ -2846,39 +2846,39 @@ Types:
       RawFields:
         - Name: Scheme
           Offset: 0
-          Type: 5 GoStringHeaderType string
+          Type: 9 GoStringHeaderType string
         - Name: Opaque
           Offset: 16
-          Type: 5 GoStringHeaderType string
+          Type: 9 GoStringHeaderType string
         - Name: User
           Offset: 32
-          Type: 11 PointerType *net/url.Userinfo
+          Type: 41 PointerType *net/url.Userinfo
         - Name: Host
           Offset: 40
-          Type: 5 GoStringHeaderType string
+          Type: 9 GoStringHeaderType string
         - Name: Path
           Offset: 56
-          Type: 5 GoStringHeaderType string
+          Type: 9 GoStringHeaderType string
         - Name: RawPath
           Offset: 72
-          Type: 5 GoStringHeaderType string
+          Type: 9 GoStringHeaderType string
         - Name: OmitHost
           Offset: 88
-          Type: 13 BaseType bool
+          Type: 4 BaseType bool
         - Name: ForceQuery
           Offset: 89
-          Type: 13 BaseType bool
+          Type: 4 BaseType bool
         - Name: RawQuery
           Offset: 96
-          Type: 5 GoStringHeaderType string
+          Type: 9 GoStringHeaderType string
         - Name: Fragment
           Offset: 112
-          Type: 5 GoStringHeaderType string
+          Type: 9 GoStringHeaderType string
         - Name: RawFragment
           Offset: 128
-          Type: 5 GoStringHeaderType string
+          Type: 9 GoStringHeaderType string
     - __kind: StructureType
-      ID: 12
+      ID: 42
       Name: net/url.Userinfo
       ByteSize: 40
       GoRuntimeType: 1.65808e+06
@@ -2886,76 +2886,76 @@ Types:
       RawFields:
         - Name: username
           Offset: 0
-          Type: 5 GoStringHeaderType string
+          Type: 9 GoStringHeaderType string
         - Name: password
           Offset: 16
-          Type: 5 GoStringHeaderType string
+          Type: 9 GoStringHeaderType string
         - Name: passwordSet
           Offset: 32
-          Type: 13 BaseType bool
+          Type: 4 BaseType bool
     - __kind: GoMapType
-      ID: 33
+      ID: 57
       Name: net/url.Values
       ByteSize: 8
       GoRuntimeType: 1.927712e+06
       GoKind: 21
-      HeaderType: 16 GoSwissMapHeaderType map<string,[]string>
+      HeaderType: 45 GoSwissMapHeaderType map<string,[]string>
     - __kind: ArrayType
-      ID: 183
+      ID: 203
       Name: noalg.[8]struct { key string; elem *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute }
       ByteSize: 192
       GoRuntimeType: 715104
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 184 StructureType noalg.struct { key string; elem *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute }
+      Element: 204 StructureType noalg.struct { key string; elem *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute }
     - __kind: ArrayType
-      ID: 46
+      ID: 70
       Name: noalg.[8]struct { key string; elem []*mime/multipart.FileHeader }
       ByteSize: 320
       GoRuntimeType: 710720
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 47 StructureType noalg.struct { key string; elem []*mime/multipart.FileHeader }
+      Element: 71 StructureType noalg.struct { key string; elem []*mime/multipart.FileHeader }
     - __kind: ArrayType
-      ID: 26
+      ID: 52
       Name: noalg.[8]struct { key string; elem []string }
       ByteSize: 320
       GoRuntimeType: 700896
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 27 StructureType noalg.struct { key string; elem []string }
+      Element: 53 StructureType noalg.struct { key string; elem []string }
     - __kind: ArrayType
-      ID: 165
+      ID: 186
       Name: noalg.[8]struct { key string; elem float64 }
       ByteSize: 192
       GoRuntimeType: 715008
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 166 StructureType noalg.struct { key string; elem float64 }
+      Element: 187 StructureType noalg.struct { key string; elem float64 }
     - __kind: ArrayType
-      ID: 154
+      ID: 175
       Name: noalg.[8]struct { key string; elem interface {} }
       ByteSize: 256
       GoRuntimeType: 692352
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 155 StructureType noalg.struct { key string; elem interface {} }
+      Element: 176 StructureType noalg.struct { key string; elem interface {} }
     - __kind: ArrayType
-      ID: 133
+      ID: 156
       Name: noalg.[8]struct { key string; elem string }
       ByteSize: 256
       GoRuntimeType: 705056
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 134 StructureType noalg.struct { key string; elem string }
+      Element: 157 StructureType noalg.struct { key string; elem string }
     - __kind: StructureType
-      ID: 182
+      ID: 202
       Name: noalg.map.group[string]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
       ByteSize: 200
       GoRuntimeType: 1.331296e+06
@@ -2963,12 +2963,12 @@ Types:
       RawFields:
         - Name: ctrl
           Offset: 0
-          Type: 17 BaseType uint64
+          Type: 8 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 183 ArrayType noalg.[8]struct { key string; elem *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute }
+          Type: 203 ArrayType noalg.[8]struct { key string; elem *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute }
     - __kind: StructureType
-      ID: 45
+      ID: 69
       Name: noalg.map.group[string][]*mime/multipart.FileHeader
       ByteSize: 328
       GoRuntimeType: 1.325024e+06
@@ -2976,12 +2976,12 @@ Types:
       RawFields:
         - Name: ctrl
           Offset: 0
-          Type: 17 BaseType uint64
+          Type: 8 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 46 ArrayType noalg.[8]struct { key string; elem []*mime/multipart.FileHeader }
+          Type: 70 ArrayType noalg.[8]struct { key string; elem []*mime/multipart.FileHeader }
     - __kind: StructureType
-      ID: 25
+      ID: 51
       Name: noalg.map.group[string][]string
       ByteSize: 328
       GoRuntimeType: 1.315936e+06
@@ -2989,12 +2989,12 @@ Types:
       RawFields:
         - Name: ctrl
           Offset: 0
-          Type: 17 BaseType uint64
+          Type: 8 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 26 ArrayType noalg.[8]struct { key string; elem []string }
+          Type: 52 ArrayType noalg.[8]struct { key string; elem []string }
     - __kind: StructureType
-      ID: 164
+      ID: 185
       Name: noalg.map.group[string]float64
       ByteSize: 200
       GoRuntimeType: 1.33104e+06
@@ -3002,12 +3002,12 @@ Types:
       RawFields:
         - Name: ctrl
           Offset: 0
-          Type: 17 BaseType uint64
+          Type: 8 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 165 ArrayType noalg.[8]struct { key string; elem float64 }
+          Type: 186 ArrayType noalg.[8]struct { key string; elem float64 }
     - __kind: StructureType
-      ID: 153
+      ID: 174
       Name: noalg.map.group[string]interface {}
       ByteSize: 264
       GoRuntimeType: 1.313376e+06
@@ -3015,12 +3015,12 @@ Types:
       RawFields:
         - Name: ctrl
           Offset: 0
-          Type: 17 BaseType uint64
+          Type: 8 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 154 ArrayType noalg.[8]struct { key string; elem interface {} }
+          Type: 175 ArrayType noalg.[8]struct { key string; elem interface {} }
     - __kind: StructureType
-      ID: 132
+      ID: 155
       Name: noalg.map.group[string]string
       ByteSize: 264
       GoRuntimeType: 1.318368e+06
@@ -3028,12 +3028,12 @@ Types:
       RawFields:
         - Name: ctrl
           Offset: 0
-          Type: 17 BaseType uint64
+          Type: 8 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 133 ArrayType noalg.[8]struct { key string; elem string }
+          Type: 156 ArrayType noalg.[8]struct { key string; elem string }
     - __kind: StructureType
-      ID: 184
+      ID: 204
       Name: noalg.struct { key string; elem *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute }
       ByteSize: 24
       GoRuntimeType: 1.331168e+06
@@ -3041,12 +3041,12 @@ Types:
       RawFields:
         - Name: key
           Offset: 0
-          Type: 5 GoStringHeaderType string
+          Type: 9 GoStringHeaderType string
         - Name: elem
           Offset: 16
-          Type: 185 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
+          Type: 205 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
     - __kind: StructureType
-      ID: 47
+      ID: 71
       Name: noalg.struct { key string; elem []*mime/multipart.FileHeader }
       ByteSize: 40
       GoRuntimeType: 1.324896e+06
@@ -3054,12 +3054,12 @@ Types:
       RawFields:
         - Name: key
           Offset: 0
-          Type: 5 GoStringHeaderType string
+          Type: 9 GoStringHeaderType string
         - Name: elem
           Offset: 16
-          Type: 48 GoSliceHeaderType []*mime/multipart.FileHeader
+          Type: 72 GoSliceHeaderType []*mime/multipart.FileHeader
     - __kind: StructureType
-      ID: 27
+      ID: 53
       Name: noalg.struct { key string; elem []string }
       ByteSize: 40
       GoRuntimeType: 1.315808e+06
@@ -3067,12 +3067,12 @@ Types:
       RawFields:
         - Name: key
           Offset: 0
-          Type: 5 GoStringHeaderType string
+          Type: 9 GoStringHeaderType string
         - Name: elem
           Offset: 16
-          Type: 28 GoSliceHeaderType []string
+          Type: 54 GoSliceHeaderType []string
     - __kind: StructureType
-      ID: 166
+      ID: 187
       Name: noalg.struct { key string; elem float64 }
       ByteSize: 24
       GoRuntimeType: 1.330912e+06
@@ -3080,12 +3080,12 @@ Types:
       RawFields:
         - Name: key
           Offset: 0
-          Type: 5 GoStringHeaderType string
+          Type: 9 GoStringHeaderType string
         - Name: elem
           Offset: 16
-          Type: 167 BaseType float64
+          Type: 16 BaseType float64
     - __kind: StructureType
-      ID: 155
+      ID: 176
       Name: noalg.struct { key string; elem interface {} }
       ByteSize: 32
       GoRuntimeType: 1.313248e+06
@@ -3093,12 +3093,12 @@ Types:
       RawFields:
         - Name: key
           Offset: 0
-          Type: 5 GoStringHeaderType string
+          Type: 9 GoStringHeaderType string
         - Name: elem
           Offset: 16
-          Type: 63 GoEmptyInterfaceType interface {}
+          Type: 87 GoEmptyInterfaceType interface {}
     - __kind: StructureType
-      ID: 134
+      ID: 157
       Name: noalg.struct { key string; elem string }
       ByteSize: 32
       GoRuntimeType: 1.31824e+06
@@ -3106,12 +3106,12 @@ Types:
       RawFields:
         - Name: key
           Offset: 0
-          Type: 5 GoStringHeaderType string
+          Type: 9 GoStringHeaderType string
         - Name: elem
           Offset: 16
-          Type: 5 GoStringHeaderType string
+          Type: 9 GoStringHeaderType string
     - __kind: GoStringHeaderType
-      ID: 5
+      ID: 9
       Name: string
       ByteSize: 16
       GoRuntimeType: 593984
@@ -3122,14 +3122,14 @@ Types:
           Type: 229 PointerType *string.str
         - Name: len
           Offset: 8
-          Type: 8 BaseType int
+          Type: 7 BaseType int
       Data: 228 GoStringDataType string.str
     - __kind: GoStringDataType
       ID: 228
       Name: string.str
       ByteSize: 2048
     - __kind: StructureType
-      ID: 138
+      ID: 161
       Name: sync.Mutex
       ByteSize: 8
       GoRuntimeType: 1.493632e+06
@@ -3137,12 +3137,12 @@ Types:
       RawFields:
         - Name: _
           Offset: 0
-          Type: 139 StructureType sync.noCopy
+          Type: 162 StructureType sync.noCopy
         - Name: mu
           Offset: 0
-          Type: 140 StructureType internal/sync.Mutex
+          Type: 163 StructureType internal/sync.Mutex
     - __kind: StructureType
-      ID: 137
+      ID: 160
       Name: sync.RWMutex
       ByteSize: 24
       GoRuntimeType: 1.880896e+06
@@ -3150,27 +3150,27 @@ Types:
       RawFields:
         - Name: w
           Offset: 0
-          Type: 138 StructureType sync.Mutex
+          Type: 161 StructureType sync.Mutex
         - Name: writerSem
           Offset: 8
-          Type: 142 BaseType uint32
+          Type: 2 BaseType uint32
         - Name: readerSem
           Offset: 12
-          Type: 142 BaseType uint32
+          Type: 2 BaseType uint32
         - Name: readerCount
           Offset: 16
-          Type: 143 StructureType sync/atomic.Int32
+          Type: 164 StructureType sync/atomic.Int32
         - Name: readerWait
           Offset: 20
-          Type: 143 StructureType sync/atomic.Int32
+          Type: 164 StructureType sync/atomic.Int32
     - __kind: StructureType
-      ID: 139
+      ID: 162
       Name: sync.noCopy
       GoRuntimeType: 1.006688e+06
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 143
+      ID: 164
       Name: sync/atomic.Int32
       ByteSize: 4
       GoRuntimeType: 1.494912e+06
@@ -3178,162 +3178,162 @@ Types:
       RawFields:
         - Name: _
           Offset: 0
-          Type: 144 StructureType sync/atomic.noCopy
+          Type: 165 StructureType sync/atomic.noCopy
         - Name: v
           Offset: 0
-          Type: 141 BaseType int32
+          Type: 12 BaseType int32
     - __kind: StructureType
-      ID: 144
+      ID: 165
       Name: sync/atomic.noCopy
       GoRuntimeType: 1.006784e+06
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 179
+      ID: 199
       Name: table<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
       ByteSize: 32
       GoKind: 25
       RawFields:
         - Name: used
           Offset: 0
-          Type: 22 BaseType uint16
+          Type: 6 BaseType uint16
         - Name: capacity
           Offset: 2
-          Type: 22 BaseType uint16
+          Type: 6 BaseType uint16
         - Name: growthLeft
           Offset: 4
-          Type: 22 BaseType uint16
+          Type: 6 BaseType uint16
         - Name: localDepth
           Offset: 6
-          Type: 7 BaseType uint8
+          Type: 3 BaseType uint8
         - Name: index
           Offset: 8
-          Type: 8 BaseType int
+          Type: 7 BaseType int
         - Name: groups
           Offset: 16
-          Type: 180 GoSwissMapGroupsType groupReference<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
+          Type: 200 GoSwissMapGroupsType groupReference<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
     - __kind: StructureType
-      ID: 42
+      ID: 66
       Name: table<string,[]*mime/multipart.FileHeader>
       ByteSize: 32
       GoKind: 25
       RawFields:
         - Name: used
           Offset: 0
-          Type: 22 BaseType uint16
+          Type: 6 BaseType uint16
         - Name: capacity
           Offset: 2
-          Type: 22 BaseType uint16
+          Type: 6 BaseType uint16
         - Name: growthLeft
           Offset: 4
-          Type: 22 BaseType uint16
+          Type: 6 BaseType uint16
         - Name: localDepth
           Offset: 6
-          Type: 7 BaseType uint8
+          Type: 3 BaseType uint8
         - Name: index
           Offset: 8
-          Type: 8 BaseType int
+          Type: 7 BaseType int
         - Name: groups
           Offset: 16
-          Type: 43 GoSwissMapGroupsType groupReference<string,[]*mime/multipart.FileHeader>
+          Type: 67 GoSwissMapGroupsType groupReference<string,[]*mime/multipart.FileHeader>
     - __kind: StructureType
-      ID: 21
+      ID: 48
       Name: table<string,[]string>
       ByteSize: 32
       GoKind: 25
       RawFields:
         - Name: used
           Offset: 0
-          Type: 22 BaseType uint16
+          Type: 6 BaseType uint16
         - Name: capacity
           Offset: 2
-          Type: 22 BaseType uint16
+          Type: 6 BaseType uint16
         - Name: growthLeft
           Offset: 4
-          Type: 22 BaseType uint16
+          Type: 6 BaseType uint16
         - Name: localDepth
           Offset: 6
-          Type: 7 BaseType uint8
+          Type: 3 BaseType uint8
         - Name: index
           Offset: 8
-          Type: 8 BaseType int
+          Type: 7 BaseType int
         - Name: groups
           Offset: 16
-          Type: 23 GoSwissMapGroupsType groupReference<string,[]string>
+          Type: 49 GoSwissMapGroupsType groupReference<string,[]string>
     - __kind: StructureType
-      ID: 161
+      ID: 182
       Name: table<string,float64>
       ByteSize: 32
       GoKind: 25
       RawFields:
         - Name: used
           Offset: 0
-          Type: 22 BaseType uint16
+          Type: 6 BaseType uint16
         - Name: capacity
           Offset: 2
-          Type: 22 BaseType uint16
+          Type: 6 BaseType uint16
         - Name: growthLeft
           Offset: 4
-          Type: 22 BaseType uint16
+          Type: 6 BaseType uint16
         - Name: localDepth
           Offset: 6
-          Type: 7 BaseType uint8
+          Type: 3 BaseType uint8
         - Name: index
           Offset: 8
-          Type: 8 BaseType int
+          Type: 7 BaseType int
         - Name: groups
           Offset: 16
-          Type: 162 GoSwissMapGroupsType groupReference<string,float64>
+          Type: 183 GoSwissMapGroupsType groupReference<string,float64>
     - __kind: StructureType
-      ID: 150
+      ID: 171
       Name: table<string,interface {}>
       ByteSize: 32
       GoKind: 25
       RawFields:
         - Name: used
           Offset: 0
-          Type: 22 BaseType uint16
+          Type: 6 BaseType uint16
         - Name: capacity
           Offset: 2
-          Type: 22 BaseType uint16
+          Type: 6 BaseType uint16
         - Name: growthLeft
           Offset: 4
-          Type: 22 BaseType uint16
+          Type: 6 BaseType uint16
         - Name: localDepth
           Offset: 6
-          Type: 7 BaseType uint8
+          Type: 3 BaseType uint8
         - Name: index
           Offset: 8
-          Type: 8 BaseType int
+          Type: 7 BaseType int
         - Name: groups
           Offset: 16
-          Type: 151 GoSwissMapGroupsType groupReference<string,interface {}>
+          Type: 172 GoSwissMapGroupsType groupReference<string,interface {}>
     - __kind: StructureType
-      ID: 129
+      ID: 152
       Name: table<string,string>
       ByteSize: 32
       GoKind: 25
       RawFields:
         - Name: used
           Offset: 0
-          Type: 22 BaseType uint16
+          Type: 6 BaseType uint16
         - Name: capacity
           Offset: 2
-          Type: 22 BaseType uint16
+          Type: 6 BaseType uint16
         - Name: growthLeft
           Offset: 4
-          Type: 22 BaseType uint16
+          Type: 6 BaseType uint16
         - Name: localDepth
           Offset: 6
-          Type: 7 BaseType uint8
+          Type: 3 BaseType uint8
         - Name: index
           Offset: 8
-          Type: 8 BaseType int
+          Type: 7 BaseType int
         - Name: groups
           Offset: 16
-          Type: 130 GoSwissMapGroupsType groupReference<string,string>
+          Type: 153 GoSwissMapGroupsType groupReference<string,string>
     - __kind: StructureType
-      ID: 77
+      ID: 100
       Name: time.Location
       ByteSize: 104
       GoRuntimeType: 2.013984e+06
@@ -3341,27 +3341,27 @@ Types:
       RawFields:
         - Name: name
           Offset: 0
-          Type: 5 GoStringHeaderType string
+          Type: 9 GoStringHeaderType string
         - Name: zone
           Offset: 16
-          Type: 78 GoSliceHeaderType []time.zone
+          Type: 101 GoSliceHeaderType []time.zone
         - Name: tx
           Offset: 40
-          Type: 81 GoSliceHeaderType []time.zoneTrans
+          Type: 104 GoSliceHeaderType []time.zoneTrans
         - Name: extend
           Offset: 64
-          Type: 5 GoStringHeaderType string
+          Type: 9 GoStringHeaderType string
         - Name: cacheStart
           Offset: 80
-          Type: 32 BaseType int64
+          Type: 13 BaseType int64
         - Name: cacheEnd
           Offset: 88
-          Type: 32 BaseType int64
+          Type: 13 BaseType int64
         - Name: cacheZone
           Offset: 96
-          Type: 79 PointerType *time.zone
+          Type: 102 PointerType *time.zone
     - __kind: StructureType
-      ID: 75
+      ID: 98
       Name: time.Time
       ByteSize: 24
       GoRuntimeType: 2.428992e+06
@@ -3369,15 +3369,15 @@ Types:
       RawFields:
         - Name: wall
           Offset: 0
-          Type: 17 BaseType uint64
+          Type: 8 BaseType uint64
         - Name: ext
           Offset: 8
-          Type: 32 BaseType int64
+          Type: 13 BaseType int64
         - Name: loc
           Offset: 16
-          Type: 76 PointerType *time.Location
+          Type: 99 PointerType *time.Location
     - __kind: StructureType
-      ID: 80
+      ID: 103
       Name: time.zone
       ByteSize: 32
       GoRuntimeType: 1.646944e+06
@@ -3385,15 +3385,15 @@ Types:
       RawFields:
         - Name: name
           Offset: 0
-          Type: 5 GoStringHeaderType string
+          Type: 9 GoStringHeaderType string
         - Name: offset
           Offset: 16
-          Type: 8 BaseType int
+          Type: 7 BaseType int
         - Name: isDST
           Offset: 24
-          Type: 13 BaseType bool
+          Type: 4 BaseType bool
     - __kind: StructureType
-      ID: 83
+      ID: 106
       Name: time.zoneTrans
       ByteSize: 16
       GoRuntimeType: 1.788928e+06
@@ -3401,54 +3401,54 @@ Types:
       RawFields:
         - Name: when
           Offset: 0
-          Type: 32 BaseType int64
+          Type: 13 BaseType int64
         - Name: index
           Offset: 8
-          Type: 7 BaseType uint8
+          Type: 3 BaseType uint8
         - Name: isstd
           Offset: 9
-          Type: 13 BaseType bool
+          Type: 4 BaseType bool
         - Name: isutc
           Offset: 10
-          Type: 13 BaseType bool
+          Type: 4 BaseType bool
     - __kind: BaseType
-      ID: 209
+      ID: 10
       Name: uint
       ByteSize: 8
       GoRuntimeType: 594624
       GoKind: 7
     - __kind: BaseType
-      ID: 22
+      ID: 6
       Name: uint16
       ByteSize: 2
       GoRuntimeType: 594240
       GoKind: 9
     - __kind: BaseType
-      ID: 142
+      ID: 2
       Name: uint32
       ByteSize: 4
       GoRuntimeType: 594368
       GoKind: 10
     - __kind: BaseType
-      ID: 17
+      ID: 8
       Name: uint64
       ByteSize: 8
       GoRuntimeType: 594496
       GoKind: 11
     - __kind: BaseType
-      ID: 7
+      ID: 3
       Name: uint8
       ByteSize: 1
       GoRuntimeType: 594112
       GoKind: 8
     - __kind: BaseType
-      ID: 18
+      ID: 1
       Name: uintptr
       ByteSize: 8
       GoRuntimeType: 594688
       GoKind: 12
     - __kind: VoidPointerType
-      ID: 2
+      ID: 15
       Name: unsafe.Pointer
       ByteSize: 8
       GoRuntimeType: 595072

--- a/pkg/dyninst/irgen/testdata/snapshot/rc_tester.arch=arm64,toolchain=go1.25.0.yaml
+++ b/pkg/dyninst/irgen/testdata/snapshot/rc_tester.arch=arm64,toolchain=go1.25.0.yaml
@@ -10,7 +10,7 @@ Probes:
       subprogram: {subprogram: 1}
       events:
         - ID: 1
-          Type: 302 EventRootType Probe[main.HandleHTTP]
+          Type: 294 EventRootType Probe[main.HandleHTTP]
           InjectionPoints: [{PC: "0x859980", Frameless: true}]
           Condition: null
     - id: look_at_the_request
@@ -23,7 +23,7 @@ Probes:
       subprogram: {subprogram: 2}
       events:
         - ID: 2
-          Type: 303 EventRootType Probe[main.LookAtTheRequest]
+          Type: 295 EventRootType Probe[main.LookAtTheRequest]
           InjectionPoints: [{PC: "0x859c5c", Frameless: true}]
           Condition: null
 Subprograms:
@@ -362,7 +362,7 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 17 BaseType uint64
-      TablePtrSliceType: 242 GoSliceDataType []*table<string,[]string>.array
+      TablePtrSliceType: 230 GoSliceDataType []*table<string,[]string>.array
       GroupType: 25 StructureType noalg.map.group[string][]string
     - __kind: BaseType
       ID: 17
@@ -429,7 +429,7 @@ Types:
           Offset: 8
           Type: 17 BaseType uint64
       GroupType: 25 StructureType noalg.map.group[string][]string
-      GroupSliceType: 243 GoSliceDataType []noalg.map.group[string][]string.array
+      GroupSliceType: 231 GoSliceDataType []noalg.map.group[string][]string.array
     - __kind: PointerType
       ID: 24
       Name: '*noalg.map.group[string][]string'
@@ -598,7 +598,7 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 17 BaseType uint64
-      TablePtrSliceType: 238 GoSliceDataType []*table<string,[]*mime/multipart.FileHeader>.array
+      TablePtrSliceType: 234 GoSliceDataType []*table<string,[]*mime/multipart.FileHeader>.array
       GroupType: 45 StructureType noalg.map.group[string][]*mime/multipart.FileHeader
     - __kind: PointerType
       ID: 40
@@ -647,7 +647,7 @@ Types:
           Offset: 8
           Type: 17 BaseType uint64
       GroupType: 45 StructureType noalg.map.group[string][]*mime/multipart.FileHeader
-      GroupSliceType: 239 GoSliceDataType []noalg.map.group[string][]*mime/multipart.FileHeader.array
+      GroupSliceType: 235 GoSliceDataType []noalg.map.group[string][]*mime/multipart.FileHeader.array
     - __kind: PointerType
       ID: 44
       Name: '*noalg.map.group[string][]*mime/multipart.FileHeader'
@@ -704,7 +704,7 @@ Types:
         - Name: cap
           Offset: 16
           Type: 8 BaseType int
-      Data: 240 GoSliceDataType []*mime/multipart.FileHeader.array
+      Data: 236 GoSliceDataType []*mime/multipart.FileHeader.array
     - __kind: PointerType
       ID: 49
       Name: '**mime/multipart.FileHeader'
@@ -769,7 +769,7 @@ Types:
         - Name: cap
           Offset: 16
           Type: 8 BaseType int
-      Data: 244 GoSliceDataType []uint8.array
+      Data: 238 GoSliceDataType []uint8.array
     - __kind: PointerType
       ID: 54
       Name: '*crypto/tls.ConnectionState'
@@ -857,7 +857,7 @@ Types:
         - Name: cap
           Offset: 16
           Type: 8 BaseType int
-      Data: 246 GoSliceDataType []*crypto/x509.Certificate.array
+      Data: 240 GoSliceDataType []*crypto/x509.Certificate.array
     - __kind: PointerType
       ID: 58
       Name: '**crypto/x509.Certificate'
@@ -1095,7 +1095,7 @@ Types:
         - Name: cap
           Offset: 16
           Type: 8 BaseType int
-      Data: 248 GoSliceDataType math/big.nat.array
+      Data: 242 GoSliceDataType math/big.nat.array
     - __kind: PointerType
       ID: 67
       Name: '*math/big.Word'
@@ -1165,7 +1165,7 @@ Types:
         - Name: cap
           Offset: 16
           Type: 8 BaseType int
-      Data: 250 GoSliceDataType []crypto/x509/pkix.AttributeTypeAndValue.array
+      Data: 244 GoSliceDataType []crypto/x509/pkix.AttributeTypeAndValue.array
     - __kind: PointerType
       ID: 71
       Name: '*crypto/x509/pkix.AttributeTypeAndValue'
@@ -1202,7 +1202,7 @@ Types:
         - Name: cap
           Offset: 16
           Type: 8 BaseType int
-      Data: 252 GoSliceDataType encoding/asn1.ObjectIdentifier.array
+      Data: 246 GoSliceDataType encoding/asn1.ObjectIdentifier.array
     - __kind: PointerType
       ID: 74
       Name: '*int'
@@ -1277,7 +1277,7 @@ Types:
         - Name: cap
           Offset: 16
           Type: 8 BaseType int
-      Data: 254 GoSliceDataType []time.zone.array
+      Data: 248 GoSliceDataType []time.zone.array
     - __kind: PointerType
       ID: 79
       Name: '*time.zone'
@@ -1317,7 +1317,7 @@ Types:
         - Name: cap
           Offset: 16
           Type: 8 BaseType int
-      Data: 256 GoSliceDataType []time.zoneTrans.array
+      Data: 250 GoSliceDataType []time.zoneTrans.array
     - __kind: PointerType
       ID: 82
       Name: '*time.zoneTrans'
@@ -1366,7 +1366,7 @@ Types:
         - Name: cap
           Offset: 16
           Type: 8 BaseType int
-      Data: 258 GoSliceDataType []crypto/x509/pkix.Extension.array
+      Data: 252 GoSliceDataType []crypto/x509/pkix.Extension.array
     - __kind: PointerType
       ID: 86
       Name: '*crypto/x509/pkix.Extension'
@@ -1406,7 +1406,7 @@ Types:
         - Name: cap
           Offset: 16
           Type: 8 BaseType int
-      Data: 260 GoSliceDataType []encoding/asn1.ObjectIdentifier.array
+      Data: 254 GoSliceDataType []encoding/asn1.ObjectIdentifier.array
     - __kind: PointerType
       ID: 89
       Name: '*encoding/asn1.ObjectIdentifier'
@@ -1430,7 +1430,7 @@ Types:
         - Name: cap
           Offset: 16
           Type: 8 BaseType int
-      Data: 262 GoSliceDataType []crypto/x509.ExtKeyUsage.array
+      Data: 256 GoSliceDataType []crypto/x509.ExtKeyUsage.array
     - __kind: PointerType
       ID: 91
       Name: '*crypto/x509.ExtKeyUsage'
@@ -1460,7 +1460,7 @@ Types:
         - Name: cap
           Offset: 16
           Type: 8 BaseType int
-      Data: 264 GoSliceDataType []net.IP.array
+      Data: 258 GoSliceDataType []net.IP.array
     - __kind: PointerType
       ID: 94
       Name: '*net.IP'
@@ -1484,7 +1484,7 @@ Types:
         - Name: cap
           Offset: 16
           Type: 8 BaseType int
-      Data: 266 GoSliceDataType net.IP.array
+      Data: 260 GoSliceDataType net.IP.array
     - __kind: GoSliceHeaderType
       ID: 96
       Name: '[]*net/url.URL'
@@ -1501,7 +1501,7 @@ Types:
         - Name: cap
           Offset: 16
           Type: 8 BaseType int
-      Data: 268 GoSliceDataType []*net/url.URL.array
+      Data: 262 GoSliceDataType []*net/url.URL.array
     - __kind: PointerType
       ID: 97
       Name: '**net/url.URL'
@@ -1523,7 +1523,7 @@ Types:
         - Name: cap
           Offset: 16
           Type: 8 BaseType int
-      Data: 270 GoSliceDataType []*net.IPNet.array
+      Data: 264 GoSliceDataType []*net.IPNet.array
     - __kind: PointerType
       ID: 99
       Name: '**net.IPNet'
@@ -1566,7 +1566,7 @@ Types:
         - Name: cap
           Offset: 16
           Type: 8 BaseType int
-      Data: 272 GoSliceDataType net.IPMask.array
+      Data: 266 GoSliceDataType net.IPMask.array
     - __kind: GoSliceHeaderType
       ID: 103
       Name: '[]crypto/x509.OID'
@@ -1583,7 +1583,7 @@ Types:
         - Name: cap
           Offset: 16
           Type: 8 BaseType int
-      Data: 274 GoSliceDataType []crypto/x509.OID.array
+      Data: 268 GoSliceDataType []crypto/x509.OID.array
     - __kind: PointerType
       ID: 104
       Name: '*crypto/x509.OID'
@@ -1617,7 +1617,7 @@ Types:
         - Name: cap
           Offset: 16
           Type: 8 BaseType int
-      Data: 276 GoSliceDataType []crypto/x509.PolicyMapping.array
+      Data: 270 GoSliceDataType []crypto/x509.PolicyMapping.array
     - __kind: PointerType
       ID: 107
       Name: '*crypto/x509.PolicyMapping'
@@ -1654,7 +1654,7 @@ Types:
         - Name: cap
           Offset: 16
           Type: 8 BaseType int
-      Data: 278 GoSliceDataType [][]*crypto/x509.Certificate.array
+      Data: 272 GoSliceDataType [][]*crypto/x509.Certificate.array
     - __kind: PointerType
       ID: 110
       Name: '*[]*crypto/x509.Certificate'
@@ -1677,7 +1677,7 @@ Types:
         - Name: cap
           Offset: 16
           Type: 8 BaseType int
-      Data: 280 GoSliceDataType [][]uint8.array
+      Data: 274 GoSliceDataType [][]uint8.array
     - __kind: PointerType
       ID: 112
       Name: '*[]uint8'
@@ -1816,7 +1816,7 @@ Types:
         - Name: cap
           Offset: 16
           Type: 8 BaseType int
-      Data: 282 GoSliceDataType []net/http.segment.array
+      Data: 276 GoSliceDataType []net/http.segment.array
     - __kind: PointerType
       ID: 122
       Name: '*net/http.segment'
@@ -1885,7 +1885,7 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 17 BaseType uint64
-      TablePtrSliceType: 284 GoSliceDataType []*table<string,string>.array
+      TablePtrSliceType: 278 GoSliceDataType []*table<string,string>.array
       GroupType: 132 StructureType noalg.map.group[string]string
     - __kind: PointerType
       ID: 127
@@ -1934,7 +1934,7 @@ Types:
           Offset: 8
           Type: 17 BaseType uint64
       GroupType: 132 StructureType noalg.map.group[string]string
-      GroupSliceType: 285 GoSliceDataType []noalg.map.group[string]string.array
+      GroupSliceType: 279 GoSliceDataType []noalg.map.group[string]string.array
     - __kind: PointerType
       ID: 131
       Name: '*noalg.map.group[string]string'
@@ -2194,7 +2194,7 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 17 BaseType uint64
-      TablePtrSliceType: 298 GoSliceDataType []*table<string,interface {}>.array
+      TablePtrSliceType: 280 GoSliceDataType []*table<string,interface {}>.array
       GroupType: 153 StructureType noalg.map.group[string]interface {}
     - __kind: PointerType
       ID: 148
@@ -2243,7 +2243,7 @@ Types:
           Offset: 8
           Type: 17 BaseType uint64
       GroupType: 153 StructureType noalg.map.group[string]interface {}
-      GroupSliceType: 299 GoSliceDataType []noalg.map.group[string]interface {}.array
+      GroupSliceType: 281 GoSliceDataType []noalg.map.group[string]interface {}.array
     - __kind: PointerType
       ID: 152
       Name: '*noalg.map.group[string]interface {}'
@@ -2329,7 +2329,7 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 17 BaseType uint64
-      TablePtrSliceType: 288 GoSliceDataType []*table<string,float64>.array
+      TablePtrSliceType: 282 GoSliceDataType []*table<string,float64>.array
       GroupType: 164 StructureType noalg.map.group[string]float64
     - __kind: PointerType
       ID: 159
@@ -2378,7 +2378,7 @@ Types:
           Offset: 8
           Type: 17 BaseType uint64
       GroupType: 164 StructureType noalg.map.group[string]float64
-      GroupSliceType: 289 GoSliceDataType []noalg.map.group[string]float64.array
+      GroupSliceType: 283 GoSliceDataType []noalg.map.group[string]float64.array
     - __kind: PointerType
       ID: 163
       Name: '*noalg.map.group[string]float64'
@@ -2441,7 +2441,7 @@ Types:
         - Name: cap
           Offset: 16
           Type: 8 BaseType int
-      Data: 290 GoSliceDataType []github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink.array
+      Data: 284 GoSliceDataType []github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink.array
     - __kind: PointerType
       ID: 169
       Name: '*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink'
@@ -2490,7 +2490,7 @@ Types:
         - Name: cap
           Offset: 16
           Type: 8 BaseType int
-      Data: 292 GoSliceDataType []github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent.array
+      Data: 286 GoSliceDataType []github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent.array
     - __kind: PointerType
       ID: 172
       Name: '*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent'
@@ -2562,7 +2562,7 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 17 BaseType uint64
-      TablePtrSliceType: 294 GoSliceDataType []*table<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>.array
+      TablePtrSliceType: 288 GoSliceDataType []*table<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>.array
       GroupType: 182 StructureType noalg.map.group[string]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
     - __kind: PointerType
       ID: 177
@@ -2611,7 +2611,7 @@ Types:
           Offset: 8
           Type: 17 BaseType uint64
       GroupType: 182 StructureType noalg.map.group[string]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
-      GroupSliceType: 295 GoSliceDataType []noalg.map.group[string]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute.array
+      GroupSliceType: 289 GoSliceDataType []noalg.map.group[string]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute.array
     - __kind: PointerType
       ID: 181
       Name: '*noalg.map.group[string]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute'
@@ -2723,7 +2723,7 @@ Types:
         - Name: cap
           Offset: 16
           Type: 8 BaseType int
-      Data: 296 GoSliceDataType []*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttributeValue.array
+      Data: 290 GoSliceDataType []*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttributeValue.array
     - __kind: PointerType
       ID: 191
       Name: '**github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttributeValue'
@@ -2888,7 +2888,7 @@ Types:
         - Name: cap
           Offset: 16
           Type: 8 BaseType int
-      Data: 300 GoSliceDataType []*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span.array
+      Data: 292 GoSliceDataType []*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span.array
     - __kind: PointerType
       ID: 201
       Name: '**github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span'
@@ -3116,346 +3116,306 @@ Types:
       Pointee: 232 GoSliceDataType []string.array
     - __kind: GoSliceDataType
       ID: 234
-      Name: '[]*table<string,[]string>.array'
-      ByteSize: 8192
-      Element: 20 PointerType *table<string,[]string>
-    - __kind: GoSliceDataType
-      ID: 235
-      Name: '[]noalg.map.group[string][]string.array'
-      ByteSize: 2048
-      Element: 25 StructureType noalg.map.group[string][]string
-    - __kind: GoSliceDataType
-      ID: 236
-      Name: '[]*table<string,[]string>.array'
-      ByteSize: 8192
-      Element: 20 PointerType *table<string,[]string>
-    - __kind: GoSliceDataType
-      ID: 237
-      Name: '[]noalg.map.group[string][]string.array'
-      ByteSize: 2048
-      Element: 25 StructureType noalg.map.group[string][]string
-    - __kind: GoSliceDataType
-      ID: 238
       Name: '[]*table<string,[]*mime/multipart.FileHeader>.array'
       ByteSize: 8192
       Element: 41 PointerType *table<string,[]*mime/multipart.FileHeader>
     - __kind: GoSliceDataType
-      ID: 239
+      ID: 235
       Name: '[]noalg.map.group[string][]*mime/multipart.FileHeader.array'
       ByteSize: 2048
       Element: 45 StructureType noalg.map.group[string][]*mime/multipart.FileHeader
     - __kind: GoSliceDataType
-      ID: 240
+      ID: 236
       Name: '[]*mime/multipart.FileHeader.array'
       ByteSize: 2048
       Element: 50 PointerType *mime/multipart.FileHeader
     - __kind: PointerType
-      ID: 241
+      ID: 237
       Name: '*[]*mime/multipart.FileHeader.array'
       ByteSize: 8
-      Pointee: 240 GoSliceDataType []*mime/multipart.FileHeader.array
+      Pointee: 236 GoSliceDataType []*mime/multipart.FileHeader.array
     - __kind: GoSliceDataType
-      ID: 242
-      Name: '[]*table<string,[]string>.array'
-      ByteSize: 8192
-      Element: 20 PointerType *table<string,[]string>
-    - __kind: GoSliceDataType
-      ID: 243
-      Name: '[]noalg.map.group[string][]string.array'
-      ByteSize: 2048
-      Element: 25 StructureType noalg.map.group[string][]string
-    - __kind: GoSliceDataType
-      ID: 244
+      ID: 238
       Name: '[]uint8.array'
       ByteSize: 2048
       Element: 7 BaseType uint8
     - __kind: PointerType
-      ID: 245
+      ID: 239
       Name: '*[]uint8.array'
       ByteSize: 8
-      Pointee: 244 GoSliceDataType []uint8.array
+      Pointee: 238 GoSliceDataType []uint8.array
     - __kind: GoSliceDataType
-      ID: 246
+      ID: 240
       Name: '[]*crypto/x509.Certificate.array'
       ByteSize: 2048
       Element: 59 PointerType *crypto/x509.Certificate
     - __kind: PointerType
-      ID: 247
+      ID: 241
       Name: '*[]*crypto/x509.Certificate.array'
       ByteSize: 8
-      Pointee: 246 GoSliceDataType []*crypto/x509.Certificate.array
+      Pointee: 240 GoSliceDataType []*crypto/x509.Certificate.array
     - __kind: GoSliceDataType
-      ID: 248
+      ID: 242
       Name: math/big.nat.array
       ByteSize: 2048
       Element: 68 BaseType math/big.Word
     - __kind: PointerType
-      ID: 249
+      ID: 243
       Name: '*math/big.nat.array'
       ByteSize: 8
-      Pointee: 248 GoSliceDataType math/big.nat.array
+      Pointee: 242 GoSliceDataType math/big.nat.array
     - __kind: GoSliceDataType
-      ID: 250
+      ID: 244
       Name: '[]crypto/x509/pkix.AttributeTypeAndValue.array'
       ByteSize: 2048
       Element: 72 StructureType crypto/x509/pkix.AttributeTypeAndValue
     - __kind: PointerType
-      ID: 251
+      ID: 245
       Name: '*[]crypto/x509/pkix.AttributeTypeAndValue.array'
       ByteSize: 8
-      Pointee: 250 GoSliceDataType []crypto/x509/pkix.AttributeTypeAndValue.array
+      Pointee: 244 GoSliceDataType []crypto/x509/pkix.AttributeTypeAndValue.array
     - __kind: GoSliceDataType
-      ID: 252
+      ID: 246
       Name: encoding/asn1.ObjectIdentifier.array
       ByteSize: 2048
       Element: 8 BaseType int
     - __kind: PointerType
-      ID: 253
+      ID: 247
       Name: '*encoding/asn1.ObjectIdentifier.array'
       ByteSize: 8
-      Pointee: 252 GoSliceDataType encoding/asn1.ObjectIdentifier.array
+      Pointee: 246 GoSliceDataType encoding/asn1.ObjectIdentifier.array
     - __kind: GoSliceDataType
-      ID: 254
+      ID: 248
       Name: '[]time.zone.array'
       ByteSize: 2048
       Element: 80 StructureType time.zone
     - __kind: PointerType
-      ID: 255
+      ID: 249
       Name: '*[]time.zone.array'
       ByteSize: 8
-      Pointee: 254 GoSliceDataType []time.zone.array
+      Pointee: 248 GoSliceDataType []time.zone.array
     - __kind: GoSliceDataType
-      ID: 256
+      ID: 250
       Name: '[]time.zoneTrans.array'
       ByteSize: 2048
       Element: 83 StructureType time.zoneTrans
     - __kind: PointerType
-      ID: 257
+      ID: 251
       Name: '*[]time.zoneTrans.array'
       ByteSize: 8
-      Pointee: 256 GoSliceDataType []time.zoneTrans.array
+      Pointee: 250 GoSliceDataType []time.zoneTrans.array
     - __kind: GoSliceDataType
-      ID: 258
+      ID: 252
       Name: '[]crypto/x509/pkix.Extension.array'
       ByteSize: 2048
       Element: 87 StructureType crypto/x509/pkix.Extension
     - __kind: PointerType
-      ID: 259
+      ID: 253
       Name: '*[]crypto/x509/pkix.Extension.array'
       ByteSize: 8
-      Pointee: 258 GoSliceDataType []crypto/x509/pkix.Extension.array
+      Pointee: 252 GoSliceDataType []crypto/x509/pkix.Extension.array
     - __kind: GoSliceDataType
-      ID: 260
+      ID: 254
       Name: '[]encoding/asn1.ObjectIdentifier.array'
       ByteSize: 2048
       Element: 73 GoSliceHeaderType encoding/asn1.ObjectIdentifier
     - __kind: PointerType
-      ID: 261
+      ID: 255
       Name: '*[]encoding/asn1.ObjectIdentifier.array'
       ByteSize: 8
-      Pointee: 260 GoSliceDataType []encoding/asn1.ObjectIdentifier.array
+      Pointee: 254 GoSliceDataType []encoding/asn1.ObjectIdentifier.array
     - __kind: GoSliceDataType
-      ID: 262
+      ID: 256
       Name: '[]crypto/x509.ExtKeyUsage.array'
       ByteSize: 2048
       Element: 92 BaseType crypto/x509.ExtKeyUsage
     - __kind: PointerType
-      ID: 263
+      ID: 257
       Name: '*[]crypto/x509.ExtKeyUsage.array'
       ByteSize: 8
-      Pointee: 262 GoSliceDataType []crypto/x509.ExtKeyUsage.array
+      Pointee: 256 GoSliceDataType []crypto/x509.ExtKeyUsage.array
     - __kind: GoSliceDataType
-      ID: 264
+      ID: 258
       Name: '[]net.IP.array'
       ByteSize: 2048
       Element: 95 GoSliceHeaderType net.IP
     - __kind: PointerType
-      ID: 265
+      ID: 259
       Name: '*[]net.IP.array'
       ByteSize: 8
-      Pointee: 264 GoSliceDataType []net.IP.array
+      Pointee: 258 GoSliceDataType []net.IP.array
     - __kind: GoSliceDataType
-      ID: 266
+      ID: 260
       Name: net.IP.array
       ByteSize: 2048
       Element: 7 BaseType uint8
     - __kind: PointerType
-      ID: 267
+      ID: 261
       Name: '*net.IP.array'
       ByteSize: 8
-      Pointee: 266 GoSliceDataType net.IP.array
+      Pointee: 260 GoSliceDataType net.IP.array
     - __kind: GoSliceDataType
-      ID: 268
+      ID: 262
       Name: '[]*net/url.URL.array'
       ByteSize: 2048
       Element: 9 PointerType *net/url.URL
     - __kind: PointerType
-      ID: 269
+      ID: 263
       Name: '*[]*net/url.URL.array'
       ByteSize: 8
-      Pointee: 268 GoSliceDataType []*net/url.URL.array
+      Pointee: 262 GoSliceDataType []*net/url.URL.array
     - __kind: GoSliceDataType
-      ID: 270
+      ID: 264
       Name: '[]*net.IPNet.array'
       ByteSize: 2048
       Element: 100 PointerType *net.IPNet
     - __kind: PointerType
-      ID: 271
+      ID: 265
       Name: '*[]*net.IPNet.array'
       ByteSize: 8
-      Pointee: 270 GoSliceDataType []*net.IPNet.array
+      Pointee: 264 GoSliceDataType []*net.IPNet.array
     - __kind: GoSliceDataType
-      ID: 272
+      ID: 266
       Name: net.IPMask.array
       ByteSize: 2048
       Element: 7 BaseType uint8
     - __kind: PointerType
-      ID: 273
+      ID: 267
       Name: '*net.IPMask.array'
       ByteSize: 8
-      Pointee: 272 GoSliceDataType net.IPMask.array
+      Pointee: 266 GoSliceDataType net.IPMask.array
     - __kind: GoSliceDataType
-      ID: 274
+      ID: 268
       Name: '[]crypto/x509.OID.array'
       ByteSize: 2048
       Element: 105 StructureType crypto/x509.OID
     - __kind: PointerType
-      ID: 275
+      ID: 269
       Name: '*[]crypto/x509.OID.array'
       ByteSize: 8
-      Pointee: 274 GoSliceDataType []crypto/x509.OID.array
+      Pointee: 268 GoSliceDataType []crypto/x509.OID.array
     - __kind: GoSliceDataType
-      ID: 276
+      ID: 270
       Name: '[]crypto/x509.PolicyMapping.array'
       ByteSize: 2048
       Element: 108 StructureType crypto/x509.PolicyMapping
     - __kind: PointerType
-      ID: 277
+      ID: 271
       Name: '*[]crypto/x509.PolicyMapping.array'
       ByteSize: 8
-      Pointee: 276 GoSliceDataType []crypto/x509.PolicyMapping.array
+      Pointee: 270 GoSliceDataType []crypto/x509.PolicyMapping.array
     - __kind: GoSliceDataType
-      ID: 278
+      ID: 272
       Name: '[][]*crypto/x509.Certificate.array'
       ByteSize: 2048
       Element: 57 GoSliceHeaderType []*crypto/x509.Certificate
     - __kind: PointerType
-      ID: 279
+      ID: 273
       Name: '*[][]*crypto/x509.Certificate.array'
       ByteSize: 8
-      Pointee: 278 GoSliceDataType [][]*crypto/x509.Certificate.array
+      Pointee: 272 GoSliceDataType [][]*crypto/x509.Certificate.array
     - __kind: GoSliceDataType
-      ID: 280
+      ID: 274
       Name: '[][]uint8.array'
       ByteSize: 2048
       Element: 53 GoSliceHeaderType []uint8
     - __kind: PointerType
-      ID: 281
+      ID: 275
       Name: '*[][]uint8.array'
       ByteSize: 8
-      Pointee: 280 GoSliceDataType [][]uint8.array
+      Pointee: 274 GoSliceDataType [][]uint8.array
     - __kind: GoSliceDataType
-      ID: 282
+      ID: 276
       Name: '[]net/http.segment.array'
       ByteSize: 2048
       Element: 123 StructureType net/http.segment
     - __kind: PointerType
-      ID: 283
+      ID: 277
       Name: '*[]net/http.segment.array'
       ByteSize: 8
-      Pointee: 282 GoSliceDataType []net/http.segment.array
+      Pointee: 276 GoSliceDataType []net/http.segment.array
     - __kind: GoSliceDataType
-      ID: 284
+      ID: 278
       Name: '[]*table<string,string>.array'
       ByteSize: 8192
       Element: 128 PointerType *table<string,string>
     - __kind: GoSliceDataType
-      ID: 285
+      ID: 279
       Name: '[]noalg.map.group[string]string.array'
       ByteSize: 2048
       Element: 132 StructureType noalg.map.group[string]string
     - __kind: GoSliceDataType
-      ID: 286
+      ID: 280
       Name: '[]*table<string,interface {}>.array'
       ByteSize: 8192
       Element: 149 PointerType *table<string,interface {}>
     - __kind: GoSliceDataType
-      ID: 287
+      ID: 281
       Name: '[]noalg.map.group[string]interface {}.array'
       ByteSize: 2048
       Element: 153 StructureType noalg.map.group[string]interface {}
     - __kind: GoSliceDataType
-      ID: 288
+      ID: 282
       Name: '[]*table<string,float64>.array'
       ByteSize: 8192
       Element: 160 PointerType *table<string,float64>
     - __kind: GoSliceDataType
-      ID: 289
+      ID: 283
       Name: '[]noalg.map.group[string]float64.array'
       ByteSize: 2048
       Element: 164 StructureType noalg.map.group[string]float64
     - __kind: GoSliceDataType
-      ID: 290
+      ID: 284
       Name: '[]github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink.array'
       ByteSize: 2048
       Element: 170 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink
     - __kind: PointerType
-      ID: 291
+      ID: 285
       Name: '*[]github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink.array'
       ByteSize: 8
-      Pointee: 290 GoSliceDataType []github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink.array
+      Pointee: 284 GoSliceDataType []github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink.array
     - __kind: GoSliceDataType
-      ID: 292
+      ID: 286
       Name: '[]github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent.array'
       ByteSize: 2048
       Element: 173 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent
     - __kind: PointerType
-      ID: 293
+      ID: 287
       Name: '*[]github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent.array'
       ByteSize: 8
-      Pointee: 292 GoSliceDataType []github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent.array
+      Pointee: 286 GoSliceDataType []github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent.array
     - __kind: GoSliceDataType
-      ID: 294
+      ID: 288
       Name: '[]*table<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>.array'
       ByteSize: 8192
       Element: 178 PointerType *table<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
     - __kind: GoSliceDataType
-      ID: 295
+      ID: 289
       Name: '[]noalg.map.group[string]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute.array'
       ByteSize: 2048
       Element: 182 StructureType noalg.map.group[string]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
     - __kind: GoSliceDataType
-      ID: 296
+      ID: 290
       Name: '[]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttributeValue.array'
       ByteSize: 2048
       Element: 192 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttributeValue
     - __kind: PointerType
-      ID: 297
+      ID: 291
       Name: '*[]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttributeValue.array'
       ByteSize: 8
-      Pointee: 296 GoSliceDataType []*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttributeValue.array
+      Pointee: 290 GoSliceDataType []*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttributeValue.array
     - __kind: GoSliceDataType
-      ID: 298
-      Name: '[]*table<string,interface {}>.array'
-      ByteSize: 8192
-      Element: 149 PointerType *table<string,interface {}>
-    - __kind: GoSliceDataType
-      ID: 299
-      Name: '[]noalg.map.group[string]interface {}.array'
-      ByteSize: 2048
-      Element: 153 StructureType noalg.map.group[string]interface {}
-    - __kind: GoSliceDataType
-      ID: 300
+      ID: 292
       Name: '[]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span.array'
       ByteSize: 2048
       Element: 135 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span
     - __kind: PointerType
-      ID: 301
+      ID: 293
       Name: '*[]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span.array'
       ByteSize: 8
-      Pointee: 300 GoSliceDataType []*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span.array
+      Pointee: 292 GoSliceDataType []*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span.array
     - __kind: EventRootType
-      ID: 302
+      ID: 294
       Name: Probe[main.HandleHTTP]
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -3479,7 +3439,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 303
+      ID: 295
       Name: Probe[main.LookAtTheRequest]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -3493,6 +3453,6 @@ Types:
                   Variable: {subprogram: 2, index: 0, name: path}
                   Offset: 0
                   ByteSize: 16
-MaxTypeID: 303
+MaxTypeID: 295
 Issues: []
 GoModuledataInfo: {FirstModuledataAddr: "0x139d860", TypesOffset: 296}

--- a/pkg/dyninst/irgen/testdata/snapshot/rc_tester.arch=arm64,toolchain=go1.25.0.yaml
+++ b/pkg/dyninst/irgen/testdata/snapshot/rc_tester.arch=arm64,toolchain=go1.25.0.yaml
@@ -65,14 +65,14 @@ Subprograms:
           IsParameter: true
           IsReturn: false
         - Name: span
-          Type: 158 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span
+          Type: 39 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span
           Locations:
             - Range: 0x8599e4..0x859a14
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: false
           IsReturn: false
         - Name: '&buf'
-          Type: 225 PointerType *bytes.Buffer
+          Type: 41 PointerType *bytes.Buffer
           Locations:
             - Range: 0x859aa0..0x859ab8
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
@@ -98,193 +98,193 @@ Subprograms:
           IsReturn: false
 Types:
     - __kind: PointerType
-      ID: 82
+      ID: 107
       Name: '**crypto/x509.Certificate'
       ByteSize: 8
       GoKind: 22
-      Pointee: 83 PointerType *crypto/x509.Certificate
+      Pointee: 108 PointerType *crypto/x509.Certificate
     - __kind: PointerType
-      ID: 221
+      ID: 146
       Name: '**github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span'
       ByteSize: 8
       GoKind: 22
-      Pointee: 158 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span
+      Pointee: 39 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span
     - __kind: PointerType
-      ID: 211
+      ID: 224
       Name: '**github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttributeValue'
       ByteSize: 8
       GoKind: 22
-      Pointee: 212 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttributeValue
+      Pointee: 225 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttributeValue
     - __kind: PointerType
-      ID: 73
+      ID: 201
       Name: '**mime/multipart.FileHeader'
       ByteSize: 8
       GoKind: 22
-      Pointee: 74 PointerType *mime/multipart.FileHeader
+      Pointee: 202 PointerType *mime/multipart.FileHeader
     - __kind: PointerType
-      ID: 122
+      ID: 181
       Name: '**net.IPNet'
       ByteSize: 8
       GoKind: 22
-      Pointee: 123 PointerType *net.IPNet
+      Pointee: 182 PointerType *net.IPNet
     - __kind: PointerType
-      ID: 120
+      ID: 179
       Name: '**net/url.URL'
       ByteSize: 8
-      Pointee: 39 PointerType *net/url.URL
+      Pointee: 43 PointerType *net/url.URL
     - __kind: PointerType
-      ID: 197
+      ID: 124
       Name: '**table<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>'
       ByteSize: 8
-      Pointee: 198 PointerType *table<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
+      Pointee: 125 PointerType *table<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
     - __kind: PointerType
-      ID: 64
+      ID: 103
       Name: '**table<string,[]*mime/multipart.FileHeader>'
       ByteSize: 8
-      Pointee: 65 PointerType *table<string,[]*mime/multipart.FileHeader>
+      Pointee: 104 PointerType *table<string,[]*mime/multipart.FileHeader>
     - __kind: PointerType
-      ID: 46
+      ID: 48
       Name: '**table<string,[]string>'
       ByteSize: 8
-      Pointee: 47 PointerType *table<string,[]string>
+      Pointee: 49 PointerType *table<string,[]string>
     - __kind: PointerType
-      ID: 180
+      ID: 83
       Name: '**table<string,float64>'
       ByteSize: 8
-      Pointee: 181 PointerType *table<string,float64>
+      Pointee: 84 PointerType *table<string,float64>
     - __kind: PointerType
-      ID: 169
+      ID: 78
       Name: '**table<string,interface {}>'
       ByteSize: 8
-      Pointee: 170 PointerType *table<string,interface {}>
+      Pointee: 79 PointerType *table<string,interface {}>
     - __kind: PointerType
-      ID: 150
+      ID: 67
       Name: '**table<string,string>'
       ByteSize: 8
-      Pointee: 151 PointerType *table<string,string>
+      Pointee: 68 PointerType *table<string,string>
     - __kind: PointerType
-      ID: 133
+      ID: 110
       Name: '*[]*crypto/x509.Certificate'
       ByteSize: 8
       GoKind: 22
-      Pointee: 81 GoSliceHeaderType []*crypto/x509.Certificate
+      Pointee: 106 GoSliceHeaderType []*crypto/x509.Certificate
     - __kind: PointerType
-      ID: 241
+      ID: 249
       Name: '*[]*crypto/x509.Certificate.array'
       ByteSize: 8
-      Pointee: 240 GoSliceDataType []*crypto/x509.Certificate.array
-    - __kind: PointerType
-      ID: 293
-      Name: '*[]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span.array'
-      ByteSize: 8
-      Pointee: 292 GoSliceDataType []*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span.array
-    - __kind: PointerType
-      ID: 291
-      Name: '*[]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttributeValue.array'
-      ByteSize: 8
-      Pointee: 290 GoSliceDataType []*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttributeValue.array
-    - __kind: PointerType
-      ID: 237
-      Name: '*[]*mime/multipart.FileHeader.array'
-      ByteSize: 8
-      Pointee: 236 GoSliceDataType []*mime/multipart.FileHeader.array
-    - __kind: PointerType
-      ID: 265
-      Name: '*[]*net.IPNet.array'
-      ByteSize: 8
-      Pointee: 264 GoSliceDataType []*net.IPNet.array
-    - __kind: PointerType
-      ID: 263
-      Name: '*[]*net/url.URL.array'
-      ByteSize: 8
-      Pointee: 262 GoSliceDataType []*net/url.URL.array
-    - __kind: PointerType
-      ID: 273
-      Name: '*[][]*crypto/x509.Certificate.array'
-      ByteSize: 8
-      Pointee: 272 GoSliceDataType [][]*crypto/x509.Certificate.array
-    - __kind: PointerType
-      ID: 275
-      Name: '*[][]uint8.array'
-      ByteSize: 8
-      Pointee: 274 GoSliceDataType [][]uint8.array
-    - __kind: PointerType
-      ID: 257
-      Name: '*[]crypto/x509.ExtKeyUsage.array'
-      ByteSize: 8
-      Pointee: 256 GoSliceDataType []crypto/x509.ExtKeyUsage.array
-    - __kind: PointerType
-      ID: 269
-      Name: '*[]crypto/x509.OID.array'
-      ByteSize: 8
-      Pointee: 268 GoSliceDataType []crypto/x509.OID.array
-    - __kind: PointerType
-      ID: 271
-      Name: '*[]crypto/x509.PolicyMapping.array'
-      ByteSize: 8
-      Pointee: 270 GoSliceDataType []crypto/x509.PolicyMapping.array
-    - __kind: PointerType
-      ID: 245
-      Name: '*[]crypto/x509/pkix.AttributeTypeAndValue.array'
-      ByteSize: 8
-      Pointee: 244 GoSliceDataType []crypto/x509/pkix.AttributeTypeAndValue.array
-    - __kind: PointerType
-      ID: 253
-      Name: '*[]crypto/x509/pkix.Extension.array'
-      ByteSize: 8
-      Pointee: 252 GoSliceDataType []crypto/x509/pkix.Extension.array
-    - __kind: PointerType
-      ID: 255
-      Name: '*[]encoding/asn1.ObjectIdentifier.array'
-      ByteSize: 8
-      Pointee: 254 GoSliceDataType []encoding/asn1.ObjectIdentifier.array
-    - __kind: PointerType
-      ID: 285
-      Name: '*[]github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink.array'
-      ByteSize: 8
-      Pointee: 284 GoSliceDataType []github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink.array
-    - __kind: PointerType
-      ID: 287
-      Name: '*[]github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent.array'
-      ByteSize: 8
-      Pointee: 286 GoSliceDataType []github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent.array
+      Pointee: 248 GoSliceDataType []*crypto/x509.Certificate.array
     - __kind: PointerType
       ID: 259
-      Name: '*[]net.IP.array'
+      Name: '*[]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span.array'
       ByteSize: 8
-      Pointee: 258 GoSliceDataType []net.IP.array
+      Pointee: 258 GoSliceDataType []*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span.array
+    - __kind: PointerType
+      ID: 293
+      Name: '*[]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttributeValue.array'
+      ByteSize: 8
+      Pointee: 292 GoSliceDataType []*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttributeValue.array
+    - __kind: PointerType
+      ID: 283
+      Name: '*[]*mime/multipart.FileHeader.array'
+      ByteSize: 8
+      Pointee: 282 GoSliceDataType []*mime/multipart.FileHeader.array
     - __kind: PointerType
       ID: 277
+      Name: '*[]*net.IPNet.array'
+      ByteSize: 8
+      Pointee: 276 GoSliceDataType []*net.IPNet.array
+    - __kind: PointerType
+      ID: 275
+      Name: '*[]*net/url.URL.array'
+      ByteSize: 8
+      Pointee: 274 GoSliceDataType []*net/url.URL.array
+    - __kind: PointerType
+      ID: 251
+      Name: '*[][]*crypto/x509.Certificate.array'
+      ByteSize: 8
+      Pointee: 250 GoSliceDataType [][]*crypto/x509.Certificate.array
+    - __kind: PointerType
+      ID: 253
+      Name: '*[][]uint8.array'
+      ByteSize: 8
+      Pointee: 252 GoSliceDataType [][]uint8.array
+    - __kind: PointerType
+      ID: 269
+      Name: '*[]crypto/x509.ExtKeyUsage.array'
+      ByteSize: 8
+      Pointee: 268 GoSliceDataType []crypto/x509.ExtKeyUsage.array
+    - __kind: PointerType
+      ID: 279
+      Name: '*[]crypto/x509.OID.array'
+      ByteSize: 8
+      Pointee: 278 GoSliceDataType []crypto/x509.OID.array
+    - __kind: PointerType
+      ID: 281
+      Name: '*[]crypto/x509.PolicyMapping.array'
+      ByteSize: 8
+      Pointee: 280 GoSliceDataType []crypto/x509.PolicyMapping.array
+    - __kind: PointerType
+      ID: 261
+      Name: '*[]crypto/x509/pkix.AttributeTypeAndValue.array'
+      ByteSize: 8
+      Pointee: 260 GoSliceDataType []crypto/x509/pkix.AttributeTypeAndValue.array
+    - __kind: PointerType
+      ID: 263
+      Name: '*[]crypto/x509/pkix.Extension.array'
+      ByteSize: 8
+      Pointee: 262 GoSliceDataType []crypto/x509/pkix.Extension.array
+    - __kind: PointerType
+      ID: 265
+      Name: '*[]encoding/asn1.ObjectIdentifier.array'
+      ByteSize: 8
+      Pointee: 264 GoSliceDataType []encoding/asn1.ObjectIdentifier.array
+    - __kind: PointerType
+      ID: 241
+      Name: '*[]github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink.array'
+      ByteSize: 8
+      Pointee: 240 GoSliceDataType []github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink.array
+    - __kind: PointerType
+      ID: 243
+      Name: '*[]github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent.array'
+      ByteSize: 8
+      Pointee: 242 GoSliceDataType []github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent.array
+    - __kind: PointerType
+      ID: 271
+      Name: '*[]net.IP.array'
+      ByteSize: 8
+      Pointee: 270 GoSliceDataType []net.IP.array
+    - __kind: PointerType
+      ID: 255
       Name: '*[]net/http.segment.array'
       ByteSize: 8
-      Pointee: 276 GoSliceDataType []net/http.segment.array
+      Pointee: 254 GoSliceDataType []net/http.segment.array
     - __kind: PointerType
       ID: 233
       Name: '*[]string.array'
       ByteSize: 8
       Pointee: 232 GoSliceDataType []string.array
     - __kind: PointerType
-      ID: 249
+      ID: 287
       Name: '*[]time.zone.array'
       ByteSize: 8
-      Pointee: 248 GoSliceDataType []time.zone.array
+      Pointee: 286 GoSliceDataType []time.zone.array
     - __kind: PointerType
-      ID: 251
+      ID: 289
       Name: '*[]time.zoneTrans.array'
       ByteSize: 8
-      Pointee: 250 GoSliceDataType []time.zoneTrans.array
+      Pointee: 288 GoSliceDataType []time.zoneTrans.array
     - __kind: PointerType
-      ID: 135
+      ID: 112
       Name: '*[]uint8'
       ByteSize: 8
       GoRuntimeType: 486400
       GoKind: 22
-      Pointee: 77 GoSliceHeaderType []uint8
+      Pointee: 94 GoSliceHeaderType []uint8
     - __kind: PointerType
-      ID: 239
+      ID: 245
       Name: '*[]uint8.array'
       ByteSize: 8
-      Pointee: 238 GoSliceDataType []uint8.array
+      Pointee: 244 GoSliceDataType []uint8.array
     - __kind: PointerType
       ID: 11
       Name: '*bool'
@@ -293,73 +293,73 @@ Types:
       GoKind: 22
       Pointee: 4 BaseType bool
     - __kind: PointerType
-      ID: 225
+      ID: 41
       Name: '*bytes.Buffer'
       ByteSize: 8
       GoRuntimeType: 2.320608e+06
       GoKind: 22
-      Pointee: 226 StructureType bytes.Buffer
+      Pointee: 42 StructureType bytes.Buffer
     - __kind: PointerType
-      ID: 78
+      ID: 56
       Name: '*crypto/tls.ConnectionState'
       ByteSize: 8
       GoRuntimeType: 923424
       GoKind: 22
-      Pointee: 79 StructureType crypto/tls.ConnectionState
+      Pointee: 57 StructureType crypto/tls.ConnectionState
     - __kind: PointerType
-      ID: 83
+      ID: 108
       Name: '*crypto/x509.Certificate'
       ByteSize: 8
       GoRuntimeType: 2.088896e+06
       GoKind: 22
-      Pointee: 84 StructureType crypto/x509.Certificate
+      Pointee: 134 StructureType crypto/x509.Certificate
     - __kind: PointerType
-      ID: 114
+      ID: 173
       Name: '*crypto/x509.ExtKeyUsage'
       ByteSize: 8
       GoRuntimeType: 429824
       GoKind: 22
-      Pointee: 115 BaseType crypto/x509.ExtKeyUsage
+      Pointee: 174 BaseType crypto/x509.ExtKeyUsage
     - __kind: PointerType
-      ID: 127
+      ID: 184
       Name: '*crypto/x509.OID'
       ByteSize: 8
       GoRuntimeType: 1.997344e+06
       GoKind: 22
-      Pointee: 128 StructureType crypto/x509.OID
+      Pointee: 185 StructureType crypto/x509.OID
     - __kind: PointerType
-      ID: 130
+      ID: 187
       Name: '*crypto/x509.PolicyMapping'
       ByteSize: 8
       GoRuntimeType: 429888
       GoKind: 22
-      Pointee: 131 StructureType crypto/x509.PolicyMapping
+      Pointee: 188 StructureType crypto/x509.PolicyMapping
     - __kind: PointerType
-      ID: 95
+      ID: 160
       Name: '*crypto/x509/pkix.AttributeTypeAndValue'
       ByteSize: 8
       GoRuntimeType: 446528
       GoKind: 22
-      Pointee: 96 StructureType crypto/x509/pkix.AttributeTypeAndValue
+      Pointee: 161 StructureType crypto/x509/pkix.AttributeTypeAndValue
     - __kind: PointerType
-      ID: 109
+      ID: 167
       Name: '*crypto/x509/pkix.Extension'
       ByteSize: 8
       GoRuntimeType: 446720
       GoKind: 22
-      Pointee: 110 StructureType crypto/x509/pkix.Extension
+      Pointee: 168 StructureType crypto/x509/pkix.Extension
     - __kind: PointerType
-      ID: 112
+      ID: 170
       Name: '*encoding/asn1.ObjectIdentifier'
       ByteSize: 8
       GoRuntimeType: 1.079072e+06
       GoKind: 22
-      Pointee: 97 GoSliceHeaderType encoding/asn1.ObjectIdentifier
+      Pointee: 171 GoSliceHeaderType encoding/asn1.ObjectIdentifier
     - __kind: PointerType
-      ID: 247
+      ID: 267
       Name: '*encoding/asn1.ObjectIdentifier.array'
       ByteSize: 8
-      Pointee: 246 GoSliceDataType encoding/asn1.ObjectIdentifier.array
+      Pointee: 266 GoSliceDataType encoding/asn1.ObjectIdentifier.array
     - __kind: PointerType
       ID: 33
       Name: '*error'
@@ -382,61 +382,61 @@ Types:
       GoKind: 22
       Pointee: 16 BaseType float64
     - __kind: PointerType
-      ID: 158
+      ID: 39
       Name: '*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span'
       ByteSize: 8
       GoRuntimeType: 2.331872e+06
       GoKind: 22
-      Pointee: 159 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span
+      Pointee: 40 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span
     - __kind: PointerType
-      ID: 216
+      ID: 91
       Name: '*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanContext'
       ByteSize: 8
       GoRuntimeType: 2.053568e+06
       GoKind: 22
-      Pointee: 217 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanContext
+      Pointee: 92 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanContext
     - __kind: PointerType
-      ID: 189
+      ID: 86
       Name: '*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink'
       ByteSize: 8
       GoRuntimeType: 1.213856e+06
       GoKind: 22
-      Pointee: 190 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink
+      Pointee: 87 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink
     - __kind: PointerType
-      ID: 192
+      ID: 89
       Name: '*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent'
       ByteSize: 8
       GoRuntimeType: 1.213984e+06
       GoKind: 22
-      Pointee: 193 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent
+      Pointee: 90 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent
     - __kind: PointerType
-      ID: 208
+      ID: 220
       Name: '*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttribute'
       ByteSize: 8
       GoRuntimeType: 1.214624e+06
       GoKind: 22
-      Pointee: 209 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttribute
+      Pointee: 221 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttribute
     - __kind: PointerType
-      ID: 212
+      ID: 225
       Name: '*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttributeValue'
       ByteSize: 8
       GoRuntimeType: 1.214368e+06
       GoKind: 22
-      Pointee: 213 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttributeValue
+      Pointee: 226 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttributeValue
     - __kind: PointerType
-      ID: 205
+      ID: 215
       Name: '*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute'
       ByteSize: 8
       GoRuntimeType: 1.214752e+06
       GoKind: 22
-      Pointee: 206 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
+      Pointee: 216 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
     - __kind: PointerType
-      ID: 218
+      ID: 127
       Name: '*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.trace'
       ByteSize: 8
       GoRuntimeType: 2.2768e+06
       GoKind: 22
-      Pointee: 219 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.trace
+      Pointee: 128 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.trace
     - __kind: PointerType
       ID: 27
       Name: '*int'
@@ -473,92 +473,92 @@ Types:
       GoKind: 22
       Pointee: 17 BaseType int8
     - __kind: PointerType
-      ID: 195
+      ID: 122
       Name: '*map<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>'
       ByteSize: 8
-      Pointee: 196 GoSwissMapHeaderType map<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
+      Pointee: 123 GoSwissMapHeaderType map<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
     - __kind: PointerType
-      ID: 62
+      ID: 101
       Name: '*map<string,[]*mime/multipart.FileHeader>'
       ByteSize: 8
-      Pointee: 63 GoSwissMapHeaderType map<string,[]*mime/multipart.FileHeader>
+      Pointee: 102 GoSwissMapHeaderType map<string,[]*mime/multipart.FileHeader>
     - __kind: PointerType
-      ID: 44
+      ID: 46
       Name: '*map<string,[]string>'
       ByteSize: 8
-      Pointee: 45 GoSwissMapHeaderType map<string,[]string>
+      Pointee: 47 GoSwissMapHeaderType map<string,[]string>
     - __kind: PointerType
-      ID: 178
+      ID: 81
       Name: '*map<string,float64>'
       ByteSize: 8
-      Pointee: 179 GoSwissMapHeaderType map<string,float64>
+      Pointee: 82 GoSwissMapHeaderType map<string,float64>
     - __kind: PointerType
-      ID: 167
+      ID: 76
       Name: '*map<string,interface {}>'
       ByteSize: 8
-      Pointee: 168 GoSwissMapHeaderType map<string,interface {}>
+      Pointee: 77 GoSwissMapHeaderType map<string,interface {}>
     - __kind: PointerType
-      ID: 148
+      ID: 65
       Name: '*map<string,string>'
       ByteSize: 8
-      Pointee: 149 GoSwissMapHeaderType map<string,string>
+      Pointee: 66 GoSwissMapHeaderType map<string,string>
     - __kind: PointerType
-      ID: 88
+      ID: 156
       Name: '*math/big.Int'
       ByteSize: 8
       GoRuntimeType: 2.446656e+06
       GoKind: 22
-      Pointee: 89 StructureType math/big.Int
+      Pointee: 157 StructureType math/big.Int
     - __kind: PointerType
-      ID: 91
+      ID: 204
       Name: '*math/big.Word'
       ByteSize: 8
       GoRuntimeType: 432640
       GoKind: 22
-      Pointee: 92 BaseType math/big.Word
+      Pointee: 205 BaseType math/big.Word
     - __kind: PointerType
-      ID: 243
+      ID: 285
       Name: '*math/big.nat.array'
       ByteSize: 8
-      Pointee: 242 GoSliceDataType math/big.nat.array
+      Pointee: 284 GoSliceDataType math/big.nat.array
     - __kind: PointerType
-      ID: 74
+      ID: 202
       Name: '*mime/multipart.FileHeader'
       ByteSize: 8
       GoRuntimeType: 924960
       GoKind: 22
-      Pointee: 75 StructureType mime/multipart.FileHeader
+      Pointee: 217 StructureType mime/multipart.FileHeader
     - __kind: PointerType
-      ID: 58
+      ID: 54
       Name: '*mime/multipart.Form'
       ByteSize: 8
       GoRuntimeType: 925056
       GoKind: 22
-      Pointee: 59 StructureType mime/multipart.Form
+      Pointee: 55 StructureType mime/multipart.Form
     - __kind: PointerType
-      ID: 117
+      ID: 176
       Name: '*net.IP'
       ByteSize: 8
       GoRuntimeType: 2.206144e+06
       GoKind: 22
-      Pointee: 118 GoSliceHeaderType net.IP
+      Pointee: 177 GoSliceHeaderType net.IP
     - __kind: PointerType
-      ID: 261
+      ID: 273
       Name: '*net.IP.array'
       ByteSize: 8
-      Pointee: 260 GoSliceDataType net.IP.array
+      Pointee: 272 GoSliceDataType net.IP.array
     - __kind: PointerType
-      ID: 267
+      ID: 291
       Name: '*net.IPMask.array'
       ByteSize: 8
-      Pointee: 266 GoSliceDataType net.IPMask.array
+      Pointee: 290 GoSliceDataType net.IPMask.array
     - __kind: PointerType
-      ID: 123
+      ID: 182
       Name: '*net.IPNet'
       ByteSize: 8
       GoRuntimeType: 1.207712e+06
       GoKind: 22
-      Pointee: 124 StructureType net.IPNet
+      Pointee: 212 StructureType net.IPNet
     - __kind: PointerType
       ID: 37
       Name: '*net/http.Request'
@@ -567,70 +567,70 @@ Types:
       GoKind: 22
       Pointee: 38 StructureType net/http.Request
     - __kind: PointerType
-      ID: 139
+      ID: 59
       Name: '*net/http.Response'
       ByteSize: 8
       GoRuntimeType: 1.757856e+06
       GoKind: 22
-      Pointee: 140 StructureType net/http.Response
+      Pointee: 60 StructureType net/http.Response
     - __kind: PointerType
-      ID: 142
+      ID: 62
       Name: '*net/http.pattern'
       ByteSize: 8
       GoRuntimeType: 1.642144e+06
       GoKind: 22
-      Pointee: 143 StructureType net/http.pattern
+      Pointee: 63 StructureType net/http.pattern
     - __kind: PointerType
-      ID: 145
+      ID: 116
       Name: '*net/http.segment'
       ByteSize: 8
       GoRuntimeType: 396288
       GoKind: 22
-      Pointee: 146 StructureType net/http.segment
+      Pointee: 117 StructureType net/http.segment
     - __kind: PointerType
-      ID: 39
+      ID: 43
       Name: '*net/url.URL'
       ByteSize: 8
       GoRuntimeType: 2.16656e+06
       GoKind: 22
-      Pointee: 40 StructureType net/url.URL
+      Pointee: 44 StructureType net/url.URL
     - __kind: PointerType
-      ID: 41
+      ID: 96
       Name: '*net/url.Userinfo'
       ByteSize: 8
       GoRuntimeType: 1.225376e+06
       GoKind: 22
-      Pointee: 42 StructureType net/url.Userinfo
+      Pointee: 97 StructureType net/url.Userinfo
     - __kind: PointerType
-      ID: 201
+      ID: 196
       Name: '*noalg.map.group[string]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute'
       ByteSize: 8
-      Pointee: 202 StructureType noalg.map.group[string]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
+      Pointee: 197 StructureType noalg.map.group[string]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
     - __kind: PointerType
-      ID: 68
+      ID: 151
       Name: '*noalg.map.group[string][]*mime/multipart.FileHeader'
       ByteSize: 8
-      Pointee: 69 StructureType noalg.map.group[string][]*mime/multipart.FileHeader
+      Pointee: 152 StructureType noalg.map.group[string][]*mime/multipart.FileHeader
     - __kind: PointerType
-      ID: 50
+      ID: 131
       Name: '*noalg.map.group[string][]string'
       ByteSize: 8
-      Pointee: 51 StructureType noalg.map.group[string][]string
+      Pointee: 132 StructureType noalg.map.group[string][]string
     - __kind: PointerType
-      ID: 184
+      ID: 142
       Name: '*noalg.map.group[string]float64'
       ByteSize: 8
-      Pointee: 185 StructureType noalg.map.group[string]float64
+      Pointee: 143 StructureType noalg.map.group[string]float64
     - __kind: PointerType
-      ID: 173
+      ID: 139
       Name: '*noalg.map.group[string]interface {}'
       ByteSize: 8
-      Pointee: 174 StructureType noalg.map.group[string]interface {}
+      Pointee: 140 StructureType noalg.map.group[string]interface {}
     - __kind: PointerType
-      ID: 154
+      ID: 136
       Name: '*noalg.map.group[string]string'
       ByteSize: 8
-      Pointee: 155 StructureType noalg.map.group[string]string
+      Pointee: 137 StructureType noalg.map.group[string]string
     - __kind: PointerType
       ID: 22
       Name: '*string'
@@ -644,56 +644,56 @@ Types:
       ByteSize: 8
       Pointee: 228 GoStringDataType string.str
     - __kind: PointerType
-      ID: 198
+      ID: 125
       Name: '*table<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>'
       ByteSize: 8
-      Pointee: 199 StructureType table<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
+      Pointee: 144 StructureType table<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
     - __kind: PointerType
-      ID: 65
+      ID: 104
       Name: '*table<string,[]*mime/multipart.FileHeader>'
       ByteSize: 8
-      Pointee: 66 StructureType table<string,[]*mime/multipart.FileHeader>
+      Pointee: 133 StructureType table<string,[]*mime/multipart.FileHeader>
     - __kind: PointerType
-      ID: 47
+      ID: 49
       Name: '*table<string,[]string>'
       ByteSize: 8
-      Pointee: 48 StructureType table<string,[]string>
+      Pointee: 98 StructureType table<string,[]string>
     - __kind: PointerType
-      ID: 181
+      ID: 84
       Name: '*table<string,float64>'
       ByteSize: 8
-      Pointee: 182 StructureType table<string,float64>
+      Pointee: 120 StructureType table<string,float64>
     - __kind: PointerType
-      ID: 170
+      ID: 79
       Name: '*table<string,interface {}>'
       ByteSize: 8
-      Pointee: 171 StructureType table<string,interface {}>
+      Pointee: 119 StructureType table<string,interface {}>
     - __kind: PointerType
-      ID: 151
+      ID: 68
       Name: '*table<string,string>'
       ByteSize: 8
-      Pointee: 152 StructureType table<string,string>
+      Pointee: 118 StructureType table<string,string>
     - __kind: PointerType
-      ID: 99
+      ID: 163
       Name: '*time.Location'
       ByteSize: 8
       GoRuntimeType: 1.647136e+06
       GoKind: 22
-      Pointee: 100 StructureType time.Location
+      Pointee: 164 StructureType time.Location
     - __kind: PointerType
-      ID: 102
+      ID: 207
       Name: '*time.zone'
       ByteSize: 8
       GoRuntimeType: 399360
       GoKind: 22
-      Pointee: 103 StructureType time.zone
+      Pointee: 208 StructureType time.zone
     - __kind: PointerType
-      ID: 105
+      ID: 210
       Name: '*time.zoneTrans'
       ByteSize: 8
       GoRuntimeType: 399424
       GoKind: 22
-      Pointee: 106 StructureType time.zoneTrans
+      Pointee: 211 StructureType time.zoneTrans
     - __kind: PointerType
       ID: 34
       Name: '*uint'
@@ -737,7 +737,7 @@ Types:
       GoKind: 22
       Pointee: 1 BaseType uintptr
     - __kind: GoChannelType
-      ID: 138
+      ID: 58
       Name: <-chan struct {}
       GoRuntimeType: 607040
       GoKind: 18
@@ -781,7 +781,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: GoSliceHeaderType
-      ID: 81
+      ID: 106
       Name: '[]*crypto/x509.Certificate'
       ByteSize: 24
       GoRuntimeType: 507264
@@ -789,21 +789,21 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 82 PointerType **crypto/x509.Certificate
+          Type: 107 PointerType **crypto/x509.Certificate
         - Name: len
           Offset: 8
           Type: 7 BaseType int
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 240 GoSliceDataType []*crypto/x509.Certificate.array
+      Data: 248 GoSliceDataType []*crypto/x509.Certificate.array
     - __kind: GoSliceDataType
-      ID: 240
+      ID: 248
       Name: '[]*crypto/x509.Certificate.array'
       ByteSize: 2048
-      Element: 83 PointerType *crypto/x509.Certificate
+      Element: 108 PointerType *crypto/x509.Certificate
     - __kind: GoSliceHeaderType
-      ID: 220
+      ID: 145
       Name: '[]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span'
       ByteSize: 24
       GoRuntimeType: 495072
@@ -811,21 +811,21 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 221 PointerType **github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span
+          Type: 146 PointerType **github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span
         - Name: len
           Offset: 8
           Type: 7 BaseType int
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 292 GoSliceDataType []*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span.array
+      Data: 258 GoSliceDataType []*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span.array
     - __kind: GoSliceDataType
-      ID: 292
+      ID: 258
       Name: '[]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span.array'
       ByteSize: 2048
-      Element: 158 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span
+      Element: 39 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span
     - __kind: GoSliceHeaderType
-      ID: 210
+      ID: 223
       Name: '[]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttributeValue'
       ByteSize: 24
       GoRuntimeType: 494688
@@ -833,21 +833,21 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 211 PointerType **github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttributeValue
+          Type: 224 PointerType **github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttributeValue
         - Name: len
           Offset: 8
           Type: 7 BaseType int
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 290 GoSliceDataType []*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttributeValue.array
+      Data: 292 GoSliceDataType []*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttributeValue.array
     - __kind: GoSliceDataType
-      ID: 290
+      ID: 292
       Name: '[]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttributeValue.array'
       ByteSize: 2048
-      Element: 212 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttributeValue
+      Element: 225 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttributeValue
     - __kind: GoSliceHeaderType
-      ID: 72
+      ID: 200
       Name: '[]*mime/multipart.FileHeader'
       ByteSize: 24
       GoRuntimeType: 492064
@@ -855,21 +855,21 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 73 PointerType **mime/multipart.FileHeader
+          Type: 201 PointerType **mime/multipart.FileHeader
         - Name: len
           Offset: 8
           Type: 7 BaseType int
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 236 GoSliceDataType []*mime/multipart.FileHeader.array
+      Data: 282 GoSliceDataType []*mime/multipart.FileHeader.array
     - __kind: GoSliceDataType
-      ID: 236
+      ID: 282
       Name: '[]*mime/multipart.FileHeader.array'
       ByteSize: 2048
-      Element: 74 PointerType *mime/multipart.FileHeader
+      Element: 202 PointerType *mime/multipart.FileHeader
     - __kind: GoSliceHeaderType
-      ID: 121
+      ID: 180
       Name: '[]*net.IPNet'
       ByteSize: 24
       GoRuntimeType: 508864
@@ -877,21 +877,21 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 122 PointerType **net.IPNet
+          Type: 181 PointerType **net.IPNet
         - Name: len
           Offset: 8
           Type: 7 BaseType int
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 264 GoSliceDataType []*net.IPNet.array
+      Data: 276 GoSliceDataType []*net.IPNet.array
     - __kind: GoSliceDataType
-      ID: 264
+      ID: 276
       Name: '[]*net.IPNet.array'
       ByteSize: 2048
-      Element: 123 PointerType *net.IPNet
+      Element: 182 PointerType *net.IPNet
     - __kind: GoSliceHeaderType
-      ID: 119
+      ID: 178
       Name: '[]*net/url.URL'
       ByteSize: 24
       GoRuntimeType: 508800
@@ -899,51 +899,51 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 120 PointerType **net/url.URL
+          Type: 179 PointerType **net/url.URL
         - Name: len
           Offset: 8
           Type: 7 BaseType int
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 262 GoSliceDataType []*net/url.URL.array
+      Data: 274 GoSliceDataType []*net/url.URL.array
     - __kind: GoSliceDataType
-      ID: 262
+      ID: 274
       Name: '[]*net/url.URL.array'
       ByteSize: 2048
-      Element: 39 PointerType *net/url.URL
+      Element: 43 PointerType *net/url.URL
     - __kind: GoSliceDataType
-      ID: 288
+      ID: 256
       Name: '[]*table<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>.array'
       ByteSize: 8192
-      Element: 198 PointerType *table<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
+      Element: 125 PointerType *table<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
     - __kind: GoSliceDataType
-      ID: 234
+      ID: 246
       Name: '[]*table<string,[]*mime/multipart.FileHeader>.array'
       ByteSize: 8192
-      Element: 65 PointerType *table<string,[]*mime/multipart.FileHeader>
+      Element: 104 PointerType *table<string,[]*mime/multipart.FileHeader>
     - __kind: GoSliceDataType
       ID: 230
       Name: '[]*table<string,[]string>.array'
       ByteSize: 8192
-      Element: 47 PointerType *table<string,[]string>
+      Element: 49 PointerType *table<string,[]string>
     - __kind: GoSliceDataType
-      ID: 282
+      ID: 238
       Name: '[]*table<string,float64>.array'
       ByteSize: 8192
-      Element: 181 PointerType *table<string,float64>
+      Element: 84 PointerType *table<string,float64>
     - __kind: GoSliceDataType
-      ID: 280
+      ID: 236
       Name: '[]*table<string,interface {}>.array'
       ByteSize: 8192
-      Element: 170 PointerType *table<string,interface {}>
+      Element: 79 PointerType *table<string,interface {}>
     - __kind: GoSliceDataType
-      ID: 278
+      ID: 234
       Name: '[]*table<string,string>.array'
       ByteSize: 8192
-      Element: 151 PointerType *table<string,string>
+      Element: 68 PointerType *table<string,string>
     - __kind: GoSliceHeaderType
-      ID: 132
+      ID: 109
       Name: '[][]*crypto/x509.Certificate'
       ByteSize: 24
       GoRuntimeType: 507328
@@ -951,21 +951,21 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 133 PointerType *[]*crypto/x509.Certificate
+          Type: 110 PointerType *[]*crypto/x509.Certificate
         - Name: len
           Offset: 8
           Type: 7 BaseType int
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 272 GoSliceDataType [][]*crypto/x509.Certificate.array
+      Data: 250 GoSliceDataType [][]*crypto/x509.Certificate.array
     - __kind: GoSliceDataType
-      ID: 272
+      ID: 250
       Name: '[][]*crypto/x509.Certificate.array'
       ByteSize: 2048
-      Element: 81 GoSliceHeaderType []*crypto/x509.Certificate
+      Element: 106 GoSliceHeaderType []*crypto/x509.Certificate
     - __kind: GoSliceHeaderType
-      ID: 134
+      ID: 111
       Name: '[][]uint8'
       ByteSize: 24
       GoRuntimeType: 486720
@@ -973,21 +973,21 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 135 PointerType *[]uint8
+          Type: 112 PointerType *[]uint8
         - Name: len
           Offset: 8
           Type: 7 BaseType int
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 274 GoSliceDataType [][]uint8.array
+      Data: 252 GoSliceDataType [][]uint8.array
     - __kind: GoSliceDataType
-      ID: 274
+      ID: 252
       Name: '[][]uint8.array'
       ByteSize: 2048
-      Element: 77 GoSliceHeaderType []uint8
+      Element: 94 GoSliceHeaderType []uint8
     - __kind: GoSliceHeaderType
-      ID: 113
+      ID: 172
       Name: '[]crypto/x509.ExtKeyUsage'
       ByteSize: 24
       GoRuntimeType: 508736
@@ -995,21 +995,21 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 114 PointerType *crypto/x509.ExtKeyUsage
+          Type: 173 PointerType *crypto/x509.ExtKeyUsage
         - Name: len
           Offset: 8
           Type: 7 BaseType int
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 256 GoSliceDataType []crypto/x509.ExtKeyUsage.array
+      Data: 268 GoSliceDataType []crypto/x509.ExtKeyUsage.array
     - __kind: GoSliceDataType
-      ID: 256
+      ID: 268
       Name: '[]crypto/x509.ExtKeyUsage.array'
       ByteSize: 2048
-      Element: 115 BaseType crypto/x509.ExtKeyUsage
+      Element: 174 BaseType crypto/x509.ExtKeyUsage
     - __kind: GoSliceHeaderType
-      ID: 126
+      ID: 183
       Name: '[]crypto/x509.OID'
       ByteSize: 24
       GoRuntimeType: 508928
@@ -1017,21 +1017,21 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 127 PointerType *crypto/x509.OID
+          Type: 184 PointerType *crypto/x509.OID
         - Name: len
           Offset: 8
           Type: 7 BaseType int
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 268 GoSliceDataType []crypto/x509.OID.array
+      Data: 278 GoSliceDataType []crypto/x509.OID.array
     - __kind: GoSliceDataType
-      ID: 268
+      ID: 278
       Name: '[]crypto/x509.OID.array'
       ByteSize: 2048
-      Element: 128 StructureType crypto/x509.OID
+      Element: 185 StructureType crypto/x509.OID
     - __kind: GoSliceHeaderType
-      ID: 129
+      ID: 186
       Name: '[]crypto/x509.PolicyMapping'
       ByteSize: 24
       GoRuntimeType: 508992
@@ -1039,21 +1039,21 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 130 PointerType *crypto/x509.PolicyMapping
+          Type: 187 PointerType *crypto/x509.PolicyMapping
         - Name: len
           Offset: 8
           Type: 7 BaseType int
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 270 GoSliceDataType []crypto/x509.PolicyMapping.array
+      Data: 280 GoSliceDataType []crypto/x509.PolicyMapping.array
     - __kind: GoSliceDataType
-      ID: 270
+      ID: 280
       Name: '[]crypto/x509.PolicyMapping.array'
       ByteSize: 2048
-      Element: 131 StructureType crypto/x509.PolicyMapping
+      Element: 188 StructureType crypto/x509.PolicyMapping
     - __kind: GoSliceHeaderType
-      ID: 94
+      ID: 159
       Name: '[]crypto/x509/pkix.AttributeTypeAndValue'
       ByteSize: 24
       GoRuntimeType: 523520
@@ -1061,21 +1061,21 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 95 PointerType *crypto/x509/pkix.AttributeTypeAndValue
+          Type: 160 PointerType *crypto/x509/pkix.AttributeTypeAndValue
         - Name: len
           Offset: 8
           Type: 7 BaseType int
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 244 GoSliceDataType []crypto/x509/pkix.AttributeTypeAndValue.array
+      Data: 260 GoSliceDataType []crypto/x509/pkix.AttributeTypeAndValue.array
     - __kind: GoSliceDataType
-      ID: 244
+      ID: 260
       Name: '[]crypto/x509/pkix.AttributeTypeAndValue.array'
       ByteSize: 2048
-      Element: 96 StructureType crypto/x509/pkix.AttributeTypeAndValue
+      Element: 161 StructureType crypto/x509/pkix.AttributeTypeAndValue
     - __kind: GoSliceHeaderType
-      ID: 108
+      ID: 166
       Name: '[]crypto/x509/pkix.Extension'
       ByteSize: 24
       GoRuntimeType: 508608
@@ -1083,21 +1083,21 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 109 PointerType *crypto/x509/pkix.Extension
+          Type: 167 PointerType *crypto/x509/pkix.Extension
         - Name: len
           Offset: 8
           Type: 7 BaseType int
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 252 GoSliceDataType []crypto/x509/pkix.Extension.array
+      Data: 262 GoSliceDataType []crypto/x509/pkix.Extension.array
     - __kind: GoSliceDataType
-      ID: 252
+      ID: 262
       Name: '[]crypto/x509/pkix.Extension.array'
       ByteSize: 2048
-      Element: 110 StructureType crypto/x509/pkix.Extension
+      Element: 168 StructureType crypto/x509/pkix.Extension
     - __kind: GoSliceHeaderType
-      ID: 111
+      ID: 169
       Name: '[]encoding/asn1.ObjectIdentifier'
       ByteSize: 24
       GoRuntimeType: 508672
@@ -1105,21 +1105,21 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 112 PointerType *encoding/asn1.ObjectIdentifier
+          Type: 170 PointerType *encoding/asn1.ObjectIdentifier
         - Name: len
           Offset: 8
           Type: 7 BaseType int
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 254 GoSliceDataType []encoding/asn1.ObjectIdentifier.array
+      Data: 264 GoSliceDataType []encoding/asn1.ObjectIdentifier.array
     - __kind: GoSliceDataType
-      ID: 254
+      ID: 264
       Name: '[]encoding/asn1.ObjectIdentifier.array'
       ByteSize: 2048
-      Element: 97 GoSliceHeaderType encoding/asn1.ObjectIdentifier
+      Element: 171 GoSliceHeaderType encoding/asn1.ObjectIdentifier
     - __kind: GoSliceHeaderType
-      ID: 188
+      ID: 85
       Name: '[]github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink'
       ByteSize: 24
       GoRuntimeType: 494624
@@ -1127,21 +1127,21 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 189 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink
+          Type: 86 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink
         - Name: len
           Offset: 8
           Type: 7 BaseType int
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 284 GoSliceDataType []github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink.array
+      Data: 240 GoSliceDataType []github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink.array
     - __kind: GoSliceDataType
-      ID: 284
+      ID: 240
       Name: '[]github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink.array'
       ByteSize: 2048
-      Element: 190 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink
+      Element: 87 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink
     - __kind: GoSliceHeaderType
-      ID: 191
+      ID: 88
       Name: '[]github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent'
       ByteSize: 24
       GoRuntimeType: 494816
@@ -1149,21 +1149,21 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 192 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent
+          Type: 89 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent
         - Name: len
           Offset: 8
           Type: 7 BaseType int
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 286 GoSliceDataType []github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent.array
+      Data: 242 GoSliceDataType []github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent.array
     - __kind: GoSliceDataType
-      ID: 286
+      ID: 242
       Name: '[]github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent.array'
       ByteSize: 2048
-      Element: 193 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent
+      Element: 90 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent
     - __kind: GoSliceHeaderType
-      ID: 116
+      ID: 175
       Name: '[]net.IP'
       ByteSize: 24
       GoRuntimeType: 487744
@@ -1171,21 +1171,21 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 117 PointerType *net.IP
+          Type: 176 PointerType *net.IP
         - Name: len
           Offset: 8
           Type: 7 BaseType int
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 258 GoSliceDataType []net.IP.array
+      Data: 270 GoSliceDataType []net.IP.array
     - __kind: GoSliceDataType
-      ID: 258
+      ID: 270
       Name: '[]net.IP.array'
       ByteSize: 2048
-      Element: 118 GoSliceHeaderType net.IP
+      Element: 177 GoSliceHeaderType net.IP
     - __kind: GoSliceHeaderType
-      ID: 144
+      ID: 115
       Name: '[]net/http.segment'
       ByteSize: 24
       GoRuntimeType: 489440
@@ -1193,51 +1193,51 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 145 PointerType *net/http.segment
+          Type: 116 PointerType *net/http.segment
         - Name: len
           Offset: 8
           Type: 7 BaseType int
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 276 GoSliceDataType []net/http.segment.array
+      Data: 254 GoSliceDataType []net/http.segment.array
     - __kind: GoSliceDataType
-      ID: 276
+      ID: 254
       Name: '[]net/http.segment.array'
       ByteSize: 2048
-      Element: 146 StructureType net/http.segment
+      Element: 117 StructureType net/http.segment
     - __kind: GoSliceDataType
-      ID: 289
+      ID: 257
       Name: '[]noalg.map.group[string]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute.array'
       ByteSize: 2048
-      Element: 202 StructureType noalg.map.group[string]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
+      Element: 197 StructureType noalg.map.group[string]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
     - __kind: GoSliceDataType
-      ID: 235
+      ID: 247
       Name: '[]noalg.map.group[string][]*mime/multipart.FileHeader.array'
       ByteSize: 2048
-      Element: 69 StructureType noalg.map.group[string][]*mime/multipart.FileHeader
+      Element: 152 StructureType noalg.map.group[string][]*mime/multipart.FileHeader
     - __kind: GoSliceDataType
       ID: 231
       Name: '[]noalg.map.group[string][]string.array'
       ByteSize: 2048
-      Element: 51 StructureType noalg.map.group[string][]string
+      Element: 132 StructureType noalg.map.group[string][]string
     - __kind: GoSliceDataType
-      ID: 283
+      ID: 239
       Name: '[]noalg.map.group[string]float64.array'
       ByteSize: 2048
-      Element: 185 StructureType noalg.map.group[string]float64
+      Element: 143 StructureType noalg.map.group[string]float64
     - __kind: GoSliceDataType
-      ID: 281
+      ID: 237
       Name: '[]noalg.map.group[string]interface {}.array'
       ByteSize: 2048
-      Element: 174 StructureType noalg.map.group[string]interface {}
+      Element: 140 StructureType noalg.map.group[string]interface {}
     - __kind: GoSliceDataType
-      ID: 279
+      ID: 235
       Name: '[]noalg.map.group[string]string.array'
       ByteSize: 2048
-      Element: 155 StructureType noalg.map.group[string]string
+      Element: 137 StructureType noalg.map.group[string]string
     - __kind: GoSliceHeaderType
-      ID: 54
+      ID: 52
       Name: '[]string'
       ByteSize: 24
       GoRuntimeType: 501280
@@ -1259,7 +1259,7 @@ Types:
       ByteSize: 2048
       Element: 9 GoStringHeaderType string
     - __kind: GoSliceHeaderType
-      ID: 101
+      ID: 206
       Name: '[]time.zone'
       ByteSize: 24
       GoRuntimeType: 494176
@@ -1267,21 +1267,21 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 102 PointerType *time.zone
+          Type: 207 PointerType *time.zone
         - Name: len
           Offset: 8
           Type: 7 BaseType int
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 248 GoSliceDataType []time.zone.array
+      Data: 286 GoSliceDataType []time.zone.array
     - __kind: GoSliceDataType
-      ID: 248
+      ID: 286
       Name: '[]time.zone.array'
       ByteSize: 2048
-      Element: 103 StructureType time.zone
+      Element: 208 StructureType time.zone
     - __kind: GoSliceHeaderType
-      ID: 104
+      ID: 209
       Name: '[]time.zoneTrans'
       ByteSize: 24
       GoRuntimeType: 494240
@@ -1289,21 +1289,21 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 105 PointerType *time.zoneTrans
+          Type: 210 PointerType *time.zoneTrans
         - Name: len
           Offset: 8
           Type: 7 BaseType int
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 250 GoSliceDataType []time.zoneTrans.array
+      Data: 288 GoSliceDataType []time.zoneTrans.array
     - __kind: GoSliceDataType
-      ID: 250
+      ID: 288
       Name: '[]time.zoneTrans.array'
       ByteSize: 2048
-      Element: 106 StructureType time.zoneTrans
+      Element: 211 StructureType time.zoneTrans
     - __kind: GoSliceHeaderType
-      ID: 77
+      ID: 94
       Name: '[]uint8'
       ByteSize: 24
       GoRuntimeType: 500128
@@ -1318,9 +1318,9 @@ Types:
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 238 GoSliceDataType []uint8.array
+      Data: 244 GoSliceDataType []uint8.array
     - __kind: GoSliceDataType
-      ID: 238
+      ID: 244
       Name: '[]uint8.array'
       ByteSize: 2048
       Element: 3 BaseType uint8
@@ -1331,7 +1331,7 @@ Types:
       GoRuntimeType: 595008
       GoKind: 1
     - __kind: StructureType
-      ID: 226
+      ID: 42
       Name: bytes.Buffer
       ByteSize: 40
       GoRuntimeType: 1.63984e+06
@@ -1339,15 +1339,15 @@ Types:
       RawFields:
         - Name: buf
           Offset: 0
-          Type: 77 GoSliceHeaderType []uint8
+          Type: 94 GoSliceHeaderType []uint8
         - Name: off
           Offset: 24
           Type: 7 BaseType int
         - Name: lastRead
           Offset: 32
-          Type: 227 BaseType bytes.readOp
+          Type: 95 BaseType bytes.readOp
     - __kind: BaseType
-      ID: 227
+      ID: 95
       Name: bytes.readOp
       ByteSize: 1
       GoRuntimeType: 593216
@@ -1365,7 +1365,7 @@ Types:
       GoRuntimeType: 594752
       GoKind: 15
     - __kind: GoInterfaceType
-      ID: 141
+      ID: 61
       Name: context.Context
       ByteSize: 16
       GoRuntimeType: 1.302496e+06
@@ -1378,7 +1378,7 @@ Types:
           Offset: 8
           Type: 15 VoidPointerType unsafe.Pointer
     - __kind: StructureType
-      ID: 79
+      ID: 57
       Name: crypto/tls.ConnectionState
       ByteSize: 192
       GoRuntimeType: 2.322656e+06
@@ -1398,7 +1398,7 @@ Types:
           Type: 6 BaseType uint16
         - Name: CurveID
           Offset: 6
-          Type: 80 BaseType crypto/tls.CurveID
+          Type: 105 BaseType crypto/tls.CurveID
         - Name: NegotiatedProtocol
           Offset: 8
           Type: 9 GoStringHeaderType string
@@ -1410,45 +1410,45 @@ Types:
           Type: 9 GoStringHeaderType string
         - Name: PeerCertificates
           Offset: 48
-          Type: 81 GoSliceHeaderType []*crypto/x509.Certificate
+          Type: 106 GoSliceHeaderType []*crypto/x509.Certificate
         - Name: VerifiedChains
           Offset: 72
-          Type: 132 GoSliceHeaderType [][]*crypto/x509.Certificate
+          Type: 109 GoSliceHeaderType [][]*crypto/x509.Certificate
         - Name: SignedCertificateTimestamps
           Offset: 96
-          Type: 134 GoSliceHeaderType [][]uint8
+          Type: 111 GoSliceHeaderType [][]uint8
         - Name: OCSPResponse
           Offset: 120
-          Type: 77 GoSliceHeaderType []uint8
+          Type: 94 GoSliceHeaderType []uint8
         - Name: TLSUnique
           Offset: 144
-          Type: 77 GoSliceHeaderType []uint8
+          Type: 94 GoSliceHeaderType []uint8
         - Name: ECHAccepted
           Offset: 168
           Type: 4 BaseType bool
         - Name: ekm
           Offset: 176
-          Type: 136 GoSubroutineType func(string, []uint8, int) ([]uint8, error)
+          Type: 113 GoSubroutineType func(string, []uint8, int) ([]uint8, error)
         - Name: testingOnlyDidHRR
           Offset: 184
           Type: 4 BaseType bool
         - Name: testingOnlyPeerSignatureAlgorithm
           Offset: 186
-          Type: 137 BaseType crypto/tls.SignatureScheme
+          Type: 114 BaseType crypto/tls.SignatureScheme
     - __kind: BaseType
-      ID: 80
+      ID: 105
       Name: crypto/tls.CurveID
       ByteSize: 2
       GoRuntimeType: 846592
       GoKind: 9
     - __kind: BaseType
-      ID: 137
+      ID: 114
       Name: crypto/tls.SignatureScheme
       ByteSize: 2
       GoRuntimeType: 846688
       GoKind: 9
     - __kind: StructureType
-      ID: 84
+      ID: 134
       Name: crypto/x509.Certificate
       ByteSize: 1424
       GoRuntimeType: 2.45792e+06
@@ -1456,67 +1456,67 @@ Types:
       RawFields:
         - Name: Raw
           Offset: 0
-          Type: 77 GoSliceHeaderType []uint8
+          Type: 94 GoSliceHeaderType []uint8
         - Name: RawTBSCertificate
           Offset: 24
-          Type: 77 GoSliceHeaderType []uint8
+          Type: 94 GoSliceHeaderType []uint8
         - Name: RawSubjectPublicKeyInfo
           Offset: 48
-          Type: 77 GoSliceHeaderType []uint8
+          Type: 94 GoSliceHeaderType []uint8
         - Name: RawSubject
           Offset: 72
-          Type: 77 GoSliceHeaderType []uint8
+          Type: 94 GoSliceHeaderType []uint8
         - Name: RawIssuer
           Offset: 96
-          Type: 77 GoSliceHeaderType []uint8
+          Type: 94 GoSliceHeaderType []uint8
         - Name: Signature
           Offset: 120
-          Type: 77 GoSliceHeaderType []uint8
+          Type: 94 GoSliceHeaderType []uint8
         - Name: SignatureAlgorithm
           Offset: 144
-          Type: 85 BaseType crypto/x509.SignatureAlgorithm
+          Type: 153 BaseType crypto/x509.SignatureAlgorithm
         - Name: PublicKeyAlgorithm
           Offset: 152
-          Type: 86 BaseType crypto/x509.PublicKeyAlgorithm
+          Type: 154 BaseType crypto/x509.PublicKeyAlgorithm
         - Name: PublicKey
           Offset: 160
-          Type: 87 GoEmptyInterfaceType interface {}
+          Type: 155 GoEmptyInterfaceType interface {}
         - Name: Version
           Offset: 176
           Type: 7 BaseType int
         - Name: SerialNumber
           Offset: 184
-          Type: 88 PointerType *math/big.Int
+          Type: 156 PointerType *math/big.Int
         - Name: Issuer
           Offset: 192
-          Type: 93 StructureType crypto/x509/pkix.Name
+          Type: 158 StructureType crypto/x509/pkix.Name
         - Name: Subject
           Offset: 440
-          Type: 93 StructureType crypto/x509/pkix.Name
+          Type: 158 StructureType crypto/x509/pkix.Name
         - Name: NotBefore
           Offset: 688
-          Type: 98 StructureType time.Time
+          Type: 162 StructureType time.Time
         - Name: NotAfter
           Offset: 712
-          Type: 98 StructureType time.Time
+          Type: 162 StructureType time.Time
         - Name: KeyUsage
           Offset: 736
-          Type: 107 BaseType crypto/x509.KeyUsage
+          Type: 165 BaseType crypto/x509.KeyUsage
         - Name: Extensions
           Offset: 744
-          Type: 108 GoSliceHeaderType []crypto/x509/pkix.Extension
+          Type: 166 GoSliceHeaderType []crypto/x509/pkix.Extension
         - Name: ExtraExtensions
           Offset: 768
-          Type: 108 GoSliceHeaderType []crypto/x509/pkix.Extension
+          Type: 166 GoSliceHeaderType []crypto/x509/pkix.Extension
         - Name: UnhandledCriticalExtensions
           Offset: 792
-          Type: 111 GoSliceHeaderType []encoding/asn1.ObjectIdentifier
+          Type: 169 GoSliceHeaderType []encoding/asn1.ObjectIdentifier
         - Name: ExtKeyUsage
           Offset: 816
-          Type: 113 GoSliceHeaderType []crypto/x509.ExtKeyUsage
+          Type: 172 GoSliceHeaderType []crypto/x509.ExtKeyUsage
         - Name: UnknownExtKeyUsage
           Offset: 840
-          Type: 111 GoSliceHeaderType []encoding/asn1.ObjectIdentifier
+          Type: 169 GoSliceHeaderType []encoding/asn1.ObjectIdentifier
         - Name: BasicConstraintsValid
           Offset: 864
           Type: 4 BaseType bool
@@ -1531,64 +1531,64 @@ Types:
           Type: 4 BaseType bool
         - Name: SubjectKeyId
           Offset: 888
-          Type: 77 GoSliceHeaderType []uint8
+          Type: 94 GoSliceHeaderType []uint8
         - Name: AuthorityKeyId
           Offset: 912
-          Type: 77 GoSliceHeaderType []uint8
+          Type: 94 GoSliceHeaderType []uint8
         - Name: OCSPServer
           Offset: 936
-          Type: 54 GoSliceHeaderType []string
+          Type: 52 GoSliceHeaderType []string
         - Name: IssuingCertificateURL
           Offset: 960
-          Type: 54 GoSliceHeaderType []string
+          Type: 52 GoSliceHeaderType []string
         - Name: DNSNames
           Offset: 984
-          Type: 54 GoSliceHeaderType []string
+          Type: 52 GoSliceHeaderType []string
         - Name: EmailAddresses
           Offset: 1008
-          Type: 54 GoSliceHeaderType []string
+          Type: 52 GoSliceHeaderType []string
         - Name: IPAddresses
           Offset: 1032
-          Type: 116 GoSliceHeaderType []net.IP
+          Type: 175 GoSliceHeaderType []net.IP
         - Name: URIs
           Offset: 1056
-          Type: 119 GoSliceHeaderType []*net/url.URL
+          Type: 178 GoSliceHeaderType []*net/url.URL
         - Name: PermittedDNSDomainsCritical
           Offset: 1080
           Type: 4 BaseType bool
         - Name: PermittedDNSDomains
           Offset: 1088
-          Type: 54 GoSliceHeaderType []string
+          Type: 52 GoSliceHeaderType []string
         - Name: ExcludedDNSDomains
           Offset: 1112
-          Type: 54 GoSliceHeaderType []string
+          Type: 52 GoSliceHeaderType []string
         - Name: PermittedIPRanges
           Offset: 1136
-          Type: 121 GoSliceHeaderType []*net.IPNet
+          Type: 180 GoSliceHeaderType []*net.IPNet
         - Name: ExcludedIPRanges
           Offset: 1160
-          Type: 121 GoSliceHeaderType []*net.IPNet
+          Type: 180 GoSliceHeaderType []*net.IPNet
         - Name: PermittedEmailAddresses
           Offset: 1184
-          Type: 54 GoSliceHeaderType []string
+          Type: 52 GoSliceHeaderType []string
         - Name: ExcludedEmailAddresses
           Offset: 1208
-          Type: 54 GoSliceHeaderType []string
+          Type: 52 GoSliceHeaderType []string
         - Name: PermittedURIDomains
           Offset: 1232
-          Type: 54 GoSliceHeaderType []string
+          Type: 52 GoSliceHeaderType []string
         - Name: ExcludedURIDomains
           Offset: 1256
-          Type: 54 GoSliceHeaderType []string
+          Type: 52 GoSliceHeaderType []string
         - Name: CRLDistributionPoints
           Offset: 1280
-          Type: 54 GoSliceHeaderType []string
+          Type: 52 GoSliceHeaderType []string
         - Name: PolicyIdentifiers
           Offset: 1304
-          Type: 111 GoSliceHeaderType []encoding/asn1.ObjectIdentifier
+          Type: 169 GoSliceHeaderType []encoding/asn1.ObjectIdentifier
         - Name: Policies
           Offset: 1328
-          Type: 126 GoSliceHeaderType []crypto/x509.OID
+          Type: 183 GoSliceHeaderType []crypto/x509.OID
         - Name: InhibitAnyPolicy
           Offset: 1352
           Type: 7 BaseType int
@@ -1609,21 +1609,21 @@ Types:
           Type: 4 BaseType bool
         - Name: PolicyMappings
           Offset: 1400
-          Type: 129 GoSliceHeaderType []crypto/x509.PolicyMapping
+          Type: 186 GoSliceHeaderType []crypto/x509.PolicyMapping
     - __kind: BaseType
-      ID: 115
+      ID: 174
       Name: crypto/x509.ExtKeyUsage
       ByteSize: 8
       GoRuntimeType: 598080
       GoKind: 2
     - __kind: BaseType
-      ID: 107
+      ID: 165
       Name: crypto/x509.KeyUsage
       ByteSize: 8
       GoRuntimeType: 598016
       GoKind: 2
     - __kind: StructureType
-      ID: 128
+      ID: 185
       Name: crypto/x509.OID
       ByteSize: 24
       GoRuntimeType: 1.9976e+06
@@ -1631,9 +1631,9 @@ Types:
       RawFields:
         - Name: der
           Offset: 0
-          Type: 77 GoSliceHeaderType []uint8
+          Type: 94 GoSliceHeaderType []uint8
     - __kind: StructureType
-      ID: 131
+      ID: 188
       Name: crypto/x509.PolicyMapping
       ByteSize: 48
       GoRuntimeType: 1.519712e+06
@@ -1641,24 +1641,24 @@ Types:
       RawFields:
         - Name: IssuerDomainPolicy
           Offset: 0
-          Type: 128 StructureType crypto/x509.OID
+          Type: 185 StructureType crypto/x509.OID
         - Name: SubjectDomainPolicy
           Offset: 24
-          Type: 128 StructureType crypto/x509.OID
+          Type: 185 StructureType crypto/x509.OID
     - __kind: BaseType
-      ID: 86
+      ID: 154
       Name: crypto/x509.PublicKeyAlgorithm
       ByteSize: 8
       GoRuntimeType: 849088
       GoKind: 2
     - __kind: BaseType
-      ID: 85
+      ID: 153
       Name: crypto/x509.SignatureAlgorithm
       ByteSize: 8
       GoRuntimeType: 1.138944e+06
       GoKind: 2
     - __kind: StructureType
-      ID: 96
+      ID: 161
       Name: crypto/x509/pkix.AttributeTypeAndValue
       ByteSize: 40
       GoRuntimeType: 1.532192e+06
@@ -1666,12 +1666,12 @@ Types:
       RawFields:
         - Name: Type
           Offset: 0
-          Type: 97 GoSliceHeaderType encoding/asn1.ObjectIdentifier
+          Type: 171 GoSliceHeaderType encoding/asn1.ObjectIdentifier
         - Name: Value
           Offset: 24
-          Type: 87 GoEmptyInterfaceType interface {}
+          Type: 155 GoEmptyInterfaceType interface {}
     - __kind: StructureType
-      ID: 110
+      ID: 168
       Name: crypto/x509/pkix.Extension
       ByteSize: 56
       GoRuntimeType: 1.683232e+06
@@ -1679,15 +1679,15 @@ Types:
       RawFields:
         - Name: Id
           Offset: 0
-          Type: 97 GoSliceHeaderType encoding/asn1.ObjectIdentifier
+          Type: 171 GoSliceHeaderType encoding/asn1.ObjectIdentifier
         - Name: Critical
           Offset: 24
           Type: 4 BaseType bool
         - Name: Value
           Offset: 32
-          Type: 77 GoSliceHeaderType []uint8
+          Type: 94 GoSliceHeaderType []uint8
     - __kind: StructureType
-      ID: 93
+      ID: 158
       Name: crypto/x509/pkix.Name
       ByteSize: 248
       GoRuntimeType: 2.249504e+06
@@ -1695,25 +1695,25 @@ Types:
       RawFields:
         - Name: Country
           Offset: 0
-          Type: 54 GoSliceHeaderType []string
+          Type: 52 GoSliceHeaderType []string
         - Name: Organization
           Offset: 24
-          Type: 54 GoSliceHeaderType []string
+          Type: 52 GoSliceHeaderType []string
         - Name: OrganizationalUnit
           Offset: 48
-          Type: 54 GoSliceHeaderType []string
+          Type: 52 GoSliceHeaderType []string
         - Name: Locality
           Offset: 72
-          Type: 54 GoSliceHeaderType []string
+          Type: 52 GoSliceHeaderType []string
         - Name: Province
           Offset: 96
-          Type: 54 GoSliceHeaderType []string
+          Type: 52 GoSliceHeaderType []string
         - Name: StreetAddress
           Offset: 120
-          Type: 54 GoSliceHeaderType []string
+          Type: 52 GoSliceHeaderType []string
         - Name: PostalCode
           Offset: 144
-          Type: 54 GoSliceHeaderType []string
+          Type: 52 GoSliceHeaderType []string
         - Name: SerialNumber
           Offset: 168
           Type: 9 GoStringHeaderType string
@@ -1722,12 +1722,12 @@ Types:
           Type: 9 GoStringHeaderType string
         - Name: Names
           Offset: 200
-          Type: 94 GoSliceHeaderType []crypto/x509/pkix.AttributeTypeAndValue
+          Type: 159 GoSliceHeaderType []crypto/x509/pkix.AttributeTypeAndValue
         - Name: ExtraNames
           Offset: 224
-          Type: 94 GoSliceHeaderType []crypto/x509/pkix.AttributeTypeAndValue
+          Type: 159 GoSliceHeaderType []crypto/x509/pkix.AttributeTypeAndValue
     - __kind: GoSliceHeaderType
-      ID: 97
+      ID: 171
       Name: encoding/asn1.ObjectIdentifier
       ByteSize: 24
       GoRuntimeType: 1.0792e+06
@@ -1742,9 +1742,9 @@ Types:
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 246 GoSliceDataType encoding/asn1.ObjectIdentifier.array
+      Data: 266 GoSliceDataType encoding/asn1.ObjectIdentifier.array
     - __kind: GoSliceDataType
-      ID: 246
+      ID: 266
       Name: encoding/asn1.ObjectIdentifier.array
       ByteSize: 2048
       Element: 7 BaseType int
@@ -1774,25 +1774,25 @@ Types:
       GoRuntimeType: 594944
       GoKind: 14
     - __kind: GoSubroutineType
-      ID: 224
+      ID: 93
       Name: func()
       ByteSize: 8
       GoRuntimeType: 484800
       GoKind: 19
     - __kind: GoSubroutineType
-      ID: 56
+      ID: 51
       Name: func() (io.ReadCloser, error)
       ByteSize: 8
       GoRuntimeType: 704864
       GoKind: 19
     - __kind: GoSubroutineType
-      ID: 136
+      ID: 113
       Name: func(string, []uint8, int) ([]uint8, error)
       ByteSize: 8
       GoRuntimeType: 1.024448e+06
       GoKind: 19
     - __kind: StructureType
-      ID: 159
+      ID: 40
       Name: github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span
       ByteSize: 288
       GoRuntimeType: 2.396832e+06
@@ -1800,7 +1800,7 @@ Types:
       RawFields:
         - Name: mu
           Offset: 0
-          Type: 160 StructureType sync.RWMutex
+          Type: 69 StructureType sync.RWMutex
         - Name: name
           Offset: 24
           Type: 9 GoStringHeaderType string
@@ -1821,13 +1821,13 @@ Types:
           Type: 13 BaseType int64
         - Name: meta
           Offset: 104
-          Type: 147 GoMapType map[string]string
+          Type: 64 GoMapType map[string]string
         - Name: metaStruct
           Offset: 112
-          Type: 166 GoMapType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.metaStructMap
+          Type: 75 GoMapType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.metaStructMap
         - Name: metrics
           Offset: 120
-          Type: 177 GoMapType map[string]float64
+          Type: 80 GoMapType map[string]float64
         - Name: spanID
           Offset: 128
           Type: 8 BaseType uint64
@@ -1842,10 +1842,10 @@ Types:
           Type: 12 BaseType int32
         - Name: spanLinks
           Offset: 160
-          Type: 188 GoSliceHeaderType []github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink
+          Type: 85 GoSliceHeaderType []github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink
         - Name: spanEvents
           Offset: 184
-          Type: 191 GoSliceHeaderType []github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent
+          Type: 88 GoSliceHeaderType []github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent
         - Name: goExecTraced
           Offset: 208
           Type: 4 BaseType bool
@@ -1857,7 +1857,7 @@ Types:
           Type: 4 BaseType bool
         - Name: context
           Offset: 216
-          Type: 216 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanContext
+          Type: 91 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanContext
         - Name: integration
           Offset: 224
           Type: 9 GoStringHeaderType string
@@ -1866,15 +1866,15 @@ Types:
           Type: 4 BaseType bool
         - Name: pprofCtxActive
           Offset: 248
-          Type: 141 GoInterfaceType context.Context
+          Type: 61 GoInterfaceType context.Context
         - Name: pprofCtxRestore
           Offset: 264
-          Type: 141 GoInterfaceType context.Context
+          Type: 61 GoInterfaceType context.Context
         - Name: taskEnd
           Offset: 280
-          Type: 224 GoSubroutineType func()
+          Type: 93 GoSubroutineType func()
     - __kind: StructureType
-      ID: 217
+      ID: 92
       Name: github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanContext
       ByteSize: 168
       GoRuntimeType: 2.269184e+06
@@ -1885,13 +1885,13 @@ Types:
           Type: 4 BaseType bool
         - Name: trace
           Offset: 8
-          Type: 218 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.trace
+          Type: 127 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.trace
         - Name: span
           Offset: 16
-          Type: 158 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span
+          Type: 39 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span
         - Name: errors
           Offset: 24
-          Type: 164 StructureType sync/atomic.Int32
+          Type: 73 StructureType sync/atomic.Int32
         - Name: reparentID
           Offset: 32
           Type: 9 GoStringHeaderType string
@@ -1900,16 +1900,16 @@ Types:
           Type: 4 BaseType bool
         - Name: traceID
           Offset: 49
-          Type: 223 ArrayType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.traceID
+          Type: 129 ArrayType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.traceID
         - Name: spanID
           Offset: 72
           Type: 8 BaseType uint64
         - Name: mu
           Offset: 80
-          Type: 160 StructureType sync.RWMutex
+          Type: 69 StructureType sync.RWMutex
         - Name: baggage
           Offset: 104
-          Type: 147 GoMapType map[string]string
+          Type: 64 GoMapType map[string]string
         - Name: hasBaggage
           Offset: 112
           Type: 2 BaseType uint32
@@ -1918,12 +1918,12 @@ Types:
           Type: 9 GoStringHeaderType string
         - Name: spanLinks
           Offset: 136
-          Type: 188 GoSliceHeaderType []github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink
+          Type: 85 GoSliceHeaderType []github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink
         - Name: baggageOnly
           Offset: 160
           Type: 4 BaseType bool
     - __kind: StructureType
-      ID: 190
+      ID: 87
       Name: github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink
       ByteSize: 56
       GoRuntimeType: 1.954848e+06
@@ -1940,7 +1940,7 @@ Types:
           Type: 8 BaseType uint64
         - Name: Attributes
           Offset: 24
-          Type: 147 GoMapType map[string]string
+          Type: 64 GoMapType map[string]string
         - Name: Tracestate
           Offset: 32
           Type: 9 GoStringHeaderType string
@@ -1948,20 +1948,20 @@ Types:
           Offset: 48
           Type: 2 BaseType uint32
     - __kind: GoMapType
-      ID: 166
+      ID: 75
       Name: github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.metaStructMap
       ByteSize: 8
       GoRuntimeType: 1.303776e+06
       GoKind: 21
-      HeaderType: 168 GoSwissMapHeaderType map<string,interface {}>
+      HeaderType: 77 GoSwissMapHeaderType map<string,interface {}>
     - __kind: BaseType
-      ID: 222
+      ID: 147
       Name: github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.samplingDecision
       ByteSize: 4
       GoRuntimeType: 593792
       GoKind: 10
     - __kind: StructureType
-      ID: 193
+      ID: 90
       Name: github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent
       ByteSize: 40
       GoRuntimeType: 1.78912e+06
@@ -1975,12 +1975,12 @@ Types:
           Type: 8 BaseType uint64
         - Name: Attributes
           Offset: 24
-          Type: 194 GoMapType map[string]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
+          Type: 121 GoMapType map[string]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
         - Name: RawAttributes
           Offset: 32
-          Type: 215 GoMapType map[string]interface {}
+          Type: 126 GoMapType map[string]interface {}
     - __kind: StructureType
-      ID: 209
+      ID: 221
       Name: github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttribute
       ByteSize: 24
       GoRuntimeType: 1.214496e+06
@@ -1988,9 +1988,9 @@ Types:
       RawFields:
         - Name: Values
           Offset: 0
-          Type: 210 GoSliceHeaderType []*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttributeValue
+          Type: 223 GoSliceHeaderType []*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttributeValue
     - __kind: StructureType
-      ID: 213
+      ID: 226
       Name: github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttributeValue
       ByteSize: 48
       GoRuntimeType: 1.878208e+06
@@ -1998,7 +1998,7 @@ Types:
       RawFields:
         - Name: Type
           Offset: 0
-          Type: 214 BaseType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttributeValueType
+          Type: 227 BaseType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttributeValueType
         - Name: StringValue
           Offset: 8
           Type: 9 GoStringHeaderType string
@@ -2012,13 +2012,13 @@ Types:
           Offset: 40
           Type: 16 BaseType float64
     - __kind: BaseType
-      ID: 214
+      ID: 227
       Name: github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttributeValueType
       ByteSize: 4
       GoRuntimeType: 1.006112e+06
       GoKind: 5
     - __kind: StructureType
-      ID: 206
+      ID: 216
       Name: github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
       ByteSize: 56
       GoRuntimeType: 1.955104e+06
@@ -2026,7 +2026,7 @@ Types:
       RawFields:
         - Name: Type
           Offset: 0
-          Type: 207 BaseType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttributeType
+          Type: 219 BaseType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttributeType
         - Name: StringValue
           Offset: 8
           Type: 9 GoStringHeaderType string
@@ -2041,15 +2041,15 @@ Types:
           Type: 16 BaseType float64
         - Name: ArrayValue
           Offset: 48
-          Type: 208 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttribute
+          Type: 220 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttribute
     - __kind: BaseType
-      ID: 207
+      ID: 219
       Name: github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttributeType
       ByteSize: 4
       GoRuntimeType: 1.006016e+06
       GoKind: 5
     - __kind: StructureType
-      ID: 219
+      ID: 128
       Name: github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.trace
       ByteSize: 104
       GoRuntimeType: 2.154976e+06
@@ -2057,16 +2057,16 @@ Types:
       RawFields:
         - Name: mu
           Offset: 0
-          Type: 160 StructureType sync.RWMutex
+          Type: 69 StructureType sync.RWMutex
         - Name: spans
           Offset: 24
-          Type: 220 GoSliceHeaderType []*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span
+          Type: 145 GoSliceHeaderType []*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span
         - Name: tags
           Offset: 48
-          Type: 147 GoMapType map[string]string
+          Type: 64 GoMapType map[string]string
         - Name: propagatingTags
           Offset: 56
-          Type: 147 GoMapType map[string]string
+          Type: 64 GoMapType map[string]string
         - Name: finished
           Offset: 64
           Type: 7 BaseType int
@@ -2081,12 +2081,12 @@ Types:
           Type: 4 BaseType bool
         - Name: samplingDecision
           Offset: 92
-          Type: 222 BaseType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.samplingDecision
+          Type: 147 BaseType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.samplingDecision
         - Name: root
           Offset: 96
-          Type: 158 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span
+          Type: 39 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span
     - __kind: ArrayType
-      ID: 223
+      ID: 129
       Name: github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.traceID
       ByteSize: 16
       GoRuntimeType: 918624
@@ -2095,89 +2095,89 @@ Types:
       HasCount: true
       Element: 3 BaseType uint8
     - __kind: GoSwissMapGroupsType
-      ID: 200
+      ID: 195
       Name: groupReference<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 201 PointerType *noalg.map.group[string]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
+          Type: 196 PointerType *noalg.map.group[string]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
         - Name: lengthMask
           Offset: 8
           Type: 8 BaseType uint64
-      GroupType: 202 StructureType noalg.map.group[string]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
-      GroupSliceType: 289 GoSliceDataType []noalg.map.group[string]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute.array
+      GroupType: 197 StructureType noalg.map.group[string]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
+      GroupSliceType: 257 GoSliceDataType []noalg.map.group[string]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute.array
     - __kind: GoSwissMapGroupsType
-      ID: 67
+      ID: 150
       Name: groupReference<string,[]*mime/multipart.FileHeader>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 68 PointerType *noalg.map.group[string][]*mime/multipart.FileHeader
+          Type: 151 PointerType *noalg.map.group[string][]*mime/multipart.FileHeader
         - Name: lengthMask
           Offset: 8
           Type: 8 BaseType uint64
-      GroupType: 69 StructureType noalg.map.group[string][]*mime/multipart.FileHeader
-      GroupSliceType: 235 GoSliceDataType []noalg.map.group[string][]*mime/multipart.FileHeader.array
+      GroupType: 152 StructureType noalg.map.group[string][]*mime/multipart.FileHeader
+      GroupSliceType: 247 GoSliceDataType []noalg.map.group[string][]*mime/multipart.FileHeader.array
     - __kind: GoSwissMapGroupsType
-      ID: 49
+      ID: 130
       Name: groupReference<string,[]string>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 50 PointerType *noalg.map.group[string][]string
+          Type: 131 PointerType *noalg.map.group[string][]string
         - Name: lengthMask
           Offset: 8
           Type: 8 BaseType uint64
-      GroupType: 51 StructureType noalg.map.group[string][]string
+      GroupType: 132 StructureType noalg.map.group[string][]string
       GroupSliceType: 231 GoSliceDataType []noalg.map.group[string][]string.array
     - __kind: GoSwissMapGroupsType
-      ID: 183
+      ID: 141
       Name: groupReference<string,float64>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 184 PointerType *noalg.map.group[string]float64
+          Type: 142 PointerType *noalg.map.group[string]float64
         - Name: lengthMask
           Offset: 8
           Type: 8 BaseType uint64
-      GroupType: 185 StructureType noalg.map.group[string]float64
-      GroupSliceType: 283 GoSliceDataType []noalg.map.group[string]float64.array
+      GroupType: 143 StructureType noalg.map.group[string]float64
+      GroupSliceType: 239 GoSliceDataType []noalg.map.group[string]float64.array
     - __kind: GoSwissMapGroupsType
-      ID: 172
+      ID: 138
       Name: groupReference<string,interface {}>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 173 PointerType *noalg.map.group[string]interface {}
+          Type: 139 PointerType *noalg.map.group[string]interface {}
         - Name: lengthMask
           Offset: 8
           Type: 8 BaseType uint64
-      GroupType: 174 StructureType noalg.map.group[string]interface {}
-      GroupSliceType: 281 GoSliceDataType []noalg.map.group[string]interface {}.array
+      GroupType: 140 StructureType noalg.map.group[string]interface {}
+      GroupSliceType: 237 GoSliceDataType []noalg.map.group[string]interface {}.array
     - __kind: GoSwissMapGroupsType
-      ID: 153
+      ID: 135
       Name: groupReference<string,string>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 154 PointerType *noalg.map.group[string]string
+          Type: 136 PointerType *noalg.map.group[string]string
         - Name: lengthMask
           Offset: 8
           Type: 8 BaseType uint64
-      GroupType: 155 StructureType noalg.map.group[string]string
-      GroupSliceType: 279 GoSliceDataType []noalg.map.group[string]string.array
+      GroupType: 137 StructureType noalg.map.group[string]string
+      GroupSliceType: 235 GoSliceDataType []noalg.map.group[string]string.array
     - __kind: BaseType
       ID: 7
       Name: int
@@ -2209,7 +2209,7 @@ Types:
       GoRuntimeType: 594048
       GoKind: 3
     - __kind: GoEmptyInterfaceType
-      ID: 87
+      ID: 155
       Name: interface {}
       ByteSize: 16
       GoRuntimeType: 866496
@@ -2222,7 +2222,7 @@ Types:
           Offset: 8
           Type: 15 VoidPointerType unsafe.Pointer
     - __kind: StructureType
-      ID: 163
+      ID: 72
       Name: internal/sync.Mutex
       ByteSize: 8
       GoRuntimeType: 1.517472e+06
@@ -2235,7 +2235,7 @@ Types:
           Offset: 4
           Type: 2 BaseType uint32
     - __kind: GoInterfaceType
-      ID: 55
+      ID: 50
       Name: io.ReadCloser
       ByteSize: 16
       GoRuntimeType: 1.134464e+06
@@ -2248,7 +2248,7 @@ Types:
           Offset: 8
           Type: 15 VoidPointerType unsafe.Pointer
     - __kind: GoSwissMapHeaderType
-      ID: 196
+      ID: 123
       Name: map<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
       ByteSize: 48
       GoKind: 25
@@ -2261,7 +2261,7 @@ Types:
           Type: 1 BaseType uintptr
         - Name: dirPtr
           Offset: 16
-          Type: 197 PointerType **table<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
+          Type: 124 PointerType **table<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
         - Name: dirLen
           Offset: 24
           Type: 7 BaseType int
@@ -2280,10 +2280,10 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 8 BaseType uint64
-      TablePtrSliceType: 288 GoSliceDataType []*table<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>.array
-      GroupType: 202 StructureType noalg.map.group[string]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
+      TablePtrSliceType: 256 GoSliceDataType []*table<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>.array
+      GroupType: 197 StructureType noalg.map.group[string]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
     - __kind: GoSwissMapHeaderType
-      ID: 63
+      ID: 102
       Name: map<string,[]*mime/multipart.FileHeader>
       ByteSize: 48
       GoKind: 25
@@ -2296,7 +2296,7 @@ Types:
           Type: 1 BaseType uintptr
         - Name: dirPtr
           Offset: 16
-          Type: 64 PointerType **table<string,[]*mime/multipart.FileHeader>
+          Type: 103 PointerType **table<string,[]*mime/multipart.FileHeader>
         - Name: dirLen
           Offset: 24
           Type: 7 BaseType int
@@ -2315,10 +2315,10 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 8 BaseType uint64
-      TablePtrSliceType: 234 GoSliceDataType []*table<string,[]*mime/multipart.FileHeader>.array
-      GroupType: 69 StructureType noalg.map.group[string][]*mime/multipart.FileHeader
+      TablePtrSliceType: 246 GoSliceDataType []*table<string,[]*mime/multipart.FileHeader>.array
+      GroupType: 152 StructureType noalg.map.group[string][]*mime/multipart.FileHeader
     - __kind: GoSwissMapHeaderType
-      ID: 45
+      ID: 47
       Name: map<string,[]string>
       ByteSize: 48
       GoKind: 25
@@ -2331,7 +2331,7 @@ Types:
           Type: 1 BaseType uintptr
         - Name: dirPtr
           Offset: 16
-          Type: 46 PointerType **table<string,[]string>
+          Type: 48 PointerType **table<string,[]string>
         - Name: dirLen
           Offset: 24
           Type: 7 BaseType int
@@ -2351,9 +2351,9 @@ Types:
           Offset: 40
           Type: 8 BaseType uint64
       TablePtrSliceType: 230 GoSliceDataType []*table<string,[]string>.array
-      GroupType: 51 StructureType noalg.map.group[string][]string
+      GroupType: 132 StructureType noalg.map.group[string][]string
     - __kind: GoSwissMapHeaderType
-      ID: 179
+      ID: 82
       Name: map<string,float64>
       ByteSize: 48
       GoKind: 25
@@ -2366,7 +2366,7 @@ Types:
           Type: 1 BaseType uintptr
         - Name: dirPtr
           Offset: 16
-          Type: 180 PointerType **table<string,float64>
+          Type: 83 PointerType **table<string,float64>
         - Name: dirLen
           Offset: 24
           Type: 7 BaseType int
@@ -2385,10 +2385,10 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 8 BaseType uint64
-      TablePtrSliceType: 282 GoSliceDataType []*table<string,float64>.array
-      GroupType: 185 StructureType noalg.map.group[string]float64
+      TablePtrSliceType: 238 GoSliceDataType []*table<string,float64>.array
+      GroupType: 143 StructureType noalg.map.group[string]float64
     - __kind: GoSwissMapHeaderType
-      ID: 168
+      ID: 77
       Name: map<string,interface {}>
       ByteSize: 48
       GoKind: 25
@@ -2401,7 +2401,7 @@ Types:
           Type: 1 BaseType uintptr
         - Name: dirPtr
           Offset: 16
-          Type: 169 PointerType **table<string,interface {}>
+          Type: 78 PointerType **table<string,interface {}>
         - Name: dirLen
           Offset: 24
           Type: 7 BaseType int
@@ -2420,10 +2420,10 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 8 BaseType uint64
-      TablePtrSliceType: 280 GoSliceDataType []*table<string,interface {}>.array
-      GroupType: 174 StructureType noalg.map.group[string]interface {}
+      TablePtrSliceType: 236 GoSliceDataType []*table<string,interface {}>.array
+      GroupType: 140 StructureType noalg.map.group[string]interface {}
     - __kind: GoSwissMapHeaderType
-      ID: 149
+      ID: 66
       Name: map<string,string>
       ByteSize: 48
       GoKind: 25
@@ -2436,7 +2436,7 @@ Types:
           Type: 1 BaseType uintptr
         - Name: dirPtr
           Offset: 16
-          Type: 150 PointerType **table<string,string>
+          Type: 67 PointerType **table<string,string>
         - Name: dirLen
           Offset: 24
           Type: 7 BaseType int
@@ -2455,52 +2455,52 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 8 BaseType uint64
-      TablePtrSliceType: 278 GoSliceDataType []*table<string,string>.array
-      GroupType: 155 StructureType noalg.map.group[string]string
+      TablePtrSliceType: 234 GoSliceDataType []*table<string,string>.array
+      GroupType: 137 StructureType noalg.map.group[string]string
     - __kind: GoMapType
-      ID: 194
+      ID: 121
       Name: map[string]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
       ByteSize: 8
       GoRuntimeType: 1.157632e+06
       GoKind: 21
-      HeaderType: 196 GoSwissMapHeaderType map<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
+      HeaderType: 123 GoSwissMapHeaderType map<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
     - __kind: GoMapType
-      ID: 61
+      ID: 100
       Name: map[string][]*mime/multipart.FileHeader
       ByteSize: 8
       GoRuntimeType: 1.156864e+06
       GoKind: 21
-      HeaderType: 63 GoSwissMapHeaderType map<string,[]*mime/multipart.FileHeader>
+      HeaderType: 102 GoSwissMapHeaderType map<string,[]*mime/multipart.FileHeader>
     - __kind: GoMapType
-      ID: 60
+      ID: 99
       Name: map[string][]string
       ByteSize: 8
       GoRuntimeType: 1.152512e+06
       GoKind: 21
-      HeaderType: 45 GoSwissMapHeaderType map<string,[]string>
+      HeaderType: 47 GoSwissMapHeaderType map<string,[]string>
     - __kind: GoMapType
-      ID: 177
+      ID: 80
       Name: map[string]float64
       ByteSize: 8
       GoRuntimeType: 1.157504e+06
       GoKind: 21
-      HeaderType: 179 GoSwissMapHeaderType map<string,float64>
+      HeaderType: 82 GoSwissMapHeaderType map<string,float64>
     - __kind: GoMapType
-      ID: 215
+      ID: 126
       Name: map[string]interface {}
       ByteSize: 8
       GoRuntimeType: 1.151104e+06
       GoKind: 21
-      HeaderType: 168 GoSwissMapHeaderType map<string,interface {}>
+      HeaderType: 77 GoSwissMapHeaderType map<string,interface {}>
     - __kind: GoMapType
-      ID: 147
+      ID: 64
       Name: map[string]string
       ByteSize: 8
       GoRuntimeType: 1.153536e+06
       GoKind: 21
-      HeaderType: 149 GoSwissMapHeaderType map<string,string>
+      HeaderType: 66 GoSwissMapHeaderType map<string,string>
     - __kind: StructureType
-      ID: 89
+      ID: 157
       Name: math/big.Int
       ByteSize: 32
       GoRuntimeType: 1.522752e+06
@@ -2511,15 +2511,15 @@ Types:
           Type: 4 BaseType bool
         - Name: abs
           Offset: 8
-          Type: 90 GoSliceHeaderType math/big.nat
+          Type: 203 GoSliceHeaderType math/big.nat
     - __kind: BaseType
-      ID: 92
+      ID: 205
       Name: math/big.Word
       ByteSize: 8
       GoRuntimeType: 598272
       GoKind: 7
     - __kind: GoSliceHeaderType
-      ID: 90
+      ID: 203
       Name: math/big.nat
       ByteSize: 24
       GoRuntimeType: 2.426144e+06
@@ -2527,21 +2527,21 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 91 PointerType *math/big.Word
+          Type: 204 PointerType *math/big.Word
         - Name: len
           Offset: 8
           Type: 7 BaseType int
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 242 GoSliceDataType math/big.nat.array
+      Data: 284 GoSliceDataType math/big.nat.array
     - __kind: GoSliceDataType
-      ID: 242
+      ID: 284
       Name: math/big.nat.array
       ByteSize: 2048
-      Element: 92 BaseType math/big.Word
+      Element: 205 BaseType math/big.Word
     - __kind: StructureType
-      ID: 75
+      ID: 217
       Name: mime/multipart.FileHeader
       ByteSize: 88
       GoRuntimeType: 2.018016e+06
@@ -2552,13 +2552,13 @@ Types:
           Type: 9 GoStringHeaderType string
         - Name: Header
           Offset: 16
-          Type: 76 GoMapType net/textproto.MIMEHeader
+          Type: 222 GoMapType net/textproto.MIMEHeader
         - Name: Size
           Offset: 24
           Type: 13 BaseType int64
         - Name: content
           Offset: 32
-          Type: 77 GoSliceHeaderType []uint8
+          Type: 94 GoSliceHeaderType []uint8
         - Name: tmpfile
           Offset: 56
           Type: 9 GoStringHeaderType string
@@ -2569,7 +2569,7 @@ Types:
           Offset: 80
           Type: 4 BaseType bool
     - __kind: StructureType
-      ID: 59
+      ID: 55
       Name: mime/multipart.Form
       ByteSize: 16
       GoRuntimeType: 1.505952e+06
@@ -2577,12 +2577,12 @@ Types:
       RawFields:
         - Name: Value
           Offset: 0
-          Type: 60 GoMapType map[string][]string
+          Type: 99 GoMapType map[string][]string
         - Name: File
           Offset: 8
-          Type: 61 GoMapType map[string][]*mime/multipart.FileHeader
+          Type: 100 GoMapType map[string][]*mime/multipart.FileHeader
     - __kind: GoSliceHeaderType
-      ID: 118
+      ID: 177
       Name: net.IP
       ByteSize: 24
       GoRuntimeType: 2.178176e+06
@@ -2597,14 +2597,14 @@ Types:
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 260 GoSliceDataType net.IP.array
+      Data: 272 GoSliceDataType net.IP.array
     - __kind: GoSliceDataType
-      ID: 260
+      ID: 272
       Name: net.IP.array
       ByteSize: 2048
       Element: 3 BaseType uint8
     - __kind: GoSliceHeaderType
-      ID: 125
+      ID: 218
       Name: net.IPMask
       ByteSize: 24
       GoRuntimeType: 1.041568e+06
@@ -2619,14 +2619,14 @@ Types:
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 266 GoSliceDataType net.IPMask.array
+      Data: 290 GoSliceDataType net.IPMask.array
     - __kind: GoSliceDataType
-      ID: 266
+      ID: 290
       Name: net.IPMask.array
       ByteSize: 2048
       Element: 3 BaseType uint8
     - __kind: StructureType
-      ID: 124
+      ID: 212
       Name: net.IPNet
       ByteSize: 48
       GoRuntimeType: 1.486272e+06
@@ -2634,17 +2634,17 @@ Types:
       RawFields:
         - Name: IP
           Offset: 0
-          Type: 118 GoSliceHeaderType net.IP
+          Type: 177 GoSliceHeaderType net.IP
         - Name: Mask
           Offset: 24
-          Type: 125 GoSliceHeaderType net.IPMask
+          Type: 218 GoSliceHeaderType net.IPMask
     - __kind: GoMapType
-      ID: 43
+      ID: 45
       Name: net/http.Header
       ByteSize: 8
       GoRuntimeType: 2.154272e+06
       GoKind: 21
-      HeaderType: 45 GoSwissMapHeaderType map<string,[]string>
+      HeaderType: 47 GoSwissMapHeaderType map<string,[]string>
     - __kind: StructureType
       ID: 38
       Name: net/http.Request
@@ -2657,7 +2657,7 @@ Types:
           Type: 9 GoStringHeaderType string
         - Name: URL
           Offset: 16
-          Type: 39 PointerType *net/url.URL
+          Type: 43 PointerType *net/url.URL
         - Name: Proto
           Offset: 24
           Type: 9 GoStringHeaderType string
@@ -2669,19 +2669,19 @@ Types:
           Type: 7 BaseType int
         - Name: Header
           Offset: 56
-          Type: 43 GoMapType net/http.Header
+          Type: 45 GoMapType net/http.Header
         - Name: Body
           Offset: 64
-          Type: 55 GoInterfaceType io.ReadCloser
+          Type: 50 GoInterfaceType io.ReadCloser
         - Name: GetBody
           Offset: 80
-          Type: 56 GoSubroutineType func() (io.ReadCloser, error)
+          Type: 51 GoSubroutineType func() (io.ReadCloser, error)
         - Name: ContentLength
           Offset: 88
           Type: 13 BaseType int64
         - Name: TransferEncoding
           Offset: 96
-          Type: 54 GoSliceHeaderType []string
+          Type: 52 GoSliceHeaderType []string
         - Name: Close
           Offset: 120
           Type: 4 BaseType bool
@@ -2690,16 +2690,16 @@ Types:
           Type: 9 GoStringHeaderType string
         - Name: Form
           Offset: 144
-          Type: 57 GoMapType net/url.Values
+          Type: 53 GoMapType net/url.Values
         - Name: PostForm
           Offset: 152
-          Type: 57 GoMapType net/url.Values
+          Type: 53 GoMapType net/url.Values
         - Name: MultipartForm
           Offset: 160
-          Type: 58 PointerType *mime/multipart.Form
+          Type: 54 PointerType *mime/multipart.Form
         - Name: Trailer
           Offset: 168
-          Type: 43 GoMapType net/http.Header
+          Type: 45 GoMapType net/http.Header
         - Name: RemoteAddr
           Offset: 176
           Type: 9 GoStringHeaderType string
@@ -2708,30 +2708,30 @@ Types:
           Type: 9 GoStringHeaderType string
         - Name: TLS
           Offset: 208
-          Type: 78 PointerType *crypto/tls.ConnectionState
+          Type: 56 PointerType *crypto/tls.ConnectionState
         - Name: Cancel
           Offset: 216
-          Type: 138 GoChannelType <-chan struct {}
+          Type: 58 GoChannelType <-chan struct {}
         - Name: Response
           Offset: 224
-          Type: 139 PointerType *net/http.Response
+          Type: 59 PointerType *net/http.Response
         - Name: Pattern
           Offset: 232
           Type: 9 GoStringHeaderType string
         - Name: ctx
           Offset: 248
-          Type: 141 GoInterfaceType context.Context
+          Type: 61 GoInterfaceType context.Context
         - Name: pat
           Offset: 264
-          Type: 142 PointerType *net/http.pattern
+          Type: 62 PointerType *net/http.pattern
         - Name: matches
           Offset: 272
-          Type: 54 GoSliceHeaderType []string
+          Type: 52 GoSliceHeaderType []string
         - Name: otherValues
           Offset: 296
-          Type: 147 GoMapType map[string]string
+          Type: 64 GoMapType map[string]string
     - __kind: StructureType
-      ID: 140
+      ID: 60
       Name: net/http.Response
       ByteSize: 144
       GoRuntimeType: 2.26784e+06
@@ -2754,16 +2754,16 @@ Types:
           Type: 7 BaseType int
         - Name: Header
           Offset: 56
-          Type: 43 GoMapType net/http.Header
+          Type: 45 GoMapType net/http.Header
         - Name: Body
           Offset: 64
-          Type: 55 GoInterfaceType io.ReadCloser
+          Type: 50 GoInterfaceType io.ReadCloser
         - Name: ContentLength
           Offset: 80
           Type: 13 BaseType int64
         - Name: TransferEncoding
           Offset: 88
-          Type: 54 GoSliceHeaderType []string
+          Type: 52 GoSliceHeaderType []string
         - Name: Close
           Offset: 112
           Type: 4 BaseType bool
@@ -2772,13 +2772,13 @@ Types:
           Type: 4 BaseType bool
         - Name: Trailer
           Offset: 120
-          Type: 43 GoMapType net/http.Header
+          Type: 45 GoMapType net/http.Header
         - Name: Request
           Offset: 128
           Type: 37 PointerType *net/http.Request
         - Name: TLS
           Offset: 136
-          Type: 78 PointerType *crypto/tls.ConnectionState
+          Type: 56 PointerType *crypto/tls.ConnectionState
     - __kind: GoInterfaceType
       ID: 36
       Name: net/http.ResponseWriter
@@ -2793,7 +2793,7 @@ Types:
           Offset: 8
           Type: 15 VoidPointerType unsafe.Pointer
     - __kind: StructureType
-      ID: 143
+      ID: 63
       Name: net/http.pattern
       ByteSize: 88
       GoRuntimeType: 1.875072e+06
@@ -2810,12 +2810,12 @@ Types:
           Type: 9 GoStringHeaderType string
         - Name: segments
           Offset: 48
-          Type: 144 GoSliceHeaderType []net/http.segment
+          Type: 115 GoSliceHeaderType []net/http.segment
         - Name: loc
           Offset: 72
           Type: 9 GoStringHeaderType string
     - __kind: StructureType
-      ID: 146
+      ID: 117
       Name: net/http.segment
       ByteSize: 24
       GoRuntimeType: 1.641952e+06
@@ -2831,14 +2831,14 @@ Types:
           Offset: 17
           Type: 4 BaseType bool
     - __kind: GoMapType
-      ID: 76
+      ID: 222
       Name: net/textproto.MIMEHeader
       ByteSize: 8
       GoRuntimeType: 1.863136e+06
       GoKind: 21
-      HeaderType: 45 GoSwissMapHeaderType map<string,[]string>
+      HeaderType: 47 GoSwissMapHeaderType map<string,[]string>
     - __kind: StructureType
-      ID: 40
+      ID: 44
       Name: net/url.URL
       ByteSize: 144
       GoRuntimeType: 2.180864e+06
@@ -2852,7 +2852,7 @@ Types:
           Type: 9 GoStringHeaderType string
         - Name: User
           Offset: 32
-          Type: 41 PointerType *net/url.Userinfo
+          Type: 96 PointerType *net/url.Userinfo
         - Name: Host
           Offset: 40
           Type: 9 GoStringHeaderType string
@@ -2878,7 +2878,7 @@ Types:
           Offset: 128
           Type: 9 GoStringHeaderType string
     - __kind: StructureType
-      ID: 42
+      ID: 97
       Name: net/url.Userinfo
       ByteSize: 40
       GoRuntimeType: 1.65808e+06
@@ -2894,68 +2894,68 @@ Types:
           Offset: 32
           Type: 4 BaseType bool
     - __kind: GoMapType
-      ID: 57
+      ID: 53
       Name: net/url.Values
       ByteSize: 8
       GoRuntimeType: 1.927712e+06
       GoKind: 21
-      HeaderType: 45 GoSwissMapHeaderType map<string,[]string>
+      HeaderType: 47 GoSwissMapHeaderType map<string,[]string>
     - __kind: ArrayType
-      ID: 203
+      ID: 213
       Name: noalg.[8]struct { key string; elem *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute }
       ByteSize: 192
       GoRuntimeType: 715104
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 204 StructureType noalg.struct { key string; elem *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute }
+      Element: 214 StructureType noalg.struct { key string; elem *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute }
     - __kind: ArrayType
-      ID: 70
+      ID: 198
       Name: noalg.[8]struct { key string; elem []*mime/multipart.FileHeader }
       ByteSize: 320
       GoRuntimeType: 710720
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 71 StructureType noalg.struct { key string; elem []*mime/multipart.FileHeader }
+      Element: 199 StructureType noalg.struct { key string; elem []*mime/multipart.FileHeader }
     - __kind: ArrayType
-      ID: 52
+      ID: 148
       Name: noalg.[8]struct { key string; elem []string }
       ByteSize: 320
       GoRuntimeType: 700896
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 53 StructureType noalg.struct { key string; elem []string }
+      Element: 149 StructureType noalg.struct { key string; elem []string }
     - __kind: ArrayType
-      ID: 186
+      ID: 193
       Name: noalg.[8]struct { key string; elem float64 }
       ByteSize: 192
       GoRuntimeType: 715008
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 187 StructureType noalg.struct { key string; elem float64 }
+      Element: 194 StructureType noalg.struct { key string; elem float64 }
     - __kind: ArrayType
-      ID: 175
+      ID: 191
       Name: noalg.[8]struct { key string; elem interface {} }
       ByteSize: 256
       GoRuntimeType: 692352
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 176 StructureType noalg.struct { key string; elem interface {} }
+      Element: 192 StructureType noalg.struct { key string; elem interface {} }
     - __kind: ArrayType
-      ID: 156
+      ID: 189
       Name: noalg.[8]struct { key string; elem string }
       ByteSize: 256
       GoRuntimeType: 705056
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 157 StructureType noalg.struct { key string; elem string }
+      Element: 190 StructureType noalg.struct { key string; elem string }
     - __kind: StructureType
-      ID: 202
+      ID: 197
       Name: noalg.map.group[string]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
       ByteSize: 200
       GoRuntimeType: 1.331296e+06
@@ -2966,9 +2966,9 @@ Types:
           Type: 8 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 203 ArrayType noalg.[8]struct { key string; elem *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute }
+          Type: 213 ArrayType noalg.[8]struct { key string; elem *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute }
     - __kind: StructureType
-      ID: 69
+      ID: 152
       Name: noalg.map.group[string][]*mime/multipart.FileHeader
       ByteSize: 328
       GoRuntimeType: 1.325024e+06
@@ -2979,9 +2979,9 @@ Types:
           Type: 8 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 70 ArrayType noalg.[8]struct { key string; elem []*mime/multipart.FileHeader }
+          Type: 198 ArrayType noalg.[8]struct { key string; elem []*mime/multipart.FileHeader }
     - __kind: StructureType
-      ID: 51
+      ID: 132
       Name: noalg.map.group[string][]string
       ByteSize: 328
       GoRuntimeType: 1.315936e+06
@@ -2992,9 +2992,9 @@ Types:
           Type: 8 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 52 ArrayType noalg.[8]struct { key string; elem []string }
+          Type: 148 ArrayType noalg.[8]struct { key string; elem []string }
     - __kind: StructureType
-      ID: 185
+      ID: 143
       Name: noalg.map.group[string]float64
       ByteSize: 200
       GoRuntimeType: 1.33104e+06
@@ -3005,9 +3005,9 @@ Types:
           Type: 8 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 186 ArrayType noalg.[8]struct { key string; elem float64 }
+          Type: 193 ArrayType noalg.[8]struct { key string; elem float64 }
     - __kind: StructureType
-      ID: 174
+      ID: 140
       Name: noalg.map.group[string]interface {}
       ByteSize: 264
       GoRuntimeType: 1.313376e+06
@@ -3018,9 +3018,9 @@ Types:
           Type: 8 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 175 ArrayType noalg.[8]struct { key string; elem interface {} }
+          Type: 191 ArrayType noalg.[8]struct { key string; elem interface {} }
     - __kind: StructureType
-      ID: 155
+      ID: 137
       Name: noalg.map.group[string]string
       ByteSize: 264
       GoRuntimeType: 1.318368e+06
@@ -3031,9 +3031,9 @@ Types:
           Type: 8 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 156 ArrayType noalg.[8]struct { key string; elem string }
+          Type: 189 ArrayType noalg.[8]struct { key string; elem string }
     - __kind: StructureType
-      ID: 204
+      ID: 214
       Name: noalg.struct { key string; elem *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute }
       ByteSize: 24
       GoRuntimeType: 1.331168e+06
@@ -3044,9 +3044,9 @@ Types:
           Type: 9 GoStringHeaderType string
         - Name: elem
           Offset: 16
-          Type: 205 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
+          Type: 215 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
     - __kind: StructureType
-      ID: 71
+      ID: 199
       Name: noalg.struct { key string; elem []*mime/multipart.FileHeader }
       ByteSize: 40
       GoRuntimeType: 1.324896e+06
@@ -3057,9 +3057,9 @@ Types:
           Type: 9 GoStringHeaderType string
         - Name: elem
           Offset: 16
-          Type: 72 GoSliceHeaderType []*mime/multipart.FileHeader
+          Type: 200 GoSliceHeaderType []*mime/multipart.FileHeader
     - __kind: StructureType
-      ID: 53
+      ID: 149
       Name: noalg.struct { key string; elem []string }
       ByteSize: 40
       GoRuntimeType: 1.315808e+06
@@ -3070,9 +3070,9 @@ Types:
           Type: 9 GoStringHeaderType string
         - Name: elem
           Offset: 16
-          Type: 54 GoSliceHeaderType []string
+          Type: 52 GoSliceHeaderType []string
     - __kind: StructureType
-      ID: 187
+      ID: 194
       Name: noalg.struct { key string; elem float64 }
       ByteSize: 24
       GoRuntimeType: 1.330912e+06
@@ -3085,7 +3085,7 @@ Types:
           Offset: 16
           Type: 16 BaseType float64
     - __kind: StructureType
-      ID: 176
+      ID: 192
       Name: noalg.struct { key string; elem interface {} }
       ByteSize: 32
       GoRuntimeType: 1.313248e+06
@@ -3096,9 +3096,9 @@ Types:
           Type: 9 GoStringHeaderType string
         - Name: elem
           Offset: 16
-          Type: 87 GoEmptyInterfaceType interface {}
+          Type: 155 GoEmptyInterfaceType interface {}
     - __kind: StructureType
-      ID: 157
+      ID: 190
       Name: noalg.struct { key string; elem string }
       ByteSize: 32
       GoRuntimeType: 1.31824e+06
@@ -3129,7 +3129,7 @@ Types:
       Name: string.str
       ByteSize: 2048
     - __kind: StructureType
-      ID: 161
+      ID: 70
       Name: sync.Mutex
       ByteSize: 8
       GoRuntimeType: 1.493632e+06
@@ -3137,12 +3137,12 @@ Types:
       RawFields:
         - Name: _
           Offset: 0
-          Type: 162 StructureType sync.noCopy
+          Type: 71 StructureType sync.noCopy
         - Name: mu
           Offset: 0
-          Type: 163 StructureType internal/sync.Mutex
+          Type: 72 StructureType internal/sync.Mutex
     - __kind: StructureType
-      ID: 160
+      ID: 69
       Name: sync.RWMutex
       ByteSize: 24
       GoRuntimeType: 1.880896e+06
@@ -3150,7 +3150,7 @@ Types:
       RawFields:
         - Name: w
           Offset: 0
-          Type: 161 StructureType sync.Mutex
+          Type: 70 StructureType sync.Mutex
         - Name: writerSem
           Offset: 8
           Type: 2 BaseType uint32
@@ -3159,18 +3159,18 @@ Types:
           Type: 2 BaseType uint32
         - Name: readerCount
           Offset: 16
-          Type: 164 StructureType sync/atomic.Int32
+          Type: 73 StructureType sync/atomic.Int32
         - Name: readerWait
           Offset: 20
-          Type: 164 StructureType sync/atomic.Int32
+          Type: 73 StructureType sync/atomic.Int32
     - __kind: StructureType
-      ID: 162
+      ID: 71
       Name: sync.noCopy
       GoRuntimeType: 1.006688e+06
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 164
+      ID: 73
       Name: sync/atomic.Int32
       ByteSize: 4
       GoRuntimeType: 1.494912e+06
@@ -3178,18 +3178,18 @@ Types:
       RawFields:
         - Name: _
           Offset: 0
-          Type: 165 StructureType sync/atomic.noCopy
+          Type: 74 StructureType sync/atomic.noCopy
         - Name: v
           Offset: 0
           Type: 12 BaseType int32
     - __kind: StructureType
-      ID: 165
+      ID: 74
       Name: sync/atomic.noCopy
       GoRuntimeType: 1.006784e+06
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 199
+      ID: 144
       Name: table<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
       ByteSize: 32
       GoKind: 25
@@ -3211,9 +3211,9 @@ Types:
           Type: 7 BaseType int
         - Name: groups
           Offset: 16
-          Type: 200 GoSwissMapGroupsType groupReference<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
+          Type: 195 GoSwissMapGroupsType groupReference<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
     - __kind: StructureType
-      ID: 66
+      ID: 133
       Name: table<string,[]*mime/multipart.FileHeader>
       ByteSize: 32
       GoKind: 25
@@ -3235,9 +3235,9 @@ Types:
           Type: 7 BaseType int
         - Name: groups
           Offset: 16
-          Type: 67 GoSwissMapGroupsType groupReference<string,[]*mime/multipart.FileHeader>
+          Type: 150 GoSwissMapGroupsType groupReference<string,[]*mime/multipart.FileHeader>
     - __kind: StructureType
-      ID: 48
+      ID: 98
       Name: table<string,[]string>
       ByteSize: 32
       GoKind: 25
@@ -3259,9 +3259,9 @@ Types:
           Type: 7 BaseType int
         - Name: groups
           Offset: 16
-          Type: 49 GoSwissMapGroupsType groupReference<string,[]string>
+          Type: 130 GoSwissMapGroupsType groupReference<string,[]string>
     - __kind: StructureType
-      ID: 182
+      ID: 120
       Name: table<string,float64>
       ByteSize: 32
       GoKind: 25
@@ -3283,9 +3283,9 @@ Types:
           Type: 7 BaseType int
         - Name: groups
           Offset: 16
-          Type: 183 GoSwissMapGroupsType groupReference<string,float64>
+          Type: 141 GoSwissMapGroupsType groupReference<string,float64>
     - __kind: StructureType
-      ID: 171
+      ID: 119
       Name: table<string,interface {}>
       ByteSize: 32
       GoKind: 25
@@ -3307,9 +3307,9 @@ Types:
           Type: 7 BaseType int
         - Name: groups
           Offset: 16
-          Type: 172 GoSwissMapGroupsType groupReference<string,interface {}>
+          Type: 138 GoSwissMapGroupsType groupReference<string,interface {}>
     - __kind: StructureType
-      ID: 152
+      ID: 118
       Name: table<string,string>
       ByteSize: 32
       GoKind: 25
@@ -3331,9 +3331,9 @@ Types:
           Type: 7 BaseType int
         - Name: groups
           Offset: 16
-          Type: 153 GoSwissMapGroupsType groupReference<string,string>
+          Type: 135 GoSwissMapGroupsType groupReference<string,string>
     - __kind: StructureType
-      ID: 100
+      ID: 164
       Name: time.Location
       ByteSize: 104
       GoRuntimeType: 2.013984e+06
@@ -3344,10 +3344,10 @@ Types:
           Type: 9 GoStringHeaderType string
         - Name: zone
           Offset: 16
-          Type: 101 GoSliceHeaderType []time.zone
+          Type: 206 GoSliceHeaderType []time.zone
         - Name: tx
           Offset: 40
-          Type: 104 GoSliceHeaderType []time.zoneTrans
+          Type: 209 GoSliceHeaderType []time.zoneTrans
         - Name: extend
           Offset: 64
           Type: 9 GoStringHeaderType string
@@ -3359,9 +3359,9 @@ Types:
           Type: 13 BaseType int64
         - Name: cacheZone
           Offset: 96
-          Type: 102 PointerType *time.zone
+          Type: 207 PointerType *time.zone
     - __kind: StructureType
-      ID: 98
+      ID: 162
       Name: time.Time
       ByteSize: 24
       GoRuntimeType: 2.428992e+06
@@ -3375,9 +3375,9 @@ Types:
           Type: 13 BaseType int64
         - Name: loc
           Offset: 16
-          Type: 99 PointerType *time.Location
+          Type: 163 PointerType *time.Location
     - __kind: StructureType
-      ID: 103
+      ID: 208
       Name: time.zone
       ByteSize: 32
       GoRuntimeType: 1.646944e+06
@@ -3393,7 +3393,7 @@ Types:
           Offset: 24
           Type: 4 BaseType bool
     - __kind: StructureType
-      ID: 106
+      ID: 211
       Name: time.zoneTrans
       ByteSize: 16
       GoRuntimeType: 1.788928e+06

--- a/pkg/dyninst/irgen/testdata/snapshot/rc_tester.arch=arm64,toolchain=go1.25.0.yaml
+++ b/pkg/dyninst/irgen/testdata/snapshot/rc_tester.arch=arm64,toolchain=go1.25.0.yaml
@@ -98,50 +98,50 @@ Subprograms:
           IsReturn: false
 Types:
     - __kind: PointerType
-      ID: 107
+      ID: 109
       Name: '**crypto/x509.Certificate'
       ByteSize: 8
       GoKind: 22
-      Pointee: 108 PointerType *crypto/x509.Certificate
+      Pointee: 110 PointerType *crypto/x509.Certificate
     - __kind: PointerType
-      ID: 146
+      ID: 173
       Name: '**github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span'
       ByteSize: 8
       GoKind: 22
       Pointee: 39 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span
     - __kind: PointerType
-      ID: 224
+      ID: 257
       Name: '**github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttributeValue'
       ByteSize: 8
       GoKind: 22
-      Pointee: 225 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttributeValue
+      Pointee: 258 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttributeValue
     - __kind: PointerType
-      ID: 201
+      ID: 181
       Name: '**mime/multipart.FileHeader'
       ByteSize: 8
       GoKind: 22
-      Pointee: 202 PointerType *mime/multipart.FileHeader
+      Pointee: 182 PointerType *mime/multipart.FileHeader
     - __kind: PointerType
-      ID: 181
+      ID: 229
       Name: '**net.IPNet'
       ByteSize: 8
       GoKind: 22
-      Pointee: 182 PointerType *net.IPNet
+      Pointee: 230 PointerType *net.IPNet
     - __kind: PointerType
-      ID: 179
+      ID: 227
       Name: '**net/url.URL'
       ByteSize: 8
       Pointee: 43 PointerType *net/url.URL
     - __kind: PointerType
-      ID: 124
+      ID: 126
       Name: '**table<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>'
       ByteSize: 8
-      Pointee: 125 PointerType *table<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
+      Pointee: 127 PointerType *table<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
     - __kind: PointerType
-      ID: 103
+      ID: 105
       Name: '**table<string,[]*mime/multipart.FileHeader>'
       ByteSize: 8
-      Pointee: 104 PointerType *table<string,[]*mime/multipart.FileHeader>
+      Pointee: 106 PointerType *table<string,[]*mime/multipart.FileHeader>
     - __kind: PointerType
       ID: 48
       Name: '**table<string,[]string>'
@@ -163,128 +163,128 @@ Types:
       ByteSize: 8
       Pointee: 68 PointerType *table<string,string>
     - __kind: PointerType
-      ID: 110
+      ID: 112
       Name: '*[]*crypto/x509.Certificate'
       ByteSize: 8
       GoKind: 22
-      Pointee: 106 GoSliceHeaderType []*crypto/x509.Certificate
+      Pointee: 108 GoSliceHeaderType []*crypto/x509.Certificate
     - __kind: PointerType
-      ID: 249
+      ID: 186
       Name: '*[]*crypto/x509.Certificate.array'
       ByteSize: 8
-      Pointee: 248 GoSliceDataType []*crypto/x509.Certificate.array
+      Pointee: 185 GoSliceDataType []*crypto/x509.Certificate.array
     - __kind: PointerType
-      ID: 259
+      ID: 242
       Name: '*[]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span.array'
       ByteSize: 8
-      Pointee: 258 GoSliceDataType []*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span.array
+      Pointee: 241 GoSliceDataType []*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span.array
     - __kind: PointerType
-      ID: 293
+      ID: 290
       Name: '*[]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttributeValue.array'
       ByteSize: 8
-      Pointee: 292 GoSliceDataType []*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttributeValue.array
+      Pointee: 289 GoSliceDataType []*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttributeValue.array
     - __kind: PointerType
-      ID: 283
+      ID: 244
       Name: '*[]*mime/multipart.FileHeader.array'
       ByteSize: 8
-      Pointee: 282 GoSliceDataType []*mime/multipart.FileHeader.array
+      Pointee: 243 GoSliceDataType []*mime/multipart.FileHeader.array
     - __kind: PointerType
-      ID: 277
+      ID: 276
       Name: '*[]*net.IPNet.array'
       ByteSize: 8
-      Pointee: 276 GoSliceDataType []*net.IPNet.array
+      Pointee: 275 GoSliceDataType []*net.IPNet.array
     - __kind: PointerType
-      ID: 275
+      ID: 274
       Name: '*[]*net/url.URL.array'
       ByteSize: 8
-      Pointee: 274 GoSliceDataType []*net/url.URL.array
+      Pointee: 273 GoSliceDataType []*net/url.URL.array
     - __kind: PointerType
-      ID: 251
+      ID: 188
       Name: '*[][]*crypto/x509.Certificate.array'
       ByteSize: 8
-      Pointee: 250 GoSliceDataType [][]*crypto/x509.Certificate.array
+      Pointee: 187 GoSliceDataType [][]*crypto/x509.Certificate.array
     - __kind: PointerType
-      ID: 253
+      ID: 190
       Name: '*[][]uint8.array'
       ByteSize: 8
-      Pointee: 252 GoSliceDataType [][]uint8.array
+      Pointee: 189 GoSliceDataType [][]uint8.array
     - __kind: PointerType
-      ID: 269
+      ID: 268
       Name: '*[]crypto/x509.ExtKeyUsage.array'
       ByteSize: 8
-      Pointee: 268 GoSliceDataType []crypto/x509.ExtKeyUsage.array
+      Pointee: 267 GoSliceDataType []crypto/x509.ExtKeyUsage.array
     - __kind: PointerType
-      ID: 279
+      ID: 278
       Name: '*[]crypto/x509.OID.array'
       ByteSize: 8
-      Pointee: 278 GoSliceDataType []crypto/x509.OID.array
+      Pointee: 277 GoSliceDataType []crypto/x509.OID.array
     - __kind: PointerType
-      ID: 281
+      ID: 280
       Name: '*[]crypto/x509.PolicyMapping.array'
       ByteSize: 8
-      Pointee: 280 GoSliceDataType []crypto/x509.PolicyMapping.array
+      Pointee: 279 GoSliceDataType []crypto/x509.PolicyMapping.array
     - __kind: PointerType
-      ID: 261
+      ID: 260
       Name: '*[]crypto/x509/pkix.AttributeTypeAndValue.array'
       ByteSize: 8
-      Pointee: 260 GoSliceDataType []crypto/x509/pkix.AttributeTypeAndValue.array
+      Pointee: 259 GoSliceDataType []crypto/x509/pkix.AttributeTypeAndValue.array
     - __kind: PointerType
-      ID: 263
+      ID: 262
       Name: '*[]crypto/x509/pkix.Extension.array'
       ByteSize: 8
-      Pointee: 262 GoSliceDataType []crypto/x509/pkix.Extension.array
+      Pointee: 261 GoSliceDataType []crypto/x509/pkix.Extension.array
     - __kind: PointerType
-      ID: 265
+      ID: 264
       Name: '*[]encoding/asn1.ObjectIdentifier.array'
       ByteSize: 8
-      Pointee: 264 GoSliceDataType []encoding/asn1.ObjectIdentifier.array
+      Pointee: 263 GoSliceDataType []encoding/asn1.ObjectIdentifier.array
     - __kind: PointerType
-      ID: 241
+      ID: 164
       Name: '*[]github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink.array'
       ByteSize: 8
-      Pointee: 240 GoSliceDataType []github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink.array
+      Pointee: 163 GoSliceDataType []github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink.array
     - __kind: PointerType
-      ID: 243
+      ID: 166
       Name: '*[]github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent.array'
       ByteSize: 8
-      Pointee: 242 GoSliceDataType []github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent.array
+      Pointee: 165 GoSliceDataType []github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent.array
     - __kind: PointerType
-      ID: 271
+      ID: 270
       Name: '*[]net.IP.array'
       ByteSize: 8
-      Pointee: 270 GoSliceDataType []net.IP.array
+      Pointee: 269 GoSliceDataType []net.IP.array
     - __kind: PointerType
-      ID: 255
+      ID: 192
       Name: '*[]net/http.segment.array'
       ByteSize: 8
-      Pointee: 254 GoSliceDataType []net/http.segment.array
+      Pointee: 191 GoSliceDataType []net/http.segment.array
     - __kind: PointerType
-      ID: 233
+      ID: 140
       Name: '*[]string.array'
       ByteSize: 8
-      Pointee: 232 GoSliceDataType []string.array
+      Pointee: 139 GoSliceDataType []string.array
     - __kind: PointerType
-      ID: 287
+      ID: 286
       Name: '*[]time.zone.array'
       ByteSize: 8
-      Pointee: 286 GoSliceDataType []time.zone.array
+      Pointee: 285 GoSliceDataType []time.zone.array
     - __kind: PointerType
-      ID: 289
+      ID: 288
       Name: '*[]time.zoneTrans.array'
       ByteSize: 8
-      Pointee: 288 GoSliceDataType []time.zoneTrans.array
+      Pointee: 287 GoSliceDataType []time.zoneTrans.array
     - __kind: PointerType
-      ID: 112
+      ID: 114
       Name: '*[]uint8'
       ByteSize: 8
       GoRuntimeType: 486400
       GoKind: 22
       Pointee: 94 GoSliceHeaderType []uint8
     - __kind: PointerType
-      ID: 245
+      ID: 168
       Name: '*[]uint8.array'
       ByteSize: 8
-      Pointee: 244 GoSliceDataType []uint8.array
+      Pointee: 167 GoSliceDataType []uint8.array
     - __kind: PointerType
       ID: 11
       Name: '*bool'
@@ -307,59 +307,59 @@ Types:
       GoKind: 22
       Pointee: 57 StructureType crypto/tls.ConnectionState
     - __kind: PointerType
-      ID: 108
+      ID: 110
       Name: '*crypto/x509.Certificate'
       ByteSize: 8
       GoRuntimeType: 2.088896e+06
       GoKind: 22
-      Pointee: 134 StructureType crypto/x509.Certificate
+      Pointee: 170 StructureType crypto/x509.Certificate
     - __kind: PointerType
-      ID: 173
+      ID: 221
       Name: '*crypto/x509.ExtKeyUsage'
       ByteSize: 8
       GoRuntimeType: 429824
       GoKind: 22
-      Pointee: 174 BaseType crypto/x509.ExtKeyUsage
+      Pointee: 222 BaseType crypto/x509.ExtKeyUsage
     - __kind: PointerType
-      ID: 184
+      ID: 232
       Name: '*crypto/x509.OID'
       ByteSize: 8
       GoRuntimeType: 1.997344e+06
       GoKind: 22
-      Pointee: 185 StructureType crypto/x509.OID
+      Pointee: 233 StructureType crypto/x509.OID
     - __kind: PointerType
-      ID: 187
+      ID: 235
       Name: '*crypto/x509.PolicyMapping'
       ByteSize: 8
       GoRuntimeType: 429888
       GoKind: 22
-      Pointee: 188 StructureType crypto/x509.PolicyMapping
+      Pointee: 236 StructureType crypto/x509.PolicyMapping
     - __kind: PointerType
-      ID: 160
+      ID: 208
       Name: '*crypto/x509/pkix.AttributeTypeAndValue'
       ByteSize: 8
       GoRuntimeType: 446528
       GoKind: 22
-      Pointee: 161 StructureType crypto/x509/pkix.AttributeTypeAndValue
+      Pointee: 209 StructureType crypto/x509/pkix.AttributeTypeAndValue
     - __kind: PointerType
-      ID: 167
+      ID: 215
       Name: '*crypto/x509/pkix.Extension'
       ByteSize: 8
       GoRuntimeType: 446720
       GoKind: 22
-      Pointee: 168 StructureType crypto/x509/pkix.Extension
+      Pointee: 216 StructureType crypto/x509/pkix.Extension
     - __kind: PointerType
-      ID: 170
+      ID: 218
       Name: '*encoding/asn1.ObjectIdentifier'
       ByteSize: 8
       GoRuntimeType: 1.079072e+06
       GoKind: 22
-      Pointee: 171 GoSliceHeaderType encoding/asn1.ObjectIdentifier
+      Pointee: 219 GoSliceHeaderType encoding/asn1.ObjectIdentifier
     - __kind: PointerType
-      ID: 267
+      ID: 266
       Name: '*encoding/asn1.ObjectIdentifier.array'
       ByteSize: 8
-      Pointee: 266 GoSliceDataType encoding/asn1.ObjectIdentifier.array
+      Pointee: 265 GoSliceDataType encoding/asn1.ObjectIdentifier.array
     - __kind: PointerType
       ID: 33
       Name: '*error'
@@ -410,33 +410,33 @@ Types:
       GoKind: 22
       Pointee: 90 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent
     - __kind: PointerType
-      ID: 220
+      ID: 239
       Name: '*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttribute'
       ByteSize: 8
       GoRuntimeType: 1.214624e+06
       GoKind: 22
-      Pointee: 221 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttribute
+      Pointee: 240 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttribute
     - __kind: PointerType
-      ID: 225
+      ID: 258
       Name: '*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttributeValue'
       ByteSize: 8
       GoRuntimeType: 1.214368e+06
       GoKind: 22
-      Pointee: 226 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttributeValue
+      Pointee: 282 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttributeValue
     - __kind: PointerType
-      ID: 215
+      ID: 198
       Name: '*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute'
       ByteSize: 8
       GoRuntimeType: 1.214752e+06
       GoKind: 22
-      Pointee: 216 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
+      Pointee: 199 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
     - __kind: PointerType
-      ID: 127
+      ID: 129
       Name: '*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.trace'
       ByteSize: 8
       GoRuntimeType: 2.2768e+06
       GoKind: 22
-      Pointee: 128 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.trace
+      Pointee: 130 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.trace
     - __kind: PointerType
       ID: 27
       Name: '*int'
@@ -473,15 +473,15 @@ Types:
       GoKind: 22
       Pointee: 17 BaseType int8
     - __kind: PointerType
-      ID: 122
+      ID: 124
       Name: '*map<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>'
       ByteSize: 8
-      Pointee: 123 GoSwissMapHeaderType map<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
+      Pointee: 125 GoSwissMapHeaderType map<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
     - __kind: PointerType
-      ID: 101
+      ID: 103
       Name: '*map<string,[]*mime/multipart.FileHeader>'
       ByteSize: 8
-      Pointee: 102 GoSwissMapHeaderType map<string,[]*mime/multipart.FileHeader>
+      Pointee: 104 GoSwissMapHeaderType map<string,[]*mime/multipart.FileHeader>
     - __kind: PointerType
       ID: 46
       Name: '*map<string,[]string>'
@@ -503,31 +503,31 @@ Types:
       ByteSize: 8
       Pointee: 66 GoSwissMapHeaderType map<string,string>
     - __kind: PointerType
-      ID: 156
+      ID: 204
       Name: '*math/big.Int'
       ByteSize: 8
       GoRuntimeType: 2.446656e+06
       GoKind: 22
-      Pointee: 157 StructureType math/big.Int
+      Pointee: 205 StructureType math/big.Int
     - __kind: PointerType
-      ID: 204
+      ID: 246
       Name: '*math/big.Word'
       ByteSize: 8
       GoRuntimeType: 432640
       GoKind: 22
-      Pointee: 205 BaseType math/big.Word
+      Pointee: 247 BaseType math/big.Word
     - __kind: PointerType
-      ID: 285
+      ID: 284
       Name: '*math/big.nat.array'
       ByteSize: 8
-      Pointee: 284 GoSliceDataType math/big.nat.array
+      Pointee: 283 GoSliceDataType math/big.nat.array
     - __kind: PointerType
-      ID: 202
+      ID: 182
       Name: '*mime/multipart.FileHeader'
       ByteSize: 8
       GoRuntimeType: 924960
       GoKind: 22
-      Pointee: 217 StructureType mime/multipart.FileHeader
+      Pointee: 237 StructureType mime/multipart.FileHeader
     - __kind: PointerType
       ID: 54
       Name: '*mime/multipart.Form'
@@ -536,29 +536,29 @@ Types:
       GoKind: 22
       Pointee: 55 StructureType mime/multipart.Form
     - __kind: PointerType
-      ID: 176
+      ID: 224
       Name: '*net.IP'
       ByteSize: 8
       GoRuntimeType: 2.206144e+06
       GoKind: 22
-      Pointee: 177 GoSliceHeaderType net.IP
+      Pointee: 225 GoSliceHeaderType net.IP
     - __kind: PointerType
-      ID: 273
+      ID: 272
       Name: '*net.IP.array'
       ByteSize: 8
-      Pointee: 272 GoSliceDataType net.IP.array
+      Pointee: 271 GoSliceDataType net.IP.array
     - __kind: PointerType
-      ID: 291
+      ID: 293
       Name: '*net.IPMask.array'
       ByteSize: 8
-      Pointee: 290 GoSliceDataType net.IPMask.array
+      Pointee: 292 GoSliceDataType net.IPMask.array
     - __kind: PointerType
-      ID: 182
+      ID: 230
       Name: '*net.IPNet'
       ByteSize: 8
       GoRuntimeType: 1.207712e+06
       GoKind: 22
-      Pointee: 212 StructureType net.IPNet
+      Pointee: 254 StructureType net.IPNet
     - __kind: PointerType
       ID: 37
       Name: '*net/http.Request'
@@ -581,12 +581,12 @@ Types:
       GoKind: 22
       Pointee: 63 StructureType net/http.pattern
     - __kind: PointerType
-      ID: 116
+      ID: 118
       Name: '*net/http.segment'
       ByteSize: 8
       GoRuntimeType: 396288
       GoKind: 22
-      Pointee: 117 StructureType net/http.segment
+      Pointee: 119 StructureType net/http.segment
     - __kind: PointerType
       ID: 43
       Name: '*net/url.URL'
@@ -595,42 +595,42 @@ Types:
       GoKind: 22
       Pointee: 44 StructureType net/url.URL
     - __kind: PointerType
-      ID: 96
+      ID: 98
       Name: '*net/url.Userinfo'
       ByteSize: 8
       GoRuntimeType: 1.225376e+06
       GoKind: 22
-      Pointee: 97 StructureType net/url.Userinfo
+      Pointee: 99 StructureType net/url.Userinfo
     - __kind: PointerType
-      ID: 196
+      ID: 194
       Name: '*noalg.map.group[string]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute'
       ByteSize: 8
-      Pointee: 197 StructureType noalg.map.group[string]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
+      Pointee: 195 StructureType noalg.map.group[string]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
     - __kind: PointerType
-      ID: 151
+      ID: 176
       Name: '*noalg.map.group[string][]*mime/multipart.FileHeader'
       ByteSize: 8
-      Pointee: 152 StructureType noalg.map.group[string][]*mime/multipart.FileHeader
+      Pointee: 177 StructureType noalg.map.group[string][]*mime/multipart.FileHeader
     - __kind: PointerType
-      ID: 131
+      ID: 133
       Name: '*noalg.map.group[string][]string'
       ByteSize: 8
-      Pointee: 132 StructureType noalg.map.group[string][]string
+      Pointee: 134 StructureType noalg.map.group[string][]string
     - __kind: PointerType
-      ID: 142
+      ID: 157
       Name: '*noalg.map.group[string]float64'
       ByteSize: 8
-      Pointee: 143 StructureType noalg.map.group[string]float64
+      Pointee: 158 StructureType noalg.map.group[string]float64
     - __kind: PointerType
-      ID: 139
+      ID: 149
       Name: '*noalg.map.group[string]interface {}'
       ByteSize: 8
-      Pointee: 140 StructureType noalg.map.group[string]interface {}
+      Pointee: 150 StructureType noalg.map.group[string]interface {}
     - __kind: PointerType
-      ID: 136
+      ID: 142
       Name: '*noalg.map.group[string]string'
       ByteSize: 8
-      Pointee: 137 StructureType noalg.map.group[string]string
+      Pointee: 143 StructureType noalg.map.group[string]string
     - __kind: PointerType
       ID: 22
       Name: '*string'
@@ -639,61 +639,61 @@ Types:
       GoKind: 22
       Pointee: 9 GoStringHeaderType string
     - __kind: PointerType
-      ID: 229
+      ID: 97
       Name: '*string.str'
       ByteSize: 8
-      Pointee: 228 GoStringDataType string.str
+      Pointee: 96 GoStringDataType string.str
     - __kind: PointerType
-      ID: 125
+      ID: 127
       Name: '*table<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>'
       ByteSize: 8
-      Pointee: 144 StructureType table<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
+      Pointee: 171 StructureType table<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
     - __kind: PointerType
-      ID: 104
+      ID: 106
       Name: '*table<string,[]*mime/multipart.FileHeader>'
       ByteSize: 8
-      Pointee: 133 StructureType table<string,[]*mime/multipart.FileHeader>
+      Pointee: 169 StructureType table<string,[]*mime/multipart.FileHeader>
     - __kind: PointerType
       ID: 49
       Name: '*table<string,[]string>'
       ByteSize: 8
-      Pointee: 98 StructureType table<string,[]string>
+      Pointee: 100 StructureType table<string,[]string>
     - __kind: PointerType
       ID: 84
       Name: '*table<string,float64>'
       ByteSize: 8
-      Pointee: 120 StructureType table<string,float64>
+      Pointee: 122 StructureType table<string,float64>
     - __kind: PointerType
       ID: 79
       Name: '*table<string,interface {}>'
       ByteSize: 8
-      Pointee: 119 StructureType table<string,interface {}>
+      Pointee: 121 StructureType table<string,interface {}>
     - __kind: PointerType
       ID: 68
       Name: '*table<string,string>'
       ByteSize: 8
-      Pointee: 118 StructureType table<string,string>
+      Pointee: 120 StructureType table<string,string>
     - __kind: PointerType
-      ID: 163
+      ID: 211
       Name: '*time.Location'
       ByteSize: 8
       GoRuntimeType: 1.647136e+06
       GoKind: 22
-      Pointee: 164 StructureType time.Location
+      Pointee: 212 StructureType time.Location
     - __kind: PointerType
-      ID: 207
+      ID: 249
       Name: '*time.zone'
       ByteSize: 8
       GoRuntimeType: 399360
       GoKind: 22
-      Pointee: 208 StructureType time.zone
+      Pointee: 250 StructureType time.zone
     - __kind: PointerType
-      ID: 210
+      ID: 252
       Name: '*time.zoneTrans'
       ByteSize: 8
       GoRuntimeType: 399424
       GoKind: 22
-      Pointee: 211 StructureType time.zoneTrans
+      Pointee: 253 StructureType time.zoneTrans
     - __kind: PointerType
       ID: 34
       Name: '*uint'
@@ -781,7 +781,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: GoSliceHeaderType
-      ID: 106
+      ID: 108
       Name: '[]*crypto/x509.Certificate'
       ByteSize: 24
       GoRuntimeType: 507264
@@ -789,21 +789,21 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 107 PointerType **crypto/x509.Certificate
+          Type: 109 PointerType **crypto/x509.Certificate
         - Name: len
           Offset: 8
           Type: 7 BaseType int
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 248 GoSliceDataType []*crypto/x509.Certificate.array
+      Data: 185 GoSliceDataType []*crypto/x509.Certificate.array
     - __kind: GoSliceDataType
-      ID: 248
+      ID: 185
       Name: '[]*crypto/x509.Certificate.array'
       ByteSize: 2048
-      Element: 108 PointerType *crypto/x509.Certificate
+      Element: 110 PointerType *crypto/x509.Certificate
     - __kind: GoSliceHeaderType
-      ID: 145
+      ID: 172
       Name: '[]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span'
       ByteSize: 24
       GoRuntimeType: 495072
@@ -811,21 +811,21 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 146 PointerType **github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span
+          Type: 173 PointerType **github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span
         - Name: len
           Offset: 8
           Type: 7 BaseType int
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 258 GoSliceDataType []*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span.array
+      Data: 241 GoSliceDataType []*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span.array
     - __kind: GoSliceDataType
-      ID: 258
+      ID: 241
       Name: '[]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span.array'
       ByteSize: 2048
       Element: 39 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span
     - __kind: GoSliceHeaderType
-      ID: 223
+      ID: 256
       Name: '[]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttributeValue'
       ByteSize: 24
       GoRuntimeType: 494688
@@ -833,21 +833,21 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 224 PointerType **github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttributeValue
+          Type: 257 PointerType **github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttributeValue
         - Name: len
           Offset: 8
           Type: 7 BaseType int
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 292 GoSliceDataType []*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttributeValue.array
+      Data: 289 GoSliceDataType []*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttributeValue.array
     - __kind: GoSliceDataType
-      ID: 292
+      ID: 289
       Name: '[]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttributeValue.array'
       ByteSize: 2048
-      Element: 225 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttributeValue
+      Element: 258 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttributeValue
     - __kind: GoSliceHeaderType
-      ID: 200
+      ID: 180
       Name: '[]*mime/multipart.FileHeader'
       ByteSize: 24
       GoRuntimeType: 492064
@@ -855,21 +855,21 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 201 PointerType **mime/multipart.FileHeader
+          Type: 181 PointerType **mime/multipart.FileHeader
         - Name: len
           Offset: 8
           Type: 7 BaseType int
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 282 GoSliceDataType []*mime/multipart.FileHeader.array
+      Data: 243 GoSliceDataType []*mime/multipart.FileHeader.array
     - __kind: GoSliceDataType
-      ID: 282
+      ID: 243
       Name: '[]*mime/multipart.FileHeader.array'
       ByteSize: 2048
-      Element: 202 PointerType *mime/multipart.FileHeader
+      Element: 182 PointerType *mime/multipart.FileHeader
     - __kind: GoSliceHeaderType
-      ID: 180
+      ID: 228
       Name: '[]*net.IPNet'
       ByteSize: 24
       GoRuntimeType: 508864
@@ -877,21 +877,21 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 181 PointerType **net.IPNet
+          Type: 229 PointerType **net.IPNet
         - Name: len
           Offset: 8
           Type: 7 BaseType int
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 276 GoSliceDataType []*net.IPNet.array
+      Data: 275 GoSliceDataType []*net.IPNet.array
     - __kind: GoSliceDataType
-      ID: 276
+      ID: 275
       Name: '[]*net.IPNet.array'
       ByteSize: 2048
-      Element: 182 PointerType *net.IPNet
+      Element: 230 PointerType *net.IPNet
     - __kind: GoSliceHeaderType
-      ID: 178
+      ID: 226
       Name: '[]*net/url.URL'
       ByteSize: 24
       GoRuntimeType: 508800
@@ -899,51 +899,51 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 179 PointerType **net/url.URL
+          Type: 227 PointerType **net/url.URL
         - Name: len
           Offset: 8
           Type: 7 BaseType int
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 274 GoSliceDataType []*net/url.URL.array
+      Data: 273 GoSliceDataType []*net/url.URL.array
     - __kind: GoSliceDataType
-      ID: 274
+      ID: 273
       Name: '[]*net/url.URL.array'
       ByteSize: 2048
       Element: 43 PointerType *net/url.URL
     - __kind: GoSliceDataType
-      ID: 256
+      ID: 200
       Name: '[]*table<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>.array'
       ByteSize: 8192
-      Element: 125 PointerType *table<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
+      Element: 127 PointerType *table<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
     - __kind: GoSliceDataType
-      ID: 246
+      ID: 183
       Name: '[]*table<string,[]*mime/multipart.FileHeader>.array'
       ByteSize: 8192
-      Element: 104 PointerType *table<string,[]*mime/multipart.FileHeader>
+      Element: 106 PointerType *table<string,[]*mime/multipart.FileHeader>
     - __kind: GoSliceDataType
-      ID: 230
+      ID: 137
       Name: '[]*table<string,[]string>.array'
       ByteSize: 8192
       Element: 49 PointerType *table<string,[]string>
     - __kind: GoSliceDataType
-      ID: 238
+      ID: 161
       Name: '[]*table<string,float64>.array'
       ByteSize: 8192
       Element: 84 PointerType *table<string,float64>
     - __kind: GoSliceDataType
-      ID: 236
+      ID: 154
       Name: '[]*table<string,interface {}>.array'
       ByteSize: 8192
       Element: 79 PointerType *table<string,interface {}>
     - __kind: GoSliceDataType
-      ID: 234
+      ID: 146
       Name: '[]*table<string,string>.array'
       ByteSize: 8192
       Element: 68 PointerType *table<string,string>
     - __kind: GoSliceHeaderType
-      ID: 109
+      ID: 111
       Name: '[][]*crypto/x509.Certificate'
       ByteSize: 24
       GoRuntimeType: 507328
@@ -951,21 +951,21 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 110 PointerType *[]*crypto/x509.Certificate
+          Type: 112 PointerType *[]*crypto/x509.Certificate
         - Name: len
           Offset: 8
           Type: 7 BaseType int
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 250 GoSliceDataType [][]*crypto/x509.Certificate.array
+      Data: 187 GoSliceDataType [][]*crypto/x509.Certificate.array
     - __kind: GoSliceDataType
-      ID: 250
+      ID: 187
       Name: '[][]*crypto/x509.Certificate.array'
       ByteSize: 2048
-      Element: 106 GoSliceHeaderType []*crypto/x509.Certificate
+      Element: 108 GoSliceHeaderType []*crypto/x509.Certificate
     - __kind: GoSliceHeaderType
-      ID: 111
+      ID: 113
       Name: '[][]uint8'
       ByteSize: 24
       GoRuntimeType: 486720
@@ -973,21 +973,21 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 112 PointerType *[]uint8
+          Type: 114 PointerType *[]uint8
         - Name: len
           Offset: 8
           Type: 7 BaseType int
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 252 GoSliceDataType [][]uint8.array
+      Data: 189 GoSliceDataType [][]uint8.array
     - __kind: GoSliceDataType
-      ID: 252
+      ID: 189
       Name: '[][]uint8.array'
       ByteSize: 2048
       Element: 94 GoSliceHeaderType []uint8
     - __kind: GoSliceHeaderType
-      ID: 172
+      ID: 220
       Name: '[]crypto/x509.ExtKeyUsage'
       ByteSize: 24
       GoRuntimeType: 508736
@@ -995,21 +995,21 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 173 PointerType *crypto/x509.ExtKeyUsage
+          Type: 221 PointerType *crypto/x509.ExtKeyUsage
         - Name: len
           Offset: 8
           Type: 7 BaseType int
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 268 GoSliceDataType []crypto/x509.ExtKeyUsage.array
+      Data: 267 GoSliceDataType []crypto/x509.ExtKeyUsage.array
     - __kind: GoSliceDataType
-      ID: 268
+      ID: 267
       Name: '[]crypto/x509.ExtKeyUsage.array'
       ByteSize: 2048
-      Element: 174 BaseType crypto/x509.ExtKeyUsage
+      Element: 222 BaseType crypto/x509.ExtKeyUsage
     - __kind: GoSliceHeaderType
-      ID: 183
+      ID: 231
       Name: '[]crypto/x509.OID'
       ByteSize: 24
       GoRuntimeType: 508928
@@ -1017,21 +1017,21 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 184 PointerType *crypto/x509.OID
+          Type: 232 PointerType *crypto/x509.OID
         - Name: len
           Offset: 8
           Type: 7 BaseType int
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 278 GoSliceDataType []crypto/x509.OID.array
+      Data: 277 GoSliceDataType []crypto/x509.OID.array
     - __kind: GoSliceDataType
-      ID: 278
+      ID: 277
       Name: '[]crypto/x509.OID.array'
       ByteSize: 2048
-      Element: 185 StructureType crypto/x509.OID
+      Element: 233 StructureType crypto/x509.OID
     - __kind: GoSliceHeaderType
-      ID: 186
+      ID: 234
       Name: '[]crypto/x509.PolicyMapping'
       ByteSize: 24
       GoRuntimeType: 508992
@@ -1039,21 +1039,21 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 187 PointerType *crypto/x509.PolicyMapping
+          Type: 235 PointerType *crypto/x509.PolicyMapping
         - Name: len
           Offset: 8
           Type: 7 BaseType int
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 280 GoSliceDataType []crypto/x509.PolicyMapping.array
+      Data: 279 GoSliceDataType []crypto/x509.PolicyMapping.array
     - __kind: GoSliceDataType
-      ID: 280
+      ID: 279
       Name: '[]crypto/x509.PolicyMapping.array'
       ByteSize: 2048
-      Element: 188 StructureType crypto/x509.PolicyMapping
+      Element: 236 StructureType crypto/x509.PolicyMapping
     - __kind: GoSliceHeaderType
-      ID: 159
+      ID: 207
       Name: '[]crypto/x509/pkix.AttributeTypeAndValue'
       ByteSize: 24
       GoRuntimeType: 523520
@@ -1061,21 +1061,21 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 160 PointerType *crypto/x509/pkix.AttributeTypeAndValue
+          Type: 208 PointerType *crypto/x509/pkix.AttributeTypeAndValue
         - Name: len
           Offset: 8
           Type: 7 BaseType int
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 260 GoSliceDataType []crypto/x509/pkix.AttributeTypeAndValue.array
+      Data: 259 GoSliceDataType []crypto/x509/pkix.AttributeTypeAndValue.array
     - __kind: GoSliceDataType
-      ID: 260
+      ID: 259
       Name: '[]crypto/x509/pkix.AttributeTypeAndValue.array'
       ByteSize: 2048
-      Element: 161 StructureType crypto/x509/pkix.AttributeTypeAndValue
+      Element: 209 StructureType crypto/x509/pkix.AttributeTypeAndValue
     - __kind: GoSliceHeaderType
-      ID: 166
+      ID: 214
       Name: '[]crypto/x509/pkix.Extension'
       ByteSize: 24
       GoRuntimeType: 508608
@@ -1083,21 +1083,21 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 167 PointerType *crypto/x509/pkix.Extension
+          Type: 215 PointerType *crypto/x509/pkix.Extension
         - Name: len
           Offset: 8
           Type: 7 BaseType int
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 262 GoSliceDataType []crypto/x509/pkix.Extension.array
+      Data: 261 GoSliceDataType []crypto/x509/pkix.Extension.array
     - __kind: GoSliceDataType
-      ID: 262
+      ID: 261
       Name: '[]crypto/x509/pkix.Extension.array'
       ByteSize: 2048
-      Element: 168 StructureType crypto/x509/pkix.Extension
+      Element: 216 StructureType crypto/x509/pkix.Extension
     - __kind: GoSliceHeaderType
-      ID: 169
+      ID: 217
       Name: '[]encoding/asn1.ObjectIdentifier'
       ByteSize: 24
       GoRuntimeType: 508672
@@ -1105,19 +1105,19 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 170 PointerType *encoding/asn1.ObjectIdentifier
+          Type: 218 PointerType *encoding/asn1.ObjectIdentifier
         - Name: len
           Offset: 8
           Type: 7 BaseType int
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 264 GoSliceDataType []encoding/asn1.ObjectIdentifier.array
+      Data: 263 GoSliceDataType []encoding/asn1.ObjectIdentifier.array
     - __kind: GoSliceDataType
-      ID: 264
+      ID: 263
       Name: '[]encoding/asn1.ObjectIdentifier.array'
       ByteSize: 2048
-      Element: 171 GoSliceHeaderType encoding/asn1.ObjectIdentifier
+      Element: 219 GoSliceHeaderType encoding/asn1.ObjectIdentifier
     - __kind: GoSliceHeaderType
       ID: 85
       Name: '[]github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink'
@@ -1134,9 +1134,9 @@ Types:
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 240 GoSliceDataType []github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink.array
+      Data: 163 GoSliceDataType []github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink.array
     - __kind: GoSliceDataType
-      ID: 240
+      ID: 163
       Name: '[]github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink.array'
       ByteSize: 2048
       Element: 87 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink
@@ -1156,14 +1156,14 @@ Types:
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 242 GoSliceDataType []github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent.array
+      Data: 165 GoSliceDataType []github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent.array
     - __kind: GoSliceDataType
-      ID: 242
+      ID: 165
       Name: '[]github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent.array'
       ByteSize: 2048
       Element: 90 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent
     - __kind: GoSliceHeaderType
-      ID: 175
+      ID: 223
       Name: '[]net.IP'
       ByteSize: 24
       GoRuntimeType: 487744
@@ -1171,21 +1171,21 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 176 PointerType *net.IP
+          Type: 224 PointerType *net.IP
         - Name: len
           Offset: 8
           Type: 7 BaseType int
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 270 GoSliceDataType []net.IP.array
+      Data: 269 GoSliceDataType []net.IP.array
     - __kind: GoSliceDataType
-      ID: 270
+      ID: 269
       Name: '[]net.IP.array'
       ByteSize: 2048
-      Element: 177 GoSliceHeaderType net.IP
+      Element: 225 GoSliceHeaderType net.IP
     - __kind: GoSliceHeaderType
-      ID: 115
+      ID: 117
       Name: '[]net/http.segment'
       ByteSize: 24
       GoRuntimeType: 489440
@@ -1193,49 +1193,49 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 116 PointerType *net/http.segment
+          Type: 118 PointerType *net/http.segment
         - Name: len
           Offset: 8
           Type: 7 BaseType int
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 254 GoSliceDataType []net/http.segment.array
+      Data: 191 GoSliceDataType []net/http.segment.array
     - __kind: GoSliceDataType
-      ID: 254
+      ID: 191
       Name: '[]net/http.segment.array'
       ByteSize: 2048
-      Element: 117 StructureType net/http.segment
+      Element: 119 StructureType net/http.segment
     - __kind: GoSliceDataType
-      ID: 257
+      ID: 201
       Name: '[]noalg.map.group[string]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute.array'
       ByteSize: 2048
-      Element: 197 StructureType noalg.map.group[string]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
+      Element: 195 StructureType noalg.map.group[string]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
     - __kind: GoSliceDataType
-      ID: 247
+      ID: 184
       Name: '[]noalg.map.group[string][]*mime/multipart.FileHeader.array'
       ByteSize: 2048
-      Element: 152 StructureType noalg.map.group[string][]*mime/multipart.FileHeader
+      Element: 177 StructureType noalg.map.group[string][]*mime/multipart.FileHeader
     - __kind: GoSliceDataType
-      ID: 231
+      ID: 138
       Name: '[]noalg.map.group[string][]string.array'
       ByteSize: 2048
-      Element: 132 StructureType noalg.map.group[string][]string
+      Element: 134 StructureType noalg.map.group[string][]string
     - __kind: GoSliceDataType
-      ID: 239
+      ID: 162
       Name: '[]noalg.map.group[string]float64.array'
       ByteSize: 2048
-      Element: 143 StructureType noalg.map.group[string]float64
+      Element: 158 StructureType noalg.map.group[string]float64
     - __kind: GoSliceDataType
-      ID: 237
+      ID: 155
       Name: '[]noalg.map.group[string]interface {}.array'
       ByteSize: 2048
-      Element: 140 StructureType noalg.map.group[string]interface {}
+      Element: 150 StructureType noalg.map.group[string]interface {}
     - __kind: GoSliceDataType
-      ID: 235
+      ID: 147
       Name: '[]noalg.map.group[string]string.array'
       ByteSize: 2048
-      Element: 137 StructureType noalg.map.group[string]string
+      Element: 143 StructureType noalg.map.group[string]string
     - __kind: GoSliceHeaderType
       ID: 52
       Name: '[]string'
@@ -1252,14 +1252,14 @@ Types:
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 232 GoSliceDataType []string.array
+      Data: 139 GoSliceDataType []string.array
     - __kind: GoSliceDataType
-      ID: 232
+      ID: 139
       Name: '[]string.array'
       ByteSize: 2048
       Element: 9 GoStringHeaderType string
     - __kind: GoSliceHeaderType
-      ID: 206
+      ID: 248
       Name: '[]time.zone'
       ByteSize: 24
       GoRuntimeType: 494176
@@ -1267,21 +1267,21 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 207 PointerType *time.zone
+          Type: 249 PointerType *time.zone
         - Name: len
           Offset: 8
           Type: 7 BaseType int
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 286 GoSliceDataType []time.zone.array
+      Data: 285 GoSliceDataType []time.zone.array
     - __kind: GoSliceDataType
-      ID: 286
+      ID: 285
       Name: '[]time.zone.array'
       ByteSize: 2048
-      Element: 208 StructureType time.zone
+      Element: 250 StructureType time.zone
     - __kind: GoSliceHeaderType
-      ID: 209
+      ID: 251
       Name: '[]time.zoneTrans'
       ByteSize: 24
       GoRuntimeType: 494240
@@ -1289,19 +1289,19 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 210 PointerType *time.zoneTrans
+          Type: 252 PointerType *time.zoneTrans
         - Name: len
           Offset: 8
           Type: 7 BaseType int
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 288 GoSliceDataType []time.zoneTrans.array
+      Data: 287 GoSliceDataType []time.zoneTrans.array
     - __kind: GoSliceDataType
-      ID: 288
+      ID: 287
       Name: '[]time.zoneTrans.array'
       ByteSize: 2048
-      Element: 211 StructureType time.zoneTrans
+      Element: 253 StructureType time.zoneTrans
     - __kind: GoSliceHeaderType
       ID: 94
       Name: '[]uint8'
@@ -1318,9 +1318,9 @@ Types:
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 244 GoSliceDataType []uint8.array
+      Data: 167 GoSliceDataType []uint8.array
     - __kind: GoSliceDataType
-      ID: 244
+      ID: 167
       Name: '[]uint8.array'
       ByteSize: 2048
       Element: 3 BaseType uint8
@@ -1398,7 +1398,7 @@ Types:
           Type: 6 BaseType uint16
         - Name: CurveID
           Offset: 6
-          Type: 105 BaseType crypto/tls.CurveID
+          Type: 107 BaseType crypto/tls.CurveID
         - Name: NegotiatedProtocol
           Offset: 8
           Type: 9 GoStringHeaderType string
@@ -1410,13 +1410,13 @@ Types:
           Type: 9 GoStringHeaderType string
         - Name: PeerCertificates
           Offset: 48
-          Type: 106 GoSliceHeaderType []*crypto/x509.Certificate
+          Type: 108 GoSliceHeaderType []*crypto/x509.Certificate
         - Name: VerifiedChains
           Offset: 72
-          Type: 109 GoSliceHeaderType [][]*crypto/x509.Certificate
+          Type: 111 GoSliceHeaderType [][]*crypto/x509.Certificate
         - Name: SignedCertificateTimestamps
           Offset: 96
-          Type: 111 GoSliceHeaderType [][]uint8
+          Type: 113 GoSliceHeaderType [][]uint8
         - Name: OCSPResponse
           Offset: 120
           Type: 94 GoSliceHeaderType []uint8
@@ -1428,27 +1428,27 @@ Types:
           Type: 4 BaseType bool
         - Name: ekm
           Offset: 176
-          Type: 113 GoSubroutineType func(string, []uint8, int) ([]uint8, error)
+          Type: 115 GoSubroutineType func(string, []uint8, int) ([]uint8, error)
         - Name: testingOnlyDidHRR
           Offset: 184
           Type: 4 BaseType bool
         - Name: testingOnlyPeerSignatureAlgorithm
           Offset: 186
-          Type: 114 BaseType crypto/tls.SignatureScheme
+          Type: 116 BaseType crypto/tls.SignatureScheme
     - __kind: BaseType
-      ID: 105
+      ID: 107
       Name: crypto/tls.CurveID
       ByteSize: 2
       GoRuntimeType: 846592
       GoKind: 9
     - __kind: BaseType
-      ID: 114
+      ID: 116
       Name: crypto/tls.SignatureScheme
       ByteSize: 2
       GoRuntimeType: 846688
       GoKind: 9
     - __kind: StructureType
-      ID: 134
+      ID: 170
       Name: crypto/x509.Certificate
       ByteSize: 1424
       GoRuntimeType: 2.45792e+06
@@ -1474,49 +1474,49 @@ Types:
           Type: 94 GoSliceHeaderType []uint8
         - Name: SignatureAlgorithm
           Offset: 144
-          Type: 153 BaseType crypto/x509.SignatureAlgorithm
+          Type: 202 BaseType crypto/x509.SignatureAlgorithm
         - Name: PublicKeyAlgorithm
           Offset: 152
-          Type: 154 BaseType crypto/x509.PublicKeyAlgorithm
+          Type: 203 BaseType crypto/x509.PublicKeyAlgorithm
         - Name: PublicKey
           Offset: 160
-          Type: 155 GoEmptyInterfaceType interface {}
+          Type: 153 GoEmptyInterfaceType interface {}
         - Name: Version
           Offset: 176
           Type: 7 BaseType int
         - Name: SerialNumber
           Offset: 184
-          Type: 156 PointerType *math/big.Int
+          Type: 204 PointerType *math/big.Int
         - Name: Issuer
           Offset: 192
-          Type: 158 StructureType crypto/x509/pkix.Name
+          Type: 206 StructureType crypto/x509/pkix.Name
         - Name: Subject
           Offset: 440
-          Type: 158 StructureType crypto/x509/pkix.Name
+          Type: 206 StructureType crypto/x509/pkix.Name
         - Name: NotBefore
           Offset: 688
-          Type: 162 StructureType time.Time
+          Type: 210 StructureType time.Time
         - Name: NotAfter
           Offset: 712
-          Type: 162 StructureType time.Time
+          Type: 210 StructureType time.Time
         - Name: KeyUsage
           Offset: 736
-          Type: 165 BaseType crypto/x509.KeyUsage
+          Type: 213 BaseType crypto/x509.KeyUsage
         - Name: Extensions
           Offset: 744
-          Type: 166 GoSliceHeaderType []crypto/x509/pkix.Extension
+          Type: 214 GoSliceHeaderType []crypto/x509/pkix.Extension
         - Name: ExtraExtensions
           Offset: 768
-          Type: 166 GoSliceHeaderType []crypto/x509/pkix.Extension
+          Type: 214 GoSliceHeaderType []crypto/x509/pkix.Extension
         - Name: UnhandledCriticalExtensions
           Offset: 792
-          Type: 169 GoSliceHeaderType []encoding/asn1.ObjectIdentifier
+          Type: 217 GoSliceHeaderType []encoding/asn1.ObjectIdentifier
         - Name: ExtKeyUsage
           Offset: 816
-          Type: 172 GoSliceHeaderType []crypto/x509.ExtKeyUsage
+          Type: 220 GoSliceHeaderType []crypto/x509.ExtKeyUsage
         - Name: UnknownExtKeyUsage
           Offset: 840
-          Type: 169 GoSliceHeaderType []encoding/asn1.ObjectIdentifier
+          Type: 217 GoSliceHeaderType []encoding/asn1.ObjectIdentifier
         - Name: BasicConstraintsValid
           Offset: 864
           Type: 4 BaseType bool
@@ -1549,10 +1549,10 @@ Types:
           Type: 52 GoSliceHeaderType []string
         - Name: IPAddresses
           Offset: 1032
-          Type: 175 GoSliceHeaderType []net.IP
+          Type: 223 GoSliceHeaderType []net.IP
         - Name: URIs
           Offset: 1056
-          Type: 178 GoSliceHeaderType []*net/url.URL
+          Type: 226 GoSliceHeaderType []*net/url.URL
         - Name: PermittedDNSDomainsCritical
           Offset: 1080
           Type: 4 BaseType bool
@@ -1564,10 +1564,10 @@ Types:
           Type: 52 GoSliceHeaderType []string
         - Name: PermittedIPRanges
           Offset: 1136
-          Type: 180 GoSliceHeaderType []*net.IPNet
+          Type: 228 GoSliceHeaderType []*net.IPNet
         - Name: ExcludedIPRanges
           Offset: 1160
-          Type: 180 GoSliceHeaderType []*net.IPNet
+          Type: 228 GoSliceHeaderType []*net.IPNet
         - Name: PermittedEmailAddresses
           Offset: 1184
           Type: 52 GoSliceHeaderType []string
@@ -1585,10 +1585,10 @@ Types:
           Type: 52 GoSliceHeaderType []string
         - Name: PolicyIdentifiers
           Offset: 1304
-          Type: 169 GoSliceHeaderType []encoding/asn1.ObjectIdentifier
+          Type: 217 GoSliceHeaderType []encoding/asn1.ObjectIdentifier
         - Name: Policies
           Offset: 1328
-          Type: 183 GoSliceHeaderType []crypto/x509.OID
+          Type: 231 GoSliceHeaderType []crypto/x509.OID
         - Name: InhibitAnyPolicy
           Offset: 1352
           Type: 7 BaseType int
@@ -1609,21 +1609,21 @@ Types:
           Type: 4 BaseType bool
         - Name: PolicyMappings
           Offset: 1400
-          Type: 186 GoSliceHeaderType []crypto/x509.PolicyMapping
+          Type: 234 GoSliceHeaderType []crypto/x509.PolicyMapping
     - __kind: BaseType
-      ID: 174
+      ID: 222
       Name: crypto/x509.ExtKeyUsage
       ByteSize: 8
       GoRuntimeType: 598080
       GoKind: 2
     - __kind: BaseType
-      ID: 165
+      ID: 213
       Name: crypto/x509.KeyUsage
       ByteSize: 8
       GoRuntimeType: 598016
       GoKind: 2
     - __kind: StructureType
-      ID: 185
+      ID: 233
       Name: crypto/x509.OID
       ByteSize: 24
       GoRuntimeType: 1.9976e+06
@@ -1633,7 +1633,7 @@ Types:
           Offset: 0
           Type: 94 GoSliceHeaderType []uint8
     - __kind: StructureType
-      ID: 188
+      ID: 236
       Name: crypto/x509.PolicyMapping
       ByteSize: 48
       GoRuntimeType: 1.519712e+06
@@ -1641,24 +1641,24 @@ Types:
       RawFields:
         - Name: IssuerDomainPolicy
           Offset: 0
-          Type: 185 StructureType crypto/x509.OID
+          Type: 233 StructureType crypto/x509.OID
         - Name: SubjectDomainPolicy
           Offset: 24
-          Type: 185 StructureType crypto/x509.OID
+          Type: 233 StructureType crypto/x509.OID
     - __kind: BaseType
-      ID: 154
+      ID: 203
       Name: crypto/x509.PublicKeyAlgorithm
       ByteSize: 8
       GoRuntimeType: 849088
       GoKind: 2
     - __kind: BaseType
-      ID: 153
+      ID: 202
       Name: crypto/x509.SignatureAlgorithm
       ByteSize: 8
       GoRuntimeType: 1.138944e+06
       GoKind: 2
     - __kind: StructureType
-      ID: 161
+      ID: 209
       Name: crypto/x509/pkix.AttributeTypeAndValue
       ByteSize: 40
       GoRuntimeType: 1.532192e+06
@@ -1666,12 +1666,12 @@ Types:
       RawFields:
         - Name: Type
           Offset: 0
-          Type: 171 GoSliceHeaderType encoding/asn1.ObjectIdentifier
+          Type: 219 GoSliceHeaderType encoding/asn1.ObjectIdentifier
         - Name: Value
           Offset: 24
-          Type: 155 GoEmptyInterfaceType interface {}
+          Type: 153 GoEmptyInterfaceType interface {}
     - __kind: StructureType
-      ID: 168
+      ID: 216
       Name: crypto/x509/pkix.Extension
       ByteSize: 56
       GoRuntimeType: 1.683232e+06
@@ -1679,7 +1679,7 @@ Types:
       RawFields:
         - Name: Id
           Offset: 0
-          Type: 171 GoSliceHeaderType encoding/asn1.ObjectIdentifier
+          Type: 219 GoSliceHeaderType encoding/asn1.ObjectIdentifier
         - Name: Critical
           Offset: 24
           Type: 4 BaseType bool
@@ -1687,7 +1687,7 @@ Types:
           Offset: 32
           Type: 94 GoSliceHeaderType []uint8
     - __kind: StructureType
-      ID: 158
+      ID: 206
       Name: crypto/x509/pkix.Name
       ByteSize: 248
       GoRuntimeType: 2.249504e+06
@@ -1722,12 +1722,12 @@ Types:
           Type: 9 GoStringHeaderType string
         - Name: Names
           Offset: 200
-          Type: 159 GoSliceHeaderType []crypto/x509/pkix.AttributeTypeAndValue
+          Type: 207 GoSliceHeaderType []crypto/x509/pkix.AttributeTypeAndValue
         - Name: ExtraNames
           Offset: 224
-          Type: 159 GoSliceHeaderType []crypto/x509/pkix.AttributeTypeAndValue
+          Type: 207 GoSliceHeaderType []crypto/x509/pkix.AttributeTypeAndValue
     - __kind: GoSliceHeaderType
-      ID: 171
+      ID: 219
       Name: encoding/asn1.ObjectIdentifier
       ByteSize: 24
       GoRuntimeType: 1.0792e+06
@@ -1742,9 +1742,9 @@ Types:
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 266 GoSliceDataType encoding/asn1.ObjectIdentifier.array
+      Data: 265 GoSliceDataType encoding/asn1.ObjectIdentifier.array
     - __kind: GoSliceDataType
-      ID: 266
+      ID: 265
       Name: encoding/asn1.ObjectIdentifier.array
       ByteSize: 2048
       Element: 7 BaseType int
@@ -1786,7 +1786,7 @@ Types:
       GoRuntimeType: 704864
       GoKind: 19
     - __kind: GoSubroutineType
-      ID: 113
+      ID: 115
       Name: func(string, []uint8, int) ([]uint8, error)
       ByteSize: 8
       GoRuntimeType: 1.024448e+06
@@ -1885,7 +1885,7 @@ Types:
           Type: 4 BaseType bool
         - Name: trace
           Offset: 8
-          Type: 127 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.trace
+          Type: 129 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.trace
         - Name: span
           Offset: 16
           Type: 39 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span
@@ -1900,7 +1900,7 @@ Types:
           Type: 4 BaseType bool
         - Name: traceID
           Offset: 49
-          Type: 129 ArrayType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.traceID
+          Type: 131 ArrayType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.traceID
         - Name: spanID
           Offset: 72
           Type: 8 BaseType uint64
@@ -1955,7 +1955,7 @@ Types:
       GoKind: 21
       HeaderType: 77 GoSwissMapHeaderType map<string,interface {}>
     - __kind: BaseType
-      ID: 147
+      ID: 174
       Name: github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.samplingDecision
       ByteSize: 4
       GoRuntimeType: 593792
@@ -1975,12 +1975,12 @@ Types:
           Type: 8 BaseType uint64
         - Name: Attributes
           Offset: 24
-          Type: 121 GoMapType map[string]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
+          Type: 123 GoMapType map[string]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
         - Name: RawAttributes
           Offset: 32
-          Type: 126 GoMapType map[string]interface {}
+          Type: 128 GoMapType map[string]interface {}
     - __kind: StructureType
-      ID: 221
+      ID: 240
       Name: github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttribute
       ByteSize: 24
       GoRuntimeType: 1.214496e+06
@@ -1988,9 +1988,9 @@ Types:
       RawFields:
         - Name: Values
           Offset: 0
-          Type: 223 GoSliceHeaderType []*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttributeValue
+          Type: 256 GoSliceHeaderType []*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttributeValue
     - __kind: StructureType
-      ID: 226
+      ID: 282
       Name: github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttributeValue
       ByteSize: 48
       GoRuntimeType: 1.878208e+06
@@ -1998,7 +1998,7 @@ Types:
       RawFields:
         - Name: Type
           Offset: 0
-          Type: 227 BaseType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttributeValueType
+          Type: 291 BaseType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttributeValueType
         - Name: StringValue
           Offset: 8
           Type: 9 GoStringHeaderType string
@@ -2012,13 +2012,13 @@ Types:
           Offset: 40
           Type: 16 BaseType float64
     - __kind: BaseType
-      ID: 227
+      ID: 291
       Name: github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttributeValueType
       ByteSize: 4
       GoRuntimeType: 1.006112e+06
       GoKind: 5
     - __kind: StructureType
-      ID: 216
+      ID: 199
       Name: github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
       ByteSize: 56
       GoRuntimeType: 1.955104e+06
@@ -2026,7 +2026,7 @@ Types:
       RawFields:
         - Name: Type
           Offset: 0
-          Type: 219 BaseType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttributeType
+          Type: 238 BaseType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttributeType
         - Name: StringValue
           Offset: 8
           Type: 9 GoStringHeaderType string
@@ -2041,15 +2041,15 @@ Types:
           Type: 16 BaseType float64
         - Name: ArrayValue
           Offset: 48
-          Type: 220 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttribute
+          Type: 239 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttribute
     - __kind: BaseType
-      ID: 219
+      ID: 238
       Name: github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttributeType
       ByteSize: 4
       GoRuntimeType: 1.006016e+06
       GoKind: 5
     - __kind: StructureType
-      ID: 128
+      ID: 130
       Name: github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.trace
       ByteSize: 104
       GoRuntimeType: 2.154976e+06
@@ -2060,7 +2060,7 @@ Types:
           Type: 69 StructureType sync.RWMutex
         - Name: spans
           Offset: 24
-          Type: 145 GoSliceHeaderType []*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span
+          Type: 172 GoSliceHeaderType []*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span
         - Name: tags
           Offset: 48
           Type: 64 GoMapType map[string]string
@@ -2081,12 +2081,12 @@ Types:
           Type: 4 BaseType bool
         - Name: samplingDecision
           Offset: 92
-          Type: 147 BaseType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.samplingDecision
+          Type: 174 BaseType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.samplingDecision
         - Name: root
           Offset: 96
           Type: 39 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span
     - __kind: ArrayType
-      ID: 129
+      ID: 131
       Name: github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.traceID
       ByteSize: 16
       GoRuntimeType: 918624
@@ -2095,89 +2095,89 @@ Types:
       HasCount: true
       Element: 3 BaseType uint8
     - __kind: GoSwissMapGroupsType
-      ID: 195
+      ID: 193
       Name: groupReference<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 196 PointerType *noalg.map.group[string]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
+          Type: 194 PointerType *noalg.map.group[string]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
         - Name: lengthMask
           Offset: 8
           Type: 8 BaseType uint64
-      GroupType: 197 StructureType noalg.map.group[string]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
-      GroupSliceType: 257 GoSliceDataType []noalg.map.group[string]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute.array
+      GroupType: 195 StructureType noalg.map.group[string]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
+      GroupSliceType: 201 GoSliceDataType []noalg.map.group[string]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute.array
     - __kind: GoSwissMapGroupsType
-      ID: 150
+      ID: 175
       Name: groupReference<string,[]*mime/multipart.FileHeader>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 151 PointerType *noalg.map.group[string][]*mime/multipart.FileHeader
+          Type: 176 PointerType *noalg.map.group[string][]*mime/multipart.FileHeader
         - Name: lengthMask
           Offset: 8
           Type: 8 BaseType uint64
-      GroupType: 152 StructureType noalg.map.group[string][]*mime/multipart.FileHeader
-      GroupSliceType: 247 GoSliceDataType []noalg.map.group[string][]*mime/multipart.FileHeader.array
+      GroupType: 177 StructureType noalg.map.group[string][]*mime/multipart.FileHeader
+      GroupSliceType: 184 GoSliceDataType []noalg.map.group[string][]*mime/multipart.FileHeader.array
     - __kind: GoSwissMapGroupsType
-      ID: 130
+      ID: 132
       Name: groupReference<string,[]string>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 131 PointerType *noalg.map.group[string][]string
+          Type: 133 PointerType *noalg.map.group[string][]string
         - Name: lengthMask
           Offset: 8
           Type: 8 BaseType uint64
-      GroupType: 132 StructureType noalg.map.group[string][]string
-      GroupSliceType: 231 GoSliceDataType []noalg.map.group[string][]string.array
+      GroupType: 134 StructureType noalg.map.group[string][]string
+      GroupSliceType: 138 GoSliceDataType []noalg.map.group[string][]string.array
     - __kind: GoSwissMapGroupsType
-      ID: 141
+      ID: 156
       Name: groupReference<string,float64>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 142 PointerType *noalg.map.group[string]float64
+          Type: 157 PointerType *noalg.map.group[string]float64
         - Name: lengthMask
           Offset: 8
           Type: 8 BaseType uint64
-      GroupType: 143 StructureType noalg.map.group[string]float64
-      GroupSliceType: 239 GoSliceDataType []noalg.map.group[string]float64.array
+      GroupType: 158 StructureType noalg.map.group[string]float64
+      GroupSliceType: 162 GoSliceDataType []noalg.map.group[string]float64.array
     - __kind: GoSwissMapGroupsType
-      ID: 138
+      ID: 148
       Name: groupReference<string,interface {}>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 139 PointerType *noalg.map.group[string]interface {}
+          Type: 149 PointerType *noalg.map.group[string]interface {}
         - Name: lengthMask
           Offset: 8
           Type: 8 BaseType uint64
-      GroupType: 140 StructureType noalg.map.group[string]interface {}
-      GroupSliceType: 237 GoSliceDataType []noalg.map.group[string]interface {}.array
+      GroupType: 150 StructureType noalg.map.group[string]interface {}
+      GroupSliceType: 155 GoSliceDataType []noalg.map.group[string]interface {}.array
     - __kind: GoSwissMapGroupsType
-      ID: 135
+      ID: 141
       Name: groupReference<string,string>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 136 PointerType *noalg.map.group[string]string
+          Type: 142 PointerType *noalg.map.group[string]string
         - Name: lengthMask
           Offset: 8
           Type: 8 BaseType uint64
-      GroupType: 137 StructureType noalg.map.group[string]string
-      GroupSliceType: 235 GoSliceDataType []noalg.map.group[string]string.array
+      GroupType: 143 StructureType noalg.map.group[string]string
+      GroupSliceType: 147 GoSliceDataType []noalg.map.group[string]string.array
     - __kind: BaseType
       ID: 7
       Name: int
@@ -2209,7 +2209,7 @@ Types:
       GoRuntimeType: 594048
       GoKind: 3
     - __kind: GoEmptyInterfaceType
-      ID: 155
+      ID: 153
       Name: interface {}
       ByteSize: 16
       GoRuntimeType: 866496
@@ -2248,7 +2248,7 @@ Types:
           Offset: 8
           Type: 15 VoidPointerType unsafe.Pointer
     - __kind: GoSwissMapHeaderType
-      ID: 123
+      ID: 125
       Name: map<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
       ByteSize: 48
       GoKind: 25
@@ -2261,7 +2261,7 @@ Types:
           Type: 1 BaseType uintptr
         - Name: dirPtr
           Offset: 16
-          Type: 124 PointerType **table<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
+          Type: 126 PointerType **table<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
         - Name: dirLen
           Offset: 24
           Type: 7 BaseType int
@@ -2280,10 +2280,10 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 8 BaseType uint64
-      TablePtrSliceType: 256 GoSliceDataType []*table<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>.array
-      GroupType: 197 StructureType noalg.map.group[string]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
+      TablePtrSliceType: 200 GoSliceDataType []*table<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>.array
+      GroupType: 195 StructureType noalg.map.group[string]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
     - __kind: GoSwissMapHeaderType
-      ID: 102
+      ID: 104
       Name: map<string,[]*mime/multipart.FileHeader>
       ByteSize: 48
       GoKind: 25
@@ -2296,7 +2296,7 @@ Types:
           Type: 1 BaseType uintptr
         - Name: dirPtr
           Offset: 16
-          Type: 103 PointerType **table<string,[]*mime/multipart.FileHeader>
+          Type: 105 PointerType **table<string,[]*mime/multipart.FileHeader>
         - Name: dirLen
           Offset: 24
           Type: 7 BaseType int
@@ -2315,8 +2315,8 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 8 BaseType uint64
-      TablePtrSliceType: 246 GoSliceDataType []*table<string,[]*mime/multipart.FileHeader>.array
-      GroupType: 152 StructureType noalg.map.group[string][]*mime/multipart.FileHeader
+      TablePtrSliceType: 183 GoSliceDataType []*table<string,[]*mime/multipart.FileHeader>.array
+      GroupType: 177 StructureType noalg.map.group[string][]*mime/multipart.FileHeader
     - __kind: GoSwissMapHeaderType
       ID: 47
       Name: map<string,[]string>
@@ -2350,8 +2350,8 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 8 BaseType uint64
-      TablePtrSliceType: 230 GoSliceDataType []*table<string,[]string>.array
-      GroupType: 132 StructureType noalg.map.group[string][]string
+      TablePtrSliceType: 137 GoSliceDataType []*table<string,[]string>.array
+      GroupType: 134 StructureType noalg.map.group[string][]string
     - __kind: GoSwissMapHeaderType
       ID: 82
       Name: map<string,float64>
@@ -2385,8 +2385,8 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 8 BaseType uint64
-      TablePtrSliceType: 238 GoSliceDataType []*table<string,float64>.array
-      GroupType: 143 StructureType noalg.map.group[string]float64
+      TablePtrSliceType: 161 GoSliceDataType []*table<string,float64>.array
+      GroupType: 158 StructureType noalg.map.group[string]float64
     - __kind: GoSwissMapHeaderType
       ID: 77
       Name: map<string,interface {}>
@@ -2420,8 +2420,8 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 8 BaseType uint64
-      TablePtrSliceType: 236 GoSliceDataType []*table<string,interface {}>.array
-      GroupType: 140 StructureType noalg.map.group[string]interface {}
+      TablePtrSliceType: 154 GoSliceDataType []*table<string,interface {}>.array
+      GroupType: 150 StructureType noalg.map.group[string]interface {}
     - __kind: GoSwissMapHeaderType
       ID: 66
       Name: map<string,string>
@@ -2455,24 +2455,24 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 8 BaseType uint64
-      TablePtrSliceType: 234 GoSliceDataType []*table<string,string>.array
-      GroupType: 137 StructureType noalg.map.group[string]string
+      TablePtrSliceType: 146 GoSliceDataType []*table<string,string>.array
+      GroupType: 143 StructureType noalg.map.group[string]string
     - __kind: GoMapType
-      ID: 121
+      ID: 123
       Name: map[string]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
       ByteSize: 8
       GoRuntimeType: 1.157632e+06
       GoKind: 21
-      HeaderType: 123 GoSwissMapHeaderType map<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
+      HeaderType: 125 GoSwissMapHeaderType map<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
     - __kind: GoMapType
-      ID: 100
+      ID: 102
       Name: map[string][]*mime/multipart.FileHeader
       ByteSize: 8
       GoRuntimeType: 1.156864e+06
       GoKind: 21
-      HeaderType: 102 GoSwissMapHeaderType map<string,[]*mime/multipart.FileHeader>
+      HeaderType: 104 GoSwissMapHeaderType map<string,[]*mime/multipart.FileHeader>
     - __kind: GoMapType
-      ID: 99
+      ID: 101
       Name: map[string][]string
       ByteSize: 8
       GoRuntimeType: 1.152512e+06
@@ -2486,7 +2486,7 @@ Types:
       GoKind: 21
       HeaderType: 82 GoSwissMapHeaderType map<string,float64>
     - __kind: GoMapType
-      ID: 126
+      ID: 128
       Name: map[string]interface {}
       ByteSize: 8
       GoRuntimeType: 1.151104e+06
@@ -2500,7 +2500,7 @@ Types:
       GoKind: 21
       HeaderType: 66 GoSwissMapHeaderType map<string,string>
     - __kind: StructureType
-      ID: 157
+      ID: 205
       Name: math/big.Int
       ByteSize: 32
       GoRuntimeType: 1.522752e+06
@@ -2511,15 +2511,15 @@ Types:
           Type: 4 BaseType bool
         - Name: abs
           Offset: 8
-          Type: 203 GoSliceHeaderType math/big.nat
+          Type: 245 GoSliceHeaderType math/big.nat
     - __kind: BaseType
-      ID: 205
+      ID: 247
       Name: math/big.Word
       ByteSize: 8
       GoRuntimeType: 598272
       GoKind: 7
     - __kind: GoSliceHeaderType
-      ID: 203
+      ID: 245
       Name: math/big.nat
       ByteSize: 24
       GoRuntimeType: 2.426144e+06
@@ -2527,21 +2527,21 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 204 PointerType *math/big.Word
+          Type: 246 PointerType *math/big.Word
         - Name: len
           Offset: 8
           Type: 7 BaseType int
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 284 GoSliceDataType math/big.nat.array
+      Data: 283 GoSliceDataType math/big.nat.array
     - __kind: GoSliceDataType
-      ID: 284
+      ID: 283
       Name: math/big.nat.array
       ByteSize: 2048
-      Element: 205 BaseType math/big.Word
+      Element: 247 BaseType math/big.Word
     - __kind: StructureType
-      ID: 217
+      ID: 237
       Name: mime/multipart.FileHeader
       ByteSize: 88
       GoRuntimeType: 2.018016e+06
@@ -2552,7 +2552,7 @@ Types:
           Type: 9 GoStringHeaderType string
         - Name: Header
           Offset: 16
-          Type: 222 GoMapType net/textproto.MIMEHeader
+          Type: 255 GoMapType net/textproto.MIMEHeader
         - Name: Size
           Offset: 24
           Type: 13 BaseType int64
@@ -2577,12 +2577,12 @@ Types:
       RawFields:
         - Name: Value
           Offset: 0
-          Type: 99 GoMapType map[string][]string
+          Type: 101 GoMapType map[string][]string
         - Name: File
           Offset: 8
-          Type: 100 GoMapType map[string][]*mime/multipart.FileHeader
+          Type: 102 GoMapType map[string][]*mime/multipart.FileHeader
     - __kind: GoSliceHeaderType
-      ID: 177
+      ID: 225
       Name: net.IP
       ByteSize: 24
       GoRuntimeType: 2.178176e+06
@@ -2597,14 +2597,14 @@ Types:
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 272 GoSliceDataType net.IP.array
+      Data: 271 GoSliceDataType net.IP.array
     - __kind: GoSliceDataType
-      ID: 272
+      ID: 271
       Name: net.IP.array
       ByteSize: 2048
       Element: 3 BaseType uint8
     - __kind: GoSliceHeaderType
-      ID: 218
+      ID: 281
       Name: net.IPMask
       ByteSize: 24
       GoRuntimeType: 1.041568e+06
@@ -2619,14 +2619,14 @@ Types:
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 290 GoSliceDataType net.IPMask.array
+      Data: 292 GoSliceDataType net.IPMask.array
     - __kind: GoSliceDataType
-      ID: 290
+      ID: 292
       Name: net.IPMask.array
       ByteSize: 2048
       Element: 3 BaseType uint8
     - __kind: StructureType
-      ID: 212
+      ID: 254
       Name: net.IPNet
       ByteSize: 48
       GoRuntimeType: 1.486272e+06
@@ -2634,10 +2634,10 @@ Types:
       RawFields:
         - Name: IP
           Offset: 0
-          Type: 177 GoSliceHeaderType net.IP
+          Type: 225 GoSliceHeaderType net.IP
         - Name: Mask
           Offset: 24
-          Type: 218 GoSliceHeaderType net.IPMask
+          Type: 281 GoSliceHeaderType net.IPMask
     - __kind: GoMapType
       ID: 45
       Name: net/http.Header
@@ -2810,12 +2810,12 @@ Types:
           Type: 9 GoStringHeaderType string
         - Name: segments
           Offset: 48
-          Type: 115 GoSliceHeaderType []net/http.segment
+          Type: 117 GoSliceHeaderType []net/http.segment
         - Name: loc
           Offset: 72
           Type: 9 GoStringHeaderType string
     - __kind: StructureType
-      ID: 117
+      ID: 119
       Name: net/http.segment
       ByteSize: 24
       GoRuntimeType: 1.641952e+06
@@ -2831,7 +2831,7 @@ Types:
           Offset: 17
           Type: 4 BaseType bool
     - __kind: GoMapType
-      ID: 222
+      ID: 255
       Name: net/textproto.MIMEHeader
       ByteSize: 8
       GoRuntimeType: 1.863136e+06
@@ -2852,7 +2852,7 @@ Types:
           Type: 9 GoStringHeaderType string
         - Name: User
           Offset: 32
-          Type: 96 PointerType *net/url.Userinfo
+          Type: 98 PointerType *net/url.Userinfo
         - Name: Host
           Offset: 40
           Type: 9 GoStringHeaderType string
@@ -2878,7 +2878,7 @@ Types:
           Offset: 128
           Type: 9 GoStringHeaderType string
     - __kind: StructureType
-      ID: 97
+      ID: 99
       Name: net/url.Userinfo
       ByteSize: 40
       GoRuntimeType: 1.65808e+06
@@ -2901,61 +2901,61 @@ Types:
       GoKind: 21
       HeaderType: 47 GoSwissMapHeaderType map<string,[]string>
     - __kind: ArrayType
-      ID: 213
+      ID: 196
       Name: noalg.[8]struct { key string; elem *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute }
       ByteSize: 192
       GoRuntimeType: 715104
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 214 StructureType noalg.struct { key string; elem *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute }
+      Element: 197 StructureType noalg.struct { key string; elem *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute }
     - __kind: ArrayType
-      ID: 198
+      ID: 178
       Name: noalg.[8]struct { key string; elem []*mime/multipart.FileHeader }
       ByteSize: 320
       GoRuntimeType: 710720
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 199 StructureType noalg.struct { key string; elem []*mime/multipart.FileHeader }
+      Element: 179 StructureType noalg.struct { key string; elem []*mime/multipart.FileHeader }
     - __kind: ArrayType
-      ID: 148
+      ID: 135
       Name: noalg.[8]struct { key string; elem []string }
       ByteSize: 320
       GoRuntimeType: 700896
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 149 StructureType noalg.struct { key string; elem []string }
+      Element: 136 StructureType noalg.struct { key string; elem []string }
     - __kind: ArrayType
-      ID: 193
+      ID: 159
       Name: noalg.[8]struct { key string; elem float64 }
       ByteSize: 192
       GoRuntimeType: 715008
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 194 StructureType noalg.struct { key string; elem float64 }
+      Element: 160 StructureType noalg.struct { key string; elem float64 }
     - __kind: ArrayType
-      ID: 191
+      ID: 151
       Name: noalg.[8]struct { key string; elem interface {} }
       ByteSize: 256
       GoRuntimeType: 692352
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 192 StructureType noalg.struct { key string; elem interface {} }
+      Element: 152 StructureType noalg.struct { key string; elem interface {} }
     - __kind: ArrayType
-      ID: 189
+      ID: 144
       Name: noalg.[8]struct { key string; elem string }
       ByteSize: 256
       GoRuntimeType: 705056
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 190 StructureType noalg.struct { key string; elem string }
+      Element: 145 StructureType noalg.struct { key string; elem string }
     - __kind: StructureType
-      ID: 197
+      ID: 195
       Name: noalg.map.group[string]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
       ByteSize: 200
       GoRuntimeType: 1.331296e+06
@@ -2966,9 +2966,9 @@ Types:
           Type: 8 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 213 ArrayType noalg.[8]struct { key string; elem *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute }
+          Type: 196 ArrayType noalg.[8]struct { key string; elem *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute }
     - __kind: StructureType
-      ID: 152
+      ID: 177
       Name: noalg.map.group[string][]*mime/multipart.FileHeader
       ByteSize: 328
       GoRuntimeType: 1.325024e+06
@@ -2979,9 +2979,9 @@ Types:
           Type: 8 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 198 ArrayType noalg.[8]struct { key string; elem []*mime/multipart.FileHeader }
+          Type: 178 ArrayType noalg.[8]struct { key string; elem []*mime/multipart.FileHeader }
     - __kind: StructureType
-      ID: 132
+      ID: 134
       Name: noalg.map.group[string][]string
       ByteSize: 328
       GoRuntimeType: 1.315936e+06
@@ -2992,9 +2992,9 @@ Types:
           Type: 8 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 148 ArrayType noalg.[8]struct { key string; elem []string }
+          Type: 135 ArrayType noalg.[8]struct { key string; elem []string }
     - __kind: StructureType
-      ID: 143
+      ID: 158
       Name: noalg.map.group[string]float64
       ByteSize: 200
       GoRuntimeType: 1.33104e+06
@@ -3005,9 +3005,9 @@ Types:
           Type: 8 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 193 ArrayType noalg.[8]struct { key string; elem float64 }
+          Type: 159 ArrayType noalg.[8]struct { key string; elem float64 }
     - __kind: StructureType
-      ID: 140
+      ID: 150
       Name: noalg.map.group[string]interface {}
       ByteSize: 264
       GoRuntimeType: 1.313376e+06
@@ -3018,9 +3018,9 @@ Types:
           Type: 8 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 191 ArrayType noalg.[8]struct { key string; elem interface {} }
+          Type: 151 ArrayType noalg.[8]struct { key string; elem interface {} }
     - __kind: StructureType
-      ID: 137
+      ID: 143
       Name: noalg.map.group[string]string
       ByteSize: 264
       GoRuntimeType: 1.318368e+06
@@ -3031,9 +3031,9 @@ Types:
           Type: 8 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 189 ArrayType noalg.[8]struct { key string; elem string }
+          Type: 144 ArrayType noalg.[8]struct { key string; elem string }
     - __kind: StructureType
-      ID: 214
+      ID: 197
       Name: noalg.struct { key string; elem *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute }
       ByteSize: 24
       GoRuntimeType: 1.331168e+06
@@ -3044,9 +3044,9 @@ Types:
           Type: 9 GoStringHeaderType string
         - Name: elem
           Offset: 16
-          Type: 215 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
+          Type: 198 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
     - __kind: StructureType
-      ID: 199
+      ID: 179
       Name: noalg.struct { key string; elem []*mime/multipart.FileHeader }
       ByteSize: 40
       GoRuntimeType: 1.324896e+06
@@ -3057,9 +3057,9 @@ Types:
           Type: 9 GoStringHeaderType string
         - Name: elem
           Offset: 16
-          Type: 200 GoSliceHeaderType []*mime/multipart.FileHeader
+          Type: 180 GoSliceHeaderType []*mime/multipart.FileHeader
     - __kind: StructureType
-      ID: 149
+      ID: 136
       Name: noalg.struct { key string; elem []string }
       ByteSize: 40
       GoRuntimeType: 1.315808e+06
@@ -3072,7 +3072,7 @@ Types:
           Offset: 16
           Type: 52 GoSliceHeaderType []string
     - __kind: StructureType
-      ID: 194
+      ID: 160
       Name: noalg.struct { key string; elem float64 }
       ByteSize: 24
       GoRuntimeType: 1.330912e+06
@@ -3085,7 +3085,7 @@ Types:
           Offset: 16
           Type: 16 BaseType float64
     - __kind: StructureType
-      ID: 192
+      ID: 152
       Name: noalg.struct { key string; elem interface {} }
       ByteSize: 32
       GoRuntimeType: 1.313248e+06
@@ -3096,9 +3096,9 @@ Types:
           Type: 9 GoStringHeaderType string
         - Name: elem
           Offset: 16
-          Type: 155 GoEmptyInterfaceType interface {}
+          Type: 153 GoEmptyInterfaceType interface {}
     - __kind: StructureType
-      ID: 190
+      ID: 145
       Name: noalg.struct { key string; elem string }
       ByteSize: 32
       GoRuntimeType: 1.31824e+06
@@ -3119,13 +3119,13 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 229 PointerType *string.str
+          Type: 97 PointerType *string.str
         - Name: len
           Offset: 8
           Type: 7 BaseType int
-      Data: 228 GoStringDataType string.str
+      Data: 96 GoStringDataType string.str
     - __kind: GoStringDataType
-      ID: 228
+      ID: 96
       Name: string.str
       ByteSize: 2048
     - __kind: StructureType
@@ -3189,7 +3189,7 @@ Types:
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 144
+      ID: 171
       Name: table<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
       ByteSize: 32
       GoKind: 25
@@ -3211,9 +3211,9 @@ Types:
           Type: 7 BaseType int
         - Name: groups
           Offset: 16
-          Type: 195 GoSwissMapGroupsType groupReference<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
+          Type: 193 GoSwissMapGroupsType groupReference<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
     - __kind: StructureType
-      ID: 133
+      ID: 169
       Name: table<string,[]*mime/multipart.FileHeader>
       ByteSize: 32
       GoKind: 25
@@ -3235,9 +3235,9 @@ Types:
           Type: 7 BaseType int
         - Name: groups
           Offset: 16
-          Type: 150 GoSwissMapGroupsType groupReference<string,[]*mime/multipart.FileHeader>
+          Type: 175 GoSwissMapGroupsType groupReference<string,[]*mime/multipart.FileHeader>
     - __kind: StructureType
-      ID: 98
+      ID: 100
       Name: table<string,[]string>
       ByteSize: 32
       GoKind: 25
@@ -3259,9 +3259,9 @@ Types:
           Type: 7 BaseType int
         - Name: groups
           Offset: 16
-          Type: 130 GoSwissMapGroupsType groupReference<string,[]string>
+          Type: 132 GoSwissMapGroupsType groupReference<string,[]string>
     - __kind: StructureType
-      ID: 120
+      ID: 122
       Name: table<string,float64>
       ByteSize: 32
       GoKind: 25
@@ -3283,9 +3283,9 @@ Types:
           Type: 7 BaseType int
         - Name: groups
           Offset: 16
-          Type: 141 GoSwissMapGroupsType groupReference<string,float64>
+          Type: 156 GoSwissMapGroupsType groupReference<string,float64>
     - __kind: StructureType
-      ID: 119
+      ID: 121
       Name: table<string,interface {}>
       ByteSize: 32
       GoKind: 25
@@ -3307,9 +3307,9 @@ Types:
           Type: 7 BaseType int
         - Name: groups
           Offset: 16
-          Type: 138 GoSwissMapGroupsType groupReference<string,interface {}>
+          Type: 148 GoSwissMapGroupsType groupReference<string,interface {}>
     - __kind: StructureType
-      ID: 118
+      ID: 120
       Name: table<string,string>
       ByteSize: 32
       GoKind: 25
@@ -3331,9 +3331,9 @@ Types:
           Type: 7 BaseType int
         - Name: groups
           Offset: 16
-          Type: 135 GoSwissMapGroupsType groupReference<string,string>
+          Type: 141 GoSwissMapGroupsType groupReference<string,string>
     - __kind: StructureType
-      ID: 164
+      ID: 212
       Name: time.Location
       ByteSize: 104
       GoRuntimeType: 2.013984e+06
@@ -3344,10 +3344,10 @@ Types:
           Type: 9 GoStringHeaderType string
         - Name: zone
           Offset: 16
-          Type: 206 GoSliceHeaderType []time.zone
+          Type: 248 GoSliceHeaderType []time.zone
         - Name: tx
           Offset: 40
-          Type: 209 GoSliceHeaderType []time.zoneTrans
+          Type: 251 GoSliceHeaderType []time.zoneTrans
         - Name: extend
           Offset: 64
           Type: 9 GoStringHeaderType string
@@ -3359,9 +3359,9 @@ Types:
           Type: 13 BaseType int64
         - Name: cacheZone
           Offset: 96
-          Type: 207 PointerType *time.zone
+          Type: 249 PointerType *time.zone
     - __kind: StructureType
-      ID: 162
+      ID: 210
       Name: time.Time
       ByteSize: 24
       GoRuntimeType: 2.428992e+06
@@ -3375,9 +3375,9 @@ Types:
           Type: 13 BaseType int64
         - Name: loc
           Offset: 16
-          Type: 163 PointerType *time.Location
+          Type: 211 PointerType *time.Location
     - __kind: StructureType
-      ID: 208
+      ID: 250
       Name: time.zone
       ByteSize: 32
       GoRuntimeType: 1.646944e+06
@@ -3393,7 +3393,7 @@ Types:
           Offset: 24
           Type: 4 BaseType bool
     - __kind: StructureType
-      ID: 211
+      ID: 253
       Name: time.zoneTrans
       ByteSize: 16
       GoRuntimeType: 1.788928e+06

--- a/pkg/dyninst/irgen/testdata/snapshot/rc_tester.arch=arm64,toolchain=go1.25.0.yaml
+++ b/pkg/dyninst/irgen/testdata/snapshot/rc_tester.arch=arm64,toolchain=go1.25.0.yaml
@@ -10,7 +10,7 @@ Probes:
       subprogram: {subprogram: 1}
       events:
         - ID: 1
-          Type: 294 EventRootType Probe[main.HandleHTTP]
+          Type: 214 EventRootType Probe[main.HandleHTTP]
           InjectionPoints: [{PC: "0x859980", Frameless: true}]
           Condition: null
     - id: look_at_the_request
@@ -23,7 +23,7 @@ Probes:
       subprogram: {subprogram: 2}
       events:
         - ID: 2
-          Type: 295 EventRootType Probe[main.LookAtTheRequest]
+          Type: 215 EventRootType Probe[main.LookAtTheRequest]
           InjectionPoints: [{PC: "0x859c5c", Frameless: true}]
           Condition: null
 Subprograms:
@@ -104,64 +104,37 @@ Types:
       GoKind: 22
       Pointee: 110 PointerType *crypto/x509.Certificate
     - __kind: PointerType
-      ID: 173
-      Name: '**github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span'
-      ByteSize: 8
-      GoKind: 22
-      Pointee: 39 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span
-    - __kind: PointerType
-      ID: 257
-      Name: '**github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttributeValue'
-      ByteSize: 8
-      GoKind: 22
-      Pointee: 258 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttributeValue
-    - __kind: PointerType
-      ID: 181
+      ID: 96
       Name: '**mime/multipart.FileHeader'
       ByteSize: 8
       GoKind: 22
-      Pointee: 182 PointerType *mime/multipart.FileHeader
+      Pointee: 97 PointerType *mime/multipart.FileHeader
     - __kind: PointerType
-      ID: 229
+      ID: 152
       Name: '**net.IPNet'
       ByteSize: 8
       GoKind: 22
-      Pointee: 230 PointerType *net.IPNet
+      Pointee: 153 PointerType *net.IPNet
     - __kind: PointerType
-      ID: 227
+      ID: 150
       Name: '**net/url.URL'
       ByteSize: 8
-      Pointee: 43 PointerType *net/url.URL
+      Pointee: 45 PointerType *net/url.URL
     - __kind: PointerType
-      ID: 126
-      Name: '**table<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>'
-      ByteSize: 8
-      Pointee: 127 PointerType *table<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
-    - __kind: PointerType
-      ID: 105
+      ID: 87
       Name: '**table<string,[]*mime/multipart.FileHeader>'
       ByteSize: 8
-      Pointee: 106 PointerType *table<string,[]*mime/multipart.FileHeader>
+      Pointee: 88 PointerType *table<string,[]*mime/multipart.FileHeader>
     - __kind: PointerType
-      ID: 48
+      ID: 50
       Name: '**table<string,[]string>'
       ByteSize: 8
-      Pointee: 49 PointerType *table<string,[]string>
+      Pointee: 51 PointerType *table<string,[]string>
     - __kind: PointerType
-      ID: 83
-      Name: '**table<string,float64>'
-      ByteSize: 8
-      Pointee: 84 PointerType *table<string,float64>
-    - __kind: PointerType
-      ID: 78
-      Name: '**table<string,interface {}>'
-      ByteSize: 8
-      Pointee: 79 PointerType *table<string,interface {}>
-    - __kind: PointerType
-      ID: 67
+      ID: 69
       Name: '**table<string,string>'
       ByteSize: 8
-      Pointee: 68 PointerType *table<string,string>
+      Pointee: 70 PointerType *table<string,string>
     - __kind: PointerType
       ID: 112
       Name: '*[]*crypto/x509.Certificate'
@@ -169,122 +142,102 @@ Types:
       GoKind: 22
       Pointee: 108 GoSliceHeaderType []*crypto/x509.Certificate
     - __kind: PointerType
-      ID: 186
+      ID: 119
       Name: '*[]*crypto/x509.Certificate.array'
       ByteSize: 8
-      Pointee: 185 GoSliceDataType []*crypto/x509.Certificate.array
+      Pointee: 118 GoSliceDataType []*crypto/x509.Certificate.array
     - __kind: PointerType
-      ID: 242
-      Name: '*[]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span.array'
-      ByteSize: 8
-      Pointee: 241 GoSliceDataType []*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span.array
-    - __kind: PointerType
-      ID: 290
-      Name: '*[]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttributeValue.array'
-      ByteSize: 8
-      Pointee: 289 GoSliceDataType []*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttributeValue.array
-    - __kind: PointerType
-      ID: 244
+      ID: 102
       Name: '*[]*mime/multipart.FileHeader.array'
       ByteSize: 8
-      Pointee: 243 GoSliceDataType []*mime/multipart.FileHeader.array
+      Pointee: 101 GoSliceDataType []*mime/multipart.FileHeader.array
     - __kind: PointerType
-      ID: 276
+      ID: 189
       Name: '*[]*net.IPNet.array'
       ByteSize: 8
-      Pointee: 275 GoSliceDataType []*net.IPNet.array
+      Pointee: 188 GoSliceDataType []*net.IPNet.array
     - __kind: PointerType
-      ID: 274
+      ID: 186
       Name: '*[]*net/url.URL.array'
       ByteSize: 8
-      Pointee: 273 GoSliceDataType []*net/url.URL.array
+      Pointee: 185 GoSliceDataType []*net/url.URL.array
     - __kind: PointerType
-      ID: 188
+      ID: 121
       Name: '*[][]*crypto/x509.Certificate.array'
       ByteSize: 8
-      Pointee: 187 GoSliceDataType [][]*crypto/x509.Certificate.array
+      Pointee: 120 GoSliceDataType [][]*crypto/x509.Certificate.array
     - __kind: PointerType
-      ID: 190
+      ID: 123
       Name: '*[][]uint8.array'
       ByteSize: 8
-      Pointee: 189 GoSliceDataType [][]uint8.array
+      Pointee: 122 GoSliceDataType [][]uint8.array
     - __kind: PointerType
-      ID: 268
+      ID: 182
       Name: '*[]crypto/x509.ExtKeyUsage.array'
       ByteSize: 8
-      Pointee: 267 GoSliceDataType []crypto/x509.ExtKeyUsage.array
+      Pointee: 181 GoSliceDataType []crypto/x509.ExtKeyUsage.array
     - __kind: PointerType
-      ID: 278
+      ID: 191
       Name: '*[]crypto/x509.OID.array'
       ByteSize: 8
-      Pointee: 277 GoSliceDataType []crypto/x509.OID.array
+      Pointee: 190 GoSliceDataType []crypto/x509.OID.array
     - __kind: PointerType
-      ID: 280
+      ID: 193
       Name: '*[]crypto/x509.PolicyMapping.array'
       ByteSize: 8
-      Pointee: 279 GoSliceDataType []crypto/x509.PolicyMapping.array
-    - __kind: PointerType
-      ID: 260
-      Name: '*[]crypto/x509/pkix.AttributeTypeAndValue.array'
-      ByteSize: 8
-      Pointee: 259 GoSliceDataType []crypto/x509/pkix.AttributeTypeAndValue.array
-    - __kind: PointerType
-      ID: 262
-      Name: '*[]crypto/x509/pkix.Extension.array'
-      ByteSize: 8
-      Pointee: 261 GoSliceDataType []crypto/x509/pkix.Extension.array
-    - __kind: PointerType
-      ID: 264
-      Name: '*[]encoding/asn1.ObjectIdentifier.array'
-      ByteSize: 8
-      Pointee: 263 GoSliceDataType []encoding/asn1.ObjectIdentifier.array
-    - __kind: PointerType
-      ID: 164
-      Name: '*[]github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink.array'
-      ByteSize: 8
-      Pointee: 163 GoSliceDataType []github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink.array
+      Pointee: 192 GoSliceDataType []crypto/x509.PolicyMapping.array
     - __kind: PointerType
       ID: 166
-      Name: '*[]github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent.array'
+      Name: '*[]crypto/x509/pkix.AttributeTypeAndValue.array'
       ByteSize: 8
-      Pointee: 165 GoSliceDataType []github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent.array
+      Pointee: 165 GoSliceDataType []crypto/x509/pkix.AttributeTypeAndValue.array
     - __kind: PointerType
-      ID: 270
+      ID: 178
+      Name: '*[]crypto/x509/pkix.Extension.array'
+      ByteSize: 8
+      Pointee: 177 GoSliceDataType []crypto/x509/pkix.Extension.array
+    - __kind: PointerType
+      ID: 180
+      Name: '*[]encoding/asn1.ObjectIdentifier.array'
+      ByteSize: 8
+      Pointee: 179 GoSliceDataType []encoding/asn1.ObjectIdentifier.array
+    - __kind: PointerType
+      ID: 184
       Name: '*[]net.IP.array'
       ByteSize: 8
-      Pointee: 269 GoSliceDataType []net.IP.array
+      Pointee: 183 GoSliceDataType []net.IP.array
     - __kind: PointerType
-      ID: 192
+      ID: 205
       Name: '*[]net/http.segment.array'
       ByteSize: 8
-      Pointee: 191 GoSliceDataType []net/http.segment.array
+      Pointee: 204 GoSliceDataType []net/http.segment.array
     - __kind: PointerType
-      ID: 140
+      ID: 82
       Name: '*[]string.array'
       ByteSize: 8
-      Pointee: 139 GoSliceDataType []string.array
+      Pointee: 81 GoSliceDataType []string.array
     - __kind: PointerType
-      ID: 286
+      ID: 174
       Name: '*[]time.zone.array'
       ByteSize: 8
-      Pointee: 285 GoSliceDataType []time.zone.array
+      Pointee: 173 GoSliceDataType []time.zone.array
     - __kind: PointerType
-      ID: 288
+      ID: 176
       Name: '*[]time.zoneTrans.array'
       ByteSize: 8
-      Pointee: 287 GoSliceDataType []time.zoneTrans.array
+      Pointee: 175 GoSliceDataType []time.zoneTrans.array
     - __kind: PointerType
       ID: 114
       Name: '*[]uint8'
       ByteSize: 8
       GoRuntimeType: 486400
       GoKind: 22
-      Pointee: 94 GoSliceHeaderType []uint8
+      Pointee: 104 GoSliceHeaderType []uint8
     - __kind: PointerType
-      ID: 168
+      ID: 106
       Name: '*[]uint8.array'
       ByteSize: 8
-      Pointee: 167 GoSliceDataType []uint8.array
+      Pointee: 105 GoSliceDataType []uint8.array
     - __kind: PointerType
       ID: 11
       Name: '*bool'
@@ -298,68 +251,68 @@ Types:
       ByteSize: 8
       GoRuntimeType: 2.320608e+06
       GoKind: 22
-      Pointee: 42 StructureType bytes.Buffer
+      Pointee: 42 UnresolvedPointeeType bytes.Buffer
     - __kind: PointerType
-      ID: 56
+      ID: 58
       Name: '*crypto/tls.ConnectionState'
       ByteSize: 8
       GoRuntimeType: 923424
       GoKind: 22
-      Pointee: 57 StructureType crypto/tls.ConnectionState
+      Pointee: 59 StructureType crypto/tls.ConnectionState
     - __kind: PointerType
       ID: 110
       Name: '*crypto/x509.Certificate'
       ByteSize: 8
       GoRuntimeType: 2.088896e+06
       GoKind: 22
-      Pointee: 170 StructureType crypto/x509.Certificate
+      Pointee: 117 StructureType crypto/x509.Certificate
     - __kind: PointerType
-      ID: 221
+      ID: 144
       Name: '*crypto/x509.ExtKeyUsage'
       ByteSize: 8
       GoRuntimeType: 429824
       GoKind: 22
-      Pointee: 222 BaseType crypto/x509.ExtKeyUsage
+      Pointee: 145 BaseType crypto/x509.ExtKeyUsage
     - __kind: PointerType
-      ID: 232
+      ID: 155
       Name: '*crypto/x509.OID'
       ByteSize: 8
       GoRuntimeType: 1.997344e+06
       GoKind: 22
-      Pointee: 233 StructureType crypto/x509.OID
+      Pointee: 156 StructureType crypto/x509.OID
     - __kind: PointerType
-      ID: 235
+      ID: 158
       Name: '*crypto/x509.PolicyMapping'
       ByteSize: 8
       GoRuntimeType: 429888
       GoKind: 22
-      Pointee: 236 StructureType crypto/x509.PolicyMapping
+      Pointee: 159 StructureType crypto/x509.PolicyMapping
     - __kind: PointerType
-      ID: 208
+      ID: 131
       Name: '*crypto/x509/pkix.AttributeTypeAndValue'
       ByteSize: 8
       GoRuntimeType: 446528
       GoKind: 22
-      Pointee: 209 StructureType crypto/x509/pkix.AttributeTypeAndValue
+      Pointee: 132 StructureType crypto/x509/pkix.AttributeTypeAndValue
     - __kind: PointerType
-      ID: 215
+      ID: 138
       Name: '*crypto/x509/pkix.Extension'
       ByteSize: 8
       GoRuntimeType: 446720
       GoKind: 22
-      Pointee: 216 StructureType crypto/x509/pkix.Extension
+      Pointee: 139 StructureType crypto/x509/pkix.Extension
     - __kind: PointerType
-      ID: 218
+      ID: 141
       Name: '*encoding/asn1.ObjectIdentifier'
       ByteSize: 8
       GoRuntimeType: 1.079072e+06
       GoKind: 22
-      Pointee: 219 GoSliceHeaderType encoding/asn1.ObjectIdentifier
+      Pointee: 142 GoSliceHeaderType encoding/asn1.ObjectIdentifier
     - __kind: PointerType
-      ID: 266
+      ID: 195
       Name: '*encoding/asn1.ObjectIdentifier.array'
       ByteSize: 8
-      Pointee: 265 GoSliceDataType encoding/asn1.ObjectIdentifier.array
+      Pointee: 194 GoSliceDataType encoding/asn1.ObjectIdentifier.array
     - __kind: PointerType
       ID: 33
       Name: '*error'
@@ -387,56 +340,7 @@ Types:
       ByteSize: 8
       GoRuntimeType: 2.331872e+06
       GoKind: 22
-      Pointee: 40 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span
-    - __kind: PointerType
-      ID: 91
-      Name: '*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanContext'
-      ByteSize: 8
-      GoRuntimeType: 2.053568e+06
-      GoKind: 22
-      Pointee: 92 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanContext
-    - __kind: PointerType
-      ID: 86
-      Name: '*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink'
-      ByteSize: 8
-      GoRuntimeType: 1.213856e+06
-      GoKind: 22
-      Pointee: 87 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink
-    - __kind: PointerType
-      ID: 89
-      Name: '*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent'
-      ByteSize: 8
-      GoRuntimeType: 1.213984e+06
-      GoKind: 22
-      Pointee: 90 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent
-    - __kind: PointerType
-      ID: 239
-      Name: '*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttribute'
-      ByteSize: 8
-      GoRuntimeType: 1.214624e+06
-      GoKind: 22
-      Pointee: 240 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttribute
-    - __kind: PointerType
-      ID: 258
-      Name: '*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttributeValue'
-      ByteSize: 8
-      GoRuntimeType: 1.214368e+06
-      GoKind: 22
-      Pointee: 282 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttributeValue
-    - __kind: PointerType
-      ID: 198
-      Name: '*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute'
-      ByteSize: 8
-      GoRuntimeType: 1.214752e+06
-      GoKind: 22
-      Pointee: 199 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
-    - __kind: PointerType
-      ID: 129
-      Name: '*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.trace'
-      ByteSize: 8
-      GoRuntimeType: 2.2768e+06
-      GoKind: 22
-      Pointee: 130 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.trace
+      Pointee: 40 UnresolvedPointeeType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span
     - __kind: PointerType
       ID: 27
       Name: '*int'
@@ -473,92 +377,77 @@ Types:
       GoKind: 22
       Pointee: 17 BaseType int8
     - __kind: PointerType
-      ID: 124
-      Name: '*map<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>'
-      ByteSize: 8
-      Pointee: 125 GoSwissMapHeaderType map<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
-    - __kind: PointerType
-      ID: 103
+      ID: 85
       Name: '*map<string,[]*mime/multipart.FileHeader>'
       ByteSize: 8
-      Pointee: 104 GoSwissMapHeaderType map<string,[]*mime/multipart.FileHeader>
+      Pointee: 86 GoSwissMapHeaderType map<string,[]*mime/multipart.FileHeader>
     - __kind: PointerType
-      ID: 46
+      ID: 48
       Name: '*map<string,[]string>'
       ByteSize: 8
-      Pointee: 47 GoSwissMapHeaderType map<string,[]string>
+      Pointee: 49 GoSwissMapHeaderType map<string,[]string>
     - __kind: PointerType
-      ID: 81
-      Name: '*map<string,float64>'
-      ByteSize: 8
-      Pointee: 82 GoSwissMapHeaderType map<string,float64>
-    - __kind: PointerType
-      ID: 76
-      Name: '*map<string,interface {}>'
-      ByteSize: 8
-      Pointee: 77 GoSwissMapHeaderType map<string,interface {}>
-    - __kind: PointerType
-      ID: 65
+      ID: 67
       Name: '*map<string,string>'
       ByteSize: 8
-      Pointee: 66 GoSwissMapHeaderType map<string,string>
+      Pointee: 68 GoSwissMapHeaderType map<string,string>
     - __kind: PointerType
-      ID: 204
+      ID: 127
       Name: '*math/big.Int'
       ByteSize: 8
       GoRuntimeType: 2.446656e+06
       GoKind: 22
-      Pointee: 205 StructureType math/big.Int
+      Pointee: 128 StructureType math/big.Int
     - __kind: PointerType
-      ID: 246
+      ID: 161
       Name: '*math/big.Word'
       ByteSize: 8
       GoRuntimeType: 432640
       GoKind: 22
-      Pointee: 247 BaseType math/big.Word
+      Pointee: 162 BaseType math/big.Word
     - __kind: PointerType
-      ID: 284
+      ID: 164
       Name: '*math/big.nat.array'
       ByteSize: 8
-      Pointee: 283 GoSliceDataType math/big.nat.array
+      Pointee: 163 GoSliceDataType math/big.nat.array
     - __kind: PointerType
-      ID: 182
+      ID: 97
       Name: '*mime/multipart.FileHeader'
       ByteSize: 8
       GoRuntimeType: 924960
       GoKind: 22
-      Pointee: 237 StructureType mime/multipart.FileHeader
+      Pointee: 100 StructureType mime/multipart.FileHeader
     - __kind: PointerType
-      ID: 54
+      ID: 56
       Name: '*mime/multipart.Form'
       ByteSize: 8
       GoRuntimeType: 925056
       GoKind: 22
-      Pointee: 55 StructureType mime/multipart.Form
+      Pointee: 57 StructureType mime/multipart.Form
     - __kind: PointerType
-      ID: 224
+      ID: 147
       Name: '*net.IP'
       ByteSize: 8
       GoRuntimeType: 2.206144e+06
       GoKind: 22
-      Pointee: 225 GoSliceHeaderType net.IP
+      Pointee: 148 GoSliceHeaderType net.IP
     - __kind: PointerType
-      ID: 272
+      ID: 197
       Name: '*net.IP.array'
       ByteSize: 8
-      Pointee: 271 GoSliceDataType net.IP.array
+      Pointee: 196 GoSliceDataType net.IP.array
     - __kind: PointerType
-      ID: 293
+      ID: 200
       Name: '*net.IPMask.array'
       ByteSize: 8
-      Pointee: 292 GoSliceDataType net.IPMask.array
+      Pointee: 199 GoSliceDataType net.IPMask.array
     - __kind: PointerType
-      ID: 230
+      ID: 153
       Name: '*net.IPNet'
       ByteSize: 8
       GoRuntimeType: 1.207712e+06
       GoKind: 22
-      Pointee: 254 StructureType net.IPNet
+      Pointee: 187 StructureType net.IPNet
     - __kind: PointerType
       ID: 37
       Name: '*net/http.Request'
@@ -567,70 +456,55 @@ Types:
       GoKind: 22
       Pointee: 38 StructureType net/http.Request
     - __kind: PointerType
-      ID: 59
+      ID: 61
       Name: '*net/http.Response'
       ByteSize: 8
       GoRuntimeType: 1.757856e+06
       GoKind: 22
-      Pointee: 60 StructureType net/http.Response
+      Pointee: 62 StructureType net/http.Response
     - __kind: PointerType
-      ID: 62
+      ID: 64
       Name: '*net/http.pattern'
       ByteSize: 8
       GoRuntimeType: 1.642144e+06
       GoKind: 22
-      Pointee: 63 StructureType net/http.pattern
+      Pointee: 65 StructureType net/http.pattern
     - __kind: PointerType
-      ID: 118
+      ID: 202
       Name: '*net/http.segment'
       ByteSize: 8
       GoRuntimeType: 396288
       GoKind: 22
-      Pointee: 119 StructureType net/http.segment
+      Pointee: 203 StructureType net/http.segment
     - __kind: PointerType
-      ID: 43
+      ID: 45
       Name: '*net/url.URL'
       ByteSize: 8
       GoRuntimeType: 2.16656e+06
       GoKind: 22
-      Pointee: 44 StructureType net/url.URL
+      Pointee: 46 StructureType net/url.URL
     - __kind: PointerType
-      ID: 98
+      ID: 71
       Name: '*net/url.Userinfo'
       ByteSize: 8
       GoRuntimeType: 1.225376e+06
       GoKind: 22
-      Pointee: 99 StructureType net/url.Userinfo
+      Pointee: 72 StructureType net/url.Userinfo
     - __kind: PointerType
-      ID: 194
-      Name: '*noalg.map.group[string]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute'
-      ByteSize: 8
-      Pointee: 195 StructureType noalg.map.group[string]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
-    - __kind: PointerType
-      ID: 176
+      ID: 91
       Name: '*noalg.map.group[string][]*mime/multipart.FileHeader'
       ByteSize: 8
-      Pointee: 177 StructureType noalg.map.group[string][]*mime/multipart.FileHeader
+      Pointee: 92 StructureType noalg.map.group[string][]*mime/multipart.FileHeader
     - __kind: PointerType
-      ID: 133
+      ID: 75
       Name: '*noalg.map.group[string][]string'
       ByteSize: 8
-      Pointee: 134 StructureType noalg.map.group[string][]string
+      Pointee: 76 StructureType noalg.map.group[string][]string
     - __kind: PointerType
-      ID: 157
-      Name: '*noalg.map.group[string]float64'
-      ByteSize: 8
-      Pointee: 158 StructureType noalg.map.group[string]float64
-    - __kind: PointerType
-      ID: 149
-      Name: '*noalg.map.group[string]interface {}'
-      ByteSize: 8
-      Pointee: 150 StructureType noalg.map.group[string]interface {}
-    - __kind: PointerType
-      ID: 142
+      ID: 208
       Name: '*noalg.map.group[string]string'
       ByteSize: 8
-      Pointee: 143 StructureType noalg.map.group[string]string
+      Pointee: 209 StructureType noalg.map.group[string]string
     - __kind: PointerType
       ID: 22
       Name: '*string'
@@ -639,61 +513,46 @@ Types:
       GoKind: 22
       Pointee: 9 GoStringHeaderType string
     - __kind: PointerType
-      ID: 97
+      ID: 44
       Name: '*string.str'
       ByteSize: 8
-      Pointee: 96 GoStringDataType string.str
+      Pointee: 43 GoStringDataType string.str
     - __kind: PointerType
-      ID: 127
-      Name: '*table<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>'
-      ByteSize: 8
-      Pointee: 171 StructureType table<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
-    - __kind: PointerType
-      ID: 106
+      ID: 88
       Name: '*table<string,[]*mime/multipart.FileHeader>'
       ByteSize: 8
-      Pointee: 169 StructureType table<string,[]*mime/multipart.FileHeader>
+      Pointee: 89 StructureType table<string,[]*mime/multipart.FileHeader>
     - __kind: PointerType
-      ID: 49
+      ID: 51
       Name: '*table<string,[]string>'
       ByteSize: 8
-      Pointee: 100 StructureType table<string,[]string>
+      Pointee: 73 StructureType table<string,[]string>
     - __kind: PointerType
-      ID: 84
-      Name: '*table<string,float64>'
-      ByteSize: 8
-      Pointee: 122 StructureType table<string,float64>
-    - __kind: PointerType
-      ID: 79
-      Name: '*table<string,interface {}>'
-      ByteSize: 8
-      Pointee: 121 StructureType table<string,interface {}>
-    - __kind: PointerType
-      ID: 68
+      ID: 70
       Name: '*table<string,string>'
       ByteSize: 8
-      Pointee: 120 StructureType table<string,string>
+      Pointee: 206 StructureType table<string,string>
     - __kind: PointerType
-      ID: 211
+      ID: 134
       Name: '*time.Location'
       ByteSize: 8
       GoRuntimeType: 1.647136e+06
       GoKind: 22
-      Pointee: 212 StructureType time.Location
+      Pointee: 135 StructureType time.Location
     - __kind: PointerType
-      ID: 249
+      ID: 168
       Name: '*time.zone'
       ByteSize: 8
       GoRuntimeType: 399360
       GoKind: 22
-      Pointee: 250 StructureType time.zone
+      Pointee: 169 StructureType time.zone
     - __kind: PointerType
-      ID: 252
+      ID: 171
       Name: '*time.zoneTrans'
       ByteSize: 8
       GoRuntimeType: 399424
       GoKind: 22
-      Pointee: 253 StructureType time.zoneTrans
+      Pointee: 172 StructureType time.zoneTrans
     - __kind: PointerType
       ID: 34
       Name: '*uint'
@@ -737,12 +596,12 @@ Types:
       GoKind: 22
       Pointee: 1 BaseType uintptr
     - __kind: GoChannelType
-      ID: 58
+      ID: 60
       Name: <-chan struct {}
       GoRuntimeType: 607040
       GoKind: 18
     - __kind: EventRootType
-      ID: 294
+      ID: 214
       Name: Probe[main.HandleHTTP]
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -766,7 +625,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 295
+      ID: 215
       Name: Probe[main.LookAtTheRequest]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -796,58 +655,14 @@ Types:
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 185 GoSliceDataType []*crypto/x509.Certificate.array
+      Data: 118 GoSliceDataType []*crypto/x509.Certificate.array
     - __kind: GoSliceDataType
-      ID: 185
+      ID: 118
       Name: '[]*crypto/x509.Certificate.array'
       ByteSize: 2048
       Element: 110 PointerType *crypto/x509.Certificate
     - __kind: GoSliceHeaderType
-      ID: 172
-      Name: '[]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span'
-      ByteSize: 24
-      GoRuntimeType: 495072
-      GoKind: 23
-      RawFields:
-        - Name: array
-          Offset: 0
-          Type: 173 PointerType **github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span
-        - Name: len
-          Offset: 8
-          Type: 7 BaseType int
-        - Name: cap
-          Offset: 16
-          Type: 7 BaseType int
-      Data: 241 GoSliceDataType []*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span.array
-    - __kind: GoSliceDataType
-      ID: 241
-      Name: '[]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span.array'
-      ByteSize: 2048
-      Element: 39 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span
-    - __kind: GoSliceHeaderType
-      ID: 256
-      Name: '[]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttributeValue'
-      ByteSize: 24
-      GoRuntimeType: 494688
-      GoKind: 23
-      RawFields:
-        - Name: array
-          Offset: 0
-          Type: 257 PointerType **github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttributeValue
-        - Name: len
-          Offset: 8
-          Type: 7 BaseType int
-        - Name: cap
-          Offset: 16
-          Type: 7 BaseType int
-      Data: 289 GoSliceDataType []*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttributeValue.array
-    - __kind: GoSliceDataType
-      ID: 289
-      Name: '[]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttributeValue.array'
-      ByteSize: 2048
-      Element: 258 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttributeValue
-    - __kind: GoSliceHeaderType
-      ID: 180
+      ID: 95
       Name: '[]*mime/multipart.FileHeader'
       ByteSize: 24
       GoRuntimeType: 492064
@@ -855,21 +670,21 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 181 PointerType **mime/multipart.FileHeader
+          Type: 96 PointerType **mime/multipart.FileHeader
         - Name: len
           Offset: 8
           Type: 7 BaseType int
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 243 GoSliceDataType []*mime/multipart.FileHeader.array
+      Data: 101 GoSliceDataType []*mime/multipart.FileHeader.array
     - __kind: GoSliceDataType
-      ID: 243
+      ID: 101
       Name: '[]*mime/multipart.FileHeader.array'
       ByteSize: 2048
-      Element: 182 PointerType *mime/multipart.FileHeader
+      Element: 97 PointerType *mime/multipart.FileHeader
     - __kind: GoSliceHeaderType
-      ID: 228
+      ID: 151
       Name: '[]*net.IPNet'
       ByteSize: 24
       GoRuntimeType: 508864
@@ -877,21 +692,21 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 229 PointerType **net.IPNet
+          Type: 152 PointerType **net.IPNet
         - Name: len
           Offset: 8
           Type: 7 BaseType int
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 275 GoSliceDataType []*net.IPNet.array
+      Data: 188 GoSliceDataType []*net.IPNet.array
     - __kind: GoSliceDataType
-      ID: 275
+      ID: 188
       Name: '[]*net.IPNet.array'
       ByteSize: 2048
-      Element: 230 PointerType *net.IPNet
+      Element: 153 PointerType *net.IPNet
     - __kind: GoSliceHeaderType
-      ID: 226
+      ID: 149
       Name: '[]*net/url.URL'
       ByteSize: 24
       GoRuntimeType: 508800
@@ -899,49 +714,34 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 227 PointerType **net/url.URL
+          Type: 150 PointerType **net/url.URL
         - Name: len
           Offset: 8
           Type: 7 BaseType int
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 273 GoSliceDataType []*net/url.URL.array
+      Data: 185 GoSliceDataType []*net/url.URL.array
     - __kind: GoSliceDataType
-      ID: 273
+      ID: 185
       Name: '[]*net/url.URL.array'
       ByteSize: 2048
-      Element: 43 PointerType *net/url.URL
+      Element: 45 PointerType *net/url.URL
     - __kind: GoSliceDataType
-      ID: 200
-      Name: '[]*table<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>.array'
-      ByteSize: 8192
-      Element: 127 PointerType *table<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
-    - __kind: GoSliceDataType
-      ID: 183
+      ID: 98
       Name: '[]*table<string,[]*mime/multipart.FileHeader>.array'
       ByteSize: 8192
-      Element: 106 PointerType *table<string,[]*mime/multipart.FileHeader>
+      Element: 88 PointerType *table<string,[]*mime/multipart.FileHeader>
     - __kind: GoSliceDataType
-      ID: 137
+      ID: 79
       Name: '[]*table<string,[]string>.array'
       ByteSize: 8192
-      Element: 49 PointerType *table<string,[]string>
+      Element: 51 PointerType *table<string,[]string>
     - __kind: GoSliceDataType
-      ID: 161
-      Name: '[]*table<string,float64>.array'
-      ByteSize: 8192
-      Element: 84 PointerType *table<string,float64>
-    - __kind: GoSliceDataType
-      ID: 154
-      Name: '[]*table<string,interface {}>.array'
-      ByteSize: 8192
-      Element: 79 PointerType *table<string,interface {}>
-    - __kind: GoSliceDataType
-      ID: 146
+      ID: 212
       Name: '[]*table<string,string>.array'
       ByteSize: 8192
-      Element: 68 PointerType *table<string,string>
+      Element: 70 PointerType *table<string,string>
     - __kind: GoSliceHeaderType
       ID: 111
       Name: '[][]*crypto/x509.Certificate'
@@ -958,9 +758,9 @@ Types:
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 187 GoSliceDataType [][]*crypto/x509.Certificate.array
+      Data: 120 GoSliceDataType [][]*crypto/x509.Certificate.array
     - __kind: GoSliceDataType
-      ID: 187
+      ID: 120
       Name: '[][]*crypto/x509.Certificate.array'
       ByteSize: 2048
       Element: 108 GoSliceHeaderType []*crypto/x509.Certificate
@@ -980,14 +780,14 @@ Types:
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 189 GoSliceDataType [][]uint8.array
+      Data: 122 GoSliceDataType [][]uint8.array
     - __kind: GoSliceDataType
-      ID: 189
+      ID: 122
       Name: '[][]uint8.array'
       ByteSize: 2048
-      Element: 94 GoSliceHeaderType []uint8
+      Element: 104 GoSliceHeaderType []uint8
     - __kind: GoSliceHeaderType
-      ID: 220
+      ID: 143
       Name: '[]crypto/x509.ExtKeyUsage'
       ByteSize: 24
       GoRuntimeType: 508736
@@ -995,21 +795,21 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 221 PointerType *crypto/x509.ExtKeyUsage
+          Type: 144 PointerType *crypto/x509.ExtKeyUsage
         - Name: len
           Offset: 8
           Type: 7 BaseType int
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 267 GoSliceDataType []crypto/x509.ExtKeyUsage.array
+      Data: 181 GoSliceDataType []crypto/x509.ExtKeyUsage.array
     - __kind: GoSliceDataType
-      ID: 267
+      ID: 181
       Name: '[]crypto/x509.ExtKeyUsage.array'
       ByteSize: 2048
-      Element: 222 BaseType crypto/x509.ExtKeyUsage
+      Element: 145 BaseType crypto/x509.ExtKeyUsage
     - __kind: GoSliceHeaderType
-      ID: 231
+      ID: 154
       Name: '[]crypto/x509.OID'
       ByteSize: 24
       GoRuntimeType: 508928
@@ -1017,21 +817,21 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 232 PointerType *crypto/x509.OID
+          Type: 155 PointerType *crypto/x509.OID
         - Name: len
           Offset: 8
           Type: 7 BaseType int
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 277 GoSliceDataType []crypto/x509.OID.array
+      Data: 190 GoSliceDataType []crypto/x509.OID.array
     - __kind: GoSliceDataType
-      ID: 277
+      ID: 190
       Name: '[]crypto/x509.OID.array'
       ByteSize: 2048
-      Element: 233 StructureType crypto/x509.OID
+      Element: 156 StructureType crypto/x509.OID
     - __kind: GoSliceHeaderType
-      ID: 234
+      ID: 157
       Name: '[]crypto/x509.PolicyMapping'
       ByteSize: 24
       GoRuntimeType: 508992
@@ -1039,21 +839,21 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 235 PointerType *crypto/x509.PolicyMapping
+          Type: 158 PointerType *crypto/x509.PolicyMapping
         - Name: len
           Offset: 8
           Type: 7 BaseType int
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 279 GoSliceDataType []crypto/x509.PolicyMapping.array
+      Data: 192 GoSliceDataType []crypto/x509.PolicyMapping.array
     - __kind: GoSliceDataType
-      ID: 279
+      ID: 192
       Name: '[]crypto/x509.PolicyMapping.array'
       ByteSize: 2048
-      Element: 236 StructureType crypto/x509.PolicyMapping
+      Element: 159 StructureType crypto/x509.PolicyMapping
     - __kind: GoSliceHeaderType
-      ID: 207
+      ID: 130
       Name: '[]crypto/x509/pkix.AttributeTypeAndValue'
       ByteSize: 24
       GoRuntimeType: 523520
@@ -1061,21 +861,21 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 208 PointerType *crypto/x509/pkix.AttributeTypeAndValue
+          Type: 131 PointerType *crypto/x509/pkix.AttributeTypeAndValue
         - Name: len
           Offset: 8
           Type: 7 BaseType int
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 259 GoSliceDataType []crypto/x509/pkix.AttributeTypeAndValue.array
+      Data: 165 GoSliceDataType []crypto/x509/pkix.AttributeTypeAndValue.array
     - __kind: GoSliceDataType
-      ID: 259
+      ID: 165
       Name: '[]crypto/x509/pkix.AttributeTypeAndValue.array'
       ByteSize: 2048
-      Element: 209 StructureType crypto/x509/pkix.AttributeTypeAndValue
+      Element: 132 StructureType crypto/x509/pkix.AttributeTypeAndValue
     - __kind: GoSliceHeaderType
-      ID: 214
+      ID: 137
       Name: '[]crypto/x509/pkix.Extension'
       ByteSize: 24
       GoRuntimeType: 508608
@@ -1083,21 +883,21 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 215 PointerType *crypto/x509/pkix.Extension
+          Type: 138 PointerType *crypto/x509/pkix.Extension
         - Name: len
           Offset: 8
           Type: 7 BaseType int
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 261 GoSliceDataType []crypto/x509/pkix.Extension.array
+      Data: 177 GoSliceDataType []crypto/x509/pkix.Extension.array
     - __kind: GoSliceDataType
-      ID: 261
+      ID: 177
       Name: '[]crypto/x509/pkix.Extension.array'
       ByteSize: 2048
-      Element: 216 StructureType crypto/x509/pkix.Extension
+      Element: 139 StructureType crypto/x509/pkix.Extension
     - __kind: GoSliceHeaderType
-      ID: 217
+      ID: 140
       Name: '[]encoding/asn1.ObjectIdentifier'
       ByteSize: 24
       GoRuntimeType: 508672
@@ -1105,65 +905,21 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 218 PointerType *encoding/asn1.ObjectIdentifier
+          Type: 141 PointerType *encoding/asn1.ObjectIdentifier
         - Name: len
           Offset: 8
           Type: 7 BaseType int
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 263 GoSliceDataType []encoding/asn1.ObjectIdentifier.array
+      Data: 179 GoSliceDataType []encoding/asn1.ObjectIdentifier.array
     - __kind: GoSliceDataType
-      ID: 263
+      ID: 179
       Name: '[]encoding/asn1.ObjectIdentifier.array'
       ByteSize: 2048
-      Element: 219 GoSliceHeaderType encoding/asn1.ObjectIdentifier
+      Element: 142 GoSliceHeaderType encoding/asn1.ObjectIdentifier
     - __kind: GoSliceHeaderType
-      ID: 85
-      Name: '[]github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink'
-      ByteSize: 24
-      GoRuntimeType: 494624
-      GoKind: 23
-      RawFields:
-        - Name: array
-          Offset: 0
-          Type: 86 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink
-        - Name: len
-          Offset: 8
-          Type: 7 BaseType int
-        - Name: cap
-          Offset: 16
-          Type: 7 BaseType int
-      Data: 163 GoSliceDataType []github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink.array
-    - __kind: GoSliceDataType
-      ID: 163
-      Name: '[]github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink.array'
-      ByteSize: 2048
-      Element: 87 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink
-    - __kind: GoSliceHeaderType
-      ID: 88
-      Name: '[]github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent'
-      ByteSize: 24
-      GoRuntimeType: 494816
-      GoKind: 23
-      RawFields:
-        - Name: array
-          Offset: 0
-          Type: 89 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent
-        - Name: len
-          Offset: 8
-          Type: 7 BaseType int
-        - Name: cap
-          Offset: 16
-          Type: 7 BaseType int
-      Data: 165 GoSliceDataType []github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent.array
-    - __kind: GoSliceDataType
-      ID: 165
-      Name: '[]github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent.array'
-      ByteSize: 2048
-      Element: 90 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent
-    - __kind: GoSliceHeaderType
-      ID: 223
+      ID: 146
       Name: '[]net.IP'
       ByteSize: 24
       GoRuntimeType: 487744
@@ -1171,21 +927,21 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 224 PointerType *net.IP
+          Type: 147 PointerType *net.IP
         - Name: len
           Offset: 8
           Type: 7 BaseType int
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 269 GoSliceDataType []net.IP.array
+      Data: 183 GoSliceDataType []net.IP.array
     - __kind: GoSliceDataType
-      ID: 269
+      ID: 183
       Name: '[]net.IP.array'
       ByteSize: 2048
-      Element: 225 GoSliceHeaderType net.IP
+      Element: 148 GoSliceHeaderType net.IP
     - __kind: GoSliceHeaderType
-      ID: 117
+      ID: 201
       Name: '[]net/http.segment'
       ByteSize: 24
       GoRuntimeType: 489440
@@ -1193,51 +949,36 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 118 PointerType *net/http.segment
+          Type: 202 PointerType *net/http.segment
         - Name: len
           Offset: 8
           Type: 7 BaseType int
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 191 GoSliceDataType []net/http.segment.array
+      Data: 204 GoSliceDataType []net/http.segment.array
     - __kind: GoSliceDataType
-      ID: 191
+      ID: 204
       Name: '[]net/http.segment.array'
       ByteSize: 2048
-      Element: 119 StructureType net/http.segment
+      Element: 203 StructureType net/http.segment
     - __kind: GoSliceDataType
-      ID: 201
-      Name: '[]noalg.map.group[string]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute.array'
-      ByteSize: 2048
-      Element: 195 StructureType noalg.map.group[string]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
-    - __kind: GoSliceDataType
-      ID: 184
+      ID: 99
       Name: '[]noalg.map.group[string][]*mime/multipart.FileHeader.array'
       ByteSize: 2048
-      Element: 177 StructureType noalg.map.group[string][]*mime/multipart.FileHeader
+      Element: 92 StructureType noalg.map.group[string][]*mime/multipart.FileHeader
     - __kind: GoSliceDataType
-      ID: 138
+      ID: 80
       Name: '[]noalg.map.group[string][]string.array'
       ByteSize: 2048
-      Element: 134 StructureType noalg.map.group[string][]string
+      Element: 76 StructureType noalg.map.group[string][]string
     - __kind: GoSliceDataType
-      ID: 162
-      Name: '[]noalg.map.group[string]float64.array'
-      ByteSize: 2048
-      Element: 158 StructureType noalg.map.group[string]float64
-    - __kind: GoSliceDataType
-      ID: 155
-      Name: '[]noalg.map.group[string]interface {}.array'
-      ByteSize: 2048
-      Element: 150 StructureType noalg.map.group[string]interface {}
-    - __kind: GoSliceDataType
-      ID: 147
+      ID: 213
       Name: '[]noalg.map.group[string]string.array'
       ByteSize: 2048
-      Element: 143 StructureType noalg.map.group[string]string
+      Element: 209 StructureType noalg.map.group[string]string
     - __kind: GoSliceHeaderType
-      ID: 52
+      ID: 54
       Name: '[]string'
       ByteSize: 24
       GoRuntimeType: 501280
@@ -1252,14 +993,14 @@ Types:
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 139 GoSliceDataType []string.array
+      Data: 81 GoSliceDataType []string.array
     - __kind: GoSliceDataType
-      ID: 139
+      ID: 81
       Name: '[]string.array'
       ByteSize: 2048
       Element: 9 GoStringHeaderType string
     - __kind: GoSliceHeaderType
-      ID: 248
+      ID: 167
       Name: '[]time.zone'
       ByteSize: 24
       GoRuntimeType: 494176
@@ -1267,21 +1008,21 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 249 PointerType *time.zone
+          Type: 168 PointerType *time.zone
         - Name: len
           Offset: 8
           Type: 7 BaseType int
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 285 GoSliceDataType []time.zone.array
+      Data: 173 GoSliceDataType []time.zone.array
     - __kind: GoSliceDataType
-      ID: 285
+      ID: 173
       Name: '[]time.zone.array'
       ByteSize: 2048
-      Element: 250 StructureType time.zone
+      Element: 169 StructureType time.zone
     - __kind: GoSliceHeaderType
-      ID: 251
+      ID: 170
       Name: '[]time.zoneTrans'
       ByteSize: 24
       GoRuntimeType: 494240
@@ -1289,21 +1030,21 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 252 PointerType *time.zoneTrans
+          Type: 171 PointerType *time.zoneTrans
         - Name: len
           Offset: 8
           Type: 7 BaseType int
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 287 GoSliceDataType []time.zoneTrans.array
+      Data: 175 GoSliceDataType []time.zoneTrans.array
     - __kind: GoSliceDataType
-      ID: 287
+      ID: 175
       Name: '[]time.zoneTrans.array'
       ByteSize: 2048
-      Element: 253 StructureType time.zoneTrans
+      Element: 172 StructureType time.zoneTrans
     - __kind: GoSliceHeaderType
-      ID: 94
+      ID: 104
       Name: '[]uint8'
       ByteSize: 24
       GoRuntimeType: 500128
@@ -1318,9 +1059,9 @@ Types:
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 167 GoSliceDataType []uint8.array
+      Data: 105 GoSliceDataType []uint8.array
     - __kind: GoSliceDataType
-      ID: 167
+      ID: 105
       Name: '[]uint8.array'
       ByteSize: 2048
       Element: 3 BaseType uint8
@@ -1330,28 +1071,10 @@ Types:
       ByteSize: 1
       GoRuntimeType: 595008
       GoKind: 1
-    - __kind: StructureType
+    - __kind: UnresolvedPointeeType
       ID: 42
       Name: bytes.Buffer
-      ByteSize: 40
-      GoRuntimeType: 1.63984e+06
-      GoKind: 25
-      RawFields:
-        - Name: buf
-          Offset: 0
-          Type: 94 GoSliceHeaderType []uint8
-        - Name: off
-          Offset: 24
-          Type: 7 BaseType int
-        - Name: lastRead
-          Offset: 32
-          Type: 95 BaseType bytes.readOp
-    - __kind: BaseType
-      ID: 95
-      Name: bytes.readOp
-      ByteSize: 1
-      GoRuntimeType: 593216
-      GoKind: 3
+      ByteSize: 8
     - __kind: BaseType
       ID: 25
       Name: complex128
@@ -1365,7 +1088,7 @@ Types:
       GoRuntimeType: 594752
       GoKind: 15
     - __kind: GoInterfaceType
-      ID: 61
+      ID: 63
       Name: context.Context
       ByteSize: 16
       GoRuntimeType: 1.302496e+06
@@ -1378,7 +1101,7 @@ Types:
           Offset: 8
           Type: 15 VoidPointerType unsafe.Pointer
     - __kind: StructureType
-      ID: 57
+      ID: 59
       Name: crypto/tls.ConnectionState
       ByteSize: 192
       GoRuntimeType: 2.322656e+06
@@ -1419,10 +1142,10 @@ Types:
           Type: 113 GoSliceHeaderType [][]uint8
         - Name: OCSPResponse
           Offset: 120
-          Type: 94 GoSliceHeaderType []uint8
+          Type: 104 GoSliceHeaderType []uint8
         - Name: TLSUnique
           Offset: 144
-          Type: 94 GoSliceHeaderType []uint8
+          Type: 104 GoSliceHeaderType []uint8
         - Name: ECHAccepted
           Offset: 168
           Type: 4 BaseType bool
@@ -1448,7 +1171,7 @@ Types:
       GoRuntimeType: 846688
       GoKind: 9
     - __kind: StructureType
-      ID: 170
+      ID: 117
       Name: crypto/x509.Certificate
       ByteSize: 1424
       GoRuntimeType: 2.45792e+06
@@ -1456,67 +1179,67 @@ Types:
       RawFields:
         - Name: Raw
           Offset: 0
-          Type: 94 GoSliceHeaderType []uint8
+          Type: 104 GoSliceHeaderType []uint8
         - Name: RawTBSCertificate
           Offset: 24
-          Type: 94 GoSliceHeaderType []uint8
+          Type: 104 GoSliceHeaderType []uint8
         - Name: RawSubjectPublicKeyInfo
           Offset: 48
-          Type: 94 GoSliceHeaderType []uint8
+          Type: 104 GoSliceHeaderType []uint8
         - Name: RawSubject
           Offset: 72
-          Type: 94 GoSliceHeaderType []uint8
+          Type: 104 GoSliceHeaderType []uint8
         - Name: RawIssuer
           Offset: 96
-          Type: 94 GoSliceHeaderType []uint8
+          Type: 104 GoSliceHeaderType []uint8
         - Name: Signature
           Offset: 120
-          Type: 94 GoSliceHeaderType []uint8
+          Type: 104 GoSliceHeaderType []uint8
         - Name: SignatureAlgorithm
           Offset: 144
-          Type: 202 BaseType crypto/x509.SignatureAlgorithm
+          Type: 124 BaseType crypto/x509.SignatureAlgorithm
         - Name: PublicKeyAlgorithm
           Offset: 152
-          Type: 203 BaseType crypto/x509.PublicKeyAlgorithm
+          Type: 125 BaseType crypto/x509.PublicKeyAlgorithm
         - Name: PublicKey
           Offset: 160
-          Type: 153 GoEmptyInterfaceType interface {}
+          Type: 126 GoEmptyInterfaceType interface {}
         - Name: Version
           Offset: 176
           Type: 7 BaseType int
         - Name: SerialNumber
           Offset: 184
-          Type: 204 PointerType *math/big.Int
+          Type: 127 PointerType *math/big.Int
         - Name: Issuer
           Offset: 192
-          Type: 206 StructureType crypto/x509/pkix.Name
+          Type: 129 StructureType crypto/x509/pkix.Name
         - Name: Subject
           Offset: 440
-          Type: 206 StructureType crypto/x509/pkix.Name
+          Type: 129 StructureType crypto/x509/pkix.Name
         - Name: NotBefore
           Offset: 688
-          Type: 210 StructureType time.Time
+          Type: 133 StructureType time.Time
         - Name: NotAfter
           Offset: 712
-          Type: 210 StructureType time.Time
+          Type: 133 StructureType time.Time
         - Name: KeyUsage
           Offset: 736
-          Type: 213 BaseType crypto/x509.KeyUsage
+          Type: 136 BaseType crypto/x509.KeyUsage
         - Name: Extensions
           Offset: 744
-          Type: 214 GoSliceHeaderType []crypto/x509/pkix.Extension
+          Type: 137 GoSliceHeaderType []crypto/x509/pkix.Extension
         - Name: ExtraExtensions
           Offset: 768
-          Type: 214 GoSliceHeaderType []crypto/x509/pkix.Extension
+          Type: 137 GoSliceHeaderType []crypto/x509/pkix.Extension
         - Name: UnhandledCriticalExtensions
           Offset: 792
-          Type: 217 GoSliceHeaderType []encoding/asn1.ObjectIdentifier
+          Type: 140 GoSliceHeaderType []encoding/asn1.ObjectIdentifier
         - Name: ExtKeyUsage
           Offset: 816
-          Type: 220 GoSliceHeaderType []crypto/x509.ExtKeyUsage
+          Type: 143 GoSliceHeaderType []crypto/x509.ExtKeyUsage
         - Name: UnknownExtKeyUsage
           Offset: 840
-          Type: 217 GoSliceHeaderType []encoding/asn1.ObjectIdentifier
+          Type: 140 GoSliceHeaderType []encoding/asn1.ObjectIdentifier
         - Name: BasicConstraintsValid
           Offset: 864
           Type: 4 BaseType bool
@@ -1531,64 +1254,64 @@ Types:
           Type: 4 BaseType bool
         - Name: SubjectKeyId
           Offset: 888
-          Type: 94 GoSliceHeaderType []uint8
+          Type: 104 GoSliceHeaderType []uint8
         - Name: AuthorityKeyId
           Offset: 912
-          Type: 94 GoSliceHeaderType []uint8
+          Type: 104 GoSliceHeaderType []uint8
         - Name: OCSPServer
           Offset: 936
-          Type: 52 GoSliceHeaderType []string
+          Type: 54 GoSliceHeaderType []string
         - Name: IssuingCertificateURL
           Offset: 960
-          Type: 52 GoSliceHeaderType []string
+          Type: 54 GoSliceHeaderType []string
         - Name: DNSNames
           Offset: 984
-          Type: 52 GoSliceHeaderType []string
+          Type: 54 GoSliceHeaderType []string
         - Name: EmailAddresses
           Offset: 1008
-          Type: 52 GoSliceHeaderType []string
+          Type: 54 GoSliceHeaderType []string
         - Name: IPAddresses
           Offset: 1032
-          Type: 223 GoSliceHeaderType []net.IP
+          Type: 146 GoSliceHeaderType []net.IP
         - Name: URIs
           Offset: 1056
-          Type: 226 GoSliceHeaderType []*net/url.URL
+          Type: 149 GoSliceHeaderType []*net/url.URL
         - Name: PermittedDNSDomainsCritical
           Offset: 1080
           Type: 4 BaseType bool
         - Name: PermittedDNSDomains
           Offset: 1088
-          Type: 52 GoSliceHeaderType []string
+          Type: 54 GoSliceHeaderType []string
         - Name: ExcludedDNSDomains
           Offset: 1112
-          Type: 52 GoSliceHeaderType []string
+          Type: 54 GoSliceHeaderType []string
         - Name: PermittedIPRanges
           Offset: 1136
-          Type: 228 GoSliceHeaderType []*net.IPNet
+          Type: 151 GoSliceHeaderType []*net.IPNet
         - Name: ExcludedIPRanges
           Offset: 1160
-          Type: 228 GoSliceHeaderType []*net.IPNet
+          Type: 151 GoSliceHeaderType []*net.IPNet
         - Name: PermittedEmailAddresses
           Offset: 1184
-          Type: 52 GoSliceHeaderType []string
+          Type: 54 GoSliceHeaderType []string
         - Name: ExcludedEmailAddresses
           Offset: 1208
-          Type: 52 GoSliceHeaderType []string
+          Type: 54 GoSliceHeaderType []string
         - Name: PermittedURIDomains
           Offset: 1232
-          Type: 52 GoSliceHeaderType []string
+          Type: 54 GoSliceHeaderType []string
         - Name: ExcludedURIDomains
           Offset: 1256
-          Type: 52 GoSliceHeaderType []string
+          Type: 54 GoSliceHeaderType []string
         - Name: CRLDistributionPoints
           Offset: 1280
-          Type: 52 GoSliceHeaderType []string
+          Type: 54 GoSliceHeaderType []string
         - Name: PolicyIdentifiers
           Offset: 1304
-          Type: 217 GoSliceHeaderType []encoding/asn1.ObjectIdentifier
+          Type: 140 GoSliceHeaderType []encoding/asn1.ObjectIdentifier
         - Name: Policies
           Offset: 1328
-          Type: 231 GoSliceHeaderType []crypto/x509.OID
+          Type: 154 GoSliceHeaderType []crypto/x509.OID
         - Name: InhibitAnyPolicy
           Offset: 1352
           Type: 7 BaseType int
@@ -1609,21 +1332,21 @@ Types:
           Type: 4 BaseType bool
         - Name: PolicyMappings
           Offset: 1400
-          Type: 234 GoSliceHeaderType []crypto/x509.PolicyMapping
+          Type: 157 GoSliceHeaderType []crypto/x509.PolicyMapping
     - __kind: BaseType
-      ID: 222
+      ID: 145
       Name: crypto/x509.ExtKeyUsage
       ByteSize: 8
       GoRuntimeType: 598080
       GoKind: 2
     - __kind: BaseType
-      ID: 213
+      ID: 136
       Name: crypto/x509.KeyUsage
       ByteSize: 8
       GoRuntimeType: 598016
       GoKind: 2
     - __kind: StructureType
-      ID: 233
+      ID: 156
       Name: crypto/x509.OID
       ByteSize: 24
       GoRuntimeType: 1.9976e+06
@@ -1631,9 +1354,9 @@ Types:
       RawFields:
         - Name: der
           Offset: 0
-          Type: 94 GoSliceHeaderType []uint8
+          Type: 104 GoSliceHeaderType []uint8
     - __kind: StructureType
-      ID: 236
+      ID: 159
       Name: crypto/x509.PolicyMapping
       ByteSize: 48
       GoRuntimeType: 1.519712e+06
@@ -1641,24 +1364,24 @@ Types:
       RawFields:
         - Name: IssuerDomainPolicy
           Offset: 0
-          Type: 233 StructureType crypto/x509.OID
+          Type: 156 StructureType crypto/x509.OID
         - Name: SubjectDomainPolicy
           Offset: 24
-          Type: 233 StructureType crypto/x509.OID
+          Type: 156 StructureType crypto/x509.OID
     - __kind: BaseType
-      ID: 203
+      ID: 125
       Name: crypto/x509.PublicKeyAlgorithm
       ByteSize: 8
       GoRuntimeType: 849088
       GoKind: 2
     - __kind: BaseType
-      ID: 202
+      ID: 124
       Name: crypto/x509.SignatureAlgorithm
       ByteSize: 8
       GoRuntimeType: 1.138944e+06
       GoKind: 2
     - __kind: StructureType
-      ID: 209
+      ID: 132
       Name: crypto/x509/pkix.AttributeTypeAndValue
       ByteSize: 40
       GoRuntimeType: 1.532192e+06
@@ -1666,12 +1389,12 @@ Types:
       RawFields:
         - Name: Type
           Offset: 0
-          Type: 219 GoSliceHeaderType encoding/asn1.ObjectIdentifier
+          Type: 142 GoSliceHeaderType encoding/asn1.ObjectIdentifier
         - Name: Value
           Offset: 24
-          Type: 153 GoEmptyInterfaceType interface {}
+          Type: 126 GoEmptyInterfaceType interface {}
     - __kind: StructureType
-      ID: 216
+      ID: 139
       Name: crypto/x509/pkix.Extension
       ByteSize: 56
       GoRuntimeType: 1.683232e+06
@@ -1679,15 +1402,15 @@ Types:
       RawFields:
         - Name: Id
           Offset: 0
-          Type: 219 GoSliceHeaderType encoding/asn1.ObjectIdentifier
+          Type: 142 GoSliceHeaderType encoding/asn1.ObjectIdentifier
         - Name: Critical
           Offset: 24
           Type: 4 BaseType bool
         - Name: Value
           Offset: 32
-          Type: 94 GoSliceHeaderType []uint8
+          Type: 104 GoSliceHeaderType []uint8
     - __kind: StructureType
-      ID: 206
+      ID: 129
       Name: crypto/x509/pkix.Name
       ByteSize: 248
       GoRuntimeType: 2.249504e+06
@@ -1695,25 +1418,25 @@ Types:
       RawFields:
         - Name: Country
           Offset: 0
-          Type: 52 GoSliceHeaderType []string
+          Type: 54 GoSliceHeaderType []string
         - Name: Organization
           Offset: 24
-          Type: 52 GoSliceHeaderType []string
+          Type: 54 GoSliceHeaderType []string
         - Name: OrganizationalUnit
           Offset: 48
-          Type: 52 GoSliceHeaderType []string
+          Type: 54 GoSliceHeaderType []string
         - Name: Locality
           Offset: 72
-          Type: 52 GoSliceHeaderType []string
+          Type: 54 GoSliceHeaderType []string
         - Name: Province
           Offset: 96
-          Type: 52 GoSliceHeaderType []string
+          Type: 54 GoSliceHeaderType []string
         - Name: StreetAddress
           Offset: 120
-          Type: 52 GoSliceHeaderType []string
+          Type: 54 GoSliceHeaderType []string
         - Name: PostalCode
           Offset: 144
-          Type: 52 GoSliceHeaderType []string
+          Type: 54 GoSliceHeaderType []string
         - Name: SerialNumber
           Offset: 168
           Type: 9 GoStringHeaderType string
@@ -1722,12 +1445,12 @@ Types:
           Type: 9 GoStringHeaderType string
         - Name: Names
           Offset: 200
-          Type: 207 GoSliceHeaderType []crypto/x509/pkix.AttributeTypeAndValue
+          Type: 130 GoSliceHeaderType []crypto/x509/pkix.AttributeTypeAndValue
         - Name: ExtraNames
           Offset: 224
-          Type: 207 GoSliceHeaderType []crypto/x509/pkix.AttributeTypeAndValue
+          Type: 130 GoSliceHeaderType []crypto/x509/pkix.AttributeTypeAndValue
     - __kind: GoSliceHeaderType
-      ID: 219
+      ID: 142
       Name: encoding/asn1.ObjectIdentifier
       ByteSize: 24
       GoRuntimeType: 1.0792e+06
@@ -1742,9 +1465,9 @@ Types:
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 265 GoSliceDataType encoding/asn1.ObjectIdentifier.array
+      Data: 194 GoSliceDataType encoding/asn1.ObjectIdentifier.array
     - __kind: GoSliceDataType
-      ID: 265
+      ID: 194
       Name: encoding/asn1.ObjectIdentifier.array
       ByteSize: 2048
       Element: 7 BaseType int
@@ -1774,13 +1497,7 @@ Types:
       GoRuntimeType: 594944
       GoKind: 14
     - __kind: GoSubroutineType
-      ID: 93
-      Name: func()
-      ByteSize: 8
-      GoRuntimeType: 484800
-      GoKind: 19
-    - __kind: GoSubroutineType
-      ID: 51
+      ID: 53
       Name: func() (io.ReadCloser, error)
       ByteSize: 8
       GoRuntimeType: 704864
@@ -1791,393 +1508,52 @@ Types:
       ByteSize: 8
       GoRuntimeType: 1.024448e+06
       GoKind: 19
-    - __kind: StructureType
+    - __kind: UnresolvedPointeeType
       ID: 40
       Name: github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span
-      ByteSize: 288
-      GoRuntimeType: 2.396832e+06
-      GoKind: 25
-      RawFields:
-        - Name: mu
-          Offset: 0
-          Type: 69 StructureType sync.RWMutex
-        - Name: name
-          Offset: 24
-          Type: 9 GoStringHeaderType string
-        - Name: service
-          Offset: 40
-          Type: 9 GoStringHeaderType string
-        - Name: resource
-          Offset: 56
-          Type: 9 GoStringHeaderType string
-        - Name: spanType
-          Offset: 72
-          Type: 9 GoStringHeaderType string
-        - Name: start
-          Offset: 88
-          Type: 13 BaseType int64
-        - Name: duration
-          Offset: 96
-          Type: 13 BaseType int64
-        - Name: meta
-          Offset: 104
-          Type: 64 GoMapType map[string]string
-        - Name: metaStruct
-          Offset: 112
-          Type: 75 GoMapType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.metaStructMap
-        - Name: metrics
-          Offset: 120
-          Type: 80 GoMapType map[string]float64
-        - Name: spanID
-          Offset: 128
-          Type: 8 BaseType uint64
-        - Name: traceID
-          Offset: 136
-          Type: 8 BaseType uint64
-        - Name: parentID
-          Offset: 144
-          Type: 8 BaseType uint64
-        - Name: error
-          Offset: 152
-          Type: 12 BaseType int32
-        - Name: spanLinks
-          Offset: 160
-          Type: 85 GoSliceHeaderType []github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink
-        - Name: spanEvents
-          Offset: 184
-          Type: 88 GoSliceHeaderType []github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent
-        - Name: goExecTraced
-          Offset: 208
-          Type: 4 BaseType bool
-        - Name: noDebugStack
-          Offset: 209
-          Type: 4 BaseType bool
-        - Name: finished
-          Offset: 210
-          Type: 4 BaseType bool
-        - Name: context
-          Offset: 216
-          Type: 91 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanContext
-        - Name: integration
-          Offset: 224
-          Type: 9 GoStringHeaderType string
-        - Name: supportsEvents
-          Offset: 240
-          Type: 4 BaseType bool
-        - Name: pprofCtxActive
-          Offset: 248
-          Type: 61 GoInterfaceType context.Context
-        - Name: pprofCtxRestore
-          Offset: 264
-          Type: 61 GoInterfaceType context.Context
-        - Name: taskEnd
-          Offset: 280
-          Type: 93 GoSubroutineType func()
-    - __kind: StructureType
-      ID: 92
-      Name: github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanContext
-      ByteSize: 168
-      GoRuntimeType: 2.269184e+06
-      GoKind: 25
-      RawFields:
-        - Name: updated
-          Offset: 0
-          Type: 4 BaseType bool
-        - Name: trace
-          Offset: 8
-          Type: 129 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.trace
-        - Name: span
-          Offset: 16
-          Type: 39 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span
-        - Name: errors
-          Offset: 24
-          Type: 73 StructureType sync/atomic.Int32
-        - Name: reparentID
-          Offset: 32
-          Type: 9 GoStringHeaderType string
-        - Name: isRemote
-          Offset: 48
-          Type: 4 BaseType bool
-        - Name: traceID
-          Offset: 49
-          Type: 131 ArrayType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.traceID
-        - Name: spanID
-          Offset: 72
-          Type: 8 BaseType uint64
-        - Name: mu
-          Offset: 80
-          Type: 69 StructureType sync.RWMutex
-        - Name: baggage
-          Offset: 104
-          Type: 64 GoMapType map[string]string
-        - Name: hasBaggage
-          Offset: 112
-          Type: 2 BaseType uint32
-        - Name: origin
-          Offset: 120
-          Type: 9 GoStringHeaderType string
-        - Name: spanLinks
-          Offset: 136
-          Type: 85 GoSliceHeaderType []github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink
-        - Name: baggageOnly
-          Offset: 160
-          Type: 4 BaseType bool
-    - __kind: StructureType
-      ID: 87
-      Name: github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink
-      ByteSize: 56
-      GoRuntimeType: 1.954848e+06
-      GoKind: 25
-      RawFields:
-        - Name: TraceID
-          Offset: 0
-          Type: 8 BaseType uint64
-        - Name: TraceIDHigh
-          Offset: 8
-          Type: 8 BaseType uint64
-        - Name: SpanID
-          Offset: 16
-          Type: 8 BaseType uint64
-        - Name: Attributes
-          Offset: 24
-          Type: 64 GoMapType map[string]string
-        - Name: Tracestate
-          Offset: 32
-          Type: 9 GoStringHeaderType string
-        - Name: Flags
-          Offset: 48
-          Type: 2 BaseType uint32
-    - __kind: GoMapType
-      ID: 75
-      Name: github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.metaStructMap
       ByteSize: 8
-      GoRuntimeType: 1.303776e+06
-      GoKind: 21
-      HeaderType: 77 GoSwissMapHeaderType map<string,interface {}>
-    - __kind: BaseType
-      ID: 174
-      Name: github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.samplingDecision
-      ByteSize: 4
-      GoRuntimeType: 593792
-      GoKind: 10
-    - __kind: StructureType
+    - __kind: GoSwissMapGroupsType
       ID: 90
-      Name: github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent
-      ByteSize: 40
-      GoRuntimeType: 1.78912e+06
-      GoKind: 25
-      RawFields:
-        - Name: Name
-          Offset: 0
-          Type: 9 GoStringHeaderType string
-        - Name: TimeUnixNano
-          Offset: 16
-          Type: 8 BaseType uint64
-        - Name: Attributes
-          Offset: 24
-          Type: 123 GoMapType map[string]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
-        - Name: RawAttributes
-          Offset: 32
-          Type: 128 GoMapType map[string]interface {}
-    - __kind: StructureType
-      ID: 240
-      Name: github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttribute
-      ByteSize: 24
-      GoRuntimeType: 1.214496e+06
-      GoKind: 25
-      RawFields:
-        - Name: Values
-          Offset: 0
-          Type: 256 GoSliceHeaderType []*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttributeValue
-    - __kind: StructureType
-      ID: 282
-      Name: github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttributeValue
-      ByteSize: 48
-      GoRuntimeType: 1.878208e+06
-      GoKind: 25
-      RawFields:
-        - Name: Type
-          Offset: 0
-          Type: 291 BaseType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttributeValueType
-        - Name: StringValue
-          Offset: 8
-          Type: 9 GoStringHeaderType string
-        - Name: BoolValue
-          Offset: 24
-          Type: 4 BaseType bool
-        - Name: IntValue
-          Offset: 32
-          Type: 13 BaseType int64
-        - Name: DoubleValue
-          Offset: 40
-          Type: 16 BaseType float64
-    - __kind: BaseType
-      ID: 291
-      Name: github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttributeValueType
-      ByteSize: 4
-      GoRuntimeType: 1.006112e+06
-      GoKind: 5
-    - __kind: StructureType
-      ID: 199
-      Name: github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
-      ByteSize: 56
-      GoRuntimeType: 1.955104e+06
-      GoKind: 25
-      RawFields:
-        - Name: Type
-          Offset: 0
-          Type: 238 BaseType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttributeType
-        - Name: StringValue
-          Offset: 8
-          Type: 9 GoStringHeaderType string
-        - Name: BoolValue
-          Offset: 24
-          Type: 4 BaseType bool
-        - Name: IntValue
-          Offset: 32
-          Type: 13 BaseType int64
-        - Name: DoubleValue
-          Offset: 40
-          Type: 16 BaseType float64
-        - Name: ArrayValue
-          Offset: 48
-          Type: 239 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttribute
-    - __kind: BaseType
-      ID: 238
-      Name: github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttributeType
-      ByteSize: 4
-      GoRuntimeType: 1.006016e+06
-      GoKind: 5
-    - __kind: StructureType
-      ID: 130
-      Name: github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.trace
-      ByteSize: 104
-      GoRuntimeType: 2.154976e+06
-      GoKind: 25
-      RawFields:
-        - Name: mu
-          Offset: 0
-          Type: 69 StructureType sync.RWMutex
-        - Name: spans
-          Offset: 24
-          Type: 172 GoSliceHeaderType []*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span
-        - Name: tags
-          Offset: 48
-          Type: 64 GoMapType map[string]string
-        - Name: propagatingTags
-          Offset: 56
-          Type: 64 GoMapType map[string]string
-        - Name: finished
-          Offset: 64
-          Type: 7 BaseType int
-        - Name: full
-          Offset: 72
-          Type: 4 BaseType bool
-        - Name: priority
-          Offset: 80
-          Type: 26 PointerType *float64
-        - Name: locked
-          Offset: 88
-          Type: 4 BaseType bool
-        - Name: samplingDecision
-          Offset: 92
-          Type: 174 BaseType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.samplingDecision
-        - Name: root
-          Offset: 96
-          Type: 39 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span
-    - __kind: ArrayType
-      ID: 131
-      Name: github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.traceID
-      ByteSize: 16
-      GoRuntimeType: 918624
-      GoKind: 17
-      Count: 16
-      HasCount: true
-      Element: 3 BaseType uint8
-    - __kind: GoSwissMapGroupsType
-      ID: 193
-      Name: groupReference<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
-      ByteSize: 16
-      GoKind: 25
-      RawFields:
-        - Name: data
-          Offset: 0
-          Type: 194 PointerType *noalg.map.group[string]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
-        - Name: lengthMask
-          Offset: 8
-          Type: 8 BaseType uint64
-      GroupType: 195 StructureType noalg.map.group[string]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
-      GroupSliceType: 201 GoSliceDataType []noalg.map.group[string]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute.array
-    - __kind: GoSwissMapGroupsType
-      ID: 175
       Name: groupReference<string,[]*mime/multipart.FileHeader>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 176 PointerType *noalg.map.group[string][]*mime/multipart.FileHeader
+          Type: 91 PointerType *noalg.map.group[string][]*mime/multipart.FileHeader
         - Name: lengthMask
           Offset: 8
           Type: 8 BaseType uint64
-      GroupType: 177 StructureType noalg.map.group[string][]*mime/multipart.FileHeader
-      GroupSliceType: 184 GoSliceDataType []noalg.map.group[string][]*mime/multipart.FileHeader.array
+      GroupType: 92 StructureType noalg.map.group[string][]*mime/multipart.FileHeader
+      GroupSliceType: 99 GoSliceDataType []noalg.map.group[string][]*mime/multipart.FileHeader.array
     - __kind: GoSwissMapGroupsType
-      ID: 132
+      ID: 74
       Name: groupReference<string,[]string>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 133 PointerType *noalg.map.group[string][]string
+          Type: 75 PointerType *noalg.map.group[string][]string
         - Name: lengthMask
           Offset: 8
           Type: 8 BaseType uint64
-      GroupType: 134 StructureType noalg.map.group[string][]string
-      GroupSliceType: 138 GoSliceDataType []noalg.map.group[string][]string.array
+      GroupType: 76 StructureType noalg.map.group[string][]string
+      GroupSliceType: 80 GoSliceDataType []noalg.map.group[string][]string.array
     - __kind: GoSwissMapGroupsType
-      ID: 156
-      Name: groupReference<string,float64>
-      ByteSize: 16
-      GoKind: 25
-      RawFields:
-        - Name: data
-          Offset: 0
-          Type: 157 PointerType *noalg.map.group[string]float64
-        - Name: lengthMask
-          Offset: 8
-          Type: 8 BaseType uint64
-      GroupType: 158 StructureType noalg.map.group[string]float64
-      GroupSliceType: 162 GoSliceDataType []noalg.map.group[string]float64.array
-    - __kind: GoSwissMapGroupsType
-      ID: 148
-      Name: groupReference<string,interface {}>
-      ByteSize: 16
-      GoKind: 25
-      RawFields:
-        - Name: data
-          Offset: 0
-          Type: 149 PointerType *noalg.map.group[string]interface {}
-        - Name: lengthMask
-          Offset: 8
-          Type: 8 BaseType uint64
-      GroupType: 150 StructureType noalg.map.group[string]interface {}
-      GroupSliceType: 155 GoSliceDataType []noalg.map.group[string]interface {}.array
-    - __kind: GoSwissMapGroupsType
-      ID: 141
+      ID: 207
       Name: groupReference<string,string>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 142 PointerType *noalg.map.group[string]string
+          Type: 208 PointerType *noalg.map.group[string]string
         - Name: lengthMask
           Offset: 8
           Type: 8 BaseType uint64
-      GroupType: 143 StructureType noalg.map.group[string]string
-      GroupSliceType: 147 GoSliceDataType []noalg.map.group[string]string.array
+      GroupType: 209 StructureType noalg.map.group[string]string
+      GroupSliceType: 213 GoSliceDataType []noalg.map.group[string]string.array
     - __kind: BaseType
       ID: 7
       Name: int
@@ -2209,7 +1585,7 @@ Types:
       GoRuntimeType: 594048
       GoKind: 3
     - __kind: GoEmptyInterfaceType
-      ID: 153
+      ID: 126
       Name: interface {}
       ByteSize: 16
       GoRuntimeType: 866496
@@ -2221,21 +1597,8 @@ Types:
         - Name: data
           Offset: 8
           Type: 15 VoidPointerType unsafe.Pointer
-    - __kind: StructureType
-      ID: 72
-      Name: internal/sync.Mutex
-      ByteSize: 8
-      GoRuntimeType: 1.517472e+06
-      GoKind: 25
-      RawFields:
-        - Name: state
-          Offset: 0
-          Type: 12 BaseType int32
-        - Name: sema
-          Offset: 4
-          Type: 2 BaseType uint32
     - __kind: GoInterfaceType
-      ID: 50
+      ID: 52
       Name: io.ReadCloser
       ByteSize: 16
       GoRuntimeType: 1.134464e+06
@@ -2248,42 +1611,7 @@ Types:
           Offset: 8
           Type: 15 VoidPointerType unsafe.Pointer
     - __kind: GoSwissMapHeaderType
-      ID: 125
-      Name: map<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
-      ByteSize: 48
-      GoKind: 25
-      RawFields:
-        - Name: used
-          Offset: 0
-          Type: 8 BaseType uint64
-        - Name: seed
-          Offset: 8
-          Type: 1 BaseType uintptr
-        - Name: dirPtr
-          Offset: 16
-          Type: 126 PointerType **table<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
-        - Name: dirLen
-          Offset: 24
-          Type: 7 BaseType int
-        - Name: globalDepth
-          Offset: 32
-          Type: 3 BaseType uint8
-        - Name: globalShift
-          Offset: 33
-          Type: 3 BaseType uint8
-        - Name: writing
-          Offset: 34
-          Type: 3 BaseType uint8
-        - Name: tombstonePossible
-          Offset: 35
-          Type: 4 BaseType bool
-        - Name: clearSeq
-          Offset: 40
-          Type: 8 BaseType uint64
-      TablePtrSliceType: 200 GoSliceDataType []*table<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>.array
-      GroupType: 195 StructureType noalg.map.group[string]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
-    - __kind: GoSwissMapHeaderType
-      ID: 104
+      ID: 86
       Name: map<string,[]*mime/multipart.FileHeader>
       ByteSize: 48
       GoKind: 25
@@ -2296,7 +1624,7 @@ Types:
           Type: 1 BaseType uintptr
         - Name: dirPtr
           Offset: 16
-          Type: 105 PointerType **table<string,[]*mime/multipart.FileHeader>
+          Type: 87 PointerType **table<string,[]*mime/multipart.FileHeader>
         - Name: dirLen
           Offset: 24
           Type: 7 BaseType int
@@ -2315,10 +1643,10 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 8 BaseType uint64
-      TablePtrSliceType: 183 GoSliceDataType []*table<string,[]*mime/multipart.FileHeader>.array
-      GroupType: 177 StructureType noalg.map.group[string][]*mime/multipart.FileHeader
+      TablePtrSliceType: 98 GoSliceDataType []*table<string,[]*mime/multipart.FileHeader>.array
+      GroupType: 92 StructureType noalg.map.group[string][]*mime/multipart.FileHeader
     - __kind: GoSwissMapHeaderType
-      ID: 47
+      ID: 49
       Name: map<string,[]string>
       ByteSize: 48
       GoKind: 25
@@ -2331,7 +1659,7 @@ Types:
           Type: 1 BaseType uintptr
         - Name: dirPtr
           Offset: 16
-          Type: 48 PointerType **table<string,[]string>
+          Type: 50 PointerType **table<string,[]string>
         - Name: dirLen
           Offset: 24
           Type: 7 BaseType int
@@ -2350,80 +1678,10 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 8 BaseType uint64
-      TablePtrSliceType: 137 GoSliceDataType []*table<string,[]string>.array
-      GroupType: 134 StructureType noalg.map.group[string][]string
+      TablePtrSliceType: 79 GoSliceDataType []*table<string,[]string>.array
+      GroupType: 76 StructureType noalg.map.group[string][]string
     - __kind: GoSwissMapHeaderType
-      ID: 82
-      Name: map<string,float64>
-      ByteSize: 48
-      GoKind: 25
-      RawFields:
-        - Name: used
-          Offset: 0
-          Type: 8 BaseType uint64
-        - Name: seed
-          Offset: 8
-          Type: 1 BaseType uintptr
-        - Name: dirPtr
-          Offset: 16
-          Type: 83 PointerType **table<string,float64>
-        - Name: dirLen
-          Offset: 24
-          Type: 7 BaseType int
-        - Name: globalDepth
-          Offset: 32
-          Type: 3 BaseType uint8
-        - Name: globalShift
-          Offset: 33
-          Type: 3 BaseType uint8
-        - Name: writing
-          Offset: 34
-          Type: 3 BaseType uint8
-        - Name: tombstonePossible
-          Offset: 35
-          Type: 4 BaseType bool
-        - Name: clearSeq
-          Offset: 40
-          Type: 8 BaseType uint64
-      TablePtrSliceType: 161 GoSliceDataType []*table<string,float64>.array
-      GroupType: 158 StructureType noalg.map.group[string]float64
-    - __kind: GoSwissMapHeaderType
-      ID: 77
-      Name: map<string,interface {}>
-      ByteSize: 48
-      GoKind: 25
-      RawFields:
-        - Name: used
-          Offset: 0
-          Type: 8 BaseType uint64
-        - Name: seed
-          Offset: 8
-          Type: 1 BaseType uintptr
-        - Name: dirPtr
-          Offset: 16
-          Type: 78 PointerType **table<string,interface {}>
-        - Name: dirLen
-          Offset: 24
-          Type: 7 BaseType int
-        - Name: globalDepth
-          Offset: 32
-          Type: 3 BaseType uint8
-        - Name: globalShift
-          Offset: 33
-          Type: 3 BaseType uint8
-        - Name: writing
-          Offset: 34
-          Type: 3 BaseType uint8
-        - Name: tombstonePossible
-          Offset: 35
-          Type: 4 BaseType bool
-        - Name: clearSeq
-          Offset: 40
-          Type: 8 BaseType uint64
-      TablePtrSliceType: 154 GoSliceDataType []*table<string,interface {}>.array
-      GroupType: 150 StructureType noalg.map.group[string]interface {}
-    - __kind: GoSwissMapHeaderType
-      ID: 66
+      ID: 68
       Name: map<string,string>
       ByteSize: 48
       GoKind: 25
@@ -2436,7 +1694,7 @@ Types:
           Type: 1 BaseType uintptr
         - Name: dirPtr
           Offset: 16
-          Type: 67 PointerType **table<string,string>
+          Type: 69 PointerType **table<string,string>
         - Name: dirLen
           Offset: 24
           Type: 7 BaseType int
@@ -2455,52 +1713,31 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 8 BaseType uint64
-      TablePtrSliceType: 146 GoSliceDataType []*table<string,string>.array
-      GroupType: 143 StructureType noalg.map.group[string]string
+      TablePtrSliceType: 212 GoSliceDataType []*table<string,string>.array
+      GroupType: 209 StructureType noalg.map.group[string]string
     - __kind: GoMapType
-      ID: 123
-      Name: map[string]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
-      ByteSize: 8
-      GoRuntimeType: 1.157632e+06
-      GoKind: 21
-      HeaderType: 125 GoSwissMapHeaderType map<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
-    - __kind: GoMapType
-      ID: 102
+      ID: 84
       Name: map[string][]*mime/multipart.FileHeader
       ByteSize: 8
       GoRuntimeType: 1.156864e+06
       GoKind: 21
-      HeaderType: 104 GoSwissMapHeaderType map<string,[]*mime/multipart.FileHeader>
+      HeaderType: 86 GoSwissMapHeaderType map<string,[]*mime/multipart.FileHeader>
     - __kind: GoMapType
-      ID: 101
+      ID: 83
       Name: map[string][]string
       ByteSize: 8
       GoRuntimeType: 1.152512e+06
       GoKind: 21
-      HeaderType: 47 GoSwissMapHeaderType map<string,[]string>
+      HeaderType: 49 GoSwissMapHeaderType map<string,[]string>
     - __kind: GoMapType
-      ID: 80
-      Name: map[string]float64
-      ByteSize: 8
-      GoRuntimeType: 1.157504e+06
-      GoKind: 21
-      HeaderType: 82 GoSwissMapHeaderType map<string,float64>
-    - __kind: GoMapType
-      ID: 128
-      Name: map[string]interface {}
-      ByteSize: 8
-      GoRuntimeType: 1.151104e+06
-      GoKind: 21
-      HeaderType: 77 GoSwissMapHeaderType map<string,interface {}>
-    - __kind: GoMapType
-      ID: 64
+      ID: 66
       Name: map[string]string
       ByteSize: 8
       GoRuntimeType: 1.153536e+06
       GoKind: 21
-      HeaderType: 66 GoSwissMapHeaderType map<string,string>
+      HeaderType: 68 GoSwissMapHeaderType map<string,string>
     - __kind: StructureType
-      ID: 205
+      ID: 128
       Name: math/big.Int
       ByteSize: 32
       GoRuntimeType: 1.522752e+06
@@ -2511,15 +1748,15 @@ Types:
           Type: 4 BaseType bool
         - Name: abs
           Offset: 8
-          Type: 245 GoSliceHeaderType math/big.nat
+          Type: 160 GoSliceHeaderType math/big.nat
     - __kind: BaseType
-      ID: 247
+      ID: 162
       Name: math/big.Word
       ByteSize: 8
       GoRuntimeType: 598272
       GoKind: 7
     - __kind: GoSliceHeaderType
-      ID: 245
+      ID: 160
       Name: math/big.nat
       ByteSize: 24
       GoRuntimeType: 2.426144e+06
@@ -2527,21 +1764,21 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 246 PointerType *math/big.Word
+          Type: 161 PointerType *math/big.Word
         - Name: len
           Offset: 8
           Type: 7 BaseType int
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 283 GoSliceDataType math/big.nat.array
+      Data: 163 GoSliceDataType math/big.nat.array
     - __kind: GoSliceDataType
-      ID: 283
+      ID: 163
       Name: math/big.nat.array
       ByteSize: 2048
-      Element: 247 BaseType math/big.Word
+      Element: 162 BaseType math/big.Word
     - __kind: StructureType
-      ID: 237
+      ID: 100
       Name: mime/multipart.FileHeader
       ByteSize: 88
       GoRuntimeType: 2.018016e+06
@@ -2552,13 +1789,13 @@ Types:
           Type: 9 GoStringHeaderType string
         - Name: Header
           Offset: 16
-          Type: 255 GoMapType net/textproto.MIMEHeader
+          Type: 103 GoMapType net/textproto.MIMEHeader
         - Name: Size
           Offset: 24
           Type: 13 BaseType int64
         - Name: content
           Offset: 32
-          Type: 94 GoSliceHeaderType []uint8
+          Type: 104 GoSliceHeaderType []uint8
         - Name: tmpfile
           Offset: 56
           Type: 9 GoStringHeaderType string
@@ -2569,7 +1806,7 @@ Types:
           Offset: 80
           Type: 4 BaseType bool
     - __kind: StructureType
-      ID: 55
+      ID: 57
       Name: mime/multipart.Form
       ByteSize: 16
       GoRuntimeType: 1.505952e+06
@@ -2577,12 +1814,12 @@ Types:
       RawFields:
         - Name: Value
           Offset: 0
-          Type: 101 GoMapType map[string][]string
+          Type: 83 GoMapType map[string][]string
         - Name: File
           Offset: 8
-          Type: 102 GoMapType map[string][]*mime/multipart.FileHeader
+          Type: 84 GoMapType map[string][]*mime/multipart.FileHeader
     - __kind: GoSliceHeaderType
-      ID: 225
+      ID: 148
       Name: net.IP
       ByteSize: 24
       GoRuntimeType: 2.178176e+06
@@ -2597,14 +1834,14 @@ Types:
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 271 GoSliceDataType net.IP.array
+      Data: 196 GoSliceDataType net.IP.array
     - __kind: GoSliceDataType
-      ID: 271
+      ID: 196
       Name: net.IP.array
       ByteSize: 2048
       Element: 3 BaseType uint8
     - __kind: GoSliceHeaderType
-      ID: 281
+      ID: 198
       Name: net.IPMask
       ByteSize: 24
       GoRuntimeType: 1.041568e+06
@@ -2619,14 +1856,14 @@ Types:
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 292 GoSliceDataType net.IPMask.array
+      Data: 199 GoSliceDataType net.IPMask.array
     - __kind: GoSliceDataType
-      ID: 292
+      ID: 199
       Name: net.IPMask.array
       ByteSize: 2048
       Element: 3 BaseType uint8
     - __kind: StructureType
-      ID: 254
+      ID: 187
       Name: net.IPNet
       ByteSize: 48
       GoRuntimeType: 1.486272e+06
@@ -2634,17 +1871,17 @@ Types:
       RawFields:
         - Name: IP
           Offset: 0
-          Type: 225 GoSliceHeaderType net.IP
+          Type: 148 GoSliceHeaderType net.IP
         - Name: Mask
           Offset: 24
-          Type: 281 GoSliceHeaderType net.IPMask
+          Type: 198 GoSliceHeaderType net.IPMask
     - __kind: GoMapType
-      ID: 45
+      ID: 47
       Name: net/http.Header
       ByteSize: 8
       GoRuntimeType: 2.154272e+06
       GoKind: 21
-      HeaderType: 47 GoSwissMapHeaderType map<string,[]string>
+      HeaderType: 49 GoSwissMapHeaderType map<string,[]string>
     - __kind: StructureType
       ID: 38
       Name: net/http.Request
@@ -2657,7 +1894,7 @@ Types:
           Type: 9 GoStringHeaderType string
         - Name: URL
           Offset: 16
-          Type: 43 PointerType *net/url.URL
+          Type: 45 PointerType *net/url.URL
         - Name: Proto
           Offset: 24
           Type: 9 GoStringHeaderType string
@@ -2669,19 +1906,19 @@ Types:
           Type: 7 BaseType int
         - Name: Header
           Offset: 56
-          Type: 45 GoMapType net/http.Header
+          Type: 47 GoMapType net/http.Header
         - Name: Body
           Offset: 64
-          Type: 50 GoInterfaceType io.ReadCloser
+          Type: 52 GoInterfaceType io.ReadCloser
         - Name: GetBody
           Offset: 80
-          Type: 51 GoSubroutineType func() (io.ReadCloser, error)
+          Type: 53 GoSubroutineType func() (io.ReadCloser, error)
         - Name: ContentLength
           Offset: 88
           Type: 13 BaseType int64
         - Name: TransferEncoding
           Offset: 96
-          Type: 52 GoSliceHeaderType []string
+          Type: 54 GoSliceHeaderType []string
         - Name: Close
           Offset: 120
           Type: 4 BaseType bool
@@ -2690,16 +1927,16 @@ Types:
           Type: 9 GoStringHeaderType string
         - Name: Form
           Offset: 144
-          Type: 53 GoMapType net/url.Values
+          Type: 55 GoMapType net/url.Values
         - Name: PostForm
           Offset: 152
-          Type: 53 GoMapType net/url.Values
+          Type: 55 GoMapType net/url.Values
         - Name: MultipartForm
           Offset: 160
-          Type: 54 PointerType *mime/multipart.Form
+          Type: 56 PointerType *mime/multipart.Form
         - Name: Trailer
           Offset: 168
-          Type: 45 GoMapType net/http.Header
+          Type: 47 GoMapType net/http.Header
         - Name: RemoteAddr
           Offset: 176
           Type: 9 GoStringHeaderType string
@@ -2708,30 +1945,30 @@ Types:
           Type: 9 GoStringHeaderType string
         - Name: TLS
           Offset: 208
-          Type: 56 PointerType *crypto/tls.ConnectionState
+          Type: 58 PointerType *crypto/tls.ConnectionState
         - Name: Cancel
           Offset: 216
-          Type: 58 GoChannelType <-chan struct {}
+          Type: 60 GoChannelType <-chan struct {}
         - Name: Response
           Offset: 224
-          Type: 59 PointerType *net/http.Response
+          Type: 61 PointerType *net/http.Response
         - Name: Pattern
           Offset: 232
           Type: 9 GoStringHeaderType string
         - Name: ctx
           Offset: 248
-          Type: 61 GoInterfaceType context.Context
+          Type: 63 GoInterfaceType context.Context
         - Name: pat
           Offset: 264
-          Type: 62 PointerType *net/http.pattern
+          Type: 64 PointerType *net/http.pattern
         - Name: matches
           Offset: 272
-          Type: 52 GoSliceHeaderType []string
+          Type: 54 GoSliceHeaderType []string
         - Name: otherValues
           Offset: 296
-          Type: 64 GoMapType map[string]string
+          Type: 66 GoMapType map[string]string
     - __kind: StructureType
-      ID: 60
+      ID: 62
       Name: net/http.Response
       ByteSize: 144
       GoRuntimeType: 2.26784e+06
@@ -2754,16 +1991,16 @@ Types:
           Type: 7 BaseType int
         - Name: Header
           Offset: 56
-          Type: 45 GoMapType net/http.Header
+          Type: 47 GoMapType net/http.Header
         - Name: Body
           Offset: 64
-          Type: 50 GoInterfaceType io.ReadCloser
+          Type: 52 GoInterfaceType io.ReadCloser
         - Name: ContentLength
           Offset: 80
           Type: 13 BaseType int64
         - Name: TransferEncoding
           Offset: 88
-          Type: 52 GoSliceHeaderType []string
+          Type: 54 GoSliceHeaderType []string
         - Name: Close
           Offset: 112
           Type: 4 BaseType bool
@@ -2772,13 +2009,13 @@ Types:
           Type: 4 BaseType bool
         - Name: Trailer
           Offset: 120
-          Type: 45 GoMapType net/http.Header
+          Type: 47 GoMapType net/http.Header
         - Name: Request
           Offset: 128
           Type: 37 PointerType *net/http.Request
         - Name: TLS
           Offset: 136
-          Type: 56 PointerType *crypto/tls.ConnectionState
+          Type: 58 PointerType *crypto/tls.ConnectionState
     - __kind: GoInterfaceType
       ID: 36
       Name: net/http.ResponseWriter
@@ -2793,7 +2030,7 @@ Types:
           Offset: 8
           Type: 15 VoidPointerType unsafe.Pointer
     - __kind: StructureType
-      ID: 63
+      ID: 65
       Name: net/http.pattern
       ByteSize: 88
       GoRuntimeType: 1.875072e+06
@@ -2810,12 +2047,12 @@ Types:
           Type: 9 GoStringHeaderType string
         - Name: segments
           Offset: 48
-          Type: 117 GoSliceHeaderType []net/http.segment
+          Type: 201 GoSliceHeaderType []net/http.segment
         - Name: loc
           Offset: 72
           Type: 9 GoStringHeaderType string
     - __kind: StructureType
-      ID: 119
+      ID: 203
       Name: net/http.segment
       ByteSize: 24
       GoRuntimeType: 1.641952e+06
@@ -2831,14 +2068,14 @@ Types:
           Offset: 17
           Type: 4 BaseType bool
     - __kind: GoMapType
-      ID: 255
+      ID: 103
       Name: net/textproto.MIMEHeader
       ByteSize: 8
       GoRuntimeType: 1.863136e+06
       GoKind: 21
-      HeaderType: 47 GoSwissMapHeaderType map<string,[]string>
+      HeaderType: 49 GoSwissMapHeaderType map<string,[]string>
     - __kind: StructureType
-      ID: 44
+      ID: 46
       Name: net/url.URL
       ByteSize: 144
       GoRuntimeType: 2.180864e+06
@@ -2852,7 +2089,7 @@ Types:
           Type: 9 GoStringHeaderType string
         - Name: User
           Offset: 32
-          Type: 98 PointerType *net/url.Userinfo
+          Type: 71 PointerType *net/url.Userinfo
         - Name: Host
           Offset: 40
           Type: 9 GoStringHeaderType string
@@ -2878,7 +2115,7 @@ Types:
           Offset: 128
           Type: 9 GoStringHeaderType string
     - __kind: StructureType
-      ID: 99
+      ID: 72
       Name: net/url.Userinfo
       ByteSize: 40
       GoRuntimeType: 1.65808e+06
@@ -2894,81 +2131,41 @@ Types:
           Offset: 32
           Type: 4 BaseType bool
     - __kind: GoMapType
-      ID: 53
+      ID: 55
       Name: net/url.Values
       ByteSize: 8
       GoRuntimeType: 1.927712e+06
       GoKind: 21
-      HeaderType: 47 GoSwissMapHeaderType map<string,[]string>
+      HeaderType: 49 GoSwissMapHeaderType map<string,[]string>
     - __kind: ArrayType
-      ID: 196
-      Name: noalg.[8]struct { key string; elem *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute }
-      ByteSize: 192
-      GoRuntimeType: 715104
-      GoKind: 17
-      Count: 8
-      HasCount: true
-      Element: 197 StructureType noalg.struct { key string; elem *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute }
-    - __kind: ArrayType
-      ID: 178
+      ID: 93
       Name: noalg.[8]struct { key string; elem []*mime/multipart.FileHeader }
       ByteSize: 320
       GoRuntimeType: 710720
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 179 StructureType noalg.struct { key string; elem []*mime/multipart.FileHeader }
+      Element: 94 StructureType noalg.struct { key string; elem []*mime/multipart.FileHeader }
     - __kind: ArrayType
-      ID: 135
+      ID: 77
       Name: noalg.[8]struct { key string; elem []string }
       ByteSize: 320
       GoRuntimeType: 700896
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 136 StructureType noalg.struct { key string; elem []string }
+      Element: 78 StructureType noalg.struct { key string; elem []string }
     - __kind: ArrayType
-      ID: 159
-      Name: noalg.[8]struct { key string; elem float64 }
-      ByteSize: 192
-      GoRuntimeType: 715008
-      GoKind: 17
-      Count: 8
-      HasCount: true
-      Element: 160 StructureType noalg.struct { key string; elem float64 }
-    - __kind: ArrayType
-      ID: 151
-      Name: noalg.[8]struct { key string; elem interface {} }
-      ByteSize: 256
-      GoRuntimeType: 692352
-      GoKind: 17
-      Count: 8
-      HasCount: true
-      Element: 152 StructureType noalg.struct { key string; elem interface {} }
-    - __kind: ArrayType
-      ID: 144
+      ID: 210
       Name: noalg.[8]struct { key string; elem string }
       ByteSize: 256
       GoRuntimeType: 705056
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 145 StructureType noalg.struct { key string; elem string }
+      Element: 211 StructureType noalg.struct { key string; elem string }
     - __kind: StructureType
-      ID: 195
-      Name: noalg.map.group[string]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
-      ByteSize: 200
-      GoRuntimeType: 1.331296e+06
-      GoKind: 25
-      RawFields:
-        - Name: ctrl
-          Offset: 0
-          Type: 8 BaseType uint64
-        - Name: slots
-          Offset: 8
-          Type: 196 ArrayType noalg.[8]struct { key string; elem *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute }
-    - __kind: StructureType
-      ID: 177
+      ID: 92
       Name: noalg.map.group[string][]*mime/multipart.FileHeader
       ByteSize: 328
       GoRuntimeType: 1.325024e+06
@@ -2979,9 +2176,9 @@ Types:
           Type: 8 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 178 ArrayType noalg.[8]struct { key string; elem []*mime/multipart.FileHeader }
+          Type: 93 ArrayType noalg.[8]struct { key string; elem []*mime/multipart.FileHeader }
     - __kind: StructureType
-      ID: 134
+      ID: 76
       Name: noalg.map.group[string][]string
       ByteSize: 328
       GoRuntimeType: 1.315936e+06
@@ -2992,35 +2189,9 @@ Types:
           Type: 8 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 135 ArrayType noalg.[8]struct { key string; elem []string }
+          Type: 77 ArrayType noalg.[8]struct { key string; elem []string }
     - __kind: StructureType
-      ID: 158
-      Name: noalg.map.group[string]float64
-      ByteSize: 200
-      GoRuntimeType: 1.33104e+06
-      GoKind: 25
-      RawFields:
-        - Name: ctrl
-          Offset: 0
-          Type: 8 BaseType uint64
-        - Name: slots
-          Offset: 8
-          Type: 159 ArrayType noalg.[8]struct { key string; elem float64 }
-    - __kind: StructureType
-      ID: 150
-      Name: noalg.map.group[string]interface {}
-      ByteSize: 264
-      GoRuntimeType: 1.313376e+06
-      GoKind: 25
-      RawFields:
-        - Name: ctrl
-          Offset: 0
-          Type: 8 BaseType uint64
-        - Name: slots
-          Offset: 8
-          Type: 151 ArrayType noalg.[8]struct { key string; elem interface {} }
-    - __kind: StructureType
-      ID: 143
+      ID: 209
       Name: noalg.map.group[string]string
       ByteSize: 264
       GoRuntimeType: 1.318368e+06
@@ -3031,22 +2202,9 @@ Types:
           Type: 8 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 144 ArrayType noalg.[8]struct { key string; elem string }
+          Type: 210 ArrayType noalg.[8]struct { key string; elem string }
     - __kind: StructureType
-      ID: 197
-      Name: noalg.struct { key string; elem *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute }
-      ByteSize: 24
-      GoRuntimeType: 1.331168e+06
-      GoKind: 25
-      RawFields:
-        - Name: key
-          Offset: 0
-          Type: 9 GoStringHeaderType string
-        - Name: elem
-          Offset: 16
-          Type: 198 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
-    - __kind: StructureType
-      ID: 179
+      ID: 94
       Name: noalg.struct { key string; elem []*mime/multipart.FileHeader }
       ByteSize: 40
       GoRuntimeType: 1.324896e+06
@@ -3057,9 +2215,9 @@ Types:
           Type: 9 GoStringHeaderType string
         - Name: elem
           Offset: 16
-          Type: 180 GoSliceHeaderType []*mime/multipart.FileHeader
+          Type: 95 GoSliceHeaderType []*mime/multipart.FileHeader
     - __kind: StructureType
-      ID: 136
+      ID: 78
       Name: noalg.struct { key string; elem []string }
       ByteSize: 40
       GoRuntimeType: 1.315808e+06
@@ -3070,35 +2228,9 @@ Types:
           Type: 9 GoStringHeaderType string
         - Name: elem
           Offset: 16
-          Type: 52 GoSliceHeaderType []string
+          Type: 54 GoSliceHeaderType []string
     - __kind: StructureType
-      ID: 160
-      Name: noalg.struct { key string; elem float64 }
-      ByteSize: 24
-      GoRuntimeType: 1.330912e+06
-      GoKind: 25
-      RawFields:
-        - Name: key
-          Offset: 0
-          Type: 9 GoStringHeaderType string
-        - Name: elem
-          Offset: 16
-          Type: 16 BaseType float64
-    - __kind: StructureType
-      ID: 152
-      Name: noalg.struct { key string; elem interface {} }
-      ByteSize: 32
-      GoRuntimeType: 1.313248e+06
-      GoKind: 25
-      RawFields:
-        - Name: key
-          Offset: 0
-          Type: 9 GoStringHeaderType string
-        - Name: elem
-          Offset: 16
-          Type: 153 GoEmptyInterfaceType interface {}
-    - __kind: StructureType
-      ID: 145
+      ID: 211
       Name: noalg.struct { key string; elem string }
       ByteSize: 32
       GoRuntimeType: 1.31824e+06
@@ -3119,101 +2251,17 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 97 PointerType *string.str
+          Type: 44 PointerType *string.str
         - Name: len
           Offset: 8
           Type: 7 BaseType int
-      Data: 96 GoStringDataType string.str
+      Data: 43 GoStringDataType string.str
     - __kind: GoStringDataType
-      ID: 96
+      ID: 43
       Name: string.str
       ByteSize: 2048
     - __kind: StructureType
-      ID: 70
-      Name: sync.Mutex
-      ByteSize: 8
-      GoRuntimeType: 1.493632e+06
-      GoKind: 25
-      RawFields:
-        - Name: _
-          Offset: 0
-          Type: 71 StructureType sync.noCopy
-        - Name: mu
-          Offset: 0
-          Type: 72 StructureType internal/sync.Mutex
-    - __kind: StructureType
-      ID: 69
-      Name: sync.RWMutex
-      ByteSize: 24
-      GoRuntimeType: 1.880896e+06
-      GoKind: 25
-      RawFields:
-        - Name: w
-          Offset: 0
-          Type: 70 StructureType sync.Mutex
-        - Name: writerSem
-          Offset: 8
-          Type: 2 BaseType uint32
-        - Name: readerSem
-          Offset: 12
-          Type: 2 BaseType uint32
-        - Name: readerCount
-          Offset: 16
-          Type: 73 StructureType sync/atomic.Int32
-        - Name: readerWait
-          Offset: 20
-          Type: 73 StructureType sync/atomic.Int32
-    - __kind: StructureType
-      ID: 71
-      Name: sync.noCopy
-      GoRuntimeType: 1.006688e+06
-      GoKind: 25
-      RawFields: []
-    - __kind: StructureType
-      ID: 73
-      Name: sync/atomic.Int32
-      ByteSize: 4
-      GoRuntimeType: 1.494912e+06
-      GoKind: 25
-      RawFields:
-        - Name: _
-          Offset: 0
-          Type: 74 StructureType sync/atomic.noCopy
-        - Name: v
-          Offset: 0
-          Type: 12 BaseType int32
-    - __kind: StructureType
-      ID: 74
-      Name: sync/atomic.noCopy
-      GoRuntimeType: 1.006784e+06
-      GoKind: 25
-      RawFields: []
-    - __kind: StructureType
-      ID: 171
-      Name: table<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
-      ByteSize: 32
-      GoKind: 25
-      RawFields:
-        - Name: used
-          Offset: 0
-          Type: 6 BaseType uint16
-        - Name: capacity
-          Offset: 2
-          Type: 6 BaseType uint16
-        - Name: growthLeft
-          Offset: 4
-          Type: 6 BaseType uint16
-        - Name: localDepth
-          Offset: 6
-          Type: 3 BaseType uint8
-        - Name: index
-          Offset: 8
-          Type: 7 BaseType int
-        - Name: groups
-          Offset: 16
-          Type: 193 GoSwissMapGroupsType groupReference<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
-    - __kind: StructureType
-      ID: 169
+      ID: 89
       Name: table<string,[]*mime/multipart.FileHeader>
       ByteSize: 32
       GoKind: 25
@@ -3235,9 +2283,9 @@ Types:
           Type: 7 BaseType int
         - Name: groups
           Offset: 16
-          Type: 175 GoSwissMapGroupsType groupReference<string,[]*mime/multipart.FileHeader>
+          Type: 90 GoSwissMapGroupsType groupReference<string,[]*mime/multipart.FileHeader>
     - __kind: StructureType
-      ID: 100
+      ID: 73
       Name: table<string,[]string>
       ByteSize: 32
       GoKind: 25
@@ -3259,57 +2307,9 @@ Types:
           Type: 7 BaseType int
         - Name: groups
           Offset: 16
-          Type: 132 GoSwissMapGroupsType groupReference<string,[]string>
+          Type: 74 GoSwissMapGroupsType groupReference<string,[]string>
     - __kind: StructureType
-      ID: 122
-      Name: table<string,float64>
-      ByteSize: 32
-      GoKind: 25
-      RawFields:
-        - Name: used
-          Offset: 0
-          Type: 6 BaseType uint16
-        - Name: capacity
-          Offset: 2
-          Type: 6 BaseType uint16
-        - Name: growthLeft
-          Offset: 4
-          Type: 6 BaseType uint16
-        - Name: localDepth
-          Offset: 6
-          Type: 3 BaseType uint8
-        - Name: index
-          Offset: 8
-          Type: 7 BaseType int
-        - Name: groups
-          Offset: 16
-          Type: 156 GoSwissMapGroupsType groupReference<string,float64>
-    - __kind: StructureType
-      ID: 121
-      Name: table<string,interface {}>
-      ByteSize: 32
-      GoKind: 25
-      RawFields:
-        - Name: used
-          Offset: 0
-          Type: 6 BaseType uint16
-        - Name: capacity
-          Offset: 2
-          Type: 6 BaseType uint16
-        - Name: growthLeft
-          Offset: 4
-          Type: 6 BaseType uint16
-        - Name: localDepth
-          Offset: 6
-          Type: 3 BaseType uint8
-        - Name: index
-          Offset: 8
-          Type: 7 BaseType int
-        - Name: groups
-          Offset: 16
-          Type: 148 GoSwissMapGroupsType groupReference<string,interface {}>
-    - __kind: StructureType
-      ID: 120
+      ID: 206
       Name: table<string,string>
       ByteSize: 32
       GoKind: 25
@@ -3331,9 +2331,9 @@ Types:
           Type: 7 BaseType int
         - Name: groups
           Offset: 16
-          Type: 141 GoSwissMapGroupsType groupReference<string,string>
+          Type: 207 GoSwissMapGroupsType groupReference<string,string>
     - __kind: StructureType
-      ID: 212
+      ID: 135
       Name: time.Location
       ByteSize: 104
       GoRuntimeType: 2.013984e+06
@@ -3344,10 +2344,10 @@ Types:
           Type: 9 GoStringHeaderType string
         - Name: zone
           Offset: 16
-          Type: 248 GoSliceHeaderType []time.zone
+          Type: 167 GoSliceHeaderType []time.zone
         - Name: tx
           Offset: 40
-          Type: 251 GoSliceHeaderType []time.zoneTrans
+          Type: 170 GoSliceHeaderType []time.zoneTrans
         - Name: extend
           Offset: 64
           Type: 9 GoStringHeaderType string
@@ -3359,9 +2359,9 @@ Types:
           Type: 13 BaseType int64
         - Name: cacheZone
           Offset: 96
-          Type: 249 PointerType *time.zone
+          Type: 168 PointerType *time.zone
     - __kind: StructureType
-      ID: 210
+      ID: 133
       Name: time.Time
       ByteSize: 24
       GoRuntimeType: 2.428992e+06
@@ -3375,9 +2375,9 @@ Types:
           Type: 13 BaseType int64
         - Name: loc
           Offset: 16
-          Type: 211 PointerType *time.Location
+          Type: 134 PointerType *time.Location
     - __kind: StructureType
-      ID: 250
+      ID: 169
       Name: time.zone
       ByteSize: 32
       GoRuntimeType: 1.646944e+06
@@ -3393,7 +2393,7 @@ Types:
           Offset: 24
           Type: 4 BaseType bool
     - __kind: StructureType
-      ID: 253
+      ID: 172
       Name: time.zoneTrans
       ByteSize: 16
       GoRuntimeType: 1.788928e+06
@@ -3453,6 +2453,6 @@ Types:
       ByteSize: 8
       GoRuntimeType: 595072
       GoKind: 26
-MaxTypeID: 295
+MaxTypeID: 215
 Issues: []
 GoModuledataInfo: {FirstModuledataAddr: "0x139d860", TypesOffset: 296}

--- a/pkg/dyninst/irgen/testdata/snapshot/rc_tester.arch=arm64,toolchain=go1.25.0.yaml
+++ b/pkg/dyninst/irgen/testdata/snapshot/rc_tester.arch=arm64,toolchain=go1.25.0.yaml
@@ -97,435 +97,437 @@ Subprograms:
           IsParameter: true
           IsReturn: false
 Types:
-    - __kind: GoInterfaceType
-      ID: 1
-      Name: net/http.ResponseWriter
-      ByteSize: 16
-      GoRuntimeType: 1.210144e+06
-      GoKind: 20
-      RawFields:
-        - Name: tab
-          Offset: 0
-          Type: 2 VoidPointerType unsafe.Pointer
-        - Name: data
-          Offset: 8
-          Type: 2 VoidPointerType unsafe.Pointer
-    - __kind: VoidPointerType
-      ID: 2
-      Name: unsafe.Pointer
-      ByteSize: 8
-      GoRuntimeType: 595072
-      GoKind: 26
     - __kind: PointerType
-      ID: 3
-      Name: '*net/http.Request'
+      ID: 58
+      Name: '**crypto/x509.Certificate'
       ByteSize: 8
-      GoRuntimeType: 2.364736e+06
       GoKind: 22
-      Pointee: 4 StructureType net/http.Request
-    - __kind: StructureType
-      ID: 4
-      Name: net/http.Request
-      ByteSize: 304
-      GoRuntimeType: 2.40112e+06
-      GoKind: 25
-      RawFields:
-        - Name: Method
-          Offset: 0
-          Type: 5 GoStringHeaderType string
-        - Name: URL
-          Offset: 16
-          Type: 9 PointerType *net/url.URL
-        - Name: Proto
-          Offset: 24
-          Type: 5 GoStringHeaderType string
-        - Name: ProtoMajor
-          Offset: 40
-          Type: 8 BaseType int
-        - Name: ProtoMinor
-          Offset: 48
-          Type: 8 BaseType int
-        - Name: Header
-          Offset: 56
-          Type: 14 GoMapType net/http.Header
-        - Name: Body
-          Offset: 64
-          Type: 30 GoInterfaceType io.ReadCloser
-        - Name: GetBody
-          Offset: 80
-          Type: 31 GoSubroutineType func() (io.ReadCloser, error)
-        - Name: ContentLength
-          Offset: 88
-          Type: 32 BaseType int64
-        - Name: TransferEncoding
-          Offset: 96
-          Type: 28 GoSliceHeaderType []string
-        - Name: Close
-          Offset: 120
-          Type: 13 BaseType bool
-        - Name: Host
-          Offset: 128
-          Type: 5 GoStringHeaderType string
-        - Name: Form
-          Offset: 144
-          Type: 33 GoMapType net/url.Values
-        - Name: PostForm
-          Offset: 152
-          Type: 33 GoMapType net/url.Values
-        - Name: MultipartForm
-          Offset: 160
-          Type: 34 PointerType *mime/multipart.Form
-        - Name: Trailer
-          Offset: 168
-          Type: 14 GoMapType net/http.Header
-        - Name: RemoteAddr
-          Offset: 176
-          Type: 5 GoStringHeaderType string
-        - Name: RequestURI
-          Offset: 192
-          Type: 5 GoStringHeaderType string
-        - Name: TLS
-          Offset: 208
-          Type: 54 PointerType *crypto/tls.ConnectionState
-        - Name: Cancel
-          Offset: 216
-          Type: 115 GoChannelType <-chan struct {}
-        - Name: Response
-          Offset: 224
-          Type: 116 PointerType *net/http.Response
-        - Name: Pattern
-          Offset: 232
-          Type: 5 GoStringHeaderType string
-        - Name: ctx
-          Offset: 248
-          Type: 118 GoInterfaceType context.Context
-        - Name: pat
-          Offset: 264
-          Type: 119 PointerType *net/http.pattern
-        - Name: matches
-          Offset: 272
-          Type: 28 GoSliceHeaderType []string
-        - Name: otherValues
-          Offset: 296
-          Type: 124 GoMapType map[string]string
-    - __kind: GoStringHeaderType
-      ID: 5
-      Name: string
-      ByteSize: 16
-      GoRuntimeType: 593984
-      GoKind: 24
-      RawFields:
-        - Name: str
-          Offset: 0
-          Type: 229 PointerType *string.str
-        - Name: len
-          Offset: 8
-          Type: 8 BaseType int
-      Data: 228 GoStringDataType string.str
+      Pointee: 59 PointerType *crypto/x509.Certificate
     - __kind: PointerType
-      ID: 6
-      Name: '*uint8'
+      ID: 201
+      Name: '**github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span'
       ByteSize: 8
-      GoRuntimeType: 404480
       GoKind: 22
-      Pointee: 7 BaseType uint8
-    - __kind: BaseType
-      ID: 7
-      Name: uint8
-      ByteSize: 1
-      GoRuntimeType: 594112
-      GoKind: 8
-    - __kind: BaseType
-      ID: 8
-      Name: int
-      ByteSize: 8
-      GoRuntimeType: 594560
-      GoKind: 2
+      Pointee: 135 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span
     - __kind: PointerType
-      ID: 9
-      Name: '*net/url.URL'
+      ID: 191
+      Name: '**github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttributeValue'
       ByteSize: 8
-      GoRuntimeType: 2.16656e+06
       GoKind: 22
-      Pointee: 10 StructureType net/url.URL
-    - __kind: StructureType
-      ID: 10
-      Name: net/url.URL
-      ByteSize: 144
-      GoRuntimeType: 2.180864e+06
-      GoKind: 25
-      RawFields:
-        - Name: Scheme
-          Offset: 0
-          Type: 5 GoStringHeaderType string
-        - Name: Opaque
-          Offset: 16
-          Type: 5 GoStringHeaderType string
-        - Name: User
-          Offset: 32
-          Type: 11 PointerType *net/url.Userinfo
-        - Name: Host
-          Offset: 40
-          Type: 5 GoStringHeaderType string
-        - Name: Path
-          Offset: 56
-          Type: 5 GoStringHeaderType string
-        - Name: RawPath
-          Offset: 72
-          Type: 5 GoStringHeaderType string
-        - Name: OmitHost
-          Offset: 88
-          Type: 13 BaseType bool
-        - Name: ForceQuery
-          Offset: 89
-          Type: 13 BaseType bool
-        - Name: RawQuery
-          Offset: 96
-          Type: 5 GoStringHeaderType string
-        - Name: Fragment
-          Offset: 112
-          Type: 5 GoStringHeaderType string
-        - Name: RawFragment
-          Offset: 128
-          Type: 5 GoStringHeaderType string
+      Pointee: 192 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttributeValue
     - __kind: PointerType
-      ID: 11
-      Name: '*net/url.Userinfo'
+      ID: 49
+      Name: '**mime/multipart.FileHeader'
       ByteSize: 8
-      GoRuntimeType: 1.225376e+06
       GoKind: 22
-      Pointee: 12 StructureType net/url.Userinfo
-    - __kind: StructureType
-      ID: 12
-      Name: net/url.Userinfo
-      ByteSize: 40
-      GoRuntimeType: 1.65808e+06
-      GoKind: 25
-      RawFields:
-        - Name: username
-          Offset: 0
-          Type: 5 GoStringHeaderType string
-        - Name: password
-          Offset: 16
-          Type: 5 GoStringHeaderType string
-        - Name: passwordSet
-          Offset: 32
-          Type: 13 BaseType bool
-    - __kind: BaseType
-      ID: 13
-      Name: bool
-      ByteSize: 1
-      GoRuntimeType: 595008
-      GoKind: 1
-    - __kind: GoMapType
-      ID: 14
-      Name: net/http.Header
-      ByteSize: 8
-      GoRuntimeType: 2.154272e+06
-      GoKind: 21
-      HeaderType: 16 GoSwissMapHeaderType map<string,[]string>
+      Pointee: 50 PointerType *mime/multipart.FileHeader
     - __kind: PointerType
-      ID: 15
-      Name: '*map<string,[]string>'
+      ID: 99
+      Name: '**net.IPNet'
       ByteSize: 8
-      Pointee: 16 GoSwissMapHeaderType map<string,[]string>
-    - __kind: GoSwissMapHeaderType
-      ID: 16
-      Name: map<string,[]string>
-      ByteSize: 48
-      GoKind: 25
-      RawFields:
-        - Name: used
-          Offset: 0
-          Type: 17 BaseType uint64
-        - Name: seed
-          Offset: 8
-          Type: 18 BaseType uintptr
-        - Name: dirPtr
-          Offset: 16
-          Type: 19 PointerType **table<string,[]string>
-        - Name: dirLen
-          Offset: 24
-          Type: 8 BaseType int
-        - Name: globalDepth
-          Offset: 32
-          Type: 7 BaseType uint8
-        - Name: globalShift
-          Offset: 33
-          Type: 7 BaseType uint8
-        - Name: writing
-          Offset: 34
-          Type: 7 BaseType uint8
-        - Name: tombstonePossible
-          Offset: 35
-          Type: 13 BaseType bool
-        - Name: clearSeq
-          Offset: 40
-          Type: 17 BaseType uint64
-      TablePtrSliceType: 230 GoSliceDataType []*table<string,[]string>.array
-      GroupType: 25 StructureType noalg.map.group[string][]string
-    - __kind: BaseType
-      ID: 17
-      Name: uint64
+      GoKind: 22
+      Pointee: 100 PointerType *net.IPNet
+    - __kind: PointerType
+      ID: 97
+      Name: '**net/url.URL'
       ByteSize: 8
-      GoRuntimeType: 594496
-      GoKind: 11
-    - __kind: BaseType
-      ID: 18
-      Name: uintptr
+      Pointee: 9 PointerType *net/url.URL
+    - __kind: PointerType
+      ID: 177
+      Name: '**table<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>'
       ByteSize: 8
-      GoRuntimeType: 594688
-      GoKind: 12
+      Pointee: 178 PointerType *table<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
+    - __kind: PointerType
+      ID: 40
+      Name: '**table<string,[]*mime/multipart.FileHeader>'
+      ByteSize: 8
+      Pointee: 41 PointerType *table<string,[]*mime/multipart.FileHeader>
     - __kind: PointerType
       ID: 19
       Name: '**table<string,[]string>'
       ByteSize: 8
       Pointee: 20 PointerType *table<string,[]string>
     - __kind: PointerType
-      ID: 20
-      Name: '*table<string,[]string>'
+      ID: 159
+      Name: '**table<string,float64>'
       ByteSize: 8
-      Pointee: 21 StructureType table<string,[]string>
-    - __kind: StructureType
-      ID: 21
-      Name: table<string,[]string>
-      ByteSize: 32
-      GoKind: 25
-      RawFields:
-        - Name: used
-          Offset: 0
-          Type: 22 BaseType uint16
-        - Name: capacity
-          Offset: 2
-          Type: 22 BaseType uint16
-        - Name: growthLeft
-          Offset: 4
-          Type: 22 BaseType uint16
-        - Name: localDepth
-          Offset: 6
-          Type: 7 BaseType uint8
-        - Name: index
-          Offset: 8
-          Type: 8 BaseType int
-        - Name: groups
-          Offset: 16
-          Type: 23 GoSwissMapGroupsType groupReference<string,[]string>
-    - __kind: BaseType
-      ID: 22
-      Name: uint16
-      ByteSize: 2
-      GoRuntimeType: 594240
-      GoKind: 9
-    - __kind: GoSwissMapGroupsType
-      ID: 23
-      Name: groupReference<string,[]string>
-      ByteSize: 16
-      GoKind: 25
-      RawFields:
-        - Name: data
-          Offset: 0
-          Type: 24 PointerType *noalg.map.group[string][]string
-        - Name: lengthMask
-          Offset: 8
-          Type: 17 BaseType uint64
-      GroupType: 25 StructureType noalg.map.group[string][]string
-      GroupSliceType: 231 GoSliceDataType []noalg.map.group[string][]string.array
+      Pointee: 160 PointerType *table<string,float64>
     - __kind: PointerType
-      ID: 24
-      Name: '*noalg.map.group[string][]string'
+      ID: 148
+      Name: '**table<string,interface {}>'
       ByteSize: 8
-      Pointee: 25 StructureType noalg.map.group[string][]string
-    - __kind: StructureType
-      ID: 25
-      Name: noalg.map.group[string][]string
-      ByteSize: 328
-      GoRuntimeType: 1.315936e+06
-      GoKind: 25
-      RawFields:
-        - Name: ctrl
-          Offset: 0
-          Type: 17 BaseType uint64
-        - Name: slots
-          Offset: 8
-          Type: 26 ArrayType noalg.[8]struct { key string; elem []string }
-    - __kind: ArrayType
-      ID: 26
-      Name: noalg.[8]struct { key string; elem []string }
-      ByteSize: 320
-      GoRuntimeType: 700896
-      GoKind: 17
-      Count: 8
-      HasCount: true
-      Element: 27 StructureType noalg.struct { key string; elem []string }
-    - __kind: StructureType
-      ID: 27
-      Name: noalg.struct { key string; elem []string }
-      ByteSize: 40
-      GoRuntimeType: 1.315808e+06
-      GoKind: 25
-      RawFields:
-        - Name: key
-          Offset: 0
-          Type: 5 GoStringHeaderType string
-        - Name: elem
-          Offset: 16
-          Type: 28 GoSliceHeaderType []string
-    - __kind: GoSliceHeaderType
-      ID: 28
-      Name: '[]string'
-      ByteSize: 24
-      GoRuntimeType: 501280
-      GoKind: 23
-      RawFields:
-        - Name: array
-          Offset: 0
-          Type: 29 PointerType *string
-        - Name: len
-          Offset: 8
-          Type: 8 BaseType int
-        - Name: cap
-          Offset: 16
-          Type: 8 BaseType int
-      Data: 232 GoSliceDataType []string.array
+      Pointee: 149 PointerType *table<string,interface {}>
     - __kind: PointerType
-      ID: 29
-      Name: '*string'
+      ID: 127
+      Name: '**table<string,string>'
       ByteSize: 8
-      GoRuntimeType: 404352
+      Pointee: 128 PointerType *table<string,string>
+    - __kind: PointerType
+      ID: 110
+      Name: '*[]*crypto/x509.Certificate'
+      ByteSize: 8
       GoKind: 22
-      Pointee: 5 GoStringHeaderType string
-    - __kind: GoInterfaceType
-      ID: 30
-      Name: io.ReadCloser
-      ByteSize: 16
-      GoRuntimeType: 1.134464e+06
-      GoKind: 20
-      RawFields:
-        - Name: tab
-          Offset: 0
-          Type: 2 VoidPointerType unsafe.Pointer
-        - Name: data
-          Offset: 8
-          Type: 2 VoidPointerType unsafe.Pointer
-    - __kind: GoSubroutineType
-      ID: 31
-      Name: func() (io.ReadCloser, error)
+      Pointee: 57 GoSliceHeaderType []*crypto/x509.Certificate
+    - __kind: PointerType
+      ID: 241
+      Name: '*[]*crypto/x509.Certificate.array'
       ByteSize: 8
-      GoRuntimeType: 704864
-      GoKind: 19
-    - __kind: BaseType
-      ID: 32
-      Name: int64
+      Pointee: 240 GoSliceDataType []*crypto/x509.Certificate.array
+    - __kind: PointerType
+      ID: 293
+      Name: '*[]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span.array'
       ByteSize: 8
-      GoRuntimeType: 594432
-      GoKind: 6
-    - __kind: GoMapType
-      ID: 33
-      Name: net/url.Values
+      Pointee: 292 GoSliceDataType []*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span.array
+    - __kind: PointerType
+      ID: 291
+      Name: '*[]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttributeValue.array'
       ByteSize: 8
-      GoRuntimeType: 1.927712e+06
-      GoKind: 21
-      HeaderType: 16 GoSwissMapHeaderType map<string,[]string>
+      Pointee: 290 GoSliceDataType []*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttributeValue.array
+    - __kind: PointerType
+      ID: 237
+      Name: '*[]*mime/multipart.FileHeader.array'
+      ByteSize: 8
+      Pointee: 236 GoSliceDataType []*mime/multipart.FileHeader.array
+    - __kind: PointerType
+      ID: 265
+      Name: '*[]*net.IPNet.array'
+      ByteSize: 8
+      Pointee: 264 GoSliceDataType []*net.IPNet.array
+    - __kind: PointerType
+      ID: 263
+      Name: '*[]*net/url.URL.array'
+      ByteSize: 8
+      Pointee: 262 GoSliceDataType []*net/url.URL.array
+    - __kind: PointerType
+      ID: 273
+      Name: '*[][]*crypto/x509.Certificate.array'
+      ByteSize: 8
+      Pointee: 272 GoSliceDataType [][]*crypto/x509.Certificate.array
+    - __kind: PointerType
+      ID: 275
+      Name: '*[][]uint8.array'
+      ByteSize: 8
+      Pointee: 274 GoSliceDataType [][]uint8.array
+    - __kind: PointerType
+      ID: 257
+      Name: '*[]crypto/x509.ExtKeyUsage.array'
+      ByteSize: 8
+      Pointee: 256 GoSliceDataType []crypto/x509.ExtKeyUsage.array
+    - __kind: PointerType
+      ID: 269
+      Name: '*[]crypto/x509.OID.array'
+      ByteSize: 8
+      Pointee: 268 GoSliceDataType []crypto/x509.OID.array
+    - __kind: PointerType
+      ID: 271
+      Name: '*[]crypto/x509.PolicyMapping.array'
+      ByteSize: 8
+      Pointee: 270 GoSliceDataType []crypto/x509.PolicyMapping.array
+    - __kind: PointerType
+      ID: 245
+      Name: '*[]crypto/x509/pkix.AttributeTypeAndValue.array'
+      ByteSize: 8
+      Pointee: 244 GoSliceDataType []crypto/x509/pkix.AttributeTypeAndValue.array
+    - __kind: PointerType
+      ID: 253
+      Name: '*[]crypto/x509/pkix.Extension.array'
+      ByteSize: 8
+      Pointee: 252 GoSliceDataType []crypto/x509/pkix.Extension.array
+    - __kind: PointerType
+      ID: 255
+      Name: '*[]encoding/asn1.ObjectIdentifier.array'
+      ByteSize: 8
+      Pointee: 254 GoSliceDataType []encoding/asn1.ObjectIdentifier.array
+    - __kind: PointerType
+      ID: 285
+      Name: '*[]github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink.array'
+      ByteSize: 8
+      Pointee: 284 GoSliceDataType []github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink.array
+    - __kind: PointerType
+      ID: 287
+      Name: '*[]github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent.array'
+      ByteSize: 8
+      Pointee: 286 GoSliceDataType []github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent.array
+    - __kind: PointerType
+      ID: 259
+      Name: '*[]net.IP.array'
+      ByteSize: 8
+      Pointee: 258 GoSliceDataType []net.IP.array
+    - __kind: PointerType
+      ID: 277
+      Name: '*[]net/http.segment.array'
+      ByteSize: 8
+      Pointee: 276 GoSliceDataType []net/http.segment.array
+    - __kind: PointerType
+      ID: 233
+      Name: '*[]string.array'
+      ByteSize: 8
+      Pointee: 232 GoSliceDataType []string.array
+    - __kind: PointerType
+      ID: 249
+      Name: '*[]time.zone.array'
+      ByteSize: 8
+      Pointee: 248 GoSliceDataType []time.zone.array
+    - __kind: PointerType
+      ID: 251
+      Name: '*[]time.zoneTrans.array'
+      ByteSize: 8
+      Pointee: 250 GoSliceDataType []time.zoneTrans.array
+    - __kind: PointerType
+      ID: 112
+      Name: '*[]uint8'
+      ByteSize: 8
+      GoRuntimeType: 486400
+      GoKind: 22
+      Pointee: 53 GoSliceHeaderType []uint8
+    - __kind: PointerType
+      ID: 239
+      Name: '*[]uint8.array'
+      ByteSize: 8
+      Pointee: 238 GoSliceDataType []uint8.array
+    - __kind: PointerType
+      ID: 210
+      Name: '*bool'
+      ByteSize: 8
+      GoRuntimeType: 405376
+      GoKind: 22
+      Pointee: 13 BaseType bool
+    - __kind: PointerType
+      ID: 206
+      Name: '*bytes.Buffer'
+      ByteSize: 8
+      GoRuntimeType: 2.320608e+06
+      GoKind: 22
+      Pointee: 207 StructureType bytes.Buffer
+    - __kind: PointerType
+      ID: 54
+      Name: '*crypto/tls.ConnectionState'
+      ByteSize: 8
+      GoRuntimeType: 923424
+      GoKind: 22
+      Pointee: 55 StructureType crypto/tls.ConnectionState
+    - __kind: PointerType
+      ID: 59
+      Name: '*crypto/x509.Certificate'
+      ByteSize: 8
+      GoRuntimeType: 2.088896e+06
+      GoKind: 22
+      Pointee: 60 StructureType crypto/x509.Certificate
+    - __kind: PointerType
+      ID: 91
+      Name: '*crypto/x509.ExtKeyUsage'
+      ByteSize: 8
+      GoRuntimeType: 429824
+      GoKind: 22
+      Pointee: 92 BaseType crypto/x509.ExtKeyUsage
+    - __kind: PointerType
+      ID: 104
+      Name: '*crypto/x509.OID'
+      ByteSize: 8
+      GoRuntimeType: 1.997344e+06
+      GoKind: 22
+      Pointee: 105 StructureType crypto/x509.OID
+    - __kind: PointerType
+      ID: 107
+      Name: '*crypto/x509.PolicyMapping'
+      ByteSize: 8
+      GoRuntimeType: 429888
+      GoKind: 22
+      Pointee: 108 StructureType crypto/x509.PolicyMapping
+    - __kind: PointerType
+      ID: 71
+      Name: '*crypto/x509/pkix.AttributeTypeAndValue'
+      ByteSize: 8
+      GoRuntimeType: 446528
+      GoKind: 22
+      Pointee: 72 StructureType crypto/x509/pkix.AttributeTypeAndValue
+    - __kind: PointerType
+      ID: 86
+      Name: '*crypto/x509/pkix.Extension'
+      ByteSize: 8
+      GoRuntimeType: 446720
+      GoKind: 22
+      Pointee: 87 StructureType crypto/x509/pkix.Extension
+    - __kind: PointerType
+      ID: 89
+      Name: '*encoding/asn1.ObjectIdentifier'
+      ByteSize: 8
+      GoRuntimeType: 1.079072e+06
+      GoKind: 22
+      Pointee: 73 GoSliceHeaderType encoding/asn1.ObjectIdentifier
+    - __kind: PointerType
+      ID: 247
+      Name: '*encoding/asn1.ObjectIdentifier.array'
+      ByteSize: 8
+      Pointee: 246 GoSliceDataType encoding/asn1.ObjectIdentifier.array
+    - __kind: PointerType
+      ID: 225
+      Name: '*error'
+      ByteSize: 8
+      GoRuntimeType: 404288
+      GoKind: 22
+      Pointee: 211 GoInterfaceType error
+    - __kind: PointerType
+      ID: 227
+      Name: '*float32'
+      ByteSize: 8
+      GoRuntimeType: 405248
+      GoKind: 22
+      Pointee: 213 BaseType float32
+    - __kind: PointerType
+      ID: 202
+      Name: '*float64'
+      ByteSize: 8
+      GoRuntimeType: 405312
+      GoKind: 22
+      Pointee: 167 BaseType float64
+    - __kind: PointerType
+      ID: 135
+      Name: '*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span'
+      ByteSize: 8
+      GoRuntimeType: 2.331872e+06
+      GoKind: 22
+      Pointee: 136 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span
+    - __kind: PointerType
+      ID: 196
+      Name: '*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanContext'
+      ByteSize: 8
+      GoRuntimeType: 2.053568e+06
+      GoKind: 22
+      Pointee: 197 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanContext
+    - __kind: PointerType
+      ID: 169
+      Name: '*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink'
+      ByteSize: 8
+      GoRuntimeType: 1.213856e+06
+      GoKind: 22
+      Pointee: 170 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink
+    - __kind: PointerType
+      ID: 172
+      Name: '*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent'
+      ByteSize: 8
+      GoRuntimeType: 1.213984e+06
+      GoKind: 22
+      Pointee: 173 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent
+    - __kind: PointerType
+      ID: 188
+      Name: '*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttribute'
+      ByteSize: 8
+      GoRuntimeType: 1.214624e+06
+      GoKind: 22
+      Pointee: 189 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttribute
+    - __kind: PointerType
+      ID: 192
+      Name: '*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttributeValue'
+      ByteSize: 8
+      GoRuntimeType: 1.214368e+06
+      GoKind: 22
+      Pointee: 193 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttributeValue
+    - __kind: PointerType
+      ID: 185
+      Name: '*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute'
+      ByteSize: 8
+      GoRuntimeType: 1.214752e+06
+      GoKind: 22
+      Pointee: 186 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
+    - __kind: PointerType
+      ID: 198
+      Name: '*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.trace'
+      ByteSize: 8
+      GoRuntimeType: 2.2768e+06
+      GoKind: 22
+      Pointee: 199 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.trace
+    - __kind: PointerType
+      ID: 74
+      Name: '*int'
+      ByteSize: 8
+      GoRuntimeType: 404928
+      GoKind: 22
+      Pointee: 8 BaseType int
+    - __kind: PointerType
+      ID: 223
+      Name: '*int16'
+      ByteSize: 8
+      GoRuntimeType: 404544
+      GoKind: 22
+      Pointee: 217 BaseType int16
+    - __kind: PointerType
+      ID: 215
+      Name: '*int32'
+      ByteSize: 8
+      GoRuntimeType: 404672
+      GoKind: 22
+      Pointee: 141 BaseType int32
+    - __kind: PointerType
+      ID: 221
+      Name: '*int64'
+      ByteSize: 8
+      GoRuntimeType: 404800
+      GoKind: 22
+      Pointee: 32 BaseType int64
+    - __kind: PointerType
+      ID: 224
+      Name: '*int8'
+      ByteSize: 8
+      GoRuntimeType: 404416
+      GoKind: 22
+      Pointee: 212 BaseType int8
+    - __kind: PointerType
+      ID: 175
+      Name: '*map<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>'
+      ByteSize: 8
+      Pointee: 176 GoSwissMapHeaderType map<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
+    - __kind: PointerType
+      ID: 38
+      Name: '*map<string,[]*mime/multipart.FileHeader>'
+      ByteSize: 8
+      Pointee: 39 GoSwissMapHeaderType map<string,[]*mime/multipart.FileHeader>
+    - __kind: PointerType
+      ID: 15
+      Name: '*map<string,[]string>'
+      ByteSize: 8
+      Pointee: 16 GoSwissMapHeaderType map<string,[]string>
+    - __kind: PointerType
+      ID: 157
+      Name: '*map<string,float64>'
+      ByteSize: 8
+      Pointee: 158 GoSwissMapHeaderType map<string,float64>
+    - __kind: PointerType
+      ID: 146
+      Name: '*map<string,interface {}>'
+      ByteSize: 8
+      Pointee: 147 GoSwissMapHeaderType map<string,interface {}>
+    - __kind: PointerType
+      ID: 125
+      Name: '*map<string,string>'
+      ByteSize: 8
+      Pointee: 126 GoSwissMapHeaderType map<string,string>
+    - __kind: PointerType
+      ID: 64
+      Name: '*math/big.Int'
+      ByteSize: 8
+      GoRuntimeType: 2.446656e+06
+      GoKind: 22
+      Pointee: 65 StructureType math/big.Int
+    - __kind: PointerType
+      ID: 67
+      Name: '*math/big.Word'
+      ByteSize: 8
+      GoRuntimeType: 432640
+      GoKind: 22
+      Pointee: 68 BaseType math/big.Word
+    - __kind: PointerType
+      ID: 243
+      Name: '*math/big.nat.array'
+      ByteSize: 8
+      Pointee: 242 GoSliceDataType math/big.nat.array
+    - __kind: PointerType
+      ID: 50
+      Name: '*mime/multipart.FileHeader'
+      ByteSize: 8
+      GoRuntimeType: 924960
+      GoKind: 22
+      Pointee: 51 StructureType mime/multipart.FileHeader
     - __kind: PointerType
       ID: 34
       Name: '*mime/multipart.Form'
@@ -533,161 +535,317 @@ Types:
       GoRuntimeType: 925056
       GoKind: 22
       Pointee: 35 StructureType mime/multipart.Form
-    - __kind: StructureType
-      ID: 35
-      Name: mime/multipart.Form
-      ByteSize: 16
-      GoRuntimeType: 1.505952e+06
-      GoKind: 25
-      RawFields:
-        - Name: Value
-          Offset: 0
-          Type: 36 GoMapType map[string][]string
-        - Name: File
-          Offset: 8
-          Type: 37 GoMapType map[string][]*mime/multipart.FileHeader
-    - __kind: GoMapType
-      ID: 36
-      Name: map[string][]string
-      ByteSize: 8
-      GoRuntimeType: 1.152512e+06
-      GoKind: 21
-      HeaderType: 16 GoSwissMapHeaderType map<string,[]string>
-    - __kind: GoMapType
-      ID: 37
-      Name: map[string][]*mime/multipart.FileHeader
-      ByteSize: 8
-      GoRuntimeType: 1.156864e+06
-      GoKind: 21
-      HeaderType: 39 GoSwissMapHeaderType map<string,[]*mime/multipart.FileHeader>
     - __kind: PointerType
-      ID: 38
-      Name: '*map<string,[]*mime/multipart.FileHeader>'
+      ID: 94
+      Name: '*net.IP'
       ByteSize: 8
-      Pointee: 39 GoSwissMapHeaderType map<string,[]*mime/multipart.FileHeader>
-    - __kind: GoSwissMapHeaderType
-      ID: 39
-      Name: map<string,[]*mime/multipart.FileHeader>
-      ByteSize: 48
-      GoKind: 25
-      RawFields:
-        - Name: used
-          Offset: 0
-          Type: 17 BaseType uint64
-        - Name: seed
-          Offset: 8
-          Type: 18 BaseType uintptr
-        - Name: dirPtr
-          Offset: 16
-          Type: 40 PointerType **table<string,[]*mime/multipart.FileHeader>
-        - Name: dirLen
-          Offset: 24
-          Type: 8 BaseType int
-        - Name: globalDepth
-          Offset: 32
-          Type: 7 BaseType uint8
-        - Name: globalShift
-          Offset: 33
-          Type: 7 BaseType uint8
-        - Name: writing
-          Offset: 34
-          Type: 7 BaseType uint8
-        - Name: tombstonePossible
-          Offset: 35
-          Type: 13 BaseType bool
-        - Name: clearSeq
-          Offset: 40
-          Type: 17 BaseType uint64
-      TablePtrSliceType: 234 GoSliceDataType []*table<string,[]*mime/multipart.FileHeader>.array
-      GroupType: 45 StructureType noalg.map.group[string][]*mime/multipart.FileHeader
+      GoRuntimeType: 2.206144e+06
+      GoKind: 22
+      Pointee: 95 GoSliceHeaderType net.IP
     - __kind: PointerType
-      ID: 40
-      Name: '**table<string,[]*mime/multipart.FileHeader>'
+      ID: 261
+      Name: '*net.IP.array'
       ByteSize: 8
-      Pointee: 41 PointerType *table<string,[]*mime/multipart.FileHeader>
+      Pointee: 260 GoSliceDataType net.IP.array
     - __kind: PointerType
-      ID: 41
-      Name: '*table<string,[]*mime/multipart.FileHeader>'
+      ID: 267
+      Name: '*net.IPMask.array'
       ByteSize: 8
-      Pointee: 42 StructureType table<string,[]*mime/multipart.FileHeader>
-    - __kind: StructureType
-      ID: 42
-      Name: table<string,[]*mime/multipart.FileHeader>
-      ByteSize: 32
-      GoKind: 25
-      RawFields:
-        - Name: used
-          Offset: 0
-          Type: 22 BaseType uint16
-        - Name: capacity
-          Offset: 2
-          Type: 22 BaseType uint16
-        - Name: growthLeft
-          Offset: 4
-          Type: 22 BaseType uint16
-        - Name: localDepth
-          Offset: 6
-          Type: 7 BaseType uint8
-        - Name: index
-          Offset: 8
-          Type: 8 BaseType int
-        - Name: groups
-          Offset: 16
-          Type: 43 GoSwissMapGroupsType groupReference<string,[]*mime/multipart.FileHeader>
-    - __kind: GoSwissMapGroupsType
-      ID: 43
-      Name: groupReference<string,[]*mime/multipart.FileHeader>
-      ByteSize: 16
-      GoKind: 25
-      RawFields:
-        - Name: data
-          Offset: 0
-          Type: 44 PointerType *noalg.map.group[string][]*mime/multipart.FileHeader
-        - Name: lengthMask
-          Offset: 8
-          Type: 17 BaseType uint64
-      GroupType: 45 StructureType noalg.map.group[string][]*mime/multipart.FileHeader
-      GroupSliceType: 235 GoSliceDataType []noalg.map.group[string][]*mime/multipart.FileHeader.array
+      Pointee: 266 GoSliceDataType net.IPMask.array
+    - __kind: PointerType
+      ID: 100
+      Name: '*net.IPNet'
+      ByteSize: 8
+      GoRuntimeType: 1.207712e+06
+      GoKind: 22
+      Pointee: 101 StructureType net.IPNet
+    - __kind: PointerType
+      ID: 3
+      Name: '*net/http.Request'
+      ByteSize: 8
+      GoRuntimeType: 2.364736e+06
+      GoKind: 22
+      Pointee: 4 StructureType net/http.Request
+    - __kind: PointerType
+      ID: 116
+      Name: '*net/http.Response'
+      ByteSize: 8
+      GoRuntimeType: 1.757856e+06
+      GoKind: 22
+      Pointee: 117 StructureType net/http.Response
+    - __kind: PointerType
+      ID: 119
+      Name: '*net/http.pattern'
+      ByteSize: 8
+      GoRuntimeType: 1.642144e+06
+      GoKind: 22
+      Pointee: 120 StructureType net/http.pattern
+    - __kind: PointerType
+      ID: 122
+      Name: '*net/http.segment'
+      ByteSize: 8
+      GoRuntimeType: 396288
+      GoKind: 22
+      Pointee: 123 StructureType net/http.segment
+    - __kind: PointerType
+      ID: 9
+      Name: '*net/url.URL'
+      ByteSize: 8
+      GoRuntimeType: 2.16656e+06
+      GoKind: 22
+      Pointee: 10 StructureType net/url.URL
+    - __kind: PointerType
+      ID: 11
+      Name: '*net/url.Userinfo'
+      ByteSize: 8
+      GoRuntimeType: 1.225376e+06
+      GoKind: 22
+      Pointee: 12 StructureType net/url.Userinfo
+    - __kind: PointerType
+      ID: 181
+      Name: '*noalg.map.group[string]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute'
+      ByteSize: 8
+      Pointee: 182 StructureType noalg.map.group[string]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
     - __kind: PointerType
       ID: 44
       Name: '*noalg.map.group[string][]*mime/multipart.FileHeader'
       ByteSize: 8
       Pointee: 45 StructureType noalg.map.group[string][]*mime/multipart.FileHeader
-    - __kind: StructureType
-      ID: 45
-      Name: noalg.map.group[string][]*mime/multipart.FileHeader
-      ByteSize: 328
-      GoRuntimeType: 1.325024e+06
-      GoKind: 25
+    - __kind: PointerType
+      ID: 24
+      Name: '*noalg.map.group[string][]string'
+      ByteSize: 8
+      Pointee: 25 StructureType noalg.map.group[string][]string
+    - __kind: PointerType
+      ID: 163
+      Name: '*noalg.map.group[string]float64'
+      ByteSize: 8
+      Pointee: 164 StructureType noalg.map.group[string]float64
+    - __kind: PointerType
+      ID: 152
+      Name: '*noalg.map.group[string]interface {}'
+      ByteSize: 8
+      Pointee: 153 StructureType noalg.map.group[string]interface {}
+    - __kind: PointerType
+      ID: 131
+      Name: '*noalg.map.group[string]string'
+      ByteSize: 8
+      Pointee: 132 StructureType noalg.map.group[string]string
+    - __kind: PointerType
+      ID: 29
+      Name: '*string'
+      ByteSize: 8
+      GoRuntimeType: 404352
+      GoKind: 22
+      Pointee: 5 GoStringHeaderType string
+    - __kind: PointerType
+      ID: 229
+      Name: '*string.str'
+      ByteSize: 8
+      Pointee: 228 GoStringDataType string.str
+    - __kind: PointerType
+      ID: 178
+      Name: '*table<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>'
+      ByteSize: 8
+      Pointee: 179 StructureType table<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
+    - __kind: PointerType
+      ID: 41
+      Name: '*table<string,[]*mime/multipart.FileHeader>'
+      ByteSize: 8
+      Pointee: 42 StructureType table<string,[]*mime/multipart.FileHeader>
+    - __kind: PointerType
+      ID: 20
+      Name: '*table<string,[]string>'
+      ByteSize: 8
+      Pointee: 21 StructureType table<string,[]string>
+    - __kind: PointerType
+      ID: 160
+      Name: '*table<string,float64>'
+      ByteSize: 8
+      Pointee: 161 StructureType table<string,float64>
+    - __kind: PointerType
+      ID: 149
+      Name: '*table<string,interface {}>'
+      ByteSize: 8
+      Pointee: 150 StructureType table<string,interface {}>
+    - __kind: PointerType
+      ID: 128
+      Name: '*table<string,string>'
+      ByteSize: 8
+      Pointee: 129 StructureType table<string,string>
+    - __kind: PointerType
+      ID: 76
+      Name: '*time.Location'
+      ByteSize: 8
+      GoRuntimeType: 1.647136e+06
+      GoKind: 22
+      Pointee: 77 StructureType time.Location
+    - __kind: PointerType
+      ID: 79
+      Name: '*time.zone'
+      ByteSize: 8
+      GoRuntimeType: 399360
+      GoKind: 22
+      Pointee: 80 StructureType time.zone
+    - __kind: PointerType
+      ID: 82
+      Name: '*time.zoneTrans'
+      ByteSize: 8
+      GoRuntimeType: 399424
+      GoKind: 22
+      Pointee: 83 StructureType time.zoneTrans
+    - __kind: PointerType
+      ID: 226
+      Name: '*uint'
+      ByteSize: 8
+      GoRuntimeType: 404992
+      GoKind: 22
+      Pointee: 209 BaseType uint
+    - __kind: PointerType
+      ID: 222
+      Name: '*uint16'
+      ByteSize: 8
+      GoRuntimeType: 404608
+      GoKind: 22
+      Pointee: 22 BaseType uint16
+    - __kind: PointerType
+      ID: 216
+      Name: '*uint32'
+      ByteSize: 8
+      GoRuntimeType: 404736
+      GoKind: 22
+      Pointee: 142 BaseType uint32
+    - __kind: PointerType
+      ID: 220
+      Name: '*uint64'
+      ByteSize: 8
+      GoRuntimeType: 404864
+      GoKind: 22
+      Pointee: 17 BaseType uint64
+    - __kind: PointerType
+      ID: 6
+      Name: '*uint8'
+      ByteSize: 8
+      GoRuntimeType: 404480
+      GoKind: 22
+      Pointee: 7 BaseType uint8
+    - __kind: PointerType
+      ID: 214
+      Name: '*uintptr'
+      ByteSize: 8
+      GoRuntimeType: 405056
+      GoKind: 22
+      Pointee: 18 BaseType uintptr
+    - __kind: GoChannelType
+      ID: 115
+      Name: <-chan struct {}
+      GoRuntimeType: 607040
+      GoKind: 18
+    - __kind: EventRootType
+      ID: 294
+      Name: Probe[main.HandleHTTP]
+      ByteSize: 25
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: w
+          Offset: 1
+          Expression:
+            Type: 1 GoInterfaceType net/http.ResponseWriter
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 1, index: 0, name: w}
+                  Offset: 0
+                  ByteSize: 16
+        - Name: r
+          Offset: 17
+          Expression:
+            Type: 3 PointerType *net/http.Request
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 1, index: 1, name: r}
+                  Offset: 0
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 295
+      Name: Probe[main.LookAtTheRequest]
+      ByteSize: 17
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: path
+          Offset: 1
+          Expression:
+            Type: 5 GoStringHeaderType string
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 2, index: 0, name: path}
+                  Offset: 0
+                  ByteSize: 16
+    - __kind: GoSliceHeaderType
+      ID: 57
+      Name: '[]*crypto/x509.Certificate'
+      ByteSize: 24
+      GoRuntimeType: 507264
+      GoKind: 23
       RawFields:
-        - Name: ctrl
+        - Name: array
           Offset: 0
-          Type: 17 BaseType uint64
-        - Name: slots
+          Type: 58 PointerType **crypto/x509.Certificate
+        - Name: len
           Offset: 8
-          Type: 46 ArrayType noalg.[8]struct { key string; elem []*mime/multipart.FileHeader }
-    - __kind: ArrayType
-      ID: 46
-      Name: noalg.[8]struct { key string; elem []*mime/multipart.FileHeader }
-      ByteSize: 320
-      GoRuntimeType: 710720
-      GoKind: 17
-      Count: 8
-      HasCount: true
-      Element: 47 StructureType noalg.struct { key string; elem []*mime/multipart.FileHeader }
-    - __kind: StructureType
-      ID: 47
-      Name: noalg.struct { key string; elem []*mime/multipart.FileHeader }
-      ByteSize: 40
-      GoRuntimeType: 1.324896e+06
-      GoKind: 25
-      RawFields:
-        - Name: key
-          Offset: 0
-          Type: 5 GoStringHeaderType string
-        - Name: elem
+          Type: 8 BaseType int
+        - Name: cap
           Offset: 16
-          Type: 48 GoSliceHeaderType []*mime/multipart.FileHeader
+          Type: 8 BaseType int
+      Data: 240 GoSliceDataType []*crypto/x509.Certificate.array
+    - __kind: GoSliceDataType
+      ID: 240
+      Name: '[]*crypto/x509.Certificate.array'
+      ByteSize: 2048
+      Element: 59 PointerType *crypto/x509.Certificate
+    - __kind: GoSliceHeaderType
+      ID: 200
+      Name: '[]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span'
+      ByteSize: 24
+      GoRuntimeType: 495072
+      GoKind: 23
+      RawFields:
+        - Name: array
+          Offset: 0
+          Type: 201 PointerType **github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span
+        - Name: len
+          Offset: 8
+          Type: 8 BaseType int
+        - Name: cap
+          Offset: 16
+          Type: 8 BaseType int
+      Data: 292 GoSliceDataType []*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span.array
+    - __kind: GoSliceDataType
+      ID: 292
+      Name: '[]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span.array'
+      ByteSize: 2048
+      Element: 135 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span
+    - __kind: GoSliceHeaderType
+      ID: 190
+      Name: '[]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttributeValue'
+      ByteSize: 24
+      GoRuntimeType: 494688
+      GoKind: 23
+      RawFields:
+        - Name: array
+          Offset: 0
+          Type: 191 PointerType **github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttributeValue
+        - Name: len
+          Offset: 8
+          Type: 8 BaseType int
+        - Name: cap
+          Offset: 16
+          Type: 8 BaseType int
+      Data: 290 GoSliceDataType []*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttributeValue.array
+    - __kind: GoSliceDataType
+      ID: 290
+      Name: '[]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttributeValue.array'
+      ByteSize: 2048
+      Element: 192 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttributeValue
     - __kind: GoSliceHeaderType
       ID: 48
       Name: '[]*mime/multipart.FileHeader'
@@ -705,54 +863,445 @@ Types:
           Offset: 16
           Type: 8 BaseType int
       Data: 236 GoSliceDataType []*mime/multipart.FileHeader.array
-    - __kind: PointerType
-      ID: 49
-      Name: '**mime/multipart.FileHeader'
-      ByteSize: 8
-      GoKind: 22
-      Pointee: 50 PointerType *mime/multipart.FileHeader
-    - __kind: PointerType
-      ID: 50
-      Name: '*mime/multipart.FileHeader'
-      ByteSize: 8
-      GoRuntimeType: 924960
-      GoKind: 22
-      Pointee: 51 StructureType mime/multipart.FileHeader
-    - __kind: StructureType
-      ID: 51
-      Name: mime/multipart.FileHeader
-      ByteSize: 88
-      GoRuntimeType: 2.018016e+06
-      GoKind: 25
+    - __kind: GoSliceDataType
+      ID: 236
+      Name: '[]*mime/multipart.FileHeader.array'
+      ByteSize: 2048
+      Element: 50 PointerType *mime/multipart.FileHeader
+    - __kind: GoSliceHeaderType
+      ID: 98
+      Name: '[]*net.IPNet'
+      ByteSize: 24
+      GoRuntimeType: 508864
+      GoKind: 23
       RawFields:
-        - Name: Filename
+        - Name: array
           Offset: 0
-          Type: 5 GoStringHeaderType string
-        - Name: Header
+          Type: 99 PointerType **net.IPNet
+        - Name: len
+          Offset: 8
+          Type: 8 BaseType int
+        - Name: cap
           Offset: 16
-          Type: 52 GoMapType net/textproto.MIMEHeader
-        - Name: Size
-          Offset: 24
-          Type: 32 BaseType int64
-        - Name: content
-          Offset: 32
-          Type: 53 GoSliceHeaderType []uint8
-        - Name: tmpfile
-          Offset: 56
-          Type: 5 GoStringHeaderType string
-        - Name: tmpoff
-          Offset: 72
-          Type: 32 BaseType int64
-        - Name: tmpshared
-          Offset: 80
-          Type: 13 BaseType bool
-    - __kind: GoMapType
-      ID: 52
-      Name: net/textproto.MIMEHeader
-      ByteSize: 8
-      GoRuntimeType: 1.863136e+06
-      GoKind: 21
-      HeaderType: 16 GoSwissMapHeaderType map<string,[]string>
+          Type: 8 BaseType int
+      Data: 264 GoSliceDataType []*net.IPNet.array
+    - __kind: GoSliceDataType
+      ID: 264
+      Name: '[]*net.IPNet.array'
+      ByteSize: 2048
+      Element: 100 PointerType *net.IPNet
+    - __kind: GoSliceHeaderType
+      ID: 96
+      Name: '[]*net/url.URL'
+      ByteSize: 24
+      GoRuntimeType: 508800
+      GoKind: 23
+      RawFields:
+        - Name: array
+          Offset: 0
+          Type: 97 PointerType **net/url.URL
+        - Name: len
+          Offset: 8
+          Type: 8 BaseType int
+        - Name: cap
+          Offset: 16
+          Type: 8 BaseType int
+      Data: 262 GoSliceDataType []*net/url.URL.array
+    - __kind: GoSliceDataType
+      ID: 262
+      Name: '[]*net/url.URL.array'
+      ByteSize: 2048
+      Element: 9 PointerType *net/url.URL
+    - __kind: GoSliceDataType
+      ID: 288
+      Name: '[]*table<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>.array'
+      ByteSize: 8192
+      Element: 178 PointerType *table<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
+    - __kind: GoSliceDataType
+      ID: 234
+      Name: '[]*table<string,[]*mime/multipart.FileHeader>.array'
+      ByteSize: 8192
+      Element: 41 PointerType *table<string,[]*mime/multipart.FileHeader>
+    - __kind: GoSliceDataType
+      ID: 230
+      Name: '[]*table<string,[]string>.array'
+      ByteSize: 8192
+      Element: 20 PointerType *table<string,[]string>
+    - __kind: GoSliceDataType
+      ID: 282
+      Name: '[]*table<string,float64>.array'
+      ByteSize: 8192
+      Element: 160 PointerType *table<string,float64>
+    - __kind: GoSliceDataType
+      ID: 280
+      Name: '[]*table<string,interface {}>.array'
+      ByteSize: 8192
+      Element: 149 PointerType *table<string,interface {}>
+    - __kind: GoSliceDataType
+      ID: 278
+      Name: '[]*table<string,string>.array'
+      ByteSize: 8192
+      Element: 128 PointerType *table<string,string>
+    - __kind: GoSliceHeaderType
+      ID: 109
+      Name: '[][]*crypto/x509.Certificate'
+      ByteSize: 24
+      GoRuntimeType: 507328
+      GoKind: 23
+      RawFields:
+        - Name: array
+          Offset: 0
+          Type: 110 PointerType *[]*crypto/x509.Certificate
+        - Name: len
+          Offset: 8
+          Type: 8 BaseType int
+        - Name: cap
+          Offset: 16
+          Type: 8 BaseType int
+      Data: 272 GoSliceDataType [][]*crypto/x509.Certificate.array
+    - __kind: GoSliceDataType
+      ID: 272
+      Name: '[][]*crypto/x509.Certificate.array'
+      ByteSize: 2048
+      Element: 57 GoSliceHeaderType []*crypto/x509.Certificate
+    - __kind: GoSliceHeaderType
+      ID: 111
+      Name: '[][]uint8'
+      ByteSize: 24
+      GoRuntimeType: 486720
+      GoKind: 23
+      RawFields:
+        - Name: array
+          Offset: 0
+          Type: 112 PointerType *[]uint8
+        - Name: len
+          Offset: 8
+          Type: 8 BaseType int
+        - Name: cap
+          Offset: 16
+          Type: 8 BaseType int
+      Data: 274 GoSliceDataType [][]uint8.array
+    - __kind: GoSliceDataType
+      ID: 274
+      Name: '[][]uint8.array'
+      ByteSize: 2048
+      Element: 53 GoSliceHeaderType []uint8
+    - __kind: GoSliceHeaderType
+      ID: 90
+      Name: '[]crypto/x509.ExtKeyUsage'
+      ByteSize: 24
+      GoRuntimeType: 508736
+      GoKind: 23
+      RawFields:
+        - Name: array
+          Offset: 0
+          Type: 91 PointerType *crypto/x509.ExtKeyUsage
+        - Name: len
+          Offset: 8
+          Type: 8 BaseType int
+        - Name: cap
+          Offset: 16
+          Type: 8 BaseType int
+      Data: 256 GoSliceDataType []crypto/x509.ExtKeyUsage.array
+    - __kind: GoSliceDataType
+      ID: 256
+      Name: '[]crypto/x509.ExtKeyUsage.array'
+      ByteSize: 2048
+      Element: 92 BaseType crypto/x509.ExtKeyUsage
+    - __kind: GoSliceHeaderType
+      ID: 103
+      Name: '[]crypto/x509.OID'
+      ByteSize: 24
+      GoRuntimeType: 508928
+      GoKind: 23
+      RawFields:
+        - Name: array
+          Offset: 0
+          Type: 104 PointerType *crypto/x509.OID
+        - Name: len
+          Offset: 8
+          Type: 8 BaseType int
+        - Name: cap
+          Offset: 16
+          Type: 8 BaseType int
+      Data: 268 GoSliceDataType []crypto/x509.OID.array
+    - __kind: GoSliceDataType
+      ID: 268
+      Name: '[]crypto/x509.OID.array'
+      ByteSize: 2048
+      Element: 105 StructureType crypto/x509.OID
+    - __kind: GoSliceHeaderType
+      ID: 106
+      Name: '[]crypto/x509.PolicyMapping'
+      ByteSize: 24
+      GoRuntimeType: 508992
+      GoKind: 23
+      RawFields:
+        - Name: array
+          Offset: 0
+          Type: 107 PointerType *crypto/x509.PolicyMapping
+        - Name: len
+          Offset: 8
+          Type: 8 BaseType int
+        - Name: cap
+          Offset: 16
+          Type: 8 BaseType int
+      Data: 270 GoSliceDataType []crypto/x509.PolicyMapping.array
+    - __kind: GoSliceDataType
+      ID: 270
+      Name: '[]crypto/x509.PolicyMapping.array'
+      ByteSize: 2048
+      Element: 108 StructureType crypto/x509.PolicyMapping
+    - __kind: GoSliceHeaderType
+      ID: 70
+      Name: '[]crypto/x509/pkix.AttributeTypeAndValue'
+      ByteSize: 24
+      GoRuntimeType: 523520
+      GoKind: 23
+      RawFields:
+        - Name: array
+          Offset: 0
+          Type: 71 PointerType *crypto/x509/pkix.AttributeTypeAndValue
+        - Name: len
+          Offset: 8
+          Type: 8 BaseType int
+        - Name: cap
+          Offset: 16
+          Type: 8 BaseType int
+      Data: 244 GoSliceDataType []crypto/x509/pkix.AttributeTypeAndValue.array
+    - __kind: GoSliceDataType
+      ID: 244
+      Name: '[]crypto/x509/pkix.AttributeTypeAndValue.array'
+      ByteSize: 2048
+      Element: 72 StructureType crypto/x509/pkix.AttributeTypeAndValue
+    - __kind: GoSliceHeaderType
+      ID: 85
+      Name: '[]crypto/x509/pkix.Extension'
+      ByteSize: 24
+      GoRuntimeType: 508608
+      GoKind: 23
+      RawFields:
+        - Name: array
+          Offset: 0
+          Type: 86 PointerType *crypto/x509/pkix.Extension
+        - Name: len
+          Offset: 8
+          Type: 8 BaseType int
+        - Name: cap
+          Offset: 16
+          Type: 8 BaseType int
+      Data: 252 GoSliceDataType []crypto/x509/pkix.Extension.array
+    - __kind: GoSliceDataType
+      ID: 252
+      Name: '[]crypto/x509/pkix.Extension.array'
+      ByteSize: 2048
+      Element: 87 StructureType crypto/x509/pkix.Extension
+    - __kind: GoSliceHeaderType
+      ID: 88
+      Name: '[]encoding/asn1.ObjectIdentifier'
+      ByteSize: 24
+      GoRuntimeType: 508672
+      GoKind: 23
+      RawFields:
+        - Name: array
+          Offset: 0
+          Type: 89 PointerType *encoding/asn1.ObjectIdentifier
+        - Name: len
+          Offset: 8
+          Type: 8 BaseType int
+        - Name: cap
+          Offset: 16
+          Type: 8 BaseType int
+      Data: 254 GoSliceDataType []encoding/asn1.ObjectIdentifier.array
+    - __kind: GoSliceDataType
+      ID: 254
+      Name: '[]encoding/asn1.ObjectIdentifier.array'
+      ByteSize: 2048
+      Element: 73 GoSliceHeaderType encoding/asn1.ObjectIdentifier
+    - __kind: GoSliceHeaderType
+      ID: 168
+      Name: '[]github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink'
+      ByteSize: 24
+      GoRuntimeType: 494624
+      GoKind: 23
+      RawFields:
+        - Name: array
+          Offset: 0
+          Type: 169 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink
+        - Name: len
+          Offset: 8
+          Type: 8 BaseType int
+        - Name: cap
+          Offset: 16
+          Type: 8 BaseType int
+      Data: 284 GoSliceDataType []github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink.array
+    - __kind: GoSliceDataType
+      ID: 284
+      Name: '[]github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink.array'
+      ByteSize: 2048
+      Element: 170 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink
+    - __kind: GoSliceHeaderType
+      ID: 171
+      Name: '[]github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent'
+      ByteSize: 24
+      GoRuntimeType: 494816
+      GoKind: 23
+      RawFields:
+        - Name: array
+          Offset: 0
+          Type: 172 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent
+        - Name: len
+          Offset: 8
+          Type: 8 BaseType int
+        - Name: cap
+          Offset: 16
+          Type: 8 BaseType int
+      Data: 286 GoSliceDataType []github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent.array
+    - __kind: GoSliceDataType
+      ID: 286
+      Name: '[]github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent.array'
+      ByteSize: 2048
+      Element: 173 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent
+    - __kind: GoSliceHeaderType
+      ID: 93
+      Name: '[]net.IP'
+      ByteSize: 24
+      GoRuntimeType: 487744
+      GoKind: 23
+      RawFields:
+        - Name: array
+          Offset: 0
+          Type: 94 PointerType *net.IP
+        - Name: len
+          Offset: 8
+          Type: 8 BaseType int
+        - Name: cap
+          Offset: 16
+          Type: 8 BaseType int
+      Data: 258 GoSliceDataType []net.IP.array
+    - __kind: GoSliceDataType
+      ID: 258
+      Name: '[]net.IP.array'
+      ByteSize: 2048
+      Element: 95 GoSliceHeaderType net.IP
+    - __kind: GoSliceHeaderType
+      ID: 121
+      Name: '[]net/http.segment'
+      ByteSize: 24
+      GoRuntimeType: 489440
+      GoKind: 23
+      RawFields:
+        - Name: array
+          Offset: 0
+          Type: 122 PointerType *net/http.segment
+        - Name: len
+          Offset: 8
+          Type: 8 BaseType int
+        - Name: cap
+          Offset: 16
+          Type: 8 BaseType int
+      Data: 276 GoSliceDataType []net/http.segment.array
+    - __kind: GoSliceDataType
+      ID: 276
+      Name: '[]net/http.segment.array'
+      ByteSize: 2048
+      Element: 123 StructureType net/http.segment
+    - __kind: GoSliceDataType
+      ID: 289
+      Name: '[]noalg.map.group[string]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute.array'
+      ByteSize: 2048
+      Element: 182 StructureType noalg.map.group[string]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
+    - __kind: GoSliceDataType
+      ID: 235
+      Name: '[]noalg.map.group[string][]*mime/multipart.FileHeader.array'
+      ByteSize: 2048
+      Element: 45 StructureType noalg.map.group[string][]*mime/multipart.FileHeader
+    - __kind: GoSliceDataType
+      ID: 231
+      Name: '[]noalg.map.group[string][]string.array'
+      ByteSize: 2048
+      Element: 25 StructureType noalg.map.group[string][]string
+    - __kind: GoSliceDataType
+      ID: 283
+      Name: '[]noalg.map.group[string]float64.array'
+      ByteSize: 2048
+      Element: 164 StructureType noalg.map.group[string]float64
+    - __kind: GoSliceDataType
+      ID: 281
+      Name: '[]noalg.map.group[string]interface {}.array'
+      ByteSize: 2048
+      Element: 153 StructureType noalg.map.group[string]interface {}
+    - __kind: GoSliceDataType
+      ID: 279
+      Name: '[]noalg.map.group[string]string.array'
+      ByteSize: 2048
+      Element: 132 StructureType noalg.map.group[string]string
+    - __kind: GoSliceHeaderType
+      ID: 28
+      Name: '[]string'
+      ByteSize: 24
+      GoRuntimeType: 501280
+      GoKind: 23
+      RawFields:
+        - Name: array
+          Offset: 0
+          Type: 29 PointerType *string
+        - Name: len
+          Offset: 8
+          Type: 8 BaseType int
+        - Name: cap
+          Offset: 16
+          Type: 8 BaseType int
+      Data: 232 GoSliceDataType []string.array
+    - __kind: GoSliceDataType
+      ID: 232
+      Name: '[]string.array'
+      ByteSize: 2048
+      Element: 5 GoStringHeaderType string
+    - __kind: GoSliceHeaderType
+      ID: 78
+      Name: '[]time.zone'
+      ByteSize: 24
+      GoRuntimeType: 494176
+      GoKind: 23
+      RawFields:
+        - Name: array
+          Offset: 0
+          Type: 79 PointerType *time.zone
+        - Name: len
+          Offset: 8
+          Type: 8 BaseType int
+        - Name: cap
+          Offset: 16
+          Type: 8 BaseType int
+      Data: 248 GoSliceDataType []time.zone.array
+    - __kind: GoSliceDataType
+      ID: 248
+      Name: '[]time.zone.array'
+      ByteSize: 2048
+      Element: 80 StructureType time.zone
+    - __kind: GoSliceHeaderType
+      ID: 81
+      Name: '[]time.zoneTrans'
+      ByteSize: 24
+      GoRuntimeType: 494240
+      GoKind: 23
+      RawFields:
+        - Name: array
+          Offset: 0
+          Type: 82 PointerType *time.zoneTrans
+        - Name: len
+          Offset: 8
+          Type: 8 BaseType int
+        - Name: cap
+          Offset: 16
+          Type: 8 BaseType int
+      Data: 250 GoSliceDataType []time.zoneTrans.array
+    - __kind: GoSliceDataType
+      ID: 250
+      Name: '[]time.zoneTrans.array'
+      ByteSize: 2048
+      Element: 83 StructureType time.zoneTrans
     - __kind: GoSliceHeaderType
       ID: 53
       Name: '[]uint8'
@@ -770,13 +1319,64 @@ Types:
           Offset: 16
           Type: 8 BaseType int
       Data: 238 GoSliceDataType []uint8.array
-    - __kind: PointerType
-      ID: 54
-      Name: '*crypto/tls.ConnectionState'
+    - __kind: GoSliceDataType
+      ID: 238
+      Name: '[]uint8.array'
+      ByteSize: 2048
+      Element: 7 BaseType uint8
+    - __kind: BaseType
+      ID: 13
+      Name: bool
+      ByteSize: 1
+      GoRuntimeType: 595008
+      GoKind: 1
+    - __kind: StructureType
+      ID: 207
+      Name: bytes.Buffer
+      ByteSize: 40
+      GoRuntimeType: 1.63984e+06
+      GoKind: 25
+      RawFields:
+        - Name: buf
+          Offset: 0
+          Type: 53 GoSliceHeaderType []uint8
+        - Name: off
+          Offset: 24
+          Type: 8 BaseType int
+        - Name: lastRead
+          Offset: 32
+          Type: 208 BaseType bytes.readOp
+    - __kind: BaseType
+      ID: 208
+      Name: bytes.readOp
+      ByteSize: 1
+      GoRuntimeType: 593216
+      GoKind: 3
+    - __kind: BaseType
+      ID: 219
+      Name: complex128
+      ByteSize: 16
+      GoRuntimeType: 594816
+      GoKind: 16
+    - __kind: BaseType
+      ID: 218
+      Name: complex64
       ByteSize: 8
-      GoRuntimeType: 923424
-      GoKind: 22
-      Pointee: 55 StructureType crypto/tls.ConnectionState
+      GoRuntimeType: 594752
+      GoKind: 15
+    - __kind: GoInterfaceType
+      ID: 118
+      Name: context.Context
+      ByteSize: 16
+      GoRuntimeType: 1.302496e+06
+      GoKind: 20
+      RawFields:
+        - Name: tab
+          Offset: 0
+          Type: 2 VoidPointerType unsafe.Pointer
+        - Name: data
+          Offset: 8
+          Type: 2 VoidPointerType unsafe.Pointer
     - __kind: StructureType
       ID: 55
       Name: crypto/tls.ConnectionState
@@ -841,36 +1441,12 @@ Types:
       ByteSize: 2
       GoRuntimeType: 846592
       GoKind: 9
-    - __kind: GoSliceHeaderType
-      ID: 57
-      Name: '[]*crypto/x509.Certificate'
-      ByteSize: 24
-      GoRuntimeType: 507264
-      GoKind: 23
-      RawFields:
-        - Name: array
-          Offset: 0
-          Type: 58 PointerType **crypto/x509.Certificate
-        - Name: len
-          Offset: 8
-          Type: 8 BaseType int
-        - Name: cap
-          Offset: 16
-          Type: 8 BaseType int
-      Data: 240 GoSliceDataType []*crypto/x509.Certificate.array
-    - __kind: PointerType
-      ID: 58
-      Name: '**crypto/x509.Certificate'
-      ByteSize: 8
-      GoKind: 22
-      Pointee: 59 PointerType *crypto/x509.Certificate
-    - __kind: PointerType
-      ID: 59
-      Name: '*crypto/x509.Certificate'
-      ByteSize: 8
-      GoRuntimeType: 2.088896e+06
-      GoKind: 22
-      Pointee: 60 StructureType crypto/x509.Certificate
+    - __kind: BaseType
+      ID: 114
+      Name: crypto/tls.SignatureScheme
+      ByteSize: 2
+      GoRuntimeType: 846688
+      GoKind: 9
     - __kind: StructureType
       ID: 60
       Name: crypto/x509.Certificate
@@ -1035,80 +1611,81 @@ Types:
           Offset: 1400
           Type: 106 GoSliceHeaderType []crypto/x509.PolicyMapping
     - __kind: BaseType
-      ID: 61
-      Name: crypto/x509.SignatureAlgorithm
+      ID: 92
+      Name: crypto/x509.ExtKeyUsage
       ByteSize: 8
-      GoRuntimeType: 1.138944e+06
+      GoRuntimeType: 598080
       GoKind: 2
+    - __kind: BaseType
+      ID: 84
+      Name: crypto/x509.KeyUsage
+      ByteSize: 8
+      GoRuntimeType: 598016
+      GoKind: 2
+    - __kind: StructureType
+      ID: 105
+      Name: crypto/x509.OID
+      ByteSize: 24
+      GoRuntimeType: 1.9976e+06
+      GoKind: 25
+      RawFields:
+        - Name: der
+          Offset: 0
+          Type: 53 GoSliceHeaderType []uint8
+    - __kind: StructureType
+      ID: 108
+      Name: crypto/x509.PolicyMapping
+      ByteSize: 48
+      GoRuntimeType: 1.519712e+06
+      GoKind: 25
+      RawFields:
+        - Name: IssuerDomainPolicy
+          Offset: 0
+          Type: 105 StructureType crypto/x509.OID
+        - Name: SubjectDomainPolicy
+          Offset: 24
+          Type: 105 StructureType crypto/x509.OID
     - __kind: BaseType
       ID: 62
       Name: crypto/x509.PublicKeyAlgorithm
       ByteSize: 8
       GoRuntimeType: 849088
       GoKind: 2
-    - __kind: GoEmptyInterfaceType
-      ID: 63
-      Name: interface {}
-      ByteSize: 16
-      GoRuntimeType: 866496
-      GoKind: 20
-      RawFields:
-        - Name: _type
-          Offset: 0
-          Type: 2 VoidPointerType unsafe.Pointer
-        - Name: data
-          Offset: 8
-          Type: 2 VoidPointerType unsafe.Pointer
-    - __kind: PointerType
-      ID: 64
-      Name: '*math/big.Int'
+    - __kind: BaseType
+      ID: 61
+      Name: crypto/x509.SignatureAlgorithm
       ByteSize: 8
-      GoRuntimeType: 2.446656e+06
-      GoKind: 22
-      Pointee: 65 StructureType math/big.Int
+      GoRuntimeType: 1.138944e+06
+      GoKind: 2
     - __kind: StructureType
-      ID: 65
-      Name: math/big.Int
-      ByteSize: 32
-      GoRuntimeType: 1.522752e+06
+      ID: 72
+      Name: crypto/x509/pkix.AttributeTypeAndValue
+      ByteSize: 40
+      GoRuntimeType: 1.532192e+06
       GoKind: 25
       RawFields:
-        - Name: neg
+        - Name: Type
           Offset: 0
-          Type: 13 BaseType bool
-        - Name: abs
-          Offset: 8
-          Type: 66 GoSliceHeaderType math/big.nat
-    - __kind: GoSliceHeaderType
-      ID: 66
-      Name: math/big.nat
-      ByteSize: 24
-      GoRuntimeType: 2.426144e+06
-      GoKind: 23
+          Type: 73 GoSliceHeaderType encoding/asn1.ObjectIdentifier
+        - Name: Value
+          Offset: 24
+          Type: 63 GoEmptyInterfaceType interface {}
+    - __kind: StructureType
+      ID: 87
+      Name: crypto/x509/pkix.Extension
+      ByteSize: 56
+      GoRuntimeType: 1.683232e+06
+      GoKind: 25
       RawFields:
-        - Name: array
+        - Name: Id
           Offset: 0
-          Type: 67 PointerType *math/big.Word
-        - Name: len
-          Offset: 8
-          Type: 8 BaseType int
-        - Name: cap
-          Offset: 16
-          Type: 8 BaseType int
-      Data: 242 GoSliceDataType math/big.nat.array
-    - __kind: PointerType
-      ID: 67
-      Name: '*math/big.Word'
-      ByteSize: 8
-      GoRuntimeType: 432640
-      GoKind: 22
-      Pointee: 68 BaseType math/big.Word
-    - __kind: BaseType
-      ID: 68
-      Name: math/big.Word
-      ByteSize: 8
-      GoRuntimeType: 598272
-      GoKind: 7
+          Type: 73 GoSliceHeaderType encoding/asn1.ObjectIdentifier
+        - Name: Critical
+          Offset: 24
+          Type: 13 BaseType bool
+        - Name: Value
+          Offset: 32
+          Type: 53 GoSliceHeaderType []uint8
     - __kind: StructureType
       ID: 69
       Name: crypto/x509/pkix.Name
@@ -1150,43 +1727,6 @@ Types:
           Offset: 224
           Type: 70 GoSliceHeaderType []crypto/x509/pkix.AttributeTypeAndValue
     - __kind: GoSliceHeaderType
-      ID: 70
-      Name: '[]crypto/x509/pkix.AttributeTypeAndValue'
-      ByteSize: 24
-      GoRuntimeType: 523520
-      GoKind: 23
-      RawFields:
-        - Name: array
-          Offset: 0
-          Type: 71 PointerType *crypto/x509/pkix.AttributeTypeAndValue
-        - Name: len
-          Offset: 8
-          Type: 8 BaseType int
-        - Name: cap
-          Offset: 16
-          Type: 8 BaseType int
-      Data: 244 GoSliceDataType []crypto/x509/pkix.AttributeTypeAndValue.array
-    - __kind: PointerType
-      ID: 71
-      Name: '*crypto/x509/pkix.AttributeTypeAndValue'
-      ByteSize: 8
-      GoRuntimeType: 446528
-      GoKind: 22
-      Pointee: 72 StructureType crypto/x509/pkix.AttributeTypeAndValue
-    - __kind: StructureType
-      ID: 72
-      Name: crypto/x509/pkix.AttributeTypeAndValue
-      ByteSize: 40
-      GoRuntimeType: 1.532192e+06
-      GoKind: 25
-      RawFields:
-        - Name: Type
-          Offset: 0
-          Type: 73 GoSliceHeaderType encoding/asn1.ObjectIdentifier
-        - Name: Value
-          Offset: 24
-          Type: 63 GoEmptyInterfaceType interface {}
-    - __kind: GoSliceHeaderType
       ID: 73
       Name: encoding/asn1.ObjectIdentifier
       ByteSize: 24
@@ -1203,566 +1743,16 @@ Types:
           Offset: 16
           Type: 8 BaseType int
       Data: 246 GoSliceDataType encoding/asn1.ObjectIdentifier.array
-    - __kind: PointerType
-      ID: 74
-      Name: '*int'
-      ByteSize: 8
-      GoRuntimeType: 404928
-      GoKind: 22
-      Pointee: 8 BaseType int
-    - __kind: StructureType
-      ID: 75
-      Name: time.Time
-      ByteSize: 24
-      GoRuntimeType: 2.428992e+06
-      GoKind: 25
-      RawFields:
-        - Name: wall
-          Offset: 0
-          Type: 17 BaseType uint64
-        - Name: ext
-          Offset: 8
-          Type: 32 BaseType int64
-        - Name: loc
-          Offset: 16
-          Type: 76 PointerType *time.Location
-    - __kind: PointerType
-      ID: 76
-      Name: '*time.Location'
-      ByteSize: 8
-      GoRuntimeType: 1.647136e+06
-      GoKind: 22
-      Pointee: 77 StructureType time.Location
-    - __kind: StructureType
-      ID: 77
-      Name: time.Location
-      ByteSize: 104
-      GoRuntimeType: 2.013984e+06
-      GoKind: 25
-      RawFields:
-        - Name: name
-          Offset: 0
-          Type: 5 GoStringHeaderType string
-        - Name: zone
-          Offset: 16
-          Type: 78 GoSliceHeaderType []time.zone
-        - Name: tx
-          Offset: 40
-          Type: 81 GoSliceHeaderType []time.zoneTrans
-        - Name: extend
-          Offset: 64
-          Type: 5 GoStringHeaderType string
-        - Name: cacheStart
-          Offset: 80
-          Type: 32 BaseType int64
-        - Name: cacheEnd
-          Offset: 88
-          Type: 32 BaseType int64
-        - Name: cacheZone
-          Offset: 96
-          Type: 79 PointerType *time.zone
-    - __kind: GoSliceHeaderType
-      ID: 78
-      Name: '[]time.zone'
-      ByteSize: 24
-      GoRuntimeType: 494176
-      GoKind: 23
-      RawFields:
-        - Name: array
-          Offset: 0
-          Type: 79 PointerType *time.zone
-        - Name: len
-          Offset: 8
-          Type: 8 BaseType int
-        - Name: cap
-          Offset: 16
-          Type: 8 BaseType int
-      Data: 248 GoSliceDataType []time.zone.array
-    - __kind: PointerType
-      ID: 79
-      Name: '*time.zone'
-      ByteSize: 8
-      GoRuntimeType: 399360
-      GoKind: 22
-      Pointee: 80 StructureType time.zone
-    - __kind: StructureType
-      ID: 80
-      Name: time.zone
-      ByteSize: 32
-      GoRuntimeType: 1.646944e+06
-      GoKind: 25
-      RawFields:
-        - Name: name
-          Offset: 0
-          Type: 5 GoStringHeaderType string
-        - Name: offset
-          Offset: 16
-          Type: 8 BaseType int
-        - Name: isDST
-          Offset: 24
-          Type: 13 BaseType bool
-    - __kind: GoSliceHeaderType
-      ID: 81
-      Name: '[]time.zoneTrans'
-      ByteSize: 24
-      GoRuntimeType: 494240
-      GoKind: 23
-      RawFields:
-        - Name: array
-          Offset: 0
-          Type: 82 PointerType *time.zoneTrans
-        - Name: len
-          Offset: 8
-          Type: 8 BaseType int
-        - Name: cap
-          Offset: 16
-          Type: 8 BaseType int
-      Data: 250 GoSliceDataType []time.zoneTrans.array
-    - __kind: PointerType
-      ID: 82
-      Name: '*time.zoneTrans'
-      ByteSize: 8
-      GoRuntimeType: 399424
-      GoKind: 22
-      Pointee: 83 StructureType time.zoneTrans
-    - __kind: StructureType
-      ID: 83
-      Name: time.zoneTrans
-      ByteSize: 16
-      GoRuntimeType: 1.788928e+06
-      GoKind: 25
-      RawFields:
-        - Name: when
-          Offset: 0
-          Type: 32 BaseType int64
-        - Name: index
-          Offset: 8
-          Type: 7 BaseType uint8
-        - Name: isstd
-          Offset: 9
-          Type: 13 BaseType bool
-        - Name: isutc
-          Offset: 10
-          Type: 13 BaseType bool
-    - __kind: BaseType
-      ID: 84
-      Name: crypto/x509.KeyUsage
-      ByteSize: 8
-      GoRuntimeType: 598016
-      GoKind: 2
-    - __kind: GoSliceHeaderType
-      ID: 85
-      Name: '[]crypto/x509/pkix.Extension'
-      ByteSize: 24
-      GoRuntimeType: 508608
-      GoKind: 23
-      RawFields:
-        - Name: array
-          Offset: 0
-          Type: 86 PointerType *crypto/x509/pkix.Extension
-        - Name: len
-          Offset: 8
-          Type: 8 BaseType int
-        - Name: cap
-          Offset: 16
-          Type: 8 BaseType int
-      Data: 252 GoSliceDataType []crypto/x509/pkix.Extension.array
-    - __kind: PointerType
-      ID: 86
-      Name: '*crypto/x509/pkix.Extension'
-      ByteSize: 8
-      GoRuntimeType: 446720
-      GoKind: 22
-      Pointee: 87 StructureType crypto/x509/pkix.Extension
-    - __kind: StructureType
-      ID: 87
-      Name: crypto/x509/pkix.Extension
-      ByteSize: 56
-      GoRuntimeType: 1.683232e+06
-      GoKind: 25
-      RawFields:
-        - Name: Id
-          Offset: 0
-          Type: 73 GoSliceHeaderType encoding/asn1.ObjectIdentifier
-        - Name: Critical
-          Offset: 24
-          Type: 13 BaseType bool
-        - Name: Value
-          Offset: 32
-          Type: 53 GoSliceHeaderType []uint8
-    - __kind: GoSliceHeaderType
-      ID: 88
-      Name: '[]encoding/asn1.ObjectIdentifier'
-      ByteSize: 24
-      GoRuntimeType: 508672
-      GoKind: 23
-      RawFields:
-        - Name: array
-          Offset: 0
-          Type: 89 PointerType *encoding/asn1.ObjectIdentifier
-        - Name: len
-          Offset: 8
-          Type: 8 BaseType int
-        - Name: cap
-          Offset: 16
-          Type: 8 BaseType int
-      Data: 254 GoSliceDataType []encoding/asn1.ObjectIdentifier.array
-    - __kind: PointerType
-      ID: 89
-      Name: '*encoding/asn1.ObjectIdentifier'
-      ByteSize: 8
-      GoRuntimeType: 1.079072e+06
-      GoKind: 22
-      Pointee: 73 GoSliceHeaderType encoding/asn1.ObjectIdentifier
-    - __kind: GoSliceHeaderType
-      ID: 90
-      Name: '[]crypto/x509.ExtKeyUsage'
-      ByteSize: 24
-      GoRuntimeType: 508736
-      GoKind: 23
-      RawFields:
-        - Name: array
-          Offset: 0
-          Type: 91 PointerType *crypto/x509.ExtKeyUsage
-        - Name: len
-          Offset: 8
-          Type: 8 BaseType int
-        - Name: cap
-          Offset: 16
-          Type: 8 BaseType int
-      Data: 256 GoSliceDataType []crypto/x509.ExtKeyUsage.array
-    - __kind: PointerType
-      ID: 91
-      Name: '*crypto/x509.ExtKeyUsage'
-      ByteSize: 8
-      GoRuntimeType: 429824
-      GoKind: 22
-      Pointee: 92 BaseType crypto/x509.ExtKeyUsage
-    - __kind: BaseType
-      ID: 92
-      Name: crypto/x509.ExtKeyUsage
-      ByteSize: 8
-      GoRuntimeType: 598080
-      GoKind: 2
-    - __kind: GoSliceHeaderType
-      ID: 93
-      Name: '[]net.IP'
-      ByteSize: 24
-      GoRuntimeType: 487744
-      GoKind: 23
-      RawFields:
-        - Name: array
-          Offset: 0
-          Type: 94 PointerType *net.IP
-        - Name: len
-          Offset: 8
-          Type: 8 BaseType int
-        - Name: cap
-          Offset: 16
-          Type: 8 BaseType int
-      Data: 258 GoSliceDataType []net.IP.array
-    - __kind: PointerType
-      ID: 94
-      Name: '*net.IP'
-      ByteSize: 8
-      GoRuntimeType: 2.206144e+06
-      GoKind: 22
-      Pointee: 95 GoSliceHeaderType net.IP
-    - __kind: GoSliceHeaderType
-      ID: 95
-      Name: net.IP
-      ByteSize: 24
-      GoRuntimeType: 2.178176e+06
-      GoKind: 23
-      RawFields:
-        - Name: array
-          Offset: 0
-          Type: 6 PointerType *uint8
-        - Name: len
-          Offset: 8
-          Type: 8 BaseType int
-        - Name: cap
-          Offset: 16
-          Type: 8 BaseType int
-      Data: 260 GoSliceDataType net.IP.array
-    - __kind: GoSliceHeaderType
-      ID: 96
-      Name: '[]*net/url.URL'
-      ByteSize: 24
-      GoRuntimeType: 508800
-      GoKind: 23
-      RawFields:
-        - Name: array
-          Offset: 0
-          Type: 97 PointerType **net/url.URL
-        - Name: len
-          Offset: 8
-          Type: 8 BaseType int
-        - Name: cap
-          Offset: 16
-          Type: 8 BaseType int
-      Data: 262 GoSliceDataType []*net/url.URL.array
-    - __kind: PointerType
-      ID: 97
-      Name: '**net/url.URL'
-      ByteSize: 8
-      Pointee: 9 PointerType *net/url.URL
-    - __kind: GoSliceHeaderType
-      ID: 98
-      Name: '[]*net.IPNet'
-      ByteSize: 24
-      GoRuntimeType: 508864
-      GoKind: 23
-      RawFields:
-        - Name: array
-          Offset: 0
-          Type: 99 PointerType **net.IPNet
-        - Name: len
-          Offset: 8
-          Type: 8 BaseType int
-        - Name: cap
-          Offset: 16
-          Type: 8 BaseType int
-      Data: 264 GoSliceDataType []*net.IPNet.array
-    - __kind: PointerType
-      ID: 99
-      Name: '**net.IPNet'
-      ByteSize: 8
-      GoKind: 22
-      Pointee: 100 PointerType *net.IPNet
-    - __kind: PointerType
-      ID: 100
-      Name: '*net.IPNet'
-      ByteSize: 8
-      GoRuntimeType: 1.207712e+06
-      GoKind: 22
-      Pointee: 101 StructureType net.IPNet
-    - __kind: StructureType
-      ID: 101
-      Name: net.IPNet
-      ByteSize: 48
-      GoRuntimeType: 1.486272e+06
-      GoKind: 25
-      RawFields:
-        - Name: IP
-          Offset: 0
-          Type: 95 GoSliceHeaderType net.IP
-        - Name: Mask
-          Offset: 24
-          Type: 102 GoSliceHeaderType net.IPMask
-    - __kind: GoSliceHeaderType
-      ID: 102
-      Name: net.IPMask
-      ByteSize: 24
-      GoRuntimeType: 1.041568e+06
-      GoKind: 23
-      RawFields:
-        - Name: array
-          Offset: 0
-          Type: 6 PointerType *uint8
-        - Name: len
-          Offset: 8
-          Type: 8 BaseType int
-        - Name: cap
-          Offset: 16
-          Type: 8 BaseType int
-      Data: 266 GoSliceDataType net.IPMask.array
-    - __kind: GoSliceHeaderType
-      ID: 103
-      Name: '[]crypto/x509.OID'
-      ByteSize: 24
-      GoRuntimeType: 508928
-      GoKind: 23
-      RawFields:
-        - Name: array
-          Offset: 0
-          Type: 104 PointerType *crypto/x509.OID
-        - Name: len
-          Offset: 8
-          Type: 8 BaseType int
-        - Name: cap
-          Offset: 16
-          Type: 8 BaseType int
-      Data: 268 GoSliceDataType []crypto/x509.OID.array
-    - __kind: PointerType
-      ID: 104
-      Name: '*crypto/x509.OID'
-      ByteSize: 8
-      GoRuntimeType: 1.997344e+06
-      GoKind: 22
-      Pointee: 105 StructureType crypto/x509.OID
-    - __kind: StructureType
-      ID: 105
-      Name: crypto/x509.OID
-      ByteSize: 24
-      GoRuntimeType: 1.9976e+06
-      GoKind: 25
-      RawFields:
-        - Name: der
-          Offset: 0
-          Type: 53 GoSliceHeaderType []uint8
-    - __kind: GoSliceHeaderType
-      ID: 106
-      Name: '[]crypto/x509.PolicyMapping'
-      ByteSize: 24
-      GoRuntimeType: 508992
-      GoKind: 23
-      RawFields:
-        - Name: array
-          Offset: 0
-          Type: 107 PointerType *crypto/x509.PolicyMapping
-        - Name: len
-          Offset: 8
-          Type: 8 BaseType int
-        - Name: cap
-          Offset: 16
-          Type: 8 BaseType int
-      Data: 270 GoSliceDataType []crypto/x509.PolicyMapping.array
-    - __kind: PointerType
-      ID: 107
-      Name: '*crypto/x509.PolicyMapping'
-      ByteSize: 8
-      GoRuntimeType: 429888
-      GoKind: 22
-      Pointee: 108 StructureType crypto/x509.PolicyMapping
-    - __kind: StructureType
-      ID: 108
-      Name: crypto/x509.PolicyMapping
-      ByteSize: 48
-      GoRuntimeType: 1.519712e+06
-      GoKind: 25
-      RawFields:
-        - Name: IssuerDomainPolicy
-          Offset: 0
-          Type: 105 StructureType crypto/x509.OID
-        - Name: SubjectDomainPolicy
-          Offset: 24
-          Type: 105 StructureType crypto/x509.OID
-    - __kind: GoSliceHeaderType
-      ID: 109
-      Name: '[][]*crypto/x509.Certificate'
-      ByteSize: 24
-      GoRuntimeType: 507328
-      GoKind: 23
-      RawFields:
-        - Name: array
-          Offset: 0
-          Type: 110 PointerType *[]*crypto/x509.Certificate
-        - Name: len
-          Offset: 8
-          Type: 8 BaseType int
-        - Name: cap
-          Offset: 16
-          Type: 8 BaseType int
-      Data: 272 GoSliceDataType [][]*crypto/x509.Certificate.array
-    - __kind: PointerType
-      ID: 110
-      Name: '*[]*crypto/x509.Certificate'
-      ByteSize: 8
-      GoKind: 22
-      Pointee: 57 GoSliceHeaderType []*crypto/x509.Certificate
-    - __kind: GoSliceHeaderType
-      ID: 111
-      Name: '[][]uint8'
-      ByteSize: 24
-      GoRuntimeType: 486720
-      GoKind: 23
-      RawFields:
-        - Name: array
-          Offset: 0
-          Type: 112 PointerType *[]uint8
-        - Name: len
-          Offset: 8
-          Type: 8 BaseType int
-        - Name: cap
-          Offset: 16
-          Type: 8 BaseType int
-      Data: 274 GoSliceDataType [][]uint8.array
-    - __kind: PointerType
-      ID: 112
-      Name: '*[]uint8'
-      ByteSize: 8
-      GoRuntimeType: 486400
-      GoKind: 22
-      Pointee: 53 GoSliceHeaderType []uint8
-    - __kind: GoSubroutineType
-      ID: 113
-      Name: func(string, []uint8, int) ([]uint8, error)
-      ByteSize: 8
-      GoRuntimeType: 1.024448e+06
-      GoKind: 19
-    - __kind: BaseType
-      ID: 114
-      Name: crypto/tls.SignatureScheme
-      ByteSize: 2
-      GoRuntimeType: 846688
-      GoKind: 9
-    - __kind: GoChannelType
-      ID: 115
-      Name: <-chan struct {}
-      GoRuntimeType: 607040
-      GoKind: 18
-    - __kind: PointerType
-      ID: 116
-      Name: '*net/http.Response'
-      ByteSize: 8
-      GoRuntimeType: 1.757856e+06
-      GoKind: 22
-      Pointee: 117 StructureType net/http.Response
-    - __kind: StructureType
-      ID: 117
-      Name: net/http.Response
-      ByteSize: 144
-      GoRuntimeType: 2.26784e+06
-      GoKind: 25
-      RawFields:
-        - Name: Status
-          Offset: 0
-          Type: 5 GoStringHeaderType string
-        - Name: StatusCode
-          Offset: 16
-          Type: 8 BaseType int
-        - Name: Proto
-          Offset: 24
-          Type: 5 GoStringHeaderType string
-        - Name: ProtoMajor
-          Offset: 40
-          Type: 8 BaseType int
-        - Name: ProtoMinor
-          Offset: 48
-          Type: 8 BaseType int
-        - Name: Header
-          Offset: 56
-          Type: 14 GoMapType net/http.Header
-        - Name: Body
-          Offset: 64
-          Type: 30 GoInterfaceType io.ReadCloser
-        - Name: ContentLength
-          Offset: 80
-          Type: 32 BaseType int64
-        - Name: TransferEncoding
-          Offset: 88
-          Type: 28 GoSliceHeaderType []string
-        - Name: Close
-          Offset: 112
-          Type: 13 BaseType bool
-        - Name: Uncompressed
-          Offset: 113
-          Type: 13 BaseType bool
-        - Name: Trailer
-          Offset: 120
-          Type: 14 GoMapType net/http.Header
-        - Name: Request
-          Offset: 128
-          Type: 3 PointerType *net/http.Request
-        - Name: TLS
-          Offset: 136
-          Type: 54 PointerType *crypto/tls.ConnectionState
+    - __kind: GoSliceDataType
+      ID: 246
+      Name: encoding/asn1.ObjectIdentifier.array
+      ByteSize: 2048
+      Element: 8 BaseType int
     - __kind: GoInterfaceType
-      ID: 118
-      Name: context.Context
+      ID: 211
+      Name: error
       ByteSize: 16
-      GoRuntimeType: 1.302496e+06
+      GoRuntimeType: 1.0536e+06
       GoKind: 20
       RawFields:
         - Name: tab
@@ -1771,217 +1761,36 @@ Types:
         - Name: data
           Offset: 8
           Type: 2 VoidPointerType unsafe.Pointer
-    - __kind: PointerType
-      ID: 119
-      Name: '*net/http.pattern'
+    - __kind: BaseType
+      ID: 213
+      Name: float32
+      ByteSize: 4
+      GoRuntimeType: 594880
+      GoKind: 13
+    - __kind: BaseType
+      ID: 167
+      Name: float64
       ByteSize: 8
-      GoRuntimeType: 1.642144e+06
-      GoKind: 22
-      Pointee: 120 StructureType net/http.pattern
-    - __kind: StructureType
-      ID: 120
-      Name: net/http.pattern
-      ByteSize: 88
-      GoRuntimeType: 1.875072e+06
-      GoKind: 25
-      RawFields:
-        - Name: str
-          Offset: 0
-          Type: 5 GoStringHeaderType string
-        - Name: method
-          Offset: 16
-          Type: 5 GoStringHeaderType string
-        - Name: host
-          Offset: 32
-          Type: 5 GoStringHeaderType string
-        - Name: segments
-          Offset: 48
-          Type: 121 GoSliceHeaderType []net/http.segment
-        - Name: loc
-          Offset: 72
-          Type: 5 GoStringHeaderType string
-    - __kind: GoSliceHeaderType
-      ID: 121
-      Name: '[]net/http.segment'
-      ByteSize: 24
-      GoRuntimeType: 489440
-      GoKind: 23
-      RawFields:
-        - Name: array
-          Offset: 0
-          Type: 122 PointerType *net/http.segment
-        - Name: len
-          Offset: 8
-          Type: 8 BaseType int
-        - Name: cap
-          Offset: 16
-          Type: 8 BaseType int
-      Data: 276 GoSliceDataType []net/http.segment.array
-    - __kind: PointerType
-      ID: 122
-      Name: '*net/http.segment'
+      GoRuntimeType: 594944
+      GoKind: 14
+    - __kind: GoSubroutineType
+      ID: 205
+      Name: func()
       ByteSize: 8
-      GoRuntimeType: 396288
-      GoKind: 22
-      Pointee: 123 StructureType net/http.segment
-    - __kind: StructureType
-      ID: 123
-      Name: net/http.segment
-      ByteSize: 24
-      GoRuntimeType: 1.641952e+06
-      GoKind: 25
-      RawFields:
-        - Name: s
-          Offset: 0
-          Type: 5 GoStringHeaderType string
-        - Name: wild
-          Offset: 16
-          Type: 13 BaseType bool
-        - Name: multi
-          Offset: 17
-          Type: 13 BaseType bool
-    - __kind: GoMapType
-      ID: 124
-      Name: map[string]string
+      GoRuntimeType: 484800
+      GoKind: 19
+    - __kind: GoSubroutineType
+      ID: 31
+      Name: func() (io.ReadCloser, error)
       ByteSize: 8
-      GoRuntimeType: 1.153536e+06
-      GoKind: 21
-      HeaderType: 126 GoSwissMapHeaderType map<string,string>
-    - __kind: PointerType
-      ID: 125
-      Name: '*map<string,string>'
+      GoRuntimeType: 704864
+      GoKind: 19
+    - __kind: GoSubroutineType
+      ID: 113
+      Name: func(string, []uint8, int) ([]uint8, error)
       ByteSize: 8
-      Pointee: 126 GoSwissMapHeaderType map<string,string>
-    - __kind: GoSwissMapHeaderType
-      ID: 126
-      Name: map<string,string>
-      ByteSize: 48
-      GoKind: 25
-      RawFields:
-        - Name: used
-          Offset: 0
-          Type: 17 BaseType uint64
-        - Name: seed
-          Offset: 8
-          Type: 18 BaseType uintptr
-        - Name: dirPtr
-          Offset: 16
-          Type: 127 PointerType **table<string,string>
-        - Name: dirLen
-          Offset: 24
-          Type: 8 BaseType int
-        - Name: globalDepth
-          Offset: 32
-          Type: 7 BaseType uint8
-        - Name: globalShift
-          Offset: 33
-          Type: 7 BaseType uint8
-        - Name: writing
-          Offset: 34
-          Type: 7 BaseType uint8
-        - Name: tombstonePossible
-          Offset: 35
-          Type: 13 BaseType bool
-        - Name: clearSeq
-          Offset: 40
-          Type: 17 BaseType uint64
-      TablePtrSliceType: 278 GoSliceDataType []*table<string,string>.array
-      GroupType: 132 StructureType noalg.map.group[string]string
-    - __kind: PointerType
-      ID: 127
-      Name: '**table<string,string>'
-      ByteSize: 8
-      Pointee: 128 PointerType *table<string,string>
-    - __kind: PointerType
-      ID: 128
-      Name: '*table<string,string>'
-      ByteSize: 8
-      Pointee: 129 StructureType table<string,string>
-    - __kind: StructureType
-      ID: 129
-      Name: table<string,string>
-      ByteSize: 32
-      GoKind: 25
-      RawFields:
-        - Name: used
-          Offset: 0
-          Type: 22 BaseType uint16
-        - Name: capacity
-          Offset: 2
-          Type: 22 BaseType uint16
-        - Name: growthLeft
-          Offset: 4
-          Type: 22 BaseType uint16
-        - Name: localDepth
-          Offset: 6
-          Type: 7 BaseType uint8
-        - Name: index
-          Offset: 8
-          Type: 8 BaseType int
-        - Name: groups
-          Offset: 16
-          Type: 130 GoSwissMapGroupsType groupReference<string,string>
-    - __kind: GoSwissMapGroupsType
-      ID: 130
-      Name: groupReference<string,string>
-      ByteSize: 16
-      GoKind: 25
-      RawFields:
-        - Name: data
-          Offset: 0
-          Type: 131 PointerType *noalg.map.group[string]string
-        - Name: lengthMask
-          Offset: 8
-          Type: 17 BaseType uint64
-      GroupType: 132 StructureType noalg.map.group[string]string
-      GroupSliceType: 279 GoSliceDataType []noalg.map.group[string]string.array
-    - __kind: PointerType
-      ID: 131
-      Name: '*noalg.map.group[string]string'
-      ByteSize: 8
-      Pointee: 132 StructureType noalg.map.group[string]string
-    - __kind: StructureType
-      ID: 132
-      Name: noalg.map.group[string]string
-      ByteSize: 264
-      GoRuntimeType: 1.318368e+06
-      GoKind: 25
-      RawFields:
-        - Name: ctrl
-          Offset: 0
-          Type: 17 BaseType uint64
-        - Name: slots
-          Offset: 8
-          Type: 133 ArrayType noalg.[8]struct { key string; elem string }
-    - __kind: ArrayType
-      ID: 133
-      Name: noalg.[8]struct { key string; elem string }
-      ByteSize: 256
-      GoRuntimeType: 705056
-      GoKind: 17
-      Count: 8
-      HasCount: true
-      Element: 134 StructureType noalg.struct { key string; elem string }
-    - __kind: StructureType
-      ID: 134
-      Name: noalg.struct { key string; elem string }
-      ByteSize: 32
-      GoRuntimeType: 1.31824e+06
-      GoKind: 25
-      RawFields:
-        - Name: key
-          Offset: 0
-          Type: 5 GoStringHeaderType string
-        - Name: elem
-          Offset: 16
-          Type: 5 GoStringHeaderType string
-    - __kind: PointerType
-      ID: 135
-      Name: '*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span'
-      ByteSize: 8
-      GoRuntimeType: 2.331872e+06
-      GoKind: 22
-      Pointee: 136 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span
+      GoRuntimeType: 1.024448e+06
+      GoKind: 19
     - __kind: StructureType
       ID: 136
       Name: github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span
@@ -2065,721 +1874,6 @@ Types:
           Offset: 280
           Type: 205 GoSubroutineType func()
     - __kind: StructureType
-      ID: 137
-      Name: sync.RWMutex
-      ByteSize: 24
-      GoRuntimeType: 1.880896e+06
-      GoKind: 25
-      RawFields:
-        - Name: w
-          Offset: 0
-          Type: 138 StructureType sync.Mutex
-        - Name: writerSem
-          Offset: 8
-          Type: 142 BaseType uint32
-        - Name: readerSem
-          Offset: 12
-          Type: 142 BaseType uint32
-        - Name: readerCount
-          Offset: 16
-          Type: 143 StructureType sync/atomic.Int32
-        - Name: readerWait
-          Offset: 20
-          Type: 143 StructureType sync/atomic.Int32
-    - __kind: StructureType
-      ID: 138
-      Name: sync.Mutex
-      ByteSize: 8
-      GoRuntimeType: 1.493632e+06
-      GoKind: 25
-      RawFields:
-        - Name: _
-          Offset: 0
-          Type: 139 StructureType sync.noCopy
-        - Name: mu
-          Offset: 0
-          Type: 140 StructureType internal/sync.Mutex
-    - __kind: StructureType
-      ID: 139
-      Name: sync.noCopy
-      GoRuntimeType: 1.006688e+06
-      GoKind: 25
-      RawFields: []
-    - __kind: StructureType
-      ID: 140
-      Name: internal/sync.Mutex
-      ByteSize: 8
-      GoRuntimeType: 1.517472e+06
-      GoKind: 25
-      RawFields:
-        - Name: state
-          Offset: 0
-          Type: 141 BaseType int32
-        - Name: sema
-          Offset: 4
-          Type: 142 BaseType uint32
-    - __kind: BaseType
-      ID: 141
-      Name: int32
-      ByteSize: 4
-      GoRuntimeType: 594304
-      GoKind: 5
-    - __kind: BaseType
-      ID: 142
-      Name: uint32
-      ByteSize: 4
-      GoRuntimeType: 594368
-      GoKind: 10
-    - __kind: StructureType
-      ID: 143
-      Name: sync/atomic.Int32
-      ByteSize: 4
-      GoRuntimeType: 1.494912e+06
-      GoKind: 25
-      RawFields:
-        - Name: _
-          Offset: 0
-          Type: 144 StructureType sync/atomic.noCopy
-        - Name: v
-          Offset: 0
-          Type: 141 BaseType int32
-    - __kind: StructureType
-      ID: 144
-      Name: sync/atomic.noCopy
-      GoRuntimeType: 1.006784e+06
-      GoKind: 25
-      RawFields: []
-    - __kind: GoMapType
-      ID: 145
-      Name: github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.metaStructMap
-      ByteSize: 8
-      GoRuntimeType: 1.303776e+06
-      GoKind: 21
-      HeaderType: 147 GoSwissMapHeaderType map<string,interface {}>
-    - __kind: PointerType
-      ID: 146
-      Name: '*map<string,interface {}>'
-      ByteSize: 8
-      Pointee: 147 GoSwissMapHeaderType map<string,interface {}>
-    - __kind: GoSwissMapHeaderType
-      ID: 147
-      Name: map<string,interface {}>
-      ByteSize: 48
-      GoKind: 25
-      RawFields:
-        - Name: used
-          Offset: 0
-          Type: 17 BaseType uint64
-        - Name: seed
-          Offset: 8
-          Type: 18 BaseType uintptr
-        - Name: dirPtr
-          Offset: 16
-          Type: 148 PointerType **table<string,interface {}>
-        - Name: dirLen
-          Offset: 24
-          Type: 8 BaseType int
-        - Name: globalDepth
-          Offset: 32
-          Type: 7 BaseType uint8
-        - Name: globalShift
-          Offset: 33
-          Type: 7 BaseType uint8
-        - Name: writing
-          Offset: 34
-          Type: 7 BaseType uint8
-        - Name: tombstonePossible
-          Offset: 35
-          Type: 13 BaseType bool
-        - Name: clearSeq
-          Offset: 40
-          Type: 17 BaseType uint64
-      TablePtrSliceType: 280 GoSliceDataType []*table<string,interface {}>.array
-      GroupType: 153 StructureType noalg.map.group[string]interface {}
-    - __kind: PointerType
-      ID: 148
-      Name: '**table<string,interface {}>'
-      ByteSize: 8
-      Pointee: 149 PointerType *table<string,interface {}>
-    - __kind: PointerType
-      ID: 149
-      Name: '*table<string,interface {}>'
-      ByteSize: 8
-      Pointee: 150 StructureType table<string,interface {}>
-    - __kind: StructureType
-      ID: 150
-      Name: table<string,interface {}>
-      ByteSize: 32
-      GoKind: 25
-      RawFields:
-        - Name: used
-          Offset: 0
-          Type: 22 BaseType uint16
-        - Name: capacity
-          Offset: 2
-          Type: 22 BaseType uint16
-        - Name: growthLeft
-          Offset: 4
-          Type: 22 BaseType uint16
-        - Name: localDepth
-          Offset: 6
-          Type: 7 BaseType uint8
-        - Name: index
-          Offset: 8
-          Type: 8 BaseType int
-        - Name: groups
-          Offset: 16
-          Type: 151 GoSwissMapGroupsType groupReference<string,interface {}>
-    - __kind: GoSwissMapGroupsType
-      ID: 151
-      Name: groupReference<string,interface {}>
-      ByteSize: 16
-      GoKind: 25
-      RawFields:
-        - Name: data
-          Offset: 0
-          Type: 152 PointerType *noalg.map.group[string]interface {}
-        - Name: lengthMask
-          Offset: 8
-          Type: 17 BaseType uint64
-      GroupType: 153 StructureType noalg.map.group[string]interface {}
-      GroupSliceType: 281 GoSliceDataType []noalg.map.group[string]interface {}.array
-    - __kind: PointerType
-      ID: 152
-      Name: '*noalg.map.group[string]interface {}'
-      ByteSize: 8
-      Pointee: 153 StructureType noalg.map.group[string]interface {}
-    - __kind: StructureType
-      ID: 153
-      Name: noalg.map.group[string]interface {}
-      ByteSize: 264
-      GoRuntimeType: 1.313376e+06
-      GoKind: 25
-      RawFields:
-        - Name: ctrl
-          Offset: 0
-          Type: 17 BaseType uint64
-        - Name: slots
-          Offset: 8
-          Type: 154 ArrayType noalg.[8]struct { key string; elem interface {} }
-    - __kind: ArrayType
-      ID: 154
-      Name: noalg.[8]struct { key string; elem interface {} }
-      ByteSize: 256
-      GoRuntimeType: 692352
-      GoKind: 17
-      Count: 8
-      HasCount: true
-      Element: 155 StructureType noalg.struct { key string; elem interface {} }
-    - __kind: StructureType
-      ID: 155
-      Name: noalg.struct { key string; elem interface {} }
-      ByteSize: 32
-      GoRuntimeType: 1.313248e+06
-      GoKind: 25
-      RawFields:
-        - Name: key
-          Offset: 0
-          Type: 5 GoStringHeaderType string
-        - Name: elem
-          Offset: 16
-          Type: 63 GoEmptyInterfaceType interface {}
-    - __kind: GoMapType
-      ID: 156
-      Name: map[string]float64
-      ByteSize: 8
-      GoRuntimeType: 1.157504e+06
-      GoKind: 21
-      HeaderType: 158 GoSwissMapHeaderType map<string,float64>
-    - __kind: PointerType
-      ID: 157
-      Name: '*map<string,float64>'
-      ByteSize: 8
-      Pointee: 158 GoSwissMapHeaderType map<string,float64>
-    - __kind: GoSwissMapHeaderType
-      ID: 158
-      Name: map<string,float64>
-      ByteSize: 48
-      GoKind: 25
-      RawFields:
-        - Name: used
-          Offset: 0
-          Type: 17 BaseType uint64
-        - Name: seed
-          Offset: 8
-          Type: 18 BaseType uintptr
-        - Name: dirPtr
-          Offset: 16
-          Type: 159 PointerType **table<string,float64>
-        - Name: dirLen
-          Offset: 24
-          Type: 8 BaseType int
-        - Name: globalDepth
-          Offset: 32
-          Type: 7 BaseType uint8
-        - Name: globalShift
-          Offset: 33
-          Type: 7 BaseType uint8
-        - Name: writing
-          Offset: 34
-          Type: 7 BaseType uint8
-        - Name: tombstonePossible
-          Offset: 35
-          Type: 13 BaseType bool
-        - Name: clearSeq
-          Offset: 40
-          Type: 17 BaseType uint64
-      TablePtrSliceType: 282 GoSliceDataType []*table<string,float64>.array
-      GroupType: 164 StructureType noalg.map.group[string]float64
-    - __kind: PointerType
-      ID: 159
-      Name: '**table<string,float64>'
-      ByteSize: 8
-      Pointee: 160 PointerType *table<string,float64>
-    - __kind: PointerType
-      ID: 160
-      Name: '*table<string,float64>'
-      ByteSize: 8
-      Pointee: 161 StructureType table<string,float64>
-    - __kind: StructureType
-      ID: 161
-      Name: table<string,float64>
-      ByteSize: 32
-      GoKind: 25
-      RawFields:
-        - Name: used
-          Offset: 0
-          Type: 22 BaseType uint16
-        - Name: capacity
-          Offset: 2
-          Type: 22 BaseType uint16
-        - Name: growthLeft
-          Offset: 4
-          Type: 22 BaseType uint16
-        - Name: localDepth
-          Offset: 6
-          Type: 7 BaseType uint8
-        - Name: index
-          Offset: 8
-          Type: 8 BaseType int
-        - Name: groups
-          Offset: 16
-          Type: 162 GoSwissMapGroupsType groupReference<string,float64>
-    - __kind: GoSwissMapGroupsType
-      ID: 162
-      Name: groupReference<string,float64>
-      ByteSize: 16
-      GoKind: 25
-      RawFields:
-        - Name: data
-          Offset: 0
-          Type: 163 PointerType *noalg.map.group[string]float64
-        - Name: lengthMask
-          Offset: 8
-          Type: 17 BaseType uint64
-      GroupType: 164 StructureType noalg.map.group[string]float64
-      GroupSliceType: 283 GoSliceDataType []noalg.map.group[string]float64.array
-    - __kind: PointerType
-      ID: 163
-      Name: '*noalg.map.group[string]float64'
-      ByteSize: 8
-      Pointee: 164 StructureType noalg.map.group[string]float64
-    - __kind: StructureType
-      ID: 164
-      Name: noalg.map.group[string]float64
-      ByteSize: 200
-      GoRuntimeType: 1.33104e+06
-      GoKind: 25
-      RawFields:
-        - Name: ctrl
-          Offset: 0
-          Type: 17 BaseType uint64
-        - Name: slots
-          Offset: 8
-          Type: 165 ArrayType noalg.[8]struct { key string; elem float64 }
-    - __kind: ArrayType
-      ID: 165
-      Name: noalg.[8]struct { key string; elem float64 }
-      ByteSize: 192
-      GoRuntimeType: 715008
-      GoKind: 17
-      Count: 8
-      HasCount: true
-      Element: 166 StructureType noalg.struct { key string; elem float64 }
-    - __kind: StructureType
-      ID: 166
-      Name: noalg.struct { key string; elem float64 }
-      ByteSize: 24
-      GoRuntimeType: 1.330912e+06
-      GoKind: 25
-      RawFields:
-        - Name: key
-          Offset: 0
-          Type: 5 GoStringHeaderType string
-        - Name: elem
-          Offset: 16
-          Type: 167 BaseType float64
-    - __kind: BaseType
-      ID: 167
-      Name: float64
-      ByteSize: 8
-      GoRuntimeType: 594944
-      GoKind: 14
-    - __kind: GoSliceHeaderType
-      ID: 168
-      Name: '[]github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink'
-      ByteSize: 24
-      GoRuntimeType: 494624
-      GoKind: 23
-      RawFields:
-        - Name: array
-          Offset: 0
-          Type: 169 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink
-        - Name: len
-          Offset: 8
-          Type: 8 BaseType int
-        - Name: cap
-          Offset: 16
-          Type: 8 BaseType int
-      Data: 284 GoSliceDataType []github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink.array
-    - __kind: PointerType
-      ID: 169
-      Name: '*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink'
-      ByteSize: 8
-      GoRuntimeType: 1.213856e+06
-      GoKind: 22
-      Pointee: 170 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink
-    - __kind: StructureType
-      ID: 170
-      Name: github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink
-      ByteSize: 56
-      GoRuntimeType: 1.954848e+06
-      GoKind: 25
-      RawFields:
-        - Name: TraceID
-          Offset: 0
-          Type: 17 BaseType uint64
-        - Name: TraceIDHigh
-          Offset: 8
-          Type: 17 BaseType uint64
-        - Name: SpanID
-          Offset: 16
-          Type: 17 BaseType uint64
-        - Name: Attributes
-          Offset: 24
-          Type: 124 GoMapType map[string]string
-        - Name: Tracestate
-          Offset: 32
-          Type: 5 GoStringHeaderType string
-        - Name: Flags
-          Offset: 48
-          Type: 142 BaseType uint32
-    - __kind: GoSliceHeaderType
-      ID: 171
-      Name: '[]github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent'
-      ByteSize: 24
-      GoRuntimeType: 494816
-      GoKind: 23
-      RawFields:
-        - Name: array
-          Offset: 0
-          Type: 172 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent
-        - Name: len
-          Offset: 8
-          Type: 8 BaseType int
-        - Name: cap
-          Offset: 16
-          Type: 8 BaseType int
-      Data: 286 GoSliceDataType []github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent.array
-    - __kind: PointerType
-      ID: 172
-      Name: '*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent'
-      ByteSize: 8
-      GoRuntimeType: 1.213984e+06
-      GoKind: 22
-      Pointee: 173 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent
-    - __kind: StructureType
-      ID: 173
-      Name: github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent
-      ByteSize: 40
-      GoRuntimeType: 1.78912e+06
-      GoKind: 25
-      RawFields:
-        - Name: Name
-          Offset: 0
-          Type: 5 GoStringHeaderType string
-        - Name: TimeUnixNano
-          Offset: 16
-          Type: 17 BaseType uint64
-        - Name: Attributes
-          Offset: 24
-          Type: 174 GoMapType map[string]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
-        - Name: RawAttributes
-          Offset: 32
-          Type: 195 GoMapType map[string]interface {}
-    - __kind: GoMapType
-      ID: 174
-      Name: map[string]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
-      ByteSize: 8
-      GoRuntimeType: 1.157632e+06
-      GoKind: 21
-      HeaderType: 176 GoSwissMapHeaderType map<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
-    - __kind: PointerType
-      ID: 175
-      Name: '*map<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>'
-      ByteSize: 8
-      Pointee: 176 GoSwissMapHeaderType map<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
-    - __kind: GoSwissMapHeaderType
-      ID: 176
-      Name: map<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
-      ByteSize: 48
-      GoKind: 25
-      RawFields:
-        - Name: used
-          Offset: 0
-          Type: 17 BaseType uint64
-        - Name: seed
-          Offset: 8
-          Type: 18 BaseType uintptr
-        - Name: dirPtr
-          Offset: 16
-          Type: 177 PointerType **table<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
-        - Name: dirLen
-          Offset: 24
-          Type: 8 BaseType int
-        - Name: globalDepth
-          Offset: 32
-          Type: 7 BaseType uint8
-        - Name: globalShift
-          Offset: 33
-          Type: 7 BaseType uint8
-        - Name: writing
-          Offset: 34
-          Type: 7 BaseType uint8
-        - Name: tombstonePossible
-          Offset: 35
-          Type: 13 BaseType bool
-        - Name: clearSeq
-          Offset: 40
-          Type: 17 BaseType uint64
-      TablePtrSliceType: 288 GoSliceDataType []*table<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>.array
-      GroupType: 182 StructureType noalg.map.group[string]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
-    - __kind: PointerType
-      ID: 177
-      Name: '**table<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>'
-      ByteSize: 8
-      Pointee: 178 PointerType *table<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
-    - __kind: PointerType
-      ID: 178
-      Name: '*table<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>'
-      ByteSize: 8
-      Pointee: 179 StructureType table<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
-    - __kind: StructureType
-      ID: 179
-      Name: table<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
-      ByteSize: 32
-      GoKind: 25
-      RawFields:
-        - Name: used
-          Offset: 0
-          Type: 22 BaseType uint16
-        - Name: capacity
-          Offset: 2
-          Type: 22 BaseType uint16
-        - Name: growthLeft
-          Offset: 4
-          Type: 22 BaseType uint16
-        - Name: localDepth
-          Offset: 6
-          Type: 7 BaseType uint8
-        - Name: index
-          Offset: 8
-          Type: 8 BaseType int
-        - Name: groups
-          Offset: 16
-          Type: 180 GoSwissMapGroupsType groupReference<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
-    - __kind: GoSwissMapGroupsType
-      ID: 180
-      Name: groupReference<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
-      ByteSize: 16
-      GoKind: 25
-      RawFields:
-        - Name: data
-          Offset: 0
-          Type: 181 PointerType *noalg.map.group[string]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
-        - Name: lengthMask
-          Offset: 8
-          Type: 17 BaseType uint64
-      GroupType: 182 StructureType noalg.map.group[string]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
-      GroupSliceType: 289 GoSliceDataType []noalg.map.group[string]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute.array
-    - __kind: PointerType
-      ID: 181
-      Name: '*noalg.map.group[string]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute'
-      ByteSize: 8
-      Pointee: 182 StructureType noalg.map.group[string]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
-    - __kind: StructureType
-      ID: 182
-      Name: noalg.map.group[string]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
-      ByteSize: 200
-      GoRuntimeType: 1.331296e+06
-      GoKind: 25
-      RawFields:
-        - Name: ctrl
-          Offset: 0
-          Type: 17 BaseType uint64
-        - Name: slots
-          Offset: 8
-          Type: 183 ArrayType noalg.[8]struct { key string; elem *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute }
-    - __kind: ArrayType
-      ID: 183
-      Name: noalg.[8]struct { key string; elem *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute }
-      ByteSize: 192
-      GoRuntimeType: 715104
-      GoKind: 17
-      Count: 8
-      HasCount: true
-      Element: 184 StructureType noalg.struct { key string; elem *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute }
-    - __kind: StructureType
-      ID: 184
-      Name: noalg.struct { key string; elem *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute }
-      ByteSize: 24
-      GoRuntimeType: 1.331168e+06
-      GoKind: 25
-      RawFields:
-        - Name: key
-          Offset: 0
-          Type: 5 GoStringHeaderType string
-        - Name: elem
-          Offset: 16
-          Type: 185 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
-    - __kind: PointerType
-      ID: 185
-      Name: '*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute'
-      ByteSize: 8
-      GoRuntimeType: 1.214752e+06
-      GoKind: 22
-      Pointee: 186 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
-    - __kind: StructureType
-      ID: 186
-      Name: github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
-      ByteSize: 56
-      GoRuntimeType: 1.955104e+06
-      GoKind: 25
-      RawFields:
-        - Name: Type
-          Offset: 0
-          Type: 187 BaseType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttributeType
-        - Name: StringValue
-          Offset: 8
-          Type: 5 GoStringHeaderType string
-        - Name: BoolValue
-          Offset: 24
-          Type: 13 BaseType bool
-        - Name: IntValue
-          Offset: 32
-          Type: 32 BaseType int64
-        - Name: DoubleValue
-          Offset: 40
-          Type: 167 BaseType float64
-        - Name: ArrayValue
-          Offset: 48
-          Type: 188 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttribute
-    - __kind: BaseType
-      ID: 187
-      Name: github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttributeType
-      ByteSize: 4
-      GoRuntimeType: 1.006016e+06
-      GoKind: 5
-    - __kind: PointerType
-      ID: 188
-      Name: '*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttribute'
-      ByteSize: 8
-      GoRuntimeType: 1.214624e+06
-      GoKind: 22
-      Pointee: 189 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttribute
-    - __kind: StructureType
-      ID: 189
-      Name: github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttribute
-      ByteSize: 24
-      GoRuntimeType: 1.214496e+06
-      GoKind: 25
-      RawFields:
-        - Name: Values
-          Offset: 0
-          Type: 190 GoSliceHeaderType []*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttributeValue
-    - __kind: GoSliceHeaderType
-      ID: 190
-      Name: '[]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttributeValue'
-      ByteSize: 24
-      GoRuntimeType: 494688
-      GoKind: 23
-      RawFields:
-        - Name: array
-          Offset: 0
-          Type: 191 PointerType **github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttributeValue
-        - Name: len
-          Offset: 8
-          Type: 8 BaseType int
-        - Name: cap
-          Offset: 16
-          Type: 8 BaseType int
-      Data: 290 GoSliceDataType []*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttributeValue.array
-    - __kind: PointerType
-      ID: 191
-      Name: '**github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttributeValue'
-      ByteSize: 8
-      GoKind: 22
-      Pointee: 192 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttributeValue
-    - __kind: PointerType
-      ID: 192
-      Name: '*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttributeValue'
-      ByteSize: 8
-      GoRuntimeType: 1.214368e+06
-      GoKind: 22
-      Pointee: 193 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttributeValue
-    - __kind: StructureType
-      ID: 193
-      Name: github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttributeValue
-      ByteSize: 48
-      GoRuntimeType: 1.878208e+06
-      GoKind: 25
-      RawFields:
-        - Name: Type
-          Offset: 0
-          Type: 194 BaseType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttributeValueType
-        - Name: StringValue
-          Offset: 8
-          Type: 5 GoStringHeaderType string
-        - Name: BoolValue
-          Offset: 24
-          Type: 13 BaseType bool
-        - Name: IntValue
-          Offset: 32
-          Type: 32 BaseType int64
-        - Name: DoubleValue
-          Offset: 40
-          Type: 167 BaseType float64
-    - __kind: BaseType
-      ID: 194
-      Name: github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttributeValueType
-      ByteSize: 4
-      GoRuntimeType: 1.006112e+06
-      GoKind: 5
-    - __kind: GoMapType
-      ID: 195
-      Name: map[string]interface {}
-      ByteSize: 8
-      GoRuntimeType: 1.151104e+06
-      GoKind: 21
-      HeaderType: 147 GoSwissMapHeaderType map<string,interface {}>
-    - __kind: PointerType
-      ID: 196
-      Name: '*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanContext'
-      ByteSize: 8
-      GoRuntimeType: 2.053568e+06
-      GoKind: 22
-      Pointee: 197 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanContext
-    - __kind: StructureType
       ID: 197
       Name: github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanContext
       ByteSize: 168
@@ -2828,13 +1922,132 @@ Types:
         - Name: baggageOnly
           Offset: 160
           Type: 13 BaseType bool
-    - __kind: PointerType
-      ID: 198
-      Name: '*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.trace'
+    - __kind: StructureType
+      ID: 170
+      Name: github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink
+      ByteSize: 56
+      GoRuntimeType: 1.954848e+06
+      GoKind: 25
+      RawFields:
+        - Name: TraceID
+          Offset: 0
+          Type: 17 BaseType uint64
+        - Name: TraceIDHigh
+          Offset: 8
+          Type: 17 BaseType uint64
+        - Name: SpanID
+          Offset: 16
+          Type: 17 BaseType uint64
+        - Name: Attributes
+          Offset: 24
+          Type: 124 GoMapType map[string]string
+        - Name: Tracestate
+          Offset: 32
+          Type: 5 GoStringHeaderType string
+        - Name: Flags
+          Offset: 48
+          Type: 142 BaseType uint32
+    - __kind: GoMapType
+      ID: 145
+      Name: github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.metaStructMap
       ByteSize: 8
-      GoRuntimeType: 2.2768e+06
-      GoKind: 22
-      Pointee: 199 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.trace
+      GoRuntimeType: 1.303776e+06
+      GoKind: 21
+      HeaderType: 147 GoSwissMapHeaderType map<string,interface {}>
+    - __kind: BaseType
+      ID: 203
+      Name: github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.samplingDecision
+      ByteSize: 4
+      GoRuntimeType: 593792
+      GoKind: 10
+    - __kind: StructureType
+      ID: 173
+      Name: github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent
+      ByteSize: 40
+      GoRuntimeType: 1.78912e+06
+      GoKind: 25
+      RawFields:
+        - Name: Name
+          Offset: 0
+          Type: 5 GoStringHeaderType string
+        - Name: TimeUnixNano
+          Offset: 16
+          Type: 17 BaseType uint64
+        - Name: Attributes
+          Offset: 24
+          Type: 174 GoMapType map[string]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
+        - Name: RawAttributes
+          Offset: 32
+          Type: 195 GoMapType map[string]interface {}
+    - __kind: StructureType
+      ID: 189
+      Name: github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttribute
+      ByteSize: 24
+      GoRuntimeType: 1.214496e+06
+      GoKind: 25
+      RawFields:
+        - Name: Values
+          Offset: 0
+          Type: 190 GoSliceHeaderType []*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttributeValue
+    - __kind: StructureType
+      ID: 193
+      Name: github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttributeValue
+      ByteSize: 48
+      GoRuntimeType: 1.878208e+06
+      GoKind: 25
+      RawFields:
+        - Name: Type
+          Offset: 0
+          Type: 194 BaseType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttributeValueType
+        - Name: StringValue
+          Offset: 8
+          Type: 5 GoStringHeaderType string
+        - Name: BoolValue
+          Offset: 24
+          Type: 13 BaseType bool
+        - Name: IntValue
+          Offset: 32
+          Type: 32 BaseType int64
+        - Name: DoubleValue
+          Offset: 40
+          Type: 167 BaseType float64
+    - __kind: BaseType
+      ID: 194
+      Name: github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttributeValueType
+      ByteSize: 4
+      GoRuntimeType: 1.006112e+06
+      GoKind: 5
+    - __kind: StructureType
+      ID: 186
+      Name: github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
+      ByteSize: 56
+      GoRuntimeType: 1.955104e+06
+      GoKind: 25
+      RawFields:
+        - Name: Type
+          Offset: 0
+          Type: 187 BaseType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttributeType
+        - Name: StringValue
+          Offset: 8
+          Type: 5 GoStringHeaderType string
+        - Name: BoolValue
+          Offset: 24
+          Type: 13 BaseType bool
+        - Name: IntValue
+          Offset: 32
+          Type: 32 BaseType int64
+        - Name: DoubleValue
+          Offset: 40
+          Type: 167 BaseType float64
+        - Name: ArrayValue
+          Offset: 48
+          Type: 188 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttribute
+    - __kind: BaseType
+      ID: 187
+      Name: github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttributeType
+      ByteSize: 4
+      GoRuntimeType: 1.006016e+06
+      GoKind: 5
     - __kind: StructureType
       ID: 199
       Name: github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.trace
@@ -2872,42 +2085,6 @@ Types:
         - Name: root
           Offset: 96
           Type: 135 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span
-    - __kind: GoSliceHeaderType
-      ID: 200
-      Name: '[]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span'
-      ByteSize: 24
-      GoRuntimeType: 495072
-      GoKind: 23
-      RawFields:
-        - Name: array
-          Offset: 0
-          Type: 201 PointerType **github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span
-        - Name: len
-          Offset: 8
-          Type: 8 BaseType int
-        - Name: cap
-          Offset: 16
-          Type: 8 BaseType int
-      Data: 292 GoSliceDataType []*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span.array
-    - __kind: PointerType
-      ID: 201
-      Name: '**github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span'
-      ByteSize: 8
-      GoKind: 22
-      Pointee: 135 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span
-    - __kind: PointerType
-      ID: 202
-      Name: '*float64'
-      ByteSize: 8
-      GoRuntimeType: 405312
-      GoKind: 22
-      Pointee: 167 BaseType float64
-    - __kind: BaseType
-      ID: 203
-      Name: github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.samplingDecision
-      ByteSize: 4
-      GoRuntimeType: 593792
-      GoKind: 10
     - __kind: ArrayType
       ID: 204
       Name: github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.traceID
@@ -2917,59 +2094,151 @@ Types:
       Count: 16
       HasCount: true
       Element: 7 BaseType uint8
-    - __kind: GoSubroutineType
-      ID: 205
-      Name: func()
-      ByteSize: 8
-      GoRuntimeType: 484800
-      GoKind: 19
-    - __kind: PointerType
-      ID: 206
-      Name: '*bytes.Buffer'
-      ByteSize: 8
-      GoRuntimeType: 2.320608e+06
-      GoKind: 22
-      Pointee: 207 StructureType bytes.Buffer
-    - __kind: StructureType
-      ID: 207
-      Name: bytes.Buffer
-      ByteSize: 40
-      GoRuntimeType: 1.63984e+06
+    - __kind: GoSwissMapGroupsType
+      ID: 180
+      Name: groupReference<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
+      ByteSize: 16
       GoKind: 25
       RawFields:
-        - Name: buf
+        - Name: data
           Offset: 0
-          Type: 53 GoSliceHeaderType []uint8
-        - Name: off
-          Offset: 24
-          Type: 8 BaseType int
-        - Name: lastRead
-          Offset: 32
-          Type: 208 BaseType bytes.readOp
-    - __kind: BaseType
-      ID: 208
-      Name: bytes.readOp
-      ByteSize: 1
-      GoRuntimeType: 593216
-      GoKind: 3
-    - __kind: BaseType
-      ID: 209
-      Name: uint
-      ByteSize: 8
-      GoRuntimeType: 594624
-      GoKind: 7
-    - __kind: PointerType
-      ID: 210
-      Name: '*bool'
-      ByteSize: 8
-      GoRuntimeType: 405376
-      GoKind: 22
-      Pointee: 13 BaseType bool
-    - __kind: GoInterfaceType
-      ID: 211
-      Name: error
+          Type: 181 PointerType *noalg.map.group[string]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
+        - Name: lengthMask
+          Offset: 8
+          Type: 17 BaseType uint64
+      GroupType: 182 StructureType noalg.map.group[string]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
+      GroupSliceType: 289 GoSliceDataType []noalg.map.group[string]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute.array
+    - __kind: GoSwissMapGroupsType
+      ID: 43
+      Name: groupReference<string,[]*mime/multipart.FileHeader>
       ByteSize: 16
-      GoRuntimeType: 1.0536e+06
+      GoKind: 25
+      RawFields:
+        - Name: data
+          Offset: 0
+          Type: 44 PointerType *noalg.map.group[string][]*mime/multipart.FileHeader
+        - Name: lengthMask
+          Offset: 8
+          Type: 17 BaseType uint64
+      GroupType: 45 StructureType noalg.map.group[string][]*mime/multipart.FileHeader
+      GroupSliceType: 235 GoSliceDataType []noalg.map.group[string][]*mime/multipart.FileHeader.array
+    - __kind: GoSwissMapGroupsType
+      ID: 23
+      Name: groupReference<string,[]string>
+      ByteSize: 16
+      GoKind: 25
+      RawFields:
+        - Name: data
+          Offset: 0
+          Type: 24 PointerType *noalg.map.group[string][]string
+        - Name: lengthMask
+          Offset: 8
+          Type: 17 BaseType uint64
+      GroupType: 25 StructureType noalg.map.group[string][]string
+      GroupSliceType: 231 GoSliceDataType []noalg.map.group[string][]string.array
+    - __kind: GoSwissMapGroupsType
+      ID: 162
+      Name: groupReference<string,float64>
+      ByteSize: 16
+      GoKind: 25
+      RawFields:
+        - Name: data
+          Offset: 0
+          Type: 163 PointerType *noalg.map.group[string]float64
+        - Name: lengthMask
+          Offset: 8
+          Type: 17 BaseType uint64
+      GroupType: 164 StructureType noalg.map.group[string]float64
+      GroupSliceType: 283 GoSliceDataType []noalg.map.group[string]float64.array
+    - __kind: GoSwissMapGroupsType
+      ID: 151
+      Name: groupReference<string,interface {}>
+      ByteSize: 16
+      GoKind: 25
+      RawFields:
+        - Name: data
+          Offset: 0
+          Type: 152 PointerType *noalg.map.group[string]interface {}
+        - Name: lengthMask
+          Offset: 8
+          Type: 17 BaseType uint64
+      GroupType: 153 StructureType noalg.map.group[string]interface {}
+      GroupSliceType: 281 GoSliceDataType []noalg.map.group[string]interface {}.array
+    - __kind: GoSwissMapGroupsType
+      ID: 130
+      Name: groupReference<string,string>
+      ByteSize: 16
+      GoKind: 25
+      RawFields:
+        - Name: data
+          Offset: 0
+          Type: 131 PointerType *noalg.map.group[string]string
+        - Name: lengthMask
+          Offset: 8
+          Type: 17 BaseType uint64
+      GroupType: 132 StructureType noalg.map.group[string]string
+      GroupSliceType: 279 GoSliceDataType []noalg.map.group[string]string.array
+    - __kind: BaseType
+      ID: 8
+      Name: int
+      ByteSize: 8
+      GoRuntimeType: 594560
+      GoKind: 2
+    - __kind: BaseType
+      ID: 217
+      Name: int16
+      ByteSize: 2
+      GoRuntimeType: 594176
+      GoKind: 4
+    - __kind: BaseType
+      ID: 141
+      Name: int32
+      ByteSize: 4
+      GoRuntimeType: 594304
+      GoKind: 5
+    - __kind: BaseType
+      ID: 32
+      Name: int64
+      ByteSize: 8
+      GoRuntimeType: 594432
+      GoKind: 6
+    - __kind: BaseType
+      ID: 212
+      Name: int8
+      ByteSize: 1
+      GoRuntimeType: 594048
+      GoKind: 3
+    - __kind: GoEmptyInterfaceType
+      ID: 63
+      Name: interface {}
+      ByteSize: 16
+      GoRuntimeType: 866496
+      GoKind: 20
+      RawFields:
+        - Name: _type
+          Offset: 0
+          Type: 2 VoidPointerType unsafe.Pointer
+        - Name: data
+          Offset: 8
+          Type: 2 VoidPointerType unsafe.Pointer
+    - __kind: StructureType
+      ID: 140
+      Name: internal/sync.Mutex
+      ByteSize: 8
+      GoRuntimeType: 1.517472e+06
+      GoKind: 25
+      RawFields:
+        - Name: state
+          Offset: 0
+          Type: 141 BaseType int32
+        - Name: sema
+          Offset: 4
+          Type: 142 BaseType uint32
+    - __kind: GoInterfaceType
+      ID: 30
+      Name: io.ReadCloser
+      ByteSize: 16
+      GoRuntimeType: 1.134464e+06
       GoKind: 20
       RawFields:
         - Name: tab
@@ -2978,481 +2247,1212 @@ Types:
         - Name: data
           Offset: 8
           Type: 2 VoidPointerType unsafe.Pointer
+    - __kind: GoSwissMapHeaderType
+      ID: 176
+      Name: map<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
+      ByteSize: 48
+      GoKind: 25
+      RawFields:
+        - Name: used
+          Offset: 0
+          Type: 17 BaseType uint64
+        - Name: seed
+          Offset: 8
+          Type: 18 BaseType uintptr
+        - Name: dirPtr
+          Offset: 16
+          Type: 177 PointerType **table<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
+        - Name: dirLen
+          Offset: 24
+          Type: 8 BaseType int
+        - Name: globalDepth
+          Offset: 32
+          Type: 7 BaseType uint8
+        - Name: globalShift
+          Offset: 33
+          Type: 7 BaseType uint8
+        - Name: writing
+          Offset: 34
+          Type: 7 BaseType uint8
+        - Name: tombstonePossible
+          Offset: 35
+          Type: 13 BaseType bool
+        - Name: clearSeq
+          Offset: 40
+          Type: 17 BaseType uint64
+      TablePtrSliceType: 288 GoSliceDataType []*table<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>.array
+      GroupType: 182 StructureType noalg.map.group[string]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
+    - __kind: GoSwissMapHeaderType
+      ID: 39
+      Name: map<string,[]*mime/multipart.FileHeader>
+      ByteSize: 48
+      GoKind: 25
+      RawFields:
+        - Name: used
+          Offset: 0
+          Type: 17 BaseType uint64
+        - Name: seed
+          Offset: 8
+          Type: 18 BaseType uintptr
+        - Name: dirPtr
+          Offset: 16
+          Type: 40 PointerType **table<string,[]*mime/multipart.FileHeader>
+        - Name: dirLen
+          Offset: 24
+          Type: 8 BaseType int
+        - Name: globalDepth
+          Offset: 32
+          Type: 7 BaseType uint8
+        - Name: globalShift
+          Offset: 33
+          Type: 7 BaseType uint8
+        - Name: writing
+          Offset: 34
+          Type: 7 BaseType uint8
+        - Name: tombstonePossible
+          Offset: 35
+          Type: 13 BaseType bool
+        - Name: clearSeq
+          Offset: 40
+          Type: 17 BaseType uint64
+      TablePtrSliceType: 234 GoSliceDataType []*table<string,[]*mime/multipart.FileHeader>.array
+      GroupType: 45 StructureType noalg.map.group[string][]*mime/multipart.FileHeader
+    - __kind: GoSwissMapHeaderType
+      ID: 16
+      Name: map<string,[]string>
+      ByteSize: 48
+      GoKind: 25
+      RawFields:
+        - Name: used
+          Offset: 0
+          Type: 17 BaseType uint64
+        - Name: seed
+          Offset: 8
+          Type: 18 BaseType uintptr
+        - Name: dirPtr
+          Offset: 16
+          Type: 19 PointerType **table<string,[]string>
+        - Name: dirLen
+          Offset: 24
+          Type: 8 BaseType int
+        - Name: globalDepth
+          Offset: 32
+          Type: 7 BaseType uint8
+        - Name: globalShift
+          Offset: 33
+          Type: 7 BaseType uint8
+        - Name: writing
+          Offset: 34
+          Type: 7 BaseType uint8
+        - Name: tombstonePossible
+          Offset: 35
+          Type: 13 BaseType bool
+        - Name: clearSeq
+          Offset: 40
+          Type: 17 BaseType uint64
+      TablePtrSliceType: 230 GoSliceDataType []*table<string,[]string>.array
+      GroupType: 25 StructureType noalg.map.group[string][]string
+    - __kind: GoSwissMapHeaderType
+      ID: 158
+      Name: map<string,float64>
+      ByteSize: 48
+      GoKind: 25
+      RawFields:
+        - Name: used
+          Offset: 0
+          Type: 17 BaseType uint64
+        - Name: seed
+          Offset: 8
+          Type: 18 BaseType uintptr
+        - Name: dirPtr
+          Offset: 16
+          Type: 159 PointerType **table<string,float64>
+        - Name: dirLen
+          Offset: 24
+          Type: 8 BaseType int
+        - Name: globalDepth
+          Offset: 32
+          Type: 7 BaseType uint8
+        - Name: globalShift
+          Offset: 33
+          Type: 7 BaseType uint8
+        - Name: writing
+          Offset: 34
+          Type: 7 BaseType uint8
+        - Name: tombstonePossible
+          Offset: 35
+          Type: 13 BaseType bool
+        - Name: clearSeq
+          Offset: 40
+          Type: 17 BaseType uint64
+      TablePtrSliceType: 282 GoSliceDataType []*table<string,float64>.array
+      GroupType: 164 StructureType noalg.map.group[string]float64
+    - __kind: GoSwissMapHeaderType
+      ID: 147
+      Name: map<string,interface {}>
+      ByteSize: 48
+      GoKind: 25
+      RawFields:
+        - Name: used
+          Offset: 0
+          Type: 17 BaseType uint64
+        - Name: seed
+          Offset: 8
+          Type: 18 BaseType uintptr
+        - Name: dirPtr
+          Offset: 16
+          Type: 148 PointerType **table<string,interface {}>
+        - Name: dirLen
+          Offset: 24
+          Type: 8 BaseType int
+        - Name: globalDepth
+          Offset: 32
+          Type: 7 BaseType uint8
+        - Name: globalShift
+          Offset: 33
+          Type: 7 BaseType uint8
+        - Name: writing
+          Offset: 34
+          Type: 7 BaseType uint8
+        - Name: tombstonePossible
+          Offset: 35
+          Type: 13 BaseType bool
+        - Name: clearSeq
+          Offset: 40
+          Type: 17 BaseType uint64
+      TablePtrSliceType: 280 GoSliceDataType []*table<string,interface {}>.array
+      GroupType: 153 StructureType noalg.map.group[string]interface {}
+    - __kind: GoSwissMapHeaderType
+      ID: 126
+      Name: map<string,string>
+      ByteSize: 48
+      GoKind: 25
+      RawFields:
+        - Name: used
+          Offset: 0
+          Type: 17 BaseType uint64
+        - Name: seed
+          Offset: 8
+          Type: 18 BaseType uintptr
+        - Name: dirPtr
+          Offset: 16
+          Type: 127 PointerType **table<string,string>
+        - Name: dirLen
+          Offset: 24
+          Type: 8 BaseType int
+        - Name: globalDepth
+          Offset: 32
+          Type: 7 BaseType uint8
+        - Name: globalShift
+          Offset: 33
+          Type: 7 BaseType uint8
+        - Name: writing
+          Offset: 34
+          Type: 7 BaseType uint8
+        - Name: tombstonePossible
+          Offset: 35
+          Type: 13 BaseType bool
+        - Name: clearSeq
+          Offset: 40
+          Type: 17 BaseType uint64
+      TablePtrSliceType: 278 GoSliceDataType []*table<string,string>.array
+      GroupType: 132 StructureType noalg.map.group[string]string
+    - __kind: GoMapType
+      ID: 174
+      Name: map[string]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
+      ByteSize: 8
+      GoRuntimeType: 1.157632e+06
+      GoKind: 21
+      HeaderType: 176 GoSwissMapHeaderType map<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
+    - __kind: GoMapType
+      ID: 37
+      Name: map[string][]*mime/multipart.FileHeader
+      ByteSize: 8
+      GoRuntimeType: 1.156864e+06
+      GoKind: 21
+      HeaderType: 39 GoSwissMapHeaderType map<string,[]*mime/multipart.FileHeader>
+    - __kind: GoMapType
+      ID: 36
+      Name: map[string][]string
+      ByteSize: 8
+      GoRuntimeType: 1.152512e+06
+      GoKind: 21
+      HeaderType: 16 GoSwissMapHeaderType map<string,[]string>
+    - __kind: GoMapType
+      ID: 156
+      Name: map[string]float64
+      ByteSize: 8
+      GoRuntimeType: 1.157504e+06
+      GoKind: 21
+      HeaderType: 158 GoSwissMapHeaderType map<string,float64>
+    - __kind: GoMapType
+      ID: 195
+      Name: map[string]interface {}
+      ByteSize: 8
+      GoRuntimeType: 1.151104e+06
+      GoKind: 21
+      HeaderType: 147 GoSwissMapHeaderType map<string,interface {}>
+    - __kind: GoMapType
+      ID: 124
+      Name: map[string]string
+      ByteSize: 8
+      GoRuntimeType: 1.153536e+06
+      GoKind: 21
+      HeaderType: 126 GoSwissMapHeaderType map<string,string>
+    - __kind: StructureType
+      ID: 65
+      Name: math/big.Int
+      ByteSize: 32
+      GoRuntimeType: 1.522752e+06
+      GoKind: 25
+      RawFields:
+        - Name: neg
+          Offset: 0
+          Type: 13 BaseType bool
+        - Name: abs
+          Offset: 8
+          Type: 66 GoSliceHeaderType math/big.nat
     - __kind: BaseType
-      ID: 212
-      Name: int8
-      ByteSize: 1
-      GoRuntimeType: 594048
-      GoKind: 3
-    - __kind: BaseType
-      ID: 213
-      Name: float32
-      ByteSize: 4
-      GoRuntimeType: 594880
-      GoKind: 13
-    - __kind: PointerType
-      ID: 214
-      Name: '*uintptr'
+      ID: 68
+      Name: math/big.Word
       ByteSize: 8
-      GoRuntimeType: 405056
-      GoKind: 22
-      Pointee: 18 BaseType uintptr
-    - __kind: PointerType
-      ID: 215
-      Name: '*int32'
-      ByteSize: 8
-      GoRuntimeType: 404672
-      GoKind: 22
-      Pointee: 141 BaseType int32
-    - __kind: PointerType
-      ID: 216
-      Name: '*uint32'
-      ByteSize: 8
-      GoRuntimeType: 404736
-      GoKind: 22
-      Pointee: 142 BaseType uint32
-    - __kind: BaseType
-      ID: 217
-      Name: int16
-      ByteSize: 2
-      GoRuntimeType: 594176
-      GoKind: 4
-    - __kind: BaseType
-      ID: 218
-      Name: complex64
-      ByteSize: 8
-      GoRuntimeType: 594752
-      GoKind: 15
-    - __kind: BaseType
-      ID: 219
-      Name: complex128
-      ByteSize: 16
-      GoRuntimeType: 594816
-      GoKind: 16
-    - __kind: PointerType
-      ID: 220
-      Name: '*uint64'
-      ByteSize: 8
-      GoRuntimeType: 404864
-      GoKind: 22
-      Pointee: 17 BaseType uint64
-    - __kind: PointerType
-      ID: 221
-      Name: '*int64'
-      ByteSize: 8
-      GoRuntimeType: 404800
-      GoKind: 22
-      Pointee: 32 BaseType int64
-    - __kind: PointerType
-      ID: 222
-      Name: '*uint16'
-      ByteSize: 8
-      GoRuntimeType: 404608
-      GoKind: 22
-      Pointee: 22 BaseType uint16
-    - __kind: PointerType
-      ID: 223
-      Name: '*int16'
-      ByteSize: 8
-      GoRuntimeType: 404544
-      GoKind: 22
-      Pointee: 217 BaseType int16
-    - __kind: PointerType
-      ID: 224
-      Name: '*int8'
-      ByteSize: 8
-      GoRuntimeType: 404416
-      GoKind: 22
-      Pointee: 212 BaseType int8
-    - __kind: PointerType
-      ID: 225
-      Name: '*error'
-      ByteSize: 8
-      GoRuntimeType: 404288
-      GoKind: 22
-      Pointee: 211 GoInterfaceType error
-    - __kind: PointerType
-      ID: 226
-      Name: '*uint'
-      ByteSize: 8
-      GoRuntimeType: 404992
-      GoKind: 22
-      Pointee: 209 BaseType uint
-    - __kind: PointerType
-      ID: 227
-      Name: '*float32'
-      ByteSize: 8
-      GoRuntimeType: 405248
-      GoKind: 22
-      Pointee: 213 BaseType float32
-    - __kind: GoStringDataType
-      ID: 228
-      Name: string.str
-      ByteSize: 2048
-    - __kind: PointerType
-      ID: 229
-      Name: '*string.str'
-      ByteSize: 8
-      Pointee: 228 GoStringDataType string.str
-    - __kind: GoSliceDataType
-      ID: 230
-      Name: '[]*table<string,[]string>.array'
-      ByteSize: 8192
-      Element: 20 PointerType *table<string,[]string>
-    - __kind: GoSliceDataType
-      ID: 231
-      Name: '[]noalg.map.group[string][]string.array'
-      ByteSize: 2048
-      Element: 25 StructureType noalg.map.group[string][]string
-    - __kind: GoSliceDataType
-      ID: 232
-      Name: '[]string.array'
-      ByteSize: 2048
-      Element: 5 GoStringHeaderType string
-    - __kind: PointerType
-      ID: 233
-      Name: '*[]string.array'
-      ByteSize: 8
-      Pointee: 232 GoSliceDataType []string.array
-    - __kind: GoSliceDataType
-      ID: 234
-      Name: '[]*table<string,[]*mime/multipart.FileHeader>.array'
-      ByteSize: 8192
-      Element: 41 PointerType *table<string,[]*mime/multipart.FileHeader>
-    - __kind: GoSliceDataType
-      ID: 235
-      Name: '[]noalg.map.group[string][]*mime/multipart.FileHeader.array'
-      ByteSize: 2048
-      Element: 45 StructureType noalg.map.group[string][]*mime/multipart.FileHeader
-    - __kind: GoSliceDataType
-      ID: 236
-      Name: '[]*mime/multipart.FileHeader.array'
-      ByteSize: 2048
-      Element: 50 PointerType *mime/multipart.FileHeader
-    - __kind: PointerType
-      ID: 237
-      Name: '*[]*mime/multipart.FileHeader.array'
-      ByteSize: 8
-      Pointee: 236 GoSliceDataType []*mime/multipart.FileHeader.array
-    - __kind: GoSliceDataType
-      ID: 238
-      Name: '[]uint8.array'
-      ByteSize: 2048
-      Element: 7 BaseType uint8
-    - __kind: PointerType
-      ID: 239
-      Name: '*[]uint8.array'
-      ByteSize: 8
-      Pointee: 238 GoSliceDataType []uint8.array
-    - __kind: GoSliceDataType
-      ID: 240
-      Name: '[]*crypto/x509.Certificate.array'
-      ByteSize: 2048
-      Element: 59 PointerType *crypto/x509.Certificate
-    - __kind: PointerType
-      ID: 241
-      Name: '*[]*crypto/x509.Certificate.array'
-      ByteSize: 8
-      Pointee: 240 GoSliceDataType []*crypto/x509.Certificate.array
+      GoRuntimeType: 598272
+      GoKind: 7
+    - __kind: GoSliceHeaderType
+      ID: 66
+      Name: math/big.nat
+      ByteSize: 24
+      GoRuntimeType: 2.426144e+06
+      GoKind: 23
+      RawFields:
+        - Name: array
+          Offset: 0
+          Type: 67 PointerType *math/big.Word
+        - Name: len
+          Offset: 8
+          Type: 8 BaseType int
+        - Name: cap
+          Offset: 16
+          Type: 8 BaseType int
+      Data: 242 GoSliceDataType math/big.nat.array
     - __kind: GoSliceDataType
       ID: 242
       Name: math/big.nat.array
       ByteSize: 2048
       Element: 68 BaseType math/big.Word
-    - __kind: PointerType
-      ID: 243
-      Name: '*math/big.nat.array'
-      ByteSize: 8
-      Pointee: 242 GoSliceDataType math/big.nat.array
-    - __kind: GoSliceDataType
-      ID: 244
-      Name: '[]crypto/x509/pkix.AttributeTypeAndValue.array'
-      ByteSize: 2048
-      Element: 72 StructureType crypto/x509/pkix.AttributeTypeAndValue
-    - __kind: PointerType
-      ID: 245
-      Name: '*[]crypto/x509/pkix.AttributeTypeAndValue.array'
-      ByteSize: 8
-      Pointee: 244 GoSliceDataType []crypto/x509/pkix.AttributeTypeAndValue.array
-    - __kind: GoSliceDataType
-      ID: 246
-      Name: encoding/asn1.ObjectIdentifier.array
-      ByteSize: 2048
-      Element: 8 BaseType int
-    - __kind: PointerType
-      ID: 247
-      Name: '*encoding/asn1.ObjectIdentifier.array'
-      ByteSize: 8
-      Pointee: 246 GoSliceDataType encoding/asn1.ObjectIdentifier.array
-    - __kind: GoSliceDataType
-      ID: 248
-      Name: '[]time.zone.array'
-      ByteSize: 2048
-      Element: 80 StructureType time.zone
-    - __kind: PointerType
-      ID: 249
-      Name: '*[]time.zone.array'
-      ByteSize: 8
-      Pointee: 248 GoSliceDataType []time.zone.array
-    - __kind: GoSliceDataType
-      ID: 250
-      Name: '[]time.zoneTrans.array'
-      ByteSize: 2048
-      Element: 83 StructureType time.zoneTrans
-    - __kind: PointerType
-      ID: 251
-      Name: '*[]time.zoneTrans.array'
-      ByteSize: 8
-      Pointee: 250 GoSliceDataType []time.zoneTrans.array
-    - __kind: GoSliceDataType
-      ID: 252
-      Name: '[]crypto/x509/pkix.Extension.array'
-      ByteSize: 2048
-      Element: 87 StructureType crypto/x509/pkix.Extension
-    - __kind: PointerType
-      ID: 253
-      Name: '*[]crypto/x509/pkix.Extension.array'
-      ByteSize: 8
-      Pointee: 252 GoSliceDataType []crypto/x509/pkix.Extension.array
-    - __kind: GoSliceDataType
-      ID: 254
-      Name: '[]encoding/asn1.ObjectIdentifier.array'
-      ByteSize: 2048
-      Element: 73 GoSliceHeaderType encoding/asn1.ObjectIdentifier
-    - __kind: PointerType
-      ID: 255
-      Name: '*[]encoding/asn1.ObjectIdentifier.array'
-      ByteSize: 8
-      Pointee: 254 GoSliceDataType []encoding/asn1.ObjectIdentifier.array
-    - __kind: GoSliceDataType
-      ID: 256
-      Name: '[]crypto/x509.ExtKeyUsage.array'
-      ByteSize: 2048
-      Element: 92 BaseType crypto/x509.ExtKeyUsage
-    - __kind: PointerType
-      ID: 257
-      Name: '*[]crypto/x509.ExtKeyUsage.array'
-      ByteSize: 8
-      Pointee: 256 GoSliceDataType []crypto/x509.ExtKeyUsage.array
-    - __kind: GoSliceDataType
-      ID: 258
-      Name: '[]net.IP.array'
-      ByteSize: 2048
-      Element: 95 GoSliceHeaderType net.IP
-    - __kind: PointerType
-      ID: 259
-      Name: '*[]net.IP.array'
-      ByteSize: 8
-      Pointee: 258 GoSliceDataType []net.IP.array
+    - __kind: StructureType
+      ID: 51
+      Name: mime/multipart.FileHeader
+      ByteSize: 88
+      GoRuntimeType: 2.018016e+06
+      GoKind: 25
+      RawFields:
+        - Name: Filename
+          Offset: 0
+          Type: 5 GoStringHeaderType string
+        - Name: Header
+          Offset: 16
+          Type: 52 GoMapType net/textproto.MIMEHeader
+        - Name: Size
+          Offset: 24
+          Type: 32 BaseType int64
+        - Name: content
+          Offset: 32
+          Type: 53 GoSliceHeaderType []uint8
+        - Name: tmpfile
+          Offset: 56
+          Type: 5 GoStringHeaderType string
+        - Name: tmpoff
+          Offset: 72
+          Type: 32 BaseType int64
+        - Name: tmpshared
+          Offset: 80
+          Type: 13 BaseType bool
+    - __kind: StructureType
+      ID: 35
+      Name: mime/multipart.Form
+      ByteSize: 16
+      GoRuntimeType: 1.505952e+06
+      GoKind: 25
+      RawFields:
+        - Name: Value
+          Offset: 0
+          Type: 36 GoMapType map[string][]string
+        - Name: File
+          Offset: 8
+          Type: 37 GoMapType map[string][]*mime/multipart.FileHeader
+    - __kind: GoSliceHeaderType
+      ID: 95
+      Name: net.IP
+      ByteSize: 24
+      GoRuntimeType: 2.178176e+06
+      GoKind: 23
+      RawFields:
+        - Name: array
+          Offset: 0
+          Type: 6 PointerType *uint8
+        - Name: len
+          Offset: 8
+          Type: 8 BaseType int
+        - Name: cap
+          Offset: 16
+          Type: 8 BaseType int
+      Data: 260 GoSliceDataType net.IP.array
     - __kind: GoSliceDataType
       ID: 260
       Name: net.IP.array
       ByteSize: 2048
       Element: 7 BaseType uint8
-    - __kind: PointerType
-      ID: 261
-      Name: '*net.IP.array'
-      ByteSize: 8
-      Pointee: 260 GoSliceDataType net.IP.array
-    - __kind: GoSliceDataType
-      ID: 262
-      Name: '[]*net/url.URL.array'
-      ByteSize: 2048
-      Element: 9 PointerType *net/url.URL
-    - __kind: PointerType
-      ID: 263
-      Name: '*[]*net/url.URL.array'
-      ByteSize: 8
-      Pointee: 262 GoSliceDataType []*net/url.URL.array
-    - __kind: GoSliceDataType
-      ID: 264
-      Name: '[]*net.IPNet.array'
-      ByteSize: 2048
-      Element: 100 PointerType *net.IPNet
-    - __kind: PointerType
-      ID: 265
-      Name: '*[]*net.IPNet.array'
-      ByteSize: 8
-      Pointee: 264 GoSliceDataType []*net.IPNet.array
+    - __kind: GoSliceHeaderType
+      ID: 102
+      Name: net.IPMask
+      ByteSize: 24
+      GoRuntimeType: 1.041568e+06
+      GoKind: 23
+      RawFields:
+        - Name: array
+          Offset: 0
+          Type: 6 PointerType *uint8
+        - Name: len
+          Offset: 8
+          Type: 8 BaseType int
+        - Name: cap
+          Offset: 16
+          Type: 8 BaseType int
+      Data: 266 GoSliceDataType net.IPMask.array
     - __kind: GoSliceDataType
       ID: 266
       Name: net.IPMask.array
       ByteSize: 2048
       Element: 7 BaseType uint8
-    - __kind: PointerType
-      ID: 267
-      Name: '*net.IPMask.array'
+    - __kind: StructureType
+      ID: 101
+      Name: net.IPNet
+      ByteSize: 48
+      GoRuntimeType: 1.486272e+06
+      GoKind: 25
+      RawFields:
+        - Name: IP
+          Offset: 0
+          Type: 95 GoSliceHeaderType net.IP
+        - Name: Mask
+          Offset: 24
+          Type: 102 GoSliceHeaderType net.IPMask
+    - __kind: GoMapType
+      ID: 14
+      Name: net/http.Header
       ByteSize: 8
-      Pointee: 266 GoSliceDataType net.IPMask.array
-    - __kind: GoSliceDataType
-      ID: 268
-      Name: '[]crypto/x509.OID.array'
-      ByteSize: 2048
-      Element: 105 StructureType crypto/x509.OID
-    - __kind: PointerType
-      ID: 269
-      Name: '*[]crypto/x509.OID.array'
-      ByteSize: 8
-      Pointee: 268 GoSliceDataType []crypto/x509.OID.array
-    - __kind: GoSliceDataType
-      ID: 270
-      Name: '[]crypto/x509.PolicyMapping.array'
-      ByteSize: 2048
-      Element: 108 StructureType crypto/x509.PolicyMapping
-    - __kind: PointerType
-      ID: 271
-      Name: '*[]crypto/x509.PolicyMapping.array'
-      ByteSize: 8
-      Pointee: 270 GoSliceDataType []crypto/x509.PolicyMapping.array
-    - __kind: GoSliceDataType
-      ID: 272
-      Name: '[][]*crypto/x509.Certificate.array'
-      ByteSize: 2048
-      Element: 57 GoSliceHeaderType []*crypto/x509.Certificate
-    - __kind: PointerType
-      ID: 273
-      Name: '*[][]*crypto/x509.Certificate.array'
-      ByteSize: 8
-      Pointee: 272 GoSliceDataType [][]*crypto/x509.Certificate.array
-    - __kind: GoSliceDataType
-      ID: 274
-      Name: '[][]uint8.array'
-      ByteSize: 2048
-      Element: 53 GoSliceHeaderType []uint8
-    - __kind: PointerType
-      ID: 275
-      Name: '*[][]uint8.array'
-      ByteSize: 8
-      Pointee: 274 GoSliceDataType [][]uint8.array
-    - __kind: GoSliceDataType
-      ID: 276
-      Name: '[]net/http.segment.array'
-      ByteSize: 2048
-      Element: 123 StructureType net/http.segment
-    - __kind: PointerType
-      ID: 277
-      Name: '*[]net/http.segment.array'
-      ByteSize: 8
-      Pointee: 276 GoSliceDataType []net/http.segment.array
-    - __kind: GoSliceDataType
-      ID: 278
-      Name: '[]*table<string,string>.array'
-      ByteSize: 8192
-      Element: 128 PointerType *table<string,string>
-    - __kind: GoSliceDataType
-      ID: 279
-      Name: '[]noalg.map.group[string]string.array'
-      ByteSize: 2048
-      Element: 132 StructureType noalg.map.group[string]string
-    - __kind: GoSliceDataType
-      ID: 280
-      Name: '[]*table<string,interface {}>.array'
-      ByteSize: 8192
-      Element: 149 PointerType *table<string,interface {}>
-    - __kind: GoSliceDataType
-      ID: 281
-      Name: '[]noalg.map.group[string]interface {}.array'
-      ByteSize: 2048
-      Element: 153 StructureType noalg.map.group[string]interface {}
-    - __kind: GoSliceDataType
-      ID: 282
-      Name: '[]*table<string,float64>.array'
-      ByteSize: 8192
-      Element: 160 PointerType *table<string,float64>
-    - __kind: GoSliceDataType
-      ID: 283
-      Name: '[]noalg.map.group[string]float64.array'
-      ByteSize: 2048
-      Element: 164 StructureType noalg.map.group[string]float64
-    - __kind: GoSliceDataType
-      ID: 284
-      Name: '[]github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink.array'
-      ByteSize: 2048
-      Element: 170 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink
-    - __kind: PointerType
-      ID: 285
-      Name: '*[]github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink.array'
-      ByteSize: 8
-      Pointee: 284 GoSliceDataType []github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink.array
-    - __kind: GoSliceDataType
-      ID: 286
-      Name: '[]github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent.array'
-      ByteSize: 2048
-      Element: 173 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent
-    - __kind: PointerType
-      ID: 287
-      Name: '*[]github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent.array'
-      ByteSize: 8
-      Pointee: 286 GoSliceDataType []github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent.array
-    - __kind: GoSliceDataType
-      ID: 288
-      Name: '[]*table<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>.array'
-      ByteSize: 8192
-      Element: 178 PointerType *table<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
-    - __kind: GoSliceDataType
-      ID: 289
-      Name: '[]noalg.map.group[string]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute.array'
-      ByteSize: 2048
-      Element: 182 StructureType noalg.map.group[string]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
-    - __kind: GoSliceDataType
-      ID: 290
-      Name: '[]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttributeValue.array'
-      ByteSize: 2048
-      Element: 192 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttributeValue
-    - __kind: PointerType
-      ID: 291
-      Name: '*[]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttributeValue.array'
-      ByteSize: 8
-      Pointee: 290 GoSliceDataType []*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttributeValue.array
-    - __kind: GoSliceDataType
-      ID: 292
-      Name: '[]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span.array'
-      ByteSize: 2048
-      Element: 135 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span
-    - __kind: PointerType
-      ID: 293
-      Name: '*[]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span.array'
-      ByteSize: 8
-      Pointee: 292 GoSliceDataType []*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span.array
-    - __kind: EventRootType
-      ID: 294
-      Name: Probe[main.HandleHTTP]
-      ByteSize: 25
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: w
-          Offset: 1
-          Expression:
-            Type: 1 GoInterfaceType net/http.ResponseWriter
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 1, index: 0, name: w}
-                  Offset: 0
-                  ByteSize: 16
-        - Name: r
+      GoRuntimeType: 2.154272e+06
+      GoKind: 21
+      HeaderType: 16 GoSwissMapHeaderType map<string,[]string>
+    - __kind: StructureType
+      ID: 4
+      Name: net/http.Request
+      ByteSize: 304
+      GoRuntimeType: 2.40112e+06
+      GoKind: 25
+      RawFields:
+        - Name: Method
+          Offset: 0
+          Type: 5 GoStringHeaderType string
+        - Name: URL
+          Offset: 16
+          Type: 9 PointerType *net/url.URL
+        - Name: Proto
+          Offset: 24
+          Type: 5 GoStringHeaderType string
+        - Name: ProtoMajor
+          Offset: 40
+          Type: 8 BaseType int
+        - Name: ProtoMinor
+          Offset: 48
+          Type: 8 BaseType int
+        - Name: Header
+          Offset: 56
+          Type: 14 GoMapType net/http.Header
+        - Name: Body
+          Offset: 64
+          Type: 30 GoInterfaceType io.ReadCloser
+        - Name: GetBody
+          Offset: 80
+          Type: 31 GoSubroutineType func() (io.ReadCloser, error)
+        - Name: ContentLength
+          Offset: 88
+          Type: 32 BaseType int64
+        - Name: TransferEncoding
+          Offset: 96
+          Type: 28 GoSliceHeaderType []string
+        - Name: Close
+          Offset: 120
+          Type: 13 BaseType bool
+        - Name: Host
+          Offset: 128
+          Type: 5 GoStringHeaderType string
+        - Name: Form
+          Offset: 144
+          Type: 33 GoMapType net/url.Values
+        - Name: PostForm
+          Offset: 152
+          Type: 33 GoMapType net/url.Values
+        - Name: MultipartForm
+          Offset: 160
+          Type: 34 PointerType *mime/multipart.Form
+        - Name: Trailer
+          Offset: 168
+          Type: 14 GoMapType net/http.Header
+        - Name: RemoteAddr
+          Offset: 176
+          Type: 5 GoStringHeaderType string
+        - Name: RequestURI
+          Offset: 192
+          Type: 5 GoStringHeaderType string
+        - Name: TLS
+          Offset: 208
+          Type: 54 PointerType *crypto/tls.ConnectionState
+        - Name: Cancel
+          Offset: 216
+          Type: 115 GoChannelType <-chan struct {}
+        - Name: Response
+          Offset: 224
+          Type: 116 PointerType *net/http.Response
+        - Name: Pattern
+          Offset: 232
+          Type: 5 GoStringHeaderType string
+        - Name: ctx
+          Offset: 248
+          Type: 118 GoInterfaceType context.Context
+        - Name: pat
+          Offset: 264
+          Type: 119 PointerType *net/http.pattern
+        - Name: matches
+          Offset: 272
+          Type: 28 GoSliceHeaderType []string
+        - Name: otherValues
+          Offset: 296
+          Type: 124 GoMapType map[string]string
+    - __kind: StructureType
+      ID: 117
+      Name: net/http.Response
+      ByteSize: 144
+      GoRuntimeType: 2.26784e+06
+      GoKind: 25
+      RawFields:
+        - Name: Status
+          Offset: 0
+          Type: 5 GoStringHeaderType string
+        - Name: StatusCode
+          Offset: 16
+          Type: 8 BaseType int
+        - Name: Proto
+          Offset: 24
+          Type: 5 GoStringHeaderType string
+        - Name: ProtoMajor
+          Offset: 40
+          Type: 8 BaseType int
+        - Name: ProtoMinor
+          Offset: 48
+          Type: 8 BaseType int
+        - Name: Header
+          Offset: 56
+          Type: 14 GoMapType net/http.Header
+        - Name: Body
+          Offset: 64
+          Type: 30 GoInterfaceType io.ReadCloser
+        - Name: ContentLength
+          Offset: 80
+          Type: 32 BaseType int64
+        - Name: TransferEncoding
+          Offset: 88
+          Type: 28 GoSliceHeaderType []string
+        - Name: Close
+          Offset: 112
+          Type: 13 BaseType bool
+        - Name: Uncompressed
+          Offset: 113
+          Type: 13 BaseType bool
+        - Name: Trailer
+          Offset: 120
+          Type: 14 GoMapType net/http.Header
+        - Name: Request
+          Offset: 128
+          Type: 3 PointerType *net/http.Request
+        - Name: TLS
+          Offset: 136
+          Type: 54 PointerType *crypto/tls.ConnectionState
+    - __kind: GoInterfaceType
+      ID: 1
+      Name: net/http.ResponseWriter
+      ByteSize: 16
+      GoRuntimeType: 1.210144e+06
+      GoKind: 20
+      RawFields:
+        - Name: tab
+          Offset: 0
+          Type: 2 VoidPointerType unsafe.Pointer
+        - Name: data
+          Offset: 8
+          Type: 2 VoidPointerType unsafe.Pointer
+    - __kind: StructureType
+      ID: 120
+      Name: net/http.pattern
+      ByteSize: 88
+      GoRuntimeType: 1.875072e+06
+      GoKind: 25
+      RawFields:
+        - Name: str
+          Offset: 0
+          Type: 5 GoStringHeaderType string
+        - Name: method
+          Offset: 16
+          Type: 5 GoStringHeaderType string
+        - Name: host
+          Offset: 32
+          Type: 5 GoStringHeaderType string
+        - Name: segments
+          Offset: 48
+          Type: 121 GoSliceHeaderType []net/http.segment
+        - Name: loc
+          Offset: 72
+          Type: 5 GoStringHeaderType string
+    - __kind: StructureType
+      ID: 123
+      Name: net/http.segment
+      ByteSize: 24
+      GoRuntimeType: 1.641952e+06
+      GoKind: 25
+      RawFields:
+        - Name: s
+          Offset: 0
+          Type: 5 GoStringHeaderType string
+        - Name: wild
+          Offset: 16
+          Type: 13 BaseType bool
+        - Name: multi
           Offset: 17
-          Expression:
-            Type: 3 PointerType *net/http.Request
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 1, index: 1, name: r}
-                  Offset: 0
-                  ByteSize: 8
-    - __kind: EventRootType
-      ID: 295
-      Name: Probe[main.LookAtTheRequest]
-      ByteSize: 17
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: path
-          Offset: 1
-          Expression:
-            Type: 5 GoStringHeaderType string
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 2, index: 0, name: path}
-                  Offset: 0
-                  ByteSize: 16
+          Type: 13 BaseType bool
+    - __kind: GoMapType
+      ID: 52
+      Name: net/textproto.MIMEHeader
+      ByteSize: 8
+      GoRuntimeType: 1.863136e+06
+      GoKind: 21
+      HeaderType: 16 GoSwissMapHeaderType map<string,[]string>
+    - __kind: StructureType
+      ID: 10
+      Name: net/url.URL
+      ByteSize: 144
+      GoRuntimeType: 2.180864e+06
+      GoKind: 25
+      RawFields:
+        - Name: Scheme
+          Offset: 0
+          Type: 5 GoStringHeaderType string
+        - Name: Opaque
+          Offset: 16
+          Type: 5 GoStringHeaderType string
+        - Name: User
+          Offset: 32
+          Type: 11 PointerType *net/url.Userinfo
+        - Name: Host
+          Offset: 40
+          Type: 5 GoStringHeaderType string
+        - Name: Path
+          Offset: 56
+          Type: 5 GoStringHeaderType string
+        - Name: RawPath
+          Offset: 72
+          Type: 5 GoStringHeaderType string
+        - Name: OmitHost
+          Offset: 88
+          Type: 13 BaseType bool
+        - Name: ForceQuery
+          Offset: 89
+          Type: 13 BaseType bool
+        - Name: RawQuery
+          Offset: 96
+          Type: 5 GoStringHeaderType string
+        - Name: Fragment
+          Offset: 112
+          Type: 5 GoStringHeaderType string
+        - Name: RawFragment
+          Offset: 128
+          Type: 5 GoStringHeaderType string
+    - __kind: StructureType
+      ID: 12
+      Name: net/url.Userinfo
+      ByteSize: 40
+      GoRuntimeType: 1.65808e+06
+      GoKind: 25
+      RawFields:
+        - Name: username
+          Offset: 0
+          Type: 5 GoStringHeaderType string
+        - Name: password
+          Offset: 16
+          Type: 5 GoStringHeaderType string
+        - Name: passwordSet
+          Offset: 32
+          Type: 13 BaseType bool
+    - __kind: GoMapType
+      ID: 33
+      Name: net/url.Values
+      ByteSize: 8
+      GoRuntimeType: 1.927712e+06
+      GoKind: 21
+      HeaderType: 16 GoSwissMapHeaderType map<string,[]string>
+    - __kind: ArrayType
+      ID: 183
+      Name: noalg.[8]struct { key string; elem *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute }
+      ByteSize: 192
+      GoRuntimeType: 715104
+      GoKind: 17
+      Count: 8
+      HasCount: true
+      Element: 184 StructureType noalg.struct { key string; elem *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute }
+    - __kind: ArrayType
+      ID: 46
+      Name: noalg.[8]struct { key string; elem []*mime/multipart.FileHeader }
+      ByteSize: 320
+      GoRuntimeType: 710720
+      GoKind: 17
+      Count: 8
+      HasCount: true
+      Element: 47 StructureType noalg.struct { key string; elem []*mime/multipart.FileHeader }
+    - __kind: ArrayType
+      ID: 26
+      Name: noalg.[8]struct { key string; elem []string }
+      ByteSize: 320
+      GoRuntimeType: 700896
+      GoKind: 17
+      Count: 8
+      HasCount: true
+      Element: 27 StructureType noalg.struct { key string; elem []string }
+    - __kind: ArrayType
+      ID: 165
+      Name: noalg.[8]struct { key string; elem float64 }
+      ByteSize: 192
+      GoRuntimeType: 715008
+      GoKind: 17
+      Count: 8
+      HasCount: true
+      Element: 166 StructureType noalg.struct { key string; elem float64 }
+    - __kind: ArrayType
+      ID: 154
+      Name: noalg.[8]struct { key string; elem interface {} }
+      ByteSize: 256
+      GoRuntimeType: 692352
+      GoKind: 17
+      Count: 8
+      HasCount: true
+      Element: 155 StructureType noalg.struct { key string; elem interface {} }
+    - __kind: ArrayType
+      ID: 133
+      Name: noalg.[8]struct { key string; elem string }
+      ByteSize: 256
+      GoRuntimeType: 705056
+      GoKind: 17
+      Count: 8
+      HasCount: true
+      Element: 134 StructureType noalg.struct { key string; elem string }
+    - __kind: StructureType
+      ID: 182
+      Name: noalg.map.group[string]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
+      ByteSize: 200
+      GoRuntimeType: 1.331296e+06
+      GoKind: 25
+      RawFields:
+        - Name: ctrl
+          Offset: 0
+          Type: 17 BaseType uint64
+        - Name: slots
+          Offset: 8
+          Type: 183 ArrayType noalg.[8]struct { key string; elem *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute }
+    - __kind: StructureType
+      ID: 45
+      Name: noalg.map.group[string][]*mime/multipart.FileHeader
+      ByteSize: 328
+      GoRuntimeType: 1.325024e+06
+      GoKind: 25
+      RawFields:
+        - Name: ctrl
+          Offset: 0
+          Type: 17 BaseType uint64
+        - Name: slots
+          Offset: 8
+          Type: 46 ArrayType noalg.[8]struct { key string; elem []*mime/multipart.FileHeader }
+    - __kind: StructureType
+      ID: 25
+      Name: noalg.map.group[string][]string
+      ByteSize: 328
+      GoRuntimeType: 1.315936e+06
+      GoKind: 25
+      RawFields:
+        - Name: ctrl
+          Offset: 0
+          Type: 17 BaseType uint64
+        - Name: slots
+          Offset: 8
+          Type: 26 ArrayType noalg.[8]struct { key string; elem []string }
+    - __kind: StructureType
+      ID: 164
+      Name: noalg.map.group[string]float64
+      ByteSize: 200
+      GoRuntimeType: 1.33104e+06
+      GoKind: 25
+      RawFields:
+        - Name: ctrl
+          Offset: 0
+          Type: 17 BaseType uint64
+        - Name: slots
+          Offset: 8
+          Type: 165 ArrayType noalg.[8]struct { key string; elem float64 }
+    - __kind: StructureType
+      ID: 153
+      Name: noalg.map.group[string]interface {}
+      ByteSize: 264
+      GoRuntimeType: 1.313376e+06
+      GoKind: 25
+      RawFields:
+        - Name: ctrl
+          Offset: 0
+          Type: 17 BaseType uint64
+        - Name: slots
+          Offset: 8
+          Type: 154 ArrayType noalg.[8]struct { key string; elem interface {} }
+    - __kind: StructureType
+      ID: 132
+      Name: noalg.map.group[string]string
+      ByteSize: 264
+      GoRuntimeType: 1.318368e+06
+      GoKind: 25
+      RawFields:
+        - Name: ctrl
+          Offset: 0
+          Type: 17 BaseType uint64
+        - Name: slots
+          Offset: 8
+          Type: 133 ArrayType noalg.[8]struct { key string; elem string }
+    - __kind: StructureType
+      ID: 184
+      Name: noalg.struct { key string; elem *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute }
+      ByteSize: 24
+      GoRuntimeType: 1.331168e+06
+      GoKind: 25
+      RawFields:
+        - Name: key
+          Offset: 0
+          Type: 5 GoStringHeaderType string
+        - Name: elem
+          Offset: 16
+          Type: 185 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
+    - __kind: StructureType
+      ID: 47
+      Name: noalg.struct { key string; elem []*mime/multipart.FileHeader }
+      ByteSize: 40
+      GoRuntimeType: 1.324896e+06
+      GoKind: 25
+      RawFields:
+        - Name: key
+          Offset: 0
+          Type: 5 GoStringHeaderType string
+        - Name: elem
+          Offset: 16
+          Type: 48 GoSliceHeaderType []*mime/multipart.FileHeader
+    - __kind: StructureType
+      ID: 27
+      Name: noalg.struct { key string; elem []string }
+      ByteSize: 40
+      GoRuntimeType: 1.315808e+06
+      GoKind: 25
+      RawFields:
+        - Name: key
+          Offset: 0
+          Type: 5 GoStringHeaderType string
+        - Name: elem
+          Offset: 16
+          Type: 28 GoSliceHeaderType []string
+    - __kind: StructureType
+      ID: 166
+      Name: noalg.struct { key string; elem float64 }
+      ByteSize: 24
+      GoRuntimeType: 1.330912e+06
+      GoKind: 25
+      RawFields:
+        - Name: key
+          Offset: 0
+          Type: 5 GoStringHeaderType string
+        - Name: elem
+          Offset: 16
+          Type: 167 BaseType float64
+    - __kind: StructureType
+      ID: 155
+      Name: noalg.struct { key string; elem interface {} }
+      ByteSize: 32
+      GoRuntimeType: 1.313248e+06
+      GoKind: 25
+      RawFields:
+        - Name: key
+          Offset: 0
+          Type: 5 GoStringHeaderType string
+        - Name: elem
+          Offset: 16
+          Type: 63 GoEmptyInterfaceType interface {}
+    - __kind: StructureType
+      ID: 134
+      Name: noalg.struct { key string; elem string }
+      ByteSize: 32
+      GoRuntimeType: 1.31824e+06
+      GoKind: 25
+      RawFields:
+        - Name: key
+          Offset: 0
+          Type: 5 GoStringHeaderType string
+        - Name: elem
+          Offset: 16
+          Type: 5 GoStringHeaderType string
+    - __kind: GoStringHeaderType
+      ID: 5
+      Name: string
+      ByteSize: 16
+      GoRuntimeType: 593984
+      GoKind: 24
+      RawFields:
+        - Name: str
+          Offset: 0
+          Type: 229 PointerType *string.str
+        - Name: len
+          Offset: 8
+          Type: 8 BaseType int
+      Data: 228 GoStringDataType string.str
+    - __kind: GoStringDataType
+      ID: 228
+      Name: string.str
+      ByteSize: 2048
+    - __kind: StructureType
+      ID: 138
+      Name: sync.Mutex
+      ByteSize: 8
+      GoRuntimeType: 1.493632e+06
+      GoKind: 25
+      RawFields:
+        - Name: _
+          Offset: 0
+          Type: 139 StructureType sync.noCopy
+        - Name: mu
+          Offset: 0
+          Type: 140 StructureType internal/sync.Mutex
+    - __kind: StructureType
+      ID: 137
+      Name: sync.RWMutex
+      ByteSize: 24
+      GoRuntimeType: 1.880896e+06
+      GoKind: 25
+      RawFields:
+        - Name: w
+          Offset: 0
+          Type: 138 StructureType sync.Mutex
+        - Name: writerSem
+          Offset: 8
+          Type: 142 BaseType uint32
+        - Name: readerSem
+          Offset: 12
+          Type: 142 BaseType uint32
+        - Name: readerCount
+          Offset: 16
+          Type: 143 StructureType sync/atomic.Int32
+        - Name: readerWait
+          Offset: 20
+          Type: 143 StructureType sync/atomic.Int32
+    - __kind: StructureType
+      ID: 139
+      Name: sync.noCopy
+      GoRuntimeType: 1.006688e+06
+      GoKind: 25
+      RawFields: []
+    - __kind: StructureType
+      ID: 143
+      Name: sync/atomic.Int32
+      ByteSize: 4
+      GoRuntimeType: 1.494912e+06
+      GoKind: 25
+      RawFields:
+        - Name: _
+          Offset: 0
+          Type: 144 StructureType sync/atomic.noCopy
+        - Name: v
+          Offset: 0
+          Type: 141 BaseType int32
+    - __kind: StructureType
+      ID: 144
+      Name: sync/atomic.noCopy
+      GoRuntimeType: 1.006784e+06
+      GoKind: 25
+      RawFields: []
+    - __kind: StructureType
+      ID: 179
+      Name: table<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
+      ByteSize: 32
+      GoKind: 25
+      RawFields:
+        - Name: used
+          Offset: 0
+          Type: 22 BaseType uint16
+        - Name: capacity
+          Offset: 2
+          Type: 22 BaseType uint16
+        - Name: growthLeft
+          Offset: 4
+          Type: 22 BaseType uint16
+        - Name: localDepth
+          Offset: 6
+          Type: 7 BaseType uint8
+        - Name: index
+          Offset: 8
+          Type: 8 BaseType int
+        - Name: groups
+          Offset: 16
+          Type: 180 GoSwissMapGroupsType groupReference<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
+    - __kind: StructureType
+      ID: 42
+      Name: table<string,[]*mime/multipart.FileHeader>
+      ByteSize: 32
+      GoKind: 25
+      RawFields:
+        - Name: used
+          Offset: 0
+          Type: 22 BaseType uint16
+        - Name: capacity
+          Offset: 2
+          Type: 22 BaseType uint16
+        - Name: growthLeft
+          Offset: 4
+          Type: 22 BaseType uint16
+        - Name: localDepth
+          Offset: 6
+          Type: 7 BaseType uint8
+        - Name: index
+          Offset: 8
+          Type: 8 BaseType int
+        - Name: groups
+          Offset: 16
+          Type: 43 GoSwissMapGroupsType groupReference<string,[]*mime/multipart.FileHeader>
+    - __kind: StructureType
+      ID: 21
+      Name: table<string,[]string>
+      ByteSize: 32
+      GoKind: 25
+      RawFields:
+        - Name: used
+          Offset: 0
+          Type: 22 BaseType uint16
+        - Name: capacity
+          Offset: 2
+          Type: 22 BaseType uint16
+        - Name: growthLeft
+          Offset: 4
+          Type: 22 BaseType uint16
+        - Name: localDepth
+          Offset: 6
+          Type: 7 BaseType uint8
+        - Name: index
+          Offset: 8
+          Type: 8 BaseType int
+        - Name: groups
+          Offset: 16
+          Type: 23 GoSwissMapGroupsType groupReference<string,[]string>
+    - __kind: StructureType
+      ID: 161
+      Name: table<string,float64>
+      ByteSize: 32
+      GoKind: 25
+      RawFields:
+        - Name: used
+          Offset: 0
+          Type: 22 BaseType uint16
+        - Name: capacity
+          Offset: 2
+          Type: 22 BaseType uint16
+        - Name: growthLeft
+          Offset: 4
+          Type: 22 BaseType uint16
+        - Name: localDepth
+          Offset: 6
+          Type: 7 BaseType uint8
+        - Name: index
+          Offset: 8
+          Type: 8 BaseType int
+        - Name: groups
+          Offset: 16
+          Type: 162 GoSwissMapGroupsType groupReference<string,float64>
+    - __kind: StructureType
+      ID: 150
+      Name: table<string,interface {}>
+      ByteSize: 32
+      GoKind: 25
+      RawFields:
+        - Name: used
+          Offset: 0
+          Type: 22 BaseType uint16
+        - Name: capacity
+          Offset: 2
+          Type: 22 BaseType uint16
+        - Name: growthLeft
+          Offset: 4
+          Type: 22 BaseType uint16
+        - Name: localDepth
+          Offset: 6
+          Type: 7 BaseType uint8
+        - Name: index
+          Offset: 8
+          Type: 8 BaseType int
+        - Name: groups
+          Offset: 16
+          Type: 151 GoSwissMapGroupsType groupReference<string,interface {}>
+    - __kind: StructureType
+      ID: 129
+      Name: table<string,string>
+      ByteSize: 32
+      GoKind: 25
+      RawFields:
+        - Name: used
+          Offset: 0
+          Type: 22 BaseType uint16
+        - Name: capacity
+          Offset: 2
+          Type: 22 BaseType uint16
+        - Name: growthLeft
+          Offset: 4
+          Type: 22 BaseType uint16
+        - Name: localDepth
+          Offset: 6
+          Type: 7 BaseType uint8
+        - Name: index
+          Offset: 8
+          Type: 8 BaseType int
+        - Name: groups
+          Offset: 16
+          Type: 130 GoSwissMapGroupsType groupReference<string,string>
+    - __kind: StructureType
+      ID: 77
+      Name: time.Location
+      ByteSize: 104
+      GoRuntimeType: 2.013984e+06
+      GoKind: 25
+      RawFields:
+        - Name: name
+          Offset: 0
+          Type: 5 GoStringHeaderType string
+        - Name: zone
+          Offset: 16
+          Type: 78 GoSliceHeaderType []time.zone
+        - Name: tx
+          Offset: 40
+          Type: 81 GoSliceHeaderType []time.zoneTrans
+        - Name: extend
+          Offset: 64
+          Type: 5 GoStringHeaderType string
+        - Name: cacheStart
+          Offset: 80
+          Type: 32 BaseType int64
+        - Name: cacheEnd
+          Offset: 88
+          Type: 32 BaseType int64
+        - Name: cacheZone
+          Offset: 96
+          Type: 79 PointerType *time.zone
+    - __kind: StructureType
+      ID: 75
+      Name: time.Time
+      ByteSize: 24
+      GoRuntimeType: 2.428992e+06
+      GoKind: 25
+      RawFields:
+        - Name: wall
+          Offset: 0
+          Type: 17 BaseType uint64
+        - Name: ext
+          Offset: 8
+          Type: 32 BaseType int64
+        - Name: loc
+          Offset: 16
+          Type: 76 PointerType *time.Location
+    - __kind: StructureType
+      ID: 80
+      Name: time.zone
+      ByteSize: 32
+      GoRuntimeType: 1.646944e+06
+      GoKind: 25
+      RawFields:
+        - Name: name
+          Offset: 0
+          Type: 5 GoStringHeaderType string
+        - Name: offset
+          Offset: 16
+          Type: 8 BaseType int
+        - Name: isDST
+          Offset: 24
+          Type: 13 BaseType bool
+    - __kind: StructureType
+      ID: 83
+      Name: time.zoneTrans
+      ByteSize: 16
+      GoRuntimeType: 1.788928e+06
+      GoKind: 25
+      RawFields:
+        - Name: when
+          Offset: 0
+          Type: 32 BaseType int64
+        - Name: index
+          Offset: 8
+          Type: 7 BaseType uint8
+        - Name: isstd
+          Offset: 9
+          Type: 13 BaseType bool
+        - Name: isutc
+          Offset: 10
+          Type: 13 BaseType bool
+    - __kind: BaseType
+      ID: 209
+      Name: uint
+      ByteSize: 8
+      GoRuntimeType: 594624
+      GoKind: 7
+    - __kind: BaseType
+      ID: 22
+      Name: uint16
+      ByteSize: 2
+      GoRuntimeType: 594240
+      GoKind: 9
+    - __kind: BaseType
+      ID: 142
+      Name: uint32
+      ByteSize: 4
+      GoRuntimeType: 594368
+      GoKind: 10
+    - __kind: BaseType
+      ID: 17
+      Name: uint64
+      ByteSize: 8
+      GoRuntimeType: 594496
+      GoKind: 11
+    - __kind: BaseType
+      ID: 7
+      Name: uint8
+      ByteSize: 1
+      GoRuntimeType: 594112
+      GoKind: 8
+    - __kind: BaseType
+      ID: 18
+      Name: uintptr
+      ByteSize: 8
+      GoRuntimeType: 594688
+      GoKind: 12
+    - __kind: VoidPointerType
+      ID: 2
+      Name: unsafe.Pointer
+      ByteSize: 8
+      GoRuntimeType: 595072
+      GoKind: 26
 MaxTypeID: 295
 Issues: []
 GoModuledataInfo: {FirstModuledataAddr: "0x139d860", TypesOffset: 296}

--- a/pkg/dyninst/irgen/testdata/snapshot/rc_tester_v1.arch=amd64,toolchain=go1.23.11.yaml
+++ b/pkg/dyninst/irgen/testdata/snapshot/rc_tester_v1.arch=amd64,toolchain=go1.23.11.yaml
@@ -10,7 +10,7 @@ Probes:
       subprogram: {subprogram: 1}
       events:
         - ID: 1
-          Type: 203 EventRootType Probe[main.HandleHTTP]
+          Type: 195 EventRootType Probe[main.HandleHTTP]
           InjectionPoints: [{PC: "0xd289f3", Frameless: false}]
           Condition: null
     - id: look_at_the_request
@@ -23,7 +23,7 @@ Probes:
       subprogram: {subprogram: 2}
       events:
         - ID: 2
-          Type: 204 EventRootType Probe[main.LookAtTheRequest]
+          Type: 196 EventRootType Probe[main.LookAtTheRequest]
           InjectionPoints: [{PC: "0xd28d6e", Frameless: false}]
           Condition: null
 Subprograms:
@@ -121,143 +121,126 @@ Subprograms:
           IsReturn: false
 Types:
     - __kind: PointerType
-      ID: 92
+      ID: 101
       Name: '**crypto/x509.Certificate'
       ByteSize: 8
-      Pointee: 93 PointerType *crypto/x509.Certificate
+      Pointee: 102 PointerType *crypto/x509.Certificate
     - __kind: PointerType
-      ID: 113
+      ID: 90
       Name: '**mime/multipart.FileHeader'
       ByteSize: 8
       GoKind: 22
-      Pointee: 114 PointerType *mime/multipart.FileHeader
+      Pointee: 91 PointerType *mime/multipart.FileHeader
     - __kind: PointerType
-      ID: 156
+      ID: 144
       Name: '**net.IPNet'
       ByteSize: 8
       GoKind: 22
-      Pointee: 157 PointerType *net.IPNet
+      Pointee: 145 PointerType *net.IPNet
     - __kind: PointerType
-      ID: 154
+      ID: 142
       Name: '**net/url.URL'
       ByteSize: 8
       GoKind: 22
-      Pointee: 44 PointerType *net/url.URL
+      Pointee: 46 PointerType *net/url.URL
     - __kind: PointerType
-      ID: 110
-      Name: '**runtime.bmap'
-      ByteSize: 8
-      Pointee: 83 PointerType *runtime.bmap
-    - __kind: PointerType
-      ID: 95
+      ID: 104
       Name: '*[]*crypto/x509.Certificate'
       ByteSize: 8
       GoKind: 22
-      Pointee: 91 GoSliceHeaderType []*crypto/x509.Certificate
+      Pointee: 100 GoSliceHeaderType []*crypto/x509.Certificate
     - __kind: PointerType
-      ID: 120
+      ID: 111
       Name: '*[]*crypto/x509.Certificate.array'
       ByteSize: 8
-      Pointee: 119 GoSliceDataType []*crypto/x509.Certificate.array
+      Pointee: 110 GoSliceDataType []*crypto/x509.Certificate.array
     - __kind: PointerType
-      ID: 162
+      ID: 95
       Name: '*[]*mime/multipart.FileHeader.array'
       ByteSize: 8
-      Pointee: 161 GoSliceDataType []*mime/multipart.FileHeader.array
+      Pointee: 94 GoSliceDataType []*mime/multipart.FileHeader.array
     - __kind: PointerType
-      ID: 191
+      ID: 178
       Name: '*[]*net.IPNet.array'
       ByteSize: 8
-      Pointee: 190 GoSliceDataType []*net.IPNet.array
-    - __kind: PointerType
-      ID: 189
-      Name: '*[]*net/url.URL.array'
-      ByteSize: 8
-      Pointee: 188 GoSliceDataType []*net/url.URL.array
-    - __kind: PointerType
-      ID: 81
-      Name: '*[]*runtime.bmap'
-      ByteSize: 8
-      GoRuntimeType: 466432
-      GoKind: 22
-      Pointee: 82 GoSliceHeaderType []*runtime.bmap
-    - __kind: PointerType
-      ID: 117
-      Name: '*[]*runtime.bmap.array'
-      ByteSize: 8
-      Pointee: 116 GoSliceDataType []*runtime.bmap.array
-    - __kind: PointerType
-      ID: 122
-      Name: '*[][]*crypto/x509.Certificate.array'
-      ByteSize: 8
-      Pointee: 121 GoSliceDataType [][]*crypto/x509.Certificate.array
-    - __kind: PointerType
-      ID: 124
-      Name: '*[][]uint8.array'
-      ByteSize: 8
-      Pointee: 123 GoSliceDataType [][]uint8.array
-    - __kind: PointerType
-      ID: 183
-      Name: '*[]crypto/x509.ExtKeyUsage.array'
-      ByteSize: 8
-      Pointee: 182 GoSliceDataType []crypto/x509.ExtKeyUsage.array
-    - __kind: PointerType
-      ID: 193
-      Name: '*[]crypto/x509.OID.array'
-      ByteSize: 8
-      Pointee: 192 GoSliceDataType []crypto/x509.OID.array
+      Pointee: 177 GoSliceDataType []*net.IPNet.array
     - __kind: PointerType
       ID: 175
+      Name: '*[]*net/url.URL.array'
+      ByteSize: 8
+      Pointee: 174 GoSliceDataType []*net/url.URL.array
+    - __kind: PointerType
+      ID: 113
+      Name: '*[][]*crypto/x509.Certificate.array'
+      ByteSize: 8
+      Pointee: 112 GoSliceDataType [][]*crypto/x509.Certificate.array
+    - __kind: PointerType
+      ID: 115
+      Name: '*[][]uint8.array'
+      ByteSize: 8
+      Pointee: 114 GoSliceDataType [][]uint8.array
+    - __kind: PointerType
+      ID: 171
+      Name: '*[]crypto/x509.ExtKeyUsage.array'
+      ByteSize: 8
+      Pointee: 170 GoSliceDataType []crypto/x509.ExtKeyUsage.array
+    - __kind: PointerType
+      ID: 180
+      Name: '*[]crypto/x509.OID.array'
+      ByteSize: 8
+      Pointee: 179 GoSliceDataType []crypto/x509.OID.array
+    - __kind: PointerType
+      ID: 155
       Name: '*[]crypto/x509/pkix.AttributeTypeAndValue.array'
       ByteSize: 8
-      Pointee: 174 GoSliceDataType []crypto/x509/pkix.AttributeTypeAndValue.array
+      Pointee: 154 GoSliceDataType []crypto/x509/pkix.AttributeTypeAndValue.array
     - __kind: PointerType
-      ID: 177
+      ID: 167
       Name: '*[]crypto/x509/pkix.Extension.array'
       ByteSize: 8
-      Pointee: 176 GoSliceDataType []crypto/x509/pkix.Extension.array
+      Pointee: 166 GoSliceDataType []crypto/x509/pkix.Extension.array
     - __kind: PointerType
-      ID: 179
+      ID: 169
       Name: '*[]encoding/asn1.ObjectIdentifier.array'
       ByteSize: 8
-      Pointee: 178 GoSliceDataType []encoding/asn1.ObjectIdentifier.array
+      Pointee: 168 GoSliceDataType []encoding/asn1.ObjectIdentifier.array
     - __kind: PointerType
-      ID: 185
+      ID: 173
       Name: '*[]net.IP.array'
       ByteSize: 8
-      Pointee: 184 GoSliceDataType []net.IP.array
+      Pointee: 172 GoSliceDataType []net.IP.array
     - __kind: PointerType
-      ID: 126
+      ID: 192
       Name: '*[]net/http.segment.array'
       ByteSize: 8
-      Pointee: 125 GoSliceDataType []net/http.segment.array
+      Pointee: 191 GoSliceDataType []net/http.segment.array
     - __kind: PointerType
-      ID: 106
+      ID: 81
       Name: '*[]string.array'
       ByteSize: 8
-      Pointee: 105 GoSliceDataType []string.array
+      Pointee: 80 GoSliceDataType []string.array
     - __kind: PointerType
-      ID: 198
+      ID: 163
       Name: '*[]time.zone.array'
       ByteSize: 8
-      Pointee: 197 GoSliceDataType []time.zone.array
+      Pointee: 162 GoSliceDataType []time.zone.array
     - __kind: PointerType
-      ID: 200
+      ID: 165
       Name: '*[]time.zoneTrans.array'
       ByteSize: 8
-      Pointee: 199 GoSliceDataType []time.zoneTrans.array
+      Pointee: 164 GoSliceDataType []time.zoneTrans.array
     - __kind: PointerType
-      ID: 97
+      ID: 106
       Name: '*[]uint8'
       ByteSize: 8
       GoRuntimeType: 452512
       GoKind: 22
-      Pointee: 72 GoSliceHeaderType []uint8
+      Pointee: 97 GoSliceHeaderType []uint8
     - __kind: PointerType
-      ID: 109
+      ID: 99
       Name: '*[]uint8.array'
       ByteSize: 8
-      Pointee: 108 GoSliceDataType []uint8.array
+      Pointee: 98 GoSliceDataType []uint8.array
     - __kind: PointerType
       ID: 5
       Name: '*bool'
@@ -266,81 +249,81 @@ Types:
       GoKind: 22
       Pointee: 4 BaseType bool
     - __kind: PointerType
-      ID: 89
+      ID: 86
       Name: '*bucket<string,[]*mime/multipart.FileHeader>'
       ByteSize: 8
-      Pointee: 90 GoHMapBucketType bucket<string,[]*mime/multipart.FileHeader>
+      Pointee: 87 GoHMapBucketType bucket<string,[]*mime/multipart.FileHeader>
     - __kind: PointerType
-      ID: 49
+      ID: 51
       Name: '*bucket<string,[]string>'
       ByteSize: 8
-      Pointee: 50 GoHMapBucketType bucket<string,[]string>
+      Pointee: 52 GoHMapBucketType bucket<string,[]string>
     - __kind: PointerType
-      ID: 70
+      ID: 72
       Name: '*bucket<string,string>'
       ByteSize: 8
-      Pointee: 71 GoHMapBucketType bucket<string,string>
+      Pointee: 73 GoHMapBucketType bucket<string,string>
     - __kind: PointerType
       ID: 39
       Name: '*bytes.Buffer'
       ByteSize: 8
       GoRuntimeType: 2.114976e+06
       GoKind: 22
-      Pointee: 40 StructureType bytes.Buffer
+      Pointee: 40 UnresolvedPointeeType bytes.Buffer
     - __kind: PointerType
-      ID: 59
+      ID: 61
       Name: '*crypto/tls.ConnectionState'
       ByteSize: 8
       GoRuntimeType: 835936
       GoKind: 22
-      Pointee: 60 StructureType crypto/tls.ConnectionState
+      Pointee: 62 StructureType crypto/tls.ConnectionState
     - __kind: PointerType
-      ID: 93
+      ID: 102
       Name: '*crypto/x509.Certificate'
       ByteSize: 8
       GoRuntimeType: 1.90528e+06
       GoKind: 22
-      Pointee: 115 StructureType crypto/x509.Certificate
+      Pointee: 109 StructureType crypto/x509.Certificate
     - __kind: PointerType
-      ID: 148
+      ID: 136
       Name: '*crypto/x509.ExtKeyUsage'
       ByteSize: 8
       GoRuntimeType: 395040
       GoKind: 22
-      Pointee: 149 BaseType crypto/x509.ExtKeyUsage
+      Pointee: 137 BaseType crypto/x509.ExtKeyUsage
     - __kind: PointerType
-      ID: 159
+      ID: 147
       Name: '*crypto/x509.OID'
       ByteSize: 8
       GoRuntimeType: 1.717248e+06
       GoKind: 22
-      Pointee: 160 StructureType crypto/x509.OID
+      Pointee: 148 StructureType crypto/x509.OID
     - __kind: PointerType
-      ID: 135
+      ID: 123
       Name: '*crypto/x509/pkix.AttributeTypeAndValue'
       ByteSize: 8
       GoRuntimeType: 408800
       GoKind: 22
-      Pointee: 136 StructureType crypto/x509/pkix.AttributeTypeAndValue
+      Pointee: 124 StructureType crypto/x509/pkix.AttributeTypeAndValue
     - __kind: PointerType
-      ID: 142
+      ID: 130
       Name: '*crypto/x509/pkix.Extension'
       ByteSize: 8
       GoRuntimeType: 408992
       GoKind: 22
-      Pointee: 143 StructureType crypto/x509/pkix.Extension
+      Pointee: 131 StructureType crypto/x509/pkix.Extension
     - __kind: PointerType
-      ID: 145
+      ID: 133
       Name: '*encoding/asn1.ObjectIdentifier'
       ByteSize: 8
       GoRuntimeType: 1.009728e+06
       GoKind: 22
-      Pointee: 146 GoSliceHeaderType encoding/asn1.ObjectIdentifier
+      Pointee: 134 GoSliceHeaderType encoding/asn1.ObjectIdentifier
     - __kind: PointerType
-      ID: 181
+      ID: 182
       Name: '*encoding/asn1.ObjectIdentifier.array'
       ByteSize: 8
-      Pointee: 180 GoSliceDataType encoding/asn1.ObjectIdentifier.array
+      Pointee: 181 GoSliceDataType encoding/asn1.ObjectIdentifier.array
     - __kind: PointerType
       ID: 33
       Name: '*error'
@@ -363,20 +346,20 @@ Types:
       GoKind: 22
       Pointee: 17 BaseType float64
     - __kind: PointerType
-      ID: 87
+      ID: 84
       Name: '*hash<string,[]*mime/multipart.FileHeader>'
       ByteSize: 8
-      Pointee: 88 GoHMapHeaderType hash<string,[]*mime/multipart.FileHeader>
+      Pointee: 85 GoHMapHeaderType hash<string,[]*mime/multipart.FileHeader>
     - __kind: PointerType
-      ID: 47
+      ID: 49
       Name: '*hash<string,[]string>'
       ByteSize: 8
-      Pointee: 48 GoHMapHeaderType hash<string,[]string>
+      Pointee: 50 GoHMapHeaderType hash<string,[]string>
     - __kind: PointerType
-      ID: 68
+      ID: 70
       Name: '*hash<string,string>'
       ByteSize: 8
-      Pointee: 69 GoHMapHeaderType hash<string,string>
+      Pointee: 71 GoHMapHeaderType hash<string,string>
     - __kind: PointerType
       ID: 27
       Name: '*int'
@@ -413,62 +396,62 @@ Types:
       GoKind: 22
       Pointee: 14 BaseType int8
     - __kind: PointerType
-      ID: 131
+      ID: 119
       Name: '*math/big.Int'
       ByteSize: 8
       GoRuntimeType: 2.231104e+06
       GoKind: 22
-      Pointee: 132 StructureType math/big.Int
+      Pointee: 120 StructureType math/big.Int
     - __kind: PointerType
-      ID: 165
+      ID: 150
       Name: '*math/big.Word'
       ByteSize: 8
       GoRuntimeType: 397856
       GoKind: 22
-      Pointee: 166 BaseType math/big.Word
+      Pointee: 151 BaseType math/big.Word
     - __kind: PointerType
-      ID: 196
+      ID: 153
       Name: '*math/big.nat.array'
       ByteSize: 8
-      Pointee: 195 GoSliceDataType math/big.nat.array
+      Pointee: 152 GoSliceDataType math/big.nat.array
     - __kind: PointerType
-      ID: 114
+      ID: 91
       Name: '*mime/multipart.FileHeader'
       ByteSize: 8
       GoRuntimeType: 837376
       GoKind: 22
-      Pointee: 127 StructureType mime/multipart.FileHeader
+      Pointee: 93 StructureType mime/multipart.FileHeader
     - __kind: PointerType
-      ID: 57
+      ID: 59
       Name: '*mime/multipart.Form'
       ByteSize: 8
       GoRuntimeType: 837472
       GoKind: 22
-      Pointee: 58 StructureType mime/multipart.Form
+      Pointee: 60 StructureType mime/multipart.Form
     - __kind: PointerType
-      ID: 151
+      ID: 139
       Name: '*net.IP'
       ByteSize: 8
       GoRuntimeType: 1.974144e+06
       GoKind: 22
-      Pointee: 152 GoSliceHeaderType net.IP
+      Pointee: 140 GoSliceHeaderType net.IP
     - __kind: PointerType
-      ID: 187
+      ID: 184
       Name: '*net.IP.array'
       ByteSize: 8
-      Pointee: 186 GoSliceDataType net.IP.array
+      Pointee: 183 GoSliceDataType net.IP.array
     - __kind: PointerType
-      ID: 202
+      ID: 187
       Name: '*net.IPMask.array'
       ByteSize: 8
-      Pointee: 201 GoSliceDataType net.IPMask.array
+      Pointee: 186 GoSliceDataType net.IPMask.array
     - __kind: PointerType
-      ID: 157
+      ID: 145
       Name: '*net.IPNet'
       ByteSize: 8
       GoRuntimeType: 1.095776e+06
       GoKind: 22
-      Pointee: 173 StructureType net.IPNet
+      Pointee: 176 StructureType net.IPNet
     - __kind: PointerType
       ID: 37
       Name: '*net/http.Request'
@@ -477,54 +460,47 @@ Types:
       GoKind: 22
       Pointee: 38 StructureType net/http.Request
     - __kind: PointerType
-      ID: 62
+      ID: 64
       Name: '*net/http.Response'
       ByteSize: 8
       GoRuntimeType: 1.590912e+06
       GoKind: 22
-      Pointee: 63 StructureType net/http.Response
+      Pointee: 65 StructureType net/http.Response
     - __kind: PointerType
-      ID: 65
+      ID: 67
       Name: '*net/http.pattern'
       ByteSize: 8
       GoRuntimeType: 1.416224e+06
       GoKind: 22
-      Pointee: 66 StructureType net/http.pattern
+      Pointee: 68 StructureType net/http.pattern
     - __kind: PointerType
-      ID: 101
+      ID: 189
       Name: '*net/http.segment'
       ByteSize: 8
       GoRuntimeType: 364000
       GoKind: 22
-      Pointee: 102 StructureType net/http.segment
+      Pointee: 190 StructureType net/http.segment
     - __kind: PointerType
-      ID: 44
+      ID: 46
       Name: '*net/url.URL'
       ByteSize: 8
       GoRuntimeType: 1.949216e+06
       GoKind: 22
-      Pointee: 45 StructureType net/url.URL
+      Pointee: 47 StructureType net/url.URL
     - __kind: PointerType
-      ID: 76
+      ID: 74
       Name: '*net/url.Userinfo'
       ByteSize: 8
       GoRuntimeType: 1.114208e+06
       GoKind: 22
-      Pointee: 77 StructureType net/url.Userinfo
+      Pointee: 75 StructureType net/url.Userinfo
     - __kind: PointerType
-      ID: 83
-      Name: '*runtime.bmap'
-      ByteSize: 8
-      GoRuntimeType: 1.109856e+06
-      GoKind: 22
-      Pointee: 84 StructureType runtime.bmap
-    - __kind: PointerType
-      ID: 51
+      ID: 53
       Name: '*runtime.mapextra'
       ByteSize: 8
       GoRuntimeType: 375520
       GoKind: 22
-      Pointee: 52 StructureType runtime.mapextra
+      Pointee: 54 UnresolvedPointeeType runtime.mapextra
     - __kind: PointerType
       ID: 22
       Name: '*string'
@@ -533,31 +509,31 @@ Types:
       GoKind: 22
       Pointee: 11 GoStringHeaderType string
     - __kind: PointerType
-      ID: 75
+      ID: 45
       Name: '*string.str'
       ByteSize: 8
-      Pointee: 74 GoStringDataType string.str
+      Pointee: 44 GoStringDataType string.str
     - __kind: PointerType
-      ID: 138
+      ID: 126
       Name: '*time.Location'
       ByteSize: 8
       GoRuntimeType: 1.421216e+06
       GoKind: 22
-      Pointee: 139 StructureType time.Location
+      Pointee: 127 StructureType time.Location
     - __kind: PointerType
-      ID: 168
+      ID: 157
       Name: '*time.zone'
       ByteSize: 8
       GoRuntimeType: 367072
       GoKind: 22
-      Pointee: 169 StructureType time.zone
+      Pointee: 158 StructureType time.zone
     - __kind: PointerType
-      ID: 171
+      ID: 160
       Name: '*time.zoneTrans'
       ByteSize: 8
       GoRuntimeType: 367136
       GoKind: 22
-      Pointee: 172 StructureType time.zoneTrans
+      Pointee: 161 StructureType time.zoneTrans
     - __kind: PointerType
       ID: 34
       Name: '*uint'
@@ -601,12 +577,12 @@ Types:
       GoKind: 22
       Pointee: 1 BaseType uintptr
     - __kind: GoChannelType
-      ID: 61
+      ID: 63
       Name: <-chan struct {}
       GoRuntimeType: 546752
       GoKind: 18
     - __kind: EventRootType
-      ID: 203
+      ID: 195
       Name: Probe[main.HandleHTTP]
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -630,7 +606,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 204
+      ID: 196
       Name: Probe[main.LookAtTheRequest]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -645,7 +621,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: ArrayType
-      ID: 78
+      ID: 76
       Name: '[8]uint8'
       ByteSize: 8
       GoRuntimeType: 621728
@@ -654,7 +630,7 @@ Types:
       HasCount: true
       Element: 3 BaseType uint8
     - __kind: GoSliceHeaderType
-      ID: 91
+      ID: 100
       Name: '[]*crypto/x509.Certificate'
       ByteSize: 24
       GoRuntimeType: 469536
@@ -662,21 +638,21 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 92 PointerType **crypto/x509.Certificate
+          Type: 101 PointerType **crypto/x509.Certificate
         - Name: len
           Offset: 8
           Type: 9 BaseType int
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 119 GoSliceDataType []*crypto/x509.Certificate.array
+      Data: 110 GoSliceDataType []*crypto/x509.Certificate.array
     - __kind: GoSliceDataType
-      ID: 119
+      ID: 110
       Name: '[]*crypto/x509.Certificate.array'
       ByteSize: 2048
-      Element: 93 PointerType *crypto/x509.Certificate
+      Element: 102 PointerType *crypto/x509.Certificate
     - __kind: GoSliceHeaderType
-      ID: 112
+      ID: 89
       Name: '[]*mime/multipart.FileHeader'
       ByteSize: 24
       GoRuntimeType: 457376
@@ -684,21 +660,21 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 113 PointerType **mime/multipart.FileHeader
+          Type: 90 PointerType **mime/multipart.FileHeader
         - Name: len
           Offset: 8
           Type: 9 BaseType int
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 161 GoSliceDataType []*mime/multipart.FileHeader.array
+      Data: 94 GoSliceDataType []*mime/multipart.FileHeader.array
     - __kind: GoSliceDataType
-      ID: 161
+      ID: 94
       Name: '[]*mime/multipart.FileHeader.array'
       ByteSize: 2048
-      Element: 114 PointerType *mime/multipart.FileHeader
+      Element: 91 PointerType *mime/multipart.FileHeader
     - __kind: GoSliceHeaderType
-      ID: 155
+      ID: 143
       Name: '[]*net.IPNet'
       ByteSize: 24
       GoRuntimeType: 481568
@@ -706,21 +682,21 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 156 PointerType **net.IPNet
+          Type: 144 PointerType **net.IPNet
         - Name: len
           Offset: 8
           Type: 9 BaseType int
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 190 GoSliceDataType []*net.IPNet.array
+      Data: 177 GoSliceDataType []*net.IPNet.array
     - __kind: GoSliceDataType
-      ID: 190
+      ID: 177
       Name: '[]*net.IPNet.array'
       ByteSize: 2048
-      Element: 157 PointerType *net.IPNet
+      Element: 145 PointerType *net.IPNet
     - __kind: GoSliceHeaderType
-      ID: 153
+      ID: 141
       Name: '[]*net/url.URL'
       ByteSize: 24
       GoRuntimeType: 481504
@@ -728,43 +704,21 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 154 PointerType **net/url.URL
+          Type: 142 PointerType **net/url.URL
         - Name: len
           Offset: 8
           Type: 9 BaseType int
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 188 GoSliceDataType []*net/url.URL.array
+      Data: 174 GoSliceDataType []*net/url.URL.array
     - __kind: GoSliceDataType
-      ID: 188
+      ID: 174
       Name: '[]*net/url.URL.array'
       ByteSize: 2048
-      Element: 44 PointerType *net/url.URL
+      Element: 46 PointerType *net/url.URL
     - __kind: GoSliceHeaderType
-      ID: 82
-      Name: '[]*runtime.bmap'
-      ByteSize: 24
-      GoRuntimeType: 466368
-      GoKind: 23
-      RawFields:
-        - Name: array
-          Offset: 0
-          Type: 110 PointerType **runtime.bmap
-        - Name: len
-          Offset: 8
-          Type: 9 BaseType int
-        - Name: cap
-          Offset: 16
-          Type: 9 BaseType int
-      Data: 116 GoSliceDataType []*runtime.bmap.array
-    - __kind: GoSliceDataType
-      ID: 116
-      Name: '[]*runtime.bmap.array'
-      ByteSize: 2048
-      Element: 83 PointerType *runtime.bmap
-    - __kind: GoSliceHeaderType
-      ID: 94
+      ID: 103
       Name: '[][]*crypto/x509.Certificate'
       ByteSize: 24
       GoRuntimeType: 469664
@@ -772,21 +726,21 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 95 PointerType *[]*crypto/x509.Certificate
+          Type: 104 PointerType *[]*crypto/x509.Certificate
         - Name: len
           Offset: 8
           Type: 9 BaseType int
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 121 GoSliceDataType [][]*crypto/x509.Certificate.array
+      Data: 112 GoSliceDataType [][]*crypto/x509.Certificate.array
     - __kind: GoSliceDataType
-      ID: 121
+      ID: 112
       Name: '[][]*crypto/x509.Certificate.array'
       ByteSize: 2048
-      Element: 91 GoSliceHeaderType []*crypto/x509.Certificate
+      Element: 100 GoSliceHeaderType []*crypto/x509.Certificate
     - __kind: GoSliceHeaderType
-      ID: 96
+      ID: 105
       Name: '[][]uint8'
       ByteSize: 24
       GoRuntimeType: 452832
@@ -794,36 +748,36 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 97 PointerType *[]uint8
+          Type: 106 PointerType *[]uint8
         - Name: len
           Offset: 8
           Type: 9 BaseType int
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 123 GoSliceDataType [][]uint8.array
+      Data: 114 GoSliceDataType [][]uint8.array
     - __kind: GoSliceDataType
-      ID: 123
+      ID: 114
       Name: '[][]uint8.array'
       ByteSize: 2048
-      Element: 72 GoSliceHeaderType []uint8
+      Element: 97 GoSliceHeaderType []uint8
     - __kind: GoSliceDataType
-      ID: 118
+      ID: 92
       Name: '[]bucket<string,[]*mime/multipart.FileHeader>.array'
       ByteSize: 2048
-      Element: 90 GoHMapBucketType bucket<string,[]*mime/multipart.FileHeader>
+      Element: 87 GoHMapBucketType bucket<string,[]*mime/multipart.FileHeader>
     - __kind: GoSliceDataType
-      ID: 104
+      ID: 79
       Name: '[]bucket<string,[]string>.array'
       ByteSize: 2048
-      Element: 50 GoHMapBucketType bucket<string,[]string>
+      Element: 52 GoHMapBucketType bucket<string,[]string>
     - __kind: GoSliceDataType
-      ID: 107
+      ID: 194
       Name: '[]bucket<string,string>.array'
       ByteSize: 2048
-      Element: 71 GoHMapBucketType bucket<string,string>
+      Element: 73 GoHMapBucketType bucket<string,string>
     - __kind: GoSliceHeaderType
-      ID: 147
+      ID: 135
       Name: '[]crypto/x509.ExtKeyUsage'
       ByteSize: 24
       GoRuntimeType: 470816
@@ -831,21 +785,21 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 148 PointerType *crypto/x509.ExtKeyUsage
+          Type: 136 PointerType *crypto/x509.ExtKeyUsage
         - Name: len
           Offset: 8
           Type: 9 BaseType int
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 182 GoSliceDataType []crypto/x509.ExtKeyUsage.array
+      Data: 170 GoSliceDataType []crypto/x509.ExtKeyUsage.array
     - __kind: GoSliceDataType
-      ID: 182
+      ID: 170
       Name: '[]crypto/x509.ExtKeyUsage.array'
       ByteSize: 2048
-      Element: 149 BaseType crypto/x509.ExtKeyUsage
+      Element: 137 BaseType crypto/x509.ExtKeyUsage
     - __kind: GoSliceHeaderType
-      ID: 158
+      ID: 146
       Name: '[]crypto/x509.OID'
       ByteSize: 24
       GoRuntimeType: 481632
@@ -853,21 +807,21 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 159 PointerType *crypto/x509.OID
+          Type: 147 PointerType *crypto/x509.OID
         - Name: len
           Offset: 8
           Type: 9 BaseType int
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 192 GoSliceDataType []crypto/x509.OID.array
+      Data: 179 GoSliceDataType []crypto/x509.OID.array
     - __kind: GoSliceDataType
-      ID: 192
+      ID: 179
       Name: '[]crypto/x509.OID.array'
       ByteSize: 2048
-      Element: 160 StructureType crypto/x509.OID
+      Element: 148 StructureType crypto/x509.OID
     - __kind: GoSliceHeaderType
-      ID: 134
+      ID: 122
       Name: '[]crypto/x509/pkix.AttributeTypeAndValue'
       ByteSize: 24
       GoRuntimeType: 481888
@@ -875,21 +829,21 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 135 PointerType *crypto/x509/pkix.AttributeTypeAndValue
+          Type: 123 PointerType *crypto/x509/pkix.AttributeTypeAndValue
         - Name: len
           Offset: 8
           Type: 9 BaseType int
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 174 GoSliceDataType []crypto/x509/pkix.AttributeTypeAndValue.array
+      Data: 154 GoSliceDataType []crypto/x509/pkix.AttributeTypeAndValue.array
     - __kind: GoSliceDataType
-      ID: 174
+      ID: 154
       Name: '[]crypto/x509/pkix.AttributeTypeAndValue.array'
       ByteSize: 2048
-      Element: 136 StructureType crypto/x509/pkix.AttributeTypeAndValue
+      Element: 124 StructureType crypto/x509/pkix.AttributeTypeAndValue
     - __kind: GoSliceHeaderType
-      ID: 141
+      ID: 129
       Name: '[]crypto/x509/pkix.Extension'
       ByteSize: 24
       GoRuntimeType: 481376
@@ -897,21 +851,21 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 142 PointerType *crypto/x509/pkix.Extension
+          Type: 130 PointerType *crypto/x509/pkix.Extension
         - Name: len
           Offset: 8
           Type: 9 BaseType int
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 176 GoSliceDataType []crypto/x509/pkix.Extension.array
+      Data: 166 GoSliceDataType []crypto/x509/pkix.Extension.array
     - __kind: GoSliceDataType
-      ID: 176
+      ID: 166
       Name: '[]crypto/x509/pkix.Extension.array'
       ByteSize: 2048
-      Element: 143 StructureType crypto/x509/pkix.Extension
+      Element: 131 StructureType crypto/x509/pkix.Extension
     - __kind: GoSliceHeaderType
-      ID: 144
+      ID: 132
       Name: '[]encoding/asn1.ObjectIdentifier'
       ByteSize: 24
       GoRuntimeType: 481440
@@ -919,28 +873,28 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 145 PointerType *encoding/asn1.ObjectIdentifier
+          Type: 133 PointerType *encoding/asn1.ObjectIdentifier
         - Name: len
           Offset: 8
           Type: 9 BaseType int
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 178 GoSliceDataType []encoding/asn1.ObjectIdentifier.array
+      Data: 168 GoSliceDataType []encoding/asn1.ObjectIdentifier.array
     - __kind: GoSliceDataType
-      ID: 178
+      ID: 168
       Name: '[]encoding/asn1.ObjectIdentifier.array'
       ByteSize: 2048
-      Element: 146 GoSliceHeaderType encoding/asn1.ObjectIdentifier
+      Element: 134 GoSliceHeaderType encoding/asn1.ObjectIdentifier
     - __kind: ArrayType
-      ID: 79
+      ID: 77
       Name: '[]key<string>'
       ByteSize: 128
       Count: 8
       HasCount: true
       Element: 11 GoStringHeaderType string
     - __kind: GoSliceHeaderType
-      ID: 150
+      ID: 138
       Name: '[]net.IP'
       ByteSize: 24
       GoRuntimeType: 454048
@@ -948,21 +902,21 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 151 PointerType *net.IP
+          Type: 139 PointerType *net.IP
         - Name: len
           Offset: 8
           Type: 9 BaseType int
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 184 GoSliceDataType []net.IP.array
+      Data: 172 GoSliceDataType []net.IP.array
     - __kind: GoSliceDataType
-      ID: 184
+      ID: 172
       Name: '[]net.IP.array'
       ByteSize: 2048
-      Element: 152 GoSliceHeaderType net.IP
+      Element: 140 GoSliceHeaderType net.IP
     - __kind: GoSliceHeaderType
-      ID: 100
+      ID: 188
       Name: '[]net/http.segment'
       ByteSize: 24
       GoRuntimeType: 454816
@@ -970,21 +924,21 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 101 PointerType *net/http.segment
+          Type: 189 PointerType *net/http.segment
         - Name: len
           Offset: 8
           Type: 9 BaseType int
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 125 GoSliceDataType []net/http.segment.array
+      Data: 191 GoSliceDataType []net/http.segment.array
     - __kind: GoSliceDataType
-      ID: 125
+      ID: 191
       Name: '[]net/http.segment.array'
       ByteSize: 2048
-      Element: 102 StructureType net/http.segment
+      Element: 190 StructureType net/http.segment
     - __kind: GoSliceHeaderType
-      ID: 55
+      ID: 57
       Name: '[]string'
       ByteSize: 24
       GoRuntimeType: 464704
@@ -999,14 +953,14 @@ Types:
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 105 GoSliceDataType []string.array
+      Data: 80 GoSliceDataType []string.array
     - __kind: GoSliceDataType
-      ID: 105
+      ID: 80
       Name: '[]string.array'
       ByteSize: 2048
       Element: 11 GoStringHeaderType string
     - __kind: GoSliceHeaderType
-      ID: 167
+      ID: 156
       Name: '[]time.zone'
       ByteSize: 24
       GoRuntimeType: 459040
@@ -1014,21 +968,21 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 168 PointerType *time.zone
+          Type: 157 PointerType *time.zone
         - Name: len
           Offset: 8
           Type: 9 BaseType int
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 197 GoSliceDataType []time.zone.array
+      Data: 162 GoSliceDataType []time.zone.array
     - __kind: GoSliceDataType
-      ID: 197
+      ID: 162
       Name: '[]time.zone.array'
       ByteSize: 2048
-      Element: 169 StructureType time.zone
+      Element: 158 StructureType time.zone
     - __kind: GoSliceHeaderType
-      ID: 170
+      ID: 159
       Name: '[]time.zoneTrans'
       ByteSize: 24
       GoRuntimeType: 459104
@@ -1036,21 +990,21 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 171 PointerType *time.zoneTrans
+          Type: 160 PointerType *time.zoneTrans
         - Name: len
           Offset: 8
           Type: 9 BaseType int
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 199 GoSliceDataType []time.zoneTrans.array
+      Data: 164 GoSliceDataType []time.zoneTrans.array
     - __kind: GoSliceDataType
-      ID: 199
+      ID: 164
       Name: '[]time.zoneTrans.array'
       ByteSize: 2048
-      Element: 172 StructureType time.zoneTrans
+      Element: 161 StructureType time.zoneTrans
     - __kind: GoSliceHeaderType
-      ID: 72
+      ID: 97
       Name: '[]uint8'
       ByteSize: 24
       GoRuntimeType: 463552
@@ -1065,28 +1019,28 @@ Types:
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 108 GoSliceDataType []uint8.array
+      Data: 98 GoSliceDataType []uint8.array
     - __kind: GoSliceDataType
-      ID: 108
+      ID: 98
       Name: '[]uint8.array'
       ByteSize: 2048
       Element: 3 BaseType uint8
     - __kind: ArrayType
-      ID: 111
+      ID: 88
       Name: '[]val<[]*mime/multipart.FileHeader>'
       ByteSize: 192
       Count: 8
       HasCount: true
-      Element: 112 GoSliceHeaderType []*mime/multipart.FileHeader
+      Element: 89 GoSliceHeaderType []*mime/multipart.FileHeader
     - __kind: ArrayType
-      ID: 80
+      ID: 78
       Name: '[]val<[]string>'
       ByteSize: 192
       Count: 8
       HasCount: true
-      Element: 55 GoSliceHeaderType []string
+      Element: 57 GoSliceHeaderType []string
     - __kind: ArrayType
-      ID: 103
+      ID: 193
       Name: '[]val<string>'
       ByteSize: 128
       Count: 8
@@ -1099,84 +1053,66 @@ Types:
       GoRuntimeType: 534592
       GoKind: 1
     - __kind: GoHMapBucketType
-      ID: 90
+      ID: 87
       Name: bucket<string,[]*mime/multipart.FileHeader>
       ByteSize: 336
       RawFields:
         - Name: tophash
           Offset: 0
-          Type: 78 ArrayType [8]uint8
+          Type: 76 ArrayType [8]uint8
         - Name: keys
           Offset: 8
-          Type: 79 ArrayType []key<string>
+          Type: 77 ArrayType []key<string>
         - Name: values
           Offset: 136
-          Type: 111 ArrayType []val<[]*mime/multipart.FileHeader>
+          Type: 88 ArrayType []val<[]*mime/multipart.FileHeader>
         - Name: overflow
           Offset: 328
-          Type: 89 PointerType *bucket<string,[]*mime/multipart.FileHeader>
+          Type: 86 PointerType *bucket<string,[]*mime/multipart.FileHeader>
       KeyType: 11 GoStringHeaderType string
-      ValueType: 112 GoSliceHeaderType []*mime/multipart.FileHeader
+      ValueType: 89 GoSliceHeaderType []*mime/multipart.FileHeader
     - __kind: GoHMapBucketType
-      ID: 50
+      ID: 52
       Name: bucket<string,[]string>
       ByteSize: 336
       RawFields:
         - Name: tophash
           Offset: 0
-          Type: 78 ArrayType [8]uint8
+          Type: 76 ArrayType [8]uint8
         - Name: keys
           Offset: 8
-          Type: 79 ArrayType []key<string>
+          Type: 77 ArrayType []key<string>
         - Name: values
           Offset: 136
-          Type: 80 ArrayType []val<[]string>
+          Type: 78 ArrayType []val<[]string>
         - Name: overflow
           Offset: 328
-          Type: 49 PointerType *bucket<string,[]string>
+          Type: 51 PointerType *bucket<string,[]string>
       KeyType: 11 GoStringHeaderType string
-      ValueType: 55 GoSliceHeaderType []string
+      ValueType: 57 GoSliceHeaderType []string
     - __kind: GoHMapBucketType
-      ID: 71
+      ID: 73
       Name: bucket<string,string>
       ByteSize: 272
       RawFields:
         - Name: tophash
           Offset: 0
-          Type: 78 ArrayType [8]uint8
+          Type: 76 ArrayType [8]uint8
         - Name: keys
           Offset: 8
-          Type: 79 ArrayType []key<string>
+          Type: 77 ArrayType []key<string>
         - Name: values
           Offset: 136
-          Type: 103 ArrayType []val<string>
+          Type: 193 ArrayType []val<string>
         - Name: overflow
           Offset: 264
-          Type: 70 PointerType *bucket<string,string>
+          Type: 72 PointerType *bucket<string,string>
       KeyType: 11 GoStringHeaderType string
       ValueType: 11 GoStringHeaderType string
-    - __kind: StructureType
+    - __kind: UnresolvedPointeeType
       ID: 40
       Name: bytes.Buffer
-      ByteSize: 40
-      GoRuntimeType: 1.41392e+06
-      GoKind: 25
-      RawFields:
-        - Name: buf
-          Offset: 0
-          Type: 72 GoSliceHeaderType []uint8
-        - Name: off
-          Offset: 24
-          Type: 9 BaseType int
-        - Name: lastRead
-          Offset: 32
-          Type: 73 BaseType bytes.readOp
-    - __kind: BaseType
-      ID: 73
-      Name: bytes.readOp
-      ByteSize: 1
-      GoRuntimeType: 532800
-      GoKind: 3
+      ByteSize: 8
     - __kind: BaseType
       ID: 24
       Name: complex128
@@ -1190,7 +1126,7 @@ Types:
       GoRuntimeType: 534336
       GoKind: 15
     - __kind: GoInterfaceType
-      ID: 64
+      ID: 66
       Name: context.Context
       ByteSize: 16
       GoRuntimeType: 1.187104e+06
@@ -1218,7 +1154,7 @@ Types:
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 60
+      ID: 62
       Name: crypto/tls.ConnectionState
       ByteSize: 192
       GoRuntimeType: 2.1e+06
@@ -1247,39 +1183,39 @@ Types:
           Type: 11 GoStringHeaderType string
         - Name: PeerCertificates
           Offset: 48
-          Type: 91 GoSliceHeaderType []*crypto/x509.Certificate
+          Type: 100 GoSliceHeaderType []*crypto/x509.Certificate
         - Name: VerifiedChains
           Offset: 72
-          Type: 94 GoSliceHeaderType [][]*crypto/x509.Certificate
+          Type: 103 GoSliceHeaderType [][]*crypto/x509.Certificate
         - Name: SignedCertificateTimestamps
           Offset: 96
-          Type: 96 GoSliceHeaderType [][]uint8
+          Type: 105 GoSliceHeaderType [][]uint8
         - Name: OCSPResponse
           Offset: 120
-          Type: 72 GoSliceHeaderType []uint8
+          Type: 97 GoSliceHeaderType []uint8
         - Name: TLSUnique
           Offset: 144
-          Type: 72 GoSliceHeaderType []uint8
+          Type: 97 GoSliceHeaderType []uint8
         - Name: ECHAccepted
           Offset: 168
           Type: 4 BaseType bool
         - Name: ekm
           Offset: 176
-          Type: 98 GoSubroutineType func(string, []uint8, int) ([]uint8, error)
+          Type: 107 GoSubroutineType func(string, []uint8, int) ([]uint8, error)
         - Name: testingOnlyDidHRR
           Offset: 184
           Type: 4 BaseType bool
         - Name: testingOnlyCurveID
           Offset: 186
-          Type: 99 BaseType crypto/tls.CurveID
+          Type: 108 BaseType crypto/tls.CurveID
     - __kind: BaseType
-      ID: 99
+      ID: 108
       Name: crypto/tls.CurveID
       ByteSize: 2
       GoRuntimeType: 766048
       GoKind: 9
     - __kind: StructureType
-      ID: 115
+      ID: 109
       Name: crypto/x509.Certificate
       ByteSize: 1352
       GoRuntimeType: 2.234656e+06
@@ -1287,67 +1223,67 @@ Types:
       RawFields:
         - Name: Raw
           Offset: 0
-          Type: 72 GoSliceHeaderType []uint8
+          Type: 97 GoSliceHeaderType []uint8
         - Name: RawTBSCertificate
           Offset: 24
-          Type: 72 GoSliceHeaderType []uint8
+          Type: 97 GoSliceHeaderType []uint8
         - Name: RawSubjectPublicKeyInfo
           Offset: 48
-          Type: 72 GoSliceHeaderType []uint8
+          Type: 97 GoSliceHeaderType []uint8
         - Name: RawSubject
           Offset: 72
-          Type: 72 GoSliceHeaderType []uint8
+          Type: 97 GoSliceHeaderType []uint8
         - Name: RawIssuer
           Offset: 96
-          Type: 72 GoSliceHeaderType []uint8
+          Type: 97 GoSliceHeaderType []uint8
         - Name: Signature
           Offset: 120
-          Type: 72 GoSliceHeaderType []uint8
+          Type: 97 GoSliceHeaderType []uint8
         - Name: SignatureAlgorithm
           Offset: 144
-          Type: 128 BaseType crypto/x509.SignatureAlgorithm
+          Type: 116 BaseType crypto/x509.SignatureAlgorithm
         - Name: PublicKeyAlgorithm
           Offset: 152
-          Type: 129 BaseType crypto/x509.PublicKeyAlgorithm
+          Type: 117 BaseType crypto/x509.PublicKeyAlgorithm
         - Name: PublicKey
           Offset: 160
-          Type: 130 GoEmptyInterfaceType interface {}
+          Type: 118 GoEmptyInterfaceType interface {}
         - Name: Version
           Offset: 176
           Type: 9 BaseType int
         - Name: SerialNumber
           Offset: 184
-          Type: 131 PointerType *math/big.Int
+          Type: 119 PointerType *math/big.Int
         - Name: Issuer
           Offset: 192
-          Type: 133 StructureType crypto/x509/pkix.Name
+          Type: 121 StructureType crypto/x509/pkix.Name
         - Name: Subject
           Offset: 440
-          Type: 133 StructureType crypto/x509/pkix.Name
+          Type: 121 StructureType crypto/x509/pkix.Name
         - Name: NotBefore
           Offset: 688
-          Type: 137 StructureType time.Time
+          Type: 125 StructureType time.Time
         - Name: NotAfter
           Offset: 712
-          Type: 137 StructureType time.Time
+          Type: 125 StructureType time.Time
         - Name: KeyUsage
           Offset: 736
-          Type: 140 BaseType crypto/x509.KeyUsage
+          Type: 128 BaseType crypto/x509.KeyUsage
         - Name: Extensions
           Offset: 744
-          Type: 141 GoSliceHeaderType []crypto/x509/pkix.Extension
+          Type: 129 GoSliceHeaderType []crypto/x509/pkix.Extension
         - Name: ExtraExtensions
           Offset: 768
-          Type: 141 GoSliceHeaderType []crypto/x509/pkix.Extension
+          Type: 129 GoSliceHeaderType []crypto/x509/pkix.Extension
         - Name: UnhandledCriticalExtensions
           Offset: 792
-          Type: 144 GoSliceHeaderType []encoding/asn1.ObjectIdentifier
+          Type: 132 GoSliceHeaderType []encoding/asn1.ObjectIdentifier
         - Name: ExtKeyUsage
           Offset: 816
-          Type: 147 GoSliceHeaderType []crypto/x509.ExtKeyUsage
+          Type: 135 GoSliceHeaderType []crypto/x509.ExtKeyUsage
         - Name: UnknownExtKeyUsage
           Offset: 840
-          Type: 144 GoSliceHeaderType []encoding/asn1.ObjectIdentifier
+          Type: 132 GoSliceHeaderType []encoding/asn1.ObjectIdentifier
         - Name: BasicConstraintsValid
           Offset: 864
           Type: 4 BaseType bool
@@ -1362,78 +1298,78 @@ Types:
           Type: 4 BaseType bool
         - Name: SubjectKeyId
           Offset: 888
-          Type: 72 GoSliceHeaderType []uint8
+          Type: 97 GoSliceHeaderType []uint8
         - Name: AuthorityKeyId
           Offset: 912
-          Type: 72 GoSliceHeaderType []uint8
+          Type: 97 GoSliceHeaderType []uint8
         - Name: OCSPServer
           Offset: 936
-          Type: 55 GoSliceHeaderType []string
+          Type: 57 GoSliceHeaderType []string
         - Name: IssuingCertificateURL
           Offset: 960
-          Type: 55 GoSliceHeaderType []string
+          Type: 57 GoSliceHeaderType []string
         - Name: DNSNames
           Offset: 984
-          Type: 55 GoSliceHeaderType []string
+          Type: 57 GoSliceHeaderType []string
         - Name: EmailAddresses
           Offset: 1008
-          Type: 55 GoSliceHeaderType []string
+          Type: 57 GoSliceHeaderType []string
         - Name: IPAddresses
           Offset: 1032
-          Type: 150 GoSliceHeaderType []net.IP
+          Type: 138 GoSliceHeaderType []net.IP
         - Name: URIs
           Offset: 1056
-          Type: 153 GoSliceHeaderType []*net/url.URL
+          Type: 141 GoSliceHeaderType []*net/url.URL
         - Name: PermittedDNSDomainsCritical
           Offset: 1080
           Type: 4 BaseType bool
         - Name: PermittedDNSDomains
           Offset: 1088
-          Type: 55 GoSliceHeaderType []string
+          Type: 57 GoSliceHeaderType []string
         - Name: ExcludedDNSDomains
           Offset: 1112
-          Type: 55 GoSliceHeaderType []string
+          Type: 57 GoSliceHeaderType []string
         - Name: PermittedIPRanges
           Offset: 1136
-          Type: 155 GoSliceHeaderType []*net.IPNet
+          Type: 143 GoSliceHeaderType []*net.IPNet
         - Name: ExcludedIPRanges
           Offset: 1160
-          Type: 155 GoSliceHeaderType []*net.IPNet
+          Type: 143 GoSliceHeaderType []*net.IPNet
         - Name: PermittedEmailAddresses
           Offset: 1184
-          Type: 55 GoSliceHeaderType []string
+          Type: 57 GoSliceHeaderType []string
         - Name: ExcludedEmailAddresses
           Offset: 1208
-          Type: 55 GoSliceHeaderType []string
+          Type: 57 GoSliceHeaderType []string
         - Name: PermittedURIDomains
           Offset: 1232
-          Type: 55 GoSliceHeaderType []string
+          Type: 57 GoSliceHeaderType []string
         - Name: ExcludedURIDomains
           Offset: 1256
-          Type: 55 GoSliceHeaderType []string
+          Type: 57 GoSliceHeaderType []string
         - Name: CRLDistributionPoints
           Offset: 1280
-          Type: 55 GoSliceHeaderType []string
+          Type: 57 GoSliceHeaderType []string
         - Name: PolicyIdentifiers
           Offset: 1304
-          Type: 144 GoSliceHeaderType []encoding/asn1.ObjectIdentifier
+          Type: 132 GoSliceHeaderType []encoding/asn1.ObjectIdentifier
         - Name: Policies
           Offset: 1328
-          Type: 158 GoSliceHeaderType []crypto/x509.OID
+          Type: 146 GoSliceHeaderType []crypto/x509.OID
     - __kind: BaseType
-      ID: 149
+      ID: 137
       Name: crypto/x509.ExtKeyUsage
       ByteSize: 8
       GoRuntimeType: 537280
       GoKind: 2
     - __kind: BaseType
-      ID: 140
+      ID: 128
       Name: crypto/x509.KeyUsage
       ByteSize: 8
       GoRuntimeType: 537216
       GoKind: 2
     - __kind: StructureType
-      ID: 160
+      ID: 148
       Name: crypto/x509.OID
       ByteSize: 24
       GoRuntimeType: 1.717472e+06
@@ -1441,21 +1377,21 @@ Types:
       RawFields:
         - Name: der
           Offset: 0
-          Type: 72 GoSliceHeaderType []uint8
+          Type: 97 GoSliceHeaderType []uint8
     - __kind: BaseType
-      ID: 129
+      ID: 117
       Name: crypto/x509.PublicKeyAlgorithm
       ByteSize: 8
       GoRuntimeType: 768448
       GoKind: 2
     - __kind: BaseType
-      ID: 128
+      ID: 116
       Name: crypto/x509.SignatureAlgorithm
       ByteSize: 8
       GoRuntimeType: 1.070976e+06
       GoKind: 2
     - __kind: StructureType
-      ID: 136
+      ID: 124
       Name: crypto/x509/pkix.AttributeTypeAndValue
       ByteSize: 40
       GoRuntimeType: 1.316256e+06
@@ -1463,12 +1399,12 @@ Types:
       RawFields:
         - Name: Type
           Offset: 0
-          Type: 146 GoSliceHeaderType encoding/asn1.ObjectIdentifier
+          Type: 134 GoSliceHeaderType encoding/asn1.ObjectIdentifier
         - Name: Value
           Offset: 24
-          Type: 130 GoEmptyInterfaceType interface {}
+          Type: 118 GoEmptyInterfaceType interface {}
     - __kind: StructureType
-      ID: 143
+      ID: 131
       Name: crypto/x509/pkix.Extension
       ByteSize: 56
       GoRuntimeType: 1.455008e+06
@@ -1476,15 +1412,15 @@ Types:
       RawFields:
         - Name: Id
           Offset: 0
-          Type: 146 GoSliceHeaderType encoding/asn1.ObjectIdentifier
+          Type: 134 GoSliceHeaderType encoding/asn1.ObjectIdentifier
         - Name: Critical
           Offset: 24
           Type: 4 BaseType bool
         - Name: Value
           Offset: 32
-          Type: 72 GoSliceHeaderType []uint8
+          Type: 97 GoSliceHeaderType []uint8
     - __kind: StructureType
-      ID: 133
+      ID: 121
       Name: crypto/x509/pkix.Name
       ByteSize: 248
       GoRuntimeType: 2.046944e+06
@@ -1492,25 +1428,25 @@ Types:
       RawFields:
         - Name: Country
           Offset: 0
-          Type: 55 GoSliceHeaderType []string
+          Type: 57 GoSliceHeaderType []string
         - Name: Organization
           Offset: 24
-          Type: 55 GoSliceHeaderType []string
+          Type: 57 GoSliceHeaderType []string
         - Name: OrganizationalUnit
           Offset: 48
-          Type: 55 GoSliceHeaderType []string
+          Type: 57 GoSliceHeaderType []string
         - Name: Locality
           Offset: 72
-          Type: 55 GoSliceHeaderType []string
+          Type: 57 GoSliceHeaderType []string
         - Name: Province
           Offset: 96
-          Type: 55 GoSliceHeaderType []string
+          Type: 57 GoSliceHeaderType []string
         - Name: StreetAddress
           Offset: 120
-          Type: 55 GoSliceHeaderType []string
+          Type: 57 GoSliceHeaderType []string
         - Name: PostalCode
           Offset: 144
-          Type: 55 GoSliceHeaderType []string
+          Type: 57 GoSliceHeaderType []string
         - Name: SerialNumber
           Offset: 168
           Type: 11 GoStringHeaderType string
@@ -1519,12 +1455,12 @@ Types:
           Type: 11 GoStringHeaderType string
         - Name: Names
           Offset: 200
-          Type: 134 GoSliceHeaderType []crypto/x509/pkix.AttributeTypeAndValue
+          Type: 122 GoSliceHeaderType []crypto/x509/pkix.AttributeTypeAndValue
         - Name: ExtraNames
           Offset: 224
-          Type: 134 GoSliceHeaderType []crypto/x509/pkix.AttributeTypeAndValue
+          Type: 122 GoSliceHeaderType []crypto/x509/pkix.AttributeTypeAndValue
     - __kind: GoSliceHeaderType
-      ID: 146
+      ID: 134
       Name: encoding/asn1.ObjectIdentifier
       ByteSize: 24
       GoRuntimeType: 1.009856e+06
@@ -1539,9 +1475,9 @@ Types:
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 180 GoSliceDataType encoding/asn1.ObjectIdentifier.array
+      Data: 181 GoSliceDataType encoding/asn1.ObjectIdentifier.array
     - __kind: GoSliceDataType
-      ID: 180
+      ID: 181
       Name: encoding/asn1.ObjectIdentifier.array
       ByteSize: 2048
       Element: 9 BaseType int
@@ -1571,13 +1507,13 @@ Types:
       GoRuntimeType: 534528
       GoKind: 14
     - __kind: GoSubroutineType
-      ID: 54
+      ID: 56
       Name: func() (io.ReadCloser, error)
       ByteSize: 8
       GoRuntimeType: 634112
       GoKind: 19
     - __kind: GoSubroutineType
-      ID: 98
+      ID: 107
       Name: func(string, []uint8, int) ([]uint8, error)
       ByteSize: 8
       GoRuntimeType: 960256
@@ -1596,7 +1532,7 @@ Types:
           Offset: 8
           Type: 19 VoidPointerType unsafe.Pointer
     - __kind: GoHMapHeaderType
-      ID: 88
+      ID: 85
       Name: hash<string,[]*mime/multipart.FileHeader>
       ByteSize: 48
       RawFields:
@@ -1617,20 +1553,20 @@ Types:
           Type: 2 BaseType uint32
         - Name: buckets
           Offset: 16
-          Type: 89 PointerType *bucket<string,[]*mime/multipart.FileHeader>
+          Type: 86 PointerType *bucket<string,[]*mime/multipart.FileHeader>
         - Name: oldbuckets
           Offset: 24
-          Type: 89 PointerType *bucket<string,[]*mime/multipart.FileHeader>
+          Type: 86 PointerType *bucket<string,[]*mime/multipart.FileHeader>
         - Name: nevacuate
           Offset: 32
           Type: 1 BaseType uintptr
         - Name: extra
           Offset: 40
-          Type: 51 PointerType *runtime.mapextra
-      BucketType: 90 GoHMapBucketType bucket<string,[]*mime/multipart.FileHeader>
-      BucketsType: 118 GoSliceDataType []bucket<string,[]*mime/multipart.FileHeader>.array
+          Type: 53 PointerType *runtime.mapextra
+      BucketType: 87 GoHMapBucketType bucket<string,[]*mime/multipart.FileHeader>
+      BucketsType: 92 GoSliceDataType []bucket<string,[]*mime/multipart.FileHeader>.array
     - __kind: GoHMapHeaderType
-      ID: 48
+      ID: 50
       Name: hash<string,[]string>
       ByteSize: 48
       RawFields:
@@ -1651,20 +1587,20 @@ Types:
           Type: 2 BaseType uint32
         - Name: buckets
           Offset: 16
-          Type: 49 PointerType *bucket<string,[]string>
+          Type: 51 PointerType *bucket<string,[]string>
         - Name: oldbuckets
           Offset: 24
-          Type: 49 PointerType *bucket<string,[]string>
+          Type: 51 PointerType *bucket<string,[]string>
         - Name: nevacuate
           Offset: 32
           Type: 1 BaseType uintptr
         - Name: extra
           Offset: 40
-          Type: 51 PointerType *runtime.mapextra
-      BucketType: 50 GoHMapBucketType bucket<string,[]string>
-      BucketsType: 104 GoSliceDataType []bucket<string,[]string>.array
+          Type: 53 PointerType *runtime.mapextra
+      BucketType: 52 GoHMapBucketType bucket<string,[]string>
+      BucketsType: 79 GoSliceDataType []bucket<string,[]string>.array
     - __kind: GoHMapHeaderType
-      ID: 69
+      ID: 71
       Name: hash<string,string>
       ByteSize: 48
       RawFields:
@@ -1685,18 +1621,18 @@ Types:
           Type: 2 BaseType uint32
         - Name: buckets
           Offset: 16
-          Type: 70 PointerType *bucket<string,string>
+          Type: 72 PointerType *bucket<string,string>
         - Name: oldbuckets
           Offset: 24
-          Type: 70 PointerType *bucket<string,string>
+          Type: 72 PointerType *bucket<string,string>
         - Name: nevacuate
           Offset: 32
           Type: 1 BaseType uintptr
         - Name: extra
           Offset: 40
-          Type: 51 PointerType *runtime.mapextra
-      BucketType: 71 GoHMapBucketType bucket<string,string>
-      BucketsType: 107 GoSliceDataType []bucket<string,string>.array
+          Type: 53 PointerType *runtime.mapextra
+      BucketType: 73 GoHMapBucketType bucket<string,string>
+      BucketsType: 194 GoSliceDataType []bucket<string,string>.array
     - __kind: BaseType
       ID: 9
       Name: int
@@ -1728,7 +1664,7 @@ Types:
       GoRuntimeType: 533632
       GoKind: 3
     - __kind: GoEmptyInterfaceType
-      ID: 130
+      ID: 118
       Name: interface {}
       ByteSize: 16
       GoRuntimeType: 785376
@@ -1741,7 +1677,7 @@ Types:
           Offset: 8
           Type: 19 VoidPointerType unsafe.Pointer
     - __kind: GoInterfaceType
-      ID: 53
+      ID: 55
       Name: io.ReadCloser
       ByteSize: 16
       GoRuntimeType: 1.067136e+06
@@ -1754,28 +1690,28 @@ Types:
           Offset: 8
           Type: 19 VoidPointerType unsafe.Pointer
     - __kind: GoMapType
-      ID: 86
+      ID: 83
       Name: map[string][]*mime/multipart.FileHeader
       ByteSize: 8
       GoRuntimeType: 887296
       GoKind: 21
-      HeaderType: 88 GoHMapHeaderType hash<string,[]*mime/multipart.FileHeader>
+      HeaderType: 85 GoHMapHeaderType hash<string,[]*mime/multipart.FileHeader>
     - __kind: GoMapType
-      ID: 85
+      ID: 82
       Name: map[string][]string
       ByteSize: 8
       GoRuntimeType: 882496
       GoKind: 21
-      HeaderType: 48 GoHMapHeaderType hash<string,[]string>
+      HeaderType: 50 GoHMapHeaderType hash<string,[]string>
     - __kind: GoMapType
-      ID: 67
+      ID: 69
       Name: map[string]string
       ByteSize: 8
       GoRuntimeType: 884128
       GoKind: 21
-      HeaderType: 69 GoHMapHeaderType hash<string,string>
+      HeaderType: 71 GoHMapHeaderType hash<string,string>
     - __kind: StructureType
-      ID: 132
+      ID: 120
       Name: math/big.Int
       ByteSize: 32
       GoRuntimeType: 1.308416e+06
@@ -1786,15 +1722,15 @@ Types:
           Type: 4 BaseType bool
         - Name: abs
           Offset: 8
-          Type: 164 GoSliceHeaderType math/big.nat
+          Type: 149 GoSliceHeaderType math/big.nat
     - __kind: BaseType
-      ID: 166
+      ID: 151
       Name: math/big.Word
       ByteSize: 8
       GoRuntimeType: 537536
       GoKind: 7
     - __kind: GoSliceHeaderType
-      ID: 164
+      ID: 149
       Name: math/big.nat
       ByteSize: 24
       GoRuntimeType: 2.21424e+06
@@ -1802,21 +1738,21 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 165 PointerType *math/big.Word
+          Type: 150 PointerType *math/big.Word
         - Name: len
           Offset: 8
           Type: 9 BaseType int
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 195 GoSliceDataType math/big.nat.array
+      Data: 152 GoSliceDataType math/big.nat.array
     - __kind: GoSliceDataType
-      ID: 195
+      ID: 152
       Name: math/big.nat.array
       ByteSize: 2048
-      Element: 166 BaseType math/big.Word
+      Element: 151 BaseType math/big.Word
     - __kind: StructureType
-      ID: 127
+      ID: 93
       Name: mime/multipart.FileHeader
       ByteSize: 88
       GoRuntimeType: 1.838016e+06
@@ -1827,13 +1763,13 @@ Types:
           Type: 11 GoStringHeaderType string
         - Name: Header
           Offset: 16
-          Type: 163 GoMapType net/textproto.MIMEHeader
+          Type: 96 GoMapType net/textproto.MIMEHeader
         - Name: Size
           Offset: 24
           Type: 13 BaseType int64
         - Name: content
           Offset: 32
-          Type: 72 GoSliceHeaderType []uint8
+          Type: 97 GoSliceHeaderType []uint8
         - Name: tmpfile
           Offset: 56
           Type: 11 GoStringHeaderType string
@@ -1844,7 +1780,7 @@ Types:
           Offset: 80
           Type: 4 BaseType bool
     - __kind: StructureType
-      ID: 58
+      ID: 60
       Name: mime/multipart.Form
       ByteSize: 16
       GoRuntimeType: 1.294336e+06
@@ -1852,12 +1788,12 @@ Types:
       RawFields:
         - Name: Value
           Offset: 0
-          Type: 85 GoMapType map[string][]string
+          Type: 82 GoMapType map[string][]string
         - Name: File
           Offset: 8
-          Type: 86 GoMapType map[string][]*mime/multipart.FileHeader
+          Type: 83 GoMapType map[string][]*mime/multipart.FileHeader
     - __kind: GoSliceHeaderType
-      ID: 152
+      ID: 140
       Name: net.IP
       ByteSize: 24
       GoRuntimeType: 1.94816e+06
@@ -1872,14 +1808,14 @@ Types:
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 186 GoSliceDataType net.IP.array
+      Data: 183 GoSliceDataType net.IP.array
     - __kind: GoSliceDataType
-      ID: 186
+      ID: 183
       Name: net.IP.array
       ByteSize: 2048
       Element: 3 BaseType uint8
     - __kind: GoSliceHeaderType
-      ID: 194
+      ID: 185
       Name: net.IPMask
       ByteSize: 24
       GoRuntimeType: 975808
@@ -1894,14 +1830,14 @@ Types:
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 201 GoSliceDataType net.IPMask.array
+      Data: 186 GoSliceDataType net.IPMask.array
     - __kind: GoSliceDataType
-      ID: 201
+      ID: 186
       Name: net.IPMask.array
       ByteSize: 2048
       Element: 3 BaseType uint8
     - __kind: StructureType
-      ID: 173
+      ID: 176
       Name: net.IPNet
       ByteSize: 48
       GoRuntimeType: 1.275936e+06
@@ -1909,17 +1845,17 @@ Types:
       RawFields:
         - Name: IP
           Offset: 0
-          Type: 152 GoSliceHeaderType net.IP
+          Type: 140 GoSliceHeaderType net.IP
         - Name: Mask
           Offset: 24
-          Type: 194 GoSliceHeaderType net.IPMask
+          Type: 185 GoSliceHeaderType net.IPMask
     - __kind: GoMapType
-      ID: 46
+      ID: 48
       Name: net/http.Header
       ByteSize: 8
       GoRuntimeType: 1.91744e+06
       GoKind: 21
-      HeaderType: 48 GoHMapHeaderType hash<string,[]string>
+      HeaderType: 50 GoHMapHeaderType hash<string,[]string>
     - __kind: StructureType
       ID: 38
       Name: net/http.Request
@@ -1932,7 +1868,7 @@ Types:
           Type: 11 GoStringHeaderType string
         - Name: URL
           Offset: 16
-          Type: 44 PointerType *net/url.URL
+          Type: 46 PointerType *net/url.URL
         - Name: Proto
           Offset: 24
           Type: 11 GoStringHeaderType string
@@ -1944,19 +1880,19 @@ Types:
           Type: 9 BaseType int
         - Name: Header
           Offset: 56
-          Type: 46 GoMapType net/http.Header
+          Type: 48 GoMapType net/http.Header
         - Name: Body
           Offset: 64
-          Type: 53 GoInterfaceType io.ReadCloser
+          Type: 55 GoInterfaceType io.ReadCloser
         - Name: GetBody
           Offset: 80
-          Type: 54 GoSubroutineType func() (io.ReadCloser, error)
+          Type: 56 GoSubroutineType func() (io.ReadCloser, error)
         - Name: ContentLength
           Offset: 88
           Type: 13 BaseType int64
         - Name: TransferEncoding
           Offset: 96
-          Type: 55 GoSliceHeaderType []string
+          Type: 57 GoSliceHeaderType []string
         - Name: Close
           Offset: 120
           Type: 4 BaseType bool
@@ -1965,16 +1901,16 @@ Types:
           Type: 11 GoStringHeaderType string
         - Name: Form
           Offset: 144
-          Type: 56 GoMapType net/url.Values
+          Type: 58 GoMapType net/url.Values
         - Name: PostForm
           Offset: 152
-          Type: 56 GoMapType net/url.Values
+          Type: 58 GoMapType net/url.Values
         - Name: MultipartForm
           Offset: 160
-          Type: 57 PointerType *mime/multipart.Form
+          Type: 59 PointerType *mime/multipart.Form
         - Name: Trailer
           Offset: 168
-          Type: 46 GoMapType net/http.Header
+          Type: 48 GoMapType net/http.Header
         - Name: RemoteAddr
           Offset: 176
           Type: 11 GoStringHeaderType string
@@ -1983,30 +1919,30 @@ Types:
           Type: 11 GoStringHeaderType string
         - Name: TLS
           Offset: 208
-          Type: 59 PointerType *crypto/tls.ConnectionState
+          Type: 61 PointerType *crypto/tls.ConnectionState
         - Name: Cancel
           Offset: 216
-          Type: 61 GoChannelType <-chan struct {}
+          Type: 63 GoChannelType <-chan struct {}
         - Name: Response
           Offset: 224
-          Type: 62 PointerType *net/http.Response
+          Type: 64 PointerType *net/http.Response
         - Name: Pattern
           Offset: 232
           Type: 11 GoStringHeaderType string
         - Name: ctx
           Offset: 248
-          Type: 64 GoInterfaceType context.Context
+          Type: 66 GoInterfaceType context.Context
         - Name: pat
           Offset: 264
-          Type: 65 PointerType *net/http.pattern
+          Type: 67 PointerType *net/http.pattern
         - Name: matches
           Offset: 272
-          Type: 55 GoSliceHeaderType []string
+          Type: 57 GoSliceHeaderType []string
         - Name: otherValues
           Offset: 296
-          Type: 67 GoMapType map[string]string
+          Type: 69 GoMapType map[string]string
     - __kind: StructureType
-      ID: 63
+      ID: 65
       Name: net/http.Response
       ByteSize: 144
       GoRuntimeType: 2.064832e+06
@@ -2029,16 +1965,16 @@ Types:
           Type: 9 BaseType int
         - Name: Header
           Offset: 56
-          Type: 46 GoMapType net/http.Header
+          Type: 48 GoMapType net/http.Header
         - Name: Body
           Offset: 64
-          Type: 53 GoInterfaceType io.ReadCloser
+          Type: 55 GoInterfaceType io.ReadCloser
         - Name: ContentLength
           Offset: 80
           Type: 13 BaseType int64
         - Name: TransferEncoding
           Offset: 88
-          Type: 55 GoSliceHeaderType []string
+          Type: 57 GoSliceHeaderType []string
         - Name: Close
           Offset: 112
           Type: 4 BaseType bool
@@ -2047,13 +1983,13 @@ Types:
           Type: 4 BaseType bool
         - Name: Trailer
           Offset: 120
-          Type: 46 GoMapType net/http.Header
+          Type: 48 GoMapType net/http.Header
         - Name: Request
           Offset: 128
           Type: 37 PointerType *net/http.Request
         - Name: TLS
           Offset: 136
-          Type: 59 PointerType *crypto/tls.ConnectionState
+          Type: 61 PointerType *crypto/tls.ConnectionState
     - __kind: GoInterfaceType
       ID: 36
       Name: net/http.ResponseWriter
@@ -2068,7 +2004,7 @@ Types:
           Offset: 8
           Type: 19 VoidPointerType unsafe.Pointer
     - __kind: StructureType
-      ID: 66
+      ID: 68
       Name: net/http.pattern
       ByteSize: 88
       GoRuntimeType: 1.701568e+06
@@ -2085,12 +2021,12 @@ Types:
           Type: 11 GoStringHeaderType string
         - Name: segments
           Offset: 48
-          Type: 100 GoSliceHeaderType []net/http.segment
+          Type: 188 GoSliceHeaderType []net/http.segment
         - Name: loc
           Offset: 72
           Type: 11 GoStringHeaderType string
     - __kind: StructureType
-      ID: 102
+      ID: 190
       Name: net/http.segment
       ByteSize: 24
       GoRuntimeType: 1.416032e+06
@@ -2106,14 +2042,14 @@ Types:
           Offset: 17
           Type: 4 BaseType bool
     - __kind: GoMapType
-      ID: 163
+      ID: 96
       Name: net/textproto.MIMEHeader
       ByteSize: 8
       GoRuntimeType: 1.595904e+06
       GoKind: 21
-      HeaderType: 48 GoHMapHeaderType hash<string,[]string>
+      HeaderType: 50 GoHMapHeaderType hash<string,[]string>
     - __kind: StructureType
-      ID: 45
+      ID: 47
       Name: net/url.URL
       ByteSize: 144
       GoRuntimeType: 1.986272e+06
@@ -2127,7 +2063,7 @@ Types:
           Type: 11 GoStringHeaderType string
         - Name: User
           Offset: 32
-          Type: 76 PointerType *net/url.Userinfo
+          Type: 74 PointerType *net/url.Userinfo
         - Name: Host
           Offset: 40
           Type: 11 GoStringHeaderType string
@@ -2153,7 +2089,7 @@ Types:
           Offset: 128
           Type: 11 GoStringHeaderType string
     - __kind: StructureType
-      ID: 77
+      ID: 75
       Name: net/url.Userinfo
       ByteSize: 40
       GoRuntimeType: 1.432736e+06
@@ -2169,38 +2105,16 @@ Types:
           Offset: 32
           Type: 4 BaseType bool
     - __kind: GoMapType
-      ID: 56
+      ID: 58
       Name: net/url.Values
       ByteSize: 8
       GoRuntimeType: 1.670784e+06
       GoKind: 21
-      HeaderType: 48 GoHMapHeaderType hash<string,[]string>
-    - __kind: StructureType
-      ID: 84
-      Name: runtime.bmap
-      ByteSize: 8
-      GoRuntimeType: 1.109728e+06
-      GoKind: 25
-      RawFields:
-        - Name: tophash
-          Offset: 0
-          Type: 78 ArrayType [8]uint8
-    - __kind: StructureType
-      ID: 52
+      HeaderType: 50 GoHMapHeaderType hash<string,[]string>
+    - __kind: UnresolvedPointeeType
+      ID: 54
       Name: runtime.mapextra
-      ByteSize: 24
-      GoRuntimeType: 1.428704e+06
-      GoKind: 25
-      RawFields:
-        - Name: overflow
-          Offset: 0
-          Type: 81 PointerType *[]*runtime.bmap
-        - Name: oldoverflow
-          Offset: 8
-          Type: 81 PointerType *[]*runtime.bmap
-        - Name: nextOverflow
-          Offset: 16
-          Type: 83 PointerType *runtime.bmap
+      ByteSize: 8
     - __kind: GoStringHeaderType
       ID: 11
       Name: string
@@ -2210,17 +2124,17 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 75 PointerType *string.str
+          Type: 45 PointerType *string.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 74 GoStringDataType string.str
+      Data: 44 GoStringDataType string.str
     - __kind: GoStringDataType
-      ID: 74
+      ID: 44
       Name: string.str
       ByteSize: 2048
     - __kind: StructureType
-      ID: 139
+      ID: 127
       Name: time.Location
       ByteSize: 104
       GoRuntimeType: 1.833984e+06
@@ -2231,10 +2145,10 @@ Types:
           Type: 11 GoStringHeaderType string
         - Name: zone
           Offset: 16
-          Type: 167 GoSliceHeaderType []time.zone
+          Type: 156 GoSliceHeaderType []time.zone
         - Name: tx
           Offset: 40
-          Type: 170 GoSliceHeaderType []time.zoneTrans
+          Type: 159 GoSliceHeaderType []time.zoneTrans
         - Name: extend
           Offset: 64
           Type: 11 GoStringHeaderType string
@@ -2246,9 +2160,9 @@ Types:
           Type: 13 BaseType int64
         - Name: cacheZone
           Offset: 96
-          Type: 168 PointerType *time.zone
+          Type: 157 PointerType *time.zone
     - __kind: StructureType
-      ID: 137
+      ID: 125
       Name: time.Time
       ByteSize: 24
       GoRuntimeType: 2.215168e+06
@@ -2262,9 +2176,9 @@ Types:
           Type: 13 BaseType int64
         - Name: loc
           Offset: 16
-          Type: 138 PointerType *time.Location
+          Type: 126 PointerType *time.Location
     - __kind: StructureType
-      ID: 169
+      ID: 158
       Name: time.zone
       ByteSize: 32
       GoRuntimeType: 1.421024e+06
@@ -2280,7 +2194,7 @@ Types:
           Offset: 24
           Type: 4 BaseType bool
     - __kind: StructureType
-      ID: 172
+      ID: 161
       Name: time.zoneTrans
       ByteSize: 16
       GoRuntimeType: 1.623328e+06
@@ -2340,6 +2254,6 @@ Types:
       ByteSize: 8
       GoRuntimeType: 534656
       GoKind: 26
-MaxTypeID: 204
+MaxTypeID: 196
 Issues: []
 GoModuledataInfo: {FirstModuledataAddr: "0x1776bc0", TypesOffset: 296}

--- a/pkg/dyninst/irgen/testdata/snapshot/rc_tester_v1.arch=amd64,toolchain=go1.23.11.yaml
+++ b/pkg/dyninst/irgen/testdata/snapshot/rc_tester_v1.arch=amd64,toolchain=go1.23.11.yaml
@@ -121,121 +121,121 @@ Subprograms:
           IsReturn: false
 Types:
     - __kind: PointerType
-      ID: 90
+      ID: 92
       Name: '**crypto/x509.Certificate'
       ByteSize: 8
-      Pointee: 91 PointerType *crypto/x509.Certificate
+      Pointee: 93 PointerType *crypto/x509.Certificate
     - __kind: PointerType
-      ID: 105
+      ID: 113
       Name: '**mime/multipart.FileHeader'
       ByteSize: 8
       GoKind: 22
-      Pointee: 106 PointerType *mime/multipart.FileHeader
+      Pointee: 114 PointerType *mime/multipart.FileHeader
     - __kind: PointerType
-      ID: 137
+      ID: 156
       Name: '**net.IPNet'
       ByteSize: 8
       GoKind: 22
-      Pointee: 138 PointerType *net.IPNet
+      Pointee: 157 PointerType *net.IPNet
     - __kind: PointerType
-      ID: 135
+      ID: 154
       Name: '**net/url.URL'
       ByteSize: 8
       GoKind: 22
       Pointee: 44 PointerType *net/url.URL
     - __kind: PointerType
-      ID: 102
+      ID: 110
       Name: '**runtime.bmap'
       ByteSize: 8
-      Pointee: 81 PointerType *runtime.bmap
+      Pointee: 83 PointerType *runtime.bmap
     - __kind: PointerType
-      ID: 93
+      ID: 95
       Name: '*[]*crypto/x509.Certificate'
       ByteSize: 8
       GoKind: 22
-      Pointee: 89 GoSliceHeaderType []*crypto/x509.Certificate
+      Pointee: 91 GoSliceHeaderType []*crypto/x509.Certificate
     - __kind: PointerType
-      ID: 166
+      ID: 120
       Name: '*[]*crypto/x509.Certificate.array'
       ByteSize: 8
-      Pointee: 165 GoSliceDataType []*crypto/x509.Certificate.array
+      Pointee: 119 GoSliceDataType []*crypto/x509.Certificate.array
     - __kind: PointerType
-      ID: 174
+      ID: 162
       Name: '*[]*mime/multipart.FileHeader.array'
       ByteSize: 8
-      Pointee: 173 GoSliceDataType []*mime/multipart.FileHeader.array
+      Pointee: 161 GoSliceDataType []*mime/multipart.FileHeader.array
     - __kind: PointerType
-      ID: 192
+      ID: 191
       Name: '*[]*net.IPNet.array'
       ByteSize: 8
-      Pointee: 191 GoSliceDataType []*net.IPNet.array
+      Pointee: 190 GoSliceDataType []*net.IPNet.array
     - __kind: PointerType
-      ID: 190
+      ID: 189
       Name: '*[]*net/url.URL.array'
       ByteSize: 8
-      Pointee: 189 GoSliceDataType []*net/url.URL.array
+      Pointee: 188 GoSliceDataType []*net/url.URL.array
     - __kind: PointerType
-      ID: 79
+      ID: 81
       Name: '*[]*runtime.bmap'
       ByteSize: 8
       GoRuntimeType: 466432
       GoKind: 22
-      Pointee: 80 GoSliceHeaderType []*runtime.bmap
+      Pointee: 82 GoSliceHeaderType []*runtime.bmap
     - __kind: PointerType
-      ID: 163
+      ID: 117
       Name: '*[]*runtime.bmap.array'
       ByteSize: 8
-      Pointee: 162 GoSliceDataType []*runtime.bmap.array
+      Pointee: 116 GoSliceDataType []*runtime.bmap.array
     - __kind: PointerType
-      ID: 168
+      ID: 122
       Name: '*[][]*crypto/x509.Certificate.array'
       ByteSize: 8
-      Pointee: 167 GoSliceDataType [][]*crypto/x509.Certificate.array
+      Pointee: 121 GoSliceDataType [][]*crypto/x509.Certificate.array
     - __kind: PointerType
-      ID: 170
+      ID: 124
       Name: '*[][]uint8.array'
       ByteSize: 8
-      Pointee: 169 GoSliceDataType [][]uint8.array
+      Pointee: 123 GoSliceDataType [][]uint8.array
     - __kind: PointerType
-      ID: 184
+      ID: 183
       Name: '*[]crypto/x509.ExtKeyUsage.array'
       ByteSize: 8
-      Pointee: 183 GoSliceDataType []crypto/x509.ExtKeyUsage.array
+      Pointee: 182 GoSliceDataType []crypto/x509.ExtKeyUsage.array
     - __kind: PointerType
-      ID: 194
+      ID: 193
       Name: '*[]crypto/x509.OID.array'
       ByteSize: 8
-      Pointee: 193 GoSliceDataType []crypto/x509.OID.array
+      Pointee: 192 GoSliceDataType []crypto/x509.OID.array
     - __kind: PointerType
-      ID: 176
+      ID: 175
       Name: '*[]crypto/x509/pkix.AttributeTypeAndValue.array'
       ByteSize: 8
-      Pointee: 175 GoSliceDataType []crypto/x509/pkix.AttributeTypeAndValue.array
+      Pointee: 174 GoSliceDataType []crypto/x509/pkix.AttributeTypeAndValue.array
     - __kind: PointerType
-      ID: 178
+      ID: 177
       Name: '*[]crypto/x509/pkix.Extension.array'
       ByteSize: 8
-      Pointee: 177 GoSliceDataType []crypto/x509/pkix.Extension.array
+      Pointee: 176 GoSliceDataType []crypto/x509/pkix.Extension.array
     - __kind: PointerType
-      ID: 180
+      ID: 179
       Name: '*[]encoding/asn1.ObjectIdentifier.array'
       ByteSize: 8
-      Pointee: 179 GoSliceDataType []encoding/asn1.ObjectIdentifier.array
+      Pointee: 178 GoSliceDataType []encoding/asn1.ObjectIdentifier.array
     - __kind: PointerType
-      ID: 186
+      ID: 185
       Name: '*[]net.IP.array'
       ByteSize: 8
-      Pointee: 185 GoSliceDataType []net.IP.array
+      Pointee: 184 GoSliceDataType []net.IP.array
     - __kind: PointerType
-      ID: 172
+      ID: 126
       Name: '*[]net/http.segment.array'
       ByteSize: 8
-      Pointee: 171 GoSliceDataType []net/http.segment.array
+      Pointee: 125 GoSliceDataType []net/http.segment.array
     - __kind: PointerType
-      ID: 158
+      ID: 106
       Name: '*[]string.array'
       ByteSize: 8
-      Pointee: 157 GoSliceDataType []string.array
+      Pointee: 105 GoSliceDataType []string.array
     - __kind: PointerType
       ID: 198
       Name: '*[]time.zone.array'
@@ -247,17 +247,17 @@ Types:
       ByteSize: 8
       Pointee: 199 GoSliceDataType []time.zoneTrans.array
     - __kind: PointerType
-      ID: 95
+      ID: 97
       Name: '*[]uint8'
       ByteSize: 8
       GoRuntimeType: 452512
       GoKind: 22
       Pointee: 72 GoSliceHeaderType []uint8
     - __kind: PointerType
-      ID: 161
+      ID: 109
       Name: '*[]uint8.array'
       ByteSize: 8
-      Pointee: 160 GoSliceDataType []uint8.array
+      Pointee: 108 GoSliceDataType []uint8.array
     - __kind: PointerType
       ID: 5
       Name: '*bool'
@@ -266,10 +266,10 @@ Types:
       GoKind: 22
       Pointee: 4 BaseType bool
     - __kind: PointerType
-      ID: 87
+      ID: 89
       Name: '*bucket<string,[]*mime/multipart.FileHeader>'
       ByteSize: 8
-      Pointee: 88 GoHMapBucketType bucket<string,[]*mime/multipart.FileHeader>
+      Pointee: 90 GoHMapBucketType bucket<string,[]*mime/multipart.FileHeader>
     - __kind: PointerType
       ID: 49
       Name: '*bucket<string,[]string>'
@@ -295,52 +295,52 @@ Types:
       GoKind: 22
       Pointee: 60 StructureType crypto/tls.ConnectionState
     - __kind: PointerType
-      ID: 91
+      ID: 93
       Name: '*crypto/x509.Certificate'
       ByteSize: 8
       GoRuntimeType: 1.90528e+06
       GoKind: 22
-      Pointee: 107 StructureType crypto/x509.Certificate
+      Pointee: 115 StructureType crypto/x509.Certificate
     - __kind: PointerType
-      ID: 129
+      ID: 148
       Name: '*crypto/x509.ExtKeyUsage'
       ByteSize: 8
       GoRuntimeType: 395040
       GoKind: 22
-      Pointee: 130 BaseType crypto/x509.ExtKeyUsage
+      Pointee: 149 BaseType crypto/x509.ExtKeyUsage
     - __kind: PointerType
-      ID: 140
+      ID: 159
       Name: '*crypto/x509.OID'
       ByteSize: 8
       GoRuntimeType: 1.717248e+06
       GoKind: 22
-      Pointee: 141 StructureType crypto/x509.OID
+      Pointee: 160 StructureType crypto/x509.OID
     - __kind: PointerType
-      ID: 116
+      ID: 135
       Name: '*crypto/x509/pkix.AttributeTypeAndValue'
       ByteSize: 8
       GoRuntimeType: 408800
       GoKind: 22
-      Pointee: 117 StructureType crypto/x509/pkix.AttributeTypeAndValue
+      Pointee: 136 StructureType crypto/x509/pkix.AttributeTypeAndValue
     - __kind: PointerType
-      ID: 123
+      ID: 142
       Name: '*crypto/x509/pkix.Extension'
       ByteSize: 8
       GoRuntimeType: 408992
       GoKind: 22
-      Pointee: 124 StructureType crypto/x509/pkix.Extension
+      Pointee: 143 StructureType crypto/x509/pkix.Extension
     - __kind: PointerType
-      ID: 126
+      ID: 145
       Name: '*encoding/asn1.ObjectIdentifier'
       ByteSize: 8
       GoRuntimeType: 1.009728e+06
       GoKind: 22
-      Pointee: 127 GoSliceHeaderType encoding/asn1.ObjectIdentifier
+      Pointee: 146 GoSliceHeaderType encoding/asn1.ObjectIdentifier
     - __kind: PointerType
-      ID: 182
+      ID: 181
       Name: '*encoding/asn1.ObjectIdentifier.array'
       ByteSize: 8
-      Pointee: 181 GoSliceDataType encoding/asn1.ObjectIdentifier.array
+      Pointee: 180 GoSliceDataType encoding/asn1.ObjectIdentifier.array
     - __kind: PointerType
       ID: 33
       Name: '*error'
@@ -363,10 +363,10 @@ Types:
       GoKind: 22
       Pointee: 17 BaseType float64
     - __kind: PointerType
-      ID: 85
+      ID: 87
       Name: '*hash<string,[]*mime/multipart.FileHeader>'
       ByteSize: 8
-      Pointee: 86 GoHMapHeaderType hash<string,[]*mime/multipart.FileHeader>
+      Pointee: 88 GoHMapHeaderType hash<string,[]*mime/multipart.FileHeader>
     - __kind: PointerType
       ID: 47
       Name: '*hash<string,[]string>'
@@ -413,31 +413,31 @@ Types:
       GoKind: 22
       Pointee: 14 BaseType int8
     - __kind: PointerType
-      ID: 112
+      ID: 131
       Name: '*math/big.Int'
       ByteSize: 8
       GoRuntimeType: 2.231104e+06
       GoKind: 22
-      Pointee: 113 StructureType math/big.Int
+      Pointee: 132 StructureType math/big.Int
     - __kind: PointerType
-      ID: 144
+      ID: 165
       Name: '*math/big.Word'
       ByteSize: 8
       GoRuntimeType: 397856
       GoKind: 22
-      Pointee: 145 BaseType math/big.Word
+      Pointee: 166 BaseType math/big.Word
     - __kind: PointerType
       ID: 196
       Name: '*math/big.nat.array'
       ByteSize: 8
       Pointee: 195 GoSliceDataType math/big.nat.array
     - __kind: PointerType
-      ID: 106
+      ID: 114
       Name: '*mime/multipart.FileHeader'
       ByteSize: 8
       GoRuntimeType: 837376
       GoKind: 22
-      Pointee: 108 StructureType mime/multipart.FileHeader
+      Pointee: 127 StructureType mime/multipart.FileHeader
     - __kind: PointerType
       ID: 57
       Name: '*mime/multipart.Form'
@@ -446,29 +446,29 @@ Types:
       GoKind: 22
       Pointee: 58 StructureType mime/multipart.Form
     - __kind: PointerType
-      ID: 132
+      ID: 151
       Name: '*net.IP'
       ByteSize: 8
       GoRuntimeType: 1.974144e+06
       GoKind: 22
-      Pointee: 133 GoSliceHeaderType net.IP
+      Pointee: 152 GoSliceHeaderType net.IP
     - __kind: PointerType
-      ID: 188
+      ID: 187
       Name: '*net.IP.array'
       ByteSize: 8
-      Pointee: 187 GoSliceDataType net.IP.array
+      Pointee: 186 GoSliceDataType net.IP.array
     - __kind: PointerType
       ID: 202
       Name: '*net.IPMask.array'
       ByteSize: 8
       Pointee: 201 GoSliceDataType net.IPMask.array
     - __kind: PointerType
-      ID: 138
+      ID: 157
       Name: '*net.IPNet'
       ByteSize: 8
       GoRuntimeType: 1.095776e+06
       GoKind: 22
-      Pointee: 152 StructureType net.IPNet
+      Pointee: 173 StructureType net.IPNet
     - __kind: PointerType
       ID: 37
       Name: '*net/http.Request'
@@ -491,12 +491,12 @@ Types:
       GoKind: 22
       Pointee: 66 StructureType net/http.pattern
     - __kind: PointerType
-      ID: 99
+      ID: 101
       Name: '*net/http.segment'
       ByteSize: 8
       GoRuntimeType: 364000
       GoKind: 22
-      Pointee: 100 StructureType net/http.segment
+      Pointee: 102 StructureType net/http.segment
     - __kind: PointerType
       ID: 44
       Name: '*net/url.URL'
@@ -505,19 +505,19 @@ Types:
       GoKind: 22
       Pointee: 45 StructureType net/url.URL
     - __kind: PointerType
-      ID: 74
+      ID: 76
       Name: '*net/url.Userinfo'
       ByteSize: 8
       GoRuntimeType: 1.114208e+06
       GoKind: 22
-      Pointee: 75 StructureType net/url.Userinfo
+      Pointee: 77 StructureType net/url.Userinfo
     - __kind: PointerType
-      ID: 81
+      ID: 83
       Name: '*runtime.bmap'
       ByteSize: 8
       GoRuntimeType: 1.109856e+06
       GoKind: 22
-      Pointee: 82 StructureType runtime.bmap
+      Pointee: 84 StructureType runtime.bmap
     - __kind: PointerType
       ID: 51
       Name: '*runtime.mapextra'
@@ -533,31 +533,31 @@ Types:
       GoKind: 22
       Pointee: 11 GoStringHeaderType string
     - __kind: PointerType
-      ID: 155
+      ID: 75
       Name: '*string.str'
       ByteSize: 8
-      Pointee: 154 GoStringDataType string.str
+      Pointee: 74 GoStringDataType string.str
     - __kind: PointerType
-      ID: 119
+      ID: 138
       Name: '*time.Location'
       ByteSize: 8
       GoRuntimeType: 1.421216e+06
       GoKind: 22
-      Pointee: 120 StructureType time.Location
+      Pointee: 139 StructureType time.Location
     - __kind: PointerType
-      ID: 147
+      ID: 168
       Name: '*time.zone'
       ByteSize: 8
       GoRuntimeType: 367072
       GoKind: 22
-      Pointee: 148 StructureType time.zone
+      Pointee: 169 StructureType time.zone
     - __kind: PointerType
-      ID: 150
+      ID: 171
       Name: '*time.zoneTrans'
       ByteSize: 8
       GoRuntimeType: 367136
       GoKind: 22
-      Pointee: 151 StructureType time.zoneTrans
+      Pointee: 172 StructureType time.zoneTrans
     - __kind: PointerType
       ID: 34
       Name: '*uint'
@@ -645,7 +645,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: ArrayType
-      ID: 76
+      ID: 78
       Name: '[8]uint8'
       ByteSize: 8
       GoRuntimeType: 621728
@@ -654,7 +654,7 @@ Types:
       HasCount: true
       Element: 3 BaseType uint8
     - __kind: GoSliceHeaderType
-      ID: 89
+      ID: 91
       Name: '[]*crypto/x509.Certificate'
       ByteSize: 24
       GoRuntimeType: 469536
@@ -662,21 +662,21 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 90 PointerType **crypto/x509.Certificate
+          Type: 92 PointerType **crypto/x509.Certificate
         - Name: len
           Offset: 8
           Type: 9 BaseType int
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 165 GoSliceDataType []*crypto/x509.Certificate.array
+      Data: 119 GoSliceDataType []*crypto/x509.Certificate.array
     - __kind: GoSliceDataType
-      ID: 165
+      ID: 119
       Name: '[]*crypto/x509.Certificate.array'
       ByteSize: 2048
-      Element: 91 PointerType *crypto/x509.Certificate
+      Element: 93 PointerType *crypto/x509.Certificate
     - __kind: GoSliceHeaderType
-      ID: 104
+      ID: 112
       Name: '[]*mime/multipart.FileHeader'
       ByteSize: 24
       GoRuntimeType: 457376
@@ -684,21 +684,21 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 105 PointerType **mime/multipart.FileHeader
+          Type: 113 PointerType **mime/multipart.FileHeader
         - Name: len
           Offset: 8
           Type: 9 BaseType int
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 173 GoSliceDataType []*mime/multipart.FileHeader.array
+      Data: 161 GoSliceDataType []*mime/multipart.FileHeader.array
     - __kind: GoSliceDataType
-      ID: 173
+      ID: 161
       Name: '[]*mime/multipart.FileHeader.array'
       ByteSize: 2048
-      Element: 106 PointerType *mime/multipart.FileHeader
+      Element: 114 PointerType *mime/multipart.FileHeader
     - __kind: GoSliceHeaderType
-      ID: 136
+      ID: 155
       Name: '[]*net.IPNet'
       ByteSize: 24
       GoRuntimeType: 481568
@@ -706,21 +706,21 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 137 PointerType **net.IPNet
+          Type: 156 PointerType **net.IPNet
         - Name: len
           Offset: 8
           Type: 9 BaseType int
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 191 GoSliceDataType []*net.IPNet.array
+      Data: 190 GoSliceDataType []*net.IPNet.array
     - __kind: GoSliceDataType
-      ID: 191
+      ID: 190
       Name: '[]*net.IPNet.array'
       ByteSize: 2048
-      Element: 138 PointerType *net.IPNet
+      Element: 157 PointerType *net.IPNet
     - __kind: GoSliceHeaderType
-      ID: 134
+      ID: 153
       Name: '[]*net/url.URL'
       ByteSize: 24
       GoRuntimeType: 481504
@@ -728,21 +728,21 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 135 PointerType **net/url.URL
+          Type: 154 PointerType **net/url.URL
         - Name: len
           Offset: 8
           Type: 9 BaseType int
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 189 GoSliceDataType []*net/url.URL.array
+      Data: 188 GoSliceDataType []*net/url.URL.array
     - __kind: GoSliceDataType
-      ID: 189
+      ID: 188
       Name: '[]*net/url.URL.array'
       ByteSize: 2048
       Element: 44 PointerType *net/url.URL
     - __kind: GoSliceHeaderType
-      ID: 80
+      ID: 82
       Name: '[]*runtime.bmap'
       ByteSize: 24
       GoRuntimeType: 466368
@@ -750,21 +750,21 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 102 PointerType **runtime.bmap
+          Type: 110 PointerType **runtime.bmap
         - Name: len
           Offset: 8
           Type: 9 BaseType int
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 162 GoSliceDataType []*runtime.bmap.array
+      Data: 116 GoSliceDataType []*runtime.bmap.array
     - __kind: GoSliceDataType
-      ID: 162
+      ID: 116
       Name: '[]*runtime.bmap.array'
       ByteSize: 2048
-      Element: 81 PointerType *runtime.bmap
+      Element: 83 PointerType *runtime.bmap
     - __kind: GoSliceHeaderType
-      ID: 92
+      ID: 94
       Name: '[][]*crypto/x509.Certificate'
       ByteSize: 24
       GoRuntimeType: 469664
@@ -772,21 +772,21 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 93 PointerType *[]*crypto/x509.Certificate
+          Type: 95 PointerType *[]*crypto/x509.Certificate
         - Name: len
           Offset: 8
           Type: 9 BaseType int
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 167 GoSliceDataType [][]*crypto/x509.Certificate.array
+      Data: 121 GoSliceDataType [][]*crypto/x509.Certificate.array
     - __kind: GoSliceDataType
-      ID: 167
+      ID: 121
       Name: '[][]*crypto/x509.Certificate.array'
       ByteSize: 2048
-      Element: 89 GoSliceHeaderType []*crypto/x509.Certificate
+      Element: 91 GoSliceHeaderType []*crypto/x509.Certificate
     - __kind: GoSliceHeaderType
-      ID: 94
+      ID: 96
       Name: '[][]uint8'
       ByteSize: 24
       GoRuntimeType: 452832
@@ -794,36 +794,36 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 95 PointerType *[]uint8
+          Type: 97 PointerType *[]uint8
         - Name: len
           Offset: 8
           Type: 9 BaseType int
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 169 GoSliceDataType [][]uint8.array
+      Data: 123 GoSliceDataType [][]uint8.array
     - __kind: GoSliceDataType
-      ID: 169
+      ID: 123
       Name: '[][]uint8.array'
       ByteSize: 2048
       Element: 72 GoSliceHeaderType []uint8
     - __kind: GoSliceDataType
-      ID: 164
+      ID: 118
       Name: '[]bucket<string,[]*mime/multipart.FileHeader>.array'
       ByteSize: 2048
-      Element: 88 GoHMapBucketType bucket<string,[]*mime/multipart.FileHeader>
+      Element: 90 GoHMapBucketType bucket<string,[]*mime/multipart.FileHeader>
     - __kind: GoSliceDataType
-      ID: 156
+      ID: 104
       Name: '[]bucket<string,[]string>.array'
       ByteSize: 2048
       Element: 50 GoHMapBucketType bucket<string,[]string>
     - __kind: GoSliceDataType
-      ID: 159
+      ID: 107
       Name: '[]bucket<string,string>.array'
       ByteSize: 2048
       Element: 71 GoHMapBucketType bucket<string,string>
     - __kind: GoSliceHeaderType
-      ID: 128
+      ID: 147
       Name: '[]crypto/x509.ExtKeyUsage'
       ByteSize: 24
       GoRuntimeType: 470816
@@ -831,21 +831,21 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 129 PointerType *crypto/x509.ExtKeyUsage
+          Type: 148 PointerType *crypto/x509.ExtKeyUsage
         - Name: len
           Offset: 8
           Type: 9 BaseType int
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 183 GoSliceDataType []crypto/x509.ExtKeyUsage.array
+      Data: 182 GoSliceDataType []crypto/x509.ExtKeyUsage.array
     - __kind: GoSliceDataType
-      ID: 183
+      ID: 182
       Name: '[]crypto/x509.ExtKeyUsage.array'
       ByteSize: 2048
-      Element: 130 BaseType crypto/x509.ExtKeyUsage
+      Element: 149 BaseType crypto/x509.ExtKeyUsage
     - __kind: GoSliceHeaderType
-      ID: 139
+      ID: 158
       Name: '[]crypto/x509.OID'
       ByteSize: 24
       GoRuntimeType: 481632
@@ -853,21 +853,21 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 140 PointerType *crypto/x509.OID
+          Type: 159 PointerType *crypto/x509.OID
         - Name: len
           Offset: 8
           Type: 9 BaseType int
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 193 GoSliceDataType []crypto/x509.OID.array
+      Data: 192 GoSliceDataType []crypto/x509.OID.array
     - __kind: GoSliceDataType
-      ID: 193
+      ID: 192
       Name: '[]crypto/x509.OID.array'
       ByteSize: 2048
-      Element: 141 StructureType crypto/x509.OID
+      Element: 160 StructureType crypto/x509.OID
     - __kind: GoSliceHeaderType
-      ID: 115
+      ID: 134
       Name: '[]crypto/x509/pkix.AttributeTypeAndValue'
       ByteSize: 24
       GoRuntimeType: 481888
@@ -875,21 +875,21 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 116 PointerType *crypto/x509/pkix.AttributeTypeAndValue
+          Type: 135 PointerType *crypto/x509/pkix.AttributeTypeAndValue
         - Name: len
           Offset: 8
           Type: 9 BaseType int
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 175 GoSliceDataType []crypto/x509/pkix.AttributeTypeAndValue.array
+      Data: 174 GoSliceDataType []crypto/x509/pkix.AttributeTypeAndValue.array
     - __kind: GoSliceDataType
-      ID: 175
+      ID: 174
       Name: '[]crypto/x509/pkix.AttributeTypeAndValue.array'
       ByteSize: 2048
-      Element: 117 StructureType crypto/x509/pkix.AttributeTypeAndValue
+      Element: 136 StructureType crypto/x509/pkix.AttributeTypeAndValue
     - __kind: GoSliceHeaderType
-      ID: 122
+      ID: 141
       Name: '[]crypto/x509/pkix.Extension'
       ByteSize: 24
       GoRuntimeType: 481376
@@ -897,21 +897,21 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 123 PointerType *crypto/x509/pkix.Extension
+          Type: 142 PointerType *crypto/x509/pkix.Extension
         - Name: len
           Offset: 8
           Type: 9 BaseType int
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 177 GoSliceDataType []crypto/x509/pkix.Extension.array
+      Data: 176 GoSliceDataType []crypto/x509/pkix.Extension.array
     - __kind: GoSliceDataType
-      ID: 177
+      ID: 176
       Name: '[]crypto/x509/pkix.Extension.array'
       ByteSize: 2048
-      Element: 124 StructureType crypto/x509/pkix.Extension
+      Element: 143 StructureType crypto/x509/pkix.Extension
     - __kind: GoSliceHeaderType
-      ID: 125
+      ID: 144
       Name: '[]encoding/asn1.ObjectIdentifier'
       ByteSize: 24
       GoRuntimeType: 481440
@@ -919,28 +919,28 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 126 PointerType *encoding/asn1.ObjectIdentifier
+          Type: 145 PointerType *encoding/asn1.ObjectIdentifier
         - Name: len
           Offset: 8
           Type: 9 BaseType int
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 179 GoSliceDataType []encoding/asn1.ObjectIdentifier.array
+      Data: 178 GoSliceDataType []encoding/asn1.ObjectIdentifier.array
     - __kind: GoSliceDataType
-      ID: 179
+      ID: 178
       Name: '[]encoding/asn1.ObjectIdentifier.array'
       ByteSize: 2048
-      Element: 127 GoSliceHeaderType encoding/asn1.ObjectIdentifier
+      Element: 146 GoSliceHeaderType encoding/asn1.ObjectIdentifier
     - __kind: ArrayType
-      ID: 77
+      ID: 79
       Name: '[]key<string>'
       ByteSize: 128
       Count: 8
       HasCount: true
       Element: 11 GoStringHeaderType string
     - __kind: GoSliceHeaderType
-      ID: 131
+      ID: 150
       Name: '[]net.IP'
       ByteSize: 24
       GoRuntimeType: 454048
@@ -948,21 +948,21 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 132 PointerType *net.IP
+          Type: 151 PointerType *net.IP
         - Name: len
           Offset: 8
           Type: 9 BaseType int
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 185 GoSliceDataType []net.IP.array
+      Data: 184 GoSliceDataType []net.IP.array
     - __kind: GoSliceDataType
-      ID: 185
+      ID: 184
       Name: '[]net.IP.array'
       ByteSize: 2048
-      Element: 133 GoSliceHeaderType net.IP
+      Element: 152 GoSliceHeaderType net.IP
     - __kind: GoSliceHeaderType
-      ID: 98
+      ID: 100
       Name: '[]net/http.segment'
       ByteSize: 24
       GoRuntimeType: 454816
@@ -970,19 +970,19 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 99 PointerType *net/http.segment
+          Type: 101 PointerType *net/http.segment
         - Name: len
           Offset: 8
           Type: 9 BaseType int
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 171 GoSliceDataType []net/http.segment.array
+      Data: 125 GoSliceDataType []net/http.segment.array
     - __kind: GoSliceDataType
-      ID: 171
+      ID: 125
       Name: '[]net/http.segment.array'
       ByteSize: 2048
-      Element: 100 StructureType net/http.segment
+      Element: 102 StructureType net/http.segment
     - __kind: GoSliceHeaderType
       ID: 55
       Name: '[]string'
@@ -999,14 +999,14 @@ Types:
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 157 GoSliceDataType []string.array
+      Data: 105 GoSliceDataType []string.array
     - __kind: GoSliceDataType
-      ID: 157
+      ID: 105
       Name: '[]string.array'
       ByteSize: 2048
       Element: 11 GoStringHeaderType string
     - __kind: GoSliceHeaderType
-      ID: 146
+      ID: 167
       Name: '[]time.zone'
       ByteSize: 24
       GoRuntimeType: 459040
@@ -1014,7 +1014,7 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 147 PointerType *time.zone
+          Type: 168 PointerType *time.zone
         - Name: len
           Offset: 8
           Type: 9 BaseType int
@@ -1026,9 +1026,9 @@ Types:
       ID: 197
       Name: '[]time.zone.array'
       ByteSize: 2048
-      Element: 148 StructureType time.zone
+      Element: 169 StructureType time.zone
     - __kind: GoSliceHeaderType
-      ID: 149
+      ID: 170
       Name: '[]time.zoneTrans'
       ByteSize: 24
       GoRuntimeType: 459104
@@ -1036,7 +1036,7 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 150 PointerType *time.zoneTrans
+          Type: 171 PointerType *time.zoneTrans
         - Name: len
           Offset: 8
           Type: 9 BaseType int
@@ -1048,7 +1048,7 @@ Types:
       ID: 199
       Name: '[]time.zoneTrans.array'
       ByteSize: 2048
-      Element: 151 StructureType time.zoneTrans
+      Element: 172 StructureType time.zoneTrans
     - __kind: GoSliceHeaderType
       ID: 72
       Name: '[]uint8'
@@ -1065,28 +1065,28 @@ Types:
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 160 GoSliceDataType []uint8.array
+      Data: 108 GoSliceDataType []uint8.array
     - __kind: GoSliceDataType
-      ID: 160
+      ID: 108
       Name: '[]uint8.array'
       ByteSize: 2048
       Element: 3 BaseType uint8
     - __kind: ArrayType
-      ID: 103
+      ID: 111
       Name: '[]val<[]*mime/multipart.FileHeader>'
       ByteSize: 192
       Count: 8
       HasCount: true
-      Element: 104 GoSliceHeaderType []*mime/multipart.FileHeader
+      Element: 112 GoSliceHeaderType []*mime/multipart.FileHeader
     - __kind: ArrayType
-      ID: 78
+      ID: 80
       Name: '[]val<[]string>'
       ByteSize: 192
       Count: 8
       HasCount: true
       Element: 55 GoSliceHeaderType []string
     - __kind: ArrayType
-      ID: 101
+      ID: 103
       Name: '[]val<string>'
       ByteSize: 128
       Count: 8
@@ -1099,24 +1099,24 @@ Types:
       GoRuntimeType: 534592
       GoKind: 1
     - __kind: GoHMapBucketType
-      ID: 88
+      ID: 90
       Name: bucket<string,[]*mime/multipart.FileHeader>
       ByteSize: 336
       RawFields:
         - Name: tophash
           Offset: 0
-          Type: 76 ArrayType [8]uint8
+          Type: 78 ArrayType [8]uint8
         - Name: keys
           Offset: 8
-          Type: 77 ArrayType []key<string>
+          Type: 79 ArrayType []key<string>
         - Name: values
           Offset: 136
-          Type: 103 ArrayType []val<[]*mime/multipart.FileHeader>
+          Type: 111 ArrayType []val<[]*mime/multipart.FileHeader>
         - Name: overflow
           Offset: 328
-          Type: 87 PointerType *bucket<string,[]*mime/multipart.FileHeader>
+          Type: 89 PointerType *bucket<string,[]*mime/multipart.FileHeader>
       KeyType: 11 GoStringHeaderType string
-      ValueType: 104 GoSliceHeaderType []*mime/multipart.FileHeader
+      ValueType: 112 GoSliceHeaderType []*mime/multipart.FileHeader
     - __kind: GoHMapBucketType
       ID: 50
       Name: bucket<string,[]string>
@@ -1124,13 +1124,13 @@ Types:
       RawFields:
         - Name: tophash
           Offset: 0
-          Type: 76 ArrayType [8]uint8
+          Type: 78 ArrayType [8]uint8
         - Name: keys
           Offset: 8
-          Type: 77 ArrayType []key<string>
+          Type: 79 ArrayType []key<string>
         - Name: values
           Offset: 136
-          Type: 78 ArrayType []val<[]string>
+          Type: 80 ArrayType []val<[]string>
         - Name: overflow
           Offset: 328
           Type: 49 PointerType *bucket<string,[]string>
@@ -1143,13 +1143,13 @@ Types:
       RawFields:
         - Name: tophash
           Offset: 0
-          Type: 76 ArrayType [8]uint8
+          Type: 78 ArrayType [8]uint8
         - Name: keys
           Offset: 8
-          Type: 77 ArrayType []key<string>
+          Type: 79 ArrayType []key<string>
         - Name: values
           Offset: 136
-          Type: 101 ArrayType []val<string>
+          Type: 103 ArrayType []val<string>
         - Name: overflow
           Offset: 264
           Type: 70 PointerType *bucket<string,string>
@@ -1247,13 +1247,13 @@ Types:
           Type: 11 GoStringHeaderType string
         - Name: PeerCertificates
           Offset: 48
-          Type: 89 GoSliceHeaderType []*crypto/x509.Certificate
+          Type: 91 GoSliceHeaderType []*crypto/x509.Certificate
         - Name: VerifiedChains
           Offset: 72
-          Type: 92 GoSliceHeaderType [][]*crypto/x509.Certificate
+          Type: 94 GoSliceHeaderType [][]*crypto/x509.Certificate
         - Name: SignedCertificateTimestamps
           Offset: 96
-          Type: 94 GoSliceHeaderType [][]uint8
+          Type: 96 GoSliceHeaderType [][]uint8
         - Name: OCSPResponse
           Offset: 120
           Type: 72 GoSliceHeaderType []uint8
@@ -1265,21 +1265,21 @@ Types:
           Type: 4 BaseType bool
         - Name: ekm
           Offset: 176
-          Type: 96 GoSubroutineType func(string, []uint8, int) ([]uint8, error)
+          Type: 98 GoSubroutineType func(string, []uint8, int) ([]uint8, error)
         - Name: testingOnlyDidHRR
           Offset: 184
           Type: 4 BaseType bool
         - Name: testingOnlyCurveID
           Offset: 186
-          Type: 97 BaseType crypto/tls.CurveID
+          Type: 99 BaseType crypto/tls.CurveID
     - __kind: BaseType
-      ID: 97
+      ID: 99
       Name: crypto/tls.CurveID
       ByteSize: 2
       GoRuntimeType: 766048
       GoKind: 9
     - __kind: StructureType
-      ID: 107
+      ID: 115
       Name: crypto/x509.Certificate
       ByteSize: 1352
       GoRuntimeType: 2.234656e+06
@@ -1305,49 +1305,49 @@ Types:
           Type: 72 GoSliceHeaderType []uint8
         - Name: SignatureAlgorithm
           Offset: 144
-          Type: 109 BaseType crypto/x509.SignatureAlgorithm
+          Type: 128 BaseType crypto/x509.SignatureAlgorithm
         - Name: PublicKeyAlgorithm
           Offset: 152
-          Type: 110 BaseType crypto/x509.PublicKeyAlgorithm
+          Type: 129 BaseType crypto/x509.PublicKeyAlgorithm
         - Name: PublicKey
           Offset: 160
-          Type: 111 GoEmptyInterfaceType interface {}
+          Type: 130 GoEmptyInterfaceType interface {}
         - Name: Version
           Offset: 176
           Type: 9 BaseType int
         - Name: SerialNumber
           Offset: 184
-          Type: 112 PointerType *math/big.Int
+          Type: 131 PointerType *math/big.Int
         - Name: Issuer
           Offset: 192
-          Type: 114 StructureType crypto/x509/pkix.Name
+          Type: 133 StructureType crypto/x509/pkix.Name
         - Name: Subject
           Offset: 440
-          Type: 114 StructureType crypto/x509/pkix.Name
+          Type: 133 StructureType crypto/x509/pkix.Name
         - Name: NotBefore
           Offset: 688
-          Type: 118 StructureType time.Time
+          Type: 137 StructureType time.Time
         - Name: NotAfter
           Offset: 712
-          Type: 118 StructureType time.Time
+          Type: 137 StructureType time.Time
         - Name: KeyUsage
           Offset: 736
-          Type: 121 BaseType crypto/x509.KeyUsage
+          Type: 140 BaseType crypto/x509.KeyUsage
         - Name: Extensions
           Offset: 744
-          Type: 122 GoSliceHeaderType []crypto/x509/pkix.Extension
+          Type: 141 GoSliceHeaderType []crypto/x509/pkix.Extension
         - Name: ExtraExtensions
           Offset: 768
-          Type: 122 GoSliceHeaderType []crypto/x509/pkix.Extension
+          Type: 141 GoSliceHeaderType []crypto/x509/pkix.Extension
         - Name: UnhandledCriticalExtensions
           Offset: 792
-          Type: 125 GoSliceHeaderType []encoding/asn1.ObjectIdentifier
+          Type: 144 GoSliceHeaderType []encoding/asn1.ObjectIdentifier
         - Name: ExtKeyUsage
           Offset: 816
-          Type: 128 GoSliceHeaderType []crypto/x509.ExtKeyUsage
+          Type: 147 GoSliceHeaderType []crypto/x509.ExtKeyUsage
         - Name: UnknownExtKeyUsage
           Offset: 840
-          Type: 125 GoSliceHeaderType []encoding/asn1.ObjectIdentifier
+          Type: 144 GoSliceHeaderType []encoding/asn1.ObjectIdentifier
         - Name: BasicConstraintsValid
           Offset: 864
           Type: 4 BaseType bool
@@ -1380,10 +1380,10 @@ Types:
           Type: 55 GoSliceHeaderType []string
         - Name: IPAddresses
           Offset: 1032
-          Type: 131 GoSliceHeaderType []net.IP
+          Type: 150 GoSliceHeaderType []net.IP
         - Name: URIs
           Offset: 1056
-          Type: 134 GoSliceHeaderType []*net/url.URL
+          Type: 153 GoSliceHeaderType []*net/url.URL
         - Name: PermittedDNSDomainsCritical
           Offset: 1080
           Type: 4 BaseType bool
@@ -1395,10 +1395,10 @@ Types:
           Type: 55 GoSliceHeaderType []string
         - Name: PermittedIPRanges
           Offset: 1136
-          Type: 136 GoSliceHeaderType []*net.IPNet
+          Type: 155 GoSliceHeaderType []*net.IPNet
         - Name: ExcludedIPRanges
           Offset: 1160
-          Type: 136 GoSliceHeaderType []*net.IPNet
+          Type: 155 GoSliceHeaderType []*net.IPNet
         - Name: PermittedEmailAddresses
           Offset: 1184
           Type: 55 GoSliceHeaderType []string
@@ -1416,24 +1416,24 @@ Types:
           Type: 55 GoSliceHeaderType []string
         - Name: PolicyIdentifiers
           Offset: 1304
-          Type: 125 GoSliceHeaderType []encoding/asn1.ObjectIdentifier
+          Type: 144 GoSliceHeaderType []encoding/asn1.ObjectIdentifier
         - Name: Policies
           Offset: 1328
-          Type: 139 GoSliceHeaderType []crypto/x509.OID
+          Type: 158 GoSliceHeaderType []crypto/x509.OID
     - __kind: BaseType
-      ID: 130
+      ID: 149
       Name: crypto/x509.ExtKeyUsage
       ByteSize: 8
       GoRuntimeType: 537280
       GoKind: 2
     - __kind: BaseType
-      ID: 121
+      ID: 140
       Name: crypto/x509.KeyUsage
       ByteSize: 8
       GoRuntimeType: 537216
       GoKind: 2
     - __kind: StructureType
-      ID: 141
+      ID: 160
       Name: crypto/x509.OID
       ByteSize: 24
       GoRuntimeType: 1.717472e+06
@@ -1443,19 +1443,19 @@ Types:
           Offset: 0
           Type: 72 GoSliceHeaderType []uint8
     - __kind: BaseType
-      ID: 110
+      ID: 129
       Name: crypto/x509.PublicKeyAlgorithm
       ByteSize: 8
       GoRuntimeType: 768448
       GoKind: 2
     - __kind: BaseType
-      ID: 109
+      ID: 128
       Name: crypto/x509.SignatureAlgorithm
       ByteSize: 8
       GoRuntimeType: 1.070976e+06
       GoKind: 2
     - __kind: StructureType
-      ID: 117
+      ID: 136
       Name: crypto/x509/pkix.AttributeTypeAndValue
       ByteSize: 40
       GoRuntimeType: 1.316256e+06
@@ -1463,12 +1463,12 @@ Types:
       RawFields:
         - Name: Type
           Offset: 0
-          Type: 127 GoSliceHeaderType encoding/asn1.ObjectIdentifier
+          Type: 146 GoSliceHeaderType encoding/asn1.ObjectIdentifier
         - Name: Value
           Offset: 24
-          Type: 111 GoEmptyInterfaceType interface {}
+          Type: 130 GoEmptyInterfaceType interface {}
     - __kind: StructureType
-      ID: 124
+      ID: 143
       Name: crypto/x509/pkix.Extension
       ByteSize: 56
       GoRuntimeType: 1.455008e+06
@@ -1476,7 +1476,7 @@ Types:
       RawFields:
         - Name: Id
           Offset: 0
-          Type: 127 GoSliceHeaderType encoding/asn1.ObjectIdentifier
+          Type: 146 GoSliceHeaderType encoding/asn1.ObjectIdentifier
         - Name: Critical
           Offset: 24
           Type: 4 BaseType bool
@@ -1484,7 +1484,7 @@ Types:
           Offset: 32
           Type: 72 GoSliceHeaderType []uint8
     - __kind: StructureType
-      ID: 114
+      ID: 133
       Name: crypto/x509/pkix.Name
       ByteSize: 248
       GoRuntimeType: 2.046944e+06
@@ -1519,12 +1519,12 @@ Types:
           Type: 11 GoStringHeaderType string
         - Name: Names
           Offset: 200
-          Type: 115 GoSliceHeaderType []crypto/x509/pkix.AttributeTypeAndValue
+          Type: 134 GoSliceHeaderType []crypto/x509/pkix.AttributeTypeAndValue
         - Name: ExtraNames
           Offset: 224
-          Type: 115 GoSliceHeaderType []crypto/x509/pkix.AttributeTypeAndValue
+          Type: 134 GoSliceHeaderType []crypto/x509/pkix.AttributeTypeAndValue
     - __kind: GoSliceHeaderType
-      ID: 127
+      ID: 146
       Name: encoding/asn1.ObjectIdentifier
       ByteSize: 24
       GoRuntimeType: 1.009856e+06
@@ -1539,9 +1539,9 @@ Types:
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 181 GoSliceDataType encoding/asn1.ObjectIdentifier.array
+      Data: 180 GoSliceDataType encoding/asn1.ObjectIdentifier.array
     - __kind: GoSliceDataType
-      ID: 181
+      ID: 180
       Name: encoding/asn1.ObjectIdentifier.array
       ByteSize: 2048
       Element: 9 BaseType int
@@ -1577,7 +1577,7 @@ Types:
       GoRuntimeType: 634112
       GoKind: 19
     - __kind: GoSubroutineType
-      ID: 96
+      ID: 98
       Name: func(string, []uint8, int) ([]uint8, error)
       ByteSize: 8
       GoRuntimeType: 960256
@@ -1596,7 +1596,7 @@ Types:
           Offset: 8
           Type: 19 VoidPointerType unsafe.Pointer
     - __kind: GoHMapHeaderType
-      ID: 86
+      ID: 88
       Name: hash<string,[]*mime/multipart.FileHeader>
       ByteSize: 48
       RawFields:
@@ -1617,18 +1617,18 @@ Types:
           Type: 2 BaseType uint32
         - Name: buckets
           Offset: 16
-          Type: 87 PointerType *bucket<string,[]*mime/multipart.FileHeader>
+          Type: 89 PointerType *bucket<string,[]*mime/multipart.FileHeader>
         - Name: oldbuckets
           Offset: 24
-          Type: 87 PointerType *bucket<string,[]*mime/multipart.FileHeader>
+          Type: 89 PointerType *bucket<string,[]*mime/multipart.FileHeader>
         - Name: nevacuate
           Offset: 32
           Type: 1 BaseType uintptr
         - Name: extra
           Offset: 40
           Type: 51 PointerType *runtime.mapextra
-      BucketType: 88 GoHMapBucketType bucket<string,[]*mime/multipart.FileHeader>
-      BucketsType: 164 GoSliceDataType []bucket<string,[]*mime/multipart.FileHeader>.array
+      BucketType: 90 GoHMapBucketType bucket<string,[]*mime/multipart.FileHeader>
+      BucketsType: 118 GoSliceDataType []bucket<string,[]*mime/multipart.FileHeader>.array
     - __kind: GoHMapHeaderType
       ID: 48
       Name: hash<string,[]string>
@@ -1662,7 +1662,7 @@ Types:
           Offset: 40
           Type: 51 PointerType *runtime.mapextra
       BucketType: 50 GoHMapBucketType bucket<string,[]string>
-      BucketsType: 156 GoSliceDataType []bucket<string,[]string>.array
+      BucketsType: 104 GoSliceDataType []bucket<string,[]string>.array
     - __kind: GoHMapHeaderType
       ID: 69
       Name: hash<string,string>
@@ -1696,7 +1696,7 @@ Types:
           Offset: 40
           Type: 51 PointerType *runtime.mapextra
       BucketType: 71 GoHMapBucketType bucket<string,string>
-      BucketsType: 159 GoSliceDataType []bucket<string,string>.array
+      BucketsType: 107 GoSliceDataType []bucket<string,string>.array
     - __kind: BaseType
       ID: 9
       Name: int
@@ -1728,7 +1728,7 @@ Types:
       GoRuntimeType: 533632
       GoKind: 3
     - __kind: GoEmptyInterfaceType
-      ID: 111
+      ID: 130
       Name: interface {}
       ByteSize: 16
       GoRuntimeType: 785376
@@ -1754,14 +1754,14 @@ Types:
           Offset: 8
           Type: 19 VoidPointerType unsafe.Pointer
     - __kind: GoMapType
-      ID: 84
+      ID: 86
       Name: map[string][]*mime/multipart.FileHeader
       ByteSize: 8
       GoRuntimeType: 887296
       GoKind: 21
-      HeaderType: 86 GoHMapHeaderType hash<string,[]*mime/multipart.FileHeader>
+      HeaderType: 88 GoHMapHeaderType hash<string,[]*mime/multipart.FileHeader>
     - __kind: GoMapType
-      ID: 83
+      ID: 85
       Name: map[string][]string
       ByteSize: 8
       GoRuntimeType: 882496
@@ -1775,7 +1775,7 @@ Types:
       GoKind: 21
       HeaderType: 69 GoHMapHeaderType hash<string,string>
     - __kind: StructureType
-      ID: 113
+      ID: 132
       Name: math/big.Int
       ByteSize: 32
       GoRuntimeType: 1.308416e+06
@@ -1786,15 +1786,15 @@ Types:
           Type: 4 BaseType bool
         - Name: abs
           Offset: 8
-          Type: 143 GoSliceHeaderType math/big.nat
+          Type: 164 GoSliceHeaderType math/big.nat
     - __kind: BaseType
-      ID: 145
+      ID: 166
       Name: math/big.Word
       ByteSize: 8
       GoRuntimeType: 537536
       GoKind: 7
     - __kind: GoSliceHeaderType
-      ID: 143
+      ID: 164
       Name: math/big.nat
       ByteSize: 24
       GoRuntimeType: 2.21424e+06
@@ -1802,7 +1802,7 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 144 PointerType *math/big.Word
+          Type: 165 PointerType *math/big.Word
         - Name: len
           Offset: 8
           Type: 9 BaseType int
@@ -1814,9 +1814,9 @@ Types:
       ID: 195
       Name: math/big.nat.array
       ByteSize: 2048
-      Element: 145 BaseType math/big.Word
+      Element: 166 BaseType math/big.Word
     - __kind: StructureType
-      ID: 108
+      ID: 127
       Name: mime/multipart.FileHeader
       ByteSize: 88
       GoRuntimeType: 1.838016e+06
@@ -1827,7 +1827,7 @@ Types:
           Type: 11 GoStringHeaderType string
         - Name: Header
           Offset: 16
-          Type: 142 GoMapType net/textproto.MIMEHeader
+          Type: 163 GoMapType net/textproto.MIMEHeader
         - Name: Size
           Offset: 24
           Type: 13 BaseType int64
@@ -1852,12 +1852,12 @@ Types:
       RawFields:
         - Name: Value
           Offset: 0
-          Type: 83 GoMapType map[string][]string
+          Type: 85 GoMapType map[string][]string
         - Name: File
           Offset: 8
-          Type: 84 GoMapType map[string][]*mime/multipart.FileHeader
+          Type: 86 GoMapType map[string][]*mime/multipart.FileHeader
     - __kind: GoSliceHeaderType
-      ID: 133
+      ID: 152
       Name: net.IP
       ByteSize: 24
       GoRuntimeType: 1.94816e+06
@@ -1872,14 +1872,14 @@ Types:
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 187 GoSliceDataType net.IP.array
+      Data: 186 GoSliceDataType net.IP.array
     - __kind: GoSliceDataType
-      ID: 187
+      ID: 186
       Name: net.IP.array
       ByteSize: 2048
       Element: 3 BaseType uint8
     - __kind: GoSliceHeaderType
-      ID: 153
+      ID: 194
       Name: net.IPMask
       ByteSize: 24
       GoRuntimeType: 975808
@@ -1901,7 +1901,7 @@ Types:
       ByteSize: 2048
       Element: 3 BaseType uint8
     - __kind: StructureType
-      ID: 152
+      ID: 173
       Name: net.IPNet
       ByteSize: 48
       GoRuntimeType: 1.275936e+06
@@ -1909,10 +1909,10 @@ Types:
       RawFields:
         - Name: IP
           Offset: 0
-          Type: 133 GoSliceHeaderType net.IP
+          Type: 152 GoSliceHeaderType net.IP
         - Name: Mask
           Offset: 24
-          Type: 153 GoSliceHeaderType net.IPMask
+          Type: 194 GoSliceHeaderType net.IPMask
     - __kind: GoMapType
       ID: 46
       Name: net/http.Header
@@ -2085,12 +2085,12 @@ Types:
           Type: 11 GoStringHeaderType string
         - Name: segments
           Offset: 48
-          Type: 98 GoSliceHeaderType []net/http.segment
+          Type: 100 GoSliceHeaderType []net/http.segment
         - Name: loc
           Offset: 72
           Type: 11 GoStringHeaderType string
     - __kind: StructureType
-      ID: 100
+      ID: 102
       Name: net/http.segment
       ByteSize: 24
       GoRuntimeType: 1.416032e+06
@@ -2106,7 +2106,7 @@ Types:
           Offset: 17
           Type: 4 BaseType bool
     - __kind: GoMapType
-      ID: 142
+      ID: 163
       Name: net/textproto.MIMEHeader
       ByteSize: 8
       GoRuntimeType: 1.595904e+06
@@ -2127,7 +2127,7 @@ Types:
           Type: 11 GoStringHeaderType string
         - Name: User
           Offset: 32
-          Type: 74 PointerType *net/url.Userinfo
+          Type: 76 PointerType *net/url.Userinfo
         - Name: Host
           Offset: 40
           Type: 11 GoStringHeaderType string
@@ -2153,7 +2153,7 @@ Types:
           Offset: 128
           Type: 11 GoStringHeaderType string
     - __kind: StructureType
-      ID: 75
+      ID: 77
       Name: net/url.Userinfo
       ByteSize: 40
       GoRuntimeType: 1.432736e+06
@@ -2176,7 +2176,7 @@ Types:
       GoKind: 21
       HeaderType: 48 GoHMapHeaderType hash<string,[]string>
     - __kind: StructureType
-      ID: 82
+      ID: 84
       Name: runtime.bmap
       ByteSize: 8
       GoRuntimeType: 1.109728e+06
@@ -2184,7 +2184,7 @@ Types:
       RawFields:
         - Name: tophash
           Offset: 0
-          Type: 76 ArrayType [8]uint8
+          Type: 78 ArrayType [8]uint8
     - __kind: StructureType
       ID: 52
       Name: runtime.mapextra
@@ -2194,13 +2194,13 @@ Types:
       RawFields:
         - Name: overflow
           Offset: 0
-          Type: 79 PointerType *[]*runtime.bmap
+          Type: 81 PointerType *[]*runtime.bmap
         - Name: oldoverflow
           Offset: 8
-          Type: 79 PointerType *[]*runtime.bmap
+          Type: 81 PointerType *[]*runtime.bmap
         - Name: nextOverflow
           Offset: 16
-          Type: 81 PointerType *runtime.bmap
+          Type: 83 PointerType *runtime.bmap
     - __kind: GoStringHeaderType
       ID: 11
       Name: string
@@ -2210,17 +2210,17 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 155 PointerType *string.str
+          Type: 75 PointerType *string.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 154 GoStringDataType string.str
+      Data: 74 GoStringDataType string.str
     - __kind: GoStringDataType
-      ID: 154
+      ID: 74
       Name: string.str
       ByteSize: 2048
     - __kind: StructureType
-      ID: 120
+      ID: 139
       Name: time.Location
       ByteSize: 104
       GoRuntimeType: 1.833984e+06
@@ -2231,10 +2231,10 @@ Types:
           Type: 11 GoStringHeaderType string
         - Name: zone
           Offset: 16
-          Type: 146 GoSliceHeaderType []time.zone
+          Type: 167 GoSliceHeaderType []time.zone
         - Name: tx
           Offset: 40
-          Type: 149 GoSliceHeaderType []time.zoneTrans
+          Type: 170 GoSliceHeaderType []time.zoneTrans
         - Name: extend
           Offset: 64
           Type: 11 GoStringHeaderType string
@@ -2246,9 +2246,9 @@ Types:
           Type: 13 BaseType int64
         - Name: cacheZone
           Offset: 96
-          Type: 147 PointerType *time.zone
+          Type: 168 PointerType *time.zone
     - __kind: StructureType
-      ID: 118
+      ID: 137
       Name: time.Time
       ByteSize: 24
       GoRuntimeType: 2.215168e+06
@@ -2262,9 +2262,9 @@ Types:
           Type: 13 BaseType int64
         - Name: loc
           Offset: 16
-          Type: 119 PointerType *time.Location
+          Type: 138 PointerType *time.Location
     - __kind: StructureType
-      ID: 148
+      ID: 169
       Name: time.zone
       ByteSize: 32
       GoRuntimeType: 1.421024e+06
@@ -2280,7 +2280,7 @@ Types:
           Offset: 24
           Type: 4 BaseType bool
     - __kind: StructureType
-      ID: 151
+      ID: 172
       Name: time.zoneTrans
       ByteSize: 16
       GoRuntimeType: 1.623328e+06

--- a/pkg/dyninst/irgen/testdata/snapshot/rc_tester_v1.arch=amd64,toolchain=go1.23.11.yaml
+++ b/pkg/dyninst/irgen/testdata/snapshot/rc_tester_v1.arch=amd64,toolchain=go1.23.11.yaml
@@ -10,7 +10,7 @@ Probes:
       subprogram: {subprogram: 1}
       events:
         - ID: 1
-          Type: 206 EventRootType Probe[main.HandleHTTP]
+          Type: 203 EventRootType Probe[main.HandleHTTP]
           InjectionPoints: [{PC: "0xd289f3", Frameless: false}]
           Condition: null
     - id: look_at_the_request
@@ -23,7 +23,7 @@ Probes:
       subprogram: {subprogram: 2}
       events:
         - ID: 2
-          Type: 207 EventRootType Probe[main.LookAtTheRequest]
+          Type: 204 EventRootType Probe[main.LookAtTheRequest]
           InjectionPoints: [{PC: "0xd28d6e", Frameless: false}]
           Condition: null
 Subprograms:
@@ -385,7 +385,7 @@ Types:
           Offset: 40
           Type: 27 PointerType *runtime.mapextra
       BucketType: 20 GoHMapBucketType bucket<string,[]string>
-      BucketsType: 166 GoSliceDataType []bucket<string,[]string>.array
+      BucketsType: 156 GoSliceDataType []bucket<string,[]string>.array
     - __kind: BaseType
       ID: 17
       Name: uint16
@@ -648,7 +648,7 @@ Types:
           Offset: 40
           Type: 27 PointerType *runtime.mapextra
       BucketType: 45 GoHMapBucketType bucket<string,[]*mime/multipart.FileHeader>
-      BucketsType: 163 GoSliceDataType []bucket<string,[]*mime/multipart.FileHeader>.array
+      BucketsType: 161 GoSliceDataType []bucket<string,[]*mime/multipart.FileHeader>.array
     - __kind: PointerType
       ID: 44
       Name: '*bucket<string,[]*mime/multipart.FileHeader>'
@@ -696,7 +696,7 @@ Types:
         - Name: cap
           Offset: 16
           Type: 8 BaseType int
-      Data: 164 GoSliceDataType []*mime/multipart.FileHeader.array
+      Data: 162 GoSliceDataType []*mime/multipart.FileHeader.array
     - __kind: PointerType
       ID: 48
       Name: '**mime/multipart.FileHeader'
@@ -761,7 +761,7 @@ Types:
         - Name: cap
           Offset: 16
           Type: 8 BaseType int
-      Data: 167 GoSliceDataType []uint8.array
+      Data: 164 GoSliceDataType []uint8.array
     - __kind: PointerType
       ID: 53
       Name: '*crypto/tls.ConnectionState'
@@ -840,7 +840,7 @@ Types:
         - Name: cap
           Offset: 16
           Type: 8 BaseType int
-      Data: 169 GoSliceDataType []*crypto/x509.Certificate.array
+      Data: 166 GoSliceDataType []*crypto/x509.Certificate.array
     - __kind: PointerType
       ID: 56
       Name: '**crypto/x509.Certificate'
@@ -1056,7 +1056,7 @@ Types:
         - Name: cap
           Offset: 16
           Type: 8 BaseType int
-      Data: 171 GoSliceDataType math/big.nat.array
+      Data: 168 GoSliceDataType math/big.nat.array
     - __kind: PointerType
       ID: 65
       Name: '*math/big.Word'
@@ -1126,7 +1126,7 @@ Types:
         - Name: cap
           Offset: 16
           Type: 8 BaseType int
-      Data: 173 GoSliceDataType []crypto/x509/pkix.AttributeTypeAndValue.array
+      Data: 170 GoSliceDataType []crypto/x509/pkix.AttributeTypeAndValue.array
     - __kind: PointerType
       ID: 69
       Name: '*crypto/x509/pkix.AttributeTypeAndValue'
@@ -1163,7 +1163,7 @@ Types:
         - Name: cap
           Offset: 16
           Type: 8 BaseType int
-      Data: 175 GoSliceDataType encoding/asn1.ObjectIdentifier.array
+      Data: 172 GoSliceDataType encoding/asn1.ObjectIdentifier.array
     - __kind: PointerType
       ID: 72
       Name: '*int'
@@ -1244,7 +1244,7 @@ Types:
         - Name: cap
           Offset: 16
           Type: 8 BaseType int
-      Data: 177 GoSliceDataType []time.zone.array
+      Data: 174 GoSliceDataType []time.zone.array
     - __kind: PointerType
       ID: 78
       Name: '*time.zone'
@@ -1284,7 +1284,7 @@ Types:
         - Name: cap
           Offset: 16
           Type: 8 BaseType int
-      Data: 179 GoSliceDataType []time.zoneTrans.array
+      Data: 176 GoSliceDataType []time.zoneTrans.array
     - __kind: PointerType
       ID: 81
       Name: '*time.zoneTrans'
@@ -1333,7 +1333,7 @@ Types:
         - Name: cap
           Offset: 16
           Type: 8 BaseType int
-      Data: 181 GoSliceDataType []crypto/x509/pkix.Extension.array
+      Data: 178 GoSliceDataType []crypto/x509/pkix.Extension.array
     - __kind: PointerType
       ID: 85
       Name: '*crypto/x509/pkix.Extension'
@@ -1373,7 +1373,7 @@ Types:
         - Name: cap
           Offset: 16
           Type: 8 BaseType int
-      Data: 183 GoSliceDataType []encoding/asn1.ObjectIdentifier.array
+      Data: 180 GoSliceDataType []encoding/asn1.ObjectIdentifier.array
     - __kind: PointerType
       ID: 88
       Name: '*encoding/asn1.ObjectIdentifier'
@@ -1397,7 +1397,7 @@ Types:
         - Name: cap
           Offset: 16
           Type: 8 BaseType int
-      Data: 185 GoSliceDataType []crypto/x509.ExtKeyUsage.array
+      Data: 182 GoSliceDataType []crypto/x509.ExtKeyUsage.array
     - __kind: PointerType
       ID: 90
       Name: '*crypto/x509.ExtKeyUsage'
@@ -1427,7 +1427,7 @@ Types:
         - Name: cap
           Offset: 16
           Type: 8 BaseType int
-      Data: 187 GoSliceDataType []net.IP.array
+      Data: 184 GoSliceDataType []net.IP.array
     - __kind: PointerType
       ID: 93
       Name: '*net.IP'
@@ -1451,7 +1451,7 @@ Types:
         - Name: cap
           Offset: 16
           Type: 8 BaseType int
-      Data: 189 GoSliceDataType net.IP.array
+      Data: 186 GoSliceDataType net.IP.array
     - __kind: GoSliceHeaderType
       ID: 95
       Name: '[]*net/url.URL'
@@ -1468,7 +1468,7 @@ Types:
         - Name: cap
           Offset: 16
           Type: 8 BaseType int
-      Data: 191 GoSliceDataType []*net/url.URL.array
+      Data: 188 GoSliceDataType []*net/url.URL.array
     - __kind: PointerType
       ID: 96
       Name: '**net/url.URL'
@@ -1491,7 +1491,7 @@ Types:
         - Name: cap
           Offset: 16
           Type: 8 BaseType int
-      Data: 193 GoSliceDataType []*net.IPNet.array
+      Data: 190 GoSliceDataType []*net.IPNet.array
     - __kind: PointerType
       ID: 98
       Name: '**net.IPNet'
@@ -1534,7 +1534,7 @@ Types:
         - Name: cap
           Offset: 16
           Type: 8 BaseType int
-      Data: 195 GoSliceDataType net.IPMask.array
+      Data: 192 GoSliceDataType net.IPMask.array
     - __kind: GoSliceHeaderType
       ID: 102
       Name: '[]crypto/x509.OID'
@@ -1551,7 +1551,7 @@ Types:
         - Name: cap
           Offset: 16
           Type: 8 BaseType int
-      Data: 197 GoSliceDataType []crypto/x509.OID.array
+      Data: 194 GoSliceDataType []crypto/x509.OID.array
     - __kind: PointerType
       ID: 103
       Name: '*crypto/x509.OID'
@@ -1585,7 +1585,7 @@ Types:
         - Name: cap
           Offset: 16
           Type: 8 BaseType int
-      Data: 199 GoSliceDataType [][]*crypto/x509.Certificate.array
+      Data: 196 GoSliceDataType [][]*crypto/x509.Certificate.array
     - __kind: PointerType
       ID: 106
       Name: '*[]*crypto/x509.Certificate'
@@ -1608,7 +1608,7 @@ Types:
         - Name: cap
           Offset: 16
           Type: 8 BaseType int
-      Data: 201 GoSliceDataType [][]uint8.array
+      Data: 198 GoSliceDataType [][]uint8.array
     - __kind: PointerType
       ID: 108
       Name: '*[]uint8'
@@ -1747,7 +1747,7 @@ Types:
         - Name: cap
           Offset: 16
           Type: 8 BaseType int
-      Data: 203 GoSliceDataType []net/http.segment.array
+      Data: 200 GoSliceDataType []net/http.segment.array
     - __kind: PointerType
       ID: 118
       Name: '*net/http.segment'
@@ -1816,7 +1816,7 @@ Types:
           Offset: 40
           Type: 27 PointerType *runtime.mapextra
       BucketType: 124 GoHMapBucketType bucket<string,string>
-      BucketsType: 205 GoSliceDataType []bucket<string,string>.array
+      BucketsType: 202 GoSliceDataType []bucket<string,string>.array
     - __kind: PointerType
       ID: 123
       Name: '*bucket<string,string>'
@@ -2093,231 +2093,216 @@ Types:
       Pointee: 159 GoSliceDataType []*runtime.bmap.array
     - __kind: GoSliceDataType
       ID: 161
-      Name: '[]bucket<string,[]string>.array'
-      ByteSize: 2048
-      Element: 20 GoHMapBucketType bucket<string,[]string>
-    - __kind: GoSliceDataType
-      ID: 162
-      Name: '[]bucket<string,[]string>.array'
-      ByteSize: 2048
-      Element: 20 GoHMapBucketType bucket<string,[]string>
-    - __kind: GoSliceDataType
-      ID: 163
       Name: '[]bucket<string,[]*mime/multipart.FileHeader>.array'
       ByteSize: 2048
       Element: 45 GoHMapBucketType bucket<string,[]*mime/multipart.FileHeader>
     - __kind: GoSliceDataType
-      ID: 164
+      ID: 162
       Name: '[]*mime/multipart.FileHeader.array'
       ByteSize: 2048
       Element: 49 PointerType *mime/multipart.FileHeader
     - __kind: PointerType
-      ID: 165
+      ID: 163
       Name: '*[]*mime/multipart.FileHeader.array'
       ByteSize: 8
-      Pointee: 164 GoSliceDataType []*mime/multipart.FileHeader.array
+      Pointee: 162 GoSliceDataType []*mime/multipart.FileHeader.array
     - __kind: GoSliceDataType
-      ID: 166
-      Name: '[]bucket<string,[]string>.array'
-      ByteSize: 2048
-      Element: 20 GoHMapBucketType bucket<string,[]string>
-    - __kind: GoSliceDataType
-      ID: 167
+      ID: 164
       Name: '[]uint8.array'
       ByteSize: 2048
       Element: 7 BaseType uint8
     - __kind: PointerType
-      ID: 168
+      ID: 165
       Name: '*[]uint8.array'
       ByteSize: 8
-      Pointee: 167 GoSliceDataType []uint8.array
+      Pointee: 164 GoSliceDataType []uint8.array
     - __kind: GoSliceDataType
-      ID: 169
+      ID: 166
       Name: '[]*crypto/x509.Certificate.array'
       ByteSize: 2048
       Element: 57 PointerType *crypto/x509.Certificate
     - __kind: PointerType
-      ID: 170
+      ID: 167
       Name: '*[]*crypto/x509.Certificate.array'
       ByteSize: 8
-      Pointee: 169 GoSliceDataType []*crypto/x509.Certificate.array
+      Pointee: 166 GoSliceDataType []*crypto/x509.Certificate.array
     - __kind: GoSliceDataType
-      ID: 171
+      ID: 168
       Name: math/big.nat.array
       ByteSize: 2048
       Element: 66 BaseType math/big.Word
     - __kind: PointerType
-      ID: 172
+      ID: 169
       Name: '*math/big.nat.array'
       ByteSize: 8
-      Pointee: 171 GoSliceDataType math/big.nat.array
+      Pointee: 168 GoSliceDataType math/big.nat.array
     - __kind: GoSliceDataType
-      ID: 173
+      ID: 170
       Name: '[]crypto/x509/pkix.AttributeTypeAndValue.array'
       ByteSize: 2048
       Element: 70 StructureType crypto/x509/pkix.AttributeTypeAndValue
     - __kind: PointerType
-      ID: 174
+      ID: 171
       Name: '*[]crypto/x509/pkix.AttributeTypeAndValue.array'
       ByteSize: 8
-      Pointee: 173 GoSliceDataType []crypto/x509/pkix.AttributeTypeAndValue.array
+      Pointee: 170 GoSliceDataType []crypto/x509/pkix.AttributeTypeAndValue.array
     - __kind: GoSliceDataType
-      ID: 175
+      ID: 172
       Name: encoding/asn1.ObjectIdentifier.array
       ByteSize: 2048
       Element: 8 BaseType int
     - __kind: PointerType
-      ID: 176
+      ID: 173
       Name: '*encoding/asn1.ObjectIdentifier.array'
       ByteSize: 8
-      Pointee: 175 GoSliceDataType encoding/asn1.ObjectIdentifier.array
+      Pointee: 172 GoSliceDataType encoding/asn1.ObjectIdentifier.array
     - __kind: GoSliceDataType
-      ID: 177
+      ID: 174
       Name: '[]time.zone.array'
       ByteSize: 2048
       Element: 79 StructureType time.zone
     - __kind: PointerType
-      ID: 178
+      ID: 175
       Name: '*[]time.zone.array'
       ByteSize: 8
-      Pointee: 177 GoSliceDataType []time.zone.array
+      Pointee: 174 GoSliceDataType []time.zone.array
     - __kind: GoSliceDataType
-      ID: 179
+      ID: 176
       Name: '[]time.zoneTrans.array'
       ByteSize: 2048
       Element: 82 StructureType time.zoneTrans
     - __kind: PointerType
-      ID: 180
+      ID: 177
       Name: '*[]time.zoneTrans.array'
       ByteSize: 8
-      Pointee: 179 GoSliceDataType []time.zoneTrans.array
+      Pointee: 176 GoSliceDataType []time.zoneTrans.array
     - __kind: GoSliceDataType
-      ID: 181
+      ID: 178
       Name: '[]crypto/x509/pkix.Extension.array'
       ByteSize: 2048
       Element: 86 StructureType crypto/x509/pkix.Extension
     - __kind: PointerType
-      ID: 182
+      ID: 179
       Name: '*[]crypto/x509/pkix.Extension.array'
       ByteSize: 8
-      Pointee: 181 GoSliceDataType []crypto/x509/pkix.Extension.array
+      Pointee: 178 GoSliceDataType []crypto/x509/pkix.Extension.array
     - __kind: GoSliceDataType
-      ID: 183
+      ID: 180
       Name: '[]encoding/asn1.ObjectIdentifier.array'
       ByteSize: 2048
       Element: 71 GoSliceHeaderType encoding/asn1.ObjectIdentifier
     - __kind: PointerType
-      ID: 184
+      ID: 181
       Name: '*[]encoding/asn1.ObjectIdentifier.array'
       ByteSize: 8
-      Pointee: 183 GoSliceDataType []encoding/asn1.ObjectIdentifier.array
+      Pointee: 180 GoSliceDataType []encoding/asn1.ObjectIdentifier.array
     - __kind: GoSliceDataType
-      ID: 185
+      ID: 182
       Name: '[]crypto/x509.ExtKeyUsage.array'
       ByteSize: 2048
       Element: 91 BaseType crypto/x509.ExtKeyUsage
     - __kind: PointerType
-      ID: 186
+      ID: 183
       Name: '*[]crypto/x509.ExtKeyUsage.array'
       ByteSize: 8
-      Pointee: 185 GoSliceDataType []crypto/x509.ExtKeyUsage.array
+      Pointee: 182 GoSliceDataType []crypto/x509.ExtKeyUsage.array
     - __kind: GoSliceDataType
-      ID: 187
+      ID: 184
       Name: '[]net.IP.array'
       ByteSize: 2048
       Element: 94 GoSliceHeaderType net.IP
     - __kind: PointerType
-      ID: 188
+      ID: 185
       Name: '*[]net.IP.array'
       ByteSize: 8
-      Pointee: 187 GoSliceDataType []net.IP.array
+      Pointee: 184 GoSliceDataType []net.IP.array
     - __kind: GoSliceDataType
-      ID: 189
+      ID: 186
       Name: net.IP.array
       ByteSize: 2048
       Element: 7 BaseType uint8
     - __kind: PointerType
-      ID: 190
+      ID: 187
       Name: '*net.IP.array'
       ByteSize: 8
-      Pointee: 189 GoSliceDataType net.IP.array
+      Pointee: 186 GoSliceDataType net.IP.array
     - __kind: GoSliceDataType
-      ID: 191
+      ID: 188
       Name: '[]*net/url.URL.array'
       ByteSize: 2048
       Element: 9 PointerType *net/url.URL
     - __kind: PointerType
-      ID: 192
+      ID: 189
       Name: '*[]*net/url.URL.array'
       ByteSize: 8
-      Pointee: 191 GoSliceDataType []*net/url.URL.array
+      Pointee: 188 GoSliceDataType []*net/url.URL.array
     - __kind: GoSliceDataType
-      ID: 193
+      ID: 190
       Name: '[]*net.IPNet.array'
       ByteSize: 2048
       Element: 99 PointerType *net.IPNet
     - __kind: PointerType
-      ID: 194
+      ID: 191
       Name: '*[]*net.IPNet.array'
       ByteSize: 8
-      Pointee: 193 GoSliceDataType []*net.IPNet.array
+      Pointee: 190 GoSliceDataType []*net.IPNet.array
     - __kind: GoSliceDataType
-      ID: 195
+      ID: 192
       Name: net.IPMask.array
       ByteSize: 2048
       Element: 7 BaseType uint8
     - __kind: PointerType
-      ID: 196
+      ID: 193
       Name: '*net.IPMask.array'
       ByteSize: 8
-      Pointee: 195 GoSliceDataType net.IPMask.array
+      Pointee: 192 GoSliceDataType net.IPMask.array
     - __kind: GoSliceDataType
-      ID: 197
+      ID: 194
       Name: '[]crypto/x509.OID.array'
       ByteSize: 2048
       Element: 104 StructureType crypto/x509.OID
     - __kind: PointerType
-      ID: 198
+      ID: 195
       Name: '*[]crypto/x509.OID.array'
       ByteSize: 8
-      Pointee: 197 GoSliceDataType []crypto/x509.OID.array
+      Pointee: 194 GoSliceDataType []crypto/x509.OID.array
     - __kind: GoSliceDataType
-      ID: 199
+      ID: 196
       Name: '[][]*crypto/x509.Certificate.array'
       ByteSize: 2048
       Element: 55 GoSliceHeaderType []*crypto/x509.Certificate
     - __kind: PointerType
-      ID: 200
+      ID: 197
       Name: '*[][]*crypto/x509.Certificate.array'
       ByteSize: 8
-      Pointee: 199 GoSliceDataType [][]*crypto/x509.Certificate.array
+      Pointee: 196 GoSliceDataType [][]*crypto/x509.Certificate.array
     - __kind: GoSliceDataType
-      ID: 201
+      ID: 198
       Name: '[][]uint8.array'
       ByteSize: 2048
       Element: 52 GoSliceHeaderType []uint8
     - __kind: PointerType
-      ID: 202
+      ID: 199
       Name: '*[][]uint8.array'
       ByteSize: 8
-      Pointee: 201 GoSliceDataType [][]uint8.array
+      Pointee: 198 GoSliceDataType [][]uint8.array
     - __kind: GoSliceDataType
-      ID: 203
+      ID: 200
       Name: '[]net/http.segment.array'
       ByteSize: 2048
       Element: 119 StructureType net/http.segment
     - __kind: PointerType
-      ID: 204
+      ID: 201
       Name: '*[]net/http.segment.array'
       ByteSize: 8
-      Pointee: 203 GoSliceDataType []net/http.segment.array
+      Pointee: 200 GoSliceDataType []net/http.segment.array
     - __kind: GoSliceDataType
-      ID: 205
+      ID: 202
       Name: '[]bucket<string,string>.array'
       ByteSize: 2048
       Element: 124 GoHMapBucketType bucket<string,string>
     - __kind: EventRootType
-      ID: 206
+      ID: 203
       Name: Probe[main.HandleHTTP]
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -2341,7 +2326,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 207
+      ID: 204
       Name: Probe[main.LookAtTheRequest]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -2355,6 +2340,6 @@ Types:
                   Variable: {subprogram: 2, index: 0, name: path}
                   Offset: 0
                   ByteSize: 16
-MaxTypeID: 207
+MaxTypeID: 204
 Issues: []
 GoModuledataInfo: {FirstModuledataAddr: "0x1776bc0", TypesOffset: 296}

--- a/pkg/dyninst/irgen/testdata/snapshot/rc_tester_v1.arch=amd64,toolchain=go1.23.11.yaml
+++ b/pkg/dyninst/irgen/testdata/snapshot/rc_tester_v1.arch=amd64,toolchain=go1.23.11.yaml
@@ -120,25 +120,355 @@ Subprograms:
           IsParameter: true
           IsReturn: false
 Types:
-    - __kind: GoInterfaceType
-      ID: 1
-      Name: net/http.ResponseWriter
-      ByteSize: 16
-      GoRuntimeType: 1.098336e+06
-      GoKind: 20
-      RawFields:
-        - Name: tab
-          Offset: 0
-          Type: 2 VoidPointerType unsafe.Pointer
-        - Name: data
-          Offset: 8
-          Type: 2 VoidPointerType unsafe.Pointer
-    - __kind: VoidPointerType
-      ID: 2
-      Name: unsafe.Pointer
+    - __kind: PointerType
+      ID: 56
+      Name: '**crypto/x509.Certificate'
       ByteSize: 8
-      GoRuntimeType: 534656
-      GoKind: 26
+      Pointee: 57 PointerType *crypto/x509.Certificate
+    - __kind: PointerType
+      ID: 48
+      Name: '**mime/multipart.FileHeader'
+      ByteSize: 8
+      GoKind: 22
+      Pointee: 49 PointerType *mime/multipart.FileHeader
+    - __kind: PointerType
+      ID: 98
+      Name: '**net.IPNet'
+      ByteSize: 8
+      GoKind: 22
+      Pointee: 99 PointerType *net.IPNet
+    - __kind: PointerType
+      ID: 96
+      Name: '**net/url.URL'
+      ByteSize: 8
+      GoKind: 22
+      Pointee: 9 PointerType *net/url.URL
+    - __kind: PointerType
+      ID: 31
+      Name: '**runtime.bmap'
+      ByteSize: 8
+      Pointee: 32 PointerType *runtime.bmap
+    - __kind: PointerType
+      ID: 106
+      Name: '*[]*crypto/x509.Certificate'
+      ByteSize: 8
+      GoKind: 22
+      Pointee: 55 GoSliceHeaderType []*crypto/x509.Certificate
+    - __kind: PointerType
+      ID: 167
+      Name: '*[]*crypto/x509.Certificate.array'
+      ByteSize: 8
+      Pointee: 166 GoSliceDataType []*crypto/x509.Certificate.array
+    - __kind: PointerType
+      ID: 163
+      Name: '*[]*mime/multipart.FileHeader.array'
+      ByteSize: 8
+      Pointee: 162 GoSliceDataType []*mime/multipart.FileHeader.array
+    - __kind: PointerType
+      ID: 191
+      Name: '*[]*net.IPNet.array'
+      ByteSize: 8
+      Pointee: 190 GoSliceDataType []*net.IPNet.array
+    - __kind: PointerType
+      ID: 189
+      Name: '*[]*net/url.URL.array'
+      ByteSize: 8
+      Pointee: 188 GoSliceDataType []*net/url.URL.array
+    - __kind: PointerType
+      ID: 29
+      Name: '*[]*runtime.bmap'
+      ByteSize: 8
+      GoRuntimeType: 466432
+      GoKind: 22
+      Pointee: 30 GoSliceHeaderType []*runtime.bmap
+    - __kind: PointerType
+      ID: 160
+      Name: '*[]*runtime.bmap.array'
+      ByteSize: 8
+      Pointee: 159 GoSliceDataType []*runtime.bmap.array
+    - __kind: PointerType
+      ID: 197
+      Name: '*[][]*crypto/x509.Certificate.array'
+      ByteSize: 8
+      Pointee: 196 GoSliceDataType [][]*crypto/x509.Certificate.array
+    - __kind: PointerType
+      ID: 199
+      Name: '*[][]uint8.array'
+      ByteSize: 8
+      Pointee: 198 GoSliceDataType [][]uint8.array
+    - __kind: PointerType
+      ID: 183
+      Name: '*[]crypto/x509.ExtKeyUsage.array'
+      ByteSize: 8
+      Pointee: 182 GoSliceDataType []crypto/x509.ExtKeyUsage.array
+    - __kind: PointerType
+      ID: 195
+      Name: '*[]crypto/x509.OID.array'
+      ByteSize: 8
+      Pointee: 194 GoSliceDataType []crypto/x509.OID.array
+    - __kind: PointerType
+      ID: 171
+      Name: '*[]crypto/x509/pkix.AttributeTypeAndValue.array'
+      ByteSize: 8
+      Pointee: 170 GoSliceDataType []crypto/x509/pkix.AttributeTypeAndValue.array
+    - __kind: PointerType
+      ID: 179
+      Name: '*[]crypto/x509/pkix.Extension.array'
+      ByteSize: 8
+      Pointee: 178 GoSliceDataType []crypto/x509/pkix.Extension.array
+    - __kind: PointerType
+      ID: 181
+      Name: '*[]encoding/asn1.ObjectIdentifier.array'
+      ByteSize: 8
+      Pointee: 180 GoSliceDataType []encoding/asn1.ObjectIdentifier.array
+    - __kind: PointerType
+      ID: 185
+      Name: '*[]net.IP.array'
+      ByteSize: 8
+      Pointee: 184 GoSliceDataType []net.IP.array
+    - __kind: PointerType
+      ID: 201
+      Name: '*[]net/http.segment.array'
+      ByteSize: 8
+      Pointee: 200 GoSliceDataType []net/http.segment.array
+    - __kind: PointerType
+      ID: 158
+      Name: '*[]string.array'
+      ByteSize: 8
+      Pointee: 157 GoSliceDataType []string.array
+    - __kind: PointerType
+      ID: 175
+      Name: '*[]time.zone.array'
+      ByteSize: 8
+      Pointee: 174 GoSliceDataType []time.zone.array
+    - __kind: PointerType
+      ID: 177
+      Name: '*[]time.zoneTrans.array'
+      ByteSize: 8
+      Pointee: 176 GoSliceDataType []time.zoneTrans.array
+    - __kind: PointerType
+      ID: 108
+      Name: '*[]uint8'
+      ByteSize: 8
+      GoRuntimeType: 452512
+      GoKind: 22
+      Pointee: 52 GoSliceHeaderType []uint8
+    - __kind: PointerType
+      ID: 165
+      Name: '*[]uint8.array'
+      ByteSize: 8
+      Pointee: 164 GoSliceDataType []uint8.array
+    - __kind: PointerType
+      ID: 132
+      Name: '*bool'
+      ByteSize: 8
+      GoRuntimeType: 372640
+      GoKind: 22
+      Pointee: 13 BaseType bool
+    - __kind: PointerType
+      ID: 44
+      Name: '*bucket<string,[]*mime/multipart.FileHeader>'
+      ByteSize: 8
+      Pointee: 45 GoHMapBucketType bucket<string,[]*mime/multipart.FileHeader>
+    - __kind: PointerType
+      ID: 19
+      Name: '*bucket<string,[]string>'
+      ByteSize: 8
+      Pointee: 20 GoHMapBucketType bucket<string,[]string>
+    - __kind: PointerType
+      ID: 123
+      Name: '*bucket<string,string>'
+      ByteSize: 8
+      Pointee: 124 GoHMapBucketType bucket<string,string>
+    - __kind: PointerType
+      ID: 126
+      Name: '*bytes.Buffer'
+      ByteSize: 8
+      GoRuntimeType: 2.114976e+06
+      GoKind: 22
+      Pointee: 127 StructureType bytes.Buffer
+    - __kind: PointerType
+      ID: 53
+      Name: '*crypto/tls.ConnectionState'
+      ByteSize: 8
+      GoRuntimeType: 835936
+      GoKind: 22
+      Pointee: 54 StructureType crypto/tls.ConnectionState
+    - __kind: PointerType
+      ID: 57
+      Name: '*crypto/x509.Certificate'
+      ByteSize: 8
+      GoRuntimeType: 1.90528e+06
+      GoKind: 22
+      Pointee: 58 StructureType crypto/x509.Certificate
+    - __kind: PointerType
+      ID: 90
+      Name: '*crypto/x509.ExtKeyUsage'
+      ByteSize: 8
+      GoRuntimeType: 395040
+      GoKind: 22
+      Pointee: 91 BaseType crypto/x509.ExtKeyUsage
+    - __kind: PointerType
+      ID: 103
+      Name: '*crypto/x509.OID'
+      ByteSize: 8
+      GoRuntimeType: 1.717248e+06
+      GoKind: 22
+      Pointee: 104 StructureType crypto/x509.OID
+    - __kind: PointerType
+      ID: 69
+      Name: '*crypto/x509/pkix.AttributeTypeAndValue'
+      ByteSize: 8
+      GoRuntimeType: 408800
+      GoKind: 22
+      Pointee: 70 StructureType crypto/x509/pkix.AttributeTypeAndValue
+    - __kind: PointerType
+      ID: 85
+      Name: '*crypto/x509/pkix.Extension'
+      ByteSize: 8
+      GoRuntimeType: 408992
+      GoKind: 22
+      Pointee: 86 StructureType crypto/x509/pkix.Extension
+    - __kind: PointerType
+      ID: 88
+      Name: '*encoding/asn1.ObjectIdentifier'
+      ByteSize: 8
+      GoRuntimeType: 1.009728e+06
+      GoKind: 22
+      Pointee: 71 GoSliceHeaderType encoding/asn1.ObjectIdentifier
+    - __kind: PointerType
+      ID: 173
+      Name: '*encoding/asn1.ObjectIdentifier.array'
+      ByteSize: 8
+      Pointee: 172 GoSliceDataType encoding/asn1.ObjectIdentifier.array
+    - __kind: PointerType
+      ID: 151
+      Name: '*error'
+      ByteSize: 8
+      GoRuntimeType: 371552
+      GoKind: 22
+      Pointee: 139 GoInterfaceType error
+    - __kind: PointerType
+      ID: 153
+      Name: '*float32'
+      ByteSize: 8
+      GoRuntimeType: 372512
+      GoKind: 22
+      Pointee: 137 BaseType float32
+    - __kind: PointerType
+      ID: 144
+      Name: '*float64'
+      ByteSize: 8
+      GoRuntimeType: 372576
+      GoKind: 22
+      Pointee: 138 BaseType float64
+    - __kind: PointerType
+      ID: 42
+      Name: '*hash<string,[]*mime/multipart.FileHeader>'
+      ByteSize: 8
+      Pointee: 43 GoHMapHeaderType hash<string,[]*mime/multipart.FileHeader>
+    - __kind: PointerType
+      ID: 15
+      Name: '*hash<string,[]string>'
+      ByteSize: 8
+      Pointee: 16 GoHMapHeaderType hash<string,[]string>
+    - __kind: PointerType
+      ID: 121
+      Name: '*hash<string,string>'
+      ByteSize: 8
+      Pointee: 122 GoHMapHeaderType hash<string,string>
+    - __kind: PointerType
+      ID: 72
+      Name: '*int'
+      ByteSize: 8
+      GoRuntimeType: 372192
+      GoKind: 22
+      Pointee: 8 BaseType int
+    - __kind: PointerType
+      ID: 148
+      Name: '*int16'
+      ByteSize: 8
+      GoRuntimeType: 371808
+      GoKind: 22
+      Pointee: 149 BaseType int16
+    - __kind: PointerType
+      ID: 140
+      Name: '*int32'
+      ByteSize: 8
+      GoRuntimeType: 371936
+      GoKind: 22
+      Pointee: 134 BaseType int32
+    - __kind: PointerType
+      ID: 145
+      Name: '*int64'
+      ByteSize: 8
+      GoRuntimeType: 372064
+      GoKind: 22
+      Pointee: 36 BaseType int64
+    - __kind: PointerType
+      ID: 150
+      Name: '*int8'
+      ByteSize: 8
+      GoRuntimeType: 371680
+      GoKind: 22
+      Pointee: 135 BaseType int8
+    - __kind: PointerType
+      ID: 62
+      Name: '*math/big.Int'
+      ByteSize: 8
+      GoRuntimeType: 2.231104e+06
+      GoKind: 22
+      Pointee: 63 StructureType math/big.Int
+    - __kind: PointerType
+      ID: 65
+      Name: '*math/big.Word'
+      ByteSize: 8
+      GoRuntimeType: 397856
+      GoKind: 22
+      Pointee: 66 BaseType math/big.Word
+    - __kind: PointerType
+      ID: 169
+      Name: '*math/big.nat.array'
+      ByteSize: 8
+      Pointee: 168 GoSliceDataType math/big.nat.array
+    - __kind: PointerType
+      ID: 49
+      Name: '*mime/multipart.FileHeader'
+      ByteSize: 8
+      GoRuntimeType: 837376
+      GoKind: 22
+      Pointee: 50 StructureType mime/multipart.FileHeader
+    - __kind: PointerType
+      ID: 38
+      Name: '*mime/multipart.Form'
+      ByteSize: 8
+      GoRuntimeType: 837472
+      GoKind: 22
+      Pointee: 39 StructureType mime/multipart.Form
+    - __kind: PointerType
+      ID: 93
+      Name: '*net.IP'
+      ByteSize: 8
+      GoRuntimeType: 1.974144e+06
+      GoKind: 22
+      Pointee: 94 GoSliceHeaderType net.IP
+    - __kind: PointerType
+      ID: 187
+      Name: '*net.IP.array'
+      ByteSize: 8
+      Pointee: 186 GoSliceDataType net.IP.array
+    - __kind: PointerType
+      ID: 193
+      Name: '*net.IPMask.array'
+      ByteSize: 8
+      Pointee: 192 GoSliceDataType net.IPMask.array
+    - __kind: PointerType
+      ID: 99
+      Name: '*net.IPNet'
+      ByteSize: 8
+      GoRuntimeType: 1.095776e+06
+      GoKind: 22
+      Pointee: 100 StructureType net.IPNet
     - __kind: PointerType
       ID: 3
       Name: '*net/http.Request'
@@ -146,124 +476,27 @@ Types:
       GoRuntimeType: 2.154176e+06
       GoKind: 22
       Pointee: 4 StructureType net/http.Request
-    - __kind: StructureType
-      ID: 4
-      Name: net/http.Request
-      ByteSize: 304
-      GoRuntimeType: 2.189984e+06
-      GoKind: 25
-      RawFields:
-        - Name: Method
-          Offset: 0
-          Type: 5 GoStringHeaderType string
-        - Name: URL
-          Offset: 16
-          Type: 9 PointerType *net/url.URL
-        - Name: Proto
-          Offset: 24
-          Type: 5 GoStringHeaderType string
-        - Name: ProtoMajor
-          Offset: 40
-          Type: 8 BaseType int
-        - Name: ProtoMinor
-          Offset: 48
-          Type: 8 BaseType int
-        - Name: Header
-          Offset: 56
-          Type: 14 GoMapType net/http.Header
-        - Name: Body
-          Offset: 64
-          Type: 34 GoInterfaceType io.ReadCloser
-        - Name: GetBody
-          Offset: 80
-          Type: 35 GoSubroutineType func() (io.ReadCloser, error)
-        - Name: ContentLength
-          Offset: 88
-          Type: 36 BaseType int64
-        - Name: TransferEncoding
-          Offset: 96
-          Type: 24 GoSliceHeaderType []string
-        - Name: Close
-          Offset: 120
-          Type: 13 BaseType bool
-        - Name: Host
-          Offset: 128
-          Type: 5 GoStringHeaderType string
-        - Name: Form
-          Offset: 144
-          Type: 37 GoMapType net/url.Values
-        - Name: PostForm
-          Offset: 152
-          Type: 37 GoMapType net/url.Values
-        - Name: MultipartForm
-          Offset: 160
-          Type: 38 PointerType *mime/multipart.Form
-        - Name: Trailer
-          Offset: 168
-          Type: 14 GoMapType net/http.Header
-        - Name: RemoteAddr
-          Offset: 176
-          Type: 5 GoStringHeaderType string
-        - Name: RequestURI
-          Offset: 192
-          Type: 5 GoStringHeaderType string
-        - Name: TLS
-          Offset: 208
-          Type: 53 PointerType *crypto/tls.ConnectionState
-        - Name: Cancel
-          Offset: 216
-          Type: 111 GoChannelType <-chan struct {}
-        - Name: Response
-          Offset: 224
-          Type: 112 PointerType *net/http.Response
-        - Name: Pattern
-          Offset: 232
-          Type: 5 GoStringHeaderType string
-        - Name: ctx
-          Offset: 248
-          Type: 114 GoInterfaceType context.Context
-        - Name: pat
-          Offset: 264
-          Type: 115 PointerType *net/http.pattern
-        - Name: matches
-          Offset: 272
-          Type: 24 GoSliceHeaderType []string
-        - Name: otherValues
-          Offset: 296
-          Type: 120 GoMapType map[string]string
-    - __kind: GoStringHeaderType
-      ID: 5
-      Name: string
-      ByteSize: 16
-      GoRuntimeType: 533568
-      GoKind: 24
-      RawFields:
-        - Name: str
-          Offset: 0
-          Type: 155 PointerType *string.str
-        - Name: len
-          Offset: 8
-          Type: 8 BaseType int
-      Data: 154 GoStringDataType string.str
     - __kind: PointerType
-      ID: 6
-      Name: '*uint8'
+      ID: 112
+      Name: '*net/http.Response'
       ByteSize: 8
-      GoRuntimeType: 371744
+      GoRuntimeType: 1.590912e+06
       GoKind: 22
-      Pointee: 7 BaseType uint8
-    - __kind: BaseType
-      ID: 7
-      Name: uint8
-      ByteSize: 1
-      GoRuntimeType: 533696
-      GoKind: 8
-    - __kind: BaseType
-      ID: 8
-      Name: int
+      Pointee: 113 StructureType net/http.Response
+    - __kind: PointerType
+      ID: 115
+      Name: '*net/http.pattern'
       ByteSize: 8
-      GoRuntimeType: 534144
-      GoKind: 2
+      GoRuntimeType: 1.416224e+06
+      GoKind: 22
+      Pointee: 116 StructureType net/http.pattern
+    - __kind: PointerType
+      ID: 118
+      Name: '*net/http.segment'
+      ByteSize: 8
+      GoRuntimeType: 364000
+      GoKind: 22
+      Pointee: 119 StructureType net/http.segment
     - __kind: PointerType
       ID: 9
       Name: '*net/url.URL'
@@ -271,46 +504,6 @@ Types:
       GoRuntimeType: 1.949216e+06
       GoKind: 22
       Pointee: 10 StructureType net/url.URL
-    - __kind: StructureType
-      ID: 10
-      Name: net/url.URL
-      ByteSize: 144
-      GoRuntimeType: 1.986272e+06
-      GoKind: 25
-      RawFields:
-        - Name: Scheme
-          Offset: 0
-          Type: 5 GoStringHeaderType string
-        - Name: Opaque
-          Offset: 16
-          Type: 5 GoStringHeaderType string
-        - Name: User
-          Offset: 32
-          Type: 11 PointerType *net/url.Userinfo
-        - Name: Host
-          Offset: 40
-          Type: 5 GoStringHeaderType string
-        - Name: Path
-          Offset: 56
-          Type: 5 GoStringHeaderType string
-        - Name: RawPath
-          Offset: 72
-          Type: 5 GoStringHeaderType string
-        - Name: OmitHost
-          Offset: 88
-          Type: 13 BaseType bool
-        - Name: ForceQuery
-          Offset: 89
-          Type: 13 BaseType bool
-        - Name: RawQuery
-          Offset: 96
-          Type: 5 GoStringHeaderType string
-        - Name: Fragment
-          Offset: 112
-          Type: 5 GoStringHeaderType string
-        - Name: RawFragment
-          Offset: 128
-          Type: 5 GoStringHeaderType string
     - __kind: PointerType
       ID: 11
       Name: '*net/url.Userinfo'
@@ -318,110 +511,139 @@ Types:
       GoRuntimeType: 1.114208e+06
       GoKind: 22
       Pointee: 12 StructureType net/url.Userinfo
-    - __kind: StructureType
-      ID: 12
-      Name: net/url.Userinfo
-      ByteSize: 40
-      GoRuntimeType: 1.432736e+06
-      GoKind: 25
-      RawFields:
-        - Name: username
-          Offset: 0
-          Type: 5 GoStringHeaderType string
-        - Name: password
-          Offset: 16
-          Type: 5 GoStringHeaderType string
-        - Name: passwordSet
-          Offset: 32
-          Type: 13 BaseType bool
-    - __kind: BaseType
-      ID: 13
-      Name: bool
-      ByteSize: 1
-      GoRuntimeType: 534592
-      GoKind: 1
-    - __kind: GoMapType
-      ID: 14
-      Name: net/http.Header
-      ByteSize: 8
-      GoRuntimeType: 1.91744e+06
-      GoKind: 21
-      HeaderType: 16 GoHMapHeaderType hash<string,[]string>
     - __kind: PointerType
-      ID: 15
-      Name: '*hash<string,[]string>'
+      ID: 32
+      Name: '*runtime.bmap'
       ByteSize: 8
-      Pointee: 16 GoHMapHeaderType hash<string,[]string>
-    - __kind: GoHMapHeaderType
-      ID: 16
-      Name: hash<string,[]string>
-      ByteSize: 48
-      RawFields:
-        - Name: count
-          Offset: 0
-          Type: 8 BaseType int
-        - Name: flags
-          Offset: 8
-          Type: 7 BaseType uint8
-        - Name: B
-          Offset: 9
-          Type: 7 BaseType uint8
-        - Name: noverflow
-          Offset: 10
-          Type: 17 BaseType uint16
-        - Name: hash0
-          Offset: 12
-          Type: 18 BaseType uint32
-        - Name: buckets
-          Offset: 16
-          Type: 19 PointerType *bucket<string,[]string>
-        - Name: oldbuckets
-          Offset: 24
-          Type: 19 PointerType *bucket<string,[]string>
-        - Name: nevacuate
-          Offset: 32
-          Type: 26 BaseType uintptr
-        - Name: extra
-          Offset: 40
-          Type: 27 PointerType *runtime.mapextra
-      BucketType: 20 GoHMapBucketType bucket<string,[]string>
-      BucketsType: 156 GoSliceDataType []bucket<string,[]string>.array
-    - __kind: BaseType
-      ID: 17
-      Name: uint16
-      ByteSize: 2
-      GoRuntimeType: 533824
-      GoKind: 9
-    - __kind: BaseType
-      ID: 18
-      Name: uint32
-      ByteSize: 4
-      GoRuntimeType: 533952
-      GoKind: 10
+      GoRuntimeType: 1.109856e+06
+      GoKind: 22
+      Pointee: 33 StructureType runtime.bmap
     - __kind: PointerType
-      ID: 19
-      Name: '*bucket<string,[]string>'
+      ID: 27
+      Name: '*runtime.mapextra'
       ByteSize: 8
-      Pointee: 20 GoHMapBucketType bucket<string,[]string>
-    - __kind: GoHMapBucketType
-      ID: 20
-      Name: bucket<string,[]string>
-      ByteSize: 336
-      RawFields:
-        - Name: tophash
-          Offset: 0
-          Type: 21 ArrayType [8]uint8
-        - Name: keys
-          Offset: 8
-          Type: 22 ArrayType []key<string>
-        - Name: values
-          Offset: 136
-          Type: 23 ArrayType []val<[]string>
-        - Name: overflow
-          Offset: 328
-          Type: 19 PointerType *bucket<string,[]string>
-      KeyType: 5 GoStringHeaderType string
-      ValueType: 24 GoSliceHeaderType []string
+      GoRuntimeType: 375520
+      GoKind: 22
+      Pointee: 28 StructureType runtime.mapextra
+    - __kind: PointerType
+      ID: 25
+      Name: '*string'
+      ByteSize: 8
+      GoRuntimeType: 371616
+      GoKind: 22
+      Pointee: 5 GoStringHeaderType string
+    - __kind: PointerType
+      ID: 155
+      Name: '*string.str'
+      ByteSize: 8
+      Pointee: 154 GoStringDataType string.str
+    - __kind: PointerType
+      ID: 75
+      Name: '*time.Location'
+      ByteSize: 8
+      GoRuntimeType: 1.421216e+06
+      GoKind: 22
+      Pointee: 76 StructureType time.Location
+    - __kind: PointerType
+      ID: 78
+      Name: '*time.zone'
+      ByteSize: 8
+      GoRuntimeType: 367072
+      GoKind: 22
+      Pointee: 79 StructureType time.zone
+    - __kind: PointerType
+      ID: 81
+      Name: '*time.zoneTrans'
+      ByteSize: 8
+      GoRuntimeType: 367136
+      GoKind: 22
+      Pointee: 82 StructureType time.zoneTrans
+    - __kind: PointerType
+      ID: 152
+      Name: '*uint'
+      ByteSize: 8
+      GoRuntimeType: 372256
+      GoKind: 22
+      Pointee: 136 BaseType uint
+    - __kind: PointerType
+      ID: 147
+      Name: '*uint16'
+      ByteSize: 8
+      GoRuntimeType: 371872
+      GoKind: 22
+      Pointee: 17 BaseType uint16
+    - __kind: PointerType
+      ID: 141
+      Name: '*uint32'
+      ByteSize: 8
+      GoRuntimeType: 372000
+      GoKind: 22
+      Pointee: 18 BaseType uint32
+    - __kind: PointerType
+      ID: 146
+      Name: '*uint64'
+      ByteSize: 8
+      GoRuntimeType: 372128
+      GoKind: 22
+      Pointee: 74 BaseType uint64
+    - __kind: PointerType
+      ID: 6
+      Name: '*uint8'
+      ByteSize: 8
+      GoRuntimeType: 371744
+      GoKind: 22
+      Pointee: 7 BaseType uint8
+    - __kind: PointerType
+      ID: 133
+      Name: '*uintptr'
+      ByteSize: 8
+      GoRuntimeType: 372320
+      GoKind: 22
+      Pointee: 26 BaseType uintptr
+    - __kind: GoChannelType
+      ID: 111
+      Name: <-chan struct {}
+      GoRuntimeType: 546752
+      GoKind: 18
+    - __kind: EventRootType
+      ID: 203
+      Name: Probe[main.HandleHTTP]
+      ByteSize: 25
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: w
+          Offset: 1
+          Expression:
+            Type: 1 GoInterfaceType net/http.ResponseWriter
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 1, index: 0, name: w}
+                  Offset: 0
+                  ByteSize: 16
+        - Name: r
+          Offset: 17
+          Expression:
+            Type: 3 PointerType *net/http.Request
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 1, index: 1, name: r}
+                  Offset: 0
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 204
+      Name: Probe[main.LookAtTheRequest]
+      ByteSize: 17
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: path
+          Offset: 1
+          Expression:
+            Type: 5 GoStringHeaderType string
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 2, index: 0, name: path}
+                  Offset: 0
+                  ByteSize: 16
     - __kind: ArrayType
       ID: 21
       Name: '[8]uint8'
@@ -431,80 +653,94 @@ Types:
       Count: 8
       HasCount: true
       Element: 7 BaseType uint8
-    - __kind: ArrayType
-      ID: 22
-      Name: '[]key<string>'
-      ByteSize: 128
-      Count: 8
-      HasCount: true
-      Element: 5 GoStringHeaderType string
-    - __kind: ArrayType
-      ID: 23
-      Name: '[]val<[]string>'
-      ByteSize: 192
-      Count: 8
-      HasCount: true
-      Element: 24 GoSliceHeaderType []string
     - __kind: GoSliceHeaderType
-      ID: 24
-      Name: '[]string'
+      ID: 55
+      Name: '[]*crypto/x509.Certificate'
       ByteSize: 24
-      GoRuntimeType: 464704
+      GoRuntimeType: 469536
       GoKind: 23
       RawFields:
         - Name: array
           Offset: 0
-          Type: 25 PointerType *string
+          Type: 56 PointerType **crypto/x509.Certificate
         - Name: len
           Offset: 8
           Type: 8 BaseType int
         - Name: cap
           Offset: 16
           Type: 8 BaseType int
-      Data: 157 GoSliceDataType []string.array
-    - __kind: PointerType
-      ID: 25
-      Name: '*string'
-      ByteSize: 8
-      GoRuntimeType: 371616
-      GoKind: 22
-      Pointee: 5 GoStringHeaderType string
-    - __kind: BaseType
-      ID: 26
-      Name: uintptr
-      ByteSize: 8
-      GoRuntimeType: 534272
-      GoKind: 12
-    - __kind: PointerType
-      ID: 27
-      Name: '*runtime.mapextra'
-      ByteSize: 8
-      GoRuntimeType: 375520
-      GoKind: 22
-      Pointee: 28 StructureType runtime.mapextra
-    - __kind: StructureType
-      ID: 28
-      Name: runtime.mapextra
+      Data: 166 GoSliceDataType []*crypto/x509.Certificate.array
+    - __kind: GoSliceDataType
+      ID: 166
+      Name: '[]*crypto/x509.Certificate.array'
+      ByteSize: 2048
+      Element: 57 PointerType *crypto/x509.Certificate
+    - __kind: GoSliceHeaderType
+      ID: 47
+      Name: '[]*mime/multipart.FileHeader'
       ByteSize: 24
-      GoRuntimeType: 1.428704e+06
-      GoKind: 25
+      GoRuntimeType: 457376
+      GoKind: 23
       RawFields:
-        - Name: overflow
+        - Name: array
           Offset: 0
-          Type: 29 PointerType *[]*runtime.bmap
-        - Name: oldoverflow
+          Type: 48 PointerType **mime/multipart.FileHeader
+        - Name: len
           Offset: 8
-          Type: 29 PointerType *[]*runtime.bmap
-        - Name: nextOverflow
+          Type: 8 BaseType int
+        - Name: cap
           Offset: 16
-          Type: 32 PointerType *runtime.bmap
-    - __kind: PointerType
-      ID: 29
-      Name: '*[]*runtime.bmap'
-      ByteSize: 8
-      GoRuntimeType: 466432
-      GoKind: 22
-      Pointee: 30 GoSliceHeaderType []*runtime.bmap
+          Type: 8 BaseType int
+      Data: 162 GoSliceDataType []*mime/multipart.FileHeader.array
+    - __kind: GoSliceDataType
+      ID: 162
+      Name: '[]*mime/multipart.FileHeader.array'
+      ByteSize: 2048
+      Element: 49 PointerType *mime/multipart.FileHeader
+    - __kind: GoSliceHeaderType
+      ID: 97
+      Name: '[]*net.IPNet'
+      ByteSize: 24
+      GoRuntimeType: 481568
+      GoKind: 23
+      RawFields:
+        - Name: array
+          Offset: 0
+          Type: 98 PointerType **net.IPNet
+        - Name: len
+          Offset: 8
+          Type: 8 BaseType int
+        - Name: cap
+          Offset: 16
+          Type: 8 BaseType int
+      Data: 190 GoSliceDataType []*net.IPNet.array
+    - __kind: GoSliceDataType
+      ID: 190
+      Name: '[]*net.IPNet.array'
+      ByteSize: 2048
+      Element: 99 PointerType *net.IPNet
+    - __kind: GoSliceHeaderType
+      ID: 95
+      Name: '[]*net/url.URL'
+      ByteSize: 24
+      GoRuntimeType: 481504
+      GoKind: 23
+      RawFields:
+        - Name: array
+          Offset: 0
+          Type: 96 PointerType **net/url.URL
+        - Name: len
+          Offset: 8
+          Type: 8 BaseType int
+        - Name: cap
+          Offset: 16
+          Type: 8 BaseType int
+      Data: 188 GoSliceDataType []*net/url.URL.array
+    - __kind: GoSliceDataType
+      ID: 188
+      Name: '[]*net/url.URL.array'
+      ByteSize: 2048
+      Element: 9 PointerType *net/url.URL
     - __kind: GoSliceHeaderType
       ID: 30
       Name: '[]*runtime.bmap'
@@ -522,138 +758,346 @@ Types:
           Offset: 16
           Type: 8 BaseType int
       Data: 159 GoSliceDataType []*runtime.bmap.array
-    - __kind: PointerType
-      ID: 31
-      Name: '**runtime.bmap'
-      ByteSize: 8
-      Pointee: 32 PointerType *runtime.bmap
-    - __kind: PointerType
-      ID: 32
-      Name: '*runtime.bmap'
-      ByteSize: 8
-      GoRuntimeType: 1.109856e+06
-      GoKind: 22
-      Pointee: 33 StructureType runtime.bmap
-    - __kind: StructureType
-      ID: 33
-      Name: runtime.bmap
-      ByteSize: 8
-      GoRuntimeType: 1.109728e+06
-      GoKind: 25
+    - __kind: GoSliceDataType
+      ID: 159
+      Name: '[]*runtime.bmap.array'
+      ByteSize: 2048
+      Element: 32 PointerType *runtime.bmap
+    - __kind: GoSliceHeaderType
+      ID: 105
+      Name: '[][]*crypto/x509.Certificate'
+      ByteSize: 24
+      GoRuntimeType: 469664
+      GoKind: 23
       RawFields:
-        - Name: tophash
+        - Name: array
           Offset: 0
-          Type: 21 ArrayType [8]uint8
-    - __kind: GoInterfaceType
-      ID: 34
-      Name: io.ReadCloser
-      ByteSize: 16
-      GoRuntimeType: 1.067136e+06
-      GoKind: 20
-      RawFields:
-        - Name: tab
-          Offset: 0
-          Type: 2 VoidPointerType unsafe.Pointer
-        - Name: data
+          Type: 106 PointerType *[]*crypto/x509.Certificate
+        - Name: len
           Offset: 8
-          Type: 2 VoidPointerType unsafe.Pointer
-    - __kind: GoSubroutineType
-      ID: 35
-      Name: func() (io.ReadCloser, error)
-      ByteSize: 8
-      GoRuntimeType: 634112
-      GoKind: 19
-    - __kind: BaseType
-      ID: 36
-      Name: int64
-      ByteSize: 8
-      GoRuntimeType: 534016
-      GoKind: 6
-    - __kind: GoMapType
-      ID: 37
-      Name: net/url.Values
-      ByteSize: 8
-      GoRuntimeType: 1.670784e+06
-      GoKind: 21
-      HeaderType: 16 GoHMapHeaderType hash<string,[]string>
-    - __kind: PointerType
-      ID: 38
-      Name: '*mime/multipart.Form'
-      ByteSize: 8
-      GoRuntimeType: 837472
-      GoKind: 22
-      Pointee: 39 StructureType mime/multipart.Form
-    - __kind: StructureType
-      ID: 39
-      Name: mime/multipart.Form
-      ByteSize: 16
-      GoRuntimeType: 1.294336e+06
-      GoKind: 25
-      RawFields:
-        - Name: Value
-          Offset: 0
-          Type: 40 GoMapType map[string][]string
-        - Name: File
-          Offset: 8
-          Type: 41 GoMapType map[string][]*mime/multipart.FileHeader
-    - __kind: GoMapType
-      ID: 40
-      Name: map[string][]string
-      ByteSize: 8
-      GoRuntimeType: 882496
-      GoKind: 21
-      HeaderType: 16 GoHMapHeaderType hash<string,[]string>
-    - __kind: GoMapType
-      ID: 41
-      Name: map[string][]*mime/multipart.FileHeader
-      ByteSize: 8
-      GoRuntimeType: 887296
-      GoKind: 21
-      HeaderType: 43 GoHMapHeaderType hash<string,[]*mime/multipart.FileHeader>
-    - __kind: PointerType
-      ID: 42
-      Name: '*hash<string,[]*mime/multipart.FileHeader>'
-      ByteSize: 8
-      Pointee: 43 GoHMapHeaderType hash<string,[]*mime/multipart.FileHeader>
-    - __kind: GoHMapHeaderType
-      ID: 43
-      Name: hash<string,[]*mime/multipart.FileHeader>
-      ByteSize: 48
-      RawFields:
-        - Name: count
-          Offset: 0
           Type: 8 BaseType int
-        - Name: flags
-          Offset: 8
-          Type: 7 BaseType uint8
-        - Name: B
-          Offset: 9
-          Type: 7 BaseType uint8
-        - Name: noverflow
-          Offset: 10
-          Type: 17 BaseType uint16
-        - Name: hash0
-          Offset: 12
-          Type: 18 BaseType uint32
-        - Name: buckets
+        - Name: cap
           Offset: 16
-          Type: 44 PointerType *bucket<string,[]*mime/multipart.FileHeader>
-        - Name: oldbuckets
-          Offset: 24
-          Type: 44 PointerType *bucket<string,[]*mime/multipart.FileHeader>
-        - Name: nevacuate
-          Offset: 32
-          Type: 26 BaseType uintptr
-        - Name: extra
-          Offset: 40
-          Type: 27 PointerType *runtime.mapextra
-      BucketType: 45 GoHMapBucketType bucket<string,[]*mime/multipart.FileHeader>
-      BucketsType: 161 GoSliceDataType []bucket<string,[]*mime/multipart.FileHeader>.array
-    - __kind: PointerType
-      ID: 44
-      Name: '*bucket<string,[]*mime/multipart.FileHeader>'
-      ByteSize: 8
-      Pointee: 45 GoHMapBucketType bucket<string,[]*mime/multipart.FileHeader>
+          Type: 8 BaseType int
+      Data: 196 GoSliceDataType [][]*crypto/x509.Certificate.array
+    - __kind: GoSliceDataType
+      ID: 196
+      Name: '[][]*crypto/x509.Certificate.array'
+      ByteSize: 2048
+      Element: 55 GoSliceHeaderType []*crypto/x509.Certificate
+    - __kind: GoSliceHeaderType
+      ID: 107
+      Name: '[][]uint8'
+      ByteSize: 24
+      GoRuntimeType: 452832
+      GoKind: 23
+      RawFields:
+        - Name: array
+          Offset: 0
+          Type: 108 PointerType *[]uint8
+        - Name: len
+          Offset: 8
+          Type: 8 BaseType int
+        - Name: cap
+          Offset: 16
+          Type: 8 BaseType int
+      Data: 198 GoSliceDataType [][]uint8.array
+    - __kind: GoSliceDataType
+      ID: 198
+      Name: '[][]uint8.array'
+      ByteSize: 2048
+      Element: 52 GoSliceHeaderType []uint8
+    - __kind: GoSliceDataType
+      ID: 161
+      Name: '[]bucket<string,[]*mime/multipart.FileHeader>.array'
+      ByteSize: 2048
+      Element: 45 GoHMapBucketType bucket<string,[]*mime/multipart.FileHeader>
+    - __kind: GoSliceDataType
+      ID: 156
+      Name: '[]bucket<string,[]string>.array'
+      ByteSize: 2048
+      Element: 20 GoHMapBucketType bucket<string,[]string>
+    - __kind: GoSliceDataType
+      ID: 202
+      Name: '[]bucket<string,string>.array'
+      ByteSize: 2048
+      Element: 124 GoHMapBucketType bucket<string,string>
+    - __kind: GoSliceHeaderType
+      ID: 89
+      Name: '[]crypto/x509.ExtKeyUsage'
+      ByteSize: 24
+      GoRuntimeType: 470816
+      GoKind: 23
+      RawFields:
+        - Name: array
+          Offset: 0
+          Type: 90 PointerType *crypto/x509.ExtKeyUsage
+        - Name: len
+          Offset: 8
+          Type: 8 BaseType int
+        - Name: cap
+          Offset: 16
+          Type: 8 BaseType int
+      Data: 182 GoSliceDataType []crypto/x509.ExtKeyUsage.array
+    - __kind: GoSliceDataType
+      ID: 182
+      Name: '[]crypto/x509.ExtKeyUsage.array'
+      ByteSize: 2048
+      Element: 91 BaseType crypto/x509.ExtKeyUsage
+    - __kind: GoSliceHeaderType
+      ID: 102
+      Name: '[]crypto/x509.OID'
+      ByteSize: 24
+      GoRuntimeType: 481632
+      GoKind: 23
+      RawFields:
+        - Name: array
+          Offset: 0
+          Type: 103 PointerType *crypto/x509.OID
+        - Name: len
+          Offset: 8
+          Type: 8 BaseType int
+        - Name: cap
+          Offset: 16
+          Type: 8 BaseType int
+      Data: 194 GoSliceDataType []crypto/x509.OID.array
+    - __kind: GoSliceDataType
+      ID: 194
+      Name: '[]crypto/x509.OID.array'
+      ByteSize: 2048
+      Element: 104 StructureType crypto/x509.OID
+    - __kind: GoSliceHeaderType
+      ID: 68
+      Name: '[]crypto/x509/pkix.AttributeTypeAndValue'
+      ByteSize: 24
+      GoRuntimeType: 481888
+      GoKind: 23
+      RawFields:
+        - Name: array
+          Offset: 0
+          Type: 69 PointerType *crypto/x509/pkix.AttributeTypeAndValue
+        - Name: len
+          Offset: 8
+          Type: 8 BaseType int
+        - Name: cap
+          Offset: 16
+          Type: 8 BaseType int
+      Data: 170 GoSliceDataType []crypto/x509/pkix.AttributeTypeAndValue.array
+    - __kind: GoSliceDataType
+      ID: 170
+      Name: '[]crypto/x509/pkix.AttributeTypeAndValue.array'
+      ByteSize: 2048
+      Element: 70 StructureType crypto/x509/pkix.AttributeTypeAndValue
+    - __kind: GoSliceHeaderType
+      ID: 84
+      Name: '[]crypto/x509/pkix.Extension'
+      ByteSize: 24
+      GoRuntimeType: 481376
+      GoKind: 23
+      RawFields:
+        - Name: array
+          Offset: 0
+          Type: 85 PointerType *crypto/x509/pkix.Extension
+        - Name: len
+          Offset: 8
+          Type: 8 BaseType int
+        - Name: cap
+          Offset: 16
+          Type: 8 BaseType int
+      Data: 178 GoSliceDataType []crypto/x509/pkix.Extension.array
+    - __kind: GoSliceDataType
+      ID: 178
+      Name: '[]crypto/x509/pkix.Extension.array'
+      ByteSize: 2048
+      Element: 86 StructureType crypto/x509/pkix.Extension
+    - __kind: GoSliceHeaderType
+      ID: 87
+      Name: '[]encoding/asn1.ObjectIdentifier'
+      ByteSize: 24
+      GoRuntimeType: 481440
+      GoKind: 23
+      RawFields:
+        - Name: array
+          Offset: 0
+          Type: 88 PointerType *encoding/asn1.ObjectIdentifier
+        - Name: len
+          Offset: 8
+          Type: 8 BaseType int
+        - Name: cap
+          Offset: 16
+          Type: 8 BaseType int
+      Data: 180 GoSliceDataType []encoding/asn1.ObjectIdentifier.array
+    - __kind: GoSliceDataType
+      ID: 180
+      Name: '[]encoding/asn1.ObjectIdentifier.array'
+      ByteSize: 2048
+      Element: 71 GoSliceHeaderType encoding/asn1.ObjectIdentifier
+    - __kind: ArrayType
+      ID: 22
+      Name: '[]key<string>'
+      ByteSize: 128
+      Count: 8
+      HasCount: true
+      Element: 5 GoStringHeaderType string
+    - __kind: GoSliceHeaderType
+      ID: 92
+      Name: '[]net.IP'
+      ByteSize: 24
+      GoRuntimeType: 454048
+      GoKind: 23
+      RawFields:
+        - Name: array
+          Offset: 0
+          Type: 93 PointerType *net.IP
+        - Name: len
+          Offset: 8
+          Type: 8 BaseType int
+        - Name: cap
+          Offset: 16
+          Type: 8 BaseType int
+      Data: 184 GoSliceDataType []net.IP.array
+    - __kind: GoSliceDataType
+      ID: 184
+      Name: '[]net.IP.array'
+      ByteSize: 2048
+      Element: 94 GoSliceHeaderType net.IP
+    - __kind: GoSliceHeaderType
+      ID: 117
+      Name: '[]net/http.segment'
+      ByteSize: 24
+      GoRuntimeType: 454816
+      GoKind: 23
+      RawFields:
+        - Name: array
+          Offset: 0
+          Type: 118 PointerType *net/http.segment
+        - Name: len
+          Offset: 8
+          Type: 8 BaseType int
+        - Name: cap
+          Offset: 16
+          Type: 8 BaseType int
+      Data: 200 GoSliceDataType []net/http.segment.array
+    - __kind: GoSliceDataType
+      ID: 200
+      Name: '[]net/http.segment.array'
+      ByteSize: 2048
+      Element: 119 StructureType net/http.segment
+    - __kind: GoSliceHeaderType
+      ID: 24
+      Name: '[]string'
+      ByteSize: 24
+      GoRuntimeType: 464704
+      GoKind: 23
+      RawFields:
+        - Name: array
+          Offset: 0
+          Type: 25 PointerType *string
+        - Name: len
+          Offset: 8
+          Type: 8 BaseType int
+        - Name: cap
+          Offset: 16
+          Type: 8 BaseType int
+      Data: 157 GoSliceDataType []string.array
+    - __kind: GoSliceDataType
+      ID: 157
+      Name: '[]string.array'
+      ByteSize: 2048
+      Element: 5 GoStringHeaderType string
+    - __kind: GoSliceHeaderType
+      ID: 77
+      Name: '[]time.zone'
+      ByteSize: 24
+      GoRuntimeType: 459040
+      GoKind: 23
+      RawFields:
+        - Name: array
+          Offset: 0
+          Type: 78 PointerType *time.zone
+        - Name: len
+          Offset: 8
+          Type: 8 BaseType int
+        - Name: cap
+          Offset: 16
+          Type: 8 BaseType int
+      Data: 174 GoSliceDataType []time.zone.array
+    - __kind: GoSliceDataType
+      ID: 174
+      Name: '[]time.zone.array'
+      ByteSize: 2048
+      Element: 79 StructureType time.zone
+    - __kind: GoSliceHeaderType
+      ID: 80
+      Name: '[]time.zoneTrans'
+      ByteSize: 24
+      GoRuntimeType: 459104
+      GoKind: 23
+      RawFields:
+        - Name: array
+          Offset: 0
+          Type: 81 PointerType *time.zoneTrans
+        - Name: len
+          Offset: 8
+          Type: 8 BaseType int
+        - Name: cap
+          Offset: 16
+          Type: 8 BaseType int
+      Data: 176 GoSliceDataType []time.zoneTrans.array
+    - __kind: GoSliceDataType
+      ID: 176
+      Name: '[]time.zoneTrans.array'
+      ByteSize: 2048
+      Element: 82 StructureType time.zoneTrans
+    - __kind: GoSliceHeaderType
+      ID: 52
+      Name: '[]uint8'
+      ByteSize: 24
+      GoRuntimeType: 463552
+      GoKind: 23
+      RawFields:
+        - Name: array
+          Offset: 0
+          Type: 6 PointerType *uint8
+        - Name: len
+          Offset: 8
+          Type: 8 BaseType int
+        - Name: cap
+          Offset: 16
+          Type: 8 BaseType int
+      Data: 164 GoSliceDataType []uint8.array
+    - __kind: GoSliceDataType
+      ID: 164
+      Name: '[]uint8.array'
+      ByteSize: 2048
+      Element: 7 BaseType uint8
+    - __kind: ArrayType
+      ID: 46
+      Name: '[]val<[]*mime/multipart.FileHeader>'
+      ByteSize: 192
+      Count: 8
+      HasCount: true
+      Element: 47 GoSliceHeaderType []*mime/multipart.FileHeader
+    - __kind: ArrayType
+      ID: 23
+      Name: '[]val<[]string>'
+      ByteSize: 192
+      Count: 8
+      HasCount: true
+      Element: 24 GoSliceHeaderType []string
+    - __kind: ArrayType
+      ID: 125
+      Name: '[]val<string>'
+      ByteSize: 128
+      Count: 8
+      HasCount: true
+      Element: 5 GoStringHeaderType string
+    - __kind: BaseType
+      ID: 13
+      Name: bool
+      ByteSize: 1
+      GoRuntimeType: 534592
+      GoKind: 1
     - __kind: GoHMapBucketType
       ID: 45
       Name: bucket<string,[]*mime/multipart.FileHeader>
@@ -673,102 +1117,106 @@ Types:
           Type: 44 PointerType *bucket<string,[]*mime/multipart.FileHeader>
       KeyType: 5 GoStringHeaderType string
       ValueType: 47 GoSliceHeaderType []*mime/multipart.FileHeader
-    - __kind: ArrayType
-      ID: 46
-      Name: '[]val<[]*mime/multipart.FileHeader>'
-      ByteSize: 192
-      Count: 8
-      HasCount: true
-      Element: 47 GoSliceHeaderType []*mime/multipart.FileHeader
-    - __kind: GoSliceHeaderType
-      ID: 47
-      Name: '[]*mime/multipart.FileHeader'
-      ByteSize: 24
-      GoRuntimeType: 457376
-      GoKind: 23
+    - __kind: GoHMapBucketType
+      ID: 20
+      Name: bucket<string,[]string>
+      ByteSize: 336
       RawFields:
-        - Name: array
+        - Name: tophash
           Offset: 0
-          Type: 48 PointerType **mime/multipart.FileHeader
-        - Name: len
+          Type: 21 ArrayType [8]uint8
+        - Name: keys
           Offset: 8
-          Type: 8 BaseType int
-        - Name: cap
-          Offset: 16
-          Type: 8 BaseType int
-      Data: 162 GoSliceDataType []*mime/multipart.FileHeader.array
-    - __kind: PointerType
-      ID: 48
-      Name: '**mime/multipart.FileHeader'
-      ByteSize: 8
-      GoKind: 22
-      Pointee: 49 PointerType *mime/multipart.FileHeader
-    - __kind: PointerType
-      ID: 49
-      Name: '*mime/multipart.FileHeader'
-      ByteSize: 8
-      GoRuntimeType: 837376
-      GoKind: 22
-      Pointee: 50 StructureType mime/multipart.FileHeader
+          Type: 22 ArrayType []key<string>
+        - Name: values
+          Offset: 136
+          Type: 23 ArrayType []val<[]string>
+        - Name: overflow
+          Offset: 328
+          Type: 19 PointerType *bucket<string,[]string>
+      KeyType: 5 GoStringHeaderType string
+      ValueType: 24 GoSliceHeaderType []string
+    - __kind: GoHMapBucketType
+      ID: 124
+      Name: bucket<string,string>
+      ByteSize: 272
+      RawFields:
+        - Name: tophash
+          Offset: 0
+          Type: 21 ArrayType [8]uint8
+        - Name: keys
+          Offset: 8
+          Type: 22 ArrayType []key<string>
+        - Name: values
+          Offset: 136
+          Type: 125 ArrayType []val<string>
+        - Name: overflow
+          Offset: 264
+          Type: 123 PointerType *bucket<string,string>
+      KeyType: 5 GoStringHeaderType string
+      ValueType: 5 GoStringHeaderType string
     - __kind: StructureType
-      ID: 50
-      Name: mime/multipart.FileHeader
-      ByteSize: 88
-      GoRuntimeType: 1.838016e+06
+      ID: 127
+      Name: bytes.Buffer
+      ByteSize: 40
+      GoRuntimeType: 1.41392e+06
       GoKind: 25
       RawFields:
-        - Name: Filename
+        - Name: buf
           Offset: 0
-          Type: 5 GoStringHeaderType string
-        - Name: Header
-          Offset: 16
-          Type: 51 GoMapType net/textproto.MIMEHeader
-        - Name: Size
-          Offset: 24
-          Type: 36 BaseType int64
-        - Name: content
-          Offset: 32
           Type: 52 GoSliceHeaderType []uint8
-        - Name: tmpfile
-          Offset: 56
-          Type: 5 GoStringHeaderType string
-        - Name: tmpoff
-          Offset: 72
-          Type: 36 BaseType int64
-        - Name: tmpshared
-          Offset: 80
-          Type: 13 BaseType bool
-    - __kind: GoMapType
-      ID: 51
-      Name: net/textproto.MIMEHeader
+        - Name: off
+          Offset: 24
+          Type: 8 BaseType int
+        - Name: lastRead
+          Offset: 32
+          Type: 128 BaseType bytes.readOp
+    - __kind: BaseType
+      ID: 128
+      Name: bytes.readOp
+      ByteSize: 1
+      GoRuntimeType: 532800
+      GoKind: 3
+    - __kind: BaseType
+      ID: 143
+      Name: complex128
+      ByteSize: 16
+      GoRuntimeType: 534400
+      GoKind: 16
+    - __kind: BaseType
+      ID: 142
+      Name: complex64
       ByteSize: 8
-      GoRuntimeType: 1.595904e+06
-      GoKind: 21
-      HeaderType: 16 GoHMapHeaderType hash<string,[]string>
-    - __kind: GoSliceHeaderType
-      ID: 52
-      Name: '[]uint8'
-      ByteSize: 24
-      GoRuntimeType: 463552
-      GoKind: 23
+      GoRuntimeType: 534336
+      GoKind: 15
+    - __kind: GoInterfaceType
+      ID: 114
+      Name: context.Context
+      ByteSize: 16
+      GoRuntimeType: 1.187104e+06
+      GoKind: 20
       RawFields:
-        - Name: array
+        - Name: tab
           Offset: 0
-          Type: 6 PointerType *uint8
-        - Name: len
+          Type: 2 VoidPointerType unsafe.Pointer
+        - Name: data
           Offset: 8
-          Type: 8 BaseType int
-        - Name: cap
-          Offset: 16
-          Type: 8 BaseType int
-      Data: 164 GoSliceDataType []uint8.array
-    - __kind: PointerType
-      ID: 53
-      Name: '*crypto/tls.ConnectionState'
-      ByteSize: 8
-      GoRuntimeType: 835936
-      GoKind: 22
-      Pointee: 54 StructureType crypto/tls.ConnectionState
+          Type: 2 VoidPointerType unsafe.Pointer
+    - __kind: StructureType
+      ID: 130
+      Name: context.backgroundCtx
+      GoRuntimeType: 1.6672e+06
+      GoKind: 25
+      RawFields:
+        - Name: emptyCtx
+          Offset: 0
+          Type: 131 StructureType context.emptyCtx
+    - __kind: StructureType
+      ID: 131
+      Name: context.emptyCtx
+      GoRuntimeType: 1.399456e+06
+      GoKind: 25
+      RawFields: []
     - __kind: StructureType
       ID: 54
       Name: crypto/tls.ConnectionState
@@ -824,35 +1272,12 @@ Types:
         - Name: testingOnlyCurveID
           Offset: 186
           Type: 110 BaseType crypto/tls.CurveID
-    - __kind: GoSliceHeaderType
-      ID: 55
-      Name: '[]*crypto/x509.Certificate'
-      ByteSize: 24
-      GoRuntimeType: 469536
-      GoKind: 23
-      RawFields:
-        - Name: array
-          Offset: 0
-          Type: 56 PointerType **crypto/x509.Certificate
-        - Name: len
-          Offset: 8
-          Type: 8 BaseType int
-        - Name: cap
-          Offset: 16
-          Type: 8 BaseType int
-      Data: 166 GoSliceDataType []*crypto/x509.Certificate.array
-    - __kind: PointerType
-      ID: 56
-      Name: '**crypto/x509.Certificate'
-      ByteSize: 8
-      Pointee: 57 PointerType *crypto/x509.Certificate
-    - __kind: PointerType
-      ID: 57
-      Name: '*crypto/x509.Certificate'
-      ByteSize: 8
-      GoRuntimeType: 1.90528e+06
-      GoKind: 22
-      Pointee: 58 StructureType crypto/x509.Certificate
+    - __kind: BaseType
+      ID: 110
+      Name: crypto/tls.CurveID
+      ByteSize: 2
+      GoRuntimeType: 766048
+      GoKind: 9
     - __kind: StructureType
       ID: 58
       Name: crypto/x509.Certificate
@@ -996,80 +1421,68 @@ Types:
           Offset: 1328
           Type: 102 GoSliceHeaderType []crypto/x509.OID
     - __kind: BaseType
-      ID: 59
-      Name: crypto/x509.SignatureAlgorithm
+      ID: 91
+      Name: crypto/x509.ExtKeyUsage
       ByteSize: 8
-      GoRuntimeType: 1.070976e+06
+      GoRuntimeType: 537280
       GoKind: 2
+    - __kind: BaseType
+      ID: 83
+      Name: crypto/x509.KeyUsage
+      ByteSize: 8
+      GoRuntimeType: 537216
+      GoKind: 2
+    - __kind: StructureType
+      ID: 104
+      Name: crypto/x509.OID
+      ByteSize: 24
+      GoRuntimeType: 1.717472e+06
+      GoKind: 25
+      RawFields:
+        - Name: der
+          Offset: 0
+          Type: 52 GoSliceHeaderType []uint8
     - __kind: BaseType
       ID: 60
       Name: crypto/x509.PublicKeyAlgorithm
       ByteSize: 8
       GoRuntimeType: 768448
       GoKind: 2
-    - __kind: GoEmptyInterfaceType
-      ID: 61
-      Name: interface {}
-      ByteSize: 16
-      GoRuntimeType: 785376
-      GoKind: 20
-      RawFields:
-        - Name: _type
-          Offset: 0
-          Type: 2 VoidPointerType unsafe.Pointer
-        - Name: data
-          Offset: 8
-          Type: 2 VoidPointerType unsafe.Pointer
-    - __kind: PointerType
-      ID: 62
-      Name: '*math/big.Int'
+    - __kind: BaseType
+      ID: 59
+      Name: crypto/x509.SignatureAlgorithm
       ByteSize: 8
-      GoRuntimeType: 2.231104e+06
-      GoKind: 22
-      Pointee: 63 StructureType math/big.Int
+      GoRuntimeType: 1.070976e+06
+      GoKind: 2
     - __kind: StructureType
-      ID: 63
-      Name: math/big.Int
-      ByteSize: 32
-      GoRuntimeType: 1.308416e+06
+      ID: 70
+      Name: crypto/x509/pkix.AttributeTypeAndValue
+      ByteSize: 40
+      GoRuntimeType: 1.316256e+06
       GoKind: 25
       RawFields:
-        - Name: neg
+        - Name: Type
           Offset: 0
-          Type: 13 BaseType bool
-        - Name: abs
-          Offset: 8
-          Type: 64 GoSliceHeaderType math/big.nat
-    - __kind: GoSliceHeaderType
-      ID: 64
-      Name: math/big.nat
-      ByteSize: 24
-      GoRuntimeType: 2.21424e+06
-      GoKind: 23
+          Type: 71 GoSliceHeaderType encoding/asn1.ObjectIdentifier
+        - Name: Value
+          Offset: 24
+          Type: 61 GoEmptyInterfaceType interface {}
+    - __kind: StructureType
+      ID: 86
+      Name: crypto/x509/pkix.Extension
+      ByteSize: 56
+      GoRuntimeType: 1.455008e+06
+      GoKind: 25
       RawFields:
-        - Name: array
+        - Name: Id
           Offset: 0
-          Type: 65 PointerType *math/big.Word
-        - Name: len
-          Offset: 8
-          Type: 8 BaseType int
-        - Name: cap
-          Offset: 16
-          Type: 8 BaseType int
-      Data: 168 GoSliceDataType math/big.nat.array
-    - __kind: PointerType
-      ID: 65
-      Name: '*math/big.Word'
-      ByteSize: 8
-      GoRuntimeType: 397856
-      GoKind: 22
-      Pointee: 66 BaseType math/big.Word
-    - __kind: BaseType
-      ID: 66
-      Name: math/big.Word
-      ByteSize: 8
-      GoRuntimeType: 537536
-      GoKind: 7
+          Type: 71 GoSliceHeaderType encoding/asn1.ObjectIdentifier
+        - Name: Critical
+          Offset: 24
+          Type: 13 BaseType bool
+        - Name: Value
+          Offset: 32
+          Type: 52 GoSliceHeaderType []uint8
     - __kind: StructureType
       ID: 67
       Name: crypto/x509/pkix.Name
@@ -1111,43 +1524,6 @@ Types:
           Offset: 224
           Type: 68 GoSliceHeaderType []crypto/x509/pkix.AttributeTypeAndValue
     - __kind: GoSliceHeaderType
-      ID: 68
-      Name: '[]crypto/x509/pkix.AttributeTypeAndValue'
-      ByteSize: 24
-      GoRuntimeType: 481888
-      GoKind: 23
-      RawFields:
-        - Name: array
-          Offset: 0
-          Type: 69 PointerType *crypto/x509/pkix.AttributeTypeAndValue
-        - Name: len
-          Offset: 8
-          Type: 8 BaseType int
-        - Name: cap
-          Offset: 16
-          Type: 8 BaseType int
-      Data: 170 GoSliceDataType []crypto/x509/pkix.AttributeTypeAndValue.array
-    - __kind: PointerType
-      ID: 69
-      Name: '*crypto/x509/pkix.AttributeTypeAndValue'
-      ByteSize: 8
-      GoRuntimeType: 408800
-      GoKind: 22
-      Pointee: 70 StructureType crypto/x509/pkix.AttributeTypeAndValue
-    - __kind: StructureType
-      ID: 70
-      Name: crypto/x509/pkix.AttributeTypeAndValue
-      ByteSize: 40
-      GoRuntimeType: 1.316256e+06
-      GoKind: 25
-      RawFields:
-        - Name: Type
-          Offset: 0
-          Type: 71 GoSliceHeaderType encoding/asn1.ObjectIdentifier
-        - Name: Value
-          Offset: 24
-          Type: 61 GoEmptyInterfaceType interface {}
-    - __kind: GoSliceHeaderType
       ID: 71
       Name: encoding/asn1.ObjectIdentifier
       ByteSize: 24
@@ -1164,277 +1540,322 @@ Types:
           Offset: 16
           Type: 8 BaseType int
       Data: 172 GoSliceDataType encoding/asn1.ObjectIdentifier.array
-    - __kind: PointerType
-      ID: 72
-      Name: '*int'
-      ByteSize: 8
-      GoRuntimeType: 372192
-      GoKind: 22
-      Pointee: 8 BaseType int
-    - __kind: StructureType
-      ID: 73
-      Name: time.Time
-      ByteSize: 24
-      GoRuntimeType: 2.215168e+06
-      GoKind: 25
-      RawFields:
-        - Name: wall
-          Offset: 0
-          Type: 74 BaseType uint64
-        - Name: ext
-          Offset: 8
-          Type: 36 BaseType int64
-        - Name: loc
-          Offset: 16
-          Type: 75 PointerType *time.Location
-    - __kind: BaseType
-      ID: 74
-      Name: uint64
-      ByteSize: 8
-      GoRuntimeType: 534080
-      GoKind: 11
-    - __kind: PointerType
-      ID: 75
-      Name: '*time.Location'
-      ByteSize: 8
-      GoRuntimeType: 1.421216e+06
-      GoKind: 22
-      Pointee: 76 StructureType time.Location
-    - __kind: StructureType
-      ID: 76
-      Name: time.Location
-      ByteSize: 104
-      GoRuntimeType: 1.833984e+06
-      GoKind: 25
-      RawFields:
-        - Name: name
-          Offset: 0
-          Type: 5 GoStringHeaderType string
-        - Name: zone
-          Offset: 16
-          Type: 77 GoSliceHeaderType []time.zone
-        - Name: tx
-          Offset: 40
-          Type: 80 GoSliceHeaderType []time.zoneTrans
-        - Name: extend
-          Offset: 64
-          Type: 5 GoStringHeaderType string
-        - Name: cacheStart
-          Offset: 80
-          Type: 36 BaseType int64
-        - Name: cacheEnd
-          Offset: 88
-          Type: 36 BaseType int64
-        - Name: cacheZone
-          Offset: 96
-          Type: 78 PointerType *time.zone
-    - __kind: GoSliceHeaderType
-      ID: 77
-      Name: '[]time.zone'
-      ByteSize: 24
-      GoRuntimeType: 459040
-      GoKind: 23
-      RawFields:
-        - Name: array
-          Offset: 0
-          Type: 78 PointerType *time.zone
-        - Name: len
-          Offset: 8
-          Type: 8 BaseType int
-        - Name: cap
-          Offset: 16
-          Type: 8 BaseType int
-      Data: 174 GoSliceDataType []time.zone.array
-    - __kind: PointerType
-      ID: 78
-      Name: '*time.zone'
-      ByteSize: 8
-      GoRuntimeType: 367072
-      GoKind: 22
-      Pointee: 79 StructureType time.zone
-    - __kind: StructureType
-      ID: 79
-      Name: time.zone
-      ByteSize: 32
-      GoRuntimeType: 1.421024e+06
-      GoKind: 25
-      RawFields:
-        - Name: name
-          Offset: 0
-          Type: 5 GoStringHeaderType string
-        - Name: offset
-          Offset: 16
-          Type: 8 BaseType int
-        - Name: isDST
-          Offset: 24
-          Type: 13 BaseType bool
-    - __kind: GoSliceHeaderType
-      ID: 80
-      Name: '[]time.zoneTrans'
-      ByteSize: 24
-      GoRuntimeType: 459104
-      GoKind: 23
-      RawFields:
-        - Name: array
-          Offset: 0
-          Type: 81 PointerType *time.zoneTrans
-        - Name: len
-          Offset: 8
-          Type: 8 BaseType int
-        - Name: cap
-          Offset: 16
-          Type: 8 BaseType int
-      Data: 176 GoSliceDataType []time.zoneTrans.array
-    - __kind: PointerType
-      ID: 81
-      Name: '*time.zoneTrans'
-      ByteSize: 8
-      GoRuntimeType: 367136
-      GoKind: 22
-      Pointee: 82 StructureType time.zoneTrans
-    - __kind: StructureType
-      ID: 82
-      Name: time.zoneTrans
+    - __kind: GoSliceDataType
+      ID: 172
+      Name: encoding/asn1.ObjectIdentifier.array
+      ByteSize: 2048
+      Element: 8 BaseType int
+    - __kind: GoInterfaceType
+      ID: 139
+      Name: error
       ByteSize: 16
-      GoRuntimeType: 1.623328e+06
-      GoKind: 25
+      GoRuntimeType: 987456
+      GoKind: 20
       RawFields:
-        - Name: when
+        - Name: tab
           Offset: 0
-          Type: 36 BaseType int64
-        - Name: index
+          Type: 2 VoidPointerType unsafe.Pointer
+        - Name: data
+          Offset: 8
+          Type: 2 VoidPointerType unsafe.Pointer
+    - __kind: BaseType
+      ID: 137
+      Name: float32
+      ByteSize: 4
+      GoRuntimeType: 534464
+      GoKind: 13
+    - __kind: BaseType
+      ID: 138
+      Name: float64
+      ByteSize: 8
+      GoRuntimeType: 534528
+      GoKind: 14
+    - __kind: GoSubroutineType
+      ID: 35
+      Name: func() (io.ReadCloser, error)
+      ByteSize: 8
+      GoRuntimeType: 634112
+      GoKind: 19
+    - __kind: GoSubroutineType
+      ID: 109
+      Name: func(string, []uint8, int) ([]uint8, error)
+      ByteSize: 8
+      GoRuntimeType: 960256
+      GoKind: 19
+    - __kind: GoInterfaceType
+      ID: 129
+      Name: gopkg.in/DataDog/dd-trace-go.v1/ddtrace.Span
+      ByteSize: 16
+      GoRuntimeType: 1.295936e+06
+      GoKind: 20
+      RawFields:
+        - Name: tab
+          Offset: 0
+          Type: 2 VoidPointerType unsafe.Pointer
+        - Name: data
+          Offset: 8
+          Type: 2 VoidPointerType unsafe.Pointer
+    - __kind: GoHMapHeaderType
+      ID: 43
+      Name: hash<string,[]*mime/multipart.FileHeader>
+      ByteSize: 48
+      RawFields:
+        - Name: count
+          Offset: 0
+          Type: 8 BaseType int
+        - Name: flags
           Offset: 8
           Type: 7 BaseType uint8
-        - Name: isstd
+        - Name: B
           Offset: 9
-          Type: 13 BaseType bool
-        - Name: isutc
+          Type: 7 BaseType uint8
+        - Name: noverflow
           Offset: 10
-          Type: 13 BaseType bool
-    - __kind: BaseType
-      ID: 83
-      Name: crypto/x509.KeyUsage
-      ByteSize: 8
-      GoRuntimeType: 537216
-      GoKind: 2
-    - __kind: GoSliceHeaderType
-      ID: 84
-      Name: '[]crypto/x509/pkix.Extension'
-      ByteSize: 24
-      GoRuntimeType: 481376
-      GoKind: 23
-      RawFields:
-        - Name: array
-          Offset: 0
-          Type: 85 PointerType *crypto/x509/pkix.Extension
-        - Name: len
-          Offset: 8
-          Type: 8 BaseType int
-        - Name: cap
+          Type: 17 BaseType uint16
+        - Name: hash0
+          Offset: 12
+          Type: 18 BaseType uint32
+        - Name: buckets
           Offset: 16
+          Type: 44 PointerType *bucket<string,[]*mime/multipart.FileHeader>
+        - Name: oldbuckets
+          Offset: 24
+          Type: 44 PointerType *bucket<string,[]*mime/multipart.FileHeader>
+        - Name: nevacuate
+          Offset: 32
+          Type: 26 BaseType uintptr
+        - Name: extra
+          Offset: 40
+          Type: 27 PointerType *runtime.mapextra
+      BucketType: 45 GoHMapBucketType bucket<string,[]*mime/multipart.FileHeader>
+      BucketsType: 161 GoSliceDataType []bucket<string,[]*mime/multipart.FileHeader>.array
+    - __kind: GoHMapHeaderType
+      ID: 16
+      Name: hash<string,[]string>
+      ByteSize: 48
+      RawFields:
+        - Name: count
+          Offset: 0
           Type: 8 BaseType int
-      Data: 178 GoSliceDataType []crypto/x509/pkix.Extension.array
-    - __kind: PointerType
-      ID: 85
-      Name: '*crypto/x509/pkix.Extension'
+        - Name: flags
+          Offset: 8
+          Type: 7 BaseType uint8
+        - Name: B
+          Offset: 9
+          Type: 7 BaseType uint8
+        - Name: noverflow
+          Offset: 10
+          Type: 17 BaseType uint16
+        - Name: hash0
+          Offset: 12
+          Type: 18 BaseType uint32
+        - Name: buckets
+          Offset: 16
+          Type: 19 PointerType *bucket<string,[]string>
+        - Name: oldbuckets
+          Offset: 24
+          Type: 19 PointerType *bucket<string,[]string>
+        - Name: nevacuate
+          Offset: 32
+          Type: 26 BaseType uintptr
+        - Name: extra
+          Offset: 40
+          Type: 27 PointerType *runtime.mapextra
+      BucketType: 20 GoHMapBucketType bucket<string,[]string>
+      BucketsType: 156 GoSliceDataType []bucket<string,[]string>.array
+    - __kind: GoHMapHeaderType
+      ID: 122
+      Name: hash<string,string>
+      ByteSize: 48
+      RawFields:
+        - Name: count
+          Offset: 0
+          Type: 8 BaseType int
+        - Name: flags
+          Offset: 8
+          Type: 7 BaseType uint8
+        - Name: B
+          Offset: 9
+          Type: 7 BaseType uint8
+        - Name: noverflow
+          Offset: 10
+          Type: 17 BaseType uint16
+        - Name: hash0
+          Offset: 12
+          Type: 18 BaseType uint32
+        - Name: buckets
+          Offset: 16
+          Type: 123 PointerType *bucket<string,string>
+        - Name: oldbuckets
+          Offset: 24
+          Type: 123 PointerType *bucket<string,string>
+        - Name: nevacuate
+          Offset: 32
+          Type: 26 BaseType uintptr
+        - Name: extra
+          Offset: 40
+          Type: 27 PointerType *runtime.mapextra
+      BucketType: 124 GoHMapBucketType bucket<string,string>
+      BucketsType: 202 GoSliceDataType []bucket<string,string>.array
+    - __kind: BaseType
+      ID: 8
+      Name: int
       ByteSize: 8
-      GoRuntimeType: 408992
-      GoKind: 22
-      Pointee: 86 StructureType crypto/x509/pkix.Extension
+      GoRuntimeType: 534144
+      GoKind: 2
+    - __kind: BaseType
+      ID: 149
+      Name: int16
+      ByteSize: 2
+      GoRuntimeType: 533760
+      GoKind: 4
+    - __kind: BaseType
+      ID: 134
+      Name: int32
+      ByteSize: 4
+      GoRuntimeType: 533888
+      GoKind: 5
+    - __kind: BaseType
+      ID: 36
+      Name: int64
+      ByteSize: 8
+      GoRuntimeType: 534016
+      GoKind: 6
+    - __kind: BaseType
+      ID: 135
+      Name: int8
+      ByteSize: 1
+      GoRuntimeType: 533632
+      GoKind: 3
+    - __kind: GoEmptyInterfaceType
+      ID: 61
+      Name: interface {}
+      ByteSize: 16
+      GoRuntimeType: 785376
+      GoKind: 20
+      RawFields:
+        - Name: _type
+          Offset: 0
+          Type: 2 VoidPointerType unsafe.Pointer
+        - Name: data
+          Offset: 8
+          Type: 2 VoidPointerType unsafe.Pointer
+    - __kind: GoInterfaceType
+      ID: 34
+      Name: io.ReadCloser
+      ByteSize: 16
+      GoRuntimeType: 1.067136e+06
+      GoKind: 20
+      RawFields:
+        - Name: tab
+          Offset: 0
+          Type: 2 VoidPointerType unsafe.Pointer
+        - Name: data
+          Offset: 8
+          Type: 2 VoidPointerType unsafe.Pointer
+    - __kind: GoMapType
+      ID: 41
+      Name: map[string][]*mime/multipart.FileHeader
+      ByteSize: 8
+      GoRuntimeType: 887296
+      GoKind: 21
+      HeaderType: 43 GoHMapHeaderType hash<string,[]*mime/multipart.FileHeader>
+    - __kind: GoMapType
+      ID: 40
+      Name: map[string][]string
+      ByteSize: 8
+      GoRuntimeType: 882496
+      GoKind: 21
+      HeaderType: 16 GoHMapHeaderType hash<string,[]string>
+    - __kind: GoMapType
+      ID: 120
+      Name: map[string]string
+      ByteSize: 8
+      GoRuntimeType: 884128
+      GoKind: 21
+      HeaderType: 122 GoHMapHeaderType hash<string,string>
     - __kind: StructureType
-      ID: 86
-      Name: crypto/x509/pkix.Extension
-      ByteSize: 56
-      GoRuntimeType: 1.455008e+06
+      ID: 63
+      Name: math/big.Int
+      ByteSize: 32
+      GoRuntimeType: 1.308416e+06
       GoKind: 25
       RawFields:
-        - Name: Id
+        - Name: neg
           Offset: 0
-          Type: 71 GoSliceHeaderType encoding/asn1.ObjectIdentifier
-        - Name: Critical
-          Offset: 24
           Type: 13 BaseType bool
-        - Name: Value
+        - Name: abs
+          Offset: 8
+          Type: 64 GoSliceHeaderType math/big.nat
+    - __kind: BaseType
+      ID: 66
+      Name: math/big.Word
+      ByteSize: 8
+      GoRuntimeType: 537536
+      GoKind: 7
+    - __kind: GoSliceHeaderType
+      ID: 64
+      Name: math/big.nat
+      ByteSize: 24
+      GoRuntimeType: 2.21424e+06
+      GoKind: 23
+      RawFields:
+        - Name: array
+          Offset: 0
+          Type: 65 PointerType *math/big.Word
+        - Name: len
+          Offset: 8
+          Type: 8 BaseType int
+        - Name: cap
+          Offset: 16
+          Type: 8 BaseType int
+      Data: 168 GoSliceDataType math/big.nat.array
+    - __kind: GoSliceDataType
+      ID: 168
+      Name: math/big.nat.array
+      ByteSize: 2048
+      Element: 66 BaseType math/big.Word
+    - __kind: StructureType
+      ID: 50
+      Name: mime/multipart.FileHeader
+      ByteSize: 88
+      GoRuntimeType: 1.838016e+06
+      GoKind: 25
+      RawFields:
+        - Name: Filename
+          Offset: 0
+          Type: 5 GoStringHeaderType string
+        - Name: Header
+          Offset: 16
+          Type: 51 GoMapType net/textproto.MIMEHeader
+        - Name: Size
+          Offset: 24
+          Type: 36 BaseType int64
+        - Name: content
           Offset: 32
           Type: 52 GoSliceHeaderType []uint8
-    - __kind: GoSliceHeaderType
-      ID: 87
-      Name: '[]encoding/asn1.ObjectIdentifier'
-      ByteSize: 24
-      GoRuntimeType: 481440
-      GoKind: 23
+        - Name: tmpfile
+          Offset: 56
+          Type: 5 GoStringHeaderType string
+        - Name: tmpoff
+          Offset: 72
+          Type: 36 BaseType int64
+        - Name: tmpshared
+          Offset: 80
+          Type: 13 BaseType bool
+    - __kind: StructureType
+      ID: 39
+      Name: mime/multipart.Form
+      ByteSize: 16
+      GoRuntimeType: 1.294336e+06
+      GoKind: 25
       RawFields:
-        - Name: array
+        - Name: Value
           Offset: 0
-          Type: 88 PointerType *encoding/asn1.ObjectIdentifier
-        - Name: len
+          Type: 40 GoMapType map[string][]string
+        - Name: File
           Offset: 8
-          Type: 8 BaseType int
-        - Name: cap
-          Offset: 16
-          Type: 8 BaseType int
-      Data: 180 GoSliceDataType []encoding/asn1.ObjectIdentifier.array
-    - __kind: PointerType
-      ID: 88
-      Name: '*encoding/asn1.ObjectIdentifier'
-      ByteSize: 8
-      GoRuntimeType: 1.009728e+06
-      GoKind: 22
-      Pointee: 71 GoSliceHeaderType encoding/asn1.ObjectIdentifier
-    - __kind: GoSliceHeaderType
-      ID: 89
-      Name: '[]crypto/x509.ExtKeyUsage'
-      ByteSize: 24
-      GoRuntimeType: 470816
-      GoKind: 23
-      RawFields:
-        - Name: array
-          Offset: 0
-          Type: 90 PointerType *crypto/x509.ExtKeyUsage
-        - Name: len
-          Offset: 8
-          Type: 8 BaseType int
-        - Name: cap
-          Offset: 16
-          Type: 8 BaseType int
-      Data: 182 GoSliceDataType []crypto/x509.ExtKeyUsage.array
-    - __kind: PointerType
-      ID: 90
-      Name: '*crypto/x509.ExtKeyUsage'
-      ByteSize: 8
-      GoRuntimeType: 395040
-      GoKind: 22
-      Pointee: 91 BaseType crypto/x509.ExtKeyUsage
-    - __kind: BaseType
-      ID: 91
-      Name: crypto/x509.ExtKeyUsage
-      ByteSize: 8
-      GoRuntimeType: 537280
-      GoKind: 2
-    - __kind: GoSliceHeaderType
-      ID: 92
-      Name: '[]net.IP'
-      ByteSize: 24
-      GoRuntimeType: 454048
-      GoKind: 23
-      RawFields:
-        - Name: array
-          Offset: 0
-          Type: 93 PointerType *net.IP
-        - Name: len
-          Offset: 8
-          Type: 8 BaseType int
-        - Name: cap
-          Offset: 16
-          Type: 8 BaseType int
-      Data: 184 GoSliceDataType []net.IP.array
-    - __kind: PointerType
-      ID: 93
-      Name: '*net.IP'
-      ByteSize: 8
-      GoRuntimeType: 1.974144e+06
-      GoKind: 22
-      Pointee: 94 GoSliceHeaderType net.IP
+          Type: 41 GoMapType map[string][]*mime/multipart.FileHeader
     - __kind: GoSliceHeaderType
       ID: 94
       Name: net.IP
@@ -1452,72 +1873,11 @@ Types:
           Offset: 16
           Type: 8 BaseType int
       Data: 186 GoSliceDataType net.IP.array
-    - __kind: GoSliceHeaderType
-      ID: 95
-      Name: '[]*net/url.URL'
-      ByteSize: 24
-      GoRuntimeType: 481504
-      GoKind: 23
-      RawFields:
-        - Name: array
-          Offset: 0
-          Type: 96 PointerType **net/url.URL
-        - Name: len
-          Offset: 8
-          Type: 8 BaseType int
-        - Name: cap
-          Offset: 16
-          Type: 8 BaseType int
-      Data: 188 GoSliceDataType []*net/url.URL.array
-    - __kind: PointerType
-      ID: 96
-      Name: '**net/url.URL'
-      ByteSize: 8
-      GoKind: 22
-      Pointee: 9 PointerType *net/url.URL
-    - __kind: GoSliceHeaderType
-      ID: 97
-      Name: '[]*net.IPNet'
-      ByteSize: 24
-      GoRuntimeType: 481568
-      GoKind: 23
-      RawFields:
-        - Name: array
-          Offset: 0
-          Type: 98 PointerType **net.IPNet
-        - Name: len
-          Offset: 8
-          Type: 8 BaseType int
-        - Name: cap
-          Offset: 16
-          Type: 8 BaseType int
-      Data: 190 GoSliceDataType []*net.IPNet.array
-    - __kind: PointerType
-      ID: 98
-      Name: '**net.IPNet'
-      ByteSize: 8
-      GoKind: 22
-      Pointee: 99 PointerType *net.IPNet
-    - __kind: PointerType
-      ID: 99
-      Name: '*net.IPNet'
-      ByteSize: 8
-      GoRuntimeType: 1.095776e+06
-      GoKind: 22
-      Pointee: 100 StructureType net.IPNet
-    - __kind: StructureType
-      ID: 100
-      Name: net.IPNet
-      ByteSize: 48
-      GoRuntimeType: 1.275936e+06
-      GoKind: 25
-      RawFields:
-        - Name: IP
-          Offset: 0
-          Type: 94 GoSliceHeaderType net.IP
-        - Name: Mask
-          Offset: 24
-          Type: 101 GoSliceHeaderType net.IPMask
+    - __kind: GoSliceDataType
+      ID: 186
+      Name: net.IP.array
+      ByteSize: 2048
+      Element: 7 BaseType uint8
     - __kind: GoSliceHeaderType
       ID: 101
       Name: net.IPMask
@@ -1535,111 +1895,116 @@ Types:
           Offset: 16
           Type: 8 BaseType int
       Data: 192 GoSliceDataType net.IPMask.array
-    - __kind: GoSliceHeaderType
-      ID: 102
-      Name: '[]crypto/x509.OID'
-      ByteSize: 24
-      GoRuntimeType: 481632
-      GoKind: 23
-      RawFields:
-        - Name: array
-          Offset: 0
-          Type: 103 PointerType *crypto/x509.OID
-        - Name: len
-          Offset: 8
-          Type: 8 BaseType int
-        - Name: cap
-          Offset: 16
-          Type: 8 BaseType int
-      Data: 194 GoSliceDataType []crypto/x509.OID.array
-    - __kind: PointerType
-      ID: 103
-      Name: '*crypto/x509.OID'
-      ByteSize: 8
-      GoRuntimeType: 1.717248e+06
-      GoKind: 22
-      Pointee: 104 StructureType crypto/x509.OID
+    - __kind: GoSliceDataType
+      ID: 192
+      Name: net.IPMask.array
+      ByteSize: 2048
+      Element: 7 BaseType uint8
     - __kind: StructureType
-      ID: 104
-      Name: crypto/x509.OID
-      ByteSize: 24
-      GoRuntimeType: 1.717472e+06
+      ID: 100
+      Name: net.IPNet
+      ByteSize: 48
+      GoRuntimeType: 1.275936e+06
       GoKind: 25
       RawFields:
-        - Name: der
+        - Name: IP
           Offset: 0
-          Type: 52 GoSliceHeaderType []uint8
-    - __kind: GoSliceHeaderType
-      ID: 105
-      Name: '[][]*crypto/x509.Certificate'
-      ByteSize: 24
-      GoRuntimeType: 469664
-      GoKind: 23
+          Type: 94 GoSliceHeaderType net.IP
+        - Name: Mask
+          Offset: 24
+          Type: 101 GoSliceHeaderType net.IPMask
+    - __kind: GoMapType
+      ID: 14
+      Name: net/http.Header
+      ByteSize: 8
+      GoRuntimeType: 1.91744e+06
+      GoKind: 21
+      HeaderType: 16 GoHMapHeaderType hash<string,[]string>
+    - __kind: StructureType
+      ID: 4
+      Name: net/http.Request
+      ByteSize: 304
+      GoRuntimeType: 2.189984e+06
+      GoKind: 25
       RawFields:
-        - Name: array
+        - Name: Method
           Offset: 0
-          Type: 106 PointerType *[]*crypto/x509.Certificate
-        - Name: len
-          Offset: 8
-          Type: 8 BaseType int
-        - Name: cap
+          Type: 5 GoStringHeaderType string
+        - Name: URL
           Offset: 16
+          Type: 9 PointerType *net/url.URL
+        - Name: Proto
+          Offset: 24
+          Type: 5 GoStringHeaderType string
+        - Name: ProtoMajor
+          Offset: 40
           Type: 8 BaseType int
-      Data: 196 GoSliceDataType [][]*crypto/x509.Certificate.array
-    - __kind: PointerType
-      ID: 106
-      Name: '*[]*crypto/x509.Certificate'
-      ByteSize: 8
-      GoKind: 22
-      Pointee: 55 GoSliceHeaderType []*crypto/x509.Certificate
-    - __kind: GoSliceHeaderType
-      ID: 107
-      Name: '[][]uint8'
-      ByteSize: 24
-      GoRuntimeType: 452832
-      GoKind: 23
-      RawFields:
-        - Name: array
-          Offset: 0
-          Type: 108 PointerType *[]uint8
-        - Name: len
-          Offset: 8
+        - Name: ProtoMinor
+          Offset: 48
           Type: 8 BaseType int
-        - Name: cap
-          Offset: 16
-          Type: 8 BaseType int
-      Data: 198 GoSliceDataType [][]uint8.array
-    - __kind: PointerType
-      ID: 108
-      Name: '*[]uint8'
-      ByteSize: 8
-      GoRuntimeType: 452512
-      GoKind: 22
-      Pointee: 52 GoSliceHeaderType []uint8
-    - __kind: GoSubroutineType
-      ID: 109
-      Name: func(string, []uint8, int) ([]uint8, error)
-      ByteSize: 8
-      GoRuntimeType: 960256
-      GoKind: 19
-    - __kind: BaseType
-      ID: 110
-      Name: crypto/tls.CurveID
-      ByteSize: 2
-      GoRuntimeType: 766048
-      GoKind: 9
-    - __kind: GoChannelType
-      ID: 111
-      Name: <-chan struct {}
-      GoRuntimeType: 546752
-      GoKind: 18
-    - __kind: PointerType
-      ID: 112
-      Name: '*net/http.Response'
-      ByteSize: 8
-      GoRuntimeType: 1.590912e+06
-      GoKind: 22
-      Pointee: 113 StructureType net/http.Response
+        - Name: Header
+          Offset: 56
+          Type: 14 GoMapType net/http.Header
+        - Name: Body
+          Offset: 64
+          Type: 34 GoInterfaceType io.ReadCloser
+        - Name: GetBody
+          Offset: 80
+          Type: 35 GoSubroutineType func() (io.ReadCloser, error)
+        - Name: ContentLength
+          Offset: 88
+          Type: 36 BaseType int64
+        - Name: TransferEncoding
+          Offset: 96
+          Type: 24 GoSliceHeaderType []string
+        - Name: Close
+          Offset: 120
+          Type: 13 BaseType bool
+        - Name: Host
+          Offset: 128
+          Type: 5 GoStringHeaderType string
+        - Name: Form
+          Offset: 144
+          Type: 37 GoMapType net/url.Values
+        - Name: PostForm
+          Offset: 152
+          Type: 37 GoMapType net/url.Values
+        - Name: MultipartForm
+          Offset: 160
+          Type: 38 PointerType *mime/multipart.Form
+        - Name: Trailer
+          Offset: 168
+          Type: 14 GoMapType net/http.Header
+        - Name: RemoteAddr
+          Offset: 176
+          Type: 5 GoStringHeaderType string
+        - Name: RequestURI
+          Offset: 192
+          Type: 5 GoStringHeaderType string
+        - Name: TLS
+          Offset: 208
+          Type: 53 PointerType *crypto/tls.ConnectionState
+        - Name: Cancel
+          Offset: 216
+          Type: 111 GoChannelType <-chan struct {}
+        - Name: Response
+          Offset: 224
+          Type: 112 PointerType *net/http.Response
+        - Name: Pattern
+          Offset: 232
+          Type: 5 GoStringHeaderType string
+        - Name: ctx
+          Offset: 248
+          Type: 114 GoInterfaceType context.Context
+        - Name: pat
+          Offset: 264
+          Type: 115 PointerType *net/http.pattern
+        - Name: matches
+          Offset: 272
+          Type: 24 GoSliceHeaderType []string
+        - Name: otherValues
+          Offset: 296
+          Type: 120 GoMapType map[string]string
     - __kind: StructureType
       ID: 113
       Name: net/http.Response
@@ -1690,10 +2055,10 @@ Types:
           Offset: 136
           Type: 53 PointerType *crypto/tls.ConnectionState
     - __kind: GoInterfaceType
-      ID: 114
-      Name: context.Context
+      ID: 1
+      Name: net/http.ResponseWriter
       ByteSize: 16
-      GoRuntimeType: 1.187104e+06
+      GoRuntimeType: 1.098336e+06
       GoKind: 20
       RawFields:
         - Name: tab
@@ -1702,13 +2067,6 @@ Types:
         - Name: data
           Offset: 8
           Type: 2 VoidPointerType unsafe.Pointer
-    - __kind: PointerType
-      ID: 115
-      Name: '*net/http.pattern'
-      ByteSize: 8
-      GoRuntimeType: 1.416224e+06
-      GoKind: 22
-      Pointee: 116 StructureType net/http.pattern
     - __kind: StructureType
       ID: 116
       Name: net/http.pattern
@@ -1731,30 +2089,6 @@ Types:
         - Name: loc
           Offset: 72
           Type: 5 GoStringHeaderType string
-    - __kind: GoSliceHeaderType
-      ID: 117
-      Name: '[]net/http.segment'
-      ByteSize: 24
-      GoRuntimeType: 454816
-      GoKind: 23
-      RawFields:
-        - Name: array
-          Offset: 0
-          Type: 118 PointerType *net/http.segment
-        - Name: len
-          Offset: 8
-          Type: 8 BaseType int
-        - Name: cap
-          Offset: 16
-          Type: 8 BaseType int
-      Data: 200 GoSliceDataType []net/http.segment.array
-    - __kind: PointerType
-      ID: 118
-      Name: '*net/http.segment'
-      ByteSize: 8
-      GoRuntimeType: 364000
-      GoKind: 22
-      Pointee: 119 StructureType net/http.segment
     - __kind: StructureType
       ID: 119
       Name: net/http.segment
@@ -1772,165 +2106,198 @@ Types:
           Offset: 17
           Type: 13 BaseType bool
     - __kind: GoMapType
-      ID: 120
-      Name: map[string]string
+      ID: 51
+      Name: net/textproto.MIMEHeader
       ByteSize: 8
-      GoRuntimeType: 884128
+      GoRuntimeType: 1.595904e+06
       GoKind: 21
-      HeaderType: 122 GoHMapHeaderType hash<string,string>
-    - __kind: PointerType
-      ID: 121
-      Name: '*hash<string,string>'
-      ByteSize: 8
-      Pointee: 122 GoHMapHeaderType hash<string,string>
-    - __kind: GoHMapHeaderType
-      ID: 122
-      Name: hash<string,string>
-      ByteSize: 48
+      HeaderType: 16 GoHMapHeaderType hash<string,[]string>
+    - __kind: StructureType
+      ID: 10
+      Name: net/url.URL
+      ByteSize: 144
+      GoRuntimeType: 1.986272e+06
+      GoKind: 25
       RawFields:
-        - Name: count
+        - Name: Scheme
           Offset: 0
-          Type: 8 BaseType int
-        - Name: flags
-          Offset: 8
-          Type: 7 BaseType uint8
-        - Name: B
-          Offset: 9
-          Type: 7 BaseType uint8
-        - Name: noverflow
-          Offset: 10
-          Type: 17 BaseType uint16
-        - Name: hash0
-          Offset: 12
-          Type: 18 BaseType uint32
-        - Name: buckets
+          Type: 5 GoStringHeaderType string
+        - Name: Opaque
           Offset: 16
-          Type: 123 PointerType *bucket<string,string>
-        - Name: oldbuckets
-          Offset: 24
-          Type: 123 PointerType *bucket<string,string>
-        - Name: nevacuate
+          Type: 5 GoStringHeaderType string
+        - Name: User
           Offset: 32
-          Type: 26 BaseType uintptr
-        - Name: extra
+          Type: 11 PointerType *net/url.Userinfo
+        - Name: Host
           Offset: 40
-          Type: 27 PointerType *runtime.mapextra
-      BucketType: 124 GoHMapBucketType bucket<string,string>
-      BucketsType: 202 GoSliceDataType []bucket<string,string>.array
-    - __kind: PointerType
-      ID: 123
-      Name: '*bucket<string,string>'
+          Type: 5 GoStringHeaderType string
+        - Name: Path
+          Offset: 56
+          Type: 5 GoStringHeaderType string
+        - Name: RawPath
+          Offset: 72
+          Type: 5 GoStringHeaderType string
+        - Name: OmitHost
+          Offset: 88
+          Type: 13 BaseType bool
+        - Name: ForceQuery
+          Offset: 89
+          Type: 13 BaseType bool
+        - Name: RawQuery
+          Offset: 96
+          Type: 5 GoStringHeaderType string
+        - Name: Fragment
+          Offset: 112
+          Type: 5 GoStringHeaderType string
+        - Name: RawFragment
+          Offset: 128
+          Type: 5 GoStringHeaderType string
+    - __kind: StructureType
+      ID: 12
+      Name: net/url.Userinfo
+      ByteSize: 40
+      GoRuntimeType: 1.432736e+06
+      GoKind: 25
+      RawFields:
+        - Name: username
+          Offset: 0
+          Type: 5 GoStringHeaderType string
+        - Name: password
+          Offset: 16
+          Type: 5 GoStringHeaderType string
+        - Name: passwordSet
+          Offset: 32
+          Type: 13 BaseType bool
+    - __kind: GoMapType
+      ID: 37
+      Name: net/url.Values
       ByteSize: 8
-      Pointee: 124 GoHMapBucketType bucket<string,string>
-    - __kind: GoHMapBucketType
-      ID: 124
-      Name: bucket<string,string>
-      ByteSize: 272
+      GoRuntimeType: 1.670784e+06
+      GoKind: 21
+      HeaderType: 16 GoHMapHeaderType hash<string,[]string>
+    - __kind: StructureType
+      ID: 33
+      Name: runtime.bmap
+      ByteSize: 8
+      GoRuntimeType: 1.109728e+06
+      GoKind: 25
       RawFields:
         - Name: tophash
           Offset: 0
           Type: 21 ArrayType [8]uint8
-        - Name: keys
-          Offset: 8
-          Type: 22 ArrayType []key<string>
-        - Name: values
-          Offset: 136
-          Type: 125 ArrayType []val<string>
+    - __kind: StructureType
+      ID: 28
+      Name: runtime.mapextra
+      ByteSize: 24
+      GoRuntimeType: 1.428704e+06
+      GoKind: 25
+      RawFields:
         - Name: overflow
-          Offset: 264
-          Type: 123 PointerType *bucket<string,string>
-      KeyType: 5 GoStringHeaderType string
-      ValueType: 5 GoStringHeaderType string
-    - __kind: ArrayType
-      ID: 125
-      Name: '[]val<string>'
-      ByteSize: 128
-      Count: 8
-      HasCount: true
-      Element: 5 GoStringHeaderType string
-    - __kind: PointerType
-      ID: 126
-      Name: '*bytes.Buffer'
-      ByteSize: 8
-      GoRuntimeType: 2.114976e+06
-      GoKind: 22
-      Pointee: 127 StructureType bytes.Buffer
-    - __kind: StructureType
-      ID: 127
-      Name: bytes.Buffer
-      ByteSize: 40
-      GoRuntimeType: 1.41392e+06
-      GoKind: 25
-      RawFields:
-        - Name: buf
           Offset: 0
-          Type: 52 GoSliceHeaderType []uint8
-        - Name: off
-          Offset: 24
-          Type: 8 BaseType int
-        - Name: lastRead
-          Offset: 32
-          Type: 128 BaseType bytes.readOp
-    - __kind: BaseType
-      ID: 128
-      Name: bytes.readOp
-      ByteSize: 1
-      GoRuntimeType: 532800
-      GoKind: 3
-    - __kind: GoInterfaceType
-      ID: 129
-      Name: gopkg.in/DataDog/dd-trace-go.v1/ddtrace.Span
-      ByteSize: 16
-      GoRuntimeType: 1.295936e+06
-      GoKind: 20
-      RawFields:
-        - Name: tab
-          Offset: 0
-          Type: 2 VoidPointerType unsafe.Pointer
-        - Name: data
+          Type: 29 PointerType *[]*runtime.bmap
+        - Name: oldoverflow
           Offset: 8
-          Type: 2 VoidPointerType unsafe.Pointer
+          Type: 29 PointerType *[]*runtime.bmap
+        - Name: nextOverflow
+          Offset: 16
+          Type: 32 PointerType *runtime.bmap
+    - __kind: GoStringHeaderType
+      ID: 5
+      Name: string
+      ByteSize: 16
+      GoRuntimeType: 533568
+      GoKind: 24
+      RawFields:
+        - Name: str
+          Offset: 0
+          Type: 155 PointerType *string.str
+        - Name: len
+          Offset: 8
+          Type: 8 BaseType int
+      Data: 154 GoStringDataType string.str
+    - __kind: GoStringDataType
+      ID: 154
+      Name: string.str
+      ByteSize: 2048
     - __kind: StructureType
-      ID: 130
-      Name: context.backgroundCtx
-      GoRuntimeType: 1.6672e+06
+      ID: 76
+      Name: time.Location
+      ByteSize: 104
+      GoRuntimeType: 1.833984e+06
       GoKind: 25
       RawFields:
-        - Name: emptyCtx
+        - Name: name
           Offset: 0
-          Type: 131 StructureType context.emptyCtx
+          Type: 5 GoStringHeaderType string
+        - Name: zone
+          Offset: 16
+          Type: 77 GoSliceHeaderType []time.zone
+        - Name: tx
+          Offset: 40
+          Type: 80 GoSliceHeaderType []time.zoneTrans
+        - Name: extend
+          Offset: 64
+          Type: 5 GoStringHeaderType string
+        - Name: cacheStart
+          Offset: 80
+          Type: 36 BaseType int64
+        - Name: cacheEnd
+          Offset: 88
+          Type: 36 BaseType int64
+        - Name: cacheZone
+          Offset: 96
+          Type: 78 PointerType *time.zone
     - __kind: StructureType
-      ID: 131
-      Name: context.emptyCtx
-      GoRuntimeType: 1.399456e+06
+      ID: 73
+      Name: time.Time
+      ByteSize: 24
+      GoRuntimeType: 2.215168e+06
       GoKind: 25
-      RawFields: []
-    - __kind: PointerType
-      ID: 132
-      Name: '*bool'
-      ByteSize: 8
-      GoRuntimeType: 372640
-      GoKind: 22
-      Pointee: 13 BaseType bool
-    - __kind: PointerType
-      ID: 133
-      Name: '*uintptr'
-      ByteSize: 8
-      GoRuntimeType: 372320
-      GoKind: 22
-      Pointee: 26 BaseType uintptr
-    - __kind: BaseType
-      ID: 134
-      Name: int32
-      ByteSize: 4
-      GoRuntimeType: 533888
-      GoKind: 5
-    - __kind: BaseType
-      ID: 135
-      Name: int8
-      ByteSize: 1
-      GoRuntimeType: 533632
-      GoKind: 3
+      RawFields:
+        - Name: wall
+          Offset: 0
+          Type: 74 BaseType uint64
+        - Name: ext
+          Offset: 8
+          Type: 36 BaseType int64
+        - Name: loc
+          Offset: 16
+          Type: 75 PointerType *time.Location
+    - __kind: StructureType
+      ID: 79
+      Name: time.zone
+      ByteSize: 32
+      GoRuntimeType: 1.421024e+06
+      GoKind: 25
+      RawFields:
+        - Name: name
+          Offset: 0
+          Type: 5 GoStringHeaderType string
+        - Name: offset
+          Offset: 16
+          Type: 8 BaseType int
+        - Name: isDST
+          Offset: 24
+          Type: 13 BaseType bool
+    - __kind: StructureType
+      ID: 82
+      Name: time.zoneTrans
+      ByteSize: 16
+      GoRuntimeType: 1.623328e+06
+      GoKind: 25
+      RawFields:
+        - Name: when
+          Offset: 0
+          Type: 36 BaseType int64
+        - Name: index
+          Offset: 8
+          Type: 7 BaseType uint8
+        - Name: isstd
+          Offset: 9
+          Type: 13 BaseType bool
+        - Name: isutc
+          Offset: 10
+          Type: 13 BaseType bool
     - __kind: BaseType
       ID: 136
       Name: uint
@@ -1938,408 +2305,41 @@ Types:
       GoRuntimeType: 534208
       GoKind: 7
     - __kind: BaseType
-      ID: 137
-      Name: float32
-      ByteSize: 4
-      GoRuntimeType: 534464
-      GoKind: 13
-    - __kind: BaseType
-      ID: 138
-      Name: float64
-      ByteSize: 8
-      GoRuntimeType: 534528
-      GoKind: 14
-    - __kind: GoInterfaceType
-      ID: 139
-      Name: error
-      ByteSize: 16
-      GoRuntimeType: 987456
-      GoKind: 20
-      RawFields:
-        - Name: tab
-          Offset: 0
-          Type: 2 VoidPointerType unsafe.Pointer
-        - Name: data
-          Offset: 8
-          Type: 2 VoidPointerType unsafe.Pointer
-    - __kind: PointerType
-      ID: 140
-      Name: '*int32'
-      ByteSize: 8
-      GoRuntimeType: 371936
-      GoKind: 22
-      Pointee: 134 BaseType int32
-    - __kind: PointerType
-      ID: 141
-      Name: '*uint32'
-      ByteSize: 8
-      GoRuntimeType: 372000
-      GoKind: 22
-      Pointee: 18 BaseType uint32
-    - __kind: BaseType
-      ID: 142
-      Name: complex64
-      ByteSize: 8
-      GoRuntimeType: 534336
-      GoKind: 15
-    - __kind: BaseType
-      ID: 143
-      Name: complex128
-      ByteSize: 16
-      GoRuntimeType: 534400
-      GoKind: 16
-    - __kind: PointerType
-      ID: 144
-      Name: '*float64'
-      ByteSize: 8
-      GoRuntimeType: 372576
-      GoKind: 22
-      Pointee: 138 BaseType float64
-    - __kind: PointerType
-      ID: 145
-      Name: '*int64'
-      ByteSize: 8
-      GoRuntimeType: 372064
-      GoKind: 22
-      Pointee: 36 BaseType int64
-    - __kind: PointerType
-      ID: 146
-      Name: '*uint64'
-      ByteSize: 8
-      GoRuntimeType: 372128
-      GoKind: 22
-      Pointee: 74 BaseType uint64
-    - __kind: PointerType
-      ID: 147
-      Name: '*uint16'
-      ByteSize: 8
-      GoRuntimeType: 371872
-      GoKind: 22
-      Pointee: 17 BaseType uint16
-    - __kind: PointerType
-      ID: 148
-      Name: '*int16'
-      ByteSize: 8
-      GoRuntimeType: 371808
-      GoKind: 22
-      Pointee: 149 BaseType int16
-    - __kind: BaseType
-      ID: 149
-      Name: int16
+      ID: 17
+      Name: uint16
       ByteSize: 2
-      GoRuntimeType: 533760
-      GoKind: 4
-    - __kind: PointerType
-      ID: 150
-      Name: '*int8'
+      GoRuntimeType: 533824
+      GoKind: 9
+    - __kind: BaseType
+      ID: 18
+      Name: uint32
+      ByteSize: 4
+      GoRuntimeType: 533952
+      GoKind: 10
+    - __kind: BaseType
+      ID: 74
+      Name: uint64
       ByteSize: 8
-      GoRuntimeType: 371680
-      GoKind: 22
-      Pointee: 135 BaseType int8
-    - __kind: PointerType
-      ID: 151
-      Name: '*error'
+      GoRuntimeType: 534080
+      GoKind: 11
+    - __kind: BaseType
+      ID: 7
+      Name: uint8
+      ByteSize: 1
+      GoRuntimeType: 533696
+      GoKind: 8
+    - __kind: BaseType
+      ID: 26
+      Name: uintptr
       ByteSize: 8
-      GoRuntimeType: 371552
-      GoKind: 22
-      Pointee: 139 GoInterfaceType error
-    - __kind: PointerType
-      ID: 152
-      Name: '*uint'
+      GoRuntimeType: 534272
+      GoKind: 12
+    - __kind: VoidPointerType
+      ID: 2
+      Name: unsafe.Pointer
       ByteSize: 8
-      GoRuntimeType: 372256
-      GoKind: 22
-      Pointee: 136 BaseType uint
-    - __kind: PointerType
-      ID: 153
-      Name: '*float32'
-      ByteSize: 8
-      GoRuntimeType: 372512
-      GoKind: 22
-      Pointee: 137 BaseType float32
-    - __kind: GoStringDataType
-      ID: 154
-      Name: string.str
-      ByteSize: 2048
-    - __kind: PointerType
-      ID: 155
-      Name: '*string.str'
-      ByteSize: 8
-      Pointee: 154 GoStringDataType string.str
-    - __kind: GoSliceDataType
-      ID: 156
-      Name: '[]bucket<string,[]string>.array'
-      ByteSize: 2048
-      Element: 20 GoHMapBucketType bucket<string,[]string>
-    - __kind: GoSliceDataType
-      ID: 157
-      Name: '[]string.array'
-      ByteSize: 2048
-      Element: 5 GoStringHeaderType string
-    - __kind: PointerType
-      ID: 158
-      Name: '*[]string.array'
-      ByteSize: 8
-      Pointee: 157 GoSliceDataType []string.array
-    - __kind: GoSliceDataType
-      ID: 159
-      Name: '[]*runtime.bmap.array'
-      ByteSize: 2048
-      Element: 32 PointerType *runtime.bmap
-    - __kind: PointerType
-      ID: 160
-      Name: '*[]*runtime.bmap.array'
-      ByteSize: 8
-      Pointee: 159 GoSliceDataType []*runtime.bmap.array
-    - __kind: GoSliceDataType
-      ID: 161
-      Name: '[]bucket<string,[]*mime/multipart.FileHeader>.array'
-      ByteSize: 2048
-      Element: 45 GoHMapBucketType bucket<string,[]*mime/multipart.FileHeader>
-    - __kind: GoSliceDataType
-      ID: 162
-      Name: '[]*mime/multipart.FileHeader.array'
-      ByteSize: 2048
-      Element: 49 PointerType *mime/multipart.FileHeader
-    - __kind: PointerType
-      ID: 163
-      Name: '*[]*mime/multipart.FileHeader.array'
-      ByteSize: 8
-      Pointee: 162 GoSliceDataType []*mime/multipart.FileHeader.array
-    - __kind: GoSliceDataType
-      ID: 164
-      Name: '[]uint8.array'
-      ByteSize: 2048
-      Element: 7 BaseType uint8
-    - __kind: PointerType
-      ID: 165
-      Name: '*[]uint8.array'
-      ByteSize: 8
-      Pointee: 164 GoSliceDataType []uint8.array
-    - __kind: GoSliceDataType
-      ID: 166
-      Name: '[]*crypto/x509.Certificate.array'
-      ByteSize: 2048
-      Element: 57 PointerType *crypto/x509.Certificate
-    - __kind: PointerType
-      ID: 167
-      Name: '*[]*crypto/x509.Certificate.array'
-      ByteSize: 8
-      Pointee: 166 GoSliceDataType []*crypto/x509.Certificate.array
-    - __kind: GoSliceDataType
-      ID: 168
-      Name: math/big.nat.array
-      ByteSize: 2048
-      Element: 66 BaseType math/big.Word
-    - __kind: PointerType
-      ID: 169
-      Name: '*math/big.nat.array'
-      ByteSize: 8
-      Pointee: 168 GoSliceDataType math/big.nat.array
-    - __kind: GoSliceDataType
-      ID: 170
-      Name: '[]crypto/x509/pkix.AttributeTypeAndValue.array'
-      ByteSize: 2048
-      Element: 70 StructureType crypto/x509/pkix.AttributeTypeAndValue
-    - __kind: PointerType
-      ID: 171
-      Name: '*[]crypto/x509/pkix.AttributeTypeAndValue.array'
-      ByteSize: 8
-      Pointee: 170 GoSliceDataType []crypto/x509/pkix.AttributeTypeAndValue.array
-    - __kind: GoSliceDataType
-      ID: 172
-      Name: encoding/asn1.ObjectIdentifier.array
-      ByteSize: 2048
-      Element: 8 BaseType int
-    - __kind: PointerType
-      ID: 173
-      Name: '*encoding/asn1.ObjectIdentifier.array'
-      ByteSize: 8
-      Pointee: 172 GoSliceDataType encoding/asn1.ObjectIdentifier.array
-    - __kind: GoSliceDataType
-      ID: 174
-      Name: '[]time.zone.array'
-      ByteSize: 2048
-      Element: 79 StructureType time.zone
-    - __kind: PointerType
-      ID: 175
-      Name: '*[]time.zone.array'
-      ByteSize: 8
-      Pointee: 174 GoSliceDataType []time.zone.array
-    - __kind: GoSliceDataType
-      ID: 176
-      Name: '[]time.zoneTrans.array'
-      ByteSize: 2048
-      Element: 82 StructureType time.zoneTrans
-    - __kind: PointerType
-      ID: 177
-      Name: '*[]time.zoneTrans.array'
-      ByteSize: 8
-      Pointee: 176 GoSliceDataType []time.zoneTrans.array
-    - __kind: GoSliceDataType
-      ID: 178
-      Name: '[]crypto/x509/pkix.Extension.array'
-      ByteSize: 2048
-      Element: 86 StructureType crypto/x509/pkix.Extension
-    - __kind: PointerType
-      ID: 179
-      Name: '*[]crypto/x509/pkix.Extension.array'
-      ByteSize: 8
-      Pointee: 178 GoSliceDataType []crypto/x509/pkix.Extension.array
-    - __kind: GoSliceDataType
-      ID: 180
-      Name: '[]encoding/asn1.ObjectIdentifier.array'
-      ByteSize: 2048
-      Element: 71 GoSliceHeaderType encoding/asn1.ObjectIdentifier
-    - __kind: PointerType
-      ID: 181
-      Name: '*[]encoding/asn1.ObjectIdentifier.array'
-      ByteSize: 8
-      Pointee: 180 GoSliceDataType []encoding/asn1.ObjectIdentifier.array
-    - __kind: GoSliceDataType
-      ID: 182
-      Name: '[]crypto/x509.ExtKeyUsage.array'
-      ByteSize: 2048
-      Element: 91 BaseType crypto/x509.ExtKeyUsage
-    - __kind: PointerType
-      ID: 183
-      Name: '*[]crypto/x509.ExtKeyUsage.array'
-      ByteSize: 8
-      Pointee: 182 GoSliceDataType []crypto/x509.ExtKeyUsage.array
-    - __kind: GoSliceDataType
-      ID: 184
-      Name: '[]net.IP.array'
-      ByteSize: 2048
-      Element: 94 GoSliceHeaderType net.IP
-    - __kind: PointerType
-      ID: 185
-      Name: '*[]net.IP.array'
-      ByteSize: 8
-      Pointee: 184 GoSliceDataType []net.IP.array
-    - __kind: GoSliceDataType
-      ID: 186
-      Name: net.IP.array
-      ByteSize: 2048
-      Element: 7 BaseType uint8
-    - __kind: PointerType
-      ID: 187
-      Name: '*net.IP.array'
-      ByteSize: 8
-      Pointee: 186 GoSliceDataType net.IP.array
-    - __kind: GoSliceDataType
-      ID: 188
-      Name: '[]*net/url.URL.array'
-      ByteSize: 2048
-      Element: 9 PointerType *net/url.URL
-    - __kind: PointerType
-      ID: 189
-      Name: '*[]*net/url.URL.array'
-      ByteSize: 8
-      Pointee: 188 GoSliceDataType []*net/url.URL.array
-    - __kind: GoSliceDataType
-      ID: 190
-      Name: '[]*net.IPNet.array'
-      ByteSize: 2048
-      Element: 99 PointerType *net.IPNet
-    - __kind: PointerType
-      ID: 191
-      Name: '*[]*net.IPNet.array'
-      ByteSize: 8
-      Pointee: 190 GoSliceDataType []*net.IPNet.array
-    - __kind: GoSliceDataType
-      ID: 192
-      Name: net.IPMask.array
-      ByteSize: 2048
-      Element: 7 BaseType uint8
-    - __kind: PointerType
-      ID: 193
-      Name: '*net.IPMask.array'
-      ByteSize: 8
-      Pointee: 192 GoSliceDataType net.IPMask.array
-    - __kind: GoSliceDataType
-      ID: 194
-      Name: '[]crypto/x509.OID.array'
-      ByteSize: 2048
-      Element: 104 StructureType crypto/x509.OID
-    - __kind: PointerType
-      ID: 195
-      Name: '*[]crypto/x509.OID.array'
-      ByteSize: 8
-      Pointee: 194 GoSliceDataType []crypto/x509.OID.array
-    - __kind: GoSliceDataType
-      ID: 196
-      Name: '[][]*crypto/x509.Certificate.array'
-      ByteSize: 2048
-      Element: 55 GoSliceHeaderType []*crypto/x509.Certificate
-    - __kind: PointerType
-      ID: 197
-      Name: '*[][]*crypto/x509.Certificate.array'
-      ByteSize: 8
-      Pointee: 196 GoSliceDataType [][]*crypto/x509.Certificate.array
-    - __kind: GoSliceDataType
-      ID: 198
-      Name: '[][]uint8.array'
-      ByteSize: 2048
-      Element: 52 GoSliceHeaderType []uint8
-    - __kind: PointerType
-      ID: 199
-      Name: '*[][]uint8.array'
-      ByteSize: 8
-      Pointee: 198 GoSliceDataType [][]uint8.array
-    - __kind: GoSliceDataType
-      ID: 200
-      Name: '[]net/http.segment.array'
-      ByteSize: 2048
-      Element: 119 StructureType net/http.segment
-    - __kind: PointerType
-      ID: 201
-      Name: '*[]net/http.segment.array'
-      ByteSize: 8
-      Pointee: 200 GoSliceDataType []net/http.segment.array
-    - __kind: GoSliceDataType
-      ID: 202
-      Name: '[]bucket<string,string>.array'
-      ByteSize: 2048
-      Element: 124 GoHMapBucketType bucket<string,string>
-    - __kind: EventRootType
-      ID: 203
-      Name: Probe[main.HandleHTTP]
-      ByteSize: 25
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: w
-          Offset: 1
-          Expression:
-            Type: 1 GoInterfaceType net/http.ResponseWriter
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 1, index: 0, name: w}
-                  Offset: 0
-                  ByteSize: 16
-        - Name: r
-          Offset: 17
-          Expression:
-            Type: 3 PointerType *net/http.Request
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 1, index: 1, name: r}
-                  Offset: 0
-                  ByteSize: 8
-    - __kind: EventRootType
-      ID: 204
-      Name: Probe[main.LookAtTheRequest]
-      ByteSize: 17
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: path
-          Offset: 1
-          Expression:
-            Type: 5 GoStringHeaderType string
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 2, index: 0, name: path}
-                  Offset: 0
-                  ByteSize: 16
+      GoRuntimeType: 534656
+      GoKind: 26
 MaxTypeID: 204
 Issues: []
 GoModuledataInfo: {FirstModuledataAddr: "0x1776bc0", TypesOffset: 296}

--- a/pkg/dyninst/irgen/testdata/snapshot/rc_tester_v1.arch=amd64,toolchain=go1.23.11.yaml
+++ b/pkg/dyninst/irgen/testdata/snapshot/rc_tester_v1.arch=amd64,toolchain=go1.23.11.yaml
@@ -65,7 +65,7 @@ Subprograms:
           IsParameter: true
           IsReturn: false
         - Name: '&buf'
-          Type: 148 PointerType *bytes.Buffer
+          Type: 39 PointerType *bytes.Buffer
           Locations:
             - Range: 0xd28b8f..0xd28bb1
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
@@ -74,7 +74,7 @@ Subprograms:
           IsParameter: false
           IsReturn: false
         - Name: span
-          Type: 151 GoInterfaceType gopkg.in/DataDog/dd-trace-go.v1/ddtrace.Span
+          Type: 41 GoInterfaceType gopkg.in/DataDog/dd-trace-go.v1/ddtrace.Span
           Locations:
             - Range: 0xd28a68..0xd28a68
               Pieces:
@@ -97,7 +97,7 @@ Subprograms:
           IsParameter: false
           IsReturn: false
         - Name: .autotmp_14
-          Type: 152 StructureType context.backgroundCtx
+          Type: 42 StructureType context.backgroundCtx
           Locations:
             - Range: 0xd289e0..0xd28c90
               Pieces: [{Size: 0, Op: {CfaOffset: 0}}]
@@ -121,143 +121,143 @@ Subprograms:
           IsReturn: false
 Types:
     - __kind: PointerType
-      ID: 80
+      ID: 90
       Name: '**crypto/x509.Certificate'
       ByteSize: 8
-      Pointee: 81 PointerType *crypto/x509.Certificate
+      Pointee: 91 PointerType *crypto/x509.Certificate
     - __kind: PointerType
-      ID: 72
+      ID: 105
       Name: '**mime/multipart.FileHeader'
       ByteSize: 8
       GoKind: 22
-      Pointee: 73 PointerType *mime/multipart.FileHeader
+      Pointee: 106 PointerType *mime/multipart.FileHeader
     - __kind: PointerType
-      ID: 120
+      ID: 137
       Name: '**net.IPNet'
       ByteSize: 8
       GoKind: 22
-      Pointee: 121 PointerType *net.IPNet
+      Pointee: 138 PointerType *net.IPNet
     - __kind: PointerType
-      ID: 118
+      ID: 135
       Name: '**net/url.URL'
       ByteSize: 8
       GoKind: 22
-      Pointee: 39 PointerType *net/url.URL
+      Pointee: 44 PointerType *net/url.URL
     - __kind: PointerType
-      ID: 56
+      ID: 102
       Name: '**runtime.bmap'
       ByteSize: 8
-      Pointee: 57 PointerType *runtime.bmap
+      Pointee: 81 PointerType *runtime.bmap
     - __kind: PointerType
-      ID: 128
+      ID: 93
       Name: '*[]*crypto/x509.Certificate'
       ByteSize: 8
       GoKind: 22
-      Pointee: 79 GoSliceHeaderType []*crypto/x509.Certificate
+      Pointee: 89 GoSliceHeaderType []*crypto/x509.Certificate
     - __kind: PointerType
-      ID: 167
+      ID: 166
       Name: '*[]*crypto/x509.Certificate.array'
       ByteSize: 8
-      Pointee: 166 GoSliceDataType []*crypto/x509.Certificate.array
+      Pointee: 165 GoSliceDataType []*crypto/x509.Certificate.array
     - __kind: PointerType
-      ID: 163
+      ID: 174
       Name: '*[]*mime/multipart.FileHeader.array'
       ByteSize: 8
-      Pointee: 162 GoSliceDataType []*mime/multipart.FileHeader.array
+      Pointee: 173 GoSliceDataType []*mime/multipart.FileHeader.array
     - __kind: PointerType
-      ID: 191
+      ID: 192
       Name: '*[]*net.IPNet.array'
       ByteSize: 8
-      Pointee: 190 GoSliceDataType []*net.IPNet.array
+      Pointee: 191 GoSliceDataType []*net.IPNet.array
     - __kind: PointerType
-      ID: 189
+      ID: 190
       Name: '*[]*net/url.URL.array'
       ByteSize: 8
-      Pointee: 188 GoSliceDataType []*net/url.URL.array
+      Pointee: 189 GoSliceDataType []*net/url.URL.array
     - __kind: PointerType
-      ID: 54
+      ID: 79
       Name: '*[]*runtime.bmap'
       ByteSize: 8
       GoRuntimeType: 466432
       GoKind: 22
-      Pointee: 55 GoSliceHeaderType []*runtime.bmap
+      Pointee: 80 GoSliceHeaderType []*runtime.bmap
     - __kind: PointerType
-      ID: 160
+      ID: 163
       Name: '*[]*runtime.bmap.array'
       ByteSize: 8
-      Pointee: 159 GoSliceDataType []*runtime.bmap.array
+      Pointee: 162 GoSliceDataType []*runtime.bmap.array
     - __kind: PointerType
-      ID: 197
+      ID: 168
       Name: '*[][]*crypto/x509.Certificate.array'
       ByteSize: 8
-      Pointee: 196 GoSliceDataType [][]*crypto/x509.Certificate.array
+      Pointee: 167 GoSliceDataType [][]*crypto/x509.Certificate.array
     - __kind: PointerType
-      ID: 199
+      ID: 170
       Name: '*[][]uint8.array'
       ByteSize: 8
-      Pointee: 198 GoSliceDataType [][]uint8.array
+      Pointee: 169 GoSliceDataType [][]uint8.array
     - __kind: PointerType
-      ID: 183
+      ID: 184
       Name: '*[]crypto/x509.ExtKeyUsage.array'
       ByteSize: 8
-      Pointee: 182 GoSliceDataType []crypto/x509.ExtKeyUsage.array
+      Pointee: 183 GoSliceDataType []crypto/x509.ExtKeyUsage.array
     - __kind: PointerType
-      ID: 195
+      ID: 194
       Name: '*[]crypto/x509.OID.array'
       ByteSize: 8
-      Pointee: 194 GoSliceDataType []crypto/x509.OID.array
+      Pointee: 193 GoSliceDataType []crypto/x509.OID.array
     - __kind: PointerType
-      ID: 171
+      ID: 176
       Name: '*[]crypto/x509/pkix.AttributeTypeAndValue.array'
       ByteSize: 8
-      Pointee: 170 GoSliceDataType []crypto/x509/pkix.AttributeTypeAndValue.array
+      Pointee: 175 GoSliceDataType []crypto/x509/pkix.AttributeTypeAndValue.array
     - __kind: PointerType
-      ID: 179
+      ID: 178
       Name: '*[]crypto/x509/pkix.Extension.array'
       ByteSize: 8
-      Pointee: 178 GoSliceDataType []crypto/x509/pkix.Extension.array
+      Pointee: 177 GoSliceDataType []crypto/x509/pkix.Extension.array
     - __kind: PointerType
-      ID: 181
+      ID: 180
       Name: '*[]encoding/asn1.ObjectIdentifier.array'
       ByteSize: 8
-      Pointee: 180 GoSliceDataType []encoding/asn1.ObjectIdentifier.array
+      Pointee: 179 GoSliceDataType []encoding/asn1.ObjectIdentifier.array
     - __kind: PointerType
-      ID: 185
+      ID: 186
       Name: '*[]net.IP.array'
       ByteSize: 8
-      Pointee: 184 GoSliceDataType []net.IP.array
+      Pointee: 185 GoSliceDataType []net.IP.array
     - __kind: PointerType
-      ID: 201
+      ID: 172
       Name: '*[]net/http.segment.array'
       ByteSize: 8
-      Pointee: 200 GoSliceDataType []net/http.segment.array
+      Pointee: 171 GoSliceDataType []net/http.segment.array
     - __kind: PointerType
       ID: 158
       Name: '*[]string.array'
       ByteSize: 8
       Pointee: 157 GoSliceDataType []string.array
     - __kind: PointerType
-      ID: 175
+      ID: 198
       Name: '*[]time.zone.array'
       ByteSize: 8
-      Pointee: 174 GoSliceDataType []time.zone.array
+      Pointee: 197 GoSliceDataType []time.zone.array
     - __kind: PointerType
-      ID: 177
+      ID: 200
       Name: '*[]time.zoneTrans.array'
       ByteSize: 8
-      Pointee: 176 GoSliceDataType []time.zoneTrans.array
+      Pointee: 199 GoSliceDataType []time.zoneTrans.array
     - __kind: PointerType
-      ID: 130
+      ID: 95
       Name: '*[]uint8'
       ByteSize: 8
       GoRuntimeType: 452512
       GoKind: 22
-      Pointee: 76 GoSliceHeaderType []uint8
+      Pointee: 72 GoSliceHeaderType []uint8
     - __kind: PointerType
-      ID: 165
+      ID: 161
       Name: '*[]uint8.array'
       ByteSize: 8
-      Pointee: 164 GoSliceDataType []uint8.array
+      Pointee: 160 GoSliceDataType []uint8.array
     - __kind: PointerType
       ID: 5
       Name: '*bool'
@@ -266,81 +266,81 @@ Types:
       GoKind: 22
       Pointee: 4 BaseType bool
     - __kind: PointerType
-      ID: 68
+      ID: 87
       Name: '*bucket<string,[]*mime/multipart.FileHeader>'
       ByteSize: 8
-      Pointee: 69 GoHMapBucketType bucket<string,[]*mime/multipart.FileHeader>
+      Pointee: 88 GoHMapBucketType bucket<string,[]*mime/multipart.FileHeader>
     - __kind: PointerType
-      ID: 46
+      ID: 49
       Name: '*bucket<string,[]string>'
       ByteSize: 8
-      Pointee: 47 GoHMapBucketType bucket<string,[]string>
+      Pointee: 50 GoHMapBucketType bucket<string,[]string>
     - __kind: PointerType
-      ID: 145
+      ID: 70
       Name: '*bucket<string,string>'
       ByteSize: 8
-      Pointee: 146 GoHMapBucketType bucket<string,string>
+      Pointee: 71 GoHMapBucketType bucket<string,string>
     - __kind: PointerType
-      ID: 148
+      ID: 39
       Name: '*bytes.Buffer'
       ByteSize: 8
       GoRuntimeType: 2.114976e+06
       GoKind: 22
-      Pointee: 149 StructureType bytes.Buffer
+      Pointee: 40 StructureType bytes.Buffer
     - __kind: PointerType
-      ID: 77
+      ID: 59
       Name: '*crypto/tls.ConnectionState'
       ByteSize: 8
       GoRuntimeType: 835936
       GoKind: 22
-      Pointee: 78 StructureType crypto/tls.ConnectionState
+      Pointee: 60 StructureType crypto/tls.ConnectionState
     - __kind: PointerType
-      ID: 81
+      ID: 91
       Name: '*crypto/x509.Certificate'
       ByteSize: 8
       GoRuntimeType: 1.90528e+06
       GoKind: 22
-      Pointee: 82 StructureType crypto/x509.Certificate
+      Pointee: 107 StructureType crypto/x509.Certificate
     - __kind: PointerType
-      ID: 112
+      ID: 129
       Name: '*crypto/x509.ExtKeyUsage'
       ByteSize: 8
       GoRuntimeType: 395040
       GoKind: 22
-      Pointee: 113 BaseType crypto/x509.ExtKeyUsage
+      Pointee: 130 BaseType crypto/x509.ExtKeyUsage
     - __kind: PointerType
-      ID: 125
+      ID: 140
       Name: '*crypto/x509.OID'
       ByteSize: 8
       GoRuntimeType: 1.717248e+06
       GoKind: 22
-      Pointee: 126 StructureType crypto/x509.OID
+      Pointee: 141 StructureType crypto/x509.OID
     - __kind: PointerType
-      ID: 93
+      ID: 116
       Name: '*crypto/x509/pkix.AttributeTypeAndValue'
       ByteSize: 8
       GoRuntimeType: 408800
       GoKind: 22
-      Pointee: 94 StructureType crypto/x509/pkix.AttributeTypeAndValue
+      Pointee: 117 StructureType crypto/x509/pkix.AttributeTypeAndValue
     - __kind: PointerType
-      ID: 107
+      ID: 123
       Name: '*crypto/x509/pkix.Extension'
       ByteSize: 8
       GoRuntimeType: 408992
       GoKind: 22
-      Pointee: 108 StructureType crypto/x509/pkix.Extension
+      Pointee: 124 StructureType crypto/x509/pkix.Extension
     - __kind: PointerType
-      ID: 110
+      ID: 126
       Name: '*encoding/asn1.ObjectIdentifier'
       ByteSize: 8
       GoRuntimeType: 1.009728e+06
       GoKind: 22
-      Pointee: 95 GoSliceHeaderType encoding/asn1.ObjectIdentifier
+      Pointee: 127 GoSliceHeaderType encoding/asn1.ObjectIdentifier
     - __kind: PointerType
-      ID: 173
+      ID: 182
       Name: '*encoding/asn1.ObjectIdentifier.array'
       ByteSize: 8
-      Pointee: 172 GoSliceDataType encoding/asn1.ObjectIdentifier.array
+      Pointee: 181 GoSliceDataType encoding/asn1.ObjectIdentifier.array
     - __kind: PointerType
       ID: 33
       Name: '*error'
@@ -363,20 +363,20 @@ Types:
       GoKind: 22
       Pointee: 17 BaseType float64
     - __kind: PointerType
-      ID: 66
+      ID: 85
       Name: '*hash<string,[]*mime/multipart.FileHeader>'
       ByteSize: 8
-      Pointee: 67 GoHMapHeaderType hash<string,[]*mime/multipart.FileHeader>
+      Pointee: 86 GoHMapHeaderType hash<string,[]*mime/multipart.FileHeader>
     - __kind: PointerType
-      ID: 44
+      ID: 47
       Name: '*hash<string,[]string>'
       ByteSize: 8
-      Pointee: 45 GoHMapHeaderType hash<string,[]string>
+      Pointee: 48 GoHMapHeaderType hash<string,[]string>
     - __kind: PointerType
-      ID: 143
+      ID: 68
       Name: '*hash<string,string>'
       ByteSize: 8
-      Pointee: 144 GoHMapHeaderType hash<string,string>
+      Pointee: 69 GoHMapHeaderType hash<string,string>
     - __kind: PointerType
       ID: 27
       Name: '*int'
@@ -413,62 +413,62 @@ Types:
       GoKind: 22
       Pointee: 14 BaseType int8
     - __kind: PointerType
-      ID: 86
+      ID: 112
       Name: '*math/big.Int'
       ByteSize: 8
       GoRuntimeType: 2.231104e+06
       GoKind: 22
-      Pointee: 87 StructureType math/big.Int
+      Pointee: 113 StructureType math/big.Int
     - __kind: PointerType
-      ID: 89
+      ID: 144
       Name: '*math/big.Word'
       ByteSize: 8
       GoRuntimeType: 397856
       GoKind: 22
-      Pointee: 90 BaseType math/big.Word
+      Pointee: 145 BaseType math/big.Word
     - __kind: PointerType
-      ID: 169
+      ID: 196
       Name: '*math/big.nat.array'
       ByteSize: 8
-      Pointee: 168 GoSliceDataType math/big.nat.array
+      Pointee: 195 GoSliceDataType math/big.nat.array
     - __kind: PointerType
-      ID: 73
+      ID: 106
       Name: '*mime/multipart.FileHeader'
       ByteSize: 8
       GoRuntimeType: 837376
       GoKind: 22
-      Pointee: 74 StructureType mime/multipart.FileHeader
+      Pointee: 108 StructureType mime/multipart.FileHeader
     - __kind: PointerType
-      ID: 62
+      ID: 57
       Name: '*mime/multipart.Form'
       ByteSize: 8
       GoRuntimeType: 837472
       GoKind: 22
-      Pointee: 63 StructureType mime/multipart.Form
+      Pointee: 58 StructureType mime/multipart.Form
     - __kind: PointerType
-      ID: 115
+      ID: 132
       Name: '*net.IP'
       ByteSize: 8
       GoRuntimeType: 1.974144e+06
       GoKind: 22
-      Pointee: 116 GoSliceHeaderType net.IP
+      Pointee: 133 GoSliceHeaderType net.IP
     - __kind: PointerType
-      ID: 187
+      ID: 188
       Name: '*net.IP.array'
       ByteSize: 8
-      Pointee: 186 GoSliceDataType net.IP.array
+      Pointee: 187 GoSliceDataType net.IP.array
     - __kind: PointerType
-      ID: 193
+      ID: 202
       Name: '*net.IPMask.array'
       ByteSize: 8
-      Pointee: 192 GoSliceDataType net.IPMask.array
+      Pointee: 201 GoSliceDataType net.IPMask.array
     - __kind: PointerType
-      ID: 121
+      ID: 138
       Name: '*net.IPNet'
       ByteSize: 8
       GoRuntimeType: 1.095776e+06
       GoKind: 22
-      Pointee: 122 StructureType net.IPNet
+      Pointee: 152 StructureType net.IPNet
     - __kind: PointerType
       ID: 37
       Name: '*net/http.Request'
@@ -477,54 +477,54 @@ Types:
       GoKind: 22
       Pointee: 38 StructureType net/http.Request
     - __kind: PointerType
-      ID: 134
+      ID: 62
       Name: '*net/http.Response'
       ByteSize: 8
       GoRuntimeType: 1.590912e+06
       GoKind: 22
-      Pointee: 135 StructureType net/http.Response
+      Pointee: 63 StructureType net/http.Response
     - __kind: PointerType
-      ID: 137
+      ID: 65
       Name: '*net/http.pattern'
       ByteSize: 8
       GoRuntimeType: 1.416224e+06
       GoKind: 22
-      Pointee: 138 StructureType net/http.pattern
+      Pointee: 66 StructureType net/http.pattern
     - __kind: PointerType
-      ID: 140
+      ID: 99
       Name: '*net/http.segment'
       ByteSize: 8
       GoRuntimeType: 364000
       GoKind: 22
-      Pointee: 141 StructureType net/http.segment
+      Pointee: 100 StructureType net/http.segment
     - __kind: PointerType
-      ID: 39
+      ID: 44
       Name: '*net/url.URL'
       ByteSize: 8
       GoRuntimeType: 1.949216e+06
       GoKind: 22
-      Pointee: 40 StructureType net/url.URL
+      Pointee: 45 StructureType net/url.URL
     - __kind: PointerType
-      ID: 41
+      ID: 74
       Name: '*net/url.Userinfo'
       ByteSize: 8
       GoRuntimeType: 1.114208e+06
       GoKind: 22
-      Pointee: 42 StructureType net/url.Userinfo
+      Pointee: 75 StructureType net/url.Userinfo
     - __kind: PointerType
-      ID: 57
+      ID: 81
       Name: '*runtime.bmap'
       ByteSize: 8
       GoRuntimeType: 1.109856e+06
       GoKind: 22
-      Pointee: 58 StructureType runtime.bmap
+      Pointee: 82 StructureType runtime.bmap
     - __kind: PointerType
-      ID: 52
+      ID: 51
       Name: '*runtime.mapextra'
       ByteSize: 8
       GoRuntimeType: 375520
       GoKind: 22
-      Pointee: 53 StructureType runtime.mapextra
+      Pointee: 52 StructureType runtime.mapextra
     - __kind: PointerType
       ID: 22
       Name: '*string'
@@ -538,26 +538,26 @@ Types:
       ByteSize: 8
       Pointee: 154 GoStringDataType string.str
     - __kind: PointerType
-      ID: 97
+      ID: 119
       Name: '*time.Location'
       ByteSize: 8
       GoRuntimeType: 1.421216e+06
       GoKind: 22
-      Pointee: 98 StructureType time.Location
+      Pointee: 120 StructureType time.Location
     - __kind: PointerType
-      ID: 100
+      ID: 147
       Name: '*time.zone'
       ByteSize: 8
       GoRuntimeType: 367072
       GoKind: 22
-      Pointee: 101 StructureType time.zone
+      Pointee: 148 StructureType time.zone
     - __kind: PointerType
-      ID: 103
+      ID: 150
       Name: '*time.zoneTrans'
       ByteSize: 8
       GoRuntimeType: 367136
       GoKind: 22
-      Pointee: 104 StructureType time.zoneTrans
+      Pointee: 151 StructureType time.zoneTrans
     - __kind: PointerType
       ID: 34
       Name: '*uint'
@@ -601,7 +601,7 @@ Types:
       GoKind: 22
       Pointee: 1 BaseType uintptr
     - __kind: GoChannelType
-      ID: 133
+      ID: 61
       Name: <-chan struct {}
       GoRuntimeType: 546752
       GoKind: 18
@@ -645,7 +645,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: ArrayType
-      ID: 48
+      ID: 76
       Name: '[8]uint8'
       ByteSize: 8
       GoRuntimeType: 621728
@@ -654,7 +654,7 @@ Types:
       HasCount: true
       Element: 3 BaseType uint8
     - __kind: GoSliceHeaderType
-      ID: 79
+      ID: 89
       Name: '[]*crypto/x509.Certificate'
       ByteSize: 24
       GoRuntimeType: 469536
@@ -662,21 +662,21 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 80 PointerType **crypto/x509.Certificate
+          Type: 90 PointerType **crypto/x509.Certificate
         - Name: len
           Offset: 8
           Type: 9 BaseType int
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 166 GoSliceDataType []*crypto/x509.Certificate.array
+      Data: 165 GoSliceDataType []*crypto/x509.Certificate.array
     - __kind: GoSliceDataType
-      ID: 166
+      ID: 165
       Name: '[]*crypto/x509.Certificate.array'
       ByteSize: 2048
-      Element: 81 PointerType *crypto/x509.Certificate
+      Element: 91 PointerType *crypto/x509.Certificate
     - __kind: GoSliceHeaderType
-      ID: 71
+      ID: 104
       Name: '[]*mime/multipart.FileHeader'
       ByteSize: 24
       GoRuntimeType: 457376
@@ -684,21 +684,21 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 72 PointerType **mime/multipart.FileHeader
+          Type: 105 PointerType **mime/multipart.FileHeader
         - Name: len
           Offset: 8
           Type: 9 BaseType int
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 162 GoSliceDataType []*mime/multipart.FileHeader.array
+      Data: 173 GoSliceDataType []*mime/multipart.FileHeader.array
     - __kind: GoSliceDataType
-      ID: 162
+      ID: 173
       Name: '[]*mime/multipart.FileHeader.array'
       ByteSize: 2048
-      Element: 73 PointerType *mime/multipart.FileHeader
+      Element: 106 PointerType *mime/multipart.FileHeader
     - __kind: GoSliceHeaderType
-      ID: 119
+      ID: 136
       Name: '[]*net.IPNet'
       ByteSize: 24
       GoRuntimeType: 481568
@@ -706,21 +706,21 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 120 PointerType **net.IPNet
+          Type: 137 PointerType **net.IPNet
         - Name: len
           Offset: 8
           Type: 9 BaseType int
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 190 GoSliceDataType []*net.IPNet.array
+      Data: 191 GoSliceDataType []*net.IPNet.array
     - __kind: GoSliceDataType
-      ID: 190
+      ID: 191
       Name: '[]*net.IPNet.array'
       ByteSize: 2048
-      Element: 121 PointerType *net.IPNet
+      Element: 138 PointerType *net.IPNet
     - __kind: GoSliceHeaderType
-      ID: 117
+      ID: 134
       Name: '[]*net/url.URL'
       ByteSize: 24
       GoRuntimeType: 481504
@@ -728,21 +728,21 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 118 PointerType **net/url.URL
+          Type: 135 PointerType **net/url.URL
         - Name: len
           Offset: 8
           Type: 9 BaseType int
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 188 GoSliceDataType []*net/url.URL.array
+      Data: 189 GoSliceDataType []*net/url.URL.array
     - __kind: GoSliceDataType
-      ID: 188
+      ID: 189
       Name: '[]*net/url.URL.array'
       ByteSize: 2048
-      Element: 39 PointerType *net/url.URL
+      Element: 44 PointerType *net/url.URL
     - __kind: GoSliceHeaderType
-      ID: 55
+      ID: 80
       Name: '[]*runtime.bmap'
       ByteSize: 24
       GoRuntimeType: 466368
@@ -750,21 +750,21 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 56 PointerType **runtime.bmap
+          Type: 102 PointerType **runtime.bmap
         - Name: len
           Offset: 8
           Type: 9 BaseType int
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 159 GoSliceDataType []*runtime.bmap.array
+      Data: 162 GoSliceDataType []*runtime.bmap.array
     - __kind: GoSliceDataType
-      ID: 159
+      ID: 162
       Name: '[]*runtime.bmap.array'
       ByteSize: 2048
-      Element: 57 PointerType *runtime.bmap
+      Element: 81 PointerType *runtime.bmap
     - __kind: GoSliceHeaderType
-      ID: 127
+      ID: 92
       Name: '[][]*crypto/x509.Certificate'
       ByteSize: 24
       GoRuntimeType: 469664
@@ -772,21 +772,21 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 128 PointerType *[]*crypto/x509.Certificate
+          Type: 93 PointerType *[]*crypto/x509.Certificate
         - Name: len
           Offset: 8
           Type: 9 BaseType int
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 196 GoSliceDataType [][]*crypto/x509.Certificate.array
+      Data: 167 GoSliceDataType [][]*crypto/x509.Certificate.array
     - __kind: GoSliceDataType
-      ID: 196
+      ID: 167
       Name: '[][]*crypto/x509.Certificate.array'
       ByteSize: 2048
-      Element: 79 GoSliceHeaderType []*crypto/x509.Certificate
+      Element: 89 GoSliceHeaderType []*crypto/x509.Certificate
     - __kind: GoSliceHeaderType
-      ID: 129
+      ID: 94
       Name: '[][]uint8'
       ByteSize: 24
       GoRuntimeType: 452832
@@ -794,36 +794,36 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 130 PointerType *[]uint8
+          Type: 95 PointerType *[]uint8
         - Name: len
           Offset: 8
           Type: 9 BaseType int
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 198 GoSliceDataType [][]uint8.array
+      Data: 169 GoSliceDataType [][]uint8.array
     - __kind: GoSliceDataType
-      ID: 198
+      ID: 169
       Name: '[][]uint8.array'
       ByteSize: 2048
-      Element: 76 GoSliceHeaderType []uint8
+      Element: 72 GoSliceHeaderType []uint8
     - __kind: GoSliceDataType
-      ID: 161
+      ID: 164
       Name: '[]bucket<string,[]*mime/multipart.FileHeader>.array'
       ByteSize: 2048
-      Element: 69 GoHMapBucketType bucket<string,[]*mime/multipart.FileHeader>
+      Element: 88 GoHMapBucketType bucket<string,[]*mime/multipart.FileHeader>
     - __kind: GoSliceDataType
       ID: 156
       Name: '[]bucket<string,[]string>.array'
       ByteSize: 2048
-      Element: 47 GoHMapBucketType bucket<string,[]string>
+      Element: 50 GoHMapBucketType bucket<string,[]string>
     - __kind: GoSliceDataType
-      ID: 202
+      ID: 159
       Name: '[]bucket<string,string>.array'
       ByteSize: 2048
-      Element: 146 GoHMapBucketType bucket<string,string>
+      Element: 71 GoHMapBucketType bucket<string,string>
     - __kind: GoSliceHeaderType
-      ID: 111
+      ID: 128
       Name: '[]crypto/x509.ExtKeyUsage'
       ByteSize: 24
       GoRuntimeType: 470816
@@ -831,21 +831,21 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 112 PointerType *crypto/x509.ExtKeyUsage
+          Type: 129 PointerType *crypto/x509.ExtKeyUsage
         - Name: len
           Offset: 8
           Type: 9 BaseType int
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 182 GoSliceDataType []crypto/x509.ExtKeyUsage.array
+      Data: 183 GoSliceDataType []crypto/x509.ExtKeyUsage.array
     - __kind: GoSliceDataType
-      ID: 182
+      ID: 183
       Name: '[]crypto/x509.ExtKeyUsage.array'
       ByteSize: 2048
-      Element: 113 BaseType crypto/x509.ExtKeyUsage
+      Element: 130 BaseType crypto/x509.ExtKeyUsage
     - __kind: GoSliceHeaderType
-      ID: 124
+      ID: 139
       Name: '[]crypto/x509.OID'
       ByteSize: 24
       GoRuntimeType: 481632
@@ -853,21 +853,21 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 125 PointerType *crypto/x509.OID
+          Type: 140 PointerType *crypto/x509.OID
         - Name: len
           Offset: 8
           Type: 9 BaseType int
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 194 GoSliceDataType []crypto/x509.OID.array
+      Data: 193 GoSliceDataType []crypto/x509.OID.array
     - __kind: GoSliceDataType
-      ID: 194
+      ID: 193
       Name: '[]crypto/x509.OID.array'
       ByteSize: 2048
-      Element: 126 StructureType crypto/x509.OID
+      Element: 141 StructureType crypto/x509.OID
     - __kind: GoSliceHeaderType
-      ID: 92
+      ID: 115
       Name: '[]crypto/x509/pkix.AttributeTypeAndValue'
       ByteSize: 24
       GoRuntimeType: 481888
@@ -875,21 +875,21 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 93 PointerType *crypto/x509/pkix.AttributeTypeAndValue
+          Type: 116 PointerType *crypto/x509/pkix.AttributeTypeAndValue
         - Name: len
           Offset: 8
           Type: 9 BaseType int
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 170 GoSliceDataType []crypto/x509/pkix.AttributeTypeAndValue.array
+      Data: 175 GoSliceDataType []crypto/x509/pkix.AttributeTypeAndValue.array
     - __kind: GoSliceDataType
-      ID: 170
+      ID: 175
       Name: '[]crypto/x509/pkix.AttributeTypeAndValue.array'
       ByteSize: 2048
-      Element: 94 StructureType crypto/x509/pkix.AttributeTypeAndValue
+      Element: 117 StructureType crypto/x509/pkix.AttributeTypeAndValue
     - __kind: GoSliceHeaderType
-      ID: 106
+      ID: 122
       Name: '[]crypto/x509/pkix.Extension'
       ByteSize: 24
       GoRuntimeType: 481376
@@ -897,21 +897,21 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 107 PointerType *crypto/x509/pkix.Extension
+          Type: 123 PointerType *crypto/x509/pkix.Extension
         - Name: len
           Offset: 8
           Type: 9 BaseType int
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 178 GoSliceDataType []crypto/x509/pkix.Extension.array
+      Data: 177 GoSliceDataType []crypto/x509/pkix.Extension.array
     - __kind: GoSliceDataType
-      ID: 178
+      ID: 177
       Name: '[]crypto/x509/pkix.Extension.array'
       ByteSize: 2048
-      Element: 108 StructureType crypto/x509/pkix.Extension
+      Element: 124 StructureType crypto/x509/pkix.Extension
     - __kind: GoSliceHeaderType
-      ID: 109
+      ID: 125
       Name: '[]encoding/asn1.ObjectIdentifier'
       ByteSize: 24
       GoRuntimeType: 481440
@@ -919,28 +919,28 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 110 PointerType *encoding/asn1.ObjectIdentifier
+          Type: 126 PointerType *encoding/asn1.ObjectIdentifier
         - Name: len
           Offset: 8
           Type: 9 BaseType int
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 180 GoSliceDataType []encoding/asn1.ObjectIdentifier.array
+      Data: 179 GoSliceDataType []encoding/asn1.ObjectIdentifier.array
     - __kind: GoSliceDataType
-      ID: 180
+      ID: 179
       Name: '[]encoding/asn1.ObjectIdentifier.array'
       ByteSize: 2048
-      Element: 95 GoSliceHeaderType encoding/asn1.ObjectIdentifier
+      Element: 127 GoSliceHeaderType encoding/asn1.ObjectIdentifier
     - __kind: ArrayType
-      ID: 49
+      ID: 77
       Name: '[]key<string>'
       ByteSize: 128
       Count: 8
       HasCount: true
       Element: 11 GoStringHeaderType string
     - __kind: GoSliceHeaderType
-      ID: 114
+      ID: 131
       Name: '[]net.IP'
       ByteSize: 24
       GoRuntimeType: 454048
@@ -948,21 +948,21 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 115 PointerType *net.IP
+          Type: 132 PointerType *net.IP
         - Name: len
           Offset: 8
           Type: 9 BaseType int
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 184 GoSliceDataType []net.IP.array
+      Data: 185 GoSliceDataType []net.IP.array
     - __kind: GoSliceDataType
-      ID: 184
+      ID: 185
       Name: '[]net.IP.array'
       ByteSize: 2048
-      Element: 116 GoSliceHeaderType net.IP
+      Element: 133 GoSliceHeaderType net.IP
     - __kind: GoSliceHeaderType
-      ID: 139
+      ID: 98
       Name: '[]net/http.segment'
       ByteSize: 24
       GoRuntimeType: 454816
@@ -970,21 +970,21 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 140 PointerType *net/http.segment
+          Type: 99 PointerType *net/http.segment
         - Name: len
           Offset: 8
           Type: 9 BaseType int
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 200 GoSliceDataType []net/http.segment.array
+      Data: 171 GoSliceDataType []net/http.segment.array
     - __kind: GoSliceDataType
-      ID: 200
+      ID: 171
       Name: '[]net/http.segment.array'
       ByteSize: 2048
-      Element: 141 StructureType net/http.segment
+      Element: 100 StructureType net/http.segment
     - __kind: GoSliceHeaderType
-      ID: 51
+      ID: 55
       Name: '[]string'
       ByteSize: 24
       GoRuntimeType: 464704
@@ -1006,7 +1006,7 @@ Types:
       ByteSize: 2048
       Element: 11 GoStringHeaderType string
     - __kind: GoSliceHeaderType
-      ID: 99
+      ID: 146
       Name: '[]time.zone'
       ByteSize: 24
       GoRuntimeType: 459040
@@ -1014,21 +1014,21 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 100 PointerType *time.zone
+          Type: 147 PointerType *time.zone
         - Name: len
           Offset: 8
           Type: 9 BaseType int
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 174 GoSliceDataType []time.zone.array
+      Data: 197 GoSliceDataType []time.zone.array
     - __kind: GoSliceDataType
-      ID: 174
+      ID: 197
       Name: '[]time.zone.array'
       ByteSize: 2048
-      Element: 101 StructureType time.zone
+      Element: 148 StructureType time.zone
     - __kind: GoSliceHeaderType
-      ID: 102
+      ID: 149
       Name: '[]time.zoneTrans'
       ByteSize: 24
       GoRuntimeType: 459104
@@ -1036,21 +1036,21 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 103 PointerType *time.zoneTrans
+          Type: 150 PointerType *time.zoneTrans
         - Name: len
           Offset: 8
           Type: 9 BaseType int
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 176 GoSliceDataType []time.zoneTrans.array
+      Data: 199 GoSliceDataType []time.zoneTrans.array
     - __kind: GoSliceDataType
-      ID: 176
+      ID: 199
       Name: '[]time.zoneTrans.array'
       ByteSize: 2048
-      Element: 104 StructureType time.zoneTrans
+      Element: 151 StructureType time.zoneTrans
     - __kind: GoSliceHeaderType
-      ID: 76
+      ID: 72
       Name: '[]uint8'
       ByteSize: 24
       GoRuntimeType: 463552
@@ -1065,28 +1065,28 @@ Types:
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 164 GoSliceDataType []uint8.array
+      Data: 160 GoSliceDataType []uint8.array
     - __kind: GoSliceDataType
-      ID: 164
+      ID: 160
       Name: '[]uint8.array'
       ByteSize: 2048
       Element: 3 BaseType uint8
     - __kind: ArrayType
-      ID: 70
+      ID: 103
       Name: '[]val<[]*mime/multipart.FileHeader>'
       ByteSize: 192
       Count: 8
       HasCount: true
-      Element: 71 GoSliceHeaderType []*mime/multipart.FileHeader
+      Element: 104 GoSliceHeaderType []*mime/multipart.FileHeader
     - __kind: ArrayType
-      ID: 50
+      ID: 78
       Name: '[]val<[]string>'
       ByteSize: 192
       Count: 8
       HasCount: true
-      Element: 51 GoSliceHeaderType []string
+      Element: 55 GoSliceHeaderType []string
     - __kind: ArrayType
-      ID: 147
+      ID: 101
       Name: '[]val<string>'
       ByteSize: 128
       Count: 8
@@ -1099,64 +1099,64 @@ Types:
       GoRuntimeType: 534592
       GoKind: 1
     - __kind: GoHMapBucketType
-      ID: 69
+      ID: 88
       Name: bucket<string,[]*mime/multipart.FileHeader>
       ByteSize: 336
       RawFields:
         - Name: tophash
           Offset: 0
-          Type: 48 ArrayType [8]uint8
+          Type: 76 ArrayType [8]uint8
         - Name: keys
           Offset: 8
-          Type: 49 ArrayType []key<string>
+          Type: 77 ArrayType []key<string>
         - Name: values
           Offset: 136
-          Type: 70 ArrayType []val<[]*mime/multipart.FileHeader>
+          Type: 103 ArrayType []val<[]*mime/multipart.FileHeader>
         - Name: overflow
           Offset: 328
-          Type: 68 PointerType *bucket<string,[]*mime/multipart.FileHeader>
+          Type: 87 PointerType *bucket<string,[]*mime/multipart.FileHeader>
       KeyType: 11 GoStringHeaderType string
-      ValueType: 71 GoSliceHeaderType []*mime/multipart.FileHeader
+      ValueType: 104 GoSliceHeaderType []*mime/multipart.FileHeader
     - __kind: GoHMapBucketType
-      ID: 47
+      ID: 50
       Name: bucket<string,[]string>
       ByteSize: 336
       RawFields:
         - Name: tophash
           Offset: 0
-          Type: 48 ArrayType [8]uint8
+          Type: 76 ArrayType [8]uint8
         - Name: keys
           Offset: 8
-          Type: 49 ArrayType []key<string>
+          Type: 77 ArrayType []key<string>
         - Name: values
           Offset: 136
-          Type: 50 ArrayType []val<[]string>
+          Type: 78 ArrayType []val<[]string>
         - Name: overflow
           Offset: 328
-          Type: 46 PointerType *bucket<string,[]string>
+          Type: 49 PointerType *bucket<string,[]string>
       KeyType: 11 GoStringHeaderType string
-      ValueType: 51 GoSliceHeaderType []string
+      ValueType: 55 GoSliceHeaderType []string
     - __kind: GoHMapBucketType
-      ID: 146
+      ID: 71
       Name: bucket<string,string>
       ByteSize: 272
       RawFields:
         - Name: tophash
           Offset: 0
-          Type: 48 ArrayType [8]uint8
+          Type: 76 ArrayType [8]uint8
         - Name: keys
           Offset: 8
-          Type: 49 ArrayType []key<string>
+          Type: 77 ArrayType []key<string>
         - Name: values
           Offset: 136
-          Type: 147 ArrayType []val<string>
+          Type: 101 ArrayType []val<string>
         - Name: overflow
           Offset: 264
-          Type: 145 PointerType *bucket<string,string>
+          Type: 70 PointerType *bucket<string,string>
       KeyType: 11 GoStringHeaderType string
       ValueType: 11 GoStringHeaderType string
     - __kind: StructureType
-      ID: 149
+      ID: 40
       Name: bytes.Buffer
       ByteSize: 40
       GoRuntimeType: 1.41392e+06
@@ -1164,15 +1164,15 @@ Types:
       RawFields:
         - Name: buf
           Offset: 0
-          Type: 76 GoSliceHeaderType []uint8
+          Type: 72 GoSliceHeaderType []uint8
         - Name: off
           Offset: 24
           Type: 9 BaseType int
         - Name: lastRead
           Offset: 32
-          Type: 150 BaseType bytes.readOp
+          Type: 73 BaseType bytes.readOp
     - __kind: BaseType
-      ID: 150
+      ID: 73
       Name: bytes.readOp
       ByteSize: 1
       GoRuntimeType: 532800
@@ -1190,7 +1190,7 @@ Types:
       GoRuntimeType: 534336
       GoKind: 15
     - __kind: GoInterfaceType
-      ID: 136
+      ID: 64
       Name: context.Context
       ByteSize: 16
       GoRuntimeType: 1.187104e+06
@@ -1203,22 +1203,22 @@ Types:
           Offset: 8
           Type: 19 VoidPointerType unsafe.Pointer
     - __kind: StructureType
-      ID: 152
+      ID: 42
       Name: context.backgroundCtx
       GoRuntimeType: 1.6672e+06
       GoKind: 25
       RawFields:
         - Name: emptyCtx
           Offset: 0
-          Type: 153 StructureType context.emptyCtx
+          Type: 43 StructureType context.emptyCtx
     - __kind: StructureType
-      ID: 153
+      ID: 43
       Name: context.emptyCtx
       GoRuntimeType: 1.399456e+06
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 78
+      ID: 60
       Name: crypto/tls.ConnectionState
       ByteSize: 192
       GoRuntimeType: 2.1e+06
@@ -1247,39 +1247,39 @@ Types:
           Type: 11 GoStringHeaderType string
         - Name: PeerCertificates
           Offset: 48
-          Type: 79 GoSliceHeaderType []*crypto/x509.Certificate
+          Type: 89 GoSliceHeaderType []*crypto/x509.Certificate
         - Name: VerifiedChains
           Offset: 72
-          Type: 127 GoSliceHeaderType [][]*crypto/x509.Certificate
+          Type: 92 GoSliceHeaderType [][]*crypto/x509.Certificate
         - Name: SignedCertificateTimestamps
           Offset: 96
-          Type: 129 GoSliceHeaderType [][]uint8
+          Type: 94 GoSliceHeaderType [][]uint8
         - Name: OCSPResponse
           Offset: 120
-          Type: 76 GoSliceHeaderType []uint8
+          Type: 72 GoSliceHeaderType []uint8
         - Name: TLSUnique
           Offset: 144
-          Type: 76 GoSliceHeaderType []uint8
+          Type: 72 GoSliceHeaderType []uint8
         - Name: ECHAccepted
           Offset: 168
           Type: 4 BaseType bool
         - Name: ekm
           Offset: 176
-          Type: 131 GoSubroutineType func(string, []uint8, int) ([]uint8, error)
+          Type: 96 GoSubroutineType func(string, []uint8, int) ([]uint8, error)
         - Name: testingOnlyDidHRR
           Offset: 184
           Type: 4 BaseType bool
         - Name: testingOnlyCurveID
           Offset: 186
-          Type: 132 BaseType crypto/tls.CurveID
+          Type: 97 BaseType crypto/tls.CurveID
     - __kind: BaseType
-      ID: 132
+      ID: 97
       Name: crypto/tls.CurveID
       ByteSize: 2
       GoRuntimeType: 766048
       GoKind: 9
     - __kind: StructureType
-      ID: 82
+      ID: 107
       Name: crypto/x509.Certificate
       ByteSize: 1352
       GoRuntimeType: 2.234656e+06
@@ -1287,67 +1287,67 @@ Types:
       RawFields:
         - Name: Raw
           Offset: 0
-          Type: 76 GoSliceHeaderType []uint8
+          Type: 72 GoSliceHeaderType []uint8
         - Name: RawTBSCertificate
           Offset: 24
-          Type: 76 GoSliceHeaderType []uint8
+          Type: 72 GoSliceHeaderType []uint8
         - Name: RawSubjectPublicKeyInfo
           Offset: 48
-          Type: 76 GoSliceHeaderType []uint8
+          Type: 72 GoSliceHeaderType []uint8
         - Name: RawSubject
           Offset: 72
-          Type: 76 GoSliceHeaderType []uint8
+          Type: 72 GoSliceHeaderType []uint8
         - Name: RawIssuer
           Offset: 96
-          Type: 76 GoSliceHeaderType []uint8
+          Type: 72 GoSliceHeaderType []uint8
         - Name: Signature
           Offset: 120
-          Type: 76 GoSliceHeaderType []uint8
+          Type: 72 GoSliceHeaderType []uint8
         - Name: SignatureAlgorithm
           Offset: 144
-          Type: 83 BaseType crypto/x509.SignatureAlgorithm
+          Type: 109 BaseType crypto/x509.SignatureAlgorithm
         - Name: PublicKeyAlgorithm
           Offset: 152
-          Type: 84 BaseType crypto/x509.PublicKeyAlgorithm
+          Type: 110 BaseType crypto/x509.PublicKeyAlgorithm
         - Name: PublicKey
           Offset: 160
-          Type: 85 GoEmptyInterfaceType interface {}
+          Type: 111 GoEmptyInterfaceType interface {}
         - Name: Version
           Offset: 176
           Type: 9 BaseType int
         - Name: SerialNumber
           Offset: 184
-          Type: 86 PointerType *math/big.Int
+          Type: 112 PointerType *math/big.Int
         - Name: Issuer
           Offset: 192
-          Type: 91 StructureType crypto/x509/pkix.Name
+          Type: 114 StructureType crypto/x509/pkix.Name
         - Name: Subject
           Offset: 440
-          Type: 91 StructureType crypto/x509/pkix.Name
+          Type: 114 StructureType crypto/x509/pkix.Name
         - Name: NotBefore
           Offset: 688
-          Type: 96 StructureType time.Time
+          Type: 118 StructureType time.Time
         - Name: NotAfter
           Offset: 712
-          Type: 96 StructureType time.Time
+          Type: 118 StructureType time.Time
         - Name: KeyUsage
           Offset: 736
-          Type: 105 BaseType crypto/x509.KeyUsage
+          Type: 121 BaseType crypto/x509.KeyUsage
         - Name: Extensions
           Offset: 744
-          Type: 106 GoSliceHeaderType []crypto/x509/pkix.Extension
+          Type: 122 GoSliceHeaderType []crypto/x509/pkix.Extension
         - Name: ExtraExtensions
           Offset: 768
-          Type: 106 GoSliceHeaderType []crypto/x509/pkix.Extension
+          Type: 122 GoSliceHeaderType []crypto/x509/pkix.Extension
         - Name: UnhandledCriticalExtensions
           Offset: 792
-          Type: 109 GoSliceHeaderType []encoding/asn1.ObjectIdentifier
+          Type: 125 GoSliceHeaderType []encoding/asn1.ObjectIdentifier
         - Name: ExtKeyUsage
           Offset: 816
-          Type: 111 GoSliceHeaderType []crypto/x509.ExtKeyUsage
+          Type: 128 GoSliceHeaderType []crypto/x509.ExtKeyUsage
         - Name: UnknownExtKeyUsage
           Offset: 840
-          Type: 109 GoSliceHeaderType []encoding/asn1.ObjectIdentifier
+          Type: 125 GoSliceHeaderType []encoding/asn1.ObjectIdentifier
         - Name: BasicConstraintsValid
           Offset: 864
           Type: 4 BaseType bool
@@ -1362,78 +1362,78 @@ Types:
           Type: 4 BaseType bool
         - Name: SubjectKeyId
           Offset: 888
-          Type: 76 GoSliceHeaderType []uint8
+          Type: 72 GoSliceHeaderType []uint8
         - Name: AuthorityKeyId
           Offset: 912
-          Type: 76 GoSliceHeaderType []uint8
+          Type: 72 GoSliceHeaderType []uint8
         - Name: OCSPServer
           Offset: 936
-          Type: 51 GoSliceHeaderType []string
+          Type: 55 GoSliceHeaderType []string
         - Name: IssuingCertificateURL
           Offset: 960
-          Type: 51 GoSliceHeaderType []string
+          Type: 55 GoSliceHeaderType []string
         - Name: DNSNames
           Offset: 984
-          Type: 51 GoSliceHeaderType []string
+          Type: 55 GoSliceHeaderType []string
         - Name: EmailAddresses
           Offset: 1008
-          Type: 51 GoSliceHeaderType []string
+          Type: 55 GoSliceHeaderType []string
         - Name: IPAddresses
           Offset: 1032
-          Type: 114 GoSliceHeaderType []net.IP
+          Type: 131 GoSliceHeaderType []net.IP
         - Name: URIs
           Offset: 1056
-          Type: 117 GoSliceHeaderType []*net/url.URL
+          Type: 134 GoSliceHeaderType []*net/url.URL
         - Name: PermittedDNSDomainsCritical
           Offset: 1080
           Type: 4 BaseType bool
         - Name: PermittedDNSDomains
           Offset: 1088
-          Type: 51 GoSliceHeaderType []string
+          Type: 55 GoSliceHeaderType []string
         - Name: ExcludedDNSDomains
           Offset: 1112
-          Type: 51 GoSliceHeaderType []string
+          Type: 55 GoSliceHeaderType []string
         - Name: PermittedIPRanges
           Offset: 1136
-          Type: 119 GoSliceHeaderType []*net.IPNet
+          Type: 136 GoSliceHeaderType []*net.IPNet
         - Name: ExcludedIPRanges
           Offset: 1160
-          Type: 119 GoSliceHeaderType []*net.IPNet
+          Type: 136 GoSliceHeaderType []*net.IPNet
         - Name: PermittedEmailAddresses
           Offset: 1184
-          Type: 51 GoSliceHeaderType []string
+          Type: 55 GoSliceHeaderType []string
         - Name: ExcludedEmailAddresses
           Offset: 1208
-          Type: 51 GoSliceHeaderType []string
+          Type: 55 GoSliceHeaderType []string
         - Name: PermittedURIDomains
           Offset: 1232
-          Type: 51 GoSliceHeaderType []string
+          Type: 55 GoSliceHeaderType []string
         - Name: ExcludedURIDomains
           Offset: 1256
-          Type: 51 GoSliceHeaderType []string
+          Type: 55 GoSliceHeaderType []string
         - Name: CRLDistributionPoints
           Offset: 1280
-          Type: 51 GoSliceHeaderType []string
+          Type: 55 GoSliceHeaderType []string
         - Name: PolicyIdentifiers
           Offset: 1304
-          Type: 109 GoSliceHeaderType []encoding/asn1.ObjectIdentifier
+          Type: 125 GoSliceHeaderType []encoding/asn1.ObjectIdentifier
         - Name: Policies
           Offset: 1328
-          Type: 124 GoSliceHeaderType []crypto/x509.OID
+          Type: 139 GoSliceHeaderType []crypto/x509.OID
     - __kind: BaseType
-      ID: 113
+      ID: 130
       Name: crypto/x509.ExtKeyUsage
       ByteSize: 8
       GoRuntimeType: 537280
       GoKind: 2
     - __kind: BaseType
-      ID: 105
+      ID: 121
       Name: crypto/x509.KeyUsage
       ByteSize: 8
       GoRuntimeType: 537216
       GoKind: 2
     - __kind: StructureType
-      ID: 126
+      ID: 141
       Name: crypto/x509.OID
       ByteSize: 24
       GoRuntimeType: 1.717472e+06
@@ -1441,21 +1441,21 @@ Types:
       RawFields:
         - Name: der
           Offset: 0
-          Type: 76 GoSliceHeaderType []uint8
+          Type: 72 GoSliceHeaderType []uint8
     - __kind: BaseType
-      ID: 84
+      ID: 110
       Name: crypto/x509.PublicKeyAlgorithm
       ByteSize: 8
       GoRuntimeType: 768448
       GoKind: 2
     - __kind: BaseType
-      ID: 83
+      ID: 109
       Name: crypto/x509.SignatureAlgorithm
       ByteSize: 8
       GoRuntimeType: 1.070976e+06
       GoKind: 2
     - __kind: StructureType
-      ID: 94
+      ID: 117
       Name: crypto/x509/pkix.AttributeTypeAndValue
       ByteSize: 40
       GoRuntimeType: 1.316256e+06
@@ -1463,12 +1463,12 @@ Types:
       RawFields:
         - Name: Type
           Offset: 0
-          Type: 95 GoSliceHeaderType encoding/asn1.ObjectIdentifier
+          Type: 127 GoSliceHeaderType encoding/asn1.ObjectIdentifier
         - Name: Value
           Offset: 24
-          Type: 85 GoEmptyInterfaceType interface {}
+          Type: 111 GoEmptyInterfaceType interface {}
     - __kind: StructureType
-      ID: 108
+      ID: 124
       Name: crypto/x509/pkix.Extension
       ByteSize: 56
       GoRuntimeType: 1.455008e+06
@@ -1476,15 +1476,15 @@ Types:
       RawFields:
         - Name: Id
           Offset: 0
-          Type: 95 GoSliceHeaderType encoding/asn1.ObjectIdentifier
+          Type: 127 GoSliceHeaderType encoding/asn1.ObjectIdentifier
         - Name: Critical
           Offset: 24
           Type: 4 BaseType bool
         - Name: Value
           Offset: 32
-          Type: 76 GoSliceHeaderType []uint8
+          Type: 72 GoSliceHeaderType []uint8
     - __kind: StructureType
-      ID: 91
+      ID: 114
       Name: crypto/x509/pkix.Name
       ByteSize: 248
       GoRuntimeType: 2.046944e+06
@@ -1492,25 +1492,25 @@ Types:
       RawFields:
         - Name: Country
           Offset: 0
-          Type: 51 GoSliceHeaderType []string
+          Type: 55 GoSliceHeaderType []string
         - Name: Organization
           Offset: 24
-          Type: 51 GoSliceHeaderType []string
+          Type: 55 GoSliceHeaderType []string
         - Name: OrganizationalUnit
           Offset: 48
-          Type: 51 GoSliceHeaderType []string
+          Type: 55 GoSliceHeaderType []string
         - Name: Locality
           Offset: 72
-          Type: 51 GoSliceHeaderType []string
+          Type: 55 GoSliceHeaderType []string
         - Name: Province
           Offset: 96
-          Type: 51 GoSliceHeaderType []string
+          Type: 55 GoSliceHeaderType []string
         - Name: StreetAddress
           Offset: 120
-          Type: 51 GoSliceHeaderType []string
+          Type: 55 GoSliceHeaderType []string
         - Name: PostalCode
           Offset: 144
-          Type: 51 GoSliceHeaderType []string
+          Type: 55 GoSliceHeaderType []string
         - Name: SerialNumber
           Offset: 168
           Type: 11 GoStringHeaderType string
@@ -1519,12 +1519,12 @@ Types:
           Type: 11 GoStringHeaderType string
         - Name: Names
           Offset: 200
-          Type: 92 GoSliceHeaderType []crypto/x509/pkix.AttributeTypeAndValue
+          Type: 115 GoSliceHeaderType []crypto/x509/pkix.AttributeTypeAndValue
         - Name: ExtraNames
           Offset: 224
-          Type: 92 GoSliceHeaderType []crypto/x509/pkix.AttributeTypeAndValue
+          Type: 115 GoSliceHeaderType []crypto/x509/pkix.AttributeTypeAndValue
     - __kind: GoSliceHeaderType
-      ID: 95
+      ID: 127
       Name: encoding/asn1.ObjectIdentifier
       ByteSize: 24
       GoRuntimeType: 1.009856e+06
@@ -1539,9 +1539,9 @@ Types:
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 172 GoSliceDataType encoding/asn1.ObjectIdentifier.array
+      Data: 181 GoSliceDataType encoding/asn1.ObjectIdentifier.array
     - __kind: GoSliceDataType
-      ID: 172
+      ID: 181
       Name: encoding/asn1.ObjectIdentifier.array
       ByteSize: 2048
       Element: 9 BaseType int
@@ -1571,19 +1571,19 @@ Types:
       GoRuntimeType: 534528
       GoKind: 14
     - __kind: GoSubroutineType
-      ID: 60
+      ID: 54
       Name: func() (io.ReadCloser, error)
       ByteSize: 8
       GoRuntimeType: 634112
       GoKind: 19
     - __kind: GoSubroutineType
-      ID: 131
+      ID: 96
       Name: func(string, []uint8, int) ([]uint8, error)
       ByteSize: 8
       GoRuntimeType: 960256
       GoKind: 19
     - __kind: GoInterfaceType
-      ID: 151
+      ID: 41
       Name: gopkg.in/DataDog/dd-trace-go.v1/ddtrace.Span
       ByteSize: 16
       GoRuntimeType: 1.295936e+06
@@ -1596,7 +1596,7 @@ Types:
           Offset: 8
           Type: 19 VoidPointerType unsafe.Pointer
     - __kind: GoHMapHeaderType
-      ID: 67
+      ID: 86
       Name: hash<string,[]*mime/multipart.FileHeader>
       ByteSize: 48
       RawFields:
@@ -1617,20 +1617,20 @@ Types:
           Type: 2 BaseType uint32
         - Name: buckets
           Offset: 16
-          Type: 68 PointerType *bucket<string,[]*mime/multipart.FileHeader>
+          Type: 87 PointerType *bucket<string,[]*mime/multipart.FileHeader>
         - Name: oldbuckets
           Offset: 24
-          Type: 68 PointerType *bucket<string,[]*mime/multipart.FileHeader>
+          Type: 87 PointerType *bucket<string,[]*mime/multipart.FileHeader>
         - Name: nevacuate
           Offset: 32
           Type: 1 BaseType uintptr
         - Name: extra
           Offset: 40
-          Type: 52 PointerType *runtime.mapextra
-      BucketType: 69 GoHMapBucketType bucket<string,[]*mime/multipart.FileHeader>
-      BucketsType: 161 GoSliceDataType []bucket<string,[]*mime/multipart.FileHeader>.array
+          Type: 51 PointerType *runtime.mapextra
+      BucketType: 88 GoHMapBucketType bucket<string,[]*mime/multipart.FileHeader>
+      BucketsType: 164 GoSliceDataType []bucket<string,[]*mime/multipart.FileHeader>.array
     - __kind: GoHMapHeaderType
-      ID: 45
+      ID: 48
       Name: hash<string,[]string>
       ByteSize: 48
       RawFields:
@@ -1651,20 +1651,20 @@ Types:
           Type: 2 BaseType uint32
         - Name: buckets
           Offset: 16
-          Type: 46 PointerType *bucket<string,[]string>
+          Type: 49 PointerType *bucket<string,[]string>
         - Name: oldbuckets
           Offset: 24
-          Type: 46 PointerType *bucket<string,[]string>
+          Type: 49 PointerType *bucket<string,[]string>
         - Name: nevacuate
           Offset: 32
           Type: 1 BaseType uintptr
         - Name: extra
           Offset: 40
-          Type: 52 PointerType *runtime.mapextra
-      BucketType: 47 GoHMapBucketType bucket<string,[]string>
+          Type: 51 PointerType *runtime.mapextra
+      BucketType: 50 GoHMapBucketType bucket<string,[]string>
       BucketsType: 156 GoSliceDataType []bucket<string,[]string>.array
     - __kind: GoHMapHeaderType
-      ID: 144
+      ID: 69
       Name: hash<string,string>
       ByteSize: 48
       RawFields:
@@ -1685,18 +1685,18 @@ Types:
           Type: 2 BaseType uint32
         - Name: buckets
           Offset: 16
-          Type: 145 PointerType *bucket<string,string>
+          Type: 70 PointerType *bucket<string,string>
         - Name: oldbuckets
           Offset: 24
-          Type: 145 PointerType *bucket<string,string>
+          Type: 70 PointerType *bucket<string,string>
         - Name: nevacuate
           Offset: 32
           Type: 1 BaseType uintptr
         - Name: extra
           Offset: 40
-          Type: 52 PointerType *runtime.mapextra
-      BucketType: 146 GoHMapBucketType bucket<string,string>
-      BucketsType: 202 GoSliceDataType []bucket<string,string>.array
+          Type: 51 PointerType *runtime.mapextra
+      BucketType: 71 GoHMapBucketType bucket<string,string>
+      BucketsType: 159 GoSliceDataType []bucket<string,string>.array
     - __kind: BaseType
       ID: 9
       Name: int
@@ -1728,7 +1728,7 @@ Types:
       GoRuntimeType: 533632
       GoKind: 3
     - __kind: GoEmptyInterfaceType
-      ID: 85
+      ID: 111
       Name: interface {}
       ByteSize: 16
       GoRuntimeType: 785376
@@ -1741,7 +1741,7 @@ Types:
           Offset: 8
           Type: 19 VoidPointerType unsafe.Pointer
     - __kind: GoInterfaceType
-      ID: 59
+      ID: 53
       Name: io.ReadCloser
       ByteSize: 16
       GoRuntimeType: 1.067136e+06
@@ -1754,28 +1754,28 @@ Types:
           Offset: 8
           Type: 19 VoidPointerType unsafe.Pointer
     - __kind: GoMapType
-      ID: 65
+      ID: 84
       Name: map[string][]*mime/multipart.FileHeader
       ByteSize: 8
       GoRuntimeType: 887296
       GoKind: 21
-      HeaderType: 67 GoHMapHeaderType hash<string,[]*mime/multipart.FileHeader>
+      HeaderType: 86 GoHMapHeaderType hash<string,[]*mime/multipart.FileHeader>
     - __kind: GoMapType
-      ID: 64
+      ID: 83
       Name: map[string][]string
       ByteSize: 8
       GoRuntimeType: 882496
       GoKind: 21
-      HeaderType: 45 GoHMapHeaderType hash<string,[]string>
+      HeaderType: 48 GoHMapHeaderType hash<string,[]string>
     - __kind: GoMapType
-      ID: 142
+      ID: 67
       Name: map[string]string
       ByteSize: 8
       GoRuntimeType: 884128
       GoKind: 21
-      HeaderType: 144 GoHMapHeaderType hash<string,string>
+      HeaderType: 69 GoHMapHeaderType hash<string,string>
     - __kind: StructureType
-      ID: 87
+      ID: 113
       Name: math/big.Int
       ByteSize: 32
       GoRuntimeType: 1.308416e+06
@@ -1786,15 +1786,15 @@ Types:
           Type: 4 BaseType bool
         - Name: abs
           Offset: 8
-          Type: 88 GoSliceHeaderType math/big.nat
+          Type: 143 GoSliceHeaderType math/big.nat
     - __kind: BaseType
-      ID: 90
+      ID: 145
       Name: math/big.Word
       ByteSize: 8
       GoRuntimeType: 537536
       GoKind: 7
     - __kind: GoSliceHeaderType
-      ID: 88
+      ID: 143
       Name: math/big.nat
       ByteSize: 24
       GoRuntimeType: 2.21424e+06
@@ -1802,21 +1802,21 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 89 PointerType *math/big.Word
+          Type: 144 PointerType *math/big.Word
         - Name: len
           Offset: 8
           Type: 9 BaseType int
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 168 GoSliceDataType math/big.nat.array
+      Data: 195 GoSliceDataType math/big.nat.array
     - __kind: GoSliceDataType
-      ID: 168
+      ID: 195
       Name: math/big.nat.array
       ByteSize: 2048
-      Element: 90 BaseType math/big.Word
+      Element: 145 BaseType math/big.Word
     - __kind: StructureType
-      ID: 74
+      ID: 108
       Name: mime/multipart.FileHeader
       ByteSize: 88
       GoRuntimeType: 1.838016e+06
@@ -1827,13 +1827,13 @@ Types:
           Type: 11 GoStringHeaderType string
         - Name: Header
           Offset: 16
-          Type: 75 GoMapType net/textproto.MIMEHeader
+          Type: 142 GoMapType net/textproto.MIMEHeader
         - Name: Size
           Offset: 24
           Type: 13 BaseType int64
         - Name: content
           Offset: 32
-          Type: 76 GoSliceHeaderType []uint8
+          Type: 72 GoSliceHeaderType []uint8
         - Name: tmpfile
           Offset: 56
           Type: 11 GoStringHeaderType string
@@ -1844,7 +1844,7 @@ Types:
           Offset: 80
           Type: 4 BaseType bool
     - __kind: StructureType
-      ID: 63
+      ID: 58
       Name: mime/multipart.Form
       ByteSize: 16
       GoRuntimeType: 1.294336e+06
@@ -1852,12 +1852,12 @@ Types:
       RawFields:
         - Name: Value
           Offset: 0
-          Type: 64 GoMapType map[string][]string
+          Type: 83 GoMapType map[string][]string
         - Name: File
           Offset: 8
-          Type: 65 GoMapType map[string][]*mime/multipart.FileHeader
+          Type: 84 GoMapType map[string][]*mime/multipart.FileHeader
     - __kind: GoSliceHeaderType
-      ID: 116
+      ID: 133
       Name: net.IP
       ByteSize: 24
       GoRuntimeType: 1.94816e+06
@@ -1872,14 +1872,14 @@ Types:
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 186 GoSliceDataType net.IP.array
+      Data: 187 GoSliceDataType net.IP.array
     - __kind: GoSliceDataType
-      ID: 186
+      ID: 187
       Name: net.IP.array
       ByteSize: 2048
       Element: 3 BaseType uint8
     - __kind: GoSliceHeaderType
-      ID: 123
+      ID: 153
       Name: net.IPMask
       ByteSize: 24
       GoRuntimeType: 975808
@@ -1894,14 +1894,14 @@ Types:
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 192 GoSliceDataType net.IPMask.array
+      Data: 201 GoSliceDataType net.IPMask.array
     - __kind: GoSliceDataType
-      ID: 192
+      ID: 201
       Name: net.IPMask.array
       ByteSize: 2048
       Element: 3 BaseType uint8
     - __kind: StructureType
-      ID: 122
+      ID: 152
       Name: net.IPNet
       ByteSize: 48
       GoRuntimeType: 1.275936e+06
@@ -1909,17 +1909,17 @@ Types:
       RawFields:
         - Name: IP
           Offset: 0
-          Type: 116 GoSliceHeaderType net.IP
+          Type: 133 GoSliceHeaderType net.IP
         - Name: Mask
           Offset: 24
-          Type: 123 GoSliceHeaderType net.IPMask
+          Type: 153 GoSliceHeaderType net.IPMask
     - __kind: GoMapType
-      ID: 43
+      ID: 46
       Name: net/http.Header
       ByteSize: 8
       GoRuntimeType: 1.91744e+06
       GoKind: 21
-      HeaderType: 45 GoHMapHeaderType hash<string,[]string>
+      HeaderType: 48 GoHMapHeaderType hash<string,[]string>
     - __kind: StructureType
       ID: 38
       Name: net/http.Request
@@ -1932,7 +1932,7 @@ Types:
           Type: 11 GoStringHeaderType string
         - Name: URL
           Offset: 16
-          Type: 39 PointerType *net/url.URL
+          Type: 44 PointerType *net/url.URL
         - Name: Proto
           Offset: 24
           Type: 11 GoStringHeaderType string
@@ -1944,19 +1944,19 @@ Types:
           Type: 9 BaseType int
         - Name: Header
           Offset: 56
-          Type: 43 GoMapType net/http.Header
+          Type: 46 GoMapType net/http.Header
         - Name: Body
           Offset: 64
-          Type: 59 GoInterfaceType io.ReadCloser
+          Type: 53 GoInterfaceType io.ReadCloser
         - Name: GetBody
           Offset: 80
-          Type: 60 GoSubroutineType func() (io.ReadCloser, error)
+          Type: 54 GoSubroutineType func() (io.ReadCloser, error)
         - Name: ContentLength
           Offset: 88
           Type: 13 BaseType int64
         - Name: TransferEncoding
           Offset: 96
-          Type: 51 GoSliceHeaderType []string
+          Type: 55 GoSliceHeaderType []string
         - Name: Close
           Offset: 120
           Type: 4 BaseType bool
@@ -1965,16 +1965,16 @@ Types:
           Type: 11 GoStringHeaderType string
         - Name: Form
           Offset: 144
-          Type: 61 GoMapType net/url.Values
+          Type: 56 GoMapType net/url.Values
         - Name: PostForm
           Offset: 152
-          Type: 61 GoMapType net/url.Values
+          Type: 56 GoMapType net/url.Values
         - Name: MultipartForm
           Offset: 160
-          Type: 62 PointerType *mime/multipart.Form
+          Type: 57 PointerType *mime/multipart.Form
         - Name: Trailer
           Offset: 168
-          Type: 43 GoMapType net/http.Header
+          Type: 46 GoMapType net/http.Header
         - Name: RemoteAddr
           Offset: 176
           Type: 11 GoStringHeaderType string
@@ -1983,30 +1983,30 @@ Types:
           Type: 11 GoStringHeaderType string
         - Name: TLS
           Offset: 208
-          Type: 77 PointerType *crypto/tls.ConnectionState
+          Type: 59 PointerType *crypto/tls.ConnectionState
         - Name: Cancel
           Offset: 216
-          Type: 133 GoChannelType <-chan struct {}
+          Type: 61 GoChannelType <-chan struct {}
         - Name: Response
           Offset: 224
-          Type: 134 PointerType *net/http.Response
+          Type: 62 PointerType *net/http.Response
         - Name: Pattern
           Offset: 232
           Type: 11 GoStringHeaderType string
         - Name: ctx
           Offset: 248
-          Type: 136 GoInterfaceType context.Context
+          Type: 64 GoInterfaceType context.Context
         - Name: pat
           Offset: 264
-          Type: 137 PointerType *net/http.pattern
+          Type: 65 PointerType *net/http.pattern
         - Name: matches
           Offset: 272
-          Type: 51 GoSliceHeaderType []string
+          Type: 55 GoSliceHeaderType []string
         - Name: otherValues
           Offset: 296
-          Type: 142 GoMapType map[string]string
+          Type: 67 GoMapType map[string]string
     - __kind: StructureType
-      ID: 135
+      ID: 63
       Name: net/http.Response
       ByteSize: 144
       GoRuntimeType: 2.064832e+06
@@ -2029,16 +2029,16 @@ Types:
           Type: 9 BaseType int
         - Name: Header
           Offset: 56
-          Type: 43 GoMapType net/http.Header
+          Type: 46 GoMapType net/http.Header
         - Name: Body
           Offset: 64
-          Type: 59 GoInterfaceType io.ReadCloser
+          Type: 53 GoInterfaceType io.ReadCloser
         - Name: ContentLength
           Offset: 80
           Type: 13 BaseType int64
         - Name: TransferEncoding
           Offset: 88
-          Type: 51 GoSliceHeaderType []string
+          Type: 55 GoSliceHeaderType []string
         - Name: Close
           Offset: 112
           Type: 4 BaseType bool
@@ -2047,13 +2047,13 @@ Types:
           Type: 4 BaseType bool
         - Name: Trailer
           Offset: 120
-          Type: 43 GoMapType net/http.Header
+          Type: 46 GoMapType net/http.Header
         - Name: Request
           Offset: 128
           Type: 37 PointerType *net/http.Request
         - Name: TLS
           Offset: 136
-          Type: 77 PointerType *crypto/tls.ConnectionState
+          Type: 59 PointerType *crypto/tls.ConnectionState
     - __kind: GoInterfaceType
       ID: 36
       Name: net/http.ResponseWriter
@@ -2068,7 +2068,7 @@ Types:
           Offset: 8
           Type: 19 VoidPointerType unsafe.Pointer
     - __kind: StructureType
-      ID: 138
+      ID: 66
       Name: net/http.pattern
       ByteSize: 88
       GoRuntimeType: 1.701568e+06
@@ -2085,12 +2085,12 @@ Types:
           Type: 11 GoStringHeaderType string
         - Name: segments
           Offset: 48
-          Type: 139 GoSliceHeaderType []net/http.segment
+          Type: 98 GoSliceHeaderType []net/http.segment
         - Name: loc
           Offset: 72
           Type: 11 GoStringHeaderType string
     - __kind: StructureType
-      ID: 141
+      ID: 100
       Name: net/http.segment
       ByteSize: 24
       GoRuntimeType: 1.416032e+06
@@ -2106,14 +2106,14 @@ Types:
           Offset: 17
           Type: 4 BaseType bool
     - __kind: GoMapType
-      ID: 75
+      ID: 142
       Name: net/textproto.MIMEHeader
       ByteSize: 8
       GoRuntimeType: 1.595904e+06
       GoKind: 21
-      HeaderType: 45 GoHMapHeaderType hash<string,[]string>
+      HeaderType: 48 GoHMapHeaderType hash<string,[]string>
     - __kind: StructureType
-      ID: 40
+      ID: 45
       Name: net/url.URL
       ByteSize: 144
       GoRuntimeType: 1.986272e+06
@@ -2127,7 +2127,7 @@ Types:
           Type: 11 GoStringHeaderType string
         - Name: User
           Offset: 32
-          Type: 41 PointerType *net/url.Userinfo
+          Type: 74 PointerType *net/url.Userinfo
         - Name: Host
           Offset: 40
           Type: 11 GoStringHeaderType string
@@ -2153,7 +2153,7 @@ Types:
           Offset: 128
           Type: 11 GoStringHeaderType string
     - __kind: StructureType
-      ID: 42
+      ID: 75
       Name: net/url.Userinfo
       ByteSize: 40
       GoRuntimeType: 1.432736e+06
@@ -2169,14 +2169,14 @@ Types:
           Offset: 32
           Type: 4 BaseType bool
     - __kind: GoMapType
-      ID: 61
+      ID: 56
       Name: net/url.Values
       ByteSize: 8
       GoRuntimeType: 1.670784e+06
       GoKind: 21
-      HeaderType: 45 GoHMapHeaderType hash<string,[]string>
+      HeaderType: 48 GoHMapHeaderType hash<string,[]string>
     - __kind: StructureType
-      ID: 58
+      ID: 82
       Name: runtime.bmap
       ByteSize: 8
       GoRuntimeType: 1.109728e+06
@@ -2184,9 +2184,9 @@ Types:
       RawFields:
         - Name: tophash
           Offset: 0
-          Type: 48 ArrayType [8]uint8
+          Type: 76 ArrayType [8]uint8
     - __kind: StructureType
-      ID: 53
+      ID: 52
       Name: runtime.mapextra
       ByteSize: 24
       GoRuntimeType: 1.428704e+06
@@ -2194,13 +2194,13 @@ Types:
       RawFields:
         - Name: overflow
           Offset: 0
-          Type: 54 PointerType *[]*runtime.bmap
+          Type: 79 PointerType *[]*runtime.bmap
         - Name: oldoverflow
           Offset: 8
-          Type: 54 PointerType *[]*runtime.bmap
+          Type: 79 PointerType *[]*runtime.bmap
         - Name: nextOverflow
           Offset: 16
-          Type: 57 PointerType *runtime.bmap
+          Type: 81 PointerType *runtime.bmap
     - __kind: GoStringHeaderType
       ID: 11
       Name: string
@@ -2220,7 +2220,7 @@ Types:
       Name: string.str
       ByteSize: 2048
     - __kind: StructureType
-      ID: 98
+      ID: 120
       Name: time.Location
       ByteSize: 104
       GoRuntimeType: 1.833984e+06
@@ -2231,10 +2231,10 @@ Types:
           Type: 11 GoStringHeaderType string
         - Name: zone
           Offset: 16
-          Type: 99 GoSliceHeaderType []time.zone
+          Type: 146 GoSliceHeaderType []time.zone
         - Name: tx
           Offset: 40
-          Type: 102 GoSliceHeaderType []time.zoneTrans
+          Type: 149 GoSliceHeaderType []time.zoneTrans
         - Name: extend
           Offset: 64
           Type: 11 GoStringHeaderType string
@@ -2246,9 +2246,9 @@ Types:
           Type: 13 BaseType int64
         - Name: cacheZone
           Offset: 96
-          Type: 100 PointerType *time.zone
+          Type: 147 PointerType *time.zone
     - __kind: StructureType
-      ID: 96
+      ID: 118
       Name: time.Time
       ByteSize: 24
       GoRuntimeType: 2.215168e+06
@@ -2262,9 +2262,9 @@ Types:
           Type: 13 BaseType int64
         - Name: loc
           Offset: 16
-          Type: 97 PointerType *time.Location
+          Type: 119 PointerType *time.Location
     - __kind: StructureType
-      ID: 101
+      ID: 148
       Name: time.zone
       ByteSize: 32
       GoRuntimeType: 1.421024e+06
@@ -2280,7 +2280,7 @@ Types:
           Offset: 24
           Type: 4 BaseType bool
     - __kind: StructureType
-      ID: 104
+      ID: 151
       Name: time.zoneTrans
       ByteSize: 16
       GoRuntimeType: 1.623328e+06

--- a/pkg/dyninst/irgen/testdata/snapshot/rc_tester_v1.arch=amd64,toolchain=go1.23.11.yaml
+++ b/pkg/dyninst/irgen/testdata/snapshot/rc_tester_v1.arch=amd64,toolchain=go1.23.11.yaml
@@ -33,7 +33,7 @@ Subprograms:
       InlinePCRanges: []
       Variables:
         - Name: w
-          Type: 1 GoInterfaceType net/http.ResponseWriter
+          Type: 36 GoInterfaceType net/http.ResponseWriter
           Locations:
             - Range: 0xd289e0..0xd28a4c
               Pieces:
@@ -56,7 +56,7 @@ Subprograms:
           IsParameter: true
           IsReturn: false
         - Name: r
-          Type: 3 PointerType *net/http.Request
+          Type: 37 PointerType *net/http.Request
           Locations:
             - Range: 0xd289e0..0xd28a56
               Pieces: [{Size: 8, Op: {RegNo: 2, Shift: 0}}]
@@ -65,7 +65,7 @@ Subprograms:
           IsParameter: true
           IsReturn: false
         - Name: '&buf'
-          Type: 126 PointerType *bytes.Buffer
+          Type: 148 PointerType *bytes.Buffer
           Locations:
             - Range: 0xd28b8f..0xd28bb1
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
@@ -74,7 +74,7 @@ Subprograms:
           IsParameter: false
           IsReturn: false
         - Name: span
-          Type: 129 GoInterfaceType gopkg.in/DataDog/dd-trace-go.v1/ddtrace.Span
+          Type: 151 GoInterfaceType gopkg.in/DataDog/dd-trace-go.v1/ddtrace.Span
           Locations:
             - Range: 0xd28a68..0xd28a68
               Pieces:
@@ -97,7 +97,7 @@ Subprograms:
           IsParameter: false
           IsReturn: false
         - Name: .autotmp_14
-          Type: 130 StructureType context.backgroundCtx
+          Type: 152 StructureType context.backgroundCtx
           Locations:
             - Range: 0xd289e0..0xd28c90
               Pieces: [{Size: 0, Op: {CfaOffset: 0}}]
@@ -109,7 +109,7 @@ Subprograms:
       InlinePCRanges: []
       Variables:
         - Name: path
-          Type: 5 GoStringHeaderType string
+          Type: 11 GoStringHeaderType string
           Locations:
             - Range: 0xd28d60..0xd28d85
               Pieces:
@@ -121,39 +121,39 @@ Subprograms:
           IsReturn: false
 Types:
     - __kind: PointerType
-      ID: 56
+      ID: 80
       Name: '**crypto/x509.Certificate'
       ByteSize: 8
-      Pointee: 57 PointerType *crypto/x509.Certificate
+      Pointee: 81 PointerType *crypto/x509.Certificate
     - __kind: PointerType
-      ID: 48
+      ID: 72
       Name: '**mime/multipart.FileHeader'
       ByteSize: 8
       GoKind: 22
-      Pointee: 49 PointerType *mime/multipart.FileHeader
+      Pointee: 73 PointerType *mime/multipart.FileHeader
     - __kind: PointerType
-      ID: 98
+      ID: 120
       Name: '**net.IPNet'
       ByteSize: 8
       GoKind: 22
-      Pointee: 99 PointerType *net.IPNet
+      Pointee: 121 PointerType *net.IPNet
     - __kind: PointerType
-      ID: 96
+      ID: 118
       Name: '**net/url.URL'
       ByteSize: 8
       GoKind: 22
-      Pointee: 9 PointerType *net/url.URL
+      Pointee: 39 PointerType *net/url.URL
     - __kind: PointerType
-      ID: 31
+      ID: 56
       Name: '**runtime.bmap'
       ByteSize: 8
-      Pointee: 32 PointerType *runtime.bmap
+      Pointee: 57 PointerType *runtime.bmap
     - __kind: PointerType
-      ID: 106
+      ID: 128
       Name: '*[]*crypto/x509.Certificate'
       ByteSize: 8
       GoKind: 22
-      Pointee: 55 GoSliceHeaderType []*crypto/x509.Certificate
+      Pointee: 79 GoSliceHeaderType []*crypto/x509.Certificate
     - __kind: PointerType
       ID: 167
       Name: '*[]*crypto/x509.Certificate.array'
@@ -175,12 +175,12 @@ Types:
       ByteSize: 8
       Pointee: 188 GoSliceDataType []*net/url.URL.array
     - __kind: PointerType
-      ID: 29
+      ID: 54
       Name: '*[]*runtime.bmap'
       ByteSize: 8
       GoRuntimeType: 466432
       GoKind: 22
-      Pointee: 30 GoSliceHeaderType []*runtime.bmap
+      Pointee: 55 GoSliceHeaderType []*runtime.bmap
     - __kind: PointerType
       ID: 160
       Name: '*[]*runtime.bmap.array'
@@ -247,211 +247,211 @@ Types:
       ByteSize: 8
       Pointee: 176 GoSliceDataType []time.zoneTrans.array
     - __kind: PointerType
-      ID: 108
+      ID: 130
       Name: '*[]uint8'
       ByteSize: 8
       GoRuntimeType: 452512
       GoKind: 22
-      Pointee: 52 GoSliceHeaderType []uint8
+      Pointee: 76 GoSliceHeaderType []uint8
     - __kind: PointerType
       ID: 165
       Name: '*[]uint8.array'
       ByteSize: 8
       Pointee: 164 GoSliceDataType []uint8.array
     - __kind: PointerType
-      ID: 132
+      ID: 5
       Name: '*bool'
       ByteSize: 8
       GoRuntimeType: 372640
       GoKind: 22
-      Pointee: 13 BaseType bool
+      Pointee: 4 BaseType bool
     - __kind: PointerType
-      ID: 44
+      ID: 68
       Name: '*bucket<string,[]*mime/multipart.FileHeader>'
       ByteSize: 8
-      Pointee: 45 GoHMapBucketType bucket<string,[]*mime/multipart.FileHeader>
+      Pointee: 69 GoHMapBucketType bucket<string,[]*mime/multipart.FileHeader>
     - __kind: PointerType
-      ID: 19
+      ID: 46
       Name: '*bucket<string,[]string>'
       ByteSize: 8
-      Pointee: 20 GoHMapBucketType bucket<string,[]string>
+      Pointee: 47 GoHMapBucketType bucket<string,[]string>
     - __kind: PointerType
-      ID: 123
+      ID: 145
       Name: '*bucket<string,string>'
       ByteSize: 8
-      Pointee: 124 GoHMapBucketType bucket<string,string>
+      Pointee: 146 GoHMapBucketType bucket<string,string>
     - __kind: PointerType
-      ID: 126
+      ID: 148
       Name: '*bytes.Buffer'
       ByteSize: 8
       GoRuntimeType: 2.114976e+06
       GoKind: 22
-      Pointee: 127 StructureType bytes.Buffer
+      Pointee: 149 StructureType bytes.Buffer
     - __kind: PointerType
-      ID: 53
+      ID: 77
       Name: '*crypto/tls.ConnectionState'
       ByteSize: 8
       GoRuntimeType: 835936
       GoKind: 22
-      Pointee: 54 StructureType crypto/tls.ConnectionState
+      Pointee: 78 StructureType crypto/tls.ConnectionState
     - __kind: PointerType
-      ID: 57
+      ID: 81
       Name: '*crypto/x509.Certificate'
       ByteSize: 8
       GoRuntimeType: 1.90528e+06
       GoKind: 22
-      Pointee: 58 StructureType crypto/x509.Certificate
+      Pointee: 82 StructureType crypto/x509.Certificate
     - __kind: PointerType
-      ID: 90
+      ID: 112
       Name: '*crypto/x509.ExtKeyUsage'
       ByteSize: 8
       GoRuntimeType: 395040
       GoKind: 22
-      Pointee: 91 BaseType crypto/x509.ExtKeyUsage
+      Pointee: 113 BaseType crypto/x509.ExtKeyUsage
     - __kind: PointerType
-      ID: 103
+      ID: 125
       Name: '*crypto/x509.OID'
       ByteSize: 8
       GoRuntimeType: 1.717248e+06
       GoKind: 22
-      Pointee: 104 StructureType crypto/x509.OID
+      Pointee: 126 StructureType crypto/x509.OID
     - __kind: PointerType
-      ID: 69
+      ID: 93
       Name: '*crypto/x509/pkix.AttributeTypeAndValue'
       ByteSize: 8
       GoRuntimeType: 408800
       GoKind: 22
-      Pointee: 70 StructureType crypto/x509/pkix.AttributeTypeAndValue
+      Pointee: 94 StructureType crypto/x509/pkix.AttributeTypeAndValue
     - __kind: PointerType
-      ID: 85
+      ID: 107
       Name: '*crypto/x509/pkix.Extension'
       ByteSize: 8
       GoRuntimeType: 408992
       GoKind: 22
-      Pointee: 86 StructureType crypto/x509/pkix.Extension
+      Pointee: 108 StructureType crypto/x509/pkix.Extension
     - __kind: PointerType
-      ID: 88
+      ID: 110
       Name: '*encoding/asn1.ObjectIdentifier'
       ByteSize: 8
       GoRuntimeType: 1.009728e+06
       GoKind: 22
-      Pointee: 71 GoSliceHeaderType encoding/asn1.ObjectIdentifier
+      Pointee: 95 GoSliceHeaderType encoding/asn1.ObjectIdentifier
     - __kind: PointerType
       ID: 173
       Name: '*encoding/asn1.ObjectIdentifier.array'
       ByteSize: 8
       Pointee: 172 GoSliceDataType encoding/asn1.ObjectIdentifier.array
     - __kind: PointerType
-      ID: 151
+      ID: 33
       Name: '*error'
       ByteSize: 8
       GoRuntimeType: 371552
       GoKind: 22
-      Pointee: 139 GoInterfaceType error
+      Pointee: 18 GoInterfaceType error
     - __kind: PointerType
-      ID: 153
+      ID: 35
       Name: '*float32'
       ByteSize: 8
       GoRuntimeType: 372512
       GoKind: 22
-      Pointee: 137 BaseType float32
+      Pointee: 16 BaseType float32
     - __kind: PointerType
-      ID: 144
+      ID: 25
       Name: '*float64'
       ByteSize: 8
       GoRuntimeType: 372576
       GoKind: 22
-      Pointee: 138 BaseType float64
+      Pointee: 17 BaseType float64
     - __kind: PointerType
-      ID: 42
+      ID: 66
       Name: '*hash<string,[]*mime/multipart.FileHeader>'
       ByteSize: 8
-      Pointee: 43 GoHMapHeaderType hash<string,[]*mime/multipart.FileHeader>
+      Pointee: 67 GoHMapHeaderType hash<string,[]*mime/multipart.FileHeader>
     - __kind: PointerType
-      ID: 15
+      ID: 44
       Name: '*hash<string,[]string>'
       ByteSize: 8
-      Pointee: 16 GoHMapHeaderType hash<string,[]string>
+      Pointee: 45 GoHMapHeaderType hash<string,[]string>
     - __kind: PointerType
-      ID: 121
+      ID: 143
       Name: '*hash<string,string>'
       ByteSize: 8
-      Pointee: 122 GoHMapHeaderType hash<string,string>
+      Pointee: 144 GoHMapHeaderType hash<string,string>
     - __kind: PointerType
-      ID: 72
+      ID: 27
       Name: '*int'
       ByteSize: 8
       GoRuntimeType: 372192
       GoKind: 22
-      Pointee: 8 BaseType int
+      Pointee: 9 BaseType int
     - __kind: PointerType
-      ID: 148
+      ID: 30
       Name: '*int16'
       ByteSize: 8
       GoRuntimeType: 371808
       GoKind: 22
-      Pointee: 149 BaseType int16
+      Pointee: 31 BaseType int16
     - __kind: PointerType
-      ID: 140
+      ID: 20
       Name: '*int32'
       ByteSize: 8
       GoRuntimeType: 371936
       GoKind: 22
-      Pointee: 134 BaseType int32
+      Pointee: 12 BaseType int32
     - __kind: PointerType
-      ID: 145
+      ID: 26
       Name: '*int64'
       ByteSize: 8
       GoRuntimeType: 372064
       GoKind: 22
-      Pointee: 36 BaseType int64
+      Pointee: 13 BaseType int64
     - __kind: PointerType
-      ID: 150
+      ID: 32
       Name: '*int8'
       ByteSize: 8
       GoRuntimeType: 371680
       GoKind: 22
-      Pointee: 135 BaseType int8
+      Pointee: 14 BaseType int8
     - __kind: PointerType
-      ID: 62
+      ID: 86
       Name: '*math/big.Int'
       ByteSize: 8
       GoRuntimeType: 2.231104e+06
       GoKind: 22
-      Pointee: 63 StructureType math/big.Int
+      Pointee: 87 StructureType math/big.Int
     - __kind: PointerType
-      ID: 65
+      ID: 89
       Name: '*math/big.Word'
       ByteSize: 8
       GoRuntimeType: 397856
       GoKind: 22
-      Pointee: 66 BaseType math/big.Word
+      Pointee: 90 BaseType math/big.Word
     - __kind: PointerType
       ID: 169
       Name: '*math/big.nat.array'
       ByteSize: 8
       Pointee: 168 GoSliceDataType math/big.nat.array
     - __kind: PointerType
-      ID: 49
+      ID: 73
       Name: '*mime/multipart.FileHeader'
       ByteSize: 8
       GoRuntimeType: 837376
       GoKind: 22
-      Pointee: 50 StructureType mime/multipart.FileHeader
+      Pointee: 74 StructureType mime/multipart.FileHeader
     - __kind: PointerType
-      ID: 38
+      ID: 62
       Name: '*mime/multipart.Form'
       ByteSize: 8
       GoRuntimeType: 837472
       GoKind: 22
-      Pointee: 39 StructureType mime/multipart.Form
+      Pointee: 63 StructureType mime/multipart.Form
     - __kind: PointerType
-      ID: 93
+      ID: 115
       Name: '*net.IP'
       ByteSize: 8
       GoRuntimeType: 1.974144e+06
       GoKind: 22
-      Pointee: 94 GoSliceHeaderType net.IP
+      Pointee: 116 GoSliceHeaderType net.IP
     - __kind: PointerType
       ID: 187
       Name: '*net.IP.array'
@@ -463,145 +463,145 @@ Types:
       ByteSize: 8
       Pointee: 192 GoSliceDataType net.IPMask.array
     - __kind: PointerType
-      ID: 99
+      ID: 121
       Name: '*net.IPNet'
       ByteSize: 8
       GoRuntimeType: 1.095776e+06
       GoKind: 22
-      Pointee: 100 StructureType net.IPNet
+      Pointee: 122 StructureType net.IPNet
     - __kind: PointerType
-      ID: 3
+      ID: 37
       Name: '*net/http.Request'
       ByteSize: 8
       GoRuntimeType: 2.154176e+06
       GoKind: 22
-      Pointee: 4 StructureType net/http.Request
+      Pointee: 38 StructureType net/http.Request
     - __kind: PointerType
-      ID: 112
+      ID: 134
       Name: '*net/http.Response'
       ByteSize: 8
       GoRuntimeType: 1.590912e+06
       GoKind: 22
-      Pointee: 113 StructureType net/http.Response
+      Pointee: 135 StructureType net/http.Response
     - __kind: PointerType
-      ID: 115
+      ID: 137
       Name: '*net/http.pattern'
       ByteSize: 8
       GoRuntimeType: 1.416224e+06
       GoKind: 22
-      Pointee: 116 StructureType net/http.pattern
+      Pointee: 138 StructureType net/http.pattern
     - __kind: PointerType
-      ID: 118
+      ID: 140
       Name: '*net/http.segment'
       ByteSize: 8
       GoRuntimeType: 364000
       GoKind: 22
-      Pointee: 119 StructureType net/http.segment
+      Pointee: 141 StructureType net/http.segment
     - __kind: PointerType
-      ID: 9
+      ID: 39
       Name: '*net/url.URL'
       ByteSize: 8
       GoRuntimeType: 1.949216e+06
       GoKind: 22
-      Pointee: 10 StructureType net/url.URL
+      Pointee: 40 StructureType net/url.URL
     - __kind: PointerType
-      ID: 11
+      ID: 41
       Name: '*net/url.Userinfo'
       ByteSize: 8
       GoRuntimeType: 1.114208e+06
       GoKind: 22
-      Pointee: 12 StructureType net/url.Userinfo
+      Pointee: 42 StructureType net/url.Userinfo
     - __kind: PointerType
-      ID: 32
+      ID: 57
       Name: '*runtime.bmap'
       ByteSize: 8
       GoRuntimeType: 1.109856e+06
       GoKind: 22
-      Pointee: 33 StructureType runtime.bmap
+      Pointee: 58 StructureType runtime.bmap
     - __kind: PointerType
-      ID: 27
+      ID: 52
       Name: '*runtime.mapextra'
       ByteSize: 8
       GoRuntimeType: 375520
       GoKind: 22
-      Pointee: 28 StructureType runtime.mapextra
+      Pointee: 53 StructureType runtime.mapextra
     - __kind: PointerType
-      ID: 25
+      ID: 22
       Name: '*string'
       ByteSize: 8
       GoRuntimeType: 371616
       GoKind: 22
-      Pointee: 5 GoStringHeaderType string
+      Pointee: 11 GoStringHeaderType string
     - __kind: PointerType
       ID: 155
       Name: '*string.str'
       ByteSize: 8
       Pointee: 154 GoStringDataType string.str
     - __kind: PointerType
-      ID: 75
+      ID: 97
       Name: '*time.Location'
       ByteSize: 8
       GoRuntimeType: 1.421216e+06
       GoKind: 22
-      Pointee: 76 StructureType time.Location
+      Pointee: 98 StructureType time.Location
     - __kind: PointerType
-      ID: 78
+      ID: 100
       Name: '*time.zone'
       ByteSize: 8
       GoRuntimeType: 367072
       GoKind: 22
-      Pointee: 79 StructureType time.zone
+      Pointee: 101 StructureType time.zone
     - __kind: PointerType
-      ID: 81
+      ID: 103
       Name: '*time.zoneTrans'
       ByteSize: 8
       GoRuntimeType: 367136
       GoKind: 22
-      Pointee: 82 StructureType time.zoneTrans
+      Pointee: 104 StructureType time.zoneTrans
     - __kind: PointerType
-      ID: 152
+      ID: 34
       Name: '*uint'
       ByteSize: 8
       GoRuntimeType: 372256
       GoKind: 22
-      Pointee: 136 BaseType uint
+      Pointee: 15 BaseType uint
     - __kind: PointerType
-      ID: 147
+      ID: 29
       Name: '*uint16'
       ByteSize: 8
       GoRuntimeType: 371872
       GoKind: 22
-      Pointee: 17 BaseType uint16
+      Pointee: 7 BaseType uint16
     - __kind: PointerType
-      ID: 141
+      ID: 21
       Name: '*uint32'
       ByteSize: 8
       GoRuntimeType: 372000
       GoKind: 22
-      Pointee: 18 BaseType uint32
+      Pointee: 2 BaseType uint32
     - __kind: PointerType
-      ID: 146
+      ID: 28
       Name: '*uint64'
       ByteSize: 8
       GoRuntimeType: 372128
       GoKind: 22
-      Pointee: 74 BaseType uint64
+      Pointee: 10 BaseType uint64
     - __kind: PointerType
       ID: 6
       Name: '*uint8'
       ByteSize: 8
       GoRuntimeType: 371744
       GoKind: 22
-      Pointee: 7 BaseType uint8
+      Pointee: 3 BaseType uint8
     - __kind: PointerType
-      ID: 133
+      ID: 8
       Name: '*uintptr'
       ByteSize: 8
       GoRuntimeType: 372320
       GoKind: 22
-      Pointee: 26 BaseType uintptr
+      Pointee: 1 BaseType uintptr
     - __kind: GoChannelType
-      ID: 111
+      ID: 133
       Name: <-chan struct {}
       GoRuntimeType: 546752
       GoKind: 18
@@ -614,7 +614,7 @@ Types:
         - Name: w
           Offset: 1
           Expression:
-            Type: 1 GoInterfaceType net/http.ResponseWriter
+            Type: 36 GoInterfaceType net/http.ResponseWriter
             Operations:
                 - __kind: LocationOp
                   Variable: {subprogram: 1, index: 0, name: w}
@@ -623,7 +623,7 @@ Types:
         - Name: r
           Offset: 17
           Expression:
-            Type: 3 PointerType *net/http.Request
+            Type: 37 PointerType *net/http.Request
             Operations:
                 - __kind: LocationOp
                   Variable: {subprogram: 1, index: 1, name: r}
@@ -638,23 +638,23 @@ Types:
         - Name: path
           Offset: 1
           Expression:
-            Type: 5 GoStringHeaderType string
+            Type: 11 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
                   Variable: {subprogram: 2, index: 0, name: path}
                   Offset: 0
                   ByteSize: 16
     - __kind: ArrayType
-      ID: 21
+      ID: 48
       Name: '[8]uint8'
       ByteSize: 8
       GoRuntimeType: 621728
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 7 BaseType uint8
+      Element: 3 BaseType uint8
     - __kind: GoSliceHeaderType
-      ID: 55
+      ID: 79
       Name: '[]*crypto/x509.Certificate'
       ByteSize: 24
       GoRuntimeType: 469536
@@ -662,21 +662,21 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 56 PointerType **crypto/x509.Certificate
+          Type: 80 PointerType **crypto/x509.Certificate
         - Name: len
           Offset: 8
-          Type: 8 BaseType int
+          Type: 9 BaseType int
         - Name: cap
           Offset: 16
-          Type: 8 BaseType int
+          Type: 9 BaseType int
       Data: 166 GoSliceDataType []*crypto/x509.Certificate.array
     - __kind: GoSliceDataType
       ID: 166
       Name: '[]*crypto/x509.Certificate.array'
       ByteSize: 2048
-      Element: 57 PointerType *crypto/x509.Certificate
+      Element: 81 PointerType *crypto/x509.Certificate
     - __kind: GoSliceHeaderType
-      ID: 47
+      ID: 71
       Name: '[]*mime/multipart.FileHeader'
       ByteSize: 24
       GoRuntimeType: 457376
@@ -684,21 +684,21 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 48 PointerType **mime/multipart.FileHeader
+          Type: 72 PointerType **mime/multipart.FileHeader
         - Name: len
           Offset: 8
-          Type: 8 BaseType int
+          Type: 9 BaseType int
         - Name: cap
           Offset: 16
-          Type: 8 BaseType int
+          Type: 9 BaseType int
       Data: 162 GoSliceDataType []*mime/multipart.FileHeader.array
     - __kind: GoSliceDataType
       ID: 162
       Name: '[]*mime/multipart.FileHeader.array'
       ByteSize: 2048
-      Element: 49 PointerType *mime/multipart.FileHeader
+      Element: 73 PointerType *mime/multipart.FileHeader
     - __kind: GoSliceHeaderType
-      ID: 97
+      ID: 119
       Name: '[]*net.IPNet'
       ByteSize: 24
       GoRuntimeType: 481568
@@ -706,21 +706,21 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 98 PointerType **net.IPNet
+          Type: 120 PointerType **net.IPNet
         - Name: len
           Offset: 8
-          Type: 8 BaseType int
+          Type: 9 BaseType int
         - Name: cap
           Offset: 16
-          Type: 8 BaseType int
+          Type: 9 BaseType int
       Data: 190 GoSliceDataType []*net.IPNet.array
     - __kind: GoSliceDataType
       ID: 190
       Name: '[]*net.IPNet.array'
       ByteSize: 2048
-      Element: 99 PointerType *net.IPNet
+      Element: 121 PointerType *net.IPNet
     - __kind: GoSliceHeaderType
-      ID: 95
+      ID: 117
       Name: '[]*net/url.URL'
       ByteSize: 24
       GoRuntimeType: 481504
@@ -728,21 +728,21 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 96 PointerType **net/url.URL
+          Type: 118 PointerType **net/url.URL
         - Name: len
           Offset: 8
-          Type: 8 BaseType int
+          Type: 9 BaseType int
         - Name: cap
           Offset: 16
-          Type: 8 BaseType int
+          Type: 9 BaseType int
       Data: 188 GoSliceDataType []*net/url.URL.array
     - __kind: GoSliceDataType
       ID: 188
       Name: '[]*net/url.URL.array'
       ByteSize: 2048
-      Element: 9 PointerType *net/url.URL
+      Element: 39 PointerType *net/url.URL
     - __kind: GoSliceHeaderType
-      ID: 30
+      ID: 55
       Name: '[]*runtime.bmap'
       ByteSize: 24
       GoRuntimeType: 466368
@@ -750,21 +750,21 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 31 PointerType **runtime.bmap
+          Type: 56 PointerType **runtime.bmap
         - Name: len
           Offset: 8
-          Type: 8 BaseType int
+          Type: 9 BaseType int
         - Name: cap
           Offset: 16
-          Type: 8 BaseType int
+          Type: 9 BaseType int
       Data: 159 GoSliceDataType []*runtime.bmap.array
     - __kind: GoSliceDataType
       ID: 159
       Name: '[]*runtime.bmap.array'
       ByteSize: 2048
-      Element: 32 PointerType *runtime.bmap
+      Element: 57 PointerType *runtime.bmap
     - __kind: GoSliceHeaderType
-      ID: 105
+      ID: 127
       Name: '[][]*crypto/x509.Certificate'
       ByteSize: 24
       GoRuntimeType: 469664
@@ -772,21 +772,21 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 106 PointerType *[]*crypto/x509.Certificate
+          Type: 128 PointerType *[]*crypto/x509.Certificate
         - Name: len
           Offset: 8
-          Type: 8 BaseType int
+          Type: 9 BaseType int
         - Name: cap
           Offset: 16
-          Type: 8 BaseType int
+          Type: 9 BaseType int
       Data: 196 GoSliceDataType [][]*crypto/x509.Certificate.array
     - __kind: GoSliceDataType
       ID: 196
       Name: '[][]*crypto/x509.Certificate.array'
       ByteSize: 2048
-      Element: 55 GoSliceHeaderType []*crypto/x509.Certificate
+      Element: 79 GoSliceHeaderType []*crypto/x509.Certificate
     - __kind: GoSliceHeaderType
-      ID: 107
+      ID: 129
       Name: '[][]uint8'
       ByteSize: 24
       GoRuntimeType: 452832
@@ -794,36 +794,36 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 108 PointerType *[]uint8
+          Type: 130 PointerType *[]uint8
         - Name: len
           Offset: 8
-          Type: 8 BaseType int
+          Type: 9 BaseType int
         - Name: cap
           Offset: 16
-          Type: 8 BaseType int
+          Type: 9 BaseType int
       Data: 198 GoSliceDataType [][]uint8.array
     - __kind: GoSliceDataType
       ID: 198
       Name: '[][]uint8.array'
       ByteSize: 2048
-      Element: 52 GoSliceHeaderType []uint8
+      Element: 76 GoSliceHeaderType []uint8
     - __kind: GoSliceDataType
       ID: 161
       Name: '[]bucket<string,[]*mime/multipart.FileHeader>.array'
       ByteSize: 2048
-      Element: 45 GoHMapBucketType bucket<string,[]*mime/multipart.FileHeader>
+      Element: 69 GoHMapBucketType bucket<string,[]*mime/multipart.FileHeader>
     - __kind: GoSliceDataType
       ID: 156
       Name: '[]bucket<string,[]string>.array'
       ByteSize: 2048
-      Element: 20 GoHMapBucketType bucket<string,[]string>
+      Element: 47 GoHMapBucketType bucket<string,[]string>
     - __kind: GoSliceDataType
       ID: 202
       Name: '[]bucket<string,string>.array'
       ByteSize: 2048
-      Element: 124 GoHMapBucketType bucket<string,string>
+      Element: 146 GoHMapBucketType bucket<string,string>
     - __kind: GoSliceHeaderType
-      ID: 89
+      ID: 111
       Name: '[]crypto/x509.ExtKeyUsage'
       ByteSize: 24
       GoRuntimeType: 470816
@@ -831,21 +831,21 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 90 PointerType *crypto/x509.ExtKeyUsage
+          Type: 112 PointerType *crypto/x509.ExtKeyUsage
         - Name: len
           Offset: 8
-          Type: 8 BaseType int
+          Type: 9 BaseType int
         - Name: cap
           Offset: 16
-          Type: 8 BaseType int
+          Type: 9 BaseType int
       Data: 182 GoSliceDataType []crypto/x509.ExtKeyUsage.array
     - __kind: GoSliceDataType
       ID: 182
       Name: '[]crypto/x509.ExtKeyUsage.array'
       ByteSize: 2048
-      Element: 91 BaseType crypto/x509.ExtKeyUsage
+      Element: 113 BaseType crypto/x509.ExtKeyUsage
     - __kind: GoSliceHeaderType
-      ID: 102
+      ID: 124
       Name: '[]crypto/x509.OID'
       ByteSize: 24
       GoRuntimeType: 481632
@@ -853,21 +853,21 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 103 PointerType *crypto/x509.OID
+          Type: 125 PointerType *crypto/x509.OID
         - Name: len
           Offset: 8
-          Type: 8 BaseType int
+          Type: 9 BaseType int
         - Name: cap
           Offset: 16
-          Type: 8 BaseType int
+          Type: 9 BaseType int
       Data: 194 GoSliceDataType []crypto/x509.OID.array
     - __kind: GoSliceDataType
       ID: 194
       Name: '[]crypto/x509.OID.array'
       ByteSize: 2048
-      Element: 104 StructureType crypto/x509.OID
+      Element: 126 StructureType crypto/x509.OID
     - __kind: GoSliceHeaderType
-      ID: 68
+      ID: 92
       Name: '[]crypto/x509/pkix.AttributeTypeAndValue'
       ByteSize: 24
       GoRuntimeType: 481888
@@ -875,21 +875,21 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 69 PointerType *crypto/x509/pkix.AttributeTypeAndValue
+          Type: 93 PointerType *crypto/x509/pkix.AttributeTypeAndValue
         - Name: len
           Offset: 8
-          Type: 8 BaseType int
+          Type: 9 BaseType int
         - Name: cap
           Offset: 16
-          Type: 8 BaseType int
+          Type: 9 BaseType int
       Data: 170 GoSliceDataType []crypto/x509/pkix.AttributeTypeAndValue.array
     - __kind: GoSliceDataType
       ID: 170
       Name: '[]crypto/x509/pkix.AttributeTypeAndValue.array'
       ByteSize: 2048
-      Element: 70 StructureType crypto/x509/pkix.AttributeTypeAndValue
+      Element: 94 StructureType crypto/x509/pkix.AttributeTypeAndValue
     - __kind: GoSliceHeaderType
-      ID: 84
+      ID: 106
       Name: '[]crypto/x509/pkix.Extension'
       ByteSize: 24
       GoRuntimeType: 481376
@@ -897,21 +897,21 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 85 PointerType *crypto/x509/pkix.Extension
+          Type: 107 PointerType *crypto/x509/pkix.Extension
         - Name: len
           Offset: 8
-          Type: 8 BaseType int
+          Type: 9 BaseType int
         - Name: cap
           Offset: 16
-          Type: 8 BaseType int
+          Type: 9 BaseType int
       Data: 178 GoSliceDataType []crypto/x509/pkix.Extension.array
     - __kind: GoSliceDataType
       ID: 178
       Name: '[]crypto/x509/pkix.Extension.array'
       ByteSize: 2048
-      Element: 86 StructureType crypto/x509/pkix.Extension
+      Element: 108 StructureType crypto/x509/pkix.Extension
     - __kind: GoSliceHeaderType
-      ID: 87
+      ID: 109
       Name: '[]encoding/asn1.ObjectIdentifier'
       ByteSize: 24
       GoRuntimeType: 481440
@@ -919,28 +919,28 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 88 PointerType *encoding/asn1.ObjectIdentifier
+          Type: 110 PointerType *encoding/asn1.ObjectIdentifier
         - Name: len
           Offset: 8
-          Type: 8 BaseType int
+          Type: 9 BaseType int
         - Name: cap
           Offset: 16
-          Type: 8 BaseType int
+          Type: 9 BaseType int
       Data: 180 GoSliceDataType []encoding/asn1.ObjectIdentifier.array
     - __kind: GoSliceDataType
       ID: 180
       Name: '[]encoding/asn1.ObjectIdentifier.array'
       ByteSize: 2048
-      Element: 71 GoSliceHeaderType encoding/asn1.ObjectIdentifier
+      Element: 95 GoSliceHeaderType encoding/asn1.ObjectIdentifier
     - __kind: ArrayType
-      ID: 22
+      ID: 49
       Name: '[]key<string>'
       ByteSize: 128
       Count: 8
       HasCount: true
-      Element: 5 GoStringHeaderType string
+      Element: 11 GoStringHeaderType string
     - __kind: GoSliceHeaderType
-      ID: 92
+      ID: 114
       Name: '[]net.IP'
       ByteSize: 24
       GoRuntimeType: 454048
@@ -948,21 +948,21 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 93 PointerType *net.IP
+          Type: 115 PointerType *net.IP
         - Name: len
           Offset: 8
-          Type: 8 BaseType int
+          Type: 9 BaseType int
         - Name: cap
           Offset: 16
-          Type: 8 BaseType int
+          Type: 9 BaseType int
       Data: 184 GoSliceDataType []net.IP.array
     - __kind: GoSliceDataType
       ID: 184
       Name: '[]net.IP.array'
       ByteSize: 2048
-      Element: 94 GoSliceHeaderType net.IP
+      Element: 116 GoSliceHeaderType net.IP
     - __kind: GoSliceHeaderType
-      ID: 117
+      ID: 139
       Name: '[]net/http.segment'
       ByteSize: 24
       GoRuntimeType: 454816
@@ -970,21 +970,21 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 118 PointerType *net/http.segment
+          Type: 140 PointerType *net/http.segment
         - Name: len
           Offset: 8
-          Type: 8 BaseType int
+          Type: 9 BaseType int
         - Name: cap
           Offset: 16
-          Type: 8 BaseType int
+          Type: 9 BaseType int
       Data: 200 GoSliceDataType []net/http.segment.array
     - __kind: GoSliceDataType
       ID: 200
       Name: '[]net/http.segment.array'
       ByteSize: 2048
-      Element: 119 StructureType net/http.segment
+      Element: 141 StructureType net/http.segment
     - __kind: GoSliceHeaderType
-      ID: 24
+      ID: 51
       Name: '[]string'
       ByteSize: 24
       GoRuntimeType: 464704
@@ -992,21 +992,21 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 25 PointerType *string
+          Type: 22 PointerType *string
         - Name: len
           Offset: 8
-          Type: 8 BaseType int
+          Type: 9 BaseType int
         - Name: cap
           Offset: 16
-          Type: 8 BaseType int
+          Type: 9 BaseType int
       Data: 157 GoSliceDataType []string.array
     - __kind: GoSliceDataType
       ID: 157
       Name: '[]string.array'
       ByteSize: 2048
-      Element: 5 GoStringHeaderType string
+      Element: 11 GoStringHeaderType string
     - __kind: GoSliceHeaderType
-      ID: 77
+      ID: 99
       Name: '[]time.zone'
       ByteSize: 24
       GoRuntimeType: 459040
@@ -1014,21 +1014,21 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 78 PointerType *time.zone
+          Type: 100 PointerType *time.zone
         - Name: len
           Offset: 8
-          Type: 8 BaseType int
+          Type: 9 BaseType int
         - Name: cap
           Offset: 16
-          Type: 8 BaseType int
+          Type: 9 BaseType int
       Data: 174 GoSliceDataType []time.zone.array
     - __kind: GoSliceDataType
       ID: 174
       Name: '[]time.zone.array'
       ByteSize: 2048
-      Element: 79 StructureType time.zone
+      Element: 101 StructureType time.zone
     - __kind: GoSliceHeaderType
-      ID: 80
+      ID: 102
       Name: '[]time.zoneTrans'
       ByteSize: 24
       GoRuntimeType: 459104
@@ -1036,21 +1036,21 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 81 PointerType *time.zoneTrans
+          Type: 103 PointerType *time.zoneTrans
         - Name: len
           Offset: 8
-          Type: 8 BaseType int
+          Type: 9 BaseType int
         - Name: cap
           Offset: 16
-          Type: 8 BaseType int
+          Type: 9 BaseType int
       Data: 176 GoSliceDataType []time.zoneTrans.array
     - __kind: GoSliceDataType
       ID: 176
       Name: '[]time.zoneTrans.array'
       ByteSize: 2048
-      Element: 82 StructureType time.zoneTrans
+      Element: 104 StructureType time.zoneTrans
     - __kind: GoSliceHeaderType
-      ID: 52
+      ID: 76
       Name: '[]uint8'
       ByteSize: 24
       GoRuntimeType: 463552
@@ -1061,102 +1061,102 @@ Types:
           Type: 6 PointerType *uint8
         - Name: len
           Offset: 8
-          Type: 8 BaseType int
+          Type: 9 BaseType int
         - Name: cap
           Offset: 16
-          Type: 8 BaseType int
+          Type: 9 BaseType int
       Data: 164 GoSliceDataType []uint8.array
     - __kind: GoSliceDataType
       ID: 164
       Name: '[]uint8.array'
       ByteSize: 2048
-      Element: 7 BaseType uint8
+      Element: 3 BaseType uint8
     - __kind: ArrayType
-      ID: 46
+      ID: 70
       Name: '[]val<[]*mime/multipart.FileHeader>'
       ByteSize: 192
       Count: 8
       HasCount: true
-      Element: 47 GoSliceHeaderType []*mime/multipart.FileHeader
+      Element: 71 GoSliceHeaderType []*mime/multipart.FileHeader
     - __kind: ArrayType
-      ID: 23
+      ID: 50
       Name: '[]val<[]string>'
       ByteSize: 192
       Count: 8
       HasCount: true
-      Element: 24 GoSliceHeaderType []string
+      Element: 51 GoSliceHeaderType []string
     - __kind: ArrayType
-      ID: 125
+      ID: 147
       Name: '[]val<string>'
       ByteSize: 128
       Count: 8
       HasCount: true
-      Element: 5 GoStringHeaderType string
+      Element: 11 GoStringHeaderType string
     - __kind: BaseType
-      ID: 13
+      ID: 4
       Name: bool
       ByteSize: 1
       GoRuntimeType: 534592
       GoKind: 1
     - __kind: GoHMapBucketType
-      ID: 45
+      ID: 69
       Name: bucket<string,[]*mime/multipart.FileHeader>
       ByteSize: 336
       RawFields:
         - Name: tophash
           Offset: 0
-          Type: 21 ArrayType [8]uint8
+          Type: 48 ArrayType [8]uint8
         - Name: keys
           Offset: 8
-          Type: 22 ArrayType []key<string>
+          Type: 49 ArrayType []key<string>
         - Name: values
           Offset: 136
-          Type: 46 ArrayType []val<[]*mime/multipart.FileHeader>
+          Type: 70 ArrayType []val<[]*mime/multipart.FileHeader>
         - Name: overflow
           Offset: 328
-          Type: 44 PointerType *bucket<string,[]*mime/multipart.FileHeader>
-      KeyType: 5 GoStringHeaderType string
-      ValueType: 47 GoSliceHeaderType []*mime/multipart.FileHeader
+          Type: 68 PointerType *bucket<string,[]*mime/multipart.FileHeader>
+      KeyType: 11 GoStringHeaderType string
+      ValueType: 71 GoSliceHeaderType []*mime/multipart.FileHeader
     - __kind: GoHMapBucketType
-      ID: 20
+      ID: 47
       Name: bucket<string,[]string>
       ByteSize: 336
       RawFields:
         - Name: tophash
           Offset: 0
-          Type: 21 ArrayType [8]uint8
+          Type: 48 ArrayType [8]uint8
         - Name: keys
           Offset: 8
-          Type: 22 ArrayType []key<string>
+          Type: 49 ArrayType []key<string>
         - Name: values
           Offset: 136
-          Type: 23 ArrayType []val<[]string>
+          Type: 50 ArrayType []val<[]string>
         - Name: overflow
           Offset: 328
-          Type: 19 PointerType *bucket<string,[]string>
-      KeyType: 5 GoStringHeaderType string
-      ValueType: 24 GoSliceHeaderType []string
+          Type: 46 PointerType *bucket<string,[]string>
+      KeyType: 11 GoStringHeaderType string
+      ValueType: 51 GoSliceHeaderType []string
     - __kind: GoHMapBucketType
-      ID: 124
+      ID: 146
       Name: bucket<string,string>
       ByteSize: 272
       RawFields:
         - Name: tophash
           Offset: 0
-          Type: 21 ArrayType [8]uint8
+          Type: 48 ArrayType [8]uint8
         - Name: keys
           Offset: 8
-          Type: 22 ArrayType []key<string>
+          Type: 49 ArrayType []key<string>
         - Name: values
           Offset: 136
-          Type: 125 ArrayType []val<string>
+          Type: 147 ArrayType []val<string>
         - Name: overflow
           Offset: 264
-          Type: 123 PointerType *bucket<string,string>
-      KeyType: 5 GoStringHeaderType string
-      ValueType: 5 GoStringHeaderType string
+          Type: 145 PointerType *bucket<string,string>
+      KeyType: 11 GoStringHeaderType string
+      ValueType: 11 GoStringHeaderType string
     - __kind: StructureType
-      ID: 127
+      ID: 149
       Name: bytes.Buffer
       ByteSize: 40
       GoRuntimeType: 1.41392e+06
@@ -1164,33 +1164,33 @@ Types:
       RawFields:
         - Name: buf
           Offset: 0
-          Type: 52 GoSliceHeaderType []uint8
+          Type: 76 GoSliceHeaderType []uint8
         - Name: off
           Offset: 24
-          Type: 8 BaseType int
+          Type: 9 BaseType int
         - Name: lastRead
           Offset: 32
-          Type: 128 BaseType bytes.readOp
+          Type: 150 BaseType bytes.readOp
     - __kind: BaseType
-      ID: 128
+      ID: 150
       Name: bytes.readOp
       ByteSize: 1
       GoRuntimeType: 532800
       GoKind: 3
     - __kind: BaseType
-      ID: 143
+      ID: 24
       Name: complex128
       ByteSize: 16
       GoRuntimeType: 534400
       GoKind: 16
     - __kind: BaseType
-      ID: 142
+      ID: 23
       Name: complex64
       ByteSize: 8
       GoRuntimeType: 534336
       GoKind: 15
     - __kind: GoInterfaceType
-      ID: 114
+      ID: 136
       Name: context.Context
       ByteSize: 16
       GoRuntimeType: 1.187104e+06
@@ -1198,27 +1198,27 @@ Types:
       RawFields:
         - Name: tab
           Offset: 0
-          Type: 2 VoidPointerType unsafe.Pointer
+          Type: 19 VoidPointerType unsafe.Pointer
         - Name: data
           Offset: 8
-          Type: 2 VoidPointerType unsafe.Pointer
+          Type: 19 VoidPointerType unsafe.Pointer
     - __kind: StructureType
-      ID: 130
+      ID: 152
       Name: context.backgroundCtx
       GoRuntimeType: 1.6672e+06
       GoKind: 25
       RawFields:
         - Name: emptyCtx
           Offset: 0
-          Type: 131 StructureType context.emptyCtx
+          Type: 153 StructureType context.emptyCtx
     - __kind: StructureType
-      ID: 131
+      ID: 153
       Name: context.emptyCtx
       GoRuntimeType: 1.399456e+06
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 54
+      ID: 78
       Name: crypto/tls.ConnectionState
       ByteSize: 192
       GoRuntimeType: 2.1e+06
@@ -1226,60 +1226,60 @@ Types:
       RawFields:
         - Name: Version
           Offset: 0
-          Type: 17 BaseType uint16
+          Type: 7 BaseType uint16
         - Name: HandshakeComplete
           Offset: 2
-          Type: 13 BaseType bool
+          Type: 4 BaseType bool
         - Name: DidResume
           Offset: 3
-          Type: 13 BaseType bool
+          Type: 4 BaseType bool
         - Name: CipherSuite
           Offset: 4
-          Type: 17 BaseType uint16
+          Type: 7 BaseType uint16
         - Name: NegotiatedProtocol
           Offset: 8
-          Type: 5 GoStringHeaderType string
+          Type: 11 GoStringHeaderType string
         - Name: NegotiatedProtocolIsMutual
           Offset: 24
-          Type: 13 BaseType bool
+          Type: 4 BaseType bool
         - Name: ServerName
           Offset: 32
-          Type: 5 GoStringHeaderType string
+          Type: 11 GoStringHeaderType string
         - Name: PeerCertificates
           Offset: 48
-          Type: 55 GoSliceHeaderType []*crypto/x509.Certificate
+          Type: 79 GoSliceHeaderType []*crypto/x509.Certificate
         - Name: VerifiedChains
           Offset: 72
-          Type: 105 GoSliceHeaderType [][]*crypto/x509.Certificate
+          Type: 127 GoSliceHeaderType [][]*crypto/x509.Certificate
         - Name: SignedCertificateTimestamps
           Offset: 96
-          Type: 107 GoSliceHeaderType [][]uint8
+          Type: 129 GoSliceHeaderType [][]uint8
         - Name: OCSPResponse
           Offset: 120
-          Type: 52 GoSliceHeaderType []uint8
+          Type: 76 GoSliceHeaderType []uint8
         - Name: TLSUnique
           Offset: 144
-          Type: 52 GoSliceHeaderType []uint8
+          Type: 76 GoSliceHeaderType []uint8
         - Name: ECHAccepted
           Offset: 168
-          Type: 13 BaseType bool
+          Type: 4 BaseType bool
         - Name: ekm
           Offset: 176
-          Type: 109 GoSubroutineType func(string, []uint8, int) ([]uint8, error)
+          Type: 131 GoSubroutineType func(string, []uint8, int) ([]uint8, error)
         - Name: testingOnlyDidHRR
           Offset: 184
-          Type: 13 BaseType bool
+          Type: 4 BaseType bool
         - Name: testingOnlyCurveID
           Offset: 186
-          Type: 110 BaseType crypto/tls.CurveID
+          Type: 132 BaseType crypto/tls.CurveID
     - __kind: BaseType
-      ID: 110
+      ID: 132
       Name: crypto/tls.CurveID
       ByteSize: 2
       GoRuntimeType: 766048
       GoKind: 9
     - __kind: StructureType
-      ID: 58
+      ID: 82
       Name: crypto/x509.Certificate
       ByteSize: 1352
       GoRuntimeType: 2.234656e+06
@@ -1287,153 +1287,153 @@ Types:
       RawFields:
         - Name: Raw
           Offset: 0
-          Type: 52 GoSliceHeaderType []uint8
+          Type: 76 GoSliceHeaderType []uint8
         - Name: RawTBSCertificate
           Offset: 24
-          Type: 52 GoSliceHeaderType []uint8
+          Type: 76 GoSliceHeaderType []uint8
         - Name: RawSubjectPublicKeyInfo
           Offset: 48
-          Type: 52 GoSliceHeaderType []uint8
+          Type: 76 GoSliceHeaderType []uint8
         - Name: RawSubject
           Offset: 72
-          Type: 52 GoSliceHeaderType []uint8
+          Type: 76 GoSliceHeaderType []uint8
         - Name: RawIssuer
           Offset: 96
-          Type: 52 GoSliceHeaderType []uint8
+          Type: 76 GoSliceHeaderType []uint8
         - Name: Signature
           Offset: 120
-          Type: 52 GoSliceHeaderType []uint8
+          Type: 76 GoSliceHeaderType []uint8
         - Name: SignatureAlgorithm
           Offset: 144
-          Type: 59 BaseType crypto/x509.SignatureAlgorithm
+          Type: 83 BaseType crypto/x509.SignatureAlgorithm
         - Name: PublicKeyAlgorithm
           Offset: 152
-          Type: 60 BaseType crypto/x509.PublicKeyAlgorithm
+          Type: 84 BaseType crypto/x509.PublicKeyAlgorithm
         - Name: PublicKey
           Offset: 160
-          Type: 61 GoEmptyInterfaceType interface {}
+          Type: 85 GoEmptyInterfaceType interface {}
         - Name: Version
           Offset: 176
-          Type: 8 BaseType int
+          Type: 9 BaseType int
         - Name: SerialNumber
           Offset: 184
-          Type: 62 PointerType *math/big.Int
+          Type: 86 PointerType *math/big.Int
         - Name: Issuer
           Offset: 192
-          Type: 67 StructureType crypto/x509/pkix.Name
+          Type: 91 StructureType crypto/x509/pkix.Name
         - Name: Subject
           Offset: 440
-          Type: 67 StructureType crypto/x509/pkix.Name
+          Type: 91 StructureType crypto/x509/pkix.Name
         - Name: NotBefore
           Offset: 688
-          Type: 73 StructureType time.Time
+          Type: 96 StructureType time.Time
         - Name: NotAfter
           Offset: 712
-          Type: 73 StructureType time.Time
+          Type: 96 StructureType time.Time
         - Name: KeyUsage
           Offset: 736
-          Type: 83 BaseType crypto/x509.KeyUsage
+          Type: 105 BaseType crypto/x509.KeyUsage
         - Name: Extensions
           Offset: 744
-          Type: 84 GoSliceHeaderType []crypto/x509/pkix.Extension
+          Type: 106 GoSliceHeaderType []crypto/x509/pkix.Extension
         - Name: ExtraExtensions
           Offset: 768
-          Type: 84 GoSliceHeaderType []crypto/x509/pkix.Extension
+          Type: 106 GoSliceHeaderType []crypto/x509/pkix.Extension
         - Name: UnhandledCriticalExtensions
           Offset: 792
-          Type: 87 GoSliceHeaderType []encoding/asn1.ObjectIdentifier
+          Type: 109 GoSliceHeaderType []encoding/asn1.ObjectIdentifier
         - Name: ExtKeyUsage
           Offset: 816
-          Type: 89 GoSliceHeaderType []crypto/x509.ExtKeyUsage
+          Type: 111 GoSliceHeaderType []crypto/x509.ExtKeyUsage
         - Name: UnknownExtKeyUsage
           Offset: 840
-          Type: 87 GoSliceHeaderType []encoding/asn1.ObjectIdentifier
+          Type: 109 GoSliceHeaderType []encoding/asn1.ObjectIdentifier
         - Name: BasicConstraintsValid
           Offset: 864
-          Type: 13 BaseType bool
+          Type: 4 BaseType bool
         - Name: IsCA
           Offset: 865
-          Type: 13 BaseType bool
+          Type: 4 BaseType bool
         - Name: MaxPathLen
           Offset: 872
-          Type: 8 BaseType int
+          Type: 9 BaseType int
         - Name: MaxPathLenZero
           Offset: 880
-          Type: 13 BaseType bool
+          Type: 4 BaseType bool
         - Name: SubjectKeyId
           Offset: 888
-          Type: 52 GoSliceHeaderType []uint8
+          Type: 76 GoSliceHeaderType []uint8
         - Name: AuthorityKeyId
           Offset: 912
-          Type: 52 GoSliceHeaderType []uint8
+          Type: 76 GoSliceHeaderType []uint8
         - Name: OCSPServer
           Offset: 936
-          Type: 24 GoSliceHeaderType []string
+          Type: 51 GoSliceHeaderType []string
         - Name: IssuingCertificateURL
           Offset: 960
-          Type: 24 GoSliceHeaderType []string
+          Type: 51 GoSliceHeaderType []string
         - Name: DNSNames
           Offset: 984
-          Type: 24 GoSliceHeaderType []string
+          Type: 51 GoSliceHeaderType []string
         - Name: EmailAddresses
           Offset: 1008
-          Type: 24 GoSliceHeaderType []string
+          Type: 51 GoSliceHeaderType []string
         - Name: IPAddresses
           Offset: 1032
-          Type: 92 GoSliceHeaderType []net.IP
+          Type: 114 GoSliceHeaderType []net.IP
         - Name: URIs
           Offset: 1056
-          Type: 95 GoSliceHeaderType []*net/url.URL
+          Type: 117 GoSliceHeaderType []*net/url.URL
         - Name: PermittedDNSDomainsCritical
           Offset: 1080
-          Type: 13 BaseType bool
+          Type: 4 BaseType bool
         - Name: PermittedDNSDomains
           Offset: 1088
-          Type: 24 GoSliceHeaderType []string
+          Type: 51 GoSliceHeaderType []string
         - Name: ExcludedDNSDomains
           Offset: 1112
-          Type: 24 GoSliceHeaderType []string
+          Type: 51 GoSliceHeaderType []string
         - Name: PermittedIPRanges
           Offset: 1136
-          Type: 97 GoSliceHeaderType []*net.IPNet
+          Type: 119 GoSliceHeaderType []*net.IPNet
         - Name: ExcludedIPRanges
           Offset: 1160
-          Type: 97 GoSliceHeaderType []*net.IPNet
+          Type: 119 GoSliceHeaderType []*net.IPNet
         - Name: PermittedEmailAddresses
           Offset: 1184
-          Type: 24 GoSliceHeaderType []string
+          Type: 51 GoSliceHeaderType []string
         - Name: ExcludedEmailAddresses
           Offset: 1208
-          Type: 24 GoSliceHeaderType []string
+          Type: 51 GoSliceHeaderType []string
         - Name: PermittedURIDomains
           Offset: 1232
-          Type: 24 GoSliceHeaderType []string
+          Type: 51 GoSliceHeaderType []string
         - Name: ExcludedURIDomains
           Offset: 1256
-          Type: 24 GoSliceHeaderType []string
+          Type: 51 GoSliceHeaderType []string
         - Name: CRLDistributionPoints
           Offset: 1280
-          Type: 24 GoSliceHeaderType []string
+          Type: 51 GoSliceHeaderType []string
         - Name: PolicyIdentifiers
           Offset: 1304
-          Type: 87 GoSliceHeaderType []encoding/asn1.ObjectIdentifier
+          Type: 109 GoSliceHeaderType []encoding/asn1.ObjectIdentifier
         - Name: Policies
           Offset: 1328
-          Type: 102 GoSliceHeaderType []crypto/x509.OID
+          Type: 124 GoSliceHeaderType []crypto/x509.OID
     - __kind: BaseType
-      ID: 91
+      ID: 113
       Name: crypto/x509.ExtKeyUsage
       ByteSize: 8
       GoRuntimeType: 537280
       GoKind: 2
     - __kind: BaseType
-      ID: 83
+      ID: 105
       Name: crypto/x509.KeyUsage
       ByteSize: 8
       GoRuntimeType: 537216
       GoKind: 2
     - __kind: StructureType
-      ID: 104
+      ID: 126
       Name: crypto/x509.OID
       ByteSize: 24
       GoRuntimeType: 1.717472e+06
@@ -1441,21 +1441,21 @@ Types:
       RawFields:
         - Name: der
           Offset: 0
-          Type: 52 GoSliceHeaderType []uint8
+          Type: 76 GoSliceHeaderType []uint8
     - __kind: BaseType
-      ID: 60
+      ID: 84
       Name: crypto/x509.PublicKeyAlgorithm
       ByteSize: 8
       GoRuntimeType: 768448
       GoKind: 2
     - __kind: BaseType
-      ID: 59
+      ID: 83
       Name: crypto/x509.SignatureAlgorithm
       ByteSize: 8
       GoRuntimeType: 1.070976e+06
       GoKind: 2
     - __kind: StructureType
-      ID: 70
+      ID: 94
       Name: crypto/x509/pkix.AttributeTypeAndValue
       ByteSize: 40
       GoRuntimeType: 1.316256e+06
@@ -1463,12 +1463,12 @@ Types:
       RawFields:
         - Name: Type
           Offset: 0
-          Type: 71 GoSliceHeaderType encoding/asn1.ObjectIdentifier
+          Type: 95 GoSliceHeaderType encoding/asn1.ObjectIdentifier
         - Name: Value
           Offset: 24
-          Type: 61 GoEmptyInterfaceType interface {}
+          Type: 85 GoEmptyInterfaceType interface {}
     - __kind: StructureType
-      ID: 86
+      ID: 108
       Name: crypto/x509/pkix.Extension
       ByteSize: 56
       GoRuntimeType: 1.455008e+06
@@ -1476,15 +1476,15 @@ Types:
       RawFields:
         - Name: Id
           Offset: 0
-          Type: 71 GoSliceHeaderType encoding/asn1.ObjectIdentifier
+          Type: 95 GoSliceHeaderType encoding/asn1.ObjectIdentifier
         - Name: Critical
           Offset: 24
-          Type: 13 BaseType bool
+          Type: 4 BaseType bool
         - Name: Value
           Offset: 32
-          Type: 52 GoSliceHeaderType []uint8
+          Type: 76 GoSliceHeaderType []uint8
     - __kind: StructureType
-      ID: 67
+      ID: 91
       Name: crypto/x509/pkix.Name
       ByteSize: 248
       GoRuntimeType: 2.046944e+06
@@ -1492,39 +1492,39 @@ Types:
       RawFields:
         - Name: Country
           Offset: 0
-          Type: 24 GoSliceHeaderType []string
+          Type: 51 GoSliceHeaderType []string
         - Name: Organization
           Offset: 24
-          Type: 24 GoSliceHeaderType []string
+          Type: 51 GoSliceHeaderType []string
         - Name: OrganizationalUnit
           Offset: 48
-          Type: 24 GoSliceHeaderType []string
+          Type: 51 GoSliceHeaderType []string
         - Name: Locality
           Offset: 72
-          Type: 24 GoSliceHeaderType []string
+          Type: 51 GoSliceHeaderType []string
         - Name: Province
           Offset: 96
-          Type: 24 GoSliceHeaderType []string
+          Type: 51 GoSliceHeaderType []string
         - Name: StreetAddress
           Offset: 120
-          Type: 24 GoSliceHeaderType []string
+          Type: 51 GoSliceHeaderType []string
         - Name: PostalCode
           Offset: 144
-          Type: 24 GoSliceHeaderType []string
+          Type: 51 GoSliceHeaderType []string
         - Name: SerialNumber
           Offset: 168
-          Type: 5 GoStringHeaderType string
+          Type: 11 GoStringHeaderType string
         - Name: CommonName
           Offset: 184
-          Type: 5 GoStringHeaderType string
+          Type: 11 GoStringHeaderType string
         - Name: Names
           Offset: 200
-          Type: 68 GoSliceHeaderType []crypto/x509/pkix.AttributeTypeAndValue
+          Type: 92 GoSliceHeaderType []crypto/x509/pkix.AttributeTypeAndValue
         - Name: ExtraNames
           Offset: 224
-          Type: 68 GoSliceHeaderType []crypto/x509/pkix.AttributeTypeAndValue
+          Type: 92 GoSliceHeaderType []crypto/x509/pkix.AttributeTypeAndValue
     - __kind: GoSliceHeaderType
-      ID: 71
+      ID: 95
       Name: encoding/asn1.ObjectIdentifier
       ByteSize: 24
       GoRuntimeType: 1.009856e+06
@@ -1532,21 +1532,21 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 72 PointerType *int
+          Type: 27 PointerType *int
         - Name: len
           Offset: 8
-          Type: 8 BaseType int
+          Type: 9 BaseType int
         - Name: cap
           Offset: 16
-          Type: 8 BaseType int
+          Type: 9 BaseType int
       Data: 172 GoSliceDataType encoding/asn1.ObjectIdentifier.array
     - __kind: GoSliceDataType
       ID: 172
       Name: encoding/asn1.ObjectIdentifier.array
       ByteSize: 2048
-      Element: 8 BaseType int
+      Element: 9 BaseType int
     - __kind: GoInterfaceType
-      ID: 139
+      ID: 18
       Name: error
       ByteSize: 16
       GoRuntimeType: 987456
@@ -1554,36 +1554,36 @@ Types:
       RawFields:
         - Name: tab
           Offset: 0
-          Type: 2 VoidPointerType unsafe.Pointer
+          Type: 19 VoidPointerType unsafe.Pointer
         - Name: data
           Offset: 8
-          Type: 2 VoidPointerType unsafe.Pointer
+          Type: 19 VoidPointerType unsafe.Pointer
     - __kind: BaseType
-      ID: 137
+      ID: 16
       Name: float32
       ByteSize: 4
       GoRuntimeType: 534464
       GoKind: 13
     - __kind: BaseType
-      ID: 138
+      ID: 17
       Name: float64
       ByteSize: 8
       GoRuntimeType: 534528
       GoKind: 14
     - __kind: GoSubroutineType
-      ID: 35
+      ID: 60
       Name: func() (io.ReadCloser, error)
       ByteSize: 8
       GoRuntimeType: 634112
       GoKind: 19
     - __kind: GoSubroutineType
-      ID: 109
+      ID: 131
       Name: func(string, []uint8, int) ([]uint8, error)
       ByteSize: 8
       GoRuntimeType: 960256
       GoKind: 19
     - __kind: GoInterfaceType
-      ID: 129
+      ID: 151
       Name: gopkg.in/DataDog/dd-trace-go.v1/ddtrace.Span
       ByteSize: 16
       GoRuntimeType: 1.295936e+06
@@ -1591,144 +1591,144 @@ Types:
       RawFields:
         - Name: tab
           Offset: 0
-          Type: 2 VoidPointerType unsafe.Pointer
+          Type: 19 VoidPointerType unsafe.Pointer
         - Name: data
           Offset: 8
-          Type: 2 VoidPointerType unsafe.Pointer
+          Type: 19 VoidPointerType unsafe.Pointer
     - __kind: GoHMapHeaderType
-      ID: 43
+      ID: 67
       Name: hash<string,[]*mime/multipart.FileHeader>
       ByteSize: 48
       RawFields:
         - Name: count
           Offset: 0
-          Type: 8 BaseType int
+          Type: 9 BaseType int
         - Name: flags
           Offset: 8
-          Type: 7 BaseType uint8
+          Type: 3 BaseType uint8
         - Name: B
           Offset: 9
-          Type: 7 BaseType uint8
+          Type: 3 BaseType uint8
         - Name: noverflow
           Offset: 10
-          Type: 17 BaseType uint16
+          Type: 7 BaseType uint16
         - Name: hash0
           Offset: 12
-          Type: 18 BaseType uint32
+          Type: 2 BaseType uint32
         - Name: buckets
           Offset: 16
-          Type: 44 PointerType *bucket<string,[]*mime/multipart.FileHeader>
+          Type: 68 PointerType *bucket<string,[]*mime/multipart.FileHeader>
         - Name: oldbuckets
           Offset: 24
-          Type: 44 PointerType *bucket<string,[]*mime/multipart.FileHeader>
+          Type: 68 PointerType *bucket<string,[]*mime/multipart.FileHeader>
         - Name: nevacuate
           Offset: 32
-          Type: 26 BaseType uintptr
+          Type: 1 BaseType uintptr
         - Name: extra
           Offset: 40
-          Type: 27 PointerType *runtime.mapextra
-      BucketType: 45 GoHMapBucketType bucket<string,[]*mime/multipart.FileHeader>
+          Type: 52 PointerType *runtime.mapextra
+      BucketType: 69 GoHMapBucketType bucket<string,[]*mime/multipart.FileHeader>
       BucketsType: 161 GoSliceDataType []bucket<string,[]*mime/multipart.FileHeader>.array
     - __kind: GoHMapHeaderType
-      ID: 16
+      ID: 45
       Name: hash<string,[]string>
       ByteSize: 48
       RawFields:
         - Name: count
           Offset: 0
-          Type: 8 BaseType int
+          Type: 9 BaseType int
         - Name: flags
           Offset: 8
-          Type: 7 BaseType uint8
+          Type: 3 BaseType uint8
         - Name: B
           Offset: 9
-          Type: 7 BaseType uint8
+          Type: 3 BaseType uint8
         - Name: noverflow
           Offset: 10
-          Type: 17 BaseType uint16
+          Type: 7 BaseType uint16
         - Name: hash0
           Offset: 12
-          Type: 18 BaseType uint32
+          Type: 2 BaseType uint32
         - Name: buckets
           Offset: 16
-          Type: 19 PointerType *bucket<string,[]string>
+          Type: 46 PointerType *bucket<string,[]string>
         - Name: oldbuckets
           Offset: 24
-          Type: 19 PointerType *bucket<string,[]string>
+          Type: 46 PointerType *bucket<string,[]string>
         - Name: nevacuate
           Offset: 32
-          Type: 26 BaseType uintptr
+          Type: 1 BaseType uintptr
         - Name: extra
           Offset: 40
-          Type: 27 PointerType *runtime.mapextra
-      BucketType: 20 GoHMapBucketType bucket<string,[]string>
+          Type: 52 PointerType *runtime.mapextra
+      BucketType: 47 GoHMapBucketType bucket<string,[]string>
       BucketsType: 156 GoSliceDataType []bucket<string,[]string>.array
     - __kind: GoHMapHeaderType
-      ID: 122
+      ID: 144
       Name: hash<string,string>
       ByteSize: 48
       RawFields:
         - Name: count
           Offset: 0
-          Type: 8 BaseType int
+          Type: 9 BaseType int
         - Name: flags
           Offset: 8
-          Type: 7 BaseType uint8
+          Type: 3 BaseType uint8
         - Name: B
           Offset: 9
-          Type: 7 BaseType uint8
+          Type: 3 BaseType uint8
         - Name: noverflow
           Offset: 10
-          Type: 17 BaseType uint16
+          Type: 7 BaseType uint16
         - Name: hash0
           Offset: 12
-          Type: 18 BaseType uint32
+          Type: 2 BaseType uint32
         - Name: buckets
           Offset: 16
-          Type: 123 PointerType *bucket<string,string>
+          Type: 145 PointerType *bucket<string,string>
         - Name: oldbuckets
           Offset: 24
-          Type: 123 PointerType *bucket<string,string>
+          Type: 145 PointerType *bucket<string,string>
         - Name: nevacuate
           Offset: 32
-          Type: 26 BaseType uintptr
+          Type: 1 BaseType uintptr
         - Name: extra
           Offset: 40
-          Type: 27 PointerType *runtime.mapextra
-      BucketType: 124 GoHMapBucketType bucket<string,string>
+          Type: 52 PointerType *runtime.mapextra
+      BucketType: 146 GoHMapBucketType bucket<string,string>
       BucketsType: 202 GoSliceDataType []bucket<string,string>.array
     - __kind: BaseType
-      ID: 8
+      ID: 9
       Name: int
       ByteSize: 8
       GoRuntimeType: 534144
       GoKind: 2
     - __kind: BaseType
-      ID: 149
+      ID: 31
       Name: int16
       ByteSize: 2
       GoRuntimeType: 533760
       GoKind: 4
     - __kind: BaseType
-      ID: 134
+      ID: 12
       Name: int32
       ByteSize: 4
       GoRuntimeType: 533888
       GoKind: 5
     - __kind: BaseType
-      ID: 36
+      ID: 13
       Name: int64
       ByteSize: 8
       GoRuntimeType: 534016
       GoKind: 6
     - __kind: BaseType
-      ID: 135
+      ID: 14
       Name: int8
       ByteSize: 1
       GoRuntimeType: 533632
       GoKind: 3
     - __kind: GoEmptyInterfaceType
-      ID: 61
+      ID: 85
       Name: interface {}
       ByteSize: 16
       GoRuntimeType: 785376
@@ -1736,12 +1736,12 @@ Types:
       RawFields:
         - Name: _type
           Offset: 0
-          Type: 2 VoidPointerType unsafe.Pointer
+          Type: 19 VoidPointerType unsafe.Pointer
         - Name: data
           Offset: 8
-          Type: 2 VoidPointerType unsafe.Pointer
+          Type: 19 VoidPointerType unsafe.Pointer
     - __kind: GoInterfaceType
-      ID: 34
+      ID: 59
       Name: io.ReadCloser
       ByteSize: 16
       GoRuntimeType: 1.067136e+06
@@ -1749,33 +1749,33 @@ Types:
       RawFields:
         - Name: tab
           Offset: 0
-          Type: 2 VoidPointerType unsafe.Pointer
+          Type: 19 VoidPointerType unsafe.Pointer
         - Name: data
           Offset: 8
-          Type: 2 VoidPointerType unsafe.Pointer
+          Type: 19 VoidPointerType unsafe.Pointer
     - __kind: GoMapType
-      ID: 41
+      ID: 65
       Name: map[string][]*mime/multipart.FileHeader
       ByteSize: 8
       GoRuntimeType: 887296
       GoKind: 21
-      HeaderType: 43 GoHMapHeaderType hash<string,[]*mime/multipart.FileHeader>
+      HeaderType: 67 GoHMapHeaderType hash<string,[]*mime/multipart.FileHeader>
     - __kind: GoMapType
-      ID: 40
+      ID: 64
       Name: map[string][]string
       ByteSize: 8
       GoRuntimeType: 882496
       GoKind: 21
-      HeaderType: 16 GoHMapHeaderType hash<string,[]string>
+      HeaderType: 45 GoHMapHeaderType hash<string,[]string>
     - __kind: GoMapType
-      ID: 120
+      ID: 142
       Name: map[string]string
       ByteSize: 8
       GoRuntimeType: 884128
       GoKind: 21
-      HeaderType: 122 GoHMapHeaderType hash<string,string>
+      HeaderType: 144 GoHMapHeaderType hash<string,string>
     - __kind: StructureType
-      ID: 63
+      ID: 87
       Name: math/big.Int
       ByteSize: 32
       GoRuntimeType: 1.308416e+06
@@ -1783,18 +1783,18 @@ Types:
       RawFields:
         - Name: neg
           Offset: 0
-          Type: 13 BaseType bool
+          Type: 4 BaseType bool
         - Name: abs
           Offset: 8
-          Type: 64 GoSliceHeaderType math/big.nat
+          Type: 88 GoSliceHeaderType math/big.nat
     - __kind: BaseType
-      ID: 66
+      ID: 90
       Name: math/big.Word
       ByteSize: 8
       GoRuntimeType: 537536
       GoKind: 7
     - __kind: GoSliceHeaderType
-      ID: 64
+      ID: 88
       Name: math/big.nat
       ByteSize: 24
       GoRuntimeType: 2.21424e+06
@@ -1802,21 +1802,21 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 65 PointerType *math/big.Word
+          Type: 89 PointerType *math/big.Word
         - Name: len
           Offset: 8
-          Type: 8 BaseType int
+          Type: 9 BaseType int
         - Name: cap
           Offset: 16
-          Type: 8 BaseType int
+          Type: 9 BaseType int
       Data: 168 GoSliceDataType math/big.nat.array
     - __kind: GoSliceDataType
       ID: 168
       Name: math/big.nat.array
       ByteSize: 2048
-      Element: 66 BaseType math/big.Word
+      Element: 90 BaseType math/big.Word
     - __kind: StructureType
-      ID: 50
+      ID: 74
       Name: mime/multipart.FileHeader
       ByteSize: 88
       GoRuntimeType: 1.838016e+06
@@ -1824,27 +1824,27 @@ Types:
       RawFields:
         - Name: Filename
           Offset: 0
-          Type: 5 GoStringHeaderType string
+          Type: 11 GoStringHeaderType string
         - Name: Header
           Offset: 16
-          Type: 51 GoMapType net/textproto.MIMEHeader
+          Type: 75 GoMapType net/textproto.MIMEHeader
         - Name: Size
           Offset: 24
-          Type: 36 BaseType int64
+          Type: 13 BaseType int64
         - Name: content
           Offset: 32
-          Type: 52 GoSliceHeaderType []uint8
+          Type: 76 GoSliceHeaderType []uint8
         - Name: tmpfile
           Offset: 56
-          Type: 5 GoStringHeaderType string
+          Type: 11 GoStringHeaderType string
         - Name: tmpoff
           Offset: 72
-          Type: 36 BaseType int64
+          Type: 13 BaseType int64
         - Name: tmpshared
           Offset: 80
-          Type: 13 BaseType bool
+          Type: 4 BaseType bool
     - __kind: StructureType
-      ID: 39
+      ID: 63
       Name: mime/multipart.Form
       ByteSize: 16
       GoRuntimeType: 1.294336e+06
@@ -1852,12 +1852,12 @@ Types:
       RawFields:
         - Name: Value
           Offset: 0
-          Type: 40 GoMapType map[string][]string
+          Type: 64 GoMapType map[string][]string
         - Name: File
           Offset: 8
-          Type: 41 GoMapType map[string][]*mime/multipart.FileHeader
+          Type: 65 GoMapType map[string][]*mime/multipart.FileHeader
     - __kind: GoSliceHeaderType
-      ID: 94
+      ID: 116
       Name: net.IP
       ByteSize: 24
       GoRuntimeType: 1.94816e+06
@@ -1868,18 +1868,18 @@ Types:
           Type: 6 PointerType *uint8
         - Name: len
           Offset: 8
-          Type: 8 BaseType int
+          Type: 9 BaseType int
         - Name: cap
           Offset: 16
-          Type: 8 BaseType int
+          Type: 9 BaseType int
       Data: 186 GoSliceDataType net.IP.array
     - __kind: GoSliceDataType
       ID: 186
       Name: net.IP.array
       ByteSize: 2048
-      Element: 7 BaseType uint8
+      Element: 3 BaseType uint8
     - __kind: GoSliceHeaderType
-      ID: 101
+      ID: 123
       Name: net.IPMask
       ByteSize: 24
       GoRuntimeType: 975808
@@ -1890,18 +1890,18 @@ Types:
           Type: 6 PointerType *uint8
         - Name: len
           Offset: 8
-          Type: 8 BaseType int
+          Type: 9 BaseType int
         - Name: cap
           Offset: 16
-          Type: 8 BaseType int
+          Type: 9 BaseType int
       Data: 192 GoSliceDataType net.IPMask.array
     - __kind: GoSliceDataType
       ID: 192
       Name: net.IPMask.array
       ByteSize: 2048
-      Element: 7 BaseType uint8
+      Element: 3 BaseType uint8
     - __kind: StructureType
-      ID: 100
+      ID: 122
       Name: net.IPNet
       ByteSize: 48
       GoRuntimeType: 1.275936e+06
@@ -1909,19 +1909,19 @@ Types:
       RawFields:
         - Name: IP
           Offset: 0
-          Type: 94 GoSliceHeaderType net.IP
+          Type: 116 GoSliceHeaderType net.IP
         - Name: Mask
           Offset: 24
-          Type: 101 GoSliceHeaderType net.IPMask
+          Type: 123 GoSliceHeaderType net.IPMask
     - __kind: GoMapType
-      ID: 14
+      ID: 43
       Name: net/http.Header
       ByteSize: 8
       GoRuntimeType: 1.91744e+06
       GoKind: 21
-      HeaderType: 16 GoHMapHeaderType hash<string,[]string>
+      HeaderType: 45 GoHMapHeaderType hash<string,[]string>
     - __kind: StructureType
-      ID: 4
+      ID: 38
       Name: net/http.Request
       ByteSize: 304
       GoRuntimeType: 2.189984e+06
@@ -1929,84 +1929,84 @@ Types:
       RawFields:
         - Name: Method
           Offset: 0
-          Type: 5 GoStringHeaderType string
+          Type: 11 GoStringHeaderType string
         - Name: URL
           Offset: 16
-          Type: 9 PointerType *net/url.URL
+          Type: 39 PointerType *net/url.URL
         - Name: Proto
           Offset: 24
-          Type: 5 GoStringHeaderType string
+          Type: 11 GoStringHeaderType string
         - Name: ProtoMajor
           Offset: 40
-          Type: 8 BaseType int
+          Type: 9 BaseType int
         - Name: ProtoMinor
           Offset: 48
-          Type: 8 BaseType int
+          Type: 9 BaseType int
         - Name: Header
           Offset: 56
-          Type: 14 GoMapType net/http.Header
+          Type: 43 GoMapType net/http.Header
         - Name: Body
           Offset: 64
-          Type: 34 GoInterfaceType io.ReadCloser
+          Type: 59 GoInterfaceType io.ReadCloser
         - Name: GetBody
           Offset: 80
-          Type: 35 GoSubroutineType func() (io.ReadCloser, error)
+          Type: 60 GoSubroutineType func() (io.ReadCloser, error)
         - Name: ContentLength
           Offset: 88
-          Type: 36 BaseType int64
+          Type: 13 BaseType int64
         - Name: TransferEncoding
           Offset: 96
-          Type: 24 GoSliceHeaderType []string
+          Type: 51 GoSliceHeaderType []string
         - Name: Close
           Offset: 120
-          Type: 13 BaseType bool
+          Type: 4 BaseType bool
         - Name: Host
           Offset: 128
-          Type: 5 GoStringHeaderType string
+          Type: 11 GoStringHeaderType string
         - Name: Form
           Offset: 144
-          Type: 37 GoMapType net/url.Values
+          Type: 61 GoMapType net/url.Values
         - Name: PostForm
           Offset: 152
-          Type: 37 GoMapType net/url.Values
+          Type: 61 GoMapType net/url.Values
         - Name: MultipartForm
           Offset: 160
-          Type: 38 PointerType *mime/multipart.Form
+          Type: 62 PointerType *mime/multipart.Form
         - Name: Trailer
           Offset: 168
-          Type: 14 GoMapType net/http.Header
+          Type: 43 GoMapType net/http.Header
         - Name: RemoteAddr
           Offset: 176
-          Type: 5 GoStringHeaderType string
+          Type: 11 GoStringHeaderType string
         - Name: RequestURI
           Offset: 192
-          Type: 5 GoStringHeaderType string
+          Type: 11 GoStringHeaderType string
         - Name: TLS
           Offset: 208
-          Type: 53 PointerType *crypto/tls.ConnectionState
+          Type: 77 PointerType *crypto/tls.ConnectionState
         - Name: Cancel
           Offset: 216
-          Type: 111 GoChannelType <-chan struct {}
+          Type: 133 GoChannelType <-chan struct {}
         - Name: Response
           Offset: 224
-          Type: 112 PointerType *net/http.Response
+          Type: 134 PointerType *net/http.Response
         - Name: Pattern
           Offset: 232
-          Type: 5 GoStringHeaderType string
+          Type: 11 GoStringHeaderType string
         - Name: ctx
           Offset: 248
-          Type: 114 GoInterfaceType context.Context
+          Type: 136 GoInterfaceType context.Context
         - Name: pat
           Offset: 264
-          Type: 115 PointerType *net/http.pattern
+          Type: 137 PointerType *net/http.pattern
         - Name: matches
           Offset: 272
-          Type: 24 GoSliceHeaderType []string
+          Type: 51 GoSliceHeaderType []string
         - Name: otherValues
           Offset: 296
-          Type: 120 GoMapType map[string]string
+          Type: 142 GoMapType map[string]string
     - __kind: StructureType
-      ID: 113
+      ID: 135
       Name: net/http.Response
       ByteSize: 144
       GoRuntimeType: 2.064832e+06
@@ -2014,48 +2014,48 @@ Types:
       RawFields:
         - Name: Status
           Offset: 0
-          Type: 5 GoStringHeaderType string
+          Type: 11 GoStringHeaderType string
         - Name: StatusCode
           Offset: 16
-          Type: 8 BaseType int
+          Type: 9 BaseType int
         - Name: Proto
           Offset: 24
-          Type: 5 GoStringHeaderType string
+          Type: 11 GoStringHeaderType string
         - Name: ProtoMajor
           Offset: 40
-          Type: 8 BaseType int
+          Type: 9 BaseType int
         - Name: ProtoMinor
           Offset: 48
-          Type: 8 BaseType int
+          Type: 9 BaseType int
         - Name: Header
           Offset: 56
-          Type: 14 GoMapType net/http.Header
+          Type: 43 GoMapType net/http.Header
         - Name: Body
           Offset: 64
-          Type: 34 GoInterfaceType io.ReadCloser
+          Type: 59 GoInterfaceType io.ReadCloser
         - Name: ContentLength
           Offset: 80
-          Type: 36 BaseType int64
+          Type: 13 BaseType int64
         - Name: TransferEncoding
           Offset: 88
-          Type: 24 GoSliceHeaderType []string
+          Type: 51 GoSliceHeaderType []string
         - Name: Close
           Offset: 112
-          Type: 13 BaseType bool
+          Type: 4 BaseType bool
         - Name: Uncompressed
           Offset: 113
-          Type: 13 BaseType bool
+          Type: 4 BaseType bool
         - Name: Trailer
           Offset: 120
-          Type: 14 GoMapType net/http.Header
+          Type: 43 GoMapType net/http.Header
         - Name: Request
           Offset: 128
-          Type: 3 PointerType *net/http.Request
+          Type: 37 PointerType *net/http.Request
         - Name: TLS
           Offset: 136
-          Type: 53 PointerType *crypto/tls.ConnectionState
+          Type: 77 PointerType *crypto/tls.ConnectionState
     - __kind: GoInterfaceType
-      ID: 1
+      ID: 36
       Name: net/http.ResponseWriter
       ByteSize: 16
       GoRuntimeType: 1.098336e+06
@@ -2063,12 +2063,12 @@ Types:
       RawFields:
         - Name: tab
           Offset: 0
-          Type: 2 VoidPointerType unsafe.Pointer
+          Type: 19 VoidPointerType unsafe.Pointer
         - Name: data
           Offset: 8
-          Type: 2 VoidPointerType unsafe.Pointer
+          Type: 19 VoidPointerType unsafe.Pointer
     - __kind: StructureType
-      ID: 116
+      ID: 138
       Name: net/http.pattern
       ByteSize: 88
       GoRuntimeType: 1.701568e+06
@@ -2076,21 +2076,21 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 5 GoStringHeaderType string
+          Type: 11 GoStringHeaderType string
         - Name: method
           Offset: 16
-          Type: 5 GoStringHeaderType string
+          Type: 11 GoStringHeaderType string
         - Name: host
           Offset: 32
-          Type: 5 GoStringHeaderType string
+          Type: 11 GoStringHeaderType string
         - Name: segments
           Offset: 48
-          Type: 117 GoSliceHeaderType []net/http.segment
+          Type: 139 GoSliceHeaderType []net/http.segment
         - Name: loc
           Offset: 72
-          Type: 5 GoStringHeaderType string
+          Type: 11 GoStringHeaderType string
     - __kind: StructureType
-      ID: 119
+      ID: 141
       Name: net/http.segment
       ByteSize: 24
       GoRuntimeType: 1.416032e+06
@@ -2098,22 +2098,22 @@ Types:
       RawFields:
         - Name: s
           Offset: 0
-          Type: 5 GoStringHeaderType string
+          Type: 11 GoStringHeaderType string
         - Name: wild
           Offset: 16
-          Type: 13 BaseType bool
+          Type: 4 BaseType bool
         - Name: multi
           Offset: 17
-          Type: 13 BaseType bool
+          Type: 4 BaseType bool
     - __kind: GoMapType
-      ID: 51
+      ID: 75
       Name: net/textproto.MIMEHeader
       ByteSize: 8
       GoRuntimeType: 1.595904e+06
       GoKind: 21
-      HeaderType: 16 GoHMapHeaderType hash<string,[]string>
+      HeaderType: 45 GoHMapHeaderType hash<string,[]string>
     - __kind: StructureType
-      ID: 10
+      ID: 40
       Name: net/url.URL
       ByteSize: 144
       GoRuntimeType: 1.986272e+06
@@ -2121,39 +2121,39 @@ Types:
       RawFields:
         - Name: Scheme
           Offset: 0
-          Type: 5 GoStringHeaderType string
+          Type: 11 GoStringHeaderType string
         - Name: Opaque
           Offset: 16
-          Type: 5 GoStringHeaderType string
+          Type: 11 GoStringHeaderType string
         - Name: User
           Offset: 32
-          Type: 11 PointerType *net/url.Userinfo
+          Type: 41 PointerType *net/url.Userinfo
         - Name: Host
           Offset: 40
-          Type: 5 GoStringHeaderType string
+          Type: 11 GoStringHeaderType string
         - Name: Path
           Offset: 56
-          Type: 5 GoStringHeaderType string
+          Type: 11 GoStringHeaderType string
         - Name: RawPath
           Offset: 72
-          Type: 5 GoStringHeaderType string
+          Type: 11 GoStringHeaderType string
         - Name: OmitHost
           Offset: 88
-          Type: 13 BaseType bool
+          Type: 4 BaseType bool
         - Name: ForceQuery
           Offset: 89
-          Type: 13 BaseType bool
+          Type: 4 BaseType bool
         - Name: RawQuery
           Offset: 96
-          Type: 5 GoStringHeaderType string
+          Type: 11 GoStringHeaderType string
         - Name: Fragment
           Offset: 112
-          Type: 5 GoStringHeaderType string
+          Type: 11 GoStringHeaderType string
         - Name: RawFragment
           Offset: 128
-          Type: 5 GoStringHeaderType string
+          Type: 11 GoStringHeaderType string
     - __kind: StructureType
-      ID: 12
+      ID: 42
       Name: net/url.Userinfo
       ByteSize: 40
       GoRuntimeType: 1.432736e+06
@@ -2161,22 +2161,22 @@ Types:
       RawFields:
         - Name: username
           Offset: 0
-          Type: 5 GoStringHeaderType string
+          Type: 11 GoStringHeaderType string
         - Name: password
           Offset: 16
-          Type: 5 GoStringHeaderType string
+          Type: 11 GoStringHeaderType string
         - Name: passwordSet
           Offset: 32
-          Type: 13 BaseType bool
+          Type: 4 BaseType bool
     - __kind: GoMapType
-      ID: 37
+      ID: 61
       Name: net/url.Values
       ByteSize: 8
       GoRuntimeType: 1.670784e+06
       GoKind: 21
-      HeaderType: 16 GoHMapHeaderType hash<string,[]string>
+      HeaderType: 45 GoHMapHeaderType hash<string,[]string>
     - __kind: StructureType
-      ID: 33
+      ID: 58
       Name: runtime.bmap
       ByteSize: 8
       GoRuntimeType: 1.109728e+06
@@ -2184,9 +2184,9 @@ Types:
       RawFields:
         - Name: tophash
           Offset: 0
-          Type: 21 ArrayType [8]uint8
+          Type: 48 ArrayType [8]uint8
     - __kind: StructureType
-      ID: 28
+      ID: 53
       Name: runtime.mapextra
       ByteSize: 24
       GoRuntimeType: 1.428704e+06
@@ -2194,15 +2194,15 @@ Types:
       RawFields:
         - Name: overflow
           Offset: 0
-          Type: 29 PointerType *[]*runtime.bmap
+          Type: 54 PointerType *[]*runtime.bmap
         - Name: oldoverflow
           Offset: 8
-          Type: 29 PointerType *[]*runtime.bmap
+          Type: 54 PointerType *[]*runtime.bmap
         - Name: nextOverflow
           Offset: 16
-          Type: 32 PointerType *runtime.bmap
+          Type: 57 PointerType *runtime.bmap
     - __kind: GoStringHeaderType
-      ID: 5
+      ID: 11
       Name: string
       ByteSize: 16
       GoRuntimeType: 533568
@@ -2213,14 +2213,14 @@ Types:
           Type: 155 PointerType *string.str
         - Name: len
           Offset: 8
-          Type: 8 BaseType int
+          Type: 9 BaseType int
       Data: 154 GoStringDataType string.str
     - __kind: GoStringDataType
       ID: 154
       Name: string.str
       ByteSize: 2048
     - __kind: StructureType
-      ID: 76
+      ID: 98
       Name: time.Location
       ByteSize: 104
       GoRuntimeType: 1.833984e+06
@@ -2228,27 +2228,27 @@ Types:
       RawFields:
         - Name: name
           Offset: 0
-          Type: 5 GoStringHeaderType string
+          Type: 11 GoStringHeaderType string
         - Name: zone
           Offset: 16
-          Type: 77 GoSliceHeaderType []time.zone
+          Type: 99 GoSliceHeaderType []time.zone
         - Name: tx
           Offset: 40
-          Type: 80 GoSliceHeaderType []time.zoneTrans
+          Type: 102 GoSliceHeaderType []time.zoneTrans
         - Name: extend
           Offset: 64
-          Type: 5 GoStringHeaderType string
+          Type: 11 GoStringHeaderType string
         - Name: cacheStart
           Offset: 80
-          Type: 36 BaseType int64
+          Type: 13 BaseType int64
         - Name: cacheEnd
           Offset: 88
-          Type: 36 BaseType int64
+          Type: 13 BaseType int64
         - Name: cacheZone
           Offset: 96
-          Type: 78 PointerType *time.zone
+          Type: 100 PointerType *time.zone
     - __kind: StructureType
-      ID: 73
+      ID: 96
       Name: time.Time
       ByteSize: 24
       GoRuntimeType: 2.215168e+06
@@ -2256,15 +2256,15 @@ Types:
       RawFields:
         - Name: wall
           Offset: 0
-          Type: 74 BaseType uint64
+          Type: 10 BaseType uint64
         - Name: ext
           Offset: 8
-          Type: 36 BaseType int64
+          Type: 13 BaseType int64
         - Name: loc
           Offset: 16
-          Type: 75 PointerType *time.Location
+          Type: 97 PointerType *time.Location
     - __kind: StructureType
-      ID: 79
+      ID: 101
       Name: time.zone
       ByteSize: 32
       GoRuntimeType: 1.421024e+06
@@ -2272,15 +2272,15 @@ Types:
       RawFields:
         - Name: name
           Offset: 0
-          Type: 5 GoStringHeaderType string
+          Type: 11 GoStringHeaderType string
         - Name: offset
           Offset: 16
-          Type: 8 BaseType int
+          Type: 9 BaseType int
         - Name: isDST
           Offset: 24
-          Type: 13 BaseType bool
+          Type: 4 BaseType bool
     - __kind: StructureType
-      ID: 82
+      ID: 104
       Name: time.zoneTrans
       ByteSize: 16
       GoRuntimeType: 1.623328e+06
@@ -2288,54 +2288,54 @@ Types:
       RawFields:
         - Name: when
           Offset: 0
-          Type: 36 BaseType int64
+          Type: 13 BaseType int64
         - Name: index
           Offset: 8
-          Type: 7 BaseType uint8
+          Type: 3 BaseType uint8
         - Name: isstd
           Offset: 9
-          Type: 13 BaseType bool
+          Type: 4 BaseType bool
         - Name: isutc
           Offset: 10
-          Type: 13 BaseType bool
+          Type: 4 BaseType bool
     - __kind: BaseType
-      ID: 136
+      ID: 15
       Name: uint
       ByteSize: 8
       GoRuntimeType: 534208
       GoKind: 7
     - __kind: BaseType
-      ID: 17
+      ID: 7
       Name: uint16
       ByteSize: 2
       GoRuntimeType: 533824
       GoKind: 9
     - __kind: BaseType
-      ID: 18
+      ID: 2
       Name: uint32
       ByteSize: 4
       GoRuntimeType: 533952
       GoKind: 10
     - __kind: BaseType
-      ID: 74
+      ID: 10
       Name: uint64
       ByteSize: 8
       GoRuntimeType: 534080
       GoKind: 11
     - __kind: BaseType
-      ID: 7
+      ID: 3
       Name: uint8
       ByteSize: 1
       GoRuntimeType: 533696
       GoKind: 8
     - __kind: BaseType
-      ID: 26
+      ID: 1
       Name: uintptr
       ByteSize: 8
       GoRuntimeType: 534272
       GoKind: 12
     - __kind: VoidPointerType
-      ID: 2
+      ID: 19
       Name: unsafe.Pointer
       ByteSize: 8
       GoRuntimeType: 534656

--- a/pkg/dyninst/irgen/testdata/snapshot/rc_tester_v1.arch=amd64,toolchain=go1.24.3.yaml
+++ b/pkg/dyninst/irgen/testdata/snapshot/rc_tester_v1.arch=amd64,toolchain=go1.24.3.yaml
@@ -65,7 +65,7 @@ Subprograms:
           IsParameter: true
           IsReturn: false
         - Name: '&buf'
-          Type: 157 PointerType *bytes.Buffer
+          Type: 39 PointerType *bytes.Buffer
           Locations:
             - Range: 0xcfc7ee..0xcfc809
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
@@ -74,7 +74,7 @@ Subprograms:
           IsParameter: false
           IsReturn: false
         - Name: span
-          Type: 160 GoInterfaceType gopkg.in/DataDog/dd-trace-go.v1/ddtrace.Span
+          Type: 41 GoInterfaceType gopkg.in/DataDog/dd-trace-go.v1/ddtrace.Span
           Locations:
             - Range: 0xcfc6c8..0xcfc6c8
               Pieces:
@@ -97,7 +97,7 @@ Subprograms:
           IsParameter: false
           IsReturn: false
         - Name: .autotmp_14
-          Type: 161 StructureType context.backgroundCtx
+          Type: 42 StructureType context.backgroundCtx
           Locations:
             - Range: 0xcfc640..0xcfc8f0
               Pieces: [{Size: 0, Op: {CfaOffset: 0}}]
@@ -121,60 +121,60 @@ Subprograms:
           IsReturn: false
 Types:
     - __kind: PointerType
-      ID: 81
+      ID: 82
       Name: '**crypto/x509.Certificate'
       ByteSize: 8
       GoKind: 22
-      Pointee: 82 PointerType *crypto/x509.Certificate
+      Pointee: 83 PointerType *crypto/x509.Certificate
     - __kind: PointerType
-      ID: 73
+      ID: 148
       Name: '**mime/multipart.FileHeader'
       ByteSize: 8
       GoKind: 22
-      Pointee: 74 PointerType *mime/multipart.FileHeader
+      Pointee: 149 PointerType *mime/multipart.FileHeader
     - __kind: PointerType
-      ID: 121
+      ID: 135
       Name: '**net.IPNet'
       ByteSize: 8
       GoKind: 22
-      Pointee: 122 PointerType *net.IPNet
+      Pointee: 136 PointerType *net.IPNet
     - __kind: PointerType
-      ID: 119
+      ID: 133
       Name: '**net/url.URL'
       ByteSize: 8
       GoKind: 22
-      Pointee: 39 PointerType *net/url.URL
+      Pointee: 44 PointerType *net/url.URL
     - __kind: PointerType
-      ID: 64
+      ID: 79
       Name: '**table<string,[]*mime/multipart.FileHeader>'
       ByteSize: 8
-      Pointee: 65 PointerType *table<string,[]*mime/multipart.FileHeader>
+      Pointee: 80 PointerType *table<string,[]*mime/multipart.FileHeader>
     - __kind: PointerType
-      ID: 46
+      ID: 49
       Name: '**table<string,[]string>'
       ByteSize: 8
-      Pointee: 47 PointerType *table<string,[]string>
+      Pointee: 50 PointerType *table<string,[]string>
     - __kind: PointerType
-      ID: 149
+      ID: 68
       Name: '**table<string,string>'
       ByteSize: 8
-      Pointee: 150 PointerType *table<string,string>
+      Pointee: 69 PointerType *table<string,string>
     - __kind: PointerType
-      ID: 132
+      ID: 85
       Name: '*[]*crypto/x509.Certificate'
       ByteSize: 8
       GoKind: 22
-      Pointee: 80 GoSliceHeaderType []*crypto/x509.Certificate
+      Pointee: 81 GoSliceHeaderType []*crypto/x509.Certificate
     - __kind: PointerType
       ID: 176
       Name: '*[]*crypto/x509.Certificate.array'
       ByteSize: 8
       Pointee: 175 GoSliceDataType []*crypto/x509.Certificate.array
     - __kind: PointerType
-      ID: 172
+      ID: 206
       Name: '*[]*mime/multipart.FileHeader.array'
       ByteSize: 8
-      Pointee: 171 GoSliceDataType []*mime/multipart.FileHeader.array
+      Pointee: 205 GoSliceDataType []*mime/multipart.FileHeader.array
     - __kind: PointerType
       ID: 200
       Name: '*[]*net.IPNet.array'
@@ -186,82 +186,82 @@ Types:
       ByteSize: 8
       Pointee: 197 GoSliceDataType []*net/url.URL.array
     - __kind: PointerType
-      ID: 208
+      ID: 178
       Name: '*[][]*crypto/x509.Certificate.array'
       ByteSize: 8
-      Pointee: 207 GoSliceDataType [][]*crypto/x509.Certificate.array
+      Pointee: 177 GoSliceDataType [][]*crypto/x509.Certificate.array
     - __kind: PointerType
-      ID: 210
+      ID: 180
       Name: '*[][]uint8.array'
       ByteSize: 8
-      Pointee: 209 GoSliceDataType [][]uint8.array
+      Pointee: 179 GoSliceDataType [][]uint8.array
     - __kind: PointerType
       ID: 192
       Name: '*[]crypto/x509.ExtKeyUsage.array'
       ByteSize: 8
       Pointee: 191 GoSliceDataType []crypto/x509.ExtKeyUsage.array
     - __kind: PointerType
-      ID: 204
+      ID: 202
       Name: '*[]crypto/x509.OID.array'
       ByteSize: 8
-      Pointee: 203 GoSliceDataType []crypto/x509.OID.array
+      Pointee: 201 GoSliceDataType []crypto/x509.OID.array
     - __kind: PointerType
-      ID: 206
+      ID: 204
       Name: '*[]crypto/x509.PolicyMapping.array'
       ByteSize: 8
-      Pointee: 205 GoSliceDataType []crypto/x509.PolicyMapping.array
+      Pointee: 203 GoSliceDataType []crypto/x509.PolicyMapping.array
     - __kind: PointerType
-      ID: 180
+      ID: 184
       Name: '*[]crypto/x509/pkix.AttributeTypeAndValue.array'
       ByteSize: 8
-      Pointee: 179 GoSliceDataType []crypto/x509/pkix.AttributeTypeAndValue.array
+      Pointee: 183 GoSliceDataType []crypto/x509/pkix.AttributeTypeAndValue.array
     - __kind: PointerType
-      ID: 188
+      ID: 186
       Name: '*[]crypto/x509/pkix.Extension.array'
       ByteSize: 8
-      Pointee: 187 GoSliceDataType []crypto/x509/pkix.Extension.array
+      Pointee: 185 GoSliceDataType []crypto/x509/pkix.Extension.array
     - __kind: PointerType
-      ID: 190
+      ID: 188
       Name: '*[]encoding/asn1.ObjectIdentifier.array'
       ByteSize: 8
-      Pointee: 189 GoSliceDataType []encoding/asn1.ObjectIdentifier.array
+      Pointee: 187 GoSliceDataType []encoding/asn1.ObjectIdentifier.array
     - __kind: PointerType
       ID: 194
       Name: '*[]net.IP.array'
       ByteSize: 8
       Pointee: 193 GoSliceDataType []net.IP.array
     - __kind: PointerType
-      ID: 212
+      ID: 182
       Name: '*[]net/http.segment.array'
       ByteSize: 8
-      Pointee: 211 GoSliceDataType []net/http.segment.array
+      Pointee: 181 GoSliceDataType []net/http.segment.array
     - __kind: PointerType
       ID: 168
       Name: '*[]string.array'
       ByteSize: 8
       Pointee: 167 GoSliceDataType []string.array
     - __kind: PointerType
-      ID: 184
+      ID: 210
       Name: '*[]time.zone.array'
       ByteSize: 8
-      Pointee: 183 GoSliceDataType []time.zone.array
+      Pointee: 209 GoSliceDataType []time.zone.array
     - __kind: PointerType
-      ID: 186
+      ID: 212
       Name: '*[]time.zoneTrans.array'
       ByteSize: 8
-      Pointee: 185 GoSliceDataType []time.zoneTrans.array
+      Pointee: 211 GoSliceDataType []time.zoneTrans.array
     - __kind: PointerType
-      ID: 134
+      ID: 87
       Name: '*[]uint8'
       ByteSize: 8
       GoRuntimeType: 478304
       GoKind: 22
-      Pointee: 77 GoSliceHeaderType []uint8
+      Pointee: 70 GoSliceHeaderType []uint8
     - __kind: PointerType
-      ID: 174
+      ID: 172
       Name: '*[]uint8.array'
       ByteSize: 8
-      Pointee: 173 GoSliceDataType []uint8.array
+      Pointee: 171 GoSliceDataType []uint8.array
     - __kind: PointerType
       ID: 11
       Name: '*bool'
@@ -270,73 +270,73 @@ Types:
       GoKind: 22
       Pointee: 4 BaseType bool
     - __kind: PointerType
-      ID: 157
+      ID: 39
       Name: '*bytes.Buffer'
       ByteSize: 8
       GoRuntimeType: 2.245824e+06
       GoKind: 22
-      Pointee: 158 StructureType bytes.Buffer
+      Pointee: 40 StructureType bytes.Buffer
     - __kind: PointerType
-      ID: 78
+      ID: 57
       Name: '*crypto/tls.ConnectionState'
       ByteSize: 8
       GoRuntimeType: 901472
       GoKind: 22
-      Pointee: 79 StructureType crypto/tls.ConnectionState
+      Pointee: 58 StructureType crypto/tls.ConnectionState
     - __kind: PointerType
-      ID: 82
+      ID: 83
       Name: '*crypto/x509.Certificate'
       ByteSize: 8
       GoRuntimeType: 2.031072e+06
       GoKind: 22
-      Pointee: 83 StructureType crypto/x509.Certificate
+      Pointee: 98 StructureType crypto/x509.Certificate
     - __kind: PointerType
-      ID: 113
+      ID: 127
       Name: '*crypto/x509.ExtKeyUsage'
       ByteSize: 8
       GoRuntimeType: 420256
       GoKind: 22
-      Pointee: 114 BaseType crypto/x509.ExtKeyUsage
+      Pointee: 128 BaseType crypto/x509.ExtKeyUsage
     - __kind: PointerType
-      ID: 126
+      ID: 138
       Name: '*crypto/x509.OID'
       ByteSize: 8
       GoRuntimeType: 1.938912e+06
       GoKind: 22
-      Pointee: 127 StructureType crypto/x509.OID
+      Pointee: 139 StructureType crypto/x509.OID
     - __kind: PointerType
-      ID: 129
+      ID: 141
       Name: '*crypto/x509.PolicyMapping'
       ByteSize: 8
       GoRuntimeType: 420320
       GoKind: 22
-      Pointee: 130 StructureType crypto/x509.PolicyMapping
+      Pointee: 142 StructureType crypto/x509.PolicyMapping
     - __kind: PointerType
-      ID: 94
+      ID: 114
       Name: '*crypto/x509/pkix.AttributeTypeAndValue'
       ByteSize: 8
       GoRuntimeType: 434080
       GoKind: 22
-      Pointee: 95 StructureType crypto/x509/pkix.AttributeTypeAndValue
+      Pointee: 115 StructureType crypto/x509/pkix.AttributeTypeAndValue
     - __kind: PointerType
-      ID: 108
+      ID: 121
       Name: '*crypto/x509/pkix.Extension'
       ByteSize: 8
       GoRuntimeType: 434272
       GoKind: 22
-      Pointee: 109 StructureType crypto/x509/pkix.Extension
+      Pointee: 122 StructureType crypto/x509/pkix.Extension
     - __kind: PointerType
-      ID: 111
+      ID: 124
       Name: '*encoding/asn1.ObjectIdentifier'
       ByteSize: 8
       GoRuntimeType: 1.044704e+06
       GoKind: 22
-      Pointee: 96 GoSliceHeaderType encoding/asn1.ObjectIdentifier
+      Pointee: 125 GoSliceHeaderType encoding/asn1.ObjectIdentifier
     - __kind: PointerType
-      ID: 182
+      ID: 190
       Name: '*encoding/asn1.ObjectIdentifier.array'
       ByteSize: 8
-      Pointee: 181 GoSliceDataType encoding/asn1.ObjectIdentifier.array
+      Pointee: 189 GoSliceDataType encoding/asn1.ObjectIdentifier.array
     - __kind: PointerType
       ID: 33
       Name: '*error'
@@ -394,77 +394,77 @@ Types:
       GoKind: 22
       Pointee: 15 BaseType int8
     - __kind: PointerType
-      ID: 62
+      ID: 77
       Name: '*map<string,[]*mime/multipart.FileHeader>'
       ByteSize: 8
-      Pointee: 63 GoSwissMapHeaderType map<string,[]*mime/multipart.FileHeader>
+      Pointee: 78 GoSwissMapHeaderType map<string,[]*mime/multipart.FileHeader>
     - __kind: PointerType
-      ID: 44
+      ID: 47
       Name: '*map<string,[]string>'
       ByteSize: 8
-      Pointee: 45 GoSwissMapHeaderType map<string,[]string>
+      Pointee: 48 GoSwissMapHeaderType map<string,[]string>
     - __kind: PointerType
-      ID: 147
+      ID: 66
       Name: '*map<string,string>'
       ByteSize: 8
-      Pointee: 148 GoSwissMapHeaderType map<string,string>
+      Pointee: 67 GoSwissMapHeaderType map<string,string>
     - __kind: PointerType
-      ID: 87
+      ID: 110
       Name: '*math/big.Int'
       ByteSize: 8
       GoRuntimeType: 2.365472e+06
       GoKind: 22
-      Pointee: 88 StructureType math/big.Int
+      Pointee: 111 StructureType math/big.Int
     - __kind: PointerType
-      ID: 90
+      ID: 151
       Name: '*math/big.Word'
       ByteSize: 8
       GoRuntimeType: 423200
       GoKind: 22
-      Pointee: 91 BaseType math/big.Word
+      Pointee: 152 BaseType math/big.Word
     - __kind: PointerType
-      ID: 178
+      ID: 208
       Name: '*math/big.nat.array'
       ByteSize: 8
-      Pointee: 177 GoSliceDataType math/big.nat.array
+      Pointee: 207 GoSliceDataType math/big.nat.array
     - __kind: PointerType
-      ID: 74
+      ID: 149
       Name: '*mime/multipart.FileHeader'
       ByteSize: 8
       GoRuntimeType: 902912
       GoKind: 22
-      Pointee: 75 StructureType mime/multipart.FileHeader
+      Pointee: 160 StructureType mime/multipart.FileHeader
     - __kind: PointerType
-      ID: 58
+      ID: 55
       Name: '*mime/multipart.Form'
       ByteSize: 8
       GoRuntimeType: 903008
       GoKind: 22
-      Pointee: 59 StructureType mime/multipart.Form
+      Pointee: 56 StructureType mime/multipart.Form
     - __kind: PointerType
-      ID: 116
+      ID: 130
       Name: '*net.IP'
       ByteSize: 8
       GoRuntimeType: 2.13488e+06
       GoKind: 22
-      Pointee: 117 GoSliceHeaderType net.IP
+      Pointee: 131 GoSliceHeaderType net.IP
     - __kind: PointerType
       ID: 196
       Name: '*net.IP.array'
       ByteSize: 8
       Pointee: 195 GoSliceDataType net.IP.array
     - __kind: PointerType
-      ID: 202
+      ID: 214
       Name: '*net.IPMask.array'
       ByteSize: 8
-      Pointee: 201 GoSliceDataType net.IPMask.array
+      Pointee: 213 GoSliceDataType net.IPMask.array
     - __kind: PointerType
-      ID: 122
+      ID: 136
       Name: '*net.IPNet'
       ByteSize: 8
       GoRuntimeType: 1.174624e+06
       GoKind: 22
-      Pointee: 123 StructureType net.IPNet
+      Pointee: 159 StructureType net.IPNet
     - __kind: PointerType
       ID: 37
       Name: '*net/http.Request'
@@ -473,55 +473,55 @@ Types:
       GoKind: 22
       Pointee: 38 StructureType net/http.Request
     - __kind: PointerType
-      ID: 138
+      ID: 60
       Name: '*net/http.Response'
       ByteSize: 8
       GoRuntimeType: 1.706048e+06
       GoKind: 22
-      Pointee: 139 StructureType net/http.Response
+      Pointee: 61 StructureType net/http.Response
     - __kind: PointerType
-      ID: 141
+      ID: 63
       Name: '*net/http.pattern'
       ByteSize: 8
       GoRuntimeType: 1.597952e+06
       GoKind: 22
-      Pointee: 142 StructureType net/http.pattern
+      Pointee: 64 StructureType net/http.pattern
     - __kind: PointerType
-      ID: 144
+      ID: 91
       Name: '*net/http.segment'
       ByteSize: 8
       GoRuntimeType: 388640
       GoKind: 22
-      Pointee: 145 StructureType net/http.segment
+      Pointee: 92 StructureType net/http.segment
     - __kind: PointerType
-      ID: 39
+      ID: 44
       Name: '*net/url.URL'
       ByteSize: 8
       GoRuntimeType: 2.100096e+06
       GoKind: 22
-      Pointee: 40 StructureType net/url.URL
+      Pointee: 45 StructureType net/url.URL
     - __kind: PointerType
-      ID: 41
+      ID: 72
       Name: '*net/url.Userinfo'
       ByteSize: 8
       GoRuntimeType: 1.19216e+06
       GoKind: 22
-      Pointee: 42 StructureType net/url.Userinfo
+      Pointee: 73 StructureType net/url.Userinfo
     - __kind: PointerType
-      ID: 68
+      ID: 105
       Name: '*noalg.map.group[string][]*mime/multipart.FileHeader'
       ByteSize: 8
-      Pointee: 69 StructureType noalg.map.group[string][]*mime/multipart.FileHeader
+      Pointee: 106 StructureType noalg.map.group[string][]*mime/multipart.FileHeader
     - __kind: PointerType
-      ID: 50
+      ID: 95
       Name: '*noalg.map.group[string][]string'
       ByteSize: 8
-      Pointee: 51 StructureType noalg.map.group[string][]string
+      Pointee: 96 StructureType noalg.map.group[string][]string
     - __kind: PointerType
-      ID: 153
+      ID: 100
       Name: '*noalg.map.group[string]string'
       ByteSize: 8
-      Pointee: 154 StructureType noalg.map.group[string]string
+      Pointee: 101 StructureType noalg.map.group[string]string
     - __kind: PointerType
       ID: 22
       Name: '*string'
@@ -535,41 +535,41 @@ Types:
       ByteSize: 8
       Pointee: 163 GoStringDataType string.str
     - __kind: PointerType
-      ID: 65
+      ID: 80
       Name: '*table<string,[]*mime/multipart.FileHeader>'
       ByteSize: 8
-      Pointee: 66 StructureType table<string,[]*mime/multipart.FileHeader>
+      Pointee: 97 StructureType table<string,[]*mime/multipart.FileHeader>
     - __kind: PointerType
-      ID: 47
+      ID: 50
       Name: '*table<string,[]string>'
       ByteSize: 8
-      Pointee: 48 StructureType table<string,[]string>
+      Pointee: 74 StructureType table<string,[]string>
     - __kind: PointerType
-      ID: 150
+      ID: 69
       Name: '*table<string,string>'
       ByteSize: 8
-      Pointee: 151 StructureType table<string,string>
+      Pointee: 93 StructureType table<string,string>
     - __kind: PointerType
-      ID: 98
+      ID: 117
       Name: '*time.Location'
       ByteSize: 8
       GoRuntimeType: 1.602944e+06
       GoKind: 22
-      Pointee: 99 StructureType time.Location
+      Pointee: 118 StructureType time.Location
     - __kind: PointerType
-      ID: 101
+      ID: 154
       Name: '*time.zone'
       ByteSize: 8
       GoRuntimeType: 391776
       GoKind: 22
-      Pointee: 102 StructureType time.zone
+      Pointee: 155 StructureType time.zone
     - __kind: PointerType
-      ID: 104
+      ID: 157
       Name: '*time.zoneTrans'
       ByteSize: 8
       GoRuntimeType: 391840
       GoKind: 22
-      Pointee: 105 StructureType time.zoneTrans
+      Pointee: 158 StructureType time.zoneTrans
     - __kind: PointerType
       ID: 34
       Name: '*uint'
@@ -613,7 +613,7 @@ Types:
       GoKind: 22
       Pointee: 1 BaseType uintptr
     - __kind: GoChannelType
-      ID: 137
+      ID: 59
       Name: <-chan struct {}
       GoRuntimeType: 592896
       GoKind: 18
@@ -657,7 +657,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: GoSliceHeaderType
-      ID: 80
+      ID: 81
       Name: '[]*crypto/x509.Certificate'
       ByteSize: 24
       GoRuntimeType: 498464
@@ -665,7 +665,7 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 81 PointerType **crypto/x509.Certificate
+          Type: 82 PointerType **crypto/x509.Certificate
         - Name: len
           Offset: 8
           Type: 7 BaseType int
@@ -677,9 +677,9 @@ Types:
       ID: 175
       Name: '[]*crypto/x509.Certificate.array'
       ByteSize: 2048
-      Element: 82 PointerType *crypto/x509.Certificate
+      Element: 83 PointerType *crypto/x509.Certificate
     - __kind: GoSliceHeaderType
-      ID: 72
+      ID: 147
       Name: '[]*mime/multipart.FileHeader'
       ByteSize: 24
       GoRuntimeType: 483904
@@ -687,21 +687,21 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 73 PointerType **mime/multipart.FileHeader
+          Type: 148 PointerType **mime/multipart.FileHeader
         - Name: len
           Offset: 8
           Type: 7 BaseType int
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 171 GoSliceDataType []*mime/multipart.FileHeader.array
+      Data: 205 GoSliceDataType []*mime/multipart.FileHeader.array
     - __kind: GoSliceDataType
-      ID: 171
+      ID: 205
       Name: '[]*mime/multipart.FileHeader.array'
       ByteSize: 2048
-      Element: 74 PointerType *mime/multipart.FileHeader
+      Element: 149 PointerType *mime/multipart.FileHeader
     - __kind: GoSliceHeaderType
-      ID: 120
+      ID: 134
       Name: '[]*net.IPNet'
       ByteSize: 24
       GoRuntimeType: 512000
@@ -709,7 +709,7 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 121 PointerType **net.IPNet
+          Type: 135 PointerType **net.IPNet
         - Name: len
           Offset: 8
           Type: 7 BaseType int
@@ -721,9 +721,9 @@ Types:
       ID: 199
       Name: '[]*net.IPNet.array'
       ByteSize: 2048
-      Element: 122 PointerType *net.IPNet
+      Element: 136 PointerType *net.IPNet
     - __kind: GoSliceHeaderType
-      ID: 118
+      ID: 132
       Name: '[]*net/url.URL'
       ByteSize: 24
       GoRuntimeType: 511936
@@ -731,7 +731,7 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 119 PointerType **net/url.URL
+          Type: 133 PointerType **net/url.URL
         - Name: len
           Offset: 8
           Type: 7 BaseType int
@@ -743,24 +743,24 @@ Types:
       ID: 197
       Name: '[]*net/url.URL.array'
       ByteSize: 2048
-      Element: 39 PointerType *net/url.URL
+      Element: 44 PointerType *net/url.URL
     - __kind: GoSliceDataType
-      ID: 169
+      ID: 173
       Name: '[]*table<string,[]*mime/multipart.FileHeader>.array'
       ByteSize: 8192
-      Element: 65 PointerType *table<string,[]*mime/multipart.FileHeader>
+      Element: 80 PointerType *table<string,[]*mime/multipart.FileHeader>
     - __kind: GoSliceDataType
       ID: 165
       Name: '[]*table<string,[]string>.array'
       ByteSize: 8192
-      Element: 47 PointerType *table<string,[]string>
+      Element: 50 PointerType *table<string,[]string>
     - __kind: GoSliceDataType
-      ID: 213
+      ID: 169
       Name: '[]*table<string,string>.array'
       ByteSize: 8192
-      Element: 150 PointerType *table<string,string>
+      Element: 69 PointerType *table<string,string>
     - __kind: GoSliceHeaderType
-      ID: 131
+      ID: 84
       Name: '[][]*crypto/x509.Certificate'
       ByteSize: 24
       GoRuntimeType: 498592
@@ -768,21 +768,21 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 132 PointerType *[]*crypto/x509.Certificate
+          Type: 85 PointerType *[]*crypto/x509.Certificate
         - Name: len
           Offset: 8
           Type: 7 BaseType int
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 207 GoSliceDataType [][]*crypto/x509.Certificate.array
+      Data: 177 GoSliceDataType [][]*crypto/x509.Certificate.array
     - __kind: GoSliceDataType
-      ID: 207
+      ID: 177
       Name: '[][]*crypto/x509.Certificate.array'
       ByteSize: 2048
-      Element: 80 GoSliceHeaderType []*crypto/x509.Certificate
+      Element: 81 GoSliceHeaderType []*crypto/x509.Certificate
     - __kind: GoSliceHeaderType
-      ID: 133
+      ID: 86
       Name: '[][]uint8'
       ByteSize: 24
       GoRuntimeType: 478688
@@ -790,21 +790,21 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 134 PointerType *[]uint8
+          Type: 87 PointerType *[]uint8
         - Name: len
           Offset: 8
           Type: 7 BaseType int
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 209 GoSliceDataType [][]uint8.array
+      Data: 179 GoSliceDataType [][]uint8.array
     - __kind: GoSliceDataType
-      ID: 209
+      ID: 179
       Name: '[][]uint8.array'
       ByteSize: 2048
-      Element: 77 GoSliceHeaderType []uint8
+      Element: 70 GoSliceHeaderType []uint8
     - __kind: GoSliceHeaderType
-      ID: 112
+      ID: 126
       Name: '[]crypto/x509.ExtKeyUsage'
       ByteSize: 24
       GoRuntimeType: 499936
@@ -812,7 +812,7 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 113 PointerType *crypto/x509.ExtKeyUsage
+          Type: 127 PointerType *crypto/x509.ExtKeyUsage
         - Name: len
           Offset: 8
           Type: 7 BaseType int
@@ -824,9 +824,9 @@ Types:
       ID: 191
       Name: '[]crypto/x509.ExtKeyUsage.array'
       ByteSize: 2048
-      Element: 114 BaseType crypto/x509.ExtKeyUsage
+      Element: 128 BaseType crypto/x509.ExtKeyUsage
     - __kind: GoSliceHeaderType
-      ID: 125
+      ID: 137
       Name: '[]crypto/x509.OID'
       ByteSize: 24
       GoRuntimeType: 512064
@@ -834,21 +834,21 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 126 PointerType *crypto/x509.OID
+          Type: 138 PointerType *crypto/x509.OID
         - Name: len
           Offset: 8
           Type: 7 BaseType int
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 203 GoSliceDataType []crypto/x509.OID.array
+      Data: 201 GoSliceDataType []crypto/x509.OID.array
     - __kind: GoSliceDataType
-      ID: 203
+      ID: 201
       Name: '[]crypto/x509.OID.array'
       ByteSize: 2048
-      Element: 127 StructureType crypto/x509.OID
+      Element: 139 StructureType crypto/x509.OID
     - __kind: GoSliceHeaderType
-      ID: 128
+      ID: 140
       Name: '[]crypto/x509.PolicyMapping'
       ByteSize: 24
       GoRuntimeType: 512128
@@ -856,21 +856,21 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 129 PointerType *crypto/x509.PolicyMapping
+          Type: 141 PointerType *crypto/x509.PolicyMapping
         - Name: len
           Offset: 8
           Type: 7 BaseType int
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 205 GoSliceDataType []crypto/x509.PolicyMapping.array
+      Data: 203 GoSliceDataType []crypto/x509.PolicyMapping.array
     - __kind: GoSliceDataType
-      ID: 205
+      ID: 203
       Name: '[]crypto/x509.PolicyMapping.array'
       ByteSize: 2048
-      Element: 130 StructureType crypto/x509.PolicyMapping
+      Element: 142 StructureType crypto/x509.PolicyMapping
     - __kind: GoSliceHeaderType
-      ID: 93
+      ID: 113
       Name: '[]crypto/x509/pkix.AttributeTypeAndValue'
       ByteSize: 24
       GoRuntimeType: 512576
@@ -878,21 +878,21 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 94 PointerType *crypto/x509/pkix.AttributeTypeAndValue
+          Type: 114 PointerType *crypto/x509/pkix.AttributeTypeAndValue
         - Name: len
           Offset: 8
           Type: 7 BaseType int
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 179 GoSliceDataType []crypto/x509/pkix.AttributeTypeAndValue.array
+      Data: 183 GoSliceDataType []crypto/x509/pkix.AttributeTypeAndValue.array
     - __kind: GoSliceDataType
-      ID: 179
+      ID: 183
       Name: '[]crypto/x509/pkix.AttributeTypeAndValue.array'
       ByteSize: 2048
-      Element: 95 StructureType crypto/x509/pkix.AttributeTypeAndValue
+      Element: 115 StructureType crypto/x509/pkix.AttributeTypeAndValue
     - __kind: GoSliceHeaderType
-      ID: 107
+      ID: 120
       Name: '[]crypto/x509/pkix.Extension'
       ByteSize: 24
       GoRuntimeType: 511808
@@ -900,21 +900,21 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 108 PointerType *crypto/x509/pkix.Extension
+          Type: 121 PointerType *crypto/x509/pkix.Extension
         - Name: len
           Offset: 8
           Type: 7 BaseType int
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 187 GoSliceDataType []crypto/x509/pkix.Extension.array
+      Data: 185 GoSliceDataType []crypto/x509/pkix.Extension.array
     - __kind: GoSliceDataType
-      ID: 187
+      ID: 185
       Name: '[]crypto/x509/pkix.Extension.array'
       ByteSize: 2048
-      Element: 109 StructureType crypto/x509/pkix.Extension
+      Element: 122 StructureType crypto/x509/pkix.Extension
     - __kind: GoSliceHeaderType
-      ID: 110
+      ID: 123
       Name: '[]encoding/asn1.ObjectIdentifier'
       ByteSize: 24
       GoRuntimeType: 511872
@@ -922,21 +922,21 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 111 PointerType *encoding/asn1.ObjectIdentifier
+          Type: 124 PointerType *encoding/asn1.ObjectIdentifier
         - Name: len
           Offset: 8
           Type: 7 BaseType int
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 189 GoSliceDataType []encoding/asn1.ObjectIdentifier.array
+      Data: 187 GoSliceDataType []encoding/asn1.ObjectIdentifier.array
     - __kind: GoSliceDataType
-      ID: 189
+      ID: 187
       Name: '[]encoding/asn1.ObjectIdentifier.array'
       ByteSize: 2048
-      Element: 96 GoSliceHeaderType encoding/asn1.ObjectIdentifier
+      Element: 125 GoSliceHeaderType encoding/asn1.ObjectIdentifier
     - __kind: GoSliceHeaderType
-      ID: 115
+      ID: 129
       Name: '[]net.IP'
       ByteSize: 24
       GoRuntimeType: 479648
@@ -944,7 +944,7 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 116 PointerType *net.IP
+          Type: 130 PointerType *net.IP
         - Name: len
           Offset: 8
           Type: 7 BaseType int
@@ -956,9 +956,9 @@ Types:
       ID: 193
       Name: '[]net.IP.array'
       ByteSize: 2048
-      Element: 117 GoSliceHeaderType net.IP
+      Element: 131 GoSliceHeaderType net.IP
     - __kind: GoSliceHeaderType
-      ID: 143
+      ID: 90
       Name: '[]net/http.segment'
       ByteSize: 24
       GoRuntimeType: 481280
@@ -966,36 +966,36 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 144 PointerType *net/http.segment
+          Type: 91 PointerType *net/http.segment
         - Name: len
           Offset: 8
           Type: 7 BaseType int
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 211 GoSliceDataType []net/http.segment.array
+      Data: 181 GoSliceDataType []net/http.segment.array
     - __kind: GoSliceDataType
-      ID: 211
+      ID: 181
       Name: '[]net/http.segment.array'
       ByteSize: 2048
-      Element: 145 StructureType net/http.segment
+      Element: 92 StructureType net/http.segment
     - __kind: GoSliceDataType
-      ID: 170
+      ID: 174
       Name: '[]noalg.map.group[string][]*mime/multipart.FileHeader.array'
       ByteSize: 2048
-      Element: 69 StructureType noalg.map.group[string][]*mime/multipart.FileHeader
+      Element: 106 StructureType noalg.map.group[string][]*mime/multipart.FileHeader
     - __kind: GoSliceDataType
       ID: 166
       Name: '[]noalg.map.group[string][]string.array'
       ByteSize: 2048
-      Element: 51 StructureType noalg.map.group[string][]string
+      Element: 96 StructureType noalg.map.group[string][]string
     - __kind: GoSliceDataType
-      ID: 214
+      ID: 170
       Name: '[]noalg.map.group[string]string.array'
       ByteSize: 2048
-      Element: 154 StructureType noalg.map.group[string]string
+      Element: 101 StructureType noalg.map.group[string]string
     - __kind: GoSliceHeaderType
-      ID: 54
+      ID: 53
       Name: '[]string'
       ByteSize: 24
       GoRuntimeType: 492832
@@ -1017,7 +1017,7 @@ Types:
       ByteSize: 2048
       Element: 9 GoStringHeaderType string
     - __kind: GoSliceHeaderType
-      ID: 100
+      ID: 153
       Name: '[]time.zone'
       ByteSize: 24
       GoRuntimeType: 485952
@@ -1025,21 +1025,21 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 101 PointerType *time.zone
+          Type: 154 PointerType *time.zone
         - Name: len
           Offset: 8
           Type: 7 BaseType int
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 183 GoSliceDataType []time.zone.array
+      Data: 209 GoSliceDataType []time.zone.array
     - __kind: GoSliceDataType
-      ID: 183
+      ID: 209
       Name: '[]time.zone.array'
       ByteSize: 2048
-      Element: 102 StructureType time.zone
+      Element: 155 StructureType time.zone
     - __kind: GoSliceHeaderType
-      ID: 103
+      ID: 156
       Name: '[]time.zoneTrans'
       ByteSize: 24
       GoRuntimeType: 486016
@@ -1047,21 +1047,21 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 104 PointerType *time.zoneTrans
+          Type: 157 PointerType *time.zoneTrans
         - Name: len
           Offset: 8
           Type: 7 BaseType int
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 185 GoSliceDataType []time.zoneTrans.array
+      Data: 211 GoSliceDataType []time.zoneTrans.array
     - __kind: GoSliceDataType
-      ID: 185
+      ID: 211
       Name: '[]time.zoneTrans.array'
       ByteSize: 2048
-      Element: 105 StructureType time.zoneTrans
+      Element: 158 StructureType time.zoneTrans
     - __kind: GoSliceHeaderType
-      ID: 77
+      ID: 70
       Name: '[]uint8'
       ByteSize: 24
       GoRuntimeType: 491680
@@ -1076,9 +1076,9 @@ Types:
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 173 GoSliceDataType []uint8.array
+      Data: 171 GoSliceDataType []uint8.array
     - __kind: GoSliceDataType
-      ID: 173
+      ID: 171
       Name: '[]uint8.array'
       ByteSize: 2048
       Element: 3 BaseType uint8
@@ -1089,7 +1089,7 @@ Types:
       GoRuntimeType: 580672
       GoKind: 1
     - __kind: StructureType
-      ID: 158
+      ID: 40
       Name: bytes.Buffer
       ByteSize: 40
       GoRuntimeType: 1.595648e+06
@@ -1097,15 +1097,15 @@ Types:
       RawFields:
         - Name: buf
           Offset: 0
-          Type: 77 GoSliceHeaderType []uint8
+          Type: 70 GoSliceHeaderType []uint8
         - Name: off
           Offset: 24
           Type: 7 BaseType int
         - Name: lastRead
           Offset: 32
-          Type: 159 BaseType bytes.readOp
+          Type: 71 BaseType bytes.readOp
     - __kind: BaseType
-      ID: 159
+      ID: 71
       Name: bytes.readOp
       ByteSize: 1
       GoRuntimeType: 578816
@@ -1123,7 +1123,7 @@ Types:
       GoRuntimeType: 580416
       GoKind: 15
     - __kind: GoInterfaceType
-      ID: 140
+      ID: 62
       Name: context.Context
       ByteSize: 16
       GoRuntimeType: 1.267616e+06
@@ -1136,22 +1136,22 @@ Types:
           Offset: 8
           Type: 14 VoidPointerType unsafe.Pointer
     - __kind: StructureType
-      ID: 161
+      ID: 42
       Name: context.backgroundCtx
       GoRuntimeType: 1.781952e+06
       GoKind: 25
       RawFields:
         - Name: emptyCtx
           Offset: 0
-          Type: 162 StructureType context.emptyCtx
+          Type: 43 StructureType context.emptyCtx
     - __kind: StructureType
-      ID: 162
+      ID: 43
       Name: context.emptyCtx
       GoRuntimeType: 1.580704e+06
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 79
+      ID: 58
       Name: crypto/tls.ConnectionState
       ByteSize: 192
       GoRuntimeType: 2.232384e+06
@@ -1180,39 +1180,39 @@ Types:
           Type: 9 GoStringHeaderType string
         - Name: PeerCertificates
           Offset: 48
-          Type: 80 GoSliceHeaderType []*crypto/x509.Certificate
+          Type: 81 GoSliceHeaderType []*crypto/x509.Certificate
         - Name: VerifiedChains
           Offset: 72
-          Type: 131 GoSliceHeaderType [][]*crypto/x509.Certificate
+          Type: 84 GoSliceHeaderType [][]*crypto/x509.Certificate
         - Name: SignedCertificateTimestamps
           Offset: 96
-          Type: 133 GoSliceHeaderType [][]uint8
+          Type: 86 GoSliceHeaderType [][]uint8
         - Name: OCSPResponse
           Offset: 120
-          Type: 77 GoSliceHeaderType []uint8
+          Type: 70 GoSliceHeaderType []uint8
         - Name: TLSUnique
           Offset: 144
-          Type: 77 GoSliceHeaderType []uint8
+          Type: 70 GoSliceHeaderType []uint8
         - Name: ECHAccepted
           Offset: 168
           Type: 4 BaseType bool
         - Name: ekm
           Offset: 176
-          Type: 135 GoSubroutineType func(string, []uint8, int) ([]uint8, error)
+          Type: 88 GoSubroutineType func(string, []uint8, int) ([]uint8, error)
         - Name: testingOnlyDidHRR
           Offset: 184
           Type: 4 BaseType bool
         - Name: testingOnlyCurveID
           Offset: 186
-          Type: 136 BaseType crypto/tls.CurveID
+          Type: 89 BaseType crypto/tls.CurveID
     - __kind: BaseType
-      ID: 136
+      ID: 89
       Name: crypto/tls.CurveID
       ByteSize: 2
       GoRuntimeType: 829664
       GoKind: 9
     - __kind: StructureType
-      ID: 83
+      ID: 98
       Name: crypto/x509.Certificate
       ByteSize: 1424
       GoRuntimeType: 2.377888e+06
@@ -1220,67 +1220,67 @@ Types:
       RawFields:
         - Name: Raw
           Offset: 0
-          Type: 77 GoSliceHeaderType []uint8
+          Type: 70 GoSliceHeaderType []uint8
         - Name: RawTBSCertificate
           Offset: 24
-          Type: 77 GoSliceHeaderType []uint8
+          Type: 70 GoSliceHeaderType []uint8
         - Name: RawSubjectPublicKeyInfo
           Offset: 48
-          Type: 77 GoSliceHeaderType []uint8
+          Type: 70 GoSliceHeaderType []uint8
         - Name: RawSubject
           Offset: 72
-          Type: 77 GoSliceHeaderType []uint8
+          Type: 70 GoSliceHeaderType []uint8
         - Name: RawIssuer
           Offset: 96
-          Type: 77 GoSliceHeaderType []uint8
+          Type: 70 GoSliceHeaderType []uint8
         - Name: Signature
           Offset: 120
-          Type: 77 GoSliceHeaderType []uint8
+          Type: 70 GoSliceHeaderType []uint8
         - Name: SignatureAlgorithm
           Offset: 144
-          Type: 84 BaseType crypto/x509.SignatureAlgorithm
+          Type: 107 BaseType crypto/x509.SignatureAlgorithm
         - Name: PublicKeyAlgorithm
           Offset: 152
-          Type: 85 BaseType crypto/x509.PublicKeyAlgorithm
+          Type: 108 BaseType crypto/x509.PublicKeyAlgorithm
         - Name: PublicKey
           Offset: 160
-          Type: 86 GoEmptyInterfaceType interface {}
+          Type: 109 GoEmptyInterfaceType interface {}
         - Name: Version
           Offset: 176
           Type: 7 BaseType int
         - Name: SerialNumber
           Offset: 184
-          Type: 87 PointerType *math/big.Int
+          Type: 110 PointerType *math/big.Int
         - Name: Issuer
           Offset: 192
-          Type: 92 StructureType crypto/x509/pkix.Name
+          Type: 112 StructureType crypto/x509/pkix.Name
         - Name: Subject
           Offset: 440
-          Type: 92 StructureType crypto/x509/pkix.Name
+          Type: 112 StructureType crypto/x509/pkix.Name
         - Name: NotBefore
           Offset: 688
-          Type: 97 StructureType time.Time
+          Type: 116 StructureType time.Time
         - Name: NotAfter
           Offset: 712
-          Type: 97 StructureType time.Time
+          Type: 116 StructureType time.Time
         - Name: KeyUsage
           Offset: 736
-          Type: 106 BaseType crypto/x509.KeyUsage
+          Type: 119 BaseType crypto/x509.KeyUsage
         - Name: Extensions
           Offset: 744
-          Type: 107 GoSliceHeaderType []crypto/x509/pkix.Extension
+          Type: 120 GoSliceHeaderType []crypto/x509/pkix.Extension
         - Name: ExtraExtensions
           Offset: 768
-          Type: 107 GoSliceHeaderType []crypto/x509/pkix.Extension
+          Type: 120 GoSliceHeaderType []crypto/x509/pkix.Extension
         - Name: UnhandledCriticalExtensions
           Offset: 792
-          Type: 110 GoSliceHeaderType []encoding/asn1.ObjectIdentifier
+          Type: 123 GoSliceHeaderType []encoding/asn1.ObjectIdentifier
         - Name: ExtKeyUsage
           Offset: 816
-          Type: 112 GoSliceHeaderType []crypto/x509.ExtKeyUsage
+          Type: 126 GoSliceHeaderType []crypto/x509.ExtKeyUsage
         - Name: UnknownExtKeyUsage
           Offset: 840
-          Type: 110 GoSliceHeaderType []encoding/asn1.ObjectIdentifier
+          Type: 123 GoSliceHeaderType []encoding/asn1.ObjectIdentifier
         - Name: BasicConstraintsValid
           Offset: 864
           Type: 4 BaseType bool
@@ -1295,64 +1295,64 @@ Types:
           Type: 4 BaseType bool
         - Name: SubjectKeyId
           Offset: 888
-          Type: 77 GoSliceHeaderType []uint8
+          Type: 70 GoSliceHeaderType []uint8
         - Name: AuthorityKeyId
           Offset: 912
-          Type: 77 GoSliceHeaderType []uint8
+          Type: 70 GoSliceHeaderType []uint8
         - Name: OCSPServer
           Offset: 936
-          Type: 54 GoSliceHeaderType []string
+          Type: 53 GoSliceHeaderType []string
         - Name: IssuingCertificateURL
           Offset: 960
-          Type: 54 GoSliceHeaderType []string
+          Type: 53 GoSliceHeaderType []string
         - Name: DNSNames
           Offset: 984
-          Type: 54 GoSliceHeaderType []string
+          Type: 53 GoSliceHeaderType []string
         - Name: EmailAddresses
           Offset: 1008
-          Type: 54 GoSliceHeaderType []string
+          Type: 53 GoSliceHeaderType []string
         - Name: IPAddresses
           Offset: 1032
-          Type: 115 GoSliceHeaderType []net.IP
+          Type: 129 GoSliceHeaderType []net.IP
         - Name: URIs
           Offset: 1056
-          Type: 118 GoSliceHeaderType []*net/url.URL
+          Type: 132 GoSliceHeaderType []*net/url.URL
         - Name: PermittedDNSDomainsCritical
           Offset: 1080
           Type: 4 BaseType bool
         - Name: PermittedDNSDomains
           Offset: 1088
-          Type: 54 GoSliceHeaderType []string
+          Type: 53 GoSliceHeaderType []string
         - Name: ExcludedDNSDomains
           Offset: 1112
-          Type: 54 GoSliceHeaderType []string
+          Type: 53 GoSliceHeaderType []string
         - Name: PermittedIPRanges
           Offset: 1136
-          Type: 120 GoSliceHeaderType []*net.IPNet
+          Type: 134 GoSliceHeaderType []*net.IPNet
         - Name: ExcludedIPRanges
           Offset: 1160
-          Type: 120 GoSliceHeaderType []*net.IPNet
+          Type: 134 GoSliceHeaderType []*net.IPNet
         - Name: PermittedEmailAddresses
           Offset: 1184
-          Type: 54 GoSliceHeaderType []string
+          Type: 53 GoSliceHeaderType []string
         - Name: ExcludedEmailAddresses
           Offset: 1208
-          Type: 54 GoSliceHeaderType []string
+          Type: 53 GoSliceHeaderType []string
         - Name: PermittedURIDomains
           Offset: 1232
-          Type: 54 GoSliceHeaderType []string
+          Type: 53 GoSliceHeaderType []string
         - Name: ExcludedURIDomains
           Offset: 1256
-          Type: 54 GoSliceHeaderType []string
+          Type: 53 GoSliceHeaderType []string
         - Name: CRLDistributionPoints
           Offset: 1280
-          Type: 54 GoSliceHeaderType []string
+          Type: 53 GoSliceHeaderType []string
         - Name: PolicyIdentifiers
           Offset: 1304
-          Type: 110 GoSliceHeaderType []encoding/asn1.ObjectIdentifier
+          Type: 123 GoSliceHeaderType []encoding/asn1.ObjectIdentifier
         - Name: Policies
           Offset: 1328
-          Type: 125 GoSliceHeaderType []crypto/x509.OID
+          Type: 137 GoSliceHeaderType []crypto/x509.OID
         - Name: InhibitAnyPolicy
           Offset: 1352
           Type: 7 BaseType int
@@ -1373,21 +1373,21 @@ Types:
           Type: 4 BaseType bool
         - Name: PolicyMappings
           Offset: 1400
-          Type: 128 GoSliceHeaderType []crypto/x509.PolicyMapping
+          Type: 140 GoSliceHeaderType []crypto/x509.PolicyMapping
     - __kind: BaseType
-      ID: 114
+      ID: 128
       Name: crypto/x509.ExtKeyUsage
       ByteSize: 8
       GoRuntimeType: 583360
       GoKind: 2
     - __kind: BaseType
-      ID: 106
+      ID: 119
       Name: crypto/x509.KeyUsage
       ByteSize: 8
       GoRuntimeType: 583296
       GoKind: 2
     - __kind: StructureType
-      ID: 127
+      ID: 139
       Name: crypto/x509.OID
       ByteSize: 24
       GoRuntimeType: 1.939168e+06
@@ -1395,9 +1395,9 @@ Types:
       RawFields:
         - Name: der
           Offset: 0
-          Type: 77 GoSliceHeaderType []uint8
+          Type: 70 GoSliceHeaderType []uint8
     - __kind: StructureType
-      ID: 130
+      ID: 142
       Name: crypto/x509.PolicyMapping
       ByteSize: 48
       GoRuntimeType: 1.480928e+06
@@ -1405,24 +1405,24 @@ Types:
       RawFields:
         - Name: IssuerDomainPolicy
           Offset: 0
-          Type: 127 StructureType crypto/x509.OID
+          Type: 139 StructureType crypto/x509.OID
         - Name: SubjectDomainPolicy
           Offset: 24
-          Type: 127 StructureType crypto/x509.OID
+          Type: 139 StructureType crypto/x509.OID
     - __kind: BaseType
-      ID: 85
+      ID: 108
       Name: crypto/x509.PublicKeyAlgorithm
       ByteSize: 8
       GoRuntimeType: 832064
       GoKind: 2
     - __kind: BaseType
-      ID: 84
+      ID: 107
       Name: crypto/x509.SignatureAlgorithm
       ByteSize: 8
       GoRuntimeType: 1.105248e+06
       GoKind: 2
     - __kind: StructureType
-      ID: 95
+      ID: 115
       Name: crypto/x509/pkix.AttributeTypeAndValue
       ByteSize: 40
       GoRuntimeType: 1.492608e+06
@@ -1430,12 +1430,12 @@ Types:
       RawFields:
         - Name: Type
           Offset: 0
-          Type: 96 GoSliceHeaderType encoding/asn1.ObjectIdentifier
+          Type: 125 GoSliceHeaderType encoding/asn1.ObjectIdentifier
         - Name: Value
           Offset: 24
-          Type: 86 GoEmptyInterfaceType interface {}
+          Type: 109 GoEmptyInterfaceType interface {}
     - __kind: StructureType
-      ID: 109
+      ID: 122
       Name: crypto/x509/pkix.Extension
       ByteSize: 56
       GoRuntimeType: 1.63616e+06
@@ -1443,15 +1443,15 @@ Types:
       RawFields:
         - Name: Id
           Offset: 0
-          Type: 96 GoSliceHeaderType encoding/asn1.ObjectIdentifier
+          Type: 125 GoSliceHeaderType encoding/asn1.ObjectIdentifier
         - Name: Critical
           Offset: 24
           Type: 4 BaseType bool
         - Name: Value
           Offset: 32
-          Type: 77 GoSliceHeaderType []uint8
+          Type: 70 GoSliceHeaderType []uint8
     - __kind: StructureType
-      ID: 92
+      ID: 112
       Name: crypto/x509/pkix.Name
       ByteSize: 248
       GoRuntimeType: 2.177504e+06
@@ -1459,25 +1459,25 @@ Types:
       RawFields:
         - Name: Country
           Offset: 0
-          Type: 54 GoSliceHeaderType []string
+          Type: 53 GoSliceHeaderType []string
         - Name: Organization
           Offset: 24
-          Type: 54 GoSliceHeaderType []string
+          Type: 53 GoSliceHeaderType []string
         - Name: OrganizationalUnit
           Offset: 48
-          Type: 54 GoSliceHeaderType []string
+          Type: 53 GoSliceHeaderType []string
         - Name: Locality
           Offset: 72
-          Type: 54 GoSliceHeaderType []string
+          Type: 53 GoSliceHeaderType []string
         - Name: Province
           Offset: 96
-          Type: 54 GoSliceHeaderType []string
+          Type: 53 GoSliceHeaderType []string
         - Name: StreetAddress
           Offset: 120
-          Type: 54 GoSliceHeaderType []string
+          Type: 53 GoSliceHeaderType []string
         - Name: PostalCode
           Offset: 144
-          Type: 54 GoSliceHeaderType []string
+          Type: 53 GoSliceHeaderType []string
         - Name: SerialNumber
           Offset: 168
           Type: 9 GoStringHeaderType string
@@ -1486,12 +1486,12 @@ Types:
           Type: 9 GoStringHeaderType string
         - Name: Names
           Offset: 200
-          Type: 93 GoSliceHeaderType []crypto/x509/pkix.AttributeTypeAndValue
+          Type: 113 GoSliceHeaderType []crypto/x509/pkix.AttributeTypeAndValue
         - Name: ExtraNames
           Offset: 224
-          Type: 93 GoSliceHeaderType []crypto/x509/pkix.AttributeTypeAndValue
+          Type: 113 GoSliceHeaderType []crypto/x509/pkix.AttributeTypeAndValue
     - __kind: GoSliceHeaderType
-      ID: 96
+      ID: 125
       Name: encoding/asn1.ObjectIdentifier
       ByteSize: 24
       GoRuntimeType: 1.044832e+06
@@ -1506,9 +1506,9 @@ Types:
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 181 GoSliceDataType encoding/asn1.ObjectIdentifier.array
+      Data: 189 GoSliceDataType encoding/asn1.ObjectIdentifier.array
     - __kind: GoSliceDataType
-      ID: 181
+      ID: 189
       Name: encoding/asn1.ObjectIdentifier.array
       ByteSize: 2048
       Element: 7 BaseType int
@@ -1538,19 +1538,19 @@ Types:
       GoRuntimeType: 580608
       GoKind: 14
     - __kind: GoSubroutineType
-      ID: 56
+      ID: 52
       Name: func() (io.ReadCloser, error)
       ByteSize: 8
       GoRuntimeType: 687968
       GoKind: 19
     - __kind: GoSubroutineType
-      ID: 135
+      ID: 88
       Name: func(string, []uint8, int) ([]uint8, error)
       ByteSize: 8
       GoRuntimeType: 995552
       GoKind: 19
     - __kind: GoInterfaceType
-      ID: 160
+      ID: 41
       Name: gopkg.in/DataDog/dd-trace-go.v1/ddtrace.Span
       ByteSize: 16
       GoRuntimeType: 1.469568e+06
@@ -1563,47 +1563,47 @@ Types:
           Offset: 8
           Type: 14 VoidPointerType unsafe.Pointer
     - __kind: GoSwissMapGroupsType
-      ID: 67
+      ID: 104
       Name: groupReference<string,[]*mime/multipart.FileHeader>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 68 PointerType *noalg.map.group[string][]*mime/multipart.FileHeader
+          Type: 105 PointerType *noalg.map.group[string][]*mime/multipart.FileHeader
         - Name: lengthMask
           Offset: 8
           Type: 8 BaseType uint64
-      GroupType: 69 StructureType noalg.map.group[string][]*mime/multipart.FileHeader
-      GroupSliceType: 170 GoSliceDataType []noalg.map.group[string][]*mime/multipart.FileHeader.array
+      GroupType: 106 StructureType noalg.map.group[string][]*mime/multipart.FileHeader
+      GroupSliceType: 174 GoSliceDataType []noalg.map.group[string][]*mime/multipart.FileHeader.array
     - __kind: GoSwissMapGroupsType
-      ID: 49
+      ID: 94
       Name: groupReference<string,[]string>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 50 PointerType *noalg.map.group[string][]string
+          Type: 95 PointerType *noalg.map.group[string][]string
         - Name: lengthMask
           Offset: 8
           Type: 8 BaseType uint64
-      GroupType: 51 StructureType noalg.map.group[string][]string
+      GroupType: 96 StructureType noalg.map.group[string][]string
       GroupSliceType: 166 GoSliceDataType []noalg.map.group[string][]string.array
     - __kind: GoSwissMapGroupsType
-      ID: 152
+      ID: 99
       Name: groupReference<string,string>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 153 PointerType *noalg.map.group[string]string
+          Type: 100 PointerType *noalg.map.group[string]string
         - Name: lengthMask
           Offset: 8
           Type: 8 BaseType uint64
-      GroupType: 154 StructureType noalg.map.group[string]string
-      GroupSliceType: 214 GoSliceDataType []noalg.map.group[string]string.array
+      GroupType: 101 StructureType noalg.map.group[string]string
+      GroupSliceType: 170 GoSliceDataType []noalg.map.group[string]string.array
     - __kind: BaseType
       ID: 7
       Name: int
@@ -1635,7 +1635,7 @@ Types:
       GoRuntimeType: 579712
       GoKind: 3
     - __kind: GoEmptyInterfaceType
-      ID: 86
+      ID: 109
       Name: interface {}
       ByteSize: 16
       GoRuntimeType: 849280
@@ -1648,7 +1648,7 @@ Types:
           Offset: 8
           Type: 14 VoidPointerType unsafe.Pointer
     - __kind: GoInterfaceType
-      ID: 55
+      ID: 51
       Name: io.ReadCloser
       ByteSize: 16
       GoRuntimeType: 1.10128e+06
@@ -1661,7 +1661,7 @@ Types:
           Offset: 8
           Type: 14 VoidPointerType unsafe.Pointer
     - __kind: GoSwissMapHeaderType
-      ID: 63
+      ID: 78
       Name: map<string,[]*mime/multipart.FileHeader>
       ByteSize: 48
       GoKind: 25
@@ -1674,7 +1674,7 @@ Types:
           Type: 1 BaseType uintptr
         - Name: dirPtr
           Offset: 16
-          Type: 64 PointerType **table<string,[]*mime/multipart.FileHeader>
+          Type: 79 PointerType **table<string,[]*mime/multipart.FileHeader>
         - Name: dirLen
           Offset: 24
           Type: 7 BaseType int
@@ -1690,10 +1690,10 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 8 BaseType uint64
-      TablePtrSliceType: 169 GoSliceDataType []*table<string,[]*mime/multipart.FileHeader>.array
-      GroupType: 69 StructureType noalg.map.group[string][]*mime/multipart.FileHeader
+      TablePtrSliceType: 173 GoSliceDataType []*table<string,[]*mime/multipart.FileHeader>.array
+      GroupType: 106 StructureType noalg.map.group[string][]*mime/multipart.FileHeader
     - __kind: GoSwissMapHeaderType
-      ID: 45
+      ID: 48
       Name: map<string,[]string>
       ByteSize: 48
       GoKind: 25
@@ -1706,7 +1706,7 @@ Types:
           Type: 1 BaseType uintptr
         - Name: dirPtr
           Offset: 16
-          Type: 46 PointerType **table<string,[]string>
+          Type: 49 PointerType **table<string,[]string>
         - Name: dirLen
           Offset: 24
           Type: 7 BaseType int
@@ -1723,9 +1723,9 @@ Types:
           Offset: 40
           Type: 8 BaseType uint64
       TablePtrSliceType: 165 GoSliceDataType []*table<string,[]string>.array
-      GroupType: 51 StructureType noalg.map.group[string][]string
+      GroupType: 96 StructureType noalg.map.group[string][]string
     - __kind: GoSwissMapHeaderType
-      ID: 148
+      ID: 67
       Name: map<string,string>
       ByteSize: 48
       GoKind: 25
@@ -1738,7 +1738,7 @@ Types:
           Type: 1 BaseType uintptr
         - Name: dirPtr
           Offset: 16
-          Type: 149 PointerType **table<string,string>
+          Type: 68 PointerType **table<string,string>
         - Name: dirLen
           Offset: 24
           Type: 7 BaseType int
@@ -1754,31 +1754,31 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 8 BaseType uint64
-      TablePtrSliceType: 213 GoSliceDataType []*table<string,string>.array
-      GroupType: 154 StructureType noalg.map.group[string]string
+      TablePtrSliceType: 169 GoSliceDataType []*table<string,string>.array
+      GroupType: 101 StructureType noalg.map.group[string]string
     - __kind: GoMapType
-      ID: 61
+      ID: 76
       Name: map[string][]*mime/multipart.FileHeader
       ByteSize: 8
       GoRuntimeType: 1.123296e+06
       GoKind: 21
-      HeaderType: 63 GoSwissMapHeaderType map<string,[]*mime/multipart.FileHeader>
+      HeaderType: 78 GoSwissMapHeaderType map<string,[]*mime/multipart.FileHeader>
     - __kind: GoMapType
-      ID: 60
+      ID: 75
       Name: map[string][]string
       ByteSize: 8
       GoRuntimeType: 1.118688e+06
       GoKind: 21
-      HeaderType: 45 GoSwissMapHeaderType map<string,[]string>
+      HeaderType: 48 GoSwissMapHeaderType map<string,[]string>
     - __kind: GoMapType
-      ID: 146
+      ID: 65
       Name: map[string]string
       ByteSize: 8
       GoRuntimeType: 1.119712e+06
       GoKind: 21
-      HeaderType: 148 GoSwissMapHeaderType map<string,string>
+      HeaderType: 67 GoSwissMapHeaderType map<string,string>
     - __kind: StructureType
-      ID: 88
+      ID: 111
       Name: math/big.Int
       ByteSize: 32
       GoRuntimeType: 1.483968e+06
@@ -1789,15 +1789,15 @@ Types:
           Type: 4 BaseType bool
         - Name: abs
           Offset: 8
-          Type: 89 GoSliceHeaderType math/big.nat
+          Type: 150 GoSliceHeaderType math/big.nat
     - __kind: BaseType
-      ID: 91
+      ID: 152
       Name: math/big.Word
       ByteSize: 8
       GoRuntimeType: 583552
       GoKind: 7
     - __kind: GoSliceHeaderType
-      ID: 89
+      ID: 150
       Name: math/big.nat
       ByteSize: 24
       GoRuntimeType: 2.346272e+06
@@ -1805,21 +1805,21 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 90 PointerType *math/big.Word
+          Type: 151 PointerType *math/big.Word
         - Name: len
           Offset: 8
           Type: 7 BaseType int
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 177 GoSliceDataType math/big.nat.array
+      Data: 207 GoSliceDataType math/big.nat.array
     - __kind: GoSliceDataType
-      ID: 177
+      ID: 207
       Name: math/big.nat.array
       ByteSize: 2048
-      Element: 91 BaseType math/big.Word
+      Element: 152 BaseType math/big.Word
     - __kind: StructureType
-      ID: 75
+      ID: 160
       Name: mime/multipart.FileHeader
       ByteSize: 88
       GoRuntimeType: 1.962912e+06
@@ -1830,13 +1830,13 @@ Types:
           Type: 9 GoStringHeaderType string
         - Name: Header
           Offset: 16
-          Type: 76 GoMapType net/textproto.MIMEHeader
+          Type: 162 GoMapType net/textproto.MIMEHeader
         - Name: Size
           Offset: 24
           Type: 12 BaseType int64
         - Name: content
           Offset: 32
-          Type: 77 GoSliceHeaderType []uint8
+          Type: 70 GoSliceHeaderType []uint8
         - Name: tmpfile
           Offset: 56
           Type: 9 GoStringHeaderType string
@@ -1847,7 +1847,7 @@ Types:
           Offset: 80
           Type: 4 BaseType bool
     - __kind: StructureType
-      ID: 59
+      ID: 56
       Name: mime/multipart.Form
       ByteSize: 16
       GoRuntimeType: 1.467968e+06
@@ -1855,12 +1855,12 @@ Types:
       RawFields:
         - Name: Value
           Offset: 0
-          Type: 60 GoMapType map[string][]string
+          Type: 75 GoMapType map[string][]string
         - Name: File
           Offset: 8
-          Type: 61 GoMapType map[string][]*mime/multipart.FileHeader
+          Type: 76 GoMapType map[string][]*mime/multipart.FileHeader
     - __kind: GoSliceHeaderType
-      ID: 117
+      ID: 131
       Name: net.IP
       ByteSize: 24
       GoRuntimeType: 2.109952e+06
@@ -1882,7 +1882,7 @@ Types:
       ByteSize: 2048
       Element: 3 BaseType uint8
     - __kind: GoSliceHeaderType
-      ID: 124
+      ID: 161
       Name: net.IPMask
       ByteSize: 24
       GoRuntimeType: 1.011424e+06
@@ -1897,14 +1897,14 @@ Types:
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 201 GoSliceDataType net.IPMask.array
+      Data: 213 GoSliceDataType net.IPMask.array
     - __kind: GoSliceDataType
-      ID: 201
+      ID: 213
       Name: net.IPMask.array
       ByteSize: 2048
       Element: 3 BaseType uint8
     - __kind: StructureType
-      ID: 123
+      ID: 159
       Name: net.IPNet
       ByteSize: 48
       GoRuntimeType: 1.449408e+06
@@ -1912,17 +1912,17 @@ Types:
       RawFields:
         - Name: IP
           Offset: 0
-          Type: 117 GoSliceHeaderType net.IP
+          Type: 131 GoSliceHeaderType net.IP
         - Name: Mask
           Offset: 24
-          Type: 124 GoSliceHeaderType net.IPMask
+          Type: 161 GoSliceHeaderType net.IPMask
     - __kind: GoMapType
-      ID: 43
+      ID: 46
       Name: net/http.Header
       ByteSize: 8
       GoRuntimeType: 2.088128e+06
       GoKind: 21
-      HeaderType: 45 GoSwissMapHeaderType map<string,[]string>
+      HeaderType: 48 GoSwissMapHeaderType map<string,[]string>
     - __kind: StructureType
       ID: 38
       Name: net/http.Request
@@ -1935,7 +1935,7 @@ Types:
           Type: 9 GoStringHeaderType string
         - Name: URL
           Offset: 16
-          Type: 39 PointerType *net/url.URL
+          Type: 44 PointerType *net/url.URL
         - Name: Proto
           Offset: 24
           Type: 9 GoStringHeaderType string
@@ -1947,19 +1947,19 @@ Types:
           Type: 7 BaseType int
         - Name: Header
           Offset: 56
-          Type: 43 GoMapType net/http.Header
+          Type: 46 GoMapType net/http.Header
         - Name: Body
           Offset: 64
-          Type: 55 GoInterfaceType io.ReadCloser
+          Type: 51 GoInterfaceType io.ReadCloser
         - Name: GetBody
           Offset: 80
-          Type: 56 GoSubroutineType func() (io.ReadCloser, error)
+          Type: 52 GoSubroutineType func() (io.ReadCloser, error)
         - Name: ContentLength
           Offset: 88
           Type: 12 BaseType int64
         - Name: TransferEncoding
           Offset: 96
-          Type: 54 GoSliceHeaderType []string
+          Type: 53 GoSliceHeaderType []string
         - Name: Close
           Offset: 120
           Type: 4 BaseType bool
@@ -1968,16 +1968,16 @@ Types:
           Type: 9 GoStringHeaderType string
         - Name: Form
           Offset: 144
-          Type: 57 GoMapType net/url.Values
+          Type: 54 GoMapType net/url.Values
         - Name: PostForm
           Offset: 152
-          Type: 57 GoMapType net/url.Values
+          Type: 54 GoMapType net/url.Values
         - Name: MultipartForm
           Offset: 160
-          Type: 58 PointerType *mime/multipart.Form
+          Type: 55 PointerType *mime/multipart.Form
         - Name: Trailer
           Offset: 168
-          Type: 43 GoMapType net/http.Header
+          Type: 46 GoMapType net/http.Header
         - Name: RemoteAddr
           Offset: 176
           Type: 9 GoStringHeaderType string
@@ -1986,30 +1986,30 @@ Types:
           Type: 9 GoStringHeaderType string
         - Name: TLS
           Offset: 208
-          Type: 78 PointerType *crypto/tls.ConnectionState
+          Type: 57 PointerType *crypto/tls.ConnectionState
         - Name: Cancel
           Offset: 216
-          Type: 137 GoChannelType <-chan struct {}
+          Type: 59 GoChannelType <-chan struct {}
         - Name: Response
           Offset: 224
-          Type: 138 PointerType *net/http.Response
+          Type: 60 PointerType *net/http.Response
         - Name: Pattern
           Offset: 232
           Type: 9 GoStringHeaderType string
         - Name: ctx
           Offset: 248
-          Type: 140 GoInterfaceType context.Context
+          Type: 62 GoInterfaceType context.Context
         - Name: pat
           Offset: 264
-          Type: 141 PointerType *net/http.pattern
+          Type: 63 PointerType *net/http.pattern
         - Name: matches
           Offset: 272
-          Type: 54 GoSliceHeaderType []string
+          Type: 53 GoSliceHeaderType []string
         - Name: otherValues
           Offset: 296
-          Type: 146 GoMapType map[string]string
+          Type: 65 GoMapType map[string]string
     - __kind: StructureType
-      ID: 139
+      ID: 61
       Name: net/http.Response
       ByteSize: 144
       GoRuntimeType: 2.195808e+06
@@ -2032,16 +2032,16 @@ Types:
           Type: 7 BaseType int
         - Name: Header
           Offset: 56
-          Type: 43 GoMapType net/http.Header
+          Type: 46 GoMapType net/http.Header
         - Name: Body
           Offset: 64
-          Type: 55 GoInterfaceType io.ReadCloser
+          Type: 51 GoInterfaceType io.ReadCloser
         - Name: ContentLength
           Offset: 80
           Type: 12 BaseType int64
         - Name: TransferEncoding
           Offset: 88
-          Type: 54 GoSliceHeaderType []string
+          Type: 53 GoSliceHeaderType []string
         - Name: Close
           Offset: 112
           Type: 4 BaseType bool
@@ -2050,13 +2050,13 @@ Types:
           Type: 4 BaseType bool
         - Name: Trailer
           Offset: 120
-          Type: 43 GoMapType net/http.Header
+          Type: 46 GoMapType net/http.Header
         - Name: Request
           Offset: 128
           Type: 37 PointerType *net/http.Request
         - Name: TLS
           Offset: 136
-          Type: 78 PointerType *crypto/tls.ConnectionState
+          Type: 57 PointerType *crypto/tls.ConnectionState
     - __kind: GoInterfaceType
       ID: 36
       Name: net/http.ResponseWriter
@@ -2071,7 +2071,7 @@ Types:
           Offset: 8
           Type: 14 VoidPointerType unsafe.Pointer
     - __kind: StructureType
-      ID: 142
+      ID: 64
       Name: net/http.pattern
       ByteSize: 88
       GoRuntimeType: 1.818656e+06
@@ -2088,12 +2088,12 @@ Types:
           Type: 9 GoStringHeaderType string
         - Name: segments
           Offset: 48
-          Type: 143 GoSliceHeaderType []net/http.segment
+          Type: 90 GoSliceHeaderType []net/http.segment
         - Name: loc
           Offset: 72
           Type: 9 GoStringHeaderType string
     - __kind: StructureType
-      ID: 145
+      ID: 92
       Name: net/http.segment
       ByteSize: 24
       GoRuntimeType: 1.59776e+06
@@ -2109,14 +2109,14 @@ Types:
           Offset: 17
           Type: 4 BaseType bool
     - __kind: GoMapType
-      ID: 76
+      ID: 162
       Name: net/textproto.MIMEHeader
       ByteSize: 8
       GoRuntimeType: 1.808832e+06
       GoKind: 21
-      HeaderType: 45 GoSwissMapHeaderType map<string,[]string>
+      HeaderType: 48 GoSwissMapHeaderType map<string,[]string>
     - __kind: StructureType
-      ID: 40
+      ID: 45
       Name: net/url.URL
       ByteSize: 144
       GoRuntimeType: 2.113024e+06
@@ -2130,7 +2130,7 @@ Types:
           Type: 9 GoStringHeaderType string
         - Name: User
           Offset: 32
-          Type: 41 PointerType *net/url.Userinfo
+          Type: 72 PointerType *net/url.Userinfo
         - Name: Host
           Offset: 40
           Type: 9 GoStringHeaderType string
@@ -2156,7 +2156,7 @@ Types:
           Offset: 128
           Type: 9 GoStringHeaderType string
     - __kind: StructureType
-      ID: 42
+      ID: 73
       Name: net/url.Userinfo
       ByteSize: 40
       GoRuntimeType: 1.61408e+06
@@ -2172,41 +2172,41 @@ Types:
           Offset: 32
           Type: 4 BaseType bool
     - __kind: GoMapType
-      ID: 57
+      ID: 54
       Name: net/url.Values
       ByteSize: 8
       GoRuntimeType: 1.871296e+06
       GoKind: 21
-      HeaderType: 45 GoSwissMapHeaderType map<string,[]string>
+      HeaderType: 48 GoSwissMapHeaderType map<string,[]string>
     - __kind: ArrayType
-      ID: 70
+      ID: 145
       Name: noalg.[8]struct { key string; elem []*mime/multipart.FileHeader }
       ByteSize: 320
       GoRuntimeType: 694016
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 71 StructureType noalg.struct { key string; elem []*mime/multipart.FileHeader }
+      Element: 146 StructureType noalg.struct { key string; elem []*mime/multipart.FileHeader }
     - __kind: ArrayType
-      ID: 52
+      ID: 102
       Name: noalg.[8]struct { key string; elem []string }
       ByteSize: 320
       GoRuntimeType: 684000
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 53 StructureType noalg.struct { key string; elem []string }
+      Element: 103 StructureType noalg.struct { key string; elem []string }
     - __kind: ArrayType
-      ID: 155
+      ID: 143
       Name: noalg.[8]struct { key string; elem string }
       ByteSize: 256
       GoRuntimeType: 688160
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 156 StructureType noalg.struct { key string; elem string }
+      Element: 144 StructureType noalg.struct { key string; elem string }
     - __kind: StructureType
-      ID: 69
+      ID: 106
       Name: noalg.map.group[string][]*mime/multipart.FileHeader
       ByteSize: 328
       GoRuntimeType: 1.290528e+06
@@ -2217,9 +2217,9 @@ Types:
           Type: 8 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 70 ArrayType noalg.[8]struct { key string; elem []*mime/multipart.FileHeader }
+          Type: 145 ArrayType noalg.[8]struct { key string; elem []*mime/multipart.FileHeader }
     - __kind: StructureType
-      ID: 51
+      ID: 96
       Name: noalg.map.group[string][]string
       ByteSize: 328
       GoRuntimeType: 1.281056e+06
@@ -2230,9 +2230,9 @@ Types:
           Type: 8 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 52 ArrayType noalg.[8]struct { key string; elem []string }
+          Type: 102 ArrayType noalg.[8]struct { key string; elem []string }
     - __kind: StructureType
-      ID: 154
+      ID: 101
       Name: noalg.map.group[string]string
       ByteSize: 264
       GoRuntimeType: 1.28336e+06
@@ -2243,9 +2243,9 @@ Types:
           Type: 8 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 155 ArrayType noalg.[8]struct { key string; elem string }
+          Type: 143 ArrayType noalg.[8]struct { key string; elem string }
     - __kind: StructureType
-      ID: 71
+      ID: 146
       Name: noalg.struct { key string; elem []*mime/multipart.FileHeader }
       ByteSize: 40
       GoRuntimeType: 1.2904e+06
@@ -2256,9 +2256,9 @@ Types:
           Type: 9 GoStringHeaderType string
         - Name: elem
           Offset: 16
-          Type: 72 GoSliceHeaderType []*mime/multipart.FileHeader
+          Type: 147 GoSliceHeaderType []*mime/multipart.FileHeader
     - __kind: StructureType
-      ID: 53
+      ID: 103
       Name: noalg.struct { key string; elem []string }
       ByteSize: 40
       GoRuntimeType: 1.280928e+06
@@ -2269,9 +2269,9 @@ Types:
           Type: 9 GoStringHeaderType string
         - Name: elem
           Offset: 16
-          Type: 54 GoSliceHeaderType []string
+          Type: 53 GoSliceHeaderType []string
     - __kind: StructureType
-      ID: 156
+      ID: 144
       Name: noalg.struct { key string; elem string }
       ByteSize: 32
       GoRuntimeType: 1.283232e+06
@@ -2302,7 +2302,7 @@ Types:
       Name: string.str
       ByteSize: 2048
     - __kind: StructureType
-      ID: 66
+      ID: 97
       Name: table<string,[]*mime/multipart.FileHeader>
       ByteSize: 32
       GoKind: 25
@@ -2324,9 +2324,9 @@ Types:
           Type: 7 BaseType int
         - Name: groups
           Offset: 16
-          Type: 67 GoSwissMapGroupsType groupReference<string,[]*mime/multipart.FileHeader>
+          Type: 104 GoSwissMapGroupsType groupReference<string,[]*mime/multipart.FileHeader>
     - __kind: StructureType
-      ID: 48
+      ID: 74
       Name: table<string,[]string>
       ByteSize: 32
       GoKind: 25
@@ -2348,9 +2348,9 @@ Types:
           Type: 7 BaseType int
         - Name: groups
           Offset: 16
-          Type: 49 GoSwissMapGroupsType groupReference<string,[]string>
+          Type: 94 GoSwissMapGroupsType groupReference<string,[]string>
     - __kind: StructureType
-      ID: 151
+      ID: 93
       Name: table<string,string>
       ByteSize: 32
       GoKind: 25
@@ -2372,9 +2372,9 @@ Types:
           Type: 7 BaseType int
         - Name: groups
           Offset: 16
-          Type: 152 GoSwissMapGroupsType groupReference<string,string>
+          Type: 99 GoSwissMapGroupsType groupReference<string,string>
     - __kind: StructureType
-      ID: 99
+      ID: 118
       Name: time.Location
       ByteSize: 104
       GoRuntimeType: 1.958592e+06
@@ -2385,10 +2385,10 @@ Types:
           Type: 9 GoStringHeaderType string
         - Name: zone
           Offset: 16
-          Type: 100 GoSliceHeaderType []time.zone
+          Type: 153 GoSliceHeaderType []time.zone
         - Name: tx
           Offset: 40
-          Type: 103 GoSliceHeaderType []time.zoneTrans
+          Type: 156 GoSliceHeaderType []time.zoneTrans
         - Name: extend
           Offset: 64
           Type: 9 GoStringHeaderType string
@@ -2400,9 +2400,9 @@ Types:
           Type: 12 BaseType int64
         - Name: cacheZone
           Offset: 96
-          Type: 101 PointerType *time.zone
+          Type: 154 PointerType *time.zone
     - __kind: StructureType
-      ID: 97
+      ID: 116
       Name: time.Time
       ByteSize: 24
       GoRuntimeType: 2.349088e+06
@@ -2416,9 +2416,9 @@ Types:
           Type: 12 BaseType int64
         - Name: loc
           Offset: 16
-          Type: 98 PointerType *time.Location
+          Type: 117 PointerType *time.Location
     - __kind: StructureType
-      ID: 102
+      ID: 155
       Name: time.zone
       ByteSize: 32
       GoRuntimeType: 1.602752e+06
@@ -2434,7 +2434,7 @@ Types:
           Offset: 24
           Type: 4 BaseType bool
     - __kind: StructureType
-      ID: 105
+      ID: 158
       Name: time.zoneTrans
       ByteSize: 16
       GoRuntimeType: 1.73712e+06

--- a/pkg/dyninst/irgen/testdata/snapshot/rc_tester_v1.arch=amd64,toolchain=go1.24.3.yaml
+++ b/pkg/dyninst/irgen/testdata/snapshot/rc_tester_v1.arch=amd64,toolchain=go1.24.3.yaml
@@ -121,34 +121,34 @@ Subprograms:
           IsReturn: false
 Types:
     - __kind: PointerType
-      ID: 82
+      ID: 84
       Name: '**crypto/x509.Certificate'
       ByteSize: 8
       GoKind: 22
-      Pointee: 83 PointerType *crypto/x509.Certificate
+      Pointee: 85 PointerType *crypto/x509.Certificate
     - __kind: PointerType
-      ID: 148
+      ID: 122
       Name: '**mime/multipart.FileHeader'
       ByteSize: 8
       GoKind: 22
-      Pointee: 149 PointerType *mime/multipart.FileHeader
+      Pointee: 123 PointerType *mime/multipart.FileHeader
     - __kind: PointerType
-      ID: 135
+      ID: 162
       Name: '**net.IPNet'
       ByteSize: 8
       GoKind: 22
-      Pointee: 136 PointerType *net.IPNet
+      Pointee: 163 PointerType *net.IPNet
     - __kind: PointerType
-      ID: 133
+      ID: 160
       Name: '**net/url.URL'
       ByteSize: 8
       GoKind: 22
       Pointee: 44 PointerType *net/url.URL
     - __kind: PointerType
-      ID: 79
+      ID: 81
       Name: '**table<string,[]*mime/multipart.FileHeader>'
       ByteSize: 8
-      Pointee: 80 PointerType *table<string,[]*mime/multipart.FileHeader>
+      Pointee: 82 PointerType *table<string,[]*mime/multipart.FileHeader>
     - __kind: PointerType
       ID: 49
       Name: '**table<string,[]string>'
@@ -160,86 +160,86 @@ Types:
       ByteSize: 8
       Pointee: 69 PointerType *table<string,string>
     - __kind: PointerType
-      ID: 85
+      ID: 87
       Name: '*[]*crypto/x509.Certificate'
       ByteSize: 8
       GoKind: 22
-      Pointee: 81 GoSliceHeaderType []*crypto/x509.Certificate
+      Pointee: 83 GoSliceHeaderType []*crypto/x509.Certificate
     - __kind: PointerType
-      ID: 176
+      ID: 127
       Name: '*[]*crypto/x509.Certificate.array'
       ByteSize: 8
-      Pointee: 175 GoSliceDataType []*crypto/x509.Certificate.array
+      Pointee: 126 GoSliceDataType []*crypto/x509.Certificate.array
     - __kind: PointerType
-      ID: 206
+      ID: 172
       Name: '*[]*mime/multipart.FileHeader.array'
       ByteSize: 8
-      Pointee: 205 GoSliceDataType []*mime/multipart.FileHeader.array
+      Pointee: 171 GoSliceDataType []*mime/multipart.FileHeader.array
     - __kind: PointerType
-      ID: 200
+      ID: 201
       Name: '*[]*net.IPNet.array'
       ByteSize: 8
-      Pointee: 199 GoSliceDataType []*net.IPNet.array
+      Pointee: 200 GoSliceDataType []*net.IPNet.array
     - __kind: PointerType
-      ID: 198
+      ID: 199
       Name: '*[]*net/url.URL.array'
       ByteSize: 8
-      Pointee: 197 GoSliceDataType []*net/url.URL.array
+      Pointee: 198 GoSliceDataType []*net/url.URL.array
     - __kind: PointerType
-      ID: 178
+      ID: 129
       Name: '*[][]*crypto/x509.Certificate.array'
       ByteSize: 8
-      Pointee: 177 GoSliceDataType [][]*crypto/x509.Certificate.array
+      Pointee: 128 GoSliceDataType [][]*crypto/x509.Certificate.array
     - __kind: PointerType
-      ID: 180
+      ID: 131
       Name: '*[][]uint8.array'
       ByteSize: 8
-      Pointee: 179 GoSliceDataType [][]uint8.array
+      Pointee: 130 GoSliceDataType [][]uint8.array
     - __kind: PointerType
-      ID: 192
+      ID: 193
       Name: '*[]crypto/x509.ExtKeyUsage.array'
       ByteSize: 8
-      Pointee: 191 GoSliceDataType []crypto/x509.ExtKeyUsage.array
+      Pointee: 192 GoSliceDataType []crypto/x509.ExtKeyUsage.array
     - __kind: PointerType
-      ID: 202
+      ID: 203
       Name: '*[]crypto/x509.OID.array'
       ByteSize: 8
-      Pointee: 201 GoSliceDataType []crypto/x509.OID.array
+      Pointee: 202 GoSliceDataType []crypto/x509.OID.array
     - __kind: PointerType
-      ID: 204
+      ID: 205
       Name: '*[]crypto/x509.PolicyMapping.array'
       ByteSize: 8
-      Pointee: 203 GoSliceDataType []crypto/x509.PolicyMapping.array
+      Pointee: 204 GoSliceDataType []crypto/x509.PolicyMapping.array
     - __kind: PointerType
-      ID: 184
+      ID: 185
       Name: '*[]crypto/x509/pkix.AttributeTypeAndValue.array'
       ByteSize: 8
-      Pointee: 183 GoSliceDataType []crypto/x509/pkix.AttributeTypeAndValue.array
+      Pointee: 184 GoSliceDataType []crypto/x509/pkix.AttributeTypeAndValue.array
     - __kind: PointerType
-      ID: 186
+      ID: 187
       Name: '*[]crypto/x509/pkix.Extension.array'
       ByteSize: 8
-      Pointee: 185 GoSliceDataType []crypto/x509/pkix.Extension.array
+      Pointee: 186 GoSliceDataType []crypto/x509/pkix.Extension.array
     - __kind: PointerType
-      ID: 188
+      ID: 189
       Name: '*[]encoding/asn1.ObjectIdentifier.array'
       ByteSize: 8
-      Pointee: 187 GoSliceDataType []encoding/asn1.ObjectIdentifier.array
+      Pointee: 188 GoSliceDataType []encoding/asn1.ObjectIdentifier.array
     - __kind: PointerType
-      ID: 194
+      ID: 195
       Name: '*[]net.IP.array'
       ByteSize: 8
-      Pointee: 193 GoSliceDataType []net.IP.array
+      Pointee: 194 GoSliceDataType []net.IP.array
     - __kind: PointerType
-      ID: 182
+      ID: 133
       Name: '*[]net/http.segment.array'
       ByteSize: 8
-      Pointee: 181 GoSliceDataType []net/http.segment.array
+      Pointee: 132 GoSliceDataType []net/http.segment.array
     - __kind: PointerType
-      ID: 168
+      ID: 104
       Name: '*[]string.array'
       ByteSize: 8
-      Pointee: 167 GoSliceDataType []string.array
+      Pointee: 103 GoSliceDataType []string.array
     - __kind: PointerType
       ID: 210
       Name: '*[]time.zone.array'
@@ -251,17 +251,17 @@ Types:
       ByteSize: 8
       Pointee: 211 GoSliceDataType []time.zoneTrans.array
     - __kind: PointerType
-      ID: 87
+      ID: 89
       Name: '*[]uint8'
       ByteSize: 8
       GoRuntimeType: 478304
       GoKind: 22
       Pointee: 70 GoSliceHeaderType []uint8
     - __kind: PointerType
-      ID: 172
+      ID: 113
       Name: '*[]uint8.array'
       ByteSize: 8
-      Pointee: 171 GoSliceDataType []uint8.array
+      Pointee: 112 GoSliceDataType []uint8.array
     - __kind: PointerType
       ID: 11
       Name: '*bool'
@@ -284,59 +284,59 @@ Types:
       GoKind: 22
       Pointee: 58 StructureType crypto/tls.ConnectionState
     - __kind: PointerType
-      ID: 83
+      ID: 85
       Name: '*crypto/x509.Certificate'
       ByteSize: 8
       GoRuntimeType: 2.031072e+06
       GoKind: 22
-      Pointee: 98 StructureType crypto/x509.Certificate
+      Pointee: 115 StructureType crypto/x509.Certificate
     - __kind: PointerType
-      ID: 127
+      ID: 154
       Name: '*crypto/x509.ExtKeyUsage'
       ByteSize: 8
       GoRuntimeType: 420256
       GoKind: 22
-      Pointee: 128 BaseType crypto/x509.ExtKeyUsage
+      Pointee: 155 BaseType crypto/x509.ExtKeyUsage
     - __kind: PointerType
-      ID: 138
+      ID: 165
       Name: '*crypto/x509.OID'
       ByteSize: 8
       GoRuntimeType: 1.938912e+06
       GoKind: 22
-      Pointee: 139 StructureType crypto/x509.OID
+      Pointee: 166 StructureType crypto/x509.OID
     - __kind: PointerType
-      ID: 141
+      ID: 168
       Name: '*crypto/x509.PolicyMapping'
       ByteSize: 8
       GoRuntimeType: 420320
       GoKind: 22
-      Pointee: 142 StructureType crypto/x509.PolicyMapping
+      Pointee: 169 StructureType crypto/x509.PolicyMapping
     - __kind: PointerType
-      ID: 114
+      ID: 141
       Name: '*crypto/x509/pkix.AttributeTypeAndValue'
       ByteSize: 8
       GoRuntimeType: 434080
       GoKind: 22
-      Pointee: 115 StructureType crypto/x509/pkix.AttributeTypeAndValue
+      Pointee: 142 StructureType crypto/x509/pkix.AttributeTypeAndValue
     - __kind: PointerType
-      ID: 121
+      ID: 148
       Name: '*crypto/x509/pkix.Extension'
       ByteSize: 8
       GoRuntimeType: 434272
       GoKind: 22
-      Pointee: 122 StructureType crypto/x509/pkix.Extension
+      Pointee: 149 StructureType crypto/x509/pkix.Extension
     - __kind: PointerType
-      ID: 124
+      ID: 151
       Name: '*encoding/asn1.ObjectIdentifier'
       ByteSize: 8
       GoRuntimeType: 1.044704e+06
       GoKind: 22
-      Pointee: 125 GoSliceHeaderType encoding/asn1.ObjectIdentifier
+      Pointee: 152 GoSliceHeaderType encoding/asn1.ObjectIdentifier
     - __kind: PointerType
-      ID: 190
+      ID: 191
       Name: '*encoding/asn1.ObjectIdentifier.array'
       ByteSize: 8
-      Pointee: 189 GoSliceDataType encoding/asn1.ObjectIdentifier.array
+      Pointee: 190 GoSliceDataType encoding/asn1.ObjectIdentifier.array
     - __kind: PointerType
       ID: 33
       Name: '*error'
@@ -394,10 +394,10 @@ Types:
       GoKind: 22
       Pointee: 15 BaseType int8
     - __kind: PointerType
-      ID: 77
+      ID: 79
       Name: '*map<string,[]*mime/multipart.FileHeader>'
       ByteSize: 8
-      Pointee: 78 GoSwissMapHeaderType map<string,[]*mime/multipart.FileHeader>
+      Pointee: 80 GoSwissMapHeaderType map<string,[]*mime/multipart.FileHeader>
     - __kind: PointerType
       ID: 47
       Name: '*map<string,[]string>'
@@ -409,31 +409,31 @@ Types:
       ByteSize: 8
       Pointee: 67 GoSwissMapHeaderType map<string,string>
     - __kind: PointerType
-      ID: 110
+      ID: 137
       Name: '*math/big.Int'
       ByteSize: 8
       GoRuntimeType: 2.365472e+06
       GoKind: 22
-      Pointee: 111 StructureType math/big.Int
+      Pointee: 138 StructureType math/big.Int
     - __kind: PointerType
-      ID: 151
+      ID: 174
       Name: '*math/big.Word'
       ByteSize: 8
       GoRuntimeType: 423200
       GoKind: 22
-      Pointee: 152 BaseType math/big.Word
+      Pointee: 175 BaseType math/big.Word
     - __kind: PointerType
       ID: 208
       Name: '*math/big.nat.array'
       ByteSize: 8
       Pointee: 207 GoSliceDataType math/big.nat.array
     - __kind: PointerType
-      ID: 149
+      ID: 123
       Name: '*mime/multipart.FileHeader'
       ByteSize: 8
       GoRuntimeType: 902912
       GoKind: 22
-      Pointee: 160 StructureType mime/multipart.FileHeader
+      Pointee: 170 StructureType mime/multipart.FileHeader
     - __kind: PointerType
       ID: 55
       Name: '*mime/multipart.Form'
@@ -442,29 +442,29 @@ Types:
       GoKind: 22
       Pointee: 56 StructureType mime/multipart.Form
     - __kind: PointerType
-      ID: 130
+      ID: 157
       Name: '*net.IP'
       ByteSize: 8
       GoRuntimeType: 2.13488e+06
       GoKind: 22
-      Pointee: 131 GoSliceHeaderType net.IP
+      Pointee: 158 GoSliceHeaderType net.IP
     - __kind: PointerType
-      ID: 196
+      ID: 197
       Name: '*net.IP.array'
       ByteSize: 8
-      Pointee: 195 GoSliceDataType net.IP.array
+      Pointee: 196 GoSliceDataType net.IP.array
     - __kind: PointerType
       ID: 214
       Name: '*net.IPMask.array'
       ByteSize: 8
       Pointee: 213 GoSliceDataType net.IPMask.array
     - __kind: PointerType
-      ID: 136
+      ID: 163
       Name: '*net.IPNet'
       ByteSize: 8
       GoRuntimeType: 1.174624e+06
       GoKind: 22
-      Pointee: 159 StructureType net.IPNet
+      Pointee: 182 StructureType net.IPNet
     - __kind: PointerType
       ID: 37
       Name: '*net/http.Request'
@@ -487,12 +487,12 @@ Types:
       GoKind: 22
       Pointee: 64 StructureType net/http.pattern
     - __kind: PointerType
-      ID: 91
+      ID: 93
       Name: '*net/http.segment'
       ByteSize: 8
       GoRuntimeType: 388640
       GoKind: 22
-      Pointee: 92 StructureType net/http.segment
+      Pointee: 94 StructureType net/http.segment
     - __kind: PointerType
       ID: 44
       Name: '*net/url.URL'
@@ -501,27 +501,27 @@ Types:
       GoKind: 22
       Pointee: 45 StructureType net/url.URL
     - __kind: PointerType
-      ID: 72
+      ID: 74
       Name: '*net/url.Userinfo'
       ByteSize: 8
       GoRuntimeType: 1.19216e+06
       GoKind: 22
-      Pointee: 73 StructureType net/url.Userinfo
+      Pointee: 75 StructureType net/url.Userinfo
     - __kind: PointerType
-      ID: 105
+      ID: 117
       Name: '*noalg.map.group[string][]*mime/multipart.FileHeader'
       ByteSize: 8
-      Pointee: 106 StructureType noalg.map.group[string][]*mime/multipart.FileHeader
+      Pointee: 118 StructureType noalg.map.group[string][]*mime/multipart.FileHeader
     - __kind: PointerType
-      ID: 95
+      ID: 97
       Name: '*noalg.map.group[string][]string'
       ByteSize: 8
-      Pointee: 96 StructureType noalg.map.group[string][]string
+      Pointee: 98 StructureType noalg.map.group[string][]string
     - __kind: PointerType
-      ID: 100
+      ID: 106
       Name: '*noalg.map.group[string]string'
       ByteSize: 8
-      Pointee: 101 StructureType noalg.map.group[string]string
+      Pointee: 107 StructureType noalg.map.group[string]string
     - __kind: PointerType
       ID: 22
       Name: '*string'
@@ -530,46 +530,46 @@ Types:
       GoKind: 22
       Pointee: 9 GoStringHeaderType string
     - __kind: PointerType
-      ID: 164
+      ID: 73
       Name: '*string.str'
       ByteSize: 8
-      Pointee: 163 GoStringDataType string.str
+      Pointee: 72 GoStringDataType string.str
     - __kind: PointerType
-      ID: 80
+      ID: 82
       Name: '*table<string,[]*mime/multipart.FileHeader>'
       ByteSize: 8
-      Pointee: 97 StructureType table<string,[]*mime/multipart.FileHeader>
+      Pointee: 114 StructureType table<string,[]*mime/multipart.FileHeader>
     - __kind: PointerType
       ID: 50
       Name: '*table<string,[]string>'
       ByteSize: 8
-      Pointee: 74 StructureType table<string,[]string>
+      Pointee: 76 StructureType table<string,[]string>
     - __kind: PointerType
       ID: 69
       Name: '*table<string,string>'
       ByteSize: 8
-      Pointee: 93 StructureType table<string,string>
+      Pointee: 95 StructureType table<string,string>
     - __kind: PointerType
-      ID: 117
+      ID: 144
       Name: '*time.Location'
       ByteSize: 8
       GoRuntimeType: 1.602944e+06
       GoKind: 22
-      Pointee: 118 StructureType time.Location
+      Pointee: 145 StructureType time.Location
     - __kind: PointerType
-      ID: 154
+      ID: 177
       Name: '*time.zone'
       ByteSize: 8
       GoRuntimeType: 391776
       GoKind: 22
-      Pointee: 155 StructureType time.zone
+      Pointee: 178 StructureType time.zone
     - __kind: PointerType
-      ID: 157
+      ID: 180
       Name: '*time.zoneTrans'
       ByteSize: 8
       GoRuntimeType: 391840
       GoKind: 22
-      Pointee: 158 StructureType time.zoneTrans
+      Pointee: 181 StructureType time.zoneTrans
     - __kind: PointerType
       ID: 34
       Name: '*uint'
@@ -657,7 +657,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: GoSliceHeaderType
-      ID: 81
+      ID: 83
       Name: '[]*crypto/x509.Certificate'
       ByteSize: 24
       GoRuntimeType: 498464
@@ -665,21 +665,21 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 82 PointerType **crypto/x509.Certificate
+          Type: 84 PointerType **crypto/x509.Certificate
         - Name: len
           Offset: 8
           Type: 7 BaseType int
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 175 GoSliceDataType []*crypto/x509.Certificate.array
+      Data: 126 GoSliceDataType []*crypto/x509.Certificate.array
     - __kind: GoSliceDataType
-      ID: 175
+      ID: 126
       Name: '[]*crypto/x509.Certificate.array'
       ByteSize: 2048
-      Element: 83 PointerType *crypto/x509.Certificate
+      Element: 85 PointerType *crypto/x509.Certificate
     - __kind: GoSliceHeaderType
-      ID: 147
+      ID: 121
       Name: '[]*mime/multipart.FileHeader'
       ByteSize: 24
       GoRuntimeType: 483904
@@ -687,21 +687,21 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 148 PointerType **mime/multipart.FileHeader
+          Type: 122 PointerType **mime/multipart.FileHeader
         - Name: len
           Offset: 8
           Type: 7 BaseType int
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 205 GoSliceDataType []*mime/multipart.FileHeader.array
+      Data: 171 GoSliceDataType []*mime/multipart.FileHeader.array
     - __kind: GoSliceDataType
-      ID: 205
+      ID: 171
       Name: '[]*mime/multipart.FileHeader.array'
       ByteSize: 2048
-      Element: 149 PointerType *mime/multipart.FileHeader
+      Element: 123 PointerType *mime/multipart.FileHeader
     - __kind: GoSliceHeaderType
-      ID: 134
+      ID: 161
       Name: '[]*net.IPNet'
       ByteSize: 24
       GoRuntimeType: 512000
@@ -709,21 +709,21 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 135 PointerType **net.IPNet
+          Type: 162 PointerType **net.IPNet
         - Name: len
           Offset: 8
           Type: 7 BaseType int
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 199 GoSliceDataType []*net.IPNet.array
+      Data: 200 GoSliceDataType []*net.IPNet.array
     - __kind: GoSliceDataType
-      ID: 199
+      ID: 200
       Name: '[]*net.IPNet.array'
       ByteSize: 2048
-      Element: 136 PointerType *net.IPNet
+      Element: 163 PointerType *net.IPNet
     - __kind: GoSliceHeaderType
-      ID: 132
+      ID: 159
       Name: '[]*net/url.URL'
       ByteSize: 24
       GoRuntimeType: 511936
@@ -731,36 +731,36 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 133 PointerType **net/url.URL
+          Type: 160 PointerType **net/url.URL
         - Name: len
           Offset: 8
           Type: 7 BaseType int
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 197 GoSliceDataType []*net/url.URL.array
+      Data: 198 GoSliceDataType []*net/url.URL.array
     - __kind: GoSliceDataType
-      ID: 197
+      ID: 198
       Name: '[]*net/url.URL.array'
       ByteSize: 2048
       Element: 44 PointerType *net/url.URL
     - __kind: GoSliceDataType
-      ID: 173
+      ID: 124
       Name: '[]*table<string,[]*mime/multipart.FileHeader>.array'
       ByteSize: 8192
-      Element: 80 PointerType *table<string,[]*mime/multipart.FileHeader>
+      Element: 82 PointerType *table<string,[]*mime/multipart.FileHeader>
     - __kind: GoSliceDataType
-      ID: 165
+      ID: 101
       Name: '[]*table<string,[]string>.array'
       ByteSize: 8192
       Element: 50 PointerType *table<string,[]string>
     - __kind: GoSliceDataType
-      ID: 169
+      ID: 110
       Name: '[]*table<string,string>.array'
       ByteSize: 8192
       Element: 69 PointerType *table<string,string>
     - __kind: GoSliceHeaderType
-      ID: 84
+      ID: 86
       Name: '[][]*crypto/x509.Certificate'
       ByteSize: 24
       GoRuntimeType: 498592
@@ -768,21 +768,21 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 85 PointerType *[]*crypto/x509.Certificate
+          Type: 87 PointerType *[]*crypto/x509.Certificate
         - Name: len
           Offset: 8
           Type: 7 BaseType int
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 177 GoSliceDataType [][]*crypto/x509.Certificate.array
+      Data: 128 GoSliceDataType [][]*crypto/x509.Certificate.array
     - __kind: GoSliceDataType
-      ID: 177
+      ID: 128
       Name: '[][]*crypto/x509.Certificate.array'
       ByteSize: 2048
-      Element: 81 GoSliceHeaderType []*crypto/x509.Certificate
+      Element: 83 GoSliceHeaderType []*crypto/x509.Certificate
     - __kind: GoSliceHeaderType
-      ID: 86
+      ID: 88
       Name: '[][]uint8'
       ByteSize: 24
       GoRuntimeType: 478688
@@ -790,21 +790,21 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 87 PointerType *[]uint8
+          Type: 89 PointerType *[]uint8
         - Name: len
           Offset: 8
           Type: 7 BaseType int
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 179 GoSliceDataType [][]uint8.array
+      Data: 130 GoSliceDataType [][]uint8.array
     - __kind: GoSliceDataType
-      ID: 179
+      ID: 130
       Name: '[][]uint8.array'
       ByteSize: 2048
       Element: 70 GoSliceHeaderType []uint8
     - __kind: GoSliceHeaderType
-      ID: 126
+      ID: 153
       Name: '[]crypto/x509.ExtKeyUsage'
       ByteSize: 24
       GoRuntimeType: 499936
@@ -812,21 +812,21 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 127 PointerType *crypto/x509.ExtKeyUsage
+          Type: 154 PointerType *crypto/x509.ExtKeyUsage
         - Name: len
           Offset: 8
           Type: 7 BaseType int
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 191 GoSliceDataType []crypto/x509.ExtKeyUsage.array
+      Data: 192 GoSliceDataType []crypto/x509.ExtKeyUsage.array
     - __kind: GoSliceDataType
-      ID: 191
+      ID: 192
       Name: '[]crypto/x509.ExtKeyUsage.array'
       ByteSize: 2048
-      Element: 128 BaseType crypto/x509.ExtKeyUsage
+      Element: 155 BaseType crypto/x509.ExtKeyUsage
     - __kind: GoSliceHeaderType
-      ID: 137
+      ID: 164
       Name: '[]crypto/x509.OID'
       ByteSize: 24
       GoRuntimeType: 512064
@@ -834,21 +834,21 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 138 PointerType *crypto/x509.OID
+          Type: 165 PointerType *crypto/x509.OID
         - Name: len
           Offset: 8
           Type: 7 BaseType int
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 201 GoSliceDataType []crypto/x509.OID.array
+      Data: 202 GoSliceDataType []crypto/x509.OID.array
     - __kind: GoSliceDataType
-      ID: 201
+      ID: 202
       Name: '[]crypto/x509.OID.array'
       ByteSize: 2048
-      Element: 139 StructureType crypto/x509.OID
+      Element: 166 StructureType crypto/x509.OID
     - __kind: GoSliceHeaderType
-      ID: 140
+      ID: 167
       Name: '[]crypto/x509.PolicyMapping'
       ByteSize: 24
       GoRuntimeType: 512128
@@ -856,21 +856,21 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 141 PointerType *crypto/x509.PolicyMapping
+          Type: 168 PointerType *crypto/x509.PolicyMapping
         - Name: len
           Offset: 8
           Type: 7 BaseType int
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 203 GoSliceDataType []crypto/x509.PolicyMapping.array
+      Data: 204 GoSliceDataType []crypto/x509.PolicyMapping.array
     - __kind: GoSliceDataType
-      ID: 203
+      ID: 204
       Name: '[]crypto/x509.PolicyMapping.array'
       ByteSize: 2048
-      Element: 142 StructureType crypto/x509.PolicyMapping
+      Element: 169 StructureType crypto/x509.PolicyMapping
     - __kind: GoSliceHeaderType
-      ID: 113
+      ID: 140
       Name: '[]crypto/x509/pkix.AttributeTypeAndValue'
       ByteSize: 24
       GoRuntimeType: 512576
@@ -878,21 +878,21 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 114 PointerType *crypto/x509/pkix.AttributeTypeAndValue
+          Type: 141 PointerType *crypto/x509/pkix.AttributeTypeAndValue
         - Name: len
           Offset: 8
           Type: 7 BaseType int
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 183 GoSliceDataType []crypto/x509/pkix.AttributeTypeAndValue.array
+      Data: 184 GoSliceDataType []crypto/x509/pkix.AttributeTypeAndValue.array
     - __kind: GoSliceDataType
-      ID: 183
+      ID: 184
       Name: '[]crypto/x509/pkix.AttributeTypeAndValue.array'
       ByteSize: 2048
-      Element: 115 StructureType crypto/x509/pkix.AttributeTypeAndValue
+      Element: 142 StructureType crypto/x509/pkix.AttributeTypeAndValue
     - __kind: GoSliceHeaderType
-      ID: 120
+      ID: 147
       Name: '[]crypto/x509/pkix.Extension'
       ByteSize: 24
       GoRuntimeType: 511808
@@ -900,21 +900,21 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 121 PointerType *crypto/x509/pkix.Extension
+          Type: 148 PointerType *crypto/x509/pkix.Extension
         - Name: len
           Offset: 8
           Type: 7 BaseType int
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 185 GoSliceDataType []crypto/x509/pkix.Extension.array
+      Data: 186 GoSliceDataType []crypto/x509/pkix.Extension.array
     - __kind: GoSliceDataType
-      ID: 185
+      ID: 186
       Name: '[]crypto/x509/pkix.Extension.array'
       ByteSize: 2048
-      Element: 122 StructureType crypto/x509/pkix.Extension
+      Element: 149 StructureType crypto/x509/pkix.Extension
     - __kind: GoSliceHeaderType
-      ID: 123
+      ID: 150
       Name: '[]encoding/asn1.ObjectIdentifier'
       ByteSize: 24
       GoRuntimeType: 511872
@@ -922,21 +922,21 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 124 PointerType *encoding/asn1.ObjectIdentifier
+          Type: 151 PointerType *encoding/asn1.ObjectIdentifier
         - Name: len
           Offset: 8
           Type: 7 BaseType int
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 187 GoSliceDataType []encoding/asn1.ObjectIdentifier.array
+      Data: 188 GoSliceDataType []encoding/asn1.ObjectIdentifier.array
     - __kind: GoSliceDataType
-      ID: 187
+      ID: 188
       Name: '[]encoding/asn1.ObjectIdentifier.array'
       ByteSize: 2048
-      Element: 125 GoSliceHeaderType encoding/asn1.ObjectIdentifier
+      Element: 152 GoSliceHeaderType encoding/asn1.ObjectIdentifier
     - __kind: GoSliceHeaderType
-      ID: 129
+      ID: 156
       Name: '[]net.IP'
       ByteSize: 24
       GoRuntimeType: 479648
@@ -944,21 +944,21 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 130 PointerType *net.IP
+          Type: 157 PointerType *net.IP
         - Name: len
           Offset: 8
           Type: 7 BaseType int
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 193 GoSliceDataType []net.IP.array
+      Data: 194 GoSliceDataType []net.IP.array
     - __kind: GoSliceDataType
-      ID: 193
+      ID: 194
       Name: '[]net.IP.array'
       ByteSize: 2048
-      Element: 131 GoSliceHeaderType net.IP
+      Element: 158 GoSliceHeaderType net.IP
     - __kind: GoSliceHeaderType
-      ID: 90
+      ID: 92
       Name: '[]net/http.segment'
       ByteSize: 24
       GoRuntimeType: 481280
@@ -966,34 +966,34 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 91 PointerType *net/http.segment
+          Type: 93 PointerType *net/http.segment
         - Name: len
           Offset: 8
           Type: 7 BaseType int
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 181 GoSliceDataType []net/http.segment.array
+      Data: 132 GoSliceDataType []net/http.segment.array
     - __kind: GoSliceDataType
-      ID: 181
+      ID: 132
       Name: '[]net/http.segment.array'
       ByteSize: 2048
-      Element: 92 StructureType net/http.segment
+      Element: 94 StructureType net/http.segment
     - __kind: GoSliceDataType
-      ID: 174
+      ID: 125
       Name: '[]noalg.map.group[string][]*mime/multipart.FileHeader.array'
       ByteSize: 2048
-      Element: 106 StructureType noalg.map.group[string][]*mime/multipart.FileHeader
+      Element: 118 StructureType noalg.map.group[string][]*mime/multipart.FileHeader
     - __kind: GoSliceDataType
-      ID: 166
+      ID: 102
       Name: '[]noalg.map.group[string][]string.array'
       ByteSize: 2048
-      Element: 96 StructureType noalg.map.group[string][]string
+      Element: 98 StructureType noalg.map.group[string][]string
     - __kind: GoSliceDataType
-      ID: 170
+      ID: 111
       Name: '[]noalg.map.group[string]string.array'
       ByteSize: 2048
-      Element: 101 StructureType noalg.map.group[string]string
+      Element: 107 StructureType noalg.map.group[string]string
     - __kind: GoSliceHeaderType
       ID: 53
       Name: '[]string'
@@ -1010,14 +1010,14 @@ Types:
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 167 GoSliceDataType []string.array
+      Data: 103 GoSliceDataType []string.array
     - __kind: GoSliceDataType
-      ID: 167
+      ID: 103
       Name: '[]string.array'
       ByteSize: 2048
       Element: 9 GoStringHeaderType string
     - __kind: GoSliceHeaderType
-      ID: 153
+      ID: 176
       Name: '[]time.zone'
       ByteSize: 24
       GoRuntimeType: 485952
@@ -1025,7 +1025,7 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 154 PointerType *time.zone
+          Type: 177 PointerType *time.zone
         - Name: len
           Offset: 8
           Type: 7 BaseType int
@@ -1037,9 +1037,9 @@ Types:
       ID: 209
       Name: '[]time.zone.array'
       ByteSize: 2048
-      Element: 155 StructureType time.zone
+      Element: 178 StructureType time.zone
     - __kind: GoSliceHeaderType
-      ID: 156
+      ID: 179
       Name: '[]time.zoneTrans'
       ByteSize: 24
       GoRuntimeType: 486016
@@ -1047,7 +1047,7 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 157 PointerType *time.zoneTrans
+          Type: 180 PointerType *time.zoneTrans
         - Name: len
           Offset: 8
           Type: 7 BaseType int
@@ -1059,7 +1059,7 @@ Types:
       ID: 211
       Name: '[]time.zoneTrans.array'
       ByteSize: 2048
-      Element: 158 StructureType time.zoneTrans
+      Element: 181 StructureType time.zoneTrans
     - __kind: GoSliceHeaderType
       ID: 70
       Name: '[]uint8'
@@ -1076,9 +1076,9 @@ Types:
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 171 GoSliceDataType []uint8.array
+      Data: 112 GoSliceDataType []uint8.array
     - __kind: GoSliceDataType
-      ID: 171
+      ID: 112
       Name: '[]uint8.array'
       ByteSize: 2048
       Element: 3 BaseType uint8
@@ -1180,13 +1180,13 @@ Types:
           Type: 9 GoStringHeaderType string
         - Name: PeerCertificates
           Offset: 48
-          Type: 81 GoSliceHeaderType []*crypto/x509.Certificate
+          Type: 83 GoSliceHeaderType []*crypto/x509.Certificate
         - Name: VerifiedChains
           Offset: 72
-          Type: 84 GoSliceHeaderType [][]*crypto/x509.Certificate
+          Type: 86 GoSliceHeaderType [][]*crypto/x509.Certificate
         - Name: SignedCertificateTimestamps
           Offset: 96
-          Type: 86 GoSliceHeaderType [][]uint8
+          Type: 88 GoSliceHeaderType [][]uint8
         - Name: OCSPResponse
           Offset: 120
           Type: 70 GoSliceHeaderType []uint8
@@ -1198,21 +1198,21 @@ Types:
           Type: 4 BaseType bool
         - Name: ekm
           Offset: 176
-          Type: 88 GoSubroutineType func(string, []uint8, int) ([]uint8, error)
+          Type: 90 GoSubroutineType func(string, []uint8, int) ([]uint8, error)
         - Name: testingOnlyDidHRR
           Offset: 184
           Type: 4 BaseType bool
         - Name: testingOnlyCurveID
           Offset: 186
-          Type: 89 BaseType crypto/tls.CurveID
+          Type: 91 BaseType crypto/tls.CurveID
     - __kind: BaseType
-      ID: 89
+      ID: 91
       Name: crypto/tls.CurveID
       ByteSize: 2
       GoRuntimeType: 829664
       GoKind: 9
     - __kind: StructureType
-      ID: 98
+      ID: 115
       Name: crypto/x509.Certificate
       ByteSize: 1424
       GoRuntimeType: 2.377888e+06
@@ -1238,49 +1238,49 @@ Types:
           Type: 70 GoSliceHeaderType []uint8
         - Name: SignatureAlgorithm
           Offset: 144
-          Type: 107 BaseType crypto/x509.SignatureAlgorithm
+          Type: 134 BaseType crypto/x509.SignatureAlgorithm
         - Name: PublicKeyAlgorithm
           Offset: 152
-          Type: 108 BaseType crypto/x509.PublicKeyAlgorithm
+          Type: 135 BaseType crypto/x509.PublicKeyAlgorithm
         - Name: PublicKey
           Offset: 160
-          Type: 109 GoEmptyInterfaceType interface {}
+          Type: 136 GoEmptyInterfaceType interface {}
         - Name: Version
           Offset: 176
           Type: 7 BaseType int
         - Name: SerialNumber
           Offset: 184
-          Type: 110 PointerType *math/big.Int
+          Type: 137 PointerType *math/big.Int
         - Name: Issuer
           Offset: 192
-          Type: 112 StructureType crypto/x509/pkix.Name
+          Type: 139 StructureType crypto/x509/pkix.Name
         - Name: Subject
           Offset: 440
-          Type: 112 StructureType crypto/x509/pkix.Name
+          Type: 139 StructureType crypto/x509/pkix.Name
         - Name: NotBefore
           Offset: 688
-          Type: 116 StructureType time.Time
+          Type: 143 StructureType time.Time
         - Name: NotAfter
           Offset: 712
-          Type: 116 StructureType time.Time
+          Type: 143 StructureType time.Time
         - Name: KeyUsage
           Offset: 736
-          Type: 119 BaseType crypto/x509.KeyUsage
+          Type: 146 BaseType crypto/x509.KeyUsage
         - Name: Extensions
           Offset: 744
-          Type: 120 GoSliceHeaderType []crypto/x509/pkix.Extension
+          Type: 147 GoSliceHeaderType []crypto/x509/pkix.Extension
         - Name: ExtraExtensions
           Offset: 768
-          Type: 120 GoSliceHeaderType []crypto/x509/pkix.Extension
+          Type: 147 GoSliceHeaderType []crypto/x509/pkix.Extension
         - Name: UnhandledCriticalExtensions
           Offset: 792
-          Type: 123 GoSliceHeaderType []encoding/asn1.ObjectIdentifier
+          Type: 150 GoSliceHeaderType []encoding/asn1.ObjectIdentifier
         - Name: ExtKeyUsage
           Offset: 816
-          Type: 126 GoSliceHeaderType []crypto/x509.ExtKeyUsage
+          Type: 153 GoSliceHeaderType []crypto/x509.ExtKeyUsage
         - Name: UnknownExtKeyUsage
           Offset: 840
-          Type: 123 GoSliceHeaderType []encoding/asn1.ObjectIdentifier
+          Type: 150 GoSliceHeaderType []encoding/asn1.ObjectIdentifier
         - Name: BasicConstraintsValid
           Offset: 864
           Type: 4 BaseType bool
@@ -1313,10 +1313,10 @@ Types:
           Type: 53 GoSliceHeaderType []string
         - Name: IPAddresses
           Offset: 1032
-          Type: 129 GoSliceHeaderType []net.IP
+          Type: 156 GoSliceHeaderType []net.IP
         - Name: URIs
           Offset: 1056
-          Type: 132 GoSliceHeaderType []*net/url.URL
+          Type: 159 GoSliceHeaderType []*net/url.URL
         - Name: PermittedDNSDomainsCritical
           Offset: 1080
           Type: 4 BaseType bool
@@ -1328,10 +1328,10 @@ Types:
           Type: 53 GoSliceHeaderType []string
         - Name: PermittedIPRanges
           Offset: 1136
-          Type: 134 GoSliceHeaderType []*net.IPNet
+          Type: 161 GoSliceHeaderType []*net.IPNet
         - Name: ExcludedIPRanges
           Offset: 1160
-          Type: 134 GoSliceHeaderType []*net.IPNet
+          Type: 161 GoSliceHeaderType []*net.IPNet
         - Name: PermittedEmailAddresses
           Offset: 1184
           Type: 53 GoSliceHeaderType []string
@@ -1349,10 +1349,10 @@ Types:
           Type: 53 GoSliceHeaderType []string
         - Name: PolicyIdentifiers
           Offset: 1304
-          Type: 123 GoSliceHeaderType []encoding/asn1.ObjectIdentifier
+          Type: 150 GoSliceHeaderType []encoding/asn1.ObjectIdentifier
         - Name: Policies
           Offset: 1328
-          Type: 137 GoSliceHeaderType []crypto/x509.OID
+          Type: 164 GoSliceHeaderType []crypto/x509.OID
         - Name: InhibitAnyPolicy
           Offset: 1352
           Type: 7 BaseType int
@@ -1373,21 +1373,21 @@ Types:
           Type: 4 BaseType bool
         - Name: PolicyMappings
           Offset: 1400
-          Type: 140 GoSliceHeaderType []crypto/x509.PolicyMapping
+          Type: 167 GoSliceHeaderType []crypto/x509.PolicyMapping
     - __kind: BaseType
-      ID: 128
+      ID: 155
       Name: crypto/x509.ExtKeyUsage
       ByteSize: 8
       GoRuntimeType: 583360
       GoKind: 2
     - __kind: BaseType
-      ID: 119
+      ID: 146
       Name: crypto/x509.KeyUsage
       ByteSize: 8
       GoRuntimeType: 583296
       GoKind: 2
     - __kind: StructureType
-      ID: 139
+      ID: 166
       Name: crypto/x509.OID
       ByteSize: 24
       GoRuntimeType: 1.939168e+06
@@ -1397,7 +1397,7 @@ Types:
           Offset: 0
           Type: 70 GoSliceHeaderType []uint8
     - __kind: StructureType
-      ID: 142
+      ID: 169
       Name: crypto/x509.PolicyMapping
       ByteSize: 48
       GoRuntimeType: 1.480928e+06
@@ -1405,24 +1405,24 @@ Types:
       RawFields:
         - Name: IssuerDomainPolicy
           Offset: 0
-          Type: 139 StructureType crypto/x509.OID
+          Type: 166 StructureType crypto/x509.OID
         - Name: SubjectDomainPolicy
           Offset: 24
-          Type: 139 StructureType crypto/x509.OID
+          Type: 166 StructureType crypto/x509.OID
     - __kind: BaseType
-      ID: 108
+      ID: 135
       Name: crypto/x509.PublicKeyAlgorithm
       ByteSize: 8
       GoRuntimeType: 832064
       GoKind: 2
     - __kind: BaseType
-      ID: 107
+      ID: 134
       Name: crypto/x509.SignatureAlgorithm
       ByteSize: 8
       GoRuntimeType: 1.105248e+06
       GoKind: 2
     - __kind: StructureType
-      ID: 115
+      ID: 142
       Name: crypto/x509/pkix.AttributeTypeAndValue
       ByteSize: 40
       GoRuntimeType: 1.492608e+06
@@ -1430,12 +1430,12 @@ Types:
       RawFields:
         - Name: Type
           Offset: 0
-          Type: 125 GoSliceHeaderType encoding/asn1.ObjectIdentifier
+          Type: 152 GoSliceHeaderType encoding/asn1.ObjectIdentifier
         - Name: Value
           Offset: 24
-          Type: 109 GoEmptyInterfaceType interface {}
+          Type: 136 GoEmptyInterfaceType interface {}
     - __kind: StructureType
-      ID: 122
+      ID: 149
       Name: crypto/x509/pkix.Extension
       ByteSize: 56
       GoRuntimeType: 1.63616e+06
@@ -1443,7 +1443,7 @@ Types:
       RawFields:
         - Name: Id
           Offset: 0
-          Type: 125 GoSliceHeaderType encoding/asn1.ObjectIdentifier
+          Type: 152 GoSliceHeaderType encoding/asn1.ObjectIdentifier
         - Name: Critical
           Offset: 24
           Type: 4 BaseType bool
@@ -1451,7 +1451,7 @@ Types:
           Offset: 32
           Type: 70 GoSliceHeaderType []uint8
     - __kind: StructureType
-      ID: 112
+      ID: 139
       Name: crypto/x509/pkix.Name
       ByteSize: 248
       GoRuntimeType: 2.177504e+06
@@ -1486,12 +1486,12 @@ Types:
           Type: 9 GoStringHeaderType string
         - Name: Names
           Offset: 200
-          Type: 113 GoSliceHeaderType []crypto/x509/pkix.AttributeTypeAndValue
+          Type: 140 GoSliceHeaderType []crypto/x509/pkix.AttributeTypeAndValue
         - Name: ExtraNames
           Offset: 224
-          Type: 113 GoSliceHeaderType []crypto/x509/pkix.AttributeTypeAndValue
+          Type: 140 GoSliceHeaderType []crypto/x509/pkix.AttributeTypeAndValue
     - __kind: GoSliceHeaderType
-      ID: 125
+      ID: 152
       Name: encoding/asn1.ObjectIdentifier
       ByteSize: 24
       GoRuntimeType: 1.044832e+06
@@ -1506,9 +1506,9 @@ Types:
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 189 GoSliceDataType encoding/asn1.ObjectIdentifier.array
+      Data: 190 GoSliceDataType encoding/asn1.ObjectIdentifier.array
     - __kind: GoSliceDataType
-      ID: 189
+      ID: 190
       Name: encoding/asn1.ObjectIdentifier.array
       ByteSize: 2048
       Element: 7 BaseType int
@@ -1544,7 +1544,7 @@ Types:
       GoRuntimeType: 687968
       GoKind: 19
     - __kind: GoSubroutineType
-      ID: 88
+      ID: 90
       Name: func(string, []uint8, int) ([]uint8, error)
       ByteSize: 8
       GoRuntimeType: 995552
@@ -1563,47 +1563,47 @@ Types:
           Offset: 8
           Type: 14 VoidPointerType unsafe.Pointer
     - __kind: GoSwissMapGroupsType
-      ID: 104
+      ID: 116
       Name: groupReference<string,[]*mime/multipart.FileHeader>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 105 PointerType *noalg.map.group[string][]*mime/multipart.FileHeader
+          Type: 117 PointerType *noalg.map.group[string][]*mime/multipart.FileHeader
         - Name: lengthMask
           Offset: 8
           Type: 8 BaseType uint64
-      GroupType: 106 StructureType noalg.map.group[string][]*mime/multipart.FileHeader
-      GroupSliceType: 174 GoSliceDataType []noalg.map.group[string][]*mime/multipart.FileHeader.array
+      GroupType: 118 StructureType noalg.map.group[string][]*mime/multipart.FileHeader
+      GroupSliceType: 125 GoSliceDataType []noalg.map.group[string][]*mime/multipart.FileHeader.array
     - __kind: GoSwissMapGroupsType
-      ID: 94
+      ID: 96
       Name: groupReference<string,[]string>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 95 PointerType *noalg.map.group[string][]string
+          Type: 97 PointerType *noalg.map.group[string][]string
         - Name: lengthMask
           Offset: 8
           Type: 8 BaseType uint64
-      GroupType: 96 StructureType noalg.map.group[string][]string
-      GroupSliceType: 166 GoSliceDataType []noalg.map.group[string][]string.array
+      GroupType: 98 StructureType noalg.map.group[string][]string
+      GroupSliceType: 102 GoSliceDataType []noalg.map.group[string][]string.array
     - __kind: GoSwissMapGroupsType
-      ID: 99
+      ID: 105
       Name: groupReference<string,string>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 100 PointerType *noalg.map.group[string]string
+          Type: 106 PointerType *noalg.map.group[string]string
         - Name: lengthMask
           Offset: 8
           Type: 8 BaseType uint64
-      GroupType: 101 StructureType noalg.map.group[string]string
-      GroupSliceType: 170 GoSliceDataType []noalg.map.group[string]string.array
+      GroupType: 107 StructureType noalg.map.group[string]string
+      GroupSliceType: 111 GoSliceDataType []noalg.map.group[string]string.array
     - __kind: BaseType
       ID: 7
       Name: int
@@ -1635,7 +1635,7 @@ Types:
       GoRuntimeType: 579712
       GoKind: 3
     - __kind: GoEmptyInterfaceType
-      ID: 109
+      ID: 136
       Name: interface {}
       ByteSize: 16
       GoRuntimeType: 849280
@@ -1661,7 +1661,7 @@ Types:
           Offset: 8
           Type: 14 VoidPointerType unsafe.Pointer
     - __kind: GoSwissMapHeaderType
-      ID: 78
+      ID: 80
       Name: map<string,[]*mime/multipart.FileHeader>
       ByteSize: 48
       GoKind: 25
@@ -1674,7 +1674,7 @@ Types:
           Type: 1 BaseType uintptr
         - Name: dirPtr
           Offset: 16
-          Type: 79 PointerType **table<string,[]*mime/multipart.FileHeader>
+          Type: 81 PointerType **table<string,[]*mime/multipart.FileHeader>
         - Name: dirLen
           Offset: 24
           Type: 7 BaseType int
@@ -1690,8 +1690,8 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 8 BaseType uint64
-      TablePtrSliceType: 173 GoSliceDataType []*table<string,[]*mime/multipart.FileHeader>.array
-      GroupType: 106 StructureType noalg.map.group[string][]*mime/multipart.FileHeader
+      TablePtrSliceType: 124 GoSliceDataType []*table<string,[]*mime/multipart.FileHeader>.array
+      GroupType: 118 StructureType noalg.map.group[string][]*mime/multipart.FileHeader
     - __kind: GoSwissMapHeaderType
       ID: 48
       Name: map<string,[]string>
@@ -1722,8 +1722,8 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 8 BaseType uint64
-      TablePtrSliceType: 165 GoSliceDataType []*table<string,[]string>.array
-      GroupType: 96 StructureType noalg.map.group[string][]string
+      TablePtrSliceType: 101 GoSliceDataType []*table<string,[]string>.array
+      GroupType: 98 StructureType noalg.map.group[string][]string
     - __kind: GoSwissMapHeaderType
       ID: 67
       Name: map<string,string>
@@ -1754,17 +1754,17 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 8 BaseType uint64
-      TablePtrSliceType: 169 GoSliceDataType []*table<string,string>.array
-      GroupType: 101 StructureType noalg.map.group[string]string
+      TablePtrSliceType: 110 GoSliceDataType []*table<string,string>.array
+      GroupType: 107 StructureType noalg.map.group[string]string
     - __kind: GoMapType
-      ID: 76
+      ID: 78
       Name: map[string][]*mime/multipart.FileHeader
       ByteSize: 8
       GoRuntimeType: 1.123296e+06
       GoKind: 21
-      HeaderType: 78 GoSwissMapHeaderType map<string,[]*mime/multipart.FileHeader>
+      HeaderType: 80 GoSwissMapHeaderType map<string,[]*mime/multipart.FileHeader>
     - __kind: GoMapType
-      ID: 75
+      ID: 77
       Name: map[string][]string
       ByteSize: 8
       GoRuntimeType: 1.118688e+06
@@ -1778,7 +1778,7 @@ Types:
       GoKind: 21
       HeaderType: 67 GoSwissMapHeaderType map<string,string>
     - __kind: StructureType
-      ID: 111
+      ID: 138
       Name: math/big.Int
       ByteSize: 32
       GoRuntimeType: 1.483968e+06
@@ -1789,15 +1789,15 @@ Types:
           Type: 4 BaseType bool
         - Name: abs
           Offset: 8
-          Type: 150 GoSliceHeaderType math/big.nat
+          Type: 173 GoSliceHeaderType math/big.nat
     - __kind: BaseType
-      ID: 152
+      ID: 175
       Name: math/big.Word
       ByteSize: 8
       GoRuntimeType: 583552
       GoKind: 7
     - __kind: GoSliceHeaderType
-      ID: 150
+      ID: 173
       Name: math/big.nat
       ByteSize: 24
       GoRuntimeType: 2.346272e+06
@@ -1805,7 +1805,7 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 151 PointerType *math/big.Word
+          Type: 174 PointerType *math/big.Word
         - Name: len
           Offset: 8
           Type: 7 BaseType int
@@ -1817,9 +1817,9 @@ Types:
       ID: 207
       Name: math/big.nat.array
       ByteSize: 2048
-      Element: 152 BaseType math/big.Word
+      Element: 175 BaseType math/big.Word
     - __kind: StructureType
-      ID: 160
+      ID: 170
       Name: mime/multipart.FileHeader
       ByteSize: 88
       GoRuntimeType: 1.962912e+06
@@ -1830,7 +1830,7 @@ Types:
           Type: 9 GoStringHeaderType string
         - Name: Header
           Offset: 16
-          Type: 162 GoMapType net/textproto.MIMEHeader
+          Type: 183 GoMapType net/textproto.MIMEHeader
         - Name: Size
           Offset: 24
           Type: 12 BaseType int64
@@ -1855,12 +1855,12 @@ Types:
       RawFields:
         - Name: Value
           Offset: 0
-          Type: 75 GoMapType map[string][]string
+          Type: 77 GoMapType map[string][]string
         - Name: File
           Offset: 8
-          Type: 76 GoMapType map[string][]*mime/multipart.FileHeader
+          Type: 78 GoMapType map[string][]*mime/multipart.FileHeader
     - __kind: GoSliceHeaderType
-      ID: 131
+      ID: 158
       Name: net.IP
       ByteSize: 24
       GoRuntimeType: 2.109952e+06
@@ -1875,14 +1875,14 @@ Types:
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 195 GoSliceDataType net.IP.array
+      Data: 196 GoSliceDataType net.IP.array
     - __kind: GoSliceDataType
-      ID: 195
+      ID: 196
       Name: net.IP.array
       ByteSize: 2048
       Element: 3 BaseType uint8
     - __kind: GoSliceHeaderType
-      ID: 161
+      ID: 206
       Name: net.IPMask
       ByteSize: 24
       GoRuntimeType: 1.011424e+06
@@ -1904,7 +1904,7 @@ Types:
       ByteSize: 2048
       Element: 3 BaseType uint8
     - __kind: StructureType
-      ID: 159
+      ID: 182
       Name: net.IPNet
       ByteSize: 48
       GoRuntimeType: 1.449408e+06
@@ -1912,10 +1912,10 @@ Types:
       RawFields:
         - Name: IP
           Offset: 0
-          Type: 131 GoSliceHeaderType net.IP
+          Type: 158 GoSliceHeaderType net.IP
         - Name: Mask
           Offset: 24
-          Type: 161 GoSliceHeaderType net.IPMask
+          Type: 206 GoSliceHeaderType net.IPMask
     - __kind: GoMapType
       ID: 46
       Name: net/http.Header
@@ -2088,12 +2088,12 @@ Types:
           Type: 9 GoStringHeaderType string
         - Name: segments
           Offset: 48
-          Type: 90 GoSliceHeaderType []net/http.segment
+          Type: 92 GoSliceHeaderType []net/http.segment
         - Name: loc
           Offset: 72
           Type: 9 GoStringHeaderType string
     - __kind: StructureType
-      ID: 92
+      ID: 94
       Name: net/http.segment
       ByteSize: 24
       GoRuntimeType: 1.59776e+06
@@ -2109,7 +2109,7 @@ Types:
           Offset: 17
           Type: 4 BaseType bool
     - __kind: GoMapType
-      ID: 162
+      ID: 183
       Name: net/textproto.MIMEHeader
       ByteSize: 8
       GoRuntimeType: 1.808832e+06
@@ -2130,7 +2130,7 @@ Types:
           Type: 9 GoStringHeaderType string
         - Name: User
           Offset: 32
-          Type: 72 PointerType *net/url.Userinfo
+          Type: 74 PointerType *net/url.Userinfo
         - Name: Host
           Offset: 40
           Type: 9 GoStringHeaderType string
@@ -2156,7 +2156,7 @@ Types:
           Offset: 128
           Type: 9 GoStringHeaderType string
     - __kind: StructureType
-      ID: 73
+      ID: 75
       Name: net/url.Userinfo
       ByteSize: 40
       GoRuntimeType: 1.61408e+06
@@ -2179,34 +2179,34 @@ Types:
       GoKind: 21
       HeaderType: 48 GoSwissMapHeaderType map<string,[]string>
     - __kind: ArrayType
-      ID: 145
+      ID: 119
       Name: noalg.[8]struct { key string; elem []*mime/multipart.FileHeader }
       ByteSize: 320
       GoRuntimeType: 694016
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 146 StructureType noalg.struct { key string; elem []*mime/multipart.FileHeader }
+      Element: 120 StructureType noalg.struct { key string; elem []*mime/multipart.FileHeader }
     - __kind: ArrayType
-      ID: 102
+      ID: 99
       Name: noalg.[8]struct { key string; elem []string }
       ByteSize: 320
       GoRuntimeType: 684000
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 103 StructureType noalg.struct { key string; elem []string }
+      Element: 100 StructureType noalg.struct { key string; elem []string }
     - __kind: ArrayType
-      ID: 143
+      ID: 108
       Name: noalg.[8]struct { key string; elem string }
       ByteSize: 256
       GoRuntimeType: 688160
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 144 StructureType noalg.struct { key string; elem string }
+      Element: 109 StructureType noalg.struct { key string; elem string }
     - __kind: StructureType
-      ID: 106
+      ID: 118
       Name: noalg.map.group[string][]*mime/multipart.FileHeader
       ByteSize: 328
       GoRuntimeType: 1.290528e+06
@@ -2217,9 +2217,9 @@ Types:
           Type: 8 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 145 ArrayType noalg.[8]struct { key string; elem []*mime/multipart.FileHeader }
+          Type: 119 ArrayType noalg.[8]struct { key string; elem []*mime/multipart.FileHeader }
     - __kind: StructureType
-      ID: 96
+      ID: 98
       Name: noalg.map.group[string][]string
       ByteSize: 328
       GoRuntimeType: 1.281056e+06
@@ -2230,9 +2230,9 @@ Types:
           Type: 8 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 102 ArrayType noalg.[8]struct { key string; elem []string }
+          Type: 99 ArrayType noalg.[8]struct { key string; elem []string }
     - __kind: StructureType
-      ID: 101
+      ID: 107
       Name: noalg.map.group[string]string
       ByteSize: 264
       GoRuntimeType: 1.28336e+06
@@ -2243,9 +2243,9 @@ Types:
           Type: 8 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 143 ArrayType noalg.[8]struct { key string; elem string }
+          Type: 108 ArrayType noalg.[8]struct { key string; elem string }
     - __kind: StructureType
-      ID: 146
+      ID: 120
       Name: noalg.struct { key string; elem []*mime/multipart.FileHeader }
       ByteSize: 40
       GoRuntimeType: 1.2904e+06
@@ -2256,9 +2256,9 @@ Types:
           Type: 9 GoStringHeaderType string
         - Name: elem
           Offset: 16
-          Type: 147 GoSliceHeaderType []*mime/multipart.FileHeader
+          Type: 121 GoSliceHeaderType []*mime/multipart.FileHeader
     - __kind: StructureType
-      ID: 103
+      ID: 100
       Name: noalg.struct { key string; elem []string }
       ByteSize: 40
       GoRuntimeType: 1.280928e+06
@@ -2271,7 +2271,7 @@ Types:
           Offset: 16
           Type: 53 GoSliceHeaderType []string
     - __kind: StructureType
-      ID: 144
+      ID: 109
       Name: noalg.struct { key string; elem string }
       ByteSize: 32
       GoRuntimeType: 1.283232e+06
@@ -2292,17 +2292,17 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 164 PointerType *string.str
+          Type: 73 PointerType *string.str
         - Name: len
           Offset: 8
           Type: 7 BaseType int
-      Data: 163 GoStringDataType string.str
+      Data: 72 GoStringDataType string.str
     - __kind: GoStringDataType
-      ID: 163
+      ID: 72
       Name: string.str
       ByteSize: 2048
     - __kind: StructureType
-      ID: 97
+      ID: 114
       Name: table<string,[]*mime/multipart.FileHeader>
       ByteSize: 32
       GoKind: 25
@@ -2324,9 +2324,9 @@ Types:
           Type: 7 BaseType int
         - Name: groups
           Offset: 16
-          Type: 104 GoSwissMapGroupsType groupReference<string,[]*mime/multipart.FileHeader>
+          Type: 116 GoSwissMapGroupsType groupReference<string,[]*mime/multipart.FileHeader>
     - __kind: StructureType
-      ID: 74
+      ID: 76
       Name: table<string,[]string>
       ByteSize: 32
       GoKind: 25
@@ -2348,9 +2348,9 @@ Types:
           Type: 7 BaseType int
         - Name: groups
           Offset: 16
-          Type: 94 GoSwissMapGroupsType groupReference<string,[]string>
+          Type: 96 GoSwissMapGroupsType groupReference<string,[]string>
     - __kind: StructureType
-      ID: 93
+      ID: 95
       Name: table<string,string>
       ByteSize: 32
       GoKind: 25
@@ -2372,9 +2372,9 @@ Types:
           Type: 7 BaseType int
         - Name: groups
           Offset: 16
-          Type: 99 GoSwissMapGroupsType groupReference<string,string>
+          Type: 105 GoSwissMapGroupsType groupReference<string,string>
     - __kind: StructureType
-      ID: 118
+      ID: 145
       Name: time.Location
       ByteSize: 104
       GoRuntimeType: 1.958592e+06
@@ -2385,10 +2385,10 @@ Types:
           Type: 9 GoStringHeaderType string
         - Name: zone
           Offset: 16
-          Type: 153 GoSliceHeaderType []time.zone
+          Type: 176 GoSliceHeaderType []time.zone
         - Name: tx
           Offset: 40
-          Type: 156 GoSliceHeaderType []time.zoneTrans
+          Type: 179 GoSliceHeaderType []time.zoneTrans
         - Name: extend
           Offset: 64
           Type: 9 GoStringHeaderType string
@@ -2400,9 +2400,9 @@ Types:
           Type: 12 BaseType int64
         - Name: cacheZone
           Offset: 96
-          Type: 154 PointerType *time.zone
+          Type: 177 PointerType *time.zone
     - __kind: StructureType
-      ID: 116
+      ID: 143
       Name: time.Time
       ByteSize: 24
       GoRuntimeType: 2.349088e+06
@@ -2416,9 +2416,9 @@ Types:
           Type: 12 BaseType int64
         - Name: loc
           Offset: 16
-          Type: 117 PointerType *time.Location
+          Type: 144 PointerType *time.Location
     - __kind: StructureType
-      ID: 155
+      ID: 178
       Name: time.zone
       ByteSize: 32
       GoRuntimeType: 1.602752e+06
@@ -2434,7 +2434,7 @@ Types:
           Offset: 24
           Type: 4 BaseType bool
     - __kind: StructureType
-      ID: 158
+      ID: 181
       Name: time.zoneTrans
       ByteSize: 16
       GoRuntimeType: 1.73712e+06

--- a/pkg/dyninst/irgen/testdata/snapshot/rc_tester_v1.arch=amd64,toolchain=go1.24.3.yaml
+++ b/pkg/dyninst/irgen/testdata/snapshot/rc_tester_v1.arch=amd64,toolchain=go1.24.3.yaml
@@ -10,7 +10,7 @@ Probes:
       subprogram: {subprogram: 1}
       events:
         - ID: 1
-          Type: 215 EventRootType Probe[main.HandleHTTP]
+          Type: 214 EventRootType Probe[main.HandleHTTP]
           InjectionPoints: [{PC: "0xcfc653", Frameless: false}]
           Condition: null
     - id: look_at_the_request
@@ -23,7 +23,7 @@ Probes:
       subprogram: {subprogram: 2}
       events:
         - ID: 2
-          Type: 216 EventRootType Probe[main.LookAtTheRequest]
+          Type: 215 EventRootType Probe[main.LookAtTheRequest]
           InjectionPoints: [{PC: "0xcfc9ce", Frameless: false}]
           Condition: null
 Subprograms:
@@ -121,147 +121,147 @@ Subprograms:
           IsReturn: false
 Types:
     - __kind: PointerType
-      ID: 84
+      ID: 109
       Name: '**crypto/x509.Certificate'
       ByteSize: 8
       GoKind: 22
-      Pointee: 85 PointerType *crypto/x509.Certificate
+      Pointee: 110 PointerType *crypto/x509.Certificate
     - __kind: PointerType
-      ID: 122
+      ID: 97
       Name: '**mime/multipart.FileHeader'
       ByteSize: 8
       GoKind: 22
-      Pointee: 123 PointerType *mime/multipart.FileHeader
+      Pointee: 98 PointerType *mime/multipart.FileHeader
     - __kind: PointerType
-      ID: 162
+      ID: 152
       Name: '**net.IPNet'
       ByteSize: 8
       GoKind: 22
-      Pointee: 163 PointerType *net.IPNet
+      Pointee: 153 PointerType *net.IPNet
     - __kind: PointerType
-      ID: 160
+      ID: 150
       Name: '**net/url.URL'
       ByteSize: 8
       GoKind: 22
-      Pointee: 44 PointerType *net/url.URL
+      Pointee: 46 PointerType *net/url.URL
     - __kind: PointerType
-      ID: 81
+      ID: 88
       Name: '**table<string,[]*mime/multipart.FileHeader>'
       ByteSize: 8
-      Pointee: 82 PointerType *table<string,[]*mime/multipart.FileHeader>
+      Pointee: 89 PointerType *table<string,[]*mime/multipart.FileHeader>
     - __kind: PointerType
-      ID: 49
+      ID: 51
       Name: '**table<string,[]string>'
       ByteSize: 8
-      Pointee: 50 PointerType *table<string,[]string>
+      Pointee: 52 PointerType *table<string,[]string>
     - __kind: PointerType
-      ID: 68
+      ID: 70
       Name: '**table<string,string>'
       ByteSize: 8
-      Pointee: 69 PointerType *table<string,string>
+      Pointee: 71 PointerType *table<string,string>
     - __kind: PointerType
-      ID: 87
+      ID: 112
       Name: '*[]*crypto/x509.Certificate'
       ByteSize: 8
       GoKind: 22
-      Pointee: 83 GoSliceHeaderType []*crypto/x509.Certificate
+      Pointee: 108 GoSliceHeaderType []*crypto/x509.Certificate
     - __kind: PointerType
-      ID: 127
+      ID: 119
       Name: '*[]*crypto/x509.Certificate.array'
       ByteSize: 8
-      Pointee: 126 GoSliceDataType []*crypto/x509.Certificate.array
+      Pointee: 118 GoSliceDataType []*crypto/x509.Certificate.array
     - __kind: PointerType
-      ID: 172
+      ID: 103
       Name: '*[]*mime/multipart.FileHeader.array'
       ByteSize: 8
-      Pointee: 171 GoSliceDataType []*mime/multipart.FileHeader.array
-    - __kind: PointerType
-      ID: 201
-      Name: '*[]*net.IPNet.array'
-      ByteSize: 8
-      Pointee: 200 GoSliceDataType []*net.IPNet.array
-    - __kind: PointerType
-      ID: 199
-      Name: '*[]*net/url.URL.array'
-      ByteSize: 8
-      Pointee: 198 GoSliceDataType []*net/url.URL.array
-    - __kind: PointerType
-      ID: 129
-      Name: '*[][]*crypto/x509.Certificate.array'
-      ByteSize: 8
-      Pointee: 128 GoSliceDataType [][]*crypto/x509.Certificate.array
-    - __kind: PointerType
-      ID: 131
-      Name: '*[][]uint8.array'
-      ByteSize: 8
-      Pointee: 130 GoSliceDataType [][]uint8.array
-    - __kind: PointerType
-      ID: 193
-      Name: '*[]crypto/x509.ExtKeyUsage.array'
-      ByteSize: 8
-      Pointee: 192 GoSliceDataType []crypto/x509.ExtKeyUsage.array
-    - __kind: PointerType
-      ID: 203
-      Name: '*[]crypto/x509.OID.array'
-      ByteSize: 8
-      Pointee: 202 GoSliceDataType []crypto/x509.OID.array
-    - __kind: PointerType
-      ID: 205
-      Name: '*[]crypto/x509.PolicyMapping.array'
-      ByteSize: 8
-      Pointee: 204 GoSliceDataType []crypto/x509.PolicyMapping.array
-    - __kind: PointerType
-      ID: 185
-      Name: '*[]crypto/x509/pkix.AttributeTypeAndValue.array'
-      ByteSize: 8
-      Pointee: 184 GoSliceDataType []crypto/x509/pkix.AttributeTypeAndValue.array
-    - __kind: PointerType
-      ID: 187
-      Name: '*[]crypto/x509/pkix.Extension.array'
-      ByteSize: 8
-      Pointee: 186 GoSliceDataType []crypto/x509/pkix.Extension.array
+      Pointee: 102 GoSliceDataType []*mime/multipart.FileHeader.array
     - __kind: PointerType
       ID: 189
+      Name: '*[]*net.IPNet.array'
+      ByteSize: 8
+      Pointee: 188 GoSliceDataType []*net.IPNet.array
+    - __kind: PointerType
+      ID: 186
+      Name: '*[]*net/url.URL.array'
+      ByteSize: 8
+      Pointee: 185 GoSliceDataType []*net/url.URL.array
+    - __kind: PointerType
+      ID: 121
+      Name: '*[][]*crypto/x509.Certificate.array'
+      ByteSize: 8
+      Pointee: 120 GoSliceDataType [][]*crypto/x509.Certificate.array
+    - __kind: PointerType
+      ID: 123
+      Name: '*[][]uint8.array'
+      ByteSize: 8
+      Pointee: 122 GoSliceDataType [][]uint8.array
+    - __kind: PointerType
+      ID: 182
+      Name: '*[]crypto/x509.ExtKeyUsage.array'
+      ByteSize: 8
+      Pointee: 181 GoSliceDataType []crypto/x509.ExtKeyUsage.array
+    - __kind: PointerType
+      ID: 191
+      Name: '*[]crypto/x509.OID.array'
+      ByteSize: 8
+      Pointee: 190 GoSliceDataType []crypto/x509.OID.array
+    - __kind: PointerType
+      ID: 193
+      Name: '*[]crypto/x509.PolicyMapping.array'
+      ByteSize: 8
+      Pointee: 192 GoSliceDataType []crypto/x509.PolicyMapping.array
+    - __kind: PointerType
+      ID: 166
+      Name: '*[]crypto/x509/pkix.AttributeTypeAndValue.array'
+      ByteSize: 8
+      Pointee: 165 GoSliceDataType []crypto/x509/pkix.AttributeTypeAndValue.array
+    - __kind: PointerType
+      ID: 178
+      Name: '*[]crypto/x509/pkix.Extension.array'
+      ByteSize: 8
+      Pointee: 177 GoSliceDataType []crypto/x509/pkix.Extension.array
+    - __kind: PointerType
+      ID: 180
       Name: '*[]encoding/asn1.ObjectIdentifier.array'
       ByteSize: 8
-      Pointee: 188 GoSliceDataType []encoding/asn1.ObjectIdentifier.array
+      Pointee: 179 GoSliceDataType []encoding/asn1.ObjectIdentifier.array
     - __kind: PointerType
-      ID: 195
+      ID: 184
       Name: '*[]net.IP.array'
       ByteSize: 8
-      Pointee: 194 GoSliceDataType []net.IP.array
+      Pointee: 183 GoSliceDataType []net.IP.array
     - __kind: PointerType
-      ID: 133
+      ID: 205
       Name: '*[]net/http.segment.array'
       ByteSize: 8
-      Pointee: 132 GoSliceDataType []net/http.segment.array
+      Pointee: 204 GoSliceDataType []net/http.segment.array
     - __kind: PointerType
-      ID: 104
+      ID: 83
       Name: '*[]string.array'
       ByteSize: 8
-      Pointee: 103 GoSliceDataType []string.array
+      Pointee: 82 GoSliceDataType []string.array
     - __kind: PointerType
-      ID: 210
+      ID: 174
       Name: '*[]time.zone.array'
       ByteSize: 8
-      Pointee: 209 GoSliceDataType []time.zone.array
+      Pointee: 173 GoSliceDataType []time.zone.array
     - __kind: PointerType
-      ID: 212
+      ID: 176
       Name: '*[]time.zoneTrans.array'
       ByteSize: 8
-      Pointee: 211 GoSliceDataType []time.zoneTrans.array
+      Pointee: 175 GoSliceDataType []time.zoneTrans.array
     - __kind: PointerType
-      ID: 89
+      ID: 114
       Name: '*[]uint8'
       ByteSize: 8
       GoRuntimeType: 478304
       GoKind: 22
-      Pointee: 70 GoSliceHeaderType []uint8
+      Pointee: 105 GoSliceHeaderType []uint8
     - __kind: PointerType
-      ID: 113
+      ID: 107
       Name: '*[]uint8.array'
       ByteSize: 8
-      Pointee: 112 GoSliceDataType []uint8.array
+      Pointee: 106 GoSliceDataType []uint8.array
     - __kind: PointerType
       ID: 11
       Name: '*bool'
@@ -275,68 +275,68 @@ Types:
       ByteSize: 8
       GoRuntimeType: 2.245824e+06
       GoKind: 22
-      Pointee: 40 StructureType bytes.Buffer
+      Pointee: 40 UnresolvedPointeeType bytes.Buffer
     - __kind: PointerType
-      ID: 57
+      ID: 59
       Name: '*crypto/tls.ConnectionState'
       ByteSize: 8
       GoRuntimeType: 901472
       GoKind: 22
-      Pointee: 58 StructureType crypto/tls.ConnectionState
+      Pointee: 60 StructureType crypto/tls.ConnectionState
     - __kind: PointerType
-      ID: 85
+      ID: 110
       Name: '*crypto/x509.Certificate'
       ByteSize: 8
       GoRuntimeType: 2.031072e+06
       GoKind: 22
-      Pointee: 115 StructureType crypto/x509.Certificate
+      Pointee: 117 StructureType crypto/x509.Certificate
     - __kind: PointerType
-      ID: 154
+      ID: 144
       Name: '*crypto/x509.ExtKeyUsage'
       ByteSize: 8
       GoRuntimeType: 420256
       GoKind: 22
-      Pointee: 155 BaseType crypto/x509.ExtKeyUsage
+      Pointee: 145 BaseType crypto/x509.ExtKeyUsage
     - __kind: PointerType
-      ID: 165
+      ID: 155
       Name: '*crypto/x509.OID'
       ByteSize: 8
       GoRuntimeType: 1.938912e+06
       GoKind: 22
-      Pointee: 166 StructureType crypto/x509.OID
+      Pointee: 156 StructureType crypto/x509.OID
     - __kind: PointerType
-      ID: 168
+      ID: 158
       Name: '*crypto/x509.PolicyMapping'
       ByteSize: 8
       GoRuntimeType: 420320
       GoKind: 22
-      Pointee: 169 StructureType crypto/x509.PolicyMapping
+      Pointee: 159 StructureType crypto/x509.PolicyMapping
     - __kind: PointerType
-      ID: 141
+      ID: 131
       Name: '*crypto/x509/pkix.AttributeTypeAndValue'
       ByteSize: 8
       GoRuntimeType: 434080
       GoKind: 22
-      Pointee: 142 StructureType crypto/x509/pkix.AttributeTypeAndValue
+      Pointee: 132 StructureType crypto/x509/pkix.AttributeTypeAndValue
     - __kind: PointerType
-      ID: 148
+      ID: 138
       Name: '*crypto/x509/pkix.Extension'
       ByteSize: 8
       GoRuntimeType: 434272
       GoKind: 22
-      Pointee: 149 StructureType crypto/x509/pkix.Extension
+      Pointee: 139 StructureType crypto/x509/pkix.Extension
     - __kind: PointerType
-      ID: 151
+      ID: 141
       Name: '*encoding/asn1.ObjectIdentifier'
       ByteSize: 8
       GoRuntimeType: 1.044704e+06
       GoKind: 22
-      Pointee: 152 GoSliceHeaderType encoding/asn1.ObjectIdentifier
+      Pointee: 142 GoSliceHeaderType encoding/asn1.ObjectIdentifier
     - __kind: PointerType
-      ID: 191
+      ID: 195
       Name: '*encoding/asn1.ObjectIdentifier.array'
       ByteSize: 8
-      Pointee: 190 GoSliceDataType encoding/asn1.ObjectIdentifier.array
+      Pointee: 194 GoSliceDataType encoding/asn1.ObjectIdentifier.array
     - __kind: PointerType
       ID: 33
       Name: '*error'
@@ -394,77 +394,77 @@ Types:
       GoKind: 22
       Pointee: 15 BaseType int8
     - __kind: PointerType
-      ID: 79
+      ID: 86
       Name: '*map<string,[]*mime/multipart.FileHeader>'
       ByteSize: 8
-      Pointee: 80 GoSwissMapHeaderType map<string,[]*mime/multipart.FileHeader>
+      Pointee: 87 GoSwissMapHeaderType map<string,[]*mime/multipart.FileHeader>
     - __kind: PointerType
-      ID: 47
+      ID: 49
       Name: '*map<string,[]string>'
       ByteSize: 8
-      Pointee: 48 GoSwissMapHeaderType map<string,[]string>
+      Pointee: 50 GoSwissMapHeaderType map<string,[]string>
     - __kind: PointerType
-      ID: 66
+      ID: 68
       Name: '*map<string,string>'
       ByteSize: 8
-      Pointee: 67 GoSwissMapHeaderType map<string,string>
+      Pointee: 69 GoSwissMapHeaderType map<string,string>
     - __kind: PointerType
-      ID: 137
+      ID: 127
       Name: '*math/big.Int'
       ByteSize: 8
       GoRuntimeType: 2.365472e+06
       GoKind: 22
-      Pointee: 138 StructureType math/big.Int
+      Pointee: 128 StructureType math/big.Int
     - __kind: PointerType
-      ID: 174
+      ID: 161
       Name: '*math/big.Word'
       ByteSize: 8
       GoRuntimeType: 423200
       GoKind: 22
-      Pointee: 175 BaseType math/big.Word
+      Pointee: 162 BaseType math/big.Word
     - __kind: PointerType
-      ID: 208
+      ID: 164
       Name: '*math/big.nat.array'
       ByteSize: 8
-      Pointee: 207 GoSliceDataType math/big.nat.array
+      Pointee: 163 GoSliceDataType math/big.nat.array
     - __kind: PointerType
-      ID: 123
+      ID: 98
       Name: '*mime/multipart.FileHeader'
       ByteSize: 8
       GoRuntimeType: 902912
       GoKind: 22
-      Pointee: 170 StructureType mime/multipart.FileHeader
+      Pointee: 101 StructureType mime/multipart.FileHeader
     - __kind: PointerType
-      ID: 55
+      ID: 57
       Name: '*mime/multipart.Form'
       ByteSize: 8
       GoRuntimeType: 903008
       GoKind: 22
-      Pointee: 56 StructureType mime/multipart.Form
+      Pointee: 58 StructureType mime/multipart.Form
     - __kind: PointerType
-      ID: 157
+      ID: 147
       Name: '*net.IP'
       ByteSize: 8
       GoRuntimeType: 2.13488e+06
       GoKind: 22
-      Pointee: 158 GoSliceHeaderType net.IP
+      Pointee: 148 GoSliceHeaderType net.IP
     - __kind: PointerType
       ID: 197
       Name: '*net.IP.array'
       ByteSize: 8
       Pointee: 196 GoSliceDataType net.IP.array
     - __kind: PointerType
-      ID: 214
+      ID: 200
       Name: '*net.IPMask.array'
       ByteSize: 8
-      Pointee: 213 GoSliceDataType net.IPMask.array
+      Pointee: 199 GoSliceDataType net.IPMask.array
     - __kind: PointerType
-      ID: 163
+      ID: 153
       Name: '*net.IPNet'
       ByteSize: 8
       GoRuntimeType: 1.174624e+06
       GoKind: 22
-      Pointee: 182 StructureType net.IPNet
+      Pointee: 187 StructureType net.IPNet
     - __kind: PointerType
       ID: 37
       Name: '*net/http.Request'
@@ -473,55 +473,55 @@ Types:
       GoKind: 22
       Pointee: 38 StructureType net/http.Request
     - __kind: PointerType
-      ID: 60
+      ID: 62
       Name: '*net/http.Response'
       ByteSize: 8
       GoRuntimeType: 1.706048e+06
       GoKind: 22
-      Pointee: 61 StructureType net/http.Response
+      Pointee: 63 StructureType net/http.Response
     - __kind: PointerType
-      ID: 63
+      ID: 65
       Name: '*net/http.pattern'
       ByteSize: 8
       GoRuntimeType: 1.597952e+06
       GoKind: 22
-      Pointee: 64 StructureType net/http.pattern
+      Pointee: 66 StructureType net/http.pattern
     - __kind: PointerType
-      ID: 93
+      ID: 202
       Name: '*net/http.segment'
       ByteSize: 8
       GoRuntimeType: 388640
       GoKind: 22
-      Pointee: 94 StructureType net/http.segment
+      Pointee: 203 StructureType net/http.segment
     - __kind: PointerType
-      ID: 44
+      ID: 46
       Name: '*net/url.URL'
       ByteSize: 8
       GoRuntimeType: 2.100096e+06
       GoKind: 22
-      Pointee: 45 StructureType net/url.URL
+      Pointee: 47 StructureType net/url.URL
     - __kind: PointerType
-      ID: 74
+      ID: 72
       Name: '*net/url.Userinfo'
       ByteSize: 8
       GoRuntimeType: 1.19216e+06
       GoKind: 22
-      Pointee: 75 StructureType net/url.Userinfo
+      Pointee: 73 StructureType net/url.Userinfo
     - __kind: PointerType
-      ID: 117
+      ID: 92
       Name: '*noalg.map.group[string][]*mime/multipart.FileHeader'
       ByteSize: 8
-      Pointee: 118 StructureType noalg.map.group[string][]*mime/multipart.FileHeader
+      Pointee: 93 StructureType noalg.map.group[string][]*mime/multipart.FileHeader
     - __kind: PointerType
-      ID: 97
+      ID: 76
       Name: '*noalg.map.group[string][]string'
       ByteSize: 8
-      Pointee: 98 StructureType noalg.map.group[string][]string
+      Pointee: 77 StructureType noalg.map.group[string][]string
     - __kind: PointerType
-      ID: 106
+      ID: 208
       Name: '*noalg.map.group[string]string'
       ByteSize: 8
-      Pointee: 107 StructureType noalg.map.group[string]string
+      Pointee: 209 StructureType noalg.map.group[string]string
     - __kind: PointerType
       ID: 22
       Name: '*string'
@@ -530,46 +530,46 @@ Types:
       GoKind: 22
       Pointee: 9 GoStringHeaderType string
     - __kind: PointerType
-      ID: 73
+      ID: 45
       Name: '*string.str'
       ByteSize: 8
-      Pointee: 72 GoStringDataType string.str
+      Pointee: 44 GoStringDataType string.str
     - __kind: PointerType
-      ID: 82
+      ID: 89
       Name: '*table<string,[]*mime/multipart.FileHeader>'
       ByteSize: 8
-      Pointee: 114 StructureType table<string,[]*mime/multipart.FileHeader>
+      Pointee: 90 StructureType table<string,[]*mime/multipart.FileHeader>
     - __kind: PointerType
-      ID: 50
+      ID: 52
       Name: '*table<string,[]string>'
       ByteSize: 8
-      Pointee: 76 StructureType table<string,[]string>
+      Pointee: 74 StructureType table<string,[]string>
     - __kind: PointerType
-      ID: 69
+      ID: 71
       Name: '*table<string,string>'
       ByteSize: 8
-      Pointee: 95 StructureType table<string,string>
+      Pointee: 206 StructureType table<string,string>
     - __kind: PointerType
-      ID: 144
+      ID: 134
       Name: '*time.Location'
       ByteSize: 8
       GoRuntimeType: 1.602944e+06
       GoKind: 22
-      Pointee: 145 StructureType time.Location
+      Pointee: 135 StructureType time.Location
     - __kind: PointerType
-      ID: 177
+      ID: 168
       Name: '*time.zone'
       ByteSize: 8
       GoRuntimeType: 391776
       GoKind: 22
-      Pointee: 178 StructureType time.zone
+      Pointee: 169 StructureType time.zone
     - __kind: PointerType
-      ID: 180
+      ID: 171
       Name: '*time.zoneTrans'
       ByteSize: 8
       GoRuntimeType: 391840
       GoKind: 22
-      Pointee: 181 StructureType time.zoneTrans
+      Pointee: 172 StructureType time.zoneTrans
     - __kind: PointerType
       ID: 34
       Name: '*uint'
@@ -613,12 +613,12 @@ Types:
       GoKind: 22
       Pointee: 1 BaseType uintptr
     - __kind: GoChannelType
-      ID: 59
+      ID: 61
       Name: <-chan struct {}
       GoRuntimeType: 592896
       GoKind: 18
     - __kind: EventRootType
-      ID: 215
+      ID: 214
       Name: Probe[main.HandleHTTP]
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -642,7 +642,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 216
+      ID: 215
       Name: Probe[main.LookAtTheRequest]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -657,7 +657,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: GoSliceHeaderType
-      ID: 83
+      ID: 108
       Name: '[]*crypto/x509.Certificate'
       ByteSize: 24
       GoRuntimeType: 498464
@@ -665,21 +665,21 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 84 PointerType **crypto/x509.Certificate
+          Type: 109 PointerType **crypto/x509.Certificate
         - Name: len
           Offset: 8
           Type: 7 BaseType int
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 126 GoSliceDataType []*crypto/x509.Certificate.array
+      Data: 118 GoSliceDataType []*crypto/x509.Certificate.array
     - __kind: GoSliceDataType
-      ID: 126
+      ID: 118
       Name: '[]*crypto/x509.Certificate.array'
       ByteSize: 2048
-      Element: 85 PointerType *crypto/x509.Certificate
+      Element: 110 PointerType *crypto/x509.Certificate
     - __kind: GoSliceHeaderType
-      ID: 121
+      ID: 96
       Name: '[]*mime/multipart.FileHeader'
       ByteSize: 24
       GoRuntimeType: 483904
@@ -687,21 +687,21 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 122 PointerType **mime/multipart.FileHeader
+          Type: 97 PointerType **mime/multipart.FileHeader
         - Name: len
           Offset: 8
           Type: 7 BaseType int
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 171 GoSliceDataType []*mime/multipart.FileHeader.array
+      Data: 102 GoSliceDataType []*mime/multipart.FileHeader.array
     - __kind: GoSliceDataType
-      ID: 171
+      ID: 102
       Name: '[]*mime/multipart.FileHeader.array'
       ByteSize: 2048
-      Element: 123 PointerType *mime/multipart.FileHeader
+      Element: 98 PointerType *mime/multipart.FileHeader
     - __kind: GoSliceHeaderType
-      ID: 161
+      ID: 151
       Name: '[]*net.IPNet'
       ByteSize: 24
       GoRuntimeType: 512000
@@ -709,21 +709,21 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 162 PointerType **net.IPNet
+          Type: 152 PointerType **net.IPNet
         - Name: len
           Offset: 8
           Type: 7 BaseType int
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 200 GoSliceDataType []*net.IPNet.array
+      Data: 188 GoSliceDataType []*net.IPNet.array
     - __kind: GoSliceDataType
-      ID: 200
+      ID: 188
       Name: '[]*net.IPNet.array'
       ByteSize: 2048
-      Element: 163 PointerType *net.IPNet
+      Element: 153 PointerType *net.IPNet
     - __kind: GoSliceHeaderType
-      ID: 159
+      ID: 149
       Name: '[]*net/url.URL'
       ByteSize: 24
       GoRuntimeType: 511936
@@ -731,36 +731,36 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 160 PointerType **net/url.URL
+          Type: 150 PointerType **net/url.URL
         - Name: len
           Offset: 8
           Type: 7 BaseType int
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 198 GoSliceDataType []*net/url.URL.array
+      Data: 185 GoSliceDataType []*net/url.URL.array
     - __kind: GoSliceDataType
-      ID: 198
+      ID: 185
       Name: '[]*net/url.URL.array'
       ByteSize: 2048
-      Element: 44 PointerType *net/url.URL
+      Element: 46 PointerType *net/url.URL
     - __kind: GoSliceDataType
-      ID: 124
+      ID: 99
       Name: '[]*table<string,[]*mime/multipart.FileHeader>.array'
       ByteSize: 8192
-      Element: 82 PointerType *table<string,[]*mime/multipart.FileHeader>
+      Element: 89 PointerType *table<string,[]*mime/multipart.FileHeader>
     - __kind: GoSliceDataType
-      ID: 101
+      ID: 80
       Name: '[]*table<string,[]string>.array'
       ByteSize: 8192
-      Element: 50 PointerType *table<string,[]string>
+      Element: 52 PointerType *table<string,[]string>
     - __kind: GoSliceDataType
-      ID: 110
+      ID: 212
       Name: '[]*table<string,string>.array'
       ByteSize: 8192
-      Element: 69 PointerType *table<string,string>
+      Element: 71 PointerType *table<string,string>
     - __kind: GoSliceHeaderType
-      ID: 86
+      ID: 111
       Name: '[][]*crypto/x509.Certificate'
       ByteSize: 24
       GoRuntimeType: 498592
@@ -768,21 +768,21 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 87 PointerType *[]*crypto/x509.Certificate
+          Type: 112 PointerType *[]*crypto/x509.Certificate
         - Name: len
           Offset: 8
           Type: 7 BaseType int
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 128 GoSliceDataType [][]*crypto/x509.Certificate.array
+      Data: 120 GoSliceDataType [][]*crypto/x509.Certificate.array
     - __kind: GoSliceDataType
-      ID: 128
+      ID: 120
       Name: '[][]*crypto/x509.Certificate.array'
       ByteSize: 2048
-      Element: 83 GoSliceHeaderType []*crypto/x509.Certificate
+      Element: 108 GoSliceHeaderType []*crypto/x509.Certificate
     - __kind: GoSliceHeaderType
-      ID: 88
+      ID: 113
       Name: '[][]uint8'
       ByteSize: 24
       GoRuntimeType: 478688
@@ -790,21 +790,21 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 89 PointerType *[]uint8
+          Type: 114 PointerType *[]uint8
         - Name: len
           Offset: 8
           Type: 7 BaseType int
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 130 GoSliceDataType [][]uint8.array
+      Data: 122 GoSliceDataType [][]uint8.array
     - __kind: GoSliceDataType
-      ID: 130
+      ID: 122
       Name: '[][]uint8.array'
       ByteSize: 2048
-      Element: 70 GoSliceHeaderType []uint8
+      Element: 105 GoSliceHeaderType []uint8
     - __kind: GoSliceHeaderType
-      ID: 153
+      ID: 143
       Name: '[]crypto/x509.ExtKeyUsage'
       ByteSize: 24
       GoRuntimeType: 499936
@@ -812,21 +812,21 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 154 PointerType *crypto/x509.ExtKeyUsage
+          Type: 144 PointerType *crypto/x509.ExtKeyUsage
         - Name: len
           Offset: 8
           Type: 7 BaseType int
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 192 GoSliceDataType []crypto/x509.ExtKeyUsage.array
+      Data: 181 GoSliceDataType []crypto/x509.ExtKeyUsage.array
     - __kind: GoSliceDataType
-      ID: 192
+      ID: 181
       Name: '[]crypto/x509.ExtKeyUsage.array'
       ByteSize: 2048
-      Element: 155 BaseType crypto/x509.ExtKeyUsage
+      Element: 145 BaseType crypto/x509.ExtKeyUsage
     - __kind: GoSliceHeaderType
-      ID: 164
+      ID: 154
       Name: '[]crypto/x509.OID'
       ByteSize: 24
       GoRuntimeType: 512064
@@ -834,21 +834,21 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 165 PointerType *crypto/x509.OID
+          Type: 155 PointerType *crypto/x509.OID
         - Name: len
           Offset: 8
           Type: 7 BaseType int
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 202 GoSliceDataType []crypto/x509.OID.array
+      Data: 190 GoSliceDataType []crypto/x509.OID.array
     - __kind: GoSliceDataType
-      ID: 202
+      ID: 190
       Name: '[]crypto/x509.OID.array'
       ByteSize: 2048
-      Element: 166 StructureType crypto/x509.OID
+      Element: 156 StructureType crypto/x509.OID
     - __kind: GoSliceHeaderType
-      ID: 167
+      ID: 157
       Name: '[]crypto/x509.PolicyMapping'
       ByteSize: 24
       GoRuntimeType: 512128
@@ -856,21 +856,21 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 168 PointerType *crypto/x509.PolicyMapping
+          Type: 158 PointerType *crypto/x509.PolicyMapping
         - Name: len
           Offset: 8
           Type: 7 BaseType int
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 204 GoSliceDataType []crypto/x509.PolicyMapping.array
+      Data: 192 GoSliceDataType []crypto/x509.PolicyMapping.array
     - __kind: GoSliceDataType
-      ID: 204
+      ID: 192
       Name: '[]crypto/x509.PolicyMapping.array'
       ByteSize: 2048
-      Element: 169 StructureType crypto/x509.PolicyMapping
+      Element: 159 StructureType crypto/x509.PolicyMapping
     - __kind: GoSliceHeaderType
-      ID: 140
+      ID: 130
       Name: '[]crypto/x509/pkix.AttributeTypeAndValue'
       ByteSize: 24
       GoRuntimeType: 512576
@@ -878,21 +878,21 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 141 PointerType *crypto/x509/pkix.AttributeTypeAndValue
+          Type: 131 PointerType *crypto/x509/pkix.AttributeTypeAndValue
         - Name: len
           Offset: 8
           Type: 7 BaseType int
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 184 GoSliceDataType []crypto/x509/pkix.AttributeTypeAndValue.array
+      Data: 165 GoSliceDataType []crypto/x509/pkix.AttributeTypeAndValue.array
     - __kind: GoSliceDataType
-      ID: 184
+      ID: 165
       Name: '[]crypto/x509/pkix.AttributeTypeAndValue.array'
       ByteSize: 2048
-      Element: 142 StructureType crypto/x509/pkix.AttributeTypeAndValue
+      Element: 132 StructureType crypto/x509/pkix.AttributeTypeAndValue
     - __kind: GoSliceHeaderType
-      ID: 147
+      ID: 137
       Name: '[]crypto/x509/pkix.Extension'
       ByteSize: 24
       GoRuntimeType: 511808
@@ -900,21 +900,21 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 148 PointerType *crypto/x509/pkix.Extension
+          Type: 138 PointerType *crypto/x509/pkix.Extension
         - Name: len
           Offset: 8
           Type: 7 BaseType int
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 186 GoSliceDataType []crypto/x509/pkix.Extension.array
+      Data: 177 GoSliceDataType []crypto/x509/pkix.Extension.array
     - __kind: GoSliceDataType
-      ID: 186
+      ID: 177
       Name: '[]crypto/x509/pkix.Extension.array'
       ByteSize: 2048
-      Element: 149 StructureType crypto/x509/pkix.Extension
+      Element: 139 StructureType crypto/x509/pkix.Extension
     - __kind: GoSliceHeaderType
-      ID: 150
+      ID: 140
       Name: '[]encoding/asn1.ObjectIdentifier'
       ByteSize: 24
       GoRuntimeType: 511872
@@ -922,21 +922,21 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 151 PointerType *encoding/asn1.ObjectIdentifier
+          Type: 141 PointerType *encoding/asn1.ObjectIdentifier
         - Name: len
           Offset: 8
           Type: 7 BaseType int
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 188 GoSliceDataType []encoding/asn1.ObjectIdentifier.array
+      Data: 179 GoSliceDataType []encoding/asn1.ObjectIdentifier.array
     - __kind: GoSliceDataType
-      ID: 188
+      ID: 179
       Name: '[]encoding/asn1.ObjectIdentifier.array'
       ByteSize: 2048
-      Element: 152 GoSliceHeaderType encoding/asn1.ObjectIdentifier
+      Element: 142 GoSliceHeaderType encoding/asn1.ObjectIdentifier
     - __kind: GoSliceHeaderType
-      ID: 156
+      ID: 146
       Name: '[]net.IP'
       ByteSize: 24
       GoRuntimeType: 479648
@@ -944,21 +944,21 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 157 PointerType *net.IP
+          Type: 147 PointerType *net.IP
         - Name: len
           Offset: 8
           Type: 7 BaseType int
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 194 GoSliceDataType []net.IP.array
+      Data: 183 GoSliceDataType []net.IP.array
     - __kind: GoSliceDataType
-      ID: 194
+      ID: 183
       Name: '[]net.IP.array'
       ByteSize: 2048
-      Element: 158 GoSliceHeaderType net.IP
+      Element: 148 GoSliceHeaderType net.IP
     - __kind: GoSliceHeaderType
-      ID: 92
+      ID: 201
       Name: '[]net/http.segment'
       ByteSize: 24
       GoRuntimeType: 481280
@@ -966,36 +966,36 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 93 PointerType *net/http.segment
+          Type: 202 PointerType *net/http.segment
         - Name: len
           Offset: 8
           Type: 7 BaseType int
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 132 GoSliceDataType []net/http.segment.array
+      Data: 204 GoSliceDataType []net/http.segment.array
     - __kind: GoSliceDataType
-      ID: 132
+      ID: 204
       Name: '[]net/http.segment.array'
       ByteSize: 2048
-      Element: 94 StructureType net/http.segment
+      Element: 203 StructureType net/http.segment
     - __kind: GoSliceDataType
-      ID: 125
+      ID: 100
       Name: '[]noalg.map.group[string][]*mime/multipart.FileHeader.array'
       ByteSize: 2048
-      Element: 118 StructureType noalg.map.group[string][]*mime/multipart.FileHeader
+      Element: 93 StructureType noalg.map.group[string][]*mime/multipart.FileHeader
     - __kind: GoSliceDataType
-      ID: 102
+      ID: 81
       Name: '[]noalg.map.group[string][]string.array'
       ByteSize: 2048
-      Element: 98 StructureType noalg.map.group[string][]string
+      Element: 77 StructureType noalg.map.group[string][]string
     - __kind: GoSliceDataType
-      ID: 111
+      ID: 213
       Name: '[]noalg.map.group[string]string.array'
       ByteSize: 2048
-      Element: 107 StructureType noalg.map.group[string]string
+      Element: 209 StructureType noalg.map.group[string]string
     - __kind: GoSliceHeaderType
-      ID: 53
+      ID: 55
       Name: '[]string'
       ByteSize: 24
       GoRuntimeType: 492832
@@ -1010,14 +1010,14 @@ Types:
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 103 GoSliceDataType []string.array
+      Data: 82 GoSliceDataType []string.array
     - __kind: GoSliceDataType
-      ID: 103
+      ID: 82
       Name: '[]string.array'
       ByteSize: 2048
       Element: 9 GoStringHeaderType string
     - __kind: GoSliceHeaderType
-      ID: 176
+      ID: 167
       Name: '[]time.zone'
       ByteSize: 24
       GoRuntimeType: 485952
@@ -1025,21 +1025,21 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 177 PointerType *time.zone
+          Type: 168 PointerType *time.zone
         - Name: len
           Offset: 8
           Type: 7 BaseType int
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 209 GoSliceDataType []time.zone.array
+      Data: 173 GoSliceDataType []time.zone.array
     - __kind: GoSliceDataType
-      ID: 209
+      ID: 173
       Name: '[]time.zone.array'
       ByteSize: 2048
-      Element: 178 StructureType time.zone
+      Element: 169 StructureType time.zone
     - __kind: GoSliceHeaderType
-      ID: 179
+      ID: 170
       Name: '[]time.zoneTrans'
       ByteSize: 24
       GoRuntimeType: 486016
@@ -1047,21 +1047,21 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 180 PointerType *time.zoneTrans
+          Type: 171 PointerType *time.zoneTrans
         - Name: len
           Offset: 8
           Type: 7 BaseType int
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 211 GoSliceDataType []time.zoneTrans.array
+      Data: 175 GoSliceDataType []time.zoneTrans.array
     - __kind: GoSliceDataType
-      ID: 211
+      ID: 175
       Name: '[]time.zoneTrans.array'
       ByteSize: 2048
-      Element: 181 StructureType time.zoneTrans
+      Element: 172 StructureType time.zoneTrans
     - __kind: GoSliceHeaderType
-      ID: 70
+      ID: 105
       Name: '[]uint8'
       ByteSize: 24
       GoRuntimeType: 491680
@@ -1076,9 +1076,9 @@ Types:
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 112 GoSliceDataType []uint8.array
+      Data: 106 GoSliceDataType []uint8.array
     - __kind: GoSliceDataType
-      ID: 112
+      ID: 106
       Name: '[]uint8.array'
       ByteSize: 2048
       Element: 3 BaseType uint8
@@ -1088,28 +1088,10 @@ Types:
       ByteSize: 1
       GoRuntimeType: 580672
       GoKind: 1
-    - __kind: StructureType
+    - __kind: UnresolvedPointeeType
       ID: 40
       Name: bytes.Buffer
-      ByteSize: 40
-      GoRuntimeType: 1.595648e+06
-      GoKind: 25
-      RawFields:
-        - Name: buf
-          Offset: 0
-          Type: 70 GoSliceHeaderType []uint8
-        - Name: off
-          Offset: 24
-          Type: 7 BaseType int
-        - Name: lastRead
-          Offset: 32
-          Type: 71 BaseType bytes.readOp
-    - __kind: BaseType
-      ID: 71
-      Name: bytes.readOp
-      ByteSize: 1
-      GoRuntimeType: 578816
-      GoKind: 3
+      ByteSize: 8
     - __kind: BaseType
       ID: 24
       Name: complex128
@@ -1123,7 +1105,7 @@ Types:
       GoRuntimeType: 580416
       GoKind: 15
     - __kind: GoInterfaceType
-      ID: 62
+      ID: 64
       Name: context.Context
       ByteSize: 16
       GoRuntimeType: 1.267616e+06
@@ -1151,7 +1133,7 @@ Types:
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 58
+      ID: 60
       Name: crypto/tls.ConnectionState
       ByteSize: 192
       GoRuntimeType: 2.232384e+06
@@ -1180,39 +1162,39 @@ Types:
           Type: 9 GoStringHeaderType string
         - Name: PeerCertificates
           Offset: 48
-          Type: 83 GoSliceHeaderType []*crypto/x509.Certificate
+          Type: 108 GoSliceHeaderType []*crypto/x509.Certificate
         - Name: VerifiedChains
           Offset: 72
-          Type: 86 GoSliceHeaderType [][]*crypto/x509.Certificate
+          Type: 111 GoSliceHeaderType [][]*crypto/x509.Certificate
         - Name: SignedCertificateTimestamps
           Offset: 96
-          Type: 88 GoSliceHeaderType [][]uint8
+          Type: 113 GoSliceHeaderType [][]uint8
         - Name: OCSPResponse
           Offset: 120
-          Type: 70 GoSliceHeaderType []uint8
+          Type: 105 GoSliceHeaderType []uint8
         - Name: TLSUnique
           Offset: 144
-          Type: 70 GoSliceHeaderType []uint8
+          Type: 105 GoSliceHeaderType []uint8
         - Name: ECHAccepted
           Offset: 168
           Type: 4 BaseType bool
         - Name: ekm
           Offset: 176
-          Type: 90 GoSubroutineType func(string, []uint8, int) ([]uint8, error)
+          Type: 115 GoSubroutineType func(string, []uint8, int) ([]uint8, error)
         - Name: testingOnlyDidHRR
           Offset: 184
           Type: 4 BaseType bool
         - Name: testingOnlyCurveID
           Offset: 186
-          Type: 91 BaseType crypto/tls.CurveID
+          Type: 116 BaseType crypto/tls.CurveID
     - __kind: BaseType
-      ID: 91
+      ID: 116
       Name: crypto/tls.CurveID
       ByteSize: 2
       GoRuntimeType: 829664
       GoKind: 9
     - __kind: StructureType
-      ID: 115
+      ID: 117
       Name: crypto/x509.Certificate
       ByteSize: 1424
       GoRuntimeType: 2.377888e+06
@@ -1220,67 +1202,67 @@ Types:
       RawFields:
         - Name: Raw
           Offset: 0
-          Type: 70 GoSliceHeaderType []uint8
+          Type: 105 GoSliceHeaderType []uint8
         - Name: RawTBSCertificate
           Offset: 24
-          Type: 70 GoSliceHeaderType []uint8
+          Type: 105 GoSliceHeaderType []uint8
         - Name: RawSubjectPublicKeyInfo
           Offset: 48
-          Type: 70 GoSliceHeaderType []uint8
+          Type: 105 GoSliceHeaderType []uint8
         - Name: RawSubject
           Offset: 72
-          Type: 70 GoSliceHeaderType []uint8
+          Type: 105 GoSliceHeaderType []uint8
         - Name: RawIssuer
           Offset: 96
-          Type: 70 GoSliceHeaderType []uint8
+          Type: 105 GoSliceHeaderType []uint8
         - Name: Signature
           Offset: 120
-          Type: 70 GoSliceHeaderType []uint8
+          Type: 105 GoSliceHeaderType []uint8
         - Name: SignatureAlgorithm
           Offset: 144
-          Type: 134 BaseType crypto/x509.SignatureAlgorithm
+          Type: 124 BaseType crypto/x509.SignatureAlgorithm
         - Name: PublicKeyAlgorithm
           Offset: 152
-          Type: 135 BaseType crypto/x509.PublicKeyAlgorithm
+          Type: 125 BaseType crypto/x509.PublicKeyAlgorithm
         - Name: PublicKey
           Offset: 160
-          Type: 136 GoEmptyInterfaceType interface {}
+          Type: 126 GoEmptyInterfaceType interface {}
         - Name: Version
           Offset: 176
           Type: 7 BaseType int
         - Name: SerialNumber
           Offset: 184
-          Type: 137 PointerType *math/big.Int
+          Type: 127 PointerType *math/big.Int
         - Name: Issuer
           Offset: 192
-          Type: 139 StructureType crypto/x509/pkix.Name
+          Type: 129 StructureType crypto/x509/pkix.Name
         - Name: Subject
           Offset: 440
-          Type: 139 StructureType crypto/x509/pkix.Name
+          Type: 129 StructureType crypto/x509/pkix.Name
         - Name: NotBefore
           Offset: 688
-          Type: 143 StructureType time.Time
+          Type: 133 StructureType time.Time
         - Name: NotAfter
           Offset: 712
-          Type: 143 StructureType time.Time
+          Type: 133 StructureType time.Time
         - Name: KeyUsage
           Offset: 736
-          Type: 146 BaseType crypto/x509.KeyUsage
+          Type: 136 BaseType crypto/x509.KeyUsage
         - Name: Extensions
           Offset: 744
-          Type: 147 GoSliceHeaderType []crypto/x509/pkix.Extension
+          Type: 137 GoSliceHeaderType []crypto/x509/pkix.Extension
         - Name: ExtraExtensions
           Offset: 768
-          Type: 147 GoSliceHeaderType []crypto/x509/pkix.Extension
+          Type: 137 GoSliceHeaderType []crypto/x509/pkix.Extension
         - Name: UnhandledCriticalExtensions
           Offset: 792
-          Type: 150 GoSliceHeaderType []encoding/asn1.ObjectIdentifier
+          Type: 140 GoSliceHeaderType []encoding/asn1.ObjectIdentifier
         - Name: ExtKeyUsage
           Offset: 816
-          Type: 153 GoSliceHeaderType []crypto/x509.ExtKeyUsage
+          Type: 143 GoSliceHeaderType []crypto/x509.ExtKeyUsage
         - Name: UnknownExtKeyUsage
           Offset: 840
-          Type: 150 GoSliceHeaderType []encoding/asn1.ObjectIdentifier
+          Type: 140 GoSliceHeaderType []encoding/asn1.ObjectIdentifier
         - Name: BasicConstraintsValid
           Offset: 864
           Type: 4 BaseType bool
@@ -1295,64 +1277,64 @@ Types:
           Type: 4 BaseType bool
         - Name: SubjectKeyId
           Offset: 888
-          Type: 70 GoSliceHeaderType []uint8
+          Type: 105 GoSliceHeaderType []uint8
         - Name: AuthorityKeyId
           Offset: 912
-          Type: 70 GoSliceHeaderType []uint8
+          Type: 105 GoSliceHeaderType []uint8
         - Name: OCSPServer
           Offset: 936
-          Type: 53 GoSliceHeaderType []string
+          Type: 55 GoSliceHeaderType []string
         - Name: IssuingCertificateURL
           Offset: 960
-          Type: 53 GoSliceHeaderType []string
+          Type: 55 GoSliceHeaderType []string
         - Name: DNSNames
           Offset: 984
-          Type: 53 GoSliceHeaderType []string
+          Type: 55 GoSliceHeaderType []string
         - Name: EmailAddresses
           Offset: 1008
-          Type: 53 GoSliceHeaderType []string
+          Type: 55 GoSliceHeaderType []string
         - Name: IPAddresses
           Offset: 1032
-          Type: 156 GoSliceHeaderType []net.IP
+          Type: 146 GoSliceHeaderType []net.IP
         - Name: URIs
           Offset: 1056
-          Type: 159 GoSliceHeaderType []*net/url.URL
+          Type: 149 GoSliceHeaderType []*net/url.URL
         - Name: PermittedDNSDomainsCritical
           Offset: 1080
           Type: 4 BaseType bool
         - Name: PermittedDNSDomains
           Offset: 1088
-          Type: 53 GoSliceHeaderType []string
+          Type: 55 GoSliceHeaderType []string
         - Name: ExcludedDNSDomains
           Offset: 1112
-          Type: 53 GoSliceHeaderType []string
+          Type: 55 GoSliceHeaderType []string
         - Name: PermittedIPRanges
           Offset: 1136
-          Type: 161 GoSliceHeaderType []*net.IPNet
+          Type: 151 GoSliceHeaderType []*net.IPNet
         - Name: ExcludedIPRanges
           Offset: 1160
-          Type: 161 GoSliceHeaderType []*net.IPNet
+          Type: 151 GoSliceHeaderType []*net.IPNet
         - Name: PermittedEmailAddresses
           Offset: 1184
-          Type: 53 GoSliceHeaderType []string
+          Type: 55 GoSliceHeaderType []string
         - Name: ExcludedEmailAddresses
           Offset: 1208
-          Type: 53 GoSliceHeaderType []string
+          Type: 55 GoSliceHeaderType []string
         - Name: PermittedURIDomains
           Offset: 1232
-          Type: 53 GoSliceHeaderType []string
+          Type: 55 GoSliceHeaderType []string
         - Name: ExcludedURIDomains
           Offset: 1256
-          Type: 53 GoSliceHeaderType []string
+          Type: 55 GoSliceHeaderType []string
         - Name: CRLDistributionPoints
           Offset: 1280
-          Type: 53 GoSliceHeaderType []string
+          Type: 55 GoSliceHeaderType []string
         - Name: PolicyIdentifiers
           Offset: 1304
-          Type: 150 GoSliceHeaderType []encoding/asn1.ObjectIdentifier
+          Type: 140 GoSliceHeaderType []encoding/asn1.ObjectIdentifier
         - Name: Policies
           Offset: 1328
-          Type: 164 GoSliceHeaderType []crypto/x509.OID
+          Type: 154 GoSliceHeaderType []crypto/x509.OID
         - Name: InhibitAnyPolicy
           Offset: 1352
           Type: 7 BaseType int
@@ -1373,21 +1355,21 @@ Types:
           Type: 4 BaseType bool
         - Name: PolicyMappings
           Offset: 1400
-          Type: 167 GoSliceHeaderType []crypto/x509.PolicyMapping
+          Type: 157 GoSliceHeaderType []crypto/x509.PolicyMapping
     - __kind: BaseType
-      ID: 155
+      ID: 145
       Name: crypto/x509.ExtKeyUsage
       ByteSize: 8
       GoRuntimeType: 583360
       GoKind: 2
     - __kind: BaseType
-      ID: 146
+      ID: 136
       Name: crypto/x509.KeyUsage
       ByteSize: 8
       GoRuntimeType: 583296
       GoKind: 2
     - __kind: StructureType
-      ID: 166
+      ID: 156
       Name: crypto/x509.OID
       ByteSize: 24
       GoRuntimeType: 1.939168e+06
@@ -1395,9 +1377,9 @@ Types:
       RawFields:
         - Name: der
           Offset: 0
-          Type: 70 GoSliceHeaderType []uint8
+          Type: 105 GoSliceHeaderType []uint8
     - __kind: StructureType
-      ID: 169
+      ID: 159
       Name: crypto/x509.PolicyMapping
       ByteSize: 48
       GoRuntimeType: 1.480928e+06
@@ -1405,24 +1387,24 @@ Types:
       RawFields:
         - Name: IssuerDomainPolicy
           Offset: 0
-          Type: 166 StructureType crypto/x509.OID
+          Type: 156 StructureType crypto/x509.OID
         - Name: SubjectDomainPolicy
           Offset: 24
-          Type: 166 StructureType crypto/x509.OID
+          Type: 156 StructureType crypto/x509.OID
     - __kind: BaseType
-      ID: 135
+      ID: 125
       Name: crypto/x509.PublicKeyAlgorithm
       ByteSize: 8
       GoRuntimeType: 832064
       GoKind: 2
     - __kind: BaseType
-      ID: 134
+      ID: 124
       Name: crypto/x509.SignatureAlgorithm
       ByteSize: 8
       GoRuntimeType: 1.105248e+06
       GoKind: 2
     - __kind: StructureType
-      ID: 142
+      ID: 132
       Name: crypto/x509/pkix.AttributeTypeAndValue
       ByteSize: 40
       GoRuntimeType: 1.492608e+06
@@ -1430,12 +1412,12 @@ Types:
       RawFields:
         - Name: Type
           Offset: 0
-          Type: 152 GoSliceHeaderType encoding/asn1.ObjectIdentifier
+          Type: 142 GoSliceHeaderType encoding/asn1.ObjectIdentifier
         - Name: Value
           Offset: 24
-          Type: 136 GoEmptyInterfaceType interface {}
+          Type: 126 GoEmptyInterfaceType interface {}
     - __kind: StructureType
-      ID: 149
+      ID: 139
       Name: crypto/x509/pkix.Extension
       ByteSize: 56
       GoRuntimeType: 1.63616e+06
@@ -1443,15 +1425,15 @@ Types:
       RawFields:
         - Name: Id
           Offset: 0
-          Type: 152 GoSliceHeaderType encoding/asn1.ObjectIdentifier
+          Type: 142 GoSliceHeaderType encoding/asn1.ObjectIdentifier
         - Name: Critical
           Offset: 24
           Type: 4 BaseType bool
         - Name: Value
           Offset: 32
-          Type: 70 GoSliceHeaderType []uint8
+          Type: 105 GoSliceHeaderType []uint8
     - __kind: StructureType
-      ID: 139
+      ID: 129
       Name: crypto/x509/pkix.Name
       ByteSize: 248
       GoRuntimeType: 2.177504e+06
@@ -1459,25 +1441,25 @@ Types:
       RawFields:
         - Name: Country
           Offset: 0
-          Type: 53 GoSliceHeaderType []string
+          Type: 55 GoSliceHeaderType []string
         - Name: Organization
           Offset: 24
-          Type: 53 GoSliceHeaderType []string
+          Type: 55 GoSliceHeaderType []string
         - Name: OrganizationalUnit
           Offset: 48
-          Type: 53 GoSliceHeaderType []string
+          Type: 55 GoSliceHeaderType []string
         - Name: Locality
           Offset: 72
-          Type: 53 GoSliceHeaderType []string
+          Type: 55 GoSliceHeaderType []string
         - Name: Province
           Offset: 96
-          Type: 53 GoSliceHeaderType []string
+          Type: 55 GoSliceHeaderType []string
         - Name: StreetAddress
           Offset: 120
-          Type: 53 GoSliceHeaderType []string
+          Type: 55 GoSliceHeaderType []string
         - Name: PostalCode
           Offset: 144
-          Type: 53 GoSliceHeaderType []string
+          Type: 55 GoSliceHeaderType []string
         - Name: SerialNumber
           Offset: 168
           Type: 9 GoStringHeaderType string
@@ -1486,12 +1468,12 @@ Types:
           Type: 9 GoStringHeaderType string
         - Name: Names
           Offset: 200
-          Type: 140 GoSliceHeaderType []crypto/x509/pkix.AttributeTypeAndValue
+          Type: 130 GoSliceHeaderType []crypto/x509/pkix.AttributeTypeAndValue
         - Name: ExtraNames
           Offset: 224
-          Type: 140 GoSliceHeaderType []crypto/x509/pkix.AttributeTypeAndValue
+          Type: 130 GoSliceHeaderType []crypto/x509/pkix.AttributeTypeAndValue
     - __kind: GoSliceHeaderType
-      ID: 152
+      ID: 142
       Name: encoding/asn1.ObjectIdentifier
       ByteSize: 24
       GoRuntimeType: 1.044832e+06
@@ -1506,9 +1488,9 @@ Types:
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 190 GoSliceDataType encoding/asn1.ObjectIdentifier.array
+      Data: 194 GoSliceDataType encoding/asn1.ObjectIdentifier.array
     - __kind: GoSliceDataType
-      ID: 190
+      ID: 194
       Name: encoding/asn1.ObjectIdentifier.array
       ByteSize: 2048
       Element: 7 BaseType int
@@ -1538,13 +1520,13 @@ Types:
       GoRuntimeType: 580608
       GoKind: 14
     - __kind: GoSubroutineType
-      ID: 52
+      ID: 54
       Name: func() (io.ReadCloser, error)
       ByteSize: 8
       GoRuntimeType: 687968
       GoKind: 19
     - __kind: GoSubroutineType
-      ID: 90
+      ID: 115
       Name: func(string, []uint8, int) ([]uint8, error)
       ByteSize: 8
       GoRuntimeType: 995552
@@ -1563,47 +1545,47 @@ Types:
           Offset: 8
           Type: 14 VoidPointerType unsafe.Pointer
     - __kind: GoSwissMapGroupsType
-      ID: 116
+      ID: 91
       Name: groupReference<string,[]*mime/multipart.FileHeader>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 117 PointerType *noalg.map.group[string][]*mime/multipart.FileHeader
+          Type: 92 PointerType *noalg.map.group[string][]*mime/multipart.FileHeader
         - Name: lengthMask
           Offset: 8
           Type: 8 BaseType uint64
-      GroupType: 118 StructureType noalg.map.group[string][]*mime/multipart.FileHeader
-      GroupSliceType: 125 GoSliceDataType []noalg.map.group[string][]*mime/multipart.FileHeader.array
+      GroupType: 93 StructureType noalg.map.group[string][]*mime/multipart.FileHeader
+      GroupSliceType: 100 GoSliceDataType []noalg.map.group[string][]*mime/multipart.FileHeader.array
     - __kind: GoSwissMapGroupsType
-      ID: 96
+      ID: 75
       Name: groupReference<string,[]string>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 97 PointerType *noalg.map.group[string][]string
+          Type: 76 PointerType *noalg.map.group[string][]string
         - Name: lengthMask
           Offset: 8
           Type: 8 BaseType uint64
-      GroupType: 98 StructureType noalg.map.group[string][]string
-      GroupSliceType: 102 GoSliceDataType []noalg.map.group[string][]string.array
+      GroupType: 77 StructureType noalg.map.group[string][]string
+      GroupSliceType: 81 GoSliceDataType []noalg.map.group[string][]string.array
     - __kind: GoSwissMapGroupsType
-      ID: 105
+      ID: 207
       Name: groupReference<string,string>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 106 PointerType *noalg.map.group[string]string
+          Type: 208 PointerType *noalg.map.group[string]string
         - Name: lengthMask
           Offset: 8
           Type: 8 BaseType uint64
-      GroupType: 107 StructureType noalg.map.group[string]string
-      GroupSliceType: 111 GoSliceDataType []noalg.map.group[string]string.array
+      GroupType: 209 StructureType noalg.map.group[string]string
+      GroupSliceType: 213 GoSliceDataType []noalg.map.group[string]string.array
     - __kind: BaseType
       ID: 7
       Name: int
@@ -1635,7 +1617,7 @@ Types:
       GoRuntimeType: 579712
       GoKind: 3
     - __kind: GoEmptyInterfaceType
-      ID: 136
+      ID: 126
       Name: interface {}
       ByteSize: 16
       GoRuntimeType: 849280
@@ -1648,7 +1630,7 @@ Types:
           Offset: 8
           Type: 14 VoidPointerType unsafe.Pointer
     - __kind: GoInterfaceType
-      ID: 51
+      ID: 53
       Name: io.ReadCloser
       ByteSize: 16
       GoRuntimeType: 1.10128e+06
@@ -1661,7 +1643,7 @@ Types:
           Offset: 8
           Type: 14 VoidPointerType unsafe.Pointer
     - __kind: GoSwissMapHeaderType
-      ID: 80
+      ID: 87
       Name: map<string,[]*mime/multipart.FileHeader>
       ByteSize: 48
       GoKind: 25
@@ -1674,7 +1656,7 @@ Types:
           Type: 1 BaseType uintptr
         - Name: dirPtr
           Offset: 16
-          Type: 81 PointerType **table<string,[]*mime/multipart.FileHeader>
+          Type: 88 PointerType **table<string,[]*mime/multipart.FileHeader>
         - Name: dirLen
           Offset: 24
           Type: 7 BaseType int
@@ -1690,10 +1672,10 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 8 BaseType uint64
-      TablePtrSliceType: 124 GoSliceDataType []*table<string,[]*mime/multipart.FileHeader>.array
-      GroupType: 118 StructureType noalg.map.group[string][]*mime/multipart.FileHeader
+      TablePtrSliceType: 99 GoSliceDataType []*table<string,[]*mime/multipart.FileHeader>.array
+      GroupType: 93 StructureType noalg.map.group[string][]*mime/multipart.FileHeader
     - __kind: GoSwissMapHeaderType
-      ID: 48
+      ID: 50
       Name: map<string,[]string>
       ByteSize: 48
       GoKind: 25
@@ -1706,7 +1688,7 @@ Types:
           Type: 1 BaseType uintptr
         - Name: dirPtr
           Offset: 16
-          Type: 49 PointerType **table<string,[]string>
+          Type: 51 PointerType **table<string,[]string>
         - Name: dirLen
           Offset: 24
           Type: 7 BaseType int
@@ -1722,10 +1704,10 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 8 BaseType uint64
-      TablePtrSliceType: 101 GoSliceDataType []*table<string,[]string>.array
-      GroupType: 98 StructureType noalg.map.group[string][]string
+      TablePtrSliceType: 80 GoSliceDataType []*table<string,[]string>.array
+      GroupType: 77 StructureType noalg.map.group[string][]string
     - __kind: GoSwissMapHeaderType
-      ID: 67
+      ID: 69
       Name: map<string,string>
       ByteSize: 48
       GoKind: 25
@@ -1738,7 +1720,7 @@ Types:
           Type: 1 BaseType uintptr
         - Name: dirPtr
           Offset: 16
-          Type: 68 PointerType **table<string,string>
+          Type: 70 PointerType **table<string,string>
         - Name: dirLen
           Offset: 24
           Type: 7 BaseType int
@@ -1754,31 +1736,31 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 8 BaseType uint64
-      TablePtrSliceType: 110 GoSliceDataType []*table<string,string>.array
-      GroupType: 107 StructureType noalg.map.group[string]string
+      TablePtrSliceType: 212 GoSliceDataType []*table<string,string>.array
+      GroupType: 209 StructureType noalg.map.group[string]string
     - __kind: GoMapType
-      ID: 78
+      ID: 85
       Name: map[string][]*mime/multipart.FileHeader
       ByteSize: 8
       GoRuntimeType: 1.123296e+06
       GoKind: 21
-      HeaderType: 80 GoSwissMapHeaderType map<string,[]*mime/multipart.FileHeader>
+      HeaderType: 87 GoSwissMapHeaderType map<string,[]*mime/multipart.FileHeader>
     - __kind: GoMapType
-      ID: 77
+      ID: 84
       Name: map[string][]string
       ByteSize: 8
       GoRuntimeType: 1.118688e+06
       GoKind: 21
-      HeaderType: 48 GoSwissMapHeaderType map<string,[]string>
+      HeaderType: 50 GoSwissMapHeaderType map<string,[]string>
     - __kind: GoMapType
-      ID: 65
+      ID: 67
       Name: map[string]string
       ByteSize: 8
       GoRuntimeType: 1.119712e+06
       GoKind: 21
-      HeaderType: 67 GoSwissMapHeaderType map<string,string>
+      HeaderType: 69 GoSwissMapHeaderType map<string,string>
     - __kind: StructureType
-      ID: 138
+      ID: 128
       Name: math/big.Int
       ByteSize: 32
       GoRuntimeType: 1.483968e+06
@@ -1789,15 +1771,15 @@ Types:
           Type: 4 BaseType bool
         - Name: abs
           Offset: 8
-          Type: 173 GoSliceHeaderType math/big.nat
+          Type: 160 GoSliceHeaderType math/big.nat
     - __kind: BaseType
-      ID: 175
+      ID: 162
       Name: math/big.Word
       ByteSize: 8
       GoRuntimeType: 583552
       GoKind: 7
     - __kind: GoSliceHeaderType
-      ID: 173
+      ID: 160
       Name: math/big.nat
       ByteSize: 24
       GoRuntimeType: 2.346272e+06
@@ -1805,21 +1787,21 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 174 PointerType *math/big.Word
+          Type: 161 PointerType *math/big.Word
         - Name: len
           Offset: 8
           Type: 7 BaseType int
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 207 GoSliceDataType math/big.nat.array
+      Data: 163 GoSliceDataType math/big.nat.array
     - __kind: GoSliceDataType
-      ID: 207
+      ID: 163
       Name: math/big.nat.array
       ByteSize: 2048
-      Element: 175 BaseType math/big.Word
+      Element: 162 BaseType math/big.Word
     - __kind: StructureType
-      ID: 170
+      ID: 101
       Name: mime/multipart.FileHeader
       ByteSize: 88
       GoRuntimeType: 1.962912e+06
@@ -1830,13 +1812,13 @@ Types:
           Type: 9 GoStringHeaderType string
         - Name: Header
           Offset: 16
-          Type: 183 GoMapType net/textproto.MIMEHeader
+          Type: 104 GoMapType net/textproto.MIMEHeader
         - Name: Size
           Offset: 24
           Type: 12 BaseType int64
         - Name: content
           Offset: 32
-          Type: 70 GoSliceHeaderType []uint8
+          Type: 105 GoSliceHeaderType []uint8
         - Name: tmpfile
           Offset: 56
           Type: 9 GoStringHeaderType string
@@ -1847,7 +1829,7 @@ Types:
           Offset: 80
           Type: 4 BaseType bool
     - __kind: StructureType
-      ID: 56
+      ID: 58
       Name: mime/multipart.Form
       ByteSize: 16
       GoRuntimeType: 1.467968e+06
@@ -1855,12 +1837,12 @@ Types:
       RawFields:
         - Name: Value
           Offset: 0
-          Type: 77 GoMapType map[string][]string
+          Type: 84 GoMapType map[string][]string
         - Name: File
           Offset: 8
-          Type: 78 GoMapType map[string][]*mime/multipart.FileHeader
+          Type: 85 GoMapType map[string][]*mime/multipart.FileHeader
     - __kind: GoSliceHeaderType
-      ID: 158
+      ID: 148
       Name: net.IP
       ByteSize: 24
       GoRuntimeType: 2.109952e+06
@@ -1882,7 +1864,7 @@ Types:
       ByteSize: 2048
       Element: 3 BaseType uint8
     - __kind: GoSliceHeaderType
-      ID: 206
+      ID: 198
       Name: net.IPMask
       ByteSize: 24
       GoRuntimeType: 1.011424e+06
@@ -1897,14 +1879,14 @@ Types:
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 213 GoSliceDataType net.IPMask.array
+      Data: 199 GoSliceDataType net.IPMask.array
     - __kind: GoSliceDataType
-      ID: 213
+      ID: 199
       Name: net.IPMask.array
       ByteSize: 2048
       Element: 3 BaseType uint8
     - __kind: StructureType
-      ID: 182
+      ID: 187
       Name: net.IPNet
       ByteSize: 48
       GoRuntimeType: 1.449408e+06
@@ -1912,17 +1894,17 @@ Types:
       RawFields:
         - Name: IP
           Offset: 0
-          Type: 158 GoSliceHeaderType net.IP
+          Type: 148 GoSliceHeaderType net.IP
         - Name: Mask
           Offset: 24
-          Type: 206 GoSliceHeaderType net.IPMask
+          Type: 198 GoSliceHeaderType net.IPMask
     - __kind: GoMapType
-      ID: 46
+      ID: 48
       Name: net/http.Header
       ByteSize: 8
       GoRuntimeType: 2.088128e+06
       GoKind: 21
-      HeaderType: 48 GoSwissMapHeaderType map<string,[]string>
+      HeaderType: 50 GoSwissMapHeaderType map<string,[]string>
     - __kind: StructureType
       ID: 38
       Name: net/http.Request
@@ -1935,7 +1917,7 @@ Types:
           Type: 9 GoStringHeaderType string
         - Name: URL
           Offset: 16
-          Type: 44 PointerType *net/url.URL
+          Type: 46 PointerType *net/url.URL
         - Name: Proto
           Offset: 24
           Type: 9 GoStringHeaderType string
@@ -1947,19 +1929,19 @@ Types:
           Type: 7 BaseType int
         - Name: Header
           Offset: 56
-          Type: 46 GoMapType net/http.Header
+          Type: 48 GoMapType net/http.Header
         - Name: Body
           Offset: 64
-          Type: 51 GoInterfaceType io.ReadCloser
+          Type: 53 GoInterfaceType io.ReadCloser
         - Name: GetBody
           Offset: 80
-          Type: 52 GoSubroutineType func() (io.ReadCloser, error)
+          Type: 54 GoSubroutineType func() (io.ReadCloser, error)
         - Name: ContentLength
           Offset: 88
           Type: 12 BaseType int64
         - Name: TransferEncoding
           Offset: 96
-          Type: 53 GoSliceHeaderType []string
+          Type: 55 GoSliceHeaderType []string
         - Name: Close
           Offset: 120
           Type: 4 BaseType bool
@@ -1968,16 +1950,16 @@ Types:
           Type: 9 GoStringHeaderType string
         - Name: Form
           Offset: 144
-          Type: 54 GoMapType net/url.Values
+          Type: 56 GoMapType net/url.Values
         - Name: PostForm
           Offset: 152
-          Type: 54 GoMapType net/url.Values
+          Type: 56 GoMapType net/url.Values
         - Name: MultipartForm
           Offset: 160
-          Type: 55 PointerType *mime/multipart.Form
+          Type: 57 PointerType *mime/multipart.Form
         - Name: Trailer
           Offset: 168
-          Type: 46 GoMapType net/http.Header
+          Type: 48 GoMapType net/http.Header
         - Name: RemoteAddr
           Offset: 176
           Type: 9 GoStringHeaderType string
@@ -1986,30 +1968,30 @@ Types:
           Type: 9 GoStringHeaderType string
         - Name: TLS
           Offset: 208
-          Type: 57 PointerType *crypto/tls.ConnectionState
+          Type: 59 PointerType *crypto/tls.ConnectionState
         - Name: Cancel
           Offset: 216
-          Type: 59 GoChannelType <-chan struct {}
+          Type: 61 GoChannelType <-chan struct {}
         - Name: Response
           Offset: 224
-          Type: 60 PointerType *net/http.Response
+          Type: 62 PointerType *net/http.Response
         - Name: Pattern
           Offset: 232
           Type: 9 GoStringHeaderType string
         - Name: ctx
           Offset: 248
-          Type: 62 GoInterfaceType context.Context
+          Type: 64 GoInterfaceType context.Context
         - Name: pat
           Offset: 264
-          Type: 63 PointerType *net/http.pattern
+          Type: 65 PointerType *net/http.pattern
         - Name: matches
           Offset: 272
-          Type: 53 GoSliceHeaderType []string
+          Type: 55 GoSliceHeaderType []string
         - Name: otherValues
           Offset: 296
-          Type: 65 GoMapType map[string]string
+          Type: 67 GoMapType map[string]string
     - __kind: StructureType
-      ID: 61
+      ID: 63
       Name: net/http.Response
       ByteSize: 144
       GoRuntimeType: 2.195808e+06
@@ -2032,16 +2014,16 @@ Types:
           Type: 7 BaseType int
         - Name: Header
           Offset: 56
-          Type: 46 GoMapType net/http.Header
+          Type: 48 GoMapType net/http.Header
         - Name: Body
           Offset: 64
-          Type: 51 GoInterfaceType io.ReadCloser
+          Type: 53 GoInterfaceType io.ReadCloser
         - Name: ContentLength
           Offset: 80
           Type: 12 BaseType int64
         - Name: TransferEncoding
           Offset: 88
-          Type: 53 GoSliceHeaderType []string
+          Type: 55 GoSliceHeaderType []string
         - Name: Close
           Offset: 112
           Type: 4 BaseType bool
@@ -2050,13 +2032,13 @@ Types:
           Type: 4 BaseType bool
         - Name: Trailer
           Offset: 120
-          Type: 46 GoMapType net/http.Header
+          Type: 48 GoMapType net/http.Header
         - Name: Request
           Offset: 128
           Type: 37 PointerType *net/http.Request
         - Name: TLS
           Offset: 136
-          Type: 57 PointerType *crypto/tls.ConnectionState
+          Type: 59 PointerType *crypto/tls.ConnectionState
     - __kind: GoInterfaceType
       ID: 36
       Name: net/http.ResponseWriter
@@ -2071,7 +2053,7 @@ Types:
           Offset: 8
           Type: 14 VoidPointerType unsafe.Pointer
     - __kind: StructureType
-      ID: 64
+      ID: 66
       Name: net/http.pattern
       ByteSize: 88
       GoRuntimeType: 1.818656e+06
@@ -2088,12 +2070,12 @@ Types:
           Type: 9 GoStringHeaderType string
         - Name: segments
           Offset: 48
-          Type: 92 GoSliceHeaderType []net/http.segment
+          Type: 201 GoSliceHeaderType []net/http.segment
         - Name: loc
           Offset: 72
           Type: 9 GoStringHeaderType string
     - __kind: StructureType
-      ID: 94
+      ID: 203
       Name: net/http.segment
       ByteSize: 24
       GoRuntimeType: 1.59776e+06
@@ -2109,14 +2091,14 @@ Types:
           Offset: 17
           Type: 4 BaseType bool
     - __kind: GoMapType
-      ID: 183
+      ID: 104
       Name: net/textproto.MIMEHeader
       ByteSize: 8
       GoRuntimeType: 1.808832e+06
       GoKind: 21
-      HeaderType: 48 GoSwissMapHeaderType map<string,[]string>
+      HeaderType: 50 GoSwissMapHeaderType map<string,[]string>
     - __kind: StructureType
-      ID: 45
+      ID: 47
       Name: net/url.URL
       ByteSize: 144
       GoRuntimeType: 2.113024e+06
@@ -2130,7 +2112,7 @@ Types:
           Type: 9 GoStringHeaderType string
         - Name: User
           Offset: 32
-          Type: 74 PointerType *net/url.Userinfo
+          Type: 72 PointerType *net/url.Userinfo
         - Name: Host
           Offset: 40
           Type: 9 GoStringHeaderType string
@@ -2156,7 +2138,7 @@ Types:
           Offset: 128
           Type: 9 GoStringHeaderType string
     - __kind: StructureType
-      ID: 75
+      ID: 73
       Name: net/url.Userinfo
       ByteSize: 40
       GoRuntimeType: 1.61408e+06
@@ -2172,41 +2154,41 @@ Types:
           Offset: 32
           Type: 4 BaseType bool
     - __kind: GoMapType
-      ID: 54
+      ID: 56
       Name: net/url.Values
       ByteSize: 8
       GoRuntimeType: 1.871296e+06
       GoKind: 21
-      HeaderType: 48 GoSwissMapHeaderType map<string,[]string>
+      HeaderType: 50 GoSwissMapHeaderType map<string,[]string>
     - __kind: ArrayType
-      ID: 119
+      ID: 94
       Name: noalg.[8]struct { key string; elem []*mime/multipart.FileHeader }
       ByteSize: 320
       GoRuntimeType: 694016
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 120 StructureType noalg.struct { key string; elem []*mime/multipart.FileHeader }
+      Element: 95 StructureType noalg.struct { key string; elem []*mime/multipart.FileHeader }
     - __kind: ArrayType
-      ID: 99
+      ID: 78
       Name: noalg.[8]struct { key string; elem []string }
       ByteSize: 320
       GoRuntimeType: 684000
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 100 StructureType noalg.struct { key string; elem []string }
+      Element: 79 StructureType noalg.struct { key string; elem []string }
     - __kind: ArrayType
-      ID: 108
+      ID: 210
       Name: noalg.[8]struct { key string; elem string }
       ByteSize: 256
       GoRuntimeType: 688160
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 109 StructureType noalg.struct { key string; elem string }
+      Element: 211 StructureType noalg.struct { key string; elem string }
     - __kind: StructureType
-      ID: 118
+      ID: 93
       Name: noalg.map.group[string][]*mime/multipart.FileHeader
       ByteSize: 328
       GoRuntimeType: 1.290528e+06
@@ -2217,9 +2199,9 @@ Types:
           Type: 8 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 119 ArrayType noalg.[8]struct { key string; elem []*mime/multipart.FileHeader }
+          Type: 94 ArrayType noalg.[8]struct { key string; elem []*mime/multipart.FileHeader }
     - __kind: StructureType
-      ID: 98
+      ID: 77
       Name: noalg.map.group[string][]string
       ByteSize: 328
       GoRuntimeType: 1.281056e+06
@@ -2230,9 +2212,9 @@ Types:
           Type: 8 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 99 ArrayType noalg.[8]struct { key string; elem []string }
+          Type: 78 ArrayType noalg.[8]struct { key string; elem []string }
     - __kind: StructureType
-      ID: 107
+      ID: 209
       Name: noalg.map.group[string]string
       ByteSize: 264
       GoRuntimeType: 1.28336e+06
@@ -2243,9 +2225,9 @@ Types:
           Type: 8 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 108 ArrayType noalg.[8]struct { key string; elem string }
+          Type: 210 ArrayType noalg.[8]struct { key string; elem string }
     - __kind: StructureType
-      ID: 120
+      ID: 95
       Name: noalg.struct { key string; elem []*mime/multipart.FileHeader }
       ByteSize: 40
       GoRuntimeType: 1.2904e+06
@@ -2256,9 +2238,9 @@ Types:
           Type: 9 GoStringHeaderType string
         - Name: elem
           Offset: 16
-          Type: 121 GoSliceHeaderType []*mime/multipart.FileHeader
+          Type: 96 GoSliceHeaderType []*mime/multipart.FileHeader
     - __kind: StructureType
-      ID: 100
+      ID: 79
       Name: noalg.struct { key string; elem []string }
       ByteSize: 40
       GoRuntimeType: 1.280928e+06
@@ -2269,9 +2251,9 @@ Types:
           Type: 9 GoStringHeaderType string
         - Name: elem
           Offset: 16
-          Type: 53 GoSliceHeaderType []string
+          Type: 55 GoSliceHeaderType []string
     - __kind: StructureType
-      ID: 109
+      ID: 211
       Name: noalg.struct { key string; elem string }
       ByteSize: 32
       GoRuntimeType: 1.283232e+06
@@ -2292,17 +2274,17 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 73 PointerType *string.str
+          Type: 45 PointerType *string.str
         - Name: len
           Offset: 8
           Type: 7 BaseType int
-      Data: 72 GoStringDataType string.str
+      Data: 44 GoStringDataType string.str
     - __kind: GoStringDataType
-      ID: 72
+      ID: 44
       Name: string.str
       ByteSize: 2048
     - __kind: StructureType
-      ID: 114
+      ID: 90
       Name: table<string,[]*mime/multipart.FileHeader>
       ByteSize: 32
       GoKind: 25
@@ -2324,9 +2306,9 @@ Types:
           Type: 7 BaseType int
         - Name: groups
           Offset: 16
-          Type: 116 GoSwissMapGroupsType groupReference<string,[]*mime/multipart.FileHeader>
+          Type: 91 GoSwissMapGroupsType groupReference<string,[]*mime/multipart.FileHeader>
     - __kind: StructureType
-      ID: 76
+      ID: 74
       Name: table<string,[]string>
       ByteSize: 32
       GoKind: 25
@@ -2348,9 +2330,9 @@ Types:
           Type: 7 BaseType int
         - Name: groups
           Offset: 16
-          Type: 96 GoSwissMapGroupsType groupReference<string,[]string>
+          Type: 75 GoSwissMapGroupsType groupReference<string,[]string>
     - __kind: StructureType
-      ID: 95
+      ID: 206
       Name: table<string,string>
       ByteSize: 32
       GoKind: 25
@@ -2372,9 +2354,9 @@ Types:
           Type: 7 BaseType int
         - Name: groups
           Offset: 16
-          Type: 105 GoSwissMapGroupsType groupReference<string,string>
+          Type: 207 GoSwissMapGroupsType groupReference<string,string>
     - __kind: StructureType
-      ID: 145
+      ID: 135
       Name: time.Location
       ByteSize: 104
       GoRuntimeType: 1.958592e+06
@@ -2385,10 +2367,10 @@ Types:
           Type: 9 GoStringHeaderType string
         - Name: zone
           Offset: 16
-          Type: 176 GoSliceHeaderType []time.zone
+          Type: 167 GoSliceHeaderType []time.zone
         - Name: tx
           Offset: 40
-          Type: 179 GoSliceHeaderType []time.zoneTrans
+          Type: 170 GoSliceHeaderType []time.zoneTrans
         - Name: extend
           Offset: 64
           Type: 9 GoStringHeaderType string
@@ -2400,9 +2382,9 @@ Types:
           Type: 12 BaseType int64
         - Name: cacheZone
           Offset: 96
-          Type: 177 PointerType *time.zone
+          Type: 168 PointerType *time.zone
     - __kind: StructureType
-      ID: 143
+      ID: 133
       Name: time.Time
       ByteSize: 24
       GoRuntimeType: 2.349088e+06
@@ -2416,9 +2398,9 @@ Types:
           Type: 12 BaseType int64
         - Name: loc
           Offset: 16
-          Type: 144 PointerType *time.Location
+          Type: 134 PointerType *time.Location
     - __kind: StructureType
-      ID: 178
+      ID: 169
       Name: time.zone
       ByteSize: 32
       GoRuntimeType: 1.602752e+06
@@ -2434,7 +2416,7 @@ Types:
           Offset: 24
           Type: 4 BaseType bool
     - __kind: StructureType
-      ID: 181
+      ID: 172
       Name: time.zoneTrans
       ByteSize: 16
       GoRuntimeType: 1.73712e+06
@@ -2494,6 +2476,6 @@ Types:
       ByteSize: 8
       GoRuntimeType: 580736
       GoKind: 26
-MaxTypeID: 216
+MaxTypeID: 215
 Issues: []
 GoModuledataInfo: {FirstModuledataAddr: "0x181b800", TypesOffset: 296}

--- a/pkg/dyninst/irgen/testdata/snapshot/rc_tester_v1.arch=amd64,toolchain=go1.24.3.yaml
+++ b/pkg/dyninst/irgen/testdata/snapshot/rc_tester_v1.arch=amd64,toolchain=go1.24.3.yaml
@@ -33,7 +33,7 @@ Subprograms:
       InlinePCRanges: []
       Variables:
         - Name: w
-          Type: 1 GoInterfaceType net/http.ResponseWriter
+          Type: 36 GoInterfaceType net/http.ResponseWriter
           Locations:
             - Range: 0xcfc640..0xcfc6ac
               Pieces:
@@ -56,7 +56,7 @@ Subprograms:
           IsParameter: true
           IsReturn: false
         - Name: r
-          Type: 3 PointerType *net/http.Request
+          Type: 37 PointerType *net/http.Request
           Locations:
             - Range: 0xcfc640..0xcfc6b6
               Pieces: [{Size: 8, Op: {RegNo: 2, Shift: 0}}]
@@ -65,7 +65,7 @@ Subprograms:
           IsParameter: true
           IsReturn: false
         - Name: '&buf'
-          Type: 134 PointerType *bytes.Buffer
+          Type: 157 PointerType *bytes.Buffer
           Locations:
             - Range: 0xcfc7ee..0xcfc809
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
@@ -74,7 +74,7 @@ Subprograms:
           IsParameter: false
           IsReturn: false
         - Name: span
-          Type: 137 GoInterfaceType gopkg.in/DataDog/dd-trace-go.v1/ddtrace.Span
+          Type: 160 GoInterfaceType gopkg.in/DataDog/dd-trace-go.v1/ddtrace.Span
           Locations:
             - Range: 0xcfc6c8..0xcfc6c8
               Pieces:
@@ -97,7 +97,7 @@ Subprograms:
           IsParameter: false
           IsReturn: false
         - Name: .autotmp_14
-          Type: 138 StructureType context.backgroundCtx
+          Type: 161 StructureType context.backgroundCtx
           Locations:
             - Range: 0xcfc640..0xcfc8f0
               Pieces: [{Size: 0, Op: {CfaOffset: 0}}]
@@ -109,7 +109,7 @@ Subprograms:
       InlinePCRanges: []
       Variables:
         - Name: path
-          Type: 5 GoStringHeaderType string
+          Type: 9 GoStringHeaderType string
           Locations:
             - Range: 0xcfc9c0..0xcfc9e5
               Pieces:
@@ -121,50 +121,50 @@ Subprograms:
           IsReturn: false
 Types:
     - __kind: PointerType
-      ID: 57
+      ID: 81
       Name: '**crypto/x509.Certificate'
       ByteSize: 8
       GoKind: 22
-      Pointee: 58 PointerType *crypto/x509.Certificate
+      Pointee: 82 PointerType *crypto/x509.Certificate
     - __kind: PointerType
-      ID: 49
+      ID: 73
       Name: '**mime/multipart.FileHeader'
       ByteSize: 8
       GoKind: 22
-      Pointee: 50 PointerType *mime/multipart.FileHeader
+      Pointee: 74 PointerType *mime/multipart.FileHeader
     - __kind: PointerType
-      ID: 98
+      ID: 121
       Name: '**net.IPNet'
       ByteSize: 8
       GoKind: 22
-      Pointee: 99 PointerType *net.IPNet
+      Pointee: 122 PointerType *net.IPNet
     - __kind: PointerType
-      ID: 96
+      ID: 119
       Name: '**net/url.URL'
       ByteSize: 8
       GoKind: 22
-      Pointee: 9 PointerType *net/url.URL
+      Pointee: 39 PointerType *net/url.URL
     - __kind: PointerType
-      ID: 40
+      ID: 64
       Name: '**table<string,[]*mime/multipart.FileHeader>'
       ByteSize: 8
-      Pointee: 41 PointerType *table<string,[]*mime/multipart.FileHeader>
+      Pointee: 65 PointerType *table<string,[]*mime/multipart.FileHeader>
     - __kind: PointerType
-      ID: 19
+      ID: 46
       Name: '**table<string,[]string>'
       ByteSize: 8
-      Pointee: 20 PointerType *table<string,[]string>
+      Pointee: 47 PointerType *table<string,[]string>
     - __kind: PointerType
-      ID: 126
+      ID: 149
       Name: '**table<string,string>'
       ByteSize: 8
-      Pointee: 127 PointerType *table<string,string>
+      Pointee: 150 PointerType *table<string,string>
     - __kind: PointerType
-      ID: 109
+      ID: 132
       Name: '*[]*crypto/x509.Certificate'
       ByteSize: 8
       GoKind: 22
-      Pointee: 56 GoSliceHeaderType []*crypto/x509.Certificate
+      Pointee: 80 GoSliceHeaderType []*crypto/x509.Certificate
     - __kind: PointerType
       ID: 176
       Name: '*[]*crypto/x509.Certificate.array'
@@ -251,203 +251,203 @@ Types:
       ByteSize: 8
       Pointee: 185 GoSliceDataType []time.zoneTrans.array
     - __kind: PointerType
-      ID: 111
+      ID: 134
       Name: '*[]uint8'
       ByteSize: 8
       GoRuntimeType: 478304
       GoKind: 22
-      Pointee: 53 GoSliceHeaderType []uint8
+      Pointee: 77 GoSliceHeaderType []uint8
     - __kind: PointerType
       ID: 174
       Name: '*[]uint8.array'
       ByteSize: 8
       Pointee: 173 GoSliceDataType []uint8.array
     - __kind: PointerType
-      ID: 142
+      ID: 11
       Name: '*bool'
       ByteSize: 8
       GoRuntimeType: 397280
       GoKind: 22
-      Pointee: 13 BaseType bool
+      Pointee: 4 BaseType bool
     - __kind: PointerType
-      ID: 134
+      ID: 157
       Name: '*bytes.Buffer'
       ByteSize: 8
       GoRuntimeType: 2.245824e+06
       GoKind: 22
-      Pointee: 135 StructureType bytes.Buffer
+      Pointee: 158 StructureType bytes.Buffer
     - __kind: PointerType
-      ID: 54
+      ID: 78
       Name: '*crypto/tls.ConnectionState'
       ByteSize: 8
       GoRuntimeType: 901472
       GoKind: 22
-      Pointee: 55 StructureType crypto/tls.ConnectionState
+      Pointee: 79 StructureType crypto/tls.ConnectionState
     - __kind: PointerType
-      ID: 58
+      ID: 82
       Name: '*crypto/x509.Certificate'
       ByteSize: 8
       GoRuntimeType: 2.031072e+06
       GoKind: 22
-      Pointee: 59 StructureType crypto/x509.Certificate
+      Pointee: 83 StructureType crypto/x509.Certificate
     - __kind: PointerType
-      ID: 90
+      ID: 113
       Name: '*crypto/x509.ExtKeyUsage'
       ByteSize: 8
       GoRuntimeType: 420256
       GoKind: 22
-      Pointee: 91 BaseType crypto/x509.ExtKeyUsage
+      Pointee: 114 BaseType crypto/x509.ExtKeyUsage
     - __kind: PointerType
-      ID: 103
+      ID: 126
       Name: '*crypto/x509.OID'
       ByteSize: 8
       GoRuntimeType: 1.938912e+06
       GoKind: 22
-      Pointee: 104 StructureType crypto/x509.OID
+      Pointee: 127 StructureType crypto/x509.OID
     - __kind: PointerType
-      ID: 106
+      ID: 129
       Name: '*crypto/x509.PolicyMapping'
       ByteSize: 8
       GoRuntimeType: 420320
       GoKind: 22
-      Pointee: 107 StructureType crypto/x509.PolicyMapping
+      Pointee: 130 StructureType crypto/x509.PolicyMapping
     - __kind: PointerType
-      ID: 70
+      ID: 94
       Name: '*crypto/x509/pkix.AttributeTypeAndValue'
       ByteSize: 8
       GoRuntimeType: 434080
       GoKind: 22
-      Pointee: 71 StructureType crypto/x509/pkix.AttributeTypeAndValue
+      Pointee: 95 StructureType crypto/x509/pkix.AttributeTypeAndValue
     - __kind: PointerType
-      ID: 85
+      ID: 108
       Name: '*crypto/x509/pkix.Extension'
       ByteSize: 8
       GoRuntimeType: 434272
       GoKind: 22
-      Pointee: 86 StructureType crypto/x509/pkix.Extension
+      Pointee: 109 StructureType crypto/x509/pkix.Extension
     - __kind: PointerType
-      ID: 88
+      ID: 111
       Name: '*encoding/asn1.ObjectIdentifier'
       ByteSize: 8
       GoRuntimeType: 1.044704e+06
       GoKind: 22
-      Pointee: 72 GoSliceHeaderType encoding/asn1.ObjectIdentifier
+      Pointee: 96 GoSliceHeaderType encoding/asn1.ObjectIdentifier
     - __kind: PointerType
       ID: 182
       Name: '*encoding/asn1.ObjectIdentifier.array'
       ByteSize: 8
       Pointee: 181 GoSliceDataType encoding/asn1.ObjectIdentifier.array
     - __kind: PointerType
-      ID: 160
+      ID: 33
       Name: '*error'
       ByteSize: 8
       GoRuntimeType: 396192
       GoKind: 22
-      Pointee: 143 GoInterfaceType error
+      Pointee: 13 GoInterfaceType error
     - __kind: PointerType
-      ID: 162
+      ID: 35
       Name: '*float32'
       ByteSize: 8
       GoRuntimeType: 397152
       GoKind: 22
-      Pointee: 146 BaseType float32
+      Pointee: 17 BaseType float32
     - __kind: PointerType
-      ID: 153
+      ID: 25
       Name: '*float64'
       ByteSize: 8
       GoRuntimeType: 397216
       GoKind: 22
-      Pointee: 147 BaseType float64
+      Pointee: 18 BaseType float64
     - __kind: PointerType
-      ID: 73
+      ID: 27
       Name: '*int'
       ByteSize: 8
       GoRuntimeType: 396832
       GoKind: 22
-      Pointee: 8 BaseType int
+      Pointee: 7 BaseType int
     - __kind: PointerType
-      ID: 157
+      ID: 30
       Name: '*int16'
       ByteSize: 8
       GoRuntimeType: 396448
       GoKind: 22
-      Pointee: 158 BaseType int16
+      Pointee: 31 BaseType int16
     - __kind: PointerType
-      ID: 149
+      ID: 20
       Name: '*int32'
       ByteSize: 8
       GoRuntimeType: 396576
       GoKind: 22
-      Pointee: 141 BaseType int32
+      Pointee: 10 BaseType int32
     - __kind: PointerType
-      ID: 154
+      ID: 26
       Name: '*int64'
       ByteSize: 8
       GoRuntimeType: 396704
       GoKind: 22
-      Pointee: 32 BaseType int64
+      Pointee: 12 BaseType int64
     - __kind: PointerType
-      ID: 159
+      ID: 32
       Name: '*int8'
       ByteSize: 8
       GoRuntimeType: 396320
       GoKind: 22
-      Pointee: 144 BaseType int8
+      Pointee: 15 BaseType int8
     - __kind: PointerType
-      ID: 38
+      ID: 62
       Name: '*map<string,[]*mime/multipart.FileHeader>'
       ByteSize: 8
-      Pointee: 39 GoSwissMapHeaderType map<string,[]*mime/multipart.FileHeader>
+      Pointee: 63 GoSwissMapHeaderType map<string,[]*mime/multipart.FileHeader>
     - __kind: PointerType
-      ID: 15
+      ID: 44
       Name: '*map<string,[]string>'
       ByteSize: 8
-      Pointee: 16 GoSwissMapHeaderType map<string,[]string>
+      Pointee: 45 GoSwissMapHeaderType map<string,[]string>
     - __kind: PointerType
-      ID: 124
+      ID: 147
       Name: '*map<string,string>'
       ByteSize: 8
-      Pointee: 125 GoSwissMapHeaderType map<string,string>
+      Pointee: 148 GoSwissMapHeaderType map<string,string>
     - __kind: PointerType
-      ID: 63
+      ID: 87
       Name: '*math/big.Int'
       ByteSize: 8
       GoRuntimeType: 2.365472e+06
       GoKind: 22
-      Pointee: 64 StructureType math/big.Int
+      Pointee: 88 StructureType math/big.Int
     - __kind: PointerType
-      ID: 66
+      ID: 90
       Name: '*math/big.Word'
       ByteSize: 8
       GoRuntimeType: 423200
       GoKind: 22
-      Pointee: 67 BaseType math/big.Word
+      Pointee: 91 BaseType math/big.Word
     - __kind: PointerType
       ID: 178
       Name: '*math/big.nat.array'
       ByteSize: 8
       Pointee: 177 GoSliceDataType math/big.nat.array
     - __kind: PointerType
-      ID: 50
+      ID: 74
       Name: '*mime/multipart.FileHeader'
       ByteSize: 8
       GoRuntimeType: 902912
       GoKind: 22
-      Pointee: 51 StructureType mime/multipart.FileHeader
+      Pointee: 75 StructureType mime/multipart.FileHeader
     - __kind: PointerType
-      ID: 34
+      ID: 58
       Name: '*mime/multipart.Form'
       ByteSize: 8
       GoRuntimeType: 903008
       GoKind: 22
-      Pointee: 35 StructureType mime/multipart.Form
+      Pointee: 59 StructureType mime/multipart.Form
     - __kind: PointerType
-      ID: 93
+      ID: 116
       Name: '*net.IP'
       ByteSize: 8
       GoRuntimeType: 2.13488e+06
       GoKind: 22
-      Pointee: 94 GoSliceHeaderType net.IP
+      Pointee: 117 GoSliceHeaderType net.IP
     - __kind: PointerType
       ID: 196
       Name: '*net.IP.array'
@@ -459,161 +459,161 @@ Types:
       ByteSize: 8
       Pointee: 201 GoSliceDataType net.IPMask.array
     - __kind: PointerType
-      ID: 99
+      ID: 122
       Name: '*net.IPNet'
       ByteSize: 8
       GoRuntimeType: 1.174624e+06
       GoKind: 22
-      Pointee: 100 StructureType net.IPNet
+      Pointee: 123 StructureType net.IPNet
     - __kind: PointerType
-      ID: 3
+      ID: 37
       Name: '*net/http.Request'
       ByteSize: 8
       GoRuntimeType: 2.285568e+06
       GoKind: 22
-      Pointee: 4 StructureType net/http.Request
+      Pointee: 38 StructureType net/http.Request
     - __kind: PointerType
-      ID: 115
+      ID: 138
       Name: '*net/http.Response'
       ByteSize: 8
       GoRuntimeType: 1.706048e+06
       GoKind: 22
-      Pointee: 116 StructureType net/http.Response
+      Pointee: 139 StructureType net/http.Response
     - __kind: PointerType
-      ID: 118
+      ID: 141
       Name: '*net/http.pattern'
       ByteSize: 8
       GoRuntimeType: 1.597952e+06
       GoKind: 22
-      Pointee: 119 StructureType net/http.pattern
+      Pointee: 142 StructureType net/http.pattern
     - __kind: PointerType
-      ID: 121
+      ID: 144
       Name: '*net/http.segment'
       ByteSize: 8
       GoRuntimeType: 388640
       GoKind: 22
-      Pointee: 122 StructureType net/http.segment
+      Pointee: 145 StructureType net/http.segment
     - __kind: PointerType
-      ID: 9
+      ID: 39
       Name: '*net/url.URL'
       ByteSize: 8
       GoRuntimeType: 2.100096e+06
       GoKind: 22
-      Pointee: 10 StructureType net/url.URL
+      Pointee: 40 StructureType net/url.URL
     - __kind: PointerType
-      ID: 11
+      ID: 41
       Name: '*net/url.Userinfo'
       ByteSize: 8
       GoRuntimeType: 1.19216e+06
       GoKind: 22
-      Pointee: 12 StructureType net/url.Userinfo
+      Pointee: 42 StructureType net/url.Userinfo
     - __kind: PointerType
-      ID: 44
+      ID: 68
       Name: '*noalg.map.group[string][]*mime/multipart.FileHeader'
       ByteSize: 8
-      Pointee: 45 StructureType noalg.map.group[string][]*mime/multipart.FileHeader
+      Pointee: 69 StructureType noalg.map.group[string][]*mime/multipart.FileHeader
     - __kind: PointerType
-      ID: 24
+      ID: 50
       Name: '*noalg.map.group[string][]string'
       ByteSize: 8
-      Pointee: 25 StructureType noalg.map.group[string][]string
+      Pointee: 51 StructureType noalg.map.group[string][]string
     - __kind: PointerType
-      ID: 130
+      ID: 153
       Name: '*noalg.map.group[string]string'
       ByteSize: 8
-      Pointee: 131 StructureType noalg.map.group[string]string
+      Pointee: 154 StructureType noalg.map.group[string]string
     - __kind: PointerType
-      ID: 29
+      ID: 22
       Name: '*string'
       ByteSize: 8
       GoRuntimeType: 396256
       GoKind: 22
-      Pointee: 5 GoStringHeaderType string
+      Pointee: 9 GoStringHeaderType string
     - __kind: PointerType
       ID: 164
       Name: '*string.str'
       ByteSize: 8
       Pointee: 163 GoStringDataType string.str
     - __kind: PointerType
-      ID: 41
+      ID: 65
       Name: '*table<string,[]*mime/multipart.FileHeader>'
       ByteSize: 8
-      Pointee: 42 StructureType table<string,[]*mime/multipart.FileHeader>
+      Pointee: 66 StructureType table<string,[]*mime/multipart.FileHeader>
     - __kind: PointerType
-      ID: 20
+      ID: 47
       Name: '*table<string,[]string>'
       ByteSize: 8
-      Pointee: 21 StructureType table<string,[]string>
+      Pointee: 48 StructureType table<string,[]string>
     - __kind: PointerType
-      ID: 127
+      ID: 150
       Name: '*table<string,string>'
       ByteSize: 8
-      Pointee: 128 StructureType table<string,string>
+      Pointee: 151 StructureType table<string,string>
     - __kind: PointerType
-      ID: 75
+      ID: 98
       Name: '*time.Location'
       ByteSize: 8
       GoRuntimeType: 1.602944e+06
       GoKind: 22
-      Pointee: 76 StructureType time.Location
+      Pointee: 99 StructureType time.Location
     - __kind: PointerType
-      ID: 78
+      ID: 101
       Name: '*time.zone'
       ByteSize: 8
       GoRuntimeType: 391776
       GoKind: 22
-      Pointee: 79 StructureType time.zone
+      Pointee: 102 StructureType time.zone
     - __kind: PointerType
-      ID: 81
+      ID: 104
       Name: '*time.zoneTrans'
       ByteSize: 8
       GoRuntimeType: 391840
       GoKind: 22
-      Pointee: 82 StructureType time.zoneTrans
+      Pointee: 105 StructureType time.zoneTrans
     - __kind: PointerType
-      ID: 161
+      ID: 34
       Name: '*uint'
       ByteSize: 8
       GoRuntimeType: 396896
       GoKind: 22
-      Pointee: 145 BaseType uint
+      Pointee: 16 BaseType uint
     - __kind: PointerType
-      ID: 156
+      ID: 29
       Name: '*uint16'
       ByteSize: 8
       GoRuntimeType: 396512
       GoKind: 22
-      Pointee: 22 BaseType uint16
+      Pointee: 6 BaseType uint16
     - __kind: PointerType
-      ID: 150
+      ID: 21
       Name: '*uint32'
       ByteSize: 8
       GoRuntimeType: 396640
       GoKind: 22
-      Pointee: 140 BaseType uint32
+      Pointee: 2 BaseType uint32
     - __kind: PointerType
-      ID: 155
+      ID: 28
       Name: '*uint64'
       ByteSize: 8
       GoRuntimeType: 396768
       GoKind: 22
-      Pointee: 17 BaseType uint64
+      Pointee: 8 BaseType uint64
     - __kind: PointerType
-      ID: 6
+      ID: 5
       Name: '*uint8'
       ByteSize: 8
       GoRuntimeType: 396384
       GoKind: 22
-      Pointee: 7 BaseType uint8
+      Pointee: 3 BaseType uint8
     - __kind: PointerType
-      ID: 148
+      ID: 19
       Name: '*uintptr'
       ByteSize: 8
       GoRuntimeType: 396960
       GoKind: 22
-      Pointee: 18 BaseType uintptr
+      Pointee: 1 BaseType uintptr
     - __kind: GoChannelType
-      ID: 114
+      ID: 137
       Name: <-chan struct {}
       GoRuntimeType: 592896
       GoKind: 18
@@ -626,7 +626,7 @@ Types:
         - Name: w
           Offset: 1
           Expression:
-            Type: 1 GoInterfaceType net/http.ResponseWriter
+            Type: 36 GoInterfaceType net/http.ResponseWriter
             Operations:
                 - __kind: LocationOp
                   Variable: {subprogram: 1, index: 0, name: w}
@@ -635,7 +635,7 @@ Types:
         - Name: r
           Offset: 17
           Expression:
-            Type: 3 PointerType *net/http.Request
+            Type: 37 PointerType *net/http.Request
             Operations:
                 - __kind: LocationOp
                   Variable: {subprogram: 1, index: 1, name: r}
@@ -650,14 +650,14 @@ Types:
         - Name: path
           Offset: 1
           Expression:
-            Type: 5 GoStringHeaderType string
+            Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
                   Variable: {subprogram: 2, index: 0, name: path}
                   Offset: 0
                   ByteSize: 16
     - __kind: GoSliceHeaderType
-      ID: 56
+      ID: 80
       Name: '[]*crypto/x509.Certificate'
       ByteSize: 24
       GoRuntimeType: 498464
@@ -665,21 +665,21 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 57 PointerType **crypto/x509.Certificate
+          Type: 81 PointerType **crypto/x509.Certificate
         - Name: len
           Offset: 8
-          Type: 8 BaseType int
+          Type: 7 BaseType int
         - Name: cap
           Offset: 16
-          Type: 8 BaseType int
+          Type: 7 BaseType int
       Data: 175 GoSliceDataType []*crypto/x509.Certificate.array
     - __kind: GoSliceDataType
       ID: 175
       Name: '[]*crypto/x509.Certificate.array'
       ByteSize: 2048
-      Element: 58 PointerType *crypto/x509.Certificate
+      Element: 82 PointerType *crypto/x509.Certificate
     - __kind: GoSliceHeaderType
-      ID: 48
+      ID: 72
       Name: '[]*mime/multipart.FileHeader'
       ByteSize: 24
       GoRuntimeType: 483904
@@ -687,21 +687,21 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 49 PointerType **mime/multipart.FileHeader
+          Type: 73 PointerType **mime/multipart.FileHeader
         - Name: len
           Offset: 8
-          Type: 8 BaseType int
+          Type: 7 BaseType int
         - Name: cap
           Offset: 16
-          Type: 8 BaseType int
+          Type: 7 BaseType int
       Data: 171 GoSliceDataType []*mime/multipart.FileHeader.array
     - __kind: GoSliceDataType
       ID: 171
       Name: '[]*mime/multipart.FileHeader.array'
       ByteSize: 2048
-      Element: 50 PointerType *mime/multipart.FileHeader
+      Element: 74 PointerType *mime/multipart.FileHeader
     - __kind: GoSliceHeaderType
-      ID: 97
+      ID: 120
       Name: '[]*net.IPNet'
       ByteSize: 24
       GoRuntimeType: 512000
@@ -709,21 +709,21 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 98 PointerType **net.IPNet
+          Type: 121 PointerType **net.IPNet
         - Name: len
           Offset: 8
-          Type: 8 BaseType int
+          Type: 7 BaseType int
         - Name: cap
           Offset: 16
-          Type: 8 BaseType int
+          Type: 7 BaseType int
       Data: 199 GoSliceDataType []*net.IPNet.array
     - __kind: GoSliceDataType
       ID: 199
       Name: '[]*net.IPNet.array'
       ByteSize: 2048
-      Element: 99 PointerType *net.IPNet
+      Element: 122 PointerType *net.IPNet
     - __kind: GoSliceHeaderType
-      ID: 95
+      ID: 118
       Name: '[]*net/url.URL'
       ByteSize: 24
       GoRuntimeType: 511936
@@ -731,36 +731,36 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 96 PointerType **net/url.URL
+          Type: 119 PointerType **net/url.URL
         - Name: len
           Offset: 8
-          Type: 8 BaseType int
+          Type: 7 BaseType int
         - Name: cap
           Offset: 16
-          Type: 8 BaseType int
+          Type: 7 BaseType int
       Data: 197 GoSliceDataType []*net/url.URL.array
     - __kind: GoSliceDataType
       ID: 197
       Name: '[]*net/url.URL.array'
       ByteSize: 2048
-      Element: 9 PointerType *net/url.URL
+      Element: 39 PointerType *net/url.URL
     - __kind: GoSliceDataType
       ID: 169
       Name: '[]*table<string,[]*mime/multipart.FileHeader>.array'
       ByteSize: 8192
-      Element: 41 PointerType *table<string,[]*mime/multipart.FileHeader>
+      Element: 65 PointerType *table<string,[]*mime/multipart.FileHeader>
     - __kind: GoSliceDataType
       ID: 165
       Name: '[]*table<string,[]string>.array'
       ByteSize: 8192
-      Element: 20 PointerType *table<string,[]string>
+      Element: 47 PointerType *table<string,[]string>
     - __kind: GoSliceDataType
       ID: 213
       Name: '[]*table<string,string>.array'
       ByteSize: 8192
-      Element: 127 PointerType *table<string,string>
+      Element: 150 PointerType *table<string,string>
     - __kind: GoSliceHeaderType
-      ID: 108
+      ID: 131
       Name: '[][]*crypto/x509.Certificate'
       ByteSize: 24
       GoRuntimeType: 498592
@@ -768,21 +768,21 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 109 PointerType *[]*crypto/x509.Certificate
+          Type: 132 PointerType *[]*crypto/x509.Certificate
         - Name: len
           Offset: 8
-          Type: 8 BaseType int
+          Type: 7 BaseType int
         - Name: cap
           Offset: 16
-          Type: 8 BaseType int
+          Type: 7 BaseType int
       Data: 207 GoSliceDataType [][]*crypto/x509.Certificate.array
     - __kind: GoSliceDataType
       ID: 207
       Name: '[][]*crypto/x509.Certificate.array'
       ByteSize: 2048
-      Element: 56 GoSliceHeaderType []*crypto/x509.Certificate
+      Element: 80 GoSliceHeaderType []*crypto/x509.Certificate
     - __kind: GoSliceHeaderType
-      ID: 110
+      ID: 133
       Name: '[][]uint8'
       ByteSize: 24
       GoRuntimeType: 478688
@@ -790,21 +790,21 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 111 PointerType *[]uint8
+          Type: 134 PointerType *[]uint8
         - Name: len
           Offset: 8
-          Type: 8 BaseType int
+          Type: 7 BaseType int
         - Name: cap
           Offset: 16
-          Type: 8 BaseType int
+          Type: 7 BaseType int
       Data: 209 GoSliceDataType [][]uint8.array
     - __kind: GoSliceDataType
       ID: 209
       Name: '[][]uint8.array'
       ByteSize: 2048
-      Element: 53 GoSliceHeaderType []uint8
+      Element: 77 GoSliceHeaderType []uint8
     - __kind: GoSliceHeaderType
-      ID: 89
+      ID: 112
       Name: '[]crypto/x509.ExtKeyUsage'
       ByteSize: 24
       GoRuntimeType: 499936
@@ -812,21 +812,21 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 90 PointerType *crypto/x509.ExtKeyUsage
+          Type: 113 PointerType *crypto/x509.ExtKeyUsage
         - Name: len
           Offset: 8
-          Type: 8 BaseType int
+          Type: 7 BaseType int
         - Name: cap
           Offset: 16
-          Type: 8 BaseType int
+          Type: 7 BaseType int
       Data: 191 GoSliceDataType []crypto/x509.ExtKeyUsage.array
     - __kind: GoSliceDataType
       ID: 191
       Name: '[]crypto/x509.ExtKeyUsage.array'
       ByteSize: 2048
-      Element: 91 BaseType crypto/x509.ExtKeyUsage
+      Element: 114 BaseType crypto/x509.ExtKeyUsage
     - __kind: GoSliceHeaderType
-      ID: 102
+      ID: 125
       Name: '[]crypto/x509.OID'
       ByteSize: 24
       GoRuntimeType: 512064
@@ -834,21 +834,21 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 103 PointerType *crypto/x509.OID
+          Type: 126 PointerType *crypto/x509.OID
         - Name: len
           Offset: 8
-          Type: 8 BaseType int
+          Type: 7 BaseType int
         - Name: cap
           Offset: 16
-          Type: 8 BaseType int
+          Type: 7 BaseType int
       Data: 203 GoSliceDataType []crypto/x509.OID.array
     - __kind: GoSliceDataType
       ID: 203
       Name: '[]crypto/x509.OID.array'
       ByteSize: 2048
-      Element: 104 StructureType crypto/x509.OID
+      Element: 127 StructureType crypto/x509.OID
     - __kind: GoSliceHeaderType
-      ID: 105
+      ID: 128
       Name: '[]crypto/x509.PolicyMapping'
       ByteSize: 24
       GoRuntimeType: 512128
@@ -856,21 +856,21 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 106 PointerType *crypto/x509.PolicyMapping
+          Type: 129 PointerType *crypto/x509.PolicyMapping
         - Name: len
           Offset: 8
-          Type: 8 BaseType int
+          Type: 7 BaseType int
         - Name: cap
           Offset: 16
-          Type: 8 BaseType int
+          Type: 7 BaseType int
       Data: 205 GoSliceDataType []crypto/x509.PolicyMapping.array
     - __kind: GoSliceDataType
       ID: 205
       Name: '[]crypto/x509.PolicyMapping.array'
       ByteSize: 2048
-      Element: 107 StructureType crypto/x509.PolicyMapping
+      Element: 130 StructureType crypto/x509.PolicyMapping
     - __kind: GoSliceHeaderType
-      ID: 69
+      ID: 93
       Name: '[]crypto/x509/pkix.AttributeTypeAndValue'
       ByteSize: 24
       GoRuntimeType: 512576
@@ -878,21 +878,21 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 70 PointerType *crypto/x509/pkix.AttributeTypeAndValue
+          Type: 94 PointerType *crypto/x509/pkix.AttributeTypeAndValue
         - Name: len
           Offset: 8
-          Type: 8 BaseType int
+          Type: 7 BaseType int
         - Name: cap
           Offset: 16
-          Type: 8 BaseType int
+          Type: 7 BaseType int
       Data: 179 GoSliceDataType []crypto/x509/pkix.AttributeTypeAndValue.array
     - __kind: GoSliceDataType
       ID: 179
       Name: '[]crypto/x509/pkix.AttributeTypeAndValue.array'
       ByteSize: 2048
-      Element: 71 StructureType crypto/x509/pkix.AttributeTypeAndValue
+      Element: 95 StructureType crypto/x509/pkix.AttributeTypeAndValue
     - __kind: GoSliceHeaderType
-      ID: 84
+      ID: 107
       Name: '[]crypto/x509/pkix.Extension'
       ByteSize: 24
       GoRuntimeType: 511808
@@ -900,21 +900,21 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 85 PointerType *crypto/x509/pkix.Extension
+          Type: 108 PointerType *crypto/x509/pkix.Extension
         - Name: len
           Offset: 8
-          Type: 8 BaseType int
+          Type: 7 BaseType int
         - Name: cap
           Offset: 16
-          Type: 8 BaseType int
+          Type: 7 BaseType int
       Data: 187 GoSliceDataType []crypto/x509/pkix.Extension.array
     - __kind: GoSliceDataType
       ID: 187
       Name: '[]crypto/x509/pkix.Extension.array'
       ByteSize: 2048
-      Element: 86 StructureType crypto/x509/pkix.Extension
+      Element: 109 StructureType crypto/x509/pkix.Extension
     - __kind: GoSliceHeaderType
-      ID: 87
+      ID: 110
       Name: '[]encoding/asn1.ObjectIdentifier'
       ByteSize: 24
       GoRuntimeType: 511872
@@ -922,21 +922,21 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 88 PointerType *encoding/asn1.ObjectIdentifier
+          Type: 111 PointerType *encoding/asn1.ObjectIdentifier
         - Name: len
           Offset: 8
-          Type: 8 BaseType int
+          Type: 7 BaseType int
         - Name: cap
           Offset: 16
-          Type: 8 BaseType int
+          Type: 7 BaseType int
       Data: 189 GoSliceDataType []encoding/asn1.ObjectIdentifier.array
     - __kind: GoSliceDataType
       ID: 189
       Name: '[]encoding/asn1.ObjectIdentifier.array'
       ByteSize: 2048
-      Element: 72 GoSliceHeaderType encoding/asn1.ObjectIdentifier
+      Element: 96 GoSliceHeaderType encoding/asn1.ObjectIdentifier
     - __kind: GoSliceHeaderType
-      ID: 92
+      ID: 115
       Name: '[]net.IP'
       ByteSize: 24
       GoRuntimeType: 479648
@@ -944,21 +944,21 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 93 PointerType *net.IP
+          Type: 116 PointerType *net.IP
         - Name: len
           Offset: 8
-          Type: 8 BaseType int
+          Type: 7 BaseType int
         - Name: cap
           Offset: 16
-          Type: 8 BaseType int
+          Type: 7 BaseType int
       Data: 193 GoSliceDataType []net.IP.array
     - __kind: GoSliceDataType
       ID: 193
       Name: '[]net.IP.array'
       ByteSize: 2048
-      Element: 94 GoSliceHeaderType net.IP
+      Element: 117 GoSliceHeaderType net.IP
     - __kind: GoSliceHeaderType
-      ID: 120
+      ID: 143
       Name: '[]net/http.segment'
       ByteSize: 24
       GoRuntimeType: 481280
@@ -966,36 +966,36 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 121 PointerType *net/http.segment
+          Type: 144 PointerType *net/http.segment
         - Name: len
           Offset: 8
-          Type: 8 BaseType int
+          Type: 7 BaseType int
         - Name: cap
           Offset: 16
-          Type: 8 BaseType int
+          Type: 7 BaseType int
       Data: 211 GoSliceDataType []net/http.segment.array
     - __kind: GoSliceDataType
       ID: 211
       Name: '[]net/http.segment.array'
       ByteSize: 2048
-      Element: 122 StructureType net/http.segment
+      Element: 145 StructureType net/http.segment
     - __kind: GoSliceDataType
       ID: 170
       Name: '[]noalg.map.group[string][]*mime/multipart.FileHeader.array'
       ByteSize: 2048
-      Element: 45 StructureType noalg.map.group[string][]*mime/multipart.FileHeader
+      Element: 69 StructureType noalg.map.group[string][]*mime/multipart.FileHeader
     - __kind: GoSliceDataType
       ID: 166
       Name: '[]noalg.map.group[string][]string.array'
       ByteSize: 2048
-      Element: 25 StructureType noalg.map.group[string][]string
+      Element: 51 StructureType noalg.map.group[string][]string
     - __kind: GoSliceDataType
       ID: 214
       Name: '[]noalg.map.group[string]string.array'
       ByteSize: 2048
-      Element: 131 StructureType noalg.map.group[string]string
+      Element: 154 StructureType noalg.map.group[string]string
     - __kind: GoSliceHeaderType
-      ID: 28
+      ID: 54
       Name: '[]string'
       ByteSize: 24
       GoRuntimeType: 492832
@@ -1003,21 +1003,21 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 29 PointerType *string
+          Type: 22 PointerType *string
         - Name: len
           Offset: 8
-          Type: 8 BaseType int
+          Type: 7 BaseType int
         - Name: cap
           Offset: 16
-          Type: 8 BaseType int
+          Type: 7 BaseType int
       Data: 167 GoSliceDataType []string.array
     - __kind: GoSliceDataType
       ID: 167
       Name: '[]string.array'
       ByteSize: 2048
-      Element: 5 GoStringHeaderType string
+      Element: 9 GoStringHeaderType string
     - __kind: GoSliceHeaderType
-      ID: 77
+      ID: 100
       Name: '[]time.zone'
       ByteSize: 24
       GoRuntimeType: 485952
@@ -1025,21 +1025,21 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 78 PointerType *time.zone
+          Type: 101 PointerType *time.zone
         - Name: len
           Offset: 8
-          Type: 8 BaseType int
+          Type: 7 BaseType int
         - Name: cap
           Offset: 16
-          Type: 8 BaseType int
+          Type: 7 BaseType int
       Data: 183 GoSliceDataType []time.zone.array
     - __kind: GoSliceDataType
       ID: 183
       Name: '[]time.zone.array'
       ByteSize: 2048
-      Element: 79 StructureType time.zone
+      Element: 102 StructureType time.zone
     - __kind: GoSliceHeaderType
-      ID: 80
+      ID: 103
       Name: '[]time.zoneTrans'
       ByteSize: 24
       GoRuntimeType: 486016
@@ -1047,21 +1047,21 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 81 PointerType *time.zoneTrans
+          Type: 104 PointerType *time.zoneTrans
         - Name: len
           Offset: 8
-          Type: 8 BaseType int
+          Type: 7 BaseType int
         - Name: cap
           Offset: 16
-          Type: 8 BaseType int
+          Type: 7 BaseType int
       Data: 185 GoSliceDataType []time.zoneTrans.array
     - __kind: GoSliceDataType
       ID: 185
       Name: '[]time.zoneTrans.array'
       ByteSize: 2048
-      Element: 82 StructureType time.zoneTrans
+      Element: 105 StructureType time.zoneTrans
     - __kind: GoSliceHeaderType
-      ID: 53
+      ID: 77
       Name: '[]uint8'
       ByteSize: 24
       GoRuntimeType: 491680
@@ -1069,27 +1069,27 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 6 PointerType *uint8
+          Type: 5 PointerType *uint8
         - Name: len
           Offset: 8
-          Type: 8 BaseType int
+          Type: 7 BaseType int
         - Name: cap
           Offset: 16
-          Type: 8 BaseType int
+          Type: 7 BaseType int
       Data: 173 GoSliceDataType []uint8.array
     - __kind: GoSliceDataType
       ID: 173
       Name: '[]uint8.array'
       ByteSize: 2048
-      Element: 7 BaseType uint8
+      Element: 3 BaseType uint8
     - __kind: BaseType
-      ID: 13
+      ID: 4
       Name: bool
       ByteSize: 1
       GoRuntimeType: 580672
       GoKind: 1
     - __kind: StructureType
-      ID: 135
+      ID: 158
       Name: bytes.Buffer
       ByteSize: 40
       GoRuntimeType: 1.595648e+06
@@ -1097,33 +1097,33 @@ Types:
       RawFields:
         - Name: buf
           Offset: 0
-          Type: 53 GoSliceHeaderType []uint8
+          Type: 77 GoSliceHeaderType []uint8
         - Name: off
           Offset: 24
-          Type: 8 BaseType int
+          Type: 7 BaseType int
         - Name: lastRead
           Offset: 32
-          Type: 136 BaseType bytes.readOp
+          Type: 159 BaseType bytes.readOp
     - __kind: BaseType
-      ID: 136
+      ID: 159
       Name: bytes.readOp
       ByteSize: 1
       GoRuntimeType: 578816
       GoKind: 3
     - __kind: BaseType
-      ID: 152
+      ID: 24
       Name: complex128
       ByteSize: 16
       GoRuntimeType: 580480
       GoKind: 16
     - __kind: BaseType
-      ID: 151
+      ID: 23
       Name: complex64
       ByteSize: 8
       GoRuntimeType: 580416
       GoKind: 15
     - __kind: GoInterfaceType
-      ID: 117
+      ID: 140
       Name: context.Context
       ByteSize: 16
       GoRuntimeType: 1.267616e+06
@@ -1131,27 +1131,27 @@ Types:
       RawFields:
         - Name: tab
           Offset: 0
-          Type: 2 VoidPointerType unsafe.Pointer
+          Type: 14 VoidPointerType unsafe.Pointer
         - Name: data
           Offset: 8
-          Type: 2 VoidPointerType unsafe.Pointer
+          Type: 14 VoidPointerType unsafe.Pointer
     - __kind: StructureType
-      ID: 138
+      ID: 161
       Name: context.backgroundCtx
       GoRuntimeType: 1.781952e+06
       GoKind: 25
       RawFields:
         - Name: emptyCtx
           Offset: 0
-          Type: 139 StructureType context.emptyCtx
+          Type: 162 StructureType context.emptyCtx
     - __kind: StructureType
-      ID: 139
+      ID: 162
       Name: context.emptyCtx
       GoRuntimeType: 1.580704e+06
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 55
+      ID: 79
       Name: crypto/tls.ConnectionState
       ByteSize: 192
       GoRuntimeType: 2.232384e+06
@@ -1159,60 +1159,60 @@ Types:
       RawFields:
         - Name: Version
           Offset: 0
-          Type: 22 BaseType uint16
+          Type: 6 BaseType uint16
         - Name: HandshakeComplete
           Offset: 2
-          Type: 13 BaseType bool
+          Type: 4 BaseType bool
         - Name: DidResume
           Offset: 3
-          Type: 13 BaseType bool
+          Type: 4 BaseType bool
         - Name: CipherSuite
           Offset: 4
-          Type: 22 BaseType uint16
+          Type: 6 BaseType uint16
         - Name: NegotiatedProtocol
           Offset: 8
-          Type: 5 GoStringHeaderType string
+          Type: 9 GoStringHeaderType string
         - Name: NegotiatedProtocolIsMutual
           Offset: 24
-          Type: 13 BaseType bool
+          Type: 4 BaseType bool
         - Name: ServerName
           Offset: 32
-          Type: 5 GoStringHeaderType string
+          Type: 9 GoStringHeaderType string
         - Name: PeerCertificates
           Offset: 48
-          Type: 56 GoSliceHeaderType []*crypto/x509.Certificate
+          Type: 80 GoSliceHeaderType []*crypto/x509.Certificate
         - Name: VerifiedChains
           Offset: 72
-          Type: 108 GoSliceHeaderType [][]*crypto/x509.Certificate
+          Type: 131 GoSliceHeaderType [][]*crypto/x509.Certificate
         - Name: SignedCertificateTimestamps
           Offset: 96
-          Type: 110 GoSliceHeaderType [][]uint8
+          Type: 133 GoSliceHeaderType [][]uint8
         - Name: OCSPResponse
           Offset: 120
-          Type: 53 GoSliceHeaderType []uint8
+          Type: 77 GoSliceHeaderType []uint8
         - Name: TLSUnique
           Offset: 144
-          Type: 53 GoSliceHeaderType []uint8
+          Type: 77 GoSliceHeaderType []uint8
         - Name: ECHAccepted
           Offset: 168
-          Type: 13 BaseType bool
+          Type: 4 BaseType bool
         - Name: ekm
           Offset: 176
-          Type: 112 GoSubroutineType func(string, []uint8, int) ([]uint8, error)
+          Type: 135 GoSubroutineType func(string, []uint8, int) ([]uint8, error)
         - Name: testingOnlyDidHRR
           Offset: 184
-          Type: 13 BaseType bool
+          Type: 4 BaseType bool
         - Name: testingOnlyCurveID
           Offset: 186
-          Type: 113 BaseType crypto/tls.CurveID
+          Type: 136 BaseType crypto/tls.CurveID
     - __kind: BaseType
-      ID: 113
+      ID: 136
       Name: crypto/tls.CurveID
       ByteSize: 2
       GoRuntimeType: 829664
       GoKind: 9
     - __kind: StructureType
-      ID: 59
+      ID: 83
       Name: crypto/x509.Certificate
       ByteSize: 1424
       GoRuntimeType: 2.377888e+06
@@ -1220,174 +1220,174 @@ Types:
       RawFields:
         - Name: Raw
           Offset: 0
-          Type: 53 GoSliceHeaderType []uint8
+          Type: 77 GoSliceHeaderType []uint8
         - Name: RawTBSCertificate
           Offset: 24
-          Type: 53 GoSliceHeaderType []uint8
+          Type: 77 GoSliceHeaderType []uint8
         - Name: RawSubjectPublicKeyInfo
           Offset: 48
-          Type: 53 GoSliceHeaderType []uint8
+          Type: 77 GoSliceHeaderType []uint8
         - Name: RawSubject
           Offset: 72
-          Type: 53 GoSliceHeaderType []uint8
+          Type: 77 GoSliceHeaderType []uint8
         - Name: RawIssuer
           Offset: 96
-          Type: 53 GoSliceHeaderType []uint8
+          Type: 77 GoSliceHeaderType []uint8
         - Name: Signature
           Offset: 120
-          Type: 53 GoSliceHeaderType []uint8
+          Type: 77 GoSliceHeaderType []uint8
         - Name: SignatureAlgorithm
           Offset: 144
-          Type: 60 BaseType crypto/x509.SignatureAlgorithm
+          Type: 84 BaseType crypto/x509.SignatureAlgorithm
         - Name: PublicKeyAlgorithm
           Offset: 152
-          Type: 61 BaseType crypto/x509.PublicKeyAlgorithm
+          Type: 85 BaseType crypto/x509.PublicKeyAlgorithm
         - Name: PublicKey
           Offset: 160
-          Type: 62 GoEmptyInterfaceType interface {}
+          Type: 86 GoEmptyInterfaceType interface {}
         - Name: Version
           Offset: 176
-          Type: 8 BaseType int
+          Type: 7 BaseType int
         - Name: SerialNumber
           Offset: 184
-          Type: 63 PointerType *math/big.Int
+          Type: 87 PointerType *math/big.Int
         - Name: Issuer
           Offset: 192
-          Type: 68 StructureType crypto/x509/pkix.Name
+          Type: 92 StructureType crypto/x509/pkix.Name
         - Name: Subject
           Offset: 440
-          Type: 68 StructureType crypto/x509/pkix.Name
+          Type: 92 StructureType crypto/x509/pkix.Name
         - Name: NotBefore
           Offset: 688
-          Type: 74 StructureType time.Time
+          Type: 97 StructureType time.Time
         - Name: NotAfter
           Offset: 712
-          Type: 74 StructureType time.Time
+          Type: 97 StructureType time.Time
         - Name: KeyUsage
           Offset: 736
-          Type: 83 BaseType crypto/x509.KeyUsage
+          Type: 106 BaseType crypto/x509.KeyUsage
         - Name: Extensions
           Offset: 744
-          Type: 84 GoSliceHeaderType []crypto/x509/pkix.Extension
+          Type: 107 GoSliceHeaderType []crypto/x509/pkix.Extension
         - Name: ExtraExtensions
           Offset: 768
-          Type: 84 GoSliceHeaderType []crypto/x509/pkix.Extension
+          Type: 107 GoSliceHeaderType []crypto/x509/pkix.Extension
         - Name: UnhandledCriticalExtensions
           Offset: 792
-          Type: 87 GoSliceHeaderType []encoding/asn1.ObjectIdentifier
+          Type: 110 GoSliceHeaderType []encoding/asn1.ObjectIdentifier
         - Name: ExtKeyUsage
           Offset: 816
-          Type: 89 GoSliceHeaderType []crypto/x509.ExtKeyUsage
+          Type: 112 GoSliceHeaderType []crypto/x509.ExtKeyUsage
         - Name: UnknownExtKeyUsage
           Offset: 840
-          Type: 87 GoSliceHeaderType []encoding/asn1.ObjectIdentifier
+          Type: 110 GoSliceHeaderType []encoding/asn1.ObjectIdentifier
         - Name: BasicConstraintsValid
           Offset: 864
-          Type: 13 BaseType bool
+          Type: 4 BaseType bool
         - Name: IsCA
           Offset: 865
-          Type: 13 BaseType bool
+          Type: 4 BaseType bool
         - Name: MaxPathLen
           Offset: 872
-          Type: 8 BaseType int
+          Type: 7 BaseType int
         - Name: MaxPathLenZero
           Offset: 880
-          Type: 13 BaseType bool
+          Type: 4 BaseType bool
         - Name: SubjectKeyId
           Offset: 888
-          Type: 53 GoSliceHeaderType []uint8
+          Type: 77 GoSliceHeaderType []uint8
         - Name: AuthorityKeyId
           Offset: 912
-          Type: 53 GoSliceHeaderType []uint8
+          Type: 77 GoSliceHeaderType []uint8
         - Name: OCSPServer
           Offset: 936
-          Type: 28 GoSliceHeaderType []string
+          Type: 54 GoSliceHeaderType []string
         - Name: IssuingCertificateURL
           Offset: 960
-          Type: 28 GoSliceHeaderType []string
+          Type: 54 GoSliceHeaderType []string
         - Name: DNSNames
           Offset: 984
-          Type: 28 GoSliceHeaderType []string
+          Type: 54 GoSliceHeaderType []string
         - Name: EmailAddresses
           Offset: 1008
-          Type: 28 GoSliceHeaderType []string
+          Type: 54 GoSliceHeaderType []string
         - Name: IPAddresses
           Offset: 1032
-          Type: 92 GoSliceHeaderType []net.IP
+          Type: 115 GoSliceHeaderType []net.IP
         - Name: URIs
           Offset: 1056
-          Type: 95 GoSliceHeaderType []*net/url.URL
+          Type: 118 GoSliceHeaderType []*net/url.URL
         - Name: PermittedDNSDomainsCritical
           Offset: 1080
-          Type: 13 BaseType bool
+          Type: 4 BaseType bool
         - Name: PermittedDNSDomains
           Offset: 1088
-          Type: 28 GoSliceHeaderType []string
+          Type: 54 GoSliceHeaderType []string
         - Name: ExcludedDNSDomains
           Offset: 1112
-          Type: 28 GoSliceHeaderType []string
+          Type: 54 GoSliceHeaderType []string
         - Name: PermittedIPRanges
           Offset: 1136
-          Type: 97 GoSliceHeaderType []*net.IPNet
+          Type: 120 GoSliceHeaderType []*net.IPNet
         - Name: ExcludedIPRanges
           Offset: 1160
-          Type: 97 GoSliceHeaderType []*net.IPNet
+          Type: 120 GoSliceHeaderType []*net.IPNet
         - Name: PermittedEmailAddresses
           Offset: 1184
-          Type: 28 GoSliceHeaderType []string
+          Type: 54 GoSliceHeaderType []string
         - Name: ExcludedEmailAddresses
           Offset: 1208
-          Type: 28 GoSliceHeaderType []string
+          Type: 54 GoSliceHeaderType []string
         - Name: PermittedURIDomains
           Offset: 1232
-          Type: 28 GoSliceHeaderType []string
+          Type: 54 GoSliceHeaderType []string
         - Name: ExcludedURIDomains
           Offset: 1256
-          Type: 28 GoSliceHeaderType []string
+          Type: 54 GoSliceHeaderType []string
         - Name: CRLDistributionPoints
           Offset: 1280
-          Type: 28 GoSliceHeaderType []string
+          Type: 54 GoSliceHeaderType []string
         - Name: PolicyIdentifiers
           Offset: 1304
-          Type: 87 GoSliceHeaderType []encoding/asn1.ObjectIdentifier
+          Type: 110 GoSliceHeaderType []encoding/asn1.ObjectIdentifier
         - Name: Policies
           Offset: 1328
-          Type: 102 GoSliceHeaderType []crypto/x509.OID
+          Type: 125 GoSliceHeaderType []crypto/x509.OID
         - Name: InhibitAnyPolicy
           Offset: 1352
-          Type: 8 BaseType int
+          Type: 7 BaseType int
         - Name: InhibitAnyPolicyZero
           Offset: 1360
-          Type: 13 BaseType bool
+          Type: 4 BaseType bool
         - Name: InhibitPolicyMapping
           Offset: 1368
-          Type: 8 BaseType int
+          Type: 7 BaseType int
         - Name: InhibitPolicyMappingZero
           Offset: 1376
-          Type: 13 BaseType bool
+          Type: 4 BaseType bool
         - Name: RequireExplicitPolicy
           Offset: 1384
-          Type: 8 BaseType int
+          Type: 7 BaseType int
         - Name: RequireExplicitPolicyZero
           Offset: 1392
-          Type: 13 BaseType bool
+          Type: 4 BaseType bool
         - Name: PolicyMappings
           Offset: 1400
-          Type: 105 GoSliceHeaderType []crypto/x509.PolicyMapping
+          Type: 128 GoSliceHeaderType []crypto/x509.PolicyMapping
     - __kind: BaseType
-      ID: 91
+      ID: 114
       Name: crypto/x509.ExtKeyUsage
       ByteSize: 8
       GoRuntimeType: 583360
       GoKind: 2
     - __kind: BaseType
-      ID: 83
+      ID: 106
       Name: crypto/x509.KeyUsage
       ByteSize: 8
       GoRuntimeType: 583296
       GoKind: 2
     - __kind: StructureType
-      ID: 104
+      ID: 127
       Name: crypto/x509.OID
       ByteSize: 24
       GoRuntimeType: 1.939168e+06
@@ -1395,9 +1395,9 @@ Types:
       RawFields:
         - Name: der
           Offset: 0
-          Type: 53 GoSliceHeaderType []uint8
+          Type: 77 GoSliceHeaderType []uint8
     - __kind: StructureType
-      ID: 107
+      ID: 130
       Name: crypto/x509.PolicyMapping
       ByteSize: 48
       GoRuntimeType: 1.480928e+06
@@ -1405,24 +1405,24 @@ Types:
       RawFields:
         - Name: IssuerDomainPolicy
           Offset: 0
-          Type: 104 StructureType crypto/x509.OID
+          Type: 127 StructureType crypto/x509.OID
         - Name: SubjectDomainPolicy
           Offset: 24
-          Type: 104 StructureType crypto/x509.OID
+          Type: 127 StructureType crypto/x509.OID
     - __kind: BaseType
-      ID: 61
+      ID: 85
       Name: crypto/x509.PublicKeyAlgorithm
       ByteSize: 8
       GoRuntimeType: 832064
       GoKind: 2
     - __kind: BaseType
-      ID: 60
+      ID: 84
       Name: crypto/x509.SignatureAlgorithm
       ByteSize: 8
       GoRuntimeType: 1.105248e+06
       GoKind: 2
     - __kind: StructureType
-      ID: 71
+      ID: 95
       Name: crypto/x509/pkix.AttributeTypeAndValue
       ByteSize: 40
       GoRuntimeType: 1.492608e+06
@@ -1430,12 +1430,12 @@ Types:
       RawFields:
         - Name: Type
           Offset: 0
-          Type: 72 GoSliceHeaderType encoding/asn1.ObjectIdentifier
+          Type: 96 GoSliceHeaderType encoding/asn1.ObjectIdentifier
         - Name: Value
           Offset: 24
-          Type: 62 GoEmptyInterfaceType interface {}
+          Type: 86 GoEmptyInterfaceType interface {}
     - __kind: StructureType
-      ID: 86
+      ID: 109
       Name: crypto/x509/pkix.Extension
       ByteSize: 56
       GoRuntimeType: 1.63616e+06
@@ -1443,15 +1443,15 @@ Types:
       RawFields:
         - Name: Id
           Offset: 0
-          Type: 72 GoSliceHeaderType encoding/asn1.ObjectIdentifier
+          Type: 96 GoSliceHeaderType encoding/asn1.ObjectIdentifier
         - Name: Critical
           Offset: 24
-          Type: 13 BaseType bool
+          Type: 4 BaseType bool
         - Name: Value
           Offset: 32
-          Type: 53 GoSliceHeaderType []uint8
+          Type: 77 GoSliceHeaderType []uint8
     - __kind: StructureType
-      ID: 68
+      ID: 92
       Name: crypto/x509/pkix.Name
       ByteSize: 248
       GoRuntimeType: 2.177504e+06
@@ -1459,39 +1459,39 @@ Types:
       RawFields:
         - Name: Country
           Offset: 0
-          Type: 28 GoSliceHeaderType []string
+          Type: 54 GoSliceHeaderType []string
         - Name: Organization
           Offset: 24
-          Type: 28 GoSliceHeaderType []string
+          Type: 54 GoSliceHeaderType []string
         - Name: OrganizationalUnit
           Offset: 48
-          Type: 28 GoSliceHeaderType []string
+          Type: 54 GoSliceHeaderType []string
         - Name: Locality
           Offset: 72
-          Type: 28 GoSliceHeaderType []string
+          Type: 54 GoSliceHeaderType []string
         - Name: Province
           Offset: 96
-          Type: 28 GoSliceHeaderType []string
+          Type: 54 GoSliceHeaderType []string
         - Name: StreetAddress
           Offset: 120
-          Type: 28 GoSliceHeaderType []string
+          Type: 54 GoSliceHeaderType []string
         - Name: PostalCode
           Offset: 144
-          Type: 28 GoSliceHeaderType []string
+          Type: 54 GoSliceHeaderType []string
         - Name: SerialNumber
           Offset: 168
-          Type: 5 GoStringHeaderType string
+          Type: 9 GoStringHeaderType string
         - Name: CommonName
           Offset: 184
-          Type: 5 GoStringHeaderType string
+          Type: 9 GoStringHeaderType string
         - Name: Names
           Offset: 200
-          Type: 69 GoSliceHeaderType []crypto/x509/pkix.AttributeTypeAndValue
+          Type: 93 GoSliceHeaderType []crypto/x509/pkix.AttributeTypeAndValue
         - Name: ExtraNames
           Offset: 224
-          Type: 69 GoSliceHeaderType []crypto/x509/pkix.AttributeTypeAndValue
+          Type: 93 GoSliceHeaderType []crypto/x509/pkix.AttributeTypeAndValue
     - __kind: GoSliceHeaderType
-      ID: 72
+      ID: 96
       Name: encoding/asn1.ObjectIdentifier
       ByteSize: 24
       GoRuntimeType: 1.044832e+06
@@ -1499,21 +1499,21 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 73 PointerType *int
+          Type: 27 PointerType *int
         - Name: len
           Offset: 8
-          Type: 8 BaseType int
+          Type: 7 BaseType int
         - Name: cap
           Offset: 16
-          Type: 8 BaseType int
+          Type: 7 BaseType int
       Data: 181 GoSliceDataType encoding/asn1.ObjectIdentifier.array
     - __kind: GoSliceDataType
       ID: 181
       Name: encoding/asn1.ObjectIdentifier.array
       ByteSize: 2048
-      Element: 8 BaseType int
+      Element: 7 BaseType int
     - __kind: GoInterfaceType
-      ID: 143
+      ID: 13
       Name: error
       ByteSize: 16
       GoRuntimeType: 1.023328e+06
@@ -1521,36 +1521,36 @@ Types:
       RawFields:
         - Name: tab
           Offset: 0
-          Type: 2 VoidPointerType unsafe.Pointer
+          Type: 14 VoidPointerType unsafe.Pointer
         - Name: data
           Offset: 8
-          Type: 2 VoidPointerType unsafe.Pointer
+          Type: 14 VoidPointerType unsafe.Pointer
     - __kind: BaseType
-      ID: 146
+      ID: 17
       Name: float32
       ByteSize: 4
       GoRuntimeType: 580544
       GoKind: 13
     - __kind: BaseType
-      ID: 147
+      ID: 18
       Name: float64
       ByteSize: 8
       GoRuntimeType: 580608
       GoKind: 14
     - __kind: GoSubroutineType
-      ID: 31
+      ID: 56
       Name: func() (io.ReadCloser, error)
       ByteSize: 8
       GoRuntimeType: 687968
       GoKind: 19
     - __kind: GoSubroutineType
-      ID: 112
+      ID: 135
       Name: func(string, []uint8, int) ([]uint8, error)
       ByteSize: 8
       GoRuntimeType: 995552
       GoKind: 19
     - __kind: GoInterfaceType
-      ID: 137
+      ID: 160
       Name: gopkg.in/DataDog/dd-trace-go.v1/ddtrace.Span
       ByteSize: 16
       GoRuntimeType: 1.469568e+06
@@ -1558,84 +1558,84 @@ Types:
       RawFields:
         - Name: tab
           Offset: 0
-          Type: 2 VoidPointerType unsafe.Pointer
+          Type: 14 VoidPointerType unsafe.Pointer
         - Name: data
           Offset: 8
-          Type: 2 VoidPointerType unsafe.Pointer
+          Type: 14 VoidPointerType unsafe.Pointer
     - __kind: GoSwissMapGroupsType
-      ID: 43
+      ID: 67
       Name: groupReference<string,[]*mime/multipart.FileHeader>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 44 PointerType *noalg.map.group[string][]*mime/multipart.FileHeader
+          Type: 68 PointerType *noalg.map.group[string][]*mime/multipart.FileHeader
         - Name: lengthMask
           Offset: 8
-          Type: 17 BaseType uint64
-      GroupType: 45 StructureType noalg.map.group[string][]*mime/multipart.FileHeader
+          Type: 8 BaseType uint64
+      GroupType: 69 StructureType noalg.map.group[string][]*mime/multipart.FileHeader
       GroupSliceType: 170 GoSliceDataType []noalg.map.group[string][]*mime/multipart.FileHeader.array
     - __kind: GoSwissMapGroupsType
-      ID: 23
+      ID: 49
       Name: groupReference<string,[]string>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 24 PointerType *noalg.map.group[string][]string
+          Type: 50 PointerType *noalg.map.group[string][]string
         - Name: lengthMask
           Offset: 8
-          Type: 17 BaseType uint64
-      GroupType: 25 StructureType noalg.map.group[string][]string
+          Type: 8 BaseType uint64
+      GroupType: 51 StructureType noalg.map.group[string][]string
       GroupSliceType: 166 GoSliceDataType []noalg.map.group[string][]string.array
     - __kind: GoSwissMapGroupsType
-      ID: 129
+      ID: 152
       Name: groupReference<string,string>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 130 PointerType *noalg.map.group[string]string
+          Type: 153 PointerType *noalg.map.group[string]string
         - Name: lengthMask
           Offset: 8
-          Type: 17 BaseType uint64
-      GroupType: 131 StructureType noalg.map.group[string]string
+          Type: 8 BaseType uint64
+      GroupType: 154 StructureType noalg.map.group[string]string
       GroupSliceType: 214 GoSliceDataType []noalg.map.group[string]string.array
     - __kind: BaseType
-      ID: 8
+      ID: 7
       Name: int
       ByteSize: 8
       GoRuntimeType: 580224
       GoKind: 2
     - __kind: BaseType
-      ID: 158
+      ID: 31
       Name: int16
       ByteSize: 2
       GoRuntimeType: 579840
       GoKind: 4
     - __kind: BaseType
-      ID: 141
+      ID: 10
       Name: int32
       ByteSize: 4
       GoRuntimeType: 579968
       GoKind: 5
     - __kind: BaseType
-      ID: 32
+      ID: 12
       Name: int64
       ByteSize: 8
       GoRuntimeType: 580096
       GoKind: 6
     - __kind: BaseType
-      ID: 144
+      ID: 15
       Name: int8
       ByteSize: 1
       GoRuntimeType: 579712
       GoKind: 3
     - __kind: GoEmptyInterfaceType
-      ID: 62
+      ID: 86
       Name: interface {}
       ByteSize: 16
       GoRuntimeType: 849280
@@ -1643,12 +1643,12 @@ Types:
       RawFields:
         - Name: _type
           Offset: 0
-          Type: 2 VoidPointerType unsafe.Pointer
+          Type: 14 VoidPointerType unsafe.Pointer
         - Name: data
           Offset: 8
-          Type: 2 VoidPointerType unsafe.Pointer
+          Type: 14 VoidPointerType unsafe.Pointer
     - __kind: GoInterfaceType
-      ID: 30
+      ID: 55
       Name: io.ReadCloser
       ByteSize: 16
       GoRuntimeType: 1.10128e+06
@@ -1656,129 +1656,129 @@ Types:
       RawFields:
         - Name: tab
           Offset: 0
-          Type: 2 VoidPointerType unsafe.Pointer
+          Type: 14 VoidPointerType unsafe.Pointer
         - Name: data
           Offset: 8
-          Type: 2 VoidPointerType unsafe.Pointer
+          Type: 14 VoidPointerType unsafe.Pointer
     - __kind: GoSwissMapHeaderType
-      ID: 39
+      ID: 63
       Name: map<string,[]*mime/multipart.FileHeader>
       ByteSize: 48
       GoKind: 25
       RawFields:
         - Name: used
           Offset: 0
-          Type: 17 BaseType uint64
+          Type: 8 BaseType uint64
         - Name: seed
           Offset: 8
-          Type: 18 BaseType uintptr
+          Type: 1 BaseType uintptr
         - Name: dirPtr
           Offset: 16
-          Type: 40 PointerType **table<string,[]*mime/multipart.FileHeader>
+          Type: 64 PointerType **table<string,[]*mime/multipart.FileHeader>
         - Name: dirLen
           Offset: 24
-          Type: 8 BaseType int
+          Type: 7 BaseType int
         - Name: globalDepth
           Offset: 32
-          Type: 7 BaseType uint8
+          Type: 3 BaseType uint8
         - Name: globalShift
           Offset: 33
-          Type: 7 BaseType uint8
+          Type: 3 BaseType uint8
         - Name: writing
           Offset: 34
-          Type: 7 BaseType uint8
+          Type: 3 BaseType uint8
         - Name: clearSeq
           Offset: 40
-          Type: 17 BaseType uint64
+          Type: 8 BaseType uint64
       TablePtrSliceType: 169 GoSliceDataType []*table<string,[]*mime/multipart.FileHeader>.array
-      GroupType: 45 StructureType noalg.map.group[string][]*mime/multipart.FileHeader
+      GroupType: 69 StructureType noalg.map.group[string][]*mime/multipart.FileHeader
     - __kind: GoSwissMapHeaderType
-      ID: 16
+      ID: 45
       Name: map<string,[]string>
       ByteSize: 48
       GoKind: 25
       RawFields:
         - Name: used
           Offset: 0
-          Type: 17 BaseType uint64
+          Type: 8 BaseType uint64
         - Name: seed
           Offset: 8
-          Type: 18 BaseType uintptr
+          Type: 1 BaseType uintptr
         - Name: dirPtr
           Offset: 16
-          Type: 19 PointerType **table<string,[]string>
+          Type: 46 PointerType **table<string,[]string>
         - Name: dirLen
           Offset: 24
-          Type: 8 BaseType int
+          Type: 7 BaseType int
         - Name: globalDepth
           Offset: 32
-          Type: 7 BaseType uint8
+          Type: 3 BaseType uint8
         - Name: globalShift
           Offset: 33
-          Type: 7 BaseType uint8
+          Type: 3 BaseType uint8
         - Name: writing
           Offset: 34
-          Type: 7 BaseType uint8
+          Type: 3 BaseType uint8
         - Name: clearSeq
           Offset: 40
-          Type: 17 BaseType uint64
+          Type: 8 BaseType uint64
       TablePtrSliceType: 165 GoSliceDataType []*table<string,[]string>.array
-      GroupType: 25 StructureType noalg.map.group[string][]string
+      GroupType: 51 StructureType noalg.map.group[string][]string
     - __kind: GoSwissMapHeaderType
-      ID: 125
+      ID: 148
       Name: map<string,string>
       ByteSize: 48
       GoKind: 25
       RawFields:
         - Name: used
           Offset: 0
-          Type: 17 BaseType uint64
+          Type: 8 BaseType uint64
         - Name: seed
           Offset: 8
-          Type: 18 BaseType uintptr
+          Type: 1 BaseType uintptr
         - Name: dirPtr
           Offset: 16
-          Type: 126 PointerType **table<string,string>
+          Type: 149 PointerType **table<string,string>
         - Name: dirLen
           Offset: 24
-          Type: 8 BaseType int
+          Type: 7 BaseType int
         - Name: globalDepth
           Offset: 32
-          Type: 7 BaseType uint8
+          Type: 3 BaseType uint8
         - Name: globalShift
           Offset: 33
-          Type: 7 BaseType uint8
+          Type: 3 BaseType uint8
         - Name: writing
           Offset: 34
-          Type: 7 BaseType uint8
+          Type: 3 BaseType uint8
         - Name: clearSeq
           Offset: 40
-          Type: 17 BaseType uint64
+          Type: 8 BaseType uint64
       TablePtrSliceType: 213 GoSliceDataType []*table<string,string>.array
-      GroupType: 131 StructureType noalg.map.group[string]string
+      GroupType: 154 StructureType noalg.map.group[string]string
     - __kind: GoMapType
-      ID: 37
+      ID: 61
       Name: map[string][]*mime/multipart.FileHeader
       ByteSize: 8
       GoRuntimeType: 1.123296e+06
       GoKind: 21
-      HeaderType: 39 GoSwissMapHeaderType map<string,[]*mime/multipart.FileHeader>
+      HeaderType: 63 GoSwissMapHeaderType map<string,[]*mime/multipart.FileHeader>
     - __kind: GoMapType
-      ID: 36
+      ID: 60
       Name: map[string][]string
       ByteSize: 8
       GoRuntimeType: 1.118688e+06
       GoKind: 21
-      HeaderType: 16 GoSwissMapHeaderType map<string,[]string>
+      HeaderType: 45 GoSwissMapHeaderType map<string,[]string>
     - __kind: GoMapType
-      ID: 123
+      ID: 146
       Name: map[string]string
       ByteSize: 8
       GoRuntimeType: 1.119712e+06
       GoKind: 21
-      HeaderType: 125 GoSwissMapHeaderType map<string,string>
+      HeaderType: 148 GoSwissMapHeaderType map<string,string>
     - __kind: StructureType
-      ID: 64
+      ID: 88
       Name: math/big.Int
       ByteSize: 32
       GoRuntimeType: 1.483968e+06
@@ -1786,18 +1786,18 @@ Types:
       RawFields:
         - Name: neg
           Offset: 0
-          Type: 13 BaseType bool
+          Type: 4 BaseType bool
         - Name: abs
           Offset: 8
-          Type: 65 GoSliceHeaderType math/big.nat
+          Type: 89 GoSliceHeaderType math/big.nat
     - __kind: BaseType
-      ID: 67
+      ID: 91
       Name: math/big.Word
       ByteSize: 8
       GoRuntimeType: 583552
       GoKind: 7
     - __kind: GoSliceHeaderType
-      ID: 65
+      ID: 89
       Name: math/big.nat
       ByteSize: 24
       GoRuntimeType: 2.346272e+06
@@ -1805,21 +1805,21 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 66 PointerType *math/big.Word
+          Type: 90 PointerType *math/big.Word
         - Name: len
           Offset: 8
-          Type: 8 BaseType int
+          Type: 7 BaseType int
         - Name: cap
           Offset: 16
-          Type: 8 BaseType int
+          Type: 7 BaseType int
       Data: 177 GoSliceDataType math/big.nat.array
     - __kind: GoSliceDataType
       ID: 177
       Name: math/big.nat.array
       ByteSize: 2048
-      Element: 67 BaseType math/big.Word
+      Element: 91 BaseType math/big.Word
     - __kind: StructureType
-      ID: 51
+      ID: 75
       Name: mime/multipart.FileHeader
       ByteSize: 88
       GoRuntimeType: 1.962912e+06
@@ -1827,27 +1827,27 @@ Types:
       RawFields:
         - Name: Filename
           Offset: 0
-          Type: 5 GoStringHeaderType string
+          Type: 9 GoStringHeaderType string
         - Name: Header
           Offset: 16
-          Type: 52 GoMapType net/textproto.MIMEHeader
+          Type: 76 GoMapType net/textproto.MIMEHeader
         - Name: Size
           Offset: 24
-          Type: 32 BaseType int64
+          Type: 12 BaseType int64
         - Name: content
           Offset: 32
-          Type: 53 GoSliceHeaderType []uint8
+          Type: 77 GoSliceHeaderType []uint8
         - Name: tmpfile
           Offset: 56
-          Type: 5 GoStringHeaderType string
+          Type: 9 GoStringHeaderType string
         - Name: tmpoff
           Offset: 72
-          Type: 32 BaseType int64
+          Type: 12 BaseType int64
         - Name: tmpshared
           Offset: 80
-          Type: 13 BaseType bool
+          Type: 4 BaseType bool
     - __kind: StructureType
-      ID: 35
+      ID: 59
       Name: mime/multipart.Form
       ByteSize: 16
       GoRuntimeType: 1.467968e+06
@@ -1855,12 +1855,12 @@ Types:
       RawFields:
         - Name: Value
           Offset: 0
-          Type: 36 GoMapType map[string][]string
+          Type: 60 GoMapType map[string][]string
         - Name: File
           Offset: 8
-          Type: 37 GoMapType map[string][]*mime/multipart.FileHeader
+          Type: 61 GoMapType map[string][]*mime/multipart.FileHeader
     - __kind: GoSliceHeaderType
-      ID: 94
+      ID: 117
       Name: net.IP
       ByteSize: 24
       GoRuntimeType: 2.109952e+06
@@ -1868,21 +1868,21 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 6 PointerType *uint8
+          Type: 5 PointerType *uint8
         - Name: len
           Offset: 8
-          Type: 8 BaseType int
+          Type: 7 BaseType int
         - Name: cap
           Offset: 16
-          Type: 8 BaseType int
+          Type: 7 BaseType int
       Data: 195 GoSliceDataType net.IP.array
     - __kind: GoSliceDataType
       ID: 195
       Name: net.IP.array
       ByteSize: 2048
-      Element: 7 BaseType uint8
+      Element: 3 BaseType uint8
     - __kind: GoSliceHeaderType
-      ID: 101
+      ID: 124
       Name: net.IPMask
       ByteSize: 24
       GoRuntimeType: 1.011424e+06
@@ -1890,21 +1890,21 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 6 PointerType *uint8
+          Type: 5 PointerType *uint8
         - Name: len
           Offset: 8
-          Type: 8 BaseType int
+          Type: 7 BaseType int
         - Name: cap
           Offset: 16
-          Type: 8 BaseType int
+          Type: 7 BaseType int
       Data: 201 GoSliceDataType net.IPMask.array
     - __kind: GoSliceDataType
       ID: 201
       Name: net.IPMask.array
       ByteSize: 2048
-      Element: 7 BaseType uint8
+      Element: 3 BaseType uint8
     - __kind: StructureType
-      ID: 100
+      ID: 123
       Name: net.IPNet
       ByteSize: 48
       GoRuntimeType: 1.449408e+06
@@ -1912,19 +1912,19 @@ Types:
       RawFields:
         - Name: IP
           Offset: 0
-          Type: 94 GoSliceHeaderType net.IP
+          Type: 117 GoSliceHeaderType net.IP
         - Name: Mask
           Offset: 24
-          Type: 101 GoSliceHeaderType net.IPMask
+          Type: 124 GoSliceHeaderType net.IPMask
     - __kind: GoMapType
-      ID: 14
+      ID: 43
       Name: net/http.Header
       ByteSize: 8
       GoRuntimeType: 2.088128e+06
       GoKind: 21
-      HeaderType: 16 GoSwissMapHeaderType map<string,[]string>
+      HeaderType: 45 GoSwissMapHeaderType map<string,[]string>
     - __kind: StructureType
-      ID: 4
+      ID: 38
       Name: net/http.Request
       ByteSize: 304
       GoRuntimeType: 2.322816e+06
@@ -1932,84 +1932,84 @@ Types:
       RawFields:
         - Name: Method
           Offset: 0
-          Type: 5 GoStringHeaderType string
+          Type: 9 GoStringHeaderType string
         - Name: URL
           Offset: 16
-          Type: 9 PointerType *net/url.URL
+          Type: 39 PointerType *net/url.URL
         - Name: Proto
           Offset: 24
-          Type: 5 GoStringHeaderType string
+          Type: 9 GoStringHeaderType string
         - Name: ProtoMajor
           Offset: 40
-          Type: 8 BaseType int
+          Type: 7 BaseType int
         - Name: ProtoMinor
           Offset: 48
-          Type: 8 BaseType int
+          Type: 7 BaseType int
         - Name: Header
           Offset: 56
-          Type: 14 GoMapType net/http.Header
+          Type: 43 GoMapType net/http.Header
         - Name: Body
           Offset: 64
-          Type: 30 GoInterfaceType io.ReadCloser
+          Type: 55 GoInterfaceType io.ReadCloser
         - Name: GetBody
           Offset: 80
-          Type: 31 GoSubroutineType func() (io.ReadCloser, error)
+          Type: 56 GoSubroutineType func() (io.ReadCloser, error)
         - Name: ContentLength
           Offset: 88
-          Type: 32 BaseType int64
+          Type: 12 BaseType int64
         - Name: TransferEncoding
           Offset: 96
-          Type: 28 GoSliceHeaderType []string
+          Type: 54 GoSliceHeaderType []string
         - Name: Close
           Offset: 120
-          Type: 13 BaseType bool
+          Type: 4 BaseType bool
         - Name: Host
           Offset: 128
-          Type: 5 GoStringHeaderType string
+          Type: 9 GoStringHeaderType string
         - Name: Form
           Offset: 144
-          Type: 33 GoMapType net/url.Values
+          Type: 57 GoMapType net/url.Values
         - Name: PostForm
           Offset: 152
-          Type: 33 GoMapType net/url.Values
+          Type: 57 GoMapType net/url.Values
         - Name: MultipartForm
           Offset: 160
-          Type: 34 PointerType *mime/multipart.Form
+          Type: 58 PointerType *mime/multipart.Form
         - Name: Trailer
           Offset: 168
-          Type: 14 GoMapType net/http.Header
+          Type: 43 GoMapType net/http.Header
         - Name: RemoteAddr
           Offset: 176
-          Type: 5 GoStringHeaderType string
+          Type: 9 GoStringHeaderType string
         - Name: RequestURI
           Offset: 192
-          Type: 5 GoStringHeaderType string
+          Type: 9 GoStringHeaderType string
         - Name: TLS
           Offset: 208
-          Type: 54 PointerType *crypto/tls.ConnectionState
+          Type: 78 PointerType *crypto/tls.ConnectionState
         - Name: Cancel
           Offset: 216
-          Type: 114 GoChannelType <-chan struct {}
+          Type: 137 GoChannelType <-chan struct {}
         - Name: Response
           Offset: 224
-          Type: 115 PointerType *net/http.Response
+          Type: 138 PointerType *net/http.Response
         - Name: Pattern
           Offset: 232
-          Type: 5 GoStringHeaderType string
+          Type: 9 GoStringHeaderType string
         - Name: ctx
           Offset: 248
-          Type: 117 GoInterfaceType context.Context
+          Type: 140 GoInterfaceType context.Context
         - Name: pat
           Offset: 264
-          Type: 118 PointerType *net/http.pattern
+          Type: 141 PointerType *net/http.pattern
         - Name: matches
           Offset: 272
-          Type: 28 GoSliceHeaderType []string
+          Type: 54 GoSliceHeaderType []string
         - Name: otherValues
           Offset: 296
-          Type: 123 GoMapType map[string]string
+          Type: 146 GoMapType map[string]string
     - __kind: StructureType
-      ID: 116
+      ID: 139
       Name: net/http.Response
       ByteSize: 144
       GoRuntimeType: 2.195808e+06
@@ -2017,48 +2017,48 @@ Types:
       RawFields:
         - Name: Status
           Offset: 0
-          Type: 5 GoStringHeaderType string
+          Type: 9 GoStringHeaderType string
         - Name: StatusCode
           Offset: 16
-          Type: 8 BaseType int
+          Type: 7 BaseType int
         - Name: Proto
           Offset: 24
-          Type: 5 GoStringHeaderType string
+          Type: 9 GoStringHeaderType string
         - Name: ProtoMajor
           Offset: 40
-          Type: 8 BaseType int
+          Type: 7 BaseType int
         - Name: ProtoMinor
           Offset: 48
-          Type: 8 BaseType int
+          Type: 7 BaseType int
         - Name: Header
           Offset: 56
-          Type: 14 GoMapType net/http.Header
+          Type: 43 GoMapType net/http.Header
         - Name: Body
           Offset: 64
-          Type: 30 GoInterfaceType io.ReadCloser
+          Type: 55 GoInterfaceType io.ReadCloser
         - Name: ContentLength
           Offset: 80
-          Type: 32 BaseType int64
+          Type: 12 BaseType int64
         - Name: TransferEncoding
           Offset: 88
-          Type: 28 GoSliceHeaderType []string
+          Type: 54 GoSliceHeaderType []string
         - Name: Close
           Offset: 112
-          Type: 13 BaseType bool
+          Type: 4 BaseType bool
         - Name: Uncompressed
           Offset: 113
-          Type: 13 BaseType bool
+          Type: 4 BaseType bool
         - Name: Trailer
           Offset: 120
-          Type: 14 GoMapType net/http.Header
+          Type: 43 GoMapType net/http.Header
         - Name: Request
           Offset: 128
-          Type: 3 PointerType *net/http.Request
+          Type: 37 PointerType *net/http.Request
         - Name: TLS
           Offset: 136
-          Type: 54 PointerType *crypto/tls.ConnectionState
+          Type: 78 PointerType *crypto/tls.ConnectionState
     - __kind: GoInterfaceType
-      ID: 1
+      ID: 36
       Name: net/http.ResponseWriter
       ByteSize: 16
       GoRuntimeType: 1.177056e+06
@@ -2066,12 +2066,12 @@ Types:
       RawFields:
         - Name: tab
           Offset: 0
-          Type: 2 VoidPointerType unsafe.Pointer
+          Type: 14 VoidPointerType unsafe.Pointer
         - Name: data
           Offset: 8
-          Type: 2 VoidPointerType unsafe.Pointer
+          Type: 14 VoidPointerType unsafe.Pointer
     - __kind: StructureType
-      ID: 119
+      ID: 142
       Name: net/http.pattern
       ByteSize: 88
       GoRuntimeType: 1.818656e+06
@@ -2079,21 +2079,21 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 5 GoStringHeaderType string
+          Type: 9 GoStringHeaderType string
         - Name: method
           Offset: 16
-          Type: 5 GoStringHeaderType string
+          Type: 9 GoStringHeaderType string
         - Name: host
           Offset: 32
-          Type: 5 GoStringHeaderType string
+          Type: 9 GoStringHeaderType string
         - Name: segments
           Offset: 48
-          Type: 120 GoSliceHeaderType []net/http.segment
+          Type: 143 GoSliceHeaderType []net/http.segment
         - Name: loc
           Offset: 72
-          Type: 5 GoStringHeaderType string
+          Type: 9 GoStringHeaderType string
     - __kind: StructureType
-      ID: 122
+      ID: 145
       Name: net/http.segment
       ByteSize: 24
       GoRuntimeType: 1.59776e+06
@@ -2101,22 +2101,22 @@ Types:
       RawFields:
         - Name: s
           Offset: 0
-          Type: 5 GoStringHeaderType string
+          Type: 9 GoStringHeaderType string
         - Name: wild
           Offset: 16
-          Type: 13 BaseType bool
+          Type: 4 BaseType bool
         - Name: multi
           Offset: 17
-          Type: 13 BaseType bool
+          Type: 4 BaseType bool
     - __kind: GoMapType
-      ID: 52
+      ID: 76
       Name: net/textproto.MIMEHeader
       ByteSize: 8
       GoRuntimeType: 1.808832e+06
       GoKind: 21
-      HeaderType: 16 GoSwissMapHeaderType map<string,[]string>
+      HeaderType: 45 GoSwissMapHeaderType map<string,[]string>
     - __kind: StructureType
-      ID: 10
+      ID: 40
       Name: net/url.URL
       ByteSize: 144
       GoRuntimeType: 2.113024e+06
@@ -2124,39 +2124,39 @@ Types:
       RawFields:
         - Name: Scheme
           Offset: 0
-          Type: 5 GoStringHeaderType string
+          Type: 9 GoStringHeaderType string
         - Name: Opaque
           Offset: 16
-          Type: 5 GoStringHeaderType string
+          Type: 9 GoStringHeaderType string
         - Name: User
           Offset: 32
-          Type: 11 PointerType *net/url.Userinfo
+          Type: 41 PointerType *net/url.Userinfo
         - Name: Host
           Offset: 40
-          Type: 5 GoStringHeaderType string
+          Type: 9 GoStringHeaderType string
         - Name: Path
           Offset: 56
-          Type: 5 GoStringHeaderType string
+          Type: 9 GoStringHeaderType string
         - Name: RawPath
           Offset: 72
-          Type: 5 GoStringHeaderType string
+          Type: 9 GoStringHeaderType string
         - Name: OmitHost
           Offset: 88
-          Type: 13 BaseType bool
+          Type: 4 BaseType bool
         - Name: ForceQuery
           Offset: 89
-          Type: 13 BaseType bool
+          Type: 4 BaseType bool
         - Name: RawQuery
           Offset: 96
-          Type: 5 GoStringHeaderType string
+          Type: 9 GoStringHeaderType string
         - Name: Fragment
           Offset: 112
-          Type: 5 GoStringHeaderType string
+          Type: 9 GoStringHeaderType string
         - Name: RawFragment
           Offset: 128
-          Type: 5 GoStringHeaderType string
+          Type: 9 GoStringHeaderType string
     - __kind: StructureType
-      ID: 12
+      ID: 42
       Name: net/url.Userinfo
       ByteSize: 40
       GoRuntimeType: 1.61408e+06
@@ -2164,49 +2164,49 @@ Types:
       RawFields:
         - Name: username
           Offset: 0
-          Type: 5 GoStringHeaderType string
+          Type: 9 GoStringHeaderType string
         - Name: password
           Offset: 16
-          Type: 5 GoStringHeaderType string
+          Type: 9 GoStringHeaderType string
         - Name: passwordSet
           Offset: 32
-          Type: 13 BaseType bool
+          Type: 4 BaseType bool
     - __kind: GoMapType
-      ID: 33
+      ID: 57
       Name: net/url.Values
       ByteSize: 8
       GoRuntimeType: 1.871296e+06
       GoKind: 21
-      HeaderType: 16 GoSwissMapHeaderType map<string,[]string>
+      HeaderType: 45 GoSwissMapHeaderType map<string,[]string>
     - __kind: ArrayType
-      ID: 46
+      ID: 70
       Name: noalg.[8]struct { key string; elem []*mime/multipart.FileHeader }
       ByteSize: 320
       GoRuntimeType: 694016
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 47 StructureType noalg.struct { key string; elem []*mime/multipart.FileHeader }
+      Element: 71 StructureType noalg.struct { key string; elem []*mime/multipart.FileHeader }
     - __kind: ArrayType
-      ID: 26
+      ID: 52
       Name: noalg.[8]struct { key string; elem []string }
       ByteSize: 320
       GoRuntimeType: 684000
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 27 StructureType noalg.struct { key string; elem []string }
+      Element: 53 StructureType noalg.struct { key string; elem []string }
     - __kind: ArrayType
-      ID: 132
+      ID: 155
       Name: noalg.[8]struct { key string; elem string }
       ByteSize: 256
       GoRuntimeType: 688160
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 133 StructureType noalg.struct { key string; elem string }
+      Element: 156 StructureType noalg.struct { key string; elem string }
     - __kind: StructureType
-      ID: 45
+      ID: 69
       Name: noalg.map.group[string][]*mime/multipart.FileHeader
       ByteSize: 328
       GoRuntimeType: 1.290528e+06
@@ -2214,12 +2214,12 @@ Types:
       RawFields:
         - Name: ctrl
           Offset: 0
-          Type: 17 BaseType uint64
+          Type: 8 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 46 ArrayType noalg.[8]struct { key string; elem []*mime/multipart.FileHeader }
+          Type: 70 ArrayType noalg.[8]struct { key string; elem []*mime/multipart.FileHeader }
     - __kind: StructureType
-      ID: 25
+      ID: 51
       Name: noalg.map.group[string][]string
       ByteSize: 328
       GoRuntimeType: 1.281056e+06
@@ -2227,12 +2227,12 @@ Types:
       RawFields:
         - Name: ctrl
           Offset: 0
-          Type: 17 BaseType uint64
+          Type: 8 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 26 ArrayType noalg.[8]struct { key string; elem []string }
+          Type: 52 ArrayType noalg.[8]struct { key string; elem []string }
     - __kind: StructureType
-      ID: 131
+      ID: 154
       Name: noalg.map.group[string]string
       ByteSize: 264
       GoRuntimeType: 1.28336e+06
@@ -2240,12 +2240,12 @@ Types:
       RawFields:
         - Name: ctrl
           Offset: 0
-          Type: 17 BaseType uint64
+          Type: 8 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 132 ArrayType noalg.[8]struct { key string; elem string }
+          Type: 155 ArrayType noalg.[8]struct { key string; elem string }
     - __kind: StructureType
-      ID: 47
+      ID: 71
       Name: noalg.struct { key string; elem []*mime/multipart.FileHeader }
       ByteSize: 40
       GoRuntimeType: 1.2904e+06
@@ -2253,12 +2253,12 @@ Types:
       RawFields:
         - Name: key
           Offset: 0
-          Type: 5 GoStringHeaderType string
+          Type: 9 GoStringHeaderType string
         - Name: elem
           Offset: 16
-          Type: 48 GoSliceHeaderType []*mime/multipart.FileHeader
+          Type: 72 GoSliceHeaderType []*mime/multipart.FileHeader
     - __kind: StructureType
-      ID: 27
+      ID: 53
       Name: noalg.struct { key string; elem []string }
       ByteSize: 40
       GoRuntimeType: 1.280928e+06
@@ -2266,12 +2266,12 @@ Types:
       RawFields:
         - Name: key
           Offset: 0
-          Type: 5 GoStringHeaderType string
+          Type: 9 GoStringHeaderType string
         - Name: elem
           Offset: 16
-          Type: 28 GoSliceHeaderType []string
+          Type: 54 GoSliceHeaderType []string
     - __kind: StructureType
-      ID: 133
+      ID: 156
       Name: noalg.struct { key string; elem string }
       ByteSize: 32
       GoRuntimeType: 1.283232e+06
@@ -2279,12 +2279,12 @@ Types:
       RawFields:
         - Name: key
           Offset: 0
-          Type: 5 GoStringHeaderType string
+          Type: 9 GoStringHeaderType string
         - Name: elem
           Offset: 16
-          Type: 5 GoStringHeaderType string
+          Type: 9 GoStringHeaderType string
     - __kind: GoStringHeaderType
-      ID: 5
+      ID: 9
       Name: string
       ByteSize: 16
       GoRuntimeType: 579648
@@ -2295,86 +2295,86 @@ Types:
           Type: 164 PointerType *string.str
         - Name: len
           Offset: 8
-          Type: 8 BaseType int
+          Type: 7 BaseType int
       Data: 163 GoStringDataType string.str
     - __kind: GoStringDataType
       ID: 163
       Name: string.str
       ByteSize: 2048
     - __kind: StructureType
-      ID: 42
+      ID: 66
       Name: table<string,[]*mime/multipart.FileHeader>
       ByteSize: 32
       GoKind: 25
       RawFields:
         - Name: used
           Offset: 0
-          Type: 22 BaseType uint16
+          Type: 6 BaseType uint16
         - Name: capacity
           Offset: 2
-          Type: 22 BaseType uint16
+          Type: 6 BaseType uint16
         - Name: growthLeft
           Offset: 4
-          Type: 22 BaseType uint16
+          Type: 6 BaseType uint16
         - Name: localDepth
           Offset: 6
-          Type: 7 BaseType uint8
+          Type: 3 BaseType uint8
         - Name: index
           Offset: 8
-          Type: 8 BaseType int
+          Type: 7 BaseType int
         - Name: groups
           Offset: 16
-          Type: 43 GoSwissMapGroupsType groupReference<string,[]*mime/multipart.FileHeader>
+          Type: 67 GoSwissMapGroupsType groupReference<string,[]*mime/multipart.FileHeader>
     - __kind: StructureType
-      ID: 21
+      ID: 48
       Name: table<string,[]string>
       ByteSize: 32
       GoKind: 25
       RawFields:
         - Name: used
           Offset: 0
-          Type: 22 BaseType uint16
+          Type: 6 BaseType uint16
         - Name: capacity
           Offset: 2
-          Type: 22 BaseType uint16
+          Type: 6 BaseType uint16
         - Name: growthLeft
           Offset: 4
-          Type: 22 BaseType uint16
+          Type: 6 BaseType uint16
         - Name: localDepth
           Offset: 6
-          Type: 7 BaseType uint8
+          Type: 3 BaseType uint8
         - Name: index
           Offset: 8
-          Type: 8 BaseType int
+          Type: 7 BaseType int
         - Name: groups
           Offset: 16
-          Type: 23 GoSwissMapGroupsType groupReference<string,[]string>
+          Type: 49 GoSwissMapGroupsType groupReference<string,[]string>
     - __kind: StructureType
-      ID: 128
+      ID: 151
       Name: table<string,string>
       ByteSize: 32
       GoKind: 25
       RawFields:
         - Name: used
           Offset: 0
-          Type: 22 BaseType uint16
+          Type: 6 BaseType uint16
         - Name: capacity
           Offset: 2
-          Type: 22 BaseType uint16
+          Type: 6 BaseType uint16
         - Name: growthLeft
           Offset: 4
-          Type: 22 BaseType uint16
+          Type: 6 BaseType uint16
         - Name: localDepth
           Offset: 6
-          Type: 7 BaseType uint8
+          Type: 3 BaseType uint8
         - Name: index
           Offset: 8
-          Type: 8 BaseType int
+          Type: 7 BaseType int
         - Name: groups
           Offset: 16
-          Type: 129 GoSwissMapGroupsType groupReference<string,string>
+          Type: 152 GoSwissMapGroupsType groupReference<string,string>
     - __kind: StructureType
-      ID: 76
+      ID: 99
       Name: time.Location
       ByteSize: 104
       GoRuntimeType: 1.958592e+06
@@ -2382,27 +2382,27 @@ Types:
       RawFields:
         - Name: name
           Offset: 0
-          Type: 5 GoStringHeaderType string
+          Type: 9 GoStringHeaderType string
         - Name: zone
           Offset: 16
-          Type: 77 GoSliceHeaderType []time.zone
+          Type: 100 GoSliceHeaderType []time.zone
         - Name: tx
           Offset: 40
-          Type: 80 GoSliceHeaderType []time.zoneTrans
+          Type: 103 GoSliceHeaderType []time.zoneTrans
         - Name: extend
           Offset: 64
-          Type: 5 GoStringHeaderType string
+          Type: 9 GoStringHeaderType string
         - Name: cacheStart
           Offset: 80
-          Type: 32 BaseType int64
+          Type: 12 BaseType int64
         - Name: cacheEnd
           Offset: 88
-          Type: 32 BaseType int64
+          Type: 12 BaseType int64
         - Name: cacheZone
           Offset: 96
-          Type: 78 PointerType *time.zone
+          Type: 101 PointerType *time.zone
     - __kind: StructureType
-      ID: 74
+      ID: 97
       Name: time.Time
       ByteSize: 24
       GoRuntimeType: 2.349088e+06
@@ -2410,15 +2410,15 @@ Types:
       RawFields:
         - Name: wall
           Offset: 0
-          Type: 17 BaseType uint64
+          Type: 8 BaseType uint64
         - Name: ext
           Offset: 8
-          Type: 32 BaseType int64
+          Type: 12 BaseType int64
         - Name: loc
           Offset: 16
-          Type: 75 PointerType *time.Location
+          Type: 98 PointerType *time.Location
     - __kind: StructureType
-      ID: 79
+      ID: 102
       Name: time.zone
       ByteSize: 32
       GoRuntimeType: 1.602752e+06
@@ -2426,15 +2426,15 @@ Types:
       RawFields:
         - Name: name
           Offset: 0
-          Type: 5 GoStringHeaderType string
+          Type: 9 GoStringHeaderType string
         - Name: offset
           Offset: 16
-          Type: 8 BaseType int
+          Type: 7 BaseType int
         - Name: isDST
           Offset: 24
-          Type: 13 BaseType bool
+          Type: 4 BaseType bool
     - __kind: StructureType
-      ID: 82
+      ID: 105
       Name: time.zoneTrans
       ByteSize: 16
       GoRuntimeType: 1.73712e+06
@@ -2442,54 +2442,54 @@ Types:
       RawFields:
         - Name: when
           Offset: 0
-          Type: 32 BaseType int64
+          Type: 12 BaseType int64
         - Name: index
           Offset: 8
-          Type: 7 BaseType uint8
+          Type: 3 BaseType uint8
         - Name: isstd
           Offset: 9
-          Type: 13 BaseType bool
+          Type: 4 BaseType bool
         - Name: isutc
           Offset: 10
-          Type: 13 BaseType bool
+          Type: 4 BaseType bool
     - __kind: BaseType
-      ID: 145
+      ID: 16
       Name: uint
       ByteSize: 8
       GoRuntimeType: 580288
       GoKind: 7
     - __kind: BaseType
-      ID: 22
+      ID: 6
       Name: uint16
       ByteSize: 2
       GoRuntimeType: 579904
       GoKind: 9
     - __kind: BaseType
-      ID: 140
+      ID: 2
       Name: uint32
       ByteSize: 4
       GoRuntimeType: 580032
       GoKind: 10
     - __kind: BaseType
-      ID: 17
+      ID: 8
       Name: uint64
       ByteSize: 8
       GoRuntimeType: 580160
       GoKind: 11
     - __kind: BaseType
-      ID: 7
+      ID: 3
       Name: uint8
       ByteSize: 1
       GoRuntimeType: 579776
       GoKind: 8
     - __kind: BaseType
-      ID: 18
+      ID: 1
       Name: uintptr
       ByteSize: 8
       GoRuntimeType: 580352
       GoKind: 12
     - __kind: VoidPointerType
-      ID: 2
+      ID: 14
       Name: unsafe.Pointer
       ByteSize: 8
       GoRuntimeType: 580736

--- a/pkg/dyninst/irgen/testdata/snapshot/rc_tester_v1.arch=amd64,toolchain=go1.24.3.yaml
+++ b/pkg/dyninst/irgen/testdata/snapshot/rc_tester_v1.arch=amd64,toolchain=go1.24.3.yaml
@@ -10,7 +10,7 @@ Probes:
       subprogram: {subprogram: 1}
       events:
         - ID: 1
-          Type: 221 EventRootType Probe[main.HandleHTTP]
+          Type: 215 EventRootType Probe[main.HandleHTTP]
           InjectionPoints: [{PC: "0xcfc653", Frameless: false}]
           Condition: null
     - id: look_at_the_request
@@ -23,7 +23,7 @@ Probes:
       subprogram: {subprogram: 2}
       events:
         - ID: 2
-          Type: 222 EventRootType Probe[main.LookAtTheRequest]
+          Type: 216 EventRootType Probe[main.LookAtTheRequest]
           InjectionPoints: [{PC: "0xcfc9ce", Frameless: false}]
           Condition: null
 Subprograms:
@@ -382,7 +382,7 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 17 BaseType uint64
-      TablePtrSliceType: 177 GoSliceDataType []*table<string,[]string>.array
+      TablePtrSliceType: 165 GoSliceDataType []*table<string,[]string>.array
       GroupType: 25 StructureType noalg.map.group[string][]string
     - __kind: BaseType
       ID: 17
@@ -449,7 +449,7 @@ Types:
           Offset: 8
           Type: 17 BaseType uint64
       GroupType: 25 StructureType noalg.map.group[string][]string
-      GroupSliceType: 178 GoSliceDataType []noalg.map.group[string][]string.array
+      GroupSliceType: 166 GoSliceDataType []noalg.map.group[string][]string.array
     - __kind: PointerType
       ID: 24
       Name: '*noalg.map.group[string][]string'
@@ -615,7 +615,7 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 17 BaseType uint64
-      TablePtrSliceType: 173 GoSliceDataType []*table<string,[]*mime/multipart.FileHeader>.array
+      TablePtrSliceType: 169 GoSliceDataType []*table<string,[]*mime/multipart.FileHeader>.array
       GroupType: 45 StructureType noalg.map.group[string][]*mime/multipart.FileHeader
     - __kind: PointerType
       ID: 40
@@ -664,7 +664,7 @@ Types:
           Offset: 8
           Type: 17 BaseType uint64
       GroupType: 45 StructureType noalg.map.group[string][]*mime/multipart.FileHeader
-      GroupSliceType: 174 GoSliceDataType []noalg.map.group[string][]*mime/multipart.FileHeader.array
+      GroupSliceType: 170 GoSliceDataType []noalg.map.group[string][]*mime/multipart.FileHeader.array
     - __kind: PointerType
       ID: 44
       Name: '*noalg.map.group[string][]*mime/multipart.FileHeader'
@@ -721,7 +721,7 @@ Types:
         - Name: cap
           Offset: 16
           Type: 8 BaseType int
-      Data: 175 GoSliceDataType []*mime/multipart.FileHeader.array
+      Data: 171 GoSliceDataType []*mime/multipart.FileHeader.array
     - __kind: PointerType
       ID: 49
       Name: '**mime/multipart.FileHeader'
@@ -786,7 +786,7 @@ Types:
         - Name: cap
           Offset: 16
           Type: 8 BaseType int
-      Data: 179 GoSliceDataType []uint8.array
+      Data: 173 GoSliceDataType []uint8.array
     - __kind: PointerType
       ID: 54
       Name: '*crypto/tls.ConnectionState'
@@ -865,7 +865,7 @@ Types:
         - Name: cap
           Offset: 16
           Type: 8 BaseType int
-      Data: 181 GoSliceDataType []*crypto/x509.Certificate.array
+      Data: 175 GoSliceDataType []*crypto/x509.Certificate.array
     - __kind: PointerType
       ID: 57
       Name: '**crypto/x509.Certificate'
@@ -1103,7 +1103,7 @@ Types:
         - Name: cap
           Offset: 16
           Type: 8 BaseType int
-      Data: 183 GoSliceDataType math/big.nat.array
+      Data: 177 GoSliceDataType math/big.nat.array
     - __kind: PointerType
       ID: 66
       Name: '*math/big.Word'
@@ -1173,7 +1173,7 @@ Types:
         - Name: cap
           Offset: 16
           Type: 8 BaseType int
-      Data: 185 GoSliceDataType []crypto/x509/pkix.AttributeTypeAndValue.array
+      Data: 179 GoSliceDataType []crypto/x509/pkix.AttributeTypeAndValue.array
     - __kind: PointerType
       ID: 70
       Name: '*crypto/x509/pkix.AttributeTypeAndValue'
@@ -1210,7 +1210,7 @@ Types:
         - Name: cap
           Offset: 16
           Type: 8 BaseType int
-      Data: 187 GoSliceDataType encoding/asn1.ObjectIdentifier.array
+      Data: 181 GoSliceDataType encoding/asn1.ObjectIdentifier.array
     - __kind: PointerType
       ID: 73
       Name: '*int'
@@ -1285,7 +1285,7 @@ Types:
         - Name: cap
           Offset: 16
           Type: 8 BaseType int
-      Data: 189 GoSliceDataType []time.zone.array
+      Data: 183 GoSliceDataType []time.zone.array
     - __kind: PointerType
       ID: 78
       Name: '*time.zone'
@@ -1325,7 +1325,7 @@ Types:
         - Name: cap
           Offset: 16
           Type: 8 BaseType int
-      Data: 191 GoSliceDataType []time.zoneTrans.array
+      Data: 185 GoSliceDataType []time.zoneTrans.array
     - __kind: PointerType
       ID: 81
       Name: '*time.zoneTrans'
@@ -1374,7 +1374,7 @@ Types:
         - Name: cap
           Offset: 16
           Type: 8 BaseType int
-      Data: 193 GoSliceDataType []crypto/x509/pkix.Extension.array
+      Data: 187 GoSliceDataType []crypto/x509/pkix.Extension.array
     - __kind: PointerType
       ID: 85
       Name: '*crypto/x509/pkix.Extension'
@@ -1414,7 +1414,7 @@ Types:
         - Name: cap
           Offset: 16
           Type: 8 BaseType int
-      Data: 195 GoSliceDataType []encoding/asn1.ObjectIdentifier.array
+      Data: 189 GoSliceDataType []encoding/asn1.ObjectIdentifier.array
     - __kind: PointerType
       ID: 88
       Name: '*encoding/asn1.ObjectIdentifier'
@@ -1438,7 +1438,7 @@ Types:
         - Name: cap
           Offset: 16
           Type: 8 BaseType int
-      Data: 197 GoSliceDataType []crypto/x509.ExtKeyUsage.array
+      Data: 191 GoSliceDataType []crypto/x509.ExtKeyUsage.array
     - __kind: PointerType
       ID: 90
       Name: '*crypto/x509.ExtKeyUsage'
@@ -1468,7 +1468,7 @@ Types:
         - Name: cap
           Offset: 16
           Type: 8 BaseType int
-      Data: 199 GoSliceDataType []net.IP.array
+      Data: 193 GoSliceDataType []net.IP.array
     - __kind: PointerType
       ID: 93
       Name: '*net.IP'
@@ -1492,7 +1492,7 @@ Types:
         - Name: cap
           Offset: 16
           Type: 8 BaseType int
-      Data: 201 GoSliceDataType net.IP.array
+      Data: 195 GoSliceDataType net.IP.array
     - __kind: GoSliceHeaderType
       ID: 95
       Name: '[]*net/url.URL'
@@ -1509,7 +1509,7 @@ Types:
         - Name: cap
           Offset: 16
           Type: 8 BaseType int
-      Data: 203 GoSliceDataType []*net/url.URL.array
+      Data: 197 GoSliceDataType []*net/url.URL.array
     - __kind: PointerType
       ID: 96
       Name: '**net/url.URL'
@@ -1532,7 +1532,7 @@ Types:
         - Name: cap
           Offset: 16
           Type: 8 BaseType int
-      Data: 205 GoSliceDataType []*net.IPNet.array
+      Data: 199 GoSliceDataType []*net.IPNet.array
     - __kind: PointerType
       ID: 98
       Name: '**net.IPNet'
@@ -1575,7 +1575,7 @@ Types:
         - Name: cap
           Offset: 16
           Type: 8 BaseType int
-      Data: 207 GoSliceDataType net.IPMask.array
+      Data: 201 GoSliceDataType net.IPMask.array
     - __kind: GoSliceHeaderType
       ID: 102
       Name: '[]crypto/x509.OID'
@@ -1592,7 +1592,7 @@ Types:
         - Name: cap
           Offset: 16
           Type: 8 BaseType int
-      Data: 209 GoSliceDataType []crypto/x509.OID.array
+      Data: 203 GoSliceDataType []crypto/x509.OID.array
     - __kind: PointerType
       ID: 103
       Name: '*crypto/x509.OID'
@@ -1626,7 +1626,7 @@ Types:
         - Name: cap
           Offset: 16
           Type: 8 BaseType int
-      Data: 211 GoSliceDataType []crypto/x509.PolicyMapping.array
+      Data: 205 GoSliceDataType []crypto/x509.PolicyMapping.array
     - __kind: PointerType
       ID: 106
       Name: '*crypto/x509.PolicyMapping'
@@ -1663,7 +1663,7 @@ Types:
         - Name: cap
           Offset: 16
           Type: 8 BaseType int
-      Data: 213 GoSliceDataType [][]*crypto/x509.Certificate.array
+      Data: 207 GoSliceDataType [][]*crypto/x509.Certificate.array
     - __kind: PointerType
       ID: 109
       Name: '*[]*crypto/x509.Certificate'
@@ -1686,7 +1686,7 @@ Types:
         - Name: cap
           Offset: 16
           Type: 8 BaseType int
-      Data: 215 GoSliceDataType [][]uint8.array
+      Data: 209 GoSliceDataType [][]uint8.array
     - __kind: PointerType
       ID: 111
       Name: '*[]uint8'
@@ -1825,7 +1825,7 @@ Types:
         - Name: cap
           Offset: 16
           Type: 8 BaseType int
-      Data: 217 GoSliceDataType []net/http.segment.array
+      Data: 211 GoSliceDataType []net/http.segment.array
     - __kind: PointerType
       ID: 121
       Name: '*net/http.segment'
@@ -1891,7 +1891,7 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 17 BaseType uint64
-      TablePtrSliceType: 219 GoSliceDataType []*table<string,string>.array
+      TablePtrSliceType: 213 GoSliceDataType []*table<string,string>.array
       GroupType: 131 StructureType noalg.map.group[string]string
     - __kind: PointerType
       ID: 126
@@ -1940,7 +1940,7 @@ Types:
           Offset: 8
           Type: 17 BaseType uint64
       GroupType: 131 StructureType noalg.map.group[string]string
-      GroupSliceType: 220 GoSliceDataType []noalg.map.group[string]string.array
+      GroupSliceType: 214 GoSliceDataType []noalg.map.group[string]string.array
     - __kind: PointerType
       ID: 130
       Name: '*noalg.map.group[string]string'
@@ -2227,266 +2227,236 @@ Types:
       Pointee: 167 GoSliceDataType []string.array
     - __kind: GoSliceDataType
       ID: 169
-      Name: '[]*table<string,[]string>.array'
-      ByteSize: 8192
-      Element: 20 PointerType *table<string,[]string>
-    - __kind: GoSliceDataType
-      ID: 170
-      Name: '[]noalg.map.group[string][]string.array'
-      ByteSize: 2048
-      Element: 25 StructureType noalg.map.group[string][]string
-    - __kind: GoSliceDataType
-      ID: 171
-      Name: '[]*table<string,[]string>.array'
-      ByteSize: 8192
-      Element: 20 PointerType *table<string,[]string>
-    - __kind: GoSliceDataType
-      ID: 172
-      Name: '[]noalg.map.group[string][]string.array'
-      ByteSize: 2048
-      Element: 25 StructureType noalg.map.group[string][]string
-    - __kind: GoSliceDataType
-      ID: 173
       Name: '[]*table<string,[]*mime/multipart.FileHeader>.array'
       ByteSize: 8192
       Element: 41 PointerType *table<string,[]*mime/multipart.FileHeader>
     - __kind: GoSliceDataType
-      ID: 174
+      ID: 170
       Name: '[]noalg.map.group[string][]*mime/multipart.FileHeader.array'
       ByteSize: 2048
       Element: 45 StructureType noalg.map.group[string][]*mime/multipart.FileHeader
     - __kind: GoSliceDataType
-      ID: 175
+      ID: 171
       Name: '[]*mime/multipart.FileHeader.array'
       ByteSize: 2048
       Element: 50 PointerType *mime/multipart.FileHeader
     - __kind: PointerType
-      ID: 176
+      ID: 172
       Name: '*[]*mime/multipart.FileHeader.array'
       ByteSize: 8
-      Pointee: 175 GoSliceDataType []*mime/multipart.FileHeader.array
+      Pointee: 171 GoSliceDataType []*mime/multipart.FileHeader.array
     - __kind: GoSliceDataType
-      ID: 177
-      Name: '[]*table<string,[]string>.array'
-      ByteSize: 8192
-      Element: 20 PointerType *table<string,[]string>
-    - __kind: GoSliceDataType
-      ID: 178
-      Name: '[]noalg.map.group[string][]string.array'
-      ByteSize: 2048
-      Element: 25 StructureType noalg.map.group[string][]string
-    - __kind: GoSliceDataType
-      ID: 179
+      ID: 173
       Name: '[]uint8.array'
       ByteSize: 2048
       Element: 7 BaseType uint8
     - __kind: PointerType
-      ID: 180
+      ID: 174
       Name: '*[]uint8.array'
       ByteSize: 8
-      Pointee: 179 GoSliceDataType []uint8.array
+      Pointee: 173 GoSliceDataType []uint8.array
     - __kind: GoSliceDataType
-      ID: 181
+      ID: 175
       Name: '[]*crypto/x509.Certificate.array'
       ByteSize: 2048
       Element: 58 PointerType *crypto/x509.Certificate
     - __kind: PointerType
-      ID: 182
+      ID: 176
       Name: '*[]*crypto/x509.Certificate.array'
       ByteSize: 8
-      Pointee: 181 GoSliceDataType []*crypto/x509.Certificate.array
+      Pointee: 175 GoSliceDataType []*crypto/x509.Certificate.array
     - __kind: GoSliceDataType
-      ID: 183
+      ID: 177
       Name: math/big.nat.array
       ByteSize: 2048
       Element: 67 BaseType math/big.Word
     - __kind: PointerType
-      ID: 184
+      ID: 178
       Name: '*math/big.nat.array'
       ByteSize: 8
-      Pointee: 183 GoSliceDataType math/big.nat.array
+      Pointee: 177 GoSliceDataType math/big.nat.array
     - __kind: GoSliceDataType
-      ID: 185
+      ID: 179
       Name: '[]crypto/x509/pkix.AttributeTypeAndValue.array'
       ByteSize: 2048
       Element: 71 StructureType crypto/x509/pkix.AttributeTypeAndValue
     - __kind: PointerType
-      ID: 186
+      ID: 180
       Name: '*[]crypto/x509/pkix.AttributeTypeAndValue.array'
       ByteSize: 8
-      Pointee: 185 GoSliceDataType []crypto/x509/pkix.AttributeTypeAndValue.array
+      Pointee: 179 GoSliceDataType []crypto/x509/pkix.AttributeTypeAndValue.array
     - __kind: GoSliceDataType
-      ID: 187
+      ID: 181
       Name: encoding/asn1.ObjectIdentifier.array
       ByteSize: 2048
       Element: 8 BaseType int
     - __kind: PointerType
-      ID: 188
+      ID: 182
       Name: '*encoding/asn1.ObjectIdentifier.array'
       ByteSize: 8
-      Pointee: 187 GoSliceDataType encoding/asn1.ObjectIdentifier.array
+      Pointee: 181 GoSliceDataType encoding/asn1.ObjectIdentifier.array
     - __kind: GoSliceDataType
-      ID: 189
+      ID: 183
       Name: '[]time.zone.array'
       ByteSize: 2048
       Element: 79 StructureType time.zone
     - __kind: PointerType
-      ID: 190
+      ID: 184
       Name: '*[]time.zone.array'
       ByteSize: 8
-      Pointee: 189 GoSliceDataType []time.zone.array
+      Pointee: 183 GoSliceDataType []time.zone.array
     - __kind: GoSliceDataType
-      ID: 191
+      ID: 185
       Name: '[]time.zoneTrans.array'
       ByteSize: 2048
       Element: 82 StructureType time.zoneTrans
     - __kind: PointerType
-      ID: 192
+      ID: 186
       Name: '*[]time.zoneTrans.array'
       ByteSize: 8
-      Pointee: 191 GoSliceDataType []time.zoneTrans.array
+      Pointee: 185 GoSliceDataType []time.zoneTrans.array
     - __kind: GoSliceDataType
-      ID: 193
+      ID: 187
       Name: '[]crypto/x509/pkix.Extension.array'
       ByteSize: 2048
       Element: 86 StructureType crypto/x509/pkix.Extension
     - __kind: PointerType
-      ID: 194
+      ID: 188
       Name: '*[]crypto/x509/pkix.Extension.array'
       ByteSize: 8
-      Pointee: 193 GoSliceDataType []crypto/x509/pkix.Extension.array
+      Pointee: 187 GoSliceDataType []crypto/x509/pkix.Extension.array
     - __kind: GoSliceDataType
-      ID: 195
+      ID: 189
       Name: '[]encoding/asn1.ObjectIdentifier.array'
       ByteSize: 2048
       Element: 72 GoSliceHeaderType encoding/asn1.ObjectIdentifier
     - __kind: PointerType
-      ID: 196
+      ID: 190
       Name: '*[]encoding/asn1.ObjectIdentifier.array'
       ByteSize: 8
-      Pointee: 195 GoSliceDataType []encoding/asn1.ObjectIdentifier.array
+      Pointee: 189 GoSliceDataType []encoding/asn1.ObjectIdentifier.array
     - __kind: GoSliceDataType
-      ID: 197
+      ID: 191
       Name: '[]crypto/x509.ExtKeyUsage.array'
       ByteSize: 2048
       Element: 91 BaseType crypto/x509.ExtKeyUsage
     - __kind: PointerType
-      ID: 198
+      ID: 192
       Name: '*[]crypto/x509.ExtKeyUsage.array'
       ByteSize: 8
-      Pointee: 197 GoSliceDataType []crypto/x509.ExtKeyUsage.array
+      Pointee: 191 GoSliceDataType []crypto/x509.ExtKeyUsage.array
     - __kind: GoSliceDataType
-      ID: 199
+      ID: 193
       Name: '[]net.IP.array'
       ByteSize: 2048
       Element: 94 GoSliceHeaderType net.IP
     - __kind: PointerType
-      ID: 200
+      ID: 194
       Name: '*[]net.IP.array'
       ByteSize: 8
-      Pointee: 199 GoSliceDataType []net.IP.array
+      Pointee: 193 GoSliceDataType []net.IP.array
     - __kind: GoSliceDataType
-      ID: 201
+      ID: 195
       Name: net.IP.array
       ByteSize: 2048
       Element: 7 BaseType uint8
     - __kind: PointerType
-      ID: 202
+      ID: 196
       Name: '*net.IP.array'
       ByteSize: 8
-      Pointee: 201 GoSliceDataType net.IP.array
+      Pointee: 195 GoSliceDataType net.IP.array
     - __kind: GoSliceDataType
-      ID: 203
+      ID: 197
       Name: '[]*net/url.URL.array'
       ByteSize: 2048
       Element: 9 PointerType *net/url.URL
     - __kind: PointerType
-      ID: 204
+      ID: 198
       Name: '*[]*net/url.URL.array'
       ByteSize: 8
-      Pointee: 203 GoSliceDataType []*net/url.URL.array
+      Pointee: 197 GoSliceDataType []*net/url.URL.array
     - __kind: GoSliceDataType
-      ID: 205
+      ID: 199
       Name: '[]*net.IPNet.array'
       ByteSize: 2048
       Element: 99 PointerType *net.IPNet
     - __kind: PointerType
-      ID: 206
+      ID: 200
       Name: '*[]*net.IPNet.array'
       ByteSize: 8
-      Pointee: 205 GoSliceDataType []*net.IPNet.array
+      Pointee: 199 GoSliceDataType []*net.IPNet.array
     - __kind: GoSliceDataType
-      ID: 207
+      ID: 201
       Name: net.IPMask.array
       ByteSize: 2048
       Element: 7 BaseType uint8
     - __kind: PointerType
-      ID: 208
+      ID: 202
       Name: '*net.IPMask.array'
       ByteSize: 8
-      Pointee: 207 GoSliceDataType net.IPMask.array
+      Pointee: 201 GoSliceDataType net.IPMask.array
     - __kind: GoSliceDataType
-      ID: 209
+      ID: 203
       Name: '[]crypto/x509.OID.array'
       ByteSize: 2048
       Element: 104 StructureType crypto/x509.OID
     - __kind: PointerType
-      ID: 210
+      ID: 204
       Name: '*[]crypto/x509.OID.array'
       ByteSize: 8
-      Pointee: 209 GoSliceDataType []crypto/x509.OID.array
+      Pointee: 203 GoSliceDataType []crypto/x509.OID.array
     - __kind: GoSliceDataType
-      ID: 211
+      ID: 205
       Name: '[]crypto/x509.PolicyMapping.array'
       ByteSize: 2048
       Element: 107 StructureType crypto/x509.PolicyMapping
     - __kind: PointerType
-      ID: 212
+      ID: 206
       Name: '*[]crypto/x509.PolicyMapping.array'
       ByteSize: 8
-      Pointee: 211 GoSliceDataType []crypto/x509.PolicyMapping.array
+      Pointee: 205 GoSliceDataType []crypto/x509.PolicyMapping.array
     - __kind: GoSliceDataType
-      ID: 213
+      ID: 207
       Name: '[][]*crypto/x509.Certificate.array'
       ByteSize: 2048
       Element: 56 GoSliceHeaderType []*crypto/x509.Certificate
     - __kind: PointerType
-      ID: 214
+      ID: 208
       Name: '*[][]*crypto/x509.Certificate.array'
       ByteSize: 8
-      Pointee: 213 GoSliceDataType [][]*crypto/x509.Certificate.array
+      Pointee: 207 GoSliceDataType [][]*crypto/x509.Certificate.array
     - __kind: GoSliceDataType
-      ID: 215
+      ID: 209
       Name: '[][]uint8.array'
       ByteSize: 2048
       Element: 53 GoSliceHeaderType []uint8
     - __kind: PointerType
-      ID: 216
+      ID: 210
       Name: '*[][]uint8.array'
       ByteSize: 8
-      Pointee: 215 GoSliceDataType [][]uint8.array
+      Pointee: 209 GoSliceDataType [][]uint8.array
     - __kind: GoSliceDataType
-      ID: 217
+      ID: 211
       Name: '[]net/http.segment.array'
       ByteSize: 2048
       Element: 122 StructureType net/http.segment
     - __kind: PointerType
-      ID: 218
+      ID: 212
       Name: '*[]net/http.segment.array'
       ByteSize: 8
-      Pointee: 217 GoSliceDataType []net/http.segment.array
+      Pointee: 211 GoSliceDataType []net/http.segment.array
     - __kind: GoSliceDataType
-      ID: 219
+      ID: 213
       Name: '[]*table<string,string>.array'
       ByteSize: 8192
       Element: 127 PointerType *table<string,string>
     - __kind: GoSliceDataType
-      ID: 220
+      ID: 214
       Name: '[]noalg.map.group[string]string.array'
       ByteSize: 2048
       Element: 131 StructureType noalg.map.group[string]string
     - __kind: EventRootType
-      ID: 221
+      ID: 215
       Name: Probe[main.HandleHTTP]
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -2510,7 +2480,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 222
+      ID: 216
       Name: Probe[main.LookAtTheRequest]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -2524,6 +2494,6 @@ Types:
                   Variable: {subprogram: 2, index: 0, name: path}
                   Offset: 0
                   ByteSize: 16
-MaxTypeID: 222
+MaxTypeID: 216
 Issues: []
 GoModuledataInfo: {FirstModuledataAddr: "0x181b800", TypesOffset: 296}

--- a/pkg/dyninst/irgen/testdata/snapshot/rc_tester_v1.arch=amd64,toolchain=go1.24.3.yaml
+++ b/pkg/dyninst/irgen/testdata/snapshot/rc_tester_v1.arch=amd64,toolchain=go1.24.3.yaml
@@ -120,432 +120,320 @@ Subprograms:
           IsParameter: true
           IsReturn: false
 Types:
-    - __kind: GoInterfaceType
-      ID: 1
-      Name: net/http.ResponseWriter
-      ByteSize: 16
-      GoRuntimeType: 1.177056e+06
-      GoKind: 20
-      RawFields:
-        - Name: tab
-          Offset: 0
-          Type: 2 VoidPointerType unsafe.Pointer
-        - Name: data
-          Offset: 8
-          Type: 2 VoidPointerType unsafe.Pointer
-    - __kind: VoidPointerType
-      ID: 2
-      Name: unsafe.Pointer
-      ByteSize: 8
-      GoRuntimeType: 580736
-      GoKind: 26
     - __kind: PointerType
-      ID: 3
-      Name: '*net/http.Request'
+      ID: 57
+      Name: '**crypto/x509.Certificate'
       ByteSize: 8
-      GoRuntimeType: 2.285568e+06
       GoKind: 22
-      Pointee: 4 StructureType net/http.Request
-    - __kind: StructureType
-      ID: 4
-      Name: net/http.Request
-      ByteSize: 304
-      GoRuntimeType: 2.322816e+06
-      GoKind: 25
-      RawFields:
-        - Name: Method
-          Offset: 0
-          Type: 5 GoStringHeaderType string
-        - Name: URL
-          Offset: 16
-          Type: 9 PointerType *net/url.URL
-        - Name: Proto
-          Offset: 24
-          Type: 5 GoStringHeaderType string
-        - Name: ProtoMajor
-          Offset: 40
-          Type: 8 BaseType int
-        - Name: ProtoMinor
-          Offset: 48
-          Type: 8 BaseType int
-        - Name: Header
-          Offset: 56
-          Type: 14 GoMapType net/http.Header
-        - Name: Body
-          Offset: 64
-          Type: 30 GoInterfaceType io.ReadCloser
-        - Name: GetBody
-          Offset: 80
-          Type: 31 GoSubroutineType func() (io.ReadCloser, error)
-        - Name: ContentLength
-          Offset: 88
-          Type: 32 BaseType int64
-        - Name: TransferEncoding
-          Offset: 96
-          Type: 28 GoSliceHeaderType []string
-        - Name: Close
-          Offset: 120
-          Type: 13 BaseType bool
-        - Name: Host
-          Offset: 128
-          Type: 5 GoStringHeaderType string
-        - Name: Form
-          Offset: 144
-          Type: 33 GoMapType net/url.Values
-        - Name: PostForm
-          Offset: 152
-          Type: 33 GoMapType net/url.Values
-        - Name: MultipartForm
-          Offset: 160
-          Type: 34 PointerType *mime/multipart.Form
-        - Name: Trailer
-          Offset: 168
-          Type: 14 GoMapType net/http.Header
-        - Name: RemoteAddr
-          Offset: 176
-          Type: 5 GoStringHeaderType string
-        - Name: RequestURI
-          Offset: 192
-          Type: 5 GoStringHeaderType string
-        - Name: TLS
-          Offset: 208
-          Type: 54 PointerType *crypto/tls.ConnectionState
-        - Name: Cancel
-          Offset: 216
-          Type: 114 GoChannelType <-chan struct {}
-        - Name: Response
-          Offset: 224
-          Type: 115 PointerType *net/http.Response
-        - Name: Pattern
-          Offset: 232
-          Type: 5 GoStringHeaderType string
-        - Name: ctx
-          Offset: 248
-          Type: 117 GoInterfaceType context.Context
-        - Name: pat
-          Offset: 264
-          Type: 118 PointerType *net/http.pattern
-        - Name: matches
-          Offset: 272
-          Type: 28 GoSliceHeaderType []string
-        - Name: otherValues
-          Offset: 296
-          Type: 123 GoMapType map[string]string
-    - __kind: GoStringHeaderType
-      ID: 5
-      Name: string
-      ByteSize: 16
-      GoRuntimeType: 579648
-      GoKind: 24
-      RawFields:
-        - Name: str
-          Offset: 0
-          Type: 164 PointerType *string.str
-        - Name: len
-          Offset: 8
-          Type: 8 BaseType int
-      Data: 163 GoStringDataType string.str
+      Pointee: 58 PointerType *crypto/x509.Certificate
     - __kind: PointerType
-      ID: 6
-      Name: '*uint8'
+      ID: 49
+      Name: '**mime/multipart.FileHeader'
       ByteSize: 8
-      GoRuntimeType: 396384
       GoKind: 22
-      Pointee: 7 BaseType uint8
-    - __kind: BaseType
-      ID: 7
-      Name: uint8
-      ByteSize: 1
-      GoRuntimeType: 579776
-      GoKind: 8
-    - __kind: BaseType
-      ID: 8
-      Name: int
-      ByteSize: 8
-      GoRuntimeType: 580224
-      GoKind: 2
+      Pointee: 50 PointerType *mime/multipart.FileHeader
     - __kind: PointerType
-      ID: 9
-      Name: '*net/url.URL'
+      ID: 98
+      Name: '**net.IPNet'
       ByteSize: 8
-      GoRuntimeType: 2.100096e+06
       GoKind: 22
-      Pointee: 10 StructureType net/url.URL
-    - __kind: StructureType
-      ID: 10
-      Name: net/url.URL
-      ByteSize: 144
-      GoRuntimeType: 2.113024e+06
-      GoKind: 25
-      RawFields:
-        - Name: Scheme
-          Offset: 0
-          Type: 5 GoStringHeaderType string
-        - Name: Opaque
-          Offset: 16
-          Type: 5 GoStringHeaderType string
-        - Name: User
-          Offset: 32
-          Type: 11 PointerType *net/url.Userinfo
-        - Name: Host
-          Offset: 40
-          Type: 5 GoStringHeaderType string
-        - Name: Path
-          Offset: 56
-          Type: 5 GoStringHeaderType string
-        - Name: RawPath
-          Offset: 72
-          Type: 5 GoStringHeaderType string
-        - Name: OmitHost
-          Offset: 88
-          Type: 13 BaseType bool
-        - Name: ForceQuery
-          Offset: 89
-          Type: 13 BaseType bool
-        - Name: RawQuery
-          Offset: 96
-          Type: 5 GoStringHeaderType string
-        - Name: Fragment
-          Offset: 112
-          Type: 5 GoStringHeaderType string
-        - Name: RawFragment
-          Offset: 128
-          Type: 5 GoStringHeaderType string
+      Pointee: 99 PointerType *net.IPNet
     - __kind: PointerType
-      ID: 11
-      Name: '*net/url.Userinfo'
+      ID: 96
+      Name: '**net/url.URL'
       ByteSize: 8
-      GoRuntimeType: 1.19216e+06
       GoKind: 22
-      Pointee: 12 StructureType net/url.Userinfo
-    - __kind: StructureType
-      ID: 12
-      Name: net/url.Userinfo
-      ByteSize: 40
-      GoRuntimeType: 1.61408e+06
-      GoKind: 25
-      RawFields:
-        - Name: username
-          Offset: 0
-          Type: 5 GoStringHeaderType string
-        - Name: password
-          Offset: 16
-          Type: 5 GoStringHeaderType string
-        - Name: passwordSet
-          Offset: 32
-          Type: 13 BaseType bool
-    - __kind: BaseType
-      ID: 13
-      Name: bool
-      ByteSize: 1
-      GoRuntimeType: 580672
-      GoKind: 1
-    - __kind: GoMapType
-      ID: 14
-      Name: net/http.Header
-      ByteSize: 8
-      GoRuntimeType: 2.088128e+06
-      GoKind: 21
-      HeaderType: 16 GoSwissMapHeaderType map<string,[]string>
+      Pointee: 9 PointerType *net/url.URL
     - __kind: PointerType
-      ID: 15
-      Name: '*map<string,[]string>'
+      ID: 40
+      Name: '**table<string,[]*mime/multipart.FileHeader>'
       ByteSize: 8
-      Pointee: 16 GoSwissMapHeaderType map<string,[]string>
-    - __kind: GoSwissMapHeaderType
-      ID: 16
-      Name: map<string,[]string>
-      ByteSize: 48
-      GoKind: 25
-      RawFields:
-        - Name: used
-          Offset: 0
-          Type: 17 BaseType uint64
-        - Name: seed
-          Offset: 8
-          Type: 18 BaseType uintptr
-        - Name: dirPtr
-          Offset: 16
-          Type: 19 PointerType **table<string,[]string>
-        - Name: dirLen
-          Offset: 24
-          Type: 8 BaseType int
-        - Name: globalDepth
-          Offset: 32
-          Type: 7 BaseType uint8
-        - Name: globalShift
-          Offset: 33
-          Type: 7 BaseType uint8
-        - Name: writing
-          Offset: 34
-          Type: 7 BaseType uint8
-        - Name: clearSeq
-          Offset: 40
-          Type: 17 BaseType uint64
-      TablePtrSliceType: 165 GoSliceDataType []*table<string,[]string>.array
-      GroupType: 25 StructureType noalg.map.group[string][]string
-    - __kind: BaseType
-      ID: 17
-      Name: uint64
-      ByteSize: 8
-      GoRuntimeType: 580160
-      GoKind: 11
-    - __kind: BaseType
-      ID: 18
-      Name: uintptr
-      ByteSize: 8
-      GoRuntimeType: 580352
-      GoKind: 12
+      Pointee: 41 PointerType *table<string,[]*mime/multipart.FileHeader>
     - __kind: PointerType
       ID: 19
       Name: '**table<string,[]string>'
       ByteSize: 8
       Pointee: 20 PointerType *table<string,[]string>
     - __kind: PointerType
-      ID: 20
-      Name: '*table<string,[]string>'
+      ID: 126
+      Name: '**table<string,string>'
       ByteSize: 8
-      Pointee: 21 StructureType table<string,[]string>
-    - __kind: StructureType
-      ID: 21
-      Name: table<string,[]string>
-      ByteSize: 32
-      GoKind: 25
-      RawFields:
-        - Name: used
-          Offset: 0
-          Type: 22 BaseType uint16
-        - Name: capacity
-          Offset: 2
-          Type: 22 BaseType uint16
-        - Name: growthLeft
-          Offset: 4
-          Type: 22 BaseType uint16
-        - Name: localDepth
-          Offset: 6
-          Type: 7 BaseType uint8
-        - Name: index
-          Offset: 8
-          Type: 8 BaseType int
-        - Name: groups
-          Offset: 16
-          Type: 23 GoSwissMapGroupsType groupReference<string,[]string>
-    - __kind: BaseType
-      ID: 22
-      Name: uint16
-      ByteSize: 2
-      GoRuntimeType: 579904
-      GoKind: 9
-    - __kind: GoSwissMapGroupsType
-      ID: 23
-      Name: groupReference<string,[]string>
-      ByteSize: 16
-      GoKind: 25
-      RawFields:
-        - Name: data
-          Offset: 0
-          Type: 24 PointerType *noalg.map.group[string][]string
-        - Name: lengthMask
-          Offset: 8
-          Type: 17 BaseType uint64
-      GroupType: 25 StructureType noalg.map.group[string][]string
-      GroupSliceType: 166 GoSliceDataType []noalg.map.group[string][]string.array
+      Pointee: 127 PointerType *table<string,string>
     - __kind: PointerType
-      ID: 24
-      Name: '*noalg.map.group[string][]string'
+      ID: 109
+      Name: '*[]*crypto/x509.Certificate'
       ByteSize: 8
-      Pointee: 25 StructureType noalg.map.group[string][]string
-    - __kind: StructureType
-      ID: 25
-      Name: noalg.map.group[string][]string
-      ByteSize: 328
-      GoRuntimeType: 1.281056e+06
-      GoKind: 25
-      RawFields:
-        - Name: ctrl
-          Offset: 0
-          Type: 17 BaseType uint64
-        - Name: slots
-          Offset: 8
-          Type: 26 ArrayType noalg.[8]struct { key string; elem []string }
-    - __kind: ArrayType
-      ID: 26
-      Name: noalg.[8]struct { key string; elem []string }
-      ByteSize: 320
-      GoRuntimeType: 684000
-      GoKind: 17
-      Count: 8
-      HasCount: true
-      Element: 27 StructureType noalg.struct { key string; elem []string }
-    - __kind: StructureType
-      ID: 27
-      Name: noalg.struct { key string; elem []string }
-      ByteSize: 40
-      GoRuntimeType: 1.280928e+06
-      GoKind: 25
-      RawFields:
-        - Name: key
-          Offset: 0
-          Type: 5 GoStringHeaderType string
-        - Name: elem
-          Offset: 16
-          Type: 28 GoSliceHeaderType []string
-    - __kind: GoSliceHeaderType
-      ID: 28
-      Name: '[]string'
-      ByteSize: 24
-      GoRuntimeType: 492832
-      GoKind: 23
-      RawFields:
-        - Name: array
-          Offset: 0
-          Type: 29 PointerType *string
-        - Name: len
-          Offset: 8
-          Type: 8 BaseType int
-        - Name: cap
-          Offset: 16
-          Type: 8 BaseType int
-      Data: 167 GoSliceDataType []string.array
-    - __kind: PointerType
-      ID: 29
-      Name: '*string'
-      ByteSize: 8
-      GoRuntimeType: 396256
       GoKind: 22
-      Pointee: 5 GoStringHeaderType string
-    - __kind: GoInterfaceType
-      ID: 30
-      Name: io.ReadCloser
-      ByteSize: 16
-      GoRuntimeType: 1.10128e+06
-      GoKind: 20
-      RawFields:
-        - Name: tab
-          Offset: 0
-          Type: 2 VoidPointerType unsafe.Pointer
-        - Name: data
-          Offset: 8
-          Type: 2 VoidPointerType unsafe.Pointer
-    - __kind: GoSubroutineType
-      ID: 31
-      Name: func() (io.ReadCloser, error)
+      Pointee: 56 GoSliceHeaderType []*crypto/x509.Certificate
+    - __kind: PointerType
+      ID: 176
+      Name: '*[]*crypto/x509.Certificate.array'
       ByteSize: 8
-      GoRuntimeType: 687968
-      GoKind: 19
-    - __kind: BaseType
-      ID: 32
-      Name: int64
+      Pointee: 175 GoSliceDataType []*crypto/x509.Certificate.array
+    - __kind: PointerType
+      ID: 172
+      Name: '*[]*mime/multipart.FileHeader.array'
       ByteSize: 8
-      GoRuntimeType: 580096
-      GoKind: 6
-    - __kind: GoMapType
-      ID: 33
-      Name: net/url.Values
+      Pointee: 171 GoSliceDataType []*mime/multipart.FileHeader.array
+    - __kind: PointerType
+      ID: 200
+      Name: '*[]*net.IPNet.array'
       ByteSize: 8
-      GoRuntimeType: 1.871296e+06
-      GoKind: 21
-      HeaderType: 16 GoSwissMapHeaderType map<string,[]string>
+      Pointee: 199 GoSliceDataType []*net.IPNet.array
+    - __kind: PointerType
+      ID: 198
+      Name: '*[]*net/url.URL.array'
+      ByteSize: 8
+      Pointee: 197 GoSliceDataType []*net/url.URL.array
+    - __kind: PointerType
+      ID: 208
+      Name: '*[][]*crypto/x509.Certificate.array'
+      ByteSize: 8
+      Pointee: 207 GoSliceDataType [][]*crypto/x509.Certificate.array
+    - __kind: PointerType
+      ID: 210
+      Name: '*[][]uint8.array'
+      ByteSize: 8
+      Pointee: 209 GoSliceDataType [][]uint8.array
+    - __kind: PointerType
+      ID: 192
+      Name: '*[]crypto/x509.ExtKeyUsage.array'
+      ByteSize: 8
+      Pointee: 191 GoSliceDataType []crypto/x509.ExtKeyUsage.array
+    - __kind: PointerType
+      ID: 204
+      Name: '*[]crypto/x509.OID.array'
+      ByteSize: 8
+      Pointee: 203 GoSliceDataType []crypto/x509.OID.array
+    - __kind: PointerType
+      ID: 206
+      Name: '*[]crypto/x509.PolicyMapping.array'
+      ByteSize: 8
+      Pointee: 205 GoSliceDataType []crypto/x509.PolicyMapping.array
+    - __kind: PointerType
+      ID: 180
+      Name: '*[]crypto/x509/pkix.AttributeTypeAndValue.array'
+      ByteSize: 8
+      Pointee: 179 GoSliceDataType []crypto/x509/pkix.AttributeTypeAndValue.array
+    - __kind: PointerType
+      ID: 188
+      Name: '*[]crypto/x509/pkix.Extension.array'
+      ByteSize: 8
+      Pointee: 187 GoSliceDataType []crypto/x509/pkix.Extension.array
+    - __kind: PointerType
+      ID: 190
+      Name: '*[]encoding/asn1.ObjectIdentifier.array'
+      ByteSize: 8
+      Pointee: 189 GoSliceDataType []encoding/asn1.ObjectIdentifier.array
+    - __kind: PointerType
+      ID: 194
+      Name: '*[]net.IP.array'
+      ByteSize: 8
+      Pointee: 193 GoSliceDataType []net.IP.array
+    - __kind: PointerType
+      ID: 212
+      Name: '*[]net/http.segment.array'
+      ByteSize: 8
+      Pointee: 211 GoSliceDataType []net/http.segment.array
+    - __kind: PointerType
+      ID: 168
+      Name: '*[]string.array'
+      ByteSize: 8
+      Pointee: 167 GoSliceDataType []string.array
+    - __kind: PointerType
+      ID: 184
+      Name: '*[]time.zone.array'
+      ByteSize: 8
+      Pointee: 183 GoSliceDataType []time.zone.array
+    - __kind: PointerType
+      ID: 186
+      Name: '*[]time.zoneTrans.array'
+      ByteSize: 8
+      Pointee: 185 GoSliceDataType []time.zoneTrans.array
+    - __kind: PointerType
+      ID: 111
+      Name: '*[]uint8'
+      ByteSize: 8
+      GoRuntimeType: 478304
+      GoKind: 22
+      Pointee: 53 GoSliceHeaderType []uint8
+    - __kind: PointerType
+      ID: 174
+      Name: '*[]uint8.array'
+      ByteSize: 8
+      Pointee: 173 GoSliceDataType []uint8.array
+    - __kind: PointerType
+      ID: 142
+      Name: '*bool'
+      ByteSize: 8
+      GoRuntimeType: 397280
+      GoKind: 22
+      Pointee: 13 BaseType bool
+    - __kind: PointerType
+      ID: 134
+      Name: '*bytes.Buffer'
+      ByteSize: 8
+      GoRuntimeType: 2.245824e+06
+      GoKind: 22
+      Pointee: 135 StructureType bytes.Buffer
+    - __kind: PointerType
+      ID: 54
+      Name: '*crypto/tls.ConnectionState'
+      ByteSize: 8
+      GoRuntimeType: 901472
+      GoKind: 22
+      Pointee: 55 StructureType crypto/tls.ConnectionState
+    - __kind: PointerType
+      ID: 58
+      Name: '*crypto/x509.Certificate'
+      ByteSize: 8
+      GoRuntimeType: 2.031072e+06
+      GoKind: 22
+      Pointee: 59 StructureType crypto/x509.Certificate
+    - __kind: PointerType
+      ID: 90
+      Name: '*crypto/x509.ExtKeyUsage'
+      ByteSize: 8
+      GoRuntimeType: 420256
+      GoKind: 22
+      Pointee: 91 BaseType crypto/x509.ExtKeyUsage
+    - __kind: PointerType
+      ID: 103
+      Name: '*crypto/x509.OID'
+      ByteSize: 8
+      GoRuntimeType: 1.938912e+06
+      GoKind: 22
+      Pointee: 104 StructureType crypto/x509.OID
+    - __kind: PointerType
+      ID: 106
+      Name: '*crypto/x509.PolicyMapping'
+      ByteSize: 8
+      GoRuntimeType: 420320
+      GoKind: 22
+      Pointee: 107 StructureType crypto/x509.PolicyMapping
+    - __kind: PointerType
+      ID: 70
+      Name: '*crypto/x509/pkix.AttributeTypeAndValue'
+      ByteSize: 8
+      GoRuntimeType: 434080
+      GoKind: 22
+      Pointee: 71 StructureType crypto/x509/pkix.AttributeTypeAndValue
+    - __kind: PointerType
+      ID: 85
+      Name: '*crypto/x509/pkix.Extension'
+      ByteSize: 8
+      GoRuntimeType: 434272
+      GoKind: 22
+      Pointee: 86 StructureType crypto/x509/pkix.Extension
+    - __kind: PointerType
+      ID: 88
+      Name: '*encoding/asn1.ObjectIdentifier'
+      ByteSize: 8
+      GoRuntimeType: 1.044704e+06
+      GoKind: 22
+      Pointee: 72 GoSliceHeaderType encoding/asn1.ObjectIdentifier
+    - __kind: PointerType
+      ID: 182
+      Name: '*encoding/asn1.ObjectIdentifier.array'
+      ByteSize: 8
+      Pointee: 181 GoSliceDataType encoding/asn1.ObjectIdentifier.array
+    - __kind: PointerType
+      ID: 160
+      Name: '*error'
+      ByteSize: 8
+      GoRuntimeType: 396192
+      GoKind: 22
+      Pointee: 143 GoInterfaceType error
+    - __kind: PointerType
+      ID: 162
+      Name: '*float32'
+      ByteSize: 8
+      GoRuntimeType: 397152
+      GoKind: 22
+      Pointee: 146 BaseType float32
+    - __kind: PointerType
+      ID: 153
+      Name: '*float64'
+      ByteSize: 8
+      GoRuntimeType: 397216
+      GoKind: 22
+      Pointee: 147 BaseType float64
+    - __kind: PointerType
+      ID: 73
+      Name: '*int'
+      ByteSize: 8
+      GoRuntimeType: 396832
+      GoKind: 22
+      Pointee: 8 BaseType int
+    - __kind: PointerType
+      ID: 157
+      Name: '*int16'
+      ByteSize: 8
+      GoRuntimeType: 396448
+      GoKind: 22
+      Pointee: 158 BaseType int16
+    - __kind: PointerType
+      ID: 149
+      Name: '*int32'
+      ByteSize: 8
+      GoRuntimeType: 396576
+      GoKind: 22
+      Pointee: 141 BaseType int32
+    - __kind: PointerType
+      ID: 154
+      Name: '*int64'
+      ByteSize: 8
+      GoRuntimeType: 396704
+      GoKind: 22
+      Pointee: 32 BaseType int64
+    - __kind: PointerType
+      ID: 159
+      Name: '*int8'
+      ByteSize: 8
+      GoRuntimeType: 396320
+      GoKind: 22
+      Pointee: 144 BaseType int8
+    - __kind: PointerType
+      ID: 38
+      Name: '*map<string,[]*mime/multipart.FileHeader>'
+      ByteSize: 8
+      Pointee: 39 GoSwissMapHeaderType map<string,[]*mime/multipart.FileHeader>
+    - __kind: PointerType
+      ID: 15
+      Name: '*map<string,[]string>'
+      ByteSize: 8
+      Pointee: 16 GoSwissMapHeaderType map<string,[]string>
+    - __kind: PointerType
+      ID: 124
+      Name: '*map<string,string>'
+      ByteSize: 8
+      Pointee: 125 GoSwissMapHeaderType map<string,string>
+    - __kind: PointerType
+      ID: 63
+      Name: '*math/big.Int'
+      ByteSize: 8
+      GoRuntimeType: 2.365472e+06
+      GoKind: 22
+      Pointee: 64 StructureType math/big.Int
+    - __kind: PointerType
+      ID: 66
+      Name: '*math/big.Word'
+      ByteSize: 8
+      GoRuntimeType: 423200
+      GoKind: 22
+      Pointee: 67 BaseType math/big.Word
+    - __kind: PointerType
+      ID: 178
+      Name: '*math/big.nat.array'
+      ByteSize: 8
+      Pointee: 177 GoSliceDataType math/big.nat.array
+    - __kind: PointerType
+      ID: 50
+      Name: '*mime/multipart.FileHeader'
+      ByteSize: 8
+      GoRuntimeType: 902912
+      GoKind: 22
+      Pointee: 51 StructureType mime/multipart.FileHeader
     - __kind: PointerType
       ID: 34
       Name: '*mime/multipart.Form'
@@ -553,158 +441,243 @@ Types:
       GoRuntimeType: 903008
       GoKind: 22
       Pointee: 35 StructureType mime/multipart.Form
-    - __kind: StructureType
-      ID: 35
-      Name: mime/multipart.Form
-      ByteSize: 16
-      GoRuntimeType: 1.467968e+06
-      GoKind: 25
-      RawFields:
-        - Name: Value
-          Offset: 0
-          Type: 36 GoMapType map[string][]string
-        - Name: File
-          Offset: 8
-          Type: 37 GoMapType map[string][]*mime/multipart.FileHeader
-    - __kind: GoMapType
-      ID: 36
-      Name: map[string][]string
-      ByteSize: 8
-      GoRuntimeType: 1.118688e+06
-      GoKind: 21
-      HeaderType: 16 GoSwissMapHeaderType map<string,[]string>
-    - __kind: GoMapType
-      ID: 37
-      Name: map[string][]*mime/multipart.FileHeader
-      ByteSize: 8
-      GoRuntimeType: 1.123296e+06
-      GoKind: 21
-      HeaderType: 39 GoSwissMapHeaderType map<string,[]*mime/multipart.FileHeader>
     - __kind: PointerType
-      ID: 38
-      Name: '*map<string,[]*mime/multipart.FileHeader>'
+      ID: 93
+      Name: '*net.IP'
       ByteSize: 8
-      Pointee: 39 GoSwissMapHeaderType map<string,[]*mime/multipart.FileHeader>
-    - __kind: GoSwissMapHeaderType
-      ID: 39
-      Name: map<string,[]*mime/multipart.FileHeader>
-      ByteSize: 48
-      GoKind: 25
-      RawFields:
-        - Name: used
-          Offset: 0
-          Type: 17 BaseType uint64
-        - Name: seed
-          Offset: 8
-          Type: 18 BaseType uintptr
-        - Name: dirPtr
-          Offset: 16
-          Type: 40 PointerType **table<string,[]*mime/multipart.FileHeader>
-        - Name: dirLen
-          Offset: 24
-          Type: 8 BaseType int
-        - Name: globalDepth
-          Offset: 32
-          Type: 7 BaseType uint8
-        - Name: globalShift
-          Offset: 33
-          Type: 7 BaseType uint8
-        - Name: writing
-          Offset: 34
-          Type: 7 BaseType uint8
-        - Name: clearSeq
-          Offset: 40
-          Type: 17 BaseType uint64
-      TablePtrSliceType: 169 GoSliceDataType []*table<string,[]*mime/multipart.FileHeader>.array
-      GroupType: 45 StructureType noalg.map.group[string][]*mime/multipart.FileHeader
+      GoRuntimeType: 2.13488e+06
+      GoKind: 22
+      Pointee: 94 GoSliceHeaderType net.IP
     - __kind: PointerType
-      ID: 40
-      Name: '**table<string,[]*mime/multipart.FileHeader>'
+      ID: 196
+      Name: '*net.IP.array'
       ByteSize: 8
-      Pointee: 41 PointerType *table<string,[]*mime/multipart.FileHeader>
+      Pointee: 195 GoSliceDataType net.IP.array
     - __kind: PointerType
-      ID: 41
-      Name: '*table<string,[]*mime/multipart.FileHeader>'
+      ID: 202
+      Name: '*net.IPMask.array'
       ByteSize: 8
-      Pointee: 42 StructureType table<string,[]*mime/multipart.FileHeader>
-    - __kind: StructureType
-      ID: 42
-      Name: table<string,[]*mime/multipart.FileHeader>
-      ByteSize: 32
-      GoKind: 25
-      RawFields:
-        - Name: used
-          Offset: 0
-          Type: 22 BaseType uint16
-        - Name: capacity
-          Offset: 2
-          Type: 22 BaseType uint16
-        - Name: growthLeft
-          Offset: 4
-          Type: 22 BaseType uint16
-        - Name: localDepth
-          Offset: 6
-          Type: 7 BaseType uint8
-        - Name: index
-          Offset: 8
-          Type: 8 BaseType int
-        - Name: groups
-          Offset: 16
-          Type: 43 GoSwissMapGroupsType groupReference<string,[]*mime/multipart.FileHeader>
-    - __kind: GoSwissMapGroupsType
-      ID: 43
-      Name: groupReference<string,[]*mime/multipart.FileHeader>
-      ByteSize: 16
-      GoKind: 25
-      RawFields:
-        - Name: data
-          Offset: 0
-          Type: 44 PointerType *noalg.map.group[string][]*mime/multipart.FileHeader
-        - Name: lengthMask
-          Offset: 8
-          Type: 17 BaseType uint64
-      GroupType: 45 StructureType noalg.map.group[string][]*mime/multipart.FileHeader
-      GroupSliceType: 170 GoSliceDataType []noalg.map.group[string][]*mime/multipart.FileHeader.array
+      Pointee: 201 GoSliceDataType net.IPMask.array
+    - __kind: PointerType
+      ID: 99
+      Name: '*net.IPNet'
+      ByteSize: 8
+      GoRuntimeType: 1.174624e+06
+      GoKind: 22
+      Pointee: 100 StructureType net.IPNet
+    - __kind: PointerType
+      ID: 3
+      Name: '*net/http.Request'
+      ByteSize: 8
+      GoRuntimeType: 2.285568e+06
+      GoKind: 22
+      Pointee: 4 StructureType net/http.Request
+    - __kind: PointerType
+      ID: 115
+      Name: '*net/http.Response'
+      ByteSize: 8
+      GoRuntimeType: 1.706048e+06
+      GoKind: 22
+      Pointee: 116 StructureType net/http.Response
+    - __kind: PointerType
+      ID: 118
+      Name: '*net/http.pattern'
+      ByteSize: 8
+      GoRuntimeType: 1.597952e+06
+      GoKind: 22
+      Pointee: 119 StructureType net/http.pattern
+    - __kind: PointerType
+      ID: 121
+      Name: '*net/http.segment'
+      ByteSize: 8
+      GoRuntimeType: 388640
+      GoKind: 22
+      Pointee: 122 StructureType net/http.segment
+    - __kind: PointerType
+      ID: 9
+      Name: '*net/url.URL'
+      ByteSize: 8
+      GoRuntimeType: 2.100096e+06
+      GoKind: 22
+      Pointee: 10 StructureType net/url.URL
+    - __kind: PointerType
+      ID: 11
+      Name: '*net/url.Userinfo'
+      ByteSize: 8
+      GoRuntimeType: 1.19216e+06
+      GoKind: 22
+      Pointee: 12 StructureType net/url.Userinfo
     - __kind: PointerType
       ID: 44
       Name: '*noalg.map.group[string][]*mime/multipart.FileHeader'
       ByteSize: 8
       Pointee: 45 StructureType noalg.map.group[string][]*mime/multipart.FileHeader
-    - __kind: StructureType
-      ID: 45
-      Name: noalg.map.group[string][]*mime/multipart.FileHeader
-      ByteSize: 328
-      GoRuntimeType: 1.290528e+06
-      GoKind: 25
+    - __kind: PointerType
+      ID: 24
+      Name: '*noalg.map.group[string][]string'
+      ByteSize: 8
+      Pointee: 25 StructureType noalg.map.group[string][]string
+    - __kind: PointerType
+      ID: 130
+      Name: '*noalg.map.group[string]string'
+      ByteSize: 8
+      Pointee: 131 StructureType noalg.map.group[string]string
+    - __kind: PointerType
+      ID: 29
+      Name: '*string'
+      ByteSize: 8
+      GoRuntimeType: 396256
+      GoKind: 22
+      Pointee: 5 GoStringHeaderType string
+    - __kind: PointerType
+      ID: 164
+      Name: '*string.str'
+      ByteSize: 8
+      Pointee: 163 GoStringDataType string.str
+    - __kind: PointerType
+      ID: 41
+      Name: '*table<string,[]*mime/multipart.FileHeader>'
+      ByteSize: 8
+      Pointee: 42 StructureType table<string,[]*mime/multipart.FileHeader>
+    - __kind: PointerType
+      ID: 20
+      Name: '*table<string,[]string>'
+      ByteSize: 8
+      Pointee: 21 StructureType table<string,[]string>
+    - __kind: PointerType
+      ID: 127
+      Name: '*table<string,string>'
+      ByteSize: 8
+      Pointee: 128 StructureType table<string,string>
+    - __kind: PointerType
+      ID: 75
+      Name: '*time.Location'
+      ByteSize: 8
+      GoRuntimeType: 1.602944e+06
+      GoKind: 22
+      Pointee: 76 StructureType time.Location
+    - __kind: PointerType
+      ID: 78
+      Name: '*time.zone'
+      ByteSize: 8
+      GoRuntimeType: 391776
+      GoKind: 22
+      Pointee: 79 StructureType time.zone
+    - __kind: PointerType
+      ID: 81
+      Name: '*time.zoneTrans'
+      ByteSize: 8
+      GoRuntimeType: 391840
+      GoKind: 22
+      Pointee: 82 StructureType time.zoneTrans
+    - __kind: PointerType
+      ID: 161
+      Name: '*uint'
+      ByteSize: 8
+      GoRuntimeType: 396896
+      GoKind: 22
+      Pointee: 145 BaseType uint
+    - __kind: PointerType
+      ID: 156
+      Name: '*uint16'
+      ByteSize: 8
+      GoRuntimeType: 396512
+      GoKind: 22
+      Pointee: 22 BaseType uint16
+    - __kind: PointerType
+      ID: 150
+      Name: '*uint32'
+      ByteSize: 8
+      GoRuntimeType: 396640
+      GoKind: 22
+      Pointee: 140 BaseType uint32
+    - __kind: PointerType
+      ID: 155
+      Name: '*uint64'
+      ByteSize: 8
+      GoRuntimeType: 396768
+      GoKind: 22
+      Pointee: 17 BaseType uint64
+    - __kind: PointerType
+      ID: 6
+      Name: '*uint8'
+      ByteSize: 8
+      GoRuntimeType: 396384
+      GoKind: 22
+      Pointee: 7 BaseType uint8
+    - __kind: PointerType
+      ID: 148
+      Name: '*uintptr'
+      ByteSize: 8
+      GoRuntimeType: 396960
+      GoKind: 22
+      Pointee: 18 BaseType uintptr
+    - __kind: GoChannelType
+      ID: 114
+      Name: <-chan struct {}
+      GoRuntimeType: 592896
+      GoKind: 18
+    - __kind: EventRootType
+      ID: 215
+      Name: Probe[main.HandleHTTP]
+      ByteSize: 25
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: w
+          Offset: 1
+          Expression:
+            Type: 1 GoInterfaceType net/http.ResponseWriter
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 1, index: 0, name: w}
+                  Offset: 0
+                  ByteSize: 16
+        - Name: r
+          Offset: 17
+          Expression:
+            Type: 3 PointerType *net/http.Request
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 1, index: 1, name: r}
+                  Offset: 0
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 216
+      Name: Probe[main.LookAtTheRequest]
+      ByteSize: 17
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: path
+          Offset: 1
+          Expression:
+            Type: 5 GoStringHeaderType string
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 2, index: 0, name: path}
+                  Offset: 0
+                  ByteSize: 16
+    - __kind: GoSliceHeaderType
+      ID: 56
+      Name: '[]*crypto/x509.Certificate'
+      ByteSize: 24
+      GoRuntimeType: 498464
+      GoKind: 23
       RawFields:
-        - Name: ctrl
+        - Name: array
           Offset: 0
-          Type: 17 BaseType uint64
-        - Name: slots
+          Type: 57 PointerType **crypto/x509.Certificate
+        - Name: len
           Offset: 8
-          Type: 46 ArrayType noalg.[8]struct { key string; elem []*mime/multipart.FileHeader }
-    - __kind: ArrayType
-      ID: 46
-      Name: noalg.[8]struct { key string; elem []*mime/multipart.FileHeader }
-      ByteSize: 320
-      GoRuntimeType: 694016
-      GoKind: 17
-      Count: 8
-      HasCount: true
-      Element: 47 StructureType noalg.struct { key string; elem []*mime/multipart.FileHeader }
-    - __kind: StructureType
-      ID: 47
-      Name: noalg.struct { key string; elem []*mime/multipart.FileHeader }
-      ByteSize: 40
-      GoRuntimeType: 1.2904e+06
-      GoKind: 25
-      RawFields:
-        - Name: key
-          Offset: 0
-          Type: 5 GoStringHeaderType string
-        - Name: elem
+          Type: 8 BaseType int
+        - Name: cap
           Offset: 16
-          Type: 48 GoSliceHeaderType []*mime/multipart.FileHeader
+          Type: 8 BaseType int
+      Data: 175 GoSliceDataType []*crypto/x509.Certificate.array
+    - __kind: GoSliceDataType
+      ID: 175
+      Name: '[]*crypto/x509.Certificate.array'
+      ByteSize: 2048
+      Element: 58 PointerType *crypto/x509.Certificate
     - __kind: GoSliceHeaderType
       ID: 48
       Name: '[]*mime/multipart.FileHeader'
@@ -722,54 +695,371 @@ Types:
           Offset: 16
           Type: 8 BaseType int
       Data: 171 GoSliceDataType []*mime/multipart.FileHeader.array
-    - __kind: PointerType
-      ID: 49
-      Name: '**mime/multipart.FileHeader'
-      ByteSize: 8
-      GoKind: 22
-      Pointee: 50 PointerType *mime/multipart.FileHeader
-    - __kind: PointerType
-      ID: 50
-      Name: '*mime/multipart.FileHeader'
-      ByteSize: 8
-      GoRuntimeType: 902912
-      GoKind: 22
-      Pointee: 51 StructureType mime/multipart.FileHeader
-    - __kind: StructureType
-      ID: 51
-      Name: mime/multipart.FileHeader
-      ByteSize: 88
-      GoRuntimeType: 1.962912e+06
-      GoKind: 25
+    - __kind: GoSliceDataType
+      ID: 171
+      Name: '[]*mime/multipart.FileHeader.array'
+      ByteSize: 2048
+      Element: 50 PointerType *mime/multipart.FileHeader
+    - __kind: GoSliceHeaderType
+      ID: 97
+      Name: '[]*net.IPNet'
+      ByteSize: 24
+      GoRuntimeType: 512000
+      GoKind: 23
       RawFields:
-        - Name: Filename
+        - Name: array
           Offset: 0
-          Type: 5 GoStringHeaderType string
-        - Name: Header
+          Type: 98 PointerType **net.IPNet
+        - Name: len
+          Offset: 8
+          Type: 8 BaseType int
+        - Name: cap
           Offset: 16
-          Type: 52 GoMapType net/textproto.MIMEHeader
-        - Name: Size
-          Offset: 24
-          Type: 32 BaseType int64
-        - Name: content
-          Offset: 32
-          Type: 53 GoSliceHeaderType []uint8
-        - Name: tmpfile
-          Offset: 56
-          Type: 5 GoStringHeaderType string
-        - Name: tmpoff
-          Offset: 72
-          Type: 32 BaseType int64
-        - Name: tmpshared
-          Offset: 80
-          Type: 13 BaseType bool
-    - __kind: GoMapType
-      ID: 52
-      Name: net/textproto.MIMEHeader
-      ByteSize: 8
-      GoRuntimeType: 1.808832e+06
-      GoKind: 21
-      HeaderType: 16 GoSwissMapHeaderType map<string,[]string>
+          Type: 8 BaseType int
+      Data: 199 GoSliceDataType []*net.IPNet.array
+    - __kind: GoSliceDataType
+      ID: 199
+      Name: '[]*net.IPNet.array'
+      ByteSize: 2048
+      Element: 99 PointerType *net.IPNet
+    - __kind: GoSliceHeaderType
+      ID: 95
+      Name: '[]*net/url.URL'
+      ByteSize: 24
+      GoRuntimeType: 511936
+      GoKind: 23
+      RawFields:
+        - Name: array
+          Offset: 0
+          Type: 96 PointerType **net/url.URL
+        - Name: len
+          Offset: 8
+          Type: 8 BaseType int
+        - Name: cap
+          Offset: 16
+          Type: 8 BaseType int
+      Data: 197 GoSliceDataType []*net/url.URL.array
+    - __kind: GoSliceDataType
+      ID: 197
+      Name: '[]*net/url.URL.array'
+      ByteSize: 2048
+      Element: 9 PointerType *net/url.URL
+    - __kind: GoSliceDataType
+      ID: 169
+      Name: '[]*table<string,[]*mime/multipart.FileHeader>.array'
+      ByteSize: 8192
+      Element: 41 PointerType *table<string,[]*mime/multipart.FileHeader>
+    - __kind: GoSliceDataType
+      ID: 165
+      Name: '[]*table<string,[]string>.array'
+      ByteSize: 8192
+      Element: 20 PointerType *table<string,[]string>
+    - __kind: GoSliceDataType
+      ID: 213
+      Name: '[]*table<string,string>.array'
+      ByteSize: 8192
+      Element: 127 PointerType *table<string,string>
+    - __kind: GoSliceHeaderType
+      ID: 108
+      Name: '[][]*crypto/x509.Certificate'
+      ByteSize: 24
+      GoRuntimeType: 498592
+      GoKind: 23
+      RawFields:
+        - Name: array
+          Offset: 0
+          Type: 109 PointerType *[]*crypto/x509.Certificate
+        - Name: len
+          Offset: 8
+          Type: 8 BaseType int
+        - Name: cap
+          Offset: 16
+          Type: 8 BaseType int
+      Data: 207 GoSliceDataType [][]*crypto/x509.Certificate.array
+    - __kind: GoSliceDataType
+      ID: 207
+      Name: '[][]*crypto/x509.Certificate.array'
+      ByteSize: 2048
+      Element: 56 GoSliceHeaderType []*crypto/x509.Certificate
+    - __kind: GoSliceHeaderType
+      ID: 110
+      Name: '[][]uint8'
+      ByteSize: 24
+      GoRuntimeType: 478688
+      GoKind: 23
+      RawFields:
+        - Name: array
+          Offset: 0
+          Type: 111 PointerType *[]uint8
+        - Name: len
+          Offset: 8
+          Type: 8 BaseType int
+        - Name: cap
+          Offset: 16
+          Type: 8 BaseType int
+      Data: 209 GoSliceDataType [][]uint8.array
+    - __kind: GoSliceDataType
+      ID: 209
+      Name: '[][]uint8.array'
+      ByteSize: 2048
+      Element: 53 GoSliceHeaderType []uint8
+    - __kind: GoSliceHeaderType
+      ID: 89
+      Name: '[]crypto/x509.ExtKeyUsage'
+      ByteSize: 24
+      GoRuntimeType: 499936
+      GoKind: 23
+      RawFields:
+        - Name: array
+          Offset: 0
+          Type: 90 PointerType *crypto/x509.ExtKeyUsage
+        - Name: len
+          Offset: 8
+          Type: 8 BaseType int
+        - Name: cap
+          Offset: 16
+          Type: 8 BaseType int
+      Data: 191 GoSliceDataType []crypto/x509.ExtKeyUsage.array
+    - __kind: GoSliceDataType
+      ID: 191
+      Name: '[]crypto/x509.ExtKeyUsage.array'
+      ByteSize: 2048
+      Element: 91 BaseType crypto/x509.ExtKeyUsage
+    - __kind: GoSliceHeaderType
+      ID: 102
+      Name: '[]crypto/x509.OID'
+      ByteSize: 24
+      GoRuntimeType: 512064
+      GoKind: 23
+      RawFields:
+        - Name: array
+          Offset: 0
+          Type: 103 PointerType *crypto/x509.OID
+        - Name: len
+          Offset: 8
+          Type: 8 BaseType int
+        - Name: cap
+          Offset: 16
+          Type: 8 BaseType int
+      Data: 203 GoSliceDataType []crypto/x509.OID.array
+    - __kind: GoSliceDataType
+      ID: 203
+      Name: '[]crypto/x509.OID.array'
+      ByteSize: 2048
+      Element: 104 StructureType crypto/x509.OID
+    - __kind: GoSliceHeaderType
+      ID: 105
+      Name: '[]crypto/x509.PolicyMapping'
+      ByteSize: 24
+      GoRuntimeType: 512128
+      GoKind: 23
+      RawFields:
+        - Name: array
+          Offset: 0
+          Type: 106 PointerType *crypto/x509.PolicyMapping
+        - Name: len
+          Offset: 8
+          Type: 8 BaseType int
+        - Name: cap
+          Offset: 16
+          Type: 8 BaseType int
+      Data: 205 GoSliceDataType []crypto/x509.PolicyMapping.array
+    - __kind: GoSliceDataType
+      ID: 205
+      Name: '[]crypto/x509.PolicyMapping.array'
+      ByteSize: 2048
+      Element: 107 StructureType crypto/x509.PolicyMapping
+    - __kind: GoSliceHeaderType
+      ID: 69
+      Name: '[]crypto/x509/pkix.AttributeTypeAndValue'
+      ByteSize: 24
+      GoRuntimeType: 512576
+      GoKind: 23
+      RawFields:
+        - Name: array
+          Offset: 0
+          Type: 70 PointerType *crypto/x509/pkix.AttributeTypeAndValue
+        - Name: len
+          Offset: 8
+          Type: 8 BaseType int
+        - Name: cap
+          Offset: 16
+          Type: 8 BaseType int
+      Data: 179 GoSliceDataType []crypto/x509/pkix.AttributeTypeAndValue.array
+    - __kind: GoSliceDataType
+      ID: 179
+      Name: '[]crypto/x509/pkix.AttributeTypeAndValue.array'
+      ByteSize: 2048
+      Element: 71 StructureType crypto/x509/pkix.AttributeTypeAndValue
+    - __kind: GoSliceHeaderType
+      ID: 84
+      Name: '[]crypto/x509/pkix.Extension'
+      ByteSize: 24
+      GoRuntimeType: 511808
+      GoKind: 23
+      RawFields:
+        - Name: array
+          Offset: 0
+          Type: 85 PointerType *crypto/x509/pkix.Extension
+        - Name: len
+          Offset: 8
+          Type: 8 BaseType int
+        - Name: cap
+          Offset: 16
+          Type: 8 BaseType int
+      Data: 187 GoSliceDataType []crypto/x509/pkix.Extension.array
+    - __kind: GoSliceDataType
+      ID: 187
+      Name: '[]crypto/x509/pkix.Extension.array'
+      ByteSize: 2048
+      Element: 86 StructureType crypto/x509/pkix.Extension
+    - __kind: GoSliceHeaderType
+      ID: 87
+      Name: '[]encoding/asn1.ObjectIdentifier'
+      ByteSize: 24
+      GoRuntimeType: 511872
+      GoKind: 23
+      RawFields:
+        - Name: array
+          Offset: 0
+          Type: 88 PointerType *encoding/asn1.ObjectIdentifier
+        - Name: len
+          Offset: 8
+          Type: 8 BaseType int
+        - Name: cap
+          Offset: 16
+          Type: 8 BaseType int
+      Data: 189 GoSliceDataType []encoding/asn1.ObjectIdentifier.array
+    - __kind: GoSliceDataType
+      ID: 189
+      Name: '[]encoding/asn1.ObjectIdentifier.array'
+      ByteSize: 2048
+      Element: 72 GoSliceHeaderType encoding/asn1.ObjectIdentifier
+    - __kind: GoSliceHeaderType
+      ID: 92
+      Name: '[]net.IP'
+      ByteSize: 24
+      GoRuntimeType: 479648
+      GoKind: 23
+      RawFields:
+        - Name: array
+          Offset: 0
+          Type: 93 PointerType *net.IP
+        - Name: len
+          Offset: 8
+          Type: 8 BaseType int
+        - Name: cap
+          Offset: 16
+          Type: 8 BaseType int
+      Data: 193 GoSliceDataType []net.IP.array
+    - __kind: GoSliceDataType
+      ID: 193
+      Name: '[]net.IP.array'
+      ByteSize: 2048
+      Element: 94 GoSliceHeaderType net.IP
+    - __kind: GoSliceHeaderType
+      ID: 120
+      Name: '[]net/http.segment'
+      ByteSize: 24
+      GoRuntimeType: 481280
+      GoKind: 23
+      RawFields:
+        - Name: array
+          Offset: 0
+          Type: 121 PointerType *net/http.segment
+        - Name: len
+          Offset: 8
+          Type: 8 BaseType int
+        - Name: cap
+          Offset: 16
+          Type: 8 BaseType int
+      Data: 211 GoSliceDataType []net/http.segment.array
+    - __kind: GoSliceDataType
+      ID: 211
+      Name: '[]net/http.segment.array'
+      ByteSize: 2048
+      Element: 122 StructureType net/http.segment
+    - __kind: GoSliceDataType
+      ID: 170
+      Name: '[]noalg.map.group[string][]*mime/multipart.FileHeader.array'
+      ByteSize: 2048
+      Element: 45 StructureType noalg.map.group[string][]*mime/multipart.FileHeader
+    - __kind: GoSliceDataType
+      ID: 166
+      Name: '[]noalg.map.group[string][]string.array'
+      ByteSize: 2048
+      Element: 25 StructureType noalg.map.group[string][]string
+    - __kind: GoSliceDataType
+      ID: 214
+      Name: '[]noalg.map.group[string]string.array'
+      ByteSize: 2048
+      Element: 131 StructureType noalg.map.group[string]string
+    - __kind: GoSliceHeaderType
+      ID: 28
+      Name: '[]string'
+      ByteSize: 24
+      GoRuntimeType: 492832
+      GoKind: 23
+      RawFields:
+        - Name: array
+          Offset: 0
+          Type: 29 PointerType *string
+        - Name: len
+          Offset: 8
+          Type: 8 BaseType int
+        - Name: cap
+          Offset: 16
+          Type: 8 BaseType int
+      Data: 167 GoSliceDataType []string.array
+    - __kind: GoSliceDataType
+      ID: 167
+      Name: '[]string.array'
+      ByteSize: 2048
+      Element: 5 GoStringHeaderType string
+    - __kind: GoSliceHeaderType
+      ID: 77
+      Name: '[]time.zone'
+      ByteSize: 24
+      GoRuntimeType: 485952
+      GoKind: 23
+      RawFields:
+        - Name: array
+          Offset: 0
+          Type: 78 PointerType *time.zone
+        - Name: len
+          Offset: 8
+          Type: 8 BaseType int
+        - Name: cap
+          Offset: 16
+          Type: 8 BaseType int
+      Data: 183 GoSliceDataType []time.zone.array
+    - __kind: GoSliceDataType
+      ID: 183
+      Name: '[]time.zone.array'
+      ByteSize: 2048
+      Element: 79 StructureType time.zone
+    - __kind: GoSliceHeaderType
+      ID: 80
+      Name: '[]time.zoneTrans'
+      ByteSize: 24
+      GoRuntimeType: 486016
+      GoKind: 23
+      RawFields:
+        - Name: array
+          Offset: 0
+          Type: 81 PointerType *time.zoneTrans
+        - Name: len
+          Offset: 8
+          Type: 8 BaseType int
+        - Name: cap
+          Offset: 16
+          Type: 8 BaseType int
+      Data: 185 GoSliceDataType []time.zoneTrans.array
+    - __kind: GoSliceDataType
+      ID: 185
+      Name: '[]time.zoneTrans.array'
+      ByteSize: 2048
+      Element: 82 StructureType time.zoneTrans
     - __kind: GoSliceHeaderType
       ID: 53
       Name: '[]uint8'
@@ -787,13 +1077,79 @@ Types:
           Offset: 16
           Type: 8 BaseType int
       Data: 173 GoSliceDataType []uint8.array
-    - __kind: PointerType
-      ID: 54
-      Name: '*crypto/tls.ConnectionState'
+    - __kind: GoSliceDataType
+      ID: 173
+      Name: '[]uint8.array'
+      ByteSize: 2048
+      Element: 7 BaseType uint8
+    - __kind: BaseType
+      ID: 13
+      Name: bool
+      ByteSize: 1
+      GoRuntimeType: 580672
+      GoKind: 1
+    - __kind: StructureType
+      ID: 135
+      Name: bytes.Buffer
+      ByteSize: 40
+      GoRuntimeType: 1.595648e+06
+      GoKind: 25
+      RawFields:
+        - Name: buf
+          Offset: 0
+          Type: 53 GoSliceHeaderType []uint8
+        - Name: off
+          Offset: 24
+          Type: 8 BaseType int
+        - Name: lastRead
+          Offset: 32
+          Type: 136 BaseType bytes.readOp
+    - __kind: BaseType
+      ID: 136
+      Name: bytes.readOp
+      ByteSize: 1
+      GoRuntimeType: 578816
+      GoKind: 3
+    - __kind: BaseType
+      ID: 152
+      Name: complex128
+      ByteSize: 16
+      GoRuntimeType: 580480
+      GoKind: 16
+    - __kind: BaseType
+      ID: 151
+      Name: complex64
       ByteSize: 8
-      GoRuntimeType: 901472
-      GoKind: 22
-      Pointee: 55 StructureType crypto/tls.ConnectionState
+      GoRuntimeType: 580416
+      GoKind: 15
+    - __kind: GoInterfaceType
+      ID: 117
+      Name: context.Context
+      ByteSize: 16
+      GoRuntimeType: 1.267616e+06
+      GoKind: 20
+      RawFields:
+        - Name: tab
+          Offset: 0
+          Type: 2 VoidPointerType unsafe.Pointer
+        - Name: data
+          Offset: 8
+          Type: 2 VoidPointerType unsafe.Pointer
+    - __kind: StructureType
+      ID: 138
+      Name: context.backgroundCtx
+      GoRuntimeType: 1.781952e+06
+      GoKind: 25
+      RawFields:
+        - Name: emptyCtx
+          Offset: 0
+          Type: 139 StructureType context.emptyCtx
+    - __kind: StructureType
+      ID: 139
+      Name: context.emptyCtx
+      GoRuntimeType: 1.580704e+06
+      GoKind: 25
+      RawFields: []
     - __kind: StructureType
       ID: 55
       Name: crypto/tls.ConnectionState
@@ -849,36 +1205,12 @@ Types:
         - Name: testingOnlyCurveID
           Offset: 186
           Type: 113 BaseType crypto/tls.CurveID
-    - __kind: GoSliceHeaderType
-      ID: 56
-      Name: '[]*crypto/x509.Certificate'
-      ByteSize: 24
-      GoRuntimeType: 498464
-      GoKind: 23
-      RawFields:
-        - Name: array
-          Offset: 0
-          Type: 57 PointerType **crypto/x509.Certificate
-        - Name: len
-          Offset: 8
-          Type: 8 BaseType int
-        - Name: cap
-          Offset: 16
-          Type: 8 BaseType int
-      Data: 175 GoSliceDataType []*crypto/x509.Certificate.array
-    - __kind: PointerType
-      ID: 57
-      Name: '**crypto/x509.Certificate'
-      ByteSize: 8
-      GoKind: 22
-      Pointee: 58 PointerType *crypto/x509.Certificate
-    - __kind: PointerType
-      ID: 58
-      Name: '*crypto/x509.Certificate'
-      ByteSize: 8
-      GoRuntimeType: 2.031072e+06
-      GoKind: 22
-      Pointee: 59 StructureType crypto/x509.Certificate
+    - __kind: BaseType
+      ID: 113
+      Name: crypto/tls.CurveID
+      ByteSize: 2
+      GoRuntimeType: 829664
+      GoKind: 9
     - __kind: StructureType
       ID: 59
       Name: crypto/x509.Certificate
@@ -1043,80 +1375,81 @@ Types:
           Offset: 1400
           Type: 105 GoSliceHeaderType []crypto/x509.PolicyMapping
     - __kind: BaseType
-      ID: 60
-      Name: crypto/x509.SignatureAlgorithm
+      ID: 91
+      Name: crypto/x509.ExtKeyUsage
       ByteSize: 8
-      GoRuntimeType: 1.105248e+06
+      GoRuntimeType: 583360
       GoKind: 2
+    - __kind: BaseType
+      ID: 83
+      Name: crypto/x509.KeyUsage
+      ByteSize: 8
+      GoRuntimeType: 583296
+      GoKind: 2
+    - __kind: StructureType
+      ID: 104
+      Name: crypto/x509.OID
+      ByteSize: 24
+      GoRuntimeType: 1.939168e+06
+      GoKind: 25
+      RawFields:
+        - Name: der
+          Offset: 0
+          Type: 53 GoSliceHeaderType []uint8
+    - __kind: StructureType
+      ID: 107
+      Name: crypto/x509.PolicyMapping
+      ByteSize: 48
+      GoRuntimeType: 1.480928e+06
+      GoKind: 25
+      RawFields:
+        - Name: IssuerDomainPolicy
+          Offset: 0
+          Type: 104 StructureType crypto/x509.OID
+        - Name: SubjectDomainPolicy
+          Offset: 24
+          Type: 104 StructureType crypto/x509.OID
     - __kind: BaseType
       ID: 61
       Name: crypto/x509.PublicKeyAlgorithm
       ByteSize: 8
       GoRuntimeType: 832064
       GoKind: 2
-    - __kind: GoEmptyInterfaceType
-      ID: 62
-      Name: interface {}
-      ByteSize: 16
-      GoRuntimeType: 849280
-      GoKind: 20
-      RawFields:
-        - Name: _type
-          Offset: 0
-          Type: 2 VoidPointerType unsafe.Pointer
-        - Name: data
-          Offset: 8
-          Type: 2 VoidPointerType unsafe.Pointer
-    - __kind: PointerType
-      ID: 63
-      Name: '*math/big.Int'
+    - __kind: BaseType
+      ID: 60
+      Name: crypto/x509.SignatureAlgorithm
       ByteSize: 8
-      GoRuntimeType: 2.365472e+06
-      GoKind: 22
-      Pointee: 64 StructureType math/big.Int
+      GoRuntimeType: 1.105248e+06
+      GoKind: 2
     - __kind: StructureType
-      ID: 64
-      Name: math/big.Int
-      ByteSize: 32
-      GoRuntimeType: 1.483968e+06
+      ID: 71
+      Name: crypto/x509/pkix.AttributeTypeAndValue
+      ByteSize: 40
+      GoRuntimeType: 1.492608e+06
       GoKind: 25
       RawFields:
-        - Name: neg
+        - Name: Type
           Offset: 0
-          Type: 13 BaseType bool
-        - Name: abs
-          Offset: 8
-          Type: 65 GoSliceHeaderType math/big.nat
-    - __kind: GoSliceHeaderType
-      ID: 65
-      Name: math/big.nat
-      ByteSize: 24
-      GoRuntimeType: 2.346272e+06
-      GoKind: 23
+          Type: 72 GoSliceHeaderType encoding/asn1.ObjectIdentifier
+        - Name: Value
+          Offset: 24
+          Type: 62 GoEmptyInterfaceType interface {}
+    - __kind: StructureType
+      ID: 86
+      Name: crypto/x509/pkix.Extension
+      ByteSize: 56
+      GoRuntimeType: 1.63616e+06
+      GoKind: 25
       RawFields:
-        - Name: array
+        - Name: Id
           Offset: 0
-          Type: 66 PointerType *math/big.Word
-        - Name: len
-          Offset: 8
-          Type: 8 BaseType int
-        - Name: cap
-          Offset: 16
-          Type: 8 BaseType int
-      Data: 177 GoSliceDataType math/big.nat.array
-    - __kind: PointerType
-      ID: 66
-      Name: '*math/big.Word'
-      ByteSize: 8
-      GoRuntimeType: 423200
-      GoKind: 22
-      Pointee: 67 BaseType math/big.Word
-    - __kind: BaseType
-      ID: 67
-      Name: math/big.Word
-      ByteSize: 8
-      GoRuntimeType: 583552
-      GoKind: 7
+          Type: 72 GoSliceHeaderType encoding/asn1.ObjectIdentifier
+        - Name: Critical
+          Offset: 24
+          Type: 13 BaseType bool
+        - Name: Value
+          Offset: 32
+          Type: 53 GoSliceHeaderType []uint8
     - __kind: StructureType
       ID: 68
       Name: crypto/x509/pkix.Name
@@ -1158,43 +1491,6 @@ Types:
           Offset: 224
           Type: 69 GoSliceHeaderType []crypto/x509/pkix.AttributeTypeAndValue
     - __kind: GoSliceHeaderType
-      ID: 69
-      Name: '[]crypto/x509/pkix.AttributeTypeAndValue'
-      ByteSize: 24
-      GoRuntimeType: 512576
-      GoKind: 23
-      RawFields:
-        - Name: array
-          Offset: 0
-          Type: 70 PointerType *crypto/x509/pkix.AttributeTypeAndValue
-        - Name: len
-          Offset: 8
-          Type: 8 BaseType int
-        - Name: cap
-          Offset: 16
-          Type: 8 BaseType int
-      Data: 179 GoSliceDataType []crypto/x509/pkix.AttributeTypeAndValue.array
-    - __kind: PointerType
-      ID: 70
-      Name: '*crypto/x509/pkix.AttributeTypeAndValue'
-      ByteSize: 8
-      GoRuntimeType: 434080
-      GoKind: 22
-      Pointee: 71 StructureType crypto/x509/pkix.AttributeTypeAndValue
-    - __kind: StructureType
-      ID: 71
-      Name: crypto/x509/pkix.AttributeTypeAndValue
-      ByteSize: 40
-      GoRuntimeType: 1.492608e+06
-      GoKind: 25
-      RawFields:
-        - Name: Type
-          Offset: 0
-          Type: 72 GoSliceHeaderType encoding/asn1.ObjectIdentifier
-        - Name: Value
-          Offset: 24
-          Type: 62 GoEmptyInterfaceType interface {}
-    - __kind: GoSliceHeaderType
       ID: 72
       Name: encoding/asn1.ObjectIdentifier
       ByteSize: 24
@@ -1211,271 +1507,358 @@ Types:
           Offset: 16
           Type: 8 BaseType int
       Data: 181 GoSliceDataType encoding/asn1.ObjectIdentifier.array
-    - __kind: PointerType
-      ID: 73
-      Name: '*int'
+    - __kind: GoSliceDataType
+      ID: 181
+      Name: encoding/asn1.ObjectIdentifier.array
+      ByteSize: 2048
+      Element: 8 BaseType int
+    - __kind: GoInterfaceType
+      ID: 143
+      Name: error
+      ByteSize: 16
+      GoRuntimeType: 1.023328e+06
+      GoKind: 20
+      RawFields:
+        - Name: tab
+          Offset: 0
+          Type: 2 VoidPointerType unsafe.Pointer
+        - Name: data
+          Offset: 8
+          Type: 2 VoidPointerType unsafe.Pointer
+    - __kind: BaseType
+      ID: 146
+      Name: float32
+      ByteSize: 4
+      GoRuntimeType: 580544
+      GoKind: 13
+    - __kind: BaseType
+      ID: 147
+      Name: float64
       ByteSize: 8
-      GoRuntimeType: 396832
-      GoKind: 22
-      Pointee: 8 BaseType int
-    - __kind: StructureType
-      ID: 74
-      Name: time.Time
-      ByteSize: 24
-      GoRuntimeType: 2.349088e+06
+      GoRuntimeType: 580608
+      GoKind: 14
+    - __kind: GoSubroutineType
+      ID: 31
+      Name: func() (io.ReadCloser, error)
+      ByteSize: 8
+      GoRuntimeType: 687968
+      GoKind: 19
+    - __kind: GoSubroutineType
+      ID: 112
+      Name: func(string, []uint8, int) ([]uint8, error)
+      ByteSize: 8
+      GoRuntimeType: 995552
+      GoKind: 19
+    - __kind: GoInterfaceType
+      ID: 137
+      Name: gopkg.in/DataDog/dd-trace-go.v1/ddtrace.Span
+      ByteSize: 16
+      GoRuntimeType: 1.469568e+06
+      GoKind: 20
+      RawFields:
+        - Name: tab
+          Offset: 0
+          Type: 2 VoidPointerType unsafe.Pointer
+        - Name: data
+          Offset: 8
+          Type: 2 VoidPointerType unsafe.Pointer
+    - __kind: GoSwissMapGroupsType
+      ID: 43
+      Name: groupReference<string,[]*mime/multipart.FileHeader>
+      ByteSize: 16
       GoKind: 25
       RawFields:
-        - Name: wall
+        - Name: data
+          Offset: 0
+          Type: 44 PointerType *noalg.map.group[string][]*mime/multipart.FileHeader
+        - Name: lengthMask
+          Offset: 8
+          Type: 17 BaseType uint64
+      GroupType: 45 StructureType noalg.map.group[string][]*mime/multipart.FileHeader
+      GroupSliceType: 170 GoSliceDataType []noalg.map.group[string][]*mime/multipart.FileHeader.array
+    - __kind: GoSwissMapGroupsType
+      ID: 23
+      Name: groupReference<string,[]string>
+      ByteSize: 16
+      GoKind: 25
+      RawFields:
+        - Name: data
+          Offset: 0
+          Type: 24 PointerType *noalg.map.group[string][]string
+        - Name: lengthMask
+          Offset: 8
+          Type: 17 BaseType uint64
+      GroupType: 25 StructureType noalg.map.group[string][]string
+      GroupSliceType: 166 GoSliceDataType []noalg.map.group[string][]string.array
+    - __kind: GoSwissMapGroupsType
+      ID: 129
+      Name: groupReference<string,string>
+      ByteSize: 16
+      GoKind: 25
+      RawFields:
+        - Name: data
+          Offset: 0
+          Type: 130 PointerType *noalg.map.group[string]string
+        - Name: lengthMask
+          Offset: 8
+          Type: 17 BaseType uint64
+      GroupType: 131 StructureType noalg.map.group[string]string
+      GroupSliceType: 214 GoSliceDataType []noalg.map.group[string]string.array
+    - __kind: BaseType
+      ID: 8
+      Name: int
+      ByteSize: 8
+      GoRuntimeType: 580224
+      GoKind: 2
+    - __kind: BaseType
+      ID: 158
+      Name: int16
+      ByteSize: 2
+      GoRuntimeType: 579840
+      GoKind: 4
+    - __kind: BaseType
+      ID: 141
+      Name: int32
+      ByteSize: 4
+      GoRuntimeType: 579968
+      GoKind: 5
+    - __kind: BaseType
+      ID: 32
+      Name: int64
+      ByteSize: 8
+      GoRuntimeType: 580096
+      GoKind: 6
+    - __kind: BaseType
+      ID: 144
+      Name: int8
+      ByteSize: 1
+      GoRuntimeType: 579712
+      GoKind: 3
+    - __kind: GoEmptyInterfaceType
+      ID: 62
+      Name: interface {}
+      ByteSize: 16
+      GoRuntimeType: 849280
+      GoKind: 20
+      RawFields:
+        - Name: _type
+          Offset: 0
+          Type: 2 VoidPointerType unsafe.Pointer
+        - Name: data
+          Offset: 8
+          Type: 2 VoidPointerType unsafe.Pointer
+    - __kind: GoInterfaceType
+      ID: 30
+      Name: io.ReadCloser
+      ByteSize: 16
+      GoRuntimeType: 1.10128e+06
+      GoKind: 20
+      RawFields:
+        - Name: tab
+          Offset: 0
+          Type: 2 VoidPointerType unsafe.Pointer
+        - Name: data
+          Offset: 8
+          Type: 2 VoidPointerType unsafe.Pointer
+    - __kind: GoSwissMapHeaderType
+      ID: 39
+      Name: map<string,[]*mime/multipart.FileHeader>
+      ByteSize: 48
+      GoKind: 25
+      RawFields:
+        - Name: used
           Offset: 0
           Type: 17 BaseType uint64
-        - Name: ext
+        - Name: seed
           Offset: 8
-          Type: 32 BaseType int64
-        - Name: loc
+          Type: 18 BaseType uintptr
+        - Name: dirPtr
           Offset: 16
-          Type: 75 PointerType *time.Location
-    - __kind: PointerType
-      ID: 75
-      Name: '*time.Location'
-      ByteSize: 8
-      GoRuntimeType: 1.602944e+06
-      GoKind: 22
-      Pointee: 76 StructureType time.Location
-    - __kind: StructureType
-      ID: 76
-      Name: time.Location
-      ByteSize: 104
-      GoRuntimeType: 1.958592e+06
-      GoKind: 25
-      RawFields:
-        - Name: name
-          Offset: 0
-          Type: 5 GoStringHeaderType string
-        - Name: zone
-          Offset: 16
-          Type: 77 GoSliceHeaderType []time.zone
-        - Name: tx
-          Offset: 40
-          Type: 80 GoSliceHeaderType []time.zoneTrans
-        - Name: extend
-          Offset: 64
-          Type: 5 GoStringHeaderType string
-        - Name: cacheStart
-          Offset: 80
-          Type: 32 BaseType int64
-        - Name: cacheEnd
-          Offset: 88
-          Type: 32 BaseType int64
-        - Name: cacheZone
-          Offset: 96
-          Type: 78 PointerType *time.zone
-    - __kind: GoSliceHeaderType
-      ID: 77
-      Name: '[]time.zone'
-      ByteSize: 24
-      GoRuntimeType: 485952
-      GoKind: 23
-      RawFields:
-        - Name: array
-          Offset: 0
-          Type: 78 PointerType *time.zone
-        - Name: len
-          Offset: 8
-          Type: 8 BaseType int
-        - Name: cap
-          Offset: 16
-          Type: 8 BaseType int
-      Data: 183 GoSliceDataType []time.zone.array
-    - __kind: PointerType
-      ID: 78
-      Name: '*time.zone'
-      ByteSize: 8
-      GoRuntimeType: 391776
-      GoKind: 22
-      Pointee: 79 StructureType time.zone
-    - __kind: StructureType
-      ID: 79
-      Name: time.zone
-      ByteSize: 32
-      GoRuntimeType: 1.602752e+06
-      GoKind: 25
-      RawFields:
-        - Name: name
-          Offset: 0
-          Type: 5 GoStringHeaderType string
-        - Name: offset
-          Offset: 16
-          Type: 8 BaseType int
-        - Name: isDST
+          Type: 40 PointerType **table<string,[]*mime/multipart.FileHeader>
+        - Name: dirLen
           Offset: 24
-          Type: 13 BaseType bool
-    - __kind: GoSliceHeaderType
-      ID: 80
-      Name: '[]time.zoneTrans'
-      ByteSize: 24
-      GoRuntimeType: 486016
-      GoKind: 23
-      RawFields:
-        - Name: array
-          Offset: 0
-          Type: 81 PointerType *time.zoneTrans
-        - Name: len
-          Offset: 8
           Type: 8 BaseType int
-        - Name: cap
-          Offset: 16
-          Type: 8 BaseType int
-      Data: 185 GoSliceDataType []time.zoneTrans.array
-    - __kind: PointerType
-      ID: 81
-      Name: '*time.zoneTrans'
-      ByteSize: 8
-      GoRuntimeType: 391840
-      GoKind: 22
-      Pointee: 82 StructureType time.zoneTrans
-    - __kind: StructureType
-      ID: 82
-      Name: time.zoneTrans
-      ByteSize: 16
-      GoRuntimeType: 1.73712e+06
-      GoKind: 25
-      RawFields:
-        - Name: when
-          Offset: 0
-          Type: 32 BaseType int64
-        - Name: index
-          Offset: 8
+        - Name: globalDepth
+          Offset: 32
           Type: 7 BaseType uint8
-        - Name: isstd
-          Offset: 9
-          Type: 13 BaseType bool
-        - Name: isutc
-          Offset: 10
-          Type: 13 BaseType bool
-    - __kind: BaseType
-      ID: 83
-      Name: crypto/x509.KeyUsage
+        - Name: globalShift
+          Offset: 33
+          Type: 7 BaseType uint8
+        - Name: writing
+          Offset: 34
+          Type: 7 BaseType uint8
+        - Name: clearSeq
+          Offset: 40
+          Type: 17 BaseType uint64
+      TablePtrSliceType: 169 GoSliceDataType []*table<string,[]*mime/multipart.FileHeader>.array
+      GroupType: 45 StructureType noalg.map.group[string][]*mime/multipart.FileHeader
+    - __kind: GoSwissMapHeaderType
+      ID: 16
+      Name: map<string,[]string>
+      ByteSize: 48
+      GoKind: 25
+      RawFields:
+        - Name: used
+          Offset: 0
+          Type: 17 BaseType uint64
+        - Name: seed
+          Offset: 8
+          Type: 18 BaseType uintptr
+        - Name: dirPtr
+          Offset: 16
+          Type: 19 PointerType **table<string,[]string>
+        - Name: dirLen
+          Offset: 24
+          Type: 8 BaseType int
+        - Name: globalDepth
+          Offset: 32
+          Type: 7 BaseType uint8
+        - Name: globalShift
+          Offset: 33
+          Type: 7 BaseType uint8
+        - Name: writing
+          Offset: 34
+          Type: 7 BaseType uint8
+        - Name: clearSeq
+          Offset: 40
+          Type: 17 BaseType uint64
+      TablePtrSliceType: 165 GoSliceDataType []*table<string,[]string>.array
+      GroupType: 25 StructureType noalg.map.group[string][]string
+    - __kind: GoSwissMapHeaderType
+      ID: 125
+      Name: map<string,string>
+      ByteSize: 48
+      GoKind: 25
+      RawFields:
+        - Name: used
+          Offset: 0
+          Type: 17 BaseType uint64
+        - Name: seed
+          Offset: 8
+          Type: 18 BaseType uintptr
+        - Name: dirPtr
+          Offset: 16
+          Type: 126 PointerType **table<string,string>
+        - Name: dirLen
+          Offset: 24
+          Type: 8 BaseType int
+        - Name: globalDepth
+          Offset: 32
+          Type: 7 BaseType uint8
+        - Name: globalShift
+          Offset: 33
+          Type: 7 BaseType uint8
+        - Name: writing
+          Offset: 34
+          Type: 7 BaseType uint8
+        - Name: clearSeq
+          Offset: 40
+          Type: 17 BaseType uint64
+      TablePtrSliceType: 213 GoSliceDataType []*table<string,string>.array
+      GroupType: 131 StructureType noalg.map.group[string]string
+    - __kind: GoMapType
+      ID: 37
+      Name: map[string][]*mime/multipart.FileHeader
       ByteSize: 8
-      GoRuntimeType: 583296
-      GoKind: 2
+      GoRuntimeType: 1.123296e+06
+      GoKind: 21
+      HeaderType: 39 GoSwissMapHeaderType map<string,[]*mime/multipart.FileHeader>
+    - __kind: GoMapType
+      ID: 36
+      Name: map[string][]string
+      ByteSize: 8
+      GoRuntimeType: 1.118688e+06
+      GoKind: 21
+      HeaderType: 16 GoSwissMapHeaderType map<string,[]string>
+    - __kind: GoMapType
+      ID: 123
+      Name: map[string]string
+      ByteSize: 8
+      GoRuntimeType: 1.119712e+06
+      GoKind: 21
+      HeaderType: 125 GoSwissMapHeaderType map<string,string>
+    - __kind: StructureType
+      ID: 64
+      Name: math/big.Int
+      ByteSize: 32
+      GoRuntimeType: 1.483968e+06
+      GoKind: 25
+      RawFields:
+        - Name: neg
+          Offset: 0
+          Type: 13 BaseType bool
+        - Name: abs
+          Offset: 8
+          Type: 65 GoSliceHeaderType math/big.nat
+    - __kind: BaseType
+      ID: 67
+      Name: math/big.Word
+      ByteSize: 8
+      GoRuntimeType: 583552
+      GoKind: 7
     - __kind: GoSliceHeaderType
-      ID: 84
-      Name: '[]crypto/x509/pkix.Extension'
+      ID: 65
+      Name: math/big.nat
       ByteSize: 24
-      GoRuntimeType: 511808
+      GoRuntimeType: 2.346272e+06
       GoKind: 23
       RawFields:
         - Name: array
           Offset: 0
-          Type: 85 PointerType *crypto/x509/pkix.Extension
+          Type: 66 PointerType *math/big.Word
         - Name: len
           Offset: 8
           Type: 8 BaseType int
         - Name: cap
           Offset: 16
           Type: 8 BaseType int
-      Data: 187 GoSliceDataType []crypto/x509/pkix.Extension.array
-    - __kind: PointerType
-      ID: 85
-      Name: '*crypto/x509/pkix.Extension'
-      ByteSize: 8
-      GoRuntimeType: 434272
-      GoKind: 22
-      Pointee: 86 StructureType crypto/x509/pkix.Extension
+      Data: 177 GoSliceDataType math/big.nat.array
+    - __kind: GoSliceDataType
+      ID: 177
+      Name: math/big.nat.array
+      ByteSize: 2048
+      Element: 67 BaseType math/big.Word
     - __kind: StructureType
-      ID: 86
-      Name: crypto/x509/pkix.Extension
-      ByteSize: 56
-      GoRuntimeType: 1.63616e+06
+      ID: 51
+      Name: mime/multipart.FileHeader
+      ByteSize: 88
+      GoRuntimeType: 1.962912e+06
       GoKind: 25
       RawFields:
-        - Name: Id
+        - Name: Filename
           Offset: 0
-          Type: 72 GoSliceHeaderType encoding/asn1.ObjectIdentifier
-        - Name: Critical
+          Type: 5 GoStringHeaderType string
+        - Name: Header
+          Offset: 16
+          Type: 52 GoMapType net/textproto.MIMEHeader
+        - Name: Size
           Offset: 24
-          Type: 13 BaseType bool
-        - Name: Value
+          Type: 32 BaseType int64
+        - Name: content
           Offset: 32
           Type: 53 GoSliceHeaderType []uint8
-    - __kind: GoSliceHeaderType
-      ID: 87
-      Name: '[]encoding/asn1.ObjectIdentifier'
-      ByteSize: 24
-      GoRuntimeType: 511872
-      GoKind: 23
+        - Name: tmpfile
+          Offset: 56
+          Type: 5 GoStringHeaderType string
+        - Name: tmpoff
+          Offset: 72
+          Type: 32 BaseType int64
+        - Name: tmpshared
+          Offset: 80
+          Type: 13 BaseType bool
+    - __kind: StructureType
+      ID: 35
+      Name: mime/multipart.Form
+      ByteSize: 16
+      GoRuntimeType: 1.467968e+06
+      GoKind: 25
       RawFields:
-        - Name: array
+        - Name: Value
           Offset: 0
-          Type: 88 PointerType *encoding/asn1.ObjectIdentifier
-        - Name: len
+          Type: 36 GoMapType map[string][]string
+        - Name: File
           Offset: 8
-          Type: 8 BaseType int
-        - Name: cap
-          Offset: 16
-          Type: 8 BaseType int
-      Data: 189 GoSliceDataType []encoding/asn1.ObjectIdentifier.array
-    - __kind: PointerType
-      ID: 88
-      Name: '*encoding/asn1.ObjectIdentifier'
-      ByteSize: 8
-      GoRuntimeType: 1.044704e+06
-      GoKind: 22
-      Pointee: 72 GoSliceHeaderType encoding/asn1.ObjectIdentifier
-    - __kind: GoSliceHeaderType
-      ID: 89
-      Name: '[]crypto/x509.ExtKeyUsage'
-      ByteSize: 24
-      GoRuntimeType: 499936
-      GoKind: 23
-      RawFields:
-        - Name: array
-          Offset: 0
-          Type: 90 PointerType *crypto/x509.ExtKeyUsage
-        - Name: len
-          Offset: 8
-          Type: 8 BaseType int
-        - Name: cap
-          Offset: 16
-          Type: 8 BaseType int
-      Data: 191 GoSliceDataType []crypto/x509.ExtKeyUsage.array
-    - __kind: PointerType
-      ID: 90
-      Name: '*crypto/x509.ExtKeyUsage'
-      ByteSize: 8
-      GoRuntimeType: 420256
-      GoKind: 22
-      Pointee: 91 BaseType crypto/x509.ExtKeyUsage
-    - __kind: BaseType
-      ID: 91
-      Name: crypto/x509.ExtKeyUsage
-      ByteSize: 8
-      GoRuntimeType: 583360
-      GoKind: 2
-    - __kind: GoSliceHeaderType
-      ID: 92
-      Name: '[]net.IP'
-      ByteSize: 24
-      GoRuntimeType: 479648
-      GoKind: 23
-      RawFields:
-        - Name: array
-          Offset: 0
-          Type: 93 PointerType *net.IP
-        - Name: len
-          Offset: 8
-          Type: 8 BaseType int
-        - Name: cap
-          Offset: 16
-          Type: 8 BaseType int
-      Data: 193 GoSliceDataType []net.IP.array
-    - __kind: PointerType
-      ID: 93
-      Name: '*net.IP'
-      ByteSize: 8
-      GoRuntimeType: 2.13488e+06
-      GoKind: 22
-      Pointee: 94 GoSliceHeaderType net.IP
+          Type: 37 GoMapType map[string][]*mime/multipart.FileHeader
     - __kind: GoSliceHeaderType
       ID: 94
       Name: net.IP
@@ -1493,72 +1876,11 @@ Types:
           Offset: 16
           Type: 8 BaseType int
       Data: 195 GoSliceDataType net.IP.array
-    - __kind: GoSliceHeaderType
-      ID: 95
-      Name: '[]*net/url.URL'
-      ByteSize: 24
-      GoRuntimeType: 511936
-      GoKind: 23
-      RawFields:
-        - Name: array
-          Offset: 0
-          Type: 96 PointerType **net/url.URL
-        - Name: len
-          Offset: 8
-          Type: 8 BaseType int
-        - Name: cap
-          Offset: 16
-          Type: 8 BaseType int
-      Data: 197 GoSliceDataType []*net/url.URL.array
-    - __kind: PointerType
-      ID: 96
-      Name: '**net/url.URL'
-      ByteSize: 8
-      GoKind: 22
-      Pointee: 9 PointerType *net/url.URL
-    - __kind: GoSliceHeaderType
-      ID: 97
-      Name: '[]*net.IPNet'
-      ByteSize: 24
-      GoRuntimeType: 512000
-      GoKind: 23
-      RawFields:
-        - Name: array
-          Offset: 0
-          Type: 98 PointerType **net.IPNet
-        - Name: len
-          Offset: 8
-          Type: 8 BaseType int
-        - Name: cap
-          Offset: 16
-          Type: 8 BaseType int
-      Data: 199 GoSliceDataType []*net.IPNet.array
-    - __kind: PointerType
-      ID: 98
-      Name: '**net.IPNet'
-      ByteSize: 8
-      GoKind: 22
-      Pointee: 99 PointerType *net.IPNet
-    - __kind: PointerType
-      ID: 99
-      Name: '*net.IPNet'
-      ByteSize: 8
-      GoRuntimeType: 1.174624e+06
-      GoKind: 22
-      Pointee: 100 StructureType net.IPNet
-    - __kind: StructureType
-      ID: 100
-      Name: net.IPNet
-      ByteSize: 48
-      GoRuntimeType: 1.449408e+06
-      GoKind: 25
-      RawFields:
-        - Name: IP
-          Offset: 0
-          Type: 94 GoSliceHeaderType net.IP
-        - Name: Mask
-          Offset: 24
-          Type: 101 GoSliceHeaderType net.IPMask
+    - __kind: GoSliceDataType
+      ID: 195
+      Name: net.IP.array
+      ByteSize: 2048
+      Element: 7 BaseType uint8
     - __kind: GoSliceHeaderType
       ID: 101
       Name: net.IPMask
@@ -1576,148 +1898,116 @@ Types:
           Offset: 16
           Type: 8 BaseType int
       Data: 201 GoSliceDataType net.IPMask.array
-    - __kind: GoSliceHeaderType
-      ID: 102
-      Name: '[]crypto/x509.OID'
-      ByteSize: 24
-      GoRuntimeType: 512064
-      GoKind: 23
-      RawFields:
-        - Name: array
-          Offset: 0
-          Type: 103 PointerType *crypto/x509.OID
-        - Name: len
-          Offset: 8
-          Type: 8 BaseType int
-        - Name: cap
-          Offset: 16
-          Type: 8 BaseType int
-      Data: 203 GoSliceDataType []crypto/x509.OID.array
-    - __kind: PointerType
-      ID: 103
-      Name: '*crypto/x509.OID'
-      ByteSize: 8
-      GoRuntimeType: 1.938912e+06
-      GoKind: 22
-      Pointee: 104 StructureType crypto/x509.OID
+    - __kind: GoSliceDataType
+      ID: 201
+      Name: net.IPMask.array
+      ByteSize: 2048
+      Element: 7 BaseType uint8
     - __kind: StructureType
-      ID: 104
-      Name: crypto/x509.OID
-      ByteSize: 24
-      GoRuntimeType: 1.939168e+06
-      GoKind: 25
-      RawFields:
-        - Name: der
-          Offset: 0
-          Type: 53 GoSliceHeaderType []uint8
-    - __kind: GoSliceHeaderType
-      ID: 105
-      Name: '[]crypto/x509.PolicyMapping'
-      ByteSize: 24
-      GoRuntimeType: 512128
-      GoKind: 23
-      RawFields:
-        - Name: array
-          Offset: 0
-          Type: 106 PointerType *crypto/x509.PolicyMapping
-        - Name: len
-          Offset: 8
-          Type: 8 BaseType int
-        - Name: cap
-          Offset: 16
-          Type: 8 BaseType int
-      Data: 205 GoSliceDataType []crypto/x509.PolicyMapping.array
-    - __kind: PointerType
-      ID: 106
-      Name: '*crypto/x509.PolicyMapping'
-      ByteSize: 8
-      GoRuntimeType: 420320
-      GoKind: 22
-      Pointee: 107 StructureType crypto/x509.PolicyMapping
-    - __kind: StructureType
-      ID: 107
-      Name: crypto/x509.PolicyMapping
+      ID: 100
+      Name: net.IPNet
       ByteSize: 48
-      GoRuntimeType: 1.480928e+06
+      GoRuntimeType: 1.449408e+06
       GoKind: 25
       RawFields:
-        - Name: IssuerDomainPolicy
+        - Name: IP
           Offset: 0
-          Type: 104 StructureType crypto/x509.OID
-        - Name: SubjectDomainPolicy
+          Type: 94 GoSliceHeaderType net.IP
+        - Name: Mask
           Offset: 24
-          Type: 104 StructureType crypto/x509.OID
-    - __kind: GoSliceHeaderType
-      ID: 108
-      Name: '[][]*crypto/x509.Certificate'
-      ByteSize: 24
-      GoRuntimeType: 498592
-      GoKind: 23
+          Type: 101 GoSliceHeaderType net.IPMask
+    - __kind: GoMapType
+      ID: 14
+      Name: net/http.Header
+      ByteSize: 8
+      GoRuntimeType: 2.088128e+06
+      GoKind: 21
+      HeaderType: 16 GoSwissMapHeaderType map<string,[]string>
+    - __kind: StructureType
+      ID: 4
+      Name: net/http.Request
+      ByteSize: 304
+      GoRuntimeType: 2.322816e+06
+      GoKind: 25
       RawFields:
-        - Name: array
+        - Name: Method
           Offset: 0
-          Type: 109 PointerType *[]*crypto/x509.Certificate
-        - Name: len
-          Offset: 8
-          Type: 8 BaseType int
-        - Name: cap
+          Type: 5 GoStringHeaderType string
+        - Name: URL
           Offset: 16
+          Type: 9 PointerType *net/url.URL
+        - Name: Proto
+          Offset: 24
+          Type: 5 GoStringHeaderType string
+        - Name: ProtoMajor
+          Offset: 40
           Type: 8 BaseType int
-      Data: 207 GoSliceDataType [][]*crypto/x509.Certificate.array
-    - __kind: PointerType
-      ID: 109
-      Name: '*[]*crypto/x509.Certificate'
-      ByteSize: 8
-      GoKind: 22
-      Pointee: 56 GoSliceHeaderType []*crypto/x509.Certificate
-    - __kind: GoSliceHeaderType
-      ID: 110
-      Name: '[][]uint8'
-      ByteSize: 24
-      GoRuntimeType: 478688
-      GoKind: 23
-      RawFields:
-        - Name: array
-          Offset: 0
-          Type: 111 PointerType *[]uint8
-        - Name: len
-          Offset: 8
+        - Name: ProtoMinor
+          Offset: 48
           Type: 8 BaseType int
-        - Name: cap
-          Offset: 16
-          Type: 8 BaseType int
-      Data: 209 GoSliceDataType [][]uint8.array
-    - __kind: PointerType
-      ID: 111
-      Name: '*[]uint8'
-      ByteSize: 8
-      GoRuntimeType: 478304
-      GoKind: 22
-      Pointee: 53 GoSliceHeaderType []uint8
-    - __kind: GoSubroutineType
-      ID: 112
-      Name: func(string, []uint8, int) ([]uint8, error)
-      ByteSize: 8
-      GoRuntimeType: 995552
-      GoKind: 19
-    - __kind: BaseType
-      ID: 113
-      Name: crypto/tls.CurveID
-      ByteSize: 2
-      GoRuntimeType: 829664
-      GoKind: 9
-    - __kind: GoChannelType
-      ID: 114
-      Name: <-chan struct {}
-      GoRuntimeType: 592896
-      GoKind: 18
-    - __kind: PointerType
-      ID: 115
-      Name: '*net/http.Response'
-      ByteSize: 8
-      GoRuntimeType: 1.706048e+06
-      GoKind: 22
-      Pointee: 116 StructureType net/http.Response
+        - Name: Header
+          Offset: 56
+          Type: 14 GoMapType net/http.Header
+        - Name: Body
+          Offset: 64
+          Type: 30 GoInterfaceType io.ReadCloser
+        - Name: GetBody
+          Offset: 80
+          Type: 31 GoSubroutineType func() (io.ReadCloser, error)
+        - Name: ContentLength
+          Offset: 88
+          Type: 32 BaseType int64
+        - Name: TransferEncoding
+          Offset: 96
+          Type: 28 GoSliceHeaderType []string
+        - Name: Close
+          Offset: 120
+          Type: 13 BaseType bool
+        - Name: Host
+          Offset: 128
+          Type: 5 GoStringHeaderType string
+        - Name: Form
+          Offset: 144
+          Type: 33 GoMapType net/url.Values
+        - Name: PostForm
+          Offset: 152
+          Type: 33 GoMapType net/url.Values
+        - Name: MultipartForm
+          Offset: 160
+          Type: 34 PointerType *mime/multipart.Form
+        - Name: Trailer
+          Offset: 168
+          Type: 14 GoMapType net/http.Header
+        - Name: RemoteAddr
+          Offset: 176
+          Type: 5 GoStringHeaderType string
+        - Name: RequestURI
+          Offset: 192
+          Type: 5 GoStringHeaderType string
+        - Name: TLS
+          Offset: 208
+          Type: 54 PointerType *crypto/tls.ConnectionState
+        - Name: Cancel
+          Offset: 216
+          Type: 114 GoChannelType <-chan struct {}
+        - Name: Response
+          Offset: 224
+          Type: 115 PointerType *net/http.Response
+        - Name: Pattern
+          Offset: 232
+          Type: 5 GoStringHeaderType string
+        - Name: ctx
+          Offset: 248
+          Type: 117 GoInterfaceType context.Context
+        - Name: pat
+          Offset: 264
+          Type: 118 PointerType *net/http.pattern
+        - Name: matches
+          Offset: 272
+          Type: 28 GoSliceHeaderType []string
+        - Name: otherValues
+          Offset: 296
+          Type: 123 GoMapType map[string]string
     - __kind: StructureType
       ID: 116
       Name: net/http.Response
@@ -1768,10 +2058,10 @@ Types:
           Offset: 136
           Type: 54 PointerType *crypto/tls.ConnectionState
     - __kind: GoInterfaceType
-      ID: 117
-      Name: context.Context
+      ID: 1
+      Name: net/http.ResponseWriter
       ByteSize: 16
-      GoRuntimeType: 1.267616e+06
+      GoRuntimeType: 1.177056e+06
       GoKind: 20
       RawFields:
         - Name: tab
@@ -1780,13 +2070,6 @@ Types:
         - Name: data
           Offset: 8
           Type: 2 VoidPointerType unsafe.Pointer
-    - __kind: PointerType
-      ID: 118
-      Name: '*net/http.pattern'
-      ByteSize: 8
-      GoRuntimeType: 1.597952e+06
-      GoKind: 22
-      Pointee: 119 StructureType net/http.pattern
     - __kind: StructureType
       ID: 119
       Name: net/http.pattern
@@ -1809,30 +2092,6 @@ Types:
         - Name: loc
           Offset: 72
           Type: 5 GoStringHeaderType string
-    - __kind: GoSliceHeaderType
-      ID: 120
-      Name: '[]net/http.segment'
-      ByteSize: 24
-      GoRuntimeType: 481280
-      GoKind: 23
-      RawFields:
-        - Name: array
-          Offset: 0
-          Type: 121 PointerType *net/http.segment
-        - Name: len
-          Offset: 8
-          Type: 8 BaseType int
-        - Name: cap
-          Offset: 16
-          Type: 8 BaseType int
-      Data: 211 GoSliceDataType []net/http.segment.array
-    - __kind: PointerType
-      ID: 121
-      Name: '*net/http.segment'
-      ByteSize: 8
-      GoRuntimeType: 388640
-      GoKind: 22
-      Pointee: 122 StructureType net/http.segment
     - __kind: StructureType
       ID: 122
       Name: net/http.segment
@@ -1850,59 +2109,246 @@ Types:
           Offset: 17
           Type: 13 BaseType bool
     - __kind: GoMapType
-      ID: 123
-      Name: map[string]string
+      ID: 52
+      Name: net/textproto.MIMEHeader
       ByteSize: 8
-      GoRuntimeType: 1.119712e+06
+      GoRuntimeType: 1.808832e+06
       GoKind: 21
-      HeaderType: 125 GoSwissMapHeaderType map<string,string>
-    - __kind: PointerType
-      ID: 124
-      Name: '*map<string,string>'
+      HeaderType: 16 GoSwissMapHeaderType map<string,[]string>
+    - __kind: StructureType
+      ID: 10
+      Name: net/url.URL
+      ByteSize: 144
+      GoRuntimeType: 2.113024e+06
+      GoKind: 25
+      RawFields:
+        - Name: Scheme
+          Offset: 0
+          Type: 5 GoStringHeaderType string
+        - Name: Opaque
+          Offset: 16
+          Type: 5 GoStringHeaderType string
+        - Name: User
+          Offset: 32
+          Type: 11 PointerType *net/url.Userinfo
+        - Name: Host
+          Offset: 40
+          Type: 5 GoStringHeaderType string
+        - Name: Path
+          Offset: 56
+          Type: 5 GoStringHeaderType string
+        - Name: RawPath
+          Offset: 72
+          Type: 5 GoStringHeaderType string
+        - Name: OmitHost
+          Offset: 88
+          Type: 13 BaseType bool
+        - Name: ForceQuery
+          Offset: 89
+          Type: 13 BaseType bool
+        - Name: RawQuery
+          Offset: 96
+          Type: 5 GoStringHeaderType string
+        - Name: Fragment
+          Offset: 112
+          Type: 5 GoStringHeaderType string
+        - Name: RawFragment
+          Offset: 128
+          Type: 5 GoStringHeaderType string
+    - __kind: StructureType
+      ID: 12
+      Name: net/url.Userinfo
+      ByteSize: 40
+      GoRuntimeType: 1.61408e+06
+      GoKind: 25
+      RawFields:
+        - Name: username
+          Offset: 0
+          Type: 5 GoStringHeaderType string
+        - Name: password
+          Offset: 16
+          Type: 5 GoStringHeaderType string
+        - Name: passwordSet
+          Offset: 32
+          Type: 13 BaseType bool
+    - __kind: GoMapType
+      ID: 33
+      Name: net/url.Values
       ByteSize: 8
-      Pointee: 125 GoSwissMapHeaderType map<string,string>
-    - __kind: GoSwissMapHeaderType
-      ID: 125
-      Name: map<string,string>
-      ByteSize: 48
+      GoRuntimeType: 1.871296e+06
+      GoKind: 21
+      HeaderType: 16 GoSwissMapHeaderType map<string,[]string>
+    - __kind: ArrayType
+      ID: 46
+      Name: noalg.[8]struct { key string; elem []*mime/multipart.FileHeader }
+      ByteSize: 320
+      GoRuntimeType: 694016
+      GoKind: 17
+      Count: 8
+      HasCount: true
+      Element: 47 StructureType noalg.struct { key string; elem []*mime/multipart.FileHeader }
+    - __kind: ArrayType
+      ID: 26
+      Name: noalg.[8]struct { key string; elem []string }
+      ByteSize: 320
+      GoRuntimeType: 684000
+      GoKind: 17
+      Count: 8
+      HasCount: true
+      Element: 27 StructureType noalg.struct { key string; elem []string }
+    - __kind: ArrayType
+      ID: 132
+      Name: noalg.[8]struct { key string; elem string }
+      ByteSize: 256
+      GoRuntimeType: 688160
+      GoKind: 17
+      Count: 8
+      HasCount: true
+      Element: 133 StructureType noalg.struct { key string; elem string }
+    - __kind: StructureType
+      ID: 45
+      Name: noalg.map.group[string][]*mime/multipart.FileHeader
+      ByteSize: 328
+      GoRuntimeType: 1.290528e+06
+      GoKind: 25
+      RawFields:
+        - Name: ctrl
+          Offset: 0
+          Type: 17 BaseType uint64
+        - Name: slots
+          Offset: 8
+          Type: 46 ArrayType noalg.[8]struct { key string; elem []*mime/multipart.FileHeader }
+    - __kind: StructureType
+      ID: 25
+      Name: noalg.map.group[string][]string
+      ByteSize: 328
+      GoRuntimeType: 1.281056e+06
+      GoKind: 25
+      RawFields:
+        - Name: ctrl
+          Offset: 0
+          Type: 17 BaseType uint64
+        - Name: slots
+          Offset: 8
+          Type: 26 ArrayType noalg.[8]struct { key string; elem []string }
+    - __kind: StructureType
+      ID: 131
+      Name: noalg.map.group[string]string
+      ByteSize: 264
+      GoRuntimeType: 1.28336e+06
+      GoKind: 25
+      RawFields:
+        - Name: ctrl
+          Offset: 0
+          Type: 17 BaseType uint64
+        - Name: slots
+          Offset: 8
+          Type: 132 ArrayType noalg.[8]struct { key string; elem string }
+    - __kind: StructureType
+      ID: 47
+      Name: noalg.struct { key string; elem []*mime/multipart.FileHeader }
+      ByteSize: 40
+      GoRuntimeType: 1.2904e+06
+      GoKind: 25
+      RawFields:
+        - Name: key
+          Offset: 0
+          Type: 5 GoStringHeaderType string
+        - Name: elem
+          Offset: 16
+          Type: 48 GoSliceHeaderType []*mime/multipart.FileHeader
+    - __kind: StructureType
+      ID: 27
+      Name: noalg.struct { key string; elem []string }
+      ByteSize: 40
+      GoRuntimeType: 1.280928e+06
+      GoKind: 25
+      RawFields:
+        - Name: key
+          Offset: 0
+          Type: 5 GoStringHeaderType string
+        - Name: elem
+          Offset: 16
+          Type: 28 GoSliceHeaderType []string
+    - __kind: StructureType
+      ID: 133
+      Name: noalg.struct { key string; elem string }
+      ByteSize: 32
+      GoRuntimeType: 1.283232e+06
+      GoKind: 25
+      RawFields:
+        - Name: key
+          Offset: 0
+          Type: 5 GoStringHeaderType string
+        - Name: elem
+          Offset: 16
+          Type: 5 GoStringHeaderType string
+    - __kind: GoStringHeaderType
+      ID: 5
+      Name: string
+      ByteSize: 16
+      GoRuntimeType: 579648
+      GoKind: 24
+      RawFields:
+        - Name: str
+          Offset: 0
+          Type: 164 PointerType *string.str
+        - Name: len
+          Offset: 8
+          Type: 8 BaseType int
+      Data: 163 GoStringDataType string.str
+    - __kind: GoStringDataType
+      ID: 163
+      Name: string.str
+      ByteSize: 2048
+    - __kind: StructureType
+      ID: 42
+      Name: table<string,[]*mime/multipart.FileHeader>
+      ByteSize: 32
       GoKind: 25
       RawFields:
         - Name: used
           Offset: 0
-          Type: 17 BaseType uint64
-        - Name: seed
+          Type: 22 BaseType uint16
+        - Name: capacity
+          Offset: 2
+          Type: 22 BaseType uint16
+        - Name: growthLeft
+          Offset: 4
+          Type: 22 BaseType uint16
+        - Name: localDepth
+          Offset: 6
+          Type: 7 BaseType uint8
+        - Name: index
           Offset: 8
-          Type: 18 BaseType uintptr
-        - Name: dirPtr
-          Offset: 16
-          Type: 126 PointerType **table<string,string>
-        - Name: dirLen
-          Offset: 24
           Type: 8 BaseType int
-        - Name: globalDepth
-          Offset: 32
+        - Name: groups
+          Offset: 16
+          Type: 43 GoSwissMapGroupsType groupReference<string,[]*mime/multipart.FileHeader>
+    - __kind: StructureType
+      ID: 21
+      Name: table<string,[]string>
+      ByteSize: 32
+      GoKind: 25
+      RawFields:
+        - Name: used
+          Offset: 0
+          Type: 22 BaseType uint16
+        - Name: capacity
+          Offset: 2
+          Type: 22 BaseType uint16
+        - Name: growthLeft
+          Offset: 4
+          Type: 22 BaseType uint16
+        - Name: localDepth
+          Offset: 6
           Type: 7 BaseType uint8
-        - Name: globalShift
-          Offset: 33
-          Type: 7 BaseType uint8
-        - Name: writing
-          Offset: 34
-          Type: 7 BaseType uint8
-        - Name: clearSeq
-          Offset: 40
-          Type: 17 BaseType uint64
-      TablePtrSliceType: 213 GoSliceDataType []*table<string,string>.array
-      GroupType: 131 StructureType noalg.map.group[string]string
-    - __kind: PointerType
-      ID: 126
-      Name: '**table<string,string>'
-      ByteSize: 8
-      Pointee: 127 PointerType *table<string,string>
-    - __kind: PointerType
-      ID: 127
-      Name: '*table<string,string>'
-      ByteSize: 8
-      Pointee: 128 StructureType table<string,string>
+        - Name: index
+          Offset: 8
+          Type: 8 BaseType int
+        - Name: groups
+          Offset: 16
+          Type: 23 GoSwissMapGroupsType groupReference<string,[]string>
     - __kind: StructureType
       ID: 128
       Name: table<string,string>
@@ -1927,155 +2373,85 @@ Types:
         - Name: groups
           Offset: 16
           Type: 129 GoSwissMapGroupsType groupReference<string,string>
-    - __kind: GoSwissMapGroupsType
-      ID: 129
-      Name: groupReference<string,string>
-      ByteSize: 16
-      GoKind: 25
-      RawFields:
-        - Name: data
-          Offset: 0
-          Type: 130 PointerType *noalg.map.group[string]string
-        - Name: lengthMask
-          Offset: 8
-          Type: 17 BaseType uint64
-      GroupType: 131 StructureType noalg.map.group[string]string
-      GroupSliceType: 214 GoSliceDataType []noalg.map.group[string]string.array
-    - __kind: PointerType
-      ID: 130
-      Name: '*noalg.map.group[string]string'
-      ByteSize: 8
-      Pointee: 131 StructureType noalg.map.group[string]string
     - __kind: StructureType
-      ID: 131
-      Name: noalg.map.group[string]string
-      ByteSize: 264
-      GoRuntimeType: 1.28336e+06
+      ID: 76
+      Name: time.Location
+      ByteSize: 104
+      GoRuntimeType: 1.958592e+06
       GoKind: 25
       RawFields:
-        - Name: ctrl
-          Offset: 0
-          Type: 17 BaseType uint64
-        - Name: slots
-          Offset: 8
-          Type: 132 ArrayType noalg.[8]struct { key string; elem string }
-    - __kind: ArrayType
-      ID: 132
-      Name: noalg.[8]struct { key string; elem string }
-      ByteSize: 256
-      GoRuntimeType: 688160
-      GoKind: 17
-      Count: 8
-      HasCount: true
-      Element: 133 StructureType noalg.struct { key string; elem string }
-    - __kind: StructureType
-      ID: 133
-      Name: noalg.struct { key string; elem string }
-      ByteSize: 32
-      GoRuntimeType: 1.283232e+06
-      GoKind: 25
-      RawFields:
-        - Name: key
+        - Name: name
           Offset: 0
           Type: 5 GoStringHeaderType string
-        - Name: elem
+        - Name: zone
           Offset: 16
+          Type: 77 GoSliceHeaderType []time.zone
+        - Name: tx
+          Offset: 40
+          Type: 80 GoSliceHeaderType []time.zoneTrans
+        - Name: extend
+          Offset: 64
           Type: 5 GoStringHeaderType string
-    - __kind: PointerType
-      ID: 134
-      Name: '*bytes.Buffer'
-      ByteSize: 8
-      GoRuntimeType: 2.245824e+06
-      GoKind: 22
-      Pointee: 135 StructureType bytes.Buffer
+        - Name: cacheStart
+          Offset: 80
+          Type: 32 BaseType int64
+        - Name: cacheEnd
+          Offset: 88
+          Type: 32 BaseType int64
+        - Name: cacheZone
+          Offset: 96
+          Type: 78 PointerType *time.zone
     - __kind: StructureType
-      ID: 135
-      Name: bytes.Buffer
-      ByteSize: 40
-      GoRuntimeType: 1.595648e+06
+      ID: 74
+      Name: time.Time
+      ByteSize: 24
+      GoRuntimeType: 2.349088e+06
       GoKind: 25
       RawFields:
-        - Name: buf
+        - Name: wall
           Offset: 0
-          Type: 53 GoSliceHeaderType []uint8
-        - Name: off
-          Offset: 24
+          Type: 17 BaseType uint64
+        - Name: ext
+          Offset: 8
+          Type: 32 BaseType int64
+        - Name: loc
+          Offset: 16
+          Type: 75 PointerType *time.Location
+    - __kind: StructureType
+      ID: 79
+      Name: time.zone
+      ByteSize: 32
+      GoRuntimeType: 1.602752e+06
+      GoKind: 25
+      RawFields:
+        - Name: name
+          Offset: 0
+          Type: 5 GoStringHeaderType string
+        - Name: offset
+          Offset: 16
           Type: 8 BaseType int
-        - Name: lastRead
-          Offset: 32
-          Type: 136 BaseType bytes.readOp
-    - __kind: BaseType
-      ID: 136
-      Name: bytes.readOp
-      ByteSize: 1
-      GoRuntimeType: 578816
-      GoKind: 3
-    - __kind: GoInterfaceType
-      ID: 137
-      Name: gopkg.in/DataDog/dd-trace-go.v1/ddtrace.Span
-      ByteSize: 16
-      GoRuntimeType: 1.469568e+06
-      GoKind: 20
-      RawFields:
-        - Name: tab
-          Offset: 0
-          Type: 2 VoidPointerType unsafe.Pointer
-        - Name: data
-          Offset: 8
-          Type: 2 VoidPointerType unsafe.Pointer
+        - Name: isDST
+          Offset: 24
+          Type: 13 BaseType bool
     - __kind: StructureType
-      ID: 138
-      Name: context.backgroundCtx
-      GoRuntimeType: 1.781952e+06
+      ID: 82
+      Name: time.zoneTrans
+      ByteSize: 16
+      GoRuntimeType: 1.73712e+06
       GoKind: 25
       RawFields:
-        - Name: emptyCtx
+        - Name: when
           Offset: 0
-          Type: 139 StructureType context.emptyCtx
-    - __kind: StructureType
-      ID: 139
-      Name: context.emptyCtx
-      GoRuntimeType: 1.580704e+06
-      GoKind: 25
-      RawFields: []
-    - __kind: BaseType
-      ID: 140
-      Name: uint32
-      ByteSize: 4
-      GoRuntimeType: 580032
-      GoKind: 10
-    - __kind: BaseType
-      ID: 141
-      Name: int32
-      ByteSize: 4
-      GoRuntimeType: 579968
-      GoKind: 5
-    - __kind: PointerType
-      ID: 142
-      Name: '*bool'
-      ByteSize: 8
-      GoRuntimeType: 397280
-      GoKind: 22
-      Pointee: 13 BaseType bool
-    - __kind: GoInterfaceType
-      ID: 143
-      Name: error
-      ByteSize: 16
-      GoRuntimeType: 1.023328e+06
-      GoKind: 20
-      RawFields:
-        - Name: tab
-          Offset: 0
-          Type: 2 VoidPointerType unsafe.Pointer
-        - Name: data
+          Type: 32 BaseType int64
+        - Name: index
           Offset: 8
-          Type: 2 VoidPointerType unsafe.Pointer
-    - __kind: BaseType
-      ID: 144
-      Name: int8
-      ByteSize: 1
-      GoRuntimeType: 579712
-      GoKind: 3
+          Type: 7 BaseType uint8
+        - Name: isstd
+          Offset: 9
+          Type: 13 BaseType bool
+        - Name: isutc
+          Offset: 10
+          Type: 13 BaseType bool
     - __kind: BaseType
       ID: 145
       Name: uint
@@ -2083,417 +2459,41 @@ Types:
       GoRuntimeType: 580288
       GoKind: 7
     - __kind: BaseType
-      ID: 146
-      Name: float32
-      ByteSize: 4
-      GoRuntimeType: 580544
-      GoKind: 13
-    - __kind: BaseType
-      ID: 147
-      Name: float64
-      ByteSize: 8
-      GoRuntimeType: 580608
-      GoKind: 14
-    - __kind: PointerType
-      ID: 148
-      Name: '*uintptr'
-      ByteSize: 8
-      GoRuntimeType: 396960
-      GoKind: 22
-      Pointee: 18 BaseType uintptr
-    - __kind: PointerType
-      ID: 149
-      Name: '*int32'
-      ByteSize: 8
-      GoRuntimeType: 396576
-      GoKind: 22
-      Pointee: 141 BaseType int32
-    - __kind: PointerType
-      ID: 150
-      Name: '*uint32'
-      ByteSize: 8
-      GoRuntimeType: 396640
-      GoKind: 22
-      Pointee: 140 BaseType uint32
-    - __kind: BaseType
-      ID: 151
-      Name: complex64
-      ByteSize: 8
-      GoRuntimeType: 580416
-      GoKind: 15
-    - __kind: BaseType
-      ID: 152
-      Name: complex128
-      ByteSize: 16
-      GoRuntimeType: 580480
-      GoKind: 16
-    - __kind: PointerType
-      ID: 153
-      Name: '*float64'
-      ByteSize: 8
-      GoRuntimeType: 397216
-      GoKind: 22
-      Pointee: 147 BaseType float64
-    - __kind: PointerType
-      ID: 154
-      Name: '*int64'
-      ByteSize: 8
-      GoRuntimeType: 396704
-      GoKind: 22
-      Pointee: 32 BaseType int64
-    - __kind: PointerType
-      ID: 155
-      Name: '*uint64'
-      ByteSize: 8
-      GoRuntimeType: 396768
-      GoKind: 22
-      Pointee: 17 BaseType uint64
-    - __kind: PointerType
-      ID: 156
-      Name: '*uint16'
-      ByteSize: 8
-      GoRuntimeType: 396512
-      GoKind: 22
-      Pointee: 22 BaseType uint16
-    - __kind: PointerType
-      ID: 157
-      Name: '*int16'
-      ByteSize: 8
-      GoRuntimeType: 396448
-      GoKind: 22
-      Pointee: 158 BaseType int16
-    - __kind: BaseType
-      ID: 158
-      Name: int16
+      ID: 22
+      Name: uint16
       ByteSize: 2
-      GoRuntimeType: 579840
-      GoKind: 4
-    - __kind: PointerType
-      ID: 159
-      Name: '*int8'
+      GoRuntimeType: 579904
+      GoKind: 9
+    - __kind: BaseType
+      ID: 140
+      Name: uint32
+      ByteSize: 4
+      GoRuntimeType: 580032
+      GoKind: 10
+    - __kind: BaseType
+      ID: 17
+      Name: uint64
       ByteSize: 8
-      GoRuntimeType: 396320
-      GoKind: 22
-      Pointee: 144 BaseType int8
-    - __kind: PointerType
-      ID: 160
-      Name: '*error'
+      GoRuntimeType: 580160
+      GoKind: 11
+    - __kind: BaseType
+      ID: 7
+      Name: uint8
+      ByteSize: 1
+      GoRuntimeType: 579776
+      GoKind: 8
+    - __kind: BaseType
+      ID: 18
+      Name: uintptr
       ByteSize: 8
-      GoRuntimeType: 396192
-      GoKind: 22
-      Pointee: 143 GoInterfaceType error
-    - __kind: PointerType
-      ID: 161
-      Name: '*uint'
+      GoRuntimeType: 580352
+      GoKind: 12
+    - __kind: VoidPointerType
+      ID: 2
+      Name: unsafe.Pointer
       ByteSize: 8
-      GoRuntimeType: 396896
-      GoKind: 22
-      Pointee: 145 BaseType uint
-    - __kind: PointerType
-      ID: 162
-      Name: '*float32'
-      ByteSize: 8
-      GoRuntimeType: 397152
-      GoKind: 22
-      Pointee: 146 BaseType float32
-    - __kind: GoStringDataType
-      ID: 163
-      Name: string.str
-      ByteSize: 2048
-    - __kind: PointerType
-      ID: 164
-      Name: '*string.str'
-      ByteSize: 8
-      Pointee: 163 GoStringDataType string.str
-    - __kind: GoSliceDataType
-      ID: 165
-      Name: '[]*table<string,[]string>.array'
-      ByteSize: 8192
-      Element: 20 PointerType *table<string,[]string>
-    - __kind: GoSliceDataType
-      ID: 166
-      Name: '[]noalg.map.group[string][]string.array'
-      ByteSize: 2048
-      Element: 25 StructureType noalg.map.group[string][]string
-    - __kind: GoSliceDataType
-      ID: 167
-      Name: '[]string.array'
-      ByteSize: 2048
-      Element: 5 GoStringHeaderType string
-    - __kind: PointerType
-      ID: 168
-      Name: '*[]string.array'
-      ByteSize: 8
-      Pointee: 167 GoSliceDataType []string.array
-    - __kind: GoSliceDataType
-      ID: 169
-      Name: '[]*table<string,[]*mime/multipart.FileHeader>.array'
-      ByteSize: 8192
-      Element: 41 PointerType *table<string,[]*mime/multipart.FileHeader>
-    - __kind: GoSliceDataType
-      ID: 170
-      Name: '[]noalg.map.group[string][]*mime/multipart.FileHeader.array'
-      ByteSize: 2048
-      Element: 45 StructureType noalg.map.group[string][]*mime/multipart.FileHeader
-    - __kind: GoSliceDataType
-      ID: 171
-      Name: '[]*mime/multipart.FileHeader.array'
-      ByteSize: 2048
-      Element: 50 PointerType *mime/multipart.FileHeader
-    - __kind: PointerType
-      ID: 172
-      Name: '*[]*mime/multipart.FileHeader.array'
-      ByteSize: 8
-      Pointee: 171 GoSliceDataType []*mime/multipart.FileHeader.array
-    - __kind: GoSliceDataType
-      ID: 173
-      Name: '[]uint8.array'
-      ByteSize: 2048
-      Element: 7 BaseType uint8
-    - __kind: PointerType
-      ID: 174
-      Name: '*[]uint8.array'
-      ByteSize: 8
-      Pointee: 173 GoSliceDataType []uint8.array
-    - __kind: GoSliceDataType
-      ID: 175
-      Name: '[]*crypto/x509.Certificate.array'
-      ByteSize: 2048
-      Element: 58 PointerType *crypto/x509.Certificate
-    - __kind: PointerType
-      ID: 176
-      Name: '*[]*crypto/x509.Certificate.array'
-      ByteSize: 8
-      Pointee: 175 GoSliceDataType []*crypto/x509.Certificate.array
-    - __kind: GoSliceDataType
-      ID: 177
-      Name: math/big.nat.array
-      ByteSize: 2048
-      Element: 67 BaseType math/big.Word
-    - __kind: PointerType
-      ID: 178
-      Name: '*math/big.nat.array'
-      ByteSize: 8
-      Pointee: 177 GoSliceDataType math/big.nat.array
-    - __kind: GoSliceDataType
-      ID: 179
-      Name: '[]crypto/x509/pkix.AttributeTypeAndValue.array'
-      ByteSize: 2048
-      Element: 71 StructureType crypto/x509/pkix.AttributeTypeAndValue
-    - __kind: PointerType
-      ID: 180
-      Name: '*[]crypto/x509/pkix.AttributeTypeAndValue.array'
-      ByteSize: 8
-      Pointee: 179 GoSliceDataType []crypto/x509/pkix.AttributeTypeAndValue.array
-    - __kind: GoSliceDataType
-      ID: 181
-      Name: encoding/asn1.ObjectIdentifier.array
-      ByteSize: 2048
-      Element: 8 BaseType int
-    - __kind: PointerType
-      ID: 182
-      Name: '*encoding/asn1.ObjectIdentifier.array'
-      ByteSize: 8
-      Pointee: 181 GoSliceDataType encoding/asn1.ObjectIdentifier.array
-    - __kind: GoSliceDataType
-      ID: 183
-      Name: '[]time.zone.array'
-      ByteSize: 2048
-      Element: 79 StructureType time.zone
-    - __kind: PointerType
-      ID: 184
-      Name: '*[]time.zone.array'
-      ByteSize: 8
-      Pointee: 183 GoSliceDataType []time.zone.array
-    - __kind: GoSliceDataType
-      ID: 185
-      Name: '[]time.zoneTrans.array'
-      ByteSize: 2048
-      Element: 82 StructureType time.zoneTrans
-    - __kind: PointerType
-      ID: 186
-      Name: '*[]time.zoneTrans.array'
-      ByteSize: 8
-      Pointee: 185 GoSliceDataType []time.zoneTrans.array
-    - __kind: GoSliceDataType
-      ID: 187
-      Name: '[]crypto/x509/pkix.Extension.array'
-      ByteSize: 2048
-      Element: 86 StructureType crypto/x509/pkix.Extension
-    - __kind: PointerType
-      ID: 188
-      Name: '*[]crypto/x509/pkix.Extension.array'
-      ByteSize: 8
-      Pointee: 187 GoSliceDataType []crypto/x509/pkix.Extension.array
-    - __kind: GoSliceDataType
-      ID: 189
-      Name: '[]encoding/asn1.ObjectIdentifier.array'
-      ByteSize: 2048
-      Element: 72 GoSliceHeaderType encoding/asn1.ObjectIdentifier
-    - __kind: PointerType
-      ID: 190
-      Name: '*[]encoding/asn1.ObjectIdentifier.array'
-      ByteSize: 8
-      Pointee: 189 GoSliceDataType []encoding/asn1.ObjectIdentifier.array
-    - __kind: GoSliceDataType
-      ID: 191
-      Name: '[]crypto/x509.ExtKeyUsage.array'
-      ByteSize: 2048
-      Element: 91 BaseType crypto/x509.ExtKeyUsage
-    - __kind: PointerType
-      ID: 192
-      Name: '*[]crypto/x509.ExtKeyUsage.array'
-      ByteSize: 8
-      Pointee: 191 GoSliceDataType []crypto/x509.ExtKeyUsage.array
-    - __kind: GoSliceDataType
-      ID: 193
-      Name: '[]net.IP.array'
-      ByteSize: 2048
-      Element: 94 GoSliceHeaderType net.IP
-    - __kind: PointerType
-      ID: 194
-      Name: '*[]net.IP.array'
-      ByteSize: 8
-      Pointee: 193 GoSliceDataType []net.IP.array
-    - __kind: GoSliceDataType
-      ID: 195
-      Name: net.IP.array
-      ByteSize: 2048
-      Element: 7 BaseType uint8
-    - __kind: PointerType
-      ID: 196
-      Name: '*net.IP.array'
-      ByteSize: 8
-      Pointee: 195 GoSliceDataType net.IP.array
-    - __kind: GoSliceDataType
-      ID: 197
-      Name: '[]*net/url.URL.array'
-      ByteSize: 2048
-      Element: 9 PointerType *net/url.URL
-    - __kind: PointerType
-      ID: 198
-      Name: '*[]*net/url.URL.array'
-      ByteSize: 8
-      Pointee: 197 GoSliceDataType []*net/url.URL.array
-    - __kind: GoSliceDataType
-      ID: 199
-      Name: '[]*net.IPNet.array'
-      ByteSize: 2048
-      Element: 99 PointerType *net.IPNet
-    - __kind: PointerType
-      ID: 200
-      Name: '*[]*net.IPNet.array'
-      ByteSize: 8
-      Pointee: 199 GoSliceDataType []*net.IPNet.array
-    - __kind: GoSliceDataType
-      ID: 201
-      Name: net.IPMask.array
-      ByteSize: 2048
-      Element: 7 BaseType uint8
-    - __kind: PointerType
-      ID: 202
-      Name: '*net.IPMask.array'
-      ByteSize: 8
-      Pointee: 201 GoSliceDataType net.IPMask.array
-    - __kind: GoSliceDataType
-      ID: 203
-      Name: '[]crypto/x509.OID.array'
-      ByteSize: 2048
-      Element: 104 StructureType crypto/x509.OID
-    - __kind: PointerType
-      ID: 204
-      Name: '*[]crypto/x509.OID.array'
-      ByteSize: 8
-      Pointee: 203 GoSliceDataType []crypto/x509.OID.array
-    - __kind: GoSliceDataType
-      ID: 205
-      Name: '[]crypto/x509.PolicyMapping.array'
-      ByteSize: 2048
-      Element: 107 StructureType crypto/x509.PolicyMapping
-    - __kind: PointerType
-      ID: 206
-      Name: '*[]crypto/x509.PolicyMapping.array'
-      ByteSize: 8
-      Pointee: 205 GoSliceDataType []crypto/x509.PolicyMapping.array
-    - __kind: GoSliceDataType
-      ID: 207
-      Name: '[][]*crypto/x509.Certificate.array'
-      ByteSize: 2048
-      Element: 56 GoSliceHeaderType []*crypto/x509.Certificate
-    - __kind: PointerType
-      ID: 208
-      Name: '*[][]*crypto/x509.Certificate.array'
-      ByteSize: 8
-      Pointee: 207 GoSliceDataType [][]*crypto/x509.Certificate.array
-    - __kind: GoSliceDataType
-      ID: 209
-      Name: '[][]uint8.array'
-      ByteSize: 2048
-      Element: 53 GoSliceHeaderType []uint8
-    - __kind: PointerType
-      ID: 210
-      Name: '*[][]uint8.array'
-      ByteSize: 8
-      Pointee: 209 GoSliceDataType [][]uint8.array
-    - __kind: GoSliceDataType
-      ID: 211
-      Name: '[]net/http.segment.array'
-      ByteSize: 2048
-      Element: 122 StructureType net/http.segment
-    - __kind: PointerType
-      ID: 212
-      Name: '*[]net/http.segment.array'
-      ByteSize: 8
-      Pointee: 211 GoSliceDataType []net/http.segment.array
-    - __kind: GoSliceDataType
-      ID: 213
-      Name: '[]*table<string,string>.array'
-      ByteSize: 8192
-      Element: 127 PointerType *table<string,string>
-    - __kind: GoSliceDataType
-      ID: 214
-      Name: '[]noalg.map.group[string]string.array'
-      ByteSize: 2048
-      Element: 131 StructureType noalg.map.group[string]string
-    - __kind: EventRootType
-      ID: 215
-      Name: Probe[main.HandleHTTP]
-      ByteSize: 25
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: w
-          Offset: 1
-          Expression:
-            Type: 1 GoInterfaceType net/http.ResponseWriter
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 1, index: 0, name: w}
-                  Offset: 0
-                  ByteSize: 16
-        - Name: r
-          Offset: 17
-          Expression:
-            Type: 3 PointerType *net/http.Request
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 1, index: 1, name: r}
-                  Offset: 0
-                  ByteSize: 8
-    - __kind: EventRootType
-      ID: 216
-      Name: Probe[main.LookAtTheRequest]
-      ByteSize: 17
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: path
-          Offset: 1
-          Expression:
-            Type: 5 GoStringHeaderType string
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 2, index: 0, name: path}
-                  Offset: 0
-                  ByteSize: 16
+      GoRuntimeType: 580736
+      GoKind: 26
 MaxTypeID: 216
 Issues: []
 GoModuledataInfo: {FirstModuledataAddr: "0x181b800", TypesOffset: 296}

--- a/pkg/dyninst/irgen/testdata/snapshot/rc_tester_v1.arch=amd64,toolchain=go1.25.0.yaml
+++ b/pkg/dyninst/irgen/testdata/snapshot/rc_tester_v1.arch=amd64,toolchain=go1.25.0.yaml
@@ -113,435 +113,320 @@ Subprograms:
           IsParameter: true
           IsReturn: false
 Types:
-    - __kind: GoInterfaceType
-      ID: 1
-      Name: net/http.ResponseWriter
-      ByteSize: 16
-      GoRuntimeType: 1.185792e+06
-      GoKind: 20
-      RawFields:
-        - Name: tab
-          Offset: 0
-          Type: 2 VoidPointerType unsafe.Pointer
-        - Name: data
-          Offset: 8
-          Type: 2 VoidPointerType unsafe.Pointer
-    - __kind: VoidPointerType
-      ID: 2
-      Name: unsafe.Pointer
-      ByteSize: 8
-      GoRuntimeType: 585536
-      GoKind: 26
     - __kind: PointerType
-      ID: 3
-      Name: '*net/http.Request'
+      ID: 58
+      Name: '**crypto/x509.Certificate'
       ByteSize: 8
-      GoRuntimeType: 2.30096e+06
       GoKind: 22
-      Pointee: 4 StructureType net/http.Request
-    - __kind: StructureType
-      ID: 4
-      Name: net/http.Request
-      ByteSize: 304
-      GoRuntimeType: 2.336832e+06
-      GoKind: 25
-      RawFields:
-        - Name: Method
-          Offset: 0
-          Type: 5 GoStringHeaderType string
-        - Name: URL
-          Offset: 16
-          Type: 9 PointerType *net/url.URL
-        - Name: Proto
-          Offset: 24
-          Type: 5 GoStringHeaderType string
-        - Name: ProtoMajor
-          Offset: 40
-          Type: 8 BaseType int
-        - Name: ProtoMinor
-          Offset: 48
-          Type: 8 BaseType int
-        - Name: Header
-          Offset: 56
-          Type: 14 GoMapType net/http.Header
-        - Name: Body
-          Offset: 64
-          Type: 30 GoInterfaceType io.ReadCloser
-        - Name: GetBody
-          Offset: 80
-          Type: 31 GoSubroutineType func() (io.ReadCloser, error)
-        - Name: ContentLength
-          Offset: 88
-          Type: 32 BaseType int64
-        - Name: TransferEncoding
-          Offset: 96
-          Type: 28 GoSliceHeaderType []string
-        - Name: Close
-          Offset: 120
-          Type: 13 BaseType bool
-        - Name: Host
-          Offset: 128
-          Type: 5 GoStringHeaderType string
-        - Name: Form
-          Offset: 144
-          Type: 33 GoMapType net/url.Values
-        - Name: PostForm
-          Offset: 152
-          Type: 33 GoMapType net/url.Values
-        - Name: MultipartForm
-          Offset: 160
-          Type: 34 PointerType *mime/multipart.Form
-        - Name: Trailer
-          Offset: 168
-          Type: 14 GoMapType net/http.Header
-        - Name: RemoteAddr
-          Offset: 176
-          Type: 5 GoStringHeaderType string
-        - Name: RequestURI
-          Offset: 192
-          Type: 5 GoStringHeaderType string
-        - Name: TLS
-          Offset: 208
-          Type: 54 PointerType *crypto/tls.ConnectionState
-        - Name: Cancel
-          Offset: 216
-          Type: 115 GoChannelType <-chan struct {}
-        - Name: Response
-          Offset: 224
-          Type: 116 PointerType *net/http.Response
-        - Name: Pattern
-          Offset: 232
-          Type: 5 GoStringHeaderType string
-        - Name: ctx
-          Offset: 248
-          Type: 118 GoInterfaceType context.Context
-        - Name: pat
-          Offset: 264
-          Type: 119 PointerType *net/http.pattern
-        - Name: matches
-          Offset: 272
-          Type: 28 GoSliceHeaderType []string
-        - Name: otherValues
-          Offset: 296
-          Type: 124 GoMapType map[string]string
-    - __kind: GoStringHeaderType
-      ID: 5
-      Name: string
-      ByteSize: 16
-      GoRuntimeType: 584448
-      GoKind: 24
-      RawFields:
-        - Name: str
-          Offset: 0
-          Type: 163 PointerType *string.str
-        - Name: len
-          Offset: 8
-          Type: 8 BaseType int
-      Data: 162 GoStringDataType string.str
+      Pointee: 59 PointerType *crypto/x509.Certificate
     - __kind: PointerType
-      ID: 6
-      Name: '*uint8'
+      ID: 49
+      Name: '**mime/multipart.FileHeader'
       ByteSize: 8
-      GoRuntimeType: 399424
       GoKind: 22
-      Pointee: 7 BaseType uint8
-    - __kind: BaseType
-      ID: 7
-      Name: uint8
-      ByteSize: 1
-      GoRuntimeType: 584576
-      GoKind: 8
-    - __kind: BaseType
-      ID: 8
-      Name: int
-      ByteSize: 8
-      GoRuntimeType: 585024
-      GoKind: 2
+      Pointee: 50 PointerType *mime/multipart.FileHeader
     - __kind: PointerType
-      ID: 9
-      Name: '*net/url.URL'
+      ID: 99
+      Name: '**net.IPNet'
       ByteSize: 8
-      GoRuntimeType: 2.1136e+06
       GoKind: 22
-      Pointee: 10 StructureType net/url.URL
-    - __kind: StructureType
-      ID: 10
-      Name: net/url.URL
-      ByteSize: 144
-      GoRuntimeType: 2.127584e+06
-      GoKind: 25
-      RawFields:
-        - Name: Scheme
-          Offset: 0
-          Type: 5 GoStringHeaderType string
-        - Name: Opaque
-          Offset: 16
-          Type: 5 GoStringHeaderType string
-        - Name: User
-          Offset: 32
-          Type: 11 PointerType *net/url.Userinfo
-        - Name: Host
-          Offset: 40
-          Type: 5 GoStringHeaderType string
-        - Name: Path
-          Offset: 56
-          Type: 5 GoStringHeaderType string
-        - Name: RawPath
-          Offset: 72
-          Type: 5 GoStringHeaderType string
-        - Name: OmitHost
-          Offset: 88
-          Type: 13 BaseType bool
-        - Name: ForceQuery
-          Offset: 89
-          Type: 13 BaseType bool
-        - Name: RawQuery
-          Offset: 96
-          Type: 5 GoStringHeaderType string
-        - Name: Fragment
-          Offset: 112
-          Type: 5 GoStringHeaderType string
-        - Name: RawFragment
-          Offset: 128
-          Type: 5 GoStringHeaderType string
+      Pointee: 100 PointerType *net.IPNet
     - __kind: PointerType
-      ID: 11
-      Name: '*net/url.Userinfo'
+      ID: 97
+      Name: '**net/url.URL'
       ByteSize: 8
-      GoRuntimeType: 1.200768e+06
       GoKind: 22
-      Pointee: 12 StructureType net/url.Userinfo
-    - __kind: StructureType
-      ID: 12
-      Name: net/url.Userinfo
-      ByteSize: 40
-      GoRuntimeType: 1.624928e+06
-      GoKind: 25
-      RawFields:
-        - Name: username
-          Offset: 0
-          Type: 5 GoStringHeaderType string
-        - Name: password
-          Offset: 16
-          Type: 5 GoStringHeaderType string
-        - Name: passwordSet
-          Offset: 32
-          Type: 13 BaseType bool
-    - __kind: BaseType
-      ID: 13
-      Name: bool
-      ByteSize: 1
-      GoRuntimeType: 585472
-      GoKind: 1
-    - __kind: GoMapType
-      ID: 14
-      Name: net/http.Header
-      ByteSize: 8
-      GoRuntimeType: 2.101632e+06
-      GoKind: 21
-      HeaderType: 16 GoSwissMapHeaderType map<string,[]string>
+      Pointee: 9 PointerType *net/url.URL
     - __kind: PointerType
-      ID: 15
-      Name: '*map<string,[]string>'
+      ID: 40
+      Name: '**table<string,[]*mime/multipart.FileHeader>'
       ByteSize: 8
-      Pointee: 16 GoSwissMapHeaderType map<string,[]string>
-    - __kind: GoSwissMapHeaderType
-      ID: 16
-      Name: map<string,[]string>
-      ByteSize: 48
-      GoKind: 25
-      RawFields:
-        - Name: used
-          Offset: 0
-          Type: 17 BaseType uint64
-        - Name: seed
-          Offset: 8
-          Type: 18 BaseType uintptr
-        - Name: dirPtr
-          Offset: 16
-          Type: 19 PointerType **table<string,[]string>
-        - Name: dirLen
-          Offset: 24
-          Type: 8 BaseType int
-        - Name: globalDepth
-          Offset: 32
-          Type: 7 BaseType uint8
-        - Name: globalShift
-          Offset: 33
-          Type: 7 BaseType uint8
-        - Name: writing
-          Offset: 34
-          Type: 7 BaseType uint8
-        - Name: tombstonePossible
-          Offset: 35
-          Type: 13 BaseType bool
-        - Name: clearSeq
-          Offset: 40
-          Type: 17 BaseType uint64
-      TablePtrSliceType: 164 GoSliceDataType []*table<string,[]string>.array
-      GroupType: 25 StructureType noalg.map.group[string][]string
-    - __kind: BaseType
-      ID: 17
-      Name: uint64
-      ByteSize: 8
-      GoRuntimeType: 584960
-      GoKind: 11
-    - __kind: BaseType
-      ID: 18
-      Name: uintptr
-      ByteSize: 8
-      GoRuntimeType: 585152
-      GoKind: 12
+      Pointee: 41 PointerType *table<string,[]*mime/multipart.FileHeader>
     - __kind: PointerType
       ID: 19
       Name: '**table<string,[]string>'
       ByteSize: 8
       Pointee: 20 PointerType *table<string,[]string>
     - __kind: PointerType
-      ID: 20
-      Name: '*table<string,[]string>'
+      ID: 127
+      Name: '**table<string,string>'
       ByteSize: 8
-      Pointee: 21 StructureType table<string,[]string>
-    - __kind: StructureType
-      ID: 21
-      Name: table<string,[]string>
-      ByteSize: 32
-      GoKind: 25
-      RawFields:
-        - Name: used
-          Offset: 0
-          Type: 22 BaseType uint16
-        - Name: capacity
-          Offset: 2
-          Type: 22 BaseType uint16
-        - Name: growthLeft
-          Offset: 4
-          Type: 22 BaseType uint16
-        - Name: localDepth
-          Offset: 6
-          Type: 7 BaseType uint8
-        - Name: index
-          Offset: 8
-          Type: 8 BaseType int
-        - Name: groups
-          Offset: 16
-          Type: 23 GoSwissMapGroupsType groupReference<string,[]string>
-    - __kind: BaseType
-      ID: 22
-      Name: uint16
-      ByteSize: 2
-      GoRuntimeType: 584704
-      GoKind: 9
-    - __kind: GoSwissMapGroupsType
-      ID: 23
-      Name: groupReference<string,[]string>
-      ByteSize: 16
-      GoKind: 25
-      RawFields:
-        - Name: data
-          Offset: 0
-          Type: 24 PointerType *noalg.map.group[string][]string
-        - Name: lengthMask
-          Offset: 8
-          Type: 17 BaseType uint64
-      GroupType: 25 StructureType noalg.map.group[string][]string
-      GroupSliceType: 165 GoSliceDataType []noalg.map.group[string][]string.array
+      Pointee: 128 PointerType *table<string,string>
     - __kind: PointerType
-      ID: 24
-      Name: '*noalg.map.group[string][]string'
+      ID: 110
+      Name: '*[]*crypto/x509.Certificate'
       ByteSize: 8
-      Pointee: 25 StructureType noalg.map.group[string][]string
-    - __kind: StructureType
-      ID: 25
-      Name: noalg.map.group[string][]string
-      ByteSize: 328
-      GoRuntimeType: 1.290432e+06
-      GoKind: 25
-      RawFields:
-        - Name: ctrl
-          Offset: 0
-          Type: 17 BaseType uint64
-        - Name: slots
-          Offset: 8
-          Type: 26 ArrayType noalg.[8]struct { key string; elem []string }
-    - __kind: ArrayType
-      ID: 26
-      Name: noalg.[8]struct { key string; elem []string }
-      ByteSize: 320
-      GoRuntimeType: 689376
-      GoKind: 17
-      Count: 8
-      HasCount: true
-      Element: 27 StructureType noalg.struct { key string; elem []string }
-    - __kind: StructureType
-      ID: 27
-      Name: noalg.struct { key string; elem []string }
-      ByteSize: 40
-      GoRuntimeType: 1.290304e+06
-      GoKind: 25
-      RawFields:
-        - Name: key
-          Offset: 0
-          Type: 5 GoStringHeaderType string
-        - Name: elem
-          Offset: 16
-          Type: 28 GoSliceHeaderType []string
-    - __kind: GoSliceHeaderType
-      ID: 28
-      Name: '[]string'
-      ByteSize: 24
-      GoRuntimeType: 496448
-      GoKind: 23
-      RawFields:
-        - Name: array
-          Offset: 0
-          Type: 29 PointerType *string
-        - Name: len
-          Offset: 8
-          Type: 8 BaseType int
-        - Name: cap
-          Offset: 16
-          Type: 8 BaseType int
-      Data: 166 GoSliceDataType []string.array
-    - __kind: PointerType
-      ID: 29
-      Name: '*string'
-      ByteSize: 8
-      GoRuntimeType: 399296
       GoKind: 22
-      Pointee: 5 GoStringHeaderType string
-    - __kind: GoInterfaceType
-      ID: 30
-      Name: io.ReadCloser
-      ByteSize: 16
-      GoRuntimeType: 1.110464e+06
-      GoKind: 20
-      RawFields:
-        - Name: tab
-          Offset: 0
-          Type: 2 VoidPointerType unsafe.Pointer
-        - Name: data
-          Offset: 8
-          Type: 2 VoidPointerType unsafe.Pointer
-    - __kind: GoSubroutineType
-      ID: 31
-      Name: func() (io.ReadCloser, error)
+      Pointee: 57 GoSliceHeaderType []*crypto/x509.Certificate
+    - __kind: PointerType
+      ID: 175
+      Name: '*[]*crypto/x509.Certificate.array'
       ByteSize: 8
-      GoRuntimeType: 693344
-      GoKind: 19
-    - __kind: BaseType
-      ID: 32
-      Name: int64
+      Pointee: 174 GoSliceDataType []*crypto/x509.Certificate.array
+    - __kind: PointerType
+      ID: 171
+      Name: '*[]*mime/multipart.FileHeader.array'
       ByteSize: 8
-      GoRuntimeType: 584896
-      GoKind: 6
-    - __kind: GoMapType
-      ID: 33
-      Name: net/url.Values
+      Pointee: 170 GoSliceDataType []*mime/multipart.FileHeader.array
+    - __kind: PointerType
+      ID: 199
+      Name: '*[]*net.IPNet.array'
       ByteSize: 8
-      GoRuntimeType: 1.885152e+06
-      GoKind: 21
-      HeaderType: 16 GoSwissMapHeaderType map<string,[]string>
+      Pointee: 198 GoSliceDataType []*net.IPNet.array
+    - __kind: PointerType
+      ID: 197
+      Name: '*[]*net/url.URL.array'
+      ByteSize: 8
+      Pointee: 196 GoSliceDataType []*net/url.URL.array
+    - __kind: PointerType
+      ID: 207
+      Name: '*[][]*crypto/x509.Certificate.array'
+      ByteSize: 8
+      Pointee: 206 GoSliceDataType [][]*crypto/x509.Certificate.array
+    - __kind: PointerType
+      ID: 209
+      Name: '*[][]uint8.array'
+      ByteSize: 8
+      Pointee: 208 GoSliceDataType [][]uint8.array
+    - __kind: PointerType
+      ID: 191
+      Name: '*[]crypto/x509.ExtKeyUsage.array'
+      ByteSize: 8
+      Pointee: 190 GoSliceDataType []crypto/x509.ExtKeyUsage.array
+    - __kind: PointerType
+      ID: 203
+      Name: '*[]crypto/x509.OID.array'
+      ByteSize: 8
+      Pointee: 202 GoSliceDataType []crypto/x509.OID.array
+    - __kind: PointerType
+      ID: 205
+      Name: '*[]crypto/x509.PolicyMapping.array'
+      ByteSize: 8
+      Pointee: 204 GoSliceDataType []crypto/x509.PolicyMapping.array
+    - __kind: PointerType
+      ID: 179
+      Name: '*[]crypto/x509/pkix.AttributeTypeAndValue.array'
+      ByteSize: 8
+      Pointee: 178 GoSliceDataType []crypto/x509/pkix.AttributeTypeAndValue.array
+    - __kind: PointerType
+      ID: 187
+      Name: '*[]crypto/x509/pkix.Extension.array'
+      ByteSize: 8
+      Pointee: 186 GoSliceDataType []crypto/x509/pkix.Extension.array
+    - __kind: PointerType
+      ID: 189
+      Name: '*[]encoding/asn1.ObjectIdentifier.array'
+      ByteSize: 8
+      Pointee: 188 GoSliceDataType []encoding/asn1.ObjectIdentifier.array
+    - __kind: PointerType
+      ID: 193
+      Name: '*[]net.IP.array'
+      ByteSize: 8
+      Pointee: 192 GoSliceDataType []net.IP.array
+    - __kind: PointerType
+      ID: 211
+      Name: '*[]net/http.segment.array'
+      ByteSize: 8
+      Pointee: 210 GoSliceDataType []net/http.segment.array
+    - __kind: PointerType
+      ID: 167
+      Name: '*[]string.array'
+      ByteSize: 8
+      Pointee: 166 GoSliceDataType []string.array
+    - __kind: PointerType
+      ID: 183
+      Name: '*[]time.zone.array'
+      ByteSize: 8
+      Pointee: 182 GoSliceDataType []time.zone.array
+    - __kind: PointerType
+      ID: 185
+      Name: '*[]time.zoneTrans.array'
+      ByteSize: 8
+      Pointee: 184 GoSliceDataType []time.zoneTrans.array
+    - __kind: PointerType
+      ID: 112
+      Name: '*[]uint8'
+      ByteSize: 8
+      GoRuntimeType: 481600
+      GoKind: 22
+      Pointee: 53 GoSliceHeaderType []uint8
+    - __kind: PointerType
+      ID: 173
+      Name: '*[]uint8.array'
+      ByteSize: 8
+      Pointee: 172 GoSliceDataType []uint8.array
+    - __kind: PointerType
+      ID: 141
+      Name: '*bool'
+      ByteSize: 8
+      GoRuntimeType: 400320
+      GoKind: 22
+      Pointee: 13 BaseType bool
+    - __kind: PointerType
+      ID: 135
+      Name: '*bytes.Buffer'
+      ByteSize: 8
+      GoRuntimeType: 2.260704e+06
+      GoKind: 22
+      Pointee: 136 StructureType bytes.Buffer
+    - __kind: PointerType
+      ID: 54
+      Name: '*crypto/tls.ConnectionState'
+      ByteSize: 8
+      GoRuntimeType: 908352
+      GoKind: 22
+      Pointee: 55 StructureType crypto/tls.ConnectionState
+    - __kind: PointerType
+      ID: 59
+      Name: '*crypto/x509.Certificate'
+      ByteSize: 8
+      GoRuntimeType: 2.043968e+06
+      GoKind: 22
+      Pointee: 60 StructureType crypto/x509.Certificate
+    - __kind: PointerType
+      ID: 91
+      Name: '*crypto/x509.ExtKeyUsage'
+      ByteSize: 8
+      GoRuntimeType: 423552
+      GoKind: 22
+      Pointee: 92 BaseType crypto/x509.ExtKeyUsage
+    - __kind: PointerType
+      ID: 104
+      Name: '*crypto/x509.OID'
+      ByteSize: 8
+      GoRuntimeType: 1.954336e+06
+      GoKind: 22
+      Pointee: 105 StructureType crypto/x509.OID
+    - __kind: PointerType
+      ID: 107
+      Name: '*crypto/x509.PolicyMapping'
+      ByteSize: 8
+      GoRuntimeType: 423616
+      GoKind: 22
+      Pointee: 108 StructureType crypto/x509.PolicyMapping
+    - __kind: PointerType
+      ID: 71
+      Name: '*crypto/x509/pkix.AttributeTypeAndValue'
+      ByteSize: 8
+      GoRuntimeType: 437312
+      GoKind: 22
+      Pointee: 72 StructureType crypto/x509/pkix.AttributeTypeAndValue
+    - __kind: PointerType
+      ID: 86
+      Name: '*crypto/x509/pkix.Extension'
+      ByteSize: 8
+      GoRuntimeType: 437504
+      GoKind: 22
+      Pointee: 87 StructureType crypto/x509/pkix.Extension
+    - __kind: PointerType
+      ID: 89
+      Name: '*encoding/asn1.ObjectIdentifier'
+      ByteSize: 8
+      GoRuntimeType: 1.053408e+06
+      GoKind: 22
+      Pointee: 73 GoSliceHeaderType encoding/asn1.ObjectIdentifier
+    - __kind: PointerType
+      ID: 181
+      Name: '*encoding/asn1.ObjectIdentifier.array'
+      ByteSize: 8
+      Pointee: 180 GoSliceDataType encoding/asn1.ObjectIdentifier.array
+    - __kind: PointerType
+      ID: 159
+      Name: '*error'
+      ByteSize: 8
+      GoRuntimeType: 399232
+      GoKind: 22
+      Pointee: 142 GoInterfaceType error
+    - __kind: PointerType
+      ID: 161
+      Name: '*float32'
+      ByteSize: 8
+      GoRuntimeType: 400192
+      GoKind: 22
+      Pointee: 146 BaseType float32
+    - __kind: PointerType
+      ID: 152
+      Name: '*float64'
+      ByteSize: 8
+      GoRuntimeType: 400256
+      GoKind: 22
+      Pointee: 143 BaseType float64
+    - __kind: PointerType
+      ID: 74
+      Name: '*int'
+      ByteSize: 8
+      GoRuntimeType: 399872
+      GoKind: 22
+      Pointee: 8 BaseType int
+    - __kind: PointerType
+      ID: 156
+      Name: '*int16'
+      ByteSize: 8
+      GoRuntimeType: 399488
+      GoKind: 22
+      Pointee: 157 BaseType int16
+    - __kind: PointerType
+      ID: 148
+      Name: '*int32'
+      ByteSize: 8
+      GoRuntimeType: 399616
+      GoKind: 22
+      Pointee: 140 BaseType int32
+    - __kind: PointerType
+      ID: 153
+      Name: '*int64'
+      ByteSize: 8
+      GoRuntimeType: 399744
+      GoKind: 22
+      Pointee: 32 BaseType int64
+    - __kind: PointerType
+      ID: 158
+      Name: '*int8'
+      ByteSize: 8
+      GoRuntimeType: 399360
+      GoKind: 22
+      Pointee: 144 BaseType int8
+    - __kind: PointerType
+      ID: 38
+      Name: '*map<string,[]*mime/multipart.FileHeader>'
+      ByteSize: 8
+      Pointee: 39 GoSwissMapHeaderType map<string,[]*mime/multipart.FileHeader>
+    - __kind: PointerType
+      ID: 15
+      Name: '*map<string,[]string>'
+      ByteSize: 8
+      Pointee: 16 GoSwissMapHeaderType map<string,[]string>
+    - __kind: PointerType
+      ID: 125
+      Name: '*map<string,string>'
+      ByteSize: 8
+      Pointee: 126 GoSwissMapHeaderType map<string,string>
+    - __kind: PointerType
+      ID: 64
+      Name: '*math/big.Int'
+      ByteSize: 8
+      GoRuntimeType: 2.382336e+06
+      GoKind: 22
+      Pointee: 65 StructureType math/big.Int
+    - __kind: PointerType
+      ID: 67
+      Name: '*math/big.Word'
+      ByteSize: 8
+      GoRuntimeType: 426432
+      GoKind: 22
+      Pointee: 68 BaseType math/big.Word
+    - __kind: PointerType
+      ID: 177
+      Name: '*math/big.nat.array'
+      ByteSize: 8
+      Pointee: 176 GoSliceDataType math/big.nat.array
+    - __kind: PointerType
+      ID: 50
+      Name: '*mime/multipart.FileHeader'
+      ByteSize: 8
+      GoRuntimeType: 909888
+      GoKind: 22
+      Pointee: 51 StructureType mime/multipart.FileHeader
     - __kind: PointerType
       ID: 34
       Name: '*mime/multipart.Form'
@@ -549,161 +434,243 @@ Types:
       GoRuntimeType: 909984
       GoKind: 22
       Pointee: 35 StructureType mime/multipart.Form
-    - __kind: StructureType
-      ID: 35
-      Name: mime/multipart.Form
-      ByteSize: 16
-      GoRuntimeType: 1.478112e+06
-      GoKind: 25
-      RawFields:
-        - Name: Value
-          Offset: 0
-          Type: 36 GoMapType map[string][]string
-        - Name: File
-          Offset: 8
-          Type: 37 GoMapType map[string][]*mime/multipart.FileHeader
-    - __kind: GoMapType
-      ID: 36
-      Name: map[string][]string
-      ByteSize: 8
-      GoRuntimeType: 1.128e+06
-      GoKind: 21
-      HeaderType: 16 GoSwissMapHeaderType map<string,[]string>
-    - __kind: GoMapType
-      ID: 37
-      Name: map[string][]*mime/multipart.FileHeader
-      ByteSize: 8
-      GoRuntimeType: 1.132352e+06
-      GoKind: 21
-      HeaderType: 39 GoSwissMapHeaderType map<string,[]*mime/multipart.FileHeader>
     - __kind: PointerType
-      ID: 38
-      Name: '*map<string,[]*mime/multipart.FileHeader>'
+      ID: 94
+      Name: '*net.IP'
       ByteSize: 8
-      Pointee: 39 GoSwissMapHeaderType map<string,[]*mime/multipart.FileHeader>
-    - __kind: GoSwissMapHeaderType
-      ID: 39
-      Name: map<string,[]*mime/multipart.FileHeader>
-      ByteSize: 48
-      GoKind: 25
-      RawFields:
-        - Name: used
-          Offset: 0
-          Type: 17 BaseType uint64
-        - Name: seed
-          Offset: 8
-          Type: 18 BaseType uintptr
-        - Name: dirPtr
-          Offset: 16
-          Type: 40 PointerType **table<string,[]*mime/multipart.FileHeader>
-        - Name: dirLen
-          Offset: 24
-          Type: 8 BaseType int
-        - Name: globalDepth
-          Offset: 32
-          Type: 7 BaseType uint8
-        - Name: globalShift
-          Offset: 33
-          Type: 7 BaseType uint8
-        - Name: writing
-          Offset: 34
-          Type: 7 BaseType uint8
-        - Name: tombstonePossible
-          Offset: 35
-          Type: 13 BaseType bool
-        - Name: clearSeq
-          Offset: 40
-          Type: 17 BaseType uint64
-      TablePtrSliceType: 168 GoSliceDataType []*table<string,[]*mime/multipart.FileHeader>.array
-      GroupType: 45 StructureType noalg.map.group[string][]*mime/multipart.FileHeader
+      GoRuntimeType: 2.150176e+06
+      GoKind: 22
+      Pointee: 95 GoSliceHeaderType net.IP
     - __kind: PointerType
-      ID: 40
-      Name: '**table<string,[]*mime/multipart.FileHeader>'
+      ID: 195
+      Name: '*net.IP.array'
       ByteSize: 8
-      Pointee: 41 PointerType *table<string,[]*mime/multipart.FileHeader>
+      Pointee: 194 GoSliceDataType net.IP.array
     - __kind: PointerType
-      ID: 41
-      Name: '*table<string,[]*mime/multipart.FileHeader>'
+      ID: 201
+      Name: '*net.IPMask.array'
       ByteSize: 8
-      Pointee: 42 StructureType table<string,[]*mime/multipart.FileHeader>
-    - __kind: StructureType
-      ID: 42
-      Name: table<string,[]*mime/multipart.FileHeader>
-      ByteSize: 32
-      GoKind: 25
-      RawFields:
-        - Name: used
-          Offset: 0
-          Type: 22 BaseType uint16
-        - Name: capacity
-          Offset: 2
-          Type: 22 BaseType uint16
-        - Name: growthLeft
-          Offset: 4
-          Type: 22 BaseType uint16
-        - Name: localDepth
-          Offset: 6
-          Type: 7 BaseType uint8
-        - Name: index
-          Offset: 8
-          Type: 8 BaseType int
-        - Name: groups
-          Offset: 16
-          Type: 43 GoSwissMapGroupsType groupReference<string,[]*mime/multipart.FileHeader>
-    - __kind: GoSwissMapGroupsType
-      ID: 43
-      Name: groupReference<string,[]*mime/multipart.FileHeader>
-      ByteSize: 16
-      GoKind: 25
-      RawFields:
-        - Name: data
-          Offset: 0
-          Type: 44 PointerType *noalg.map.group[string][]*mime/multipart.FileHeader
-        - Name: lengthMask
-          Offset: 8
-          Type: 17 BaseType uint64
-      GroupType: 45 StructureType noalg.map.group[string][]*mime/multipart.FileHeader
-      GroupSliceType: 169 GoSliceDataType []noalg.map.group[string][]*mime/multipart.FileHeader.array
+      Pointee: 200 GoSliceDataType net.IPMask.array
+    - __kind: PointerType
+      ID: 100
+      Name: '*net.IPNet'
+      ByteSize: 8
+      GoRuntimeType: 1.18336e+06
+      GoKind: 22
+      Pointee: 101 StructureType net.IPNet
+    - __kind: PointerType
+      ID: 3
+      Name: '*net/http.Request'
+      ByteSize: 8
+      GoRuntimeType: 2.30096e+06
+      GoKind: 22
+      Pointee: 4 StructureType net/http.Request
+    - __kind: PointerType
+      ID: 116
+      Name: '*net/http.Response'
+      ByteSize: 8
+      GoRuntimeType: 1.718816e+06
+      GoKind: 22
+      Pointee: 117 StructureType net/http.Response
+    - __kind: PointerType
+      ID: 119
+      Name: '*net/http.pattern'
+      ByteSize: 8
+      GoRuntimeType: 1.608608e+06
+      GoKind: 22
+      Pointee: 120 StructureType net/http.pattern
+    - __kind: PointerType
+      ID: 122
+      Name: '*net/http.segment'
+      ByteSize: 8
+      GoRuntimeType: 391808
+      GoKind: 22
+      Pointee: 123 StructureType net/http.segment
+    - __kind: PointerType
+      ID: 9
+      Name: '*net/url.URL'
+      ByteSize: 8
+      GoRuntimeType: 2.1136e+06
+      GoKind: 22
+      Pointee: 10 StructureType net/url.URL
+    - __kind: PointerType
+      ID: 11
+      Name: '*net/url.Userinfo'
+      ByteSize: 8
+      GoRuntimeType: 1.200768e+06
+      GoKind: 22
+      Pointee: 12 StructureType net/url.Userinfo
     - __kind: PointerType
       ID: 44
       Name: '*noalg.map.group[string][]*mime/multipart.FileHeader'
       ByteSize: 8
       Pointee: 45 StructureType noalg.map.group[string][]*mime/multipart.FileHeader
-    - __kind: StructureType
-      ID: 45
-      Name: noalg.map.group[string][]*mime/multipart.FileHeader
-      ByteSize: 328
-      GoRuntimeType: 1.29952e+06
-      GoKind: 25
+    - __kind: PointerType
+      ID: 24
+      Name: '*noalg.map.group[string][]string'
+      ByteSize: 8
+      Pointee: 25 StructureType noalg.map.group[string][]string
+    - __kind: PointerType
+      ID: 131
+      Name: '*noalg.map.group[string]string'
+      ByteSize: 8
+      Pointee: 132 StructureType noalg.map.group[string]string
+    - __kind: PointerType
+      ID: 29
+      Name: '*string'
+      ByteSize: 8
+      GoRuntimeType: 399296
+      GoKind: 22
+      Pointee: 5 GoStringHeaderType string
+    - __kind: PointerType
+      ID: 163
+      Name: '*string.str'
+      ByteSize: 8
+      Pointee: 162 GoStringDataType string.str
+    - __kind: PointerType
+      ID: 41
+      Name: '*table<string,[]*mime/multipart.FileHeader>'
+      ByteSize: 8
+      Pointee: 42 StructureType table<string,[]*mime/multipart.FileHeader>
+    - __kind: PointerType
+      ID: 20
+      Name: '*table<string,[]string>'
+      ByteSize: 8
+      Pointee: 21 StructureType table<string,[]string>
+    - __kind: PointerType
+      ID: 128
+      Name: '*table<string,string>'
+      ByteSize: 8
+      Pointee: 129 StructureType table<string,string>
+    - __kind: PointerType
+      ID: 76
+      Name: '*time.Location'
+      ByteSize: 8
+      GoRuntimeType: 1.6136e+06
+      GoKind: 22
+      Pointee: 77 StructureType time.Location
+    - __kind: PointerType
+      ID: 79
+      Name: '*time.zone'
+      ByteSize: 8
+      GoRuntimeType: 394880
+      GoKind: 22
+      Pointee: 80 StructureType time.zone
+    - __kind: PointerType
+      ID: 82
+      Name: '*time.zoneTrans'
+      ByteSize: 8
+      GoRuntimeType: 394944
+      GoKind: 22
+      Pointee: 83 StructureType time.zoneTrans
+    - __kind: PointerType
+      ID: 160
+      Name: '*uint'
+      ByteSize: 8
+      GoRuntimeType: 399936
+      GoKind: 22
+      Pointee: 145 BaseType uint
+    - __kind: PointerType
+      ID: 155
+      Name: '*uint16'
+      ByteSize: 8
+      GoRuntimeType: 399552
+      GoKind: 22
+      Pointee: 22 BaseType uint16
+    - __kind: PointerType
+      ID: 149
+      Name: '*uint32'
+      ByteSize: 8
+      GoRuntimeType: 399680
+      GoKind: 22
+      Pointee: 139 BaseType uint32
+    - __kind: PointerType
+      ID: 154
+      Name: '*uint64'
+      ByteSize: 8
+      GoRuntimeType: 399808
+      GoKind: 22
+      Pointee: 17 BaseType uint64
+    - __kind: PointerType
+      ID: 6
+      Name: '*uint8'
+      ByteSize: 8
+      GoRuntimeType: 399424
+      GoKind: 22
+      Pointee: 7 BaseType uint8
+    - __kind: PointerType
+      ID: 147
+      Name: '*uintptr'
+      ByteSize: 8
+      GoRuntimeType: 400000
+      GoKind: 22
+      Pointee: 18 BaseType uintptr
+    - __kind: GoChannelType
+      ID: 115
+      Name: <-chan struct {}
+      GoRuntimeType: 597696
+      GoKind: 18
+    - __kind: EventRootType
+      ID: 214
+      Name: Probe[main.HandleHTTP]
+      ByteSize: 25
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: w
+          Offset: 1
+          Expression:
+            Type: 1 GoInterfaceType net/http.ResponseWriter
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 1, index: 0, name: w}
+                  Offset: 0
+                  ByteSize: 16
+        - Name: r
+          Offset: 17
+          Expression:
+            Type: 3 PointerType *net/http.Request
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 1, index: 1, name: r}
+                  Offset: 0
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 215
+      Name: Probe[main.LookAtTheRequest]
+      ByteSize: 17
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: path
+          Offset: 1
+          Expression:
+            Type: 5 GoStringHeaderType string
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 2, index: 0, name: path}
+                  Offset: 0
+                  ByteSize: 16
+    - __kind: GoSliceHeaderType
+      ID: 57
+      Name: '[]*crypto/x509.Certificate'
+      ByteSize: 24
+      GoRuntimeType: 502496
+      GoKind: 23
       RawFields:
-        - Name: ctrl
+        - Name: array
           Offset: 0
-          Type: 17 BaseType uint64
-        - Name: slots
+          Type: 58 PointerType **crypto/x509.Certificate
+        - Name: len
           Offset: 8
-          Type: 46 ArrayType noalg.[8]struct { key string; elem []*mime/multipart.FileHeader }
-    - __kind: ArrayType
-      ID: 46
-      Name: noalg.[8]struct { key string; elem []*mime/multipart.FileHeader }
-      ByteSize: 320
-      GoRuntimeType: 699200
-      GoKind: 17
-      Count: 8
-      HasCount: true
-      Element: 47 StructureType noalg.struct { key string; elem []*mime/multipart.FileHeader }
-    - __kind: StructureType
-      ID: 47
-      Name: noalg.struct { key string; elem []*mime/multipart.FileHeader }
-      ByteSize: 40
-      GoRuntimeType: 1.299392e+06
-      GoKind: 25
-      RawFields:
-        - Name: key
-          Offset: 0
-          Type: 5 GoStringHeaderType string
-        - Name: elem
+          Type: 8 BaseType int
+        - Name: cap
           Offset: 16
-          Type: 48 GoSliceHeaderType []*mime/multipart.FileHeader
+          Type: 8 BaseType int
+      Data: 174 GoSliceDataType []*crypto/x509.Certificate.array
+    - __kind: GoSliceDataType
+      ID: 174
+      Name: '[]*crypto/x509.Certificate.array'
+      ByteSize: 2048
+      Element: 59 PointerType *crypto/x509.Certificate
     - __kind: GoSliceHeaderType
       ID: 48
       Name: '[]*mime/multipart.FileHeader'
@@ -721,54 +688,371 @@ Types:
           Offset: 16
           Type: 8 BaseType int
       Data: 170 GoSliceDataType []*mime/multipart.FileHeader.array
-    - __kind: PointerType
-      ID: 49
-      Name: '**mime/multipart.FileHeader'
-      ByteSize: 8
-      GoKind: 22
-      Pointee: 50 PointerType *mime/multipart.FileHeader
-    - __kind: PointerType
-      ID: 50
-      Name: '*mime/multipart.FileHeader'
-      ByteSize: 8
-      GoRuntimeType: 909888
-      GoKind: 22
-      Pointee: 51 StructureType mime/multipart.FileHeader
-    - __kind: StructureType
-      ID: 51
-      Name: mime/multipart.FileHeader
-      ByteSize: 88
-      GoRuntimeType: 1.977856e+06
-      GoKind: 25
+    - __kind: GoSliceDataType
+      ID: 170
+      Name: '[]*mime/multipart.FileHeader.array'
+      ByteSize: 2048
+      Element: 50 PointerType *mime/multipart.FileHeader
+    - __kind: GoSliceHeaderType
+      ID: 98
+      Name: '[]*net.IPNet'
+      ByteSize: 24
+      GoRuntimeType: 504096
+      GoKind: 23
       RawFields:
-        - Name: Filename
+        - Name: array
           Offset: 0
-          Type: 5 GoStringHeaderType string
-        - Name: Header
+          Type: 99 PointerType **net.IPNet
+        - Name: len
+          Offset: 8
+          Type: 8 BaseType int
+        - Name: cap
           Offset: 16
-          Type: 52 GoMapType net/textproto.MIMEHeader
-        - Name: Size
-          Offset: 24
-          Type: 32 BaseType int64
-        - Name: content
-          Offset: 32
-          Type: 53 GoSliceHeaderType []uint8
-        - Name: tmpfile
-          Offset: 56
-          Type: 5 GoStringHeaderType string
-        - Name: tmpoff
-          Offset: 72
-          Type: 32 BaseType int64
-        - Name: tmpshared
-          Offset: 80
-          Type: 13 BaseType bool
-    - __kind: GoMapType
-      ID: 52
-      Name: net/textproto.MIMEHeader
-      ByteSize: 8
-      GoRuntimeType: 1.823584e+06
-      GoKind: 21
-      HeaderType: 16 GoSwissMapHeaderType map<string,[]string>
+          Type: 8 BaseType int
+      Data: 198 GoSliceDataType []*net.IPNet.array
+    - __kind: GoSliceDataType
+      ID: 198
+      Name: '[]*net.IPNet.array'
+      ByteSize: 2048
+      Element: 100 PointerType *net.IPNet
+    - __kind: GoSliceHeaderType
+      ID: 96
+      Name: '[]*net/url.URL'
+      ByteSize: 24
+      GoRuntimeType: 504032
+      GoKind: 23
+      RawFields:
+        - Name: array
+          Offset: 0
+          Type: 97 PointerType **net/url.URL
+        - Name: len
+          Offset: 8
+          Type: 8 BaseType int
+        - Name: cap
+          Offset: 16
+          Type: 8 BaseType int
+      Data: 196 GoSliceDataType []*net/url.URL.array
+    - __kind: GoSliceDataType
+      ID: 196
+      Name: '[]*net/url.URL.array'
+      ByteSize: 2048
+      Element: 9 PointerType *net/url.URL
+    - __kind: GoSliceDataType
+      ID: 168
+      Name: '[]*table<string,[]*mime/multipart.FileHeader>.array'
+      ByteSize: 8192
+      Element: 41 PointerType *table<string,[]*mime/multipart.FileHeader>
+    - __kind: GoSliceDataType
+      ID: 164
+      Name: '[]*table<string,[]string>.array'
+      ByteSize: 8192
+      Element: 20 PointerType *table<string,[]string>
+    - __kind: GoSliceDataType
+      ID: 212
+      Name: '[]*table<string,string>.array'
+      ByteSize: 8192
+      Element: 128 PointerType *table<string,string>
+    - __kind: GoSliceHeaderType
+      ID: 109
+      Name: '[][]*crypto/x509.Certificate'
+      ByteSize: 24
+      GoRuntimeType: 502560
+      GoKind: 23
+      RawFields:
+        - Name: array
+          Offset: 0
+          Type: 110 PointerType *[]*crypto/x509.Certificate
+        - Name: len
+          Offset: 8
+          Type: 8 BaseType int
+        - Name: cap
+          Offset: 16
+          Type: 8 BaseType int
+      Data: 206 GoSliceDataType [][]*crypto/x509.Certificate.array
+    - __kind: GoSliceDataType
+      ID: 206
+      Name: '[][]*crypto/x509.Certificate.array'
+      ByteSize: 2048
+      Element: 57 GoSliceHeaderType []*crypto/x509.Certificate
+    - __kind: GoSliceHeaderType
+      ID: 111
+      Name: '[][]uint8'
+      ByteSize: 24
+      GoRuntimeType: 481920
+      GoKind: 23
+      RawFields:
+        - Name: array
+          Offset: 0
+          Type: 112 PointerType *[]uint8
+        - Name: len
+          Offset: 8
+          Type: 8 BaseType int
+        - Name: cap
+          Offset: 16
+          Type: 8 BaseType int
+      Data: 208 GoSliceDataType [][]uint8.array
+    - __kind: GoSliceDataType
+      ID: 208
+      Name: '[][]uint8.array'
+      ByteSize: 2048
+      Element: 53 GoSliceHeaderType []uint8
+    - __kind: GoSliceHeaderType
+      ID: 90
+      Name: '[]crypto/x509.ExtKeyUsage'
+      ByteSize: 24
+      GoRuntimeType: 503968
+      GoKind: 23
+      RawFields:
+        - Name: array
+          Offset: 0
+          Type: 91 PointerType *crypto/x509.ExtKeyUsage
+        - Name: len
+          Offset: 8
+          Type: 8 BaseType int
+        - Name: cap
+          Offset: 16
+          Type: 8 BaseType int
+      Data: 190 GoSliceDataType []crypto/x509.ExtKeyUsage.array
+    - __kind: GoSliceDataType
+      ID: 190
+      Name: '[]crypto/x509.ExtKeyUsage.array'
+      ByteSize: 2048
+      Element: 92 BaseType crypto/x509.ExtKeyUsage
+    - __kind: GoSliceHeaderType
+      ID: 103
+      Name: '[]crypto/x509.OID'
+      ByteSize: 24
+      GoRuntimeType: 504160
+      GoKind: 23
+      RawFields:
+        - Name: array
+          Offset: 0
+          Type: 104 PointerType *crypto/x509.OID
+        - Name: len
+          Offset: 8
+          Type: 8 BaseType int
+        - Name: cap
+          Offset: 16
+          Type: 8 BaseType int
+      Data: 202 GoSliceDataType []crypto/x509.OID.array
+    - __kind: GoSliceDataType
+      ID: 202
+      Name: '[]crypto/x509.OID.array'
+      ByteSize: 2048
+      Element: 105 StructureType crypto/x509.OID
+    - __kind: GoSliceHeaderType
+      ID: 106
+      Name: '[]crypto/x509.PolicyMapping'
+      ByteSize: 24
+      GoRuntimeType: 504224
+      GoKind: 23
+      RawFields:
+        - Name: array
+          Offset: 0
+          Type: 107 PointerType *crypto/x509.PolicyMapping
+        - Name: len
+          Offset: 8
+          Type: 8 BaseType int
+        - Name: cap
+          Offset: 16
+          Type: 8 BaseType int
+      Data: 204 GoSliceDataType []crypto/x509.PolicyMapping.array
+    - __kind: GoSliceDataType
+      ID: 204
+      Name: '[]crypto/x509.PolicyMapping.array'
+      ByteSize: 2048
+      Element: 108 StructureType crypto/x509.PolicyMapping
+    - __kind: GoSliceHeaderType
+      ID: 70
+      Name: '[]crypto/x509/pkix.AttributeTypeAndValue'
+      ByteSize: 24
+      GoRuntimeType: 517440
+      GoKind: 23
+      RawFields:
+        - Name: array
+          Offset: 0
+          Type: 71 PointerType *crypto/x509/pkix.AttributeTypeAndValue
+        - Name: len
+          Offset: 8
+          Type: 8 BaseType int
+        - Name: cap
+          Offset: 16
+          Type: 8 BaseType int
+      Data: 178 GoSliceDataType []crypto/x509/pkix.AttributeTypeAndValue.array
+    - __kind: GoSliceDataType
+      ID: 178
+      Name: '[]crypto/x509/pkix.AttributeTypeAndValue.array'
+      ByteSize: 2048
+      Element: 72 StructureType crypto/x509/pkix.AttributeTypeAndValue
+    - __kind: GoSliceHeaderType
+      ID: 85
+      Name: '[]crypto/x509/pkix.Extension'
+      ByteSize: 24
+      GoRuntimeType: 503840
+      GoKind: 23
+      RawFields:
+        - Name: array
+          Offset: 0
+          Type: 86 PointerType *crypto/x509/pkix.Extension
+        - Name: len
+          Offset: 8
+          Type: 8 BaseType int
+        - Name: cap
+          Offset: 16
+          Type: 8 BaseType int
+      Data: 186 GoSliceDataType []crypto/x509/pkix.Extension.array
+    - __kind: GoSliceDataType
+      ID: 186
+      Name: '[]crypto/x509/pkix.Extension.array'
+      ByteSize: 2048
+      Element: 87 StructureType crypto/x509/pkix.Extension
+    - __kind: GoSliceHeaderType
+      ID: 88
+      Name: '[]encoding/asn1.ObjectIdentifier'
+      ByteSize: 24
+      GoRuntimeType: 503904
+      GoKind: 23
+      RawFields:
+        - Name: array
+          Offset: 0
+          Type: 89 PointerType *encoding/asn1.ObjectIdentifier
+        - Name: len
+          Offset: 8
+          Type: 8 BaseType int
+        - Name: cap
+          Offset: 16
+          Type: 8 BaseType int
+      Data: 188 GoSliceDataType []encoding/asn1.ObjectIdentifier.array
+    - __kind: GoSliceDataType
+      ID: 188
+      Name: '[]encoding/asn1.ObjectIdentifier.array'
+      ByteSize: 2048
+      Element: 73 GoSliceHeaderType encoding/asn1.ObjectIdentifier
+    - __kind: GoSliceHeaderType
+      ID: 93
+      Name: '[]net.IP'
+      ByteSize: 24
+      GoRuntimeType: 482944
+      GoKind: 23
+      RawFields:
+        - Name: array
+          Offset: 0
+          Type: 94 PointerType *net.IP
+        - Name: len
+          Offset: 8
+          Type: 8 BaseType int
+        - Name: cap
+          Offset: 16
+          Type: 8 BaseType int
+      Data: 192 GoSliceDataType []net.IP.array
+    - __kind: GoSliceDataType
+      ID: 192
+      Name: '[]net.IP.array'
+      ByteSize: 2048
+      Element: 95 GoSliceHeaderType net.IP
+    - __kind: GoSliceHeaderType
+      ID: 121
+      Name: '[]net/http.segment'
+      ByteSize: 24
+      GoRuntimeType: 484640
+      GoKind: 23
+      RawFields:
+        - Name: array
+          Offset: 0
+          Type: 122 PointerType *net/http.segment
+        - Name: len
+          Offset: 8
+          Type: 8 BaseType int
+        - Name: cap
+          Offset: 16
+          Type: 8 BaseType int
+      Data: 210 GoSliceDataType []net/http.segment.array
+    - __kind: GoSliceDataType
+      ID: 210
+      Name: '[]net/http.segment.array'
+      ByteSize: 2048
+      Element: 123 StructureType net/http.segment
+    - __kind: GoSliceDataType
+      ID: 169
+      Name: '[]noalg.map.group[string][]*mime/multipart.FileHeader.array'
+      ByteSize: 2048
+      Element: 45 StructureType noalg.map.group[string][]*mime/multipart.FileHeader
+    - __kind: GoSliceDataType
+      ID: 165
+      Name: '[]noalg.map.group[string][]string.array'
+      ByteSize: 2048
+      Element: 25 StructureType noalg.map.group[string][]string
+    - __kind: GoSliceDataType
+      ID: 213
+      Name: '[]noalg.map.group[string]string.array'
+      ByteSize: 2048
+      Element: 132 StructureType noalg.map.group[string]string
+    - __kind: GoSliceHeaderType
+      ID: 28
+      Name: '[]string'
+      ByteSize: 24
+      GoRuntimeType: 496448
+      GoKind: 23
+      RawFields:
+        - Name: array
+          Offset: 0
+          Type: 29 PointerType *string
+        - Name: len
+          Offset: 8
+          Type: 8 BaseType int
+        - Name: cap
+          Offset: 16
+          Type: 8 BaseType int
+      Data: 166 GoSliceDataType []string.array
+    - __kind: GoSliceDataType
+      ID: 166
+      Name: '[]string.array'
+      ByteSize: 2048
+      Element: 5 GoStringHeaderType string
+    - __kind: GoSliceHeaderType
+      ID: 78
+      Name: '[]time.zone'
+      ByteSize: 24
+      GoRuntimeType: 489504
+      GoKind: 23
+      RawFields:
+        - Name: array
+          Offset: 0
+          Type: 79 PointerType *time.zone
+        - Name: len
+          Offset: 8
+          Type: 8 BaseType int
+        - Name: cap
+          Offset: 16
+          Type: 8 BaseType int
+      Data: 182 GoSliceDataType []time.zone.array
+    - __kind: GoSliceDataType
+      ID: 182
+      Name: '[]time.zone.array'
+      ByteSize: 2048
+      Element: 80 StructureType time.zone
+    - __kind: GoSliceHeaderType
+      ID: 81
+      Name: '[]time.zoneTrans'
+      ByteSize: 24
+      GoRuntimeType: 489568
+      GoKind: 23
+      RawFields:
+        - Name: array
+          Offset: 0
+          Type: 82 PointerType *time.zoneTrans
+        - Name: len
+          Offset: 8
+          Type: 8 BaseType int
+        - Name: cap
+          Offset: 16
+          Type: 8 BaseType int
+      Data: 184 GoSliceDataType []time.zoneTrans.array
+    - __kind: GoSliceDataType
+      ID: 184
+      Name: '[]time.zoneTrans.array'
+      ByteSize: 2048
+      Element: 83 StructureType time.zoneTrans
     - __kind: GoSliceHeaderType
       ID: 53
       Name: '[]uint8'
@@ -786,13 +1070,64 @@ Types:
           Offset: 16
           Type: 8 BaseType int
       Data: 172 GoSliceDataType []uint8.array
-    - __kind: PointerType
-      ID: 54
-      Name: '*crypto/tls.ConnectionState'
+    - __kind: GoSliceDataType
+      ID: 172
+      Name: '[]uint8.array'
+      ByteSize: 2048
+      Element: 7 BaseType uint8
+    - __kind: BaseType
+      ID: 13
+      Name: bool
+      ByteSize: 1
+      GoRuntimeType: 585472
+      GoKind: 1
+    - __kind: StructureType
+      ID: 136
+      Name: bytes.Buffer
+      ByteSize: 40
+      GoRuntimeType: 1.606304e+06
+      GoKind: 25
+      RawFields:
+        - Name: buf
+          Offset: 0
+          Type: 53 GoSliceHeaderType []uint8
+        - Name: off
+          Offset: 24
+          Type: 8 BaseType int
+        - Name: lastRead
+          Offset: 32
+          Type: 137 BaseType bytes.readOp
+    - __kind: BaseType
+      ID: 137
+      Name: bytes.readOp
+      ByteSize: 1
+      GoRuntimeType: 583680
+      GoKind: 3
+    - __kind: BaseType
+      ID: 151
+      Name: complex128
+      ByteSize: 16
+      GoRuntimeType: 585280
+      GoKind: 16
+    - __kind: BaseType
+      ID: 150
+      Name: complex64
       ByteSize: 8
-      GoRuntimeType: 908352
-      GoKind: 22
-      Pointee: 55 StructureType crypto/tls.ConnectionState
+      GoRuntimeType: 585216
+      GoKind: 15
+    - __kind: GoInterfaceType
+      ID: 118
+      Name: context.Context
+      ByteSize: 16
+      GoRuntimeType: 1.276992e+06
+      GoKind: 20
+      RawFields:
+        - Name: tab
+          Offset: 0
+          Type: 2 VoidPointerType unsafe.Pointer
+        - Name: data
+          Offset: 8
+          Type: 2 VoidPointerType unsafe.Pointer
     - __kind: StructureType
       ID: 55
       Name: crypto/tls.ConnectionState
@@ -857,36 +1192,12 @@ Types:
       ByteSize: 2
       GoRuntimeType: 835040
       GoKind: 9
-    - __kind: GoSliceHeaderType
-      ID: 57
-      Name: '[]*crypto/x509.Certificate'
-      ByteSize: 24
-      GoRuntimeType: 502496
-      GoKind: 23
-      RawFields:
-        - Name: array
-          Offset: 0
-          Type: 58 PointerType **crypto/x509.Certificate
-        - Name: len
-          Offset: 8
-          Type: 8 BaseType int
-        - Name: cap
-          Offset: 16
-          Type: 8 BaseType int
-      Data: 174 GoSliceDataType []*crypto/x509.Certificate.array
-    - __kind: PointerType
-      ID: 58
-      Name: '**crypto/x509.Certificate'
-      ByteSize: 8
-      GoKind: 22
-      Pointee: 59 PointerType *crypto/x509.Certificate
-    - __kind: PointerType
-      ID: 59
-      Name: '*crypto/x509.Certificate'
-      ByteSize: 8
-      GoRuntimeType: 2.043968e+06
-      GoKind: 22
-      Pointee: 60 StructureType crypto/x509.Certificate
+    - __kind: BaseType
+      ID: 114
+      Name: crypto/tls.SignatureScheme
+      ByteSize: 2
+      GoRuntimeType: 835136
+      GoKind: 9
     - __kind: StructureType
       ID: 60
       Name: crypto/x509.Certificate
@@ -1051,80 +1362,81 @@ Types:
           Offset: 1400
           Type: 106 GoSliceHeaderType []crypto/x509.PolicyMapping
     - __kind: BaseType
-      ID: 61
-      Name: crypto/x509.SignatureAlgorithm
+      ID: 92
+      Name: crypto/x509.ExtKeyUsage
       ByteSize: 8
-      GoRuntimeType: 1.114432e+06
+      GoRuntimeType: 588160
       GoKind: 2
+    - __kind: BaseType
+      ID: 84
+      Name: crypto/x509.KeyUsage
+      ByteSize: 8
+      GoRuntimeType: 588096
+      GoKind: 2
+    - __kind: StructureType
+      ID: 105
+      Name: crypto/x509.OID
+      ByteSize: 24
+      GoRuntimeType: 1.954592e+06
+      GoKind: 25
+      RawFields:
+        - Name: der
+          Offset: 0
+          Type: 53 GoSliceHeaderType []uint8
+    - __kind: StructureType
+      ID: 108
+      Name: crypto/x509.PolicyMapping
+      ByteSize: 48
+      GoRuntimeType: 1.491232e+06
+      GoKind: 25
+      RawFields:
+        - Name: IssuerDomainPolicy
+          Offset: 0
+          Type: 105 StructureType crypto/x509.OID
+        - Name: SubjectDomainPolicy
+          Offset: 24
+          Type: 105 StructureType crypto/x509.OID
     - __kind: BaseType
       ID: 62
       Name: crypto/x509.PublicKeyAlgorithm
       ByteSize: 8
       GoRuntimeType: 837632
       GoKind: 2
-    - __kind: GoEmptyInterfaceType
-      ID: 63
-      Name: interface {}
-      ByteSize: 16
-      GoRuntimeType: 854848
-      GoKind: 20
-      RawFields:
-        - Name: _type
-          Offset: 0
-          Type: 2 VoidPointerType unsafe.Pointer
-        - Name: data
-          Offset: 8
-          Type: 2 VoidPointerType unsafe.Pointer
-    - __kind: PointerType
-      ID: 64
-      Name: '*math/big.Int'
+    - __kind: BaseType
+      ID: 61
+      Name: crypto/x509.SignatureAlgorithm
       ByteSize: 8
-      GoRuntimeType: 2.382336e+06
-      GoKind: 22
-      Pointee: 65 StructureType math/big.Int
+      GoRuntimeType: 1.114432e+06
+      GoKind: 2
     - __kind: StructureType
-      ID: 65
-      Name: math/big.Int
-      ByteSize: 32
-      GoRuntimeType: 1.494272e+06
+      ID: 72
+      Name: crypto/x509/pkix.AttributeTypeAndValue
+      ByteSize: 40
+      GoRuntimeType: 1.502912e+06
       GoKind: 25
       RawFields:
-        - Name: neg
+        - Name: Type
           Offset: 0
-          Type: 13 BaseType bool
-        - Name: abs
-          Offset: 8
-          Type: 66 GoSliceHeaderType math/big.nat
-    - __kind: GoSliceHeaderType
-      ID: 66
-      Name: math/big.nat
-      ByteSize: 24
-      GoRuntimeType: 2.361856e+06
-      GoKind: 23
+          Type: 73 GoSliceHeaderType encoding/asn1.ObjectIdentifier
+        - Name: Value
+          Offset: 24
+          Type: 63 GoEmptyInterfaceType interface {}
+    - __kind: StructureType
+      ID: 87
+      Name: crypto/x509/pkix.Extension
+      ByteSize: 56
+      GoRuntimeType: 1.647008e+06
+      GoKind: 25
       RawFields:
-        - Name: array
+        - Name: Id
           Offset: 0
-          Type: 67 PointerType *math/big.Word
-        - Name: len
-          Offset: 8
-          Type: 8 BaseType int
-        - Name: cap
-          Offset: 16
-          Type: 8 BaseType int
-      Data: 176 GoSliceDataType math/big.nat.array
-    - __kind: PointerType
-      ID: 67
-      Name: '*math/big.Word'
-      ByteSize: 8
-      GoRuntimeType: 426432
-      GoKind: 22
-      Pointee: 68 BaseType math/big.Word
-    - __kind: BaseType
-      ID: 68
-      Name: math/big.Word
-      ByteSize: 8
-      GoRuntimeType: 588352
-      GoKind: 7
+          Type: 73 GoSliceHeaderType encoding/asn1.ObjectIdentifier
+        - Name: Critical
+          Offset: 24
+          Type: 13 BaseType bool
+        - Name: Value
+          Offset: 32
+          Type: 53 GoSliceHeaderType []uint8
     - __kind: StructureType
       ID: 69
       Name: crypto/x509/pkix.Name
@@ -1166,43 +1478,6 @@ Types:
           Offset: 224
           Type: 70 GoSliceHeaderType []crypto/x509/pkix.AttributeTypeAndValue
     - __kind: GoSliceHeaderType
-      ID: 70
-      Name: '[]crypto/x509/pkix.AttributeTypeAndValue'
-      ByteSize: 24
-      GoRuntimeType: 517440
-      GoKind: 23
-      RawFields:
-        - Name: array
-          Offset: 0
-          Type: 71 PointerType *crypto/x509/pkix.AttributeTypeAndValue
-        - Name: len
-          Offset: 8
-          Type: 8 BaseType int
-        - Name: cap
-          Offset: 16
-          Type: 8 BaseType int
-      Data: 178 GoSliceDataType []crypto/x509/pkix.AttributeTypeAndValue.array
-    - __kind: PointerType
-      ID: 71
-      Name: '*crypto/x509/pkix.AttributeTypeAndValue'
-      ByteSize: 8
-      GoRuntimeType: 437312
-      GoKind: 22
-      Pointee: 72 StructureType crypto/x509/pkix.AttributeTypeAndValue
-    - __kind: StructureType
-      ID: 72
-      Name: crypto/x509/pkix.AttributeTypeAndValue
-      ByteSize: 40
-      GoRuntimeType: 1.502912e+06
-      GoKind: 25
-      RawFields:
-        - Name: Type
-          Offset: 0
-          Type: 73 GoSliceHeaderType encoding/asn1.ObjectIdentifier
-        - Name: Value
-          Offset: 24
-          Type: 63 GoEmptyInterfaceType interface {}
-    - __kind: GoSliceHeaderType
       ID: 73
       Name: encoding/asn1.ObjectIdentifier
       ByteSize: 24
@@ -1219,271 +1494,367 @@ Types:
           Offset: 16
           Type: 8 BaseType int
       Data: 180 GoSliceDataType encoding/asn1.ObjectIdentifier.array
-    - __kind: PointerType
-      ID: 74
-      Name: '*int'
+    - __kind: GoSliceDataType
+      ID: 180
+      Name: encoding/asn1.ObjectIdentifier.array
+      ByteSize: 2048
+      Element: 8 BaseType int
+    - __kind: GoInterfaceType
+      ID: 142
+      Name: error
+      ByteSize: 16
+      GoRuntimeType: 1.031776e+06
+      GoKind: 20
+      RawFields:
+        - Name: tab
+          Offset: 0
+          Type: 2 VoidPointerType unsafe.Pointer
+        - Name: data
+          Offset: 8
+          Type: 2 VoidPointerType unsafe.Pointer
+    - __kind: BaseType
+      ID: 146
+      Name: float32
+      ByteSize: 4
+      GoRuntimeType: 585344
+      GoKind: 13
+    - __kind: BaseType
+      ID: 143
+      Name: float64
       ByteSize: 8
-      GoRuntimeType: 399872
-      GoKind: 22
-      Pointee: 8 BaseType int
-    - __kind: StructureType
-      ID: 75
-      Name: time.Time
-      ByteSize: 24
-      GoRuntimeType: 2.364704e+06
+      GoRuntimeType: 585408
+      GoKind: 14
+    - __kind: GoSubroutineType
+      ID: 31
+      Name: func() (io.ReadCloser, error)
+      ByteSize: 8
+      GoRuntimeType: 693344
+      GoKind: 19
+    - __kind: GoSubroutineType
+      ID: 113
+      Name: func(string, []uint8, int) ([]uint8, error)
+      ByteSize: 8
+      GoRuntimeType: 1.003296e+06
+      GoKind: 19
+    - __kind: GoInterfaceType
+      ID: 138
+      Name: gopkg.in/DataDog/dd-trace-go.v1/ddtrace.Span
+      ByteSize: 16
+      GoRuntimeType: 1.479712e+06
+      GoKind: 20
+      RawFields:
+        - Name: tab
+          Offset: 0
+          Type: 2 VoidPointerType unsafe.Pointer
+        - Name: data
+          Offset: 8
+          Type: 2 VoidPointerType unsafe.Pointer
+    - __kind: GoSwissMapGroupsType
+      ID: 43
+      Name: groupReference<string,[]*mime/multipart.FileHeader>
+      ByteSize: 16
       GoKind: 25
       RawFields:
-        - Name: wall
+        - Name: data
+          Offset: 0
+          Type: 44 PointerType *noalg.map.group[string][]*mime/multipart.FileHeader
+        - Name: lengthMask
+          Offset: 8
+          Type: 17 BaseType uint64
+      GroupType: 45 StructureType noalg.map.group[string][]*mime/multipart.FileHeader
+      GroupSliceType: 169 GoSliceDataType []noalg.map.group[string][]*mime/multipart.FileHeader.array
+    - __kind: GoSwissMapGroupsType
+      ID: 23
+      Name: groupReference<string,[]string>
+      ByteSize: 16
+      GoKind: 25
+      RawFields:
+        - Name: data
+          Offset: 0
+          Type: 24 PointerType *noalg.map.group[string][]string
+        - Name: lengthMask
+          Offset: 8
+          Type: 17 BaseType uint64
+      GroupType: 25 StructureType noalg.map.group[string][]string
+      GroupSliceType: 165 GoSliceDataType []noalg.map.group[string][]string.array
+    - __kind: GoSwissMapGroupsType
+      ID: 130
+      Name: groupReference<string,string>
+      ByteSize: 16
+      GoKind: 25
+      RawFields:
+        - Name: data
+          Offset: 0
+          Type: 131 PointerType *noalg.map.group[string]string
+        - Name: lengthMask
+          Offset: 8
+          Type: 17 BaseType uint64
+      GroupType: 132 StructureType noalg.map.group[string]string
+      GroupSliceType: 213 GoSliceDataType []noalg.map.group[string]string.array
+    - __kind: BaseType
+      ID: 8
+      Name: int
+      ByteSize: 8
+      GoRuntimeType: 585024
+      GoKind: 2
+    - __kind: BaseType
+      ID: 157
+      Name: int16
+      ByteSize: 2
+      GoRuntimeType: 584640
+      GoKind: 4
+    - __kind: BaseType
+      ID: 140
+      Name: int32
+      ByteSize: 4
+      GoRuntimeType: 584768
+      GoKind: 5
+    - __kind: BaseType
+      ID: 32
+      Name: int64
+      ByteSize: 8
+      GoRuntimeType: 584896
+      GoKind: 6
+    - __kind: BaseType
+      ID: 144
+      Name: int8
+      ByteSize: 1
+      GoRuntimeType: 584512
+      GoKind: 3
+    - __kind: GoEmptyInterfaceType
+      ID: 63
+      Name: interface {}
+      ByteSize: 16
+      GoRuntimeType: 854848
+      GoKind: 20
+      RawFields:
+        - Name: _type
+          Offset: 0
+          Type: 2 VoidPointerType unsafe.Pointer
+        - Name: data
+          Offset: 8
+          Type: 2 VoidPointerType unsafe.Pointer
+    - __kind: GoInterfaceType
+      ID: 30
+      Name: io.ReadCloser
+      ByteSize: 16
+      GoRuntimeType: 1.110464e+06
+      GoKind: 20
+      RawFields:
+        - Name: tab
+          Offset: 0
+          Type: 2 VoidPointerType unsafe.Pointer
+        - Name: data
+          Offset: 8
+          Type: 2 VoidPointerType unsafe.Pointer
+    - __kind: GoSwissMapHeaderType
+      ID: 39
+      Name: map<string,[]*mime/multipart.FileHeader>
+      ByteSize: 48
+      GoKind: 25
+      RawFields:
+        - Name: used
           Offset: 0
           Type: 17 BaseType uint64
-        - Name: ext
+        - Name: seed
           Offset: 8
-          Type: 32 BaseType int64
-        - Name: loc
+          Type: 18 BaseType uintptr
+        - Name: dirPtr
           Offset: 16
-          Type: 76 PointerType *time.Location
-    - __kind: PointerType
-      ID: 76
-      Name: '*time.Location'
-      ByteSize: 8
-      GoRuntimeType: 1.6136e+06
-      GoKind: 22
-      Pointee: 77 StructureType time.Location
-    - __kind: StructureType
-      ID: 77
-      Name: time.Location
-      ByteSize: 104
-      GoRuntimeType: 1.973536e+06
-      GoKind: 25
-      RawFields:
-        - Name: name
-          Offset: 0
-          Type: 5 GoStringHeaderType string
-        - Name: zone
-          Offset: 16
-          Type: 78 GoSliceHeaderType []time.zone
-        - Name: tx
-          Offset: 40
-          Type: 81 GoSliceHeaderType []time.zoneTrans
-        - Name: extend
-          Offset: 64
-          Type: 5 GoStringHeaderType string
-        - Name: cacheStart
-          Offset: 80
-          Type: 32 BaseType int64
-        - Name: cacheEnd
-          Offset: 88
-          Type: 32 BaseType int64
-        - Name: cacheZone
-          Offset: 96
-          Type: 79 PointerType *time.zone
-    - __kind: GoSliceHeaderType
-      ID: 78
-      Name: '[]time.zone'
-      ByteSize: 24
-      GoRuntimeType: 489504
-      GoKind: 23
-      RawFields:
-        - Name: array
-          Offset: 0
-          Type: 79 PointerType *time.zone
-        - Name: len
-          Offset: 8
-          Type: 8 BaseType int
-        - Name: cap
-          Offset: 16
-          Type: 8 BaseType int
-      Data: 182 GoSliceDataType []time.zone.array
-    - __kind: PointerType
-      ID: 79
-      Name: '*time.zone'
-      ByteSize: 8
-      GoRuntimeType: 394880
-      GoKind: 22
-      Pointee: 80 StructureType time.zone
-    - __kind: StructureType
-      ID: 80
-      Name: time.zone
-      ByteSize: 32
-      GoRuntimeType: 1.613408e+06
-      GoKind: 25
-      RawFields:
-        - Name: name
-          Offset: 0
-          Type: 5 GoStringHeaderType string
-        - Name: offset
-          Offset: 16
-          Type: 8 BaseType int
-        - Name: isDST
+          Type: 40 PointerType **table<string,[]*mime/multipart.FileHeader>
+        - Name: dirLen
           Offset: 24
-          Type: 13 BaseType bool
-    - __kind: GoSliceHeaderType
-      ID: 81
-      Name: '[]time.zoneTrans'
-      ByteSize: 24
-      GoRuntimeType: 489568
-      GoKind: 23
-      RawFields:
-        - Name: array
-          Offset: 0
-          Type: 82 PointerType *time.zoneTrans
-        - Name: len
-          Offset: 8
           Type: 8 BaseType int
-        - Name: cap
-          Offset: 16
-          Type: 8 BaseType int
-      Data: 184 GoSliceDataType []time.zoneTrans.array
-    - __kind: PointerType
-      ID: 82
-      Name: '*time.zoneTrans'
-      ByteSize: 8
-      GoRuntimeType: 394944
-      GoKind: 22
-      Pointee: 83 StructureType time.zoneTrans
-    - __kind: StructureType
-      ID: 83
-      Name: time.zoneTrans
-      ByteSize: 16
-      GoRuntimeType: 1.750848e+06
-      GoKind: 25
-      RawFields:
-        - Name: when
-          Offset: 0
-          Type: 32 BaseType int64
-        - Name: index
-          Offset: 8
+        - Name: globalDepth
+          Offset: 32
           Type: 7 BaseType uint8
-        - Name: isstd
-          Offset: 9
+        - Name: globalShift
+          Offset: 33
+          Type: 7 BaseType uint8
+        - Name: writing
+          Offset: 34
+          Type: 7 BaseType uint8
+        - Name: tombstonePossible
+          Offset: 35
           Type: 13 BaseType bool
-        - Name: isutc
-          Offset: 10
+        - Name: clearSeq
+          Offset: 40
+          Type: 17 BaseType uint64
+      TablePtrSliceType: 168 GoSliceDataType []*table<string,[]*mime/multipart.FileHeader>.array
+      GroupType: 45 StructureType noalg.map.group[string][]*mime/multipart.FileHeader
+    - __kind: GoSwissMapHeaderType
+      ID: 16
+      Name: map<string,[]string>
+      ByteSize: 48
+      GoKind: 25
+      RawFields:
+        - Name: used
+          Offset: 0
+          Type: 17 BaseType uint64
+        - Name: seed
+          Offset: 8
+          Type: 18 BaseType uintptr
+        - Name: dirPtr
+          Offset: 16
+          Type: 19 PointerType **table<string,[]string>
+        - Name: dirLen
+          Offset: 24
+          Type: 8 BaseType int
+        - Name: globalDepth
+          Offset: 32
+          Type: 7 BaseType uint8
+        - Name: globalShift
+          Offset: 33
+          Type: 7 BaseType uint8
+        - Name: writing
+          Offset: 34
+          Type: 7 BaseType uint8
+        - Name: tombstonePossible
+          Offset: 35
           Type: 13 BaseType bool
-    - __kind: BaseType
-      ID: 84
-      Name: crypto/x509.KeyUsage
+        - Name: clearSeq
+          Offset: 40
+          Type: 17 BaseType uint64
+      TablePtrSliceType: 164 GoSliceDataType []*table<string,[]string>.array
+      GroupType: 25 StructureType noalg.map.group[string][]string
+    - __kind: GoSwissMapHeaderType
+      ID: 126
+      Name: map<string,string>
+      ByteSize: 48
+      GoKind: 25
+      RawFields:
+        - Name: used
+          Offset: 0
+          Type: 17 BaseType uint64
+        - Name: seed
+          Offset: 8
+          Type: 18 BaseType uintptr
+        - Name: dirPtr
+          Offset: 16
+          Type: 127 PointerType **table<string,string>
+        - Name: dirLen
+          Offset: 24
+          Type: 8 BaseType int
+        - Name: globalDepth
+          Offset: 32
+          Type: 7 BaseType uint8
+        - Name: globalShift
+          Offset: 33
+          Type: 7 BaseType uint8
+        - Name: writing
+          Offset: 34
+          Type: 7 BaseType uint8
+        - Name: tombstonePossible
+          Offset: 35
+          Type: 13 BaseType bool
+        - Name: clearSeq
+          Offset: 40
+          Type: 17 BaseType uint64
+      TablePtrSliceType: 212 GoSliceDataType []*table<string,string>.array
+      GroupType: 132 StructureType noalg.map.group[string]string
+    - __kind: GoMapType
+      ID: 37
+      Name: map[string][]*mime/multipart.FileHeader
       ByteSize: 8
-      GoRuntimeType: 588096
-      GoKind: 2
+      GoRuntimeType: 1.132352e+06
+      GoKind: 21
+      HeaderType: 39 GoSwissMapHeaderType map<string,[]*mime/multipart.FileHeader>
+    - __kind: GoMapType
+      ID: 36
+      Name: map[string][]string
+      ByteSize: 8
+      GoRuntimeType: 1.128e+06
+      GoKind: 21
+      HeaderType: 16 GoSwissMapHeaderType map<string,[]string>
+    - __kind: GoMapType
+      ID: 124
+      Name: map[string]string
+      ByteSize: 8
+      GoRuntimeType: 1.129024e+06
+      GoKind: 21
+      HeaderType: 126 GoSwissMapHeaderType map<string,string>
+    - __kind: StructureType
+      ID: 65
+      Name: math/big.Int
+      ByteSize: 32
+      GoRuntimeType: 1.494272e+06
+      GoKind: 25
+      RawFields:
+        - Name: neg
+          Offset: 0
+          Type: 13 BaseType bool
+        - Name: abs
+          Offset: 8
+          Type: 66 GoSliceHeaderType math/big.nat
+    - __kind: BaseType
+      ID: 68
+      Name: math/big.Word
+      ByteSize: 8
+      GoRuntimeType: 588352
+      GoKind: 7
     - __kind: GoSliceHeaderType
-      ID: 85
-      Name: '[]crypto/x509/pkix.Extension'
+      ID: 66
+      Name: math/big.nat
       ByteSize: 24
-      GoRuntimeType: 503840
+      GoRuntimeType: 2.361856e+06
       GoKind: 23
       RawFields:
         - Name: array
           Offset: 0
-          Type: 86 PointerType *crypto/x509/pkix.Extension
+          Type: 67 PointerType *math/big.Word
         - Name: len
           Offset: 8
           Type: 8 BaseType int
         - Name: cap
           Offset: 16
           Type: 8 BaseType int
-      Data: 186 GoSliceDataType []crypto/x509/pkix.Extension.array
-    - __kind: PointerType
-      ID: 86
-      Name: '*crypto/x509/pkix.Extension'
-      ByteSize: 8
-      GoRuntimeType: 437504
-      GoKind: 22
-      Pointee: 87 StructureType crypto/x509/pkix.Extension
+      Data: 176 GoSliceDataType math/big.nat.array
+    - __kind: GoSliceDataType
+      ID: 176
+      Name: math/big.nat.array
+      ByteSize: 2048
+      Element: 68 BaseType math/big.Word
     - __kind: StructureType
-      ID: 87
-      Name: crypto/x509/pkix.Extension
-      ByteSize: 56
-      GoRuntimeType: 1.647008e+06
+      ID: 51
+      Name: mime/multipart.FileHeader
+      ByteSize: 88
+      GoRuntimeType: 1.977856e+06
       GoKind: 25
       RawFields:
-        - Name: Id
+        - Name: Filename
           Offset: 0
-          Type: 73 GoSliceHeaderType encoding/asn1.ObjectIdentifier
-        - Name: Critical
+          Type: 5 GoStringHeaderType string
+        - Name: Header
+          Offset: 16
+          Type: 52 GoMapType net/textproto.MIMEHeader
+        - Name: Size
           Offset: 24
-          Type: 13 BaseType bool
-        - Name: Value
+          Type: 32 BaseType int64
+        - Name: content
           Offset: 32
           Type: 53 GoSliceHeaderType []uint8
-    - __kind: GoSliceHeaderType
-      ID: 88
-      Name: '[]encoding/asn1.ObjectIdentifier'
-      ByteSize: 24
-      GoRuntimeType: 503904
-      GoKind: 23
+        - Name: tmpfile
+          Offset: 56
+          Type: 5 GoStringHeaderType string
+        - Name: tmpoff
+          Offset: 72
+          Type: 32 BaseType int64
+        - Name: tmpshared
+          Offset: 80
+          Type: 13 BaseType bool
+    - __kind: StructureType
+      ID: 35
+      Name: mime/multipart.Form
+      ByteSize: 16
+      GoRuntimeType: 1.478112e+06
+      GoKind: 25
       RawFields:
-        - Name: array
+        - Name: Value
           Offset: 0
-          Type: 89 PointerType *encoding/asn1.ObjectIdentifier
-        - Name: len
+          Type: 36 GoMapType map[string][]string
+        - Name: File
           Offset: 8
-          Type: 8 BaseType int
-        - Name: cap
-          Offset: 16
-          Type: 8 BaseType int
-      Data: 188 GoSliceDataType []encoding/asn1.ObjectIdentifier.array
-    - __kind: PointerType
-      ID: 89
-      Name: '*encoding/asn1.ObjectIdentifier'
-      ByteSize: 8
-      GoRuntimeType: 1.053408e+06
-      GoKind: 22
-      Pointee: 73 GoSliceHeaderType encoding/asn1.ObjectIdentifier
-    - __kind: GoSliceHeaderType
-      ID: 90
-      Name: '[]crypto/x509.ExtKeyUsage'
-      ByteSize: 24
-      GoRuntimeType: 503968
-      GoKind: 23
-      RawFields:
-        - Name: array
-          Offset: 0
-          Type: 91 PointerType *crypto/x509.ExtKeyUsage
-        - Name: len
-          Offset: 8
-          Type: 8 BaseType int
-        - Name: cap
-          Offset: 16
-          Type: 8 BaseType int
-      Data: 190 GoSliceDataType []crypto/x509.ExtKeyUsage.array
-    - __kind: PointerType
-      ID: 91
-      Name: '*crypto/x509.ExtKeyUsage'
-      ByteSize: 8
-      GoRuntimeType: 423552
-      GoKind: 22
-      Pointee: 92 BaseType crypto/x509.ExtKeyUsage
-    - __kind: BaseType
-      ID: 92
-      Name: crypto/x509.ExtKeyUsage
-      ByteSize: 8
-      GoRuntimeType: 588160
-      GoKind: 2
-    - __kind: GoSliceHeaderType
-      ID: 93
-      Name: '[]net.IP'
-      ByteSize: 24
-      GoRuntimeType: 482944
-      GoKind: 23
-      RawFields:
-        - Name: array
-          Offset: 0
-          Type: 94 PointerType *net.IP
-        - Name: len
-          Offset: 8
-          Type: 8 BaseType int
-        - Name: cap
-          Offset: 16
-          Type: 8 BaseType int
-      Data: 192 GoSliceDataType []net.IP.array
-    - __kind: PointerType
-      ID: 94
-      Name: '*net.IP'
-      ByteSize: 8
-      GoRuntimeType: 2.150176e+06
-      GoKind: 22
-      Pointee: 95 GoSliceHeaderType net.IP
+          Type: 37 GoMapType map[string][]*mime/multipart.FileHeader
     - __kind: GoSliceHeaderType
       ID: 95
       Name: net.IP
@@ -1501,72 +1872,11 @@ Types:
           Offset: 16
           Type: 8 BaseType int
       Data: 194 GoSliceDataType net.IP.array
-    - __kind: GoSliceHeaderType
-      ID: 96
-      Name: '[]*net/url.URL'
-      ByteSize: 24
-      GoRuntimeType: 504032
-      GoKind: 23
-      RawFields:
-        - Name: array
-          Offset: 0
-          Type: 97 PointerType **net/url.URL
-        - Name: len
-          Offset: 8
-          Type: 8 BaseType int
-        - Name: cap
-          Offset: 16
-          Type: 8 BaseType int
-      Data: 196 GoSliceDataType []*net/url.URL.array
-    - __kind: PointerType
-      ID: 97
-      Name: '**net/url.URL'
-      ByteSize: 8
-      GoKind: 22
-      Pointee: 9 PointerType *net/url.URL
-    - __kind: GoSliceHeaderType
-      ID: 98
-      Name: '[]*net.IPNet'
-      ByteSize: 24
-      GoRuntimeType: 504096
-      GoKind: 23
-      RawFields:
-        - Name: array
-          Offset: 0
-          Type: 99 PointerType **net.IPNet
-        - Name: len
-          Offset: 8
-          Type: 8 BaseType int
-        - Name: cap
-          Offset: 16
-          Type: 8 BaseType int
-      Data: 198 GoSliceDataType []*net.IPNet.array
-    - __kind: PointerType
-      ID: 99
-      Name: '**net.IPNet'
-      ByteSize: 8
-      GoKind: 22
-      Pointee: 100 PointerType *net.IPNet
-    - __kind: PointerType
-      ID: 100
-      Name: '*net.IPNet'
-      ByteSize: 8
-      GoRuntimeType: 1.18336e+06
-      GoKind: 22
-      Pointee: 101 StructureType net.IPNet
-    - __kind: StructureType
-      ID: 101
-      Name: net.IPNet
-      ByteSize: 48
-      GoRuntimeType: 1.458912e+06
-      GoKind: 25
-      RawFields:
-        - Name: IP
-          Offset: 0
-          Type: 95 GoSliceHeaderType net.IP
-        - Name: Mask
-          Offset: 24
-          Type: 102 GoSliceHeaderType net.IPMask
+    - __kind: GoSliceDataType
+      ID: 194
+      Name: net.IP.array
+      ByteSize: 2048
+      Element: 7 BaseType uint8
     - __kind: GoSliceHeaderType
       ID: 102
       Name: net.IPMask
@@ -1584,148 +1894,116 @@ Types:
           Offset: 16
           Type: 8 BaseType int
       Data: 200 GoSliceDataType net.IPMask.array
-    - __kind: GoSliceHeaderType
-      ID: 103
-      Name: '[]crypto/x509.OID'
-      ByteSize: 24
-      GoRuntimeType: 504160
-      GoKind: 23
-      RawFields:
-        - Name: array
-          Offset: 0
-          Type: 104 PointerType *crypto/x509.OID
-        - Name: len
-          Offset: 8
-          Type: 8 BaseType int
-        - Name: cap
-          Offset: 16
-          Type: 8 BaseType int
-      Data: 202 GoSliceDataType []crypto/x509.OID.array
-    - __kind: PointerType
-      ID: 104
-      Name: '*crypto/x509.OID'
-      ByteSize: 8
-      GoRuntimeType: 1.954336e+06
-      GoKind: 22
-      Pointee: 105 StructureType crypto/x509.OID
+    - __kind: GoSliceDataType
+      ID: 200
+      Name: net.IPMask.array
+      ByteSize: 2048
+      Element: 7 BaseType uint8
     - __kind: StructureType
-      ID: 105
-      Name: crypto/x509.OID
-      ByteSize: 24
-      GoRuntimeType: 1.954592e+06
-      GoKind: 25
-      RawFields:
-        - Name: der
-          Offset: 0
-          Type: 53 GoSliceHeaderType []uint8
-    - __kind: GoSliceHeaderType
-      ID: 106
-      Name: '[]crypto/x509.PolicyMapping'
-      ByteSize: 24
-      GoRuntimeType: 504224
-      GoKind: 23
-      RawFields:
-        - Name: array
-          Offset: 0
-          Type: 107 PointerType *crypto/x509.PolicyMapping
-        - Name: len
-          Offset: 8
-          Type: 8 BaseType int
-        - Name: cap
-          Offset: 16
-          Type: 8 BaseType int
-      Data: 204 GoSliceDataType []crypto/x509.PolicyMapping.array
-    - __kind: PointerType
-      ID: 107
-      Name: '*crypto/x509.PolicyMapping'
-      ByteSize: 8
-      GoRuntimeType: 423616
-      GoKind: 22
-      Pointee: 108 StructureType crypto/x509.PolicyMapping
-    - __kind: StructureType
-      ID: 108
-      Name: crypto/x509.PolicyMapping
+      ID: 101
+      Name: net.IPNet
       ByteSize: 48
-      GoRuntimeType: 1.491232e+06
+      GoRuntimeType: 1.458912e+06
       GoKind: 25
       RawFields:
-        - Name: IssuerDomainPolicy
+        - Name: IP
           Offset: 0
-          Type: 105 StructureType crypto/x509.OID
-        - Name: SubjectDomainPolicy
+          Type: 95 GoSliceHeaderType net.IP
+        - Name: Mask
           Offset: 24
-          Type: 105 StructureType crypto/x509.OID
-    - __kind: GoSliceHeaderType
-      ID: 109
-      Name: '[][]*crypto/x509.Certificate'
-      ByteSize: 24
-      GoRuntimeType: 502560
-      GoKind: 23
+          Type: 102 GoSliceHeaderType net.IPMask
+    - __kind: GoMapType
+      ID: 14
+      Name: net/http.Header
+      ByteSize: 8
+      GoRuntimeType: 2.101632e+06
+      GoKind: 21
+      HeaderType: 16 GoSwissMapHeaderType map<string,[]string>
+    - __kind: StructureType
+      ID: 4
+      Name: net/http.Request
+      ByteSize: 304
+      GoRuntimeType: 2.336832e+06
+      GoKind: 25
       RawFields:
-        - Name: array
+        - Name: Method
           Offset: 0
-          Type: 110 PointerType *[]*crypto/x509.Certificate
-        - Name: len
-          Offset: 8
-          Type: 8 BaseType int
-        - Name: cap
+          Type: 5 GoStringHeaderType string
+        - Name: URL
           Offset: 16
+          Type: 9 PointerType *net/url.URL
+        - Name: Proto
+          Offset: 24
+          Type: 5 GoStringHeaderType string
+        - Name: ProtoMajor
+          Offset: 40
           Type: 8 BaseType int
-      Data: 206 GoSliceDataType [][]*crypto/x509.Certificate.array
-    - __kind: PointerType
-      ID: 110
-      Name: '*[]*crypto/x509.Certificate'
-      ByteSize: 8
-      GoKind: 22
-      Pointee: 57 GoSliceHeaderType []*crypto/x509.Certificate
-    - __kind: GoSliceHeaderType
-      ID: 111
-      Name: '[][]uint8'
-      ByteSize: 24
-      GoRuntimeType: 481920
-      GoKind: 23
-      RawFields:
-        - Name: array
-          Offset: 0
-          Type: 112 PointerType *[]uint8
-        - Name: len
-          Offset: 8
+        - Name: ProtoMinor
+          Offset: 48
           Type: 8 BaseType int
-        - Name: cap
-          Offset: 16
-          Type: 8 BaseType int
-      Data: 208 GoSliceDataType [][]uint8.array
-    - __kind: PointerType
-      ID: 112
-      Name: '*[]uint8'
-      ByteSize: 8
-      GoRuntimeType: 481600
-      GoKind: 22
-      Pointee: 53 GoSliceHeaderType []uint8
-    - __kind: GoSubroutineType
-      ID: 113
-      Name: func(string, []uint8, int) ([]uint8, error)
-      ByteSize: 8
-      GoRuntimeType: 1.003296e+06
-      GoKind: 19
-    - __kind: BaseType
-      ID: 114
-      Name: crypto/tls.SignatureScheme
-      ByteSize: 2
-      GoRuntimeType: 835136
-      GoKind: 9
-    - __kind: GoChannelType
-      ID: 115
-      Name: <-chan struct {}
-      GoRuntimeType: 597696
-      GoKind: 18
-    - __kind: PointerType
-      ID: 116
-      Name: '*net/http.Response'
-      ByteSize: 8
-      GoRuntimeType: 1.718816e+06
-      GoKind: 22
-      Pointee: 117 StructureType net/http.Response
+        - Name: Header
+          Offset: 56
+          Type: 14 GoMapType net/http.Header
+        - Name: Body
+          Offset: 64
+          Type: 30 GoInterfaceType io.ReadCloser
+        - Name: GetBody
+          Offset: 80
+          Type: 31 GoSubroutineType func() (io.ReadCloser, error)
+        - Name: ContentLength
+          Offset: 88
+          Type: 32 BaseType int64
+        - Name: TransferEncoding
+          Offset: 96
+          Type: 28 GoSliceHeaderType []string
+        - Name: Close
+          Offset: 120
+          Type: 13 BaseType bool
+        - Name: Host
+          Offset: 128
+          Type: 5 GoStringHeaderType string
+        - Name: Form
+          Offset: 144
+          Type: 33 GoMapType net/url.Values
+        - Name: PostForm
+          Offset: 152
+          Type: 33 GoMapType net/url.Values
+        - Name: MultipartForm
+          Offset: 160
+          Type: 34 PointerType *mime/multipart.Form
+        - Name: Trailer
+          Offset: 168
+          Type: 14 GoMapType net/http.Header
+        - Name: RemoteAddr
+          Offset: 176
+          Type: 5 GoStringHeaderType string
+        - Name: RequestURI
+          Offset: 192
+          Type: 5 GoStringHeaderType string
+        - Name: TLS
+          Offset: 208
+          Type: 54 PointerType *crypto/tls.ConnectionState
+        - Name: Cancel
+          Offset: 216
+          Type: 115 GoChannelType <-chan struct {}
+        - Name: Response
+          Offset: 224
+          Type: 116 PointerType *net/http.Response
+        - Name: Pattern
+          Offset: 232
+          Type: 5 GoStringHeaderType string
+        - Name: ctx
+          Offset: 248
+          Type: 118 GoInterfaceType context.Context
+        - Name: pat
+          Offset: 264
+          Type: 119 PointerType *net/http.pattern
+        - Name: matches
+          Offset: 272
+          Type: 28 GoSliceHeaderType []string
+        - Name: otherValues
+          Offset: 296
+          Type: 124 GoMapType map[string]string
     - __kind: StructureType
       ID: 117
       Name: net/http.Response
@@ -1776,10 +2054,10 @@ Types:
           Offset: 136
           Type: 54 PointerType *crypto/tls.ConnectionState
     - __kind: GoInterfaceType
-      ID: 118
-      Name: context.Context
+      ID: 1
+      Name: net/http.ResponseWriter
       ByteSize: 16
-      GoRuntimeType: 1.276992e+06
+      GoRuntimeType: 1.185792e+06
       GoKind: 20
       RawFields:
         - Name: tab
@@ -1788,13 +2066,6 @@ Types:
         - Name: data
           Offset: 8
           Type: 2 VoidPointerType unsafe.Pointer
-    - __kind: PointerType
-      ID: 119
-      Name: '*net/http.pattern'
-      ByteSize: 8
-      GoRuntimeType: 1.608608e+06
-      GoKind: 22
-      Pointee: 120 StructureType net/http.pattern
     - __kind: StructureType
       ID: 120
       Name: net/http.pattern
@@ -1817,30 +2088,6 @@ Types:
         - Name: loc
           Offset: 72
           Type: 5 GoStringHeaderType string
-    - __kind: GoSliceHeaderType
-      ID: 121
-      Name: '[]net/http.segment'
-      ByteSize: 24
-      GoRuntimeType: 484640
-      GoKind: 23
-      RawFields:
-        - Name: array
-          Offset: 0
-          Type: 122 PointerType *net/http.segment
-        - Name: len
-          Offset: 8
-          Type: 8 BaseType int
-        - Name: cap
-          Offset: 16
-          Type: 8 BaseType int
-      Data: 210 GoSliceDataType []net/http.segment.array
-    - __kind: PointerType
-      ID: 122
-      Name: '*net/http.segment'
-      ByteSize: 8
-      GoRuntimeType: 391808
-      GoKind: 22
-      Pointee: 123 StructureType net/http.segment
     - __kind: StructureType
       ID: 123
       Name: net/http.segment
@@ -1858,62 +2105,246 @@ Types:
           Offset: 17
           Type: 13 BaseType bool
     - __kind: GoMapType
-      ID: 124
-      Name: map[string]string
+      ID: 52
+      Name: net/textproto.MIMEHeader
       ByteSize: 8
-      GoRuntimeType: 1.129024e+06
+      GoRuntimeType: 1.823584e+06
       GoKind: 21
-      HeaderType: 126 GoSwissMapHeaderType map<string,string>
-    - __kind: PointerType
-      ID: 125
-      Name: '*map<string,string>'
+      HeaderType: 16 GoSwissMapHeaderType map<string,[]string>
+    - __kind: StructureType
+      ID: 10
+      Name: net/url.URL
+      ByteSize: 144
+      GoRuntimeType: 2.127584e+06
+      GoKind: 25
+      RawFields:
+        - Name: Scheme
+          Offset: 0
+          Type: 5 GoStringHeaderType string
+        - Name: Opaque
+          Offset: 16
+          Type: 5 GoStringHeaderType string
+        - Name: User
+          Offset: 32
+          Type: 11 PointerType *net/url.Userinfo
+        - Name: Host
+          Offset: 40
+          Type: 5 GoStringHeaderType string
+        - Name: Path
+          Offset: 56
+          Type: 5 GoStringHeaderType string
+        - Name: RawPath
+          Offset: 72
+          Type: 5 GoStringHeaderType string
+        - Name: OmitHost
+          Offset: 88
+          Type: 13 BaseType bool
+        - Name: ForceQuery
+          Offset: 89
+          Type: 13 BaseType bool
+        - Name: RawQuery
+          Offset: 96
+          Type: 5 GoStringHeaderType string
+        - Name: Fragment
+          Offset: 112
+          Type: 5 GoStringHeaderType string
+        - Name: RawFragment
+          Offset: 128
+          Type: 5 GoStringHeaderType string
+    - __kind: StructureType
+      ID: 12
+      Name: net/url.Userinfo
+      ByteSize: 40
+      GoRuntimeType: 1.624928e+06
+      GoKind: 25
+      RawFields:
+        - Name: username
+          Offset: 0
+          Type: 5 GoStringHeaderType string
+        - Name: password
+          Offset: 16
+          Type: 5 GoStringHeaderType string
+        - Name: passwordSet
+          Offset: 32
+          Type: 13 BaseType bool
+    - __kind: GoMapType
+      ID: 33
+      Name: net/url.Values
       ByteSize: 8
-      Pointee: 126 GoSwissMapHeaderType map<string,string>
-    - __kind: GoSwissMapHeaderType
-      ID: 126
-      Name: map<string,string>
-      ByteSize: 48
+      GoRuntimeType: 1.885152e+06
+      GoKind: 21
+      HeaderType: 16 GoSwissMapHeaderType map<string,[]string>
+    - __kind: ArrayType
+      ID: 46
+      Name: noalg.[8]struct { key string; elem []*mime/multipart.FileHeader }
+      ByteSize: 320
+      GoRuntimeType: 699200
+      GoKind: 17
+      Count: 8
+      HasCount: true
+      Element: 47 StructureType noalg.struct { key string; elem []*mime/multipart.FileHeader }
+    - __kind: ArrayType
+      ID: 26
+      Name: noalg.[8]struct { key string; elem []string }
+      ByteSize: 320
+      GoRuntimeType: 689376
+      GoKind: 17
+      Count: 8
+      HasCount: true
+      Element: 27 StructureType noalg.struct { key string; elem []string }
+    - __kind: ArrayType
+      ID: 133
+      Name: noalg.[8]struct { key string; elem string }
+      ByteSize: 256
+      GoRuntimeType: 693536
+      GoKind: 17
+      Count: 8
+      HasCount: true
+      Element: 134 StructureType noalg.struct { key string; elem string }
+    - __kind: StructureType
+      ID: 45
+      Name: noalg.map.group[string][]*mime/multipart.FileHeader
+      ByteSize: 328
+      GoRuntimeType: 1.29952e+06
+      GoKind: 25
+      RawFields:
+        - Name: ctrl
+          Offset: 0
+          Type: 17 BaseType uint64
+        - Name: slots
+          Offset: 8
+          Type: 46 ArrayType noalg.[8]struct { key string; elem []*mime/multipart.FileHeader }
+    - __kind: StructureType
+      ID: 25
+      Name: noalg.map.group[string][]string
+      ByteSize: 328
+      GoRuntimeType: 1.290432e+06
+      GoKind: 25
+      RawFields:
+        - Name: ctrl
+          Offset: 0
+          Type: 17 BaseType uint64
+        - Name: slots
+          Offset: 8
+          Type: 26 ArrayType noalg.[8]struct { key string; elem []string }
+    - __kind: StructureType
+      ID: 132
+      Name: noalg.map.group[string]string
+      ByteSize: 264
+      GoRuntimeType: 1.292864e+06
+      GoKind: 25
+      RawFields:
+        - Name: ctrl
+          Offset: 0
+          Type: 17 BaseType uint64
+        - Name: slots
+          Offset: 8
+          Type: 133 ArrayType noalg.[8]struct { key string; elem string }
+    - __kind: StructureType
+      ID: 47
+      Name: noalg.struct { key string; elem []*mime/multipart.FileHeader }
+      ByteSize: 40
+      GoRuntimeType: 1.299392e+06
+      GoKind: 25
+      RawFields:
+        - Name: key
+          Offset: 0
+          Type: 5 GoStringHeaderType string
+        - Name: elem
+          Offset: 16
+          Type: 48 GoSliceHeaderType []*mime/multipart.FileHeader
+    - __kind: StructureType
+      ID: 27
+      Name: noalg.struct { key string; elem []string }
+      ByteSize: 40
+      GoRuntimeType: 1.290304e+06
+      GoKind: 25
+      RawFields:
+        - Name: key
+          Offset: 0
+          Type: 5 GoStringHeaderType string
+        - Name: elem
+          Offset: 16
+          Type: 28 GoSliceHeaderType []string
+    - __kind: StructureType
+      ID: 134
+      Name: noalg.struct { key string; elem string }
+      ByteSize: 32
+      GoRuntimeType: 1.292736e+06
+      GoKind: 25
+      RawFields:
+        - Name: key
+          Offset: 0
+          Type: 5 GoStringHeaderType string
+        - Name: elem
+          Offset: 16
+          Type: 5 GoStringHeaderType string
+    - __kind: GoStringHeaderType
+      ID: 5
+      Name: string
+      ByteSize: 16
+      GoRuntimeType: 584448
+      GoKind: 24
+      RawFields:
+        - Name: str
+          Offset: 0
+          Type: 163 PointerType *string.str
+        - Name: len
+          Offset: 8
+          Type: 8 BaseType int
+      Data: 162 GoStringDataType string.str
+    - __kind: GoStringDataType
+      ID: 162
+      Name: string.str
+      ByteSize: 2048
+    - __kind: StructureType
+      ID: 42
+      Name: table<string,[]*mime/multipart.FileHeader>
+      ByteSize: 32
       GoKind: 25
       RawFields:
         - Name: used
           Offset: 0
-          Type: 17 BaseType uint64
-        - Name: seed
+          Type: 22 BaseType uint16
+        - Name: capacity
+          Offset: 2
+          Type: 22 BaseType uint16
+        - Name: growthLeft
+          Offset: 4
+          Type: 22 BaseType uint16
+        - Name: localDepth
+          Offset: 6
+          Type: 7 BaseType uint8
+        - Name: index
           Offset: 8
-          Type: 18 BaseType uintptr
-        - Name: dirPtr
-          Offset: 16
-          Type: 127 PointerType **table<string,string>
-        - Name: dirLen
-          Offset: 24
           Type: 8 BaseType int
-        - Name: globalDepth
-          Offset: 32
+        - Name: groups
+          Offset: 16
+          Type: 43 GoSwissMapGroupsType groupReference<string,[]*mime/multipart.FileHeader>
+    - __kind: StructureType
+      ID: 21
+      Name: table<string,[]string>
+      ByteSize: 32
+      GoKind: 25
+      RawFields:
+        - Name: used
+          Offset: 0
+          Type: 22 BaseType uint16
+        - Name: capacity
+          Offset: 2
+          Type: 22 BaseType uint16
+        - Name: growthLeft
+          Offset: 4
+          Type: 22 BaseType uint16
+        - Name: localDepth
+          Offset: 6
           Type: 7 BaseType uint8
-        - Name: globalShift
-          Offset: 33
-          Type: 7 BaseType uint8
-        - Name: writing
-          Offset: 34
-          Type: 7 BaseType uint8
-        - Name: tombstonePossible
-          Offset: 35
-          Type: 13 BaseType bool
-        - Name: clearSeq
-          Offset: 40
-          Type: 17 BaseType uint64
-      TablePtrSliceType: 212 GoSliceDataType []*table<string,string>.array
-      GroupType: 132 StructureType noalg.map.group[string]string
-    - __kind: PointerType
-      ID: 127
-      Name: '**table<string,string>'
-      ByteSize: 8
-      Pointee: 128 PointerType *table<string,string>
-    - __kind: PointerType
-      ID: 128
-      Name: '*table<string,string>'
-      ByteSize: 8
-      Pointee: 129 StructureType table<string,string>
+        - Name: index
+          Offset: 8
+          Type: 8 BaseType int
+        - Name: groups
+          Offset: 16
+          Type: 23 GoSwissMapGroupsType groupReference<string,[]string>
     - __kind: StructureType
       ID: 129
       Name: table<string,string>
@@ -1938,146 +2369,85 @@ Types:
         - Name: groups
           Offset: 16
           Type: 130 GoSwissMapGroupsType groupReference<string,string>
-    - __kind: GoSwissMapGroupsType
-      ID: 130
-      Name: groupReference<string,string>
-      ByteSize: 16
-      GoKind: 25
-      RawFields:
-        - Name: data
-          Offset: 0
-          Type: 131 PointerType *noalg.map.group[string]string
-        - Name: lengthMask
-          Offset: 8
-          Type: 17 BaseType uint64
-      GroupType: 132 StructureType noalg.map.group[string]string
-      GroupSliceType: 213 GoSliceDataType []noalg.map.group[string]string.array
-    - __kind: PointerType
-      ID: 131
-      Name: '*noalg.map.group[string]string'
-      ByteSize: 8
-      Pointee: 132 StructureType noalg.map.group[string]string
     - __kind: StructureType
-      ID: 132
-      Name: noalg.map.group[string]string
-      ByteSize: 264
-      GoRuntimeType: 1.292864e+06
+      ID: 77
+      Name: time.Location
+      ByteSize: 104
+      GoRuntimeType: 1.973536e+06
       GoKind: 25
       RawFields:
-        - Name: ctrl
-          Offset: 0
-          Type: 17 BaseType uint64
-        - Name: slots
-          Offset: 8
-          Type: 133 ArrayType noalg.[8]struct { key string; elem string }
-    - __kind: ArrayType
-      ID: 133
-      Name: noalg.[8]struct { key string; elem string }
-      ByteSize: 256
-      GoRuntimeType: 693536
-      GoKind: 17
-      Count: 8
-      HasCount: true
-      Element: 134 StructureType noalg.struct { key string; elem string }
-    - __kind: StructureType
-      ID: 134
-      Name: noalg.struct { key string; elem string }
-      ByteSize: 32
-      GoRuntimeType: 1.292736e+06
-      GoKind: 25
-      RawFields:
-        - Name: key
+        - Name: name
           Offset: 0
           Type: 5 GoStringHeaderType string
-        - Name: elem
+        - Name: zone
           Offset: 16
+          Type: 78 GoSliceHeaderType []time.zone
+        - Name: tx
+          Offset: 40
+          Type: 81 GoSliceHeaderType []time.zoneTrans
+        - Name: extend
+          Offset: 64
           Type: 5 GoStringHeaderType string
-    - __kind: PointerType
-      ID: 135
-      Name: '*bytes.Buffer'
-      ByteSize: 8
-      GoRuntimeType: 2.260704e+06
-      GoKind: 22
-      Pointee: 136 StructureType bytes.Buffer
+        - Name: cacheStart
+          Offset: 80
+          Type: 32 BaseType int64
+        - Name: cacheEnd
+          Offset: 88
+          Type: 32 BaseType int64
+        - Name: cacheZone
+          Offset: 96
+          Type: 79 PointerType *time.zone
     - __kind: StructureType
-      ID: 136
-      Name: bytes.Buffer
-      ByteSize: 40
-      GoRuntimeType: 1.606304e+06
+      ID: 75
+      Name: time.Time
+      ByteSize: 24
+      GoRuntimeType: 2.364704e+06
       GoKind: 25
       RawFields:
-        - Name: buf
+        - Name: wall
           Offset: 0
-          Type: 53 GoSliceHeaderType []uint8
-        - Name: off
-          Offset: 24
+          Type: 17 BaseType uint64
+        - Name: ext
+          Offset: 8
+          Type: 32 BaseType int64
+        - Name: loc
+          Offset: 16
+          Type: 76 PointerType *time.Location
+    - __kind: StructureType
+      ID: 80
+      Name: time.zone
+      ByteSize: 32
+      GoRuntimeType: 1.613408e+06
+      GoKind: 25
+      RawFields:
+        - Name: name
+          Offset: 0
+          Type: 5 GoStringHeaderType string
+        - Name: offset
+          Offset: 16
           Type: 8 BaseType int
-        - Name: lastRead
-          Offset: 32
-          Type: 137 BaseType bytes.readOp
-    - __kind: BaseType
-      ID: 137
-      Name: bytes.readOp
-      ByteSize: 1
-      GoRuntimeType: 583680
-      GoKind: 3
-    - __kind: GoInterfaceType
-      ID: 138
-      Name: gopkg.in/DataDog/dd-trace-go.v1/ddtrace.Span
+        - Name: isDST
+          Offset: 24
+          Type: 13 BaseType bool
+    - __kind: StructureType
+      ID: 83
+      Name: time.zoneTrans
       ByteSize: 16
-      GoRuntimeType: 1.479712e+06
-      GoKind: 20
+      GoRuntimeType: 1.750848e+06
+      GoKind: 25
       RawFields:
-        - Name: tab
+        - Name: when
           Offset: 0
-          Type: 2 VoidPointerType unsafe.Pointer
-        - Name: data
+          Type: 32 BaseType int64
+        - Name: index
           Offset: 8
-          Type: 2 VoidPointerType unsafe.Pointer
-    - __kind: BaseType
-      ID: 139
-      Name: uint32
-      ByteSize: 4
-      GoRuntimeType: 584832
-      GoKind: 10
-    - __kind: BaseType
-      ID: 140
-      Name: int32
-      ByteSize: 4
-      GoRuntimeType: 584768
-      GoKind: 5
-    - __kind: PointerType
-      ID: 141
-      Name: '*bool'
-      ByteSize: 8
-      GoRuntimeType: 400320
-      GoKind: 22
-      Pointee: 13 BaseType bool
-    - __kind: GoInterfaceType
-      ID: 142
-      Name: error
-      ByteSize: 16
-      GoRuntimeType: 1.031776e+06
-      GoKind: 20
-      RawFields:
-        - Name: tab
-          Offset: 0
-          Type: 2 VoidPointerType unsafe.Pointer
-        - Name: data
-          Offset: 8
-          Type: 2 VoidPointerType unsafe.Pointer
-    - __kind: BaseType
-      ID: 143
-      Name: float64
-      ByteSize: 8
-      GoRuntimeType: 585408
-      GoKind: 14
-    - __kind: BaseType
-      ID: 144
-      Name: int8
-      ByteSize: 1
-      GoRuntimeType: 584512
-      GoKind: 3
+          Type: 7 BaseType uint8
+        - Name: isstd
+          Offset: 9
+          Type: 13 BaseType bool
+        - Name: isutc
+          Offset: 10
+          Type: 13 BaseType bool
     - __kind: BaseType
       ID: 145
       Name: uint
@@ -2085,411 +2455,41 @@ Types:
       GoRuntimeType: 585088
       GoKind: 7
     - __kind: BaseType
-      ID: 146
-      Name: float32
-      ByteSize: 4
-      GoRuntimeType: 585344
-      GoKind: 13
-    - __kind: PointerType
-      ID: 147
-      Name: '*uintptr'
-      ByteSize: 8
-      GoRuntimeType: 400000
-      GoKind: 22
-      Pointee: 18 BaseType uintptr
-    - __kind: PointerType
-      ID: 148
-      Name: '*int32'
-      ByteSize: 8
-      GoRuntimeType: 399616
-      GoKind: 22
-      Pointee: 140 BaseType int32
-    - __kind: PointerType
-      ID: 149
-      Name: '*uint32'
-      ByteSize: 8
-      GoRuntimeType: 399680
-      GoKind: 22
-      Pointee: 139 BaseType uint32
-    - __kind: BaseType
-      ID: 150
-      Name: complex64
-      ByteSize: 8
-      GoRuntimeType: 585216
-      GoKind: 15
-    - __kind: BaseType
-      ID: 151
-      Name: complex128
-      ByteSize: 16
-      GoRuntimeType: 585280
-      GoKind: 16
-    - __kind: PointerType
-      ID: 152
-      Name: '*float64'
-      ByteSize: 8
-      GoRuntimeType: 400256
-      GoKind: 22
-      Pointee: 143 BaseType float64
-    - __kind: PointerType
-      ID: 153
-      Name: '*int64'
-      ByteSize: 8
-      GoRuntimeType: 399744
-      GoKind: 22
-      Pointee: 32 BaseType int64
-    - __kind: PointerType
-      ID: 154
-      Name: '*uint64'
-      ByteSize: 8
-      GoRuntimeType: 399808
-      GoKind: 22
-      Pointee: 17 BaseType uint64
-    - __kind: PointerType
-      ID: 155
-      Name: '*uint16'
-      ByteSize: 8
-      GoRuntimeType: 399552
-      GoKind: 22
-      Pointee: 22 BaseType uint16
-    - __kind: PointerType
-      ID: 156
-      Name: '*int16'
-      ByteSize: 8
-      GoRuntimeType: 399488
-      GoKind: 22
-      Pointee: 157 BaseType int16
-    - __kind: BaseType
-      ID: 157
-      Name: int16
+      ID: 22
+      Name: uint16
       ByteSize: 2
-      GoRuntimeType: 584640
-      GoKind: 4
-    - __kind: PointerType
-      ID: 158
-      Name: '*int8'
+      GoRuntimeType: 584704
+      GoKind: 9
+    - __kind: BaseType
+      ID: 139
+      Name: uint32
+      ByteSize: 4
+      GoRuntimeType: 584832
+      GoKind: 10
+    - __kind: BaseType
+      ID: 17
+      Name: uint64
       ByteSize: 8
-      GoRuntimeType: 399360
-      GoKind: 22
-      Pointee: 144 BaseType int8
-    - __kind: PointerType
-      ID: 159
-      Name: '*error'
+      GoRuntimeType: 584960
+      GoKind: 11
+    - __kind: BaseType
+      ID: 7
+      Name: uint8
+      ByteSize: 1
+      GoRuntimeType: 584576
+      GoKind: 8
+    - __kind: BaseType
+      ID: 18
+      Name: uintptr
       ByteSize: 8
-      GoRuntimeType: 399232
-      GoKind: 22
-      Pointee: 142 GoInterfaceType error
-    - __kind: PointerType
-      ID: 160
-      Name: '*uint'
+      GoRuntimeType: 585152
+      GoKind: 12
+    - __kind: VoidPointerType
+      ID: 2
+      Name: unsafe.Pointer
       ByteSize: 8
-      GoRuntimeType: 399936
-      GoKind: 22
-      Pointee: 145 BaseType uint
-    - __kind: PointerType
-      ID: 161
-      Name: '*float32'
-      ByteSize: 8
-      GoRuntimeType: 400192
-      GoKind: 22
-      Pointee: 146 BaseType float32
-    - __kind: GoStringDataType
-      ID: 162
-      Name: string.str
-      ByteSize: 2048
-    - __kind: PointerType
-      ID: 163
-      Name: '*string.str'
-      ByteSize: 8
-      Pointee: 162 GoStringDataType string.str
-    - __kind: GoSliceDataType
-      ID: 164
-      Name: '[]*table<string,[]string>.array'
-      ByteSize: 8192
-      Element: 20 PointerType *table<string,[]string>
-    - __kind: GoSliceDataType
-      ID: 165
-      Name: '[]noalg.map.group[string][]string.array'
-      ByteSize: 2048
-      Element: 25 StructureType noalg.map.group[string][]string
-    - __kind: GoSliceDataType
-      ID: 166
-      Name: '[]string.array'
-      ByteSize: 2048
-      Element: 5 GoStringHeaderType string
-    - __kind: PointerType
-      ID: 167
-      Name: '*[]string.array'
-      ByteSize: 8
-      Pointee: 166 GoSliceDataType []string.array
-    - __kind: GoSliceDataType
-      ID: 168
-      Name: '[]*table<string,[]*mime/multipart.FileHeader>.array'
-      ByteSize: 8192
-      Element: 41 PointerType *table<string,[]*mime/multipart.FileHeader>
-    - __kind: GoSliceDataType
-      ID: 169
-      Name: '[]noalg.map.group[string][]*mime/multipart.FileHeader.array'
-      ByteSize: 2048
-      Element: 45 StructureType noalg.map.group[string][]*mime/multipart.FileHeader
-    - __kind: GoSliceDataType
-      ID: 170
-      Name: '[]*mime/multipart.FileHeader.array'
-      ByteSize: 2048
-      Element: 50 PointerType *mime/multipart.FileHeader
-    - __kind: PointerType
-      ID: 171
-      Name: '*[]*mime/multipart.FileHeader.array'
-      ByteSize: 8
-      Pointee: 170 GoSliceDataType []*mime/multipart.FileHeader.array
-    - __kind: GoSliceDataType
-      ID: 172
-      Name: '[]uint8.array'
-      ByteSize: 2048
-      Element: 7 BaseType uint8
-    - __kind: PointerType
-      ID: 173
-      Name: '*[]uint8.array'
-      ByteSize: 8
-      Pointee: 172 GoSliceDataType []uint8.array
-    - __kind: GoSliceDataType
-      ID: 174
-      Name: '[]*crypto/x509.Certificate.array'
-      ByteSize: 2048
-      Element: 59 PointerType *crypto/x509.Certificate
-    - __kind: PointerType
-      ID: 175
-      Name: '*[]*crypto/x509.Certificate.array'
-      ByteSize: 8
-      Pointee: 174 GoSliceDataType []*crypto/x509.Certificate.array
-    - __kind: GoSliceDataType
-      ID: 176
-      Name: math/big.nat.array
-      ByteSize: 2048
-      Element: 68 BaseType math/big.Word
-    - __kind: PointerType
-      ID: 177
-      Name: '*math/big.nat.array'
-      ByteSize: 8
-      Pointee: 176 GoSliceDataType math/big.nat.array
-    - __kind: GoSliceDataType
-      ID: 178
-      Name: '[]crypto/x509/pkix.AttributeTypeAndValue.array'
-      ByteSize: 2048
-      Element: 72 StructureType crypto/x509/pkix.AttributeTypeAndValue
-    - __kind: PointerType
-      ID: 179
-      Name: '*[]crypto/x509/pkix.AttributeTypeAndValue.array'
-      ByteSize: 8
-      Pointee: 178 GoSliceDataType []crypto/x509/pkix.AttributeTypeAndValue.array
-    - __kind: GoSliceDataType
-      ID: 180
-      Name: encoding/asn1.ObjectIdentifier.array
-      ByteSize: 2048
-      Element: 8 BaseType int
-    - __kind: PointerType
-      ID: 181
-      Name: '*encoding/asn1.ObjectIdentifier.array'
-      ByteSize: 8
-      Pointee: 180 GoSliceDataType encoding/asn1.ObjectIdentifier.array
-    - __kind: GoSliceDataType
-      ID: 182
-      Name: '[]time.zone.array'
-      ByteSize: 2048
-      Element: 80 StructureType time.zone
-    - __kind: PointerType
-      ID: 183
-      Name: '*[]time.zone.array'
-      ByteSize: 8
-      Pointee: 182 GoSliceDataType []time.zone.array
-    - __kind: GoSliceDataType
-      ID: 184
-      Name: '[]time.zoneTrans.array'
-      ByteSize: 2048
-      Element: 83 StructureType time.zoneTrans
-    - __kind: PointerType
-      ID: 185
-      Name: '*[]time.zoneTrans.array'
-      ByteSize: 8
-      Pointee: 184 GoSliceDataType []time.zoneTrans.array
-    - __kind: GoSliceDataType
-      ID: 186
-      Name: '[]crypto/x509/pkix.Extension.array'
-      ByteSize: 2048
-      Element: 87 StructureType crypto/x509/pkix.Extension
-    - __kind: PointerType
-      ID: 187
-      Name: '*[]crypto/x509/pkix.Extension.array'
-      ByteSize: 8
-      Pointee: 186 GoSliceDataType []crypto/x509/pkix.Extension.array
-    - __kind: GoSliceDataType
-      ID: 188
-      Name: '[]encoding/asn1.ObjectIdentifier.array'
-      ByteSize: 2048
-      Element: 73 GoSliceHeaderType encoding/asn1.ObjectIdentifier
-    - __kind: PointerType
-      ID: 189
-      Name: '*[]encoding/asn1.ObjectIdentifier.array'
-      ByteSize: 8
-      Pointee: 188 GoSliceDataType []encoding/asn1.ObjectIdentifier.array
-    - __kind: GoSliceDataType
-      ID: 190
-      Name: '[]crypto/x509.ExtKeyUsage.array'
-      ByteSize: 2048
-      Element: 92 BaseType crypto/x509.ExtKeyUsage
-    - __kind: PointerType
-      ID: 191
-      Name: '*[]crypto/x509.ExtKeyUsage.array'
-      ByteSize: 8
-      Pointee: 190 GoSliceDataType []crypto/x509.ExtKeyUsage.array
-    - __kind: GoSliceDataType
-      ID: 192
-      Name: '[]net.IP.array'
-      ByteSize: 2048
-      Element: 95 GoSliceHeaderType net.IP
-    - __kind: PointerType
-      ID: 193
-      Name: '*[]net.IP.array'
-      ByteSize: 8
-      Pointee: 192 GoSliceDataType []net.IP.array
-    - __kind: GoSliceDataType
-      ID: 194
-      Name: net.IP.array
-      ByteSize: 2048
-      Element: 7 BaseType uint8
-    - __kind: PointerType
-      ID: 195
-      Name: '*net.IP.array'
-      ByteSize: 8
-      Pointee: 194 GoSliceDataType net.IP.array
-    - __kind: GoSliceDataType
-      ID: 196
-      Name: '[]*net/url.URL.array'
-      ByteSize: 2048
-      Element: 9 PointerType *net/url.URL
-    - __kind: PointerType
-      ID: 197
-      Name: '*[]*net/url.URL.array'
-      ByteSize: 8
-      Pointee: 196 GoSliceDataType []*net/url.URL.array
-    - __kind: GoSliceDataType
-      ID: 198
-      Name: '[]*net.IPNet.array'
-      ByteSize: 2048
-      Element: 100 PointerType *net.IPNet
-    - __kind: PointerType
-      ID: 199
-      Name: '*[]*net.IPNet.array'
-      ByteSize: 8
-      Pointee: 198 GoSliceDataType []*net.IPNet.array
-    - __kind: GoSliceDataType
-      ID: 200
-      Name: net.IPMask.array
-      ByteSize: 2048
-      Element: 7 BaseType uint8
-    - __kind: PointerType
-      ID: 201
-      Name: '*net.IPMask.array'
-      ByteSize: 8
-      Pointee: 200 GoSliceDataType net.IPMask.array
-    - __kind: GoSliceDataType
-      ID: 202
-      Name: '[]crypto/x509.OID.array'
-      ByteSize: 2048
-      Element: 105 StructureType crypto/x509.OID
-    - __kind: PointerType
-      ID: 203
-      Name: '*[]crypto/x509.OID.array'
-      ByteSize: 8
-      Pointee: 202 GoSliceDataType []crypto/x509.OID.array
-    - __kind: GoSliceDataType
-      ID: 204
-      Name: '[]crypto/x509.PolicyMapping.array'
-      ByteSize: 2048
-      Element: 108 StructureType crypto/x509.PolicyMapping
-    - __kind: PointerType
-      ID: 205
-      Name: '*[]crypto/x509.PolicyMapping.array'
-      ByteSize: 8
-      Pointee: 204 GoSliceDataType []crypto/x509.PolicyMapping.array
-    - __kind: GoSliceDataType
-      ID: 206
-      Name: '[][]*crypto/x509.Certificate.array'
-      ByteSize: 2048
-      Element: 57 GoSliceHeaderType []*crypto/x509.Certificate
-    - __kind: PointerType
-      ID: 207
-      Name: '*[][]*crypto/x509.Certificate.array'
-      ByteSize: 8
-      Pointee: 206 GoSliceDataType [][]*crypto/x509.Certificate.array
-    - __kind: GoSliceDataType
-      ID: 208
-      Name: '[][]uint8.array'
-      ByteSize: 2048
-      Element: 53 GoSliceHeaderType []uint8
-    - __kind: PointerType
-      ID: 209
-      Name: '*[][]uint8.array'
-      ByteSize: 8
-      Pointee: 208 GoSliceDataType [][]uint8.array
-    - __kind: GoSliceDataType
-      ID: 210
-      Name: '[]net/http.segment.array'
-      ByteSize: 2048
-      Element: 123 StructureType net/http.segment
-    - __kind: PointerType
-      ID: 211
-      Name: '*[]net/http.segment.array'
-      ByteSize: 8
-      Pointee: 210 GoSliceDataType []net/http.segment.array
-    - __kind: GoSliceDataType
-      ID: 212
-      Name: '[]*table<string,string>.array'
-      ByteSize: 8192
-      Element: 128 PointerType *table<string,string>
-    - __kind: GoSliceDataType
-      ID: 213
-      Name: '[]noalg.map.group[string]string.array'
-      ByteSize: 2048
-      Element: 132 StructureType noalg.map.group[string]string
-    - __kind: EventRootType
-      ID: 214
-      Name: Probe[main.HandleHTTP]
-      ByteSize: 25
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: w
-          Offset: 1
-          Expression:
-            Type: 1 GoInterfaceType net/http.ResponseWriter
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 1, index: 0, name: w}
-                  Offset: 0
-                  ByteSize: 16
-        - Name: r
-          Offset: 17
-          Expression:
-            Type: 3 PointerType *net/http.Request
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 1, index: 1, name: r}
-                  Offset: 0
-                  ByteSize: 8
-    - __kind: EventRootType
-      ID: 215
-      Name: Probe[main.LookAtTheRequest]
-      ByteSize: 17
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: path
-          Offset: 1
-          Expression:
-            Type: 5 GoStringHeaderType string
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 2, index: 0, name: path}
-                  Offset: 0
-                  ByteSize: 16
+      GoRuntimeType: 585536
+      GoKind: 26
 MaxTypeID: 215
 Issues: []
 GoModuledataInfo: {FirstModuledataAddr: "0x182c9a0", TypesOffset: 296}

--- a/pkg/dyninst/irgen/testdata/snapshot/rc_tester_v1.arch=amd64,toolchain=go1.25.0.yaml
+++ b/pkg/dyninst/irgen/testdata/snapshot/rc_tester_v1.arch=amd64,toolchain=go1.25.0.yaml
@@ -10,7 +10,7 @@ Probes:
       subprogram: {subprogram: 1}
       events:
         - ID: 1
-          Type: 220 EventRootType Probe[main.HandleHTTP]
+          Type: 214 EventRootType Probe[main.HandleHTTP]
           InjectionPoints: [{PC: "0xd04e73", Frameless: false}]
           Condition: null
     - id: look_at_the_request
@@ -23,7 +23,7 @@ Probes:
       subprogram: {subprogram: 2}
       events:
         - ID: 2
-          Type: 221 EventRootType Probe[main.LookAtTheRequest]
+          Type: 215 EventRootType Probe[main.LookAtTheRequest]
           InjectionPoints: [{PC: "0xd051ee", Frameless: false}]
           Condition: null
 Subprograms:
@@ -378,7 +378,7 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 17 BaseType uint64
-      TablePtrSliceType: 176 GoSliceDataType []*table<string,[]string>.array
+      TablePtrSliceType: 164 GoSliceDataType []*table<string,[]string>.array
       GroupType: 25 StructureType noalg.map.group[string][]string
     - __kind: BaseType
       ID: 17
@@ -445,7 +445,7 @@ Types:
           Offset: 8
           Type: 17 BaseType uint64
       GroupType: 25 StructureType noalg.map.group[string][]string
-      GroupSliceType: 177 GoSliceDataType []noalg.map.group[string][]string.array
+      GroupSliceType: 165 GoSliceDataType []noalg.map.group[string][]string.array
     - __kind: PointerType
       ID: 24
       Name: '*noalg.map.group[string][]string'
@@ -614,7 +614,7 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 17 BaseType uint64
-      TablePtrSliceType: 172 GoSliceDataType []*table<string,[]*mime/multipart.FileHeader>.array
+      TablePtrSliceType: 168 GoSliceDataType []*table<string,[]*mime/multipart.FileHeader>.array
       GroupType: 45 StructureType noalg.map.group[string][]*mime/multipart.FileHeader
     - __kind: PointerType
       ID: 40
@@ -663,7 +663,7 @@ Types:
           Offset: 8
           Type: 17 BaseType uint64
       GroupType: 45 StructureType noalg.map.group[string][]*mime/multipart.FileHeader
-      GroupSliceType: 173 GoSliceDataType []noalg.map.group[string][]*mime/multipart.FileHeader.array
+      GroupSliceType: 169 GoSliceDataType []noalg.map.group[string][]*mime/multipart.FileHeader.array
     - __kind: PointerType
       ID: 44
       Name: '*noalg.map.group[string][]*mime/multipart.FileHeader'
@@ -720,7 +720,7 @@ Types:
         - Name: cap
           Offset: 16
           Type: 8 BaseType int
-      Data: 174 GoSliceDataType []*mime/multipart.FileHeader.array
+      Data: 170 GoSliceDataType []*mime/multipart.FileHeader.array
     - __kind: PointerType
       ID: 49
       Name: '**mime/multipart.FileHeader'
@@ -785,7 +785,7 @@ Types:
         - Name: cap
           Offset: 16
           Type: 8 BaseType int
-      Data: 178 GoSliceDataType []uint8.array
+      Data: 172 GoSliceDataType []uint8.array
     - __kind: PointerType
       ID: 54
       Name: '*crypto/tls.ConnectionState'
@@ -873,7 +873,7 @@ Types:
         - Name: cap
           Offset: 16
           Type: 8 BaseType int
-      Data: 180 GoSliceDataType []*crypto/x509.Certificate.array
+      Data: 174 GoSliceDataType []*crypto/x509.Certificate.array
     - __kind: PointerType
       ID: 58
       Name: '**crypto/x509.Certificate'
@@ -1111,7 +1111,7 @@ Types:
         - Name: cap
           Offset: 16
           Type: 8 BaseType int
-      Data: 182 GoSliceDataType math/big.nat.array
+      Data: 176 GoSliceDataType math/big.nat.array
     - __kind: PointerType
       ID: 67
       Name: '*math/big.Word'
@@ -1181,7 +1181,7 @@ Types:
         - Name: cap
           Offset: 16
           Type: 8 BaseType int
-      Data: 184 GoSliceDataType []crypto/x509/pkix.AttributeTypeAndValue.array
+      Data: 178 GoSliceDataType []crypto/x509/pkix.AttributeTypeAndValue.array
     - __kind: PointerType
       ID: 71
       Name: '*crypto/x509/pkix.AttributeTypeAndValue'
@@ -1218,7 +1218,7 @@ Types:
         - Name: cap
           Offset: 16
           Type: 8 BaseType int
-      Data: 186 GoSliceDataType encoding/asn1.ObjectIdentifier.array
+      Data: 180 GoSliceDataType encoding/asn1.ObjectIdentifier.array
     - __kind: PointerType
       ID: 74
       Name: '*int'
@@ -1293,7 +1293,7 @@ Types:
         - Name: cap
           Offset: 16
           Type: 8 BaseType int
-      Data: 188 GoSliceDataType []time.zone.array
+      Data: 182 GoSliceDataType []time.zone.array
     - __kind: PointerType
       ID: 79
       Name: '*time.zone'
@@ -1333,7 +1333,7 @@ Types:
         - Name: cap
           Offset: 16
           Type: 8 BaseType int
-      Data: 190 GoSliceDataType []time.zoneTrans.array
+      Data: 184 GoSliceDataType []time.zoneTrans.array
     - __kind: PointerType
       ID: 82
       Name: '*time.zoneTrans'
@@ -1382,7 +1382,7 @@ Types:
         - Name: cap
           Offset: 16
           Type: 8 BaseType int
-      Data: 192 GoSliceDataType []crypto/x509/pkix.Extension.array
+      Data: 186 GoSliceDataType []crypto/x509/pkix.Extension.array
     - __kind: PointerType
       ID: 86
       Name: '*crypto/x509/pkix.Extension'
@@ -1422,7 +1422,7 @@ Types:
         - Name: cap
           Offset: 16
           Type: 8 BaseType int
-      Data: 194 GoSliceDataType []encoding/asn1.ObjectIdentifier.array
+      Data: 188 GoSliceDataType []encoding/asn1.ObjectIdentifier.array
     - __kind: PointerType
       ID: 89
       Name: '*encoding/asn1.ObjectIdentifier'
@@ -1446,7 +1446,7 @@ Types:
         - Name: cap
           Offset: 16
           Type: 8 BaseType int
-      Data: 196 GoSliceDataType []crypto/x509.ExtKeyUsage.array
+      Data: 190 GoSliceDataType []crypto/x509.ExtKeyUsage.array
     - __kind: PointerType
       ID: 91
       Name: '*crypto/x509.ExtKeyUsage'
@@ -1476,7 +1476,7 @@ Types:
         - Name: cap
           Offset: 16
           Type: 8 BaseType int
-      Data: 198 GoSliceDataType []net.IP.array
+      Data: 192 GoSliceDataType []net.IP.array
     - __kind: PointerType
       ID: 94
       Name: '*net.IP'
@@ -1500,7 +1500,7 @@ Types:
         - Name: cap
           Offset: 16
           Type: 8 BaseType int
-      Data: 200 GoSliceDataType net.IP.array
+      Data: 194 GoSliceDataType net.IP.array
     - __kind: GoSliceHeaderType
       ID: 96
       Name: '[]*net/url.URL'
@@ -1517,7 +1517,7 @@ Types:
         - Name: cap
           Offset: 16
           Type: 8 BaseType int
-      Data: 202 GoSliceDataType []*net/url.URL.array
+      Data: 196 GoSliceDataType []*net/url.URL.array
     - __kind: PointerType
       ID: 97
       Name: '**net/url.URL'
@@ -1540,7 +1540,7 @@ Types:
         - Name: cap
           Offset: 16
           Type: 8 BaseType int
-      Data: 204 GoSliceDataType []*net.IPNet.array
+      Data: 198 GoSliceDataType []*net.IPNet.array
     - __kind: PointerType
       ID: 99
       Name: '**net.IPNet'
@@ -1583,7 +1583,7 @@ Types:
         - Name: cap
           Offset: 16
           Type: 8 BaseType int
-      Data: 206 GoSliceDataType net.IPMask.array
+      Data: 200 GoSliceDataType net.IPMask.array
     - __kind: GoSliceHeaderType
       ID: 103
       Name: '[]crypto/x509.OID'
@@ -1600,7 +1600,7 @@ Types:
         - Name: cap
           Offset: 16
           Type: 8 BaseType int
-      Data: 208 GoSliceDataType []crypto/x509.OID.array
+      Data: 202 GoSliceDataType []crypto/x509.OID.array
     - __kind: PointerType
       ID: 104
       Name: '*crypto/x509.OID'
@@ -1634,7 +1634,7 @@ Types:
         - Name: cap
           Offset: 16
           Type: 8 BaseType int
-      Data: 210 GoSliceDataType []crypto/x509.PolicyMapping.array
+      Data: 204 GoSliceDataType []crypto/x509.PolicyMapping.array
     - __kind: PointerType
       ID: 107
       Name: '*crypto/x509.PolicyMapping'
@@ -1671,7 +1671,7 @@ Types:
         - Name: cap
           Offset: 16
           Type: 8 BaseType int
-      Data: 212 GoSliceDataType [][]*crypto/x509.Certificate.array
+      Data: 206 GoSliceDataType [][]*crypto/x509.Certificate.array
     - __kind: PointerType
       ID: 110
       Name: '*[]*crypto/x509.Certificate'
@@ -1694,7 +1694,7 @@ Types:
         - Name: cap
           Offset: 16
           Type: 8 BaseType int
-      Data: 214 GoSliceDataType [][]uint8.array
+      Data: 208 GoSliceDataType [][]uint8.array
     - __kind: PointerType
       ID: 112
       Name: '*[]uint8'
@@ -1833,7 +1833,7 @@ Types:
         - Name: cap
           Offset: 16
           Type: 8 BaseType int
-      Data: 216 GoSliceDataType []net/http.segment.array
+      Data: 210 GoSliceDataType []net/http.segment.array
     - __kind: PointerType
       ID: 122
       Name: '*net/http.segment'
@@ -1902,7 +1902,7 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 17 BaseType uint64
-      TablePtrSliceType: 218 GoSliceDataType []*table<string,string>.array
+      TablePtrSliceType: 212 GoSliceDataType []*table<string,string>.array
       GroupType: 132 StructureType noalg.map.group[string]string
     - __kind: PointerType
       ID: 127
@@ -1951,7 +1951,7 @@ Types:
           Offset: 8
           Type: 17 BaseType uint64
       GroupType: 132 StructureType noalg.map.group[string]string
-      GroupSliceType: 219 GoSliceDataType []noalg.map.group[string]string.array
+      GroupSliceType: 213 GoSliceDataType []noalg.map.group[string]string.array
     - __kind: PointerType
       ID: 131
       Name: '*noalg.map.group[string]string'
@@ -2223,266 +2223,236 @@ Types:
       Pointee: 166 GoSliceDataType []string.array
     - __kind: GoSliceDataType
       ID: 168
-      Name: '[]*table<string,[]string>.array'
-      ByteSize: 8192
-      Element: 20 PointerType *table<string,[]string>
-    - __kind: GoSliceDataType
-      ID: 169
-      Name: '[]noalg.map.group[string][]string.array'
-      ByteSize: 2048
-      Element: 25 StructureType noalg.map.group[string][]string
-    - __kind: GoSliceDataType
-      ID: 170
-      Name: '[]*table<string,[]string>.array'
-      ByteSize: 8192
-      Element: 20 PointerType *table<string,[]string>
-    - __kind: GoSliceDataType
-      ID: 171
-      Name: '[]noalg.map.group[string][]string.array'
-      ByteSize: 2048
-      Element: 25 StructureType noalg.map.group[string][]string
-    - __kind: GoSliceDataType
-      ID: 172
       Name: '[]*table<string,[]*mime/multipart.FileHeader>.array'
       ByteSize: 8192
       Element: 41 PointerType *table<string,[]*mime/multipart.FileHeader>
     - __kind: GoSliceDataType
-      ID: 173
+      ID: 169
       Name: '[]noalg.map.group[string][]*mime/multipart.FileHeader.array'
       ByteSize: 2048
       Element: 45 StructureType noalg.map.group[string][]*mime/multipart.FileHeader
     - __kind: GoSliceDataType
-      ID: 174
+      ID: 170
       Name: '[]*mime/multipart.FileHeader.array'
       ByteSize: 2048
       Element: 50 PointerType *mime/multipart.FileHeader
     - __kind: PointerType
-      ID: 175
+      ID: 171
       Name: '*[]*mime/multipart.FileHeader.array'
       ByteSize: 8
-      Pointee: 174 GoSliceDataType []*mime/multipart.FileHeader.array
+      Pointee: 170 GoSliceDataType []*mime/multipart.FileHeader.array
     - __kind: GoSliceDataType
-      ID: 176
-      Name: '[]*table<string,[]string>.array'
-      ByteSize: 8192
-      Element: 20 PointerType *table<string,[]string>
-    - __kind: GoSliceDataType
-      ID: 177
-      Name: '[]noalg.map.group[string][]string.array'
-      ByteSize: 2048
-      Element: 25 StructureType noalg.map.group[string][]string
-    - __kind: GoSliceDataType
-      ID: 178
+      ID: 172
       Name: '[]uint8.array'
       ByteSize: 2048
       Element: 7 BaseType uint8
     - __kind: PointerType
-      ID: 179
+      ID: 173
       Name: '*[]uint8.array'
       ByteSize: 8
-      Pointee: 178 GoSliceDataType []uint8.array
+      Pointee: 172 GoSliceDataType []uint8.array
     - __kind: GoSliceDataType
-      ID: 180
+      ID: 174
       Name: '[]*crypto/x509.Certificate.array'
       ByteSize: 2048
       Element: 59 PointerType *crypto/x509.Certificate
     - __kind: PointerType
-      ID: 181
+      ID: 175
       Name: '*[]*crypto/x509.Certificate.array'
       ByteSize: 8
-      Pointee: 180 GoSliceDataType []*crypto/x509.Certificate.array
+      Pointee: 174 GoSliceDataType []*crypto/x509.Certificate.array
     - __kind: GoSliceDataType
-      ID: 182
+      ID: 176
       Name: math/big.nat.array
       ByteSize: 2048
       Element: 68 BaseType math/big.Word
     - __kind: PointerType
-      ID: 183
+      ID: 177
       Name: '*math/big.nat.array'
       ByteSize: 8
-      Pointee: 182 GoSliceDataType math/big.nat.array
+      Pointee: 176 GoSliceDataType math/big.nat.array
     - __kind: GoSliceDataType
-      ID: 184
+      ID: 178
       Name: '[]crypto/x509/pkix.AttributeTypeAndValue.array'
       ByteSize: 2048
       Element: 72 StructureType crypto/x509/pkix.AttributeTypeAndValue
     - __kind: PointerType
-      ID: 185
+      ID: 179
       Name: '*[]crypto/x509/pkix.AttributeTypeAndValue.array'
       ByteSize: 8
-      Pointee: 184 GoSliceDataType []crypto/x509/pkix.AttributeTypeAndValue.array
+      Pointee: 178 GoSliceDataType []crypto/x509/pkix.AttributeTypeAndValue.array
     - __kind: GoSliceDataType
-      ID: 186
+      ID: 180
       Name: encoding/asn1.ObjectIdentifier.array
       ByteSize: 2048
       Element: 8 BaseType int
     - __kind: PointerType
-      ID: 187
+      ID: 181
       Name: '*encoding/asn1.ObjectIdentifier.array'
       ByteSize: 8
-      Pointee: 186 GoSliceDataType encoding/asn1.ObjectIdentifier.array
+      Pointee: 180 GoSliceDataType encoding/asn1.ObjectIdentifier.array
     - __kind: GoSliceDataType
-      ID: 188
+      ID: 182
       Name: '[]time.zone.array'
       ByteSize: 2048
       Element: 80 StructureType time.zone
     - __kind: PointerType
-      ID: 189
+      ID: 183
       Name: '*[]time.zone.array'
       ByteSize: 8
-      Pointee: 188 GoSliceDataType []time.zone.array
+      Pointee: 182 GoSliceDataType []time.zone.array
     - __kind: GoSliceDataType
-      ID: 190
+      ID: 184
       Name: '[]time.zoneTrans.array'
       ByteSize: 2048
       Element: 83 StructureType time.zoneTrans
     - __kind: PointerType
-      ID: 191
+      ID: 185
       Name: '*[]time.zoneTrans.array'
       ByteSize: 8
-      Pointee: 190 GoSliceDataType []time.zoneTrans.array
+      Pointee: 184 GoSliceDataType []time.zoneTrans.array
     - __kind: GoSliceDataType
-      ID: 192
+      ID: 186
       Name: '[]crypto/x509/pkix.Extension.array'
       ByteSize: 2048
       Element: 87 StructureType crypto/x509/pkix.Extension
     - __kind: PointerType
-      ID: 193
+      ID: 187
       Name: '*[]crypto/x509/pkix.Extension.array'
       ByteSize: 8
-      Pointee: 192 GoSliceDataType []crypto/x509/pkix.Extension.array
+      Pointee: 186 GoSliceDataType []crypto/x509/pkix.Extension.array
     - __kind: GoSliceDataType
-      ID: 194
+      ID: 188
       Name: '[]encoding/asn1.ObjectIdentifier.array'
       ByteSize: 2048
       Element: 73 GoSliceHeaderType encoding/asn1.ObjectIdentifier
     - __kind: PointerType
-      ID: 195
+      ID: 189
       Name: '*[]encoding/asn1.ObjectIdentifier.array'
       ByteSize: 8
-      Pointee: 194 GoSliceDataType []encoding/asn1.ObjectIdentifier.array
+      Pointee: 188 GoSliceDataType []encoding/asn1.ObjectIdentifier.array
     - __kind: GoSliceDataType
-      ID: 196
+      ID: 190
       Name: '[]crypto/x509.ExtKeyUsage.array'
       ByteSize: 2048
       Element: 92 BaseType crypto/x509.ExtKeyUsage
     - __kind: PointerType
-      ID: 197
+      ID: 191
       Name: '*[]crypto/x509.ExtKeyUsage.array'
       ByteSize: 8
-      Pointee: 196 GoSliceDataType []crypto/x509.ExtKeyUsage.array
+      Pointee: 190 GoSliceDataType []crypto/x509.ExtKeyUsage.array
     - __kind: GoSliceDataType
-      ID: 198
+      ID: 192
       Name: '[]net.IP.array'
       ByteSize: 2048
       Element: 95 GoSliceHeaderType net.IP
     - __kind: PointerType
-      ID: 199
+      ID: 193
       Name: '*[]net.IP.array'
       ByteSize: 8
-      Pointee: 198 GoSliceDataType []net.IP.array
+      Pointee: 192 GoSliceDataType []net.IP.array
     - __kind: GoSliceDataType
-      ID: 200
+      ID: 194
       Name: net.IP.array
       ByteSize: 2048
       Element: 7 BaseType uint8
     - __kind: PointerType
-      ID: 201
+      ID: 195
       Name: '*net.IP.array'
       ByteSize: 8
-      Pointee: 200 GoSliceDataType net.IP.array
+      Pointee: 194 GoSliceDataType net.IP.array
     - __kind: GoSliceDataType
-      ID: 202
+      ID: 196
       Name: '[]*net/url.URL.array'
       ByteSize: 2048
       Element: 9 PointerType *net/url.URL
     - __kind: PointerType
-      ID: 203
+      ID: 197
       Name: '*[]*net/url.URL.array'
       ByteSize: 8
-      Pointee: 202 GoSliceDataType []*net/url.URL.array
+      Pointee: 196 GoSliceDataType []*net/url.URL.array
     - __kind: GoSliceDataType
-      ID: 204
+      ID: 198
       Name: '[]*net.IPNet.array'
       ByteSize: 2048
       Element: 100 PointerType *net.IPNet
     - __kind: PointerType
-      ID: 205
+      ID: 199
       Name: '*[]*net.IPNet.array'
       ByteSize: 8
-      Pointee: 204 GoSliceDataType []*net.IPNet.array
+      Pointee: 198 GoSliceDataType []*net.IPNet.array
     - __kind: GoSliceDataType
-      ID: 206
+      ID: 200
       Name: net.IPMask.array
       ByteSize: 2048
       Element: 7 BaseType uint8
     - __kind: PointerType
-      ID: 207
+      ID: 201
       Name: '*net.IPMask.array'
       ByteSize: 8
-      Pointee: 206 GoSliceDataType net.IPMask.array
+      Pointee: 200 GoSliceDataType net.IPMask.array
     - __kind: GoSliceDataType
-      ID: 208
+      ID: 202
       Name: '[]crypto/x509.OID.array'
       ByteSize: 2048
       Element: 105 StructureType crypto/x509.OID
     - __kind: PointerType
-      ID: 209
+      ID: 203
       Name: '*[]crypto/x509.OID.array'
       ByteSize: 8
-      Pointee: 208 GoSliceDataType []crypto/x509.OID.array
+      Pointee: 202 GoSliceDataType []crypto/x509.OID.array
     - __kind: GoSliceDataType
-      ID: 210
+      ID: 204
       Name: '[]crypto/x509.PolicyMapping.array'
       ByteSize: 2048
       Element: 108 StructureType crypto/x509.PolicyMapping
     - __kind: PointerType
-      ID: 211
+      ID: 205
       Name: '*[]crypto/x509.PolicyMapping.array'
       ByteSize: 8
-      Pointee: 210 GoSliceDataType []crypto/x509.PolicyMapping.array
+      Pointee: 204 GoSliceDataType []crypto/x509.PolicyMapping.array
     - __kind: GoSliceDataType
-      ID: 212
+      ID: 206
       Name: '[][]*crypto/x509.Certificate.array'
       ByteSize: 2048
       Element: 57 GoSliceHeaderType []*crypto/x509.Certificate
     - __kind: PointerType
-      ID: 213
+      ID: 207
       Name: '*[][]*crypto/x509.Certificate.array'
       ByteSize: 8
-      Pointee: 212 GoSliceDataType [][]*crypto/x509.Certificate.array
+      Pointee: 206 GoSliceDataType [][]*crypto/x509.Certificate.array
     - __kind: GoSliceDataType
-      ID: 214
+      ID: 208
       Name: '[][]uint8.array'
       ByteSize: 2048
       Element: 53 GoSliceHeaderType []uint8
     - __kind: PointerType
-      ID: 215
+      ID: 209
       Name: '*[][]uint8.array'
       ByteSize: 8
-      Pointee: 214 GoSliceDataType [][]uint8.array
+      Pointee: 208 GoSliceDataType [][]uint8.array
     - __kind: GoSliceDataType
-      ID: 216
+      ID: 210
       Name: '[]net/http.segment.array'
       ByteSize: 2048
       Element: 123 StructureType net/http.segment
     - __kind: PointerType
-      ID: 217
+      ID: 211
       Name: '*[]net/http.segment.array'
       ByteSize: 8
-      Pointee: 216 GoSliceDataType []net/http.segment.array
+      Pointee: 210 GoSliceDataType []net/http.segment.array
     - __kind: GoSliceDataType
-      ID: 218
+      ID: 212
       Name: '[]*table<string,string>.array'
       ByteSize: 8192
       Element: 128 PointerType *table<string,string>
     - __kind: GoSliceDataType
-      ID: 219
+      ID: 213
       Name: '[]noalg.map.group[string]string.array'
       ByteSize: 2048
       Element: 132 StructureType noalg.map.group[string]string
     - __kind: EventRootType
-      ID: 220
+      ID: 214
       Name: Probe[main.HandleHTTP]
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -2506,7 +2476,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 221
+      ID: 215
       Name: Probe[main.LookAtTheRequest]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -2520,6 +2490,6 @@ Types:
                   Variable: {subprogram: 2, index: 0, name: path}
                   Offset: 0
                   ByteSize: 16
-MaxTypeID: 221
+MaxTypeID: 215
 Issues: []
 GoModuledataInfo: {FirstModuledataAddr: "0x182c9a0", TypesOffset: 296}

--- a/pkg/dyninst/irgen/testdata/snapshot/rc_tester_v1.arch=amd64,toolchain=go1.25.0.yaml
+++ b/pkg/dyninst/irgen/testdata/snapshot/rc_tester_v1.arch=amd64,toolchain=go1.25.0.yaml
@@ -65,7 +65,7 @@ Subprograms:
           IsParameter: true
           IsReturn: false
         - Name: '&buf'
-          Type: 158 PointerType *bytes.Buffer
+          Type: 39 PointerType *bytes.Buffer
           Locations:
             - Range: 0xd0500e..0xd05029
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
@@ -74,7 +74,7 @@ Subprograms:
           IsParameter: false
           IsReturn: false
         - Name: span
-          Type: 161 GoInterfaceType gopkg.in/DataDog/dd-trace-go.v1/ddtrace.Span
+          Type: 41 GoInterfaceType gopkg.in/DataDog/dd-trace-go.v1/ddtrace.Span
           Locations:
             - Range: 0xd04ee8..0xd04ee8
               Pieces:
@@ -114,60 +114,60 @@ Subprograms:
           IsReturn: false
 Types:
     - __kind: PointerType
-      ID: 82
+      ID: 81
       Name: '**crypto/x509.Certificate'
       ByteSize: 8
       GoKind: 22
-      Pointee: 83 PointerType *crypto/x509.Certificate
+      Pointee: 82 PointerType *crypto/x509.Certificate
     - __kind: PointerType
-      ID: 73
+      ID: 147
       Name: '**mime/multipart.FileHeader'
       ByteSize: 8
       GoKind: 22
-      Pointee: 74 PointerType *mime/multipart.FileHeader
+      Pointee: 148 PointerType *mime/multipart.FileHeader
     - __kind: PointerType
-      ID: 122
+      ID: 134
       Name: '**net.IPNet'
       ByteSize: 8
       GoKind: 22
-      Pointee: 123 PointerType *net.IPNet
+      Pointee: 135 PointerType *net.IPNet
     - __kind: PointerType
-      ID: 120
+      ID: 132
       Name: '**net/url.URL'
       ByteSize: 8
       GoKind: 22
-      Pointee: 39 PointerType *net/url.URL
+      Pointee: 42 PointerType *net/url.URL
     - __kind: PointerType
-      ID: 64
+      ID: 77
       Name: '**table<string,[]*mime/multipart.FileHeader>'
       ByteSize: 8
-      Pointee: 65 PointerType *table<string,[]*mime/multipart.FileHeader>
+      Pointee: 78 PointerType *table<string,[]*mime/multipart.FileHeader>
     - __kind: PointerType
-      ID: 46
+      ID: 47
       Name: '**table<string,[]string>'
       ByteSize: 8
-      Pointee: 47 PointerType *table<string,[]string>
+      Pointee: 48 PointerType *table<string,[]string>
     - __kind: PointerType
-      ID: 150
+      ID: 66
       Name: '**table<string,string>'
       ByteSize: 8
-      Pointee: 151 PointerType *table<string,string>
+      Pointee: 67 PointerType *table<string,string>
     - __kind: PointerType
-      ID: 133
+      ID: 84
       Name: '*[]*crypto/x509.Certificate'
       ByteSize: 8
       GoKind: 22
-      Pointee: 81 GoSliceHeaderType []*crypto/x509.Certificate
+      Pointee: 80 GoSliceHeaderType []*crypto/x509.Certificate
     - __kind: PointerType
       ID: 175
       Name: '*[]*crypto/x509.Certificate.array'
       ByteSize: 8
       Pointee: 174 GoSliceDataType []*crypto/x509.Certificate.array
     - __kind: PointerType
-      ID: 171
+      ID: 205
       Name: '*[]*mime/multipart.FileHeader.array'
       ByteSize: 8
-      Pointee: 170 GoSliceDataType []*mime/multipart.FileHeader.array
+      Pointee: 204 GoSliceDataType []*mime/multipart.FileHeader.array
     - __kind: PointerType
       ID: 199
       Name: '*[]*net.IPNet.array'
@@ -179,82 +179,82 @@ Types:
       ByteSize: 8
       Pointee: 196 GoSliceDataType []*net/url.URL.array
     - __kind: PointerType
-      ID: 207
+      ID: 177
       Name: '*[][]*crypto/x509.Certificate.array'
       ByteSize: 8
-      Pointee: 206 GoSliceDataType [][]*crypto/x509.Certificate.array
+      Pointee: 176 GoSliceDataType [][]*crypto/x509.Certificate.array
     - __kind: PointerType
-      ID: 209
+      ID: 179
       Name: '*[][]uint8.array'
       ByteSize: 8
-      Pointee: 208 GoSliceDataType [][]uint8.array
+      Pointee: 178 GoSliceDataType [][]uint8.array
     - __kind: PointerType
       ID: 191
       Name: '*[]crypto/x509.ExtKeyUsage.array'
       ByteSize: 8
       Pointee: 190 GoSliceDataType []crypto/x509.ExtKeyUsage.array
     - __kind: PointerType
-      ID: 203
+      ID: 201
       Name: '*[]crypto/x509.OID.array'
       ByteSize: 8
-      Pointee: 202 GoSliceDataType []crypto/x509.OID.array
+      Pointee: 200 GoSliceDataType []crypto/x509.OID.array
     - __kind: PointerType
-      ID: 205
+      ID: 203
       Name: '*[]crypto/x509.PolicyMapping.array'
       ByteSize: 8
-      Pointee: 204 GoSliceDataType []crypto/x509.PolicyMapping.array
+      Pointee: 202 GoSliceDataType []crypto/x509.PolicyMapping.array
     - __kind: PointerType
-      ID: 179
+      ID: 183
       Name: '*[]crypto/x509/pkix.AttributeTypeAndValue.array'
       ByteSize: 8
-      Pointee: 178 GoSliceDataType []crypto/x509/pkix.AttributeTypeAndValue.array
+      Pointee: 182 GoSliceDataType []crypto/x509/pkix.AttributeTypeAndValue.array
     - __kind: PointerType
-      ID: 187
+      ID: 185
       Name: '*[]crypto/x509/pkix.Extension.array'
       ByteSize: 8
-      Pointee: 186 GoSliceDataType []crypto/x509/pkix.Extension.array
+      Pointee: 184 GoSliceDataType []crypto/x509/pkix.Extension.array
     - __kind: PointerType
-      ID: 189
+      ID: 187
       Name: '*[]encoding/asn1.ObjectIdentifier.array'
       ByteSize: 8
-      Pointee: 188 GoSliceDataType []encoding/asn1.ObjectIdentifier.array
+      Pointee: 186 GoSliceDataType []encoding/asn1.ObjectIdentifier.array
     - __kind: PointerType
       ID: 193
       Name: '*[]net.IP.array'
       ByteSize: 8
       Pointee: 192 GoSliceDataType []net.IP.array
     - __kind: PointerType
-      ID: 211
+      ID: 181
       Name: '*[]net/http.segment.array'
       ByteSize: 8
-      Pointee: 210 GoSliceDataType []net/http.segment.array
+      Pointee: 180 GoSliceDataType []net/http.segment.array
     - __kind: PointerType
       ID: 167
       Name: '*[]string.array'
       ByteSize: 8
       Pointee: 166 GoSliceDataType []string.array
     - __kind: PointerType
-      ID: 183
+      ID: 209
       Name: '*[]time.zone.array'
       ByteSize: 8
-      Pointee: 182 GoSliceDataType []time.zone.array
+      Pointee: 208 GoSliceDataType []time.zone.array
     - __kind: PointerType
-      ID: 185
+      ID: 211
       Name: '*[]time.zoneTrans.array'
       ByteSize: 8
-      Pointee: 184 GoSliceDataType []time.zoneTrans.array
+      Pointee: 210 GoSliceDataType []time.zoneTrans.array
     - __kind: PointerType
-      ID: 135
+      ID: 86
       Name: '*[]uint8'
       ByteSize: 8
       GoRuntimeType: 481600
       GoKind: 22
-      Pointee: 77 GoSliceHeaderType []uint8
+      Pointee: 68 GoSliceHeaderType []uint8
     - __kind: PointerType
-      ID: 173
+      ID: 171
       Name: '*[]uint8.array'
       ByteSize: 8
-      Pointee: 172 GoSliceDataType []uint8.array
+      Pointee: 170 GoSliceDataType []uint8.array
     - __kind: PointerType
       ID: 11
       Name: '*bool'
@@ -263,73 +263,73 @@ Types:
       GoKind: 22
       Pointee: 4 BaseType bool
     - __kind: PointerType
-      ID: 158
+      ID: 39
       Name: '*bytes.Buffer'
       ByteSize: 8
       GoRuntimeType: 2.260704e+06
       GoKind: 22
-      Pointee: 159 StructureType bytes.Buffer
+      Pointee: 40 StructureType bytes.Buffer
     - __kind: PointerType
-      ID: 78
+      ID: 55
       Name: '*crypto/tls.ConnectionState'
       ByteSize: 8
       GoRuntimeType: 908352
       GoKind: 22
-      Pointee: 79 StructureType crypto/tls.ConnectionState
+      Pointee: 56 StructureType crypto/tls.ConnectionState
     - __kind: PointerType
-      ID: 83
+      ID: 82
       Name: '*crypto/x509.Certificate'
       ByteSize: 8
       GoRuntimeType: 2.043968e+06
       GoKind: 22
-      Pointee: 84 StructureType crypto/x509.Certificate
+      Pointee: 97 StructureType crypto/x509.Certificate
     - __kind: PointerType
-      ID: 114
+      ID: 126
       Name: '*crypto/x509.ExtKeyUsage'
       ByteSize: 8
       GoRuntimeType: 423552
       GoKind: 22
-      Pointee: 115 BaseType crypto/x509.ExtKeyUsage
+      Pointee: 127 BaseType crypto/x509.ExtKeyUsage
     - __kind: PointerType
-      ID: 127
+      ID: 137
       Name: '*crypto/x509.OID'
       ByteSize: 8
       GoRuntimeType: 1.954336e+06
       GoKind: 22
-      Pointee: 128 StructureType crypto/x509.OID
+      Pointee: 138 StructureType crypto/x509.OID
     - __kind: PointerType
-      ID: 130
+      ID: 140
       Name: '*crypto/x509.PolicyMapping'
       ByteSize: 8
       GoRuntimeType: 423616
       GoKind: 22
-      Pointee: 131 StructureType crypto/x509.PolicyMapping
+      Pointee: 141 StructureType crypto/x509.PolicyMapping
     - __kind: PointerType
-      ID: 95
+      ID: 113
       Name: '*crypto/x509/pkix.AttributeTypeAndValue'
       ByteSize: 8
       GoRuntimeType: 437312
       GoKind: 22
-      Pointee: 96 StructureType crypto/x509/pkix.AttributeTypeAndValue
+      Pointee: 114 StructureType crypto/x509/pkix.AttributeTypeAndValue
     - __kind: PointerType
-      ID: 109
+      ID: 120
       Name: '*crypto/x509/pkix.Extension'
       ByteSize: 8
       GoRuntimeType: 437504
       GoKind: 22
-      Pointee: 110 StructureType crypto/x509/pkix.Extension
+      Pointee: 121 StructureType crypto/x509/pkix.Extension
     - __kind: PointerType
-      ID: 112
+      ID: 123
       Name: '*encoding/asn1.ObjectIdentifier'
       ByteSize: 8
       GoRuntimeType: 1.053408e+06
       GoKind: 22
-      Pointee: 97 GoSliceHeaderType encoding/asn1.ObjectIdentifier
+      Pointee: 124 GoSliceHeaderType encoding/asn1.ObjectIdentifier
     - __kind: PointerType
-      ID: 181
+      ID: 189
       Name: '*encoding/asn1.ObjectIdentifier.array'
       ByteSize: 8
-      Pointee: 180 GoSliceDataType encoding/asn1.ObjectIdentifier.array
+      Pointee: 188 GoSliceDataType encoding/asn1.ObjectIdentifier.array
     - __kind: PointerType
       ID: 33
       Name: '*error'
@@ -387,77 +387,77 @@ Types:
       GoKind: 22
       Pointee: 16 BaseType int8
     - __kind: PointerType
-      ID: 62
+      ID: 75
       Name: '*map<string,[]*mime/multipart.FileHeader>'
       ByteSize: 8
-      Pointee: 63 GoSwissMapHeaderType map<string,[]*mime/multipart.FileHeader>
+      Pointee: 76 GoSwissMapHeaderType map<string,[]*mime/multipart.FileHeader>
     - __kind: PointerType
-      ID: 44
+      ID: 45
       Name: '*map<string,[]string>'
       ByteSize: 8
-      Pointee: 45 GoSwissMapHeaderType map<string,[]string>
+      Pointee: 46 GoSwissMapHeaderType map<string,[]string>
     - __kind: PointerType
-      ID: 148
+      ID: 64
       Name: '*map<string,string>'
       ByteSize: 8
-      Pointee: 149 GoSwissMapHeaderType map<string,string>
+      Pointee: 65 GoSwissMapHeaderType map<string,string>
     - __kind: PointerType
-      ID: 88
+      ID: 109
       Name: '*math/big.Int'
       ByteSize: 8
       GoRuntimeType: 2.382336e+06
       GoKind: 22
-      Pointee: 89 StructureType math/big.Int
+      Pointee: 110 StructureType math/big.Int
     - __kind: PointerType
-      ID: 91
+      ID: 150
       Name: '*math/big.Word'
       ByteSize: 8
       GoRuntimeType: 426432
       GoKind: 22
-      Pointee: 92 BaseType math/big.Word
+      Pointee: 151 BaseType math/big.Word
     - __kind: PointerType
-      ID: 177
+      ID: 207
       Name: '*math/big.nat.array'
       ByteSize: 8
-      Pointee: 176 GoSliceDataType math/big.nat.array
+      Pointee: 206 GoSliceDataType math/big.nat.array
     - __kind: PointerType
-      ID: 74
+      ID: 148
       Name: '*mime/multipart.FileHeader'
       ByteSize: 8
       GoRuntimeType: 909888
       GoKind: 22
-      Pointee: 75 StructureType mime/multipart.FileHeader
+      Pointee: 159 StructureType mime/multipart.FileHeader
     - __kind: PointerType
-      ID: 58
+      ID: 53
       Name: '*mime/multipart.Form'
       ByteSize: 8
       GoRuntimeType: 909984
       GoKind: 22
-      Pointee: 59 StructureType mime/multipart.Form
+      Pointee: 54 StructureType mime/multipart.Form
     - __kind: PointerType
-      ID: 117
+      ID: 129
       Name: '*net.IP'
       ByteSize: 8
       GoRuntimeType: 2.150176e+06
       GoKind: 22
-      Pointee: 118 GoSliceHeaderType net.IP
+      Pointee: 130 GoSliceHeaderType net.IP
     - __kind: PointerType
       ID: 195
       Name: '*net.IP.array'
       ByteSize: 8
       Pointee: 194 GoSliceDataType net.IP.array
     - __kind: PointerType
-      ID: 201
+      ID: 213
       Name: '*net.IPMask.array'
       ByteSize: 8
-      Pointee: 200 GoSliceDataType net.IPMask.array
+      Pointee: 212 GoSliceDataType net.IPMask.array
     - __kind: PointerType
-      ID: 123
+      ID: 135
       Name: '*net.IPNet'
       ByteSize: 8
       GoRuntimeType: 1.18336e+06
       GoKind: 22
-      Pointee: 124 StructureType net.IPNet
+      Pointee: 158 StructureType net.IPNet
     - __kind: PointerType
       ID: 37
       Name: '*net/http.Request'
@@ -466,55 +466,55 @@ Types:
       GoKind: 22
       Pointee: 38 StructureType net/http.Request
     - __kind: PointerType
-      ID: 139
+      ID: 58
       Name: '*net/http.Response'
       ByteSize: 8
       GoRuntimeType: 1.718816e+06
       GoKind: 22
-      Pointee: 140 StructureType net/http.Response
+      Pointee: 59 StructureType net/http.Response
     - __kind: PointerType
-      ID: 142
+      ID: 61
       Name: '*net/http.pattern'
       ByteSize: 8
       GoRuntimeType: 1.608608e+06
       GoKind: 22
-      Pointee: 143 StructureType net/http.pattern
+      Pointee: 62 StructureType net/http.pattern
     - __kind: PointerType
-      ID: 145
+      ID: 90
       Name: '*net/http.segment'
       ByteSize: 8
       GoRuntimeType: 391808
       GoKind: 22
-      Pointee: 146 StructureType net/http.segment
+      Pointee: 91 StructureType net/http.segment
     - __kind: PointerType
-      ID: 39
+      ID: 42
       Name: '*net/url.URL'
       ByteSize: 8
       GoRuntimeType: 2.1136e+06
       GoKind: 22
-      Pointee: 40 StructureType net/url.URL
+      Pointee: 43 StructureType net/url.URL
     - __kind: PointerType
-      ID: 41
+      ID: 70
       Name: '*net/url.Userinfo'
       ByteSize: 8
       GoRuntimeType: 1.200768e+06
       GoKind: 22
-      Pointee: 42 StructureType net/url.Userinfo
+      Pointee: 71 StructureType net/url.Userinfo
     - __kind: PointerType
-      ID: 68
+      ID: 104
       Name: '*noalg.map.group[string][]*mime/multipart.FileHeader'
       ByteSize: 8
-      Pointee: 69 StructureType noalg.map.group[string][]*mime/multipart.FileHeader
+      Pointee: 105 StructureType noalg.map.group[string][]*mime/multipart.FileHeader
     - __kind: PointerType
-      ID: 50
+      ID: 94
       Name: '*noalg.map.group[string][]string'
       ByteSize: 8
-      Pointee: 51 StructureType noalg.map.group[string][]string
+      Pointee: 95 StructureType noalg.map.group[string][]string
     - __kind: PointerType
-      ID: 154
+      ID: 99
       Name: '*noalg.map.group[string]string'
       ByteSize: 8
-      Pointee: 155 StructureType noalg.map.group[string]string
+      Pointee: 100 StructureType noalg.map.group[string]string
     - __kind: PointerType
       ID: 22
       Name: '*string'
@@ -528,41 +528,41 @@ Types:
       ByteSize: 8
       Pointee: 162 GoStringDataType string.str
     - __kind: PointerType
-      ID: 65
+      ID: 78
       Name: '*table<string,[]*mime/multipart.FileHeader>'
       ByteSize: 8
-      Pointee: 66 StructureType table<string,[]*mime/multipart.FileHeader>
+      Pointee: 96 StructureType table<string,[]*mime/multipart.FileHeader>
     - __kind: PointerType
-      ID: 47
+      ID: 48
       Name: '*table<string,[]string>'
       ByteSize: 8
-      Pointee: 48 StructureType table<string,[]string>
+      Pointee: 72 StructureType table<string,[]string>
     - __kind: PointerType
-      ID: 151
+      ID: 67
       Name: '*table<string,string>'
       ByteSize: 8
-      Pointee: 152 StructureType table<string,string>
+      Pointee: 92 StructureType table<string,string>
     - __kind: PointerType
-      ID: 99
+      ID: 116
       Name: '*time.Location'
       ByteSize: 8
       GoRuntimeType: 1.6136e+06
       GoKind: 22
-      Pointee: 100 StructureType time.Location
+      Pointee: 117 StructureType time.Location
     - __kind: PointerType
-      ID: 102
+      ID: 153
       Name: '*time.zone'
       ByteSize: 8
       GoRuntimeType: 394880
       GoKind: 22
-      Pointee: 103 StructureType time.zone
+      Pointee: 154 StructureType time.zone
     - __kind: PointerType
-      ID: 105
+      ID: 156
       Name: '*time.zoneTrans'
       ByteSize: 8
       GoRuntimeType: 394944
       GoKind: 22
-      Pointee: 106 StructureType time.zoneTrans
+      Pointee: 157 StructureType time.zoneTrans
     - __kind: PointerType
       ID: 34
       Name: '*uint'
@@ -606,7 +606,7 @@ Types:
       GoKind: 22
       Pointee: 1 BaseType uintptr
     - __kind: GoChannelType
-      ID: 138
+      ID: 57
       Name: <-chan struct {}
       GoRuntimeType: 597696
       GoKind: 18
@@ -650,7 +650,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: GoSliceHeaderType
-      ID: 81
+      ID: 80
       Name: '[]*crypto/x509.Certificate'
       ByteSize: 24
       GoRuntimeType: 502496
@@ -658,7 +658,7 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 82 PointerType **crypto/x509.Certificate
+          Type: 81 PointerType **crypto/x509.Certificate
         - Name: len
           Offset: 8
           Type: 7 BaseType int
@@ -670,9 +670,9 @@ Types:
       ID: 174
       Name: '[]*crypto/x509.Certificate.array'
       ByteSize: 2048
-      Element: 83 PointerType *crypto/x509.Certificate
+      Element: 82 PointerType *crypto/x509.Certificate
     - __kind: GoSliceHeaderType
-      ID: 72
+      ID: 146
       Name: '[]*mime/multipart.FileHeader'
       ByteSize: 24
       GoRuntimeType: 487328
@@ -680,21 +680,21 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 73 PointerType **mime/multipart.FileHeader
+          Type: 147 PointerType **mime/multipart.FileHeader
         - Name: len
           Offset: 8
           Type: 7 BaseType int
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 170 GoSliceDataType []*mime/multipart.FileHeader.array
+      Data: 204 GoSliceDataType []*mime/multipart.FileHeader.array
     - __kind: GoSliceDataType
-      ID: 170
+      ID: 204
       Name: '[]*mime/multipart.FileHeader.array'
       ByteSize: 2048
-      Element: 74 PointerType *mime/multipart.FileHeader
+      Element: 148 PointerType *mime/multipart.FileHeader
     - __kind: GoSliceHeaderType
-      ID: 121
+      ID: 133
       Name: '[]*net.IPNet'
       ByteSize: 24
       GoRuntimeType: 504096
@@ -702,7 +702,7 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 122 PointerType **net.IPNet
+          Type: 134 PointerType **net.IPNet
         - Name: len
           Offset: 8
           Type: 7 BaseType int
@@ -714,9 +714,9 @@ Types:
       ID: 198
       Name: '[]*net.IPNet.array'
       ByteSize: 2048
-      Element: 123 PointerType *net.IPNet
+      Element: 135 PointerType *net.IPNet
     - __kind: GoSliceHeaderType
-      ID: 119
+      ID: 131
       Name: '[]*net/url.URL'
       ByteSize: 24
       GoRuntimeType: 504032
@@ -724,7 +724,7 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 120 PointerType **net/url.URL
+          Type: 132 PointerType **net/url.URL
         - Name: len
           Offset: 8
           Type: 7 BaseType int
@@ -736,24 +736,24 @@ Types:
       ID: 196
       Name: '[]*net/url.URL.array'
       ByteSize: 2048
-      Element: 39 PointerType *net/url.URL
+      Element: 42 PointerType *net/url.URL
     - __kind: GoSliceDataType
-      ID: 168
+      ID: 172
       Name: '[]*table<string,[]*mime/multipart.FileHeader>.array'
       ByteSize: 8192
-      Element: 65 PointerType *table<string,[]*mime/multipart.FileHeader>
+      Element: 78 PointerType *table<string,[]*mime/multipart.FileHeader>
     - __kind: GoSliceDataType
       ID: 164
       Name: '[]*table<string,[]string>.array'
       ByteSize: 8192
-      Element: 47 PointerType *table<string,[]string>
+      Element: 48 PointerType *table<string,[]string>
     - __kind: GoSliceDataType
-      ID: 212
+      ID: 168
       Name: '[]*table<string,string>.array'
       ByteSize: 8192
-      Element: 151 PointerType *table<string,string>
+      Element: 67 PointerType *table<string,string>
     - __kind: GoSliceHeaderType
-      ID: 132
+      ID: 83
       Name: '[][]*crypto/x509.Certificate'
       ByteSize: 24
       GoRuntimeType: 502560
@@ -761,21 +761,21 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 133 PointerType *[]*crypto/x509.Certificate
+          Type: 84 PointerType *[]*crypto/x509.Certificate
         - Name: len
           Offset: 8
           Type: 7 BaseType int
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 206 GoSliceDataType [][]*crypto/x509.Certificate.array
+      Data: 176 GoSliceDataType [][]*crypto/x509.Certificate.array
     - __kind: GoSliceDataType
-      ID: 206
+      ID: 176
       Name: '[][]*crypto/x509.Certificate.array'
       ByteSize: 2048
-      Element: 81 GoSliceHeaderType []*crypto/x509.Certificate
+      Element: 80 GoSliceHeaderType []*crypto/x509.Certificate
     - __kind: GoSliceHeaderType
-      ID: 134
+      ID: 85
       Name: '[][]uint8'
       ByteSize: 24
       GoRuntimeType: 481920
@@ -783,21 +783,21 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 135 PointerType *[]uint8
+          Type: 86 PointerType *[]uint8
         - Name: len
           Offset: 8
           Type: 7 BaseType int
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 208 GoSliceDataType [][]uint8.array
+      Data: 178 GoSliceDataType [][]uint8.array
     - __kind: GoSliceDataType
-      ID: 208
+      ID: 178
       Name: '[][]uint8.array'
       ByteSize: 2048
-      Element: 77 GoSliceHeaderType []uint8
+      Element: 68 GoSliceHeaderType []uint8
     - __kind: GoSliceHeaderType
-      ID: 113
+      ID: 125
       Name: '[]crypto/x509.ExtKeyUsage'
       ByteSize: 24
       GoRuntimeType: 503968
@@ -805,7 +805,7 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 114 PointerType *crypto/x509.ExtKeyUsage
+          Type: 126 PointerType *crypto/x509.ExtKeyUsage
         - Name: len
           Offset: 8
           Type: 7 BaseType int
@@ -817,9 +817,9 @@ Types:
       ID: 190
       Name: '[]crypto/x509.ExtKeyUsage.array'
       ByteSize: 2048
-      Element: 115 BaseType crypto/x509.ExtKeyUsage
+      Element: 127 BaseType crypto/x509.ExtKeyUsage
     - __kind: GoSliceHeaderType
-      ID: 126
+      ID: 136
       Name: '[]crypto/x509.OID'
       ByteSize: 24
       GoRuntimeType: 504160
@@ -827,21 +827,21 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 127 PointerType *crypto/x509.OID
+          Type: 137 PointerType *crypto/x509.OID
         - Name: len
           Offset: 8
           Type: 7 BaseType int
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 202 GoSliceDataType []crypto/x509.OID.array
+      Data: 200 GoSliceDataType []crypto/x509.OID.array
     - __kind: GoSliceDataType
-      ID: 202
+      ID: 200
       Name: '[]crypto/x509.OID.array'
       ByteSize: 2048
-      Element: 128 StructureType crypto/x509.OID
+      Element: 138 StructureType crypto/x509.OID
     - __kind: GoSliceHeaderType
-      ID: 129
+      ID: 139
       Name: '[]crypto/x509.PolicyMapping'
       ByteSize: 24
       GoRuntimeType: 504224
@@ -849,21 +849,21 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 130 PointerType *crypto/x509.PolicyMapping
+          Type: 140 PointerType *crypto/x509.PolicyMapping
         - Name: len
           Offset: 8
           Type: 7 BaseType int
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 204 GoSliceDataType []crypto/x509.PolicyMapping.array
+      Data: 202 GoSliceDataType []crypto/x509.PolicyMapping.array
     - __kind: GoSliceDataType
-      ID: 204
+      ID: 202
       Name: '[]crypto/x509.PolicyMapping.array'
       ByteSize: 2048
-      Element: 131 StructureType crypto/x509.PolicyMapping
+      Element: 141 StructureType crypto/x509.PolicyMapping
     - __kind: GoSliceHeaderType
-      ID: 94
+      ID: 112
       Name: '[]crypto/x509/pkix.AttributeTypeAndValue'
       ByteSize: 24
       GoRuntimeType: 517440
@@ -871,21 +871,21 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 95 PointerType *crypto/x509/pkix.AttributeTypeAndValue
+          Type: 113 PointerType *crypto/x509/pkix.AttributeTypeAndValue
         - Name: len
           Offset: 8
           Type: 7 BaseType int
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 178 GoSliceDataType []crypto/x509/pkix.AttributeTypeAndValue.array
+      Data: 182 GoSliceDataType []crypto/x509/pkix.AttributeTypeAndValue.array
     - __kind: GoSliceDataType
-      ID: 178
+      ID: 182
       Name: '[]crypto/x509/pkix.AttributeTypeAndValue.array'
       ByteSize: 2048
-      Element: 96 StructureType crypto/x509/pkix.AttributeTypeAndValue
+      Element: 114 StructureType crypto/x509/pkix.AttributeTypeAndValue
     - __kind: GoSliceHeaderType
-      ID: 108
+      ID: 119
       Name: '[]crypto/x509/pkix.Extension'
       ByteSize: 24
       GoRuntimeType: 503840
@@ -893,21 +893,21 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 109 PointerType *crypto/x509/pkix.Extension
+          Type: 120 PointerType *crypto/x509/pkix.Extension
         - Name: len
           Offset: 8
           Type: 7 BaseType int
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 186 GoSliceDataType []crypto/x509/pkix.Extension.array
+      Data: 184 GoSliceDataType []crypto/x509/pkix.Extension.array
     - __kind: GoSliceDataType
-      ID: 186
+      ID: 184
       Name: '[]crypto/x509/pkix.Extension.array'
       ByteSize: 2048
-      Element: 110 StructureType crypto/x509/pkix.Extension
+      Element: 121 StructureType crypto/x509/pkix.Extension
     - __kind: GoSliceHeaderType
-      ID: 111
+      ID: 122
       Name: '[]encoding/asn1.ObjectIdentifier'
       ByteSize: 24
       GoRuntimeType: 503904
@@ -915,21 +915,21 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 112 PointerType *encoding/asn1.ObjectIdentifier
+          Type: 123 PointerType *encoding/asn1.ObjectIdentifier
         - Name: len
           Offset: 8
           Type: 7 BaseType int
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 188 GoSliceDataType []encoding/asn1.ObjectIdentifier.array
+      Data: 186 GoSliceDataType []encoding/asn1.ObjectIdentifier.array
     - __kind: GoSliceDataType
-      ID: 188
+      ID: 186
       Name: '[]encoding/asn1.ObjectIdentifier.array'
       ByteSize: 2048
-      Element: 97 GoSliceHeaderType encoding/asn1.ObjectIdentifier
+      Element: 124 GoSliceHeaderType encoding/asn1.ObjectIdentifier
     - __kind: GoSliceHeaderType
-      ID: 116
+      ID: 128
       Name: '[]net.IP'
       ByteSize: 24
       GoRuntimeType: 482944
@@ -937,7 +937,7 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 117 PointerType *net.IP
+          Type: 129 PointerType *net.IP
         - Name: len
           Offset: 8
           Type: 7 BaseType int
@@ -949,9 +949,9 @@ Types:
       ID: 192
       Name: '[]net.IP.array'
       ByteSize: 2048
-      Element: 118 GoSliceHeaderType net.IP
+      Element: 130 GoSliceHeaderType net.IP
     - __kind: GoSliceHeaderType
-      ID: 144
+      ID: 89
       Name: '[]net/http.segment'
       ByteSize: 24
       GoRuntimeType: 484640
@@ -959,36 +959,36 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 145 PointerType *net/http.segment
+          Type: 90 PointerType *net/http.segment
         - Name: len
           Offset: 8
           Type: 7 BaseType int
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 210 GoSliceDataType []net/http.segment.array
+      Data: 180 GoSliceDataType []net/http.segment.array
     - __kind: GoSliceDataType
-      ID: 210
+      ID: 180
       Name: '[]net/http.segment.array'
       ByteSize: 2048
-      Element: 146 StructureType net/http.segment
+      Element: 91 StructureType net/http.segment
     - __kind: GoSliceDataType
-      ID: 169
+      ID: 173
       Name: '[]noalg.map.group[string][]*mime/multipart.FileHeader.array'
       ByteSize: 2048
-      Element: 69 StructureType noalg.map.group[string][]*mime/multipart.FileHeader
+      Element: 105 StructureType noalg.map.group[string][]*mime/multipart.FileHeader
     - __kind: GoSliceDataType
       ID: 165
       Name: '[]noalg.map.group[string][]string.array'
       ByteSize: 2048
-      Element: 51 StructureType noalg.map.group[string][]string
+      Element: 95 StructureType noalg.map.group[string][]string
     - __kind: GoSliceDataType
-      ID: 213
+      ID: 169
       Name: '[]noalg.map.group[string]string.array'
       ByteSize: 2048
-      Element: 155 StructureType noalg.map.group[string]string
+      Element: 100 StructureType noalg.map.group[string]string
     - __kind: GoSliceHeaderType
-      ID: 54
+      ID: 51
       Name: '[]string'
       ByteSize: 24
       GoRuntimeType: 496448
@@ -1010,7 +1010,7 @@ Types:
       ByteSize: 2048
       Element: 9 GoStringHeaderType string
     - __kind: GoSliceHeaderType
-      ID: 101
+      ID: 152
       Name: '[]time.zone'
       ByteSize: 24
       GoRuntimeType: 489504
@@ -1018,21 +1018,21 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 102 PointerType *time.zone
+          Type: 153 PointerType *time.zone
         - Name: len
           Offset: 8
           Type: 7 BaseType int
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 182 GoSliceDataType []time.zone.array
+      Data: 208 GoSliceDataType []time.zone.array
     - __kind: GoSliceDataType
-      ID: 182
+      ID: 208
       Name: '[]time.zone.array'
       ByteSize: 2048
-      Element: 103 StructureType time.zone
+      Element: 154 StructureType time.zone
     - __kind: GoSliceHeaderType
-      ID: 104
+      ID: 155
       Name: '[]time.zoneTrans'
       ByteSize: 24
       GoRuntimeType: 489568
@@ -1040,21 +1040,21 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 105 PointerType *time.zoneTrans
+          Type: 156 PointerType *time.zoneTrans
         - Name: len
           Offset: 8
           Type: 7 BaseType int
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 184 GoSliceDataType []time.zoneTrans.array
+      Data: 210 GoSliceDataType []time.zoneTrans.array
     - __kind: GoSliceDataType
-      ID: 184
+      ID: 210
       Name: '[]time.zoneTrans.array'
       ByteSize: 2048
-      Element: 106 StructureType time.zoneTrans
+      Element: 157 StructureType time.zoneTrans
     - __kind: GoSliceHeaderType
-      ID: 77
+      ID: 68
       Name: '[]uint8'
       ByteSize: 24
       GoRuntimeType: 495296
@@ -1069,9 +1069,9 @@ Types:
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 172 GoSliceDataType []uint8.array
+      Data: 170 GoSliceDataType []uint8.array
     - __kind: GoSliceDataType
-      ID: 172
+      ID: 170
       Name: '[]uint8.array'
       ByteSize: 2048
       Element: 3 BaseType uint8
@@ -1082,7 +1082,7 @@ Types:
       GoRuntimeType: 585472
       GoKind: 1
     - __kind: StructureType
-      ID: 159
+      ID: 40
       Name: bytes.Buffer
       ByteSize: 40
       GoRuntimeType: 1.606304e+06
@@ -1090,15 +1090,15 @@ Types:
       RawFields:
         - Name: buf
           Offset: 0
-          Type: 77 GoSliceHeaderType []uint8
+          Type: 68 GoSliceHeaderType []uint8
         - Name: off
           Offset: 24
           Type: 7 BaseType int
         - Name: lastRead
           Offset: 32
-          Type: 160 BaseType bytes.readOp
+          Type: 69 BaseType bytes.readOp
     - __kind: BaseType
-      ID: 160
+      ID: 69
       Name: bytes.readOp
       ByteSize: 1
       GoRuntimeType: 583680
@@ -1116,7 +1116,7 @@ Types:
       GoRuntimeType: 585216
       GoKind: 15
     - __kind: GoInterfaceType
-      ID: 141
+      ID: 60
       Name: context.Context
       ByteSize: 16
       GoRuntimeType: 1.276992e+06
@@ -1129,7 +1129,7 @@ Types:
           Offset: 8
           Type: 14 VoidPointerType unsafe.Pointer
     - __kind: StructureType
-      ID: 79
+      ID: 56
       Name: crypto/tls.ConnectionState
       ByteSize: 192
       GoRuntimeType: 2.262752e+06
@@ -1149,7 +1149,7 @@ Types:
           Type: 6 BaseType uint16
         - Name: CurveID
           Offset: 6
-          Type: 80 BaseType crypto/tls.CurveID
+          Type: 79 BaseType crypto/tls.CurveID
         - Name: NegotiatedProtocol
           Offset: 8
           Type: 9 GoStringHeaderType string
@@ -1161,45 +1161,45 @@ Types:
           Type: 9 GoStringHeaderType string
         - Name: PeerCertificates
           Offset: 48
-          Type: 81 GoSliceHeaderType []*crypto/x509.Certificate
+          Type: 80 GoSliceHeaderType []*crypto/x509.Certificate
         - Name: VerifiedChains
           Offset: 72
-          Type: 132 GoSliceHeaderType [][]*crypto/x509.Certificate
+          Type: 83 GoSliceHeaderType [][]*crypto/x509.Certificate
         - Name: SignedCertificateTimestamps
           Offset: 96
-          Type: 134 GoSliceHeaderType [][]uint8
+          Type: 85 GoSliceHeaderType [][]uint8
         - Name: OCSPResponse
           Offset: 120
-          Type: 77 GoSliceHeaderType []uint8
+          Type: 68 GoSliceHeaderType []uint8
         - Name: TLSUnique
           Offset: 144
-          Type: 77 GoSliceHeaderType []uint8
+          Type: 68 GoSliceHeaderType []uint8
         - Name: ECHAccepted
           Offset: 168
           Type: 4 BaseType bool
         - Name: ekm
           Offset: 176
-          Type: 136 GoSubroutineType func(string, []uint8, int) ([]uint8, error)
+          Type: 87 GoSubroutineType func(string, []uint8, int) ([]uint8, error)
         - Name: testingOnlyDidHRR
           Offset: 184
           Type: 4 BaseType bool
         - Name: testingOnlyPeerSignatureAlgorithm
           Offset: 186
-          Type: 137 BaseType crypto/tls.SignatureScheme
+          Type: 88 BaseType crypto/tls.SignatureScheme
     - __kind: BaseType
-      ID: 80
+      ID: 79
       Name: crypto/tls.CurveID
       ByteSize: 2
       GoRuntimeType: 835040
       GoKind: 9
     - __kind: BaseType
-      ID: 137
+      ID: 88
       Name: crypto/tls.SignatureScheme
       ByteSize: 2
       GoRuntimeType: 835136
       GoKind: 9
     - __kind: StructureType
-      ID: 84
+      ID: 97
       Name: crypto/x509.Certificate
       ByteSize: 1424
       GoRuntimeType: 2.3936e+06
@@ -1207,67 +1207,67 @@ Types:
       RawFields:
         - Name: Raw
           Offset: 0
-          Type: 77 GoSliceHeaderType []uint8
+          Type: 68 GoSliceHeaderType []uint8
         - Name: RawTBSCertificate
           Offset: 24
-          Type: 77 GoSliceHeaderType []uint8
+          Type: 68 GoSliceHeaderType []uint8
         - Name: RawSubjectPublicKeyInfo
           Offset: 48
-          Type: 77 GoSliceHeaderType []uint8
+          Type: 68 GoSliceHeaderType []uint8
         - Name: RawSubject
           Offset: 72
-          Type: 77 GoSliceHeaderType []uint8
+          Type: 68 GoSliceHeaderType []uint8
         - Name: RawIssuer
           Offset: 96
-          Type: 77 GoSliceHeaderType []uint8
+          Type: 68 GoSliceHeaderType []uint8
         - Name: Signature
           Offset: 120
-          Type: 77 GoSliceHeaderType []uint8
+          Type: 68 GoSliceHeaderType []uint8
         - Name: SignatureAlgorithm
           Offset: 144
-          Type: 85 BaseType crypto/x509.SignatureAlgorithm
+          Type: 106 BaseType crypto/x509.SignatureAlgorithm
         - Name: PublicKeyAlgorithm
           Offset: 152
-          Type: 86 BaseType crypto/x509.PublicKeyAlgorithm
+          Type: 107 BaseType crypto/x509.PublicKeyAlgorithm
         - Name: PublicKey
           Offset: 160
-          Type: 87 GoEmptyInterfaceType interface {}
+          Type: 108 GoEmptyInterfaceType interface {}
         - Name: Version
           Offset: 176
           Type: 7 BaseType int
         - Name: SerialNumber
           Offset: 184
-          Type: 88 PointerType *math/big.Int
+          Type: 109 PointerType *math/big.Int
         - Name: Issuer
           Offset: 192
-          Type: 93 StructureType crypto/x509/pkix.Name
+          Type: 111 StructureType crypto/x509/pkix.Name
         - Name: Subject
           Offset: 440
-          Type: 93 StructureType crypto/x509/pkix.Name
+          Type: 111 StructureType crypto/x509/pkix.Name
         - Name: NotBefore
           Offset: 688
-          Type: 98 StructureType time.Time
+          Type: 115 StructureType time.Time
         - Name: NotAfter
           Offset: 712
-          Type: 98 StructureType time.Time
+          Type: 115 StructureType time.Time
         - Name: KeyUsage
           Offset: 736
-          Type: 107 BaseType crypto/x509.KeyUsage
+          Type: 118 BaseType crypto/x509.KeyUsage
         - Name: Extensions
           Offset: 744
-          Type: 108 GoSliceHeaderType []crypto/x509/pkix.Extension
+          Type: 119 GoSliceHeaderType []crypto/x509/pkix.Extension
         - Name: ExtraExtensions
           Offset: 768
-          Type: 108 GoSliceHeaderType []crypto/x509/pkix.Extension
+          Type: 119 GoSliceHeaderType []crypto/x509/pkix.Extension
         - Name: UnhandledCriticalExtensions
           Offset: 792
-          Type: 111 GoSliceHeaderType []encoding/asn1.ObjectIdentifier
+          Type: 122 GoSliceHeaderType []encoding/asn1.ObjectIdentifier
         - Name: ExtKeyUsage
           Offset: 816
-          Type: 113 GoSliceHeaderType []crypto/x509.ExtKeyUsage
+          Type: 125 GoSliceHeaderType []crypto/x509.ExtKeyUsage
         - Name: UnknownExtKeyUsage
           Offset: 840
-          Type: 111 GoSliceHeaderType []encoding/asn1.ObjectIdentifier
+          Type: 122 GoSliceHeaderType []encoding/asn1.ObjectIdentifier
         - Name: BasicConstraintsValid
           Offset: 864
           Type: 4 BaseType bool
@@ -1282,64 +1282,64 @@ Types:
           Type: 4 BaseType bool
         - Name: SubjectKeyId
           Offset: 888
-          Type: 77 GoSliceHeaderType []uint8
+          Type: 68 GoSliceHeaderType []uint8
         - Name: AuthorityKeyId
           Offset: 912
-          Type: 77 GoSliceHeaderType []uint8
+          Type: 68 GoSliceHeaderType []uint8
         - Name: OCSPServer
           Offset: 936
-          Type: 54 GoSliceHeaderType []string
+          Type: 51 GoSliceHeaderType []string
         - Name: IssuingCertificateURL
           Offset: 960
-          Type: 54 GoSliceHeaderType []string
+          Type: 51 GoSliceHeaderType []string
         - Name: DNSNames
           Offset: 984
-          Type: 54 GoSliceHeaderType []string
+          Type: 51 GoSliceHeaderType []string
         - Name: EmailAddresses
           Offset: 1008
-          Type: 54 GoSliceHeaderType []string
+          Type: 51 GoSliceHeaderType []string
         - Name: IPAddresses
           Offset: 1032
-          Type: 116 GoSliceHeaderType []net.IP
+          Type: 128 GoSliceHeaderType []net.IP
         - Name: URIs
           Offset: 1056
-          Type: 119 GoSliceHeaderType []*net/url.URL
+          Type: 131 GoSliceHeaderType []*net/url.URL
         - Name: PermittedDNSDomainsCritical
           Offset: 1080
           Type: 4 BaseType bool
         - Name: PermittedDNSDomains
           Offset: 1088
-          Type: 54 GoSliceHeaderType []string
+          Type: 51 GoSliceHeaderType []string
         - Name: ExcludedDNSDomains
           Offset: 1112
-          Type: 54 GoSliceHeaderType []string
+          Type: 51 GoSliceHeaderType []string
         - Name: PermittedIPRanges
           Offset: 1136
-          Type: 121 GoSliceHeaderType []*net.IPNet
+          Type: 133 GoSliceHeaderType []*net.IPNet
         - Name: ExcludedIPRanges
           Offset: 1160
-          Type: 121 GoSliceHeaderType []*net.IPNet
+          Type: 133 GoSliceHeaderType []*net.IPNet
         - Name: PermittedEmailAddresses
           Offset: 1184
-          Type: 54 GoSliceHeaderType []string
+          Type: 51 GoSliceHeaderType []string
         - Name: ExcludedEmailAddresses
           Offset: 1208
-          Type: 54 GoSliceHeaderType []string
+          Type: 51 GoSliceHeaderType []string
         - Name: PermittedURIDomains
           Offset: 1232
-          Type: 54 GoSliceHeaderType []string
+          Type: 51 GoSliceHeaderType []string
         - Name: ExcludedURIDomains
           Offset: 1256
-          Type: 54 GoSliceHeaderType []string
+          Type: 51 GoSliceHeaderType []string
         - Name: CRLDistributionPoints
           Offset: 1280
-          Type: 54 GoSliceHeaderType []string
+          Type: 51 GoSliceHeaderType []string
         - Name: PolicyIdentifiers
           Offset: 1304
-          Type: 111 GoSliceHeaderType []encoding/asn1.ObjectIdentifier
+          Type: 122 GoSliceHeaderType []encoding/asn1.ObjectIdentifier
         - Name: Policies
           Offset: 1328
-          Type: 126 GoSliceHeaderType []crypto/x509.OID
+          Type: 136 GoSliceHeaderType []crypto/x509.OID
         - Name: InhibitAnyPolicy
           Offset: 1352
           Type: 7 BaseType int
@@ -1360,21 +1360,21 @@ Types:
           Type: 4 BaseType bool
         - Name: PolicyMappings
           Offset: 1400
-          Type: 129 GoSliceHeaderType []crypto/x509.PolicyMapping
+          Type: 139 GoSliceHeaderType []crypto/x509.PolicyMapping
     - __kind: BaseType
-      ID: 115
+      ID: 127
       Name: crypto/x509.ExtKeyUsage
       ByteSize: 8
       GoRuntimeType: 588160
       GoKind: 2
     - __kind: BaseType
-      ID: 107
+      ID: 118
       Name: crypto/x509.KeyUsage
       ByteSize: 8
       GoRuntimeType: 588096
       GoKind: 2
     - __kind: StructureType
-      ID: 128
+      ID: 138
       Name: crypto/x509.OID
       ByteSize: 24
       GoRuntimeType: 1.954592e+06
@@ -1382,9 +1382,9 @@ Types:
       RawFields:
         - Name: der
           Offset: 0
-          Type: 77 GoSliceHeaderType []uint8
+          Type: 68 GoSliceHeaderType []uint8
     - __kind: StructureType
-      ID: 131
+      ID: 141
       Name: crypto/x509.PolicyMapping
       ByteSize: 48
       GoRuntimeType: 1.491232e+06
@@ -1392,24 +1392,24 @@ Types:
       RawFields:
         - Name: IssuerDomainPolicy
           Offset: 0
-          Type: 128 StructureType crypto/x509.OID
+          Type: 138 StructureType crypto/x509.OID
         - Name: SubjectDomainPolicy
           Offset: 24
-          Type: 128 StructureType crypto/x509.OID
+          Type: 138 StructureType crypto/x509.OID
     - __kind: BaseType
-      ID: 86
+      ID: 107
       Name: crypto/x509.PublicKeyAlgorithm
       ByteSize: 8
       GoRuntimeType: 837632
       GoKind: 2
     - __kind: BaseType
-      ID: 85
+      ID: 106
       Name: crypto/x509.SignatureAlgorithm
       ByteSize: 8
       GoRuntimeType: 1.114432e+06
       GoKind: 2
     - __kind: StructureType
-      ID: 96
+      ID: 114
       Name: crypto/x509/pkix.AttributeTypeAndValue
       ByteSize: 40
       GoRuntimeType: 1.502912e+06
@@ -1417,12 +1417,12 @@ Types:
       RawFields:
         - Name: Type
           Offset: 0
-          Type: 97 GoSliceHeaderType encoding/asn1.ObjectIdentifier
+          Type: 124 GoSliceHeaderType encoding/asn1.ObjectIdentifier
         - Name: Value
           Offset: 24
-          Type: 87 GoEmptyInterfaceType interface {}
+          Type: 108 GoEmptyInterfaceType interface {}
     - __kind: StructureType
-      ID: 110
+      ID: 121
       Name: crypto/x509/pkix.Extension
       ByteSize: 56
       GoRuntimeType: 1.647008e+06
@@ -1430,15 +1430,15 @@ Types:
       RawFields:
         - Name: Id
           Offset: 0
-          Type: 97 GoSliceHeaderType encoding/asn1.ObjectIdentifier
+          Type: 124 GoSliceHeaderType encoding/asn1.ObjectIdentifier
         - Name: Critical
           Offset: 24
           Type: 4 BaseType bool
         - Name: Value
           Offset: 32
-          Type: 77 GoSliceHeaderType []uint8
+          Type: 68 GoSliceHeaderType []uint8
     - __kind: StructureType
-      ID: 93
+      ID: 111
       Name: crypto/x509/pkix.Name
       ByteSize: 248
       GoRuntimeType: 2.192768e+06
@@ -1446,25 +1446,25 @@ Types:
       RawFields:
         - Name: Country
           Offset: 0
-          Type: 54 GoSliceHeaderType []string
+          Type: 51 GoSliceHeaderType []string
         - Name: Organization
           Offset: 24
-          Type: 54 GoSliceHeaderType []string
+          Type: 51 GoSliceHeaderType []string
         - Name: OrganizationalUnit
           Offset: 48
-          Type: 54 GoSliceHeaderType []string
+          Type: 51 GoSliceHeaderType []string
         - Name: Locality
           Offset: 72
-          Type: 54 GoSliceHeaderType []string
+          Type: 51 GoSliceHeaderType []string
         - Name: Province
           Offset: 96
-          Type: 54 GoSliceHeaderType []string
+          Type: 51 GoSliceHeaderType []string
         - Name: StreetAddress
           Offset: 120
-          Type: 54 GoSliceHeaderType []string
+          Type: 51 GoSliceHeaderType []string
         - Name: PostalCode
           Offset: 144
-          Type: 54 GoSliceHeaderType []string
+          Type: 51 GoSliceHeaderType []string
         - Name: SerialNumber
           Offset: 168
           Type: 9 GoStringHeaderType string
@@ -1473,12 +1473,12 @@ Types:
           Type: 9 GoStringHeaderType string
         - Name: Names
           Offset: 200
-          Type: 94 GoSliceHeaderType []crypto/x509/pkix.AttributeTypeAndValue
+          Type: 112 GoSliceHeaderType []crypto/x509/pkix.AttributeTypeAndValue
         - Name: ExtraNames
           Offset: 224
-          Type: 94 GoSliceHeaderType []crypto/x509/pkix.AttributeTypeAndValue
+          Type: 112 GoSliceHeaderType []crypto/x509/pkix.AttributeTypeAndValue
     - __kind: GoSliceHeaderType
-      ID: 97
+      ID: 124
       Name: encoding/asn1.ObjectIdentifier
       ByteSize: 24
       GoRuntimeType: 1.053536e+06
@@ -1493,9 +1493,9 @@ Types:
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 180 GoSliceDataType encoding/asn1.ObjectIdentifier.array
+      Data: 188 GoSliceDataType encoding/asn1.ObjectIdentifier.array
     - __kind: GoSliceDataType
-      ID: 180
+      ID: 188
       Name: encoding/asn1.ObjectIdentifier.array
       ByteSize: 2048
       Element: 7 BaseType int
@@ -1525,19 +1525,19 @@ Types:
       GoRuntimeType: 585408
       GoKind: 14
     - __kind: GoSubroutineType
-      ID: 56
+      ID: 50
       Name: func() (io.ReadCloser, error)
       ByteSize: 8
       GoRuntimeType: 693344
       GoKind: 19
     - __kind: GoSubroutineType
-      ID: 136
+      ID: 87
       Name: func(string, []uint8, int) ([]uint8, error)
       ByteSize: 8
       GoRuntimeType: 1.003296e+06
       GoKind: 19
     - __kind: GoInterfaceType
-      ID: 161
+      ID: 41
       Name: gopkg.in/DataDog/dd-trace-go.v1/ddtrace.Span
       ByteSize: 16
       GoRuntimeType: 1.479712e+06
@@ -1550,47 +1550,47 @@ Types:
           Offset: 8
           Type: 14 VoidPointerType unsafe.Pointer
     - __kind: GoSwissMapGroupsType
-      ID: 67
+      ID: 103
       Name: groupReference<string,[]*mime/multipart.FileHeader>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 68 PointerType *noalg.map.group[string][]*mime/multipart.FileHeader
+          Type: 104 PointerType *noalg.map.group[string][]*mime/multipart.FileHeader
         - Name: lengthMask
           Offset: 8
           Type: 8 BaseType uint64
-      GroupType: 69 StructureType noalg.map.group[string][]*mime/multipart.FileHeader
-      GroupSliceType: 169 GoSliceDataType []noalg.map.group[string][]*mime/multipart.FileHeader.array
+      GroupType: 105 StructureType noalg.map.group[string][]*mime/multipart.FileHeader
+      GroupSliceType: 173 GoSliceDataType []noalg.map.group[string][]*mime/multipart.FileHeader.array
     - __kind: GoSwissMapGroupsType
-      ID: 49
+      ID: 93
       Name: groupReference<string,[]string>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 50 PointerType *noalg.map.group[string][]string
+          Type: 94 PointerType *noalg.map.group[string][]string
         - Name: lengthMask
           Offset: 8
           Type: 8 BaseType uint64
-      GroupType: 51 StructureType noalg.map.group[string][]string
+      GroupType: 95 StructureType noalg.map.group[string][]string
       GroupSliceType: 165 GoSliceDataType []noalg.map.group[string][]string.array
     - __kind: GoSwissMapGroupsType
-      ID: 153
+      ID: 98
       Name: groupReference<string,string>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 154 PointerType *noalg.map.group[string]string
+          Type: 99 PointerType *noalg.map.group[string]string
         - Name: lengthMask
           Offset: 8
           Type: 8 BaseType uint64
-      GroupType: 155 StructureType noalg.map.group[string]string
-      GroupSliceType: 213 GoSliceDataType []noalg.map.group[string]string.array
+      GroupType: 100 StructureType noalg.map.group[string]string
+      GroupSliceType: 169 GoSliceDataType []noalg.map.group[string]string.array
     - __kind: BaseType
       ID: 7
       Name: int
@@ -1622,7 +1622,7 @@ Types:
       GoRuntimeType: 584512
       GoKind: 3
     - __kind: GoEmptyInterfaceType
-      ID: 87
+      ID: 108
       Name: interface {}
       ByteSize: 16
       GoRuntimeType: 854848
@@ -1635,7 +1635,7 @@ Types:
           Offset: 8
           Type: 14 VoidPointerType unsafe.Pointer
     - __kind: GoInterfaceType
-      ID: 55
+      ID: 49
       Name: io.ReadCloser
       ByteSize: 16
       GoRuntimeType: 1.110464e+06
@@ -1648,7 +1648,7 @@ Types:
           Offset: 8
           Type: 14 VoidPointerType unsafe.Pointer
     - __kind: GoSwissMapHeaderType
-      ID: 63
+      ID: 76
       Name: map<string,[]*mime/multipart.FileHeader>
       ByteSize: 48
       GoKind: 25
@@ -1661,7 +1661,7 @@ Types:
           Type: 1 BaseType uintptr
         - Name: dirPtr
           Offset: 16
-          Type: 64 PointerType **table<string,[]*mime/multipart.FileHeader>
+          Type: 77 PointerType **table<string,[]*mime/multipart.FileHeader>
         - Name: dirLen
           Offset: 24
           Type: 7 BaseType int
@@ -1680,10 +1680,10 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 8 BaseType uint64
-      TablePtrSliceType: 168 GoSliceDataType []*table<string,[]*mime/multipart.FileHeader>.array
-      GroupType: 69 StructureType noalg.map.group[string][]*mime/multipart.FileHeader
+      TablePtrSliceType: 172 GoSliceDataType []*table<string,[]*mime/multipart.FileHeader>.array
+      GroupType: 105 StructureType noalg.map.group[string][]*mime/multipart.FileHeader
     - __kind: GoSwissMapHeaderType
-      ID: 45
+      ID: 46
       Name: map<string,[]string>
       ByteSize: 48
       GoKind: 25
@@ -1696,7 +1696,7 @@ Types:
           Type: 1 BaseType uintptr
         - Name: dirPtr
           Offset: 16
-          Type: 46 PointerType **table<string,[]string>
+          Type: 47 PointerType **table<string,[]string>
         - Name: dirLen
           Offset: 24
           Type: 7 BaseType int
@@ -1716,9 +1716,9 @@ Types:
           Offset: 40
           Type: 8 BaseType uint64
       TablePtrSliceType: 164 GoSliceDataType []*table<string,[]string>.array
-      GroupType: 51 StructureType noalg.map.group[string][]string
+      GroupType: 95 StructureType noalg.map.group[string][]string
     - __kind: GoSwissMapHeaderType
-      ID: 149
+      ID: 65
       Name: map<string,string>
       ByteSize: 48
       GoKind: 25
@@ -1731,7 +1731,7 @@ Types:
           Type: 1 BaseType uintptr
         - Name: dirPtr
           Offset: 16
-          Type: 150 PointerType **table<string,string>
+          Type: 66 PointerType **table<string,string>
         - Name: dirLen
           Offset: 24
           Type: 7 BaseType int
@@ -1750,31 +1750,31 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 8 BaseType uint64
-      TablePtrSliceType: 212 GoSliceDataType []*table<string,string>.array
-      GroupType: 155 StructureType noalg.map.group[string]string
+      TablePtrSliceType: 168 GoSliceDataType []*table<string,string>.array
+      GroupType: 100 StructureType noalg.map.group[string]string
     - __kind: GoMapType
-      ID: 61
+      ID: 74
       Name: map[string][]*mime/multipart.FileHeader
       ByteSize: 8
       GoRuntimeType: 1.132352e+06
       GoKind: 21
-      HeaderType: 63 GoSwissMapHeaderType map<string,[]*mime/multipart.FileHeader>
+      HeaderType: 76 GoSwissMapHeaderType map<string,[]*mime/multipart.FileHeader>
     - __kind: GoMapType
-      ID: 60
+      ID: 73
       Name: map[string][]string
       ByteSize: 8
       GoRuntimeType: 1.128e+06
       GoKind: 21
-      HeaderType: 45 GoSwissMapHeaderType map<string,[]string>
+      HeaderType: 46 GoSwissMapHeaderType map<string,[]string>
     - __kind: GoMapType
-      ID: 147
+      ID: 63
       Name: map[string]string
       ByteSize: 8
       GoRuntimeType: 1.129024e+06
       GoKind: 21
-      HeaderType: 149 GoSwissMapHeaderType map<string,string>
+      HeaderType: 65 GoSwissMapHeaderType map<string,string>
     - __kind: StructureType
-      ID: 89
+      ID: 110
       Name: math/big.Int
       ByteSize: 32
       GoRuntimeType: 1.494272e+06
@@ -1785,15 +1785,15 @@ Types:
           Type: 4 BaseType bool
         - Name: abs
           Offset: 8
-          Type: 90 GoSliceHeaderType math/big.nat
+          Type: 149 GoSliceHeaderType math/big.nat
     - __kind: BaseType
-      ID: 92
+      ID: 151
       Name: math/big.Word
       ByteSize: 8
       GoRuntimeType: 588352
       GoKind: 7
     - __kind: GoSliceHeaderType
-      ID: 90
+      ID: 149
       Name: math/big.nat
       ByteSize: 24
       GoRuntimeType: 2.361856e+06
@@ -1801,21 +1801,21 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 91 PointerType *math/big.Word
+          Type: 150 PointerType *math/big.Word
         - Name: len
           Offset: 8
           Type: 7 BaseType int
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 176 GoSliceDataType math/big.nat.array
+      Data: 206 GoSliceDataType math/big.nat.array
     - __kind: GoSliceDataType
-      ID: 176
+      ID: 206
       Name: math/big.nat.array
       ByteSize: 2048
-      Element: 92 BaseType math/big.Word
+      Element: 151 BaseType math/big.Word
     - __kind: StructureType
-      ID: 75
+      ID: 159
       Name: mime/multipart.FileHeader
       ByteSize: 88
       GoRuntimeType: 1.977856e+06
@@ -1826,13 +1826,13 @@ Types:
           Type: 9 GoStringHeaderType string
         - Name: Header
           Offset: 16
-          Type: 76 GoMapType net/textproto.MIMEHeader
+          Type: 161 GoMapType net/textproto.MIMEHeader
         - Name: Size
           Offset: 24
           Type: 12 BaseType int64
         - Name: content
           Offset: 32
-          Type: 77 GoSliceHeaderType []uint8
+          Type: 68 GoSliceHeaderType []uint8
         - Name: tmpfile
           Offset: 56
           Type: 9 GoStringHeaderType string
@@ -1843,7 +1843,7 @@ Types:
           Offset: 80
           Type: 4 BaseType bool
     - __kind: StructureType
-      ID: 59
+      ID: 54
       Name: mime/multipart.Form
       ByteSize: 16
       GoRuntimeType: 1.478112e+06
@@ -1851,12 +1851,12 @@ Types:
       RawFields:
         - Name: Value
           Offset: 0
-          Type: 60 GoMapType map[string][]string
+          Type: 73 GoMapType map[string][]string
         - Name: File
           Offset: 8
-          Type: 61 GoMapType map[string][]*mime/multipart.FileHeader
+          Type: 74 GoMapType map[string][]*mime/multipart.FileHeader
     - __kind: GoSliceHeaderType
-      ID: 118
+      ID: 130
       Name: net.IP
       ByteSize: 24
       GoRuntimeType: 2.124512e+06
@@ -1878,7 +1878,7 @@ Types:
       ByteSize: 2048
       Element: 3 BaseType uint8
     - __kind: GoSliceHeaderType
-      ID: 125
+      ID: 160
       Name: net.IPMask
       ByteSize: 24
       GoRuntimeType: 1.019744e+06
@@ -1893,14 +1893,14 @@ Types:
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 200 GoSliceDataType net.IPMask.array
+      Data: 212 GoSliceDataType net.IPMask.array
     - __kind: GoSliceDataType
-      ID: 200
+      ID: 212
       Name: net.IPMask.array
       ByteSize: 2048
       Element: 3 BaseType uint8
     - __kind: StructureType
-      ID: 124
+      ID: 158
       Name: net.IPNet
       ByteSize: 48
       GoRuntimeType: 1.458912e+06
@@ -1908,17 +1908,17 @@ Types:
       RawFields:
         - Name: IP
           Offset: 0
-          Type: 118 GoSliceHeaderType net.IP
+          Type: 130 GoSliceHeaderType net.IP
         - Name: Mask
           Offset: 24
-          Type: 125 GoSliceHeaderType net.IPMask
+          Type: 160 GoSliceHeaderType net.IPMask
     - __kind: GoMapType
-      ID: 43
+      ID: 44
       Name: net/http.Header
       ByteSize: 8
       GoRuntimeType: 2.101632e+06
       GoKind: 21
-      HeaderType: 45 GoSwissMapHeaderType map<string,[]string>
+      HeaderType: 46 GoSwissMapHeaderType map<string,[]string>
     - __kind: StructureType
       ID: 38
       Name: net/http.Request
@@ -1931,7 +1931,7 @@ Types:
           Type: 9 GoStringHeaderType string
         - Name: URL
           Offset: 16
-          Type: 39 PointerType *net/url.URL
+          Type: 42 PointerType *net/url.URL
         - Name: Proto
           Offset: 24
           Type: 9 GoStringHeaderType string
@@ -1943,19 +1943,19 @@ Types:
           Type: 7 BaseType int
         - Name: Header
           Offset: 56
-          Type: 43 GoMapType net/http.Header
+          Type: 44 GoMapType net/http.Header
         - Name: Body
           Offset: 64
-          Type: 55 GoInterfaceType io.ReadCloser
+          Type: 49 GoInterfaceType io.ReadCloser
         - Name: GetBody
           Offset: 80
-          Type: 56 GoSubroutineType func() (io.ReadCloser, error)
+          Type: 50 GoSubroutineType func() (io.ReadCloser, error)
         - Name: ContentLength
           Offset: 88
           Type: 12 BaseType int64
         - Name: TransferEncoding
           Offset: 96
-          Type: 54 GoSliceHeaderType []string
+          Type: 51 GoSliceHeaderType []string
         - Name: Close
           Offset: 120
           Type: 4 BaseType bool
@@ -1964,16 +1964,16 @@ Types:
           Type: 9 GoStringHeaderType string
         - Name: Form
           Offset: 144
-          Type: 57 GoMapType net/url.Values
+          Type: 52 GoMapType net/url.Values
         - Name: PostForm
           Offset: 152
-          Type: 57 GoMapType net/url.Values
+          Type: 52 GoMapType net/url.Values
         - Name: MultipartForm
           Offset: 160
-          Type: 58 PointerType *mime/multipart.Form
+          Type: 53 PointerType *mime/multipart.Form
         - Name: Trailer
           Offset: 168
-          Type: 43 GoMapType net/http.Header
+          Type: 44 GoMapType net/http.Header
         - Name: RemoteAddr
           Offset: 176
           Type: 9 GoStringHeaderType string
@@ -1982,30 +1982,30 @@ Types:
           Type: 9 GoStringHeaderType string
         - Name: TLS
           Offset: 208
-          Type: 78 PointerType *crypto/tls.ConnectionState
+          Type: 55 PointerType *crypto/tls.ConnectionState
         - Name: Cancel
           Offset: 216
-          Type: 138 GoChannelType <-chan struct {}
+          Type: 57 GoChannelType <-chan struct {}
         - Name: Response
           Offset: 224
-          Type: 139 PointerType *net/http.Response
+          Type: 58 PointerType *net/http.Response
         - Name: Pattern
           Offset: 232
           Type: 9 GoStringHeaderType string
         - Name: ctx
           Offset: 248
-          Type: 141 GoInterfaceType context.Context
+          Type: 60 GoInterfaceType context.Context
         - Name: pat
           Offset: 264
-          Type: 142 PointerType *net/http.pattern
+          Type: 61 PointerType *net/http.pattern
         - Name: matches
           Offset: 272
-          Type: 54 GoSliceHeaderType []string
+          Type: 51 GoSliceHeaderType []string
         - Name: otherValues
           Offset: 296
-          Type: 147 GoMapType map[string]string
+          Type: 63 GoMapType map[string]string
     - __kind: StructureType
-      ID: 140
+      ID: 59
       Name: net/http.Response
       ByteSize: 144
       GoRuntimeType: 2.210656e+06
@@ -2028,16 +2028,16 @@ Types:
           Type: 7 BaseType int
         - Name: Header
           Offset: 56
-          Type: 43 GoMapType net/http.Header
+          Type: 44 GoMapType net/http.Header
         - Name: Body
           Offset: 64
-          Type: 55 GoInterfaceType io.ReadCloser
+          Type: 49 GoInterfaceType io.ReadCloser
         - Name: ContentLength
           Offset: 80
           Type: 12 BaseType int64
         - Name: TransferEncoding
           Offset: 88
-          Type: 54 GoSliceHeaderType []string
+          Type: 51 GoSliceHeaderType []string
         - Name: Close
           Offset: 112
           Type: 4 BaseType bool
@@ -2046,13 +2046,13 @@ Types:
           Type: 4 BaseType bool
         - Name: Trailer
           Offset: 120
-          Type: 43 GoMapType net/http.Header
+          Type: 44 GoMapType net/http.Header
         - Name: Request
           Offset: 128
           Type: 37 PointerType *net/http.Request
         - Name: TLS
           Offset: 136
-          Type: 78 PointerType *crypto/tls.ConnectionState
+          Type: 55 PointerType *crypto/tls.ConnectionState
     - __kind: GoInterfaceType
       ID: 36
       Name: net/http.ResponseWriter
@@ -2067,7 +2067,7 @@ Types:
           Offset: 8
           Type: 14 VoidPointerType unsafe.Pointer
     - __kind: StructureType
-      ID: 143
+      ID: 62
       Name: net/http.pattern
       ByteSize: 88
       GoRuntimeType: 1.833632e+06
@@ -2084,12 +2084,12 @@ Types:
           Type: 9 GoStringHeaderType string
         - Name: segments
           Offset: 48
-          Type: 144 GoSliceHeaderType []net/http.segment
+          Type: 89 GoSliceHeaderType []net/http.segment
         - Name: loc
           Offset: 72
           Type: 9 GoStringHeaderType string
     - __kind: StructureType
-      ID: 146
+      ID: 91
       Name: net/http.segment
       ByteSize: 24
       GoRuntimeType: 1.608416e+06
@@ -2105,14 +2105,14 @@ Types:
           Offset: 17
           Type: 4 BaseType bool
     - __kind: GoMapType
-      ID: 76
+      ID: 161
       Name: net/textproto.MIMEHeader
       ByteSize: 8
       GoRuntimeType: 1.823584e+06
       GoKind: 21
-      HeaderType: 45 GoSwissMapHeaderType map<string,[]string>
+      HeaderType: 46 GoSwissMapHeaderType map<string,[]string>
     - __kind: StructureType
-      ID: 40
+      ID: 43
       Name: net/url.URL
       ByteSize: 144
       GoRuntimeType: 2.127584e+06
@@ -2126,7 +2126,7 @@ Types:
           Type: 9 GoStringHeaderType string
         - Name: User
           Offset: 32
-          Type: 41 PointerType *net/url.Userinfo
+          Type: 70 PointerType *net/url.Userinfo
         - Name: Host
           Offset: 40
           Type: 9 GoStringHeaderType string
@@ -2152,7 +2152,7 @@ Types:
           Offset: 128
           Type: 9 GoStringHeaderType string
     - __kind: StructureType
-      ID: 42
+      ID: 71
       Name: net/url.Userinfo
       ByteSize: 40
       GoRuntimeType: 1.624928e+06
@@ -2168,41 +2168,41 @@ Types:
           Offset: 32
           Type: 4 BaseType bool
     - __kind: GoMapType
-      ID: 57
+      ID: 52
       Name: net/url.Values
       ByteSize: 8
       GoRuntimeType: 1.885152e+06
       GoKind: 21
-      HeaderType: 45 GoSwissMapHeaderType map<string,[]string>
+      HeaderType: 46 GoSwissMapHeaderType map<string,[]string>
     - __kind: ArrayType
-      ID: 70
+      ID: 144
       Name: noalg.[8]struct { key string; elem []*mime/multipart.FileHeader }
       ByteSize: 320
       GoRuntimeType: 699200
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 71 StructureType noalg.struct { key string; elem []*mime/multipart.FileHeader }
+      Element: 145 StructureType noalg.struct { key string; elem []*mime/multipart.FileHeader }
     - __kind: ArrayType
-      ID: 52
+      ID: 101
       Name: noalg.[8]struct { key string; elem []string }
       ByteSize: 320
       GoRuntimeType: 689376
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 53 StructureType noalg.struct { key string; elem []string }
+      Element: 102 StructureType noalg.struct { key string; elem []string }
     - __kind: ArrayType
-      ID: 156
+      ID: 142
       Name: noalg.[8]struct { key string; elem string }
       ByteSize: 256
       GoRuntimeType: 693536
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 157 StructureType noalg.struct { key string; elem string }
+      Element: 143 StructureType noalg.struct { key string; elem string }
     - __kind: StructureType
-      ID: 69
+      ID: 105
       Name: noalg.map.group[string][]*mime/multipart.FileHeader
       ByteSize: 328
       GoRuntimeType: 1.29952e+06
@@ -2213,9 +2213,9 @@ Types:
           Type: 8 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 70 ArrayType noalg.[8]struct { key string; elem []*mime/multipart.FileHeader }
+          Type: 144 ArrayType noalg.[8]struct { key string; elem []*mime/multipart.FileHeader }
     - __kind: StructureType
-      ID: 51
+      ID: 95
       Name: noalg.map.group[string][]string
       ByteSize: 328
       GoRuntimeType: 1.290432e+06
@@ -2226,9 +2226,9 @@ Types:
           Type: 8 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 52 ArrayType noalg.[8]struct { key string; elem []string }
+          Type: 101 ArrayType noalg.[8]struct { key string; elem []string }
     - __kind: StructureType
-      ID: 155
+      ID: 100
       Name: noalg.map.group[string]string
       ByteSize: 264
       GoRuntimeType: 1.292864e+06
@@ -2239,9 +2239,9 @@ Types:
           Type: 8 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 156 ArrayType noalg.[8]struct { key string; elem string }
+          Type: 142 ArrayType noalg.[8]struct { key string; elem string }
     - __kind: StructureType
-      ID: 71
+      ID: 145
       Name: noalg.struct { key string; elem []*mime/multipart.FileHeader }
       ByteSize: 40
       GoRuntimeType: 1.299392e+06
@@ -2252,9 +2252,9 @@ Types:
           Type: 9 GoStringHeaderType string
         - Name: elem
           Offset: 16
-          Type: 72 GoSliceHeaderType []*mime/multipart.FileHeader
+          Type: 146 GoSliceHeaderType []*mime/multipart.FileHeader
     - __kind: StructureType
-      ID: 53
+      ID: 102
       Name: noalg.struct { key string; elem []string }
       ByteSize: 40
       GoRuntimeType: 1.290304e+06
@@ -2265,9 +2265,9 @@ Types:
           Type: 9 GoStringHeaderType string
         - Name: elem
           Offset: 16
-          Type: 54 GoSliceHeaderType []string
+          Type: 51 GoSliceHeaderType []string
     - __kind: StructureType
-      ID: 157
+      ID: 143
       Name: noalg.struct { key string; elem string }
       ByteSize: 32
       GoRuntimeType: 1.292736e+06
@@ -2298,7 +2298,7 @@ Types:
       Name: string.str
       ByteSize: 2048
     - __kind: StructureType
-      ID: 66
+      ID: 96
       Name: table<string,[]*mime/multipart.FileHeader>
       ByteSize: 32
       GoKind: 25
@@ -2320,9 +2320,9 @@ Types:
           Type: 7 BaseType int
         - Name: groups
           Offset: 16
-          Type: 67 GoSwissMapGroupsType groupReference<string,[]*mime/multipart.FileHeader>
+          Type: 103 GoSwissMapGroupsType groupReference<string,[]*mime/multipart.FileHeader>
     - __kind: StructureType
-      ID: 48
+      ID: 72
       Name: table<string,[]string>
       ByteSize: 32
       GoKind: 25
@@ -2344,9 +2344,9 @@ Types:
           Type: 7 BaseType int
         - Name: groups
           Offset: 16
-          Type: 49 GoSwissMapGroupsType groupReference<string,[]string>
+          Type: 93 GoSwissMapGroupsType groupReference<string,[]string>
     - __kind: StructureType
-      ID: 152
+      ID: 92
       Name: table<string,string>
       ByteSize: 32
       GoKind: 25
@@ -2368,9 +2368,9 @@ Types:
           Type: 7 BaseType int
         - Name: groups
           Offset: 16
-          Type: 153 GoSwissMapGroupsType groupReference<string,string>
+          Type: 98 GoSwissMapGroupsType groupReference<string,string>
     - __kind: StructureType
-      ID: 100
+      ID: 117
       Name: time.Location
       ByteSize: 104
       GoRuntimeType: 1.973536e+06
@@ -2381,10 +2381,10 @@ Types:
           Type: 9 GoStringHeaderType string
         - Name: zone
           Offset: 16
-          Type: 101 GoSliceHeaderType []time.zone
+          Type: 152 GoSliceHeaderType []time.zone
         - Name: tx
           Offset: 40
-          Type: 104 GoSliceHeaderType []time.zoneTrans
+          Type: 155 GoSliceHeaderType []time.zoneTrans
         - Name: extend
           Offset: 64
           Type: 9 GoStringHeaderType string
@@ -2396,9 +2396,9 @@ Types:
           Type: 12 BaseType int64
         - Name: cacheZone
           Offset: 96
-          Type: 102 PointerType *time.zone
+          Type: 153 PointerType *time.zone
     - __kind: StructureType
-      ID: 98
+      ID: 115
       Name: time.Time
       ByteSize: 24
       GoRuntimeType: 2.364704e+06
@@ -2412,9 +2412,9 @@ Types:
           Type: 12 BaseType int64
         - Name: loc
           Offset: 16
-          Type: 99 PointerType *time.Location
+          Type: 116 PointerType *time.Location
     - __kind: StructureType
-      ID: 103
+      ID: 154
       Name: time.zone
       ByteSize: 32
       GoRuntimeType: 1.613408e+06
@@ -2430,7 +2430,7 @@ Types:
           Offset: 24
           Type: 4 BaseType bool
     - __kind: StructureType
-      ID: 106
+      ID: 157
       Name: time.zoneTrans
       ByteSize: 16
       GoRuntimeType: 1.750848e+06

--- a/pkg/dyninst/irgen/testdata/snapshot/rc_tester_v1.arch=amd64,toolchain=go1.25.0.yaml
+++ b/pkg/dyninst/irgen/testdata/snapshot/rc_tester_v1.arch=amd64,toolchain=go1.25.0.yaml
@@ -10,7 +10,7 @@ Probes:
       subprogram: {subprogram: 1}
       events:
         - ID: 1
-          Type: 214 EventRootType Probe[main.HandleHTTP]
+          Type: 213 EventRootType Probe[main.HandleHTTP]
           InjectionPoints: [{PC: "0xd04e73", Frameless: false}]
           Condition: null
     - id: look_at_the_request
@@ -23,7 +23,7 @@ Probes:
       subprogram: {subprogram: 2}
       events:
         - ID: 2
-          Type: 215 EventRootType Probe[main.LookAtTheRequest]
+          Type: 214 EventRootType Probe[main.LookAtTheRequest]
           InjectionPoints: [{PC: "0xd051ee", Frameless: false}]
           Condition: null
 Subprograms:
@@ -114,147 +114,147 @@ Subprograms:
           IsReturn: false
 Types:
     - __kind: PointerType
-      ID: 83
+      ID: 108
       Name: '**crypto/x509.Certificate'
       ByteSize: 8
       GoKind: 22
-      Pointee: 84 PointerType *crypto/x509.Certificate
+      Pointee: 109 PointerType *crypto/x509.Certificate
     - __kind: PointerType
-      ID: 121
+      ID: 95
       Name: '**mime/multipart.FileHeader'
       ByteSize: 8
       GoKind: 22
-      Pointee: 122 PointerType *mime/multipart.FileHeader
+      Pointee: 96 PointerType *mime/multipart.FileHeader
     - __kind: PointerType
-      ID: 161
+      ID: 151
       Name: '**net.IPNet'
       ByteSize: 8
       GoKind: 22
-      Pointee: 162 PointerType *net.IPNet
+      Pointee: 152 PointerType *net.IPNet
     - __kind: PointerType
-      ID: 159
+      ID: 149
       Name: '**net/url.URL'
       ByteSize: 8
       GoKind: 22
-      Pointee: 42 PointerType *net/url.URL
-    - __kind: PointerType
-      ID: 79
-      Name: '**table<string,[]*mime/multipart.FileHeader>'
-      ByteSize: 8
-      Pointee: 80 PointerType *table<string,[]*mime/multipart.FileHeader>
-    - __kind: PointerType
-      ID: 47
-      Name: '**table<string,[]string>'
-      ByteSize: 8
-      Pointee: 48 PointerType *table<string,[]string>
-    - __kind: PointerType
-      ID: 66
-      Name: '**table<string,string>'
-      ByteSize: 8
-      Pointee: 67 PointerType *table<string,string>
+      Pointee: 44 PointerType *net/url.URL
     - __kind: PointerType
       ID: 86
+      Name: '**table<string,[]*mime/multipart.FileHeader>'
+      ByteSize: 8
+      Pointee: 87 PointerType *table<string,[]*mime/multipart.FileHeader>
+    - __kind: PointerType
+      ID: 49
+      Name: '**table<string,[]string>'
+      ByteSize: 8
+      Pointee: 50 PointerType *table<string,[]string>
+    - __kind: PointerType
+      ID: 68
+      Name: '**table<string,string>'
+      ByteSize: 8
+      Pointee: 69 PointerType *table<string,string>
+    - __kind: PointerType
+      ID: 111
       Name: '*[]*crypto/x509.Certificate'
       ByteSize: 8
       GoKind: 22
-      Pointee: 82 GoSliceHeaderType []*crypto/x509.Certificate
+      Pointee: 107 GoSliceHeaderType []*crypto/x509.Certificate
     - __kind: PointerType
-      ID: 126
+      ID: 118
       Name: '*[]*crypto/x509.Certificate.array'
       ByteSize: 8
-      Pointee: 125 GoSliceDataType []*crypto/x509.Certificate.array
+      Pointee: 117 GoSliceDataType []*crypto/x509.Certificate.array
     - __kind: PointerType
-      ID: 171
+      ID: 101
       Name: '*[]*mime/multipart.FileHeader.array'
       ByteSize: 8
-      Pointee: 170 GoSliceDataType []*mime/multipart.FileHeader.array
-    - __kind: PointerType
-      ID: 200
-      Name: '*[]*net.IPNet.array'
-      ByteSize: 8
-      Pointee: 199 GoSliceDataType []*net.IPNet.array
-    - __kind: PointerType
-      ID: 198
-      Name: '*[]*net/url.URL.array'
-      ByteSize: 8
-      Pointee: 197 GoSliceDataType []*net/url.URL.array
-    - __kind: PointerType
-      ID: 128
-      Name: '*[][]*crypto/x509.Certificate.array'
-      ByteSize: 8
-      Pointee: 127 GoSliceDataType [][]*crypto/x509.Certificate.array
-    - __kind: PointerType
-      ID: 130
-      Name: '*[][]uint8.array'
-      ByteSize: 8
-      Pointee: 129 GoSliceDataType [][]uint8.array
-    - __kind: PointerType
-      ID: 192
-      Name: '*[]crypto/x509.ExtKeyUsage.array'
-      ByteSize: 8
-      Pointee: 191 GoSliceDataType []crypto/x509.ExtKeyUsage.array
-    - __kind: PointerType
-      ID: 202
-      Name: '*[]crypto/x509.OID.array'
-      ByteSize: 8
-      Pointee: 201 GoSliceDataType []crypto/x509.OID.array
-    - __kind: PointerType
-      ID: 204
-      Name: '*[]crypto/x509.PolicyMapping.array'
-      ByteSize: 8
-      Pointee: 203 GoSliceDataType []crypto/x509.PolicyMapping.array
-    - __kind: PointerType
-      ID: 184
-      Name: '*[]crypto/x509/pkix.AttributeTypeAndValue.array'
-      ByteSize: 8
-      Pointee: 183 GoSliceDataType []crypto/x509/pkix.AttributeTypeAndValue.array
-    - __kind: PointerType
-      ID: 186
-      Name: '*[]crypto/x509/pkix.Extension.array'
-      ByteSize: 8
-      Pointee: 185 GoSliceDataType []crypto/x509/pkix.Extension.array
+      Pointee: 100 GoSliceDataType []*mime/multipart.FileHeader.array
     - __kind: PointerType
       ID: 188
+      Name: '*[]*net.IPNet.array'
+      ByteSize: 8
+      Pointee: 187 GoSliceDataType []*net.IPNet.array
+    - __kind: PointerType
+      ID: 185
+      Name: '*[]*net/url.URL.array'
+      ByteSize: 8
+      Pointee: 184 GoSliceDataType []*net/url.URL.array
+    - __kind: PointerType
+      ID: 120
+      Name: '*[][]*crypto/x509.Certificate.array'
+      ByteSize: 8
+      Pointee: 119 GoSliceDataType [][]*crypto/x509.Certificate.array
+    - __kind: PointerType
+      ID: 122
+      Name: '*[][]uint8.array'
+      ByteSize: 8
+      Pointee: 121 GoSliceDataType [][]uint8.array
+    - __kind: PointerType
+      ID: 181
+      Name: '*[]crypto/x509.ExtKeyUsage.array'
+      ByteSize: 8
+      Pointee: 180 GoSliceDataType []crypto/x509.ExtKeyUsage.array
+    - __kind: PointerType
+      ID: 190
+      Name: '*[]crypto/x509.OID.array'
+      ByteSize: 8
+      Pointee: 189 GoSliceDataType []crypto/x509.OID.array
+    - __kind: PointerType
+      ID: 192
+      Name: '*[]crypto/x509.PolicyMapping.array'
+      ByteSize: 8
+      Pointee: 191 GoSliceDataType []crypto/x509.PolicyMapping.array
+    - __kind: PointerType
+      ID: 165
+      Name: '*[]crypto/x509/pkix.AttributeTypeAndValue.array'
+      ByteSize: 8
+      Pointee: 164 GoSliceDataType []crypto/x509/pkix.AttributeTypeAndValue.array
+    - __kind: PointerType
+      ID: 177
+      Name: '*[]crypto/x509/pkix.Extension.array'
+      ByteSize: 8
+      Pointee: 176 GoSliceDataType []crypto/x509/pkix.Extension.array
+    - __kind: PointerType
+      ID: 179
       Name: '*[]encoding/asn1.ObjectIdentifier.array'
       ByteSize: 8
-      Pointee: 187 GoSliceDataType []encoding/asn1.ObjectIdentifier.array
+      Pointee: 178 GoSliceDataType []encoding/asn1.ObjectIdentifier.array
     - __kind: PointerType
-      ID: 194
+      ID: 183
       Name: '*[]net.IP.array'
       ByteSize: 8
-      Pointee: 193 GoSliceDataType []net.IP.array
+      Pointee: 182 GoSliceDataType []net.IP.array
     - __kind: PointerType
-      ID: 132
+      ID: 204
       Name: '*[]net/http.segment.array'
       ByteSize: 8
-      Pointee: 131 GoSliceDataType []net/http.segment.array
+      Pointee: 203 GoSliceDataType []net/http.segment.array
     - __kind: PointerType
-      ID: 103
+      ID: 81
       Name: '*[]string.array'
       ByteSize: 8
-      Pointee: 102 GoSliceDataType []string.array
+      Pointee: 80 GoSliceDataType []string.array
     - __kind: PointerType
-      ID: 209
+      ID: 173
       Name: '*[]time.zone.array'
       ByteSize: 8
-      Pointee: 208 GoSliceDataType []time.zone.array
+      Pointee: 172 GoSliceDataType []time.zone.array
     - __kind: PointerType
-      ID: 211
+      ID: 175
       Name: '*[]time.zoneTrans.array'
       ByteSize: 8
-      Pointee: 210 GoSliceDataType []time.zoneTrans.array
+      Pointee: 174 GoSliceDataType []time.zoneTrans.array
     - __kind: PointerType
-      ID: 88
+      ID: 113
       Name: '*[]uint8'
       ByteSize: 8
       GoRuntimeType: 481600
       GoKind: 22
-      Pointee: 68 GoSliceHeaderType []uint8
+      Pointee: 103 GoSliceHeaderType []uint8
     - __kind: PointerType
-      ID: 112
+      ID: 105
       Name: '*[]uint8.array'
       ByteSize: 8
-      Pointee: 111 GoSliceDataType []uint8.array
+      Pointee: 104 GoSliceDataType []uint8.array
     - __kind: PointerType
       ID: 11
       Name: '*bool'
@@ -268,68 +268,68 @@ Types:
       ByteSize: 8
       GoRuntimeType: 2.260704e+06
       GoKind: 22
-      Pointee: 40 StructureType bytes.Buffer
+      Pointee: 40 UnresolvedPointeeType bytes.Buffer
     - __kind: PointerType
-      ID: 55
+      ID: 57
       Name: '*crypto/tls.ConnectionState'
       ByteSize: 8
       GoRuntimeType: 908352
       GoKind: 22
-      Pointee: 56 StructureType crypto/tls.ConnectionState
+      Pointee: 58 StructureType crypto/tls.ConnectionState
     - __kind: PointerType
-      ID: 84
+      ID: 109
       Name: '*crypto/x509.Certificate'
       ByteSize: 8
       GoRuntimeType: 2.043968e+06
       GoKind: 22
-      Pointee: 114 StructureType crypto/x509.Certificate
+      Pointee: 116 StructureType crypto/x509.Certificate
     - __kind: PointerType
-      ID: 153
+      ID: 143
       Name: '*crypto/x509.ExtKeyUsage'
       ByteSize: 8
       GoRuntimeType: 423552
       GoKind: 22
-      Pointee: 154 BaseType crypto/x509.ExtKeyUsage
+      Pointee: 144 BaseType crypto/x509.ExtKeyUsage
     - __kind: PointerType
-      ID: 164
+      ID: 154
       Name: '*crypto/x509.OID'
       ByteSize: 8
       GoRuntimeType: 1.954336e+06
       GoKind: 22
-      Pointee: 165 StructureType crypto/x509.OID
+      Pointee: 155 StructureType crypto/x509.OID
     - __kind: PointerType
-      ID: 167
+      ID: 157
       Name: '*crypto/x509.PolicyMapping'
       ByteSize: 8
       GoRuntimeType: 423616
       GoKind: 22
-      Pointee: 168 StructureType crypto/x509.PolicyMapping
+      Pointee: 158 StructureType crypto/x509.PolicyMapping
     - __kind: PointerType
-      ID: 140
+      ID: 130
       Name: '*crypto/x509/pkix.AttributeTypeAndValue'
       ByteSize: 8
       GoRuntimeType: 437312
       GoKind: 22
-      Pointee: 141 StructureType crypto/x509/pkix.AttributeTypeAndValue
+      Pointee: 131 StructureType crypto/x509/pkix.AttributeTypeAndValue
     - __kind: PointerType
-      ID: 147
+      ID: 137
       Name: '*crypto/x509/pkix.Extension'
       ByteSize: 8
       GoRuntimeType: 437504
       GoKind: 22
-      Pointee: 148 StructureType crypto/x509/pkix.Extension
+      Pointee: 138 StructureType crypto/x509/pkix.Extension
     - __kind: PointerType
-      ID: 150
+      ID: 140
       Name: '*encoding/asn1.ObjectIdentifier'
       ByteSize: 8
       GoRuntimeType: 1.053408e+06
       GoKind: 22
-      Pointee: 151 GoSliceHeaderType encoding/asn1.ObjectIdentifier
+      Pointee: 141 GoSliceHeaderType encoding/asn1.ObjectIdentifier
     - __kind: PointerType
-      ID: 190
+      ID: 194
       Name: '*encoding/asn1.ObjectIdentifier.array'
       ByteSize: 8
-      Pointee: 189 GoSliceDataType encoding/asn1.ObjectIdentifier.array
+      Pointee: 193 GoSliceDataType encoding/asn1.ObjectIdentifier.array
     - __kind: PointerType
       ID: 33
       Name: '*error'
@@ -387,77 +387,77 @@ Types:
       GoKind: 22
       Pointee: 16 BaseType int8
     - __kind: PointerType
-      ID: 77
+      ID: 84
       Name: '*map<string,[]*mime/multipart.FileHeader>'
       ByteSize: 8
-      Pointee: 78 GoSwissMapHeaderType map<string,[]*mime/multipart.FileHeader>
+      Pointee: 85 GoSwissMapHeaderType map<string,[]*mime/multipart.FileHeader>
     - __kind: PointerType
-      ID: 45
+      ID: 47
       Name: '*map<string,[]string>'
       ByteSize: 8
-      Pointee: 46 GoSwissMapHeaderType map<string,[]string>
+      Pointee: 48 GoSwissMapHeaderType map<string,[]string>
     - __kind: PointerType
-      ID: 64
+      ID: 66
       Name: '*map<string,string>'
       ByteSize: 8
-      Pointee: 65 GoSwissMapHeaderType map<string,string>
+      Pointee: 67 GoSwissMapHeaderType map<string,string>
     - __kind: PointerType
-      ID: 136
+      ID: 126
       Name: '*math/big.Int'
       ByteSize: 8
       GoRuntimeType: 2.382336e+06
       GoKind: 22
-      Pointee: 137 StructureType math/big.Int
+      Pointee: 127 StructureType math/big.Int
     - __kind: PointerType
-      ID: 173
+      ID: 160
       Name: '*math/big.Word'
       ByteSize: 8
       GoRuntimeType: 426432
       GoKind: 22
-      Pointee: 174 BaseType math/big.Word
+      Pointee: 161 BaseType math/big.Word
     - __kind: PointerType
-      ID: 207
+      ID: 163
       Name: '*math/big.nat.array'
       ByteSize: 8
-      Pointee: 206 GoSliceDataType math/big.nat.array
+      Pointee: 162 GoSliceDataType math/big.nat.array
     - __kind: PointerType
-      ID: 122
+      ID: 96
       Name: '*mime/multipart.FileHeader'
       ByteSize: 8
       GoRuntimeType: 909888
       GoKind: 22
-      Pointee: 169 StructureType mime/multipart.FileHeader
+      Pointee: 99 StructureType mime/multipart.FileHeader
     - __kind: PointerType
-      ID: 53
+      ID: 55
       Name: '*mime/multipart.Form'
       ByteSize: 8
       GoRuntimeType: 909984
       GoKind: 22
-      Pointee: 54 StructureType mime/multipart.Form
+      Pointee: 56 StructureType mime/multipart.Form
     - __kind: PointerType
-      ID: 156
+      ID: 146
       Name: '*net.IP'
       ByteSize: 8
       GoRuntimeType: 2.150176e+06
       GoKind: 22
-      Pointee: 157 GoSliceHeaderType net.IP
+      Pointee: 147 GoSliceHeaderType net.IP
     - __kind: PointerType
       ID: 196
       Name: '*net.IP.array'
       ByteSize: 8
       Pointee: 195 GoSliceDataType net.IP.array
     - __kind: PointerType
-      ID: 213
+      ID: 199
       Name: '*net.IPMask.array'
       ByteSize: 8
-      Pointee: 212 GoSliceDataType net.IPMask.array
+      Pointee: 198 GoSliceDataType net.IPMask.array
     - __kind: PointerType
-      ID: 162
+      ID: 152
       Name: '*net.IPNet'
       ByteSize: 8
       GoRuntimeType: 1.18336e+06
       GoKind: 22
-      Pointee: 181 StructureType net.IPNet
+      Pointee: 186 StructureType net.IPNet
     - __kind: PointerType
       ID: 37
       Name: '*net/http.Request'
@@ -466,55 +466,55 @@ Types:
       GoKind: 22
       Pointee: 38 StructureType net/http.Request
     - __kind: PointerType
-      ID: 58
+      ID: 60
       Name: '*net/http.Response'
       ByteSize: 8
       GoRuntimeType: 1.718816e+06
       GoKind: 22
-      Pointee: 59 StructureType net/http.Response
+      Pointee: 61 StructureType net/http.Response
     - __kind: PointerType
-      ID: 61
+      ID: 63
       Name: '*net/http.pattern'
       ByteSize: 8
       GoRuntimeType: 1.608608e+06
       GoKind: 22
-      Pointee: 62 StructureType net/http.pattern
+      Pointee: 64 StructureType net/http.pattern
     - __kind: PointerType
-      ID: 92
+      ID: 201
       Name: '*net/http.segment'
       ByteSize: 8
       GoRuntimeType: 391808
       GoKind: 22
-      Pointee: 93 StructureType net/http.segment
+      Pointee: 202 StructureType net/http.segment
     - __kind: PointerType
-      ID: 42
+      ID: 44
       Name: '*net/url.URL'
       ByteSize: 8
       GoRuntimeType: 2.1136e+06
       GoKind: 22
-      Pointee: 43 StructureType net/url.URL
+      Pointee: 45 StructureType net/url.URL
     - __kind: PointerType
-      ID: 72
+      ID: 70
       Name: '*net/url.Userinfo'
       ByteSize: 8
       GoRuntimeType: 1.200768e+06
       GoKind: 22
-      Pointee: 73 StructureType net/url.Userinfo
+      Pointee: 71 StructureType net/url.Userinfo
     - __kind: PointerType
-      ID: 116
+      ID: 90
       Name: '*noalg.map.group[string][]*mime/multipart.FileHeader'
       ByteSize: 8
-      Pointee: 117 StructureType noalg.map.group[string][]*mime/multipart.FileHeader
+      Pointee: 91 StructureType noalg.map.group[string][]*mime/multipart.FileHeader
     - __kind: PointerType
-      ID: 96
+      ID: 74
       Name: '*noalg.map.group[string][]string'
       ByteSize: 8
-      Pointee: 97 StructureType noalg.map.group[string][]string
+      Pointee: 75 StructureType noalg.map.group[string][]string
     - __kind: PointerType
-      ID: 105
+      ID: 207
       Name: '*noalg.map.group[string]string'
       ByteSize: 8
-      Pointee: 106 StructureType noalg.map.group[string]string
+      Pointee: 208 StructureType noalg.map.group[string]string
     - __kind: PointerType
       ID: 22
       Name: '*string'
@@ -523,46 +523,46 @@ Types:
       GoKind: 22
       Pointee: 9 GoStringHeaderType string
     - __kind: PointerType
-      ID: 71
+      ID: 43
       Name: '*string.str'
       ByteSize: 8
-      Pointee: 70 GoStringDataType string.str
+      Pointee: 42 GoStringDataType string.str
     - __kind: PointerType
-      ID: 80
+      ID: 87
       Name: '*table<string,[]*mime/multipart.FileHeader>'
       ByteSize: 8
-      Pointee: 113 StructureType table<string,[]*mime/multipart.FileHeader>
+      Pointee: 88 StructureType table<string,[]*mime/multipart.FileHeader>
     - __kind: PointerType
-      ID: 48
+      ID: 50
       Name: '*table<string,[]string>'
       ByteSize: 8
-      Pointee: 74 StructureType table<string,[]string>
+      Pointee: 72 StructureType table<string,[]string>
     - __kind: PointerType
-      ID: 67
+      ID: 69
       Name: '*table<string,string>'
       ByteSize: 8
-      Pointee: 94 StructureType table<string,string>
+      Pointee: 205 StructureType table<string,string>
     - __kind: PointerType
-      ID: 143
+      ID: 133
       Name: '*time.Location'
       ByteSize: 8
       GoRuntimeType: 1.6136e+06
       GoKind: 22
-      Pointee: 144 StructureType time.Location
+      Pointee: 134 StructureType time.Location
     - __kind: PointerType
-      ID: 176
+      ID: 167
       Name: '*time.zone'
       ByteSize: 8
       GoRuntimeType: 394880
       GoKind: 22
-      Pointee: 177 StructureType time.zone
+      Pointee: 168 StructureType time.zone
     - __kind: PointerType
-      ID: 179
+      ID: 170
       Name: '*time.zoneTrans'
       ByteSize: 8
       GoRuntimeType: 394944
       GoKind: 22
-      Pointee: 180 StructureType time.zoneTrans
+      Pointee: 171 StructureType time.zoneTrans
     - __kind: PointerType
       ID: 34
       Name: '*uint'
@@ -606,12 +606,12 @@ Types:
       GoKind: 22
       Pointee: 1 BaseType uintptr
     - __kind: GoChannelType
-      ID: 57
+      ID: 59
       Name: <-chan struct {}
       GoRuntimeType: 597696
       GoKind: 18
     - __kind: EventRootType
-      ID: 214
+      ID: 213
       Name: Probe[main.HandleHTTP]
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -635,7 +635,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 215
+      ID: 214
       Name: Probe[main.LookAtTheRequest]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -650,7 +650,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: GoSliceHeaderType
-      ID: 82
+      ID: 107
       Name: '[]*crypto/x509.Certificate'
       ByteSize: 24
       GoRuntimeType: 502496
@@ -658,21 +658,21 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 83 PointerType **crypto/x509.Certificate
+          Type: 108 PointerType **crypto/x509.Certificate
         - Name: len
           Offset: 8
           Type: 7 BaseType int
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 125 GoSliceDataType []*crypto/x509.Certificate.array
+      Data: 117 GoSliceDataType []*crypto/x509.Certificate.array
     - __kind: GoSliceDataType
-      ID: 125
+      ID: 117
       Name: '[]*crypto/x509.Certificate.array'
       ByteSize: 2048
-      Element: 84 PointerType *crypto/x509.Certificate
+      Element: 109 PointerType *crypto/x509.Certificate
     - __kind: GoSliceHeaderType
-      ID: 120
+      ID: 94
       Name: '[]*mime/multipart.FileHeader'
       ByteSize: 24
       GoRuntimeType: 487328
@@ -680,21 +680,21 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 121 PointerType **mime/multipart.FileHeader
+          Type: 95 PointerType **mime/multipart.FileHeader
         - Name: len
           Offset: 8
           Type: 7 BaseType int
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 170 GoSliceDataType []*mime/multipart.FileHeader.array
+      Data: 100 GoSliceDataType []*mime/multipart.FileHeader.array
     - __kind: GoSliceDataType
-      ID: 170
+      ID: 100
       Name: '[]*mime/multipart.FileHeader.array'
       ByteSize: 2048
-      Element: 122 PointerType *mime/multipart.FileHeader
+      Element: 96 PointerType *mime/multipart.FileHeader
     - __kind: GoSliceHeaderType
-      ID: 160
+      ID: 150
       Name: '[]*net.IPNet'
       ByteSize: 24
       GoRuntimeType: 504096
@@ -702,21 +702,21 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 161 PointerType **net.IPNet
+          Type: 151 PointerType **net.IPNet
         - Name: len
           Offset: 8
           Type: 7 BaseType int
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 199 GoSliceDataType []*net.IPNet.array
+      Data: 187 GoSliceDataType []*net.IPNet.array
     - __kind: GoSliceDataType
-      ID: 199
+      ID: 187
       Name: '[]*net.IPNet.array'
       ByteSize: 2048
-      Element: 162 PointerType *net.IPNet
+      Element: 152 PointerType *net.IPNet
     - __kind: GoSliceHeaderType
-      ID: 158
+      ID: 148
       Name: '[]*net/url.URL'
       ByteSize: 24
       GoRuntimeType: 504032
@@ -724,36 +724,36 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 159 PointerType **net/url.URL
+          Type: 149 PointerType **net/url.URL
         - Name: len
           Offset: 8
           Type: 7 BaseType int
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 197 GoSliceDataType []*net/url.URL.array
+      Data: 184 GoSliceDataType []*net/url.URL.array
     - __kind: GoSliceDataType
-      ID: 197
+      ID: 184
       Name: '[]*net/url.URL.array'
       ByteSize: 2048
-      Element: 42 PointerType *net/url.URL
+      Element: 44 PointerType *net/url.URL
     - __kind: GoSliceDataType
-      ID: 123
+      ID: 97
       Name: '[]*table<string,[]*mime/multipart.FileHeader>.array'
       ByteSize: 8192
-      Element: 80 PointerType *table<string,[]*mime/multipart.FileHeader>
+      Element: 87 PointerType *table<string,[]*mime/multipart.FileHeader>
     - __kind: GoSliceDataType
-      ID: 100
+      ID: 78
       Name: '[]*table<string,[]string>.array'
       ByteSize: 8192
-      Element: 48 PointerType *table<string,[]string>
+      Element: 50 PointerType *table<string,[]string>
     - __kind: GoSliceDataType
-      ID: 109
+      ID: 211
       Name: '[]*table<string,string>.array'
       ByteSize: 8192
-      Element: 67 PointerType *table<string,string>
+      Element: 69 PointerType *table<string,string>
     - __kind: GoSliceHeaderType
-      ID: 85
+      ID: 110
       Name: '[][]*crypto/x509.Certificate'
       ByteSize: 24
       GoRuntimeType: 502560
@@ -761,21 +761,21 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 86 PointerType *[]*crypto/x509.Certificate
+          Type: 111 PointerType *[]*crypto/x509.Certificate
         - Name: len
           Offset: 8
           Type: 7 BaseType int
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 127 GoSliceDataType [][]*crypto/x509.Certificate.array
+      Data: 119 GoSliceDataType [][]*crypto/x509.Certificate.array
     - __kind: GoSliceDataType
-      ID: 127
+      ID: 119
       Name: '[][]*crypto/x509.Certificate.array'
       ByteSize: 2048
-      Element: 82 GoSliceHeaderType []*crypto/x509.Certificate
+      Element: 107 GoSliceHeaderType []*crypto/x509.Certificate
     - __kind: GoSliceHeaderType
-      ID: 87
+      ID: 112
       Name: '[][]uint8'
       ByteSize: 24
       GoRuntimeType: 481920
@@ -783,21 +783,21 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 88 PointerType *[]uint8
+          Type: 113 PointerType *[]uint8
         - Name: len
           Offset: 8
           Type: 7 BaseType int
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 129 GoSliceDataType [][]uint8.array
+      Data: 121 GoSliceDataType [][]uint8.array
     - __kind: GoSliceDataType
-      ID: 129
+      ID: 121
       Name: '[][]uint8.array'
       ByteSize: 2048
-      Element: 68 GoSliceHeaderType []uint8
+      Element: 103 GoSliceHeaderType []uint8
     - __kind: GoSliceHeaderType
-      ID: 152
+      ID: 142
       Name: '[]crypto/x509.ExtKeyUsage'
       ByteSize: 24
       GoRuntimeType: 503968
@@ -805,21 +805,21 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 153 PointerType *crypto/x509.ExtKeyUsage
+          Type: 143 PointerType *crypto/x509.ExtKeyUsage
         - Name: len
           Offset: 8
           Type: 7 BaseType int
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 191 GoSliceDataType []crypto/x509.ExtKeyUsage.array
+      Data: 180 GoSliceDataType []crypto/x509.ExtKeyUsage.array
     - __kind: GoSliceDataType
-      ID: 191
+      ID: 180
       Name: '[]crypto/x509.ExtKeyUsage.array'
       ByteSize: 2048
-      Element: 154 BaseType crypto/x509.ExtKeyUsage
+      Element: 144 BaseType crypto/x509.ExtKeyUsage
     - __kind: GoSliceHeaderType
-      ID: 163
+      ID: 153
       Name: '[]crypto/x509.OID'
       ByteSize: 24
       GoRuntimeType: 504160
@@ -827,21 +827,21 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 164 PointerType *crypto/x509.OID
+          Type: 154 PointerType *crypto/x509.OID
         - Name: len
           Offset: 8
           Type: 7 BaseType int
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 201 GoSliceDataType []crypto/x509.OID.array
+      Data: 189 GoSliceDataType []crypto/x509.OID.array
     - __kind: GoSliceDataType
-      ID: 201
+      ID: 189
       Name: '[]crypto/x509.OID.array'
       ByteSize: 2048
-      Element: 165 StructureType crypto/x509.OID
+      Element: 155 StructureType crypto/x509.OID
     - __kind: GoSliceHeaderType
-      ID: 166
+      ID: 156
       Name: '[]crypto/x509.PolicyMapping'
       ByteSize: 24
       GoRuntimeType: 504224
@@ -849,21 +849,21 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 167 PointerType *crypto/x509.PolicyMapping
+          Type: 157 PointerType *crypto/x509.PolicyMapping
         - Name: len
           Offset: 8
           Type: 7 BaseType int
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 203 GoSliceDataType []crypto/x509.PolicyMapping.array
+      Data: 191 GoSliceDataType []crypto/x509.PolicyMapping.array
     - __kind: GoSliceDataType
-      ID: 203
+      ID: 191
       Name: '[]crypto/x509.PolicyMapping.array'
       ByteSize: 2048
-      Element: 168 StructureType crypto/x509.PolicyMapping
+      Element: 158 StructureType crypto/x509.PolicyMapping
     - __kind: GoSliceHeaderType
-      ID: 139
+      ID: 129
       Name: '[]crypto/x509/pkix.AttributeTypeAndValue'
       ByteSize: 24
       GoRuntimeType: 517440
@@ -871,21 +871,21 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 140 PointerType *crypto/x509/pkix.AttributeTypeAndValue
+          Type: 130 PointerType *crypto/x509/pkix.AttributeTypeAndValue
         - Name: len
           Offset: 8
           Type: 7 BaseType int
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 183 GoSliceDataType []crypto/x509/pkix.AttributeTypeAndValue.array
+      Data: 164 GoSliceDataType []crypto/x509/pkix.AttributeTypeAndValue.array
     - __kind: GoSliceDataType
-      ID: 183
+      ID: 164
       Name: '[]crypto/x509/pkix.AttributeTypeAndValue.array'
       ByteSize: 2048
-      Element: 141 StructureType crypto/x509/pkix.AttributeTypeAndValue
+      Element: 131 StructureType crypto/x509/pkix.AttributeTypeAndValue
     - __kind: GoSliceHeaderType
-      ID: 146
+      ID: 136
       Name: '[]crypto/x509/pkix.Extension'
       ByteSize: 24
       GoRuntimeType: 503840
@@ -893,21 +893,21 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 147 PointerType *crypto/x509/pkix.Extension
+          Type: 137 PointerType *crypto/x509/pkix.Extension
         - Name: len
           Offset: 8
           Type: 7 BaseType int
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 185 GoSliceDataType []crypto/x509/pkix.Extension.array
+      Data: 176 GoSliceDataType []crypto/x509/pkix.Extension.array
     - __kind: GoSliceDataType
-      ID: 185
+      ID: 176
       Name: '[]crypto/x509/pkix.Extension.array'
       ByteSize: 2048
-      Element: 148 StructureType crypto/x509/pkix.Extension
+      Element: 138 StructureType crypto/x509/pkix.Extension
     - __kind: GoSliceHeaderType
-      ID: 149
+      ID: 139
       Name: '[]encoding/asn1.ObjectIdentifier'
       ByteSize: 24
       GoRuntimeType: 503904
@@ -915,21 +915,21 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 150 PointerType *encoding/asn1.ObjectIdentifier
+          Type: 140 PointerType *encoding/asn1.ObjectIdentifier
         - Name: len
           Offset: 8
           Type: 7 BaseType int
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 187 GoSliceDataType []encoding/asn1.ObjectIdentifier.array
+      Data: 178 GoSliceDataType []encoding/asn1.ObjectIdentifier.array
     - __kind: GoSliceDataType
-      ID: 187
+      ID: 178
       Name: '[]encoding/asn1.ObjectIdentifier.array'
       ByteSize: 2048
-      Element: 151 GoSliceHeaderType encoding/asn1.ObjectIdentifier
+      Element: 141 GoSliceHeaderType encoding/asn1.ObjectIdentifier
     - __kind: GoSliceHeaderType
-      ID: 155
+      ID: 145
       Name: '[]net.IP'
       ByteSize: 24
       GoRuntimeType: 482944
@@ -937,21 +937,21 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 156 PointerType *net.IP
+          Type: 146 PointerType *net.IP
         - Name: len
           Offset: 8
           Type: 7 BaseType int
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 193 GoSliceDataType []net.IP.array
+      Data: 182 GoSliceDataType []net.IP.array
     - __kind: GoSliceDataType
-      ID: 193
+      ID: 182
       Name: '[]net.IP.array'
       ByteSize: 2048
-      Element: 157 GoSliceHeaderType net.IP
+      Element: 147 GoSliceHeaderType net.IP
     - __kind: GoSliceHeaderType
-      ID: 91
+      ID: 200
       Name: '[]net/http.segment'
       ByteSize: 24
       GoRuntimeType: 484640
@@ -959,36 +959,36 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 92 PointerType *net/http.segment
+          Type: 201 PointerType *net/http.segment
         - Name: len
           Offset: 8
           Type: 7 BaseType int
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 131 GoSliceDataType []net/http.segment.array
+      Data: 203 GoSliceDataType []net/http.segment.array
     - __kind: GoSliceDataType
-      ID: 131
+      ID: 203
       Name: '[]net/http.segment.array'
       ByteSize: 2048
-      Element: 93 StructureType net/http.segment
+      Element: 202 StructureType net/http.segment
     - __kind: GoSliceDataType
-      ID: 124
+      ID: 98
       Name: '[]noalg.map.group[string][]*mime/multipart.FileHeader.array'
       ByteSize: 2048
-      Element: 117 StructureType noalg.map.group[string][]*mime/multipart.FileHeader
+      Element: 91 StructureType noalg.map.group[string][]*mime/multipart.FileHeader
     - __kind: GoSliceDataType
-      ID: 101
+      ID: 79
       Name: '[]noalg.map.group[string][]string.array'
       ByteSize: 2048
-      Element: 97 StructureType noalg.map.group[string][]string
+      Element: 75 StructureType noalg.map.group[string][]string
     - __kind: GoSliceDataType
-      ID: 110
+      ID: 212
       Name: '[]noalg.map.group[string]string.array'
       ByteSize: 2048
-      Element: 106 StructureType noalg.map.group[string]string
+      Element: 208 StructureType noalg.map.group[string]string
     - __kind: GoSliceHeaderType
-      ID: 51
+      ID: 53
       Name: '[]string'
       ByteSize: 24
       GoRuntimeType: 496448
@@ -1003,14 +1003,14 @@ Types:
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 102 GoSliceDataType []string.array
+      Data: 80 GoSliceDataType []string.array
     - __kind: GoSliceDataType
-      ID: 102
+      ID: 80
       Name: '[]string.array'
       ByteSize: 2048
       Element: 9 GoStringHeaderType string
     - __kind: GoSliceHeaderType
-      ID: 175
+      ID: 166
       Name: '[]time.zone'
       ByteSize: 24
       GoRuntimeType: 489504
@@ -1018,21 +1018,21 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 176 PointerType *time.zone
+          Type: 167 PointerType *time.zone
         - Name: len
           Offset: 8
           Type: 7 BaseType int
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 208 GoSliceDataType []time.zone.array
+      Data: 172 GoSliceDataType []time.zone.array
     - __kind: GoSliceDataType
-      ID: 208
+      ID: 172
       Name: '[]time.zone.array'
       ByteSize: 2048
-      Element: 177 StructureType time.zone
+      Element: 168 StructureType time.zone
     - __kind: GoSliceHeaderType
-      ID: 178
+      ID: 169
       Name: '[]time.zoneTrans'
       ByteSize: 24
       GoRuntimeType: 489568
@@ -1040,21 +1040,21 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 179 PointerType *time.zoneTrans
+          Type: 170 PointerType *time.zoneTrans
         - Name: len
           Offset: 8
           Type: 7 BaseType int
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 210 GoSliceDataType []time.zoneTrans.array
+      Data: 174 GoSliceDataType []time.zoneTrans.array
     - __kind: GoSliceDataType
-      ID: 210
+      ID: 174
       Name: '[]time.zoneTrans.array'
       ByteSize: 2048
-      Element: 180 StructureType time.zoneTrans
+      Element: 171 StructureType time.zoneTrans
     - __kind: GoSliceHeaderType
-      ID: 68
+      ID: 103
       Name: '[]uint8'
       ByteSize: 24
       GoRuntimeType: 495296
@@ -1069,9 +1069,9 @@ Types:
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 111 GoSliceDataType []uint8.array
+      Data: 104 GoSliceDataType []uint8.array
     - __kind: GoSliceDataType
-      ID: 111
+      ID: 104
       Name: '[]uint8.array'
       ByteSize: 2048
       Element: 3 BaseType uint8
@@ -1081,28 +1081,10 @@ Types:
       ByteSize: 1
       GoRuntimeType: 585472
       GoKind: 1
-    - __kind: StructureType
+    - __kind: UnresolvedPointeeType
       ID: 40
       Name: bytes.Buffer
-      ByteSize: 40
-      GoRuntimeType: 1.606304e+06
-      GoKind: 25
-      RawFields:
-        - Name: buf
-          Offset: 0
-          Type: 68 GoSliceHeaderType []uint8
-        - Name: off
-          Offset: 24
-          Type: 7 BaseType int
-        - Name: lastRead
-          Offset: 32
-          Type: 69 BaseType bytes.readOp
-    - __kind: BaseType
-      ID: 69
-      Name: bytes.readOp
-      ByteSize: 1
-      GoRuntimeType: 583680
-      GoKind: 3
+      ByteSize: 8
     - __kind: BaseType
       ID: 24
       Name: complex128
@@ -1116,7 +1098,7 @@ Types:
       GoRuntimeType: 585216
       GoKind: 15
     - __kind: GoInterfaceType
-      ID: 60
+      ID: 62
       Name: context.Context
       ByteSize: 16
       GoRuntimeType: 1.276992e+06
@@ -1129,7 +1111,7 @@ Types:
           Offset: 8
           Type: 14 VoidPointerType unsafe.Pointer
     - __kind: StructureType
-      ID: 56
+      ID: 58
       Name: crypto/tls.ConnectionState
       ByteSize: 192
       GoRuntimeType: 2.262752e+06
@@ -1149,7 +1131,7 @@ Types:
           Type: 6 BaseType uint16
         - Name: CurveID
           Offset: 6
-          Type: 81 BaseType crypto/tls.CurveID
+          Type: 106 BaseType crypto/tls.CurveID
         - Name: NegotiatedProtocol
           Offset: 8
           Type: 9 GoStringHeaderType string
@@ -1161,45 +1143,45 @@ Types:
           Type: 9 GoStringHeaderType string
         - Name: PeerCertificates
           Offset: 48
-          Type: 82 GoSliceHeaderType []*crypto/x509.Certificate
+          Type: 107 GoSliceHeaderType []*crypto/x509.Certificate
         - Name: VerifiedChains
           Offset: 72
-          Type: 85 GoSliceHeaderType [][]*crypto/x509.Certificate
+          Type: 110 GoSliceHeaderType [][]*crypto/x509.Certificate
         - Name: SignedCertificateTimestamps
           Offset: 96
-          Type: 87 GoSliceHeaderType [][]uint8
+          Type: 112 GoSliceHeaderType [][]uint8
         - Name: OCSPResponse
           Offset: 120
-          Type: 68 GoSliceHeaderType []uint8
+          Type: 103 GoSliceHeaderType []uint8
         - Name: TLSUnique
           Offset: 144
-          Type: 68 GoSliceHeaderType []uint8
+          Type: 103 GoSliceHeaderType []uint8
         - Name: ECHAccepted
           Offset: 168
           Type: 4 BaseType bool
         - Name: ekm
           Offset: 176
-          Type: 89 GoSubroutineType func(string, []uint8, int) ([]uint8, error)
+          Type: 114 GoSubroutineType func(string, []uint8, int) ([]uint8, error)
         - Name: testingOnlyDidHRR
           Offset: 184
           Type: 4 BaseType bool
         - Name: testingOnlyPeerSignatureAlgorithm
           Offset: 186
-          Type: 90 BaseType crypto/tls.SignatureScheme
+          Type: 115 BaseType crypto/tls.SignatureScheme
     - __kind: BaseType
-      ID: 81
+      ID: 106
       Name: crypto/tls.CurveID
       ByteSize: 2
       GoRuntimeType: 835040
       GoKind: 9
     - __kind: BaseType
-      ID: 90
+      ID: 115
       Name: crypto/tls.SignatureScheme
       ByteSize: 2
       GoRuntimeType: 835136
       GoKind: 9
     - __kind: StructureType
-      ID: 114
+      ID: 116
       Name: crypto/x509.Certificate
       ByteSize: 1424
       GoRuntimeType: 2.3936e+06
@@ -1207,67 +1189,67 @@ Types:
       RawFields:
         - Name: Raw
           Offset: 0
-          Type: 68 GoSliceHeaderType []uint8
+          Type: 103 GoSliceHeaderType []uint8
         - Name: RawTBSCertificate
           Offset: 24
-          Type: 68 GoSliceHeaderType []uint8
+          Type: 103 GoSliceHeaderType []uint8
         - Name: RawSubjectPublicKeyInfo
           Offset: 48
-          Type: 68 GoSliceHeaderType []uint8
+          Type: 103 GoSliceHeaderType []uint8
         - Name: RawSubject
           Offset: 72
-          Type: 68 GoSliceHeaderType []uint8
+          Type: 103 GoSliceHeaderType []uint8
         - Name: RawIssuer
           Offset: 96
-          Type: 68 GoSliceHeaderType []uint8
+          Type: 103 GoSliceHeaderType []uint8
         - Name: Signature
           Offset: 120
-          Type: 68 GoSliceHeaderType []uint8
+          Type: 103 GoSliceHeaderType []uint8
         - Name: SignatureAlgorithm
           Offset: 144
-          Type: 133 BaseType crypto/x509.SignatureAlgorithm
+          Type: 123 BaseType crypto/x509.SignatureAlgorithm
         - Name: PublicKeyAlgorithm
           Offset: 152
-          Type: 134 BaseType crypto/x509.PublicKeyAlgorithm
+          Type: 124 BaseType crypto/x509.PublicKeyAlgorithm
         - Name: PublicKey
           Offset: 160
-          Type: 135 GoEmptyInterfaceType interface {}
+          Type: 125 GoEmptyInterfaceType interface {}
         - Name: Version
           Offset: 176
           Type: 7 BaseType int
         - Name: SerialNumber
           Offset: 184
-          Type: 136 PointerType *math/big.Int
+          Type: 126 PointerType *math/big.Int
         - Name: Issuer
           Offset: 192
-          Type: 138 StructureType crypto/x509/pkix.Name
+          Type: 128 StructureType crypto/x509/pkix.Name
         - Name: Subject
           Offset: 440
-          Type: 138 StructureType crypto/x509/pkix.Name
+          Type: 128 StructureType crypto/x509/pkix.Name
         - Name: NotBefore
           Offset: 688
-          Type: 142 StructureType time.Time
+          Type: 132 StructureType time.Time
         - Name: NotAfter
           Offset: 712
-          Type: 142 StructureType time.Time
+          Type: 132 StructureType time.Time
         - Name: KeyUsage
           Offset: 736
-          Type: 145 BaseType crypto/x509.KeyUsage
+          Type: 135 BaseType crypto/x509.KeyUsage
         - Name: Extensions
           Offset: 744
-          Type: 146 GoSliceHeaderType []crypto/x509/pkix.Extension
+          Type: 136 GoSliceHeaderType []crypto/x509/pkix.Extension
         - Name: ExtraExtensions
           Offset: 768
-          Type: 146 GoSliceHeaderType []crypto/x509/pkix.Extension
+          Type: 136 GoSliceHeaderType []crypto/x509/pkix.Extension
         - Name: UnhandledCriticalExtensions
           Offset: 792
-          Type: 149 GoSliceHeaderType []encoding/asn1.ObjectIdentifier
+          Type: 139 GoSliceHeaderType []encoding/asn1.ObjectIdentifier
         - Name: ExtKeyUsage
           Offset: 816
-          Type: 152 GoSliceHeaderType []crypto/x509.ExtKeyUsage
+          Type: 142 GoSliceHeaderType []crypto/x509.ExtKeyUsage
         - Name: UnknownExtKeyUsage
           Offset: 840
-          Type: 149 GoSliceHeaderType []encoding/asn1.ObjectIdentifier
+          Type: 139 GoSliceHeaderType []encoding/asn1.ObjectIdentifier
         - Name: BasicConstraintsValid
           Offset: 864
           Type: 4 BaseType bool
@@ -1282,64 +1264,64 @@ Types:
           Type: 4 BaseType bool
         - Name: SubjectKeyId
           Offset: 888
-          Type: 68 GoSliceHeaderType []uint8
+          Type: 103 GoSliceHeaderType []uint8
         - Name: AuthorityKeyId
           Offset: 912
-          Type: 68 GoSliceHeaderType []uint8
+          Type: 103 GoSliceHeaderType []uint8
         - Name: OCSPServer
           Offset: 936
-          Type: 51 GoSliceHeaderType []string
+          Type: 53 GoSliceHeaderType []string
         - Name: IssuingCertificateURL
           Offset: 960
-          Type: 51 GoSliceHeaderType []string
+          Type: 53 GoSliceHeaderType []string
         - Name: DNSNames
           Offset: 984
-          Type: 51 GoSliceHeaderType []string
+          Type: 53 GoSliceHeaderType []string
         - Name: EmailAddresses
           Offset: 1008
-          Type: 51 GoSliceHeaderType []string
+          Type: 53 GoSliceHeaderType []string
         - Name: IPAddresses
           Offset: 1032
-          Type: 155 GoSliceHeaderType []net.IP
+          Type: 145 GoSliceHeaderType []net.IP
         - Name: URIs
           Offset: 1056
-          Type: 158 GoSliceHeaderType []*net/url.URL
+          Type: 148 GoSliceHeaderType []*net/url.URL
         - Name: PermittedDNSDomainsCritical
           Offset: 1080
           Type: 4 BaseType bool
         - Name: PermittedDNSDomains
           Offset: 1088
-          Type: 51 GoSliceHeaderType []string
+          Type: 53 GoSliceHeaderType []string
         - Name: ExcludedDNSDomains
           Offset: 1112
-          Type: 51 GoSliceHeaderType []string
+          Type: 53 GoSliceHeaderType []string
         - Name: PermittedIPRanges
           Offset: 1136
-          Type: 160 GoSliceHeaderType []*net.IPNet
+          Type: 150 GoSliceHeaderType []*net.IPNet
         - Name: ExcludedIPRanges
           Offset: 1160
-          Type: 160 GoSliceHeaderType []*net.IPNet
+          Type: 150 GoSliceHeaderType []*net.IPNet
         - Name: PermittedEmailAddresses
           Offset: 1184
-          Type: 51 GoSliceHeaderType []string
+          Type: 53 GoSliceHeaderType []string
         - Name: ExcludedEmailAddresses
           Offset: 1208
-          Type: 51 GoSliceHeaderType []string
+          Type: 53 GoSliceHeaderType []string
         - Name: PermittedURIDomains
           Offset: 1232
-          Type: 51 GoSliceHeaderType []string
+          Type: 53 GoSliceHeaderType []string
         - Name: ExcludedURIDomains
           Offset: 1256
-          Type: 51 GoSliceHeaderType []string
+          Type: 53 GoSliceHeaderType []string
         - Name: CRLDistributionPoints
           Offset: 1280
-          Type: 51 GoSliceHeaderType []string
+          Type: 53 GoSliceHeaderType []string
         - Name: PolicyIdentifiers
           Offset: 1304
-          Type: 149 GoSliceHeaderType []encoding/asn1.ObjectIdentifier
+          Type: 139 GoSliceHeaderType []encoding/asn1.ObjectIdentifier
         - Name: Policies
           Offset: 1328
-          Type: 163 GoSliceHeaderType []crypto/x509.OID
+          Type: 153 GoSliceHeaderType []crypto/x509.OID
         - Name: InhibitAnyPolicy
           Offset: 1352
           Type: 7 BaseType int
@@ -1360,21 +1342,21 @@ Types:
           Type: 4 BaseType bool
         - Name: PolicyMappings
           Offset: 1400
-          Type: 166 GoSliceHeaderType []crypto/x509.PolicyMapping
+          Type: 156 GoSliceHeaderType []crypto/x509.PolicyMapping
     - __kind: BaseType
-      ID: 154
+      ID: 144
       Name: crypto/x509.ExtKeyUsage
       ByteSize: 8
       GoRuntimeType: 588160
       GoKind: 2
     - __kind: BaseType
-      ID: 145
+      ID: 135
       Name: crypto/x509.KeyUsage
       ByteSize: 8
       GoRuntimeType: 588096
       GoKind: 2
     - __kind: StructureType
-      ID: 165
+      ID: 155
       Name: crypto/x509.OID
       ByteSize: 24
       GoRuntimeType: 1.954592e+06
@@ -1382,9 +1364,9 @@ Types:
       RawFields:
         - Name: der
           Offset: 0
-          Type: 68 GoSliceHeaderType []uint8
+          Type: 103 GoSliceHeaderType []uint8
     - __kind: StructureType
-      ID: 168
+      ID: 158
       Name: crypto/x509.PolicyMapping
       ByteSize: 48
       GoRuntimeType: 1.491232e+06
@@ -1392,24 +1374,24 @@ Types:
       RawFields:
         - Name: IssuerDomainPolicy
           Offset: 0
-          Type: 165 StructureType crypto/x509.OID
+          Type: 155 StructureType crypto/x509.OID
         - Name: SubjectDomainPolicy
           Offset: 24
-          Type: 165 StructureType crypto/x509.OID
+          Type: 155 StructureType crypto/x509.OID
     - __kind: BaseType
-      ID: 134
+      ID: 124
       Name: crypto/x509.PublicKeyAlgorithm
       ByteSize: 8
       GoRuntimeType: 837632
       GoKind: 2
     - __kind: BaseType
-      ID: 133
+      ID: 123
       Name: crypto/x509.SignatureAlgorithm
       ByteSize: 8
       GoRuntimeType: 1.114432e+06
       GoKind: 2
     - __kind: StructureType
-      ID: 141
+      ID: 131
       Name: crypto/x509/pkix.AttributeTypeAndValue
       ByteSize: 40
       GoRuntimeType: 1.502912e+06
@@ -1417,12 +1399,12 @@ Types:
       RawFields:
         - Name: Type
           Offset: 0
-          Type: 151 GoSliceHeaderType encoding/asn1.ObjectIdentifier
+          Type: 141 GoSliceHeaderType encoding/asn1.ObjectIdentifier
         - Name: Value
           Offset: 24
-          Type: 135 GoEmptyInterfaceType interface {}
+          Type: 125 GoEmptyInterfaceType interface {}
     - __kind: StructureType
-      ID: 148
+      ID: 138
       Name: crypto/x509/pkix.Extension
       ByteSize: 56
       GoRuntimeType: 1.647008e+06
@@ -1430,15 +1412,15 @@ Types:
       RawFields:
         - Name: Id
           Offset: 0
-          Type: 151 GoSliceHeaderType encoding/asn1.ObjectIdentifier
+          Type: 141 GoSliceHeaderType encoding/asn1.ObjectIdentifier
         - Name: Critical
           Offset: 24
           Type: 4 BaseType bool
         - Name: Value
           Offset: 32
-          Type: 68 GoSliceHeaderType []uint8
+          Type: 103 GoSliceHeaderType []uint8
     - __kind: StructureType
-      ID: 138
+      ID: 128
       Name: crypto/x509/pkix.Name
       ByteSize: 248
       GoRuntimeType: 2.192768e+06
@@ -1446,25 +1428,25 @@ Types:
       RawFields:
         - Name: Country
           Offset: 0
-          Type: 51 GoSliceHeaderType []string
+          Type: 53 GoSliceHeaderType []string
         - Name: Organization
           Offset: 24
-          Type: 51 GoSliceHeaderType []string
+          Type: 53 GoSliceHeaderType []string
         - Name: OrganizationalUnit
           Offset: 48
-          Type: 51 GoSliceHeaderType []string
+          Type: 53 GoSliceHeaderType []string
         - Name: Locality
           Offset: 72
-          Type: 51 GoSliceHeaderType []string
+          Type: 53 GoSliceHeaderType []string
         - Name: Province
           Offset: 96
-          Type: 51 GoSliceHeaderType []string
+          Type: 53 GoSliceHeaderType []string
         - Name: StreetAddress
           Offset: 120
-          Type: 51 GoSliceHeaderType []string
+          Type: 53 GoSliceHeaderType []string
         - Name: PostalCode
           Offset: 144
-          Type: 51 GoSliceHeaderType []string
+          Type: 53 GoSliceHeaderType []string
         - Name: SerialNumber
           Offset: 168
           Type: 9 GoStringHeaderType string
@@ -1473,12 +1455,12 @@ Types:
           Type: 9 GoStringHeaderType string
         - Name: Names
           Offset: 200
-          Type: 139 GoSliceHeaderType []crypto/x509/pkix.AttributeTypeAndValue
+          Type: 129 GoSliceHeaderType []crypto/x509/pkix.AttributeTypeAndValue
         - Name: ExtraNames
           Offset: 224
-          Type: 139 GoSliceHeaderType []crypto/x509/pkix.AttributeTypeAndValue
+          Type: 129 GoSliceHeaderType []crypto/x509/pkix.AttributeTypeAndValue
     - __kind: GoSliceHeaderType
-      ID: 151
+      ID: 141
       Name: encoding/asn1.ObjectIdentifier
       ByteSize: 24
       GoRuntimeType: 1.053536e+06
@@ -1493,9 +1475,9 @@ Types:
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 189 GoSliceDataType encoding/asn1.ObjectIdentifier.array
+      Data: 193 GoSliceDataType encoding/asn1.ObjectIdentifier.array
     - __kind: GoSliceDataType
-      ID: 189
+      ID: 193
       Name: encoding/asn1.ObjectIdentifier.array
       ByteSize: 2048
       Element: 7 BaseType int
@@ -1525,13 +1507,13 @@ Types:
       GoRuntimeType: 585408
       GoKind: 14
     - __kind: GoSubroutineType
-      ID: 50
+      ID: 52
       Name: func() (io.ReadCloser, error)
       ByteSize: 8
       GoRuntimeType: 693344
       GoKind: 19
     - __kind: GoSubroutineType
-      ID: 89
+      ID: 114
       Name: func(string, []uint8, int) ([]uint8, error)
       ByteSize: 8
       GoRuntimeType: 1.003296e+06
@@ -1550,47 +1532,47 @@ Types:
           Offset: 8
           Type: 14 VoidPointerType unsafe.Pointer
     - __kind: GoSwissMapGroupsType
-      ID: 115
+      ID: 89
       Name: groupReference<string,[]*mime/multipart.FileHeader>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 116 PointerType *noalg.map.group[string][]*mime/multipart.FileHeader
+          Type: 90 PointerType *noalg.map.group[string][]*mime/multipart.FileHeader
         - Name: lengthMask
           Offset: 8
           Type: 8 BaseType uint64
-      GroupType: 117 StructureType noalg.map.group[string][]*mime/multipart.FileHeader
-      GroupSliceType: 124 GoSliceDataType []noalg.map.group[string][]*mime/multipart.FileHeader.array
+      GroupType: 91 StructureType noalg.map.group[string][]*mime/multipart.FileHeader
+      GroupSliceType: 98 GoSliceDataType []noalg.map.group[string][]*mime/multipart.FileHeader.array
     - __kind: GoSwissMapGroupsType
-      ID: 95
+      ID: 73
       Name: groupReference<string,[]string>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 96 PointerType *noalg.map.group[string][]string
+          Type: 74 PointerType *noalg.map.group[string][]string
         - Name: lengthMask
           Offset: 8
           Type: 8 BaseType uint64
-      GroupType: 97 StructureType noalg.map.group[string][]string
-      GroupSliceType: 101 GoSliceDataType []noalg.map.group[string][]string.array
+      GroupType: 75 StructureType noalg.map.group[string][]string
+      GroupSliceType: 79 GoSliceDataType []noalg.map.group[string][]string.array
     - __kind: GoSwissMapGroupsType
-      ID: 104
+      ID: 206
       Name: groupReference<string,string>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 105 PointerType *noalg.map.group[string]string
+          Type: 207 PointerType *noalg.map.group[string]string
         - Name: lengthMask
           Offset: 8
           Type: 8 BaseType uint64
-      GroupType: 106 StructureType noalg.map.group[string]string
-      GroupSliceType: 110 GoSliceDataType []noalg.map.group[string]string.array
+      GroupType: 208 StructureType noalg.map.group[string]string
+      GroupSliceType: 212 GoSliceDataType []noalg.map.group[string]string.array
     - __kind: BaseType
       ID: 7
       Name: int
@@ -1622,7 +1604,7 @@ Types:
       GoRuntimeType: 584512
       GoKind: 3
     - __kind: GoEmptyInterfaceType
-      ID: 135
+      ID: 125
       Name: interface {}
       ByteSize: 16
       GoRuntimeType: 854848
@@ -1635,7 +1617,7 @@ Types:
           Offset: 8
           Type: 14 VoidPointerType unsafe.Pointer
     - __kind: GoInterfaceType
-      ID: 49
+      ID: 51
       Name: io.ReadCloser
       ByteSize: 16
       GoRuntimeType: 1.110464e+06
@@ -1648,7 +1630,7 @@ Types:
           Offset: 8
           Type: 14 VoidPointerType unsafe.Pointer
     - __kind: GoSwissMapHeaderType
-      ID: 78
+      ID: 85
       Name: map<string,[]*mime/multipart.FileHeader>
       ByteSize: 48
       GoKind: 25
@@ -1661,7 +1643,7 @@ Types:
           Type: 1 BaseType uintptr
         - Name: dirPtr
           Offset: 16
-          Type: 79 PointerType **table<string,[]*mime/multipart.FileHeader>
+          Type: 86 PointerType **table<string,[]*mime/multipart.FileHeader>
         - Name: dirLen
           Offset: 24
           Type: 7 BaseType int
@@ -1680,10 +1662,10 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 8 BaseType uint64
-      TablePtrSliceType: 123 GoSliceDataType []*table<string,[]*mime/multipart.FileHeader>.array
-      GroupType: 117 StructureType noalg.map.group[string][]*mime/multipart.FileHeader
+      TablePtrSliceType: 97 GoSliceDataType []*table<string,[]*mime/multipart.FileHeader>.array
+      GroupType: 91 StructureType noalg.map.group[string][]*mime/multipart.FileHeader
     - __kind: GoSwissMapHeaderType
-      ID: 46
+      ID: 48
       Name: map<string,[]string>
       ByteSize: 48
       GoKind: 25
@@ -1696,7 +1678,7 @@ Types:
           Type: 1 BaseType uintptr
         - Name: dirPtr
           Offset: 16
-          Type: 47 PointerType **table<string,[]string>
+          Type: 49 PointerType **table<string,[]string>
         - Name: dirLen
           Offset: 24
           Type: 7 BaseType int
@@ -1715,10 +1697,10 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 8 BaseType uint64
-      TablePtrSliceType: 100 GoSliceDataType []*table<string,[]string>.array
-      GroupType: 97 StructureType noalg.map.group[string][]string
+      TablePtrSliceType: 78 GoSliceDataType []*table<string,[]string>.array
+      GroupType: 75 StructureType noalg.map.group[string][]string
     - __kind: GoSwissMapHeaderType
-      ID: 65
+      ID: 67
       Name: map<string,string>
       ByteSize: 48
       GoKind: 25
@@ -1731,7 +1713,7 @@ Types:
           Type: 1 BaseType uintptr
         - Name: dirPtr
           Offset: 16
-          Type: 66 PointerType **table<string,string>
+          Type: 68 PointerType **table<string,string>
         - Name: dirLen
           Offset: 24
           Type: 7 BaseType int
@@ -1750,31 +1732,31 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 8 BaseType uint64
-      TablePtrSliceType: 109 GoSliceDataType []*table<string,string>.array
-      GroupType: 106 StructureType noalg.map.group[string]string
+      TablePtrSliceType: 211 GoSliceDataType []*table<string,string>.array
+      GroupType: 208 StructureType noalg.map.group[string]string
     - __kind: GoMapType
-      ID: 76
+      ID: 83
       Name: map[string][]*mime/multipart.FileHeader
       ByteSize: 8
       GoRuntimeType: 1.132352e+06
       GoKind: 21
-      HeaderType: 78 GoSwissMapHeaderType map<string,[]*mime/multipart.FileHeader>
+      HeaderType: 85 GoSwissMapHeaderType map<string,[]*mime/multipart.FileHeader>
     - __kind: GoMapType
-      ID: 75
+      ID: 82
       Name: map[string][]string
       ByteSize: 8
       GoRuntimeType: 1.128e+06
       GoKind: 21
-      HeaderType: 46 GoSwissMapHeaderType map<string,[]string>
+      HeaderType: 48 GoSwissMapHeaderType map<string,[]string>
     - __kind: GoMapType
-      ID: 63
+      ID: 65
       Name: map[string]string
       ByteSize: 8
       GoRuntimeType: 1.129024e+06
       GoKind: 21
-      HeaderType: 65 GoSwissMapHeaderType map<string,string>
+      HeaderType: 67 GoSwissMapHeaderType map<string,string>
     - __kind: StructureType
-      ID: 137
+      ID: 127
       Name: math/big.Int
       ByteSize: 32
       GoRuntimeType: 1.494272e+06
@@ -1785,15 +1767,15 @@ Types:
           Type: 4 BaseType bool
         - Name: abs
           Offset: 8
-          Type: 172 GoSliceHeaderType math/big.nat
+          Type: 159 GoSliceHeaderType math/big.nat
     - __kind: BaseType
-      ID: 174
+      ID: 161
       Name: math/big.Word
       ByteSize: 8
       GoRuntimeType: 588352
       GoKind: 7
     - __kind: GoSliceHeaderType
-      ID: 172
+      ID: 159
       Name: math/big.nat
       ByteSize: 24
       GoRuntimeType: 2.361856e+06
@@ -1801,21 +1783,21 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 173 PointerType *math/big.Word
+          Type: 160 PointerType *math/big.Word
         - Name: len
           Offset: 8
           Type: 7 BaseType int
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 206 GoSliceDataType math/big.nat.array
+      Data: 162 GoSliceDataType math/big.nat.array
     - __kind: GoSliceDataType
-      ID: 206
+      ID: 162
       Name: math/big.nat.array
       ByteSize: 2048
-      Element: 174 BaseType math/big.Word
+      Element: 161 BaseType math/big.Word
     - __kind: StructureType
-      ID: 169
+      ID: 99
       Name: mime/multipart.FileHeader
       ByteSize: 88
       GoRuntimeType: 1.977856e+06
@@ -1826,13 +1808,13 @@ Types:
           Type: 9 GoStringHeaderType string
         - Name: Header
           Offset: 16
-          Type: 182 GoMapType net/textproto.MIMEHeader
+          Type: 102 GoMapType net/textproto.MIMEHeader
         - Name: Size
           Offset: 24
           Type: 12 BaseType int64
         - Name: content
           Offset: 32
-          Type: 68 GoSliceHeaderType []uint8
+          Type: 103 GoSliceHeaderType []uint8
         - Name: tmpfile
           Offset: 56
           Type: 9 GoStringHeaderType string
@@ -1843,7 +1825,7 @@ Types:
           Offset: 80
           Type: 4 BaseType bool
     - __kind: StructureType
-      ID: 54
+      ID: 56
       Name: mime/multipart.Form
       ByteSize: 16
       GoRuntimeType: 1.478112e+06
@@ -1851,12 +1833,12 @@ Types:
       RawFields:
         - Name: Value
           Offset: 0
-          Type: 75 GoMapType map[string][]string
+          Type: 82 GoMapType map[string][]string
         - Name: File
           Offset: 8
-          Type: 76 GoMapType map[string][]*mime/multipart.FileHeader
+          Type: 83 GoMapType map[string][]*mime/multipart.FileHeader
     - __kind: GoSliceHeaderType
-      ID: 157
+      ID: 147
       Name: net.IP
       ByteSize: 24
       GoRuntimeType: 2.124512e+06
@@ -1878,7 +1860,7 @@ Types:
       ByteSize: 2048
       Element: 3 BaseType uint8
     - __kind: GoSliceHeaderType
-      ID: 205
+      ID: 197
       Name: net.IPMask
       ByteSize: 24
       GoRuntimeType: 1.019744e+06
@@ -1893,14 +1875,14 @@ Types:
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 212 GoSliceDataType net.IPMask.array
+      Data: 198 GoSliceDataType net.IPMask.array
     - __kind: GoSliceDataType
-      ID: 212
+      ID: 198
       Name: net.IPMask.array
       ByteSize: 2048
       Element: 3 BaseType uint8
     - __kind: StructureType
-      ID: 181
+      ID: 186
       Name: net.IPNet
       ByteSize: 48
       GoRuntimeType: 1.458912e+06
@@ -1908,17 +1890,17 @@ Types:
       RawFields:
         - Name: IP
           Offset: 0
-          Type: 157 GoSliceHeaderType net.IP
+          Type: 147 GoSliceHeaderType net.IP
         - Name: Mask
           Offset: 24
-          Type: 205 GoSliceHeaderType net.IPMask
+          Type: 197 GoSliceHeaderType net.IPMask
     - __kind: GoMapType
-      ID: 44
+      ID: 46
       Name: net/http.Header
       ByteSize: 8
       GoRuntimeType: 2.101632e+06
       GoKind: 21
-      HeaderType: 46 GoSwissMapHeaderType map<string,[]string>
+      HeaderType: 48 GoSwissMapHeaderType map<string,[]string>
     - __kind: StructureType
       ID: 38
       Name: net/http.Request
@@ -1931,7 +1913,7 @@ Types:
           Type: 9 GoStringHeaderType string
         - Name: URL
           Offset: 16
-          Type: 42 PointerType *net/url.URL
+          Type: 44 PointerType *net/url.URL
         - Name: Proto
           Offset: 24
           Type: 9 GoStringHeaderType string
@@ -1943,19 +1925,19 @@ Types:
           Type: 7 BaseType int
         - Name: Header
           Offset: 56
-          Type: 44 GoMapType net/http.Header
+          Type: 46 GoMapType net/http.Header
         - Name: Body
           Offset: 64
-          Type: 49 GoInterfaceType io.ReadCloser
+          Type: 51 GoInterfaceType io.ReadCloser
         - Name: GetBody
           Offset: 80
-          Type: 50 GoSubroutineType func() (io.ReadCloser, error)
+          Type: 52 GoSubroutineType func() (io.ReadCloser, error)
         - Name: ContentLength
           Offset: 88
           Type: 12 BaseType int64
         - Name: TransferEncoding
           Offset: 96
-          Type: 51 GoSliceHeaderType []string
+          Type: 53 GoSliceHeaderType []string
         - Name: Close
           Offset: 120
           Type: 4 BaseType bool
@@ -1964,16 +1946,16 @@ Types:
           Type: 9 GoStringHeaderType string
         - Name: Form
           Offset: 144
-          Type: 52 GoMapType net/url.Values
+          Type: 54 GoMapType net/url.Values
         - Name: PostForm
           Offset: 152
-          Type: 52 GoMapType net/url.Values
+          Type: 54 GoMapType net/url.Values
         - Name: MultipartForm
           Offset: 160
-          Type: 53 PointerType *mime/multipart.Form
+          Type: 55 PointerType *mime/multipart.Form
         - Name: Trailer
           Offset: 168
-          Type: 44 GoMapType net/http.Header
+          Type: 46 GoMapType net/http.Header
         - Name: RemoteAddr
           Offset: 176
           Type: 9 GoStringHeaderType string
@@ -1982,30 +1964,30 @@ Types:
           Type: 9 GoStringHeaderType string
         - Name: TLS
           Offset: 208
-          Type: 55 PointerType *crypto/tls.ConnectionState
+          Type: 57 PointerType *crypto/tls.ConnectionState
         - Name: Cancel
           Offset: 216
-          Type: 57 GoChannelType <-chan struct {}
+          Type: 59 GoChannelType <-chan struct {}
         - Name: Response
           Offset: 224
-          Type: 58 PointerType *net/http.Response
+          Type: 60 PointerType *net/http.Response
         - Name: Pattern
           Offset: 232
           Type: 9 GoStringHeaderType string
         - Name: ctx
           Offset: 248
-          Type: 60 GoInterfaceType context.Context
+          Type: 62 GoInterfaceType context.Context
         - Name: pat
           Offset: 264
-          Type: 61 PointerType *net/http.pattern
+          Type: 63 PointerType *net/http.pattern
         - Name: matches
           Offset: 272
-          Type: 51 GoSliceHeaderType []string
+          Type: 53 GoSliceHeaderType []string
         - Name: otherValues
           Offset: 296
-          Type: 63 GoMapType map[string]string
+          Type: 65 GoMapType map[string]string
     - __kind: StructureType
-      ID: 59
+      ID: 61
       Name: net/http.Response
       ByteSize: 144
       GoRuntimeType: 2.210656e+06
@@ -2028,16 +2010,16 @@ Types:
           Type: 7 BaseType int
         - Name: Header
           Offset: 56
-          Type: 44 GoMapType net/http.Header
+          Type: 46 GoMapType net/http.Header
         - Name: Body
           Offset: 64
-          Type: 49 GoInterfaceType io.ReadCloser
+          Type: 51 GoInterfaceType io.ReadCloser
         - Name: ContentLength
           Offset: 80
           Type: 12 BaseType int64
         - Name: TransferEncoding
           Offset: 88
-          Type: 51 GoSliceHeaderType []string
+          Type: 53 GoSliceHeaderType []string
         - Name: Close
           Offset: 112
           Type: 4 BaseType bool
@@ -2046,13 +2028,13 @@ Types:
           Type: 4 BaseType bool
         - Name: Trailer
           Offset: 120
-          Type: 44 GoMapType net/http.Header
+          Type: 46 GoMapType net/http.Header
         - Name: Request
           Offset: 128
           Type: 37 PointerType *net/http.Request
         - Name: TLS
           Offset: 136
-          Type: 55 PointerType *crypto/tls.ConnectionState
+          Type: 57 PointerType *crypto/tls.ConnectionState
     - __kind: GoInterfaceType
       ID: 36
       Name: net/http.ResponseWriter
@@ -2067,7 +2049,7 @@ Types:
           Offset: 8
           Type: 14 VoidPointerType unsafe.Pointer
     - __kind: StructureType
-      ID: 62
+      ID: 64
       Name: net/http.pattern
       ByteSize: 88
       GoRuntimeType: 1.833632e+06
@@ -2084,12 +2066,12 @@ Types:
           Type: 9 GoStringHeaderType string
         - Name: segments
           Offset: 48
-          Type: 91 GoSliceHeaderType []net/http.segment
+          Type: 200 GoSliceHeaderType []net/http.segment
         - Name: loc
           Offset: 72
           Type: 9 GoStringHeaderType string
     - __kind: StructureType
-      ID: 93
+      ID: 202
       Name: net/http.segment
       ByteSize: 24
       GoRuntimeType: 1.608416e+06
@@ -2105,14 +2087,14 @@ Types:
           Offset: 17
           Type: 4 BaseType bool
     - __kind: GoMapType
-      ID: 182
+      ID: 102
       Name: net/textproto.MIMEHeader
       ByteSize: 8
       GoRuntimeType: 1.823584e+06
       GoKind: 21
-      HeaderType: 46 GoSwissMapHeaderType map<string,[]string>
+      HeaderType: 48 GoSwissMapHeaderType map<string,[]string>
     - __kind: StructureType
-      ID: 43
+      ID: 45
       Name: net/url.URL
       ByteSize: 144
       GoRuntimeType: 2.127584e+06
@@ -2126,7 +2108,7 @@ Types:
           Type: 9 GoStringHeaderType string
         - Name: User
           Offset: 32
-          Type: 72 PointerType *net/url.Userinfo
+          Type: 70 PointerType *net/url.Userinfo
         - Name: Host
           Offset: 40
           Type: 9 GoStringHeaderType string
@@ -2152,7 +2134,7 @@ Types:
           Offset: 128
           Type: 9 GoStringHeaderType string
     - __kind: StructureType
-      ID: 73
+      ID: 71
       Name: net/url.Userinfo
       ByteSize: 40
       GoRuntimeType: 1.624928e+06
@@ -2168,41 +2150,41 @@ Types:
           Offset: 32
           Type: 4 BaseType bool
     - __kind: GoMapType
-      ID: 52
+      ID: 54
       Name: net/url.Values
       ByteSize: 8
       GoRuntimeType: 1.885152e+06
       GoKind: 21
-      HeaderType: 46 GoSwissMapHeaderType map<string,[]string>
+      HeaderType: 48 GoSwissMapHeaderType map<string,[]string>
     - __kind: ArrayType
-      ID: 118
+      ID: 92
       Name: noalg.[8]struct { key string; elem []*mime/multipart.FileHeader }
       ByteSize: 320
       GoRuntimeType: 699200
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 119 StructureType noalg.struct { key string; elem []*mime/multipart.FileHeader }
+      Element: 93 StructureType noalg.struct { key string; elem []*mime/multipart.FileHeader }
     - __kind: ArrayType
-      ID: 98
+      ID: 76
       Name: noalg.[8]struct { key string; elem []string }
       ByteSize: 320
       GoRuntimeType: 689376
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 99 StructureType noalg.struct { key string; elem []string }
+      Element: 77 StructureType noalg.struct { key string; elem []string }
     - __kind: ArrayType
-      ID: 107
+      ID: 209
       Name: noalg.[8]struct { key string; elem string }
       ByteSize: 256
       GoRuntimeType: 693536
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 108 StructureType noalg.struct { key string; elem string }
+      Element: 210 StructureType noalg.struct { key string; elem string }
     - __kind: StructureType
-      ID: 117
+      ID: 91
       Name: noalg.map.group[string][]*mime/multipart.FileHeader
       ByteSize: 328
       GoRuntimeType: 1.29952e+06
@@ -2213,9 +2195,9 @@ Types:
           Type: 8 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 118 ArrayType noalg.[8]struct { key string; elem []*mime/multipart.FileHeader }
+          Type: 92 ArrayType noalg.[8]struct { key string; elem []*mime/multipart.FileHeader }
     - __kind: StructureType
-      ID: 97
+      ID: 75
       Name: noalg.map.group[string][]string
       ByteSize: 328
       GoRuntimeType: 1.290432e+06
@@ -2226,9 +2208,9 @@ Types:
           Type: 8 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 98 ArrayType noalg.[8]struct { key string; elem []string }
+          Type: 76 ArrayType noalg.[8]struct { key string; elem []string }
     - __kind: StructureType
-      ID: 106
+      ID: 208
       Name: noalg.map.group[string]string
       ByteSize: 264
       GoRuntimeType: 1.292864e+06
@@ -2239,9 +2221,9 @@ Types:
           Type: 8 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 107 ArrayType noalg.[8]struct { key string; elem string }
+          Type: 209 ArrayType noalg.[8]struct { key string; elem string }
     - __kind: StructureType
-      ID: 119
+      ID: 93
       Name: noalg.struct { key string; elem []*mime/multipart.FileHeader }
       ByteSize: 40
       GoRuntimeType: 1.299392e+06
@@ -2252,9 +2234,9 @@ Types:
           Type: 9 GoStringHeaderType string
         - Name: elem
           Offset: 16
-          Type: 120 GoSliceHeaderType []*mime/multipart.FileHeader
+          Type: 94 GoSliceHeaderType []*mime/multipart.FileHeader
     - __kind: StructureType
-      ID: 99
+      ID: 77
       Name: noalg.struct { key string; elem []string }
       ByteSize: 40
       GoRuntimeType: 1.290304e+06
@@ -2265,9 +2247,9 @@ Types:
           Type: 9 GoStringHeaderType string
         - Name: elem
           Offset: 16
-          Type: 51 GoSliceHeaderType []string
+          Type: 53 GoSliceHeaderType []string
     - __kind: StructureType
-      ID: 108
+      ID: 210
       Name: noalg.struct { key string; elem string }
       ByteSize: 32
       GoRuntimeType: 1.292736e+06
@@ -2288,17 +2270,17 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 71 PointerType *string.str
+          Type: 43 PointerType *string.str
         - Name: len
           Offset: 8
           Type: 7 BaseType int
-      Data: 70 GoStringDataType string.str
+      Data: 42 GoStringDataType string.str
     - __kind: GoStringDataType
-      ID: 70
+      ID: 42
       Name: string.str
       ByteSize: 2048
     - __kind: StructureType
-      ID: 113
+      ID: 88
       Name: table<string,[]*mime/multipart.FileHeader>
       ByteSize: 32
       GoKind: 25
@@ -2320,9 +2302,9 @@ Types:
           Type: 7 BaseType int
         - Name: groups
           Offset: 16
-          Type: 115 GoSwissMapGroupsType groupReference<string,[]*mime/multipart.FileHeader>
+          Type: 89 GoSwissMapGroupsType groupReference<string,[]*mime/multipart.FileHeader>
     - __kind: StructureType
-      ID: 74
+      ID: 72
       Name: table<string,[]string>
       ByteSize: 32
       GoKind: 25
@@ -2344,9 +2326,9 @@ Types:
           Type: 7 BaseType int
         - Name: groups
           Offset: 16
-          Type: 95 GoSwissMapGroupsType groupReference<string,[]string>
+          Type: 73 GoSwissMapGroupsType groupReference<string,[]string>
     - __kind: StructureType
-      ID: 94
+      ID: 205
       Name: table<string,string>
       ByteSize: 32
       GoKind: 25
@@ -2368,9 +2350,9 @@ Types:
           Type: 7 BaseType int
         - Name: groups
           Offset: 16
-          Type: 104 GoSwissMapGroupsType groupReference<string,string>
+          Type: 206 GoSwissMapGroupsType groupReference<string,string>
     - __kind: StructureType
-      ID: 144
+      ID: 134
       Name: time.Location
       ByteSize: 104
       GoRuntimeType: 1.973536e+06
@@ -2381,10 +2363,10 @@ Types:
           Type: 9 GoStringHeaderType string
         - Name: zone
           Offset: 16
-          Type: 175 GoSliceHeaderType []time.zone
+          Type: 166 GoSliceHeaderType []time.zone
         - Name: tx
           Offset: 40
-          Type: 178 GoSliceHeaderType []time.zoneTrans
+          Type: 169 GoSliceHeaderType []time.zoneTrans
         - Name: extend
           Offset: 64
           Type: 9 GoStringHeaderType string
@@ -2396,9 +2378,9 @@ Types:
           Type: 12 BaseType int64
         - Name: cacheZone
           Offset: 96
-          Type: 176 PointerType *time.zone
+          Type: 167 PointerType *time.zone
     - __kind: StructureType
-      ID: 142
+      ID: 132
       Name: time.Time
       ByteSize: 24
       GoRuntimeType: 2.364704e+06
@@ -2412,9 +2394,9 @@ Types:
           Type: 12 BaseType int64
         - Name: loc
           Offset: 16
-          Type: 143 PointerType *time.Location
+          Type: 133 PointerType *time.Location
     - __kind: StructureType
-      ID: 177
+      ID: 168
       Name: time.zone
       ByteSize: 32
       GoRuntimeType: 1.613408e+06
@@ -2430,7 +2412,7 @@ Types:
           Offset: 24
           Type: 4 BaseType bool
     - __kind: StructureType
-      ID: 180
+      ID: 171
       Name: time.zoneTrans
       ByteSize: 16
       GoRuntimeType: 1.750848e+06
@@ -2490,6 +2472,6 @@ Types:
       ByteSize: 8
       GoRuntimeType: 585536
       GoKind: 26
-MaxTypeID: 215
+MaxTypeID: 214
 Issues: []
 GoModuledataInfo: {FirstModuledataAddr: "0x182c9a0", TypesOffset: 296}

--- a/pkg/dyninst/irgen/testdata/snapshot/rc_tester_v1.arch=amd64,toolchain=go1.25.0.yaml
+++ b/pkg/dyninst/irgen/testdata/snapshot/rc_tester_v1.arch=amd64,toolchain=go1.25.0.yaml
@@ -33,7 +33,7 @@ Subprograms:
       InlinePCRanges: []
       Variables:
         - Name: w
-          Type: 1 GoInterfaceType net/http.ResponseWriter
+          Type: 36 GoInterfaceType net/http.ResponseWriter
           Locations:
             - Range: 0xd04e60..0xd04ecc
               Pieces:
@@ -56,7 +56,7 @@ Subprograms:
           IsParameter: true
           IsReturn: false
         - Name: r
-          Type: 3 PointerType *net/http.Request
+          Type: 37 PointerType *net/http.Request
           Locations:
             - Range: 0xd04e60..0xd04ed6
               Pieces: [{Size: 8, Op: {RegNo: 2, Shift: 0}}]
@@ -65,7 +65,7 @@ Subprograms:
           IsParameter: true
           IsReturn: false
         - Name: '&buf'
-          Type: 135 PointerType *bytes.Buffer
+          Type: 158 PointerType *bytes.Buffer
           Locations:
             - Range: 0xd0500e..0xd05029
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
@@ -74,7 +74,7 @@ Subprograms:
           IsParameter: false
           IsReturn: false
         - Name: span
-          Type: 138 GoInterfaceType gopkg.in/DataDog/dd-trace-go.v1/ddtrace.Span
+          Type: 161 GoInterfaceType gopkg.in/DataDog/dd-trace-go.v1/ddtrace.Span
           Locations:
             - Range: 0xd04ee8..0xd04ee8
               Pieces:
@@ -102,7 +102,7 @@ Subprograms:
       InlinePCRanges: []
       Variables:
         - Name: path
-          Type: 5 GoStringHeaderType string
+          Type: 9 GoStringHeaderType string
           Locations:
             - Range: 0xd051e0..0xd05205
               Pieces:
@@ -114,50 +114,50 @@ Subprograms:
           IsReturn: false
 Types:
     - __kind: PointerType
-      ID: 58
+      ID: 82
       Name: '**crypto/x509.Certificate'
       ByteSize: 8
       GoKind: 22
-      Pointee: 59 PointerType *crypto/x509.Certificate
+      Pointee: 83 PointerType *crypto/x509.Certificate
     - __kind: PointerType
-      ID: 49
+      ID: 73
       Name: '**mime/multipart.FileHeader'
       ByteSize: 8
       GoKind: 22
-      Pointee: 50 PointerType *mime/multipart.FileHeader
+      Pointee: 74 PointerType *mime/multipart.FileHeader
     - __kind: PointerType
-      ID: 99
+      ID: 122
       Name: '**net.IPNet'
       ByteSize: 8
       GoKind: 22
-      Pointee: 100 PointerType *net.IPNet
+      Pointee: 123 PointerType *net.IPNet
     - __kind: PointerType
-      ID: 97
+      ID: 120
       Name: '**net/url.URL'
       ByteSize: 8
       GoKind: 22
-      Pointee: 9 PointerType *net/url.URL
+      Pointee: 39 PointerType *net/url.URL
     - __kind: PointerType
-      ID: 40
+      ID: 64
       Name: '**table<string,[]*mime/multipart.FileHeader>'
       ByteSize: 8
-      Pointee: 41 PointerType *table<string,[]*mime/multipart.FileHeader>
+      Pointee: 65 PointerType *table<string,[]*mime/multipart.FileHeader>
     - __kind: PointerType
-      ID: 19
+      ID: 46
       Name: '**table<string,[]string>'
       ByteSize: 8
-      Pointee: 20 PointerType *table<string,[]string>
+      Pointee: 47 PointerType *table<string,[]string>
     - __kind: PointerType
-      ID: 127
+      ID: 150
       Name: '**table<string,string>'
       ByteSize: 8
-      Pointee: 128 PointerType *table<string,string>
+      Pointee: 151 PointerType *table<string,string>
     - __kind: PointerType
-      ID: 110
+      ID: 133
       Name: '*[]*crypto/x509.Certificate'
       ByteSize: 8
       GoKind: 22
-      Pointee: 57 GoSliceHeaderType []*crypto/x509.Certificate
+      Pointee: 81 GoSliceHeaderType []*crypto/x509.Certificate
     - __kind: PointerType
       ID: 175
       Name: '*[]*crypto/x509.Certificate.array'
@@ -244,203 +244,203 @@ Types:
       ByteSize: 8
       Pointee: 184 GoSliceDataType []time.zoneTrans.array
     - __kind: PointerType
-      ID: 112
+      ID: 135
       Name: '*[]uint8'
       ByteSize: 8
       GoRuntimeType: 481600
       GoKind: 22
-      Pointee: 53 GoSliceHeaderType []uint8
+      Pointee: 77 GoSliceHeaderType []uint8
     - __kind: PointerType
       ID: 173
       Name: '*[]uint8.array'
       ByteSize: 8
       Pointee: 172 GoSliceDataType []uint8.array
     - __kind: PointerType
-      ID: 141
+      ID: 11
       Name: '*bool'
       ByteSize: 8
       GoRuntimeType: 400320
       GoKind: 22
-      Pointee: 13 BaseType bool
+      Pointee: 4 BaseType bool
     - __kind: PointerType
-      ID: 135
+      ID: 158
       Name: '*bytes.Buffer'
       ByteSize: 8
       GoRuntimeType: 2.260704e+06
       GoKind: 22
-      Pointee: 136 StructureType bytes.Buffer
+      Pointee: 159 StructureType bytes.Buffer
     - __kind: PointerType
-      ID: 54
+      ID: 78
       Name: '*crypto/tls.ConnectionState'
       ByteSize: 8
       GoRuntimeType: 908352
       GoKind: 22
-      Pointee: 55 StructureType crypto/tls.ConnectionState
+      Pointee: 79 StructureType crypto/tls.ConnectionState
     - __kind: PointerType
-      ID: 59
+      ID: 83
       Name: '*crypto/x509.Certificate'
       ByteSize: 8
       GoRuntimeType: 2.043968e+06
       GoKind: 22
-      Pointee: 60 StructureType crypto/x509.Certificate
+      Pointee: 84 StructureType crypto/x509.Certificate
     - __kind: PointerType
-      ID: 91
+      ID: 114
       Name: '*crypto/x509.ExtKeyUsage'
       ByteSize: 8
       GoRuntimeType: 423552
       GoKind: 22
-      Pointee: 92 BaseType crypto/x509.ExtKeyUsage
+      Pointee: 115 BaseType crypto/x509.ExtKeyUsage
     - __kind: PointerType
-      ID: 104
+      ID: 127
       Name: '*crypto/x509.OID'
       ByteSize: 8
       GoRuntimeType: 1.954336e+06
       GoKind: 22
-      Pointee: 105 StructureType crypto/x509.OID
+      Pointee: 128 StructureType crypto/x509.OID
     - __kind: PointerType
-      ID: 107
+      ID: 130
       Name: '*crypto/x509.PolicyMapping'
       ByteSize: 8
       GoRuntimeType: 423616
       GoKind: 22
-      Pointee: 108 StructureType crypto/x509.PolicyMapping
+      Pointee: 131 StructureType crypto/x509.PolicyMapping
     - __kind: PointerType
-      ID: 71
+      ID: 95
       Name: '*crypto/x509/pkix.AttributeTypeAndValue'
       ByteSize: 8
       GoRuntimeType: 437312
       GoKind: 22
-      Pointee: 72 StructureType crypto/x509/pkix.AttributeTypeAndValue
+      Pointee: 96 StructureType crypto/x509/pkix.AttributeTypeAndValue
     - __kind: PointerType
-      ID: 86
+      ID: 109
       Name: '*crypto/x509/pkix.Extension'
       ByteSize: 8
       GoRuntimeType: 437504
       GoKind: 22
-      Pointee: 87 StructureType crypto/x509/pkix.Extension
+      Pointee: 110 StructureType crypto/x509/pkix.Extension
     - __kind: PointerType
-      ID: 89
+      ID: 112
       Name: '*encoding/asn1.ObjectIdentifier'
       ByteSize: 8
       GoRuntimeType: 1.053408e+06
       GoKind: 22
-      Pointee: 73 GoSliceHeaderType encoding/asn1.ObjectIdentifier
+      Pointee: 97 GoSliceHeaderType encoding/asn1.ObjectIdentifier
     - __kind: PointerType
       ID: 181
       Name: '*encoding/asn1.ObjectIdentifier.array'
       ByteSize: 8
       Pointee: 180 GoSliceDataType encoding/asn1.ObjectIdentifier.array
     - __kind: PointerType
-      ID: 159
+      ID: 33
       Name: '*error'
       ByteSize: 8
       GoRuntimeType: 399232
       GoKind: 22
-      Pointee: 142 GoInterfaceType error
+      Pointee: 13 GoInterfaceType error
     - __kind: PointerType
-      ID: 161
+      ID: 35
       Name: '*float32'
       ByteSize: 8
       GoRuntimeType: 400192
       GoKind: 22
-      Pointee: 146 BaseType float32
+      Pointee: 18 BaseType float32
     - __kind: PointerType
-      ID: 152
+      ID: 25
       Name: '*float64'
       ByteSize: 8
       GoRuntimeType: 400256
       GoKind: 22
-      Pointee: 143 BaseType float64
+      Pointee: 15 BaseType float64
     - __kind: PointerType
-      ID: 74
+      ID: 26
       Name: '*int'
       ByteSize: 8
       GoRuntimeType: 399872
       GoKind: 22
-      Pointee: 8 BaseType int
+      Pointee: 7 BaseType int
     - __kind: PointerType
-      ID: 156
+      ID: 30
       Name: '*int16'
       ByteSize: 8
       GoRuntimeType: 399488
       GoKind: 22
-      Pointee: 157 BaseType int16
+      Pointee: 31 BaseType int16
     - __kind: PointerType
-      ID: 148
+      ID: 20
       Name: '*int32'
       ByteSize: 8
       GoRuntimeType: 399616
       GoKind: 22
-      Pointee: 140 BaseType int32
+      Pointee: 10 BaseType int32
     - __kind: PointerType
-      ID: 153
+      ID: 27
       Name: '*int64'
       ByteSize: 8
       GoRuntimeType: 399744
       GoKind: 22
-      Pointee: 32 BaseType int64
+      Pointee: 12 BaseType int64
     - __kind: PointerType
-      ID: 158
+      ID: 32
       Name: '*int8'
       ByteSize: 8
       GoRuntimeType: 399360
       GoKind: 22
-      Pointee: 144 BaseType int8
+      Pointee: 16 BaseType int8
     - __kind: PointerType
-      ID: 38
+      ID: 62
       Name: '*map<string,[]*mime/multipart.FileHeader>'
       ByteSize: 8
-      Pointee: 39 GoSwissMapHeaderType map<string,[]*mime/multipart.FileHeader>
+      Pointee: 63 GoSwissMapHeaderType map<string,[]*mime/multipart.FileHeader>
     - __kind: PointerType
-      ID: 15
+      ID: 44
       Name: '*map<string,[]string>'
       ByteSize: 8
-      Pointee: 16 GoSwissMapHeaderType map<string,[]string>
+      Pointee: 45 GoSwissMapHeaderType map<string,[]string>
     - __kind: PointerType
-      ID: 125
+      ID: 148
       Name: '*map<string,string>'
       ByteSize: 8
-      Pointee: 126 GoSwissMapHeaderType map<string,string>
+      Pointee: 149 GoSwissMapHeaderType map<string,string>
     - __kind: PointerType
-      ID: 64
+      ID: 88
       Name: '*math/big.Int'
       ByteSize: 8
       GoRuntimeType: 2.382336e+06
       GoKind: 22
-      Pointee: 65 StructureType math/big.Int
+      Pointee: 89 StructureType math/big.Int
     - __kind: PointerType
-      ID: 67
+      ID: 91
       Name: '*math/big.Word'
       ByteSize: 8
       GoRuntimeType: 426432
       GoKind: 22
-      Pointee: 68 BaseType math/big.Word
+      Pointee: 92 BaseType math/big.Word
     - __kind: PointerType
       ID: 177
       Name: '*math/big.nat.array'
       ByteSize: 8
       Pointee: 176 GoSliceDataType math/big.nat.array
     - __kind: PointerType
-      ID: 50
+      ID: 74
       Name: '*mime/multipart.FileHeader'
       ByteSize: 8
       GoRuntimeType: 909888
       GoKind: 22
-      Pointee: 51 StructureType mime/multipart.FileHeader
+      Pointee: 75 StructureType mime/multipart.FileHeader
     - __kind: PointerType
-      ID: 34
+      ID: 58
       Name: '*mime/multipart.Form'
       ByteSize: 8
       GoRuntimeType: 909984
       GoKind: 22
-      Pointee: 35 StructureType mime/multipart.Form
+      Pointee: 59 StructureType mime/multipart.Form
     - __kind: PointerType
-      ID: 94
+      ID: 117
       Name: '*net.IP'
       ByteSize: 8
       GoRuntimeType: 2.150176e+06
       GoKind: 22
-      Pointee: 95 GoSliceHeaderType net.IP
+      Pointee: 118 GoSliceHeaderType net.IP
     - __kind: PointerType
       ID: 195
       Name: '*net.IP.array'
@@ -452,161 +452,161 @@ Types:
       ByteSize: 8
       Pointee: 200 GoSliceDataType net.IPMask.array
     - __kind: PointerType
-      ID: 100
+      ID: 123
       Name: '*net.IPNet'
       ByteSize: 8
       GoRuntimeType: 1.18336e+06
       GoKind: 22
-      Pointee: 101 StructureType net.IPNet
+      Pointee: 124 StructureType net.IPNet
     - __kind: PointerType
-      ID: 3
+      ID: 37
       Name: '*net/http.Request'
       ByteSize: 8
       GoRuntimeType: 2.30096e+06
       GoKind: 22
-      Pointee: 4 StructureType net/http.Request
+      Pointee: 38 StructureType net/http.Request
     - __kind: PointerType
-      ID: 116
+      ID: 139
       Name: '*net/http.Response'
       ByteSize: 8
       GoRuntimeType: 1.718816e+06
       GoKind: 22
-      Pointee: 117 StructureType net/http.Response
+      Pointee: 140 StructureType net/http.Response
     - __kind: PointerType
-      ID: 119
+      ID: 142
       Name: '*net/http.pattern'
       ByteSize: 8
       GoRuntimeType: 1.608608e+06
       GoKind: 22
-      Pointee: 120 StructureType net/http.pattern
+      Pointee: 143 StructureType net/http.pattern
     - __kind: PointerType
-      ID: 122
+      ID: 145
       Name: '*net/http.segment'
       ByteSize: 8
       GoRuntimeType: 391808
       GoKind: 22
-      Pointee: 123 StructureType net/http.segment
+      Pointee: 146 StructureType net/http.segment
     - __kind: PointerType
-      ID: 9
+      ID: 39
       Name: '*net/url.URL'
       ByteSize: 8
       GoRuntimeType: 2.1136e+06
       GoKind: 22
-      Pointee: 10 StructureType net/url.URL
+      Pointee: 40 StructureType net/url.URL
     - __kind: PointerType
-      ID: 11
+      ID: 41
       Name: '*net/url.Userinfo'
       ByteSize: 8
       GoRuntimeType: 1.200768e+06
       GoKind: 22
-      Pointee: 12 StructureType net/url.Userinfo
+      Pointee: 42 StructureType net/url.Userinfo
     - __kind: PointerType
-      ID: 44
+      ID: 68
       Name: '*noalg.map.group[string][]*mime/multipart.FileHeader'
       ByteSize: 8
-      Pointee: 45 StructureType noalg.map.group[string][]*mime/multipart.FileHeader
+      Pointee: 69 StructureType noalg.map.group[string][]*mime/multipart.FileHeader
     - __kind: PointerType
-      ID: 24
+      ID: 50
       Name: '*noalg.map.group[string][]string'
       ByteSize: 8
-      Pointee: 25 StructureType noalg.map.group[string][]string
+      Pointee: 51 StructureType noalg.map.group[string][]string
     - __kind: PointerType
-      ID: 131
+      ID: 154
       Name: '*noalg.map.group[string]string'
       ByteSize: 8
-      Pointee: 132 StructureType noalg.map.group[string]string
+      Pointee: 155 StructureType noalg.map.group[string]string
     - __kind: PointerType
-      ID: 29
+      ID: 22
       Name: '*string'
       ByteSize: 8
       GoRuntimeType: 399296
       GoKind: 22
-      Pointee: 5 GoStringHeaderType string
+      Pointee: 9 GoStringHeaderType string
     - __kind: PointerType
       ID: 163
       Name: '*string.str'
       ByteSize: 8
       Pointee: 162 GoStringDataType string.str
     - __kind: PointerType
-      ID: 41
+      ID: 65
       Name: '*table<string,[]*mime/multipart.FileHeader>'
       ByteSize: 8
-      Pointee: 42 StructureType table<string,[]*mime/multipart.FileHeader>
+      Pointee: 66 StructureType table<string,[]*mime/multipart.FileHeader>
     - __kind: PointerType
-      ID: 20
+      ID: 47
       Name: '*table<string,[]string>'
       ByteSize: 8
-      Pointee: 21 StructureType table<string,[]string>
+      Pointee: 48 StructureType table<string,[]string>
     - __kind: PointerType
-      ID: 128
+      ID: 151
       Name: '*table<string,string>'
       ByteSize: 8
-      Pointee: 129 StructureType table<string,string>
+      Pointee: 152 StructureType table<string,string>
     - __kind: PointerType
-      ID: 76
+      ID: 99
       Name: '*time.Location'
       ByteSize: 8
       GoRuntimeType: 1.6136e+06
       GoKind: 22
-      Pointee: 77 StructureType time.Location
+      Pointee: 100 StructureType time.Location
     - __kind: PointerType
-      ID: 79
+      ID: 102
       Name: '*time.zone'
       ByteSize: 8
       GoRuntimeType: 394880
       GoKind: 22
-      Pointee: 80 StructureType time.zone
+      Pointee: 103 StructureType time.zone
     - __kind: PointerType
-      ID: 82
+      ID: 105
       Name: '*time.zoneTrans'
       ByteSize: 8
       GoRuntimeType: 394944
       GoKind: 22
-      Pointee: 83 StructureType time.zoneTrans
+      Pointee: 106 StructureType time.zoneTrans
     - __kind: PointerType
-      ID: 160
+      ID: 34
       Name: '*uint'
       ByteSize: 8
       GoRuntimeType: 399936
       GoKind: 22
-      Pointee: 145 BaseType uint
+      Pointee: 17 BaseType uint
     - __kind: PointerType
-      ID: 155
+      ID: 29
       Name: '*uint16'
       ByteSize: 8
       GoRuntimeType: 399552
       GoKind: 22
-      Pointee: 22 BaseType uint16
+      Pointee: 6 BaseType uint16
     - __kind: PointerType
-      ID: 149
+      ID: 21
       Name: '*uint32'
       ByteSize: 8
       GoRuntimeType: 399680
       GoKind: 22
-      Pointee: 139 BaseType uint32
+      Pointee: 2 BaseType uint32
     - __kind: PointerType
-      ID: 154
+      ID: 28
       Name: '*uint64'
       ByteSize: 8
       GoRuntimeType: 399808
       GoKind: 22
-      Pointee: 17 BaseType uint64
+      Pointee: 8 BaseType uint64
     - __kind: PointerType
-      ID: 6
+      ID: 5
       Name: '*uint8'
       ByteSize: 8
       GoRuntimeType: 399424
       GoKind: 22
-      Pointee: 7 BaseType uint8
+      Pointee: 3 BaseType uint8
     - __kind: PointerType
-      ID: 147
+      ID: 19
       Name: '*uintptr'
       ByteSize: 8
       GoRuntimeType: 400000
       GoKind: 22
-      Pointee: 18 BaseType uintptr
+      Pointee: 1 BaseType uintptr
     - __kind: GoChannelType
-      ID: 115
+      ID: 138
       Name: <-chan struct {}
       GoRuntimeType: 597696
       GoKind: 18
@@ -619,7 +619,7 @@ Types:
         - Name: w
           Offset: 1
           Expression:
-            Type: 1 GoInterfaceType net/http.ResponseWriter
+            Type: 36 GoInterfaceType net/http.ResponseWriter
             Operations:
                 - __kind: LocationOp
                   Variable: {subprogram: 1, index: 0, name: w}
@@ -628,7 +628,7 @@ Types:
         - Name: r
           Offset: 17
           Expression:
-            Type: 3 PointerType *net/http.Request
+            Type: 37 PointerType *net/http.Request
             Operations:
                 - __kind: LocationOp
                   Variable: {subprogram: 1, index: 1, name: r}
@@ -643,14 +643,14 @@ Types:
         - Name: path
           Offset: 1
           Expression:
-            Type: 5 GoStringHeaderType string
+            Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
                   Variable: {subprogram: 2, index: 0, name: path}
                   Offset: 0
                   ByteSize: 16
     - __kind: GoSliceHeaderType
-      ID: 57
+      ID: 81
       Name: '[]*crypto/x509.Certificate'
       ByteSize: 24
       GoRuntimeType: 502496
@@ -658,21 +658,21 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 58 PointerType **crypto/x509.Certificate
+          Type: 82 PointerType **crypto/x509.Certificate
         - Name: len
           Offset: 8
-          Type: 8 BaseType int
+          Type: 7 BaseType int
         - Name: cap
           Offset: 16
-          Type: 8 BaseType int
+          Type: 7 BaseType int
       Data: 174 GoSliceDataType []*crypto/x509.Certificate.array
     - __kind: GoSliceDataType
       ID: 174
       Name: '[]*crypto/x509.Certificate.array'
       ByteSize: 2048
-      Element: 59 PointerType *crypto/x509.Certificate
+      Element: 83 PointerType *crypto/x509.Certificate
     - __kind: GoSliceHeaderType
-      ID: 48
+      ID: 72
       Name: '[]*mime/multipart.FileHeader'
       ByteSize: 24
       GoRuntimeType: 487328
@@ -680,21 +680,21 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 49 PointerType **mime/multipart.FileHeader
+          Type: 73 PointerType **mime/multipart.FileHeader
         - Name: len
           Offset: 8
-          Type: 8 BaseType int
+          Type: 7 BaseType int
         - Name: cap
           Offset: 16
-          Type: 8 BaseType int
+          Type: 7 BaseType int
       Data: 170 GoSliceDataType []*mime/multipart.FileHeader.array
     - __kind: GoSliceDataType
       ID: 170
       Name: '[]*mime/multipart.FileHeader.array'
       ByteSize: 2048
-      Element: 50 PointerType *mime/multipart.FileHeader
+      Element: 74 PointerType *mime/multipart.FileHeader
     - __kind: GoSliceHeaderType
-      ID: 98
+      ID: 121
       Name: '[]*net.IPNet'
       ByteSize: 24
       GoRuntimeType: 504096
@@ -702,21 +702,21 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 99 PointerType **net.IPNet
+          Type: 122 PointerType **net.IPNet
         - Name: len
           Offset: 8
-          Type: 8 BaseType int
+          Type: 7 BaseType int
         - Name: cap
           Offset: 16
-          Type: 8 BaseType int
+          Type: 7 BaseType int
       Data: 198 GoSliceDataType []*net.IPNet.array
     - __kind: GoSliceDataType
       ID: 198
       Name: '[]*net.IPNet.array'
       ByteSize: 2048
-      Element: 100 PointerType *net.IPNet
+      Element: 123 PointerType *net.IPNet
     - __kind: GoSliceHeaderType
-      ID: 96
+      ID: 119
       Name: '[]*net/url.URL'
       ByteSize: 24
       GoRuntimeType: 504032
@@ -724,36 +724,36 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 97 PointerType **net/url.URL
+          Type: 120 PointerType **net/url.URL
         - Name: len
           Offset: 8
-          Type: 8 BaseType int
+          Type: 7 BaseType int
         - Name: cap
           Offset: 16
-          Type: 8 BaseType int
+          Type: 7 BaseType int
       Data: 196 GoSliceDataType []*net/url.URL.array
     - __kind: GoSliceDataType
       ID: 196
       Name: '[]*net/url.URL.array'
       ByteSize: 2048
-      Element: 9 PointerType *net/url.URL
+      Element: 39 PointerType *net/url.URL
     - __kind: GoSliceDataType
       ID: 168
       Name: '[]*table<string,[]*mime/multipart.FileHeader>.array'
       ByteSize: 8192
-      Element: 41 PointerType *table<string,[]*mime/multipart.FileHeader>
+      Element: 65 PointerType *table<string,[]*mime/multipart.FileHeader>
     - __kind: GoSliceDataType
       ID: 164
       Name: '[]*table<string,[]string>.array'
       ByteSize: 8192
-      Element: 20 PointerType *table<string,[]string>
+      Element: 47 PointerType *table<string,[]string>
     - __kind: GoSliceDataType
       ID: 212
       Name: '[]*table<string,string>.array'
       ByteSize: 8192
-      Element: 128 PointerType *table<string,string>
+      Element: 151 PointerType *table<string,string>
     - __kind: GoSliceHeaderType
-      ID: 109
+      ID: 132
       Name: '[][]*crypto/x509.Certificate'
       ByteSize: 24
       GoRuntimeType: 502560
@@ -761,21 +761,21 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 110 PointerType *[]*crypto/x509.Certificate
+          Type: 133 PointerType *[]*crypto/x509.Certificate
         - Name: len
           Offset: 8
-          Type: 8 BaseType int
+          Type: 7 BaseType int
         - Name: cap
           Offset: 16
-          Type: 8 BaseType int
+          Type: 7 BaseType int
       Data: 206 GoSliceDataType [][]*crypto/x509.Certificate.array
     - __kind: GoSliceDataType
       ID: 206
       Name: '[][]*crypto/x509.Certificate.array'
       ByteSize: 2048
-      Element: 57 GoSliceHeaderType []*crypto/x509.Certificate
+      Element: 81 GoSliceHeaderType []*crypto/x509.Certificate
     - __kind: GoSliceHeaderType
-      ID: 111
+      ID: 134
       Name: '[][]uint8'
       ByteSize: 24
       GoRuntimeType: 481920
@@ -783,21 +783,21 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 112 PointerType *[]uint8
+          Type: 135 PointerType *[]uint8
         - Name: len
           Offset: 8
-          Type: 8 BaseType int
+          Type: 7 BaseType int
         - Name: cap
           Offset: 16
-          Type: 8 BaseType int
+          Type: 7 BaseType int
       Data: 208 GoSliceDataType [][]uint8.array
     - __kind: GoSliceDataType
       ID: 208
       Name: '[][]uint8.array'
       ByteSize: 2048
-      Element: 53 GoSliceHeaderType []uint8
+      Element: 77 GoSliceHeaderType []uint8
     - __kind: GoSliceHeaderType
-      ID: 90
+      ID: 113
       Name: '[]crypto/x509.ExtKeyUsage'
       ByteSize: 24
       GoRuntimeType: 503968
@@ -805,21 +805,21 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 91 PointerType *crypto/x509.ExtKeyUsage
+          Type: 114 PointerType *crypto/x509.ExtKeyUsage
         - Name: len
           Offset: 8
-          Type: 8 BaseType int
+          Type: 7 BaseType int
         - Name: cap
           Offset: 16
-          Type: 8 BaseType int
+          Type: 7 BaseType int
       Data: 190 GoSliceDataType []crypto/x509.ExtKeyUsage.array
     - __kind: GoSliceDataType
       ID: 190
       Name: '[]crypto/x509.ExtKeyUsage.array'
       ByteSize: 2048
-      Element: 92 BaseType crypto/x509.ExtKeyUsage
+      Element: 115 BaseType crypto/x509.ExtKeyUsage
     - __kind: GoSliceHeaderType
-      ID: 103
+      ID: 126
       Name: '[]crypto/x509.OID'
       ByteSize: 24
       GoRuntimeType: 504160
@@ -827,21 +827,21 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 104 PointerType *crypto/x509.OID
+          Type: 127 PointerType *crypto/x509.OID
         - Name: len
           Offset: 8
-          Type: 8 BaseType int
+          Type: 7 BaseType int
         - Name: cap
           Offset: 16
-          Type: 8 BaseType int
+          Type: 7 BaseType int
       Data: 202 GoSliceDataType []crypto/x509.OID.array
     - __kind: GoSliceDataType
       ID: 202
       Name: '[]crypto/x509.OID.array'
       ByteSize: 2048
-      Element: 105 StructureType crypto/x509.OID
+      Element: 128 StructureType crypto/x509.OID
     - __kind: GoSliceHeaderType
-      ID: 106
+      ID: 129
       Name: '[]crypto/x509.PolicyMapping'
       ByteSize: 24
       GoRuntimeType: 504224
@@ -849,21 +849,21 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 107 PointerType *crypto/x509.PolicyMapping
+          Type: 130 PointerType *crypto/x509.PolicyMapping
         - Name: len
           Offset: 8
-          Type: 8 BaseType int
+          Type: 7 BaseType int
         - Name: cap
           Offset: 16
-          Type: 8 BaseType int
+          Type: 7 BaseType int
       Data: 204 GoSliceDataType []crypto/x509.PolicyMapping.array
     - __kind: GoSliceDataType
       ID: 204
       Name: '[]crypto/x509.PolicyMapping.array'
       ByteSize: 2048
-      Element: 108 StructureType crypto/x509.PolicyMapping
+      Element: 131 StructureType crypto/x509.PolicyMapping
     - __kind: GoSliceHeaderType
-      ID: 70
+      ID: 94
       Name: '[]crypto/x509/pkix.AttributeTypeAndValue'
       ByteSize: 24
       GoRuntimeType: 517440
@@ -871,21 +871,21 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 71 PointerType *crypto/x509/pkix.AttributeTypeAndValue
+          Type: 95 PointerType *crypto/x509/pkix.AttributeTypeAndValue
         - Name: len
           Offset: 8
-          Type: 8 BaseType int
+          Type: 7 BaseType int
         - Name: cap
           Offset: 16
-          Type: 8 BaseType int
+          Type: 7 BaseType int
       Data: 178 GoSliceDataType []crypto/x509/pkix.AttributeTypeAndValue.array
     - __kind: GoSliceDataType
       ID: 178
       Name: '[]crypto/x509/pkix.AttributeTypeAndValue.array'
       ByteSize: 2048
-      Element: 72 StructureType crypto/x509/pkix.AttributeTypeAndValue
+      Element: 96 StructureType crypto/x509/pkix.AttributeTypeAndValue
     - __kind: GoSliceHeaderType
-      ID: 85
+      ID: 108
       Name: '[]crypto/x509/pkix.Extension'
       ByteSize: 24
       GoRuntimeType: 503840
@@ -893,21 +893,21 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 86 PointerType *crypto/x509/pkix.Extension
+          Type: 109 PointerType *crypto/x509/pkix.Extension
         - Name: len
           Offset: 8
-          Type: 8 BaseType int
+          Type: 7 BaseType int
         - Name: cap
           Offset: 16
-          Type: 8 BaseType int
+          Type: 7 BaseType int
       Data: 186 GoSliceDataType []crypto/x509/pkix.Extension.array
     - __kind: GoSliceDataType
       ID: 186
       Name: '[]crypto/x509/pkix.Extension.array'
       ByteSize: 2048
-      Element: 87 StructureType crypto/x509/pkix.Extension
+      Element: 110 StructureType crypto/x509/pkix.Extension
     - __kind: GoSliceHeaderType
-      ID: 88
+      ID: 111
       Name: '[]encoding/asn1.ObjectIdentifier'
       ByteSize: 24
       GoRuntimeType: 503904
@@ -915,21 +915,21 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 89 PointerType *encoding/asn1.ObjectIdentifier
+          Type: 112 PointerType *encoding/asn1.ObjectIdentifier
         - Name: len
           Offset: 8
-          Type: 8 BaseType int
+          Type: 7 BaseType int
         - Name: cap
           Offset: 16
-          Type: 8 BaseType int
+          Type: 7 BaseType int
       Data: 188 GoSliceDataType []encoding/asn1.ObjectIdentifier.array
     - __kind: GoSliceDataType
       ID: 188
       Name: '[]encoding/asn1.ObjectIdentifier.array'
       ByteSize: 2048
-      Element: 73 GoSliceHeaderType encoding/asn1.ObjectIdentifier
+      Element: 97 GoSliceHeaderType encoding/asn1.ObjectIdentifier
     - __kind: GoSliceHeaderType
-      ID: 93
+      ID: 116
       Name: '[]net.IP'
       ByteSize: 24
       GoRuntimeType: 482944
@@ -937,21 +937,21 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 94 PointerType *net.IP
+          Type: 117 PointerType *net.IP
         - Name: len
           Offset: 8
-          Type: 8 BaseType int
+          Type: 7 BaseType int
         - Name: cap
           Offset: 16
-          Type: 8 BaseType int
+          Type: 7 BaseType int
       Data: 192 GoSliceDataType []net.IP.array
     - __kind: GoSliceDataType
       ID: 192
       Name: '[]net.IP.array'
       ByteSize: 2048
-      Element: 95 GoSliceHeaderType net.IP
+      Element: 118 GoSliceHeaderType net.IP
     - __kind: GoSliceHeaderType
-      ID: 121
+      ID: 144
       Name: '[]net/http.segment'
       ByteSize: 24
       GoRuntimeType: 484640
@@ -959,36 +959,36 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 122 PointerType *net/http.segment
+          Type: 145 PointerType *net/http.segment
         - Name: len
           Offset: 8
-          Type: 8 BaseType int
+          Type: 7 BaseType int
         - Name: cap
           Offset: 16
-          Type: 8 BaseType int
+          Type: 7 BaseType int
       Data: 210 GoSliceDataType []net/http.segment.array
     - __kind: GoSliceDataType
       ID: 210
       Name: '[]net/http.segment.array'
       ByteSize: 2048
-      Element: 123 StructureType net/http.segment
+      Element: 146 StructureType net/http.segment
     - __kind: GoSliceDataType
       ID: 169
       Name: '[]noalg.map.group[string][]*mime/multipart.FileHeader.array'
       ByteSize: 2048
-      Element: 45 StructureType noalg.map.group[string][]*mime/multipart.FileHeader
+      Element: 69 StructureType noalg.map.group[string][]*mime/multipart.FileHeader
     - __kind: GoSliceDataType
       ID: 165
       Name: '[]noalg.map.group[string][]string.array'
       ByteSize: 2048
-      Element: 25 StructureType noalg.map.group[string][]string
+      Element: 51 StructureType noalg.map.group[string][]string
     - __kind: GoSliceDataType
       ID: 213
       Name: '[]noalg.map.group[string]string.array'
       ByteSize: 2048
-      Element: 132 StructureType noalg.map.group[string]string
+      Element: 155 StructureType noalg.map.group[string]string
     - __kind: GoSliceHeaderType
-      ID: 28
+      ID: 54
       Name: '[]string'
       ByteSize: 24
       GoRuntimeType: 496448
@@ -996,21 +996,21 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 29 PointerType *string
+          Type: 22 PointerType *string
         - Name: len
           Offset: 8
-          Type: 8 BaseType int
+          Type: 7 BaseType int
         - Name: cap
           Offset: 16
-          Type: 8 BaseType int
+          Type: 7 BaseType int
       Data: 166 GoSliceDataType []string.array
     - __kind: GoSliceDataType
       ID: 166
       Name: '[]string.array'
       ByteSize: 2048
-      Element: 5 GoStringHeaderType string
+      Element: 9 GoStringHeaderType string
     - __kind: GoSliceHeaderType
-      ID: 78
+      ID: 101
       Name: '[]time.zone'
       ByteSize: 24
       GoRuntimeType: 489504
@@ -1018,21 +1018,21 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 79 PointerType *time.zone
+          Type: 102 PointerType *time.zone
         - Name: len
           Offset: 8
-          Type: 8 BaseType int
+          Type: 7 BaseType int
         - Name: cap
           Offset: 16
-          Type: 8 BaseType int
+          Type: 7 BaseType int
       Data: 182 GoSliceDataType []time.zone.array
     - __kind: GoSliceDataType
       ID: 182
       Name: '[]time.zone.array'
       ByteSize: 2048
-      Element: 80 StructureType time.zone
+      Element: 103 StructureType time.zone
     - __kind: GoSliceHeaderType
-      ID: 81
+      ID: 104
       Name: '[]time.zoneTrans'
       ByteSize: 24
       GoRuntimeType: 489568
@@ -1040,21 +1040,21 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 82 PointerType *time.zoneTrans
+          Type: 105 PointerType *time.zoneTrans
         - Name: len
           Offset: 8
-          Type: 8 BaseType int
+          Type: 7 BaseType int
         - Name: cap
           Offset: 16
-          Type: 8 BaseType int
+          Type: 7 BaseType int
       Data: 184 GoSliceDataType []time.zoneTrans.array
     - __kind: GoSliceDataType
       ID: 184
       Name: '[]time.zoneTrans.array'
       ByteSize: 2048
-      Element: 83 StructureType time.zoneTrans
+      Element: 106 StructureType time.zoneTrans
     - __kind: GoSliceHeaderType
-      ID: 53
+      ID: 77
       Name: '[]uint8'
       ByteSize: 24
       GoRuntimeType: 495296
@@ -1062,27 +1062,27 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 6 PointerType *uint8
+          Type: 5 PointerType *uint8
         - Name: len
           Offset: 8
-          Type: 8 BaseType int
+          Type: 7 BaseType int
         - Name: cap
           Offset: 16
-          Type: 8 BaseType int
+          Type: 7 BaseType int
       Data: 172 GoSliceDataType []uint8.array
     - __kind: GoSliceDataType
       ID: 172
       Name: '[]uint8.array'
       ByteSize: 2048
-      Element: 7 BaseType uint8
+      Element: 3 BaseType uint8
     - __kind: BaseType
-      ID: 13
+      ID: 4
       Name: bool
       ByteSize: 1
       GoRuntimeType: 585472
       GoKind: 1
     - __kind: StructureType
-      ID: 136
+      ID: 159
       Name: bytes.Buffer
       ByteSize: 40
       GoRuntimeType: 1.606304e+06
@@ -1090,33 +1090,33 @@ Types:
       RawFields:
         - Name: buf
           Offset: 0
-          Type: 53 GoSliceHeaderType []uint8
+          Type: 77 GoSliceHeaderType []uint8
         - Name: off
           Offset: 24
-          Type: 8 BaseType int
+          Type: 7 BaseType int
         - Name: lastRead
           Offset: 32
-          Type: 137 BaseType bytes.readOp
+          Type: 160 BaseType bytes.readOp
     - __kind: BaseType
-      ID: 137
+      ID: 160
       Name: bytes.readOp
       ByteSize: 1
       GoRuntimeType: 583680
       GoKind: 3
     - __kind: BaseType
-      ID: 151
+      ID: 24
       Name: complex128
       ByteSize: 16
       GoRuntimeType: 585280
       GoKind: 16
     - __kind: BaseType
-      ID: 150
+      ID: 23
       Name: complex64
       ByteSize: 8
       GoRuntimeType: 585216
       GoKind: 15
     - __kind: GoInterfaceType
-      ID: 118
+      ID: 141
       Name: context.Context
       ByteSize: 16
       GoRuntimeType: 1.276992e+06
@@ -1124,12 +1124,12 @@ Types:
       RawFields:
         - Name: tab
           Offset: 0
-          Type: 2 VoidPointerType unsafe.Pointer
+          Type: 14 VoidPointerType unsafe.Pointer
         - Name: data
           Offset: 8
-          Type: 2 VoidPointerType unsafe.Pointer
+          Type: 14 VoidPointerType unsafe.Pointer
     - __kind: StructureType
-      ID: 55
+      ID: 79
       Name: crypto/tls.ConnectionState
       ByteSize: 192
       GoRuntimeType: 2.262752e+06
@@ -1137,69 +1137,69 @@ Types:
       RawFields:
         - Name: Version
           Offset: 0
-          Type: 22 BaseType uint16
+          Type: 6 BaseType uint16
         - Name: HandshakeComplete
           Offset: 2
-          Type: 13 BaseType bool
+          Type: 4 BaseType bool
         - Name: DidResume
           Offset: 3
-          Type: 13 BaseType bool
+          Type: 4 BaseType bool
         - Name: CipherSuite
           Offset: 4
-          Type: 22 BaseType uint16
+          Type: 6 BaseType uint16
         - Name: CurveID
           Offset: 6
-          Type: 56 BaseType crypto/tls.CurveID
+          Type: 80 BaseType crypto/tls.CurveID
         - Name: NegotiatedProtocol
           Offset: 8
-          Type: 5 GoStringHeaderType string
+          Type: 9 GoStringHeaderType string
         - Name: NegotiatedProtocolIsMutual
           Offset: 24
-          Type: 13 BaseType bool
+          Type: 4 BaseType bool
         - Name: ServerName
           Offset: 32
-          Type: 5 GoStringHeaderType string
+          Type: 9 GoStringHeaderType string
         - Name: PeerCertificates
           Offset: 48
-          Type: 57 GoSliceHeaderType []*crypto/x509.Certificate
+          Type: 81 GoSliceHeaderType []*crypto/x509.Certificate
         - Name: VerifiedChains
           Offset: 72
-          Type: 109 GoSliceHeaderType [][]*crypto/x509.Certificate
+          Type: 132 GoSliceHeaderType [][]*crypto/x509.Certificate
         - Name: SignedCertificateTimestamps
           Offset: 96
-          Type: 111 GoSliceHeaderType [][]uint8
+          Type: 134 GoSliceHeaderType [][]uint8
         - Name: OCSPResponse
           Offset: 120
-          Type: 53 GoSliceHeaderType []uint8
+          Type: 77 GoSliceHeaderType []uint8
         - Name: TLSUnique
           Offset: 144
-          Type: 53 GoSliceHeaderType []uint8
+          Type: 77 GoSliceHeaderType []uint8
         - Name: ECHAccepted
           Offset: 168
-          Type: 13 BaseType bool
+          Type: 4 BaseType bool
         - Name: ekm
           Offset: 176
-          Type: 113 GoSubroutineType func(string, []uint8, int) ([]uint8, error)
+          Type: 136 GoSubroutineType func(string, []uint8, int) ([]uint8, error)
         - Name: testingOnlyDidHRR
           Offset: 184
-          Type: 13 BaseType bool
+          Type: 4 BaseType bool
         - Name: testingOnlyPeerSignatureAlgorithm
           Offset: 186
-          Type: 114 BaseType crypto/tls.SignatureScheme
+          Type: 137 BaseType crypto/tls.SignatureScheme
     - __kind: BaseType
-      ID: 56
+      ID: 80
       Name: crypto/tls.CurveID
       ByteSize: 2
       GoRuntimeType: 835040
       GoKind: 9
     - __kind: BaseType
-      ID: 114
+      ID: 137
       Name: crypto/tls.SignatureScheme
       ByteSize: 2
       GoRuntimeType: 835136
       GoKind: 9
     - __kind: StructureType
-      ID: 60
+      ID: 84
       Name: crypto/x509.Certificate
       ByteSize: 1424
       GoRuntimeType: 2.3936e+06
@@ -1207,174 +1207,174 @@ Types:
       RawFields:
         - Name: Raw
           Offset: 0
-          Type: 53 GoSliceHeaderType []uint8
+          Type: 77 GoSliceHeaderType []uint8
         - Name: RawTBSCertificate
           Offset: 24
-          Type: 53 GoSliceHeaderType []uint8
+          Type: 77 GoSliceHeaderType []uint8
         - Name: RawSubjectPublicKeyInfo
           Offset: 48
-          Type: 53 GoSliceHeaderType []uint8
+          Type: 77 GoSliceHeaderType []uint8
         - Name: RawSubject
           Offset: 72
-          Type: 53 GoSliceHeaderType []uint8
+          Type: 77 GoSliceHeaderType []uint8
         - Name: RawIssuer
           Offset: 96
-          Type: 53 GoSliceHeaderType []uint8
+          Type: 77 GoSliceHeaderType []uint8
         - Name: Signature
           Offset: 120
-          Type: 53 GoSliceHeaderType []uint8
+          Type: 77 GoSliceHeaderType []uint8
         - Name: SignatureAlgorithm
           Offset: 144
-          Type: 61 BaseType crypto/x509.SignatureAlgorithm
+          Type: 85 BaseType crypto/x509.SignatureAlgorithm
         - Name: PublicKeyAlgorithm
           Offset: 152
-          Type: 62 BaseType crypto/x509.PublicKeyAlgorithm
+          Type: 86 BaseType crypto/x509.PublicKeyAlgorithm
         - Name: PublicKey
           Offset: 160
-          Type: 63 GoEmptyInterfaceType interface {}
+          Type: 87 GoEmptyInterfaceType interface {}
         - Name: Version
           Offset: 176
-          Type: 8 BaseType int
+          Type: 7 BaseType int
         - Name: SerialNumber
           Offset: 184
-          Type: 64 PointerType *math/big.Int
+          Type: 88 PointerType *math/big.Int
         - Name: Issuer
           Offset: 192
-          Type: 69 StructureType crypto/x509/pkix.Name
+          Type: 93 StructureType crypto/x509/pkix.Name
         - Name: Subject
           Offset: 440
-          Type: 69 StructureType crypto/x509/pkix.Name
+          Type: 93 StructureType crypto/x509/pkix.Name
         - Name: NotBefore
           Offset: 688
-          Type: 75 StructureType time.Time
+          Type: 98 StructureType time.Time
         - Name: NotAfter
           Offset: 712
-          Type: 75 StructureType time.Time
+          Type: 98 StructureType time.Time
         - Name: KeyUsage
           Offset: 736
-          Type: 84 BaseType crypto/x509.KeyUsage
+          Type: 107 BaseType crypto/x509.KeyUsage
         - Name: Extensions
           Offset: 744
-          Type: 85 GoSliceHeaderType []crypto/x509/pkix.Extension
+          Type: 108 GoSliceHeaderType []crypto/x509/pkix.Extension
         - Name: ExtraExtensions
           Offset: 768
-          Type: 85 GoSliceHeaderType []crypto/x509/pkix.Extension
+          Type: 108 GoSliceHeaderType []crypto/x509/pkix.Extension
         - Name: UnhandledCriticalExtensions
           Offset: 792
-          Type: 88 GoSliceHeaderType []encoding/asn1.ObjectIdentifier
+          Type: 111 GoSliceHeaderType []encoding/asn1.ObjectIdentifier
         - Name: ExtKeyUsage
           Offset: 816
-          Type: 90 GoSliceHeaderType []crypto/x509.ExtKeyUsage
+          Type: 113 GoSliceHeaderType []crypto/x509.ExtKeyUsage
         - Name: UnknownExtKeyUsage
           Offset: 840
-          Type: 88 GoSliceHeaderType []encoding/asn1.ObjectIdentifier
+          Type: 111 GoSliceHeaderType []encoding/asn1.ObjectIdentifier
         - Name: BasicConstraintsValid
           Offset: 864
-          Type: 13 BaseType bool
+          Type: 4 BaseType bool
         - Name: IsCA
           Offset: 865
-          Type: 13 BaseType bool
+          Type: 4 BaseType bool
         - Name: MaxPathLen
           Offset: 872
-          Type: 8 BaseType int
+          Type: 7 BaseType int
         - Name: MaxPathLenZero
           Offset: 880
-          Type: 13 BaseType bool
+          Type: 4 BaseType bool
         - Name: SubjectKeyId
           Offset: 888
-          Type: 53 GoSliceHeaderType []uint8
+          Type: 77 GoSliceHeaderType []uint8
         - Name: AuthorityKeyId
           Offset: 912
-          Type: 53 GoSliceHeaderType []uint8
+          Type: 77 GoSliceHeaderType []uint8
         - Name: OCSPServer
           Offset: 936
-          Type: 28 GoSliceHeaderType []string
+          Type: 54 GoSliceHeaderType []string
         - Name: IssuingCertificateURL
           Offset: 960
-          Type: 28 GoSliceHeaderType []string
+          Type: 54 GoSliceHeaderType []string
         - Name: DNSNames
           Offset: 984
-          Type: 28 GoSliceHeaderType []string
+          Type: 54 GoSliceHeaderType []string
         - Name: EmailAddresses
           Offset: 1008
-          Type: 28 GoSliceHeaderType []string
+          Type: 54 GoSliceHeaderType []string
         - Name: IPAddresses
           Offset: 1032
-          Type: 93 GoSliceHeaderType []net.IP
+          Type: 116 GoSliceHeaderType []net.IP
         - Name: URIs
           Offset: 1056
-          Type: 96 GoSliceHeaderType []*net/url.URL
+          Type: 119 GoSliceHeaderType []*net/url.URL
         - Name: PermittedDNSDomainsCritical
           Offset: 1080
-          Type: 13 BaseType bool
+          Type: 4 BaseType bool
         - Name: PermittedDNSDomains
           Offset: 1088
-          Type: 28 GoSliceHeaderType []string
+          Type: 54 GoSliceHeaderType []string
         - Name: ExcludedDNSDomains
           Offset: 1112
-          Type: 28 GoSliceHeaderType []string
+          Type: 54 GoSliceHeaderType []string
         - Name: PermittedIPRanges
           Offset: 1136
-          Type: 98 GoSliceHeaderType []*net.IPNet
+          Type: 121 GoSliceHeaderType []*net.IPNet
         - Name: ExcludedIPRanges
           Offset: 1160
-          Type: 98 GoSliceHeaderType []*net.IPNet
+          Type: 121 GoSliceHeaderType []*net.IPNet
         - Name: PermittedEmailAddresses
           Offset: 1184
-          Type: 28 GoSliceHeaderType []string
+          Type: 54 GoSliceHeaderType []string
         - Name: ExcludedEmailAddresses
           Offset: 1208
-          Type: 28 GoSliceHeaderType []string
+          Type: 54 GoSliceHeaderType []string
         - Name: PermittedURIDomains
           Offset: 1232
-          Type: 28 GoSliceHeaderType []string
+          Type: 54 GoSliceHeaderType []string
         - Name: ExcludedURIDomains
           Offset: 1256
-          Type: 28 GoSliceHeaderType []string
+          Type: 54 GoSliceHeaderType []string
         - Name: CRLDistributionPoints
           Offset: 1280
-          Type: 28 GoSliceHeaderType []string
+          Type: 54 GoSliceHeaderType []string
         - Name: PolicyIdentifiers
           Offset: 1304
-          Type: 88 GoSliceHeaderType []encoding/asn1.ObjectIdentifier
+          Type: 111 GoSliceHeaderType []encoding/asn1.ObjectIdentifier
         - Name: Policies
           Offset: 1328
-          Type: 103 GoSliceHeaderType []crypto/x509.OID
+          Type: 126 GoSliceHeaderType []crypto/x509.OID
         - Name: InhibitAnyPolicy
           Offset: 1352
-          Type: 8 BaseType int
+          Type: 7 BaseType int
         - Name: InhibitAnyPolicyZero
           Offset: 1360
-          Type: 13 BaseType bool
+          Type: 4 BaseType bool
         - Name: InhibitPolicyMapping
           Offset: 1368
-          Type: 8 BaseType int
+          Type: 7 BaseType int
         - Name: InhibitPolicyMappingZero
           Offset: 1376
-          Type: 13 BaseType bool
+          Type: 4 BaseType bool
         - Name: RequireExplicitPolicy
           Offset: 1384
-          Type: 8 BaseType int
+          Type: 7 BaseType int
         - Name: RequireExplicitPolicyZero
           Offset: 1392
-          Type: 13 BaseType bool
+          Type: 4 BaseType bool
         - Name: PolicyMappings
           Offset: 1400
-          Type: 106 GoSliceHeaderType []crypto/x509.PolicyMapping
+          Type: 129 GoSliceHeaderType []crypto/x509.PolicyMapping
     - __kind: BaseType
-      ID: 92
+      ID: 115
       Name: crypto/x509.ExtKeyUsage
       ByteSize: 8
       GoRuntimeType: 588160
       GoKind: 2
     - __kind: BaseType
-      ID: 84
+      ID: 107
       Name: crypto/x509.KeyUsage
       ByteSize: 8
       GoRuntimeType: 588096
       GoKind: 2
     - __kind: StructureType
-      ID: 105
+      ID: 128
       Name: crypto/x509.OID
       ByteSize: 24
       GoRuntimeType: 1.954592e+06
@@ -1382,9 +1382,9 @@ Types:
       RawFields:
         - Name: der
           Offset: 0
-          Type: 53 GoSliceHeaderType []uint8
+          Type: 77 GoSliceHeaderType []uint8
     - __kind: StructureType
-      ID: 108
+      ID: 131
       Name: crypto/x509.PolicyMapping
       ByteSize: 48
       GoRuntimeType: 1.491232e+06
@@ -1392,24 +1392,24 @@ Types:
       RawFields:
         - Name: IssuerDomainPolicy
           Offset: 0
-          Type: 105 StructureType crypto/x509.OID
+          Type: 128 StructureType crypto/x509.OID
         - Name: SubjectDomainPolicy
           Offset: 24
-          Type: 105 StructureType crypto/x509.OID
+          Type: 128 StructureType crypto/x509.OID
     - __kind: BaseType
-      ID: 62
+      ID: 86
       Name: crypto/x509.PublicKeyAlgorithm
       ByteSize: 8
       GoRuntimeType: 837632
       GoKind: 2
     - __kind: BaseType
-      ID: 61
+      ID: 85
       Name: crypto/x509.SignatureAlgorithm
       ByteSize: 8
       GoRuntimeType: 1.114432e+06
       GoKind: 2
     - __kind: StructureType
-      ID: 72
+      ID: 96
       Name: crypto/x509/pkix.AttributeTypeAndValue
       ByteSize: 40
       GoRuntimeType: 1.502912e+06
@@ -1417,12 +1417,12 @@ Types:
       RawFields:
         - Name: Type
           Offset: 0
-          Type: 73 GoSliceHeaderType encoding/asn1.ObjectIdentifier
+          Type: 97 GoSliceHeaderType encoding/asn1.ObjectIdentifier
         - Name: Value
           Offset: 24
-          Type: 63 GoEmptyInterfaceType interface {}
+          Type: 87 GoEmptyInterfaceType interface {}
     - __kind: StructureType
-      ID: 87
+      ID: 110
       Name: crypto/x509/pkix.Extension
       ByteSize: 56
       GoRuntimeType: 1.647008e+06
@@ -1430,15 +1430,15 @@ Types:
       RawFields:
         - Name: Id
           Offset: 0
-          Type: 73 GoSliceHeaderType encoding/asn1.ObjectIdentifier
+          Type: 97 GoSliceHeaderType encoding/asn1.ObjectIdentifier
         - Name: Critical
           Offset: 24
-          Type: 13 BaseType bool
+          Type: 4 BaseType bool
         - Name: Value
           Offset: 32
-          Type: 53 GoSliceHeaderType []uint8
+          Type: 77 GoSliceHeaderType []uint8
     - __kind: StructureType
-      ID: 69
+      ID: 93
       Name: crypto/x509/pkix.Name
       ByteSize: 248
       GoRuntimeType: 2.192768e+06
@@ -1446,39 +1446,39 @@ Types:
       RawFields:
         - Name: Country
           Offset: 0
-          Type: 28 GoSliceHeaderType []string
+          Type: 54 GoSliceHeaderType []string
         - Name: Organization
           Offset: 24
-          Type: 28 GoSliceHeaderType []string
+          Type: 54 GoSliceHeaderType []string
         - Name: OrganizationalUnit
           Offset: 48
-          Type: 28 GoSliceHeaderType []string
+          Type: 54 GoSliceHeaderType []string
         - Name: Locality
           Offset: 72
-          Type: 28 GoSliceHeaderType []string
+          Type: 54 GoSliceHeaderType []string
         - Name: Province
           Offset: 96
-          Type: 28 GoSliceHeaderType []string
+          Type: 54 GoSliceHeaderType []string
         - Name: StreetAddress
           Offset: 120
-          Type: 28 GoSliceHeaderType []string
+          Type: 54 GoSliceHeaderType []string
         - Name: PostalCode
           Offset: 144
-          Type: 28 GoSliceHeaderType []string
+          Type: 54 GoSliceHeaderType []string
         - Name: SerialNumber
           Offset: 168
-          Type: 5 GoStringHeaderType string
+          Type: 9 GoStringHeaderType string
         - Name: CommonName
           Offset: 184
-          Type: 5 GoStringHeaderType string
+          Type: 9 GoStringHeaderType string
         - Name: Names
           Offset: 200
-          Type: 70 GoSliceHeaderType []crypto/x509/pkix.AttributeTypeAndValue
+          Type: 94 GoSliceHeaderType []crypto/x509/pkix.AttributeTypeAndValue
         - Name: ExtraNames
           Offset: 224
-          Type: 70 GoSliceHeaderType []crypto/x509/pkix.AttributeTypeAndValue
+          Type: 94 GoSliceHeaderType []crypto/x509/pkix.AttributeTypeAndValue
     - __kind: GoSliceHeaderType
-      ID: 73
+      ID: 97
       Name: encoding/asn1.ObjectIdentifier
       ByteSize: 24
       GoRuntimeType: 1.053536e+06
@@ -1486,21 +1486,21 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 74 PointerType *int
+          Type: 26 PointerType *int
         - Name: len
           Offset: 8
-          Type: 8 BaseType int
+          Type: 7 BaseType int
         - Name: cap
           Offset: 16
-          Type: 8 BaseType int
+          Type: 7 BaseType int
       Data: 180 GoSliceDataType encoding/asn1.ObjectIdentifier.array
     - __kind: GoSliceDataType
       ID: 180
       Name: encoding/asn1.ObjectIdentifier.array
       ByteSize: 2048
-      Element: 8 BaseType int
+      Element: 7 BaseType int
     - __kind: GoInterfaceType
-      ID: 142
+      ID: 13
       Name: error
       ByteSize: 16
       GoRuntimeType: 1.031776e+06
@@ -1508,36 +1508,36 @@ Types:
       RawFields:
         - Name: tab
           Offset: 0
-          Type: 2 VoidPointerType unsafe.Pointer
+          Type: 14 VoidPointerType unsafe.Pointer
         - Name: data
           Offset: 8
-          Type: 2 VoidPointerType unsafe.Pointer
+          Type: 14 VoidPointerType unsafe.Pointer
     - __kind: BaseType
-      ID: 146
+      ID: 18
       Name: float32
       ByteSize: 4
       GoRuntimeType: 585344
       GoKind: 13
     - __kind: BaseType
-      ID: 143
+      ID: 15
       Name: float64
       ByteSize: 8
       GoRuntimeType: 585408
       GoKind: 14
     - __kind: GoSubroutineType
-      ID: 31
+      ID: 56
       Name: func() (io.ReadCloser, error)
       ByteSize: 8
       GoRuntimeType: 693344
       GoKind: 19
     - __kind: GoSubroutineType
-      ID: 113
+      ID: 136
       Name: func(string, []uint8, int) ([]uint8, error)
       ByteSize: 8
       GoRuntimeType: 1.003296e+06
       GoKind: 19
     - __kind: GoInterfaceType
-      ID: 138
+      ID: 161
       Name: gopkg.in/DataDog/dd-trace-go.v1/ddtrace.Span
       ByteSize: 16
       GoRuntimeType: 1.479712e+06
@@ -1545,84 +1545,84 @@ Types:
       RawFields:
         - Name: tab
           Offset: 0
-          Type: 2 VoidPointerType unsafe.Pointer
+          Type: 14 VoidPointerType unsafe.Pointer
         - Name: data
           Offset: 8
-          Type: 2 VoidPointerType unsafe.Pointer
+          Type: 14 VoidPointerType unsafe.Pointer
     - __kind: GoSwissMapGroupsType
-      ID: 43
+      ID: 67
       Name: groupReference<string,[]*mime/multipart.FileHeader>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 44 PointerType *noalg.map.group[string][]*mime/multipart.FileHeader
+          Type: 68 PointerType *noalg.map.group[string][]*mime/multipart.FileHeader
         - Name: lengthMask
           Offset: 8
-          Type: 17 BaseType uint64
-      GroupType: 45 StructureType noalg.map.group[string][]*mime/multipart.FileHeader
+          Type: 8 BaseType uint64
+      GroupType: 69 StructureType noalg.map.group[string][]*mime/multipart.FileHeader
       GroupSliceType: 169 GoSliceDataType []noalg.map.group[string][]*mime/multipart.FileHeader.array
     - __kind: GoSwissMapGroupsType
-      ID: 23
+      ID: 49
       Name: groupReference<string,[]string>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 24 PointerType *noalg.map.group[string][]string
+          Type: 50 PointerType *noalg.map.group[string][]string
         - Name: lengthMask
           Offset: 8
-          Type: 17 BaseType uint64
-      GroupType: 25 StructureType noalg.map.group[string][]string
+          Type: 8 BaseType uint64
+      GroupType: 51 StructureType noalg.map.group[string][]string
       GroupSliceType: 165 GoSliceDataType []noalg.map.group[string][]string.array
     - __kind: GoSwissMapGroupsType
-      ID: 130
+      ID: 153
       Name: groupReference<string,string>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 131 PointerType *noalg.map.group[string]string
+          Type: 154 PointerType *noalg.map.group[string]string
         - Name: lengthMask
           Offset: 8
-          Type: 17 BaseType uint64
-      GroupType: 132 StructureType noalg.map.group[string]string
+          Type: 8 BaseType uint64
+      GroupType: 155 StructureType noalg.map.group[string]string
       GroupSliceType: 213 GoSliceDataType []noalg.map.group[string]string.array
     - __kind: BaseType
-      ID: 8
+      ID: 7
       Name: int
       ByteSize: 8
       GoRuntimeType: 585024
       GoKind: 2
     - __kind: BaseType
-      ID: 157
+      ID: 31
       Name: int16
       ByteSize: 2
       GoRuntimeType: 584640
       GoKind: 4
     - __kind: BaseType
-      ID: 140
+      ID: 10
       Name: int32
       ByteSize: 4
       GoRuntimeType: 584768
       GoKind: 5
     - __kind: BaseType
-      ID: 32
+      ID: 12
       Name: int64
       ByteSize: 8
       GoRuntimeType: 584896
       GoKind: 6
     - __kind: BaseType
-      ID: 144
+      ID: 16
       Name: int8
       ByteSize: 1
       GoRuntimeType: 584512
       GoKind: 3
     - __kind: GoEmptyInterfaceType
-      ID: 63
+      ID: 87
       Name: interface {}
       ByteSize: 16
       GoRuntimeType: 854848
@@ -1630,12 +1630,12 @@ Types:
       RawFields:
         - Name: _type
           Offset: 0
-          Type: 2 VoidPointerType unsafe.Pointer
+          Type: 14 VoidPointerType unsafe.Pointer
         - Name: data
           Offset: 8
-          Type: 2 VoidPointerType unsafe.Pointer
+          Type: 14 VoidPointerType unsafe.Pointer
     - __kind: GoInterfaceType
-      ID: 30
+      ID: 55
       Name: io.ReadCloser
       ByteSize: 16
       GoRuntimeType: 1.110464e+06
@@ -1643,138 +1643,138 @@ Types:
       RawFields:
         - Name: tab
           Offset: 0
-          Type: 2 VoidPointerType unsafe.Pointer
+          Type: 14 VoidPointerType unsafe.Pointer
         - Name: data
           Offset: 8
-          Type: 2 VoidPointerType unsafe.Pointer
+          Type: 14 VoidPointerType unsafe.Pointer
     - __kind: GoSwissMapHeaderType
-      ID: 39
+      ID: 63
       Name: map<string,[]*mime/multipart.FileHeader>
       ByteSize: 48
       GoKind: 25
       RawFields:
         - Name: used
           Offset: 0
-          Type: 17 BaseType uint64
+          Type: 8 BaseType uint64
         - Name: seed
           Offset: 8
-          Type: 18 BaseType uintptr
+          Type: 1 BaseType uintptr
         - Name: dirPtr
           Offset: 16
-          Type: 40 PointerType **table<string,[]*mime/multipart.FileHeader>
+          Type: 64 PointerType **table<string,[]*mime/multipart.FileHeader>
         - Name: dirLen
           Offset: 24
-          Type: 8 BaseType int
+          Type: 7 BaseType int
         - Name: globalDepth
           Offset: 32
-          Type: 7 BaseType uint8
+          Type: 3 BaseType uint8
         - Name: globalShift
           Offset: 33
-          Type: 7 BaseType uint8
+          Type: 3 BaseType uint8
         - Name: writing
           Offset: 34
-          Type: 7 BaseType uint8
+          Type: 3 BaseType uint8
         - Name: tombstonePossible
           Offset: 35
-          Type: 13 BaseType bool
+          Type: 4 BaseType bool
         - Name: clearSeq
           Offset: 40
-          Type: 17 BaseType uint64
+          Type: 8 BaseType uint64
       TablePtrSliceType: 168 GoSliceDataType []*table<string,[]*mime/multipart.FileHeader>.array
-      GroupType: 45 StructureType noalg.map.group[string][]*mime/multipart.FileHeader
+      GroupType: 69 StructureType noalg.map.group[string][]*mime/multipart.FileHeader
     - __kind: GoSwissMapHeaderType
-      ID: 16
+      ID: 45
       Name: map<string,[]string>
       ByteSize: 48
       GoKind: 25
       RawFields:
         - Name: used
           Offset: 0
-          Type: 17 BaseType uint64
+          Type: 8 BaseType uint64
         - Name: seed
           Offset: 8
-          Type: 18 BaseType uintptr
+          Type: 1 BaseType uintptr
         - Name: dirPtr
           Offset: 16
-          Type: 19 PointerType **table<string,[]string>
+          Type: 46 PointerType **table<string,[]string>
         - Name: dirLen
           Offset: 24
-          Type: 8 BaseType int
+          Type: 7 BaseType int
         - Name: globalDepth
           Offset: 32
-          Type: 7 BaseType uint8
+          Type: 3 BaseType uint8
         - Name: globalShift
           Offset: 33
-          Type: 7 BaseType uint8
+          Type: 3 BaseType uint8
         - Name: writing
           Offset: 34
-          Type: 7 BaseType uint8
+          Type: 3 BaseType uint8
         - Name: tombstonePossible
           Offset: 35
-          Type: 13 BaseType bool
+          Type: 4 BaseType bool
         - Name: clearSeq
           Offset: 40
-          Type: 17 BaseType uint64
+          Type: 8 BaseType uint64
       TablePtrSliceType: 164 GoSliceDataType []*table<string,[]string>.array
-      GroupType: 25 StructureType noalg.map.group[string][]string
+      GroupType: 51 StructureType noalg.map.group[string][]string
     - __kind: GoSwissMapHeaderType
-      ID: 126
+      ID: 149
       Name: map<string,string>
       ByteSize: 48
       GoKind: 25
       RawFields:
         - Name: used
           Offset: 0
-          Type: 17 BaseType uint64
+          Type: 8 BaseType uint64
         - Name: seed
           Offset: 8
-          Type: 18 BaseType uintptr
+          Type: 1 BaseType uintptr
         - Name: dirPtr
           Offset: 16
-          Type: 127 PointerType **table<string,string>
+          Type: 150 PointerType **table<string,string>
         - Name: dirLen
           Offset: 24
-          Type: 8 BaseType int
+          Type: 7 BaseType int
         - Name: globalDepth
           Offset: 32
-          Type: 7 BaseType uint8
+          Type: 3 BaseType uint8
         - Name: globalShift
           Offset: 33
-          Type: 7 BaseType uint8
+          Type: 3 BaseType uint8
         - Name: writing
           Offset: 34
-          Type: 7 BaseType uint8
+          Type: 3 BaseType uint8
         - Name: tombstonePossible
           Offset: 35
-          Type: 13 BaseType bool
+          Type: 4 BaseType bool
         - Name: clearSeq
           Offset: 40
-          Type: 17 BaseType uint64
+          Type: 8 BaseType uint64
       TablePtrSliceType: 212 GoSliceDataType []*table<string,string>.array
-      GroupType: 132 StructureType noalg.map.group[string]string
+      GroupType: 155 StructureType noalg.map.group[string]string
     - __kind: GoMapType
-      ID: 37
+      ID: 61
       Name: map[string][]*mime/multipart.FileHeader
       ByteSize: 8
       GoRuntimeType: 1.132352e+06
       GoKind: 21
-      HeaderType: 39 GoSwissMapHeaderType map<string,[]*mime/multipart.FileHeader>
+      HeaderType: 63 GoSwissMapHeaderType map<string,[]*mime/multipart.FileHeader>
     - __kind: GoMapType
-      ID: 36
+      ID: 60
       Name: map[string][]string
       ByteSize: 8
       GoRuntimeType: 1.128e+06
       GoKind: 21
-      HeaderType: 16 GoSwissMapHeaderType map<string,[]string>
+      HeaderType: 45 GoSwissMapHeaderType map<string,[]string>
     - __kind: GoMapType
-      ID: 124
+      ID: 147
       Name: map[string]string
       ByteSize: 8
       GoRuntimeType: 1.129024e+06
       GoKind: 21
-      HeaderType: 126 GoSwissMapHeaderType map<string,string>
+      HeaderType: 149 GoSwissMapHeaderType map<string,string>
     - __kind: StructureType
-      ID: 65
+      ID: 89
       Name: math/big.Int
       ByteSize: 32
       GoRuntimeType: 1.494272e+06
@@ -1782,18 +1782,18 @@ Types:
       RawFields:
         - Name: neg
           Offset: 0
-          Type: 13 BaseType bool
+          Type: 4 BaseType bool
         - Name: abs
           Offset: 8
-          Type: 66 GoSliceHeaderType math/big.nat
+          Type: 90 GoSliceHeaderType math/big.nat
     - __kind: BaseType
-      ID: 68
+      ID: 92
       Name: math/big.Word
       ByteSize: 8
       GoRuntimeType: 588352
       GoKind: 7
     - __kind: GoSliceHeaderType
-      ID: 66
+      ID: 90
       Name: math/big.nat
       ByteSize: 24
       GoRuntimeType: 2.361856e+06
@@ -1801,21 +1801,21 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 67 PointerType *math/big.Word
+          Type: 91 PointerType *math/big.Word
         - Name: len
           Offset: 8
-          Type: 8 BaseType int
+          Type: 7 BaseType int
         - Name: cap
           Offset: 16
-          Type: 8 BaseType int
+          Type: 7 BaseType int
       Data: 176 GoSliceDataType math/big.nat.array
     - __kind: GoSliceDataType
       ID: 176
       Name: math/big.nat.array
       ByteSize: 2048
-      Element: 68 BaseType math/big.Word
+      Element: 92 BaseType math/big.Word
     - __kind: StructureType
-      ID: 51
+      ID: 75
       Name: mime/multipart.FileHeader
       ByteSize: 88
       GoRuntimeType: 1.977856e+06
@@ -1823,27 +1823,27 @@ Types:
       RawFields:
         - Name: Filename
           Offset: 0
-          Type: 5 GoStringHeaderType string
+          Type: 9 GoStringHeaderType string
         - Name: Header
           Offset: 16
-          Type: 52 GoMapType net/textproto.MIMEHeader
+          Type: 76 GoMapType net/textproto.MIMEHeader
         - Name: Size
           Offset: 24
-          Type: 32 BaseType int64
+          Type: 12 BaseType int64
         - Name: content
           Offset: 32
-          Type: 53 GoSliceHeaderType []uint8
+          Type: 77 GoSliceHeaderType []uint8
         - Name: tmpfile
           Offset: 56
-          Type: 5 GoStringHeaderType string
+          Type: 9 GoStringHeaderType string
         - Name: tmpoff
           Offset: 72
-          Type: 32 BaseType int64
+          Type: 12 BaseType int64
         - Name: tmpshared
           Offset: 80
-          Type: 13 BaseType bool
+          Type: 4 BaseType bool
     - __kind: StructureType
-      ID: 35
+      ID: 59
       Name: mime/multipart.Form
       ByteSize: 16
       GoRuntimeType: 1.478112e+06
@@ -1851,12 +1851,12 @@ Types:
       RawFields:
         - Name: Value
           Offset: 0
-          Type: 36 GoMapType map[string][]string
+          Type: 60 GoMapType map[string][]string
         - Name: File
           Offset: 8
-          Type: 37 GoMapType map[string][]*mime/multipart.FileHeader
+          Type: 61 GoMapType map[string][]*mime/multipart.FileHeader
     - __kind: GoSliceHeaderType
-      ID: 95
+      ID: 118
       Name: net.IP
       ByteSize: 24
       GoRuntimeType: 2.124512e+06
@@ -1864,21 +1864,21 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 6 PointerType *uint8
+          Type: 5 PointerType *uint8
         - Name: len
           Offset: 8
-          Type: 8 BaseType int
+          Type: 7 BaseType int
         - Name: cap
           Offset: 16
-          Type: 8 BaseType int
+          Type: 7 BaseType int
       Data: 194 GoSliceDataType net.IP.array
     - __kind: GoSliceDataType
       ID: 194
       Name: net.IP.array
       ByteSize: 2048
-      Element: 7 BaseType uint8
+      Element: 3 BaseType uint8
     - __kind: GoSliceHeaderType
-      ID: 102
+      ID: 125
       Name: net.IPMask
       ByteSize: 24
       GoRuntimeType: 1.019744e+06
@@ -1886,21 +1886,21 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 6 PointerType *uint8
+          Type: 5 PointerType *uint8
         - Name: len
           Offset: 8
-          Type: 8 BaseType int
+          Type: 7 BaseType int
         - Name: cap
           Offset: 16
-          Type: 8 BaseType int
+          Type: 7 BaseType int
       Data: 200 GoSliceDataType net.IPMask.array
     - __kind: GoSliceDataType
       ID: 200
       Name: net.IPMask.array
       ByteSize: 2048
-      Element: 7 BaseType uint8
+      Element: 3 BaseType uint8
     - __kind: StructureType
-      ID: 101
+      ID: 124
       Name: net.IPNet
       ByteSize: 48
       GoRuntimeType: 1.458912e+06
@@ -1908,19 +1908,19 @@ Types:
       RawFields:
         - Name: IP
           Offset: 0
-          Type: 95 GoSliceHeaderType net.IP
+          Type: 118 GoSliceHeaderType net.IP
         - Name: Mask
           Offset: 24
-          Type: 102 GoSliceHeaderType net.IPMask
+          Type: 125 GoSliceHeaderType net.IPMask
     - __kind: GoMapType
-      ID: 14
+      ID: 43
       Name: net/http.Header
       ByteSize: 8
       GoRuntimeType: 2.101632e+06
       GoKind: 21
-      HeaderType: 16 GoSwissMapHeaderType map<string,[]string>
+      HeaderType: 45 GoSwissMapHeaderType map<string,[]string>
     - __kind: StructureType
-      ID: 4
+      ID: 38
       Name: net/http.Request
       ByteSize: 304
       GoRuntimeType: 2.336832e+06
@@ -1928,84 +1928,84 @@ Types:
       RawFields:
         - Name: Method
           Offset: 0
-          Type: 5 GoStringHeaderType string
+          Type: 9 GoStringHeaderType string
         - Name: URL
           Offset: 16
-          Type: 9 PointerType *net/url.URL
+          Type: 39 PointerType *net/url.URL
         - Name: Proto
           Offset: 24
-          Type: 5 GoStringHeaderType string
+          Type: 9 GoStringHeaderType string
         - Name: ProtoMajor
           Offset: 40
-          Type: 8 BaseType int
+          Type: 7 BaseType int
         - Name: ProtoMinor
           Offset: 48
-          Type: 8 BaseType int
+          Type: 7 BaseType int
         - Name: Header
           Offset: 56
-          Type: 14 GoMapType net/http.Header
+          Type: 43 GoMapType net/http.Header
         - Name: Body
           Offset: 64
-          Type: 30 GoInterfaceType io.ReadCloser
+          Type: 55 GoInterfaceType io.ReadCloser
         - Name: GetBody
           Offset: 80
-          Type: 31 GoSubroutineType func() (io.ReadCloser, error)
+          Type: 56 GoSubroutineType func() (io.ReadCloser, error)
         - Name: ContentLength
           Offset: 88
-          Type: 32 BaseType int64
+          Type: 12 BaseType int64
         - Name: TransferEncoding
           Offset: 96
-          Type: 28 GoSliceHeaderType []string
+          Type: 54 GoSliceHeaderType []string
         - Name: Close
           Offset: 120
-          Type: 13 BaseType bool
+          Type: 4 BaseType bool
         - Name: Host
           Offset: 128
-          Type: 5 GoStringHeaderType string
+          Type: 9 GoStringHeaderType string
         - Name: Form
           Offset: 144
-          Type: 33 GoMapType net/url.Values
+          Type: 57 GoMapType net/url.Values
         - Name: PostForm
           Offset: 152
-          Type: 33 GoMapType net/url.Values
+          Type: 57 GoMapType net/url.Values
         - Name: MultipartForm
           Offset: 160
-          Type: 34 PointerType *mime/multipart.Form
+          Type: 58 PointerType *mime/multipart.Form
         - Name: Trailer
           Offset: 168
-          Type: 14 GoMapType net/http.Header
+          Type: 43 GoMapType net/http.Header
         - Name: RemoteAddr
           Offset: 176
-          Type: 5 GoStringHeaderType string
+          Type: 9 GoStringHeaderType string
         - Name: RequestURI
           Offset: 192
-          Type: 5 GoStringHeaderType string
+          Type: 9 GoStringHeaderType string
         - Name: TLS
           Offset: 208
-          Type: 54 PointerType *crypto/tls.ConnectionState
+          Type: 78 PointerType *crypto/tls.ConnectionState
         - Name: Cancel
           Offset: 216
-          Type: 115 GoChannelType <-chan struct {}
+          Type: 138 GoChannelType <-chan struct {}
         - Name: Response
           Offset: 224
-          Type: 116 PointerType *net/http.Response
+          Type: 139 PointerType *net/http.Response
         - Name: Pattern
           Offset: 232
-          Type: 5 GoStringHeaderType string
+          Type: 9 GoStringHeaderType string
         - Name: ctx
           Offset: 248
-          Type: 118 GoInterfaceType context.Context
+          Type: 141 GoInterfaceType context.Context
         - Name: pat
           Offset: 264
-          Type: 119 PointerType *net/http.pattern
+          Type: 142 PointerType *net/http.pattern
         - Name: matches
           Offset: 272
-          Type: 28 GoSliceHeaderType []string
+          Type: 54 GoSliceHeaderType []string
         - Name: otherValues
           Offset: 296
-          Type: 124 GoMapType map[string]string
+          Type: 147 GoMapType map[string]string
     - __kind: StructureType
-      ID: 117
+      ID: 140
       Name: net/http.Response
       ByteSize: 144
       GoRuntimeType: 2.210656e+06
@@ -2013,48 +2013,48 @@ Types:
       RawFields:
         - Name: Status
           Offset: 0
-          Type: 5 GoStringHeaderType string
+          Type: 9 GoStringHeaderType string
         - Name: StatusCode
           Offset: 16
-          Type: 8 BaseType int
+          Type: 7 BaseType int
         - Name: Proto
           Offset: 24
-          Type: 5 GoStringHeaderType string
+          Type: 9 GoStringHeaderType string
         - Name: ProtoMajor
           Offset: 40
-          Type: 8 BaseType int
+          Type: 7 BaseType int
         - Name: ProtoMinor
           Offset: 48
-          Type: 8 BaseType int
+          Type: 7 BaseType int
         - Name: Header
           Offset: 56
-          Type: 14 GoMapType net/http.Header
+          Type: 43 GoMapType net/http.Header
         - Name: Body
           Offset: 64
-          Type: 30 GoInterfaceType io.ReadCloser
+          Type: 55 GoInterfaceType io.ReadCloser
         - Name: ContentLength
           Offset: 80
-          Type: 32 BaseType int64
+          Type: 12 BaseType int64
         - Name: TransferEncoding
           Offset: 88
-          Type: 28 GoSliceHeaderType []string
+          Type: 54 GoSliceHeaderType []string
         - Name: Close
           Offset: 112
-          Type: 13 BaseType bool
+          Type: 4 BaseType bool
         - Name: Uncompressed
           Offset: 113
-          Type: 13 BaseType bool
+          Type: 4 BaseType bool
         - Name: Trailer
           Offset: 120
-          Type: 14 GoMapType net/http.Header
+          Type: 43 GoMapType net/http.Header
         - Name: Request
           Offset: 128
-          Type: 3 PointerType *net/http.Request
+          Type: 37 PointerType *net/http.Request
         - Name: TLS
           Offset: 136
-          Type: 54 PointerType *crypto/tls.ConnectionState
+          Type: 78 PointerType *crypto/tls.ConnectionState
     - __kind: GoInterfaceType
-      ID: 1
+      ID: 36
       Name: net/http.ResponseWriter
       ByteSize: 16
       GoRuntimeType: 1.185792e+06
@@ -2062,12 +2062,12 @@ Types:
       RawFields:
         - Name: tab
           Offset: 0
-          Type: 2 VoidPointerType unsafe.Pointer
+          Type: 14 VoidPointerType unsafe.Pointer
         - Name: data
           Offset: 8
-          Type: 2 VoidPointerType unsafe.Pointer
+          Type: 14 VoidPointerType unsafe.Pointer
     - __kind: StructureType
-      ID: 120
+      ID: 143
       Name: net/http.pattern
       ByteSize: 88
       GoRuntimeType: 1.833632e+06
@@ -2075,21 +2075,21 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 5 GoStringHeaderType string
+          Type: 9 GoStringHeaderType string
         - Name: method
           Offset: 16
-          Type: 5 GoStringHeaderType string
+          Type: 9 GoStringHeaderType string
         - Name: host
           Offset: 32
-          Type: 5 GoStringHeaderType string
+          Type: 9 GoStringHeaderType string
         - Name: segments
           Offset: 48
-          Type: 121 GoSliceHeaderType []net/http.segment
+          Type: 144 GoSliceHeaderType []net/http.segment
         - Name: loc
           Offset: 72
-          Type: 5 GoStringHeaderType string
+          Type: 9 GoStringHeaderType string
     - __kind: StructureType
-      ID: 123
+      ID: 146
       Name: net/http.segment
       ByteSize: 24
       GoRuntimeType: 1.608416e+06
@@ -2097,22 +2097,22 @@ Types:
       RawFields:
         - Name: s
           Offset: 0
-          Type: 5 GoStringHeaderType string
+          Type: 9 GoStringHeaderType string
         - Name: wild
           Offset: 16
-          Type: 13 BaseType bool
+          Type: 4 BaseType bool
         - Name: multi
           Offset: 17
-          Type: 13 BaseType bool
+          Type: 4 BaseType bool
     - __kind: GoMapType
-      ID: 52
+      ID: 76
       Name: net/textproto.MIMEHeader
       ByteSize: 8
       GoRuntimeType: 1.823584e+06
       GoKind: 21
-      HeaderType: 16 GoSwissMapHeaderType map<string,[]string>
+      HeaderType: 45 GoSwissMapHeaderType map<string,[]string>
     - __kind: StructureType
-      ID: 10
+      ID: 40
       Name: net/url.URL
       ByteSize: 144
       GoRuntimeType: 2.127584e+06
@@ -2120,39 +2120,39 @@ Types:
       RawFields:
         - Name: Scheme
           Offset: 0
-          Type: 5 GoStringHeaderType string
+          Type: 9 GoStringHeaderType string
         - Name: Opaque
           Offset: 16
-          Type: 5 GoStringHeaderType string
+          Type: 9 GoStringHeaderType string
         - Name: User
           Offset: 32
-          Type: 11 PointerType *net/url.Userinfo
+          Type: 41 PointerType *net/url.Userinfo
         - Name: Host
           Offset: 40
-          Type: 5 GoStringHeaderType string
+          Type: 9 GoStringHeaderType string
         - Name: Path
           Offset: 56
-          Type: 5 GoStringHeaderType string
+          Type: 9 GoStringHeaderType string
         - Name: RawPath
           Offset: 72
-          Type: 5 GoStringHeaderType string
+          Type: 9 GoStringHeaderType string
         - Name: OmitHost
           Offset: 88
-          Type: 13 BaseType bool
+          Type: 4 BaseType bool
         - Name: ForceQuery
           Offset: 89
-          Type: 13 BaseType bool
+          Type: 4 BaseType bool
         - Name: RawQuery
           Offset: 96
-          Type: 5 GoStringHeaderType string
+          Type: 9 GoStringHeaderType string
         - Name: Fragment
           Offset: 112
-          Type: 5 GoStringHeaderType string
+          Type: 9 GoStringHeaderType string
         - Name: RawFragment
           Offset: 128
-          Type: 5 GoStringHeaderType string
+          Type: 9 GoStringHeaderType string
     - __kind: StructureType
-      ID: 12
+      ID: 42
       Name: net/url.Userinfo
       ByteSize: 40
       GoRuntimeType: 1.624928e+06
@@ -2160,49 +2160,49 @@ Types:
       RawFields:
         - Name: username
           Offset: 0
-          Type: 5 GoStringHeaderType string
+          Type: 9 GoStringHeaderType string
         - Name: password
           Offset: 16
-          Type: 5 GoStringHeaderType string
+          Type: 9 GoStringHeaderType string
         - Name: passwordSet
           Offset: 32
-          Type: 13 BaseType bool
+          Type: 4 BaseType bool
     - __kind: GoMapType
-      ID: 33
+      ID: 57
       Name: net/url.Values
       ByteSize: 8
       GoRuntimeType: 1.885152e+06
       GoKind: 21
-      HeaderType: 16 GoSwissMapHeaderType map<string,[]string>
+      HeaderType: 45 GoSwissMapHeaderType map<string,[]string>
     - __kind: ArrayType
-      ID: 46
+      ID: 70
       Name: noalg.[8]struct { key string; elem []*mime/multipart.FileHeader }
       ByteSize: 320
       GoRuntimeType: 699200
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 47 StructureType noalg.struct { key string; elem []*mime/multipart.FileHeader }
+      Element: 71 StructureType noalg.struct { key string; elem []*mime/multipart.FileHeader }
     - __kind: ArrayType
-      ID: 26
+      ID: 52
       Name: noalg.[8]struct { key string; elem []string }
       ByteSize: 320
       GoRuntimeType: 689376
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 27 StructureType noalg.struct { key string; elem []string }
+      Element: 53 StructureType noalg.struct { key string; elem []string }
     - __kind: ArrayType
-      ID: 133
+      ID: 156
       Name: noalg.[8]struct { key string; elem string }
       ByteSize: 256
       GoRuntimeType: 693536
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 134 StructureType noalg.struct { key string; elem string }
+      Element: 157 StructureType noalg.struct { key string; elem string }
     - __kind: StructureType
-      ID: 45
+      ID: 69
       Name: noalg.map.group[string][]*mime/multipart.FileHeader
       ByteSize: 328
       GoRuntimeType: 1.29952e+06
@@ -2210,12 +2210,12 @@ Types:
       RawFields:
         - Name: ctrl
           Offset: 0
-          Type: 17 BaseType uint64
+          Type: 8 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 46 ArrayType noalg.[8]struct { key string; elem []*mime/multipart.FileHeader }
+          Type: 70 ArrayType noalg.[8]struct { key string; elem []*mime/multipart.FileHeader }
     - __kind: StructureType
-      ID: 25
+      ID: 51
       Name: noalg.map.group[string][]string
       ByteSize: 328
       GoRuntimeType: 1.290432e+06
@@ -2223,12 +2223,12 @@ Types:
       RawFields:
         - Name: ctrl
           Offset: 0
-          Type: 17 BaseType uint64
+          Type: 8 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 26 ArrayType noalg.[8]struct { key string; elem []string }
+          Type: 52 ArrayType noalg.[8]struct { key string; elem []string }
     - __kind: StructureType
-      ID: 132
+      ID: 155
       Name: noalg.map.group[string]string
       ByteSize: 264
       GoRuntimeType: 1.292864e+06
@@ -2236,12 +2236,12 @@ Types:
       RawFields:
         - Name: ctrl
           Offset: 0
-          Type: 17 BaseType uint64
+          Type: 8 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 133 ArrayType noalg.[8]struct { key string; elem string }
+          Type: 156 ArrayType noalg.[8]struct { key string; elem string }
     - __kind: StructureType
-      ID: 47
+      ID: 71
       Name: noalg.struct { key string; elem []*mime/multipart.FileHeader }
       ByteSize: 40
       GoRuntimeType: 1.299392e+06
@@ -2249,12 +2249,12 @@ Types:
       RawFields:
         - Name: key
           Offset: 0
-          Type: 5 GoStringHeaderType string
+          Type: 9 GoStringHeaderType string
         - Name: elem
           Offset: 16
-          Type: 48 GoSliceHeaderType []*mime/multipart.FileHeader
+          Type: 72 GoSliceHeaderType []*mime/multipart.FileHeader
     - __kind: StructureType
-      ID: 27
+      ID: 53
       Name: noalg.struct { key string; elem []string }
       ByteSize: 40
       GoRuntimeType: 1.290304e+06
@@ -2262,12 +2262,12 @@ Types:
       RawFields:
         - Name: key
           Offset: 0
-          Type: 5 GoStringHeaderType string
+          Type: 9 GoStringHeaderType string
         - Name: elem
           Offset: 16
-          Type: 28 GoSliceHeaderType []string
+          Type: 54 GoSliceHeaderType []string
     - __kind: StructureType
-      ID: 134
+      ID: 157
       Name: noalg.struct { key string; elem string }
       ByteSize: 32
       GoRuntimeType: 1.292736e+06
@@ -2275,12 +2275,12 @@ Types:
       RawFields:
         - Name: key
           Offset: 0
-          Type: 5 GoStringHeaderType string
+          Type: 9 GoStringHeaderType string
         - Name: elem
           Offset: 16
-          Type: 5 GoStringHeaderType string
+          Type: 9 GoStringHeaderType string
     - __kind: GoStringHeaderType
-      ID: 5
+      ID: 9
       Name: string
       ByteSize: 16
       GoRuntimeType: 584448
@@ -2291,86 +2291,86 @@ Types:
           Type: 163 PointerType *string.str
         - Name: len
           Offset: 8
-          Type: 8 BaseType int
+          Type: 7 BaseType int
       Data: 162 GoStringDataType string.str
     - __kind: GoStringDataType
       ID: 162
       Name: string.str
       ByteSize: 2048
     - __kind: StructureType
-      ID: 42
+      ID: 66
       Name: table<string,[]*mime/multipart.FileHeader>
       ByteSize: 32
       GoKind: 25
       RawFields:
         - Name: used
           Offset: 0
-          Type: 22 BaseType uint16
+          Type: 6 BaseType uint16
         - Name: capacity
           Offset: 2
-          Type: 22 BaseType uint16
+          Type: 6 BaseType uint16
         - Name: growthLeft
           Offset: 4
-          Type: 22 BaseType uint16
+          Type: 6 BaseType uint16
         - Name: localDepth
           Offset: 6
-          Type: 7 BaseType uint8
+          Type: 3 BaseType uint8
         - Name: index
           Offset: 8
-          Type: 8 BaseType int
+          Type: 7 BaseType int
         - Name: groups
           Offset: 16
-          Type: 43 GoSwissMapGroupsType groupReference<string,[]*mime/multipart.FileHeader>
+          Type: 67 GoSwissMapGroupsType groupReference<string,[]*mime/multipart.FileHeader>
     - __kind: StructureType
-      ID: 21
+      ID: 48
       Name: table<string,[]string>
       ByteSize: 32
       GoKind: 25
       RawFields:
         - Name: used
           Offset: 0
-          Type: 22 BaseType uint16
+          Type: 6 BaseType uint16
         - Name: capacity
           Offset: 2
-          Type: 22 BaseType uint16
+          Type: 6 BaseType uint16
         - Name: growthLeft
           Offset: 4
-          Type: 22 BaseType uint16
+          Type: 6 BaseType uint16
         - Name: localDepth
           Offset: 6
-          Type: 7 BaseType uint8
+          Type: 3 BaseType uint8
         - Name: index
           Offset: 8
-          Type: 8 BaseType int
+          Type: 7 BaseType int
         - Name: groups
           Offset: 16
-          Type: 23 GoSwissMapGroupsType groupReference<string,[]string>
+          Type: 49 GoSwissMapGroupsType groupReference<string,[]string>
     - __kind: StructureType
-      ID: 129
+      ID: 152
       Name: table<string,string>
       ByteSize: 32
       GoKind: 25
       RawFields:
         - Name: used
           Offset: 0
-          Type: 22 BaseType uint16
+          Type: 6 BaseType uint16
         - Name: capacity
           Offset: 2
-          Type: 22 BaseType uint16
+          Type: 6 BaseType uint16
         - Name: growthLeft
           Offset: 4
-          Type: 22 BaseType uint16
+          Type: 6 BaseType uint16
         - Name: localDepth
           Offset: 6
-          Type: 7 BaseType uint8
+          Type: 3 BaseType uint8
         - Name: index
           Offset: 8
-          Type: 8 BaseType int
+          Type: 7 BaseType int
         - Name: groups
           Offset: 16
-          Type: 130 GoSwissMapGroupsType groupReference<string,string>
+          Type: 153 GoSwissMapGroupsType groupReference<string,string>
     - __kind: StructureType
-      ID: 77
+      ID: 100
       Name: time.Location
       ByteSize: 104
       GoRuntimeType: 1.973536e+06
@@ -2378,27 +2378,27 @@ Types:
       RawFields:
         - Name: name
           Offset: 0
-          Type: 5 GoStringHeaderType string
+          Type: 9 GoStringHeaderType string
         - Name: zone
           Offset: 16
-          Type: 78 GoSliceHeaderType []time.zone
+          Type: 101 GoSliceHeaderType []time.zone
         - Name: tx
           Offset: 40
-          Type: 81 GoSliceHeaderType []time.zoneTrans
+          Type: 104 GoSliceHeaderType []time.zoneTrans
         - Name: extend
           Offset: 64
-          Type: 5 GoStringHeaderType string
+          Type: 9 GoStringHeaderType string
         - Name: cacheStart
           Offset: 80
-          Type: 32 BaseType int64
+          Type: 12 BaseType int64
         - Name: cacheEnd
           Offset: 88
-          Type: 32 BaseType int64
+          Type: 12 BaseType int64
         - Name: cacheZone
           Offset: 96
-          Type: 79 PointerType *time.zone
+          Type: 102 PointerType *time.zone
     - __kind: StructureType
-      ID: 75
+      ID: 98
       Name: time.Time
       ByteSize: 24
       GoRuntimeType: 2.364704e+06
@@ -2406,15 +2406,15 @@ Types:
       RawFields:
         - Name: wall
           Offset: 0
-          Type: 17 BaseType uint64
+          Type: 8 BaseType uint64
         - Name: ext
           Offset: 8
-          Type: 32 BaseType int64
+          Type: 12 BaseType int64
         - Name: loc
           Offset: 16
-          Type: 76 PointerType *time.Location
+          Type: 99 PointerType *time.Location
     - __kind: StructureType
-      ID: 80
+      ID: 103
       Name: time.zone
       ByteSize: 32
       GoRuntimeType: 1.613408e+06
@@ -2422,15 +2422,15 @@ Types:
       RawFields:
         - Name: name
           Offset: 0
-          Type: 5 GoStringHeaderType string
+          Type: 9 GoStringHeaderType string
         - Name: offset
           Offset: 16
-          Type: 8 BaseType int
+          Type: 7 BaseType int
         - Name: isDST
           Offset: 24
-          Type: 13 BaseType bool
+          Type: 4 BaseType bool
     - __kind: StructureType
-      ID: 83
+      ID: 106
       Name: time.zoneTrans
       ByteSize: 16
       GoRuntimeType: 1.750848e+06
@@ -2438,54 +2438,54 @@ Types:
       RawFields:
         - Name: when
           Offset: 0
-          Type: 32 BaseType int64
+          Type: 12 BaseType int64
         - Name: index
           Offset: 8
-          Type: 7 BaseType uint8
+          Type: 3 BaseType uint8
         - Name: isstd
           Offset: 9
-          Type: 13 BaseType bool
+          Type: 4 BaseType bool
         - Name: isutc
           Offset: 10
-          Type: 13 BaseType bool
+          Type: 4 BaseType bool
     - __kind: BaseType
-      ID: 145
+      ID: 17
       Name: uint
       ByteSize: 8
       GoRuntimeType: 585088
       GoKind: 7
     - __kind: BaseType
-      ID: 22
+      ID: 6
       Name: uint16
       ByteSize: 2
       GoRuntimeType: 584704
       GoKind: 9
     - __kind: BaseType
-      ID: 139
+      ID: 2
       Name: uint32
       ByteSize: 4
       GoRuntimeType: 584832
       GoKind: 10
     - __kind: BaseType
-      ID: 17
+      ID: 8
       Name: uint64
       ByteSize: 8
       GoRuntimeType: 584960
       GoKind: 11
     - __kind: BaseType
-      ID: 7
+      ID: 3
       Name: uint8
       ByteSize: 1
       GoRuntimeType: 584576
       GoKind: 8
     - __kind: BaseType
-      ID: 18
+      ID: 1
       Name: uintptr
       ByteSize: 8
       GoRuntimeType: 585152
       GoKind: 12
     - __kind: VoidPointerType
-      ID: 2
+      ID: 14
       Name: unsafe.Pointer
       ByteSize: 8
       GoRuntimeType: 585536

--- a/pkg/dyninst/irgen/testdata/snapshot/rc_tester_v1.arch=amd64,toolchain=go1.25.0.yaml
+++ b/pkg/dyninst/irgen/testdata/snapshot/rc_tester_v1.arch=amd64,toolchain=go1.25.0.yaml
@@ -114,34 +114,34 @@ Subprograms:
           IsReturn: false
 Types:
     - __kind: PointerType
-      ID: 81
+      ID: 83
       Name: '**crypto/x509.Certificate'
       ByteSize: 8
       GoKind: 22
-      Pointee: 82 PointerType *crypto/x509.Certificate
+      Pointee: 84 PointerType *crypto/x509.Certificate
     - __kind: PointerType
-      ID: 147
+      ID: 121
       Name: '**mime/multipart.FileHeader'
       ByteSize: 8
       GoKind: 22
-      Pointee: 148 PointerType *mime/multipart.FileHeader
+      Pointee: 122 PointerType *mime/multipart.FileHeader
     - __kind: PointerType
-      ID: 134
+      ID: 161
       Name: '**net.IPNet'
       ByteSize: 8
       GoKind: 22
-      Pointee: 135 PointerType *net.IPNet
+      Pointee: 162 PointerType *net.IPNet
     - __kind: PointerType
-      ID: 132
+      ID: 159
       Name: '**net/url.URL'
       ByteSize: 8
       GoKind: 22
       Pointee: 42 PointerType *net/url.URL
     - __kind: PointerType
-      ID: 77
+      ID: 79
       Name: '**table<string,[]*mime/multipart.FileHeader>'
       ByteSize: 8
-      Pointee: 78 PointerType *table<string,[]*mime/multipart.FileHeader>
+      Pointee: 80 PointerType *table<string,[]*mime/multipart.FileHeader>
     - __kind: PointerType
       ID: 47
       Name: '**table<string,[]string>'
@@ -153,86 +153,86 @@ Types:
       ByteSize: 8
       Pointee: 67 PointerType *table<string,string>
     - __kind: PointerType
-      ID: 84
+      ID: 86
       Name: '*[]*crypto/x509.Certificate'
       ByteSize: 8
       GoKind: 22
-      Pointee: 80 GoSliceHeaderType []*crypto/x509.Certificate
+      Pointee: 82 GoSliceHeaderType []*crypto/x509.Certificate
     - __kind: PointerType
-      ID: 175
+      ID: 126
       Name: '*[]*crypto/x509.Certificate.array'
       ByteSize: 8
-      Pointee: 174 GoSliceDataType []*crypto/x509.Certificate.array
+      Pointee: 125 GoSliceDataType []*crypto/x509.Certificate.array
     - __kind: PointerType
-      ID: 205
+      ID: 171
       Name: '*[]*mime/multipart.FileHeader.array'
       ByteSize: 8
-      Pointee: 204 GoSliceDataType []*mime/multipart.FileHeader.array
+      Pointee: 170 GoSliceDataType []*mime/multipart.FileHeader.array
     - __kind: PointerType
-      ID: 199
+      ID: 200
       Name: '*[]*net.IPNet.array'
       ByteSize: 8
-      Pointee: 198 GoSliceDataType []*net.IPNet.array
+      Pointee: 199 GoSliceDataType []*net.IPNet.array
     - __kind: PointerType
-      ID: 197
+      ID: 198
       Name: '*[]*net/url.URL.array'
       ByteSize: 8
-      Pointee: 196 GoSliceDataType []*net/url.URL.array
+      Pointee: 197 GoSliceDataType []*net/url.URL.array
     - __kind: PointerType
-      ID: 177
+      ID: 128
       Name: '*[][]*crypto/x509.Certificate.array'
       ByteSize: 8
-      Pointee: 176 GoSliceDataType [][]*crypto/x509.Certificate.array
+      Pointee: 127 GoSliceDataType [][]*crypto/x509.Certificate.array
     - __kind: PointerType
-      ID: 179
+      ID: 130
       Name: '*[][]uint8.array'
       ByteSize: 8
-      Pointee: 178 GoSliceDataType [][]uint8.array
+      Pointee: 129 GoSliceDataType [][]uint8.array
     - __kind: PointerType
-      ID: 191
+      ID: 192
       Name: '*[]crypto/x509.ExtKeyUsage.array'
       ByteSize: 8
-      Pointee: 190 GoSliceDataType []crypto/x509.ExtKeyUsage.array
+      Pointee: 191 GoSliceDataType []crypto/x509.ExtKeyUsage.array
     - __kind: PointerType
-      ID: 201
+      ID: 202
       Name: '*[]crypto/x509.OID.array'
       ByteSize: 8
-      Pointee: 200 GoSliceDataType []crypto/x509.OID.array
+      Pointee: 201 GoSliceDataType []crypto/x509.OID.array
     - __kind: PointerType
-      ID: 203
+      ID: 204
       Name: '*[]crypto/x509.PolicyMapping.array'
       ByteSize: 8
-      Pointee: 202 GoSliceDataType []crypto/x509.PolicyMapping.array
+      Pointee: 203 GoSliceDataType []crypto/x509.PolicyMapping.array
     - __kind: PointerType
-      ID: 183
+      ID: 184
       Name: '*[]crypto/x509/pkix.AttributeTypeAndValue.array'
       ByteSize: 8
-      Pointee: 182 GoSliceDataType []crypto/x509/pkix.AttributeTypeAndValue.array
+      Pointee: 183 GoSliceDataType []crypto/x509/pkix.AttributeTypeAndValue.array
     - __kind: PointerType
-      ID: 185
+      ID: 186
       Name: '*[]crypto/x509/pkix.Extension.array'
       ByteSize: 8
-      Pointee: 184 GoSliceDataType []crypto/x509/pkix.Extension.array
+      Pointee: 185 GoSliceDataType []crypto/x509/pkix.Extension.array
     - __kind: PointerType
-      ID: 187
+      ID: 188
       Name: '*[]encoding/asn1.ObjectIdentifier.array'
       ByteSize: 8
-      Pointee: 186 GoSliceDataType []encoding/asn1.ObjectIdentifier.array
+      Pointee: 187 GoSliceDataType []encoding/asn1.ObjectIdentifier.array
     - __kind: PointerType
-      ID: 193
+      ID: 194
       Name: '*[]net.IP.array'
       ByteSize: 8
-      Pointee: 192 GoSliceDataType []net.IP.array
+      Pointee: 193 GoSliceDataType []net.IP.array
     - __kind: PointerType
-      ID: 181
+      ID: 132
       Name: '*[]net/http.segment.array'
       ByteSize: 8
-      Pointee: 180 GoSliceDataType []net/http.segment.array
+      Pointee: 131 GoSliceDataType []net/http.segment.array
     - __kind: PointerType
-      ID: 167
+      ID: 103
       Name: '*[]string.array'
       ByteSize: 8
-      Pointee: 166 GoSliceDataType []string.array
+      Pointee: 102 GoSliceDataType []string.array
     - __kind: PointerType
       ID: 209
       Name: '*[]time.zone.array'
@@ -244,17 +244,17 @@ Types:
       ByteSize: 8
       Pointee: 210 GoSliceDataType []time.zoneTrans.array
     - __kind: PointerType
-      ID: 86
+      ID: 88
       Name: '*[]uint8'
       ByteSize: 8
       GoRuntimeType: 481600
       GoKind: 22
       Pointee: 68 GoSliceHeaderType []uint8
     - __kind: PointerType
-      ID: 171
+      ID: 112
       Name: '*[]uint8.array'
       ByteSize: 8
-      Pointee: 170 GoSliceDataType []uint8.array
+      Pointee: 111 GoSliceDataType []uint8.array
     - __kind: PointerType
       ID: 11
       Name: '*bool'
@@ -277,59 +277,59 @@ Types:
       GoKind: 22
       Pointee: 56 StructureType crypto/tls.ConnectionState
     - __kind: PointerType
-      ID: 82
+      ID: 84
       Name: '*crypto/x509.Certificate'
       ByteSize: 8
       GoRuntimeType: 2.043968e+06
       GoKind: 22
-      Pointee: 97 StructureType crypto/x509.Certificate
+      Pointee: 114 StructureType crypto/x509.Certificate
     - __kind: PointerType
-      ID: 126
+      ID: 153
       Name: '*crypto/x509.ExtKeyUsage'
       ByteSize: 8
       GoRuntimeType: 423552
       GoKind: 22
-      Pointee: 127 BaseType crypto/x509.ExtKeyUsage
+      Pointee: 154 BaseType crypto/x509.ExtKeyUsage
     - __kind: PointerType
-      ID: 137
+      ID: 164
       Name: '*crypto/x509.OID'
       ByteSize: 8
       GoRuntimeType: 1.954336e+06
       GoKind: 22
-      Pointee: 138 StructureType crypto/x509.OID
+      Pointee: 165 StructureType crypto/x509.OID
     - __kind: PointerType
-      ID: 140
+      ID: 167
       Name: '*crypto/x509.PolicyMapping'
       ByteSize: 8
       GoRuntimeType: 423616
       GoKind: 22
-      Pointee: 141 StructureType crypto/x509.PolicyMapping
+      Pointee: 168 StructureType crypto/x509.PolicyMapping
     - __kind: PointerType
-      ID: 113
+      ID: 140
       Name: '*crypto/x509/pkix.AttributeTypeAndValue'
       ByteSize: 8
       GoRuntimeType: 437312
       GoKind: 22
-      Pointee: 114 StructureType crypto/x509/pkix.AttributeTypeAndValue
+      Pointee: 141 StructureType crypto/x509/pkix.AttributeTypeAndValue
     - __kind: PointerType
-      ID: 120
+      ID: 147
       Name: '*crypto/x509/pkix.Extension'
       ByteSize: 8
       GoRuntimeType: 437504
       GoKind: 22
-      Pointee: 121 StructureType crypto/x509/pkix.Extension
+      Pointee: 148 StructureType crypto/x509/pkix.Extension
     - __kind: PointerType
-      ID: 123
+      ID: 150
       Name: '*encoding/asn1.ObjectIdentifier'
       ByteSize: 8
       GoRuntimeType: 1.053408e+06
       GoKind: 22
-      Pointee: 124 GoSliceHeaderType encoding/asn1.ObjectIdentifier
+      Pointee: 151 GoSliceHeaderType encoding/asn1.ObjectIdentifier
     - __kind: PointerType
-      ID: 189
+      ID: 190
       Name: '*encoding/asn1.ObjectIdentifier.array'
       ByteSize: 8
-      Pointee: 188 GoSliceDataType encoding/asn1.ObjectIdentifier.array
+      Pointee: 189 GoSliceDataType encoding/asn1.ObjectIdentifier.array
     - __kind: PointerType
       ID: 33
       Name: '*error'
@@ -387,10 +387,10 @@ Types:
       GoKind: 22
       Pointee: 16 BaseType int8
     - __kind: PointerType
-      ID: 75
+      ID: 77
       Name: '*map<string,[]*mime/multipart.FileHeader>'
       ByteSize: 8
-      Pointee: 76 GoSwissMapHeaderType map<string,[]*mime/multipart.FileHeader>
+      Pointee: 78 GoSwissMapHeaderType map<string,[]*mime/multipart.FileHeader>
     - __kind: PointerType
       ID: 45
       Name: '*map<string,[]string>'
@@ -402,31 +402,31 @@ Types:
       ByteSize: 8
       Pointee: 65 GoSwissMapHeaderType map<string,string>
     - __kind: PointerType
-      ID: 109
+      ID: 136
       Name: '*math/big.Int'
       ByteSize: 8
       GoRuntimeType: 2.382336e+06
       GoKind: 22
-      Pointee: 110 StructureType math/big.Int
+      Pointee: 137 StructureType math/big.Int
     - __kind: PointerType
-      ID: 150
+      ID: 173
       Name: '*math/big.Word'
       ByteSize: 8
       GoRuntimeType: 426432
       GoKind: 22
-      Pointee: 151 BaseType math/big.Word
+      Pointee: 174 BaseType math/big.Word
     - __kind: PointerType
       ID: 207
       Name: '*math/big.nat.array'
       ByteSize: 8
       Pointee: 206 GoSliceDataType math/big.nat.array
     - __kind: PointerType
-      ID: 148
+      ID: 122
       Name: '*mime/multipart.FileHeader'
       ByteSize: 8
       GoRuntimeType: 909888
       GoKind: 22
-      Pointee: 159 StructureType mime/multipart.FileHeader
+      Pointee: 169 StructureType mime/multipart.FileHeader
     - __kind: PointerType
       ID: 53
       Name: '*mime/multipart.Form'
@@ -435,29 +435,29 @@ Types:
       GoKind: 22
       Pointee: 54 StructureType mime/multipart.Form
     - __kind: PointerType
-      ID: 129
+      ID: 156
       Name: '*net.IP'
       ByteSize: 8
       GoRuntimeType: 2.150176e+06
       GoKind: 22
-      Pointee: 130 GoSliceHeaderType net.IP
+      Pointee: 157 GoSliceHeaderType net.IP
     - __kind: PointerType
-      ID: 195
+      ID: 196
       Name: '*net.IP.array'
       ByteSize: 8
-      Pointee: 194 GoSliceDataType net.IP.array
+      Pointee: 195 GoSliceDataType net.IP.array
     - __kind: PointerType
       ID: 213
       Name: '*net.IPMask.array'
       ByteSize: 8
       Pointee: 212 GoSliceDataType net.IPMask.array
     - __kind: PointerType
-      ID: 135
+      ID: 162
       Name: '*net.IPNet'
       ByteSize: 8
       GoRuntimeType: 1.18336e+06
       GoKind: 22
-      Pointee: 158 StructureType net.IPNet
+      Pointee: 181 StructureType net.IPNet
     - __kind: PointerType
       ID: 37
       Name: '*net/http.Request'
@@ -480,12 +480,12 @@ Types:
       GoKind: 22
       Pointee: 62 StructureType net/http.pattern
     - __kind: PointerType
-      ID: 90
+      ID: 92
       Name: '*net/http.segment'
       ByteSize: 8
       GoRuntimeType: 391808
       GoKind: 22
-      Pointee: 91 StructureType net/http.segment
+      Pointee: 93 StructureType net/http.segment
     - __kind: PointerType
       ID: 42
       Name: '*net/url.URL'
@@ -494,27 +494,27 @@ Types:
       GoKind: 22
       Pointee: 43 StructureType net/url.URL
     - __kind: PointerType
-      ID: 70
+      ID: 72
       Name: '*net/url.Userinfo'
       ByteSize: 8
       GoRuntimeType: 1.200768e+06
       GoKind: 22
-      Pointee: 71 StructureType net/url.Userinfo
+      Pointee: 73 StructureType net/url.Userinfo
     - __kind: PointerType
-      ID: 104
+      ID: 116
       Name: '*noalg.map.group[string][]*mime/multipart.FileHeader'
       ByteSize: 8
-      Pointee: 105 StructureType noalg.map.group[string][]*mime/multipart.FileHeader
+      Pointee: 117 StructureType noalg.map.group[string][]*mime/multipart.FileHeader
     - __kind: PointerType
-      ID: 94
+      ID: 96
       Name: '*noalg.map.group[string][]string'
       ByteSize: 8
-      Pointee: 95 StructureType noalg.map.group[string][]string
+      Pointee: 97 StructureType noalg.map.group[string][]string
     - __kind: PointerType
-      ID: 99
+      ID: 105
       Name: '*noalg.map.group[string]string'
       ByteSize: 8
-      Pointee: 100 StructureType noalg.map.group[string]string
+      Pointee: 106 StructureType noalg.map.group[string]string
     - __kind: PointerType
       ID: 22
       Name: '*string'
@@ -523,46 +523,46 @@ Types:
       GoKind: 22
       Pointee: 9 GoStringHeaderType string
     - __kind: PointerType
-      ID: 163
+      ID: 71
       Name: '*string.str'
       ByteSize: 8
-      Pointee: 162 GoStringDataType string.str
+      Pointee: 70 GoStringDataType string.str
     - __kind: PointerType
-      ID: 78
+      ID: 80
       Name: '*table<string,[]*mime/multipart.FileHeader>'
       ByteSize: 8
-      Pointee: 96 StructureType table<string,[]*mime/multipart.FileHeader>
+      Pointee: 113 StructureType table<string,[]*mime/multipart.FileHeader>
     - __kind: PointerType
       ID: 48
       Name: '*table<string,[]string>'
       ByteSize: 8
-      Pointee: 72 StructureType table<string,[]string>
+      Pointee: 74 StructureType table<string,[]string>
     - __kind: PointerType
       ID: 67
       Name: '*table<string,string>'
       ByteSize: 8
-      Pointee: 92 StructureType table<string,string>
+      Pointee: 94 StructureType table<string,string>
     - __kind: PointerType
-      ID: 116
+      ID: 143
       Name: '*time.Location'
       ByteSize: 8
       GoRuntimeType: 1.6136e+06
       GoKind: 22
-      Pointee: 117 StructureType time.Location
+      Pointee: 144 StructureType time.Location
     - __kind: PointerType
-      ID: 153
+      ID: 176
       Name: '*time.zone'
       ByteSize: 8
       GoRuntimeType: 394880
       GoKind: 22
-      Pointee: 154 StructureType time.zone
+      Pointee: 177 StructureType time.zone
     - __kind: PointerType
-      ID: 156
+      ID: 179
       Name: '*time.zoneTrans'
       ByteSize: 8
       GoRuntimeType: 394944
       GoKind: 22
-      Pointee: 157 StructureType time.zoneTrans
+      Pointee: 180 StructureType time.zoneTrans
     - __kind: PointerType
       ID: 34
       Name: '*uint'
@@ -650,7 +650,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: GoSliceHeaderType
-      ID: 80
+      ID: 82
       Name: '[]*crypto/x509.Certificate'
       ByteSize: 24
       GoRuntimeType: 502496
@@ -658,21 +658,21 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 81 PointerType **crypto/x509.Certificate
+          Type: 83 PointerType **crypto/x509.Certificate
         - Name: len
           Offset: 8
           Type: 7 BaseType int
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 174 GoSliceDataType []*crypto/x509.Certificate.array
+      Data: 125 GoSliceDataType []*crypto/x509.Certificate.array
     - __kind: GoSliceDataType
-      ID: 174
+      ID: 125
       Name: '[]*crypto/x509.Certificate.array'
       ByteSize: 2048
-      Element: 82 PointerType *crypto/x509.Certificate
+      Element: 84 PointerType *crypto/x509.Certificate
     - __kind: GoSliceHeaderType
-      ID: 146
+      ID: 120
       Name: '[]*mime/multipart.FileHeader'
       ByteSize: 24
       GoRuntimeType: 487328
@@ -680,21 +680,21 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 147 PointerType **mime/multipart.FileHeader
+          Type: 121 PointerType **mime/multipart.FileHeader
         - Name: len
           Offset: 8
           Type: 7 BaseType int
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 204 GoSliceDataType []*mime/multipart.FileHeader.array
+      Data: 170 GoSliceDataType []*mime/multipart.FileHeader.array
     - __kind: GoSliceDataType
-      ID: 204
+      ID: 170
       Name: '[]*mime/multipart.FileHeader.array'
       ByteSize: 2048
-      Element: 148 PointerType *mime/multipart.FileHeader
+      Element: 122 PointerType *mime/multipart.FileHeader
     - __kind: GoSliceHeaderType
-      ID: 133
+      ID: 160
       Name: '[]*net.IPNet'
       ByteSize: 24
       GoRuntimeType: 504096
@@ -702,21 +702,21 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 134 PointerType **net.IPNet
+          Type: 161 PointerType **net.IPNet
         - Name: len
           Offset: 8
           Type: 7 BaseType int
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 198 GoSliceDataType []*net.IPNet.array
+      Data: 199 GoSliceDataType []*net.IPNet.array
     - __kind: GoSliceDataType
-      ID: 198
+      ID: 199
       Name: '[]*net.IPNet.array'
       ByteSize: 2048
-      Element: 135 PointerType *net.IPNet
+      Element: 162 PointerType *net.IPNet
     - __kind: GoSliceHeaderType
-      ID: 131
+      ID: 158
       Name: '[]*net/url.URL'
       ByteSize: 24
       GoRuntimeType: 504032
@@ -724,36 +724,36 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 132 PointerType **net/url.URL
+          Type: 159 PointerType **net/url.URL
         - Name: len
           Offset: 8
           Type: 7 BaseType int
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 196 GoSliceDataType []*net/url.URL.array
+      Data: 197 GoSliceDataType []*net/url.URL.array
     - __kind: GoSliceDataType
-      ID: 196
+      ID: 197
       Name: '[]*net/url.URL.array'
       ByteSize: 2048
       Element: 42 PointerType *net/url.URL
     - __kind: GoSliceDataType
-      ID: 172
+      ID: 123
       Name: '[]*table<string,[]*mime/multipart.FileHeader>.array'
       ByteSize: 8192
-      Element: 78 PointerType *table<string,[]*mime/multipart.FileHeader>
+      Element: 80 PointerType *table<string,[]*mime/multipart.FileHeader>
     - __kind: GoSliceDataType
-      ID: 164
+      ID: 100
       Name: '[]*table<string,[]string>.array'
       ByteSize: 8192
       Element: 48 PointerType *table<string,[]string>
     - __kind: GoSliceDataType
-      ID: 168
+      ID: 109
       Name: '[]*table<string,string>.array'
       ByteSize: 8192
       Element: 67 PointerType *table<string,string>
     - __kind: GoSliceHeaderType
-      ID: 83
+      ID: 85
       Name: '[][]*crypto/x509.Certificate'
       ByteSize: 24
       GoRuntimeType: 502560
@@ -761,21 +761,21 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 84 PointerType *[]*crypto/x509.Certificate
+          Type: 86 PointerType *[]*crypto/x509.Certificate
         - Name: len
           Offset: 8
           Type: 7 BaseType int
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 176 GoSliceDataType [][]*crypto/x509.Certificate.array
+      Data: 127 GoSliceDataType [][]*crypto/x509.Certificate.array
     - __kind: GoSliceDataType
-      ID: 176
+      ID: 127
       Name: '[][]*crypto/x509.Certificate.array'
       ByteSize: 2048
-      Element: 80 GoSliceHeaderType []*crypto/x509.Certificate
+      Element: 82 GoSliceHeaderType []*crypto/x509.Certificate
     - __kind: GoSliceHeaderType
-      ID: 85
+      ID: 87
       Name: '[][]uint8'
       ByteSize: 24
       GoRuntimeType: 481920
@@ -783,21 +783,21 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 86 PointerType *[]uint8
+          Type: 88 PointerType *[]uint8
         - Name: len
           Offset: 8
           Type: 7 BaseType int
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 178 GoSliceDataType [][]uint8.array
+      Data: 129 GoSliceDataType [][]uint8.array
     - __kind: GoSliceDataType
-      ID: 178
+      ID: 129
       Name: '[][]uint8.array'
       ByteSize: 2048
       Element: 68 GoSliceHeaderType []uint8
     - __kind: GoSliceHeaderType
-      ID: 125
+      ID: 152
       Name: '[]crypto/x509.ExtKeyUsage'
       ByteSize: 24
       GoRuntimeType: 503968
@@ -805,21 +805,21 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 126 PointerType *crypto/x509.ExtKeyUsage
+          Type: 153 PointerType *crypto/x509.ExtKeyUsage
         - Name: len
           Offset: 8
           Type: 7 BaseType int
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 190 GoSliceDataType []crypto/x509.ExtKeyUsage.array
+      Data: 191 GoSliceDataType []crypto/x509.ExtKeyUsage.array
     - __kind: GoSliceDataType
-      ID: 190
+      ID: 191
       Name: '[]crypto/x509.ExtKeyUsage.array'
       ByteSize: 2048
-      Element: 127 BaseType crypto/x509.ExtKeyUsage
+      Element: 154 BaseType crypto/x509.ExtKeyUsage
     - __kind: GoSliceHeaderType
-      ID: 136
+      ID: 163
       Name: '[]crypto/x509.OID'
       ByteSize: 24
       GoRuntimeType: 504160
@@ -827,21 +827,21 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 137 PointerType *crypto/x509.OID
+          Type: 164 PointerType *crypto/x509.OID
         - Name: len
           Offset: 8
           Type: 7 BaseType int
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 200 GoSliceDataType []crypto/x509.OID.array
+      Data: 201 GoSliceDataType []crypto/x509.OID.array
     - __kind: GoSliceDataType
-      ID: 200
+      ID: 201
       Name: '[]crypto/x509.OID.array'
       ByteSize: 2048
-      Element: 138 StructureType crypto/x509.OID
+      Element: 165 StructureType crypto/x509.OID
     - __kind: GoSliceHeaderType
-      ID: 139
+      ID: 166
       Name: '[]crypto/x509.PolicyMapping'
       ByteSize: 24
       GoRuntimeType: 504224
@@ -849,21 +849,21 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 140 PointerType *crypto/x509.PolicyMapping
+          Type: 167 PointerType *crypto/x509.PolicyMapping
         - Name: len
           Offset: 8
           Type: 7 BaseType int
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 202 GoSliceDataType []crypto/x509.PolicyMapping.array
+      Data: 203 GoSliceDataType []crypto/x509.PolicyMapping.array
     - __kind: GoSliceDataType
-      ID: 202
+      ID: 203
       Name: '[]crypto/x509.PolicyMapping.array'
       ByteSize: 2048
-      Element: 141 StructureType crypto/x509.PolicyMapping
+      Element: 168 StructureType crypto/x509.PolicyMapping
     - __kind: GoSliceHeaderType
-      ID: 112
+      ID: 139
       Name: '[]crypto/x509/pkix.AttributeTypeAndValue'
       ByteSize: 24
       GoRuntimeType: 517440
@@ -871,21 +871,21 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 113 PointerType *crypto/x509/pkix.AttributeTypeAndValue
+          Type: 140 PointerType *crypto/x509/pkix.AttributeTypeAndValue
         - Name: len
           Offset: 8
           Type: 7 BaseType int
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 182 GoSliceDataType []crypto/x509/pkix.AttributeTypeAndValue.array
+      Data: 183 GoSliceDataType []crypto/x509/pkix.AttributeTypeAndValue.array
     - __kind: GoSliceDataType
-      ID: 182
+      ID: 183
       Name: '[]crypto/x509/pkix.AttributeTypeAndValue.array'
       ByteSize: 2048
-      Element: 114 StructureType crypto/x509/pkix.AttributeTypeAndValue
+      Element: 141 StructureType crypto/x509/pkix.AttributeTypeAndValue
     - __kind: GoSliceHeaderType
-      ID: 119
+      ID: 146
       Name: '[]crypto/x509/pkix.Extension'
       ByteSize: 24
       GoRuntimeType: 503840
@@ -893,21 +893,21 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 120 PointerType *crypto/x509/pkix.Extension
+          Type: 147 PointerType *crypto/x509/pkix.Extension
         - Name: len
           Offset: 8
           Type: 7 BaseType int
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 184 GoSliceDataType []crypto/x509/pkix.Extension.array
+      Data: 185 GoSliceDataType []crypto/x509/pkix.Extension.array
     - __kind: GoSliceDataType
-      ID: 184
+      ID: 185
       Name: '[]crypto/x509/pkix.Extension.array'
       ByteSize: 2048
-      Element: 121 StructureType crypto/x509/pkix.Extension
+      Element: 148 StructureType crypto/x509/pkix.Extension
     - __kind: GoSliceHeaderType
-      ID: 122
+      ID: 149
       Name: '[]encoding/asn1.ObjectIdentifier'
       ByteSize: 24
       GoRuntimeType: 503904
@@ -915,21 +915,21 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 123 PointerType *encoding/asn1.ObjectIdentifier
+          Type: 150 PointerType *encoding/asn1.ObjectIdentifier
         - Name: len
           Offset: 8
           Type: 7 BaseType int
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 186 GoSliceDataType []encoding/asn1.ObjectIdentifier.array
+      Data: 187 GoSliceDataType []encoding/asn1.ObjectIdentifier.array
     - __kind: GoSliceDataType
-      ID: 186
+      ID: 187
       Name: '[]encoding/asn1.ObjectIdentifier.array'
       ByteSize: 2048
-      Element: 124 GoSliceHeaderType encoding/asn1.ObjectIdentifier
+      Element: 151 GoSliceHeaderType encoding/asn1.ObjectIdentifier
     - __kind: GoSliceHeaderType
-      ID: 128
+      ID: 155
       Name: '[]net.IP'
       ByteSize: 24
       GoRuntimeType: 482944
@@ -937,21 +937,21 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 129 PointerType *net.IP
+          Type: 156 PointerType *net.IP
         - Name: len
           Offset: 8
           Type: 7 BaseType int
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 192 GoSliceDataType []net.IP.array
+      Data: 193 GoSliceDataType []net.IP.array
     - __kind: GoSliceDataType
-      ID: 192
+      ID: 193
       Name: '[]net.IP.array'
       ByteSize: 2048
-      Element: 130 GoSliceHeaderType net.IP
+      Element: 157 GoSliceHeaderType net.IP
     - __kind: GoSliceHeaderType
-      ID: 89
+      ID: 91
       Name: '[]net/http.segment'
       ByteSize: 24
       GoRuntimeType: 484640
@@ -959,34 +959,34 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 90 PointerType *net/http.segment
+          Type: 92 PointerType *net/http.segment
         - Name: len
           Offset: 8
           Type: 7 BaseType int
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 180 GoSliceDataType []net/http.segment.array
+      Data: 131 GoSliceDataType []net/http.segment.array
     - __kind: GoSliceDataType
-      ID: 180
+      ID: 131
       Name: '[]net/http.segment.array'
       ByteSize: 2048
-      Element: 91 StructureType net/http.segment
+      Element: 93 StructureType net/http.segment
     - __kind: GoSliceDataType
-      ID: 173
+      ID: 124
       Name: '[]noalg.map.group[string][]*mime/multipart.FileHeader.array'
       ByteSize: 2048
-      Element: 105 StructureType noalg.map.group[string][]*mime/multipart.FileHeader
+      Element: 117 StructureType noalg.map.group[string][]*mime/multipart.FileHeader
     - __kind: GoSliceDataType
-      ID: 165
+      ID: 101
       Name: '[]noalg.map.group[string][]string.array'
       ByteSize: 2048
-      Element: 95 StructureType noalg.map.group[string][]string
+      Element: 97 StructureType noalg.map.group[string][]string
     - __kind: GoSliceDataType
-      ID: 169
+      ID: 110
       Name: '[]noalg.map.group[string]string.array'
       ByteSize: 2048
-      Element: 100 StructureType noalg.map.group[string]string
+      Element: 106 StructureType noalg.map.group[string]string
     - __kind: GoSliceHeaderType
       ID: 51
       Name: '[]string'
@@ -1003,14 +1003,14 @@ Types:
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 166 GoSliceDataType []string.array
+      Data: 102 GoSliceDataType []string.array
     - __kind: GoSliceDataType
-      ID: 166
+      ID: 102
       Name: '[]string.array'
       ByteSize: 2048
       Element: 9 GoStringHeaderType string
     - __kind: GoSliceHeaderType
-      ID: 152
+      ID: 175
       Name: '[]time.zone'
       ByteSize: 24
       GoRuntimeType: 489504
@@ -1018,7 +1018,7 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 153 PointerType *time.zone
+          Type: 176 PointerType *time.zone
         - Name: len
           Offset: 8
           Type: 7 BaseType int
@@ -1030,9 +1030,9 @@ Types:
       ID: 208
       Name: '[]time.zone.array'
       ByteSize: 2048
-      Element: 154 StructureType time.zone
+      Element: 177 StructureType time.zone
     - __kind: GoSliceHeaderType
-      ID: 155
+      ID: 178
       Name: '[]time.zoneTrans'
       ByteSize: 24
       GoRuntimeType: 489568
@@ -1040,7 +1040,7 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 156 PointerType *time.zoneTrans
+          Type: 179 PointerType *time.zoneTrans
         - Name: len
           Offset: 8
           Type: 7 BaseType int
@@ -1052,7 +1052,7 @@ Types:
       ID: 210
       Name: '[]time.zoneTrans.array'
       ByteSize: 2048
-      Element: 157 StructureType time.zoneTrans
+      Element: 180 StructureType time.zoneTrans
     - __kind: GoSliceHeaderType
       ID: 68
       Name: '[]uint8'
@@ -1069,9 +1069,9 @@ Types:
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 170 GoSliceDataType []uint8.array
+      Data: 111 GoSliceDataType []uint8.array
     - __kind: GoSliceDataType
-      ID: 170
+      ID: 111
       Name: '[]uint8.array'
       ByteSize: 2048
       Element: 3 BaseType uint8
@@ -1149,7 +1149,7 @@ Types:
           Type: 6 BaseType uint16
         - Name: CurveID
           Offset: 6
-          Type: 79 BaseType crypto/tls.CurveID
+          Type: 81 BaseType crypto/tls.CurveID
         - Name: NegotiatedProtocol
           Offset: 8
           Type: 9 GoStringHeaderType string
@@ -1161,13 +1161,13 @@ Types:
           Type: 9 GoStringHeaderType string
         - Name: PeerCertificates
           Offset: 48
-          Type: 80 GoSliceHeaderType []*crypto/x509.Certificate
+          Type: 82 GoSliceHeaderType []*crypto/x509.Certificate
         - Name: VerifiedChains
           Offset: 72
-          Type: 83 GoSliceHeaderType [][]*crypto/x509.Certificate
+          Type: 85 GoSliceHeaderType [][]*crypto/x509.Certificate
         - Name: SignedCertificateTimestamps
           Offset: 96
-          Type: 85 GoSliceHeaderType [][]uint8
+          Type: 87 GoSliceHeaderType [][]uint8
         - Name: OCSPResponse
           Offset: 120
           Type: 68 GoSliceHeaderType []uint8
@@ -1179,27 +1179,27 @@ Types:
           Type: 4 BaseType bool
         - Name: ekm
           Offset: 176
-          Type: 87 GoSubroutineType func(string, []uint8, int) ([]uint8, error)
+          Type: 89 GoSubroutineType func(string, []uint8, int) ([]uint8, error)
         - Name: testingOnlyDidHRR
           Offset: 184
           Type: 4 BaseType bool
         - Name: testingOnlyPeerSignatureAlgorithm
           Offset: 186
-          Type: 88 BaseType crypto/tls.SignatureScheme
+          Type: 90 BaseType crypto/tls.SignatureScheme
     - __kind: BaseType
-      ID: 79
+      ID: 81
       Name: crypto/tls.CurveID
       ByteSize: 2
       GoRuntimeType: 835040
       GoKind: 9
     - __kind: BaseType
-      ID: 88
+      ID: 90
       Name: crypto/tls.SignatureScheme
       ByteSize: 2
       GoRuntimeType: 835136
       GoKind: 9
     - __kind: StructureType
-      ID: 97
+      ID: 114
       Name: crypto/x509.Certificate
       ByteSize: 1424
       GoRuntimeType: 2.3936e+06
@@ -1225,49 +1225,49 @@ Types:
           Type: 68 GoSliceHeaderType []uint8
         - Name: SignatureAlgorithm
           Offset: 144
-          Type: 106 BaseType crypto/x509.SignatureAlgorithm
+          Type: 133 BaseType crypto/x509.SignatureAlgorithm
         - Name: PublicKeyAlgorithm
           Offset: 152
-          Type: 107 BaseType crypto/x509.PublicKeyAlgorithm
+          Type: 134 BaseType crypto/x509.PublicKeyAlgorithm
         - Name: PublicKey
           Offset: 160
-          Type: 108 GoEmptyInterfaceType interface {}
+          Type: 135 GoEmptyInterfaceType interface {}
         - Name: Version
           Offset: 176
           Type: 7 BaseType int
         - Name: SerialNumber
           Offset: 184
-          Type: 109 PointerType *math/big.Int
+          Type: 136 PointerType *math/big.Int
         - Name: Issuer
           Offset: 192
-          Type: 111 StructureType crypto/x509/pkix.Name
+          Type: 138 StructureType crypto/x509/pkix.Name
         - Name: Subject
           Offset: 440
-          Type: 111 StructureType crypto/x509/pkix.Name
+          Type: 138 StructureType crypto/x509/pkix.Name
         - Name: NotBefore
           Offset: 688
-          Type: 115 StructureType time.Time
+          Type: 142 StructureType time.Time
         - Name: NotAfter
           Offset: 712
-          Type: 115 StructureType time.Time
+          Type: 142 StructureType time.Time
         - Name: KeyUsage
           Offset: 736
-          Type: 118 BaseType crypto/x509.KeyUsage
+          Type: 145 BaseType crypto/x509.KeyUsage
         - Name: Extensions
           Offset: 744
-          Type: 119 GoSliceHeaderType []crypto/x509/pkix.Extension
+          Type: 146 GoSliceHeaderType []crypto/x509/pkix.Extension
         - Name: ExtraExtensions
           Offset: 768
-          Type: 119 GoSliceHeaderType []crypto/x509/pkix.Extension
+          Type: 146 GoSliceHeaderType []crypto/x509/pkix.Extension
         - Name: UnhandledCriticalExtensions
           Offset: 792
-          Type: 122 GoSliceHeaderType []encoding/asn1.ObjectIdentifier
+          Type: 149 GoSliceHeaderType []encoding/asn1.ObjectIdentifier
         - Name: ExtKeyUsage
           Offset: 816
-          Type: 125 GoSliceHeaderType []crypto/x509.ExtKeyUsage
+          Type: 152 GoSliceHeaderType []crypto/x509.ExtKeyUsage
         - Name: UnknownExtKeyUsage
           Offset: 840
-          Type: 122 GoSliceHeaderType []encoding/asn1.ObjectIdentifier
+          Type: 149 GoSliceHeaderType []encoding/asn1.ObjectIdentifier
         - Name: BasicConstraintsValid
           Offset: 864
           Type: 4 BaseType bool
@@ -1300,10 +1300,10 @@ Types:
           Type: 51 GoSliceHeaderType []string
         - Name: IPAddresses
           Offset: 1032
-          Type: 128 GoSliceHeaderType []net.IP
+          Type: 155 GoSliceHeaderType []net.IP
         - Name: URIs
           Offset: 1056
-          Type: 131 GoSliceHeaderType []*net/url.URL
+          Type: 158 GoSliceHeaderType []*net/url.URL
         - Name: PermittedDNSDomainsCritical
           Offset: 1080
           Type: 4 BaseType bool
@@ -1315,10 +1315,10 @@ Types:
           Type: 51 GoSliceHeaderType []string
         - Name: PermittedIPRanges
           Offset: 1136
-          Type: 133 GoSliceHeaderType []*net.IPNet
+          Type: 160 GoSliceHeaderType []*net.IPNet
         - Name: ExcludedIPRanges
           Offset: 1160
-          Type: 133 GoSliceHeaderType []*net.IPNet
+          Type: 160 GoSliceHeaderType []*net.IPNet
         - Name: PermittedEmailAddresses
           Offset: 1184
           Type: 51 GoSliceHeaderType []string
@@ -1336,10 +1336,10 @@ Types:
           Type: 51 GoSliceHeaderType []string
         - Name: PolicyIdentifiers
           Offset: 1304
-          Type: 122 GoSliceHeaderType []encoding/asn1.ObjectIdentifier
+          Type: 149 GoSliceHeaderType []encoding/asn1.ObjectIdentifier
         - Name: Policies
           Offset: 1328
-          Type: 136 GoSliceHeaderType []crypto/x509.OID
+          Type: 163 GoSliceHeaderType []crypto/x509.OID
         - Name: InhibitAnyPolicy
           Offset: 1352
           Type: 7 BaseType int
@@ -1360,21 +1360,21 @@ Types:
           Type: 4 BaseType bool
         - Name: PolicyMappings
           Offset: 1400
-          Type: 139 GoSliceHeaderType []crypto/x509.PolicyMapping
+          Type: 166 GoSliceHeaderType []crypto/x509.PolicyMapping
     - __kind: BaseType
-      ID: 127
+      ID: 154
       Name: crypto/x509.ExtKeyUsage
       ByteSize: 8
       GoRuntimeType: 588160
       GoKind: 2
     - __kind: BaseType
-      ID: 118
+      ID: 145
       Name: crypto/x509.KeyUsage
       ByteSize: 8
       GoRuntimeType: 588096
       GoKind: 2
     - __kind: StructureType
-      ID: 138
+      ID: 165
       Name: crypto/x509.OID
       ByteSize: 24
       GoRuntimeType: 1.954592e+06
@@ -1384,7 +1384,7 @@ Types:
           Offset: 0
           Type: 68 GoSliceHeaderType []uint8
     - __kind: StructureType
-      ID: 141
+      ID: 168
       Name: crypto/x509.PolicyMapping
       ByteSize: 48
       GoRuntimeType: 1.491232e+06
@@ -1392,24 +1392,24 @@ Types:
       RawFields:
         - Name: IssuerDomainPolicy
           Offset: 0
-          Type: 138 StructureType crypto/x509.OID
+          Type: 165 StructureType crypto/x509.OID
         - Name: SubjectDomainPolicy
           Offset: 24
-          Type: 138 StructureType crypto/x509.OID
+          Type: 165 StructureType crypto/x509.OID
     - __kind: BaseType
-      ID: 107
+      ID: 134
       Name: crypto/x509.PublicKeyAlgorithm
       ByteSize: 8
       GoRuntimeType: 837632
       GoKind: 2
     - __kind: BaseType
-      ID: 106
+      ID: 133
       Name: crypto/x509.SignatureAlgorithm
       ByteSize: 8
       GoRuntimeType: 1.114432e+06
       GoKind: 2
     - __kind: StructureType
-      ID: 114
+      ID: 141
       Name: crypto/x509/pkix.AttributeTypeAndValue
       ByteSize: 40
       GoRuntimeType: 1.502912e+06
@@ -1417,12 +1417,12 @@ Types:
       RawFields:
         - Name: Type
           Offset: 0
-          Type: 124 GoSliceHeaderType encoding/asn1.ObjectIdentifier
+          Type: 151 GoSliceHeaderType encoding/asn1.ObjectIdentifier
         - Name: Value
           Offset: 24
-          Type: 108 GoEmptyInterfaceType interface {}
+          Type: 135 GoEmptyInterfaceType interface {}
     - __kind: StructureType
-      ID: 121
+      ID: 148
       Name: crypto/x509/pkix.Extension
       ByteSize: 56
       GoRuntimeType: 1.647008e+06
@@ -1430,7 +1430,7 @@ Types:
       RawFields:
         - Name: Id
           Offset: 0
-          Type: 124 GoSliceHeaderType encoding/asn1.ObjectIdentifier
+          Type: 151 GoSliceHeaderType encoding/asn1.ObjectIdentifier
         - Name: Critical
           Offset: 24
           Type: 4 BaseType bool
@@ -1438,7 +1438,7 @@ Types:
           Offset: 32
           Type: 68 GoSliceHeaderType []uint8
     - __kind: StructureType
-      ID: 111
+      ID: 138
       Name: crypto/x509/pkix.Name
       ByteSize: 248
       GoRuntimeType: 2.192768e+06
@@ -1473,12 +1473,12 @@ Types:
           Type: 9 GoStringHeaderType string
         - Name: Names
           Offset: 200
-          Type: 112 GoSliceHeaderType []crypto/x509/pkix.AttributeTypeAndValue
+          Type: 139 GoSliceHeaderType []crypto/x509/pkix.AttributeTypeAndValue
         - Name: ExtraNames
           Offset: 224
-          Type: 112 GoSliceHeaderType []crypto/x509/pkix.AttributeTypeAndValue
+          Type: 139 GoSliceHeaderType []crypto/x509/pkix.AttributeTypeAndValue
     - __kind: GoSliceHeaderType
-      ID: 124
+      ID: 151
       Name: encoding/asn1.ObjectIdentifier
       ByteSize: 24
       GoRuntimeType: 1.053536e+06
@@ -1493,9 +1493,9 @@ Types:
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 188 GoSliceDataType encoding/asn1.ObjectIdentifier.array
+      Data: 189 GoSliceDataType encoding/asn1.ObjectIdentifier.array
     - __kind: GoSliceDataType
-      ID: 188
+      ID: 189
       Name: encoding/asn1.ObjectIdentifier.array
       ByteSize: 2048
       Element: 7 BaseType int
@@ -1531,7 +1531,7 @@ Types:
       GoRuntimeType: 693344
       GoKind: 19
     - __kind: GoSubroutineType
-      ID: 87
+      ID: 89
       Name: func(string, []uint8, int) ([]uint8, error)
       ByteSize: 8
       GoRuntimeType: 1.003296e+06
@@ -1550,47 +1550,47 @@ Types:
           Offset: 8
           Type: 14 VoidPointerType unsafe.Pointer
     - __kind: GoSwissMapGroupsType
-      ID: 103
+      ID: 115
       Name: groupReference<string,[]*mime/multipart.FileHeader>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 104 PointerType *noalg.map.group[string][]*mime/multipart.FileHeader
+          Type: 116 PointerType *noalg.map.group[string][]*mime/multipart.FileHeader
         - Name: lengthMask
           Offset: 8
           Type: 8 BaseType uint64
-      GroupType: 105 StructureType noalg.map.group[string][]*mime/multipart.FileHeader
-      GroupSliceType: 173 GoSliceDataType []noalg.map.group[string][]*mime/multipart.FileHeader.array
+      GroupType: 117 StructureType noalg.map.group[string][]*mime/multipart.FileHeader
+      GroupSliceType: 124 GoSliceDataType []noalg.map.group[string][]*mime/multipart.FileHeader.array
     - __kind: GoSwissMapGroupsType
-      ID: 93
+      ID: 95
       Name: groupReference<string,[]string>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 94 PointerType *noalg.map.group[string][]string
+          Type: 96 PointerType *noalg.map.group[string][]string
         - Name: lengthMask
           Offset: 8
           Type: 8 BaseType uint64
-      GroupType: 95 StructureType noalg.map.group[string][]string
-      GroupSliceType: 165 GoSliceDataType []noalg.map.group[string][]string.array
+      GroupType: 97 StructureType noalg.map.group[string][]string
+      GroupSliceType: 101 GoSliceDataType []noalg.map.group[string][]string.array
     - __kind: GoSwissMapGroupsType
-      ID: 98
+      ID: 104
       Name: groupReference<string,string>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 99 PointerType *noalg.map.group[string]string
+          Type: 105 PointerType *noalg.map.group[string]string
         - Name: lengthMask
           Offset: 8
           Type: 8 BaseType uint64
-      GroupType: 100 StructureType noalg.map.group[string]string
-      GroupSliceType: 169 GoSliceDataType []noalg.map.group[string]string.array
+      GroupType: 106 StructureType noalg.map.group[string]string
+      GroupSliceType: 110 GoSliceDataType []noalg.map.group[string]string.array
     - __kind: BaseType
       ID: 7
       Name: int
@@ -1622,7 +1622,7 @@ Types:
       GoRuntimeType: 584512
       GoKind: 3
     - __kind: GoEmptyInterfaceType
-      ID: 108
+      ID: 135
       Name: interface {}
       ByteSize: 16
       GoRuntimeType: 854848
@@ -1648,7 +1648,7 @@ Types:
           Offset: 8
           Type: 14 VoidPointerType unsafe.Pointer
     - __kind: GoSwissMapHeaderType
-      ID: 76
+      ID: 78
       Name: map<string,[]*mime/multipart.FileHeader>
       ByteSize: 48
       GoKind: 25
@@ -1661,7 +1661,7 @@ Types:
           Type: 1 BaseType uintptr
         - Name: dirPtr
           Offset: 16
-          Type: 77 PointerType **table<string,[]*mime/multipart.FileHeader>
+          Type: 79 PointerType **table<string,[]*mime/multipart.FileHeader>
         - Name: dirLen
           Offset: 24
           Type: 7 BaseType int
@@ -1680,8 +1680,8 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 8 BaseType uint64
-      TablePtrSliceType: 172 GoSliceDataType []*table<string,[]*mime/multipart.FileHeader>.array
-      GroupType: 105 StructureType noalg.map.group[string][]*mime/multipart.FileHeader
+      TablePtrSliceType: 123 GoSliceDataType []*table<string,[]*mime/multipart.FileHeader>.array
+      GroupType: 117 StructureType noalg.map.group[string][]*mime/multipart.FileHeader
     - __kind: GoSwissMapHeaderType
       ID: 46
       Name: map<string,[]string>
@@ -1715,8 +1715,8 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 8 BaseType uint64
-      TablePtrSliceType: 164 GoSliceDataType []*table<string,[]string>.array
-      GroupType: 95 StructureType noalg.map.group[string][]string
+      TablePtrSliceType: 100 GoSliceDataType []*table<string,[]string>.array
+      GroupType: 97 StructureType noalg.map.group[string][]string
     - __kind: GoSwissMapHeaderType
       ID: 65
       Name: map<string,string>
@@ -1750,17 +1750,17 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 8 BaseType uint64
-      TablePtrSliceType: 168 GoSliceDataType []*table<string,string>.array
-      GroupType: 100 StructureType noalg.map.group[string]string
+      TablePtrSliceType: 109 GoSliceDataType []*table<string,string>.array
+      GroupType: 106 StructureType noalg.map.group[string]string
     - __kind: GoMapType
-      ID: 74
+      ID: 76
       Name: map[string][]*mime/multipart.FileHeader
       ByteSize: 8
       GoRuntimeType: 1.132352e+06
       GoKind: 21
-      HeaderType: 76 GoSwissMapHeaderType map<string,[]*mime/multipart.FileHeader>
+      HeaderType: 78 GoSwissMapHeaderType map<string,[]*mime/multipart.FileHeader>
     - __kind: GoMapType
-      ID: 73
+      ID: 75
       Name: map[string][]string
       ByteSize: 8
       GoRuntimeType: 1.128e+06
@@ -1774,7 +1774,7 @@ Types:
       GoKind: 21
       HeaderType: 65 GoSwissMapHeaderType map<string,string>
     - __kind: StructureType
-      ID: 110
+      ID: 137
       Name: math/big.Int
       ByteSize: 32
       GoRuntimeType: 1.494272e+06
@@ -1785,15 +1785,15 @@ Types:
           Type: 4 BaseType bool
         - Name: abs
           Offset: 8
-          Type: 149 GoSliceHeaderType math/big.nat
+          Type: 172 GoSliceHeaderType math/big.nat
     - __kind: BaseType
-      ID: 151
+      ID: 174
       Name: math/big.Word
       ByteSize: 8
       GoRuntimeType: 588352
       GoKind: 7
     - __kind: GoSliceHeaderType
-      ID: 149
+      ID: 172
       Name: math/big.nat
       ByteSize: 24
       GoRuntimeType: 2.361856e+06
@@ -1801,7 +1801,7 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 150 PointerType *math/big.Word
+          Type: 173 PointerType *math/big.Word
         - Name: len
           Offset: 8
           Type: 7 BaseType int
@@ -1813,9 +1813,9 @@ Types:
       ID: 206
       Name: math/big.nat.array
       ByteSize: 2048
-      Element: 151 BaseType math/big.Word
+      Element: 174 BaseType math/big.Word
     - __kind: StructureType
-      ID: 159
+      ID: 169
       Name: mime/multipart.FileHeader
       ByteSize: 88
       GoRuntimeType: 1.977856e+06
@@ -1826,7 +1826,7 @@ Types:
           Type: 9 GoStringHeaderType string
         - Name: Header
           Offset: 16
-          Type: 161 GoMapType net/textproto.MIMEHeader
+          Type: 182 GoMapType net/textproto.MIMEHeader
         - Name: Size
           Offset: 24
           Type: 12 BaseType int64
@@ -1851,12 +1851,12 @@ Types:
       RawFields:
         - Name: Value
           Offset: 0
-          Type: 73 GoMapType map[string][]string
+          Type: 75 GoMapType map[string][]string
         - Name: File
           Offset: 8
-          Type: 74 GoMapType map[string][]*mime/multipart.FileHeader
+          Type: 76 GoMapType map[string][]*mime/multipart.FileHeader
     - __kind: GoSliceHeaderType
-      ID: 130
+      ID: 157
       Name: net.IP
       ByteSize: 24
       GoRuntimeType: 2.124512e+06
@@ -1871,14 +1871,14 @@ Types:
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 194 GoSliceDataType net.IP.array
+      Data: 195 GoSliceDataType net.IP.array
     - __kind: GoSliceDataType
-      ID: 194
+      ID: 195
       Name: net.IP.array
       ByteSize: 2048
       Element: 3 BaseType uint8
     - __kind: GoSliceHeaderType
-      ID: 160
+      ID: 205
       Name: net.IPMask
       ByteSize: 24
       GoRuntimeType: 1.019744e+06
@@ -1900,7 +1900,7 @@ Types:
       ByteSize: 2048
       Element: 3 BaseType uint8
     - __kind: StructureType
-      ID: 158
+      ID: 181
       Name: net.IPNet
       ByteSize: 48
       GoRuntimeType: 1.458912e+06
@@ -1908,10 +1908,10 @@ Types:
       RawFields:
         - Name: IP
           Offset: 0
-          Type: 130 GoSliceHeaderType net.IP
+          Type: 157 GoSliceHeaderType net.IP
         - Name: Mask
           Offset: 24
-          Type: 160 GoSliceHeaderType net.IPMask
+          Type: 205 GoSliceHeaderType net.IPMask
     - __kind: GoMapType
       ID: 44
       Name: net/http.Header
@@ -2084,12 +2084,12 @@ Types:
           Type: 9 GoStringHeaderType string
         - Name: segments
           Offset: 48
-          Type: 89 GoSliceHeaderType []net/http.segment
+          Type: 91 GoSliceHeaderType []net/http.segment
         - Name: loc
           Offset: 72
           Type: 9 GoStringHeaderType string
     - __kind: StructureType
-      ID: 91
+      ID: 93
       Name: net/http.segment
       ByteSize: 24
       GoRuntimeType: 1.608416e+06
@@ -2105,7 +2105,7 @@ Types:
           Offset: 17
           Type: 4 BaseType bool
     - __kind: GoMapType
-      ID: 161
+      ID: 182
       Name: net/textproto.MIMEHeader
       ByteSize: 8
       GoRuntimeType: 1.823584e+06
@@ -2126,7 +2126,7 @@ Types:
           Type: 9 GoStringHeaderType string
         - Name: User
           Offset: 32
-          Type: 70 PointerType *net/url.Userinfo
+          Type: 72 PointerType *net/url.Userinfo
         - Name: Host
           Offset: 40
           Type: 9 GoStringHeaderType string
@@ -2152,7 +2152,7 @@ Types:
           Offset: 128
           Type: 9 GoStringHeaderType string
     - __kind: StructureType
-      ID: 71
+      ID: 73
       Name: net/url.Userinfo
       ByteSize: 40
       GoRuntimeType: 1.624928e+06
@@ -2175,34 +2175,34 @@ Types:
       GoKind: 21
       HeaderType: 46 GoSwissMapHeaderType map<string,[]string>
     - __kind: ArrayType
-      ID: 144
+      ID: 118
       Name: noalg.[8]struct { key string; elem []*mime/multipart.FileHeader }
       ByteSize: 320
       GoRuntimeType: 699200
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 145 StructureType noalg.struct { key string; elem []*mime/multipart.FileHeader }
+      Element: 119 StructureType noalg.struct { key string; elem []*mime/multipart.FileHeader }
     - __kind: ArrayType
-      ID: 101
+      ID: 98
       Name: noalg.[8]struct { key string; elem []string }
       ByteSize: 320
       GoRuntimeType: 689376
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 102 StructureType noalg.struct { key string; elem []string }
+      Element: 99 StructureType noalg.struct { key string; elem []string }
     - __kind: ArrayType
-      ID: 142
+      ID: 107
       Name: noalg.[8]struct { key string; elem string }
       ByteSize: 256
       GoRuntimeType: 693536
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 143 StructureType noalg.struct { key string; elem string }
+      Element: 108 StructureType noalg.struct { key string; elem string }
     - __kind: StructureType
-      ID: 105
+      ID: 117
       Name: noalg.map.group[string][]*mime/multipart.FileHeader
       ByteSize: 328
       GoRuntimeType: 1.29952e+06
@@ -2213,9 +2213,9 @@ Types:
           Type: 8 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 144 ArrayType noalg.[8]struct { key string; elem []*mime/multipart.FileHeader }
+          Type: 118 ArrayType noalg.[8]struct { key string; elem []*mime/multipart.FileHeader }
     - __kind: StructureType
-      ID: 95
+      ID: 97
       Name: noalg.map.group[string][]string
       ByteSize: 328
       GoRuntimeType: 1.290432e+06
@@ -2226,9 +2226,9 @@ Types:
           Type: 8 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 101 ArrayType noalg.[8]struct { key string; elem []string }
+          Type: 98 ArrayType noalg.[8]struct { key string; elem []string }
     - __kind: StructureType
-      ID: 100
+      ID: 106
       Name: noalg.map.group[string]string
       ByteSize: 264
       GoRuntimeType: 1.292864e+06
@@ -2239,9 +2239,9 @@ Types:
           Type: 8 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 142 ArrayType noalg.[8]struct { key string; elem string }
+          Type: 107 ArrayType noalg.[8]struct { key string; elem string }
     - __kind: StructureType
-      ID: 145
+      ID: 119
       Name: noalg.struct { key string; elem []*mime/multipart.FileHeader }
       ByteSize: 40
       GoRuntimeType: 1.299392e+06
@@ -2252,9 +2252,9 @@ Types:
           Type: 9 GoStringHeaderType string
         - Name: elem
           Offset: 16
-          Type: 146 GoSliceHeaderType []*mime/multipart.FileHeader
+          Type: 120 GoSliceHeaderType []*mime/multipart.FileHeader
     - __kind: StructureType
-      ID: 102
+      ID: 99
       Name: noalg.struct { key string; elem []string }
       ByteSize: 40
       GoRuntimeType: 1.290304e+06
@@ -2267,7 +2267,7 @@ Types:
           Offset: 16
           Type: 51 GoSliceHeaderType []string
     - __kind: StructureType
-      ID: 143
+      ID: 108
       Name: noalg.struct { key string; elem string }
       ByteSize: 32
       GoRuntimeType: 1.292736e+06
@@ -2288,17 +2288,17 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 163 PointerType *string.str
+          Type: 71 PointerType *string.str
         - Name: len
           Offset: 8
           Type: 7 BaseType int
-      Data: 162 GoStringDataType string.str
+      Data: 70 GoStringDataType string.str
     - __kind: GoStringDataType
-      ID: 162
+      ID: 70
       Name: string.str
       ByteSize: 2048
     - __kind: StructureType
-      ID: 96
+      ID: 113
       Name: table<string,[]*mime/multipart.FileHeader>
       ByteSize: 32
       GoKind: 25
@@ -2320,9 +2320,9 @@ Types:
           Type: 7 BaseType int
         - Name: groups
           Offset: 16
-          Type: 103 GoSwissMapGroupsType groupReference<string,[]*mime/multipart.FileHeader>
+          Type: 115 GoSwissMapGroupsType groupReference<string,[]*mime/multipart.FileHeader>
     - __kind: StructureType
-      ID: 72
+      ID: 74
       Name: table<string,[]string>
       ByteSize: 32
       GoKind: 25
@@ -2344,9 +2344,9 @@ Types:
           Type: 7 BaseType int
         - Name: groups
           Offset: 16
-          Type: 93 GoSwissMapGroupsType groupReference<string,[]string>
+          Type: 95 GoSwissMapGroupsType groupReference<string,[]string>
     - __kind: StructureType
-      ID: 92
+      ID: 94
       Name: table<string,string>
       ByteSize: 32
       GoKind: 25
@@ -2368,9 +2368,9 @@ Types:
           Type: 7 BaseType int
         - Name: groups
           Offset: 16
-          Type: 98 GoSwissMapGroupsType groupReference<string,string>
+          Type: 104 GoSwissMapGroupsType groupReference<string,string>
     - __kind: StructureType
-      ID: 117
+      ID: 144
       Name: time.Location
       ByteSize: 104
       GoRuntimeType: 1.973536e+06
@@ -2381,10 +2381,10 @@ Types:
           Type: 9 GoStringHeaderType string
         - Name: zone
           Offset: 16
-          Type: 152 GoSliceHeaderType []time.zone
+          Type: 175 GoSliceHeaderType []time.zone
         - Name: tx
           Offset: 40
-          Type: 155 GoSliceHeaderType []time.zoneTrans
+          Type: 178 GoSliceHeaderType []time.zoneTrans
         - Name: extend
           Offset: 64
           Type: 9 GoStringHeaderType string
@@ -2396,9 +2396,9 @@ Types:
           Type: 12 BaseType int64
         - Name: cacheZone
           Offset: 96
-          Type: 153 PointerType *time.zone
+          Type: 176 PointerType *time.zone
     - __kind: StructureType
-      ID: 115
+      ID: 142
       Name: time.Time
       ByteSize: 24
       GoRuntimeType: 2.364704e+06
@@ -2412,9 +2412,9 @@ Types:
           Type: 12 BaseType int64
         - Name: loc
           Offset: 16
-          Type: 116 PointerType *time.Location
+          Type: 143 PointerType *time.Location
     - __kind: StructureType
-      ID: 154
+      ID: 177
       Name: time.zone
       ByteSize: 32
       GoRuntimeType: 1.613408e+06
@@ -2430,7 +2430,7 @@ Types:
           Offset: 24
           Type: 4 BaseType bool
     - __kind: StructureType
-      ID: 157
+      ID: 180
       Name: time.zoneTrans
       ByteSize: 16
       GoRuntimeType: 1.750848e+06

--- a/pkg/dyninst/irgen/testdata/snapshot/rc_tester_v1.arch=arm64,toolchain=go1.23.11.yaml
+++ b/pkg/dyninst/irgen/testdata/snapshot/rc_tester_v1.arch=arm64,toolchain=go1.23.11.yaml
@@ -121,120 +121,120 @@ Subprograms:
           IsReturn: false
 Types:
     - __kind: PointerType
-      ID: 90
+      ID: 92
       Name: '**crypto/x509.Certificate'
       ByteSize: 8
-      Pointee: 91 PointerType *crypto/x509.Certificate
+      Pointee: 93 PointerType *crypto/x509.Certificate
     - __kind: PointerType
-      ID: 105
+      ID: 113
       Name: '**mime/multipart.FileHeader'
       ByteSize: 8
       GoKind: 22
-      Pointee: 106 PointerType *mime/multipart.FileHeader
+      Pointee: 114 PointerType *mime/multipart.FileHeader
     - __kind: PointerType
-      ID: 137
+      ID: 156
       Name: '**net.IPNet'
       ByteSize: 8
       GoKind: 22
-      Pointee: 138 PointerType *net.IPNet
+      Pointee: 157 PointerType *net.IPNet
     - __kind: PointerType
-      ID: 135
+      ID: 154
       Name: '**net/url.URL'
       ByteSize: 8
       Pointee: 44 PointerType *net/url.URL
     - __kind: PointerType
-      ID: 102
+      ID: 110
       Name: '**runtime.bmap'
       ByteSize: 8
-      Pointee: 81 PointerType *runtime.bmap
+      Pointee: 83 PointerType *runtime.bmap
     - __kind: PointerType
-      ID: 93
+      ID: 95
       Name: '*[]*crypto/x509.Certificate'
       ByteSize: 8
       GoKind: 22
-      Pointee: 89 GoSliceHeaderType []*crypto/x509.Certificate
+      Pointee: 91 GoSliceHeaderType []*crypto/x509.Certificate
     - __kind: PointerType
-      ID: 166
+      ID: 120
       Name: '*[]*crypto/x509.Certificate.array'
       ByteSize: 8
-      Pointee: 165 GoSliceDataType []*crypto/x509.Certificate.array
+      Pointee: 119 GoSliceDataType []*crypto/x509.Certificate.array
     - __kind: PointerType
-      ID: 174
+      ID: 162
       Name: '*[]*mime/multipart.FileHeader.array'
       ByteSize: 8
-      Pointee: 173 GoSliceDataType []*mime/multipart.FileHeader.array
+      Pointee: 161 GoSliceDataType []*mime/multipart.FileHeader.array
     - __kind: PointerType
-      ID: 192
+      ID: 191
       Name: '*[]*net.IPNet.array'
       ByteSize: 8
-      Pointee: 191 GoSliceDataType []*net.IPNet.array
+      Pointee: 190 GoSliceDataType []*net.IPNet.array
     - __kind: PointerType
-      ID: 190
+      ID: 189
       Name: '*[]*net/url.URL.array'
       ByteSize: 8
-      Pointee: 189 GoSliceDataType []*net/url.URL.array
+      Pointee: 188 GoSliceDataType []*net/url.URL.array
     - __kind: PointerType
-      ID: 79
+      ID: 81
       Name: '*[]*runtime.bmap'
       ByteSize: 8
       GoRuntimeType: 466496
       GoKind: 22
-      Pointee: 80 GoSliceHeaderType []*runtime.bmap
+      Pointee: 82 GoSliceHeaderType []*runtime.bmap
     - __kind: PointerType
-      ID: 163
+      ID: 117
       Name: '*[]*runtime.bmap.array'
       ByteSize: 8
-      Pointee: 162 GoSliceDataType []*runtime.bmap.array
+      Pointee: 116 GoSliceDataType []*runtime.bmap.array
     - __kind: PointerType
-      ID: 168
+      ID: 122
       Name: '*[][]*crypto/x509.Certificate.array'
       ByteSize: 8
-      Pointee: 167 GoSliceDataType [][]*crypto/x509.Certificate.array
+      Pointee: 121 GoSliceDataType [][]*crypto/x509.Certificate.array
     - __kind: PointerType
-      ID: 170
+      ID: 124
       Name: '*[][]uint8.array'
       ByteSize: 8
-      Pointee: 169 GoSliceDataType [][]uint8.array
+      Pointee: 123 GoSliceDataType [][]uint8.array
     - __kind: PointerType
-      ID: 184
+      ID: 183
       Name: '*[]crypto/x509.ExtKeyUsage.array'
       ByteSize: 8
-      Pointee: 183 GoSliceDataType []crypto/x509.ExtKeyUsage.array
+      Pointee: 182 GoSliceDataType []crypto/x509.ExtKeyUsage.array
     - __kind: PointerType
-      ID: 194
+      ID: 193
       Name: '*[]crypto/x509.OID.array'
       ByteSize: 8
-      Pointee: 193 GoSliceDataType []crypto/x509.OID.array
+      Pointee: 192 GoSliceDataType []crypto/x509.OID.array
     - __kind: PointerType
-      ID: 176
+      ID: 175
       Name: '*[]crypto/x509/pkix.AttributeTypeAndValue.array'
       ByteSize: 8
-      Pointee: 175 GoSliceDataType []crypto/x509/pkix.AttributeTypeAndValue.array
+      Pointee: 174 GoSliceDataType []crypto/x509/pkix.AttributeTypeAndValue.array
     - __kind: PointerType
-      ID: 178
+      ID: 177
       Name: '*[]crypto/x509/pkix.Extension.array'
       ByteSize: 8
-      Pointee: 177 GoSliceDataType []crypto/x509/pkix.Extension.array
+      Pointee: 176 GoSliceDataType []crypto/x509/pkix.Extension.array
     - __kind: PointerType
-      ID: 180
+      ID: 179
       Name: '*[]encoding/asn1.ObjectIdentifier.array'
       ByteSize: 8
-      Pointee: 179 GoSliceDataType []encoding/asn1.ObjectIdentifier.array
+      Pointee: 178 GoSliceDataType []encoding/asn1.ObjectIdentifier.array
     - __kind: PointerType
-      ID: 186
+      ID: 185
       Name: '*[]net.IP.array'
       ByteSize: 8
-      Pointee: 185 GoSliceDataType []net.IP.array
+      Pointee: 184 GoSliceDataType []net.IP.array
     - __kind: PointerType
-      ID: 172
+      ID: 126
       Name: '*[]net/http.segment.array'
       ByteSize: 8
-      Pointee: 171 GoSliceDataType []net/http.segment.array
+      Pointee: 125 GoSliceDataType []net/http.segment.array
     - __kind: PointerType
-      ID: 158
+      ID: 106
       Name: '*[]string.array'
       ByteSize: 8
-      Pointee: 157 GoSliceDataType []string.array
+      Pointee: 105 GoSliceDataType []string.array
     - __kind: PointerType
       ID: 198
       Name: '*[]time.zone.array'
@@ -246,17 +246,17 @@ Types:
       ByteSize: 8
       Pointee: 199 GoSliceDataType []time.zoneTrans.array
     - __kind: PointerType
-      ID: 95
+      ID: 97
       Name: '*[]uint8'
       ByteSize: 8
       GoRuntimeType: 452640
       GoKind: 22
       Pointee: 72 GoSliceHeaderType []uint8
     - __kind: PointerType
-      ID: 161
+      ID: 109
       Name: '*[]uint8.array'
       ByteSize: 8
-      Pointee: 160 GoSliceDataType []uint8.array
+      Pointee: 108 GoSliceDataType []uint8.array
     - __kind: PointerType
       ID: 5
       Name: '*bool'
@@ -265,10 +265,10 @@ Types:
       GoKind: 22
       Pointee: 4 BaseType bool
     - __kind: PointerType
-      ID: 87
+      ID: 89
       Name: '*bucket<string,[]*mime/multipart.FileHeader>'
       ByteSize: 8
-      Pointee: 88 GoHMapBucketType bucket<string,[]*mime/multipart.FileHeader>
+      Pointee: 90 GoHMapBucketType bucket<string,[]*mime/multipart.FileHeader>
     - __kind: PointerType
       ID: 49
       Name: '*bucket<string,[]string>'
@@ -294,52 +294,52 @@ Types:
       GoKind: 22
       Pointee: 60 StructureType crypto/tls.ConnectionState
     - __kind: PointerType
-      ID: 91
+      ID: 93
       Name: '*crypto/x509.Certificate'
       ByteSize: 8
       GoRuntimeType: 1.905824e+06
       GoKind: 22
-      Pointee: 107 StructureType crypto/x509.Certificate
+      Pointee: 115 StructureType crypto/x509.Certificate
     - __kind: PointerType
-      ID: 129
+      ID: 148
       Name: '*crypto/x509.ExtKeyUsage'
       ByteSize: 8
       GoRuntimeType: 395104
       GoKind: 22
-      Pointee: 130 BaseType crypto/x509.ExtKeyUsage
+      Pointee: 149 BaseType crypto/x509.ExtKeyUsage
     - __kind: PointerType
-      ID: 140
+      ID: 159
       Name: '*crypto/x509.OID'
       ByteSize: 8
       GoRuntimeType: 1.717792e+06
       GoKind: 22
-      Pointee: 141 StructureType crypto/x509.OID
+      Pointee: 160 StructureType crypto/x509.OID
     - __kind: PointerType
-      ID: 116
+      ID: 135
       Name: '*crypto/x509/pkix.AttributeTypeAndValue'
       ByteSize: 8
       GoRuntimeType: 408928
       GoKind: 22
-      Pointee: 117 StructureType crypto/x509/pkix.AttributeTypeAndValue
+      Pointee: 136 StructureType crypto/x509/pkix.AttributeTypeAndValue
     - __kind: PointerType
-      ID: 123
+      ID: 142
       Name: '*crypto/x509/pkix.Extension'
       ByteSize: 8
       GoRuntimeType: 409120
       GoKind: 22
-      Pointee: 124 StructureType crypto/x509/pkix.Extension
+      Pointee: 143 StructureType crypto/x509/pkix.Extension
     - __kind: PointerType
-      ID: 126
+      ID: 145
       Name: '*encoding/asn1.ObjectIdentifier'
       ByteSize: 8
       GoRuntimeType: 1.00992e+06
       GoKind: 22
-      Pointee: 127 GoSliceHeaderType encoding/asn1.ObjectIdentifier
+      Pointee: 146 GoSliceHeaderType encoding/asn1.ObjectIdentifier
     - __kind: PointerType
-      ID: 182
+      ID: 181
       Name: '*encoding/asn1.ObjectIdentifier.array'
       ByteSize: 8
-      Pointee: 181 GoSliceDataType encoding/asn1.ObjectIdentifier.array
+      Pointee: 180 GoSliceDataType encoding/asn1.ObjectIdentifier.array
     - __kind: PointerType
       ID: 33
       Name: '*error'
@@ -362,10 +362,10 @@ Types:
       GoKind: 22
       Pointee: 17 BaseType float64
     - __kind: PointerType
-      ID: 85
+      ID: 87
       Name: '*hash<string,[]*mime/multipart.FileHeader>'
       ByteSize: 8
-      Pointee: 86 GoHMapHeaderType hash<string,[]*mime/multipart.FileHeader>
+      Pointee: 88 GoHMapHeaderType hash<string,[]*mime/multipart.FileHeader>
     - __kind: PointerType
       ID: 47
       Name: '*hash<string,[]string>'
@@ -412,31 +412,31 @@ Types:
       GoKind: 22
       Pointee: 15 BaseType int8
     - __kind: PointerType
-      ID: 112
+      ID: 131
       Name: '*math/big.Int'
       ByteSize: 8
       GoRuntimeType: 2.231648e+06
       GoKind: 22
-      Pointee: 113 StructureType math/big.Int
+      Pointee: 132 StructureType math/big.Int
     - __kind: PointerType
-      ID: 144
+      ID: 165
       Name: '*math/big.Word'
       ByteSize: 8
       GoRuntimeType: 397920
       GoKind: 22
-      Pointee: 145 BaseType math/big.Word
+      Pointee: 166 BaseType math/big.Word
     - __kind: PointerType
       ID: 196
       Name: '*math/big.nat.array'
       ByteSize: 8
       Pointee: 195 GoSliceDataType math/big.nat.array
     - __kind: PointerType
-      ID: 106
+      ID: 114
       Name: '*mime/multipart.FileHeader'
       ByteSize: 8
       GoRuntimeType: 837472
       GoKind: 22
-      Pointee: 108 StructureType mime/multipart.FileHeader
+      Pointee: 127 StructureType mime/multipart.FileHeader
     - __kind: PointerType
       ID: 57
       Name: '*mime/multipart.Form'
@@ -445,29 +445,29 @@ Types:
       GoKind: 22
       Pointee: 58 StructureType mime/multipart.Form
     - __kind: PointerType
-      ID: 132
+      ID: 151
       Name: '*net.IP'
       ByteSize: 8
       GoRuntimeType: 1.974688e+06
       GoKind: 22
-      Pointee: 133 GoSliceHeaderType net.IP
+      Pointee: 152 GoSliceHeaderType net.IP
     - __kind: PointerType
-      ID: 188
+      ID: 187
       Name: '*net.IP.array'
       ByteSize: 8
-      Pointee: 187 GoSliceDataType net.IP.array
+      Pointee: 186 GoSliceDataType net.IP.array
     - __kind: PointerType
       ID: 202
       Name: '*net.IPMask.array'
       ByteSize: 8
       Pointee: 201 GoSliceDataType net.IPMask.array
     - __kind: PointerType
-      ID: 138
+      ID: 157
       Name: '*net.IPNet'
       ByteSize: 8
       GoRuntimeType: 1.095968e+06
       GoKind: 22
-      Pointee: 152 StructureType net.IPNet
+      Pointee: 173 StructureType net.IPNet
     - __kind: PointerType
       ID: 37
       Name: '*net/http.Request'
@@ -490,12 +490,12 @@ Types:
       GoKind: 22
       Pointee: 66 StructureType net/http.pattern
     - __kind: PointerType
-      ID: 99
+      ID: 101
       Name: '*net/http.segment'
       ByteSize: 8
       GoRuntimeType: 364064
       GoKind: 22
-      Pointee: 100 StructureType net/http.segment
+      Pointee: 102 StructureType net/http.segment
     - __kind: PointerType
       ID: 44
       Name: '*net/url.URL'
@@ -504,19 +504,19 @@ Types:
       GoKind: 22
       Pointee: 45 StructureType net/url.URL
     - __kind: PointerType
-      ID: 74
+      ID: 76
       Name: '*net/url.Userinfo'
       ByteSize: 8
       GoRuntimeType: 1.1144e+06
       GoKind: 22
-      Pointee: 75 StructureType net/url.Userinfo
+      Pointee: 77 StructureType net/url.Userinfo
     - __kind: PointerType
-      ID: 81
+      ID: 83
       Name: '*runtime.bmap'
       ByteSize: 8
       GoRuntimeType: 1.110048e+06
       GoKind: 22
-      Pointee: 82 StructureType runtime.bmap
+      Pointee: 84 StructureType runtime.bmap
     - __kind: PointerType
       ID: 51
       Name: '*runtime.mapextra'
@@ -532,31 +532,31 @@ Types:
       GoKind: 22
       Pointee: 11 GoStringHeaderType string
     - __kind: PointerType
-      ID: 155
+      ID: 75
       Name: '*string.str'
       ByteSize: 8
-      Pointee: 154 GoStringDataType string.str
+      Pointee: 74 GoStringDataType string.str
     - __kind: PointerType
-      ID: 119
+      ID: 138
       Name: '*time.Location'
       ByteSize: 8
       GoRuntimeType: 1.421568e+06
       GoKind: 22
-      Pointee: 120 StructureType time.Location
+      Pointee: 139 StructureType time.Location
     - __kind: PointerType
-      ID: 147
+      ID: 168
       Name: '*time.zone'
       ByteSize: 8
       GoRuntimeType: 367136
       GoKind: 22
-      Pointee: 148 StructureType time.zone
+      Pointee: 169 StructureType time.zone
     - __kind: PointerType
-      ID: 150
+      ID: 171
       Name: '*time.zoneTrans'
       ByteSize: 8
       GoRuntimeType: 367200
       GoKind: 22
-      Pointee: 151 StructureType time.zoneTrans
+      Pointee: 172 StructureType time.zoneTrans
     - __kind: PointerType
       ID: 34
       Name: '*uint'
@@ -644,7 +644,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: ArrayType
-      ID: 76
+      ID: 78
       Name: '[8]uint8'
       ByteSize: 8
       GoRuntimeType: 621920
@@ -653,7 +653,7 @@ Types:
       HasCount: true
       Element: 3 BaseType uint8
     - __kind: GoSliceHeaderType
-      ID: 89
+      ID: 91
       Name: '[]*crypto/x509.Certificate'
       ByteSize: 24
       GoRuntimeType: 469664
@@ -661,21 +661,21 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 90 PointerType **crypto/x509.Certificate
+          Type: 92 PointerType **crypto/x509.Certificate
         - Name: len
           Offset: 8
           Type: 9 BaseType int
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 165 GoSliceDataType []*crypto/x509.Certificate.array
+      Data: 119 GoSliceDataType []*crypto/x509.Certificate.array
     - __kind: GoSliceDataType
-      ID: 165
+      ID: 119
       Name: '[]*crypto/x509.Certificate.array'
       ByteSize: 2048
-      Element: 91 PointerType *crypto/x509.Certificate
+      Element: 93 PointerType *crypto/x509.Certificate
     - __kind: GoSliceHeaderType
-      ID: 104
+      ID: 112
       Name: '[]*mime/multipart.FileHeader'
       ByteSize: 24
       GoRuntimeType: 457504
@@ -683,21 +683,21 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 105 PointerType **mime/multipart.FileHeader
+          Type: 113 PointerType **mime/multipart.FileHeader
         - Name: len
           Offset: 8
           Type: 9 BaseType int
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 173 GoSliceDataType []*mime/multipart.FileHeader.array
+      Data: 161 GoSliceDataType []*mime/multipart.FileHeader.array
     - __kind: GoSliceDataType
-      ID: 173
+      ID: 161
       Name: '[]*mime/multipart.FileHeader.array'
       ByteSize: 2048
-      Element: 106 PointerType *mime/multipart.FileHeader
+      Element: 114 PointerType *mime/multipart.FileHeader
     - __kind: GoSliceHeaderType
-      ID: 136
+      ID: 155
       Name: '[]*net.IPNet'
       ByteSize: 24
       GoRuntimeType: 481696
@@ -705,21 +705,21 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 137 PointerType **net.IPNet
+          Type: 156 PointerType **net.IPNet
         - Name: len
           Offset: 8
           Type: 9 BaseType int
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 191 GoSliceDataType []*net.IPNet.array
+      Data: 190 GoSliceDataType []*net.IPNet.array
     - __kind: GoSliceDataType
-      ID: 191
+      ID: 190
       Name: '[]*net.IPNet.array'
       ByteSize: 2048
-      Element: 138 PointerType *net.IPNet
+      Element: 157 PointerType *net.IPNet
     - __kind: GoSliceHeaderType
-      ID: 134
+      ID: 153
       Name: '[]*net/url.URL'
       ByteSize: 24
       GoRuntimeType: 481632
@@ -727,21 +727,21 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 135 PointerType **net/url.URL
+          Type: 154 PointerType **net/url.URL
         - Name: len
           Offset: 8
           Type: 9 BaseType int
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 189 GoSliceDataType []*net/url.URL.array
+      Data: 188 GoSliceDataType []*net/url.URL.array
     - __kind: GoSliceDataType
-      ID: 189
+      ID: 188
       Name: '[]*net/url.URL.array'
       ByteSize: 2048
       Element: 44 PointerType *net/url.URL
     - __kind: GoSliceHeaderType
-      ID: 80
+      ID: 82
       Name: '[]*runtime.bmap'
       ByteSize: 24
       GoRuntimeType: 466432
@@ -749,21 +749,21 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 102 PointerType **runtime.bmap
+          Type: 110 PointerType **runtime.bmap
         - Name: len
           Offset: 8
           Type: 9 BaseType int
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 162 GoSliceDataType []*runtime.bmap.array
+      Data: 116 GoSliceDataType []*runtime.bmap.array
     - __kind: GoSliceDataType
-      ID: 162
+      ID: 116
       Name: '[]*runtime.bmap.array'
       ByteSize: 2048
-      Element: 81 PointerType *runtime.bmap
+      Element: 83 PointerType *runtime.bmap
     - __kind: GoSliceHeaderType
-      ID: 92
+      ID: 94
       Name: '[][]*crypto/x509.Certificate'
       ByteSize: 24
       GoRuntimeType: 469792
@@ -771,21 +771,21 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 93 PointerType *[]*crypto/x509.Certificate
+          Type: 95 PointerType *[]*crypto/x509.Certificate
         - Name: len
           Offset: 8
           Type: 9 BaseType int
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 167 GoSliceDataType [][]*crypto/x509.Certificate.array
+      Data: 121 GoSliceDataType [][]*crypto/x509.Certificate.array
     - __kind: GoSliceDataType
-      ID: 167
+      ID: 121
       Name: '[][]*crypto/x509.Certificate.array'
       ByteSize: 2048
-      Element: 89 GoSliceHeaderType []*crypto/x509.Certificate
+      Element: 91 GoSliceHeaderType []*crypto/x509.Certificate
     - __kind: GoSliceHeaderType
-      ID: 94
+      ID: 96
       Name: '[][]uint8'
       ByteSize: 24
       GoRuntimeType: 452960
@@ -793,36 +793,36 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 95 PointerType *[]uint8
+          Type: 97 PointerType *[]uint8
         - Name: len
           Offset: 8
           Type: 9 BaseType int
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 169 GoSliceDataType [][]uint8.array
+      Data: 123 GoSliceDataType [][]uint8.array
     - __kind: GoSliceDataType
-      ID: 169
+      ID: 123
       Name: '[][]uint8.array'
       ByteSize: 2048
       Element: 72 GoSliceHeaderType []uint8
     - __kind: GoSliceDataType
-      ID: 164
+      ID: 118
       Name: '[]bucket<string,[]*mime/multipart.FileHeader>.array'
       ByteSize: 2048
-      Element: 88 GoHMapBucketType bucket<string,[]*mime/multipart.FileHeader>
+      Element: 90 GoHMapBucketType bucket<string,[]*mime/multipart.FileHeader>
     - __kind: GoSliceDataType
-      ID: 156
+      ID: 104
       Name: '[]bucket<string,[]string>.array'
       ByteSize: 2048
       Element: 50 GoHMapBucketType bucket<string,[]string>
     - __kind: GoSliceDataType
-      ID: 159
+      ID: 107
       Name: '[]bucket<string,string>.array'
       ByteSize: 2048
       Element: 71 GoHMapBucketType bucket<string,string>
     - __kind: GoSliceHeaderType
-      ID: 128
+      ID: 147
       Name: '[]crypto/x509.ExtKeyUsage'
       ByteSize: 24
       GoRuntimeType: 470944
@@ -830,21 +830,21 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 129 PointerType *crypto/x509.ExtKeyUsage
+          Type: 148 PointerType *crypto/x509.ExtKeyUsage
         - Name: len
           Offset: 8
           Type: 9 BaseType int
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 183 GoSliceDataType []crypto/x509.ExtKeyUsage.array
+      Data: 182 GoSliceDataType []crypto/x509.ExtKeyUsage.array
     - __kind: GoSliceDataType
-      ID: 183
+      ID: 182
       Name: '[]crypto/x509.ExtKeyUsage.array'
       ByteSize: 2048
-      Element: 130 BaseType crypto/x509.ExtKeyUsage
+      Element: 149 BaseType crypto/x509.ExtKeyUsage
     - __kind: GoSliceHeaderType
-      ID: 139
+      ID: 158
       Name: '[]crypto/x509.OID'
       ByteSize: 24
       GoRuntimeType: 481760
@@ -852,21 +852,21 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 140 PointerType *crypto/x509.OID
+          Type: 159 PointerType *crypto/x509.OID
         - Name: len
           Offset: 8
           Type: 9 BaseType int
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 193 GoSliceDataType []crypto/x509.OID.array
+      Data: 192 GoSliceDataType []crypto/x509.OID.array
     - __kind: GoSliceDataType
-      ID: 193
+      ID: 192
       Name: '[]crypto/x509.OID.array'
       ByteSize: 2048
-      Element: 141 StructureType crypto/x509.OID
+      Element: 160 StructureType crypto/x509.OID
     - __kind: GoSliceHeaderType
-      ID: 115
+      ID: 134
       Name: '[]crypto/x509/pkix.AttributeTypeAndValue'
       ByteSize: 24
       GoRuntimeType: 482016
@@ -874,21 +874,21 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 116 PointerType *crypto/x509/pkix.AttributeTypeAndValue
+          Type: 135 PointerType *crypto/x509/pkix.AttributeTypeAndValue
         - Name: len
           Offset: 8
           Type: 9 BaseType int
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 175 GoSliceDataType []crypto/x509/pkix.AttributeTypeAndValue.array
+      Data: 174 GoSliceDataType []crypto/x509/pkix.AttributeTypeAndValue.array
     - __kind: GoSliceDataType
-      ID: 175
+      ID: 174
       Name: '[]crypto/x509/pkix.AttributeTypeAndValue.array'
       ByteSize: 2048
-      Element: 117 StructureType crypto/x509/pkix.AttributeTypeAndValue
+      Element: 136 StructureType crypto/x509/pkix.AttributeTypeAndValue
     - __kind: GoSliceHeaderType
-      ID: 122
+      ID: 141
       Name: '[]crypto/x509/pkix.Extension'
       ByteSize: 24
       GoRuntimeType: 481504
@@ -896,21 +896,21 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 123 PointerType *crypto/x509/pkix.Extension
+          Type: 142 PointerType *crypto/x509/pkix.Extension
         - Name: len
           Offset: 8
           Type: 9 BaseType int
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 177 GoSliceDataType []crypto/x509/pkix.Extension.array
+      Data: 176 GoSliceDataType []crypto/x509/pkix.Extension.array
     - __kind: GoSliceDataType
-      ID: 177
+      ID: 176
       Name: '[]crypto/x509/pkix.Extension.array'
       ByteSize: 2048
-      Element: 124 StructureType crypto/x509/pkix.Extension
+      Element: 143 StructureType crypto/x509/pkix.Extension
     - __kind: GoSliceHeaderType
-      ID: 125
+      ID: 144
       Name: '[]encoding/asn1.ObjectIdentifier'
       ByteSize: 24
       GoRuntimeType: 481568
@@ -918,28 +918,28 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 126 PointerType *encoding/asn1.ObjectIdentifier
+          Type: 145 PointerType *encoding/asn1.ObjectIdentifier
         - Name: len
           Offset: 8
           Type: 9 BaseType int
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 179 GoSliceDataType []encoding/asn1.ObjectIdentifier.array
+      Data: 178 GoSliceDataType []encoding/asn1.ObjectIdentifier.array
     - __kind: GoSliceDataType
-      ID: 179
+      ID: 178
       Name: '[]encoding/asn1.ObjectIdentifier.array'
       ByteSize: 2048
-      Element: 127 GoSliceHeaderType encoding/asn1.ObjectIdentifier
+      Element: 146 GoSliceHeaderType encoding/asn1.ObjectIdentifier
     - __kind: ArrayType
-      ID: 77
+      ID: 79
       Name: '[]key<string>'
       ByteSize: 128
       Count: 8
       HasCount: true
       Element: 11 GoStringHeaderType string
     - __kind: GoSliceHeaderType
-      ID: 131
+      ID: 150
       Name: '[]net.IP'
       ByteSize: 24
       GoRuntimeType: 454176
@@ -947,21 +947,21 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 132 PointerType *net.IP
+          Type: 151 PointerType *net.IP
         - Name: len
           Offset: 8
           Type: 9 BaseType int
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 185 GoSliceDataType []net.IP.array
+      Data: 184 GoSliceDataType []net.IP.array
     - __kind: GoSliceDataType
-      ID: 185
+      ID: 184
       Name: '[]net.IP.array'
       ByteSize: 2048
-      Element: 133 GoSliceHeaderType net.IP
+      Element: 152 GoSliceHeaderType net.IP
     - __kind: GoSliceHeaderType
-      ID: 98
+      ID: 100
       Name: '[]net/http.segment'
       ByteSize: 24
       GoRuntimeType: 454944
@@ -969,19 +969,19 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 99 PointerType *net/http.segment
+          Type: 101 PointerType *net/http.segment
         - Name: len
           Offset: 8
           Type: 9 BaseType int
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 171 GoSliceDataType []net/http.segment.array
+      Data: 125 GoSliceDataType []net/http.segment.array
     - __kind: GoSliceDataType
-      ID: 171
+      ID: 125
       Name: '[]net/http.segment.array'
       ByteSize: 2048
-      Element: 100 StructureType net/http.segment
+      Element: 102 StructureType net/http.segment
     - __kind: GoSliceHeaderType
       ID: 55
       Name: '[]string'
@@ -998,14 +998,14 @@ Types:
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 157 GoSliceDataType []string.array
+      Data: 105 GoSliceDataType []string.array
     - __kind: GoSliceDataType
-      ID: 157
+      ID: 105
       Name: '[]string.array'
       ByteSize: 2048
       Element: 11 GoStringHeaderType string
     - __kind: GoSliceHeaderType
-      ID: 146
+      ID: 167
       Name: '[]time.zone'
       ByteSize: 24
       GoRuntimeType: 459168
@@ -1013,7 +1013,7 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 147 PointerType *time.zone
+          Type: 168 PointerType *time.zone
         - Name: len
           Offset: 8
           Type: 9 BaseType int
@@ -1025,9 +1025,9 @@ Types:
       ID: 197
       Name: '[]time.zone.array'
       ByteSize: 2048
-      Element: 148 StructureType time.zone
+      Element: 169 StructureType time.zone
     - __kind: GoSliceHeaderType
-      ID: 149
+      ID: 170
       Name: '[]time.zoneTrans'
       ByteSize: 24
       GoRuntimeType: 459232
@@ -1035,7 +1035,7 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 150 PointerType *time.zoneTrans
+          Type: 171 PointerType *time.zoneTrans
         - Name: len
           Offset: 8
           Type: 9 BaseType int
@@ -1047,7 +1047,7 @@ Types:
       ID: 199
       Name: '[]time.zoneTrans.array'
       ByteSize: 2048
-      Element: 151 StructureType time.zoneTrans
+      Element: 172 StructureType time.zoneTrans
     - __kind: GoSliceHeaderType
       ID: 72
       Name: '[]uint8'
@@ -1064,28 +1064,28 @@ Types:
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 160 GoSliceDataType []uint8.array
+      Data: 108 GoSliceDataType []uint8.array
     - __kind: GoSliceDataType
-      ID: 160
+      ID: 108
       Name: '[]uint8.array'
       ByteSize: 2048
       Element: 3 BaseType uint8
     - __kind: ArrayType
-      ID: 103
+      ID: 111
       Name: '[]val<[]*mime/multipart.FileHeader>'
       ByteSize: 192
       Count: 8
       HasCount: true
-      Element: 104 GoSliceHeaderType []*mime/multipart.FileHeader
+      Element: 112 GoSliceHeaderType []*mime/multipart.FileHeader
     - __kind: ArrayType
-      ID: 78
+      ID: 80
       Name: '[]val<[]string>'
       ByteSize: 192
       Count: 8
       HasCount: true
       Element: 55 GoSliceHeaderType []string
     - __kind: ArrayType
-      ID: 101
+      ID: 103
       Name: '[]val<string>'
       ByteSize: 128
       Count: 8
@@ -1098,24 +1098,24 @@ Types:
       GoRuntimeType: 534784
       GoKind: 1
     - __kind: GoHMapBucketType
-      ID: 88
+      ID: 90
       Name: bucket<string,[]*mime/multipart.FileHeader>
       ByteSize: 336
       RawFields:
         - Name: tophash
           Offset: 0
-          Type: 76 ArrayType [8]uint8
+          Type: 78 ArrayType [8]uint8
         - Name: keys
           Offset: 8
-          Type: 77 ArrayType []key<string>
+          Type: 79 ArrayType []key<string>
         - Name: values
           Offset: 136
-          Type: 103 ArrayType []val<[]*mime/multipart.FileHeader>
+          Type: 111 ArrayType []val<[]*mime/multipart.FileHeader>
         - Name: overflow
           Offset: 328
-          Type: 87 PointerType *bucket<string,[]*mime/multipart.FileHeader>
+          Type: 89 PointerType *bucket<string,[]*mime/multipart.FileHeader>
       KeyType: 11 GoStringHeaderType string
-      ValueType: 104 GoSliceHeaderType []*mime/multipart.FileHeader
+      ValueType: 112 GoSliceHeaderType []*mime/multipart.FileHeader
     - __kind: GoHMapBucketType
       ID: 50
       Name: bucket<string,[]string>
@@ -1123,13 +1123,13 @@ Types:
       RawFields:
         - Name: tophash
           Offset: 0
-          Type: 76 ArrayType [8]uint8
+          Type: 78 ArrayType [8]uint8
         - Name: keys
           Offset: 8
-          Type: 77 ArrayType []key<string>
+          Type: 79 ArrayType []key<string>
         - Name: values
           Offset: 136
-          Type: 78 ArrayType []val<[]string>
+          Type: 80 ArrayType []val<[]string>
         - Name: overflow
           Offset: 328
           Type: 49 PointerType *bucket<string,[]string>
@@ -1142,13 +1142,13 @@ Types:
       RawFields:
         - Name: tophash
           Offset: 0
-          Type: 76 ArrayType [8]uint8
+          Type: 78 ArrayType [8]uint8
         - Name: keys
           Offset: 8
-          Type: 77 ArrayType []key<string>
+          Type: 79 ArrayType []key<string>
         - Name: values
           Offset: 136
-          Type: 101 ArrayType []val<string>
+          Type: 103 ArrayType []val<string>
         - Name: overflow
           Offset: 264
           Type: 70 PointerType *bucket<string,string>
@@ -1246,13 +1246,13 @@ Types:
           Type: 11 GoStringHeaderType string
         - Name: PeerCertificates
           Offset: 48
-          Type: 89 GoSliceHeaderType []*crypto/x509.Certificate
+          Type: 91 GoSliceHeaderType []*crypto/x509.Certificate
         - Name: VerifiedChains
           Offset: 72
-          Type: 92 GoSliceHeaderType [][]*crypto/x509.Certificate
+          Type: 94 GoSliceHeaderType [][]*crypto/x509.Certificate
         - Name: SignedCertificateTimestamps
           Offset: 96
-          Type: 94 GoSliceHeaderType [][]uint8
+          Type: 96 GoSliceHeaderType [][]uint8
         - Name: OCSPResponse
           Offset: 120
           Type: 72 GoSliceHeaderType []uint8
@@ -1264,21 +1264,21 @@ Types:
           Type: 4 BaseType bool
         - Name: ekm
           Offset: 176
-          Type: 96 GoSubroutineType func(string, []uint8, int) ([]uint8, error)
+          Type: 98 GoSubroutineType func(string, []uint8, int) ([]uint8, error)
         - Name: testingOnlyDidHRR
           Offset: 184
           Type: 4 BaseType bool
         - Name: testingOnlyCurveID
           Offset: 186
-          Type: 97 BaseType crypto/tls.CurveID
+          Type: 99 BaseType crypto/tls.CurveID
     - __kind: BaseType
-      ID: 97
+      ID: 99
       Name: crypto/tls.CurveID
       ByteSize: 2
       GoRuntimeType: 766144
       GoKind: 9
     - __kind: StructureType
-      ID: 107
+      ID: 115
       Name: crypto/x509.Certificate
       ByteSize: 1352
       GoRuntimeType: 2.2352e+06
@@ -1304,49 +1304,49 @@ Types:
           Type: 72 GoSliceHeaderType []uint8
         - Name: SignatureAlgorithm
           Offset: 144
-          Type: 109 BaseType crypto/x509.SignatureAlgorithm
+          Type: 128 BaseType crypto/x509.SignatureAlgorithm
         - Name: PublicKeyAlgorithm
           Offset: 152
-          Type: 110 BaseType crypto/x509.PublicKeyAlgorithm
+          Type: 129 BaseType crypto/x509.PublicKeyAlgorithm
         - Name: PublicKey
           Offset: 160
-          Type: 111 GoEmptyInterfaceType interface {}
+          Type: 130 GoEmptyInterfaceType interface {}
         - Name: Version
           Offset: 176
           Type: 9 BaseType int
         - Name: SerialNumber
           Offset: 184
-          Type: 112 PointerType *math/big.Int
+          Type: 131 PointerType *math/big.Int
         - Name: Issuer
           Offset: 192
-          Type: 114 StructureType crypto/x509/pkix.Name
+          Type: 133 StructureType crypto/x509/pkix.Name
         - Name: Subject
           Offset: 440
-          Type: 114 StructureType crypto/x509/pkix.Name
+          Type: 133 StructureType crypto/x509/pkix.Name
         - Name: NotBefore
           Offset: 688
-          Type: 118 StructureType time.Time
+          Type: 137 StructureType time.Time
         - Name: NotAfter
           Offset: 712
-          Type: 118 StructureType time.Time
+          Type: 137 StructureType time.Time
         - Name: KeyUsage
           Offset: 736
-          Type: 121 BaseType crypto/x509.KeyUsage
+          Type: 140 BaseType crypto/x509.KeyUsage
         - Name: Extensions
           Offset: 744
-          Type: 122 GoSliceHeaderType []crypto/x509/pkix.Extension
+          Type: 141 GoSliceHeaderType []crypto/x509/pkix.Extension
         - Name: ExtraExtensions
           Offset: 768
-          Type: 122 GoSliceHeaderType []crypto/x509/pkix.Extension
+          Type: 141 GoSliceHeaderType []crypto/x509/pkix.Extension
         - Name: UnhandledCriticalExtensions
           Offset: 792
-          Type: 125 GoSliceHeaderType []encoding/asn1.ObjectIdentifier
+          Type: 144 GoSliceHeaderType []encoding/asn1.ObjectIdentifier
         - Name: ExtKeyUsage
           Offset: 816
-          Type: 128 GoSliceHeaderType []crypto/x509.ExtKeyUsage
+          Type: 147 GoSliceHeaderType []crypto/x509.ExtKeyUsage
         - Name: UnknownExtKeyUsage
           Offset: 840
-          Type: 125 GoSliceHeaderType []encoding/asn1.ObjectIdentifier
+          Type: 144 GoSliceHeaderType []encoding/asn1.ObjectIdentifier
         - Name: BasicConstraintsValid
           Offset: 864
           Type: 4 BaseType bool
@@ -1379,10 +1379,10 @@ Types:
           Type: 55 GoSliceHeaderType []string
         - Name: IPAddresses
           Offset: 1032
-          Type: 131 GoSliceHeaderType []net.IP
+          Type: 150 GoSliceHeaderType []net.IP
         - Name: URIs
           Offset: 1056
-          Type: 134 GoSliceHeaderType []*net/url.URL
+          Type: 153 GoSliceHeaderType []*net/url.URL
         - Name: PermittedDNSDomainsCritical
           Offset: 1080
           Type: 4 BaseType bool
@@ -1394,10 +1394,10 @@ Types:
           Type: 55 GoSliceHeaderType []string
         - Name: PermittedIPRanges
           Offset: 1136
-          Type: 136 GoSliceHeaderType []*net.IPNet
+          Type: 155 GoSliceHeaderType []*net.IPNet
         - Name: ExcludedIPRanges
           Offset: 1160
-          Type: 136 GoSliceHeaderType []*net.IPNet
+          Type: 155 GoSliceHeaderType []*net.IPNet
         - Name: PermittedEmailAddresses
           Offset: 1184
           Type: 55 GoSliceHeaderType []string
@@ -1415,24 +1415,24 @@ Types:
           Type: 55 GoSliceHeaderType []string
         - Name: PolicyIdentifiers
           Offset: 1304
-          Type: 125 GoSliceHeaderType []encoding/asn1.ObjectIdentifier
+          Type: 144 GoSliceHeaderType []encoding/asn1.ObjectIdentifier
         - Name: Policies
           Offset: 1328
-          Type: 139 GoSliceHeaderType []crypto/x509.OID
+          Type: 158 GoSliceHeaderType []crypto/x509.OID
     - __kind: BaseType
-      ID: 130
+      ID: 149
       Name: crypto/x509.ExtKeyUsage
       ByteSize: 8
       GoRuntimeType: 537472
       GoKind: 2
     - __kind: BaseType
-      ID: 121
+      ID: 140
       Name: crypto/x509.KeyUsage
       ByteSize: 8
       GoRuntimeType: 537408
       GoKind: 2
     - __kind: StructureType
-      ID: 141
+      ID: 160
       Name: crypto/x509.OID
       ByteSize: 24
       GoRuntimeType: 1.718016e+06
@@ -1442,19 +1442,19 @@ Types:
           Offset: 0
           Type: 72 GoSliceHeaderType []uint8
     - __kind: BaseType
-      ID: 110
+      ID: 129
       Name: crypto/x509.PublicKeyAlgorithm
       ByteSize: 8
       GoRuntimeType: 768544
       GoKind: 2
     - __kind: BaseType
-      ID: 109
+      ID: 128
       Name: crypto/x509.SignatureAlgorithm
       ByteSize: 8
       GoRuntimeType: 1.071168e+06
       GoKind: 2
     - __kind: StructureType
-      ID: 117
+      ID: 136
       Name: crypto/x509/pkix.AttributeTypeAndValue
       ByteSize: 40
       GoRuntimeType: 1.316608e+06
@@ -1462,12 +1462,12 @@ Types:
       RawFields:
         - Name: Type
           Offset: 0
-          Type: 127 GoSliceHeaderType encoding/asn1.ObjectIdentifier
+          Type: 146 GoSliceHeaderType encoding/asn1.ObjectIdentifier
         - Name: Value
           Offset: 24
-          Type: 111 GoEmptyInterfaceType interface {}
+          Type: 130 GoEmptyInterfaceType interface {}
     - __kind: StructureType
-      ID: 124
+      ID: 143
       Name: crypto/x509/pkix.Extension
       ByteSize: 56
       GoRuntimeType: 1.45536e+06
@@ -1475,7 +1475,7 @@ Types:
       RawFields:
         - Name: Id
           Offset: 0
-          Type: 127 GoSliceHeaderType encoding/asn1.ObjectIdentifier
+          Type: 146 GoSliceHeaderType encoding/asn1.ObjectIdentifier
         - Name: Critical
           Offset: 24
           Type: 4 BaseType bool
@@ -1483,7 +1483,7 @@ Types:
           Offset: 32
           Type: 72 GoSliceHeaderType []uint8
     - __kind: StructureType
-      ID: 114
+      ID: 133
       Name: crypto/x509/pkix.Name
       ByteSize: 248
       GoRuntimeType: 2.047488e+06
@@ -1518,12 +1518,12 @@ Types:
           Type: 11 GoStringHeaderType string
         - Name: Names
           Offset: 200
-          Type: 115 GoSliceHeaderType []crypto/x509/pkix.AttributeTypeAndValue
+          Type: 134 GoSliceHeaderType []crypto/x509/pkix.AttributeTypeAndValue
         - Name: ExtraNames
           Offset: 224
-          Type: 115 GoSliceHeaderType []crypto/x509/pkix.AttributeTypeAndValue
+          Type: 134 GoSliceHeaderType []crypto/x509/pkix.AttributeTypeAndValue
     - __kind: GoSliceHeaderType
-      ID: 127
+      ID: 146
       Name: encoding/asn1.ObjectIdentifier
       ByteSize: 24
       GoRuntimeType: 1.010048e+06
@@ -1538,9 +1538,9 @@ Types:
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 181 GoSliceDataType encoding/asn1.ObjectIdentifier.array
+      Data: 180 GoSliceDataType encoding/asn1.ObjectIdentifier.array
     - __kind: GoSliceDataType
-      ID: 181
+      ID: 180
       Name: encoding/asn1.ObjectIdentifier.array
       ByteSize: 2048
       Element: 9 BaseType int
@@ -1576,7 +1576,7 @@ Types:
       GoRuntimeType: 634400
       GoKind: 19
     - __kind: GoSubroutineType
-      ID: 96
+      ID: 98
       Name: func(string, []uint8, int) ([]uint8, error)
       ByteSize: 8
       GoRuntimeType: 960448
@@ -1595,7 +1595,7 @@ Types:
           Offset: 8
           Type: 19 VoidPointerType unsafe.Pointer
     - __kind: GoHMapHeaderType
-      ID: 86
+      ID: 88
       Name: hash<string,[]*mime/multipart.FileHeader>
       ByteSize: 48
       RawFields:
@@ -1616,18 +1616,18 @@ Types:
           Type: 2 BaseType uint32
         - Name: buckets
           Offset: 16
-          Type: 87 PointerType *bucket<string,[]*mime/multipart.FileHeader>
+          Type: 89 PointerType *bucket<string,[]*mime/multipart.FileHeader>
         - Name: oldbuckets
           Offset: 24
-          Type: 87 PointerType *bucket<string,[]*mime/multipart.FileHeader>
+          Type: 89 PointerType *bucket<string,[]*mime/multipart.FileHeader>
         - Name: nevacuate
           Offset: 32
           Type: 1 BaseType uintptr
         - Name: extra
           Offset: 40
           Type: 51 PointerType *runtime.mapextra
-      BucketType: 88 GoHMapBucketType bucket<string,[]*mime/multipart.FileHeader>
-      BucketsType: 164 GoSliceDataType []bucket<string,[]*mime/multipart.FileHeader>.array
+      BucketType: 90 GoHMapBucketType bucket<string,[]*mime/multipart.FileHeader>
+      BucketsType: 118 GoSliceDataType []bucket<string,[]*mime/multipart.FileHeader>.array
     - __kind: GoHMapHeaderType
       ID: 48
       Name: hash<string,[]string>
@@ -1661,7 +1661,7 @@ Types:
           Offset: 40
           Type: 51 PointerType *runtime.mapextra
       BucketType: 50 GoHMapBucketType bucket<string,[]string>
-      BucketsType: 156 GoSliceDataType []bucket<string,[]string>.array
+      BucketsType: 104 GoSliceDataType []bucket<string,[]string>.array
     - __kind: GoHMapHeaderType
       ID: 69
       Name: hash<string,string>
@@ -1695,7 +1695,7 @@ Types:
           Offset: 40
           Type: 51 PointerType *runtime.mapextra
       BucketType: 71 GoHMapBucketType bucket<string,string>
-      BucketsType: 159 GoSliceDataType []bucket<string,string>.array
+      BucketsType: 107 GoSliceDataType []bucket<string,string>.array
     - __kind: BaseType
       ID: 9
       Name: int
@@ -1727,7 +1727,7 @@ Types:
       GoRuntimeType: 533824
       GoKind: 3
     - __kind: GoEmptyInterfaceType
-      ID: 111
+      ID: 130
       Name: interface {}
       ByteSize: 16
       GoRuntimeType: 785472
@@ -1753,14 +1753,14 @@ Types:
           Offset: 8
           Type: 19 VoidPointerType unsafe.Pointer
     - __kind: GoMapType
-      ID: 84
+      ID: 86
       Name: map[string][]*mime/multipart.FileHeader
       ByteSize: 8
       GoRuntimeType: 887392
       GoKind: 21
-      HeaderType: 86 GoHMapHeaderType hash<string,[]*mime/multipart.FileHeader>
+      HeaderType: 88 GoHMapHeaderType hash<string,[]*mime/multipart.FileHeader>
     - __kind: GoMapType
-      ID: 83
+      ID: 85
       Name: map[string][]string
       ByteSize: 8
       GoRuntimeType: 882592
@@ -1774,7 +1774,7 @@ Types:
       GoKind: 21
       HeaderType: 69 GoHMapHeaderType hash<string,string>
     - __kind: StructureType
-      ID: 113
+      ID: 132
       Name: math/big.Int
       ByteSize: 32
       GoRuntimeType: 1.308608e+06
@@ -1785,15 +1785,15 @@ Types:
           Type: 4 BaseType bool
         - Name: abs
           Offset: 8
-          Type: 143 GoSliceHeaderType math/big.nat
+          Type: 164 GoSliceHeaderType math/big.nat
     - __kind: BaseType
-      ID: 145
+      ID: 166
       Name: math/big.Word
       ByteSize: 8
       GoRuntimeType: 537728
       GoKind: 7
     - __kind: GoSliceHeaderType
-      ID: 143
+      ID: 164
       Name: math/big.nat
       ByteSize: 24
       GoRuntimeType: 2.214784e+06
@@ -1801,7 +1801,7 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 144 PointerType *math/big.Word
+          Type: 165 PointerType *math/big.Word
         - Name: len
           Offset: 8
           Type: 9 BaseType int
@@ -1813,9 +1813,9 @@ Types:
       ID: 195
       Name: math/big.nat.array
       ByteSize: 2048
-      Element: 145 BaseType math/big.Word
+      Element: 166 BaseType math/big.Word
     - __kind: StructureType
-      ID: 108
+      ID: 127
       Name: mime/multipart.FileHeader
       ByteSize: 88
       GoRuntimeType: 1.83856e+06
@@ -1826,7 +1826,7 @@ Types:
           Type: 11 GoStringHeaderType string
         - Name: Header
           Offset: 16
-          Type: 142 GoMapType net/textproto.MIMEHeader
+          Type: 163 GoMapType net/textproto.MIMEHeader
         - Name: Size
           Offset: 24
           Type: 14 BaseType int64
@@ -1851,12 +1851,12 @@ Types:
       RawFields:
         - Name: Value
           Offset: 0
-          Type: 83 GoMapType map[string][]string
+          Type: 85 GoMapType map[string][]string
         - Name: File
           Offset: 8
-          Type: 84 GoMapType map[string][]*mime/multipart.FileHeader
+          Type: 86 GoMapType map[string][]*mime/multipart.FileHeader
     - __kind: GoSliceHeaderType
-      ID: 133
+      ID: 152
       Name: net.IP
       ByteSize: 24
       GoRuntimeType: 1.948704e+06
@@ -1871,14 +1871,14 @@ Types:
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 187 GoSliceDataType net.IP.array
+      Data: 186 GoSliceDataType net.IP.array
     - __kind: GoSliceDataType
-      ID: 187
+      ID: 186
       Name: net.IP.array
       ByteSize: 2048
       Element: 3 BaseType uint8
     - __kind: GoSliceHeaderType
-      ID: 153
+      ID: 194
       Name: net.IPMask
       ByteSize: 24
       GoRuntimeType: 976000
@@ -1900,7 +1900,7 @@ Types:
       ByteSize: 2048
       Element: 3 BaseType uint8
     - __kind: StructureType
-      ID: 152
+      ID: 173
       Name: net.IPNet
       ByteSize: 48
       GoRuntimeType: 1.276128e+06
@@ -1908,10 +1908,10 @@ Types:
       RawFields:
         - Name: IP
           Offset: 0
-          Type: 133 GoSliceHeaderType net.IP
+          Type: 152 GoSliceHeaderType net.IP
         - Name: Mask
           Offset: 24
-          Type: 153 GoSliceHeaderType net.IPMask
+          Type: 194 GoSliceHeaderType net.IPMask
     - __kind: GoMapType
       ID: 46
       Name: net/http.Header
@@ -2084,12 +2084,12 @@ Types:
           Type: 11 GoStringHeaderType string
         - Name: segments
           Offset: 48
-          Type: 98 GoSliceHeaderType []net/http.segment
+          Type: 100 GoSliceHeaderType []net/http.segment
         - Name: loc
           Offset: 72
           Type: 11 GoStringHeaderType string
     - __kind: StructureType
-      ID: 100
+      ID: 102
       Name: net/http.segment
       ByteSize: 24
       GoRuntimeType: 1.416384e+06
@@ -2105,7 +2105,7 @@ Types:
           Offset: 17
           Type: 4 BaseType bool
     - __kind: GoMapType
-      ID: 142
+      ID: 163
       Name: net/textproto.MIMEHeader
       ByteSize: 8
       GoRuntimeType: 1.596448e+06
@@ -2126,7 +2126,7 @@ Types:
           Type: 11 GoStringHeaderType string
         - Name: User
           Offset: 32
-          Type: 74 PointerType *net/url.Userinfo
+          Type: 76 PointerType *net/url.Userinfo
         - Name: Host
           Offset: 40
           Type: 11 GoStringHeaderType string
@@ -2152,7 +2152,7 @@ Types:
           Offset: 128
           Type: 11 GoStringHeaderType string
     - __kind: StructureType
-      ID: 75
+      ID: 77
       Name: net/url.Userinfo
       ByteSize: 40
       GoRuntimeType: 1.433088e+06
@@ -2175,7 +2175,7 @@ Types:
       GoKind: 21
       HeaderType: 48 GoHMapHeaderType hash<string,[]string>
     - __kind: StructureType
-      ID: 82
+      ID: 84
       Name: runtime.bmap
       ByteSize: 8
       GoRuntimeType: 1.10992e+06
@@ -2183,7 +2183,7 @@ Types:
       RawFields:
         - Name: tophash
           Offset: 0
-          Type: 76 ArrayType [8]uint8
+          Type: 78 ArrayType [8]uint8
     - __kind: StructureType
       ID: 52
       Name: runtime.mapextra
@@ -2193,13 +2193,13 @@ Types:
       RawFields:
         - Name: overflow
           Offset: 0
-          Type: 79 PointerType *[]*runtime.bmap
+          Type: 81 PointerType *[]*runtime.bmap
         - Name: oldoverflow
           Offset: 8
-          Type: 79 PointerType *[]*runtime.bmap
+          Type: 81 PointerType *[]*runtime.bmap
         - Name: nextOverflow
           Offset: 16
-          Type: 81 PointerType *runtime.bmap
+          Type: 83 PointerType *runtime.bmap
     - __kind: GoStringHeaderType
       ID: 11
       Name: string
@@ -2209,17 +2209,17 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 155 PointerType *string.str
+          Type: 75 PointerType *string.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 154 GoStringDataType string.str
+      Data: 74 GoStringDataType string.str
     - __kind: GoStringDataType
-      ID: 154
+      ID: 74
       Name: string.str
       ByteSize: 2048
     - __kind: StructureType
-      ID: 120
+      ID: 139
       Name: time.Location
       ByteSize: 104
       GoRuntimeType: 1.834528e+06
@@ -2230,10 +2230,10 @@ Types:
           Type: 11 GoStringHeaderType string
         - Name: zone
           Offset: 16
-          Type: 146 GoSliceHeaderType []time.zone
+          Type: 167 GoSliceHeaderType []time.zone
         - Name: tx
           Offset: 40
-          Type: 149 GoSliceHeaderType []time.zoneTrans
+          Type: 170 GoSliceHeaderType []time.zoneTrans
         - Name: extend
           Offset: 64
           Type: 11 GoStringHeaderType string
@@ -2245,9 +2245,9 @@ Types:
           Type: 14 BaseType int64
         - Name: cacheZone
           Offset: 96
-          Type: 147 PointerType *time.zone
+          Type: 168 PointerType *time.zone
     - __kind: StructureType
-      ID: 118
+      ID: 137
       Name: time.Time
       ByteSize: 24
       GoRuntimeType: 2.215712e+06
@@ -2261,9 +2261,9 @@ Types:
           Type: 14 BaseType int64
         - Name: loc
           Offset: 16
-          Type: 119 PointerType *time.Location
+          Type: 138 PointerType *time.Location
     - __kind: StructureType
-      ID: 148
+      ID: 169
       Name: time.zone
       ByteSize: 32
       GoRuntimeType: 1.421376e+06
@@ -2279,7 +2279,7 @@ Types:
           Offset: 24
           Type: 4 BaseType bool
     - __kind: StructureType
-      ID: 151
+      ID: 172
       Name: time.zoneTrans
       ByteSize: 16
       GoRuntimeType: 1.623872e+06

--- a/pkg/dyninst/irgen/testdata/snapshot/rc_tester_v1.arch=arm64,toolchain=go1.23.11.yaml
+++ b/pkg/dyninst/irgen/testdata/snapshot/rc_tester_v1.arch=arm64,toolchain=go1.23.11.yaml
@@ -33,7 +33,7 @@ Subprograms:
       InlinePCRanges: []
       Variables:
         - Name: w
-          Type: 1 GoInterfaceType net/http.ResponseWriter
+          Type: 36 GoInterfaceType net/http.ResponseWriter
           Locations:
             - Range: 0x8ad860..0x8ad8b8
               Pieces:
@@ -56,7 +56,7 @@ Subprograms:
           IsParameter: true
           IsReturn: false
         - Name: r
-          Type: 3 PointerType *net/http.Request
+          Type: 37 PointerType *net/http.Request
           Locations:
             - Range: 0x8ad860..0x8ad8c4
               Pieces: [{Size: 8, Op: {RegNo: 2, Shift: 0}}]
@@ -65,7 +65,7 @@ Subprograms:
           IsParameter: true
           IsReturn: false
         - Name: '&buf'
-          Type: 126 PointerType *bytes.Buffer
+          Type: 148 PointerType *bytes.Buffer
           Locations:
             - Range: 0x8ad9b4..0x8ad9d0
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
@@ -74,7 +74,7 @@ Subprograms:
           IsParameter: false
           IsReturn: false
         - Name: span
-          Type: 129 GoInterfaceType gopkg.in/DataDog/dd-trace-go.v1/ddtrace.Span
+          Type: 151 GoInterfaceType gopkg.in/DataDog/dd-trace-go.v1/ddtrace.Span
           Locations:
             - Range: 0x8ad8d8..0x8ad8d8
               Pieces:
@@ -97,7 +97,7 @@ Subprograms:
           IsParameter: false
           IsReturn: false
         - Name: .autotmp_14
-          Type: 130 StructureType context.backgroundCtx
+          Type: 152 StructureType context.backgroundCtx
           Locations:
             - Range: 0x8ad860..0x8adab0
               Pieces: [{Size: 0, Op: {CfaOffset: 0}}]
@@ -109,7 +109,7 @@ Subprograms:
       InlinePCRanges: []
       Variables:
         - Name: path
-          Type: 5 GoStringHeaderType string
+          Type: 11 GoStringHeaderType string
           Locations:
             - Range: 0x8adb90..0x8adbb4
               Pieces:
@@ -121,38 +121,38 @@ Subprograms:
           IsReturn: false
 Types:
     - __kind: PointerType
-      ID: 56
+      ID: 80
       Name: '**crypto/x509.Certificate'
       ByteSize: 8
-      Pointee: 57 PointerType *crypto/x509.Certificate
+      Pointee: 81 PointerType *crypto/x509.Certificate
     - __kind: PointerType
-      ID: 48
+      ID: 72
       Name: '**mime/multipart.FileHeader'
       ByteSize: 8
       GoKind: 22
-      Pointee: 49 PointerType *mime/multipart.FileHeader
+      Pointee: 73 PointerType *mime/multipart.FileHeader
     - __kind: PointerType
-      ID: 98
+      ID: 120
       Name: '**net.IPNet'
       ByteSize: 8
       GoKind: 22
-      Pointee: 99 PointerType *net.IPNet
+      Pointee: 121 PointerType *net.IPNet
     - __kind: PointerType
-      ID: 96
+      ID: 118
       Name: '**net/url.URL'
       ByteSize: 8
-      Pointee: 9 PointerType *net/url.URL
+      Pointee: 39 PointerType *net/url.URL
     - __kind: PointerType
-      ID: 31
+      ID: 56
       Name: '**runtime.bmap'
       ByteSize: 8
-      Pointee: 32 PointerType *runtime.bmap
+      Pointee: 57 PointerType *runtime.bmap
     - __kind: PointerType
-      ID: 106
+      ID: 128
       Name: '*[]*crypto/x509.Certificate'
       ByteSize: 8
       GoKind: 22
-      Pointee: 55 GoSliceHeaderType []*crypto/x509.Certificate
+      Pointee: 79 GoSliceHeaderType []*crypto/x509.Certificate
     - __kind: PointerType
       ID: 167
       Name: '*[]*crypto/x509.Certificate.array'
@@ -174,12 +174,12 @@ Types:
       ByteSize: 8
       Pointee: 188 GoSliceDataType []*net/url.URL.array
     - __kind: PointerType
-      ID: 29
+      ID: 54
       Name: '*[]*runtime.bmap'
       ByteSize: 8
       GoRuntimeType: 466496
       GoKind: 22
-      Pointee: 30 GoSliceHeaderType []*runtime.bmap
+      Pointee: 55 GoSliceHeaderType []*runtime.bmap
     - __kind: PointerType
       ID: 160
       Name: '*[]*runtime.bmap.array'
@@ -246,211 +246,211 @@ Types:
       ByteSize: 8
       Pointee: 176 GoSliceDataType []time.zoneTrans.array
     - __kind: PointerType
-      ID: 108
+      ID: 130
       Name: '*[]uint8'
       ByteSize: 8
       GoRuntimeType: 452640
       GoKind: 22
-      Pointee: 52 GoSliceHeaderType []uint8
+      Pointee: 76 GoSliceHeaderType []uint8
     - __kind: PointerType
       ID: 165
       Name: '*[]uint8.array'
       ByteSize: 8
       Pointee: 164 GoSliceDataType []uint8.array
     - __kind: PointerType
-      ID: 132
+      ID: 5
       Name: '*bool'
       ByteSize: 8
       GoRuntimeType: 372704
       GoKind: 22
-      Pointee: 13 BaseType bool
+      Pointee: 4 BaseType bool
     - __kind: PointerType
-      ID: 44
+      ID: 68
       Name: '*bucket<string,[]*mime/multipart.FileHeader>'
       ByteSize: 8
-      Pointee: 45 GoHMapBucketType bucket<string,[]*mime/multipart.FileHeader>
+      Pointee: 69 GoHMapBucketType bucket<string,[]*mime/multipart.FileHeader>
     - __kind: PointerType
-      ID: 19
+      ID: 46
       Name: '*bucket<string,[]string>'
       ByteSize: 8
-      Pointee: 20 GoHMapBucketType bucket<string,[]string>
+      Pointee: 47 GoHMapBucketType bucket<string,[]string>
     - __kind: PointerType
-      ID: 123
+      ID: 145
       Name: '*bucket<string,string>'
       ByteSize: 8
-      Pointee: 124 GoHMapBucketType bucket<string,string>
+      Pointee: 146 GoHMapBucketType bucket<string,string>
     - __kind: PointerType
-      ID: 126
+      ID: 148
       Name: '*bytes.Buffer'
       ByteSize: 8
       GoRuntimeType: 2.11552e+06
       GoKind: 22
-      Pointee: 127 StructureType bytes.Buffer
+      Pointee: 149 StructureType bytes.Buffer
     - __kind: PointerType
-      ID: 53
+      ID: 77
       Name: '*crypto/tls.ConnectionState'
       ByteSize: 8
       GoRuntimeType: 836032
       GoKind: 22
-      Pointee: 54 StructureType crypto/tls.ConnectionState
+      Pointee: 78 StructureType crypto/tls.ConnectionState
     - __kind: PointerType
-      ID: 57
+      ID: 81
       Name: '*crypto/x509.Certificate'
       ByteSize: 8
       GoRuntimeType: 1.905824e+06
       GoKind: 22
-      Pointee: 58 StructureType crypto/x509.Certificate
+      Pointee: 82 StructureType crypto/x509.Certificate
     - __kind: PointerType
-      ID: 90
+      ID: 112
       Name: '*crypto/x509.ExtKeyUsage'
       ByteSize: 8
       GoRuntimeType: 395104
       GoKind: 22
-      Pointee: 91 BaseType crypto/x509.ExtKeyUsage
+      Pointee: 113 BaseType crypto/x509.ExtKeyUsage
     - __kind: PointerType
-      ID: 103
+      ID: 125
       Name: '*crypto/x509.OID'
       ByteSize: 8
       GoRuntimeType: 1.717792e+06
       GoKind: 22
-      Pointee: 104 StructureType crypto/x509.OID
+      Pointee: 126 StructureType crypto/x509.OID
     - __kind: PointerType
-      ID: 69
+      ID: 93
       Name: '*crypto/x509/pkix.AttributeTypeAndValue'
       ByteSize: 8
       GoRuntimeType: 408928
       GoKind: 22
-      Pointee: 70 StructureType crypto/x509/pkix.AttributeTypeAndValue
+      Pointee: 94 StructureType crypto/x509/pkix.AttributeTypeAndValue
     - __kind: PointerType
-      ID: 85
+      ID: 107
       Name: '*crypto/x509/pkix.Extension'
       ByteSize: 8
       GoRuntimeType: 409120
       GoKind: 22
-      Pointee: 86 StructureType crypto/x509/pkix.Extension
+      Pointee: 108 StructureType crypto/x509/pkix.Extension
     - __kind: PointerType
-      ID: 88
+      ID: 110
       Name: '*encoding/asn1.ObjectIdentifier'
       ByteSize: 8
       GoRuntimeType: 1.00992e+06
       GoKind: 22
-      Pointee: 71 GoSliceHeaderType encoding/asn1.ObjectIdentifier
+      Pointee: 95 GoSliceHeaderType encoding/asn1.ObjectIdentifier
     - __kind: PointerType
       ID: 173
       Name: '*encoding/asn1.ObjectIdentifier.array'
       ByteSize: 8
       Pointee: 172 GoSliceDataType encoding/asn1.ObjectIdentifier.array
     - __kind: PointerType
-      ID: 151
+      ID: 33
       Name: '*error'
       ByteSize: 8
       GoRuntimeType: 371616
       GoKind: 22
-      Pointee: 139 GoInterfaceType error
+      Pointee: 18 GoInterfaceType error
     - __kind: PointerType
-      ID: 153
+      ID: 35
       Name: '*float32'
       ByteSize: 8
       GoRuntimeType: 372576
       GoKind: 22
-      Pointee: 137 BaseType float32
+      Pointee: 16 BaseType float32
     - __kind: PointerType
-      ID: 145
+      ID: 26
       Name: '*float64'
       ByteSize: 8
       GoRuntimeType: 372640
       GoKind: 22
-      Pointee: 138 BaseType float64
+      Pointee: 17 BaseType float64
     - __kind: PointerType
-      ID: 42
+      ID: 66
       Name: '*hash<string,[]*mime/multipart.FileHeader>'
       ByteSize: 8
-      Pointee: 43 GoHMapHeaderType hash<string,[]*mime/multipart.FileHeader>
+      Pointee: 67 GoHMapHeaderType hash<string,[]*mime/multipart.FileHeader>
     - __kind: PointerType
-      ID: 15
+      ID: 44
       Name: '*hash<string,[]string>'
       ByteSize: 8
-      Pointee: 16 GoHMapHeaderType hash<string,[]string>
+      Pointee: 45 GoHMapHeaderType hash<string,[]string>
     - __kind: PointerType
-      ID: 121
+      ID: 143
       Name: '*hash<string,string>'
       ByteSize: 8
-      Pointee: 122 GoHMapHeaderType hash<string,string>
+      Pointee: 144 GoHMapHeaderType hash<string,string>
     - __kind: PointerType
-      ID: 72
+      ID: 28
       Name: '*int'
       ByteSize: 8
       GoRuntimeType: 372256
       GoKind: 22
-      Pointee: 8 BaseType int
+      Pointee: 9 BaseType int
     - __kind: PointerType
-      ID: 149
+      ID: 31
       Name: '*int16'
       ByteSize: 8
       GoRuntimeType: 371872
       GoKind: 22
-      Pointee: 142 BaseType int16
+      Pointee: 23 BaseType int16
     - __kind: PointerType
-      ID: 140
+      ID: 20
       Name: '*int32'
       ByteSize: 8
       GoRuntimeType: 372000
       GoKind: 22
-      Pointee: 135 BaseType int32
+      Pointee: 13 BaseType int32
     - __kind: PointerType
-      ID: 146
+      ID: 27
       Name: '*int64'
       ByteSize: 8
       GoRuntimeType: 372128
       GoKind: 22
-      Pointee: 36 BaseType int64
+      Pointee: 14 BaseType int64
     - __kind: PointerType
-      ID: 150
+      ID: 32
       Name: '*int8'
       ByteSize: 8
       GoRuntimeType: 371744
       GoKind: 22
-      Pointee: 136 BaseType int8
+      Pointee: 15 BaseType int8
     - __kind: PointerType
-      ID: 62
+      ID: 86
       Name: '*math/big.Int'
       ByteSize: 8
       GoRuntimeType: 2.231648e+06
       GoKind: 22
-      Pointee: 63 StructureType math/big.Int
+      Pointee: 87 StructureType math/big.Int
     - __kind: PointerType
-      ID: 65
+      ID: 89
       Name: '*math/big.Word'
       ByteSize: 8
       GoRuntimeType: 397920
       GoKind: 22
-      Pointee: 66 BaseType math/big.Word
+      Pointee: 90 BaseType math/big.Word
     - __kind: PointerType
       ID: 169
       Name: '*math/big.nat.array'
       ByteSize: 8
       Pointee: 168 GoSliceDataType math/big.nat.array
     - __kind: PointerType
-      ID: 49
+      ID: 73
       Name: '*mime/multipart.FileHeader'
       ByteSize: 8
       GoRuntimeType: 837472
       GoKind: 22
-      Pointee: 50 StructureType mime/multipart.FileHeader
+      Pointee: 74 StructureType mime/multipart.FileHeader
     - __kind: PointerType
-      ID: 38
+      ID: 62
       Name: '*mime/multipart.Form'
       ByteSize: 8
       GoRuntimeType: 837568
       GoKind: 22
-      Pointee: 39 StructureType mime/multipart.Form
+      Pointee: 63 StructureType mime/multipart.Form
     - __kind: PointerType
-      ID: 93
+      ID: 115
       Name: '*net.IP'
       ByteSize: 8
       GoRuntimeType: 1.974688e+06
       GoKind: 22
-      Pointee: 94 GoSliceHeaderType net.IP
+      Pointee: 116 GoSliceHeaderType net.IP
     - __kind: PointerType
       ID: 187
       Name: '*net.IP.array'
@@ -462,145 +462,145 @@ Types:
       ByteSize: 8
       Pointee: 192 GoSliceDataType net.IPMask.array
     - __kind: PointerType
-      ID: 99
+      ID: 121
       Name: '*net.IPNet'
       ByteSize: 8
       GoRuntimeType: 1.095968e+06
       GoKind: 22
-      Pointee: 100 StructureType net.IPNet
+      Pointee: 122 StructureType net.IPNet
     - __kind: PointerType
-      ID: 3
+      ID: 37
       Name: '*net/http.Request'
       ByteSize: 8
       GoRuntimeType: 2.15472e+06
       GoKind: 22
-      Pointee: 4 StructureType net/http.Request
+      Pointee: 38 StructureType net/http.Request
     - __kind: PointerType
-      ID: 112
+      ID: 134
       Name: '*net/http.Response'
       ByteSize: 8
       GoRuntimeType: 1.591456e+06
       GoKind: 22
-      Pointee: 113 StructureType net/http.Response
+      Pointee: 135 StructureType net/http.Response
     - __kind: PointerType
-      ID: 115
+      ID: 137
       Name: '*net/http.pattern'
       ByteSize: 8
       GoRuntimeType: 1.416576e+06
       GoKind: 22
-      Pointee: 116 StructureType net/http.pattern
+      Pointee: 138 StructureType net/http.pattern
     - __kind: PointerType
-      ID: 118
+      ID: 140
       Name: '*net/http.segment'
       ByteSize: 8
       GoRuntimeType: 364064
       GoKind: 22
-      Pointee: 119 StructureType net/http.segment
+      Pointee: 141 StructureType net/http.segment
     - __kind: PointerType
-      ID: 9
+      ID: 39
       Name: '*net/url.URL'
       ByteSize: 8
       GoRuntimeType: 1.94976e+06
       GoKind: 22
-      Pointee: 10 StructureType net/url.URL
+      Pointee: 40 StructureType net/url.URL
     - __kind: PointerType
-      ID: 11
+      ID: 41
       Name: '*net/url.Userinfo'
       ByteSize: 8
       GoRuntimeType: 1.1144e+06
       GoKind: 22
-      Pointee: 12 StructureType net/url.Userinfo
+      Pointee: 42 StructureType net/url.Userinfo
     - __kind: PointerType
-      ID: 32
+      ID: 57
       Name: '*runtime.bmap'
       ByteSize: 8
       GoRuntimeType: 1.110048e+06
       GoKind: 22
-      Pointee: 33 StructureType runtime.bmap
+      Pointee: 58 StructureType runtime.bmap
     - __kind: PointerType
-      ID: 27
+      ID: 52
       Name: '*runtime.mapextra'
       ByteSize: 8
       GoRuntimeType: 375584
       GoKind: 22
-      Pointee: 28 StructureType runtime.mapextra
+      Pointee: 53 StructureType runtime.mapextra
     - __kind: PointerType
-      ID: 25
+      ID: 22
       Name: '*string'
       ByteSize: 8
       GoRuntimeType: 371680
       GoKind: 22
-      Pointee: 5 GoStringHeaderType string
+      Pointee: 11 GoStringHeaderType string
     - __kind: PointerType
       ID: 155
       Name: '*string.str'
       ByteSize: 8
       Pointee: 154 GoStringDataType string.str
     - __kind: PointerType
-      ID: 75
+      ID: 97
       Name: '*time.Location'
       ByteSize: 8
       GoRuntimeType: 1.421568e+06
       GoKind: 22
-      Pointee: 76 StructureType time.Location
+      Pointee: 98 StructureType time.Location
     - __kind: PointerType
-      ID: 78
+      ID: 100
       Name: '*time.zone'
       ByteSize: 8
       GoRuntimeType: 367136
       GoKind: 22
-      Pointee: 79 StructureType time.zone
+      Pointee: 101 StructureType time.zone
     - __kind: PointerType
-      ID: 81
+      ID: 103
       Name: '*time.zoneTrans'
       ByteSize: 8
       GoRuntimeType: 367200
       GoKind: 22
-      Pointee: 82 StructureType time.zoneTrans
+      Pointee: 104 StructureType time.zoneTrans
     - __kind: PointerType
-      ID: 152
+      ID: 34
       Name: '*uint'
       ByteSize: 8
       GoRuntimeType: 372320
       GoKind: 22
-      Pointee: 134 BaseType uint
+      Pointee: 12 BaseType uint
     - __kind: PointerType
-      ID: 148
+      ID: 30
       Name: '*uint16'
       ByteSize: 8
       GoRuntimeType: 371936
       GoKind: 22
-      Pointee: 17 BaseType uint16
+      Pointee: 7 BaseType uint16
     - __kind: PointerType
-      ID: 141
+      ID: 21
       Name: '*uint32'
       ByteSize: 8
       GoRuntimeType: 372064
       GoKind: 22
-      Pointee: 18 BaseType uint32
+      Pointee: 2 BaseType uint32
     - __kind: PointerType
-      ID: 147
+      ID: 29
       Name: '*uint64'
       ByteSize: 8
       GoRuntimeType: 372192
       GoKind: 22
-      Pointee: 74 BaseType uint64
+      Pointee: 10 BaseType uint64
     - __kind: PointerType
       ID: 6
       Name: '*uint8'
       ByteSize: 8
       GoRuntimeType: 371808
       GoKind: 22
-      Pointee: 7 BaseType uint8
+      Pointee: 3 BaseType uint8
     - __kind: PointerType
-      ID: 133
+      ID: 8
       Name: '*uintptr'
       ByteSize: 8
       GoRuntimeType: 372384
       GoKind: 22
-      Pointee: 26 BaseType uintptr
+      Pointee: 1 BaseType uintptr
     - __kind: GoChannelType
-      ID: 111
+      ID: 133
       Name: <-chan struct {}
       GoRuntimeType: 546944
       GoKind: 18
@@ -613,7 +613,7 @@ Types:
         - Name: w
           Offset: 1
           Expression:
-            Type: 1 GoInterfaceType net/http.ResponseWriter
+            Type: 36 GoInterfaceType net/http.ResponseWriter
             Operations:
                 - __kind: LocationOp
                   Variable: {subprogram: 1, index: 0, name: w}
@@ -622,7 +622,7 @@ Types:
         - Name: r
           Offset: 17
           Expression:
-            Type: 3 PointerType *net/http.Request
+            Type: 37 PointerType *net/http.Request
             Operations:
                 - __kind: LocationOp
                   Variable: {subprogram: 1, index: 1, name: r}
@@ -637,23 +637,23 @@ Types:
         - Name: path
           Offset: 1
           Expression:
-            Type: 5 GoStringHeaderType string
+            Type: 11 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
                   Variable: {subprogram: 2, index: 0, name: path}
                   Offset: 0
                   ByteSize: 16
     - __kind: ArrayType
-      ID: 21
+      ID: 48
       Name: '[8]uint8'
       ByteSize: 8
       GoRuntimeType: 621920
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 7 BaseType uint8
+      Element: 3 BaseType uint8
     - __kind: GoSliceHeaderType
-      ID: 55
+      ID: 79
       Name: '[]*crypto/x509.Certificate'
       ByteSize: 24
       GoRuntimeType: 469664
@@ -661,21 +661,21 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 56 PointerType **crypto/x509.Certificate
+          Type: 80 PointerType **crypto/x509.Certificate
         - Name: len
           Offset: 8
-          Type: 8 BaseType int
+          Type: 9 BaseType int
         - Name: cap
           Offset: 16
-          Type: 8 BaseType int
+          Type: 9 BaseType int
       Data: 166 GoSliceDataType []*crypto/x509.Certificate.array
     - __kind: GoSliceDataType
       ID: 166
       Name: '[]*crypto/x509.Certificate.array'
       ByteSize: 2048
-      Element: 57 PointerType *crypto/x509.Certificate
+      Element: 81 PointerType *crypto/x509.Certificate
     - __kind: GoSliceHeaderType
-      ID: 47
+      ID: 71
       Name: '[]*mime/multipart.FileHeader'
       ByteSize: 24
       GoRuntimeType: 457504
@@ -683,21 +683,21 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 48 PointerType **mime/multipart.FileHeader
+          Type: 72 PointerType **mime/multipart.FileHeader
         - Name: len
           Offset: 8
-          Type: 8 BaseType int
+          Type: 9 BaseType int
         - Name: cap
           Offset: 16
-          Type: 8 BaseType int
+          Type: 9 BaseType int
       Data: 162 GoSliceDataType []*mime/multipart.FileHeader.array
     - __kind: GoSliceDataType
       ID: 162
       Name: '[]*mime/multipart.FileHeader.array'
       ByteSize: 2048
-      Element: 49 PointerType *mime/multipart.FileHeader
+      Element: 73 PointerType *mime/multipart.FileHeader
     - __kind: GoSliceHeaderType
-      ID: 97
+      ID: 119
       Name: '[]*net.IPNet'
       ByteSize: 24
       GoRuntimeType: 481696
@@ -705,21 +705,21 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 98 PointerType **net.IPNet
+          Type: 120 PointerType **net.IPNet
         - Name: len
           Offset: 8
-          Type: 8 BaseType int
+          Type: 9 BaseType int
         - Name: cap
           Offset: 16
-          Type: 8 BaseType int
+          Type: 9 BaseType int
       Data: 190 GoSliceDataType []*net.IPNet.array
     - __kind: GoSliceDataType
       ID: 190
       Name: '[]*net.IPNet.array'
       ByteSize: 2048
-      Element: 99 PointerType *net.IPNet
+      Element: 121 PointerType *net.IPNet
     - __kind: GoSliceHeaderType
-      ID: 95
+      ID: 117
       Name: '[]*net/url.URL'
       ByteSize: 24
       GoRuntimeType: 481632
@@ -727,21 +727,21 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 96 PointerType **net/url.URL
+          Type: 118 PointerType **net/url.URL
         - Name: len
           Offset: 8
-          Type: 8 BaseType int
+          Type: 9 BaseType int
         - Name: cap
           Offset: 16
-          Type: 8 BaseType int
+          Type: 9 BaseType int
       Data: 188 GoSliceDataType []*net/url.URL.array
     - __kind: GoSliceDataType
       ID: 188
       Name: '[]*net/url.URL.array'
       ByteSize: 2048
-      Element: 9 PointerType *net/url.URL
+      Element: 39 PointerType *net/url.URL
     - __kind: GoSliceHeaderType
-      ID: 30
+      ID: 55
       Name: '[]*runtime.bmap'
       ByteSize: 24
       GoRuntimeType: 466432
@@ -749,21 +749,21 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 31 PointerType **runtime.bmap
+          Type: 56 PointerType **runtime.bmap
         - Name: len
           Offset: 8
-          Type: 8 BaseType int
+          Type: 9 BaseType int
         - Name: cap
           Offset: 16
-          Type: 8 BaseType int
+          Type: 9 BaseType int
       Data: 159 GoSliceDataType []*runtime.bmap.array
     - __kind: GoSliceDataType
       ID: 159
       Name: '[]*runtime.bmap.array'
       ByteSize: 2048
-      Element: 32 PointerType *runtime.bmap
+      Element: 57 PointerType *runtime.bmap
     - __kind: GoSliceHeaderType
-      ID: 105
+      ID: 127
       Name: '[][]*crypto/x509.Certificate'
       ByteSize: 24
       GoRuntimeType: 469792
@@ -771,21 +771,21 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 106 PointerType *[]*crypto/x509.Certificate
+          Type: 128 PointerType *[]*crypto/x509.Certificate
         - Name: len
           Offset: 8
-          Type: 8 BaseType int
+          Type: 9 BaseType int
         - Name: cap
           Offset: 16
-          Type: 8 BaseType int
+          Type: 9 BaseType int
       Data: 196 GoSliceDataType [][]*crypto/x509.Certificate.array
     - __kind: GoSliceDataType
       ID: 196
       Name: '[][]*crypto/x509.Certificate.array'
       ByteSize: 2048
-      Element: 55 GoSliceHeaderType []*crypto/x509.Certificate
+      Element: 79 GoSliceHeaderType []*crypto/x509.Certificate
     - __kind: GoSliceHeaderType
-      ID: 107
+      ID: 129
       Name: '[][]uint8'
       ByteSize: 24
       GoRuntimeType: 452960
@@ -793,36 +793,36 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 108 PointerType *[]uint8
+          Type: 130 PointerType *[]uint8
         - Name: len
           Offset: 8
-          Type: 8 BaseType int
+          Type: 9 BaseType int
         - Name: cap
           Offset: 16
-          Type: 8 BaseType int
+          Type: 9 BaseType int
       Data: 198 GoSliceDataType [][]uint8.array
     - __kind: GoSliceDataType
       ID: 198
       Name: '[][]uint8.array'
       ByteSize: 2048
-      Element: 52 GoSliceHeaderType []uint8
+      Element: 76 GoSliceHeaderType []uint8
     - __kind: GoSliceDataType
       ID: 161
       Name: '[]bucket<string,[]*mime/multipart.FileHeader>.array'
       ByteSize: 2048
-      Element: 45 GoHMapBucketType bucket<string,[]*mime/multipart.FileHeader>
+      Element: 69 GoHMapBucketType bucket<string,[]*mime/multipart.FileHeader>
     - __kind: GoSliceDataType
       ID: 156
       Name: '[]bucket<string,[]string>.array'
       ByteSize: 2048
-      Element: 20 GoHMapBucketType bucket<string,[]string>
+      Element: 47 GoHMapBucketType bucket<string,[]string>
     - __kind: GoSliceDataType
       ID: 202
       Name: '[]bucket<string,string>.array'
       ByteSize: 2048
-      Element: 124 GoHMapBucketType bucket<string,string>
+      Element: 146 GoHMapBucketType bucket<string,string>
     - __kind: GoSliceHeaderType
-      ID: 89
+      ID: 111
       Name: '[]crypto/x509.ExtKeyUsage'
       ByteSize: 24
       GoRuntimeType: 470944
@@ -830,21 +830,21 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 90 PointerType *crypto/x509.ExtKeyUsage
+          Type: 112 PointerType *crypto/x509.ExtKeyUsage
         - Name: len
           Offset: 8
-          Type: 8 BaseType int
+          Type: 9 BaseType int
         - Name: cap
           Offset: 16
-          Type: 8 BaseType int
+          Type: 9 BaseType int
       Data: 182 GoSliceDataType []crypto/x509.ExtKeyUsage.array
     - __kind: GoSliceDataType
       ID: 182
       Name: '[]crypto/x509.ExtKeyUsage.array'
       ByteSize: 2048
-      Element: 91 BaseType crypto/x509.ExtKeyUsage
+      Element: 113 BaseType crypto/x509.ExtKeyUsage
     - __kind: GoSliceHeaderType
-      ID: 102
+      ID: 124
       Name: '[]crypto/x509.OID'
       ByteSize: 24
       GoRuntimeType: 481760
@@ -852,21 +852,21 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 103 PointerType *crypto/x509.OID
+          Type: 125 PointerType *crypto/x509.OID
         - Name: len
           Offset: 8
-          Type: 8 BaseType int
+          Type: 9 BaseType int
         - Name: cap
           Offset: 16
-          Type: 8 BaseType int
+          Type: 9 BaseType int
       Data: 194 GoSliceDataType []crypto/x509.OID.array
     - __kind: GoSliceDataType
       ID: 194
       Name: '[]crypto/x509.OID.array'
       ByteSize: 2048
-      Element: 104 StructureType crypto/x509.OID
+      Element: 126 StructureType crypto/x509.OID
     - __kind: GoSliceHeaderType
-      ID: 68
+      ID: 92
       Name: '[]crypto/x509/pkix.AttributeTypeAndValue'
       ByteSize: 24
       GoRuntimeType: 482016
@@ -874,21 +874,21 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 69 PointerType *crypto/x509/pkix.AttributeTypeAndValue
+          Type: 93 PointerType *crypto/x509/pkix.AttributeTypeAndValue
         - Name: len
           Offset: 8
-          Type: 8 BaseType int
+          Type: 9 BaseType int
         - Name: cap
           Offset: 16
-          Type: 8 BaseType int
+          Type: 9 BaseType int
       Data: 170 GoSliceDataType []crypto/x509/pkix.AttributeTypeAndValue.array
     - __kind: GoSliceDataType
       ID: 170
       Name: '[]crypto/x509/pkix.AttributeTypeAndValue.array'
       ByteSize: 2048
-      Element: 70 StructureType crypto/x509/pkix.AttributeTypeAndValue
+      Element: 94 StructureType crypto/x509/pkix.AttributeTypeAndValue
     - __kind: GoSliceHeaderType
-      ID: 84
+      ID: 106
       Name: '[]crypto/x509/pkix.Extension'
       ByteSize: 24
       GoRuntimeType: 481504
@@ -896,21 +896,21 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 85 PointerType *crypto/x509/pkix.Extension
+          Type: 107 PointerType *crypto/x509/pkix.Extension
         - Name: len
           Offset: 8
-          Type: 8 BaseType int
+          Type: 9 BaseType int
         - Name: cap
           Offset: 16
-          Type: 8 BaseType int
+          Type: 9 BaseType int
       Data: 178 GoSliceDataType []crypto/x509/pkix.Extension.array
     - __kind: GoSliceDataType
       ID: 178
       Name: '[]crypto/x509/pkix.Extension.array'
       ByteSize: 2048
-      Element: 86 StructureType crypto/x509/pkix.Extension
+      Element: 108 StructureType crypto/x509/pkix.Extension
     - __kind: GoSliceHeaderType
-      ID: 87
+      ID: 109
       Name: '[]encoding/asn1.ObjectIdentifier'
       ByteSize: 24
       GoRuntimeType: 481568
@@ -918,28 +918,28 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 88 PointerType *encoding/asn1.ObjectIdentifier
+          Type: 110 PointerType *encoding/asn1.ObjectIdentifier
         - Name: len
           Offset: 8
-          Type: 8 BaseType int
+          Type: 9 BaseType int
         - Name: cap
           Offset: 16
-          Type: 8 BaseType int
+          Type: 9 BaseType int
       Data: 180 GoSliceDataType []encoding/asn1.ObjectIdentifier.array
     - __kind: GoSliceDataType
       ID: 180
       Name: '[]encoding/asn1.ObjectIdentifier.array'
       ByteSize: 2048
-      Element: 71 GoSliceHeaderType encoding/asn1.ObjectIdentifier
+      Element: 95 GoSliceHeaderType encoding/asn1.ObjectIdentifier
     - __kind: ArrayType
-      ID: 22
+      ID: 49
       Name: '[]key<string>'
       ByteSize: 128
       Count: 8
       HasCount: true
-      Element: 5 GoStringHeaderType string
+      Element: 11 GoStringHeaderType string
     - __kind: GoSliceHeaderType
-      ID: 92
+      ID: 114
       Name: '[]net.IP'
       ByteSize: 24
       GoRuntimeType: 454176
@@ -947,21 +947,21 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 93 PointerType *net.IP
+          Type: 115 PointerType *net.IP
         - Name: len
           Offset: 8
-          Type: 8 BaseType int
+          Type: 9 BaseType int
         - Name: cap
           Offset: 16
-          Type: 8 BaseType int
+          Type: 9 BaseType int
       Data: 184 GoSliceDataType []net.IP.array
     - __kind: GoSliceDataType
       ID: 184
       Name: '[]net.IP.array'
       ByteSize: 2048
-      Element: 94 GoSliceHeaderType net.IP
+      Element: 116 GoSliceHeaderType net.IP
     - __kind: GoSliceHeaderType
-      ID: 117
+      ID: 139
       Name: '[]net/http.segment'
       ByteSize: 24
       GoRuntimeType: 454944
@@ -969,21 +969,21 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 118 PointerType *net/http.segment
+          Type: 140 PointerType *net/http.segment
         - Name: len
           Offset: 8
-          Type: 8 BaseType int
+          Type: 9 BaseType int
         - Name: cap
           Offset: 16
-          Type: 8 BaseType int
+          Type: 9 BaseType int
       Data: 200 GoSliceDataType []net/http.segment.array
     - __kind: GoSliceDataType
       ID: 200
       Name: '[]net/http.segment.array'
       ByteSize: 2048
-      Element: 119 StructureType net/http.segment
+      Element: 141 StructureType net/http.segment
     - __kind: GoSliceHeaderType
-      ID: 24
+      ID: 51
       Name: '[]string'
       ByteSize: 24
       GoRuntimeType: 464768
@@ -991,21 +991,21 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 25 PointerType *string
+          Type: 22 PointerType *string
         - Name: len
           Offset: 8
-          Type: 8 BaseType int
+          Type: 9 BaseType int
         - Name: cap
           Offset: 16
-          Type: 8 BaseType int
+          Type: 9 BaseType int
       Data: 157 GoSliceDataType []string.array
     - __kind: GoSliceDataType
       ID: 157
       Name: '[]string.array'
       ByteSize: 2048
-      Element: 5 GoStringHeaderType string
+      Element: 11 GoStringHeaderType string
     - __kind: GoSliceHeaderType
-      ID: 77
+      ID: 99
       Name: '[]time.zone'
       ByteSize: 24
       GoRuntimeType: 459168
@@ -1013,21 +1013,21 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 78 PointerType *time.zone
+          Type: 100 PointerType *time.zone
         - Name: len
           Offset: 8
-          Type: 8 BaseType int
+          Type: 9 BaseType int
         - Name: cap
           Offset: 16
-          Type: 8 BaseType int
+          Type: 9 BaseType int
       Data: 174 GoSliceDataType []time.zone.array
     - __kind: GoSliceDataType
       ID: 174
       Name: '[]time.zone.array'
       ByteSize: 2048
-      Element: 79 StructureType time.zone
+      Element: 101 StructureType time.zone
     - __kind: GoSliceHeaderType
-      ID: 80
+      ID: 102
       Name: '[]time.zoneTrans'
       ByteSize: 24
       GoRuntimeType: 459232
@@ -1035,21 +1035,21 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 81 PointerType *time.zoneTrans
+          Type: 103 PointerType *time.zoneTrans
         - Name: len
           Offset: 8
-          Type: 8 BaseType int
+          Type: 9 BaseType int
         - Name: cap
           Offset: 16
-          Type: 8 BaseType int
+          Type: 9 BaseType int
       Data: 176 GoSliceDataType []time.zoneTrans.array
     - __kind: GoSliceDataType
       ID: 176
       Name: '[]time.zoneTrans.array'
       ByteSize: 2048
-      Element: 82 StructureType time.zoneTrans
+      Element: 104 StructureType time.zoneTrans
     - __kind: GoSliceHeaderType
-      ID: 52
+      ID: 76
       Name: '[]uint8'
       ByteSize: 24
       GoRuntimeType: 463616
@@ -1060,102 +1060,102 @@ Types:
           Type: 6 PointerType *uint8
         - Name: len
           Offset: 8
-          Type: 8 BaseType int
+          Type: 9 BaseType int
         - Name: cap
           Offset: 16
-          Type: 8 BaseType int
+          Type: 9 BaseType int
       Data: 164 GoSliceDataType []uint8.array
     - __kind: GoSliceDataType
       ID: 164
       Name: '[]uint8.array'
       ByteSize: 2048
-      Element: 7 BaseType uint8
+      Element: 3 BaseType uint8
     - __kind: ArrayType
-      ID: 46
+      ID: 70
       Name: '[]val<[]*mime/multipart.FileHeader>'
       ByteSize: 192
       Count: 8
       HasCount: true
-      Element: 47 GoSliceHeaderType []*mime/multipart.FileHeader
+      Element: 71 GoSliceHeaderType []*mime/multipart.FileHeader
     - __kind: ArrayType
-      ID: 23
+      ID: 50
       Name: '[]val<[]string>'
       ByteSize: 192
       Count: 8
       HasCount: true
-      Element: 24 GoSliceHeaderType []string
+      Element: 51 GoSliceHeaderType []string
     - __kind: ArrayType
-      ID: 125
+      ID: 147
       Name: '[]val<string>'
       ByteSize: 128
       Count: 8
       HasCount: true
-      Element: 5 GoStringHeaderType string
+      Element: 11 GoStringHeaderType string
     - __kind: BaseType
-      ID: 13
+      ID: 4
       Name: bool
       ByteSize: 1
       GoRuntimeType: 534784
       GoKind: 1
     - __kind: GoHMapBucketType
-      ID: 45
+      ID: 69
       Name: bucket<string,[]*mime/multipart.FileHeader>
       ByteSize: 336
       RawFields:
         - Name: tophash
           Offset: 0
-          Type: 21 ArrayType [8]uint8
+          Type: 48 ArrayType [8]uint8
         - Name: keys
           Offset: 8
-          Type: 22 ArrayType []key<string>
+          Type: 49 ArrayType []key<string>
         - Name: values
           Offset: 136
-          Type: 46 ArrayType []val<[]*mime/multipart.FileHeader>
+          Type: 70 ArrayType []val<[]*mime/multipart.FileHeader>
         - Name: overflow
           Offset: 328
-          Type: 44 PointerType *bucket<string,[]*mime/multipart.FileHeader>
-      KeyType: 5 GoStringHeaderType string
-      ValueType: 47 GoSliceHeaderType []*mime/multipart.FileHeader
+          Type: 68 PointerType *bucket<string,[]*mime/multipart.FileHeader>
+      KeyType: 11 GoStringHeaderType string
+      ValueType: 71 GoSliceHeaderType []*mime/multipart.FileHeader
     - __kind: GoHMapBucketType
-      ID: 20
+      ID: 47
       Name: bucket<string,[]string>
       ByteSize: 336
       RawFields:
         - Name: tophash
           Offset: 0
-          Type: 21 ArrayType [8]uint8
+          Type: 48 ArrayType [8]uint8
         - Name: keys
           Offset: 8
-          Type: 22 ArrayType []key<string>
+          Type: 49 ArrayType []key<string>
         - Name: values
           Offset: 136
-          Type: 23 ArrayType []val<[]string>
+          Type: 50 ArrayType []val<[]string>
         - Name: overflow
           Offset: 328
-          Type: 19 PointerType *bucket<string,[]string>
-      KeyType: 5 GoStringHeaderType string
-      ValueType: 24 GoSliceHeaderType []string
+          Type: 46 PointerType *bucket<string,[]string>
+      KeyType: 11 GoStringHeaderType string
+      ValueType: 51 GoSliceHeaderType []string
     - __kind: GoHMapBucketType
-      ID: 124
+      ID: 146
       Name: bucket<string,string>
       ByteSize: 272
       RawFields:
         - Name: tophash
           Offset: 0
-          Type: 21 ArrayType [8]uint8
+          Type: 48 ArrayType [8]uint8
         - Name: keys
           Offset: 8
-          Type: 22 ArrayType []key<string>
+          Type: 49 ArrayType []key<string>
         - Name: values
           Offset: 136
-          Type: 125 ArrayType []val<string>
+          Type: 147 ArrayType []val<string>
         - Name: overflow
           Offset: 264
-          Type: 123 PointerType *bucket<string,string>
-      KeyType: 5 GoStringHeaderType string
-      ValueType: 5 GoStringHeaderType string
+          Type: 145 PointerType *bucket<string,string>
+      KeyType: 11 GoStringHeaderType string
+      ValueType: 11 GoStringHeaderType string
     - __kind: StructureType
-      ID: 127
+      ID: 149
       Name: bytes.Buffer
       ByteSize: 40
       GoRuntimeType: 1.414272e+06
@@ -1163,33 +1163,33 @@ Types:
       RawFields:
         - Name: buf
           Offset: 0
-          Type: 52 GoSliceHeaderType []uint8
+          Type: 76 GoSliceHeaderType []uint8
         - Name: off
           Offset: 24
-          Type: 8 BaseType int
+          Type: 9 BaseType int
         - Name: lastRead
           Offset: 32
-          Type: 128 BaseType bytes.readOp
+          Type: 150 BaseType bytes.readOp
     - __kind: BaseType
-      ID: 128
+      ID: 150
       Name: bytes.readOp
       ByteSize: 1
       GoRuntimeType: 532992
       GoKind: 3
     - __kind: BaseType
-      ID: 144
+      ID: 25
       Name: complex128
       ByteSize: 16
       GoRuntimeType: 534592
       GoKind: 16
     - __kind: BaseType
-      ID: 143
+      ID: 24
       Name: complex64
       ByteSize: 8
       GoRuntimeType: 534528
       GoKind: 15
     - __kind: GoInterfaceType
-      ID: 114
+      ID: 136
       Name: context.Context
       ByteSize: 16
       GoRuntimeType: 1.187296e+06
@@ -1197,27 +1197,27 @@ Types:
       RawFields:
         - Name: tab
           Offset: 0
-          Type: 2 VoidPointerType unsafe.Pointer
+          Type: 19 VoidPointerType unsafe.Pointer
         - Name: data
           Offset: 8
-          Type: 2 VoidPointerType unsafe.Pointer
+          Type: 19 VoidPointerType unsafe.Pointer
     - __kind: StructureType
-      ID: 130
+      ID: 152
       Name: context.backgroundCtx
       GoRuntimeType: 1.667744e+06
       GoKind: 25
       RawFields:
         - Name: emptyCtx
           Offset: 0
-          Type: 131 StructureType context.emptyCtx
+          Type: 153 StructureType context.emptyCtx
     - __kind: StructureType
-      ID: 131
+      ID: 153
       Name: context.emptyCtx
       GoRuntimeType: 1.399808e+06
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 54
+      ID: 78
       Name: crypto/tls.ConnectionState
       ByteSize: 192
       GoRuntimeType: 2.100544e+06
@@ -1225,60 +1225,60 @@ Types:
       RawFields:
         - Name: Version
           Offset: 0
-          Type: 17 BaseType uint16
+          Type: 7 BaseType uint16
         - Name: HandshakeComplete
           Offset: 2
-          Type: 13 BaseType bool
+          Type: 4 BaseType bool
         - Name: DidResume
           Offset: 3
-          Type: 13 BaseType bool
+          Type: 4 BaseType bool
         - Name: CipherSuite
           Offset: 4
-          Type: 17 BaseType uint16
+          Type: 7 BaseType uint16
         - Name: NegotiatedProtocol
           Offset: 8
-          Type: 5 GoStringHeaderType string
+          Type: 11 GoStringHeaderType string
         - Name: NegotiatedProtocolIsMutual
           Offset: 24
-          Type: 13 BaseType bool
+          Type: 4 BaseType bool
         - Name: ServerName
           Offset: 32
-          Type: 5 GoStringHeaderType string
+          Type: 11 GoStringHeaderType string
         - Name: PeerCertificates
           Offset: 48
-          Type: 55 GoSliceHeaderType []*crypto/x509.Certificate
+          Type: 79 GoSliceHeaderType []*crypto/x509.Certificate
         - Name: VerifiedChains
           Offset: 72
-          Type: 105 GoSliceHeaderType [][]*crypto/x509.Certificate
+          Type: 127 GoSliceHeaderType [][]*crypto/x509.Certificate
         - Name: SignedCertificateTimestamps
           Offset: 96
-          Type: 107 GoSliceHeaderType [][]uint8
+          Type: 129 GoSliceHeaderType [][]uint8
         - Name: OCSPResponse
           Offset: 120
-          Type: 52 GoSliceHeaderType []uint8
+          Type: 76 GoSliceHeaderType []uint8
         - Name: TLSUnique
           Offset: 144
-          Type: 52 GoSliceHeaderType []uint8
+          Type: 76 GoSliceHeaderType []uint8
         - Name: ECHAccepted
           Offset: 168
-          Type: 13 BaseType bool
+          Type: 4 BaseType bool
         - Name: ekm
           Offset: 176
-          Type: 109 GoSubroutineType func(string, []uint8, int) ([]uint8, error)
+          Type: 131 GoSubroutineType func(string, []uint8, int) ([]uint8, error)
         - Name: testingOnlyDidHRR
           Offset: 184
-          Type: 13 BaseType bool
+          Type: 4 BaseType bool
         - Name: testingOnlyCurveID
           Offset: 186
-          Type: 110 BaseType crypto/tls.CurveID
+          Type: 132 BaseType crypto/tls.CurveID
     - __kind: BaseType
-      ID: 110
+      ID: 132
       Name: crypto/tls.CurveID
       ByteSize: 2
       GoRuntimeType: 766144
       GoKind: 9
     - __kind: StructureType
-      ID: 58
+      ID: 82
       Name: crypto/x509.Certificate
       ByteSize: 1352
       GoRuntimeType: 2.2352e+06
@@ -1286,153 +1286,153 @@ Types:
       RawFields:
         - Name: Raw
           Offset: 0
-          Type: 52 GoSliceHeaderType []uint8
+          Type: 76 GoSliceHeaderType []uint8
         - Name: RawTBSCertificate
           Offset: 24
-          Type: 52 GoSliceHeaderType []uint8
+          Type: 76 GoSliceHeaderType []uint8
         - Name: RawSubjectPublicKeyInfo
           Offset: 48
-          Type: 52 GoSliceHeaderType []uint8
+          Type: 76 GoSliceHeaderType []uint8
         - Name: RawSubject
           Offset: 72
-          Type: 52 GoSliceHeaderType []uint8
+          Type: 76 GoSliceHeaderType []uint8
         - Name: RawIssuer
           Offset: 96
-          Type: 52 GoSliceHeaderType []uint8
+          Type: 76 GoSliceHeaderType []uint8
         - Name: Signature
           Offset: 120
-          Type: 52 GoSliceHeaderType []uint8
+          Type: 76 GoSliceHeaderType []uint8
         - Name: SignatureAlgorithm
           Offset: 144
-          Type: 59 BaseType crypto/x509.SignatureAlgorithm
+          Type: 83 BaseType crypto/x509.SignatureAlgorithm
         - Name: PublicKeyAlgorithm
           Offset: 152
-          Type: 60 BaseType crypto/x509.PublicKeyAlgorithm
+          Type: 84 BaseType crypto/x509.PublicKeyAlgorithm
         - Name: PublicKey
           Offset: 160
-          Type: 61 GoEmptyInterfaceType interface {}
+          Type: 85 GoEmptyInterfaceType interface {}
         - Name: Version
           Offset: 176
-          Type: 8 BaseType int
+          Type: 9 BaseType int
         - Name: SerialNumber
           Offset: 184
-          Type: 62 PointerType *math/big.Int
+          Type: 86 PointerType *math/big.Int
         - Name: Issuer
           Offset: 192
-          Type: 67 StructureType crypto/x509/pkix.Name
+          Type: 91 StructureType crypto/x509/pkix.Name
         - Name: Subject
           Offset: 440
-          Type: 67 StructureType crypto/x509/pkix.Name
+          Type: 91 StructureType crypto/x509/pkix.Name
         - Name: NotBefore
           Offset: 688
-          Type: 73 StructureType time.Time
+          Type: 96 StructureType time.Time
         - Name: NotAfter
           Offset: 712
-          Type: 73 StructureType time.Time
+          Type: 96 StructureType time.Time
         - Name: KeyUsage
           Offset: 736
-          Type: 83 BaseType crypto/x509.KeyUsage
+          Type: 105 BaseType crypto/x509.KeyUsage
         - Name: Extensions
           Offset: 744
-          Type: 84 GoSliceHeaderType []crypto/x509/pkix.Extension
+          Type: 106 GoSliceHeaderType []crypto/x509/pkix.Extension
         - Name: ExtraExtensions
           Offset: 768
-          Type: 84 GoSliceHeaderType []crypto/x509/pkix.Extension
+          Type: 106 GoSliceHeaderType []crypto/x509/pkix.Extension
         - Name: UnhandledCriticalExtensions
           Offset: 792
-          Type: 87 GoSliceHeaderType []encoding/asn1.ObjectIdentifier
+          Type: 109 GoSliceHeaderType []encoding/asn1.ObjectIdentifier
         - Name: ExtKeyUsage
           Offset: 816
-          Type: 89 GoSliceHeaderType []crypto/x509.ExtKeyUsage
+          Type: 111 GoSliceHeaderType []crypto/x509.ExtKeyUsage
         - Name: UnknownExtKeyUsage
           Offset: 840
-          Type: 87 GoSliceHeaderType []encoding/asn1.ObjectIdentifier
+          Type: 109 GoSliceHeaderType []encoding/asn1.ObjectIdentifier
         - Name: BasicConstraintsValid
           Offset: 864
-          Type: 13 BaseType bool
+          Type: 4 BaseType bool
         - Name: IsCA
           Offset: 865
-          Type: 13 BaseType bool
+          Type: 4 BaseType bool
         - Name: MaxPathLen
           Offset: 872
-          Type: 8 BaseType int
+          Type: 9 BaseType int
         - Name: MaxPathLenZero
           Offset: 880
-          Type: 13 BaseType bool
+          Type: 4 BaseType bool
         - Name: SubjectKeyId
           Offset: 888
-          Type: 52 GoSliceHeaderType []uint8
+          Type: 76 GoSliceHeaderType []uint8
         - Name: AuthorityKeyId
           Offset: 912
-          Type: 52 GoSliceHeaderType []uint8
+          Type: 76 GoSliceHeaderType []uint8
         - Name: OCSPServer
           Offset: 936
-          Type: 24 GoSliceHeaderType []string
+          Type: 51 GoSliceHeaderType []string
         - Name: IssuingCertificateURL
           Offset: 960
-          Type: 24 GoSliceHeaderType []string
+          Type: 51 GoSliceHeaderType []string
         - Name: DNSNames
           Offset: 984
-          Type: 24 GoSliceHeaderType []string
+          Type: 51 GoSliceHeaderType []string
         - Name: EmailAddresses
           Offset: 1008
-          Type: 24 GoSliceHeaderType []string
+          Type: 51 GoSliceHeaderType []string
         - Name: IPAddresses
           Offset: 1032
-          Type: 92 GoSliceHeaderType []net.IP
+          Type: 114 GoSliceHeaderType []net.IP
         - Name: URIs
           Offset: 1056
-          Type: 95 GoSliceHeaderType []*net/url.URL
+          Type: 117 GoSliceHeaderType []*net/url.URL
         - Name: PermittedDNSDomainsCritical
           Offset: 1080
-          Type: 13 BaseType bool
+          Type: 4 BaseType bool
         - Name: PermittedDNSDomains
           Offset: 1088
-          Type: 24 GoSliceHeaderType []string
+          Type: 51 GoSliceHeaderType []string
         - Name: ExcludedDNSDomains
           Offset: 1112
-          Type: 24 GoSliceHeaderType []string
+          Type: 51 GoSliceHeaderType []string
         - Name: PermittedIPRanges
           Offset: 1136
-          Type: 97 GoSliceHeaderType []*net.IPNet
+          Type: 119 GoSliceHeaderType []*net.IPNet
         - Name: ExcludedIPRanges
           Offset: 1160
-          Type: 97 GoSliceHeaderType []*net.IPNet
+          Type: 119 GoSliceHeaderType []*net.IPNet
         - Name: PermittedEmailAddresses
           Offset: 1184
-          Type: 24 GoSliceHeaderType []string
+          Type: 51 GoSliceHeaderType []string
         - Name: ExcludedEmailAddresses
           Offset: 1208
-          Type: 24 GoSliceHeaderType []string
+          Type: 51 GoSliceHeaderType []string
         - Name: PermittedURIDomains
           Offset: 1232
-          Type: 24 GoSliceHeaderType []string
+          Type: 51 GoSliceHeaderType []string
         - Name: ExcludedURIDomains
           Offset: 1256
-          Type: 24 GoSliceHeaderType []string
+          Type: 51 GoSliceHeaderType []string
         - Name: CRLDistributionPoints
           Offset: 1280
-          Type: 24 GoSliceHeaderType []string
+          Type: 51 GoSliceHeaderType []string
         - Name: PolicyIdentifiers
           Offset: 1304
-          Type: 87 GoSliceHeaderType []encoding/asn1.ObjectIdentifier
+          Type: 109 GoSliceHeaderType []encoding/asn1.ObjectIdentifier
         - Name: Policies
           Offset: 1328
-          Type: 102 GoSliceHeaderType []crypto/x509.OID
+          Type: 124 GoSliceHeaderType []crypto/x509.OID
     - __kind: BaseType
-      ID: 91
+      ID: 113
       Name: crypto/x509.ExtKeyUsage
       ByteSize: 8
       GoRuntimeType: 537472
       GoKind: 2
     - __kind: BaseType
-      ID: 83
+      ID: 105
       Name: crypto/x509.KeyUsage
       ByteSize: 8
       GoRuntimeType: 537408
       GoKind: 2
     - __kind: StructureType
-      ID: 104
+      ID: 126
       Name: crypto/x509.OID
       ByteSize: 24
       GoRuntimeType: 1.718016e+06
@@ -1440,21 +1440,21 @@ Types:
       RawFields:
         - Name: der
           Offset: 0
-          Type: 52 GoSliceHeaderType []uint8
+          Type: 76 GoSliceHeaderType []uint8
     - __kind: BaseType
-      ID: 60
+      ID: 84
       Name: crypto/x509.PublicKeyAlgorithm
       ByteSize: 8
       GoRuntimeType: 768544
       GoKind: 2
     - __kind: BaseType
-      ID: 59
+      ID: 83
       Name: crypto/x509.SignatureAlgorithm
       ByteSize: 8
       GoRuntimeType: 1.071168e+06
       GoKind: 2
     - __kind: StructureType
-      ID: 70
+      ID: 94
       Name: crypto/x509/pkix.AttributeTypeAndValue
       ByteSize: 40
       GoRuntimeType: 1.316608e+06
@@ -1462,12 +1462,12 @@ Types:
       RawFields:
         - Name: Type
           Offset: 0
-          Type: 71 GoSliceHeaderType encoding/asn1.ObjectIdentifier
+          Type: 95 GoSliceHeaderType encoding/asn1.ObjectIdentifier
         - Name: Value
           Offset: 24
-          Type: 61 GoEmptyInterfaceType interface {}
+          Type: 85 GoEmptyInterfaceType interface {}
     - __kind: StructureType
-      ID: 86
+      ID: 108
       Name: crypto/x509/pkix.Extension
       ByteSize: 56
       GoRuntimeType: 1.45536e+06
@@ -1475,15 +1475,15 @@ Types:
       RawFields:
         - Name: Id
           Offset: 0
-          Type: 71 GoSliceHeaderType encoding/asn1.ObjectIdentifier
+          Type: 95 GoSliceHeaderType encoding/asn1.ObjectIdentifier
         - Name: Critical
           Offset: 24
-          Type: 13 BaseType bool
+          Type: 4 BaseType bool
         - Name: Value
           Offset: 32
-          Type: 52 GoSliceHeaderType []uint8
+          Type: 76 GoSliceHeaderType []uint8
     - __kind: StructureType
-      ID: 67
+      ID: 91
       Name: crypto/x509/pkix.Name
       ByteSize: 248
       GoRuntimeType: 2.047488e+06
@@ -1491,39 +1491,39 @@ Types:
       RawFields:
         - Name: Country
           Offset: 0
-          Type: 24 GoSliceHeaderType []string
+          Type: 51 GoSliceHeaderType []string
         - Name: Organization
           Offset: 24
-          Type: 24 GoSliceHeaderType []string
+          Type: 51 GoSliceHeaderType []string
         - Name: OrganizationalUnit
           Offset: 48
-          Type: 24 GoSliceHeaderType []string
+          Type: 51 GoSliceHeaderType []string
         - Name: Locality
           Offset: 72
-          Type: 24 GoSliceHeaderType []string
+          Type: 51 GoSliceHeaderType []string
         - Name: Province
           Offset: 96
-          Type: 24 GoSliceHeaderType []string
+          Type: 51 GoSliceHeaderType []string
         - Name: StreetAddress
           Offset: 120
-          Type: 24 GoSliceHeaderType []string
+          Type: 51 GoSliceHeaderType []string
         - Name: PostalCode
           Offset: 144
-          Type: 24 GoSliceHeaderType []string
+          Type: 51 GoSliceHeaderType []string
         - Name: SerialNumber
           Offset: 168
-          Type: 5 GoStringHeaderType string
+          Type: 11 GoStringHeaderType string
         - Name: CommonName
           Offset: 184
-          Type: 5 GoStringHeaderType string
+          Type: 11 GoStringHeaderType string
         - Name: Names
           Offset: 200
-          Type: 68 GoSliceHeaderType []crypto/x509/pkix.AttributeTypeAndValue
+          Type: 92 GoSliceHeaderType []crypto/x509/pkix.AttributeTypeAndValue
         - Name: ExtraNames
           Offset: 224
-          Type: 68 GoSliceHeaderType []crypto/x509/pkix.AttributeTypeAndValue
+          Type: 92 GoSliceHeaderType []crypto/x509/pkix.AttributeTypeAndValue
     - __kind: GoSliceHeaderType
-      ID: 71
+      ID: 95
       Name: encoding/asn1.ObjectIdentifier
       ByteSize: 24
       GoRuntimeType: 1.010048e+06
@@ -1531,21 +1531,21 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 72 PointerType *int
+          Type: 28 PointerType *int
         - Name: len
           Offset: 8
-          Type: 8 BaseType int
+          Type: 9 BaseType int
         - Name: cap
           Offset: 16
-          Type: 8 BaseType int
+          Type: 9 BaseType int
       Data: 172 GoSliceDataType encoding/asn1.ObjectIdentifier.array
     - __kind: GoSliceDataType
       ID: 172
       Name: encoding/asn1.ObjectIdentifier.array
       ByteSize: 2048
-      Element: 8 BaseType int
+      Element: 9 BaseType int
     - __kind: GoInterfaceType
-      ID: 139
+      ID: 18
       Name: error
       ByteSize: 16
       GoRuntimeType: 987648
@@ -1553,36 +1553,36 @@ Types:
       RawFields:
         - Name: tab
           Offset: 0
-          Type: 2 VoidPointerType unsafe.Pointer
+          Type: 19 VoidPointerType unsafe.Pointer
         - Name: data
           Offset: 8
-          Type: 2 VoidPointerType unsafe.Pointer
+          Type: 19 VoidPointerType unsafe.Pointer
     - __kind: BaseType
-      ID: 137
+      ID: 16
       Name: float32
       ByteSize: 4
       GoRuntimeType: 534656
       GoKind: 13
     - __kind: BaseType
-      ID: 138
+      ID: 17
       Name: float64
       ByteSize: 8
       GoRuntimeType: 534720
       GoKind: 14
     - __kind: GoSubroutineType
-      ID: 35
+      ID: 60
       Name: func() (io.ReadCloser, error)
       ByteSize: 8
       GoRuntimeType: 634400
       GoKind: 19
     - __kind: GoSubroutineType
-      ID: 109
+      ID: 131
       Name: func(string, []uint8, int) ([]uint8, error)
       ByteSize: 8
       GoRuntimeType: 960448
       GoKind: 19
     - __kind: GoInterfaceType
-      ID: 129
+      ID: 151
       Name: gopkg.in/DataDog/dd-trace-go.v1/ddtrace.Span
       ByteSize: 16
       GoRuntimeType: 1.296128e+06
@@ -1590,144 +1590,144 @@ Types:
       RawFields:
         - Name: tab
           Offset: 0
-          Type: 2 VoidPointerType unsafe.Pointer
+          Type: 19 VoidPointerType unsafe.Pointer
         - Name: data
           Offset: 8
-          Type: 2 VoidPointerType unsafe.Pointer
+          Type: 19 VoidPointerType unsafe.Pointer
     - __kind: GoHMapHeaderType
-      ID: 43
+      ID: 67
       Name: hash<string,[]*mime/multipart.FileHeader>
       ByteSize: 48
       RawFields:
         - Name: count
           Offset: 0
-          Type: 8 BaseType int
+          Type: 9 BaseType int
         - Name: flags
           Offset: 8
-          Type: 7 BaseType uint8
+          Type: 3 BaseType uint8
         - Name: B
           Offset: 9
-          Type: 7 BaseType uint8
+          Type: 3 BaseType uint8
         - Name: noverflow
           Offset: 10
-          Type: 17 BaseType uint16
+          Type: 7 BaseType uint16
         - Name: hash0
           Offset: 12
-          Type: 18 BaseType uint32
+          Type: 2 BaseType uint32
         - Name: buckets
           Offset: 16
-          Type: 44 PointerType *bucket<string,[]*mime/multipart.FileHeader>
+          Type: 68 PointerType *bucket<string,[]*mime/multipart.FileHeader>
         - Name: oldbuckets
           Offset: 24
-          Type: 44 PointerType *bucket<string,[]*mime/multipart.FileHeader>
+          Type: 68 PointerType *bucket<string,[]*mime/multipart.FileHeader>
         - Name: nevacuate
           Offset: 32
-          Type: 26 BaseType uintptr
+          Type: 1 BaseType uintptr
         - Name: extra
           Offset: 40
-          Type: 27 PointerType *runtime.mapextra
-      BucketType: 45 GoHMapBucketType bucket<string,[]*mime/multipart.FileHeader>
+          Type: 52 PointerType *runtime.mapextra
+      BucketType: 69 GoHMapBucketType bucket<string,[]*mime/multipart.FileHeader>
       BucketsType: 161 GoSliceDataType []bucket<string,[]*mime/multipart.FileHeader>.array
     - __kind: GoHMapHeaderType
-      ID: 16
+      ID: 45
       Name: hash<string,[]string>
       ByteSize: 48
       RawFields:
         - Name: count
           Offset: 0
-          Type: 8 BaseType int
+          Type: 9 BaseType int
         - Name: flags
           Offset: 8
-          Type: 7 BaseType uint8
+          Type: 3 BaseType uint8
         - Name: B
           Offset: 9
-          Type: 7 BaseType uint8
+          Type: 3 BaseType uint8
         - Name: noverflow
           Offset: 10
-          Type: 17 BaseType uint16
+          Type: 7 BaseType uint16
         - Name: hash0
           Offset: 12
-          Type: 18 BaseType uint32
+          Type: 2 BaseType uint32
         - Name: buckets
           Offset: 16
-          Type: 19 PointerType *bucket<string,[]string>
+          Type: 46 PointerType *bucket<string,[]string>
         - Name: oldbuckets
           Offset: 24
-          Type: 19 PointerType *bucket<string,[]string>
+          Type: 46 PointerType *bucket<string,[]string>
         - Name: nevacuate
           Offset: 32
-          Type: 26 BaseType uintptr
+          Type: 1 BaseType uintptr
         - Name: extra
           Offset: 40
-          Type: 27 PointerType *runtime.mapextra
-      BucketType: 20 GoHMapBucketType bucket<string,[]string>
+          Type: 52 PointerType *runtime.mapextra
+      BucketType: 47 GoHMapBucketType bucket<string,[]string>
       BucketsType: 156 GoSliceDataType []bucket<string,[]string>.array
     - __kind: GoHMapHeaderType
-      ID: 122
+      ID: 144
       Name: hash<string,string>
       ByteSize: 48
       RawFields:
         - Name: count
           Offset: 0
-          Type: 8 BaseType int
+          Type: 9 BaseType int
         - Name: flags
           Offset: 8
-          Type: 7 BaseType uint8
+          Type: 3 BaseType uint8
         - Name: B
           Offset: 9
-          Type: 7 BaseType uint8
+          Type: 3 BaseType uint8
         - Name: noverflow
           Offset: 10
-          Type: 17 BaseType uint16
+          Type: 7 BaseType uint16
         - Name: hash0
           Offset: 12
-          Type: 18 BaseType uint32
+          Type: 2 BaseType uint32
         - Name: buckets
           Offset: 16
-          Type: 123 PointerType *bucket<string,string>
+          Type: 145 PointerType *bucket<string,string>
         - Name: oldbuckets
           Offset: 24
-          Type: 123 PointerType *bucket<string,string>
+          Type: 145 PointerType *bucket<string,string>
         - Name: nevacuate
           Offset: 32
-          Type: 26 BaseType uintptr
+          Type: 1 BaseType uintptr
         - Name: extra
           Offset: 40
-          Type: 27 PointerType *runtime.mapextra
-      BucketType: 124 GoHMapBucketType bucket<string,string>
+          Type: 52 PointerType *runtime.mapextra
+      BucketType: 146 GoHMapBucketType bucket<string,string>
       BucketsType: 202 GoSliceDataType []bucket<string,string>.array
     - __kind: BaseType
-      ID: 8
+      ID: 9
       Name: int
       ByteSize: 8
       GoRuntimeType: 534336
       GoKind: 2
     - __kind: BaseType
-      ID: 142
+      ID: 23
       Name: int16
       ByteSize: 2
       GoRuntimeType: 533952
       GoKind: 4
     - __kind: BaseType
-      ID: 135
+      ID: 13
       Name: int32
       ByteSize: 4
       GoRuntimeType: 534080
       GoKind: 5
     - __kind: BaseType
-      ID: 36
+      ID: 14
       Name: int64
       ByteSize: 8
       GoRuntimeType: 534208
       GoKind: 6
     - __kind: BaseType
-      ID: 136
+      ID: 15
       Name: int8
       ByteSize: 1
       GoRuntimeType: 533824
       GoKind: 3
     - __kind: GoEmptyInterfaceType
-      ID: 61
+      ID: 85
       Name: interface {}
       ByteSize: 16
       GoRuntimeType: 785472
@@ -1735,12 +1735,12 @@ Types:
       RawFields:
         - Name: _type
           Offset: 0
-          Type: 2 VoidPointerType unsafe.Pointer
+          Type: 19 VoidPointerType unsafe.Pointer
         - Name: data
           Offset: 8
-          Type: 2 VoidPointerType unsafe.Pointer
+          Type: 19 VoidPointerType unsafe.Pointer
     - __kind: GoInterfaceType
-      ID: 34
+      ID: 59
       Name: io.ReadCloser
       ByteSize: 16
       GoRuntimeType: 1.067328e+06
@@ -1748,33 +1748,33 @@ Types:
       RawFields:
         - Name: tab
           Offset: 0
-          Type: 2 VoidPointerType unsafe.Pointer
+          Type: 19 VoidPointerType unsafe.Pointer
         - Name: data
           Offset: 8
-          Type: 2 VoidPointerType unsafe.Pointer
+          Type: 19 VoidPointerType unsafe.Pointer
     - __kind: GoMapType
-      ID: 41
+      ID: 65
       Name: map[string][]*mime/multipart.FileHeader
       ByteSize: 8
       GoRuntimeType: 887392
       GoKind: 21
-      HeaderType: 43 GoHMapHeaderType hash<string,[]*mime/multipart.FileHeader>
+      HeaderType: 67 GoHMapHeaderType hash<string,[]*mime/multipart.FileHeader>
     - __kind: GoMapType
-      ID: 40
+      ID: 64
       Name: map[string][]string
       ByteSize: 8
       GoRuntimeType: 882592
       GoKind: 21
-      HeaderType: 16 GoHMapHeaderType hash<string,[]string>
+      HeaderType: 45 GoHMapHeaderType hash<string,[]string>
     - __kind: GoMapType
-      ID: 120
+      ID: 142
       Name: map[string]string
       ByteSize: 8
       GoRuntimeType: 884224
       GoKind: 21
-      HeaderType: 122 GoHMapHeaderType hash<string,string>
+      HeaderType: 144 GoHMapHeaderType hash<string,string>
     - __kind: StructureType
-      ID: 63
+      ID: 87
       Name: math/big.Int
       ByteSize: 32
       GoRuntimeType: 1.308608e+06
@@ -1782,18 +1782,18 @@ Types:
       RawFields:
         - Name: neg
           Offset: 0
-          Type: 13 BaseType bool
+          Type: 4 BaseType bool
         - Name: abs
           Offset: 8
-          Type: 64 GoSliceHeaderType math/big.nat
+          Type: 88 GoSliceHeaderType math/big.nat
     - __kind: BaseType
-      ID: 66
+      ID: 90
       Name: math/big.Word
       ByteSize: 8
       GoRuntimeType: 537728
       GoKind: 7
     - __kind: GoSliceHeaderType
-      ID: 64
+      ID: 88
       Name: math/big.nat
       ByteSize: 24
       GoRuntimeType: 2.214784e+06
@@ -1801,21 +1801,21 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 65 PointerType *math/big.Word
+          Type: 89 PointerType *math/big.Word
         - Name: len
           Offset: 8
-          Type: 8 BaseType int
+          Type: 9 BaseType int
         - Name: cap
           Offset: 16
-          Type: 8 BaseType int
+          Type: 9 BaseType int
       Data: 168 GoSliceDataType math/big.nat.array
     - __kind: GoSliceDataType
       ID: 168
       Name: math/big.nat.array
       ByteSize: 2048
-      Element: 66 BaseType math/big.Word
+      Element: 90 BaseType math/big.Word
     - __kind: StructureType
-      ID: 50
+      ID: 74
       Name: mime/multipart.FileHeader
       ByteSize: 88
       GoRuntimeType: 1.83856e+06
@@ -1823,27 +1823,27 @@ Types:
       RawFields:
         - Name: Filename
           Offset: 0
-          Type: 5 GoStringHeaderType string
+          Type: 11 GoStringHeaderType string
         - Name: Header
           Offset: 16
-          Type: 51 GoMapType net/textproto.MIMEHeader
+          Type: 75 GoMapType net/textproto.MIMEHeader
         - Name: Size
           Offset: 24
-          Type: 36 BaseType int64
+          Type: 14 BaseType int64
         - Name: content
           Offset: 32
-          Type: 52 GoSliceHeaderType []uint8
+          Type: 76 GoSliceHeaderType []uint8
         - Name: tmpfile
           Offset: 56
-          Type: 5 GoStringHeaderType string
+          Type: 11 GoStringHeaderType string
         - Name: tmpoff
           Offset: 72
-          Type: 36 BaseType int64
+          Type: 14 BaseType int64
         - Name: tmpshared
           Offset: 80
-          Type: 13 BaseType bool
+          Type: 4 BaseType bool
     - __kind: StructureType
-      ID: 39
+      ID: 63
       Name: mime/multipart.Form
       ByteSize: 16
       GoRuntimeType: 1.294528e+06
@@ -1851,12 +1851,12 @@ Types:
       RawFields:
         - Name: Value
           Offset: 0
-          Type: 40 GoMapType map[string][]string
+          Type: 64 GoMapType map[string][]string
         - Name: File
           Offset: 8
-          Type: 41 GoMapType map[string][]*mime/multipart.FileHeader
+          Type: 65 GoMapType map[string][]*mime/multipart.FileHeader
     - __kind: GoSliceHeaderType
-      ID: 94
+      ID: 116
       Name: net.IP
       ByteSize: 24
       GoRuntimeType: 1.948704e+06
@@ -1867,18 +1867,18 @@ Types:
           Type: 6 PointerType *uint8
         - Name: len
           Offset: 8
-          Type: 8 BaseType int
+          Type: 9 BaseType int
         - Name: cap
           Offset: 16
-          Type: 8 BaseType int
+          Type: 9 BaseType int
       Data: 186 GoSliceDataType net.IP.array
     - __kind: GoSliceDataType
       ID: 186
       Name: net.IP.array
       ByteSize: 2048
-      Element: 7 BaseType uint8
+      Element: 3 BaseType uint8
     - __kind: GoSliceHeaderType
-      ID: 101
+      ID: 123
       Name: net.IPMask
       ByteSize: 24
       GoRuntimeType: 976000
@@ -1889,18 +1889,18 @@ Types:
           Type: 6 PointerType *uint8
         - Name: len
           Offset: 8
-          Type: 8 BaseType int
+          Type: 9 BaseType int
         - Name: cap
           Offset: 16
-          Type: 8 BaseType int
+          Type: 9 BaseType int
       Data: 192 GoSliceDataType net.IPMask.array
     - __kind: GoSliceDataType
       ID: 192
       Name: net.IPMask.array
       ByteSize: 2048
-      Element: 7 BaseType uint8
+      Element: 3 BaseType uint8
     - __kind: StructureType
-      ID: 100
+      ID: 122
       Name: net.IPNet
       ByteSize: 48
       GoRuntimeType: 1.276128e+06
@@ -1908,19 +1908,19 @@ Types:
       RawFields:
         - Name: IP
           Offset: 0
-          Type: 94 GoSliceHeaderType net.IP
+          Type: 116 GoSliceHeaderType net.IP
         - Name: Mask
           Offset: 24
-          Type: 101 GoSliceHeaderType net.IPMask
+          Type: 123 GoSliceHeaderType net.IPMask
     - __kind: GoMapType
-      ID: 14
+      ID: 43
       Name: net/http.Header
       ByteSize: 8
       GoRuntimeType: 1.917984e+06
       GoKind: 21
-      HeaderType: 16 GoHMapHeaderType hash<string,[]string>
+      HeaderType: 45 GoHMapHeaderType hash<string,[]string>
     - __kind: StructureType
-      ID: 4
+      ID: 38
       Name: net/http.Request
       ByteSize: 304
       GoRuntimeType: 2.190528e+06
@@ -1928,84 +1928,84 @@ Types:
       RawFields:
         - Name: Method
           Offset: 0
-          Type: 5 GoStringHeaderType string
+          Type: 11 GoStringHeaderType string
         - Name: URL
           Offset: 16
-          Type: 9 PointerType *net/url.URL
+          Type: 39 PointerType *net/url.URL
         - Name: Proto
           Offset: 24
-          Type: 5 GoStringHeaderType string
+          Type: 11 GoStringHeaderType string
         - Name: ProtoMajor
           Offset: 40
-          Type: 8 BaseType int
+          Type: 9 BaseType int
         - Name: ProtoMinor
           Offset: 48
-          Type: 8 BaseType int
+          Type: 9 BaseType int
         - Name: Header
           Offset: 56
-          Type: 14 GoMapType net/http.Header
+          Type: 43 GoMapType net/http.Header
         - Name: Body
           Offset: 64
-          Type: 34 GoInterfaceType io.ReadCloser
+          Type: 59 GoInterfaceType io.ReadCloser
         - Name: GetBody
           Offset: 80
-          Type: 35 GoSubroutineType func() (io.ReadCloser, error)
+          Type: 60 GoSubroutineType func() (io.ReadCloser, error)
         - Name: ContentLength
           Offset: 88
-          Type: 36 BaseType int64
+          Type: 14 BaseType int64
         - Name: TransferEncoding
           Offset: 96
-          Type: 24 GoSliceHeaderType []string
+          Type: 51 GoSliceHeaderType []string
         - Name: Close
           Offset: 120
-          Type: 13 BaseType bool
+          Type: 4 BaseType bool
         - Name: Host
           Offset: 128
-          Type: 5 GoStringHeaderType string
+          Type: 11 GoStringHeaderType string
         - Name: Form
           Offset: 144
-          Type: 37 GoMapType net/url.Values
+          Type: 61 GoMapType net/url.Values
         - Name: PostForm
           Offset: 152
-          Type: 37 GoMapType net/url.Values
+          Type: 61 GoMapType net/url.Values
         - Name: MultipartForm
           Offset: 160
-          Type: 38 PointerType *mime/multipart.Form
+          Type: 62 PointerType *mime/multipart.Form
         - Name: Trailer
           Offset: 168
-          Type: 14 GoMapType net/http.Header
+          Type: 43 GoMapType net/http.Header
         - Name: RemoteAddr
           Offset: 176
-          Type: 5 GoStringHeaderType string
+          Type: 11 GoStringHeaderType string
         - Name: RequestURI
           Offset: 192
-          Type: 5 GoStringHeaderType string
+          Type: 11 GoStringHeaderType string
         - Name: TLS
           Offset: 208
-          Type: 53 PointerType *crypto/tls.ConnectionState
+          Type: 77 PointerType *crypto/tls.ConnectionState
         - Name: Cancel
           Offset: 216
-          Type: 111 GoChannelType <-chan struct {}
+          Type: 133 GoChannelType <-chan struct {}
         - Name: Response
           Offset: 224
-          Type: 112 PointerType *net/http.Response
+          Type: 134 PointerType *net/http.Response
         - Name: Pattern
           Offset: 232
-          Type: 5 GoStringHeaderType string
+          Type: 11 GoStringHeaderType string
         - Name: ctx
           Offset: 248
-          Type: 114 GoInterfaceType context.Context
+          Type: 136 GoInterfaceType context.Context
         - Name: pat
           Offset: 264
-          Type: 115 PointerType *net/http.pattern
+          Type: 137 PointerType *net/http.pattern
         - Name: matches
           Offset: 272
-          Type: 24 GoSliceHeaderType []string
+          Type: 51 GoSliceHeaderType []string
         - Name: otherValues
           Offset: 296
-          Type: 120 GoMapType map[string]string
+          Type: 142 GoMapType map[string]string
     - __kind: StructureType
-      ID: 113
+      ID: 135
       Name: net/http.Response
       ByteSize: 144
       GoRuntimeType: 2.065376e+06
@@ -2013,48 +2013,48 @@ Types:
       RawFields:
         - Name: Status
           Offset: 0
-          Type: 5 GoStringHeaderType string
+          Type: 11 GoStringHeaderType string
         - Name: StatusCode
           Offset: 16
-          Type: 8 BaseType int
+          Type: 9 BaseType int
         - Name: Proto
           Offset: 24
-          Type: 5 GoStringHeaderType string
+          Type: 11 GoStringHeaderType string
         - Name: ProtoMajor
           Offset: 40
-          Type: 8 BaseType int
+          Type: 9 BaseType int
         - Name: ProtoMinor
           Offset: 48
-          Type: 8 BaseType int
+          Type: 9 BaseType int
         - Name: Header
           Offset: 56
-          Type: 14 GoMapType net/http.Header
+          Type: 43 GoMapType net/http.Header
         - Name: Body
           Offset: 64
-          Type: 34 GoInterfaceType io.ReadCloser
+          Type: 59 GoInterfaceType io.ReadCloser
         - Name: ContentLength
           Offset: 80
-          Type: 36 BaseType int64
+          Type: 14 BaseType int64
         - Name: TransferEncoding
           Offset: 88
-          Type: 24 GoSliceHeaderType []string
+          Type: 51 GoSliceHeaderType []string
         - Name: Close
           Offset: 112
-          Type: 13 BaseType bool
+          Type: 4 BaseType bool
         - Name: Uncompressed
           Offset: 113
-          Type: 13 BaseType bool
+          Type: 4 BaseType bool
         - Name: Trailer
           Offset: 120
-          Type: 14 GoMapType net/http.Header
+          Type: 43 GoMapType net/http.Header
         - Name: Request
           Offset: 128
-          Type: 3 PointerType *net/http.Request
+          Type: 37 PointerType *net/http.Request
         - Name: TLS
           Offset: 136
-          Type: 53 PointerType *crypto/tls.ConnectionState
+          Type: 77 PointerType *crypto/tls.ConnectionState
     - __kind: GoInterfaceType
-      ID: 1
+      ID: 36
       Name: net/http.ResponseWriter
       ByteSize: 16
       GoRuntimeType: 1.098528e+06
@@ -2062,12 +2062,12 @@ Types:
       RawFields:
         - Name: tab
           Offset: 0
-          Type: 2 VoidPointerType unsafe.Pointer
+          Type: 19 VoidPointerType unsafe.Pointer
         - Name: data
           Offset: 8
-          Type: 2 VoidPointerType unsafe.Pointer
+          Type: 19 VoidPointerType unsafe.Pointer
     - __kind: StructureType
-      ID: 116
+      ID: 138
       Name: net/http.pattern
       ByteSize: 88
       GoRuntimeType: 1.702112e+06
@@ -2075,21 +2075,21 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 5 GoStringHeaderType string
+          Type: 11 GoStringHeaderType string
         - Name: method
           Offset: 16
-          Type: 5 GoStringHeaderType string
+          Type: 11 GoStringHeaderType string
         - Name: host
           Offset: 32
-          Type: 5 GoStringHeaderType string
+          Type: 11 GoStringHeaderType string
         - Name: segments
           Offset: 48
-          Type: 117 GoSliceHeaderType []net/http.segment
+          Type: 139 GoSliceHeaderType []net/http.segment
         - Name: loc
           Offset: 72
-          Type: 5 GoStringHeaderType string
+          Type: 11 GoStringHeaderType string
     - __kind: StructureType
-      ID: 119
+      ID: 141
       Name: net/http.segment
       ByteSize: 24
       GoRuntimeType: 1.416384e+06
@@ -2097,22 +2097,22 @@ Types:
       RawFields:
         - Name: s
           Offset: 0
-          Type: 5 GoStringHeaderType string
+          Type: 11 GoStringHeaderType string
         - Name: wild
           Offset: 16
-          Type: 13 BaseType bool
+          Type: 4 BaseType bool
         - Name: multi
           Offset: 17
-          Type: 13 BaseType bool
+          Type: 4 BaseType bool
     - __kind: GoMapType
-      ID: 51
+      ID: 75
       Name: net/textproto.MIMEHeader
       ByteSize: 8
       GoRuntimeType: 1.596448e+06
       GoKind: 21
-      HeaderType: 16 GoHMapHeaderType hash<string,[]string>
+      HeaderType: 45 GoHMapHeaderType hash<string,[]string>
     - __kind: StructureType
-      ID: 10
+      ID: 40
       Name: net/url.URL
       ByteSize: 144
       GoRuntimeType: 1.986816e+06
@@ -2120,39 +2120,39 @@ Types:
       RawFields:
         - Name: Scheme
           Offset: 0
-          Type: 5 GoStringHeaderType string
+          Type: 11 GoStringHeaderType string
         - Name: Opaque
           Offset: 16
-          Type: 5 GoStringHeaderType string
+          Type: 11 GoStringHeaderType string
         - Name: User
           Offset: 32
-          Type: 11 PointerType *net/url.Userinfo
+          Type: 41 PointerType *net/url.Userinfo
         - Name: Host
           Offset: 40
-          Type: 5 GoStringHeaderType string
+          Type: 11 GoStringHeaderType string
         - Name: Path
           Offset: 56
-          Type: 5 GoStringHeaderType string
+          Type: 11 GoStringHeaderType string
         - Name: RawPath
           Offset: 72
-          Type: 5 GoStringHeaderType string
+          Type: 11 GoStringHeaderType string
         - Name: OmitHost
           Offset: 88
-          Type: 13 BaseType bool
+          Type: 4 BaseType bool
         - Name: ForceQuery
           Offset: 89
-          Type: 13 BaseType bool
+          Type: 4 BaseType bool
         - Name: RawQuery
           Offset: 96
-          Type: 5 GoStringHeaderType string
+          Type: 11 GoStringHeaderType string
         - Name: Fragment
           Offset: 112
-          Type: 5 GoStringHeaderType string
+          Type: 11 GoStringHeaderType string
         - Name: RawFragment
           Offset: 128
-          Type: 5 GoStringHeaderType string
+          Type: 11 GoStringHeaderType string
     - __kind: StructureType
-      ID: 12
+      ID: 42
       Name: net/url.Userinfo
       ByteSize: 40
       GoRuntimeType: 1.433088e+06
@@ -2160,22 +2160,22 @@ Types:
       RawFields:
         - Name: username
           Offset: 0
-          Type: 5 GoStringHeaderType string
+          Type: 11 GoStringHeaderType string
         - Name: password
           Offset: 16
-          Type: 5 GoStringHeaderType string
+          Type: 11 GoStringHeaderType string
         - Name: passwordSet
           Offset: 32
-          Type: 13 BaseType bool
+          Type: 4 BaseType bool
     - __kind: GoMapType
-      ID: 37
+      ID: 61
       Name: net/url.Values
       ByteSize: 8
       GoRuntimeType: 1.671328e+06
       GoKind: 21
-      HeaderType: 16 GoHMapHeaderType hash<string,[]string>
+      HeaderType: 45 GoHMapHeaderType hash<string,[]string>
     - __kind: StructureType
-      ID: 33
+      ID: 58
       Name: runtime.bmap
       ByteSize: 8
       GoRuntimeType: 1.10992e+06
@@ -2183,9 +2183,9 @@ Types:
       RawFields:
         - Name: tophash
           Offset: 0
-          Type: 21 ArrayType [8]uint8
+          Type: 48 ArrayType [8]uint8
     - __kind: StructureType
-      ID: 28
+      ID: 53
       Name: runtime.mapextra
       ByteSize: 24
       GoRuntimeType: 1.429056e+06
@@ -2193,15 +2193,15 @@ Types:
       RawFields:
         - Name: overflow
           Offset: 0
-          Type: 29 PointerType *[]*runtime.bmap
+          Type: 54 PointerType *[]*runtime.bmap
         - Name: oldoverflow
           Offset: 8
-          Type: 29 PointerType *[]*runtime.bmap
+          Type: 54 PointerType *[]*runtime.bmap
         - Name: nextOverflow
           Offset: 16
-          Type: 32 PointerType *runtime.bmap
+          Type: 57 PointerType *runtime.bmap
     - __kind: GoStringHeaderType
-      ID: 5
+      ID: 11
       Name: string
       ByteSize: 16
       GoRuntimeType: 533760
@@ -2212,14 +2212,14 @@ Types:
           Type: 155 PointerType *string.str
         - Name: len
           Offset: 8
-          Type: 8 BaseType int
+          Type: 9 BaseType int
       Data: 154 GoStringDataType string.str
     - __kind: GoStringDataType
       ID: 154
       Name: string.str
       ByteSize: 2048
     - __kind: StructureType
-      ID: 76
+      ID: 98
       Name: time.Location
       ByteSize: 104
       GoRuntimeType: 1.834528e+06
@@ -2227,27 +2227,27 @@ Types:
       RawFields:
         - Name: name
           Offset: 0
-          Type: 5 GoStringHeaderType string
+          Type: 11 GoStringHeaderType string
         - Name: zone
           Offset: 16
-          Type: 77 GoSliceHeaderType []time.zone
+          Type: 99 GoSliceHeaderType []time.zone
         - Name: tx
           Offset: 40
-          Type: 80 GoSliceHeaderType []time.zoneTrans
+          Type: 102 GoSliceHeaderType []time.zoneTrans
         - Name: extend
           Offset: 64
-          Type: 5 GoStringHeaderType string
+          Type: 11 GoStringHeaderType string
         - Name: cacheStart
           Offset: 80
-          Type: 36 BaseType int64
+          Type: 14 BaseType int64
         - Name: cacheEnd
           Offset: 88
-          Type: 36 BaseType int64
+          Type: 14 BaseType int64
         - Name: cacheZone
           Offset: 96
-          Type: 78 PointerType *time.zone
+          Type: 100 PointerType *time.zone
     - __kind: StructureType
-      ID: 73
+      ID: 96
       Name: time.Time
       ByteSize: 24
       GoRuntimeType: 2.215712e+06
@@ -2255,15 +2255,15 @@ Types:
       RawFields:
         - Name: wall
           Offset: 0
-          Type: 74 BaseType uint64
+          Type: 10 BaseType uint64
         - Name: ext
           Offset: 8
-          Type: 36 BaseType int64
+          Type: 14 BaseType int64
         - Name: loc
           Offset: 16
-          Type: 75 PointerType *time.Location
+          Type: 97 PointerType *time.Location
     - __kind: StructureType
-      ID: 79
+      ID: 101
       Name: time.zone
       ByteSize: 32
       GoRuntimeType: 1.421376e+06
@@ -2271,15 +2271,15 @@ Types:
       RawFields:
         - Name: name
           Offset: 0
-          Type: 5 GoStringHeaderType string
+          Type: 11 GoStringHeaderType string
         - Name: offset
           Offset: 16
-          Type: 8 BaseType int
+          Type: 9 BaseType int
         - Name: isDST
           Offset: 24
-          Type: 13 BaseType bool
+          Type: 4 BaseType bool
     - __kind: StructureType
-      ID: 82
+      ID: 104
       Name: time.zoneTrans
       ByteSize: 16
       GoRuntimeType: 1.623872e+06
@@ -2287,54 +2287,54 @@ Types:
       RawFields:
         - Name: when
           Offset: 0
-          Type: 36 BaseType int64
+          Type: 14 BaseType int64
         - Name: index
           Offset: 8
-          Type: 7 BaseType uint8
+          Type: 3 BaseType uint8
         - Name: isstd
           Offset: 9
-          Type: 13 BaseType bool
+          Type: 4 BaseType bool
         - Name: isutc
           Offset: 10
-          Type: 13 BaseType bool
+          Type: 4 BaseType bool
     - __kind: BaseType
-      ID: 134
+      ID: 12
       Name: uint
       ByteSize: 8
       GoRuntimeType: 534400
       GoKind: 7
     - __kind: BaseType
-      ID: 17
+      ID: 7
       Name: uint16
       ByteSize: 2
       GoRuntimeType: 534016
       GoKind: 9
     - __kind: BaseType
-      ID: 18
+      ID: 2
       Name: uint32
       ByteSize: 4
       GoRuntimeType: 534144
       GoKind: 10
     - __kind: BaseType
-      ID: 74
+      ID: 10
       Name: uint64
       ByteSize: 8
       GoRuntimeType: 534272
       GoKind: 11
     - __kind: BaseType
-      ID: 7
+      ID: 3
       Name: uint8
       ByteSize: 1
       GoRuntimeType: 533888
       GoKind: 8
     - __kind: BaseType
-      ID: 26
+      ID: 1
       Name: uintptr
       ByteSize: 8
       GoRuntimeType: 534464
       GoKind: 12
     - __kind: VoidPointerType
-      ID: 2
+      ID: 19
       Name: unsafe.Pointer
       ByteSize: 8
       GoRuntimeType: 534848

--- a/pkg/dyninst/irgen/testdata/snapshot/rc_tester_v1.arch=arm64,toolchain=go1.23.11.yaml
+++ b/pkg/dyninst/irgen/testdata/snapshot/rc_tester_v1.arch=arm64,toolchain=go1.23.11.yaml
@@ -120,25 +120,354 @@ Subprograms:
           IsParameter: true
           IsReturn: false
 Types:
-    - __kind: GoInterfaceType
-      ID: 1
-      Name: net/http.ResponseWriter
-      ByteSize: 16
-      GoRuntimeType: 1.098528e+06
-      GoKind: 20
-      RawFields:
-        - Name: tab
-          Offset: 0
-          Type: 2 VoidPointerType unsafe.Pointer
-        - Name: data
-          Offset: 8
-          Type: 2 VoidPointerType unsafe.Pointer
-    - __kind: VoidPointerType
-      ID: 2
-      Name: unsafe.Pointer
+    - __kind: PointerType
+      ID: 56
+      Name: '**crypto/x509.Certificate'
       ByteSize: 8
-      GoRuntimeType: 534848
-      GoKind: 26
+      Pointee: 57 PointerType *crypto/x509.Certificate
+    - __kind: PointerType
+      ID: 48
+      Name: '**mime/multipart.FileHeader'
+      ByteSize: 8
+      GoKind: 22
+      Pointee: 49 PointerType *mime/multipart.FileHeader
+    - __kind: PointerType
+      ID: 98
+      Name: '**net.IPNet'
+      ByteSize: 8
+      GoKind: 22
+      Pointee: 99 PointerType *net.IPNet
+    - __kind: PointerType
+      ID: 96
+      Name: '**net/url.URL'
+      ByteSize: 8
+      Pointee: 9 PointerType *net/url.URL
+    - __kind: PointerType
+      ID: 31
+      Name: '**runtime.bmap'
+      ByteSize: 8
+      Pointee: 32 PointerType *runtime.bmap
+    - __kind: PointerType
+      ID: 106
+      Name: '*[]*crypto/x509.Certificate'
+      ByteSize: 8
+      GoKind: 22
+      Pointee: 55 GoSliceHeaderType []*crypto/x509.Certificate
+    - __kind: PointerType
+      ID: 167
+      Name: '*[]*crypto/x509.Certificate.array'
+      ByteSize: 8
+      Pointee: 166 GoSliceDataType []*crypto/x509.Certificate.array
+    - __kind: PointerType
+      ID: 163
+      Name: '*[]*mime/multipart.FileHeader.array'
+      ByteSize: 8
+      Pointee: 162 GoSliceDataType []*mime/multipart.FileHeader.array
+    - __kind: PointerType
+      ID: 191
+      Name: '*[]*net.IPNet.array'
+      ByteSize: 8
+      Pointee: 190 GoSliceDataType []*net.IPNet.array
+    - __kind: PointerType
+      ID: 189
+      Name: '*[]*net/url.URL.array'
+      ByteSize: 8
+      Pointee: 188 GoSliceDataType []*net/url.URL.array
+    - __kind: PointerType
+      ID: 29
+      Name: '*[]*runtime.bmap'
+      ByteSize: 8
+      GoRuntimeType: 466496
+      GoKind: 22
+      Pointee: 30 GoSliceHeaderType []*runtime.bmap
+    - __kind: PointerType
+      ID: 160
+      Name: '*[]*runtime.bmap.array'
+      ByteSize: 8
+      Pointee: 159 GoSliceDataType []*runtime.bmap.array
+    - __kind: PointerType
+      ID: 197
+      Name: '*[][]*crypto/x509.Certificate.array'
+      ByteSize: 8
+      Pointee: 196 GoSliceDataType [][]*crypto/x509.Certificate.array
+    - __kind: PointerType
+      ID: 199
+      Name: '*[][]uint8.array'
+      ByteSize: 8
+      Pointee: 198 GoSliceDataType [][]uint8.array
+    - __kind: PointerType
+      ID: 183
+      Name: '*[]crypto/x509.ExtKeyUsage.array'
+      ByteSize: 8
+      Pointee: 182 GoSliceDataType []crypto/x509.ExtKeyUsage.array
+    - __kind: PointerType
+      ID: 195
+      Name: '*[]crypto/x509.OID.array'
+      ByteSize: 8
+      Pointee: 194 GoSliceDataType []crypto/x509.OID.array
+    - __kind: PointerType
+      ID: 171
+      Name: '*[]crypto/x509/pkix.AttributeTypeAndValue.array'
+      ByteSize: 8
+      Pointee: 170 GoSliceDataType []crypto/x509/pkix.AttributeTypeAndValue.array
+    - __kind: PointerType
+      ID: 179
+      Name: '*[]crypto/x509/pkix.Extension.array'
+      ByteSize: 8
+      Pointee: 178 GoSliceDataType []crypto/x509/pkix.Extension.array
+    - __kind: PointerType
+      ID: 181
+      Name: '*[]encoding/asn1.ObjectIdentifier.array'
+      ByteSize: 8
+      Pointee: 180 GoSliceDataType []encoding/asn1.ObjectIdentifier.array
+    - __kind: PointerType
+      ID: 185
+      Name: '*[]net.IP.array'
+      ByteSize: 8
+      Pointee: 184 GoSliceDataType []net.IP.array
+    - __kind: PointerType
+      ID: 201
+      Name: '*[]net/http.segment.array'
+      ByteSize: 8
+      Pointee: 200 GoSliceDataType []net/http.segment.array
+    - __kind: PointerType
+      ID: 158
+      Name: '*[]string.array'
+      ByteSize: 8
+      Pointee: 157 GoSliceDataType []string.array
+    - __kind: PointerType
+      ID: 175
+      Name: '*[]time.zone.array'
+      ByteSize: 8
+      Pointee: 174 GoSliceDataType []time.zone.array
+    - __kind: PointerType
+      ID: 177
+      Name: '*[]time.zoneTrans.array'
+      ByteSize: 8
+      Pointee: 176 GoSliceDataType []time.zoneTrans.array
+    - __kind: PointerType
+      ID: 108
+      Name: '*[]uint8'
+      ByteSize: 8
+      GoRuntimeType: 452640
+      GoKind: 22
+      Pointee: 52 GoSliceHeaderType []uint8
+    - __kind: PointerType
+      ID: 165
+      Name: '*[]uint8.array'
+      ByteSize: 8
+      Pointee: 164 GoSliceDataType []uint8.array
+    - __kind: PointerType
+      ID: 132
+      Name: '*bool'
+      ByteSize: 8
+      GoRuntimeType: 372704
+      GoKind: 22
+      Pointee: 13 BaseType bool
+    - __kind: PointerType
+      ID: 44
+      Name: '*bucket<string,[]*mime/multipart.FileHeader>'
+      ByteSize: 8
+      Pointee: 45 GoHMapBucketType bucket<string,[]*mime/multipart.FileHeader>
+    - __kind: PointerType
+      ID: 19
+      Name: '*bucket<string,[]string>'
+      ByteSize: 8
+      Pointee: 20 GoHMapBucketType bucket<string,[]string>
+    - __kind: PointerType
+      ID: 123
+      Name: '*bucket<string,string>'
+      ByteSize: 8
+      Pointee: 124 GoHMapBucketType bucket<string,string>
+    - __kind: PointerType
+      ID: 126
+      Name: '*bytes.Buffer'
+      ByteSize: 8
+      GoRuntimeType: 2.11552e+06
+      GoKind: 22
+      Pointee: 127 StructureType bytes.Buffer
+    - __kind: PointerType
+      ID: 53
+      Name: '*crypto/tls.ConnectionState'
+      ByteSize: 8
+      GoRuntimeType: 836032
+      GoKind: 22
+      Pointee: 54 StructureType crypto/tls.ConnectionState
+    - __kind: PointerType
+      ID: 57
+      Name: '*crypto/x509.Certificate'
+      ByteSize: 8
+      GoRuntimeType: 1.905824e+06
+      GoKind: 22
+      Pointee: 58 StructureType crypto/x509.Certificate
+    - __kind: PointerType
+      ID: 90
+      Name: '*crypto/x509.ExtKeyUsage'
+      ByteSize: 8
+      GoRuntimeType: 395104
+      GoKind: 22
+      Pointee: 91 BaseType crypto/x509.ExtKeyUsage
+    - __kind: PointerType
+      ID: 103
+      Name: '*crypto/x509.OID'
+      ByteSize: 8
+      GoRuntimeType: 1.717792e+06
+      GoKind: 22
+      Pointee: 104 StructureType crypto/x509.OID
+    - __kind: PointerType
+      ID: 69
+      Name: '*crypto/x509/pkix.AttributeTypeAndValue'
+      ByteSize: 8
+      GoRuntimeType: 408928
+      GoKind: 22
+      Pointee: 70 StructureType crypto/x509/pkix.AttributeTypeAndValue
+    - __kind: PointerType
+      ID: 85
+      Name: '*crypto/x509/pkix.Extension'
+      ByteSize: 8
+      GoRuntimeType: 409120
+      GoKind: 22
+      Pointee: 86 StructureType crypto/x509/pkix.Extension
+    - __kind: PointerType
+      ID: 88
+      Name: '*encoding/asn1.ObjectIdentifier'
+      ByteSize: 8
+      GoRuntimeType: 1.00992e+06
+      GoKind: 22
+      Pointee: 71 GoSliceHeaderType encoding/asn1.ObjectIdentifier
+    - __kind: PointerType
+      ID: 173
+      Name: '*encoding/asn1.ObjectIdentifier.array'
+      ByteSize: 8
+      Pointee: 172 GoSliceDataType encoding/asn1.ObjectIdentifier.array
+    - __kind: PointerType
+      ID: 151
+      Name: '*error'
+      ByteSize: 8
+      GoRuntimeType: 371616
+      GoKind: 22
+      Pointee: 139 GoInterfaceType error
+    - __kind: PointerType
+      ID: 153
+      Name: '*float32'
+      ByteSize: 8
+      GoRuntimeType: 372576
+      GoKind: 22
+      Pointee: 137 BaseType float32
+    - __kind: PointerType
+      ID: 145
+      Name: '*float64'
+      ByteSize: 8
+      GoRuntimeType: 372640
+      GoKind: 22
+      Pointee: 138 BaseType float64
+    - __kind: PointerType
+      ID: 42
+      Name: '*hash<string,[]*mime/multipart.FileHeader>'
+      ByteSize: 8
+      Pointee: 43 GoHMapHeaderType hash<string,[]*mime/multipart.FileHeader>
+    - __kind: PointerType
+      ID: 15
+      Name: '*hash<string,[]string>'
+      ByteSize: 8
+      Pointee: 16 GoHMapHeaderType hash<string,[]string>
+    - __kind: PointerType
+      ID: 121
+      Name: '*hash<string,string>'
+      ByteSize: 8
+      Pointee: 122 GoHMapHeaderType hash<string,string>
+    - __kind: PointerType
+      ID: 72
+      Name: '*int'
+      ByteSize: 8
+      GoRuntimeType: 372256
+      GoKind: 22
+      Pointee: 8 BaseType int
+    - __kind: PointerType
+      ID: 149
+      Name: '*int16'
+      ByteSize: 8
+      GoRuntimeType: 371872
+      GoKind: 22
+      Pointee: 142 BaseType int16
+    - __kind: PointerType
+      ID: 140
+      Name: '*int32'
+      ByteSize: 8
+      GoRuntimeType: 372000
+      GoKind: 22
+      Pointee: 135 BaseType int32
+    - __kind: PointerType
+      ID: 146
+      Name: '*int64'
+      ByteSize: 8
+      GoRuntimeType: 372128
+      GoKind: 22
+      Pointee: 36 BaseType int64
+    - __kind: PointerType
+      ID: 150
+      Name: '*int8'
+      ByteSize: 8
+      GoRuntimeType: 371744
+      GoKind: 22
+      Pointee: 136 BaseType int8
+    - __kind: PointerType
+      ID: 62
+      Name: '*math/big.Int'
+      ByteSize: 8
+      GoRuntimeType: 2.231648e+06
+      GoKind: 22
+      Pointee: 63 StructureType math/big.Int
+    - __kind: PointerType
+      ID: 65
+      Name: '*math/big.Word'
+      ByteSize: 8
+      GoRuntimeType: 397920
+      GoKind: 22
+      Pointee: 66 BaseType math/big.Word
+    - __kind: PointerType
+      ID: 169
+      Name: '*math/big.nat.array'
+      ByteSize: 8
+      Pointee: 168 GoSliceDataType math/big.nat.array
+    - __kind: PointerType
+      ID: 49
+      Name: '*mime/multipart.FileHeader'
+      ByteSize: 8
+      GoRuntimeType: 837472
+      GoKind: 22
+      Pointee: 50 StructureType mime/multipart.FileHeader
+    - __kind: PointerType
+      ID: 38
+      Name: '*mime/multipart.Form'
+      ByteSize: 8
+      GoRuntimeType: 837568
+      GoKind: 22
+      Pointee: 39 StructureType mime/multipart.Form
+    - __kind: PointerType
+      ID: 93
+      Name: '*net.IP'
+      ByteSize: 8
+      GoRuntimeType: 1.974688e+06
+      GoKind: 22
+      Pointee: 94 GoSliceHeaderType net.IP
+    - __kind: PointerType
+      ID: 187
+      Name: '*net.IP.array'
+      ByteSize: 8
+      Pointee: 186 GoSliceDataType net.IP.array
+    - __kind: PointerType
+      ID: 193
+      Name: '*net.IPMask.array'
+      ByteSize: 8
+      Pointee: 192 GoSliceDataType net.IPMask.array
+    - __kind: PointerType
+      ID: 99
+      Name: '*net.IPNet'
+      ByteSize: 8
+      GoRuntimeType: 1.095968e+06
+      GoKind: 22
+      Pointee: 100 StructureType net.IPNet
     - __kind: PointerType
       ID: 3
       Name: '*net/http.Request'
@@ -146,124 +475,27 @@ Types:
       GoRuntimeType: 2.15472e+06
       GoKind: 22
       Pointee: 4 StructureType net/http.Request
-    - __kind: StructureType
-      ID: 4
-      Name: net/http.Request
-      ByteSize: 304
-      GoRuntimeType: 2.190528e+06
-      GoKind: 25
-      RawFields:
-        - Name: Method
-          Offset: 0
-          Type: 5 GoStringHeaderType string
-        - Name: URL
-          Offset: 16
-          Type: 9 PointerType *net/url.URL
-        - Name: Proto
-          Offset: 24
-          Type: 5 GoStringHeaderType string
-        - Name: ProtoMajor
-          Offset: 40
-          Type: 8 BaseType int
-        - Name: ProtoMinor
-          Offset: 48
-          Type: 8 BaseType int
-        - Name: Header
-          Offset: 56
-          Type: 14 GoMapType net/http.Header
-        - Name: Body
-          Offset: 64
-          Type: 34 GoInterfaceType io.ReadCloser
-        - Name: GetBody
-          Offset: 80
-          Type: 35 GoSubroutineType func() (io.ReadCloser, error)
-        - Name: ContentLength
-          Offset: 88
-          Type: 36 BaseType int64
-        - Name: TransferEncoding
-          Offset: 96
-          Type: 24 GoSliceHeaderType []string
-        - Name: Close
-          Offset: 120
-          Type: 13 BaseType bool
-        - Name: Host
-          Offset: 128
-          Type: 5 GoStringHeaderType string
-        - Name: Form
-          Offset: 144
-          Type: 37 GoMapType net/url.Values
-        - Name: PostForm
-          Offset: 152
-          Type: 37 GoMapType net/url.Values
-        - Name: MultipartForm
-          Offset: 160
-          Type: 38 PointerType *mime/multipart.Form
-        - Name: Trailer
-          Offset: 168
-          Type: 14 GoMapType net/http.Header
-        - Name: RemoteAddr
-          Offset: 176
-          Type: 5 GoStringHeaderType string
-        - Name: RequestURI
-          Offset: 192
-          Type: 5 GoStringHeaderType string
-        - Name: TLS
-          Offset: 208
-          Type: 53 PointerType *crypto/tls.ConnectionState
-        - Name: Cancel
-          Offset: 216
-          Type: 111 GoChannelType <-chan struct {}
-        - Name: Response
-          Offset: 224
-          Type: 112 PointerType *net/http.Response
-        - Name: Pattern
-          Offset: 232
-          Type: 5 GoStringHeaderType string
-        - Name: ctx
-          Offset: 248
-          Type: 114 GoInterfaceType context.Context
-        - Name: pat
-          Offset: 264
-          Type: 115 PointerType *net/http.pattern
-        - Name: matches
-          Offset: 272
-          Type: 24 GoSliceHeaderType []string
-        - Name: otherValues
-          Offset: 296
-          Type: 120 GoMapType map[string]string
-    - __kind: GoStringHeaderType
-      ID: 5
-      Name: string
-      ByteSize: 16
-      GoRuntimeType: 533760
-      GoKind: 24
-      RawFields:
-        - Name: str
-          Offset: 0
-          Type: 155 PointerType *string.str
-        - Name: len
-          Offset: 8
-          Type: 8 BaseType int
-      Data: 154 GoStringDataType string.str
     - __kind: PointerType
-      ID: 6
-      Name: '*uint8'
+      ID: 112
+      Name: '*net/http.Response'
       ByteSize: 8
-      GoRuntimeType: 371808
+      GoRuntimeType: 1.591456e+06
       GoKind: 22
-      Pointee: 7 BaseType uint8
-    - __kind: BaseType
-      ID: 7
-      Name: uint8
-      ByteSize: 1
-      GoRuntimeType: 533888
-      GoKind: 8
-    - __kind: BaseType
-      ID: 8
-      Name: int
+      Pointee: 113 StructureType net/http.Response
+    - __kind: PointerType
+      ID: 115
+      Name: '*net/http.pattern'
       ByteSize: 8
-      GoRuntimeType: 534336
-      GoKind: 2
+      GoRuntimeType: 1.416576e+06
+      GoKind: 22
+      Pointee: 116 StructureType net/http.pattern
+    - __kind: PointerType
+      ID: 118
+      Name: '*net/http.segment'
+      ByteSize: 8
+      GoRuntimeType: 364064
+      GoKind: 22
+      Pointee: 119 StructureType net/http.segment
     - __kind: PointerType
       ID: 9
       Name: '*net/url.URL'
@@ -271,46 +503,6 @@ Types:
       GoRuntimeType: 1.94976e+06
       GoKind: 22
       Pointee: 10 StructureType net/url.URL
-    - __kind: StructureType
-      ID: 10
-      Name: net/url.URL
-      ByteSize: 144
-      GoRuntimeType: 1.986816e+06
-      GoKind: 25
-      RawFields:
-        - Name: Scheme
-          Offset: 0
-          Type: 5 GoStringHeaderType string
-        - Name: Opaque
-          Offset: 16
-          Type: 5 GoStringHeaderType string
-        - Name: User
-          Offset: 32
-          Type: 11 PointerType *net/url.Userinfo
-        - Name: Host
-          Offset: 40
-          Type: 5 GoStringHeaderType string
-        - Name: Path
-          Offset: 56
-          Type: 5 GoStringHeaderType string
-        - Name: RawPath
-          Offset: 72
-          Type: 5 GoStringHeaderType string
-        - Name: OmitHost
-          Offset: 88
-          Type: 13 BaseType bool
-        - Name: ForceQuery
-          Offset: 89
-          Type: 13 BaseType bool
-        - Name: RawQuery
-          Offset: 96
-          Type: 5 GoStringHeaderType string
-        - Name: Fragment
-          Offset: 112
-          Type: 5 GoStringHeaderType string
-        - Name: RawFragment
-          Offset: 128
-          Type: 5 GoStringHeaderType string
     - __kind: PointerType
       ID: 11
       Name: '*net/url.Userinfo'
@@ -318,110 +510,139 @@ Types:
       GoRuntimeType: 1.1144e+06
       GoKind: 22
       Pointee: 12 StructureType net/url.Userinfo
-    - __kind: StructureType
-      ID: 12
-      Name: net/url.Userinfo
-      ByteSize: 40
-      GoRuntimeType: 1.433088e+06
-      GoKind: 25
-      RawFields:
-        - Name: username
-          Offset: 0
-          Type: 5 GoStringHeaderType string
-        - Name: password
-          Offset: 16
-          Type: 5 GoStringHeaderType string
-        - Name: passwordSet
-          Offset: 32
-          Type: 13 BaseType bool
-    - __kind: BaseType
-      ID: 13
-      Name: bool
-      ByteSize: 1
-      GoRuntimeType: 534784
-      GoKind: 1
-    - __kind: GoMapType
-      ID: 14
-      Name: net/http.Header
-      ByteSize: 8
-      GoRuntimeType: 1.917984e+06
-      GoKind: 21
-      HeaderType: 16 GoHMapHeaderType hash<string,[]string>
     - __kind: PointerType
-      ID: 15
-      Name: '*hash<string,[]string>'
+      ID: 32
+      Name: '*runtime.bmap'
       ByteSize: 8
-      Pointee: 16 GoHMapHeaderType hash<string,[]string>
-    - __kind: GoHMapHeaderType
-      ID: 16
-      Name: hash<string,[]string>
-      ByteSize: 48
-      RawFields:
-        - Name: count
-          Offset: 0
-          Type: 8 BaseType int
-        - Name: flags
-          Offset: 8
-          Type: 7 BaseType uint8
-        - Name: B
-          Offset: 9
-          Type: 7 BaseType uint8
-        - Name: noverflow
-          Offset: 10
-          Type: 17 BaseType uint16
-        - Name: hash0
-          Offset: 12
-          Type: 18 BaseType uint32
-        - Name: buckets
-          Offset: 16
-          Type: 19 PointerType *bucket<string,[]string>
-        - Name: oldbuckets
-          Offset: 24
-          Type: 19 PointerType *bucket<string,[]string>
-        - Name: nevacuate
-          Offset: 32
-          Type: 26 BaseType uintptr
-        - Name: extra
-          Offset: 40
-          Type: 27 PointerType *runtime.mapextra
-      BucketType: 20 GoHMapBucketType bucket<string,[]string>
-      BucketsType: 156 GoSliceDataType []bucket<string,[]string>.array
-    - __kind: BaseType
-      ID: 17
-      Name: uint16
-      ByteSize: 2
-      GoRuntimeType: 534016
-      GoKind: 9
-    - __kind: BaseType
-      ID: 18
-      Name: uint32
-      ByteSize: 4
-      GoRuntimeType: 534144
-      GoKind: 10
+      GoRuntimeType: 1.110048e+06
+      GoKind: 22
+      Pointee: 33 StructureType runtime.bmap
     - __kind: PointerType
-      ID: 19
-      Name: '*bucket<string,[]string>'
+      ID: 27
+      Name: '*runtime.mapextra'
       ByteSize: 8
-      Pointee: 20 GoHMapBucketType bucket<string,[]string>
-    - __kind: GoHMapBucketType
-      ID: 20
-      Name: bucket<string,[]string>
-      ByteSize: 336
-      RawFields:
-        - Name: tophash
-          Offset: 0
-          Type: 21 ArrayType [8]uint8
-        - Name: keys
-          Offset: 8
-          Type: 22 ArrayType []key<string>
-        - Name: values
-          Offset: 136
-          Type: 23 ArrayType []val<[]string>
-        - Name: overflow
-          Offset: 328
-          Type: 19 PointerType *bucket<string,[]string>
-      KeyType: 5 GoStringHeaderType string
-      ValueType: 24 GoSliceHeaderType []string
+      GoRuntimeType: 375584
+      GoKind: 22
+      Pointee: 28 StructureType runtime.mapextra
+    - __kind: PointerType
+      ID: 25
+      Name: '*string'
+      ByteSize: 8
+      GoRuntimeType: 371680
+      GoKind: 22
+      Pointee: 5 GoStringHeaderType string
+    - __kind: PointerType
+      ID: 155
+      Name: '*string.str'
+      ByteSize: 8
+      Pointee: 154 GoStringDataType string.str
+    - __kind: PointerType
+      ID: 75
+      Name: '*time.Location'
+      ByteSize: 8
+      GoRuntimeType: 1.421568e+06
+      GoKind: 22
+      Pointee: 76 StructureType time.Location
+    - __kind: PointerType
+      ID: 78
+      Name: '*time.zone'
+      ByteSize: 8
+      GoRuntimeType: 367136
+      GoKind: 22
+      Pointee: 79 StructureType time.zone
+    - __kind: PointerType
+      ID: 81
+      Name: '*time.zoneTrans'
+      ByteSize: 8
+      GoRuntimeType: 367200
+      GoKind: 22
+      Pointee: 82 StructureType time.zoneTrans
+    - __kind: PointerType
+      ID: 152
+      Name: '*uint'
+      ByteSize: 8
+      GoRuntimeType: 372320
+      GoKind: 22
+      Pointee: 134 BaseType uint
+    - __kind: PointerType
+      ID: 148
+      Name: '*uint16'
+      ByteSize: 8
+      GoRuntimeType: 371936
+      GoKind: 22
+      Pointee: 17 BaseType uint16
+    - __kind: PointerType
+      ID: 141
+      Name: '*uint32'
+      ByteSize: 8
+      GoRuntimeType: 372064
+      GoKind: 22
+      Pointee: 18 BaseType uint32
+    - __kind: PointerType
+      ID: 147
+      Name: '*uint64'
+      ByteSize: 8
+      GoRuntimeType: 372192
+      GoKind: 22
+      Pointee: 74 BaseType uint64
+    - __kind: PointerType
+      ID: 6
+      Name: '*uint8'
+      ByteSize: 8
+      GoRuntimeType: 371808
+      GoKind: 22
+      Pointee: 7 BaseType uint8
+    - __kind: PointerType
+      ID: 133
+      Name: '*uintptr'
+      ByteSize: 8
+      GoRuntimeType: 372384
+      GoKind: 22
+      Pointee: 26 BaseType uintptr
+    - __kind: GoChannelType
+      ID: 111
+      Name: <-chan struct {}
+      GoRuntimeType: 546944
+      GoKind: 18
+    - __kind: EventRootType
+      ID: 203
+      Name: Probe[main.HandleHTTP]
+      ByteSize: 25
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: w
+          Offset: 1
+          Expression:
+            Type: 1 GoInterfaceType net/http.ResponseWriter
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 1, index: 0, name: w}
+                  Offset: 0
+                  ByteSize: 16
+        - Name: r
+          Offset: 17
+          Expression:
+            Type: 3 PointerType *net/http.Request
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 1, index: 1, name: r}
+                  Offset: 0
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 204
+      Name: Probe[main.LookAtTheRequest]
+      ByteSize: 17
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: path
+          Offset: 1
+          Expression:
+            Type: 5 GoStringHeaderType string
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 2, index: 0, name: path}
+                  Offset: 0
+                  ByteSize: 16
     - __kind: ArrayType
       ID: 21
       Name: '[8]uint8'
@@ -431,80 +652,94 @@ Types:
       Count: 8
       HasCount: true
       Element: 7 BaseType uint8
-    - __kind: ArrayType
-      ID: 22
-      Name: '[]key<string>'
-      ByteSize: 128
-      Count: 8
-      HasCount: true
-      Element: 5 GoStringHeaderType string
-    - __kind: ArrayType
-      ID: 23
-      Name: '[]val<[]string>'
-      ByteSize: 192
-      Count: 8
-      HasCount: true
-      Element: 24 GoSliceHeaderType []string
     - __kind: GoSliceHeaderType
-      ID: 24
-      Name: '[]string'
+      ID: 55
+      Name: '[]*crypto/x509.Certificate'
       ByteSize: 24
-      GoRuntimeType: 464768
+      GoRuntimeType: 469664
       GoKind: 23
       RawFields:
         - Name: array
           Offset: 0
-          Type: 25 PointerType *string
+          Type: 56 PointerType **crypto/x509.Certificate
         - Name: len
           Offset: 8
           Type: 8 BaseType int
         - Name: cap
           Offset: 16
           Type: 8 BaseType int
-      Data: 157 GoSliceDataType []string.array
-    - __kind: PointerType
-      ID: 25
-      Name: '*string'
-      ByteSize: 8
-      GoRuntimeType: 371680
-      GoKind: 22
-      Pointee: 5 GoStringHeaderType string
-    - __kind: BaseType
-      ID: 26
-      Name: uintptr
-      ByteSize: 8
-      GoRuntimeType: 534464
-      GoKind: 12
-    - __kind: PointerType
-      ID: 27
-      Name: '*runtime.mapextra'
-      ByteSize: 8
-      GoRuntimeType: 375584
-      GoKind: 22
-      Pointee: 28 StructureType runtime.mapextra
-    - __kind: StructureType
-      ID: 28
-      Name: runtime.mapextra
+      Data: 166 GoSliceDataType []*crypto/x509.Certificate.array
+    - __kind: GoSliceDataType
+      ID: 166
+      Name: '[]*crypto/x509.Certificate.array'
+      ByteSize: 2048
+      Element: 57 PointerType *crypto/x509.Certificate
+    - __kind: GoSliceHeaderType
+      ID: 47
+      Name: '[]*mime/multipart.FileHeader'
       ByteSize: 24
-      GoRuntimeType: 1.429056e+06
-      GoKind: 25
+      GoRuntimeType: 457504
+      GoKind: 23
       RawFields:
-        - Name: overflow
+        - Name: array
           Offset: 0
-          Type: 29 PointerType *[]*runtime.bmap
-        - Name: oldoverflow
+          Type: 48 PointerType **mime/multipart.FileHeader
+        - Name: len
           Offset: 8
-          Type: 29 PointerType *[]*runtime.bmap
-        - Name: nextOverflow
+          Type: 8 BaseType int
+        - Name: cap
           Offset: 16
-          Type: 32 PointerType *runtime.bmap
-    - __kind: PointerType
-      ID: 29
-      Name: '*[]*runtime.bmap'
-      ByteSize: 8
-      GoRuntimeType: 466496
-      GoKind: 22
-      Pointee: 30 GoSliceHeaderType []*runtime.bmap
+          Type: 8 BaseType int
+      Data: 162 GoSliceDataType []*mime/multipart.FileHeader.array
+    - __kind: GoSliceDataType
+      ID: 162
+      Name: '[]*mime/multipart.FileHeader.array'
+      ByteSize: 2048
+      Element: 49 PointerType *mime/multipart.FileHeader
+    - __kind: GoSliceHeaderType
+      ID: 97
+      Name: '[]*net.IPNet'
+      ByteSize: 24
+      GoRuntimeType: 481696
+      GoKind: 23
+      RawFields:
+        - Name: array
+          Offset: 0
+          Type: 98 PointerType **net.IPNet
+        - Name: len
+          Offset: 8
+          Type: 8 BaseType int
+        - Name: cap
+          Offset: 16
+          Type: 8 BaseType int
+      Data: 190 GoSliceDataType []*net.IPNet.array
+    - __kind: GoSliceDataType
+      ID: 190
+      Name: '[]*net.IPNet.array'
+      ByteSize: 2048
+      Element: 99 PointerType *net.IPNet
+    - __kind: GoSliceHeaderType
+      ID: 95
+      Name: '[]*net/url.URL'
+      ByteSize: 24
+      GoRuntimeType: 481632
+      GoKind: 23
+      RawFields:
+        - Name: array
+          Offset: 0
+          Type: 96 PointerType **net/url.URL
+        - Name: len
+          Offset: 8
+          Type: 8 BaseType int
+        - Name: cap
+          Offset: 16
+          Type: 8 BaseType int
+      Data: 188 GoSliceDataType []*net/url.URL.array
+    - __kind: GoSliceDataType
+      ID: 188
+      Name: '[]*net/url.URL.array'
+      ByteSize: 2048
+      Element: 9 PointerType *net/url.URL
     - __kind: GoSliceHeaderType
       ID: 30
       Name: '[]*runtime.bmap'
@@ -522,138 +757,346 @@ Types:
           Offset: 16
           Type: 8 BaseType int
       Data: 159 GoSliceDataType []*runtime.bmap.array
-    - __kind: PointerType
-      ID: 31
-      Name: '**runtime.bmap'
-      ByteSize: 8
-      Pointee: 32 PointerType *runtime.bmap
-    - __kind: PointerType
-      ID: 32
-      Name: '*runtime.bmap'
-      ByteSize: 8
-      GoRuntimeType: 1.110048e+06
-      GoKind: 22
-      Pointee: 33 StructureType runtime.bmap
-    - __kind: StructureType
-      ID: 33
-      Name: runtime.bmap
-      ByteSize: 8
-      GoRuntimeType: 1.10992e+06
-      GoKind: 25
+    - __kind: GoSliceDataType
+      ID: 159
+      Name: '[]*runtime.bmap.array'
+      ByteSize: 2048
+      Element: 32 PointerType *runtime.bmap
+    - __kind: GoSliceHeaderType
+      ID: 105
+      Name: '[][]*crypto/x509.Certificate'
+      ByteSize: 24
+      GoRuntimeType: 469792
+      GoKind: 23
       RawFields:
-        - Name: tophash
+        - Name: array
           Offset: 0
-          Type: 21 ArrayType [8]uint8
-    - __kind: GoInterfaceType
-      ID: 34
-      Name: io.ReadCloser
-      ByteSize: 16
-      GoRuntimeType: 1.067328e+06
-      GoKind: 20
-      RawFields:
-        - Name: tab
-          Offset: 0
-          Type: 2 VoidPointerType unsafe.Pointer
-        - Name: data
+          Type: 106 PointerType *[]*crypto/x509.Certificate
+        - Name: len
           Offset: 8
-          Type: 2 VoidPointerType unsafe.Pointer
-    - __kind: GoSubroutineType
-      ID: 35
-      Name: func() (io.ReadCloser, error)
-      ByteSize: 8
-      GoRuntimeType: 634400
-      GoKind: 19
-    - __kind: BaseType
-      ID: 36
-      Name: int64
-      ByteSize: 8
-      GoRuntimeType: 534208
-      GoKind: 6
-    - __kind: GoMapType
-      ID: 37
-      Name: net/url.Values
-      ByteSize: 8
-      GoRuntimeType: 1.671328e+06
-      GoKind: 21
-      HeaderType: 16 GoHMapHeaderType hash<string,[]string>
-    - __kind: PointerType
-      ID: 38
-      Name: '*mime/multipart.Form'
-      ByteSize: 8
-      GoRuntimeType: 837568
-      GoKind: 22
-      Pointee: 39 StructureType mime/multipart.Form
-    - __kind: StructureType
-      ID: 39
-      Name: mime/multipart.Form
-      ByteSize: 16
-      GoRuntimeType: 1.294528e+06
-      GoKind: 25
-      RawFields:
-        - Name: Value
-          Offset: 0
-          Type: 40 GoMapType map[string][]string
-        - Name: File
-          Offset: 8
-          Type: 41 GoMapType map[string][]*mime/multipart.FileHeader
-    - __kind: GoMapType
-      ID: 40
-      Name: map[string][]string
-      ByteSize: 8
-      GoRuntimeType: 882592
-      GoKind: 21
-      HeaderType: 16 GoHMapHeaderType hash<string,[]string>
-    - __kind: GoMapType
-      ID: 41
-      Name: map[string][]*mime/multipart.FileHeader
-      ByteSize: 8
-      GoRuntimeType: 887392
-      GoKind: 21
-      HeaderType: 43 GoHMapHeaderType hash<string,[]*mime/multipart.FileHeader>
-    - __kind: PointerType
-      ID: 42
-      Name: '*hash<string,[]*mime/multipart.FileHeader>'
-      ByteSize: 8
-      Pointee: 43 GoHMapHeaderType hash<string,[]*mime/multipart.FileHeader>
-    - __kind: GoHMapHeaderType
-      ID: 43
-      Name: hash<string,[]*mime/multipart.FileHeader>
-      ByteSize: 48
-      RawFields:
-        - Name: count
-          Offset: 0
           Type: 8 BaseType int
-        - Name: flags
-          Offset: 8
-          Type: 7 BaseType uint8
-        - Name: B
-          Offset: 9
-          Type: 7 BaseType uint8
-        - Name: noverflow
-          Offset: 10
-          Type: 17 BaseType uint16
-        - Name: hash0
-          Offset: 12
-          Type: 18 BaseType uint32
-        - Name: buckets
+        - Name: cap
           Offset: 16
-          Type: 44 PointerType *bucket<string,[]*mime/multipart.FileHeader>
-        - Name: oldbuckets
-          Offset: 24
-          Type: 44 PointerType *bucket<string,[]*mime/multipart.FileHeader>
-        - Name: nevacuate
-          Offset: 32
-          Type: 26 BaseType uintptr
-        - Name: extra
-          Offset: 40
-          Type: 27 PointerType *runtime.mapextra
-      BucketType: 45 GoHMapBucketType bucket<string,[]*mime/multipart.FileHeader>
-      BucketsType: 161 GoSliceDataType []bucket<string,[]*mime/multipart.FileHeader>.array
-    - __kind: PointerType
-      ID: 44
-      Name: '*bucket<string,[]*mime/multipart.FileHeader>'
-      ByteSize: 8
-      Pointee: 45 GoHMapBucketType bucket<string,[]*mime/multipart.FileHeader>
+          Type: 8 BaseType int
+      Data: 196 GoSliceDataType [][]*crypto/x509.Certificate.array
+    - __kind: GoSliceDataType
+      ID: 196
+      Name: '[][]*crypto/x509.Certificate.array'
+      ByteSize: 2048
+      Element: 55 GoSliceHeaderType []*crypto/x509.Certificate
+    - __kind: GoSliceHeaderType
+      ID: 107
+      Name: '[][]uint8'
+      ByteSize: 24
+      GoRuntimeType: 452960
+      GoKind: 23
+      RawFields:
+        - Name: array
+          Offset: 0
+          Type: 108 PointerType *[]uint8
+        - Name: len
+          Offset: 8
+          Type: 8 BaseType int
+        - Name: cap
+          Offset: 16
+          Type: 8 BaseType int
+      Data: 198 GoSliceDataType [][]uint8.array
+    - __kind: GoSliceDataType
+      ID: 198
+      Name: '[][]uint8.array'
+      ByteSize: 2048
+      Element: 52 GoSliceHeaderType []uint8
+    - __kind: GoSliceDataType
+      ID: 161
+      Name: '[]bucket<string,[]*mime/multipart.FileHeader>.array'
+      ByteSize: 2048
+      Element: 45 GoHMapBucketType bucket<string,[]*mime/multipart.FileHeader>
+    - __kind: GoSliceDataType
+      ID: 156
+      Name: '[]bucket<string,[]string>.array'
+      ByteSize: 2048
+      Element: 20 GoHMapBucketType bucket<string,[]string>
+    - __kind: GoSliceDataType
+      ID: 202
+      Name: '[]bucket<string,string>.array'
+      ByteSize: 2048
+      Element: 124 GoHMapBucketType bucket<string,string>
+    - __kind: GoSliceHeaderType
+      ID: 89
+      Name: '[]crypto/x509.ExtKeyUsage'
+      ByteSize: 24
+      GoRuntimeType: 470944
+      GoKind: 23
+      RawFields:
+        - Name: array
+          Offset: 0
+          Type: 90 PointerType *crypto/x509.ExtKeyUsage
+        - Name: len
+          Offset: 8
+          Type: 8 BaseType int
+        - Name: cap
+          Offset: 16
+          Type: 8 BaseType int
+      Data: 182 GoSliceDataType []crypto/x509.ExtKeyUsage.array
+    - __kind: GoSliceDataType
+      ID: 182
+      Name: '[]crypto/x509.ExtKeyUsage.array'
+      ByteSize: 2048
+      Element: 91 BaseType crypto/x509.ExtKeyUsage
+    - __kind: GoSliceHeaderType
+      ID: 102
+      Name: '[]crypto/x509.OID'
+      ByteSize: 24
+      GoRuntimeType: 481760
+      GoKind: 23
+      RawFields:
+        - Name: array
+          Offset: 0
+          Type: 103 PointerType *crypto/x509.OID
+        - Name: len
+          Offset: 8
+          Type: 8 BaseType int
+        - Name: cap
+          Offset: 16
+          Type: 8 BaseType int
+      Data: 194 GoSliceDataType []crypto/x509.OID.array
+    - __kind: GoSliceDataType
+      ID: 194
+      Name: '[]crypto/x509.OID.array'
+      ByteSize: 2048
+      Element: 104 StructureType crypto/x509.OID
+    - __kind: GoSliceHeaderType
+      ID: 68
+      Name: '[]crypto/x509/pkix.AttributeTypeAndValue'
+      ByteSize: 24
+      GoRuntimeType: 482016
+      GoKind: 23
+      RawFields:
+        - Name: array
+          Offset: 0
+          Type: 69 PointerType *crypto/x509/pkix.AttributeTypeAndValue
+        - Name: len
+          Offset: 8
+          Type: 8 BaseType int
+        - Name: cap
+          Offset: 16
+          Type: 8 BaseType int
+      Data: 170 GoSliceDataType []crypto/x509/pkix.AttributeTypeAndValue.array
+    - __kind: GoSliceDataType
+      ID: 170
+      Name: '[]crypto/x509/pkix.AttributeTypeAndValue.array'
+      ByteSize: 2048
+      Element: 70 StructureType crypto/x509/pkix.AttributeTypeAndValue
+    - __kind: GoSliceHeaderType
+      ID: 84
+      Name: '[]crypto/x509/pkix.Extension'
+      ByteSize: 24
+      GoRuntimeType: 481504
+      GoKind: 23
+      RawFields:
+        - Name: array
+          Offset: 0
+          Type: 85 PointerType *crypto/x509/pkix.Extension
+        - Name: len
+          Offset: 8
+          Type: 8 BaseType int
+        - Name: cap
+          Offset: 16
+          Type: 8 BaseType int
+      Data: 178 GoSliceDataType []crypto/x509/pkix.Extension.array
+    - __kind: GoSliceDataType
+      ID: 178
+      Name: '[]crypto/x509/pkix.Extension.array'
+      ByteSize: 2048
+      Element: 86 StructureType crypto/x509/pkix.Extension
+    - __kind: GoSliceHeaderType
+      ID: 87
+      Name: '[]encoding/asn1.ObjectIdentifier'
+      ByteSize: 24
+      GoRuntimeType: 481568
+      GoKind: 23
+      RawFields:
+        - Name: array
+          Offset: 0
+          Type: 88 PointerType *encoding/asn1.ObjectIdentifier
+        - Name: len
+          Offset: 8
+          Type: 8 BaseType int
+        - Name: cap
+          Offset: 16
+          Type: 8 BaseType int
+      Data: 180 GoSliceDataType []encoding/asn1.ObjectIdentifier.array
+    - __kind: GoSliceDataType
+      ID: 180
+      Name: '[]encoding/asn1.ObjectIdentifier.array'
+      ByteSize: 2048
+      Element: 71 GoSliceHeaderType encoding/asn1.ObjectIdentifier
+    - __kind: ArrayType
+      ID: 22
+      Name: '[]key<string>'
+      ByteSize: 128
+      Count: 8
+      HasCount: true
+      Element: 5 GoStringHeaderType string
+    - __kind: GoSliceHeaderType
+      ID: 92
+      Name: '[]net.IP'
+      ByteSize: 24
+      GoRuntimeType: 454176
+      GoKind: 23
+      RawFields:
+        - Name: array
+          Offset: 0
+          Type: 93 PointerType *net.IP
+        - Name: len
+          Offset: 8
+          Type: 8 BaseType int
+        - Name: cap
+          Offset: 16
+          Type: 8 BaseType int
+      Data: 184 GoSliceDataType []net.IP.array
+    - __kind: GoSliceDataType
+      ID: 184
+      Name: '[]net.IP.array'
+      ByteSize: 2048
+      Element: 94 GoSliceHeaderType net.IP
+    - __kind: GoSliceHeaderType
+      ID: 117
+      Name: '[]net/http.segment'
+      ByteSize: 24
+      GoRuntimeType: 454944
+      GoKind: 23
+      RawFields:
+        - Name: array
+          Offset: 0
+          Type: 118 PointerType *net/http.segment
+        - Name: len
+          Offset: 8
+          Type: 8 BaseType int
+        - Name: cap
+          Offset: 16
+          Type: 8 BaseType int
+      Data: 200 GoSliceDataType []net/http.segment.array
+    - __kind: GoSliceDataType
+      ID: 200
+      Name: '[]net/http.segment.array'
+      ByteSize: 2048
+      Element: 119 StructureType net/http.segment
+    - __kind: GoSliceHeaderType
+      ID: 24
+      Name: '[]string'
+      ByteSize: 24
+      GoRuntimeType: 464768
+      GoKind: 23
+      RawFields:
+        - Name: array
+          Offset: 0
+          Type: 25 PointerType *string
+        - Name: len
+          Offset: 8
+          Type: 8 BaseType int
+        - Name: cap
+          Offset: 16
+          Type: 8 BaseType int
+      Data: 157 GoSliceDataType []string.array
+    - __kind: GoSliceDataType
+      ID: 157
+      Name: '[]string.array'
+      ByteSize: 2048
+      Element: 5 GoStringHeaderType string
+    - __kind: GoSliceHeaderType
+      ID: 77
+      Name: '[]time.zone'
+      ByteSize: 24
+      GoRuntimeType: 459168
+      GoKind: 23
+      RawFields:
+        - Name: array
+          Offset: 0
+          Type: 78 PointerType *time.zone
+        - Name: len
+          Offset: 8
+          Type: 8 BaseType int
+        - Name: cap
+          Offset: 16
+          Type: 8 BaseType int
+      Data: 174 GoSliceDataType []time.zone.array
+    - __kind: GoSliceDataType
+      ID: 174
+      Name: '[]time.zone.array'
+      ByteSize: 2048
+      Element: 79 StructureType time.zone
+    - __kind: GoSliceHeaderType
+      ID: 80
+      Name: '[]time.zoneTrans'
+      ByteSize: 24
+      GoRuntimeType: 459232
+      GoKind: 23
+      RawFields:
+        - Name: array
+          Offset: 0
+          Type: 81 PointerType *time.zoneTrans
+        - Name: len
+          Offset: 8
+          Type: 8 BaseType int
+        - Name: cap
+          Offset: 16
+          Type: 8 BaseType int
+      Data: 176 GoSliceDataType []time.zoneTrans.array
+    - __kind: GoSliceDataType
+      ID: 176
+      Name: '[]time.zoneTrans.array'
+      ByteSize: 2048
+      Element: 82 StructureType time.zoneTrans
+    - __kind: GoSliceHeaderType
+      ID: 52
+      Name: '[]uint8'
+      ByteSize: 24
+      GoRuntimeType: 463616
+      GoKind: 23
+      RawFields:
+        - Name: array
+          Offset: 0
+          Type: 6 PointerType *uint8
+        - Name: len
+          Offset: 8
+          Type: 8 BaseType int
+        - Name: cap
+          Offset: 16
+          Type: 8 BaseType int
+      Data: 164 GoSliceDataType []uint8.array
+    - __kind: GoSliceDataType
+      ID: 164
+      Name: '[]uint8.array'
+      ByteSize: 2048
+      Element: 7 BaseType uint8
+    - __kind: ArrayType
+      ID: 46
+      Name: '[]val<[]*mime/multipart.FileHeader>'
+      ByteSize: 192
+      Count: 8
+      HasCount: true
+      Element: 47 GoSliceHeaderType []*mime/multipart.FileHeader
+    - __kind: ArrayType
+      ID: 23
+      Name: '[]val<[]string>'
+      ByteSize: 192
+      Count: 8
+      HasCount: true
+      Element: 24 GoSliceHeaderType []string
+    - __kind: ArrayType
+      ID: 125
+      Name: '[]val<string>'
+      ByteSize: 128
+      Count: 8
+      HasCount: true
+      Element: 5 GoStringHeaderType string
+    - __kind: BaseType
+      ID: 13
+      Name: bool
+      ByteSize: 1
+      GoRuntimeType: 534784
+      GoKind: 1
     - __kind: GoHMapBucketType
       ID: 45
       Name: bucket<string,[]*mime/multipart.FileHeader>
@@ -673,102 +1116,106 @@ Types:
           Type: 44 PointerType *bucket<string,[]*mime/multipart.FileHeader>
       KeyType: 5 GoStringHeaderType string
       ValueType: 47 GoSliceHeaderType []*mime/multipart.FileHeader
-    - __kind: ArrayType
-      ID: 46
-      Name: '[]val<[]*mime/multipart.FileHeader>'
-      ByteSize: 192
-      Count: 8
-      HasCount: true
-      Element: 47 GoSliceHeaderType []*mime/multipart.FileHeader
-    - __kind: GoSliceHeaderType
-      ID: 47
-      Name: '[]*mime/multipart.FileHeader'
-      ByteSize: 24
-      GoRuntimeType: 457504
-      GoKind: 23
+    - __kind: GoHMapBucketType
+      ID: 20
+      Name: bucket<string,[]string>
+      ByteSize: 336
       RawFields:
-        - Name: array
+        - Name: tophash
           Offset: 0
-          Type: 48 PointerType **mime/multipart.FileHeader
-        - Name: len
+          Type: 21 ArrayType [8]uint8
+        - Name: keys
           Offset: 8
-          Type: 8 BaseType int
-        - Name: cap
-          Offset: 16
-          Type: 8 BaseType int
-      Data: 162 GoSliceDataType []*mime/multipart.FileHeader.array
-    - __kind: PointerType
-      ID: 48
-      Name: '**mime/multipart.FileHeader'
-      ByteSize: 8
-      GoKind: 22
-      Pointee: 49 PointerType *mime/multipart.FileHeader
-    - __kind: PointerType
-      ID: 49
-      Name: '*mime/multipart.FileHeader'
-      ByteSize: 8
-      GoRuntimeType: 837472
-      GoKind: 22
-      Pointee: 50 StructureType mime/multipart.FileHeader
+          Type: 22 ArrayType []key<string>
+        - Name: values
+          Offset: 136
+          Type: 23 ArrayType []val<[]string>
+        - Name: overflow
+          Offset: 328
+          Type: 19 PointerType *bucket<string,[]string>
+      KeyType: 5 GoStringHeaderType string
+      ValueType: 24 GoSliceHeaderType []string
+    - __kind: GoHMapBucketType
+      ID: 124
+      Name: bucket<string,string>
+      ByteSize: 272
+      RawFields:
+        - Name: tophash
+          Offset: 0
+          Type: 21 ArrayType [8]uint8
+        - Name: keys
+          Offset: 8
+          Type: 22 ArrayType []key<string>
+        - Name: values
+          Offset: 136
+          Type: 125 ArrayType []val<string>
+        - Name: overflow
+          Offset: 264
+          Type: 123 PointerType *bucket<string,string>
+      KeyType: 5 GoStringHeaderType string
+      ValueType: 5 GoStringHeaderType string
     - __kind: StructureType
-      ID: 50
-      Name: mime/multipart.FileHeader
-      ByteSize: 88
-      GoRuntimeType: 1.83856e+06
+      ID: 127
+      Name: bytes.Buffer
+      ByteSize: 40
+      GoRuntimeType: 1.414272e+06
       GoKind: 25
       RawFields:
-        - Name: Filename
+        - Name: buf
           Offset: 0
-          Type: 5 GoStringHeaderType string
-        - Name: Header
-          Offset: 16
-          Type: 51 GoMapType net/textproto.MIMEHeader
-        - Name: Size
-          Offset: 24
-          Type: 36 BaseType int64
-        - Name: content
-          Offset: 32
           Type: 52 GoSliceHeaderType []uint8
-        - Name: tmpfile
-          Offset: 56
-          Type: 5 GoStringHeaderType string
-        - Name: tmpoff
-          Offset: 72
-          Type: 36 BaseType int64
-        - Name: tmpshared
-          Offset: 80
-          Type: 13 BaseType bool
-    - __kind: GoMapType
-      ID: 51
-      Name: net/textproto.MIMEHeader
+        - Name: off
+          Offset: 24
+          Type: 8 BaseType int
+        - Name: lastRead
+          Offset: 32
+          Type: 128 BaseType bytes.readOp
+    - __kind: BaseType
+      ID: 128
+      Name: bytes.readOp
+      ByteSize: 1
+      GoRuntimeType: 532992
+      GoKind: 3
+    - __kind: BaseType
+      ID: 144
+      Name: complex128
+      ByteSize: 16
+      GoRuntimeType: 534592
+      GoKind: 16
+    - __kind: BaseType
+      ID: 143
+      Name: complex64
       ByteSize: 8
-      GoRuntimeType: 1.596448e+06
-      GoKind: 21
-      HeaderType: 16 GoHMapHeaderType hash<string,[]string>
-    - __kind: GoSliceHeaderType
-      ID: 52
-      Name: '[]uint8'
-      ByteSize: 24
-      GoRuntimeType: 463616
-      GoKind: 23
+      GoRuntimeType: 534528
+      GoKind: 15
+    - __kind: GoInterfaceType
+      ID: 114
+      Name: context.Context
+      ByteSize: 16
+      GoRuntimeType: 1.187296e+06
+      GoKind: 20
       RawFields:
-        - Name: array
+        - Name: tab
           Offset: 0
-          Type: 6 PointerType *uint8
-        - Name: len
+          Type: 2 VoidPointerType unsafe.Pointer
+        - Name: data
           Offset: 8
-          Type: 8 BaseType int
-        - Name: cap
-          Offset: 16
-          Type: 8 BaseType int
-      Data: 164 GoSliceDataType []uint8.array
-    - __kind: PointerType
-      ID: 53
-      Name: '*crypto/tls.ConnectionState'
-      ByteSize: 8
-      GoRuntimeType: 836032
-      GoKind: 22
-      Pointee: 54 StructureType crypto/tls.ConnectionState
+          Type: 2 VoidPointerType unsafe.Pointer
+    - __kind: StructureType
+      ID: 130
+      Name: context.backgroundCtx
+      GoRuntimeType: 1.667744e+06
+      GoKind: 25
+      RawFields:
+        - Name: emptyCtx
+          Offset: 0
+          Type: 131 StructureType context.emptyCtx
+    - __kind: StructureType
+      ID: 131
+      Name: context.emptyCtx
+      GoRuntimeType: 1.399808e+06
+      GoKind: 25
+      RawFields: []
     - __kind: StructureType
       ID: 54
       Name: crypto/tls.ConnectionState
@@ -824,35 +1271,12 @@ Types:
         - Name: testingOnlyCurveID
           Offset: 186
           Type: 110 BaseType crypto/tls.CurveID
-    - __kind: GoSliceHeaderType
-      ID: 55
-      Name: '[]*crypto/x509.Certificate'
-      ByteSize: 24
-      GoRuntimeType: 469664
-      GoKind: 23
-      RawFields:
-        - Name: array
-          Offset: 0
-          Type: 56 PointerType **crypto/x509.Certificate
-        - Name: len
-          Offset: 8
-          Type: 8 BaseType int
-        - Name: cap
-          Offset: 16
-          Type: 8 BaseType int
-      Data: 166 GoSliceDataType []*crypto/x509.Certificate.array
-    - __kind: PointerType
-      ID: 56
-      Name: '**crypto/x509.Certificate'
-      ByteSize: 8
-      Pointee: 57 PointerType *crypto/x509.Certificate
-    - __kind: PointerType
-      ID: 57
-      Name: '*crypto/x509.Certificate'
-      ByteSize: 8
-      GoRuntimeType: 1.905824e+06
-      GoKind: 22
-      Pointee: 58 StructureType crypto/x509.Certificate
+    - __kind: BaseType
+      ID: 110
+      Name: crypto/tls.CurveID
+      ByteSize: 2
+      GoRuntimeType: 766144
+      GoKind: 9
     - __kind: StructureType
       ID: 58
       Name: crypto/x509.Certificate
@@ -996,80 +1420,68 @@ Types:
           Offset: 1328
           Type: 102 GoSliceHeaderType []crypto/x509.OID
     - __kind: BaseType
-      ID: 59
-      Name: crypto/x509.SignatureAlgorithm
+      ID: 91
+      Name: crypto/x509.ExtKeyUsage
       ByteSize: 8
-      GoRuntimeType: 1.071168e+06
+      GoRuntimeType: 537472
       GoKind: 2
+    - __kind: BaseType
+      ID: 83
+      Name: crypto/x509.KeyUsage
+      ByteSize: 8
+      GoRuntimeType: 537408
+      GoKind: 2
+    - __kind: StructureType
+      ID: 104
+      Name: crypto/x509.OID
+      ByteSize: 24
+      GoRuntimeType: 1.718016e+06
+      GoKind: 25
+      RawFields:
+        - Name: der
+          Offset: 0
+          Type: 52 GoSliceHeaderType []uint8
     - __kind: BaseType
       ID: 60
       Name: crypto/x509.PublicKeyAlgorithm
       ByteSize: 8
       GoRuntimeType: 768544
       GoKind: 2
-    - __kind: GoEmptyInterfaceType
-      ID: 61
-      Name: interface {}
-      ByteSize: 16
-      GoRuntimeType: 785472
-      GoKind: 20
-      RawFields:
-        - Name: _type
-          Offset: 0
-          Type: 2 VoidPointerType unsafe.Pointer
-        - Name: data
-          Offset: 8
-          Type: 2 VoidPointerType unsafe.Pointer
-    - __kind: PointerType
-      ID: 62
-      Name: '*math/big.Int'
+    - __kind: BaseType
+      ID: 59
+      Name: crypto/x509.SignatureAlgorithm
       ByteSize: 8
-      GoRuntimeType: 2.231648e+06
-      GoKind: 22
-      Pointee: 63 StructureType math/big.Int
+      GoRuntimeType: 1.071168e+06
+      GoKind: 2
     - __kind: StructureType
-      ID: 63
-      Name: math/big.Int
-      ByteSize: 32
-      GoRuntimeType: 1.308608e+06
+      ID: 70
+      Name: crypto/x509/pkix.AttributeTypeAndValue
+      ByteSize: 40
+      GoRuntimeType: 1.316608e+06
       GoKind: 25
       RawFields:
-        - Name: neg
+        - Name: Type
           Offset: 0
-          Type: 13 BaseType bool
-        - Name: abs
-          Offset: 8
-          Type: 64 GoSliceHeaderType math/big.nat
-    - __kind: GoSliceHeaderType
-      ID: 64
-      Name: math/big.nat
-      ByteSize: 24
-      GoRuntimeType: 2.214784e+06
-      GoKind: 23
+          Type: 71 GoSliceHeaderType encoding/asn1.ObjectIdentifier
+        - Name: Value
+          Offset: 24
+          Type: 61 GoEmptyInterfaceType interface {}
+    - __kind: StructureType
+      ID: 86
+      Name: crypto/x509/pkix.Extension
+      ByteSize: 56
+      GoRuntimeType: 1.45536e+06
+      GoKind: 25
       RawFields:
-        - Name: array
+        - Name: Id
           Offset: 0
-          Type: 65 PointerType *math/big.Word
-        - Name: len
-          Offset: 8
-          Type: 8 BaseType int
-        - Name: cap
-          Offset: 16
-          Type: 8 BaseType int
-      Data: 168 GoSliceDataType math/big.nat.array
-    - __kind: PointerType
-      ID: 65
-      Name: '*math/big.Word'
-      ByteSize: 8
-      GoRuntimeType: 397920
-      GoKind: 22
-      Pointee: 66 BaseType math/big.Word
-    - __kind: BaseType
-      ID: 66
-      Name: math/big.Word
-      ByteSize: 8
-      GoRuntimeType: 537728
-      GoKind: 7
+          Type: 71 GoSliceHeaderType encoding/asn1.ObjectIdentifier
+        - Name: Critical
+          Offset: 24
+          Type: 13 BaseType bool
+        - Name: Value
+          Offset: 32
+          Type: 52 GoSliceHeaderType []uint8
     - __kind: StructureType
       ID: 67
       Name: crypto/x509/pkix.Name
@@ -1111,43 +1523,6 @@ Types:
           Offset: 224
           Type: 68 GoSliceHeaderType []crypto/x509/pkix.AttributeTypeAndValue
     - __kind: GoSliceHeaderType
-      ID: 68
-      Name: '[]crypto/x509/pkix.AttributeTypeAndValue'
-      ByteSize: 24
-      GoRuntimeType: 482016
-      GoKind: 23
-      RawFields:
-        - Name: array
-          Offset: 0
-          Type: 69 PointerType *crypto/x509/pkix.AttributeTypeAndValue
-        - Name: len
-          Offset: 8
-          Type: 8 BaseType int
-        - Name: cap
-          Offset: 16
-          Type: 8 BaseType int
-      Data: 170 GoSliceDataType []crypto/x509/pkix.AttributeTypeAndValue.array
-    - __kind: PointerType
-      ID: 69
-      Name: '*crypto/x509/pkix.AttributeTypeAndValue'
-      ByteSize: 8
-      GoRuntimeType: 408928
-      GoKind: 22
-      Pointee: 70 StructureType crypto/x509/pkix.AttributeTypeAndValue
-    - __kind: StructureType
-      ID: 70
-      Name: crypto/x509/pkix.AttributeTypeAndValue
-      ByteSize: 40
-      GoRuntimeType: 1.316608e+06
-      GoKind: 25
-      RawFields:
-        - Name: Type
-          Offset: 0
-          Type: 71 GoSliceHeaderType encoding/asn1.ObjectIdentifier
-        - Name: Value
-          Offset: 24
-          Type: 61 GoEmptyInterfaceType interface {}
-    - __kind: GoSliceHeaderType
       ID: 71
       Name: encoding/asn1.ObjectIdentifier
       ByteSize: 24
@@ -1164,277 +1539,322 @@ Types:
           Offset: 16
           Type: 8 BaseType int
       Data: 172 GoSliceDataType encoding/asn1.ObjectIdentifier.array
-    - __kind: PointerType
-      ID: 72
-      Name: '*int'
-      ByteSize: 8
-      GoRuntimeType: 372256
-      GoKind: 22
-      Pointee: 8 BaseType int
-    - __kind: StructureType
-      ID: 73
-      Name: time.Time
-      ByteSize: 24
-      GoRuntimeType: 2.215712e+06
-      GoKind: 25
-      RawFields:
-        - Name: wall
-          Offset: 0
-          Type: 74 BaseType uint64
-        - Name: ext
-          Offset: 8
-          Type: 36 BaseType int64
-        - Name: loc
-          Offset: 16
-          Type: 75 PointerType *time.Location
-    - __kind: BaseType
-      ID: 74
-      Name: uint64
-      ByteSize: 8
-      GoRuntimeType: 534272
-      GoKind: 11
-    - __kind: PointerType
-      ID: 75
-      Name: '*time.Location'
-      ByteSize: 8
-      GoRuntimeType: 1.421568e+06
-      GoKind: 22
-      Pointee: 76 StructureType time.Location
-    - __kind: StructureType
-      ID: 76
-      Name: time.Location
-      ByteSize: 104
-      GoRuntimeType: 1.834528e+06
-      GoKind: 25
-      RawFields:
-        - Name: name
-          Offset: 0
-          Type: 5 GoStringHeaderType string
-        - Name: zone
-          Offset: 16
-          Type: 77 GoSliceHeaderType []time.zone
-        - Name: tx
-          Offset: 40
-          Type: 80 GoSliceHeaderType []time.zoneTrans
-        - Name: extend
-          Offset: 64
-          Type: 5 GoStringHeaderType string
-        - Name: cacheStart
-          Offset: 80
-          Type: 36 BaseType int64
-        - Name: cacheEnd
-          Offset: 88
-          Type: 36 BaseType int64
-        - Name: cacheZone
-          Offset: 96
-          Type: 78 PointerType *time.zone
-    - __kind: GoSliceHeaderType
-      ID: 77
-      Name: '[]time.zone'
-      ByteSize: 24
-      GoRuntimeType: 459168
-      GoKind: 23
-      RawFields:
-        - Name: array
-          Offset: 0
-          Type: 78 PointerType *time.zone
-        - Name: len
-          Offset: 8
-          Type: 8 BaseType int
-        - Name: cap
-          Offset: 16
-          Type: 8 BaseType int
-      Data: 174 GoSliceDataType []time.zone.array
-    - __kind: PointerType
-      ID: 78
-      Name: '*time.zone'
-      ByteSize: 8
-      GoRuntimeType: 367136
-      GoKind: 22
-      Pointee: 79 StructureType time.zone
-    - __kind: StructureType
-      ID: 79
-      Name: time.zone
-      ByteSize: 32
-      GoRuntimeType: 1.421376e+06
-      GoKind: 25
-      RawFields:
-        - Name: name
-          Offset: 0
-          Type: 5 GoStringHeaderType string
-        - Name: offset
-          Offset: 16
-          Type: 8 BaseType int
-        - Name: isDST
-          Offset: 24
-          Type: 13 BaseType bool
-    - __kind: GoSliceHeaderType
-      ID: 80
-      Name: '[]time.zoneTrans'
-      ByteSize: 24
-      GoRuntimeType: 459232
-      GoKind: 23
-      RawFields:
-        - Name: array
-          Offset: 0
-          Type: 81 PointerType *time.zoneTrans
-        - Name: len
-          Offset: 8
-          Type: 8 BaseType int
-        - Name: cap
-          Offset: 16
-          Type: 8 BaseType int
-      Data: 176 GoSliceDataType []time.zoneTrans.array
-    - __kind: PointerType
-      ID: 81
-      Name: '*time.zoneTrans'
-      ByteSize: 8
-      GoRuntimeType: 367200
-      GoKind: 22
-      Pointee: 82 StructureType time.zoneTrans
-    - __kind: StructureType
-      ID: 82
-      Name: time.zoneTrans
+    - __kind: GoSliceDataType
+      ID: 172
+      Name: encoding/asn1.ObjectIdentifier.array
+      ByteSize: 2048
+      Element: 8 BaseType int
+    - __kind: GoInterfaceType
+      ID: 139
+      Name: error
       ByteSize: 16
-      GoRuntimeType: 1.623872e+06
-      GoKind: 25
+      GoRuntimeType: 987648
+      GoKind: 20
       RawFields:
-        - Name: when
+        - Name: tab
           Offset: 0
-          Type: 36 BaseType int64
-        - Name: index
+          Type: 2 VoidPointerType unsafe.Pointer
+        - Name: data
+          Offset: 8
+          Type: 2 VoidPointerType unsafe.Pointer
+    - __kind: BaseType
+      ID: 137
+      Name: float32
+      ByteSize: 4
+      GoRuntimeType: 534656
+      GoKind: 13
+    - __kind: BaseType
+      ID: 138
+      Name: float64
+      ByteSize: 8
+      GoRuntimeType: 534720
+      GoKind: 14
+    - __kind: GoSubroutineType
+      ID: 35
+      Name: func() (io.ReadCloser, error)
+      ByteSize: 8
+      GoRuntimeType: 634400
+      GoKind: 19
+    - __kind: GoSubroutineType
+      ID: 109
+      Name: func(string, []uint8, int) ([]uint8, error)
+      ByteSize: 8
+      GoRuntimeType: 960448
+      GoKind: 19
+    - __kind: GoInterfaceType
+      ID: 129
+      Name: gopkg.in/DataDog/dd-trace-go.v1/ddtrace.Span
+      ByteSize: 16
+      GoRuntimeType: 1.296128e+06
+      GoKind: 20
+      RawFields:
+        - Name: tab
+          Offset: 0
+          Type: 2 VoidPointerType unsafe.Pointer
+        - Name: data
+          Offset: 8
+          Type: 2 VoidPointerType unsafe.Pointer
+    - __kind: GoHMapHeaderType
+      ID: 43
+      Name: hash<string,[]*mime/multipart.FileHeader>
+      ByteSize: 48
+      RawFields:
+        - Name: count
+          Offset: 0
+          Type: 8 BaseType int
+        - Name: flags
           Offset: 8
           Type: 7 BaseType uint8
-        - Name: isstd
+        - Name: B
           Offset: 9
-          Type: 13 BaseType bool
-        - Name: isutc
+          Type: 7 BaseType uint8
+        - Name: noverflow
           Offset: 10
-          Type: 13 BaseType bool
-    - __kind: BaseType
-      ID: 83
-      Name: crypto/x509.KeyUsage
-      ByteSize: 8
-      GoRuntimeType: 537408
-      GoKind: 2
-    - __kind: GoSliceHeaderType
-      ID: 84
-      Name: '[]crypto/x509/pkix.Extension'
-      ByteSize: 24
-      GoRuntimeType: 481504
-      GoKind: 23
-      RawFields:
-        - Name: array
-          Offset: 0
-          Type: 85 PointerType *crypto/x509/pkix.Extension
-        - Name: len
-          Offset: 8
-          Type: 8 BaseType int
-        - Name: cap
+          Type: 17 BaseType uint16
+        - Name: hash0
+          Offset: 12
+          Type: 18 BaseType uint32
+        - Name: buckets
           Offset: 16
+          Type: 44 PointerType *bucket<string,[]*mime/multipart.FileHeader>
+        - Name: oldbuckets
+          Offset: 24
+          Type: 44 PointerType *bucket<string,[]*mime/multipart.FileHeader>
+        - Name: nevacuate
+          Offset: 32
+          Type: 26 BaseType uintptr
+        - Name: extra
+          Offset: 40
+          Type: 27 PointerType *runtime.mapextra
+      BucketType: 45 GoHMapBucketType bucket<string,[]*mime/multipart.FileHeader>
+      BucketsType: 161 GoSliceDataType []bucket<string,[]*mime/multipart.FileHeader>.array
+    - __kind: GoHMapHeaderType
+      ID: 16
+      Name: hash<string,[]string>
+      ByteSize: 48
+      RawFields:
+        - Name: count
+          Offset: 0
           Type: 8 BaseType int
-      Data: 178 GoSliceDataType []crypto/x509/pkix.Extension.array
-    - __kind: PointerType
-      ID: 85
-      Name: '*crypto/x509/pkix.Extension'
+        - Name: flags
+          Offset: 8
+          Type: 7 BaseType uint8
+        - Name: B
+          Offset: 9
+          Type: 7 BaseType uint8
+        - Name: noverflow
+          Offset: 10
+          Type: 17 BaseType uint16
+        - Name: hash0
+          Offset: 12
+          Type: 18 BaseType uint32
+        - Name: buckets
+          Offset: 16
+          Type: 19 PointerType *bucket<string,[]string>
+        - Name: oldbuckets
+          Offset: 24
+          Type: 19 PointerType *bucket<string,[]string>
+        - Name: nevacuate
+          Offset: 32
+          Type: 26 BaseType uintptr
+        - Name: extra
+          Offset: 40
+          Type: 27 PointerType *runtime.mapextra
+      BucketType: 20 GoHMapBucketType bucket<string,[]string>
+      BucketsType: 156 GoSliceDataType []bucket<string,[]string>.array
+    - __kind: GoHMapHeaderType
+      ID: 122
+      Name: hash<string,string>
+      ByteSize: 48
+      RawFields:
+        - Name: count
+          Offset: 0
+          Type: 8 BaseType int
+        - Name: flags
+          Offset: 8
+          Type: 7 BaseType uint8
+        - Name: B
+          Offset: 9
+          Type: 7 BaseType uint8
+        - Name: noverflow
+          Offset: 10
+          Type: 17 BaseType uint16
+        - Name: hash0
+          Offset: 12
+          Type: 18 BaseType uint32
+        - Name: buckets
+          Offset: 16
+          Type: 123 PointerType *bucket<string,string>
+        - Name: oldbuckets
+          Offset: 24
+          Type: 123 PointerType *bucket<string,string>
+        - Name: nevacuate
+          Offset: 32
+          Type: 26 BaseType uintptr
+        - Name: extra
+          Offset: 40
+          Type: 27 PointerType *runtime.mapextra
+      BucketType: 124 GoHMapBucketType bucket<string,string>
+      BucketsType: 202 GoSliceDataType []bucket<string,string>.array
+    - __kind: BaseType
+      ID: 8
+      Name: int
       ByteSize: 8
-      GoRuntimeType: 409120
-      GoKind: 22
-      Pointee: 86 StructureType crypto/x509/pkix.Extension
+      GoRuntimeType: 534336
+      GoKind: 2
+    - __kind: BaseType
+      ID: 142
+      Name: int16
+      ByteSize: 2
+      GoRuntimeType: 533952
+      GoKind: 4
+    - __kind: BaseType
+      ID: 135
+      Name: int32
+      ByteSize: 4
+      GoRuntimeType: 534080
+      GoKind: 5
+    - __kind: BaseType
+      ID: 36
+      Name: int64
+      ByteSize: 8
+      GoRuntimeType: 534208
+      GoKind: 6
+    - __kind: BaseType
+      ID: 136
+      Name: int8
+      ByteSize: 1
+      GoRuntimeType: 533824
+      GoKind: 3
+    - __kind: GoEmptyInterfaceType
+      ID: 61
+      Name: interface {}
+      ByteSize: 16
+      GoRuntimeType: 785472
+      GoKind: 20
+      RawFields:
+        - Name: _type
+          Offset: 0
+          Type: 2 VoidPointerType unsafe.Pointer
+        - Name: data
+          Offset: 8
+          Type: 2 VoidPointerType unsafe.Pointer
+    - __kind: GoInterfaceType
+      ID: 34
+      Name: io.ReadCloser
+      ByteSize: 16
+      GoRuntimeType: 1.067328e+06
+      GoKind: 20
+      RawFields:
+        - Name: tab
+          Offset: 0
+          Type: 2 VoidPointerType unsafe.Pointer
+        - Name: data
+          Offset: 8
+          Type: 2 VoidPointerType unsafe.Pointer
+    - __kind: GoMapType
+      ID: 41
+      Name: map[string][]*mime/multipart.FileHeader
+      ByteSize: 8
+      GoRuntimeType: 887392
+      GoKind: 21
+      HeaderType: 43 GoHMapHeaderType hash<string,[]*mime/multipart.FileHeader>
+    - __kind: GoMapType
+      ID: 40
+      Name: map[string][]string
+      ByteSize: 8
+      GoRuntimeType: 882592
+      GoKind: 21
+      HeaderType: 16 GoHMapHeaderType hash<string,[]string>
+    - __kind: GoMapType
+      ID: 120
+      Name: map[string]string
+      ByteSize: 8
+      GoRuntimeType: 884224
+      GoKind: 21
+      HeaderType: 122 GoHMapHeaderType hash<string,string>
     - __kind: StructureType
-      ID: 86
-      Name: crypto/x509/pkix.Extension
-      ByteSize: 56
-      GoRuntimeType: 1.45536e+06
+      ID: 63
+      Name: math/big.Int
+      ByteSize: 32
+      GoRuntimeType: 1.308608e+06
       GoKind: 25
       RawFields:
-        - Name: Id
+        - Name: neg
           Offset: 0
-          Type: 71 GoSliceHeaderType encoding/asn1.ObjectIdentifier
-        - Name: Critical
-          Offset: 24
           Type: 13 BaseType bool
-        - Name: Value
+        - Name: abs
+          Offset: 8
+          Type: 64 GoSliceHeaderType math/big.nat
+    - __kind: BaseType
+      ID: 66
+      Name: math/big.Word
+      ByteSize: 8
+      GoRuntimeType: 537728
+      GoKind: 7
+    - __kind: GoSliceHeaderType
+      ID: 64
+      Name: math/big.nat
+      ByteSize: 24
+      GoRuntimeType: 2.214784e+06
+      GoKind: 23
+      RawFields:
+        - Name: array
+          Offset: 0
+          Type: 65 PointerType *math/big.Word
+        - Name: len
+          Offset: 8
+          Type: 8 BaseType int
+        - Name: cap
+          Offset: 16
+          Type: 8 BaseType int
+      Data: 168 GoSliceDataType math/big.nat.array
+    - __kind: GoSliceDataType
+      ID: 168
+      Name: math/big.nat.array
+      ByteSize: 2048
+      Element: 66 BaseType math/big.Word
+    - __kind: StructureType
+      ID: 50
+      Name: mime/multipart.FileHeader
+      ByteSize: 88
+      GoRuntimeType: 1.83856e+06
+      GoKind: 25
+      RawFields:
+        - Name: Filename
+          Offset: 0
+          Type: 5 GoStringHeaderType string
+        - Name: Header
+          Offset: 16
+          Type: 51 GoMapType net/textproto.MIMEHeader
+        - Name: Size
+          Offset: 24
+          Type: 36 BaseType int64
+        - Name: content
           Offset: 32
           Type: 52 GoSliceHeaderType []uint8
-    - __kind: GoSliceHeaderType
-      ID: 87
-      Name: '[]encoding/asn1.ObjectIdentifier'
-      ByteSize: 24
-      GoRuntimeType: 481568
-      GoKind: 23
+        - Name: tmpfile
+          Offset: 56
+          Type: 5 GoStringHeaderType string
+        - Name: tmpoff
+          Offset: 72
+          Type: 36 BaseType int64
+        - Name: tmpshared
+          Offset: 80
+          Type: 13 BaseType bool
+    - __kind: StructureType
+      ID: 39
+      Name: mime/multipart.Form
+      ByteSize: 16
+      GoRuntimeType: 1.294528e+06
+      GoKind: 25
       RawFields:
-        - Name: array
+        - Name: Value
           Offset: 0
-          Type: 88 PointerType *encoding/asn1.ObjectIdentifier
-        - Name: len
+          Type: 40 GoMapType map[string][]string
+        - Name: File
           Offset: 8
-          Type: 8 BaseType int
-        - Name: cap
-          Offset: 16
-          Type: 8 BaseType int
-      Data: 180 GoSliceDataType []encoding/asn1.ObjectIdentifier.array
-    - __kind: PointerType
-      ID: 88
-      Name: '*encoding/asn1.ObjectIdentifier'
-      ByteSize: 8
-      GoRuntimeType: 1.00992e+06
-      GoKind: 22
-      Pointee: 71 GoSliceHeaderType encoding/asn1.ObjectIdentifier
-    - __kind: GoSliceHeaderType
-      ID: 89
-      Name: '[]crypto/x509.ExtKeyUsage'
-      ByteSize: 24
-      GoRuntimeType: 470944
-      GoKind: 23
-      RawFields:
-        - Name: array
-          Offset: 0
-          Type: 90 PointerType *crypto/x509.ExtKeyUsage
-        - Name: len
-          Offset: 8
-          Type: 8 BaseType int
-        - Name: cap
-          Offset: 16
-          Type: 8 BaseType int
-      Data: 182 GoSliceDataType []crypto/x509.ExtKeyUsage.array
-    - __kind: PointerType
-      ID: 90
-      Name: '*crypto/x509.ExtKeyUsage'
-      ByteSize: 8
-      GoRuntimeType: 395104
-      GoKind: 22
-      Pointee: 91 BaseType crypto/x509.ExtKeyUsage
-    - __kind: BaseType
-      ID: 91
-      Name: crypto/x509.ExtKeyUsage
-      ByteSize: 8
-      GoRuntimeType: 537472
-      GoKind: 2
-    - __kind: GoSliceHeaderType
-      ID: 92
-      Name: '[]net.IP'
-      ByteSize: 24
-      GoRuntimeType: 454176
-      GoKind: 23
-      RawFields:
-        - Name: array
-          Offset: 0
-          Type: 93 PointerType *net.IP
-        - Name: len
-          Offset: 8
-          Type: 8 BaseType int
-        - Name: cap
-          Offset: 16
-          Type: 8 BaseType int
-      Data: 184 GoSliceDataType []net.IP.array
-    - __kind: PointerType
-      ID: 93
-      Name: '*net.IP'
-      ByteSize: 8
-      GoRuntimeType: 1.974688e+06
-      GoKind: 22
-      Pointee: 94 GoSliceHeaderType net.IP
+          Type: 41 GoMapType map[string][]*mime/multipart.FileHeader
     - __kind: GoSliceHeaderType
       ID: 94
       Name: net.IP
@@ -1452,71 +1872,11 @@ Types:
           Offset: 16
           Type: 8 BaseType int
       Data: 186 GoSliceDataType net.IP.array
-    - __kind: GoSliceHeaderType
-      ID: 95
-      Name: '[]*net/url.URL'
-      ByteSize: 24
-      GoRuntimeType: 481632
-      GoKind: 23
-      RawFields:
-        - Name: array
-          Offset: 0
-          Type: 96 PointerType **net/url.URL
-        - Name: len
-          Offset: 8
-          Type: 8 BaseType int
-        - Name: cap
-          Offset: 16
-          Type: 8 BaseType int
-      Data: 188 GoSliceDataType []*net/url.URL.array
-    - __kind: PointerType
-      ID: 96
-      Name: '**net/url.URL'
-      ByteSize: 8
-      Pointee: 9 PointerType *net/url.URL
-    - __kind: GoSliceHeaderType
-      ID: 97
-      Name: '[]*net.IPNet'
-      ByteSize: 24
-      GoRuntimeType: 481696
-      GoKind: 23
-      RawFields:
-        - Name: array
-          Offset: 0
-          Type: 98 PointerType **net.IPNet
-        - Name: len
-          Offset: 8
-          Type: 8 BaseType int
-        - Name: cap
-          Offset: 16
-          Type: 8 BaseType int
-      Data: 190 GoSliceDataType []*net.IPNet.array
-    - __kind: PointerType
-      ID: 98
-      Name: '**net.IPNet'
-      ByteSize: 8
-      GoKind: 22
-      Pointee: 99 PointerType *net.IPNet
-    - __kind: PointerType
-      ID: 99
-      Name: '*net.IPNet'
-      ByteSize: 8
-      GoRuntimeType: 1.095968e+06
-      GoKind: 22
-      Pointee: 100 StructureType net.IPNet
-    - __kind: StructureType
-      ID: 100
-      Name: net.IPNet
-      ByteSize: 48
-      GoRuntimeType: 1.276128e+06
-      GoKind: 25
-      RawFields:
-        - Name: IP
-          Offset: 0
-          Type: 94 GoSliceHeaderType net.IP
-        - Name: Mask
-          Offset: 24
-          Type: 101 GoSliceHeaderType net.IPMask
+    - __kind: GoSliceDataType
+      ID: 186
+      Name: net.IP.array
+      ByteSize: 2048
+      Element: 7 BaseType uint8
     - __kind: GoSliceHeaderType
       ID: 101
       Name: net.IPMask
@@ -1534,111 +1894,116 @@ Types:
           Offset: 16
           Type: 8 BaseType int
       Data: 192 GoSliceDataType net.IPMask.array
-    - __kind: GoSliceHeaderType
-      ID: 102
-      Name: '[]crypto/x509.OID'
-      ByteSize: 24
-      GoRuntimeType: 481760
-      GoKind: 23
-      RawFields:
-        - Name: array
-          Offset: 0
-          Type: 103 PointerType *crypto/x509.OID
-        - Name: len
-          Offset: 8
-          Type: 8 BaseType int
-        - Name: cap
-          Offset: 16
-          Type: 8 BaseType int
-      Data: 194 GoSliceDataType []crypto/x509.OID.array
-    - __kind: PointerType
-      ID: 103
-      Name: '*crypto/x509.OID'
-      ByteSize: 8
-      GoRuntimeType: 1.717792e+06
-      GoKind: 22
-      Pointee: 104 StructureType crypto/x509.OID
+    - __kind: GoSliceDataType
+      ID: 192
+      Name: net.IPMask.array
+      ByteSize: 2048
+      Element: 7 BaseType uint8
     - __kind: StructureType
-      ID: 104
-      Name: crypto/x509.OID
-      ByteSize: 24
-      GoRuntimeType: 1.718016e+06
+      ID: 100
+      Name: net.IPNet
+      ByteSize: 48
+      GoRuntimeType: 1.276128e+06
       GoKind: 25
       RawFields:
-        - Name: der
+        - Name: IP
           Offset: 0
-          Type: 52 GoSliceHeaderType []uint8
-    - __kind: GoSliceHeaderType
-      ID: 105
-      Name: '[][]*crypto/x509.Certificate'
-      ByteSize: 24
-      GoRuntimeType: 469792
-      GoKind: 23
+          Type: 94 GoSliceHeaderType net.IP
+        - Name: Mask
+          Offset: 24
+          Type: 101 GoSliceHeaderType net.IPMask
+    - __kind: GoMapType
+      ID: 14
+      Name: net/http.Header
+      ByteSize: 8
+      GoRuntimeType: 1.917984e+06
+      GoKind: 21
+      HeaderType: 16 GoHMapHeaderType hash<string,[]string>
+    - __kind: StructureType
+      ID: 4
+      Name: net/http.Request
+      ByteSize: 304
+      GoRuntimeType: 2.190528e+06
+      GoKind: 25
       RawFields:
-        - Name: array
+        - Name: Method
           Offset: 0
-          Type: 106 PointerType *[]*crypto/x509.Certificate
-        - Name: len
-          Offset: 8
-          Type: 8 BaseType int
-        - Name: cap
+          Type: 5 GoStringHeaderType string
+        - Name: URL
           Offset: 16
+          Type: 9 PointerType *net/url.URL
+        - Name: Proto
+          Offset: 24
+          Type: 5 GoStringHeaderType string
+        - Name: ProtoMajor
+          Offset: 40
           Type: 8 BaseType int
-      Data: 196 GoSliceDataType [][]*crypto/x509.Certificate.array
-    - __kind: PointerType
-      ID: 106
-      Name: '*[]*crypto/x509.Certificate'
-      ByteSize: 8
-      GoKind: 22
-      Pointee: 55 GoSliceHeaderType []*crypto/x509.Certificate
-    - __kind: GoSliceHeaderType
-      ID: 107
-      Name: '[][]uint8'
-      ByteSize: 24
-      GoRuntimeType: 452960
-      GoKind: 23
-      RawFields:
-        - Name: array
-          Offset: 0
-          Type: 108 PointerType *[]uint8
-        - Name: len
-          Offset: 8
+        - Name: ProtoMinor
+          Offset: 48
           Type: 8 BaseType int
-        - Name: cap
-          Offset: 16
-          Type: 8 BaseType int
-      Data: 198 GoSliceDataType [][]uint8.array
-    - __kind: PointerType
-      ID: 108
-      Name: '*[]uint8'
-      ByteSize: 8
-      GoRuntimeType: 452640
-      GoKind: 22
-      Pointee: 52 GoSliceHeaderType []uint8
-    - __kind: GoSubroutineType
-      ID: 109
-      Name: func(string, []uint8, int) ([]uint8, error)
-      ByteSize: 8
-      GoRuntimeType: 960448
-      GoKind: 19
-    - __kind: BaseType
-      ID: 110
-      Name: crypto/tls.CurveID
-      ByteSize: 2
-      GoRuntimeType: 766144
-      GoKind: 9
-    - __kind: GoChannelType
-      ID: 111
-      Name: <-chan struct {}
-      GoRuntimeType: 546944
-      GoKind: 18
-    - __kind: PointerType
-      ID: 112
-      Name: '*net/http.Response'
-      ByteSize: 8
-      GoRuntimeType: 1.591456e+06
-      GoKind: 22
-      Pointee: 113 StructureType net/http.Response
+        - Name: Header
+          Offset: 56
+          Type: 14 GoMapType net/http.Header
+        - Name: Body
+          Offset: 64
+          Type: 34 GoInterfaceType io.ReadCloser
+        - Name: GetBody
+          Offset: 80
+          Type: 35 GoSubroutineType func() (io.ReadCloser, error)
+        - Name: ContentLength
+          Offset: 88
+          Type: 36 BaseType int64
+        - Name: TransferEncoding
+          Offset: 96
+          Type: 24 GoSliceHeaderType []string
+        - Name: Close
+          Offset: 120
+          Type: 13 BaseType bool
+        - Name: Host
+          Offset: 128
+          Type: 5 GoStringHeaderType string
+        - Name: Form
+          Offset: 144
+          Type: 37 GoMapType net/url.Values
+        - Name: PostForm
+          Offset: 152
+          Type: 37 GoMapType net/url.Values
+        - Name: MultipartForm
+          Offset: 160
+          Type: 38 PointerType *mime/multipart.Form
+        - Name: Trailer
+          Offset: 168
+          Type: 14 GoMapType net/http.Header
+        - Name: RemoteAddr
+          Offset: 176
+          Type: 5 GoStringHeaderType string
+        - Name: RequestURI
+          Offset: 192
+          Type: 5 GoStringHeaderType string
+        - Name: TLS
+          Offset: 208
+          Type: 53 PointerType *crypto/tls.ConnectionState
+        - Name: Cancel
+          Offset: 216
+          Type: 111 GoChannelType <-chan struct {}
+        - Name: Response
+          Offset: 224
+          Type: 112 PointerType *net/http.Response
+        - Name: Pattern
+          Offset: 232
+          Type: 5 GoStringHeaderType string
+        - Name: ctx
+          Offset: 248
+          Type: 114 GoInterfaceType context.Context
+        - Name: pat
+          Offset: 264
+          Type: 115 PointerType *net/http.pattern
+        - Name: matches
+          Offset: 272
+          Type: 24 GoSliceHeaderType []string
+        - Name: otherValues
+          Offset: 296
+          Type: 120 GoMapType map[string]string
     - __kind: StructureType
       ID: 113
       Name: net/http.Response
@@ -1689,10 +2054,10 @@ Types:
           Offset: 136
           Type: 53 PointerType *crypto/tls.ConnectionState
     - __kind: GoInterfaceType
-      ID: 114
-      Name: context.Context
+      ID: 1
+      Name: net/http.ResponseWriter
       ByteSize: 16
-      GoRuntimeType: 1.187296e+06
+      GoRuntimeType: 1.098528e+06
       GoKind: 20
       RawFields:
         - Name: tab
@@ -1701,13 +2066,6 @@ Types:
         - Name: data
           Offset: 8
           Type: 2 VoidPointerType unsafe.Pointer
-    - __kind: PointerType
-      ID: 115
-      Name: '*net/http.pattern'
-      ByteSize: 8
-      GoRuntimeType: 1.416576e+06
-      GoKind: 22
-      Pointee: 116 StructureType net/http.pattern
     - __kind: StructureType
       ID: 116
       Name: net/http.pattern
@@ -1730,30 +2088,6 @@ Types:
         - Name: loc
           Offset: 72
           Type: 5 GoStringHeaderType string
-    - __kind: GoSliceHeaderType
-      ID: 117
-      Name: '[]net/http.segment'
-      ByteSize: 24
-      GoRuntimeType: 454944
-      GoKind: 23
-      RawFields:
-        - Name: array
-          Offset: 0
-          Type: 118 PointerType *net/http.segment
-        - Name: len
-          Offset: 8
-          Type: 8 BaseType int
-        - Name: cap
-          Offset: 16
-          Type: 8 BaseType int
-      Data: 200 GoSliceDataType []net/http.segment.array
-    - __kind: PointerType
-      ID: 118
-      Name: '*net/http.segment'
-      ByteSize: 8
-      GoRuntimeType: 364064
-      GoKind: 22
-      Pointee: 119 StructureType net/http.segment
     - __kind: StructureType
       ID: 119
       Name: net/http.segment
@@ -1771,153 +2105,198 @@ Types:
           Offset: 17
           Type: 13 BaseType bool
     - __kind: GoMapType
-      ID: 120
-      Name: map[string]string
+      ID: 51
+      Name: net/textproto.MIMEHeader
       ByteSize: 8
-      GoRuntimeType: 884224
+      GoRuntimeType: 1.596448e+06
       GoKind: 21
-      HeaderType: 122 GoHMapHeaderType hash<string,string>
-    - __kind: PointerType
-      ID: 121
-      Name: '*hash<string,string>'
-      ByteSize: 8
-      Pointee: 122 GoHMapHeaderType hash<string,string>
-    - __kind: GoHMapHeaderType
-      ID: 122
-      Name: hash<string,string>
-      ByteSize: 48
+      HeaderType: 16 GoHMapHeaderType hash<string,[]string>
+    - __kind: StructureType
+      ID: 10
+      Name: net/url.URL
+      ByteSize: 144
+      GoRuntimeType: 1.986816e+06
+      GoKind: 25
       RawFields:
-        - Name: count
+        - Name: Scheme
           Offset: 0
-          Type: 8 BaseType int
-        - Name: flags
-          Offset: 8
-          Type: 7 BaseType uint8
-        - Name: B
-          Offset: 9
-          Type: 7 BaseType uint8
-        - Name: noverflow
-          Offset: 10
-          Type: 17 BaseType uint16
-        - Name: hash0
-          Offset: 12
-          Type: 18 BaseType uint32
-        - Name: buckets
+          Type: 5 GoStringHeaderType string
+        - Name: Opaque
           Offset: 16
-          Type: 123 PointerType *bucket<string,string>
-        - Name: oldbuckets
-          Offset: 24
-          Type: 123 PointerType *bucket<string,string>
-        - Name: nevacuate
+          Type: 5 GoStringHeaderType string
+        - Name: User
           Offset: 32
-          Type: 26 BaseType uintptr
-        - Name: extra
+          Type: 11 PointerType *net/url.Userinfo
+        - Name: Host
           Offset: 40
-          Type: 27 PointerType *runtime.mapextra
-      BucketType: 124 GoHMapBucketType bucket<string,string>
-      BucketsType: 202 GoSliceDataType []bucket<string,string>.array
-    - __kind: PointerType
-      ID: 123
-      Name: '*bucket<string,string>'
+          Type: 5 GoStringHeaderType string
+        - Name: Path
+          Offset: 56
+          Type: 5 GoStringHeaderType string
+        - Name: RawPath
+          Offset: 72
+          Type: 5 GoStringHeaderType string
+        - Name: OmitHost
+          Offset: 88
+          Type: 13 BaseType bool
+        - Name: ForceQuery
+          Offset: 89
+          Type: 13 BaseType bool
+        - Name: RawQuery
+          Offset: 96
+          Type: 5 GoStringHeaderType string
+        - Name: Fragment
+          Offset: 112
+          Type: 5 GoStringHeaderType string
+        - Name: RawFragment
+          Offset: 128
+          Type: 5 GoStringHeaderType string
+    - __kind: StructureType
+      ID: 12
+      Name: net/url.Userinfo
+      ByteSize: 40
+      GoRuntimeType: 1.433088e+06
+      GoKind: 25
+      RawFields:
+        - Name: username
+          Offset: 0
+          Type: 5 GoStringHeaderType string
+        - Name: password
+          Offset: 16
+          Type: 5 GoStringHeaderType string
+        - Name: passwordSet
+          Offset: 32
+          Type: 13 BaseType bool
+    - __kind: GoMapType
+      ID: 37
+      Name: net/url.Values
       ByteSize: 8
-      Pointee: 124 GoHMapBucketType bucket<string,string>
-    - __kind: GoHMapBucketType
-      ID: 124
-      Name: bucket<string,string>
-      ByteSize: 272
+      GoRuntimeType: 1.671328e+06
+      GoKind: 21
+      HeaderType: 16 GoHMapHeaderType hash<string,[]string>
+    - __kind: StructureType
+      ID: 33
+      Name: runtime.bmap
+      ByteSize: 8
+      GoRuntimeType: 1.10992e+06
+      GoKind: 25
       RawFields:
         - Name: tophash
           Offset: 0
           Type: 21 ArrayType [8]uint8
-        - Name: keys
-          Offset: 8
-          Type: 22 ArrayType []key<string>
-        - Name: values
-          Offset: 136
-          Type: 125 ArrayType []val<string>
+    - __kind: StructureType
+      ID: 28
+      Name: runtime.mapextra
+      ByteSize: 24
+      GoRuntimeType: 1.429056e+06
+      GoKind: 25
+      RawFields:
         - Name: overflow
-          Offset: 264
-          Type: 123 PointerType *bucket<string,string>
-      KeyType: 5 GoStringHeaderType string
-      ValueType: 5 GoStringHeaderType string
-    - __kind: ArrayType
-      ID: 125
-      Name: '[]val<string>'
-      ByteSize: 128
-      Count: 8
-      HasCount: true
-      Element: 5 GoStringHeaderType string
-    - __kind: PointerType
-      ID: 126
-      Name: '*bytes.Buffer'
-      ByteSize: 8
-      GoRuntimeType: 2.11552e+06
-      GoKind: 22
-      Pointee: 127 StructureType bytes.Buffer
-    - __kind: StructureType
-      ID: 127
-      Name: bytes.Buffer
-      ByteSize: 40
-      GoRuntimeType: 1.414272e+06
-      GoKind: 25
-      RawFields:
-        - Name: buf
           Offset: 0
-          Type: 52 GoSliceHeaderType []uint8
-        - Name: off
-          Offset: 24
-          Type: 8 BaseType int
-        - Name: lastRead
-          Offset: 32
-          Type: 128 BaseType bytes.readOp
-    - __kind: BaseType
-      ID: 128
-      Name: bytes.readOp
-      ByteSize: 1
-      GoRuntimeType: 532992
-      GoKind: 3
-    - __kind: GoInterfaceType
-      ID: 129
-      Name: gopkg.in/DataDog/dd-trace-go.v1/ddtrace.Span
-      ByteSize: 16
-      GoRuntimeType: 1.296128e+06
-      GoKind: 20
-      RawFields:
-        - Name: tab
-          Offset: 0
-          Type: 2 VoidPointerType unsafe.Pointer
-        - Name: data
+          Type: 29 PointerType *[]*runtime.bmap
+        - Name: oldoverflow
           Offset: 8
-          Type: 2 VoidPointerType unsafe.Pointer
+          Type: 29 PointerType *[]*runtime.bmap
+        - Name: nextOverflow
+          Offset: 16
+          Type: 32 PointerType *runtime.bmap
+    - __kind: GoStringHeaderType
+      ID: 5
+      Name: string
+      ByteSize: 16
+      GoRuntimeType: 533760
+      GoKind: 24
+      RawFields:
+        - Name: str
+          Offset: 0
+          Type: 155 PointerType *string.str
+        - Name: len
+          Offset: 8
+          Type: 8 BaseType int
+      Data: 154 GoStringDataType string.str
+    - __kind: GoStringDataType
+      ID: 154
+      Name: string.str
+      ByteSize: 2048
     - __kind: StructureType
-      ID: 130
-      Name: context.backgroundCtx
-      GoRuntimeType: 1.667744e+06
+      ID: 76
+      Name: time.Location
+      ByteSize: 104
+      GoRuntimeType: 1.834528e+06
       GoKind: 25
       RawFields:
-        - Name: emptyCtx
+        - Name: name
           Offset: 0
-          Type: 131 StructureType context.emptyCtx
+          Type: 5 GoStringHeaderType string
+        - Name: zone
+          Offset: 16
+          Type: 77 GoSliceHeaderType []time.zone
+        - Name: tx
+          Offset: 40
+          Type: 80 GoSliceHeaderType []time.zoneTrans
+        - Name: extend
+          Offset: 64
+          Type: 5 GoStringHeaderType string
+        - Name: cacheStart
+          Offset: 80
+          Type: 36 BaseType int64
+        - Name: cacheEnd
+          Offset: 88
+          Type: 36 BaseType int64
+        - Name: cacheZone
+          Offset: 96
+          Type: 78 PointerType *time.zone
     - __kind: StructureType
-      ID: 131
-      Name: context.emptyCtx
-      GoRuntimeType: 1.399808e+06
+      ID: 73
+      Name: time.Time
+      ByteSize: 24
+      GoRuntimeType: 2.215712e+06
       GoKind: 25
-      RawFields: []
-    - __kind: PointerType
-      ID: 132
-      Name: '*bool'
-      ByteSize: 8
-      GoRuntimeType: 372704
-      GoKind: 22
-      Pointee: 13 BaseType bool
-    - __kind: PointerType
-      ID: 133
-      Name: '*uintptr'
-      ByteSize: 8
-      GoRuntimeType: 372384
-      GoKind: 22
-      Pointee: 26 BaseType uintptr
+      RawFields:
+        - Name: wall
+          Offset: 0
+          Type: 74 BaseType uint64
+        - Name: ext
+          Offset: 8
+          Type: 36 BaseType int64
+        - Name: loc
+          Offset: 16
+          Type: 75 PointerType *time.Location
+    - __kind: StructureType
+      ID: 79
+      Name: time.zone
+      ByteSize: 32
+      GoRuntimeType: 1.421376e+06
+      GoKind: 25
+      RawFields:
+        - Name: name
+          Offset: 0
+          Type: 5 GoStringHeaderType string
+        - Name: offset
+          Offset: 16
+          Type: 8 BaseType int
+        - Name: isDST
+          Offset: 24
+          Type: 13 BaseType bool
+    - __kind: StructureType
+      ID: 82
+      Name: time.zoneTrans
+      ByteSize: 16
+      GoRuntimeType: 1.623872e+06
+      GoKind: 25
+      RawFields:
+        - Name: when
+          Offset: 0
+          Type: 36 BaseType int64
+        - Name: index
+          Offset: 8
+          Type: 7 BaseType uint8
+        - Name: isstd
+          Offset: 9
+          Type: 13 BaseType bool
+        - Name: isutc
+          Offset: 10
+          Type: 13 BaseType bool
     - __kind: BaseType
       ID: 134
       Name: uint
@@ -1925,420 +2304,41 @@ Types:
       GoRuntimeType: 534400
       GoKind: 7
     - __kind: BaseType
-      ID: 135
-      Name: int32
-      ByteSize: 4
-      GoRuntimeType: 534080
-      GoKind: 5
-    - __kind: BaseType
-      ID: 136
-      Name: int8
-      ByteSize: 1
-      GoRuntimeType: 533824
-      GoKind: 3
-    - __kind: BaseType
-      ID: 137
-      Name: float32
-      ByteSize: 4
-      GoRuntimeType: 534656
-      GoKind: 13
-    - __kind: BaseType
-      ID: 138
-      Name: float64
-      ByteSize: 8
-      GoRuntimeType: 534720
-      GoKind: 14
-    - __kind: GoInterfaceType
-      ID: 139
-      Name: error
-      ByteSize: 16
-      GoRuntimeType: 987648
-      GoKind: 20
-      RawFields:
-        - Name: tab
-          Offset: 0
-          Type: 2 VoidPointerType unsafe.Pointer
-        - Name: data
-          Offset: 8
-          Type: 2 VoidPointerType unsafe.Pointer
-    - __kind: PointerType
-      ID: 140
-      Name: '*int32'
-      ByteSize: 8
-      GoRuntimeType: 372000
-      GoKind: 22
-      Pointee: 135 BaseType int32
-    - __kind: PointerType
-      ID: 141
-      Name: '*uint32'
-      ByteSize: 8
-      GoRuntimeType: 372064
-      GoKind: 22
-      Pointee: 18 BaseType uint32
-    - __kind: BaseType
-      ID: 142
-      Name: int16
+      ID: 17
+      Name: uint16
       ByteSize: 2
-      GoRuntimeType: 533952
-      GoKind: 4
+      GoRuntimeType: 534016
+      GoKind: 9
     - __kind: BaseType
-      ID: 143
-      Name: complex64
-      ByteSize: 8
-      GoRuntimeType: 534528
-      GoKind: 15
+      ID: 18
+      Name: uint32
+      ByteSize: 4
+      GoRuntimeType: 534144
+      GoKind: 10
     - __kind: BaseType
-      ID: 144
-      Name: complex128
-      ByteSize: 16
-      GoRuntimeType: 534592
-      GoKind: 16
-    - __kind: PointerType
-      ID: 145
-      Name: '*float64'
+      ID: 74
+      Name: uint64
       ByteSize: 8
-      GoRuntimeType: 372640
-      GoKind: 22
-      Pointee: 138 BaseType float64
-    - __kind: PointerType
-      ID: 146
-      Name: '*int64'
+      GoRuntimeType: 534272
+      GoKind: 11
+    - __kind: BaseType
+      ID: 7
+      Name: uint8
+      ByteSize: 1
+      GoRuntimeType: 533888
+      GoKind: 8
+    - __kind: BaseType
+      ID: 26
+      Name: uintptr
       ByteSize: 8
-      GoRuntimeType: 372128
-      GoKind: 22
-      Pointee: 36 BaseType int64
-    - __kind: PointerType
-      ID: 147
-      Name: '*uint64'
+      GoRuntimeType: 534464
+      GoKind: 12
+    - __kind: VoidPointerType
+      ID: 2
+      Name: unsafe.Pointer
       ByteSize: 8
-      GoRuntimeType: 372192
-      GoKind: 22
-      Pointee: 74 BaseType uint64
-    - __kind: PointerType
-      ID: 148
-      Name: '*uint16'
-      ByteSize: 8
-      GoRuntimeType: 371936
-      GoKind: 22
-      Pointee: 17 BaseType uint16
-    - __kind: PointerType
-      ID: 149
-      Name: '*int16'
-      ByteSize: 8
-      GoRuntimeType: 371872
-      GoKind: 22
-      Pointee: 142 BaseType int16
-    - __kind: PointerType
-      ID: 150
-      Name: '*int8'
-      ByteSize: 8
-      GoRuntimeType: 371744
-      GoKind: 22
-      Pointee: 136 BaseType int8
-    - __kind: PointerType
-      ID: 151
-      Name: '*error'
-      ByteSize: 8
-      GoRuntimeType: 371616
-      GoKind: 22
-      Pointee: 139 GoInterfaceType error
-    - __kind: PointerType
-      ID: 152
-      Name: '*uint'
-      ByteSize: 8
-      GoRuntimeType: 372320
-      GoKind: 22
-      Pointee: 134 BaseType uint
-    - __kind: PointerType
-      ID: 153
-      Name: '*float32'
-      ByteSize: 8
-      GoRuntimeType: 372576
-      GoKind: 22
-      Pointee: 137 BaseType float32
-    - __kind: GoStringDataType
-      ID: 154
-      Name: string.str
-      ByteSize: 2048
-    - __kind: PointerType
-      ID: 155
-      Name: '*string.str'
-      ByteSize: 8
-      Pointee: 154 GoStringDataType string.str
-    - __kind: GoSliceDataType
-      ID: 156
-      Name: '[]bucket<string,[]string>.array'
-      ByteSize: 2048
-      Element: 20 GoHMapBucketType bucket<string,[]string>
-    - __kind: GoSliceDataType
-      ID: 157
-      Name: '[]string.array'
-      ByteSize: 2048
-      Element: 5 GoStringHeaderType string
-    - __kind: PointerType
-      ID: 158
-      Name: '*[]string.array'
-      ByteSize: 8
-      Pointee: 157 GoSliceDataType []string.array
-    - __kind: GoSliceDataType
-      ID: 159
-      Name: '[]*runtime.bmap.array'
-      ByteSize: 2048
-      Element: 32 PointerType *runtime.bmap
-    - __kind: PointerType
-      ID: 160
-      Name: '*[]*runtime.bmap.array'
-      ByteSize: 8
-      Pointee: 159 GoSliceDataType []*runtime.bmap.array
-    - __kind: GoSliceDataType
-      ID: 161
-      Name: '[]bucket<string,[]*mime/multipart.FileHeader>.array'
-      ByteSize: 2048
-      Element: 45 GoHMapBucketType bucket<string,[]*mime/multipart.FileHeader>
-    - __kind: GoSliceDataType
-      ID: 162
-      Name: '[]*mime/multipart.FileHeader.array'
-      ByteSize: 2048
-      Element: 49 PointerType *mime/multipart.FileHeader
-    - __kind: PointerType
-      ID: 163
-      Name: '*[]*mime/multipart.FileHeader.array'
-      ByteSize: 8
-      Pointee: 162 GoSliceDataType []*mime/multipart.FileHeader.array
-    - __kind: GoSliceDataType
-      ID: 164
-      Name: '[]uint8.array'
-      ByteSize: 2048
-      Element: 7 BaseType uint8
-    - __kind: PointerType
-      ID: 165
-      Name: '*[]uint8.array'
-      ByteSize: 8
-      Pointee: 164 GoSliceDataType []uint8.array
-    - __kind: GoSliceDataType
-      ID: 166
-      Name: '[]*crypto/x509.Certificate.array'
-      ByteSize: 2048
-      Element: 57 PointerType *crypto/x509.Certificate
-    - __kind: PointerType
-      ID: 167
-      Name: '*[]*crypto/x509.Certificate.array'
-      ByteSize: 8
-      Pointee: 166 GoSliceDataType []*crypto/x509.Certificate.array
-    - __kind: GoSliceDataType
-      ID: 168
-      Name: math/big.nat.array
-      ByteSize: 2048
-      Element: 66 BaseType math/big.Word
-    - __kind: PointerType
-      ID: 169
-      Name: '*math/big.nat.array'
-      ByteSize: 8
-      Pointee: 168 GoSliceDataType math/big.nat.array
-    - __kind: GoSliceDataType
-      ID: 170
-      Name: '[]crypto/x509/pkix.AttributeTypeAndValue.array'
-      ByteSize: 2048
-      Element: 70 StructureType crypto/x509/pkix.AttributeTypeAndValue
-    - __kind: PointerType
-      ID: 171
-      Name: '*[]crypto/x509/pkix.AttributeTypeAndValue.array'
-      ByteSize: 8
-      Pointee: 170 GoSliceDataType []crypto/x509/pkix.AttributeTypeAndValue.array
-    - __kind: GoSliceDataType
-      ID: 172
-      Name: encoding/asn1.ObjectIdentifier.array
-      ByteSize: 2048
-      Element: 8 BaseType int
-    - __kind: PointerType
-      ID: 173
-      Name: '*encoding/asn1.ObjectIdentifier.array'
-      ByteSize: 8
-      Pointee: 172 GoSliceDataType encoding/asn1.ObjectIdentifier.array
-    - __kind: GoSliceDataType
-      ID: 174
-      Name: '[]time.zone.array'
-      ByteSize: 2048
-      Element: 79 StructureType time.zone
-    - __kind: PointerType
-      ID: 175
-      Name: '*[]time.zone.array'
-      ByteSize: 8
-      Pointee: 174 GoSliceDataType []time.zone.array
-    - __kind: GoSliceDataType
-      ID: 176
-      Name: '[]time.zoneTrans.array'
-      ByteSize: 2048
-      Element: 82 StructureType time.zoneTrans
-    - __kind: PointerType
-      ID: 177
-      Name: '*[]time.zoneTrans.array'
-      ByteSize: 8
-      Pointee: 176 GoSliceDataType []time.zoneTrans.array
-    - __kind: GoSliceDataType
-      ID: 178
-      Name: '[]crypto/x509/pkix.Extension.array'
-      ByteSize: 2048
-      Element: 86 StructureType crypto/x509/pkix.Extension
-    - __kind: PointerType
-      ID: 179
-      Name: '*[]crypto/x509/pkix.Extension.array'
-      ByteSize: 8
-      Pointee: 178 GoSliceDataType []crypto/x509/pkix.Extension.array
-    - __kind: GoSliceDataType
-      ID: 180
-      Name: '[]encoding/asn1.ObjectIdentifier.array'
-      ByteSize: 2048
-      Element: 71 GoSliceHeaderType encoding/asn1.ObjectIdentifier
-    - __kind: PointerType
-      ID: 181
-      Name: '*[]encoding/asn1.ObjectIdentifier.array'
-      ByteSize: 8
-      Pointee: 180 GoSliceDataType []encoding/asn1.ObjectIdentifier.array
-    - __kind: GoSliceDataType
-      ID: 182
-      Name: '[]crypto/x509.ExtKeyUsage.array'
-      ByteSize: 2048
-      Element: 91 BaseType crypto/x509.ExtKeyUsage
-    - __kind: PointerType
-      ID: 183
-      Name: '*[]crypto/x509.ExtKeyUsage.array'
-      ByteSize: 8
-      Pointee: 182 GoSliceDataType []crypto/x509.ExtKeyUsage.array
-    - __kind: GoSliceDataType
-      ID: 184
-      Name: '[]net.IP.array'
-      ByteSize: 2048
-      Element: 94 GoSliceHeaderType net.IP
-    - __kind: PointerType
-      ID: 185
-      Name: '*[]net.IP.array'
-      ByteSize: 8
-      Pointee: 184 GoSliceDataType []net.IP.array
-    - __kind: GoSliceDataType
-      ID: 186
-      Name: net.IP.array
-      ByteSize: 2048
-      Element: 7 BaseType uint8
-    - __kind: PointerType
-      ID: 187
-      Name: '*net.IP.array'
-      ByteSize: 8
-      Pointee: 186 GoSliceDataType net.IP.array
-    - __kind: GoSliceDataType
-      ID: 188
-      Name: '[]*net/url.URL.array'
-      ByteSize: 2048
-      Element: 9 PointerType *net/url.URL
-    - __kind: PointerType
-      ID: 189
-      Name: '*[]*net/url.URL.array'
-      ByteSize: 8
-      Pointee: 188 GoSliceDataType []*net/url.URL.array
-    - __kind: GoSliceDataType
-      ID: 190
-      Name: '[]*net.IPNet.array'
-      ByteSize: 2048
-      Element: 99 PointerType *net.IPNet
-    - __kind: PointerType
-      ID: 191
-      Name: '*[]*net.IPNet.array'
-      ByteSize: 8
-      Pointee: 190 GoSliceDataType []*net.IPNet.array
-    - __kind: GoSliceDataType
-      ID: 192
-      Name: net.IPMask.array
-      ByteSize: 2048
-      Element: 7 BaseType uint8
-    - __kind: PointerType
-      ID: 193
-      Name: '*net.IPMask.array'
-      ByteSize: 8
-      Pointee: 192 GoSliceDataType net.IPMask.array
-    - __kind: GoSliceDataType
-      ID: 194
-      Name: '[]crypto/x509.OID.array'
-      ByteSize: 2048
-      Element: 104 StructureType crypto/x509.OID
-    - __kind: PointerType
-      ID: 195
-      Name: '*[]crypto/x509.OID.array'
-      ByteSize: 8
-      Pointee: 194 GoSliceDataType []crypto/x509.OID.array
-    - __kind: GoSliceDataType
-      ID: 196
-      Name: '[][]*crypto/x509.Certificate.array'
-      ByteSize: 2048
-      Element: 55 GoSliceHeaderType []*crypto/x509.Certificate
-    - __kind: PointerType
-      ID: 197
-      Name: '*[][]*crypto/x509.Certificate.array'
-      ByteSize: 8
-      Pointee: 196 GoSliceDataType [][]*crypto/x509.Certificate.array
-    - __kind: GoSliceDataType
-      ID: 198
-      Name: '[][]uint8.array'
-      ByteSize: 2048
-      Element: 52 GoSliceHeaderType []uint8
-    - __kind: PointerType
-      ID: 199
-      Name: '*[][]uint8.array'
-      ByteSize: 8
-      Pointee: 198 GoSliceDataType [][]uint8.array
-    - __kind: GoSliceDataType
-      ID: 200
-      Name: '[]net/http.segment.array'
-      ByteSize: 2048
-      Element: 119 StructureType net/http.segment
-    - __kind: PointerType
-      ID: 201
-      Name: '*[]net/http.segment.array'
-      ByteSize: 8
-      Pointee: 200 GoSliceDataType []net/http.segment.array
-    - __kind: GoSliceDataType
-      ID: 202
-      Name: '[]bucket<string,string>.array'
-      ByteSize: 2048
-      Element: 124 GoHMapBucketType bucket<string,string>
-    - __kind: EventRootType
-      ID: 203
-      Name: Probe[main.HandleHTTP]
-      ByteSize: 25
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: w
-          Offset: 1
-          Expression:
-            Type: 1 GoInterfaceType net/http.ResponseWriter
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 1, index: 0, name: w}
-                  Offset: 0
-                  ByteSize: 16
-        - Name: r
-          Offset: 17
-          Expression:
-            Type: 3 PointerType *net/http.Request
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 1, index: 1, name: r}
-                  Offset: 0
-                  ByteSize: 8
-    - __kind: EventRootType
-      ID: 204
-      Name: Probe[main.LookAtTheRequest]
-      ByteSize: 17
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: path
-          Offset: 1
-          Expression:
-            Type: 5 GoStringHeaderType string
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 2, index: 0, name: path}
-                  Offset: 0
-                  ByteSize: 16
+      GoRuntimeType: 534848
+      GoKind: 26
 MaxTypeID: 204
 Issues: []
 GoModuledataInfo: {FirstModuledataAddr: "0x12ddd40", TypesOffset: 296}

--- a/pkg/dyninst/irgen/testdata/snapshot/rc_tester_v1.arch=arm64,toolchain=go1.23.11.yaml
+++ b/pkg/dyninst/irgen/testdata/snapshot/rc_tester_v1.arch=arm64,toolchain=go1.23.11.yaml
@@ -10,7 +10,7 @@ Probes:
       subprogram: {subprogram: 1}
       events:
         - ID: 1
-          Type: 206 EventRootType Probe[main.HandleHTTP]
+          Type: 203 EventRootType Probe[main.HandleHTTP]
           InjectionPoints: [{PC: "0x8ad870", Frameless: true}]
           Condition: null
     - id: look_at_the_request
@@ -23,7 +23,7 @@ Probes:
       subprogram: {subprogram: 2}
       events:
         - ID: 2
-          Type: 207 EventRootType Probe[main.LookAtTheRequest]
+          Type: 204 EventRootType Probe[main.LookAtTheRequest]
           InjectionPoints: [{PC: "0x8adb9c", Frameless: true}]
           Condition: null
 Subprograms:
@@ -385,7 +385,7 @@ Types:
           Offset: 40
           Type: 27 PointerType *runtime.mapextra
       BucketType: 20 GoHMapBucketType bucket<string,[]string>
-      BucketsType: 166 GoSliceDataType []bucket<string,[]string>.array
+      BucketsType: 156 GoSliceDataType []bucket<string,[]string>.array
     - __kind: BaseType
       ID: 17
       Name: uint16
@@ -648,7 +648,7 @@ Types:
           Offset: 40
           Type: 27 PointerType *runtime.mapextra
       BucketType: 45 GoHMapBucketType bucket<string,[]*mime/multipart.FileHeader>
-      BucketsType: 163 GoSliceDataType []bucket<string,[]*mime/multipart.FileHeader>.array
+      BucketsType: 161 GoSliceDataType []bucket<string,[]*mime/multipart.FileHeader>.array
     - __kind: PointerType
       ID: 44
       Name: '*bucket<string,[]*mime/multipart.FileHeader>'
@@ -696,7 +696,7 @@ Types:
         - Name: cap
           Offset: 16
           Type: 8 BaseType int
-      Data: 164 GoSliceDataType []*mime/multipart.FileHeader.array
+      Data: 162 GoSliceDataType []*mime/multipart.FileHeader.array
     - __kind: PointerType
       ID: 48
       Name: '**mime/multipart.FileHeader'
@@ -761,7 +761,7 @@ Types:
         - Name: cap
           Offset: 16
           Type: 8 BaseType int
-      Data: 167 GoSliceDataType []uint8.array
+      Data: 164 GoSliceDataType []uint8.array
     - __kind: PointerType
       ID: 53
       Name: '*crypto/tls.ConnectionState'
@@ -840,7 +840,7 @@ Types:
         - Name: cap
           Offset: 16
           Type: 8 BaseType int
-      Data: 169 GoSliceDataType []*crypto/x509.Certificate.array
+      Data: 166 GoSliceDataType []*crypto/x509.Certificate.array
     - __kind: PointerType
       ID: 56
       Name: '**crypto/x509.Certificate'
@@ -1056,7 +1056,7 @@ Types:
         - Name: cap
           Offset: 16
           Type: 8 BaseType int
-      Data: 171 GoSliceDataType math/big.nat.array
+      Data: 168 GoSliceDataType math/big.nat.array
     - __kind: PointerType
       ID: 65
       Name: '*math/big.Word'
@@ -1126,7 +1126,7 @@ Types:
         - Name: cap
           Offset: 16
           Type: 8 BaseType int
-      Data: 173 GoSliceDataType []crypto/x509/pkix.AttributeTypeAndValue.array
+      Data: 170 GoSliceDataType []crypto/x509/pkix.AttributeTypeAndValue.array
     - __kind: PointerType
       ID: 69
       Name: '*crypto/x509/pkix.AttributeTypeAndValue'
@@ -1163,7 +1163,7 @@ Types:
         - Name: cap
           Offset: 16
           Type: 8 BaseType int
-      Data: 175 GoSliceDataType encoding/asn1.ObjectIdentifier.array
+      Data: 172 GoSliceDataType encoding/asn1.ObjectIdentifier.array
     - __kind: PointerType
       ID: 72
       Name: '*int'
@@ -1244,7 +1244,7 @@ Types:
         - Name: cap
           Offset: 16
           Type: 8 BaseType int
-      Data: 177 GoSliceDataType []time.zone.array
+      Data: 174 GoSliceDataType []time.zone.array
     - __kind: PointerType
       ID: 78
       Name: '*time.zone'
@@ -1284,7 +1284,7 @@ Types:
         - Name: cap
           Offset: 16
           Type: 8 BaseType int
-      Data: 179 GoSliceDataType []time.zoneTrans.array
+      Data: 176 GoSliceDataType []time.zoneTrans.array
     - __kind: PointerType
       ID: 81
       Name: '*time.zoneTrans'
@@ -1333,7 +1333,7 @@ Types:
         - Name: cap
           Offset: 16
           Type: 8 BaseType int
-      Data: 181 GoSliceDataType []crypto/x509/pkix.Extension.array
+      Data: 178 GoSliceDataType []crypto/x509/pkix.Extension.array
     - __kind: PointerType
       ID: 85
       Name: '*crypto/x509/pkix.Extension'
@@ -1373,7 +1373,7 @@ Types:
         - Name: cap
           Offset: 16
           Type: 8 BaseType int
-      Data: 183 GoSliceDataType []encoding/asn1.ObjectIdentifier.array
+      Data: 180 GoSliceDataType []encoding/asn1.ObjectIdentifier.array
     - __kind: PointerType
       ID: 88
       Name: '*encoding/asn1.ObjectIdentifier'
@@ -1397,7 +1397,7 @@ Types:
         - Name: cap
           Offset: 16
           Type: 8 BaseType int
-      Data: 185 GoSliceDataType []crypto/x509.ExtKeyUsage.array
+      Data: 182 GoSliceDataType []crypto/x509.ExtKeyUsage.array
     - __kind: PointerType
       ID: 90
       Name: '*crypto/x509.ExtKeyUsage'
@@ -1427,7 +1427,7 @@ Types:
         - Name: cap
           Offset: 16
           Type: 8 BaseType int
-      Data: 187 GoSliceDataType []net.IP.array
+      Data: 184 GoSliceDataType []net.IP.array
     - __kind: PointerType
       ID: 93
       Name: '*net.IP'
@@ -1451,7 +1451,7 @@ Types:
         - Name: cap
           Offset: 16
           Type: 8 BaseType int
-      Data: 189 GoSliceDataType net.IP.array
+      Data: 186 GoSliceDataType net.IP.array
     - __kind: GoSliceHeaderType
       ID: 95
       Name: '[]*net/url.URL'
@@ -1468,7 +1468,7 @@ Types:
         - Name: cap
           Offset: 16
           Type: 8 BaseType int
-      Data: 191 GoSliceDataType []*net/url.URL.array
+      Data: 188 GoSliceDataType []*net/url.URL.array
     - __kind: PointerType
       ID: 96
       Name: '**net/url.URL'
@@ -1490,7 +1490,7 @@ Types:
         - Name: cap
           Offset: 16
           Type: 8 BaseType int
-      Data: 193 GoSliceDataType []*net.IPNet.array
+      Data: 190 GoSliceDataType []*net.IPNet.array
     - __kind: PointerType
       ID: 98
       Name: '**net.IPNet'
@@ -1533,7 +1533,7 @@ Types:
         - Name: cap
           Offset: 16
           Type: 8 BaseType int
-      Data: 195 GoSliceDataType net.IPMask.array
+      Data: 192 GoSliceDataType net.IPMask.array
     - __kind: GoSliceHeaderType
       ID: 102
       Name: '[]crypto/x509.OID'
@@ -1550,7 +1550,7 @@ Types:
         - Name: cap
           Offset: 16
           Type: 8 BaseType int
-      Data: 197 GoSliceDataType []crypto/x509.OID.array
+      Data: 194 GoSliceDataType []crypto/x509.OID.array
     - __kind: PointerType
       ID: 103
       Name: '*crypto/x509.OID'
@@ -1584,7 +1584,7 @@ Types:
         - Name: cap
           Offset: 16
           Type: 8 BaseType int
-      Data: 199 GoSliceDataType [][]*crypto/x509.Certificate.array
+      Data: 196 GoSliceDataType [][]*crypto/x509.Certificate.array
     - __kind: PointerType
       ID: 106
       Name: '*[]*crypto/x509.Certificate'
@@ -1607,7 +1607,7 @@ Types:
         - Name: cap
           Offset: 16
           Type: 8 BaseType int
-      Data: 201 GoSliceDataType [][]uint8.array
+      Data: 198 GoSliceDataType [][]uint8.array
     - __kind: PointerType
       ID: 108
       Name: '*[]uint8'
@@ -1746,7 +1746,7 @@ Types:
         - Name: cap
           Offset: 16
           Type: 8 BaseType int
-      Data: 203 GoSliceDataType []net/http.segment.array
+      Data: 200 GoSliceDataType []net/http.segment.array
     - __kind: PointerType
       ID: 118
       Name: '*net/http.segment'
@@ -1815,7 +1815,7 @@ Types:
           Offset: 40
           Type: 27 PointerType *runtime.mapextra
       BucketType: 124 GoHMapBucketType bucket<string,string>
-      BucketsType: 205 GoSliceDataType []bucket<string,string>.array
+      BucketsType: 202 GoSliceDataType []bucket<string,string>.array
     - __kind: PointerType
       ID: 123
       Name: '*bucket<string,string>'
@@ -2092,231 +2092,216 @@ Types:
       Pointee: 159 GoSliceDataType []*runtime.bmap.array
     - __kind: GoSliceDataType
       ID: 161
-      Name: '[]bucket<string,[]string>.array'
-      ByteSize: 2048
-      Element: 20 GoHMapBucketType bucket<string,[]string>
-    - __kind: GoSliceDataType
-      ID: 162
-      Name: '[]bucket<string,[]string>.array'
-      ByteSize: 2048
-      Element: 20 GoHMapBucketType bucket<string,[]string>
-    - __kind: GoSliceDataType
-      ID: 163
       Name: '[]bucket<string,[]*mime/multipart.FileHeader>.array'
       ByteSize: 2048
       Element: 45 GoHMapBucketType bucket<string,[]*mime/multipart.FileHeader>
     - __kind: GoSliceDataType
-      ID: 164
+      ID: 162
       Name: '[]*mime/multipart.FileHeader.array'
       ByteSize: 2048
       Element: 49 PointerType *mime/multipart.FileHeader
     - __kind: PointerType
-      ID: 165
+      ID: 163
       Name: '*[]*mime/multipart.FileHeader.array'
       ByteSize: 8
-      Pointee: 164 GoSliceDataType []*mime/multipart.FileHeader.array
+      Pointee: 162 GoSliceDataType []*mime/multipart.FileHeader.array
     - __kind: GoSliceDataType
-      ID: 166
-      Name: '[]bucket<string,[]string>.array'
-      ByteSize: 2048
-      Element: 20 GoHMapBucketType bucket<string,[]string>
-    - __kind: GoSliceDataType
-      ID: 167
+      ID: 164
       Name: '[]uint8.array'
       ByteSize: 2048
       Element: 7 BaseType uint8
     - __kind: PointerType
-      ID: 168
+      ID: 165
       Name: '*[]uint8.array'
       ByteSize: 8
-      Pointee: 167 GoSliceDataType []uint8.array
+      Pointee: 164 GoSliceDataType []uint8.array
     - __kind: GoSliceDataType
-      ID: 169
+      ID: 166
       Name: '[]*crypto/x509.Certificate.array'
       ByteSize: 2048
       Element: 57 PointerType *crypto/x509.Certificate
     - __kind: PointerType
-      ID: 170
+      ID: 167
       Name: '*[]*crypto/x509.Certificate.array'
       ByteSize: 8
-      Pointee: 169 GoSliceDataType []*crypto/x509.Certificate.array
+      Pointee: 166 GoSliceDataType []*crypto/x509.Certificate.array
     - __kind: GoSliceDataType
-      ID: 171
+      ID: 168
       Name: math/big.nat.array
       ByteSize: 2048
       Element: 66 BaseType math/big.Word
     - __kind: PointerType
-      ID: 172
+      ID: 169
       Name: '*math/big.nat.array'
       ByteSize: 8
-      Pointee: 171 GoSliceDataType math/big.nat.array
+      Pointee: 168 GoSliceDataType math/big.nat.array
     - __kind: GoSliceDataType
-      ID: 173
+      ID: 170
       Name: '[]crypto/x509/pkix.AttributeTypeAndValue.array'
       ByteSize: 2048
       Element: 70 StructureType crypto/x509/pkix.AttributeTypeAndValue
     - __kind: PointerType
-      ID: 174
+      ID: 171
       Name: '*[]crypto/x509/pkix.AttributeTypeAndValue.array'
       ByteSize: 8
-      Pointee: 173 GoSliceDataType []crypto/x509/pkix.AttributeTypeAndValue.array
+      Pointee: 170 GoSliceDataType []crypto/x509/pkix.AttributeTypeAndValue.array
     - __kind: GoSliceDataType
-      ID: 175
+      ID: 172
       Name: encoding/asn1.ObjectIdentifier.array
       ByteSize: 2048
       Element: 8 BaseType int
     - __kind: PointerType
-      ID: 176
+      ID: 173
       Name: '*encoding/asn1.ObjectIdentifier.array'
       ByteSize: 8
-      Pointee: 175 GoSliceDataType encoding/asn1.ObjectIdentifier.array
+      Pointee: 172 GoSliceDataType encoding/asn1.ObjectIdentifier.array
     - __kind: GoSliceDataType
-      ID: 177
+      ID: 174
       Name: '[]time.zone.array'
       ByteSize: 2048
       Element: 79 StructureType time.zone
     - __kind: PointerType
-      ID: 178
+      ID: 175
       Name: '*[]time.zone.array'
       ByteSize: 8
-      Pointee: 177 GoSliceDataType []time.zone.array
+      Pointee: 174 GoSliceDataType []time.zone.array
     - __kind: GoSliceDataType
-      ID: 179
+      ID: 176
       Name: '[]time.zoneTrans.array'
       ByteSize: 2048
       Element: 82 StructureType time.zoneTrans
     - __kind: PointerType
-      ID: 180
+      ID: 177
       Name: '*[]time.zoneTrans.array'
       ByteSize: 8
-      Pointee: 179 GoSliceDataType []time.zoneTrans.array
+      Pointee: 176 GoSliceDataType []time.zoneTrans.array
     - __kind: GoSliceDataType
-      ID: 181
+      ID: 178
       Name: '[]crypto/x509/pkix.Extension.array'
       ByteSize: 2048
       Element: 86 StructureType crypto/x509/pkix.Extension
     - __kind: PointerType
-      ID: 182
+      ID: 179
       Name: '*[]crypto/x509/pkix.Extension.array'
       ByteSize: 8
-      Pointee: 181 GoSliceDataType []crypto/x509/pkix.Extension.array
+      Pointee: 178 GoSliceDataType []crypto/x509/pkix.Extension.array
     - __kind: GoSliceDataType
-      ID: 183
+      ID: 180
       Name: '[]encoding/asn1.ObjectIdentifier.array'
       ByteSize: 2048
       Element: 71 GoSliceHeaderType encoding/asn1.ObjectIdentifier
     - __kind: PointerType
-      ID: 184
+      ID: 181
       Name: '*[]encoding/asn1.ObjectIdentifier.array'
       ByteSize: 8
-      Pointee: 183 GoSliceDataType []encoding/asn1.ObjectIdentifier.array
+      Pointee: 180 GoSliceDataType []encoding/asn1.ObjectIdentifier.array
     - __kind: GoSliceDataType
-      ID: 185
+      ID: 182
       Name: '[]crypto/x509.ExtKeyUsage.array'
       ByteSize: 2048
       Element: 91 BaseType crypto/x509.ExtKeyUsage
     - __kind: PointerType
-      ID: 186
+      ID: 183
       Name: '*[]crypto/x509.ExtKeyUsage.array'
       ByteSize: 8
-      Pointee: 185 GoSliceDataType []crypto/x509.ExtKeyUsage.array
+      Pointee: 182 GoSliceDataType []crypto/x509.ExtKeyUsage.array
     - __kind: GoSliceDataType
-      ID: 187
+      ID: 184
       Name: '[]net.IP.array'
       ByteSize: 2048
       Element: 94 GoSliceHeaderType net.IP
     - __kind: PointerType
-      ID: 188
+      ID: 185
       Name: '*[]net.IP.array'
       ByteSize: 8
-      Pointee: 187 GoSliceDataType []net.IP.array
+      Pointee: 184 GoSliceDataType []net.IP.array
     - __kind: GoSliceDataType
-      ID: 189
+      ID: 186
       Name: net.IP.array
       ByteSize: 2048
       Element: 7 BaseType uint8
     - __kind: PointerType
-      ID: 190
+      ID: 187
       Name: '*net.IP.array'
       ByteSize: 8
-      Pointee: 189 GoSliceDataType net.IP.array
+      Pointee: 186 GoSliceDataType net.IP.array
     - __kind: GoSliceDataType
-      ID: 191
+      ID: 188
       Name: '[]*net/url.URL.array'
       ByteSize: 2048
       Element: 9 PointerType *net/url.URL
     - __kind: PointerType
-      ID: 192
+      ID: 189
       Name: '*[]*net/url.URL.array'
       ByteSize: 8
-      Pointee: 191 GoSliceDataType []*net/url.URL.array
+      Pointee: 188 GoSliceDataType []*net/url.URL.array
     - __kind: GoSliceDataType
-      ID: 193
+      ID: 190
       Name: '[]*net.IPNet.array'
       ByteSize: 2048
       Element: 99 PointerType *net.IPNet
     - __kind: PointerType
-      ID: 194
+      ID: 191
       Name: '*[]*net.IPNet.array'
       ByteSize: 8
-      Pointee: 193 GoSliceDataType []*net.IPNet.array
+      Pointee: 190 GoSliceDataType []*net.IPNet.array
     - __kind: GoSliceDataType
-      ID: 195
+      ID: 192
       Name: net.IPMask.array
       ByteSize: 2048
       Element: 7 BaseType uint8
     - __kind: PointerType
-      ID: 196
+      ID: 193
       Name: '*net.IPMask.array'
       ByteSize: 8
-      Pointee: 195 GoSliceDataType net.IPMask.array
+      Pointee: 192 GoSliceDataType net.IPMask.array
     - __kind: GoSliceDataType
-      ID: 197
+      ID: 194
       Name: '[]crypto/x509.OID.array'
       ByteSize: 2048
       Element: 104 StructureType crypto/x509.OID
     - __kind: PointerType
-      ID: 198
+      ID: 195
       Name: '*[]crypto/x509.OID.array'
       ByteSize: 8
-      Pointee: 197 GoSliceDataType []crypto/x509.OID.array
+      Pointee: 194 GoSliceDataType []crypto/x509.OID.array
     - __kind: GoSliceDataType
-      ID: 199
+      ID: 196
       Name: '[][]*crypto/x509.Certificate.array'
       ByteSize: 2048
       Element: 55 GoSliceHeaderType []*crypto/x509.Certificate
     - __kind: PointerType
-      ID: 200
+      ID: 197
       Name: '*[][]*crypto/x509.Certificate.array'
       ByteSize: 8
-      Pointee: 199 GoSliceDataType [][]*crypto/x509.Certificate.array
+      Pointee: 196 GoSliceDataType [][]*crypto/x509.Certificate.array
     - __kind: GoSliceDataType
-      ID: 201
+      ID: 198
       Name: '[][]uint8.array'
       ByteSize: 2048
       Element: 52 GoSliceHeaderType []uint8
     - __kind: PointerType
-      ID: 202
+      ID: 199
       Name: '*[][]uint8.array'
       ByteSize: 8
-      Pointee: 201 GoSliceDataType [][]uint8.array
+      Pointee: 198 GoSliceDataType [][]uint8.array
     - __kind: GoSliceDataType
-      ID: 203
+      ID: 200
       Name: '[]net/http.segment.array'
       ByteSize: 2048
       Element: 119 StructureType net/http.segment
     - __kind: PointerType
-      ID: 204
+      ID: 201
       Name: '*[]net/http.segment.array'
       ByteSize: 8
-      Pointee: 203 GoSliceDataType []net/http.segment.array
+      Pointee: 200 GoSliceDataType []net/http.segment.array
     - __kind: GoSliceDataType
-      ID: 205
+      ID: 202
       Name: '[]bucket<string,string>.array'
       ByteSize: 2048
       Element: 124 GoHMapBucketType bucket<string,string>
     - __kind: EventRootType
-      ID: 206
+      ID: 203
       Name: Probe[main.HandleHTTP]
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -2340,7 +2325,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 207
+      ID: 204
       Name: Probe[main.LookAtTheRequest]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -2354,6 +2339,6 @@ Types:
                   Variable: {subprogram: 2, index: 0, name: path}
                   Offset: 0
                   ByteSize: 16
-MaxTypeID: 207
+MaxTypeID: 204
 Issues: []
 GoModuledataInfo: {FirstModuledataAddr: "0x12ddd40", TypesOffset: 296}

--- a/pkg/dyninst/irgen/testdata/snapshot/rc_tester_v1.arch=arm64,toolchain=go1.23.11.yaml
+++ b/pkg/dyninst/irgen/testdata/snapshot/rc_tester_v1.arch=arm64,toolchain=go1.23.11.yaml
@@ -10,7 +10,7 @@ Probes:
       subprogram: {subprogram: 1}
       events:
         - ID: 1
-          Type: 203 EventRootType Probe[main.HandleHTTP]
+          Type: 195 EventRootType Probe[main.HandleHTTP]
           InjectionPoints: [{PC: "0x8ad870", Frameless: true}]
           Condition: null
     - id: look_at_the_request
@@ -23,7 +23,7 @@ Probes:
       subprogram: {subprogram: 2}
       events:
         - ID: 2
-          Type: 204 EventRootType Probe[main.LookAtTheRequest]
+          Type: 196 EventRootType Probe[main.LookAtTheRequest]
           InjectionPoints: [{PC: "0x8adb9c", Frameless: true}]
           Condition: null
 Subprograms:
@@ -121,142 +121,125 @@ Subprograms:
           IsReturn: false
 Types:
     - __kind: PointerType
-      ID: 92
+      ID: 101
       Name: '**crypto/x509.Certificate'
       ByteSize: 8
-      Pointee: 93 PointerType *crypto/x509.Certificate
+      Pointee: 102 PointerType *crypto/x509.Certificate
     - __kind: PointerType
-      ID: 113
+      ID: 90
       Name: '**mime/multipart.FileHeader'
       ByteSize: 8
       GoKind: 22
-      Pointee: 114 PointerType *mime/multipart.FileHeader
+      Pointee: 91 PointerType *mime/multipart.FileHeader
     - __kind: PointerType
-      ID: 156
+      ID: 144
       Name: '**net.IPNet'
       ByteSize: 8
       GoKind: 22
-      Pointee: 157 PointerType *net.IPNet
+      Pointee: 145 PointerType *net.IPNet
     - __kind: PointerType
-      ID: 154
+      ID: 142
       Name: '**net/url.URL'
       ByteSize: 8
-      Pointee: 44 PointerType *net/url.URL
+      Pointee: 46 PointerType *net/url.URL
     - __kind: PointerType
-      ID: 110
-      Name: '**runtime.bmap'
-      ByteSize: 8
-      Pointee: 83 PointerType *runtime.bmap
-    - __kind: PointerType
-      ID: 95
+      ID: 104
       Name: '*[]*crypto/x509.Certificate'
       ByteSize: 8
       GoKind: 22
-      Pointee: 91 GoSliceHeaderType []*crypto/x509.Certificate
+      Pointee: 100 GoSliceHeaderType []*crypto/x509.Certificate
     - __kind: PointerType
-      ID: 120
+      ID: 111
       Name: '*[]*crypto/x509.Certificate.array'
       ByteSize: 8
-      Pointee: 119 GoSliceDataType []*crypto/x509.Certificate.array
+      Pointee: 110 GoSliceDataType []*crypto/x509.Certificate.array
     - __kind: PointerType
-      ID: 162
+      ID: 95
       Name: '*[]*mime/multipart.FileHeader.array'
       ByteSize: 8
-      Pointee: 161 GoSliceDataType []*mime/multipart.FileHeader.array
+      Pointee: 94 GoSliceDataType []*mime/multipart.FileHeader.array
     - __kind: PointerType
-      ID: 191
+      ID: 178
       Name: '*[]*net.IPNet.array'
       ByteSize: 8
-      Pointee: 190 GoSliceDataType []*net.IPNet.array
-    - __kind: PointerType
-      ID: 189
-      Name: '*[]*net/url.URL.array'
-      ByteSize: 8
-      Pointee: 188 GoSliceDataType []*net/url.URL.array
-    - __kind: PointerType
-      ID: 81
-      Name: '*[]*runtime.bmap'
-      ByteSize: 8
-      GoRuntimeType: 466496
-      GoKind: 22
-      Pointee: 82 GoSliceHeaderType []*runtime.bmap
-    - __kind: PointerType
-      ID: 117
-      Name: '*[]*runtime.bmap.array'
-      ByteSize: 8
-      Pointee: 116 GoSliceDataType []*runtime.bmap.array
-    - __kind: PointerType
-      ID: 122
-      Name: '*[][]*crypto/x509.Certificate.array'
-      ByteSize: 8
-      Pointee: 121 GoSliceDataType [][]*crypto/x509.Certificate.array
-    - __kind: PointerType
-      ID: 124
-      Name: '*[][]uint8.array'
-      ByteSize: 8
-      Pointee: 123 GoSliceDataType [][]uint8.array
-    - __kind: PointerType
-      ID: 183
-      Name: '*[]crypto/x509.ExtKeyUsage.array'
-      ByteSize: 8
-      Pointee: 182 GoSliceDataType []crypto/x509.ExtKeyUsage.array
-    - __kind: PointerType
-      ID: 193
-      Name: '*[]crypto/x509.OID.array'
-      ByteSize: 8
-      Pointee: 192 GoSliceDataType []crypto/x509.OID.array
+      Pointee: 177 GoSliceDataType []*net.IPNet.array
     - __kind: PointerType
       ID: 175
+      Name: '*[]*net/url.URL.array'
+      ByteSize: 8
+      Pointee: 174 GoSliceDataType []*net/url.URL.array
+    - __kind: PointerType
+      ID: 113
+      Name: '*[][]*crypto/x509.Certificate.array'
+      ByteSize: 8
+      Pointee: 112 GoSliceDataType [][]*crypto/x509.Certificate.array
+    - __kind: PointerType
+      ID: 115
+      Name: '*[][]uint8.array'
+      ByteSize: 8
+      Pointee: 114 GoSliceDataType [][]uint8.array
+    - __kind: PointerType
+      ID: 171
+      Name: '*[]crypto/x509.ExtKeyUsage.array'
+      ByteSize: 8
+      Pointee: 170 GoSliceDataType []crypto/x509.ExtKeyUsage.array
+    - __kind: PointerType
+      ID: 180
+      Name: '*[]crypto/x509.OID.array'
+      ByteSize: 8
+      Pointee: 179 GoSliceDataType []crypto/x509.OID.array
+    - __kind: PointerType
+      ID: 155
       Name: '*[]crypto/x509/pkix.AttributeTypeAndValue.array'
       ByteSize: 8
-      Pointee: 174 GoSliceDataType []crypto/x509/pkix.AttributeTypeAndValue.array
+      Pointee: 154 GoSliceDataType []crypto/x509/pkix.AttributeTypeAndValue.array
     - __kind: PointerType
-      ID: 177
+      ID: 167
       Name: '*[]crypto/x509/pkix.Extension.array'
       ByteSize: 8
-      Pointee: 176 GoSliceDataType []crypto/x509/pkix.Extension.array
+      Pointee: 166 GoSliceDataType []crypto/x509/pkix.Extension.array
     - __kind: PointerType
-      ID: 179
+      ID: 169
       Name: '*[]encoding/asn1.ObjectIdentifier.array'
       ByteSize: 8
-      Pointee: 178 GoSliceDataType []encoding/asn1.ObjectIdentifier.array
+      Pointee: 168 GoSliceDataType []encoding/asn1.ObjectIdentifier.array
     - __kind: PointerType
-      ID: 185
+      ID: 173
       Name: '*[]net.IP.array'
       ByteSize: 8
-      Pointee: 184 GoSliceDataType []net.IP.array
+      Pointee: 172 GoSliceDataType []net.IP.array
     - __kind: PointerType
-      ID: 126
+      ID: 192
       Name: '*[]net/http.segment.array'
       ByteSize: 8
-      Pointee: 125 GoSliceDataType []net/http.segment.array
+      Pointee: 191 GoSliceDataType []net/http.segment.array
     - __kind: PointerType
-      ID: 106
+      ID: 81
       Name: '*[]string.array'
       ByteSize: 8
-      Pointee: 105 GoSliceDataType []string.array
+      Pointee: 80 GoSliceDataType []string.array
     - __kind: PointerType
-      ID: 198
+      ID: 163
       Name: '*[]time.zone.array'
       ByteSize: 8
-      Pointee: 197 GoSliceDataType []time.zone.array
+      Pointee: 162 GoSliceDataType []time.zone.array
     - __kind: PointerType
-      ID: 200
+      ID: 165
       Name: '*[]time.zoneTrans.array'
       ByteSize: 8
-      Pointee: 199 GoSliceDataType []time.zoneTrans.array
+      Pointee: 164 GoSliceDataType []time.zoneTrans.array
     - __kind: PointerType
-      ID: 97
+      ID: 106
       Name: '*[]uint8'
       ByteSize: 8
       GoRuntimeType: 452640
       GoKind: 22
-      Pointee: 72 GoSliceHeaderType []uint8
+      Pointee: 97 GoSliceHeaderType []uint8
     - __kind: PointerType
-      ID: 109
+      ID: 99
       Name: '*[]uint8.array'
       ByteSize: 8
-      Pointee: 108 GoSliceDataType []uint8.array
+      Pointee: 98 GoSliceDataType []uint8.array
     - __kind: PointerType
       ID: 5
       Name: '*bool'
@@ -265,81 +248,81 @@ Types:
       GoKind: 22
       Pointee: 4 BaseType bool
     - __kind: PointerType
-      ID: 89
+      ID: 86
       Name: '*bucket<string,[]*mime/multipart.FileHeader>'
       ByteSize: 8
-      Pointee: 90 GoHMapBucketType bucket<string,[]*mime/multipart.FileHeader>
+      Pointee: 87 GoHMapBucketType bucket<string,[]*mime/multipart.FileHeader>
     - __kind: PointerType
-      ID: 49
+      ID: 51
       Name: '*bucket<string,[]string>'
       ByteSize: 8
-      Pointee: 50 GoHMapBucketType bucket<string,[]string>
+      Pointee: 52 GoHMapBucketType bucket<string,[]string>
     - __kind: PointerType
-      ID: 70
+      ID: 72
       Name: '*bucket<string,string>'
       ByteSize: 8
-      Pointee: 71 GoHMapBucketType bucket<string,string>
+      Pointee: 73 GoHMapBucketType bucket<string,string>
     - __kind: PointerType
       ID: 39
       Name: '*bytes.Buffer'
       ByteSize: 8
       GoRuntimeType: 2.11552e+06
       GoKind: 22
-      Pointee: 40 StructureType bytes.Buffer
+      Pointee: 40 UnresolvedPointeeType bytes.Buffer
     - __kind: PointerType
-      ID: 59
+      ID: 61
       Name: '*crypto/tls.ConnectionState'
       ByteSize: 8
       GoRuntimeType: 836032
       GoKind: 22
-      Pointee: 60 StructureType crypto/tls.ConnectionState
+      Pointee: 62 StructureType crypto/tls.ConnectionState
     - __kind: PointerType
-      ID: 93
+      ID: 102
       Name: '*crypto/x509.Certificate'
       ByteSize: 8
       GoRuntimeType: 1.905824e+06
       GoKind: 22
-      Pointee: 115 StructureType crypto/x509.Certificate
+      Pointee: 109 StructureType crypto/x509.Certificate
     - __kind: PointerType
-      ID: 148
+      ID: 136
       Name: '*crypto/x509.ExtKeyUsage'
       ByteSize: 8
       GoRuntimeType: 395104
       GoKind: 22
-      Pointee: 149 BaseType crypto/x509.ExtKeyUsage
+      Pointee: 137 BaseType crypto/x509.ExtKeyUsage
     - __kind: PointerType
-      ID: 159
+      ID: 147
       Name: '*crypto/x509.OID'
       ByteSize: 8
       GoRuntimeType: 1.717792e+06
       GoKind: 22
-      Pointee: 160 StructureType crypto/x509.OID
+      Pointee: 148 StructureType crypto/x509.OID
     - __kind: PointerType
-      ID: 135
+      ID: 123
       Name: '*crypto/x509/pkix.AttributeTypeAndValue'
       ByteSize: 8
       GoRuntimeType: 408928
       GoKind: 22
-      Pointee: 136 StructureType crypto/x509/pkix.AttributeTypeAndValue
+      Pointee: 124 StructureType crypto/x509/pkix.AttributeTypeAndValue
     - __kind: PointerType
-      ID: 142
+      ID: 130
       Name: '*crypto/x509/pkix.Extension'
       ByteSize: 8
       GoRuntimeType: 409120
       GoKind: 22
-      Pointee: 143 StructureType crypto/x509/pkix.Extension
+      Pointee: 131 StructureType crypto/x509/pkix.Extension
     - __kind: PointerType
-      ID: 145
+      ID: 133
       Name: '*encoding/asn1.ObjectIdentifier'
       ByteSize: 8
       GoRuntimeType: 1.00992e+06
       GoKind: 22
-      Pointee: 146 GoSliceHeaderType encoding/asn1.ObjectIdentifier
+      Pointee: 134 GoSliceHeaderType encoding/asn1.ObjectIdentifier
     - __kind: PointerType
-      ID: 181
+      ID: 182
       Name: '*encoding/asn1.ObjectIdentifier.array'
       ByteSize: 8
-      Pointee: 180 GoSliceDataType encoding/asn1.ObjectIdentifier.array
+      Pointee: 181 GoSliceDataType encoding/asn1.ObjectIdentifier.array
     - __kind: PointerType
       ID: 33
       Name: '*error'
@@ -362,20 +345,20 @@ Types:
       GoKind: 22
       Pointee: 17 BaseType float64
     - __kind: PointerType
-      ID: 87
+      ID: 84
       Name: '*hash<string,[]*mime/multipart.FileHeader>'
       ByteSize: 8
-      Pointee: 88 GoHMapHeaderType hash<string,[]*mime/multipart.FileHeader>
+      Pointee: 85 GoHMapHeaderType hash<string,[]*mime/multipart.FileHeader>
     - __kind: PointerType
-      ID: 47
+      ID: 49
       Name: '*hash<string,[]string>'
       ByteSize: 8
-      Pointee: 48 GoHMapHeaderType hash<string,[]string>
+      Pointee: 50 GoHMapHeaderType hash<string,[]string>
     - __kind: PointerType
-      ID: 68
+      ID: 70
       Name: '*hash<string,string>'
       ByteSize: 8
-      Pointee: 69 GoHMapHeaderType hash<string,string>
+      Pointee: 71 GoHMapHeaderType hash<string,string>
     - __kind: PointerType
       ID: 28
       Name: '*int'
@@ -412,62 +395,62 @@ Types:
       GoKind: 22
       Pointee: 15 BaseType int8
     - __kind: PointerType
-      ID: 131
+      ID: 119
       Name: '*math/big.Int'
       ByteSize: 8
       GoRuntimeType: 2.231648e+06
       GoKind: 22
-      Pointee: 132 StructureType math/big.Int
+      Pointee: 120 StructureType math/big.Int
     - __kind: PointerType
-      ID: 165
+      ID: 150
       Name: '*math/big.Word'
       ByteSize: 8
       GoRuntimeType: 397920
       GoKind: 22
-      Pointee: 166 BaseType math/big.Word
+      Pointee: 151 BaseType math/big.Word
     - __kind: PointerType
-      ID: 196
+      ID: 153
       Name: '*math/big.nat.array'
       ByteSize: 8
-      Pointee: 195 GoSliceDataType math/big.nat.array
+      Pointee: 152 GoSliceDataType math/big.nat.array
     - __kind: PointerType
-      ID: 114
+      ID: 91
       Name: '*mime/multipart.FileHeader'
       ByteSize: 8
       GoRuntimeType: 837472
       GoKind: 22
-      Pointee: 127 StructureType mime/multipart.FileHeader
+      Pointee: 93 StructureType mime/multipart.FileHeader
     - __kind: PointerType
-      ID: 57
+      ID: 59
       Name: '*mime/multipart.Form'
       ByteSize: 8
       GoRuntimeType: 837568
       GoKind: 22
-      Pointee: 58 StructureType mime/multipart.Form
+      Pointee: 60 StructureType mime/multipart.Form
     - __kind: PointerType
-      ID: 151
+      ID: 139
       Name: '*net.IP'
       ByteSize: 8
       GoRuntimeType: 1.974688e+06
       GoKind: 22
-      Pointee: 152 GoSliceHeaderType net.IP
+      Pointee: 140 GoSliceHeaderType net.IP
     - __kind: PointerType
-      ID: 187
+      ID: 184
       Name: '*net.IP.array'
       ByteSize: 8
-      Pointee: 186 GoSliceDataType net.IP.array
+      Pointee: 183 GoSliceDataType net.IP.array
     - __kind: PointerType
-      ID: 202
+      ID: 187
       Name: '*net.IPMask.array'
       ByteSize: 8
-      Pointee: 201 GoSliceDataType net.IPMask.array
+      Pointee: 186 GoSliceDataType net.IPMask.array
     - __kind: PointerType
-      ID: 157
+      ID: 145
       Name: '*net.IPNet'
       ByteSize: 8
       GoRuntimeType: 1.095968e+06
       GoKind: 22
-      Pointee: 173 StructureType net.IPNet
+      Pointee: 176 StructureType net.IPNet
     - __kind: PointerType
       ID: 37
       Name: '*net/http.Request'
@@ -476,54 +459,47 @@ Types:
       GoKind: 22
       Pointee: 38 StructureType net/http.Request
     - __kind: PointerType
-      ID: 62
+      ID: 64
       Name: '*net/http.Response'
       ByteSize: 8
       GoRuntimeType: 1.591456e+06
       GoKind: 22
-      Pointee: 63 StructureType net/http.Response
+      Pointee: 65 StructureType net/http.Response
     - __kind: PointerType
-      ID: 65
+      ID: 67
       Name: '*net/http.pattern'
       ByteSize: 8
       GoRuntimeType: 1.416576e+06
       GoKind: 22
-      Pointee: 66 StructureType net/http.pattern
+      Pointee: 68 StructureType net/http.pattern
     - __kind: PointerType
-      ID: 101
+      ID: 189
       Name: '*net/http.segment'
       ByteSize: 8
       GoRuntimeType: 364064
       GoKind: 22
-      Pointee: 102 StructureType net/http.segment
+      Pointee: 190 StructureType net/http.segment
     - __kind: PointerType
-      ID: 44
+      ID: 46
       Name: '*net/url.URL'
       ByteSize: 8
       GoRuntimeType: 1.94976e+06
       GoKind: 22
-      Pointee: 45 StructureType net/url.URL
+      Pointee: 47 StructureType net/url.URL
     - __kind: PointerType
-      ID: 76
+      ID: 74
       Name: '*net/url.Userinfo'
       ByteSize: 8
       GoRuntimeType: 1.1144e+06
       GoKind: 22
-      Pointee: 77 StructureType net/url.Userinfo
+      Pointee: 75 StructureType net/url.Userinfo
     - __kind: PointerType
-      ID: 83
-      Name: '*runtime.bmap'
-      ByteSize: 8
-      GoRuntimeType: 1.110048e+06
-      GoKind: 22
-      Pointee: 84 StructureType runtime.bmap
-    - __kind: PointerType
-      ID: 51
+      ID: 53
       Name: '*runtime.mapextra'
       ByteSize: 8
       GoRuntimeType: 375584
       GoKind: 22
-      Pointee: 52 StructureType runtime.mapextra
+      Pointee: 54 UnresolvedPointeeType runtime.mapextra
     - __kind: PointerType
       ID: 22
       Name: '*string'
@@ -532,31 +508,31 @@ Types:
       GoKind: 22
       Pointee: 11 GoStringHeaderType string
     - __kind: PointerType
-      ID: 75
+      ID: 45
       Name: '*string.str'
       ByteSize: 8
-      Pointee: 74 GoStringDataType string.str
+      Pointee: 44 GoStringDataType string.str
     - __kind: PointerType
-      ID: 138
+      ID: 126
       Name: '*time.Location'
       ByteSize: 8
       GoRuntimeType: 1.421568e+06
       GoKind: 22
-      Pointee: 139 StructureType time.Location
+      Pointee: 127 StructureType time.Location
     - __kind: PointerType
-      ID: 168
+      ID: 157
       Name: '*time.zone'
       ByteSize: 8
       GoRuntimeType: 367136
       GoKind: 22
-      Pointee: 169 StructureType time.zone
+      Pointee: 158 StructureType time.zone
     - __kind: PointerType
-      ID: 171
+      ID: 160
       Name: '*time.zoneTrans'
       ByteSize: 8
       GoRuntimeType: 367200
       GoKind: 22
-      Pointee: 172 StructureType time.zoneTrans
+      Pointee: 161 StructureType time.zoneTrans
     - __kind: PointerType
       ID: 34
       Name: '*uint'
@@ -600,12 +576,12 @@ Types:
       GoKind: 22
       Pointee: 1 BaseType uintptr
     - __kind: GoChannelType
-      ID: 61
+      ID: 63
       Name: <-chan struct {}
       GoRuntimeType: 546944
       GoKind: 18
     - __kind: EventRootType
-      ID: 203
+      ID: 195
       Name: Probe[main.HandleHTTP]
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -629,7 +605,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 204
+      ID: 196
       Name: Probe[main.LookAtTheRequest]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -644,7 +620,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: ArrayType
-      ID: 78
+      ID: 76
       Name: '[8]uint8'
       ByteSize: 8
       GoRuntimeType: 621920
@@ -653,7 +629,7 @@ Types:
       HasCount: true
       Element: 3 BaseType uint8
     - __kind: GoSliceHeaderType
-      ID: 91
+      ID: 100
       Name: '[]*crypto/x509.Certificate'
       ByteSize: 24
       GoRuntimeType: 469664
@@ -661,21 +637,21 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 92 PointerType **crypto/x509.Certificate
+          Type: 101 PointerType **crypto/x509.Certificate
         - Name: len
           Offset: 8
           Type: 9 BaseType int
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 119 GoSliceDataType []*crypto/x509.Certificate.array
+      Data: 110 GoSliceDataType []*crypto/x509.Certificate.array
     - __kind: GoSliceDataType
-      ID: 119
+      ID: 110
       Name: '[]*crypto/x509.Certificate.array'
       ByteSize: 2048
-      Element: 93 PointerType *crypto/x509.Certificate
+      Element: 102 PointerType *crypto/x509.Certificate
     - __kind: GoSliceHeaderType
-      ID: 112
+      ID: 89
       Name: '[]*mime/multipart.FileHeader'
       ByteSize: 24
       GoRuntimeType: 457504
@@ -683,21 +659,21 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 113 PointerType **mime/multipart.FileHeader
+          Type: 90 PointerType **mime/multipart.FileHeader
         - Name: len
           Offset: 8
           Type: 9 BaseType int
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 161 GoSliceDataType []*mime/multipart.FileHeader.array
+      Data: 94 GoSliceDataType []*mime/multipart.FileHeader.array
     - __kind: GoSliceDataType
-      ID: 161
+      ID: 94
       Name: '[]*mime/multipart.FileHeader.array'
       ByteSize: 2048
-      Element: 114 PointerType *mime/multipart.FileHeader
+      Element: 91 PointerType *mime/multipart.FileHeader
     - __kind: GoSliceHeaderType
-      ID: 155
+      ID: 143
       Name: '[]*net.IPNet'
       ByteSize: 24
       GoRuntimeType: 481696
@@ -705,21 +681,21 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 156 PointerType **net.IPNet
+          Type: 144 PointerType **net.IPNet
         - Name: len
           Offset: 8
           Type: 9 BaseType int
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 190 GoSliceDataType []*net.IPNet.array
+      Data: 177 GoSliceDataType []*net.IPNet.array
     - __kind: GoSliceDataType
-      ID: 190
+      ID: 177
       Name: '[]*net.IPNet.array'
       ByteSize: 2048
-      Element: 157 PointerType *net.IPNet
+      Element: 145 PointerType *net.IPNet
     - __kind: GoSliceHeaderType
-      ID: 153
+      ID: 141
       Name: '[]*net/url.URL'
       ByteSize: 24
       GoRuntimeType: 481632
@@ -727,43 +703,21 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 154 PointerType **net/url.URL
+          Type: 142 PointerType **net/url.URL
         - Name: len
           Offset: 8
           Type: 9 BaseType int
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 188 GoSliceDataType []*net/url.URL.array
+      Data: 174 GoSliceDataType []*net/url.URL.array
     - __kind: GoSliceDataType
-      ID: 188
+      ID: 174
       Name: '[]*net/url.URL.array'
       ByteSize: 2048
-      Element: 44 PointerType *net/url.URL
+      Element: 46 PointerType *net/url.URL
     - __kind: GoSliceHeaderType
-      ID: 82
-      Name: '[]*runtime.bmap'
-      ByteSize: 24
-      GoRuntimeType: 466432
-      GoKind: 23
-      RawFields:
-        - Name: array
-          Offset: 0
-          Type: 110 PointerType **runtime.bmap
-        - Name: len
-          Offset: 8
-          Type: 9 BaseType int
-        - Name: cap
-          Offset: 16
-          Type: 9 BaseType int
-      Data: 116 GoSliceDataType []*runtime.bmap.array
-    - __kind: GoSliceDataType
-      ID: 116
-      Name: '[]*runtime.bmap.array'
-      ByteSize: 2048
-      Element: 83 PointerType *runtime.bmap
-    - __kind: GoSliceHeaderType
-      ID: 94
+      ID: 103
       Name: '[][]*crypto/x509.Certificate'
       ByteSize: 24
       GoRuntimeType: 469792
@@ -771,21 +725,21 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 95 PointerType *[]*crypto/x509.Certificate
+          Type: 104 PointerType *[]*crypto/x509.Certificate
         - Name: len
           Offset: 8
           Type: 9 BaseType int
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 121 GoSliceDataType [][]*crypto/x509.Certificate.array
+      Data: 112 GoSliceDataType [][]*crypto/x509.Certificate.array
     - __kind: GoSliceDataType
-      ID: 121
+      ID: 112
       Name: '[][]*crypto/x509.Certificate.array'
       ByteSize: 2048
-      Element: 91 GoSliceHeaderType []*crypto/x509.Certificate
+      Element: 100 GoSliceHeaderType []*crypto/x509.Certificate
     - __kind: GoSliceHeaderType
-      ID: 96
+      ID: 105
       Name: '[][]uint8'
       ByteSize: 24
       GoRuntimeType: 452960
@@ -793,36 +747,36 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 97 PointerType *[]uint8
+          Type: 106 PointerType *[]uint8
         - Name: len
           Offset: 8
           Type: 9 BaseType int
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 123 GoSliceDataType [][]uint8.array
+      Data: 114 GoSliceDataType [][]uint8.array
     - __kind: GoSliceDataType
-      ID: 123
+      ID: 114
       Name: '[][]uint8.array'
       ByteSize: 2048
-      Element: 72 GoSliceHeaderType []uint8
+      Element: 97 GoSliceHeaderType []uint8
     - __kind: GoSliceDataType
-      ID: 118
+      ID: 92
       Name: '[]bucket<string,[]*mime/multipart.FileHeader>.array'
       ByteSize: 2048
-      Element: 90 GoHMapBucketType bucket<string,[]*mime/multipart.FileHeader>
+      Element: 87 GoHMapBucketType bucket<string,[]*mime/multipart.FileHeader>
     - __kind: GoSliceDataType
-      ID: 104
+      ID: 79
       Name: '[]bucket<string,[]string>.array'
       ByteSize: 2048
-      Element: 50 GoHMapBucketType bucket<string,[]string>
+      Element: 52 GoHMapBucketType bucket<string,[]string>
     - __kind: GoSliceDataType
-      ID: 107
+      ID: 194
       Name: '[]bucket<string,string>.array'
       ByteSize: 2048
-      Element: 71 GoHMapBucketType bucket<string,string>
+      Element: 73 GoHMapBucketType bucket<string,string>
     - __kind: GoSliceHeaderType
-      ID: 147
+      ID: 135
       Name: '[]crypto/x509.ExtKeyUsage'
       ByteSize: 24
       GoRuntimeType: 470944
@@ -830,21 +784,21 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 148 PointerType *crypto/x509.ExtKeyUsage
+          Type: 136 PointerType *crypto/x509.ExtKeyUsage
         - Name: len
           Offset: 8
           Type: 9 BaseType int
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 182 GoSliceDataType []crypto/x509.ExtKeyUsage.array
+      Data: 170 GoSliceDataType []crypto/x509.ExtKeyUsage.array
     - __kind: GoSliceDataType
-      ID: 182
+      ID: 170
       Name: '[]crypto/x509.ExtKeyUsage.array'
       ByteSize: 2048
-      Element: 149 BaseType crypto/x509.ExtKeyUsage
+      Element: 137 BaseType crypto/x509.ExtKeyUsage
     - __kind: GoSliceHeaderType
-      ID: 158
+      ID: 146
       Name: '[]crypto/x509.OID'
       ByteSize: 24
       GoRuntimeType: 481760
@@ -852,21 +806,21 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 159 PointerType *crypto/x509.OID
+          Type: 147 PointerType *crypto/x509.OID
         - Name: len
           Offset: 8
           Type: 9 BaseType int
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 192 GoSliceDataType []crypto/x509.OID.array
+      Data: 179 GoSliceDataType []crypto/x509.OID.array
     - __kind: GoSliceDataType
-      ID: 192
+      ID: 179
       Name: '[]crypto/x509.OID.array'
       ByteSize: 2048
-      Element: 160 StructureType crypto/x509.OID
+      Element: 148 StructureType crypto/x509.OID
     - __kind: GoSliceHeaderType
-      ID: 134
+      ID: 122
       Name: '[]crypto/x509/pkix.AttributeTypeAndValue'
       ByteSize: 24
       GoRuntimeType: 482016
@@ -874,21 +828,21 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 135 PointerType *crypto/x509/pkix.AttributeTypeAndValue
+          Type: 123 PointerType *crypto/x509/pkix.AttributeTypeAndValue
         - Name: len
           Offset: 8
           Type: 9 BaseType int
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 174 GoSliceDataType []crypto/x509/pkix.AttributeTypeAndValue.array
+      Data: 154 GoSliceDataType []crypto/x509/pkix.AttributeTypeAndValue.array
     - __kind: GoSliceDataType
-      ID: 174
+      ID: 154
       Name: '[]crypto/x509/pkix.AttributeTypeAndValue.array'
       ByteSize: 2048
-      Element: 136 StructureType crypto/x509/pkix.AttributeTypeAndValue
+      Element: 124 StructureType crypto/x509/pkix.AttributeTypeAndValue
     - __kind: GoSliceHeaderType
-      ID: 141
+      ID: 129
       Name: '[]crypto/x509/pkix.Extension'
       ByteSize: 24
       GoRuntimeType: 481504
@@ -896,21 +850,21 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 142 PointerType *crypto/x509/pkix.Extension
+          Type: 130 PointerType *crypto/x509/pkix.Extension
         - Name: len
           Offset: 8
           Type: 9 BaseType int
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 176 GoSliceDataType []crypto/x509/pkix.Extension.array
+      Data: 166 GoSliceDataType []crypto/x509/pkix.Extension.array
     - __kind: GoSliceDataType
-      ID: 176
+      ID: 166
       Name: '[]crypto/x509/pkix.Extension.array'
       ByteSize: 2048
-      Element: 143 StructureType crypto/x509/pkix.Extension
+      Element: 131 StructureType crypto/x509/pkix.Extension
     - __kind: GoSliceHeaderType
-      ID: 144
+      ID: 132
       Name: '[]encoding/asn1.ObjectIdentifier'
       ByteSize: 24
       GoRuntimeType: 481568
@@ -918,28 +872,28 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 145 PointerType *encoding/asn1.ObjectIdentifier
+          Type: 133 PointerType *encoding/asn1.ObjectIdentifier
         - Name: len
           Offset: 8
           Type: 9 BaseType int
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 178 GoSliceDataType []encoding/asn1.ObjectIdentifier.array
+      Data: 168 GoSliceDataType []encoding/asn1.ObjectIdentifier.array
     - __kind: GoSliceDataType
-      ID: 178
+      ID: 168
       Name: '[]encoding/asn1.ObjectIdentifier.array'
       ByteSize: 2048
-      Element: 146 GoSliceHeaderType encoding/asn1.ObjectIdentifier
+      Element: 134 GoSliceHeaderType encoding/asn1.ObjectIdentifier
     - __kind: ArrayType
-      ID: 79
+      ID: 77
       Name: '[]key<string>'
       ByteSize: 128
       Count: 8
       HasCount: true
       Element: 11 GoStringHeaderType string
     - __kind: GoSliceHeaderType
-      ID: 150
+      ID: 138
       Name: '[]net.IP'
       ByteSize: 24
       GoRuntimeType: 454176
@@ -947,21 +901,21 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 151 PointerType *net.IP
+          Type: 139 PointerType *net.IP
         - Name: len
           Offset: 8
           Type: 9 BaseType int
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 184 GoSliceDataType []net.IP.array
+      Data: 172 GoSliceDataType []net.IP.array
     - __kind: GoSliceDataType
-      ID: 184
+      ID: 172
       Name: '[]net.IP.array'
       ByteSize: 2048
-      Element: 152 GoSliceHeaderType net.IP
+      Element: 140 GoSliceHeaderType net.IP
     - __kind: GoSliceHeaderType
-      ID: 100
+      ID: 188
       Name: '[]net/http.segment'
       ByteSize: 24
       GoRuntimeType: 454944
@@ -969,21 +923,21 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 101 PointerType *net/http.segment
+          Type: 189 PointerType *net/http.segment
         - Name: len
           Offset: 8
           Type: 9 BaseType int
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 125 GoSliceDataType []net/http.segment.array
+      Data: 191 GoSliceDataType []net/http.segment.array
     - __kind: GoSliceDataType
-      ID: 125
+      ID: 191
       Name: '[]net/http.segment.array'
       ByteSize: 2048
-      Element: 102 StructureType net/http.segment
+      Element: 190 StructureType net/http.segment
     - __kind: GoSliceHeaderType
-      ID: 55
+      ID: 57
       Name: '[]string'
       ByteSize: 24
       GoRuntimeType: 464768
@@ -998,14 +952,14 @@ Types:
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 105 GoSliceDataType []string.array
+      Data: 80 GoSliceDataType []string.array
     - __kind: GoSliceDataType
-      ID: 105
+      ID: 80
       Name: '[]string.array'
       ByteSize: 2048
       Element: 11 GoStringHeaderType string
     - __kind: GoSliceHeaderType
-      ID: 167
+      ID: 156
       Name: '[]time.zone'
       ByteSize: 24
       GoRuntimeType: 459168
@@ -1013,21 +967,21 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 168 PointerType *time.zone
+          Type: 157 PointerType *time.zone
         - Name: len
           Offset: 8
           Type: 9 BaseType int
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 197 GoSliceDataType []time.zone.array
+      Data: 162 GoSliceDataType []time.zone.array
     - __kind: GoSliceDataType
-      ID: 197
+      ID: 162
       Name: '[]time.zone.array'
       ByteSize: 2048
-      Element: 169 StructureType time.zone
+      Element: 158 StructureType time.zone
     - __kind: GoSliceHeaderType
-      ID: 170
+      ID: 159
       Name: '[]time.zoneTrans'
       ByteSize: 24
       GoRuntimeType: 459232
@@ -1035,21 +989,21 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 171 PointerType *time.zoneTrans
+          Type: 160 PointerType *time.zoneTrans
         - Name: len
           Offset: 8
           Type: 9 BaseType int
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 199 GoSliceDataType []time.zoneTrans.array
+      Data: 164 GoSliceDataType []time.zoneTrans.array
     - __kind: GoSliceDataType
-      ID: 199
+      ID: 164
       Name: '[]time.zoneTrans.array'
       ByteSize: 2048
-      Element: 172 StructureType time.zoneTrans
+      Element: 161 StructureType time.zoneTrans
     - __kind: GoSliceHeaderType
-      ID: 72
+      ID: 97
       Name: '[]uint8'
       ByteSize: 24
       GoRuntimeType: 463616
@@ -1064,28 +1018,28 @@ Types:
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 108 GoSliceDataType []uint8.array
+      Data: 98 GoSliceDataType []uint8.array
     - __kind: GoSliceDataType
-      ID: 108
+      ID: 98
       Name: '[]uint8.array'
       ByteSize: 2048
       Element: 3 BaseType uint8
     - __kind: ArrayType
-      ID: 111
+      ID: 88
       Name: '[]val<[]*mime/multipart.FileHeader>'
       ByteSize: 192
       Count: 8
       HasCount: true
-      Element: 112 GoSliceHeaderType []*mime/multipart.FileHeader
+      Element: 89 GoSliceHeaderType []*mime/multipart.FileHeader
     - __kind: ArrayType
-      ID: 80
+      ID: 78
       Name: '[]val<[]string>'
       ByteSize: 192
       Count: 8
       HasCount: true
-      Element: 55 GoSliceHeaderType []string
+      Element: 57 GoSliceHeaderType []string
     - __kind: ArrayType
-      ID: 103
+      ID: 193
       Name: '[]val<string>'
       ByteSize: 128
       Count: 8
@@ -1098,84 +1052,66 @@ Types:
       GoRuntimeType: 534784
       GoKind: 1
     - __kind: GoHMapBucketType
-      ID: 90
+      ID: 87
       Name: bucket<string,[]*mime/multipart.FileHeader>
       ByteSize: 336
       RawFields:
         - Name: tophash
           Offset: 0
-          Type: 78 ArrayType [8]uint8
+          Type: 76 ArrayType [8]uint8
         - Name: keys
           Offset: 8
-          Type: 79 ArrayType []key<string>
+          Type: 77 ArrayType []key<string>
         - Name: values
           Offset: 136
-          Type: 111 ArrayType []val<[]*mime/multipart.FileHeader>
+          Type: 88 ArrayType []val<[]*mime/multipart.FileHeader>
         - Name: overflow
           Offset: 328
-          Type: 89 PointerType *bucket<string,[]*mime/multipart.FileHeader>
+          Type: 86 PointerType *bucket<string,[]*mime/multipart.FileHeader>
       KeyType: 11 GoStringHeaderType string
-      ValueType: 112 GoSliceHeaderType []*mime/multipart.FileHeader
+      ValueType: 89 GoSliceHeaderType []*mime/multipart.FileHeader
     - __kind: GoHMapBucketType
-      ID: 50
+      ID: 52
       Name: bucket<string,[]string>
       ByteSize: 336
       RawFields:
         - Name: tophash
           Offset: 0
-          Type: 78 ArrayType [8]uint8
+          Type: 76 ArrayType [8]uint8
         - Name: keys
           Offset: 8
-          Type: 79 ArrayType []key<string>
+          Type: 77 ArrayType []key<string>
         - Name: values
           Offset: 136
-          Type: 80 ArrayType []val<[]string>
+          Type: 78 ArrayType []val<[]string>
         - Name: overflow
           Offset: 328
-          Type: 49 PointerType *bucket<string,[]string>
+          Type: 51 PointerType *bucket<string,[]string>
       KeyType: 11 GoStringHeaderType string
-      ValueType: 55 GoSliceHeaderType []string
+      ValueType: 57 GoSliceHeaderType []string
     - __kind: GoHMapBucketType
-      ID: 71
+      ID: 73
       Name: bucket<string,string>
       ByteSize: 272
       RawFields:
         - Name: tophash
           Offset: 0
-          Type: 78 ArrayType [8]uint8
+          Type: 76 ArrayType [8]uint8
         - Name: keys
           Offset: 8
-          Type: 79 ArrayType []key<string>
+          Type: 77 ArrayType []key<string>
         - Name: values
           Offset: 136
-          Type: 103 ArrayType []val<string>
+          Type: 193 ArrayType []val<string>
         - Name: overflow
           Offset: 264
-          Type: 70 PointerType *bucket<string,string>
+          Type: 72 PointerType *bucket<string,string>
       KeyType: 11 GoStringHeaderType string
       ValueType: 11 GoStringHeaderType string
-    - __kind: StructureType
+    - __kind: UnresolvedPointeeType
       ID: 40
       Name: bytes.Buffer
-      ByteSize: 40
-      GoRuntimeType: 1.414272e+06
-      GoKind: 25
-      RawFields:
-        - Name: buf
-          Offset: 0
-          Type: 72 GoSliceHeaderType []uint8
-        - Name: off
-          Offset: 24
-          Type: 9 BaseType int
-        - Name: lastRead
-          Offset: 32
-          Type: 73 BaseType bytes.readOp
-    - __kind: BaseType
-      ID: 73
-      Name: bytes.readOp
-      ByteSize: 1
-      GoRuntimeType: 532992
-      GoKind: 3
+      ByteSize: 8
     - __kind: BaseType
       ID: 25
       Name: complex128
@@ -1189,7 +1125,7 @@ Types:
       GoRuntimeType: 534528
       GoKind: 15
     - __kind: GoInterfaceType
-      ID: 64
+      ID: 66
       Name: context.Context
       ByteSize: 16
       GoRuntimeType: 1.187296e+06
@@ -1217,7 +1153,7 @@ Types:
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 60
+      ID: 62
       Name: crypto/tls.ConnectionState
       ByteSize: 192
       GoRuntimeType: 2.100544e+06
@@ -1246,39 +1182,39 @@ Types:
           Type: 11 GoStringHeaderType string
         - Name: PeerCertificates
           Offset: 48
-          Type: 91 GoSliceHeaderType []*crypto/x509.Certificate
+          Type: 100 GoSliceHeaderType []*crypto/x509.Certificate
         - Name: VerifiedChains
           Offset: 72
-          Type: 94 GoSliceHeaderType [][]*crypto/x509.Certificate
+          Type: 103 GoSliceHeaderType [][]*crypto/x509.Certificate
         - Name: SignedCertificateTimestamps
           Offset: 96
-          Type: 96 GoSliceHeaderType [][]uint8
+          Type: 105 GoSliceHeaderType [][]uint8
         - Name: OCSPResponse
           Offset: 120
-          Type: 72 GoSliceHeaderType []uint8
+          Type: 97 GoSliceHeaderType []uint8
         - Name: TLSUnique
           Offset: 144
-          Type: 72 GoSliceHeaderType []uint8
+          Type: 97 GoSliceHeaderType []uint8
         - Name: ECHAccepted
           Offset: 168
           Type: 4 BaseType bool
         - Name: ekm
           Offset: 176
-          Type: 98 GoSubroutineType func(string, []uint8, int) ([]uint8, error)
+          Type: 107 GoSubroutineType func(string, []uint8, int) ([]uint8, error)
         - Name: testingOnlyDidHRR
           Offset: 184
           Type: 4 BaseType bool
         - Name: testingOnlyCurveID
           Offset: 186
-          Type: 99 BaseType crypto/tls.CurveID
+          Type: 108 BaseType crypto/tls.CurveID
     - __kind: BaseType
-      ID: 99
+      ID: 108
       Name: crypto/tls.CurveID
       ByteSize: 2
       GoRuntimeType: 766144
       GoKind: 9
     - __kind: StructureType
-      ID: 115
+      ID: 109
       Name: crypto/x509.Certificate
       ByteSize: 1352
       GoRuntimeType: 2.2352e+06
@@ -1286,67 +1222,67 @@ Types:
       RawFields:
         - Name: Raw
           Offset: 0
-          Type: 72 GoSliceHeaderType []uint8
+          Type: 97 GoSliceHeaderType []uint8
         - Name: RawTBSCertificate
           Offset: 24
-          Type: 72 GoSliceHeaderType []uint8
+          Type: 97 GoSliceHeaderType []uint8
         - Name: RawSubjectPublicKeyInfo
           Offset: 48
-          Type: 72 GoSliceHeaderType []uint8
+          Type: 97 GoSliceHeaderType []uint8
         - Name: RawSubject
           Offset: 72
-          Type: 72 GoSliceHeaderType []uint8
+          Type: 97 GoSliceHeaderType []uint8
         - Name: RawIssuer
           Offset: 96
-          Type: 72 GoSliceHeaderType []uint8
+          Type: 97 GoSliceHeaderType []uint8
         - Name: Signature
           Offset: 120
-          Type: 72 GoSliceHeaderType []uint8
+          Type: 97 GoSliceHeaderType []uint8
         - Name: SignatureAlgorithm
           Offset: 144
-          Type: 128 BaseType crypto/x509.SignatureAlgorithm
+          Type: 116 BaseType crypto/x509.SignatureAlgorithm
         - Name: PublicKeyAlgorithm
           Offset: 152
-          Type: 129 BaseType crypto/x509.PublicKeyAlgorithm
+          Type: 117 BaseType crypto/x509.PublicKeyAlgorithm
         - Name: PublicKey
           Offset: 160
-          Type: 130 GoEmptyInterfaceType interface {}
+          Type: 118 GoEmptyInterfaceType interface {}
         - Name: Version
           Offset: 176
           Type: 9 BaseType int
         - Name: SerialNumber
           Offset: 184
-          Type: 131 PointerType *math/big.Int
+          Type: 119 PointerType *math/big.Int
         - Name: Issuer
           Offset: 192
-          Type: 133 StructureType crypto/x509/pkix.Name
+          Type: 121 StructureType crypto/x509/pkix.Name
         - Name: Subject
           Offset: 440
-          Type: 133 StructureType crypto/x509/pkix.Name
+          Type: 121 StructureType crypto/x509/pkix.Name
         - Name: NotBefore
           Offset: 688
-          Type: 137 StructureType time.Time
+          Type: 125 StructureType time.Time
         - Name: NotAfter
           Offset: 712
-          Type: 137 StructureType time.Time
+          Type: 125 StructureType time.Time
         - Name: KeyUsage
           Offset: 736
-          Type: 140 BaseType crypto/x509.KeyUsage
+          Type: 128 BaseType crypto/x509.KeyUsage
         - Name: Extensions
           Offset: 744
-          Type: 141 GoSliceHeaderType []crypto/x509/pkix.Extension
+          Type: 129 GoSliceHeaderType []crypto/x509/pkix.Extension
         - Name: ExtraExtensions
           Offset: 768
-          Type: 141 GoSliceHeaderType []crypto/x509/pkix.Extension
+          Type: 129 GoSliceHeaderType []crypto/x509/pkix.Extension
         - Name: UnhandledCriticalExtensions
           Offset: 792
-          Type: 144 GoSliceHeaderType []encoding/asn1.ObjectIdentifier
+          Type: 132 GoSliceHeaderType []encoding/asn1.ObjectIdentifier
         - Name: ExtKeyUsage
           Offset: 816
-          Type: 147 GoSliceHeaderType []crypto/x509.ExtKeyUsage
+          Type: 135 GoSliceHeaderType []crypto/x509.ExtKeyUsage
         - Name: UnknownExtKeyUsage
           Offset: 840
-          Type: 144 GoSliceHeaderType []encoding/asn1.ObjectIdentifier
+          Type: 132 GoSliceHeaderType []encoding/asn1.ObjectIdentifier
         - Name: BasicConstraintsValid
           Offset: 864
           Type: 4 BaseType bool
@@ -1361,78 +1297,78 @@ Types:
           Type: 4 BaseType bool
         - Name: SubjectKeyId
           Offset: 888
-          Type: 72 GoSliceHeaderType []uint8
+          Type: 97 GoSliceHeaderType []uint8
         - Name: AuthorityKeyId
           Offset: 912
-          Type: 72 GoSliceHeaderType []uint8
+          Type: 97 GoSliceHeaderType []uint8
         - Name: OCSPServer
           Offset: 936
-          Type: 55 GoSliceHeaderType []string
+          Type: 57 GoSliceHeaderType []string
         - Name: IssuingCertificateURL
           Offset: 960
-          Type: 55 GoSliceHeaderType []string
+          Type: 57 GoSliceHeaderType []string
         - Name: DNSNames
           Offset: 984
-          Type: 55 GoSliceHeaderType []string
+          Type: 57 GoSliceHeaderType []string
         - Name: EmailAddresses
           Offset: 1008
-          Type: 55 GoSliceHeaderType []string
+          Type: 57 GoSliceHeaderType []string
         - Name: IPAddresses
           Offset: 1032
-          Type: 150 GoSliceHeaderType []net.IP
+          Type: 138 GoSliceHeaderType []net.IP
         - Name: URIs
           Offset: 1056
-          Type: 153 GoSliceHeaderType []*net/url.URL
+          Type: 141 GoSliceHeaderType []*net/url.URL
         - Name: PermittedDNSDomainsCritical
           Offset: 1080
           Type: 4 BaseType bool
         - Name: PermittedDNSDomains
           Offset: 1088
-          Type: 55 GoSliceHeaderType []string
+          Type: 57 GoSliceHeaderType []string
         - Name: ExcludedDNSDomains
           Offset: 1112
-          Type: 55 GoSliceHeaderType []string
+          Type: 57 GoSliceHeaderType []string
         - Name: PermittedIPRanges
           Offset: 1136
-          Type: 155 GoSliceHeaderType []*net.IPNet
+          Type: 143 GoSliceHeaderType []*net.IPNet
         - Name: ExcludedIPRanges
           Offset: 1160
-          Type: 155 GoSliceHeaderType []*net.IPNet
+          Type: 143 GoSliceHeaderType []*net.IPNet
         - Name: PermittedEmailAddresses
           Offset: 1184
-          Type: 55 GoSliceHeaderType []string
+          Type: 57 GoSliceHeaderType []string
         - Name: ExcludedEmailAddresses
           Offset: 1208
-          Type: 55 GoSliceHeaderType []string
+          Type: 57 GoSliceHeaderType []string
         - Name: PermittedURIDomains
           Offset: 1232
-          Type: 55 GoSliceHeaderType []string
+          Type: 57 GoSliceHeaderType []string
         - Name: ExcludedURIDomains
           Offset: 1256
-          Type: 55 GoSliceHeaderType []string
+          Type: 57 GoSliceHeaderType []string
         - Name: CRLDistributionPoints
           Offset: 1280
-          Type: 55 GoSliceHeaderType []string
+          Type: 57 GoSliceHeaderType []string
         - Name: PolicyIdentifiers
           Offset: 1304
-          Type: 144 GoSliceHeaderType []encoding/asn1.ObjectIdentifier
+          Type: 132 GoSliceHeaderType []encoding/asn1.ObjectIdentifier
         - Name: Policies
           Offset: 1328
-          Type: 158 GoSliceHeaderType []crypto/x509.OID
+          Type: 146 GoSliceHeaderType []crypto/x509.OID
     - __kind: BaseType
-      ID: 149
+      ID: 137
       Name: crypto/x509.ExtKeyUsage
       ByteSize: 8
       GoRuntimeType: 537472
       GoKind: 2
     - __kind: BaseType
-      ID: 140
+      ID: 128
       Name: crypto/x509.KeyUsage
       ByteSize: 8
       GoRuntimeType: 537408
       GoKind: 2
     - __kind: StructureType
-      ID: 160
+      ID: 148
       Name: crypto/x509.OID
       ByteSize: 24
       GoRuntimeType: 1.718016e+06
@@ -1440,21 +1376,21 @@ Types:
       RawFields:
         - Name: der
           Offset: 0
-          Type: 72 GoSliceHeaderType []uint8
+          Type: 97 GoSliceHeaderType []uint8
     - __kind: BaseType
-      ID: 129
+      ID: 117
       Name: crypto/x509.PublicKeyAlgorithm
       ByteSize: 8
       GoRuntimeType: 768544
       GoKind: 2
     - __kind: BaseType
-      ID: 128
+      ID: 116
       Name: crypto/x509.SignatureAlgorithm
       ByteSize: 8
       GoRuntimeType: 1.071168e+06
       GoKind: 2
     - __kind: StructureType
-      ID: 136
+      ID: 124
       Name: crypto/x509/pkix.AttributeTypeAndValue
       ByteSize: 40
       GoRuntimeType: 1.316608e+06
@@ -1462,12 +1398,12 @@ Types:
       RawFields:
         - Name: Type
           Offset: 0
-          Type: 146 GoSliceHeaderType encoding/asn1.ObjectIdentifier
+          Type: 134 GoSliceHeaderType encoding/asn1.ObjectIdentifier
         - Name: Value
           Offset: 24
-          Type: 130 GoEmptyInterfaceType interface {}
+          Type: 118 GoEmptyInterfaceType interface {}
     - __kind: StructureType
-      ID: 143
+      ID: 131
       Name: crypto/x509/pkix.Extension
       ByteSize: 56
       GoRuntimeType: 1.45536e+06
@@ -1475,15 +1411,15 @@ Types:
       RawFields:
         - Name: Id
           Offset: 0
-          Type: 146 GoSliceHeaderType encoding/asn1.ObjectIdentifier
+          Type: 134 GoSliceHeaderType encoding/asn1.ObjectIdentifier
         - Name: Critical
           Offset: 24
           Type: 4 BaseType bool
         - Name: Value
           Offset: 32
-          Type: 72 GoSliceHeaderType []uint8
+          Type: 97 GoSliceHeaderType []uint8
     - __kind: StructureType
-      ID: 133
+      ID: 121
       Name: crypto/x509/pkix.Name
       ByteSize: 248
       GoRuntimeType: 2.047488e+06
@@ -1491,25 +1427,25 @@ Types:
       RawFields:
         - Name: Country
           Offset: 0
-          Type: 55 GoSliceHeaderType []string
+          Type: 57 GoSliceHeaderType []string
         - Name: Organization
           Offset: 24
-          Type: 55 GoSliceHeaderType []string
+          Type: 57 GoSliceHeaderType []string
         - Name: OrganizationalUnit
           Offset: 48
-          Type: 55 GoSliceHeaderType []string
+          Type: 57 GoSliceHeaderType []string
         - Name: Locality
           Offset: 72
-          Type: 55 GoSliceHeaderType []string
+          Type: 57 GoSliceHeaderType []string
         - Name: Province
           Offset: 96
-          Type: 55 GoSliceHeaderType []string
+          Type: 57 GoSliceHeaderType []string
         - Name: StreetAddress
           Offset: 120
-          Type: 55 GoSliceHeaderType []string
+          Type: 57 GoSliceHeaderType []string
         - Name: PostalCode
           Offset: 144
-          Type: 55 GoSliceHeaderType []string
+          Type: 57 GoSliceHeaderType []string
         - Name: SerialNumber
           Offset: 168
           Type: 11 GoStringHeaderType string
@@ -1518,12 +1454,12 @@ Types:
           Type: 11 GoStringHeaderType string
         - Name: Names
           Offset: 200
-          Type: 134 GoSliceHeaderType []crypto/x509/pkix.AttributeTypeAndValue
+          Type: 122 GoSliceHeaderType []crypto/x509/pkix.AttributeTypeAndValue
         - Name: ExtraNames
           Offset: 224
-          Type: 134 GoSliceHeaderType []crypto/x509/pkix.AttributeTypeAndValue
+          Type: 122 GoSliceHeaderType []crypto/x509/pkix.AttributeTypeAndValue
     - __kind: GoSliceHeaderType
-      ID: 146
+      ID: 134
       Name: encoding/asn1.ObjectIdentifier
       ByteSize: 24
       GoRuntimeType: 1.010048e+06
@@ -1538,9 +1474,9 @@ Types:
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 180 GoSliceDataType encoding/asn1.ObjectIdentifier.array
+      Data: 181 GoSliceDataType encoding/asn1.ObjectIdentifier.array
     - __kind: GoSliceDataType
-      ID: 180
+      ID: 181
       Name: encoding/asn1.ObjectIdentifier.array
       ByteSize: 2048
       Element: 9 BaseType int
@@ -1570,13 +1506,13 @@ Types:
       GoRuntimeType: 534720
       GoKind: 14
     - __kind: GoSubroutineType
-      ID: 54
+      ID: 56
       Name: func() (io.ReadCloser, error)
       ByteSize: 8
       GoRuntimeType: 634400
       GoKind: 19
     - __kind: GoSubroutineType
-      ID: 98
+      ID: 107
       Name: func(string, []uint8, int) ([]uint8, error)
       ByteSize: 8
       GoRuntimeType: 960448
@@ -1595,7 +1531,7 @@ Types:
           Offset: 8
           Type: 19 VoidPointerType unsafe.Pointer
     - __kind: GoHMapHeaderType
-      ID: 88
+      ID: 85
       Name: hash<string,[]*mime/multipart.FileHeader>
       ByteSize: 48
       RawFields:
@@ -1616,20 +1552,20 @@ Types:
           Type: 2 BaseType uint32
         - Name: buckets
           Offset: 16
-          Type: 89 PointerType *bucket<string,[]*mime/multipart.FileHeader>
+          Type: 86 PointerType *bucket<string,[]*mime/multipart.FileHeader>
         - Name: oldbuckets
           Offset: 24
-          Type: 89 PointerType *bucket<string,[]*mime/multipart.FileHeader>
+          Type: 86 PointerType *bucket<string,[]*mime/multipart.FileHeader>
         - Name: nevacuate
           Offset: 32
           Type: 1 BaseType uintptr
         - Name: extra
           Offset: 40
-          Type: 51 PointerType *runtime.mapextra
-      BucketType: 90 GoHMapBucketType bucket<string,[]*mime/multipart.FileHeader>
-      BucketsType: 118 GoSliceDataType []bucket<string,[]*mime/multipart.FileHeader>.array
+          Type: 53 PointerType *runtime.mapextra
+      BucketType: 87 GoHMapBucketType bucket<string,[]*mime/multipart.FileHeader>
+      BucketsType: 92 GoSliceDataType []bucket<string,[]*mime/multipart.FileHeader>.array
     - __kind: GoHMapHeaderType
-      ID: 48
+      ID: 50
       Name: hash<string,[]string>
       ByteSize: 48
       RawFields:
@@ -1650,20 +1586,20 @@ Types:
           Type: 2 BaseType uint32
         - Name: buckets
           Offset: 16
-          Type: 49 PointerType *bucket<string,[]string>
+          Type: 51 PointerType *bucket<string,[]string>
         - Name: oldbuckets
           Offset: 24
-          Type: 49 PointerType *bucket<string,[]string>
+          Type: 51 PointerType *bucket<string,[]string>
         - Name: nevacuate
           Offset: 32
           Type: 1 BaseType uintptr
         - Name: extra
           Offset: 40
-          Type: 51 PointerType *runtime.mapextra
-      BucketType: 50 GoHMapBucketType bucket<string,[]string>
-      BucketsType: 104 GoSliceDataType []bucket<string,[]string>.array
+          Type: 53 PointerType *runtime.mapextra
+      BucketType: 52 GoHMapBucketType bucket<string,[]string>
+      BucketsType: 79 GoSliceDataType []bucket<string,[]string>.array
     - __kind: GoHMapHeaderType
-      ID: 69
+      ID: 71
       Name: hash<string,string>
       ByteSize: 48
       RawFields:
@@ -1684,18 +1620,18 @@ Types:
           Type: 2 BaseType uint32
         - Name: buckets
           Offset: 16
-          Type: 70 PointerType *bucket<string,string>
+          Type: 72 PointerType *bucket<string,string>
         - Name: oldbuckets
           Offset: 24
-          Type: 70 PointerType *bucket<string,string>
+          Type: 72 PointerType *bucket<string,string>
         - Name: nevacuate
           Offset: 32
           Type: 1 BaseType uintptr
         - Name: extra
           Offset: 40
-          Type: 51 PointerType *runtime.mapextra
-      BucketType: 71 GoHMapBucketType bucket<string,string>
-      BucketsType: 107 GoSliceDataType []bucket<string,string>.array
+          Type: 53 PointerType *runtime.mapextra
+      BucketType: 73 GoHMapBucketType bucket<string,string>
+      BucketsType: 194 GoSliceDataType []bucket<string,string>.array
     - __kind: BaseType
       ID: 9
       Name: int
@@ -1727,7 +1663,7 @@ Types:
       GoRuntimeType: 533824
       GoKind: 3
     - __kind: GoEmptyInterfaceType
-      ID: 130
+      ID: 118
       Name: interface {}
       ByteSize: 16
       GoRuntimeType: 785472
@@ -1740,7 +1676,7 @@ Types:
           Offset: 8
           Type: 19 VoidPointerType unsafe.Pointer
     - __kind: GoInterfaceType
-      ID: 53
+      ID: 55
       Name: io.ReadCloser
       ByteSize: 16
       GoRuntimeType: 1.067328e+06
@@ -1753,28 +1689,28 @@ Types:
           Offset: 8
           Type: 19 VoidPointerType unsafe.Pointer
     - __kind: GoMapType
-      ID: 86
+      ID: 83
       Name: map[string][]*mime/multipart.FileHeader
       ByteSize: 8
       GoRuntimeType: 887392
       GoKind: 21
-      HeaderType: 88 GoHMapHeaderType hash<string,[]*mime/multipart.FileHeader>
+      HeaderType: 85 GoHMapHeaderType hash<string,[]*mime/multipart.FileHeader>
     - __kind: GoMapType
-      ID: 85
+      ID: 82
       Name: map[string][]string
       ByteSize: 8
       GoRuntimeType: 882592
       GoKind: 21
-      HeaderType: 48 GoHMapHeaderType hash<string,[]string>
+      HeaderType: 50 GoHMapHeaderType hash<string,[]string>
     - __kind: GoMapType
-      ID: 67
+      ID: 69
       Name: map[string]string
       ByteSize: 8
       GoRuntimeType: 884224
       GoKind: 21
-      HeaderType: 69 GoHMapHeaderType hash<string,string>
+      HeaderType: 71 GoHMapHeaderType hash<string,string>
     - __kind: StructureType
-      ID: 132
+      ID: 120
       Name: math/big.Int
       ByteSize: 32
       GoRuntimeType: 1.308608e+06
@@ -1785,15 +1721,15 @@ Types:
           Type: 4 BaseType bool
         - Name: abs
           Offset: 8
-          Type: 164 GoSliceHeaderType math/big.nat
+          Type: 149 GoSliceHeaderType math/big.nat
     - __kind: BaseType
-      ID: 166
+      ID: 151
       Name: math/big.Word
       ByteSize: 8
       GoRuntimeType: 537728
       GoKind: 7
     - __kind: GoSliceHeaderType
-      ID: 164
+      ID: 149
       Name: math/big.nat
       ByteSize: 24
       GoRuntimeType: 2.214784e+06
@@ -1801,21 +1737,21 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 165 PointerType *math/big.Word
+          Type: 150 PointerType *math/big.Word
         - Name: len
           Offset: 8
           Type: 9 BaseType int
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 195 GoSliceDataType math/big.nat.array
+      Data: 152 GoSliceDataType math/big.nat.array
     - __kind: GoSliceDataType
-      ID: 195
+      ID: 152
       Name: math/big.nat.array
       ByteSize: 2048
-      Element: 166 BaseType math/big.Word
+      Element: 151 BaseType math/big.Word
     - __kind: StructureType
-      ID: 127
+      ID: 93
       Name: mime/multipart.FileHeader
       ByteSize: 88
       GoRuntimeType: 1.83856e+06
@@ -1826,13 +1762,13 @@ Types:
           Type: 11 GoStringHeaderType string
         - Name: Header
           Offset: 16
-          Type: 163 GoMapType net/textproto.MIMEHeader
+          Type: 96 GoMapType net/textproto.MIMEHeader
         - Name: Size
           Offset: 24
           Type: 14 BaseType int64
         - Name: content
           Offset: 32
-          Type: 72 GoSliceHeaderType []uint8
+          Type: 97 GoSliceHeaderType []uint8
         - Name: tmpfile
           Offset: 56
           Type: 11 GoStringHeaderType string
@@ -1843,7 +1779,7 @@ Types:
           Offset: 80
           Type: 4 BaseType bool
     - __kind: StructureType
-      ID: 58
+      ID: 60
       Name: mime/multipart.Form
       ByteSize: 16
       GoRuntimeType: 1.294528e+06
@@ -1851,12 +1787,12 @@ Types:
       RawFields:
         - Name: Value
           Offset: 0
-          Type: 85 GoMapType map[string][]string
+          Type: 82 GoMapType map[string][]string
         - Name: File
           Offset: 8
-          Type: 86 GoMapType map[string][]*mime/multipart.FileHeader
+          Type: 83 GoMapType map[string][]*mime/multipart.FileHeader
     - __kind: GoSliceHeaderType
-      ID: 152
+      ID: 140
       Name: net.IP
       ByteSize: 24
       GoRuntimeType: 1.948704e+06
@@ -1871,14 +1807,14 @@ Types:
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 186 GoSliceDataType net.IP.array
+      Data: 183 GoSliceDataType net.IP.array
     - __kind: GoSliceDataType
-      ID: 186
+      ID: 183
       Name: net.IP.array
       ByteSize: 2048
       Element: 3 BaseType uint8
     - __kind: GoSliceHeaderType
-      ID: 194
+      ID: 185
       Name: net.IPMask
       ByteSize: 24
       GoRuntimeType: 976000
@@ -1893,14 +1829,14 @@ Types:
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 201 GoSliceDataType net.IPMask.array
+      Data: 186 GoSliceDataType net.IPMask.array
     - __kind: GoSliceDataType
-      ID: 201
+      ID: 186
       Name: net.IPMask.array
       ByteSize: 2048
       Element: 3 BaseType uint8
     - __kind: StructureType
-      ID: 173
+      ID: 176
       Name: net.IPNet
       ByteSize: 48
       GoRuntimeType: 1.276128e+06
@@ -1908,17 +1844,17 @@ Types:
       RawFields:
         - Name: IP
           Offset: 0
-          Type: 152 GoSliceHeaderType net.IP
+          Type: 140 GoSliceHeaderType net.IP
         - Name: Mask
           Offset: 24
-          Type: 194 GoSliceHeaderType net.IPMask
+          Type: 185 GoSliceHeaderType net.IPMask
     - __kind: GoMapType
-      ID: 46
+      ID: 48
       Name: net/http.Header
       ByteSize: 8
       GoRuntimeType: 1.917984e+06
       GoKind: 21
-      HeaderType: 48 GoHMapHeaderType hash<string,[]string>
+      HeaderType: 50 GoHMapHeaderType hash<string,[]string>
     - __kind: StructureType
       ID: 38
       Name: net/http.Request
@@ -1931,7 +1867,7 @@ Types:
           Type: 11 GoStringHeaderType string
         - Name: URL
           Offset: 16
-          Type: 44 PointerType *net/url.URL
+          Type: 46 PointerType *net/url.URL
         - Name: Proto
           Offset: 24
           Type: 11 GoStringHeaderType string
@@ -1943,19 +1879,19 @@ Types:
           Type: 9 BaseType int
         - Name: Header
           Offset: 56
-          Type: 46 GoMapType net/http.Header
+          Type: 48 GoMapType net/http.Header
         - Name: Body
           Offset: 64
-          Type: 53 GoInterfaceType io.ReadCloser
+          Type: 55 GoInterfaceType io.ReadCloser
         - Name: GetBody
           Offset: 80
-          Type: 54 GoSubroutineType func() (io.ReadCloser, error)
+          Type: 56 GoSubroutineType func() (io.ReadCloser, error)
         - Name: ContentLength
           Offset: 88
           Type: 14 BaseType int64
         - Name: TransferEncoding
           Offset: 96
-          Type: 55 GoSliceHeaderType []string
+          Type: 57 GoSliceHeaderType []string
         - Name: Close
           Offset: 120
           Type: 4 BaseType bool
@@ -1964,16 +1900,16 @@ Types:
           Type: 11 GoStringHeaderType string
         - Name: Form
           Offset: 144
-          Type: 56 GoMapType net/url.Values
+          Type: 58 GoMapType net/url.Values
         - Name: PostForm
           Offset: 152
-          Type: 56 GoMapType net/url.Values
+          Type: 58 GoMapType net/url.Values
         - Name: MultipartForm
           Offset: 160
-          Type: 57 PointerType *mime/multipart.Form
+          Type: 59 PointerType *mime/multipart.Form
         - Name: Trailer
           Offset: 168
-          Type: 46 GoMapType net/http.Header
+          Type: 48 GoMapType net/http.Header
         - Name: RemoteAddr
           Offset: 176
           Type: 11 GoStringHeaderType string
@@ -1982,30 +1918,30 @@ Types:
           Type: 11 GoStringHeaderType string
         - Name: TLS
           Offset: 208
-          Type: 59 PointerType *crypto/tls.ConnectionState
+          Type: 61 PointerType *crypto/tls.ConnectionState
         - Name: Cancel
           Offset: 216
-          Type: 61 GoChannelType <-chan struct {}
+          Type: 63 GoChannelType <-chan struct {}
         - Name: Response
           Offset: 224
-          Type: 62 PointerType *net/http.Response
+          Type: 64 PointerType *net/http.Response
         - Name: Pattern
           Offset: 232
           Type: 11 GoStringHeaderType string
         - Name: ctx
           Offset: 248
-          Type: 64 GoInterfaceType context.Context
+          Type: 66 GoInterfaceType context.Context
         - Name: pat
           Offset: 264
-          Type: 65 PointerType *net/http.pattern
+          Type: 67 PointerType *net/http.pattern
         - Name: matches
           Offset: 272
-          Type: 55 GoSliceHeaderType []string
+          Type: 57 GoSliceHeaderType []string
         - Name: otherValues
           Offset: 296
-          Type: 67 GoMapType map[string]string
+          Type: 69 GoMapType map[string]string
     - __kind: StructureType
-      ID: 63
+      ID: 65
       Name: net/http.Response
       ByteSize: 144
       GoRuntimeType: 2.065376e+06
@@ -2028,16 +1964,16 @@ Types:
           Type: 9 BaseType int
         - Name: Header
           Offset: 56
-          Type: 46 GoMapType net/http.Header
+          Type: 48 GoMapType net/http.Header
         - Name: Body
           Offset: 64
-          Type: 53 GoInterfaceType io.ReadCloser
+          Type: 55 GoInterfaceType io.ReadCloser
         - Name: ContentLength
           Offset: 80
           Type: 14 BaseType int64
         - Name: TransferEncoding
           Offset: 88
-          Type: 55 GoSliceHeaderType []string
+          Type: 57 GoSliceHeaderType []string
         - Name: Close
           Offset: 112
           Type: 4 BaseType bool
@@ -2046,13 +1982,13 @@ Types:
           Type: 4 BaseType bool
         - Name: Trailer
           Offset: 120
-          Type: 46 GoMapType net/http.Header
+          Type: 48 GoMapType net/http.Header
         - Name: Request
           Offset: 128
           Type: 37 PointerType *net/http.Request
         - Name: TLS
           Offset: 136
-          Type: 59 PointerType *crypto/tls.ConnectionState
+          Type: 61 PointerType *crypto/tls.ConnectionState
     - __kind: GoInterfaceType
       ID: 36
       Name: net/http.ResponseWriter
@@ -2067,7 +2003,7 @@ Types:
           Offset: 8
           Type: 19 VoidPointerType unsafe.Pointer
     - __kind: StructureType
-      ID: 66
+      ID: 68
       Name: net/http.pattern
       ByteSize: 88
       GoRuntimeType: 1.702112e+06
@@ -2084,12 +2020,12 @@ Types:
           Type: 11 GoStringHeaderType string
         - Name: segments
           Offset: 48
-          Type: 100 GoSliceHeaderType []net/http.segment
+          Type: 188 GoSliceHeaderType []net/http.segment
         - Name: loc
           Offset: 72
           Type: 11 GoStringHeaderType string
     - __kind: StructureType
-      ID: 102
+      ID: 190
       Name: net/http.segment
       ByteSize: 24
       GoRuntimeType: 1.416384e+06
@@ -2105,14 +2041,14 @@ Types:
           Offset: 17
           Type: 4 BaseType bool
     - __kind: GoMapType
-      ID: 163
+      ID: 96
       Name: net/textproto.MIMEHeader
       ByteSize: 8
       GoRuntimeType: 1.596448e+06
       GoKind: 21
-      HeaderType: 48 GoHMapHeaderType hash<string,[]string>
+      HeaderType: 50 GoHMapHeaderType hash<string,[]string>
     - __kind: StructureType
-      ID: 45
+      ID: 47
       Name: net/url.URL
       ByteSize: 144
       GoRuntimeType: 1.986816e+06
@@ -2126,7 +2062,7 @@ Types:
           Type: 11 GoStringHeaderType string
         - Name: User
           Offset: 32
-          Type: 76 PointerType *net/url.Userinfo
+          Type: 74 PointerType *net/url.Userinfo
         - Name: Host
           Offset: 40
           Type: 11 GoStringHeaderType string
@@ -2152,7 +2088,7 @@ Types:
           Offset: 128
           Type: 11 GoStringHeaderType string
     - __kind: StructureType
-      ID: 77
+      ID: 75
       Name: net/url.Userinfo
       ByteSize: 40
       GoRuntimeType: 1.433088e+06
@@ -2168,38 +2104,16 @@ Types:
           Offset: 32
           Type: 4 BaseType bool
     - __kind: GoMapType
-      ID: 56
+      ID: 58
       Name: net/url.Values
       ByteSize: 8
       GoRuntimeType: 1.671328e+06
       GoKind: 21
-      HeaderType: 48 GoHMapHeaderType hash<string,[]string>
-    - __kind: StructureType
-      ID: 84
-      Name: runtime.bmap
-      ByteSize: 8
-      GoRuntimeType: 1.10992e+06
-      GoKind: 25
-      RawFields:
-        - Name: tophash
-          Offset: 0
-          Type: 78 ArrayType [8]uint8
-    - __kind: StructureType
-      ID: 52
+      HeaderType: 50 GoHMapHeaderType hash<string,[]string>
+    - __kind: UnresolvedPointeeType
+      ID: 54
       Name: runtime.mapextra
-      ByteSize: 24
-      GoRuntimeType: 1.429056e+06
-      GoKind: 25
-      RawFields:
-        - Name: overflow
-          Offset: 0
-          Type: 81 PointerType *[]*runtime.bmap
-        - Name: oldoverflow
-          Offset: 8
-          Type: 81 PointerType *[]*runtime.bmap
-        - Name: nextOverflow
-          Offset: 16
-          Type: 83 PointerType *runtime.bmap
+      ByteSize: 8
     - __kind: GoStringHeaderType
       ID: 11
       Name: string
@@ -2209,17 +2123,17 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 75 PointerType *string.str
+          Type: 45 PointerType *string.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 74 GoStringDataType string.str
+      Data: 44 GoStringDataType string.str
     - __kind: GoStringDataType
-      ID: 74
+      ID: 44
       Name: string.str
       ByteSize: 2048
     - __kind: StructureType
-      ID: 139
+      ID: 127
       Name: time.Location
       ByteSize: 104
       GoRuntimeType: 1.834528e+06
@@ -2230,10 +2144,10 @@ Types:
           Type: 11 GoStringHeaderType string
         - Name: zone
           Offset: 16
-          Type: 167 GoSliceHeaderType []time.zone
+          Type: 156 GoSliceHeaderType []time.zone
         - Name: tx
           Offset: 40
-          Type: 170 GoSliceHeaderType []time.zoneTrans
+          Type: 159 GoSliceHeaderType []time.zoneTrans
         - Name: extend
           Offset: 64
           Type: 11 GoStringHeaderType string
@@ -2245,9 +2159,9 @@ Types:
           Type: 14 BaseType int64
         - Name: cacheZone
           Offset: 96
-          Type: 168 PointerType *time.zone
+          Type: 157 PointerType *time.zone
     - __kind: StructureType
-      ID: 137
+      ID: 125
       Name: time.Time
       ByteSize: 24
       GoRuntimeType: 2.215712e+06
@@ -2261,9 +2175,9 @@ Types:
           Type: 14 BaseType int64
         - Name: loc
           Offset: 16
-          Type: 138 PointerType *time.Location
+          Type: 126 PointerType *time.Location
     - __kind: StructureType
-      ID: 169
+      ID: 158
       Name: time.zone
       ByteSize: 32
       GoRuntimeType: 1.421376e+06
@@ -2279,7 +2193,7 @@ Types:
           Offset: 24
           Type: 4 BaseType bool
     - __kind: StructureType
-      ID: 172
+      ID: 161
       Name: time.zoneTrans
       ByteSize: 16
       GoRuntimeType: 1.623872e+06
@@ -2339,6 +2253,6 @@ Types:
       ByteSize: 8
       GoRuntimeType: 534848
       GoKind: 26
-MaxTypeID: 204
+MaxTypeID: 196
 Issues: []
 GoModuledataInfo: {FirstModuledataAddr: "0x12ddd40", TypesOffset: 296}

--- a/pkg/dyninst/irgen/testdata/snapshot/rc_tester_v1.arch=arm64,toolchain=go1.23.11.yaml
+++ b/pkg/dyninst/irgen/testdata/snapshot/rc_tester_v1.arch=arm64,toolchain=go1.23.11.yaml
@@ -65,7 +65,7 @@ Subprograms:
           IsParameter: true
           IsReturn: false
         - Name: '&buf'
-          Type: 148 PointerType *bytes.Buffer
+          Type: 39 PointerType *bytes.Buffer
           Locations:
             - Range: 0x8ad9b4..0x8ad9d0
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
@@ -74,7 +74,7 @@ Subprograms:
           IsParameter: false
           IsReturn: false
         - Name: span
-          Type: 151 GoInterfaceType gopkg.in/DataDog/dd-trace-go.v1/ddtrace.Span
+          Type: 41 GoInterfaceType gopkg.in/DataDog/dd-trace-go.v1/ddtrace.Span
           Locations:
             - Range: 0x8ad8d8..0x8ad8d8
               Pieces:
@@ -97,7 +97,7 @@ Subprograms:
           IsParameter: false
           IsReturn: false
         - Name: .autotmp_14
-          Type: 152 StructureType context.backgroundCtx
+          Type: 42 StructureType context.backgroundCtx
           Locations:
             - Range: 0x8ad860..0x8adab0
               Pieces: [{Size: 0, Op: {CfaOffset: 0}}]
@@ -121,142 +121,142 @@ Subprograms:
           IsReturn: false
 Types:
     - __kind: PointerType
-      ID: 80
+      ID: 90
       Name: '**crypto/x509.Certificate'
       ByteSize: 8
-      Pointee: 81 PointerType *crypto/x509.Certificate
+      Pointee: 91 PointerType *crypto/x509.Certificate
     - __kind: PointerType
-      ID: 72
+      ID: 105
       Name: '**mime/multipart.FileHeader'
       ByteSize: 8
       GoKind: 22
-      Pointee: 73 PointerType *mime/multipart.FileHeader
+      Pointee: 106 PointerType *mime/multipart.FileHeader
     - __kind: PointerType
-      ID: 120
+      ID: 137
       Name: '**net.IPNet'
       ByteSize: 8
       GoKind: 22
-      Pointee: 121 PointerType *net.IPNet
+      Pointee: 138 PointerType *net.IPNet
     - __kind: PointerType
-      ID: 118
+      ID: 135
       Name: '**net/url.URL'
       ByteSize: 8
-      Pointee: 39 PointerType *net/url.URL
+      Pointee: 44 PointerType *net/url.URL
     - __kind: PointerType
-      ID: 56
+      ID: 102
       Name: '**runtime.bmap'
       ByteSize: 8
-      Pointee: 57 PointerType *runtime.bmap
+      Pointee: 81 PointerType *runtime.bmap
     - __kind: PointerType
-      ID: 128
+      ID: 93
       Name: '*[]*crypto/x509.Certificate'
       ByteSize: 8
       GoKind: 22
-      Pointee: 79 GoSliceHeaderType []*crypto/x509.Certificate
+      Pointee: 89 GoSliceHeaderType []*crypto/x509.Certificate
     - __kind: PointerType
-      ID: 167
+      ID: 166
       Name: '*[]*crypto/x509.Certificate.array'
       ByteSize: 8
-      Pointee: 166 GoSliceDataType []*crypto/x509.Certificate.array
+      Pointee: 165 GoSliceDataType []*crypto/x509.Certificate.array
     - __kind: PointerType
-      ID: 163
+      ID: 174
       Name: '*[]*mime/multipart.FileHeader.array'
       ByteSize: 8
-      Pointee: 162 GoSliceDataType []*mime/multipart.FileHeader.array
+      Pointee: 173 GoSliceDataType []*mime/multipart.FileHeader.array
     - __kind: PointerType
-      ID: 191
+      ID: 192
       Name: '*[]*net.IPNet.array'
       ByteSize: 8
-      Pointee: 190 GoSliceDataType []*net.IPNet.array
+      Pointee: 191 GoSliceDataType []*net.IPNet.array
     - __kind: PointerType
-      ID: 189
+      ID: 190
       Name: '*[]*net/url.URL.array'
       ByteSize: 8
-      Pointee: 188 GoSliceDataType []*net/url.URL.array
+      Pointee: 189 GoSliceDataType []*net/url.URL.array
     - __kind: PointerType
-      ID: 54
+      ID: 79
       Name: '*[]*runtime.bmap'
       ByteSize: 8
       GoRuntimeType: 466496
       GoKind: 22
-      Pointee: 55 GoSliceHeaderType []*runtime.bmap
+      Pointee: 80 GoSliceHeaderType []*runtime.bmap
     - __kind: PointerType
-      ID: 160
+      ID: 163
       Name: '*[]*runtime.bmap.array'
       ByteSize: 8
-      Pointee: 159 GoSliceDataType []*runtime.bmap.array
+      Pointee: 162 GoSliceDataType []*runtime.bmap.array
     - __kind: PointerType
-      ID: 197
+      ID: 168
       Name: '*[][]*crypto/x509.Certificate.array'
       ByteSize: 8
-      Pointee: 196 GoSliceDataType [][]*crypto/x509.Certificate.array
+      Pointee: 167 GoSliceDataType [][]*crypto/x509.Certificate.array
     - __kind: PointerType
-      ID: 199
+      ID: 170
       Name: '*[][]uint8.array'
       ByteSize: 8
-      Pointee: 198 GoSliceDataType [][]uint8.array
+      Pointee: 169 GoSliceDataType [][]uint8.array
     - __kind: PointerType
-      ID: 183
+      ID: 184
       Name: '*[]crypto/x509.ExtKeyUsage.array'
       ByteSize: 8
-      Pointee: 182 GoSliceDataType []crypto/x509.ExtKeyUsage.array
+      Pointee: 183 GoSliceDataType []crypto/x509.ExtKeyUsage.array
     - __kind: PointerType
-      ID: 195
+      ID: 194
       Name: '*[]crypto/x509.OID.array'
       ByteSize: 8
-      Pointee: 194 GoSliceDataType []crypto/x509.OID.array
+      Pointee: 193 GoSliceDataType []crypto/x509.OID.array
     - __kind: PointerType
-      ID: 171
+      ID: 176
       Name: '*[]crypto/x509/pkix.AttributeTypeAndValue.array'
       ByteSize: 8
-      Pointee: 170 GoSliceDataType []crypto/x509/pkix.AttributeTypeAndValue.array
+      Pointee: 175 GoSliceDataType []crypto/x509/pkix.AttributeTypeAndValue.array
     - __kind: PointerType
-      ID: 179
+      ID: 178
       Name: '*[]crypto/x509/pkix.Extension.array'
       ByteSize: 8
-      Pointee: 178 GoSliceDataType []crypto/x509/pkix.Extension.array
+      Pointee: 177 GoSliceDataType []crypto/x509/pkix.Extension.array
     - __kind: PointerType
-      ID: 181
+      ID: 180
       Name: '*[]encoding/asn1.ObjectIdentifier.array'
       ByteSize: 8
-      Pointee: 180 GoSliceDataType []encoding/asn1.ObjectIdentifier.array
+      Pointee: 179 GoSliceDataType []encoding/asn1.ObjectIdentifier.array
     - __kind: PointerType
-      ID: 185
+      ID: 186
       Name: '*[]net.IP.array'
       ByteSize: 8
-      Pointee: 184 GoSliceDataType []net.IP.array
+      Pointee: 185 GoSliceDataType []net.IP.array
     - __kind: PointerType
-      ID: 201
+      ID: 172
       Name: '*[]net/http.segment.array'
       ByteSize: 8
-      Pointee: 200 GoSliceDataType []net/http.segment.array
+      Pointee: 171 GoSliceDataType []net/http.segment.array
     - __kind: PointerType
       ID: 158
       Name: '*[]string.array'
       ByteSize: 8
       Pointee: 157 GoSliceDataType []string.array
     - __kind: PointerType
-      ID: 175
+      ID: 198
       Name: '*[]time.zone.array'
       ByteSize: 8
-      Pointee: 174 GoSliceDataType []time.zone.array
+      Pointee: 197 GoSliceDataType []time.zone.array
     - __kind: PointerType
-      ID: 177
+      ID: 200
       Name: '*[]time.zoneTrans.array'
       ByteSize: 8
-      Pointee: 176 GoSliceDataType []time.zoneTrans.array
+      Pointee: 199 GoSliceDataType []time.zoneTrans.array
     - __kind: PointerType
-      ID: 130
+      ID: 95
       Name: '*[]uint8'
       ByteSize: 8
       GoRuntimeType: 452640
       GoKind: 22
-      Pointee: 76 GoSliceHeaderType []uint8
+      Pointee: 72 GoSliceHeaderType []uint8
     - __kind: PointerType
-      ID: 165
+      ID: 161
       Name: '*[]uint8.array'
       ByteSize: 8
-      Pointee: 164 GoSliceDataType []uint8.array
+      Pointee: 160 GoSliceDataType []uint8.array
     - __kind: PointerType
       ID: 5
       Name: '*bool'
@@ -265,81 +265,81 @@ Types:
       GoKind: 22
       Pointee: 4 BaseType bool
     - __kind: PointerType
-      ID: 68
+      ID: 87
       Name: '*bucket<string,[]*mime/multipart.FileHeader>'
       ByteSize: 8
-      Pointee: 69 GoHMapBucketType bucket<string,[]*mime/multipart.FileHeader>
+      Pointee: 88 GoHMapBucketType bucket<string,[]*mime/multipart.FileHeader>
     - __kind: PointerType
-      ID: 46
+      ID: 49
       Name: '*bucket<string,[]string>'
       ByteSize: 8
-      Pointee: 47 GoHMapBucketType bucket<string,[]string>
+      Pointee: 50 GoHMapBucketType bucket<string,[]string>
     - __kind: PointerType
-      ID: 145
+      ID: 70
       Name: '*bucket<string,string>'
       ByteSize: 8
-      Pointee: 146 GoHMapBucketType bucket<string,string>
+      Pointee: 71 GoHMapBucketType bucket<string,string>
     - __kind: PointerType
-      ID: 148
+      ID: 39
       Name: '*bytes.Buffer'
       ByteSize: 8
       GoRuntimeType: 2.11552e+06
       GoKind: 22
-      Pointee: 149 StructureType bytes.Buffer
+      Pointee: 40 StructureType bytes.Buffer
     - __kind: PointerType
-      ID: 77
+      ID: 59
       Name: '*crypto/tls.ConnectionState'
       ByteSize: 8
       GoRuntimeType: 836032
       GoKind: 22
-      Pointee: 78 StructureType crypto/tls.ConnectionState
+      Pointee: 60 StructureType crypto/tls.ConnectionState
     - __kind: PointerType
-      ID: 81
+      ID: 91
       Name: '*crypto/x509.Certificate'
       ByteSize: 8
       GoRuntimeType: 1.905824e+06
       GoKind: 22
-      Pointee: 82 StructureType crypto/x509.Certificate
+      Pointee: 107 StructureType crypto/x509.Certificate
     - __kind: PointerType
-      ID: 112
+      ID: 129
       Name: '*crypto/x509.ExtKeyUsage'
       ByteSize: 8
       GoRuntimeType: 395104
       GoKind: 22
-      Pointee: 113 BaseType crypto/x509.ExtKeyUsage
+      Pointee: 130 BaseType crypto/x509.ExtKeyUsage
     - __kind: PointerType
-      ID: 125
+      ID: 140
       Name: '*crypto/x509.OID'
       ByteSize: 8
       GoRuntimeType: 1.717792e+06
       GoKind: 22
-      Pointee: 126 StructureType crypto/x509.OID
+      Pointee: 141 StructureType crypto/x509.OID
     - __kind: PointerType
-      ID: 93
+      ID: 116
       Name: '*crypto/x509/pkix.AttributeTypeAndValue'
       ByteSize: 8
       GoRuntimeType: 408928
       GoKind: 22
-      Pointee: 94 StructureType crypto/x509/pkix.AttributeTypeAndValue
+      Pointee: 117 StructureType crypto/x509/pkix.AttributeTypeAndValue
     - __kind: PointerType
-      ID: 107
+      ID: 123
       Name: '*crypto/x509/pkix.Extension'
       ByteSize: 8
       GoRuntimeType: 409120
       GoKind: 22
-      Pointee: 108 StructureType crypto/x509/pkix.Extension
+      Pointee: 124 StructureType crypto/x509/pkix.Extension
     - __kind: PointerType
-      ID: 110
+      ID: 126
       Name: '*encoding/asn1.ObjectIdentifier'
       ByteSize: 8
       GoRuntimeType: 1.00992e+06
       GoKind: 22
-      Pointee: 95 GoSliceHeaderType encoding/asn1.ObjectIdentifier
+      Pointee: 127 GoSliceHeaderType encoding/asn1.ObjectIdentifier
     - __kind: PointerType
-      ID: 173
+      ID: 182
       Name: '*encoding/asn1.ObjectIdentifier.array'
       ByteSize: 8
-      Pointee: 172 GoSliceDataType encoding/asn1.ObjectIdentifier.array
+      Pointee: 181 GoSliceDataType encoding/asn1.ObjectIdentifier.array
     - __kind: PointerType
       ID: 33
       Name: '*error'
@@ -362,20 +362,20 @@ Types:
       GoKind: 22
       Pointee: 17 BaseType float64
     - __kind: PointerType
-      ID: 66
+      ID: 85
       Name: '*hash<string,[]*mime/multipart.FileHeader>'
       ByteSize: 8
-      Pointee: 67 GoHMapHeaderType hash<string,[]*mime/multipart.FileHeader>
+      Pointee: 86 GoHMapHeaderType hash<string,[]*mime/multipart.FileHeader>
     - __kind: PointerType
-      ID: 44
+      ID: 47
       Name: '*hash<string,[]string>'
       ByteSize: 8
-      Pointee: 45 GoHMapHeaderType hash<string,[]string>
+      Pointee: 48 GoHMapHeaderType hash<string,[]string>
     - __kind: PointerType
-      ID: 143
+      ID: 68
       Name: '*hash<string,string>'
       ByteSize: 8
-      Pointee: 144 GoHMapHeaderType hash<string,string>
+      Pointee: 69 GoHMapHeaderType hash<string,string>
     - __kind: PointerType
       ID: 28
       Name: '*int'
@@ -412,62 +412,62 @@ Types:
       GoKind: 22
       Pointee: 15 BaseType int8
     - __kind: PointerType
-      ID: 86
+      ID: 112
       Name: '*math/big.Int'
       ByteSize: 8
       GoRuntimeType: 2.231648e+06
       GoKind: 22
-      Pointee: 87 StructureType math/big.Int
+      Pointee: 113 StructureType math/big.Int
     - __kind: PointerType
-      ID: 89
+      ID: 144
       Name: '*math/big.Word'
       ByteSize: 8
       GoRuntimeType: 397920
       GoKind: 22
-      Pointee: 90 BaseType math/big.Word
+      Pointee: 145 BaseType math/big.Word
     - __kind: PointerType
-      ID: 169
+      ID: 196
       Name: '*math/big.nat.array'
       ByteSize: 8
-      Pointee: 168 GoSliceDataType math/big.nat.array
+      Pointee: 195 GoSliceDataType math/big.nat.array
     - __kind: PointerType
-      ID: 73
+      ID: 106
       Name: '*mime/multipart.FileHeader'
       ByteSize: 8
       GoRuntimeType: 837472
       GoKind: 22
-      Pointee: 74 StructureType mime/multipart.FileHeader
+      Pointee: 108 StructureType mime/multipart.FileHeader
     - __kind: PointerType
-      ID: 62
+      ID: 57
       Name: '*mime/multipart.Form'
       ByteSize: 8
       GoRuntimeType: 837568
       GoKind: 22
-      Pointee: 63 StructureType mime/multipart.Form
+      Pointee: 58 StructureType mime/multipart.Form
     - __kind: PointerType
-      ID: 115
+      ID: 132
       Name: '*net.IP'
       ByteSize: 8
       GoRuntimeType: 1.974688e+06
       GoKind: 22
-      Pointee: 116 GoSliceHeaderType net.IP
+      Pointee: 133 GoSliceHeaderType net.IP
     - __kind: PointerType
-      ID: 187
+      ID: 188
       Name: '*net.IP.array'
       ByteSize: 8
-      Pointee: 186 GoSliceDataType net.IP.array
+      Pointee: 187 GoSliceDataType net.IP.array
     - __kind: PointerType
-      ID: 193
+      ID: 202
       Name: '*net.IPMask.array'
       ByteSize: 8
-      Pointee: 192 GoSliceDataType net.IPMask.array
+      Pointee: 201 GoSliceDataType net.IPMask.array
     - __kind: PointerType
-      ID: 121
+      ID: 138
       Name: '*net.IPNet'
       ByteSize: 8
       GoRuntimeType: 1.095968e+06
       GoKind: 22
-      Pointee: 122 StructureType net.IPNet
+      Pointee: 152 StructureType net.IPNet
     - __kind: PointerType
       ID: 37
       Name: '*net/http.Request'
@@ -476,54 +476,54 @@ Types:
       GoKind: 22
       Pointee: 38 StructureType net/http.Request
     - __kind: PointerType
-      ID: 134
+      ID: 62
       Name: '*net/http.Response'
       ByteSize: 8
       GoRuntimeType: 1.591456e+06
       GoKind: 22
-      Pointee: 135 StructureType net/http.Response
+      Pointee: 63 StructureType net/http.Response
     - __kind: PointerType
-      ID: 137
+      ID: 65
       Name: '*net/http.pattern'
       ByteSize: 8
       GoRuntimeType: 1.416576e+06
       GoKind: 22
-      Pointee: 138 StructureType net/http.pattern
+      Pointee: 66 StructureType net/http.pattern
     - __kind: PointerType
-      ID: 140
+      ID: 99
       Name: '*net/http.segment'
       ByteSize: 8
       GoRuntimeType: 364064
       GoKind: 22
-      Pointee: 141 StructureType net/http.segment
+      Pointee: 100 StructureType net/http.segment
     - __kind: PointerType
-      ID: 39
+      ID: 44
       Name: '*net/url.URL'
       ByteSize: 8
       GoRuntimeType: 1.94976e+06
       GoKind: 22
-      Pointee: 40 StructureType net/url.URL
+      Pointee: 45 StructureType net/url.URL
     - __kind: PointerType
-      ID: 41
+      ID: 74
       Name: '*net/url.Userinfo'
       ByteSize: 8
       GoRuntimeType: 1.1144e+06
       GoKind: 22
-      Pointee: 42 StructureType net/url.Userinfo
+      Pointee: 75 StructureType net/url.Userinfo
     - __kind: PointerType
-      ID: 57
+      ID: 81
       Name: '*runtime.bmap'
       ByteSize: 8
       GoRuntimeType: 1.110048e+06
       GoKind: 22
-      Pointee: 58 StructureType runtime.bmap
+      Pointee: 82 StructureType runtime.bmap
     - __kind: PointerType
-      ID: 52
+      ID: 51
       Name: '*runtime.mapextra'
       ByteSize: 8
       GoRuntimeType: 375584
       GoKind: 22
-      Pointee: 53 StructureType runtime.mapextra
+      Pointee: 52 StructureType runtime.mapextra
     - __kind: PointerType
       ID: 22
       Name: '*string'
@@ -537,26 +537,26 @@ Types:
       ByteSize: 8
       Pointee: 154 GoStringDataType string.str
     - __kind: PointerType
-      ID: 97
+      ID: 119
       Name: '*time.Location'
       ByteSize: 8
       GoRuntimeType: 1.421568e+06
       GoKind: 22
-      Pointee: 98 StructureType time.Location
+      Pointee: 120 StructureType time.Location
     - __kind: PointerType
-      ID: 100
+      ID: 147
       Name: '*time.zone'
       ByteSize: 8
       GoRuntimeType: 367136
       GoKind: 22
-      Pointee: 101 StructureType time.zone
+      Pointee: 148 StructureType time.zone
     - __kind: PointerType
-      ID: 103
+      ID: 150
       Name: '*time.zoneTrans'
       ByteSize: 8
       GoRuntimeType: 367200
       GoKind: 22
-      Pointee: 104 StructureType time.zoneTrans
+      Pointee: 151 StructureType time.zoneTrans
     - __kind: PointerType
       ID: 34
       Name: '*uint'
@@ -600,7 +600,7 @@ Types:
       GoKind: 22
       Pointee: 1 BaseType uintptr
     - __kind: GoChannelType
-      ID: 133
+      ID: 61
       Name: <-chan struct {}
       GoRuntimeType: 546944
       GoKind: 18
@@ -644,7 +644,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: ArrayType
-      ID: 48
+      ID: 76
       Name: '[8]uint8'
       ByteSize: 8
       GoRuntimeType: 621920
@@ -653,7 +653,7 @@ Types:
       HasCount: true
       Element: 3 BaseType uint8
     - __kind: GoSliceHeaderType
-      ID: 79
+      ID: 89
       Name: '[]*crypto/x509.Certificate'
       ByteSize: 24
       GoRuntimeType: 469664
@@ -661,21 +661,21 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 80 PointerType **crypto/x509.Certificate
+          Type: 90 PointerType **crypto/x509.Certificate
         - Name: len
           Offset: 8
           Type: 9 BaseType int
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 166 GoSliceDataType []*crypto/x509.Certificate.array
+      Data: 165 GoSliceDataType []*crypto/x509.Certificate.array
     - __kind: GoSliceDataType
-      ID: 166
+      ID: 165
       Name: '[]*crypto/x509.Certificate.array'
       ByteSize: 2048
-      Element: 81 PointerType *crypto/x509.Certificate
+      Element: 91 PointerType *crypto/x509.Certificate
     - __kind: GoSliceHeaderType
-      ID: 71
+      ID: 104
       Name: '[]*mime/multipart.FileHeader'
       ByteSize: 24
       GoRuntimeType: 457504
@@ -683,21 +683,21 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 72 PointerType **mime/multipart.FileHeader
+          Type: 105 PointerType **mime/multipart.FileHeader
         - Name: len
           Offset: 8
           Type: 9 BaseType int
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 162 GoSliceDataType []*mime/multipart.FileHeader.array
+      Data: 173 GoSliceDataType []*mime/multipart.FileHeader.array
     - __kind: GoSliceDataType
-      ID: 162
+      ID: 173
       Name: '[]*mime/multipart.FileHeader.array'
       ByteSize: 2048
-      Element: 73 PointerType *mime/multipart.FileHeader
+      Element: 106 PointerType *mime/multipart.FileHeader
     - __kind: GoSliceHeaderType
-      ID: 119
+      ID: 136
       Name: '[]*net.IPNet'
       ByteSize: 24
       GoRuntimeType: 481696
@@ -705,21 +705,21 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 120 PointerType **net.IPNet
+          Type: 137 PointerType **net.IPNet
         - Name: len
           Offset: 8
           Type: 9 BaseType int
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 190 GoSliceDataType []*net.IPNet.array
+      Data: 191 GoSliceDataType []*net.IPNet.array
     - __kind: GoSliceDataType
-      ID: 190
+      ID: 191
       Name: '[]*net.IPNet.array'
       ByteSize: 2048
-      Element: 121 PointerType *net.IPNet
+      Element: 138 PointerType *net.IPNet
     - __kind: GoSliceHeaderType
-      ID: 117
+      ID: 134
       Name: '[]*net/url.URL'
       ByteSize: 24
       GoRuntimeType: 481632
@@ -727,21 +727,21 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 118 PointerType **net/url.URL
+          Type: 135 PointerType **net/url.URL
         - Name: len
           Offset: 8
           Type: 9 BaseType int
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 188 GoSliceDataType []*net/url.URL.array
+      Data: 189 GoSliceDataType []*net/url.URL.array
     - __kind: GoSliceDataType
-      ID: 188
+      ID: 189
       Name: '[]*net/url.URL.array'
       ByteSize: 2048
-      Element: 39 PointerType *net/url.URL
+      Element: 44 PointerType *net/url.URL
     - __kind: GoSliceHeaderType
-      ID: 55
+      ID: 80
       Name: '[]*runtime.bmap'
       ByteSize: 24
       GoRuntimeType: 466432
@@ -749,21 +749,21 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 56 PointerType **runtime.bmap
+          Type: 102 PointerType **runtime.bmap
         - Name: len
           Offset: 8
           Type: 9 BaseType int
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 159 GoSliceDataType []*runtime.bmap.array
+      Data: 162 GoSliceDataType []*runtime.bmap.array
     - __kind: GoSliceDataType
-      ID: 159
+      ID: 162
       Name: '[]*runtime.bmap.array'
       ByteSize: 2048
-      Element: 57 PointerType *runtime.bmap
+      Element: 81 PointerType *runtime.bmap
     - __kind: GoSliceHeaderType
-      ID: 127
+      ID: 92
       Name: '[][]*crypto/x509.Certificate'
       ByteSize: 24
       GoRuntimeType: 469792
@@ -771,21 +771,21 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 128 PointerType *[]*crypto/x509.Certificate
+          Type: 93 PointerType *[]*crypto/x509.Certificate
         - Name: len
           Offset: 8
           Type: 9 BaseType int
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 196 GoSliceDataType [][]*crypto/x509.Certificate.array
+      Data: 167 GoSliceDataType [][]*crypto/x509.Certificate.array
     - __kind: GoSliceDataType
-      ID: 196
+      ID: 167
       Name: '[][]*crypto/x509.Certificate.array'
       ByteSize: 2048
-      Element: 79 GoSliceHeaderType []*crypto/x509.Certificate
+      Element: 89 GoSliceHeaderType []*crypto/x509.Certificate
     - __kind: GoSliceHeaderType
-      ID: 129
+      ID: 94
       Name: '[][]uint8'
       ByteSize: 24
       GoRuntimeType: 452960
@@ -793,36 +793,36 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 130 PointerType *[]uint8
+          Type: 95 PointerType *[]uint8
         - Name: len
           Offset: 8
           Type: 9 BaseType int
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 198 GoSliceDataType [][]uint8.array
+      Data: 169 GoSliceDataType [][]uint8.array
     - __kind: GoSliceDataType
-      ID: 198
+      ID: 169
       Name: '[][]uint8.array'
       ByteSize: 2048
-      Element: 76 GoSliceHeaderType []uint8
+      Element: 72 GoSliceHeaderType []uint8
     - __kind: GoSliceDataType
-      ID: 161
+      ID: 164
       Name: '[]bucket<string,[]*mime/multipart.FileHeader>.array'
       ByteSize: 2048
-      Element: 69 GoHMapBucketType bucket<string,[]*mime/multipart.FileHeader>
+      Element: 88 GoHMapBucketType bucket<string,[]*mime/multipart.FileHeader>
     - __kind: GoSliceDataType
       ID: 156
       Name: '[]bucket<string,[]string>.array'
       ByteSize: 2048
-      Element: 47 GoHMapBucketType bucket<string,[]string>
+      Element: 50 GoHMapBucketType bucket<string,[]string>
     - __kind: GoSliceDataType
-      ID: 202
+      ID: 159
       Name: '[]bucket<string,string>.array'
       ByteSize: 2048
-      Element: 146 GoHMapBucketType bucket<string,string>
+      Element: 71 GoHMapBucketType bucket<string,string>
     - __kind: GoSliceHeaderType
-      ID: 111
+      ID: 128
       Name: '[]crypto/x509.ExtKeyUsage'
       ByteSize: 24
       GoRuntimeType: 470944
@@ -830,21 +830,21 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 112 PointerType *crypto/x509.ExtKeyUsage
+          Type: 129 PointerType *crypto/x509.ExtKeyUsage
         - Name: len
           Offset: 8
           Type: 9 BaseType int
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 182 GoSliceDataType []crypto/x509.ExtKeyUsage.array
+      Data: 183 GoSliceDataType []crypto/x509.ExtKeyUsage.array
     - __kind: GoSliceDataType
-      ID: 182
+      ID: 183
       Name: '[]crypto/x509.ExtKeyUsage.array'
       ByteSize: 2048
-      Element: 113 BaseType crypto/x509.ExtKeyUsage
+      Element: 130 BaseType crypto/x509.ExtKeyUsage
     - __kind: GoSliceHeaderType
-      ID: 124
+      ID: 139
       Name: '[]crypto/x509.OID'
       ByteSize: 24
       GoRuntimeType: 481760
@@ -852,21 +852,21 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 125 PointerType *crypto/x509.OID
+          Type: 140 PointerType *crypto/x509.OID
         - Name: len
           Offset: 8
           Type: 9 BaseType int
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 194 GoSliceDataType []crypto/x509.OID.array
+      Data: 193 GoSliceDataType []crypto/x509.OID.array
     - __kind: GoSliceDataType
-      ID: 194
+      ID: 193
       Name: '[]crypto/x509.OID.array'
       ByteSize: 2048
-      Element: 126 StructureType crypto/x509.OID
+      Element: 141 StructureType crypto/x509.OID
     - __kind: GoSliceHeaderType
-      ID: 92
+      ID: 115
       Name: '[]crypto/x509/pkix.AttributeTypeAndValue'
       ByteSize: 24
       GoRuntimeType: 482016
@@ -874,21 +874,21 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 93 PointerType *crypto/x509/pkix.AttributeTypeAndValue
+          Type: 116 PointerType *crypto/x509/pkix.AttributeTypeAndValue
         - Name: len
           Offset: 8
           Type: 9 BaseType int
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 170 GoSliceDataType []crypto/x509/pkix.AttributeTypeAndValue.array
+      Data: 175 GoSliceDataType []crypto/x509/pkix.AttributeTypeAndValue.array
     - __kind: GoSliceDataType
-      ID: 170
+      ID: 175
       Name: '[]crypto/x509/pkix.AttributeTypeAndValue.array'
       ByteSize: 2048
-      Element: 94 StructureType crypto/x509/pkix.AttributeTypeAndValue
+      Element: 117 StructureType crypto/x509/pkix.AttributeTypeAndValue
     - __kind: GoSliceHeaderType
-      ID: 106
+      ID: 122
       Name: '[]crypto/x509/pkix.Extension'
       ByteSize: 24
       GoRuntimeType: 481504
@@ -896,21 +896,21 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 107 PointerType *crypto/x509/pkix.Extension
+          Type: 123 PointerType *crypto/x509/pkix.Extension
         - Name: len
           Offset: 8
           Type: 9 BaseType int
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 178 GoSliceDataType []crypto/x509/pkix.Extension.array
+      Data: 177 GoSliceDataType []crypto/x509/pkix.Extension.array
     - __kind: GoSliceDataType
-      ID: 178
+      ID: 177
       Name: '[]crypto/x509/pkix.Extension.array'
       ByteSize: 2048
-      Element: 108 StructureType crypto/x509/pkix.Extension
+      Element: 124 StructureType crypto/x509/pkix.Extension
     - __kind: GoSliceHeaderType
-      ID: 109
+      ID: 125
       Name: '[]encoding/asn1.ObjectIdentifier'
       ByteSize: 24
       GoRuntimeType: 481568
@@ -918,28 +918,28 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 110 PointerType *encoding/asn1.ObjectIdentifier
+          Type: 126 PointerType *encoding/asn1.ObjectIdentifier
         - Name: len
           Offset: 8
           Type: 9 BaseType int
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 180 GoSliceDataType []encoding/asn1.ObjectIdentifier.array
+      Data: 179 GoSliceDataType []encoding/asn1.ObjectIdentifier.array
     - __kind: GoSliceDataType
-      ID: 180
+      ID: 179
       Name: '[]encoding/asn1.ObjectIdentifier.array'
       ByteSize: 2048
-      Element: 95 GoSliceHeaderType encoding/asn1.ObjectIdentifier
+      Element: 127 GoSliceHeaderType encoding/asn1.ObjectIdentifier
     - __kind: ArrayType
-      ID: 49
+      ID: 77
       Name: '[]key<string>'
       ByteSize: 128
       Count: 8
       HasCount: true
       Element: 11 GoStringHeaderType string
     - __kind: GoSliceHeaderType
-      ID: 114
+      ID: 131
       Name: '[]net.IP'
       ByteSize: 24
       GoRuntimeType: 454176
@@ -947,21 +947,21 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 115 PointerType *net.IP
+          Type: 132 PointerType *net.IP
         - Name: len
           Offset: 8
           Type: 9 BaseType int
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 184 GoSliceDataType []net.IP.array
+      Data: 185 GoSliceDataType []net.IP.array
     - __kind: GoSliceDataType
-      ID: 184
+      ID: 185
       Name: '[]net.IP.array'
       ByteSize: 2048
-      Element: 116 GoSliceHeaderType net.IP
+      Element: 133 GoSliceHeaderType net.IP
     - __kind: GoSliceHeaderType
-      ID: 139
+      ID: 98
       Name: '[]net/http.segment'
       ByteSize: 24
       GoRuntimeType: 454944
@@ -969,21 +969,21 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 140 PointerType *net/http.segment
+          Type: 99 PointerType *net/http.segment
         - Name: len
           Offset: 8
           Type: 9 BaseType int
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 200 GoSliceDataType []net/http.segment.array
+      Data: 171 GoSliceDataType []net/http.segment.array
     - __kind: GoSliceDataType
-      ID: 200
+      ID: 171
       Name: '[]net/http.segment.array'
       ByteSize: 2048
-      Element: 141 StructureType net/http.segment
+      Element: 100 StructureType net/http.segment
     - __kind: GoSliceHeaderType
-      ID: 51
+      ID: 55
       Name: '[]string'
       ByteSize: 24
       GoRuntimeType: 464768
@@ -1005,7 +1005,7 @@ Types:
       ByteSize: 2048
       Element: 11 GoStringHeaderType string
     - __kind: GoSliceHeaderType
-      ID: 99
+      ID: 146
       Name: '[]time.zone'
       ByteSize: 24
       GoRuntimeType: 459168
@@ -1013,21 +1013,21 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 100 PointerType *time.zone
+          Type: 147 PointerType *time.zone
         - Name: len
           Offset: 8
           Type: 9 BaseType int
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 174 GoSliceDataType []time.zone.array
+      Data: 197 GoSliceDataType []time.zone.array
     - __kind: GoSliceDataType
-      ID: 174
+      ID: 197
       Name: '[]time.zone.array'
       ByteSize: 2048
-      Element: 101 StructureType time.zone
+      Element: 148 StructureType time.zone
     - __kind: GoSliceHeaderType
-      ID: 102
+      ID: 149
       Name: '[]time.zoneTrans'
       ByteSize: 24
       GoRuntimeType: 459232
@@ -1035,21 +1035,21 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 103 PointerType *time.zoneTrans
+          Type: 150 PointerType *time.zoneTrans
         - Name: len
           Offset: 8
           Type: 9 BaseType int
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 176 GoSliceDataType []time.zoneTrans.array
+      Data: 199 GoSliceDataType []time.zoneTrans.array
     - __kind: GoSliceDataType
-      ID: 176
+      ID: 199
       Name: '[]time.zoneTrans.array'
       ByteSize: 2048
-      Element: 104 StructureType time.zoneTrans
+      Element: 151 StructureType time.zoneTrans
     - __kind: GoSliceHeaderType
-      ID: 76
+      ID: 72
       Name: '[]uint8'
       ByteSize: 24
       GoRuntimeType: 463616
@@ -1064,28 +1064,28 @@ Types:
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 164 GoSliceDataType []uint8.array
+      Data: 160 GoSliceDataType []uint8.array
     - __kind: GoSliceDataType
-      ID: 164
+      ID: 160
       Name: '[]uint8.array'
       ByteSize: 2048
       Element: 3 BaseType uint8
     - __kind: ArrayType
-      ID: 70
+      ID: 103
       Name: '[]val<[]*mime/multipart.FileHeader>'
       ByteSize: 192
       Count: 8
       HasCount: true
-      Element: 71 GoSliceHeaderType []*mime/multipart.FileHeader
+      Element: 104 GoSliceHeaderType []*mime/multipart.FileHeader
     - __kind: ArrayType
-      ID: 50
+      ID: 78
       Name: '[]val<[]string>'
       ByteSize: 192
       Count: 8
       HasCount: true
-      Element: 51 GoSliceHeaderType []string
+      Element: 55 GoSliceHeaderType []string
     - __kind: ArrayType
-      ID: 147
+      ID: 101
       Name: '[]val<string>'
       ByteSize: 128
       Count: 8
@@ -1098,64 +1098,64 @@ Types:
       GoRuntimeType: 534784
       GoKind: 1
     - __kind: GoHMapBucketType
-      ID: 69
+      ID: 88
       Name: bucket<string,[]*mime/multipart.FileHeader>
       ByteSize: 336
       RawFields:
         - Name: tophash
           Offset: 0
-          Type: 48 ArrayType [8]uint8
+          Type: 76 ArrayType [8]uint8
         - Name: keys
           Offset: 8
-          Type: 49 ArrayType []key<string>
+          Type: 77 ArrayType []key<string>
         - Name: values
           Offset: 136
-          Type: 70 ArrayType []val<[]*mime/multipart.FileHeader>
+          Type: 103 ArrayType []val<[]*mime/multipart.FileHeader>
         - Name: overflow
           Offset: 328
-          Type: 68 PointerType *bucket<string,[]*mime/multipart.FileHeader>
+          Type: 87 PointerType *bucket<string,[]*mime/multipart.FileHeader>
       KeyType: 11 GoStringHeaderType string
-      ValueType: 71 GoSliceHeaderType []*mime/multipart.FileHeader
+      ValueType: 104 GoSliceHeaderType []*mime/multipart.FileHeader
     - __kind: GoHMapBucketType
-      ID: 47
+      ID: 50
       Name: bucket<string,[]string>
       ByteSize: 336
       RawFields:
         - Name: tophash
           Offset: 0
-          Type: 48 ArrayType [8]uint8
+          Type: 76 ArrayType [8]uint8
         - Name: keys
           Offset: 8
-          Type: 49 ArrayType []key<string>
+          Type: 77 ArrayType []key<string>
         - Name: values
           Offset: 136
-          Type: 50 ArrayType []val<[]string>
+          Type: 78 ArrayType []val<[]string>
         - Name: overflow
           Offset: 328
-          Type: 46 PointerType *bucket<string,[]string>
+          Type: 49 PointerType *bucket<string,[]string>
       KeyType: 11 GoStringHeaderType string
-      ValueType: 51 GoSliceHeaderType []string
+      ValueType: 55 GoSliceHeaderType []string
     - __kind: GoHMapBucketType
-      ID: 146
+      ID: 71
       Name: bucket<string,string>
       ByteSize: 272
       RawFields:
         - Name: tophash
           Offset: 0
-          Type: 48 ArrayType [8]uint8
+          Type: 76 ArrayType [8]uint8
         - Name: keys
           Offset: 8
-          Type: 49 ArrayType []key<string>
+          Type: 77 ArrayType []key<string>
         - Name: values
           Offset: 136
-          Type: 147 ArrayType []val<string>
+          Type: 101 ArrayType []val<string>
         - Name: overflow
           Offset: 264
-          Type: 145 PointerType *bucket<string,string>
+          Type: 70 PointerType *bucket<string,string>
       KeyType: 11 GoStringHeaderType string
       ValueType: 11 GoStringHeaderType string
     - __kind: StructureType
-      ID: 149
+      ID: 40
       Name: bytes.Buffer
       ByteSize: 40
       GoRuntimeType: 1.414272e+06
@@ -1163,15 +1163,15 @@ Types:
       RawFields:
         - Name: buf
           Offset: 0
-          Type: 76 GoSliceHeaderType []uint8
+          Type: 72 GoSliceHeaderType []uint8
         - Name: off
           Offset: 24
           Type: 9 BaseType int
         - Name: lastRead
           Offset: 32
-          Type: 150 BaseType bytes.readOp
+          Type: 73 BaseType bytes.readOp
     - __kind: BaseType
-      ID: 150
+      ID: 73
       Name: bytes.readOp
       ByteSize: 1
       GoRuntimeType: 532992
@@ -1189,7 +1189,7 @@ Types:
       GoRuntimeType: 534528
       GoKind: 15
     - __kind: GoInterfaceType
-      ID: 136
+      ID: 64
       Name: context.Context
       ByteSize: 16
       GoRuntimeType: 1.187296e+06
@@ -1202,22 +1202,22 @@ Types:
           Offset: 8
           Type: 19 VoidPointerType unsafe.Pointer
     - __kind: StructureType
-      ID: 152
+      ID: 42
       Name: context.backgroundCtx
       GoRuntimeType: 1.667744e+06
       GoKind: 25
       RawFields:
         - Name: emptyCtx
           Offset: 0
-          Type: 153 StructureType context.emptyCtx
+          Type: 43 StructureType context.emptyCtx
     - __kind: StructureType
-      ID: 153
+      ID: 43
       Name: context.emptyCtx
       GoRuntimeType: 1.399808e+06
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 78
+      ID: 60
       Name: crypto/tls.ConnectionState
       ByteSize: 192
       GoRuntimeType: 2.100544e+06
@@ -1246,39 +1246,39 @@ Types:
           Type: 11 GoStringHeaderType string
         - Name: PeerCertificates
           Offset: 48
-          Type: 79 GoSliceHeaderType []*crypto/x509.Certificate
+          Type: 89 GoSliceHeaderType []*crypto/x509.Certificate
         - Name: VerifiedChains
           Offset: 72
-          Type: 127 GoSliceHeaderType [][]*crypto/x509.Certificate
+          Type: 92 GoSliceHeaderType [][]*crypto/x509.Certificate
         - Name: SignedCertificateTimestamps
           Offset: 96
-          Type: 129 GoSliceHeaderType [][]uint8
+          Type: 94 GoSliceHeaderType [][]uint8
         - Name: OCSPResponse
           Offset: 120
-          Type: 76 GoSliceHeaderType []uint8
+          Type: 72 GoSliceHeaderType []uint8
         - Name: TLSUnique
           Offset: 144
-          Type: 76 GoSliceHeaderType []uint8
+          Type: 72 GoSliceHeaderType []uint8
         - Name: ECHAccepted
           Offset: 168
           Type: 4 BaseType bool
         - Name: ekm
           Offset: 176
-          Type: 131 GoSubroutineType func(string, []uint8, int) ([]uint8, error)
+          Type: 96 GoSubroutineType func(string, []uint8, int) ([]uint8, error)
         - Name: testingOnlyDidHRR
           Offset: 184
           Type: 4 BaseType bool
         - Name: testingOnlyCurveID
           Offset: 186
-          Type: 132 BaseType crypto/tls.CurveID
+          Type: 97 BaseType crypto/tls.CurveID
     - __kind: BaseType
-      ID: 132
+      ID: 97
       Name: crypto/tls.CurveID
       ByteSize: 2
       GoRuntimeType: 766144
       GoKind: 9
     - __kind: StructureType
-      ID: 82
+      ID: 107
       Name: crypto/x509.Certificate
       ByteSize: 1352
       GoRuntimeType: 2.2352e+06
@@ -1286,67 +1286,67 @@ Types:
       RawFields:
         - Name: Raw
           Offset: 0
-          Type: 76 GoSliceHeaderType []uint8
+          Type: 72 GoSliceHeaderType []uint8
         - Name: RawTBSCertificate
           Offset: 24
-          Type: 76 GoSliceHeaderType []uint8
+          Type: 72 GoSliceHeaderType []uint8
         - Name: RawSubjectPublicKeyInfo
           Offset: 48
-          Type: 76 GoSliceHeaderType []uint8
+          Type: 72 GoSliceHeaderType []uint8
         - Name: RawSubject
           Offset: 72
-          Type: 76 GoSliceHeaderType []uint8
+          Type: 72 GoSliceHeaderType []uint8
         - Name: RawIssuer
           Offset: 96
-          Type: 76 GoSliceHeaderType []uint8
+          Type: 72 GoSliceHeaderType []uint8
         - Name: Signature
           Offset: 120
-          Type: 76 GoSliceHeaderType []uint8
+          Type: 72 GoSliceHeaderType []uint8
         - Name: SignatureAlgorithm
           Offset: 144
-          Type: 83 BaseType crypto/x509.SignatureAlgorithm
+          Type: 109 BaseType crypto/x509.SignatureAlgorithm
         - Name: PublicKeyAlgorithm
           Offset: 152
-          Type: 84 BaseType crypto/x509.PublicKeyAlgorithm
+          Type: 110 BaseType crypto/x509.PublicKeyAlgorithm
         - Name: PublicKey
           Offset: 160
-          Type: 85 GoEmptyInterfaceType interface {}
+          Type: 111 GoEmptyInterfaceType interface {}
         - Name: Version
           Offset: 176
           Type: 9 BaseType int
         - Name: SerialNumber
           Offset: 184
-          Type: 86 PointerType *math/big.Int
+          Type: 112 PointerType *math/big.Int
         - Name: Issuer
           Offset: 192
-          Type: 91 StructureType crypto/x509/pkix.Name
+          Type: 114 StructureType crypto/x509/pkix.Name
         - Name: Subject
           Offset: 440
-          Type: 91 StructureType crypto/x509/pkix.Name
+          Type: 114 StructureType crypto/x509/pkix.Name
         - Name: NotBefore
           Offset: 688
-          Type: 96 StructureType time.Time
+          Type: 118 StructureType time.Time
         - Name: NotAfter
           Offset: 712
-          Type: 96 StructureType time.Time
+          Type: 118 StructureType time.Time
         - Name: KeyUsage
           Offset: 736
-          Type: 105 BaseType crypto/x509.KeyUsage
+          Type: 121 BaseType crypto/x509.KeyUsage
         - Name: Extensions
           Offset: 744
-          Type: 106 GoSliceHeaderType []crypto/x509/pkix.Extension
+          Type: 122 GoSliceHeaderType []crypto/x509/pkix.Extension
         - Name: ExtraExtensions
           Offset: 768
-          Type: 106 GoSliceHeaderType []crypto/x509/pkix.Extension
+          Type: 122 GoSliceHeaderType []crypto/x509/pkix.Extension
         - Name: UnhandledCriticalExtensions
           Offset: 792
-          Type: 109 GoSliceHeaderType []encoding/asn1.ObjectIdentifier
+          Type: 125 GoSliceHeaderType []encoding/asn1.ObjectIdentifier
         - Name: ExtKeyUsage
           Offset: 816
-          Type: 111 GoSliceHeaderType []crypto/x509.ExtKeyUsage
+          Type: 128 GoSliceHeaderType []crypto/x509.ExtKeyUsage
         - Name: UnknownExtKeyUsage
           Offset: 840
-          Type: 109 GoSliceHeaderType []encoding/asn1.ObjectIdentifier
+          Type: 125 GoSliceHeaderType []encoding/asn1.ObjectIdentifier
         - Name: BasicConstraintsValid
           Offset: 864
           Type: 4 BaseType bool
@@ -1361,78 +1361,78 @@ Types:
           Type: 4 BaseType bool
         - Name: SubjectKeyId
           Offset: 888
-          Type: 76 GoSliceHeaderType []uint8
+          Type: 72 GoSliceHeaderType []uint8
         - Name: AuthorityKeyId
           Offset: 912
-          Type: 76 GoSliceHeaderType []uint8
+          Type: 72 GoSliceHeaderType []uint8
         - Name: OCSPServer
           Offset: 936
-          Type: 51 GoSliceHeaderType []string
+          Type: 55 GoSliceHeaderType []string
         - Name: IssuingCertificateURL
           Offset: 960
-          Type: 51 GoSliceHeaderType []string
+          Type: 55 GoSliceHeaderType []string
         - Name: DNSNames
           Offset: 984
-          Type: 51 GoSliceHeaderType []string
+          Type: 55 GoSliceHeaderType []string
         - Name: EmailAddresses
           Offset: 1008
-          Type: 51 GoSliceHeaderType []string
+          Type: 55 GoSliceHeaderType []string
         - Name: IPAddresses
           Offset: 1032
-          Type: 114 GoSliceHeaderType []net.IP
+          Type: 131 GoSliceHeaderType []net.IP
         - Name: URIs
           Offset: 1056
-          Type: 117 GoSliceHeaderType []*net/url.URL
+          Type: 134 GoSliceHeaderType []*net/url.URL
         - Name: PermittedDNSDomainsCritical
           Offset: 1080
           Type: 4 BaseType bool
         - Name: PermittedDNSDomains
           Offset: 1088
-          Type: 51 GoSliceHeaderType []string
+          Type: 55 GoSliceHeaderType []string
         - Name: ExcludedDNSDomains
           Offset: 1112
-          Type: 51 GoSliceHeaderType []string
+          Type: 55 GoSliceHeaderType []string
         - Name: PermittedIPRanges
           Offset: 1136
-          Type: 119 GoSliceHeaderType []*net.IPNet
+          Type: 136 GoSliceHeaderType []*net.IPNet
         - Name: ExcludedIPRanges
           Offset: 1160
-          Type: 119 GoSliceHeaderType []*net.IPNet
+          Type: 136 GoSliceHeaderType []*net.IPNet
         - Name: PermittedEmailAddresses
           Offset: 1184
-          Type: 51 GoSliceHeaderType []string
+          Type: 55 GoSliceHeaderType []string
         - Name: ExcludedEmailAddresses
           Offset: 1208
-          Type: 51 GoSliceHeaderType []string
+          Type: 55 GoSliceHeaderType []string
         - Name: PermittedURIDomains
           Offset: 1232
-          Type: 51 GoSliceHeaderType []string
+          Type: 55 GoSliceHeaderType []string
         - Name: ExcludedURIDomains
           Offset: 1256
-          Type: 51 GoSliceHeaderType []string
+          Type: 55 GoSliceHeaderType []string
         - Name: CRLDistributionPoints
           Offset: 1280
-          Type: 51 GoSliceHeaderType []string
+          Type: 55 GoSliceHeaderType []string
         - Name: PolicyIdentifiers
           Offset: 1304
-          Type: 109 GoSliceHeaderType []encoding/asn1.ObjectIdentifier
+          Type: 125 GoSliceHeaderType []encoding/asn1.ObjectIdentifier
         - Name: Policies
           Offset: 1328
-          Type: 124 GoSliceHeaderType []crypto/x509.OID
+          Type: 139 GoSliceHeaderType []crypto/x509.OID
     - __kind: BaseType
-      ID: 113
+      ID: 130
       Name: crypto/x509.ExtKeyUsage
       ByteSize: 8
       GoRuntimeType: 537472
       GoKind: 2
     - __kind: BaseType
-      ID: 105
+      ID: 121
       Name: crypto/x509.KeyUsage
       ByteSize: 8
       GoRuntimeType: 537408
       GoKind: 2
     - __kind: StructureType
-      ID: 126
+      ID: 141
       Name: crypto/x509.OID
       ByteSize: 24
       GoRuntimeType: 1.718016e+06
@@ -1440,21 +1440,21 @@ Types:
       RawFields:
         - Name: der
           Offset: 0
-          Type: 76 GoSliceHeaderType []uint8
+          Type: 72 GoSliceHeaderType []uint8
     - __kind: BaseType
-      ID: 84
+      ID: 110
       Name: crypto/x509.PublicKeyAlgorithm
       ByteSize: 8
       GoRuntimeType: 768544
       GoKind: 2
     - __kind: BaseType
-      ID: 83
+      ID: 109
       Name: crypto/x509.SignatureAlgorithm
       ByteSize: 8
       GoRuntimeType: 1.071168e+06
       GoKind: 2
     - __kind: StructureType
-      ID: 94
+      ID: 117
       Name: crypto/x509/pkix.AttributeTypeAndValue
       ByteSize: 40
       GoRuntimeType: 1.316608e+06
@@ -1462,12 +1462,12 @@ Types:
       RawFields:
         - Name: Type
           Offset: 0
-          Type: 95 GoSliceHeaderType encoding/asn1.ObjectIdentifier
+          Type: 127 GoSliceHeaderType encoding/asn1.ObjectIdentifier
         - Name: Value
           Offset: 24
-          Type: 85 GoEmptyInterfaceType interface {}
+          Type: 111 GoEmptyInterfaceType interface {}
     - __kind: StructureType
-      ID: 108
+      ID: 124
       Name: crypto/x509/pkix.Extension
       ByteSize: 56
       GoRuntimeType: 1.45536e+06
@@ -1475,15 +1475,15 @@ Types:
       RawFields:
         - Name: Id
           Offset: 0
-          Type: 95 GoSliceHeaderType encoding/asn1.ObjectIdentifier
+          Type: 127 GoSliceHeaderType encoding/asn1.ObjectIdentifier
         - Name: Critical
           Offset: 24
           Type: 4 BaseType bool
         - Name: Value
           Offset: 32
-          Type: 76 GoSliceHeaderType []uint8
+          Type: 72 GoSliceHeaderType []uint8
     - __kind: StructureType
-      ID: 91
+      ID: 114
       Name: crypto/x509/pkix.Name
       ByteSize: 248
       GoRuntimeType: 2.047488e+06
@@ -1491,25 +1491,25 @@ Types:
       RawFields:
         - Name: Country
           Offset: 0
-          Type: 51 GoSliceHeaderType []string
+          Type: 55 GoSliceHeaderType []string
         - Name: Organization
           Offset: 24
-          Type: 51 GoSliceHeaderType []string
+          Type: 55 GoSliceHeaderType []string
         - Name: OrganizationalUnit
           Offset: 48
-          Type: 51 GoSliceHeaderType []string
+          Type: 55 GoSliceHeaderType []string
         - Name: Locality
           Offset: 72
-          Type: 51 GoSliceHeaderType []string
+          Type: 55 GoSliceHeaderType []string
         - Name: Province
           Offset: 96
-          Type: 51 GoSliceHeaderType []string
+          Type: 55 GoSliceHeaderType []string
         - Name: StreetAddress
           Offset: 120
-          Type: 51 GoSliceHeaderType []string
+          Type: 55 GoSliceHeaderType []string
         - Name: PostalCode
           Offset: 144
-          Type: 51 GoSliceHeaderType []string
+          Type: 55 GoSliceHeaderType []string
         - Name: SerialNumber
           Offset: 168
           Type: 11 GoStringHeaderType string
@@ -1518,12 +1518,12 @@ Types:
           Type: 11 GoStringHeaderType string
         - Name: Names
           Offset: 200
-          Type: 92 GoSliceHeaderType []crypto/x509/pkix.AttributeTypeAndValue
+          Type: 115 GoSliceHeaderType []crypto/x509/pkix.AttributeTypeAndValue
         - Name: ExtraNames
           Offset: 224
-          Type: 92 GoSliceHeaderType []crypto/x509/pkix.AttributeTypeAndValue
+          Type: 115 GoSliceHeaderType []crypto/x509/pkix.AttributeTypeAndValue
     - __kind: GoSliceHeaderType
-      ID: 95
+      ID: 127
       Name: encoding/asn1.ObjectIdentifier
       ByteSize: 24
       GoRuntimeType: 1.010048e+06
@@ -1538,9 +1538,9 @@ Types:
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 172 GoSliceDataType encoding/asn1.ObjectIdentifier.array
+      Data: 181 GoSliceDataType encoding/asn1.ObjectIdentifier.array
     - __kind: GoSliceDataType
-      ID: 172
+      ID: 181
       Name: encoding/asn1.ObjectIdentifier.array
       ByteSize: 2048
       Element: 9 BaseType int
@@ -1570,19 +1570,19 @@ Types:
       GoRuntimeType: 534720
       GoKind: 14
     - __kind: GoSubroutineType
-      ID: 60
+      ID: 54
       Name: func() (io.ReadCloser, error)
       ByteSize: 8
       GoRuntimeType: 634400
       GoKind: 19
     - __kind: GoSubroutineType
-      ID: 131
+      ID: 96
       Name: func(string, []uint8, int) ([]uint8, error)
       ByteSize: 8
       GoRuntimeType: 960448
       GoKind: 19
     - __kind: GoInterfaceType
-      ID: 151
+      ID: 41
       Name: gopkg.in/DataDog/dd-trace-go.v1/ddtrace.Span
       ByteSize: 16
       GoRuntimeType: 1.296128e+06
@@ -1595,7 +1595,7 @@ Types:
           Offset: 8
           Type: 19 VoidPointerType unsafe.Pointer
     - __kind: GoHMapHeaderType
-      ID: 67
+      ID: 86
       Name: hash<string,[]*mime/multipart.FileHeader>
       ByteSize: 48
       RawFields:
@@ -1616,20 +1616,20 @@ Types:
           Type: 2 BaseType uint32
         - Name: buckets
           Offset: 16
-          Type: 68 PointerType *bucket<string,[]*mime/multipart.FileHeader>
+          Type: 87 PointerType *bucket<string,[]*mime/multipart.FileHeader>
         - Name: oldbuckets
           Offset: 24
-          Type: 68 PointerType *bucket<string,[]*mime/multipart.FileHeader>
+          Type: 87 PointerType *bucket<string,[]*mime/multipart.FileHeader>
         - Name: nevacuate
           Offset: 32
           Type: 1 BaseType uintptr
         - Name: extra
           Offset: 40
-          Type: 52 PointerType *runtime.mapextra
-      BucketType: 69 GoHMapBucketType bucket<string,[]*mime/multipart.FileHeader>
-      BucketsType: 161 GoSliceDataType []bucket<string,[]*mime/multipart.FileHeader>.array
+          Type: 51 PointerType *runtime.mapextra
+      BucketType: 88 GoHMapBucketType bucket<string,[]*mime/multipart.FileHeader>
+      BucketsType: 164 GoSliceDataType []bucket<string,[]*mime/multipart.FileHeader>.array
     - __kind: GoHMapHeaderType
-      ID: 45
+      ID: 48
       Name: hash<string,[]string>
       ByteSize: 48
       RawFields:
@@ -1650,20 +1650,20 @@ Types:
           Type: 2 BaseType uint32
         - Name: buckets
           Offset: 16
-          Type: 46 PointerType *bucket<string,[]string>
+          Type: 49 PointerType *bucket<string,[]string>
         - Name: oldbuckets
           Offset: 24
-          Type: 46 PointerType *bucket<string,[]string>
+          Type: 49 PointerType *bucket<string,[]string>
         - Name: nevacuate
           Offset: 32
           Type: 1 BaseType uintptr
         - Name: extra
           Offset: 40
-          Type: 52 PointerType *runtime.mapextra
-      BucketType: 47 GoHMapBucketType bucket<string,[]string>
+          Type: 51 PointerType *runtime.mapextra
+      BucketType: 50 GoHMapBucketType bucket<string,[]string>
       BucketsType: 156 GoSliceDataType []bucket<string,[]string>.array
     - __kind: GoHMapHeaderType
-      ID: 144
+      ID: 69
       Name: hash<string,string>
       ByteSize: 48
       RawFields:
@@ -1684,18 +1684,18 @@ Types:
           Type: 2 BaseType uint32
         - Name: buckets
           Offset: 16
-          Type: 145 PointerType *bucket<string,string>
+          Type: 70 PointerType *bucket<string,string>
         - Name: oldbuckets
           Offset: 24
-          Type: 145 PointerType *bucket<string,string>
+          Type: 70 PointerType *bucket<string,string>
         - Name: nevacuate
           Offset: 32
           Type: 1 BaseType uintptr
         - Name: extra
           Offset: 40
-          Type: 52 PointerType *runtime.mapextra
-      BucketType: 146 GoHMapBucketType bucket<string,string>
-      BucketsType: 202 GoSliceDataType []bucket<string,string>.array
+          Type: 51 PointerType *runtime.mapextra
+      BucketType: 71 GoHMapBucketType bucket<string,string>
+      BucketsType: 159 GoSliceDataType []bucket<string,string>.array
     - __kind: BaseType
       ID: 9
       Name: int
@@ -1727,7 +1727,7 @@ Types:
       GoRuntimeType: 533824
       GoKind: 3
     - __kind: GoEmptyInterfaceType
-      ID: 85
+      ID: 111
       Name: interface {}
       ByteSize: 16
       GoRuntimeType: 785472
@@ -1740,7 +1740,7 @@ Types:
           Offset: 8
           Type: 19 VoidPointerType unsafe.Pointer
     - __kind: GoInterfaceType
-      ID: 59
+      ID: 53
       Name: io.ReadCloser
       ByteSize: 16
       GoRuntimeType: 1.067328e+06
@@ -1753,28 +1753,28 @@ Types:
           Offset: 8
           Type: 19 VoidPointerType unsafe.Pointer
     - __kind: GoMapType
-      ID: 65
+      ID: 84
       Name: map[string][]*mime/multipart.FileHeader
       ByteSize: 8
       GoRuntimeType: 887392
       GoKind: 21
-      HeaderType: 67 GoHMapHeaderType hash<string,[]*mime/multipart.FileHeader>
+      HeaderType: 86 GoHMapHeaderType hash<string,[]*mime/multipart.FileHeader>
     - __kind: GoMapType
-      ID: 64
+      ID: 83
       Name: map[string][]string
       ByteSize: 8
       GoRuntimeType: 882592
       GoKind: 21
-      HeaderType: 45 GoHMapHeaderType hash<string,[]string>
+      HeaderType: 48 GoHMapHeaderType hash<string,[]string>
     - __kind: GoMapType
-      ID: 142
+      ID: 67
       Name: map[string]string
       ByteSize: 8
       GoRuntimeType: 884224
       GoKind: 21
-      HeaderType: 144 GoHMapHeaderType hash<string,string>
+      HeaderType: 69 GoHMapHeaderType hash<string,string>
     - __kind: StructureType
-      ID: 87
+      ID: 113
       Name: math/big.Int
       ByteSize: 32
       GoRuntimeType: 1.308608e+06
@@ -1785,15 +1785,15 @@ Types:
           Type: 4 BaseType bool
         - Name: abs
           Offset: 8
-          Type: 88 GoSliceHeaderType math/big.nat
+          Type: 143 GoSliceHeaderType math/big.nat
     - __kind: BaseType
-      ID: 90
+      ID: 145
       Name: math/big.Word
       ByteSize: 8
       GoRuntimeType: 537728
       GoKind: 7
     - __kind: GoSliceHeaderType
-      ID: 88
+      ID: 143
       Name: math/big.nat
       ByteSize: 24
       GoRuntimeType: 2.214784e+06
@@ -1801,21 +1801,21 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 89 PointerType *math/big.Word
+          Type: 144 PointerType *math/big.Word
         - Name: len
           Offset: 8
           Type: 9 BaseType int
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 168 GoSliceDataType math/big.nat.array
+      Data: 195 GoSliceDataType math/big.nat.array
     - __kind: GoSliceDataType
-      ID: 168
+      ID: 195
       Name: math/big.nat.array
       ByteSize: 2048
-      Element: 90 BaseType math/big.Word
+      Element: 145 BaseType math/big.Word
     - __kind: StructureType
-      ID: 74
+      ID: 108
       Name: mime/multipart.FileHeader
       ByteSize: 88
       GoRuntimeType: 1.83856e+06
@@ -1826,13 +1826,13 @@ Types:
           Type: 11 GoStringHeaderType string
         - Name: Header
           Offset: 16
-          Type: 75 GoMapType net/textproto.MIMEHeader
+          Type: 142 GoMapType net/textproto.MIMEHeader
         - Name: Size
           Offset: 24
           Type: 14 BaseType int64
         - Name: content
           Offset: 32
-          Type: 76 GoSliceHeaderType []uint8
+          Type: 72 GoSliceHeaderType []uint8
         - Name: tmpfile
           Offset: 56
           Type: 11 GoStringHeaderType string
@@ -1843,7 +1843,7 @@ Types:
           Offset: 80
           Type: 4 BaseType bool
     - __kind: StructureType
-      ID: 63
+      ID: 58
       Name: mime/multipart.Form
       ByteSize: 16
       GoRuntimeType: 1.294528e+06
@@ -1851,12 +1851,12 @@ Types:
       RawFields:
         - Name: Value
           Offset: 0
-          Type: 64 GoMapType map[string][]string
+          Type: 83 GoMapType map[string][]string
         - Name: File
           Offset: 8
-          Type: 65 GoMapType map[string][]*mime/multipart.FileHeader
+          Type: 84 GoMapType map[string][]*mime/multipart.FileHeader
     - __kind: GoSliceHeaderType
-      ID: 116
+      ID: 133
       Name: net.IP
       ByteSize: 24
       GoRuntimeType: 1.948704e+06
@@ -1871,14 +1871,14 @@ Types:
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 186 GoSliceDataType net.IP.array
+      Data: 187 GoSliceDataType net.IP.array
     - __kind: GoSliceDataType
-      ID: 186
+      ID: 187
       Name: net.IP.array
       ByteSize: 2048
       Element: 3 BaseType uint8
     - __kind: GoSliceHeaderType
-      ID: 123
+      ID: 153
       Name: net.IPMask
       ByteSize: 24
       GoRuntimeType: 976000
@@ -1893,14 +1893,14 @@ Types:
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 192 GoSliceDataType net.IPMask.array
+      Data: 201 GoSliceDataType net.IPMask.array
     - __kind: GoSliceDataType
-      ID: 192
+      ID: 201
       Name: net.IPMask.array
       ByteSize: 2048
       Element: 3 BaseType uint8
     - __kind: StructureType
-      ID: 122
+      ID: 152
       Name: net.IPNet
       ByteSize: 48
       GoRuntimeType: 1.276128e+06
@@ -1908,17 +1908,17 @@ Types:
       RawFields:
         - Name: IP
           Offset: 0
-          Type: 116 GoSliceHeaderType net.IP
+          Type: 133 GoSliceHeaderType net.IP
         - Name: Mask
           Offset: 24
-          Type: 123 GoSliceHeaderType net.IPMask
+          Type: 153 GoSliceHeaderType net.IPMask
     - __kind: GoMapType
-      ID: 43
+      ID: 46
       Name: net/http.Header
       ByteSize: 8
       GoRuntimeType: 1.917984e+06
       GoKind: 21
-      HeaderType: 45 GoHMapHeaderType hash<string,[]string>
+      HeaderType: 48 GoHMapHeaderType hash<string,[]string>
     - __kind: StructureType
       ID: 38
       Name: net/http.Request
@@ -1931,7 +1931,7 @@ Types:
           Type: 11 GoStringHeaderType string
         - Name: URL
           Offset: 16
-          Type: 39 PointerType *net/url.URL
+          Type: 44 PointerType *net/url.URL
         - Name: Proto
           Offset: 24
           Type: 11 GoStringHeaderType string
@@ -1943,19 +1943,19 @@ Types:
           Type: 9 BaseType int
         - Name: Header
           Offset: 56
-          Type: 43 GoMapType net/http.Header
+          Type: 46 GoMapType net/http.Header
         - Name: Body
           Offset: 64
-          Type: 59 GoInterfaceType io.ReadCloser
+          Type: 53 GoInterfaceType io.ReadCloser
         - Name: GetBody
           Offset: 80
-          Type: 60 GoSubroutineType func() (io.ReadCloser, error)
+          Type: 54 GoSubroutineType func() (io.ReadCloser, error)
         - Name: ContentLength
           Offset: 88
           Type: 14 BaseType int64
         - Name: TransferEncoding
           Offset: 96
-          Type: 51 GoSliceHeaderType []string
+          Type: 55 GoSliceHeaderType []string
         - Name: Close
           Offset: 120
           Type: 4 BaseType bool
@@ -1964,16 +1964,16 @@ Types:
           Type: 11 GoStringHeaderType string
         - Name: Form
           Offset: 144
-          Type: 61 GoMapType net/url.Values
+          Type: 56 GoMapType net/url.Values
         - Name: PostForm
           Offset: 152
-          Type: 61 GoMapType net/url.Values
+          Type: 56 GoMapType net/url.Values
         - Name: MultipartForm
           Offset: 160
-          Type: 62 PointerType *mime/multipart.Form
+          Type: 57 PointerType *mime/multipart.Form
         - Name: Trailer
           Offset: 168
-          Type: 43 GoMapType net/http.Header
+          Type: 46 GoMapType net/http.Header
         - Name: RemoteAddr
           Offset: 176
           Type: 11 GoStringHeaderType string
@@ -1982,30 +1982,30 @@ Types:
           Type: 11 GoStringHeaderType string
         - Name: TLS
           Offset: 208
-          Type: 77 PointerType *crypto/tls.ConnectionState
+          Type: 59 PointerType *crypto/tls.ConnectionState
         - Name: Cancel
           Offset: 216
-          Type: 133 GoChannelType <-chan struct {}
+          Type: 61 GoChannelType <-chan struct {}
         - Name: Response
           Offset: 224
-          Type: 134 PointerType *net/http.Response
+          Type: 62 PointerType *net/http.Response
         - Name: Pattern
           Offset: 232
           Type: 11 GoStringHeaderType string
         - Name: ctx
           Offset: 248
-          Type: 136 GoInterfaceType context.Context
+          Type: 64 GoInterfaceType context.Context
         - Name: pat
           Offset: 264
-          Type: 137 PointerType *net/http.pattern
+          Type: 65 PointerType *net/http.pattern
         - Name: matches
           Offset: 272
-          Type: 51 GoSliceHeaderType []string
+          Type: 55 GoSliceHeaderType []string
         - Name: otherValues
           Offset: 296
-          Type: 142 GoMapType map[string]string
+          Type: 67 GoMapType map[string]string
     - __kind: StructureType
-      ID: 135
+      ID: 63
       Name: net/http.Response
       ByteSize: 144
       GoRuntimeType: 2.065376e+06
@@ -2028,16 +2028,16 @@ Types:
           Type: 9 BaseType int
         - Name: Header
           Offset: 56
-          Type: 43 GoMapType net/http.Header
+          Type: 46 GoMapType net/http.Header
         - Name: Body
           Offset: 64
-          Type: 59 GoInterfaceType io.ReadCloser
+          Type: 53 GoInterfaceType io.ReadCloser
         - Name: ContentLength
           Offset: 80
           Type: 14 BaseType int64
         - Name: TransferEncoding
           Offset: 88
-          Type: 51 GoSliceHeaderType []string
+          Type: 55 GoSliceHeaderType []string
         - Name: Close
           Offset: 112
           Type: 4 BaseType bool
@@ -2046,13 +2046,13 @@ Types:
           Type: 4 BaseType bool
         - Name: Trailer
           Offset: 120
-          Type: 43 GoMapType net/http.Header
+          Type: 46 GoMapType net/http.Header
         - Name: Request
           Offset: 128
           Type: 37 PointerType *net/http.Request
         - Name: TLS
           Offset: 136
-          Type: 77 PointerType *crypto/tls.ConnectionState
+          Type: 59 PointerType *crypto/tls.ConnectionState
     - __kind: GoInterfaceType
       ID: 36
       Name: net/http.ResponseWriter
@@ -2067,7 +2067,7 @@ Types:
           Offset: 8
           Type: 19 VoidPointerType unsafe.Pointer
     - __kind: StructureType
-      ID: 138
+      ID: 66
       Name: net/http.pattern
       ByteSize: 88
       GoRuntimeType: 1.702112e+06
@@ -2084,12 +2084,12 @@ Types:
           Type: 11 GoStringHeaderType string
         - Name: segments
           Offset: 48
-          Type: 139 GoSliceHeaderType []net/http.segment
+          Type: 98 GoSliceHeaderType []net/http.segment
         - Name: loc
           Offset: 72
           Type: 11 GoStringHeaderType string
     - __kind: StructureType
-      ID: 141
+      ID: 100
       Name: net/http.segment
       ByteSize: 24
       GoRuntimeType: 1.416384e+06
@@ -2105,14 +2105,14 @@ Types:
           Offset: 17
           Type: 4 BaseType bool
     - __kind: GoMapType
-      ID: 75
+      ID: 142
       Name: net/textproto.MIMEHeader
       ByteSize: 8
       GoRuntimeType: 1.596448e+06
       GoKind: 21
-      HeaderType: 45 GoHMapHeaderType hash<string,[]string>
+      HeaderType: 48 GoHMapHeaderType hash<string,[]string>
     - __kind: StructureType
-      ID: 40
+      ID: 45
       Name: net/url.URL
       ByteSize: 144
       GoRuntimeType: 1.986816e+06
@@ -2126,7 +2126,7 @@ Types:
           Type: 11 GoStringHeaderType string
         - Name: User
           Offset: 32
-          Type: 41 PointerType *net/url.Userinfo
+          Type: 74 PointerType *net/url.Userinfo
         - Name: Host
           Offset: 40
           Type: 11 GoStringHeaderType string
@@ -2152,7 +2152,7 @@ Types:
           Offset: 128
           Type: 11 GoStringHeaderType string
     - __kind: StructureType
-      ID: 42
+      ID: 75
       Name: net/url.Userinfo
       ByteSize: 40
       GoRuntimeType: 1.433088e+06
@@ -2168,14 +2168,14 @@ Types:
           Offset: 32
           Type: 4 BaseType bool
     - __kind: GoMapType
-      ID: 61
+      ID: 56
       Name: net/url.Values
       ByteSize: 8
       GoRuntimeType: 1.671328e+06
       GoKind: 21
-      HeaderType: 45 GoHMapHeaderType hash<string,[]string>
+      HeaderType: 48 GoHMapHeaderType hash<string,[]string>
     - __kind: StructureType
-      ID: 58
+      ID: 82
       Name: runtime.bmap
       ByteSize: 8
       GoRuntimeType: 1.10992e+06
@@ -2183,9 +2183,9 @@ Types:
       RawFields:
         - Name: tophash
           Offset: 0
-          Type: 48 ArrayType [8]uint8
+          Type: 76 ArrayType [8]uint8
     - __kind: StructureType
-      ID: 53
+      ID: 52
       Name: runtime.mapextra
       ByteSize: 24
       GoRuntimeType: 1.429056e+06
@@ -2193,13 +2193,13 @@ Types:
       RawFields:
         - Name: overflow
           Offset: 0
-          Type: 54 PointerType *[]*runtime.bmap
+          Type: 79 PointerType *[]*runtime.bmap
         - Name: oldoverflow
           Offset: 8
-          Type: 54 PointerType *[]*runtime.bmap
+          Type: 79 PointerType *[]*runtime.bmap
         - Name: nextOverflow
           Offset: 16
-          Type: 57 PointerType *runtime.bmap
+          Type: 81 PointerType *runtime.bmap
     - __kind: GoStringHeaderType
       ID: 11
       Name: string
@@ -2219,7 +2219,7 @@ Types:
       Name: string.str
       ByteSize: 2048
     - __kind: StructureType
-      ID: 98
+      ID: 120
       Name: time.Location
       ByteSize: 104
       GoRuntimeType: 1.834528e+06
@@ -2230,10 +2230,10 @@ Types:
           Type: 11 GoStringHeaderType string
         - Name: zone
           Offset: 16
-          Type: 99 GoSliceHeaderType []time.zone
+          Type: 146 GoSliceHeaderType []time.zone
         - Name: tx
           Offset: 40
-          Type: 102 GoSliceHeaderType []time.zoneTrans
+          Type: 149 GoSliceHeaderType []time.zoneTrans
         - Name: extend
           Offset: 64
           Type: 11 GoStringHeaderType string
@@ -2245,9 +2245,9 @@ Types:
           Type: 14 BaseType int64
         - Name: cacheZone
           Offset: 96
-          Type: 100 PointerType *time.zone
+          Type: 147 PointerType *time.zone
     - __kind: StructureType
-      ID: 96
+      ID: 118
       Name: time.Time
       ByteSize: 24
       GoRuntimeType: 2.215712e+06
@@ -2261,9 +2261,9 @@ Types:
           Type: 14 BaseType int64
         - Name: loc
           Offset: 16
-          Type: 97 PointerType *time.Location
+          Type: 119 PointerType *time.Location
     - __kind: StructureType
-      ID: 101
+      ID: 148
       Name: time.zone
       ByteSize: 32
       GoRuntimeType: 1.421376e+06
@@ -2279,7 +2279,7 @@ Types:
           Offset: 24
           Type: 4 BaseType bool
     - __kind: StructureType
-      ID: 104
+      ID: 151
       Name: time.zoneTrans
       ByteSize: 16
       GoRuntimeType: 1.623872e+06

--- a/pkg/dyninst/irgen/testdata/snapshot/rc_tester_v1.arch=arm64,toolchain=go1.24.3.yaml
+++ b/pkg/dyninst/irgen/testdata/snapshot/rc_tester_v1.arch=arm64,toolchain=go1.24.3.yaml
@@ -10,7 +10,7 @@ Probes:
       subprogram: {subprogram: 1}
       events:
         - ID: 1
-          Type: 215 EventRootType Probe[main.HandleHTTP]
+          Type: 214 EventRootType Probe[main.HandleHTTP]
           InjectionPoints: [{PC: "0x86c110", Frameless: true}]
           Condition: null
     - id: look_at_the_request
@@ -23,7 +23,7 @@ Probes:
       subprogram: {subprogram: 2}
       events:
         - ID: 2
-          Type: 216 EventRootType Probe[main.LookAtTheRequest]
+          Type: 215 EventRootType Probe[main.LookAtTheRequest]
           InjectionPoints: [{PC: "0x86c41c", Frameless: true}]
           Condition: null
 Subprograms:
@@ -121,146 +121,146 @@ Subprograms:
           IsReturn: false
 Types:
     - __kind: PointerType
-      ID: 84
+      ID: 109
       Name: '**crypto/x509.Certificate'
       ByteSize: 8
       GoKind: 22
-      Pointee: 85 PointerType *crypto/x509.Certificate
+      Pointee: 110 PointerType *crypto/x509.Certificate
     - __kind: PointerType
-      ID: 122
+      ID: 97
       Name: '**mime/multipart.FileHeader'
       ByteSize: 8
       GoKind: 22
-      Pointee: 123 PointerType *mime/multipart.FileHeader
+      Pointee: 98 PointerType *mime/multipart.FileHeader
     - __kind: PointerType
-      ID: 162
+      ID: 152
       Name: '**net.IPNet'
       ByteSize: 8
       GoKind: 22
-      Pointee: 163 PointerType *net.IPNet
+      Pointee: 153 PointerType *net.IPNet
     - __kind: PointerType
-      ID: 160
+      ID: 150
       Name: '**net/url.URL'
       ByteSize: 8
-      Pointee: 44 PointerType *net/url.URL
+      Pointee: 46 PointerType *net/url.URL
     - __kind: PointerType
-      ID: 81
+      ID: 88
       Name: '**table<string,[]*mime/multipart.FileHeader>'
       ByteSize: 8
-      Pointee: 82 PointerType *table<string,[]*mime/multipart.FileHeader>
+      Pointee: 89 PointerType *table<string,[]*mime/multipart.FileHeader>
     - __kind: PointerType
-      ID: 49
+      ID: 51
       Name: '**table<string,[]string>'
       ByteSize: 8
-      Pointee: 50 PointerType *table<string,[]string>
+      Pointee: 52 PointerType *table<string,[]string>
     - __kind: PointerType
-      ID: 68
+      ID: 70
       Name: '**table<string,string>'
       ByteSize: 8
-      Pointee: 69 PointerType *table<string,string>
+      Pointee: 71 PointerType *table<string,string>
     - __kind: PointerType
-      ID: 87
+      ID: 112
       Name: '*[]*crypto/x509.Certificate'
       ByteSize: 8
       GoKind: 22
-      Pointee: 83 GoSliceHeaderType []*crypto/x509.Certificate
+      Pointee: 108 GoSliceHeaderType []*crypto/x509.Certificate
     - __kind: PointerType
-      ID: 127
+      ID: 119
       Name: '*[]*crypto/x509.Certificate.array'
       ByteSize: 8
-      Pointee: 126 GoSliceDataType []*crypto/x509.Certificate.array
+      Pointee: 118 GoSliceDataType []*crypto/x509.Certificate.array
     - __kind: PointerType
-      ID: 172
+      ID: 103
       Name: '*[]*mime/multipart.FileHeader.array'
       ByteSize: 8
-      Pointee: 171 GoSliceDataType []*mime/multipart.FileHeader.array
-    - __kind: PointerType
-      ID: 201
-      Name: '*[]*net.IPNet.array'
-      ByteSize: 8
-      Pointee: 200 GoSliceDataType []*net.IPNet.array
-    - __kind: PointerType
-      ID: 199
-      Name: '*[]*net/url.URL.array'
-      ByteSize: 8
-      Pointee: 198 GoSliceDataType []*net/url.URL.array
-    - __kind: PointerType
-      ID: 129
-      Name: '*[][]*crypto/x509.Certificate.array'
-      ByteSize: 8
-      Pointee: 128 GoSliceDataType [][]*crypto/x509.Certificate.array
-    - __kind: PointerType
-      ID: 131
-      Name: '*[][]uint8.array'
-      ByteSize: 8
-      Pointee: 130 GoSliceDataType [][]uint8.array
-    - __kind: PointerType
-      ID: 193
-      Name: '*[]crypto/x509.ExtKeyUsage.array'
-      ByteSize: 8
-      Pointee: 192 GoSliceDataType []crypto/x509.ExtKeyUsage.array
-    - __kind: PointerType
-      ID: 203
-      Name: '*[]crypto/x509.OID.array'
-      ByteSize: 8
-      Pointee: 202 GoSliceDataType []crypto/x509.OID.array
-    - __kind: PointerType
-      ID: 205
-      Name: '*[]crypto/x509.PolicyMapping.array'
-      ByteSize: 8
-      Pointee: 204 GoSliceDataType []crypto/x509.PolicyMapping.array
-    - __kind: PointerType
-      ID: 185
-      Name: '*[]crypto/x509/pkix.AttributeTypeAndValue.array'
-      ByteSize: 8
-      Pointee: 184 GoSliceDataType []crypto/x509/pkix.AttributeTypeAndValue.array
-    - __kind: PointerType
-      ID: 187
-      Name: '*[]crypto/x509/pkix.Extension.array'
-      ByteSize: 8
-      Pointee: 186 GoSliceDataType []crypto/x509/pkix.Extension.array
+      Pointee: 102 GoSliceDataType []*mime/multipart.FileHeader.array
     - __kind: PointerType
       ID: 189
+      Name: '*[]*net.IPNet.array'
+      ByteSize: 8
+      Pointee: 188 GoSliceDataType []*net.IPNet.array
+    - __kind: PointerType
+      ID: 186
+      Name: '*[]*net/url.URL.array'
+      ByteSize: 8
+      Pointee: 185 GoSliceDataType []*net/url.URL.array
+    - __kind: PointerType
+      ID: 121
+      Name: '*[][]*crypto/x509.Certificate.array'
+      ByteSize: 8
+      Pointee: 120 GoSliceDataType [][]*crypto/x509.Certificate.array
+    - __kind: PointerType
+      ID: 123
+      Name: '*[][]uint8.array'
+      ByteSize: 8
+      Pointee: 122 GoSliceDataType [][]uint8.array
+    - __kind: PointerType
+      ID: 182
+      Name: '*[]crypto/x509.ExtKeyUsage.array'
+      ByteSize: 8
+      Pointee: 181 GoSliceDataType []crypto/x509.ExtKeyUsage.array
+    - __kind: PointerType
+      ID: 191
+      Name: '*[]crypto/x509.OID.array'
+      ByteSize: 8
+      Pointee: 190 GoSliceDataType []crypto/x509.OID.array
+    - __kind: PointerType
+      ID: 193
+      Name: '*[]crypto/x509.PolicyMapping.array'
+      ByteSize: 8
+      Pointee: 192 GoSliceDataType []crypto/x509.PolicyMapping.array
+    - __kind: PointerType
+      ID: 166
+      Name: '*[]crypto/x509/pkix.AttributeTypeAndValue.array'
+      ByteSize: 8
+      Pointee: 165 GoSliceDataType []crypto/x509/pkix.AttributeTypeAndValue.array
+    - __kind: PointerType
+      ID: 178
+      Name: '*[]crypto/x509/pkix.Extension.array'
+      ByteSize: 8
+      Pointee: 177 GoSliceDataType []crypto/x509/pkix.Extension.array
+    - __kind: PointerType
+      ID: 180
       Name: '*[]encoding/asn1.ObjectIdentifier.array'
       ByteSize: 8
-      Pointee: 188 GoSliceDataType []encoding/asn1.ObjectIdentifier.array
+      Pointee: 179 GoSliceDataType []encoding/asn1.ObjectIdentifier.array
     - __kind: PointerType
-      ID: 195
+      ID: 184
       Name: '*[]net.IP.array'
       ByteSize: 8
-      Pointee: 194 GoSliceDataType []net.IP.array
+      Pointee: 183 GoSliceDataType []net.IP.array
     - __kind: PointerType
-      ID: 133
+      ID: 205
       Name: '*[]net/http.segment.array'
       ByteSize: 8
-      Pointee: 132 GoSliceDataType []net/http.segment.array
+      Pointee: 204 GoSliceDataType []net/http.segment.array
     - __kind: PointerType
-      ID: 104
+      ID: 83
       Name: '*[]string.array'
       ByteSize: 8
-      Pointee: 103 GoSliceDataType []string.array
+      Pointee: 82 GoSliceDataType []string.array
     - __kind: PointerType
-      ID: 210
+      ID: 174
       Name: '*[]time.zone.array'
       ByteSize: 8
-      Pointee: 209 GoSliceDataType []time.zone.array
+      Pointee: 173 GoSliceDataType []time.zone.array
     - __kind: PointerType
-      ID: 212
+      ID: 176
       Name: '*[]time.zoneTrans.array'
       ByteSize: 8
-      Pointee: 211 GoSliceDataType []time.zoneTrans.array
+      Pointee: 175 GoSliceDataType []time.zoneTrans.array
     - __kind: PointerType
-      ID: 89
+      ID: 114
       Name: '*[]uint8'
       ByteSize: 8
       GoRuntimeType: 478144
       GoKind: 22
-      Pointee: 70 GoSliceHeaderType []uint8
+      Pointee: 105 GoSliceHeaderType []uint8
     - __kind: PointerType
-      ID: 113
+      ID: 107
       Name: '*[]uint8.array'
       ByteSize: 8
-      Pointee: 112 GoSliceDataType []uint8.array
+      Pointee: 106 GoSliceDataType []uint8.array
     - __kind: PointerType
       ID: 11
       Name: '*bool'
@@ -274,68 +274,68 @@ Types:
       ByteSize: 8
       GoRuntimeType: 2.245056e+06
       GoKind: 22
-      Pointee: 40 StructureType bytes.Buffer
+      Pointee: 40 UnresolvedPointeeType bytes.Buffer
     - __kind: PointerType
-      ID: 57
+      ID: 59
       Name: '*crypto/tls.ConnectionState'
       ByteSize: 8
       GoRuntimeType: 900864
       GoKind: 22
-      Pointee: 58 StructureType crypto/tls.ConnectionState
+      Pointee: 60 StructureType crypto/tls.ConnectionState
     - __kind: PointerType
-      ID: 85
+      ID: 110
       Name: '*crypto/x509.Certificate'
       ByteSize: 8
       GoRuntimeType: 2.030304e+06
       GoKind: 22
-      Pointee: 115 StructureType crypto/x509.Certificate
+      Pointee: 117 StructureType crypto/x509.Certificate
     - __kind: PointerType
-      ID: 154
+      ID: 144
       Name: '*crypto/x509.ExtKeyUsage'
       ByteSize: 8
       GoRuntimeType: 420160
       GoKind: 22
-      Pointee: 155 BaseType crypto/x509.ExtKeyUsage
+      Pointee: 145 BaseType crypto/x509.ExtKeyUsage
     - __kind: PointerType
-      ID: 165
+      ID: 155
       Name: '*crypto/x509.OID'
       ByteSize: 8
       GoRuntimeType: 1.938144e+06
       GoKind: 22
-      Pointee: 166 StructureType crypto/x509.OID
+      Pointee: 156 StructureType crypto/x509.OID
     - __kind: PointerType
-      ID: 168
+      ID: 158
       Name: '*crypto/x509.PolicyMapping'
       ByteSize: 8
       GoRuntimeType: 420224
       GoKind: 22
-      Pointee: 169 StructureType crypto/x509.PolicyMapping
+      Pointee: 159 StructureType crypto/x509.PolicyMapping
     - __kind: PointerType
-      ID: 141
+      ID: 131
       Name: '*crypto/x509/pkix.AttributeTypeAndValue'
       ByteSize: 8
       GoRuntimeType: 433984
       GoKind: 22
-      Pointee: 142 StructureType crypto/x509/pkix.AttributeTypeAndValue
+      Pointee: 132 StructureType crypto/x509/pkix.AttributeTypeAndValue
     - __kind: PointerType
-      ID: 148
+      ID: 138
       Name: '*crypto/x509/pkix.Extension'
       ByteSize: 8
       GoRuntimeType: 434176
       GoKind: 22
-      Pointee: 149 StructureType crypto/x509/pkix.Extension
+      Pointee: 139 StructureType crypto/x509/pkix.Extension
     - __kind: PointerType
-      ID: 151
+      ID: 141
       Name: '*encoding/asn1.ObjectIdentifier'
       ByteSize: 8
       GoRuntimeType: 1.044e+06
       GoKind: 22
-      Pointee: 152 GoSliceHeaderType encoding/asn1.ObjectIdentifier
+      Pointee: 142 GoSliceHeaderType encoding/asn1.ObjectIdentifier
     - __kind: PointerType
-      ID: 191
+      ID: 195
       Name: '*encoding/asn1.ObjectIdentifier.array'
       ByteSize: 8
-      Pointee: 190 GoSliceDataType encoding/asn1.ObjectIdentifier.array
+      Pointee: 194 GoSliceDataType encoding/asn1.ObjectIdentifier.array
     - __kind: PointerType
       ID: 33
       Name: '*error'
@@ -393,77 +393,77 @@ Types:
       GoKind: 22
       Pointee: 16 BaseType int8
     - __kind: PointerType
-      ID: 79
+      ID: 86
       Name: '*map<string,[]*mime/multipart.FileHeader>'
       ByteSize: 8
-      Pointee: 80 GoSwissMapHeaderType map<string,[]*mime/multipart.FileHeader>
+      Pointee: 87 GoSwissMapHeaderType map<string,[]*mime/multipart.FileHeader>
     - __kind: PointerType
-      ID: 47
+      ID: 49
       Name: '*map<string,[]string>'
       ByteSize: 8
-      Pointee: 48 GoSwissMapHeaderType map<string,[]string>
+      Pointee: 50 GoSwissMapHeaderType map<string,[]string>
     - __kind: PointerType
-      ID: 66
+      ID: 68
       Name: '*map<string,string>'
       ByteSize: 8
-      Pointee: 67 GoSwissMapHeaderType map<string,string>
+      Pointee: 69 GoSwissMapHeaderType map<string,string>
     - __kind: PointerType
-      ID: 137
+      ID: 127
       Name: '*math/big.Int'
       ByteSize: 8
       GoRuntimeType: 2.364704e+06
       GoKind: 22
-      Pointee: 138 StructureType math/big.Int
+      Pointee: 128 StructureType math/big.Int
     - __kind: PointerType
-      ID: 174
+      ID: 161
       Name: '*math/big.Word'
       ByteSize: 8
       GoRuntimeType: 423040
       GoKind: 22
-      Pointee: 175 BaseType math/big.Word
+      Pointee: 162 BaseType math/big.Word
     - __kind: PointerType
-      ID: 208
+      ID: 164
       Name: '*math/big.nat.array'
       ByteSize: 8
-      Pointee: 207 GoSliceDataType math/big.nat.array
+      Pointee: 163 GoSliceDataType math/big.nat.array
     - __kind: PointerType
-      ID: 123
+      ID: 98
       Name: '*mime/multipart.FileHeader'
       ByteSize: 8
       GoRuntimeType: 902304
       GoKind: 22
-      Pointee: 170 StructureType mime/multipart.FileHeader
+      Pointee: 101 StructureType mime/multipart.FileHeader
     - __kind: PointerType
-      ID: 55
+      ID: 57
       Name: '*mime/multipart.Form'
       ByteSize: 8
       GoRuntimeType: 902400
       GoKind: 22
-      Pointee: 56 StructureType mime/multipart.Form
+      Pointee: 58 StructureType mime/multipart.Form
     - __kind: PointerType
-      ID: 157
+      ID: 147
       Name: '*net.IP'
       ByteSize: 8
       GoRuntimeType: 2.134112e+06
       GoKind: 22
-      Pointee: 158 GoSliceHeaderType net.IP
+      Pointee: 148 GoSliceHeaderType net.IP
     - __kind: PointerType
       ID: 197
       Name: '*net.IP.array'
       ByteSize: 8
       Pointee: 196 GoSliceDataType net.IP.array
     - __kind: PointerType
-      ID: 214
+      ID: 200
       Name: '*net.IPMask.array'
       ByteSize: 8
-      Pointee: 213 GoSliceDataType net.IPMask.array
+      Pointee: 199 GoSliceDataType net.IPMask.array
     - __kind: PointerType
-      ID: 163
+      ID: 153
       Name: '*net.IPNet'
       ByteSize: 8
       GoRuntimeType: 1.17392e+06
       GoKind: 22
-      Pointee: 182 StructureType net.IPNet
+      Pointee: 187 StructureType net.IPNet
     - __kind: PointerType
       ID: 37
       Name: '*net/http.Request'
@@ -472,55 +472,55 @@ Types:
       GoKind: 22
       Pointee: 38 StructureType net/http.Request
     - __kind: PointerType
-      ID: 60
+      ID: 62
       Name: '*net/http.Response'
       ByteSize: 8
       GoRuntimeType: 1.705504e+06
       GoKind: 22
-      Pointee: 61 StructureType net/http.Response
+      Pointee: 63 StructureType net/http.Response
     - __kind: PointerType
-      ID: 63
+      ID: 65
       Name: '*net/http.pattern'
       ByteSize: 8
       GoRuntimeType: 1.597408e+06
       GoKind: 22
-      Pointee: 64 StructureType net/http.pattern
+      Pointee: 66 StructureType net/http.pattern
     - __kind: PointerType
-      ID: 93
+      ID: 202
       Name: '*net/http.segment'
       ByteSize: 8
       GoRuntimeType: 388544
       GoKind: 22
-      Pointee: 94 StructureType net/http.segment
+      Pointee: 203 StructureType net/http.segment
     - __kind: PointerType
-      ID: 44
+      ID: 46
       Name: '*net/url.URL'
       ByteSize: 8
       GoRuntimeType: 2.099328e+06
       GoKind: 22
-      Pointee: 45 StructureType net/url.URL
+      Pointee: 47 StructureType net/url.URL
     - __kind: PointerType
-      ID: 74
+      ID: 72
       Name: '*net/url.Userinfo'
       ByteSize: 8
       GoRuntimeType: 1.191456e+06
       GoKind: 22
-      Pointee: 75 StructureType net/url.Userinfo
+      Pointee: 73 StructureType net/url.Userinfo
     - __kind: PointerType
-      ID: 117
+      ID: 92
       Name: '*noalg.map.group[string][]*mime/multipart.FileHeader'
       ByteSize: 8
-      Pointee: 118 StructureType noalg.map.group[string][]*mime/multipart.FileHeader
+      Pointee: 93 StructureType noalg.map.group[string][]*mime/multipart.FileHeader
     - __kind: PointerType
-      ID: 97
+      ID: 76
       Name: '*noalg.map.group[string][]string'
       ByteSize: 8
-      Pointee: 98 StructureType noalg.map.group[string][]string
+      Pointee: 77 StructureType noalg.map.group[string][]string
     - __kind: PointerType
-      ID: 106
+      ID: 208
       Name: '*noalg.map.group[string]string'
       ByteSize: 8
-      Pointee: 107 StructureType noalg.map.group[string]string
+      Pointee: 209 StructureType noalg.map.group[string]string
     - __kind: PointerType
       ID: 22
       Name: '*string'
@@ -529,46 +529,46 @@ Types:
       GoKind: 22
       Pointee: 9 GoStringHeaderType string
     - __kind: PointerType
-      ID: 73
+      ID: 45
       Name: '*string.str'
       ByteSize: 8
-      Pointee: 72 GoStringDataType string.str
+      Pointee: 44 GoStringDataType string.str
     - __kind: PointerType
-      ID: 82
+      ID: 89
       Name: '*table<string,[]*mime/multipart.FileHeader>'
       ByteSize: 8
-      Pointee: 114 StructureType table<string,[]*mime/multipart.FileHeader>
+      Pointee: 90 StructureType table<string,[]*mime/multipart.FileHeader>
     - __kind: PointerType
-      ID: 50
+      ID: 52
       Name: '*table<string,[]string>'
       ByteSize: 8
-      Pointee: 76 StructureType table<string,[]string>
+      Pointee: 74 StructureType table<string,[]string>
     - __kind: PointerType
-      ID: 69
+      ID: 71
       Name: '*table<string,string>'
       ByteSize: 8
-      Pointee: 95 StructureType table<string,string>
+      Pointee: 206 StructureType table<string,string>
     - __kind: PointerType
-      ID: 144
+      ID: 134
       Name: '*time.Location'
       ByteSize: 8
       GoRuntimeType: 1.6024e+06
       GoKind: 22
-      Pointee: 145 StructureType time.Location
+      Pointee: 135 StructureType time.Location
     - __kind: PointerType
-      ID: 177
+      ID: 168
       Name: '*time.zone'
       ByteSize: 8
       GoRuntimeType: 391680
       GoKind: 22
-      Pointee: 178 StructureType time.zone
+      Pointee: 169 StructureType time.zone
     - __kind: PointerType
-      ID: 180
+      ID: 171
       Name: '*time.zoneTrans'
       ByteSize: 8
       GoRuntimeType: 391744
       GoKind: 22
-      Pointee: 181 StructureType time.zoneTrans
+      Pointee: 172 StructureType time.zoneTrans
     - __kind: PointerType
       ID: 34
       Name: '*uint'
@@ -612,12 +612,12 @@ Types:
       GoKind: 22
       Pointee: 1 BaseType uintptr
     - __kind: GoChannelType
-      ID: 59
+      ID: 61
       Name: <-chan struct {}
       GoRuntimeType: 592672
       GoKind: 18
     - __kind: EventRootType
-      ID: 215
+      ID: 214
       Name: Probe[main.HandleHTTP]
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -641,7 +641,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 216
+      ID: 215
       Name: Probe[main.LookAtTheRequest]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -656,7 +656,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: GoSliceHeaderType
-      ID: 83
+      ID: 108
       Name: '[]*crypto/x509.Certificate'
       ByteSize: 24
       GoRuntimeType: 498304
@@ -664,21 +664,21 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 84 PointerType **crypto/x509.Certificate
+          Type: 109 PointerType **crypto/x509.Certificate
         - Name: len
           Offset: 8
           Type: 7 BaseType int
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 126 GoSliceDataType []*crypto/x509.Certificate.array
+      Data: 118 GoSliceDataType []*crypto/x509.Certificate.array
     - __kind: GoSliceDataType
-      ID: 126
+      ID: 118
       Name: '[]*crypto/x509.Certificate.array'
       ByteSize: 2048
-      Element: 85 PointerType *crypto/x509.Certificate
+      Element: 110 PointerType *crypto/x509.Certificate
     - __kind: GoSliceHeaderType
-      ID: 121
+      ID: 96
       Name: '[]*mime/multipart.FileHeader'
       ByteSize: 24
       GoRuntimeType: 483744
@@ -686,21 +686,21 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 122 PointerType **mime/multipart.FileHeader
+          Type: 97 PointerType **mime/multipart.FileHeader
         - Name: len
           Offset: 8
           Type: 7 BaseType int
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 171 GoSliceDataType []*mime/multipart.FileHeader.array
+      Data: 102 GoSliceDataType []*mime/multipart.FileHeader.array
     - __kind: GoSliceDataType
-      ID: 171
+      ID: 102
       Name: '[]*mime/multipart.FileHeader.array'
       ByteSize: 2048
-      Element: 123 PointerType *mime/multipart.FileHeader
+      Element: 98 PointerType *mime/multipart.FileHeader
     - __kind: GoSliceHeaderType
-      ID: 161
+      ID: 151
       Name: '[]*net.IPNet'
       ByteSize: 24
       GoRuntimeType: 511840
@@ -708,21 +708,21 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 162 PointerType **net.IPNet
+          Type: 152 PointerType **net.IPNet
         - Name: len
           Offset: 8
           Type: 7 BaseType int
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 200 GoSliceDataType []*net.IPNet.array
+      Data: 188 GoSliceDataType []*net.IPNet.array
     - __kind: GoSliceDataType
-      ID: 200
+      ID: 188
       Name: '[]*net.IPNet.array'
       ByteSize: 2048
-      Element: 163 PointerType *net.IPNet
+      Element: 153 PointerType *net.IPNet
     - __kind: GoSliceHeaderType
-      ID: 159
+      ID: 149
       Name: '[]*net/url.URL'
       ByteSize: 24
       GoRuntimeType: 511776
@@ -730,36 +730,36 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 160 PointerType **net/url.URL
+          Type: 150 PointerType **net/url.URL
         - Name: len
           Offset: 8
           Type: 7 BaseType int
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 198 GoSliceDataType []*net/url.URL.array
+      Data: 185 GoSliceDataType []*net/url.URL.array
     - __kind: GoSliceDataType
-      ID: 198
+      ID: 185
       Name: '[]*net/url.URL.array'
       ByteSize: 2048
-      Element: 44 PointerType *net/url.URL
+      Element: 46 PointerType *net/url.URL
     - __kind: GoSliceDataType
-      ID: 124
+      ID: 99
       Name: '[]*table<string,[]*mime/multipart.FileHeader>.array'
       ByteSize: 8192
-      Element: 82 PointerType *table<string,[]*mime/multipart.FileHeader>
+      Element: 89 PointerType *table<string,[]*mime/multipart.FileHeader>
     - __kind: GoSliceDataType
-      ID: 101
+      ID: 80
       Name: '[]*table<string,[]string>.array'
       ByteSize: 8192
-      Element: 50 PointerType *table<string,[]string>
+      Element: 52 PointerType *table<string,[]string>
     - __kind: GoSliceDataType
-      ID: 110
+      ID: 212
       Name: '[]*table<string,string>.array'
       ByteSize: 8192
-      Element: 69 PointerType *table<string,string>
+      Element: 71 PointerType *table<string,string>
     - __kind: GoSliceHeaderType
-      ID: 86
+      ID: 111
       Name: '[][]*crypto/x509.Certificate'
       ByteSize: 24
       GoRuntimeType: 498432
@@ -767,21 +767,21 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 87 PointerType *[]*crypto/x509.Certificate
+          Type: 112 PointerType *[]*crypto/x509.Certificate
         - Name: len
           Offset: 8
           Type: 7 BaseType int
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 128 GoSliceDataType [][]*crypto/x509.Certificate.array
+      Data: 120 GoSliceDataType [][]*crypto/x509.Certificate.array
     - __kind: GoSliceDataType
-      ID: 128
+      ID: 120
       Name: '[][]*crypto/x509.Certificate.array'
       ByteSize: 2048
-      Element: 83 GoSliceHeaderType []*crypto/x509.Certificate
+      Element: 108 GoSliceHeaderType []*crypto/x509.Certificate
     - __kind: GoSliceHeaderType
-      ID: 88
+      ID: 113
       Name: '[][]uint8'
       ByteSize: 24
       GoRuntimeType: 478528
@@ -789,21 +789,21 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 89 PointerType *[]uint8
+          Type: 114 PointerType *[]uint8
         - Name: len
           Offset: 8
           Type: 7 BaseType int
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 130 GoSliceDataType [][]uint8.array
+      Data: 122 GoSliceDataType [][]uint8.array
     - __kind: GoSliceDataType
-      ID: 130
+      ID: 122
       Name: '[][]uint8.array'
       ByteSize: 2048
-      Element: 70 GoSliceHeaderType []uint8
+      Element: 105 GoSliceHeaderType []uint8
     - __kind: GoSliceHeaderType
-      ID: 153
+      ID: 143
       Name: '[]crypto/x509.ExtKeyUsage'
       ByteSize: 24
       GoRuntimeType: 499776
@@ -811,21 +811,21 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 154 PointerType *crypto/x509.ExtKeyUsage
+          Type: 144 PointerType *crypto/x509.ExtKeyUsage
         - Name: len
           Offset: 8
           Type: 7 BaseType int
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 192 GoSliceDataType []crypto/x509.ExtKeyUsage.array
+      Data: 181 GoSliceDataType []crypto/x509.ExtKeyUsage.array
     - __kind: GoSliceDataType
-      ID: 192
+      ID: 181
       Name: '[]crypto/x509.ExtKeyUsage.array'
       ByteSize: 2048
-      Element: 155 BaseType crypto/x509.ExtKeyUsage
+      Element: 145 BaseType crypto/x509.ExtKeyUsage
     - __kind: GoSliceHeaderType
-      ID: 164
+      ID: 154
       Name: '[]crypto/x509.OID'
       ByteSize: 24
       GoRuntimeType: 511904
@@ -833,21 +833,21 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 165 PointerType *crypto/x509.OID
+          Type: 155 PointerType *crypto/x509.OID
         - Name: len
           Offset: 8
           Type: 7 BaseType int
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 202 GoSliceDataType []crypto/x509.OID.array
+      Data: 190 GoSliceDataType []crypto/x509.OID.array
     - __kind: GoSliceDataType
-      ID: 202
+      ID: 190
       Name: '[]crypto/x509.OID.array'
       ByteSize: 2048
-      Element: 166 StructureType crypto/x509.OID
+      Element: 156 StructureType crypto/x509.OID
     - __kind: GoSliceHeaderType
-      ID: 167
+      ID: 157
       Name: '[]crypto/x509.PolicyMapping'
       ByteSize: 24
       GoRuntimeType: 511968
@@ -855,21 +855,21 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 168 PointerType *crypto/x509.PolicyMapping
+          Type: 158 PointerType *crypto/x509.PolicyMapping
         - Name: len
           Offset: 8
           Type: 7 BaseType int
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 204 GoSliceDataType []crypto/x509.PolicyMapping.array
+      Data: 192 GoSliceDataType []crypto/x509.PolicyMapping.array
     - __kind: GoSliceDataType
-      ID: 204
+      ID: 192
       Name: '[]crypto/x509.PolicyMapping.array'
       ByteSize: 2048
-      Element: 169 StructureType crypto/x509.PolicyMapping
+      Element: 159 StructureType crypto/x509.PolicyMapping
     - __kind: GoSliceHeaderType
-      ID: 140
+      ID: 130
       Name: '[]crypto/x509/pkix.AttributeTypeAndValue'
       ByteSize: 24
       GoRuntimeType: 512416
@@ -877,21 +877,21 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 141 PointerType *crypto/x509/pkix.AttributeTypeAndValue
+          Type: 131 PointerType *crypto/x509/pkix.AttributeTypeAndValue
         - Name: len
           Offset: 8
           Type: 7 BaseType int
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 184 GoSliceDataType []crypto/x509/pkix.AttributeTypeAndValue.array
+      Data: 165 GoSliceDataType []crypto/x509/pkix.AttributeTypeAndValue.array
     - __kind: GoSliceDataType
-      ID: 184
+      ID: 165
       Name: '[]crypto/x509/pkix.AttributeTypeAndValue.array'
       ByteSize: 2048
-      Element: 142 StructureType crypto/x509/pkix.AttributeTypeAndValue
+      Element: 132 StructureType crypto/x509/pkix.AttributeTypeAndValue
     - __kind: GoSliceHeaderType
-      ID: 147
+      ID: 137
       Name: '[]crypto/x509/pkix.Extension'
       ByteSize: 24
       GoRuntimeType: 511648
@@ -899,21 +899,21 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 148 PointerType *crypto/x509/pkix.Extension
+          Type: 138 PointerType *crypto/x509/pkix.Extension
         - Name: len
           Offset: 8
           Type: 7 BaseType int
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 186 GoSliceDataType []crypto/x509/pkix.Extension.array
+      Data: 177 GoSliceDataType []crypto/x509/pkix.Extension.array
     - __kind: GoSliceDataType
-      ID: 186
+      ID: 177
       Name: '[]crypto/x509/pkix.Extension.array'
       ByteSize: 2048
-      Element: 149 StructureType crypto/x509/pkix.Extension
+      Element: 139 StructureType crypto/x509/pkix.Extension
     - __kind: GoSliceHeaderType
-      ID: 150
+      ID: 140
       Name: '[]encoding/asn1.ObjectIdentifier'
       ByteSize: 24
       GoRuntimeType: 511712
@@ -921,21 +921,21 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 151 PointerType *encoding/asn1.ObjectIdentifier
+          Type: 141 PointerType *encoding/asn1.ObjectIdentifier
         - Name: len
           Offset: 8
           Type: 7 BaseType int
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 188 GoSliceDataType []encoding/asn1.ObjectIdentifier.array
+      Data: 179 GoSliceDataType []encoding/asn1.ObjectIdentifier.array
     - __kind: GoSliceDataType
-      ID: 188
+      ID: 179
       Name: '[]encoding/asn1.ObjectIdentifier.array'
       ByteSize: 2048
-      Element: 152 GoSliceHeaderType encoding/asn1.ObjectIdentifier
+      Element: 142 GoSliceHeaderType encoding/asn1.ObjectIdentifier
     - __kind: GoSliceHeaderType
-      ID: 156
+      ID: 146
       Name: '[]net.IP'
       ByteSize: 24
       GoRuntimeType: 479488
@@ -943,21 +943,21 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 157 PointerType *net.IP
+          Type: 147 PointerType *net.IP
         - Name: len
           Offset: 8
           Type: 7 BaseType int
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 194 GoSliceDataType []net.IP.array
+      Data: 183 GoSliceDataType []net.IP.array
     - __kind: GoSliceDataType
-      ID: 194
+      ID: 183
       Name: '[]net.IP.array'
       ByteSize: 2048
-      Element: 158 GoSliceHeaderType net.IP
+      Element: 148 GoSliceHeaderType net.IP
     - __kind: GoSliceHeaderType
-      ID: 92
+      ID: 201
       Name: '[]net/http.segment'
       ByteSize: 24
       GoRuntimeType: 481120
@@ -965,36 +965,36 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 93 PointerType *net/http.segment
+          Type: 202 PointerType *net/http.segment
         - Name: len
           Offset: 8
           Type: 7 BaseType int
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 132 GoSliceDataType []net/http.segment.array
+      Data: 204 GoSliceDataType []net/http.segment.array
     - __kind: GoSliceDataType
-      ID: 132
+      ID: 204
       Name: '[]net/http.segment.array'
       ByteSize: 2048
-      Element: 94 StructureType net/http.segment
+      Element: 203 StructureType net/http.segment
     - __kind: GoSliceDataType
-      ID: 125
+      ID: 100
       Name: '[]noalg.map.group[string][]*mime/multipart.FileHeader.array'
       ByteSize: 2048
-      Element: 118 StructureType noalg.map.group[string][]*mime/multipart.FileHeader
+      Element: 93 StructureType noalg.map.group[string][]*mime/multipart.FileHeader
     - __kind: GoSliceDataType
-      ID: 102
+      ID: 81
       Name: '[]noalg.map.group[string][]string.array'
       ByteSize: 2048
-      Element: 98 StructureType noalg.map.group[string][]string
+      Element: 77 StructureType noalg.map.group[string][]string
     - __kind: GoSliceDataType
-      ID: 111
+      ID: 213
       Name: '[]noalg.map.group[string]string.array'
       ByteSize: 2048
-      Element: 107 StructureType noalg.map.group[string]string
+      Element: 209 StructureType noalg.map.group[string]string
     - __kind: GoSliceHeaderType
-      ID: 53
+      ID: 55
       Name: '[]string'
       ByteSize: 24
       GoRuntimeType: 492672
@@ -1009,14 +1009,14 @@ Types:
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 103 GoSliceDataType []string.array
+      Data: 82 GoSliceDataType []string.array
     - __kind: GoSliceDataType
-      ID: 103
+      ID: 82
       Name: '[]string.array'
       ByteSize: 2048
       Element: 9 GoStringHeaderType string
     - __kind: GoSliceHeaderType
-      ID: 176
+      ID: 167
       Name: '[]time.zone'
       ByteSize: 24
       GoRuntimeType: 485792
@@ -1024,21 +1024,21 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 177 PointerType *time.zone
+          Type: 168 PointerType *time.zone
         - Name: len
           Offset: 8
           Type: 7 BaseType int
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 209 GoSliceDataType []time.zone.array
+      Data: 173 GoSliceDataType []time.zone.array
     - __kind: GoSliceDataType
-      ID: 209
+      ID: 173
       Name: '[]time.zone.array'
       ByteSize: 2048
-      Element: 178 StructureType time.zone
+      Element: 169 StructureType time.zone
     - __kind: GoSliceHeaderType
-      ID: 179
+      ID: 170
       Name: '[]time.zoneTrans'
       ByteSize: 24
       GoRuntimeType: 485856
@@ -1046,21 +1046,21 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 180 PointerType *time.zoneTrans
+          Type: 171 PointerType *time.zoneTrans
         - Name: len
           Offset: 8
           Type: 7 BaseType int
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 211 GoSliceDataType []time.zoneTrans.array
+      Data: 175 GoSliceDataType []time.zoneTrans.array
     - __kind: GoSliceDataType
-      ID: 211
+      ID: 175
       Name: '[]time.zoneTrans.array'
       ByteSize: 2048
-      Element: 181 StructureType time.zoneTrans
+      Element: 172 StructureType time.zoneTrans
     - __kind: GoSliceHeaderType
-      ID: 70
+      ID: 105
       Name: '[]uint8'
       ByteSize: 24
       GoRuntimeType: 491520
@@ -1075,9 +1075,9 @@ Types:
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 112 GoSliceDataType []uint8.array
+      Data: 106 GoSliceDataType []uint8.array
     - __kind: GoSliceDataType
-      ID: 112
+      ID: 106
       Name: '[]uint8.array'
       ByteSize: 2048
       Element: 3 BaseType uint8
@@ -1087,28 +1087,10 @@ Types:
       ByteSize: 1
       GoRuntimeType: 580448
       GoKind: 1
-    - __kind: StructureType
+    - __kind: UnresolvedPointeeType
       ID: 40
       Name: bytes.Buffer
-      ByteSize: 40
-      GoRuntimeType: 1.595104e+06
-      GoKind: 25
-      RawFields:
-        - Name: buf
-          Offset: 0
-          Type: 70 GoSliceHeaderType []uint8
-        - Name: off
-          Offset: 24
-          Type: 7 BaseType int
-        - Name: lastRead
-          Offset: 32
-          Type: 71 BaseType bytes.readOp
-    - __kind: BaseType
-      ID: 71
-      Name: bytes.readOp
-      ByteSize: 1
-      GoRuntimeType: 578592
-      GoKind: 3
+      ByteSize: 8
     - __kind: BaseType
       ID: 25
       Name: complex128
@@ -1122,7 +1104,7 @@ Types:
       GoRuntimeType: 580192
       GoKind: 15
     - __kind: GoInterfaceType
-      ID: 62
+      ID: 64
       Name: context.Context
       ByteSize: 16
       GoRuntimeType: 1.266912e+06
@@ -1150,7 +1132,7 @@ Types:
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 58
+      ID: 60
       Name: crypto/tls.ConnectionState
       ByteSize: 192
       GoRuntimeType: 2.231616e+06
@@ -1179,39 +1161,39 @@ Types:
           Type: 9 GoStringHeaderType string
         - Name: PeerCertificates
           Offset: 48
-          Type: 83 GoSliceHeaderType []*crypto/x509.Certificate
+          Type: 108 GoSliceHeaderType []*crypto/x509.Certificate
         - Name: VerifiedChains
           Offset: 72
-          Type: 86 GoSliceHeaderType [][]*crypto/x509.Certificate
+          Type: 111 GoSliceHeaderType [][]*crypto/x509.Certificate
         - Name: SignedCertificateTimestamps
           Offset: 96
-          Type: 88 GoSliceHeaderType [][]uint8
+          Type: 113 GoSliceHeaderType [][]uint8
         - Name: OCSPResponse
           Offset: 120
-          Type: 70 GoSliceHeaderType []uint8
+          Type: 105 GoSliceHeaderType []uint8
         - Name: TLSUnique
           Offset: 144
-          Type: 70 GoSliceHeaderType []uint8
+          Type: 105 GoSliceHeaderType []uint8
         - Name: ECHAccepted
           Offset: 168
           Type: 4 BaseType bool
         - Name: ekm
           Offset: 176
-          Type: 90 GoSubroutineType func(string, []uint8, int) ([]uint8, error)
+          Type: 115 GoSubroutineType func(string, []uint8, int) ([]uint8, error)
         - Name: testingOnlyDidHRR
           Offset: 184
           Type: 4 BaseType bool
         - Name: testingOnlyCurveID
           Offset: 186
-          Type: 91 BaseType crypto/tls.CurveID
+          Type: 116 BaseType crypto/tls.CurveID
     - __kind: BaseType
-      ID: 91
+      ID: 116
       Name: crypto/tls.CurveID
       ByteSize: 2
       GoRuntimeType: 829056
       GoKind: 9
     - __kind: StructureType
-      ID: 115
+      ID: 117
       Name: crypto/x509.Certificate
       ByteSize: 1424
       GoRuntimeType: 2.37712e+06
@@ -1219,67 +1201,67 @@ Types:
       RawFields:
         - Name: Raw
           Offset: 0
-          Type: 70 GoSliceHeaderType []uint8
+          Type: 105 GoSliceHeaderType []uint8
         - Name: RawTBSCertificate
           Offset: 24
-          Type: 70 GoSliceHeaderType []uint8
+          Type: 105 GoSliceHeaderType []uint8
         - Name: RawSubjectPublicKeyInfo
           Offset: 48
-          Type: 70 GoSliceHeaderType []uint8
+          Type: 105 GoSliceHeaderType []uint8
         - Name: RawSubject
           Offset: 72
-          Type: 70 GoSliceHeaderType []uint8
+          Type: 105 GoSliceHeaderType []uint8
         - Name: RawIssuer
           Offset: 96
-          Type: 70 GoSliceHeaderType []uint8
+          Type: 105 GoSliceHeaderType []uint8
         - Name: Signature
           Offset: 120
-          Type: 70 GoSliceHeaderType []uint8
+          Type: 105 GoSliceHeaderType []uint8
         - Name: SignatureAlgorithm
           Offset: 144
-          Type: 134 BaseType crypto/x509.SignatureAlgorithm
+          Type: 124 BaseType crypto/x509.SignatureAlgorithm
         - Name: PublicKeyAlgorithm
           Offset: 152
-          Type: 135 BaseType crypto/x509.PublicKeyAlgorithm
+          Type: 125 BaseType crypto/x509.PublicKeyAlgorithm
         - Name: PublicKey
           Offset: 160
-          Type: 136 GoEmptyInterfaceType interface {}
+          Type: 126 GoEmptyInterfaceType interface {}
         - Name: Version
           Offset: 176
           Type: 7 BaseType int
         - Name: SerialNumber
           Offset: 184
-          Type: 137 PointerType *math/big.Int
+          Type: 127 PointerType *math/big.Int
         - Name: Issuer
           Offset: 192
-          Type: 139 StructureType crypto/x509/pkix.Name
+          Type: 129 StructureType crypto/x509/pkix.Name
         - Name: Subject
           Offset: 440
-          Type: 139 StructureType crypto/x509/pkix.Name
+          Type: 129 StructureType crypto/x509/pkix.Name
         - Name: NotBefore
           Offset: 688
-          Type: 143 StructureType time.Time
+          Type: 133 StructureType time.Time
         - Name: NotAfter
           Offset: 712
-          Type: 143 StructureType time.Time
+          Type: 133 StructureType time.Time
         - Name: KeyUsage
           Offset: 736
-          Type: 146 BaseType crypto/x509.KeyUsage
+          Type: 136 BaseType crypto/x509.KeyUsage
         - Name: Extensions
           Offset: 744
-          Type: 147 GoSliceHeaderType []crypto/x509/pkix.Extension
+          Type: 137 GoSliceHeaderType []crypto/x509/pkix.Extension
         - Name: ExtraExtensions
           Offset: 768
-          Type: 147 GoSliceHeaderType []crypto/x509/pkix.Extension
+          Type: 137 GoSliceHeaderType []crypto/x509/pkix.Extension
         - Name: UnhandledCriticalExtensions
           Offset: 792
-          Type: 150 GoSliceHeaderType []encoding/asn1.ObjectIdentifier
+          Type: 140 GoSliceHeaderType []encoding/asn1.ObjectIdentifier
         - Name: ExtKeyUsage
           Offset: 816
-          Type: 153 GoSliceHeaderType []crypto/x509.ExtKeyUsage
+          Type: 143 GoSliceHeaderType []crypto/x509.ExtKeyUsage
         - Name: UnknownExtKeyUsage
           Offset: 840
-          Type: 150 GoSliceHeaderType []encoding/asn1.ObjectIdentifier
+          Type: 140 GoSliceHeaderType []encoding/asn1.ObjectIdentifier
         - Name: BasicConstraintsValid
           Offset: 864
           Type: 4 BaseType bool
@@ -1294,64 +1276,64 @@ Types:
           Type: 4 BaseType bool
         - Name: SubjectKeyId
           Offset: 888
-          Type: 70 GoSliceHeaderType []uint8
+          Type: 105 GoSliceHeaderType []uint8
         - Name: AuthorityKeyId
           Offset: 912
-          Type: 70 GoSliceHeaderType []uint8
+          Type: 105 GoSliceHeaderType []uint8
         - Name: OCSPServer
           Offset: 936
-          Type: 53 GoSliceHeaderType []string
+          Type: 55 GoSliceHeaderType []string
         - Name: IssuingCertificateURL
           Offset: 960
-          Type: 53 GoSliceHeaderType []string
+          Type: 55 GoSliceHeaderType []string
         - Name: DNSNames
           Offset: 984
-          Type: 53 GoSliceHeaderType []string
+          Type: 55 GoSliceHeaderType []string
         - Name: EmailAddresses
           Offset: 1008
-          Type: 53 GoSliceHeaderType []string
+          Type: 55 GoSliceHeaderType []string
         - Name: IPAddresses
           Offset: 1032
-          Type: 156 GoSliceHeaderType []net.IP
+          Type: 146 GoSliceHeaderType []net.IP
         - Name: URIs
           Offset: 1056
-          Type: 159 GoSliceHeaderType []*net/url.URL
+          Type: 149 GoSliceHeaderType []*net/url.URL
         - Name: PermittedDNSDomainsCritical
           Offset: 1080
           Type: 4 BaseType bool
         - Name: PermittedDNSDomains
           Offset: 1088
-          Type: 53 GoSliceHeaderType []string
+          Type: 55 GoSliceHeaderType []string
         - Name: ExcludedDNSDomains
           Offset: 1112
-          Type: 53 GoSliceHeaderType []string
+          Type: 55 GoSliceHeaderType []string
         - Name: PermittedIPRanges
           Offset: 1136
-          Type: 161 GoSliceHeaderType []*net.IPNet
+          Type: 151 GoSliceHeaderType []*net.IPNet
         - Name: ExcludedIPRanges
           Offset: 1160
-          Type: 161 GoSliceHeaderType []*net.IPNet
+          Type: 151 GoSliceHeaderType []*net.IPNet
         - Name: PermittedEmailAddresses
           Offset: 1184
-          Type: 53 GoSliceHeaderType []string
+          Type: 55 GoSliceHeaderType []string
         - Name: ExcludedEmailAddresses
           Offset: 1208
-          Type: 53 GoSliceHeaderType []string
+          Type: 55 GoSliceHeaderType []string
         - Name: PermittedURIDomains
           Offset: 1232
-          Type: 53 GoSliceHeaderType []string
+          Type: 55 GoSliceHeaderType []string
         - Name: ExcludedURIDomains
           Offset: 1256
-          Type: 53 GoSliceHeaderType []string
+          Type: 55 GoSliceHeaderType []string
         - Name: CRLDistributionPoints
           Offset: 1280
-          Type: 53 GoSliceHeaderType []string
+          Type: 55 GoSliceHeaderType []string
         - Name: PolicyIdentifiers
           Offset: 1304
-          Type: 150 GoSliceHeaderType []encoding/asn1.ObjectIdentifier
+          Type: 140 GoSliceHeaderType []encoding/asn1.ObjectIdentifier
         - Name: Policies
           Offset: 1328
-          Type: 164 GoSliceHeaderType []crypto/x509.OID
+          Type: 154 GoSliceHeaderType []crypto/x509.OID
         - Name: InhibitAnyPolicy
           Offset: 1352
           Type: 7 BaseType int
@@ -1372,21 +1354,21 @@ Types:
           Type: 4 BaseType bool
         - Name: PolicyMappings
           Offset: 1400
-          Type: 167 GoSliceHeaderType []crypto/x509.PolicyMapping
+          Type: 157 GoSliceHeaderType []crypto/x509.PolicyMapping
     - __kind: BaseType
-      ID: 155
+      ID: 145
       Name: crypto/x509.ExtKeyUsage
       ByteSize: 8
       GoRuntimeType: 583136
       GoKind: 2
     - __kind: BaseType
-      ID: 146
+      ID: 136
       Name: crypto/x509.KeyUsage
       ByteSize: 8
       GoRuntimeType: 583072
       GoKind: 2
     - __kind: StructureType
-      ID: 166
+      ID: 156
       Name: crypto/x509.OID
       ByteSize: 24
       GoRuntimeType: 1.9384e+06
@@ -1394,9 +1376,9 @@ Types:
       RawFields:
         - Name: der
           Offset: 0
-          Type: 70 GoSliceHeaderType []uint8
+          Type: 105 GoSliceHeaderType []uint8
     - __kind: StructureType
-      ID: 169
+      ID: 159
       Name: crypto/x509.PolicyMapping
       ByteSize: 48
       GoRuntimeType: 1.480224e+06
@@ -1404,24 +1386,24 @@ Types:
       RawFields:
         - Name: IssuerDomainPolicy
           Offset: 0
-          Type: 166 StructureType crypto/x509.OID
+          Type: 156 StructureType crypto/x509.OID
         - Name: SubjectDomainPolicy
           Offset: 24
-          Type: 166 StructureType crypto/x509.OID
+          Type: 156 StructureType crypto/x509.OID
     - __kind: BaseType
-      ID: 135
+      ID: 125
       Name: crypto/x509.PublicKeyAlgorithm
       ByteSize: 8
       GoRuntimeType: 831456
       GoKind: 2
     - __kind: BaseType
-      ID: 134
+      ID: 124
       Name: crypto/x509.SignatureAlgorithm
       ByteSize: 8
       GoRuntimeType: 1.104544e+06
       GoKind: 2
     - __kind: StructureType
-      ID: 142
+      ID: 132
       Name: crypto/x509/pkix.AttributeTypeAndValue
       ByteSize: 40
       GoRuntimeType: 1.492064e+06
@@ -1429,12 +1411,12 @@ Types:
       RawFields:
         - Name: Type
           Offset: 0
-          Type: 152 GoSliceHeaderType encoding/asn1.ObjectIdentifier
+          Type: 142 GoSliceHeaderType encoding/asn1.ObjectIdentifier
         - Name: Value
           Offset: 24
-          Type: 136 GoEmptyInterfaceType interface {}
+          Type: 126 GoEmptyInterfaceType interface {}
     - __kind: StructureType
-      ID: 149
+      ID: 139
       Name: crypto/x509/pkix.Extension
       ByteSize: 56
       GoRuntimeType: 1.635616e+06
@@ -1442,15 +1424,15 @@ Types:
       RawFields:
         - Name: Id
           Offset: 0
-          Type: 152 GoSliceHeaderType encoding/asn1.ObjectIdentifier
+          Type: 142 GoSliceHeaderType encoding/asn1.ObjectIdentifier
         - Name: Critical
           Offset: 24
           Type: 4 BaseType bool
         - Name: Value
           Offset: 32
-          Type: 70 GoSliceHeaderType []uint8
+          Type: 105 GoSliceHeaderType []uint8
     - __kind: StructureType
-      ID: 139
+      ID: 129
       Name: crypto/x509/pkix.Name
       ByteSize: 248
       GoRuntimeType: 2.176736e+06
@@ -1458,25 +1440,25 @@ Types:
       RawFields:
         - Name: Country
           Offset: 0
-          Type: 53 GoSliceHeaderType []string
+          Type: 55 GoSliceHeaderType []string
         - Name: Organization
           Offset: 24
-          Type: 53 GoSliceHeaderType []string
+          Type: 55 GoSliceHeaderType []string
         - Name: OrganizationalUnit
           Offset: 48
-          Type: 53 GoSliceHeaderType []string
+          Type: 55 GoSliceHeaderType []string
         - Name: Locality
           Offset: 72
-          Type: 53 GoSliceHeaderType []string
+          Type: 55 GoSliceHeaderType []string
         - Name: Province
           Offset: 96
-          Type: 53 GoSliceHeaderType []string
+          Type: 55 GoSliceHeaderType []string
         - Name: StreetAddress
           Offset: 120
-          Type: 53 GoSliceHeaderType []string
+          Type: 55 GoSliceHeaderType []string
         - Name: PostalCode
           Offset: 144
-          Type: 53 GoSliceHeaderType []string
+          Type: 55 GoSliceHeaderType []string
         - Name: SerialNumber
           Offset: 168
           Type: 9 GoStringHeaderType string
@@ -1485,12 +1467,12 @@ Types:
           Type: 9 GoStringHeaderType string
         - Name: Names
           Offset: 200
-          Type: 140 GoSliceHeaderType []crypto/x509/pkix.AttributeTypeAndValue
+          Type: 130 GoSliceHeaderType []crypto/x509/pkix.AttributeTypeAndValue
         - Name: ExtraNames
           Offset: 224
-          Type: 140 GoSliceHeaderType []crypto/x509/pkix.AttributeTypeAndValue
+          Type: 130 GoSliceHeaderType []crypto/x509/pkix.AttributeTypeAndValue
     - __kind: GoSliceHeaderType
-      ID: 152
+      ID: 142
       Name: encoding/asn1.ObjectIdentifier
       ByteSize: 24
       GoRuntimeType: 1.044128e+06
@@ -1505,9 +1487,9 @@ Types:
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 190 GoSliceDataType encoding/asn1.ObjectIdentifier.array
+      Data: 194 GoSliceDataType encoding/asn1.ObjectIdentifier.array
     - __kind: GoSliceDataType
-      ID: 190
+      ID: 194
       Name: encoding/asn1.ObjectIdentifier.array
       ByteSize: 2048
       Element: 7 BaseType int
@@ -1537,13 +1519,13 @@ Types:
       GoRuntimeType: 580384
       GoKind: 14
     - __kind: GoSubroutineType
-      ID: 52
+      ID: 54
       Name: func() (io.ReadCloser, error)
       ByteSize: 8
       GoRuntimeType: 687840
       GoKind: 19
     - __kind: GoSubroutineType
-      ID: 90
+      ID: 115
       Name: func(string, []uint8, int) ([]uint8, error)
       ByteSize: 8
       GoRuntimeType: 994848
@@ -1562,47 +1544,47 @@ Types:
           Offset: 8
           Type: 15 VoidPointerType unsafe.Pointer
     - __kind: GoSwissMapGroupsType
-      ID: 116
+      ID: 91
       Name: groupReference<string,[]*mime/multipart.FileHeader>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 117 PointerType *noalg.map.group[string][]*mime/multipart.FileHeader
+          Type: 92 PointerType *noalg.map.group[string][]*mime/multipart.FileHeader
         - Name: lengthMask
           Offset: 8
           Type: 8 BaseType uint64
-      GroupType: 118 StructureType noalg.map.group[string][]*mime/multipart.FileHeader
-      GroupSliceType: 125 GoSliceDataType []noalg.map.group[string][]*mime/multipart.FileHeader.array
+      GroupType: 93 StructureType noalg.map.group[string][]*mime/multipart.FileHeader
+      GroupSliceType: 100 GoSliceDataType []noalg.map.group[string][]*mime/multipart.FileHeader.array
     - __kind: GoSwissMapGroupsType
-      ID: 96
+      ID: 75
       Name: groupReference<string,[]string>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 97 PointerType *noalg.map.group[string][]string
+          Type: 76 PointerType *noalg.map.group[string][]string
         - Name: lengthMask
           Offset: 8
           Type: 8 BaseType uint64
-      GroupType: 98 StructureType noalg.map.group[string][]string
-      GroupSliceType: 102 GoSliceDataType []noalg.map.group[string][]string.array
+      GroupType: 77 StructureType noalg.map.group[string][]string
+      GroupSliceType: 81 GoSliceDataType []noalg.map.group[string][]string.array
     - __kind: GoSwissMapGroupsType
-      ID: 105
+      ID: 207
       Name: groupReference<string,string>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 106 PointerType *noalg.map.group[string]string
+          Type: 208 PointerType *noalg.map.group[string]string
         - Name: lengthMask
           Offset: 8
           Type: 8 BaseType uint64
-      GroupType: 107 StructureType noalg.map.group[string]string
-      GroupSliceType: 111 GoSliceDataType []noalg.map.group[string]string.array
+      GroupType: 209 StructureType noalg.map.group[string]string
+      GroupSliceType: 213 GoSliceDataType []noalg.map.group[string]string.array
     - __kind: BaseType
       ID: 7
       Name: int
@@ -1634,7 +1616,7 @@ Types:
       GoRuntimeType: 579488
       GoKind: 3
     - __kind: GoEmptyInterfaceType
-      ID: 136
+      ID: 126
       Name: interface {}
       ByteSize: 16
       GoRuntimeType: 848672
@@ -1647,7 +1629,7 @@ Types:
           Offset: 8
           Type: 15 VoidPointerType unsafe.Pointer
     - __kind: GoInterfaceType
-      ID: 51
+      ID: 53
       Name: io.ReadCloser
       ByteSize: 16
       GoRuntimeType: 1.100576e+06
@@ -1660,7 +1642,7 @@ Types:
           Offset: 8
           Type: 15 VoidPointerType unsafe.Pointer
     - __kind: GoSwissMapHeaderType
-      ID: 80
+      ID: 87
       Name: map<string,[]*mime/multipart.FileHeader>
       ByteSize: 48
       GoKind: 25
@@ -1673,7 +1655,7 @@ Types:
           Type: 1 BaseType uintptr
         - Name: dirPtr
           Offset: 16
-          Type: 81 PointerType **table<string,[]*mime/multipart.FileHeader>
+          Type: 88 PointerType **table<string,[]*mime/multipart.FileHeader>
         - Name: dirLen
           Offset: 24
           Type: 7 BaseType int
@@ -1689,10 +1671,10 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 8 BaseType uint64
-      TablePtrSliceType: 124 GoSliceDataType []*table<string,[]*mime/multipart.FileHeader>.array
-      GroupType: 118 StructureType noalg.map.group[string][]*mime/multipart.FileHeader
+      TablePtrSliceType: 99 GoSliceDataType []*table<string,[]*mime/multipart.FileHeader>.array
+      GroupType: 93 StructureType noalg.map.group[string][]*mime/multipart.FileHeader
     - __kind: GoSwissMapHeaderType
-      ID: 48
+      ID: 50
       Name: map<string,[]string>
       ByteSize: 48
       GoKind: 25
@@ -1705,7 +1687,7 @@ Types:
           Type: 1 BaseType uintptr
         - Name: dirPtr
           Offset: 16
-          Type: 49 PointerType **table<string,[]string>
+          Type: 51 PointerType **table<string,[]string>
         - Name: dirLen
           Offset: 24
           Type: 7 BaseType int
@@ -1721,10 +1703,10 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 8 BaseType uint64
-      TablePtrSliceType: 101 GoSliceDataType []*table<string,[]string>.array
-      GroupType: 98 StructureType noalg.map.group[string][]string
+      TablePtrSliceType: 80 GoSliceDataType []*table<string,[]string>.array
+      GroupType: 77 StructureType noalg.map.group[string][]string
     - __kind: GoSwissMapHeaderType
-      ID: 67
+      ID: 69
       Name: map<string,string>
       ByteSize: 48
       GoKind: 25
@@ -1737,7 +1719,7 @@ Types:
           Type: 1 BaseType uintptr
         - Name: dirPtr
           Offset: 16
-          Type: 68 PointerType **table<string,string>
+          Type: 70 PointerType **table<string,string>
         - Name: dirLen
           Offset: 24
           Type: 7 BaseType int
@@ -1753,31 +1735,31 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 8 BaseType uint64
-      TablePtrSliceType: 110 GoSliceDataType []*table<string,string>.array
-      GroupType: 107 StructureType noalg.map.group[string]string
+      TablePtrSliceType: 212 GoSliceDataType []*table<string,string>.array
+      GroupType: 209 StructureType noalg.map.group[string]string
     - __kind: GoMapType
-      ID: 78
+      ID: 85
       Name: map[string][]*mime/multipart.FileHeader
       ByteSize: 8
       GoRuntimeType: 1.122592e+06
       GoKind: 21
-      HeaderType: 80 GoSwissMapHeaderType map<string,[]*mime/multipart.FileHeader>
+      HeaderType: 87 GoSwissMapHeaderType map<string,[]*mime/multipart.FileHeader>
     - __kind: GoMapType
-      ID: 77
+      ID: 84
       Name: map[string][]string
       ByteSize: 8
       GoRuntimeType: 1.117984e+06
       GoKind: 21
-      HeaderType: 48 GoSwissMapHeaderType map<string,[]string>
+      HeaderType: 50 GoSwissMapHeaderType map<string,[]string>
     - __kind: GoMapType
-      ID: 65
+      ID: 67
       Name: map[string]string
       ByteSize: 8
       GoRuntimeType: 1.119008e+06
       GoKind: 21
-      HeaderType: 67 GoSwissMapHeaderType map<string,string>
+      HeaderType: 69 GoSwissMapHeaderType map<string,string>
     - __kind: StructureType
-      ID: 138
+      ID: 128
       Name: math/big.Int
       ByteSize: 32
       GoRuntimeType: 1.483264e+06
@@ -1788,15 +1770,15 @@ Types:
           Type: 4 BaseType bool
         - Name: abs
           Offset: 8
-          Type: 173 GoSliceHeaderType math/big.nat
+          Type: 160 GoSliceHeaderType math/big.nat
     - __kind: BaseType
-      ID: 175
+      ID: 162
       Name: math/big.Word
       ByteSize: 8
       GoRuntimeType: 583328
       GoKind: 7
     - __kind: GoSliceHeaderType
-      ID: 173
+      ID: 160
       Name: math/big.nat
       ByteSize: 24
       GoRuntimeType: 2.345504e+06
@@ -1804,21 +1786,21 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 174 PointerType *math/big.Word
+          Type: 161 PointerType *math/big.Word
         - Name: len
           Offset: 8
           Type: 7 BaseType int
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 207 GoSliceDataType math/big.nat.array
+      Data: 163 GoSliceDataType math/big.nat.array
     - __kind: GoSliceDataType
-      ID: 207
+      ID: 163
       Name: math/big.nat.array
       ByteSize: 2048
-      Element: 175 BaseType math/big.Word
+      Element: 162 BaseType math/big.Word
     - __kind: StructureType
-      ID: 170
+      ID: 101
       Name: mime/multipart.FileHeader
       ByteSize: 88
       GoRuntimeType: 1.962144e+06
@@ -1829,13 +1811,13 @@ Types:
           Type: 9 GoStringHeaderType string
         - Name: Header
           Offset: 16
-          Type: 183 GoMapType net/textproto.MIMEHeader
+          Type: 104 GoMapType net/textproto.MIMEHeader
         - Name: Size
           Offset: 24
           Type: 13 BaseType int64
         - Name: content
           Offset: 32
-          Type: 70 GoSliceHeaderType []uint8
+          Type: 105 GoSliceHeaderType []uint8
         - Name: tmpfile
           Offset: 56
           Type: 9 GoStringHeaderType string
@@ -1846,7 +1828,7 @@ Types:
           Offset: 80
           Type: 4 BaseType bool
     - __kind: StructureType
-      ID: 56
+      ID: 58
       Name: mime/multipart.Form
       ByteSize: 16
       GoRuntimeType: 1.467264e+06
@@ -1854,12 +1836,12 @@ Types:
       RawFields:
         - Name: Value
           Offset: 0
-          Type: 77 GoMapType map[string][]string
+          Type: 84 GoMapType map[string][]string
         - Name: File
           Offset: 8
-          Type: 78 GoMapType map[string][]*mime/multipart.FileHeader
+          Type: 85 GoMapType map[string][]*mime/multipart.FileHeader
     - __kind: GoSliceHeaderType
-      ID: 158
+      ID: 148
       Name: net.IP
       ByteSize: 24
       GoRuntimeType: 2.109184e+06
@@ -1881,7 +1863,7 @@ Types:
       ByteSize: 2048
       Element: 3 BaseType uint8
     - __kind: GoSliceHeaderType
-      ID: 206
+      ID: 198
       Name: net.IPMask
       ByteSize: 24
       GoRuntimeType: 1.01072e+06
@@ -1896,14 +1878,14 @@ Types:
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 213 GoSliceDataType net.IPMask.array
+      Data: 199 GoSliceDataType net.IPMask.array
     - __kind: GoSliceDataType
-      ID: 213
+      ID: 199
       Name: net.IPMask.array
       ByteSize: 2048
       Element: 3 BaseType uint8
     - __kind: StructureType
-      ID: 182
+      ID: 187
       Name: net.IPNet
       ByteSize: 48
       GoRuntimeType: 1.448704e+06
@@ -1911,17 +1893,17 @@ Types:
       RawFields:
         - Name: IP
           Offset: 0
-          Type: 158 GoSliceHeaderType net.IP
+          Type: 148 GoSliceHeaderType net.IP
         - Name: Mask
           Offset: 24
-          Type: 206 GoSliceHeaderType net.IPMask
+          Type: 198 GoSliceHeaderType net.IPMask
     - __kind: GoMapType
-      ID: 46
+      ID: 48
       Name: net/http.Header
       ByteSize: 8
       GoRuntimeType: 2.08736e+06
       GoKind: 21
-      HeaderType: 48 GoSwissMapHeaderType map<string,[]string>
+      HeaderType: 50 GoSwissMapHeaderType map<string,[]string>
     - __kind: StructureType
       ID: 38
       Name: net/http.Request
@@ -1934,7 +1916,7 @@ Types:
           Type: 9 GoStringHeaderType string
         - Name: URL
           Offset: 16
-          Type: 44 PointerType *net/url.URL
+          Type: 46 PointerType *net/url.URL
         - Name: Proto
           Offset: 24
           Type: 9 GoStringHeaderType string
@@ -1946,19 +1928,19 @@ Types:
           Type: 7 BaseType int
         - Name: Header
           Offset: 56
-          Type: 46 GoMapType net/http.Header
+          Type: 48 GoMapType net/http.Header
         - Name: Body
           Offset: 64
-          Type: 51 GoInterfaceType io.ReadCloser
+          Type: 53 GoInterfaceType io.ReadCloser
         - Name: GetBody
           Offset: 80
-          Type: 52 GoSubroutineType func() (io.ReadCloser, error)
+          Type: 54 GoSubroutineType func() (io.ReadCloser, error)
         - Name: ContentLength
           Offset: 88
           Type: 13 BaseType int64
         - Name: TransferEncoding
           Offset: 96
-          Type: 53 GoSliceHeaderType []string
+          Type: 55 GoSliceHeaderType []string
         - Name: Close
           Offset: 120
           Type: 4 BaseType bool
@@ -1967,16 +1949,16 @@ Types:
           Type: 9 GoStringHeaderType string
         - Name: Form
           Offset: 144
-          Type: 54 GoMapType net/url.Values
+          Type: 56 GoMapType net/url.Values
         - Name: PostForm
           Offset: 152
-          Type: 54 GoMapType net/url.Values
+          Type: 56 GoMapType net/url.Values
         - Name: MultipartForm
           Offset: 160
-          Type: 55 PointerType *mime/multipart.Form
+          Type: 57 PointerType *mime/multipart.Form
         - Name: Trailer
           Offset: 168
-          Type: 46 GoMapType net/http.Header
+          Type: 48 GoMapType net/http.Header
         - Name: RemoteAddr
           Offset: 176
           Type: 9 GoStringHeaderType string
@@ -1985,30 +1967,30 @@ Types:
           Type: 9 GoStringHeaderType string
         - Name: TLS
           Offset: 208
-          Type: 57 PointerType *crypto/tls.ConnectionState
+          Type: 59 PointerType *crypto/tls.ConnectionState
         - Name: Cancel
           Offset: 216
-          Type: 59 GoChannelType <-chan struct {}
+          Type: 61 GoChannelType <-chan struct {}
         - Name: Response
           Offset: 224
-          Type: 60 PointerType *net/http.Response
+          Type: 62 PointerType *net/http.Response
         - Name: Pattern
           Offset: 232
           Type: 9 GoStringHeaderType string
         - Name: ctx
           Offset: 248
-          Type: 62 GoInterfaceType context.Context
+          Type: 64 GoInterfaceType context.Context
         - Name: pat
           Offset: 264
-          Type: 63 PointerType *net/http.pattern
+          Type: 65 PointerType *net/http.pattern
         - Name: matches
           Offset: 272
-          Type: 53 GoSliceHeaderType []string
+          Type: 55 GoSliceHeaderType []string
         - Name: otherValues
           Offset: 296
-          Type: 65 GoMapType map[string]string
+          Type: 67 GoMapType map[string]string
     - __kind: StructureType
-      ID: 61
+      ID: 63
       Name: net/http.Response
       ByteSize: 144
       GoRuntimeType: 2.19504e+06
@@ -2031,16 +2013,16 @@ Types:
           Type: 7 BaseType int
         - Name: Header
           Offset: 56
-          Type: 46 GoMapType net/http.Header
+          Type: 48 GoMapType net/http.Header
         - Name: Body
           Offset: 64
-          Type: 51 GoInterfaceType io.ReadCloser
+          Type: 53 GoInterfaceType io.ReadCloser
         - Name: ContentLength
           Offset: 80
           Type: 13 BaseType int64
         - Name: TransferEncoding
           Offset: 88
-          Type: 53 GoSliceHeaderType []string
+          Type: 55 GoSliceHeaderType []string
         - Name: Close
           Offset: 112
           Type: 4 BaseType bool
@@ -2049,13 +2031,13 @@ Types:
           Type: 4 BaseType bool
         - Name: Trailer
           Offset: 120
-          Type: 46 GoMapType net/http.Header
+          Type: 48 GoMapType net/http.Header
         - Name: Request
           Offset: 128
           Type: 37 PointerType *net/http.Request
         - Name: TLS
           Offset: 136
-          Type: 57 PointerType *crypto/tls.ConnectionState
+          Type: 59 PointerType *crypto/tls.ConnectionState
     - __kind: GoInterfaceType
       ID: 36
       Name: net/http.ResponseWriter
@@ -2070,7 +2052,7 @@ Types:
           Offset: 8
           Type: 15 VoidPointerType unsafe.Pointer
     - __kind: StructureType
-      ID: 64
+      ID: 66
       Name: net/http.pattern
       ByteSize: 88
       GoRuntimeType: 1.818112e+06
@@ -2087,12 +2069,12 @@ Types:
           Type: 9 GoStringHeaderType string
         - Name: segments
           Offset: 48
-          Type: 92 GoSliceHeaderType []net/http.segment
+          Type: 201 GoSliceHeaderType []net/http.segment
         - Name: loc
           Offset: 72
           Type: 9 GoStringHeaderType string
     - __kind: StructureType
-      ID: 94
+      ID: 203
       Name: net/http.segment
       ByteSize: 24
       GoRuntimeType: 1.597216e+06
@@ -2108,14 +2090,14 @@ Types:
           Offset: 17
           Type: 4 BaseType bool
     - __kind: GoMapType
-      ID: 183
+      ID: 104
       Name: net/textproto.MIMEHeader
       ByteSize: 8
       GoRuntimeType: 1.808288e+06
       GoKind: 21
-      HeaderType: 48 GoSwissMapHeaderType map<string,[]string>
+      HeaderType: 50 GoSwissMapHeaderType map<string,[]string>
     - __kind: StructureType
-      ID: 45
+      ID: 47
       Name: net/url.URL
       ByteSize: 144
       GoRuntimeType: 2.112256e+06
@@ -2129,7 +2111,7 @@ Types:
           Type: 9 GoStringHeaderType string
         - Name: User
           Offset: 32
-          Type: 74 PointerType *net/url.Userinfo
+          Type: 72 PointerType *net/url.Userinfo
         - Name: Host
           Offset: 40
           Type: 9 GoStringHeaderType string
@@ -2155,7 +2137,7 @@ Types:
           Offset: 128
           Type: 9 GoStringHeaderType string
     - __kind: StructureType
-      ID: 75
+      ID: 73
       Name: net/url.Userinfo
       ByteSize: 40
       GoRuntimeType: 1.613536e+06
@@ -2171,41 +2153,41 @@ Types:
           Offset: 32
           Type: 4 BaseType bool
     - __kind: GoMapType
-      ID: 54
+      ID: 56
       Name: net/url.Values
       ByteSize: 8
       GoRuntimeType: 1.870528e+06
       GoKind: 21
-      HeaderType: 48 GoSwissMapHeaderType map<string,[]string>
+      HeaderType: 50 GoSwissMapHeaderType map<string,[]string>
     - __kind: ArrayType
-      ID: 119
+      ID: 94
       Name: noalg.[8]struct { key string; elem []*mime/multipart.FileHeader }
       ByteSize: 320
       GoRuntimeType: 693888
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 120 StructureType noalg.struct { key string; elem []*mime/multipart.FileHeader }
+      Element: 95 StructureType noalg.struct { key string; elem []*mime/multipart.FileHeader }
     - __kind: ArrayType
-      ID: 99
+      ID: 78
       Name: noalg.[8]struct { key string; elem []string }
       ByteSize: 320
       GoRuntimeType: 683872
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 100 StructureType noalg.struct { key string; elem []string }
+      Element: 79 StructureType noalg.struct { key string; elem []string }
     - __kind: ArrayType
-      ID: 108
+      ID: 210
       Name: noalg.[8]struct { key string; elem string }
       ByteSize: 256
       GoRuntimeType: 688032
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 109 StructureType noalg.struct { key string; elem string }
+      Element: 211 StructureType noalg.struct { key string; elem string }
     - __kind: StructureType
-      ID: 118
+      ID: 93
       Name: noalg.map.group[string][]*mime/multipart.FileHeader
       ByteSize: 328
       GoRuntimeType: 1.289824e+06
@@ -2216,9 +2198,9 @@ Types:
           Type: 8 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 119 ArrayType noalg.[8]struct { key string; elem []*mime/multipart.FileHeader }
+          Type: 94 ArrayType noalg.[8]struct { key string; elem []*mime/multipart.FileHeader }
     - __kind: StructureType
-      ID: 98
+      ID: 77
       Name: noalg.map.group[string][]string
       ByteSize: 328
       GoRuntimeType: 1.280352e+06
@@ -2229,9 +2211,9 @@ Types:
           Type: 8 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 99 ArrayType noalg.[8]struct { key string; elem []string }
+          Type: 78 ArrayType noalg.[8]struct { key string; elem []string }
     - __kind: StructureType
-      ID: 107
+      ID: 209
       Name: noalg.map.group[string]string
       ByteSize: 264
       GoRuntimeType: 1.282656e+06
@@ -2242,9 +2224,9 @@ Types:
           Type: 8 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 108 ArrayType noalg.[8]struct { key string; elem string }
+          Type: 210 ArrayType noalg.[8]struct { key string; elem string }
     - __kind: StructureType
-      ID: 120
+      ID: 95
       Name: noalg.struct { key string; elem []*mime/multipart.FileHeader }
       ByteSize: 40
       GoRuntimeType: 1.289696e+06
@@ -2255,9 +2237,9 @@ Types:
           Type: 9 GoStringHeaderType string
         - Name: elem
           Offset: 16
-          Type: 121 GoSliceHeaderType []*mime/multipart.FileHeader
+          Type: 96 GoSliceHeaderType []*mime/multipart.FileHeader
     - __kind: StructureType
-      ID: 100
+      ID: 79
       Name: noalg.struct { key string; elem []string }
       ByteSize: 40
       GoRuntimeType: 1.280224e+06
@@ -2268,9 +2250,9 @@ Types:
           Type: 9 GoStringHeaderType string
         - Name: elem
           Offset: 16
-          Type: 53 GoSliceHeaderType []string
+          Type: 55 GoSliceHeaderType []string
     - __kind: StructureType
-      ID: 109
+      ID: 211
       Name: noalg.struct { key string; elem string }
       ByteSize: 32
       GoRuntimeType: 1.282528e+06
@@ -2291,17 +2273,17 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 73 PointerType *string.str
+          Type: 45 PointerType *string.str
         - Name: len
           Offset: 8
           Type: 7 BaseType int
-      Data: 72 GoStringDataType string.str
+      Data: 44 GoStringDataType string.str
     - __kind: GoStringDataType
-      ID: 72
+      ID: 44
       Name: string.str
       ByteSize: 2048
     - __kind: StructureType
-      ID: 114
+      ID: 90
       Name: table<string,[]*mime/multipart.FileHeader>
       ByteSize: 32
       GoKind: 25
@@ -2323,9 +2305,9 @@ Types:
           Type: 7 BaseType int
         - Name: groups
           Offset: 16
-          Type: 116 GoSwissMapGroupsType groupReference<string,[]*mime/multipart.FileHeader>
+          Type: 91 GoSwissMapGroupsType groupReference<string,[]*mime/multipart.FileHeader>
     - __kind: StructureType
-      ID: 76
+      ID: 74
       Name: table<string,[]string>
       ByteSize: 32
       GoKind: 25
@@ -2347,9 +2329,9 @@ Types:
           Type: 7 BaseType int
         - Name: groups
           Offset: 16
-          Type: 96 GoSwissMapGroupsType groupReference<string,[]string>
+          Type: 75 GoSwissMapGroupsType groupReference<string,[]string>
     - __kind: StructureType
-      ID: 95
+      ID: 206
       Name: table<string,string>
       ByteSize: 32
       GoKind: 25
@@ -2371,9 +2353,9 @@ Types:
           Type: 7 BaseType int
         - Name: groups
           Offset: 16
-          Type: 105 GoSwissMapGroupsType groupReference<string,string>
+          Type: 207 GoSwissMapGroupsType groupReference<string,string>
     - __kind: StructureType
-      ID: 145
+      ID: 135
       Name: time.Location
       ByteSize: 104
       GoRuntimeType: 1.957824e+06
@@ -2384,10 +2366,10 @@ Types:
           Type: 9 GoStringHeaderType string
         - Name: zone
           Offset: 16
-          Type: 176 GoSliceHeaderType []time.zone
+          Type: 167 GoSliceHeaderType []time.zone
         - Name: tx
           Offset: 40
-          Type: 179 GoSliceHeaderType []time.zoneTrans
+          Type: 170 GoSliceHeaderType []time.zoneTrans
         - Name: extend
           Offset: 64
           Type: 9 GoStringHeaderType string
@@ -2399,9 +2381,9 @@ Types:
           Type: 13 BaseType int64
         - Name: cacheZone
           Offset: 96
-          Type: 177 PointerType *time.zone
+          Type: 168 PointerType *time.zone
     - __kind: StructureType
-      ID: 143
+      ID: 133
       Name: time.Time
       ByteSize: 24
       GoRuntimeType: 2.34832e+06
@@ -2415,9 +2397,9 @@ Types:
           Type: 13 BaseType int64
         - Name: loc
           Offset: 16
-          Type: 144 PointerType *time.Location
+          Type: 134 PointerType *time.Location
     - __kind: StructureType
-      ID: 178
+      ID: 169
       Name: time.zone
       ByteSize: 32
       GoRuntimeType: 1.602208e+06
@@ -2433,7 +2415,7 @@ Types:
           Offset: 24
           Type: 4 BaseType bool
     - __kind: StructureType
-      ID: 181
+      ID: 172
       Name: time.zoneTrans
       ByteSize: 16
       GoRuntimeType: 1.736576e+06
@@ -2493,6 +2475,6 @@ Types:
       ByteSize: 8
       GoRuntimeType: 580512
       GoKind: 26
-MaxTypeID: 216
+MaxTypeID: 215
 Issues: []
 GoModuledataInfo: {FirstModuledataAddr: "0x133d7c0", TypesOffset: 296}

--- a/pkg/dyninst/irgen/testdata/snapshot/rc_tester_v1.arch=arm64,toolchain=go1.24.3.yaml
+++ b/pkg/dyninst/irgen/testdata/snapshot/rc_tester_v1.arch=arm64,toolchain=go1.24.3.yaml
@@ -65,7 +65,7 @@ Subprograms:
           IsParameter: true
           IsReturn: false
         - Name: '&buf'
-          Type: 157 PointerType *bytes.Buffer
+          Type: 39 PointerType *bytes.Buffer
           Locations:
             - Range: 0x86c254..0x86c268
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
@@ -74,7 +74,7 @@ Subprograms:
           IsParameter: false
           IsReturn: false
         - Name: span
-          Type: 160 GoInterfaceType gopkg.in/DataDog/dd-trace-go.v1/ddtrace.Span
+          Type: 41 GoInterfaceType gopkg.in/DataDog/dd-trace-go.v1/ddtrace.Span
           Locations:
             - Range: 0x86c178..0x86c178
               Pieces:
@@ -97,7 +97,7 @@ Subprograms:
           IsParameter: false
           IsReturn: false
         - Name: .autotmp_14
-          Type: 161 StructureType context.backgroundCtx
+          Type: 42 StructureType context.backgroundCtx
           Locations:
             - Range: 0x86c100..0x86c340
               Pieces: [{Size: 0, Op: {CfaOffset: 0}}]
@@ -121,59 +121,59 @@ Subprograms:
           IsReturn: false
 Types:
     - __kind: PointerType
-      ID: 81
+      ID: 82
       Name: '**crypto/x509.Certificate'
       ByteSize: 8
       GoKind: 22
-      Pointee: 82 PointerType *crypto/x509.Certificate
+      Pointee: 83 PointerType *crypto/x509.Certificate
     - __kind: PointerType
-      ID: 73
+      ID: 148
       Name: '**mime/multipart.FileHeader'
       ByteSize: 8
       GoKind: 22
-      Pointee: 74 PointerType *mime/multipart.FileHeader
+      Pointee: 149 PointerType *mime/multipart.FileHeader
     - __kind: PointerType
-      ID: 121
+      ID: 135
       Name: '**net.IPNet'
       ByteSize: 8
       GoKind: 22
-      Pointee: 122 PointerType *net.IPNet
+      Pointee: 136 PointerType *net.IPNet
     - __kind: PointerType
-      ID: 119
+      ID: 133
       Name: '**net/url.URL'
       ByteSize: 8
-      Pointee: 39 PointerType *net/url.URL
+      Pointee: 44 PointerType *net/url.URL
     - __kind: PointerType
-      ID: 64
+      ID: 79
       Name: '**table<string,[]*mime/multipart.FileHeader>'
       ByteSize: 8
-      Pointee: 65 PointerType *table<string,[]*mime/multipart.FileHeader>
+      Pointee: 80 PointerType *table<string,[]*mime/multipart.FileHeader>
     - __kind: PointerType
-      ID: 46
+      ID: 49
       Name: '**table<string,[]string>'
       ByteSize: 8
-      Pointee: 47 PointerType *table<string,[]string>
+      Pointee: 50 PointerType *table<string,[]string>
     - __kind: PointerType
-      ID: 149
+      ID: 68
       Name: '**table<string,string>'
       ByteSize: 8
-      Pointee: 150 PointerType *table<string,string>
+      Pointee: 69 PointerType *table<string,string>
     - __kind: PointerType
-      ID: 132
+      ID: 85
       Name: '*[]*crypto/x509.Certificate'
       ByteSize: 8
       GoKind: 22
-      Pointee: 80 GoSliceHeaderType []*crypto/x509.Certificate
+      Pointee: 81 GoSliceHeaderType []*crypto/x509.Certificate
     - __kind: PointerType
       ID: 176
       Name: '*[]*crypto/x509.Certificate.array'
       ByteSize: 8
       Pointee: 175 GoSliceDataType []*crypto/x509.Certificate.array
     - __kind: PointerType
-      ID: 172
+      ID: 206
       Name: '*[]*mime/multipart.FileHeader.array'
       ByteSize: 8
-      Pointee: 171 GoSliceDataType []*mime/multipart.FileHeader.array
+      Pointee: 205 GoSliceDataType []*mime/multipart.FileHeader.array
     - __kind: PointerType
       ID: 200
       Name: '*[]*net.IPNet.array'
@@ -185,82 +185,82 @@ Types:
       ByteSize: 8
       Pointee: 197 GoSliceDataType []*net/url.URL.array
     - __kind: PointerType
-      ID: 208
+      ID: 178
       Name: '*[][]*crypto/x509.Certificate.array'
       ByteSize: 8
-      Pointee: 207 GoSliceDataType [][]*crypto/x509.Certificate.array
+      Pointee: 177 GoSliceDataType [][]*crypto/x509.Certificate.array
     - __kind: PointerType
-      ID: 210
+      ID: 180
       Name: '*[][]uint8.array'
       ByteSize: 8
-      Pointee: 209 GoSliceDataType [][]uint8.array
+      Pointee: 179 GoSliceDataType [][]uint8.array
     - __kind: PointerType
       ID: 192
       Name: '*[]crypto/x509.ExtKeyUsage.array'
       ByteSize: 8
       Pointee: 191 GoSliceDataType []crypto/x509.ExtKeyUsage.array
     - __kind: PointerType
-      ID: 204
+      ID: 202
       Name: '*[]crypto/x509.OID.array'
       ByteSize: 8
-      Pointee: 203 GoSliceDataType []crypto/x509.OID.array
+      Pointee: 201 GoSliceDataType []crypto/x509.OID.array
     - __kind: PointerType
-      ID: 206
+      ID: 204
       Name: '*[]crypto/x509.PolicyMapping.array'
       ByteSize: 8
-      Pointee: 205 GoSliceDataType []crypto/x509.PolicyMapping.array
+      Pointee: 203 GoSliceDataType []crypto/x509.PolicyMapping.array
     - __kind: PointerType
-      ID: 180
+      ID: 184
       Name: '*[]crypto/x509/pkix.AttributeTypeAndValue.array'
       ByteSize: 8
-      Pointee: 179 GoSliceDataType []crypto/x509/pkix.AttributeTypeAndValue.array
+      Pointee: 183 GoSliceDataType []crypto/x509/pkix.AttributeTypeAndValue.array
     - __kind: PointerType
-      ID: 188
+      ID: 186
       Name: '*[]crypto/x509/pkix.Extension.array'
       ByteSize: 8
-      Pointee: 187 GoSliceDataType []crypto/x509/pkix.Extension.array
+      Pointee: 185 GoSliceDataType []crypto/x509/pkix.Extension.array
     - __kind: PointerType
-      ID: 190
+      ID: 188
       Name: '*[]encoding/asn1.ObjectIdentifier.array'
       ByteSize: 8
-      Pointee: 189 GoSliceDataType []encoding/asn1.ObjectIdentifier.array
+      Pointee: 187 GoSliceDataType []encoding/asn1.ObjectIdentifier.array
     - __kind: PointerType
       ID: 194
       Name: '*[]net.IP.array'
       ByteSize: 8
       Pointee: 193 GoSliceDataType []net.IP.array
     - __kind: PointerType
-      ID: 212
+      ID: 182
       Name: '*[]net/http.segment.array'
       ByteSize: 8
-      Pointee: 211 GoSliceDataType []net/http.segment.array
+      Pointee: 181 GoSliceDataType []net/http.segment.array
     - __kind: PointerType
       ID: 168
       Name: '*[]string.array'
       ByteSize: 8
       Pointee: 167 GoSliceDataType []string.array
     - __kind: PointerType
-      ID: 184
+      ID: 210
       Name: '*[]time.zone.array'
       ByteSize: 8
-      Pointee: 183 GoSliceDataType []time.zone.array
+      Pointee: 209 GoSliceDataType []time.zone.array
     - __kind: PointerType
-      ID: 186
+      ID: 212
       Name: '*[]time.zoneTrans.array'
       ByteSize: 8
-      Pointee: 185 GoSliceDataType []time.zoneTrans.array
+      Pointee: 211 GoSliceDataType []time.zoneTrans.array
     - __kind: PointerType
-      ID: 134
+      ID: 87
       Name: '*[]uint8'
       ByteSize: 8
       GoRuntimeType: 478144
       GoKind: 22
-      Pointee: 77 GoSliceHeaderType []uint8
+      Pointee: 70 GoSliceHeaderType []uint8
     - __kind: PointerType
-      ID: 174
+      ID: 172
       Name: '*[]uint8.array'
       ByteSize: 8
-      Pointee: 173 GoSliceDataType []uint8.array
+      Pointee: 171 GoSliceDataType []uint8.array
     - __kind: PointerType
       ID: 11
       Name: '*bool'
@@ -269,73 +269,73 @@ Types:
       GoKind: 22
       Pointee: 4 BaseType bool
     - __kind: PointerType
-      ID: 157
+      ID: 39
       Name: '*bytes.Buffer'
       ByteSize: 8
       GoRuntimeType: 2.245056e+06
       GoKind: 22
-      Pointee: 158 StructureType bytes.Buffer
+      Pointee: 40 StructureType bytes.Buffer
     - __kind: PointerType
-      ID: 78
+      ID: 57
       Name: '*crypto/tls.ConnectionState'
       ByteSize: 8
       GoRuntimeType: 900864
       GoKind: 22
-      Pointee: 79 StructureType crypto/tls.ConnectionState
+      Pointee: 58 StructureType crypto/tls.ConnectionState
     - __kind: PointerType
-      ID: 82
+      ID: 83
       Name: '*crypto/x509.Certificate'
       ByteSize: 8
       GoRuntimeType: 2.030304e+06
       GoKind: 22
-      Pointee: 83 StructureType crypto/x509.Certificate
+      Pointee: 98 StructureType crypto/x509.Certificate
     - __kind: PointerType
-      ID: 113
+      ID: 127
       Name: '*crypto/x509.ExtKeyUsage'
       ByteSize: 8
       GoRuntimeType: 420160
       GoKind: 22
-      Pointee: 114 BaseType crypto/x509.ExtKeyUsage
+      Pointee: 128 BaseType crypto/x509.ExtKeyUsage
     - __kind: PointerType
-      ID: 126
+      ID: 138
       Name: '*crypto/x509.OID'
       ByteSize: 8
       GoRuntimeType: 1.938144e+06
       GoKind: 22
-      Pointee: 127 StructureType crypto/x509.OID
+      Pointee: 139 StructureType crypto/x509.OID
     - __kind: PointerType
-      ID: 129
+      ID: 141
       Name: '*crypto/x509.PolicyMapping'
       ByteSize: 8
       GoRuntimeType: 420224
       GoKind: 22
-      Pointee: 130 StructureType crypto/x509.PolicyMapping
+      Pointee: 142 StructureType crypto/x509.PolicyMapping
     - __kind: PointerType
-      ID: 94
+      ID: 114
       Name: '*crypto/x509/pkix.AttributeTypeAndValue'
       ByteSize: 8
       GoRuntimeType: 433984
       GoKind: 22
-      Pointee: 95 StructureType crypto/x509/pkix.AttributeTypeAndValue
+      Pointee: 115 StructureType crypto/x509/pkix.AttributeTypeAndValue
     - __kind: PointerType
-      ID: 108
+      ID: 121
       Name: '*crypto/x509/pkix.Extension'
       ByteSize: 8
       GoRuntimeType: 434176
       GoKind: 22
-      Pointee: 109 StructureType crypto/x509/pkix.Extension
+      Pointee: 122 StructureType crypto/x509/pkix.Extension
     - __kind: PointerType
-      ID: 111
+      ID: 124
       Name: '*encoding/asn1.ObjectIdentifier'
       ByteSize: 8
       GoRuntimeType: 1.044e+06
       GoKind: 22
-      Pointee: 96 GoSliceHeaderType encoding/asn1.ObjectIdentifier
+      Pointee: 125 GoSliceHeaderType encoding/asn1.ObjectIdentifier
     - __kind: PointerType
-      ID: 182
+      ID: 190
       Name: '*encoding/asn1.ObjectIdentifier.array'
       ByteSize: 8
-      Pointee: 181 GoSliceDataType encoding/asn1.ObjectIdentifier.array
+      Pointee: 189 GoSliceDataType encoding/asn1.ObjectIdentifier.array
     - __kind: PointerType
       ID: 33
       Name: '*error'
@@ -393,77 +393,77 @@ Types:
       GoKind: 22
       Pointee: 16 BaseType int8
     - __kind: PointerType
-      ID: 62
+      ID: 77
       Name: '*map<string,[]*mime/multipart.FileHeader>'
       ByteSize: 8
-      Pointee: 63 GoSwissMapHeaderType map<string,[]*mime/multipart.FileHeader>
+      Pointee: 78 GoSwissMapHeaderType map<string,[]*mime/multipart.FileHeader>
     - __kind: PointerType
-      ID: 44
+      ID: 47
       Name: '*map<string,[]string>'
       ByteSize: 8
-      Pointee: 45 GoSwissMapHeaderType map<string,[]string>
+      Pointee: 48 GoSwissMapHeaderType map<string,[]string>
     - __kind: PointerType
-      ID: 147
+      ID: 66
       Name: '*map<string,string>'
       ByteSize: 8
-      Pointee: 148 GoSwissMapHeaderType map<string,string>
+      Pointee: 67 GoSwissMapHeaderType map<string,string>
     - __kind: PointerType
-      ID: 87
+      ID: 110
       Name: '*math/big.Int'
       ByteSize: 8
       GoRuntimeType: 2.364704e+06
       GoKind: 22
-      Pointee: 88 StructureType math/big.Int
+      Pointee: 111 StructureType math/big.Int
     - __kind: PointerType
-      ID: 90
+      ID: 151
       Name: '*math/big.Word'
       ByteSize: 8
       GoRuntimeType: 423040
       GoKind: 22
-      Pointee: 91 BaseType math/big.Word
+      Pointee: 152 BaseType math/big.Word
     - __kind: PointerType
-      ID: 178
+      ID: 208
       Name: '*math/big.nat.array'
       ByteSize: 8
-      Pointee: 177 GoSliceDataType math/big.nat.array
+      Pointee: 207 GoSliceDataType math/big.nat.array
     - __kind: PointerType
-      ID: 74
+      ID: 149
       Name: '*mime/multipart.FileHeader'
       ByteSize: 8
       GoRuntimeType: 902304
       GoKind: 22
-      Pointee: 75 StructureType mime/multipart.FileHeader
+      Pointee: 160 StructureType mime/multipart.FileHeader
     - __kind: PointerType
-      ID: 58
+      ID: 55
       Name: '*mime/multipart.Form'
       ByteSize: 8
       GoRuntimeType: 902400
       GoKind: 22
-      Pointee: 59 StructureType mime/multipart.Form
+      Pointee: 56 StructureType mime/multipart.Form
     - __kind: PointerType
-      ID: 116
+      ID: 130
       Name: '*net.IP'
       ByteSize: 8
       GoRuntimeType: 2.134112e+06
       GoKind: 22
-      Pointee: 117 GoSliceHeaderType net.IP
+      Pointee: 131 GoSliceHeaderType net.IP
     - __kind: PointerType
       ID: 196
       Name: '*net.IP.array'
       ByteSize: 8
       Pointee: 195 GoSliceDataType net.IP.array
     - __kind: PointerType
-      ID: 202
+      ID: 214
       Name: '*net.IPMask.array'
       ByteSize: 8
-      Pointee: 201 GoSliceDataType net.IPMask.array
+      Pointee: 213 GoSliceDataType net.IPMask.array
     - __kind: PointerType
-      ID: 122
+      ID: 136
       Name: '*net.IPNet'
       ByteSize: 8
       GoRuntimeType: 1.17392e+06
       GoKind: 22
-      Pointee: 123 StructureType net.IPNet
+      Pointee: 159 StructureType net.IPNet
     - __kind: PointerType
       ID: 37
       Name: '*net/http.Request'
@@ -472,55 +472,55 @@ Types:
       GoKind: 22
       Pointee: 38 StructureType net/http.Request
     - __kind: PointerType
-      ID: 138
+      ID: 60
       Name: '*net/http.Response'
       ByteSize: 8
       GoRuntimeType: 1.705504e+06
       GoKind: 22
-      Pointee: 139 StructureType net/http.Response
+      Pointee: 61 StructureType net/http.Response
     - __kind: PointerType
-      ID: 141
+      ID: 63
       Name: '*net/http.pattern'
       ByteSize: 8
       GoRuntimeType: 1.597408e+06
       GoKind: 22
-      Pointee: 142 StructureType net/http.pattern
+      Pointee: 64 StructureType net/http.pattern
     - __kind: PointerType
-      ID: 144
+      ID: 91
       Name: '*net/http.segment'
       ByteSize: 8
       GoRuntimeType: 388544
       GoKind: 22
-      Pointee: 145 StructureType net/http.segment
+      Pointee: 92 StructureType net/http.segment
     - __kind: PointerType
-      ID: 39
+      ID: 44
       Name: '*net/url.URL'
       ByteSize: 8
       GoRuntimeType: 2.099328e+06
       GoKind: 22
-      Pointee: 40 StructureType net/url.URL
+      Pointee: 45 StructureType net/url.URL
     - __kind: PointerType
-      ID: 41
+      ID: 72
       Name: '*net/url.Userinfo'
       ByteSize: 8
       GoRuntimeType: 1.191456e+06
       GoKind: 22
-      Pointee: 42 StructureType net/url.Userinfo
+      Pointee: 73 StructureType net/url.Userinfo
     - __kind: PointerType
-      ID: 68
+      ID: 105
       Name: '*noalg.map.group[string][]*mime/multipart.FileHeader'
       ByteSize: 8
-      Pointee: 69 StructureType noalg.map.group[string][]*mime/multipart.FileHeader
+      Pointee: 106 StructureType noalg.map.group[string][]*mime/multipart.FileHeader
     - __kind: PointerType
-      ID: 50
+      ID: 95
       Name: '*noalg.map.group[string][]string'
       ByteSize: 8
-      Pointee: 51 StructureType noalg.map.group[string][]string
+      Pointee: 96 StructureType noalg.map.group[string][]string
     - __kind: PointerType
-      ID: 153
+      ID: 100
       Name: '*noalg.map.group[string]string'
       ByteSize: 8
-      Pointee: 154 StructureType noalg.map.group[string]string
+      Pointee: 101 StructureType noalg.map.group[string]string
     - __kind: PointerType
       ID: 22
       Name: '*string'
@@ -534,41 +534,41 @@ Types:
       ByteSize: 8
       Pointee: 163 GoStringDataType string.str
     - __kind: PointerType
-      ID: 65
+      ID: 80
       Name: '*table<string,[]*mime/multipart.FileHeader>'
       ByteSize: 8
-      Pointee: 66 StructureType table<string,[]*mime/multipart.FileHeader>
+      Pointee: 97 StructureType table<string,[]*mime/multipart.FileHeader>
     - __kind: PointerType
-      ID: 47
+      ID: 50
       Name: '*table<string,[]string>'
       ByteSize: 8
-      Pointee: 48 StructureType table<string,[]string>
+      Pointee: 74 StructureType table<string,[]string>
     - __kind: PointerType
-      ID: 150
+      ID: 69
       Name: '*table<string,string>'
       ByteSize: 8
-      Pointee: 151 StructureType table<string,string>
+      Pointee: 93 StructureType table<string,string>
     - __kind: PointerType
-      ID: 98
+      ID: 117
       Name: '*time.Location'
       ByteSize: 8
       GoRuntimeType: 1.6024e+06
       GoKind: 22
-      Pointee: 99 StructureType time.Location
+      Pointee: 118 StructureType time.Location
     - __kind: PointerType
-      ID: 101
+      ID: 154
       Name: '*time.zone'
       ByteSize: 8
       GoRuntimeType: 391680
       GoKind: 22
-      Pointee: 102 StructureType time.zone
+      Pointee: 155 StructureType time.zone
     - __kind: PointerType
-      ID: 104
+      ID: 157
       Name: '*time.zoneTrans'
       ByteSize: 8
       GoRuntimeType: 391744
       GoKind: 22
-      Pointee: 105 StructureType time.zoneTrans
+      Pointee: 158 StructureType time.zoneTrans
     - __kind: PointerType
       ID: 34
       Name: '*uint'
@@ -612,7 +612,7 @@ Types:
       GoKind: 22
       Pointee: 1 BaseType uintptr
     - __kind: GoChannelType
-      ID: 137
+      ID: 59
       Name: <-chan struct {}
       GoRuntimeType: 592672
       GoKind: 18
@@ -656,7 +656,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: GoSliceHeaderType
-      ID: 80
+      ID: 81
       Name: '[]*crypto/x509.Certificate'
       ByteSize: 24
       GoRuntimeType: 498304
@@ -664,7 +664,7 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 81 PointerType **crypto/x509.Certificate
+          Type: 82 PointerType **crypto/x509.Certificate
         - Name: len
           Offset: 8
           Type: 7 BaseType int
@@ -676,9 +676,9 @@ Types:
       ID: 175
       Name: '[]*crypto/x509.Certificate.array'
       ByteSize: 2048
-      Element: 82 PointerType *crypto/x509.Certificate
+      Element: 83 PointerType *crypto/x509.Certificate
     - __kind: GoSliceHeaderType
-      ID: 72
+      ID: 147
       Name: '[]*mime/multipart.FileHeader'
       ByteSize: 24
       GoRuntimeType: 483744
@@ -686,21 +686,21 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 73 PointerType **mime/multipart.FileHeader
+          Type: 148 PointerType **mime/multipart.FileHeader
         - Name: len
           Offset: 8
           Type: 7 BaseType int
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 171 GoSliceDataType []*mime/multipart.FileHeader.array
+      Data: 205 GoSliceDataType []*mime/multipart.FileHeader.array
     - __kind: GoSliceDataType
-      ID: 171
+      ID: 205
       Name: '[]*mime/multipart.FileHeader.array'
       ByteSize: 2048
-      Element: 74 PointerType *mime/multipart.FileHeader
+      Element: 149 PointerType *mime/multipart.FileHeader
     - __kind: GoSliceHeaderType
-      ID: 120
+      ID: 134
       Name: '[]*net.IPNet'
       ByteSize: 24
       GoRuntimeType: 511840
@@ -708,7 +708,7 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 121 PointerType **net.IPNet
+          Type: 135 PointerType **net.IPNet
         - Name: len
           Offset: 8
           Type: 7 BaseType int
@@ -720,9 +720,9 @@ Types:
       ID: 199
       Name: '[]*net.IPNet.array'
       ByteSize: 2048
-      Element: 122 PointerType *net.IPNet
+      Element: 136 PointerType *net.IPNet
     - __kind: GoSliceHeaderType
-      ID: 118
+      ID: 132
       Name: '[]*net/url.URL'
       ByteSize: 24
       GoRuntimeType: 511776
@@ -730,7 +730,7 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 119 PointerType **net/url.URL
+          Type: 133 PointerType **net/url.URL
         - Name: len
           Offset: 8
           Type: 7 BaseType int
@@ -742,24 +742,24 @@ Types:
       ID: 197
       Name: '[]*net/url.URL.array'
       ByteSize: 2048
-      Element: 39 PointerType *net/url.URL
+      Element: 44 PointerType *net/url.URL
     - __kind: GoSliceDataType
-      ID: 169
+      ID: 173
       Name: '[]*table<string,[]*mime/multipart.FileHeader>.array'
       ByteSize: 8192
-      Element: 65 PointerType *table<string,[]*mime/multipart.FileHeader>
+      Element: 80 PointerType *table<string,[]*mime/multipart.FileHeader>
     - __kind: GoSliceDataType
       ID: 165
       Name: '[]*table<string,[]string>.array'
       ByteSize: 8192
-      Element: 47 PointerType *table<string,[]string>
+      Element: 50 PointerType *table<string,[]string>
     - __kind: GoSliceDataType
-      ID: 213
+      ID: 169
       Name: '[]*table<string,string>.array'
       ByteSize: 8192
-      Element: 150 PointerType *table<string,string>
+      Element: 69 PointerType *table<string,string>
     - __kind: GoSliceHeaderType
-      ID: 131
+      ID: 84
       Name: '[][]*crypto/x509.Certificate'
       ByteSize: 24
       GoRuntimeType: 498432
@@ -767,21 +767,21 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 132 PointerType *[]*crypto/x509.Certificate
+          Type: 85 PointerType *[]*crypto/x509.Certificate
         - Name: len
           Offset: 8
           Type: 7 BaseType int
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 207 GoSliceDataType [][]*crypto/x509.Certificate.array
+      Data: 177 GoSliceDataType [][]*crypto/x509.Certificate.array
     - __kind: GoSliceDataType
-      ID: 207
+      ID: 177
       Name: '[][]*crypto/x509.Certificate.array'
       ByteSize: 2048
-      Element: 80 GoSliceHeaderType []*crypto/x509.Certificate
+      Element: 81 GoSliceHeaderType []*crypto/x509.Certificate
     - __kind: GoSliceHeaderType
-      ID: 133
+      ID: 86
       Name: '[][]uint8'
       ByteSize: 24
       GoRuntimeType: 478528
@@ -789,21 +789,21 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 134 PointerType *[]uint8
+          Type: 87 PointerType *[]uint8
         - Name: len
           Offset: 8
           Type: 7 BaseType int
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 209 GoSliceDataType [][]uint8.array
+      Data: 179 GoSliceDataType [][]uint8.array
     - __kind: GoSliceDataType
-      ID: 209
+      ID: 179
       Name: '[][]uint8.array'
       ByteSize: 2048
-      Element: 77 GoSliceHeaderType []uint8
+      Element: 70 GoSliceHeaderType []uint8
     - __kind: GoSliceHeaderType
-      ID: 112
+      ID: 126
       Name: '[]crypto/x509.ExtKeyUsage'
       ByteSize: 24
       GoRuntimeType: 499776
@@ -811,7 +811,7 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 113 PointerType *crypto/x509.ExtKeyUsage
+          Type: 127 PointerType *crypto/x509.ExtKeyUsage
         - Name: len
           Offset: 8
           Type: 7 BaseType int
@@ -823,9 +823,9 @@ Types:
       ID: 191
       Name: '[]crypto/x509.ExtKeyUsage.array'
       ByteSize: 2048
-      Element: 114 BaseType crypto/x509.ExtKeyUsage
+      Element: 128 BaseType crypto/x509.ExtKeyUsage
     - __kind: GoSliceHeaderType
-      ID: 125
+      ID: 137
       Name: '[]crypto/x509.OID'
       ByteSize: 24
       GoRuntimeType: 511904
@@ -833,21 +833,21 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 126 PointerType *crypto/x509.OID
+          Type: 138 PointerType *crypto/x509.OID
         - Name: len
           Offset: 8
           Type: 7 BaseType int
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 203 GoSliceDataType []crypto/x509.OID.array
+      Data: 201 GoSliceDataType []crypto/x509.OID.array
     - __kind: GoSliceDataType
-      ID: 203
+      ID: 201
       Name: '[]crypto/x509.OID.array'
       ByteSize: 2048
-      Element: 127 StructureType crypto/x509.OID
+      Element: 139 StructureType crypto/x509.OID
     - __kind: GoSliceHeaderType
-      ID: 128
+      ID: 140
       Name: '[]crypto/x509.PolicyMapping'
       ByteSize: 24
       GoRuntimeType: 511968
@@ -855,21 +855,21 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 129 PointerType *crypto/x509.PolicyMapping
+          Type: 141 PointerType *crypto/x509.PolicyMapping
         - Name: len
           Offset: 8
           Type: 7 BaseType int
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 205 GoSliceDataType []crypto/x509.PolicyMapping.array
+      Data: 203 GoSliceDataType []crypto/x509.PolicyMapping.array
     - __kind: GoSliceDataType
-      ID: 205
+      ID: 203
       Name: '[]crypto/x509.PolicyMapping.array'
       ByteSize: 2048
-      Element: 130 StructureType crypto/x509.PolicyMapping
+      Element: 142 StructureType crypto/x509.PolicyMapping
     - __kind: GoSliceHeaderType
-      ID: 93
+      ID: 113
       Name: '[]crypto/x509/pkix.AttributeTypeAndValue'
       ByteSize: 24
       GoRuntimeType: 512416
@@ -877,21 +877,21 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 94 PointerType *crypto/x509/pkix.AttributeTypeAndValue
+          Type: 114 PointerType *crypto/x509/pkix.AttributeTypeAndValue
         - Name: len
           Offset: 8
           Type: 7 BaseType int
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 179 GoSliceDataType []crypto/x509/pkix.AttributeTypeAndValue.array
+      Data: 183 GoSliceDataType []crypto/x509/pkix.AttributeTypeAndValue.array
     - __kind: GoSliceDataType
-      ID: 179
+      ID: 183
       Name: '[]crypto/x509/pkix.AttributeTypeAndValue.array'
       ByteSize: 2048
-      Element: 95 StructureType crypto/x509/pkix.AttributeTypeAndValue
+      Element: 115 StructureType crypto/x509/pkix.AttributeTypeAndValue
     - __kind: GoSliceHeaderType
-      ID: 107
+      ID: 120
       Name: '[]crypto/x509/pkix.Extension'
       ByteSize: 24
       GoRuntimeType: 511648
@@ -899,21 +899,21 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 108 PointerType *crypto/x509/pkix.Extension
+          Type: 121 PointerType *crypto/x509/pkix.Extension
         - Name: len
           Offset: 8
           Type: 7 BaseType int
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 187 GoSliceDataType []crypto/x509/pkix.Extension.array
+      Data: 185 GoSliceDataType []crypto/x509/pkix.Extension.array
     - __kind: GoSliceDataType
-      ID: 187
+      ID: 185
       Name: '[]crypto/x509/pkix.Extension.array'
       ByteSize: 2048
-      Element: 109 StructureType crypto/x509/pkix.Extension
+      Element: 122 StructureType crypto/x509/pkix.Extension
     - __kind: GoSliceHeaderType
-      ID: 110
+      ID: 123
       Name: '[]encoding/asn1.ObjectIdentifier'
       ByteSize: 24
       GoRuntimeType: 511712
@@ -921,21 +921,21 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 111 PointerType *encoding/asn1.ObjectIdentifier
+          Type: 124 PointerType *encoding/asn1.ObjectIdentifier
         - Name: len
           Offset: 8
           Type: 7 BaseType int
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 189 GoSliceDataType []encoding/asn1.ObjectIdentifier.array
+      Data: 187 GoSliceDataType []encoding/asn1.ObjectIdentifier.array
     - __kind: GoSliceDataType
-      ID: 189
+      ID: 187
       Name: '[]encoding/asn1.ObjectIdentifier.array'
       ByteSize: 2048
-      Element: 96 GoSliceHeaderType encoding/asn1.ObjectIdentifier
+      Element: 125 GoSliceHeaderType encoding/asn1.ObjectIdentifier
     - __kind: GoSliceHeaderType
-      ID: 115
+      ID: 129
       Name: '[]net.IP'
       ByteSize: 24
       GoRuntimeType: 479488
@@ -943,7 +943,7 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 116 PointerType *net.IP
+          Type: 130 PointerType *net.IP
         - Name: len
           Offset: 8
           Type: 7 BaseType int
@@ -955,9 +955,9 @@ Types:
       ID: 193
       Name: '[]net.IP.array'
       ByteSize: 2048
-      Element: 117 GoSliceHeaderType net.IP
+      Element: 131 GoSliceHeaderType net.IP
     - __kind: GoSliceHeaderType
-      ID: 143
+      ID: 90
       Name: '[]net/http.segment'
       ByteSize: 24
       GoRuntimeType: 481120
@@ -965,36 +965,36 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 144 PointerType *net/http.segment
+          Type: 91 PointerType *net/http.segment
         - Name: len
           Offset: 8
           Type: 7 BaseType int
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 211 GoSliceDataType []net/http.segment.array
+      Data: 181 GoSliceDataType []net/http.segment.array
     - __kind: GoSliceDataType
-      ID: 211
+      ID: 181
       Name: '[]net/http.segment.array'
       ByteSize: 2048
-      Element: 145 StructureType net/http.segment
+      Element: 92 StructureType net/http.segment
     - __kind: GoSliceDataType
-      ID: 170
+      ID: 174
       Name: '[]noalg.map.group[string][]*mime/multipart.FileHeader.array'
       ByteSize: 2048
-      Element: 69 StructureType noalg.map.group[string][]*mime/multipart.FileHeader
+      Element: 106 StructureType noalg.map.group[string][]*mime/multipart.FileHeader
     - __kind: GoSliceDataType
       ID: 166
       Name: '[]noalg.map.group[string][]string.array'
       ByteSize: 2048
-      Element: 51 StructureType noalg.map.group[string][]string
+      Element: 96 StructureType noalg.map.group[string][]string
     - __kind: GoSliceDataType
-      ID: 214
+      ID: 170
       Name: '[]noalg.map.group[string]string.array'
       ByteSize: 2048
-      Element: 154 StructureType noalg.map.group[string]string
+      Element: 101 StructureType noalg.map.group[string]string
     - __kind: GoSliceHeaderType
-      ID: 54
+      ID: 53
       Name: '[]string'
       ByteSize: 24
       GoRuntimeType: 492672
@@ -1016,7 +1016,7 @@ Types:
       ByteSize: 2048
       Element: 9 GoStringHeaderType string
     - __kind: GoSliceHeaderType
-      ID: 100
+      ID: 153
       Name: '[]time.zone'
       ByteSize: 24
       GoRuntimeType: 485792
@@ -1024,21 +1024,21 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 101 PointerType *time.zone
+          Type: 154 PointerType *time.zone
         - Name: len
           Offset: 8
           Type: 7 BaseType int
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 183 GoSliceDataType []time.zone.array
+      Data: 209 GoSliceDataType []time.zone.array
     - __kind: GoSliceDataType
-      ID: 183
+      ID: 209
       Name: '[]time.zone.array'
       ByteSize: 2048
-      Element: 102 StructureType time.zone
+      Element: 155 StructureType time.zone
     - __kind: GoSliceHeaderType
-      ID: 103
+      ID: 156
       Name: '[]time.zoneTrans'
       ByteSize: 24
       GoRuntimeType: 485856
@@ -1046,21 +1046,21 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 104 PointerType *time.zoneTrans
+          Type: 157 PointerType *time.zoneTrans
         - Name: len
           Offset: 8
           Type: 7 BaseType int
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 185 GoSliceDataType []time.zoneTrans.array
+      Data: 211 GoSliceDataType []time.zoneTrans.array
     - __kind: GoSliceDataType
-      ID: 185
+      ID: 211
       Name: '[]time.zoneTrans.array'
       ByteSize: 2048
-      Element: 105 StructureType time.zoneTrans
+      Element: 158 StructureType time.zoneTrans
     - __kind: GoSliceHeaderType
-      ID: 77
+      ID: 70
       Name: '[]uint8'
       ByteSize: 24
       GoRuntimeType: 491520
@@ -1075,9 +1075,9 @@ Types:
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 173 GoSliceDataType []uint8.array
+      Data: 171 GoSliceDataType []uint8.array
     - __kind: GoSliceDataType
-      ID: 173
+      ID: 171
       Name: '[]uint8.array'
       ByteSize: 2048
       Element: 3 BaseType uint8
@@ -1088,7 +1088,7 @@ Types:
       GoRuntimeType: 580448
       GoKind: 1
     - __kind: StructureType
-      ID: 158
+      ID: 40
       Name: bytes.Buffer
       ByteSize: 40
       GoRuntimeType: 1.595104e+06
@@ -1096,15 +1096,15 @@ Types:
       RawFields:
         - Name: buf
           Offset: 0
-          Type: 77 GoSliceHeaderType []uint8
+          Type: 70 GoSliceHeaderType []uint8
         - Name: off
           Offset: 24
           Type: 7 BaseType int
         - Name: lastRead
           Offset: 32
-          Type: 159 BaseType bytes.readOp
+          Type: 71 BaseType bytes.readOp
     - __kind: BaseType
-      ID: 159
+      ID: 71
       Name: bytes.readOp
       ByteSize: 1
       GoRuntimeType: 578592
@@ -1122,7 +1122,7 @@ Types:
       GoRuntimeType: 580192
       GoKind: 15
     - __kind: GoInterfaceType
-      ID: 140
+      ID: 62
       Name: context.Context
       ByteSize: 16
       GoRuntimeType: 1.266912e+06
@@ -1135,22 +1135,22 @@ Types:
           Offset: 8
           Type: 15 VoidPointerType unsafe.Pointer
     - __kind: StructureType
-      ID: 161
+      ID: 42
       Name: context.backgroundCtx
       GoRuntimeType: 1.781408e+06
       GoKind: 25
       RawFields:
         - Name: emptyCtx
           Offset: 0
-          Type: 162 StructureType context.emptyCtx
+          Type: 43 StructureType context.emptyCtx
     - __kind: StructureType
-      ID: 162
+      ID: 43
       Name: context.emptyCtx
       GoRuntimeType: 1.58016e+06
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 79
+      ID: 58
       Name: crypto/tls.ConnectionState
       ByteSize: 192
       GoRuntimeType: 2.231616e+06
@@ -1179,39 +1179,39 @@ Types:
           Type: 9 GoStringHeaderType string
         - Name: PeerCertificates
           Offset: 48
-          Type: 80 GoSliceHeaderType []*crypto/x509.Certificate
+          Type: 81 GoSliceHeaderType []*crypto/x509.Certificate
         - Name: VerifiedChains
           Offset: 72
-          Type: 131 GoSliceHeaderType [][]*crypto/x509.Certificate
+          Type: 84 GoSliceHeaderType [][]*crypto/x509.Certificate
         - Name: SignedCertificateTimestamps
           Offset: 96
-          Type: 133 GoSliceHeaderType [][]uint8
+          Type: 86 GoSliceHeaderType [][]uint8
         - Name: OCSPResponse
           Offset: 120
-          Type: 77 GoSliceHeaderType []uint8
+          Type: 70 GoSliceHeaderType []uint8
         - Name: TLSUnique
           Offset: 144
-          Type: 77 GoSliceHeaderType []uint8
+          Type: 70 GoSliceHeaderType []uint8
         - Name: ECHAccepted
           Offset: 168
           Type: 4 BaseType bool
         - Name: ekm
           Offset: 176
-          Type: 135 GoSubroutineType func(string, []uint8, int) ([]uint8, error)
+          Type: 88 GoSubroutineType func(string, []uint8, int) ([]uint8, error)
         - Name: testingOnlyDidHRR
           Offset: 184
           Type: 4 BaseType bool
         - Name: testingOnlyCurveID
           Offset: 186
-          Type: 136 BaseType crypto/tls.CurveID
+          Type: 89 BaseType crypto/tls.CurveID
     - __kind: BaseType
-      ID: 136
+      ID: 89
       Name: crypto/tls.CurveID
       ByteSize: 2
       GoRuntimeType: 829056
       GoKind: 9
     - __kind: StructureType
-      ID: 83
+      ID: 98
       Name: crypto/x509.Certificate
       ByteSize: 1424
       GoRuntimeType: 2.37712e+06
@@ -1219,67 +1219,67 @@ Types:
       RawFields:
         - Name: Raw
           Offset: 0
-          Type: 77 GoSliceHeaderType []uint8
+          Type: 70 GoSliceHeaderType []uint8
         - Name: RawTBSCertificate
           Offset: 24
-          Type: 77 GoSliceHeaderType []uint8
+          Type: 70 GoSliceHeaderType []uint8
         - Name: RawSubjectPublicKeyInfo
           Offset: 48
-          Type: 77 GoSliceHeaderType []uint8
+          Type: 70 GoSliceHeaderType []uint8
         - Name: RawSubject
           Offset: 72
-          Type: 77 GoSliceHeaderType []uint8
+          Type: 70 GoSliceHeaderType []uint8
         - Name: RawIssuer
           Offset: 96
-          Type: 77 GoSliceHeaderType []uint8
+          Type: 70 GoSliceHeaderType []uint8
         - Name: Signature
           Offset: 120
-          Type: 77 GoSliceHeaderType []uint8
+          Type: 70 GoSliceHeaderType []uint8
         - Name: SignatureAlgorithm
           Offset: 144
-          Type: 84 BaseType crypto/x509.SignatureAlgorithm
+          Type: 107 BaseType crypto/x509.SignatureAlgorithm
         - Name: PublicKeyAlgorithm
           Offset: 152
-          Type: 85 BaseType crypto/x509.PublicKeyAlgorithm
+          Type: 108 BaseType crypto/x509.PublicKeyAlgorithm
         - Name: PublicKey
           Offset: 160
-          Type: 86 GoEmptyInterfaceType interface {}
+          Type: 109 GoEmptyInterfaceType interface {}
         - Name: Version
           Offset: 176
           Type: 7 BaseType int
         - Name: SerialNumber
           Offset: 184
-          Type: 87 PointerType *math/big.Int
+          Type: 110 PointerType *math/big.Int
         - Name: Issuer
           Offset: 192
-          Type: 92 StructureType crypto/x509/pkix.Name
+          Type: 112 StructureType crypto/x509/pkix.Name
         - Name: Subject
           Offset: 440
-          Type: 92 StructureType crypto/x509/pkix.Name
+          Type: 112 StructureType crypto/x509/pkix.Name
         - Name: NotBefore
           Offset: 688
-          Type: 97 StructureType time.Time
+          Type: 116 StructureType time.Time
         - Name: NotAfter
           Offset: 712
-          Type: 97 StructureType time.Time
+          Type: 116 StructureType time.Time
         - Name: KeyUsage
           Offset: 736
-          Type: 106 BaseType crypto/x509.KeyUsage
+          Type: 119 BaseType crypto/x509.KeyUsage
         - Name: Extensions
           Offset: 744
-          Type: 107 GoSliceHeaderType []crypto/x509/pkix.Extension
+          Type: 120 GoSliceHeaderType []crypto/x509/pkix.Extension
         - Name: ExtraExtensions
           Offset: 768
-          Type: 107 GoSliceHeaderType []crypto/x509/pkix.Extension
+          Type: 120 GoSliceHeaderType []crypto/x509/pkix.Extension
         - Name: UnhandledCriticalExtensions
           Offset: 792
-          Type: 110 GoSliceHeaderType []encoding/asn1.ObjectIdentifier
+          Type: 123 GoSliceHeaderType []encoding/asn1.ObjectIdentifier
         - Name: ExtKeyUsage
           Offset: 816
-          Type: 112 GoSliceHeaderType []crypto/x509.ExtKeyUsage
+          Type: 126 GoSliceHeaderType []crypto/x509.ExtKeyUsage
         - Name: UnknownExtKeyUsage
           Offset: 840
-          Type: 110 GoSliceHeaderType []encoding/asn1.ObjectIdentifier
+          Type: 123 GoSliceHeaderType []encoding/asn1.ObjectIdentifier
         - Name: BasicConstraintsValid
           Offset: 864
           Type: 4 BaseType bool
@@ -1294,64 +1294,64 @@ Types:
           Type: 4 BaseType bool
         - Name: SubjectKeyId
           Offset: 888
-          Type: 77 GoSliceHeaderType []uint8
+          Type: 70 GoSliceHeaderType []uint8
         - Name: AuthorityKeyId
           Offset: 912
-          Type: 77 GoSliceHeaderType []uint8
+          Type: 70 GoSliceHeaderType []uint8
         - Name: OCSPServer
           Offset: 936
-          Type: 54 GoSliceHeaderType []string
+          Type: 53 GoSliceHeaderType []string
         - Name: IssuingCertificateURL
           Offset: 960
-          Type: 54 GoSliceHeaderType []string
+          Type: 53 GoSliceHeaderType []string
         - Name: DNSNames
           Offset: 984
-          Type: 54 GoSliceHeaderType []string
+          Type: 53 GoSliceHeaderType []string
         - Name: EmailAddresses
           Offset: 1008
-          Type: 54 GoSliceHeaderType []string
+          Type: 53 GoSliceHeaderType []string
         - Name: IPAddresses
           Offset: 1032
-          Type: 115 GoSliceHeaderType []net.IP
+          Type: 129 GoSliceHeaderType []net.IP
         - Name: URIs
           Offset: 1056
-          Type: 118 GoSliceHeaderType []*net/url.URL
+          Type: 132 GoSliceHeaderType []*net/url.URL
         - Name: PermittedDNSDomainsCritical
           Offset: 1080
           Type: 4 BaseType bool
         - Name: PermittedDNSDomains
           Offset: 1088
-          Type: 54 GoSliceHeaderType []string
+          Type: 53 GoSliceHeaderType []string
         - Name: ExcludedDNSDomains
           Offset: 1112
-          Type: 54 GoSliceHeaderType []string
+          Type: 53 GoSliceHeaderType []string
         - Name: PermittedIPRanges
           Offset: 1136
-          Type: 120 GoSliceHeaderType []*net.IPNet
+          Type: 134 GoSliceHeaderType []*net.IPNet
         - Name: ExcludedIPRanges
           Offset: 1160
-          Type: 120 GoSliceHeaderType []*net.IPNet
+          Type: 134 GoSliceHeaderType []*net.IPNet
         - Name: PermittedEmailAddresses
           Offset: 1184
-          Type: 54 GoSliceHeaderType []string
+          Type: 53 GoSliceHeaderType []string
         - Name: ExcludedEmailAddresses
           Offset: 1208
-          Type: 54 GoSliceHeaderType []string
+          Type: 53 GoSliceHeaderType []string
         - Name: PermittedURIDomains
           Offset: 1232
-          Type: 54 GoSliceHeaderType []string
+          Type: 53 GoSliceHeaderType []string
         - Name: ExcludedURIDomains
           Offset: 1256
-          Type: 54 GoSliceHeaderType []string
+          Type: 53 GoSliceHeaderType []string
         - Name: CRLDistributionPoints
           Offset: 1280
-          Type: 54 GoSliceHeaderType []string
+          Type: 53 GoSliceHeaderType []string
         - Name: PolicyIdentifiers
           Offset: 1304
-          Type: 110 GoSliceHeaderType []encoding/asn1.ObjectIdentifier
+          Type: 123 GoSliceHeaderType []encoding/asn1.ObjectIdentifier
         - Name: Policies
           Offset: 1328
-          Type: 125 GoSliceHeaderType []crypto/x509.OID
+          Type: 137 GoSliceHeaderType []crypto/x509.OID
         - Name: InhibitAnyPolicy
           Offset: 1352
           Type: 7 BaseType int
@@ -1372,21 +1372,21 @@ Types:
           Type: 4 BaseType bool
         - Name: PolicyMappings
           Offset: 1400
-          Type: 128 GoSliceHeaderType []crypto/x509.PolicyMapping
+          Type: 140 GoSliceHeaderType []crypto/x509.PolicyMapping
     - __kind: BaseType
-      ID: 114
+      ID: 128
       Name: crypto/x509.ExtKeyUsage
       ByteSize: 8
       GoRuntimeType: 583136
       GoKind: 2
     - __kind: BaseType
-      ID: 106
+      ID: 119
       Name: crypto/x509.KeyUsage
       ByteSize: 8
       GoRuntimeType: 583072
       GoKind: 2
     - __kind: StructureType
-      ID: 127
+      ID: 139
       Name: crypto/x509.OID
       ByteSize: 24
       GoRuntimeType: 1.9384e+06
@@ -1394,9 +1394,9 @@ Types:
       RawFields:
         - Name: der
           Offset: 0
-          Type: 77 GoSliceHeaderType []uint8
+          Type: 70 GoSliceHeaderType []uint8
     - __kind: StructureType
-      ID: 130
+      ID: 142
       Name: crypto/x509.PolicyMapping
       ByteSize: 48
       GoRuntimeType: 1.480224e+06
@@ -1404,24 +1404,24 @@ Types:
       RawFields:
         - Name: IssuerDomainPolicy
           Offset: 0
-          Type: 127 StructureType crypto/x509.OID
+          Type: 139 StructureType crypto/x509.OID
         - Name: SubjectDomainPolicy
           Offset: 24
-          Type: 127 StructureType crypto/x509.OID
+          Type: 139 StructureType crypto/x509.OID
     - __kind: BaseType
-      ID: 85
+      ID: 108
       Name: crypto/x509.PublicKeyAlgorithm
       ByteSize: 8
       GoRuntimeType: 831456
       GoKind: 2
     - __kind: BaseType
-      ID: 84
+      ID: 107
       Name: crypto/x509.SignatureAlgorithm
       ByteSize: 8
       GoRuntimeType: 1.104544e+06
       GoKind: 2
     - __kind: StructureType
-      ID: 95
+      ID: 115
       Name: crypto/x509/pkix.AttributeTypeAndValue
       ByteSize: 40
       GoRuntimeType: 1.492064e+06
@@ -1429,12 +1429,12 @@ Types:
       RawFields:
         - Name: Type
           Offset: 0
-          Type: 96 GoSliceHeaderType encoding/asn1.ObjectIdentifier
+          Type: 125 GoSliceHeaderType encoding/asn1.ObjectIdentifier
         - Name: Value
           Offset: 24
-          Type: 86 GoEmptyInterfaceType interface {}
+          Type: 109 GoEmptyInterfaceType interface {}
     - __kind: StructureType
-      ID: 109
+      ID: 122
       Name: crypto/x509/pkix.Extension
       ByteSize: 56
       GoRuntimeType: 1.635616e+06
@@ -1442,15 +1442,15 @@ Types:
       RawFields:
         - Name: Id
           Offset: 0
-          Type: 96 GoSliceHeaderType encoding/asn1.ObjectIdentifier
+          Type: 125 GoSliceHeaderType encoding/asn1.ObjectIdentifier
         - Name: Critical
           Offset: 24
           Type: 4 BaseType bool
         - Name: Value
           Offset: 32
-          Type: 77 GoSliceHeaderType []uint8
+          Type: 70 GoSliceHeaderType []uint8
     - __kind: StructureType
-      ID: 92
+      ID: 112
       Name: crypto/x509/pkix.Name
       ByteSize: 248
       GoRuntimeType: 2.176736e+06
@@ -1458,25 +1458,25 @@ Types:
       RawFields:
         - Name: Country
           Offset: 0
-          Type: 54 GoSliceHeaderType []string
+          Type: 53 GoSliceHeaderType []string
         - Name: Organization
           Offset: 24
-          Type: 54 GoSliceHeaderType []string
+          Type: 53 GoSliceHeaderType []string
         - Name: OrganizationalUnit
           Offset: 48
-          Type: 54 GoSliceHeaderType []string
+          Type: 53 GoSliceHeaderType []string
         - Name: Locality
           Offset: 72
-          Type: 54 GoSliceHeaderType []string
+          Type: 53 GoSliceHeaderType []string
         - Name: Province
           Offset: 96
-          Type: 54 GoSliceHeaderType []string
+          Type: 53 GoSliceHeaderType []string
         - Name: StreetAddress
           Offset: 120
-          Type: 54 GoSliceHeaderType []string
+          Type: 53 GoSliceHeaderType []string
         - Name: PostalCode
           Offset: 144
-          Type: 54 GoSliceHeaderType []string
+          Type: 53 GoSliceHeaderType []string
         - Name: SerialNumber
           Offset: 168
           Type: 9 GoStringHeaderType string
@@ -1485,12 +1485,12 @@ Types:
           Type: 9 GoStringHeaderType string
         - Name: Names
           Offset: 200
-          Type: 93 GoSliceHeaderType []crypto/x509/pkix.AttributeTypeAndValue
+          Type: 113 GoSliceHeaderType []crypto/x509/pkix.AttributeTypeAndValue
         - Name: ExtraNames
           Offset: 224
-          Type: 93 GoSliceHeaderType []crypto/x509/pkix.AttributeTypeAndValue
+          Type: 113 GoSliceHeaderType []crypto/x509/pkix.AttributeTypeAndValue
     - __kind: GoSliceHeaderType
-      ID: 96
+      ID: 125
       Name: encoding/asn1.ObjectIdentifier
       ByteSize: 24
       GoRuntimeType: 1.044128e+06
@@ -1505,9 +1505,9 @@ Types:
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 181 GoSliceDataType encoding/asn1.ObjectIdentifier.array
+      Data: 189 GoSliceDataType encoding/asn1.ObjectIdentifier.array
     - __kind: GoSliceDataType
-      ID: 181
+      ID: 189
       Name: encoding/asn1.ObjectIdentifier.array
       ByteSize: 2048
       Element: 7 BaseType int
@@ -1537,19 +1537,19 @@ Types:
       GoRuntimeType: 580384
       GoKind: 14
     - __kind: GoSubroutineType
-      ID: 56
+      ID: 52
       Name: func() (io.ReadCloser, error)
       ByteSize: 8
       GoRuntimeType: 687840
       GoKind: 19
     - __kind: GoSubroutineType
-      ID: 135
+      ID: 88
       Name: func(string, []uint8, int) ([]uint8, error)
       ByteSize: 8
       GoRuntimeType: 994848
       GoKind: 19
     - __kind: GoInterfaceType
-      ID: 160
+      ID: 41
       Name: gopkg.in/DataDog/dd-trace-go.v1/ddtrace.Span
       ByteSize: 16
       GoRuntimeType: 1.468864e+06
@@ -1562,47 +1562,47 @@ Types:
           Offset: 8
           Type: 15 VoidPointerType unsafe.Pointer
     - __kind: GoSwissMapGroupsType
-      ID: 67
+      ID: 104
       Name: groupReference<string,[]*mime/multipart.FileHeader>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 68 PointerType *noalg.map.group[string][]*mime/multipart.FileHeader
+          Type: 105 PointerType *noalg.map.group[string][]*mime/multipart.FileHeader
         - Name: lengthMask
           Offset: 8
           Type: 8 BaseType uint64
-      GroupType: 69 StructureType noalg.map.group[string][]*mime/multipart.FileHeader
-      GroupSliceType: 170 GoSliceDataType []noalg.map.group[string][]*mime/multipart.FileHeader.array
+      GroupType: 106 StructureType noalg.map.group[string][]*mime/multipart.FileHeader
+      GroupSliceType: 174 GoSliceDataType []noalg.map.group[string][]*mime/multipart.FileHeader.array
     - __kind: GoSwissMapGroupsType
-      ID: 49
+      ID: 94
       Name: groupReference<string,[]string>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 50 PointerType *noalg.map.group[string][]string
+          Type: 95 PointerType *noalg.map.group[string][]string
         - Name: lengthMask
           Offset: 8
           Type: 8 BaseType uint64
-      GroupType: 51 StructureType noalg.map.group[string][]string
+      GroupType: 96 StructureType noalg.map.group[string][]string
       GroupSliceType: 166 GoSliceDataType []noalg.map.group[string][]string.array
     - __kind: GoSwissMapGroupsType
-      ID: 152
+      ID: 99
       Name: groupReference<string,string>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 153 PointerType *noalg.map.group[string]string
+          Type: 100 PointerType *noalg.map.group[string]string
         - Name: lengthMask
           Offset: 8
           Type: 8 BaseType uint64
-      GroupType: 154 StructureType noalg.map.group[string]string
-      GroupSliceType: 214 GoSliceDataType []noalg.map.group[string]string.array
+      GroupType: 101 StructureType noalg.map.group[string]string
+      GroupSliceType: 170 GoSliceDataType []noalg.map.group[string]string.array
     - __kind: BaseType
       ID: 7
       Name: int
@@ -1634,7 +1634,7 @@ Types:
       GoRuntimeType: 579488
       GoKind: 3
     - __kind: GoEmptyInterfaceType
-      ID: 86
+      ID: 109
       Name: interface {}
       ByteSize: 16
       GoRuntimeType: 848672
@@ -1647,7 +1647,7 @@ Types:
           Offset: 8
           Type: 15 VoidPointerType unsafe.Pointer
     - __kind: GoInterfaceType
-      ID: 55
+      ID: 51
       Name: io.ReadCloser
       ByteSize: 16
       GoRuntimeType: 1.100576e+06
@@ -1660,7 +1660,7 @@ Types:
           Offset: 8
           Type: 15 VoidPointerType unsafe.Pointer
     - __kind: GoSwissMapHeaderType
-      ID: 63
+      ID: 78
       Name: map<string,[]*mime/multipart.FileHeader>
       ByteSize: 48
       GoKind: 25
@@ -1673,7 +1673,7 @@ Types:
           Type: 1 BaseType uintptr
         - Name: dirPtr
           Offset: 16
-          Type: 64 PointerType **table<string,[]*mime/multipart.FileHeader>
+          Type: 79 PointerType **table<string,[]*mime/multipart.FileHeader>
         - Name: dirLen
           Offset: 24
           Type: 7 BaseType int
@@ -1689,10 +1689,10 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 8 BaseType uint64
-      TablePtrSliceType: 169 GoSliceDataType []*table<string,[]*mime/multipart.FileHeader>.array
-      GroupType: 69 StructureType noalg.map.group[string][]*mime/multipart.FileHeader
+      TablePtrSliceType: 173 GoSliceDataType []*table<string,[]*mime/multipart.FileHeader>.array
+      GroupType: 106 StructureType noalg.map.group[string][]*mime/multipart.FileHeader
     - __kind: GoSwissMapHeaderType
-      ID: 45
+      ID: 48
       Name: map<string,[]string>
       ByteSize: 48
       GoKind: 25
@@ -1705,7 +1705,7 @@ Types:
           Type: 1 BaseType uintptr
         - Name: dirPtr
           Offset: 16
-          Type: 46 PointerType **table<string,[]string>
+          Type: 49 PointerType **table<string,[]string>
         - Name: dirLen
           Offset: 24
           Type: 7 BaseType int
@@ -1722,9 +1722,9 @@ Types:
           Offset: 40
           Type: 8 BaseType uint64
       TablePtrSliceType: 165 GoSliceDataType []*table<string,[]string>.array
-      GroupType: 51 StructureType noalg.map.group[string][]string
+      GroupType: 96 StructureType noalg.map.group[string][]string
     - __kind: GoSwissMapHeaderType
-      ID: 148
+      ID: 67
       Name: map<string,string>
       ByteSize: 48
       GoKind: 25
@@ -1737,7 +1737,7 @@ Types:
           Type: 1 BaseType uintptr
         - Name: dirPtr
           Offset: 16
-          Type: 149 PointerType **table<string,string>
+          Type: 68 PointerType **table<string,string>
         - Name: dirLen
           Offset: 24
           Type: 7 BaseType int
@@ -1753,31 +1753,31 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 8 BaseType uint64
-      TablePtrSliceType: 213 GoSliceDataType []*table<string,string>.array
-      GroupType: 154 StructureType noalg.map.group[string]string
+      TablePtrSliceType: 169 GoSliceDataType []*table<string,string>.array
+      GroupType: 101 StructureType noalg.map.group[string]string
     - __kind: GoMapType
-      ID: 61
+      ID: 76
       Name: map[string][]*mime/multipart.FileHeader
       ByteSize: 8
       GoRuntimeType: 1.122592e+06
       GoKind: 21
-      HeaderType: 63 GoSwissMapHeaderType map<string,[]*mime/multipart.FileHeader>
+      HeaderType: 78 GoSwissMapHeaderType map<string,[]*mime/multipart.FileHeader>
     - __kind: GoMapType
-      ID: 60
+      ID: 75
       Name: map[string][]string
       ByteSize: 8
       GoRuntimeType: 1.117984e+06
       GoKind: 21
-      HeaderType: 45 GoSwissMapHeaderType map<string,[]string>
+      HeaderType: 48 GoSwissMapHeaderType map<string,[]string>
     - __kind: GoMapType
-      ID: 146
+      ID: 65
       Name: map[string]string
       ByteSize: 8
       GoRuntimeType: 1.119008e+06
       GoKind: 21
-      HeaderType: 148 GoSwissMapHeaderType map<string,string>
+      HeaderType: 67 GoSwissMapHeaderType map<string,string>
     - __kind: StructureType
-      ID: 88
+      ID: 111
       Name: math/big.Int
       ByteSize: 32
       GoRuntimeType: 1.483264e+06
@@ -1788,15 +1788,15 @@ Types:
           Type: 4 BaseType bool
         - Name: abs
           Offset: 8
-          Type: 89 GoSliceHeaderType math/big.nat
+          Type: 150 GoSliceHeaderType math/big.nat
     - __kind: BaseType
-      ID: 91
+      ID: 152
       Name: math/big.Word
       ByteSize: 8
       GoRuntimeType: 583328
       GoKind: 7
     - __kind: GoSliceHeaderType
-      ID: 89
+      ID: 150
       Name: math/big.nat
       ByteSize: 24
       GoRuntimeType: 2.345504e+06
@@ -1804,21 +1804,21 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 90 PointerType *math/big.Word
+          Type: 151 PointerType *math/big.Word
         - Name: len
           Offset: 8
           Type: 7 BaseType int
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 177 GoSliceDataType math/big.nat.array
+      Data: 207 GoSliceDataType math/big.nat.array
     - __kind: GoSliceDataType
-      ID: 177
+      ID: 207
       Name: math/big.nat.array
       ByteSize: 2048
-      Element: 91 BaseType math/big.Word
+      Element: 152 BaseType math/big.Word
     - __kind: StructureType
-      ID: 75
+      ID: 160
       Name: mime/multipart.FileHeader
       ByteSize: 88
       GoRuntimeType: 1.962144e+06
@@ -1829,13 +1829,13 @@ Types:
           Type: 9 GoStringHeaderType string
         - Name: Header
           Offset: 16
-          Type: 76 GoMapType net/textproto.MIMEHeader
+          Type: 162 GoMapType net/textproto.MIMEHeader
         - Name: Size
           Offset: 24
           Type: 13 BaseType int64
         - Name: content
           Offset: 32
-          Type: 77 GoSliceHeaderType []uint8
+          Type: 70 GoSliceHeaderType []uint8
         - Name: tmpfile
           Offset: 56
           Type: 9 GoStringHeaderType string
@@ -1846,7 +1846,7 @@ Types:
           Offset: 80
           Type: 4 BaseType bool
     - __kind: StructureType
-      ID: 59
+      ID: 56
       Name: mime/multipart.Form
       ByteSize: 16
       GoRuntimeType: 1.467264e+06
@@ -1854,12 +1854,12 @@ Types:
       RawFields:
         - Name: Value
           Offset: 0
-          Type: 60 GoMapType map[string][]string
+          Type: 75 GoMapType map[string][]string
         - Name: File
           Offset: 8
-          Type: 61 GoMapType map[string][]*mime/multipart.FileHeader
+          Type: 76 GoMapType map[string][]*mime/multipart.FileHeader
     - __kind: GoSliceHeaderType
-      ID: 117
+      ID: 131
       Name: net.IP
       ByteSize: 24
       GoRuntimeType: 2.109184e+06
@@ -1881,7 +1881,7 @@ Types:
       ByteSize: 2048
       Element: 3 BaseType uint8
     - __kind: GoSliceHeaderType
-      ID: 124
+      ID: 161
       Name: net.IPMask
       ByteSize: 24
       GoRuntimeType: 1.01072e+06
@@ -1896,14 +1896,14 @@ Types:
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 201 GoSliceDataType net.IPMask.array
+      Data: 213 GoSliceDataType net.IPMask.array
     - __kind: GoSliceDataType
-      ID: 201
+      ID: 213
       Name: net.IPMask.array
       ByteSize: 2048
       Element: 3 BaseType uint8
     - __kind: StructureType
-      ID: 123
+      ID: 159
       Name: net.IPNet
       ByteSize: 48
       GoRuntimeType: 1.448704e+06
@@ -1911,17 +1911,17 @@ Types:
       RawFields:
         - Name: IP
           Offset: 0
-          Type: 117 GoSliceHeaderType net.IP
+          Type: 131 GoSliceHeaderType net.IP
         - Name: Mask
           Offset: 24
-          Type: 124 GoSliceHeaderType net.IPMask
+          Type: 161 GoSliceHeaderType net.IPMask
     - __kind: GoMapType
-      ID: 43
+      ID: 46
       Name: net/http.Header
       ByteSize: 8
       GoRuntimeType: 2.08736e+06
       GoKind: 21
-      HeaderType: 45 GoSwissMapHeaderType map<string,[]string>
+      HeaderType: 48 GoSwissMapHeaderType map<string,[]string>
     - __kind: StructureType
       ID: 38
       Name: net/http.Request
@@ -1934,7 +1934,7 @@ Types:
           Type: 9 GoStringHeaderType string
         - Name: URL
           Offset: 16
-          Type: 39 PointerType *net/url.URL
+          Type: 44 PointerType *net/url.URL
         - Name: Proto
           Offset: 24
           Type: 9 GoStringHeaderType string
@@ -1946,19 +1946,19 @@ Types:
           Type: 7 BaseType int
         - Name: Header
           Offset: 56
-          Type: 43 GoMapType net/http.Header
+          Type: 46 GoMapType net/http.Header
         - Name: Body
           Offset: 64
-          Type: 55 GoInterfaceType io.ReadCloser
+          Type: 51 GoInterfaceType io.ReadCloser
         - Name: GetBody
           Offset: 80
-          Type: 56 GoSubroutineType func() (io.ReadCloser, error)
+          Type: 52 GoSubroutineType func() (io.ReadCloser, error)
         - Name: ContentLength
           Offset: 88
           Type: 13 BaseType int64
         - Name: TransferEncoding
           Offset: 96
-          Type: 54 GoSliceHeaderType []string
+          Type: 53 GoSliceHeaderType []string
         - Name: Close
           Offset: 120
           Type: 4 BaseType bool
@@ -1967,16 +1967,16 @@ Types:
           Type: 9 GoStringHeaderType string
         - Name: Form
           Offset: 144
-          Type: 57 GoMapType net/url.Values
+          Type: 54 GoMapType net/url.Values
         - Name: PostForm
           Offset: 152
-          Type: 57 GoMapType net/url.Values
+          Type: 54 GoMapType net/url.Values
         - Name: MultipartForm
           Offset: 160
-          Type: 58 PointerType *mime/multipart.Form
+          Type: 55 PointerType *mime/multipart.Form
         - Name: Trailer
           Offset: 168
-          Type: 43 GoMapType net/http.Header
+          Type: 46 GoMapType net/http.Header
         - Name: RemoteAddr
           Offset: 176
           Type: 9 GoStringHeaderType string
@@ -1985,30 +1985,30 @@ Types:
           Type: 9 GoStringHeaderType string
         - Name: TLS
           Offset: 208
-          Type: 78 PointerType *crypto/tls.ConnectionState
+          Type: 57 PointerType *crypto/tls.ConnectionState
         - Name: Cancel
           Offset: 216
-          Type: 137 GoChannelType <-chan struct {}
+          Type: 59 GoChannelType <-chan struct {}
         - Name: Response
           Offset: 224
-          Type: 138 PointerType *net/http.Response
+          Type: 60 PointerType *net/http.Response
         - Name: Pattern
           Offset: 232
           Type: 9 GoStringHeaderType string
         - Name: ctx
           Offset: 248
-          Type: 140 GoInterfaceType context.Context
+          Type: 62 GoInterfaceType context.Context
         - Name: pat
           Offset: 264
-          Type: 141 PointerType *net/http.pattern
+          Type: 63 PointerType *net/http.pattern
         - Name: matches
           Offset: 272
-          Type: 54 GoSliceHeaderType []string
+          Type: 53 GoSliceHeaderType []string
         - Name: otherValues
           Offset: 296
-          Type: 146 GoMapType map[string]string
+          Type: 65 GoMapType map[string]string
     - __kind: StructureType
-      ID: 139
+      ID: 61
       Name: net/http.Response
       ByteSize: 144
       GoRuntimeType: 2.19504e+06
@@ -2031,16 +2031,16 @@ Types:
           Type: 7 BaseType int
         - Name: Header
           Offset: 56
-          Type: 43 GoMapType net/http.Header
+          Type: 46 GoMapType net/http.Header
         - Name: Body
           Offset: 64
-          Type: 55 GoInterfaceType io.ReadCloser
+          Type: 51 GoInterfaceType io.ReadCloser
         - Name: ContentLength
           Offset: 80
           Type: 13 BaseType int64
         - Name: TransferEncoding
           Offset: 88
-          Type: 54 GoSliceHeaderType []string
+          Type: 53 GoSliceHeaderType []string
         - Name: Close
           Offset: 112
           Type: 4 BaseType bool
@@ -2049,13 +2049,13 @@ Types:
           Type: 4 BaseType bool
         - Name: Trailer
           Offset: 120
-          Type: 43 GoMapType net/http.Header
+          Type: 46 GoMapType net/http.Header
         - Name: Request
           Offset: 128
           Type: 37 PointerType *net/http.Request
         - Name: TLS
           Offset: 136
-          Type: 78 PointerType *crypto/tls.ConnectionState
+          Type: 57 PointerType *crypto/tls.ConnectionState
     - __kind: GoInterfaceType
       ID: 36
       Name: net/http.ResponseWriter
@@ -2070,7 +2070,7 @@ Types:
           Offset: 8
           Type: 15 VoidPointerType unsafe.Pointer
     - __kind: StructureType
-      ID: 142
+      ID: 64
       Name: net/http.pattern
       ByteSize: 88
       GoRuntimeType: 1.818112e+06
@@ -2087,12 +2087,12 @@ Types:
           Type: 9 GoStringHeaderType string
         - Name: segments
           Offset: 48
-          Type: 143 GoSliceHeaderType []net/http.segment
+          Type: 90 GoSliceHeaderType []net/http.segment
         - Name: loc
           Offset: 72
           Type: 9 GoStringHeaderType string
     - __kind: StructureType
-      ID: 145
+      ID: 92
       Name: net/http.segment
       ByteSize: 24
       GoRuntimeType: 1.597216e+06
@@ -2108,14 +2108,14 @@ Types:
           Offset: 17
           Type: 4 BaseType bool
     - __kind: GoMapType
-      ID: 76
+      ID: 162
       Name: net/textproto.MIMEHeader
       ByteSize: 8
       GoRuntimeType: 1.808288e+06
       GoKind: 21
-      HeaderType: 45 GoSwissMapHeaderType map<string,[]string>
+      HeaderType: 48 GoSwissMapHeaderType map<string,[]string>
     - __kind: StructureType
-      ID: 40
+      ID: 45
       Name: net/url.URL
       ByteSize: 144
       GoRuntimeType: 2.112256e+06
@@ -2129,7 +2129,7 @@ Types:
           Type: 9 GoStringHeaderType string
         - Name: User
           Offset: 32
-          Type: 41 PointerType *net/url.Userinfo
+          Type: 72 PointerType *net/url.Userinfo
         - Name: Host
           Offset: 40
           Type: 9 GoStringHeaderType string
@@ -2155,7 +2155,7 @@ Types:
           Offset: 128
           Type: 9 GoStringHeaderType string
     - __kind: StructureType
-      ID: 42
+      ID: 73
       Name: net/url.Userinfo
       ByteSize: 40
       GoRuntimeType: 1.613536e+06
@@ -2171,41 +2171,41 @@ Types:
           Offset: 32
           Type: 4 BaseType bool
     - __kind: GoMapType
-      ID: 57
+      ID: 54
       Name: net/url.Values
       ByteSize: 8
       GoRuntimeType: 1.870528e+06
       GoKind: 21
-      HeaderType: 45 GoSwissMapHeaderType map<string,[]string>
+      HeaderType: 48 GoSwissMapHeaderType map<string,[]string>
     - __kind: ArrayType
-      ID: 70
+      ID: 145
       Name: noalg.[8]struct { key string; elem []*mime/multipart.FileHeader }
       ByteSize: 320
       GoRuntimeType: 693888
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 71 StructureType noalg.struct { key string; elem []*mime/multipart.FileHeader }
+      Element: 146 StructureType noalg.struct { key string; elem []*mime/multipart.FileHeader }
     - __kind: ArrayType
-      ID: 52
+      ID: 102
       Name: noalg.[8]struct { key string; elem []string }
       ByteSize: 320
       GoRuntimeType: 683872
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 53 StructureType noalg.struct { key string; elem []string }
+      Element: 103 StructureType noalg.struct { key string; elem []string }
     - __kind: ArrayType
-      ID: 155
+      ID: 143
       Name: noalg.[8]struct { key string; elem string }
       ByteSize: 256
       GoRuntimeType: 688032
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 156 StructureType noalg.struct { key string; elem string }
+      Element: 144 StructureType noalg.struct { key string; elem string }
     - __kind: StructureType
-      ID: 69
+      ID: 106
       Name: noalg.map.group[string][]*mime/multipart.FileHeader
       ByteSize: 328
       GoRuntimeType: 1.289824e+06
@@ -2216,9 +2216,9 @@ Types:
           Type: 8 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 70 ArrayType noalg.[8]struct { key string; elem []*mime/multipart.FileHeader }
+          Type: 145 ArrayType noalg.[8]struct { key string; elem []*mime/multipart.FileHeader }
     - __kind: StructureType
-      ID: 51
+      ID: 96
       Name: noalg.map.group[string][]string
       ByteSize: 328
       GoRuntimeType: 1.280352e+06
@@ -2229,9 +2229,9 @@ Types:
           Type: 8 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 52 ArrayType noalg.[8]struct { key string; elem []string }
+          Type: 102 ArrayType noalg.[8]struct { key string; elem []string }
     - __kind: StructureType
-      ID: 154
+      ID: 101
       Name: noalg.map.group[string]string
       ByteSize: 264
       GoRuntimeType: 1.282656e+06
@@ -2242,9 +2242,9 @@ Types:
           Type: 8 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 155 ArrayType noalg.[8]struct { key string; elem string }
+          Type: 143 ArrayType noalg.[8]struct { key string; elem string }
     - __kind: StructureType
-      ID: 71
+      ID: 146
       Name: noalg.struct { key string; elem []*mime/multipart.FileHeader }
       ByteSize: 40
       GoRuntimeType: 1.289696e+06
@@ -2255,9 +2255,9 @@ Types:
           Type: 9 GoStringHeaderType string
         - Name: elem
           Offset: 16
-          Type: 72 GoSliceHeaderType []*mime/multipart.FileHeader
+          Type: 147 GoSliceHeaderType []*mime/multipart.FileHeader
     - __kind: StructureType
-      ID: 53
+      ID: 103
       Name: noalg.struct { key string; elem []string }
       ByteSize: 40
       GoRuntimeType: 1.280224e+06
@@ -2268,9 +2268,9 @@ Types:
           Type: 9 GoStringHeaderType string
         - Name: elem
           Offset: 16
-          Type: 54 GoSliceHeaderType []string
+          Type: 53 GoSliceHeaderType []string
     - __kind: StructureType
-      ID: 156
+      ID: 144
       Name: noalg.struct { key string; elem string }
       ByteSize: 32
       GoRuntimeType: 1.282528e+06
@@ -2301,7 +2301,7 @@ Types:
       Name: string.str
       ByteSize: 2048
     - __kind: StructureType
-      ID: 66
+      ID: 97
       Name: table<string,[]*mime/multipart.FileHeader>
       ByteSize: 32
       GoKind: 25
@@ -2323,9 +2323,9 @@ Types:
           Type: 7 BaseType int
         - Name: groups
           Offset: 16
-          Type: 67 GoSwissMapGroupsType groupReference<string,[]*mime/multipart.FileHeader>
+          Type: 104 GoSwissMapGroupsType groupReference<string,[]*mime/multipart.FileHeader>
     - __kind: StructureType
-      ID: 48
+      ID: 74
       Name: table<string,[]string>
       ByteSize: 32
       GoKind: 25
@@ -2347,9 +2347,9 @@ Types:
           Type: 7 BaseType int
         - Name: groups
           Offset: 16
-          Type: 49 GoSwissMapGroupsType groupReference<string,[]string>
+          Type: 94 GoSwissMapGroupsType groupReference<string,[]string>
     - __kind: StructureType
-      ID: 151
+      ID: 93
       Name: table<string,string>
       ByteSize: 32
       GoKind: 25
@@ -2371,9 +2371,9 @@ Types:
           Type: 7 BaseType int
         - Name: groups
           Offset: 16
-          Type: 152 GoSwissMapGroupsType groupReference<string,string>
+          Type: 99 GoSwissMapGroupsType groupReference<string,string>
     - __kind: StructureType
-      ID: 99
+      ID: 118
       Name: time.Location
       ByteSize: 104
       GoRuntimeType: 1.957824e+06
@@ -2384,10 +2384,10 @@ Types:
           Type: 9 GoStringHeaderType string
         - Name: zone
           Offset: 16
-          Type: 100 GoSliceHeaderType []time.zone
+          Type: 153 GoSliceHeaderType []time.zone
         - Name: tx
           Offset: 40
-          Type: 103 GoSliceHeaderType []time.zoneTrans
+          Type: 156 GoSliceHeaderType []time.zoneTrans
         - Name: extend
           Offset: 64
           Type: 9 GoStringHeaderType string
@@ -2399,9 +2399,9 @@ Types:
           Type: 13 BaseType int64
         - Name: cacheZone
           Offset: 96
-          Type: 101 PointerType *time.zone
+          Type: 154 PointerType *time.zone
     - __kind: StructureType
-      ID: 97
+      ID: 116
       Name: time.Time
       ByteSize: 24
       GoRuntimeType: 2.34832e+06
@@ -2415,9 +2415,9 @@ Types:
           Type: 13 BaseType int64
         - Name: loc
           Offset: 16
-          Type: 98 PointerType *time.Location
+          Type: 117 PointerType *time.Location
     - __kind: StructureType
-      ID: 102
+      ID: 155
       Name: time.zone
       ByteSize: 32
       GoRuntimeType: 1.602208e+06
@@ -2433,7 +2433,7 @@ Types:
           Offset: 24
           Type: 4 BaseType bool
     - __kind: StructureType
-      ID: 105
+      ID: 158
       Name: time.zoneTrans
       ByteSize: 16
       GoRuntimeType: 1.736576e+06

--- a/pkg/dyninst/irgen/testdata/snapshot/rc_tester_v1.arch=arm64,toolchain=go1.24.3.yaml
+++ b/pkg/dyninst/irgen/testdata/snapshot/rc_tester_v1.arch=arm64,toolchain=go1.24.3.yaml
@@ -10,7 +10,7 @@ Probes:
       subprogram: {subprogram: 1}
       events:
         - ID: 1
-          Type: 221 EventRootType Probe[main.HandleHTTP]
+          Type: 215 EventRootType Probe[main.HandleHTTP]
           InjectionPoints: [{PC: "0x86c110", Frameless: true}]
           Condition: null
     - id: look_at_the_request
@@ -23,7 +23,7 @@ Probes:
       subprogram: {subprogram: 2}
       events:
         - ID: 2
-          Type: 222 EventRootType Probe[main.LookAtTheRequest]
+          Type: 216 EventRootType Probe[main.LookAtTheRequest]
           InjectionPoints: [{PC: "0x86c41c", Frameless: true}]
           Condition: null
 Subprograms:
@@ -382,7 +382,7 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 17 BaseType uint64
-      TablePtrSliceType: 177 GoSliceDataType []*table<string,[]string>.array
+      TablePtrSliceType: 165 GoSliceDataType []*table<string,[]string>.array
       GroupType: 25 StructureType noalg.map.group[string][]string
     - __kind: BaseType
       ID: 17
@@ -449,7 +449,7 @@ Types:
           Offset: 8
           Type: 17 BaseType uint64
       GroupType: 25 StructureType noalg.map.group[string][]string
-      GroupSliceType: 178 GoSliceDataType []noalg.map.group[string][]string.array
+      GroupSliceType: 166 GoSliceDataType []noalg.map.group[string][]string.array
     - __kind: PointerType
       ID: 24
       Name: '*noalg.map.group[string][]string'
@@ -615,7 +615,7 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 17 BaseType uint64
-      TablePtrSliceType: 173 GoSliceDataType []*table<string,[]*mime/multipart.FileHeader>.array
+      TablePtrSliceType: 169 GoSliceDataType []*table<string,[]*mime/multipart.FileHeader>.array
       GroupType: 45 StructureType noalg.map.group[string][]*mime/multipart.FileHeader
     - __kind: PointerType
       ID: 40
@@ -664,7 +664,7 @@ Types:
           Offset: 8
           Type: 17 BaseType uint64
       GroupType: 45 StructureType noalg.map.group[string][]*mime/multipart.FileHeader
-      GroupSliceType: 174 GoSliceDataType []noalg.map.group[string][]*mime/multipart.FileHeader.array
+      GroupSliceType: 170 GoSliceDataType []noalg.map.group[string][]*mime/multipart.FileHeader.array
     - __kind: PointerType
       ID: 44
       Name: '*noalg.map.group[string][]*mime/multipart.FileHeader'
@@ -721,7 +721,7 @@ Types:
         - Name: cap
           Offset: 16
           Type: 8 BaseType int
-      Data: 175 GoSliceDataType []*mime/multipart.FileHeader.array
+      Data: 171 GoSliceDataType []*mime/multipart.FileHeader.array
     - __kind: PointerType
       ID: 49
       Name: '**mime/multipart.FileHeader'
@@ -786,7 +786,7 @@ Types:
         - Name: cap
           Offset: 16
           Type: 8 BaseType int
-      Data: 179 GoSliceDataType []uint8.array
+      Data: 173 GoSliceDataType []uint8.array
     - __kind: PointerType
       ID: 54
       Name: '*crypto/tls.ConnectionState'
@@ -865,7 +865,7 @@ Types:
         - Name: cap
           Offset: 16
           Type: 8 BaseType int
-      Data: 181 GoSliceDataType []*crypto/x509.Certificate.array
+      Data: 175 GoSliceDataType []*crypto/x509.Certificate.array
     - __kind: PointerType
       ID: 57
       Name: '**crypto/x509.Certificate'
@@ -1103,7 +1103,7 @@ Types:
         - Name: cap
           Offset: 16
           Type: 8 BaseType int
-      Data: 183 GoSliceDataType math/big.nat.array
+      Data: 177 GoSliceDataType math/big.nat.array
     - __kind: PointerType
       ID: 66
       Name: '*math/big.Word'
@@ -1173,7 +1173,7 @@ Types:
         - Name: cap
           Offset: 16
           Type: 8 BaseType int
-      Data: 185 GoSliceDataType []crypto/x509/pkix.AttributeTypeAndValue.array
+      Data: 179 GoSliceDataType []crypto/x509/pkix.AttributeTypeAndValue.array
     - __kind: PointerType
       ID: 70
       Name: '*crypto/x509/pkix.AttributeTypeAndValue'
@@ -1210,7 +1210,7 @@ Types:
         - Name: cap
           Offset: 16
           Type: 8 BaseType int
-      Data: 187 GoSliceDataType encoding/asn1.ObjectIdentifier.array
+      Data: 181 GoSliceDataType encoding/asn1.ObjectIdentifier.array
     - __kind: PointerType
       ID: 73
       Name: '*int'
@@ -1285,7 +1285,7 @@ Types:
         - Name: cap
           Offset: 16
           Type: 8 BaseType int
-      Data: 189 GoSliceDataType []time.zone.array
+      Data: 183 GoSliceDataType []time.zone.array
     - __kind: PointerType
       ID: 78
       Name: '*time.zone'
@@ -1325,7 +1325,7 @@ Types:
         - Name: cap
           Offset: 16
           Type: 8 BaseType int
-      Data: 191 GoSliceDataType []time.zoneTrans.array
+      Data: 185 GoSliceDataType []time.zoneTrans.array
     - __kind: PointerType
       ID: 81
       Name: '*time.zoneTrans'
@@ -1374,7 +1374,7 @@ Types:
         - Name: cap
           Offset: 16
           Type: 8 BaseType int
-      Data: 193 GoSliceDataType []crypto/x509/pkix.Extension.array
+      Data: 187 GoSliceDataType []crypto/x509/pkix.Extension.array
     - __kind: PointerType
       ID: 85
       Name: '*crypto/x509/pkix.Extension'
@@ -1414,7 +1414,7 @@ Types:
         - Name: cap
           Offset: 16
           Type: 8 BaseType int
-      Data: 195 GoSliceDataType []encoding/asn1.ObjectIdentifier.array
+      Data: 189 GoSliceDataType []encoding/asn1.ObjectIdentifier.array
     - __kind: PointerType
       ID: 88
       Name: '*encoding/asn1.ObjectIdentifier'
@@ -1438,7 +1438,7 @@ Types:
         - Name: cap
           Offset: 16
           Type: 8 BaseType int
-      Data: 197 GoSliceDataType []crypto/x509.ExtKeyUsage.array
+      Data: 191 GoSliceDataType []crypto/x509.ExtKeyUsage.array
     - __kind: PointerType
       ID: 90
       Name: '*crypto/x509.ExtKeyUsage'
@@ -1468,7 +1468,7 @@ Types:
         - Name: cap
           Offset: 16
           Type: 8 BaseType int
-      Data: 199 GoSliceDataType []net.IP.array
+      Data: 193 GoSliceDataType []net.IP.array
     - __kind: PointerType
       ID: 93
       Name: '*net.IP'
@@ -1492,7 +1492,7 @@ Types:
         - Name: cap
           Offset: 16
           Type: 8 BaseType int
-      Data: 201 GoSliceDataType net.IP.array
+      Data: 195 GoSliceDataType net.IP.array
     - __kind: GoSliceHeaderType
       ID: 95
       Name: '[]*net/url.URL'
@@ -1509,7 +1509,7 @@ Types:
         - Name: cap
           Offset: 16
           Type: 8 BaseType int
-      Data: 203 GoSliceDataType []*net/url.URL.array
+      Data: 197 GoSliceDataType []*net/url.URL.array
     - __kind: PointerType
       ID: 96
       Name: '**net/url.URL'
@@ -1531,7 +1531,7 @@ Types:
         - Name: cap
           Offset: 16
           Type: 8 BaseType int
-      Data: 205 GoSliceDataType []*net.IPNet.array
+      Data: 199 GoSliceDataType []*net.IPNet.array
     - __kind: PointerType
       ID: 98
       Name: '**net.IPNet'
@@ -1574,7 +1574,7 @@ Types:
         - Name: cap
           Offset: 16
           Type: 8 BaseType int
-      Data: 207 GoSliceDataType net.IPMask.array
+      Data: 201 GoSliceDataType net.IPMask.array
     - __kind: GoSliceHeaderType
       ID: 102
       Name: '[]crypto/x509.OID'
@@ -1591,7 +1591,7 @@ Types:
         - Name: cap
           Offset: 16
           Type: 8 BaseType int
-      Data: 209 GoSliceDataType []crypto/x509.OID.array
+      Data: 203 GoSliceDataType []crypto/x509.OID.array
     - __kind: PointerType
       ID: 103
       Name: '*crypto/x509.OID'
@@ -1625,7 +1625,7 @@ Types:
         - Name: cap
           Offset: 16
           Type: 8 BaseType int
-      Data: 211 GoSliceDataType []crypto/x509.PolicyMapping.array
+      Data: 205 GoSliceDataType []crypto/x509.PolicyMapping.array
     - __kind: PointerType
       ID: 106
       Name: '*crypto/x509.PolicyMapping'
@@ -1662,7 +1662,7 @@ Types:
         - Name: cap
           Offset: 16
           Type: 8 BaseType int
-      Data: 213 GoSliceDataType [][]*crypto/x509.Certificate.array
+      Data: 207 GoSliceDataType [][]*crypto/x509.Certificate.array
     - __kind: PointerType
       ID: 109
       Name: '*[]*crypto/x509.Certificate'
@@ -1685,7 +1685,7 @@ Types:
         - Name: cap
           Offset: 16
           Type: 8 BaseType int
-      Data: 215 GoSliceDataType [][]uint8.array
+      Data: 209 GoSliceDataType [][]uint8.array
     - __kind: PointerType
       ID: 111
       Name: '*[]uint8'
@@ -1824,7 +1824,7 @@ Types:
         - Name: cap
           Offset: 16
           Type: 8 BaseType int
-      Data: 217 GoSliceDataType []net/http.segment.array
+      Data: 211 GoSliceDataType []net/http.segment.array
     - __kind: PointerType
       ID: 121
       Name: '*net/http.segment'
@@ -1890,7 +1890,7 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 17 BaseType uint64
-      TablePtrSliceType: 219 GoSliceDataType []*table<string,string>.array
+      TablePtrSliceType: 213 GoSliceDataType []*table<string,string>.array
       GroupType: 131 StructureType noalg.map.group[string]string
     - __kind: PointerType
       ID: 126
@@ -1939,7 +1939,7 @@ Types:
           Offset: 8
           Type: 17 BaseType uint64
       GroupType: 131 StructureType noalg.map.group[string]string
-      GroupSliceType: 220 GoSliceDataType []noalg.map.group[string]string.array
+      GroupSliceType: 214 GoSliceDataType []noalg.map.group[string]string.array
     - __kind: PointerType
       ID: 130
       Name: '*noalg.map.group[string]string'
@@ -2226,266 +2226,236 @@ Types:
       Pointee: 167 GoSliceDataType []string.array
     - __kind: GoSliceDataType
       ID: 169
-      Name: '[]*table<string,[]string>.array'
-      ByteSize: 8192
-      Element: 20 PointerType *table<string,[]string>
-    - __kind: GoSliceDataType
-      ID: 170
-      Name: '[]noalg.map.group[string][]string.array'
-      ByteSize: 2048
-      Element: 25 StructureType noalg.map.group[string][]string
-    - __kind: GoSliceDataType
-      ID: 171
-      Name: '[]*table<string,[]string>.array'
-      ByteSize: 8192
-      Element: 20 PointerType *table<string,[]string>
-    - __kind: GoSliceDataType
-      ID: 172
-      Name: '[]noalg.map.group[string][]string.array'
-      ByteSize: 2048
-      Element: 25 StructureType noalg.map.group[string][]string
-    - __kind: GoSliceDataType
-      ID: 173
       Name: '[]*table<string,[]*mime/multipart.FileHeader>.array'
       ByteSize: 8192
       Element: 41 PointerType *table<string,[]*mime/multipart.FileHeader>
     - __kind: GoSliceDataType
-      ID: 174
+      ID: 170
       Name: '[]noalg.map.group[string][]*mime/multipart.FileHeader.array'
       ByteSize: 2048
       Element: 45 StructureType noalg.map.group[string][]*mime/multipart.FileHeader
     - __kind: GoSliceDataType
-      ID: 175
+      ID: 171
       Name: '[]*mime/multipart.FileHeader.array'
       ByteSize: 2048
       Element: 50 PointerType *mime/multipart.FileHeader
     - __kind: PointerType
-      ID: 176
+      ID: 172
       Name: '*[]*mime/multipart.FileHeader.array'
       ByteSize: 8
-      Pointee: 175 GoSliceDataType []*mime/multipart.FileHeader.array
+      Pointee: 171 GoSliceDataType []*mime/multipart.FileHeader.array
     - __kind: GoSliceDataType
-      ID: 177
-      Name: '[]*table<string,[]string>.array'
-      ByteSize: 8192
-      Element: 20 PointerType *table<string,[]string>
-    - __kind: GoSliceDataType
-      ID: 178
-      Name: '[]noalg.map.group[string][]string.array'
-      ByteSize: 2048
-      Element: 25 StructureType noalg.map.group[string][]string
-    - __kind: GoSliceDataType
-      ID: 179
+      ID: 173
       Name: '[]uint8.array'
       ByteSize: 2048
       Element: 7 BaseType uint8
     - __kind: PointerType
-      ID: 180
+      ID: 174
       Name: '*[]uint8.array'
       ByteSize: 8
-      Pointee: 179 GoSliceDataType []uint8.array
+      Pointee: 173 GoSliceDataType []uint8.array
     - __kind: GoSliceDataType
-      ID: 181
+      ID: 175
       Name: '[]*crypto/x509.Certificate.array'
       ByteSize: 2048
       Element: 58 PointerType *crypto/x509.Certificate
     - __kind: PointerType
-      ID: 182
+      ID: 176
       Name: '*[]*crypto/x509.Certificate.array'
       ByteSize: 8
-      Pointee: 181 GoSliceDataType []*crypto/x509.Certificate.array
+      Pointee: 175 GoSliceDataType []*crypto/x509.Certificate.array
     - __kind: GoSliceDataType
-      ID: 183
+      ID: 177
       Name: math/big.nat.array
       ByteSize: 2048
       Element: 67 BaseType math/big.Word
     - __kind: PointerType
-      ID: 184
+      ID: 178
       Name: '*math/big.nat.array'
       ByteSize: 8
-      Pointee: 183 GoSliceDataType math/big.nat.array
+      Pointee: 177 GoSliceDataType math/big.nat.array
     - __kind: GoSliceDataType
-      ID: 185
+      ID: 179
       Name: '[]crypto/x509/pkix.AttributeTypeAndValue.array'
       ByteSize: 2048
       Element: 71 StructureType crypto/x509/pkix.AttributeTypeAndValue
     - __kind: PointerType
-      ID: 186
+      ID: 180
       Name: '*[]crypto/x509/pkix.AttributeTypeAndValue.array'
       ByteSize: 8
-      Pointee: 185 GoSliceDataType []crypto/x509/pkix.AttributeTypeAndValue.array
+      Pointee: 179 GoSliceDataType []crypto/x509/pkix.AttributeTypeAndValue.array
     - __kind: GoSliceDataType
-      ID: 187
+      ID: 181
       Name: encoding/asn1.ObjectIdentifier.array
       ByteSize: 2048
       Element: 8 BaseType int
     - __kind: PointerType
-      ID: 188
+      ID: 182
       Name: '*encoding/asn1.ObjectIdentifier.array'
       ByteSize: 8
-      Pointee: 187 GoSliceDataType encoding/asn1.ObjectIdentifier.array
+      Pointee: 181 GoSliceDataType encoding/asn1.ObjectIdentifier.array
     - __kind: GoSliceDataType
-      ID: 189
+      ID: 183
       Name: '[]time.zone.array'
       ByteSize: 2048
       Element: 79 StructureType time.zone
     - __kind: PointerType
-      ID: 190
+      ID: 184
       Name: '*[]time.zone.array'
       ByteSize: 8
-      Pointee: 189 GoSliceDataType []time.zone.array
+      Pointee: 183 GoSliceDataType []time.zone.array
     - __kind: GoSliceDataType
-      ID: 191
+      ID: 185
       Name: '[]time.zoneTrans.array'
       ByteSize: 2048
       Element: 82 StructureType time.zoneTrans
     - __kind: PointerType
-      ID: 192
+      ID: 186
       Name: '*[]time.zoneTrans.array'
       ByteSize: 8
-      Pointee: 191 GoSliceDataType []time.zoneTrans.array
+      Pointee: 185 GoSliceDataType []time.zoneTrans.array
     - __kind: GoSliceDataType
-      ID: 193
+      ID: 187
       Name: '[]crypto/x509/pkix.Extension.array'
       ByteSize: 2048
       Element: 86 StructureType crypto/x509/pkix.Extension
     - __kind: PointerType
-      ID: 194
+      ID: 188
       Name: '*[]crypto/x509/pkix.Extension.array'
       ByteSize: 8
-      Pointee: 193 GoSliceDataType []crypto/x509/pkix.Extension.array
+      Pointee: 187 GoSliceDataType []crypto/x509/pkix.Extension.array
     - __kind: GoSliceDataType
-      ID: 195
+      ID: 189
       Name: '[]encoding/asn1.ObjectIdentifier.array'
       ByteSize: 2048
       Element: 72 GoSliceHeaderType encoding/asn1.ObjectIdentifier
     - __kind: PointerType
-      ID: 196
+      ID: 190
       Name: '*[]encoding/asn1.ObjectIdentifier.array'
       ByteSize: 8
-      Pointee: 195 GoSliceDataType []encoding/asn1.ObjectIdentifier.array
+      Pointee: 189 GoSliceDataType []encoding/asn1.ObjectIdentifier.array
     - __kind: GoSliceDataType
-      ID: 197
+      ID: 191
       Name: '[]crypto/x509.ExtKeyUsage.array'
       ByteSize: 2048
       Element: 91 BaseType crypto/x509.ExtKeyUsage
     - __kind: PointerType
-      ID: 198
+      ID: 192
       Name: '*[]crypto/x509.ExtKeyUsage.array'
       ByteSize: 8
-      Pointee: 197 GoSliceDataType []crypto/x509.ExtKeyUsage.array
+      Pointee: 191 GoSliceDataType []crypto/x509.ExtKeyUsage.array
     - __kind: GoSliceDataType
-      ID: 199
+      ID: 193
       Name: '[]net.IP.array'
       ByteSize: 2048
       Element: 94 GoSliceHeaderType net.IP
     - __kind: PointerType
-      ID: 200
+      ID: 194
       Name: '*[]net.IP.array'
       ByteSize: 8
-      Pointee: 199 GoSliceDataType []net.IP.array
+      Pointee: 193 GoSliceDataType []net.IP.array
     - __kind: GoSliceDataType
-      ID: 201
+      ID: 195
       Name: net.IP.array
       ByteSize: 2048
       Element: 7 BaseType uint8
     - __kind: PointerType
-      ID: 202
+      ID: 196
       Name: '*net.IP.array'
       ByteSize: 8
-      Pointee: 201 GoSliceDataType net.IP.array
+      Pointee: 195 GoSliceDataType net.IP.array
     - __kind: GoSliceDataType
-      ID: 203
+      ID: 197
       Name: '[]*net/url.URL.array'
       ByteSize: 2048
       Element: 9 PointerType *net/url.URL
     - __kind: PointerType
-      ID: 204
+      ID: 198
       Name: '*[]*net/url.URL.array'
       ByteSize: 8
-      Pointee: 203 GoSliceDataType []*net/url.URL.array
+      Pointee: 197 GoSliceDataType []*net/url.URL.array
     - __kind: GoSliceDataType
-      ID: 205
+      ID: 199
       Name: '[]*net.IPNet.array'
       ByteSize: 2048
       Element: 99 PointerType *net.IPNet
     - __kind: PointerType
-      ID: 206
+      ID: 200
       Name: '*[]*net.IPNet.array'
       ByteSize: 8
-      Pointee: 205 GoSliceDataType []*net.IPNet.array
+      Pointee: 199 GoSliceDataType []*net.IPNet.array
     - __kind: GoSliceDataType
-      ID: 207
+      ID: 201
       Name: net.IPMask.array
       ByteSize: 2048
       Element: 7 BaseType uint8
     - __kind: PointerType
-      ID: 208
+      ID: 202
       Name: '*net.IPMask.array'
       ByteSize: 8
-      Pointee: 207 GoSliceDataType net.IPMask.array
+      Pointee: 201 GoSliceDataType net.IPMask.array
     - __kind: GoSliceDataType
-      ID: 209
+      ID: 203
       Name: '[]crypto/x509.OID.array'
       ByteSize: 2048
       Element: 104 StructureType crypto/x509.OID
     - __kind: PointerType
-      ID: 210
+      ID: 204
       Name: '*[]crypto/x509.OID.array'
       ByteSize: 8
-      Pointee: 209 GoSliceDataType []crypto/x509.OID.array
+      Pointee: 203 GoSliceDataType []crypto/x509.OID.array
     - __kind: GoSliceDataType
-      ID: 211
+      ID: 205
       Name: '[]crypto/x509.PolicyMapping.array'
       ByteSize: 2048
       Element: 107 StructureType crypto/x509.PolicyMapping
     - __kind: PointerType
-      ID: 212
+      ID: 206
       Name: '*[]crypto/x509.PolicyMapping.array'
       ByteSize: 8
-      Pointee: 211 GoSliceDataType []crypto/x509.PolicyMapping.array
+      Pointee: 205 GoSliceDataType []crypto/x509.PolicyMapping.array
     - __kind: GoSliceDataType
-      ID: 213
+      ID: 207
       Name: '[][]*crypto/x509.Certificate.array'
       ByteSize: 2048
       Element: 56 GoSliceHeaderType []*crypto/x509.Certificate
     - __kind: PointerType
-      ID: 214
+      ID: 208
       Name: '*[][]*crypto/x509.Certificate.array'
       ByteSize: 8
-      Pointee: 213 GoSliceDataType [][]*crypto/x509.Certificate.array
+      Pointee: 207 GoSliceDataType [][]*crypto/x509.Certificate.array
     - __kind: GoSliceDataType
-      ID: 215
+      ID: 209
       Name: '[][]uint8.array'
       ByteSize: 2048
       Element: 53 GoSliceHeaderType []uint8
     - __kind: PointerType
-      ID: 216
+      ID: 210
       Name: '*[][]uint8.array'
       ByteSize: 8
-      Pointee: 215 GoSliceDataType [][]uint8.array
+      Pointee: 209 GoSliceDataType [][]uint8.array
     - __kind: GoSliceDataType
-      ID: 217
+      ID: 211
       Name: '[]net/http.segment.array'
       ByteSize: 2048
       Element: 122 StructureType net/http.segment
     - __kind: PointerType
-      ID: 218
+      ID: 212
       Name: '*[]net/http.segment.array'
       ByteSize: 8
-      Pointee: 217 GoSliceDataType []net/http.segment.array
+      Pointee: 211 GoSliceDataType []net/http.segment.array
     - __kind: GoSliceDataType
-      ID: 219
+      ID: 213
       Name: '[]*table<string,string>.array'
       ByteSize: 8192
       Element: 127 PointerType *table<string,string>
     - __kind: GoSliceDataType
-      ID: 220
+      ID: 214
       Name: '[]noalg.map.group[string]string.array'
       ByteSize: 2048
       Element: 131 StructureType noalg.map.group[string]string
     - __kind: EventRootType
-      ID: 221
+      ID: 215
       Name: Probe[main.HandleHTTP]
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -2509,7 +2479,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 222
+      ID: 216
       Name: Probe[main.LookAtTheRequest]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -2523,6 +2493,6 @@ Types:
                   Variable: {subprogram: 2, index: 0, name: path}
                   Offset: 0
                   ByteSize: 16
-MaxTypeID: 222
+MaxTypeID: 216
 Issues: []
 GoModuledataInfo: {FirstModuledataAddr: "0x133d7c0", TypesOffset: 296}

--- a/pkg/dyninst/irgen/testdata/snapshot/rc_tester_v1.arch=arm64,toolchain=go1.24.3.yaml
+++ b/pkg/dyninst/irgen/testdata/snapshot/rc_tester_v1.arch=arm64,toolchain=go1.24.3.yaml
@@ -121,33 +121,33 @@ Subprograms:
           IsReturn: false
 Types:
     - __kind: PointerType
-      ID: 82
+      ID: 84
       Name: '**crypto/x509.Certificate'
       ByteSize: 8
       GoKind: 22
-      Pointee: 83 PointerType *crypto/x509.Certificate
+      Pointee: 85 PointerType *crypto/x509.Certificate
     - __kind: PointerType
-      ID: 148
+      ID: 122
       Name: '**mime/multipart.FileHeader'
       ByteSize: 8
       GoKind: 22
-      Pointee: 149 PointerType *mime/multipart.FileHeader
+      Pointee: 123 PointerType *mime/multipart.FileHeader
     - __kind: PointerType
-      ID: 135
+      ID: 162
       Name: '**net.IPNet'
       ByteSize: 8
       GoKind: 22
-      Pointee: 136 PointerType *net.IPNet
+      Pointee: 163 PointerType *net.IPNet
     - __kind: PointerType
-      ID: 133
+      ID: 160
       Name: '**net/url.URL'
       ByteSize: 8
       Pointee: 44 PointerType *net/url.URL
     - __kind: PointerType
-      ID: 79
+      ID: 81
       Name: '**table<string,[]*mime/multipart.FileHeader>'
       ByteSize: 8
-      Pointee: 80 PointerType *table<string,[]*mime/multipart.FileHeader>
+      Pointee: 82 PointerType *table<string,[]*mime/multipart.FileHeader>
     - __kind: PointerType
       ID: 49
       Name: '**table<string,[]string>'
@@ -159,86 +159,86 @@ Types:
       ByteSize: 8
       Pointee: 69 PointerType *table<string,string>
     - __kind: PointerType
-      ID: 85
+      ID: 87
       Name: '*[]*crypto/x509.Certificate'
       ByteSize: 8
       GoKind: 22
-      Pointee: 81 GoSliceHeaderType []*crypto/x509.Certificate
+      Pointee: 83 GoSliceHeaderType []*crypto/x509.Certificate
     - __kind: PointerType
-      ID: 176
+      ID: 127
       Name: '*[]*crypto/x509.Certificate.array'
       ByteSize: 8
-      Pointee: 175 GoSliceDataType []*crypto/x509.Certificate.array
+      Pointee: 126 GoSliceDataType []*crypto/x509.Certificate.array
     - __kind: PointerType
-      ID: 206
+      ID: 172
       Name: '*[]*mime/multipart.FileHeader.array'
       ByteSize: 8
-      Pointee: 205 GoSliceDataType []*mime/multipart.FileHeader.array
+      Pointee: 171 GoSliceDataType []*mime/multipart.FileHeader.array
     - __kind: PointerType
-      ID: 200
+      ID: 201
       Name: '*[]*net.IPNet.array'
       ByteSize: 8
-      Pointee: 199 GoSliceDataType []*net.IPNet.array
+      Pointee: 200 GoSliceDataType []*net.IPNet.array
     - __kind: PointerType
-      ID: 198
+      ID: 199
       Name: '*[]*net/url.URL.array'
       ByteSize: 8
-      Pointee: 197 GoSliceDataType []*net/url.URL.array
+      Pointee: 198 GoSliceDataType []*net/url.URL.array
     - __kind: PointerType
-      ID: 178
+      ID: 129
       Name: '*[][]*crypto/x509.Certificate.array'
       ByteSize: 8
-      Pointee: 177 GoSliceDataType [][]*crypto/x509.Certificate.array
+      Pointee: 128 GoSliceDataType [][]*crypto/x509.Certificate.array
     - __kind: PointerType
-      ID: 180
+      ID: 131
       Name: '*[][]uint8.array'
       ByteSize: 8
-      Pointee: 179 GoSliceDataType [][]uint8.array
+      Pointee: 130 GoSliceDataType [][]uint8.array
     - __kind: PointerType
-      ID: 192
+      ID: 193
       Name: '*[]crypto/x509.ExtKeyUsage.array'
       ByteSize: 8
-      Pointee: 191 GoSliceDataType []crypto/x509.ExtKeyUsage.array
+      Pointee: 192 GoSliceDataType []crypto/x509.ExtKeyUsage.array
     - __kind: PointerType
-      ID: 202
+      ID: 203
       Name: '*[]crypto/x509.OID.array'
       ByteSize: 8
-      Pointee: 201 GoSliceDataType []crypto/x509.OID.array
+      Pointee: 202 GoSliceDataType []crypto/x509.OID.array
     - __kind: PointerType
-      ID: 204
+      ID: 205
       Name: '*[]crypto/x509.PolicyMapping.array'
       ByteSize: 8
-      Pointee: 203 GoSliceDataType []crypto/x509.PolicyMapping.array
+      Pointee: 204 GoSliceDataType []crypto/x509.PolicyMapping.array
     - __kind: PointerType
-      ID: 184
+      ID: 185
       Name: '*[]crypto/x509/pkix.AttributeTypeAndValue.array'
       ByteSize: 8
-      Pointee: 183 GoSliceDataType []crypto/x509/pkix.AttributeTypeAndValue.array
+      Pointee: 184 GoSliceDataType []crypto/x509/pkix.AttributeTypeAndValue.array
     - __kind: PointerType
-      ID: 186
+      ID: 187
       Name: '*[]crypto/x509/pkix.Extension.array'
       ByteSize: 8
-      Pointee: 185 GoSliceDataType []crypto/x509/pkix.Extension.array
+      Pointee: 186 GoSliceDataType []crypto/x509/pkix.Extension.array
     - __kind: PointerType
-      ID: 188
+      ID: 189
       Name: '*[]encoding/asn1.ObjectIdentifier.array'
       ByteSize: 8
-      Pointee: 187 GoSliceDataType []encoding/asn1.ObjectIdentifier.array
+      Pointee: 188 GoSliceDataType []encoding/asn1.ObjectIdentifier.array
     - __kind: PointerType
-      ID: 194
+      ID: 195
       Name: '*[]net.IP.array'
       ByteSize: 8
-      Pointee: 193 GoSliceDataType []net.IP.array
+      Pointee: 194 GoSliceDataType []net.IP.array
     - __kind: PointerType
-      ID: 182
+      ID: 133
       Name: '*[]net/http.segment.array'
       ByteSize: 8
-      Pointee: 181 GoSliceDataType []net/http.segment.array
+      Pointee: 132 GoSliceDataType []net/http.segment.array
     - __kind: PointerType
-      ID: 168
+      ID: 104
       Name: '*[]string.array'
       ByteSize: 8
-      Pointee: 167 GoSliceDataType []string.array
+      Pointee: 103 GoSliceDataType []string.array
     - __kind: PointerType
       ID: 210
       Name: '*[]time.zone.array'
@@ -250,17 +250,17 @@ Types:
       ByteSize: 8
       Pointee: 211 GoSliceDataType []time.zoneTrans.array
     - __kind: PointerType
-      ID: 87
+      ID: 89
       Name: '*[]uint8'
       ByteSize: 8
       GoRuntimeType: 478144
       GoKind: 22
       Pointee: 70 GoSliceHeaderType []uint8
     - __kind: PointerType
-      ID: 172
+      ID: 113
       Name: '*[]uint8.array'
       ByteSize: 8
-      Pointee: 171 GoSliceDataType []uint8.array
+      Pointee: 112 GoSliceDataType []uint8.array
     - __kind: PointerType
       ID: 11
       Name: '*bool'
@@ -283,59 +283,59 @@ Types:
       GoKind: 22
       Pointee: 58 StructureType crypto/tls.ConnectionState
     - __kind: PointerType
-      ID: 83
+      ID: 85
       Name: '*crypto/x509.Certificate'
       ByteSize: 8
       GoRuntimeType: 2.030304e+06
       GoKind: 22
-      Pointee: 98 StructureType crypto/x509.Certificate
+      Pointee: 115 StructureType crypto/x509.Certificate
     - __kind: PointerType
-      ID: 127
+      ID: 154
       Name: '*crypto/x509.ExtKeyUsage'
       ByteSize: 8
       GoRuntimeType: 420160
       GoKind: 22
-      Pointee: 128 BaseType crypto/x509.ExtKeyUsage
+      Pointee: 155 BaseType crypto/x509.ExtKeyUsage
     - __kind: PointerType
-      ID: 138
+      ID: 165
       Name: '*crypto/x509.OID'
       ByteSize: 8
       GoRuntimeType: 1.938144e+06
       GoKind: 22
-      Pointee: 139 StructureType crypto/x509.OID
+      Pointee: 166 StructureType crypto/x509.OID
     - __kind: PointerType
-      ID: 141
+      ID: 168
       Name: '*crypto/x509.PolicyMapping'
       ByteSize: 8
       GoRuntimeType: 420224
       GoKind: 22
-      Pointee: 142 StructureType crypto/x509.PolicyMapping
+      Pointee: 169 StructureType crypto/x509.PolicyMapping
     - __kind: PointerType
-      ID: 114
+      ID: 141
       Name: '*crypto/x509/pkix.AttributeTypeAndValue'
       ByteSize: 8
       GoRuntimeType: 433984
       GoKind: 22
-      Pointee: 115 StructureType crypto/x509/pkix.AttributeTypeAndValue
+      Pointee: 142 StructureType crypto/x509/pkix.AttributeTypeAndValue
     - __kind: PointerType
-      ID: 121
+      ID: 148
       Name: '*crypto/x509/pkix.Extension'
       ByteSize: 8
       GoRuntimeType: 434176
       GoKind: 22
-      Pointee: 122 StructureType crypto/x509/pkix.Extension
+      Pointee: 149 StructureType crypto/x509/pkix.Extension
     - __kind: PointerType
-      ID: 124
+      ID: 151
       Name: '*encoding/asn1.ObjectIdentifier'
       ByteSize: 8
       GoRuntimeType: 1.044e+06
       GoKind: 22
-      Pointee: 125 GoSliceHeaderType encoding/asn1.ObjectIdentifier
+      Pointee: 152 GoSliceHeaderType encoding/asn1.ObjectIdentifier
     - __kind: PointerType
-      ID: 190
+      ID: 191
       Name: '*encoding/asn1.ObjectIdentifier.array'
       ByteSize: 8
-      Pointee: 189 GoSliceDataType encoding/asn1.ObjectIdentifier.array
+      Pointee: 190 GoSliceDataType encoding/asn1.ObjectIdentifier.array
     - __kind: PointerType
       ID: 33
       Name: '*error'
@@ -393,10 +393,10 @@ Types:
       GoKind: 22
       Pointee: 16 BaseType int8
     - __kind: PointerType
-      ID: 77
+      ID: 79
       Name: '*map<string,[]*mime/multipart.FileHeader>'
       ByteSize: 8
-      Pointee: 78 GoSwissMapHeaderType map<string,[]*mime/multipart.FileHeader>
+      Pointee: 80 GoSwissMapHeaderType map<string,[]*mime/multipart.FileHeader>
     - __kind: PointerType
       ID: 47
       Name: '*map<string,[]string>'
@@ -408,31 +408,31 @@ Types:
       ByteSize: 8
       Pointee: 67 GoSwissMapHeaderType map<string,string>
     - __kind: PointerType
-      ID: 110
+      ID: 137
       Name: '*math/big.Int'
       ByteSize: 8
       GoRuntimeType: 2.364704e+06
       GoKind: 22
-      Pointee: 111 StructureType math/big.Int
+      Pointee: 138 StructureType math/big.Int
     - __kind: PointerType
-      ID: 151
+      ID: 174
       Name: '*math/big.Word'
       ByteSize: 8
       GoRuntimeType: 423040
       GoKind: 22
-      Pointee: 152 BaseType math/big.Word
+      Pointee: 175 BaseType math/big.Word
     - __kind: PointerType
       ID: 208
       Name: '*math/big.nat.array'
       ByteSize: 8
       Pointee: 207 GoSliceDataType math/big.nat.array
     - __kind: PointerType
-      ID: 149
+      ID: 123
       Name: '*mime/multipart.FileHeader'
       ByteSize: 8
       GoRuntimeType: 902304
       GoKind: 22
-      Pointee: 160 StructureType mime/multipart.FileHeader
+      Pointee: 170 StructureType mime/multipart.FileHeader
     - __kind: PointerType
       ID: 55
       Name: '*mime/multipart.Form'
@@ -441,29 +441,29 @@ Types:
       GoKind: 22
       Pointee: 56 StructureType mime/multipart.Form
     - __kind: PointerType
-      ID: 130
+      ID: 157
       Name: '*net.IP'
       ByteSize: 8
       GoRuntimeType: 2.134112e+06
       GoKind: 22
-      Pointee: 131 GoSliceHeaderType net.IP
+      Pointee: 158 GoSliceHeaderType net.IP
     - __kind: PointerType
-      ID: 196
+      ID: 197
       Name: '*net.IP.array'
       ByteSize: 8
-      Pointee: 195 GoSliceDataType net.IP.array
+      Pointee: 196 GoSliceDataType net.IP.array
     - __kind: PointerType
       ID: 214
       Name: '*net.IPMask.array'
       ByteSize: 8
       Pointee: 213 GoSliceDataType net.IPMask.array
     - __kind: PointerType
-      ID: 136
+      ID: 163
       Name: '*net.IPNet'
       ByteSize: 8
       GoRuntimeType: 1.17392e+06
       GoKind: 22
-      Pointee: 159 StructureType net.IPNet
+      Pointee: 182 StructureType net.IPNet
     - __kind: PointerType
       ID: 37
       Name: '*net/http.Request'
@@ -486,12 +486,12 @@ Types:
       GoKind: 22
       Pointee: 64 StructureType net/http.pattern
     - __kind: PointerType
-      ID: 91
+      ID: 93
       Name: '*net/http.segment'
       ByteSize: 8
       GoRuntimeType: 388544
       GoKind: 22
-      Pointee: 92 StructureType net/http.segment
+      Pointee: 94 StructureType net/http.segment
     - __kind: PointerType
       ID: 44
       Name: '*net/url.URL'
@@ -500,27 +500,27 @@ Types:
       GoKind: 22
       Pointee: 45 StructureType net/url.URL
     - __kind: PointerType
-      ID: 72
+      ID: 74
       Name: '*net/url.Userinfo'
       ByteSize: 8
       GoRuntimeType: 1.191456e+06
       GoKind: 22
-      Pointee: 73 StructureType net/url.Userinfo
+      Pointee: 75 StructureType net/url.Userinfo
     - __kind: PointerType
-      ID: 105
+      ID: 117
       Name: '*noalg.map.group[string][]*mime/multipart.FileHeader'
       ByteSize: 8
-      Pointee: 106 StructureType noalg.map.group[string][]*mime/multipart.FileHeader
+      Pointee: 118 StructureType noalg.map.group[string][]*mime/multipart.FileHeader
     - __kind: PointerType
-      ID: 95
+      ID: 97
       Name: '*noalg.map.group[string][]string'
       ByteSize: 8
-      Pointee: 96 StructureType noalg.map.group[string][]string
+      Pointee: 98 StructureType noalg.map.group[string][]string
     - __kind: PointerType
-      ID: 100
+      ID: 106
       Name: '*noalg.map.group[string]string'
       ByteSize: 8
-      Pointee: 101 StructureType noalg.map.group[string]string
+      Pointee: 107 StructureType noalg.map.group[string]string
     - __kind: PointerType
       ID: 22
       Name: '*string'
@@ -529,46 +529,46 @@ Types:
       GoKind: 22
       Pointee: 9 GoStringHeaderType string
     - __kind: PointerType
-      ID: 164
+      ID: 73
       Name: '*string.str'
       ByteSize: 8
-      Pointee: 163 GoStringDataType string.str
+      Pointee: 72 GoStringDataType string.str
     - __kind: PointerType
-      ID: 80
+      ID: 82
       Name: '*table<string,[]*mime/multipart.FileHeader>'
       ByteSize: 8
-      Pointee: 97 StructureType table<string,[]*mime/multipart.FileHeader>
+      Pointee: 114 StructureType table<string,[]*mime/multipart.FileHeader>
     - __kind: PointerType
       ID: 50
       Name: '*table<string,[]string>'
       ByteSize: 8
-      Pointee: 74 StructureType table<string,[]string>
+      Pointee: 76 StructureType table<string,[]string>
     - __kind: PointerType
       ID: 69
       Name: '*table<string,string>'
       ByteSize: 8
-      Pointee: 93 StructureType table<string,string>
+      Pointee: 95 StructureType table<string,string>
     - __kind: PointerType
-      ID: 117
+      ID: 144
       Name: '*time.Location'
       ByteSize: 8
       GoRuntimeType: 1.6024e+06
       GoKind: 22
-      Pointee: 118 StructureType time.Location
+      Pointee: 145 StructureType time.Location
     - __kind: PointerType
-      ID: 154
+      ID: 177
       Name: '*time.zone'
       ByteSize: 8
       GoRuntimeType: 391680
       GoKind: 22
-      Pointee: 155 StructureType time.zone
+      Pointee: 178 StructureType time.zone
     - __kind: PointerType
-      ID: 157
+      ID: 180
       Name: '*time.zoneTrans'
       ByteSize: 8
       GoRuntimeType: 391744
       GoKind: 22
-      Pointee: 158 StructureType time.zoneTrans
+      Pointee: 181 StructureType time.zoneTrans
     - __kind: PointerType
       ID: 34
       Name: '*uint'
@@ -656,7 +656,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: GoSliceHeaderType
-      ID: 81
+      ID: 83
       Name: '[]*crypto/x509.Certificate'
       ByteSize: 24
       GoRuntimeType: 498304
@@ -664,21 +664,21 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 82 PointerType **crypto/x509.Certificate
+          Type: 84 PointerType **crypto/x509.Certificate
         - Name: len
           Offset: 8
           Type: 7 BaseType int
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 175 GoSliceDataType []*crypto/x509.Certificate.array
+      Data: 126 GoSliceDataType []*crypto/x509.Certificate.array
     - __kind: GoSliceDataType
-      ID: 175
+      ID: 126
       Name: '[]*crypto/x509.Certificate.array'
       ByteSize: 2048
-      Element: 83 PointerType *crypto/x509.Certificate
+      Element: 85 PointerType *crypto/x509.Certificate
     - __kind: GoSliceHeaderType
-      ID: 147
+      ID: 121
       Name: '[]*mime/multipart.FileHeader'
       ByteSize: 24
       GoRuntimeType: 483744
@@ -686,21 +686,21 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 148 PointerType **mime/multipart.FileHeader
+          Type: 122 PointerType **mime/multipart.FileHeader
         - Name: len
           Offset: 8
           Type: 7 BaseType int
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 205 GoSliceDataType []*mime/multipart.FileHeader.array
+      Data: 171 GoSliceDataType []*mime/multipart.FileHeader.array
     - __kind: GoSliceDataType
-      ID: 205
+      ID: 171
       Name: '[]*mime/multipart.FileHeader.array'
       ByteSize: 2048
-      Element: 149 PointerType *mime/multipart.FileHeader
+      Element: 123 PointerType *mime/multipart.FileHeader
     - __kind: GoSliceHeaderType
-      ID: 134
+      ID: 161
       Name: '[]*net.IPNet'
       ByteSize: 24
       GoRuntimeType: 511840
@@ -708,21 +708,21 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 135 PointerType **net.IPNet
+          Type: 162 PointerType **net.IPNet
         - Name: len
           Offset: 8
           Type: 7 BaseType int
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 199 GoSliceDataType []*net.IPNet.array
+      Data: 200 GoSliceDataType []*net.IPNet.array
     - __kind: GoSliceDataType
-      ID: 199
+      ID: 200
       Name: '[]*net.IPNet.array'
       ByteSize: 2048
-      Element: 136 PointerType *net.IPNet
+      Element: 163 PointerType *net.IPNet
     - __kind: GoSliceHeaderType
-      ID: 132
+      ID: 159
       Name: '[]*net/url.URL'
       ByteSize: 24
       GoRuntimeType: 511776
@@ -730,36 +730,36 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 133 PointerType **net/url.URL
+          Type: 160 PointerType **net/url.URL
         - Name: len
           Offset: 8
           Type: 7 BaseType int
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 197 GoSliceDataType []*net/url.URL.array
+      Data: 198 GoSliceDataType []*net/url.URL.array
     - __kind: GoSliceDataType
-      ID: 197
+      ID: 198
       Name: '[]*net/url.URL.array'
       ByteSize: 2048
       Element: 44 PointerType *net/url.URL
     - __kind: GoSliceDataType
-      ID: 173
+      ID: 124
       Name: '[]*table<string,[]*mime/multipart.FileHeader>.array'
       ByteSize: 8192
-      Element: 80 PointerType *table<string,[]*mime/multipart.FileHeader>
+      Element: 82 PointerType *table<string,[]*mime/multipart.FileHeader>
     - __kind: GoSliceDataType
-      ID: 165
+      ID: 101
       Name: '[]*table<string,[]string>.array'
       ByteSize: 8192
       Element: 50 PointerType *table<string,[]string>
     - __kind: GoSliceDataType
-      ID: 169
+      ID: 110
       Name: '[]*table<string,string>.array'
       ByteSize: 8192
       Element: 69 PointerType *table<string,string>
     - __kind: GoSliceHeaderType
-      ID: 84
+      ID: 86
       Name: '[][]*crypto/x509.Certificate'
       ByteSize: 24
       GoRuntimeType: 498432
@@ -767,21 +767,21 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 85 PointerType *[]*crypto/x509.Certificate
+          Type: 87 PointerType *[]*crypto/x509.Certificate
         - Name: len
           Offset: 8
           Type: 7 BaseType int
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 177 GoSliceDataType [][]*crypto/x509.Certificate.array
+      Data: 128 GoSliceDataType [][]*crypto/x509.Certificate.array
     - __kind: GoSliceDataType
-      ID: 177
+      ID: 128
       Name: '[][]*crypto/x509.Certificate.array'
       ByteSize: 2048
-      Element: 81 GoSliceHeaderType []*crypto/x509.Certificate
+      Element: 83 GoSliceHeaderType []*crypto/x509.Certificate
     - __kind: GoSliceHeaderType
-      ID: 86
+      ID: 88
       Name: '[][]uint8'
       ByteSize: 24
       GoRuntimeType: 478528
@@ -789,21 +789,21 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 87 PointerType *[]uint8
+          Type: 89 PointerType *[]uint8
         - Name: len
           Offset: 8
           Type: 7 BaseType int
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 179 GoSliceDataType [][]uint8.array
+      Data: 130 GoSliceDataType [][]uint8.array
     - __kind: GoSliceDataType
-      ID: 179
+      ID: 130
       Name: '[][]uint8.array'
       ByteSize: 2048
       Element: 70 GoSliceHeaderType []uint8
     - __kind: GoSliceHeaderType
-      ID: 126
+      ID: 153
       Name: '[]crypto/x509.ExtKeyUsage'
       ByteSize: 24
       GoRuntimeType: 499776
@@ -811,21 +811,21 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 127 PointerType *crypto/x509.ExtKeyUsage
+          Type: 154 PointerType *crypto/x509.ExtKeyUsage
         - Name: len
           Offset: 8
           Type: 7 BaseType int
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 191 GoSliceDataType []crypto/x509.ExtKeyUsage.array
+      Data: 192 GoSliceDataType []crypto/x509.ExtKeyUsage.array
     - __kind: GoSliceDataType
-      ID: 191
+      ID: 192
       Name: '[]crypto/x509.ExtKeyUsage.array'
       ByteSize: 2048
-      Element: 128 BaseType crypto/x509.ExtKeyUsage
+      Element: 155 BaseType crypto/x509.ExtKeyUsage
     - __kind: GoSliceHeaderType
-      ID: 137
+      ID: 164
       Name: '[]crypto/x509.OID'
       ByteSize: 24
       GoRuntimeType: 511904
@@ -833,21 +833,21 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 138 PointerType *crypto/x509.OID
+          Type: 165 PointerType *crypto/x509.OID
         - Name: len
           Offset: 8
           Type: 7 BaseType int
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 201 GoSliceDataType []crypto/x509.OID.array
+      Data: 202 GoSliceDataType []crypto/x509.OID.array
     - __kind: GoSliceDataType
-      ID: 201
+      ID: 202
       Name: '[]crypto/x509.OID.array'
       ByteSize: 2048
-      Element: 139 StructureType crypto/x509.OID
+      Element: 166 StructureType crypto/x509.OID
     - __kind: GoSliceHeaderType
-      ID: 140
+      ID: 167
       Name: '[]crypto/x509.PolicyMapping'
       ByteSize: 24
       GoRuntimeType: 511968
@@ -855,21 +855,21 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 141 PointerType *crypto/x509.PolicyMapping
+          Type: 168 PointerType *crypto/x509.PolicyMapping
         - Name: len
           Offset: 8
           Type: 7 BaseType int
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 203 GoSliceDataType []crypto/x509.PolicyMapping.array
+      Data: 204 GoSliceDataType []crypto/x509.PolicyMapping.array
     - __kind: GoSliceDataType
-      ID: 203
+      ID: 204
       Name: '[]crypto/x509.PolicyMapping.array'
       ByteSize: 2048
-      Element: 142 StructureType crypto/x509.PolicyMapping
+      Element: 169 StructureType crypto/x509.PolicyMapping
     - __kind: GoSliceHeaderType
-      ID: 113
+      ID: 140
       Name: '[]crypto/x509/pkix.AttributeTypeAndValue'
       ByteSize: 24
       GoRuntimeType: 512416
@@ -877,21 +877,21 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 114 PointerType *crypto/x509/pkix.AttributeTypeAndValue
+          Type: 141 PointerType *crypto/x509/pkix.AttributeTypeAndValue
         - Name: len
           Offset: 8
           Type: 7 BaseType int
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 183 GoSliceDataType []crypto/x509/pkix.AttributeTypeAndValue.array
+      Data: 184 GoSliceDataType []crypto/x509/pkix.AttributeTypeAndValue.array
     - __kind: GoSliceDataType
-      ID: 183
+      ID: 184
       Name: '[]crypto/x509/pkix.AttributeTypeAndValue.array'
       ByteSize: 2048
-      Element: 115 StructureType crypto/x509/pkix.AttributeTypeAndValue
+      Element: 142 StructureType crypto/x509/pkix.AttributeTypeAndValue
     - __kind: GoSliceHeaderType
-      ID: 120
+      ID: 147
       Name: '[]crypto/x509/pkix.Extension'
       ByteSize: 24
       GoRuntimeType: 511648
@@ -899,21 +899,21 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 121 PointerType *crypto/x509/pkix.Extension
+          Type: 148 PointerType *crypto/x509/pkix.Extension
         - Name: len
           Offset: 8
           Type: 7 BaseType int
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 185 GoSliceDataType []crypto/x509/pkix.Extension.array
+      Data: 186 GoSliceDataType []crypto/x509/pkix.Extension.array
     - __kind: GoSliceDataType
-      ID: 185
+      ID: 186
       Name: '[]crypto/x509/pkix.Extension.array'
       ByteSize: 2048
-      Element: 122 StructureType crypto/x509/pkix.Extension
+      Element: 149 StructureType crypto/x509/pkix.Extension
     - __kind: GoSliceHeaderType
-      ID: 123
+      ID: 150
       Name: '[]encoding/asn1.ObjectIdentifier'
       ByteSize: 24
       GoRuntimeType: 511712
@@ -921,21 +921,21 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 124 PointerType *encoding/asn1.ObjectIdentifier
+          Type: 151 PointerType *encoding/asn1.ObjectIdentifier
         - Name: len
           Offset: 8
           Type: 7 BaseType int
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 187 GoSliceDataType []encoding/asn1.ObjectIdentifier.array
+      Data: 188 GoSliceDataType []encoding/asn1.ObjectIdentifier.array
     - __kind: GoSliceDataType
-      ID: 187
+      ID: 188
       Name: '[]encoding/asn1.ObjectIdentifier.array'
       ByteSize: 2048
-      Element: 125 GoSliceHeaderType encoding/asn1.ObjectIdentifier
+      Element: 152 GoSliceHeaderType encoding/asn1.ObjectIdentifier
     - __kind: GoSliceHeaderType
-      ID: 129
+      ID: 156
       Name: '[]net.IP'
       ByteSize: 24
       GoRuntimeType: 479488
@@ -943,21 +943,21 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 130 PointerType *net.IP
+          Type: 157 PointerType *net.IP
         - Name: len
           Offset: 8
           Type: 7 BaseType int
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 193 GoSliceDataType []net.IP.array
+      Data: 194 GoSliceDataType []net.IP.array
     - __kind: GoSliceDataType
-      ID: 193
+      ID: 194
       Name: '[]net.IP.array'
       ByteSize: 2048
-      Element: 131 GoSliceHeaderType net.IP
+      Element: 158 GoSliceHeaderType net.IP
     - __kind: GoSliceHeaderType
-      ID: 90
+      ID: 92
       Name: '[]net/http.segment'
       ByteSize: 24
       GoRuntimeType: 481120
@@ -965,34 +965,34 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 91 PointerType *net/http.segment
+          Type: 93 PointerType *net/http.segment
         - Name: len
           Offset: 8
           Type: 7 BaseType int
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 181 GoSliceDataType []net/http.segment.array
+      Data: 132 GoSliceDataType []net/http.segment.array
     - __kind: GoSliceDataType
-      ID: 181
+      ID: 132
       Name: '[]net/http.segment.array'
       ByteSize: 2048
-      Element: 92 StructureType net/http.segment
+      Element: 94 StructureType net/http.segment
     - __kind: GoSliceDataType
-      ID: 174
+      ID: 125
       Name: '[]noalg.map.group[string][]*mime/multipart.FileHeader.array'
       ByteSize: 2048
-      Element: 106 StructureType noalg.map.group[string][]*mime/multipart.FileHeader
+      Element: 118 StructureType noalg.map.group[string][]*mime/multipart.FileHeader
     - __kind: GoSliceDataType
-      ID: 166
+      ID: 102
       Name: '[]noalg.map.group[string][]string.array'
       ByteSize: 2048
-      Element: 96 StructureType noalg.map.group[string][]string
+      Element: 98 StructureType noalg.map.group[string][]string
     - __kind: GoSliceDataType
-      ID: 170
+      ID: 111
       Name: '[]noalg.map.group[string]string.array'
       ByteSize: 2048
-      Element: 101 StructureType noalg.map.group[string]string
+      Element: 107 StructureType noalg.map.group[string]string
     - __kind: GoSliceHeaderType
       ID: 53
       Name: '[]string'
@@ -1009,14 +1009,14 @@ Types:
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 167 GoSliceDataType []string.array
+      Data: 103 GoSliceDataType []string.array
     - __kind: GoSliceDataType
-      ID: 167
+      ID: 103
       Name: '[]string.array'
       ByteSize: 2048
       Element: 9 GoStringHeaderType string
     - __kind: GoSliceHeaderType
-      ID: 153
+      ID: 176
       Name: '[]time.zone'
       ByteSize: 24
       GoRuntimeType: 485792
@@ -1024,7 +1024,7 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 154 PointerType *time.zone
+          Type: 177 PointerType *time.zone
         - Name: len
           Offset: 8
           Type: 7 BaseType int
@@ -1036,9 +1036,9 @@ Types:
       ID: 209
       Name: '[]time.zone.array'
       ByteSize: 2048
-      Element: 155 StructureType time.zone
+      Element: 178 StructureType time.zone
     - __kind: GoSliceHeaderType
-      ID: 156
+      ID: 179
       Name: '[]time.zoneTrans'
       ByteSize: 24
       GoRuntimeType: 485856
@@ -1046,7 +1046,7 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 157 PointerType *time.zoneTrans
+          Type: 180 PointerType *time.zoneTrans
         - Name: len
           Offset: 8
           Type: 7 BaseType int
@@ -1058,7 +1058,7 @@ Types:
       ID: 211
       Name: '[]time.zoneTrans.array'
       ByteSize: 2048
-      Element: 158 StructureType time.zoneTrans
+      Element: 181 StructureType time.zoneTrans
     - __kind: GoSliceHeaderType
       ID: 70
       Name: '[]uint8'
@@ -1075,9 +1075,9 @@ Types:
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 171 GoSliceDataType []uint8.array
+      Data: 112 GoSliceDataType []uint8.array
     - __kind: GoSliceDataType
-      ID: 171
+      ID: 112
       Name: '[]uint8.array'
       ByteSize: 2048
       Element: 3 BaseType uint8
@@ -1179,13 +1179,13 @@ Types:
           Type: 9 GoStringHeaderType string
         - Name: PeerCertificates
           Offset: 48
-          Type: 81 GoSliceHeaderType []*crypto/x509.Certificate
+          Type: 83 GoSliceHeaderType []*crypto/x509.Certificate
         - Name: VerifiedChains
           Offset: 72
-          Type: 84 GoSliceHeaderType [][]*crypto/x509.Certificate
+          Type: 86 GoSliceHeaderType [][]*crypto/x509.Certificate
         - Name: SignedCertificateTimestamps
           Offset: 96
-          Type: 86 GoSliceHeaderType [][]uint8
+          Type: 88 GoSliceHeaderType [][]uint8
         - Name: OCSPResponse
           Offset: 120
           Type: 70 GoSliceHeaderType []uint8
@@ -1197,21 +1197,21 @@ Types:
           Type: 4 BaseType bool
         - Name: ekm
           Offset: 176
-          Type: 88 GoSubroutineType func(string, []uint8, int) ([]uint8, error)
+          Type: 90 GoSubroutineType func(string, []uint8, int) ([]uint8, error)
         - Name: testingOnlyDidHRR
           Offset: 184
           Type: 4 BaseType bool
         - Name: testingOnlyCurveID
           Offset: 186
-          Type: 89 BaseType crypto/tls.CurveID
+          Type: 91 BaseType crypto/tls.CurveID
     - __kind: BaseType
-      ID: 89
+      ID: 91
       Name: crypto/tls.CurveID
       ByteSize: 2
       GoRuntimeType: 829056
       GoKind: 9
     - __kind: StructureType
-      ID: 98
+      ID: 115
       Name: crypto/x509.Certificate
       ByteSize: 1424
       GoRuntimeType: 2.37712e+06
@@ -1237,49 +1237,49 @@ Types:
           Type: 70 GoSliceHeaderType []uint8
         - Name: SignatureAlgorithm
           Offset: 144
-          Type: 107 BaseType crypto/x509.SignatureAlgorithm
+          Type: 134 BaseType crypto/x509.SignatureAlgorithm
         - Name: PublicKeyAlgorithm
           Offset: 152
-          Type: 108 BaseType crypto/x509.PublicKeyAlgorithm
+          Type: 135 BaseType crypto/x509.PublicKeyAlgorithm
         - Name: PublicKey
           Offset: 160
-          Type: 109 GoEmptyInterfaceType interface {}
+          Type: 136 GoEmptyInterfaceType interface {}
         - Name: Version
           Offset: 176
           Type: 7 BaseType int
         - Name: SerialNumber
           Offset: 184
-          Type: 110 PointerType *math/big.Int
+          Type: 137 PointerType *math/big.Int
         - Name: Issuer
           Offset: 192
-          Type: 112 StructureType crypto/x509/pkix.Name
+          Type: 139 StructureType crypto/x509/pkix.Name
         - Name: Subject
           Offset: 440
-          Type: 112 StructureType crypto/x509/pkix.Name
+          Type: 139 StructureType crypto/x509/pkix.Name
         - Name: NotBefore
           Offset: 688
-          Type: 116 StructureType time.Time
+          Type: 143 StructureType time.Time
         - Name: NotAfter
           Offset: 712
-          Type: 116 StructureType time.Time
+          Type: 143 StructureType time.Time
         - Name: KeyUsage
           Offset: 736
-          Type: 119 BaseType crypto/x509.KeyUsage
+          Type: 146 BaseType crypto/x509.KeyUsage
         - Name: Extensions
           Offset: 744
-          Type: 120 GoSliceHeaderType []crypto/x509/pkix.Extension
+          Type: 147 GoSliceHeaderType []crypto/x509/pkix.Extension
         - Name: ExtraExtensions
           Offset: 768
-          Type: 120 GoSliceHeaderType []crypto/x509/pkix.Extension
+          Type: 147 GoSliceHeaderType []crypto/x509/pkix.Extension
         - Name: UnhandledCriticalExtensions
           Offset: 792
-          Type: 123 GoSliceHeaderType []encoding/asn1.ObjectIdentifier
+          Type: 150 GoSliceHeaderType []encoding/asn1.ObjectIdentifier
         - Name: ExtKeyUsage
           Offset: 816
-          Type: 126 GoSliceHeaderType []crypto/x509.ExtKeyUsage
+          Type: 153 GoSliceHeaderType []crypto/x509.ExtKeyUsage
         - Name: UnknownExtKeyUsage
           Offset: 840
-          Type: 123 GoSliceHeaderType []encoding/asn1.ObjectIdentifier
+          Type: 150 GoSliceHeaderType []encoding/asn1.ObjectIdentifier
         - Name: BasicConstraintsValid
           Offset: 864
           Type: 4 BaseType bool
@@ -1312,10 +1312,10 @@ Types:
           Type: 53 GoSliceHeaderType []string
         - Name: IPAddresses
           Offset: 1032
-          Type: 129 GoSliceHeaderType []net.IP
+          Type: 156 GoSliceHeaderType []net.IP
         - Name: URIs
           Offset: 1056
-          Type: 132 GoSliceHeaderType []*net/url.URL
+          Type: 159 GoSliceHeaderType []*net/url.URL
         - Name: PermittedDNSDomainsCritical
           Offset: 1080
           Type: 4 BaseType bool
@@ -1327,10 +1327,10 @@ Types:
           Type: 53 GoSliceHeaderType []string
         - Name: PermittedIPRanges
           Offset: 1136
-          Type: 134 GoSliceHeaderType []*net.IPNet
+          Type: 161 GoSliceHeaderType []*net.IPNet
         - Name: ExcludedIPRanges
           Offset: 1160
-          Type: 134 GoSliceHeaderType []*net.IPNet
+          Type: 161 GoSliceHeaderType []*net.IPNet
         - Name: PermittedEmailAddresses
           Offset: 1184
           Type: 53 GoSliceHeaderType []string
@@ -1348,10 +1348,10 @@ Types:
           Type: 53 GoSliceHeaderType []string
         - Name: PolicyIdentifiers
           Offset: 1304
-          Type: 123 GoSliceHeaderType []encoding/asn1.ObjectIdentifier
+          Type: 150 GoSliceHeaderType []encoding/asn1.ObjectIdentifier
         - Name: Policies
           Offset: 1328
-          Type: 137 GoSliceHeaderType []crypto/x509.OID
+          Type: 164 GoSliceHeaderType []crypto/x509.OID
         - Name: InhibitAnyPolicy
           Offset: 1352
           Type: 7 BaseType int
@@ -1372,21 +1372,21 @@ Types:
           Type: 4 BaseType bool
         - Name: PolicyMappings
           Offset: 1400
-          Type: 140 GoSliceHeaderType []crypto/x509.PolicyMapping
+          Type: 167 GoSliceHeaderType []crypto/x509.PolicyMapping
     - __kind: BaseType
-      ID: 128
+      ID: 155
       Name: crypto/x509.ExtKeyUsage
       ByteSize: 8
       GoRuntimeType: 583136
       GoKind: 2
     - __kind: BaseType
-      ID: 119
+      ID: 146
       Name: crypto/x509.KeyUsage
       ByteSize: 8
       GoRuntimeType: 583072
       GoKind: 2
     - __kind: StructureType
-      ID: 139
+      ID: 166
       Name: crypto/x509.OID
       ByteSize: 24
       GoRuntimeType: 1.9384e+06
@@ -1396,7 +1396,7 @@ Types:
           Offset: 0
           Type: 70 GoSliceHeaderType []uint8
     - __kind: StructureType
-      ID: 142
+      ID: 169
       Name: crypto/x509.PolicyMapping
       ByteSize: 48
       GoRuntimeType: 1.480224e+06
@@ -1404,24 +1404,24 @@ Types:
       RawFields:
         - Name: IssuerDomainPolicy
           Offset: 0
-          Type: 139 StructureType crypto/x509.OID
+          Type: 166 StructureType crypto/x509.OID
         - Name: SubjectDomainPolicy
           Offset: 24
-          Type: 139 StructureType crypto/x509.OID
+          Type: 166 StructureType crypto/x509.OID
     - __kind: BaseType
-      ID: 108
+      ID: 135
       Name: crypto/x509.PublicKeyAlgorithm
       ByteSize: 8
       GoRuntimeType: 831456
       GoKind: 2
     - __kind: BaseType
-      ID: 107
+      ID: 134
       Name: crypto/x509.SignatureAlgorithm
       ByteSize: 8
       GoRuntimeType: 1.104544e+06
       GoKind: 2
     - __kind: StructureType
-      ID: 115
+      ID: 142
       Name: crypto/x509/pkix.AttributeTypeAndValue
       ByteSize: 40
       GoRuntimeType: 1.492064e+06
@@ -1429,12 +1429,12 @@ Types:
       RawFields:
         - Name: Type
           Offset: 0
-          Type: 125 GoSliceHeaderType encoding/asn1.ObjectIdentifier
+          Type: 152 GoSliceHeaderType encoding/asn1.ObjectIdentifier
         - Name: Value
           Offset: 24
-          Type: 109 GoEmptyInterfaceType interface {}
+          Type: 136 GoEmptyInterfaceType interface {}
     - __kind: StructureType
-      ID: 122
+      ID: 149
       Name: crypto/x509/pkix.Extension
       ByteSize: 56
       GoRuntimeType: 1.635616e+06
@@ -1442,7 +1442,7 @@ Types:
       RawFields:
         - Name: Id
           Offset: 0
-          Type: 125 GoSliceHeaderType encoding/asn1.ObjectIdentifier
+          Type: 152 GoSliceHeaderType encoding/asn1.ObjectIdentifier
         - Name: Critical
           Offset: 24
           Type: 4 BaseType bool
@@ -1450,7 +1450,7 @@ Types:
           Offset: 32
           Type: 70 GoSliceHeaderType []uint8
     - __kind: StructureType
-      ID: 112
+      ID: 139
       Name: crypto/x509/pkix.Name
       ByteSize: 248
       GoRuntimeType: 2.176736e+06
@@ -1485,12 +1485,12 @@ Types:
           Type: 9 GoStringHeaderType string
         - Name: Names
           Offset: 200
-          Type: 113 GoSliceHeaderType []crypto/x509/pkix.AttributeTypeAndValue
+          Type: 140 GoSliceHeaderType []crypto/x509/pkix.AttributeTypeAndValue
         - Name: ExtraNames
           Offset: 224
-          Type: 113 GoSliceHeaderType []crypto/x509/pkix.AttributeTypeAndValue
+          Type: 140 GoSliceHeaderType []crypto/x509/pkix.AttributeTypeAndValue
     - __kind: GoSliceHeaderType
-      ID: 125
+      ID: 152
       Name: encoding/asn1.ObjectIdentifier
       ByteSize: 24
       GoRuntimeType: 1.044128e+06
@@ -1505,9 +1505,9 @@ Types:
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 189 GoSliceDataType encoding/asn1.ObjectIdentifier.array
+      Data: 190 GoSliceDataType encoding/asn1.ObjectIdentifier.array
     - __kind: GoSliceDataType
-      ID: 189
+      ID: 190
       Name: encoding/asn1.ObjectIdentifier.array
       ByteSize: 2048
       Element: 7 BaseType int
@@ -1543,7 +1543,7 @@ Types:
       GoRuntimeType: 687840
       GoKind: 19
     - __kind: GoSubroutineType
-      ID: 88
+      ID: 90
       Name: func(string, []uint8, int) ([]uint8, error)
       ByteSize: 8
       GoRuntimeType: 994848
@@ -1562,47 +1562,47 @@ Types:
           Offset: 8
           Type: 15 VoidPointerType unsafe.Pointer
     - __kind: GoSwissMapGroupsType
-      ID: 104
+      ID: 116
       Name: groupReference<string,[]*mime/multipart.FileHeader>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 105 PointerType *noalg.map.group[string][]*mime/multipart.FileHeader
+          Type: 117 PointerType *noalg.map.group[string][]*mime/multipart.FileHeader
         - Name: lengthMask
           Offset: 8
           Type: 8 BaseType uint64
-      GroupType: 106 StructureType noalg.map.group[string][]*mime/multipart.FileHeader
-      GroupSliceType: 174 GoSliceDataType []noalg.map.group[string][]*mime/multipart.FileHeader.array
+      GroupType: 118 StructureType noalg.map.group[string][]*mime/multipart.FileHeader
+      GroupSliceType: 125 GoSliceDataType []noalg.map.group[string][]*mime/multipart.FileHeader.array
     - __kind: GoSwissMapGroupsType
-      ID: 94
+      ID: 96
       Name: groupReference<string,[]string>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 95 PointerType *noalg.map.group[string][]string
+          Type: 97 PointerType *noalg.map.group[string][]string
         - Name: lengthMask
           Offset: 8
           Type: 8 BaseType uint64
-      GroupType: 96 StructureType noalg.map.group[string][]string
-      GroupSliceType: 166 GoSliceDataType []noalg.map.group[string][]string.array
+      GroupType: 98 StructureType noalg.map.group[string][]string
+      GroupSliceType: 102 GoSliceDataType []noalg.map.group[string][]string.array
     - __kind: GoSwissMapGroupsType
-      ID: 99
+      ID: 105
       Name: groupReference<string,string>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 100 PointerType *noalg.map.group[string]string
+          Type: 106 PointerType *noalg.map.group[string]string
         - Name: lengthMask
           Offset: 8
           Type: 8 BaseType uint64
-      GroupType: 101 StructureType noalg.map.group[string]string
-      GroupSliceType: 170 GoSliceDataType []noalg.map.group[string]string.array
+      GroupType: 107 StructureType noalg.map.group[string]string
+      GroupSliceType: 111 GoSliceDataType []noalg.map.group[string]string.array
     - __kind: BaseType
       ID: 7
       Name: int
@@ -1634,7 +1634,7 @@ Types:
       GoRuntimeType: 579488
       GoKind: 3
     - __kind: GoEmptyInterfaceType
-      ID: 109
+      ID: 136
       Name: interface {}
       ByteSize: 16
       GoRuntimeType: 848672
@@ -1660,7 +1660,7 @@ Types:
           Offset: 8
           Type: 15 VoidPointerType unsafe.Pointer
     - __kind: GoSwissMapHeaderType
-      ID: 78
+      ID: 80
       Name: map<string,[]*mime/multipart.FileHeader>
       ByteSize: 48
       GoKind: 25
@@ -1673,7 +1673,7 @@ Types:
           Type: 1 BaseType uintptr
         - Name: dirPtr
           Offset: 16
-          Type: 79 PointerType **table<string,[]*mime/multipart.FileHeader>
+          Type: 81 PointerType **table<string,[]*mime/multipart.FileHeader>
         - Name: dirLen
           Offset: 24
           Type: 7 BaseType int
@@ -1689,8 +1689,8 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 8 BaseType uint64
-      TablePtrSliceType: 173 GoSliceDataType []*table<string,[]*mime/multipart.FileHeader>.array
-      GroupType: 106 StructureType noalg.map.group[string][]*mime/multipart.FileHeader
+      TablePtrSliceType: 124 GoSliceDataType []*table<string,[]*mime/multipart.FileHeader>.array
+      GroupType: 118 StructureType noalg.map.group[string][]*mime/multipart.FileHeader
     - __kind: GoSwissMapHeaderType
       ID: 48
       Name: map<string,[]string>
@@ -1721,8 +1721,8 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 8 BaseType uint64
-      TablePtrSliceType: 165 GoSliceDataType []*table<string,[]string>.array
-      GroupType: 96 StructureType noalg.map.group[string][]string
+      TablePtrSliceType: 101 GoSliceDataType []*table<string,[]string>.array
+      GroupType: 98 StructureType noalg.map.group[string][]string
     - __kind: GoSwissMapHeaderType
       ID: 67
       Name: map<string,string>
@@ -1753,17 +1753,17 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 8 BaseType uint64
-      TablePtrSliceType: 169 GoSliceDataType []*table<string,string>.array
-      GroupType: 101 StructureType noalg.map.group[string]string
+      TablePtrSliceType: 110 GoSliceDataType []*table<string,string>.array
+      GroupType: 107 StructureType noalg.map.group[string]string
     - __kind: GoMapType
-      ID: 76
+      ID: 78
       Name: map[string][]*mime/multipart.FileHeader
       ByteSize: 8
       GoRuntimeType: 1.122592e+06
       GoKind: 21
-      HeaderType: 78 GoSwissMapHeaderType map<string,[]*mime/multipart.FileHeader>
+      HeaderType: 80 GoSwissMapHeaderType map<string,[]*mime/multipart.FileHeader>
     - __kind: GoMapType
-      ID: 75
+      ID: 77
       Name: map[string][]string
       ByteSize: 8
       GoRuntimeType: 1.117984e+06
@@ -1777,7 +1777,7 @@ Types:
       GoKind: 21
       HeaderType: 67 GoSwissMapHeaderType map<string,string>
     - __kind: StructureType
-      ID: 111
+      ID: 138
       Name: math/big.Int
       ByteSize: 32
       GoRuntimeType: 1.483264e+06
@@ -1788,15 +1788,15 @@ Types:
           Type: 4 BaseType bool
         - Name: abs
           Offset: 8
-          Type: 150 GoSliceHeaderType math/big.nat
+          Type: 173 GoSliceHeaderType math/big.nat
     - __kind: BaseType
-      ID: 152
+      ID: 175
       Name: math/big.Word
       ByteSize: 8
       GoRuntimeType: 583328
       GoKind: 7
     - __kind: GoSliceHeaderType
-      ID: 150
+      ID: 173
       Name: math/big.nat
       ByteSize: 24
       GoRuntimeType: 2.345504e+06
@@ -1804,7 +1804,7 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 151 PointerType *math/big.Word
+          Type: 174 PointerType *math/big.Word
         - Name: len
           Offset: 8
           Type: 7 BaseType int
@@ -1816,9 +1816,9 @@ Types:
       ID: 207
       Name: math/big.nat.array
       ByteSize: 2048
-      Element: 152 BaseType math/big.Word
+      Element: 175 BaseType math/big.Word
     - __kind: StructureType
-      ID: 160
+      ID: 170
       Name: mime/multipart.FileHeader
       ByteSize: 88
       GoRuntimeType: 1.962144e+06
@@ -1829,7 +1829,7 @@ Types:
           Type: 9 GoStringHeaderType string
         - Name: Header
           Offset: 16
-          Type: 162 GoMapType net/textproto.MIMEHeader
+          Type: 183 GoMapType net/textproto.MIMEHeader
         - Name: Size
           Offset: 24
           Type: 13 BaseType int64
@@ -1854,12 +1854,12 @@ Types:
       RawFields:
         - Name: Value
           Offset: 0
-          Type: 75 GoMapType map[string][]string
+          Type: 77 GoMapType map[string][]string
         - Name: File
           Offset: 8
-          Type: 76 GoMapType map[string][]*mime/multipart.FileHeader
+          Type: 78 GoMapType map[string][]*mime/multipart.FileHeader
     - __kind: GoSliceHeaderType
-      ID: 131
+      ID: 158
       Name: net.IP
       ByteSize: 24
       GoRuntimeType: 2.109184e+06
@@ -1874,14 +1874,14 @@ Types:
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 195 GoSliceDataType net.IP.array
+      Data: 196 GoSliceDataType net.IP.array
     - __kind: GoSliceDataType
-      ID: 195
+      ID: 196
       Name: net.IP.array
       ByteSize: 2048
       Element: 3 BaseType uint8
     - __kind: GoSliceHeaderType
-      ID: 161
+      ID: 206
       Name: net.IPMask
       ByteSize: 24
       GoRuntimeType: 1.01072e+06
@@ -1903,7 +1903,7 @@ Types:
       ByteSize: 2048
       Element: 3 BaseType uint8
     - __kind: StructureType
-      ID: 159
+      ID: 182
       Name: net.IPNet
       ByteSize: 48
       GoRuntimeType: 1.448704e+06
@@ -1911,10 +1911,10 @@ Types:
       RawFields:
         - Name: IP
           Offset: 0
-          Type: 131 GoSliceHeaderType net.IP
+          Type: 158 GoSliceHeaderType net.IP
         - Name: Mask
           Offset: 24
-          Type: 161 GoSliceHeaderType net.IPMask
+          Type: 206 GoSliceHeaderType net.IPMask
     - __kind: GoMapType
       ID: 46
       Name: net/http.Header
@@ -2087,12 +2087,12 @@ Types:
           Type: 9 GoStringHeaderType string
         - Name: segments
           Offset: 48
-          Type: 90 GoSliceHeaderType []net/http.segment
+          Type: 92 GoSliceHeaderType []net/http.segment
         - Name: loc
           Offset: 72
           Type: 9 GoStringHeaderType string
     - __kind: StructureType
-      ID: 92
+      ID: 94
       Name: net/http.segment
       ByteSize: 24
       GoRuntimeType: 1.597216e+06
@@ -2108,7 +2108,7 @@ Types:
           Offset: 17
           Type: 4 BaseType bool
     - __kind: GoMapType
-      ID: 162
+      ID: 183
       Name: net/textproto.MIMEHeader
       ByteSize: 8
       GoRuntimeType: 1.808288e+06
@@ -2129,7 +2129,7 @@ Types:
           Type: 9 GoStringHeaderType string
         - Name: User
           Offset: 32
-          Type: 72 PointerType *net/url.Userinfo
+          Type: 74 PointerType *net/url.Userinfo
         - Name: Host
           Offset: 40
           Type: 9 GoStringHeaderType string
@@ -2155,7 +2155,7 @@ Types:
           Offset: 128
           Type: 9 GoStringHeaderType string
     - __kind: StructureType
-      ID: 73
+      ID: 75
       Name: net/url.Userinfo
       ByteSize: 40
       GoRuntimeType: 1.613536e+06
@@ -2178,34 +2178,34 @@ Types:
       GoKind: 21
       HeaderType: 48 GoSwissMapHeaderType map<string,[]string>
     - __kind: ArrayType
-      ID: 145
+      ID: 119
       Name: noalg.[8]struct { key string; elem []*mime/multipart.FileHeader }
       ByteSize: 320
       GoRuntimeType: 693888
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 146 StructureType noalg.struct { key string; elem []*mime/multipart.FileHeader }
+      Element: 120 StructureType noalg.struct { key string; elem []*mime/multipart.FileHeader }
     - __kind: ArrayType
-      ID: 102
+      ID: 99
       Name: noalg.[8]struct { key string; elem []string }
       ByteSize: 320
       GoRuntimeType: 683872
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 103 StructureType noalg.struct { key string; elem []string }
+      Element: 100 StructureType noalg.struct { key string; elem []string }
     - __kind: ArrayType
-      ID: 143
+      ID: 108
       Name: noalg.[8]struct { key string; elem string }
       ByteSize: 256
       GoRuntimeType: 688032
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 144 StructureType noalg.struct { key string; elem string }
+      Element: 109 StructureType noalg.struct { key string; elem string }
     - __kind: StructureType
-      ID: 106
+      ID: 118
       Name: noalg.map.group[string][]*mime/multipart.FileHeader
       ByteSize: 328
       GoRuntimeType: 1.289824e+06
@@ -2216,9 +2216,9 @@ Types:
           Type: 8 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 145 ArrayType noalg.[8]struct { key string; elem []*mime/multipart.FileHeader }
+          Type: 119 ArrayType noalg.[8]struct { key string; elem []*mime/multipart.FileHeader }
     - __kind: StructureType
-      ID: 96
+      ID: 98
       Name: noalg.map.group[string][]string
       ByteSize: 328
       GoRuntimeType: 1.280352e+06
@@ -2229,9 +2229,9 @@ Types:
           Type: 8 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 102 ArrayType noalg.[8]struct { key string; elem []string }
+          Type: 99 ArrayType noalg.[8]struct { key string; elem []string }
     - __kind: StructureType
-      ID: 101
+      ID: 107
       Name: noalg.map.group[string]string
       ByteSize: 264
       GoRuntimeType: 1.282656e+06
@@ -2242,9 +2242,9 @@ Types:
           Type: 8 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 143 ArrayType noalg.[8]struct { key string; elem string }
+          Type: 108 ArrayType noalg.[8]struct { key string; elem string }
     - __kind: StructureType
-      ID: 146
+      ID: 120
       Name: noalg.struct { key string; elem []*mime/multipart.FileHeader }
       ByteSize: 40
       GoRuntimeType: 1.289696e+06
@@ -2255,9 +2255,9 @@ Types:
           Type: 9 GoStringHeaderType string
         - Name: elem
           Offset: 16
-          Type: 147 GoSliceHeaderType []*mime/multipart.FileHeader
+          Type: 121 GoSliceHeaderType []*mime/multipart.FileHeader
     - __kind: StructureType
-      ID: 103
+      ID: 100
       Name: noalg.struct { key string; elem []string }
       ByteSize: 40
       GoRuntimeType: 1.280224e+06
@@ -2270,7 +2270,7 @@ Types:
           Offset: 16
           Type: 53 GoSliceHeaderType []string
     - __kind: StructureType
-      ID: 144
+      ID: 109
       Name: noalg.struct { key string; elem string }
       ByteSize: 32
       GoRuntimeType: 1.282528e+06
@@ -2291,17 +2291,17 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 164 PointerType *string.str
+          Type: 73 PointerType *string.str
         - Name: len
           Offset: 8
           Type: 7 BaseType int
-      Data: 163 GoStringDataType string.str
+      Data: 72 GoStringDataType string.str
     - __kind: GoStringDataType
-      ID: 163
+      ID: 72
       Name: string.str
       ByteSize: 2048
     - __kind: StructureType
-      ID: 97
+      ID: 114
       Name: table<string,[]*mime/multipart.FileHeader>
       ByteSize: 32
       GoKind: 25
@@ -2323,9 +2323,9 @@ Types:
           Type: 7 BaseType int
         - Name: groups
           Offset: 16
-          Type: 104 GoSwissMapGroupsType groupReference<string,[]*mime/multipart.FileHeader>
+          Type: 116 GoSwissMapGroupsType groupReference<string,[]*mime/multipart.FileHeader>
     - __kind: StructureType
-      ID: 74
+      ID: 76
       Name: table<string,[]string>
       ByteSize: 32
       GoKind: 25
@@ -2347,9 +2347,9 @@ Types:
           Type: 7 BaseType int
         - Name: groups
           Offset: 16
-          Type: 94 GoSwissMapGroupsType groupReference<string,[]string>
+          Type: 96 GoSwissMapGroupsType groupReference<string,[]string>
     - __kind: StructureType
-      ID: 93
+      ID: 95
       Name: table<string,string>
       ByteSize: 32
       GoKind: 25
@@ -2371,9 +2371,9 @@ Types:
           Type: 7 BaseType int
         - Name: groups
           Offset: 16
-          Type: 99 GoSwissMapGroupsType groupReference<string,string>
+          Type: 105 GoSwissMapGroupsType groupReference<string,string>
     - __kind: StructureType
-      ID: 118
+      ID: 145
       Name: time.Location
       ByteSize: 104
       GoRuntimeType: 1.957824e+06
@@ -2384,10 +2384,10 @@ Types:
           Type: 9 GoStringHeaderType string
         - Name: zone
           Offset: 16
-          Type: 153 GoSliceHeaderType []time.zone
+          Type: 176 GoSliceHeaderType []time.zone
         - Name: tx
           Offset: 40
-          Type: 156 GoSliceHeaderType []time.zoneTrans
+          Type: 179 GoSliceHeaderType []time.zoneTrans
         - Name: extend
           Offset: 64
           Type: 9 GoStringHeaderType string
@@ -2399,9 +2399,9 @@ Types:
           Type: 13 BaseType int64
         - Name: cacheZone
           Offset: 96
-          Type: 154 PointerType *time.zone
+          Type: 177 PointerType *time.zone
     - __kind: StructureType
-      ID: 116
+      ID: 143
       Name: time.Time
       ByteSize: 24
       GoRuntimeType: 2.34832e+06
@@ -2415,9 +2415,9 @@ Types:
           Type: 13 BaseType int64
         - Name: loc
           Offset: 16
-          Type: 117 PointerType *time.Location
+          Type: 144 PointerType *time.Location
     - __kind: StructureType
-      ID: 155
+      ID: 178
       Name: time.zone
       ByteSize: 32
       GoRuntimeType: 1.602208e+06
@@ -2433,7 +2433,7 @@ Types:
           Offset: 24
           Type: 4 BaseType bool
     - __kind: StructureType
-      ID: 158
+      ID: 181
       Name: time.zoneTrans
       ByteSize: 16
       GoRuntimeType: 1.736576e+06

--- a/pkg/dyninst/irgen/testdata/snapshot/rc_tester_v1.arch=arm64,toolchain=go1.24.3.yaml
+++ b/pkg/dyninst/irgen/testdata/snapshot/rc_tester_v1.arch=arm64,toolchain=go1.24.3.yaml
@@ -120,432 +120,319 @@ Subprograms:
           IsParameter: true
           IsReturn: false
 Types:
-    - __kind: GoInterfaceType
-      ID: 1
-      Name: net/http.ResponseWriter
-      ByteSize: 16
-      GoRuntimeType: 1.176352e+06
-      GoKind: 20
-      RawFields:
-        - Name: tab
-          Offset: 0
-          Type: 2 VoidPointerType unsafe.Pointer
-        - Name: data
-          Offset: 8
-          Type: 2 VoidPointerType unsafe.Pointer
-    - __kind: VoidPointerType
-      ID: 2
-      Name: unsafe.Pointer
-      ByteSize: 8
-      GoRuntimeType: 580512
-      GoKind: 26
     - __kind: PointerType
-      ID: 3
-      Name: '*net/http.Request'
+      ID: 57
+      Name: '**crypto/x509.Certificate'
       ByteSize: 8
-      GoRuntimeType: 2.2848e+06
       GoKind: 22
-      Pointee: 4 StructureType net/http.Request
-    - __kind: StructureType
-      ID: 4
-      Name: net/http.Request
-      ByteSize: 304
-      GoRuntimeType: 2.322048e+06
-      GoKind: 25
-      RawFields:
-        - Name: Method
-          Offset: 0
-          Type: 5 GoStringHeaderType string
-        - Name: URL
-          Offset: 16
-          Type: 9 PointerType *net/url.URL
-        - Name: Proto
-          Offset: 24
-          Type: 5 GoStringHeaderType string
-        - Name: ProtoMajor
-          Offset: 40
-          Type: 8 BaseType int
-        - Name: ProtoMinor
-          Offset: 48
-          Type: 8 BaseType int
-        - Name: Header
-          Offset: 56
-          Type: 14 GoMapType net/http.Header
-        - Name: Body
-          Offset: 64
-          Type: 30 GoInterfaceType io.ReadCloser
-        - Name: GetBody
-          Offset: 80
-          Type: 31 GoSubroutineType func() (io.ReadCloser, error)
-        - Name: ContentLength
-          Offset: 88
-          Type: 32 BaseType int64
-        - Name: TransferEncoding
-          Offset: 96
-          Type: 28 GoSliceHeaderType []string
-        - Name: Close
-          Offset: 120
-          Type: 13 BaseType bool
-        - Name: Host
-          Offset: 128
-          Type: 5 GoStringHeaderType string
-        - Name: Form
-          Offset: 144
-          Type: 33 GoMapType net/url.Values
-        - Name: PostForm
-          Offset: 152
-          Type: 33 GoMapType net/url.Values
-        - Name: MultipartForm
-          Offset: 160
-          Type: 34 PointerType *mime/multipart.Form
-        - Name: Trailer
-          Offset: 168
-          Type: 14 GoMapType net/http.Header
-        - Name: RemoteAddr
-          Offset: 176
-          Type: 5 GoStringHeaderType string
-        - Name: RequestURI
-          Offset: 192
-          Type: 5 GoStringHeaderType string
-        - Name: TLS
-          Offset: 208
-          Type: 54 PointerType *crypto/tls.ConnectionState
-        - Name: Cancel
-          Offset: 216
-          Type: 114 GoChannelType <-chan struct {}
-        - Name: Response
-          Offset: 224
-          Type: 115 PointerType *net/http.Response
-        - Name: Pattern
-          Offset: 232
-          Type: 5 GoStringHeaderType string
-        - Name: ctx
-          Offset: 248
-          Type: 117 GoInterfaceType context.Context
-        - Name: pat
-          Offset: 264
-          Type: 118 PointerType *net/http.pattern
-        - Name: matches
-          Offset: 272
-          Type: 28 GoSliceHeaderType []string
-        - Name: otherValues
-          Offset: 296
-          Type: 123 GoMapType map[string]string
-    - __kind: GoStringHeaderType
-      ID: 5
-      Name: string
-      ByteSize: 16
-      GoRuntimeType: 579424
-      GoKind: 24
-      RawFields:
-        - Name: str
-          Offset: 0
-          Type: 164 PointerType *string.str
-        - Name: len
-          Offset: 8
-          Type: 8 BaseType int
-      Data: 163 GoStringDataType string.str
+      Pointee: 58 PointerType *crypto/x509.Certificate
     - __kind: PointerType
-      ID: 6
-      Name: '*uint8'
+      ID: 49
+      Name: '**mime/multipart.FileHeader'
       ByteSize: 8
-      GoRuntimeType: 396288
       GoKind: 22
-      Pointee: 7 BaseType uint8
-    - __kind: BaseType
-      ID: 7
-      Name: uint8
-      ByteSize: 1
-      GoRuntimeType: 579552
-      GoKind: 8
-    - __kind: BaseType
-      ID: 8
-      Name: int
-      ByteSize: 8
-      GoRuntimeType: 580000
-      GoKind: 2
+      Pointee: 50 PointerType *mime/multipart.FileHeader
     - __kind: PointerType
-      ID: 9
-      Name: '*net/url.URL'
+      ID: 98
+      Name: '**net.IPNet'
       ByteSize: 8
-      GoRuntimeType: 2.099328e+06
       GoKind: 22
-      Pointee: 10 StructureType net/url.URL
-    - __kind: StructureType
-      ID: 10
-      Name: net/url.URL
-      ByteSize: 144
-      GoRuntimeType: 2.112256e+06
-      GoKind: 25
-      RawFields:
-        - Name: Scheme
-          Offset: 0
-          Type: 5 GoStringHeaderType string
-        - Name: Opaque
-          Offset: 16
-          Type: 5 GoStringHeaderType string
-        - Name: User
-          Offset: 32
-          Type: 11 PointerType *net/url.Userinfo
-        - Name: Host
-          Offset: 40
-          Type: 5 GoStringHeaderType string
-        - Name: Path
-          Offset: 56
-          Type: 5 GoStringHeaderType string
-        - Name: RawPath
-          Offset: 72
-          Type: 5 GoStringHeaderType string
-        - Name: OmitHost
-          Offset: 88
-          Type: 13 BaseType bool
-        - Name: ForceQuery
-          Offset: 89
-          Type: 13 BaseType bool
-        - Name: RawQuery
-          Offset: 96
-          Type: 5 GoStringHeaderType string
-        - Name: Fragment
-          Offset: 112
-          Type: 5 GoStringHeaderType string
-        - Name: RawFragment
-          Offset: 128
-          Type: 5 GoStringHeaderType string
+      Pointee: 99 PointerType *net.IPNet
     - __kind: PointerType
-      ID: 11
-      Name: '*net/url.Userinfo'
+      ID: 96
+      Name: '**net/url.URL'
       ByteSize: 8
-      GoRuntimeType: 1.191456e+06
-      GoKind: 22
-      Pointee: 12 StructureType net/url.Userinfo
-    - __kind: StructureType
-      ID: 12
-      Name: net/url.Userinfo
-      ByteSize: 40
-      GoRuntimeType: 1.613536e+06
-      GoKind: 25
-      RawFields:
-        - Name: username
-          Offset: 0
-          Type: 5 GoStringHeaderType string
-        - Name: password
-          Offset: 16
-          Type: 5 GoStringHeaderType string
-        - Name: passwordSet
-          Offset: 32
-          Type: 13 BaseType bool
-    - __kind: BaseType
-      ID: 13
-      Name: bool
-      ByteSize: 1
-      GoRuntimeType: 580448
-      GoKind: 1
-    - __kind: GoMapType
-      ID: 14
-      Name: net/http.Header
-      ByteSize: 8
-      GoRuntimeType: 2.08736e+06
-      GoKind: 21
-      HeaderType: 16 GoSwissMapHeaderType map<string,[]string>
+      Pointee: 9 PointerType *net/url.URL
     - __kind: PointerType
-      ID: 15
-      Name: '*map<string,[]string>'
+      ID: 40
+      Name: '**table<string,[]*mime/multipart.FileHeader>'
       ByteSize: 8
-      Pointee: 16 GoSwissMapHeaderType map<string,[]string>
-    - __kind: GoSwissMapHeaderType
-      ID: 16
-      Name: map<string,[]string>
-      ByteSize: 48
-      GoKind: 25
-      RawFields:
-        - Name: used
-          Offset: 0
-          Type: 17 BaseType uint64
-        - Name: seed
-          Offset: 8
-          Type: 18 BaseType uintptr
-        - Name: dirPtr
-          Offset: 16
-          Type: 19 PointerType **table<string,[]string>
-        - Name: dirLen
-          Offset: 24
-          Type: 8 BaseType int
-        - Name: globalDepth
-          Offset: 32
-          Type: 7 BaseType uint8
-        - Name: globalShift
-          Offset: 33
-          Type: 7 BaseType uint8
-        - Name: writing
-          Offset: 34
-          Type: 7 BaseType uint8
-        - Name: clearSeq
-          Offset: 40
-          Type: 17 BaseType uint64
-      TablePtrSliceType: 165 GoSliceDataType []*table<string,[]string>.array
-      GroupType: 25 StructureType noalg.map.group[string][]string
-    - __kind: BaseType
-      ID: 17
-      Name: uint64
-      ByteSize: 8
-      GoRuntimeType: 579936
-      GoKind: 11
-    - __kind: BaseType
-      ID: 18
-      Name: uintptr
-      ByteSize: 8
-      GoRuntimeType: 580128
-      GoKind: 12
+      Pointee: 41 PointerType *table<string,[]*mime/multipart.FileHeader>
     - __kind: PointerType
       ID: 19
       Name: '**table<string,[]string>'
       ByteSize: 8
       Pointee: 20 PointerType *table<string,[]string>
     - __kind: PointerType
-      ID: 20
-      Name: '*table<string,[]string>'
+      ID: 126
+      Name: '**table<string,string>'
       ByteSize: 8
-      Pointee: 21 StructureType table<string,[]string>
-    - __kind: StructureType
-      ID: 21
-      Name: table<string,[]string>
-      ByteSize: 32
-      GoKind: 25
-      RawFields:
-        - Name: used
-          Offset: 0
-          Type: 22 BaseType uint16
-        - Name: capacity
-          Offset: 2
-          Type: 22 BaseType uint16
-        - Name: growthLeft
-          Offset: 4
-          Type: 22 BaseType uint16
-        - Name: localDepth
-          Offset: 6
-          Type: 7 BaseType uint8
-        - Name: index
-          Offset: 8
-          Type: 8 BaseType int
-        - Name: groups
-          Offset: 16
-          Type: 23 GoSwissMapGroupsType groupReference<string,[]string>
-    - __kind: BaseType
-      ID: 22
-      Name: uint16
-      ByteSize: 2
-      GoRuntimeType: 579680
-      GoKind: 9
-    - __kind: GoSwissMapGroupsType
-      ID: 23
-      Name: groupReference<string,[]string>
-      ByteSize: 16
-      GoKind: 25
-      RawFields:
-        - Name: data
-          Offset: 0
-          Type: 24 PointerType *noalg.map.group[string][]string
-        - Name: lengthMask
-          Offset: 8
-          Type: 17 BaseType uint64
-      GroupType: 25 StructureType noalg.map.group[string][]string
-      GroupSliceType: 166 GoSliceDataType []noalg.map.group[string][]string.array
+      Pointee: 127 PointerType *table<string,string>
     - __kind: PointerType
-      ID: 24
-      Name: '*noalg.map.group[string][]string'
+      ID: 109
+      Name: '*[]*crypto/x509.Certificate'
       ByteSize: 8
-      Pointee: 25 StructureType noalg.map.group[string][]string
-    - __kind: StructureType
-      ID: 25
-      Name: noalg.map.group[string][]string
-      ByteSize: 328
-      GoRuntimeType: 1.280352e+06
-      GoKind: 25
-      RawFields:
-        - Name: ctrl
-          Offset: 0
-          Type: 17 BaseType uint64
-        - Name: slots
-          Offset: 8
-          Type: 26 ArrayType noalg.[8]struct { key string; elem []string }
-    - __kind: ArrayType
-      ID: 26
-      Name: noalg.[8]struct { key string; elem []string }
-      ByteSize: 320
-      GoRuntimeType: 683872
-      GoKind: 17
-      Count: 8
-      HasCount: true
-      Element: 27 StructureType noalg.struct { key string; elem []string }
-    - __kind: StructureType
-      ID: 27
-      Name: noalg.struct { key string; elem []string }
-      ByteSize: 40
-      GoRuntimeType: 1.280224e+06
-      GoKind: 25
-      RawFields:
-        - Name: key
-          Offset: 0
-          Type: 5 GoStringHeaderType string
-        - Name: elem
-          Offset: 16
-          Type: 28 GoSliceHeaderType []string
-    - __kind: GoSliceHeaderType
-      ID: 28
-      Name: '[]string'
-      ByteSize: 24
-      GoRuntimeType: 492672
-      GoKind: 23
-      RawFields:
-        - Name: array
-          Offset: 0
-          Type: 29 PointerType *string
-        - Name: len
-          Offset: 8
-          Type: 8 BaseType int
-        - Name: cap
-          Offset: 16
-          Type: 8 BaseType int
-      Data: 167 GoSliceDataType []string.array
-    - __kind: PointerType
-      ID: 29
-      Name: '*string'
-      ByteSize: 8
-      GoRuntimeType: 396160
       GoKind: 22
-      Pointee: 5 GoStringHeaderType string
-    - __kind: GoInterfaceType
-      ID: 30
-      Name: io.ReadCloser
-      ByteSize: 16
-      GoRuntimeType: 1.100576e+06
-      GoKind: 20
-      RawFields:
-        - Name: tab
-          Offset: 0
-          Type: 2 VoidPointerType unsafe.Pointer
-        - Name: data
-          Offset: 8
-          Type: 2 VoidPointerType unsafe.Pointer
-    - __kind: GoSubroutineType
-      ID: 31
-      Name: func() (io.ReadCloser, error)
+      Pointee: 56 GoSliceHeaderType []*crypto/x509.Certificate
+    - __kind: PointerType
+      ID: 176
+      Name: '*[]*crypto/x509.Certificate.array'
       ByteSize: 8
-      GoRuntimeType: 687840
-      GoKind: 19
-    - __kind: BaseType
-      ID: 32
-      Name: int64
+      Pointee: 175 GoSliceDataType []*crypto/x509.Certificate.array
+    - __kind: PointerType
+      ID: 172
+      Name: '*[]*mime/multipart.FileHeader.array'
       ByteSize: 8
-      GoRuntimeType: 579872
-      GoKind: 6
-    - __kind: GoMapType
-      ID: 33
-      Name: net/url.Values
+      Pointee: 171 GoSliceDataType []*mime/multipart.FileHeader.array
+    - __kind: PointerType
+      ID: 200
+      Name: '*[]*net.IPNet.array'
       ByteSize: 8
-      GoRuntimeType: 1.870528e+06
-      GoKind: 21
-      HeaderType: 16 GoSwissMapHeaderType map<string,[]string>
+      Pointee: 199 GoSliceDataType []*net.IPNet.array
+    - __kind: PointerType
+      ID: 198
+      Name: '*[]*net/url.URL.array'
+      ByteSize: 8
+      Pointee: 197 GoSliceDataType []*net/url.URL.array
+    - __kind: PointerType
+      ID: 208
+      Name: '*[][]*crypto/x509.Certificate.array'
+      ByteSize: 8
+      Pointee: 207 GoSliceDataType [][]*crypto/x509.Certificate.array
+    - __kind: PointerType
+      ID: 210
+      Name: '*[][]uint8.array'
+      ByteSize: 8
+      Pointee: 209 GoSliceDataType [][]uint8.array
+    - __kind: PointerType
+      ID: 192
+      Name: '*[]crypto/x509.ExtKeyUsage.array'
+      ByteSize: 8
+      Pointee: 191 GoSliceDataType []crypto/x509.ExtKeyUsage.array
+    - __kind: PointerType
+      ID: 204
+      Name: '*[]crypto/x509.OID.array'
+      ByteSize: 8
+      Pointee: 203 GoSliceDataType []crypto/x509.OID.array
+    - __kind: PointerType
+      ID: 206
+      Name: '*[]crypto/x509.PolicyMapping.array'
+      ByteSize: 8
+      Pointee: 205 GoSliceDataType []crypto/x509.PolicyMapping.array
+    - __kind: PointerType
+      ID: 180
+      Name: '*[]crypto/x509/pkix.AttributeTypeAndValue.array'
+      ByteSize: 8
+      Pointee: 179 GoSliceDataType []crypto/x509/pkix.AttributeTypeAndValue.array
+    - __kind: PointerType
+      ID: 188
+      Name: '*[]crypto/x509/pkix.Extension.array'
+      ByteSize: 8
+      Pointee: 187 GoSliceDataType []crypto/x509/pkix.Extension.array
+    - __kind: PointerType
+      ID: 190
+      Name: '*[]encoding/asn1.ObjectIdentifier.array'
+      ByteSize: 8
+      Pointee: 189 GoSliceDataType []encoding/asn1.ObjectIdentifier.array
+    - __kind: PointerType
+      ID: 194
+      Name: '*[]net.IP.array'
+      ByteSize: 8
+      Pointee: 193 GoSliceDataType []net.IP.array
+    - __kind: PointerType
+      ID: 212
+      Name: '*[]net/http.segment.array'
+      ByteSize: 8
+      Pointee: 211 GoSliceDataType []net/http.segment.array
+    - __kind: PointerType
+      ID: 168
+      Name: '*[]string.array'
+      ByteSize: 8
+      Pointee: 167 GoSliceDataType []string.array
+    - __kind: PointerType
+      ID: 184
+      Name: '*[]time.zone.array'
+      ByteSize: 8
+      Pointee: 183 GoSliceDataType []time.zone.array
+    - __kind: PointerType
+      ID: 186
+      Name: '*[]time.zoneTrans.array'
+      ByteSize: 8
+      Pointee: 185 GoSliceDataType []time.zoneTrans.array
+    - __kind: PointerType
+      ID: 111
+      Name: '*[]uint8'
+      ByteSize: 8
+      GoRuntimeType: 478144
+      GoKind: 22
+      Pointee: 53 GoSliceHeaderType []uint8
+    - __kind: PointerType
+      ID: 174
+      Name: '*[]uint8.array'
+      ByteSize: 8
+      Pointee: 173 GoSliceDataType []uint8.array
+    - __kind: PointerType
+      ID: 142
+      Name: '*bool'
+      ByteSize: 8
+      GoRuntimeType: 397184
+      GoKind: 22
+      Pointee: 13 BaseType bool
+    - __kind: PointerType
+      ID: 134
+      Name: '*bytes.Buffer'
+      ByteSize: 8
+      GoRuntimeType: 2.245056e+06
+      GoKind: 22
+      Pointee: 135 StructureType bytes.Buffer
+    - __kind: PointerType
+      ID: 54
+      Name: '*crypto/tls.ConnectionState'
+      ByteSize: 8
+      GoRuntimeType: 900864
+      GoKind: 22
+      Pointee: 55 StructureType crypto/tls.ConnectionState
+    - __kind: PointerType
+      ID: 58
+      Name: '*crypto/x509.Certificate'
+      ByteSize: 8
+      GoRuntimeType: 2.030304e+06
+      GoKind: 22
+      Pointee: 59 StructureType crypto/x509.Certificate
+    - __kind: PointerType
+      ID: 90
+      Name: '*crypto/x509.ExtKeyUsage'
+      ByteSize: 8
+      GoRuntimeType: 420160
+      GoKind: 22
+      Pointee: 91 BaseType crypto/x509.ExtKeyUsage
+    - __kind: PointerType
+      ID: 103
+      Name: '*crypto/x509.OID'
+      ByteSize: 8
+      GoRuntimeType: 1.938144e+06
+      GoKind: 22
+      Pointee: 104 StructureType crypto/x509.OID
+    - __kind: PointerType
+      ID: 106
+      Name: '*crypto/x509.PolicyMapping'
+      ByteSize: 8
+      GoRuntimeType: 420224
+      GoKind: 22
+      Pointee: 107 StructureType crypto/x509.PolicyMapping
+    - __kind: PointerType
+      ID: 70
+      Name: '*crypto/x509/pkix.AttributeTypeAndValue'
+      ByteSize: 8
+      GoRuntimeType: 433984
+      GoKind: 22
+      Pointee: 71 StructureType crypto/x509/pkix.AttributeTypeAndValue
+    - __kind: PointerType
+      ID: 85
+      Name: '*crypto/x509/pkix.Extension'
+      ByteSize: 8
+      GoRuntimeType: 434176
+      GoKind: 22
+      Pointee: 86 StructureType crypto/x509/pkix.Extension
+    - __kind: PointerType
+      ID: 88
+      Name: '*encoding/asn1.ObjectIdentifier'
+      ByteSize: 8
+      GoRuntimeType: 1.044e+06
+      GoKind: 22
+      Pointee: 72 GoSliceHeaderType encoding/asn1.ObjectIdentifier
+    - __kind: PointerType
+      ID: 182
+      Name: '*encoding/asn1.ObjectIdentifier.array'
+      ByteSize: 8
+      Pointee: 181 GoSliceDataType encoding/asn1.ObjectIdentifier.array
+    - __kind: PointerType
+      ID: 160
+      Name: '*error'
+      ByteSize: 8
+      GoRuntimeType: 396096
+      GoKind: 22
+      Pointee: 144 GoInterfaceType error
+    - __kind: PointerType
+      ID: 162
+      Name: '*float32'
+      ByteSize: 8
+      GoRuntimeType: 397056
+      GoKind: 22
+      Pointee: 146 BaseType float32
+    - __kind: PointerType
+      ID: 154
+      Name: '*float64'
+      ByteSize: 8
+      GoRuntimeType: 397120
+      GoKind: 22
+      Pointee: 147 BaseType float64
+    - __kind: PointerType
+      ID: 73
+      Name: '*int'
+      ByteSize: 8
+      GoRuntimeType: 396736
+      GoKind: 22
+      Pointee: 8 BaseType int
+    - __kind: PointerType
+      ID: 158
+      Name: '*int16'
+      ByteSize: 8
+      GoRuntimeType: 396352
+      GoKind: 22
+      Pointee: 151 BaseType int16
+    - __kind: PointerType
+      ID: 149
+      Name: '*int32'
+      ByteSize: 8
+      GoRuntimeType: 396480
+      GoKind: 22
+      Pointee: 143 BaseType int32
+    - __kind: PointerType
+      ID: 155
+      Name: '*int64'
+      ByteSize: 8
+      GoRuntimeType: 396608
+      GoKind: 22
+      Pointee: 32 BaseType int64
+    - __kind: PointerType
+      ID: 159
+      Name: '*int8'
+      ByteSize: 8
+      GoRuntimeType: 396224
+      GoKind: 22
+      Pointee: 145 BaseType int8
+    - __kind: PointerType
+      ID: 38
+      Name: '*map<string,[]*mime/multipart.FileHeader>'
+      ByteSize: 8
+      Pointee: 39 GoSwissMapHeaderType map<string,[]*mime/multipart.FileHeader>
+    - __kind: PointerType
+      ID: 15
+      Name: '*map<string,[]string>'
+      ByteSize: 8
+      Pointee: 16 GoSwissMapHeaderType map<string,[]string>
+    - __kind: PointerType
+      ID: 124
+      Name: '*map<string,string>'
+      ByteSize: 8
+      Pointee: 125 GoSwissMapHeaderType map<string,string>
+    - __kind: PointerType
+      ID: 63
+      Name: '*math/big.Int'
+      ByteSize: 8
+      GoRuntimeType: 2.364704e+06
+      GoKind: 22
+      Pointee: 64 StructureType math/big.Int
+    - __kind: PointerType
+      ID: 66
+      Name: '*math/big.Word'
+      ByteSize: 8
+      GoRuntimeType: 423040
+      GoKind: 22
+      Pointee: 67 BaseType math/big.Word
+    - __kind: PointerType
+      ID: 178
+      Name: '*math/big.nat.array'
+      ByteSize: 8
+      Pointee: 177 GoSliceDataType math/big.nat.array
+    - __kind: PointerType
+      ID: 50
+      Name: '*mime/multipart.FileHeader'
+      ByteSize: 8
+      GoRuntimeType: 902304
+      GoKind: 22
+      Pointee: 51 StructureType mime/multipart.FileHeader
     - __kind: PointerType
       ID: 34
       Name: '*mime/multipart.Form'
@@ -553,158 +440,243 @@ Types:
       GoRuntimeType: 902400
       GoKind: 22
       Pointee: 35 StructureType mime/multipart.Form
-    - __kind: StructureType
-      ID: 35
-      Name: mime/multipart.Form
-      ByteSize: 16
-      GoRuntimeType: 1.467264e+06
-      GoKind: 25
-      RawFields:
-        - Name: Value
-          Offset: 0
-          Type: 36 GoMapType map[string][]string
-        - Name: File
-          Offset: 8
-          Type: 37 GoMapType map[string][]*mime/multipart.FileHeader
-    - __kind: GoMapType
-      ID: 36
-      Name: map[string][]string
-      ByteSize: 8
-      GoRuntimeType: 1.117984e+06
-      GoKind: 21
-      HeaderType: 16 GoSwissMapHeaderType map<string,[]string>
-    - __kind: GoMapType
-      ID: 37
-      Name: map[string][]*mime/multipart.FileHeader
-      ByteSize: 8
-      GoRuntimeType: 1.122592e+06
-      GoKind: 21
-      HeaderType: 39 GoSwissMapHeaderType map<string,[]*mime/multipart.FileHeader>
     - __kind: PointerType
-      ID: 38
-      Name: '*map<string,[]*mime/multipart.FileHeader>'
+      ID: 93
+      Name: '*net.IP'
       ByteSize: 8
-      Pointee: 39 GoSwissMapHeaderType map<string,[]*mime/multipart.FileHeader>
-    - __kind: GoSwissMapHeaderType
-      ID: 39
-      Name: map<string,[]*mime/multipart.FileHeader>
-      ByteSize: 48
-      GoKind: 25
-      RawFields:
-        - Name: used
-          Offset: 0
-          Type: 17 BaseType uint64
-        - Name: seed
-          Offset: 8
-          Type: 18 BaseType uintptr
-        - Name: dirPtr
-          Offset: 16
-          Type: 40 PointerType **table<string,[]*mime/multipart.FileHeader>
-        - Name: dirLen
-          Offset: 24
-          Type: 8 BaseType int
-        - Name: globalDepth
-          Offset: 32
-          Type: 7 BaseType uint8
-        - Name: globalShift
-          Offset: 33
-          Type: 7 BaseType uint8
-        - Name: writing
-          Offset: 34
-          Type: 7 BaseType uint8
-        - Name: clearSeq
-          Offset: 40
-          Type: 17 BaseType uint64
-      TablePtrSliceType: 169 GoSliceDataType []*table<string,[]*mime/multipart.FileHeader>.array
-      GroupType: 45 StructureType noalg.map.group[string][]*mime/multipart.FileHeader
+      GoRuntimeType: 2.134112e+06
+      GoKind: 22
+      Pointee: 94 GoSliceHeaderType net.IP
     - __kind: PointerType
-      ID: 40
-      Name: '**table<string,[]*mime/multipart.FileHeader>'
+      ID: 196
+      Name: '*net.IP.array'
       ByteSize: 8
-      Pointee: 41 PointerType *table<string,[]*mime/multipart.FileHeader>
+      Pointee: 195 GoSliceDataType net.IP.array
     - __kind: PointerType
-      ID: 41
-      Name: '*table<string,[]*mime/multipart.FileHeader>'
+      ID: 202
+      Name: '*net.IPMask.array'
       ByteSize: 8
-      Pointee: 42 StructureType table<string,[]*mime/multipart.FileHeader>
-    - __kind: StructureType
-      ID: 42
-      Name: table<string,[]*mime/multipart.FileHeader>
-      ByteSize: 32
-      GoKind: 25
-      RawFields:
-        - Name: used
-          Offset: 0
-          Type: 22 BaseType uint16
-        - Name: capacity
-          Offset: 2
-          Type: 22 BaseType uint16
-        - Name: growthLeft
-          Offset: 4
-          Type: 22 BaseType uint16
-        - Name: localDepth
-          Offset: 6
-          Type: 7 BaseType uint8
-        - Name: index
-          Offset: 8
-          Type: 8 BaseType int
-        - Name: groups
-          Offset: 16
-          Type: 43 GoSwissMapGroupsType groupReference<string,[]*mime/multipart.FileHeader>
-    - __kind: GoSwissMapGroupsType
-      ID: 43
-      Name: groupReference<string,[]*mime/multipart.FileHeader>
-      ByteSize: 16
-      GoKind: 25
-      RawFields:
-        - Name: data
-          Offset: 0
-          Type: 44 PointerType *noalg.map.group[string][]*mime/multipart.FileHeader
-        - Name: lengthMask
-          Offset: 8
-          Type: 17 BaseType uint64
-      GroupType: 45 StructureType noalg.map.group[string][]*mime/multipart.FileHeader
-      GroupSliceType: 170 GoSliceDataType []noalg.map.group[string][]*mime/multipart.FileHeader.array
+      Pointee: 201 GoSliceDataType net.IPMask.array
+    - __kind: PointerType
+      ID: 99
+      Name: '*net.IPNet'
+      ByteSize: 8
+      GoRuntimeType: 1.17392e+06
+      GoKind: 22
+      Pointee: 100 StructureType net.IPNet
+    - __kind: PointerType
+      ID: 3
+      Name: '*net/http.Request'
+      ByteSize: 8
+      GoRuntimeType: 2.2848e+06
+      GoKind: 22
+      Pointee: 4 StructureType net/http.Request
+    - __kind: PointerType
+      ID: 115
+      Name: '*net/http.Response'
+      ByteSize: 8
+      GoRuntimeType: 1.705504e+06
+      GoKind: 22
+      Pointee: 116 StructureType net/http.Response
+    - __kind: PointerType
+      ID: 118
+      Name: '*net/http.pattern'
+      ByteSize: 8
+      GoRuntimeType: 1.597408e+06
+      GoKind: 22
+      Pointee: 119 StructureType net/http.pattern
+    - __kind: PointerType
+      ID: 121
+      Name: '*net/http.segment'
+      ByteSize: 8
+      GoRuntimeType: 388544
+      GoKind: 22
+      Pointee: 122 StructureType net/http.segment
+    - __kind: PointerType
+      ID: 9
+      Name: '*net/url.URL'
+      ByteSize: 8
+      GoRuntimeType: 2.099328e+06
+      GoKind: 22
+      Pointee: 10 StructureType net/url.URL
+    - __kind: PointerType
+      ID: 11
+      Name: '*net/url.Userinfo'
+      ByteSize: 8
+      GoRuntimeType: 1.191456e+06
+      GoKind: 22
+      Pointee: 12 StructureType net/url.Userinfo
     - __kind: PointerType
       ID: 44
       Name: '*noalg.map.group[string][]*mime/multipart.FileHeader'
       ByteSize: 8
       Pointee: 45 StructureType noalg.map.group[string][]*mime/multipart.FileHeader
-    - __kind: StructureType
-      ID: 45
-      Name: noalg.map.group[string][]*mime/multipart.FileHeader
-      ByteSize: 328
-      GoRuntimeType: 1.289824e+06
-      GoKind: 25
+    - __kind: PointerType
+      ID: 24
+      Name: '*noalg.map.group[string][]string'
+      ByteSize: 8
+      Pointee: 25 StructureType noalg.map.group[string][]string
+    - __kind: PointerType
+      ID: 130
+      Name: '*noalg.map.group[string]string'
+      ByteSize: 8
+      Pointee: 131 StructureType noalg.map.group[string]string
+    - __kind: PointerType
+      ID: 29
+      Name: '*string'
+      ByteSize: 8
+      GoRuntimeType: 396160
+      GoKind: 22
+      Pointee: 5 GoStringHeaderType string
+    - __kind: PointerType
+      ID: 164
+      Name: '*string.str'
+      ByteSize: 8
+      Pointee: 163 GoStringDataType string.str
+    - __kind: PointerType
+      ID: 41
+      Name: '*table<string,[]*mime/multipart.FileHeader>'
+      ByteSize: 8
+      Pointee: 42 StructureType table<string,[]*mime/multipart.FileHeader>
+    - __kind: PointerType
+      ID: 20
+      Name: '*table<string,[]string>'
+      ByteSize: 8
+      Pointee: 21 StructureType table<string,[]string>
+    - __kind: PointerType
+      ID: 127
+      Name: '*table<string,string>'
+      ByteSize: 8
+      Pointee: 128 StructureType table<string,string>
+    - __kind: PointerType
+      ID: 75
+      Name: '*time.Location'
+      ByteSize: 8
+      GoRuntimeType: 1.6024e+06
+      GoKind: 22
+      Pointee: 76 StructureType time.Location
+    - __kind: PointerType
+      ID: 78
+      Name: '*time.zone'
+      ByteSize: 8
+      GoRuntimeType: 391680
+      GoKind: 22
+      Pointee: 79 StructureType time.zone
+    - __kind: PointerType
+      ID: 81
+      Name: '*time.zoneTrans'
+      ByteSize: 8
+      GoRuntimeType: 391744
+      GoKind: 22
+      Pointee: 82 StructureType time.zoneTrans
+    - __kind: PointerType
+      ID: 161
+      Name: '*uint'
+      ByteSize: 8
+      GoRuntimeType: 396800
+      GoKind: 22
+      Pointee: 141 BaseType uint
+    - __kind: PointerType
+      ID: 157
+      Name: '*uint16'
+      ByteSize: 8
+      GoRuntimeType: 396416
+      GoKind: 22
+      Pointee: 22 BaseType uint16
+    - __kind: PointerType
+      ID: 150
+      Name: '*uint32'
+      ByteSize: 8
+      GoRuntimeType: 396544
+      GoKind: 22
+      Pointee: 140 BaseType uint32
+    - __kind: PointerType
+      ID: 156
+      Name: '*uint64'
+      ByteSize: 8
+      GoRuntimeType: 396672
+      GoKind: 22
+      Pointee: 17 BaseType uint64
+    - __kind: PointerType
+      ID: 6
+      Name: '*uint8'
+      ByteSize: 8
+      GoRuntimeType: 396288
+      GoKind: 22
+      Pointee: 7 BaseType uint8
+    - __kind: PointerType
+      ID: 148
+      Name: '*uintptr'
+      ByteSize: 8
+      GoRuntimeType: 396864
+      GoKind: 22
+      Pointee: 18 BaseType uintptr
+    - __kind: GoChannelType
+      ID: 114
+      Name: <-chan struct {}
+      GoRuntimeType: 592672
+      GoKind: 18
+    - __kind: EventRootType
+      ID: 215
+      Name: Probe[main.HandleHTTP]
+      ByteSize: 25
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: w
+          Offset: 1
+          Expression:
+            Type: 1 GoInterfaceType net/http.ResponseWriter
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 1, index: 0, name: w}
+                  Offset: 0
+                  ByteSize: 16
+        - Name: r
+          Offset: 17
+          Expression:
+            Type: 3 PointerType *net/http.Request
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 1, index: 1, name: r}
+                  Offset: 0
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 216
+      Name: Probe[main.LookAtTheRequest]
+      ByteSize: 17
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: path
+          Offset: 1
+          Expression:
+            Type: 5 GoStringHeaderType string
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 2, index: 0, name: path}
+                  Offset: 0
+                  ByteSize: 16
+    - __kind: GoSliceHeaderType
+      ID: 56
+      Name: '[]*crypto/x509.Certificate'
+      ByteSize: 24
+      GoRuntimeType: 498304
+      GoKind: 23
       RawFields:
-        - Name: ctrl
+        - Name: array
           Offset: 0
-          Type: 17 BaseType uint64
-        - Name: slots
+          Type: 57 PointerType **crypto/x509.Certificate
+        - Name: len
           Offset: 8
-          Type: 46 ArrayType noalg.[8]struct { key string; elem []*mime/multipart.FileHeader }
-    - __kind: ArrayType
-      ID: 46
-      Name: noalg.[8]struct { key string; elem []*mime/multipart.FileHeader }
-      ByteSize: 320
-      GoRuntimeType: 693888
-      GoKind: 17
-      Count: 8
-      HasCount: true
-      Element: 47 StructureType noalg.struct { key string; elem []*mime/multipart.FileHeader }
-    - __kind: StructureType
-      ID: 47
-      Name: noalg.struct { key string; elem []*mime/multipart.FileHeader }
-      ByteSize: 40
-      GoRuntimeType: 1.289696e+06
-      GoKind: 25
-      RawFields:
-        - Name: key
-          Offset: 0
-          Type: 5 GoStringHeaderType string
-        - Name: elem
+          Type: 8 BaseType int
+        - Name: cap
           Offset: 16
-          Type: 48 GoSliceHeaderType []*mime/multipart.FileHeader
+          Type: 8 BaseType int
+      Data: 175 GoSliceDataType []*crypto/x509.Certificate.array
+    - __kind: GoSliceDataType
+      ID: 175
+      Name: '[]*crypto/x509.Certificate.array'
+      ByteSize: 2048
+      Element: 58 PointerType *crypto/x509.Certificate
     - __kind: GoSliceHeaderType
       ID: 48
       Name: '[]*mime/multipart.FileHeader'
@@ -722,54 +694,371 @@ Types:
           Offset: 16
           Type: 8 BaseType int
       Data: 171 GoSliceDataType []*mime/multipart.FileHeader.array
-    - __kind: PointerType
-      ID: 49
-      Name: '**mime/multipart.FileHeader'
-      ByteSize: 8
-      GoKind: 22
-      Pointee: 50 PointerType *mime/multipart.FileHeader
-    - __kind: PointerType
-      ID: 50
-      Name: '*mime/multipart.FileHeader'
-      ByteSize: 8
-      GoRuntimeType: 902304
-      GoKind: 22
-      Pointee: 51 StructureType mime/multipart.FileHeader
-    - __kind: StructureType
-      ID: 51
-      Name: mime/multipart.FileHeader
-      ByteSize: 88
-      GoRuntimeType: 1.962144e+06
-      GoKind: 25
+    - __kind: GoSliceDataType
+      ID: 171
+      Name: '[]*mime/multipart.FileHeader.array'
+      ByteSize: 2048
+      Element: 50 PointerType *mime/multipart.FileHeader
+    - __kind: GoSliceHeaderType
+      ID: 97
+      Name: '[]*net.IPNet'
+      ByteSize: 24
+      GoRuntimeType: 511840
+      GoKind: 23
       RawFields:
-        - Name: Filename
+        - Name: array
           Offset: 0
-          Type: 5 GoStringHeaderType string
-        - Name: Header
+          Type: 98 PointerType **net.IPNet
+        - Name: len
+          Offset: 8
+          Type: 8 BaseType int
+        - Name: cap
           Offset: 16
-          Type: 52 GoMapType net/textproto.MIMEHeader
-        - Name: Size
-          Offset: 24
-          Type: 32 BaseType int64
-        - Name: content
-          Offset: 32
-          Type: 53 GoSliceHeaderType []uint8
-        - Name: tmpfile
-          Offset: 56
-          Type: 5 GoStringHeaderType string
-        - Name: tmpoff
-          Offset: 72
-          Type: 32 BaseType int64
-        - Name: tmpshared
-          Offset: 80
-          Type: 13 BaseType bool
-    - __kind: GoMapType
-      ID: 52
-      Name: net/textproto.MIMEHeader
-      ByteSize: 8
-      GoRuntimeType: 1.808288e+06
-      GoKind: 21
-      HeaderType: 16 GoSwissMapHeaderType map<string,[]string>
+          Type: 8 BaseType int
+      Data: 199 GoSliceDataType []*net.IPNet.array
+    - __kind: GoSliceDataType
+      ID: 199
+      Name: '[]*net.IPNet.array'
+      ByteSize: 2048
+      Element: 99 PointerType *net.IPNet
+    - __kind: GoSliceHeaderType
+      ID: 95
+      Name: '[]*net/url.URL'
+      ByteSize: 24
+      GoRuntimeType: 511776
+      GoKind: 23
+      RawFields:
+        - Name: array
+          Offset: 0
+          Type: 96 PointerType **net/url.URL
+        - Name: len
+          Offset: 8
+          Type: 8 BaseType int
+        - Name: cap
+          Offset: 16
+          Type: 8 BaseType int
+      Data: 197 GoSliceDataType []*net/url.URL.array
+    - __kind: GoSliceDataType
+      ID: 197
+      Name: '[]*net/url.URL.array'
+      ByteSize: 2048
+      Element: 9 PointerType *net/url.URL
+    - __kind: GoSliceDataType
+      ID: 169
+      Name: '[]*table<string,[]*mime/multipart.FileHeader>.array'
+      ByteSize: 8192
+      Element: 41 PointerType *table<string,[]*mime/multipart.FileHeader>
+    - __kind: GoSliceDataType
+      ID: 165
+      Name: '[]*table<string,[]string>.array'
+      ByteSize: 8192
+      Element: 20 PointerType *table<string,[]string>
+    - __kind: GoSliceDataType
+      ID: 213
+      Name: '[]*table<string,string>.array'
+      ByteSize: 8192
+      Element: 127 PointerType *table<string,string>
+    - __kind: GoSliceHeaderType
+      ID: 108
+      Name: '[][]*crypto/x509.Certificate'
+      ByteSize: 24
+      GoRuntimeType: 498432
+      GoKind: 23
+      RawFields:
+        - Name: array
+          Offset: 0
+          Type: 109 PointerType *[]*crypto/x509.Certificate
+        - Name: len
+          Offset: 8
+          Type: 8 BaseType int
+        - Name: cap
+          Offset: 16
+          Type: 8 BaseType int
+      Data: 207 GoSliceDataType [][]*crypto/x509.Certificate.array
+    - __kind: GoSliceDataType
+      ID: 207
+      Name: '[][]*crypto/x509.Certificate.array'
+      ByteSize: 2048
+      Element: 56 GoSliceHeaderType []*crypto/x509.Certificate
+    - __kind: GoSliceHeaderType
+      ID: 110
+      Name: '[][]uint8'
+      ByteSize: 24
+      GoRuntimeType: 478528
+      GoKind: 23
+      RawFields:
+        - Name: array
+          Offset: 0
+          Type: 111 PointerType *[]uint8
+        - Name: len
+          Offset: 8
+          Type: 8 BaseType int
+        - Name: cap
+          Offset: 16
+          Type: 8 BaseType int
+      Data: 209 GoSliceDataType [][]uint8.array
+    - __kind: GoSliceDataType
+      ID: 209
+      Name: '[][]uint8.array'
+      ByteSize: 2048
+      Element: 53 GoSliceHeaderType []uint8
+    - __kind: GoSliceHeaderType
+      ID: 89
+      Name: '[]crypto/x509.ExtKeyUsage'
+      ByteSize: 24
+      GoRuntimeType: 499776
+      GoKind: 23
+      RawFields:
+        - Name: array
+          Offset: 0
+          Type: 90 PointerType *crypto/x509.ExtKeyUsage
+        - Name: len
+          Offset: 8
+          Type: 8 BaseType int
+        - Name: cap
+          Offset: 16
+          Type: 8 BaseType int
+      Data: 191 GoSliceDataType []crypto/x509.ExtKeyUsage.array
+    - __kind: GoSliceDataType
+      ID: 191
+      Name: '[]crypto/x509.ExtKeyUsage.array'
+      ByteSize: 2048
+      Element: 91 BaseType crypto/x509.ExtKeyUsage
+    - __kind: GoSliceHeaderType
+      ID: 102
+      Name: '[]crypto/x509.OID'
+      ByteSize: 24
+      GoRuntimeType: 511904
+      GoKind: 23
+      RawFields:
+        - Name: array
+          Offset: 0
+          Type: 103 PointerType *crypto/x509.OID
+        - Name: len
+          Offset: 8
+          Type: 8 BaseType int
+        - Name: cap
+          Offset: 16
+          Type: 8 BaseType int
+      Data: 203 GoSliceDataType []crypto/x509.OID.array
+    - __kind: GoSliceDataType
+      ID: 203
+      Name: '[]crypto/x509.OID.array'
+      ByteSize: 2048
+      Element: 104 StructureType crypto/x509.OID
+    - __kind: GoSliceHeaderType
+      ID: 105
+      Name: '[]crypto/x509.PolicyMapping'
+      ByteSize: 24
+      GoRuntimeType: 511968
+      GoKind: 23
+      RawFields:
+        - Name: array
+          Offset: 0
+          Type: 106 PointerType *crypto/x509.PolicyMapping
+        - Name: len
+          Offset: 8
+          Type: 8 BaseType int
+        - Name: cap
+          Offset: 16
+          Type: 8 BaseType int
+      Data: 205 GoSliceDataType []crypto/x509.PolicyMapping.array
+    - __kind: GoSliceDataType
+      ID: 205
+      Name: '[]crypto/x509.PolicyMapping.array'
+      ByteSize: 2048
+      Element: 107 StructureType crypto/x509.PolicyMapping
+    - __kind: GoSliceHeaderType
+      ID: 69
+      Name: '[]crypto/x509/pkix.AttributeTypeAndValue'
+      ByteSize: 24
+      GoRuntimeType: 512416
+      GoKind: 23
+      RawFields:
+        - Name: array
+          Offset: 0
+          Type: 70 PointerType *crypto/x509/pkix.AttributeTypeAndValue
+        - Name: len
+          Offset: 8
+          Type: 8 BaseType int
+        - Name: cap
+          Offset: 16
+          Type: 8 BaseType int
+      Data: 179 GoSliceDataType []crypto/x509/pkix.AttributeTypeAndValue.array
+    - __kind: GoSliceDataType
+      ID: 179
+      Name: '[]crypto/x509/pkix.AttributeTypeAndValue.array'
+      ByteSize: 2048
+      Element: 71 StructureType crypto/x509/pkix.AttributeTypeAndValue
+    - __kind: GoSliceHeaderType
+      ID: 84
+      Name: '[]crypto/x509/pkix.Extension'
+      ByteSize: 24
+      GoRuntimeType: 511648
+      GoKind: 23
+      RawFields:
+        - Name: array
+          Offset: 0
+          Type: 85 PointerType *crypto/x509/pkix.Extension
+        - Name: len
+          Offset: 8
+          Type: 8 BaseType int
+        - Name: cap
+          Offset: 16
+          Type: 8 BaseType int
+      Data: 187 GoSliceDataType []crypto/x509/pkix.Extension.array
+    - __kind: GoSliceDataType
+      ID: 187
+      Name: '[]crypto/x509/pkix.Extension.array'
+      ByteSize: 2048
+      Element: 86 StructureType crypto/x509/pkix.Extension
+    - __kind: GoSliceHeaderType
+      ID: 87
+      Name: '[]encoding/asn1.ObjectIdentifier'
+      ByteSize: 24
+      GoRuntimeType: 511712
+      GoKind: 23
+      RawFields:
+        - Name: array
+          Offset: 0
+          Type: 88 PointerType *encoding/asn1.ObjectIdentifier
+        - Name: len
+          Offset: 8
+          Type: 8 BaseType int
+        - Name: cap
+          Offset: 16
+          Type: 8 BaseType int
+      Data: 189 GoSliceDataType []encoding/asn1.ObjectIdentifier.array
+    - __kind: GoSliceDataType
+      ID: 189
+      Name: '[]encoding/asn1.ObjectIdentifier.array'
+      ByteSize: 2048
+      Element: 72 GoSliceHeaderType encoding/asn1.ObjectIdentifier
+    - __kind: GoSliceHeaderType
+      ID: 92
+      Name: '[]net.IP'
+      ByteSize: 24
+      GoRuntimeType: 479488
+      GoKind: 23
+      RawFields:
+        - Name: array
+          Offset: 0
+          Type: 93 PointerType *net.IP
+        - Name: len
+          Offset: 8
+          Type: 8 BaseType int
+        - Name: cap
+          Offset: 16
+          Type: 8 BaseType int
+      Data: 193 GoSliceDataType []net.IP.array
+    - __kind: GoSliceDataType
+      ID: 193
+      Name: '[]net.IP.array'
+      ByteSize: 2048
+      Element: 94 GoSliceHeaderType net.IP
+    - __kind: GoSliceHeaderType
+      ID: 120
+      Name: '[]net/http.segment'
+      ByteSize: 24
+      GoRuntimeType: 481120
+      GoKind: 23
+      RawFields:
+        - Name: array
+          Offset: 0
+          Type: 121 PointerType *net/http.segment
+        - Name: len
+          Offset: 8
+          Type: 8 BaseType int
+        - Name: cap
+          Offset: 16
+          Type: 8 BaseType int
+      Data: 211 GoSliceDataType []net/http.segment.array
+    - __kind: GoSliceDataType
+      ID: 211
+      Name: '[]net/http.segment.array'
+      ByteSize: 2048
+      Element: 122 StructureType net/http.segment
+    - __kind: GoSliceDataType
+      ID: 170
+      Name: '[]noalg.map.group[string][]*mime/multipart.FileHeader.array'
+      ByteSize: 2048
+      Element: 45 StructureType noalg.map.group[string][]*mime/multipart.FileHeader
+    - __kind: GoSliceDataType
+      ID: 166
+      Name: '[]noalg.map.group[string][]string.array'
+      ByteSize: 2048
+      Element: 25 StructureType noalg.map.group[string][]string
+    - __kind: GoSliceDataType
+      ID: 214
+      Name: '[]noalg.map.group[string]string.array'
+      ByteSize: 2048
+      Element: 131 StructureType noalg.map.group[string]string
+    - __kind: GoSliceHeaderType
+      ID: 28
+      Name: '[]string'
+      ByteSize: 24
+      GoRuntimeType: 492672
+      GoKind: 23
+      RawFields:
+        - Name: array
+          Offset: 0
+          Type: 29 PointerType *string
+        - Name: len
+          Offset: 8
+          Type: 8 BaseType int
+        - Name: cap
+          Offset: 16
+          Type: 8 BaseType int
+      Data: 167 GoSliceDataType []string.array
+    - __kind: GoSliceDataType
+      ID: 167
+      Name: '[]string.array'
+      ByteSize: 2048
+      Element: 5 GoStringHeaderType string
+    - __kind: GoSliceHeaderType
+      ID: 77
+      Name: '[]time.zone'
+      ByteSize: 24
+      GoRuntimeType: 485792
+      GoKind: 23
+      RawFields:
+        - Name: array
+          Offset: 0
+          Type: 78 PointerType *time.zone
+        - Name: len
+          Offset: 8
+          Type: 8 BaseType int
+        - Name: cap
+          Offset: 16
+          Type: 8 BaseType int
+      Data: 183 GoSliceDataType []time.zone.array
+    - __kind: GoSliceDataType
+      ID: 183
+      Name: '[]time.zone.array'
+      ByteSize: 2048
+      Element: 79 StructureType time.zone
+    - __kind: GoSliceHeaderType
+      ID: 80
+      Name: '[]time.zoneTrans'
+      ByteSize: 24
+      GoRuntimeType: 485856
+      GoKind: 23
+      RawFields:
+        - Name: array
+          Offset: 0
+          Type: 81 PointerType *time.zoneTrans
+        - Name: len
+          Offset: 8
+          Type: 8 BaseType int
+        - Name: cap
+          Offset: 16
+          Type: 8 BaseType int
+      Data: 185 GoSliceDataType []time.zoneTrans.array
+    - __kind: GoSliceDataType
+      ID: 185
+      Name: '[]time.zoneTrans.array'
+      ByteSize: 2048
+      Element: 82 StructureType time.zoneTrans
     - __kind: GoSliceHeaderType
       ID: 53
       Name: '[]uint8'
@@ -787,13 +1076,79 @@ Types:
           Offset: 16
           Type: 8 BaseType int
       Data: 173 GoSliceDataType []uint8.array
-    - __kind: PointerType
-      ID: 54
-      Name: '*crypto/tls.ConnectionState'
+    - __kind: GoSliceDataType
+      ID: 173
+      Name: '[]uint8.array'
+      ByteSize: 2048
+      Element: 7 BaseType uint8
+    - __kind: BaseType
+      ID: 13
+      Name: bool
+      ByteSize: 1
+      GoRuntimeType: 580448
+      GoKind: 1
+    - __kind: StructureType
+      ID: 135
+      Name: bytes.Buffer
+      ByteSize: 40
+      GoRuntimeType: 1.595104e+06
+      GoKind: 25
+      RawFields:
+        - Name: buf
+          Offset: 0
+          Type: 53 GoSliceHeaderType []uint8
+        - Name: off
+          Offset: 24
+          Type: 8 BaseType int
+        - Name: lastRead
+          Offset: 32
+          Type: 136 BaseType bytes.readOp
+    - __kind: BaseType
+      ID: 136
+      Name: bytes.readOp
+      ByteSize: 1
+      GoRuntimeType: 578592
+      GoKind: 3
+    - __kind: BaseType
+      ID: 153
+      Name: complex128
+      ByteSize: 16
+      GoRuntimeType: 580256
+      GoKind: 16
+    - __kind: BaseType
+      ID: 152
+      Name: complex64
       ByteSize: 8
-      GoRuntimeType: 900864
-      GoKind: 22
-      Pointee: 55 StructureType crypto/tls.ConnectionState
+      GoRuntimeType: 580192
+      GoKind: 15
+    - __kind: GoInterfaceType
+      ID: 117
+      Name: context.Context
+      ByteSize: 16
+      GoRuntimeType: 1.266912e+06
+      GoKind: 20
+      RawFields:
+        - Name: tab
+          Offset: 0
+          Type: 2 VoidPointerType unsafe.Pointer
+        - Name: data
+          Offset: 8
+          Type: 2 VoidPointerType unsafe.Pointer
+    - __kind: StructureType
+      ID: 138
+      Name: context.backgroundCtx
+      GoRuntimeType: 1.781408e+06
+      GoKind: 25
+      RawFields:
+        - Name: emptyCtx
+          Offset: 0
+          Type: 139 StructureType context.emptyCtx
+    - __kind: StructureType
+      ID: 139
+      Name: context.emptyCtx
+      GoRuntimeType: 1.58016e+06
+      GoKind: 25
+      RawFields: []
     - __kind: StructureType
       ID: 55
       Name: crypto/tls.ConnectionState
@@ -849,36 +1204,12 @@ Types:
         - Name: testingOnlyCurveID
           Offset: 186
           Type: 113 BaseType crypto/tls.CurveID
-    - __kind: GoSliceHeaderType
-      ID: 56
-      Name: '[]*crypto/x509.Certificate'
-      ByteSize: 24
-      GoRuntimeType: 498304
-      GoKind: 23
-      RawFields:
-        - Name: array
-          Offset: 0
-          Type: 57 PointerType **crypto/x509.Certificate
-        - Name: len
-          Offset: 8
-          Type: 8 BaseType int
-        - Name: cap
-          Offset: 16
-          Type: 8 BaseType int
-      Data: 175 GoSliceDataType []*crypto/x509.Certificate.array
-    - __kind: PointerType
-      ID: 57
-      Name: '**crypto/x509.Certificate'
-      ByteSize: 8
-      GoKind: 22
-      Pointee: 58 PointerType *crypto/x509.Certificate
-    - __kind: PointerType
-      ID: 58
-      Name: '*crypto/x509.Certificate'
-      ByteSize: 8
-      GoRuntimeType: 2.030304e+06
-      GoKind: 22
-      Pointee: 59 StructureType crypto/x509.Certificate
+    - __kind: BaseType
+      ID: 113
+      Name: crypto/tls.CurveID
+      ByteSize: 2
+      GoRuntimeType: 829056
+      GoKind: 9
     - __kind: StructureType
       ID: 59
       Name: crypto/x509.Certificate
@@ -1043,80 +1374,81 @@ Types:
           Offset: 1400
           Type: 105 GoSliceHeaderType []crypto/x509.PolicyMapping
     - __kind: BaseType
-      ID: 60
-      Name: crypto/x509.SignatureAlgorithm
+      ID: 91
+      Name: crypto/x509.ExtKeyUsage
       ByteSize: 8
-      GoRuntimeType: 1.104544e+06
+      GoRuntimeType: 583136
       GoKind: 2
+    - __kind: BaseType
+      ID: 83
+      Name: crypto/x509.KeyUsage
+      ByteSize: 8
+      GoRuntimeType: 583072
+      GoKind: 2
+    - __kind: StructureType
+      ID: 104
+      Name: crypto/x509.OID
+      ByteSize: 24
+      GoRuntimeType: 1.9384e+06
+      GoKind: 25
+      RawFields:
+        - Name: der
+          Offset: 0
+          Type: 53 GoSliceHeaderType []uint8
+    - __kind: StructureType
+      ID: 107
+      Name: crypto/x509.PolicyMapping
+      ByteSize: 48
+      GoRuntimeType: 1.480224e+06
+      GoKind: 25
+      RawFields:
+        - Name: IssuerDomainPolicy
+          Offset: 0
+          Type: 104 StructureType crypto/x509.OID
+        - Name: SubjectDomainPolicy
+          Offset: 24
+          Type: 104 StructureType crypto/x509.OID
     - __kind: BaseType
       ID: 61
       Name: crypto/x509.PublicKeyAlgorithm
       ByteSize: 8
       GoRuntimeType: 831456
       GoKind: 2
-    - __kind: GoEmptyInterfaceType
-      ID: 62
-      Name: interface {}
-      ByteSize: 16
-      GoRuntimeType: 848672
-      GoKind: 20
-      RawFields:
-        - Name: _type
-          Offset: 0
-          Type: 2 VoidPointerType unsafe.Pointer
-        - Name: data
-          Offset: 8
-          Type: 2 VoidPointerType unsafe.Pointer
-    - __kind: PointerType
-      ID: 63
-      Name: '*math/big.Int'
+    - __kind: BaseType
+      ID: 60
+      Name: crypto/x509.SignatureAlgorithm
       ByteSize: 8
-      GoRuntimeType: 2.364704e+06
-      GoKind: 22
-      Pointee: 64 StructureType math/big.Int
+      GoRuntimeType: 1.104544e+06
+      GoKind: 2
     - __kind: StructureType
-      ID: 64
-      Name: math/big.Int
-      ByteSize: 32
-      GoRuntimeType: 1.483264e+06
+      ID: 71
+      Name: crypto/x509/pkix.AttributeTypeAndValue
+      ByteSize: 40
+      GoRuntimeType: 1.492064e+06
       GoKind: 25
       RawFields:
-        - Name: neg
+        - Name: Type
           Offset: 0
-          Type: 13 BaseType bool
-        - Name: abs
-          Offset: 8
-          Type: 65 GoSliceHeaderType math/big.nat
-    - __kind: GoSliceHeaderType
-      ID: 65
-      Name: math/big.nat
-      ByteSize: 24
-      GoRuntimeType: 2.345504e+06
-      GoKind: 23
+          Type: 72 GoSliceHeaderType encoding/asn1.ObjectIdentifier
+        - Name: Value
+          Offset: 24
+          Type: 62 GoEmptyInterfaceType interface {}
+    - __kind: StructureType
+      ID: 86
+      Name: crypto/x509/pkix.Extension
+      ByteSize: 56
+      GoRuntimeType: 1.635616e+06
+      GoKind: 25
       RawFields:
-        - Name: array
+        - Name: Id
           Offset: 0
-          Type: 66 PointerType *math/big.Word
-        - Name: len
-          Offset: 8
-          Type: 8 BaseType int
-        - Name: cap
-          Offset: 16
-          Type: 8 BaseType int
-      Data: 177 GoSliceDataType math/big.nat.array
-    - __kind: PointerType
-      ID: 66
-      Name: '*math/big.Word'
-      ByteSize: 8
-      GoRuntimeType: 423040
-      GoKind: 22
-      Pointee: 67 BaseType math/big.Word
-    - __kind: BaseType
-      ID: 67
-      Name: math/big.Word
-      ByteSize: 8
-      GoRuntimeType: 583328
-      GoKind: 7
+          Type: 72 GoSliceHeaderType encoding/asn1.ObjectIdentifier
+        - Name: Critical
+          Offset: 24
+          Type: 13 BaseType bool
+        - Name: Value
+          Offset: 32
+          Type: 53 GoSliceHeaderType []uint8
     - __kind: StructureType
       ID: 68
       Name: crypto/x509/pkix.Name
@@ -1158,43 +1490,6 @@ Types:
           Offset: 224
           Type: 69 GoSliceHeaderType []crypto/x509/pkix.AttributeTypeAndValue
     - __kind: GoSliceHeaderType
-      ID: 69
-      Name: '[]crypto/x509/pkix.AttributeTypeAndValue'
-      ByteSize: 24
-      GoRuntimeType: 512416
-      GoKind: 23
-      RawFields:
-        - Name: array
-          Offset: 0
-          Type: 70 PointerType *crypto/x509/pkix.AttributeTypeAndValue
-        - Name: len
-          Offset: 8
-          Type: 8 BaseType int
-        - Name: cap
-          Offset: 16
-          Type: 8 BaseType int
-      Data: 179 GoSliceDataType []crypto/x509/pkix.AttributeTypeAndValue.array
-    - __kind: PointerType
-      ID: 70
-      Name: '*crypto/x509/pkix.AttributeTypeAndValue'
-      ByteSize: 8
-      GoRuntimeType: 433984
-      GoKind: 22
-      Pointee: 71 StructureType crypto/x509/pkix.AttributeTypeAndValue
-    - __kind: StructureType
-      ID: 71
-      Name: crypto/x509/pkix.AttributeTypeAndValue
-      ByteSize: 40
-      GoRuntimeType: 1.492064e+06
-      GoKind: 25
-      RawFields:
-        - Name: Type
-          Offset: 0
-          Type: 72 GoSliceHeaderType encoding/asn1.ObjectIdentifier
-        - Name: Value
-          Offset: 24
-          Type: 62 GoEmptyInterfaceType interface {}
-    - __kind: GoSliceHeaderType
       ID: 72
       Name: encoding/asn1.ObjectIdentifier
       ByteSize: 24
@@ -1211,271 +1506,358 @@ Types:
           Offset: 16
           Type: 8 BaseType int
       Data: 181 GoSliceDataType encoding/asn1.ObjectIdentifier.array
-    - __kind: PointerType
-      ID: 73
-      Name: '*int'
+    - __kind: GoSliceDataType
+      ID: 181
+      Name: encoding/asn1.ObjectIdentifier.array
+      ByteSize: 2048
+      Element: 8 BaseType int
+    - __kind: GoInterfaceType
+      ID: 144
+      Name: error
+      ByteSize: 16
+      GoRuntimeType: 1.022624e+06
+      GoKind: 20
+      RawFields:
+        - Name: tab
+          Offset: 0
+          Type: 2 VoidPointerType unsafe.Pointer
+        - Name: data
+          Offset: 8
+          Type: 2 VoidPointerType unsafe.Pointer
+    - __kind: BaseType
+      ID: 146
+      Name: float32
+      ByteSize: 4
+      GoRuntimeType: 580320
+      GoKind: 13
+    - __kind: BaseType
+      ID: 147
+      Name: float64
       ByteSize: 8
-      GoRuntimeType: 396736
-      GoKind: 22
-      Pointee: 8 BaseType int
-    - __kind: StructureType
-      ID: 74
-      Name: time.Time
-      ByteSize: 24
-      GoRuntimeType: 2.34832e+06
+      GoRuntimeType: 580384
+      GoKind: 14
+    - __kind: GoSubroutineType
+      ID: 31
+      Name: func() (io.ReadCloser, error)
+      ByteSize: 8
+      GoRuntimeType: 687840
+      GoKind: 19
+    - __kind: GoSubroutineType
+      ID: 112
+      Name: func(string, []uint8, int) ([]uint8, error)
+      ByteSize: 8
+      GoRuntimeType: 994848
+      GoKind: 19
+    - __kind: GoInterfaceType
+      ID: 137
+      Name: gopkg.in/DataDog/dd-trace-go.v1/ddtrace.Span
+      ByteSize: 16
+      GoRuntimeType: 1.468864e+06
+      GoKind: 20
+      RawFields:
+        - Name: tab
+          Offset: 0
+          Type: 2 VoidPointerType unsafe.Pointer
+        - Name: data
+          Offset: 8
+          Type: 2 VoidPointerType unsafe.Pointer
+    - __kind: GoSwissMapGroupsType
+      ID: 43
+      Name: groupReference<string,[]*mime/multipart.FileHeader>
+      ByteSize: 16
       GoKind: 25
       RawFields:
-        - Name: wall
+        - Name: data
+          Offset: 0
+          Type: 44 PointerType *noalg.map.group[string][]*mime/multipart.FileHeader
+        - Name: lengthMask
+          Offset: 8
+          Type: 17 BaseType uint64
+      GroupType: 45 StructureType noalg.map.group[string][]*mime/multipart.FileHeader
+      GroupSliceType: 170 GoSliceDataType []noalg.map.group[string][]*mime/multipart.FileHeader.array
+    - __kind: GoSwissMapGroupsType
+      ID: 23
+      Name: groupReference<string,[]string>
+      ByteSize: 16
+      GoKind: 25
+      RawFields:
+        - Name: data
+          Offset: 0
+          Type: 24 PointerType *noalg.map.group[string][]string
+        - Name: lengthMask
+          Offset: 8
+          Type: 17 BaseType uint64
+      GroupType: 25 StructureType noalg.map.group[string][]string
+      GroupSliceType: 166 GoSliceDataType []noalg.map.group[string][]string.array
+    - __kind: GoSwissMapGroupsType
+      ID: 129
+      Name: groupReference<string,string>
+      ByteSize: 16
+      GoKind: 25
+      RawFields:
+        - Name: data
+          Offset: 0
+          Type: 130 PointerType *noalg.map.group[string]string
+        - Name: lengthMask
+          Offset: 8
+          Type: 17 BaseType uint64
+      GroupType: 131 StructureType noalg.map.group[string]string
+      GroupSliceType: 214 GoSliceDataType []noalg.map.group[string]string.array
+    - __kind: BaseType
+      ID: 8
+      Name: int
+      ByteSize: 8
+      GoRuntimeType: 580000
+      GoKind: 2
+    - __kind: BaseType
+      ID: 151
+      Name: int16
+      ByteSize: 2
+      GoRuntimeType: 579616
+      GoKind: 4
+    - __kind: BaseType
+      ID: 143
+      Name: int32
+      ByteSize: 4
+      GoRuntimeType: 579744
+      GoKind: 5
+    - __kind: BaseType
+      ID: 32
+      Name: int64
+      ByteSize: 8
+      GoRuntimeType: 579872
+      GoKind: 6
+    - __kind: BaseType
+      ID: 145
+      Name: int8
+      ByteSize: 1
+      GoRuntimeType: 579488
+      GoKind: 3
+    - __kind: GoEmptyInterfaceType
+      ID: 62
+      Name: interface {}
+      ByteSize: 16
+      GoRuntimeType: 848672
+      GoKind: 20
+      RawFields:
+        - Name: _type
+          Offset: 0
+          Type: 2 VoidPointerType unsafe.Pointer
+        - Name: data
+          Offset: 8
+          Type: 2 VoidPointerType unsafe.Pointer
+    - __kind: GoInterfaceType
+      ID: 30
+      Name: io.ReadCloser
+      ByteSize: 16
+      GoRuntimeType: 1.100576e+06
+      GoKind: 20
+      RawFields:
+        - Name: tab
+          Offset: 0
+          Type: 2 VoidPointerType unsafe.Pointer
+        - Name: data
+          Offset: 8
+          Type: 2 VoidPointerType unsafe.Pointer
+    - __kind: GoSwissMapHeaderType
+      ID: 39
+      Name: map<string,[]*mime/multipart.FileHeader>
+      ByteSize: 48
+      GoKind: 25
+      RawFields:
+        - Name: used
           Offset: 0
           Type: 17 BaseType uint64
-        - Name: ext
+        - Name: seed
           Offset: 8
-          Type: 32 BaseType int64
-        - Name: loc
+          Type: 18 BaseType uintptr
+        - Name: dirPtr
           Offset: 16
-          Type: 75 PointerType *time.Location
-    - __kind: PointerType
-      ID: 75
-      Name: '*time.Location'
-      ByteSize: 8
-      GoRuntimeType: 1.6024e+06
-      GoKind: 22
-      Pointee: 76 StructureType time.Location
-    - __kind: StructureType
-      ID: 76
-      Name: time.Location
-      ByteSize: 104
-      GoRuntimeType: 1.957824e+06
-      GoKind: 25
-      RawFields:
-        - Name: name
-          Offset: 0
-          Type: 5 GoStringHeaderType string
-        - Name: zone
-          Offset: 16
-          Type: 77 GoSliceHeaderType []time.zone
-        - Name: tx
-          Offset: 40
-          Type: 80 GoSliceHeaderType []time.zoneTrans
-        - Name: extend
-          Offset: 64
-          Type: 5 GoStringHeaderType string
-        - Name: cacheStart
-          Offset: 80
-          Type: 32 BaseType int64
-        - Name: cacheEnd
-          Offset: 88
-          Type: 32 BaseType int64
-        - Name: cacheZone
-          Offset: 96
-          Type: 78 PointerType *time.zone
-    - __kind: GoSliceHeaderType
-      ID: 77
-      Name: '[]time.zone'
-      ByteSize: 24
-      GoRuntimeType: 485792
-      GoKind: 23
-      RawFields:
-        - Name: array
-          Offset: 0
-          Type: 78 PointerType *time.zone
-        - Name: len
-          Offset: 8
-          Type: 8 BaseType int
-        - Name: cap
-          Offset: 16
-          Type: 8 BaseType int
-      Data: 183 GoSliceDataType []time.zone.array
-    - __kind: PointerType
-      ID: 78
-      Name: '*time.zone'
-      ByteSize: 8
-      GoRuntimeType: 391680
-      GoKind: 22
-      Pointee: 79 StructureType time.zone
-    - __kind: StructureType
-      ID: 79
-      Name: time.zone
-      ByteSize: 32
-      GoRuntimeType: 1.602208e+06
-      GoKind: 25
-      RawFields:
-        - Name: name
-          Offset: 0
-          Type: 5 GoStringHeaderType string
-        - Name: offset
-          Offset: 16
-          Type: 8 BaseType int
-        - Name: isDST
+          Type: 40 PointerType **table<string,[]*mime/multipart.FileHeader>
+        - Name: dirLen
           Offset: 24
-          Type: 13 BaseType bool
-    - __kind: GoSliceHeaderType
-      ID: 80
-      Name: '[]time.zoneTrans'
-      ByteSize: 24
-      GoRuntimeType: 485856
-      GoKind: 23
-      RawFields:
-        - Name: array
-          Offset: 0
-          Type: 81 PointerType *time.zoneTrans
-        - Name: len
-          Offset: 8
           Type: 8 BaseType int
-        - Name: cap
-          Offset: 16
-          Type: 8 BaseType int
-      Data: 185 GoSliceDataType []time.zoneTrans.array
-    - __kind: PointerType
-      ID: 81
-      Name: '*time.zoneTrans'
-      ByteSize: 8
-      GoRuntimeType: 391744
-      GoKind: 22
-      Pointee: 82 StructureType time.zoneTrans
-    - __kind: StructureType
-      ID: 82
-      Name: time.zoneTrans
-      ByteSize: 16
-      GoRuntimeType: 1.736576e+06
-      GoKind: 25
-      RawFields:
-        - Name: when
-          Offset: 0
-          Type: 32 BaseType int64
-        - Name: index
-          Offset: 8
+        - Name: globalDepth
+          Offset: 32
           Type: 7 BaseType uint8
-        - Name: isstd
-          Offset: 9
-          Type: 13 BaseType bool
-        - Name: isutc
-          Offset: 10
-          Type: 13 BaseType bool
-    - __kind: BaseType
-      ID: 83
-      Name: crypto/x509.KeyUsage
+        - Name: globalShift
+          Offset: 33
+          Type: 7 BaseType uint8
+        - Name: writing
+          Offset: 34
+          Type: 7 BaseType uint8
+        - Name: clearSeq
+          Offset: 40
+          Type: 17 BaseType uint64
+      TablePtrSliceType: 169 GoSliceDataType []*table<string,[]*mime/multipart.FileHeader>.array
+      GroupType: 45 StructureType noalg.map.group[string][]*mime/multipart.FileHeader
+    - __kind: GoSwissMapHeaderType
+      ID: 16
+      Name: map<string,[]string>
+      ByteSize: 48
+      GoKind: 25
+      RawFields:
+        - Name: used
+          Offset: 0
+          Type: 17 BaseType uint64
+        - Name: seed
+          Offset: 8
+          Type: 18 BaseType uintptr
+        - Name: dirPtr
+          Offset: 16
+          Type: 19 PointerType **table<string,[]string>
+        - Name: dirLen
+          Offset: 24
+          Type: 8 BaseType int
+        - Name: globalDepth
+          Offset: 32
+          Type: 7 BaseType uint8
+        - Name: globalShift
+          Offset: 33
+          Type: 7 BaseType uint8
+        - Name: writing
+          Offset: 34
+          Type: 7 BaseType uint8
+        - Name: clearSeq
+          Offset: 40
+          Type: 17 BaseType uint64
+      TablePtrSliceType: 165 GoSliceDataType []*table<string,[]string>.array
+      GroupType: 25 StructureType noalg.map.group[string][]string
+    - __kind: GoSwissMapHeaderType
+      ID: 125
+      Name: map<string,string>
+      ByteSize: 48
+      GoKind: 25
+      RawFields:
+        - Name: used
+          Offset: 0
+          Type: 17 BaseType uint64
+        - Name: seed
+          Offset: 8
+          Type: 18 BaseType uintptr
+        - Name: dirPtr
+          Offset: 16
+          Type: 126 PointerType **table<string,string>
+        - Name: dirLen
+          Offset: 24
+          Type: 8 BaseType int
+        - Name: globalDepth
+          Offset: 32
+          Type: 7 BaseType uint8
+        - Name: globalShift
+          Offset: 33
+          Type: 7 BaseType uint8
+        - Name: writing
+          Offset: 34
+          Type: 7 BaseType uint8
+        - Name: clearSeq
+          Offset: 40
+          Type: 17 BaseType uint64
+      TablePtrSliceType: 213 GoSliceDataType []*table<string,string>.array
+      GroupType: 131 StructureType noalg.map.group[string]string
+    - __kind: GoMapType
+      ID: 37
+      Name: map[string][]*mime/multipart.FileHeader
       ByteSize: 8
-      GoRuntimeType: 583072
-      GoKind: 2
+      GoRuntimeType: 1.122592e+06
+      GoKind: 21
+      HeaderType: 39 GoSwissMapHeaderType map<string,[]*mime/multipart.FileHeader>
+    - __kind: GoMapType
+      ID: 36
+      Name: map[string][]string
+      ByteSize: 8
+      GoRuntimeType: 1.117984e+06
+      GoKind: 21
+      HeaderType: 16 GoSwissMapHeaderType map<string,[]string>
+    - __kind: GoMapType
+      ID: 123
+      Name: map[string]string
+      ByteSize: 8
+      GoRuntimeType: 1.119008e+06
+      GoKind: 21
+      HeaderType: 125 GoSwissMapHeaderType map<string,string>
+    - __kind: StructureType
+      ID: 64
+      Name: math/big.Int
+      ByteSize: 32
+      GoRuntimeType: 1.483264e+06
+      GoKind: 25
+      RawFields:
+        - Name: neg
+          Offset: 0
+          Type: 13 BaseType bool
+        - Name: abs
+          Offset: 8
+          Type: 65 GoSliceHeaderType math/big.nat
+    - __kind: BaseType
+      ID: 67
+      Name: math/big.Word
+      ByteSize: 8
+      GoRuntimeType: 583328
+      GoKind: 7
     - __kind: GoSliceHeaderType
-      ID: 84
-      Name: '[]crypto/x509/pkix.Extension'
+      ID: 65
+      Name: math/big.nat
       ByteSize: 24
-      GoRuntimeType: 511648
+      GoRuntimeType: 2.345504e+06
       GoKind: 23
       RawFields:
         - Name: array
           Offset: 0
-          Type: 85 PointerType *crypto/x509/pkix.Extension
+          Type: 66 PointerType *math/big.Word
         - Name: len
           Offset: 8
           Type: 8 BaseType int
         - Name: cap
           Offset: 16
           Type: 8 BaseType int
-      Data: 187 GoSliceDataType []crypto/x509/pkix.Extension.array
-    - __kind: PointerType
-      ID: 85
-      Name: '*crypto/x509/pkix.Extension'
-      ByteSize: 8
-      GoRuntimeType: 434176
-      GoKind: 22
-      Pointee: 86 StructureType crypto/x509/pkix.Extension
+      Data: 177 GoSliceDataType math/big.nat.array
+    - __kind: GoSliceDataType
+      ID: 177
+      Name: math/big.nat.array
+      ByteSize: 2048
+      Element: 67 BaseType math/big.Word
     - __kind: StructureType
-      ID: 86
-      Name: crypto/x509/pkix.Extension
-      ByteSize: 56
-      GoRuntimeType: 1.635616e+06
+      ID: 51
+      Name: mime/multipart.FileHeader
+      ByteSize: 88
+      GoRuntimeType: 1.962144e+06
       GoKind: 25
       RawFields:
-        - Name: Id
+        - Name: Filename
           Offset: 0
-          Type: 72 GoSliceHeaderType encoding/asn1.ObjectIdentifier
-        - Name: Critical
+          Type: 5 GoStringHeaderType string
+        - Name: Header
+          Offset: 16
+          Type: 52 GoMapType net/textproto.MIMEHeader
+        - Name: Size
           Offset: 24
-          Type: 13 BaseType bool
-        - Name: Value
+          Type: 32 BaseType int64
+        - Name: content
           Offset: 32
           Type: 53 GoSliceHeaderType []uint8
-    - __kind: GoSliceHeaderType
-      ID: 87
-      Name: '[]encoding/asn1.ObjectIdentifier'
-      ByteSize: 24
-      GoRuntimeType: 511712
-      GoKind: 23
+        - Name: tmpfile
+          Offset: 56
+          Type: 5 GoStringHeaderType string
+        - Name: tmpoff
+          Offset: 72
+          Type: 32 BaseType int64
+        - Name: tmpshared
+          Offset: 80
+          Type: 13 BaseType bool
+    - __kind: StructureType
+      ID: 35
+      Name: mime/multipart.Form
+      ByteSize: 16
+      GoRuntimeType: 1.467264e+06
+      GoKind: 25
       RawFields:
-        - Name: array
+        - Name: Value
           Offset: 0
-          Type: 88 PointerType *encoding/asn1.ObjectIdentifier
-        - Name: len
+          Type: 36 GoMapType map[string][]string
+        - Name: File
           Offset: 8
-          Type: 8 BaseType int
-        - Name: cap
-          Offset: 16
-          Type: 8 BaseType int
-      Data: 189 GoSliceDataType []encoding/asn1.ObjectIdentifier.array
-    - __kind: PointerType
-      ID: 88
-      Name: '*encoding/asn1.ObjectIdentifier'
-      ByteSize: 8
-      GoRuntimeType: 1.044e+06
-      GoKind: 22
-      Pointee: 72 GoSliceHeaderType encoding/asn1.ObjectIdentifier
-    - __kind: GoSliceHeaderType
-      ID: 89
-      Name: '[]crypto/x509.ExtKeyUsage'
-      ByteSize: 24
-      GoRuntimeType: 499776
-      GoKind: 23
-      RawFields:
-        - Name: array
-          Offset: 0
-          Type: 90 PointerType *crypto/x509.ExtKeyUsage
-        - Name: len
-          Offset: 8
-          Type: 8 BaseType int
-        - Name: cap
-          Offset: 16
-          Type: 8 BaseType int
-      Data: 191 GoSliceDataType []crypto/x509.ExtKeyUsage.array
-    - __kind: PointerType
-      ID: 90
-      Name: '*crypto/x509.ExtKeyUsage'
-      ByteSize: 8
-      GoRuntimeType: 420160
-      GoKind: 22
-      Pointee: 91 BaseType crypto/x509.ExtKeyUsage
-    - __kind: BaseType
-      ID: 91
-      Name: crypto/x509.ExtKeyUsage
-      ByteSize: 8
-      GoRuntimeType: 583136
-      GoKind: 2
-    - __kind: GoSliceHeaderType
-      ID: 92
-      Name: '[]net.IP'
-      ByteSize: 24
-      GoRuntimeType: 479488
-      GoKind: 23
-      RawFields:
-        - Name: array
-          Offset: 0
-          Type: 93 PointerType *net.IP
-        - Name: len
-          Offset: 8
-          Type: 8 BaseType int
-        - Name: cap
-          Offset: 16
-          Type: 8 BaseType int
-      Data: 193 GoSliceDataType []net.IP.array
-    - __kind: PointerType
-      ID: 93
-      Name: '*net.IP'
-      ByteSize: 8
-      GoRuntimeType: 2.134112e+06
-      GoKind: 22
-      Pointee: 94 GoSliceHeaderType net.IP
+          Type: 37 GoMapType map[string][]*mime/multipart.FileHeader
     - __kind: GoSliceHeaderType
       ID: 94
       Name: net.IP
@@ -1493,71 +1875,11 @@ Types:
           Offset: 16
           Type: 8 BaseType int
       Data: 195 GoSliceDataType net.IP.array
-    - __kind: GoSliceHeaderType
-      ID: 95
-      Name: '[]*net/url.URL'
-      ByteSize: 24
-      GoRuntimeType: 511776
-      GoKind: 23
-      RawFields:
-        - Name: array
-          Offset: 0
-          Type: 96 PointerType **net/url.URL
-        - Name: len
-          Offset: 8
-          Type: 8 BaseType int
-        - Name: cap
-          Offset: 16
-          Type: 8 BaseType int
-      Data: 197 GoSliceDataType []*net/url.URL.array
-    - __kind: PointerType
-      ID: 96
-      Name: '**net/url.URL'
-      ByteSize: 8
-      Pointee: 9 PointerType *net/url.URL
-    - __kind: GoSliceHeaderType
-      ID: 97
-      Name: '[]*net.IPNet'
-      ByteSize: 24
-      GoRuntimeType: 511840
-      GoKind: 23
-      RawFields:
-        - Name: array
-          Offset: 0
-          Type: 98 PointerType **net.IPNet
-        - Name: len
-          Offset: 8
-          Type: 8 BaseType int
-        - Name: cap
-          Offset: 16
-          Type: 8 BaseType int
-      Data: 199 GoSliceDataType []*net.IPNet.array
-    - __kind: PointerType
-      ID: 98
-      Name: '**net.IPNet'
-      ByteSize: 8
-      GoKind: 22
-      Pointee: 99 PointerType *net.IPNet
-    - __kind: PointerType
-      ID: 99
-      Name: '*net.IPNet'
-      ByteSize: 8
-      GoRuntimeType: 1.17392e+06
-      GoKind: 22
-      Pointee: 100 StructureType net.IPNet
-    - __kind: StructureType
-      ID: 100
-      Name: net.IPNet
-      ByteSize: 48
-      GoRuntimeType: 1.448704e+06
-      GoKind: 25
-      RawFields:
-        - Name: IP
-          Offset: 0
-          Type: 94 GoSliceHeaderType net.IP
-        - Name: Mask
-          Offset: 24
-          Type: 101 GoSliceHeaderType net.IPMask
+    - __kind: GoSliceDataType
+      ID: 195
+      Name: net.IP.array
+      ByteSize: 2048
+      Element: 7 BaseType uint8
     - __kind: GoSliceHeaderType
       ID: 101
       Name: net.IPMask
@@ -1575,148 +1897,116 @@ Types:
           Offset: 16
           Type: 8 BaseType int
       Data: 201 GoSliceDataType net.IPMask.array
-    - __kind: GoSliceHeaderType
-      ID: 102
-      Name: '[]crypto/x509.OID'
-      ByteSize: 24
-      GoRuntimeType: 511904
-      GoKind: 23
-      RawFields:
-        - Name: array
-          Offset: 0
-          Type: 103 PointerType *crypto/x509.OID
-        - Name: len
-          Offset: 8
-          Type: 8 BaseType int
-        - Name: cap
-          Offset: 16
-          Type: 8 BaseType int
-      Data: 203 GoSliceDataType []crypto/x509.OID.array
-    - __kind: PointerType
-      ID: 103
-      Name: '*crypto/x509.OID'
-      ByteSize: 8
-      GoRuntimeType: 1.938144e+06
-      GoKind: 22
-      Pointee: 104 StructureType crypto/x509.OID
+    - __kind: GoSliceDataType
+      ID: 201
+      Name: net.IPMask.array
+      ByteSize: 2048
+      Element: 7 BaseType uint8
     - __kind: StructureType
-      ID: 104
-      Name: crypto/x509.OID
-      ByteSize: 24
-      GoRuntimeType: 1.9384e+06
-      GoKind: 25
-      RawFields:
-        - Name: der
-          Offset: 0
-          Type: 53 GoSliceHeaderType []uint8
-    - __kind: GoSliceHeaderType
-      ID: 105
-      Name: '[]crypto/x509.PolicyMapping'
-      ByteSize: 24
-      GoRuntimeType: 511968
-      GoKind: 23
-      RawFields:
-        - Name: array
-          Offset: 0
-          Type: 106 PointerType *crypto/x509.PolicyMapping
-        - Name: len
-          Offset: 8
-          Type: 8 BaseType int
-        - Name: cap
-          Offset: 16
-          Type: 8 BaseType int
-      Data: 205 GoSliceDataType []crypto/x509.PolicyMapping.array
-    - __kind: PointerType
-      ID: 106
-      Name: '*crypto/x509.PolicyMapping'
-      ByteSize: 8
-      GoRuntimeType: 420224
-      GoKind: 22
-      Pointee: 107 StructureType crypto/x509.PolicyMapping
-    - __kind: StructureType
-      ID: 107
-      Name: crypto/x509.PolicyMapping
+      ID: 100
+      Name: net.IPNet
       ByteSize: 48
-      GoRuntimeType: 1.480224e+06
+      GoRuntimeType: 1.448704e+06
       GoKind: 25
       RawFields:
-        - Name: IssuerDomainPolicy
+        - Name: IP
           Offset: 0
-          Type: 104 StructureType crypto/x509.OID
-        - Name: SubjectDomainPolicy
+          Type: 94 GoSliceHeaderType net.IP
+        - Name: Mask
           Offset: 24
-          Type: 104 StructureType crypto/x509.OID
-    - __kind: GoSliceHeaderType
-      ID: 108
-      Name: '[][]*crypto/x509.Certificate'
-      ByteSize: 24
-      GoRuntimeType: 498432
-      GoKind: 23
+          Type: 101 GoSliceHeaderType net.IPMask
+    - __kind: GoMapType
+      ID: 14
+      Name: net/http.Header
+      ByteSize: 8
+      GoRuntimeType: 2.08736e+06
+      GoKind: 21
+      HeaderType: 16 GoSwissMapHeaderType map<string,[]string>
+    - __kind: StructureType
+      ID: 4
+      Name: net/http.Request
+      ByteSize: 304
+      GoRuntimeType: 2.322048e+06
+      GoKind: 25
       RawFields:
-        - Name: array
+        - Name: Method
           Offset: 0
-          Type: 109 PointerType *[]*crypto/x509.Certificate
-        - Name: len
-          Offset: 8
-          Type: 8 BaseType int
-        - Name: cap
+          Type: 5 GoStringHeaderType string
+        - Name: URL
           Offset: 16
+          Type: 9 PointerType *net/url.URL
+        - Name: Proto
+          Offset: 24
+          Type: 5 GoStringHeaderType string
+        - Name: ProtoMajor
+          Offset: 40
           Type: 8 BaseType int
-      Data: 207 GoSliceDataType [][]*crypto/x509.Certificate.array
-    - __kind: PointerType
-      ID: 109
-      Name: '*[]*crypto/x509.Certificate'
-      ByteSize: 8
-      GoKind: 22
-      Pointee: 56 GoSliceHeaderType []*crypto/x509.Certificate
-    - __kind: GoSliceHeaderType
-      ID: 110
-      Name: '[][]uint8'
-      ByteSize: 24
-      GoRuntimeType: 478528
-      GoKind: 23
-      RawFields:
-        - Name: array
-          Offset: 0
-          Type: 111 PointerType *[]uint8
-        - Name: len
-          Offset: 8
+        - Name: ProtoMinor
+          Offset: 48
           Type: 8 BaseType int
-        - Name: cap
-          Offset: 16
-          Type: 8 BaseType int
-      Data: 209 GoSliceDataType [][]uint8.array
-    - __kind: PointerType
-      ID: 111
-      Name: '*[]uint8'
-      ByteSize: 8
-      GoRuntimeType: 478144
-      GoKind: 22
-      Pointee: 53 GoSliceHeaderType []uint8
-    - __kind: GoSubroutineType
-      ID: 112
-      Name: func(string, []uint8, int) ([]uint8, error)
-      ByteSize: 8
-      GoRuntimeType: 994848
-      GoKind: 19
-    - __kind: BaseType
-      ID: 113
-      Name: crypto/tls.CurveID
-      ByteSize: 2
-      GoRuntimeType: 829056
-      GoKind: 9
-    - __kind: GoChannelType
-      ID: 114
-      Name: <-chan struct {}
-      GoRuntimeType: 592672
-      GoKind: 18
-    - __kind: PointerType
-      ID: 115
-      Name: '*net/http.Response'
-      ByteSize: 8
-      GoRuntimeType: 1.705504e+06
-      GoKind: 22
-      Pointee: 116 StructureType net/http.Response
+        - Name: Header
+          Offset: 56
+          Type: 14 GoMapType net/http.Header
+        - Name: Body
+          Offset: 64
+          Type: 30 GoInterfaceType io.ReadCloser
+        - Name: GetBody
+          Offset: 80
+          Type: 31 GoSubroutineType func() (io.ReadCloser, error)
+        - Name: ContentLength
+          Offset: 88
+          Type: 32 BaseType int64
+        - Name: TransferEncoding
+          Offset: 96
+          Type: 28 GoSliceHeaderType []string
+        - Name: Close
+          Offset: 120
+          Type: 13 BaseType bool
+        - Name: Host
+          Offset: 128
+          Type: 5 GoStringHeaderType string
+        - Name: Form
+          Offset: 144
+          Type: 33 GoMapType net/url.Values
+        - Name: PostForm
+          Offset: 152
+          Type: 33 GoMapType net/url.Values
+        - Name: MultipartForm
+          Offset: 160
+          Type: 34 PointerType *mime/multipart.Form
+        - Name: Trailer
+          Offset: 168
+          Type: 14 GoMapType net/http.Header
+        - Name: RemoteAddr
+          Offset: 176
+          Type: 5 GoStringHeaderType string
+        - Name: RequestURI
+          Offset: 192
+          Type: 5 GoStringHeaderType string
+        - Name: TLS
+          Offset: 208
+          Type: 54 PointerType *crypto/tls.ConnectionState
+        - Name: Cancel
+          Offset: 216
+          Type: 114 GoChannelType <-chan struct {}
+        - Name: Response
+          Offset: 224
+          Type: 115 PointerType *net/http.Response
+        - Name: Pattern
+          Offset: 232
+          Type: 5 GoStringHeaderType string
+        - Name: ctx
+          Offset: 248
+          Type: 117 GoInterfaceType context.Context
+        - Name: pat
+          Offset: 264
+          Type: 118 PointerType *net/http.pattern
+        - Name: matches
+          Offset: 272
+          Type: 28 GoSliceHeaderType []string
+        - Name: otherValues
+          Offset: 296
+          Type: 123 GoMapType map[string]string
     - __kind: StructureType
       ID: 116
       Name: net/http.Response
@@ -1767,10 +2057,10 @@ Types:
           Offset: 136
           Type: 54 PointerType *crypto/tls.ConnectionState
     - __kind: GoInterfaceType
-      ID: 117
-      Name: context.Context
+      ID: 1
+      Name: net/http.ResponseWriter
       ByteSize: 16
-      GoRuntimeType: 1.266912e+06
+      GoRuntimeType: 1.176352e+06
       GoKind: 20
       RawFields:
         - Name: tab
@@ -1779,13 +2069,6 @@ Types:
         - Name: data
           Offset: 8
           Type: 2 VoidPointerType unsafe.Pointer
-    - __kind: PointerType
-      ID: 118
-      Name: '*net/http.pattern'
-      ByteSize: 8
-      GoRuntimeType: 1.597408e+06
-      GoKind: 22
-      Pointee: 119 StructureType net/http.pattern
     - __kind: StructureType
       ID: 119
       Name: net/http.pattern
@@ -1808,30 +2091,6 @@ Types:
         - Name: loc
           Offset: 72
           Type: 5 GoStringHeaderType string
-    - __kind: GoSliceHeaderType
-      ID: 120
-      Name: '[]net/http.segment'
-      ByteSize: 24
-      GoRuntimeType: 481120
-      GoKind: 23
-      RawFields:
-        - Name: array
-          Offset: 0
-          Type: 121 PointerType *net/http.segment
-        - Name: len
-          Offset: 8
-          Type: 8 BaseType int
-        - Name: cap
-          Offset: 16
-          Type: 8 BaseType int
-      Data: 211 GoSliceDataType []net/http.segment.array
-    - __kind: PointerType
-      ID: 121
-      Name: '*net/http.segment'
-      ByteSize: 8
-      GoRuntimeType: 388544
-      GoKind: 22
-      Pointee: 122 StructureType net/http.segment
     - __kind: StructureType
       ID: 122
       Name: net/http.segment
@@ -1849,59 +2108,246 @@ Types:
           Offset: 17
           Type: 13 BaseType bool
     - __kind: GoMapType
-      ID: 123
-      Name: map[string]string
+      ID: 52
+      Name: net/textproto.MIMEHeader
       ByteSize: 8
-      GoRuntimeType: 1.119008e+06
+      GoRuntimeType: 1.808288e+06
       GoKind: 21
-      HeaderType: 125 GoSwissMapHeaderType map<string,string>
-    - __kind: PointerType
-      ID: 124
-      Name: '*map<string,string>'
+      HeaderType: 16 GoSwissMapHeaderType map<string,[]string>
+    - __kind: StructureType
+      ID: 10
+      Name: net/url.URL
+      ByteSize: 144
+      GoRuntimeType: 2.112256e+06
+      GoKind: 25
+      RawFields:
+        - Name: Scheme
+          Offset: 0
+          Type: 5 GoStringHeaderType string
+        - Name: Opaque
+          Offset: 16
+          Type: 5 GoStringHeaderType string
+        - Name: User
+          Offset: 32
+          Type: 11 PointerType *net/url.Userinfo
+        - Name: Host
+          Offset: 40
+          Type: 5 GoStringHeaderType string
+        - Name: Path
+          Offset: 56
+          Type: 5 GoStringHeaderType string
+        - Name: RawPath
+          Offset: 72
+          Type: 5 GoStringHeaderType string
+        - Name: OmitHost
+          Offset: 88
+          Type: 13 BaseType bool
+        - Name: ForceQuery
+          Offset: 89
+          Type: 13 BaseType bool
+        - Name: RawQuery
+          Offset: 96
+          Type: 5 GoStringHeaderType string
+        - Name: Fragment
+          Offset: 112
+          Type: 5 GoStringHeaderType string
+        - Name: RawFragment
+          Offset: 128
+          Type: 5 GoStringHeaderType string
+    - __kind: StructureType
+      ID: 12
+      Name: net/url.Userinfo
+      ByteSize: 40
+      GoRuntimeType: 1.613536e+06
+      GoKind: 25
+      RawFields:
+        - Name: username
+          Offset: 0
+          Type: 5 GoStringHeaderType string
+        - Name: password
+          Offset: 16
+          Type: 5 GoStringHeaderType string
+        - Name: passwordSet
+          Offset: 32
+          Type: 13 BaseType bool
+    - __kind: GoMapType
+      ID: 33
+      Name: net/url.Values
       ByteSize: 8
-      Pointee: 125 GoSwissMapHeaderType map<string,string>
-    - __kind: GoSwissMapHeaderType
-      ID: 125
-      Name: map<string,string>
-      ByteSize: 48
+      GoRuntimeType: 1.870528e+06
+      GoKind: 21
+      HeaderType: 16 GoSwissMapHeaderType map<string,[]string>
+    - __kind: ArrayType
+      ID: 46
+      Name: noalg.[8]struct { key string; elem []*mime/multipart.FileHeader }
+      ByteSize: 320
+      GoRuntimeType: 693888
+      GoKind: 17
+      Count: 8
+      HasCount: true
+      Element: 47 StructureType noalg.struct { key string; elem []*mime/multipart.FileHeader }
+    - __kind: ArrayType
+      ID: 26
+      Name: noalg.[8]struct { key string; elem []string }
+      ByteSize: 320
+      GoRuntimeType: 683872
+      GoKind: 17
+      Count: 8
+      HasCount: true
+      Element: 27 StructureType noalg.struct { key string; elem []string }
+    - __kind: ArrayType
+      ID: 132
+      Name: noalg.[8]struct { key string; elem string }
+      ByteSize: 256
+      GoRuntimeType: 688032
+      GoKind: 17
+      Count: 8
+      HasCount: true
+      Element: 133 StructureType noalg.struct { key string; elem string }
+    - __kind: StructureType
+      ID: 45
+      Name: noalg.map.group[string][]*mime/multipart.FileHeader
+      ByteSize: 328
+      GoRuntimeType: 1.289824e+06
+      GoKind: 25
+      RawFields:
+        - Name: ctrl
+          Offset: 0
+          Type: 17 BaseType uint64
+        - Name: slots
+          Offset: 8
+          Type: 46 ArrayType noalg.[8]struct { key string; elem []*mime/multipart.FileHeader }
+    - __kind: StructureType
+      ID: 25
+      Name: noalg.map.group[string][]string
+      ByteSize: 328
+      GoRuntimeType: 1.280352e+06
+      GoKind: 25
+      RawFields:
+        - Name: ctrl
+          Offset: 0
+          Type: 17 BaseType uint64
+        - Name: slots
+          Offset: 8
+          Type: 26 ArrayType noalg.[8]struct { key string; elem []string }
+    - __kind: StructureType
+      ID: 131
+      Name: noalg.map.group[string]string
+      ByteSize: 264
+      GoRuntimeType: 1.282656e+06
+      GoKind: 25
+      RawFields:
+        - Name: ctrl
+          Offset: 0
+          Type: 17 BaseType uint64
+        - Name: slots
+          Offset: 8
+          Type: 132 ArrayType noalg.[8]struct { key string; elem string }
+    - __kind: StructureType
+      ID: 47
+      Name: noalg.struct { key string; elem []*mime/multipart.FileHeader }
+      ByteSize: 40
+      GoRuntimeType: 1.289696e+06
+      GoKind: 25
+      RawFields:
+        - Name: key
+          Offset: 0
+          Type: 5 GoStringHeaderType string
+        - Name: elem
+          Offset: 16
+          Type: 48 GoSliceHeaderType []*mime/multipart.FileHeader
+    - __kind: StructureType
+      ID: 27
+      Name: noalg.struct { key string; elem []string }
+      ByteSize: 40
+      GoRuntimeType: 1.280224e+06
+      GoKind: 25
+      RawFields:
+        - Name: key
+          Offset: 0
+          Type: 5 GoStringHeaderType string
+        - Name: elem
+          Offset: 16
+          Type: 28 GoSliceHeaderType []string
+    - __kind: StructureType
+      ID: 133
+      Name: noalg.struct { key string; elem string }
+      ByteSize: 32
+      GoRuntimeType: 1.282528e+06
+      GoKind: 25
+      RawFields:
+        - Name: key
+          Offset: 0
+          Type: 5 GoStringHeaderType string
+        - Name: elem
+          Offset: 16
+          Type: 5 GoStringHeaderType string
+    - __kind: GoStringHeaderType
+      ID: 5
+      Name: string
+      ByteSize: 16
+      GoRuntimeType: 579424
+      GoKind: 24
+      RawFields:
+        - Name: str
+          Offset: 0
+          Type: 164 PointerType *string.str
+        - Name: len
+          Offset: 8
+          Type: 8 BaseType int
+      Data: 163 GoStringDataType string.str
+    - __kind: GoStringDataType
+      ID: 163
+      Name: string.str
+      ByteSize: 2048
+    - __kind: StructureType
+      ID: 42
+      Name: table<string,[]*mime/multipart.FileHeader>
+      ByteSize: 32
       GoKind: 25
       RawFields:
         - Name: used
           Offset: 0
-          Type: 17 BaseType uint64
-        - Name: seed
+          Type: 22 BaseType uint16
+        - Name: capacity
+          Offset: 2
+          Type: 22 BaseType uint16
+        - Name: growthLeft
+          Offset: 4
+          Type: 22 BaseType uint16
+        - Name: localDepth
+          Offset: 6
+          Type: 7 BaseType uint8
+        - Name: index
           Offset: 8
-          Type: 18 BaseType uintptr
-        - Name: dirPtr
-          Offset: 16
-          Type: 126 PointerType **table<string,string>
-        - Name: dirLen
-          Offset: 24
           Type: 8 BaseType int
-        - Name: globalDepth
-          Offset: 32
+        - Name: groups
+          Offset: 16
+          Type: 43 GoSwissMapGroupsType groupReference<string,[]*mime/multipart.FileHeader>
+    - __kind: StructureType
+      ID: 21
+      Name: table<string,[]string>
+      ByteSize: 32
+      GoKind: 25
+      RawFields:
+        - Name: used
+          Offset: 0
+          Type: 22 BaseType uint16
+        - Name: capacity
+          Offset: 2
+          Type: 22 BaseType uint16
+        - Name: growthLeft
+          Offset: 4
+          Type: 22 BaseType uint16
+        - Name: localDepth
+          Offset: 6
           Type: 7 BaseType uint8
-        - Name: globalShift
-          Offset: 33
-          Type: 7 BaseType uint8
-        - Name: writing
-          Offset: 34
-          Type: 7 BaseType uint8
-        - Name: clearSeq
-          Offset: 40
-          Type: 17 BaseType uint64
-      TablePtrSliceType: 213 GoSliceDataType []*table<string,string>.array
-      GroupType: 131 StructureType noalg.map.group[string]string
-    - __kind: PointerType
-      ID: 126
-      Name: '**table<string,string>'
-      ByteSize: 8
-      Pointee: 127 PointerType *table<string,string>
-    - __kind: PointerType
-      ID: 127
-      Name: '*table<string,string>'
-      ByteSize: 8
-      Pointee: 128 StructureType table<string,string>
+        - Name: index
+          Offset: 8
+          Type: 8 BaseType int
+        - Name: groups
+          Offset: 16
+          Type: 23 GoSwissMapGroupsType groupReference<string,[]string>
     - __kind: StructureType
       ID: 128
       Name: table<string,string>
@@ -1926,117 +2372,97 @@ Types:
         - Name: groups
           Offset: 16
           Type: 129 GoSwissMapGroupsType groupReference<string,string>
-    - __kind: GoSwissMapGroupsType
-      ID: 129
-      Name: groupReference<string,string>
-      ByteSize: 16
-      GoKind: 25
-      RawFields:
-        - Name: data
-          Offset: 0
-          Type: 130 PointerType *noalg.map.group[string]string
-        - Name: lengthMask
-          Offset: 8
-          Type: 17 BaseType uint64
-      GroupType: 131 StructureType noalg.map.group[string]string
-      GroupSliceType: 214 GoSliceDataType []noalg.map.group[string]string.array
-    - __kind: PointerType
-      ID: 130
-      Name: '*noalg.map.group[string]string'
-      ByteSize: 8
-      Pointee: 131 StructureType noalg.map.group[string]string
     - __kind: StructureType
-      ID: 131
-      Name: noalg.map.group[string]string
-      ByteSize: 264
-      GoRuntimeType: 1.282656e+06
+      ID: 76
+      Name: time.Location
+      ByteSize: 104
+      GoRuntimeType: 1.957824e+06
       GoKind: 25
       RawFields:
-        - Name: ctrl
-          Offset: 0
-          Type: 17 BaseType uint64
-        - Name: slots
-          Offset: 8
-          Type: 132 ArrayType noalg.[8]struct { key string; elem string }
-    - __kind: ArrayType
-      ID: 132
-      Name: noalg.[8]struct { key string; elem string }
-      ByteSize: 256
-      GoRuntimeType: 688032
-      GoKind: 17
-      Count: 8
-      HasCount: true
-      Element: 133 StructureType noalg.struct { key string; elem string }
-    - __kind: StructureType
-      ID: 133
-      Name: noalg.struct { key string; elem string }
-      ByteSize: 32
-      GoRuntimeType: 1.282528e+06
-      GoKind: 25
-      RawFields:
-        - Name: key
+        - Name: name
           Offset: 0
           Type: 5 GoStringHeaderType string
-        - Name: elem
+        - Name: zone
           Offset: 16
+          Type: 77 GoSliceHeaderType []time.zone
+        - Name: tx
+          Offset: 40
+          Type: 80 GoSliceHeaderType []time.zoneTrans
+        - Name: extend
+          Offset: 64
           Type: 5 GoStringHeaderType string
-    - __kind: PointerType
-      ID: 134
-      Name: '*bytes.Buffer'
-      ByteSize: 8
-      GoRuntimeType: 2.245056e+06
-      GoKind: 22
-      Pointee: 135 StructureType bytes.Buffer
+        - Name: cacheStart
+          Offset: 80
+          Type: 32 BaseType int64
+        - Name: cacheEnd
+          Offset: 88
+          Type: 32 BaseType int64
+        - Name: cacheZone
+          Offset: 96
+          Type: 78 PointerType *time.zone
     - __kind: StructureType
-      ID: 135
-      Name: bytes.Buffer
-      ByteSize: 40
-      GoRuntimeType: 1.595104e+06
+      ID: 74
+      Name: time.Time
+      ByteSize: 24
+      GoRuntimeType: 2.34832e+06
       GoKind: 25
       RawFields:
-        - Name: buf
+        - Name: wall
           Offset: 0
-          Type: 53 GoSliceHeaderType []uint8
-        - Name: off
-          Offset: 24
-          Type: 8 BaseType int
-        - Name: lastRead
-          Offset: 32
-          Type: 136 BaseType bytes.readOp
-    - __kind: BaseType
-      ID: 136
-      Name: bytes.readOp
-      ByteSize: 1
-      GoRuntimeType: 578592
-      GoKind: 3
-    - __kind: GoInterfaceType
-      ID: 137
-      Name: gopkg.in/DataDog/dd-trace-go.v1/ddtrace.Span
-      ByteSize: 16
-      GoRuntimeType: 1.468864e+06
-      GoKind: 20
-      RawFields:
-        - Name: tab
-          Offset: 0
-          Type: 2 VoidPointerType unsafe.Pointer
-        - Name: data
+          Type: 17 BaseType uint64
+        - Name: ext
           Offset: 8
-          Type: 2 VoidPointerType unsafe.Pointer
+          Type: 32 BaseType int64
+        - Name: loc
+          Offset: 16
+          Type: 75 PointerType *time.Location
     - __kind: StructureType
-      ID: 138
-      Name: context.backgroundCtx
-      GoRuntimeType: 1.781408e+06
+      ID: 79
+      Name: time.zone
+      ByteSize: 32
+      GoRuntimeType: 1.602208e+06
       GoKind: 25
       RawFields:
-        - Name: emptyCtx
+        - Name: name
           Offset: 0
-          Type: 139 StructureType context.emptyCtx
+          Type: 5 GoStringHeaderType string
+        - Name: offset
+          Offset: 16
+          Type: 8 BaseType int
+        - Name: isDST
+          Offset: 24
+          Type: 13 BaseType bool
     - __kind: StructureType
-      ID: 139
-      Name: context.emptyCtx
-      GoRuntimeType: 1.58016e+06
+      ID: 82
+      Name: time.zoneTrans
+      ByteSize: 16
+      GoRuntimeType: 1.736576e+06
       GoKind: 25
-      RawFields: []
+      RawFields:
+        - Name: when
+          Offset: 0
+          Type: 32 BaseType int64
+        - Name: index
+          Offset: 8
+          Type: 7 BaseType uint8
+        - Name: isstd
+          Offset: 9
+          Type: 13 BaseType bool
+        - Name: isutc
+          Offset: 10
+          Type: 13 BaseType bool
+    - __kind: BaseType
+      ID: 141
+      Name: uint
+      ByteSize: 8
+      GoRuntimeType: 580064
+      GoKind: 7
+    - __kind: BaseType
+      ID: 22
+      Name: uint16
+      ByteSize: 2
+      GoRuntimeType: 579680
+      GoKind: 9
     - __kind: BaseType
       ID: 140
       Name: uint32
@@ -2044,455 +2470,29 @@ Types:
       GoRuntimeType: 579808
       GoKind: 10
     - __kind: BaseType
-      ID: 141
-      Name: uint
+      ID: 17
+      Name: uint64
       ByteSize: 8
-      GoRuntimeType: 580064
-      GoKind: 7
-    - __kind: PointerType
-      ID: 142
-      Name: '*bool'
-      ByteSize: 8
-      GoRuntimeType: 397184
-      GoKind: 22
-      Pointee: 13 BaseType bool
+      GoRuntimeType: 579936
+      GoKind: 11
     - __kind: BaseType
-      ID: 143
-      Name: int32
-      ByteSize: 4
-      GoRuntimeType: 579744
-      GoKind: 5
-    - __kind: GoInterfaceType
-      ID: 144
-      Name: error
-      ByteSize: 16
-      GoRuntimeType: 1.022624e+06
-      GoKind: 20
-      RawFields:
-        - Name: tab
-          Offset: 0
-          Type: 2 VoidPointerType unsafe.Pointer
-        - Name: data
-          Offset: 8
-          Type: 2 VoidPointerType unsafe.Pointer
-    - __kind: BaseType
-      ID: 145
-      Name: int8
+      ID: 7
+      Name: uint8
       ByteSize: 1
-      GoRuntimeType: 579488
-      GoKind: 3
+      GoRuntimeType: 579552
+      GoKind: 8
     - __kind: BaseType
-      ID: 146
-      Name: float32
-      ByteSize: 4
-      GoRuntimeType: 580320
-      GoKind: 13
-    - __kind: BaseType
-      ID: 147
-      Name: float64
+      ID: 18
+      Name: uintptr
       ByteSize: 8
-      GoRuntimeType: 580384
-      GoKind: 14
-    - __kind: PointerType
-      ID: 148
-      Name: '*uintptr'
+      GoRuntimeType: 580128
+      GoKind: 12
+    - __kind: VoidPointerType
+      ID: 2
+      Name: unsafe.Pointer
       ByteSize: 8
-      GoRuntimeType: 396864
-      GoKind: 22
-      Pointee: 18 BaseType uintptr
-    - __kind: PointerType
-      ID: 149
-      Name: '*int32'
-      ByteSize: 8
-      GoRuntimeType: 396480
-      GoKind: 22
-      Pointee: 143 BaseType int32
-    - __kind: PointerType
-      ID: 150
-      Name: '*uint32'
-      ByteSize: 8
-      GoRuntimeType: 396544
-      GoKind: 22
-      Pointee: 140 BaseType uint32
-    - __kind: BaseType
-      ID: 151
-      Name: int16
-      ByteSize: 2
-      GoRuntimeType: 579616
-      GoKind: 4
-    - __kind: BaseType
-      ID: 152
-      Name: complex64
-      ByteSize: 8
-      GoRuntimeType: 580192
-      GoKind: 15
-    - __kind: BaseType
-      ID: 153
-      Name: complex128
-      ByteSize: 16
-      GoRuntimeType: 580256
-      GoKind: 16
-    - __kind: PointerType
-      ID: 154
-      Name: '*float64'
-      ByteSize: 8
-      GoRuntimeType: 397120
-      GoKind: 22
-      Pointee: 147 BaseType float64
-    - __kind: PointerType
-      ID: 155
-      Name: '*int64'
-      ByteSize: 8
-      GoRuntimeType: 396608
-      GoKind: 22
-      Pointee: 32 BaseType int64
-    - __kind: PointerType
-      ID: 156
-      Name: '*uint64'
-      ByteSize: 8
-      GoRuntimeType: 396672
-      GoKind: 22
-      Pointee: 17 BaseType uint64
-    - __kind: PointerType
-      ID: 157
-      Name: '*uint16'
-      ByteSize: 8
-      GoRuntimeType: 396416
-      GoKind: 22
-      Pointee: 22 BaseType uint16
-    - __kind: PointerType
-      ID: 158
-      Name: '*int16'
-      ByteSize: 8
-      GoRuntimeType: 396352
-      GoKind: 22
-      Pointee: 151 BaseType int16
-    - __kind: PointerType
-      ID: 159
-      Name: '*int8'
-      ByteSize: 8
-      GoRuntimeType: 396224
-      GoKind: 22
-      Pointee: 145 BaseType int8
-    - __kind: PointerType
-      ID: 160
-      Name: '*error'
-      ByteSize: 8
-      GoRuntimeType: 396096
-      GoKind: 22
-      Pointee: 144 GoInterfaceType error
-    - __kind: PointerType
-      ID: 161
-      Name: '*uint'
-      ByteSize: 8
-      GoRuntimeType: 396800
-      GoKind: 22
-      Pointee: 141 BaseType uint
-    - __kind: PointerType
-      ID: 162
-      Name: '*float32'
-      ByteSize: 8
-      GoRuntimeType: 397056
-      GoKind: 22
-      Pointee: 146 BaseType float32
-    - __kind: GoStringDataType
-      ID: 163
-      Name: string.str
-      ByteSize: 2048
-    - __kind: PointerType
-      ID: 164
-      Name: '*string.str'
-      ByteSize: 8
-      Pointee: 163 GoStringDataType string.str
-    - __kind: GoSliceDataType
-      ID: 165
-      Name: '[]*table<string,[]string>.array'
-      ByteSize: 8192
-      Element: 20 PointerType *table<string,[]string>
-    - __kind: GoSliceDataType
-      ID: 166
-      Name: '[]noalg.map.group[string][]string.array'
-      ByteSize: 2048
-      Element: 25 StructureType noalg.map.group[string][]string
-    - __kind: GoSliceDataType
-      ID: 167
-      Name: '[]string.array'
-      ByteSize: 2048
-      Element: 5 GoStringHeaderType string
-    - __kind: PointerType
-      ID: 168
-      Name: '*[]string.array'
-      ByteSize: 8
-      Pointee: 167 GoSliceDataType []string.array
-    - __kind: GoSliceDataType
-      ID: 169
-      Name: '[]*table<string,[]*mime/multipart.FileHeader>.array'
-      ByteSize: 8192
-      Element: 41 PointerType *table<string,[]*mime/multipart.FileHeader>
-    - __kind: GoSliceDataType
-      ID: 170
-      Name: '[]noalg.map.group[string][]*mime/multipart.FileHeader.array'
-      ByteSize: 2048
-      Element: 45 StructureType noalg.map.group[string][]*mime/multipart.FileHeader
-    - __kind: GoSliceDataType
-      ID: 171
-      Name: '[]*mime/multipart.FileHeader.array'
-      ByteSize: 2048
-      Element: 50 PointerType *mime/multipart.FileHeader
-    - __kind: PointerType
-      ID: 172
-      Name: '*[]*mime/multipart.FileHeader.array'
-      ByteSize: 8
-      Pointee: 171 GoSliceDataType []*mime/multipart.FileHeader.array
-    - __kind: GoSliceDataType
-      ID: 173
-      Name: '[]uint8.array'
-      ByteSize: 2048
-      Element: 7 BaseType uint8
-    - __kind: PointerType
-      ID: 174
-      Name: '*[]uint8.array'
-      ByteSize: 8
-      Pointee: 173 GoSliceDataType []uint8.array
-    - __kind: GoSliceDataType
-      ID: 175
-      Name: '[]*crypto/x509.Certificate.array'
-      ByteSize: 2048
-      Element: 58 PointerType *crypto/x509.Certificate
-    - __kind: PointerType
-      ID: 176
-      Name: '*[]*crypto/x509.Certificate.array'
-      ByteSize: 8
-      Pointee: 175 GoSliceDataType []*crypto/x509.Certificate.array
-    - __kind: GoSliceDataType
-      ID: 177
-      Name: math/big.nat.array
-      ByteSize: 2048
-      Element: 67 BaseType math/big.Word
-    - __kind: PointerType
-      ID: 178
-      Name: '*math/big.nat.array'
-      ByteSize: 8
-      Pointee: 177 GoSliceDataType math/big.nat.array
-    - __kind: GoSliceDataType
-      ID: 179
-      Name: '[]crypto/x509/pkix.AttributeTypeAndValue.array'
-      ByteSize: 2048
-      Element: 71 StructureType crypto/x509/pkix.AttributeTypeAndValue
-    - __kind: PointerType
-      ID: 180
-      Name: '*[]crypto/x509/pkix.AttributeTypeAndValue.array'
-      ByteSize: 8
-      Pointee: 179 GoSliceDataType []crypto/x509/pkix.AttributeTypeAndValue.array
-    - __kind: GoSliceDataType
-      ID: 181
-      Name: encoding/asn1.ObjectIdentifier.array
-      ByteSize: 2048
-      Element: 8 BaseType int
-    - __kind: PointerType
-      ID: 182
-      Name: '*encoding/asn1.ObjectIdentifier.array'
-      ByteSize: 8
-      Pointee: 181 GoSliceDataType encoding/asn1.ObjectIdentifier.array
-    - __kind: GoSliceDataType
-      ID: 183
-      Name: '[]time.zone.array'
-      ByteSize: 2048
-      Element: 79 StructureType time.zone
-    - __kind: PointerType
-      ID: 184
-      Name: '*[]time.zone.array'
-      ByteSize: 8
-      Pointee: 183 GoSliceDataType []time.zone.array
-    - __kind: GoSliceDataType
-      ID: 185
-      Name: '[]time.zoneTrans.array'
-      ByteSize: 2048
-      Element: 82 StructureType time.zoneTrans
-    - __kind: PointerType
-      ID: 186
-      Name: '*[]time.zoneTrans.array'
-      ByteSize: 8
-      Pointee: 185 GoSliceDataType []time.zoneTrans.array
-    - __kind: GoSliceDataType
-      ID: 187
-      Name: '[]crypto/x509/pkix.Extension.array'
-      ByteSize: 2048
-      Element: 86 StructureType crypto/x509/pkix.Extension
-    - __kind: PointerType
-      ID: 188
-      Name: '*[]crypto/x509/pkix.Extension.array'
-      ByteSize: 8
-      Pointee: 187 GoSliceDataType []crypto/x509/pkix.Extension.array
-    - __kind: GoSliceDataType
-      ID: 189
-      Name: '[]encoding/asn1.ObjectIdentifier.array'
-      ByteSize: 2048
-      Element: 72 GoSliceHeaderType encoding/asn1.ObjectIdentifier
-    - __kind: PointerType
-      ID: 190
-      Name: '*[]encoding/asn1.ObjectIdentifier.array'
-      ByteSize: 8
-      Pointee: 189 GoSliceDataType []encoding/asn1.ObjectIdentifier.array
-    - __kind: GoSliceDataType
-      ID: 191
-      Name: '[]crypto/x509.ExtKeyUsage.array'
-      ByteSize: 2048
-      Element: 91 BaseType crypto/x509.ExtKeyUsage
-    - __kind: PointerType
-      ID: 192
-      Name: '*[]crypto/x509.ExtKeyUsage.array'
-      ByteSize: 8
-      Pointee: 191 GoSliceDataType []crypto/x509.ExtKeyUsage.array
-    - __kind: GoSliceDataType
-      ID: 193
-      Name: '[]net.IP.array'
-      ByteSize: 2048
-      Element: 94 GoSliceHeaderType net.IP
-    - __kind: PointerType
-      ID: 194
-      Name: '*[]net.IP.array'
-      ByteSize: 8
-      Pointee: 193 GoSliceDataType []net.IP.array
-    - __kind: GoSliceDataType
-      ID: 195
-      Name: net.IP.array
-      ByteSize: 2048
-      Element: 7 BaseType uint8
-    - __kind: PointerType
-      ID: 196
-      Name: '*net.IP.array'
-      ByteSize: 8
-      Pointee: 195 GoSliceDataType net.IP.array
-    - __kind: GoSliceDataType
-      ID: 197
-      Name: '[]*net/url.URL.array'
-      ByteSize: 2048
-      Element: 9 PointerType *net/url.URL
-    - __kind: PointerType
-      ID: 198
-      Name: '*[]*net/url.URL.array'
-      ByteSize: 8
-      Pointee: 197 GoSliceDataType []*net/url.URL.array
-    - __kind: GoSliceDataType
-      ID: 199
-      Name: '[]*net.IPNet.array'
-      ByteSize: 2048
-      Element: 99 PointerType *net.IPNet
-    - __kind: PointerType
-      ID: 200
-      Name: '*[]*net.IPNet.array'
-      ByteSize: 8
-      Pointee: 199 GoSliceDataType []*net.IPNet.array
-    - __kind: GoSliceDataType
-      ID: 201
-      Name: net.IPMask.array
-      ByteSize: 2048
-      Element: 7 BaseType uint8
-    - __kind: PointerType
-      ID: 202
-      Name: '*net.IPMask.array'
-      ByteSize: 8
-      Pointee: 201 GoSliceDataType net.IPMask.array
-    - __kind: GoSliceDataType
-      ID: 203
-      Name: '[]crypto/x509.OID.array'
-      ByteSize: 2048
-      Element: 104 StructureType crypto/x509.OID
-    - __kind: PointerType
-      ID: 204
-      Name: '*[]crypto/x509.OID.array'
-      ByteSize: 8
-      Pointee: 203 GoSliceDataType []crypto/x509.OID.array
-    - __kind: GoSliceDataType
-      ID: 205
-      Name: '[]crypto/x509.PolicyMapping.array'
-      ByteSize: 2048
-      Element: 107 StructureType crypto/x509.PolicyMapping
-    - __kind: PointerType
-      ID: 206
-      Name: '*[]crypto/x509.PolicyMapping.array'
-      ByteSize: 8
-      Pointee: 205 GoSliceDataType []crypto/x509.PolicyMapping.array
-    - __kind: GoSliceDataType
-      ID: 207
-      Name: '[][]*crypto/x509.Certificate.array'
-      ByteSize: 2048
-      Element: 56 GoSliceHeaderType []*crypto/x509.Certificate
-    - __kind: PointerType
-      ID: 208
-      Name: '*[][]*crypto/x509.Certificate.array'
-      ByteSize: 8
-      Pointee: 207 GoSliceDataType [][]*crypto/x509.Certificate.array
-    - __kind: GoSliceDataType
-      ID: 209
-      Name: '[][]uint8.array'
-      ByteSize: 2048
-      Element: 53 GoSliceHeaderType []uint8
-    - __kind: PointerType
-      ID: 210
-      Name: '*[][]uint8.array'
-      ByteSize: 8
-      Pointee: 209 GoSliceDataType [][]uint8.array
-    - __kind: GoSliceDataType
-      ID: 211
-      Name: '[]net/http.segment.array'
-      ByteSize: 2048
-      Element: 122 StructureType net/http.segment
-    - __kind: PointerType
-      ID: 212
-      Name: '*[]net/http.segment.array'
-      ByteSize: 8
-      Pointee: 211 GoSliceDataType []net/http.segment.array
-    - __kind: GoSliceDataType
-      ID: 213
-      Name: '[]*table<string,string>.array'
-      ByteSize: 8192
-      Element: 127 PointerType *table<string,string>
-    - __kind: GoSliceDataType
-      ID: 214
-      Name: '[]noalg.map.group[string]string.array'
-      ByteSize: 2048
-      Element: 131 StructureType noalg.map.group[string]string
-    - __kind: EventRootType
-      ID: 215
-      Name: Probe[main.HandleHTTP]
-      ByteSize: 25
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: w
-          Offset: 1
-          Expression:
-            Type: 1 GoInterfaceType net/http.ResponseWriter
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 1, index: 0, name: w}
-                  Offset: 0
-                  ByteSize: 16
-        - Name: r
-          Offset: 17
-          Expression:
-            Type: 3 PointerType *net/http.Request
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 1, index: 1, name: r}
-                  Offset: 0
-                  ByteSize: 8
-    - __kind: EventRootType
-      ID: 216
-      Name: Probe[main.LookAtTheRequest]
-      ByteSize: 17
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: path
-          Offset: 1
-          Expression:
-            Type: 5 GoStringHeaderType string
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 2, index: 0, name: path}
-                  Offset: 0
-                  ByteSize: 16
+      GoRuntimeType: 580512
+      GoKind: 26
 MaxTypeID: 216
 Issues: []
 GoModuledataInfo: {FirstModuledataAddr: "0x133d7c0", TypesOffset: 296}

--- a/pkg/dyninst/irgen/testdata/snapshot/rc_tester_v1.arch=arm64,toolchain=go1.24.3.yaml
+++ b/pkg/dyninst/irgen/testdata/snapshot/rc_tester_v1.arch=arm64,toolchain=go1.24.3.yaml
@@ -33,7 +33,7 @@ Subprograms:
       InlinePCRanges: []
       Variables:
         - Name: w
-          Type: 1 GoInterfaceType net/http.ResponseWriter
+          Type: 36 GoInterfaceType net/http.ResponseWriter
           Locations:
             - Range: 0x86c100..0x86c158
               Pieces:
@@ -56,7 +56,7 @@ Subprograms:
           IsParameter: true
           IsReturn: false
         - Name: r
-          Type: 3 PointerType *net/http.Request
+          Type: 37 PointerType *net/http.Request
           Locations:
             - Range: 0x86c100..0x86c164
               Pieces: [{Size: 8, Op: {RegNo: 2, Shift: 0}}]
@@ -65,7 +65,7 @@ Subprograms:
           IsParameter: true
           IsReturn: false
         - Name: '&buf'
-          Type: 134 PointerType *bytes.Buffer
+          Type: 157 PointerType *bytes.Buffer
           Locations:
             - Range: 0x86c254..0x86c268
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
@@ -74,7 +74,7 @@ Subprograms:
           IsParameter: false
           IsReturn: false
         - Name: span
-          Type: 137 GoInterfaceType gopkg.in/DataDog/dd-trace-go.v1/ddtrace.Span
+          Type: 160 GoInterfaceType gopkg.in/DataDog/dd-trace-go.v1/ddtrace.Span
           Locations:
             - Range: 0x86c178..0x86c178
               Pieces:
@@ -97,7 +97,7 @@ Subprograms:
           IsParameter: false
           IsReturn: false
         - Name: .autotmp_14
-          Type: 138 StructureType context.backgroundCtx
+          Type: 161 StructureType context.backgroundCtx
           Locations:
             - Range: 0x86c100..0x86c340
               Pieces: [{Size: 0, Op: {CfaOffset: 0}}]
@@ -109,7 +109,7 @@ Subprograms:
       InlinePCRanges: []
       Variables:
         - Name: path
-          Type: 5 GoStringHeaderType string
+          Type: 9 GoStringHeaderType string
           Locations:
             - Range: 0x86c410..0x86c434
               Pieces:
@@ -121,49 +121,49 @@ Subprograms:
           IsReturn: false
 Types:
     - __kind: PointerType
-      ID: 57
+      ID: 81
       Name: '**crypto/x509.Certificate'
       ByteSize: 8
       GoKind: 22
-      Pointee: 58 PointerType *crypto/x509.Certificate
+      Pointee: 82 PointerType *crypto/x509.Certificate
     - __kind: PointerType
-      ID: 49
+      ID: 73
       Name: '**mime/multipart.FileHeader'
       ByteSize: 8
       GoKind: 22
-      Pointee: 50 PointerType *mime/multipart.FileHeader
+      Pointee: 74 PointerType *mime/multipart.FileHeader
     - __kind: PointerType
-      ID: 98
+      ID: 121
       Name: '**net.IPNet'
       ByteSize: 8
       GoKind: 22
-      Pointee: 99 PointerType *net.IPNet
+      Pointee: 122 PointerType *net.IPNet
     - __kind: PointerType
-      ID: 96
+      ID: 119
       Name: '**net/url.URL'
       ByteSize: 8
-      Pointee: 9 PointerType *net/url.URL
+      Pointee: 39 PointerType *net/url.URL
     - __kind: PointerType
-      ID: 40
+      ID: 64
       Name: '**table<string,[]*mime/multipart.FileHeader>'
       ByteSize: 8
-      Pointee: 41 PointerType *table<string,[]*mime/multipart.FileHeader>
+      Pointee: 65 PointerType *table<string,[]*mime/multipart.FileHeader>
     - __kind: PointerType
-      ID: 19
+      ID: 46
       Name: '**table<string,[]string>'
       ByteSize: 8
-      Pointee: 20 PointerType *table<string,[]string>
+      Pointee: 47 PointerType *table<string,[]string>
     - __kind: PointerType
-      ID: 126
+      ID: 149
       Name: '**table<string,string>'
       ByteSize: 8
-      Pointee: 127 PointerType *table<string,string>
+      Pointee: 150 PointerType *table<string,string>
     - __kind: PointerType
-      ID: 109
+      ID: 132
       Name: '*[]*crypto/x509.Certificate'
       ByteSize: 8
       GoKind: 22
-      Pointee: 56 GoSliceHeaderType []*crypto/x509.Certificate
+      Pointee: 80 GoSliceHeaderType []*crypto/x509.Certificate
     - __kind: PointerType
       ID: 176
       Name: '*[]*crypto/x509.Certificate.array'
@@ -250,203 +250,203 @@ Types:
       ByteSize: 8
       Pointee: 185 GoSliceDataType []time.zoneTrans.array
     - __kind: PointerType
-      ID: 111
+      ID: 134
       Name: '*[]uint8'
       ByteSize: 8
       GoRuntimeType: 478144
       GoKind: 22
-      Pointee: 53 GoSliceHeaderType []uint8
+      Pointee: 77 GoSliceHeaderType []uint8
     - __kind: PointerType
       ID: 174
       Name: '*[]uint8.array'
       ByteSize: 8
       Pointee: 173 GoSliceDataType []uint8.array
     - __kind: PointerType
-      ID: 142
+      ID: 11
       Name: '*bool'
       ByteSize: 8
       GoRuntimeType: 397184
       GoKind: 22
-      Pointee: 13 BaseType bool
+      Pointee: 4 BaseType bool
     - __kind: PointerType
-      ID: 134
+      ID: 157
       Name: '*bytes.Buffer'
       ByteSize: 8
       GoRuntimeType: 2.245056e+06
       GoKind: 22
-      Pointee: 135 StructureType bytes.Buffer
+      Pointee: 158 StructureType bytes.Buffer
     - __kind: PointerType
-      ID: 54
+      ID: 78
       Name: '*crypto/tls.ConnectionState'
       ByteSize: 8
       GoRuntimeType: 900864
       GoKind: 22
-      Pointee: 55 StructureType crypto/tls.ConnectionState
+      Pointee: 79 StructureType crypto/tls.ConnectionState
     - __kind: PointerType
-      ID: 58
+      ID: 82
       Name: '*crypto/x509.Certificate'
       ByteSize: 8
       GoRuntimeType: 2.030304e+06
       GoKind: 22
-      Pointee: 59 StructureType crypto/x509.Certificate
+      Pointee: 83 StructureType crypto/x509.Certificate
     - __kind: PointerType
-      ID: 90
+      ID: 113
       Name: '*crypto/x509.ExtKeyUsage'
       ByteSize: 8
       GoRuntimeType: 420160
       GoKind: 22
-      Pointee: 91 BaseType crypto/x509.ExtKeyUsage
+      Pointee: 114 BaseType crypto/x509.ExtKeyUsage
     - __kind: PointerType
-      ID: 103
+      ID: 126
       Name: '*crypto/x509.OID'
       ByteSize: 8
       GoRuntimeType: 1.938144e+06
       GoKind: 22
-      Pointee: 104 StructureType crypto/x509.OID
+      Pointee: 127 StructureType crypto/x509.OID
     - __kind: PointerType
-      ID: 106
+      ID: 129
       Name: '*crypto/x509.PolicyMapping'
       ByteSize: 8
       GoRuntimeType: 420224
       GoKind: 22
-      Pointee: 107 StructureType crypto/x509.PolicyMapping
+      Pointee: 130 StructureType crypto/x509.PolicyMapping
     - __kind: PointerType
-      ID: 70
+      ID: 94
       Name: '*crypto/x509/pkix.AttributeTypeAndValue'
       ByteSize: 8
       GoRuntimeType: 433984
       GoKind: 22
-      Pointee: 71 StructureType crypto/x509/pkix.AttributeTypeAndValue
+      Pointee: 95 StructureType crypto/x509/pkix.AttributeTypeAndValue
     - __kind: PointerType
-      ID: 85
+      ID: 108
       Name: '*crypto/x509/pkix.Extension'
       ByteSize: 8
       GoRuntimeType: 434176
       GoKind: 22
-      Pointee: 86 StructureType crypto/x509/pkix.Extension
+      Pointee: 109 StructureType crypto/x509/pkix.Extension
     - __kind: PointerType
-      ID: 88
+      ID: 111
       Name: '*encoding/asn1.ObjectIdentifier'
       ByteSize: 8
       GoRuntimeType: 1.044e+06
       GoKind: 22
-      Pointee: 72 GoSliceHeaderType encoding/asn1.ObjectIdentifier
+      Pointee: 96 GoSliceHeaderType encoding/asn1.ObjectIdentifier
     - __kind: PointerType
       ID: 182
       Name: '*encoding/asn1.ObjectIdentifier.array'
       ByteSize: 8
       Pointee: 181 GoSliceDataType encoding/asn1.ObjectIdentifier.array
     - __kind: PointerType
-      ID: 160
+      ID: 33
       Name: '*error'
       ByteSize: 8
       GoRuntimeType: 396096
       GoKind: 22
-      Pointee: 144 GoInterfaceType error
+      Pointee: 14 GoInterfaceType error
     - __kind: PointerType
-      ID: 162
+      ID: 35
       Name: '*float32'
       ByteSize: 8
       GoRuntimeType: 397056
       GoKind: 22
-      Pointee: 146 BaseType float32
+      Pointee: 17 BaseType float32
     - __kind: PointerType
-      ID: 154
+      ID: 26
       Name: '*float64'
       ByteSize: 8
       GoRuntimeType: 397120
       GoKind: 22
-      Pointee: 147 BaseType float64
+      Pointee: 18 BaseType float64
     - __kind: PointerType
-      ID: 73
+      ID: 28
       Name: '*int'
       ByteSize: 8
       GoRuntimeType: 396736
       GoKind: 22
-      Pointee: 8 BaseType int
+      Pointee: 7 BaseType int
     - __kind: PointerType
-      ID: 158
+      ID: 31
       Name: '*int16'
       ByteSize: 8
       GoRuntimeType: 396352
       GoKind: 22
-      Pointee: 151 BaseType int16
+      Pointee: 23 BaseType int16
     - __kind: PointerType
-      ID: 149
+      ID: 20
       Name: '*int32'
       ByteSize: 8
       GoRuntimeType: 396480
       GoKind: 22
-      Pointee: 143 BaseType int32
+      Pointee: 12 BaseType int32
     - __kind: PointerType
-      ID: 155
+      ID: 27
       Name: '*int64'
       ByteSize: 8
       GoRuntimeType: 396608
       GoKind: 22
-      Pointee: 32 BaseType int64
+      Pointee: 13 BaseType int64
     - __kind: PointerType
-      ID: 159
+      ID: 32
       Name: '*int8'
       ByteSize: 8
       GoRuntimeType: 396224
       GoKind: 22
-      Pointee: 145 BaseType int8
+      Pointee: 16 BaseType int8
     - __kind: PointerType
-      ID: 38
+      ID: 62
       Name: '*map<string,[]*mime/multipart.FileHeader>'
       ByteSize: 8
-      Pointee: 39 GoSwissMapHeaderType map<string,[]*mime/multipart.FileHeader>
+      Pointee: 63 GoSwissMapHeaderType map<string,[]*mime/multipart.FileHeader>
     - __kind: PointerType
-      ID: 15
+      ID: 44
       Name: '*map<string,[]string>'
       ByteSize: 8
-      Pointee: 16 GoSwissMapHeaderType map<string,[]string>
+      Pointee: 45 GoSwissMapHeaderType map<string,[]string>
     - __kind: PointerType
-      ID: 124
+      ID: 147
       Name: '*map<string,string>'
       ByteSize: 8
-      Pointee: 125 GoSwissMapHeaderType map<string,string>
+      Pointee: 148 GoSwissMapHeaderType map<string,string>
     - __kind: PointerType
-      ID: 63
+      ID: 87
       Name: '*math/big.Int'
       ByteSize: 8
       GoRuntimeType: 2.364704e+06
       GoKind: 22
-      Pointee: 64 StructureType math/big.Int
+      Pointee: 88 StructureType math/big.Int
     - __kind: PointerType
-      ID: 66
+      ID: 90
       Name: '*math/big.Word'
       ByteSize: 8
       GoRuntimeType: 423040
       GoKind: 22
-      Pointee: 67 BaseType math/big.Word
+      Pointee: 91 BaseType math/big.Word
     - __kind: PointerType
       ID: 178
       Name: '*math/big.nat.array'
       ByteSize: 8
       Pointee: 177 GoSliceDataType math/big.nat.array
     - __kind: PointerType
-      ID: 50
+      ID: 74
       Name: '*mime/multipart.FileHeader'
       ByteSize: 8
       GoRuntimeType: 902304
       GoKind: 22
-      Pointee: 51 StructureType mime/multipart.FileHeader
+      Pointee: 75 StructureType mime/multipart.FileHeader
     - __kind: PointerType
-      ID: 34
+      ID: 58
       Name: '*mime/multipart.Form'
       ByteSize: 8
       GoRuntimeType: 902400
       GoKind: 22
-      Pointee: 35 StructureType mime/multipart.Form
+      Pointee: 59 StructureType mime/multipart.Form
     - __kind: PointerType
-      ID: 93
+      ID: 116
       Name: '*net.IP'
       ByteSize: 8
       GoRuntimeType: 2.134112e+06
       GoKind: 22
-      Pointee: 94 GoSliceHeaderType net.IP
+      Pointee: 117 GoSliceHeaderType net.IP
     - __kind: PointerType
       ID: 196
       Name: '*net.IP.array'
@@ -458,161 +458,161 @@ Types:
       ByteSize: 8
       Pointee: 201 GoSliceDataType net.IPMask.array
     - __kind: PointerType
-      ID: 99
+      ID: 122
       Name: '*net.IPNet'
       ByteSize: 8
       GoRuntimeType: 1.17392e+06
       GoKind: 22
-      Pointee: 100 StructureType net.IPNet
+      Pointee: 123 StructureType net.IPNet
     - __kind: PointerType
-      ID: 3
+      ID: 37
       Name: '*net/http.Request'
       ByteSize: 8
       GoRuntimeType: 2.2848e+06
       GoKind: 22
-      Pointee: 4 StructureType net/http.Request
+      Pointee: 38 StructureType net/http.Request
     - __kind: PointerType
-      ID: 115
+      ID: 138
       Name: '*net/http.Response'
       ByteSize: 8
       GoRuntimeType: 1.705504e+06
       GoKind: 22
-      Pointee: 116 StructureType net/http.Response
+      Pointee: 139 StructureType net/http.Response
     - __kind: PointerType
-      ID: 118
+      ID: 141
       Name: '*net/http.pattern'
       ByteSize: 8
       GoRuntimeType: 1.597408e+06
       GoKind: 22
-      Pointee: 119 StructureType net/http.pattern
+      Pointee: 142 StructureType net/http.pattern
     - __kind: PointerType
-      ID: 121
+      ID: 144
       Name: '*net/http.segment'
       ByteSize: 8
       GoRuntimeType: 388544
       GoKind: 22
-      Pointee: 122 StructureType net/http.segment
+      Pointee: 145 StructureType net/http.segment
     - __kind: PointerType
-      ID: 9
+      ID: 39
       Name: '*net/url.URL'
       ByteSize: 8
       GoRuntimeType: 2.099328e+06
       GoKind: 22
-      Pointee: 10 StructureType net/url.URL
+      Pointee: 40 StructureType net/url.URL
     - __kind: PointerType
-      ID: 11
+      ID: 41
       Name: '*net/url.Userinfo'
       ByteSize: 8
       GoRuntimeType: 1.191456e+06
       GoKind: 22
-      Pointee: 12 StructureType net/url.Userinfo
+      Pointee: 42 StructureType net/url.Userinfo
     - __kind: PointerType
-      ID: 44
+      ID: 68
       Name: '*noalg.map.group[string][]*mime/multipart.FileHeader'
       ByteSize: 8
-      Pointee: 45 StructureType noalg.map.group[string][]*mime/multipart.FileHeader
+      Pointee: 69 StructureType noalg.map.group[string][]*mime/multipart.FileHeader
     - __kind: PointerType
-      ID: 24
+      ID: 50
       Name: '*noalg.map.group[string][]string'
       ByteSize: 8
-      Pointee: 25 StructureType noalg.map.group[string][]string
+      Pointee: 51 StructureType noalg.map.group[string][]string
     - __kind: PointerType
-      ID: 130
+      ID: 153
       Name: '*noalg.map.group[string]string'
       ByteSize: 8
-      Pointee: 131 StructureType noalg.map.group[string]string
+      Pointee: 154 StructureType noalg.map.group[string]string
     - __kind: PointerType
-      ID: 29
+      ID: 22
       Name: '*string'
       ByteSize: 8
       GoRuntimeType: 396160
       GoKind: 22
-      Pointee: 5 GoStringHeaderType string
+      Pointee: 9 GoStringHeaderType string
     - __kind: PointerType
       ID: 164
       Name: '*string.str'
       ByteSize: 8
       Pointee: 163 GoStringDataType string.str
     - __kind: PointerType
-      ID: 41
+      ID: 65
       Name: '*table<string,[]*mime/multipart.FileHeader>'
       ByteSize: 8
-      Pointee: 42 StructureType table<string,[]*mime/multipart.FileHeader>
+      Pointee: 66 StructureType table<string,[]*mime/multipart.FileHeader>
     - __kind: PointerType
-      ID: 20
+      ID: 47
       Name: '*table<string,[]string>'
       ByteSize: 8
-      Pointee: 21 StructureType table<string,[]string>
+      Pointee: 48 StructureType table<string,[]string>
     - __kind: PointerType
-      ID: 127
+      ID: 150
       Name: '*table<string,string>'
       ByteSize: 8
-      Pointee: 128 StructureType table<string,string>
+      Pointee: 151 StructureType table<string,string>
     - __kind: PointerType
-      ID: 75
+      ID: 98
       Name: '*time.Location'
       ByteSize: 8
       GoRuntimeType: 1.6024e+06
       GoKind: 22
-      Pointee: 76 StructureType time.Location
+      Pointee: 99 StructureType time.Location
     - __kind: PointerType
-      ID: 78
+      ID: 101
       Name: '*time.zone'
       ByteSize: 8
       GoRuntimeType: 391680
       GoKind: 22
-      Pointee: 79 StructureType time.zone
+      Pointee: 102 StructureType time.zone
     - __kind: PointerType
-      ID: 81
+      ID: 104
       Name: '*time.zoneTrans'
       ByteSize: 8
       GoRuntimeType: 391744
       GoKind: 22
-      Pointee: 82 StructureType time.zoneTrans
+      Pointee: 105 StructureType time.zoneTrans
     - __kind: PointerType
-      ID: 161
+      ID: 34
       Name: '*uint'
       ByteSize: 8
       GoRuntimeType: 396800
       GoKind: 22
-      Pointee: 141 BaseType uint
+      Pointee: 10 BaseType uint
     - __kind: PointerType
-      ID: 157
+      ID: 30
       Name: '*uint16'
       ByteSize: 8
       GoRuntimeType: 396416
       GoKind: 22
-      Pointee: 22 BaseType uint16
+      Pointee: 6 BaseType uint16
     - __kind: PointerType
-      ID: 150
+      ID: 21
       Name: '*uint32'
       ByteSize: 8
       GoRuntimeType: 396544
       GoKind: 22
-      Pointee: 140 BaseType uint32
+      Pointee: 2 BaseType uint32
     - __kind: PointerType
-      ID: 156
+      ID: 29
       Name: '*uint64'
       ByteSize: 8
       GoRuntimeType: 396672
       GoKind: 22
-      Pointee: 17 BaseType uint64
+      Pointee: 8 BaseType uint64
     - __kind: PointerType
-      ID: 6
+      ID: 5
       Name: '*uint8'
       ByteSize: 8
       GoRuntimeType: 396288
       GoKind: 22
-      Pointee: 7 BaseType uint8
+      Pointee: 3 BaseType uint8
     - __kind: PointerType
-      ID: 148
+      ID: 19
       Name: '*uintptr'
       ByteSize: 8
       GoRuntimeType: 396864
       GoKind: 22
-      Pointee: 18 BaseType uintptr
+      Pointee: 1 BaseType uintptr
     - __kind: GoChannelType
-      ID: 114
+      ID: 137
       Name: <-chan struct {}
       GoRuntimeType: 592672
       GoKind: 18
@@ -625,7 +625,7 @@ Types:
         - Name: w
           Offset: 1
           Expression:
-            Type: 1 GoInterfaceType net/http.ResponseWriter
+            Type: 36 GoInterfaceType net/http.ResponseWriter
             Operations:
                 - __kind: LocationOp
                   Variable: {subprogram: 1, index: 0, name: w}
@@ -634,7 +634,7 @@ Types:
         - Name: r
           Offset: 17
           Expression:
-            Type: 3 PointerType *net/http.Request
+            Type: 37 PointerType *net/http.Request
             Operations:
                 - __kind: LocationOp
                   Variable: {subprogram: 1, index: 1, name: r}
@@ -649,14 +649,14 @@ Types:
         - Name: path
           Offset: 1
           Expression:
-            Type: 5 GoStringHeaderType string
+            Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
                   Variable: {subprogram: 2, index: 0, name: path}
                   Offset: 0
                   ByteSize: 16
     - __kind: GoSliceHeaderType
-      ID: 56
+      ID: 80
       Name: '[]*crypto/x509.Certificate'
       ByteSize: 24
       GoRuntimeType: 498304
@@ -664,21 +664,21 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 57 PointerType **crypto/x509.Certificate
+          Type: 81 PointerType **crypto/x509.Certificate
         - Name: len
           Offset: 8
-          Type: 8 BaseType int
+          Type: 7 BaseType int
         - Name: cap
           Offset: 16
-          Type: 8 BaseType int
+          Type: 7 BaseType int
       Data: 175 GoSliceDataType []*crypto/x509.Certificate.array
     - __kind: GoSliceDataType
       ID: 175
       Name: '[]*crypto/x509.Certificate.array'
       ByteSize: 2048
-      Element: 58 PointerType *crypto/x509.Certificate
+      Element: 82 PointerType *crypto/x509.Certificate
     - __kind: GoSliceHeaderType
-      ID: 48
+      ID: 72
       Name: '[]*mime/multipart.FileHeader'
       ByteSize: 24
       GoRuntimeType: 483744
@@ -686,21 +686,21 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 49 PointerType **mime/multipart.FileHeader
+          Type: 73 PointerType **mime/multipart.FileHeader
         - Name: len
           Offset: 8
-          Type: 8 BaseType int
+          Type: 7 BaseType int
         - Name: cap
           Offset: 16
-          Type: 8 BaseType int
+          Type: 7 BaseType int
       Data: 171 GoSliceDataType []*mime/multipart.FileHeader.array
     - __kind: GoSliceDataType
       ID: 171
       Name: '[]*mime/multipart.FileHeader.array'
       ByteSize: 2048
-      Element: 50 PointerType *mime/multipart.FileHeader
+      Element: 74 PointerType *mime/multipart.FileHeader
     - __kind: GoSliceHeaderType
-      ID: 97
+      ID: 120
       Name: '[]*net.IPNet'
       ByteSize: 24
       GoRuntimeType: 511840
@@ -708,21 +708,21 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 98 PointerType **net.IPNet
+          Type: 121 PointerType **net.IPNet
         - Name: len
           Offset: 8
-          Type: 8 BaseType int
+          Type: 7 BaseType int
         - Name: cap
           Offset: 16
-          Type: 8 BaseType int
+          Type: 7 BaseType int
       Data: 199 GoSliceDataType []*net.IPNet.array
     - __kind: GoSliceDataType
       ID: 199
       Name: '[]*net.IPNet.array'
       ByteSize: 2048
-      Element: 99 PointerType *net.IPNet
+      Element: 122 PointerType *net.IPNet
     - __kind: GoSliceHeaderType
-      ID: 95
+      ID: 118
       Name: '[]*net/url.URL'
       ByteSize: 24
       GoRuntimeType: 511776
@@ -730,36 +730,36 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 96 PointerType **net/url.URL
+          Type: 119 PointerType **net/url.URL
         - Name: len
           Offset: 8
-          Type: 8 BaseType int
+          Type: 7 BaseType int
         - Name: cap
           Offset: 16
-          Type: 8 BaseType int
+          Type: 7 BaseType int
       Data: 197 GoSliceDataType []*net/url.URL.array
     - __kind: GoSliceDataType
       ID: 197
       Name: '[]*net/url.URL.array'
       ByteSize: 2048
-      Element: 9 PointerType *net/url.URL
+      Element: 39 PointerType *net/url.URL
     - __kind: GoSliceDataType
       ID: 169
       Name: '[]*table<string,[]*mime/multipart.FileHeader>.array'
       ByteSize: 8192
-      Element: 41 PointerType *table<string,[]*mime/multipart.FileHeader>
+      Element: 65 PointerType *table<string,[]*mime/multipart.FileHeader>
     - __kind: GoSliceDataType
       ID: 165
       Name: '[]*table<string,[]string>.array'
       ByteSize: 8192
-      Element: 20 PointerType *table<string,[]string>
+      Element: 47 PointerType *table<string,[]string>
     - __kind: GoSliceDataType
       ID: 213
       Name: '[]*table<string,string>.array'
       ByteSize: 8192
-      Element: 127 PointerType *table<string,string>
+      Element: 150 PointerType *table<string,string>
     - __kind: GoSliceHeaderType
-      ID: 108
+      ID: 131
       Name: '[][]*crypto/x509.Certificate'
       ByteSize: 24
       GoRuntimeType: 498432
@@ -767,21 +767,21 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 109 PointerType *[]*crypto/x509.Certificate
+          Type: 132 PointerType *[]*crypto/x509.Certificate
         - Name: len
           Offset: 8
-          Type: 8 BaseType int
+          Type: 7 BaseType int
         - Name: cap
           Offset: 16
-          Type: 8 BaseType int
+          Type: 7 BaseType int
       Data: 207 GoSliceDataType [][]*crypto/x509.Certificate.array
     - __kind: GoSliceDataType
       ID: 207
       Name: '[][]*crypto/x509.Certificate.array'
       ByteSize: 2048
-      Element: 56 GoSliceHeaderType []*crypto/x509.Certificate
+      Element: 80 GoSliceHeaderType []*crypto/x509.Certificate
     - __kind: GoSliceHeaderType
-      ID: 110
+      ID: 133
       Name: '[][]uint8'
       ByteSize: 24
       GoRuntimeType: 478528
@@ -789,21 +789,21 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 111 PointerType *[]uint8
+          Type: 134 PointerType *[]uint8
         - Name: len
           Offset: 8
-          Type: 8 BaseType int
+          Type: 7 BaseType int
         - Name: cap
           Offset: 16
-          Type: 8 BaseType int
+          Type: 7 BaseType int
       Data: 209 GoSliceDataType [][]uint8.array
     - __kind: GoSliceDataType
       ID: 209
       Name: '[][]uint8.array'
       ByteSize: 2048
-      Element: 53 GoSliceHeaderType []uint8
+      Element: 77 GoSliceHeaderType []uint8
     - __kind: GoSliceHeaderType
-      ID: 89
+      ID: 112
       Name: '[]crypto/x509.ExtKeyUsage'
       ByteSize: 24
       GoRuntimeType: 499776
@@ -811,21 +811,21 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 90 PointerType *crypto/x509.ExtKeyUsage
+          Type: 113 PointerType *crypto/x509.ExtKeyUsage
         - Name: len
           Offset: 8
-          Type: 8 BaseType int
+          Type: 7 BaseType int
         - Name: cap
           Offset: 16
-          Type: 8 BaseType int
+          Type: 7 BaseType int
       Data: 191 GoSliceDataType []crypto/x509.ExtKeyUsage.array
     - __kind: GoSliceDataType
       ID: 191
       Name: '[]crypto/x509.ExtKeyUsage.array'
       ByteSize: 2048
-      Element: 91 BaseType crypto/x509.ExtKeyUsage
+      Element: 114 BaseType crypto/x509.ExtKeyUsage
     - __kind: GoSliceHeaderType
-      ID: 102
+      ID: 125
       Name: '[]crypto/x509.OID'
       ByteSize: 24
       GoRuntimeType: 511904
@@ -833,21 +833,21 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 103 PointerType *crypto/x509.OID
+          Type: 126 PointerType *crypto/x509.OID
         - Name: len
           Offset: 8
-          Type: 8 BaseType int
+          Type: 7 BaseType int
         - Name: cap
           Offset: 16
-          Type: 8 BaseType int
+          Type: 7 BaseType int
       Data: 203 GoSliceDataType []crypto/x509.OID.array
     - __kind: GoSliceDataType
       ID: 203
       Name: '[]crypto/x509.OID.array'
       ByteSize: 2048
-      Element: 104 StructureType crypto/x509.OID
+      Element: 127 StructureType crypto/x509.OID
     - __kind: GoSliceHeaderType
-      ID: 105
+      ID: 128
       Name: '[]crypto/x509.PolicyMapping'
       ByteSize: 24
       GoRuntimeType: 511968
@@ -855,21 +855,21 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 106 PointerType *crypto/x509.PolicyMapping
+          Type: 129 PointerType *crypto/x509.PolicyMapping
         - Name: len
           Offset: 8
-          Type: 8 BaseType int
+          Type: 7 BaseType int
         - Name: cap
           Offset: 16
-          Type: 8 BaseType int
+          Type: 7 BaseType int
       Data: 205 GoSliceDataType []crypto/x509.PolicyMapping.array
     - __kind: GoSliceDataType
       ID: 205
       Name: '[]crypto/x509.PolicyMapping.array'
       ByteSize: 2048
-      Element: 107 StructureType crypto/x509.PolicyMapping
+      Element: 130 StructureType crypto/x509.PolicyMapping
     - __kind: GoSliceHeaderType
-      ID: 69
+      ID: 93
       Name: '[]crypto/x509/pkix.AttributeTypeAndValue'
       ByteSize: 24
       GoRuntimeType: 512416
@@ -877,21 +877,21 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 70 PointerType *crypto/x509/pkix.AttributeTypeAndValue
+          Type: 94 PointerType *crypto/x509/pkix.AttributeTypeAndValue
         - Name: len
           Offset: 8
-          Type: 8 BaseType int
+          Type: 7 BaseType int
         - Name: cap
           Offset: 16
-          Type: 8 BaseType int
+          Type: 7 BaseType int
       Data: 179 GoSliceDataType []crypto/x509/pkix.AttributeTypeAndValue.array
     - __kind: GoSliceDataType
       ID: 179
       Name: '[]crypto/x509/pkix.AttributeTypeAndValue.array'
       ByteSize: 2048
-      Element: 71 StructureType crypto/x509/pkix.AttributeTypeAndValue
+      Element: 95 StructureType crypto/x509/pkix.AttributeTypeAndValue
     - __kind: GoSliceHeaderType
-      ID: 84
+      ID: 107
       Name: '[]crypto/x509/pkix.Extension'
       ByteSize: 24
       GoRuntimeType: 511648
@@ -899,21 +899,21 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 85 PointerType *crypto/x509/pkix.Extension
+          Type: 108 PointerType *crypto/x509/pkix.Extension
         - Name: len
           Offset: 8
-          Type: 8 BaseType int
+          Type: 7 BaseType int
         - Name: cap
           Offset: 16
-          Type: 8 BaseType int
+          Type: 7 BaseType int
       Data: 187 GoSliceDataType []crypto/x509/pkix.Extension.array
     - __kind: GoSliceDataType
       ID: 187
       Name: '[]crypto/x509/pkix.Extension.array'
       ByteSize: 2048
-      Element: 86 StructureType crypto/x509/pkix.Extension
+      Element: 109 StructureType crypto/x509/pkix.Extension
     - __kind: GoSliceHeaderType
-      ID: 87
+      ID: 110
       Name: '[]encoding/asn1.ObjectIdentifier'
       ByteSize: 24
       GoRuntimeType: 511712
@@ -921,21 +921,21 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 88 PointerType *encoding/asn1.ObjectIdentifier
+          Type: 111 PointerType *encoding/asn1.ObjectIdentifier
         - Name: len
           Offset: 8
-          Type: 8 BaseType int
+          Type: 7 BaseType int
         - Name: cap
           Offset: 16
-          Type: 8 BaseType int
+          Type: 7 BaseType int
       Data: 189 GoSliceDataType []encoding/asn1.ObjectIdentifier.array
     - __kind: GoSliceDataType
       ID: 189
       Name: '[]encoding/asn1.ObjectIdentifier.array'
       ByteSize: 2048
-      Element: 72 GoSliceHeaderType encoding/asn1.ObjectIdentifier
+      Element: 96 GoSliceHeaderType encoding/asn1.ObjectIdentifier
     - __kind: GoSliceHeaderType
-      ID: 92
+      ID: 115
       Name: '[]net.IP'
       ByteSize: 24
       GoRuntimeType: 479488
@@ -943,21 +943,21 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 93 PointerType *net.IP
+          Type: 116 PointerType *net.IP
         - Name: len
           Offset: 8
-          Type: 8 BaseType int
+          Type: 7 BaseType int
         - Name: cap
           Offset: 16
-          Type: 8 BaseType int
+          Type: 7 BaseType int
       Data: 193 GoSliceDataType []net.IP.array
     - __kind: GoSliceDataType
       ID: 193
       Name: '[]net.IP.array'
       ByteSize: 2048
-      Element: 94 GoSliceHeaderType net.IP
+      Element: 117 GoSliceHeaderType net.IP
     - __kind: GoSliceHeaderType
-      ID: 120
+      ID: 143
       Name: '[]net/http.segment'
       ByteSize: 24
       GoRuntimeType: 481120
@@ -965,36 +965,36 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 121 PointerType *net/http.segment
+          Type: 144 PointerType *net/http.segment
         - Name: len
           Offset: 8
-          Type: 8 BaseType int
+          Type: 7 BaseType int
         - Name: cap
           Offset: 16
-          Type: 8 BaseType int
+          Type: 7 BaseType int
       Data: 211 GoSliceDataType []net/http.segment.array
     - __kind: GoSliceDataType
       ID: 211
       Name: '[]net/http.segment.array'
       ByteSize: 2048
-      Element: 122 StructureType net/http.segment
+      Element: 145 StructureType net/http.segment
     - __kind: GoSliceDataType
       ID: 170
       Name: '[]noalg.map.group[string][]*mime/multipart.FileHeader.array'
       ByteSize: 2048
-      Element: 45 StructureType noalg.map.group[string][]*mime/multipart.FileHeader
+      Element: 69 StructureType noalg.map.group[string][]*mime/multipart.FileHeader
     - __kind: GoSliceDataType
       ID: 166
       Name: '[]noalg.map.group[string][]string.array'
       ByteSize: 2048
-      Element: 25 StructureType noalg.map.group[string][]string
+      Element: 51 StructureType noalg.map.group[string][]string
     - __kind: GoSliceDataType
       ID: 214
       Name: '[]noalg.map.group[string]string.array'
       ByteSize: 2048
-      Element: 131 StructureType noalg.map.group[string]string
+      Element: 154 StructureType noalg.map.group[string]string
     - __kind: GoSliceHeaderType
-      ID: 28
+      ID: 54
       Name: '[]string'
       ByteSize: 24
       GoRuntimeType: 492672
@@ -1002,21 +1002,21 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 29 PointerType *string
+          Type: 22 PointerType *string
         - Name: len
           Offset: 8
-          Type: 8 BaseType int
+          Type: 7 BaseType int
         - Name: cap
           Offset: 16
-          Type: 8 BaseType int
+          Type: 7 BaseType int
       Data: 167 GoSliceDataType []string.array
     - __kind: GoSliceDataType
       ID: 167
       Name: '[]string.array'
       ByteSize: 2048
-      Element: 5 GoStringHeaderType string
+      Element: 9 GoStringHeaderType string
     - __kind: GoSliceHeaderType
-      ID: 77
+      ID: 100
       Name: '[]time.zone'
       ByteSize: 24
       GoRuntimeType: 485792
@@ -1024,21 +1024,21 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 78 PointerType *time.zone
+          Type: 101 PointerType *time.zone
         - Name: len
           Offset: 8
-          Type: 8 BaseType int
+          Type: 7 BaseType int
         - Name: cap
           Offset: 16
-          Type: 8 BaseType int
+          Type: 7 BaseType int
       Data: 183 GoSliceDataType []time.zone.array
     - __kind: GoSliceDataType
       ID: 183
       Name: '[]time.zone.array'
       ByteSize: 2048
-      Element: 79 StructureType time.zone
+      Element: 102 StructureType time.zone
     - __kind: GoSliceHeaderType
-      ID: 80
+      ID: 103
       Name: '[]time.zoneTrans'
       ByteSize: 24
       GoRuntimeType: 485856
@@ -1046,21 +1046,21 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 81 PointerType *time.zoneTrans
+          Type: 104 PointerType *time.zoneTrans
         - Name: len
           Offset: 8
-          Type: 8 BaseType int
+          Type: 7 BaseType int
         - Name: cap
           Offset: 16
-          Type: 8 BaseType int
+          Type: 7 BaseType int
       Data: 185 GoSliceDataType []time.zoneTrans.array
     - __kind: GoSliceDataType
       ID: 185
       Name: '[]time.zoneTrans.array'
       ByteSize: 2048
-      Element: 82 StructureType time.zoneTrans
+      Element: 105 StructureType time.zoneTrans
     - __kind: GoSliceHeaderType
-      ID: 53
+      ID: 77
       Name: '[]uint8'
       ByteSize: 24
       GoRuntimeType: 491520
@@ -1068,27 +1068,27 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 6 PointerType *uint8
+          Type: 5 PointerType *uint8
         - Name: len
           Offset: 8
-          Type: 8 BaseType int
+          Type: 7 BaseType int
         - Name: cap
           Offset: 16
-          Type: 8 BaseType int
+          Type: 7 BaseType int
       Data: 173 GoSliceDataType []uint8.array
     - __kind: GoSliceDataType
       ID: 173
       Name: '[]uint8.array'
       ByteSize: 2048
-      Element: 7 BaseType uint8
+      Element: 3 BaseType uint8
     - __kind: BaseType
-      ID: 13
+      ID: 4
       Name: bool
       ByteSize: 1
       GoRuntimeType: 580448
       GoKind: 1
     - __kind: StructureType
-      ID: 135
+      ID: 158
       Name: bytes.Buffer
       ByteSize: 40
       GoRuntimeType: 1.595104e+06
@@ -1096,33 +1096,33 @@ Types:
       RawFields:
         - Name: buf
           Offset: 0
-          Type: 53 GoSliceHeaderType []uint8
+          Type: 77 GoSliceHeaderType []uint8
         - Name: off
           Offset: 24
-          Type: 8 BaseType int
+          Type: 7 BaseType int
         - Name: lastRead
           Offset: 32
-          Type: 136 BaseType bytes.readOp
+          Type: 159 BaseType bytes.readOp
     - __kind: BaseType
-      ID: 136
+      ID: 159
       Name: bytes.readOp
       ByteSize: 1
       GoRuntimeType: 578592
       GoKind: 3
     - __kind: BaseType
-      ID: 153
+      ID: 25
       Name: complex128
       ByteSize: 16
       GoRuntimeType: 580256
       GoKind: 16
     - __kind: BaseType
-      ID: 152
+      ID: 24
       Name: complex64
       ByteSize: 8
       GoRuntimeType: 580192
       GoKind: 15
     - __kind: GoInterfaceType
-      ID: 117
+      ID: 140
       Name: context.Context
       ByteSize: 16
       GoRuntimeType: 1.266912e+06
@@ -1130,27 +1130,27 @@ Types:
       RawFields:
         - Name: tab
           Offset: 0
-          Type: 2 VoidPointerType unsafe.Pointer
+          Type: 15 VoidPointerType unsafe.Pointer
         - Name: data
           Offset: 8
-          Type: 2 VoidPointerType unsafe.Pointer
+          Type: 15 VoidPointerType unsafe.Pointer
     - __kind: StructureType
-      ID: 138
+      ID: 161
       Name: context.backgroundCtx
       GoRuntimeType: 1.781408e+06
       GoKind: 25
       RawFields:
         - Name: emptyCtx
           Offset: 0
-          Type: 139 StructureType context.emptyCtx
+          Type: 162 StructureType context.emptyCtx
     - __kind: StructureType
-      ID: 139
+      ID: 162
       Name: context.emptyCtx
       GoRuntimeType: 1.58016e+06
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 55
+      ID: 79
       Name: crypto/tls.ConnectionState
       ByteSize: 192
       GoRuntimeType: 2.231616e+06
@@ -1158,60 +1158,60 @@ Types:
       RawFields:
         - Name: Version
           Offset: 0
-          Type: 22 BaseType uint16
+          Type: 6 BaseType uint16
         - Name: HandshakeComplete
           Offset: 2
-          Type: 13 BaseType bool
+          Type: 4 BaseType bool
         - Name: DidResume
           Offset: 3
-          Type: 13 BaseType bool
+          Type: 4 BaseType bool
         - Name: CipherSuite
           Offset: 4
-          Type: 22 BaseType uint16
+          Type: 6 BaseType uint16
         - Name: NegotiatedProtocol
           Offset: 8
-          Type: 5 GoStringHeaderType string
+          Type: 9 GoStringHeaderType string
         - Name: NegotiatedProtocolIsMutual
           Offset: 24
-          Type: 13 BaseType bool
+          Type: 4 BaseType bool
         - Name: ServerName
           Offset: 32
-          Type: 5 GoStringHeaderType string
+          Type: 9 GoStringHeaderType string
         - Name: PeerCertificates
           Offset: 48
-          Type: 56 GoSliceHeaderType []*crypto/x509.Certificate
+          Type: 80 GoSliceHeaderType []*crypto/x509.Certificate
         - Name: VerifiedChains
           Offset: 72
-          Type: 108 GoSliceHeaderType [][]*crypto/x509.Certificate
+          Type: 131 GoSliceHeaderType [][]*crypto/x509.Certificate
         - Name: SignedCertificateTimestamps
           Offset: 96
-          Type: 110 GoSliceHeaderType [][]uint8
+          Type: 133 GoSliceHeaderType [][]uint8
         - Name: OCSPResponse
           Offset: 120
-          Type: 53 GoSliceHeaderType []uint8
+          Type: 77 GoSliceHeaderType []uint8
         - Name: TLSUnique
           Offset: 144
-          Type: 53 GoSliceHeaderType []uint8
+          Type: 77 GoSliceHeaderType []uint8
         - Name: ECHAccepted
           Offset: 168
-          Type: 13 BaseType bool
+          Type: 4 BaseType bool
         - Name: ekm
           Offset: 176
-          Type: 112 GoSubroutineType func(string, []uint8, int) ([]uint8, error)
+          Type: 135 GoSubroutineType func(string, []uint8, int) ([]uint8, error)
         - Name: testingOnlyDidHRR
           Offset: 184
-          Type: 13 BaseType bool
+          Type: 4 BaseType bool
         - Name: testingOnlyCurveID
           Offset: 186
-          Type: 113 BaseType crypto/tls.CurveID
+          Type: 136 BaseType crypto/tls.CurveID
     - __kind: BaseType
-      ID: 113
+      ID: 136
       Name: crypto/tls.CurveID
       ByteSize: 2
       GoRuntimeType: 829056
       GoKind: 9
     - __kind: StructureType
-      ID: 59
+      ID: 83
       Name: crypto/x509.Certificate
       ByteSize: 1424
       GoRuntimeType: 2.37712e+06
@@ -1219,174 +1219,174 @@ Types:
       RawFields:
         - Name: Raw
           Offset: 0
-          Type: 53 GoSliceHeaderType []uint8
+          Type: 77 GoSliceHeaderType []uint8
         - Name: RawTBSCertificate
           Offset: 24
-          Type: 53 GoSliceHeaderType []uint8
+          Type: 77 GoSliceHeaderType []uint8
         - Name: RawSubjectPublicKeyInfo
           Offset: 48
-          Type: 53 GoSliceHeaderType []uint8
+          Type: 77 GoSliceHeaderType []uint8
         - Name: RawSubject
           Offset: 72
-          Type: 53 GoSliceHeaderType []uint8
+          Type: 77 GoSliceHeaderType []uint8
         - Name: RawIssuer
           Offset: 96
-          Type: 53 GoSliceHeaderType []uint8
+          Type: 77 GoSliceHeaderType []uint8
         - Name: Signature
           Offset: 120
-          Type: 53 GoSliceHeaderType []uint8
+          Type: 77 GoSliceHeaderType []uint8
         - Name: SignatureAlgorithm
           Offset: 144
-          Type: 60 BaseType crypto/x509.SignatureAlgorithm
+          Type: 84 BaseType crypto/x509.SignatureAlgorithm
         - Name: PublicKeyAlgorithm
           Offset: 152
-          Type: 61 BaseType crypto/x509.PublicKeyAlgorithm
+          Type: 85 BaseType crypto/x509.PublicKeyAlgorithm
         - Name: PublicKey
           Offset: 160
-          Type: 62 GoEmptyInterfaceType interface {}
+          Type: 86 GoEmptyInterfaceType interface {}
         - Name: Version
           Offset: 176
-          Type: 8 BaseType int
+          Type: 7 BaseType int
         - Name: SerialNumber
           Offset: 184
-          Type: 63 PointerType *math/big.Int
+          Type: 87 PointerType *math/big.Int
         - Name: Issuer
           Offset: 192
-          Type: 68 StructureType crypto/x509/pkix.Name
+          Type: 92 StructureType crypto/x509/pkix.Name
         - Name: Subject
           Offset: 440
-          Type: 68 StructureType crypto/x509/pkix.Name
+          Type: 92 StructureType crypto/x509/pkix.Name
         - Name: NotBefore
           Offset: 688
-          Type: 74 StructureType time.Time
+          Type: 97 StructureType time.Time
         - Name: NotAfter
           Offset: 712
-          Type: 74 StructureType time.Time
+          Type: 97 StructureType time.Time
         - Name: KeyUsage
           Offset: 736
-          Type: 83 BaseType crypto/x509.KeyUsage
+          Type: 106 BaseType crypto/x509.KeyUsage
         - Name: Extensions
           Offset: 744
-          Type: 84 GoSliceHeaderType []crypto/x509/pkix.Extension
+          Type: 107 GoSliceHeaderType []crypto/x509/pkix.Extension
         - Name: ExtraExtensions
           Offset: 768
-          Type: 84 GoSliceHeaderType []crypto/x509/pkix.Extension
+          Type: 107 GoSliceHeaderType []crypto/x509/pkix.Extension
         - Name: UnhandledCriticalExtensions
           Offset: 792
-          Type: 87 GoSliceHeaderType []encoding/asn1.ObjectIdentifier
+          Type: 110 GoSliceHeaderType []encoding/asn1.ObjectIdentifier
         - Name: ExtKeyUsage
           Offset: 816
-          Type: 89 GoSliceHeaderType []crypto/x509.ExtKeyUsage
+          Type: 112 GoSliceHeaderType []crypto/x509.ExtKeyUsage
         - Name: UnknownExtKeyUsage
           Offset: 840
-          Type: 87 GoSliceHeaderType []encoding/asn1.ObjectIdentifier
+          Type: 110 GoSliceHeaderType []encoding/asn1.ObjectIdentifier
         - Name: BasicConstraintsValid
           Offset: 864
-          Type: 13 BaseType bool
+          Type: 4 BaseType bool
         - Name: IsCA
           Offset: 865
-          Type: 13 BaseType bool
+          Type: 4 BaseType bool
         - Name: MaxPathLen
           Offset: 872
-          Type: 8 BaseType int
+          Type: 7 BaseType int
         - Name: MaxPathLenZero
           Offset: 880
-          Type: 13 BaseType bool
+          Type: 4 BaseType bool
         - Name: SubjectKeyId
           Offset: 888
-          Type: 53 GoSliceHeaderType []uint8
+          Type: 77 GoSliceHeaderType []uint8
         - Name: AuthorityKeyId
           Offset: 912
-          Type: 53 GoSliceHeaderType []uint8
+          Type: 77 GoSliceHeaderType []uint8
         - Name: OCSPServer
           Offset: 936
-          Type: 28 GoSliceHeaderType []string
+          Type: 54 GoSliceHeaderType []string
         - Name: IssuingCertificateURL
           Offset: 960
-          Type: 28 GoSliceHeaderType []string
+          Type: 54 GoSliceHeaderType []string
         - Name: DNSNames
           Offset: 984
-          Type: 28 GoSliceHeaderType []string
+          Type: 54 GoSliceHeaderType []string
         - Name: EmailAddresses
           Offset: 1008
-          Type: 28 GoSliceHeaderType []string
+          Type: 54 GoSliceHeaderType []string
         - Name: IPAddresses
           Offset: 1032
-          Type: 92 GoSliceHeaderType []net.IP
+          Type: 115 GoSliceHeaderType []net.IP
         - Name: URIs
           Offset: 1056
-          Type: 95 GoSliceHeaderType []*net/url.URL
+          Type: 118 GoSliceHeaderType []*net/url.URL
         - Name: PermittedDNSDomainsCritical
           Offset: 1080
-          Type: 13 BaseType bool
+          Type: 4 BaseType bool
         - Name: PermittedDNSDomains
           Offset: 1088
-          Type: 28 GoSliceHeaderType []string
+          Type: 54 GoSliceHeaderType []string
         - Name: ExcludedDNSDomains
           Offset: 1112
-          Type: 28 GoSliceHeaderType []string
+          Type: 54 GoSliceHeaderType []string
         - Name: PermittedIPRanges
           Offset: 1136
-          Type: 97 GoSliceHeaderType []*net.IPNet
+          Type: 120 GoSliceHeaderType []*net.IPNet
         - Name: ExcludedIPRanges
           Offset: 1160
-          Type: 97 GoSliceHeaderType []*net.IPNet
+          Type: 120 GoSliceHeaderType []*net.IPNet
         - Name: PermittedEmailAddresses
           Offset: 1184
-          Type: 28 GoSliceHeaderType []string
+          Type: 54 GoSliceHeaderType []string
         - Name: ExcludedEmailAddresses
           Offset: 1208
-          Type: 28 GoSliceHeaderType []string
+          Type: 54 GoSliceHeaderType []string
         - Name: PermittedURIDomains
           Offset: 1232
-          Type: 28 GoSliceHeaderType []string
+          Type: 54 GoSliceHeaderType []string
         - Name: ExcludedURIDomains
           Offset: 1256
-          Type: 28 GoSliceHeaderType []string
+          Type: 54 GoSliceHeaderType []string
         - Name: CRLDistributionPoints
           Offset: 1280
-          Type: 28 GoSliceHeaderType []string
+          Type: 54 GoSliceHeaderType []string
         - Name: PolicyIdentifiers
           Offset: 1304
-          Type: 87 GoSliceHeaderType []encoding/asn1.ObjectIdentifier
+          Type: 110 GoSliceHeaderType []encoding/asn1.ObjectIdentifier
         - Name: Policies
           Offset: 1328
-          Type: 102 GoSliceHeaderType []crypto/x509.OID
+          Type: 125 GoSliceHeaderType []crypto/x509.OID
         - Name: InhibitAnyPolicy
           Offset: 1352
-          Type: 8 BaseType int
+          Type: 7 BaseType int
         - Name: InhibitAnyPolicyZero
           Offset: 1360
-          Type: 13 BaseType bool
+          Type: 4 BaseType bool
         - Name: InhibitPolicyMapping
           Offset: 1368
-          Type: 8 BaseType int
+          Type: 7 BaseType int
         - Name: InhibitPolicyMappingZero
           Offset: 1376
-          Type: 13 BaseType bool
+          Type: 4 BaseType bool
         - Name: RequireExplicitPolicy
           Offset: 1384
-          Type: 8 BaseType int
+          Type: 7 BaseType int
         - Name: RequireExplicitPolicyZero
           Offset: 1392
-          Type: 13 BaseType bool
+          Type: 4 BaseType bool
         - Name: PolicyMappings
           Offset: 1400
-          Type: 105 GoSliceHeaderType []crypto/x509.PolicyMapping
+          Type: 128 GoSliceHeaderType []crypto/x509.PolicyMapping
     - __kind: BaseType
-      ID: 91
+      ID: 114
       Name: crypto/x509.ExtKeyUsage
       ByteSize: 8
       GoRuntimeType: 583136
       GoKind: 2
     - __kind: BaseType
-      ID: 83
+      ID: 106
       Name: crypto/x509.KeyUsage
       ByteSize: 8
       GoRuntimeType: 583072
       GoKind: 2
     - __kind: StructureType
-      ID: 104
+      ID: 127
       Name: crypto/x509.OID
       ByteSize: 24
       GoRuntimeType: 1.9384e+06
@@ -1394,9 +1394,9 @@ Types:
       RawFields:
         - Name: der
           Offset: 0
-          Type: 53 GoSliceHeaderType []uint8
+          Type: 77 GoSliceHeaderType []uint8
     - __kind: StructureType
-      ID: 107
+      ID: 130
       Name: crypto/x509.PolicyMapping
       ByteSize: 48
       GoRuntimeType: 1.480224e+06
@@ -1404,24 +1404,24 @@ Types:
       RawFields:
         - Name: IssuerDomainPolicy
           Offset: 0
-          Type: 104 StructureType crypto/x509.OID
+          Type: 127 StructureType crypto/x509.OID
         - Name: SubjectDomainPolicy
           Offset: 24
-          Type: 104 StructureType crypto/x509.OID
+          Type: 127 StructureType crypto/x509.OID
     - __kind: BaseType
-      ID: 61
+      ID: 85
       Name: crypto/x509.PublicKeyAlgorithm
       ByteSize: 8
       GoRuntimeType: 831456
       GoKind: 2
     - __kind: BaseType
-      ID: 60
+      ID: 84
       Name: crypto/x509.SignatureAlgorithm
       ByteSize: 8
       GoRuntimeType: 1.104544e+06
       GoKind: 2
     - __kind: StructureType
-      ID: 71
+      ID: 95
       Name: crypto/x509/pkix.AttributeTypeAndValue
       ByteSize: 40
       GoRuntimeType: 1.492064e+06
@@ -1429,12 +1429,12 @@ Types:
       RawFields:
         - Name: Type
           Offset: 0
-          Type: 72 GoSliceHeaderType encoding/asn1.ObjectIdentifier
+          Type: 96 GoSliceHeaderType encoding/asn1.ObjectIdentifier
         - Name: Value
           Offset: 24
-          Type: 62 GoEmptyInterfaceType interface {}
+          Type: 86 GoEmptyInterfaceType interface {}
     - __kind: StructureType
-      ID: 86
+      ID: 109
       Name: crypto/x509/pkix.Extension
       ByteSize: 56
       GoRuntimeType: 1.635616e+06
@@ -1442,15 +1442,15 @@ Types:
       RawFields:
         - Name: Id
           Offset: 0
-          Type: 72 GoSliceHeaderType encoding/asn1.ObjectIdentifier
+          Type: 96 GoSliceHeaderType encoding/asn1.ObjectIdentifier
         - Name: Critical
           Offset: 24
-          Type: 13 BaseType bool
+          Type: 4 BaseType bool
         - Name: Value
           Offset: 32
-          Type: 53 GoSliceHeaderType []uint8
+          Type: 77 GoSliceHeaderType []uint8
     - __kind: StructureType
-      ID: 68
+      ID: 92
       Name: crypto/x509/pkix.Name
       ByteSize: 248
       GoRuntimeType: 2.176736e+06
@@ -1458,39 +1458,39 @@ Types:
       RawFields:
         - Name: Country
           Offset: 0
-          Type: 28 GoSliceHeaderType []string
+          Type: 54 GoSliceHeaderType []string
         - Name: Organization
           Offset: 24
-          Type: 28 GoSliceHeaderType []string
+          Type: 54 GoSliceHeaderType []string
         - Name: OrganizationalUnit
           Offset: 48
-          Type: 28 GoSliceHeaderType []string
+          Type: 54 GoSliceHeaderType []string
         - Name: Locality
           Offset: 72
-          Type: 28 GoSliceHeaderType []string
+          Type: 54 GoSliceHeaderType []string
         - Name: Province
           Offset: 96
-          Type: 28 GoSliceHeaderType []string
+          Type: 54 GoSliceHeaderType []string
         - Name: StreetAddress
           Offset: 120
-          Type: 28 GoSliceHeaderType []string
+          Type: 54 GoSliceHeaderType []string
         - Name: PostalCode
           Offset: 144
-          Type: 28 GoSliceHeaderType []string
+          Type: 54 GoSliceHeaderType []string
         - Name: SerialNumber
           Offset: 168
-          Type: 5 GoStringHeaderType string
+          Type: 9 GoStringHeaderType string
         - Name: CommonName
           Offset: 184
-          Type: 5 GoStringHeaderType string
+          Type: 9 GoStringHeaderType string
         - Name: Names
           Offset: 200
-          Type: 69 GoSliceHeaderType []crypto/x509/pkix.AttributeTypeAndValue
+          Type: 93 GoSliceHeaderType []crypto/x509/pkix.AttributeTypeAndValue
         - Name: ExtraNames
           Offset: 224
-          Type: 69 GoSliceHeaderType []crypto/x509/pkix.AttributeTypeAndValue
+          Type: 93 GoSliceHeaderType []crypto/x509/pkix.AttributeTypeAndValue
     - __kind: GoSliceHeaderType
-      ID: 72
+      ID: 96
       Name: encoding/asn1.ObjectIdentifier
       ByteSize: 24
       GoRuntimeType: 1.044128e+06
@@ -1498,21 +1498,21 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 73 PointerType *int
+          Type: 28 PointerType *int
         - Name: len
           Offset: 8
-          Type: 8 BaseType int
+          Type: 7 BaseType int
         - Name: cap
           Offset: 16
-          Type: 8 BaseType int
+          Type: 7 BaseType int
       Data: 181 GoSliceDataType encoding/asn1.ObjectIdentifier.array
     - __kind: GoSliceDataType
       ID: 181
       Name: encoding/asn1.ObjectIdentifier.array
       ByteSize: 2048
-      Element: 8 BaseType int
+      Element: 7 BaseType int
     - __kind: GoInterfaceType
-      ID: 144
+      ID: 14
       Name: error
       ByteSize: 16
       GoRuntimeType: 1.022624e+06
@@ -1520,36 +1520,36 @@ Types:
       RawFields:
         - Name: tab
           Offset: 0
-          Type: 2 VoidPointerType unsafe.Pointer
+          Type: 15 VoidPointerType unsafe.Pointer
         - Name: data
           Offset: 8
-          Type: 2 VoidPointerType unsafe.Pointer
+          Type: 15 VoidPointerType unsafe.Pointer
     - __kind: BaseType
-      ID: 146
+      ID: 17
       Name: float32
       ByteSize: 4
       GoRuntimeType: 580320
       GoKind: 13
     - __kind: BaseType
-      ID: 147
+      ID: 18
       Name: float64
       ByteSize: 8
       GoRuntimeType: 580384
       GoKind: 14
     - __kind: GoSubroutineType
-      ID: 31
+      ID: 56
       Name: func() (io.ReadCloser, error)
       ByteSize: 8
       GoRuntimeType: 687840
       GoKind: 19
     - __kind: GoSubroutineType
-      ID: 112
+      ID: 135
       Name: func(string, []uint8, int) ([]uint8, error)
       ByteSize: 8
       GoRuntimeType: 994848
       GoKind: 19
     - __kind: GoInterfaceType
-      ID: 137
+      ID: 160
       Name: gopkg.in/DataDog/dd-trace-go.v1/ddtrace.Span
       ByteSize: 16
       GoRuntimeType: 1.468864e+06
@@ -1557,84 +1557,84 @@ Types:
       RawFields:
         - Name: tab
           Offset: 0
-          Type: 2 VoidPointerType unsafe.Pointer
+          Type: 15 VoidPointerType unsafe.Pointer
         - Name: data
           Offset: 8
-          Type: 2 VoidPointerType unsafe.Pointer
+          Type: 15 VoidPointerType unsafe.Pointer
     - __kind: GoSwissMapGroupsType
-      ID: 43
+      ID: 67
       Name: groupReference<string,[]*mime/multipart.FileHeader>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 44 PointerType *noalg.map.group[string][]*mime/multipart.FileHeader
+          Type: 68 PointerType *noalg.map.group[string][]*mime/multipart.FileHeader
         - Name: lengthMask
           Offset: 8
-          Type: 17 BaseType uint64
-      GroupType: 45 StructureType noalg.map.group[string][]*mime/multipart.FileHeader
+          Type: 8 BaseType uint64
+      GroupType: 69 StructureType noalg.map.group[string][]*mime/multipart.FileHeader
       GroupSliceType: 170 GoSliceDataType []noalg.map.group[string][]*mime/multipart.FileHeader.array
     - __kind: GoSwissMapGroupsType
-      ID: 23
+      ID: 49
       Name: groupReference<string,[]string>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 24 PointerType *noalg.map.group[string][]string
+          Type: 50 PointerType *noalg.map.group[string][]string
         - Name: lengthMask
           Offset: 8
-          Type: 17 BaseType uint64
-      GroupType: 25 StructureType noalg.map.group[string][]string
+          Type: 8 BaseType uint64
+      GroupType: 51 StructureType noalg.map.group[string][]string
       GroupSliceType: 166 GoSliceDataType []noalg.map.group[string][]string.array
     - __kind: GoSwissMapGroupsType
-      ID: 129
+      ID: 152
       Name: groupReference<string,string>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 130 PointerType *noalg.map.group[string]string
+          Type: 153 PointerType *noalg.map.group[string]string
         - Name: lengthMask
           Offset: 8
-          Type: 17 BaseType uint64
-      GroupType: 131 StructureType noalg.map.group[string]string
+          Type: 8 BaseType uint64
+      GroupType: 154 StructureType noalg.map.group[string]string
       GroupSliceType: 214 GoSliceDataType []noalg.map.group[string]string.array
     - __kind: BaseType
-      ID: 8
+      ID: 7
       Name: int
       ByteSize: 8
       GoRuntimeType: 580000
       GoKind: 2
     - __kind: BaseType
-      ID: 151
+      ID: 23
       Name: int16
       ByteSize: 2
       GoRuntimeType: 579616
       GoKind: 4
     - __kind: BaseType
-      ID: 143
+      ID: 12
       Name: int32
       ByteSize: 4
       GoRuntimeType: 579744
       GoKind: 5
     - __kind: BaseType
-      ID: 32
+      ID: 13
       Name: int64
       ByteSize: 8
       GoRuntimeType: 579872
       GoKind: 6
     - __kind: BaseType
-      ID: 145
+      ID: 16
       Name: int8
       ByteSize: 1
       GoRuntimeType: 579488
       GoKind: 3
     - __kind: GoEmptyInterfaceType
-      ID: 62
+      ID: 86
       Name: interface {}
       ByteSize: 16
       GoRuntimeType: 848672
@@ -1642,12 +1642,12 @@ Types:
       RawFields:
         - Name: _type
           Offset: 0
-          Type: 2 VoidPointerType unsafe.Pointer
+          Type: 15 VoidPointerType unsafe.Pointer
         - Name: data
           Offset: 8
-          Type: 2 VoidPointerType unsafe.Pointer
+          Type: 15 VoidPointerType unsafe.Pointer
     - __kind: GoInterfaceType
-      ID: 30
+      ID: 55
       Name: io.ReadCloser
       ByteSize: 16
       GoRuntimeType: 1.100576e+06
@@ -1655,129 +1655,129 @@ Types:
       RawFields:
         - Name: tab
           Offset: 0
-          Type: 2 VoidPointerType unsafe.Pointer
+          Type: 15 VoidPointerType unsafe.Pointer
         - Name: data
           Offset: 8
-          Type: 2 VoidPointerType unsafe.Pointer
+          Type: 15 VoidPointerType unsafe.Pointer
     - __kind: GoSwissMapHeaderType
-      ID: 39
+      ID: 63
       Name: map<string,[]*mime/multipart.FileHeader>
       ByteSize: 48
       GoKind: 25
       RawFields:
         - Name: used
           Offset: 0
-          Type: 17 BaseType uint64
+          Type: 8 BaseType uint64
         - Name: seed
           Offset: 8
-          Type: 18 BaseType uintptr
+          Type: 1 BaseType uintptr
         - Name: dirPtr
           Offset: 16
-          Type: 40 PointerType **table<string,[]*mime/multipart.FileHeader>
+          Type: 64 PointerType **table<string,[]*mime/multipart.FileHeader>
         - Name: dirLen
           Offset: 24
-          Type: 8 BaseType int
+          Type: 7 BaseType int
         - Name: globalDepth
           Offset: 32
-          Type: 7 BaseType uint8
+          Type: 3 BaseType uint8
         - Name: globalShift
           Offset: 33
-          Type: 7 BaseType uint8
+          Type: 3 BaseType uint8
         - Name: writing
           Offset: 34
-          Type: 7 BaseType uint8
+          Type: 3 BaseType uint8
         - Name: clearSeq
           Offset: 40
-          Type: 17 BaseType uint64
+          Type: 8 BaseType uint64
       TablePtrSliceType: 169 GoSliceDataType []*table<string,[]*mime/multipart.FileHeader>.array
-      GroupType: 45 StructureType noalg.map.group[string][]*mime/multipart.FileHeader
+      GroupType: 69 StructureType noalg.map.group[string][]*mime/multipart.FileHeader
     - __kind: GoSwissMapHeaderType
-      ID: 16
+      ID: 45
       Name: map<string,[]string>
       ByteSize: 48
       GoKind: 25
       RawFields:
         - Name: used
           Offset: 0
-          Type: 17 BaseType uint64
+          Type: 8 BaseType uint64
         - Name: seed
           Offset: 8
-          Type: 18 BaseType uintptr
+          Type: 1 BaseType uintptr
         - Name: dirPtr
           Offset: 16
-          Type: 19 PointerType **table<string,[]string>
+          Type: 46 PointerType **table<string,[]string>
         - Name: dirLen
           Offset: 24
-          Type: 8 BaseType int
+          Type: 7 BaseType int
         - Name: globalDepth
           Offset: 32
-          Type: 7 BaseType uint8
+          Type: 3 BaseType uint8
         - Name: globalShift
           Offset: 33
-          Type: 7 BaseType uint8
+          Type: 3 BaseType uint8
         - Name: writing
           Offset: 34
-          Type: 7 BaseType uint8
+          Type: 3 BaseType uint8
         - Name: clearSeq
           Offset: 40
-          Type: 17 BaseType uint64
+          Type: 8 BaseType uint64
       TablePtrSliceType: 165 GoSliceDataType []*table<string,[]string>.array
-      GroupType: 25 StructureType noalg.map.group[string][]string
+      GroupType: 51 StructureType noalg.map.group[string][]string
     - __kind: GoSwissMapHeaderType
-      ID: 125
+      ID: 148
       Name: map<string,string>
       ByteSize: 48
       GoKind: 25
       RawFields:
         - Name: used
           Offset: 0
-          Type: 17 BaseType uint64
+          Type: 8 BaseType uint64
         - Name: seed
           Offset: 8
-          Type: 18 BaseType uintptr
+          Type: 1 BaseType uintptr
         - Name: dirPtr
           Offset: 16
-          Type: 126 PointerType **table<string,string>
+          Type: 149 PointerType **table<string,string>
         - Name: dirLen
           Offset: 24
-          Type: 8 BaseType int
+          Type: 7 BaseType int
         - Name: globalDepth
           Offset: 32
-          Type: 7 BaseType uint8
+          Type: 3 BaseType uint8
         - Name: globalShift
           Offset: 33
-          Type: 7 BaseType uint8
+          Type: 3 BaseType uint8
         - Name: writing
           Offset: 34
-          Type: 7 BaseType uint8
+          Type: 3 BaseType uint8
         - Name: clearSeq
           Offset: 40
-          Type: 17 BaseType uint64
+          Type: 8 BaseType uint64
       TablePtrSliceType: 213 GoSliceDataType []*table<string,string>.array
-      GroupType: 131 StructureType noalg.map.group[string]string
+      GroupType: 154 StructureType noalg.map.group[string]string
     - __kind: GoMapType
-      ID: 37
+      ID: 61
       Name: map[string][]*mime/multipart.FileHeader
       ByteSize: 8
       GoRuntimeType: 1.122592e+06
       GoKind: 21
-      HeaderType: 39 GoSwissMapHeaderType map<string,[]*mime/multipart.FileHeader>
+      HeaderType: 63 GoSwissMapHeaderType map<string,[]*mime/multipart.FileHeader>
     - __kind: GoMapType
-      ID: 36
+      ID: 60
       Name: map[string][]string
       ByteSize: 8
       GoRuntimeType: 1.117984e+06
       GoKind: 21
-      HeaderType: 16 GoSwissMapHeaderType map<string,[]string>
+      HeaderType: 45 GoSwissMapHeaderType map<string,[]string>
     - __kind: GoMapType
-      ID: 123
+      ID: 146
       Name: map[string]string
       ByteSize: 8
       GoRuntimeType: 1.119008e+06
       GoKind: 21
-      HeaderType: 125 GoSwissMapHeaderType map<string,string>
+      HeaderType: 148 GoSwissMapHeaderType map<string,string>
     - __kind: StructureType
-      ID: 64
+      ID: 88
       Name: math/big.Int
       ByteSize: 32
       GoRuntimeType: 1.483264e+06
@@ -1785,18 +1785,18 @@ Types:
       RawFields:
         - Name: neg
           Offset: 0
-          Type: 13 BaseType bool
+          Type: 4 BaseType bool
         - Name: abs
           Offset: 8
-          Type: 65 GoSliceHeaderType math/big.nat
+          Type: 89 GoSliceHeaderType math/big.nat
     - __kind: BaseType
-      ID: 67
+      ID: 91
       Name: math/big.Word
       ByteSize: 8
       GoRuntimeType: 583328
       GoKind: 7
     - __kind: GoSliceHeaderType
-      ID: 65
+      ID: 89
       Name: math/big.nat
       ByteSize: 24
       GoRuntimeType: 2.345504e+06
@@ -1804,21 +1804,21 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 66 PointerType *math/big.Word
+          Type: 90 PointerType *math/big.Word
         - Name: len
           Offset: 8
-          Type: 8 BaseType int
+          Type: 7 BaseType int
         - Name: cap
           Offset: 16
-          Type: 8 BaseType int
+          Type: 7 BaseType int
       Data: 177 GoSliceDataType math/big.nat.array
     - __kind: GoSliceDataType
       ID: 177
       Name: math/big.nat.array
       ByteSize: 2048
-      Element: 67 BaseType math/big.Word
+      Element: 91 BaseType math/big.Word
     - __kind: StructureType
-      ID: 51
+      ID: 75
       Name: mime/multipart.FileHeader
       ByteSize: 88
       GoRuntimeType: 1.962144e+06
@@ -1826,27 +1826,27 @@ Types:
       RawFields:
         - Name: Filename
           Offset: 0
-          Type: 5 GoStringHeaderType string
+          Type: 9 GoStringHeaderType string
         - Name: Header
           Offset: 16
-          Type: 52 GoMapType net/textproto.MIMEHeader
+          Type: 76 GoMapType net/textproto.MIMEHeader
         - Name: Size
           Offset: 24
-          Type: 32 BaseType int64
+          Type: 13 BaseType int64
         - Name: content
           Offset: 32
-          Type: 53 GoSliceHeaderType []uint8
+          Type: 77 GoSliceHeaderType []uint8
         - Name: tmpfile
           Offset: 56
-          Type: 5 GoStringHeaderType string
+          Type: 9 GoStringHeaderType string
         - Name: tmpoff
           Offset: 72
-          Type: 32 BaseType int64
+          Type: 13 BaseType int64
         - Name: tmpshared
           Offset: 80
-          Type: 13 BaseType bool
+          Type: 4 BaseType bool
     - __kind: StructureType
-      ID: 35
+      ID: 59
       Name: mime/multipart.Form
       ByteSize: 16
       GoRuntimeType: 1.467264e+06
@@ -1854,12 +1854,12 @@ Types:
       RawFields:
         - Name: Value
           Offset: 0
-          Type: 36 GoMapType map[string][]string
+          Type: 60 GoMapType map[string][]string
         - Name: File
           Offset: 8
-          Type: 37 GoMapType map[string][]*mime/multipart.FileHeader
+          Type: 61 GoMapType map[string][]*mime/multipart.FileHeader
     - __kind: GoSliceHeaderType
-      ID: 94
+      ID: 117
       Name: net.IP
       ByteSize: 24
       GoRuntimeType: 2.109184e+06
@@ -1867,21 +1867,21 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 6 PointerType *uint8
+          Type: 5 PointerType *uint8
         - Name: len
           Offset: 8
-          Type: 8 BaseType int
+          Type: 7 BaseType int
         - Name: cap
           Offset: 16
-          Type: 8 BaseType int
+          Type: 7 BaseType int
       Data: 195 GoSliceDataType net.IP.array
     - __kind: GoSliceDataType
       ID: 195
       Name: net.IP.array
       ByteSize: 2048
-      Element: 7 BaseType uint8
+      Element: 3 BaseType uint8
     - __kind: GoSliceHeaderType
-      ID: 101
+      ID: 124
       Name: net.IPMask
       ByteSize: 24
       GoRuntimeType: 1.01072e+06
@@ -1889,21 +1889,21 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 6 PointerType *uint8
+          Type: 5 PointerType *uint8
         - Name: len
           Offset: 8
-          Type: 8 BaseType int
+          Type: 7 BaseType int
         - Name: cap
           Offset: 16
-          Type: 8 BaseType int
+          Type: 7 BaseType int
       Data: 201 GoSliceDataType net.IPMask.array
     - __kind: GoSliceDataType
       ID: 201
       Name: net.IPMask.array
       ByteSize: 2048
-      Element: 7 BaseType uint8
+      Element: 3 BaseType uint8
     - __kind: StructureType
-      ID: 100
+      ID: 123
       Name: net.IPNet
       ByteSize: 48
       GoRuntimeType: 1.448704e+06
@@ -1911,19 +1911,19 @@ Types:
       RawFields:
         - Name: IP
           Offset: 0
-          Type: 94 GoSliceHeaderType net.IP
+          Type: 117 GoSliceHeaderType net.IP
         - Name: Mask
           Offset: 24
-          Type: 101 GoSliceHeaderType net.IPMask
+          Type: 124 GoSliceHeaderType net.IPMask
     - __kind: GoMapType
-      ID: 14
+      ID: 43
       Name: net/http.Header
       ByteSize: 8
       GoRuntimeType: 2.08736e+06
       GoKind: 21
-      HeaderType: 16 GoSwissMapHeaderType map<string,[]string>
+      HeaderType: 45 GoSwissMapHeaderType map<string,[]string>
     - __kind: StructureType
-      ID: 4
+      ID: 38
       Name: net/http.Request
       ByteSize: 304
       GoRuntimeType: 2.322048e+06
@@ -1931,84 +1931,84 @@ Types:
       RawFields:
         - Name: Method
           Offset: 0
-          Type: 5 GoStringHeaderType string
+          Type: 9 GoStringHeaderType string
         - Name: URL
           Offset: 16
-          Type: 9 PointerType *net/url.URL
+          Type: 39 PointerType *net/url.URL
         - Name: Proto
           Offset: 24
-          Type: 5 GoStringHeaderType string
+          Type: 9 GoStringHeaderType string
         - Name: ProtoMajor
           Offset: 40
-          Type: 8 BaseType int
+          Type: 7 BaseType int
         - Name: ProtoMinor
           Offset: 48
-          Type: 8 BaseType int
+          Type: 7 BaseType int
         - Name: Header
           Offset: 56
-          Type: 14 GoMapType net/http.Header
+          Type: 43 GoMapType net/http.Header
         - Name: Body
           Offset: 64
-          Type: 30 GoInterfaceType io.ReadCloser
+          Type: 55 GoInterfaceType io.ReadCloser
         - Name: GetBody
           Offset: 80
-          Type: 31 GoSubroutineType func() (io.ReadCloser, error)
+          Type: 56 GoSubroutineType func() (io.ReadCloser, error)
         - Name: ContentLength
           Offset: 88
-          Type: 32 BaseType int64
+          Type: 13 BaseType int64
         - Name: TransferEncoding
           Offset: 96
-          Type: 28 GoSliceHeaderType []string
+          Type: 54 GoSliceHeaderType []string
         - Name: Close
           Offset: 120
-          Type: 13 BaseType bool
+          Type: 4 BaseType bool
         - Name: Host
           Offset: 128
-          Type: 5 GoStringHeaderType string
+          Type: 9 GoStringHeaderType string
         - Name: Form
           Offset: 144
-          Type: 33 GoMapType net/url.Values
+          Type: 57 GoMapType net/url.Values
         - Name: PostForm
           Offset: 152
-          Type: 33 GoMapType net/url.Values
+          Type: 57 GoMapType net/url.Values
         - Name: MultipartForm
           Offset: 160
-          Type: 34 PointerType *mime/multipart.Form
+          Type: 58 PointerType *mime/multipart.Form
         - Name: Trailer
           Offset: 168
-          Type: 14 GoMapType net/http.Header
+          Type: 43 GoMapType net/http.Header
         - Name: RemoteAddr
           Offset: 176
-          Type: 5 GoStringHeaderType string
+          Type: 9 GoStringHeaderType string
         - Name: RequestURI
           Offset: 192
-          Type: 5 GoStringHeaderType string
+          Type: 9 GoStringHeaderType string
         - Name: TLS
           Offset: 208
-          Type: 54 PointerType *crypto/tls.ConnectionState
+          Type: 78 PointerType *crypto/tls.ConnectionState
         - Name: Cancel
           Offset: 216
-          Type: 114 GoChannelType <-chan struct {}
+          Type: 137 GoChannelType <-chan struct {}
         - Name: Response
           Offset: 224
-          Type: 115 PointerType *net/http.Response
+          Type: 138 PointerType *net/http.Response
         - Name: Pattern
           Offset: 232
-          Type: 5 GoStringHeaderType string
+          Type: 9 GoStringHeaderType string
         - Name: ctx
           Offset: 248
-          Type: 117 GoInterfaceType context.Context
+          Type: 140 GoInterfaceType context.Context
         - Name: pat
           Offset: 264
-          Type: 118 PointerType *net/http.pattern
+          Type: 141 PointerType *net/http.pattern
         - Name: matches
           Offset: 272
-          Type: 28 GoSliceHeaderType []string
+          Type: 54 GoSliceHeaderType []string
         - Name: otherValues
           Offset: 296
-          Type: 123 GoMapType map[string]string
+          Type: 146 GoMapType map[string]string
     - __kind: StructureType
-      ID: 116
+      ID: 139
       Name: net/http.Response
       ByteSize: 144
       GoRuntimeType: 2.19504e+06
@@ -2016,48 +2016,48 @@ Types:
       RawFields:
         - Name: Status
           Offset: 0
-          Type: 5 GoStringHeaderType string
+          Type: 9 GoStringHeaderType string
         - Name: StatusCode
           Offset: 16
-          Type: 8 BaseType int
+          Type: 7 BaseType int
         - Name: Proto
           Offset: 24
-          Type: 5 GoStringHeaderType string
+          Type: 9 GoStringHeaderType string
         - Name: ProtoMajor
           Offset: 40
-          Type: 8 BaseType int
+          Type: 7 BaseType int
         - Name: ProtoMinor
           Offset: 48
-          Type: 8 BaseType int
+          Type: 7 BaseType int
         - Name: Header
           Offset: 56
-          Type: 14 GoMapType net/http.Header
+          Type: 43 GoMapType net/http.Header
         - Name: Body
           Offset: 64
-          Type: 30 GoInterfaceType io.ReadCloser
+          Type: 55 GoInterfaceType io.ReadCloser
         - Name: ContentLength
           Offset: 80
-          Type: 32 BaseType int64
+          Type: 13 BaseType int64
         - Name: TransferEncoding
           Offset: 88
-          Type: 28 GoSliceHeaderType []string
+          Type: 54 GoSliceHeaderType []string
         - Name: Close
           Offset: 112
-          Type: 13 BaseType bool
+          Type: 4 BaseType bool
         - Name: Uncompressed
           Offset: 113
-          Type: 13 BaseType bool
+          Type: 4 BaseType bool
         - Name: Trailer
           Offset: 120
-          Type: 14 GoMapType net/http.Header
+          Type: 43 GoMapType net/http.Header
         - Name: Request
           Offset: 128
-          Type: 3 PointerType *net/http.Request
+          Type: 37 PointerType *net/http.Request
         - Name: TLS
           Offset: 136
-          Type: 54 PointerType *crypto/tls.ConnectionState
+          Type: 78 PointerType *crypto/tls.ConnectionState
     - __kind: GoInterfaceType
-      ID: 1
+      ID: 36
       Name: net/http.ResponseWriter
       ByteSize: 16
       GoRuntimeType: 1.176352e+06
@@ -2065,12 +2065,12 @@ Types:
       RawFields:
         - Name: tab
           Offset: 0
-          Type: 2 VoidPointerType unsafe.Pointer
+          Type: 15 VoidPointerType unsafe.Pointer
         - Name: data
           Offset: 8
-          Type: 2 VoidPointerType unsafe.Pointer
+          Type: 15 VoidPointerType unsafe.Pointer
     - __kind: StructureType
-      ID: 119
+      ID: 142
       Name: net/http.pattern
       ByteSize: 88
       GoRuntimeType: 1.818112e+06
@@ -2078,21 +2078,21 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 5 GoStringHeaderType string
+          Type: 9 GoStringHeaderType string
         - Name: method
           Offset: 16
-          Type: 5 GoStringHeaderType string
+          Type: 9 GoStringHeaderType string
         - Name: host
           Offset: 32
-          Type: 5 GoStringHeaderType string
+          Type: 9 GoStringHeaderType string
         - Name: segments
           Offset: 48
-          Type: 120 GoSliceHeaderType []net/http.segment
+          Type: 143 GoSliceHeaderType []net/http.segment
         - Name: loc
           Offset: 72
-          Type: 5 GoStringHeaderType string
+          Type: 9 GoStringHeaderType string
     - __kind: StructureType
-      ID: 122
+      ID: 145
       Name: net/http.segment
       ByteSize: 24
       GoRuntimeType: 1.597216e+06
@@ -2100,22 +2100,22 @@ Types:
       RawFields:
         - Name: s
           Offset: 0
-          Type: 5 GoStringHeaderType string
+          Type: 9 GoStringHeaderType string
         - Name: wild
           Offset: 16
-          Type: 13 BaseType bool
+          Type: 4 BaseType bool
         - Name: multi
           Offset: 17
-          Type: 13 BaseType bool
+          Type: 4 BaseType bool
     - __kind: GoMapType
-      ID: 52
+      ID: 76
       Name: net/textproto.MIMEHeader
       ByteSize: 8
       GoRuntimeType: 1.808288e+06
       GoKind: 21
-      HeaderType: 16 GoSwissMapHeaderType map<string,[]string>
+      HeaderType: 45 GoSwissMapHeaderType map<string,[]string>
     - __kind: StructureType
-      ID: 10
+      ID: 40
       Name: net/url.URL
       ByteSize: 144
       GoRuntimeType: 2.112256e+06
@@ -2123,39 +2123,39 @@ Types:
       RawFields:
         - Name: Scheme
           Offset: 0
-          Type: 5 GoStringHeaderType string
+          Type: 9 GoStringHeaderType string
         - Name: Opaque
           Offset: 16
-          Type: 5 GoStringHeaderType string
+          Type: 9 GoStringHeaderType string
         - Name: User
           Offset: 32
-          Type: 11 PointerType *net/url.Userinfo
+          Type: 41 PointerType *net/url.Userinfo
         - Name: Host
           Offset: 40
-          Type: 5 GoStringHeaderType string
+          Type: 9 GoStringHeaderType string
         - Name: Path
           Offset: 56
-          Type: 5 GoStringHeaderType string
+          Type: 9 GoStringHeaderType string
         - Name: RawPath
           Offset: 72
-          Type: 5 GoStringHeaderType string
+          Type: 9 GoStringHeaderType string
         - Name: OmitHost
           Offset: 88
-          Type: 13 BaseType bool
+          Type: 4 BaseType bool
         - Name: ForceQuery
           Offset: 89
-          Type: 13 BaseType bool
+          Type: 4 BaseType bool
         - Name: RawQuery
           Offset: 96
-          Type: 5 GoStringHeaderType string
+          Type: 9 GoStringHeaderType string
         - Name: Fragment
           Offset: 112
-          Type: 5 GoStringHeaderType string
+          Type: 9 GoStringHeaderType string
         - Name: RawFragment
           Offset: 128
-          Type: 5 GoStringHeaderType string
+          Type: 9 GoStringHeaderType string
     - __kind: StructureType
-      ID: 12
+      ID: 42
       Name: net/url.Userinfo
       ByteSize: 40
       GoRuntimeType: 1.613536e+06
@@ -2163,49 +2163,49 @@ Types:
       RawFields:
         - Name: username
           Offset: 0
-          Type: 5 GoStringHeaderType string
+          Type: 9 GoStringHeaderType string
         - Name: password
           Offset: 16
-          Type: 5 GoStringHeaderType string
+          Type: 9 GoStringHeaderType string
         - Name: passwordSet
           Offset: 32
-          Type: 13 BaseType bool
+          Type: 4 BaseType bool
     - __kind: GoMapType
-      ID: 33
+      ID: 57
       Name: net/url.Values
       ByteSize: 8
       GoRuntimeType: 1.870528e+06
       GoKind: 21
-      HeaderType: 16 GoSwissMapHeaderType map<string,[]string>
+      HeaderType: 45 GoSwissMapHeaderType map<string,[]string>
     - __kind: ArrayType
-      ID: 46
+      ID: 70
       Name: noalg.[8]struct { key string; elem []*mime/multipart.FileHeader }
       ByteSize: 320
       GoRuntimeType: 693888
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 47 StructureType noalg.struct { key string; elem []*mime/multipart.FileHeader }
+      Element: 71 StructureType noalg.struct { key string; elem []*mime/multipart.FileHeader }
     - __kind: ArrayType
-      ID: 26
+      ID: 52
       Name: noalg.[8]struct { key string; elem []string }
       ByteSize: 320
       GoRuntimeType: 683872
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 27 StructureType noalg.struct { key string; elem []string }
+      Element: 53 StructureType noalg.struct { key string; elem []string }
     - __kind: ArrayType
-      ID: 132
+      ID: 155
       Name: noalg.[8]struct { key string; elem string }
       ByteSize: 256
       GoRuntimeType: 688032
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 133 StructureType noalg.struct { key string; elem string }
+      Element: 156 StructureType noalg.struct { key string; elem string }
     - __kind: StructureType
-      ID: 45
+      ID: 69
       Name: noalg.map.group[string][]*mime/multipart.FileHeader
       ByteSize: 328
       GoRuntimeType: 1.289824e+06
@@ -2213,12 +2213,12 @@ Types:
       RawFields:
         - Name: ctrl
           Offset: 0
-          Type: 17 BaseType uint64
+          Type: 8 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 46 ArrayType noalg.[8]struct { key string; elem []*mime/multipart.FileHeader }
+          Type: 70 ArrayType noalg.[8]struct { key string; elem []*mime/multipart.FileHeader }
     - __kind: StructureType
-      ID: 25
+      ID: 51
       Name: noalg.map.group[string][]string
       ByteSize: 328
       GoRuntimeType: 1.280352e+06
@@ -2226,12 +2226,12 @@ Types:
       RawFields:
         - Name: ctrl
           Offset: 0
-          Type: 17 BaseType uint64
+          Type: 8 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 26 ArrayType noalg.[8]struct { key string; elem []string }
+          Type: 52 ArrayType noalg.[8]struct { key string; elem []string }
     - __kind: StructureType
-      ID: 131
+      ID: 154
       Name: noalg.map.group[string]string
       ByteSize: 264
       GoRuntimeType: 1.282656e+06
@@ -2239,12 +2239,12 @@ Types:
       RawFields:
         - Name: ctrl
           Offset: 0
-          Type: 17 BaseType uint64
+          Type: 8 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 132 ArrayType noalg.[8]struct { key string; elem string }
+          Type: 155 ArrayType noalg.[8]struct { key string; elem string }
     - __kind: StructureType
-      ID: 47
+      ID: 71
       Name: noalg.struct { key string; elem []*mime/multipart.FileHeader }
       ByteSize: 40
       GoRuntimeType: 1.289696e+06
@@ -2252,12 +2252,12 @@ Types:
       RawFields:
         - Name: key
           Offset: 0
-          Type: 5 GoStringHeaderType string
+          Type: 9 GoStringHeaderType string
         - Name: elem
           Offset: 16
-          Type: 48 GoSliceHeaderType []*mime/multipart.FileHeader
+          Type: 72 GoSliceHeaderType []*mime/multipart.FileHeader
     - __kind: StructureType
-      ID: 27
+      ID: 53
       Name: noalg.struct { key string; elem []string }
       ByteSize: 40
       GoRuntimeType: 1.280224e+06
@@ -2265,12 +2265,12 @@ Types:
       RawFields:
         - Name: key
           Offset: 0
-          Type: 5 GoStringHeaderType string
+          Type: 9 GoStringHeaderType string
         - Name: elem
           Offset: 16
-          Type: 28 GoSliceHeaderType []string
+          Type: 54 GoSliceHeaderType []string
     - __kind: StructureType
-      ID: 133
+      ID: 156
       Name: noalg.struct { key string; elem string }
       ByteSize: 32
       GoRuntimeType: 1.282528e+06
@@ -2278,12 +2278,12 @@ Types:
       RawFields:
         - Name: key
           Offset: 0
-          Type: 5 GoStringHeaderType string
+          Type: 9 GoStringHeaderType string
         - Name: elem
           Offset: 16
-          Type: 5 GoStringHeaderType string
+          Type: 9 GoStringHeaderType string
     - __kind: GoStringHeaderType
-      ID: 5
+      ID: 9
       Name: string
       ByteSize: 16
       GoRuntimeType: 579424
@@ -2294,86 +2294,86 @@ Types:
           Type: 164 PointerType *string.str
         - Name: len
           Offset: 8
-          Type: 8 BaseType int
+          Type: 7 BaseType int
       Data: 163 GoStringDataType string.str
     - __kind: GoStringDataType
       ID: 163
       Name: string.str
       ByteSize: 2048
     - __kind: StructureType
-      ID: 42
+      ID: 66
       Name: table<string,[]*mime/multipart.FileHeader>
       ByteSize: 32
       GoKind: 25
       RawFields:
         - Name: used
           Offset: 0
-          Type: 22 BaseType uint16
+          Type: 6 BaseType uint16
         - Name: capacity
           Offset: 2
-          Type: 22 BaseType uint16
+          Type: 6 BaseType uint16
         - Name: growthLeft
           Offset: 4
-          Type: 22 BaseType uint16
+          Type: 6 BaseType uint16
         - Name: localDepth
           Offset: 6
-          Type: 7 BaseType uint8
+          Type: 3 BaseType uint8
         - Name: index
           Offset: 8
-          Type: 8 BaseType int
+          Type: 7 BaseType int
         - Name: groups
           Offset: 16
-          Type: 43 GoSwissMapGroupsType groupReference<string,[]*mime/multipart.FileHeader>
+          Type: 67 GoSwissMapGroupsType groupReference<string,[]*mime/multipart.FileHeader>
     - __kind: StructureType
-      ID: 21
+      ID: 48
       Name: table<string,[]string>
       ByteSize: 32
       GoKind: 25
       RawFields:
         - Name: used
           Offset: 0
-          Type: 22 BaseType uint16
+          Type: 6 BaseType uint16
         - Name: capacity
           Offset: 2
-          Type: 22 BaseType uint16
+          Type: 6 BaseType uint16
         - Name: growthLeft
           Offset: 4
-          Type: 22 BaseType uint16
+          Type: 6 BaseType uint16
         - Name: localDepth
           Offset: 6
-          Type: 7 BaseType uint8
+          Type: 3 BaseType uint8
         - Name: index
           Offset: 8
-          Type: 8 BaseType int
+          Type: 7 BaseType int
         - Name: groups
           Offset: 16
-          Type: 23 GoSwissMapGroupsType groupReference<string,[]string>
+          Type: 49 GoSwissMapGroupsType groupReference<string,[]string>
     - __kind: StructureType
-      ID: 128
+      ID: 151
       Name: table<string,string>
       ByteSize: 32
       GoKind: 25
       RawFields:
         - Name: used
           Offset: 0
-          Type: 22 BaseType uint16
+          Type: 6 BaseType uint16
         - Name: capacity
           Offset: 2
-          Type: 22 BaseType uint16
+          Type: 6 BaseType uint16
         - Name: growthLeft
           Offset: 4
-          Type: 22 BaseType uint16
+          Type: 6 BaseType uint16
         - Name: localDepth
           Offset: 6
-          Type: 7 BaseType uint8
+          Type: 3 BaseType uint8
         - Name: index
           Offset: 8
-          Type: 8 BaseType int
+          Type: 7 BaseType int
         - Name: groups
           Offset: 16
-          Type: 129 GoSwissMapGroupsType groupReference<string,string>
+          Type: 152 GoSwissMapGroupsType groupReference<string,string>
     - __kind: StructureType
-      ID: 76
+      ID: 99
       Name: time.Location
       ByteSize: 104
       GoRuntimeType: 1.957824e+06
@@ -2381,27 +2381,27 @@ Types:
       RawFields:
         - Name: name
           Offset: 0
-          Type: 5 GoStringHeaderType string
+          Type: 9 GoStringHeaderType string
         - Name: zone
           Offset: 16
-          Type: 77 GoSliceHeaderType []time.zone
+          Type: 100 GoSliceHeaderType []time.zone
         - Name: tx
           Offset: 40
-          Type: 80 GoSliceHeaderType []time.zoneTrans
+          Type: 103 GoSliceHeaderType []time.zoneTrans
         - Name: extend
           Offset: 64
-          Type: 5 GoStringHeaderType string
+          Type: 9 GoStringHeaderType string
         - Name: cacheStart
           Offset: 80
-          Type: 32 BaseType int64
+          Type: 13 BaseType int64
         - Name: cacheEnd
           Offset: 88
-          Type: 32 BaseType int64
+          Type: 13 BaseType int64
         - Name: cacheZone
           Offset: 96
-          Type: 78 PointerType *time.zone
+          Type: 101 PointerType *time.zone
     - __kind: StructureType
-      ID: 74
+      ID: 97
       Name: time.Time
       ByteSize: 24
       GoRuntimeType: 2.34832e+06
@@ -2409,15 +2409,15 @@ Types:
       RawFields:
         - Name: wall
           Offset: 0
-          Type: 17 BaseType uint64
+          Type: 8 BaseType uint64
         - Name: ext
           Offset: 8
-          Type: 32 BaseType int64
+          Type: 13 BaseType int64
         - Name: loc
           Offset: 16
-          Type: 75 PointerType *time.Location
+          Type: 98 PointerType *time.Location
     - __kind: StructureType
-      ID: 79
+      ID: 102
       Name: time.zone
       ByteSize: 32
       GoRuntimeType: 1.602208e+06
@@ -2425,15 +2425,15 @@ Types:
       RawFields:
         - Name: name
           Offset: 0
-          Type: 5 GoStringHeaderType string
+          Type: 9 GoStringHeaderType string
         - Name: offset
           Offset: 16
-          Type: 8 BaseType int
+          Type: 7 BaseType int
         - Name: isDST
           Offset: 24
-          Type: 13 BaseType bool
+          Type: 4 BaseType bool
     - __kind: StructureType
-      ID: 82
+      ID: 105
       Name: time.zoneTrans
       ByteSize: 16
       GoRuntimeType: 1.736576e+06
@@ -2441,54 +2441,54 @@ Types:
       RawFields:
         - Name: when
           Offset: 0
-          Type: 32 BaseType int64
+          Type: 13 BaseType int64
         - Name: index
           Offset: 8
-          Type: 7 BaseType uint8
+          Type: 3 BaseType uint8
         - Name: isstd
           Offset: 9
-          Type: 13 BaseType bool
+          Type: 4 BaseType bool
         - Name: isutc
           Offset: 10
-          Type: 13 BaseType bool
+          Type: 4 BaseType bool
     - __kind: BaseType
-      ID: 141
+      ID: 10
       Name: uint
       ByteSize: 8
       GoRuntimeType: 580064
       GoKind: 7
     - __kind: BaseType
-      ID: 22
+      ID: 6
       Name: uint16
       ByteSize: 2
       GoRuntimeType: 579680
       GoKind: 9
     - __kind: BaseType
-      ID: 140
+      ID: 2
       Name: uint32
       ByteSize: 4
       GoRuntimeType: 579808
       GoKind: 10
     - __kind: BaseType
-      ID: 17
+      ID: 8
       Name: uint64
       ByteSize: 8
       GoRuntimeType: 579936
       GoKind: 11
     - __kind: BaseType
-      ID: 7
+      ID: 3
       Name: uint8
       ByteSize: 1
       GoRuntimeType: 579552
       GoKind: 8
     - __kind: BaseType
-      ID: 18
+      ID: 1
       Name: uintptr
       ByteSize: 8
       GoRuntimeType: 580128
       GoKind: 12
     - __kind: VoidPointerType
-      ID: 2
+      ID: 15
       Name: unsafe.Pointer
       ByteSize: 8
       GoRuntimeType: 580512

--- a/pkg/dyninst/irgen/testdata/snapshot/rc_tester_v1.arch=arm64,toolchain=go1.25.0.yaml
+++ b/pkg/dyninst/irgen/testdata/snapshot/rc_tester_v1.arch=arm64,toolchain=go1.25.0.yaml
@@ -108,33 +108,33 @@ Subprograms:
           IsReturn: false
 Types:
     - __kind: PointerType
-      ID: 81
+      ID: 83
       Name: '**crypto/x509.Certificate'
       ByteSize: 8
       GoKind: 22
-      Pointee: 82 PointerType *crypto/x509.Certificate
+      Pointee: 84 PointerType *crypto/x509.Certificate
     - __kind: PointerType
-      ID: 147
+      ID: 121
       Name: '**mime/multipart.FileHeader'
       ByteSize: 8
       GoKind: 22
-      Pointee: 148 PointerType *mime/multipart.FileHeader
+      Pointee: 122 PointerType *mime/multipart.FileHeader
     - __kind: PointerType
-      ID: 134
+      ID: 161
       Name: '**net.IPNet'
       ByteSize: 8
       GoKind: 22
-      Pointee: 135 PointerType *net.IPNet
+      Pointee: 162 PointerType *net.IPNet
     - __kind: PointerType
-      ID: 132
+      ID: 159
       Name: '**net/url.URL'
       ByteSize: 8
       Pointee: 42 PointerType *net/url.URL
     - __kind: PointerType
-      ID: 77
+      ID: 79
       Name: '**table<string,[]*mime/multipart.FileHeader>'
       ByteSize: 8
-      Pointee: 78 PointerType *table<string,[]*mime/multipart.FileHeader>
+      Pointee: 80 PointerType *table<string,[]*mime/multipart.FileHeader>
     - __kind: PointerType
       ID: 47
       Name: '**table<string,[]string>'
@@ -146,86 +146,86 @@ Types:
       ByteSize: 8
       Pointee: 67 PointerType *table<string,string>
     - __kind: PointerType
-      ID: 84
+      ID: 86
       Name: '*[]*crypto/x509.Certificate'
       ByteSize: 8
       GoKind: 22
-      Pointee: 80 GoSliceHeaderType []*crypto/x509.Certificate
+      Pointee: 82 GoSliceHeaderType []*crypto/x509.Certificate
     - __kind: PointerType
-      ID: 175
+      ID: 126
       Name: '*[]*crypto/x509.Certificate.array'
       ByteSize: 8
-      Pointee: 174 GoSliceDataType []*crypto/x509.Certificate.array
+      Pointee: 125 GoSliceDataType []*crypto/x509.Certificate.array
     - __kind: PointerType
-      ID: 205
+      ID: 171
       Name: '*[]*mime/multipart.FileHeader.array'
       ByteSize: 8
-      Pointee: 204 GoSliceDataType []*mime/multipart.FileHeader.array
+      Pointee: 170 GoSliceDataType []*mime/multipart.FileHeader.array
     - __kind: PointerType
-      ID: 199
+      ID: 200
       Name: '*[]*net.IPNet.array'
       ByteSize: 8
-      Pointee: 198 GoSliceDataType []*net.IPNet.array
+      Pointee: 199 GoSliceDataType []*net.IPNet.array
     - __kind: PointerType
-      ID: 197
+      ID: 198
       Name: '*[]*net/url.URL.array'
       ByteSize: 8
-      Pointee: 196 GoSliceDataType []*net/url.URL.array
+      Pointee: 197 GoSliceDataType []*net/url.URL.array
     - __kind: PointerType
-      ID: 177
+      ID: 128
       Name: '*[][]*crypto/x509.Certificate.array'
       ByteSize: 8
-      Pointee: 176 GoSliceDataType [][]*crypto/x509.Certificate.array
+      Pointee: 127 GoSliceDataType [][]*crypto/x509.Certificate.array
     - __kind: PointerType
-      ID: 179
+      ID: 130
       Name: '*[][]uint8.array'
       ByteSize: 8
-      Pointee: 178 GoSliceDataType [][]uint8.array
+      Pointee: 129 GoSliceDataType [][]uint8.array
     - __kind: PointerType
-      ID: 191
+      ID: 192
       Name: '*[]crypto/x509.ExtKeyUsage.array'
       ByteSize: 8
-      Pointee: 190 GoSliceDataType []crypto/x509.ExtKeyUsage.array
+      Pointee: 191 GoSliceDataType []crypto/x509.ExtKeyUsage.array
     - __kind: PointerType
-      ID: 201
+      ID: 202
       Name: '*[]crypto/x509.OID.array'
       ByteSize: 8
-      Pointee: 200 GoSliceDataType []crypto/x509.OID.array
+      Pointee: 201 GoSliceDataType []crypto/x509.OID.array
     - __kind: PointerType
-      ID: 203
+      ID: 204
       Name: '*[]crypto/x509.PolicyMapping.array'
       ByteSize: 8
-      Pointee: 202 GoSliceDataType []crypto/x509.PolicyMapping.array
+      Pointee: 203 GoSliceDataType []crypto/x509.PolicyMapping.array
     - __kind: PointerType
-      ID: 183
+      ID: 184
       Name: '*[]crypto/x509/pkix.AttributeTypeAndValue.array'
       ByteSize: 8
-      Pointee: 182 GoSliceDataType []crypto/x509/pkix.AttributeTypeAndValue.array
+      Pointee: 183 GoSliceDataType []crypto/x509/pkix.AttributeTypeAndValue.array
     - __kind: PointerType
-      ID: 185
+      ID: 186
       Name: '*[]crypto/x509/pkix.Extension.array'
       ByteSize: 8
-      Pointee: 184 GoSliceDataType []crypto/x509/pkix.Extension.array
+      Pointee: 185 GoSliceDataType []crypto/x509/pkix.Extension.array
     - __kind: PointerType
-      ID: 187
+      ID: 188
       Name: '*[]encoding/asn1.ObjectIdentifier.array'
       ByteSize: 8
-      Pointee: 186 GoSliceDataType []encoding/asn1.ObjectIdentifier.array
+      Pointee: 187 GoSliceDataType []encoding/asn1.ObjectIdentifier.array
     - __kind: PointerType
-      ID: 193
+      ID: 194
       Name: '*[]net.IP.array'
       ByteSize: 8
-      Pointee: 192 GoSliceDataType []net.IP.array
+      Pointee: 193 GoSliceDataType []net.IP.array
     - __kind: PointerType
-      ID: 181
+      ID: 132
       Name: '*[]net/http.segment.array'
       ByteSize: 8
-      Pointee: 180 GoSliceDataType []net/http.segment.array
+      Pointee: 131 GoSliceDataType []net/http.segment.array
     - __kind: PointerType
-      ID: 167
+      ID: 103
       Name: '*[]string.array'
       ByteSize: 8
-      Pointee: 166 GoSliceDataType []string.array
+      Pointee: 102 GoSliceDataType []string.array
     - __kind: PointerType
       ID: 209
       Name: '*[]time.zone.array'
@@ -237,17 +237,17 @@ Types:
       ByteSize: 8
       Pointee: 210 GoSliceDataType []time.zoneTrans.array
     - __kind: PointerType
-      ID: 86
+      ID: 88
       Name: '*[]uint8'
       ByteSize: 8
       GoRuntimeType: 481440
       GoKind: 22
       Pointee: 68 GoSliceHeaderType []uint8
     - __kind: PointerType
-      ID: 171
+      ID: 112
       Name: '*[]uint8.array'
       ByteSize: 8
-      Pointee: 170 GoSliceDataType []uint8.array
+      Pointee: 111 GoSliceDataType []uint8.array
     - __kind: PointerType
       ID: 11
       Name: '*bool'
@@ -270,59 +270,59 @@ Types:
       GoKind: 22
       Pointee: 56 StructureType crypto/tls.ConnectionState
     - __kind: PointerType
-      ID: 82
+      ID: 84
       Name: '*crypto/x509.Certificate'
       ByteSize: 8
       GoRuntimeType: 2.0432e+06
       GoKind: 22
-      Pointee: 97 StructureType crypto/x509.Certificate
+      Pointee: 114 StructureType crypto/x509.Certificate
     - __kind: PointerType
-      ID: 126
+      ID: 153
       Name: '*crypto/x509.ExtKeyUsage'
       ByteSize: 8
       GoRuntimeType: 423456
       GoKind: 22
-      Pointee: 127 BaseType crypto/x509.ExtKeyUsage
+      Pointee: 154 BaseType crypto/x509.ExtKeyUsage
     - __kind: PointerType
-      ID: 137
+      ID: 164
       Name: '*crypto/x509.OID'
       ByteSize: 8
       GoRuntimeType: 1.953568e+06
       GoKind: 22
-      Pointee: 138 StructureType crypto/x509.OID
+      Pointee: 165 StructureType crypto/x509.OID
     - __kind: PointerType
-      ID: 140
+      ID: 167
       Name: '*crypto/x509.PolicyMapping'
       ByteSize: 8
       GoRuntimeType: 423520
       GoKind: 22
-      Pointee: 141 StructureType crypto/x509.PolicyMapping
+      Pointee: 168 StructureType crypto/x509.PolicyMapping
     - __kind: PointerType
-      ID: 113
+      ID: 140
       Name: '*crypto/x509/pkix.AttributeTypeAndValue'
       ByteSize: 8
       GoRuntimeType: 437216
       GoKind: 22
-      Pointee: 114 StructureType crypto/x509/pkix.AttributeTypeAndValue
+      Pointee: 141 StructureType crypto/x509/pkix.AttributeTypeAndValue
     - __kind: PointerType
-      ID: 120
+      ID: 147
       Name: '*crypto/x509/pkix.Extension'
       ByteSize: 8
       GoRuntimeType: 437408
       GoKind: 22
-      Pointee: 121 StructureType crypto/x509/pkix.Extension
+      Pointee: 148 StructureType crypto/x509/pkix.Extension
     - __kind: PointerType
-      ID: 123
+      ID: 150
       Name: '*encoding/asn1.ObjectIdentifier'
       ByteSize: 8
       GoRuntimeType: 1.052704e+06
       GoKind: 22
-      Pointee: 124 GoSliceHeaderType encoding/asn1.ObjectIdentifier
+      Pointee: 151 GoSliceHeaderType encoding/asn1.ObjectIdentifier
     - __kind: PointerType
-      ID: 189
+      ID: 190
       Name: '*encoding/asn1.ObjectIdentifier.array'
       ByteSize: 8
-      Pointee: 188 GoSliceDataType encoding/asn1.ObjectIdentifier.array
+      Pointee: 189 GoSliceDataType encoding/asn1.ObjectIdentifier.array
     - __kind: PointerType
       ID: 33
       Name: '*error'
@@ -380,10 +380,10 @@ Types:
       GoKind: 22
       Pointee: 17 BaseType int8
     - __kind: PointerType
-      ID: 75
+      ID: 77
       Name: '*map<string,[]*mime/multipart.FileHeader>'
       ByteSize: 8
-      Pointee: 76 GoSwissMapHeaderType map<string,[]*mime/multipart.FileHeader>
+      Pointee: 78 GoSwissMapHeaderType map<string,[]*mime/multipart.FileHeader>
     - __kind: PointerType
       ID: 45
       Name: '*map<string,[]string>'
@@ -395,31 +395,31 @@ Types:
       ByteSize: 8
       Pointee: 65 GoSwissMapHeaderType map<string,string>
     - __kind: PointerType
-      ID: 109
+      ID: 136
       Name: '*math/big.Int'
       ByteSize: 8
       GoRuntimeType: 2.381568e+06
       GoKind: 22
-      Pointee: 110 StructureType math/big.Int
+      Pointee: 137 StructureType math/big.Int
     - __kind: PointerType
-      ID: 150
+      ID: 173
       Name: '*math/big.Word'
       ByteSize: 8
       GoRuntimeType: 426272
       GoKind: 22
-      Pointee: 151 BaseType math/big.Word
+      Pointee: 174 BaseType math/big.Word
     - __kind: PointerType
       ID: 207
       Name: '*math/big.nat.array'
       ByteSize: 8
       Pointee: 206 GoSliceDataType math/big.nat.array
     - __kind: PointerType
-      ID: 148
+      ID: 122
       Name: '*mime/multipart.FileHeader'
       ByteSize: 8
       GoRuntimeType: 909280
       GoKind: 22
-      Pointee: 159 StructureType mime/multipart.FileHeader
+      Pointee: 169 StructureType mime/multipart.FileHeader
     - __kind: PointerType
       ID: 53
       Name: '*mime/multipart.Form'
@@ -428,29 +428,29 @@ Types:
       GoKind: 22
       Pointee: 54 StructureType mime/multipart.Form
     - __kind: PointerType
-      ID: 129
+      ID: 156
       Name: '*net.IP'
       ByteSize: 8
       GoRuntimeType: 2.149408e+06
       GoKind: 22
-      Pointee: 130 GoSliceHeaderType net.IP
+      Pointee: 157 GoSliceHeaderType net.IP
     - __kind: PointerType
-      ID: 195
+      ID: 196
       Name: '*net.IP.array'
       ByteSize: 8
-      Pointee: 194 GoSliceDataType net.IP.array
+      Pointee: 195 GoSliceDataType net.IP.array
     - __kind: PointerType
       ID: 213
       Name: '*net.IPMask.array'
       ByteSize: 8
       Pointee: 212 GoSliceDataType net.IPMask.array
     - __kind: PointerType
-      ID: 135
+      ID: 162
       Name: '*net.IPNet'
       ByteSize: 8
       GoRuntimeType: 1.182656e+06
       GoKind: 22
-      Pointee: 158 StructureType net.IPNet
+      Pointee: 181 StructureType net.IPNet
     - __kind: PointerType
       ID: 37
       Name: '*net/http.Request'
@@ -473,12 +473,12 @@ Types:
       GoKind: 22
       Pointee: 62 StructureType net/http.pattern
     - __kind: PointerType
-      ID: 90
+      ID: 92
       Name: '*net/http.segment'
       ByteSize: 8
       GoRuntimeType: 391712
       GoKind: 22
-      Pointee: 91 StructureType net/http.segment
+      Pointee: 93 StructureType net/http.segment
     - __kind: PointerType
       ID: 42
       Name: '*net/url.URL'
@@ -487,27 +487,27 @@ Types:
       GoKind: 22
       Pointee: 43 StructureType net/url.URL
     - __kind: PointerType
-      ID: 70
+      ID: 72
       Name: '*net/url.Userinfo'
       ByteSize: 8
       GoRuntimeType: 1.200064e+06
       GoKind: 22
-      Pointee: 71 StructureType net/url.Userinfo
+      Pointee: 73 StructureType net/url.Userinfo
     - __kind: PointerType
-      ID: 104
+      ID: 116
       Name: '*noalg.map.group[string][]*mime/multipart.FileHeader'
       ByteSize: 8
-      Pointee: 105 StructureType noalg.map.group[string][]*mime/multipart.FileHeader
+      Pointee: 117 StructureType noalg.map.group[string][]*mime/multipart.FileHeader
     - __kind: PointerType
-      ID: 94
+      ID: 96
       Name: '*noalg.map.group[string][]string'
       ByteSize: 8
-      Pointee: 95 StructureType noalg.map.group[string][]string
+      Pointee: 97 StructureType noalg.map.group[string][]string
     - __kind: PointerType
-      ID: 99
+      ID: 105
       Name: '*noalg.map.group[string]string'
       ByteSize: 8
-      Pointee: 100 StructureType noalg.map.group[string]string
+      Pointee: 106 StructureType noalg.map.group[string]string
     - __kind: PointerType
       ID: 22
       Name: '*string'
@@ -516,46 +516,46 @@ Types:
       GoKind: 22
       Pointee: 9 GoStringHeaderType string
     - __kind: PointerType
-      ID: 163
+      ID: 71
       Name: '*string.str'
       ByteSize: 8
-      Pointee: 162 GoStringDataType string.str
+      Pointee: 70 GoStringDataType string.str
     - __kind: PointerType
-      ID: 78
+      ID: 80
       Name: '*table<string,[]*mime/multipart.FileHeader>'
       ByteSize: 8
-      Pointee: 96 StructureType table<string,[]*mime/multipart.FileHeader>
+      Pointee: 113 StructureType table<string,[]*mime/multipart.FileHeader>
     - __kind: PointerType
       ID: 48
       Name: '*table<string,[]string>'
       ByteSize: 8
-      Pointee: 72 StructureType table<string,[]string>
+      Pointee: 74 StructureType table<string,[]string>
     - __kind: PointerType
       ID: 67
       Name: '*table<string,string>'
       ByteSize: 8
-      Pointee: 92 StructureType table<string,string>
+      Pointee: 94 StructureType table<string,string>
     - __kind: PointerType
-      ID: 116
+      ID: 143
       Name: '*time.Location'
       ByteSize: 8
       GoRuntimeType: 1.613056e+06
       GoKind: 22
-      Pointee: 117 StructureType time.Location
+      Pointee: 144 StructureType time.Location
     - __kind: PointerType
-      ID: 153
+      ID: 176
       Name: '*time.zone'
       ByteSize: 8
       GoRuntimeType: 394784
       GoKind: 22
-      Pointee: 154 StructureType time.zone
+      Pointee: 177 StructureType time.zone
     - __kind: PointerType
-      ID: 156
+      ID: 179
       Name: '*time.zoneTrans'
       ByteSize: 8
       GoRuntimeType: 394848
       GoKind: 22
-      Pointee: 157 StructureType time.zoneTrans
+      Pointee: 180 StructureType time.zoneTrans
     - __kind: PointerType
       ID: 34
       Name: '*uint'
@@ -643,7 +643,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: GoSliceHeaderType
-      ID: 80
+      ID: 82
       Name: '[]*crypto/x509.Certificate'
       ByteSize: 24
       GoRuntimeType: 502272
@@ -651,21 +651,21 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 81 PointerType **crypto/x509.Certificate
+          Type: 83 PointerType **crypto/x509.Certificate
         - Name: len
           Offset: 8
           Type: 7 BaseType int
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 174 GoSliceDataType []*crypto/x509.Certificate.array
+      Data: 125 GoSliceDataType []*crypto/x509.Certificate.array
     - __kind: GoSliceDataType
-      ID: 174
+      ID: 125
       Name: '[]*crypto/x509.Certificate.array'
       ByteSize: 2048
-      Element: 82 PointerType *crypto/x509.Certificate
+      Element: 84 PointerType *crypto/x509.Certificate
     - __kind: GoSliceHeaderType
-      ID: 146
+      ID: 120
       Name: '[]*mime/multipart.FileHeader'
       ByteSize: 24
       GoRuntimeType: 487168
@@ -673,21 +673,21 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 147 PointerType **mime/multipart.FileHeader
+          Type: 121 PointerType **mime/multipart.FileHeader
         - Name: len
           Offset: 8
           Type: 7 BaseType int
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 204 GoSliceDataType []*mime/multipart.FileHeader.array
+      Data: 170 GoSliceDataType []*mime/multipart.FileHeader.array
     - __kind: GoSliceDataType
-      ID: 204
+      ID: 170
       Name: '[]*mime/multipart.FileHeader.array'
       ByteSize: 2048
-      Element: 148 PointerType *mime/multipart.FileHeader
+      Element: 122 PointerType *mime/multipart.FileHeader
     - __kind: GoSliceHeaderType
-      ID: 133
+      ID: 160
       Name: '[]*net.IPNet'
       ByteSize: 24
       GoRuntimeType: 503872
@@ -695,21 +695,21 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 134 PointerType **net.IPNet
+          Type: 161 PointerType **net.IPNet
         - Name: len
           Offset: 8
           Type: 7 BaseType int
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 198 GoSliceDataType []*net.IPNet.array
+      Data: 199 GoSliceDataType []*net.IPNet.array
     - __kind: GoSliceDataType
-      ID: 198
+      ID: 199
       Name: '[]*net.IPNet.array'
       ByteSize: 2048
-      Element: 135 PointerType *net.IPNet
+      Element: 162 PointerType *net.IPNet
     - __kind: GoSliceHeaderType
-      ID: 131
+      ID: 158
       Name: '[]*net/url.URL'
       ByteSize: 24
       GoRuntimeType: 503808
@@ -717,36 +717,36 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 132 PointerType **net/url.URL
+          Type: 159 PointerType **net/url.URL
         - Name: len
           Offset: 8
           Type: 7 BaseType int
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 196 GoSliceDataType []*net/url.URL.array
+      Data: 197 GoSliceDataType []*net/url.URL.array
     - __kind: GoSliceDataType
-      ID: 196
+      ID: 197
       Name: '[]*net/url.URL.array'
       ByteSize: 2048
       Element: 42 PointerType *net/url.URL
     - __kind: GoSliceDataType
-      ID: 172
+      ID: 123
       Name: '[]*table<string,[]*mime/multipart.FileHeader>.array'
       ByteSize: 8192
-      Element: 78 PointerType *table<string,[]*mime/multipart.FileHeader>
+      Element: 80 PointerType *table<string,[]*mime/multipart.FileHeader>
     - __kind: GoSliceDataType
-      ID: 164
+      ID: 100
       Name: '[]*table<string,[]string>.array'
       ByteSize: 8192
       Element: 48 PointerType *table<string,[]string>
     - __kind: GoSliceDataType
-      ID: 168
+      ID: 109
       Name: '[]*table<string,string>.array'
       ByteSize: 8192
       Element: 67 PointerType *table<string,string>
     - __kind: GoSliceHeaderType
-      ID: 83
+      ID: 85
       Name: '[][]*crypto/x509.Certificate'
       ByteSize: 24
       GoRuntimeType: 502336
@@ -754,21 +754,21 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 84 PointerType *[]*crypto/x509.Certificate
+          Type: 86 PointerType *[]*crypto/x509.Certificate
         - Name: len
           Offset: 8
           Type: 7 BaseType int
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 176 GoSliceDataType [][]*crypto/x509.Certificate.array
+      Data: 127 GoSliceDataType [][]*crypto/x509.Certificate.array
     - __kind: GoSliceDataType
-      ID: 176
+      ID: 127
       Name: '[][]*crypto/x509.Certificate.array'
       ByteSize: 2048
-      Element: 80 GoSliceHeaderType []*crypto/x509.Certificate
+      Element: 82 GoSliceHeaderType []*crypto/x509.Certificate
     - __kind: GoSliceHeaderType
-      ID: 85
+      ID: 87
       Name: '[][]uint8'
       ByteSize: 24
       GoRuntimeType: 481760
@@ -776,21 +776,21 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 86 PointerType *[]uint8
+          Type: 88 PointerType *[]uint8
         - Name: len
           Offset: 8
           Type: 7 BaseType int
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 178 GoSliceDataType [][]uint8.array
+      Data: 129 GoSliceDataType [][]uint8.array
     - __kind: GoSliceDataType
-      ID: 178
+      ID: 129
       Name: '[][]uint8.array'
       ByteSize: 2048
       Element: 68 GoSliceHeaderType []uint8
     - __kind: GoSliceHeaderType
-      ID: 125
+      ID: 152
       Name: '[]crypto/x509.ExtKeyUsage'
       ByteSize: 24
       GoRuntimeType: 503744
@@ -798,21 +798,21 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 126 PointerType *crypto/x509.ExtKeyUsage
+          Type: 153 PointerType *crypto/x509.ExtKeyUsage
         - Name: len
           Offset: 8
           Type: 7 BaseType int
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 190 GoSliceDataType []crypto/x509.ExtKeyUsage.array
+      Data: 191 GoSliceDataType []crypto/x509.ExtKeyUsage.array
     - __kind: GoSliceDataType
-      ID: 190
+      ID: 191
       Name: '[]crypto/x509.ExtKeyUsage.array'
       ByteSize: 2048
-      Element: 127 BaseType crypto/x509.ExtKeyUsage
+      Element: 154 BaseType crypto/x509.ExtKeyUsage
     - __kind: GoSliceHeaderType
-      ID: 136
+      ID: 163
       Name: '[]crypto/x509.OID'
       ByteSize: 24
       GoRuntimeType: 503936
@@ -820,21 +820,21 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 137 PointerType *crypto/x509.OID
+          Type: 164 PointerType *crypto/x509.OID
         - Name: len
           Offset: 8
           Type: 7 BaseType int
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 200 GoSliceDataType []crypto/x509.OID.array
+      Data: 201 GoSliceDataType []crypto/x509.OID.array
     - __kind: GoSliceDataType
-      ID: 200
+      ID: 201
       Name: '[]crypto/x509.OID.array'
       ByteSize: 2048
-      Element: 138 StructureType crypto/x509.OID
+      Element: 165 StructureType crypto/x509.OID
     - __kind: GoSliceHeaderType
-      ID: 139
+      ID: 166
       Name: '[]crypto/x509.PolicyMapping'
       ByteSize: 24
       GoRuntimeType: 504000
@@ -842,21 +842,21 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 140 PointerType *crypto/x509.PolicyMapping
+          Type: 167 PointerType *crypto/x509.PolicyMapping
         - Name: len
           Offset: 8
           Type: 7 BaseType int
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 202 GoSliceDataType []crypto/x509.PolicyMapping.array
+      Data: 203 GoSliceDataType []crypto/x509.PolicyMapping.array
     - __kind: GoSliceDataType
-      ID: 202
+      ID: 203
       Name: '[]crypto/x509.PolicyMapping.array'
       ByteSize: 2048
-      Element: 141 StructureType crypto/x509.PolicyMapping
+      Element: 168 StructureType crypto/x509.PolicyMapping
     - __kind: GoSliceHeaderType
-      ID: 112
+      ID: 139
       Name: '[]crypto/x509/pkix.AttributeTypeAndValue'
       ByteSize: 24
       GoRuntimeType: 517280
@@ -864,21 +864,21 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 113 PointerType *crypto/x509/pkix.AttributeTypeAndValue
+          Type: 140 PointerType *crypto/x509/pkix.AttributeTypeAndValue
         - Name: len
           Offset: 8
           Type: 7 BaseType int
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 182 GoSliceDataType []crypto/x509/pkix.AttributeTypeAndValue.array
+      Data: 183 GoSliceDataType []crypto/x509/pkix.AttributeTypeAndValue.array
     - __kind: GoSliceDataType
-      ID: 182
+      ID: 183
       Name: '[]crypto/x509/pkix.AttributeTypeAndValue.array'
       ByteSize: 2048
-      Element: 114 StructureType crypto/x509/pkix.AttributeTypeAndValue
+      Element: 141 StructureType crypto/x509/pkix.AttributeTypeAndValue
     - __kind: GoSliceHeaderType
-      ID: 119
+      ID: 146
       Name: '[]crypto/x509/pkix.Extension'
       ByteSize: 24
       GoRuntimeType: 503616
@@ -886,21 +886,21 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 120 PointerType *crypto/x509/pkix.Extension
+          Type: 147 PointerType *crypto/x509/pkix.Extension
         - Name: len
           Offset: 8
           Type: 7 BaseType int
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 184 GoSliceDataType []crypto/x509/pkix.Extension.array
+      Data: 185 GoSliceDataType []crypto/x509/pkix.Extension.array
     - __kind: GoSliceDataType
-      ID: 184
+      ID: 185
       Name: '[]crypto/x509/pkix.Extension.array'
       ByteSize: 2048
-      Element: 121 StructureType crypto/x509/pkix.Extension
+      Element: 148 StructureType crypto/x509/pkix.Extension
     - __kind: GoSliceHeaderType
-      ID: 122
+      ID: 149
       Name: '[]encoding/asn1.ObjectIdentifier'
       ByteSize: 24
       GoRuntimeType: 503680
@@ -908,21 +908,21 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 123 PointerType *encoding/asn1.ObjectIdentifier
+          Type: 150 PointerType *encoding/asn1.ObjectIdentifier
         - Name: len
           Offset: 8
           Type: 7 BaseType int
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 186 GoSliceDataType []encoding/asn1.ObjectIdentifier.array
+      Data: 187 GoSliceDataType []encoding/asn1.ObjectIdentifier.array
     - __kind: GoSliceDataType
-      ID: 186
+      ID: 187
       Name: '[]encoding/asn1.ObjectIdentifier.array'
       ByteSize: 2048
-      Element: 124 GoSliceHeaderType encoding/asn1.ObjectIdentifier
+      Element: 151 GoSliceHeaderType encoding/asn1.ObjectIdentifier
     - __kind: GoSliceHeaderType
-      ID: 128
+      ID: 155
       Name: '[]net.IP'
       ByteSize: 24
       GoRuntimeType: 482784
@@ -930,21 +930,21 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 129 PointerType *net.IP
+          Type: 156 PointerType *net.IP
         - Name: len
           Offset: 8
           Type: 7 BaseType int
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 192 GoSliceDataType []net.IP.array
+      Data: 193 GoSliceDataType []net.IP.array
     - __kind: GoSliceDataType
-      ID: 192
+      ID: 193
       Name: '[]net.IP.array'
       ByteSize: 2048
-      Element: 130 GoSliceHeaderType net.IP
+      Element: 157 GoSliceHeaderType net.IP
     - __kind: GoSliceHeaderType
-      ID: 89
+      ID: 91
       Name: '[]net/http.segment'
       ByteSize: 24
       GoRuntimeType: 484480
@@ -952,34 +952,34 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 90 PointerType *net/http.segment
+          Type: 92 PointerType *net/http.segment
         - Name: len
           Offset: 8
           Type: 7 BaseType int
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 180 GoSliceDataType []net/http.segment.array
+      Data: 131 GoSliceDataType []net/http.segment.array
     - __kind: GoSliceDataType
-      ID: 180
+      ID: 131
       Name: '[]net/http.segment.array'
       ByteSize: 2048
-      Element: 91 StructureType net/http.segment
+      Element: 93 StructureType net/http.segment
     - __kind: GoSliceDataType
-      ID: 173
+      ID: 124
       Name: '[]noalg.map.group[string][]*mime/multipart.FileHeader.array'
       ByteSize: 2048
-      Element: 105 StructureType noalg.map.group[string][]*mime/multipart.FileHeader
+      Element: 117 StructureType noalg.map.group[string][]*mime/multipart.FileHeader
     - __kind: GoSliceDataType
-      ID: 165
+      ID: 101
       Name: '[]noalg.map.group[string][]string.array'
       ByteSize: 2048
-      Element: 95 StructureType noalg.map.group[string][]string
+      Element: 97 StructureType noalg.map.group[string][]string
     - __kind: GoSliceDataType
-      ID: 169
+      ID: 110
       Name: '[]noalg.map.group[string]string.array'
       ByteSize: 2048
-      Element: 100 StructureType noalg.map.group[string]string
+      Element: 106 StructureType noalg.map.group[string]string
     - __kind: GoSliceHeaderType
       ID: 51
       Name: '[]string'
@@ -996,14 +996,14 @@ Types:
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 166 GoSliceDataType []string.array
+      Data: 102 GoSliceDataType []string.array
     - __kind: GoSliceDataType
-      ID: 166
+      ID: 102
       Name: '[]string.array'
       ByteSize: 2048
       Element: 9 GoStringHeaderType string
     - __kind: GoSliceHeaderType
-      ID: 152
+      ID: 175
       Name: '[]time.zone'
       ByteSize: 24
       GoRuntimeType: 489344
@@ -1011,7 +1011,7 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 153 PointerType *time.zone
+          Type: 176 PointerType *time.zone
         - Name: len
           Offset: 8
           Type: 7 BaseType int
@@ -1023,9 +1023,9 @@ Types:
       ID: 208
       Name: '[]time.zone.array'
       ByteSize: 2048
-      Element: 154 StructureType time.zone
+      Element: 177 StructureType time.zone
     - __kind: GoSliceHeaderType
-      ID: 155
+      ID: 178
       Name: '[]time.zoneTrans'
       ByteSize: 24
       GoRuntimeType: 489408
@@ -1033,7 +1033,7 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 156 PointerType *time.zoneTrans
+          Type: 179 PointerType *time.zoneTrans
         - Name: len
           Offset: 8
           Type: 7 BaseType int
@@ -1045,7 +1045,7 @@ Types:
       ID: 210
       Name: '[]time.zoneTrans.array'
       ByteSize: 2048
-      Element: 157 StructureType time.zoneTrans
+      Element: 180 StructureType time.zoneTrans
     - __kind: GoSliceHeaderType
       ID: 68
       Name: '[]uint8'
@@ -1062,9 +1062,9 @@ Types:
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 170 GoSliceDataType []uint8.array
+      Data: 111 GoSliceDataType []uint8.array
     - __kind: GoSliceDataType
-      ID: 170
+      ID: 111
       Name: '[]uint8.array'
       ByteSize: 2048
       Element: 3 BaseType uint8
@@ -1142,7 +1142,7 @@ Types:
           Type: 6 BaseType uint16
         - Name: CurveID
           Offset: 6
-          Type: 79 BaseType crypto/tls.CurveID
+          Type: 81 BaseType crypto/tls.CurveID
         - Name: NegotiatedProtocol
           Offset: 8
           Type: 9 GoStringHeaderType string
@@ -1154,13 +1154,13 @@ Types:
           Type: 9 GoStringHeaderType string
         - Name: PeerCertificates
           Offset: 48
-          Type: 80 GoSliceHeaderType []*crypto/x509.Certificate
+          Type: 82 GoSliceHeaderType []*crypto/x509.Certificate
         - Name: VerifiedChains
           Offset: 72
-          Type: 83 GoSliceHeaderType [][]*crypto/x509.Certificate
+          Type: 85 GoSliceHeaderType [][]*crypto/x509.Certificate
         - Name: SignedCertificateTimestamps
           Offset: 96
-          Type: 85 GoSliceHeaderType [][]uint8
+          Type: 87 GoSliceHeaderType [][]uint8
         - Name: OCSPResponse
           Offset: 120
           Type: 68 GoSliceHeaderType []uint8
@@ -1172,27 +1172,27 @@ Types:
           Type: 4 BaseType bool
         - Name: ekm
           Offset: 176
-          Type: 87 GoSubroutineType func(string, []uint8, int) ([]uint8, error)
+          Type: 89 GoSubroutineType func(string, []uint8, int) ([]uint8, error)
         - Name: testingOnlyDidHRR
           Offset: 184
           Type: 4 BaseType bool
         - Name: testingOnlyPeerSignatureAlgorithm
           Offset: 186
-          Type: 88 BaseType crypto/tls.SignatureScheme
+          Type: 90 BaseType crypto/tls.SignatureScheme
     - __kind: BaseType
-      ID: 79
+      ID: 81
       Name: crypto/tls.CurveID
       ByteSize: 2
       GoRuntimeType: 834432
       GoKind: 9
     - __kind: BaseType
-      ID: 88
+      ID: 90
       Name: crypto/tls.SignatureScheme
       ByteSize: 2
       GoRuntimeType: 834528
       GoKind: 9
     - __kind: StructureType
-      ID: 97
+      ID: 114
       Name: crypto/x509.Certificate
       ByteSize: 1424
       GoRuntimeType: 2.392832e+06
@@ -1218,49 +1218,49 @@ Types:
           Type: 68 GoSliceHeaderType []uint8
         - Name: SignatureAlgorithm
           Offset: 144
-          Type: 106 BaseType crypto/x509.SignatureAlgorithm
+          Type: 133 BaseType crypto/x509.SignatureAlgorithm
         - Name: PublicKeyAlgorithm
           Offset: 152
-          Type: 107 BaseType crypto/x509.PublicKeyAlgorithm
+          Type: 134 BaseType crypto/x509.PublicKeyAlgorithm
         - Name: PublicKey
           Offset: 160
-          Type: 108 GoEmptyInterfaceType interface {}
+          Type: 135 GoEmptyInterfaceType interface {}
         - Name: Version
           Offset: 176
           Type: 7 BaseType int
         - Name: SerialNumber
           Offset: 184
-          Type: 109 PointerType *math/big.Int
+          Type: 136 PointerType *math/big.Int
         - Name: Issuer
           Offset: 192
-          Type: 111 StructureType crypto/x509/pkix.Name
+          Type: 138 StructureType crypto/x509/pkix.Name
         - Name: Subject
           Offset: 440
-          Type: 111 StructureType crypto/x509/pkix.Name
+          Type: 138 StructureType crypto/x509/pkix.Name
         - Name: NotBefore
           Offset: 688
-          Type: 115 StructureType time.Time
+          Type: 142 StructureType time.Time
         - Name: NotAfter
           Offset: 712
-          Type: 115 StructureType time.Time
+          Type: 142 StructureType time.Time
         - Name: KeyUsage
           Offset: 736
-          Type: 118 BaseType crypto/x509.KeyUsage
+          Type: 145 BaseType crypto/x509.KeyUsage
         - Name: Extensions
           Offset: 744
-          Type: 119 GoSliceHeaderType []crypto/x509/pkix.Extension
+          Type: 146 GoSliceHeaderType []crypto/x509/pkix.Extension
         - Name: ExtraExtensions
           Offset: 768
-          Type: 119 GoSliceHeaderType []crypto/x509/pkix.Extension
+          Type: 146 GoSliceHeaderType []crypto/x509/pkix.Extension
         - Name: UnhandledCriticalExtensions
           Offset: 792
-          Type: 122 GoSliceHeaderType []encoding/asn1.ObjectIdentifier
+          Type: 149 GoSliceHeaderType []encoding/asn1.ObjectIdentifier
         - Name: ExtKeyUsage
           Offset: 816
-          Type: 125 GoSliceHeaderType []crypto/x509.ExtKeyUsage
+          Type: 152 GoSliceHeaderType []crypto/x509.ExtKeyUsage
         - Name: UnknownExtKeyUsage
           Offset: 840
-          Type: 122 GoSliceHeaderType []encoding/asn1.ObjectIdentifier
+          Type: 149 GoSliceHeaderType []encoding/asn1.ObjectIdentifier
         - Name: BasicConstraintsValid
           Offset: 864
           Type: 4 BaseType bool
@@ -1293,10 +1293,10 @@ Types:
           Type: 51 GoSliceHeaderType []string
         - Name: IPAddresses
           Offset: 1032
-          Type: 128 GoSliceHeaderType []net.IP
+          Type: 155 GoSliceHeaderType []net.IP
         - Name: URIs
           Offset: 1056
-          Type: 131 GoSliceHeaderType []*net/url.URL
+          Type: 158 GoSliceHeaderType []*net/url.URL
         - Name: PermittedDNSDomainsCritical
           Offset: 1080
           Type: 4 BaseType bool
@@ -1308,10 +1308,10 @@ Types:
           Type: 51 GoSliceHeaderType []string
         - Name: PermittedIPRanges
           Offset: 1136
-          Type: 133 GoSliceHeaderType []*net.IPNet
+          Type: 160 GoSliceHeaderType []*net.IPNet
         - Name: ExcludedIPRanges
           Offset: 1160
-          Type: 133 GoSliceHeaderType []*net.IPNet
+          Type: 160 GoSliceHeaderType []*net.IPNet
         - Name: PermittedEmailAddresses
           Offset: 1184
           Type: 51 GoSliceHeaderType []string
@@ -1329,10 +1329,10 @@ Types:
           Type: 51 GoSliceHeaderType []string
         - Name: PolicyIdentifiers
           Offset: 1304
-          Type: 122 GoSliceHeaderType []encoding/asn1.ObjectIdentifier
+          Type: 149 GoSliceHeaderType []encoding/asn1.ObjectIdentifier
         - Name: Policies
           Offset: 1328
-          Type: 136 GoSliceHeaderType []crypto/x509.OID
+          Type: 163 GoSliceHeaderType []crypto/x509.OID
         - Name: InhibitAnyPolicy
           Offset: 1352
           Type: 7 BaseType int
@@ -1353,21 +1353,21 @@ Types:
           Type: 4 BaseType bool
         - Name: PolicyMappings
           Offset: 1400
-          Type: 139 GoSliceHeaderType []crypto/x509.PolicyMapping
+          Type: 166 GoSliceHeaderType []crypto/x509.PolicyMapping
     - __kind: BaseType
-      ID: 127
+      ID: 154
       Name: crypto/x509.ExtKeyUsage
       ByteSize: 8
       GoRuntimeType: 587936
       GoKind: 2
     - __kind: BaseType
-      ID: 118
+      ID: 145
       Name: crypto/x509.KeyUsage
       ByteSize: 8
       GoRuntimeType: 587872
       GoKind: 2
     - __kind: StructureType
-      ID: 138
+      ID: 165
       Name: crypto/x509.OID
       ByteSize: 24
       GoRuntimeType: 1.953824e+06
@@ -1377,7 +1377,7 @@ Types:
           Offset: 0
           Type: 68 GoSliceHeaderType []uint8
     - __kind: StructureType
-      ID: 141
+      ID: 168
       Name: crypto/x509.PolicyMapping
       ByteSize: 48
       GoRuntimeType: 1.490528e+06
@@ -1385,24 +1385,24 @@ Types:
       RawFields:
         - Name: IssuerDomainPolicy
           Offset: 0
-          Type: 138 StructureType crypto/x509.OID
+          Type: 165 StructureType crypto/x509.OID
         - Name: SubjectDomainPolicy
           Offset: 24
-          Type: 138 StructureType crypto/x509.OID
+          Type: 165 StructureType crypto/x509.OID
     - __kind: BaseType
-      ID: 107
+      ID: 134
       Name: crypto/x509.PublicKeyAlgorithm
       ByteSize: 8
       GoRuntimeType: 837024
       GoKind: 2
     - __kind: BaseType
-      ID: 106
+      ID: 133
       Name: crypto/x509.SignatureAlgorithm
       ByteSize: 8
       GoRuntimeType: 1.113728e+06
       GoKind: 2
     - __kind: StructureType
-      ID: 114
+      ID: 141
       Name: crypto/x509/pkix.AttributeTypeAndValue
       ByteSize: 40
       GoRuntimeType: 1.502368e+06
@@ -1410,12 +1410,12 @@ Types:
       RawFields:
         - Name: Type
           Offset: 0
-          Type: 124 GoSliceHeaderType encoding/asn1.ObjectIdentifier
+          Type: 151 GoSliceHeaderType encoding/asn1.ObjectIdentifier
         - Name: Value
           Offset: 24
-          Type: 108 GoEmptyInterfaceType interface {}
+          Type: 135 GoEmptyInterfaceType interface {}
     - __kind: StructureType
-      ID: 121
+      ID: 148
       Name: crypto/x509/pkix.Extension
       ByteSize: 56
       GoRuntimeType: 1.646464e+06
@@ -1423,7 +1423,7 @@ Types:
       RawFields:
         - Name: Id
           Offset: 0
-          Type: 124 GoSliceHeaderType encoding/asn1.ObjectIdentifier
+          Type: 151 GoSliceHeaderType encoding/asn1.ObjectIdentifier
         - Name: Critical
           Offset: 24
           Type: 4 BaseType bool
@@ -1431,7 +1431,7 @@ Types:
           Offset: 32
           Type: 68 GoSliceHeaderType []uint8
     - __kind: StructureType
-      ID: 111
+      ID: 138
       Name: crypto/x509/pkix.Name
       ByteSize: 248
       GoRuntimeType: 2.192e+06
@@ -1466,12 +1466,12 @@ Types:
           Type: 9 GoStringHeaderType string
         - Name: Names
           Offset: 200
-          Type: 112 GoSliceHeaderType []crypto/x509/pkix.AttributeTypeAndValue
+          Type: 139 GoSliceHeaderType []crypto/x509/pkix.AttributeTypeAndValue
         - Name: ExtraNames
           Offset: 224
-          Type: 112 GoSliceHeaderType []crypto/x509/pkix.AttributeTypeAndValue
+          Type: 139 GoSliceHeaderType []crypto/x509/pkix.AttributeTypeAndValue
     - __kind: GoSliceHeaderType
-      ID: 124
+      ID: 151
       Name: encoding/asn1.ObjectIdentifier
       ByteSize: 24
       GoRuntimeType: 1.052832e+06
@@ -1486,9 +1486,9 @@ Types:
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 188 GoSliceDataType encoding/asn1.ObjectIdentifier.array
+      Data: 189 GoSliceDataType encoding/asn1.ObjectIdentifier.array
     - __kind: GoSliceDataType
-      ID: 188
+      ID: 189
       Name: encoding/asn1.ObjectIdentifier.array
       ByteSize: 2048
       Element: 7 BaseType int
@@ -1524,7 +1524,7 @@ Types:
       GoRuntimeType: 693216
       GoKind: 19
     - __kind: GoSubroutineType
-      ID: 87
+      ID: 89
       Name: func(string, []uint8, int) ([]uint8, error)
       ByteSize: 8
       GoRuntimeType: 1.002592e+06
@@ -1543,47 +1543,47 @@ Types:
           Offset: 8
           Type: 15 VoidPointerType unsafe.Pointer
     - __kind: GoSwissMapGroupsType
-      ID: 103
+      ID: 115
       Name: groupReference<string,[]*mime/multipart.FileHeader>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 104 PointerType *noalg.map.group[string][]*mime/multipart.FileHeader
+          Type: 116 PointerType *noalg.map.group[string][]*mime/multipart.FileHeader
         - Name: lengthMask
           Offset: 8
           Type: 8 BaseType uint64
-      GroupType: 105 StructureType noalg.map.group[string][]*mime/multipart.FileHeader
-      GroupSliceType: 173 GoSliceDataType []noalg.map.group[string][]*mime/multipart.FileHeader.array
+      GroupType: 117 StructureType noalg.map.group[string][]*mime/multipart.FileHeader
+      GroupSliceType: 124 GoSliceDataType []noalg.map.group[string][]*mime/multipart.FileHeader.array
     - __kind: GoSwissMapGroupsType
-      ID: 93
+      ID: 95
       Name: groupReference<string,[]string>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 94 PointerType *noalg.map.group[string][]string
+          Type: 96 PointerType *noalg.map.group[string][]string
         - Name: lengthMask
           Offset: 8
           Type: 8 BaseType uint64
-      GroupType: 95 StructureType noalg.map.group[string][]string
-      GroupSliceType: 165 GoSliceDataType []noalg.map.group[string][]string.array
+      GroupType: 97 StructureType noalg.map.group[string][]string
+      GroupSliceType: 101 GoSliceDataType []noalg.map.group[string][]string.array
     - __kind: GoSwissMapGroupsType
-      ID: 98
+      ID: 104
       Name: groupReference<string,string>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 99 PointerType *noalg.map.group[string]string
+          Type: 105 PointerType *noalg.map.group[string]string
         - Name: lengthMask
           Offset: 8
           Type: 8 BaseType uint64
-      GroupType: 100 StructureType noalg.map.group[string]string
-      GroupSliceType: 169 GoSliceDataType []noalg.map.group[string]string.array
+      GroupType: 106 StructureType noalg.map.group[string]string
+      GroupSliceType: 110 GoSliceDataType []noalg.map.group[string]string.array
     - __kind: BaseType
       ID: 7
       Name: int
@@ -1615,7 +1615,7 @@ Types:
       GoRuntimeType: 584288
       GoKind: 3
     - __kind: GoEmptyInterfaceType
-      ID: 108
+      ID: 135
       Name: interface {}
       ByteSize: 16
       GoRuntimeType: 854240
@@ -1641,7 +1641,7 @@ Types:
           Offset: 8
           Type: 15 VoidPointerType unsafe.Pointer
     - __kind: GoSwissMapHeaderType
-      ID: 76
+      ID: 78
       Name: map<string,[]*mime/multipart.FileHeader>
       ByteSize: 48
       GoKind: 25
@@ -1654,7 +1654,7 @@ Types:
           Type: 1 BaseType uintptr
         - Name: dirPtr
           Offset: 16
-          Type: 77 PointerType **table<string,[]*mime/multipart.FileHeader>
+          Type: 79 PointerType **table<string,[]*mime/multipart.FileHeader>
         - Name: dirLen
           Offset: 24
           Type: 7 BaseType int
@@ -1673,8 +1673,8 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 8 BaseType uint64
-      TablePtrSliceType: 172 GoSliceDataType []*table<string,[]*mime/multipart.FileHeader>.array
-      GroupType: 105 StructureType noalg.map.group[string][]*mime/multipart.FileHeader
+      TablePtrSliceType: 123 GoSliceDataType []*table<string,[]*mime/multipart.FileHeader>.array
+      GroupType: 117 StructureType noalg.map.group[string][]*mime/multipart.FileHeader
     - __kind: GoSwissMapHeaderType
       ID: 46
       Name: map<string,[]string>
@@ -1708,8 +1708,8 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 8 BaseType uint64
-      TablePtrSliceType: 164 GoSliceDataType []*table<string,[]string>.array
-      GroupType: 95 StructureType noalg.map.group[string][]string
+      TablePtrSliceType: 100 GoSliceDataType []*table<string,[]string>.array
+      GroupType: 97 StructureType noalg.map.group[string][]string
     - __kind: GoSwissMapHeaderType
       ID: 65
       Name: map<string,string>
@@ -1743,17 +1743,17 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 8 BaseType uint64
-      TablePtrSliceType: 168 GoSliceDataType []*table<string,string>.array
-      GroupType: 100 StructureType noalg.map.group[string]string
+      TablePtrSliceType: 109 GoSliceDataType []*table<string,string>.array
+      GroupType: 106 StructureType noalg.map.group[string]string
     - __kind: GoMapType
-      ID: 74
+      ID: 76
       Name: map[string][]*mime/multipart.FileHeader
       ByteSize: 8
       GoRuntimeType: 1.131648e+06
       GoKind: 21
-      HeaderType: 76 GoSwissMapHeaderType map<string,[]*mime/multipart.FileHeader>
+      HeaderType: 78 GoSwissMapHeaderType map<string,[]*mime/multipart.FileHeader>
     - __kind: GoMapType
-      ID: 73
+      ID: 75
       Name: map[string][]string
       ByteSize: 8
       GoRuntimeType: 1.127296e+06
@@ -1767,7 +1767,7 @@ Types:
       GoKind: 21
       HeaderType: 65 GoSwissMapHeaderType map<string,string>
     - __kind: StructureType
-      ID: 110
+      ID: 137
       Name: math/big.Int
       ByteSize: 32
       GoRuntimeType: 1.493568e+06
@@ -1778,15 +1778,15 @@ Types:
           Type: 4 BaseType bool
         - Name: abs
           Offset: 8
-          Type: 149 GoSliceHeaderType math/big.nat
+          Type: 172 GoSliceHeaderType math/big.nat
     - __kind: BaseType
-      ID: 151
+      ID: 174
       Name: math/big.Word
       ByteSize: 8
       GoRuntimeType: 588128
       GoKind: 7
     - __kind: GoSliceHeaderType
-      ID: 149
+      ID: 172
       Name: math/big.nat
       ByteSize: 24
       GoRuntimeType: 2.361088e+06
@@ -1794,7 +1794,7 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 150 PointerType *math/big.Word
+          Type: 173 PointerType *math/big.Word
         - Name: len
           Offset: 8
           Type: 7 BaseType int
@@ -1806,9 +1806,9 @@ Types:
       ID: 206
       Name: math/big.nat.array
       ByteSize: 2048
-      Element: 151 BaseType math/big.Word
+      Element: 174 BaseType math/big.Word
     - __kind: StructureType
-      ID: 159
+      ID: 169
       Name: mime/multipart.FileHeader
       ByteSize: 88
       GoRuntimeType: 1.977088e+06
@@ -1819,7 +1819,7 @@ Types:
           Type: 9 GoStringHeaderType string
         - Name: Header
           Offset: 16
-          Type: 161 GoMapType net/textproto.MIMEHeader
+          Type: 182 GoMapType net/textproto.MIMEHeader
         - Name: Size
           Offset: 24
           Type: 13 BaseType int64
@@ -1844,12 +1844,12 @@ Types:
       RawFields:
         - Name: Value
           Offset: 0
-          Type: 73 GoMapType map[string][]string
+          Type: 75 GoMapType map[string][]string
         - Name: File
           Offset: 8
-          Type: 74 GoMapType map[string][]*mime/multipart.FileHeader
+          Type: 76 GoMapType map[string][]*mime/multipart.FileHeader
     - __kind: GoSliceHeaderType
-      ID: 130
+      ID: 157
       Name: net.IP
       ByteSize: 24
       GoRuntimeType: 2.123744e+06
@@ -1864,14 +1864,14 @@ Types:
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 194 GoSliceDataType net.IP.array
+      Data: 195 GoSliceDataType net.IP.array
     - __kind: GoSliceDataType
-      ID: 194
+      ID: 195
       Name: net.IP.array
       ByteSize: 2048
       Element: 3 BaseType uint8
     - __kind: GoSliceHeaderType
-      ID: 160
+      ID: 205
       Name: net.IPMask
       ByteSize: 24
       GoRuntimeType: 1.01904e+06
@@ -1893,7 +1893,7 @@ Types:
       ByteSize: 2048
       Element: 3 BaseType uint8
     - __kind: StructureType
-      ID: 158
+      ID: 181
       Name: net.IPNet
       ByteSize: 48
       GoRuntimeType: 1.458208e+06
@@ -1901,10 +1901,10 @@ Types:
       RawFields:
         - Name: IP
           Offset: 0
-          Type: 130 GoSliceHeaderType net.IP
+          Type: 157 GoSliceHeaderType net.IP
         - Name: Mask
           Offset: 24
-          Type: 160 GoSliceHeaderType net.IPMask
+          Type: 205 GoSliceHeaderType net.IPMask
     - __kind: GoMapType
       ID: 44
       Name: net/http.Header
@@ -2077,12 +2077,12 @@ Types:
           Type: 9 GoStringHeaderType string
         - Name: segments
           Offset: 48
-          Type: 89 GoSliceHeaderType []net/http.segment
+          Type: 91 GoSliceHeaderType []net/http.segment
         - Name: loc
           Offset: 72
           Type: 9 GoStringHeaderType string
     - __kind: StructureType
-      ID: 91
+      ID: 93
       Name: net/http.segment
       ByteSize: 24
       GoRuntimeType: 1.607872e+06
@@ -2098,7 +2098,7 @@ Types:
           Offset: 17
           Type: 4 BaseType bool
     - __kind: GoMapType
-      ID: 161
+      ID: 182
       Name: net/textproto.MIMEHeader
       ByteSize: 8
       GoRuntimeType: 1.82304e+06
@@ -2119,7 +2119,7 @@ Types:
           Type: 9 GoStringHeaderType string
         - Name: User
           Offset: 32
-          Type: 70 PointerType *net/url.Userinfo
+          Type: 72 PointerType *net/url.Userinfo
         - Name: Host
           Offset: 40
           Type: 9 GoStringHeaderType string
@@ -2145,7 +2145,7 @@ Types:
           Offset: 128
           Type: 9 GoStringHeaderType string
     - __kind: StructureType
-      ID: 71
+      ID: 73
       Name: net/url.Userinfo
       ByteSize: 40
       GoRuntimeType: 1.624384e+06
@@ -2168,34 +2168,34 @@ Types:
       GoKind: 21
       HeaderType: 46 GoSwissMapHeaderType map<string,[]string>
     - __kind: ArrayType
-      ID: 144
+      ID: 118
       Name: noalg.[8]struct { key string; elem []*mime/multipart.FileHeader }
       ByteSize: 320
       GoRuntimeType: 699072
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 145 StructureType noalg.struct { key string; elem []*mime/multipart.FileHeader }
+      Element: 119 StructureType noalg.struct { key string; elem []*mime/multipart.FileHeader }
     - __kind: ArrayType
-      ID: 101
+      ID: 98
       Name: noalg.[8]struct { key string; elem []string }
       ByteSize: 320
       GoRuntimeType: 689248
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 102 StructureType noalg.struct { key string; elem []string }
+      Element: 99 StructureType noalg.struct { key string; elem []string }
     - __kind: ArrayType
-      ID: 142
+      ID: 107
       Name: noalg.[8]struct { key string; elem string }
       ByteSize: 256
       GoRuntimeType: 693408
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 143 StructureType noalg.struct { key string; elem string }
+      Element: 108 StructureType noalg.struct { key string; elem string }
     - __kind: StructureType
-      ID: 105
+      ID: 117
       Name: noalg.map.group[string][]*mime/multipart.FileHeader
       ByteSize: 328
       GoRuntimeType: 1.298816e+06
@@ -2206,9 +2206,9 @@ Types:
           Type: 8 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 144 ArrayType noalg.[8]struct { key string; elem []*mime/multipart.FileHeader }
+          Type: 118 ArrayType noalg.[8]struct { key string; elem []*mime/multipart.FileHeader }
     - __kind: StructureType
-      ID: 95
+      ID: 97
       Name: noalg.map.group[string][]string
       ByteSize: 328
       GoRuntimeType: 1.289728e+06
@@ -2219,9 +2219,9 @@ Types:
           Type: 8 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 101 ArrayType noalg.[8]struct { key string; elem []string }
+          Type: 98 ArrayType noalg.[8]struct { key string; elem []string }
     - __kind: StructureType
-      ID: 100
+      ID: 106
       Name: noalg.map.group[string]string
       ByteSize: 264
       GoRuntimeType: 1.29216e+06
@@ -2232,9 +2232,9 @@ Types:
           Type: 8 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 142 ArrayType noalg.[8]struct { key string; elem string }
+          Type: 107 ArrayType noalg.[8]struct { key string; elem string }
     - __kind: StructureType
-      ID: 145
+      ID: 119
       Name: noalg.struct { key string; elem []*mime/multipart.FileHeader }
       ByteSize: 40
       GoRuntimeType: 1.298688e+06
@@ -2245,9 +2245,9 @@ Types:
           Type: 9 GoStringHeaderType string
         - Name: elem
           Offset: 16
-          Type: 146 GoSliceHeaderType []*mime/multipart.FileHeader
+          Type: 120 GoSliceHeaderType []*mime/multipart.FileHeader
     - __kind: StructureType
-      ID: 102
+      ID: 99
       Name: noalg.struct { key string; elem []string }
       ByteSize: 40
       GoRuntimeType: 1.2896e+06
@@ -2260,7 +2260,7 @@ Types:
           Offset: 16
           Type: 51 GoSliceHeaderType []string
     - __kind: StructureType
-      ID: 143
+      ID: 108
       Name: noalg.struct { key string; elem string }
       ByteSize: 32
       GoRuntimeType: 1.292032e+06
@@ -2281,17 +2281,17 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 163 PointerType *string.str
+          Type: 71 PointerType *string.str
         - Name: len
           Offset: 8
           Type: 7 BaseType int
-      Data: 162 GoStringDataType string.str
+      Data: 70 GoStringDataType string.str
     - __kind: GoStringDataType
-      ID: 162
+      ID: 70
       Name: string.str
       ByteSize: 2048
     - __kind: StructureType
-      ID: 96
+      ID: 113
       Name: table<string,[]*mime/multipart.FileHeader>
       ByteSize: 32
       GoKind: 25
@@ -2313,9 +2313,9 @@ Types:
           Type: 7 BaseType int
         - Name: groups
           Offset: 16
-          Type: 103 GoSwissMapGroupsType groupReference<string,[]*mime/multipart.FileHeader>
+          Type: 115 GoSwissMapGroupsType groupReference<string,[]*mime/multipart.FileHeader>
     - __kind: StructureType
-      ID: 72
+      ID: 74
       Name: table<string,[]string>
       ByteSize: 32
       GoKind: 25
@@ -2337,9 +2337,9 @@ Types:
           Type: 7 BaseType int
         - Name: groups
           Offset: 16
-          Type: 93 GoSwissMapGroupsType groupReference<string,[]string>
+          Type: 95 GoSwissMapGroupsType groupReference<string,[]string>
     - __kind: StructureType
-      ID: 92
+      ID: 94
       Name: table<string,string>
       ByteSize: 32
       GoKind: 25
@@ -2361,9 +2361,9 @@ Types:
           Type: 7 BaseType int
         - Name: groups
           Offset: 16
-          Type: 98 GoSwissMapGroupsType groupReference<string,string>
+          Type: 104 GoSwissMapGroupsType groupReference<string,string>
     - __kind: StructureType
-      ID: 117
+      ID: 144
       Name: time.Location
       ByteSize: 104
       GoRuntimeType: 1.972768e+06
@@ -2374,10 +2374,10 @@ Types:
           Type: 9 GoStringHeaderType string
         - Name: zone
           Offset: 16
-          Type: 152 GoSliceHeaderType []time.zone
+          Type: 175 GoSliceHeaderType []time.zone
         - Name: tx
           Offset: 40
-          Type: 155 GoSliceHeaderType []time.zoneTrans
+          Type: 178 GoSliceHeaderType []time.zoneTrans
         - Name: extend
           Offset: 64
           Type: 9 GoStringHeaderType string
@@ -2389,9 +2389,9 @@ Types:
           Type: 13 BaseType int64
         - Name: cacheZone
           Offset: 96
-          Type: 153 PointerType *time.zone
+          Type: 176 PointerType *time.zone
     - __kind: StructureType
-      ID: 115
+      ID: 142
       Name: time.Time
       ByteSize: 24
       GoRuntimeType: 2.363936e+06
@@ -2405,9 +2405,9 @@ Types:
           Type: 13 BaseType int64
         - Name: loc
           Offset: 16
-          Type: 116 PointerType *time.Location
+          Type: 143 PointerType *time.Location
     - __kind: StructureType
-      ID: 154
+      ID: 177
       Name: time.zone
       ByteSize: 32
       GoRuntimeType: 1.612864e+06
@@ -2423,7 +2423,7 @@ Types:
           Offset: 24
           Type: 4 BaseType bool
     - __kind: StructureType
-      ID: 157
+      ID: 180
       Name: time.zoneTrans
       ByteSize: 16
       GoRuntimeType: 1.750304e+06

--- a/pkg/dyninst/irgen/testdata/snapshot/rc_tester_v1.arch=arm64,toolchain=go1.25.0.yaml
+++ b/pkg/dyninst/irgen/testdata/snapshot/rc_tester_v1.arch=arm64,toolchain=go1.25.0.yaml
@@ -33,7 +33,7 @@ Subprograms:
       InlinePCRanges: []
       Variables:
         - Name: w
-          Type: 1 GoInterfaceType net/http.ResponseWriter
+          Type: 36 GoInterfaceType net/http.ResponseWriter
           Locations:
             - Range: 0x82b0f0..0x82b144
               Pieces:
@@ -56,7 +56,7 @@ Subprograms:
           IsParameter: true
           IsReturn: false
         - Name: r
-          Type: 3 PointerType *net/http.Request
+          Type: 37 PointerType *net/http.Request
           Locations:
             - Range: 0x82b0f0..0x82b150
               Pieces: [{Size: 8, Op: {RegNo: 2, Shift: 0}}]
@@ -65,7 +65,7 @@ Subprograms:
           IsParameter: true
           IsReturn: false
         - Name: '&buf'
-          Type: 135 PointerType *bytes.Buffer
+          Type: 158 PointerType *bytes.Buffer
           Locations:
             - Range: 0x82b23c..0x82b258
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
@@ -74,7 +74,7 @@ Subprograms:
           IsParameter: false
           IsReturn: false
         - Name: span
-          Type: 138 GoInterfaceType gopkg.in/DataDog/dd-trace-go.v1/ddtrace.Span
+          Type: 161 GoInterfaceType gopkg.in/DataDog/dd-trace-go.v1/ddtrace.Span
           Locations:
             - Range: 0x82b164..0x82b164
               Pieces:
@@ -96,7 +96,7 @@ Subprograms:
       InlinePCRanges: []
       Variables:
         - Name: path
-          Type: 5 GoStringHeaderType string
+          Type: 9 GoStringHeaderType string
           Locations:
             - Range: 0x82b3f0..0x82b414
               Pieces:
@@ -108,49 +108,49 @@ Subprograms:
           IsReturn: false
 Types:
     - __kind: PointerType
-      ID: 58
+      ID: 82
       Name: '**crypto/x509.Certificate'
       ByteSize: 8
       GoKind: 22
-      Pointee: 59 PointerType *crypto/x509.Certificate
+      Pointee: 83 PointerType *crypto/x509.Certificate
     - __kind: PointerType
-      ID: 49
+      ID: 73
       Name: '**mime/multipart.FileHeader'
       ByteSize: 8
       GoKind: 22
-      Pointee: 50 PointerType *mime/multipart.FileHeader
+      Pointee: 74 PointerType *mime/multipart.FileHeader
     - __kind: PointerType
-      ID: 99
+      ID: 122
       Name: '**net.IPNet'
       ByteSize: 8
       GoKind: 22
-      Pointee: 100 PointerType *net.IPNet
+      Pointee: 123 PointerType *net.IPNet
     - __kind: PointerType
-      ID: 97
+      ID: 120
       Name: '**net/url.URL'
       ByteSize: 8
-      Pointee: 9 PointerType *net/url.URL
+      Pointee: 39 PointerType *net/url.URL
     - __kind: PointerType
-      ID: 40
+      ID: 64
       Name: '**table<string,[]*mime/multipart.FileHeader>'
       ByteSize: 8
-      Pointee: 41 PointerType *table<string,[]*mime/multipart.FileHeader>
+      Pointee: 65 PointerType *table<string,[]*mime/multipart.FileHeader>
     - __kind: PointerType
-      ID: 19
+      ID: 46
       Name: '**table<string,[]string>'
       ByteSize: 8
-      Pointee: 20 PointerType *table<string,[]string>
+      Pointee: 47 PointerType *table<string,[]string>
     - __kind: PointerType
-      ID: 127
+      ID: 150
       Name: '**table<string,string>'
       ByteSize: 8
-      Pointee: 128 PointerType *table<string,string>
+      Pointee: 151 PointerType *table<string,string>
     - __kind: PointerType
-      ID: 110
+      ID: 133
       Name: '*[]*crypto/x509.Certificate'
       ByteSize: 8
       GoKind: 22
-      Pointee: 57 GoSliceHeaderType []*crypto/x509.Certificate
+      Pointee: 81 GoSliceHeaderType []*crypto/x509.Certificate
     - __kind: PointerType
       ID: 175
       Name: '*[]*crypto/x509.Certificate.array'
@@ -237,203 +237,203 @@ Types:
       ByteSize: 8
       Pointee: 184 GoSliceDataType []time.zoneTrans.array
     - __kind: PointerType
-      ID: 112
+      ID: 135
       Name: '*[]uint8'
       ByteSize: 8
       GoRuntimeType: 481440
       GoKind: 22
-      Pointee: 53 GoSliceHeaderType []uint8
+      Pointee: 77 GoSliceHeaderType []uint8
     - __kind: PointerType
       ID: 173
       Name: '*[]uint8.array'
       ByteSize: 8
       Pointee: 172 GoSliceDataType []uint8.array
     - __kind: PointerType
-      ID: 141
+      ID: 11
       Name: '*bool'
       ByteSize: 8
       GoRuntimeType: 400224
       GoKind: 22
-      Pointee: 13 BaseType bool
+      Pointee: 4 BaseType bool
     - __kind: PointerType
-      ID: 135
+      ID: 158
       Name: '*bytes.Buffer'
       ByteSize: 8
       GoRuntimeType: 2.259936e+06
       GoKind: 22
-      Pointee: 136 StructureType bytes.Buffer
+      Pointee: 159 StructureType bytes.Buffer
     - __kind: PointerType
-      ID: 54
+      ID: 78
       Name: '*crypto/tls.ConnectionState'
       ByteSize: 8
       GoRuntimeType: 907744
       GoKind: 22
-      Pointee: 55 StructureType crypto/tls.ConnectionState
+      Pointee: 79 StructureType crypto/tls.ConnectionState
     - __kind: PointerType
-      ID: 59
+      ID: 83
       Name: '*crypto/x509.Certificate'
       ByteSize: 8
       GoRuntimeType: 2.0432e+06
       GoKind: 22
-      Pointee: 60 StructureType crypto/x509.Certificate
+      Pointee: 84 StructureType crypto/x509.Certificate
     - __kind: PointerType
-      ID: 91
+      ID: 114
       Name: '*crypto/x509.ExtKeyUsage'
       ByteSize: 8
       GoRuntimeType: 423456
       GoKind: 22
-      Pointee: 92 BaseType crypto/x509.ExtKeyUsage
+      Pointee: 115 BaseType crypto/x509.ExtKeyUsage
     - __kind: PointerType
-      ID: 104
+      ID: 127
       Name: '*crypto/x509.OID'
       ByteSize: 8
       GoRuntimeType: 1.953568e+06
       GoKind: 22
-      Pointee: 105 StructureType crypto/x509.OID
+      Pointee: 128 StructureType crypto/x509.OID
     - __kind: PointerType
-      ID: 107
+      ID: 130
       Name: '*crypto/x509.PolicyMapping'
       ByteSize: 8
       GoRuntimeType: 423520
       GoKind: 22
-      Pointee: 108 StructureType crypto/x509.PolicyMapping
+      Pointee: 131 StructureType crypto/x509.PolicyMapping
     - __kind: PointerType
-      ID: 71
+      ID: 95
       Name: '*crypto/x509/pkix.AttributeTypeAndValue'
       ByteSize: 8
       GoRuntimeType: 437216
       GoKind: 22
-      Pointee: 72 StructureType crypto/x509/pkix.AttributeTypeAndValue
+      Pointee: 96 StructureType crypto/x509/pkix.AttributeTypeAndValue
     - __kind: PointerType
-      ID: 86
+      ID: 109
       Name: '*crypto/x509/pkix.Extension'
       ByteSize: 8
       GoRuntimeType: 437408
       GoKind: 22
-      Pointee: 87 StructureType crypto/x509/pkix.Extension
+      Pointee: 110 StructureType crypto/x509/pkix.Extension
     - __kind: PointerType
-      ID: 89
+      ID: 112
       Name: '*encoding/asn1.ObjectIdentifier'
       ByteSize: 8
       GoRuntimeType: 1.052704e+06
       GoKind: 22
-      Pointee: 73 GoSliceHeaderType encoding/asn1.ObjectIdentifier
+      Pointee: 97 GoSliceHeaderType encoding/asn1.ObjectIdentifier
     - __kind: PointerType
       ID: 181
       Name: '*encoding/asn1.ObjectIdentifier.array'
       ByteSize: 8
       Pointee: 180 GoSliceDataType encoding/asn1.ObjectIdentifier.array
     - __kind: PointerType
-      ID: 159
+      ID: 33
       Name: '*error'
       ByteSize: 8
       GoRuntimeType: 399136
       GoKind: 22
-      Pointee: 143 GoInterfaceType error
+      Pointee: 14 GoInterfaceType error
     - __kind: PointerType
-      ID: 161
+      ID: 35
       Name: '*float32'
       ByteSize: 8
       GoRuntimeType: 400096
       GoKind: 22
-      Pointee: 146 BaseType float32
+      Pointee: 18 BaseType float32
     - __kind: PointerType
-      ID: 153
+      ID: 26
       Name: '*float64'
       ByteSize: 8
       GoRuntimeType: 400160
       GoKind: 22
-      Pointee: 144 BaseType float64
+      Pointee: 16 BaseType float64
     - __kind: PointerType
-      ID: 74
+      ID: 27
       Name: '*int'
       ByteSize: 8
       GoRuntimeType: 399776
       GoKind: 22
-      Pointee: 8 BaseType int
+      Pointee: 7 BaseType int
     - __kind: PointerType
-      ID: 157
+      ID: 31
       Name: '*int16'
       ByteSize: 8
       GoRuntimeType: 399392
       GoKind: 22
-      Pointee: 150 BaseType int16
+      Pointee: 23 BaseType int16
     - __kind: PointerType
-      ID: 148
+      ID: 20
       Name: '*int32'
       ByteSize: 8
       GoRuntimeType: 399520
       GoKind: 22
-      Pointee: 142 BaseType int32
+      Pointee: 12 BaseType int32
     - __kind: PointerType
-      ID: 155
+      ID: 29
       Name: '*int64'
       ByteSize: 8
       GoRuntimeType: 399648
       GoKind: 22
-      Pointee: 32 BaseType int64
+      Pointee: 13 BaseType int64
     - __kind: PointerType
-      ID: 158
+      ID: 32
       Name: '*int8'
       ByteSize: 8
       GoRuntimeType: 399264
       GoKind: 22
-      Pointee: 145 BaseType int8
+      Pointee: 17 BaseType int8
     - __kind: PointerType
-      ID: 38
+      ID: 62
       Name: '*map<string,[]*mime/multipart.FileHeader>'
       ByteSize: 8
-      Pointee: 39 GoSwissMapHeaderType map<string,[]*mime/multipart.FileHeader>
+      Pointee: 63 GoSwissMapHeaderType map<string,[]*mime/multipart.FileHeader>
     - __kind: PointerType
-      ID: 15
+      ID: 44
       Name: '*map<string,[]string>'
       ByteSize: 8
-      Pointee: 16 GoSwissMapHeaderType map<string,[]string>
+      Pointee: 45 GoSwissMapHeaderType map<string,[]string>
     - __kind: PointerType
-      ID: 125
+      ID: 148
       Name: '*map<string,string>'
       ByteSize: 8
-      Pointee: 126 GoSwissMapHeaderType map<string,string>
+      Pointee: 149 GoSwissMapHeaderType map<string,string>
     - __kind: PointerType
-      ID: 64
+      ID: 88
       Name: '*math/big.Int'
       ByteSize: 8
       GoRuntimeType: 2.381568e+06
       GoKind: 22
-      Pointee: 65 StructureType math/big.Int
+      Pointee: 89 StructureType math/big.Int
     - __kind: PointerType
-      ID: 67
+      ID: 91
       Name: '*math/big.Word'
       ByteSize: 8
       GoRuntimeType: 426272
       GoKind: 22
-      Pointee: 68 BaseType math/big.Word
+      Pointee: 92 BaseType math/big.Word
     - __kind: PointerType
       ID: 177
       Name: '*math/big.nat.array'
       ByteSize: 8
       Pointee: 176 GoSliceDataType math/big.nat.array
     - __kind: PointerType
-      ID: 50
+      ID: 74
       Name: '*mime/multipart.FileHeader'
       ByteSize: 8
       GoRuntimeType: 909280
       GoKind: 22
-      Pointee: 51 StructureType mime/multipart.FileHeader
+      Pointee: 75 StructureType mime/multipart.FileHeader
     - __kind: PointerType
-      ID: 34
+      ID: 58
       Name: '*mime/multipart.Form'
       ByteSize: 8
       GoRuntimeType: 909376
       GoKind: 22
-      Pointee: 35 StructureType mime/multipart.Form
+      Pointee: 59 StructureType mime/multipart.Form
     - __kind: PointerType
-      ID: 94
+      ID: 117
       Name: '*net.IP'
       ByteSize: 8
       GoRuntimeType: 2.149408e+06
       GoKind: 22
-      Pointee: 95 GoSliceHeaderType net.IP
+      Pointee: 118 GoSliceHeaderType net.IP
     - __kind: PointerType
       ID: 195
       Name: '*net.IP.array'
@@ -445,161 +445,161 @@ Types:
       ByteSize: 8
       Pointee: 200 GoSliceDataType net.IPMask.array
     - __kind: PointerType
-      ID: 100
+      ID: 123
       Name: '*net.IPNet'
       ByteSize: 8
       GoRuntimeType: 1.182656e+06
       GoKind: 22
-      Pointee: 101 StructureType net.IPNet
+      Pointee: 124 StructureType net.IPNet
     - __kind: PointerType
-      ID: 3
+      ID: 37
       Name: '*net/http.Request'
       ByteSize: 8
       GoRuntimeType: 2.300192e+06
       GoKind: 22
-      Pointee: 4 StructureType net/http.Request
+      Pointee: 38 StructureType net/http.Request
     - __kind: PointerType
-      ID: 116
+      ID: 139
       Name: '*net/http.Response'
       ByteSize: 8
       GoRuntimeType: 1.718272e+06
       GoKind: 22
-      Pointee: 117 StructureType net/http.Response
+      Pointee: 140 StructureType net/http.Response
     - __kind: PointerType
-      ID: 119
+      ID: 142
       Name: '*net/http.pattern'
       ByteSize: 8
       GoRuntimeType: 1.608064e+06
       GoKind: 22
-      Pointee: 120 StructureType net/http.pattern
+      Pointee: 143 StructureType net/http.pattern
     - __kind: PointerType
-      ID: 122
+      ID: 145
       Name: '*net/http.segment'
       ByteSize: 8
       GoRuntimeType: 391712
       GoKind: 22
-      Pointee: 123 StructureType net/http.segment
+      Pointee: 146 StructureType net/http.segment
     - __kind: PointerType
-      ID: 9
+      ID: 39
       Name: '*net/url.URL'
       ByteSize: 8
       GoRuntimeType: 2.112832e+06
       GoKind: 22
-      Pointee: 10 StructureType net/url.URL
+      Pointee: 40 StructureType net/url.URL
     - __kind: PointerType
-      ID: 11
+      ID: 41
       Name: '*net/url.Userinfo'
       ByteSize: 8
       GoRuntimeType: 1.200064e+06
       GoKind: 22
-      Pointee: 12 StructureType net/url.Userinfo
+      Pointee: 42 StructureType net/url.Userinfo
     - __kind: PointerType
-      ID: 44
+      ID: 68
       Name: '*noalg.map.group[string][]*mime/multipart.FileHeader'
       ByteSize: 8
-      Pointee: 45 StructureType noalg.map.group[string][]*mime/multipart.FileHeader
+      Pointee: 69 StructureType noalg.map.group[string][]*mime/multipart.FileHeader
     - __kind: PointerType
-      ID: 24
+      ID: 50
       Name: '*noalg.map.group[string][]string'
       ByteSize: 8
-      Pointee: 25 StructureType noalg.map.group[string][]string
+      Pointee: 51 StructureType noalg.map.group[string][]string
     - __kind: PointerType
-      ID: 131
+      ID: 154
       Name: '*noalg.map.group[string]string'
       ByteSize: 8
-      Pointee: 132 StructureType noalg.map.group[string]string
+      Pointee: 155 StructureType noalg.map.group[string]string
     - __kind: PointerType
-      ID: 29
+      ID: 22
       Name: '*string'
       ByteSize: 8
       GoRuntimeType: 399200
       GoKind: 22
-      Pointee: 5 GoStringHeaderType string
+      Pointee: 9 GoStringHeaderType string
     - __kind: PointerType
       ID: 163
       Name: '*string.str'
       ByteSize: 8
       Pointee: 162 GoStringDataType string.str
     - __kind: PointerType
-      ID: 41
+      ID: 65
       Name: '*table<string,[]*mime/multipart.FileHeader>'
       ByteSize: 8
-      Pointee: 42 StructureType table<string,[]*mime/multipart.FileHeader>
+      Pointee: 66 StructureType table<string,[]*mime/multipart.FileHeader>
     - __kind: PointerType
-      ID: 20
+      ID: 47
       Name: '*table<string,[]string>'
       ByteSize: 8
-      Pointee: 21 StructureType table<string,[]string>
+      Pointee: 48 StructureType table<string,[]string>
     - __kind: PointerType
-      ID: 128
+      ID: 151
       Name: '*table<string,string>'
       ByteSize: 8
-      Pointee: 129 StructureType table<string,string>
+      Pointee: 152 StructureType table<string,string>
     - __kind: PointerType
-      ID: 76
+      ID: 99
       Name: '*time.Location'
       ByteSize: 8
       GoRuntimeType: 1.613056e+06
       GoKind: 22
-      Pointee: 77 StructureType time.Location
+      Pointee: 100 StructureType time.Location
     - __kind: PointerType
-      ID: 79
+      ID: 102
       Name: '*time.zone'
       ByteSize: 8
       GoRuntimeType: 394784
       GoKind: 22
-      Pointee: 80 StructureType time.zone
+      Pointee: 103 StructureType time.zone
     - __kind: PointerType
-      ID: 82
+      ID: 105
       Name: '*time.zoneTrans'
       ByteSize: 8
       GoRuntimeType: 394848
       GoKind: 22
-      Pointee: 83 StructureType time.zoneTrans
+      Pointee: 106 StructureType time.zoneTrans
     - __kind: PointerType
-      ID: 160
+      ID: 34
       Name: '*uint'
       ByteSize: 8
       GoRuntimeType: 399840
       GoKind: 22
-      Pointee: 140 BaseType uint
+      Pointee: 10 BaseType uint
     - __kind: PointerType
-      ID: 156
+      ID: 30
       Name: '*uint16'
       ByteSize: 8
       GoRuntimeType: 399456
       GoKind: 22
-      Pointee: 22 BaseType uint16
+      Pointee: 6 BaseType uint16
     - __kind: PointerType
-      ID: 149
+      ID: 21
       Name: '*uint32'
       ByteSize: 8
       GoRuntimeType: 399584
       GoKind: 22
-      Pointee: 139 BaseType uint32
+      Pointee: 2 BaseType uint32
     - __kind: PointerType
-      ID: 154
+      ID: 28
       Name: '*uint64'
       ByteSize: 8
       GoRuntimeType: 399712
       GoKind: 22
-      Pointee: 17 BaseType uint64
+      Pointee: 8 BaseType uint64
     - __kind: PointerType
-      ID: 6
+      ID: 5
       Name: '*uint8'
       ByteSize: 8
       GoRuntimeType: 399328
       GoKind: 22
-      Pointee: 7 BaseType uint8
+      Pointee: 3 BaseType uint8
     - __kind: PointerType
-      ID: 147
+      ID: 19
       Name: '*uintptr'
       ByteSize: 8
       GoRuntimeType: 399904
       GoKind: 22
-      Pointee: 18 BaseType uintptr
+      Pointee: 1 BaseType uintptr
     - __kind: GoChannelType
-      ID: 115
+      ID: 138
       Name: <-chan struct {}
       GoRuntimeType: 597472
       GoKind: 18
@@ -612,7 +612,7 @@ Types:
         - Name: w
           Offset: 1
           Expression:
-            Type: 1 GoInterfaceType net/http.ResponseWriter
+            Type: 36 GoInterfaceType net/http.ResponseWriter
             Operations:
                 - __kind: LocationOp
                   Variable: {subprogram: 1, index: 0, name: w}
@@ -621,7 +621,7 @@ Types:
         - Name: r
           Offset: 17
           Expression:
-            Type: 3 PointerType *net/http.Request
+            Type: 37 PointerType *net/http.Request
             Operations:
                 - __kind: LocationOp
                   Variable: {subprogram: 1, index: 1, name: r}
@@ -636,14 +636,14 @@ Types:
         - Name: path
           Offset: 1
           Expression:
-            Type: 5 GoStringHeaderType string
+            Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
                   Variable: {subprogram: 2, index: 0, name: path}
                   Offset: 0
                   ByteSize: 16
     - __kind: GoSliceHeaderType
-      ID: 57
+      ID: 81
       Name: '[]*crypto/x509.Certificate'
       ByteSize: 24
       GoRuntimeType: 502272
@@ -651,21 +651,21 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 58 PointerType **crypto/x509.Certificate
+          Type: 82 PointerType **crypto/x509.Certificate
         - Name: len
           Offset: 8
-          Type: 8 BaseType int
+          Type: 7 BaseType int
         - Name: cap
           Offset: 16
-          Type: 8 BaseType int
+          Type: 7 BaseType int
       Data: 174 GoSliceDataType []*crypto/x509.Certificate.array
     - __kind: GoSliceDataType
       ID: 174
       Name: '[]*crypto/x509.Certificate.array'
       ByteSize: 2048
-      Element: 59 PointerType *crypto/x509.Certificate
+      Element: 83 PointerType *crypto/x509.Certificate
     - __kind: GoSliceHeaderType
-      ID: 48
+      ID: 72
       Name: '[]*mime/multipart.FileHeader'
       ByteSize: 24
       GoRuntimeType: 487168
@@ -673,21 +673,21 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 49 PointerType **mime/multipart.FileHeader
+          Type: 73 PointerType **mime/multipart.FileHeader
         - Name: len
           Offset: 8
-          Type: 8 BaseType int
+          Type: 7 BaseType int
         - Name: cap
           Offset: 16
-          Type: 8 BaseType int
+          Type: 7 BaseType int
       Data: 170 GoSliceDataType []*mime/multipart.FileHeader.array
     - __kind: GoSliceDataType
       ID: 170
       Name: '[]*mime/multipart.FileHeader.array'
       ByteSize: 2048
-      Element: 50 PointerType *mime/multipart.FileHeader
+      Element: 74 PointerType *mime/multipart.FileHeader
     - __kind: GoSliceHeaderType
-      ID: 98
+      ID: 121
       Name: '[]*net.IPNet'
       ByteSize: 24
       GoRuntimeType: 503872
@@ -695,21 +695,21 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 99 PointerType **net.IPNet
+          Type: 122 PointerType **net.IPNet
         - Name: len
           Offset: 8
-          Type: 8 BaseType int
+          Type: 7 BaseType int
         - Name: cap
           Offset: 16
-          Type: 8 BaseType int
+          Type: 7 BaseType int
       Data: 198 GoSliceDataType []*net.IPNet.array
     - __kind: GoSliceDataType
       ID: 198
       Name: '[]*net.IPNet.array'
       ByteSize: 2048
-      Element: 100 PointerType *net.IPNet
+      Element: 123 PointerType *net.IPNet
     - __kind: GoSliceHeaderType
-      ID: 96
+      ID: 119
       Name: '[]*net/url.URL'
       ByteSize: 24
       GoRuntimeType: 503808
@@ -717,36 +717,36 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 97 PointerType **net/url.URL
+          Type: 120 PointerType **net/url.URL
         - Name: len
           Offset: 8
-          Type: 8 BaseType int
+          Type: 7 BaseType int
         - Name: cap
           Offset: 16
-          Type: 8 BaseType int
+          Type: 7 BaseType int
       Data: 196 GoSliceDataType []*net/url.URL.array
     - __kind: GoSliceDataType
       ID: 196
       Name: '[]*net/url.URL.array'
       ByteSize: 2048
-      Element: 9 PointerType *net/url.URL
+      Element: 39 PointerType *net/url.URL
     - __kind: GoSliceDataType
       ID: 168
       Name: '[]*table<string,[]*mime/multipart.FileHeader>.array'
       ByteSize: 8192
-      Element: 41 PointerType *table<string,[]*mime/multipart.FileHeader>
+      Element: 65 PointerType *table<string,[]*mime/multipart.FileHeader>
     - __kind: GoSliceDataType
       ID: 164
       Name: '[]*table<string,[]string>.array'
       ByteSize: 8192
-      Element: 20 PointerType *table<string,[]string>
+      Element: 47 PointerType *table<string,[]string>
     - __kind: GoSliceDataType
       ID: 212
       Name: '[]*table<string,string>.array'
       ByteSize: 8192
-      Element: 128 PointerType *table<string,string>
+      Element: 151 PointerType *table<string,string>
     - __kind: GoSliceHeaderType
-      ID: 109
+      ID: 132
       Name: '[][]*crypto/x509.Certificate'
       ByteSize: 24
       GoRuntimeType: 502336
@@ -754,21 +754,21 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 110 PointerType *[]*crypto/x509.Certificate
+          Type: 133 PointerType *[]*crypto/x509.Certificate
         - Name: len
           Offset: 8
-          Type: 8 BaseType int
+          Type: 7 BaseType int
         - Name: cap
           Offset: 16
-          Type: 8 BaseType int
+          Type: 7 BaseType int
       Data: 206 GoSliceDataType [][]*crypto/x509.Certificate.array
     - __kind: GoSliceDataType
       ID: 206
       Name: '[][]*crypto/x509.Certificate.array'
       ByteSize: 2048
-      Element: 57 GoSliceHeaderType []*crypto/x509.Certificate
+      Element: 81 GoSliceHeaderType []*crypto/x509.Certificate
     - __kind: GoSliceHeaderType
-      ID: 111
+      ID: 134
       Name: '[][]uint8'
       ByteSize: 24
       GoRuntimeType: 481760
@@ -776,21 +776,21 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 112 PointerType *[]uint8
+          Type: 135 PointerType *[]uint8
         - Name: len
           Offset: 8
-          Type: 8 BaseType int
+          Type: 7 BaseType int
         - Name: cap
           Offset: 16
-          Type: 8 BaseType int
+          Type: 7 BaseType int
       Data: 208 GoSliceDataType [][]uint8.array
     - __kind: GoSliceDataType
       ID: 208
       Name: '[][]uint8.array'
       ByteSize: 2048
-      Element: 53 GoSliceHeaderType []uint8
+      Element: 77 GoSliceHeaderType []uint8
     - __kind: GoSliceHeaderType
-      ID: 90
+      ID: 113
       Name: '[]crypto/x509.ExtKeyUsage'
       ByteSize: 24
       GoRuntimeType: 503744
@@ -798,21 +798,21 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 91 PointerType *crypto/x509.ExtKeyUsage
+          Type: 114 PointerType *crypto/x509.ExtKeyUsage
         - Name: len
           Offset: 8
-          Type: 8 BaseType int
+          Type: 7 BaseType int
         - Name: cap
           Offset: 16
-          Type: 8 BaseType int
+          Type: 7 BaseType int
       Data: 190 GoSliceDataType []crypto/x509.ExtKeyUsage.array
     - __kind: GoSliceDataType
       ID: 190
       Name: '[]crypto/x509.ExtKeyUsage.array'
       ByteSize: 2048
-      Element: 92 BaseType crypto/x509.ExtKeyUsage
+      Element: 115 BaseType crypto/x509.ExtKeyUsage
     - __kind: GoSliceHeaderType
-      ID: 103
+      ID: 126
       Name: '[]crypto/x509.OID'
       ByteSize: 24
       GoRuntimeType: 503936
@@ -820,21 +820,21 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 104 PointerType *crypto/x509.OID
+          Type: 127 PointerType *crypto/x509.OID
         - Name: len
           Offset: 8
-          Type: 8 BaseType int
+          Type: 7 BaseType int
         - Name: cap
           Offset: 16
-          Type: 8 BaseType int
+          Type: 7 BaseType int
       Data: 202 GoSliceDataType []crypto/x509.OID.array
     - __kind: GoSliceDataType
       ID: 202
       Name: '[]crypto/x509.OID.array'
       ByteSize: 2048
-      Element: 105 StructureType crypto/x509.OID
+      Element: 128 StructureType crypto/x509.OID
     - __kind: GoSliceHeaderType
-      ID: 106
+      ID: 129
       Name: '[]crypto/x509.PolicyMapping'
       ByteSize: 24
       GoRuntimeType: 504000
@@ -842,21 +842,21 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 107 PointerType *crypto/x509.PolicyMapping
+          Type: 130 PointerType *crypto/x509.PolicyMapping
         - Name: len
           Offset: 8
-          Type: 8 BaseType int
+          Type: 7 BaseType int
         - Name: cap
           Offset: 16
-          Type: 8 BaseType int
+          Type: 7 BaseType int
       Data: 204 GoSliceDataType []crypto/x509.PolicyMapping.array
     - __kind: GoSliceDataType
       ID: 204
       Name: '[]crypto/x509.PolicyMapping.array'
       ByteSize: 2048
-      Element: 108 StructureType crypto/x509.PolicyMapping
+      Element: 131 StructureType crypto/x509.PolicyMapping
     - __kind: GoSliceHeaderType
-      ID: 70
+      ID: 94
       Name: '[]crypto/x509/pkix.AttributeTypeAndValue'
       ByteSize: 24
       GoRuntimeType: 517280
@@ -864,21 +864,21 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 71 PointerType *crypto/x509/pkix.AttributeTypeAndValue
+          Type: 95 PointerType *crypto/x509/pkix.AttributeTypeAndValue
         - Name: len
           Offset: 8
-          Type: 8 BaseType int
+          Type: 7 BaseType int
         - Name: cap
           Offset: 16
-          Type: 8 BaseType int
+          Type: 7 BaseType int
       Data: 178 GoSliceDataType []crypto/x509/pkix.AttributeTypeAndValue.array
     - __kind: GoSliceDataType
       ID: 178
       Name: '[]crypto/x509/pkix.AttributeTypeAndValue.array'
       ByteSize: 2048
-      Element: 72 StructureType crypto/x509/pkix.AttributeTypeAndValue
+      Element: 96 StructureType crypto/x509/pkix.AttributeTypeAndValue
     - __kind: GoSliceHeaderType
-      ID: 85
+      ID: 108
       Name: '[]crypto/x509/pkix.Extension'
       ByteSize: 24
       GoRuntimeType: 503616
@@ -886,21 +886,21 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 86 PointerType *crypto/x509/pkix.Extension
+          Type: 109 PointerType *crypto/x509/pkix.Extension
         - Name: len
           Offset: 8
-          Type: 8 BaseType int
+          Type: 7 BaseType int
         - Name: cap
           Offset: 16
-          Type: 8 BaseType int
+          Type: 7 BaseType int
       Data: 186 GoSliceDataType []crypto/x509/pkix.Extension.array
     - __kind: GoSliceDataType
       ID: 186
       Name: '[]crypto/x509/pkix.Extension.array'
       ByteSize: 2048
-      Element: 87 StructureType crypto/x509/pkix.Extension
+      Element: 110 StructureType crypto/x509/pkix.Extension
     - __kind: GoSliceHeaderType
-      ID: 88
+      ID: 111
       Name: '[]encoding/asn1.ObjectIdentifier'
       ByteSize: 24
       GoRuntimeType: 503680
@@ -908,21 +908,21 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 89 PointerType *encoding/asn1.ObjectIdentifier
+          Type: 112 PointerType *encoding/asn1.ObjectIdentifier
         - Name: len
           Offset: 8
-          Type: 8 BaseType int
+          Type: 7 BaseType int
         - Name: cap
           Offset: 16
-          Type: 8 BaseType int
+          Type: 7 BaseType int
       Data: 188 GoSliceDataType []encoding/asn1.ObjectIdentifier.array
     - __kind: GoSliceDataType
       ID: 188
       Name: '[]encoding/asn1.ObjectIdentifier.array'
       ByteSize: 2048
-      Element: 73 GoSliceHeaderType encoding/asn1.ObjectIdentifier
+      Element: 97 GoSliceHeaderType encoding/asn1.ObjectIdentifier
     - __kind: GoSliceHeaderType
-      ID: 93
+      ID: 116
       Name: '[]net.IP'
       ByteSize: 24
       GoRuntimeType: 482784
@@ -930,21 +930,21 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 94 PointerType *net.IP
+          Type: 117 PointerType *net.IP
         - Name: len
           Offset: 8
-          Type: 8 BaseType int
+          Type: 7 BaseType int
         - Name: cap
           Offset: 16
-          Type: 8 BaseType int
+          Type: 7 BaseType int
       Data: 192 GoSliceDataType []net.IP.array
     - __kind: GoSliceDataType
       ID: 192
       Name: '[]net.IP.array'
       ByteSize: 2048
-      Element: 95 GoSliceHeaderType net.IP
+      Element: 118 GoSliceHeaderType net.IP
     - __kind: GoSliceHeaderType
-      ID: 121
+      ID: 144
       Name: '[]net/http.segment'
       ByteSize: 24
       GoRuntimeType: 484480
@@ -952,36 +952,36 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 122 PointerType *net/http.segment
+          Type: 145 PointerType *net/http.segment
         - Name: len
           Offset: 8
-          Type: 8 BaseType int
+          Type: 7 BaseType int
         - Name: cap
           Offset: 16
-          Type: 8 BaseType int
+          Type: 7 BaseType int
       Data: 210 GoSliceDataType []net/http.segment.array
     - __kind: GoSliceDataType
       ID: 210
       Name: '[]net/http.segment.array'
       ByteSize: 2048
-      Element: 123 StructureType net/http.segment
+      Element: 146 StructureType net/http.segment
     - __kind: GoSliceDataType
       ID: 169
       Name: '[]noalg.map.group[string][]*mime/multipart.FileHeader.array'
       ByteSize: 2048
-      Element: 45 StructureType noalg.map.group[string][]*mime/multipart.FileHeader
+      Element: 69 StructureType noalg.map.group[string][]*mime/multipart.FileHeader
     - __kind: GoSliceDataType
       ID: 165
       Name: '[]noalg.map.group[string][]string.array'
       ByteSize: 2048
-      Element: 25 StructureType noalg.map.group[string][]string
+      Element: 51 StructureType noalg.map.group[string][]string
     - __kind: GoSliceDataType
       ID: 213
       Name: '[]noalg.map.group[string]string.array'
       ByteSize: 2048
-      Element: 132 StructureType noalg.map.group[string]string
+      Element: 155 StructureType noalg.map.group[string]string
     - __kind: GoSliceHeaderType
-      ID: 28
+      ID: 54
       Name: '[]string'
       ByteSize: 24
       GoRuntimeType: 496288
@@ -989,21 +989,21 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 29 PointerType *string
+          Type: 22 PointerType *string
         - Name: len
           Offset: 8
-          Type: 8 BaseType int
+          Type: 7 BaseType int
         - Name: cap
           Offset: 16
-          Type: 8 BaseType int
+          Type: 7 BaseType int
       Data: 166 GoSliceDataType []string.array
     - __kind: GoSliceDataType
       ID: 166
       Name: '[]string.array'
       ByteSize: 2048
-      Element: 5 GoStringHeaderType string
+      Element: 9 GoStringHeaderType string
     - __kind: GoSliceHeaderType
-      ID: 78
+      ID: 101
       Name: '[]time.zone'
       ByteSize: 24
       GoRuntimeType: 489344
@@ -1011,21 +1011,21 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 79 PointerType *time.zone
+          Type: 102 PointerType *time.zone
         - Name: len
           Offset: 8
-          Type: 8 BaseType int
+          Type: 7 BaseType int
         - Name: cap
           Offset: 16
-          Type: 8 BaseType int
+          Type: 7 BaseType int
       Data: 182 GoSliceDataType []time.zone.array
     - __kind: GoSliceDataType
       ID: 182
       Name: '[]time.zone.array'
       ByteSize: 2048
-      Element: 80 StructureType time.zone
+      Element: 103 StructureType time.zone
     - __kind: GoSliceHeaderType
-      ID: 81
+      ID: 104
       Name: '[]time.zoneTrans'
       ByteSize: 24
       GoRuntimeType: 489408
@@ -1033,21 +1033,21 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 82 PointerType *time.zoneTrans
+          Type: 105 PointerType *time.zoneTrans
         - Name: len
           Offset: 8
-          Type: 8 BaseType int
+          Type: 7 BaseType int
         - Name: cap
           Offset: 16
-          Type: 8 BaseType int
+          Type: 7 BaseType int
       Data: 184 GoSliceDataType []time.zoneTrans.array
     - __kind: GoSliceDataType
       ID: 184
       Name: '[]time.zoneTrans.array'
       ByteSize: 2048
-      Element: 83 StructureType time.zoneTrans
+      Element: 106 StructureType time.zoneTrans
     - __kind: GoSliceHeaderType
-      ID: 53
+      ID: 77
       Name: '[]uint8'
       ByteSize: 24
       GoRuntimeType: 495136
@@ -1055,27 +1055,27 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 6 PointerType *uint8
+          Type: 5 PointerType *uint8
         - Name: len
           Offset: 8
-          Type: 8 BaseType int
+          Type: 7 BaseType int
         - Name: cap
           Offset: 16
-          Type: 8 BaseType int
+          Type: 7 BaseType int
       Data: 172 GoSliceDataType []uint8.array
     - __kind: GoSliceDataType
       ID: 172
       Name: '[]uint8.array'
       ByteSize: 2048
-      Element: 7 BaseType uint8
+      Element: 3 BaseType uint8
     - __kind: BaseType
-      ID: 13
+      ID: 4
       Name: bool
       ByteSize: 1
       GoRuntimeType: 585248
       GoKind: 1
     - __kind: StructureType
-      ID: 136
+      ID: 159
       Name: bytes.Buffer
       ByteSize: 40
       GoRuntimeType: 1.60576e+06
@@ -1083,33 +1083,33 @@ Types:
       RawFields:
         - Name: buf
           Offset: 0
-          Type: 53 GoSliceHeaderType []uint8
+          Type: 77 GoSliceHeaderType []uint8
         - Name: off
           Offset: 24
-          Type: 8 BaseType int
+          Type: 7 BaseType int
         - Name: lastRead
           Offset: 32
-          Type: 137 BaseType bytes.readOp
+          Type: 160 BaseType bytes.readOp
     - __kind: BaseType
-      ID: 137
+      ID: 160
       Name: bytes.readOp
       ByteSize: 1
       GoRuntimeType: 583456
       GoKind: 3
     - __kind: BaseType
-      ID: 152
+      ID: 25
       Name: complex128
       ByteSize: 16
       GoRuntimeType: 585056
       GoKind: 16
     - __kind: BaseType
-      ID: 151
+      ID: 24
       Name: complex64
       ByteSize: 8
       GoRuntimeType: 584992
       GoKind: 15
     - __kind: GoInterfaceType
-      ID: 118
+      ID: 141
       Name: context.Context
       ByteSize: 16
       GoRuntimeType: 1.276288e+06
@@ -1117,12 +1117,12 @@ Types:
       RawFields:
         - Name: tab
           Offset: 0
-          Type: 2 VoidPointerType unsafe.Pointer
+          Type: 15 VoidPointerType unsafe.Pointer
         - Name: data
           Offset: 8
-          Type: 2 VoidPointerType unsafe.Pointer
+          Type: 15 VoidPointerType unsafe.Pointer
     - __kind: StructureType
-      ID: 55
+      ID: 79
       Name: crypto/tls.ConnectionState
       ByteSize: 192
       GoRuntimeType: 2.261984e+06
@@ -1130,69 +1130,69 @@ Types:
       RawFields:
         - Name: Version
           Offset: 0
-          Type: 22 BaseType uint16
+          Type: 6 BaseType uint16
         - Name: HandshakeComplete
           Offset: 2
-          Type: 13 BaseType bool
+          Type: 4 BaseType bool
         - Name: DidResume
           Offset: 3
-          Type: 13 BaseType bool
+          Type: 4 BaseType bool
         - Name: CipherSuite
           Offset: 4
-          Type: 22 BaseType uint16
+          Type: 6 BaseType uint16
         - Name: CurveID
           Offset: 6
-          Type: 56 BaseType crypto/tls.CurveID
+          Type: 80 BaseType crypto/tls.CurveID
         - Name: NegotiatedProtocol
           Offset: 8
-          Type: 5 GoStringHeaderType string
+          Type: 9 GoStringHeaderType string
         - Name: NegotiatedProtocolIsMutual
           Offset: 24
-          Type: 13 BaseType bool
+          Type: 4 BaseType bool
         - Name: ServerName
           Offset: 32
-          Type: 5 GoStringHeaderType string
+          Type: 9 GoStringHeaderType string
         - Name: PeerCertificates
           Offset: 48
-          Type: 57 GoSliceHeaderType []*crypto/x509.Certificate
+          Type: 81 GoSliceHeaderType []*crypto/x509.Certificate
         - Name: VerifiedChains
           Offset: 72
-          Type: 109 GoSliceHeaderType [][]*crypto/x509.Certificate
+          Type: 132 GoSliceHeaderType [][]*crypto/x509.Certificate
         - Name: SignedCertificateTimestamps
           Offset: 96
-          Type: 111 GoSliceHeaderType [][]uint8
+          Type: 134 GoSliceHeaderType [][]uint8
         - Name: OCSPResponse
           Offset: 120
-          Type: 53 GoSliceHeaderType []uint8
+          Type: 77 GoSliceHeaderType []uint8
         - Name: TLSUnique
           Offset: 144
-          Type: 53 GoSliceHeaderType []uint8
+          Type: 77 GoSliceHeaderType []uint8
         - Name: ECHAccepted
           Offset: 168
-          Type: 13 BaseType bool
+          Type: 4 BaseType bool
         - Name: ekm
           Offset: 176
-          Type: 113 GoSubroutineType func(string, []uint8, int) ([]uint8, error)
+          Type: 136 GoSubroutineType func(string, []uint8, int) ([]uint8, error)
         - Name: testingOnlyDidHRR
           Offset: 184
-          Type: 13 BaseType bool
+          Type: 4 BaseType bool
         - Name: testingOnlyPeerSignatureAlgorithm
           Offset: 186
-          Type: 114 BaseType crypto/tls.SignatureScheme
+          Type: 137 BaseType crypto/tls.SignatureScheme
     - __kind: BaseType
-      ID: 56
+      ID: 80
       Name: crypto/tls.CurveID
       ByteSize: 2
       GoRuntimeType: 834432
       GoKind: 9
     - __kind: BaseType
-      ID: 114
+      ID: 137
       Name: crypto/tls.SignatureScheme
       ByteSize: 2
       GoRuntimeType: 834528
       GoKind: 9
     - __kind: StructureType
-      ID: 60
+      ID: 84
       Name: crypto/x509.Certificate
       ByteSize: 1424
       GoRuntimeType: 2.392832e+06
@@ -1200,174 +1200,174 @@ Types:
       RawFields:
         - Name: Raw
           Offset: 0
-          Type: 53 GoSliceHeaderType []uint8
+          Type: 77 GoSliceHeaderType []uint8
         - Name: RawTBSCertificate
           Offset: 24
-          Type: 53 GoSliceHeaderType []uint8
+          Type: 77 GoSliceHeaderType []uint8
         - Name: RawSubjectPublicKeyInfo
           Offset: 48
-          Type: 53 GoSliceHeaderType []uint8
+          Type: 77 GoSliceHeaderType []uint8
         - Name: RawSubject
           Offset: 72
-          Type: 53 GoSliceHeaderType []uint8
+          Type: 77 GoSliceHeaderType []uint8
         - Name: RawIssuer
           Offset: 96
-          Type: 53 GoSliceHeaderType []uint8
+          Type: 77 GoSliceHeaderType []uint8
         - Name: Signature
           Offset: 120
-          Type: 53 GoSliceHeaderType []uint8
+          Type: 77 GoSliceHeaderType []uint8
         - Name: SignatureAlgorithm
           Offset: 144
-          Type: 61 BaseType crypto/x509.SignatureAlgorithm
+          Type: 85 BaseType crypto/x509.SignatureAlgorithm
         - Name: PublicKeyAlgorithm
           Offset: 152
-          Type: 62 BaseType crypto/x509.PublicKeyAlgorithm
+          Type: 86 BaseType crypto/x509.PublicKeyAlgorithm
         - Name: PublicKey
           Offset: 160
-          Type: 63 GoEmptyInterfaceType interface {}
+          Type: 87 GoEmptyInterfaceType interface {}
         - Name: Version
           Offset: 176
-          Type: 8 BaseType int
+          Type: 7 BaseType int
         - Name: SerialNumber
           Offset: 184
-          Type: 64 PointerType *math/big.Int
+          Type: 88 PointerType *math/big.Int
         - Name: Issuer
           Offset: 192
-          Type: 69 StructureType crypto/x509/pkix.Name
+          Type: 93 StructureType crypto/x509/pkix.Name
         - Name: Subject
           Offset: 440
-          Type: 69 StructureType crypto/x509/pkix.Name
+          Type: 93 StructureType crypto/x509/pkix.Name
         - Name: NotBefore
           Offset: 688
-          Type: 75 StructureType time.Time
+          Type: 98 StructureType time.Time
         - Name: NotAfter
           Offset: 712
-          Type: 75 StructureType time.Time
+          Type: 98 StructureType time.Time
         - Name: KeyUsage
           Offset: 736
-          Type: 84 BaseType crypto/x509.KeyUsage
+          Type: 107 BaseType crypto/x509.KeyUsage
         - Name: Extensions
           Offset: 744
-          Type: 85 GoSliceHeaderType []crypto/x509/pkix.Extension
+          Type: 108 GoSliceHeaderType []crypto/x509/pkix.Extension
         - Name: ExtraExtensions
           Offset: 768
-          Type: 85 GoSliceHeaderType []crypto/x509/pkix.Extension
+          Type: 108 GoSliceHeaderType []crypto/x509/pkix.Extension
         - Name: UnhandledCriticalExtensions
           Offset: 792
-          Type: 88 GoSliceHeaderType []encoding/asn1.ObjectIdentifier
+          Type: 111 GoSliceHeaderType []encoding/asn1.ObjectIdentifier
         - Name: ExtKeyUsage
           Offset: 816
-          Type: 90 GoSliceHeaderType []crypto/x509.ExtKeyUsage
+          Type: 113 GoSliceHeaderType []crypto/x509.ExtKeyUsage
         - Name: UnknownExtKeyUsage
           Offset: 840
-          Type: 88 GoSliceHeaderType []encoding/asn1.ObjectIdentifier
+          Type: 111 GoSliceHeaderType []encoding/asn1.ObjectIdentifier
         - Name: BasicConstraintsValid
           Offset: 864
-          Type: 13 BaseType bool
+          Type: 4 BaseType bool
         - Name: IsCA
           Offset: 865
-          Type: 13 BaseType bool
+          Type: 4 BaseType bool
         - Name: MaxPathLen
           Offset: 872
-          Type: 8 BaseType int
+          Type: 7 BaseType int
         - Name: MaxPathLenZero
           Offset: 880
-          Type: 13 BaseType bool
+          Type: 4 BaseType bool
         - Name: SubjectKeyId
           Offset: 888
-          Type: 53 GoSliceHeaderType []uint8
+          Type: 77 GoSliceHeaderType []uint8
         - Name: AuthorityKeyId
           Offset: 912
-          Type: 53 GoSliceHeaderType []uint8
+          Type: 77 GoSliceHeaderType []uint8
         - Name: OCSPServer
           Offset: 936
-          Type: 28 GoSliceHeaderType []string
+          Type: 54 GoSliceHeaderType []string
         - Name: IssuingCertificateURL
           Offset: 960
-          Type: 28 GoSliceHeaderType []string
+          Type: 54 GoSliceHeaderType []string
         - Name: DNSNames
           Offset: 984
-          Type: 28 GoSliceHeaderType []string
+          Type: 54 GoSliceHeaderType []string
         - Name: EmailAddresses
           Offset: 1008
-          Type: 28 GoSliceHeaderType []string
+          Type: 54 GoSliceHeaderType []string
         - Name: IPAddresses
           Offset: 1032
-          Type: 93 GoSliceHeaderType []net.IP
+          Type: 116 GoSliceHeaderType []net.IP
         - Name: URIs
           Offset: 1056
-          Type: 96 GoSliceHeaderType []*net/url.URL
+          Type: 119 GoSliceHeaderType []*net/url.URL
         - Name: PermittedDNSDomainsCritical
           Offset: 1080
-          Type: 13 BaseType bool
+          Type: 4 BaseType bool
         - Name: PermittedDNSDomains
           Offset: 1088
-          Type: 28 GoSliceHeaderType []string
+          Type: 54 GoSliceHeaderType []string
         - Name: ExcludedDNSDomains
           Offset: 1112
-          Type: 28 GoSliceHeaderType []string
+          Type: 54 GoSliceHeaderType []string
         - Name: PermittedIPRanges
           Offset: 1136
-          Type: 98 GoSliceHeaderType []*net.IPNet
+          Type: 121 GoSliceHeaderType []*net.IPNet
         - Name: ExcludedIPRanges
           Offset: 1160
-          Type: 98 GoSliceHeaderType []*net.IPNet
+          Type: 121 GoSliceHeaderType []*net.IPNet
         - Name: PermittedEmailAddresses
           Offset: 1184
-          Type: 28 GoSliceHeaderType []string
+          Type: 54 GoSliceHeaderType []string
         - Name: ExcludedEmailAddresses
           Offset: 1208
-          Type: 28 GoSliceHeaderType []string
+          Type: 54 GoSliceHeaderType []string
         - Name: PermittedURIDomains
           Offset: 1232
-          Type: 28 GoSliceHeaderType []string
+          Type: 54 GoSliceHeaderType []string
         - Name: ExcludedURIDomains
           Offset: 1256
-          Type: 28 GoSliceHeaderType []string
+          Type: 54 GoSliceHeaderType []string
         - Name: CRLDistributionPoints
           Offset: 1280
-          Type: 28 GoSliceHeaderType []string
+          Type: 54 GoSliceHeaderType []string
         - Name: PolicyIdentifiers
           Offset: 1304
-          Type: 88 GoSliceHeaderType []encoding/asn1.ObjectIdentifier
+          Type: 111 GoSliceHeaderType []encoding/asn1.ObjectIdentifier
         - Name: Policies
           Offset: 1328
-          Type: 103 GoSliceHeaderType []crypto/x509.OID
+          Type: 126 GoSliceHeaderType []crypto/x509.OID
         - Name: InhibitAnyPolicy
           Offset: 1352
-          Type: 8 BaseType int
+          Type: 7 BaseType int
         - Name: InhibitAnyPolicyZero
           Offset: 1360
-          Type: 13 BaseType bool
+          Type: 4 BaseType bool
         - Name: InhibitPolicyMapping
           Offset: 1368
-          Type: 8 BaseType int
+          Type: 7 BaseType int
         - Name: InhibitPolicyMappingZero
           Offset: 1376
-          Type: 13 BaseType bool
+          Type: 4 BaseType bool
         - Name: RequireExplicitPolicy
           Offset: 1384
-          Type: 8 BaseType int
+          Type: 7 BaseType int
         - Name: RequireExplicitPolicyZero
           Offset: 1392
-          Type: 13 BaseType bool
+          Type: 4 BaseType bool
         - Name: PolicyMappings
           Offset: 1400
-          Type: 106 GoSliceHeaderType []crypto/x509.PolicyMapping
+          Type: 129 GoSliceHeaderType []crypto/x509.PolicyMapping
     - __kind: BaseType
-      ID: 92
+      ID: 115
       Name: crypto/x509.ExtKeyUsage
       ByteSize: 8
       GoRuntimeType: 587936
       GoKind: 2
     - __kind: BaseType
-      ID: 84
+      ID: 107
       Name: crypto/x509.KeyUsage
       ByteSize: 8
       GoRuntimeType: 587872
       GoKind: 2
     - __kind: StructureType
-      ID: 105
+      ID: 128
       Name: crypto/x509.OID
       ByteSize: 24
       GoRuntimeType: 1.953824e+06
@@ -1375,9 +1375,9 @@ Types:
       RawFields:
         - Name: der
           Offset: 0
-          Type: 53 GoSliceHeaderType []uint8
+          Type: 77 GoSliceHeaderType []uint8
     - __kind: StructureType
-      ID: 108
+      ID: 131
       Name: crypto/x509.PolicyMapping
       ByteSize: 48
       GoRuntimeType: 1.490528e+06
@@ -1385,24 +1385,24 @@ Types:
       RawFields:
         - Name: IssuerDomainPolicy
           Offset: 0
-          Type: 105 StructureType crypto/x509.OID
+          Type: 128 StructureType crypto/x509.OID
         - Name: SubjectDomainPolicy
           Offset: 24
-          Type: 105 StructureType crypto/x509.OID
+          Type: 128 StructureType crypto/x509.OID
     - __kind: BaseType
-      ID: 62
+      ID: 86
       Name: crypto/x509.PublicKeyAlgorithm
       ByteSize: 8
       GoRuntimeType: 837024
       GoKind: 2
     - __kind: BaseType
-      ID: 61
+      ID: 85
       Name: crypto/x509.SignatureAlgorithm
       ByteSize: 8
       GoRuntimeType: 1.113728e+06
       GoKind: 2
     - __kind: StructureType
-      ID: 72
+      ID: 96
       Name: crypto/x509/pkix.AttributeTypeAndValue
       ByteSize: 40
       GoRuntimeType: 1.502368e+06
@@ -1410,12 +1410,12 @@ Types:
       RawFields:
         - Name: Type
           Offset: 0
-          Type: 73 GoSliceHeaderType encoding/asn1.ObjectIdentifier
+          Type: 97 GoSliceHeaderType encoding/asn1.ObjectIdentifier
         - Name: Value
           Offset: 24
-          Type: 63 GoEmptyInterfaceType interface {}
+          Type: 87 GoEmptyInterfaceType interface {}
     - __kind: StructureType
-      ID: 87
+      ID: 110
       Name: crypto/x509/pkix.Extension
       ByteSize: 56
       GoRuntimeType: 1.646464e+06
@@ -1423,15 +1423,15 @@ Types:
       RawFields:
         - Name: Id
           Offset: 0
-          Type: 73 GoSliceHeaderType encoding/asn1.ObjectIdentifier
+          Type: 97 GoSliceHeaderType encoding/asn1.ObjectIdentifier
         - Name: Critical
           Offset: 24
-          Type: 13 BaseType bool
+          Type: 4 BaseType bool
         - Name: Value
           Offset: 32
-          Type: 53 GoSliceHeaderType []uint8
+          Type: 77 GoSliceHeaderType []uint8
     - __kind: StructureType
-      ID: 69
+      ID: 93
       Name: crypto/x509/pkix.Name
       ByteSize: 248
       GoRuntimeType: 2.192e+06
@@ -1439,39 +1439,39 @@ Types:
       RawFields:
         - Name: Country
           Offset: 0
-          Type: 28 GoSliceHeaderType []string
+          Type: 54 GoSliceHeaderType []string
         - Name: Organization
           Offset: 24
-          Type: 28 GoSliceHeaderType []string
+          Type: 54 GoSliceHeaderType []string
         - Name: OrganizationalUnit
           Offset: 48
-          Type: 28 GoSliceHeaderType []string
+          Type: 54 GoSliceHeaderType []string
         - Name: Locality
           Offset: 72
-          Type: 28 GoSliceHeaderType []string
+          Type: 54 GoSliceHeaderType []string
         - Name: Province
           Offset: 96
-          Type: 28 GoSliceHeaderType []string
+          Type: 54 GoSliceHeaderType []string
         - Name: StreetAddress
           Offset: 120
-          Type: 28 GoSliceHeaderType []string
+          Type: 54 GoSliceHeaderType []string
         - Name: PostalCode
           Offset: 144
-          Type: 28 GoSliceHeaderType []string
+          Type: 54 GoSliceHeaderType []string
         - Name: SerialNumber
           Offset: 168
-          Type: 5 GoStringHeaderType string
+          Type: 9 GoStringHeaderType string
         - Name: CommonName
           Offset: 184
-          Type: 5 GoStringHeaderType string
+          Type: 9 GoStringHeaderType string
         - Name: Names
           Offset: 200
-          Type: 70 GoSliceHeaderType []crypto/x509/pkix.AttributeTypeAndValue
+          Type: 94 GoSliceHeaderType []crypto/x509/pkix.AttributeTypeAndValue
         - Name: ExtraNames
           Offset: 224
-          Type: 70 GoSliceHeaderType []crypto/x509/pkix.AttributeTypeAndValue
+          Type: 94 GoSliceHeaderType []crypto/x509/pkix.AttributeTypeAndValue
     - __kind: GoSliceHeaderType
-      ID: 73
+      ID: 97
       Name: encoding/asn1.ObjectIdentifier
       ByteSize: 24
       GoRuntimeType: 1.052832e+06
@@ -1479,21 +1479,21 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 74 PointerType *int
+          Type: 27 PointerType *int
         - Name: len
           Offset: 8
-          Type: 8 BaseType int
+          Type: 7 BaseType int
         - Name: cap
           Offset: 16
-          Type: 8 BaseType int
+          Type: 7 BaseType int
       Data: 180 GoSliceDataType encoding/asn1.ObjectIdentifier.array
     - __kind: GoSliceDataType
       ID: 180
       Name: encoding/asn1.ObjectIdentifier.array
       ByteSize: 2048
-      Element: 8 BaseType int
+      Element: 7 BaseType int
     - __kind: GoInterfaceType
-      ID: 143
+      ID: 14
       Name: error
       ByteSize: 16
       GoRuntimeType: 1.031072e+06
@@ -1501,36 +1501,36 @@ Types:
       RawFields:
         - Name: tab
           Offset: 0
-          Type: 2 VoidPointerType unsafe.Pointer
+          Type: 15 VoidPointerType unsafe.Pointer
         - Name: data
           Offset: 8
-          Type: 2 VoidPointerType unsafe.Pointer
+          Type: 15 VoidPointerType unsafe.Pointer
     - __kind: BaseType
-      ID: 146
+      ID: 18
       Name: float32
       ByteSize: 4
       GoRuntimeType: 585120
       GoKind: 13
     - __kind: BaseType
-      ID: 144
+      ID: 16
       Name: float64
       ByteSize: 8
       GoRuntimeType: 585184
       GoKind: 14
     - __kind: GoSubroutineType
-      ID: 31
+      ID: 56
       Name: func() (io.ReadCloser, error)
       ByteSize: 8
       GoRuntimeType: 693216
       GoKind: 19
     - __kind: GoSubroutineType
-      ID: 113
+      ID: 136
       Name: func(string, []uint8, int) ([]uint8, error)
       ByteSize: 8
       GoRuntimeType: 1.002592e+06
       GoKind: 19
     - __kind: GoInterfaceType
-      ID: 138
+      ID: 161
       Name: gopkg.in/DataDog/dd-trace-go.v1/ddtrace.Span
       ByteSize: 16
       GoRuntimeType: 1.479008e+06
@@ -1538,84 +1538,84 @@ Types:
       RawFields:
         - Name: tab
           Offset: 0
-          Type: 2 VoidPointerType unsafe.Pointer
+          Type: 15 VoidPointerType unsafe.Pointer
         - Name: data
           Offset: 8
-          Type: 2 VoidPointerType unsafe.Pointer
+          Type: 15 VoidPointerType unsafe.Pointer
     - __kind: GoSwissMapGroupsType
-      ID: 43
+      ID: 67
       Name: groupReference<string,[]*mime/multipart.FileHeader>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 44 PointerType *noalg.map.group[string][]*mime/multipart.FileHeader
+          Type: 68 PointerType *noalg.map.group[string][]*mime/multipart.FileHeader
         - Name: lengthMask
           Offset: 8
-          Type: 17 BaseType uint64
-      GroupType: 45 StructureType noalg.map.group[string][]*mime/multipart.FileHeader
+          Type: 8 BaseType uint64
+      GroupType: 69 StructureType noalg.map.group[string][]*mime/multipart.FileHeader
       GroupSliceType: 169 GoSliceDataType []noalg.map.group[string][]*mime/multipart.FileHeader.array
     - __kind: GoSwissMapGroupsType
-      ID: 23
+      ID: 49
       Name: groupReference<string,[]string>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 24 PointerType *noalg.map.group[string][]string
+          Type: 50 PointerType *noalg.map.group[string][]string
         - Name: lengthMask
           Offset: 8
-          Type: 17 BaseType uint64
-      GroupType: 25 StructureType noalg.map.group[string][]string
+          Type: 8 BaseType uint64
+      GroupType: 51 StructureType noalg.map.group[string][]string
       GroupSliceType: 165 GoSliceDataType []noalg.map.group[string][]string.array
     - __kind: GoSwissMapGroupsType
-      ID: 130
+      ID: 153
       Name: groupReference<string,string>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 131 PointerType *noalg.map.group[string]string
+          Type: 154 PointerType *noalg.map.group[string]string
         - Name: lengthMask
           Offset: 8
-          Type: 17 BaseType uint64
-      GroupType: 132 StructureType noalg.map.group[string]string
+          Type: 8 BaseType uint64
+      GroupType: 155 StructureType noalg.map.group[string]string
       GroupSliceType: 213 GoSliceDataType []noalg.map.group[string]string.array
     - __kind: BaseType
-      ID: 8
+      ID: 7
       Name: int
       ByteSize: 8
       GoRuntimeType: 584800
       GoKind: 2
     - __kind: BaseType
-      ID: 150
+      ID: 23
       Name: int16
       ByteSize: 2
       GoRuntimeType: 584416
       GoKind: 4
     - __kind: BaseType
-      ID: 142
+      ID: 12
       Name: int32
       ByteSize: 4
       GoRuntimeType: 584544
       GoKind: 5
     - __kind: BaseType
-      ID: 32
+      ID: 13
       Name: int64
       ByteSize: 8
       GoRuntimeType: 584672
       GoKind: 6
     - __kind: BaseType
-      ID: 145
+      ID: 17
       Name: int8
       ByteSize: 1
       GoRuntimeType: 584288
       GoKind: 3
     - __kind: GoEmptyInterfaceType
-      ID: 63
+      ID: 87
       Name: interface {}
       ByteSize: 16
       GoRuntimeType: 854240
@@ -1623,12 +1623,12 @@ Types:
       RawFields:
         - Name: _type
           Offset: 0
-          Type: 2 VoidPointerType unsafe.Pointer
+          Type: 15 VoidPointerType unsafe.Pointer
         - Name: data
           Offset: 8
-          Type: 2 VoidPointerType unsafe.Pointer
+          Type: 15 VoidPointerType unsafe.Pointer
     - __kind: GoInterfaceType
-      ID: 30
+      ID: 55
       Name: io.ReadCloser
       ByteSize: 16
       GoRuntimeType: 1.10976e+06
@@ -1636,138 +1636,138 @@ Types:
       RawFields:
         - Name: tab
           Offset: 0
-          Type: 2 VoidPointerType unsafe.Pointer
+          Type: 15 VoidPointerType unsafe.Pointer
         - Name: data
           Offset: 8
-          Type: 2 VoidPointerType unsafe.Pointer
+          Type: 15 VoidPointerType unsafe.Pointer
     - __kind: GoSwissMapHeaderType
-      ID: 39
+      ID: 63
       Name: map<string,[]*mime/multipart.FileHeader>
       ByteSize: 48
       GoKind: 25
       RawFields:
         - Name: used
           Offset: 0
-          Type: 17 BaseType uint64
+          Type: 8 BaseType uint64
         - Name: seed
           Offset: 8
-          Type: 18 BaseType uintptr
+          Type: 1 BaseType uintptr
         - Name: dirPtr
           Offset: 16
-          Type: 40 PointerType **table<string,[]*mime/multipart.FileHeader>
+          Type: 64 PointerType **table<string,[]*mime/multipart.FileHeader>
         - Name: dirLen
           Offset: 24
-          Type: 8 BaseType int
+          Type: 7 BaseType int
         - Name: globalDepth
           Offset: 32
-          Type: 7 BaseType uint8
+          Type: 3 BaseType uint8
         - Name: globalShift
           Offset: 33
-          Type: 7 BaseType uint8
+          Type: 3 BaseType uint8
         - Name: writing
           Offset: 34
-          Type: 7 BaseType uint8
+          Type: 3 BaseType uint8
         - Name: tombstonePossible
           Offset: 35
-          Type: 13 BaseType bool
+          Type: 4 BaseType bool
         - Name: clearSeq
           Offset: 40
-          Type: 17 BaseType uint64
+          Type: 8 BaseType uint64
       TablePtrSliceType: 168 GoSliceDataType []*table<string,[]*mime/multipart.FileHeader>.array
-      GroupType: 45 StructureType noalg.map.group[string][]*mime/multipart.FileHeader
+      GroupType: 69 StructureType noalg.map.group[string][]*mime/multipart.FileHeader
     - __kind: GoSwissMapHeaderType
-      ID: 16
+      ID: 45
       Name: map<string,[]string>
       ByteSize: 48
       GoKind: 25
       RawFields:
         - Name: used
           Offset: 0
-          Type: 17 BaseType uint64
+          Type: 8 BaseType uint64
         - Name: seed
           Offset: 8
-          Type: 18 BaseType uintptr
+          Type: 1 BaseType uintptr
         - Name: dirPtr
           Offset: 16
-          Type: 19 PointerType **table<string,[]string>
+          Type: 46 PointerType **table<string,[]string>
         - Name: dirLen
           Offset: 24
-          Type: 8 BaseType int
+          Type: 7 BaseType int
         - Name: globalDepth
           Offset: 32
-          Type: 7 BaseType uint8
+          Type: 3 BaseType uint8
         - Name: globalShift
           Offset: 33
-          Type: 7 BaseType uint8
+          Type: 3 BaseType uint8
         - Name: writing
           Offset: 34
-          Type: 7 BaseType uint8
+          Type: 3 BaseType uint8
         - Name: tombstonePossible
           Offset: 35
-          Type: 13 BaseType bool
+          Type: 4 BaseType bool
         - Name: clearSeq
           Offset: 40
-          Type: 17 BaseType uint64
+          Type: 8 BaseType uint64
       TablePtrSliceType: 164 GoSliceDataType []*table<string,[]string>.array
-      GroupType: 25 StructureType noalg.map.group[string][]string
+      GroupType: 51 StructureType noalg.map.group[string][]string
     - __kind: GoSwissMapHeaderType
-      ID: 126
+      ID: 149
       Name: map<string,string>
       ByteSize: 48
       GoKind: 25
       RawFields:
         - Name: used
           Offset: 0
-          Type: 17 BaseType uint64
+          Type: 8 BaseType uint64
         - Name: seed
           Offset: 8
-          Type: 18 BaseType uintptr
+          Type: 1 BaseType uintptr
         - Name: dirPtr
           Offset: 16
-          Type: 127 PointerType **table<string,string>
+          Type: 150 PointerType **table<string,string>
         - Name: dirLen
           Offset: 24
-          Type: 8 BaseType int
+          Type: 7 BaseType int
         - Name: globalDepth
           Offset: 32
-          Type: 7 BaseType uint8
+          Type: 3 BaseType uint8
         - Name: globalShift
           Offset: 33
-          Type: 7 BaseType uint8
+          Type: 3 BaseType uint8
         - Name: writing
           Offset: 34
-          Type: 7 BaseType uint8
+          Type: 3 BaseType uint8
         - Name: tombstonePossible
           Offset: 35
-          Type: 13 BaseType bool
+          Type: 4 BaseType bool
         - Name: clearSeq
           Offset: 40
-          Type: 17 BaseType uint64
+          Type: 8 BaseType uint64
       TablePtrSliceType: 212 GoSliceDataType []*table<string,string>.array
-      GroupType: 132 StructureType noalg.map.group[string]string
+      GroupType: 155 StructureType noalg.map.group[string]string
     - __kind: GoMapType
-      ID: 37
+      ID: 61
       Name: map[string][]*mime/multipart.FileHeader
       ByteSize: 8
       GoRuntimeType: 1.131648e+06
       GoKind: 21
-      HeaderType: 39 GoSwissMapHeaderType map<string,[]*mime/multipart.FileHeader>
+      HeaderType: 63 GoSwissMapHeaderType map<string,[]*mime/multipart.FileHeader>
     - __kind: GoMapType
-      ID: 36
+      ID: 60
       Name: map[string][]string
       ByteSize: 8
       GoRuntimeType: 1.127296e+06
       GoKind: 21
-      HeaderType: 16 GoSwissMapHeaderType map<string,[]string>
+      HeaderType: 45 GoSwissMapHeaderType map<string,[]string>
     - __kind: GoMapType
-      ID: 124
+      ID: 147
       Name: map[string]string
       ByteSize: 8
       GoRuntimeType: 1.12832e+06
       GoKind: 21
-      HeaderType: 126 GoSwissMapHeaderType map<string,string>
+      HeaderType: 149 GoSwissMapHeaderType map<string,string>
     - __kind: StructureType
-      ID: 65
+      ID: 89
       Name: math/big.Int
       ByteSize: 32
       GoRuntimeType: 1.493568e+06
@@ -1775,18 +1775,18 @@ Types:
       RawFields:
         - Name: neg
           Offset: 0
-          Type: 13 BaseType bool
+          Type: 4 BaseType bool
         - Name: abs
           Offset: 8
-          Type: 66 GoSliceHeaderType math/big.nat
+          Type: 90 GoSliceHeaderType math/big.nat
     - __kind: BaseType
-      ID: 68
+      ID: 92
       Name: math/big.Word
       ByteSize: 8
       GoRuntimeType: 588128
       GoKind: 7
     - __kind: GoSliceHeaderType
-      ID: 66
+      ID: 90
       Name: math/big.nat
       ByteSize: 24
       GoRuntimeType: 2.361088e+06
@@ -1794,21 +1794,21 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 67 PointerType *math/big.Word
+          Type: 91 PointerType *math/big.Word
         - Name: len
           Offset: 8
-          Type: 8 BaseType int
+          Type: 7 BaseType int
         - Name: cap
           Offset: 16
-          Type: 8 BaseType int
+          Type: 7 BaseType int
       Data: 176 GoSliceDataType math/big.nat.array
     - __kind: GoSliceDataType
       ID: 176
       Name: math/big.nat.array
       ByteSize: 2048
-      Element: 68 BaseType math/big.Word
+      Element: 92 BaseType math/big.Word
     - __kind: StructureType
-      ID: 51
+      ID: 75
       Name: mime/multipart.FileHeader
       ByteSize: 88
       GoRuntimeType: 1.977088e+06
@@ -1816,27 +1816,27 @@ Types:
       RawFields:
         - Name: Filename
           Offset: 0
-          Type: 5 GoStringHeaderType string
+          Type: 9 GoStringHeaderType string
         - Name: Header
           Offset: 16
-          Type: 52 GoMapType net/textproto.MIMEHeader
+          Type: 76 GoMapType net/textproto.MIMEHeader
         - Name: Size
           Offset: 24
-          Type: 32 BaseType int64
+          Type: 13 BaseType int64
         - Name: content
           Offset: 32
-          Type: 53 GoSliceHeaderType []uint8
+          Type: 77 GoSliceHeaderType []uint8
         - Name: tmpfile
           Offset: 56
-          Type: 5 GoStringHeaderType string
+          Type: 9 GoStringHeaderType string
         - Name: tmpoff
           Offset: 72
-          Type: 32 BaseType int64
+          Type: 13 BaseType int64
         - Name: tmpshared
           Offset: 80
-          Type: 13 BaseType bool
+          Type: 4 BaseType bool
     - __kind: StructureType
-      ID: 35
+      ID: 59
       Name: mime/multipart.Form
       ByteSize: 16
       GoRuntimeType: 1.477408e+06
@@ -1844,12 +1844,12 @@ Types:
       RawFields:
         - Name: Value
           Offset: 0
-          Type: 36 GoMapType map[string][]string
+          Type: 60 GoMapType map[string][]string
         - Name: File
           Offset: 8
-          Type: 37 GoMapType map[string][]*mime/multipart.FileHeader
+          Type: 61 GoMapType map[string][]*mime/multipart.FileHeader
     - __kind: GoSliceHeaderType
-      ID: 95
+      ID: 118
       Name: net.IP
       ByteSize: 24
       GoRuntimeType: 2.123744e+06
@@ -1857,21 +1857,21 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 6 PointerType *uint8
+          Type: 5 PointerType *uint8
         - Name: len
           Offset: 8
-          Type: 8 BaseType int
+          Type: 7 BaseType int
         - Name: cap
           Offset: 16
-          Type: 8 BaseType int
+          Type: 7 BaseType int
       Data: 194 GoSliceDataType net.IP.array
     - __kind: GoSliceDataType
       ID: 194
       Name: net.IP.array
       ByteSize: 2048
-      Element: 7 BaseType uint8
+      Element: 3 BaseType uint8
     - __kind: GoSliceHeaderType
-      ID: 102
+      ID: 125
       Name: net.IPMask
       ByteSize: 24
       GoRuntimeType: 1.01904e+06
@@ -1879,21 +1879,21 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 6 PointerType *uint8
+          Type: 5 PointerType *uint8
         - Name: len
           Offset: 8
-          Type: 8 BaseType int
+          Type: 7 BaseType int
         - Name: cap
           Offset: 16
-          Type: 8 BaseType int
+          Type: 7 BaseType int
       Data: 200 GoSliceDataType net.IPMask.array
     - __kind: GoSliceDataType
       ID: 200
       Name: net.IPMask.array
       ByteSize: 2048
-      Element: 7 BaseType uint8
+      Element: 3 BaseType uint8
     - __kind: StructureType
-      ID: 101
+      ID: 124
       Name: net.IPNet
       ByteSize: 48
       GoRuntimeType: 1.458208e+06
@@ -1901,19 +1901,19 @@ Types:
       RawFields:
         - Name: IP
           Offset: 0
-          Type: 95 GoSliceHeaderType net.IP
+          Type: 118 GoSliceHeaderType net.IP
         - Name: Mask
           Offset: 24
-          Type: 102 GoSliceHeaderType net.IPMask
+          Type: 125 GoSliceHeaderType net.IPMask
     - __kind: GoMapType
-      ID: 14
+      ID: 43
       Name: net/http.Header
       ByteSize: 8
       GoRuntimeType: 2.100864e+06
       GoKind: 21
-      HeaderType: 16 GoSwissMapHeaderType map<string,[]string>
+      HeaderType: 45 GoSwissMapHeaderType map<string,[]string>
     - __kind: StructureType
-      ID: 4
+      ID: 38
       Name: net/http.Request
       ByteSize: 304
       GoRuntimeType: 2.336064e+06
@@ -1921,84 +1921,84 @@ Types:
       RawFields:
         - Name: Method
           Offset: 0
-          Type: 5 GoStringHeaderType string
+          Type: 9 GoStringHeaderType string
         - Name: URL
           Offset: 16
-          Type: 9 PointerType *net/url.URL
+          Type: 39 PointerType *net/url.URL
         - Name: Proto
           Offset: 24
-          Type: 5 GoStringHeaderType string
+          Type: 9 GoStringHeaderType string
         - Name: ProtoMajor
           Offset: 40
-          Type: 8 BaseType int
+          Type: 7 BaseType int
         - Name: ProtoMinor
           Offset: 48
-          Type: 8 BaseType int
+          Type: 7 BaseType int
         - Name: Header
           Offset: 56
-          Type: 14 GoMapType net/http.Header
+          Type: 43 GoMapType net/http.Header
         - Name: Body
           Offset: 64
-          Type: 30 GoInterfaceType io.ReadCloser
+          Type: 55 GoInterfaceType io.ReadCloser
         - Name: GetBody
           Offset: 80
-          Type: 31 GoSubroutineType func() (io.ReadCloser, error)
+          Type: 56 GoSubroutineType func() (io.ReadCloser, error)
         - Name: ContentLength
           Offset: 88
-          Type: 32 BaseType int64
+          Type: 13 BaseType int64
         - Name: TransferEncoding
           Offset: 96
-          Type: 28 GoSliceHeaderType []string
+          Type: 54 GoSliceHeaderType []string
         - Name: Close
           Offset: 120
-          Type: 13 BaseType bool
+          Type: 4 BaseType bool
         - Name: Host
           Offset: 128
-          Type: 5 GoStringHeaderType string
+          Type: 9 GoStringHeaderType string
         - Name: Form
           Offset: 144
-          Type: 33 GoMapType net/url.Values
+          Type: 57 GoMapType net/url.Values
         - Name: PostForm
           Offset: 152
-          Type: 33 GoMapType net/url.Values
+          Type: 57 GoMapType net/url.Values
         - Name: MultipartForm
           Offset: 160
-          Type: 34 PointerType *mime/multipart.Form
+          Type: 58 PointerType *mime/multipart.Form
         - Name: Trailer
           Offset: 168
-          Type: 14 GoMapType net/http.Header
+          Type: 43 GoMapType net/http.Header
         - Name: RemoteAddr
           Offset: 176
-          Type: 5 GoStringHeaderType string
+          Type: 9 GoStringHeaderType string
         - Name: RequestURI
           Offset: 192
-          Type: 5 GoStringHeaderType string
+          Type: 9 GoStringHeaderType string
         - Name: TLS
           Offset: 208
-          Type: 54 PointerType *crypto/tls.ConnectionState
+          Type: 78 PointerType *crypto/tls.ConnectionState
         - Name: Cancel
           Offset: 216
-          Type: 115 GoChannelType <-chan struct {}
+          Type: 138 GoChannelType <-chan struct {}
         - Name: Response
           Offset: 224
-          Type: 116 PointerType *net/http.Response
+          Type: 139 PointerType *net/http.Response
         - Name: Pattern
           Offset: 232
-          Type: 5 GoStringHeaderType string
+          Type: 9 GoStringHeaderType string
         - Name: ctx
           Offset: 248
-          Type: 118 GoInterfaceType context.Context
+          Type: 141 GoInterfaceType context.Context
         - Name: pat
           Offset: 264
-          Type: 119 PointerType *net/http.pattern
+          Type: 142 PointerType *net/http.pattern
         - Name: matches
           Offset: 272
-          Type: 28 GoSliceHeaderType []string
+          Type: 54 GoSliceHeaderType []string
         - Name: otherValues
           Offset: 296
-          Type: 124 GoMapType map[string]string
+          Type: 147 GoMapType map[string]string
     - __kind: StructureType
-      ID: 117
+      ID: 140
       Name: net/http.Response
       ByteSize: 144
       GoRuntimeType: 2.209888e+06
@@ -2006,48 +2006,48 @@ Types:
       RawFields:
         - Name: Status
           Offset: 0
-          Type: 5 GoStringHeaderType string
+          Type: 9 GoStringHeaderType string
         - Name: StatusCode
           Offset: 16
-          Type: 8 BaseType int
+          Type: 7 BaseType int
         - Name: Proto
           Offset: 24
-          Type: 5 GoStringHeaderType string
+          Type: 9 GoStringHeaderType string
         - Name: ProtoMajor
           Offset: 40
-          Type: 8 BaseType int
+          Type: 7 BaseType int
         - Name: ProtoMinor
           Offset: 48
-          Type: 8 BaseType int
+          Type: 7 BaseType int
         - Name: Header
           Offset: 56
-          Type: 14 GoMapType net/http.Header
+          Type: 43 GoMapType net/http.Header
         - Name: Body
           Offset: 64
-          Type: 30 GoInterfaceType io.ReadCloser
+          Type: 55 GoInterfaceType io.ReadCloser
         - Name: ContentLength
           Offset: 80
-          Type: 32 BaseType int64
+          Type: 13 BaseType int64
         - Name: TransferEncoding
           Offset: 88
-          Type: 28 GoSliceHeaderType []string
+          Type: 54 GoSliceHeaderType []string
         - Name: Close
           Offset: 112
-          Type: 13 BaseType bool
+          Type: 4 BaseType bool
         - Name: Uncompressed
           Offset: 113
-          Type: 13 BaseType bool
+          Type: 4 BaseType bool
         - Name: Trailer
           Offset: 120
-          Type: 14 GoMapType net/http.Header
+          Type: 43 GoMapType net/http.Header
         - Name: Request
           Offset: 128
-          Type: 3 PointerType *net/http.Request
+          Type: 37 PointerType *net/http.Request
         - Name: TLS
           Offset: 136
-          Type: 54 PointerType *crypto/tls.ConnectionState
+          Type: 78 PointerType *crypto/tls.ConnectionState
     - __kind: GoInterfaceType
-      ID: 1
+      ID: 36
       Name: net/http.ResponseWriter
       ByteSize: 16
       GoRuntimeType: 1.185088e+06
@@ -2055,12 +2055,12 @@ Types:
       RawFields:
         - Name: tab
           Offset: 0
-          Type: 2 VoidPointerType unsafe.Pointer
+          Type: 15 VoidPointerType unsafe.Pointer
         - Name: data
           Offset: 8
-          Type: 2 VoidPointerType unsafe.Pointer
+          Type: 15 VoidPointerType unsafe.Pointer
     - __kind: StructureType
-      ID: 120
+      ID: 143
       Name: net/http.pattern
       ByteSize: 88
       GoRuntimeType: 1.833088e+06
@@ -2068,21 +2068,21 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 5 GoStringHeaderType string
+          Type: 9 GoStringHeaderType string
         - Name: method
           Offset: 16
-          Type: 5 GoStringHeaderType string
+          Type: 9 GoStringHeaderType string
         - Name: host
           Offset: 32
-          Type: 5 GoStringHeaderType string
+          Type: 9 GoStringHeaderType string
         - Name: segments
           Offset: 48
-          Type: 121 GoSliceHeaderType []net/http.segment
+          Type: 144 GoSliceHeaderType []net/http.segment
         - Name: loc
           Offset: 72
-          Type: 5 GoStringHeaderType string
+          Type: 9 GoStringHeaderType string
     - __kind: StructureType
-      ID: 123
+      ID: 146
       Name: net/http.segment
       ByteSize: 24
       GoRuntimeType: 1.607872e+06
@@ -2090,22 +2090,22 @@ Types:
       RawFields:
         - Name: s
           Offset: 0
-          Type: 5 GoStringHeaderType string
+          Type: 9 GoStringHeaderType string
         - Name: wild
           Offset: 16
-          Type: 13 BaseType bool
+          Type: 4 BaseType bool
         - Name: multi
           Offset: 17
-          Type: 13 BaseType bool
+          Type: 4 BaseType bool
     - __kind: GoMapType
-      ID: 52
+      ID: 76
       Name: net/textproto.MIMEHeader
       ByteSize: 8
       GoRuntimeType: 1.82304e+06
       GoKind: 21
-      HeaderType: 16 GoSwissMapHeaderType map<string,[]string>
+      HeaderType: 45 GoSwissMapHeaderType map<string,[]string>
     - __kind: StructureType
-      ID: 10
+      ID: 40
       Name: net/url.URL
       ByteSize: 144
       GoRuntimeType: 2.126816e+06
@@ -2113,39 +2113,39 @@ Types:
       RawFields:
         - Name: Scheme
           Offset: 0
-          Type: 5 GoStringHeaderType string
+          Type: 9 GoStringHeaderType string
         - Name: Opaque
           Offset: 16
-          Type: 5 GoStringHeaderType string
+          Type: 9 GoStringHeaderType string
         - Name: User
           Offset: 32
-          Type: 11 PointerType *net/url.Userinfo
+          Type: 41 PointerType *net/url.Userinfo
         - Name: Host
           Offset: 40
-          Type: 5 GoStringHeaderType string
+          Type: 9 GoStringHeaderType string
         - Name: Path
           Offset: 56
-          Type: 5 GoStringHeaderType string
+          Type: 9 GoStringHeaderType string
         - Name: RawPath
           Offset: 72
-          Type: 5 GoStringHeaderType string
+          Type: 9 GoStringHeaderType string
         - Name: OmitHost
           Offset: 88
-          Type: 13 BaseType bool
+          Type: 4 BaseType bool
         - Name: ForceQuery
           Offset: 89
-          Type: 13 BaseType bool
+          Type: 4 BaseType bool
         - Name: RawQuery
           Offset: 96
-          Type: 5 GoStringHeaderType string
+          Type: 9 GoStringHeaderType string
         - Name: Fragment
           Offset: 112
-          Type: 5 GoStringHeaderType string
+          Type: 9 GoStringHeaderType string
         - Name: RawFragment
           Offset: 128
-          Type: 5 GoStringHeaderType string
+          Type: 9 GoStringHeaderType string
     - __kind: StructureType
-      ID: 12
+      ID: 42
       Name: net/url.Userinfo
       ByteSize: 40
       GoRuntimeType: 1.624384e+06
@@ -2153,49 +2153,49 @@ Types:
       RawFields:
         - Name: username
           Offset: 0
-          Type: 5 GoStringHeaderType string
+          Type: 9 GoStringHeaderType string
         - Name: password
           Offset: 16
-          Type: 5 GoStringHeaderType string
+          Type: 9 GoStringHeaderType string
         - Name: passwordSet
           Offset: 32
-          Type: 13 BaseType bool
+          Type: 4 BaseType bool
     - __kind: GoMapType
-      ID: 33
+      ID: 57
       Name: net/url.Values
       ByteSize: 8
       GoRuntimeType: 1.884384e+06
       GoKind: 21
-      HeaderType: 16 GoSwissMapHeaderType map<string,[]string>
+      HeaderType: 45 GoSwissMapHeaderType map<string,[]string>
     - __kind: ArrayType
-      ID: 46
+      ID: 70
       Name: noalg.[8]struct { key string; elem []*mime/multipart.FileHeader }
       ByteSize: 320
       GoRuntimeType: 699072
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 47 StructureType noalg.struct { key string; elem []*mime/multipart.FileHeader }
+      Element: 71 StructureType noalg.struct { key string; elem []*mime/multipart.FileHeader }
     - __kind: ArrayType
-      ID: 26
+      ID: 52
       Name: noalg.[8]struct { key string; elem []string }
       ByteSize: 320
       GoRuntimeType: 689248
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 27 StructureType noalg.struct { key string; elem []string }
+      Element: 53 StructureType noalg.struct { key string; elem []string }
     - __kind: ArrayType
-      ID: 133
+      ID: 156
       Name: noalg.[8]struct { key string; elem string }
       ByteSize: 256
       GoRuntimeType: 693408
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 134 StructureType noalg.struct { key string; elem string }
+      Element: 157 StructureType noalg.struct { key string; elem string }
     - __kind: StructureType
-      ID: 45
+      ID: 69
       Name: noalg.map.group[string][]*mime/multipart.FileHeader
       ByteSize: 328
       GoRuntimeType: 1.298816e+06
@@ -2203,12 +2203,12 @@ Types:
       RawFields:
         - Name: ctrl
           Offset: 0
-          Type: 17 BaseType uint64
+          Type: 8 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 46 ArrayType noalg.[8]struct { key string; elem []*mime/multipart.FileHeader }
+          Type: 70 ArrayType noalg.[8]struct { key string; elem []*mime/multipart.FileHeader }
     - __kind: StructureType
-      ID: 25
+      ID: 51
       Name: noalg.map.group[string][]string
       ByteSize: 328
       GoRuntimeType: 1.289728e+06
@@ -2216,12 +2216,12 @@ Types:
       RawFields:
         - Name: ctrl
           Offset: 0
-          Type: 17 BaseType uint64
+          Type: 8 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 26 ArrayType noalg.[8]struct { key string; elem []string }
+          Type: 52 ArrayType noalg.[8]struct { key string; elem []string }
     - __kind: StructureType
-      ID: 132
+      ID: 155
       Name: noalg.map.group[string]string
       ByteSize: 264
       GoRuntimeType: 1.29216e+06
@@ -2229,12 +2229,12 @@ Types:
       RawFields:
         - Name: ctrl
           Offset: 0
-          Type: 17 BaseType uint64
+          Type: 8 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 133 ArrayType noalg.[8]struct { key string; elem string }
+          Type: 156 ArrayType noalg.[8]struct { key string; elem string }
     - __kind: StructureType
-      ID: 47
+      ID: 71
       Name: noalg.struct { key string; elem []*mime/multipart.FileHeader }
       ByteSize: 40
       GoRuntimeType: 1.298688e+06
@@ -2242,12 +2242,12 @@ Types:
       RawFields:
         - Name: key
           Offset: 0
-          Type: 5 GoStringHeaderType string
+          Type: 9 GoStringHeaderType string
         - Name: elem
           Offset: 16
-          Type: 48 GoSliceHeaderType []*mime/multipart.FileHeader
+          Type: 72 GoSliceHeaderType []*mime/multipart.FileHeader
     - __kind: StructureType
-      ID: 27
+      ID: 53
       Name: noalg.struct { key string; elem []string }
       ByteSize: 40
       GoRuntimeType: 1.2896e+06
@@ -2255,12 +2255,12 @@ Types:
       RawFields:
         - Name: key
           Offset: 0
-          Type: 5 GoStringHeaderType string
+          Type: 9 GoStringHeaderType string
         - Name: elem
           Offset: 16
-          Type: 28 GoSliceHeaderType []string
+          Type: 54 GoSliceHeaderType []string
     - __kind: StructureType
-      ID: 134
+      ID: 157
       Name: noalg.struct { key string; elem string }
       ByteSize: 32
       GoRuntimeType: 1.292032e+06
@@ -2268,12 +2268,12 @@ Types:
       RawFields:
         - Name: key
           Offset: 0
-          Type: 5 GoStringHeaderType string
+          Type: 9 GoStringHeaderType string
         - Name: elem
           Offset: 16
-          Type: 5 GoStringHeaderType string
+          Type: 9 GoStringHeaderType string
     - __kind: GoStringHeaderType
-      ID: 5
+      ID: 9
       Name: string
       ByteSize: 16
       GoRuntimeType: 584224
@@ -2284,86 +2284,86 @@ Types:
           Type: 163 PointerType *string.str
         - Name: len
           Offset: 8
-          Type: 8 BaseType int
+          Type: 7 BaseType int
       Data: 162 GoStringDataType string.str
     - __kind: GoStringDataType
       ID: 162
       Name: string.str
       ByteSize: 2048
     - __kind: StructureType
-      ID: 42
+      ID: 66
       Name: table<string,[]*mime/multipart.FileHeader>
       ByteSize: 32
       GoKind: 25
       RawFields:
         - Name: used
           Offset: 0
-          Type: 22 BaseType uint16
+          Type: 6 BaseType uint16
         - Name: capacity
           Offset: 2
-          Type: 22 BaseType uint16
+          Type: 6 BaseType uint16
         - Name: growthLeft
           Offset: 4
-          Type: 22 BaseType uint16
+          Type: 6 BaseType uint16
         - Name: localDepth
           Offset: 6
-          Type: 7 BaseType uint8
+          Type: 3 BaseType uint8
         - Name: index
           Offset: 8
-          Type: 8 BaseType int
+          Type: 7 BaseType int
         - Name: groups
           Offset: 16
-          Type: 43 GoSwissMapGroupsType groupReference<string,[]*mime/multipart.FileHeader>
+          Type: 67 GoSwissMapGroupsType groupReference<string,[]*mime/multipart.FileHeader>
     - __kind: StructureType
-      ID: 21
+      ID: 48
       Name: table<string,[]string>
       ByteSize: 32
       GoKind: 25
       RawFields:
         - Name: used
           Offset: 0
-          Type: 22 BaseType uint16
+          Type: 6 BaseType uint16
         - Name: capacity
           Offset: 2
-          Type: 22 BaseType uint16
+          Type: 6 BaseType uint16
         - Name: growthLeft
           Offset: 4
-          Type: 22 BaseType uint16
+          Type: 6 BaseType uint16
         - Name: localDepth
           Offset: 6
-          Type: 7 BaseType uint8
+          Type: 3 BaseType uint8
         - Name: index
           Offset: 8
-          Type: 8 BaseType int
+          Type: 7 BaseType int
         - Name: groups
           Offset: 16
-          Type: 23 GoSwissMapGroupsType groupReference<string,[]string>
+          Type: 49 GoSwissMapGroupsType groupReference<string,[]string>
     - __kind: StructureType
-      ID: 129
+      ID: 152
       Name: table<string,string>
       ByteSize: 32
       GoKind: 25
       RawFields:
         - Name: used
           Offset: 0
-          Type: 22 BaseType uint16
+          Type: 6 BaseType uint16
         - Name: capacity
           Offset: 2
-          Type: 22 BaseType uint16
+          Type: 6 BaseType uint16
         - Name: growthLeft
           Offset: 4
-          Type: 22 BaseType uint16
+          Type: 6 BaseType uint16
         - Name: localDepth
           Offset: 6
-          Type: 7 BaseType uint8
+          Type: 3 BaseType uint8
         - Name: index
           Offset: 8
-          Type: 8 BaseType int
+          Type: 7 BaseType int
         - Name: groups
           Offset: 16
-          Type: 130 GoSwissMapGroupsType groupReference<string,string>
+          Type: 153 GoSwissMapGroupsType groupReference<string,string>
     - __kind: StructureType
-      ID: 77
+      ID: 100
       Name: time.Location
       ByteSize: 104
       GoRuntimeType: 1.972768e+06
@@ -2371,27 +2371,27 @@ Types:
       RawFields:
         - Name: name
           Offset: 0
-          Type: 5 GoStringHeaderType string
+          Type: 9 GoStringHeaderType string
         - Name: zone
           Offset: 16
-          Type: 78 GoSliceHeaderType []time.zone
+          Type: 101 GoSliceHeaderType []time.zone
         - Name: tx
           Offset: 40
-          Type: 81 GoSliceHeaderType []time.zoneTrans
+          Type: 104 GoSliceHeaderType []time.zoneTrans
         - Name: extend
           Offset: 64
-          Type: 5 GoStringHeaderType string
+          Type: 9 GoStringHeaderType string
         - Name: cacheStart
           Offset: 80
-          Type: 32 BaseType int64
+          Type: 13 BaseType int64
         - Name: cacheEnd
           Offset: 88
-          Type: 32 BaseType int64
+          Type: 13 BaseType int64
         - Name: cacheZone
           Offset: 96
-          Type: 79 PointerType *time.zone
+          Type: 102 PointerType *time.zone
     - __kind: StructureType
-      ID: 75
+      ID: 98
       Name: time.Time
       ByteSize: 24
       GoRuntimeType: 2.363936e+06
@@ -2399,15 +2399,15 @@ Types:
       RawFields:
         - Name: wall
           Offset: 0
-          Type: 17 BaseType uint64
+          Type: 8 BaseType uint64
         - Name: ext
           Offset: 8
-          Type: 32 BaseType int64
+          Type: 13 BaseType int64
         - Name: loc
           Offset: 16
-          Type: 76 PointerType *time.Location
+          Type: 99 PointerType *time.Location
     - __kind: StructureType
-      ID: 80
+      ID: 103
       Name: time.zone
       ByteSize: 32
       GoRuntimeType: 1.612864e+06
@@ -2415,15 +2415,15 @@ Types:
       RawFields:
         - Name: name
           Offset: 0
-          Type: 5 GoStringHeaderType string
+          Type: 9 GoStringHeaderType string
         - Name: offset
           Offset: 16
-          Type: 8 BaseType int
+          Type: 7 BaseType int
         - Name: isDST
           Offset: 24
-          Type: 13 BaseType bool
+          Type: 4 BaseType bool
     - __kind: StructureType
-      ID: 83
+      ID: 106
       Name: time.zoneTrans
       ByteSize: 16
       GoRuntimeType: 1.750304e+06
@@ -2431,54 +2431,54 @@ Types:
       RawFields:
         - Name: when
           Offset: 0
-          Type: 32 BaseType int64
+          Type: 13 BaseType int64
         - Name: index
           Offset: 8
-          Type: 7 BaseType uint8
+          Type: 3 BaseType uint8
         - Name: isstd
           Offset: 9
-          Type: 13 BaseType bool
+          Type: 4 BaseType bool
         - Name: isutc
           Offset: 10
-          Type: 13 BaseType bool
+          Type: 4 BaseType bool
     - __kind: BaseType
-      ID: 140
+      ID: 10
       Name: uint
       ByteSize: 8
       GoRuntimeType: 584864
       GoKind: 7
     - __kind: BaseType
-      ID: 22
+      ID: 6
       Name: uint16
       ByteSize: 2
       GoRuntimeType: 584480
       GoKind: 9
     - __kind: BaseType
-      ID: 139
+      ID: 2
       Name: uint32
       ByteSize: 4
       GoRuntimeType: 584608
       GoKind: 10
     - __kind: BaseType
-      ID: 17
+      ID: 8
       Name: uint64
       ByteSize: 8
       GoRuntimeType: 584736
       GoKind: 11
     - __kind: BaseType
-      ID: 7
+      ID: 3
       Name: uint8
       ByteSize: 1
       GoRuntimeType: 584352
       GoKind: 8
     - __kind: BaseType
-      ID: 18
+      ID: 1
       Name: uintptr
       ByteSize: 8
       GoRuntimeType: 584928
       GoKind: 12
     - __kind: VoidPointerType
-      ID: 2
+      ID: 15
       Name: unsafe.Pointer
       ByteSize: 8
       GoRuntimeType: 585312

--- a/pkg/dyninst/irgen/testdata/snapshot/rc_tester_v1.arch=arm64,toolchain=go1.25.0.yaml
+++ b/pkg/dyninst/irgen/testdata/snapshot/rc_tester_v1.arch=arm64,toolchain=go1.25.0.yaml
@@ -65,7 +65,7 @@ Subprograms:
           IsParameter: true
           IsReturn: false
         - Name: '&buf'
-          Type: 158 PointerType *bytes.Buffer
+          Type: 39 PointerType *bytes.Buffer
           Locations:
             - Range: 0x82b23c..0x82b258
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
@@ -74,7 +74,7 @@ Subprograms:
           IsParameter: false
           IsReturn: false
         - Name: span
-          Type: 161 GoInterfaceType gopkg.in/DataDog/dd-trace-go.v1/ddtrace.Span
+          Type: 41 GoInterfaceType gopkg.in/DataDog/dd-trace-go.v1/ddtrace.Span
           Locations:
             - Range: 0x82b164..0x82b164
               Pieces:
@@ -108,59 +108,59 @@ Subprograms:
           IsReturn: false
 Types:
     - __kind: PointerType
-      ID: 82
+      ID: 81
       Name: '**crypto/x509.Certificate'
       ByteSize: 8
       GoKind: 22
-      Pointee: 83 PointerType *crypto/x509.Certificate
+      Pointee: 82 PointerType *crypto/x509.Certificate
     - __kind: PointerType
-      ID: 73
+      ID: 147
       Name: '**mime/multipart.FileHeader'
       ByteSize: 8
       GoKind: 22
-      Pointee: 74 PointerType *mime/multipart.FileHeader
+      Pointee: 148 PointerType *mime/multipart.FileHeader
     - __kind: PointerType
-      ID: 122
+      ID: 134
       Name: '**net.IPNet'
       ByteSize: 8
       GoKind: 22
-      Pointee: 123 PointerType *net.IPNet
+      Pointee: 135 PointerType *net.IPNet
     - __kind: PointerType
-      ID: 120
+      ID: 132
       Name: '**net/url.URL'
       ByteSize: 8
-      Pointee: 39 PointerType *net/url.URL
+      Pointee: 42 PointerType *net/url.URL
     - __kind: PointerType
-      ID: 64
+      ID: 77
       Name: '**table<string,[]*mime/multipart.FileHeader>'
       ByteSize: 8
-      Pointee: 65 PointerType *table<string,[]*mime/multipart.FileHeader>
+      Pointee: 78 PointerType *table<string,[]*mime/multipart.FileHeader>
     - __kind: PointerType
-      ID: 46
+      ID: 47
       Name: '**table<string,[]string>'
       ByteSize: 8
-      Pointee: 47 PointerType *table<string,[]string>
+      Pointee: 48 PointerType *table<string,[]string>
     - __kind: PointerType
-      ID: 150
+      ID: 66
       Name: '**table<string,string>'
       ByteSize: 8
-      Pointee: 151 PointerType *table<string,string>
+      Pointee: 67 PointerType *table<string,string>
     - __kind: PointerType
-      ID: 133
+      ID: 84
       Name: '*[]*crypto/x509.Certificate'
       ByteSize: 8
       GoKind: 22
-      Pointee: 81 GoSliceHeaderType []*crypto/x509.Certificate
+      Pointee: 80 GoSliceHeaderType []*crypto/x509.Certificate
     - __kind: PointerType
       ID: 175
       Name: '*[]*crypto/x509.Certificate.array'
       ByteSize: 8
       Pointee: 174 GoSliceDataType []*crypto/x509.Certificate.array
     - __kind: PointerType
-      ID: 171
+      ID: 205
       Name: '*[]*mime/multipart.FileHeader.array'
       ByteSize: 8
-      Pointee: 170 GoSliceDataType []*mime/multipart.FileHeader.array
+      Pointee: 204 GoSliceDataType []*mime/multipart.FileHeader.array
     - __kind: PointerType
       ID: 199
       Name: '*[]*net.IPNet.array'
@@ -172,82 +172,82 @@ Types:
       ByteSize: 8
       Pointee: 196 GoSliceDataType []*net/url.URL.array
     - __kind: PointerType
-      ID: 207
+      ID: 177
       Name: '*[][]*crypto/x509.Certificate.array'
       ByteSize: 8
-      Pointee: 206 GoSliceDataType [][]*crypto/x509.Certificate.array
+      Pointee: 176 GoSliceDataType [][]*crypto/x509.Certificate.array
     - __kind: PointerType
-      ID: 209
+      ID: 179
       Name: '*[][]uint8.array'
       ByteSize: 8
-      Pointee: 208 GoSliceDataType [][]uint8.array
+      Pointee: 178 GoSliceDataType [][]uint8.array
     - __kind: PointerType
       ID: 191
       Name: '*[]crypto/x509.ExtKeyUsage.array'
       ByteSize: 8
       Pointee: 190 GoSliceDataType []crypto/x509.ExtKeyUsage.array
     - __kind: PointerType
-      ID: 203
+      ID: 201
       Name: '*[]crypto/x509.OID.array'
       ByteSize: 8
-      Pointee: 202 GoSliceDataType []crypto/x509.OID.array
+      Pointee: 200 GoSliceDataType []crypto/x509.OID.array
     - __kind: PointerType
-      ID: 205
+      ID: 203
       Name: '*[]crypto/x509.PolicyMapping.array'
       ByteSize: 8
-      Pointee: 204 GoSliceDataType []crypto/x509.PolicyMapping.array
+      Pointee: 202 GoSliceDataType []crypto/x509.PolicyMapping.array
     - __kind: PointerType
-      ID: 179
+      ID: 183
       Name: '*[]crypto/x509/pkix.AttributeTypeAndValue.array'
       ByteSize: 8
-      Pointee: 178 GoSliceDataType []crypto/x509/pkix.AttributeTypeAndValue.array
+      Pointee: 182 GoSliceDataType []crypto/x509/pkix.AttributeTypeAndValue.array
     - __kind: PointerType
-      ID: 187
+      ID: 185
       Name: '*[]crypto/x509/pkix.Extension.array'
       ByteSize: 8
-      Pointee: 186 GoSliceDataType []crypto/x509/pkix.Extension.array
+      Pointee: 184 GoSliceDataType []crypto/x509/pkix.Extension.array
     - __kind: PointerType
-      ID: 189
+      ID: 187
       Name: '*[]encoding/asn1.ObjectIdentifier.array'
       ByteSize: 8
-      Pointee: 188 GoSliceDataType []encoding/asn1.ObjectIdentifier.array
+      Pointee: 186 GoSliceDataType []encoding/asn1.ObjectIdentifier.array
     - __kind: PointerType
       ID: 193
       Name: '*[]net.IP.array'
       ByteSize: 8
       Pointee: 192 GoSliceDataType []net.IP.array
     - __kind: PointerType
-      ID: 211
+      ID: 181
       Name: '*[]net/http.segment.array'
       ByteSize: 8
-      Pointee: 210 GoSliceDataType []net/http.segment.array
+      Pointee: 180 GoSliceDataType []net/http.segment.array
     - __kind: PointerType
       ID: 167
       Name: '*[]string.array'
       ByteSize: 8
       Pointee: 166 GoSliceDataType []string.array
     - __kind: PointerType
-      ID: 183
+      ID: 209
       Name: '*[]time.zone.array'
       ByteSize: 8
-      Pointee: 182 GoSliceDataType []time.zone.array
+      Pointee: 208 GoSliceDataType []time.zone.array
     - __kind: PointerType
-      ID: 185
+      ID: 211
       Name: '*[]time.zoneTrans.array'
       ByteSize: 8
-      Pointee: 184 GoSliceDataType []time.zoneTrans.array
+      Pointee: 210 GoSliceDataType []time.zoneTrans.array
     - __kind: PointerType
-      ID: 135
+      ID: 86
       Name: '*[]uint8'
       ByteSize: 8
       GoRuntimeType: 481440
       GoKind: 22
-      Pointee: 77 GoSliceHeaderType []uint8
+      Pointee: 68 GoSliceHeaderType []uint8
     - __kind: PointerType
-      ID: 173
+      ID: 171
       Name: '*[]uint8.array'
       ByteSize: 8
-      Pointee: 172 GoSliceDataType []uint8.array
+      Pointee: 170 GoSliceDataType []uint8.array
     - __kind: PointerType
       ID: 11
       Name: '*bool'
@@ -256,73 +256,73 @@ Types:
       GoKind: 22
       Pointee: 4 BaseType bool
     - __kind: PointerType
-      ID: 158
+      ID: 39
       Name: '*bytes.Buffer'
       ByteSize: 8
       GoRuntimeType: 2.259936e+06
       GoKind: 22
-      Pointee: 159 StructureType bytes.Buffer
+      Pointee: 40 StructureType bytes.Buffer
     - __kind: PointerType
-      ID: 78
+      ID: 55
       Name: '*crypto/tls.ConnectionState'
       ByteSize: 8
       GoRuntimeType: 907744
       GoKind: 22
-      Pointee: 79 StructureType crypto/tls.ConnectionState
+      Pointee: 56 StructureType crypto/tls.ConnectionState
     - __kind: PointerType
-      ID: 83
+      ID: 82
       Name: '*crypto/x509.Certificate'
       ByteSize: 8
       GoRuntimeType: 2.0432e+06
       GoKind: 22
-      Pointee: 84 StructureType crypto/x509.Certificate
+      Pointee: 97 StructureType crypto/x509.Certificate
     - __kind: PointerType
-      ID: 114
+      ID: 126
       Name: '*crypto/x509.ExtKeyUsage'
       ByteSize: 8
       GoRuntimeType: 423456
       GoKind: 22
-      Pointee: 115 BaseType crypto/x509.ExtKeyUsage
+      Pointee: 127 BaseType crypto/x509.ExtKeyUsage
     - __kind: PointerType
-      ID: 127
+      ID: 137
       Name: '*crypto/x509.OID'
       ByteSize: 8
       GoRuntimeType: 1.953568e+06
       GoKind: 22
-      Pointee: 128 StructureType crypto/x509.OID
+      Pointee: 138 StructureType crypto/x509.OID
     - __kind: PointerType
-      ID: 130
+      ID: 140
       Name: '*crypto/x509.PolicyMapping'
       ByteSize: 8
       GoRuntimeType: 423520
       GoKind: 22
-      Pointee: 131 StructureType crypto/x509.PolicyMapping
+      Pointee: 141 StructureType crypto/x509.PolicyMapping
     - __kind: PointerType
-      ID: 95
+      ID: 113
       Name: '*crypto/x509/pkix.AttributeTypeAndValue'
       ByteSize: 8
       GoRuntimeType: 437216
       GoKind: 22
-      Pointee: 96 StructureType crypto/x509/pkix.AttributeTypeAndValue
+      Pointee: 114 StructureType crypto/x509/pkix.AttributeTypeAndValue
     - __kind: PointerType
-      ID: 109
+      ID: 120
       Name: '*crypto/x509/pkix.Extension'
       ByteSize: 8
       GoRuntimeType: 437408
       GoKind: 22
-      Pointee: 110 StructureType crypto/x509/pkix.Extension
+      Pointee: 121 StructureType crypto/x509/pkix.Extension
     - __kind: PointerType
-      ID: 112
+      ID: 123
       Name: '*encoding/asn1.ObjectIdentifier'
       ByteSize: 8
       GoRuntimeType: 1.052704e+06
       GoKind: 22
-      Pointee: 97 GoSliceHeaderType encoding/asn1.ObjectIdentifier
+      Pointee: 124 GoSliceHeaderType encoding/asn1.ObjectIdentifier
     - __kind: PointerType
-      ID: 181
+      ID: 189
       Name: '*encoding/asn1.ObjectIdentifier.array'
       ByteSize: 8
-      Pointee: 180 GoSliceDataType encoding/asn1.ObjectIdentifier.array
+      Pointee: 188 GoSliceDataType encoding/asn1.ObjectIdentifier.array
     - __kind: PointerType
       ID: 33
       Name: '*error'
@@ -380,77 +380,77 @@ Types:
       GoKind: 22
       Pointee: 17 BaseType int8
     - __kind: PointerType
-      ID: 62
+      ID: 75
       Name: '*map<string,[]*mime/multipart.FileHeader>'
       ByteSize: 8
-      Pointee: 63 GoSwissMapHeaderType map<string,[]*mime/multipart.FileHeader>
+      Pointee: 76 GoSwissMapHeaderType map<string,[]*mime/multipart.FileHeader>
     - __kind: PointerType
-      ID: 44
+      ID: 45
       Name: '*map<string,[]string>'
       ByteSize: 8
-      Pointee: 45 GoSwissMapHeaderType map<string,[]string>
+      Pointee: 46 GoSwissMapHeaderType map<string,[]string>
     - __kind: PointerType
-      ID: 148
+      ID: 64
       Name: '*map<string,string>'
       ByteSize: 8
-      Pointee: 149 GoSwissMapHeaderType map<string,string>
+      Pointee: 65 GoSwissMapHeaderType map<string,string>
     - __kind: PointerType
-      ID: 88
+      ID: 109
       Name: '*math/big.Int'
       ByteSize: 8
       GoRuntimeType: 2.381568e+06
       GoKind: 22
-      Pointee: 89 StructureType math/big.Int
+      Pointee: 110 StructureType math/big.Int
     - __kind: PointerType
-      ID: 91
+      ID: 150
       Name: '*math/big.Word'
       ByteSize: 8
       GoRuntimeType: 426272
       GoKind: 22
-      Pointee: 92 BaseType math/big.Word
+      Pointee: 151 BaseType math/big.Word
     - __kind: PointerType
-      ID: 177
+      ID: 207
       Name: '*math/big.nat.array'
       ByteSize: 8
-      Pointee: 176 GoSliceDataType math/big.nat.array
+      Pointee: 206 GoSliceDataType math/big.nat.array
     - __kind: PointerType
-      ID: 74
+      ID: 148
       Name: '*mime/multipart.FileHeader'
       ByteSize: 8
       GoRuntimeType: 909280
       GoKind: 22
-      Pointee: 75 StructureType mime/multipart.FileHeader
+      Pointee: 159 StructureType mime/multipart.FileHeader
     - __kind: PointerType
-      ID: 58
+      ID: 53
       Name: '*mime/multipart.Form'
       ByteSize: 8
       GoRuntimeType: 909376
       GoKind: 22
-      Pointee: 59 StructureType mime/multipart.Form
+      Pointee: 54 StructureType mime/multipart.Form
     - __kind: PointerType
-      ID: 117
+      ID: 129
       Name: '*net.IP'
       ByteSize: 8
       GoRuntimeType: 2.149408e+06
       GoKind: 22
-      Pointee: 118 GoSliceHeaderType net.IP
+      Pointee: 130 GoSliceHeaderType net.IP
     - __kind: PointerType
       ID: 195
       Name: '*net.IP.array'
       ByteSize: 8
       Pointee: 194 GoSliceDataType net.IP.array
     - __kind: PointerType
-      ID: 201
+      ID: 213
       Name: '*net.IPMask.array'
       ByteSize: 8
-      Pointee: 200 GoSliceDataType net.IPMask.array
+      Pointee: 212 GoSliceDataType net.IPMask.array
     - __kind: PointerType
-      ID: 123
+      ID: 135
       Name: '*net.IPNet'
       ByteSize: 8
       GoRuntimeType: 1.182656e+06
       GoKind: 22
-      Pointee: 124 StructureType net.IPNet
+      Pointee: 158 StructureType net.IPNet
     - __kind: PointerType
       ID: 37
       Name: '*net/http.Request'
@@ -459,55 +459,55 @@ Types:
       GoKind: 22
       Pointee: 38 StructureType net/http.Request
     - __kind: PointerType
-      ID: 139
+      ID: 58
       Name: '*net/http.Response'
       ByteSize: 8
       GoRuntimeType: 1.718272e+06
       GoKind: 22
-      Pointee: 140 StructureType net/http.Response
+      Pointee: 59 StructureType net/http.Response
     - __kind: PointerType
-      ID: 142
+      ID: 61
       Name: '*net/http.pattern'
       ByteSize: 8
       GoRuntimeType: 1.608064e+06
       GoKind: 22
-      Pointee: 143 StructureType net/http.pattern
+      Pointee: 62 StructureType net/http.pattern
     - __kind: PointerType
-      ID: 145
+      ID: 90
       Name: '*net/http.segment'
       ByteSize: 8
       GoRuntimeType: 391712
       GoKind: 22
-      Pointee: 146 StructureType net/http.segment
+      Pointee: 91 StructureType net/http.segment
     - __kind: PointerType
-      ID: 39
+      ID: 42
       Name: '*net/url.URL'
       ByteSize: 8
       GoRuntimeType: 2.112832e+06
       GoKind: 22
-      Pointee: 40 StructureType net/url.URL
+      Pointee: 43 StructureType net/url.URL
     - __kind: PointerType
-      ID: 41
+      ID: 70
       Name: '*net/url.Userinfo'
       ByteSize: 8
       GoRuntimeType: 1.200064e+06
       GoKind: 22
-      Pointee: 42 StructureType net/url.Userinfo
+      Pointee: 71 StructureType net/url.Userinfo
     - __kind: PointerType
-      ID: 68
+      ID: 104
       Name: '*noalg.map.group[string][]*mime/multipart.FileHeader'
       ByteSize: 8
-      Pointee: 69 StructureType noalg.map.group[string][]*mime/multipart.FileHeader
+      Pointee: 105 StructureType noalg.map.group[string][]*mime/multipart.FileHeader
     - __kind: PointerType
-      ID: 50
+      ID: 94
       Name: '*noalg.map.group[string][]string'
       ByteSize: 8
-      Pointee: 51 StructureType noalg.map.group[string][]string
+      Pointee: 95 StructureType noalg.map.group[string][]string
     - __kind: PointerType
-      ID: 154
+      ID: 99
       Name: '*noalg.map.group[string]string'
       ByteSize: 8
-      Pointee: 155 StructureType noalg.map.group[string]string
+      Pointee: 100 StructureType noalg.map.group[string]string
     - __kind: PointerType
       ID: 22
       Name: '*string'
@@ -521,41 +521,41 @@ Types:
       ByteSize: 8
       Pointee: 162 GoStringDataType string.str
     - __kind: PointerType
-      ID: 65
+      ID: 78
       Name: '*table<string,[]*mime/multipart.FileHeader>'
       ByteSize: 8
-      Pointee: 66 StructureType table<string,[]*mime/multipart.FileHeader>
+      Pointee: 96 StructureType table<string,[]*mime/multipart.FileHeader>
     - __kind: PointerType
-      ID: 47
+      ID: 48
       Name: '*table<string,[]string>'
       ByteSize: 8
-      Pointee: 48 StructureType table<string,[]string>
+      Pointee: 72 StructureType table<string,[]string>
     - __kind: PointerType
-      ID: 151
+      ID: 67
       Name: '*table<string,string>'
       ByteSize: 8
-      Pointee: 152 StructureType table<string,string>
+      Pointee: 92 StructureType table<string,string>
     - __kind: PointerType
-      ID: 99
+      ID: 116
       Name: '*time.Location'
       ByteSize: 8
       GoRuntimeType: 1.613056e+06
       GoKind: 22
-      Pointee: 100 StructureType time.Location
+      Pointee: 117 StructureType time.Location
     - __kind: PointerType
-      ID: 102
+      ID: 153
       Name: '*time.zone'
       ByteSize: 8
       GoRuntimeType: 394784
       GoKind: 22
-      Pointee: 103 StructureType time.zone
+      Pointee: 154 StructureType time.zone
     - __kind: PointerType
-      ID: 105
+      ID: 156
       Name: '*time.zoneTrans'
       ByteSize: 8
       GoRuntimeType: 394848
       GoKind: 22
-      Pointee: 106 StructureType time.zoneTrans
+      Pointee: 157 StructureType time.zoneTrans
     - __kind: PointerType
       ID: 34
       Name: '*uint'
@@ -599,7 +599,7 @@ Types:
       GoKind: 22
       Pointee: 1 BaseType uintptr
     - __kind: GoChannelType
-      ID: 138
+      ID: 57
       Name: <-chan struct {}
       GoRuntimeType: 597472
       GoKind: 18
@@ -643,7 +643,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: GoSliceHeaderType
-      ID: 81
+      ID: 80
       Name: '[]*crypto/x509.Certificate'
       ByteSize: 24
       GoRuntimeType: 502272
@@ -651,7 +651,7 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 82 PointerType **crypto/x509.Certificate
+          Type: 81 PointerType **crypto/x509.Certificate
         - Name: len
           Offset: 8
           Type: 7 BaseType int
@@ -663,9 +663,9 @@ Types:
       ID: 174
       Name: '[]*crypto/x509.Certificate.array'
       ByteSize: 2048
-      Element: 83 PointerType *crypto/x509.Certificate
+      Element: 82 PointerType *crypto/x509.Certificate
     - __kind: GoSliceHeaderType
-      ID: 72
+      ID: 146
       Name: '[]*mime/multipart.FileHeader'
       ByteSize: 24
       GoRuntimeType: 487168
@@ -673,21 +673,21 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 73 PointerType **mime/multipart.FileHeader
+          Type: 147 PointerType **mime/multipart.FileHeader
         - Name: len
           Offset: 8
           Type: 7 BaseType int
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 170 GoSliceDataType []*mime/multipart.FileHeader.array
+      Data: 204 GoSliceDataType []*mime/multipart.FileHeader.array
     - __kind: GoSliceDataType
-      ID: 170
+      ID: 204
       Name: '[]*mime/multipart.FileHeader.array'
       ByteSize: 2048
-      Element: 74 PointerType *mime/multipart.FileHeader
+      Element: 148 PointerType *mime/multipart.FileHeader
     - __kind: GoSliceHeaderType
-      ID: 121
+      ID: 133
       Name: '[]*net.IPNet'
       ByteSize: 24
       GoRuntimeType: 503872
@@ -695,7 +695,7 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 122 PointerType **net.IPNet
+          Type: 134 PointerType **net.IPNet
         - Name: len
           Offset: 8
           Type: 7 BaseType int
@@ -707,9 +707,9 @@ Types:
       ID: 198
       Name: '[]*net.IPNet.array'
       ByteSize: 2048
-      Element: 123 PointerType *net.IPNet
+      Element: 135 PointerType *net.IPNet
     - __kind: GoSliceHeaderType
-      ID: 119
+      ID: 131
       Name: '[]*net/url.URL'
       ByteSize: 24
       GoRuntimeType: 503808
@@ -717,7 +717,7 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 120 PointerType **net/url.URL
+          Type: 132 PointerType **net/url.URL
         - Name: len
           Offset: 8
           Type: 7 BaseType int
@@ -729,24 +729,24 @@ Types:
       ID: 196
       Name: '[]*net/url.URL.array'
       ByteSize: 2048
-      Element: 39 PointerType *net/url.URL
+      Element: 42 PointerType *net/url.URL
     - __kind: GoSliceDataType
-      ID: 168
+      ID: 172
       Name: '[]*table<string,[]*mime/multipart.FileHeader>.array'
       ByteSize: 8192
-      Element: 65 PointerType *table<string,[]*mime/multipart.FileHeader>
+      Element: 78 PointerType *table<string,[]*mime/multipart.FileHeader>
     - __kind: GoSliceDataType
       ID: 164
       Name: '[]*table<string,[]string>.array'
       ByteSize: 8192
-      Element: 47 PointerType *table<string,[]string>
+      Element: 48 PointerType *table<string,[]string>
     - __kind: GoSliceDataType
-      ID: 212
+      ID: 168
       Name: '[]*table<string,string>.array'
       ByteSize: 8192
-      Element: 151 PointerType *table<string,string>
+      Element: 67 PointerType *table<string,string>
     - __kind: GoSliceHeaderType
-      ID: 132
+      ID: 83
       Name: '[][]*crypto/x509.Certificate'
       ByteSize: 24
       GoRuntimeType: 502336
@@ -754,21 +754,21 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 133 PointerType *[]*crypto/x509.Certificate
+          Type: 84 PointerType *[]*crypto/x509.Certificate
         - Name: len
           Offset: 8
           Type: 7 BaseType int
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 206 GoSliceDataType [][]*crypto/x509.Certificate.array
+      Data: 176 GoSliceDataType [][]*crypto/x509.Certificate.array
     - __kind: GoSliceDataType
-      ID: 206
+      ID: 176
       Name: '[][]*crypto/x509.Certificate.array'
       ByteSize: 2048
-      Element: 81 GoSliceHeaderType []*crypto/x509.Certificate
+      Element: 80 GoSliceHeaderType []*crypto/x509.Certificate
     - __kind: GoSliceHeaderType
-      ID: 134
+      ID: 85
       Name: '[][]uint8'
       ByteSize: 24
       GoRuntimeType: 481760
@@ -776,21 +776,21 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 135 PointerType *[]uint8
+          Type: 86 PointerType *[]uint8
         - Name: len
           Offset: 8
           Type: 7 BaseType int
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 208 GoSliceDataType [][]uint8.array
+      Data: 178 GoSliceDataType [][]uint8.array
     - __kind: GoSliceDataType
-      ID: 208
+      ID: 178
       Name: '[][]uint8.array'
       ByteSize: 2048
-      Element: 77 GoSliceHeaderType []uint8
+      Element: 68 GoSliceHeaderType []uint8
     - __kind: GoSliceHeaderType
-      ID: 113
+      ID: 125
       Name: '[]crypto/x509.ExtKeyUsage'
       ByteSize: 24
       GoRuntimeType: 503744
@@ -798,7 +798,7 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 114 PointerType *crypto/x509.ExtKeyUsage
+          Type: 126 PointerType *crypto/x509.ExtKeyUsage
         - Name: len
           Offset: 8
           Type: 7 BaseType int
@@ -810,9 +810,9 @@ Types:
       ID: 190
       Name: '[]crypto/x509.ExtKeyUsage.array'
       ByteSize: 2048
-      Element: 115 BaseType crypto/x509.ExtKeyUsage
+      Element: 127 BaseType crypto/x509.ExtKeyUsage
     - __kind: GoSliceHeaderType
-      ID: 126
+      ID: 136
       Name: '[]crypto/x509.OID'
       ByteSize: 24
       GoRuntimeType: 503936
@@ -820,21 +820,21 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 127 PointerType *crypto/x509.OID
+          Type: 137 PointerType *crypto/x509.OID
         - Name: len
           Offset: 8
           Type: 7 BaseType int
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 202 GoSliceDataType []crypto/x509.OID.array
+      Data: 200 GoSliceDataType []crypto/x509.OID.array
     - __kind: GoSliceDataType
-      ID: 202
+      ID: 200
       Name: '[]crypto/x509.OID.array'
       ByteSize: 2048
-      Element: 128 StructureType crypto/x509.OID
+      Element: 138 StructureType crypto/x509.OID
     - __kind: GoSliceHeaderType
-      ID: 129
+      ID: 139
       Name: '[]crypto/x509.PolicyMapping'
       ByteSize: 24
       GoRuntimeType: 504000
@@ -842,21 +842,21 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 130 PointerType *crypto/x509.PolicyMapping
+          Type: 140 PointerType *crypto/x509.PolicyMapping
         - Name: len
           Offset: 8
           Type: 7 BaseType int
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 204 GoSliceDataType []crypto/x509.PolicyMapping.array
+      Data: 202 GoSliceDataType []crypto/x509.PolicyMapping.array
     - __kind: GoSliceDataType
-      ID: 204
+      ID: 202
       Name: '[]crypto/x509.PolicyMapping.array'
       ByteSize: 2048
-      Element: 131 StructureType crypto/x509.PolicyMapping
+      Element: 141 StructureType crypto/x509.PolicyMapping
     - __kind: GoSliceHeaderType
-      ID: 94
+      ID: 112
       Name: '[]crypto/x509/pkix.AttributeTypeAndValue'
       ByteSize: 24
       GoRuntimeType: 517280
@@ -864,21 +864,21 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 95 PointerType *crypto/x509/pkix.AttributeTypeAndValue
+          Type: 113 PointerType *crypto/x509/pkix.AttributeTypeAndValue
         - Name: len
           Offset: 8
           Type: 7 BaseType int
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 178 GoSliceDataType []crypto/x509/pkix.AttributeTypeAndValue.array
+      Data: 182 GoSliceDataType []crypto/x509/pkix.AttributeTypeAndValue.array
     - __kind: GoSliceDataType
-      ID: 178
+      ID: 182
       Name: '[]crypto/x509/pkix.AttributeTypeAndValue.array'
       ByteSize: 2048
-      Element: 96 StructureType crypto/x509/pkix.AttributeTypeAndValue
+      Element: 114 StructureType crypto/x509/pkix.AttributeTypeAndValue
     - __kind: GoSliceHeaderType
-      ID: 108
+      ID: 119
       Name: '[]crypto/x509/pkix.Extension'
       ByteSize: 24
       GoRuntimeType: 503616
@@ -886,21 +886,21 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 109 PointerType *crypto/x509/pkix.Extension
+          Type: 120 PointerType *crypto/x509/pkix.Extension
         - Name: len
           Offset: 8
           Type: 7 BaseType int
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 186 GoSliceDataType []crypto/x509/pkix.Extension.array
+      Data: 184 GoSliceDataType []crypto/x509/pkix.Extension.array
     - __kind: GoSliceDataType
-      ID: 186
+      ID: 184
       Name: '[]crypto/x509/pkix.Extension.array'
       ByteSize: 2048
-      Element: 110 StructureType crypto/x509/pkix.Extension
+      Element: 121 StructureType crypto/x509/pkix.Extension
     - __kind: GoSliceHeaderType
-      ID: 111
+      ID: 122
       Name: '[]encoding/asn1.ObjectIdentifier'
       ByteSize: 24
       GoRuntimeType: 503680
@@ -908,21 +908,21 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 112 PointerType *encoding/asn1.ObjectIdentifier
+          Type: 123 PointerType *encoding/asn1.ObjectIdentifier
         - Name: len
           Offset: 8
           Type: 7 BaseType int
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 188 GoSliceDataType []encoding/asn1.ObjectIdentifier.array
+      Data: 186 GoSliceDataType []encoding/asn1.ObjectIdentifier.array
     - __kind: GoSliceDataType
-      ID: 188
+      ID: 186
       Name: '[]encoding/asn1.ObjectIdentifier.array'
       ByteSize: 2048
-      Element: 97 GoSliceHeaderType encoding/asn1.ObjectIdentifier
+      Element: 124 GoSliceHeaderType encoding/asn1.ObjectIdentifier
     - __kind: GoSliceHeaderType
-      ID: 116
+      ID: 128
       Name: '[]net.IP'
       ByteSize: 24
       GoRuntimeType: 482784
@@ -930,7 +930,7 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 117 PointerType *net.IP
+          Type: 129 PointerType *net.IP
         - Name: len
           Offset: 8
           Type: 7 BaseType int
@@ -942,9 +942,9 @@ Types:
       ID: 192
       Name: '[]net.IP.array'
       ByteSize: 2048
-      Element: 118 GoSliceHeaderType net.IP
+      Element: 130 GoSliceHeaderType net.IP
     - __kind: GoSliceHeaderType
-      ID: 144
+      ID: 89
       Name: '[]net/http.segment'
       ByteSize: 24
       GoRuntimeType: 484480
@@ -952,36 +952,36 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 145 PointerType *net/http.segment
+          Type: 90 PointerType *net/http.segment
         - Name: len
           Offset: 8
           Type: 7 BaseType int
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 210 GoSliceDataType []net/http.segment.array
+      Data: 180 GoSliceDataType []net/http.segment.array
     - __kind: GoSliceDataType
-      ID: 210
+      ID: 180
       Name: '[]net/http.segment.array'
       ByteSize: 2048
-      Element: 146 StructureType net/http.segment
+      Element: 91 StructureType net/http.segment
     - __kind: GoSliceDataType
-      ID: 169
+      ID: 173
       Name: '[]noalg.map.group[string][]*mime/multipart.FileHeader.array'
       ByteSize: 2048
-      Element: 69 StructureType noalg.map.group[string][]*mime/multipart.FileHeader
+      Element: 105 StructureType noalg.map.group[string][]*mime/multipart.FileHeader
     - __kind: GoSliceDataType
       ID: 165
       Name: '[]noalg.map.group[string][]string.array'
       ByteSize: 2048
-      Element: 51 StructureType noalg.map.group[string][]string
+      Element: 95 StructureType noalg.map.group[string][]string
     - __kind: GoSliceDataType
-      ID: 213
+      ID: 169
       Name: '[]noalg.map.group[string]string.array'
       ByteSize: 2048
-      Element: 155 StructureType noalg.map.group[string]string
+      Element: 100 StructureType noalg.map.group[string]string
     - __kind: GoSliceHeaderType
-      ID: 54
+      ID: 51
       Name: '[]string'
       ByteSize: 24
       GoRuntimeType: 496288
@@ -1003,7 +1003,7 @@ Types:
       ByteSize: 2048
       Element: 9 GoStringHeaderType string
     - __kind: GoSliceHeaderType
-      ID: 101
+      ID: 152
       Name: '[]time.zone'
       ByteSize: 24
       GoRuntimeType: 489344
@@ -1011,21 +1011,21 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 102 PointerType *time.zone
+          Type: 153 PointerType *time.zone
         - Name: len
           Offset: 8
           Type: 7 BaseType int
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 182 GoSliceDataType []time.zone.array
+      Data: 208 GoSliceDataType []time.zone.array
     - __kind: GoSliceDataType
-      ID: 182
+      ID: 208
       Name: '[]time.zone.array'
       ByteSize: 2048
-      Element: 103 StructureType time.zone
+      Element: 154 StructureType time.zone
     - __kind: GoSliceHeaderType
-      ID: 104
+      ID: 155
       Name: '[]time.zoneTrans'
       ByteSize: 24
       GoRuntimeType: 489408
@@ -1033,21 +1033,21 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 105 PointerType *time.zoneTrans
+          Type: 156 PointerType *time.zoneTrans
         - Name: len
           Offset: 8
           Type: 7 BaseType int
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 184 GoSliceDataType []time.zoneTrans.array
+      Data: 210 GoSliceDataType []time.zoneTrans.array
     - __kind: GoSliceDataType
-      ID: 184
+      ID: 210
       Name: '[]time.zoneTrans.array'
       ByteSize: 2048
-      Element: 106 StructureType time.zoneTrans
+      Element: 157 StructureType time.zoneTrans
     - __kind: GoSliceHeaderType
-      ID: 77
+      ID: 68
       Name: '[]uint8'
       ByteSize: 24
       GoRuntimeType: 495136
@@ -1062,9 +1062,9 @@ Types:
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 172 GoSliceDataType []uint8.array
+      Data: 170 GoSliceDataType []uint8.array
     - __kind: GoSliceDataType
-      ID: 172
+      ID: 170
       Name: '[]uint8.array'
       ByteSize: 2048
       Element: 3 BaseType uint8
@@ -1075,7 +1075,7 @@ Types:
       GoRuntimeType: 585248
       GoKind: 1
     - __kind: StructureType
-      ID: 159
+      ID: 40
       Name: bytes.Buffer
       ByteSize: 40
       GoRuntimeType: 1.60576e+06
@@ -1083,15 +1083,15 @@ Types:
       RawFields:
         - Name: buf
           Offset: 0
-          Type: 77 GoSliceHeaderType []uint8
+          Type: 68 GoSliceHeaderType []uint8
         - Name: off
           Offset: 24
           Type: 7 BaseType int
         - Name: lastRead
           Offset: 32
-          Type: 160 BaseType bytes.readOp
+          Type: 69 BaseType bytes.readOp
     - __kind: BaseType
-      ID: 160
+      ID: 69
       Name: bytes.readOp
       ByteSize: 1
       GoRuntimeType: 583456
@@ -1109,7 +1109,7 @@ Types:
       GoRuntimeType: 584992
       GoKind: 15
     - __kind: GoInterfaceType
-      ID: 141
+      ID: 60
       Name: context.Context
       ByteSize: 16
       GoRuntimeType: 1.276288e+06
@@ -1122,7 +1122,7 @@ Types:
           Offset: 8
           Type: 15 VoidPointerType unsafe.Pointer
     - __kind: StructureType
-      ID: 79
+      ID: 56
       Name: crypto/tls.ConnectionState
       ByteSize: 192
       GoRuntimeType: 2.261984e+06
@@ -1142,7 +1142,7 @@ Types:
           Type: 6 BaseType uint16
         - Name: CurveID
           Offset: 6
-          Type: 80 BaseType crypto/tls.CurveID
+          Type: 79 BaseType crypto/tls.CurveID
         - Name: NegotiatedProtocol
           Offset: 8
           Type: 9 GoStringHeaderType string
@@ -1154,45 +1154,45 @@ Types:
           Type: 9 GoStringHeaderType string
         - Name: PeerCertificates
           Offset: 48
-          Type: 81 GoSliceHeaderType []*crypto/x509.Certificate
+          Type: 80 GoSliceHeaderType []*crypto/x509.Certificate
         - Name: VerifiedChains
           Offset: 72
-          Type: 132 GoSliceHeaderType [][]*crypto/x509.Certificate
+          Type: 83 GoSliceHeaderType [][]*crypto/x509.Certificate
         - Name: SignedCertificateTimestamps
           Offset: 96
-          Type: 134 GoSliceHeaderType [][]uint8
+          Type: 85 GoSliceHeaderType [][]uint8
         - Name: OCSPResponse
           Offset: 120
-          Type: 77 GoSliceHeaderType []uint8
+          Type: 68 GoSliceHeaderType []uint8
         - Name: TLSUnique
           Offset: 144
-          Type: 77 GoSliceHeaderType []uint8
+          Type: 68 GoSliceHeaderType []uint8
         - Name: ECHAccepted
           Offset: 168
           Type: 4 BaseType bool
         - Name: ekm
           Offset: 176
-          Type: 136 GoSubroutineType func(string, []uint8, int) ([]uint8, error)
+          Type: 87 GoSubroutineType func(string, []uint8, int) ([]uint8, error)
         - Name: testingOnlyDidHRR
           Offset: 184
           Type: 4 BaseType bool
         - Name: testingOnlyPeerSignatureAlgorithm
           Offset: 186
-          Type: 137 BaseType crypto/tls.SignatureScheme
+          Type: 88 BaseType crypto/tls.SignatureScheme
     - __kind: BaseType
-      ID: 80
+      ID: 79
       Name: crypto/tls.CurveID
       ByteSize: 2
       GoRuntimeType: 834432
       GoKind: 9
     - __kind: BaseType
-      ID: 137
+      ID: 88
       Name: crypto/tls.SignatureScheme
       ByteSize: 2
       GoRuntimeType: 834528
       GoKind: 9
     - __kind: StructureType
-      ID: 84
+      ID: 97
       Name: crypto/x509.Certificate
       ByteSize: 1424
       GoRuntimeType: 2.392832e+06
@@ -1200,67 +1200,67 @@ Types:
       RawFields:
         - Name: Raw
           Offset: 0
-          Type: 77 GoSliceHeaderType []uint8
+          Type: 68 GoSliceHeaderType []uint8
         - Name: RawTBSCertificate
           Offset: 24
-          Type: 77 GoSliceHeaderType []uint8
+          Type: 68 GoSliceHeaderType []uint8
         - Name: RawSubjectPublicKeyInfo
           Offset: 48
-          Type: 77 GoSliceHeaderType []uint8
+          Type: 68 GoSliceHeaderType []uint8
         - Name: RawSubject
           Offset: 72
-          Type: 77 GoSliceHeaderType []uint8
+          Type: 68 GoSliceHeaderType []uint8
         - Name: RawIssuer
           Offset: 96
-          Type: 77 GoSliceHeaderType []uint8
+          Type: 68 GoSliceHeaderType []uint8
         - Name: Signature
           Offset: 120
-          Type: 77 GoSliceHeaderType []uint8
+          Type: 68 GoSliceHeaderType []uint8
         - Name: SignatureAlgorithm
           Offset: 144
-          Type: 85 BaseType crypto/x509.SignatureAlgorithm
+          Type: 106 BaseType crypto/x509.SignatureAlgorithm
         - Name: PublicKeyAlgorithm
           Offset: 152
-          Type: 86 BaseType crypto/x509.PublicKeyAlgorithm
+          Type: 107 BaseType crypto/x509.PublicKeyAlgorithm
         - Name: PublicKey
           Offset: 160
-          Type: 87 GoEmptyInterfaceType interface {}
+          Type: 108 GoEmptyInterfaceType interface {}
         - Name: Version
           Offset: 176
           Type: 7 BaseType int
         - Name: SerialNumber
           Offset: 184
-          Type: 88 PointerType *math/big.Int
+          Type: 109 PointerType *math/big.Int
         - Name: Issuer
           Offset: 192
-          Type: 93 StructureType crypto/x509/pkix.Name
+          Type: 111 StructureType crypto/x509/pkix.Name
         - Name: Subject
           Offset: 440
-          Type: 93 StructureType crypto/x509/pkix.Name
+          Type: 111 StructureType crypto/x509/pkix.Name
         - Name: NotBefore
           Offset: 688
-          Type: 98 StructureType time.Time
+          Type: 115 StructureType time.Time
         - Name: NotAfter
           Offset: 712
-          Type: 98 StructureType time.Time
+          Type: 115 StructureType time.Time
         - Name: KeyUsage
           Offset: 736
-          Type: 107 BaseType crypto/x509.KeyUsage
+          Type: 118 BaseType crypto/x509.KeyUsage
         - Name: Extensions
           Offset: 744
-          Type: 108 GoSliceHeaderType []crypto/x509/pkix.Extension
+          Type: 119 GoSliceHeaderType []crypto/x509/pkix.Extension
         - Name: ExtraExtensions
           Offset: 768
-          Type: 108 GoSliceHeaderType []crypto/x509/pkix.Extension
+          Type: 119 GoSliceHeaderType []crypto/x509/pkix.Extension
         - Name: UnhandledCriticalExtensions
           Offset: 792
-          Type: 111 GoSliceHeaderType []encoding/asn1.ObjectIdentifier
+          Type: 122 GoSliceHeaderType []encoding/asn1.ObjectIdentifier
         - Name: ExtKeyUsage
           Offset: 816
-          Type: 113 GoSliceHeaderType []crypto/x509.ExtKeyUsage
+          Type: 125 GoSliceHeaderType []crypto/x509.ExtKeyUsage
         - Name: UnknownExtKeyUsage
           Offset: 840
-          Type: 111 GoSliceHeaderType []encoding/asn1.ObjectIdentifier
+          Type: 122 GoSliceHeaderType []encoding/asn1.ObjectIdentifier
         - Name: BasicConstraintsValid
           Offset: 864
           Type: 4 BaseType bool
@@ -1275,64 +1275,64 @@ Types:
           Type: 4 BaseType bool
         - Name: SubjectKeyId
           Offset: 888
-          Type: 77 GoSliceHeaderType []uint8
+          Type: 68 GoSliceHeaderType []uint8
         - Name: AuthorityKeyId
           Offset: 912
-          Type: 77 GoSliceHeaderType []uint8
+          Type: 68 GoSliceHeaderType []uint8
         - Name: OCSPServer
           Offset: 936
-          Type: 54 GoSliceHeaderType []string
+          Type: 51 GoSliceHeaderType []string
         - Name: IssuingCertificateURL
           Offset: 960
-          Type: 54 GoSliceHeaderType []string
+          Type: 51 GoSliceHeaderType []string
         - Name: DNSNames
           Offset: 984
-          Type: 54 GoSliceHeaderType []string
+          Type: 51 GoSliceHeaderType []string
         - Name: EmailAddresses
           Offset: 1008
-          Type: 54 GoSliceHeaderType []string
+          Type: 51 GoSliceHeaderType []string
         - Name: IPAddresses
           Offset: 1032
-          Type: 116 GoSliceHeaderType []net.IP
+          Type: 128 GoSliceHeaderType []net.IP
         - Name: URIs
           Offset: 1056
-          Type: 119 GoSliceHeaderType []*net/url.URL
+          Type: 131 GoSliceHeaderType []*net/url.URL
         - Name: PermittedDNSDomainsCritical
           Offset: 1080
           Type: 4 BaseType bool
         - Name: PermittedDNSDomains
           Offset: 1088
-          Type: 54 GoSliceHeaderType []string
+          Type: 51 GoSliceHeaderType []string
         - Name: ExcludedDNSDomains
           Offset: 1112
-          Type: 54 GoSliceHeaderType []string
+          Type: 51 GoSliceHeaderType []string
         - Name: PermittedIPRanges
           Offset: 1136
-          Type: 121 GoSliceHeaderType []*net.IPNet
+          Type: 133 GoSliceHeaderType []*net.IPNet
         - Name: ExcludedIPRanges
           Offset: 1160
-          Type: 121 GoSliceHeaderType []*net.IPNet
+          Type: 133 GoSliceHeaderType []*net.IPNet
         - Name: PermittedEmailAddresses
           Offset: 1184
-          Type: 54 GoSliceHeaderType []string
+          Type: 51 GoSliceHeaderType []string
         - Name: ExcludedEmailAddresses
           Offset: 1208
-          Type: 54 GoSliceHeaderType []string
+          Type: 51 GoSliceHeaderType []string
         - Name: PermittedURIDomains
           Offset: 1232
-          Type: 54 GoSliceHeaderType []string
+          Type: 51 GoSliceHeaderType []string
         - Name: ExcludedURIDomains
           Offset: 1256
-          Type: 54 GoSliceHeaderType []string
+          Type: 51 GoSliceHeaderType []string
         - Name: CRLDistributionPoints
           Offset: 1280
-          Type: 54 GoSliceHeaderType []string
+          Type: 51 GoSliceHeaderType []string
         - Name: PolicyIdentifiers
           Offset: 1304
-          Type: 111 GoSliceHeaderType []encoding/asn1.ObjectIdentifier
+          Type: 122 GoSliceHeaderType []encoding/asn1.ObjectIdentifier
         - Name: Policies
           Offset: 1328
-          Type: 126 GoSliceHeaderType []crypto/x509.OID
+          Type: 136 GoSliceHeaderType []crypto/x509.OID
         - Name: InhibitAnyPolicy
           Offset: 1352
           Type: 7 BaseType int
@@ -1353,21 +1353,21 @@ Types:
           Type: 4 BaseType bool
         - Name: PolicyMappings
           Offset: 1400
-          Type: 129 GoSliceHeaderType []crypto/x509.PolicyMapping
+          Type: 139 GoSliceHeaderType []crypto/x509.PolicyMapping
     - __kind: BaseType
-      ID: 115
+      ID: 127
       Name: crypto/x509.ExtKeyUsage
       ByteSize: 8
       GoRuntimeType: 587936
       GoKind: 2
     - __kind: BaseType
-      ID: 107
+      ID: 118
       Name: crypto/x509.KeyUsage
       ByteSize: 8
       GoRuntimeType: 587872
       GoKind: 2
     - __kind: StructureType
-      ID: 128
+      ID: 138
       Name: crypto/x509.OID
       ByteSize: 24
       GoRuntimeType: 1.953824e+06
@@ -1375,9 +1375,9 @@ Types:
       RawFields:
         - Name: der
           Offset: 0
-          Type: 77 GoSliceHeaderType []uint8
+          Type: 68 GoSliceHeaderType []uint8
     - __kind: StructureType
-      ID: 131
+      ID: 141
       Name: crypto/x509.PolicyMapping
       ByteSize: 48
       GoRuntimeType: 1.490528e+06
@@ -1385,24 +1385,24 @@ Types:
       RawFields:
         - Name: IssuerDomainPolicy
           Offset: 0
-          Type: 128 StructureType crypto/x509.OID
+          Type: 138 StructureType crypto/x509.OID
         - Name: SubjectDomainPolicy
           Offset: 24
-          Type: 128 StructureType crypto/x509.OID
+          Type: 138 StructureType crypto/x509.OID
     - __kind: BaseType
-      ID: 86
+      ID: 107
       Name: crypto/x509.PublicKeyAlgorithm
       ByteSize: 8
       GoRuntimeType: 837024
       GoKind: 2
     - __kind: BaseType
-      ID: 85
+      ID: 106
       Name: crypto/x509.SignatureAlgorithm
       ByteSize: 8
       GoRuntimeType: 1.113728e+06
       GoKind: 2
     - __kind: StructureType
-      ID: 96
+      ID: 114
       Name: crypto/x509/pkix.AttributeTypeAndValue
       ByteSize: 40
       GoRuntimeType: 1.502368e+06
@@ -1410,12 +1410,12 @@ Types:
       RawFields:
         - Name: Type
           Offset: 0
-          Type: 97 GoSliceHeaderType encoding/asn1.ObjectIdentifier
+          Type: 124 GoSliceHeaderType encoding/asn1.ObjectIdentifier
         - Name: Value
           Offset: 24
-          Type: 87 GoEmptyInterfaceType interface {}
+          Type: 108 GoEmptyInterfaceType interface {}
     - __kind: StructureType
-      ID: 110
+      ID: 121
       Name: crypto/x509/pkix.Extension
       ByteSize: 56
       GoRuntimeType: 1.646464e+06
@@ -1423,15 +1423,15 @@ Types:
       RawFields:
         - Name: Id
           Offset: 0
-          Type: 97 GoSliceHeaderType encoding/asn1.ObjectIdentifier
+          Type: 124 GoSliceHeaderType encoding/asn1.ObjectIdentifier
         - Name: Critical
           Offset: 24
           Type: 4 BaseType bool
         - Name: Value
           Offset: 32
-          Type: 77 GoSliceHeaderType []uint8
+          Type: 68 GoSliceHeaderType []uint8
     - __kind: StructureType
-      ID: 93
+      ID: 111
       Name: crypto/x509/pkix.Name
       ByteSize: 248
       GoRuntimeType: 2.192e+06
@@ -1439,25 +1439,25 @@ Types:
       RawFields:
         - Name: Country
           Offset: 0
-          Type: 54 GoSliceHeaderType []string
+          Type: 51 GoSliceHeaderType []string
         - Name: Organization
           Offset: 24
-          Type: 54 GoSliceHeaderType []string
+          Type: 51 GoSliceHeaderType []string
         - Name: OrganizationalUnit
           Offset: 48
-          Type: 54 GoSliceHeaderType []string
+          Type: 51 GoSliceHeaderType []string
         - Name: Locality
           Offset: 72
-          Type: 54 GoSliceHeaderType []string
+          Type: 51 GoSliceHeaderType []string
         - Name: Province
           Offset: 96
-          Type: 54 GoSliceHeaderType []string
+          Type: 51 GoSliceHeaderType []string
         - Name: StreetAddress
           Offset: 120
-          Type: 54 GoSliceHeaderType []string
+          Type: 51 GoSliceHeaderType []string
         - Name: PostalCode
           Offset: 144
-          Type: 54 GoSliceHeaderType []string
+          Type: 51 GoSliceHeaderType []string
         - Name: SerialNumber
           Offset: 168
           Type: 9 GoStringHeaderType string
@@ -1466,12 +1466,12 @@ Types:
           Type: 9 GoStringHeaderType string
         - Name: Names
           Offset: 200
-          Type: 94 GoSliceHeaderType []crypto/x509/pkix.AttributeTypeAndValue
+          Type: 112 GoSliceHeaderType []crypto/x509/pkix.AttributeTypeAndValue
         - Name: ExtraNames
           Offset: 224
-          Type: 94 GoSliceHeaderType []crypto/x509/pkix.AttributeTypeAndValue
+          Type: 112 GoSliceHeaderType []crypto/x509/pkix.AttributeTypeAndValue
     - __kind: GoSliceHeaderType
-      ID: 97
+      ID: 124
       Name: encoding/asn1.ObjectIdentifier
       ByteSize: 24
       GoRuntimeType: 1.052832e+06
@@ -1486,9 +1486,9 @@ Types:
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 180 GoSliceDataType encoding/asn1.ObjectIdentifier.array
+      Data: 188 GoSliceDataType encoding/asn1.ObjectIdentifier.array
     - __kind: GoSliceDataType
-      ID: 180
+      ID: 188
       Name: encoding/asn1.ObjectIdentifier.array
       ByteSize: 2048
       Element: 7 BaseType int
@@ -1518,19 +1518,19 @@ Types:
       GoRuntimeType: 585184
       GoKind: 14
     - __kind: GoSubroutineType
-      ID: 56
+      ID: 50
       Name: func() (io.ReadCloser, error)
       ByteSize: 8
       GoRuntimeType: 693216
       GoKind: 19
     - __kind: GoSubroutineType
-      ID: 136
+      ID: 87
       Name: func(string, []uint8, int) ([]uint8, error)
       ByteSize: 8
       GoRuntimeType: 1.002592e+06
       GoKind: 19
     - __kind: GoInterfaceType
-      ID: 161
+      ID: 41
       Name: gopkg.in/DataDog/dd-trace-go.v1/ddtrace.Span
       ByteSize: 16
       GoRuntimeType: 1.479008e+06
@@ -1543,47 +1543,47 @@ Types:
           Offset: 8
           Type: 15 VoidPointerType unsafe.Pointer
     - __kind: GoSwissMapGroupsType
-      ID: 67
+      ID: 103
       Name: groupReference<string,[]*mime/multipart.FileHeader>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 68 PointerType *noalg.map.group[string][]*mime/multipart.FileHeader
+          Type: 104 PointerType *noalg.map.group[string][]*mime/multipart.FileHeader
         - Name: lengthMask
           Offset: 8
           Type: 8 BaseType uint64
-      GroupType: 69 StructureType noalg.map.group[string][]*mime/multipart.FileHeader
-      GroupSliceType: 169 GoSliceDataType []noalg.map.group[string][]*mime/multipart.FileHeader.array
+      GroupType: 105 StructureType noalg.map.group[string][]*mime/multipart.FileHeader
+      GroupSliceType: 173 GoSliceDataType []noalg.map.group[string][]*mime/multipart.FileHeader.array
     - __kind: GoSwissMapGroupsType
-      ID: 49
+      ID: 93
       Name: groupReference<string,[]string>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 50 PointerType *noalg.map.group[string][]string
+          Type: 94 PointerType *noalg.map.group[string][]string
         - Name: lengthMask
           Offset: 8
           Type: 8 BaseType uint64
-      GroupType: 51 StructureType noalg.map.group[string][]string
+      GroupType: 95 StructureType noalg.map.group[string][]string
       GroupSliceType: 165 GoSliceDataType []noalg.map.group[string][]string.array
     - __kind: GoSwissMapGroupsType
-      ID: 153
+      ID: 98
       Name: groupReference<string,string>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 154 PointerType *noalg.map.group[string]string
+          Type: 99 PointerType *noalg.map.group[string]string
         - Name: lengthMask
           Offset: 8
           Type: 8 BaseType uint64
-      GroupType: 155 StructureType noalg.map.group[string]string
-      GroupSliceType: 213 GoSliceDataType []noalg.map.group[string]string.array
+      GroupType: 100 StructureType noalg.map.group[string]string
+      GroupSliceType: 169 GoSliceDataType []noalg.map.group[string]string.array
     - __kind: BaseType
       ID: 7
       Name: int
@@ -1615,7 +1615,7 @@ Types:
       GoRuntimeType: 584288
       GoKind: 3
     - __kind: GoEmptyInterfaceType
-      ID: 87
+      ID: 108
       Name: interface {}
       ByteSize: 16
       GoRuntimeType: 854240
@@ -1628,7 +1628,7 @@ Types:
           Offset: 8
           Type: 15 VoidPointerType unsafe.Pointer
     - __kind: GoInterfaceType
-      ID: 55
+      ID: 49
       Name: io.ReadCloser
       ByteSize: 16
       GoRuntimeType: 1.10976e+06
@@ -1641,7 +1641,7 @@ Types:
           Offset: 8
           Type: 15 VoidPointerType unsafe.Pointer
     - __kind: GoSwissMapHeaderType
-      ID: 63
+      ID: 76
       Name: map<string,[]*mime/multipart.FileHeader>
       ByteSize: 48
       GoKind: 25
@@ -1654,7 +1654,7 @@ Types:
           Type: 1 BaseType uintptr
         - Name: dirPtr
           Offset: 16
-          Type: 64 PointerType **table<string,[]*mime/multipart.FileHeader>
+          Type: 77 PointerType **table<string,[]*mime/multipart.FileHeader>
         - Name: dirLen
           Offset: 24
           Type: 7 BaseType int
@@ -1673,10 +1673,10 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 8 BaseType uint64
-      TablePtrSliceType: 168 GoSliceDataType []*table<string,[]*mime/multipart.FileHeader>.array
-      GroupType: 69 StructureType noalg.map.group[string][]*mime/multipart.FileHeader
+      TablePtrSliceType: 172 GoSliceDataType []*table<string,[]*mime/multipart.FileHeader>.array
+      GroupType: 105 StructureType noalg.map.group[string][]*mime/multipart.FileHeader
     - __kind: GoSwissMapHeaderType
-      ID: 45
+      ID: 46
       Name: map<string,[]string>
       ByteSize: 48
       GoKind: 25
@@ -1689,7 +1689,7 @@ Types:
           Type: 1 BaseType uintptr
         - Name: dirPtr
           Offset: 16
-          Type: 46 PointerType **table<string,[]string>
+          Type: 47 PointerType **table<string,[]string>
         - Name: dirLen
           Offset: 24
           Type: 7 BaseType int
@@ -1709,9 +1709,9 @@ Types:
           Offset: 40
           Type: 8 BaseType uint64
       TablePtrSliceType: 164 GoSliceDataType []*table<string,[]string>.array
-      GroupType: 51 StructureType noalg.map.group[string][]string
+      GroupType: 95 StructureType noalg.map.group[string][]string
     - __kind: GoSwissMapHeaderType
-      ID: 149
+      ID: 65
       Name: map<string,string>
       ByteSize: 48
       GoKind: 25
@@ -1724,7 +1724,7 @@ Types:
           Type: 1 BaseType uintptr
         - Name: dirPtr
           Offset: 16
-          Type: 150 PointerType **table<string,string>
+          Type: 66 PointerType **table<string,string>
         - Name: dirLen
           Offset: 24
           Type: 7 BaseType int
@@ -1743,31 +1743,31 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 8 BaseType uint64
-      TablePtrSliceType: 212 GoSliceDataType []*table<string,string>.array
-      GroupType: 155 StructureType noalg.map.group[string]string
+      TablePtrSliceType: 168 GoSliceDataType []*table<string,string>.array
+      GroupType: 100 StructureType noalg.map.group[string]string
     - __kind: GoMapType
-      ID: 61
+      ID: 74
       Name: map[string][]*mime/multipart.FileHeader
       ByteSize: 8
       GoRuntimeType: 1.131648e+06
       GoKind: 21
-      HeaderType: 63 GoSwissMapHeaderType map<string,[]*mime/multipart.FileHeader>
+      HeaderType: 76 GoSwissMapHeaderType map<string,[]*mime/multipart.FileHeader>
     - __kind: GoMapType
-      ID: 60
+      ID: 73
       Name: map[string][]string
       ByteSize: 8
       GoRuntimeType: 1.127296e+06
       GoKind: 21
-      HeaderType: 45 GoSwissMapHeaderType map<string,[]string>
+      HeaderType: 46 GoSwissMapHeaderType map<string,[]string>
     - __kind: GoMapType
-      ID: 147
+      ID: 63
       Name: map[string]string
       ByteSize: 8
       GoRuntimeType: 1.12832e+06
       GoKind: 21
-      HeaderType: 149 GoSwissMapHeaderType map<string,string>
+      HeaderType: 65 GoSwissMapHeaderType map<string,string>
     - __kind: StructureType
-      ID: 89
+      ID: 110
       Name: math/big.Int
       ByteSize: 32
       GoRuntimeType: 1.493568e+06
@@ -1778,15 +1778,15 @@ Types:
           Type: 4 BaseType bool
         - Name: abs
           Offset: 8
-          Type: 90 GoSliceHeaderType math/big.nat
+          Type: 149 GoSliceHeaderType math/big.nat
     - __kind: BaseType
-      ID: 92
+      ID: 151
       Name: math/big.Word
       ByteSize: 8
       GoRuntimeType: 588128
       GoKind: 7
     - __kind: GoSliceHeaderType
-      ID: 90
+      ID: 149
       Name: math/big.nat
       ByteSize: 24
       GoRuntimeType: 2.361088e+06
@@ -1794,21 +1794,21 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 91 PointerType *math/big.Word
+          Type: 150 PointerType *math/big.Word
         - Name: len
           Offset: 8
           Type: 7 BaseType int
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 176 GoSliceDataType math/big.nat.array
+      Data: 206 GoSliceDataType math/big.nat.array
     - __kind: GoSliceDataType
-      ID: 176
+      ID: 206
       Name: math/big.nat.array
       ByteSize: 2048
-      Element: 92 BaseType math/big.Word
+      Element: 151 BaseType math/big.Word
     - __kind: StructureType
-      ID: 75
+      ID: 159
       Name: mime/multipart.FileHeader
       ByteSize: 88
       GoRuntimeType: 1.977088e+06
@@ -1819,13 +1819,13 @@ Types:
           Type: 9 GoStringHeaderType string
         - Name: Header
           Offset: 16
-          Type: 76 GoMapType net/textproto.MIMEHeader
+          Type: 161 GoMapType net/textproto.MIMEHeader
         - Name: Size
           Offset: 24
           Type: 13 BaseType int64
         - Name: content
           Offset: 32
-          Type: 77 GoSliceHeaderType []uint8
+          Type: 68 GoSliceHeaderType []uint8
         - Name: tmpfile
           Offset: 56
           Type: 9 GoStringHeaderType string
@@ -1836,7 +1836,7 @@ Types:
           Offset: 80
           Type: 4 BaseType bool
     - __kind: StructureType
-      ID: 59
+      ID: 54
       Name: mime/multipart.Form
       ByteSize: 16
       GoRuntimeType: 1.477408e+06
@@ -1844,12 +1844,12 @@ Types:
       RawFields:
         - Name: Value
           Offset: 0
-          Type: 60 GoMapType map[string][]string
+          Type: 73 GoMapType map[string][]string
         - Name: File
           Offset: 8
-          Type: 61 GoMapType map[string][]*mime/multipart.FileHeader
+          Type: 74 GoMapType map[string][]*mime/multipart.FileHeader
     - __kind: GoSliceHeaderType
-      ID: 118
+      ID: 130
       Name: net.IP
       ByteSize: 24
       GoRuntimeType: 2.123744e+06
@@ -1871,7 +1871,7 @@ Types:
       ByteSize: 2048
       Element: 3 BaseType uint8
     - __kind: GoSliceHeaderType
-      ID: 125
+      ID: 160
       Name: net.IPMask
       ByteSize: 24
       GoRuntimeType: 1.01904e+06
@@ -1886,14 +1886,14 @@ Types:
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 200 GoSliceDataType net.IPMask.array
+      Data: 212 GoSliceDataType net.IPMask.array
     - __kind: GoSliceDataType
-      ID: 200
+      ID: 212
       Name: net.IPMask.array
       ByteSize: 2048
       Element: 3 BaseType uint8
     - __kind: StructureType
-      ID: 124
+      ID: 158
       Name: net.IPNet
       ByteSize: 48
       GoRuntimeType: 1.458208e+06
@@ -1901,17 +1901,17 @@ Types:
       RawFields:
         - Name: IP
           Offset: 0
-          Type: 118 GoSliceHeaderType net.IP
+          Type: 130 GoSliceHeaderType net.IP
         - Name: Mask
           Offset: 24
-          Type: 125 GoSliceHeaderType net.IPMask
+          Type: 160 GoSliceHeaderType net.IPMask
     - __kind: GoMapType
-      ID: 43
+      ID: 44
       Name: net/http.Header
       ByteSize: 8
       GoRuntimeType: 2.100864e+06
       GoKind: 21
-      HeaderType: 45 GoSwissMapHeaderType map<string,[]string>
+      HeaderType: 46 GoSwissMapHeaderType map<string,[]string>
     - __kind: StructureType
       ID: 38
       Name: net/http.Request
@@ -1924,7 +1924,7 @@ Types:
           Type: 9 GoStringHeaderType string
         - Name: URL
           Offset: 16
-          Type: 39 PointerType *net/url.URL
+          Type: 42 PointerType *net/url.URL
         - Name: Proto
           Offset: 24
           Type: 9 GoStringHeaderType string
@@ -1936,19 +1936,19 @@ Types:
           Type: 7 BaseType int
         - Name: Header
           Offset: 56
-          Type: 43 GoMapType net/http.Header
+          Type: 44 GoMapType net/http.Header
         - Name: Body
           Offset: 64
-          Type: 55 GoInterfaceType io.ReadCloser
+          Type: 49 GoInterfaceType io.ReadCloser
         - Name: GetBody
           Offset: 80
-          Type: 56 GoSubroutineType func() (io.ReadCloser, error)
+          Type: 50 GoSubroutineType func() (io.ReadCloser, error)
         - Name: ContentLength
           Offset: 88
           Type: 13 BaseType int64
         - Name: TransferEncoding
           Offset: 96
-          Type: 54 GoSliceHeaderType []string
+          Type: 51 GoSliceHeaderType []string
         - Name: Close
           Offset: 120
           Type: 4 BaseType bool
@@ -1957,16 +1957,16 @@ Types:
           Type: 9 GoStringHeaderType string
         - Name: Form
           Offset: 144
-          Type: 57 GoMapType net/url.Values
+          Type: 52 GoMapType net/url.Values
         - Name: PostForm
           Offset: 152
-          Type: 57 GoMapType net/url.Values
+          Type: 52 GoMapType net/url.Values
         - Name: MultipartForm
           Offset: 160
-          Type: 58 PointerType *mime/multipart.Form
+          Type: 53 PointerType *mime/multipart.Form
         - Name: Trailer
           Offset: 168
-          Type: 43 GoMapType net/http.Header
+          Type: 44 GoMapType net/http.Header
         - Name: RemoteAddr
           Offset: 176
           Type: 9 GoStringHeaderType string
@@ -1975,30 +1975,30 @@ Types:
           Type: 9 GoStringHeaderType string
         - Name: TLS
           Offset: 208
-          Type: 78 PointerType *crypto/tls.ConnectionState
+          Type: 55 PointerType *crypto/tls.ConnectionState
         - Name: Cancel
           Offset: 216
-          Type: 138 GoChannelType <-chan struct {}
+          Type: 57 GoChannelType <-chan struct {}
         - Name: Response
           Offset: 224
-          Type: 139 PointerType *net/http.Response
+          Type: 58 PointerType *net/http.Response
         - Name: Pattern
           Offset: 232
           Type: 9 GoStringHeaderType string
         - Name: ctx
           Offset: 248
-          Type: 141 GoInterfaceType context.Context
+          Type: 60 GoInterfaceType context.Context
         - Name: pat
           Offset: 264
-          Type: 142 PointerType *net/http.pattern
+          Type: 61 PointerType *net/http.pattern
         - Name: matches
           Offset: 272
-          Type: 54 GoSliceHeaderType []string
+          Type: 51 GoSliceHeaderType []string
         - Name: otherValues
           Offset: 296
-          Type: 147 GoMapType map[string]string
+          Type: 63 GoMapType map[string]string
     - __kind: StructureType
-      ID: 140
+      ID: 59
       Name: net/http.Response
       ByteSize: 144
       GoRuntimeType: 2.209888e+06
@@ -2021,16 +2021,16 @@ Types:
           Type: 7 BaseType int
         - Name: Header
           Offset: 56
-          Type: 43 GoMapType net/http.Header
+          Type: 44 GoMapType net/http.Header
         - Name: Body
           Offset: 64
-          Type: 55 GoInterfaceType io.ReadCloser
+          Type: 49 GoInterfaceType io.ReadCloser
         - Name: ContentLength
           Offset: 80
           Type: 13 BaseType int64
         - Name: TransferEncoding
           Offset: 88
-          Type: 54 GoSliceHeaderType []string
+          Type: 51 GoSliceHeaderType []string
         - Name: Close
           Offset: 112
           Type: 4 BaseType bool
@@ -2039,13 +2039,13 @@ Types:
           Type: 4 BaseType bool
         - Name: Trailer
           Offset: 120
-          Type: 43 GoMapType net/http.Header
+          Type: 44 GoMapType net/http.Header
         - Name: Request
           Offset: 128
           Type: 37 PointerType *net/http.Request
         - Name: TLS
           Offset: 136
-          Type: 78 PointerType *crypto/tls.ConnectionState
+          Type: 55 PointerType *crypto/tls.ConnectionState
     - __kind: GoInterfaceType
       ID: 36
       Name: net/http.ResponseWriter
@@ -2060,7 +2060,7 @@ Types:
           Offset: 8
           Type: 15 VoidPointerType unsafe.Pointer
     - __kind: StructureType
-      ID: 143
+      ID: 62
       Name: net/http.pattern
       ByteSize: 88
       GoRuntimeType: 1.833088e+06
@@ -2077,12 +2077,12 @@ Types:
           Type: 9 GoStringHeaderType string
         - Name: segments
           Offset: 48
-          Type: 144 GoSliceHeaderType []net/http.segment
+          Type: 89 GoSliceHeaderType []net/http.segment
         - Name: loc
           Offset: 72
           Type: 9 GoStringHeaderType string
     - __kind: StructureType
-      ID: 146
+      ID: 91
       Name: net/http.segment
       ByteSize: 24
       GoRuntimeType: 1.607872e+06
@@ -2098,14 +2098,14 @@ Types:
           Offset: 17
           Type: 4 BaseType bool
     - __kind: GoMapType
-      ID: 76
+      ID: 161
       Name: net/textproto.MIMEHeader
       ByteSize: 8
       GoRuntimeType: 1.82304e+06
       GoKind: 21
-      HeaderType: 45 GoSwissMapHeaderType map<string,[]string>
+      HeaderType: 46 GoSwissMapHeaderType map<string,[]string>
     - __kind: StructureType
-      ID: 40
+      ID: 43
       Name: net/url.URL
       ByteSize: 144
       GoRuntimeType: 2.126816e+06
@@ -2119,7 +2119,7 @@ Types:
           Type: 9 GoStringHeaderType string
         - Name: User
           Offset: 32
-          Type: 41 PointerType *net/url.Userinfo
+          Type: 70 PointerType *net/url.Userinfo
         - Name: Host
           Offset: 40
           Type: 9 GoStringHeaderType string
@@ -2145,7 +2145,7 @@ Types:
           Offset: 128
           Type: 9 GoStringHeaderType string
     - __kind: StructureType
-      ID: 42
+      ID: 71
       Name: net/url.Userinfo
       ByteSize: 40
       GoRuntimeType: 1.624384e+06
@@ -2161,41 +2161,41 @@ Types:
           Offset: 32
           Type: 4 BaseType bool
     - __kind: GoMapType
-      ID: 57
+      ID: 52
       Name: net/url.Values
       ByteSize: 8
       GoRuntimeType: 1.884384e+06
       GoKind: 21
-      HeaderType: 45 GoSwissMapHeaderType map<string,[]string>
+      HeaderType: 46 GoSwissMapHeaderType map<string,[]string>
     - __kind: ArrayType
-      ID: 70
+      ID: 144
       Name: noalg.[8]struct { key string; elem []*mime/multipart.FileHeader }
       ByteSize: 320
       GoRuntimeType: 699072
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 71 StructureType noalg.struct { key string; elem []*mime/multipart.FileHeader }
+      Element: 145 StructureType noalg.struct { key string; elem []*mime/multipart.FileHeader }
     - __kind: ArrayType
-      ID: 52
+      ID: 101
       Name: noalg.[8]struct { key string; elem []string }
       ByteSize: 320
       GoRuntimeType: 689248
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 53 StructureType noalg.struct { key string; elem []string }
+      Element: 102 StructureType noalg.struct { key string; elem []string }
     - __kind: ArrayType
-      ID: 156
+      ID: 142
       Name: noalg.[8]struct { key string; elem string }
       ByteSize: 256
       GoRuntimeType: 693408
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 157 StructureType noalg.struct { key string; elem string }
+      Element: 143 StructureType noalg.struct { key string; elem string }
     - __kind: StructureType
-      ID: 69
+      ID: 105
       Name: noalg.map.group[string][]*mime/multipart.FileHeader
       ByteSize: 328
       GoRuntimeType: 1.298816e+06
@@ -2206,9 +2206,9 @@ Types:
           Type: 8 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 70 ArrayType noalg.[8]struct { key string; elem []*mime/multipart.FileHeader }
+          Type: 144 ArrayType noalg.[8]struct { key string; elem []*mime/multipart.FileHeader }
     - __kind: StructureType
-      ID: 51
+      ID: 95
       Name: noalg.map.group[string][]string
       ByteSize: 328
       GoRuntimeType: 1.289728e+06
@@ -2219,9 +2219,9 @@ Types:
           Type: 8 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 52 ArrayType noalg.[8]struct { key string; elem []string }
+          Type: 101 ArrayType noalg.[8]struct { key string; elem []string }
     - __kind: StructureType
-      ID: 155
+      ID: 100
       Name: noalg.map.group[string]string
       ByteSize: 264
       GoRuntimeType: 1.29216e+06
@@ -2232,9 +2232,9 @@ Types:
           Type: 8 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 156 ArrayType noalg.[8]struct { key string; elem string }
+          Type: 142 ArrayType noalg.[8]struct { key string; elem string }
     - __kind: StructureType
-      ID: 71
+      ID: 145
       Name: noalg.struct { key string; elem []*mime/multipart.FileHeader }
       ByteSize: 40
       GoRuntimeType: 1.298688e+06
@@ -2245,9 +2245,9 @@ Types:
           Type: 9 GoStringHeaderType string
         - Name: elem
           Offset: 16
-          Type: 72 GoSliceHeaderType []*mime/multipart.FileHeader
+          Type: 146 GoSliceHeaderType []*mime/multipart.FileHeader
     - __kind: StructureType
-      ID: 53
+      ID: 102
       Name: noalg.struct { key string; elem []string }
       ByteSize: 40
       GoRuntimeType: 1.2896e+06
@@ -2258,9 +2258,9 @@ Types:
           Type: 9 GoStringHeaderType string
         - Name: elem
           Offset: 16
-          Type: 54 GoSliceHeaderType []string
+          Type: 51 GoSliceHeaderType []string
     - __kind: StructureType
-      ID: 157
+      ID: 143
       Name: noalg.struct { key string; elem string }
       ByteSize: 32
       GoRuntimeType: 1.292032e+06
@@ -2291,7 +2291,7 @@ Types:
       Name: string.str
       ByteSize: 2048
     - __kind: StructureType
-      ID: 66
+      ID: 96
       Name: table<string,[]*mime/multipart.FileHeader>
       ByteSize: 32
       GoKind: 25
@@ -2313,9 +2313,9 @@ Types:
           Type: 7 BaseType int
         - Name: groups
           Offset: 16
-          Type: 67 GoSwissMapGroupsType groupReference<string,[]*mime/multipart.FileHeader>
+          Type: 103 GoSwissMapGroupsType groupReference<string,[]*mime/multipart.FileHeader>
     - __kind: StructureType
-      ID: 48
+      ID: 72
       Name: table<string,[]string>
       ByteSize: 32
       GoKind: 25
@@ -2337,9 +2337,9 @@ Types:
           Type: 7 BaseType int
         - Name: groups
           Offset: 16
-          Type: 49 GoSwissMapGroupsType groupReference<string,[]string>
+          Type: 93 GoSwissMapGroupsType groupReference<string,[]string>
     - __kind: StructureType
-      ID: 152
+      ID: 92
       Name: table<string,string>
       ByteSize: 32
       GoKind: 25
@@ -2361,9 +2361,9 @@ Types:
           Type: 7 BaseType int
         - Name: groups
           Offset: 16
-          Type: 153 GoSwissMapGroupsType groupReference<string,string>
+          Type: 98 GoSwissMapGroupsType groupReference<string,string>
     - __kind: StructureType
-      ID: 100
+      ID: 117
       Name: time.Location
       ByteSize: 104
       GoRuntimeType: 1.972768e+06
@@ -2374,10 +2374,10 @@ Types:
           Type: 9 GoStringHeaderType string
         - Name: zone
           Offset: 16
-          Type: 101 GoSliceHeaderType []time.zone
+          Type: 152 GoSliceHeaderType []time.zone
         - Name: tx
           Offset: 40
-          Type: 104 GoSliceHeaderType []time.zoneTrans
+          Type: 155 GoSliceHeaderType []time.zoneTrans
         - Name: extend
           Offset: 64
           Type: 9 GoStringHeaderType string
@@ -2389,9 +2389,9 @@ Types:
           Type: 13 BaseType int64
         - Name: cacheZone
           Offset: 96
-          Type: 102 PointerType *time.zone
+          Type: 153 PointerType *time.zone
     - __kind: StructureType
-      ID: 98
+      ID: 115
       Name: time.Time
       ByteSize: 24
       GoRuntimeType: 2.363936e+06
@@ -2405,9 +2405,9 @@ Types:
           Type: 13 BaseType int64
         - Name: loc
           Offset: 16
-          Type: 99 PointerType *time.Location
+          Type: 116 PointerType *time.Location
     - __kind: StructureType
-      ID: 103
+      ID: 154
       Name: time.zone
       ByteSize: 32
       GoRuntimeType: 1.612864e+06
@@ -2423,7 +2423,7 @@ Types:
           Offset: 24
           Type: 4 BaseType bool
     - __kind: StructureType
-      ID: 106
+      ID: 157
       Name: time.zoneTrans
       ByteSize: 16
       GoRuntimeType: 1.750304e+06

--- a/pkg/dyninst/irgen/testdata/snapshot/rc_tester_v1.arch=arm64,toolchain=go1.25.0.yaml
+++ b/pkg/dyninst/irgen/testdata/snapshot/rc_tester_v1.arch=arm64,toolchain=go1.25.0.yaml
@@ -107,435 +107,319 @@ Subprograms:
           IsParameter: true
           IsReturn: false
 Types:
-    - __kind: GoInterfaceType
-      ID: 1
-      Name: net/http.ResponseWriter
-      ByteSize: 16
-      GoRuntimeType: 1.185088e+06
-      GoKind: 20
-      RawFields:
-        - Name: tab
-          Offset: 0
-          Type: 2 VoidPointerType unsafe.Pointer
-        - Name: data
-          Offset: 8
-          Type: 2 VoidPointerType unsafe.Pointer
-    - __kind: VoidPointerType
-      ID: 2
-      Name: unsafe.Pointer
-      ByteSize: 8
-      GoRuntimeType: 585312
-      GoKind: 26
     - __kind: PointerType
-      ID: 3
-      Name: '*net/http.Request'
+      ID: 58
+      Name: '**crypto/x509.Certificate'
       ByteSize: 8
-      GoRuntimeType: 2.300192e+06
       GoKind: 22
-      Pointee: 4 StructureType net/http.Request
-    - __kind: StructureType
-      ID: 4
-      Name: net/http.Request
-      ByteSize: 304
-      GoRuntimeType: 2.336064e+06
-      GoKind: 25
-      RawFields:
-        - Name: Method
-          Offset: 0
-          Type: 5 GoStringHeaderType string
-        - Name: URL
-          Offset: 16
-          Type: 9 PointerType *net/url.URL
-        - Name: Proto
-          Offset: 24
-          Type: 5 GoStringHeaderType string
-        - Name: ProtoMajor
-          Offset: 40
-          Type: 8 BaseType int
-        - Name: ProtoMinor
-          Offset: 48
-          Type: 8 BaseType int
-        - Name: Header
-          Offset: 56
-          Type: 14 GoMapType net/http.Header
-        - Name: Body
-          Offset: 64
-          Type: 30 GoInterfaceType io.ReadCloser
-        - Name: GetBody
-          Offset: 80
-          Type: 31 GoSubroutineType func() (io.ReadCloser, error)
-        - Name: ContentLength
-          Offset: 88
-          Type: 32 BaseType int64
-        - Name: TransferEncoding
-          Offset: 96
-          Type: 28 GoSliceHeaderType []string
-        - Name: Close
-          Offset: 120
-          Type: 13 BaseType bool
-        - Name: Host
-          Offset: 128
-          Type: 5 GoStringHeaderType string
-        - Name: Form
-          Offset: 144
-          Type: 33 GoMapType net/url.Values
-        - Name: PostForm
-          Offset: 152
-          Type: 33 GoMapType net/url.Values
-        - Name: MultipartForm
-          Offset: 160
-          Type: 34 PointerType *mime/multipart.Form
-        - Name: Trailer
-          Offset: 168
-          Type: 14 GoMapType net/http.Header
-        - Name: RemoteAddr
-          Offset: 176
-          Type: 5 GoStringHeaderType string
-        - Name: RequestURI
-          Offset: 192
-          Type: 5 GoStringHeaderType string
-        - Name: TLS
-          Offset: 208
-          Type: 54 PointerType *crypto/tls.ConnectionState
-        - Name: Cancel
-          Offset: 216
-          Type: 115 GoChannelType <-chan struct {}
-        - Name: Response
-          Offset: 224
-          Type: 116 PointerType *net/http.Response
-        - Name: Pattern
-          Offset: 232
-          Type: 5 GoStringHeaderType string
-        - Name: ctx
-          Offset: 248
-          Type: 118 GoInterfaceType context.Context
-        - Name: pat
-          Offset: 264
-          Type: 119 PointerType *net/http.pattern
-        - Name: matches
-          Offset: 272
-          Type: 28 GoSliceHeaderType []string
-        - Name: otherValues
-          Offset: 296
-          Type: 124 GoMapType map[string]string
-    - __kind: GoStringHeaderType
-      ID: 5
-      Name: string
-      ByteSize: 16
-      GoRuntimeType: 584224
-      GoKind: 24
-      RawFields:
-        - Name: str
-          Offset: 0
-          Type: 163 PointerType *string.str
-        - Name: len
-          Offset: 8
-          Type: 8 BaseType int
-      Data: 162 GoStringDataType string.str
+      Pointee: 59 PointerType *crypto/x509.Certificate
     - __kind: PointerType
-      ID: 6
-      Name: '*uint8'
+      ID: 49
+      Name: '**mime/multipart.FileHeader'
       ByteSize: 8
-      GoRuntimeType: 399328
       GoKind: 22
-      Pointee: 7 BaseType uint8
-    - __kind: BaseType
-      ID: 7
-      Name: uint8
-      ByteSize: 1
-      GoRuntimeType: 584352
-      GoKind: 8
-    - __kind: BaseType
-      ID: 8
-      Name: int
-      ByteSize: 8
-      GoRuntimeType: 584800
-      GoKind: 2
+      Pointee: 50 PointerType *mime/multipart.FileHeader
     - __kind: PointerType
-      ID: 9
-      Name: '*net/url.URL'
+      ID: 99
+      Name: '**net.IPNet'
       ByteSize: 8
-      GoRuntimeType: 2.112832e+06
       GoKind: 22
-      Pointee: 10 StructureType net/url.URL
-    - __kind: StructureType
-      ID: 10
-      Name: net/url.URL
-      ByteSize: 144
-      GoRuntimeType: 2.126816e+06
-      GoKind: 25
-      RawFields:
-        - Name: Scheme
-          Offset: 0
-          Type: 5 GoStringHeaderType string
-        - Name: Opaque
-          Offset: 16
-          Type: 5 GoStringHeaderType string
-        - Name: User
-          Offset: 32
-          Type: 11 PointerType *net/url.Userinfo
-        - Name: Host
-          Offset: 40
-          Type: 5 GoStringHeaderType string
-        - Name: Path
-          Offset: 56
-          Type: 5 GoStringHeaderType string
-        - Name: RawPath
-          Offset: 72
-          Type: 5 GoStringHeaderType string
-        - Name: OmitHost
-          Offset: 88
-          Type: 13 BaseType bool
-        - Name: ForceQuery
-          Offset: 89
-          Type: 13 BaseType bool
-        - Name: RawQuery
-          Offset: 96
-          Type: 5 GoStringHeaderType string
-        - Name: Fragment
-          Offset: 112
-          Type: 5 GoStringHeaderType string
-        - Name: RawFragment
-          Offset: 128
-          Type: 5 GoStringHeaderType string
+      Pointee: 100 PointerType *net.IPNet
     - __kind: PointerType
-      ID: 11
-      Name: '*net/url.Userinfo'
+      ID: 97
+      Name: '**net/url.URL'
       ByteSize: 8
-      GoRuntimeType: 1.200064e+06
-      GoKind: 22
-      Pointee: 12 StructureType net/url.Userinfo
-    - __kind: StructureType
-      ID: 12
-      Name: net/url.Userinfo
-      ByteSize: 40
-      GoRuntimeType: 1.624384e+06
-      GoKind: 25
-      RawFields:
-        - Name: username
-          Offset: 0
-          Type: 5 GoStringHeaderType string
-        - Name: password
-          Offset: 16
-          Type: 5 GoStringHeaderType string
-        - Name: passwordSet
-          Offset: 32
-          Type: 13 BaseType bool
-    - __kind: BaseType
-      ID: 13
-      Name: bool
-      ByteSize: 1
-      GoRuntimeType: 585248
-      GoKind: 1
-    - __kind: GoMapType
-      ID: 14
-      Name: net/http.Header
-      ByteSize: 8
-      GoRuntimeType: 2.100864e+06
-      GoKind: 21
-      HeaderType: 16 GoSwissMapHeaderType map<string,[]string>
+      Pointee: 9 PointerType *net/url.URL
     - __kind: PointerType
-      ID: 15
-      Name: '*map<string,[]string>'
+      ID: 40
+      Name: '**table<string,[]*mime/multipart.FileHeader>'
       ByteSize: 8
-      Pointee: 16 GoSwissMapHeaderType map<string,[]string>
-    - __kind: GoSwissMapHeaderType
-      ID: 16
-      Name: map<string,[]string>
-      ByteSize: 48
-      GoKind: 25
-      RawFields:
-        - Name: used
-          Offset: 0
-          Type: 17 BaseType uint64
-        - Name: seed
-          Offset: 8
-          Type: 18 BaseType uintptr
-        - Name: dirPtr
-          Offset: 16
-          Type: 19 PointerType **table<string,[]string>
-        - Name: dirLen
-          Offset: 24
-          Type: 8 BaseType int
-        - Name: globalDepth
-          Offset: 32
-          Type: 7 BaseType uint8
-        - Name: globalShift
-          Offset: 33
-          Type: 7 BaseType uint8
-        - Name: writing
-          Offset: 34
-          Type: 7 BaseType uint8
-        - Name: tombstonePossible
-          Offset: 35
-          Type: 13 BaseType bool
-        - Name: clearSeq
-          Offset: 40
-          Type: 17 BaseType uint64
-      TablePtrSliceType: 164 GoSliceDataType []*table<string,[]string>.array
-      GroupType: 25 StructureType noalg.map.group[string][]string
-    - __kind: BaseType
-      ID: 17
-      Name: uint64
-      ByteSize: 8
-      GoRuntimeType: 584736
-      GoKind: 11
-    - __kind: BaseType
-      ID: 18
-      Name: uintptr
-      ByteSize: 8
-      GoRuntimeType: 584928
-      GoKind: 12
+      Pointee: 41 PointerType *table<string,[]*mime/multipart.FileHeader>
     - __kind: PointerType
       ID: 19
       Name: '**table<string,[]string>'
       ByteSize: 8
       Pointee: 20 PointerType *table<string,[]string>
     - __kind: PointerType
-      ID: 20
-      Name: '*table<string,[]string>'
+      ID: 127
+      Name: '**table<string,string>'
       ByteSize: 8
-      Pointee: 21 StructureType table<string,[]string>
-    - __kind: StructureType
-      ID: 21
-      Name: table<string,[]string>
-      ByteSize: 32
-      GoKind: 25
-      RawFields:
-        - Name: used
-          Offset: 0
-          Type: 22 BaseType uint16
-        - Name: capacity
-          Offset: 2
-          Type: 22 BaseType uint16
-        - Name: growthLeft
-          Offset: 4
-          Type: 22 BaseType uint16
-        - Name: localDepth
-          Offset: 6
-          Type: 7 BaseType uint8
-        - Name: index
-          Offset: 8
-          Type: 8 BaseType int
-        - Name: groups
-          Offset: 16
-          Type: 23 GoSwissMapGroupsType groupReference<string,[]string>
-    - __kind: BaseType
-      ID: 22
-      Name: uint16
-      ByteSize: 2
-      GoRuntimeType: 584480
-      GoKind: 9
-    - __kind: GoSwissMapGroupsType
-      ID: 23
-      Name: groupReference<string,[]string>
-      ByteSize: 16
-      GoKind: 25
-      RawFields:
-        - Name: data
-          Offset: 0
-          Type: 24 PointerType *noalg.map.group[string][]string
-        - Name: lengthMask
-          Offset: 8
-          Type: 17 BaseType uint64
-      GroupType: 25 StructureType noalg.map.group[string][]string
-      GroupSliceType: 165 GoSliceDataType []noalg.map.group[string][]string.array
+      Pointee: 128 PointerType *table<string,string>
     - __kind: PointerType
-      ID: 24
-      Name: '*noalg.map.group[string][]string'
+      ID: 110
+      Name: '*[]*crypto/x509.Certificate'
       ByteSize: 8
-      Pointee: 25 StructureType noalg.map.group[string][]string
-    - __kind: StructureType
-      ID: 25
-      Name: noalg.map.group[string][]string
-      ByteSize: 328
-      GoRuntimeType: 1.289728e+06
-      GoKind: 25
-      RawFields:
-        - Name: ctrl
-          Offset: 0
-          Type: 17 BaseType uint64
-        - Name: slots
-          Offset: 8
-          Type: 26 ArrayType noalg.[8]struct { key string; elem []string }
-    - __kind: ArrayType
-      ID: 26
-      Name: noalg.[8]struct { key string; elem []string }
-      ByteSize: 320
-      GoRuntimeType: 689248
-      GoKind: 17
-      Count: 8
-      HasCount: true
-      Element: 27 StructureType noalg.struct { key string; elem []string }
-    - __kind: StructureType
-      ID: 27
-      Name: noalg.struct { key string; elem []string }
-      ByteSize: 40
-      GoRuntimeType: 1.2896e+06
-      GoKind: 25
-      RawFields:
-        - Name: key
-          Offset: 0
-          Type: 5 GoStringHeaderType string
-        - Name: elem
-          Offset: 16
-          Type: 28 GoSliceHeaderType []string
-    - __kind: GoSliceHeaderType
-      ID: 28
-      Name: '[]string'
-      ByteSize: 24
-      GoRuntimeType: 496288
-      GoKind: 23
-      RawFields:
-        - Name: array
-          Offset: 0
-          Type: 29 PointerType *string
-        - Name: len
-          Offset: 8
-          Type: 8 BaseType int
-        - Name: cap
-          Offset: 16
-          Type: 8 BaseType int
-      Data: 166 GoSliceDataType []string.array
-    - __kind: PointerType
-      ID: 29
-      Name: '*string'
-      ByteSize: 8
-      GoRuntimeType: 399200
       GoKind: 22
-      Pointee: 5 GoStringHeaderType string
-    - __kind: GoInterfaceType
-      ID: 30
-      Name: io.ReadCloser
-      ByteSize: 16
-      GoRuntimeType: 1.10976e+06
-      GoKind: 20
-      RawFields:
-        - Name: tab
-          Offset: 0
-          Type: 2 VoidPointerType unsafe.Pointer
-        - Name: data
-          Offset: 8
-          Type: 2 VoidPointerType unsafe.Pointer
-    - __kind: GoSubroutineType
-      ID: 31
-      Name: func() (io.ReadCloser, error)
+      Pointee: 57 GoSliceHeaderType []*crypto/x509.Certificate
+    - __kind: PointerType
+      ID: 175
+      Name: '*[]*crypto/x509.Certificate.array'
       ByteSize: 8
-      GoRuntimeType: 693216
-      GoKind: 19
-    - __kind: BaseType
-      ID: 32
-      Name: int64
+      Pointee: 174 GoSliceDataType []*crypto/x509.Certificate.array
+    - __kind: PointerType
+      ID: 171
+      Name: '*[]*mime/multipart.FileHeader.array'
       ByteSize: 8
-      GoRuntimeType: 584672
-      GoKind: 6
-    - __kind: GoMapType
-      ID: 33
-      Name: net/url.Values
+      Pointee: 170 GoSliceDataType []*mime/multipart.FileHeader.array
+    - __kind: PointerType
+      ID: 199
+      Name: '*[]*net.IPNet.array'
       ByteSize: 8
-      GoRuntimeType: 1.884384e+06
-      GoKind: 21
-      HeaderType: 16 GoSwissMapHeaderType map<string,[]string>
+      Pointee: 198 GoSliceDataType []*net.IPNet.array
+    - __kind: PointerType
+      ID: 197
+      Name: '*[]*net/url.URL.array'
+      ByteSize: 8
+      Pointee: 196 GoSliceDataType []*net/url.URL.array
+    - __kind: PointerType
+      ID: 207
+      Name: '*[][]*crypto/x509.Certificate.array'
+      ByteSize: 8
+      Pointee: 206 GoSliceDataType [][]*crypto/x509.Certificate.array
+    - __kind: PointerType
+      ID: 209
+      Name: '*[][]uint8.array'
+      ByteSize: 8
+      Pointee: 208 GoSliceDataType [][]uint8.array
+    - __kind: PointerType
+      ID: 191
+      Name: '*[]crypto/x509.ExtKeyUsage.array'
+      ByteSize: 8
+      Pointee: 190 GoSliceDataType []crypto/x509.ExtKeyUsage.array
+    - __kind: PointerType
+      ID: 203
+      Name: '*[]crypto/x509.OID.array'
+      ByteSize: 8
+      Pointee: 202 GoSliceDataType []crypto/x509.OID.array
+    - __kind: PointerType
+      ID: 205
+      Name: '*[]crypto/x509.PolicyMapping.array'
+      ByteSize: 8
+      Pointee: 204 GoSliceDataType []crypto/x509.PolicyMapping.array
+    - __kind: PointerType
+      ID: 179
+      Name: '*[]crypto/x509/pkix.AttributeTypeAndValue.array'
+      ByteSize: 8
+      Pointee: 178 GoSliceDataType []crypto/x509/pkix.AttributeTypeAndValue.array
+    - __kind: PointerType
+      ID: 187
+      Name: '*[]crypto/x509/pkix.Extension.array'
+      ByteSize: 8
+      Pointee: 186 GoSliceDataType []crypto/x509/pkix.Extension.array
+    - __kind: PointerType
+      ID: 189
+      Name: '*[]encoding/asn1.ObjectIdentifier.array'
+      ByteSize: 8
+      Pointee: 188 GoSliceDataType []encoding/asn1.ObjectIdentifier.array
+    - __kind: PointerType
+      ID: 193
+      Name: '*[]net.IP.array'
+      ByteSize: 8
+      Pointee: 192 GoSliceDataType []net.IP.array
+    - __kind: PointerType
+      ID: 211
+      Name: '*[]net/http.segment.array'
+      ByteSize: 8
+      Pointee: 210 GoSliceDataType []net/http.segment.array
+    - __kind: PointerType
+      ID: 167
+      Name: '*[]string.array'
+      ByteSize: 8
+      Pointee: 166 GoSliceDataType []string.array
+    - __kind: PointerType
+      ID: 183
+      Name: '*[]time.zone.array'
+      ByteSize: 8
+      Pointee: 182 GoSliceDataType []time.zone.array
+    - __kind: PointerType
+      ID: 185
+      Name: '*[]time.zoneTrans.array'
+      ByteSize: 8
+      Pointee: 184 GoSliceDataType []time.zoneTrans.array
+    - __kind: PointerType
+      ID: 112
+      Name: '*[]uint8'
+      ByteSize: 8
+      GoRuntimeType: 481440
+      GoKind: 22
+      Pointee: 53 GoSliceHeaderType []uint8
+    - __kind: PointerType
+      ID: 173
+      Name: '*[]uint8.array'
+      ByteSize: 8
+      Pointee: 172 GoSliceDataType []uint8.array
+    - __kind: PointerType
+      ID: 141
+      Name: '*bool'
+      ByteSize: 8
+      GoRuntimeType: 400224
+      GoKind: 22
+      Pointee: 13 BaseType bool
+    - __kind: PointerType
+      ID: 135
+      Name: '*bytes.Buffer'
+      ByteSize: 8
+      GoRuntimeType: 2.259936e+06
+      GoKind: 22
+      Pointee: 136 StructureType bytes.Buffer
+    - __kind: PointerType
+      ID: 54
+      Name: '*crypto/tls.ConnectionState'
+      ByteSize: 8
+      GoRuntimeType: 907744
+      GoKind: 22
+      Pointee: 55 StructureType crypto/tls.ConnectionState
+    - __kind: PointerType
+      ID: 59
+      Name: '*crypto/x509.Certificate'
+      ByteSize: 8
+      GoRuntimeType: 2.0432e+06
+      GoKind: 22
+      Pointee: 60 StructureType crypto/x509.Certificate
+    - __kind: PointerType
+      ID: 91
+      Name: '*crypto/x509.ExtKeyUsage'
+      ByteSize: 8
+      GoRuntimeType: 423456
+      GoKind: 22
+      Pointee: 92 BaseType crypto/x509.ExtKeyUsage
+    - __kind: PointerType
+      ID: 104
+      Name: '*crypto/x509.OID'
+      ByteSize: 8
+      GoRuntimeType: 1.953568e+06
+      GoKind: 22
+      Pointee: 105 StructureType crypto/x509.OID
+    - __kind: PointerType
+      ID: 107
+      Name: '*crypto/x509.PolicyMapping'
+      ByteSize: 8
+      GoRuntimeType: 423520
+      GoKind: 22
+      Pointee: 108 StructureType crypto/x509.PolicyMapping
+    - __kind: PointerType
+      ID: 71
+      Name: '*crypto/x509/pkix.AttributeTypeAndValue'
+      ByteSize: 8
+      GoRuntimeType: 437216
+      GoKind: 22
+      Pointee: 72 StructureType crypto/x509/pkix.AttributeTypeAndValue
+    - __kind: PointerType
+      ID: 86
+      Name: '*crypto/x509/pkix.Extension'
+      ByteSize: 8
+      GoRuntimeType: 437408
+      GoKind: 22
+      Pointee: 87 StructureType crypto/x509/pkix.Extension
+    - __kind: PointerType
+      ID: 89
+      Name: '*encoding/asn1.ObjectIdentifier'
+      ByteSize: 8
+      GoRuntimeType: 1.052704e+06
+      GoKind: 22
+      Pointee: 73 GoSliceHeaderType encoding/asn1.ObjectIdentifier
+    - __kind: PointerType
+      ID: 181
+      Name: '*encoding/asn1.ObjectIdentifier.array'
+      ByteSize: 8
+      Pointee: 180 GoSliceDataType encoding/asn1.ObjectIdentifier.array
+    - __kind: PointerType
+      ID: 159
+      Name: '*error'
+      ByteSize: 8
+      GoRuntimeType: 399136
+      GoKind: 22
+      Pointee: 143 GoInterfaceType error
+    - __kind: PointerType
+      ID: 161
+      Name: '*float32'
+      ByteSize: 8
+      GoRuntimeType: 400096
+      GoKind: 22
+      Pointee: 146 BaseType float32
+    - __kind: PointerType
+      ID: 153
+      Name: '*float64'
+      ByteSize: 8
+      GoRuntimeType: 400160
+      GoKind: 22
+      Pointee: 144 BaseType float64
+    - __kind: PointerType
+      ID: 74
+      Name: '*int'
+      ByteSize: 8
+      GoRuntimeType: 399776
+      GoKind: 22
+      Pointee: 8 BaseType int
+    - __kind: PointerType
+      ID: 157
+      Name: '*int16'
+      ByteSize: 8
+      GoRuntimeType: 399392
+      GoKind: 22
+      Pointee: 150 BaseType int16
+    - __kind: PointerType
+      ID: 148
+      Name: '*int32'
+      ByteSize: 8
+      GoRuntimeType: 399520
+      GoKind: 22
+      Pointee: 142 BaseType int32
+    - __kind: PointerType
+      ID: 155
+      Name: '*int64'
+      ByteSize: 8
+      GoRuntimeType: 399648
+      GoKind: 22
+      Pointee: 32 BaseType int64
+    - __kind: PointerType
+      ID: 158
+      Name: '*int8'
+      ByteSize: 8
+      GoRuntimeType: 399264
+      GoKind: 22
+      Pointee: 145 BaseType int8
+    - __kind: PointerType
+      ID: 38
+      Name: '*map<string,[]*mime/multipart.FileHeader>'
+      ByteSize: 8
+      Pointee: 39 GoSwissMapHeaderType map<string,[]*mime/multipart.FileHeader>
+    - __kind: PointerType
+      ID: 15
+      Name: '*map<string,[]string>'
+      ByteSize: 8
+      Pointee: 16 GoSwissMapHeaderType map<string,[]string>
+    - __kind: PointerType
+      ID: 125
+      Name: '*map<string,string>'
+      ByteSize: 8
+      Pointee: 126 GoSwissMapHeaderType map<string,string>
+    - __kind: PointerType
+      ID: 64
+      Name: '*math/big.Int'
+      ByteSize: 8
+      GoRuntimeType: 2.381568e+06
+      GoKind: 22
+      Pointee: 65 StructureType math/big.Int
+    - __kind: PointerType
+      ID: 67
+      Name: '*math/big.Word'
+      ByteSize: 8
+      GoRuntimeType: 426272
+      GoKind: 22
+      Pointee: 68 BaseType math/big.Word
+    - __kind: PointerType
+      ID: 177
+      Name: '*math/big.nat.array'
+      ByteSize: 8
+      Pointee: 176 GoSliceDataType math/big.nat.array
+    - __kind: PointerType
+      ID: 50
+      Name: '*mime/multipart.FileHeader'
+      ByteSize: 8
+      GoRuntimeType: 909280
+      GoKind: 22
+      Pointee: 51 StructureType mime/multipart.FileHeader
     - __kind: PointerType
       ID: 34
       Name: '*mime/multipart.Form'
@@ -543,161 +427,243 @@ Types:
       GoRuntimeType: 909376
       GoKind: 22
       Pointee: 35 StructureType mime/multipart.Form
-    - __kind: StructureType
-      ID: 35
-      Name: mime/multipart.Form
-      ByteSize: 16
-      GoRuntimeType: 1.477408e+06
-      GoKind: 25
-      RawFields:
-        - Name: Value
-          Offset: 0
-          Type: 36 GoMapType map[string][]string
-        - Name: File
-          Offset: 8
-          Type: 37 GoMapType map[string][]*mime/multipart.FileHeader
-    - __kind: GoMapType
-      ID: 36
-      Name: map[string][]string
-      ByteSize: 8
-      GoRuntimeType: 1.127296e+06
-      GoKind: 21
-      HeaderType: 16 GoSwissMapHeaderType map<string,[]string>
-    - __kind: GoMapType
-      ID: 37
-      Name: map[string][]*mime/multipart.FileHeader
-      ByteSize: 8
-      GoRuntimeType: 1.131648e+06
-      GoKind: 21
-      HeaderType: 39 GoSwissMapHeaderType map<string,[]*mime/multipart.FileHeader>
     - __kind: PointerType
-      ID: 38
-      Name: '*map<string,[]*mime/multipart.FileHeader>'
+      ID: 94
+      Name: '*net.IP'
       ByteSize: 8
-      Pointee: 39 GoSwissMapHeaderType map<string,[]*mime/multipart.FileHeader>
-    - __kind: GoSwissMapHeaderType
-      ID: 39
-      Name: map<string,[]*mime/multipart.FileHeader>
-      ByteSize: 48
-      GoKind: 25
-      RawFields:
-        - Name: used
-          Offset: 0
-          Type: 17 BaseType uint64
-        - Name: seed
-          Offset: 8
-          Type: 18 BaseType uintptr
-        - Name: dirPtr
-          Offset: 16
-          Type: 40 PointerType **table<string,[]*mime/multipart.FileHeader>
-        - Name: dirLen
-          Offset: 24
-          Type: 8 BaseType int
-        - Name: globalDepth
-          Offset: 32
-          Type: 7 BaseType uint8
-        - Name: globalShift
-          Offset: 33
-          Type: 7 BaseType uint8
-        - Name: writing
-          Offset: 34
-          Type: 7 BaseType uint8
-        - Name: tombstonePossible
-          Offset: 35
-          Type: 13 BaseType bool
-        - Name: clearSeq
-          Offset: 40
-          Type: 17 BaseType uint64
-      TablePtrSliceType: 168 GoSliceDataType []*table<string,[]*mime/multipart.FileHeader>.array
-      GroupType: 45 StructureType noalg.map.group[string][]*mime/multipart.FileHeader
+      GoRuntimeType: 2.149408e+06
+      GoKind: 22
+      Pointee: 95 GoSliceHeaderType net.IP
     - __kind: PointerType
-      ID: 40
-      Name: '**table<string,[]*mime/multipart.FileHeader>'
+      ID: 195
+      Name: '*net.IP.array'
       ByteSize: 8
-      Pointee: 41 PointerType *table<string,[]*mime/multipart.FileHeader>
+      Pointee: 194 GoSliceDataType net.IP.array
     - __kind: PointerType
-      ID: 41
-      Name: '*table<string,[]*mime/multipart.FileHeader>'
+      ID: 201
+      Name: '*net.IPMask.array'
       ByteSize: 8
-      Pointee: 42 StructureType table<string,[]*mime/multipart.FileHeader>
-    - __kind: StructureType
-      ID: 42
-      Name: table<string,[]*mime/multipart.FileHeader>
-      ByteSize: 32
-      GoKind: 25
-      RawFields:
-        - Name: used
-          Offset: 0
-          Type: 22 BaseType uint16
-        - Name: capacity
-          Offset: 2
-          Type: 22 BaseType uint16
-        - Name: growthLeft
-          Offset: 4
-          Type: 22 BaseType uint16
-        - Name: localDepth
-          Offset: 6
-          Type: 7 BaseType uint8
-        - Name: index
-          Offset: 8
-          Type: 8 BaseType int
-        - Name: groups
-          Offset: 16
-          Type: 43 GoSwissMapGroupsType groupReference<string,[]*mime/multipart.FileHeader>
-    - __kind: GoSwissMapGroupsType
-      ID: 43
-      Name: groupReference<string,[]*mime/multipart.FileHeader>
-      ByteSize: 16
-      GoKind: 25
-      RawFields:
-        - Name: data
-          Offset: 0
-          Type: 44 PointerType *noalg.map.group[string][]*mime/multipart.FileHeader
-        - Name: lengthMask
-          Offset: 8
-          Type: 17 BaseType uint64
-      GroupType: 45 StructureType noalg.map.group[string][]*mime/multipart.FileHeader
-      GroupSliceType: 169 GoSliceDataType []noalg.map.group[string][]*mime/multipart.FileHeader.array
+      Pointee: 200 GoSliceDataType net.IPMask.array
+    - __kind: PointerType
+      ID: 100
+      Name: '*net.IPNet'
+      ByteSize: 8
+      GoRuntimeType: 1.182656e+06
+      GoKind: 22
+      Pointee: 101 StructureType net.IPNet
+    - __kind: PointerType
+      ID: 3
+      Name: '*net/http.Request'
+      ByteSize: 8
+      GoRuntimeType: 2.300192e+06
+      GoKind: 22
+      Pointee: 4 StructureType net/http.Request
+    - __kind: PointerType
+      ID: 116
+      Name: '*net/http.Response'
+      ByteSize: 8
+      GoRuntimeType: 1.718272e+06
+      GoKind: 22
+      Pointee: 117 StructureType net/http.Response
+    - __kind: PointerType
+      ID: 119
+      Name: '*net/http.pattern'
+      ByteSize: 8
+      GoRuntimeType: 1.608064e+06
+      GoKind: 22
+      Pointee: 120 StructureType net/http.pattern
+    - __kind: PointerType
+      ID: 122
+      Name: '*net/http.segment'
+      ByteSize: 8
+      GoRuntimeType: 391712
+      GoKind: 22
+      Pointee: 123 StructureType net/http.segment
+    - __kind: PointerType
+      ID: 9
+      Name: '*net/url.URL'
+      ByteSize: 8
+      GoRuntimeType: 2.112832e+06
+      GoKind: 22
+      Pointee: 10 StructureType net/url.URL
+    - __kind: PointerType
+      ID: 11
+      Name: '*net/url.Userinfo'
+      ByteSize: 8
+      GoRuntimeType: 1.200064e+06
+      GoKind: 22
+      Pointee: 12 StructureType net/url.Userinfo
     - __kind: PointerType
       ID: 44
       Name: '*noalg.map.group[string][]*mime/multipart.FileHeader'
       ByteSize: 8
       Pointee: 45 StructureType noalg.map.group[string][]*mime/multipart.FileHeader
-    - __kind: StructureType
-      ID: 45
-      Name: noalg.map.group[string][]*mime/multipart.FileHeader
-      ByteSize: 328
-      GoRuntimeType: 1.298816e+06
-      GoKind: 25
+    - __kind: PointerType
+      ID: 24
+      Name: '*noalg.map.group[string][]string'
+      ByteSize: 8
+      Pointee: 25 StructureType noalg.map.group[string][]string
+    - __kind: PointerType
+      ID: 131
+      Name: '*noalg.map.group[string]string'
+      ByteSize: 8
+      Pointee: 132 StructureType noalg.map.group[string]string
+    - __kind: PointerType
+      ID: 29
+      Name: '*string'
+      ByteSize: 8
+      GoRuntimeType: 399200
+      GoKind: 22
+      Pointee: 5 GoStringHeaderType string
+    - __kind: PointerType
+      ID: 163
+      Name: '*string.str'
+      ByteSize: 8
+      Pointee: 162 GoStringDataType string.str
+    - __kind: PointerType
+      ID: 41
+      Name: '*table<string,[]*mime/multipart.FileHeader>'
+      ByteSize: 8
+      Pointee: 42 StructureType table<string,[]*mime/multipart.FileHeader>
+    - __kind: PointerType
+      ID: 20
+      Name: '*table<string,[]string>'
+      ByteSize: 8
+      Pointee: 21 StructureType table<string,[]string>
+    - __kind: PointerType
+      ID: 128
+      Name: '*table<string,string>'
+      ByteSize: 8
+      Pointee: 129 StructureType table<string,string>
+    - __kind: PointerType
+      ID: 76
+      Name: '*time.Location'
+      ByteSize: 8
+      GoRuntimeType: 1.613056e+06
+      GoKind: 22
+      Pointee: 77 StructureType time.Location
+    - __kind: PointerType
+      ID: 79
+      Name: '*time.zone'
+      ByteSize: 8
+      GoRuntimeType: 394784
+      GoKind: 22
+      Pointee: 80 StructureType time.zone
+    - __kind: PointerType
+      ID: 82
+      Name: '*time.zoneTrans'
+      ByteSize: 8
+      GoRuntimeType: 394848
+      GoKind: 22
+      Pointee: 83 StructureType time.zoneTrans
+    - __kind: PointerType
+      ID: 160
+      Name: '*uint'
+      ByteSize: 8
+      GoRuntimeType: 399840
+      GoKind: 22
+      Pointee: 140 BaseType uint
+    - __kind: PointerType
+      ID: 156
+      Name: '*uint16'
+      ByteSize: 8
+      GoRuntimeType: 399456
+      GoKind: 22
+      Pointee: 22 BaseType uint16
+    - __kind: PointerType
+      ID: 149
+      Name: '*uint32'
+      ByteSize: 8
+      GoRuntimeType: 399584
+      GoKind: 22
+      Pointee: 139 BaseType uint32
+    - __kind: PointerType
+      ID: 154
+      Name: '*uint64'
+      ByteSize: 8
+      GoRuntimeType: 399712
+      GoKind: 22
+      Pointee: 17 BaseType uint64
+    - __kind: PointerType
+      ID: 6
+      Name: '*uint8'
+      ByteSize: 8
+      GoRuntimeType: 399328
+      GoKind: 22
+      Pointee: 7 BaseType uint8
+    - __kind: PointerType
+      ID: 147
+      Name: '*uintptr'
+      ByteSize: 8
+      GoRuntimeType: 399904
+      GoKind: 22
+      Pointee: 18 BaseType uintptr
+    - __kind: GoChannelType
+      ID: 115
+      Name: <-chan struct {}
+      GoRuntimeType: 597472
+      GoKind: 18
+    - __kind: EventRootType
+      ID: 214
+      Name: Probe[main.HandleHTTP]
+      ByteSize: 25
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: w
+          Offset: 1
+          Expression:
+            Type: 1 GoInterfaceType net/http.ResponseWriter
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 1, index: 0, name: w}
+                  Offset: 0
+                  ByteSize: 16
+        - Name: r
+          Offset: 17
+          Expression:
+            Type: 3 PointerType *net/http.Request
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 1, index: 1, name: r}
+                  Offset: 0
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 215
+      Name: Probe[main.LookAtTheRequest]
+      ByteSize: 17
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: path
+          Offset: 1
+          Expression:
+            Type: 5 GoStringHeaderType string
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 2, index: 0, name: path}
+                  Offset: 0
+                  ByteSize: 16
+    - __kind: GoSliceHeaderType
+      ID: 57
+      Name: '[]*crypto/x509.Certificate'
+      ByteSize: 24
+      GoRuntimeType: 502272
+      GoKind: 23
       RawFields:
-        - Name: ctrl
+        - Name: array
           Offset: 0
-          Type: 17 BaseType uint64
-        - Name: slots
+          Type: 58 PointerType **crypto/x509.Certificate
+        - Name: len
           Offset: 8
-          Type: 46 ArrayType noalg.[8]struct { key string; elem []*mime/multipart.FileHeader }
-    - __kind: ArrayType
-      ID: 46
-      Name: noalg.[8]struct { key string; elem []*mime/multipart.FileHeader }
-      ByteSize: 320
-      GoRuntimeType: 699072
-      GoKind: 17
-      Count: 8
-      HasCount: true
-      Element: 47 StructureType noalg.struct { key string; elem []*mime/multipart.FileHeader }
-    - __kind: StructureType
-      ID: 47
-      Name: noalg.struct { key string; elem []*mime/multipart.FileHeader }
-      ByteSize: 40
-      GoRuntimeType: 1.298688e+06
-      GoKind: 25
-      RawFields:
-        - Name: key
-          Offset: 0
-          Type: 5 GoStringHeaderType string
-        - Name: elem
+          Type: 8 BaseType int
+        - Name: cap
           Offset: 16
-          Type: 48 GoSliceHeaderType []*mime/multipart.FileHeader
+          Type: 8 BaseType int
+      Data: 174 GoSliceDataType []*crypto/x509.Certificate.array
+    - __kind: GoSliceDataType
+      ID: 174
+      Name: '[]*crypto/x509.Certificate.array'
+      ByteSize: 2048
+      Element: 59 PointerType *crypto/x509.Certificate
     - __kind: GoSliceHeaderType
       ID: 48
       Name: '[]*mime/multipart.FileHeader'
@@ -715,54 +681,371 @@ Types:
           Offset: 16
           Type: 8 BaseType int
       Data: 170 GoSliceDataType []*mime/multipart.FileHeader.array
-    - __kind: PointerType
-      ID: 49
-      Name: '**mime/multipart.FileHeader'
-      ByteSize: 8
-      GoKind: 22
-      Pointee: 50 PointerType *mime/multipart.FileHeader
-    - __kind: PointerType
-      ID: 50
-      Name: '*mime/multipart.FileHeader'
-      ByteSize: 8
-      GoRuntimeType: 909280
-      GoKind: 22
-      Pointee: 51 StructureType mime/multipart.FileHeader
-    - __kind: StructureType
-      ID: 51
-      Name: mime/multipart.FileHeader
-      ByteSize: 88
-      GoRuntimeType: 1.977088e+06
-      GoKind: 25
+    - __kind: GoSliceDataType
+      ID: 170
+      Name: '[]*mime/multipart.FileHeader.array'
+      ByteSize: 2048
+      Element: 50 PointerType *mime/multipart.FileHeader
+    - __kind: GoSliceHeaderType
+      ID: 98
+      Name: '[]*net.IPNet'
+      ByteSize: 24
+      GoRuntimeType: 503872
+      GoKind: 23
       RawFields:
-        - Name: Filename
+        - Name: array
           Offset: 0
-          Type: 5 GoStringHeaderType string
-        - Name: Header
+          Type: 99 PointerType **net.IPNet
+        - Name: len
+          Offset: 8
+          Type: 8 BaseType int
+        - Name: cap
           Offset: 16
-          Type: 52 GoMapType net/textproto.MIMEHeader
-        - Name: Size
-          Offset: 24
-          Type: 32 BaseType int64
-        - Name: content
-          Offset: 32
-          Type: 53 GoSliceHeaderType []uint8
-        - Name: tmpfile
-          Offset: 56
-          Type: 5 GoStringHeaderType string
-        - Name: tmpoff
-          Offset: 72
-          Type: 32 BaseType int64
-        - Name: tmpshared
-          Offset: 80
-          Type: 13 BaseType bool
-    - __kind: GoMapType
-      ID: 52
-      Name: net/textproto.MIMEHeader
-      ByteSize: 8
-      GoRuntimeType: 1.82304e+06
-      GoKind: 21
-      HeaderType: 16 GoSwissMapHeaderType map<string,[]string>
+          Type: 8 BaseType int
+      Data: 198 GoSliceDataType []*net.IPNet.array
+    - __kind: GoSliceDataType
+      ID: 198
+      Name: '[]*net.IPNet.array'
+      ByteSize: 2048
+      Element: 100 PointerType *net.IPNet
+    - __kind: GoSliceHeaderType
+      ID: 96
+      Name: '[]*net/url.URL'
+      ByteSize: 24
+      GoRuntimeType: 503808
+      GoKind: 23
+      RawFields:
+        - Name: array
+          Offset: 0
+          Type: 97 PointerType **net/url.URL
+        - Name: len
+          Offset: 8
+          Type: 8 BaseType int
+        - Name: cap
+          Offset: 16
+          Type: 8 BaseType int
+      Data: 196 GoSliceDataType []*net/url.URL.array
+    - __kind: GoSliceDataType
+      ID: 196
+      Name: '[]*net/url.URL.array'
+      ByteSize: 2048
+      Element: 9 PointerType *net/url.URL
+    - __kind: GoSliceDataType
+      ID: 168
+      Name: '[]*table<string,[]*mime/multipart.FileHeader>.array'
+      ByteSize: 8192
+      Element: 41 PointerType *table<string,[]*mime/multipart.FileHeader>
+    - __kind: GoSliceDataType
+      ID: 164
+      Name: '[]*table<string,[]string>.array'
+      ByteSize: 8192
+      Element: 20 PointerType *table<string,[]string>
+    - __kind: GoSliceDataType
+      ID: 212
+      Name: '[]*table<string,string>.array'
+      ByteSize: 8192
+      Element: 128 PointerType *table<string,string>
+    - __kind: GoSliceHeaderType
+      ID: 109
+      Name: '[][]*crypto/x509.Certificate'
+      ByteSize: 24
+      GoRuntimeType: 502336
+      GoKind: 23
+      RawFields:
+        - Name: array
+          Offset: 0
+          Type: 110 PointerType *[]*crypto/x509.Certificate
+        - Name: len
+          Offset: 8
+          Type: 8 BaseType int
+        - Name: cap
+          Offset: 16
+          Type: 8 BaseType int
+      Data: 206 GoSliceDataType [][]*crypto/x509.Certificate.array
+    - __kind: GoSliceDataType
+      ID: 206
+      Name: '[][]*crypto/x509.Certificate.array'
+      ByteSize: 2048
+      Element: 57 GoSliceHeaderType []*crypto/x509.Certificate
+    - __kind: GoSliceHeaderType
+      ID: 111
+      Name: '[][]uint8'
+      ByteSize: 24
+      GoRuntimeType: 481760
+      GoKind: 23
+      RawFields:
+        - Name: array
+          Offset: 0
+          Type: 112 PointerType *[]uint8
+        - Name: len
+          Offset: 8
+          Type: 8 BaseType int
+        - Name: cap
+          Offset: 16
+          Type: 8 BaseType int
+      Data: 208 GoSliceDataType [][]uint8.array
+    - __kind: GoSliceDataType
+      ID: 208
+      Name: '[][]uint8.array'
+      ByteSize: 2048
+      Element: 53 GoSliceHeaderType []uint8
+    - __kind: GoSliceHeaderType
+      ID: 90
+      Name: '[]crypto/x509.ExtKeyUsage'
+      ByteSize: 24
+      GoRuntimeType: 503744
+      GoKind: 23
+      RawFields:
+        - Name: array
+          Offset: 0
+          Type: 91 PointerType *crypto/x509.ExtKeyUsage
+        - Name: len
+          Offset: 8
+          Type: 8 BaseType int
+        - Name: cap
+          Offset: 16
+          Type: 8 BaseType int
+      Data: 190 GoSliceDataType []crypto/x509.ExtKeyUsage.array
+    - __kind: GoSliceDataType
+      ID: 190
+      Name: '[]crypto/x509.ExtKeyUsage.array'
+      ByteSize: 2048
+      Element: 92 BaseType crypto/x509.ExtKeyUsage
+    - __kind: GoSliceHeaderType
+      ID: 103
+      Name: '[]crypto/x509.OID'
+      ByteSize: 24
+      GoRuntimeType: 503936
+      GoKind: 23
+      RawFields:
+        - Name: array
+          Offset: 0
+          Type: 104 PointerType *crypto/x509.OID
+        - Name: len
+          Offset: 8
+          Type: 8 BaseType int
+        - Name: cap
+          Offset: 16
+          Type: 8 BaseType int
+      Data: 202 GoSliceDataType []crypto/x509.OID.array
+    - __kind: GoSliceDataType
+      ID: 202
+      Name: '[]crypto/x509.OID.array'
+      ByteSize: 2048
+      Element: 105 StructureType crypto/x509.OID
+    - __kind: GoSliceHeaderType
+      ID: 106
+      Name: '[]crypto/x509.PolicyMapping'
+      ByteSize: 24
+      GoRuntimeType: 504000
+      GoKind: 23
+      RawFields:
+        - Name: array
+          Offset: 0
+          Type: 107 PointerType *crypto/x509.PolicyMapping
+        - Name: len
+          Offset: 8
+          Type: 8 BaseType int
+        - Name: cap
+          Offset: 16
+          Type: 8 BaseType int
+      Data: 204 GoSliceDataType []crypto/x509.PolicyMapping.array
+    - __kind: GoSliceDataType
+      ID: 204
+      Name: '[]crypto/x509.PolicyMapping.array'
+      ByteSize: 2048
+      Element: 108 StructureType crypto/x509.PolicyMapping
+    - __kind: GoSliceHeaderType
+      ID: 70
+      Name: '[]crypto/x509/pkix.AttributeTypeAndValue'
+      ByteSize: 24
+      GoRuntimeType: 517280
+      GoKind: 23
+      RawFields:
+        - Name: array
+          Offset: 0
+          Type: 71 PointerType *crypto/x509/pkix.AttributeTypeAndValue
+        - Name: len
+          Offset: 8
+          Type: 8 BaseType int
+        - Name: cap
+          Offset: 16
+          Type: 8 BaseType int
+      Data: 178 GoSliceDataType []crypto/x509/pkix.AttributeTypeAndValue.array
+    - __kind: GoSliceDataType
+      ID: 178
+      Name: '[]crypto/x509/pkix.AttributeTypeAndValue.array'
+      ByteSize: 2048
+      Element: 72 StructureType crypto/x509/pkix.AttributeTypeAndValue
+    - __kind: GoSliceHeaderType
+      ID: 85
+      Name: '[]crypto/x509/pkix.Extension'
+      ByteSize: 24
+      GoRuntimeType: 503616
+      GoKind: 23
+      RawFields:
+        - Name: array
+          Offset: 0
+          Type: 86 PointerType *crypto/x509/pkix.Extension
+        - Name: len
+          Offset: 8
+          Type: 8 BaseType int
+        - Name: cap
+          Offset: 16
+          Type: 8 BaseType int
+      Data: 186 GoSliceDataType []crypto/x509/pkix.Extension.array
+    - __kind: GoSliceDataType
+      ID: 186
+      Name: '[]crypto/x509/pkix.Extension.array'
+      ByteSize: 2048
+      Element: 87 StructureType crypto/x509/pkix.Extension
+    - __kind: GoSliceHeaderType
+      ID: 88
+      Name: '[]encoding/asn1.ObjectIdentifier'
+      ByteSize: 24
+      GoRuntimeType: 503680
+      GoKind: 23
+      RawFields:
+        - Name: array
+          Offset: 0
+          Type: 89 PointerType *encoding/asn1.ObjectIdentifier
+        - Name: len
+          Offset: 8
+          Type: 8 BaseType int
+        - Name: cap
+          Offset: 16
+          Type: 8 BaseType int
+      Data: 188 GoSliceDataType []encoding/asn1.ObjectIdentifier.array
+    - __kind: GoSliceDataType
+      ID: 188
+      Name: '[]encoding/asn1.ObjectIdentifier.array'
+      ByteSize: 2048
+      Element: 73 GoSliceHeaderType encoding/asn1.ObjectIdentifier
+    - __kind: GoSliceHeaderType
+      ID: 93
+      Name: '[]net.IP'
+      ByteSize: 24
+      GoRuntimeType: 482784
+      GoKind: 23
+      RawFields:
+        - Name: array
+          Offset: 0
+          Type: 94 PointerType *net.IP
+        - Name: len
+          Offset: 8
+          Type: 8 BaseType int
+        - Name: cap
+          Offset: 16
+          Type: 8 BaseType int
+      Data: 192 GoSliceDataType []net.IP.array
+    - __kind: GoSliceDataType
+      ID: 192
+      Name: '[]net.IP.array'
+      ByteSize: 2048
+      Element: 95 GoSliceHeaderType net.IP
+    - __kind: GoSliceHeaderType
+      ID: 121
+      Name: '[]net/http.segment'
+      ByteSize: 24
+      GoRuntimeType: 484480
+      GoKind: 23
+      RawFields:
+        - Name: array
+          Offset: 0
+          Type: 122 PointerType *net/http.segment
+        - Name: len
+          Offset: 8
+          Type: 8 BaseType int
+        - Name: cap
+          Offset: 16
+          Type: 8 BaseType int
+      Data: 210 GoSliceDataType []net/http.segment.array
+    - __kind: GoSliceDataType
+      ID: 210
+      Name: '[]net/http.segment.array'
+      ByteSize: 2048
+      Element: 123 StructureType net/http.segment
+    - __kind: GoSliceDataType
+      ID: 169
+      Name: '[]noalg.map.group[string][]*mime/multipart.FileHeader.array'
+      ByteSize: 2048
+      Element: 45 StructureType noalg.map.group[string][]*mime/multipart.FileHeader
+    - __kind: GoSliceDataType
+      ID: 165
+      Name: '[]noalg.map.group[string][]string.array'
+      ByteSize: 2048
+      Element: 25 StructureType noalg.map.group[string][]string
+    - __kind: GoSliceDataType
+      ID: 213
+      Name: '[]noalg.map.group[string]string.array'
+      ByteSize: 2048
+      Element: 132 StructureType noalg.map.group[string]string
+    - __kind: GoSliceHeaderType
+      ID: 28
+      Name: '[]string'
+      ByteSize: 24
+      GoRuntimeType: 496288
+      GoKind: 23
+      RawFields:
+        - Name: array
+          Offset: 0
+          Type: 29 PointerType *string
+        - Name: len
+          Offset: 8
+          Type: 8 BaseType int
+        - Name: cap
+          Offset: 16
+          Type: 8 BaseType int
+      Data: 166 GoSliceDataType []string.array
+    - __kind: GoSliceDataType
+      ID: 166
+      Name: '[]string.array'
+      ByteSize: 2048
+      Element: 5 GoStringHeaderType string
+    - __kind: GoSliceHeaderType
+      ID: 78
+      Name: '[]time.zone'
+      ByteSize: 24
+      GoRuntimeType: 489344
+      GoKind: 23
+      RawFields:
+        - Name: array
+          Offset: 0
+          Type: 79 PointerType *time.zone
+        - Name: len
+          Offset: 8
+          Type: 8 BaseType int
+        - Name: cap
+          Offset: 16
+          Type: 8 BaseType int
+      Data: 182 GoSliceDataType []time.zone.array
+    - __kind: GoSliceDataType
+      ID: 182
+      Name: '[]time.zone.array'
+      ByteSize: 2048
+      Element: 80 StructureType time.zone
+    - __kind: GoSliceHeaderType
+      ID: 81
+      Name: '[]time.zoneTrans'
+      ByteSize: 24
+      GoRuntimeType: 489408
+      GoKind: 23
+      RawFields:
+        - Name: array
+          Offset: 0
+          Type: 82 PointerType *time.zoneTrans
+        - Name: len
+          Offset: 8
+          Type: 8 BaseType int
+        - Name: cap
+          Offset: 16
+          Type: 8 BaseType int
+      Data: 184 GoSliceDataType []time.zoneTrans.array
+    - __kind: GoSliceDataType
+      ID: 184
+      Name: '[]time.zoneTrans.array'
+      ByteSize: 2048
+      Element: 83 StructureType time.zoneTrans
     - __kind: GoSliceHeaderType
       ID: 53
       Name: '[]uint8'
@@ -780,13 +1063,64 @@ Types:
           Offset: 16
           Type: 8 BaseType int
       Data: 172 GoSliceDataType []uint8.array
-    - __kind: PointerType
-      ID: 54
-      Name: '*crypto/tls.ConnectionState'
+    - __kind: GoSliceDataType
+      ID: 172
+      Name: '[]uint8.array'
+      ByteSize: 2048
+      Element: 7 BaseType uint8
+    - __kind: BaseType
+      ID: 13
+      Name: bool
+      ByteSize: 1
+      GoRuntimeType: 585248
+      GoKind: 1
+    - __kind: StructureType
+      ID: 136
+      Name: bytes.Buffer
+      ByteSize: 40
+      GoRuntimeType: 1.60576e+06
+      GoKind: 25
+      RawFields:
+        - Name: buf
+          Offset: 0
+          Type: 53 GoSliceHeaderType []uint8
+        - Name: off
+          Offset: 24
+          Type: 8 BaseType int
+        - Name: lastRead
+          Offset: 32
+          Type: 137 BaseType bytes.readOp
+    - __kind: BaseType
+      ID: 137
+      Name: bytes.readOp
+      ByteSize: 1
+      GoRuntimeType: 583456
+      GoKind: 3
+    - __kind: BaseType
+      ID: 152
+      Name: complex128
+      ByteSize: 16
+      GoRuntimeType: 585056
+      GoKind: 16
+    - __kind: BaseType
+      ID: 151
+      Name: complex64
       ByteSize: 8
-      GoRuntimeType: 907744
-      GoKind: 22
-      Pointee: 55 StructureType crypto/tls.ConnectionState
+      GoRuntimeType: 584992
+      GoKind: 15
+    - __kind: GoInterfaceType
+      ID: 118
+      Name: context.Context
+      ByteSize: 16
+      GoRuntimeType: 1.276288e+06
+      GoKind: 20
+      RawFields:
+        - Name: tab
+          Offset: 0
+          Type: 2 VoidPointerType unsafe.Pointer
+        - Name: data
+          Offset: 8
+          Type: 2 VoidPointerType unsafe.Pointer
     - __kind: StructureType
       ID: 55
       Name: crypto/tls.ConnectionState
@@ -851,36 +1185,12 @@ Types:
       ByteSize: 2
       GoRuntimeType: 834432
       GoKind: 9
-    - __kind: GoSliceHeaderType
-      ID: 57
-      Name: '[]*crypto/x509.Certificate'
-      ByteSize: 24
-      GoRuntimeType: 502272
-      GoKind: 23
-      RawFields:
-        - Name: array
-          Offset: 0
-          Type: 58 PointerType **crypto/x509.Certificate
-        - Name: len
-          Offset: 8
-          Type: 8 BaseType int
-        - Name: cap
-          Offset: 16
-          Type: 8 BaseType int
-      Data: 174 GoSliceDataType []*crypto/x509.Certificate.array
-    - __kind: PointerType
-      ID: 58
-      Name: '**crypto/x509.Certificate'
-      ByteSize: 8
-      GoKind: 22
-      Pointee: 59 PointerType *crypto/x509.Certificate
-    - __kind: PointerType
-      ID: 59
-      Name: '*crypto/x509.Certificate'
-      ByteSize: 8
-      GoRuntimeType: 2.0432e+06
-      GoKind: 22
-      Pointee: 60 StructureType crypto/x509.Certificate
+    - __kind: BaseType
+      ID: 114
+      Name: crypto/tls.SignatureScheme
+      ByteSize: 2
+      GoRuntimeType: 834528
+      GoKind: 9
     - __kind: StructureType
       ID: 60
       Name: crypto/x509.Certificate
@@ -1045,80 +1355,81 @@ Types:
           Offset: 1400
           Type: 106 GoSliceHeaderType []crypto/x509.PolicyMapping
     - __kind: BaseType
-      ID: 61
-      Name: crypto/x509.SignatureAlgorithm
+      ID: 92
+      Name: crypto/x509.ExtKeyUsage
       ByteSize: 8
-      GoRuntimeType: 1.113728e+06
+      GoRuntimeType: 587936
       GoKind: 2
+    - __kind: BaseType
+      ID: 84
+      Name: crypto/x509.KeyUsage
+      ByteSize: 8
+      GoRuntimeType: 587872
+      GoKind: 2
+    - __kind: StructureType
+      ID: 105
+      Name: crypto/x509.OID
+      ByteSize: 24
+      GoRuntimeType: 1.953824e+06
+      GoKind: 25
+      RawFields:
+        - Name: der
+          Offset: 0
+          Type: 53 GoSliceHeaderType []uint8
+    - __kind: StructureType
+      ID: 108
+      Name: crypto/x509.PolicyMapping
+      ByteSize: 48
+      GoRuntimeType: 1.490528e+06
+      GoKind: 25
+      RawFields:
+        - Name: IssuerDomainPolicy
+          Offset: 0
+          Type: 105 StructureType crypto/x509.OID
+        - Name: SubjectDomainPolicy
+          Offset: 24
+          Type: 105 StructureType crypto/x509.OID
     - __kind: BaseType
       ID: 62
       Name: crypto/x509.PublicKeyAlgorithm
       ByteSize: 8
       GoRuntimeType: 837024
       GoKind: 2
-    - __kind: GoEmptyInterfaceType
-      ID: 63
-      Name: interface {}
-      ByteSize: 16
-      GoRuntimeType: 854240
-      GoKind: 20
-      RawFields:
-        - Name: _type
-          Offset: 0
-          Type: 2 VoidPointerType unsafe.Pointer
-        - Name: data
-          Offset: 8
-          Type: 2 VoidPointerType unsafe.Pointer
-    - __kind: PointerType
-      ID: 64
-      Name: '*math/big.Int'
+    - __kind: BaseType
+      ID: 61
+      Name: crypto/x509.SignatureAlgorithm
       ByteSize: 8
-      GoRuntimeType: 2.381568e+06
-      GoKind: 22
-      Pointee: 65 StructureType math/big.Int
+      GoRuntimeType: 1.113728e+06
+      GoKind: 2
     - __kind: StructureType
-      ID: 65
-      Name: math/big.Int
-      ByteSize: 32
-      GoRuntimeType: 1.493568e+06
+      ID: 72
+      Name: crypto/x509/pkix.AttributeTypeAndValue
+      ByteSize: 40
+      GoRuntimeType: 1.502368e+06
       GoKind: 25
       RawFields:
-        - Name: neg
+        - Name: Type
           Offset: 0
-          Type: 13 BaseType bool
-        - Name: abs
-          Offset: 8
-          Type: 66 GoSliceHeaderType math/big.nat
-    - __kind: GoSliceHeaderType
-      ID: 66
-      Name: math/big.nat
-      ByteSize: 24
-      GoRuntimeType: 2.361088e+06
-      GoKind: 23
+          Type: 73 GoSliceHeaderType encoding/asn1.ObjectIdentifier
+        - Name: Value
+          Offset: 24
+          Type: 63 GoEmptyInterfaceType interface {}
+    - __kind: StructureType
+      ID: 87
+      Name: crypto/x509/pkix.Extension
+      ByteSize: 56
+      GoRuntimeType: 1.646464e+06
+      GoKind: 25
       RawFields:
-        - Name: array
+        - Name: Id
           Offset: 0
-          Type: 67 PointerType *math/big.Word
-        - Name: len
-          Offset: 8
-          Type: 8 BaseType int
-        - Name: cap
-          Offset: 16
-          Type: 8 BaseType int
-      Data: 176 GoSliceDataType math/big.nat.array
-    - __kind: PointerType
-      ID: 67
-      Name: '*math/big.Word'
-      ByteSize: 8
-      GoRuntimeType: 426272
-      GoKind: 22
-      Pointee: 68 BaseType math/big.Word
-    - __kind: BaseType
-      ID: 68
-      Name: math/big.Word
-      ByteSize: 8
-      GoRuntimeType: 588128
-      GoKind: 7
+          Type: 73 GoSliceHeaderType encoding/asn1.ObjectIdentifier
+        - Name: Critical
+          Offset: 24
+          Type: 13 BaseType bool
+        - Name: Value
+          Offset: 32
+          Type: 53 GoSliceHeaderType []uint8
     - __kind: StructureType
       ID: 69
       Name: crypto/x509/pkix.Name
@@ -1160,43 +1471,6 @@ Types:
           Offset: 224
           Type: 70 GoSliceHeaderType []crypto/x509/pkix.AttributeTypeAndValue
     - __kind: GoSliceHeaderType
-      ID: 70
-      Name: '[]crypto/x509/pkix.AttributeTypeAndValue'
-      ByteSize: 24
-      GoRuntimeType: 517280
-      GoKind: 23
-      RawFields:
-        - Name: array
-          Offset: 0
-          Type: 71 PointerType *crypto/x509/pkix.AttributeTypeAndValue
-        - Name: len
-          Offset: 8
-          Type: 8 BaseType int
-        - Name: cap
-          Offset: 16
-          Type: 8 BaseType int
-      Data: 178 GoSliceDataType []crypto/x509/pkix.AttributeTypeAndValue.array
-    - __kind: PointerType
-      ID: 71
-      Name: '*crypto/x509/pkix.AttributeTypeAndValue'
-      ByteSize: 8
-      GoRuntimeType: 437216
-      GoKind: 22
-      Pointee: 72 StructureType crypto/x509/pkix.AttributeTypeAndValue
-    - __kind: StructureType
-      ID: 72
-      Name: crypto/x509/pkix.AttributeTypeAndValue
-      ByteSize: 40
-      GoRuntimeType: 1.502368e+06
-      GoKind: 25
-      RawFields:
-        - Name: Type
-          Offset: 0
-          Type: 73 GoSliceHeaderType encoding/asn1.ObjectIdentifier
-        - Name: Value
-          Offset: 24
-          Type: 63 GoEmptyInterfaceType interface {}
-    - __kind: GoSliceHeaderType
       ID: 73
       Name: encoding/asn1.ObjectIdentifier
       ByteSize: 24
@@ -1213,271 +1487,367 @@ Types:
           Offset: 16
           Type: 8 BaseType int
       Data: 180 GoSliceDataType encoding/asn1.ObjectIdentifier.array
-    - __kind: PointerType
-      ID: 74
-      Name: '*int'
+    - __kind: GoSliceDataType
+      ID: 180
+      Name: encoding/asn1.ObjectIdentifier.array
+      ByteSize: 2048
+      Element: 8 BaseType int
+    - __kind: GoInterfaceType
+      ID: 143
+      Name: error
+      ByteSize: 16
+      GoRuntimeType: 1.031072e+06
+      GoKind: 20
+      RawFields:
+        - Name: tab
+          Offset: 0
+          Type: 2 VoidPointerType unsafe.Pointer
+        - Name: data
+          Offset: 8
+          Type: 2 VoidPointerType unsafe.Pointer
+    - __kind: BaseType
+      ID: 146
+      Name: float32
+      ByteSize: 4
+      GoRuntimeType: 585120
+      GoKind: 13
+    - __kind: BaseType
+      ID: 144
+      Name: float64
       ByteSize: 8
-      GoRuntimeType: 399776
-      GoKind: 22
-      Pointee: 8 BaseType int
-    - __kind: StructureType
-      ID: 75
-      Name: time.Time
-      ByteSize: 24
-      GoRuntimeType: 2.363936e+06
+      GoRuntimeType: 585184
+      GoKind: 14
+    - __kind: GoSubroutineType
+      ID: 31
+      Name: func() (io.ReadCloser, error)
+      ByteSize: 8
+      GoRuntimeType: 693216
+      GoKind: 19
+    - __kind: GoSubroutineType
+      ID: 113
+      Name: func(string, []uint8, int) ([]uint8, error)
+      ByteSize: 8
+      GoRuntimeType: 1.002592e+06
+      GoKind: 19
+    - __kind: GoInterfaceType
+      ID: 138
+      Name: gopkg.in/DataDog/dd-trace-go.v1/ddtrace.Span
+      ByteSize: 16
+      GoRuntimeType: 1.479008e+06
+      GoKind: 20
+      RawFields:
+        - Name: tab
+          Offset: 0
+          Type: 2 VoidPointerType unsafe.Pointer
+        - Name: data
+          Offset: 8
+          Type: 2 VoidPointerType unsafe.Pointer
+    - __kind: GoSwissMapGroupsType
+      ID: 43
+      Name: groupReference<string,[]*mime/multipart.FileHeader>
+      ByteSize: 16
       GoKind: 25
       RawFields:
-        - Name: wall
+        - Name: data
+          Offset: 0
+          Type: 44 PointerType *noalg.map.group[string][]*mime/multipart.FileHeader
+        - Name: lengthMask
+          Offset: 8
+          Type: 17 BaseType uint64
+      GroupType: 45 StructureType noalg.map.group[string][]*mime/multipart.FileHeader
+      GroupSliceType: 169 GoSliceDataType []noalg.map.group[string][]*mime/multipart.FileHeader.array
+    - __kind: GoSwissMapGroupsType
+      ID: 23
+      Name: groupReference<string,[]string>
+      ByteSize: 16
+      GoKind: 25
+      RawFields:
+        - Name: data
+          Offset: 0
+          Type: 24 PointerType *noalg.map.group[string][]string
+        - Name: lengthMask
+          Offset: 8
+          Type: 17 BaseType uint64
+      GroupType: 25 StructureType noalg.map.group[string][]string
+      GroupSliceType: 165 GoSliceDataType []noalg.map.group[string][]string.array
+    - __kind: GoSwissMapGroupsType
+      ID: 130
+      Name: groupReference<string,string>
+      ByteSize: 16
+      GoKind: 25
+      RawFields:
+        - Name: data
+          Offset: 0
+          Type: 131 PointerType *noalg.map.group[string]string
+        - Name: lengthMask
+          Offset: 8
+          Type: 17 BaseType uint64
+      GroupType: 132 StructureType noalg.map.group[string]string
+      GroupSliceType: 213 GoSliceDataType []noalg.map.group[string]string.array
+    - __kind: BaseType
+      ID: 8
+      Name: int
+      ByteSize: 8
+      GoRuntimeType: 584800
+      GoKind: 2
+    - __kind: BaseType
+      ID: 150
+      Name: int16
+      ByteSize: 2
+      GoRuntimeType: 584416
+      GoKind: 4
+    - __kind: BaseType
+      ID: 142
+      Name: int32
+      ByteSize: 4
+      GoRuntimeType: 584544
+      GoKind: 5
+    - __kind: BaseType
+      ID: 32
+      Name: int64
+      ByteSize: 8
+      GoRuntimeType: 584672
+      GoKind: 6
+    - __kind: BaseType
+      ID: 145
+      Name: int8
+      ByteSize: 1
+      GoRuntimeType: 584288
+      GoKind: 3
+    - __kind: GoEmptyInterfaceType
+      ID: 63
+      Name: interface {}
+      ByteSize: 16
+      GoRuntimeType: 854240
+      GoKind: 20
+      RawFields:
+        - Name: _type
+          Offset: 0
+          Type: 2 VoidPointerType unsafe.Pointer
+        - Name: data
+          Offset: 8
+          Type: 2 VoidPointerType unsafe.Pointer
+    - __kind: GoInterfaceType
+      ID: 30
+      Name: io.ReadCloser
+      ByteSize: 16
+      GoRuntimeType: 1.10976e+06
+      GoKind: 20
+      RawFields:
+        - Name: tab
+          Offset: 0
+          Type: 2 VoidPointerType unsafe.Pointer
+        - Name: data
+          Offset: 8
+          Type: 2 VoidPointerType unsafe.Pointer
+    - __kind: GoSwissMapHeaderType
+      ID: 39
+      Name: map<string,[]*mime/multipart.FileHeader>
+      ByteSize: 48
+      GoKind: 25
+      RawFields:
+        - Name: used
           Offset: 0
           Type: 17 BaseType uint64
-        - Name: ext
+        - Name: seed
           Offset: 8
-          Type: 32 BaseType int64
-        - Name: loc
+          Type: 18 BaseType uintptr
+        - Name: dirPtr
           Offset: 16
-          Type: 76 PointerType *time.Location
-    - __kind: PointerType
-      ID: 76
-      Name: '*time.Location'
-      ByteSize: 8
-      GoRuntimeType: 1.613056e+06
-      GoKind: 22
-      Pointee: 77 StructureType time.Location
-    - __kind: StructureType
-      ID: 77
-      Name: time.Location
-      ByteSize: 104
-      GoRuntimeType: 1.972768e+06
-      GoKind: 25
-      RawFields:
-        - Name: name
-          Offset: 0
-          Type: 5 GoStringHeaderType string
-        - Name: zone
-          Offset: 16
-          Type: 78 GoSliceHeaderType []time.zone
-        - Name: tx
-          Offset: 40
-          Type: 81 GoSliceHeaderType []time.zoneTrans
-        - Name: extend
-          Offset: 64
-          Type: 5 GoStringHeaderType string
-        - Name: cacheStart
-          Offset: 80
-          Type: 32 BaseType int64
-        - Name: cacheEnd
-          Offset: 88
-          Type: 32 BaseType int64
-        - Name: cacheZone
-          Offset: 96
-          Type: 79 PointerType *time.zone
-    - __kind: GoSliceHeaderType
-      ID: 78
-      Name: '[]time.zone'
-      ByteSize: 24
-      GoRuntimeType: 489344
-      GoKind: 23
-      RawFields:
-        - Name: array
-          Offset: 0
-          Type: 79 PointerType *time.zone
-        - Name: len
-          Offset: 8
-          Type: 8 BaseType int
-        - Name: cap
-          Offset: 16
-          Type: 8 BaseType int
-      Data: 182 GoSliceDataType []time.zone.array
-    - __kind: PointerType
-      ID: 79
-      Name: '*time.zone'
-      ByteSize: 8
-      GoRuntimeType: 394784
-      GoKind: 22
-      Pointee: 80 StructureType time.zone
-    - __kind: StructureType
-      ID: 80
-      Name: time.zone
-      ByteSize: 32
-      GoRuntimeType: 1.612864e+06
-      GoKind: 25
-      RawFields:
-        - Name: name
-          Offset: 0
-          Type: 5 GoStringHeaderType string
-        - Name: offset
-          Offset: 16
-          Type: 8 BaseType int
-        - Name: isDST
+          Type: 40 PointerType **table<string,[]*mime/multipart.FileHeader>
+        - Name: dirLen
           Offset: 24
-          Type: 13 BaseType bool
-    - __kind: GoSliceHeaderType
-      ID: 81
-      Name: '[]time.zoneTrans'
-      ByteSize: 24
-      GoRuntimeType: 489408
-      GoKind: 23
-      RawFields:
-        - Name: array
-          Offset: 0
-          Type: 82 PointerType *time.zoneTrans
-        - Name: len
-          Offset: 8
           Type: 8 BaseType int
-        - Name: cap
-          Offset: 16
-          Type: 8 BaseType int
-      Data: 184 GoSliceDataType []time.zoneTrans.array
-    - __kind: PointerType
-      ID: 82
-      Name: '*time.zoneTrans'
-      ByteSize: 8
-      GoRuntimeType: 394848
-      GoKind: 22
-      Pointee: 83 StructureType time.zoneTrans
-    - __kind: StructureType
-      ID: 83
-      Name: time.zoneTrans
-      ByteSize: 16
-      GoRuntimeType: 1.750304e+06
-      GoKind: 25
-      RawFields:
-        - Name: when
-          Offset: 0
-          Type: 32 BaseType int64
-        - Name: index
-          Offset: 8
+        - Name: globalDepth
+          Offset: 32
           Type: 7 BaseType uint8
-        - Name: isstd
-          Offset: 9
+        - Name: globalShift
+          Offset: 33
+          Type: 7 BaseType uint8
+        - Name: writing
+          Offset: 34
+          Type: 7 BaseType uint8
+        - Name: tombstonePossible
+          Offset: 35
           Type: 13 BaseType bool
-        - Name: isutc
-          Offset: 10
+        - Name: clearSeq
+          Offset: 40
+          Type: 17 BaseType uint64
+      TablePtrSliceType: 168 GoSliceDataType []*table<string,[]*mime/multipart.FileHeader>.array
+      GroupType: 45 StructureType noalg.map.group[string][]*mime/multipart.FileHeader
+    - __kind: GoSwissMapHeaderType
+      ID: 16
+      Name: map<string,[]string>
+      ByteSize: 48
+      GoKind: 25
+      RawFields:
+        - Name: used
+          Offset: 0
+          Type: 17 BaseType uint64
+        - Name: seed
+          Offset: 8
+          Type: 18 BaseType uintptr
+        - Name: dirPtr
+          Offset: 16
+          Type: 19 PointerType **table<string,[]string>
+        - Name: dirLen
+          Offset: 24
+          Type: 8 BaseType int
+        - Name: globalDepth
+          Offset: 32
+          Type: 7 BaseType uint8
+        - Name: globalShift
+          Offset: 33
+          Type: 7 BaseType uint8
+        - Name: writing
+          Offset: 34
+          Type: 7 BaseType uint8
+        - Name: tombstonePossible
+          Offset: 35
           Type: 13 BaseType bool
-    - __kind: BaseType
-      ID: 84
-      Name: crypto/x509.KeyUsage
+        - Name: clearSeq
+          Offset: 40
+          Type: 17 BaseType uint64
+      TablePtrSliceType: 164 GoSliceDataType []*table<string,[]string>.array
+      GroupType: 25 StructureType noalg.map.group[string][]string
+    - __kind: GoSwissMapHeaderType
+      ID: 126
+      Name: map<string,string>
+      ByteSize: 48
+      GoKind: 25
+      RawFields:
+        - Name: used
+          Offset: 0
+          Type: 17 BaseType uint64
+        - Name: seed
+          Offset: 8
+          Type: 18 BaseType uintptr
+        - Name: dirPtr
+          Offset: 16
+          Type: 127 PointerType **table<string,string>
+        - Name: dirLen
+          Offset: 24
+          Type: 8 BaseType int
+        - Name: globalDepth
+          Offset: 32
+          Type: 7 BaseType uint8
+        - Name: globalShift
+          Offset: 33
+          Type: 7 BaseType uint8
+        - Name: writing
+          Offset: 34
+          Type: 7 BaseType uint8
+        - Name: tombstonePossible
+          Offset: 35
+          Type: 13 BaseType bool
+        - Name: clearSeq
+          Offset: 40
+          Type: 17 BaseType uint64
+      TablePtrSliceType: 212 GoSliceDataType []*table<string,string>.array
+      GroupType: 132 StructureType noalg.map.group[string]string
+    - __kind: GoMapType
+      ID: 37
+      Name: map[string][]*mime/multipart.FileHeader
       ByteSize: 8
-      GoRuntimeType: 587872
-      GoKind: 2
+      GoRuntimeType: 1.131648e+06
+      GoKind: 21
+      HeaderType: 39 GoSwissMapHeaderType map<string,[]*mime/multipart.FileHeader>
+    - __kind: GoMapType
+      ID: 36
+      Name: map[string][]string
+      ByteSize: 8
+      GoRuntimeType: 1.127296e+06
+      GoKind: 21
+      HeaderType: 16 GoSwissMapHeaderType map<string,[]string>
+    - __kind: GoMapType
+      ID: 124
+      Name: map[string]string
+      ByteSize: 8
+      GoRuntimeType: 1.12832e+06
+      GoKind: 21
+      HeaderType: 126 GoSwissMapHeaderType map<string,string>
+    - __kind: StructureType
+      ID: 65
+      Name: math/big.Int
+      ByteSize: 32
+      GoRuntimeType: 1.493568e+06
+      GoKind: 25
+      RawFields:
+        - Name: neg
+          Offset: 0
+          Type: 13 BaseType bool
+        - Name: abs
+          Offset: 8
+          Type: 66 GoSliceHeaderType math/big.nat
+    - __kind: BaseType
+      ID: 68
+      Name: math/big.Word
+      ByteSize: 8
+      GoRuntimeType: 588128
+      GoKind: 7
     - __kind: GoSliceHeaderType
-      ID: 85
-      Name: '[]crypto/x509/pkix.Extension'
+      ID: 66
+      Name: math/big.nat
       ByteSize: 24
-      GoRuntimeType: 503616
+      GoRuntimeType: 2.361088e+06
       GoKind: 23
       RawFields:
         - Name: array
           Offset: 0
-          Type: 86 PointerType *crypto/x509/pkix.Extension
+          Type: 67 PointerType *math/big.Word
         - Name: len
           Offset: 8
           Type: 8 BaseType int
         - Name: cap
           Offset: 16
           Type: 8 BaseType int
-      Data: 186 GoSliceDataType []crypto/x509/pkix.Extension.array
-    - __kind: PointerType
-      ID: 86
-      Name: '*crypto/x509/pkix.Extension'
-      ByteSize: 8
-      GoRuntimeType: 437408
-      GoKind: 22
-      Pointee: 87 StructureType crypto/x509/pkix.Extension
+      Data: 176 GoSliceDataType math/big.nat.array
+    - __kind: GoSliceDataType
+      ID: 176
+      Name: math/big.nat.array
+      ByteSize: 2048
+      Element: 68 BaseType math/big.Word
     - __kind: StructureType
-      ID: 87
-      Name: crypto/x509/pkix.Extension
-      ByteSize: 56
-      GoRuntimeType: 1.646464e+06
+      ID: 51
+      Name: mime/multipart.FileHeader
+      ByteSize: 88
+      GoRuntimeType: 1.977088e+06
       GoKind: 25
       RawFields:
-        - Name: Id
+        - Name: Filename
           Offset: 0
-          Type: 73 GoSliceHeaderType encoding/asn1.ObjectIdentifier
-        - Name: Critical
+          Type: 5 GoStringHeaderType string
+        - Name: Header
+          Offset: 16
+          Type: 52 GoMapType net/textproto.MIMEHeader
+        - Name: Size
           Offset: 24
-          Type: 13 BaseType bool
-        - Name: Value
+          Type: 32 BaseType int64
+        - Name: content
           Offset: 32
           Type: 53 GoSliceHeaderType []uint8
-    - __kind: GoSliceHeaderType
-      ID: 88
-      Name: '[]encoding/asn1.ObjectIdentifier'
-      ByteSize: 24
-      GoRuntimeType: 503680
-      GoKind: 23
+        - Name: tmpfile
+          Offset: 56
+          Type: 5 GoStringHeaderType string
+        - Name: tmpoff
+          Offset: 72
+          Type: 32 BaseType int64
+        - Name: tmpshared
+          Offset: 80
+          Type: 13 BaseType bool
+    - __kind: StructureType
+      ID: 35
+      Name: mime/multipart.Form
+      ByteSize: 16
+      GoRuntimeType: 1.477408e+06
+      GoKind: 25
       RawFields:
-        - Name: array
+        - Name: Value
           Offset: 0
-          Type: 89 PointerType *encoding/asn1.ObjectIdentifier
-        - Name: len
+          Type: 36 GoMapType map[string][]string
+        - Name: File
           Offset: 8
-          Type: 8 BaseType int
-        - Name: cap
-          Offset: 16
-          Type: 8 BaseType int
-      Data: 188 GoSliceDataType []encoding/asn1.ObjectIdentifier.array
-    - __kind: PointerType
-      ID: 89
-      Name: '*encoding/asn1.ObjectIdentifier'
-      ByteSize: 8
-      GoRuntimeType: 1.052704e+06
-      GoKind: 22
-      Pointee: 73 GoSliceHeaderType encoding/asn1.ObjectIdentifier
-    - __kind: GoSliceHeaderType
-      ID: 90
-      Name: '[]crypto/x509.ExtKeyUsage'
-      ByteSize: 24
-      GoRuntimeType: 503744
-      GoKind: 23
-      RawFields:
-        - Name: array
-          Offset: 0
-          Type: 91 PointerType *crypto/x509.ExtKeyUsage
-        - Name: len
-          Offset: 8
-          Type: 8 BaseType int
-        - Name: cap
-          Offset: 16
-          Type: 8 BaseType int
-      Data: 190 GoSliceDataType []crypto/x509.ExtKeyUsage.array
-    - __kind: PointerType
-      ID: 91
-      Name: '*crypto/x509.ExtKeyUsage'
-      ByteSize: 8
-      GoRuntimeType: 423456
-      GoKind: 22
-      Pointee: 92 BaseType crypto/x509.ExtKeyUsage
-    - __kind: BaseType
-      ID: 92
-      Name: crypto/x509.ExtKeyUsage
-      ByteSize: 8
-      GoRuntimeType: 587936
-      GoKind: 2
-    - __kind: GoSliceHeaderType
-      ID: 93
-      Name: '[]net.IP'
-      ByteSize: 24
-      GoRuntimeType: 482784
-      GoKind: 23
-      RawFields:
-        - Name: array
-          Offset: 0
-          Type: 94 PointerType *net.IP
-        - Name: len
-          Offset: 8
-          Type: 8 BaseType int
-        - Name: cap
-          Offset: 16
-          Type: 8 BaseType int
-      Data: 192 GoSliceDataType []net.IP.array
-    - __kind: PointerType
-      ID: 94
-      Name: '*net.IP'
-      ByteSize: 8
-      GoRuntimeType: 2.149408e+06
-      GoKind: 22
-      Pointee: 95 GoSliceHeaderType net.IP
+          Type: 37 GoMapType map[string][]*mime/multipart.FileHeader
     - __kind: GoSliceHeaderType
       ID: 95
       Name: net.IP
@@ -1495,71 +1865,11 @@ Types:
           Offset: 16
           Type: 8 BaseType int
       Data: 194 GoSliceDataType net.IP.array
-    - __kind: GoSliceHeaderType
-      ID: 96
-      Name: '[]*net/url.URL'
-      ByteSize: 24
-      GoRuntimeType: 503808
-      GoKind: 23
-      RawFields:
-        - Name: array
-          Offset: 0
-          Type: 97 PointerType **net/url.URL
-        - Name: len
-          Offset: 8
-          Type: 8 BaseType int
-        - Name: cap
-          Offset: 16
-          Type: 8 BaseType int
-      Data: 196 GoSliceDataType []*net/url.URL.array
-    - __kind: PointerType
-      ID: 97
-      Name: '**net/url.URL'
-      ByteSize: 8
-      Pointee: 9 PointerType *net/url.URL
-    - __kind: GoSliceHeaderType
-      ID: 98
-      Name: '[]*net.IPNet'
-      ByteSize: 24
-      GoRuntimeType: 503872
-      GoKind: 23
-      RawFields:
-        - Name: array
-          Offset: 0
-          Type: 99 PointerType **net.IPNet
-        - Name: len
-          Offset: 8
-          Type: 8 BaseType int
-        - Name: cap
-          Offset: 16
-          Type: 8 BaseType int
-      Data: 198 GoSliceDataType []*net.IPNet.array
-    - __kind: PointerType
-      ID: 99
-      Name: '**net.IPNet'
-      ByteSize: 8
-      GoKind: 22
-      Pointee: 100 PointerType *net.IPNet
-    - __kind: PointerType
-      ID: 100
-      Name: '*net.IPNet'
-      ByteSize: 8
-      GoRuntimeType: 1.182656e+06
-      GoKind: 22
-      Pointee: 101 StructureType net.IPNet
-    - __kind: StructureType
-      ID: 101
-      Name: net.IPNet
-      ByteSize: 48
-      GoRuntimeType: 1.458208e+06
-      GoKind: 25
-      RawFields:
-        - Name: IP
-          Offset: 0
-          Type: 95 GoSliceHeaderType net.IP
-        - Name: Mask
-          Offset: 24
-          Type: 102 GoSliceHeaderType net.IPMask
+    - __kind: GoSliceDataType
+      ID: 194
+      Name: net.IP.array
+      ByteSize: 2048
+      Element: 7 BaseType uint8
     - __kind: GoSliceHeaderType
       ID: 102
       Name: net.IPMask
@@ -1577,148 +1887,116 @@ Types:
           Offset: 16
           Type: 8 BaseType int
       Data: 200 GoSliceDataType net.IPMask.array
-    - __kind: GoSliceHeaderType
-      ID: 103
-      Name: '[]crypto/x509.OID'
-      ByteSize: 24
-      GoRuntimeType: 503936
-      GoKind: 23
-      RawFields:
-        - Name: array
-          Offset: 0
-          Type: 104 PointerType *crypto/x509.OID
-        - Name: len
-          Offset: 8
-          Type: 8 BaseType int
-        - Name: cap
-          Offset: 16
-          Type: 8 BaseType int
-      Data: 202 GoSliceDataType []crypto/x509.OID.array
-    - __kind: PointerType
-      ID: 104
-      Name: '*crypto/x509.OID'
-      ByteSize: 8
-      GoRuntimeType: 1.953568e+06
-      GoKind: 22
-      Pointee: 105 StructureType crypto/x509.OID
+    - __kind: GoSliceDataType
+      ID: 200
+      Name: net.IPMask.array
+      ByteSize: 2048
+      Element: 7 BaseType uint8
     - __kind: StructureType
-      ID: 105
-      Name: crypto/x509.OID
-      ByteSize: 24
-      GoRuntimeType: 1.953824e+06
-      GoKind: 25
-      RawFields:
-        - Name: der
-          Offset: 0
-          Type: 53 GoSliceHeaderType []uint8
-    - __kind: GoSliceHeaderType
-      ID: 106
-      Name: '[]crypto/x509.PolicyMapping'
-      ByteSize: 24
-      GoRuntimeType: 504000
-      GoKind: 23
-      RawFields:
-        - Name: array
-          Offset: 0
-          Type: 107 PointerType *crypto/x509.PolicyMapping
-        - Name: len
-          Offset: 8
-          Type: 8 BaseType int
-        - Name: cap
-          Offset: 16
-          Type: 8 BaseType int
-      Data: 204 GoSliceDataType []crypto/x509.PolicyMapping.array
-    - __kind: PointerType
-      ID: 107
-      Name: '*crypto/x509.PolicyMapping'
-      ByteSize: 8
-      GoRuntimeType: 423520
-      GoKind: 22
-      Pointee: 108 StructureType crypto/x509.PolicyMapping
-    - __kind: StructureType
-      ID: 108
-      Name: crypto/x509.PolicyMapping
+      ID: 101
+      Name: net.IPNet
       ByteSize: 48
-      GoRuntimeType: 1.490528e+06
+      GoRuntimeType: 1.458208e+06
       GoKind: 25
       RawFields:
-        - Name: IssuerDomainPolicy
+        - Name: IP
           Offset: 0
-          Type: 105 StructureType crypto/x509.OID
-        - Name: SubjectDomainPolicy
+          Type: 95 GoSliceHeaderType net.IP
+        - Name: Mask
           Offset: 24
-          Type: 105 StructureType crypto/x509.OID
-    - __kind: GoSliceHeaderType
-      ID: 109
-      Name: '[][]*crypto/x509.Certificate'
-      ByteSize: 24
-      GoRuntimeType: 502336
-      GoKind: 23
+          Type: 102 GoSliceHeaderType net.IPMask
+    - __kind: GoMapType
+      ID: 14
+      Name: net/http.Header
+      ByteSize: 8
+      GoRuntimeType: 2.100864e+06
+      GoKind: 21
+      HeaderType: 16 GoSwissMapHeaderType map<string,[]string>
+    - __kind: StructureType
+      ID: 4
+      Name: net/http.Request
+      ByteSize: 304
+      GoRuntimeType: 2.336064e+06
+      GoKind: 25
       RawFields:
-        - Name: array
+        - Name: Method
           Offset: 0
-          Type: 110 PointerType *[]*crypto/x509.Certificate
-        - Name: len
-          Offset: 8
-          Type: 8 BaseType int
-        - Name: cap
+          Type: 5 GoStringHeaderType string
+        - Name: URL
           Offset: 16
+          Type: 9 PointerType *net/url.URL
+        - Name: Proto
+          Offset: 24
+          Type: 5 GoStringHeaderType string
+        - Name: ProtoMajor
+          Offset: 40
           Type: 8 BaseType int
-      Data: 206 GoSliceDataType [][]*crypto/x509.Certificate.array
-    - __kind: PointerType
-      ID: 110
-      Name: '*[]*crypto/x509.Certificate'
-      ByteSize: 8
-      GoKind: 22
-      Pointee: 57 GoSliceHeaderType []*crypto/x509.Certificate
-    - __kind: GoSliceHeaderType
-      ID: 111
-      Name: '[][]uint8'
-      ByteSize: 24
-      GoRuntimeType: 481760
-      GoKind: 23
-      RawFields:
-        - Name: array
-          Offset: 0
-          Type: 112 PointerType *[]uint8
-        - Name: len
-          Offset: 8
+        - Name: ProtoMinor
+          Offset: 48
           Type: 8 BaseType int
-        - Name: cap
-          Offset: 16
-          Type: 8 BaseType int
-      Data: 208 GoSliceDataType [][]uint8.array
-    - __kind: PointerType
-      ID: 112
-      Name: '*[]uint8'
-      ByteSize: 8
-      GoRuntimeType: 481440
-      GoKind: 22
-      Pointee: 53 GoSliceHeaderType []uint8
-    - __kind: GoSubroutineType
-      ID: 113
-      Name: func(string, []uint8, int) ([]uint8, error)
-      ByteSize: 8
-      GoRuntimeType: 1.002592e+06
-      GoKind: 19
-    - __kind: BaseType
-      ID: 114
-      Name: crypto/tls.SignatureScheme
-      ByteSize: 2
-      GoRuntimeType: 834528
-      GoKind: 9
-    - __kind: GoChannelType
-      ID: 115
-      Name: <-chan struct {}
-      GoRuntimeType: 597472
-      GoKind: 18
-    - __kind: PointerType
-      ID: 116
-      Name: '*net/http.Response'
-      ByteSize: 8
-      GoRuntimeType: 1.718272e+06
-      GoKind: 22
-      Pointee: 117 StructureType net/http.Response
+        - Name: Header
+          Offset: 56
+          Type: 14 GoMapType net/http.Header
+        - Name: Body
+          Offset: 64
+          Type: 30 GoInterfaceType io.ReadCloser
+        - Name: GetBody
+          Offset: 80
+          Type: 31 GoSubroutineType func() (io.ReadCloser, error)
+        - Name: ContentLength
+          Offset: 88
+          Type: 32 BaseType int64
+        - Name: TransferEncoding
+          Offset: 96
+          Type: 28 GoSliceHeaderType []string
+        - Name: Close
+          Offset: 120
+          Type: 13 BaseType bool
+        - Name: Host
+          Offset: 128
+          Type: 5 GoStringHeaderType string
+        - Name: Form
+          Offset: 144
+          Type: 33 GoMapType net/url.Values
+        - Name: PostForm
+          Offset: 152
+          Type: 33 GoMapType net/url.Values
+        - Name: MultipartForm
+          Offset: 160
+          Type: 34 PointerType *mime/multipart.Form
+        - Name: Trailer
+          Offset: 168
+          Type: 14 GoMapType net/http.Header
+        - Name: RemoteAddr
+          Offset: 176
+          Type: 5 GoStringHeaderType string
+        - Name: RequestURI
+          Offset: 192
+          Type: 5 GoStringHeaderType string
+        - Name: TLS
+          Offset: 208
+          Type: 54 PointerType *crypto/tls.ConnectionState
+        - Name: Cancel
+          Offset: 216
+          Type: 115 GoChannelType <-chan struct {}
+        - Name: Response
+          Offset: 224
+          Type: 116 PointerType *net/http.Response
+        - Name: Pattern
+          Offset: 232
+          Type: 5 GoStringHeaderType string
+        - Name: ctx
+          Offset: 248
+          Type: 118 GoInterfaceType context.Context
+        - Name: pat
+          Offset: 264
+          Type: 119 PointerType *net/http.pattern
+        - Name: matches
+          Offset: 272
+          Type: 28 GoSliceHeaderType []string
+        - Name: otherValues
+          Offset: 296
+          Type: 124 GoMapType map[string]string
     - __kind: StructureType
       ID: 117
       Name: net/http.Response
@@ -1769,10 +2047,10 @@ Types:
           Offset: 136
           Type: 54 PointerType *crypto/tls.ConnectionState
     - __kind: GoInterfaceType
-      ID: 118
-      Name: context.Context
+      ID: 1
+      Name: net/http.ResponseWriter
       ByteSize: 16
-      GoRuntimeType: 1.276288e+06
+      GoRuntimeType: 1.185088e+06
       GoKind: 20
       RawFields:
         - Name: tab
@@ -1781,13 +2059,6 @@ Types:
         - Name: data
           Offset: 8
           Type: 2 VoidPointerType unsafe.Pointer
-    - __kind: PointerType
-      ID: 119
-      Name: '*net/http.pattern'
-      ByteSize: 8
-      GoRuntimeType: 1.608064e+06
-      GoKind: 22
-      Pointee: 120 StructureType net/http.pattern
     - __kind: StructureType
       ID: 120
       Name: net/http.pattern
@@ -1810,30 +2081,6 @@ Types:
         - Name: loc
           Offset: 72
           Type: 5 GoStringHeaderType string
-    - __kind: GoSliceHeaderType
-      ID: 121
-      Name: '[]net/http.segment'
-      ByteSize: 24
-      GoRuntimeType: 484480
-      GoKind: 23
-      RawFields:
-        - Name: array
-          Offset: 0
-          Type: 122 PointerType *net/http.segment
-        - Name: len
-          Offset: 8
-          Type: 8 BaseType int
-        - Name: cap
-          Offset: 16
-          Type: 8 BaseType int
-      Data: 210 GoSliceDataType []net/http.segment.array
-    - __kind: PointerType
-      ID: 122
-      Name: '*net/http.segment'
-      ByteSize: 8
-      GoRuntimeType: 391712
-      GoKind: 22
-      Pointee: 123 StructureType net/http.segment
     - __kind: StructureType
       ID: 123
       Name: net/http.segment
@@ -1851,62 +2098,246 @@ Types:
           Offset: 17
           Type: 13 BaseType bool
     - __kind: GoMapType
-      ID: 124
-      Name: map[string]string
+      ID: 52
+      Name: net/textproto.MIMEHeader
       ByteSize: 8
-      GoRuntimeType: 1.12832e+06
+      GoRuntimeType: 1.82304e+06
       GoKind: 21
-      HeaderType: 126 GoSwissMapHeaderType map<string,string>
-    - __kind: PointerType
-      ID: 125
-      Name: '*map<string,string>'
+      HeaderType: 16 GoSwissMapHeaderType map<string,[]string>
+    - __kind: StructureType
+      ID: 10
+      Name: net/url.URL
+      ByteSize: 144
+      GoRuntimeType: 2.126816e+06
+      GoKind: 25
+      RawFields:
+        - Name: Scheme
+          Offset: 0
+          Type: 5 GoStringHeaderType string
+        - Name: Opaque
+          Offset: 16
+          Type: 5 GoStringHeaderType string
+        - Name: User
+          Offset: 32
+          Type: 11 PointerType *net/url.Userinfo
+        - Name: Host
+          Offset: 40
+          Type: 5 GoStringHeaderType string
+        - Name: Path
+          Offset: 56
+          Type: 5 GoStringHeaderType string
+        - Name: RawPath
+          Offset: 72
+          Type: 5 GoStringHeaderType string
+        - Name: OmitHost
+          Offset: 88
+          Type: 13 BaseType bool
+        - Name: ForceQuery
+          Offset: 89
+          Type: 13 BaseType bool
+        - Name: RawQuery
+          Offset: 96
+          Type: 5 GoStringHeaderType string
+        - Name: Fragment
+          Offset: 112
+          Type: 5 GoStringHeaderType string
+        - Name: RawFragment
+          Offset: 128
+          Type: 5 GoStringHeaderType string
+    - __kind: StructureType
+      ID: 12
+      Name: net/url.Userinfo
+      ByteSize: 40
+      GoRuntimeType: 1.624384e+06
+      GoKind: 25
+      RawFields:
+        - Name: username
+          Offset: 0
+          Type: 5 GoStringHeaderType string
+        - Name: password
+          Offset: 16
+          Type: 5 GoStringHeaderType string
+        - Name: passwordSet
+          Offset: 32
+          Type: 13 BaseType bool
+    - __kind: GoMapType
+      ID: 33
+      Name: net/url.Values
       ByteSize: 8
-      Pointee: 126 GoSwissMapHeaderType map<string,string>
-    - __kind: GoSwissMapHeaderType
-      ID: 126
-      Name: map<string,string>
-      ByteSize: 48
+      GoRuntimeType: 1.884384e+06
+      GoKind: 21
+      HeaderType: 16 GoSwissMapHeaderType map<string,[]string>
+    - __kind: ArrayType
+      ID: 46
+      Name: noalg.[8]struct { key string; elem []*mime/multipart.FileHeader }
+      ByteSize: 320
+      GoRuntimeType: 699072
+      GoKind: 17
+      Count: 8
+      HasCount: true
+      Element: 47 StructureType noalg.struct { key string; elem []*mime/multipart.FileHeader }
+    - __kind: ArrayType
+      ID: 26
+      Name: noalg.[8]struct { key string; elem []string }
+      ByteSize: 320
+      GoRuntimeType: 689248
+      GoKind: 17
+      Count: 8
+      HasCount: true
+      Element: 27 StructureType noalg.struct { key string; elem []string }
+    - __kind: ArrayType
+      ID: 133
+      Name: noalg.[8]struct { key string; elem string }
+      ByteSize: 256
+      GoRuntimeType: 693408
+      GoKind: 17
+      Count: 8
+      HasCount: true
+      Element: 134 StructureType noalg.struct { key string; elem string }
+    - __kind: StructureType
+      ID: 45
+      Name: noalg.map.group[string][]*mime/multipart.FileHeader
+      ByteSize: 328
+      GoRuntimeType: 1.298816e+06
+      GoKind: 25
+      RawFields:
+        - Name: ctrl
+          Offset: 0
+          Type: 17 BaseType uint64
+        - Name: slots
+          Offset: 8
+          Type: 46 ArrayType noalg.[8]struct { key string; elem []*mime/multipart.FileHeader }
+    - __kind: StructureType
+      ID: 25
+      Name: noalg.map.group[string][]string
+      ByteSize: 328
+      GoRuntimeType: 1.289728e+06
+      GoKind: 25
+      RawFields:
+        - Name: ctrl
+          Offset: 0
+          Type: 17 BaseType uint64
+        - Name: slots
+          Offset: 8
+          Type: 26 ArrayType noalg.[8]struct { key string; elem []string }
+    - __kind: StructureType
+      ID: 132
+      Name: noalg.map.group[string]string
+      ByteSize: 264
+      GoRuntimeType: 1.29216e+06
+      GoKind: 25
+      RawFields:
+        - Name: ctrl
+          Offset: 0
+          Type: 17 BaseType uint64
+        - Name: slots
+          Offset: 8
+          Type: 133 ArrayType noalg.[8]struct { key string; elem string }
+    - __kind: StructureType
+      ID: 47
+      Name: noalg.struct { key string; elem []*mime/multipart.FileHeader }
+      ByteSize: 40
+      GoRuntimeType: 1.298688e+06
+      GoKind: 25
+      RawFields:
+        - Name: key
+          Offset: 0
+          Type: 5 GoStringHeaderType string
+        - Name: elem
+          Offset: 16
+          Type: 48 GoSliceHeaderType []*mime/multipart.FileHeader
+    - __kind: StructureType
+      ID: 27
+      Name: noalg.struct { key string; elem []string }
+      ByteSize: 40
+      GoRuntimeType: 1.2896e+06
+      GoKind: 25
+      RawFields:
+        - Name: key
+          Offset: 0
+          Type: 5 GoStringHeaderType string
+        - Name: elem
+          Offset: 16
+          Type: 28 GoSliceHeaderType []string
+    - __kind: StructureType
+      ID: 134
+      Name: noalg.struct { key string; elem string }
+      ByteSize: 32
+      GoRuntimeType: 1.292032e+06
+      GoKind: 25
+      RawFields:
+        - Name: key
+          Offset: 0
+          Type: 5 GoStringHeaderType string
+        - Name: elem
+          Offset: 16
+          Type: 5 GoStringHeaderType string
+    - __kind: GoStringHeaderType
+      ID: 5
+      Name: string
+      ByteSize: 16
+      GoRuntimeType: 584224
+      GoKind: 24
+      RawFields:
+        - Name: str
+          Offset: 0
+          Type: 163 PointerType *string.str
+        - Name: len
+          Offset: 8
+          Type: 8 BaseType int
+      Data: 162 GoStringDataType string.str
+    - __kind: GoStringDataType
+      ID: 162
+      Name: string.str
+      ByteSize: 2048
+    - __kind: StructureType
+      ID: 42
+      Name: table<string,[]*mime/multipart.FileHeader>
+      ByteSize: 32
       GoKind: 25
       RawFields:
         - Name: used
           Offset: 0
-          Type: 17 BaseType uint64
-        - Name: seed
+          Type: 22 BaseType uint16
+        - Name: capacity
+          Offset: 2
+          Type: 22 BaseType uint16
+        - Name: growthLeft
+          Offset: 4
+          Type: 22 BaseType uint16
+        - Name: localDepth
+          Offset: 6
+          Type: 7 BaseType uint8
+        - Name: index
           Offset: 8
-          Type: 18 BaseType uintptr
-        - Name: dirPtr
-          Offset: 16
-          Type: 127 PointerType **table<string,string>
-        - Name: dirLen
-          Offset: 24
           Type: 8 BaseType int
-        - Name: globalDepth
-          Offset: 32
+        - Name: groups
+          Offset: 16
+          Type: 43 GoSwissMapGroupsType groupReference<string,[]*mime/multipart.FileHeader>
+    - __kind: StructureType
+      ID: 21
+      Name: table<string,[]string>
+      ByteSize: 32
+      GoKind: 25
+      RawFields:
+        - Name: used
+          Offset: 0
+          Type: 22 BaseType uint16
+        - Name: capacity
+          Offset: 2
+          Type: 22 BaseType uint16
+        - Name: growthLeft
+          Offset: 4
+          Type: 22 BaseType uint16
+        - Name: localDepth
+          Offset: 6
           Type: 7 BaseType uint8
-        - Name: globalShift
-          Offset: 33
-          Type: 7 BaseType uint8
-        - Name: writing
-          Offset: 34
-          Type: 7 BaseType uint8
-        - Name: tombstonePossible
-          Offset: 35
-          Type: 13 BaseType bool
-        - Name: clearSeq
-          Offset: 40
-          Type: 17 BaseType uint64
-      TablePtrSliceType: 212 GoSliceDataType []*table<string,string>.array
-      GroupType: 132 StructureType noalg.map.group[string]string
-    - __kind: PointerType
-      ID: 127
-      Name: '**table<string,string>'
-      ByteSize: 8
-      Pointee: 128 PointerType *table<string,string>
-    - __kind: PointerType
-      ID: 128
-      Name: '*table<string,string>'
-      ByteSize: 8
-      Pointee: 129 StructureType table<string,string>
+        - Name: index
+          Offset: 8
+          Type: 8 BaseType int
+        - Name: groups
+          Offset: 16
+          Type: 23 GoSwissMapGroupsType groupReference<string,[]string>
     - __kind: StructureType
       ID: 129
       Name: table<string,string>
@@ -1931,102 +2362,97 @@ Types:
         - Name: groups
           Offset: 16
           Type: 130 GoSwissMapGroupsType groupReference<string,string>
-    - __kind: GoSwissMapGroupsType
-      ID: 130
-      Name: groupReference<string,string>
-      ByteSize: 16
-      GoKind: 25
-      RawFields:
-        - Name: data
-          Offset: 0
-          Type: 131 PointerType *noalg.map.group[string]string
-        - Name: lengthMask
-          Offset: 8
-          Type: 17 BaseType uint64
-      GroupType: 132 StructureType noalg.map.group[string]string
-      GroupSliceType: 213 GoSliceDataType []noalg.map.group[string]string.array
-    - __kind: PointerType
-      ID: 131
-      Name: '*noalg.map.group[string]string'
-      ByteSize: 8
-      Pointee: 132 StructureType noalg.map.group[string]string
     - __kind: StructureType
-      ID: 132
-      Name: noalg.map.group[string]string
-      ByteSize: 264
-      GoRuntimeType: 1.29216e+06
+      ID: 77
+      Name: time.Location
+      ByteSize: 104
+      GoRuntimeType: 1.972768e+06
       GoKind: 25
       RawFields:
-        - Name: ctrl
-          Offset: 0
-          Type: 17 BaseType uint64
-        - Name: slots
-          Offset: 8
-          Type: 133 ArrayType noalg.[8]struct { key string; elem string }
-    - __kind: ArrayType
-      ID: 133
-      Name: noalg.[8]struct { key string; elem string }
-      ByteSize: 256
-      GoRuntimeType: 693408
-      GoKind: 17
-      Count: 8
-      HasCount: true
-      Element: 134 StructureType noalg.struct { key string; elem string }
-    - __kind: StructureType
-      ID: 134
-      Name: noalg.struct { key string; elem string }
-      ByteSize: 32
-      GoRuntimeType: 1.292032e+06
-      GoKind: 25
-      RawFields:
-        - Name: key
+        - Name: name
           Offset: 0
           Type: 5 GoStringHeaderType string
-        - Name: elem
+        - Name: zone
           Offset: 16
+          Type: 78 GoSliceHeaderType []time.zone
+        - Name: tx
+          Offset: 40
+          Type: 81 GoSliceHeaderType []time.zoneTrans
+        - Name: extend
+          Offset: 64
           Type: 5 GoStringHeaderType string
-    - __kind: PointerType
-      ID: 135
-      Name: '*bytes.Buffer'
-      ByteSize: 8
-      GoRuntimeType: 2.259936e+06
-      GoKind: 22
-      Pointee: 136 StructureType bytes.Buffer
+        - Name: cacheStart
+          Offset: 80
+          Type: 32 BaseType int64
+        - Name: cacheEnd
+          Offset: 88
+          Type: 32 BaseType int64
+        - Name: cacheZone
+          Offset: 96
+          Type: 79 PointerType *time.zone
     - __kind: StructureType
-      ID: 136
-      Name: bytes.Buffer
-      ByteSize: 40
-      GoRuntimeType: 1.60576e+06
+      ID: 75
+      Name: time.Time
+      ByteSize: 24
+      GoRuntimeType: 2.363936e+06
       GoKind: 25
       RawFields:
-        - Name: buf
+        - Name: wall
           Offset: 0
-          Type: 53 GoSliceHeaderType []uint8
-        - Name: off
-          Offset: 24
-          Type: 8 BaseType int
-        - Name: lastRead
-          Offset: 32
-          Type: 137 BaseType bytes.readOp
-    - __kind: BaseType
-      ID: 137
-      Name: bytes.readOp
-      ByteSize: 1
-      GoRuntimeType: 583456
-      GoKind: 3
-    - __kind: GoInterfaceType
-      ID: 138
-      Name: gopkg.in/DataDog/dd-trace-go.v1/ddtrace.Span
-      ByteSize: 16
-      GoRuntimeType: 1.479008e+06
-      GoKind: 20
-      RawFields:
-        - Name: tab
-          Offset: 0
-          Type: 2 VoidPointerType unsafe.Pointer
-        - Name: data
+          Type: 17 BaseType uint64
+        - Name: ext
           Offset: 8
-          Type: 2 VoidPointerType unsafe.Pointer
+          Type: 32 BaseType int64
+        - Name: loc
+          Offset: 16
+          Type: 76 PointerType *time.Location
+    - __kind: StructureType
+      ID: 80
+      Name: time.zone
+      ByteSize: 32
+      GoRuntimeType: 1.612864e+06
+      GoKind: 25
+      RawFields:
+        - Name: name
+          Offset: 0
+          Type: 5 GoStringHeaderType string
+        - Name: offset
+          Offset: 16
+          Type: 8 BaseType int
+        - Name: isDST
+          Offset: 24
+          Type: 13 BaseType bool
+    - __kind: StructureType
+      ID: 83
+      Name: time.zoneTrans
+      ByteSize: 16
+      GoRuntimeType: 1.750304e+06
+      GoKind: 25
+      RawFields:
+        - Name: when
+          Offset: 0
+          Type: 32 BaseType int64
+        - Name: index
+          Offset: 8
+          Type: 7 BaseType uint8
+        - Name: isstd
+          Offset: 9
+          Type: 13 BaseType bool
+        - Name: isutc
+          Offset: 10
+          Type: 13 BaseType bool
+    - __kind: BaseType
+      ID: 140
+      Name: uint
+      ByteSize: 8
+      GoRuntimeType: 584864
+      GoKind: 7
+    - __kind: BaseType
+      ID: 22
+      Name: uint16
+      ByteSize: 2
+      GoRuntimeType: 584480
+      GoKind: 9
     - __kind: BaseType
       ID: 139
       Name: uint32
@@ -2034,455 +2460,29 @@ Types:
       GoRuntimeType: 584608
       GoKind: 10
     - __kind: BaseType
-      ID: 140
-      Name: uint
+      ID: 17
+      Name: uint64
       ByteSize: 8
-      GoRuntimeType: 584864
-      GoKind: 7
-    - __kind: PointerType
-      ID: 141
-      Name: '*bool'
-      ByteSize: 8
-      GoRuntimeType: 400224
-      GoKind: 22
-      Pointee: 13 BaseType bool
+      GoRuntimeType: 584736
+      GoKind: 11
     - __kind: BaseType
-      ID: 142
-      Name: int32
-      ByteSize: 4
-      GoRuntimeType: 584544
-      GoKind: 5
-    - __kind: GoInterfaceType
-      ID: 143
-      Name: error
-      ByteSize: 16
-      GoRuntimeType: 1.031072e+06
-      GoKind: 20
-      RawFields:
-        - Name: tab
-          Offset: 0
-          Type: 2 VoidPointerType unsafe.Pointer
-        - Name: data
-          Offset: 8
-          Type: 2 VoidPointerType unsafe.Pointer
-    - __kind: BaseType
-      ID: 144
-      Name: float64
-      ByteSize: 8
-      GoRuntimeType: 585184
-      GoKind: 14
-    - __kind: BaseType
-      ID: 145
-      Name: int8
+      ID: 7
+      Name: uint8
       ByteSize: 1
-      GoRuntimeType: 584288
-      GoKind: 3
+      GoRuntimeType: 584352
+      GoKind: 8
     - __kind: BaseType
-      ID: 146
-      Name: float32
-      ByteSize: 4
-      GoRuntimeType: 585120
-      GoKind: 13
-    - __kind: PointerType
-      ID: 147
-      Name: '*uintptr'
+      ID: 18
+      Name: uintptr
       ByteSize: 8
-      GoRuntimeType: 399904
-      GoKind: 22
-      Pointee: 18 BaseType uintptr
-    - __kind: PointerType
-      ID: 148
-      Name: '*int32'
+      GoRuntimeType: 584928
+      GoKind: 12
+    - __kind: VoidPointerType
+      ID: 2
+      Name: unsafe.Pointer
       ByteSize: 8
-      GoRuntimeType: 399520
-      GoKind: 22
-      Pointee: 142 BaseType int32
-    - __kind: PointerType
-      ID: 149
-      Name: '*uint32'
-      ByteSize: 8
-      GoRuntimeType: 399584
-      GoKind: 22
-      Pointee: 139 BaseType uint32
-    - __kind: BaseType
-      ID: 150
-      Name: int16
-      ByteSize: 2
-      GoRuntimeType: 584416
-      GoKind: 4
-    - __kind: BaseType
-      ID: 151
-      Name: complex64
-      ByteSize: 8
-      GoRuntimeType: 584992
-      GoKind: 15
-    - __kind: BaseType
-      ID: 152
-      Name: complex128
-      ByteSize: 16
-      GoRuntimeType: 585056
-      GoKind: 16
-    - __kind: PointerType
-      ID: 153
-      Name: '*float64'
-      ByteSize: 8
-      GoRuntimeType: 400160
-      GoKind: 22
-      Pointee: 144 BaseType float64
-    - __kind: PointerType
-      ID: 154
-      Name: '*uint64'
-      ByteSize: 8
-      GoRuntimeType: 399712
-      GoKind: 22
-      Pointee: 17 BaseType uint64
-    - __kind: PointerType
-      ID: 155
-      Name: '*int64'
-      ByteSize: 8
-      GoRuntimeType: 399648
-      GoKind: 22
-      Pointee: 32 BaseType int64
-    - __kind: PointerType
-      ID: 156
-      Name: '*uint16'
-      ByteSize: 8
-      GoRuntimeType: 399456
-      GoKind: 22
-      Pointee: 22 BaseType uint16
-    - __kind: PointerType
-      ID: 157
-      Name: '*int16'
-      ByteSize: 8
-      GoRuntimeType: 399392
-      GoKind: 22
-      Pointee: 150 BaseType int16
-    - __kind: PointerType
-      ID: 158
-      Name: '*int8'
-      ByteSize: 8
-      GoRuntimeType: 399264
-      GoKind: 22
-      Pointee: 145 BaseType int8
-    - __kind: PointerType
-      ID: 159
-      Name: '*error'
-      ByteSize: 8
-      GoRuntimeType: 399136
-      GoKind: 22
-      Pointee: 143 GoInterfaceType error
-    - __kind: PointerType
-      ID: 160
-      Name: '*uint'
-      ByteSize: 8
-      GoRuntimeType: 399840
-      GoKind: 22
-      Pointee: 140 BaseType uint
-    - __kind: PointerType
-      ID: 161
-      Name: '*float32'
-      ByteSize: 8
-      GoRuntimeType: 400096
-      GoKind: 22
-      Pointee: 146 BaseType float32
-    - __kind: GoStringDataType
-      ID: 162
-      Name: string.str
-      ByteSize: 2048
-    - __kind: PointerType
-      ID: 163
-      Name: '*string.str'
-      ByteSize: 8
-      Pointee: 162 GoStringDataType string.str
-    - __kind: GoSliceDataType
-      ID: 164
-      Name: '[]*table<string,[]string>.array'
-      ByteSize: 8192
-      Element: 20 PointerType *table<string,[]string>
-    - __kind: GoSliceDataType
-      ID: 165
-      Name: '[]noalg.map.group[string][]string.array'
-      ByteSize: 2048
-      Element: 25 StructureType noalg.map.group[string][]string
-    - __kind: GoSliceDataType
-      ID: 166
-      Name: '[]string.array'
-      ByteSize: 2048
-      Element: 5 GoStringHeaderType string
-    - __kind: PointerType
-      ID: 167
-      Name: '*[]string.array'
-      ByteSize: 8
-      Pointee: 166 GoSliceDataType []string.array
-    - __kind: GoSliceDataType
-      ID: 168
-      Name: '[]*table<string,[]*mime/multipart.FileHeader>.array'
-      ByteSize: 8192
-      Element: 41 PointerType *table<string,[]*mime/multipart.FileHeader>
-    - __kind: GoSliceDataType
-      ID: 169
-      Name: '[]noalg.map.group[string][]*mime/multipart.FileHeader.array'
-      ByteSize: 2048
-      Element: 45 StructureType noalg.map.group[string][]*mime/multipart.FileHeader
-    - __kind: GoSliceDataType
-      ID: 170
-      Name: '[]*mime/multipart.FileHeader.array'
-      ByteSize: 2048
-      Element: 50 PointerType *mime/multipart.FileHeader
-    - __kind: PointerType
-      ID: 171
-      Name: '*[]*mime/multipart.FileHeader.array'
-      ByteSize: 8
-      Pointee: 170 GoSliceDataType []*mime/multipart.FileHeader.array
-    - __kind: GoSliceDataType
-      ID: 172
-      Name: '[]uint8.array'
-      ByteSize: 2048
-      Element: 7 BaseType uint8
-    - __kind: PointerType
-      ID: 173
-      Name: '*[]uint8.array'
-      ByteSize: 8
-      Pointee: 172 GoSliceDataType []uint8.array
-    - __kind: GoSliceDataType
-      ID: 174
-      Name: '[]*crypto/x509.Certificate.array'
-      ByteSize: 2048
-      Element: 59 PointerType *crypto/x509.Certificate
-    - __kind: PointerType
-      ID: 175
-      Name: '*[]*crypto/x509.Certificate.array'
-      ByteSize: 8
-      Pointee: 174 GoSliceDataType []*crypto/x509.Certificate.array
-    - __kind: GoSliceDataType
-      ID: 176
-      Name: math/big.nat.array
-      ByteSize: 2048
-      Element: 68 BaseType math/big.Word
-    - __kind: PointerType
-      ID: 177
-      Name: '*math/big.nat.array'
-      ByteSize: 8
-      Pointee: 176 GoSliceDataType math/big.nat.array
-    - __kind: GoSliceDataType
-      ID: 178
-      Name: '[]crypto/x509/pkix.AttributeTypeAndValue.array'
-      ByteSize: 2048
-      Element: 72 StructureType crypto/x509/pkix.AttributeTypeAndValue
-    - __kind: PointerType
-      ID: 179
-      Name: '*[]crypto/x509/pkix.AttributeTypeAndValue.array'
-      ByteSize: 8
-      Pointee: 178 GoSliceDataType []crypto/x509/pkix.AttributeTypeAndValue.array
-    - __kind: GoSliceDataType
-      ID: 180
-      Name: encoding/asn1.ObjectIdentifier.array
-      ByteSize: 2048
-      Element: 8 BaseType int
-    - __kind: PointerType
-      ID: 181
-      Name: '*encoding/asn1.ObjectIdentifier.array'
-      ByteSize: 8
-      Pointee: 180 GoSliceDataType encoding/asn1.ObjectIdentifier.array
-    - __kind: GoSliceDataType
-      ID: 182
-      Name: '[]time.zone.array'
-      ByteSize: 2048
-      Element: 80 StructureType time.zone
-    - __kind: PointerType
-      ID: 183
-      Name: '*[]time.zone.array'
-      ByteSize: 8
-      Pointee: 182 GoSliceDataType []time.zone.array
-    - __kind: GoSliceDataType
-      ID: 184
-      Name: '[]time.zoneTrans.array'
-      ByteSize: 2048
-      Element: 83 StructureType time.zoneTrans
-    - __kind: PointerType
-      ID: 185
-      Name: '*[]time.zoneTrans.array'
-      ByteSize: 8
-      Pointee: 184 GoSliceDataType []time.zoneTrans.array
-    - __kind: GoSliceDataType
-      ID: 186
-      Name: '[]crypto/x509/pkix.Extension.array'
-      ByteSize: 2048
-      Element: 87 StructureType crypto/x509/pkix.Extension
-    - __kind: PointerType
-      ID: 187
-      Name: '*[]crypto/x509/pkix.Extension.array'
-      ByteSize: 8
-      Pointee: 186 GoSliceDataType []crypto/x509/pkix.Extension.array
-    - __kind: GoSliceDataType
-      ID: 188
-      Name: '[]encoding/asn1.ObjectIdentifier.array'
-      ByteSize: 2048
-      Element: 73 GoSliceHeaderType encoding/asn1.ObjectIdentifier
-    - __kind: PointerType
-      ID: 189
-      Name: '*[]encoding/asn1.ObjectIdentifier.array'
-      ByteSize: 8
-      Pointee: 188 GoSliceDataType []encoding/asn1.ObjectIdentifier.array
-    - __kind: GoSliceDataType
-      ID: 190
-      Name: '[]crypto/x509.ExtKeyUsage.array'
-      ByteSize: 2048
-      Element: 92 BaseType crypto/x509.ExtKeyUsage
-    - __kind: PointerType
-      ID: 191
-      Name: '*[]crypto/x509.ExtKeyUsage.array'
-      ByteSize: 8
-      Pointee: 190 GoSliceDataType []crypto/x509.ExtKeyUsage.array
-    - __kind: GoSliceDataType
-      ID: 192
-      Name: '[]net.IP.array'
-      ByteSize: 2048
-      Element: 95 GoSliceHeaderType net.IP
-    - __kind: PointerType
-      ID: 193
-      Name: '*[]net.IP.array'
-      ByteSize: 8
-      Pointee: 192 GoSliceDataType []net.IP.array
-    - __kind: GoSliceDataType
-      ID: 194
-      Name: net.IP.array
-      ByteSize: 2048
-      Element: 7 BaseType uint8
-    - __kind: PointerType
-      ID: 195
-      Name: '*net.IP.array'
-      ByteSize: 8
-      Pointee: 194 GoSliceDataType net.IP.array
-    - __kind: GoSliceDataType
-      ID: 196
-      Name: '[]*net/url.URL.array'
-      ByteSize: 2048
-      Element: 9 PointerType *net/url.URL
-    - __kind: PointerType
-      ID: 197
-      Name: '*[]*net/url.URL.array'
-      ByteSize: 8
-      Pointee: 196 GoSliceDataType []*net/url.URL.array
-    - __kind: GoSliceDataType
-      ID: 198
-      Name: '[]*net.IPNet.array'
-      ByteSize: 2048
-      Element: 100 PointerType *net.IPNet
-    - __kind: PointerType
-      ID: 199
-      Name: '*[]*net.IPNet.array'
-      ByteSize: 8
-      Pointee: 198 GoSliceDataType []*net.IPNet.array
-    - __kind: GoSliceDataType
-      ID: 200
-      Name: net.IPMask.array
-      ByteSize: 2048
-      Element: 7 BaseType uint8
-    - __kind: PointerType
-      ID: 201
-      Name: '*net.IPMask.array'
-      ByteSize: 8
-      Pointee: 200 GoSliceDataType net.IPMask.array
-    - __kind: GoSliceDataType
-      ID: 202
-      Name: '[]crypto/x509.OID.array'
-      ByteSize: 2048
-      Element: 105 StructureType crypto/x509.OID
-    - __kind: PointerType
-      ID: 203
-      Name: '*[]crypto/x509.OID.array'
-      ByteSize: 8
-      Pointee: 202 GoSliceDataType []crypto/x509.OID.array
-    - __kind: GoSliceDataType
-      ID: 204
-      Name: '[]crypto/x509.PolicyMapping.array'
-      ByteSize: 2048
-      Element: 108 StructureType crypto/x509.PolicyMapping
-    - __kind: PointerType
-      ID: 205
-      Name: '*[]crypto/x509.PolicyMapping.array'
-      ByteSize: 8
-      Pointee: 204 GoSliceDataType []crypto/x509.PolicyMapping.array
-    - __kind: GoSliceDataType
-      ID: 206
-      Name: '[][]*crypto/x509.Certificate.array'
-      ByteSize: 2048
-      Element: 57 GoSliceHeaderType []*crypto/x509.Certificate
-    - __kind: PointerType
-      ID: 207
-      Name: '*[][]*crypto/x509.Certificate.array'
-      ByteSize: 8
-      Pointee: 206 GoSliceDataType [][]*crypto/x509.Certificate.array
-    - __kind: GoSliceDataType
-      ID: 208
-      Name: '[][]uint8.array'
-      ByteSize: 2048
-      Element: 53 GoSliceHeaderType []uint8
-    - __kind: PointerType
-      ID: 209
-      Name: '*[][]uint8.array'
-      ByteSize: 8
-      Pointee: 208 GoSliceDataType [][]uint8.array
-    - __kind: GoSliceDataType
-      ID: 210
-      Name: '[]net/http.segment.array'
-      ByteSize: 2048
-      Element: 123 StructureType net/http.segment
-    - __kind: PointerType
-      ID: 211
-      Name: '*[]net/http.segment.array'
-      ByteSize: 8
-      Pointee: 210 GoSliceDataType []net/http.segment.array
-    - __kind: GoSliceDataType
-      ID: 212
-      Name: '[]*table<string,string>.array'
-      ByteSize: 8192
-      Element: 128 PointerType *table<string,string>
-    - __kind: GoSliceDataType
-      ID: 213
-      Name: '[]noalg.map.group[string]string.array'
-      ByteSize: 2048
-      Element: 132 StructureType noalg.map.group[string]string
-    - __kind: EventRootType
-      ID: 214
-      Name: Probe[main.HandleHTTP]
-      ByteSize: 25
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: w
-          Offset: 1
-          Expression:
-            Type: 1 GoInterfaceType net/http.ResponseWriter
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 1, index: 0, name: w}
-                  Offset: 0
-                  ByteSize: 16
-        - Name: r
-          Offset: 17
-          Expression:
-            Type: 3 PointerType *net/http.Request
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 1, index: 1, name: r}
-                  Offset: 0
-                  ByteSize: 8
-    - __kind: EventRootType
-      ID: 215
-      Name: Probe[main.LookAtTheRequest]
-      ByteSize: 17
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: path
-          Offset: 1
-          Expression:
-            Type: 5 GoStringHeaderType string
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 2, index: 0, name: path}
-                  Offset: 0
-                  ByteSize: 16
+      GoRuntimeType: 585312
+      GoKind: 26
 MaxTypeID: 215
 Issues: []
 GoModuledataInfo: {FirstModuledataAddr: "0x130d980", TypesOffset: 296}

--- a/pkg/dyninst/irgen/testdata/snapshot/rc_tester_v1.arch=arm64,toolchain=go1.25.0.yaml
+++ b/pkg/dyninst/irgen/testdata/snapshot/rc_tester_v1.arch=arm64,toolchain=go1.25.0.yaml
@@ -10,7 +10,7 @@ Probes:
       subprogram: {subprogram: 1}
       events:
         - ID: 1
-          Type: 220 EventRootType Probe[main.HandleHTTP]
+          Type: 214 EventRootType Probe[main.HandleHTTP]
           InjectionPoints: [{PC: "0x82b100", Frameless: true}]
           Condition: null
     - id: look_at_the_request
@@ -23,7 +23,7 @@ Probes:
       subprogram: {subprogram: 2}
       events:
         - ID: 2
-          Type: 221 EventRootType Probe[main.LookAtTheRequest]
+          Type: 215 EventRootType Probe[main.LookAtTheRequest]
           InjectionPoints: [{PC: "0x82b3fc", Frameless: true}]
           Condition: null
 Subprograms:
@@ -372,7 +372,7 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 17 BaseType uint64
-      TablePtrSliceType: 176 GoSliceDataType []*table<string,[]string>.array
+      TablePtrSliceType: 164 GoSliceDataType []*table<string,[]string>.array
       GroupType: 25 StructureType noalg.map.group[string][]string
     - __kind: BaseType
       ID: 17
@@ -439,7 +439,7 @@ Types:
           Offset: 8
           Type: 17 BaseType uint64
       GroupType: 25 StructureType noalg.map.group[string][]string
-      GroupSliceType: 177 GoSliceDataType []noalg.map.group[string][]string.array
+      GroupSliceType: 165 GoSliceDataType []noalg.map.group[string][]string.array
     - __kind: PointerType
       ID: 24
       Name: '*noalg.map.group[string][]string'
@@ -608,7 +608,7 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 17 BaseType uint64
-      TablePtrSliceType: 172 GoSliceDataType []*table<string,[]*mime/multipart.FileHeader>.array
+      TablePtrSliceType: 168 GoSliceDataType []*table<string,[]*mime/multipart.FileHeader>.array
       GroupType: 45 StructureType noalg.map.group[string][]*mime/multipart.FileHeader
     - __kind: PointerType
       ID: 40
@@ -657,7 +657,7 @@ Types:
           Offset: 8
           Type: 17 BaseType uint64
       GroupType: 45 StructureType noalg.map.group[string][]*mime/multipart.FileHeader
-      GroupSliceType: 173 GoSliceDataType []noalg.map.group[string][]*mime/multipart.FileHeader.array
+      GroupSliceType: 169 GoSliceDataType []noalg.map.group[string][]*mime/multipart.FileHeader.array
     - __kind: PointerType
       ID: 44
       Name: '*noalg.map.group[string][]*mime/multipart.FileHeader'
@@ -714,7 +714,7 @@ Types:
         - Name: cap
           Offset: 16
           Type: 8 BaseType int
-      Data: 174 GoSliceDataType []*mime/multipart.FileHeader.array
+      Data: 170 GoSliceDataType []*mime/multipart.FileHeader.array
     - __kind: PointerType
       ID: 49
       Name: '**mime/multipart.FileHeader'
@@ -779,7 +779,7 @@ Types:
         - Name: cap
           Offset: 16
           Type: 8 BaseType int
-      Data: 178 GoSliceDataType []uint8.array
+      Data: 172 GoSliceDataType []uint8.array
     - __kind: PointerType
       ID: 54
       Name: '*crypto/tls.ConnectionState'
@@ -867,7 +867,7 @@ Types:
         - Name: cap
           Offset: 16
           Type: 8 BaseType int
-      Data: 180 GoSliceDataType []*crypto/x509.Certificate.array
+      Data: 174 GoSliceDataType []*crypto/x509.Certificate.array
     - __kind: PointerType
       ID: 58
       Name: '**crypto/x509.Certificate'
@@ -1105,7 +1105,7 @@ Types:
         - Name: cap
           Offset: 16
           Type: 8 BaseType int
-      Data: 182 GoSliceDataType math/big.nat.array
+      Data: 176 GoSliceDataType math/big.nat.array
     - __kind: PointerType
       ID: 67
       Name: '*math/big.Word'
@@ -1175,7 +1175,7 @@ Types:
         - Name: cap
           Offset: 16
           Type: 8 BaseType int
-      Data: 184 GoSliceDataType []crypto/x509/pkix.AttributeTypeAndValue.array
+      Data: 178 GoSliceDataType []crypto/x509/pkix.AttributeTypeAndValue.array
     - __kind: PointerType
       ID: 71
       Name: '*crypto/x509/pkix.AttributeTypeAndValue'
@@ -1212,7 +1212,7 @@ Types:
         - Name: cap
           Offset: 16
           Type: 8 BaseType int
-      Data: 186 GoSliceDataType encoding/asn1.ObjectIdentifier.array
+      Data: 180 GoSliceDataType encoding/asn1.ObjectIdentifier.array
     - __kind: PointerType
       ID: 74
       Name: '*int'
@@ -1287,7 +1287,7 @@ Types:
         - Name: cap
           Offset: 16
           Type: 8 BaseType int
-      Data: 188 GoSliceDataType []time.zone.array
+      Data: 182 GoSliceDataType []time.zone.array
     - __kind: PointerType
       ID: 79
       Name: '*time.zone'
@@ -1327,7 +1327,7 @@ Types:
         - Name: cap
           Offset: 16
           Type: 8 BaseType int
-      Data: 190 GoSliceDataType []time.zoneTrans.array
+      Data: 184 GoSliceDataType []time.zoneTrans.array
     - __kind: PointerType
       ID: 82
       Name: '*time.zoneTrans'
@@ -1376,7 +1376,7 @@ Types:
         - Name: cap
           Offset: 16
           Type: 8 BaseType int
-      Data: 192 GoSliceDataType []crypto/x509/pkix.Extension.array
+      Data: 186 GoSliceDataType []crypto/x509/pkix.Extension.array
     - __kind: PointerType
       ID: 86
       Name: '*crypto/x509/pkix.Extension'
@@ -1416,7 +1416,7 @@ Types:
         - Name: cap
           Offset: 16
           Type: 8 BaseType int
-      Data: 194 GoSliceDataType []encoding/asn1.ObjectIdentifier.array
+      Data: 188 GoSliceDataType []encoding/asn1.ObjectIdentifier.array
     - __kind: PointerType
       ID: 89
       Name: '*encoding/asn1.ObjectIdentifier'
@@ -1440,7 +1440,7 @@ Types:
         - Name: cap
           Offset: 16
           Type: 8 BaseType int
-      Data: 196 GoSliceDataType []crypto/x509.ExtKeyUsage.array
+      Data: 190 GoSliceDataType []crypto/x509.ExtKeyUsage.array
     - __kind: PointerType
       ID: 91
       Name: '*crypto/x509.ExtKeyUsage'
@@ -1470,7 +1470,7 @@ Types:
         - Name: cap
           Offset: 16
           Type: 8 BaseType int
-      Data: 198 GoSliceDataType []net.IP.array
+      Data: 192 GoSliceDataType []net.IP.array
     - __kind: PointerType
       ID: 94
       Name: '*net.IP'
@@ -1494,7 +1494,7 @@ Types:
         - Name: cap
           Offset: 16
           Type: 8 BaseType int
-      Data: 200 GoSliceDataType net.IP.array
+      Data: 194 GoSliceDataType net.IP.array
     - __kind: GoSliceHeaderType
       ID: 96
       Name: '[]*net/url.URL'
@@ -1511,7 +1511,7 @@ Types:
         - Name: cap
           Offset: 16
           Type: 8 BaseType int
-      Data: 202 GoSliceDataType []*net/url.URL.array
+      Data: 196 GoSliceDataType []*net/url.URL.array
     - __kind: PointerType
       ID: 97
       Name: '**net/url.URL'
@@ -1533,7 +1533,7 @@ Types:
         - Name: cap
           Offset: 16
           Type: 8 BaseType int
-      Data: 204 GoSliceDataType []*net.IPNet.array
+      Data: 198 GoSliceDataType []*net.IPNet.array
     - __kind: PointerType
       ID: 99
       Name: '**net.IPNet'
@@ -1576,7 +1576,7 @@ Types:
         - Name: cap
           Offset: 16
           Type: 8 BaseType int
-      Data: 206 GoSliceDataType net.IPMask.array
+      Data: 200 GoSliceDataType net.IPMask.array
     - __kind: GoSliceHeaderType
       ID: 103
       Name: '[]crypto/x509.OID'
@@ -1593,7 +1593,7 @@ Types:
         - Name: cap
           Offset: 16
           Type: 8 BaseType int
-      Data: 208 GoSliceDataType []crypto/x509.OID.array
+      Data: 202 GoSliceDataType []crypto/x509.OID.array
     - __kind: PointerType
       ID: 104
       Name: '*crypto/x509.OID'
@@ -1627,7 +1627,7 @@ Types:
         - Name: cap
           Offset: 16
           Type: 8 BaseType int
-      Data: 210 GoSliceDataType []crypto/x509.PolicyMapping.array
+      Data: 204 GoSliceDataType []crypto/x509.PolicyMapping.array
     - __kind: PointerType
       ID: 107
       Name: '*crypto/x509.PolicyMapping'
@@ -1664,7 +1664,7 @@ Types:
         - Name: cap
           Offset: 16
           Type: 8 BaseType int
-      Data: 212 GoSliceDataType [][]*crypto/x509.Certificate.array
+      Data: 206 GoSliceDataType [][]*crypto/x509.Certificate.array
     - __kind: PointerType
       ID: 110
       Name: '*[]*crypto/x509.Certificate'
@@ -1687,7 +1687,7 @@ Types:
         - Name: cap
           Offset: 16
           Type: 8 BaseType int
-      Data: 214 GoSliceDataType [][]uint8.array
+      Data: 208 GoSliceDataType [][]uint8.array
     - __kind: PointerType
       ID: 112
       Name: '*[]uint8'
@@ -1826,7 +1826,7 @@ Types:
         - Name: cap
           Offset: 16
           Type: 8 BaseType int
-      Data: 216 GoSliceDataType []net/http.segment.array
+      Data: 210 GoSliceDataType []net/http.segment.array
     - __kind: PointerType
       ID: 122
       Name: '*net/http.segment'
@@ -1895,7 +1895,7 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 17 BaseType uint64
-      TablePtrSliceType: 218 GoSliceDataType []*table<string,string>.array
+      TablePtrSliceType: 212 GoSliceDataType []*table<string,string>.array
       GroupType: 132 StructureType noalg.map.group[string]string
     - __kind: PointerType
       ID: 127
@@ -1944,7 +1944,7 @@ Types:
           Offset: 8
           Type: 17 BaseType uint64
       GroupType: 132 StructureType noalg.map.group[string]string
-      GroupSliceType: 219 GoSliceDataType []noalg.map.group[string]string.array
+      GroupSliceType: 213 GoSliceDataType []noalg.map.group[string]string.array
     - __kind: PointerType
       ID: 131
       Name: '*noalg.map.group[string]string'
@@ -2216,266 +2216,236 @@ Types:
       Pointee: 166 GoSliceDataType []string.array
     - __kind: GoSliceDataType
       ID: 168
-      Name: '[]*table<string,[]string>.array'
-      ByteSize: 8192
-      Element: 20 PointerType *table<string,[]string>
-    - __kind: GoSliceDataType
-      ID: 169
-      Name: '[]noalg.map.group[string][]string.array'
-      ByteSize: 2048
-      Element: 25 StructureType noalg.map.group[string][]string
-    - __kind: GoSliceDataType
-      ID: 170
-      Name: '[]*table<string,[]string>.array'
-      ByteSize: 8192
-      Element: 20 PointerType *table<string,[]string>
-    - __kind: GoSliceDataType
-      ID: 171
-      Name: '[]noalg.map.group[string][]string.array'
-      ByteSize: 2048
-      Element: 25 StructureType noalg.map.group[string][]string
-    - __kind: GoSliceDataType
-      ID: 172
       Name: '[]*table<string,[]*mime/multipart.FileHeader>.array'
       ByteSize: 8192
       Element: 41 PointerType *table<string,[]*mime/multipart.FileHeader>
     - __kind: GoSliceDataType
-      ID: 173
+      ID: 169
       Name: '[]noalg.map.group[string][]*mime/multipart.FileHeader.array'
       ByteSize: 2048
       Element: 45 StructureType noalg.map.group[string][]*mime/multipart.FileHeader
     - __kind: GoSliceDataType
-      ID: 174
+      ID: 170
       Name: '[]*mime/multipart.FileHeader.array'
       ByteSize: 2048
       Element: 50 PointerType *mime/multipart.FileHeader
     - __kind: PointerType
-      ID: 175
+      ID: 171
       Name: '*[]*mime/multipart.FileHeader.array'
       ByteSize: 8
-      Pointee: 174 GoSliceDataType []*mime/multipart.FileHeader.array
+      Pointee: 170 GoSliceDataType []*mime/multipart.FileHeader.array
     - __kind: GoSliceDataType
-      ID: 176
-      Name: '[]*table<string,[]string>.array'
-      ByteSize: 8192
-      Element: 20 PointerType *table<string,[]string>
-    - __kind: GoSliceDataType
-      ID: 177
-      Name: '[]noalg.map.group[string][]string.array'
-      ByteSize: 2048
-      Element: 25 StructureType noalg.map.group[string][]string
-    - __kind: GoSliceDataType
-      ID: 178
+      ID: 172
       Name: '[]uint8.array'
       ByteSize: 2048
       Element: 7 BaseType uint8
     - __kind: PointerType
-      ID: 179
+      ID: 173
       Name: '*[]uint8.array'
       ByteSize: 8
-      Pointee: 178 GoSliceDataType []uint8.array
+      Pointee: 172 GoSliceDataType []uint8.array
     - __kind: GoSliceDataType
-      ID: 180
+      ID: 174
       Name: '[]*crypto/x509.Certificate.array'
       ByteSize: 2048
       Element: 59 PointerType *crypto/x509.Certificate
     - __kind: PointerType
-      ID: 181
+      ID: 175
       Name: '*[]*crypto/x509.Certificate.array'
       ByteSize: 8
-      Pointee: 180 GoSliceDataType []*crypto/x509.Certificate.array
+      Pointee: 174 GoSliceDataType []*crypto/x509.Certificate.array
     - __kind: GoSliceDataType
-      ID: 182
+      ID: 176
       Name: math/big.nat.array
       ByteSize: 2048
       Element: 68 BaseType math/big.Word
     - __kind: PointerType
-      ID: 183
+      ID: 177
       Name: '*math/big.nat.array'
       ByteSize: 8
-      Pointee: 182 GoSliceDataType math/big.nat.array
+      Pointee: 176 GoSliceDataType math/big.nat.array
     - __kind: GoSliceDataType
-      ID: 184
+      ID: 178
       Name: '[]crypto/x509/pkix.AttributeTypeAndValue.array'
       ByteSize: 2048
       Element: 72 StructureType crypto/x509/pkix.AttributeTypeAndValue
     - __kind: PointerType
-      ID: 185
+      ID: 179
       Name: '*[]crypto/x509/pkix.AttributeTypeAndValue.array'
       ByteSize: 8
-      Pointee: 184 GoSliceDataType []crypto/x509/pkix.AttributeTypeAndValue.array
+      Pointee: 178 GoSliceDataType []crypto/x509/pkix.AttributeTypeAndValue.array
     - __kind: GoSliceDataType
-      ID: 186
+      ID: 180
       Name: encoding/asn1.ObjectIdentifier.array
       ByteSize: 2048
       Element: 8 BaseType int
     - __kind: PointerType
-      ID: 187
+      ID: 181
       Name: '*encoding/asn1.ObjectIdentifier.array'
       ByteSize: 8
-      Pointee: 186 GoSliceDataType encoding/asn1.ObjectIdentifier.array
+      Pointee: 180 GoSliceDataType encoding/asn1.ObjectIdentifier.array
     - __kind: GoSliceDataType
-      ID: 188
+      ID: 182
       Name: '[]time.zone.array'
       ByteSize: 2048
       Element: 80 StructureType time.zone
     - __kind: PointerType
-      ID: 189
+      ID: 183
       Name: '*[]time.zone.array'
       ByteSize: 8
-      Pointee: 188 GoSliceDataType []time.zone.array
+      Pointee: 182 GoSliceDataType []time.zone.array
     - __kind: GoSliceDataType
-      ID: 190
+      ID: 184
       Name: '[]time.zoneTrans.array'
       ByteSize: 2048
       Element: 83 StructureType time.zoneTrans
     - __kind: PointerType
-      ID: 191
+      ID: 185
       Name: '*[]time.zoneTrans.array'
       ByteSize: 8
-      Pointee: 190 GoSliceDataType []time.zoneTrans.array
+      Pointee: 184 GoSliceDataType []time.zoneTrans.array
     - __kind: GoSliceDataType
-      ID: 192
+      ID: 186
       Name: '[]crypto/x509/pkix.Extension.array'
       ByteSize: 2048
       Element: 87 StructureType crypto/x509/pkix.Extension
     - __kind: PointerType
-      ID: 193
+      ID: 187
       Name: '*[]crypto/x509/pkix.Extension.array'
       ByteSize: 8
-      Pointee: 192 GoSliceDataType []crypto/x509/pkix.Extension.array
+      Pointee: 186 GoSliceDataType []crypto/x509/pkix.Extension.array
     - __kind: GoSliceDataType
-      ID: 194
+      ID: 188
       Name: '[]encoding/asn1.ObjectIdentifier.array'
       ByteSize: 2048
       Element: 73 GoSliceHeaderType encoding/asn1.ObjectIdentifier
     - __kind: PointerType
-      ID: 195
+      ID: 189
       Name: '*[]encoding/asn1.ObjectIdentifier.array'
       ByteSize: 8
-      Pointee: 194 GoSliceDataType []encoding/asn1.ObjectIdentifier.array
+      Pointee: 188 GoSliceDataType []encoding/asn1.ObjectIdentifier.array
     - __kind: GoSliceDataType
-      ID: 196
+      ID: 190
       Name: '[]crypto/x509.ExtKeyUsage.array'
       ByteSize: 2048
       Element: 92 BaseType crypto/x509.ExtKeyUsage
     - __kind: PointerType
-      ID: 197
+      ID: 191
       Name: '*[]crypto/x509.ExtKeyUsage.array'
       ByteSize: 8
-      Pointee: 196 GoSliceDataType []crypto/x509.ExtKeyUsage.array
+      Pointee: 190 GoSliceDataType []crypto/x509.ExtKeyUsage.array
     - __kind: GoSliceDataType
-      ID: 198
+      ID: 192
       Name: '[]net.IP.array'
       ByteSize: 2048
       Element: 95 GoSliceHeaderType net.IP
     - __kind: PointerType
-      ID: 199
+      ID: 193
       Name: '*[]net.IP.array'
       ByteSize: 8
-      Pointee: 198 GoSliceDataType []net.IP.array
+      Pointee: 192 GoSliceDataType []net.IP.array
     - __kind: GoSliceDataType
-      ID: 200
+      ID: 194
       Name: net.IP.array
       ByteSize: 2048
       Element: 7 BaseType uint8
     - __kind: PointerType
-      ID: 201
+      ID: 195
       Name: '*net.IP.array'
       ByteSize: 8
-      Pointee: 200 GoSliceDataType net.IP.array
+      Pointee: 194 GoSliceDataType net.IP.array
     - __kind: GoSliceDataType
-      ID: 202
+      ID: 196
       Name: '[]*net/url.URL.array'
       ByteSize: 2048
       Element: 9 PointerType *net/url.URL
     - __kind: PointerType
-      ID: 203
+      ID: 197
       Name: '*[]*net/url.URL.array'
       ByteSize: 8
-      Pointee: 202 GoSliceDataType []*net/url.URL.array
+      Pointee: 196 GoSliceDataType []*net/url.URL.array
     - __kind: GoSliceDataType
-      ID: 204
+      ID: 198
       Name: '[]*net.IPNet.array'
       ByteSize: 2048
       Element: 100 PointerType *net.IPNet
     - __kind: PointerType
-      ID: 205
+      ID: 199
       Name: '*[]*net.IPNet.array'
       ByteSize: 8
-      Pointee: 204 GoSliceDataType []*net.IPNet.array
+      Pointee: 198 GoSliceDataType []*net.IPNet.array
     - __kind: GoSliceDataType
-      ID: 206
+      ID: 200
       Name: net.IPMask.array
       ByteSize: 2048
       Element: 7 BaseType uint8
     - __kind: PointerType
-      ID: 207
+      ID: 201
       Name: '*net.IPMask.array'
       ByteSize: 8
-      Pointee: 206 GoSliceDataType net.IPMask.array
+      Pointee: 200 GoSliceDataType net.IPMask.array
     - __kind: GoSliceDataType
-      ID: 208
+      ID: 202
       Name: '[]crypto/x509.OID.array'
       ByteSize: 2048
       Element: 105 StructureType crypto/x509.OID
     - __kind: PointerType
-      ID: 209
+      ID: 203
       Name: '*[]crypto/x509.OID.array'
       ByteSize: 8
-      Pointee: 208 GoSliceDataType []crypto/x509.OID.array
+      Pointee: 202 GoSliceDataType []crypto/x509.OID.array
     - __kind: GoSliceDataType
-      ID: 210
+      ID: 204
       Name: '[]crypto/x509.PolicyMapping.array'
       ByteSize: 2048
       Element: 108 StructureType crypto/x509.PolicyMapping
     - __kind: PointerType
-      ID: 211
+      ID: 205
       Name: '*[]crypto/x509.PolicyMapping.array'
       ByteSize: 8
-      Pointee: 210 GoSliceDataType []crypto/x509.PolicyMapping.array
+      Pointee: 204 GoSliceDataType []crypto/x509.PolicyMapping.array
     - __kind: GoSliceDataType
-      ID: 212
+      ID: 206
       Name: '[][]*crypto/x509.Certificate.array'
       ByteSize: 2048
       Element: 57 GoSliceHeaderType []*crypto/x509.Certificate
     - __kind: PointerType
-      ID: 213
+      ID: 207
       Name: '*[][]*crypto/x509.Certificate.array'
       ByteSize: 8
-      Pointee: 212 GoSliceDataType [][]*crypto/x509.Certificate.array
+      Pointee: 206 GoSliceDataType [][]*crypto/x509.Certificate.array
     - __kind: GoSliceDataType
-      ID: 214
+      ID: 208
       Name: '[][]uint8.array'
       ByteSize: 2048
       Element: 53 GoSliceHeaderType []uint8
     - __kind: PointerType
-      ID: 215
+      ID: 209
       Name: '*[][]uint8.array'
       ByteSize: 8
-      Pointee: 214 GoSliceDataType [][]uint8.array
+      Pointee: 208 GoSliceDataType [][]uint8.array
     - __kind: GoSliceDataType
-      ID: 216
+      ID: 210
       Name: '[]net/http.segment.array'
       ByteSize: 2048
       Element: 123 StructureType net/http.segment
     - __kind: PointerType
-      ID: 217
+      ID: 211
       Name: '*[]net/http.segment.array'
       ByteSize: 8
-      Pointee: 216 GoSliceDataType []net/http.segment.array
+      Pointee: 210 GoSliceDataType []net/http.segment.array
     - __kind: GoSliceDataType
-      ID: 218
+      ID: 212
       Name: '[]*table<string,string>.array'
       ByteSize: 8192
       Element: 128 PointerType *table<string,string>
     - __kind: GoSliceDataType
-      ID: 219
+      ID: 213
       Name: '[]noalg.map.group[string]string.array'
       ByteSize: 2048
       Element: 132 StructureType noalg.map.group[string]string
     - __kind: EventRootType
-      ID: 220
+      ID: 214
       Name: Probe[main.HandleHTTP]
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -2499,7 +2469,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 221
+      ID: 215
       Name: Probe[main.LookAtTheRequest]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -2513,6 +2483,6 @@ Types:
                   Variable: {subprogram: 2, index: 0, name: path}
                   Offset: 0
                   ByteSize: 16
-MaxTypeID: 221
+MaxTypeID: 215
 Issues: []
 GoModuledataInfo: {FirstModuledataAddr: "0x130d980", TypesOffset: 296}

--- a/pkg/dyninst/irgen/testdata/snapshot/rc_tester_v1.arch=arm64,toolchain=go1.25.0.yaml
+++ b/pkg/dyninst/irgen/testdata/snapshot/rc_tester_v1.arch=arm64,toolchain=go1.25.0.yaml
@@ -10,7 +10,7 @@ Probes:
       subprogram: {subprogram: 1}
       events:
         - ID: 1
-          Type: 214 EventRootType Probe[main.HandleHTTP]
+          Type: 213 EventRootType Probe[main.HandleHTTP]
           InjectionPoints: [{PC: "0x82b100", Frameless: true}]
           Condition: null
     - id: look_at_the_request
@@ -23,7 +23,7 @@ Probes:
       subprogram: {subprogram: 2}
       events:
         - ID: 2
-          Type: 215 EventRootType Probe[main.LookAtTheRequest]
+          Type: 214 EventRootType Probe[main.LookAtTheRequest]
           InjectionPoints: [{PC: "0x82b3fc", Frameless: true}]
           Condition: null
 Subprograms:
@@ -108,146 +108,146 @@ Subprograms:
           IsReturn: false
 Types:
     - __kind: PointerType
-      ID: 83
+      ID: 108
       Name: '**crypto/x509.Certificate'
       ByteSize: 8
       GoKind: 22
-      Pointee: 84 PointerType *crypto/x509.Certificate
+      Pointee: 109 PointerType *crypto/x509.Certificate
     - __kind: PointerType
-      ID: 121
+      ID: 95
       Name: '**mime/multipart.FileHeader'
       ByteSize: 8
       GoKind: 22
-      Pointee: 122 PointerType *mime/multipart.FileHeader
+      Pointee: 96 PointerType *mime/multipart.FileHeader
     - __kind: PointerType
-      ID: 161
+      ID: 151
       Name: '**net.IPNet'
       ByteSize: 8
       GoKind: 22
-      Pointee: 162 PointerType *net.IPNet
+      Pointee: 152 PointerType *net.IPNet
     - __kind: PointerType
-      ID: 159
+      ID: 149
       Name: '**net/url.URL'
       ByteSize: 8
-      Pointee: 42 PointerType *net/url.URL
-    - __kind: PointerType
-      ID: 79
-      Name: '**table<string,[]*mime/multipart.FileHeader>'
-      ByteSize: 8
-      Pointee: 80 PointerType *table<string,[]*mime/multipart.FileHeader>
-    - __kind: PointerType
-      ID: 47
-      Name: '**table<string,[]string>'
-      ByteSize: 8
-      Pointee: 48 PointerType *table<string,[]string>
-    - __kind: PointerType
-      ID: 66
-      Name: '**table<string,string>'
-      ByteSize: 8
-      Pointee: 67 PointerType *table<string,string>
+      Pointee: 44 PointerType *net/url.URL
     - __kind: PointerType
       ID: 86
+      Name: '**table<string,[]*mime/multipart.FileHeader>'
+      ByteSize: 8
+      Pointee: 87 PointerType *table<string,[]*mime/multipart.FileHeader>
+    - __kind: PointerType
+      ID: 49
+      Name: '**table<string,[]string>'
+      ByteSize: 8
+      Pointee: 50 PointerType *table<string,[]string>
+    - __kind: PointerType
+      ID: 68
+      Name: '**table<string,string>'
+      ByteSize: 8
+      Pointee: 69 PointerType *table<string,string>
+    - __kind: PointerType
+      ID: 111
       Name: '*[]*crypto/x509.Certificate'
       ByteSize: 8
       GoKind: 22
-      Pointee: 82 GoSliceHeaderType []*crypto/x509.Certificate
+      Pointee: 107 GoSliceHeaderType []*crypto/x509.Certificate
     - __kind: PointerType
-      ID: 126
+      ID: 118
       Name: '*[]*crypto/x509.Certificate.array'
       ByteSize: 8
-      Pointee: 125 GoSliceDataType []*crypto/x509.Certificate.array
+      Pointee: 117 GoSliceDataType []*crypto/x509.Certificate.array
     - __kind: PointerType
-      ID: 171
+      ID: 101
       Name: '*[]*mime/multipart.FileHeader.array'
       ByteSize: 8
-      Pointee: 170 GoSliceDataType []*mime/multipart.FileHeader.array
-    - __kind: PointerType
-      ID: 200
-      Name: '*[]*net.IPNet.array'
-      ByteSize: 8
-      Pointee: 199 GoSliceDataType []*net.IPNet.array
-    - __kind: PointerType
-      ID: 198
-      Name: '*[]*net/url.URL.array'
-      ByteSize: 8
-      Pointee: 197 GoSliceDataType []*net/url.URL.array
-    - __kind: PointerType
-      ID: 128
-      Name: '*[][]*crypto/x509.Certificate.array'
-      ByteSize: 8
-      Pointee: 127 GoSliceDataType [][]*crypto/x509.Certificate.array
-    - __kind: PointerType
-      ID: 130
-      Name: '*[][]uint8.array'
-      ByteSize: 8
-      Pointee: 129 GoSliceDataType [][]uint8.array
-    - __kind: PointerType
-      ID: 192
-      Name: '*[]crypto/x509.ExtKeyUsage.array'
-      ByteSize: 8
-      Pointee: 191 GoSliceDataType []crypto/x509.ExtKeyUsage.array
-    - __kind: PointerType
-      ID: 202
-      Name: '*[]crypto/x509.OID.array'
-      ByteSize: 8
-      Pointee: 201 GoSliceDataType []crypto/x509.OID.array
-    - __kind: PointerType
-      ID: 204
-      Name: '*[]crypto/x509.PolicyMapping.array'
-      ByteSize: 8
-      Pointee: 203 GoSliceDataType []crypto/x509.PolicyMapping.array
-    - __kind: PointerType
-      ID: 184
-      Name: '*[]crypto/x509/pkix.AttributeTypeAndValue.array'
-      ByteSize: 8
-      Pointee: 183 GoSliceDataType []crypto/x509/pkix.AttributeTypeAndValue.array
-    - __kind: PointerType
-      ID: 186
-      Name: '*[]crypto/x509/pkix.Extension.array'
-      ByteSize: 8
-      Pointee: 185 GoSliceDataType []crypto/x509/pkix.Extension.array
+      Pointee: 100 GoSliceDataType []*mime/multipart.FileHeader.array
     - __kind: PointerType
       ID: 188
+      Name: '*[]*net.IPNet.array'
+      ByteSize: 8
+      Pointee: 187 GoSliceDataType []*net.IPNet.array
+    - __kind: PointerType
+      ID: 185
+      Name: '*[]*net/url.URL.array'
+      ByteSize: 8
+      Pointee: 184 GoSliceDataType []*net/url.URL.array
+    - __kind: PointerType
+      ID: 120
+      Name: '*[][]*crypto/x509.Certificate.array'
+      ByteSize: 8
+      Pointee: 119 GoSliceDataType [][]*crypto/x509.Certificate.array
+    - __kind: PointerType
+      ID: 122
+      Name: '*[][]uint8.array'
+      ByteSize: 8
+      Pointee: 121 GoSliceDataType [][]uint8.array
+    - __kind: PointerType
+      ID: 181
+      Name: '*[]crypto/x509.ExtKeyUsage.array'
+      ByteSize: 8
+      Pointee: 180 GoSliceDataType []crypto/x509.ExtKeyUsage.array
+    - __kind: PointerType
+      ID: 190
+      Name: '*[]crypto/x509.OID.array'
+      ByteSize: 8
+      Pointee: 189 GoSliceDataType []crypto/x509.OID.array
+    - __kind: PointerType
+      ID: 192
+      Name: '*[]crypto/x509.PolicyMapping.array'
+      ByteSize: 8
+      Pointee: 191 GoSliceDataType []crypto/x509.PolicyMapping.array
+    - __kind: PointerType
+      ID: 165
+      Name: '*[]crypto/x509/pkix.AttributeTypeAndValue.array'
+      ByteSize: 8
+      Pointee: 164 GoSliceDataType []crypto/x509/pkix.AttributeTypeAndValue.array
+    - __kind: PointerType
+      ID: 177
+      Name: '*[]crypto/x509/pkix.Extension.array'
+      ByteSize: 8
+      Pointee: 176 GoSliceDataType []crypto/x509/pkix.Extension.array
+    - __kind: PointerType
+      ID: 179
       Name: '*[]encoding/asn1.ObjectIdentifier.array'
       ByteSize: 8
-      Pointee: 187 GoSliceDataType []encoding/asn1.ObjectIdentifier.array
+      Pointee: 178 GoSliceDataType []encoding/asn1.ObjectIdentifier.array
     - __kind: PointerType
-      ID: 194
+      ID: 183
       Name: '*[]net.IP.array'
       ByteSize: 8
-      Pointee: 193 GoSliceDataType []net.IP.array
+      Pointee: 182 GoSliceDataType []net.IP.array
     - __kind: PointerType
-      ID: 132
+      ID: 204
       Name: '*[]net/http.segment.array'
       ByteSize: 8
-      Pointee: 131 GoSliceDataType []net/http.segment.array
+      Pointee: 203 GoSliceDataType []net/http.segment.array
     - __kind: PointerType
-      ID: 103
+      ID: 81
       Name: '*[]string.array'
       ByteSize: 8
-      Pointee: 102 GoSliceDataType []string.array
+      Pointee: 80 GoSliceDataType []string.array
     - __kind: PointerType
-      ID: 209
+      ID: 173
       Name: '*[]time.zone.array'
       ByteSize: 8
-      Pointee: 208 GoSliceDataType []time.zone.array
+      Pointee: 172 GoSliceDataType []time.zone.array
     - __kind: PointerType
-      ID: 211
+      ID: 175
       Name: '*[]time.zoneTrans.array'
       ByteSize: 8
-      Pointee: 210 GoSliceDataType []time.zoneTrans.array
+      Pointee: 174 GoSliceDataType []time.zoneTrans.array
     - __kind: PointerType
-      ID: 88
+      ID: 113
       Name: '*[]uint8'
       ByteSize: 8
       GoRuntimeType: 481440
       GoKind: 22
-      Pointee: 68 GoSliceHeaderType []uint8
+      Pointee: 103 GoSliceHeaderType []uint8
     - __kind: PointerType
-      ID: 112
+      ID: 105
       Name: '*[]uint8.array'
       ByteSize: 8
-      Pointee: 111 GoSliceDataType []uint8.array
+      Pointee: 104 GoSliceDataType []uint8.array
     - __kind: PointerType
       ID: 11
       Name: '*bool'
@@ -261,68 +261,68 @@ Types:
       ByteSize: 8
       GoRuntimeType: 2.259936e+06
       GoKind: 22
-      Pointee: 40 StructureType bytes.Buffer
+      Pointee: 40 UnresolvedPointeeType bytes.Buffer
     - __kind: PointerType
-      ID: 55
+      ID: 57
       Name: '*crypto/tls.ConnectionState'
       ByteSize: 8
       GoRuntimeType: 907744
       GoKind: 22
-      Pointee: 56 StructureType crypto/tls.ConnectionState
+      Pointee: 58 StructureType crypto/tls.ConnectionState
     - __kind: PointerType
-      ID: 84
+      ID: 109
       Name: '*crypto/x509.Certificate'
       ByteSize: 8
       GoRuntimeType: 2.0432e+06
       GoKind: 22
-      Pointee: 114 StructureType crypto/x509.Certificate
+      Pointee: 116 StructureType crypto/x509.Certificate
     - __kind: PointerType
-      ID: 153
+      ID: 143
       Name: '*crypto/x509.ExtKeyUsage'
       ByteSize: 8
       GoRuntimeType: 423456
       GoKind: 22
-      Pointee: 154 BaseType crypto/x509.ExtKeyUsage
+      Pointee: 144 BaseType crypto/x509.ExtKeyUsage
     - __kind: PointerType
-      ID: 164
+      ID: 154
       Name: '*crypto/x509.OID'
       ByteSize: 8
       GoRuntimeType: 1.953568e+06
       GoKind: 22
-      Pointee: 165 StructureType crypto/x509.OID
+      Pointee: 155 StructureType crypto/x509.OID
     - __kind: PointerType
-      ID: 167
+      ID: 157
       Name: '*crypto/x509.PolicyMapping'
       ByteSize: 8
       GoRuntimeType: 423520
       GoKind: 22
-      Pointee: 168 StructureType crypto/x509.PolicyMapping
+      Pointee: 158 StructureType crypto/x509.PolicyMapping
     - __kind: PointerType
-      ID: 140
+      ID: 130
       Name: '*crypto/x509/pkix.AttributeTypeAndValue'
       ByteSize: 8
       GoRuntimeType: 437216
       GoKind: 22
-      Pointee: 141 StructureType crypto/x509/pkix.AttributeTypeAndValue
+      Pointee: 131 StructureType crypto/x509/pkix.AttributeTypeAndValue
     - __kind: PointerType
-      ID: 147
+      ID: 137
       Name: '*crypto/x509/pkix.Extension'
       ByteSize: 8
       GoRuntimeType: 437408
       GoKind: 22
-      Pointee: 148 StructureType crypto/x509/pkix.Extension
+      Pointee: 138 StructureType crypto/x509/pkix.Extension
     - __kind: PointerType
-      ID: 150
+      ID: 140
       Name: '*encoding/asn1.ObjectIdentifier'
       ByteSize: 8
       GoRuntimeType: 1.052704e+06
       GoKind: 22
-      Pointee: 151 GoSliceHeaderType encoding/asn1.ObjectIdentifier
+      Pointee: 141 GoSliceHeaderType encoding/asn1.ObjectIdentifier
     - __kind: PointerType
-      ID: 190
+      ID: 194
       Name: '*encoding/asn1.ObjectIdentifier.array'
       ByteSize: 8
-      Pointee: 189 GoSliceDataType encoding/asn1.ObjectIdentifier.array
+      Pointee: 193 GoSliceDataType encoding/asn1.ObjectIdentifier.array
     - __kind: PointerType
       ID: 33
       Name: '*error'
@@ -380,77 +380,77 @@ Types:
       GoKind: 22
       Pointee: 17 BaseType int8
     - __kind: PointerType
-      ID: 77
+      ID: 84
       Name: '*map<string,[]*mime/multipart.FileHeader>'
       ByteSize: 8
-      Pointee: 78 GoSwissMapHeaderType map<string,[]*mime/multipart.FileHeader>
+      Pointee: 85 GoSwissMapHeaderType map<string,[]*mime/multipart.FileHeader>
     - __kind: PointerType
-      ID: 45
+      ID: 47
       Name: '*map<string,[]string>'
       ByteSize: 8
-      Pointee: 46 GoSwissMapHeaderType map<string,[]string>
+      Pointee: 48 GoSwissMapHeaderType map<string,[]string>
     - __kind: PointerType
-      ID: 64
+      ID: 66
       Name: '*map<string,string>'
       ByteSize: 8
-      Pointee: 65 GoSwissMapHeaderType map<string,string>
+      Pointee: 67 GoSwissMapHeaderType map<string,string>
     - __kind: PointerType
-      ID: 136
+      ID: 126
       Name: '*math/big.Int'
       ByteSize: 8
       GoRuntimeType: 2.381568e+06
       GoKind: 22
-      Pointee: 137 StructureType math/big.Int
+      Pointee: 127 StructureType math/big.Int
     - __kind: PointerType
-      ID: 173
+      ID: 160
       Name: '*math/big.Word'
       ByteSize: 8
       GoRuntimeType: 426272
       GoKind: 22
-      Pointee: 174 BaseType math/big.Word
+      Pointee: 161 BaseType math/big.Word
     - __kind: PointerType
-      ID: 207
+      ID: 163
       Name: '*math/big.nat.array'
       ByteSize: 8
-      Pointee: 206 GoSliceDataType math/big.nat.array
+      Pointee: 162 GoSliceDataType math/big.nat.array
     - __kind: PointerType
-      ID: 122
+      ID: 96
       Name: '*mime/multipart.FileHeader'
       ByteSize: 8
       GoRuntimeType: 909280
       GoKind: 22
-      Pointee: 169 StructureType mime/multipart.FileHeader
+      Pointee: 99 StructureType mime/multipart.FileHeader
     - __kind: PointerType
-      ID: 53
+      ID: 55
       Name: '*mime/multipart.Form'
       ByteSize: 8
       GoRuntimeType: 909376
       GoKind: 22
-      Pointee: 54 StructureType mime/multipart.Form
+      Pointee: 56 StructureType mime/multipart.Form
     - __kind: PointerType
-      ID: 156
+      ID: 146
       Name: '*net.IP'
       ByteSize: 8
       GoRuntimeType: 2.149408e+06
       GoKind: 22
-      Pointee: 157 GoSliceHeaderType net.IP
+      Pointee: 147 GoSliceHeaderType net.IP
     - __kind: PointerType
       ID: 196
       Name: '*net.IP.array'
       ByteSize: 8
       Pointee: 195 GoSliceDataType net.IP.array
     - __kind: PointerType
-      ID: 213
+      ID: 199
       Name: '*net.IPMask.array'
       ByteSize: 8
-      Pointee: 212 GoSliceDataType net.IPMask.array
+      Pointee: 198 GoSliceDataType net.IPMask.array
     - __kind: PointerType
-      ID: 162
+      ID: 152
       Name: '*net.IPNet'
       ByteSize: 8
       GoRuntimeType: 1.182656e+06
       GoKind: 22
-      Pointee: 181 StructureType net.IPNet
+      Pointee: 186 StructureType net.IPNet
     - __kind: PointerType
       ID: 37
       Name: '*net/http.Request'
@@ -459,55 +459,55 @@ Types:
       GoKind: 22
       Pointee: 38 StructureType net/http.Request
     - __kind: PointerType
-      ID: 58
+      ID: 60
       Name: '*net/http.Response'
       ByteSize: 8
       GoRuntimeType: 1.718272e+06
       GoKind: 22
-      Pointee: 59 StructureType net/http.Response
+      Pointee: 61 StructureType net/http.Response
     - __kind: PointerType
-      ID: 61
+      ID: 63
       Name: '*net/http.pattern'
       ByteSize: 8
       GoRuntimeType: 1.608064e+06
       GoKind: 22
-      Pointee: 62 StructureType net/http.pattern
+      Pointee: 64 StructureType net/http.pattern
     - __kind: PointerType
-      ID: 92
+      ID: 201
       Name: '*net/http.segment'
       ByteSize: 8
       GoRuntimeType: 391712
       GoKind: 22
-      Pointee: 93 StructureType net/http.segment
+      Pointee: 202 StructureType net/http.segment
     - __kind: PointerType
-      ID: 42
+      ID: 44
       Name: '*net/url.URL'
       ByteSize: 8
       GoRuntimeType: 2.112832e+06
       GoKind: 22
-      Pointee: 43 StructureType net/url.URL
+      Pointee: 45 StructureType net/url.URL
     - __kind: PointerType
-      ID: 72
+      ID: 70
       Name: '*net/url.Userinfo'
       ByteSize: 8
       GoRuntimeType: 1.200064e+06
       GoKind: 22
-      Pointee: 73 StructureType net/url.Userinfo
+      Pointee: 71 StructureType net/url.Userinfo
     - __kind: PointerType
-      ID: 116
+      ID: 90
       Name: '*noalg.map.group[string][]*mime/multipart.FileHeader'
       ByteSize: 8
-      Pointee: 117 StructureType noalg.map.group[string][]*mime/multipart.FileHeader
+      Pointee: 91 StructureType noalg.map.group[string][]*mime/multipart.FileHeader
     - __kind: PointerType
-      ID: 96
+      ID: 74
       Name: '*noalg.map.group[string][]string'
       ByteSize: 8
-      Pointee: 97 StructureType noalg.map.group[string][]string
+      Pointee: 75 StructureType noalg.map.group[string][]string
     - __kind: PointerType
-      ID: 105
+      ID: 207
       Name: '*noalg.map.group[string]string'
       ByteSize: 8
-      Pointee: 106 StructureType noalg.map.group[string]string
+      Pointee: 208 StructureType noalg.map.group[string]string
     - __kind: PointerType
       ID: 22
       Name: '*string'
@@ -516,46 +516,46 @@ Types:
       GoKind: 22
       Pointee: 9 GoStringHeaderType string
     - __kind: PointerType
-      ID: 71
+      ID: 43
       Name: '*string.str'
       ByteSize: 8
-      Pointee: 70 GoStringDataType string.str
+      Pointee: 42 GoStringDataType string.str
     - __kind: PointerType
-      ID: 80
+      ID: 87
       Name: '*table<string,[]*mime/multipart.FileHeader>'
       ByteSize: 8
-      Pointee: 113 StructureType table<string,[]*mime/multipart.FileHeader>
+      Pointee: 88 StructureType table<string,[]*mime/multipart.FileHeader>
     - __kind: PointerType
-      ID: 48
+      ID: 50
       Name: '*table<string,[]string>'
       ByteSize: 8
-      Pointee: 74 StructureType table<string,[]string>
+      Pointee: 72 StructureType table<string,[]string>
     - __kind: PointerType
-      ID: 67
+      ID: 69
       Name: '*table<string,string>'
       ByteSize: 8
-      Pointee: 94 StructureType table<string,string>
+      Pointee: 205 StructureType table<string,string>
     - __kind: PointerType
-      ID: 143
+      ID: 133
       Name: '*time.Location'
       ByteSize: 8
       GoRuntimeType: 1.613056e+06
       GoKind: 22
-      Pointee: 144 StructureType time.Location
+      Pointee: 134 StructureType time.Location
     - __kind: PointerType
-      ID: 176
+      ID: 167
       Name: '*time.zone'
       ByteSize: 8
       GoRuntimeType: 394784
       GoKind: 22
-      Pointee: 177 StructureType time.zone
+      Pointee: 168 StructureType time.zone
     - __kind: PointerType
-      ID: 179
+      ID: 170
       Name: '*time.zoneTrans'
       ByteSize: 8
       GoRuntimeType: 394848
       GoKind: 22
-      Pointee: 180 StructureType time.zoneTrans
+      Pointee: 171 StructureType time.zoneTrans
     - __kind: PointerType
       ID: 34
       Name: '*uint'
@@ -599,12 +599,12 @@ Types:
       GoKind: 22
       Pointee: 1 BaseType uintptr
     - __kind: GoChannelType
-      ID: 57
+      ID: 59
       Name: <-chan struct {}
       GoRuntimeType: 597472
       GoKind: 18
     - __kind: EventRootType
-      ID: 214
+      ID: 213
       Name: Probe[main.HandleHTTP]
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -628,7 +628,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 215
+      ID: 214
       Name: Probe[main.LookAtTheRequest]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -643,7 +643,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: GoSliceHeaderType
-      ID: 82
+      ID: 107
       Name: '[]*crypto/x509.Certificate'
       ByteSize: 24
       GoRuntimeType: 502272
@@ -651,21 +651,21 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 83 PointerType **crypto/x509.Certificate
+          Type: 108 PointerType **crypto/x509.Certificate
         - Name: len
           Offset: 8
           Type: 7 BaseType int
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 125 GoSliceDataType []*crypto/x509.Certificate.array
+      Data: 117 GoSliceDataType []*crypto/x509.Certificate.array
     - __kind: GoSliceDataType
-      ID: 125
+      ID: 117
       Name: '[]*crypto/x509.Certificate.array'
       ByteSize: 2048
-      Element: 84 PointerType *crypto/x509.Certificate
+      Element: 109 PointerType *crypto/x509.Certificate
     - __kind: GoSliceHeaderType
-      ID: 120
+      ID: 94
       Name: '[]*mime/multipart.FileHeader'
       ByteSize: 24
       GoRuntimeType: 487168
@@ -673,21 +673,21 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 121 PointerType **mime/multipart.FileHeader
+          Type: 95 PointerType **mime/multipart.FileHeader
         - Name: len
           Offset: 8
           Type: 7 BaseType int
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 170 GoSliceDataType []*mime/multipart.FileHeader.array
+      Data: 100 GoSliceDataType []*mime/multipart.FileHeader.array
     - __kind: GoSliceDataType
-      ID: 170
+      ID: 100
       Name: '[]*mime/multipart.FileHeader.array'
       ByteSize: 2048
-      Element: 122 PointerType *mime/multipart.FileHeader
+      Element: 96 PointerType *mime/multipart.FileHeader
     - __kind: GoSliceHeaderType
-      ID: 160
+      ID: 150
       Name: '[]*net.IPNet'
       ByteSize: 24
       GoRuntimeType: 503872
@@ -695,21 +695,21 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 161 PointerType **net.IPNet
+          Type: 151 PointerType **net.IPNet
         - Name: len
           Offset: 8
           Type: 7 BaseType int
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 199 GoSliceDataType []*net.IPNet.array
+      Data: 187 GoSliceDataType []*net.IPNet.array
     - __kind: GoSliceDataType
-      ID: 199
+      ID: 187
       Name: '[]*net.IPNet.array'
       ByteSize: 2048
-      Element: 162 PointerType *net.IPNet
+      Element: 152 PointerType *net.IPNet
     - __kind: GoSliceHeaderType
-      ID: 158
+      ID: 148
       Name: '[]*net/url.URL'
       ByteSize: 24
       GoRuntimeType: 503808
@@ -717,36 +717,36 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 159 PointerType **net/url.URL
+          Type: 149 PointerType **net/url.URL
         - Name: len
           Offset: 8
           Type: 7 BaseType int
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 197 GoSliceDataType []*net/url.URL.array
+      Data: 184 GoSliceDataType []*net/url.URL.array
     - __kind: GoSliceDataType
-      ID: 197
+      ID: 184
       Name: '[]*net/url.URL.array'
       ByteSize: 2048
-      Element: 42 PointerType *net/url.URL
+      Element: 44 PointerType *net/url.URL
     - __kind: GoSliceDataType
-      ID: 123
+      ID: 97
       Name: '[]*table<string,[]*mime/multipart.FileHeader>.array'
       ByteSize: 8192
-      Element: 80 PointerType *table<string,[]*mime/multipart.FileHeader>
+      Element: 87 PointerType *table<string,[]*mime/multipart.FileHeader>
     - __kind: GoSliceDataType
-      ID: 100
+      ID: 78
       Name: '[]*table<string,[]string>.array'
       ByteSize: 8192
-      Element: 48 PointerType *table<string,[]string>
+      Element: 50 PointerType *table<string,[]string>
     - __kind: GoSliceDataType
-      ID: 109
+      ID: 211
       Name: '[]*table<string,string>.array'
       ByteSize: 8192
-      Element: 67 PointerType *table<string,string>
+      Element: 69 PointerType *table<string,string>
     - __kind: GoSliceHeaderType
-      ID: 85
+      ID: 110
       Name: '[][]*crypto/x509.Certificate'
       ByteSize: 24
       GoRuntimeType: 502336
@@ -754,21 +754,21 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 86 PointerType *[]*crypto/x509.Certificate
+          Type: 111 PointerType *[]*crypto/x509.Certificate
         - Name: len
           Offset: 8
           Type: 7 BaseType int
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 127 GoSliceDataType [][]*crypto/x509.Certificate.array
+      Data: 119 GoSliceDataType [][]*crypto/x509.Certificate.array
     - __kind: GoSliceDataType
-      ID: 127
+      ID: 119
       Name: '[][]*crypto/x509.Certificate.array'
       ByteSize: 2048
-      Element: 82 GoSliceHeaderType []*crypto/x509.Certificate
+      Element: 107 GoSliceHeaderType []*crypto/x509.Certificate
     - __kind: GoSliceHeaderType
-      ID: 87
+      ID: 112
       Name: '[][]uint8'
       ByteSize: 24
       GoRuntimeType: 481760
@@ -776,21 +776,21 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 88 PointerType *[]uint8
+          Type: 113 PointerType *[]uint8
         - Name: len
           Offset: 8
           Type: 7 BaseType int
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 129 GoSliceDataType [][]uint8.array
+      Data: 121 GoSliceDataType [][]uint8.array
     - __kind: GoSliceDataType
-      ID: 129
+      ID: 121
       Name: '[][]uint8.array'
       ByteSize: 2048
-      Element: 68 GoSliceHeaderType []uint8
+      Element: 103 GoSliceHeaderType []uint8
     - __kind: GoSliceHeaderType
-      ID: 152
+      ID: 142
       Name: '[]crypto/x509.ExtKeyUsage'
       ByteSize: 24
       GoRuntimeType: 503744
@@ -798,21 +798,21 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 153 PointerType *crypto/x509.ExtKeyUsage
+          Type: 143 PointerType *crypto/x509.ExtKeyUsage
         - Name: len
           Offset: 8
           Type: 7 BaseType int
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 191 GoSliceDataType []crypto/x509.ExtKeyUsage.array
+      Data: 180 GoSliceDataType []crypto/x509.ExtKeyUsage.array
     - __kind: GoSliceDataType
-      ID: 191
+      ID: 180
       Name: '[]crypto/x509.ExtKeyUsage.array'
       ByteSize: 2048
-      Element: 154 BaseType crypto/x509.ExtKeyUsage
+      Element: 144 BaseType crypto/x509.ExtKeyUsage
     - __kind: GoSliceHeaderType
-      ID: 163
+      ID: 153
       Name: '[]crypto/x509.OID'
       ByteSize: 24
       GoRuntimeType: 503936
@@ -820,21 +820,21 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 164 PointerType *crypto/x509.OID
+          Type: 154 PointerType *crypto/x509.OID
         - Name: len
           Offset: 8
           Type: 7 BaseType int
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 201 GoSliceDataType []crypto/x509.OID.array
+      Data: 189 GoSliceDataType []crypto/x509.OID.array
     - __kind: GoSliceDataType
-      ID: 201
+      ID: 189
       Name: '[]crypto/x509.OID.array'
       ByteSize: 2048
-      Element: 165 StructureType crypto/x509.OID
+      Element: 155 StructureType crypto/x509.OID
     - __kind: GoSliceHeaderType
-      ID: 166
+      ID: 156
       Name: '[]crypto/x509.PolicyMapping'
       ByteSize: 24
       GoRuntimeType: 504000
@@ -842,21 +842,21 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 167 PointerType *crypto/x509.PolicyMapping
+          Type: 157 PointerType *crypto/x509.PolicyMapping
         - Name: len
           Offset: 8
           Type: 7 BaseType int
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 203 GoSliceDataType []crypto/x509.PolicyMapping.array
+      Data: 191 GoSliceDataType []crypto/x509.PolicyMapping.array
     - __kind: GoSliceDataType
-      ID: 203
+      ID: 191
       Name: '[]crypto/x509.PolicyMapping.array'
       ByteSize: 2048
-      Element: 168 StructureType crypto/x509.PolicyMapping
+      Element: 158 StructureType crypto/x509.PolicyMapping
     - __kind: GoSliceHeaderType
-      ID: 139
+      ID: 129
       Name: '[]crypto/x509/pkix.AttributeTypeAndValue'
       ByteSize: 24
       GoRuntimeType: 517280
@@ -864,21 +864,21 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 140 PointerType *crypto/x509/pkix.AttributeTypeAndValue
+          Type: 130 PointerType *crypto/x509/pkix.AttributeTypeAndValue
         - Name: len
           Offset: 8
           Type: 7 BaseType int
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 183 GoSliceDataType []crypto/x509/pkix.AttributeTypeAndValue.array
+      Data: 164 GoSliceDataType []crypto/x509/pkix.AttributeTypeAndValue.array
     - __kind: GoSliceDataType
-      ID: 183
+      ID: 164
       Name: '[]crypto/x509/pkix.AttributeTypeAndValue.array'
       ByteSize: 2048
-      Element: 141 StructureType crypto/x509/pkix.AttributeTypeAndValue
+      Element: 131 StructureType crypto/x509/pkix.AttributeTypeAndValue
     - __kind: GoSliceHeaderType
-      ID: 146
+      ID: 136
       Name: '[]crypto/x509/pkix.Extension'
       ByteSize: 24
       GoRuntimeType: 503616
@@ -886,21 +886,21 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 147 PointerType *crypto/x509/pkix.Extension
+          Type: 137 PointerType *crypto/x509/pkix.Extension
         - Name: len
           Offset: 8
           Type: 7 BaseType int
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 185 GoSliceDataType []crypto/x509/pkix.Extension.array
+      Data: 176 GoSliceDataType []crypto/x509/pkix.Extension.array
     - __kind: GoSliceDataType
-      ID: 185
+      ID: 176
       Name: '[]crypto/x509/pkix.Extension.array'
       ByteSize: 2048
-      Element: 148 StructureType crypto/x509/pkix.Extension
+      Element: 138 StructureType crypto/x509/pkix.Extension
     - __kind: GoSliceHeaderType
-      ID: 149
+      ID: 139
       Name: '[]encoding/asn1.ObjectIdentifier'
       ByteSize: 24
       GoRuntimeType: 503680
@@ -908,21 +908,21 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 150 PointerType *encoding/asn1.ObjectIdentifier
+          Type: 140 PointerType *encoding/asn1.ObjectIdentifier
         - Name: len
           Offset: 8
           Type: 7 BaseType int
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 187 GoSliceDataType []encoding/asn1.ObjectIdentifier.array
+      Data: 178 GoSliceDataType []encoding/asn1.ObjectIdentifier.array
     - __kind: GoSliceDataType
-      ID: 187
+      ID: 178
       Name: '[]encoding/asn1.ObjectIdentifier.array'
       ByteSize: 2048
-      Element: 151 GoSliceHeaderType encoding/asn1.ObjectIdentifier
+      Element: 141 GoSliceHeaderType encoding/asn1.ObjectIdentifier
     - __kind: GoSliceHeaderType
-      ID: 155
+      ID: 145
       Name: '[]net.IP'
       ByteSize: 24
       GoRuntimeType: 482784
@@ -930,21 +930,21 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 156 PointerType *net.IP
+          Type: 146 PointerType *net.IP
         - Name: len
           Offset: 8
           Type: 7 BaseType int
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 193 GoSliceDataType []net.IP.array
+      Data: 182 GoSliceDataType []net.IP.array
     - __kind: GoSliceDataType
-      ID: 193
+      ID: 182
       Name: '[]net.IP.array'
       ByteSize: 2048
-      Element: 157 GoSliceHeaderType net.IP
+      Element: 147 GoSliceHeaderType net.IP
     - __kind: GoSliceHeaderType
-      ID: 91
+      ID: 200
       Name: '[]net/http.segment'
       ByteSize: 24
       GoRuntimeType: 484480
@@ -952,36 +952,36 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 92 PointerType *net/http.segment
+          Type: 201 PointerType *net/http.segment
         - Name: len
           Offset: 8
           Type: 7 BaseType int
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 131 GoSliceDataType []net/http.segment.array
+      Data: 203 GoSliceDataType []net/http.segment.array
     - __kind: GoSliceDataType
-      ID: 131
+      ID: 203
       Name: '[]net/http.segment.array'
       ByteSize: 2048
-      Element: 93 StructureType net/http.segment
+      Element: 202 StructureType net/http.segment
     - __kind: GoSliceDataType
-      ID: 124
+      ID: 98
       Name: '[]noalg.map.group[string][]*mime/multipart.FileHeader.array'
       ByteSize: 2048
-      Element: 117 StructureType noalg.map.group[string][]*mime/multipart.FileHeader
+      Element: 91 StructureType noalg.map.group[string][]*mime/multipart.FileHeader
     - __kind: GoSliceDataType
-      ID: 101
+      ID: 79
       Name: '[]noalg.map.group[string][]string.array'
       ByteSize: 2048
-      Element: 97 StructureType noalg.map.group[string][]string
+      Element: 75 StructureType noalg.map.group[string][]string
     - __kind: GoSliceDataType
-      ID: 110
+      ID: 212
       Name: '[]noalg.map.group[string]string.array'
       ByteSize: 2048
-      Element: 106 StructureType noalg.map.group[string]string
+      Element: 208 StructureType noalg.map.group[string]string
     - __kind: GoSliceHeaderType
-      ID: 51
+      ID: 53
       Name: '[]string'
       ByteSize: 24
       GoRuntimeType: 496288
@@ -996,14 +996,14 @@ Types:
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 102 GoSliceDataType []string.array
+      Data: 80 GoSliceDataType []string.array
     - __kind: GoSliceDataType
-      ID: 102
+      ID: 80
       Name: '[]string.array'
       ByteSize: 2048
       Element: 9 GoStringHeaderType string
     - __kind: GoSliceHeaderType
-      ID: 175
+      ID: 166
       Name: '[]time.zone'
       ByteSize: 24
       GoRuntimeType: 489344
@@ -1011,21 +1011,21 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 176 PointerType *time.zone
+          Type: 167 PointerType *time.zone
         - Name: len
           Offset: 8
           Type: 7 BaseType int
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 208 GoSliceDataType []time.zone.array
+      Data: 172 GoSliceDataType []time.zone.array
     - __kind: GoSliceDataType
-      ID: 208
+      ID: 172
       Name: '[]time.zone.array'
       ByteSize: 2048
-      Element: 177 StructureType time.zone
+      Element: 168 StructureType time.zone
     - __kind: GoSliceHeaderType
-      ID: 178
+      ID: 169
       Name: '[]time.zoneTrans'
       ByteSize: 24
       GoRuntimeType: 489408
@@ -1033,21 +1033,21 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 179 PointerType *time.zoneTrans
+          Type: 170 PointerType *time.zoneTrans
         - Name: len
           Offset: 8
           Type: 7 BaseType int
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 210 GoSliceDataType []time.zoneTrans.array
+      Data: 174 GoSliceDataType []time.zoneTrans.array
     - __kind: GoSliceDataType
-      ID: 210
+      ID: 174
       Name: '[]time.zoneTrans.array'
       ByteSize: 2048
-      Element: 180 StructureType time.zoneTrans
+      Element: 171 StructureType time.zoneTrans
     - __kind: GoSliceHeaderType
-      ID: 68
+      ID: 103
       Name: '[]uint8'
       ByteSize: 24
       GoRuntimeType: 495136
@@ -1062,9 +1062,9 @@ Types:
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 111 GoSliceDataType []uint8.array
+      Data: 104 GoSliceDataType []uint8.array
     - __kind: GoSliceDataType
-      ID: 111
+      ID: 104
       Name: '[]uint8.array'
       ByteSize: 2048
       Element: 3 BaseType uint8
@@ -1074,28 +1074,10 @@ Types:
       ByteSize: 1
       GoRuntimeType: 585248
       GoKind: 1
-    - __kind: StructureType
+    - __kind: UnresolvedPointeeType
       ID: 40
       Name: bytes.Buffer
-      ByteSize: 40
-      GoRuntimeType: 1.60576e+06
-      GoKind: 25
-      RawFields:
-        - Name: buf
-          Offset: 0
-          Type: 68 GoSliceHeaderType []uint8
-        - Name: off
-          Offset: 24
-          Type: 7 BaseType int
-        - Name: lastRead
-          Offset: 32
-          Type: 69 BaseType bytes.readOp
-    - __kind: BaseType
-      ID: 69
-      Name: bytes.readOp
-      ByteSize: 1
-      GoRuntimeType: 583456
-      GoKind: 3
+      ByteSize: 8
     - __kind: BaseType
       ID: 25
       Name: complex128
@@ -1109,7 +1091,7 @@ Types:
       GoRuntimeType: 584992
       GoKind: 15
     - __kind: GoInterfaceType
-      ID: 60
+      ID: 62
       Name: context.Context
       ByteSize: 16
       GoRuntimeType: 1.276288e+06
@@ -1122,7 +1104,7 @@ Types:
           Offset: 8
           Type: 15 VoidPointerType unsafe.Pointer
     - __kind: StructureType
-      ID: 56
+      ID: 58
       Name: crypto/tls.ConnectionState
       ByteSize: 192
       GoRuntimeType: 2.261984e+06
@@ -1142,7 +1124,7 @@ Types:
           Type: 6 BaseType uint16
         - Name: CurveID
           Offset: 6
-          Type: 81 BaseType crypto/tls.CurveID
+          Type: 106 BaseType crypto/tls.CurveID
         - Name: NegotiatedProtocol
           Offset: 8
           Type: 9 GoStringHeaderType string
@@ -1154,45 +1136,45 @@ Types:
           Type: 9 GoStringHeaderType string
         - Name: PeerCertificates
           Offset: 48
-          Type: 82 GoSliceHeaderType []*crypto/x509.Certificate
+          Type: 107 GoSliceHeaderType []*crypto/x509.Certificate
         - Name: VerifiedChains
           Offset: 72
-          Type: 85 GoSliceHeaderType [][]*crypto/x509.Certificate
+          Type: 110 GoSliceHeaderType [][]*crypto/x509.Certificate
         - Name: SignedCertificateTimestamps
           Offset: 96
-          Type: 87 GoSliceHeaderType [][]uint8
+          Type: 112 GoSliceHeaderType [][]uint8
         - Name: OCSPResponse
           Offset: 120
-          Type: 68 GoSliceHeaderType []uint8
+          Type: 103 GoSliceHeaderType []uint8
         - Name: TLSUnique
           Offset: 144
-          Type: 68 GoSliceHeaderType []uint8
+          Type: 103 GoSliceHeaderType []uint8
         - Name: ECHAccepted
           Offset: 168
           Type: 4 BaseType bool
         - Name: ekm
           Offset: 176
-          Type: 89 GoSubroutineType func(string, []uint8, int) ([]uint8, error)
+          Type: 114 GoSubroutineType func(string, []uint8, int) ([]uint8, error)
         - Name: testingOnlyDidHRR
           Offset: 184
           Type: 4 BaseType bool
         - Name: testingOnlyPeerSignatureAlgorithm
           Offset: 186
-          Type: 90 BaseType crypto/tls.SignatureScheme
+          Type: 115 BaseType crypto/tls.SignatureScheme
     - __kind: BaseType
-      ID: 81
+      ID: 106
       Name: crypto/tls.CurveID
       ByteSize: 2
       GoRuntimeType: 834432
       GoKind: 9
     - __kind: BaseType
-      ID: 90
+      ID: 115
       Name: crypto/tls.SignatureScheme
       ByteSize: 2
       GoRuntimeType: 834528
       GoKind: 9
     - __kind: StructureType
-      ID: 114
+      ID: 116
       Name: crypto/x509.Certificate
       ByteSize: 1424
       GoRuntimeType: 2.392832e+06
@@ -1200,67 +1182,67 @@ Types:
       RawFields:
         - Name: Raw
           Offset: 0
-          Type: 68 GoSliceHeaderType []uint8
+          Type: 103 GoSliceHeaderType []uint8
         - Name: RawTBSCertificate
           Offset: 24
-          Type: 68 GoSliceHeaderType []uint8
+          Type: 103 GoSliceHeaderType []uint8
         - Name: RawSubjectPublicKeyInfo
           Offset: 48
-          Type: 68 GoSliceHeaderType []uint8
+          Type: 103 GoSliceHeaderType []uint8
         - Name: RawSubject
           Offset: 72
-          Type: 68 GoSliceHeaderType []uint8
+          Type: 103 GoSliceHeaderType []uint8
         - Name: RawIssuer
           Offset: 96
-          Type: 68 GoSliceHeaderType []uint8
+          Type: 103 GoSliceHeaderType []uint8
         - Name: Signature
           Offset: 120
-          Type: 68 GoSliceHeaderType []uint8
+          Type: 103 GoSliceHeaderType []uint8
         - Name: SignatureAlgorithm
           Offset: 144
-          Type: 133 BaseType crypto/x509.SignatureAlgorithm
+          Type: 123 BaseType crypto/x509.SignatureAlgorithm
         - Name: PublicKeyAlgorithm
           Offset: 152
-          Type: 134 BaseType crypto/x509.PublicKeyAlgorithm
+          Type: 124 BaseType crypto/x509.PublicKeyAlgorithm
         - Name: PublicKey
           Offset: 160
-          Type: 135 GoEmptyInterfaceType interface {}
+          Type: 125 GoEmptyInterfaceType interface {}
         - Name: Version
           Offset: 176
           Type: 7 BaseType int
         - Name: SerialNumber
           Offset: 184
-          Type: 136 PointerType *math/big.Int
+          Type: 126 PointerType *math/big.Int
         - Name: Issuer
           Offset: 192
-          Type: 138 StructureType crypto/x509/pkix.Name
+          Type: 128 StructureType crypto/x509/pkix.Name
         - Name: Subject
           Offset: 440
-          Type: 138 StructureType crypto/x509/pkix.Name
+          Type: 128 StructureType crypto/x509/pkix.Name
         - Name: NotBefore
           Offset: 688
-          Type: 142 StructureType time.Time
+          Type: 132 StructureType time.Time
         - Name: NotAfter
           Offset: 712
-          Type: 142 StructureType time.Time
+          Type: 132 StructureType time.Time
         - Name: KeyUsage
           Offset: 736
-          Type: 145 BaseType crypto/x509.KeyUsage
+          Type: 135 BaseType crypto/x509.KeyUsage
         - Name: Extensions
           Offset: 744
-          Type: 146 GoSliceHeaderType []crypto/x509/pkix.Extension
+          Type: 136 GoSliceHeaderType []crypto/x509/pkix.Extension
         - Name: ExtraExtensions
           Offset: 768
-          Type: 146 GoSliceHeaderType []crypto/x509/pkix.Extension
+          Type: 136 GoSliceHeaderType []crypto/x509/pkix.Extension
         - Name: UnhandledCriticalExtensions
           Offset: 792
-          Type: 149 GoSliceHeaderType []encoding/asn1.ObjectIdentifier
+          Type: 139 GoSliceHeaderType []encoding/asn1.ObjectIdentifier
         - Name: ExtKeyUsage
           Offset: 816
-          Type: 152 GoSliceHeaderType []crypto/x509.ExtKeyUsage
+          Type: 142 GoSliceHeaderType []crypto/x509.ExtKeyUsage
         - Name: UnknownExtKeyUsage
           Offset: 840
-          Type: 149 GoSliceHeaderType []encoding/asn1.ObjectIdentifier
+          Type: 139 GoSliceHeaderType []encoding/asn1.ObjectIdentifier
         - Name: BasicConstraintsValid
           Offset: 864
           Type: 4 BaseType bool
@@ -1275,64 +1257,64 @@ Types:
           Type: 4 BaseType bool
         - Name: SubjectKeyId
           Offset: 888
-          Type: 68 GoSliceHeaderType []uint8
+          Type: 103 GoSliceHeaderType []uint8
         - Name: AuthorityKeyId
           Offset: 912
-          Type: 68 GoSliceHeaderType []uint8
+          Type: 103 GoSliceHeaderType []uint8
         - Name: OCSPServer
           Offset: 936
-          Type: 51 GoSliceHeaderType []string
+          Type: 53 GoSliceHeaderType []string
         - Name: IssuingCertificateURL
           Offset: 960
-          Type: 51 GoSliceHeaderType []string
+          Type: 53 GoSliceHeaderType []string
         - Name: DNSNames
           Offset: 984
-          Type: 51 GoSliceHeaderType []string
+          Type: 53 GoSliceHeaderType []string
         - Name: EmailAddresses
           Offset: 1008
-          Type: 51 GoSliceHeaderType []string
+          Type: 53 GoSliceHeaderType []string
         - Name: IPAddresses
           Offset: 1032
-          Type: 155 GoSliceHeaderType []net.IP
+          Type: 145 GoSliceHeaderType []net.IP
         - Name: URIs
           Offset: 1056
-          Type: 158 GoSliceHeaderType []*net/url.URL
+          Type: 148 GoSliceHeaderType []*net/url.URL
         - Name: PermittedDNSDomainsCritical
           Offset: 1080
           Type: 4 BaseType bool
         - Name: PermittedDNSDomains
           Offset: 1088
-          Type: 51 GoSliceHeaderType []string
+          Type: 53 GoSliceHeaderType []string
         - Name: ExcludedDNSDomains
           Offset: 1112
-          Type: 51 GoSliceHeaderType []string
+          Type: 53 GoSliceHeaderType []string
         - Name: PermittedIPRanges
           Offset: 1136
-          Type: 160 GoSliceHeaderType []*net.IPNet
+          Type: 150 GoSliceHeaderType []*net.IPNet
         - Name: ExcludedIPRanges
           Offset: 1160
-          Type: 160 GoSliceHeaderType []*net.IPNet
+          Type: 150 GoSliceHeaderType []*net.IPNet
         - Name: PermittedEmailAddresses
           Offset: 1184
-          Type: 51 GoSliceHeaderType []string
+          Type: 53 GoSliceHeaderType []string
         - Name: ExcludedEmailAddresses
           Offset: 1208
-          Type: 51 GoSliceHeaderType []string
+          Type: 53 GoSliceHeaderType []string
         - Name: PermittedURIDomains
           Offset: 1232
-          Type: 51 GoSliceHeaderType []string
+          Type: 53 GoSliceHeaderType []string
         - Name: ExcludedURIDomains
           Offset: 1256
-          Type: 51 GoSliceHeaderType []string
+          Type: 53 GoSliceHeaderType []string
         - Name: CRLDistributionPoints
           Offset: 1280
-          Type: 51 GoSliceHeaderType []string
+          Type: 53 GoSliceHeaderType []string
         - Name: PolicyIdentifiers
           Offset: 1304
-          Type: 149 GoSliceHeaderType []encoding/asn1.ObjectIdentifier
+          Type: 139 GoSliceHeaderType []encoding/asn1.ObjectIdentifier
         - Name: Policies
           Offset: 1328
-          Type: 163 GoSliceHeaderType []crypto/x509.OID
+          Type: 153 GoSliceHeaderType []crypto/x509.OID
         - Name: InhibitAnyPolicy
           Offset: 1352
           Type: 7 BaseType int
@@ -1353,21 +1335,21 @@ Types:
           Type: 4 BaseType bool
         - Name: PolicyMappings
           Offset: 1400
-          Type: 166 GoSliceHeaderType []crypto/x509.PolicyMapping
+          Type: 156 GoSliceHeaderType []crypto/x509.PolicyMapping
     - __kind: BaseType
-      ID: 154
+      ID: 144
       Name: crypto/x509.ExtKeyUsage
       ByteSize: 8
       GoRuntimeType: 587936
       GoKind: 2
     - __kind: BaseType
-      ID: 145
+      ID: 135
       Name: crypto/x509.KeyUsage
       ByteSize: 8
       GoRuntimeType: 587872
       GoKind: 2
     - __kind: StructureType
-      ID: 165
+      ID: 155
       Name: crypto/x509.OID
       ByteSize: 24
       GoRuntimeType: 1.953824e+06
@@ -1375,9 +1357,9 @@ Types:
       RawFields:
         - Name: der
           Offset: 0
-          Type: 68 GoSliceHeaderType []uint8
+          Type: 103 GoSliceHeaderType []uint8
     - __kind: StructureType
-      ID: 168
+      ID: 158
       Name: crypto/x509.PolicyMapping
       ByteSize: 48
       GoRuntimeType: 1.490528e+06
@@ -1385,24 +1367,24 @@ Types:
       RawFields:
         - Name: IssuerDomainPolicy
           Offset: 0
-          Type: 165 StructureType crypto/x509.OID
+          Type: 155 StructureType crypto/x509.OID
         - Name: SubjectDomainPolicy
           Offset: 24
-          Type: 165 StructureType crypto/x509.OID
+          Type: 155 StructureType crypto/x509.OID
     - __kind: BaseType
-      ID: 134
+      ID: 124
       Name: crypto/x509.PublicKeyAlgorithm
       ByteSize: 8
       GoRuntimeType: 837024
       GoKind: 2
     - __kind: BaseType
-      ID: 133
+      ID: 123
       Name: crypto/x509.SignatureAlgorithm
       ByteSize: 8
       GoRuntimeType: 1.113728e+06
       GoKind: 2
     - __kind: StructureType
-      ID: 141
+      ID: 131
       Name: crypto/x509/pkix.AttributeTypeAndValue
       ByteSize: 40
       GoRuntimeType: 1.502368e+06
@@ -1410,12 +1392,12 @@ Types:
       RawFields:
         - Name: Type
           Offset: 0
-          Type: 151 GoSliceHeaderType encoding/asn1.ObjectIdentifier
+          Type: 141 GoSliceHeaderType encoding/asn1.ObjectIdentifier
         - Name: Value
           Offset: 24
-          Type: 135 GoEmptyInterfaceType interface {}
+          Type: 125 GoEmptyInterfaceType interface {}
     - __kind: StructureType
-      ID: 148
+      ID: 138
       Name: crypto/x509/pkix.Extension
       ByteSize: 56
       GoRuntimeType: 1.646464e+06
@@ -1423,15 +1405,15 @@ Types:
       RawFields:
         - Name: Id
           Offset: 0
-          Type: 151 GoSliceHeaderType encoding/asn1.ObjectIdentifier
+          Type: 141 GoSliceHeaderType encoding/asn1.ObjectIdentifier
         - Name: Critical
           Offset: 24
           Type: 4 BaseType bool
         - Name: Value
           Offset: 32
-          Type: 68 GoSliceHeaderType []uint8
+          Type: 103 GoSliceHeaderType []uint8
     - __kind: StructureType
-      ID: 138
+      ID: 128
       Name: crypto/x509/pkix.Name
       ByteSize: 248
       GoRuntimeType: 2.192e+06
@@ -1439,25 +1421,25 @@ Types:
       RawFields:
         - Name: Country
           Offset: 0
-          Type: 51 GoSliceHeaderType []string
+          Type: 53 GoSliceHeaderType []string
         - Name: Organization
           Offset: 24
-          Type: 51 GoSliceHeaderType []string
+          Type: 53 GoSliceHeaderType []string
         - Name: OrganizationalUnit
           Offset: 48
-          Type: 51 GoSliceHeaderType []string
+          Type: 53 GoSliceHeaderType []string
         - Name: Locality
           Offset: 72
-          Type: 51 GoSliceHeaderType []string
+          Type: 53 GoSliceHeaderType []string
         - Name: Province
           Offset: 96
-          Type: 51 GoSliceHeaderType []string
+          Type: 53 GoSliceHeaderType []string
         - Name: StreetAddress
           Offset: 120
-          Type: 51 GoSliceHeaderType []string
+          Type: 53 GoSliceHeaderType []string
         - Name: PostalCode
           Offset: 144
-          Type: 51 GoSliceHeaderType []string
+          Type: 53 GoSliceHeaderType []string
         - Name: SerialNumber
           Offset: 168
           Type: 9 GoStringHeaderType string
@@ -1466,12 +1448,12 @@ Types:
           Type: 9 GoStringHeaderType string
         - Name: Names
           Offset: 200
-          Type: 139 GoSliceHeaderType []crypto/x509/pkix.AttributeTypeAndValue
+          Type: 129 GoSliceHeaderType []crypto/x509/pkix.AttributeTypeAndValue
         - Name: ExtraNames
           Offset: 224
-          Type: 139 GoSliceHeaderType []crypto/x509/pkix.AttributeTypeAndValue
+          Type: 129 GoSliceHeaderType []crypto/x509/pkix.AttributeTypeAndValue
     - __kind: GoSliceHeaderType
-      ID: 151
+      ID: 141
       Name: encoding/asn1.ObjectIdentifier
       ByteSize: 24
       GoRuntimeType: 1.052832e+06
@@ -1486,9 +1468,9 @@ Types:
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 189 GoSliceDataType encoding/asn1.ObjectIdentifier.array
+      Data: 193 GoSliceDataType encoding/asn1.ObjectIdentifier.array
     - __kind: GoSliceDataType
-      ID: 189
+      ID: 193
       Name: encoding/asn1.ObjectIdentifier.array
       ByteSize: 2048
       Element: 7 BaseType int
@@ -1518,13 +1500,13 @@ Types:
       GoRuntimeType: 585184
       GoKind: 14
     - __kind: GoSubroutineType
-      ID: 50
+      ID: 52
       Name: func() (io.ReadCloser, error)
       ByteSize: 8
       GoRuntimeType: 693216
       GoKind: 19
     - __kind: GoSubroutineType
-      ID: 89
+      ID: 114
       Name: func(string, []uint8, int) ([]uint8, error)
       ByteSize: 8
       GoRuntimeType: 1.002592e+06
@@ -1543,47 +1525,47 @@ Types:
           Offset: 8
           Type: 15 VoidPointerType unsafe.Pointer
     - __kind: GoSwissMapGroupsType
-      ID: 115
+      ID: 89
       Name: groupReference<string,[]*mime/multipart.FileHeader>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 116 PointerType *noalg.map.group[string][]*mime/multipart.FileHeader
+          Type: 90 PointerType *noalg.map.group[string][]*mime/multipart.FileHeader
         - Name: lengthMask
           Offset: 8
           Type: 8 BaseType uint64
-      GroupType: 117 StructureType noalg.map.group[string][]*mime/multipart.FileHeader
-      GroupSliceType: 124 GoSliceDataType []noalg.map.group[string][]*mime/multipart.FileHeader.array
+      GroupType: 91 StructureType noalg.map.group[string][]*mime/multipart.FileHeader
+      GroupSliceType: 98 GoSliceDataType []noalg.map.group[string][]*mime/multipart.FileHeader.array
     - __kind: GoSwissMapGroupsType
-      ID: 95
+      ID: 73
       Name: groupReference<string,[]string>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 96 PointerType *noalg.map.group[string][]string
+          Type: 74 PointerType *noalg.map.group[string][]string
         - Name: lengthMask
           Offset: 8
           Type: 8 BaseType uint64
-      GroupType: 97 StructureType noalg.map.group[string][]string
-      GroupSliceType: 101 GoSliceDataType []noalg.map.group[string][]string.array
+      GroupType: 75 StructureType noalg.map.group[string][]string
+      GroupSliceType: 79 GoSliceDataType []noalg.map.group[string][]string.array
     - __kind: GoSwissMapGroupsType
-      ID: 104
+      ID: 206
       Name: groupReference<string,string>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 105 PointerType *noalg.map.group[string]string
+          Type: 207 PointerType *noalg.map.group[string]string
         - Name: lengthMask
           Offset: 8
           Type: 8 BaseType uint64
-      GroupType: 106 StructureType noalg.map.group[string]string
-      GroupSliceType: 110 GoSliceDataType []noalg.map.group[string]string.array
+      GroupType: 208 StructureType noalg.map.group[string]string
+      GroupSliceType: 212 GoSliceDataType []noalg.map.group[string]string.array
     - __kind: BaseType
       ID: 7
       Name: int
@@ -1615,7 +1597,7 @@ Types:
       GoRuntimeType: 584288
       GoKind: 3
     - __kind: GoEmptyInterfaceType
-      ID: 135
+      ID: 125
       Name: interface {}
       ByteSize: 16
       GoRuntimeType: 854240
@@ -1628,7 +1610,7 @@ Types:
           Offset: 8
           Type: 15 VoidPointerType unsafe.Pointer
     - __kind: GoInterfaceType
-      ID: 49
+      ID: 51
       Name: io.ReadCloser
       ByteSize: 16
       GoRuntimeType: 1.10976e+06
@@ -1641,7 +1623,7 @@ Types:
           Offset: 8
           Type: 15 VoidPointerType unsafe.Pointer
     - __kind: GoSwissMapHeaderType
-      ID: 78
+      ID: 85
       Name: map<string,[]*mime/multipart.FileHeader>
       ByteSize: 48
       GoKind: 25
@@ -1654,7 +1636,7 @@ Types:
           Type: 1 BaseType uintptr
         - Name: dirPtr
           Offset: 16
-          Type: 79 PointerType **table<string,[]*mime/multipart.FileHeader>
+          Type: 86 PointerType **table<string,[]*mime/multipart.FileHeader>
         - Name: dirLen
           Offset: 24
           Type: 7 BaseType int
@@ -1673,10 +1655,10 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 8 BaseType uint64
-      TablePtrSliceType: 123 GoSliceDataType []*table<string,[]*mime/multipart.FileHeader>.array
-      GroupType: 117 StructureType noalg.map.group[string][]*mime/multipart.FileHeader
+      TablePtrSliceType: 97 GoSliceDataType []*table<string,[]*mime/multipart.FileHeader>.array
+      GroupType: 91 StructureType noalg.map.group[string][]*mime/multipart.FileHeader
     - __kind: GoSwissMapHeaderType
-      ID: 46
+      ID: 48
       Name: map<string,[]string>
       ByteSize: 48
       GoKind: 25
@@ -1689,7 +1671,7 @@ Types:
           Type: 1 BaseType uintptr
         - Name: dirPtr
           Offset: 16
-          Type: 47 PointerType **table<string,[]string>
+          Type: 49 PointerType **table<string,[]string>
         - Name: dirLen
           Offset: 24
           Type: 7 BaseType int
@@ -1708,10 +1690,10 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 8 BaseType uint64
-      TablePtrSliceType: 100 GoSliceDataType []*table<string,[]string>.array
-      GroupType: 97 StructureType noalg.map.group[string][]string
+      TablePtrSliceType: 78 GoSliceDataType []*table<string,[]string>.array
+      GroupType: 75 StructureType noalg.map.group[string][]string
     - __kind: GoSwissMapHeaderType
-      ID: 65
+      ID: 67
       Name: map<string,string>
       ByteSize: 48
       GoKind: 25
@@ -1724,7 +1706,7 @@ Types:
           Type: 1 BaseType uintptr
         - Name: dirPtr
           Offset: 16
-          Type: 66 PointerType **table<string,string>
+          Type: 68 PointerType **table<string,string>
         - Name: dirLen
           Offset: 24
           Type: 7 BaseType int
@@ -1743,31 +1725,31 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 8 BaseType uint64
-      TablePtrSliceType: 109 GoSliceDataType []*table<string,string>.array
-      GroupType: 106 StructureType noalg.map.group[string]string
+      TablePtrSliceType: 211 GoSliceDataType []*table<string,string>.array
+      GroupType: 208 StructureType noalg.map.group[string]string
     - __kind: GoMapType
-      ID: 76
+      ID: 83
       Name: map[string][]*mime/multipart.FileHeader
       ByteSize: 8
       GoRuntimeType: 1.131648e+06
       GoKind: 21
-      HeaderType: 78 GoSwissMapHeaderType map<string,[]*mime/multipart.FileHeader>
+      HeaderType: 85 GoSwissMapHeaderType map<string,[]*mime/multipart.FileHeader>
     - __kind: GoMapType
-      ID: 75
+      ID: 82
       Name: map[string][]string
       ByteSize: 8
       GoRuntimeType: 1.127296e+06
       GoKind: 21
-      HeaderType: 46 GoSwissMapHeaderType map<string,[]string>
+      HeaderType: 48 GoSwissMapHeaderType map<string,[]string>
     - __kind: GoMapType
-      ID: 63
+      ID: 65
       Name: map[string]string
       ByteSize: 8
       GoRuntimeType: 1.12832e+06
       GoKind: 21
-      HeaderType: 65 GoSwissMapHeaderType map<string,string>
+      HeaderType: 67 GoSwissMapHeaderType map<string,string>
     - __kind: StructureType
-      ID: 137
+      ID: 127
       Name: math/big.Int
       ByteSize: 32
       GoRuntimeType: 1.493568e+06
@@ -1778,15 +1760,15 @@ Types:
           Type: 4 BaseType bool
         - Name: abs
           Offset: 8
-          Type: 172 GoSliceHeaderType math/big.nat
+          Type: 159 GoSliceHeaderType math/big.nat
     - __kind: BaseType
-      ID: 174
+      ID: 161
       Name: math/big.Word
       ByteSize: 8
       GoRuntimeType: 588128
       GoKind: 7
     - __kind: GoSliceHeaderType
-      ID: 172
+      ID: 159
       Name: math/big.nat
       ByteSize: 24
       GoRuntimeType: 2.361088e+06
@@ -1794,21 +1776,21 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 173 PointerType *math/big.Word
+          Type: 160 PointerType *math/big.Word
         - Name: len
           Offset: 8
           Type: 7 BaseType int
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 206 GoSliceDataType math/big.nat.array
+      Data: 162 GoSliceDataType math/big.nat.array
     - __kind: GoSliceDataType
-      ID: 206
+      ID: 162
       Name: math/big.nat.array
       ByteSize: 2048
-      Element: 174 BaseType math/big.Word
+      Element: 161 BaseType math/big.Word
     - __kind: StructureType
-      ID: 169
+      ID: 99
       Name: mime/multipart.FileHeader
       ByteSize: 88
       GoRuntimeType: 1.977088e+06
@@ -1819,13 +1801,13 @@ Types:
           Type: 9 GoStringHeaderType string
         - Name: Header
           Offset: 16
-          Type: 182 GoMapType net/textproto.MIMEHeader
+          Type: 102 GoMapType net/textproto.MIMEHeader
         - Name: Size
           Offset: 24
           Type: 13 BaseType int64
         - Name: content
           Offset: 32
-          Type: 68 GoSliceHeaderType []uint8
+          Type: 103 GoSliceHeaderType []uint8
         - Name: tmpfile
           Offset: 56
           Type: 9 GoStringHeaderType string
@@ -1836,7 +1818,7 @@ Types:
           Offset: 80
           Type: 4 BaseType bool
     - __kind: StructureType
-      ID: 54
+      ID: 56
       Name: mime/multipart.Form
       ByteSize: 16
       GoRuntimeType: 1.477408e+06
@@ -1844,12 +1826,12 @@ Types:
       RawFields:
         - Name: Value
           Offset: 0
-          Type: 75 GoMapType map[string][]string
+          Type: 82 GoMapType map[string][]string
         - Name: File
           Offset: 8
-          Type: 76 GoMapType map[string][]*mime/multipart.FileHeader
+          Type: 83 GoMapType map[string][]*mime/multipart.FileHeader
     - __kind: GoSliceHeaderType
-      ID: 157
+      ID: 147
       Name: net.IP
       ByteSize: 24
       GoRuntimeType: 2.123744e+06
@@ -1871,7 +1853,7 @@ Types:
       ByteSize: 2048
       Element: 3 BaseType uint8
     - __kind: GoSliceHeaderType
-      ID: 205
+      ID: 197
       Name: net.IPMask
       ByteSize: 24
       GoRuntimeType: 1.01904e+06
@@ -1886,14 +1868,14 @@ Types:
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 212 GoSliceDataType net.IPMask.array
+      Data: 198 GoSliceDataType net.IPMask.array
     - __kind: GoSliceDataType
-      ID: 212
+      ID: 198
       Name: net.IPMask.array
       ByteSize: 2048
       Element: 3 BaseType uint8
     - __kind: StructureType
-      ID: 181
+      ID: 186
       Name: net.IPNet
       ByteSize: 48
       GoRuntimeType: 1.458208e+06
@@ -1901,17 +1883,17 @@ Types:
       RawFields:
         - Name: IP
           Offset: 0
-          Type: 157 GoSliceHeaderType net.IP
+          Type: 147 GoSliceHeaderType net.IP
         - Name: Mask
           Offset: 24
-          Type: 205 GoSliceHeaderType net.IPMask
+          Type: 197 GoSliceHeaderType net.IPMask
     - __kind: GoMapType
-      ID: 44
+      ID: 46
       Name: net/http.Header
       ByteSize: 8
       GoRuntimeType: 2.100864e+06
       GoKind: 21
-      HeaderType: 46 GoSwissMapHeaderType map<string,[]string>
+      HeaderType: 48 GoSwissMapHeaderType map<string,[]string>
     - __kind: StructureType
       ID: 38
       Name: net/http.Request
@@ -1924,7 +1906,7 @@ Types:
           Type: 9 GoStringHeaderType string
         - Name: URL
           Offset: 16
-          Type: 42 PointerType *net/url.URL
+          Type: 44 PointerType *net/url.URL
         - Name: Proto
           Offset: 24
           Type: 9 GoStringHeaderType string
@@ -1936,19 +1918,19 @@ Types:
           Type: 7 BaseType int
         - Name: Header
           Offset: 56
-          Type: 44 GoMapType net/http.Header
+          Type: 46 GoMapType net/http.Header
         - Name: Body
           Offset: 64
-          Type: 49 GoInterfaceType io.ReadCloser
+          Type: 51 GoInterfaceType io.ReadCloser
         - Name: GetBody
           Offset: 80
-          Type: 50 GoSubroutineType func() (io.ReadCloser, error)
+          Type: 52 GoSubroutineType func() (io.ReadCloser, error)
         - Name: ContentLength
           Offset: 88
           Type: 13 BaseType int64
         - Name: TransferEncoding
           Offset: 96
-          Type: 51 GoSliceHeaderType []string
+          Type: 53 GoSliceHeaderType []string
         - Name: Close
           Offset: 120
           Type: 4 BaseType bool
@@ -1957,16 +1939,16 @@ Types:
           Type: 9 GoStringHeaderType string
         - Name: Form
           Offset: 144
-          Type: 52 GoMapType net/url.Values
+          Type: 54 GoMapType net/url.Values
         - Name: PostForm
           Offset: 152
-          Type: 52 GoMapType net/url.Values
+          Type: 54 GoMapType net/url.Values
         - Name: MultipartForm
           Offset: 160
-          Type: 53 PointerType *mime/multipart.Form
+          Type: 55 PointerType *mime/multipart.Form
         - Name: Trailer
           Offset: 168
-          Type: 44 GoMapType net/http.Header
+          Type: 46 GoMapType net/http.Header
         - Name: RemoteAddr
           Offset: 176
           Type: 9 GoStringHeaderType string
@@ -1975,30 +1957,30 @@ Types:
           Type: 9 GoStringHeaderType string
         - Name: TLS
           Offset: 208
-          Type: 55 PointerType *crypto/tls.ConnectionState
+          Type: 57 PointerType *crypto/tls.ConnectionState
         - Name: Cancel
           Offset: 216
-          Type: 57 GoChannelType <-chan struct {}
+          Type: 59 GoChannelType <-chan struct {}
         - Name: Response
           Offset: 224
-          Type: 58 PointerType *net/http.Response
+          Type: 60 PointerType *net/http.Response
         - Name: Pattern
           Offset: 232
           Type: 9 GoStringHeaderType string
         - Name: ctx
           Offset: 248
-          Type: 60 GoInterfaceType context.Context
+          Type: 62 GoInterfaceType context.Context
         - Name: pat
           Offset: 264
-          Type: 61 PointerType *net/http.pattern
+          Type: 63 PointerType *net/http.pattern
         - Name: matches
           Offset: 272
-          Type: 51 GoSliceHeaderType []string
+          Type: 53 GoSliceHeaderType []string
         - Name: otherValues
           Offset: 296
-          Type: 63 GoMapType map[string]string
+          Type: 65 GoMapType map[string]string
     - __kind: StructureType
-      ID: 59
+      ID: 61
       Name: net/http.Response
       ByteSize: 144
       GoRuntimeType: 2.209888e+06
@@ -2021,16 +2003,16 @@ Types:
           Type: 7 BaseType int
         - Name: Header
           Offset: 56
-          Type: 44 GoMapType net/http.Header
+          Type: 46 GoMapType net/http.Header
         - Name: Body
           Offset: 64
-          Type: 49 GoInterfaceType io.ReadCloser
+          Type: 51 GoInterfaceType io.ReadCloser
         - Name: ContentLength
           Offset: 80
           Type: 13 BaseType int64
         - Name: TransferEncoding
           Offset: 88
-          Type: 51 GoSliceHeaderType []string
+          Type: 53 GoSliceHeaderType []string
         - Name: Close
           Offset: 112
           Type: 4 BaseType bool
@@ -2039,13 +2021,13 @@ Types:
           Type: 4 BaseType bool
         - Name: Trailer
           Offset: 120
-          Type: 44 GoMapType net/http.Header
+          Type: 46 GoMapType net/http.Header
         - Name: Request
           Offset: 128
           Type: 37 PointerType *net/http.Request
         - Name: TLS
           Offset: 136
-          Type: 55 PointerType *crypto/tls.ConnectionState
+          Type: 57 PointerType *crypto/tls.ConnectionState
     - __kind: GoInterfaceType
       ID: 36
       Name: net/http.ResponseWriter
@@ -2060,7 +2042,7 @@ Types:
           Offset: 8
           Type: 15 VoidPointerType unsafe.Pointer
     - __kind: StructureType
-      ID: 62
+      ID: 64
       Name: net/http.pattern
       ByteSize: 88
       GoRuntimeType: 1.833088e+06
@@ -2077,12 +2059,12 @@ Types:
           Type: 9 GoStringHeaderType string
         - Name: segments
           Offset: 48
-          Type: 91 GoSliceHeaderType []net/http.segment
+          Type: 200 GoSliceHeaderType []net/http.segment
         - Name: loc
           Offset: 72
           Type: 9 GoStringHeaderType string
     - __kind: StructureType
-      ID: 93
+      ID: 202
       Name: net/http.segment
       ByteSize: 24
       GoRuntimeType: 1.607872e+06
@@ -2098,14 +2080,14 @@ Types:
           Offset: 17
           Type: 4 BaseType bool
     - __kind: GoMapType
-      ID: 182
+      ID: 102
       Name: net/textproto.MIMEHeader
       ByteSize: 8
       GoRuntimeType: 1.82304e+06
       GoKind: 21
-      HeaderType: 46 GoSwissMapHeaderType map<string,[]string>
+      HeaderType: 48 GoSwissMapHeaderType map<string,[]string>
     - __kind: StructureType
-      ID: 43
+      ID: 45
       Name: net/url.URL
       ByteSize: 144
       GoRuntimeType: 2.126816e+06
@@ -2119,7 +2101,7 @@ Types:
           Type: 9 GoStringHeaderType string
         - Name: User
           Offset: 32
-          Type: 72 PointerType *net/url.Userinfo
+          Type: 70 PointerType *net/url.Userinfo
         - Name: Host
           Offset: 40
           Type: 9 GoStringHeaderType string
@@ -2145,7 +2127,7 @@ Types:
           Offset: 128
           Type: 9 GoStringHeaderType string
     - __kind: StructureType
-      ID: 73
+      ID: 71
       Name: net/url.Userinfo
       ByteSize: 40
       GoRuntimeType: 1.624384e+06
@@ -2161,41 +2143,41 @@ Types:
           Offset: 32
           Type: 4 BaseType bool
     - __kind: GoMapType
-      ID: 52
+      ID: 54
       Name: net/url.Values
       ByteSize: 8
       GoRuntimeType: 1.884384e+06
       GoKind: 21
-      HeaderType: 46 GoSwissMapHeaderType map<string,[]string>
+      HeaderType: 48 GoSwissMapHeaderType map<string,[]string>
     - __kind: ArrayType
-      ID: 118
+      ID: 92
       Name: noalg.[8]struct { key string; elem []*mime/multipart.FileHeader }
       ByteSize: 320
       GoRuntimeType: 699072
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 119 StructureType noalg.struct { key string; elem []*mime/multipart.FileHeader }
+      Element: 93 StructureType noalg.struct { key string; elem []*mime/multipart.FileHeader }
     - __kind: ArrayType
-      ID: 98
+      ID: 76
       Name: noalg.[8]struct { key string; elem []string }
       ByteSize: 320
       GoRuntimeType: 689248
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 99 StructureType noalg.struct { key string; elem []string }
+      Element: 77 StructureType noalg.struct { key string; elem []string }
     - __kind: ArrayType
-      ID: 107
+      ID: 209
       Name: noalg.[8]struct { key string; elem string }
       ByteSize: 256
       GoRuntimeType: 693408
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 108 StructureType noalg.struct { key string; elem string }
+      Element: 210 StructureType noalg.struct { key string; elem string }
     - __kind: StructureType
-      ID: 117
+      ID: 91
       Name: noalg.map.group[string][]*mime/multipart.FileHeader
       ByteSize: 328
       GoRuntimeType: 1.298816e+06
@@ -2206,9 +2188,9 @@ Types:
           Type: 8 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 118 ArrayType noalg.[8]struct { key string; elem []*mime/multipart.FileHeader }
+          Type: 92 ArrayType noalg.[8]struct { key string; elem []*mime/multipart.FileHeader }
     - __kind: StructureType
-      ID: 97
+      ID: 75
       Name: noalg.map.group[string][]string
       ByteSize: 328
       GoRuntimeType: 1.289728e+06
@@ -2219,9 +2201,9 @@ Types:
           Type: 8 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 98 ArrayType noalg.[8]struct { key string; elem []string }
+          Type: 76 ArrayType noalg.[8]struct { key string; elem []string }
     - __kind: StructureType
-      ID: 106
+      ID: 208
       Name: noalg.map.group[string]string
       ByteSize: 264
       GoRuntimeType: 1.29216e+06
@@ -2232,9 +2214,9 @@ Types:
           Type: 8 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 107 ArrayType noalg.[8]struct { key string; elem string }
+          Type: 209 ArrayType noalg.[8]struct { key string; elem string }
     - __kind: StructureType
-      ID: 119
+      ID: 93
       Name: noalg.struct { key string; elem []*mime/multipart.FileHeader }
       ByteSize: 40
       GoRuntimeType: 1.298688e+06
@@ -2245,9 +2227,9 @@ Types:
           Type: 9 GoStringHeaderType string
         - Name: elem
           Offset: 16
-          Type: 120 GoSliceHeaderType []*mime/multipart.FileHeader
+          Type: 94 GoSliceHeaderType []*mime/multipart.FileHeader
     - __kind: StructureType
-      ID: 99
+      ID: 77
       Name: noalg.struct { key string; elem []string }
       ByteSize: 40
       GoRuntimeType: 1.2896e+06
@@ -2258,9 +2240,9 @@ Types:
           Type: 9 GoStringHeaderType string
         - Name: elem
           Offset: 16
-          Type: 51 GoSliceHeaderType []string
+          Type: 53 GoSliceHeaderType []string
     - __kind: StructureType
-      ID: 108
+      ID: 210
       Name: noalg.struct { key string; elem string }
       ByteSize: 32
       GoRuntimeType: 1.292032e+06
@@ -2281,17 +2263,17 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 71 PointerType *string.str
+          Type: 43 PointerType *string.str
         - Name: len
           Offset: 8
           Type: 7 BaseType int
-      Data: 70 GoStringDataType string.str
+      Data: 42 GoStringDataType string.str
     - __kind: GoStringDataType
-      ID: 70
+      ID: 42
       Name: string.str
       ByteSize: 2048
     - __kind: StructureType
-      ID: 113
+      ID: 88
       Name: table<string,[]*mime/multipart.FileHeader>
       ByteSize: 32
       GoKind: 25
@@ -2313,9 +2295,9 @@ Types:
           Type: 7 BaseType int
         - Name: groups
           Offset: 16
-          Type: 115 GoSwissMapGroupsType groupReference<string,[]*mime/multipart.FileHeader>
+          Type: 89 GoSwissMapGroupsType groupReference<string,[]*mime/multipart.FileHeader>
     - __kind: StructureType
-      ID: 74
+      ID: 72
       Name: table<string,[]string>
       ByteSize: 32
       GoKind: 25
@@ -2337,9 +2319,9 @@ Types:
           Type: 7 BaseType int
         - Name: groups
           Offset: 16
-          Type: 95 GoSwissMapGroupsType groupReference<string,[]string>
+          Type: 73 GoSwissMapGroupsType groupReference<string,[]string>
     - __kind: StructureType
-      ID: 94
+      ID: 205
       Name: table<string,string>
       ByteSize: 32
       GoKind: 25
@@ -2361,9 +2343,9 @@ Types:
           Type: 7 BaseType int
         - Name: groups
           Offset: 16
-          Type: 104 GoSwissMapGroupsType groupReference<string,string>
+          Type: 206 GoSwissMapGroupsType groupReference<string,string>
     - __kind: StructureType
-      ID: 144
+      ID: 134
       Name: time.Location
       ByteSize: 104
       GoRuntimeType: 1.972768e+06
@@ -2374,10 +2356,10 @@ Types:
           Type: 9 GoStringHeaderType string
         - Name: zone
           Offset: 16
-          Type: 175 GoSliceHeaderType []time.zone
+          Type: 166 GoSliceHeaderType []time.zone
         - Name: tx
           Offset: 40
-          Type: 178 GoSliceHeaderType []time.zoneTrans
+          Type: 169 GoSliceHeaderType []time.zoneTrans
         - Name: extend
           Offset: 64
           Type: 9 GoStringHeaderType string
@@ -2389,9 +2371,9 @@ Types:
           Type: 13 BaseType int64
         - Name: cacheZone
           Offset: 96
-          Type: 176 PointerType *time.zone
+          Type: 167 PointerType *time.zone
     - __kind: StructureType
-      ID: 142
+      ID: 132
       Name: time.Time
       ByteSize: 24
       GoRuntimeType: 2.363936e+06
@@ -2405,9 +2387,9 @@ Types:
           Type: 13 BaseType int64
         - Name: loc
           Offset: 16
-          Type: 143 PointerType *time.Location
+          Type: 133 PointerType *time.Location
     - __kind: StructureType
-      ID: 177
+      ID: 168
       Name: time.zone
       ByteSize: 32
       GoRuntimeType: 1.612864e+06
@@ -2423,7 +2405,7 @@ Types:
           Offset: 24
           Type: 4 BaseType bool
     - __kind: StructureType
-      ID: 180
+      ID: 171
       Name: time.zoneTrans
       ByteSize: 16
       GoRuntimeType: 1.750304e+06
@@ -2483,6 +2465,6 @@ Types:
       ByteSize: 8
       GoRuntimeType: 585312
       GoKind: 26
-MaxTypeID: 215
+MaxTypeID: 214
 Issues: []
 GoModuledataInfo: {FirstModuledataAddr: "0x130d980", TypesOffset: 296}

--- a/pkg/dyninst/irgen/testdata/snapshot/sample.arch=amd64,toolchain=go1.23.11.yaml
+++ b/pkg/dyninst/irgen/testdata/snapshot/sample.arch=amd64,toolchain=go1.23.11.yaml
@@ -2089,7 +2089,7 @@ Subprograms:
       InlinePCRanges: []
       Variables:
         - Name: a
-          Type: 72 ArrayType [5]int
+          Type: 63 ArrayType [5]int
           Locations:
             - Range: 0xd03dc0..0xd03e03
               Pieces: [{Size: 40, Op: {CfaOffset: 0}}]
@@ -2106,7 +2106,7 @@ Subprograms:
       InlinePCRanges: []
       Variables:
         - Name: b
-          Type: 73 GoInterfaceType main.behavior
+          Type: 64 GoInterfaceType main.behavior
           Locations:
             - Range: 0xd040a0..0xd040bf
               Pieces:
@@ -2176,7 +2176,7 @@ Subprograms:
       InlinePCRanges: []
       Variables:
         - Name: s
-          Type: 74 StructureType main.structWithMap
+          Type: 65 StructureType main.structWithMap
           Locations:
             - Range: 0xd045e0..0xd045e1
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
@@ -2188,7 +2188,7 @@ Subprograms:
       InlinePCRanges: []
       Variables:
         - Name: m
-          Type: 90 GoMapType map[string]main.nestedStruct
+          Type: 73 GoMapType map[string]main.nestedStruct
           Locations:
             - Range: 0xd04600..0xd04601
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
@@ -2200,7 +2200,7 @@ Subprograms:
       InlinePCRanges: []
       Variables:
         - Name: m
-          Type: 98 GoMapType map[string]int
+          Type: 78 GoMapType map[string]int
           Locations:
             - Range: 0xd04620..0xd04621
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
@@ -2212,7 +2212,7 @@ Subprograms:
       InlinePCRanges: []
       Variables:
         - Name: m
-          Type: 103 GoMapType map[string][]string
+          Type: 83 GoMapType map[string][]string
           Locations:
             - Range: 0xd04640..0xd04641
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
@@ -2224,7 +2224,7 @@ Subprograms:
       InlinePCRanges: []
       Variables:
         - Name: m
-          Type: 110 GoMapType map[[4]string][2]int
+          Type: 88 GoMapType map[[4]string][2]int
           Locations:
             - Range: 0xd04660..0xd04661
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
@@ -2236,7 +2236,7 @@ Subprograms:
       InlinePCRanges: []
       Variables:
         - Name: m
-          Type: 98 GoMapType map[string]int
+          Type: 78 GoMapType map[string]int
           Locations:
             - Range: 0xd04680..0xd04681
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
@@ -2248,7 +2248,7 @@ Subprograms:
       InlinePCRanges: []
       Variables:
         - Name: m
-          Type: 118 ArrayType [2]map[string]int
+          Type: 93 ArrayType [2]map[string]int
           Locations:
             - Range: 0xd046a0..0xd046a1
               Pieces: [{Size: 16, Op: {CfaOffset: 0}}]
@@ -2260,7 +2260,7 @@ Subprograms:
       InlinePCRanges: []
       Variables:
         - Name: m
-          Type: 119 PointerType *map[string]int
+          Type: 94 PointerType *map[string]int
           Locations:
             - Range: 0xd046c0..0xd046c1
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
@@ -2272,7 +2272,7 @@ Subprograms:
       InlinePCRanges: []
       Variables:
         - Name: m
-          Type: 75 GoMapType map[int]int
+          Type: 66 GoMapType map[int]int
           Locations:
             - Range: 0xd046e0..0xd046e1
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
@@ -2284,7 +2284,7 @@ Subprograms:
       InlinePCRanges: []
       Variables:
         - Name: redactMyEntries
-          Type: 120 GoMapType map[string][]main.structWithMap
+          Type: 95 GoMapType map[string][]main.structWithMap
           Locations:
             - Range: 0xd04700..0xd04701
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
@@ -2296,7 +2296,7 @@ Subprograms:
       InlinePCRanges: []
       Variables:
         - Name: m
-          Type: 120 GoMapType map[string][]main.structWithMap
+          Type: 95 GoMapType map[string][]main.structWithMap
           Locations:
             - Range: 0xd04720..0xd04721
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
@@ -2308,7 +2308,7 @@ Subprograms:
       InlinePCRanges: []
       Variables:
         - Name: m
-          Type: 128 GoMapType map[bool]main.node
+          Type: 100 GoMapType map[bool]main.node
           Locations:
             - Range: 0xd04740..0xd04741
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
@@ -2320,7 +2320,7 @@ Subprograms:
       InlinePCRanges: []
       Variables:
         - Name: m
-          Type: 137 GoMapType map[int]uint8
+          Type: 105 GoMapType map[int]uint8
           Locations:
             - Range: 0xd04760..0xd04761
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
@@ -2332,7 +2332,7 @@ Subprograms:
       InlinePCRanges: []
       Variables:
         - Name: redactMyEntries
-          Type: 137 GoMapType map[int]uint8
+          Type: 105 GoMapType map[int]uint8
           Locations:
             - Range: 0xd04780..0xd04781
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
@@ -2344,7 +2344,7 @@ Subprograms:
       InlinePCRanges: []
       Variables:
         - Name: m
-          Type: 143 GoMapType map[uint8]uint8
+          Type: 110 GoMapType map[uint8]uint8
           Locations:
             - Range: 0xd047a0..0xd047a1
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
@@ -2356,7 +2356,7 @@ Subprograms:
       InlinePCRanges: []
       Variables:
         - Name: m
-          Type: 143 GoMapType map[uint8]uint8
+          Type: 110 GoMapType map[uint8]uint8
           Locations:
             - Range: 0xd047c0..0xd047c1
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
@@ -2368,7 +2368,7 @@ Subprograms:
       InlinePCRanges: []
       Variables:
         - Name: m
-          Type: 143 GoMapType map[uint8]uint8
+          Type: 110 GoMapType map[uint8]uint8
           Locations:
             - Range: 0xd047e0..0xd047e1
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
@@ -2380,7 +2380,7 @@ Subprograms:
       InlinePCRanges: []
       Variables:
         - Name: m
-          Type: 149 GoMapType map[uint8][4]int
+          Type: 115 GoMapType map[uint8][4]int
           Locations:
             - Range: 0xd04800..0xd04801
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
@@ -2392,7 +2392,7 @@ Subprograms:
       InlinePCRanges: []
       Variables:
         - Name: m
-          Type: 156 GoMapType map[[4]int]uint8
+          Type: 120 GoMapType map[[4]int]uint8
           Locations:
             - Range: 0xd04820..0xd04821
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
@@ -2404,7 +2404,7 @@ Subprograms:
       InlinePCRanges: []
       Variables:
         - Name: m
-          Type: 162 GoMapType map[[4]int][4]int
+          Type: 125 GoMapType map[[4]int][4]int
           Locations:
             - Range: 0xd04840..0xd04841
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
@@ -2486,7 +2486,7 @@ Subprograms:
       InlinePCRanges: []
       Variables:
         - Name: c
-          Type: 167 GoChannelType chan bool
+          Type: 130 GoChannelType chan bool
           Locations:
             - Range: 0xd061e0..0xd061e1
               Pieces: [{Size: 0, Op: {RegNo: 0, Shift: 0}}]
@@ -2498,7 +2498,7 @@ Subprograms:
       InlinePCRanges: []
       Variables:
         - Name: a
-          Type: 168 PointerType *main.structWithTwoValues
+          Type: 131 PointerType *main.structWithTwoValues
           Locations:
             - Range: 0xd063a0..0xd063a1
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
@@ -2510,7 +2510,7 @@ Subprograms:
       InlinePCRanges: []
       Variables:
         - Name: a
-          Type: 135 StructureType main.node
+          Type: 133 StructureType main.node
           Locations:
             - Range: 0xd063c0..0xd063c1
               Pieces:
@@ -2526,7 +2526,7 @@ Subprograms:
       InlinePCRanges: []
       Variables:
         - Name: a
-          Type: 136 PointerType *main.node
+          Type: 134 PointerType *main.node
           Locations:
             - Range: 0xd063e0..0xd063e1
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
@@ -2593,7 +2593,7 @@ Subprograms:
       InlinePCRanges: []
       Variables:
         - Name: t
-          Type: 170 PointerType *main.t
+          Type: 135 PointerType *main.t
           Locations:
             - Range: 0xd065a0..0xd065a1
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
@@ -2605,7 +2605,7 @@ Subprograms:
       InlinePCRanges: []
       Variables:
         - Name: u
-          Type: 173 GoSliceHeaderType []uint
+          Type: 137 GoSliceHeaderType []uint
           Locations:
             - Range: 0xd06ac0..0xd06ac1
               Pieces:
@@ -2623,7 +2623,7 @@ Subprograms:
       InlinePCRanges: []
       Variables:
         - Name: u
-          Type: 173 GoSliceHeaderType []uint
+          Type: 137 GoSliceHeaderType []uint
           Locations:
             - Range: 0xd06ae0..0xd06ae1
               Pieces:
@@ -2641,7 +2641,7 @@ Subprograms:
       InlinePCRanges: []
       Variables:
         - Name: u
-          Type: 174 GoSliceHeaderType [][]uint
+          Type: 138 GoSliceHeaderType [][]uint
           Locations:
             - Range: 0xd06b00..0xd06b01
               Pieces:
@@ -2659,7 +2659,7 @@ Subprograms:
       InlinePCRanges: []
       Variables:
         - Name: xs
-          Type: 176 GoSliceHeaderType []main.structWithNoStrings
+          Type: 140 GoSliceHeaderType []main.structWithNoStrings
           Locations:
             - Range: 0xd06b20..0xd06b21
               Pieces:
@@ -2684,7 +2684,7 @@ Subprograms:
       InlinePCRanges: []
       Variables:
         - Name: xs
-          Type: 176 GoSliceHeaderType []main.structWithNoStrings
+          Type: 140 GoSliceHeaderType []main.structWithNoStrings
           Locations:
             - Range: 0xd06b40..0xd06b41
               Pieces:
@@ -2709,7 +2709,7 @@ Subprograms:
       InlinePCRanges: []
       Variables:
         - Name: xs
-          Type: 176 GoSliceHeaderType []main.structWithNoStrings
+          Type: 140 GoSliceHeaderType []main.structWithNoStrings
           Locations:
             - Range: 0xd06b60..0xd06b61
               Pieces:
@@ -2734,7 +2734,7 @@ Subprograms:
       InlinePCRanges: []
       Variables:
         - Name: s
-          Type: 109 GoSliceHeaderType []string
+          Type: 143 GoSliceHeaderType []string
           Locations:
             - Range: 0xd06b80..0xd06b81
               Pieces:
@@ -2759,7 +2759,7 @@ Subprograms:
           IsParameter: true
           IsReturn: false
         - Name: s
-          Type: 179 GoSliceHeaderType []bool
+          Type: 144 GoSliceHeaderType []bool
           Locations:
             - Range: 0xd06ba0..0xd06ba1
               Pieces:
@@ -2784,7 +2784,7 @@ Subprograms:
       InlinePCRanges: []
       Variables:
         - Name: xs
-          Type: 180 GoSliceHeaderType []uint16
+          Type: 145 GoSliceHeaderType []uint16
           Locations:
             - Range: 0xd06bc0..0xd06bc1
               Pieces:
@@ -2802,7 +2802,7 @@ Subprograms:
       InlinePCRanges: []
       Variables:
         - Name: xs
-          Type: 173 GoSliceHeaderType []uint
+          Type: 137 GoSliceHeaderType []uint
           Locations:
             - Range: 0xd06be0..0xd06be1
               Pieces:
@@ -2884,7 +2884,7 @@ Subprograms:
       InlinePCRanges: []
       Variables:
         - Name: a
-          Type: 181 StructureType main.threeStringStruct
+          Type: 146 StructureType main.threeStringStruct
           Locations:
             - Range: 0xd06fc0..0xd06fdf
               Pieces:
@@ -2908,7 +2908,7 @@ Subprograms:
       InlinePCRanges: []
       Variables:
         - Name: a
-          Type: 182 PointerType *main.threeStringStruct
+          Type: 147 PointerType *main.threeStringStruct
           Locations:
             - Range: 0xd06fe0..0xd06fe1
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
@@ -2920,7 +2920,7 @@ Subprograms:
       InlinePCRanges: []
       Variables:
         - Name: a
-          Type: 183 PointerType *main.oneStringStruct
+          Type: 148 PointerType *main.oneStringStruct
           Locations:
             - Range: 0xd07000..0xd07001
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
@@ -2980,7 +2980,7 @@ Subprograms:
       InlinePCRanges: []
       Variables:
         - Name: x
-          Type: 185 StructureType main.aStruct
+          Type: 150 StructureType main.aStruct
           Locations:
             - Range: 0xd072e0..0xd07303
               Pieces:
@@ -3006,7 +3006,7 @@ Subprograms:
       InlinePCRanges: []
       Variables:
         - Name: e
-          Type: 186 StructureType main.emptyStruct
+          Type: 152 StructureType main.emptyStruct
           Locations: [{Range: 0xd07460..0xd07461, Pieces: []}]
           IsParameter: true
           IsReturn: false
@@ -3085,7 +3085,7 @@ Subprograms:
           RootRanges: [0xd03e20..0xd03fa5]
       Variables:
         - Name: a
-          Type: 72 ArrayType [5]int
+          Type: 63 ArrayType [5]int
           Locations:
             - Range: 0xd03dcd..0xd03e03
               Pieces: [{Size: 40, Op: {CfaOffset: -56}}]
@@ -3095,15 +3095,15 @@ Subprograms:
           IsReturn: false
 Types:
     - __kind: PointerType
-      ID: 172
+      ID: 185
       Name: '**main.t'
       ByteSize: 8
-      Pointee: 170 PointerType *main.t
+      Pointee: 135 PointerType *main.t
     - __kind: PointerType
-      ID: 87
+      ID: 186
       Name: '**runtime.bmap'
       ByteSize: 8
-      Pointee: 88 PointerType *runtime.bmap
+      Pointee: 167 PointerType *runtime.bmap
     - __kind: PointerType
       ID: 54
       Name: '**string'
@@ -3112,62 +3112,62 @@ Types:
       GoKind: 22
       Pointee: 22 PointerType *string
     - __kind: PointerType
-      ID: 85
+      ID: 165
       Name: '*[]*runtime.bmap'
       ByteSize: 8
       GoRuntimeType: 451680
       GoKind: 22
-      Pointee: 86 GoSliceHeaderType []*runtime.bmap
+      Pointee: 166 GoSliceHeaderType []*runtime.bmap
     - __kind: PointerType
-      ID: 193
+      ID: 218
       Name: '*[]*runtime.bmap.array'
       ByteSize: 8
-      Pointee: 192 GoSliceDataType []*runtime.bmap.array
+      Pointee: 217 GoSliceDataType []*runtime.bmap.array
     - __kind: PointerType
       ID: 190
       Name: '*[]*string.array'
       ByteSize: 8
       Pointee: 189 GoSliceDataType []*string.array
     - __kind: PointerType
-      ID: 214
+      ID: 208
       Name: '*[][]uint.array'
       ByteSize: 8
-      Pointee: 213 GoSliceDataType [][]uint.array
+      Pointee: 207 GoSliceDataType [][]uint.array
     - __kind: PointerType
-      ID: 218
+      ID: 214
       Name: '*[]bool.array'
       ByteSize: 8
-      Pointee: 217 GoSliceDataType []bool.array
-    - __kind: PointerType
-      ID: 202
-      Name: '*[]main.structWithMap.array'
-      ByteSize: 8
-      Pointee: 201 GoSliceDataType []main.structWithMap.array
-    - __kind: PointerType
-      ID: 216
-      Name: '*[]main.structWithNoStrings.array'
-      ByteSize: 8
-      Pointee: 215 GoSliceDataType []main.structWithNoStrings.array
-    - __kind: PointerType
-      ID: 198
-      Name: '*[]string.array'
-      ByteSize: 8
-      Pointee: 197 GoSliceDataType []string.array
-    - __kind: PointerType
-      ID: 175
-      Name: '*[]uint'
-      ByteSize: 8
-      Pointee: 173 GoSliceHeaderType []uint
-    - __kind: PointerType
-      ID: 212
-      Name: '*[]uint.array'
-      ByteSize: 8
-      Pointee: 211 GoSliceDataType []uint.array
+      Pointee: 213 GoSliceDataType []bool.array
     - __kind: PointerType
       ID: 220
+      Name: '*[]main.structWithMap.array'
+      ByteSize: 8
+      Pointee: 219 GoSliceDataType []main.structWithMap.array
+    - __kind: PointerType
+      ID: 210
+      Name: '*[]main.structWithNoStrings.array'
+      ByteSize: 8
+      Pointee: 209 GoSliceDataType []main.structWithNoStrings.array
+    - __kind: PointerType
+      ID: 212
+      Name: '*[]string.array'
+      ByteSize: 8
+      Pointee: 211 GoSliceDataType []string.array
+    - __kind: PointerType
+      ID: 139
+      Name: '*[]uint'
+      ByteSize: 8
+      Pointee: 137 GoSliceHeaderType []uint
+    - __kind: PointerType
+      ID: 206
+      Name: '*[]uint.array'
+      ByteSize: 8
+      Pointee: 205 GoSliceDataType []uint.array
+    - __kind: PointerType
+      ID: 216
       Name: '*[]uint16.array'
       ByteSize: 8
-      Pointee: 219 GoSliceDataType []uint16.array
+      Pointee: 215 GoSliceDataType []uint16.array
     - __kind: PointerType
       ID: 5
       Name: '*bool'
@@ -3176,65 +3176,65 @@ Types:
       GoKind: 22
       Pointee: 4 BaseType bool
     - __kind: PointerType
-      ID: 165
+      ID: 128
       Name: '*bucket<[4]int,[4]int>'
       ByteSize: 8
-      Pointee: 166 GoHMapBucketType bucket<[4]int,[4]int>
-    - __kind: PointerType
-      ID: 159
-      Name: '*bucket<[4]int,uint8>'
-      ByteSize: 8
-      Pointee: 160 GoHMapBucketType bucket<[4]int,uint8>
-    - __kind: PointerType
-      ID: 113
-      Name: '*bucket<[4]string,[2]int>'
-      ByteSize: 8
-      Pointee: 114 GoHMapBucketType bucket<[4]string,[2]int>
-    - __kind: PointerType
-      ID: 131
-      Name: '*bucket<bool,main.node>'
-      ByteSize: 8
-      Pointee: 132 GoHMapBucketType bucket<bool,main.node>
-    - __kind: PointerType
-      ID: 78
-      Name: '*bucket<int,int>'
-      ByteSize: 8
-      Pointee: 79 GoHMapBucketType bucket<int,int>
-    - __kind: PointerType
-      ID: 140
-      Name: '*bucket<int,uint8>'
-      ByteSize: 8
-      Pointee: 141 GoHMapBucketType bucket<int,uint8>
+      Pointee: 129 GoHMapBucketType bucket<[4]int,[4]int>
     - __kind: PointerType
       ID: 123
+      Name: '*bucket<[4]int,uint8>'
+      ByteSize: 8
+      Pointee: 124 GoHMapBucketType bucket<[4]int,uint8>
+    - __kind: PointerType
+      ID: 91
+      Name: '*bucket<[4]string,[2]int>'
+      ByteSize: 8
+      Pointee: 92 GoHMapBucketType bucket<[4]string,[2]int>
+    - __kind: PointerType
+      ID: 103
+      Name: '*bucket<bool,main.node>'
+      ByteSize: 8
+      Pointee: 104 GoHMapBucketType bucket<bool,main.node>
+    - __kind: PointerType
+      ID: 69
+      Name: '*bucket<int,int>'
+      ByteSize: 8
+      Pointee: 70 GoHMapBucketType bucket<int,int>
+    - __kind: PointerType
+      ID: 108
+      Name: '*bucket<int,uint8>'
+      ByteSize: 8
+      Pointee: 109 GoHMapBucketType bucket<int,uint8>
+    - __kind: PointerType
+      ID: 98
       Name: '*bucket<string,[]main.structWithMap>'
       ByteSize: 8
-      Pointee: 124 GoHMapBucketType bucket<string,[]main.structWithMap>
+      Pointee: 99 GoHMapBucketType bucket<string,[]main.structWithMap>
     - __kind: PointerType
-      ID: 106
+      ID: 86
       Name: '*bucket<string,[]string>'
       ByteSize: 8
-      Pointee: 107 GoHMapBucketType bucket<string,[]string>
+      Pointee: 87 GoHMapBucketType bucket<string,[]string>
     - __kind: PointerType
-      ID: 101
+      ID: 81
       Name: '*bucket<string,int>'
       ByteSize: 8
-      Pointee: 102 GoHMapBucketType bucket<string,int>
+      Pointee: 82 GoHMapBucketType bucket<string,int>
     - __kind: PointerType
-      ID: 93
+      ID: 76
       Name: '*bucket<string,main.nestedStruct>'
       ByteSize: 8
-      Pointee: 94 GoHMapBucketType bucket<string,main.nestedStruct>
+      Pointee: 77 GoHMapBucketType bucket<string,main.nestedStruct>
     - __kind: PointerType
-      ID: 152
+      ID: 118
       Name: '*bucket<uint8,[4]int>'
       ByteSize: 8
-      Pointee: 153 GoHMapBucketType bucket<uint8,[4]int>
+      Pointee: 119 GoHMapBucketType bucket<uint8,[4]int>
     - __kind: PointerType
-      ID: 146
+      ID: 113
       Name: '*bucket<uint8,uint8>'
       ByteSize: 8
-      Pointee: 147 GoHMapBucketType bucket<uint8,uint8>
+      Pointee: 114 GoHMapBucketType bucket<uint8,uint8>
     - __kind: PointerType
       ID: 33
       Name: '*error'
@@ -3257,65 +3257,65 @@ Types:
       GoKind: 22
       Pointee: 17 BaseType float64
     - __kind: PointerType
-      ID: 163
+      ID: 126
       Name: '*hash<[4]int,[4]int>'
       ByteSize: 8
-      Pointee: 164 GoHMapHeaderType hash<[4]int,[4]int>
-    - __kind: PointerType
-      ID: 157
-      Name: '*hash<[4]int,uint8>'
-      ByteSize: 8
-      Pointee: 158 GoHMapHeaderType hash<[4]int,uint8>
-    - __kind: PointerType
-      ID: 111
-      Name: '*hash<[4]string,[2]int>'
-      ByteSize: 8
-      Pointee: 112 GoHMapHeaderType hash<[4]string,[2]int>
-    - __kind: PointerType
-      ID: 129
-      Name: '*hash<bool,main.node>'
-      ByteSize: 8
-      Pointee: 130 GoHMapHeaderType hash<bool,main.node>
-    - __kind: PointerType
-      ID: 76
-      Name: '*hash<int,int>'
-      ByteSize: 8
-      Pointee: 77 GoHMapHeaderType hash<int,int>
-    - __kind: PointerType
-      ID: 138
-      Name: '*hash<int,uint8>'
-      ByteSize: 8
-      Pointee: 139 GoHMapHeaderType hash<int,uint8>
+      Pointee: 127 GoHMapHeaderType hash<[4]int,[4]int>
     - __kind: PointerType
       ID: 121
+      Name: '*hash<[4]int,uint8>'
+      ByteSize: 8
+      Pointee: 122 GoHMapHeaderType hash<[4]int,uint8>
+    - __kind: PointerType
+      ID: 89
+      Name: '*hash<[4]string,[2]int>'
+      ByteSize: 8
+      Pointee: 90 GoHMapHeaderType hash<[4]string,[2]int>
+    - __kind: PointerType
+      ID: 101
+      Name: '*hash<bool,main.node>'
+      ByteSize: 8
+      Pointee: 102 GoHMapHeaderType hash<bool,main.node>
+    - __kind: PointerType
+      ID: 67
+      Name: '*hash<int,int>'
+      ByteSize: 8
+      Pointee: 68 GoHMapHeaderType hash<int,int>
+    - __kind: PointerType
+      ID: 106
+      Name: '*hash<int,uint8>'
+      ByteSize: 8
+      Pointee: 107 GoHMapHeaderType hash<int,uint8>
+    - __kind: PointerType
+      ID: 96
       Name: '*hash<string,[]main.structWithMap>'
       ByteSize: 8
-      Pointee: 122 GoHMapHeaderType hash<string,[]main.structWithMap>
+      Pointee: 97 GoHMapHeaderType hash<string,[]main.structWithMap>
     - __kind: PointerType
-      ID: 104
+      ID: 84
       Name: '*hash<string,[]string>'
       ByteSize: 8
-      Pointee: 105 GoHMapHeaderType hash<string,[]string>
+      Pointee: 85 GoHMapHeaderType hash<string,[]string>
     - __kind: PointerType
-      ID: 99
+      ID: 79
       Name: '*hash<string,int>'
       ByteSize: 8
-      Pointee: 100 GoHMapHeaderType hash<string,int>
+      Pointee: 80 GoHMapHeaderType hash<string,int>
     - __kind: PointerType
-      ID: 91
+      ID: 74
       Name: '*hash<string,main.nestedStruct>'
       ByteSize: 8
-      Pointee: 92 GoHMapHeaderType hash<string,main.nestedStruct>
+      Pointee: 75 GoHMapHeaderType hash<string,main.nestedStruct>
     - __kind: PointerType
-      ID: 150
+      ID: 116
       Name: '*hash<uint8,[4]int>'
       ByteSize: 8
-      Pointee: 151 GoHMapHeaderType hash<uint8,[4]int>
+      Pointee: 117 GoHMapHeaderType hash<uint8,[4]int>
     - __kind: PointerType
-      ID: 144
+      ID: 111
       Name: '*hash<uint8,uint8>'
       ByteSize: 8
-      Pointee: 145 GoHMapHeaderType hash<uint8,uint8>
+      Pointee: 112 GoHMapHeaderType hash<uint8,uint8>
     - __kind: PointerType
       ID: 27
       Name: '*int'
@@ -3359,73 +3359,73 @@ Types:
       GoKind: 22
       Pointee: 62 StructureType main.esotericHeap
     - __kind: PointerType
-      ID: 136
+      ID: 134
       Name: '*main.node'
       ByteSize: 8
       GoRuntimeType: 354208
       GoKind: 22
-      Pointee: 135 StructureType main.node
+      Pointee: 133 StructureType main.node
     - __kind: PointerType
-      ID: 183
+      ID: 148
       Name: '*main.oneStringStruct'
       ByteSize: 8
       GoKind: 22
-      Pointee: 184 StructureType main.oneStringStruct
+      Pointee: 149 StructureType main.oneStringStruct
     - __kind: PointerType
-      ID: 127
+      ID: 177
       Name: '*main.structWithMap'
       ByteSize: 8
       GoRuntimeType: 354080
       GoKind: 22
-      Pointee: 74 StructureType main.structWithMap
+      Pointee: 65 StructureType main.structWithMap
     - __kind: PointerType
-      ID: 177
+      ID: 141
       Name: '*main.structWithNoStrings'
       ByteSize: 8
-      Pointee: 178 StructureType main.structWithNoStrings
+      Pointee: 142 StructureType main.structWithNoStrings
     - __kind: PointerType
-      ID: 168
+      ID: 131
       Name: '*main.structWithTwoValues'
       ByteSize: 8
       GoKind: 22
-      Pointee: 169 StructureType main.structWithTwoValues
+      Pointee: 132 StructureType main.structWithTwoValues
     - __kind: PointerType
-      ID: 170
+      ID: 135
       Name: '*main.t'
       ByteSize: 8
       GoKind: 22
-      Pointee: 171 GoSliceHeaderType main.t
+      Pointee: 136 GoSliceHeaderType main.t
     - __kind: PointerType
-      ID: 210
+      ID: 204
       Name: '*main.t.array'
       ByteSize: 8
-      Pointee: 209 GoSliceDataType main.t.array
+      Pointee: 203 GoSliceDataType main.t.array
     - __kind: PointerType
-      ID: 182
+      ID: 147
       Name: '*main.threeStringStruct'
       ByteSize: 8
       GoKind: 22
-      Pointee: 181 StructureType main.threeStringStruct
+      Pointee: 146 StructureType main.threeStringStruct
     - __kind: PointerType
-      ID: 119
+      ID: 94
       Name: '*map[string]int'
       ByteSize: 8
       GoKind: 22
-      Pointee: 98 GoMapType map[string]int
+      Pointee: 78 GoMapType map[string]int
     - __kind: PointerType
-      ID: 88
+      ID: 167
       Name: '*runtime.bmap'
       ByteSize: 8
       GoRuntimeType: 1.100896e+06
       GoKind: 22
-      Pointee: 89 StructureType runtime.bmap
+      Pointee: 168 StructureType runtime.bmap
     - __kind: PointerType
-      ID: 83
+      ID: 71
       Name: '*runtime.mapextra'
       ByteSize: 8
       GoRuntimeType: 363104
       GoKind: 22
-      Pointee: 84 StructureType runtime.mapextra
+      Pointee: 72 StructureType runtime.mapextra
     - __kind: PointerType
       ID: 22
       Name: '*string'
@@ -3537,7 +3537,7 @@ Types:
         - Name: m
           Offset: 1
           Expression:
-            Type: 118 ArrayType [2]map[string]int
+            Type: 93 ArrayType [2]map[string]int
             Operations:
                 - __kind: LocationOp
                   Variable: {subprogram: 53, index: 0, name: m}
@@ -3612,7 +3612,7 @@ Types:
         - Name: c
           Offset: 1
           Expression:
-            Type: 167 GoChannelType chan bool
+            Type: 130 GoChannelType chan bool
             Operations:
                 - __kind: LocationOp
                   Variable: {subprogram: 69, index: 0, name: c}
@@ -3660,7 +3660,7 @@ Types:
         - Name: t
           Offset: 1
           Expression:
-            Type: 170 PointerType *main.t
+            Type: 135 PointerType *main.t
             Operations:
                 - __kind: LocationOp
                   Variable: {subprogram: 77, index: 0, name: t}
@@ -3675,7 +3675,7 @@ Types:
         - Name: xs
           Offset: 1
           Expression:
-            Type: 176 GoSliceHeaderType []main.structWithNoStrings
+            Type: 140 GoSliceHeaderType []main.structWithNoStrings
             Operations:
                 - __kind: LocationOp
                   Variable: {subprogram: 82, index: 0, name: xs}
@@ -3699,7 +3699,7 @@ Types:
         - Name: u
           Offset: 1
           Expression:
-            Type: 173 GoSliceHeaderType []uint
+            Type: 137 GoSliceHeaderType []uint
             Operations:
                 - __kind: LocationOp
                   Variable: {subprogram: 79, index: 0, name: u}
@@ -3729,7 +3729,7 @@ Types:
         - Name: e
           Offset: 1
           Expression:
-            Type: 186 StructureType main.emptyStruct
+            Type: 152 StructureType main.emptyStruct
             Operations:
                 - __kind: LocationOp
                   Variable: {subprogram: 98, index: 0, name: e}
@@ -3789,7 +3789,7 @@ Types:
         - Name: a
           Offset: 1
           Expression:
-            Type: 72 ArrayType [5]int
+            Type: 63 ArrayType [5]int
             Operations:
                 - __kind: LocationOp
                   Variable: {subprogram: 43, index: 0, name: a}
@@ -3915,7 +3915,7 @@ Types:
         - Name: a
           Offset: 1
           Expression:
-            Type: 72 ArrayType [5]int
+            Type: 63 ArrayType [5]int
             Operations:
                 - __kind: LocationOp
                   Variable: {subprogram: 104, index: 0, name: a}
@@ -4005,7 +4005,7 @@ Types:
         - Name: b
           Offset: 1
           Expression:
-            Type: 73 GoInterfaceType main.behavior
+            Type: 64 GoInterfaceType main.behavior
             Operations:
                 - __kind: LocationOp
                   Variable: {subprogram: 44, index: 0, name: b}
@@ -4020,7 +4020,7 @@ Types:
         - Name: a
           Offset: 1
           Expression:
-            Type: 135 StructureType main.node
+            Type: 133 StructureType main.node
             Operations:
                 - __kind: LocationOp
                   Variable: {subprogram: 71, index: 0, name: a}
@@ -4035,7 +4035,7 @@ Types:
         - Name: m
           Offset: 1
           Expression:
-            Type: 110 GoMapType map[[4]string][2]int
+            Type: 88 GoMapType map[[4]string][2]int
             Operations:
                 - __kind: LocationOp
                   Variable: {subprogram: 51, index: 0, name: m}
@@ -4050,7 +4050,7 @@ Types:
         - Name: m
           Offset: 1
           Expression:
-            Type: 120 GoMapType map[string][]main.structWithMap
+            Type: 95 GoMapType map[string][]main.structWithMap
             Operations:
                 - __kind: LocationOp
                   Variable: {subprogram: 57, index: 0, name: m}
@@ -4065,7 +4065,7 @@ Types:
         - Name: m
           Offset: 1
           Expression:
-            Type: 75 GoMapType map[int]int
+            Type: 66 GoMapType map[int]int
             Operations:
                 - __kind: LocationOp
                   Variable: {subprogram: 55, index: 0, name: m}
@@ -4080,7 +4080,7 @@ Types:
         - Name: m
           Offset: 1
           Expression:
-            Type: 162 GoMapType map[[4]int][4]int
+            Type: 125 GoMapType map[[4]int][4]int
             Operations:
                 - __kind: LocationOp
                   Variable: {subprogram: 66, index: 0, name: m}
@@ -4095,7 +4095,7 @@ Types:
         - Name: m
           Offset: 1
           Expression:
-            Type: 156 GoMapType map[[4]int]uint8
+            Type: 120 GoMapType map[[4]int]uint8
             Operations:
                 - __kind: LocationOp
                   Variable: {subprogram: 65, index: 0, name: m}
@@ -4110,7 +4110,7 @@ Types:
         - Name: redactMyEntries
           Offset: 1
           Expression:
-            Type: 120 GoMapType map[string][]main.structWithMap
+            Type: 95 GoMapType map[string][]main.structWithMap
             Operations:
                 - __kind: LocationOp
                   Variable: {subprogram: 56, index: 0, name: redactMyEntries}
@@ -4125,7 +4125,7 @@ Types:
         - Name: m
           Offset: 1
           Expression:
-            Type: 149 GoMapType map[uint8][4]int
+            Type: 115 GoMapType map[uint8][4]int
             Operations:
                 - __kind: LocationOp
                   Variable: {subprogram: 64, index: 0, name: m}
@@ -4140,7 +4140,7 @@ Types:
         - Name: m
           Offset: 1
           Expression:
-            Type: 143 GoMapType map[uint8]uint8
+            Type: 110 GoMapType map[uint8]uint8
             Operations:
                 - __kind: LocationOp
                   Variable: {subprogram: 63, index: 0, name: m}
@@ -4155,7 +4155,7 @@ Types:
         - Name: m
           Offset: 1
           Expression:
-            Type: 98 GoMapType map[string]int
+            Type: 78 GoMapType map[string]int
             Operations:
                 - __kind: LocationOp
                   Variable: {subprogram: 49, index: 0, name: m}
@@ -4170,7 +4170,7 @@ Types:
         - Name: m
           Offset: 1
           Expression:
-            Type: 103 GoMapType map[string][]string
+            Type: 83 GoMapType map[string][]string
             Operations:
                 - __kind: LocationOp
                   Variable: {subprogram: 50, index: 0, name: m}
@@ -4185,7 +4185,7 @@ Types:
         - Name: m
           Offset: 1
           Expression:
-            Type: 90 GoMapType map[string]main.nestedStruct
+            Type: 73 GoMapType map[string]main.nestedStruct
             Operations:
                 - __kind: LocationOp
                   Variable: {subprogram: 48, index: 0, name: m}
@@ -4200,7 +4200,7 @@ Types:
         - Name: m
           Offset: 1
           Expression:
-            Type: 128 GoMapType map[bool]main.node
+            Type: 100 GoMapType map[bool]main.node
             Operations:
                 - __kind: LocationOp
                   Variable: {subprogram: 58, index: 0, name: m}
@@ -4215,7 +4215,7 @@ Types:
         - Name: m
           Offset: 1
           Expression:
-            Type: 143 GoMapType map[uint8]uint8
+            Type: 110 GoMapType map[uint8]uint8
             Operations:
                 - __kind: LocationOp
                   Variable: {subprogram: 62, index: 0, name: m}
@@ -4230,7 +4230,7 @@ Types:
         - Name: m
           Offset: 1
           Expression:
-            Type: 143 GoMapType map[uint8]uint8
+            Type: 110 GoMapType map[uint8]uint8
             Operations:
                 - __kind: LocationOp
                   Variable: {subprogram: 61, index: 0, name: m}
@@ -4245,7 +4245,7 @@ Types:
         - Name: redactMyEntries
           Offset: 1
           Expression:
-            Type: 137 GoMapType map[int]uint8
+            Type: 105 GoMapType map[int]uint8
             Operations:
                 - __kind: LocationOp
                   Variable: {subprogram: 60, index: 0, name: redactMyEntries}
@@ -4260,7 +4260,7 @@ Types:
         - Name: m
           Offset: 1
           Expression:
-            Type: 137 GoMapType map[int]uint8
+            Type: 105 GoMapType map[int]uint8
             Operations:
                 - __kind: LocationOp
                   Variable: {subprogram: 59, index: 0, name: m}
@@ -4365,7 +4365,7 @@ Types:
         - Name: xs
           Offset: 1
           Expression:
-            Type: 176 GoSliceHeaderType []main.structWithNoStrings
+            Type: 140 GoSliceHeaderType []main.structWithNoStrings
             Operations:
                 - __kind: LocationOp
                   Variable: {subprogram: 83, index: 0, name: xs}
@@ -4398,7 +4398,7 @@ Types:
         - Name: s
           Offset: 2
           Expression:
-            Type: 179 GoSliceHeaderType []bool
+            Type: 144 GoSliceHeaderType []bool
             Operations:
                 - __kind: LocationOp
                   Variable: {subprogram: 85, index: 1, name: s}
@@ -4422,7 +4422,7 @@ Types:
         - Name: xs
           Offset: 1
           Expression:
-            Type: 180 GoSliceHeaderType []uint16
+            Type: 145 GoSliceHeaderType []uint16
             Operations:
                 - __kind: LocationOp
                   Variable: {subprogram: 86, index: 0, name: xs}
@@ -4437,7 +4437,7 @@ Types:
         - Name: a
           Offset: 1
           Expression:
-            Type: 183 PointerType *main.oneStringStruct
+            Type: 148 PointerType *main.oneStringStruct
             Operations:
                 - __kind: LocationOp
                   Variable: {subprogram: 93, index: 0, name: a}
@@ -4452,7 +4452,7 @@ Types:
         - Name: a
           Offset: 1
           Expression:
-            Type: 136 PointerType *main.node
+            Type: 134 PointerType *main.node
             Operations:
                 - __kind: LocationOp
                   Variable: {subprogram: 72, index: 0, name: a}
@@ -4467,7 +4467,7 @@ Types:
         - Name: m
           Offset: 1
           Expression:
-            Type: 119 PointerType *map[string]int
+            Type: 94 PointerType *map[string]int
             Operations:
                 - __kind: LocationOp
                   Variable: {subprogram: 54, index: 0, name: m}
@@ -4482,7 +4482,7 @@ Types:
         - Name: a
           Offset: 1
           Expression:
-            Type: 168 PointerType *main.structWithTwoValues
+            Type: 131 PointerType *main.structWithTwoValues
             Operations:
                 - __kind: LocationOp
                   Variable: {subprogram: 70, index: 0, name: a}
@@ -4752,7 +4752,7 @@ Types:
         - Name: u
           Offset: 1
           Expression:
-            Type: 174 GoSliceHeaderType [][]uint
+            Type: 138 GoSliceHeaderType [][]uint
             Operations:
                 - __kind: LocationOp
                   Variable: {subprogram: 80, index: 0, name: u}
@@ -4767,7 +4767,7 @@ Types:
         - Name: m
           Offset: 1
           Expression:
-            Type: 98 GoMapType map[string]int
+            Type: 78 GoMapType map[string]int
             Operations:
                 - __kind: LocationOp
                   Variable: {subprogram: 52, index: 0, name: m}
@@ -4812,7 +4812,7 @@ Types:
         - Name: s
           Offset: 1
           Expression:
-            Type: 109 GoSliceHeaderType []string
+            Type: 143 GoSliceHeaderType []string
             Operations:
                 - __kind: LocationOp
                   Variable: {subprogram: 84, index: 0, name: s}
@@ -4827,7 +4827,7 @@ Types:
         - Name: xs
           Offset: 1
           Expression:
-            Type: 176 GoSliceHeaderType []main.structWithNoStrings
+            Type: 140 GoSliceHeaderType []main.structWithNoStrings
             Operations:
                 - __kind: LocationOp
                   Variable: {subprogram: 81, index: 0, name: xs}
@@ -4851,7 +4851,7 @@ Types:
         - Name: s
           Offset: 1
           Expression:
-            Type: 74 StructureType main.structWithMap
+            Type: 65 StructureType main.structWithMap
             Operations:
                 - __kind: LocationOp
                   Variable: {subprogram: 47, index: 0, name: s}
@@ -4866,7 +4866,7 @@ Types:
         - Name: x
           Offset: 1
           Expression:
-            Type: 185 StructureType main.aStruct
+            Type: 150 StructureType main.aStruct
             Operations:
                 - __kind: LocationOp
                   Variable: {subprogram: 97, index: 0, name: x}
@@ -4881,7 +4881,7 @@ Types:
         - Name: a
           Offset: 1
           Expression:
-            Type: 182 PointerType *main.threeStringStruct
+            Type: 147 PointerType *main.threeStringStruct
             Operations:
                 - __kind: LocationOp
                   Variable: {subprogram: 92, index: 0, name: a}
@@ -4896,7 +4896,7 @@ Types:
         - Name: a
           Offset: 1
           Expression:
-            Type: 181 StructureType main.threeStringStruct
+            Type: 146 StructureType main.threeStringStruct
             Operations:
                 - __kind: LocationOp
                   Variable: {subprogram: 91, index: 0, name: a}
@@ -5049,7 +5049,7 @@ Types:
         - Name: u
           Offset: 1
           Expression:
-            Type: 173 GoSliceHeaderType []uint
+            Type: 137 GoSliceHeaderType []uint
             Operations:
                 - __kind: LocationOp
                   Variable: {subprogram: 78, index: 0, name: u}
@@ -5109,7 +5109,7 @@ Types:
         - Name: xs
           Offset: 1
           Expression:
-            Type: 173 GoSliceHeaderType []uint
+            Type: 137 GoSliceHeaderType []uint
             Operations:
                 - __kind: LocationOp
                   Variable: {subprogram: 87, index: 0, name: xs}
@@ -5190,13 +5190,13 @@ Types:
       HasCount: true
       Element: 14 BaseType int8
     - __kind: ArrayType
-      ID: 118
+      ID: 93
       Name: '[2]map[string]int'
       ByteSize: 16
       GoKind: 17
       Count: 2
       HasCount: true
-      Element: 98 GoMapType map[string]int
+      Element: 78 GoMapType map[string]int
     - __kind: ArrayType
       ID: 38
       Name: '[2]string'
@@ -5249,7 +5249,7 @@ Types:
       HasCount: true
       Element: 3 BaseType uint8
     - __kind: ArrayType
-      ID: 155
+      ID: 183
       Name: '[4]int'
       ByteSize: 32
       GoRuntimeType: 617344
@@ -5258,7 +5258,7 @@ Types:
       HasCount: true
       Element: 9 BaseType int
     - __kind: ArrayType
-      ID: 116
+      ID: 173
       Name: '[4]string'
       ByteSize: 64
       GoRuntimeType: 617632
@@ -5267,7 +5267,7 @@ Types:
       HasCount: true
       Element: 11 GoStringHeaderType string
     - __kind: ArrayType
-      ID: 72
+      ID: 63
       Name: '[5]int'
       ByteSize: 40
       GoKind: 17
@@ -5275,7 +5275,7 @@ Types:
       HasCount: true
       Element: 9 BaseType int
     - __kind: ArrayType
-      ID: 80
+      ID: 162
       Name: '[8]uint8'
       ByteSize: 8
       GoRuntimeType: 615424
@@ -5284,7 +5284,7 @@ Types:
       HasCount: true
       Element: 3 BaseType uint8
     - __kind: GoSliceHeaderType
-      ID: 86
+      ID: 166
       Name: '[]*runtime.bmap'
       ByteSize: 24
       GoRuntimeType: 451616
@@ -5292,19 +5292,19 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 87 PointerType **runtime.bmap
+          Type: 186 PointerType **runtime.bmap
         - Name: len
           Offset: 8
           Type: 9 BaseType int
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 192 GoSliceDataType []*runtime.bmap.array
+      Data: 217 GoSliceDataType []*runtime.bmap.array
     - __kind: GoSliceDataType
-      ID: 192
+      ID: 217
       Name: '[]*runtime.bmap.array'
       ByteSize: 2048
-      Element: 88 PointerType *runtime.bmap
+      Element: 167 PointerType *runtime.bmap
     - __kind: GoSliceHeaderType
       ID: 53
       Name: '[]*string'
@@ -5328,28 +5328,28 @@ Types:
       ByteSize: 2048
       Element: 22 PointerType *string
     - __kind: GoSliceHeaderType
-      ID: 174
+      ID: 138
       Name: '[][]uint'
       ByteSize: 24
       GoKind: 23
       RawFields:
         - Name: array
           Offset: 0
-          Type: 175 PointerType *[]uint
+          Type: 139 PointerType *[]uint
         - Name: len
           Offset: 8
           Type: 9 BaseType int
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 213 GoSliceDataType [][]uint.array
+      Data: 207 GoSliceDataType [][]uint.array
     - __kind: GoSliceDataType
-      ID: 213
+      ID: 207
       Name: '[][]uint.array'
       ByteSize: 2048
-      Element: 173 GoSliceHeaderType []uint
+      Element: 137 GoSliceHeaderType []uint
     - __kind: GoSliceHeaderType
-      ID: 179
+      ID: 144
       Name: '[]bool'
       ByteSize: 24
       GoRuntimeType: 449760
@@ -5364,116 +5364,116 @@ Types:
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 217 GoSliceDataType []bool.array
+      Data: 213 GoSliceDataType []bool.array
     - __kind: GoSliceDataType
-      ID: 217
+      ID: 213
       Name: '[]bool.array'
       ByteSize: 2048
       Element: 4 BaseType bool
     - __kind: GoSliceDataType
-      ID: 208
+      ID: 202
       Name: '[]bucket<[4]int,[4]int>.array'
       ByteSize: 2048
-      Element: 166 GoHMapBucketType bucket<[4]int,[4]int>
+      Element: 129 GoHMapBucketType bucket<[4]int,[4]int>
     - __kind: GoSliceDataType
-      ID: 207
+      ID: 201
       Name: '[]bucket<[4]int,uint8>.array'
       ByteSize: 2048
-      Element: 160 GoHMapBucketType bucket<[4]int,uint8>
+      Element: 124 GoHMapBucketType bucket<[4]int,uint8>
     - __kind: GoSliceDataType
-      ID: 199
+      ID: 195
       Name: '[]bucket<[4]string,[2]int>.array'
       ByteSize: 2048
-      Element: 114 GoHMapBucketType bucket<[4]string,[2]int>
+      Element: 92 GoHMapBucketType bucket<[4]string,[2]int>
     - __kind: GoSliceDataType
-      ID: 203
+      ID: 197
       Name: '[]bucket<bool,main.node>.array'
       ByteSize: 2048
-      Element: 132 GoHMapBucketType bucket<bool,main.node>
+      Element: 104 GoHMapBucketType bucket<bool,main.node>
     - __kind: GoSliceDataType
       ID: 191
       Name: '[]bucket<int,int>.array'
       ByteSize: 2048
-      Element: 79 GoHMapBucketType bucket<int,int>
+      Element: 70 GoHMapBucketType bucket<int,int>
     - __kind: GoSliceDataType
-      ID: 204
+      ID: 198
       Name: '[]bucket<int,uint8>.array'
       ByteSize: 2048
-      Element: 141 GoHMapBucketType bucket<int,uint8>
-    - __kind: GoSliceDataType
-      ID: 200
-      Name: '[]bucket<string,[]main.structWithMap>.array'
-      ByteSize: 2048
-      Element: 124 GoHMapBucketType bucket<string,[]main.structWithMap>
+      Element: 109 GoHMapBucketType bucket<int,uint8>
     - __kind: GoSliceDataType
       ID: 196
-      Name: '[]bucket<string,[]string>.array'
+      Name: '[]bucket<string,[]main.structWithMap>.array'
       ByteSize: 2048
-      Element: 107 GoHMapBucketType bucket<string,[]string>
-    - __kind: GoSliceDataType
-      ID: 195
-      Name: '[]bucket<string,int>.array'
-      ByteSize: 2048
-      Element: 102 GoHMapBucketType bucket<string,int>
+      Element: 99 GoHMapBucketType bucket<string,[]main.structWithMap>
     - __kind: GoSliceDataType
       ID: 194
+      Name: '[]bucket<string,[]string>.array'
+      ByteSize: 2048
+      Element: 87 GoHMapBucketType bucket<string,[]string>
+    - __kind: GoSliceDataType
+      ID: 193
+      Name: '[]bucket<string,int>.array'
+      ByteSize: 2048
+      Element: 82 GoHMapBucketType bucket<string,int>
+    - __kind: GoSliceDataType
+      ID: 192
       Name: '[]bucket<string,main.nestedStruct>.array'
       ByteSize: 2048
-      Element: 94 GoHMapBucketType bucket<string,main.nestedStruct>
+      Element: 77 GoHMapBucketType bucket<string,main.nestedStruct>
     - __kind: GoSliceDataType
-      ID: 206
+      ID: 200
       Name: '[]bucket<uint8,[4]int>.array'
       ByteSize: 2048
-      Element: 153 GoHMapBucketType bucket<uint8,[4]int>
+      Element: 119 GoHMapBucketType bucket<uint8,[4]int>
     - __kind: GoSliceDataType
-      ID: 205
+      ID: 199
       Name: '[]bucket<uint8,uint8>.array'
       ByteSize: 2048
-      Element: 147 GoHMapBucketType bucket<uint8,uint8>
+      Element: 114 GoHMapBucketType bucket<uint8,uint8>
     - __kind: ArrayType
-      ID: 161
+      ID: 184
       Name: '[]key<[4]int>'
       ByteSize: 256
       Count: 8
       HasCount: true
-      Element: 155 ArrayType [4]int
+      Element: 183 ArrayType [4]int
     - __kind: ArrayType
-      ID: 115
+      ID: 172
       Name: '[]key<[4]string>'
       ByteSize: 512
       Count: 8
       HasCount: true
-      Element: 116 ArrayType [4]string
+      Element: 173 ArrayType [4]string
     - __kind: ArrayType
-      ID: 133
+      ID: 178
       Name: '[]key<bool>'
       ByteSize: 8
       Count: 8
       HasCount: true
       Element: 4 BaseType bool
     - __kind: ArrayType
-      ID: 81
+      ID: 163
       Name: '[]key<int>'
       ByteSize: 64
       Count: 8
       HasCount: true
       Element: 9 BaseType int
     - __kind: ArrayType
-      ID: 95
+      ID: 169
       Name: '[]key<string>'
       ByteSize: 128
       Count: 8
       HasCount: true
       Element: 11 GoStringHeaderType string
     - __kind: ArrayType
-      ID: 148
+      ID: 181
       Name: '[]key<uint8>'
       ByteSize: 8
       Count: 8
       HasCount: true
       Element: 3 BaseType uint8
     - __kind: GoSliceHeaderType
-      ID: 126
+      ID: 176
       Name: '[]main.structWithMap'
       ByteSize: 24
       GoRuntimeType: 442720
@@ -5481,42 +5481,42 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 127 PointerType *main.structWithMap
+          Type: 177 PointerType *main.structWithMap
         - Name: len
           Offset: 8
           Type: 9 BaseType int
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 201 GoSliceDataType []main.structWithMap.array
+      Data: 219 GoSliceDataType []main.structWithMap.array
     - __kind: GoSliceDataType
-      ID: 201
+      ID: 219
       Name: '[]main.structWithMap.array'
       ByteSize: 2048
-      Element: 74 StructureType main.structWithMap
+      Element: 65 StructureType main.structWithMap
     - __kind: GoSliceHeaderType
-      ID: 176
+      ID: 140
       Name: '[]main.structWithNoStrings'
       ByteSize: 24
       GoKind: 23
       RawFields:
         - Name: array
           Offset: 0
-          Type: 177 PointerType *main.structWithNoStrings
+          Type: 141 PointerType *main.structWithNoStrings
         - Name: len
           Offset: 8
           Type: 9 BaseType int
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 215 GoSliceDataType []main.structWithNoStrings.array
+      Data: 209 GoSliceDataType []main.structWithNoStrings.array
     - __kind: GoSliceDataType
-      ID: 215
+      ID: 209
       Name: '[]main.structWithNoStrings.array'
       ByteSize: 2048
-      Element: 178 StructureType main.structWithNoStrings
+      Element: 142 StructureType main.structWithNoStrings
     - __kind: GoSliceHeaderType
-      ID: 109
+      ID: 143
       Name: '[]string'
       ByteSize: 24
       GoRuntimeType: 449888
@@ -5531,14 +5531,14 @@ Types:
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 197 GoSliceDataType []string.array
+      Data: 211 GoSliceDataType []string.array
     - __kind: GoSliceDataType
-      ID: 197
+      ID: 211
       Name: '[]string.array'
       ByteSize: 2048
       Element: 11 GoStringHeaderType string
     - __kind: GoSliceHeaderType
-      ID: 173
+      ID: 137
       Name: '[]uint'
       ByteSize: 24
       GoRuntimeType: 449376
@@ -5553,14 +5553,14 @@ Types:
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 211 GoSliceDataType []uint.array
+      Data: 205 GoSliceDataType []uint.array
     - __kind: GoSliceDataType
-      ID: 211
+      ID: 205
       Name: '[]uint.array'
       ByteSize: 2048
       Element: 15 BaseType uint
     - __kind: GoSliceHeaderType
-      ID: 180
+      ID: 145
       Name: '[]uint16'
       ByteSize: 24
       GoRuntimeType: 448736
@@ -5575,63 +5575,63 @@ Types:
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 219 GoSliceDataType []uint16.array
+      Data: 215 GoSliceDataType []uint16.array
     - __kind: GoSliceDataType
-      ID: 219
+      ID: 215
       Name: '[]uint16.array'
       ByteSize: 2048
       Element: 7 BaseType uint16
     - __kind: ArrayType
-      ID: 117
+      ID: 174
       Name: '[]val<[2]int>'
       ByteSize: 128
       Count: 8
       HasCount: true
       Element: 40 ArrayType [2]int
     - __kind: ArrayType
-      ID: 154
+      ID: 182
       Name: '[]val<[4]int>'
       ByteSize: 256
       Count: 8
       HasCount: true
-      Element: 155 ArrayType [4]int
+      Element: 183 ArrayType [4]int
     - __kind: ArrayType
-      ID: 125
+      ID: 175
       Name: '[]val<[]main.structWithMap>'
       ByteSize: 192
       Count: 8
       HasCount: true
-      Element: 126 GoSliceHeaderType []main.structWithMap
+      Element: 176 GoSliceHeaderType []main.structWithMap
     - __kind: ArrayType
-      ID: 108
+      ID: 171
       Name: '[]val<[]string>'
       ByteSize: 192
       Count: 8
       HasCount: true
-      Element: 109 GoSliceHeaderType []string
+      Element: 143 GoSliceHeaderType []string
     - __kind: ArrayType
-      ID: 82
+      ID: 164
       Name: '[]val<int>'
       ByteSize: 64
       Count: 8
       HasCount: true
       Element: 9 BaseType int
     - __kind: ArrayType
-      ID: 96
+      ID: 170
       Name: '[]val<main.nestedStruct>'
       ByteSize: 192
       Count: 8
       HasCount: true
-      Element: 97 StructureType main.nestedStruct
+      Element: 151 StructureType main.nestedStruct
     - __kind: ArrayType
-      ID: 134
+      ID: 179
       Name: '[]val<main.node>'
       ByteSize: 128
       Count: 8
       HasCount: true
-      Element: 135 StructureType main.node
+      Element: 133 StructureType main.node
     - __kind: ArrayType
-      ID: 142
+      ID: 180
       Name: '[]val<uint8>'
       ByteSize: 8
       Count: 8
@@ -5644,235 +5644,235 @@ Types:
       GoRuntimeType: 527872
       GoKind: 1
     - __kind: GoHMapBucketType
-      ID: 166
+      ID: 129
       Name: bucket<[4]int,[4]int>
       ByteSize: 528
       RawFields:
         - Name: tophash
           Offset: 0
-          Type: 80 ArrayType [8]uint8
+          Type: 162 ArrayType [8]uint8
         - Name: keys
           Offset: 8
-          Type: 161 ArrayType []key<[4]int>
+          Type: 184 ArrayType []key<[4]int>
         - Name: values
           Offset: 264
-          Type: 154 ArrayType []val<[4]int>
+          Type: 182 ArrayType []val<[4]int>
         - Name: overflow
           Offset: 520
-          Type: 165 PointerType *bucket<[4]int,[4]int>
-      KeyType: 155 ArrayType [4]int
-      ValueType: 155 ArrayType [4]int
+          Type: 128 PointerType *bucket<[4]int,[4]int>
+      KeyType: 183 ArrayType [4]int
+      ValueType: 183 ArrayType [4]int
     - __kind: GoHMapBucketType
-      ID: 160
+      ID: 124
       Name: bucket<[4]int,uint8>
       ByteSize: 280
       RawFields:
         - Name: tophash
           Offset: 0
-          Type: 80 ArrayType [8]uint8
+          Type: 162 ArrayType [8]uint8
         - Name: keys
           Offset: 8
-          Type: 161 ArrayType []key<[4]int>
+          Type: 184 ArrayType []key<[4]int>
         - Name: values
           Offset: 264
-          Type: 142 ArrayType []val<uint8>
+          Type: 180 ArrayType []val<uint8>
         - Name: overflow
           Offset: 272
-          Type: 159 PointerType *bucket<[4]int,uint8>
-      KeyType: 155 ArrayType [4]int
+          Type: 123 PointerType *bucket<[4]int,uint8>
+      KeyType: 183 ArrayType [4]int
       ValueType: 3 BaseType uint8
     - __kind: GoHMapBucketType
-      ID: 114
+      ID: 92
       Name: bucket<[4]string,[2]int>
       ByteSize: 656
       RawFields:
         - Name: tophash
           Offset: 0
-          Type: 80 ArrayType [8]uint8
+          Type: 162 ArrayType [8]uint8
         - Name: keys
           Offset: 8
-          Type: 115 ArrayType []key<[4]string>
+          Type: 172 ArrayType []key<[4]string>
         - Name: values
           Offset: 520
-          Type: 117 ArrayType []val<[2]int>
+          Type: 174 ArrayType []val<[2]int>
         - Name: overflow
           Offset: 648
-          Type: 113 PointerType *bucket<[4]string,[2]int>
-      KeyType: 116 ArrayType [4]string
+          Type: 91 PointerType *bucket<[4]string,[2]int>
+      KeyType: 173 ArrayType [4]string
       ValueType: 40 ArrayType [2]int
     - __kind: GoHMapBucketType
-      ID: 132
+      ID: 104
       Name: bucket<bool,main.node>
       ByteSize: 152
       RawFields:
         - Name: tophash
           Offset: 0
-          Type: 80 ArrayType [8]uint8
+          Type: 162 ArrayType [8]uint8
         - Name: keys
           Offset: 8
-          Type: 133 ArrayType []key<bool>
+          Type: 178 ArrayType []key<bool>
         - Name: values
           Offset: 16
-          Type: 134 ArrayType []val<main.node>
+          Type: 179 ArrayType []val<main.node>
         - Name: overflow
           Offset: 144
-          Type: 131 PointerType *bucket<bool,main.node>
+          Type: 103 PointerType *bucket<bool,main.node>
       KeyType: 4 BaseType bool
-      ValueType: 135 StructureType main.node
+      ValueType: 133 StructureType main.node
     - __kind: GoHMapBucketType
-      ID: 79
+      ID: 70
       Name: bucket<int,int>
       ByteSize: 144
       RawFields:
         - Name: tophash
           Offset: 0
-          Type: 80 ArrayType [8]uint8
+          Type: 162 ArrayType [8]uint8
         - Name: keys
           Offset: 8
-          Type: 81 ArrayType []key<int>
+          Type: 163 ArrayType []key<int>
         - Name: values
           Offset: 72
-          Type: 82 ArrayType []val<int>
+          Type: 164 ArrayType []val<int>
         - Name: overflow
           Offset: 136
-          Type: 78 PointerType *bucket<int,int>
+          Type: 69 PointerType *bucket<int,int>
       KeyType: 9 BaseType int
       ValueType: 9 BaseType int
     - __kind: GoHMapBucketType
-      ID: 141
+      ID: 109
       Name: bucket<int,uint8>
       ByteSize: 88
       RawFields:
         - Name: tophash
           Offset: 0
-          Type: 80 ArrayType [8]uint8
+          Type: 162 ArrayType [8]uint8
         - Name: keys
           Offset: 8
-          Type: 81 ArrayType []key<int>
+          Type: 163 ArrayType []key<int>
         - Name: values
           Offset: 72
-          Type: 142 ArrayType []val<uint8>
+          Type: 180 ArrayType []val<uint8>
         - Name: overflow
           Offset: 80
-          Type: 140 PointerType *bucket<int,uint8>
+          Type: 108 PointerType *bucket<int,uint8>
       KeyType: 9 BaseType int
       ValueType: 3 BaseType uint8
     - __kind: GoHMapBucketType
-      ID: 124
+      ID: 99
       Name: bucket<string,[]main.structWithMap>
       ByteSize: 336
       RawFields:
         - Name: tophash
           Offset: 0
-          Type: 80 ArrayType [8]uint8
+          Type: 162 ArrayType [8]uint8
         - Name: keys
           Offset: 8
-          Type: 95 ArrayType []key<string>
+          Type: 169 ArrayType []key<string>
         - Name: values
           Offset: 136
-          Type: 125 ArrayType []val<[]main.structWithMap>
+          Type: 175 ArrayType []val<[]main.structWithMap>
         - Name: overflow
           Offset: 328
-          Type: 123 PointerType *bucket<string,[]main.structWithMap>
+          Type: 98 PointerType *bucket<string,[]main.structWithMap>
       KeyType: 11 GoStringHeaderType string
-      ValueType: 126 GoSliceHeaderType []main.structWithMap
+      ValueType: 176 GoSliceHeaderType []main.structWithMap
     - __kind: GoHMapBucketType
-      ID: 107
+      ID: 87
       Name: bucket<string,[]string>
       ByteSize: 336
       RawFields:
         - Name: tophash
           Offset: 0
-          Type: 80 ArrayType [8]uint8
+          Type: 162 ArrayType [8]uint8
         - Name: keys
           Offset: 8
-          Type: 95 ArrayType []key<string>
+          Type: 169 ArrayType []key<string>
         - Name: values
           Offset: 136
-          Type: 108 ArrayType []val<[]string>
+          Type: 171 ArrayType []val<[]string>
         - Name: overflow
           Offset: 328
-          Type: 106 PointerType *bucket<string,[]string>
+          Type: 86 PointerType *bucket<string,[]string>
       KeyType: 11 GoStringHeaderType string
-      ValueType: 109 GoSliceHeaderType []string
+      ValueType: 143 GoSliceHeaderType []string
     - __kind: GoHMapBucketType
-      ID: 102
+      ID: 82
       Name: bucket<string,int>
       ByteSize: 208
       RawFields:
         - Name: tophash
           Offset: 0
-          Type: 80 ArrayType [8]uint8
+          Type: 162 ArrayType [8]uint8
         - Name: keys
           Offset: 8
-          Type: 95 ArrayType []key<string>
+          Type: 169 ArrayType []key<string>
         - Name: values
           Offset: 136
-          Type: 82 ArrayType []val<int>
+          Type: 164 ArrayType []val<int>
         - Name: overflow
           Offset: 200
-          Type: 101 PointerType *bucket<string,int>
+          Type: 81 PointerType *bucket<string,int>
       KeyType: 11 GoStringHeaderType string
       ValueType: 9 BaseType int
     - __kind: GoHMapBucketType
-      ID: 94
+      ID: 77
       Name: bucket<string,main.nestedStruct>
       ByteSize: 336
       RawFields:
         - Name: tophash
           Offset: 0
-          Type: 80 ArrayType [8]uint8
+          Type: 162 ArrayType [8]uint8
         - Name: keys
           Offset: 8
-          Type: 95 ArrayType []key<string>
+          Type: 169 ArrayType []key<string>
         - Name: values
           Offset: 136
-          Type: 96 ArrayType []val<main.nestedStruct>
+          Type: 170 ArrayType []val<main.nestedStruct>
         - Name: overflow
           Offset: 328
-          Type: 93 PointerType *bucket<string,main.nestedStruct>
+          Type: 76 PointerType *bucket<string,main.nestedStruct>
       KeyType: 11 GoStringHeaderType string
-      ValueType: 97 StructureType main.nestedStruct
+      ValueType: 151 StructureType main.nestedStruct
     - __kind: GoHMapBucketType
-      ID: 153
+      ID: 119
       Name: bucket<uint8,[4]int>
       ByteSize: 280
       RawFields:
         - Name: tophash
           Offset: 0
-          Type: 80 ArrayType [8]uint8
+          Type: 162 ArrayType [8]uint8
         - Name: keys
           Offset: 8
-          Type: 148 ArrayType []key<uint8>
+          Type: 181 ArrayType []key<uint8>
         - Name: values
           Offset: 16
-          Type: 154 ArrayType []val<[4]int>
+          Type: 182 ArrayType []val<[4]int>
         - Name: overflow
           Offset: 272
-          Type: 152 PointerType *bucket<uint8,[4]int>
+          Type: 118 PointerType *bucket<uint8,[4]int>
       KeyType: 3 BaseType uint8
-      ValueType: 155 ArrayType [4]int
+      ValueType: 183 ArrayType [4]int
     - __kind: GoHMapBucketType
-      ID: 147
+      ID: 114
       Name: bucket<uint8,uint8>
       ByteSize: 32
       RawFields:
         - Name: tophash
           Offset: 0
-          Type: 80 ArrayType [8]uint8
+          Type: 162 ArrayType [8]uint8
         - Name: keys
           Offset: 8
-          Type: 148 ArrayType []key<uint8>
+          Type: 181 ArrayType []key<uint8>
         - Name: values
           Offset: 16
-          Type: 142 ArrayType []val<uint8>
+          Type: 180 ArrayType []val<uint8>
         - Name: overflow
           Offset: 24
-          Type: 146 PointerType *bucket<uint8,uint8>
+          Type: 113 PointerType *bucket<uint8,uint8>
       KeyType: 3 BaseType uint8
       ValueType: 3 BaseType uint8
     - __kind: GoChannelType
-      ID: 167
+      ID: 130
       Name: chan bool
       GoRuntimeType: 539136
       GoKind: 18
@@ -5925,7 +5925,7 @@ Types:
       GoRuntimeType: 441824
       GoKind: 19
     - __kind: GoHMapHeaderType
-      ID: 164
+      ID: 127
       Name: hash<[4]int,[4]int>
       ByteSize: 48
       RawFields:
@@ -5946,20 +5946,20 @@ Types:
           Type: 2 BaseType uint32
         - Name: buckets
           Offset: 16
-          Type: 165 PointerType *bucket<[4]int,[4]int>
+          Type: 128 PointerType *bucket<[4]int,[4]int>
         - Name: oldbuckets
           Offset: 24
-          Type: 165 PointerType *bucket<[4]int,[4]int>
+          Type: 128 PointerType *bucket<[4]int,[4]int>
         - Name: nevacuate
           Offset: 32
           Type: 1 BaseType uintptr
         - Name: extra
           Offset: 40
-          Type: 83 PointerType *runtime.mapextra
-      BucketType: 166 GoHMapBucketType bucket<[4]int,[4]int>
-      BucketsType: 208 GoSliceDataType []bucket<[4]int,[4]int>.array
+          Type: 71 PointerType *runtime.mapextra
+      BucketType: 129 GoHMapBucketType bucket<[4]int,[4]int>
+      BucketsType: 202 GoSliceDataType []bucket<[4]int,[4]int>.array
     - __kind: GoHMapHeaderType
-      ID: 158
+      ID: 122
       Name: hash<[4]int,uint8>
       ByteSize: 48
       RawFields:
@@ -5980,20 +5980,20 @@ Types:
           Type: 2 BaseType uint32
         - Name: buckets
           Offset: 16
-          Type: 159 PointerType *bucket<[4]int,uint8>
+          Type: 123 PointerType *bucket<[4]int,uint8>
         - Name: oldbuckets
           Offset: 24
-          Type: 159 PointerType *bucket<[4]int,uint8>
+          Type: 123 PointerType *bucket<[4]int,uint8>
         - Name: nevacuate
           Offset: 32
           Type: 1 BaseType uintptr
         - Name: extra
           Offset: 40
-          Type: 83 PointerType *runtime.mapextra
-      BucketType: 160 GoHMapBucketType bucket<[4]int,uint8>
-      BucketsType: 207 GoSliceDataType []bucket<[4]int,uint8>.array
+          Type: 71 PointerType *runtime.mapextra
+      BucketType: 124 GoHMapBucketType bucket<[4]int,uint8>
+      BucketsType: 201 GoSliceDataType []bucket<[4]int,uint8>.array
     - __kind: GoHMapHeaderType
-      ID: 112
+      ID: 90
       Name: hash<[4]string,[2]int>
       ByteSize: 48
       RawFields:
@@ -6014,20 +6014,20 @@ Types:
           Type: 2 BaseType uint32
         - Name: buckets
           Offset: 16
-          Type: 113 PointerType *bucket<[4]string,[2]int>
+          Type: 91 PointerType *bucket<[4]string,[2]int>
         - Name: oldbuckets
           Offset: 24
-          Type: 113 PointerType *bucket<[4]string,[2]int>
+          Type: 91 PointerType *bucket<[4]string,[2]int>
         - Name: nevacuate
           Offset: 32
           Type: 1 BaseType uintptr
         - Name: extra
           Offset: 40
-          Type: 83 PointerType *runtime.mapextra
-      BucketType: 114 GoHMapBucketType bucket<[4]string,[2]int>
-      BucketsType: 199 GoSliceDataType []bucket<[4]string,[2]int>.array
+          Type: 71 PointerType *runtime.mapextra
+      BucketType: 92 GoHMapBucketType bucket<[4]string,[2]int>
+      BucketsType: 195 GoSliceDataType []bucket<[4]string,[2]int>.array
     - __kind: GoHMapHeaderType
-      ID: 130
+      ID: 102
       Name: hash<bool,main.node>
       ByteSize: 48
       RawFields:
@@ -6048,20 +6048,20 @@ Types:
           Type: 2 BaseType uint32
         - Name: buckets
           Offset: 16
-          Type: 131 PointerType *bucket<bool,main.node>
+          Type: 103 PointerType *bucket<bool,main.node>
         - Name: oldbuckets
           Offset: 24
-          Type: 131 PointerType *bucket<bool,main.node>
+          Type: 103 PointerType *bucket<bool,main.node>
         - Name: nevacuate
           Offset: 32
           Type: 1 BaseType uintptr
         - Name: extra
           Offset: 40
-          Type: 83 PointerType *runtime.mapextra
-      BucketType: 132 GoHMapBucketType bucket<bool,main.node>
-      BucketsType: 203 GoSliceDataType []bucket<bool,main.node>.array
+          Type: 71 PointerType *runtime.mapextra
+      BucketType: 104 GoHMapBucketType bucket<bool,main.node>
+      BucketsType: 197 GoSliceDataType []bucket<bool,main.node>.array
     - __kind: GoHMapHeaderType
-      ID: 77
+      ID: 68
       Name: hash<int,int>
       ByteSize: 48
       RawFields:
@@ -6082,20 +6082,20 @@ Types:
           Type: 2 BaseType uint32
         - Name: buckets
           Offset: 16
-          Type: 78 PointerType *bucket<int,int>
+          Type: 69 PointerType *bucket<int,int>
         - Name: oldbuckets
           Offset: 24
-          Type: 78 PointerType *bucket<int,int>
+          Type: 69 PointerType *bucket<int,int>
         - Name: nevacuate
           Offset: 32
           Type: 1 BaseType uintptr
         - Name: extra
           Offset: 40
-          Type: 83 PointerType *runtime.mapextra
-      BucketType: 79 GoHMapBucketType bucket<int,int>
+          Type: 71 PointerType *runtime.mapextra
+      BucketType: 70 GoHMapBucketType bucket<int,int>
       BucketsType: 191 GoSliceDataType []bucket<int,int>.array
     - __kind: GoHMapHeaderType
-      ID: 139
+      ID: 107
       Name: hash<int,uint8>
       ByteSize: 48
       RawFields:
@@ -6116,20 +6116,20 @@ Types:
           Type: 2 BaseType uint32
         - Name: buckets
           Offset: 16
-          Type: 140 PointerType *bucket<int,uint8>
+          Type: 108 PointerType *bucket<int,uint8>
         - Name: oldbuckets
           Offset: 24
-          Type: 140 PointerType *bucket<int,uint8>
+          Type: 108 PointerType *bucket<int,uint8>
         - Name: nevacuate
           Offset: 32
           Type: 1 BaseType uintptr
         - Name: extra
           Offset: 40
-          Type: 83 PointerType *runtime.mapextra
-      BucketType: 141 GoHMapBucketType bucket<int,uint8>
-      BucketsType: 204 GoSliceDataType []bucket<int,uint8>.array
+          Type: 71 PointerType *runtime.mapextra
+      BucketType: 109 GoHMapBucketType bucket<int,uint8>
+      BucketsType: 198 GoSliceDataType []bucket<int,uint8>.array
     - __kind: GoHMapHeaderType
-      ID: 122
+      ID: 97
       Name: hash<string,[]main.structWithMap>
       ByteSize: 48
       RawFields:
@@ -6150,20 +6150,20 @@ Types:
           Type: 2 BaseType uint32
         - Name: buckets
           Offset: 16
-          Type: 123 PointerType *bucket<string,[]main.structWithMap>
+          Type: 98 PointerType *bucket<string,[]main.structWithMap>
         - Name: oldbuckets
           Offset: 24
-          Type: 123 PointerType *bucket<string,[]main.structWithMap>
+          Type: 98 PointerType *bucket<string,[]main.structWithMap>
         - Name: nevacuate
           Offset: 32
           Type: 1 BaseType uintptr
         - Name: extra
           Offset: 40
-          Type: 83 PointerType *runtime.mapextra
-      BucketType: 124 GoHMapBucketType bucket<string,[]main.structWithMap>
-      BucketsType: 200 GoSliceDataType []bucket<string,[]main.structWithMap>.array
+          Type: 71 PointerType *runtime.mapextra
+      BucketType: 99 GoHMapBucketType bucket<string,[]main.structWithMap>
+      BucketsType: 196 GoSliceDataType []bucket<string,[]main.structWithMap>.array
     - __kind: GoHMapHeaderType
-      ID: 105
+      ID: 85
       Name: hash<string,[]string>
       ByteSize: 48
       RawFields:
@@ -6184,20 +6184,20 @@ Types:
           Type: 2 BaseType uint32
         - Name: buckets
           Offset: 16
-          Type: 106 PointerType *bucket<string,[]string>
+          Type: 86 PointerType *bucket<string,[]string>
         - Name: oldbuckets
           Offset: 24
-          Type: 106 PointerType *bucket<string,[]string>
+          Type: 86 PointerType *bucket<string,[]string>
         - Name: nevacuate
           Offset: 32
           Type: 1 BaseType uintptr
         - Name: extra
           Offset: 40
-          Type: 83 PointerType *runtime.mapextra
-      BucketType: 107 GoHMapBucketType bucket<string,[]string>
-      BucketsType: 196 GoSliceDataType []bucket<string,[]string>.array
+          Type: 71 PointerType *runtime.mapextra
+      BucketType: 87 GoHMapBucketType bucket<string,[]string>
+      BucketsType: 194 GoSliceDataType []bucket<string,[]string>.array
     - __kind: GoHMapHeaderType
-      ID: 100
+      ID: 80
       Name: hash<string,int>
       ByteSize: 48
       RawFields:
@@ -6218,20 +6218,20 @@ Types:
           Type: 2 BaseType uint32
         - Name: buckets
           Offset: 16
-          Type: 101 PointerType *bucket<string,int>
+          Type: 81 PointerType *bucket<string,int>
         - Name: oldbuckets
           Offset: 24
-          Type: 101 PointerType *bucket<string,int>
+          Type: 81 PointerType *bucket<string,int>
         - Name: nevacuate
           Offset: 32
           Type: 1 BaseType uintptr
         - Name: extra
           Offset: 40
-          Type: 83 PointerType *runtime.mapextra
-      BucketType: 102 GoHMapBucketType bucket<string,int>
-      BucketsType: 195 GoSliceDataType []bucket<string,int>.array
+          Type: 71 PointerType *runtime.mapextra
+      BucketType: 82 GoHMapBucketType bucket<string,int>
+      BucketsType: 193 GoSliceDataType []bucket<string,int>.array
     - __kind: GoHMapHeaderType
-      ID: 92
+      ID: 75
       Name: hash<string,main.nestedStruct>
       ByteSize: 48
       RawFields:
@@ -6252,20 +6252,20 @@ Types:
           Type: 2 BaseType uint32
         - Name: buckets
           Offset: 16
-          Type: 93 PointerType *bucket<string,main.nestedStruct>
+          Type: 76 PointerType *bucket<string,main.nestedStruct>
         - Name: oldbuckets
           Offset: 24
-          Type: 93 PointerType *bucket<string,main.nestedStruct>
+          Type: 76 PointerType *bucket<string,main.nestedStruct>
         - Name: nevacuate
           Offset: 32
           Type: 1 BaseType uintptr
         - Name: extra
           Offset: 40
-          Type: 83 PointerType *runtime.mapextra
-      BucketType: 94 GoHMapBucketType bucket<string,main.nestedStruct>
-      BucketsType: 194 GoSliceDataType []bucket<string,main.nestedStruct>.array
+          Type: 71 PointerType *runtime.mapextra
+      BucketType: 77 GoHMapBucketType bucket<string,main.nestedStruct>
+      BucketsType: 192 GoSliceDataType []bucket<string,main.nestedStruct>.array
     - __kind: GoHMapHeaderType
-      ID: 151
+      ID: 117
       Name: hash<uint8,[4]int>
       ByteSize: 48
       RawFields:
@@ -6286,20 +6286,20 @@ Types:
           Type: 2 BaseType uint32
         - Name: buckets
           Offset: 16
-          Type: 152 PointerType *bucket<uint8,[4]int>
+          Type: 118 PointerType *bucket<uint8,[4]int>
         - Name: oldbuckets
           Offset: 24
-          Type: 152 PointerType *bucket<uint8,[4]int>
+          Type: 118 PointerType *bucket<uint8,[4]int>
         - Name: nevacuate
           Offset: 32
           Type: 1 BaseType uintptr
         - Name: extra
           Offset: 40
-          Type: 83 PointerType *runtime.mapextra
-      BucketType: 153 GoHMapBucketType bucket<uint8,[4]int>
-      BucketsType: 206 GoSliceDataType []bucket<uint8,[4]int>.array
+          Type: 71 PointerType *runtime.mapextra
+      BucketType: 119 GoHMapBucketType bucket<uint8,[4]int>
+      BucketsType: 200 GoSliceDataType []bucket<uint8,[4]int>.array
     - __kind: GoHMapHeaderType
-      ID: 145
+      ID: 112
       Name: hash<uint8,uint8>
       ByteSize: 48
       RawFields:
@@ -6320,18 +6320,18 @@ Types:
           Type: 2 BaseType uint32
         - Name: buckets
           Offset: 16
-          Type: 146 PointerType *bucket<uint8,uint8>
+          Type: 113 PointerType *bucket<uint8,uint8>
         - Name: oldbuckets
           Offset: 24
-          Type: 146 PointerType *bucket<uint8,uint8>
+          Type: 113 PointerType *bucket<uint8,uint8>
         - Name: nevacuate
           Offset: 32
           Type: 1 BaseType uintptr
         - Name: extra
           Offset: 40
-          Type: 83 PointerType *runtime.mapextra
-      BucketType: 147 GoHMapBucketType bucket<uint8,uint8>
-      BucketsType: 205 GoSliceDataType []bucket<uint8,uint8>.array
+          Type: 71 PointerType *runtime.mapextra
+      BucketType: 114 GoHMapBucketType bucket<uint8,uint8>
+      BucketsType: 199 GoSliceDataType []bucket<uint8,uint8>.array
     - __kind: BaseType
       ID: 9
       Name: int
@@ -6389,7 +6389,7 @@ Types:
           Offset: 8
           Type: 19 VoidPointerType unsafe.Pointer
     - __kind: StructureType
-      ID: 185
+      ID: 150
       Name: main.aStruct
       ByteSize: 56
       GoKind: 25
@@ -6405,9 +6405,9 @@ Types:
           Type: 9 BaseType int
         - Name: nested
           Offset: 32
-          Type: 97 StructureType main.nestedStruct
+          Type: 151 StructureType main.nestedStruct
     - __kind: GoInterfaceType
-      ID: 73
+      ID: 64
       Name: main.behavior
       ByteSize: 16
       GoRuntimeType: 973376
@@ -6435,7 +6435,7 @@ Types:
           Offset: 32
           Type: 55 GoInterfaceType io.Writer
     - __kind: StructureType
-      ID: 186
+      ID: 152
       Name: main.emptyStruct
       GoKind: 25
       RawFields: []
@@ -6451,16 +6451,16 @@ Types:
           Type: 56 StructureType main.esotericStack
         - Name: mu
           Offset: 64
-          Type: 63 StructureType sync.Mutex
+          Type: 153 StructureType sync.Mutex
         - Name: once
           Offset: 72
-          Type: 64 StructureType sync.Once
+          Type: 154 StructureType sync.Once
         - Name: wg
           Offset: 88
-          Type: 67 StructureType sync.WaitGroup
+          Type: 157 StructureType sync.WaitGroup
         - Name: a
           Offset: 104
-          Type: 71 StructureType sync/atomic.Int32
+          Type: 161 StructureType sync/atomic.Int32
     - __kind: StructureType
       ID: 56
       Name: main.esotericStack
@@ -6490,7 +6490,7 @@ Types:
           Offset: 56
           Type: 60 GoSubroutineType func()
     - __kind: StructureType
-      ID: 97
+      ID: 151
       Name: main.nestedStruct
       ByteSize: 24
       GoRuntimeType: 1.270016e+06
@@ -6503,7 +6503,7 @@ Types:
           Offset: 8
           Type: 11 GoStringHeaderType string
     - __kind: StructureType
-      ID: 135
+      ID: 133
       Name: main.node
       ByteSize: 16
       GoRuntimeType: 1.269856e+06
@@ -6514,9 +6514,9 @@ Types:
           Type: 9 BaseType int
         - Name: b
           Offset: 8
-          Type: 136 PointerType *main.node
+          Type: 134 PointerType *main.node
     - __kind: StructureType
-      ID: 184
+      ID: 149
       Name: main.oneStringStruct
       ByteSize: 16
       GoKind: 25
@@ -6538,7 +6538,7 @@ Types:
           Offset: 8
           Type: 19 VoidPointerType unsafe.Pointer
     - __kind: StructureType
-      ID: 74
+      ID: 65
       Name: main.structWithMap
       ByteSize: 8
       GoRuntimeType: 1.092448e+06
@@ -6546,9 +6546,9 @@ Types:
       RawFields:
         - Name: m
           Offset: 0
-          Type: 75 GoMapType map[int]int
+          Type: 66 GoMapType map[int]int
     - __kind: StructureType
-      ID: 178
+      ID: 142
       Name: main.structWithNoStrings
       ByteSize: 2
       GoKind: 25
@@ -6560,7 +6560,7 @@ Types:
           Offset: 1
           Type: 4 BaseType bool
     - __kind: StructureType
-      ID: 169
+      ID: 132
       Name: main.structWithTwoValues
       ByteSize: 16
       GoKind: 25
@@ -6572,28 +6572,28 @@ Types:
           Offset: 8
           Type: 4 BaseType bool
     - __kind: GoSliceHeaderType
-      ID: 171
+      ID: 136
       Name: main.t
       ByteSize: 24
       GoKind: 23
       RawFields:
         - Name: array
           Offset: 0
-          Type: 172 PointerType **main.t
+          Type: 185 PointerType **main.t
         - Name: len
           Offset: 8
           Type: 9 BaseType int
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 209 GoSliceDataType main.t.array
+      Data: 203 GoSliceDataType main.t.array
     - __kind: GoSliceDataType
-      ID: 209
+      ID: 203
       Name: main.t.array
       ByteSize: 2048
-      Element: 170 PointerType *main.t
+      Element: 135 PointerType *main.t
     - __kind: StructureType
-      ID: 181
+      ID: 146
       Name: main.threeStringStruct
       ByteSize: 48
       GoKind: 25
@@ -6613,91 +6613,91 @@ Types:
       ByteSize: 2
       GoKind: 9
     - __kind: GoMapType
-      ID: 162
+      ID: 125
       Name: map[[4]int][4]int
       ByteSize: 8
       GoRuntimeType: 873856
       GoKind: 21
-      HeaderType: 164 GoHMapHeaderType hash<[4]int,[4]int>
+      HeaderType: 127 GoHMapHeaderType hash<[4]int,[4]int>
     - __kind: GoMapType
-      ID: 156
+      ID: 120
       Name: map[[4]int]uint8
       ByteSize: 8
       GoRuntimeType: 873952
       GoKind: 21
-      HeaderType: 158 GoHMapHeaderType hash<[4]int,uint8>
+      HeaderType: 122 GoHMapHeaderType hash<[4]int,uint8>
     - __kind: GoMapType
-      ID: 110
+      ID: 88
       Name: map[[4]string][2]int
       ByteSize: 8
       GoRuntimeType: 874048
       GoKind: 21
-      HeaderType: 112 GoHMapHeaderType hash<[4]string,[2]int>
+      HeaderType: 90 GoHMapHeaderType hash<[4]string,[2]int>
     - __kind: GoMapType
-      ID: 128
+      ID: 100
       Name: map[bool]main.node
       ByteSize: 8
       GoRuntimeType: 874144
       GoKind: 21
-      HeaderType: 130 GoHMapHeaderType hash<bool,main.node>
+      HeaderType: 102 GoHMapHeaderType hash<bool,main.node>
     - __kind: GoMapType
-      ID: 75
+      ID: 66
       Name: map[int]int
       ByteSize: 8
       GoRuntimeType: 872896
       GoKind: 21
-      HeaderType: 77 GoHMapHeaderType hash<int,int>
+      HeaderType: 68 GoHMapHeaderType hash<int,int>
     - __kind: GoMapType
-      ID: 137
+      ID: 105
       Name: map[int]uint8
       ByteSize: 8
       GoRuntimeType: 874240
       GoKind: 21
-      HeaderType: 139 GoHMapHeaderType hash<int,uint8>
+      HeaderType: 107 GoHMapHeaderType hash<int,uint8>
     - __kind: GoMapType
-      ID: 120
+      ID: 95
       Name: map[string][]main.structWithMap
       ByteSize: 8
       GoRuntimeType: 874336
       GoKind: 21
-      HeaderType: 122 GoHMapHeaderType hash<string,[]main.structWithMap>
+      HeaderType: 97 GoHMapHeaderType hash<string,[]main.structWithMap>
     - __kind: GoMapType
-      ID: 103
+      ID: 83
       Name: map[string][]string
       ByteSize: 8
       GoRuntimeType: 874432
       GoKind: 21
-      HeaderType: 105 GoHMapHeaderType hash<string,[]string>
+      HeaderType: 85 GoHMapHeaderType hash<string,[]string>
     - __kind: GoMapType
-      ID: 98
+      ID: 78
       Name: map[string]int
       ByteSize: 8
       GoRuntimeType: 874528
       GoKind: 21
-      HeaderType: 100 GoHMapHeaderType hash<string,int>
+      HeaderType: 80 GoHMapHeaderType hash<string,int>
     - __kind: GoMapType
-      ID: 90
+      ID: 73
       Name: map[string]main.nestedStruct
       ByteSize: 8
       GoRuntimeType: 874624
       GoKind: 21
-      HeaderType: 92 GoHMapHeaderType hash<string,main.nestedStruct>
+      HeaderType: 75 GoHMapHeaderType hash<string,main.nestedStruct>
     - __kind: GoMapType
-      ID: 149
+      ID: 115
       Name: map[uint8][4]int
       ByteSize: 8
       GoRuntimeType: 874720
       GoKind: 21
-      HeaderType: 151 GoHMapHeaderType hash<uint8,[4]int>
+      HeaderType: 117 GoHMapHeaderType hash<uint8,[4]int>
     - __kind: GoMapType
-      ID: 143
+      ID: 110
       Name: map[uint8]uint8
       ByteSize: 8
       GoRuntimeType: 874816
       GoKind: 21
-      HeaderType: 145 GoHMapHeaderType hash<uint8,uint8>
+      HeaderType: 112 GoHMapHeaderType hash<uint8,uint8>
     - __kind: StructureType
-      ID: 89
+      ID: 168
       Name: runtime.bmap
       ByteSize: 8
       GoRuntimeType: 1.100768e+06
@@ -6705,9 +6705,9 @@ Types:
       RawFields:
         - Name: tophash
           Offset: 0
-          Type: 80 ArrayType [8]uint8
+          Type: 162 ArrayType [8]uint8
     - __kind: StructureType
-      ID: 84
+      ID: 72
       Name: runtime.mapextra
       ByteSize: 24
       GoRuntimeType: 1.417056e+06
@@ -6715,13 +6715,13 @@ Types:
       RawFields:
         - Name: overflow
           Offset: 0
-          Type: 85 PointerType *[]*runtime.bmap
+          Type: 165 PointerType *[]*runtime.bmap
         - Name: oldoverflow
           Offset: 8
-          Type: 85 PointerType *[]*runtime.bmap
+          Type: 165 PointerType *[]*runtime.bmap
         - Name: nextOverflow
           Offset: 16
-          Type: 88 PointerType *runtime.bmap
+          Type: 167 PointerType *runtime.bmap
     - __kind: GoStringHeaderType
       ID: 11
       Name: string
@@ -6741,7 +6741,7 @@ Types:
       Name: string.str
       ByteSize: 2048
     - __kind: StructureType
-      ID: 63
+      ID: 153
       Name: sync.Mutex
       ByteSize: 8
       GoRuntimeType: 1.271296e+06
@@ -6754,7 +6754,7 @@ Types:
           Offset: 4
           Type: 2 BaseType uint32
     - __kind: StructureType
-      ID: 64
+      ID: 154
       Name: sync.Once
       ByteSize: 12
       GoRuntimeType: 1.272416e+06
@@ -6762,12 +6762,12 @@ Types:
       RawFields:
         - Name: done
           Offset: 0
-          Type: 65 StructureType sync/atomic.Uint32
+          Type: 155 StructureType sync/atomic.Uint32
         - Name: m
           Offset: 4
-          Type: 63 StructureType sync.Mutex
+          Type: 153 StructureType sync.Mutex
     - __kind: StructureType
-      ID: 67
+      ID: 157
       Name: sync.WaitGroup
       ByteSize: 16
       GoRuntimeType: 1.411104e+06
@@ -6775,21 +6775,21 @@ Types:
       RawFields:
         - Name: noCopy
           Offset: 0
-          Type: 68 StructureType sync.noCopy
+          Type: 158 StructureType sync.noCopy
         - Name: state
           Offset: 0
-          Type: 69 StructureType sync/atomic.Uint64
+          Type: 159 StructureType sync/atomic.Uint64
         - Name: sema
           Offset: 8
           Type: 2 BaseType uint32
     - __kind: StructureType
-      ID: 68
+      ID: 158
       Name: sync.noCopy
       GoRuntimeType: 940512
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 71
+      ID: 161
       Name: sync/atomic.Int32
       ByteSize: 4
       GoRuntimeType: 1.272736e+06
@@ -6797,12 +6797,12 @@ Types:
       RawFields:
         - Name: _
           Offset: 0
-          Type: 66 StructureType sync/atomic.noCopy
+          Type: 156 StructureType sync/atomic.noCopy
         - Name: v
           Offset: 0
           Type: 12 BaseType int32
     - __kind: StructureType
-      ID: 65
+      ID: 155
       Name: sync/atomic.Uint32
       ByteSize: 4
       GoRuntimeType: 1.272896e+06
@@ -6810,12 +6810,12 @@ Types:
       RawFields:
         - Name: _
           Offset: 0
-          Type: 66 StructureType sync/atomic.noCopy
+          Type: 156 StructureType sync/atomic.noCopy
         - Name: v
           Offset: 0
           Type: 2 BaseType uint32
     - __kind: StructureType
-      ID: 69
+      ID: 159
       Name: sync/atomic.Uint64
       ByteSize: 8
       GoRuntimeType: 1.411488e+06
@@ -6823,21 +6823,21 @@ Types:
       RawFields:
         - Name: _
           Offset: 0
-          Type: 66 StructureType sync/atomic.noCopy
+          Type: 156 StructureType sync/atomic.noCopy
         - Name: _
           Offset: 0
-          Type: 70 StructureType sync/atomic.align64
+          Type: 160 StructureType sync/atomic.align64
         - Name: v
           Offset: 0
           Type: 10 BaseType uint64
     - __kind: StructureType
-      ID: 70
+      ID: 160
       Name: sync/atomic.align64
       GoRuntimeType: 940704
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 66
+      ID: 156
       Name: sync/atomic.noCopy
       GoRuntimeType: 940608
       GoKind: 25

--- a/pkg/dyninst/irgen/testdata/snapshot/sample.arch=amd64,toolchain=go1.23.11.yaml
+++ b/pkg/dyninst/irgen/testdata/snapshot/sample.arch=amd64,toolchain=go1.23.11.yaml
@@ -8,7 +8,7 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 94}
+      subprogram: {subprogram: 88}
       events:
         - ID: 88
           Type: 308 EventRootType Probe[main.stackC]
@@ -22,7 +22,7 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 51}
+      subprogram: {subprogram: 45}
       events:
         - ID: 45
           Type: 265 EventRootType Probe[main.testAny]
@@ -36,7 +36,7 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 21}
+      subprogram: {subprogram: 15}
       events:
         - ID: 15
           Type: 235 EventRootType Probe[main.testArrayOfArrays]
@@ -50,7 +50,7 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 23}
+      subprogram: {subprogram: 17}
       events:
         - ID: 17
           Type: 237 EventRootType Probe[main.testArrayOfArraysOfArrays]
@@ -64,7 +64,7 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 59}
+      subprogram: {subprogram: 53}
       events:
         - ID: 53
           Type: 273 EventRootType Probe[main.testArrayOfMaps]
@@ -78,7 +78,7 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 22}
+      subprogram: {subprogram: 16}
       events:
         - ID: 16
           Type: 236 EventRootType Probe[main.testArrayOfStrings]
@@ -92,7 +92,7 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 41}
+      subprogram: {subprogram: 35}
       events:
         - ID: 35
           Type: 255 EventRootType Probe[main.testBigStruct]
@@ -106,7 +106,7 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 10}
+      subprogram: {subprogram: 4}
       events:
         - ID: 4
           Type: 224 EventRootType Probe[main.testBoolArray]
@@ -120,7 +120,7 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 7}
+      subprogram: {subprogram: 1}
       events:
         - ID: 1
           Type: 221 EventRootType Probe[main.testByteArray]
@@ -134,7 +134,7 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 75}
+      subprogram: {subprogram: 69}
       events:
         - ID: 69
           Type: 289 EventRootType Probe[main.testChannel]
@@ -148,7 +148,7 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 73}
+      subprogram: {subprogram: 67}
       events:
         - ID: 67
           Type: 287 EventRootType Probe[main.testCombinedByte]
@@ -162,7 +162,7 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 83}
+      subprogram: {subprogram: 77}
       events:
         - ID: 77
           Type: 297 EventRootType Probe[main.testCycle]
@@ -176,7 +176,7 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 85}
+      subprogram: {subprogram: 79}
       events:
         - ID: 79
           Type: 299 EventRootType Probe[main.testEmptySlice]
@@ -190,7 +190,7 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 88}
+      subprogram: {subprogram: 82}
       events:
         - ID: 82
           Type: 302 EventRootType Probe[main.testEmptySliceOfStructs]
@@ -204,7 +204,7 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 102}
+      subprogram: {subprogram: 96}
       events:
         - ID: 96
           Type: 316 EventRootType Probe[main.testEmptyString]
@@ -218,7 +218,7 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 104}
+      subprogram: {subprogram: 98}
       events:
         - ID: 98
           Type: 318 EventRootType Probe[main.testEmptyStruct]
@@ -232,7 +232,7 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 52}
+      subprogram: {subprogram: 46}
       events:
         - ID: 46
           Type: 266 EventRootType Probe[main.testError]
@@ -246,7 +246,7 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 43}
+      subprogram: {subprogram: 37}
       events:
         - ID: 37
           Type: 257 EventRootType Probe[main.testEsotericHeap]
@@ -260,7 +260,7 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 42}
+      subprogram: {subprogram: 36}
       events:
         - ID: 36
           Type: 256 EventRootType Probe[main.testEsotericStack]
@@ -274,7 +274,7 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 48}
+      subprogram: {subprogram: 42}
       events:
         - ID: 42
           Type: 262 EventRootType Probe[main.testFrameless]
@@ -288,7 +288,7 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 49}
+      subprogram: {subprogram: 43}
       events:
         - ID: 43
           Type: 263 EventRootType Probe[main.testFramelessArray]
@@ -302,7 +302,7 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 44}
+      subprogram: {subprogram: 38}
       events:
         - ID: 38
           Type: 258 EventRootType Probe[main.testInlinedBA]
@@ -316,7 +316,7 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 45}
+      subprogram: {subprogram: 39}
       events:
         - ID: 39
           Type: 259 EventRootType Probe[main.testInlinedBB]
@@ -330,7 +330,7 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 46}
+      subprogram: {subprogram: 40}
       events:
         - ID: 40
           Type: 260 EventRootType Probe[main.testInlinedBBA]
@@ -344,7 +344,7 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 2}
+      subprogram: {subprogram: 100}
       events:
         - ID: 100
           Type: 320 EventRootType Probe[main.testInlinedBBB]
@@ -358,7 +358,7 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 47}
+      subprogram: {subprogram: 41}
       events:
         - ID: 41
           Type: 261 EventRootType Probe[main.testInlinedBC]
@@ -372,7 +372,7 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 3}
+      subprogram: {subprogram: 101}
       events:
         - ID: 101
           Type: 321 EventRootType Probe[main.testInlinedBCA]
@@ -386,7 +386,7 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 4}
+      subprogram: {subprogram: 102}
       events:
         - ID: 102
           Type: 322 EventRootType Probe[main.testInlinedBCB]
@@ -401,7 +401,7 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 1}
+      subprogram: {subprogram: 99}
       events:
         - ID: 99
           Type: 319 EventRootType Probe[main.testInlinedPrint]
@@ -425,7 +425,7 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 5}
+      subprogram: {subprogram: 103}
       events:
         - ID: 103
           Type: 323 EventRootType Probe[main.testInlinedSq]
@@ -440,7 +440,7 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 6}
+      subprogram: {subprogram: 104}
       events:
         - ID: 104
           Type: 324 EventRootType Probe[main.testInlinedSumArray]
@@ -458,7 +458,7 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 13}
+      subprogram: {subprogram: 7}
       events:
         - ID: 7
           Type: 227 EventRootType Probe[main.testInt16Array]
@@ -472,7 +472,7 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 14}
+      subprogram: {subprogram: 8}
       events:
         - ID: 8
           Type: 228 EventRootType Probe[main.testInt32Array]
@@ -486,7 +486,7 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 15}
+      subprogram: {subprogram: 9}
       events:
         - ID: 9
           Type: 229 EventRootType Probe[main.testInt64Array]
@@ -500,7 +500,7 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 12}
+      subprogram: {subprogram: 6}
       events:
         - ID: 6
           Type: 226 EventRootType Probe[main.testInt8Array]
@@ -514,7 +514,7 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 11}
+      subprogram: {subprogram: 5}
       events:
         - ID: 5
           Type: 225 EventRootType Probe[main.testIntArray]
@@ -528,7 +528,7 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 50}
+      subprogram: {subprogram: 44}
       events:
         - ID: 44
           Type: 264 EventRootType Probe[main.testInterface]
@@ -542,7 +542,7 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 77}
+      subprogram: {subprogram: 71}
       events:
         - ID: 71
           Type: 291 EventRootType Probe[main.testLinkedList]
@@ -556,7 +556,7 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 57}
+      subprogram: {subprogram: 51}
       events:
         - ID: 51
           Type: 271 EventRootType Probe[main.testMapArrayToArray]
@@ -570,7 +570,7 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 63}
+      subprogram: {subprogram: 57}
       events:
         - ID: 57
           Type: 277 EventRootType Probe[main.testMapEmbeddedMaps]
@@ -584,7 +584,7 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 61}
+      subprogram: {subprogram: 55}
       events:
         - ID: 55
           Type: 275 EventRootType Probe[main.testMapIntToInt]
@@ -598,7 +598,7 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 72}
+      subprogram: {subprogram: 66}
       events:
         - ID: 66
           Type: 286 EventRootType Probe[main.testMapLargeKeyLargeValue]
@@ -612,7 +612,7 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 71}
+      subprogram: {subprogram: 65}
       events:
         - ID: 65
           Type: 285 EventRootType Probe[main.testMapLargeKeySmallValue]
@@ -626,7 +626,7 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 62}
+      subprogram: {subprogram: 56}
       events:
         - ID: 56
           Type: 276 EventRootType Probe[main.testMapMassive]
@@ -640,7 +640,7 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 70}
+      subprogram: {subprogram: 64}
       events:
         - ID: 64
           Type: 284 EventRootType Probe[main.testMapSmallKeyLargeValue]
@@ -654,7 +654,7 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 69}
+      subprogram: {subprogram: 63}
       events:
         - ID: 63
           Type: 283 EventRootType Probe[main.testMapSmallKeySmallValue]
@@ -668,7 +668,7 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 55}
+      subprogram: {subprogram: 49}
       events:
         - ID: 49
           Type: 269 EventRootType Probe[main.testMapStringToInt]
@@ -682,7 +682,7 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 56}
+      subprogram: {subprogram: 50}
       events:
         - ID: 50
           Type: 270 EventRootType Probe[main.testMapStringToSlice]
@@ -696,7 +696,7 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 54}
+      subprogram: {subprogram: 48}
       events:
         - ID: 48
           Type: 268 EventRootType Probe[main.testMapStringToStruct]
@@ -710,7 +710,7 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 64}
+      subprogram: {subprogram: 58}
       events:
         - ID: 58
           Type: 278 EventRootType Probe[main.testMapWithLinkedList]
@@ -724,7 +724,7 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 67}
+      subprogram: {subprogram: 61}
       events:
         - ID: 61
           Type: 281 EventRootType Probe[main.testMapWithSmallKeyAndValue]
@@ -738,7 +738,7 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 68}
+      subprogram: {subprogram: 62}
       events:
         - ID: 62
           Type: 282 EventRootType Probe[main.testMapWithSmallKeyAndValueMassive]
@@ -752,7 +752,7 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 65}
+      subprogram: {subprogram: 59}
       events:
         - ID: 59
           Type: 279 EventRootType Probe[main.testMapWithSmallValue]
@@ -766,7 +766,7 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 66}
+      subprogram: {subprogram: 60}
       events:
         - ID: 60
           Type: 280 EventRootType Probe[main.testMapWithSmallValueMassive]
@@ -780,7 +780,7 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 100}
+      subprogram: {subprogram: 94}
       events:
         - ID: 94
           Type: 314 EventRootType Probe[main.testMassiveString]
@@ -794,7 +794,7 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 74}
+      subprogram: {subprogram: 68}
       events:
         - ID: 68
           Type: 288 EventRootType Probe[main.testMultipleSimpleParams]
@@ -808,7 +808,7 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 82}
+      subprogram: {subprogram: 76}
       events:
         - ID: 76
           Type: 296 EventRootType Probe[main.testNilPointer]
@@ -822,7 +822,7 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 92}
+      subprogram: {subprogram: 86}
       events:
         - ID: 86
           Type: 306 EventRootType Probe[main.testNilSlice]
@@ -836,7 +836,7 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 89}
+      subprogram: {subprogram: 83}
       events:
         - ID: 83
           Type: 303 EventRootType Probe[main.testNilSliceOfStructs]
@@ -850,7 +850,7 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 91}
+      subprogram: {subprogram: 85}
       events:
         - ID: 85
           Type: 305 EventRootType Probe[main.testNilSliceWithOtherParams]
@@ -864,7 +864,7 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 99}
+      subprogram: {subprogram: 93}
       events:
         - ID: 93
           Type: 313 EventRootType Probe[main.testOneStringInStructPointer]
@@ -878,7 +878,7 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 78}
+      subprogram: {subprogram: 72}
       events:
         - ID: 72
           Type: 292 EventRootType Probe[main.testPointerLoop]
@@ -892,7 +892,7 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 60}
+      subprogram: {subprogram: 54}
       events:
         - ID: 54
           Type: 274 EventRootType Probe[main.testPointerToMap]
@@ -906,7 +906,7 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 76}
+      subprogram: {subprogram: 70}
       events:
         - ID: 70
           Type: 290 EventRootType Probe[main.testPointerToSimpleStruct]
@@ -920,7 +920,7 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 8}
+      subprogram: {subprogram: 2}
       events:
         - ID: 2
           Type: 222 EventRootType Probe[main.testRuneArray]
@@ -934,7 +934,7 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 27}
+      subprogram: {subprogram: 21}
       events:
         - ID: 21
           Type: 241 EventRootType Probe[main.testSingleBool]
@@ -948,7 +948,7 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 25}
+      subprogram: {subprogram: 19}
       events:
         - ID: 19
           Type: 239 EventRootType Probe[main.testSingleByte]
@@ -962,7 +962,7 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 38}
+      subprogram: {subprogram: 32}
       events:
         - ID: 32
           Type: 252 EventRootType Probe[main.testSingleFloat32]
@@ -976,7 +976,7 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 39}
+      subprogram: {subprogram: 33}
       events:
         - ID: 33
           Type: 253 EventRootType Probe[main.testSingleFloat64]
@@ -990,7 +990,7 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 28}
+      subprogram: {subprogram: 22}
       events:
         - ID: 22
           Type: 242 EventRootType Probe[main.testSingleInt]
@@ -1004,7 +1004,7 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 30}
+      subprogram: {subprogram: 24}
       events:
         - ID: 24
           Type: 244 EventRootType Probe[main.testSingleInt16]
@@ -1018,7 +1018,7 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 31}
+      subprogram: {subprogram: 25}
       events:
         - ID: 25
           Type: 245 EventRootType Probe[main.testSingleInt32]
@@ -1032,7 +1032,7 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 32}
+      subprogram: {subprogram: 26}
       events:
         - ID: 26
           Type: 246 EventRootType Probe[main.testSingleInt64]
@@ -1046,7 +1046,7 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 29}
+      subprogram: {subprogram: 23}
       events:
         - ID: 23
           Type: 243 EventRootType Probe[main.testSingleInt8]
@@ -1060,7 +1060,7 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 26}
+      subprogram: {subprogram: 20}
       events:
         - ID: 20
           Type: 240 EventRootType Probe[main.testSingleRune]
@@ -1074,7 +1074,7 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 95}
+      subprogram: {subprogram: 89}
       events:
         - ID: 89
           Type: 309 EventRootType Probe[main.testSingleString]
@@ -1088,7 +1088,7 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 33}
+      subprogram: {subprogram: 27}
       events:
         - ID: 27
           Type: 247 EventRootType Probe[main.testSingleUint]
@@ -1102,7 +1102,7 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 35}
+      subprogram: {subprogram: 29}
       events:
         - ID: 29
           Type: 249 EventRootType Probe[main.testSingleUint16]
@@ -1116,7 +1116,7 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 36}
+      subprogram: {subprogram: 30}
       events:
         - ID: 30
           Type: 250 EventRootType Probe[main.testSingleUint32]
@@ -1130,7 +1130,7 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 37}
+      subprogram: {subprogram: 31}
       events:
         - ID: 31
           Type: 251 EventRootType Probe[main.testSingleUint64]
@@ -1144,7 +1144,7 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 34}
+      subprogram: {subprogram: 28}
       events:
         - ID: 28
           Type: 248 EventRootType Probe[main.testSingleUint8]
@@ -1158,7 +1158,7 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 86}
+      subprogram: {subprogram: 80}
       events:
         - ID: 80
           Type: 300 EventRootType Probe[main.testSliceOfSlices]
@@ -1172,7 +1172,7 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 58}
+      subprogram: {subprogram: 52}
       events:
         - ID: 52
           Type: 272 EventRootType Probe[main.testSmallMap]
@@ -1186,7 +1186,7 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 9}
+      subprogram: {subprogram: 3}
       events:
         - ID: 3
           Type: 223 EventRootType Probe[main.testStringArray]
@@ -1200,7 +1200,7 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 81}
+      subprogram: {subprogram: 75}
       events:
         - ID: 75
           Type: 295 EventRootType Probe[main.testStringPointer]
@@ -1214,7 +1214,7 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 90}
+      subprogram: {subprogram: 84}
       events:
         - ID: 84
           Type: 304 EventRootType Probe[main.testStringSlice]
@@ -1228,7 +1228,7 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 103}
+      subprogram: {subprogram: 97}
       events:
         - ID: 97
           Type: 317 EventRootType Probe[main.testStruct]
@@ -1242,7 +1242,7 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 87}
+      subprogram: {subprogram: 81}
       events:
         - ID: 81
           Type: 301 EventRootType Probe[main.testStructSlice]
@@ -1256,7 +1256,7 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 53}
+      subprogram: {subprogram: 47}
       events:
         - ID: 47
           Type: 267 EventRootType Probe[main.testStructWithMap]
@@ -1270,7 +1270,7 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 96}
+      subprogram: {subprogram: 90}
       events:
         - ID: 90
           Type: 310 EventRootType Probe[main.testThreeStrings]
@@ -1284,7 +1284,7 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 97}
+      subprogram: {subprogram: 91}
       events:
         - ID: 91
           Type: 311 EventRootType Probe[main.testThreeStringsInStruct]
@@ -1298,7 +1298,7 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 98}
+      subprogram: {subprogram: 92}
       events:
         - ID: 92
           Type: 312 EventRootType Probe[main.testThreeStringsInStructPointer]
@@ -1312,7 +1312,7 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 40}
+      subprogram: {subprogram: 34}
       events:
         - ID: 34
           Type: 254 EventRootType Probe[main.testTypeAlias]
@@ -1326,7 +1326,7 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 18}
+      subprogram: {subprogram: 12}
       events:
         - ID: 12
           Type: 232 EventRootType Probe[main.testUint16Array]
@@ -1340,7 +1340,7 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 19}
+      subprogram: {subprogram: 13}
       events:
         - ID: 13
           Type: 233 EventRootType Probe[main.testUint32Array]
@@ -1354,7 +1354,7 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 20}
+      subprogram: {subprogram: 14}
       events:
         - ID: 14
           Type: 234 EventRootType Probe[main.testUint64Array]
@@ -1368,7 +1368,7 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 17}
+      subprogram: {subprogram: 11}
       events:
         - ID: 11
           Type: 231 EventRootType Probe[main.testUint8Array]
@@ -1382,7 +1382,7 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 16}
+      subprogram: {subprogram: 10}
       events:
         - ID: 10
           Type: 230 EventRootType Probe[main.testUintArray]
@@ -1396,7 +1396,7 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 80}
+      subprogram: {subprogram: 74}
       events:
         - ID: 74
           Type: 294 EventRootType Probe[main.testUintPointer]
@@ -1410,7 +1410,7 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 84}
+      subprogram: {subprogram: 78}
       events:
         - ID: 78
           Type: 298 EventRootType Probe[main.testUintSlice]
@@ -1424,7 +1424,7 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 101}
+      subprogram: {subprogram: 95}
       events:
         - ID: 95
           Type: 315 EventRootType Probe[main.testUnitializedString]
@@ -1438,7 +1438,7 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 79}
+      subprogram: {subprogram: 73}
       events:
         - ID: 73
           Type: 293 EventRootType Probe[main.testUnsafePointer]
@@ -1452,7 +1452,7 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 24}
+      subprogram: {subprogram: 18}
       events:
         - ID: 18
           Type: 238 EventRootType Probe[main.testVeryLargeArray]
@@ -1466,278 +1466,278 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 93}
+      subprogram: {subprogram: 87}
       events:
         - ID: 87
           Type: 307 EventRootType Probe[main.testVeryLargeSlice]
           InjectionPoints: [{PC: "0xd06be0", Frameless: true}]
           Condition: null
 Subprograms:
-    - ID: 7
+    - ID: 1
       Name: main.testByteArray
       OutOfLinePCRanges: [0xd02980..0xd02981]
       InlinePCRanges: []
       Variables:
         - Name: x
-          Type: 3 ArrayType [2]uint8
+          Type: 36 ArrayType [2]uint8
           Locations:
             - Range: 0xd02980..0xd02981
               Pieces: [{Size: 2, Op: {CfaOffset: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 8
+    - ID: 2
       Name: main.testRuneArray
       OutOfLinePCRanges: [0xd029a0..0xd029a1]
       InlinePCRanges: []
       Variables:
         - Name: x
-          Type: 5 ArrayType [2]int32
+          Type: 37 ArrayType [2]int32
           Locations:
             - Range: 0xd029a0..0xd029a1
               Pieces: [{Size: 8, Op: {CfaOffset: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 9
+    - ID: 3
       Name: main.testStringArray
       OutOfLinePCRanges: [0xd029c0..0xd029c1]
       InlinePCRanges: []
       Variables:
         - Name: x
-          Type: 7 ArrayType [2]string
+          Type: 38 ArrayType [2]string
           Locations:
             - Range: 0xd029c0..0xd029c1
               Pieces: [{Size: 32, Op: {CfaOffset: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 10
+    - ID: 4
       Name: main.testBoolArray
       OutOfLinePCRanges: [0xd029e0..0xd029e1]
       InlinePCRanges: []
       Variables:
         - Name: x
-          Type: 10 ArrayType [2]bool
+          Type: 39 ArrayType [2]bool
           Locations:
             - Range: 0xd029e0..0xd029e1
               Pieces: [{Size: 2, Op: {CfaOffset: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 11
+    - ID: 5
       Name: main.testIntArray
       OutOfLinePCRanges: [0xd02a00..0xd02a01]
       InlinePCRanges: []
       Variables:
         - Name: x
-          Type: 12 ArrayType [2]int
+          Type: 40 ArrayType [2]int
           Locations:
             - Range: 0xd02a00..0xd02a01
               Pieces: [{Size: 16, Op: {CfaOffset: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 12
+    - ID: 6
       Name: main.testInt8Array
       OutOfLinePCRanges: [0xd02a20..0xd02a21]
       InlinePCRanges: []
       Variables:
         - Name: x
-          Type: 13 ArrayType [2]int8
+          Type: 41 ArrayType [2]int8
           Locations:
             - Range: 0xd02a20..0xd02a21
               Pieces: [{Size: 2, Op: {CfaOffset: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 13
+    - ID: 7
       Name: main.testInt16Array
       OutOfLinePCRanges: [0xd02a40..0xd02a41]
       InlinePCRanges: []
       Variables:
         - Name: x
-          Type: 15 ArrayType [2]int16
+          Type: 42 ArrayType [2]int16
           Locations:
             - Range: 0xd02a40..0xd02a41
               Pieces: [{Size: 4, Op: {CfaOffset: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 14
+    - ID: 8
       Name: main.testInt32Array
       OutOfLinePCRanges: [0xd02a60..0xd02a61]
       InlinePCRanges: []
       Variables:
         - Name: x
-          Type: 5 ArrayType [2]int32
+          Type: 37 ArrayType [2]int32
           Locations:
             - Range: 0xd02a60..0xd02a61
               Pieces: [{Size: 8, Op: {CfaOffset: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 15
+    - ID: 9
       Name: main.testInt64Array
       OutOfLinePCRanges: [0xd02a80..0xd02a81]
       InlinePCRanges: []
       Variables:
         - Name: x
-          Type: 17 ArrayType [2]int64
+          Type: 43 ArrayType [2]int64
           Locations:
             - Range: 0xd02a80..0xd02a81
               Pieces: [{Size: 16, Op: {CfaOffset: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 16
+    - ID: 10
       Name: main.testUintArray
       OutOfLinePCRanges: [0xd02aa0..0xd02aa1]
       InlinePCRanges: []
       Variables:
         - Name: x
-          Type: 19 ArrayType [2]uint
+          Type: 44 ArrayType [2]uint
           Locations:
             - Range: 0xd02aa0..0xd02aa1
               Pieces: [{Size: 16, Op: {CfaOffset: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 17
+    - ID: 11
       Name: main.testUint8Array
       OutOfLinePCRanges: [0xd02ac0..0xd02ac1]
       InlinePCRanges: []
       Variables:
         - Name: x
-          Type: 3 ArrayType [2]uint8
+          Type: 36 ArrayType [2]uint8
           Locations:
             - Range: 0xd02ac0..0xd02ac1
               Pieces: [{Size: 2, Op: {CfaOffset: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 18
+    - ID: 12
       Name: main.testUint16Array
       OutOfLinePCRanges: [0xd02ae0..0xd02ae1]
       InlinePCRanges: []
       Variables:
         - Name: x
-          Type: 21 ArrayType [2]uint16
+          Type: 45 ArrayType [2]uint16
           Locations:
             - Range: 0xd02ae0..0xd02ae1
               Pieces: [{Size: 4, Op: {CfaOffset: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 19
+    - ID: 13
       Name: main.testUint32Array
       OutOfLinePCRanges: [0xd02b00..0xd02b01]
       InlinePCRanges: []
       Variables:
         - Name: x
-          Type: 23 ArrayType [2]uint32
+          Type: 46 ArrayType [2]uint32
           Locations:
             - Range: 0xd02b00..0xd02b01
               Pieces: [{Size: 8, Op: {CfaOffset: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 20
+    - ID: 14
       Name: main.testUint64Array
       OutOfLinePCRanges: [0xd02b20..0xd02b21]
       InlinePCRanges: []
       Variables:
         - Name: x
-          Type: 25 ArrayType [2]uint64
+          Type: 47 ArrayType [2]uint64
           Locations:
             - Range: 0xd02b20..0xd02b21
               Pieces: [{Size: 16, Op: {CfaOffset: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 21
+    - ID: 15
       Name: main.testArrayOfArrays
       OutOfLinePCRanges: [0xd02b40..0xd02b41]
       InlinePCRanges: []
       Variables:
         - Name: a
-          Type: 27 ArrayType [2][2]int
+          Type: 48 ArrayType [2][2]int
           Locations:
             - Range: 0xd02b40..0xd02b41
               Pieces: [{Size: 32, Op: {CfaOffset: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 22
+    - ID: 16
       Name: main.testArrayOfStrings
       OutOfLinePCRanges: [0xd02b60..0xd02b61]
       InlinePCRanges: []
       Variables:
         - Name: a
-          Type: 7 ArrayType [2]string
+          Type: 38 ArrayType [2]string
           Locations:
             - Range: 0xd02b60..0xd02b61
               Pieces: [{Size: 32, Op: {CfaOffset: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 23
+    - ID: 17
       Name: main.testArrayOfArraysOfArrays
       OutOfLinePCRanges: [0xd02b80..0xd02b81]
       InlinePCRanges: []
       Variables:
         - Name: b
-          Type: 28 ArrayType [2][2][2]int
+          Type: 49 ArrayType [2][2][2]int
           Locations:
             - Range: 0xd02b80..0xd02b81
               Pieces: [{Size: 64, Op: {CfaOffset: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 24
+    - ID: 18
       Name: main.testVeryLargeArray
       OutOfLinePCRanges: [0xd02be0..0xd02be1]
       InlinePCRanges: []
       Variables:
         - Name: a
-          Type: 29 ArrayType [100]uint
+          Type: 50 ArrayType [100]uint
           Locations:
             - Range: 0xd02be0..0xd02be1
               Pieces: [{Size: 800, Op: {CfaOffset: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 25
+    - ID: 19
       Name: main.testSingleByte
       OutOfLinePCRanges: [0xd02f60..0xd02f61]
       InlinePCRanges: []
       Variables:
         - Name: x
-          Type: 4 BaseType uint8
+          Type: 3 BaseType uint8
           Locations:
             - Range: 0xd02f60..0xd02f61
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 26
+    - ID: 20
       Name: main.testSingleRune
       OutOfLinePCRanges: [0xd02f80..0xd02f81]
       InlinePCRanges: []
       Variables:
         - Name: x
-          Type: 6 BaseType int32
+          Type: 12 BaseType int32
           Locations:
             - Range: 0xd02f80..0xd02f81
               Pieces: [{Size: 4, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 27
+    - ID: 21
       Name: main.testSingleBool
       OutOfLinePCRanges: [0xd02fa0..0xd02fa1]
       InlinePCRanges: []
       Variables:
         - Name: x
-          Type: 11 BaseType bool
+          Type: 4 BaseType bool
           Locations:
             - Range: 0xd02fa0..0xd02fa1
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 28
+    - ID: 22
       Name: main.testSingleInt
       OutOfLinePCRanges: [0xd02fc0..0xd02fc1]
       InlinePCRanges: []
       Variables:
         - Name: x
-          Type: 1 BaseType int
+          Type: 9 BaseType int
           Locations:
             - Range: 0xd02fc0..0xd02fc1
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 29
+    - ID: 23
       Name: main.testSingleInt8
       OutOfLinePCRanges: [0xd02fe0..0xd02fe1]
       InlinePCRanges: []
@@ -1749,145 +1749,145 @@ Subprograms:
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 30
+    - ID: 24
       Name: main.testSingleInt16
       OutOfLinePCRanges: [0xd03000..0xd03001]
       InlinePCRanges: []
       Variables:
         - Name: x
-          Type: 16 BaseType int16
+          Type: 31 BaseType int16
           Locations:
             - Range: 0xd03000..0xd03001
               Pieces: [{Size: 2, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 31
+    - ID: 25
       Name: main.testSingleInt32
       OutOfLinePCRanges: [0xd03020..0xd03021]
       InlinePCRanges: []
       Variables:
         - Name: x
-          Type: 6 BaseType int32
+          Type: 12 BaseType int32
           Locations:
             - Range: 0xd03020..0xd03021
               Pieces: [{Size: 4, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 32
+    - ID: 26
       Name: main.testSingleInt64
       OutOfLinePCRanges: [0xd03040..0xd03041]
       InlinePCRanges: []
       Variables:
         - Name: x
-          Type: 18 BaseType int64
+          Type: 13 BaseType int64
           Locations:
             - Range: 0xd03040..0xd03041
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 33
+    - ID: 27
       Name: main.testSingleUint
       OutOfLinePCRanges: [0xd03060..0xd03061]
       InlinePCRanges: []
       Variables:
         - Name: x
-          Type: 20 BaseType uint
+          Type: 15 BaseType uint
           Locations:
             - Range: 0xd03060..0xd03061
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 34
+    - ID: 28
       Name: main.testSingleUint8
       OutOfLinePCRanges: [0xd03080..0xd03081]
       InlinePCRanges: []
       Variables:
         - Name: x
-          Type: 4 BaseType uint8
+          Type: 3 BaseType uint8
           Locations:
             - Range: 0xd03080..0xd03081
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 35
+    - ID: 29
       Name: main.testSingleUint16
       OutOfLinePCRanges: [0xd030a0..0xd030a1]
       InlinePCRanges: []
       Variables:
         - Name: x
-          Type: 22 BaseType uint16
+          Type: 7 BaseType uint16
           Locations:
             - Range: 0xd030a0..0xd030a1
               Pieces: [{Size: 2, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 36
+    - ID: 30
       Name: main.testSingleUint32
       OutOfLinePCRanges: [0xd030c0..0xd030c1]
       InlinePCRanges: []
       Variables:
         - Name: x
-          Type: 24 BaseType uint32
+          Type: 2 BaseType uint32
           Locations:
             - Range: 0xd030c0..0xd030c1
               Pieces: [{Size: 4, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 37
+    - ID: 31
       Name: main.testSingleUint64
       OutOfLinePCRanges: [0xd030e0..0xd030e1]
       InlinePCRanges: []
       Variables:
         - Name: x
-          Type: 26 BaseType uint64
+          Type: 10 BaseType uint64
           Locations:
             - Range: 0xd030e0..0xd030e1
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 38
+    - ID: 32
       Name: main.testSingleFloat32
       OutOfLinePCRanges: [0xd03100..0xd03101]
       InlinePCRanges: []
       Variables:
         - Name: x
-          Type: 30 BaseType float32
+          Type: 16 BaseType float32
           Locations:
             - Range: 0xd03100..0xd03101
               Pieces: [{Size: 4, Op: {RegNo: 17, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 39
+    - ID: 33
       Name: main.testSingleFloat64
       OutOfLinePCRanges: [0xd03120..0xd03121]
       InlinePCRanges: []
       Variables:
         - Name: x
-          Type: 31 BaseType float64
+          Type: 17 BaseType float64
           Locations:
             - Range: 0xd03120..0xd03121
               Pieces: [{Size: 8, Op: {RegNo: 17, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 40
+    - ID: 34
       Name: main.testTypeAlias
       OutOfLinePCRanges: [0xd03140..0xd03141]
       InlinePCRanges: []
       Variables:
         - Name: x
-          Type: 32 BaseType main.typeAlias
+          Type: 51 BaseType main.typeAlias
           Locations:
             - Range: 0xd03140..0xd03141
               Pieces: [{Size: 2, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 41
+    - ID: 35
       Name: main.testBigStruct
       OutOfLinePCRanges: [0xd032a0..0xd032bf]
       InlinePCRanges: []
       Variables:
         - Name: b
-          Type: 33 StructureType main.bigStruct
+          Type: 52 StructureType main.bigStruct
           Locations:
             - Range: 0xd032a0..0xd032bf
               Pieces:
@@ -1905,13 +1905,13 @@ Subprograms:
                   Op: {RegNo: 8, Shift: 0}
           IsParameter: true
           IsReturn: false
-    - ID: 42
+    - ID: 36
       Name: main.testEsotericStack
       OutOfLinePCRanges: [0xd03520..0xd03625]
       InlinePCRanges: []
       Variables:
         - Name: e
-          Type: 39 StructureType main.esotericStack
+          Type: 56 StructureType main.esotericStack
           Locations:
             - Range: 0xd03520..0xd03573
               Pieces:
@@ -1975,51 +1975,51 @@ Subprograms:
                   Op: {RegNo: 11, Shift: 0}
           IsParameter: true
           IsReturn: false
-    - ID: 43
+    - ID: 37
       Name: main.testEsotericHeap
       OutOfLinePCRanges: [0xd03640..0xd036a3]
       InlinePCRanges: []
       Variables:
         - Name: e
-          Type: 44 PointerType *main.esotericHeap
+          Type: 61 PointerType *main.esotericHeap
           Locations:
             - Range: 0xd03640..0xd0366d
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 44
+    - ID: 38
       Name: main.testInlinedBA
       OutOfLinePCRanges: [0xd03a80..0xd03b08]
       InlinePCRanges: []
       Variables:
         - Name: x
-          Type: 1 BaseType int
+          Type: 9 BaseType int
           Locations:
             - Range: 0xd03a80..0xd03a95
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 45
+    - ID: 39
       Name: main.testInlinedBB
       OutOfLinePCRanges: [0xd03b20..0xd03be5]
       InlinePCRanges: []
       Variables:
         - Name: x
-          Type: 1 BaseType int
+          Type: 9 BaseType int
           Locations:
             - Range: 0xd03b20..0xd03b36
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
         - Name: y
-          Type: 1 BaseType int
+          Type: 9 BaseType int
           Locations:
             - Range: 0xd03b20..0xd03b47
               Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
           IsParameter: true
           IsReturn: false
         - Name: z
-          Type: 1 BaseType int
+          Type: 9 BaseType int
           Locations:
             - Range: 0xd03b36..0xd03b47
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
@@ -2027,25 +2027,25 @@ Subprograms:
               Pieces: [{Size: 8, Op: {CfaOffset: -56}}]
           IsParameter: false
           IsReturn: false
-    - ID: 46
+    - ID: 40
       Name: main.testInlinedBBA
       OutOfLinePCRanges: [0xd03c00..0xd03c62]
       InlinePCRanges: []
       Variables:
         - Name: x
-          Type: 1 BaseType int
+          Type: 9 BaseType int
           Locations:
             - Range: 0xd03c00..0xd03c1a
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 47
+    - ID: 41
       Name: main.testInlinedBC
       OutOfLinePCRanges: [0xd03c80..0xd03d8e]
       InlinePCRanges: []
       Variables:
         - Name: s
-          Type: 1 BaseType int
+          Type: 9 BaseType int
           Locations:
             - Range: 0xd03cdb..0xd03ce5
               Pieces: [{Size: 8, Op: {CfaOffset: -80}}]
@@ -2056,7 +2056,7 @@ Subprograms:
           IsParameter: false
           IsReturn: false
         - Name: i
-          Type: 1 BaseType int
+          Type: 9 BaseType int
           Locations:
             - Range: 0xd03cd6..0xd03ce0
               Pieces: [{Size: 8, Op: {CfaOffset: -72}}]
@@ -2066,47 +2066,47 @@ Subprograms:
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: false
           IsReturn: false
-    - ID: 48
+    - ID: 42
       Name: main.testFrameless
       OutOfLinePCRanges: [0xd03da0..0xd03da6]
       InlinePCRanges: []
       Variables:
         - Name: x
-          Type: 1 BaseType int
+          Type: 9 BaseType int
           Locations:
             - Range: 0xd03da0..0xd03da5
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
         - Name: ~r0
-          Type: 1 BaseType int
+          Type: 9 BaseType int
           Locations: [{Range: 0xd03da0..0xd03da6, Pieces: []}]
           IsParameter: true
           IsReturn: true
-    - ID: 49
+    - ID: 43
       Name: main.testFramelessArray
       OutOfLinePCRanges: [0xd03dc0..0xd03e03]
       InlinePCRanges: []
       Variables:
         - Name: a
-          Type: 2 ArrayType [5]int
+          Type: 72 ArrayType [5]int
           Locations:
             - Range: 0xd03dc0..0xd03e03
               Pieces: [{Size: 40, Op: {CfaOffset: 0}}]
           IsParameter: true
           IsReturn: false
         - Name: ~r0
-          Type: 1 BaseType int
+          Type: 9 BaseType int
           Locations: [{Range: 0xd03dc0..0xd03e03, Pieces: []}]
           IsParameter: true
           IsReturn: true
-    - ID: 50
+    - ID: 44
       Name: main.testInterface
       OutOfLinePCRanges: [0xd040a0..0xd040e3]
       InlinePCRanges: []
       Variables:
         - Name: b
-          Type: 55 GoInterfaceType main.behavior
+          Type: 73 GoInterfaceType main.behavior
           Locations:
             - Range: 0xd040a0..0xd040bf
               Pieces:
@@ -2123,17 +2123,17 @@ Subprograms:
           IsParameter: true
           IsReturn: false
         - Name: ~r0
-          Type: 8 GoStringHeaderType string
+          Type: 11 GoStringHeaderType string
           Locations: [{Range: 0xd040a0..0xd040e3, Pieces: []}]
           IsParameter: true
           IsReturn: true
-    - ID: 51
+    - ID: 45
       Name: main.testAny
       OutOfLinePCRanges: [0xd04100..0xd04166]
       InlinePCRanges: []
       Variables:
         - Name: a
-          Type: 41 GoEmptyInterfaceType interface {}
+          Type: 58 GoEmptyInterfaceType interface {}
           Locations:
             - Range: 0xd04100..0xd04129
               Pieces:
@@ -2150,17 +2150,17 @@ Subprograms:
           IsParameter: true
           IsReturn: false
         - Name: ~r0
-          Type: 8 GoStringHeaderType string
+          Type: 11 GoStringHeaderType string
           Locations: [{Range: 0xd04100..0xd04166, Pieces: []}]
           IsParameter: true
           IsReturn: true
-    - ID: 52
+    - ID: 46
       Name: main.testError
       OutOfLinePCRanges: [0xd04180..0xd04181]
       InlinePCRanges: []
       Variables:
         - Name: e
-          Type: 56 GoInterfaceType error
+          Type: 18 GoInterfaceType error
           Locations:
             - Range: 0xd04180..0xd04181
               Pieces:
@@ -2170,307 +2170,307 @@ Subprograms:
                   Op: {RegNo: 3, Shift: 0}
           IsParameter: true
           IsReturn: false
-    - ID: 53
+    - ID: 47
       Name: main.testStructWithMap
       OutOfLinePCRanges: [0xd045e0..0xd045e1]
       InlinePCRanges: []
       Variables:
         - Name: s
-          Type: 57 StructureType main.structWithMap
+          Type: 74 StructureType main.structWithMap
           Locations:
             - Range: 0xd045e0..0xd045e1
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 54
+    - ID: 48
       Name: main.testMapStringToStruct
       OutOfLinePCRanges: [0xd04600..0xd04601]
       InlinePCRanges: []
       Variables:
         - Name: m
-          Type: 74 GoMapType map[string]main.nestedStruct
+          Type: 90 GoMapType map[string]main.nestedStruct
           Locations:
             - Range: 0xd04600..0xd04601
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 55
+    - ID: 49
       Name: main.testMapStringToInt
       OutOfLinePCRanges: [0xd04620..0xd04621]
       InlinePCRanges: []
       Variables:
         - Name: m
-          Type: 82 GoMapType map[string]int
+          Type: 98 GoMapType map[string]int
           Locations:
             - Range: 0xd04620..0xd04621
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 56
+    - ID: 50
       Name: main.testMapStringToSlice
       OutOfLinePCRanges: [0xd04640..0xd04641]
       InlinePCRanges: []
       Variables:
         - Name: m
-          Type: 87 GoMapType map[string][]string
+          Type: 103 GoMapType map[string][]string
           Locations:
             - Range: 0xd04640..0xd04641
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 57
+    - ID: 51
       Name: main.testMapArrayToArray
       OutOfLinePCRanges: [0xd04660..0xd04661]
       InlinePCRanges: []
       Variables:
         - Name: m
-          Type: 94 GoMapType map[[4]string][2]int
+          Type: 110 GoMapType map[[4]string][2]int
           Locations:
             - Range: 0xd04660..0xd04661
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 58
+    - ID: 52
       Name: main.testSmallMap
       OutOfLinePCRanges: [0xd04680..0xd04681]
       InlinePCRanges: []
       Variables:
         - Name: m
-          Type: 82 GoMapType map[string]int
+          Type: 98 GoMapType map[string]int
           Locations:
             - Range: 0xd04680..0xd04681
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 59
+    - ID: 53
       Name: main.testArrayOfMaps
       OutOfLinePCRanges: [0xd046a0..0xd046a1]
       InlinePCRanges: []
       Variables:
         - Name: m
-          Type: 102 ArrayType [2]map[string]int
+          Type: 118 ArrayType [2]map[string]int
           Locations:
             - Range: 0xd046a0..0xd046a1
               Pieces: [{Size: 16, Op: {CfaOffset: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 60
+    - ID: 54
       Name: main.testPointerToMap
       OutOfLinePCRanges: [0xd046c0..0xd046c1]
       InlinePCRanges: []
       Variables:
         - Name: m
-          Type: 103 PointerType *map[string]int
+          Type: 119 PointerType *map[string]int
           Locations:
             - Range: 0xd046c0..0xd046c1
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 61
+    - ID: 55
       Name: main.testMapIntToInt
       OutOfLinePCRanges: [0xd046e0..0xd046e1]
       InlinePCRanges: []
       Variables:
         - Name: m
-          Type: 58 GoMapType map[int]int
+          Type: 75 GoMapType map[int]int
           Locations:
             - Range: 0xd046e0..0xd046e1
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 62
+    - ID: 56
       Name: main.testMapMassive
       OutOfLinePCRanges: [0xd04700..0xd04701]
       InlinePCRanges: []
       Variables:
         - Name: redactMyEntries
-          Type: 104 GoMapType map[string][]main.structWithMap
+          Type: 120 GoMapType map[string][]main.structWithMap
           Locations:
             - Range: 0xd04700..0xd04701
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 63
+    - ID: 57
       Name: main.testMapEmbeddedMaps
       OutOfLinePCRanges: [0xd04720..0xd04721]
       InlinePCRanges: []
       Variables:
         - Name: m
-          Type: 104 GoMapType map[string][]main.structWithMap
+          Type: 120 GoMapType map[string][]main.structWithMap
           Locations:
             - Range: 0xd04720..0xd04721
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 64
+    - ID: 58
       Name: main.testMapWithLinkedList
       OutOfLinePCRanges: [0xd04740..0xd04741]
       InlinePCRanges: []
       Variables:
         - Name: m
-          Type: 112 GoMapType map[bool]main.node
+          Type: 128 GoMapType map[bool]main.node
           Locations:
             - Range: 0xd04740..0xd04741
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 65
+    - ID: 59
       Name: main.testMapWithSmallValue
       OutOfLinePCRanges: [0xd04760..0xd04761]
       InlinePCRanges: []
       Variables:
         - Name: m
-          Type: 121 GoMapType map[int]uint8
+          Type: 137 GoMapType map[int]uint8
           Locations:
             - Range: 0xd04760..0xd04761
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 66
+    - ID: 60
       Name: main.testMapWithSmallValueMassive
       OutOfLinePCRanges: [0xd04780..0xd04781]
       InlinePCRanges: []
       Variables:
         - Name: redactMyEntries
-          Type: 121 GoMapType map[int]uint8
+          Type: 137 GoMapType map[int]uint8
           Locations:
             - Range: 0xd04780..0xd04781
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 67
+    - ID: 61
       Name: main.testMapWithSmallKeyAndValue
       OutOfLinePCRanges: [0xd047a0..0xd047a1]
       InlinePCRanges: []
       Variables:
         - Name: m
-          Type: 127 GoMapType map[uint8]uint8
+          Type: 143 GoMapType map[uint8]uint8
           Locations:
             - Range: 0xd047a0..0xd047a1
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 68
+    - ID: 62
       Name: main.testMapWithSmallKeyAndValueMassive
       OutOfLinePCRanges: [0xd047c0..0xd047c1]
       InlinePCRanges: []
       Variables:
         - Name: m
-          Type: 127 GoMapType map[uint8]uint8
+          Type: 143 GoMapType map[uint8]uint8
           Locations:
             - Range: 0xd047c0..0xd047c1
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 69
+    - ID: 63
       Name: main.testMapSmallKeySmallValue
       OutOfLinePCRanges: [0xd047e0..0xd047e1]
       InlinePCRanges: []
       Variables:
         - Name: m
-          Type: 127 GoMapType map[uint8]uint8
+          Type: 143 GoMapType map[uint8]uint8
           Locations:
             - Range: 0xd047e0..0xd047e1
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 70
+    - ID: 64
       Name: main.testMapSmallKeyLargeValue
       OutOfLinePCRanges: [0xd04800..0xd04801]
       InlinePCRanges: []
       Variables:
         - Name: m
-          Type: 133 GoMapType map[uint8][4]int
+          Type: 149 GoMapType map[uint8][4]int
           Locations:
             - Range: 0xd04800..0xd04801
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 71
+    - ID: 65
       Name: main.testMapLargeKeySmallValue
       OutOfLinePCRanges: [0xd04820..0xd04821]
       InlinePCRanges: []
       Variables:
         - Name: m
-          Type: 140 GoMapType map[[4]int]uint8
+          Type: 156 GoMapType map[[4]int]uint8
           Locations:
             - Range: 0xd04820..0xd04821
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 72
+    - ID: 66
       Name: main.testMapLargeKeyLargeValue
       OutOfLinePCRanges: [0xd04840..0xd04841]
       InlinePCRanges: []
       Variables:
         - Name: m
-          Type: 146 GoMapType map[[4]int][4]int
+          Type: 162 GoMapType map[[4]int][4]int
           Locations:
             - Range: 0xd04840..0xd04841
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 73
+    - ID: 67
       Name: main.testCombinedByte
       OutOfLinePCRanges: [0xd05e00..0xd05e01]
       InlinePCRanges: []
       Variables:
         - Name: w
-          Type: 4 BaseType uint8
+          Type: 3 BaseType uint8
           Locations:
             - Range: 0xd05e00..0xd05e01
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
         - Name: x
-          Type: 4 BaseType uint8
+          Type: 3 BaseType uint8
           Locations:
             - Range: 0xd05e00..0xd05e01
               Pieces: [{Size: 1, Op: {RegNo: 3, Shift: 0}}]
           IsParameter: true
           IsReturn: false
         - Name: y
-          Type: 30 BaseType float32
+          Type: 16 BaseType float32
           Locations:
             - Range: 0xd05e00..0xd05e01
               Pieces: [{Size: 4, Op: {RegNo: 17, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 74
+    - ID: 68
       Name: main.testMultipleSimpleParams
       OutOfLinePCRanges: [0xd05fc0..0xd05fc1]
       InlinePCRanges: []
       Variables:
         - Name: a
-          Type: 11 BaseType bool
+          Type: 4 BaseType bool
           Locations:
             - Range: 0xd05fc0..0xd05fc1
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
         - Name: b
-          Type: 4 BaseType uint8
+          Type: 3 BaseType uint8
           Locations:
             - Range: 0xd05fc0..0xd05fc1
               Pieces: [{Size: 1, Op: {RegNo: 3, Shift: 0}}]
           IsParameter: true
           IsReturn: false
         - Name: c
-          Type: 6 BaseType int32
+          Type: 12 BaseType int32
           Locations:
             - Range: 0xd05fc0..0xd05fc1
               Pieces: [{Size: 4, Op: {RegNo: 2, Shift: 0}}]
           IsParameter: true
           IsReturn: false
         - Name: d
-          Type: 20 BaseType uint
+          Type: 15 BaseType uint
           Locations:
             - Range: 0xd05fc0..0xd05fc1
               Pieces: [{Size: 8, Op: {RegNo: 5, Shift: 0}}]
           IsParameter: true
           IsReturn: false
         - Name: e
-          Type: 8 GoStringHeaderType string
+          Type: 11 GoStringHeaderType string
           Locations:
             - Range: 0xd05fc0..0xd05fc1
               Pieces:
@@ -2480,37 +2480,37 @@ Subprograms:
                   Op: {RegNo: 8, Shift: 0}
           IsParameter: true
           IsReturn: false
-    - ID: 75
+    - ID: 69
       Name: main.testChannel
       OutOfLinePCRanges: [0xd061e0..0xd061e1]
       InlinePCRanges: []
       Variables:
         - Name: c
-          Type: 151 GoChannelType chan bool
+          Type: 167 GoChannelType chan bool
           Locations:
             - Range: 0xd061e0..0xd061e1
               Pieces: [{Size: 0, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 76
+    - ID: 70
       Name: main.testPointerToSimpleStruct
       OutOfLinePCRanges: [0xd063a0..0xd063a1]
       InlinePCRanges: []
       Variables:
         - Name: a
-          Type: 152 PointerType *main.structWithTwoValues
+          Type: 168 PointerType *main.structWithTwoValues
           Locations:
             - Range: 0xd063a0..0xd063a1
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 77
+    - ID: 71
       Name: main.testLinkedList
       OutOfLinePCRanges: [0xd063c0..0xd063c1]
       InlinePCRanges: []
       Variables:
         - Name: a
-          Type: 119 StructureType main.node
+          Type: 135 StructureType main.node
           Locations:
             - Range: 0xd063c0..0xd063c1
               Pieces:
@@ -2520,92 +2520,92 @@ Subprograms:
                   Op: {RegNo: 3, Shift: 0}
           IsParameter: true
           IsReturn: false
-    - ID: 78
+    - ID: 72
       Name: main.testPointerLoop
       OutOfLinePCRanges: [0xd063e0..0xd063e1]
       InlinePCRanges: []
       Variables:
         - Name: a
-          Type: 120 PointerType *main.node
+          Type: 136 PointerType *main.node
           Locations:
             - Range: 0xd063e0..0xd063e1
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 79
+    - ID: 73
       Name: main.testUnsafePointer
       OutOfLinePCRanges: [0xd06400..0xd06401]
       InlinePCRanges: []
       Variables:
         - Name: x
-          Type: 38 VoidPointerType unsafe.Pointer
+          Type: 19 VoidPointerType unsafe.Pointer
           Locations:
             - Range: 0xd06400..0xd06401
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 80
+    - ID: 74
       Name: main.testUintPointer
       OutOfLinePCRanges: [0xd06440..0xd06441]
       InlinePCRanges: []
       Variables:
         - Name: x
-          Type: 154 PointerType *uint
+          Type: 34 PointerType *uint
           Locations:
             - Range: 0xd06440..0xd06441
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 81
+    - ID: 75
       Name: main.testStringPointer
       OutOfLinePCRanges: [0xd06520..0xd06521]
       InlinePCRanges: []
       Variables:
         - Name: z
-          Type: 36 PointerType *string
+          Type: 22 PointerType *string
           Locations:
             - Range: 0xd06520..0xd06521
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 82
+    - ID: 76
       Name: main.testNilPointer
       OutOfLinePCRanges: [0xd06560..0xd06561]
       InlinePCRanges: []
       Variables:
         - Name: z
-          Type: 155 PointerType *bool
+          Type: 5 PointerType *bool
           Locations:
             - Range: 0xd06560..0xd06561
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
         - Name: a
-          Type: 20 BaseType uint
+          Type: 15 BaseType uint
           Locations:
             - Range: 0xd06560..0xd06561
               Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 83
+    - ID: 77
       Name: main.testCycle
       OutOfLinePCRanges: [0xd065a0..0xd065a1]
       InlinePCRanges: []
       Variables:
         - Name: t
-          Type: 156 PointerType *main.t
+          Type: 170 PointerType *main.t
           Locations:
             - Range: 0xd065a0..0xd065a1
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 84
+    - ID: 78
       Name: main.testUintSlice
       OutOfLinePCRanges: [0xd06ac0..0xd06ac1]
       InlinePCRanges: []
       Variables:
         - Name: u
-          Type: 159 GoSliceHeaderType []uint
+          Type: 173 GoSliceHeaderType []uint
           Locations:
             - Range: 0xd06ac0..0xd06ac1
               Pieces:
@@ -2617,13 +2617,13 @@ Subprograms:
                   Op: {RegNo: 2, Shift: 0}
           IsParameter: true
           IsReturn: false
-    - ID: 85
+    - ID: 79
       Name: main.testEmptySlice
       OutOfLinePCRanges: [0xd06ae0..0xd06ae1]
       InlinePCRanges: []
       Variables:
         - Name: u
-          Type: 159 GoSliceHeaderType []uint
+          Type: 173 GoSliceHeaderType []uint
           Locations:
             - Range: 0xd06ae0..0xd06ae1
               Pieces:
@@ -2635,13 +2635,13 @@ Subprograms:
                   Op: {RegNo: 2, Shift: 0}
           IsParameter: true
           IsReturn: false
-    - ID: 86
+    - ID: 80
       Name: main.testSliceOfSlices
       OutOfLinePCRanges: [0xd06b00..0xd06b01]
       InlinePCRanges: []
       Variables:
         - Name: u
-          Type: 160 GoSliceHeaderType [][]uint
+          Type: 174 GoSliceHeaderType [][]uint
           Locations:
             - Range: 0xd06b00..0xd06b01
               Pieces:
@@ -2653,13 +2653,13 @@ Subprograms:
                   Op: {RegNo: 2, Shift: 0}
           IsParameter: true
           IsReturn: false
-    - ID: 87
+    - ID: 81
       Name: main.testStructSlice
       OutOfLinePCRanges: [0xd06b20..0xd06b21]
       InlinePCRanges: []
       Variables:
         - Name: xs
-          Type: 162 GoSliceHeaderType []main.structWithNoStrings
+          Type: 176 GoSliceHeaderType []main.structWithNoStrings
           Locations:
             - Range: 0xd06b20..0xd06b21
               Pieces:
@@ -2672,19 +2672,19 @@ Subprograms:
           IsParameter: true
           IsReturn: false
         - Name: a
-          Type: 1 BaseType int
+          Type: 9 BaseType int
           Locations:
             - Range: 0xd06b20..0xd06b21
               Pieces: [{Size: 8, Op: {RegNo: 5, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 88
+    - ID: 82
       Name: main.testEmptySliceOfStructs
       OutOfLinePCRanges: [0xd06b40..0xd06b41]
       InlinePCRanges: []
       Variables:
         - Name: xs
-          Type: 162 GoSliceHeaderType []main.structWithNoStrings
+          Type: 176 GoSliceHeaderType []main.structWithNoStrings
           Locations:
             - Range: 0xd06b40..0xd06b41
               Pieces:
@@ -2697,19 +2697,19 @@ Subprograms:
           IsParameter: true
           IsReturn: false
         - Name: a
-          Type: 1 BaseType int
+          Type: 9 BaseType int
           Locations:
             - Range: 0xd06b40..0xd06b41
               Pieces: [{Size: 8, Op: {RegNo: 5, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 89
+    - ID: 83
       Name: main.testNilSliceOfStructs
       OutOfLinePCRanges: [0xd06b60..0xd06b61]
       InlinePCRanges: []
       Variables:
         - Name: xs
-          Type: 162 GoSliceHeaderType []main.structWithNoStrings
+          Type: 176 GoSliceHeaderType []main.structWithNoStrings
           Locations:
             - Range: 0xd06b60..0xd06b61
               Pieces:
@@ -2722,19 +2722,19 @@ Subprograms:
           IsParameter: true
           IsReturn: false
         - Name: a
-          Type: 1 BaseType int
+          Type: 9 BaseType int
           Locations:
             - Range: 0xd06b60..0xd06b61
               Pieces: [{Size: 8, Op: {RegNo: 5, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 90
+    - ID: 84
       Name: main.testStringSlice
       OutOfLinePCRanges: [0xd06b80..0xd06b81]
       InlinePCRanges: []
       Variables:
         - Name: s
-          Type: 93 GoSliceHeaderType []string
+          Type: 109 GoSliceHeaderType []string
           Locations:
             - Range: 0xd06b80..0xd06b81
               Pieces:
@@ -2746,7 +2746,7 @@ Subprograms:
                   Op: {RegNo: 2, Shift: 0}
           IsParameter: true
           IsReturn: false
-    - ID: 91
+    - ID: 85
       Name: main.testNilSliceWithOtherParams
       OutOfLinePCRanges: [0xd06ba0..0xd06ba1]
       InlinePCRanges: []
@@ -2759,7 +2759,7 @@ Subprograms:
           IsParameter: true
           IsReturn: false
         - Name: s
-          Type: 165 GoSliceHeaderType []bool
+          Type: 179 GoSliceHeaderType []bool
           Locations:
             - Range: 0xd06ba0..0xd06ba1
               Pieces:
@@ -2772,19 +2772,19 @@ Subprograms:
           IsParameter: true
           IsReturn: false
         - Name: x
-          Type: 20 BaseType uint
+          Type: 15 BaseType uint
           Locations:
             - Range: 0xd06ba0..0xd06ba1
               Pieces: [{Size: 8, Op: {RegNo: 4, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 92
+    - ID: 86
       Name: main.testNilSlice
       OutOfLinePCRanges: [0xd06bc0..0xd06bc1]
       InlinePCRanges: []
       Variables:
         - Name: xs
-          Type: 166 GoSliceHeaderType []uint16
+          Type: 180 GoSliceHeaderType []uint16
           Locations:
             - Range: 0xd06bc0..0xd06bc1
               Pieces:
@@ -2796,13 +2796,13 @@ Subprograms:
                   Op: {RegNo: 2, Shift: 0}
           IsParameter: true
           IsReturn: false
-    - ID: 93
+    - ID: 87
       Name: main.testVeryLargeSlice
       OutOfLinePCRanges: [0xd06be0..0xd06be1]
       InlinePCRanges: []
       Variables:
         - Name: xs
-          Type: 159 GoSliceHeaderType []uint
+          Type: 173 GoSliceHeaderType []uint
           Locations:
             - Range: 0xd06be0..0xd06be1
               Pieces:
@@ -2814,23 +2814,23 @@ Subprograms:
                   Op: {RegNo: 2, Shift: 0}
           IsParameter: true
           IsReturn: false
-    - ID: 94
+    - ID: 88
       Name: main.stackC
       OutOfLinePCRanges: [0xd06f20..0xd06f72]
       InlinePCRanges: []
       Variables:
         - Name: ~r0
-          Type: 8 GoStringHeaderType string
+          Type: 11 GoStringHeaderType string
           Locations: [{Range: 0xd06f20..0xd06f72, Pieces: []}]
           IsParameter: true
           IsReturn: true
-    - ID: 95
+    - ID: 89
       Name: main.testSingleString
       OutOfLinePCRanges: [0xd06f80..0xd06f81]
       InlinePCRanges: []
       Variables:
         - Name: x
-          Type: 8 GoStringHeaderType string
+          Type: 11 GoStringHeaderType string
           Locations:
             - Range: 0xd06f80..0xd06f81
               Pieces:
@@ -2840,13 +2840,13 @@ Subprograms:
                   Op: {RegNo: 3, Shift: 0}
           IsParameter: true
           IsReturn: false
-    - ID: 96
+    - ID: 90
       Name: main.testThreeStrings
       OutOfLinePCRanges: [0xd06fa0..0xd06fa1]
       InlinePCRanges: []
       Variables:
         - Name: x
-          Type: 8 GoStringHeaderType string
+          Type: 11 GoStringHeaderType string
           Locations:
             - Range: 0xd06fa0..0xd06fa1
               Pieces:
@@ -2857,7 +2857,7 @@ Subprograms:
           IsParameter: true
           IsReturn: false
         - Name: y
-          Type: 8 GoStringHeaderType string
+          Type: 11 GoStringHeaderType string
           Locations:
             - Range: 0xd06fa0..0xd06fa1
               Pieces:
@@ -2868,7 +2868,7 @@ Subprograms:
           IsParameter: true
           IsReturn: false
         - Name: z
-          Type: 8 GoStringHeaderType string
+          Type: 11 GoStringHeaderType string
           Locations:
             - Range: 0xd06fa0..0xd06fa1
               Pieces:
@@ -2878,13 +2878,13 @@ Subprograms:
                   Op: {RegNo: 8, Shift: 0}
           IsParameter: true
           IsReturn: false
-    - ID: 97
+    - ID: 91
       Name: main.testThreeStringsInStruct
       OutOfLinePCRanges: [0xd06fc0..0xd06fdf]
       InlinePCRanges: []
       Variables:
         - Name: a
-          Type: 168 StructureType main.threeStringStruct
+          Type: 181 StructureType main.threeStringStruct
           Locations:
             - Range: 0xd06fc0..0xd06fdf
               Pieces:
@@ -2902,37 +2902,37 @@ Subprograms:
                   Op: {RegNo: 8, Shift: 0}
           IsParameter: true
           IsReturn: false
-    - ID: 98
+    - ID: 92
       Name: main.testThreeStringsInStructPointer
       OutOfLinePCRanges: [0xd06fe0..0xd06fe1]
       InlinePCRanges: []
       Variables:
         - Name: a
-          Type: 169 PointerType *main.threeStringStruct
+          Type: 182 PointerType *main.threeStringStruct
           Locations:
             - Range: 0xd06fe0..0xd06fe1
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 99
+    - ID: 93
       Name: main.testOneStringInStructPointer
       OutOfLinePCRanges: [0xd07000..0xd07001]
       InlinePCRanges: []
       Variables:
         - Name: a
-          Type: 170 PointerType *main.oneStringStruct
+          Type: 183 PointerType *main.oneStringStruct
           Locations:
             - Range: 0xd07000..0xd07001
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 100
+    - ID: 94
       Name: main.testMassiveString
       OutOfLinePCRanges: [0xd07020..0xd07021]
       InlinePCRanges: []
       Variables:
         - Name: x
-          Type: 8 GoStringHeaderType string
+          Type: 11 GoStringHeaderType string
           Locations:
             - Range: 0xd07020..0xd07021
               Pieces:
@@ -2942,13 +2942,13 @@ Subprograms:
                   Op: {RegNo: 3, Shift: 0}
           IsParameter: true
           IsReturn: false
-    - ID: 101
+    - ID: 95
       Name: main.testUnitializedString
       OutOfLinePCRanges: [0xd07040..0xd07041]
       InlinePCRanges: []
       Variables:
         - Name: x
-          Type: 8 GoStringHeaderType string
+          Type: 11 GoStringHeaderType string
           Locations:
             - Range: 0xd07040..0xd07041
               Pieces:
@@ -2958,13 +2958,13 @@ Subprograms:
                   Op: {RegNo: 3, Shift: 0}
           IsParameter: true
           IsReturn: false
-    - ID: 102
+    - ID: 96
       Name: main.testEmptyString
       OutOfLinePCRanges: [0xd07060..0xd07061]
       InlinePCRanges: []
       Variables:
         - Name: x
-          Type: 8 GoStringHeaderType string
+          Type: 11 GoStringHeaderType string
           Locations:
             - Range: 0xd07060..0xd07061
               Pieces:
@@ -2974,13 +2974,13 @@ Subprograms:
                   Op: {RegNo: 3, Shift: 0}
           IsParameter: true
           IsReturn: false
-    - ID: 103
+    - ID: 97
       Name: main.testStruct
       OutOfLinePCRanges: [0xd072e0..0xd07303]
       InlinePCRanges: []
       Variables:
         - Name: x
-          Type: 172 StructureType main.aStruct
+          Type: 185 StructureType main.aStruct
           Locations:
             - Range: 0xd072e0..0xd07303
               Pieces:
@@ -3000,17 +3000,17 @@ Subprograms:
                   Op: {RegNo: 9, Shift: 0}
           IsParameter: true
           IsReturn: false
-    - ID: 104
+    - ID: 98
       Name: main.testEmptyStruct
       OutOfLinePCRanges: [0xd07460..0xd07461]
       InlinePCRanges: []
       Variables:
         - Name: e
-          Type: 173 StructureType main.emptyStruct
+          Type: 186 StructureType main.emptyStruct
           Locations: [{Range: 0xd07460..0xd07461, Pieces: []}]
           IsParameter: true
           IsReturn: false
-    - ID: 1
+    - ID: 99
       Name: main.testInlinedPrint
       OutOfLinePCRanges: [0xd038e0..0xd03942]
       InlinePCRanges:
@@ -3024,7 +3024,7 @@ Subprograms:
           RootRanges: [0xd03c00..0xd03c62]
       Variables:
         - Name: x
-          Type: 1 BaseType int
+          Type: 9 BaseType int
           Locations:
             - Range: 0xd038e0..0xd038f9
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
@@ -3040,28 +3040,28 @@ Subprograms:
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 2
+    - ID: 100
       Name: main.testInlinedBBB
       OutOfLinePCRanges: []
       InlinePCRanges:
         - Ranges: [0xd03b86..0xd03bbe]
           RootRanges: [0xd03b20..0xd03be5]
       Variables: []
-    - ID: 3
+    - ID: 101
       Name: main.testInlinedBCA
       OutOfLinePCRanges: []
       InlinePCRanges:
         - Ranges: [0xd03c93..0xd03cd1]
           RootRanges: [0xd03c80..0xd03d8e]
       Variables: []
-    - ID: 4
+    - ID: 102
       Name: main.testInlinedBCB
       OutOfLinePCRanges: []
       InlinePCRanges:
         - Ranges: [0xd03d46..0xd03d7e]
           RootRanges: [0xd03c80..0xd03d8e]
       Variables: []
-    - ID: 5
+    - ID: 103
       Name: main.testInlinedSq
       OutOfLinePCRanges: []
       InlinePCRanges:
@@ -3069,13 +3069,13 @@ Subprograms:
           RootRanges: [0xd03da0..0xd03da6]
       Variables:
         - Name: x
-          Type: 1 BaseType int
+          Type: 9 BaseType int
           Locations:
             - Range: 0xd03da0..0xd03da5
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 6
+    - ID: 104
       Name: main.testInlinedSumArray
       OutOfLinePCRanges: []
       InlinePCRanges:
@@ -3085,7 +3085,7 @@ Subprograms:
           RootRanges: [0xd03e20..0xd03fa5]
       Variables:
         - Name: a
-          Type: 2 ArrayType [5]int
+          Type: 72 ArrayType [5]int
           Locations:
             - Range: 0xd03dcd..0xd03e03
               Pieces: [{Size: 40, Op: {CfaOffset: -56}}]
@@ -3095,29 +3095,29 @@ Subprograms:
           IsReturn: false
 Types:
     - __kind: PointerType
-      ID: 158
+      ID: 172
       Name: '**main.t'
       ByteSize: 8
-      Pointee: 156 PointerType *main.t
+      Pointee: 170 PointerType *main.t
     - __kind: PointerType
-      ID: 71
+      ID: 87
       Name: '**runtime.bmap'
       ByteSize: 8
-      Pointee: 72 PointerType *runtime.bmap
+      Pointee: 88 PointerType *runtime.bmap
     - __kind: PointerType
-      ID: 35
+      ID: 54
       Name: '**string'
       ByteSize: 8
       GoRuntimeType: 486016
       GoKind: 22
-      Pointee: 36 PointerType *string
+      Pointee: 22 PointerType *string
     - __kind: PointerType
-      ID: 69
+      ID: 85
       Name: '*[]*runtime.bmap'
       ByteSize: 8
       GoRuntimeType: 451680
       GoKind: 22
-      Pointee: 70 GoSliceHeaderType []*runtime.bmap
+      Pointee: 86 GoSliceHeaderType []*runtime.bmap
     - __kind: PointerType
       ID: 193
       Name: '*[]*runtime.bmap.array'
@@ -3154,10 +3154,10 @@ Types:
       ByteSize: 8
       Pointee: 197 GoSliceDataType []string.array
     - __kind: PointerType
-      ID: 161
+      ID: 175
       Name: '*[]uint'
       ByteSize: 8
-      Pointee: 159 GoSliceHeaderType []uint
+      Pointee: 173 GoSliceHeaderType []uint
     - __kind: PointerType
       ID: 212
       Name: '*[]uint.array'
@@ -3169,317 +3169,317 @@ Types:
       ByteSize: 8
       Pointee: 219 GoSliceDataType []uint16.array
     - __kind: PointerType
-      ID: 155
+      ID: 5
       Name: '*bool'
       ByteSize: 8
       GoRuntimeType: 360224
       GoKind: 22
-      Pointee: 11 BaseType bool
+      Pointee: 4 BaseType bool
     - __kind: PointerType
-      ID: 149
+      ID: 165
       Name: '*bucket<[4]int,[4]int>'
       ByteSize: 8
-      Pointee: 150 GoHMapBucketType bucket<[4]int,[4]int>
+      Pointee: 166 GoHMapBucketType bucket<[4]int,[4]int>
     - __kind: PointerType
-      ID: 143
+      ID: 159
       Name: '*bucket<[4]int,uint8>'
       ByteSize: 8
-      Pointee: 144 GoHMapBucketType bucket<[4]int,uint8>
+      Pointee: 160 GoHMapBucketType bucket<[4]int,uint8>
     - __kind: PointerType
-      ID: 97
+      ID: 113
       Name: '*bucket<[4]string,[2]int>'
       ByteSize: 8
-      Pointee: 98 GoHMapBucketType bucket<[4]string,[2]int>
+      Pointee: 114 GoHMapBucketType bucket<[4]string,[2]int>
     - __kind: PointerType
-      ID: 115
+      ID: 131
       Name: '*bucket<bool,main.node>'
       ByteSize: 8
-      Pointee: 116 GoHMapBucketType bucket<bool,main.node>
+      Pointee: 132 GoHMapBucketType bucket<bool,main.node>
     - __kind: PointerType
-      ID: 61
+      ID: 78
       Name: '*bucket<int,int>'
       ByteSize: 8
-      Pointee: 62 GoHMapBucketType bucket<int,int>
+      Pointee: 79 GoHMapBucketType bucket<int,int>
     - __kind: PointerType
-      ID: 124
+      ID: 140
       Name: '*bucket<int,uint8>'
       ByteSize: 8
-      Pointee: 125 GoHMapBucketType bucket<int,uint8>
+      Pointee: 141 GoHMapBucketType bucket<int,uint8>
     - __kind: PointerType
-      ID: 107
+      ID: 123
       Name: '*bucket<string,[]main.structWithMap>'
       ByteSize: 8
-      Pointee: 108 GoHMapBucketType bucket<string,[]main.structWithMap>
+      Pointee: 124 GoHMapBucketType bucket<string,[]main.structWithMap>
     - __kind: PointerType
-      ID: 90
+      ID: 106
       Name: '*bucket<string,[]string>'
       ByteSize: 8
-      Pointee: 91 GoHMapBucketType bucket<string,[]string>
+      Pointee: 107 GoHMapBucketType bucket<string,[]string>
     - __kind: PointerType
-      ID: 85
+      ID: 101
       Name: '*bucket<string,int>'
       ByteSize: 8
-      Pointee: 86 GoHMapBucketType bucket<string,int>
+      Pointee: 102 GoHMapBucketType bucket<string,int>
     - __kind: PointerType
-      ID: 77
+      ID: 93
       Name: '*bucket<string,main.nestedStruct>'
       ByteSize: 8
-      Pointee: 78 GoHMapBucketType bucket<string,main.nestedStruct>
+      Pointee: 94 GoHMapBucketType bucket<string,main.nestedStruct>
     - __kind: PointerType
-      ID: 136
+      ID: 152
       Name: '*bucket<uint8,[4]int>'
       ByteSize: 8
-      Pointee: 137 GoHMapBucketType bucket<uint8,[4]int>
+      Pointee: 153 GoHMapBucketType bucket<uint8,[4]int>
     - __kind: PointerType
-      ID: 130
+      ID: 146
       Name: '*bucket<uint8,uint8>'
       ByteSize: 8
-      Pointee: 131 GoHMapBucketType bucket<uint8,uint8>
+      Pointee: 147 GoHMapBucketType bucket<uint8,uint8>
     - __kind: PointerType
-      ID: 185
+      ID: 33
       Name: '*error'
       ByteSize: 8
       GoRuntimeType: 359136
       GoKind: 22
-      Pointee: 56 GoInterfaceType error
+      Pointee: 18 GoInterfaceType error
     - __kind: PointerType
-      ID: 186
+      ID: 35
       Name: '*float32'
       ByteSize: 8
       GoRuntimeType: 360096
       GoKind: 22
-      Pointee: 30 BaseType float32
+      Pointee: 16 BaseType float32
     - __kind: PointerType
-      ID: 179
+      ID: 25
       Name: '*float64'
       ByteSize: 8
       GoRuntimeType: 360160
       GoKind: 22
-      Pointee: 31 BaseType float64
+      Pointee: 17 BaseType float64
     - __kind: PointerType
-      ID: 147
+      ID: 163
       Name: '*hash<[4]int,[4]int>'
       ByteSize: 8
-      Pointee: 148 GoHMapHeaderType hash<[4]int,[4]int>
+      Pointee: 164 GoHMapHeaderType hash<[4]int,[4]int>
     - __kind: PointerType
-      ID: 141
+      ID: 157
       Name: '*hash<[4]int,uint8>'
       ByteSize: 8
-      Pointee: 142 GoHMapHeaderType hash<[4]int,uint8>
+      Pointee: 158 GoHMapHeaderType hash<[4]int,uint8>
     - __kind: PointerType
-      ID: 95
+      ID: 111
       Name: '*hash<[4]string,[2]int>'
       ByteSize: 8
-      Pointee: 96 GoHMapHeaderType hash<[4]string,[2]int>
+      Pointee: 112 GoHMapHeaderType hash<[4]string,[2]int>
     - __kind: PointerType
-      ID: 113
+      ID: 129
       Name: '*hash<bool,main.node>'
       ByteSize: 8
-      Pointee: 114 GoHMapHeaderType hash<bool,main.node>
+      Pointee: 130 GoHMapHeaderType hash<bool,main.node>
     - __kind: PointerType
-      ID: 59
+      ID: 76
       Name: '*hash<int,int>'
       ByteSize: 8
-      Pointee: 60 GoHMapHeaderType hash<int,int>
+      Pointee: 77 GoHMapHeaderType hash<int,int>
     - __kind: PointerType
-      ID: 122
+      ID: 138
       Name: '*hash<int,uint8>'
       ByteSize: 8
-      Pointee: 123 GoHMapHeaderType hash<int,uint8>
+      Pointee: 139 GoHMapHeaderType hash<int,uint8>
     - __kind: PointerType
-      ID: 105
+      ID: 121
       Name: '*hash<string,[]main.structWithMap>'
       ByteSize: 8
-      Pointee: 106 GoHMapHeaderType hash<string,[]main.structWithMap>
+      Pointee: 122 GoHMapHeaderType hash<string,[]main.structWithMap>
     - __kind: PointerType
-      ID: 88
+      ID: 104
       Name: '*hash<string,[]string>'
       ByteSize: 8
-      Pointee: 89 GoHMapHeaderType hash<string,[]string>
+      Pointee: 105 GoHMapHeaderType hash<string,[]string>
     - __kind: PointerType
-      ID: 83
+      ID: 99
       Name: '*hash<string,int>'
       ByteSize: 8
-      Pointee: 84 GoHMapHeaderType hash<string,int>
+      Pointee: 100 GoHMapHeaderType hash<string,int>
     - __kind: PointerType
-      ID: 75
+      ID: 91
       Name: '*hash<string,main.nestedStruct>'
       ByteSize: 8
-      Pointee: 76 GoHMapHeaderType hash<string,main.nestedStruct>
+      Pointee: 92 GoHMapHeaderType hash<string,main.nestedStruct>
     - __kind: PointerType
-      ID: 134
+      ID: 150
       Name: '*hash<uint8,[4]int>'
       ByteSize: 8
-      Pointee: 135 GoHMapHeaderType hash<uint8,[4]int>
+      Pointee: 151 GoHMapHeaderType hash<uint8,[4]int>
     - __kind: PointerType
-      ID: 128
+      ID: 144
       Name: '*hash<uint8,uint8>'
       ByteSize: 8
-      Pointee: 129 GoHMapHeaderType hash<uint8,uint8>
+      Pointee: 145 GoHMapHeaderType hash<uint8,uint8>
     - __kind: PointerType
-      ID: 181
+      ID: 27
       Name: '*int'
       ByteSize: 8
       GoRuntimeType: 359776
       GoKind: 22
-      Pointee: 1 BaseType int
+      Pointee: 9 BaseType int
     - __kind: PointerType
-      ID: 183
+      ID: 30
       Name: '*int16'
       ByteSize: 8
       GoRuntimeType: 359392
       GoKind: 22
-      Pointee: 16 BaseType int16
+      Pointee: 31 BaseType int16
     - __kind: PointerType
-      ID: 175
+      ID: 20
       Name: '*int32'
       ByteSize: 8
       GoRuntimeType: 359520
       GoKind: 22
-      Pointee: 6 BaseType int32
+      Pointee: 12 BaseType int32
     - __kind: PointerType
-      ID: 180
+      ID: 26
       Name: '*int64'
       ByteSize: 8
       GoRuntimeType: 359648
       GoKind: 22
-      Pointee: 18 BaseType int64
+      Pointee: 13 BaseType int64
     - __kind: PointerType
-      ID: 184
+      ID: 32
       Name: '*int8'
       ByteSize: 8
       GoRuntimeType: 359264
       GoKind: 22
       Pointee: 14 BaseType int8
     - __kind: PointerType
-      ID: 44
+      ID: 61
       Name: '*main.esotericHeap'
       ByteSize: 8
       GoRuntimeType: 354144
       GoKind: 22
-      Pointee: 45 StructureType main.esotericHeap
+      Pointee: 62 StructureType main.esotericHeap
     - __kind: PointerType
-      ID: 120
+      ID: 136
       Name: '*main.node'
       ByteSize: 8
       GoRuntimeType: 354208
       GoKind: 22
-      Pointee: 119 StructureType main.node
+      Pointee: 135 StructureType main.node
     - __kind: PointerType
-      ID: 170
+      ID: 183
       Name: '*main.oneStringStruct'
       ByteSize: 8
       GoKind: 22
-      Pointee: 171 StructureType main.oneStringStruct
+      Pointee: 184 StructureType main.oneStringStruct
     - __kind: PointerType
-      ID: 111
+      ID: 127
       Name: '*main.structWithMap'
       ByteSize: 8
       GoRuntimeType: 354080
       GoKind: 22
-      Pointee: 57 StructureType main.structWithMap
+      Pointee: 74 StructureType main.structWithMap
     - __kind: PointerType
-      ID: 163
+      ID: 177
       Name: '*main.structWithNoStrings'
       ByteSize: 8
-      Pointee: 164 StructureType main.structWithNoStrings
+      Pointee: 178 StructureType main.structWithNoStrings
     - __kind: PointerType
-      ID: 152
+      ID: 168
       Name: '*main.structWithTwoValues'
       ByteSize: 8
       GoKind: 22
-      Pointee: 153 StructureType main.structWithTwoValues
+      Pointee: 169 StructureType main.structWithTwoValues
     - __kind: PointerType
-      ID: 156
+      ID: 170
       Name: '*main.t'
       ByteSize: 8
       GoKind: 22
-      Pointee: 157 GoSliceHeaderType main.t
+      Pointee: 171 GoSliceHeaderType main.t
     - __kind: PointerType
       ID: 210
       Name: '*main.t.array'
       ByteSize: 8
       Pointee: 209 GoSliceDataType main.t.array
     - __kind: PointerType
-      ID: 169
+      ID: 182
       Name: '*main.threeStringStruct'
       ByteSize: 8
       GoKind: 22
-      Pointee: 168 StructureType main.threeStringStruct
+      Pointee: 181 StructureType main.threeStringStruct
     - __kind: PointerType
-      ID: 103
+      ID: 119
       Name: '*map[string]int'
       ByteSize: 8
       GoKind: 22
-      Pointee: 82 GoMapType map[string]int
+      Pointee: 98 GoMapType map[string]int
     - __kind: PointerType
-      ID: 72
+      ID: 88
       Name: '*runtime.bmap'
       ByteSize: 8
       GoRuntimeType: 1.100896e+06
       GoKind: 22
-      Pointee: 73 StructureType runtime.bmap
+      Pointee: 89 StructureType runtime.bmap
     - __kind: PointerType
-      ID: 67
+      ID: 83
       Name: '*runtime.mapextra'
       ByteSize: 8
       GoRuntimeType: 363104
       GoKind: 22
-      Pointee: 68 StructureType runtime.mapextra
+      Pointee: 84 StructureType runtime.mapextra
     - __kind: PointerType
-      ID: 36
+      ID: 22
       Name: '*string'
       ByteSize: 8
       GoRuntimeType: 359200
       GoKind: 22
-      Pointee: 8 GoStringHeaderType string
+      Pointee: 11 GoStringHeaderType string
     - __kind: PointerType
       ID: 188
       Name: '*string.str'
       ByteSize: 8
       Pointee: 187 GoStringDataType string.str
     - __kind: PointerType
-      ID: 154
+      ID: 34
       Name: '*uint'
       ByteSize: 8
       GoRuntimeType: 359840
       GoKind: 22
-      Pointee: 20 BaseType uint
+      Pointee: 15 BaseType uint
     - __kind: PointerType
-      ID: 167
+      ID: 29
       Name: '*uint16'
       ByteSize: 8
       GoRuntimeType: 359456
       GoKind: 22
-      Pointee: 22 BaseType uint16
+      Pointee: 7 BaseType uint16
     - __kind: PointerType
-      ID: 176
+      ID: 21
       Name: '*uint32'
       ByteSize: 8
       GoRuntimeType: 359584
       GoKind: 22
-      Pointee: 24 BaseType uint32
+      Pointee: 2 BaseType uint32
     - __kind: PointerType
-      ID: 182
+      ID: 28
       Name: '*uint64'
       ByteSize: 8
       GoRuntimeType: 359712
       GoKind: 22
-      Pointee: 26 BaseType uint64
+      Pointee: 10 BaseType uint64
     - __kind: PointerType
-      ID: 9
+      ID: 6
       Name: '*uint8'
       ByteSize: 8
       GoRuntimeType: 359328
       GoKind: 22
-      Pointee: 4 BaseType uint8
+      Pointee: 3 BaseType uint8
     - __kind: PointerType
-      ID: 174
+      ID: 8
       Name: '*uintptr'
       ByteSize: 8
       GoRuntimeType: 359904
       GoKind: 22
-      Pointee: 66 BaseType uintptr
+      Pointee: 1 BaseType uintptr
     - __kind: EventRootType
       ID: 308
       Name: Probe[main.stackC]
@@ -3492,10 +3492,10 @@ Types:
         - Name: a
           Offset: 1
           Expression:
-            Type: 41 GoEmptyInterfaceType interface {}
+            Type: 58 GoEmptyInterfaceType interface {}
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 51, index: 0, name: a}
+                  Variable: {subprogram: 45, index: 0, name: a}
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
@@ -3507,10 +3507,10 @@ Types:
         - Name: b
           Offset: 1
           Expression:
-            Type: 28 ArrayType [2][2][2]int
+            Type: 49 ArrayType [2][2][2]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 23, index: 0, name: b}
+                  Variable: {subprogram: 17, index: 0, name: b}
                   Offset: 0
                   ByteSize: 64
     - __kind: EventRootType
@@ -3522,10 +3522,10 @@ Types:
         - Name: a
           Offset: 1
           Expression:
-            Type: 27 ArrayType [2][2]int
+            Type: 48 ArrayType [2][2]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 21, index: 0, name: a}
+                  Variable: {subprogram: 15, index: 0, name: a}
                   Offset: 0
                   ByteSize: 32
     - __kind: EventRootType
@@ -3537,10 +3537,10 @@ Types:
         - Name: m
           Offset: 1
           Expression:
-            Type: 102 ArrayType [2]map[string]int
+            Type: 118 ArrayType [2]map[string]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 59, index: 0, name: m}
+                  Variable: {subprogram: 53, index: 0, name: m}
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
@@ -3552,10 +3552,10 @@ Types:
         - Name: a
           Offset: 1
           Expression:
-            Type: 7 ArrayType [2]string
+            Type: 38 ArrayType [2]string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 22, index: 0, name: a}
+                  Variable: {subprogram: 16, index: 0, name: a}
                   Offset: 0
                   ByteSize: 32
     - __kind: EventRootType
@@ -3567,10 +3567,10 @@ Types:
         - Name: b
           Offset: 1
           Expression:
-            Type: 33 StructureType main.bigStruct
+            Type: 52 StructureType main.bigStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 41, index: 0, name: b}
+                  Variable: {subprogram: 35, index: 0, name: b}
                   Offset: 0
                   ByteSize: 48
     - __kind: EventRootType
@@ -3582,10 +3582,10 @@ Types:
         - Name: x
           Offset: 1
           Expression:
-            Type: 10 ArrayType [2]bool
+            Type: 39 ArrayType [2]bool
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 10, index: 0, name: x}
+                  Variable: {subprogram: 4, index: 0, name: x}
                   Offset: 0
                   ByteSize: 2
     - __kind: EventRootType
@@ -3597,10 +3597,10 @@ Types:
         - Name: x
           Offset: 1
           Expression:
-            Type: 3 ArrayType [2]uint8
+            Type: 36 ArrayType [2]uint8
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 7, index: 0, name: x}
+                  Variable: {subprogram: 1, index: 0, name: x}
                   Offset: 0
                   ByteSize: 2
     - __kind: EventRootType
@@ -3612,10 +3612,10 @@ Types:
         - Name: c
           Offset: 1
           Expression:
-            Type: 151 GoChannelType chan bool
+            Type: 167 GoChannelType chan bool
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 75, index: 0, name: c}
+                  Variable: {subprogram: 69, index: 0, name: c}
                   Offset: 0
                   ByteSize: 0
     - __kind: EventRootType
@@ -3627,28 +3627,28 @@ Types:
         - Name: w
           Offset: 1
           Expression:
-            Type: 4 BaseType uint8
+            Type: 3 BaseType uint8
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 73, index: 0, name: w}
+                  Variable: {subprogram: 67, index: 0, name: w}
                   Offset: 0
                   ByteSize: 1
         - Name: x
           Offset: 2
           Expression:
-            Type: 4 BaseType uint8
+            Type: 3 BaseType uint8
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 73, index: 1, name: x}
+                  Variable: {subprogram: 67, index: 1, name: x}
                   Offset: 0
                   ByteSize: 1
         - Name: y
           Offset: 3
           Expression:
-            Type: 30 BaseType float32
+            Type: 16 BaseType float32
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 73, index: 2, name: y}
+                  Variable: {subprogram: 67, index: 2, name: y}
                   Offset: 0
                   ByteSize: 4
     - __kind: EventRootType
@@ -3660,10 +3660,10 @@ Types:
         - Name: t
           Offset: 1
           Expression:
-            Type: 156 PointerType *main.t
+            Type: 170 PointerType *main.t
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 83, index: 0, name: t}
+                  Variable: {subprogram: 77, index: 0, name: t}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
@@ -3675,19 +3675,19 @@ Types:
         - Name: xs
           Offset: 1
           Expression:
-            Type: 162 GoSliceHeaderType []main.structWithNoStrings
+            Type: 176 GoSliceHeaderType []main.structWithNoStrings
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 88, index: 0, name: xs}
+                  Variable: {subprogram: 82, index: 0, name: xs}
                   Offset: 0
                   ByteSize: 24
         - Name: a
           Offset: 25
           Expression:
-            Type: 1 BaseType int
+            Type: 9 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 88, index: 1, name: a}
+                  Variable: {subprogram: 82, index: 1, name: a}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
@@ -3699,10 +3699,10 @@ Types:
         - Name: u
           Offset: 1
           Expression:
-            Type: 159 GoSliceHeaderType []uint
+            Type: 173 GoSliceHeaderType []uint
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 85, index: 0, name: u}
+                  Variable: {subprogram: 79, index: 0, name: u}
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
@@ -3714,10 +3714,10 @@ Types:
         - Name: x
           Offset: 1
           Expression:
-            Type: 8 GoStringHeaderType string
+            Type: 11 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 102, index: 0, name: x}
+                  Variable: {subprogram: 96, index: 0, name: x}
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
@@ -3729,10 +3729,10 @@ Types:
         - Name: e
           Offset: 1
           Expression:
-            Type: 173 StructureType main.emptyStruct
+            Type: 186 StructureType main.emptyStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 104, index: 0, name: e}
+                  Variable: {subprogram: 98, index: 0, name: e}
                   Offset: 0
                   ByteSize: 0
     - __kind: EventRootType
@@ -3744,10 +3744,10 @@ Types:
         - Name: e
           Offset: 1
           Expression:
-            Type: 56 GoInterfaceType error
+            Type: 18 GoInterfaceType error
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 52, index: 0, name: e}
+                  Variable: {subprogram: 46, index: 0, name: e}
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
@@ -3759,10 +3759,10 @@ Types:
         - Name: e
           Offset: 1
           Expression:
-            Type: 44 PointerType *main.esotericHeap
+            Type: 61 PointerType *main.esotericHeap
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 43, index: 0, name: e}
+                  Variable: {subprogram: 37, index: 0, name: e}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
@@ -3774,10 +3774,10 @@ Types:
         - Name: e
           Offset: 1
           Expression:
-            Type: 39 StructureType main.esotericStack
+            Type: 56 StructureType main.esotericStack
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 42, index: 0, name: e}
+                  Variable: {subprogram: 36, index: 0, name: e}
                   Offset: 0
                   ByteSize: 64
     - __kind: EventRootType
@@ -3789,10 +3789,10 @@ Types:
         - Name: a
           Offset: 1
           Expression:
-            Type: 2 ArrayType [5]int
+            Type: 72 ArrayType [5]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 49, index: 0, name: a}
+                  Variable: {subprogram: 43, index: 0, name: a}
                   Offset: 0
                   ByteSize: 40
     - __kind: EventRootType
@@ -3804,10 +3804,10 @@ Types:
         - Name: x
           Offset: 1
           Expression:
-            Type: 1 BaseType int
+            Type: 9 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 48, index: 0, name: x}
+                  Variable: {subprogram: 42, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
@@ -3819,10 +3819,10 @@ Types:
         - Name: x
           Offset: 1
           Expression:
-            Type: 1 BaseType int
+            Type: 9 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 44, index: 0, name: x}
+                  Variable: {subprogram: 38, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
@@ -3834,10 +3834,10 @@ Types:
         - Name: x
           Offset: 1
           Expression:
-            Type: 1 BaseType int
+            Type: 9 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 46, index: 0, name: x}
+                  Variable: {subprogram: 40, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
@@ -3852,19 +3852,19 @@ Types:
         - Name: x
           Offset: 1
           Expression:
-            Type: 1 BaseType int
+            Type: 9 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 45, index: 0, name: x}
+                  Variable: {subprogram: 39, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
         - Name: y
           Offset: 9
           Expression:
-            Type: 1 BaseType int
+            Type: 9 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 45, index: 1, name: y}
+                  Variable: {subprogram: 39, index: 1, name: y}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
@@ -3885,10 +3885,10 @@ Types:
         - Name: x
           Offset: 1
           Expression:
-            Type: 1 BaseType int
+            Type: 9 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 1, index: 0, name: x}
+                  Variable: {subprogram: 99, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
@@ -3900,10 +3900,10 @@ Types:
         - Name: x
           Offset: 1
           Expression:
-            Type: 1 BaseType int
+            Type: 9 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 5, index: 0, name: x}
+                  Variable: {subprogram: 103, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
@@ -3915,10 +3915,10 @@ Types:
         - Name: a
           Offset: 1
           Expression:
-            Type: 2 ArrayType [5]int
+            Type: 72 ArrayType [5]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 6, index: 0, name: a}
+                  Variable: {subprogram: 104, index: 0, name: a}
                   Offset: 0
                   ByteSize: 40
     - __kind: EventRootType
@@ -3930,10 +3930,10 @@ Types:
         - Name: x
           Offset: 1
           Expression:
-            Type: 15 ArrayType [2]int16
+            Type: 42 ArrayType [2]int16
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 13, index: 0, name: x}
+                  Variable: {subprogram: 7, index: 0, name: x}
                   Offset: 0
                   ByteSize: 4
     - __kind: EventRootType
@@ -3945,10 +3945,10 @@ Types:
         - Name: x
           Offset: 1
           Expression:
-            Type: 5 ArrayType [2]int32
+            Type: 37 ArrayType [2]int32
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 14, index: 0, name: x}
+                  Variable: {subprogram: 8, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
@@ -3960,10 +3960,10 @@ Types:
         - Name: x
           Offset: 1
           Expression:
-            Type: 17 ArrayType [2]int64
+            Type: 43 ArrayType [2]int64
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 15, index: 0, name: x}
+                  Variable: {subprogram: 9, index: 0, name: x}
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
@@ -3975,10 +3975,10 @@ Types:
         - Name: x
           Offset: 1
           Expression:
-            Type: 13 ArrayType [2]int8
+            Type: 41 ArrayType [2]int8
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 12, index: 0, name: x}
+                  Variable: {subprogram: 6, index: 0, name: x}
                   Offset: 0
                   ByteSize: 2
     - __kind: EventRootType
@@ -3990,10 +3990,10 @@ Types:
         - Name: x
           Offset: 1
           Expression:
-            Type: 12 ArrayType [2]int
+            Type: 40 ArrayType [2]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 11, index: 0, name: x}
+                  Variable: {subprogram: 5, index: 0, name: x}
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
@@ -4005,10 +4005,10 @@ Types:
         - Name: b
           Offset: 1
           Expression:
-            Type: 55 GoInterfaceType main.behavior
+            Type: 73 GoInterfaceType main.behavior
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 50, index: 0, name: b}
+                  Variable: {subprogram: 44, index: 0, name: b}
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
@@ -4020,10 +4020,10 @@ Types:
         - Name: a
           Offset: 1
           Expression:
-            Type: 119 StructureType main.node
+            Type: 135 StructureType main.node
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 77, index: 0, name: a}
+                  Variable: {subprogram: 71, index: 0, name: a}
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
@@ -4035,10 +4035,10 @@ Types:
         - Name: m
           Offset: 1
           Expression:
-            Type: 94 GoMapType map[[4]string][2]int
+            Type: 110 GoMapType map[[4]string][2]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 57, index: 0, name: m}
+                  Variable: {subprogram: 51, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
@@ -4050,10 +4050,10 @@ Types:
         - Name: m
           Offset: 1
           Expression:
-            Type: 104 GoMapType map[string][]main.structWithMap
+            Type: 120 GoMapType map[string][]main.structWithMap
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 63, index: 0, name: m}
+                  Variable: {subprogram: 57, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
@@ -4065,10 +4065,10 @@ Types:
         - Name: m
           Offset: 1
           Expression:
-            Type: 58 GoMapType map[int]int
+            Type: 75 GoMapType map[int]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 61, index: 0, name: m}
+                  Variable: {subprogram: 55, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
@@ -4080,10 +4080,10 @@ Types:
         - Name: m
           Offset: 1
           Expression:
-            Type: 146 GoMapType map[[4]int][4]int
+            Type: 162 GoMapType map[[4]int][4]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 72, index: 0, name: m}
+                  Variable: {subprogram: 66, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
@@ -4095,10 +4095,10 @@ Types:
         - Name: m
           Offset: 1
           Expression:
-            Type: 140 GoMapType map[[4]int]uint8
+            Type: 156 GoMapType map[[4]int]uint8
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 71, index: 0, name: m}
+                  Variable: {subprogram: 65, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
@@ -4110,10 +4110,10 @@ Types:
         - Name: redactMyEntries
           Offset: 1
           Expression:
-            Type: 104 GoMapType map[string][]main.structWithMap
+            Type: 120 GoMapType map[string][]main.structWithMap
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 62, index: 0, name: redactMyEntries}
+                  Variable: {subprogram: 56, index: 0, name: redactMyEntries}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
@@ -4125,10 +4125,10 @@ Types:
         - Name: m
           Offset: 1
           Expression:
-            Type: 133 GoMapType map[uint8][4]int
+            Type: 149 GoMapType map[uint8][4]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 70, index: 0, name: m}
+                  Variable: {subprogram: 64, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
@@ -4140,10 +4140,10 @@ Types:
         - Name: m
           Offset: 1
           Expression:
-            Type: 127 GoMapType map[uint8]uint8
+            Type: 143 GoMapType map[uint8]uint8
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 69, index: 0, name: m}
+                  Variable: {subprogram: 63, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
@@ -4155,10 +4155,10 @@ Types:
         - Name: m
           Offset: 1
           Expression:
-            Type: 82 GoMapType map[string]int
+            Type: 98 GoMapType map[string]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 55, index: 0, name: m}
+                  Variable: {subprogram: 49, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
@@ -4170,10 +4170,10 @@ Types:
         - Name: m
           Offset: 1
           Expression:
-            Type: 87 GoMapType map[string][]string
+            Type: 103 GoMapType map[string][]string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 56, index: 0, name: m}
+                  Variable: {subprogram: 50, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
@@ -4185,10 +4185,10 @@ Types:
         - Name: m
           Offset: 1
           Expression:
-            Type: 74 GoMapType map[string]main.nestedStruct
+            Type: 90 GoMapType map[string]main.nestedStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 54, index: 0, name: m}
+                  Variable: {subprogram: 48, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
@@ -4200,10 +4200,10 @@ Types:
         - Name: m
           Offset: 1
           Expression:
-            Type: 112 GoMapType map[bool]main.node
+            Type: 128 GoMapType map[bool]main.node
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 64, index: 0, name: m}
+                  Variable: {subprogram: 58, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
@@ -4215,10 +4215,10 @@ Types:
         - Name: m
           Offset: 1
           Expression:
-            Type: 127 GoMapType map[uint8]uint8
+            Type: 143 GoMapType map[uint8]uint8
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 68, index: 0, name: m}
+                  Variable: {subprogram: 62, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
@@ -4230,10 +4230,10 @@ Types:
         - Name: m
           Offset: 1
           Expression:
-            Type: 127 GoMapType map[uint8]uint8
+            Type: 143 GoMapType map[uint8]uint8
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 67, index: 0, name: m}
+                  Variable: {subprogram: 61, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
@@ -4245,10 +4245,10 @@ Types:
         - Name: redactMyEntries
           Offset: 1
           Expression:
-            Type: 121 GoMapType map[int]uint8
+            Type: 137 GoMapType map[int]uint8
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 66, index: 0, name: redactMyEntries}
+                  Variable: {subprogram: 60, index: 0, name: redactMyEntries}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
@@ -4260,10 +4260,10 @@ Types:
         - Name: m
           Offset: 1
           Expression:
-            Type: 121 GoMapType map[int]uint8
+            Type: 137 GoMapType map[int]uint8
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 65, index: 0, name: m}
+                  Variable: {subprogram: 59, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
@@ -4275,10 +4275,10 @@ Types:
         - Name: x
           Offset: 1
           Expression:
-            Type: 8 GoStringHeaderType string
+            Type: 11 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 100, index: 0, name: x}
+                  Variable: {subprogram: 94, index: 0, name: x}
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
@@ -4290,46 +4290,46 @@ Types:
         - Name: a
           Offset: 1
           Expression:
-            Type: 11 BaseType bool
+            Type: 4 BaseType bool
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 74, index: 0, name: a}
+                  Variable: {subprogram: 68, index: 0, name: a}
                   Offset: 0
                   ByteSize: 1
         - Name: b
           Offset: 2
           Expression:
-            Type: 4 BaseType uint8
+            Type: 3 BaseType uint8
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 74, index: 1, name: b}
+                  Variable: {subprogram: 68, index: 1, name: b}
                   Offset: 0
                   ByteSize: 1
         - Name: c
           Offset: 3
           Expression:
-            Type: 6 BaseType int32
+            Type: 12 BaseType int32
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 74, index: 2, name: c}
+                  Variable: {subprogram: 68, index: 2, name: c}
                   Offset: 0
                   ByteSize: 4
         - Name: d
           Offset: 7
           Expression:
-            Type: 20 BaseType uint
+            Type: 15 BaseType uint
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 74, index: 3, name: d}
+                  Variable: {subprogram: 68, index: 3, name: d}
                   Offset: 0
                   ByteSize: 8
         - Name: e
           Offset: 15
           Expression:
-            Type: 8 GoStringHeaderType string
+            Type: 11 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 74, index: 4, name: e}
+                  Variable: {subprogram: 68, index: 4, name: e}
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
@@ -4341,19 +4341,19 @@ Types:
         - Name: z
           Offset: 1
           Expression:
-            Type: 155 PointerType *bool
+            Type: 5 PointerType *bool
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 82, index: 0, name: z}
+                  Variable: {subprogram: 76, index: 0, name: z}
                   Offset: 0
                   ByteSize: 8
         - Name: a
           Offset: 9
           Expression:
-            Type: 20 BaseType uint
+            Type: 15 BaseType uint
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 82, index: 1, name: a}
+                  Variable: {subprogram: 76, index: 1, name: a}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
@@ -4365,19 +4365,19 @@ Types:
         - Name: xs
           Offset: 1
           Expression:
-            Type: 162 GoSliceHeaderType []main.structWithNoStrings
+            Type: 176 GoSliceHeaderType []main.structWithNoStrings
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 89, index: 0, name: xs}
+                  Variable: {subprogram: 83, index: 0, name: xs}
                   Offset: 0
                   ByteSize: 24
         - Name: a
           Offset: 25
           Expression:
-            Type: 1 BaseType int
+            Type: 9 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 89, index: 1, name: a}
+                  Variable: {subprogram: 83, index: 1, name: a}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
@@ -4392,25 +4392,25 @@ Types:
             Type: 14 BaseType int8
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 91, index: 0, name: a}
+                  Variable: {subprogram: 85, index: 0, name: a}
                   Offset: 0
                   ByteSize: 1
         - Name: s
           Offset: 2
           Expression:
-            Type: 165 GoSliceHeaderType []bool
+            Type: 179 GoSliceHeaderType []bool
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 91, index: 1, name: s}
+                  Variable: {subprogram: 85, index: 1, name: s}
                   Offset: 0
                   ByteSize: 24
         - Name: x
           Offset: 26
           Expression:
-            Type: 20 BaseType uint
+            Type: 15 BaseType uint
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 91, index: 2, name: x}
+                  Variable: {subprogram: 85, index: 2, name: x}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
@@ -4422,10 +4422,10 @@ Types:
         - Name: xs
           Offset: 1
           Expression:
-            Type: 166 GoSliceHeaderType []uint16
+            Type: 180 GoSliceHeaderType []uint16
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 92, index: 0, name: xs}
+                  Variable: {subprogram: 86, index: 0, name: xs}
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
@@ -4437,10 +4437,10 @@ Types:
         - Name: a
           Offset: 1
           Expression:
-            Type: 170 PointerType *main.oneStringStruct
+            Type: 183 PointerType *main.oneStringStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 99, index: 0, name: a}
+                  Variable: {subprogram: 93, index: 0, name: a}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
@@ -4452,10 +4452,10 @@ Types:
         - Name: a
           Offset: 1
           Expression:
-            Type: 120 PointerType *main.node
+            Type: 136 PointerType *main.node
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 78, index: 0, name: a}
+                  Variable: {subprogram: 72, index: 0, name: a}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
@@ -4467,10 +4467,10 @@ Types:
         - Name: m
           Offset: 1
           Expression:
-            Type: 103 PointerType *map[string]int
+            Type: 119 PointerType *map[string]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 60, index: 0, name: m}
+                  Variable: {subprogram: 54, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
@@ -4482,10 +4482,10 @@ Types:
         - Name: a
           Offset: 1
           Expression:
-            Type: 152 PointerType *main.structWithTwoValues
+            Type: 168 PointerType *main.structWithTwoValues
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 76, index: 0, name: a}
+                  Variable: {subprogram: 70, index: 0, name: a}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
@@ -4497,10 +4497,10 @@ Types:
         - Name: x
           Offset: 1
           Expression:
-            Type: 5 ArrayType [2]int32
+            Type: 37 ArrayType [2]int32
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 8, index: 0, name: x}
+                  Variable: {subprogram: 2, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
@@ -4512,10 +4512,10 @@ Types:
         - Name: x
           Offset: 1
           Expression:
-            Type: 11 BaseType bool
+            Type: 4 BaseType bool
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 27, index: 0, name: x}
+                  Variable: {subprogram: 21, index: 0, name: x}
                   Offset: 0
                   ByteSize: 1
     - __kind: EventRootType
@@ -4527,10 +4527,10 @@ Types:
         - Name: x
           Offset: 1
           Expression:
-            Type: 4 BaseType uint8
+            Type: 3 BaseType uint8
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 25, index: 0, name: x}
+                  Variable: {subprogram: 19, index: 0, name: x}
                   Offset: 0
                   ByteSize: 1
     - __kind: EventRootType
@@ -4542,10 +4542,10 @@ Types:
         - Name: x
           Offset: 1
           Expression:
-            Type: 30 BaseType float32
+            Type: 16 BaseType float32
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 38, index: 0, name: x}
+                  Variable: {subprogram: 32, index: 0, name: x}
                   Offset: 0
                   ByteSize: 4
     - __kind: EventRootType
@@ -4557,10 +4557,10 @@ Types:
         - Name: x
           Offset: 1
           Expression:
-            Type: 31 BaseType float64
+            Type: 17 BaseType float64
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 39, index: 0, name: x}
+                  Variable: {subprogram: 33, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
@@ -4572,10 +4572,10 @@ Types:
         - Name: x
           Offset: 1
           Expression:
-            Type: 16 BaseType int16
+            Type: 31 BaseType int16
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 30, index: 0, name: x}
+                  Variable: {subprogram: 24, index: 0, name: x}
                   Offset: 0
                   ByteSize: 2
     - __kind: EventRootType
@@ -4587,10 +4587,10 @@ Types:
         - Name: x
           Offset: 1
           Expression:
-            Type: 6 BaseType int32
+            Type: 12 BaseType int32
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 31, index: 0, name: x}
+                  Variable: {subprogram: 25, index: 0, name: x}
                   Offset: 0
                   ByteSize: 4
     - __kind: EventRootType
@@ -4602,10 +4602,10 @@ Types:
         - Name: x
           Offset: 1
           Expression:
-            Type: 18 BaseType int64
+            Type: 13 BaseType int64
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 32, index: 0, name: x}
+                  Variable: {subprogram: 26, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
@@ -4620,7 +4620,7 @@ Types:
             Type: 14 BaseType int8
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 29, index: 0, name: x}
+                  Variable: {subprogram: 23, index: 0, name: x}
                   Offset: 0
                   ByteSize: 1
     - __kind: EventRootType
@@ -4632,10 +4632,10 @@ Types:
         - Name: x
           Offset: 1
           Expression:
-            Type: 1 BaseType int
+            Type: 9 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 28, index: 0, name: x}
+                  Variable: {subprogram: 22, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
@@ -4647,10 +4647,10 @@ Types:
         - Name: x
           Offset: 1
           Expression:
-            Type: 6 BaseType int32
+            Type: 12 BaseType int32
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 26, index: 0, name: x}
+                  Variable: {subprogram: 20, index: 0, name: x}
                   Offset: 0
                   ByteSize: 4
     - __kind: EventRootType
@@ -4662,10 +4662,10 @@ Types:
         - Name: x
           Offset: 1
           Expression:
-            Type: 8 GoStringHeaderType string
+            Type: 11 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 95, index: 0, name: x}
+                  Variable: {subprogram: 89, index: 0, name: x}
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
@@ -4677,10 +4677,10 @@ Types:
         - Name: x
           Offset: 1
           Expression:
-            Type: 22 BaseType uint16
+            Type: 7 BaseType uint16
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 35, index: 0, name: x}
+                  Variable: {subprogram: 29, index: 0, name: x}
                   Offset: 0
                   ByteSize: 2
     - __kind: EventRootType
@@ -4692,10 +4692,10 @@ Types:
         - Name: x
           Offset: 1
           Expression:
-            Type: 24 BaseType uint32
+            Type: 2 BaseType uint32
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 36, index: 0, name: x}
+                  Variable: {subprogram: 30, index: 0, name: x}
                   Offset: 0
                   ByteSize: 4
     - __kind: EventRootType
@@ -4707,10 +4707,10 @@ Types:
         - Name: x
           Offset: 1
           Expression:
-            Type: 26 BaseType uint64
+            Type: 10 BaseType uint64
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 37, index: 0, name: x}
+                  Variable: {subprogram: 31, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
@@ -4722,10 +4722,10 @@ Types:
         - Name: x
           Offset: 1
           Expression:
-            Type: 4 BaseType uint8
+            Type: 3 BaseType uint8
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 34, index: 0, name: x}
+                  Variable: {subprogram: 28, index: 0, name: x}
                   Offset: 0
                   ByteSize: 1
     - __kind: EventRootType
@@ -4737,10 +4737,10 @@ Types:
         - Name: x
           Offset: 1
           Expression:
-            Type: 20 BaseType uint
+            Type: 15 BaseType uint
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 33, index: 0, name: x}
+                  Variable: {subprogram: 27, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
@@ -4752,10 +4752,10 @@ Types:
         - Name: u
           Offset: 1
           Expression:
-            Type: 160 GoSliceHeaderType [][]uint
+            Type: 174 GoSliceHeaderType [][]uint
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 86, index: 0, name: u}
+                  Variable: {subprogram: 80, index: 0, name: u}
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
@@ -4767,10 +4767,10 @@ Types:
         - Name: m
           Offset: 1
           Expression:
-            Type: 82 GoMapType map[string]int
+            Type: 98 GoMapType map[string]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 58, index: 0, name: m}
+                  Variable: {subprogram: 52, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
@@ -4782,10 +4782,10 @@ Types:
         - Name: x
           Offset: 1
           Expression:
-            Type: 7 ArrayType [2]string
+            Type: 38 ArrayType [2]string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 9, index: 0, name: x}
+                  Variable: {subprogram: 3, index: 0, name: x}
                   Offset: 0
                   ByteSize: 32
     - __kind: EventRootType
@@ -4797,10 +4797,10 @@ Types:
         - Name: z
           Offset: 1
           Expression:
-            Type: 36 PointerType *string
+            Type: 22 PointerType *string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 81, index: 0, name: z}
+                  Variable: {subprogram: 75, index: 0, name: z}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
@@ -4812,10 +4812,10 @@ Types:
         - Name: s
           Offset: 1
           Expression:
-            Type: 93 GoSliceHeaderType []string
+            Type: 109 GoSliceHeaderType []string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 90, index: 0, name: s}
+                  Variable: {subprogram: 84, index: 0, name: s}
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
@@ -4827,19 +4827,19 @@ Types:
         - Name: xs
           Offset: 1
           Expression:
-            Type: 162 GoSliceHeaderType []main.structWithNoStrings
+            Type: 176 GoSliceHeaderType []main.structWithNoStrings
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 87, index: 0, name: xs}
+                  Variable: {subprogram: 81, index: 0, name: xs}
                   Offset: 0
                   ByteSize: 24
         - Name: a
           Offset: 25
           Expression:
-            Type: 1 BaseType int
+            Type: 9 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 87, index: 1, name: a}
+                  Variable: {subprogram: 81, index: 1, name: a}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
@@ -4851,10 +4851,10 @@ Types:
         - Name: s
           Offset: 1
           Expression:
-            Type: 57 StructureType main.structWithMap
+            Type: 74 StructureType main.structWithMap
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 53, index: 0, name: s}
+                  Variable: {subprogram: 47, index: 0, name: s}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
@@ -4866,10 +4866,10 @@ Types:
         - Name: x
           Offset: 1
           Expression:
-            Type: 172 StructureType main.aStruct
+            Type: 185 StructureType main.aStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 103, index: 0, name: x}
+                  Variable: {subprogram: 97, index: 0, name: x}
                   Offset: 0
                   ByteSize: 56
     - __kind: EventRootType
@@ -4881,10 +4881,10 @@ Types:
         - Name: a
           Offset: 1
           Expression:
-            Type: 169 PointerType *main.threeStringStruct
+            Type: 182 PointerType *main.threeStringStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 98, index: 0, name: a}
+                  Variable: {subprogram: 92, index: 0, name: a}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
@@ -4896,10 +4896,10 @@ Types:
         - Name: a
           Offset: 1
           Expression:
-            Type: 168 StructureType main.threeStringStruct
+            Type: 181 StructureType main.threeStringStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 97, index: 0, name: a}
+                  Variable: {subprogram: 91, index: 0, name: a}
                   Offset: 0
                   ByteSize: 48
     - __kind: EventRootType
@@ -4911,28 +4911,28 @@ Types:
         - Name: x
           Offset: 1
           Expression:
-            Type: 8 GoStringHeaderType string
+            Type: 11 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 96, index: 0, name: x}
+                  Variable: {subprogram: 90, index: 0, name: x}
                   Offset: 0
                   ByteSize: 16
         - Name: y
           Offset: 17
           Expression:
-            Type: 8 GoStringHeaderType string
+            Type: 11 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 96, index: 1, name: y}
+                  Variable: {subprogram: 90, index: 1, name: y}
                   Offset: 0
                   ByteSize: 16
         - Name: z
           Offset: 33
           Expression:
-            Type: 8 GoStringHeaderType string
+            Type: 11 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 96, index: 2, name: z}
+                  Variable: {subprogram: 90, index: 2, name: z}
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
@@ -4944,10 +4944,10 @@ Types:
         - Name: x
           Offset: 1
           Expression:
-            Type: 32 BaseType main.typeAlias
+            Type: 51 BaseType main.typeAlias
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 40, index: 0, name: x}
+                  Variable: {subprogram: 34, index: 0, name: x}
                   Offset: 0
                   ByteSize: 2
     - __kind: EventRootType
@@ -4959,10 +4959,10 @@ Types:
         - Name: x
           Offset: 1
           Expression:
-            Type: 21 ArrayType [2]uint16
+            Type: 45 ArrayType [2]uint16
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 18, index: 0, name: x}
+                  Variable: {subprogram: 12, index: 0, name: x}
                   Offset: 0
                   ByteSize: 4
     - __kind: EventRootType
@@ -4974,10 +4974,10 @@ Types:
         - Name: x
           Offset: 1
           Expression:
-            Type: 23 ArrayType [2]uint32
+            Type: 46 ArrayType [2]uint32
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 19, index: 0, name: x}
+                  Variable: {subprogram: 13, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
@@ -4989,10 +4989,10 @@ Types:
         - Name: x
           Offset: 1
           Expression:
-            Type: 25 ArrayType [2]uint64
+            Type: 47 ArrayType [2]uint64
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 20, index: 0, name: x}
+                  Variable: {subprogram: 14, index: 0, name: x}
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
@@ -5004,10 +5004,10 @@ Types:
         - Name: x
           Offset: 1
           Expression:
-            Type: 3 ArrayType [2]uint8
+            Type: 36 ArrayType [2]uint8
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 17, index: 0, name: x}
+                  Variable: {subprogram: 11, index: 0, name: x}
                   Offset: 0
                   ByteSize: 2
     - __kind: EventRootType
@@ -5019,10 +5019,10 @@ Types:
         - Name: x
           Offset: 1
           Expression:
-            Type: 19 ArrayType [2]uint
+            Type: 44 ArrayType [2]uint
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 16, index: 0, name: x}
+                  Variable: {subprogram: 10, index: 0, name: x}
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
@@ -5034,10 +5034,10 @@ Types:
         - Name: x
           Offset: 1
           Expression:
-            Type: 154 PointerType *uint
+            Type: 34 PointerType *uint
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 80, index: 0, name: x}
+                  Variable: {subprogram: 74, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
@@ -5049,10 +5049,10 @@ Types:
         - Name: u
           Offset: 1
           Expression:
-            Type: 159 GoSliceHeaderType []uint
+            Type: 173 GoSliceHeaderType []uint
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 84, index: 0, name: u}
+                  Variable: {subprogram: 78, index: 0, name: u}
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
@@ -5064,10 +5064,10 @@ Types:
         - Name: x
           Offset: 1
           Expression:
-            Type: 8 GoStringHeaderType string
+            Type: 11 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 101, index: 0, name: x}
+                  Variable: {subprogram: 95, index: 0, name: x}
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
@@ -5079,10 +5079,10 @@ Types:
         - Name: x
           Offset: 1
           Expression:
-            Type: 38 VoidPointerType unsafe.Pointer
+            Type: 19 VoidPointerType unsafe.Pointer
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 79, index: 0, name: x}
+                  Variable: {subprogram: 73, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
@@ -5094,10 +5094,10 @@ Types:
         - Name: a
           Offset: 1
           Expression:
-            Type: 29 ArrayType [100]uint
+            Type: 50 ArrayType [100]uint
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 24, index: 0, name: a}
+                  Variable: {subprogram: 18, index: 0, name: a}
                   Offset: 0
                   ByteSize: 800
     - __kind: EventRootType
@@ -5109,80 +5109,80 @@ Types:
         - Name: xs
           Offset: 1
           Expression:
-            Type: 159 GoSliceHeaderType []uint
+            Type: 173 GoSliceHeaderType []uint
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 93, index: 0, name: xs}
+                  Variable: {subprogram: 87, index: 0, name: xs}
                   Offset: 0
                   ByteSize: 24
     - __kind: ArrayType
-      ID: 29
+      ID: 50
       Name: '[100]uint'
       ByteSize: 800
       GoKind: 17
       Count: 100
       HasCount: true
-      Element: 20 BaseType uint
+      Element: 15 BaseType uint
     - __kind: ArrayType
-      ID: 28
+      ID: 49
       Name: '[2][2][2]int'
       ByteSize: 64
       GoKind: 17
       Count: 2
       HasCount: true
-      Element: 27 ArrayType [2][2]int
+      Element: 48 ArrayType [2][2]int
     - __kind: ArrayType
-      ID: 27
+      ID: 48
       Name: '[2][2]int'
       ByteSize: 32
       GoKind: 17
       Count: 2
       HasCount: true
-      Element: 12 ArrayType [2]int
+      Element: 40 ArrayType [2]int
     - __kind: ArrayType
-      ID: 10
+      ID: 39
       Name: '[2]bool'
       ByteSize: 2
       GoKind: 17
       Count: 2
       HasCount: true
-      Element: 11 BaseType bool
+      Element: 4 BaseType bool
     - __kind: ArrayType
-      ID: 12
+      ID: 40
       Name: '[2]int'
       ByteSize: 16
       GoRuntimeType: 617728
       GoKind: 17
       Count: 2
       HasCount: true
-      Element: 1 BaseType int
+      Element: 9 BaseType int
     - __kind: ArrayType
-      ID: 15
+      ID: 42
       Name: '[2]int16'
       ByteSize: 4
       GoKind: 17
       Count: 2
       HasCount: true
-      Element: 16 BaseType int16
+      Element: 31 BaseType int16
     - __kind: ArrayType
-      ID: 5
+      ID: 37
       Name: '[2]int32'
       ByteSize: 8
       GoRuntimeType: 618880
       GoKind: 17
       Count: 2
       HasCount: true
-      Element: 6 BaseType int32
+      Element: 12 BaseType int32
     - __kind: ArrayType
-      ID: 17
+      ID: 43
       Name: '[2]int64'
       ByteSize: 16
       GoKind: 17
       Count: 2
       HasCount: true
-      Element: 18 BaseType int64
+      Element: 13 BaseType int64
     - __kind: ArrayType
-      ID: 13
+      ID: 41
       Name: '[2]int8'
       ByteSize: 2
       GoKind: 17
@@ -5190,101 +5190,101 @@ Types:
       HasCount: true
       Element: 14 BaseType int8
     - __kind: ArrayType
-      ID: 102
+      ID: 118
       Name: '[2]map[string]int'
       ByteSize: 16
       GoKind: 17
       Count: 2
       HasCount: true
-      Element: 82 GoMapType map[string]int
+      Element: 98 GoMapType map[string]int
     - __kind: ArrayType
-      ID: 7
+      ID: 38
       Name: '[2]string'
       ByteSize: 32
       GoRuntimeType: 618976
       GoKind: 17
       Count: 2
       HasCount: true
-      Element: 8 GoStringHeaderType string
+      Element: 11 GoStringHeaderType string
     - __kind: ArrayType
-      ID: 19
+      ID: 44
       Name: '[2]uint'
       ByteSize: 16
       GoKind: 17
       Count: 2
       HasCount: true
-      Element: 20 BaseType uint
+      Element: 15 BaseType uint
     - __kind: ArrayType
-      ID: 21
+      ID: 45
       Name: '[2]uint16'
       ByteSize: 4
       GoKind: 17
       Count: 2
       HasCount: true
-      Element: 22 BaseType uint16
+      Element: 7 BaseType uint16
     - __kind: ArrayType
-      ID: 23
+      ID: 46
       Name: '[2]uint32'
       ByteSize: 8
       GoKind: 17
       Count: 2
       HasCount: true
-      Element: 24 BaseType uint32
+      Element: 2 BaseType uint32
     - __kind: ArrayType
-      ID: 25
+      ID: 47
       Name: '[2]uint64'
       ByteSize: 16
       GoRuntimeType: 619072
       GoKind: 17
       Count: 2
       HasCount: true
-      Element: 26 BaseType uint64
+      Element: 10 BaseType uint64
     - __kind: ArrayType
-      ID: 3
+      ID: 36
       Name: '[2]uint8'
       ByteSize: 2
       GoRuntimeType: 618784
       GoKind: 17
       Count: 2
       HasCount: true
-      Element: 4 BaseType uint8
+      Element: 3 BaseType uint8
     - __kind: ArrayType
-      ID: 139
+      ID: 155
       Name: '[4]int'
       ByteSize: 32
       GoRuntimeType: 617344
       GoKind: 17
       Count: 4
       HasCount: true
-      Element: 1 BaseType int
+      Element: 9 BaseType int
     - __kind: ArrayType
-      ID: 100
+      ID: 116
       Name: '[4]string'
       ByteSize: 64
       GoRuntimeType: 617632
       GoKind: 17
       Count: 4
       HasCount: true
-      Element: 8 GoStringHeaderType string
+      Element: 11 GoStringHeaderType string
     - __kind: ArrayType
-      ID: 2
+      ID: 72
       Name: '[5]int'
       ByteSize: 40
       GoKind: 17
       Count: 5
       HasCount: true
-      Element: 1 BaseType int
+      Element: 9 BaseType int
     - __kind: ArrayType
-      ID: 63
+      ID: 80
       Name: '[8]uint8'
       ByteSize: 8
       GoRuntimeType: 615424
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 4 BaseType uint8
+      Element: 3 BaseType uint8
     - __kind: GoSliceHeaderType
-      ID: 70
+      ID: 86
       Name: '[]*runtime.bmap'
       ByteSize: 24
       GoRuntimeType: 451616
@@ -5292,21 +5292,21 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 71 PointerType **runtime.bmap
+          Type: 87 PointerType **runtime.bmap
         - Name: len
           Offset: 8
-          Type: 1 BaseType int
+          Type: 9 BaseType int
         - Name: cap
           Offset: 16
-          Type: 1 BaseType int
+          Type: 9 BaseType int
       Data: 192 GoSliceDataType []*runtime.bmap.array
     - __kind: GoSliceDataType
       ID: 192
       Name: '[]*runtime.bmap.array'
       ByteSize: 2048
-      Element: 72 PointerType *runtime.bmap
+      Element: 88 PointerType *runtime.bmap
     - __kind: GoSliceHeaderType
-      ID: 34
+      ID: 53
       Name: '[]*string'
       ByteSize: 24
       GoRuntimeType: 443232
@@ -5314,42 +5314,42 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 35 PointerType **string
+          Type: 54 PointerType **string
         - Name: len
           Offset: 8
-          Type: 1 BaseType int
+          Type: 9 BaseType int
         - Name: cap
           Offset: 16
-          Type: 1 BaseType int
+          Type: 9 BaseType int
       Data: 189 GoSliceDataType []*string.array
     - __kind: GoSliceDataType
       ID: 189
       Name: '[]*string.array'
       ByteSize: 2048
-      Element: 36 PointerType *string
+      Element: 22 PointerType *string
     - __kind: GoSliceHeaderType
-      ID: 160
+      ID: 174
       Name: '[][]uint'
       ByteSize: 24
       GoKind: 23
       RawFields:
         - Name: array
           Offset: 0
-          Type: 161 PointerType *[]uint
+          Type: 175 PointerType *[]uint
         - Name: len
           Offset: 8
-          Type: 1 BaseType int
+          Type: 9 BaseType int
         - Name: cap
           Offset: 16
-          Type: 1 BaseType int
+          Type: 9 BaseType int
       Data: 213 GoSliceDataType [][]uint.array
     - __kind: GoSliceDataType
       ID: 213
       Name: '[][]uint.array'
       ByteSize: 2048
-      Element: 159 GoSliceHeaderType []uint
+      Element: 173 GoSliceHeaderType []uint
     - __kind: GoSliceHeaderType
-      ID: 165
+      ID: 179
       Name: '[]bool'
       ByteSize: 24
       GoRuntimeType: 449760
@@ -5357,123 +5357,123 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 155 PointerType *bool
+          Type: 5 PointerType *bool
         - Name: len
           Offset: 8
-          Type: 1 BaseType int
+          Type: 9 BaseType int
         - Name: cap
           Offset: 16
-          Type: 1 BaseType int
+          Type: 9 BaseType int
       Data: 217 GoSliceDataType []bool.array
     - __kind: GoSliceDataType
       ID: 217
       Name: '[]bool.array'
       ByteSize: 2048
-      Element: 11 BaseType bool
+      Element: 4 BaseType bool
     - __kind: GoSliceDataType
       ID: 208
       Name: '[]bucket<[4]int,[4]int>.array'
       ByteSize: 2048
-      Element: 150 GoHMapBucketType bucket<[4]int,[4]int>
+      Element: 166 GoHMapBucketType bucket<[4]int,[4]int>
     - __kind: GoSliceDataType
       ID: 207
       Name: '[]bucket<[4]int,uint8>.array'
       ByteSize: 2048
-      Element: 144 GoHMapBucketType bucket<[4]int,uint8>
+      Element: 160 GoHMapBucketType bucket<[4]int,uint8>
     - __kind: GoSliceDataType
       ID: 199
       Name: '[]bucket<[4]string,[2]int>.array'
       ByteSize: 2048
-      Element: 98 GoHMapBucketType bucket<[4]string,[2]int>
+      Element: 114 GoHMapBucketType bucket<[4]string,[2]int>
     - __kind: GoSliceDataType
       ID: 203
       Name: '[]bucket<bool,main.node>.array'
       ByteSize: 2048
-      Element: 116 GoHMapBucketType bucket<bool,main.node>
+      Element: 132 GoHMapBucketType bucket<bool,main.node>
     - __kind: GoSliceDataType
       ID: 191
       Name: '[]bucket<int,int>.array'
       ByteSize: 2048
-      Element: 62 GoHMapBucketType bucket<int,int>
+      Element: 79 GoHMapBucketType bucket<int,int>
     - __kind: GoSliceDataType
       ID: 204
       Name: '[]bucket<int,uint8>.array'
       ByteSize: 2048
-      Element: 125 GoHMapBucketType bucket<int,uint8>
+      Element: 141 GoHMapBucketType bucket<int,uint8>
     - __kind: GoSliceDataType
       ID: 200
       Name: '[]bucket<string,[]main.structWithMap>.array'
       ByteSize: 2048
-      Element: 108 GoHMapBucketType bucket<string,[]main.structWithMap>
+      Element: 124 GoHMapBucketType bucket<string,[]main.structWithMap>
     - __kind: GoSliceDataType
       ID: 196
       Name: '[]bucket<string,[]string>.array'
       ByteSize: 2048
-      Element: 91 GoHMapBucketType bucket<string,[]string>
+      Element: 107 GoHMapBucketType bucket<string,[]string>
     - __kind: GoSliceDataType
       ID: 195
       Name: '[]bucket<string,int>.array'
       ByteSize: 2048
-      Element: 86 GoHMapBucketType bucket<string,int>
+      Element: 102 GoHMapBucketType bucket<string,int>
     - __kind: GoSliceDataType
       ID: 194
       Name: '[]bucket<string,main.nestedStruct>.array'
       ByteSize: 2048
-      Element: 78 GoHMapBucketType bucket<string,main.nestedStruct>
+      Element: 94 GoHMapBucketType bucket<string,main.nestedStruct>
     - __kind: GoSliceDataType
       ID: 206
       Name: '[]bucket<uint8,[4]int>.array'
       ByteSize: 2048
-      Element: 137 GoHMapBucketType bucket<uint8,[4]int>
+      Element: 153 GoHMapBucketType bucket<uint8,[4]int>
     - __kind: GoSliceDataType
       ID: 205
       Name: '[]bucket<uint8,uint8>.array'
       ByteSize: 2048
-      Element: 131 GoHMapBucketType bucket<uint8,uint8>
+      Element: 147 GoHMapBucketType bucket<uint8,uint8>
     - __kind: ArrayType
-      ID: 145
+      ID: 161
       Name: '[]key<[4]int>'
       ByteSize: 256
       Count: 8
       HasCount: true
-      Element: 139 ArrayType [4]int
+      Element: 155 ArrayType [4]int
     - __kind: ArrayType
-      ID: 99
+      ID: 115
       Name: '[]key<[4]string>'
       ByteSize: 512
       Count: 8
       HasCount: true
-      Element: 100 ArrayType [4]string
+      Element: 116 ArrayType [4]string
     - __kind: ArrayType
-      ID: 117
+      ID: 133
       Name: '[]key<bool>'
       ByteSize: 8
       Count: 8
       HasCount: true
-      Element: 11 BaseType bool
+      Element: 4 BaseType bool
     - __kind: ArrayType
-      ID: 64
+      ID: 81
       Name: '[]key<int>'
       ByteSize: 64
       Count: 8
       HasCount: true
-      Element: 1 BaseType int
+      Element: 9 BaseType int
     - __kind: ArrayType
-      ID: 79
+      ID: 95
       Name: '[]key<string>'
       ByteSize: 128
       Count: 8
       HasCount: true
-      Element: 8 GoStringHeaderType string
+      Element: 11 GoStringHeaderType string
     - __kind: ArrayType
-      ID: 132
+      ID: 148
       Name: '[]key<uint8>'
       ByteSize: 8
       Count: 8
       HasCount: true
-      Element: 4 BaseType uint8
+      Element: 3 BaseType uint8
     - __kind: GoSliceHeaderType
-      ID: 110
+      ID: 126
       Name: '[]main.structWithMap'
       ByteSize: 24
       GoRuntimeType: 442720
@@ -5481,42 +5481,42 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 111 PointerType *main.structWithMap
+          Type: 127 PointerType *main.structWithMap
         - Name: len
           Offset: 8
-          Type: 1 BaseType int
+          Type: 9 BaseType int
         - Name: cap
           Offset: 16
-          Type: 1 BaseType int
+          Type: 9 BaseType int
       Data: 201 GoSliceDataType []main.structWithMap.array
     - __kind: GoSliceDataType
       ID: 201
       Name: '[]main.structWithMap.array'
       ByteSize: 2048
-      Element: 57 StructureType main.structWithMap
+      Element: 74 StructureType main.structWithMap
     - __kind: GoSliceHeaderType
-      ID: 162
+      ID: 176
       Name: '[]main.structWithNoStrings'
       ByteSize: 24
       GoKind: 23
       RawFields:
         - Name: array
           Offset: 0
-          Type: 163 PointerType *main.structWithNoStrings
+          Type: 177 PointerType *main.structWithNoStrings
         - Name: len
           Offset: 8
-          Type: 1 BaseType int
+          Type: 9 BaseType int
         - Name: cap
           Offset: 16
-          Type: 1 BaseType int
+          Type: 9 BaseType int
       Data: 215 GoSliceDataType []main.structWithNoStrings.array
     - __kind: GoSliceDataType
       ID: 215
       Name: '[]main.structWithNoStrings.array'
       ByteSize: 2048
-      Element: 164 StructureType main.structWithNoStrings
+      Element: 178 StructureType main.structWithNoStrings
     - __kind: GoSliceHeaderType
-      ID: 93
+      ID: 109
       Name: '[]string'
       ByteSize: 24
       GoRuntimeType: 449888
@@ -5524,21 +5524,21 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 36 PointerType *string
+          Type: 22 PointerType *string
         - Name: len
           Offset: 8
-          Type: 1 BaseType int
+          Type: 9 BaseType int
         - Name: cap
           Offset: 16
-          Type: 1 BaseType int
+          Type: 9 BaseType int
       Data: 197 GoSliceDataType []string.array
     - __kind: GoSliceDataType
       ID: 197
       Name: '[]string.array'
       ByteSize: 2048
-      Element: 8 GoStringHeaderType string
+      Element: 11 GoStringHeaderType string
     - __kind: GoSliceHeaderType
-      ID: 159
+      ID: 173
       Name: '[]uint'
       ByteSize: 24
       GoRuntimeType: 449376
@@ -5546,21 +5546,21 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 154 PointerType *uint
+          Type: 34 PointerType *uint
         - Name: len
           Offset: 8
-          Type: 1 BaseType int
+          Type: 9 BaseType int
         - Name: cap
           Offset: 16
-          Type: 1 BaseType int
+          Type: 9 BaseType int
       Data: 211 GoSliceDataType []uint.array
     - __kind: GoSliceDataType
       ID: 211
       Name: '[]uint.array'
       ByteSize: 2048
-      Element: 20 BaseType uint
+      Element: 15 BaseType uint
     - __kind: GoSliceHeaderType
-      ID: 166
+      ID: 180
       Name: '[]uint16'
       ByteSize: 24
       GoRuntimeType: 448736
@@ -5568,333 +5568,333 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 167 PointerType *uint16
+          Type: 29 PointerType *uint16
         - Name: len
           Offset: 8
-          Type: 1 BaseType int
+          Type: 9 BaseType int
         - Name: cap
           Offset: 16
-          Type: 1 BaseType int
+          Type: 9 BaseType int
       Data: 219 GoSliceDataType []uint16.array
     - __kind: GoSliceDataType
       ID: 219
       Name: '[]uint16.array'
       ByteSize: 2048
-      Element: 22 BaseType uint16
+      Element: 7 BaseType uint16
     - __kind: ArrayType
-      ID: 101
+      ID: 117
       Name: '[]val<[2]int>'
       ByteSize: 128
       Count: 8
       HasCount: true
-      Element: 12 ArrayType [2]int
+      Element: 40 ArrayType [2]int
     - __kind: ArrayType
-      ID: 138
+      ID: 154
       Name: '[]val<[4]int>'
       ByteSize: 256
       Count: 8
       HasCount: true
-      Element: 139 ArrayType [4]int
+      Element: 155 ArrayType [4]int
     - __kind: ArrayType
-      ID: 109
+      ID: 125
       Name: '[]val<[]main.structWithMap>'
       ByteSize: 192
       Count: 8
       HasCount: true
-      Element: 110 GoSliceHeaderType []main.structWithMap
+      Element: 126 GoSliceHeaderType []main.structWithMap
     - __kind: ArrayType
-      ID: 92
+      ID: 108
       Name: '[]val<[]string>'
       ByteSize: 192
       Count: 8
       HasCount: true
-      Element: 93 GoSliceHeaderType []string
+      Element: 109 GoSliceHeaderType []string
     - __kind: ArrayType
-      ID: 65
+      ID: 82
       Name: '[]val<int>'
       ByteSize: 64
       Count: 8
       HasCount: true
-      Element: 1 BaseType int
+      Element: 9 BaseType int
     - __kind: ArrayType
-      ID: 80
+      ID: 96
       Name: '[]val<main.nestedStruct>'
       ByteSize: 192
       Count: 8
       HasCount: true
-      Element: 81 StructureType main.nestedStruct
+      Element: 97 StructureType main.nestedStruct
     - __kind: ArrayType
-      ID: 118
+      ID: 134
       Name: '[]val<main.node>'
       ByteSize: 128
       Count: 8
       HasCount: true
-      Element: 119 StructureType main.node
+      Element: 135 StructureType main.node
     - __kind: ArrayType
-      ID: 126
+      ID: 142
       Name: '[]val<uint8>'
       ByteSize: 8
       Count: 8
       HasCount: true
-      Element: 4 BaseType uint8
+      Element: 3 BaseType uint8
     - __kind: BaseType
-      ID: 11
+      ID: 4
       Name: bool
       ByteSize: 1
       GoRuntimeType: 527872
       GoKind: 1
     - __kind: GoHMapBucketType
-      ID: 150
+      ID: 166
       Name: bucket<[4]int,[4]int>
       ByteSize: 528
       RawFields:
         - Name: tophash
           Offset: 0
-          Type: 63 ArrayType [8]uint8
+          Type: 80 ArrayType [8]uint8
         - Name: keys
           Offset: 8
-          Type: 145 ArrayType []key<[4]int>
+          Type: 161 ArrayType []key<[4]int>
         - Name: values
           Offset: 264
-          Type: 138 ArrayType []val<[4]int>
+          Type: 154 ArrayType []val<[4]int>
         - Name: overflow
           Offset: 520
-          Type: 149 PointerType *bucket<[4]int,[4]int>
-      KeyType: 139 ArrayType [4]int
-      ValueType: 139 ArrayType [4]int
+          Type: 165 PointerType *bucket<[4]int,[4]int>
+      KeyType: 155 ArrayType [4]int
+      ValueType: 155 ArrayType [4]int
     - __kind: GoHMapBucketType
-      ID: 144
+      ID: 160
       Name: bucket<[4]int,uint8>
       ByteSize: 280
       RawFields:
         - Name: tophash
           Offset: 0
-          Type: 63 ArrayType [8]uint8
+          Type: 80 ArrayType [8]uint8
         - Name: keys
           Offset: 8
-          Type: 145 ArrayType []key<[4]int>
+          Type: 161 ArrayType []key<[4]int>
         - Name: values
           Offset: 264
-          Type: 126 ArrayType []val<uint8>
+          Type: 142 ArrayType []val<uint8>
         - Name: overflow
           Offset: 272
-          Type: 143 PointerType *bucket<[4]int,uint8>
-      KeyType: 139 ArrayType [4]int
-      ValueType: 4 BaseType uint8
+          Type: 159 PointerType *bucket<[4]int,uint8>
+      KeyType: 155 ArrayType [4]int
+      ValueType: 3 BaseType uint8
     - __kind: GoHMapBucketType
-      ID: 98
+      ID: 114
       Name: bucket<[4]string,[2]int>
       ByteSize: 656
       RawFields:
         - Name: tophash
           Offset: 0
-          Type: 63 ArrayType [8]uint8
+          Type: 80 ArrayType [8]uint8
         - Name: keys
           Offset: 8
-          Type: 99 ArrayType []key<[4]string>
+          Type: 115 ArrayType []key<[4]string>
         - Name: values
           Offset: 520
-          Type: 101 ArrayType []val<[2]int>
+          Type: 117 ArrayType []val<[2]int>
         - Name: overflow
           Offset: 648
-          Type: 97 PointerType *bucket<[4]string,[2]int>
-      KeyType: 100 ArrayType [4]string
-      ValueType: 12 ArrayType [2]int
+          Type: 113 PointerType *bucket<[4]string,[2]int>
+      KeyType: 116 ArrayType [4]string
+      ValueType: 40 ArrayType [2]int
     - __kind: GoHMapBucketType
-      ID: 116
+      ID: 132
       Name: bucket<bool,main.node>
       ByteSize: 152
       RawFields:
         - Name: tophash
           Offset: 0
-          Type: 63 ArrayType [8]uint8
+          Type: 80 ArrayType [8]uint8
         - Name: keys
           Offset: 8
-          Type: 117 ArrayType []key<bool>
+          Type: 133 ArrayType []key<bool>
         - Name: values
           Offset: 16
-          Type: 118 ArrayType []val<main.node>
+          Type: 134 ArrayType []val<main.node>
         - Name: overflow
           Offset: 144
-          Type: 115 PointerType *bucket<bool,main.node>
-      KeyType: 11 BaseType bool
-      ValueType: 119 StructureType main.node
+          Type: 131 PointerType *bucket<bool,main.node>
+      KeyType: 4 BaseType bool
+      ValueType: 135 StructureType main.node
     - __kind: GoHMapBucketType
-      ID: 62
+      ID: 79
       Name: bucket<int,int>
       ByteSize: 144
       RawFields:
         - Name: tophash
           Offset: 0
-          Type: 63 ArrayType [8]uint8
+          Type: 80 ArrayType [8]uint8
         - Name: keys
           Offset: 8
-          Type: 64 ArrayType []key<int>
+          Type: 81 ArrayType []key<int>
         - Name: values
           Offset: 72
-          Type: 65 ArrayType []val<int>
+          Type: 82 ArrayType []val<int>
         - Name: overflow
           Offset: 136
-          Type: 61 PointerType *bucket<int,int>
-      KeyType: 1 BaseType int
-      ValueType: 1 BaseType int
+          Type: 78 PointerType *bucket<int,int>
+      KeyType: 9 BaseType int
+      ValueType: 9 BaseType int
     - __kind: GoHMapBucketType
-      ID: 125
+      ID: 141
       Name: bucket<int,uint8>
       ByteSize: 88
       RawFields:
         - Name: tophash
           Offset: 0
-          Type: 63 ArrayType [8]uint8
+          Type: 80 ArrayType [8]uint8
         - Name: keys
           Offset: 8
-          Type: 64 ArrayType []key<int>
+          Type: 81 ArrayType []key<int>
         - Name: values
           Offset: 72
-          Type: 126 ArrayType []val<uint8>
+          Type: 142 ArrayType []val<uint8>
         - Name: overflow
           Offset: 80
-          Type: 124 PointerType *bucket<int,uint8>
-      KeyType: 1 BaseType int
-      ValueType: 4 BaseType uint8
+          Type: 140 PointerType *bucket<int,uint8>
+      KeyType: 9 BaseType int
+      ValueType: 3 BaseType uint8
     - __kind: GoHMapBucketType
-      ID: 108
+      ID: 124
       Name: bucket<string,[]main.structWithMap>
       ByteSize: 336
       RawFields:
         - Name: tophash
           Offset: 0
-          Type: 63 ArrayType [8]uint8
+          Type: 80 ArrayType [8]uint8
         - Name: keys
           Offset: 8
-          Type: 79 ArrayType []key<string>
+          Type: 95 ArrayType []key<string>
         - Name: values
           Offset: 136
-          Type: 109 ArrayType []val<[]main.structWithMap>
+          Type: 125 ArrayType []val<[]main.structWithMap>
         - Name: overflow
           Offset: 328
-          Type: 107 PointerType *bucket<string,[]main.structWithMap>
-      KeyType: 8 GoStringHeaderType string
-      ValueType: 110 GoSliceHeaderType []main.structWithMap
+          Type: 123 PointerType *bucket<string,[]main.structWithMap>
+      KeyType: 11 GoStringHeaderType string
+      ValueType: 126 GoSliceHeaderType []main.structWithMap
     - __kind: GoHMapBucketType
-      ID: 91
+      ID: 107
       Name: bucket<string,[]string>
       ByteSize: 336
       RawFields:
         - Name: tophash
           Offset: 0
-          Type: 63 ArrayType [8]uint8
+          Type: 80 ArrayType [8]uint8
         - Name: keys
           Offset: 8
-          Type: 79 ArrayType []key<string>
+          Type: 95 ArrayType []key<string>
         - Name: values
           Offset: 136
-          Type: 92 ArrayType []val<[]string>
+          Type: 108 ArrayType []val<[]string>
         - Name: overflow
           Offset: 328
-          Type: 90 PointerType *bucket<string,[]string>
-      KeyType: 8 GoStringHeaderType string
-      ValueType: 93 GoSliceHeaderType []string
+          Type: 106 PointerType *bucket<string,[]string>
+      KeyType: 11 GoStringHeaderType string
+      ValueType: 109 GoSliceHeaderType []string
     - __kind: GoHMapBucketType
-      ID: 86
+      ID: 102
       Name: bucket<string,int>
       ByteSize: 208
       RawFields:
         - Name: tophash
           Offset: 0
-          Type: 63 ArrayType [8]uint8
+          Type: 80 ArrayType [8]uint8
         - Name: keys
           Offset: 8
-          Type: 79 ArrayType []key<string>
+          Type: 95 ArrayType []key<string>
         - Name: values
           Offset: 136
-          Type: 65 ArrayType []val<int>
+          Type: 82 ArrayType []val<int>
         - Name: overflow
           Offset: 200
-          Type: 85 PointerType *bucket<string,int>
-      KeyType: 8 GoStringHeaderType string
-      ValueType: 1 BaseType int
+          Type: 101 PointerType *bucket<string,int>
+      KeyType: 11 GoStringHeaderType string
+      ValueType: 9 BaseType int
     - __kind: GoHMapBucketType
-      ID: 78
+      ID: 94
       Name: bucket<string,main.nestedStruct>
       ByteSize: 336
       RawFields:
         - Name: tophash
           Offset: 0
-          Type: 63 ArrayType [8]uint8
+          Type: 80 ArrayType [8]uint8
         - Name: keys
           Offset: 8
-          Type: 79 ArrayType []key<string>
+          Type: 95 ArrayType []key<string>
         - Name: values
           Offset: 136
-          Type: 80 ArrayType []val<main.nestedStruct>
+          Type: 96 ArrayType []val<main.nestedStruct>
         - Name: overflow
           Offset: 328
-          Type: 77 PointerType *bucket<string,main.nestedStruct>
-      KeyType: 8 GoStringHeaderType string
-      ValueType: 81 StructureType main.nestedStruct
+          Type: 93 PointerType *bucket<string,main.nestedStruct>
+      KeyType: 11 GoStringHeaderType string
+      ValueType: 97 StructureType main.nestedStruct
     - __kind: GoHMapBucketType
-      ID: 137
+      ID: 153
       Name: bucket<uint8,[4]int>
       ByteSize: 280
       RawFields:
         - Name: tophash
           Offset: 0
-          Type: 63 ArrayType [8]uint8
+          Type: 80 ArrayType [8]uint8
         - Name: keys
           Offset: 8
-          Type: 132 ArrayType []key<uint8>
+          Type: 148 ArrayType []key<uint8>
         - Name: values
           Offset: 16
-          Type: 138 ArrayType []val<[4]int>
+          Type: 154 ArrayType []val<[4]int>
         - Name: overflow
           Offset: 272
-          Type: 136 PointerType *bucket<uint8,[4]int>
-      KeyType: 4 BaseType uint8
-      ValueType: 139 ArrayType [4]int
+          Type: 152 PointerType *bucket<uint8,[4]int>
+      KeyType: 3 BaseType uint8
+      ValueType: 155 ArrayType [4]int
     - __kind: GoHMapBucketType
-      ID: 131
+      ID: 147
       Name: bucket<uint8,uint8>
       ByteSize: 32
       RawFields:
         - Name: tophash
           Offset: 0
-          Type: 63 ArrayType [8]uint8
+          Type: 80 ArrayType [8]uint8
         - Name: keys
           Offset: 8
-          Type: 132 ArrayType []key<uint8>
+          Type: 148 ArrayType []key<uint8>
         - Name: values
           Offset: 16
-          Type: 126 ArrayType []val<uint8>
+          Type: 142 ArrayType []val<uint8>
         - Name: overflow
           Offset: 24
-          Type: 130 PointerType *bucket<uint8,uint8>
-      KeyType: 4 BaseType uint8
-      ValueType: 4 BaseType uint8
+          Type: 146 PointerType *bucket<uint8,uint8>
+      KeyType: 3 BaseType uint8
+      ValueType: 3 BaseType uint8
     - __kind: GoChannelType
-      ID: 151
+      ID: 167
       Name: chan bool
       GoRuntimeType: 539136
       GoKind: 18
     - __kind: GoChannelType
-      ID: 40
+      ID: 57
       Name: chan struct {}
       GoRuntimeType: 538048
       GoKind: 18
     - __kind: BaseType
-      ID: 178
+      ID: 24
       Name: complex128
       ByteSize: 16
       GoRuntimeType: 527680
       GoKind: 16
     - __kind: BaseType
-      ID: 177
+      ID: 23
       Name: complex64
       ByteSize: 8
       GoRuntimeType: 527616
       GoKind: 15
     - __kind: GoInterfaceType
-      ID: 56
+      ID: 18
       Name: error
       ByteSize: 16
       GoRuntimeType: 977856
@@ -5902,456 +5902,456 @@ Types:
       RawFields:
         - Name: tab
           Offset: 0
-          Type: 38 VoidPointerType unsafe.Pointer
+          Type: 19 VoidPointerType unsafe.Pointer
         - Name: data
           Offset: 8
-          Type: 38 VoidPointerType unsafe.Pointer
+          Type: 19 VoidPointerType unsafe.Pointer
     - __kind: BaseType
-      ID: 30
+      ID: 16
       Name: float32
       ByteSize: 4
       GoRuntimeType: 527744
       GoKind: 13
     - __kind: BaseType
-      ID: 31
+      ID: 17
       Name: float64
       ByteSize: 8
       GoRuntimeType: 527808
       GoKind: 14
     - __kind: GoSubroutineType
-      ID: 43
+      ID: 60
       Name: func()
       ByteSize: 8
       GoRuntimeType: 441824
       GoKind: 19
     - __kind: GoHMapHeaderType
-      ID: 148
+      ID: 164
       Name: hash<[4]int,[4]int>
       ByteSize: 48
       RawFields:
         - Name: count
           Offset: 0
-          Type: 1 BaseType int
+          Type: 9 BaseType int
         - Name: flags
           Offset: 8
-          Type: 4 BaseType uint8
+          Type: 3 BaseType uint8
         - Name: B
           Offset: 9
-          Type: 4 BaseType uint8
+          Type: 3 BaseType uint8
         - Name: noverflow
           Offset: 10
-          Type: 22 BaseType uint16
+          Type: 7 BaseType uint16
         - Name: hash0
           Offset: 12
-          Type: 24 BaseType uint32
+          Type: 2 BaseType uint32
         - Name: buckets
           Offset: 16
-          Type: 149 PointerType *bucket<[4]int,[4]int>
+          Type: 165 PointerType *bucket<[4]int,[4]int>
         - Name: oldbuckets
           Offset: 24
-          Type: 149 PointerType *bucket<[4]int,[4]int>
+          Type: 165 PointerType *bucket<[4]int,[4]int>
         - Name: nevacuate
           Offset: 32
-          Type: 66 BaseType uintptr
+          Type: 1 BaseType uintptr
         - Name: extra
           Offset: 40
-          Type: 67 PointerType *runtime.mapextra
-      BucketType: 150 GoHMapBucketType bucket<[4]int,[4]int>
+          Type: 83 PointerType *runtime.mapextra
+      BucketType: 166 GoHMapBucketType bucket<[4]int,[4]int>
       BucketsType: 208 GoSliceDataType []bucket<[4]int,[4]int>.array
     - __kind: GoHMapHeaderType
-      ID: 142
+      ID: 158
       Name: hash<[4]int,uint8>
       ByteSize: 48
       RawFields:
         - Name: count
           Offset: 0
-          Type: 1 BaseType int
+          Type: 9 BaseType int
         - Name: flags
           Offset: 8
-          Type: 4 BaseType uint8
+          Type: 3 BaseType uint8
         - Name: B
           Offset: 9
-          Type: 4 BaseType uint8
+          Type: 3 BaseType uint8
         - Name: noverflow
           Offset: 10
-          Type: 22 BaseType uint16
+          Type: 7 BaseType uint16
         - Name: hash0
           Offset: 12
-          Type: 24 BaseType uint32
+          Type: 2 BaseType uint32
         - Name: buckets
           Offset: 16
-          Type: 143 PointerType *bucket<[4]int,uint8>
+          Type: 159 PointerType *bucket<[4]int,uint8>
         - Name: oldbuckets
           Offset: 24
-          Type: 143 PointerType *bucket<[4]int,uint8>
+          Type: 159 PointerType *bucket<[4]int,uint8>
         - Name: nevacuate
           Offset: 32
-          Type: 66 BaseType uintptr
+          Type: 1 BaseType uintptr
         - Name: extra
           Offset: 40
-          Type: 67 PointerType *runtime.mapextra
-      BucketType: 144 GoHMapBucketType bucket<[4]int,uint8>
+          Type: 83 PointerType *runtime.mapextra
+      BucketType: 160 GoHMapBucketType bucket<[4]int,uint8>
       BucketsType: 207 GoSliceDataType []bucket<[4]int,uint8>.array
     - __kind: GoHMapHeaderType
-      ID: 96
+      ID: 112
       Name: hash<[4]string,[2]int>
       ByteSize: 48
       RawFields:
         - Name: count
           Offset: 0
-          Type: 1 BaseType int
+          Type: 9 BaseType int
         - Name: flags
           Offset: 8
-          Type: 4 BaseType uint8
+          Type: 3 BaseType uint8
         - Name: B
           Offset: 9
-          Type: 4 BaseType uint8
+          Type: 3 BaseType uint8
         - Name: noverflow
           Offset: 10
-          Type: 22 BaseType uint16
+          Type: 7 BaseType uint16
         - Name: hash0
           Offset: 12
-          Type: 24 BaseType uint32
+          Type: 2 BaseType uint32
         - Name: buckets
           Offset: 16
-          Type: 97 PointerType *bucket<[4]string,[2]int>
+          Type: 113 PointerType *bucket<[4]string,[2]int>
         - Name: oldbuckets
           Offset: 24
-          Type: 97 PointerType *bucket<[4]string,[2]int>
+          Type: 113 PointerType *bucket<[4]string,[2]int>
         - Name: nevacuate
           Offset: 32
-          Type: 66 BaseType uintptr
+          Type: 1 BaseType uintptr
         - Name: extra
           Offset: 40
-          Type: 67 PointerType *runtime.mapextra
-      BucketType: 98 GoHMapBucketType bucket<[4]string,[2]int>
+          Type: 83 PointerType *runtime.mapextra
+      BucketType: 114 GoHMapBucketType bucket<[4]string,[2]int>
       BucketsType: 199 GoSliceDataType []bucket<[4]string,[2]int>.array
     - __kind: GoHMapHeaderType
-      ID: 114
+      ID: 130
       Name: hash<bool,main.node>
       ByteSize: 48
       RawFields:
         - Name: count
           Offset: 0
-          Type: 1 BaseType int
+          Type: 9 BaseType int
         - Name: flags
           Offset: 8
-          Type: 4 BaseType uint8
+          Type: 3 BaseType uint8
         - Name: B
           Offset: 9
-          Type: 4 BaseType uint8
+          Type: 3 BaseType uint8
         - Name: noverflow
           Offset: 10
-          Type: 22 BaseType uint16
+          Type: 7 BaseType uint16
         - Name: hash0
           Offset: 12
-          Type: 24 BaseType uint32
+          Type: 2 BaseType uint32
         - Name: buckets
           Offset: 16
-          Type: 115 PointerType *bucket<bool,main.node>
+          Type: 131 PointerType *bucket<bool,main.node>
         - Name: oldbuckets
           Offset: 24
-          Type: 115 PointerType *bucket<bool,main.node>
+          Type: 131 PointerType *bucket<bool,main.node>
         - Name: nevacuate
           Offset: 32
-          Type: 66 BaseType uintptr
+          Type: 1 BaseType uintptr
         - Name: extra
           Offset: 40
-          Type: 67 PointerType *runtime.mapextra
-      BucketType: 116 GoHMapBucketType bucket<bool,main.node>
+          Type: 83 PointerType *runtime.mapextra
+      BucketType: 132 GoHMapBucketType bucket<bool,main.node>
       BucketsType: 203 GoSliceDataType []bucket<bool,main.node>.array
     - __kind: GoHMapHeaderType
-      ID: 60
+      ID: 77
       Name: hash<int,int>
       ByteSize: 48
       RawFields:
         - Name: count
           Offset: 0
-          Type: 1 BaseType int
+          Type: 9 BaseType int
         - Name: flags
           Offset: 8
-          Type: 4 BaseType uint8
+          Type: 3 BaseType uint8
         - Name: B
           Offset: 9
-          Type: 4 BaseType uint8
+          Type: 3 BaseType uint8
         - Name: noverflow
           Offset: 10
-          Type: 22 BaseType uint16
+          Type: 7 BaseType uint16
         - Name: hash0
           Offset: 12
-          Type: 24 BaseType uint32
+          Type: 2 BaseType uint32
         - Name: buckets
           Offset: 16
-          Type: 61 PointerType *bucket<int,int>
+          Type: 78 PointerType *bucket<int,int>
         - Name: oldbuckets
           Offset: 24
-          Type: 61 PointerType *bucket<int,int>
+          Type: 78 PointerType *bucket<int,int>
         - Name: nevacuate
           Offset: 32
-          Type: 66 BaseType uintptr
+          Type: 1 BaseType uintptr
         - Name: extra
           Offset: 40
-          Type: 67 PointerType *runtime.mapextra
-      BucketType: 62 GoHMapBucketType bucket<int,int>
+          Type: 83 PointerType *runtime.mapextra
+      BucketType: 79 GoHMapBucketType bucket<int,int>
       BucketsType: 191 GoSliceDataType []bucket<int,int>.array
     - __kind: GoHMapHeaderType
-      ID: 123
+      ID: 139
       Name: hash<int,uint8>
       ByteSize: 48
       RawFields:
         - Name: count
           Offset: 0
-          Type: 1 BaseType int
+          Type: 9 BaseType int
         - Name: flags
           Offset: 8
-          Type: 4 BaseType uint8
+          Type: 3 BaseType uint8
         - Name: B
           Offset: 9
-          Type: 4 BaseType uint8
+          Type: 3 BaseType uint8
         - Name: noverflow
           Offset: 10
-          Type: 22 BaseType uint16
+          Type: 7 BaseType uint16
         - Name: hash0
           Offset: 12
-          Type: 24 BaseType uint32
+          Type: 2 BaseType uint32
         - Name: buckets
           Offset: 16
-          Type: 124 PointerType *bucket<int,uint8>
+          Type: 140 PointerType *bucket<int,uint8>
         - Name: oldbuckets
           Offset: 24
-          Type: 124 PointerType *bucket<int,uint8>
+          Type: 140 PointerType *bucket<int,uint8>
         - Name: nevacuate
           Offset: 32
-          Type: 66 BaseType uintptr
+          Type: 1 BaseType uintptr
         - Name: extra
           Offset: 40
-          Type: 67 PointerType *runtime.mapextra
-      BucketType: 125 GoHMapBucketType bucket<int,uint8>
+          Type: 83 PointerType *runtime.mapextra
+      BucketType: 141 GoHMapBucketType bucket<int,uint8>
       BucketsType: 204 GoSliceDataType []bucket<int,uint8>.array
     - __kind: GoHMapHeaderType
-      ID: 106
+      ID: 122
       Name: hash<string,[]main.structWithMap>
       ByteSize: 48
       RawFields:
         - Name: count
           Offset: 0
-          Type: 1 BaseType int
+          Type: 9 BaseType int
         - Name: flags
           Offset: 8
-          Type: 4 BaseType uint8
+          Type: 3 BaseType uint8
         - Name: B
           Offset: 9
-          Type: 4 BaseType uint8
+          Type: 3 BaseType uint8
         - Name: noverflow
           Offset: 10
-          Type: 22 BaseType uint16
+          Type: 7 BaseType uint16
         - Name: hash0
           Offset: 12
-          Type: 24 BaseType uint32
+          Type: 2 BaseType uint32
         - Name: buckets
           Offset: 16
-          Type: 107 PointerType *bucket<string,[]main.structWithMap>
+          Type: 123 PointerType *bucket<string,[]main.structWithMap>
         - Name: oldbuckets
           Offset: 24
-          Type: 107 PointerType *bucket<string,[]main.structWithMap>
+          Type: 123 PointerType *bucket<string,[]main.structWithMap>
         - Name: nevacuate
           Offset: 32
-          Type: 66 BaseType uintptr
+          Type: 1 BaseType uintptr
         - Name: extra
           Offset: 40
-          Type: 67 PointerType *runtime.mapextra
-      BucketType: 108 GoHMapBucketType bucket<string,[]main.structWithMap>
+          Type: 83 PointerType *runtime.mapextra
+      BucketType: 124 GoHMapBucketType bucket<string,[]main.structWithMap>
       BucketsType: 200 GoSliceDataType []bucket<string,[]main.structWithMap>.array
     - __kind: GoHMapHeaderType
-      ID: 89
+      ID: 105
       Name: hash<string,[]string>
       ByteSize: 48
       RawFields:
         - Name: count
           Offset: 0
-          Type: 1 BaseType int
+          Type: 9 BaseType int
         - Name: flags
           Offset: 8
-          Type: 4 BaseType uint8
+          Type: 3 BaseType uint8
         - Name: B
           Offset: 9
-          Type: 4 BaseType uint8
+          Type: 3 BaseType uint8
         - Name: noverflow
           Offset: 10
-          Type: 22 BaseType uint16
+          Type: 7 BaseType uint16
         - Name: hash0
           Offset: 12
-          Type: 24 BaseType uint32
+          Type: 2 BaseType uint32
         - Name: buckets
           Offset: 16
-          Type: 90 PointerType *bucket<string,[]string>
+          Type: 106 PointerType *bucket<string,[]string>
         - Name: oldbuckets
           Offset: 24
-          Type: 90 PointerType *bucket<string,[]string>
+          Type: 106 PointerType *bucket<string,[]string>
         - Name: nevacuate
           Offset: 32
-          Type: 66 BaseType uintptr
+          Type: 1 BaseType uintptr
         - Name: extra
           Offset: 40
-          Type: 67 PointerType *runtime.mapextra
-      BucketType: 91 GoHMapBucketType bucket<string,[]string>
+          Type: 83 PointerType *runtime.mapextra
+      BucketType: 107 GoHMapBucketType bucket<string,[]string>
       BucketsType: 196 GoSliceDataType []bucket<string,[]string>.array
     - __kind: GoHMapHeaderType
-      ID: 84
+      ID: 100
       Name: hash<string,int>
       ByteSize: 48
       RawFields:
         - Name: count
           Offset: 0
-          Type: 1 BaseType int
+          Type: 9 BaseType int
         - Name: flags
           Offset: 8
-          Type: 4 BaseType uint8
+          Type: 3 BaseType uint8
         - Name: B
           Offset: 9
-          Type: 4 BaseType uint8
+          Type: 3 BaseType uint8
         - Name: noverflow
           Offset: 10
-          Type: 22 BaseType uint16
+          Type: 7 BaseType uint16
         - Name: hash0
           Offset: 12
-          Type: 24 BaseType uint32
+          Type: 2 BaseType uint32
         - Name: buckets
           Offset: 16
-          Type: 85 PointerType *bucket<string,int>
+          Type: 101 PointerType *bucket<string,int>
         - Name: oldbuckets
           Offset: 24
-          Type: 85 PointerType *bucket<string,int>
+          Type: 101 PointerType *bucket<string,int>
         - Name: nevacuate
           Offset: 32
-          Type: 66 BaseType uintptr
+          Type: 1 BaseType uintptr
         - Name: extra
           Offset: 40
-          Type: 67 PointerType *runtime.mapextra
-      BucketType: 86 GoHMapBucketType bucket<string,int>
+          Type: 83 PointerType *runtime.mapextra
+      BucketType: 102 GoHMapBucketType bucket<string,int>
       BucketsType: 195 GoSliceDataType []bucket<string,int>.array
     - __kind: GoHMapHeaderType
-      ID: 76
+      ID: 92
       Name: hash<string,main.nestedStruct>
       ByteSize: 48
       RawFields:
         - Name: count
           Offset: 0
-          Type: 1 BaseType int
+          Type: 9 BaseType int
         - Name: flags
           Offset: 8
-          Type: 4 BaseType uint8
+          Type: 3 BaseType uint8
         - Name: B
           Offset: 9
-          Type: 4 BaseType uint8
+          Type: 3 BaseType uint8
         - Name: noverflow
           Offset: 10
-          Type: 22 BaseType uint16
+          Type: 7 BaseType uint16
         - Name: hash0
           Offset: 12
-          Type: 24 BaseType uint32
+          Type: 2 BaseType uint32
         - Name: buckets
           Offset: 16
-          Type: 77 PointerType *bucket<string,main.nestedStruct>
+          Type: 93 PointerType *bucket<string,main.nestedStruct>
         - Name: oldbuckets
           Offset: 24
-          Type: 77 PointerType *bucket<string,main.nestedStruct>
+          Type: 93 PointerType *bucket<string,main.nestedStruct>
         - Name: nevacuate
           Offset: 32
-          Type: 66 BaseType uintptr
+          Type: 1 BaseType uintptr
         - Name: extra
           Offset: 40
-          Type: 67 PointerType *runtime.mapextra
-      BucketType: 78 GoHMapBucketType bucket<string,main.nestedStruct>
+          Type: 83 PointerType *runtime.mapextra
+      BucketType: 94 GoHMapBucketType bucket<string,main.nestedStruct>
       BucketsType: 194 GoSliceDataType []bucket<string,main.nestedStruct>.array
     - __kind: GoHMapHeaderType
-      ID: 135
+      ID: 151
       Name: hash<uint8,[4]int>
       ByteSize: 48
       RawFields:
         - Name: count
           Offset: 0
-          Type: 1 BaseType int
+          Type: 9 BaseType int
         - Name: flags
           Offset: 8
-          Type: 4 BaseType uint8
+          Type: 3 BaseType uint8
         - Name: B
           Offset: 9
-          Type: 4 BaseType uint8
+          Type: 3 BaseType uint8
         - Name: noverflow
           Offset: 10
-          Type: 22 BaseType uint16
+          Type: 7 BaseType uint16
         - Name: hash0
           Offset: 12
-          Type: 24 BaseType uint32
+          Type: 2 BaseType uint32
         - Name: buckets
           Offset: 16
-          Type: 136 PointerType *bucket<uint8,[4]int>
+          Type: 152 PointerType *bucket<uint8,[4]int>
         - Name: oldbuckets
           Offset: 24
-          Type: 136 PointerType *bucket<uint8,[4]int>
+          Type: 152 PointerType *bucket<uint8,[4]int>
         - Name: nevacuate
           Offset: 32
-          Type: 66 BaseType uintptr
+          Type: 1 BaseType uintptr
         - Name: extra
           Offset: 40
-          Type: 67 PointerType *runtime.mapextra
-      BucketType: 137 GoHMapBucketType bucket<uint8,[4]int>
+          Type: 83 PointerType *runtime.mapextra
+      BucketType: 153 GoHMapBucketType bucket<uint8,[4]int>
       BucketsType: 206 GoSliceDataType []bucket<uint8,[4]int>.array
     - __kind: GoHMapHeaderType
-      ID: 129
+      ID: 145
       Name: hash<uint8,uint8>
       ByteSize: 48
       RawFields:
         - Name: count
           Offset: 0
-          Type: 1 BaseType int
+          Type: 9 BaseType int
         - Name: flags
           Offset: 8
-          Type: 4 BaseType uint8
+          Type: 3 BaseType uint8
         - Name: B
           Offset: 9
-          Type: 4 BaseType uint8
+          Type: 3 BaseType uint8
         - Name: noverflow
           Offset: 10
-          Type: 22 BaseType uint16
+          Type: 7 BaseType uint16
         - Name: hash0
           Offset: 12
-          Type: 24 BaseType uint32
+          Type: 2 BaseType uint32
         - Name: buckets
           Offset: 16
-          Type: 130 PointerType *bucket<uint8,uint8>
+          Type: 146 PointerType *bucket<uint8,uint8>
         - Name: oldbuckets
           Offset: 24
-          Type: 130 PointerType *bucket<uint8,uint8>
+          Type: 146 PointerType *bucket<uint8,uint8>
         - Name: nevacuate
           Offset: 32
-          Type: 66 BaseType uintptr
+          Type: 1 BaseType uintptr
         - Name: extra
           Offset: 40
-          Type: 67 PointerType *runtime.mapextra
-      BucketType: 131 GoHMapBucketType bucket<uint8,uint8>
+          Type: 83 PointerType *runtime.mapextra
+      BucketType: 147 GoHMapBucketType bucket<uint8,uint8>
       BucketsType: 205 GoSliceDataType []bucket<uint8,uint8>.array
     - __kind: BaseType
-      ID: 1
+      ID: 9
       Name: int
       ByteSize: 8
       GoRuntimeType: 527424
       GoKind: 2
     - __kind: BaseType
-      ID: 16
+      ID: 31
       Name: int16
       ByteSize: 2
       GoRuntimeType: 527040
       GoKind: 4
     - __kind: BaseType
-      ID: 6
+      ID: 12
       Name: int32
       ByteSize: 4
       GoRuntimeType: 527168
       GoKind: 5
     - __kind: BaseType
-      ID: 18
+      ID: 13
       Name: int64
       ByteSize: 8
       GoRuntimeType: 527296
@@ -6363,7 +6363,7 @@ Types:
       GoRuntimeType: 526912
       GoKind: 3
     - __kind: GoEmptyInterfaceType
-      ID: 41
+      ID: 58
       Name: interface {}
       ByteSize: 16
       GoRuntimeType: 772384
@@ -6371,12 +6371,12 @@ Types:
       RawFields:
         - Name: _type
           Offset: 0
-          Type: 38 VoidPointerType unsafe.Pointer
+          Type: 19 VoidPointerType unsafe.Pointer
         - Name: data
           Offset: 8
-          Type: 38 VoidPointerType unsafe.Pointer
+          Type: 19 VoidPointerType unsafe.Pointer
     - __kind: GoInterfaceType
-      ID: 37
+      ID: 55
       Name: io.Writer
       ByteSize: 16
       GoRuntimeType: 973760
@@ -6384,30 +6384,30 @@ Types:
       RawFields:
         - Name: tab
           Offset: 0
-          Type: 38 VoidPointerType unsafe.Pointer
+          Type: 19 VoidPointerType unsafe.Pointer
         - Name: data
           Offset: 8
-          Type: 38 VoidPointerType unsafe.Pointer
+          Type: 19 VoidPointerType unsafe.Pointer
     - __kind: StructureType
-      ID: 172
+      ID: 185
       Name: main.aStruct
       ByteSize: 56
       GoKind: 25
       RawFields:
         - Name: aBool
           Offset: 0
-          Type: 11 BaseType bool
+          Type: 4 BaseType bool
         - Name: aString
           Offset: 8
-          Type: 8 GoStringHeaderType string
+          Type: 11 GoStringHeaderType string
         - Name: aNumber
           Offset: 24
-          Type: 1 BaseType int
+          Type: 9 BaseType int
         - Name: nested
           Offset: 32
-          Type: 81 StructureType main.nestedStruct
+          Type: 97 StructureType main.nestedStruct
     - __kind: GoInterfaceType
-      ID: 55
+      ID: 73
       Name: main.behavior
       ByteSize: 16
       GoRuntimeType: 973376
@@ -6415,32 +6415,32 @@ Types:
       RawFields:
         - Name: tab
           Offset: 0
-          Type: 38 VoidPointerType unsafe.Pointer
+          Type: 19 VoidPointerType unsafe.Pointer
         - Name: data
           Offset: 8
-          Type: 38 VoidPointerType unsafe.Pointer
+          Type: 19 VoidPointerType unsafe.Pointer
     - __kind: StructureType
-      ID: 33
+      ID: 52
       Name: main.bigStruct
       ByteSize: 48
       GoKind: 25
       RawFields:
         - Name: x
           Offset: 0
-          Type: 34 GoSliceHeaderType []*string
+          Type: 53 GoSliceHeaderType []*string
         - Name: z
           Offset: 24
-          Type: 1 BaseType int
+          Type: 9 BaseType int
         - Name: writer
           Offset: 32
-          Type: 37 GoInterfaceType io.Writer
+          Type: 55 GoInterfaceType io.Writer
     - __kind: StructureType
-      ID: 173
+      ID: 186
       Name: main.emptyStruct
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 45
+      ID: 62
       Name: main.esotericHeap
       ByteSize: 112
       GoRuntimeType: 1.692416e+06
@@ -6448,21 +6448,21 @@ Types:
       RawFields:
         - Name: esotericStack
           Offset: 0
-          Type: 39 StructureType main.esotericStack
+          Type: 56 StructureType main.esotericStack
         - Name: mu
           Offset: 64
-          Type: 46 StructureType sync.Mutex
+          Type: 63 StructureType sync.Mutex
         - Name: once
           Offset: 72
-          Type: 47 StructureType sync.Once
+          Type: 64 StructureType sync.Once
         - Name: wg
           Offset: 88
-          Type: 50 StructureType sync.WaitGroup
+          Type: 67 StructureType sync.WaitGroup
         - Name: a
           Offset: 104
-          Type: 54 StructureType sync/atomic.Int32
+          Type: 71 StructureType sync/atomic.Int32
     - __kind: StructureType
-      ID: 39
+      ID: 56
       Name: main.esotericStack
       ByteSize: 64
       GoRuntimeType: 1.81888e+06
@@ -6470,27 +6470,27 @@ Types:
       RawFields:
         - Name: _
           Offset: 0
-          Type: 6 BaseType int32
+          Type: 12 BaseType int32
         - Name: _valid
           Offset: 4
-          Type: 6 BaseType int32
+          Type: 12 BaseType int32
         - Name: c
           Offset: 8
-          Type: 40 GoChannelType chan struct {}
+          Type: 57 GoChannelType chan struct {}
         - Name: val
           Offset: 16
-          Type: 41 GoEmptyInterfaceType interface {}
+          Type: 58 GoEmptyInterfaceType interface {}
         - Name: _
           Offset: 32
-          Type: 26 BaseType uint64
+          Type: 10 BaseType uint64
         - Name: work
           Offset: 40
-          Type: 42 GoInterfaceType main.something
+          Type: 59 GoInterfaceType main.something
         - Name: foo
           Offset: 56
-          Type: 43 GoSubroutineType func()
+          Type: 60 GoSubroutineType func()
     - __kind: StructureType
-      ID: 81
+      ID: 97
       Name: main.nestedStruct
       ByteSize: 24
       GoRuntimeType: 1.270016e+06
@@ -6498,12 +6498,12 @@ Types:
       RawFields:
         - Name: anotherInt
           Offset: 0
-          Type: 1 BaseType int
+          Type: 9 BaseType int
         - Name: anotherString
           Offset: 8
-          Type: 8 GoStringHeaderType string
+          Type: 11 GoStringHeaderType string
     - __kind: StructureType
-      ID: 119
+      ID: 135
       Name: main.node
       ByteSize: 16
       GoRuntimeType: 1.269856e+06
@@ -6511,21 +6511,21 @@ Types:
       RawFields:
         - Name: val
           Offset: 0
-          Type: 1 BaseType int
+          Type: 9 BaseType int
         - Name: b
           Offset: 8
-          Type: 120 PointerType *main.node
+          Type: 136 PointerType *main.node
     - __kind: StructureType
-      ID: 171
+      ID: 184
       Name: main.oneStringStruct
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: a
           Offset: 0
-          Type: 8 GoStringHeaderType string
+          Type: 11 GoStringHeaderType string
     - __kind: GoInterfaceType
-      ID: 42
+      ID: 59
       Name: main.something
       ByteSize: 16
       GoRuntimeType: 973504
@@ -6533,12 +6533,12 @@ Types:
       RawFields:
         - Name: tab
           Offset: 0
-          Type: 38 VoidPointerType unsafe.Pointer
+          Type: 19 VoidPointerType unsafe.Pointer
         - Name: data
           Offset: 8
-          Type: 38 VoidPointerType unsafe.Pointer
+          Type: 19 VoidPointerType unsafe.Pointer
     - __kind: StructureType
-      ID: 57
+      ID: 74
       Name: main.structWithMap
       ByteSize: 8
       GoRuntimeType: 1.092448e+06
@@ -6546,158 +6546,158 @@ Types:
       RawFields:
         - Name: m
           Offset: 0
-          Type: 58 GoMapType map[int]int
+          Type: 75 GoMapType map[int]int
     - __kind: StructureType
-      ID: 164
+      ID: 178
       Name: main.structWithNoStrings
       ByteSize: 2
       GoKind: 25
       RawFields:
         - Name: aUint8
           Offset: 0
-          Type: 4 BaseType uint8
+          Type: 3 BaseType uint8
         - Name: aBool
           Offset: 1
-          Type: 11 BaseType bool
+          Type: 4 BaseType bool
     - __kind: StructureType
-      ID: 153
+      ID: 169
       Name: main.structWithTwoValues
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: a
           Offset: 0
-          Type: 20 BaseType uint
+          Type: 15 BaseType uint
         - Name: b
           Offset: 8
-          Type: 11 BaseType bool
+          Type: 4 BaseType bool
     - __kind: GoSliceHeaderType
-      ID: 157
+      ID: 171
       Name: main.t
       ByteSize: 24
       GoKind: 23
       RawFields:
         - Name: array
           Offset: 0
-          Type: 158 PointerType **main.t
+          Type: 172 PointerType **main.t
         - Name: len
           Offset: 8
-          Type: 1 BaseType int
+          Type: 9 BaseType int
         - Name: cap
           Offset: 16
-          Type: 1 BaseType int
+          Type: 9 BaseType int
       Data: 209 GoSliceDataType main.t.array
     - __kind: GoSliceDataType
       ID: 209
       Name: main.t.array
       ByteSize: 2048
-      Element: 156 PointerType *main.t
+      Element: 170 PointerType *main.t
     - __kind: StructureType
-      ID: 168
+      ID: 181
       Name: main.threeStringStruct
       ByteSize: 48
       GoKind: 25
       RawFields:
         - Name: a
           Offset: 0
-          Type: 8 GoStringHeaderType string
+          Type: 11 GoStringHeaderType string
         - Name: b
           Offset: 16
-          Type: 8 GoStringHeaderType string
+          Type: 11 GoStringHeaderType string
         - Name: c
           Offset: 32
-          Type: 8 GoStringHeaderType string
+          Type: 11 GoStringHeaderType string
     - __kind: BaseType
-      ID: 32
+      ID: 51
       Name: main.typeAlias
       ByteSize: 2
       GoKind: 9
     - __kind: GoMapType
-      ID: 146
+      ID: 162
       Name: map[[4]int][4]int
       ByteSize: 8
       GoRuntimeType: 873856
       GoKind: 21
-      HeaderType: 148 GoHMapHeaderType hash<[4]int,[4]int>
+      HeaderType: 164 GoHMapHeaderType hash<[4]int,[4]int>
     - __kind: GoMapType
-      ID: 140
+      ID: 156
       Name: map[[4]int]uint8
       ByteSize: 8
       GoRuntimeType: 873952
       GoKind: 21
-      HeaderType: 142 GoHMapHeaderType hash<[4]int,uint8>
+      HeaderType: 158 GoHMapHeaderType hash<[4]int,uint8>
     - __kind: GoMapType
-      ID: 94
+      ID: 110
       Name: map[[4]string][2]int
       ByteSize: 8
       GoRuntimeType: 874048
       GoKind: 21
-      HeaderType: 96 GoHMapHeaderType hash<[4]string,[2]int>
+      HeaderType: 112 GoHMapHeaderType hash<[4]string,[2]int>
     - __kind: GoMapType
-      ID: 112
+      ID: 128
       Name: map[bool]main.node
       ByteSize: 8
       GoRuntimeType: 874144
       GoKind: 21
-      HeaderType: 114 GoHMapHeaderType hash<bool,main.node>
+      HeaderType: 130 GoHMapHeaderType hash<bool,main.node>
     - __kind: GoMapType
-      ID: 58
+      ID: 75
       Name: map[int]int
       ByteSize: 8
       GoRuntimeType: 872896
       GoKind: 21
-      HeaderType: 60 GoHMapHeaderType hash<int,int>
+      HeaderType: 77 GoHMapHeaderType hash<int,int>
     - __kind: GoMapType
-      ID: 121
+      ID: 137
       Name: map[int]uint8
       ByteSize: 8
       GoRuntimeType: 874240
       GoKind: 21
-      HeaderType: 123 GoHMapHeaderType hash<int,uint8>
+      HeaderType: 139 GoHMapHeaderType hash<int,uint8>
     - __kind: GoMapType
-      ID: 104
+      ID: 120
       Name: map[string][]main.structWithMap
       ByteSize: 8
       GoRuntimeType: 874336
       GoKind: 21
-      HeaderType: 106 GoHMapHeaderType hash<string,[]main.structWithMap>
+      HeaderType: 122 GoHMapHeaderType hash<string,[]main.structWithMap>
     - __kind: GoMapType
-      ID: 87
+      ID: 103
       Name: map[string][]string
       ByteSize: 8
       GoRuntimeType: 874432
       GoKind: 21
-      HeaderType: 89 GoHMapHeaderType hash<string,[]string>
+      HeaderType: 105 GoHMapHeaderType hash<string,[]string>
     - __kind: GoMapType
-      ID: 82
+      ID: 98
       Name: map[string]int
       ByteSize: 8
       GoRuntimeType: 874528
       GoKind: 21
-      HeaderType: 84 GoHMapHeaderType hash<string,int>
+      HeaderType: 100 GoHMapHeaderType hash<string,int>
     - __kind: GoMapType
-      ID: 74
+      ID: 90
       Name: map[string]main.nestedStruct
       ByteSize: 8
       GoRuntimeType: 874624
       GoKind: 21
-      HeaderType: 76 GoHMapHeaderType hash<string,main.nestedStruct>
+      HeaderType: 92 GoHMapHeaderType hash<string,main.nestedStruct>
     - __kind: GoMapType
-      ID: 133
+      ID: 149
       Name: map[uint8][4]int
       ByteSize: 8
       GoRuntimeType: 874720
       GoKind: 21
-      HeaderType: 135 GoHMapHeaderType hash<uint8,[4]int>
+      HeaderType: 151 GoHMapHeaderType hash<uint8,[4]int>
     - __kind: GoMapType
-      ID: 127
+      ID: 143
       Name: map[uint8]uint8
       ByteSize: 8
       GoRuntimeType: 874816
       GoKind: 21
-      HeaderType: 129 GoHMapHeaderType hash<uint8,uint8>
+      HeaderType: 145 GoHMapHeaderType hash<uint8,uint8>
     - __kind: StructureType
-      ID: 73
+      ID: 89
       Name: runtime.bmap
       ByteSize: 8
       GoRuntimeType: 1.100768e+06
@@ -6705,9 +6705,9 @@ Types:
       RawFields:
         - Name: tophash
           Offset: 0
-          Type: 63 ArrayType [8]uint8
+          Type: 80 ArrayType [8]uint8
     - __kind: StructureType
-      ID: 68
+      ID: 84
       Name: runtime.mapextra
       ByteSize: 24
       GoRuntimeType: 1.417056e+06
@@ -6715,15 +6715,15 @@ Types:
       RawFields:
         - Name: overflow
           Offset: 0
-          Type: 69 PointerType *[]*runtime.bmap
+          Type: 85 PointerType *[]*runtime.bmap
         - Name: oldoverflow
           Offset: 8
-          Type: 69 PointerType *[]*runtime.bmap
+          Type: 85 PointerType *[]*runtime.bmap
         - Name: nextOverflow
           Offset: 16
-          Type: 72 PointerType *runtime.bmap
+          Type: 88 PointerType *runtime.bmap
     - __kind: GoStringHeaderType
-      ID: 8
+      ID: 11
       Name: string
       ByteSize: 16
       GoRuntimeType: 526848
@@ -6734,14 +6734,14 @@ Types:
           Type: 188 PointerType *string.str
         - Name: len
           Offset: 8
-          Type: 1 BaseType int
+          Type: 9 BaseType int
       Data: 187 GoStringDataType string.str
     - __kind: GoStringDataType
       ID: 187
       Name: string.str
       ByteSize: 2048
     - __kind: StructureType
-      ID: 46
+      ID: 63
       Name: sync.Mutex
       ByteSize: 8
       GoRuntimeType: 1.271296e+06
@@ -6749,12 +6749,12 @@ Types:
       RawFields:
         - Name: state
           Offset: 0
-          Type: 6 BaseType int32
+          Type: 12 BaseType int32
         - Name: sema
           Offset: 4
-          Type: 24 BaseType uint32
+          Type: 2 BaseType uint32
     - __kind: StructureType
-      ID: 47
+      ID: 64
       Name: sync.Once
       ByteSize: 12
       GoRuntimeType: 1.272416e+06
@@ -6762,12 +6762,12 @@ Types:
       RawFields:
         - Name: done
           Offset: 0
-          Type: 48 StructureType sync/atomic.Uint32
+          Type: 65 StructureType sync/atomic.Uint32
         - Name: m
           Offset: 4
-          Type: 46 StructureType sync.Mutex
+          Type: 63 StructureType sync.Mutex
     - __kind: StructureType
-      ID: 50
+      ID: 67
       Name: sync.WaitGroup
       ByteSize: 16
       GoRuntimeType: 1.411104e+06
@@ -6775,21 +6775,21 @@ Types:
       RawFields:
         - Name: noCopy
           Offset: 0
-          Type: 51 StructureType sync.noCopy
+          Type: 68 StructureType sync.noCopy
         - Name: state
           Offset: 0
-          Type: 52 StructureType sync/atomic.Uint64
+          Type: 69 StructureType sync/atomic.Uint64
         - Name: sema
           Offset: 8
-          Type: 24 BaseType uint32
+          Type: 2 BaseType uint32
     - __kind: StructureType
-      ID: 51
+      ID: 68
       Name: sync.noCopy
       GoRuntimeType: 940512
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 54
+      ID: 71
       Name: sync/atomic.Int32
       ByteSize: 4
       GoRuntimeType: 1.272736e+06
@@ -6797,12 +6797,12 @@ Types:
       RawFields:
         - Name: _
           Offset: 0
-          Type: 49 StructureType sync/atomic.noCopy
+          Type: 66 StructureType sync/atomic.noCopy
         - Name: v
           Offset: 0
-          Type: 6 BaseType int32
+          Type: 12 BaseType int32
     - __kind: StructureType
-      ID: 48
+      ID: 65
       Name: sync/atomic.Uint32
       ByteSize: 4
       GoRuntimeType: 1.272896e+06
@@ -6810,12 +6810,12 @@ Types:
       RawFields:
         - Name: _
           Offset: 0
-          Type: 49 StructureType sync/atomic.noCopy
+          Type: 66 StructureType sync/atomic.noCopy
         - Name: v
           Offset: 0
-          Type: 24 BaseType uint32
+          Type: 2 BaseType uint32
     - __kind: StructureType
-      ID: 52
+      ID: 69
       Name: sync/atomic.Uint64
       ByteSize: 8
       GoRuntimeType: 1.411488e+06
@@ -6823,63 +6823,63 @@ Types:
       RawFields:
         - Name: _
           Offset: 0
-          Type: 49 StructureType sync/atomic.noCopy
+          Type: 66 StructureType sync/atomic.noCopy
         - Name: _
           Offset: 0
-          Type: 53 StructureType sync/atomic.align64
+          Type: 70 StructureType sync/atomic.align64
         - Name: v
           Offset: 0
-          Type: 26 BaseType uint64
+          Type: 10 BaseType uint64
     - __kind: StructureType
-      ID: 53
+      ID: 70
       Name: sync/atomic.align64
       GoRuntimeType: 940704
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 49
+      ID: 66
       Name: sync/atomic.noCopy
       GoRuntimeType: 940608
       GoKind: 25
       RawFields: []
     - __kind: BaseType
-      ID: 20
+      ID: 15
       Name: uint
       ByteSize: 8
       GoRuntimeType: 527488
       GoKind: 7
     - __kind: BaseType
-      ID: 22
+      ID: 7
       Name: uint16
       ByteSize: 2
       GoRuntimeType: 527104
       GoKind: 9
     - __kind: BaseType
-      ID: 24
+      ID: 2
       Name: uint32
       ByteSize: 4
       GoRuntimeType: 527232
       GoKind: 10
     - __kind: BaseType
-      ID: 26
+      ID: 10
       Name: uint64
       ByteSize: 8
       GoRuntimeType: 527360
       GoKind: 11
     - __kind: BaseType
-      ID: 4
+      ID: 3
       Name: uint8
       ByteSize: 1
       GoRuntimeType: 526976
       GoKind: 8
     - __kind: BaseType
-      ID: 66
+      ID: 1
       Name: uintptr
       ByteSize: 8
       GoRuntimeType: 527552
       GoKind: 12
     - __kind: VoidPointerType
-      ID: 38
+      ID: 19
       Name: unsafe.Pointer
       ByteSize: 8
       GoRuntimeType: 527936

--- a/pkg/dyninst/irgen/testdata/snapshot/sample.arch=amd64,toolchain=go1.23.11.yaml
+++ b/pkg/dyninst/irgen/testdata/snapshot/sample.arch=amd64,toolchain=go1.23.11.yaml
@@ -11,7 +11,7 @@ Probes:
       subprogram: {subprogram: 88}
       events:
         - ID: 88
-          Type: 308 EventRootType Probe[main.stackC]
+          Type: 301 EventRootType Probe[main.stackC]
           InjectionPoints: [{PC: "0xd06f2a", Frameless: false}]
           Condition: null
     - id: testAny
@@ -25,7 +25,7 @@ Probes:
       subprogram: {subprogram: 45}
       events:
         - ID: 45
-          Type: 265 EventRootType Probe[main.testAny]
+          Type: 258 EventRootType Probe[main.testAny]
           InjectionPoints: [{PC: "0xd0410a", Frameless: false}]
           Condition: null
     - id: testArrayOfArrays
@@ -39,7 +39,7 @@ Probes:
       subprogram: {subprogram: 15}
       events:
         - ID: 15
-          Type: 235 EventRootType Probe[main.testArrayOfArrays]
+          Type: 228 EventRootType Probe[main.testArrayOfArrays]
           InjectionPoints: [{PC: "0xd02b40", Frameless: true}]
           Condition: null
     - id: testArrayOfArraysOfArrays
@@ -53,7 +53,7 @@ Probes:
       subprogram: {subprogram: 17}
       events:
         - ID: 17
-          Type: 237 EventRootType Probe[main.testArrayOfArraysOfArrays]
+          Type: 230 EventRootType Probe[main.testArrayOfArraysOfArrays]
           InjectionPoints: [{PC: "0xd02b80", Frameless: true}]
           Condition: null
     - id: testArrayOfMaps
@@ -67,7 +67,7 @@ Probes:
       subprogram: {subprogram: 53}
       events:
         - ID: 53
-          Type: 273 EventRootType Probe[main.testArrayOfMaps]
+          Type: 266 EventRootType Probe[main.testArrayOfMaps]
           InjectionPoints: [{PC: "0xd046a0", Frameless: true}]
           Condition: null
     - id: testArrayOfStrings
@@ -81,7 +81,7 @@ Probes:
       subprogram: {subprogram: 16}
       events:
         - ID: 16
-          Type: 236 EventRootType Probe[main.testArrayOfStrings]
+          Type: 229 EventRootType Probe[main.testArrayOfStrings]
           InjectionPoints: [{PC: "0xd02b60", Frameless: true}]
           Condition: null
     - id: testBigStruct
@@ -95,7 +95,7 @@ Probes:
       subprogram: {subprogram: 35}
       events:
         - ID: 35
-          Type: 255 EventRootType Probe[main.testBigStruct]
+          Type: 248 EventRootType Probe[main.testBigStruct]
           InjectionPoints: [{PC: "0xd032a0", Frameless: true}]
           Condition: null
     - id: testBoolArray
@@ -109,7 +109,7 @@ Probes:
       subprogram: {subprogram: 4}
       events:
         - ID: 4
-          Type: 224 EventRootType Probe[main.testBoolArray]
+          Type: 217 EventRootType Probe[main.testBoolArray]
           InjectionPoints: [{PC: "0xd029e0", Frameless: true}]
           Condition: null
     - id: testByteArray
@@ -123,7 +123,7 @@ Probes:
       subprogram: {subprogram: 1}
       events:
         - ID: 1
-          Type: 221 EventRootType Probe[main.testByteArray]
+          Type: 214 EventRootType Probe[main.testByteArray]
           InjectionPoints: [{PC: "0xd02980", Frameless: true}]
           Condition: null
     - id: testChannel
@@ -137,7 +137,7 @@ Probes:
       subprogram: {subprogram: 69}
       events:
         - ID: 69
-          Type: 289 EventRootType Probe[main.testChannel]
+          Type: 282 EventRootType Probe[main.testChannel]
           InjectionPoints: [{PC: "0xd061e0", Frameless: true}]
           Condition: null
     - id: testCombinedByte
@@ -151,7 +151,7 @@ Probes:
       subprogram: {subprogram: 67}
       events:
         - ID: 67
-          Type: 287 EventRootType Probe[main.testCombinedByte]
+          Type: 280 EventRootType Probe[main.testCombinedByte]
           InjectionPoints: [{PC: "0xd05e00", Frameless: true}]
           Condition: null
     - id: testCycle
@@ -165,7 +165,7 @@ Probes:
       subprogram: {subprogram: 77}
       events:
         - ID: 77
-          Type: 297 EventRootType Probe[main.testCycle]
+          Type: 290 EventRootType Probe[main.testCycle]
           InjectionPoints: [{PC: "0xd065a0", Frameless: true}]
           Condition: null
     - id: testEmptySlice
@@ -179,7 +179,7 @@ Probes:
       subprogram: {subprogram: 79}
       events:
         - ID: 79
-          Type: 299 EventRootType Probe[main.testEmptySlice]
+          Type: 292 EventRootType Probe[main.testEmptySlice]
           InjectionPoints: [{PC: "0xd06ae0", Frameless: true}]
           Condition: null
     - id: testEmptySliceOfStructs
@@ -193,7 +193,7 @@ Probes:
       subprogram: {subprogram: 82}
       events:
         - ID: 82
-          Type: 302 EventRootType Probe[main.testEmptySliceOfStructs]
+          Type: 295 EventRootType Probe[main.testEmptySliceOfStructs]
           InjectionPoints: [{PC: "0xd06b40", Frameless: true}]
           Condition: null
     - id: testEmptyString
@@ -207,7 +207,7 @@ Probes:
       subprogram: {subprogram: 96}
       events:
         - ID: 96
-          Type: 316 EventRootType Probe[main.testEmptyString]
+          Type: 309 EventRootType Probe[main.testEmptyString]
           InjectionPoints: [{PC: "0xd07060", Frameless: true}]
           Condition: null
     - id: testEmptyStruct
@@ -221,7 +221,7 @@ Probes:
       subprogram: {subprogram: 98}
       events:
         - ID: 98
-          Type: 318 EventRootType Probe[main.testEmptyStruct]
+          Type: 311 EventRootType Probe[main.testEmptyStruct]
           InjectionPoints: [{PC: "0xd07460", Frameless: true}]
           Condition: null
     - id: testError
@@ -235,7 +235,7 @@ Probes:
       subprogram: {subprogram: 46}
       events:
         - ID: 46
-          Type: 266 EventRootType Probe[main.testError]
+          Type: 259 EventRootType Probe[main.testError]
           InjectionPoints: [{PC: "0xd04180", Frameless: true}]
           Condition: null
     - id: testEsotericHeap
@@ -249,7 +249,7 @@ Probes:
       subprogram: {subprogram: 37}
       events:
         - ID: 37
-          Type: 257 EventRootType Probe[main.testEsotericHeap]
+          Type: 250 EventRootType Probe[main.testEsotericHeap]
           InjectionPoints: [{PC: "0xd0364a", Frameless: false}]
           Condition: null
     - id: testEsotericStack
@@ -263,7 +263,7 @@ Probes:
       subprogram: {subprogram: 36}
       events:
         - ID: 36
-          Type: 256 EventRootType Probe[main.testEsotericStack]
+          Type: 249 EventRootType Probe[main.testEsotericStack]
           InjectionPoints: [{PC: "0xd0352e", Frameless: false}]
           Condition: null
     - id: testFrameless
@@ -277,7 +277,7 @@ Probes:
       subprogram: {subprogram: 42}
       events:
         - ID: 42
-          Type: 262 EventRootType Probe[main.testFrameless]
+          Type: 255 EventRootType Probe[main.testFrameless]
           InjectionPoints: [{PC: "0xd03da0", Frameless: true}]
           Condition: null
     - id: testFramelessArray
@@ -291,7 +291,7 @@ Probes:
       subprogram: {subprogram: 43}
       events:
         - ID: 43
-          Type: 263 EventRootType Probe[main.testFramelessArray]
+          Type: 256 EventRootType Probe[main.testFramelessArray]
           InjectionPoints: [{PC: "0xd03dc4", Frameless: false}]
           Condition: null
     - id: testInlinedBA
@@ -305,7 +305,7 @@ Probes:
       subprogram: {subprogram: 38}
       events:
         - ID: 38
-          Type: 258 EventRootType Probe[main.testInlinedBA]
+          Type: 251 EventRootType Probe[main.testInlinedBA]
           InjectionPoints: [{PC: "0xd03a8a", Frameless: false}]
           Condition: null
     - id: testInlinedBB
@@ -319,7 +319,7 @@ Probes:
       subprogram: {subprogram: 39}
       events:
         - ID: 39
-          Type: 259 EventRootType Probe[main.testInlinedBB]
+          Type: 252 EventRootType Probe[main.testInlinedBB]
           InjectionPoints: [{PC: "0xd03b2e", Frameless: false}]
           Condition: null
     - id: testInlinedBBA
@@ -333,7 +333,7 @@ Probes:
       subprogram: {subprogram: 40}
       events:
         - ID: 40
-          Type: 260 EventRootType Probe[main.testInlinedBBA]
+          Type: 253 EventRootType Probe[main.testInlinedBBA]
           InjectionPoints: [{PC: "0xd03c0a", Frameless: false}]
           Condition: null
     - id: testInlinedBBB
@@ -347,7 +347,7 @@ Probes:
       subprogram: {subprogram: 100}
       events:
         - ID: 100
-          Type: 320 EventRootType Probe[main.testInlinedBBB]
+          Type: 313 EventRootType Probe[main.testInlinedBBB]
           InjectionPoints: [{PC: "0xd03b86", Frameless: false}]
           Condition: null
     - id: testInlinedBC
@@ -361,7 +361,7 @@ Probes:
       subprogram: {subprogram: 41}
       events:
         - ID: 41
-          Type: 261 EventRootType Probe[main.testInlinedBC]
+          Type: 254 EventRootType Probe[main.testInlinedBC]
           InjectionPoints: [{PC: "0xd03c8e", Frameless: false}]
           Condition: null
     - id: testInlinedBCA
@@ -375,7 +375,7 @@ Probes:
       subprogram: {subprogram: 101}
       events:
         - ID: 101
-          Type: 321 EventRootType Probe[main.testInlinedBCA]
+          Type: 314 EventRootType Probe[main.testInlinedBCA]
           InjectionPoints: [{PC: "0xd03c93", Frameless: false}]
           Condition: null
     - id: testInlinedBCB
@@ -389,7 +389,7 @@ Probes:
       subprogram: {subprogram: 102}
       events:
         - ID: 102
-          Type: 322 EventRootType Probe[main.testInlinedBCB]
+          Type: 315 EventRootType Probe[main.testInlinedBCB]
           InjectionPoints: [{PC: "0xd03d46", Frameless: false}]
           Condition: null
     - id: testInlinedPrint
@@ -404,7 +404,7 @@ Probes:
       subprogram: {subprogram: 99}
       events:
         - ID: 99
-          Type: 319 EventRootType Probe[main.testInlinedPrint]
+          Type: 312 EventRootType Probe[main.testInlinedPrint]
           InjectionPoints:
             - PC: "0xd038ea"
               Frameless: false
@@ -428,7 +428,7 @@ Probes:
       subprogram: {subprogram: 103}
       events:
         - ID: 103
-          Type: 323 EventRootType Probe[main.testInlinedSq]
+          Type: 316 EventRootType Probe[main.testInlinedSq]
           InjectionPoints: [{PC: "0xd03da1", Frameless: true}]
           Condition: null
     - id: testInlinedSumArray
@@ -443,7 +443,7 @@ Probes:
       subprogram: {subprogram: 104}
       events:
         - ID: 104
-          Type: 324 EventRootType Probe[main.testInlinedSumArray]
+          Type: 317 EventRootType Probe[main.testInlinedSumArray]
           InjectionPoints:
             - PC: "0xd03de5"
               Frameless: false
@@ -461,7 +461,7 @@ Probes:
       subprogram: {subprogram: 7}
       events:
         - ID: 7
-          Type: 227 EventRootType Probe[main.testInt16Array]
+          Type: 220 EventRootType Probe[main.testInt16Array]
           InjectionPoints: [{PC: "0xd02a40", Frameless: true}]
           Condition: null
     - id: testInt32Array
@@ -475,7 +475,7 @@ Probes:
       subprogram: {subprogram: 8}
       events:
         - ID: 8
-          Type: 228 EventRootType Probe[main.testInt32Array]
+          Type: 221 EventRootType Probe[main.testInt32Array]
           InjectionPoints: [{PC: "0xd02a60", Frameless: true}]
           Condition: null
     - id: testInt64Array
@@ -489,7 +489,7 @@ Probes:
       subprogram: {subprogram: 9}
       events:
         - ID: 9
-          Type: 229 EventRootType Probe[main.testInt64Array]
+          Type: 222 EventRootType Probe[main.testInt64Array]
           InjectionPoints: [{PC: "0xd02a80", Frameless: true}]
           Condition: null
     - id: testInt8Array
@@ -503,7 +503,7 @@ Probes:
       subprogram: {subprogram: 6}
       events:
         - ID: 6
-          Type: 226 EventRootType Probe[main.testInt8Array]
+          Type: 219 EventRootType Probe[main.testInt8Array]
           InjectionPoints: [{PC: "0xd02a20", Frameless: true}]
           Condition: null
     - id: testIntArray
@@ -517,7 +517,7 @@ Probes:
       subprogram: {subprogram: 5}
       events:
         - ID: 5
-          Type: 225 EventRootType Probe[main.testIntArray]
+          Type: 218 EventRootType Probe[main.testIntArray]
           InjectionPoints: [{PC: "0xd02a00", Frameless: true}]
           Condition: null
     - id: testInterface
@@ -531,7 +531,7 @@ Probes:
       subprogram: {subprogram: 44}
       events:
         - ID: 44
-          Type: 264 EventRootType Probe[main.testInterface]
+          Type: 257 EventRootType Probe[main.testInterface]
           InjectionPoints: [{PC: "0xd040aa", Frameless: false}]
           Condition: null
     - id: testLinkedList
@@ -545,7 +545,7 @@ Probes:
       subprogram: {subprogram: 71}
       events:
         - ID: 71
-          Type: 291 EventRootType Probe[main.testLinkedList]
+          Type: 284 EventRootType Probe[main.testLinkedList]
           InjectionPoints: [{PC: "0xd063c0", Frameless: true}]
           Condition: null
     - id: testMapArrayToArray
@@ -559,7 +559,7 @@ Probes:
       subprogram: {subprogram: 51}
       events:
         - ID: 51
-          Type: 271 EventRootType Probe[main.testMapArrayToArray]
+          Type: 264 EventRootType Probe[main.testMapArrayToArray]
           InjectionPoints: [{PC: "0xd04660", Frameless: true}]
           Condition: null
     - id: testMapEmbeddedMaps
@@ -573,7 +573,7 @@ Probes:
       subprogram: {subprogram: 57}
       events:
         - ID: 57
-          Type: 277 EventRootType Probe[main.testMapEmbeddedMaps]
+          Type: 270 EventRootType Probe[main.testMapEmbeddedMaps]
           InjectionPoints: [{PC: "0xd04720", Frameless: true}]
           Condition: null
     - id: testMapIntToInt
@@ -587,7 +587,7 @@ Probes:
       subprogram: {subprogram: 55}
       events:
         - ID: 55
-          Type: 275 EventRootType Probe[main.testMapIntToInt]
+          Type: 268 EventRootType Probe[main.testMapIntToInt]
           InjectionPoints: [{PC: "0xd046e0", Frameless: true}]
           Condition: null
     - id: testMapLargeKeyLargeValue
@@ -601,7 +601,7 @@ Probes:
       subprogram: {subprogram: 66}
       events:
         - ID: 66
-          Type: 286 EventRootType Probe[main.testMapLargeKeyLargeValue]
+          Type: 279 EventRootType Probe[main.testMapLargeKeyLargeValue]
           InjectionPoints: [{PC: "0xd04840", Frameless: true}]
           Condition: null
     - id: testMapLargeKeySmallValue
@@ -615,7 +615,7 @@ Probes:
       subprogram: {subprogram: 65}
       events:
         - ID: 65
-          Type: 285 EventRootType Probe[main.testMapLargeKeySmallValue]
+          Type: 278 EventRootType Probe[main.testMapLargeKeySmallValue]
           InjectionPoints: [{PC: "0xd04820", Frameless: true}]
           Condition: null
     - id: testMapMassive
@@ -629,7 +629,7 @@ Probes:
       subprogram: {subprogram: 56}
       events:
         - ID: 56
-          Type: 276 EventRootType Probe[main.testMapMassive]
+          Type: 269 EventRootType Probe[main.testMapMassive]
           InjectionPoints: [{PC: "0xd04700", Frameless: true}]
           Condition: null
     - id: testMapSmallKeyLargeValue
@@ -643,7 +643,7 @@ Probes:
       subprogram: {subprogram: 64}
       events:
         - ID: 64
-          Type: 284 EventRootType Probe[main.testMapSmallKeyLargeValue]
+          Type: 277 EventRootType Probe[main.testMapSmallKeyLargeValue]
           InjectionPoints: [{PC: "0xd04800", Frameless: true}]
           Condition: null
     - id: testMapSmallKeySmallValue
@@ -657,7 +657,7 @@ Probes:
       subprogram: {subprogram: 63}
       events:
         - ID: 63
-          Type: 283 EventRootType Probe[main.testMapSmallKeySmallValue]
+          Type: 276 EventRootType Probe[main.testMapSmallKeySmallValue]
           InjectionPoints: [{PC: "0xd047e0", Frameless: true}]
           Condition: null
     - id: testMapStringToInt
@@ -671,7 +671,7 @@ Probes:
       subprogram: {subprogram: 49}
       events:
         - ID: 49
-          Type: 269 EventRootType Probe[main.testMapStringToInt]
+          Type: 262 EventRootType Probe[main.testMapStringToInt]
           InjectionPoints: [{PC: "0xd04620", Frameless: true}]
           Condition: null
     - id: testMapStringToSlice
@@ -685,7 +685,7 @@ Probes:
       subprogram: {subprogram: 50}
       events:
         - ID: 50
-          Type: 270 EventRootType Probe[main.testMapStringToSlice]
+          Type: 263 EventRootType Probe[main.testMapStringToSlice]
           InjectionPoints: [{PC: "0xd04640", Frameless: true}]
           Condition: null
     - id: testMapStringToStruct
@@ -699,7 +699,7 @@ Probes:
       subprogram: {subprogram: 48}
       events:
         - ID: 48
-          Type: 268 EventRootType Probe[main.testMapStringToStruct]
+          Type: 261 EventRootType Probe[main.testMapStringToStruct]
           InjectionPoints: [{PC: "0xd04600", Frameless: true}]
           Condition: null
     - id: testMapWithLinkedList
@@ -713,7 +713,7 @@ Probes:
       subprogram: {subprogram: 58}
       events:
         - ID: 58
-          Type: 278 EventRootType Probe[main.testMapWithLinkedList]
+          Type: 271 EventRootType Probe[main.testMapWithLinkedList]
           InjectionPoints: [{PC: "0xd04740", Frameless: true}]
           Condition: null
     - id: testMapWithSmallKeyAndValue
@@ -727,7 +727,7 @@ Probes:
       subprogram: {subprogram: 61}
       events:
         - ID: 61
-          Type: 281 EventRootType Probe[main.testMapWithSmallKeyAndValue]
+          Type: 274 EventRootType Probe[main.testMapWithSmallKeyAndValue]
           InjectionPoints: [{PC: "0xd047a0", Frameless: true}]
           Condition: null
     - id: testMapWithSmallKeyAndValueMassive
@@ -741,7 +741,7 @@ Probes:
       subprogram: {subprogram: 62}
       events:
         - ID: 62
-          Type: 282 EventRootType Probe[main.testMapWithSmallKeyAndValueMassive]
+          Type: 275 EventRootType Probe[main.testMapWithSmallKeyAndValueMassive]
           InjectionPoints: [{PC: "0xd047c0", Frameless: true}]
           Condition: null
     - id: testMapWithSmallValue
@@ -755,7 +755,7 @@ Probes:
       subprogram: {subprogram: 59}
       events:
         - ID: 59
-          Type: 279 EventRootType Probe[main.testMapWithSmallValue]
+          Type: 272 EventRootType Probe[main.testMapWithSmallValue]
           InjectionPoints: [{PC: "0xd04760", Frameless: true}]
           Condition: null
     - id: testMapWithSmallValueMassive
@@ -769,7 +769,7 @@ Probes:
       subprogram: {subprogram: 60}
       events:
         - ID: 60
-          Type: 280 EventRootType Probe[main.testMapWithSmallValueMassive]
+          Type: 273 EventRootType Probe[main.testMapWithSmallValueMassive]
           InjectionPoints: [{PC: "0xd04780", Frameless: true}]
           Condition: null
     - id: testMassiveString
@@ -783,7 +783,7 @@ Probes:
       subprogram: {subprogram: 94}
       events:
         - ID: 94
-          Type: 314 EventRootType Probe[main.testMassiveString]
+          Type: 307 EventRootType Probe[main.testMassiveString]
           InjectionPoints: [{PC: "0xd07020", Frameless: true}]
           Condition: null
     - id: testMultipleSimpleParams
@@ -797,7 +797,7 @@ Probes:
       subprogram: {subprogram: 68}
       events:
         - ID: 68
-          Type: 288 EventRootType Probe[main.testMultipleSimpleParams]
+          Type: 281 EventRootType Probe[main.testMultipleSimpleParams]
           InjectionPoints: [{PC: "0xd05fc0", Frameless: true}]
           Condition: null
     - id: testNilPointer
@@ -811,7 +811,7 @@ Probes:
       subprogram: {subprogram: 76}
       events:
         - ID: 76
-          Type: 296 EventRootType Probe[main.testNilPointer]
+          Type: 289 EventRootType Probe[main.testNilPointer]
           InjectionPoints: [{PC: "0xd06560", Frameless: true}]
           Condition: null
     - id: testNilSlice
@@ -825,7 +825,7 @@ Probes:
       subprogram: {subprogram: 86}
       events:
         - ID: 86
-          Type: 306 EventRootType Probe[main.testNilSlice]
+          Type: 299 EventRootType Probe[main.testNilSlice]
           InjectionPoints: [{PC: "0xd06bc0", Frameless: true}]
           Condition: null
     - id: testNilSliceOfStructs
@@ -839,7 +839,7 @@ Probes:
       subprogram: {subprogram: 83}
       events:
         - ID: 83
-          Type: 303 EventRootType Probe[main.testNilSliceOfStructs]
+          Type: 296 EventRootType Probe[main.testNilSliceOfStructs]
           InjectionPoints: [{PC: "0xd06b60", Frameless: true}]
           Condition: null
     - id: testNilSliceWithOtherParams
@@ -853,7 +853,7 @@ Probes:
       subprogram: {subprogram: 85}
       events:
         - ID: 85
-          Type: 305 EventRootType Probe[main.testNilSliceWithOtherParams]
+          Type: 298 EventRootType Probe[main.testNilSliceWithOtherParams]
           InjectionPoints: [{PC: "0xd06ba0", Frameless: true}]
           Condition: null
     - id: testOneStringInStructPointer
@@ -867,7 +867,7 @@ Probes:
       subprogram: {subprogram: 93}
       events:
         - ID: 93
-          Type: 313 EventRootType Probe[main.testOneStringInStructPointer]
+          Type: 306 EventRootType Probe[main.testOneStringInStructPointer]
           InjectionPoints: [{PC: "0xd07000", Frameless: true}]
           Condition: null
     - id: testPointerLoop
@@ -881,7 +881,7 @@ Probes:
       subprogram: {subprogram: 72}
       events:
         - ID: 72
-          Type: 292 EventRootType Probe[main.testPointerLoop]
+          Type: 285 EventRootType Probe[main.testPointerLoop]
           InjectionPoints: [{PC: "0xd063e0", Frameless: true}]
           Condition: null
     - id: testPointerToMap
@@ -895,7 +895,7 @@ Probes:
       subprogram: {subprogram: 54}
       events:
         - ID: 54
-          Type: 274 EventRootType Probe[main.testPointerToMap]
+          Type: 267 EventRootType Probe[main.testPointerToMap]
           InjectionPoints: [{PC: "0xd046c0", Frameless: true}]
           Condition: null
     - id: testPointerToSimpleStruct
@@ -909,7 +909,7 @@ Probes:
       subprogram: {subprogram: 70}
       events:
         - ID: 70
-          Type: 290 EventRootType Probe[main.testPointerToSimpleStruct]
+          Type: 283 EventRootType Probe[main.testPointerToSimpleStruct]
           InjectionPoints: [{PC: "0xd063a0", Frameless: true}]
           Condition: null
     - id: testRuneArray
@@ -923,7 +923,7 @@ Probes:
       subprogram: {subprogram: 2}
       events:
         - ID: 2
-          Type: 222 EventRootType Probe[main.testRuneArray]
+          Type: 215 EventRootType Probe[main.testRuneArray]
           InjectionPoints: [{PC: "0xd029a0", Frameless: true}]
           Condition: null
     - id: testSingleBool
@@ -937,7 +937,7 @@ Probes:
       subprogram: {subprogram: 21}
       events:
         - ID: 21
-          Type: 241 EventRootType Probe[main.testSingleBool]
+          Type: 234 EventRootType Probe[main.testSingleBool]
           InjectionPoints: [{PC: "0xd02fa0", Frameless: true}]
           Condition: null
     - id: testSingleByte
@@ -951,7 +951,7 @@ Probes:
       subprogram: {subprogram: 19}
       events:
         - ID: 19
-          Type: 239 EventRootType Probe[main.testSingleByte]
+          Type: 232 EventRootType Probe[main.testSingleByte]
           InjectionPoints: [{PC: "0xd02f60", Frameless: true}]
           Condition: null
     - id: testSingleFloat32
@@ -965,7 +965,7 @@ Probes:
       subprogram: {subprogram: 32}
       events:
         - ID: 32
-          Type: 252 EventRootType Probe[main.testSingleFloat32]
+          Type: 245 EventRootType Probe[main.testSingleFloat32]
           InjectionPoints: [{PC: "0xd03100", Frameless: true}]
           Condition: null
     - id: testSingleFloat64
@@ -979,7 +979,7 @@ Probes:
       subprogram: {subprogram: 33}
       events:
         - ID: 33
-          Type: 253 EventRootType Probe[main.testSingleFloat64]
+          Type: 246 EventRootType Probe[main.testSingleFloat64]
           InjectionPoints: [{PC: "0xd03120", Frameless: true}]
           Condition: null
     - id: testSingleInt
@@ -993,7 +993,7 @@ Probes:
       subprogram: {subprogram: 22}
       events:
         - ID: 22
-          Type: 242 EventRootType Probe[main.testSingleInt]
+          Type: 235 EventRootType Probe[main.testSingleInt]
           InjectionPoints: [{PC: "0xd02fc0", Frameless: true}]
           Condition: null
     - id: testSingleInt16
@@ -1007,7 +1007,7 @@ Probes:
       subprogram: {subprogram: 24}
       events:
         - ID: 24
-          Type: 244 EventRootType Probe[main.testSingleInt16]
+          Type: 237 EventRootType Probe[main.testSingleInt16]
           InjectionPoints: [{PC: "0xd03000", Frameless: true}]
           Condition: null
     - id: testSingleInt32
@@ -1021,7 +1021,7 @@ Probes:
       subprogram: {subprogram: 25}
       events:
         - ID: 25
-          Type: 245 EventRootType Probe[main.testSingleInt32]
+          Type: 238 EventRootType Probe[main.testSingleInt32]
           InjectionPoints: [{PC: "0xd03020", Frameless: true}]
           Condition: null
     - id: testSingleInt64
@@ -1035,7 +1035,7 @@ Probes:
       subprogram: {subprogram: 26}
       events:
         - ID: 26
-          Type: 246 EventRootType Probe[main.testSingleInt64]
+          Type: 239 EventRootType Probe[main.testSingleInt64]
           InjectionPoints: [{PC: "0xd03040", Frameless: true}]
           Condition: null
     - id: testSingleInt8
@@ -1049,7 +1049,7 @@ Probes:
       subprogram: {subprogram: 23}
       events:
         - ID: 23
-          Type: 243 EventRootType Probe[main.testSingleInt8]
+          Type: 236 EventRootType Probe[main.testSingleInt8]
           InjectionPoints: [{PC: "0xd02fe0", Frameless: true}]
           Condition: null
     - id: testSingleRune
@@ -1063,7 +1063,7 @@ Probes:
       subprogram: {subprogram: 20}
       events:
         - ID: 20
-          Type: 240 EventRootType Probe[main.testSingleRune]
+          Type: 233 EventRootType Probe[main.testSingleRune]
           InjectionPoints: [{PC: "0xd02f80", Frameless: true}]
           Condition: null
     - id: testSingleString
@@ -1077,7 +1077,7 @@ Probes:
       subprogram: {subprogram: 89}
       events:
         - ID: 89
-          Type: 309 EventRootType Probe[main.testSingleString]
+          Type: 302 EventRootType Probe[main.testSingleString]
           InjectionPoints: [{PC: "0xd06f80", Frameless: true}]
           Condition: null
     - id: testSingleUint
@@ -1091,7 +1091,7 @@ Probes:
       subprogram: {subprogram: 27}
       events:
         - ID: 27
-          Type: 247 EventRootType Probe[main.testSingleUint]
+          Type: 240 EventRootType Probe[main.testSingleUint]
           InjectionPoints: [{PC: "0xd03060", Frameless: true}]
           Condition: null
     - id: testSingleUint16
@@ -1105,7 +1105,7 @@ Probes:
       subprogram: {subprogram: 29}
       events:
         - ID: 29
-          Type: 249 EventRootType Probe[main.testSingleUint16]
+          Type: 242 EventRootType Probe[main.testSingleUint16]
           InjectionPoints: [{PC: "0xd030a0", Frameless: true}]
           Condition: null
     - id: testSingleUint32
@@ -1119,7 +1119,7 @@ Probes:
       subprogram: {subprogram: 30}
       events:
         - ID: 30
-          Type: 250 EventRootType Probe[main.testSingleUint32]
+          Type: 243 EventRootType Probe[main.testSingleUint32]
           InjectionPoints: [{PC: "0xd030c0", Frameless: true}]
           Condition: null
     - id: testSingleUint64
@@ -1133,7 +1133,7 @@ Probes:
       subprogram: {subprogram: 31}
       events:
         - ID: 31
-          Type: 251 EventRootType Probe[main.testSingleUint64]
+          Type: 244 EventRootType Probe[main.testSingleUint64]
           InjectionPoints: [{PC: "0xd030e0", Frameless: true}]
           Condition: null
     - id: testSingleUint8
@@ -1147,7 +1147,7 @@ Probes:
       subprogram: {subprogram: 28}
       events:
         - ID: 28
-          Type: 248 EventRootType Probe[main.testSingleUint8]
+          Type: 241 EventRootType Probe[main.testSingleUint8]
           InjectionPoints: [{PC: "0xd03080", Frameless: true}]
           Condition: null
     - id: testSliceOfSlices
@@ -1161,7 +1161,7 @@ Probes:
       subprogram: {subprogram: 80}
       events:
         - ID: 80
-          Type: 300 EventRootType Probe[main.testSliceOfSlices]
+          Type: 293 EventRootType Probe[main.testSliceOfSlices]
           InjectionPoints: [{PC: "0xd06b00", Frameless: true}]
           Condition: null
     - id: testSmallMap
@@ -1175,7 +1175,7 @@ Probes:
       subprogram: {subprogram: 52}
       events:
         - ID: 52
-          Type: 272 EventRootType Probe[main.testSmallMap]
+          Type: 265 EventRootType Probe[main.testSmallMap]
           InjectionPoints: [{PC: "0xd04680", Frameless: true}]
           Condition: null
     - id: testStringArray
@@ -1189,7 +1189,7 @@ Probes:
       subprogram: {subprogram: 3}
       events:
         - ID: 3
-          Type: 223 EventRootType Probe[main.testStringArray]
+          Type: 216 EventRootType Probe[main.testStringArray]
           InjectionPoints: [{PC: "0xd029c0", Frameless: true}]
           Condition: null
     - id: testStringPointer
@@ -1203,7 +1203,7 @@ Probes:
       subprogram: {subprogram: 75}
       events:
         - ID: 75
-          Type: 295 EventRootType Probe[main.testStringPointer]
+          Type: 288 EventRootType Probe[main.testStringPointer]
           InjectionPoints: [{PC: "0xd06520", Frameless: true}]
           Condition: null
     - id: testStringSlice
@@ -1217,7 +1217,7 @@ Probes:
       subprogram: {subprogram: 84}
       events:
         - ID: 84
-          Type: 304 EventRootType Probe[main.testStringSlice]
+          Type: 297 EventRootType Probe[main.testStringSlice]
           InjectionPoints: [{PC: "0xd06b80", Frameless: true}]
           Condition: null
     - id: testStruct
@@ -1231,7 +1231,7 @@ Probes:
       subprogram: {subprogram: 97}
       events:
         - ID: 97
-          Type: 317 EventRootType Probe[main.testStruct]
+          Type: 310 EventRootType Probe[main.testStruct]
           InjectionPoints: [{PC: "0xd072e0", Frameless: true}]
           Condition: null
     - id: testStructSlice
@@ -1245,7 +1245,7 @@ Probes:
       subprogram: {subprogram: 81}
       events:
         - ID: 81
-          Type: 301 EventRootType Probe[main.testStructSlice]
+          Type: 294 EventRootType Probe[main.testStructSlice]
           InjectionPoints: [{PC: "0xd06b20", Frameless: true}]
           Condition: null
     - id: testStructWithMap
@@ -1259,7 +1259,7 @@ Probes:
       subprogram: {subprogram: 47}
       events:
         - ID: 47
-          Type: 267 EventRootType Probe[main.testStructWithMap]
+          Type: 260 EventRootType Probe[main.testStructWithMap]
           InjectionPoints: [{PC: "0xd045e0", Frameless: true}]
           Condition: null
     - id: testThreeStrings
@@ -1273,7 +1273,7 @@ Probes:
       subprogram: {subprogram: 90}
       events:
         - ID: 90
-          Type: 310 EventRootType Probe[main.testThreeStrings]
+          Type: 303 EventRootType Probe[main.testThreeStrings]
           InjectionPoints: [{PC: "0xd06fa0", Frameless: true}]
           Condition: null
     - id: testThreeStringsInStruct
@@ -1287,7 +1287,7 @@ Probes:
       subprogram: {subprogram: 91}
       events:
         - ID: 91
-          Type: 311 EventRootType Probe[main.testThreeStringsInStruct]
+          Type: 304 EventRootType Probe[main.testThreeStringsInStruct]
           InjectionPoints: [{PC: "0xd06fc0", Frameless: true}]
           Condition: null
     - id: testThreeStringsInStructPointer
@@ -1301,7 +1301,7 @@ Probes:
       subprogram: {subprogram: 92}
       events:
         - ID: 92
-          Type: 312 EventRootType Probe[main.testThreeStringsInStructPointer]
+          Type: 305 EventRootType Probe[main.testThreeStringsInStructPointer]
           InjectionPoints: [{PC: "0xd06fe0", Frameless: true}]
           Condition: null
     - id: testTypeAlias
@@ -1315,7 +1315,7 @@ Probes:
       subprogram: {subprogram: 34}
       events:
         - ID: 34
-          Type: 254 EventRootType Probe[main.testTypeAlias]
+          Type: 247 EventRootType Probe[main.testTypeAlias]
           InjectionPoints: [{PC: "0xd03140", Frameless: true}]
           Condition: null
     - id: testUint16Array
@@ -1329,7 +1329,7 @@ Probes:
       subprogram: {subprogram: 12}
       events:
         - ID: 12
-          Type: 232 EventRootType Probe[main.testUint16Array]
+          Type: 225 EventRootType Probe[main.testUint16Array]
           InjectionPoints: [{PC: "0xd02ae0", Frameless: true}]
           Condition: null
     - id: testUint32Array
@@ -1343,7 +1343,7 @@ Probes:
       subprogram: {subprogram: 13}
       events:
         - ID: 13
-          Type: 233 EventRootType Probe[main.testUint32Array]
+          Type: 226 EventRootType Probe[main.testUint32Array]
           InjectionPoints: [{PC: "0xd02b00", Frameless: true}]
           Condition: null
     - id: testUint64Array
@@ -1357,7 +1357,7 @@ Probes:
       subprogram: {subprogram: 14}
       events:
         - ID: 14
-          Type: 234 EventRootType Probe[main.testUint64Array]
+          Type: 227 EventRootType Probe[main.testUint64Array]
           InjectionPoints: [{PC: "0xd02b20", Frameless: true}]
           Condition: null
     - id: testUint8Array
@@ -1371,7 +1371,7 @@ Probes:
       subprogram: {subprogram: 11}
       events:
         - ID: 11
-          Type: 231 EventRootType Probe[main.testUint8Array]
+          Type: 224 EventRootType Probe[main.testUint8Array]
           InjectionPoints: [{PC: "0xd02ac0", Frameless: true}]
           Condition: null
     - id: testUintArray
@@ -1385,7 +1385,7 @@ Probes:
       subprogram: {subprogram: 10}
       events:
         - ID: 10
-          Type: 230 EventRootType Probe[main.testUintArray]
+          Type: 223 EventRootType Probe[main.testUintArray]
           InjectionPoints: [{PC: "0xd02aa0", Frameless: true}]
           Condition: null
     - id: testUintPointer
@@ -1399,7 +1399,7 @@ Probes:
       subprogram: {subprogram: 74}
       events:
         - ID: 74
-          Type: 294 EventRootType Probe[main.testUintPointer]
+          Type: 287 EventRootType Probe[main.testUintPointer]
           InjectionPoints: [{PC: "0xd06440", Frameless: true}]
           Condition: null
     - id: testUintSlice
@@ -1413,7 +1413,7 @@ Probes:
       subprogram: {subprogram: 78}
       events:
         - ID: 78
-          Type: 298 EventRootType Probe[main.testUintSlice]
+          Type: 291 EventRootType Probe[main.testUintSlice]
           InjectionPoints: [{PC: "0xd06ac0", Frameless: true}]
           Condition: null
     - id: testUnitializedString
@@ -1427,7 +1427,7 @@ Probes:
       subprogram: {subprogram: 95}
       events:
         - ID: 95
-          Type: 315 EventRootType Probe[main.testUnitializedString]
+          Type: 308 EventRootType Probe[main.testUnitializedString]
           InjectionPoints: [{PC: "0xd07040", Frameless: true}]
           Condition: null
     - id: testUnsafePointer
@@ -1441,7 +1441,7 @@ Probes:
       subprogram: {subprogram: 73}
       events:
         - ID: 73
-          Type: 293 EventRootType Probe[main.testUnsafePointer]
+          Type: 286 EventRootType Probe[main.testUnsafePointer]
           InjectionPoints: [{PC: "0xd06400", Frameless: true}]
           Condition: null
     - id: testVeryLargeArray
@@ -1455,7 +1455,7 @@ Probes:
       subprogram: {subprogram: 18}
       events:
         - ID: 18
-          Type: 238 EventRootType Probe[main.testVeryLargeArray]
+          Type: 231 EventRootType Probe[main.testVeryLargeArray]
           InjectionPoints: [{PC: "0xd02be0", Frameless: true}]
           Condition: null
     - id: testVeryLargeSlice
@@ -1469,7 +1469,7 @@ Probes:
       subprogram: {subprogram: 87}
       events:
         - ID: 87
-          Type: 307 EventRootType Probe[main.testVeryLargeSlice]
+          Type: 300 EventRootType Probe[main.testVeryLargeSlice]
           InjectionPoints: [{PC: "0xd06be0", Frameless: true}]
           Condition: null
 Subprograms:
@@ -3095,15 +3095,10 @@ Subprograms:
           IsReturn: false
 Types:
     - __kind: PointerType
-      ID: 185
+      ID: 209
       Name: '**main.t'
       ByteSize: 8
       Pointee: 135 PointerType *main.t
-    - __kind: PointerType
-      ID: 216
-      Name: '**runtime.bmap'
-      ByteSize: 8
-      Pointee: 167 PointerType *runtime.bmap
     - __kind: PointerType
       ID: 54
       Name: '**string'
@@ -3112,62 +3107,50 @@ Types:
       GoKind: 22
       Pointee: 22 PointerType *string
     - __kind: PointerType
-      ID: 165
-      Name: '*[]*runtime.bmap'
-      ByteSize: 8
-      GoRuntimeType: 451680
-      GoKind: 22
-      Pointee: 166 GoSliceHeaderType []*runtime.bmap
-    - __kind: PointerType
-      ID: 218
-      Name: '*[]*runtime.bmap.array'
-      ByteSize: 8
-      Pointee: 217 GoSliceDataType []*runtime.bmap.array
-    - __kind: PointerType
-      ID: 189
+      ID: 156
       Name: '*[]*string.array'
       ByteSize: 8
-      Pointee: 188 GoSliceDataType []*string.array
+      Pointee: 155 GoSliceDataType []*string.array
     - __kind: PointerType
-      ID: 207
+      ID: 191
       Name: '*[][]uint.array'
       ByteSize: 8
-      Pointee: 206 GoSliceDataType [][]uint.array
+      Pointee: 190 GoSliceDataType [][]uint.array
     - __kind: PointerType
-      ID: 213
+      ID: 197
       Name: '*[]bool.array'
       ByteSize: 8
-      Pointee: 212 GoSliceDataType []bool.array
+      Pointee: 196 GoSliceDataType []bool.array
     - __kind: PointerType
-      ID: 220
+      ID: 213
       Name: '*[]main.structWithMap.array'
       ByteSize: 8
-      Pointee: 219 GoSliceDataType []main.structWithMap.array
+      Pointee: 212 GoSliceDataType []main.structWithMap.array
     - __kind: PointerType
-      ID: 209
+      ID: 193
       Name: '*[]main.structWithNoStrings.array'
       ByteSize: 8
-      Pointee: 208 GoSliceDataType []main.structWithNoStrings.array
+      Pointee: 192 GoSliceDataType []main.structWithNoStrings.array
     - __kind: PointerType
-      ID: 211
+      ID: 195
       Name: '*[]string.array'
       ByteSize: 8
-      Pointee: 210 GoSliceDataType []string.array
+      Pointee: 194 GoSliceDataType []string.array
     - __kind: PointerType
       ID: 139
       Name: '*[]uint'
       ByteSize: 8
       Pointee: 137 GoSliceHeaderType []uint
     - __kind: PointerType
-      ID: 205
+      ID: 189
       Name: '*[]uint.array'
       ByteSize: 8
-      Pointee: 204 GoSliceDataType []uint.array
+      Pointee: 188 GoSliceDataType []uint.array
     - __kind: PointerType
-      ID: 215
+      ID: 199
       Name: '*[]uint16.array'
       ByteSize: 8
-      Pointee: 214 GoSliceDataType []uint16.array
+      Pointee: 198 GoSliceDataType []uint16.array
     - __kind: PointerType
       ID: 5
       Name: '*bool'
@@ -3372,7 +3355,7 @@ Types:
       GoKind: 22
       Pointee: 149 StructureType main.oneStringStruct
     - __kind: PointerType
-      ID: 177
+      ID: 173
       Name: '*main.structWithMap'
       ByteSize: 8
       GoRuntimeType: 354080
@@ -3396,10 +3379,10 @@ Types:
       GoKind: 22
       Pointee: 136 GoSliceHeaderType main.t
     - __kind: PointerType
-      ID: 203
+      ID: 211
       Name: '*main.t.array'
       ByteSize: 8
-      Pointee: 202 GoSliceDataType main.t.array
+      Pointee: 210 GoSliceDataType main.t.array
     - __kind: PointerType
       ID: 147
       Name: '*main.threeStringStruct'
@@ -3413,19 +3396,12 @@ Types:
       GoKind: 22
       Pointee: 78 GoMapType map[string]int
     - __kind: PointerType
-      ID: 167
-      Name: '*runtime.bmap'
-      ByteSize: 8
-      GoRuntimeType: 1.100896e+06
-      GoKind: 22
-      Pointee: 168 StructureType runtime.bmap
-    - __kind: PointerType
       ID: 71
       Name: '*runtime.mapextra'
       ByteSize: 8
       GoRuntimeType: 363104
       GoKind: 22
-      Pointee: 72 StructureType runtime.mapextra
+      Pointee: 72 UnresolvedPointeeType runtime.mapextra
     - __kind: PointerType
       ID: 22
       Name: '*string'
@@ -3434,10 +3410,10 @@ Types:
       GoKind: 22
       Pointee: 11 GoStringHeaderType string
     - __kind: PointerType
-      ID: 187
+      ID: 154
       Name: '*string.str'
       ByteSize: 8
-      Pointee: 186 GoStringDataType string.str
+      Pointee: 153 GoStringDataType string.str
     - __kind: PointerType
       ID: 34
       Name: '*uint'
@@ -3481,10 +3457,10 @@ Types:
       GoKind: 22
       Pointee: 1 BaseType uintptr
     - __kind: EventRootType
-      ID: 308
+      ID: 301
       Name: Probe[main.stackC]
     - __kind: EventRootType
-      ID: 265
+      ID: 258
       Name: Probe[main.testAny]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -3499,7 +3475,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 237
+      ID: 230
       Name: Probe[main.testArrayOfArraysOfArrays]
       ByteSize: 65
       PresenceBitsetSize: 1
@@ -3514,7 +3490,7 @@ Types:
                   Offset: 0
                   ByteSize: 64
     - __kind: EventRootType
-      ID: 235
+      ID: 228
       Name: Probe[main.testArrayOfArrays]
       ByteSize: 33
       PresenceBitsetSize: 1
@@ -3529,7 +3505,7 @@ Types:
                   Offset: 0
                   ByteSize: 32
     - __kind: EventRootType
-      ID: 273
+      ID: 266
       Name: Probe[main.testArrayOfMaps]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -3544,7 +3520,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 236
+      ID: 229
       Name: Probe[main.testArrayOfStrings]
       ByteSize: 33
       PresenceBitsetSize: 1
@@ -3559,7 +3535,7 @@ Types:
                   Offset: 0
                   ByteSize: 32
     - __kind: EventRootType
-      ID: 255
+      ID: 248
       Name: Probe[main.testBigStruct]
       ByteSize: 49
       PresenceBitsetSize: 1
@@ -3574,7 +3550,7 @@ Types:
                   Offset: 0
                   ByteSize: 48
     - __kind: EventRootType
-      ID: 224
+      ID: 217
       Name: Probe[main.testBoolArray]
       ByteSize: 3
       PresenceBitsetSize: 1
@@ -3589,7 +3565,7 @@ Types:
                   Offset: 0
                   ByteSize: 2
     - __kind: EventRootType
-      ID: 221
+      ID: 214
       Name: Probe[main.testByteArray]
       ByteSize: 3
       PresenceBitsetSize: 1
@@ -3604,7 +3580,7 @@ Types:
                   Offset: 0
                   ByteSize: 2
     - __kind: EventRootType
-      ID: 289
+      ID: 282
       Name: Probe[main.testChannel]
       ByteSize: 1
       PresenceBitsetSize: 1
@@ -3619,7 +3595,7 @@ Types:
                   Offset: 0
                   ByteSize: 0
     - __kind: EventRootType
-      ID: 287
+      ID: 280
       Name: Probe[main.testCombinedByte]
       ByteSize: 7
       PresenceBitsetSize: 1
@@ -3652,7 +3628,7 @@ Types:
                   Offset: 0
                   ByteSize: 4
     - __kind: EventRootType
-      ID: 297
+      ID: 290
       Name: Probe[main.testCycle]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -3667,7 +3643,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 302
+      ID: 295
       Name: Probe[main.testEmptySliceOfStructs]
       ByteSize: 33
       PresenceBitsetSize: 1
@@ -3691,7 +3667,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 299
+      ID: 292
       Name: Probe[main.testEmptySlice]
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -3706,7 +3682,7 @@ Types:
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 316
+      ID: 309
       Name: Probe[main.testEmptyString]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -3721,7 +3697,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 318
+      ID: 311
       Name: Probe[main.testEmptyStruct]
       ByteSize: 1
       PresenceBitsetSize: 1
@@ -3736,7 +3712,7 @@ Types:
                   Offset: 0
                   ByteSize: 0
     - __kind: EventRootType
-      ID: 266
+      ID: 259
       Name: Probe[main.testError]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -3751,7 +3727,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 257
+      ID: 250
       Name: Probe[main.testEsotericHeap]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -3766,7 +3742,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 256
+      ID: 249
       Name: Probe[main.testEsotericStack]
       ByteSize: 65
       PresenceBitsetSize: 1
@@ -3781,7 +3757,7 @@ Types:
                   Offset: 0
                   ByteSize: 64
     - __kind: EventRootType
-      ID: 263
+      ID: 256
       Name: Probe[main.testFramelessArray]
       ByteSize: 41
       PresenceBitsetSize: 1
@@ -3796,7 +3772,7 @@ Types:
                   Offset: 0
                   ByteSize: 40
     - __kind: EventRootType
-      ID: 262
+      ID: 255
       Name: Probe[main.testFrameless]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -3811,7 +3787,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 258
+      ID: 251
       Name: Probe[main.testInlinedBA]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -3826,7 +3802,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 260
+      ID: 253
       Name: Probe[main.testInlinedBBA]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -3841,10 +3817,10 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 320
+      ID: 313
       Name: Probe[main.testInlinedBBB]
     - __kind: EventRootType
-      ID: 259
+      ID: 252
       Name: Probe[main.testInlinedBB]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -3868,16 +3844,16 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 321
+      ID: 314
       Name: Probe[main.testInlinedBCA]
     - __kind: EventRootType
-      ID: 322
+      ID: 315
       Name: Probe[main.testInlinedBCB]
     - __kind: EventRootType
-      ID: 261
+      ID: 254
       Name: Probe[main.testInlinedBC]
     - __kind: EventRootType
-      ID: 319
+      ID: 312
       Name: Probe[main.testInlinedPrint]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -3892,7 +3868,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 323
+      ID: 316
       Name: Probe[main.testInlinedSq]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -3907,7 +3883,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 324
+      ID: 317
       Name: Probe[main.testInlinedSumArray]
       ByteSize: 41
       PresenceBitsetSize: 1
@@ -3922,7 +3898,7 @@ Types:
                   Offset: 0
                   ByteSize: 40
     - __kind: EventRootType
-      ID: 227
+      ID: 220
       Name: Probe[main.testInt16Array]
       ByteSize: 5
       PresenceBitsetSize: 1
@@ -3937,7 +3913,7 @@ Types:
                   Offset: 0
                   ByteSize: 4
     - __kind: EventRootType
-      ID: 228
+      ID: 221
       Name: Probe[main.testInt32Array]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -3952,7 +3928,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 229
+      ID: 222
       Name: Probe[main.testInt64Array]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -3967,7 +3943,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 226
+      ID: 219
       Name: Probe[main.testInt8Array]
       ByteSize: 3
       PresenceBitsetSize: 1
@@ -3982,7 +3958,7 @@ Types:
                   Offset: 0
                   ByteSize: 2
     - __kind: EventRootType
-      ID: 225
+      ID: 218
       Name: Probe[main.testIntArray]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -3997,7 +3973,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 264
+      ID: 257
       Name: Probe[main.testInterface]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -4012,7 +3988,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 291
+      ID: 284
       Name: Probe[main.testLinkedList]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -4027,7 +4003,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 271
+      ID: 264
       Name: Probe[main.testMapArrayToArray]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -4042,7 +4018,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 277
+      ID: 270
       Name: Probe[main.testMapEmbeddedMaps]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -4057,7 +4033,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 275
+      ID: 268
       Name: Probe[main.testMapIntToInt]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -4072,7 +4048,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 286
+      ID: 279
       Name: Probe[main.testMapLargeKeyLargeValue]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -4087,7 +4063,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 285
+      ID: 278
       Name: Probe[main.testMapLargeKeySmallValue]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -4102,7 +4078,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 276
+      ID: 269
       Name: Probe[main.testMapMassive]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -4117,7 +4093,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 284
+      ID: 277
       Name: Probe[main.testMapSmallKeyLargeValue]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -4132,7 +4108,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 283
+      ID: 276
       Name: Probe[main.testMapSmallKeySmallValue]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -4147,7 +4123,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 269
+      ID: 262
       Name: Probe[main.testMapStringToInt]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -4162,7 +4138,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 270
+      ID: 263
       Name: Probe[main.testMapStringToSlice]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -4177,7 +4153,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 268
+      ID: 261
       Name: Probe[main.testMapStringToStruct]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -4192,7 +4168,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 278
+      ID: 271
       Name: Probe[main.testMapWithLinkedList]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -4207,7 +4183,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 282
+      ID: 275
       Name: Probe[main.testMapWithSmallKeyAndValueMassive]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -4222,7 +4198,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 281
+      ID: 274
       Name: Probe[main.testMapWithSmallKeyAndValue]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -4237,7 +4213,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 280
+      ID: 273
       Name: Probe[main.testMapWithSmallValueMassive]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -4252,7 +4228,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 279
+      ID: 272
       Name: Probe[main.testMapWithSmallValue]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -4267,7 +4243,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 314
+      ID: 307
       Name: Probe[main.testMassiveString]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -4282,7 +4258,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 288
+      ID: 281
       Name: Probe[main.testMultipleSimpleParams]
       ByteSize: 31
       PresenceBitsetSize: 1
@@ -4333,7 +4309,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 296
+      ID: 289
       Name: Probe[main.testNilPointer]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -4357,7 +4333,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 303
+      ID: 296
       Name: Probe[main.testNilSliceOfStructs]
       ByteSize: 33
       PresenceBitsetSize: 1
@@ -4381,7 +4357,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 305
+      ID: 298
       Name: Probe[main.testNilSliceWithOtherParams]
       ByteSize: 34
       PresenceBitsetSize: 1
@@ -4414,7 +4390,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 306
+      ID: 299
       Name: Probe[main.testNilSlice]
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -4429,7 +4405,7 @@ Types:
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 313
+      ID: 306
       Name: Probe[main.testOneStringInStructPointer]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -4444,7 +4420,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 292
+      ID: 285
       Name: Probe[main.testPointerLoop]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -4459,7 +4435,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 274
+      ID: 267
       Name: Probe[main.testPointerToMap]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -4474,7 +4450,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 290
+      ID: 283
       Name: Probe[main.testPointerToSimpleStruct]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -4489,7 +4465,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 222
+      ID: 215
       Name: Probe[main.testRuneArray]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -4504,7 +4480,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 241
+      ID: 234
       Name: Probe[main.testSingleBool]
       ByteSize: 2
       PresenceBitsetSize: 1
@@ -4519,7 +4495,7 @@ Types:
                   Offset: 0
                   ByteSize: 1
     - __kind: EventRootType
-      ID: 239
+      ID: 232
       Name: Probe[main.testSingleByte]
       ByteSize: 2
       PresenceBitsetSize: 1
@@ -4534,7 +4510,7 @@ Types:
                   Offset: 0
                   ByteSize: 1
     - __kind: EventRootType
-      ID: 252
+      ID: 245
       Name: Probe[main.testSingleFloat32]
       ByteSize: 5
       PresenceBitsetSize: 1
@@ -4549,7 +4525,7 @@ Types:
                   Offset: 0
                   ByteSize: 4
     - __kind: EventRootType
-      ID: 253
+      ID: 246
       Name: Probe[main.testSingleFloat64]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -4564,7 +4540,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 244
+      ID: 237
       Name: Probe[main.testSingleInt16]
       ByteSize: 3
       PresenceBitsetSize: 1
@@ -4579,7 +4555,7 @@ Types:
                   Offset: 0
                   ByteSize: 2
     - __kind: EventRootType
-      ID: 245
+      ID: 238
       Name: Probe[main.testSingleInt32]
       ByteSize: 5
       PresenceBitsetSize: 1
@@ -4594,7 +4570,7 @@ Types:
                   Offset: 0
                   ByteSize: 4
     - __kind: EventRootType
-      ID: 246
+      ID: 239
       Name: Probe[main.testSingleInt64]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -4609,7 +4585,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 243
+      ID: 236
       Name: Probe[main.testSingleInt8]
       ByteSize: 2
       PresenceBitsetSize: 1
@@ -4624,7 +4600,7 @@ Types:
                   Offset: 0
                   ByteSize: 1
     - __kind: EventRootType
-      ID: 242
+      ID: 235
       Name: Probe[main.testSingleInt]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -4639,7 +4615,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 240
+      ID: 233
       Name: Probe[main.testSingleRune]
       ByteSize: 5
       PresenceBitsetSize: 1
@@ -4654,7 +4630,7 @@ Types:
                   Offset: 0
                   ByteSize: 4
     - __kind: EventRootType
-      ID: 309
+      ID: 302
       Name: Probe[main.testSingleString]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -4669,7 +4645,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 249
+      ID: 242
       Name: Probe[main.testSingleUint16]
       ByteSize: 3
       PresenceBitsetSize: 1
@@ -4684,7 +4660,7 @@ Types:
                   Offset: 0
                   ByteSize: 2
     - __kind: EventRootType
-      ID: 250
+      ID: 243
       Name: Probe[main.testSingleUint32]
       ByteSize: 5
       PresenceBitsetSize: 1
@@ -4699,7 +4675,7 @@ Types:
                   Offset: 0
                   ByteSize: 4
     - __kind: EventRootType
-      ID: 251
+      ID: 244
       Name: Probe[main.testSingleUint64]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -4714,7 +4690,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 248
+      ID: 241
       Name: Probe[main.testSingleUint8]
       ByteSize: 2
       PresenceBitsetSize: 1
@@ -4729,7 +4705,7 @@ Types:
                   Offset: 0
                   ByteSize: 1
     - __kind: EventRootType
-      ID: 247
+      ID: 240
       Name: Probe[main.testSingleUint]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -4744,7 +4720,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 300
+      ID: 293
       Name: Probe[main.testSliceOfSlices]
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -4759,7 +4735,7 @@ Types:
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 272
+      ID: 265
       Name: Probe[main.testSmallMap]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -4774,7 +4750,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 223
+      ID: 216
       Name: Probe[main.testStringArray]
       ByteSize: 33
       PresenceBitsetSize: 1
@@ -4789,7 +4765,7 @@ Types:
                   Offset: 0
                   ByteSize: 32
     - __kind: EventRootType
-      ID: 295
+      ID: 288
       Name: Probe[main.testStringPointer]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -4804,7 +4780,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 304
+      ID: 297
       Name: Probe[main.testStringSlice]
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -4819,7 +4795,7 @@ Types:
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 301
+      ID: 294
       Name: Probe[main.testStructSlice]
       ByteSize: 33
       PresenceBitsetSize: 1
@@ -4843,7 +4819,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 267
+      ID: 260
       Name: Probe[main.testStructWithMap]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -4858,7 +4834,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 317
+      ID: 310
       Name: Probe[main.testStruct]
       ByteSize: 57
       PresenceBitsetSize: 1
@@ -4873,7 +4849,7 @@ Types:
                   Offset: 0
                   ByteSize: 56
     - __kind: EventRootType
-      ID: 312
+      ID: 305
       Name: Probe[main.testThreeStringsInStructPointer]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -4888,7 +4864,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 311
+      ID: 304
       Name: Probe[main.testThreeStringsInStruct]
       ByteSize: 49
       PresenceBitsetSize: 1
@@ -4903,7 +4879,7 @@ Types:
                   Offset: 0
                   ByteSize: 48
     - __kind: EventRootType
-      ID: 310
+      ID: 303
       Name: Probe[main.testThreeStrings]
       ByteSize: 49
       PresenceBitsetSize: 1
@@ -4936,7 +4912,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 254
+      ID: 247
       Name: Probe[main.testTypeAlias]
       ByteSize: 3
       PresenceBitsetSize: 1
@@ -4951,7 +4927,7 @@ Types:
                   Offset: 0
                   ByteSize: 2
     - __kind: EventRootType
-      ID: 232
+      ID: 225
       Name: Probe[main.testUint16Array]
       ByteSize: 5
       PresenceBitsetSize: 1
@@ -4966,7 +4942,7 @@ Types:
                   Offset: 0
                   ByteSize: 4
     - __kind: EventRootType
-      ID: 233
+      ID: 226
       Name: Probe[main.testUint32Array]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -4981,7 +4957,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 234
+      ID: 227
       Name: Probe[main.testUint64Array]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -4996,7 +4972,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 231
+      ID: 224
       Name: Probe[main.testUint8Array]
       ByteSize: 3
       PresenceBitsetSize: 1
@@ -5011,7 +4987,7 @@ Types:
                   Offset: 0
                   ByteSize: 2
     - __kind: EventRootType
-      ID: 230
+      ID: 223
       Name: Probe[main.testUintArray]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -5026,7 +5002,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 294
+      ID: 287
       Name: Probe[main.testUintPointer]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -5041,7 +5017,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 298
+      ID: 291
       Name: Probe[main.testUintSlice]
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -5056,7 +5032,7 @@ Types:
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 315
+      ID: 308
       Name: Probe[main.testUnitializedString]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -5071,7 +5047,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 293
+      ID: 286
       Name: Probe[main.testUnsafePointer]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -5086,7 +5062,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 238
+      ID: 231
       Name: Probe[main.testVeryLargeArray]
       ByteSize: 801
       PresenceBitsetSize: 1
@@ -5101,7 +5077,7 @@ Types:
                   Offset: 0
                   ByteSize: 800
     - __kind: EventRootType
-      ID: 307
+      ID: 300
       Name: Probe[main.testVeryLargeSlice]
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -5258,7 +5234,7 @@ Types:
       HasCount: true
       Element: 9 BaseType int
     - __kind: ArrayType
-      ID: 173
+      ID: 168
       Name: '[4]string'
       ByteSize: 64
       GoRuntimeType: 617632
@@ -5275,7 +5251,7 @@ Types:
       HasCount: true
       Element: 9 BaseType int
     - __kind: ArrayType
-      ID: 162
+      ID: 157
       Name: '[8]uint8'
       ByteSize: 8
       GoRuntimeType: 615424
@@ -5283,28 +5259,6 @@ Types:
       Count: 8
       HasCount: true
       Element: 3 BaseType uint8
-    - __kind: GoSliceHeaderType
-      ID: 166
-      Name: '[]*runtime.bmap'
-      ByteSize: 24
-      GoRuntimeType: 451616
-      GoKind: 23
-      RawFields:
-        - Name: array
-          Offset: 0
-          Type: 216 PointerType **runtime.bmap
-        - Name: len
-          Offset: 8
-          Type: 9 BaseType int
-        - Name: cap
-          Offset: 16
-          Type: 9 BaseType int
-      Data: 217 GoSliceDataType []*runtime.bmap.array
-    - __kind: GoSliceDataType
-      ID: 217
-      Name: '[]*runtime.bmap.array'
-      ByteSize: 2048
-      Element: 167 PointerType *runtime.bmap
     - __kind: GoSliceHeaderType
       ID: 53
       Name: '[]*string'
@@ -5321,9 +5275,9 @@ Types:
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 188 GoSliceDataType []*string.array
+      Data: 155 GoSliceDataType []*string.array
     - __kind: GoSliceDataType
-      ID: 188
+      ID: 155
       Name: '[]*string.array'
       ByteSize: 2048
       Element: 22 PointerType *string
@@ -5342,9 +5296,9 @@ Types:
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 206 GoSliceDataType [][]uint.array
+      Data: 190 GoSliceDataType [][]uint.array
     - __kind: GoSliceDataType
-      ID: 206
+      ID: 190
       Name: '[][]uint.array'
       ByteSize: 2048
       Element: 137 GoSliceHeaderType []uint
@@ -5364,116 +5318,116 @@ Types:
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 212 GoSliceDataType []bool.array
+      Data: 196 GoSliceDataType []bool.array
     - __kind: GoSliceDataType
-      ID: 212
+      ID: 196
       Name: '[]bool.array'
       ByteSize: 2048
       Element: 4 BaseType bool
     - __kind: GoSliceDataType
-      ID: 201
+      ID: 187
       Name: '[]bucket<[4]int,[4]int>.array'
       ByteSize: 2048
       Element: 129 GoHMapBucketType bucket<[4]int,[4]int>
     - __kind: GoSliceDataType
-      ID: 200
+      ID: 186
       Name: '[]bucket<[4]int,uint8>.array'
       ByteSize: 2048
       Element: 124 GoHMapBucketType bucket<[4]int,uint8>
     - __kind: GoSliceDataType
-      ID: 194
+      ID: 170
       Name: '[]bucket<[4]string,[2]int>.array'
       ByteSize: 2048
       Element: 92 GoHMapBucketType bucket<[4]string,[2]int>
     - __kind: GoSliceDataType
-      ID: 196
+      ID: 177
       Name: '[]bucket<bool,main.node>.array'
       ByteSize: 2048
       Element: 104 GoHMapBucketType bucket<bool,main.node>
     - __kind: GoSliceDataType
-      ID: 190
+      ID: 160
       Name: '[]bucket<int,int>.array'
       ByteSize: 2048
       Element: 70 GoHMapBucketType bucket<int,int>
     - __kind: GoSliceDataType
-      ID: 197
+      ID: 179
       Name: '[]bucket<int,uint8>.array'
       ByteSize: 2048
       Element: 109 GoHMapBucketType bucket<int,uint8>
     - __kind: GoSliceDataType
-      ID: 195
+      ID: 174
       Name: '[]bucket<string,[]main.structWithMap>.array'
       ByteSize: 2048
       Element: 99 GoHMapBucketType bucket<string,[]main.structWithMap>
     - __kind: GoSliceDataType
-      ID: 193
+      ID: 166
       Name: '[]bucket<string,[]string>.array'
       ByteSize: 2048
       Element: 87 GoHMapBucketType bucket<string,[]string>
     - __kind: GoSliceDataType
-      ID: 192
+      ID: 164
       Name: '[]bucket<string,int>.array'
       ByteSize: 2048
       Element: 82 GoHMapBucketType bucket<string,int>
     - __kind: GoSliceDataType
-      ID: 191
+      ID: 163
       Name: '[]bucket<string,main.nestedStruct>.array'
       ByteSize: 2048
       Element: 77 GoHMapBucketType bucket<string,main.nestedStruct>
     - __kind: GoSliceDataType
-      ID: 199
+      ID: 184
       Name: '[]bucket<uint8,[4]int>.array'
       ByteSize: 2048
       Element: 119 GoHMapBucketType bucket<uint8,[4]int>
     - __kind: GoSliceDataType
-      ID: 198
+      ID: 181
       Name: '[]bucket<uint8,uint8>.array'
       ByteSize: 2048
       Element: 114 GoHMapBucketType bucket<uint8,uint8>
     - __kind: ArrayType
-      ID: 184
+      ID: 185
       Name: '[]key<[4]int>'
       ByteSize: 256
       Count: 8
       HasCount: true
       Element: 183 ArrayType [4]int
     - __kind: ArrayType
-      ID: 172
+      ID: 167
       Name: '[]key<[4]string>'
       ByteSize: 512
       Count: 8
       HasCount: true
-      Element: 173 ArrayType [4]string
+      Element: 168 ArrayType [4]string
     - __kind: ArrayType
-      ID: 178
+      ID: 175
       Name: '[]key<bool>'
       ByteSize: 8
       Count: 8
       HasCount: true
       Element: 4 BaseType bool
     - __kind: ArrayType
-      ID: 163
+      ID: 158
       Name: '[]key<int>'
       ByteSize: 64
       Count: 8
       HasCount: true
       Element: 9 BaseType int
     - __kind: ArrayType
-      ID: 169
+      ID: 161
       Name: '[]key<string>'
       ByteSize: 128
       Count: 8
       HasCount: true
       Element: 11 GoStringHeaderType string
     - __kind: ArrayType
-      ID: 181
+      ID: 180
       Name: '[]key<uint8>'
       ByteSize: 8
       Count: 8
       HasCount: true
       Element: 3 BaseType uint8
     - __kind: GoSliceHeaderType
-      ID: 176
+      ID: 172
       Name: '[]main.structWithMap'
       ByteSize: 24
       GoRuntimeType: 442720
@@ -5481,16 +5435,16 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 177 PointerType *main.structWithMap
+          Type: 173 PointerType *main.structWithMap
         - Name: len
           Offset: 8
           Type: 9 BaseType int
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 219 GoSliceDataType []main.structWithMap.array
+      Data: 212 GoSliceDataType []main.structWithMap.array
     - __kind: GoSliceDataType
-      ID: 219
+      ID: 212
       Name: '[]main.structWithMap.array'
       ByteSize: 2048
       Element: 65 StructureType main.structWithMap
@@ -5509,9 +5463,9 @@ Types:
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 208 GoSliceDataType []main.structWithNoStrings.array
+      Data: 192 GoSliceDataType []main.structWithNoStrings.array
     - __kind: GoSliceDataType
-      ID: 208
+      ID: 192
       Name: '[]main.structWithNoStrings.array'
       ByteSize: 2048
       Element: 142 StructureType main.structWithNoStrings
@@ -5531,9 +5485,9 @@ Types:
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 210 GoSliceDataType []string.array
+      Data: 194 GoSliceDataType []string.array
     - __kind: GoSliceDataType
-      ID: 210
+      ID: 194
       Name: '[]string.array'
       ByteSize: 2048
       Element: 11 GoStringHeaderType string
@@ -5553,9 +5507,9 @@ Types:
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 204 GoSliceDataType []uint.array
+      Data: 188 GoSliceDataType []uint.array
     - __kind: GoSliceDataType
-      ID: 204
+      ID: 188
       Name: '[]uint.array'
       ByteSize: 2048
       Element: 15 BaseType uint
@@ -5575,14 +5529,14 @@ Types:
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 214 GoSliceDataType []uint16.array
+      Data: 198 GoSliceDataType []uint16.array
     - __kind: GoSliceDataType
-      ID: 214
+      ID: 198
       Name: '[]uint16.array'
       ByteSize: 2048
       Element: 7 BaseType uint16
     - __kind: ArrayType
-      ID: 174
+      ID: 169
       Name: '[]val<[2]int>'
       ByteSize: 128
       Count: 8
@@ -5596,42 +5550,42 @@ Types:
       HasCount: true
       Element: 183 ArrayType [4]int
     - __kind: ArrayType
-      ID: 175
+      ID: 171
       Name: '[]val<[]main.structWithMap>'
       ByteSize: 192
       Count: 8
       HasCount: true
-      Element: 176 GoSliceHeaderType []main.structWithMap
+      Element: 172 GoSliceHeaderType []main.structWithMap
     - __kind: ArrayType
-      ID: 171
+      ID: 165
       Name: '[]val<[]string>'
       ByteSize: 192
       Count: 8
       HasCount: true
       Element: 143 GoSliceHeaderType []string
     - __kind: ArrayType
-      ID: 164
+      ID: 159
       Name: '[]val<int>'
       ByteSize: 64
       Count: 8
       HasCount: true
       Element: 9 BaseType int
     - __kind: ArrayType
-      ID: 170
+      ID: 162
       Name: '[]val<main.nestedStruct>'
       ByteSize: 192
       Count: 8
       HasCount: true
       Element: 151 StructureType main.nestedStruct
     - __kind: ArrayType
-      ID: 179
+      ID: 176
       Name: '[]val<main.node>'
       ByteSize: 128
       Count: 8
       HasCount: true
       Element: 133 StructureType main.node
     - __kind: ArrayType
-      ID: 180
+      ID: 178
       Name: '[]val<uint8>'
       ByteSize: 8
       Count: 8
@@ -5650,10 +5604,10 @@ Types:
       RawFields:
         - Name: tophash
           Offset: 0
-          Type: 162 ArrayType [8]uint8
+          Type: 157 ArrayType [8]uint8
         - Name: keys
           Offset: 8
-          Type: 184 ArrayType []key<[4]int>
+          Type: 185 ArrayType []key<[4]int>
         - Name: values
           Offset: 264
           Type: 182 ArrayType []val<[4]int>
@@ -5669,13 +5623,13 @@ Types:
       RawFields:
         - Name: tophash
           Offset: 0
-          Type: 162 ArrayType [8]uint8
+          Type: 157 ArrayType [8]uint8
         - Name: keys
           Offset: 8
-          Type: 184 ArrayType []key<[4]int>
+          Type: 185 ArrayType []key<[4]int>
         - Name: values
           Offset: 264
-          Type: 180 ArrayType []val<uint8>
+          Type: 178 ArrayType []val<uint8>
         - Name: overflow
           Offset: 272
           Type: 123 PointerType *bucket<[4]int,uint8>
@@ -5688,17 +5642,17 @@ Types:
       RawFields:
         - Name: tophash
           Offset: 0
-          Type: 162 ArrayType [8]uint8
+          Type: 157 ArrayType [8]uint8
         - Name: keys
           Offset: 8
-          Type: 172 ArrayType []key<[4]string>
+          Type: 167 ArrayType []key<[4]string>
         - Name: values
           Offset: 520
-          Type: 174 ArrayType []val<[2]int>
+          Type: 169 ArrayType []val<[2]int>
         - Name: overflow
           Offset: 648
           Type: 91 PointerType *bucket<[4]string,[2]int>
-      KeyType: 173 ArrayType [4]string
+      KeyType: 168 ArrayType [4]string
       ValueType: 40 ArrayType [2]int
     - __kind: GoHMapBucketType
       ID: 104
@@ -5707,13 +5661,13 @@ Types:
       RawFields:
         - Name: tophash
           Offset: 0
-          Type: 162 ArrayType [8]uint8
+          Type: 157 ArrayType [8]uint8
         - Name: keys
           Offset: 8
-          Type: 178 ArrayType []key<bool>
+          Type: 175 ArrayType []key<bool>
         - Name: values
           Offset: 16
-          Type: 179 ArrayType []val<main.node>
+          Type: 176 ArrayType []val<main.node>
         - Name: overflow
           Offset: 144
           Type: 103 PointerType *bucket<bool,main.node>
@@ -5726,13 +5680,13 @@ Types:
       RawFields:
         - Name: tophash
           Offset: 0
-          Type: 162 ArrayType [8]uint8
+          Type: 157 ArrayType [8]uint8
         - Name: keys
           Offset: 8
-          Type: 163 ArrayType []key<int>
+          Type: 158 ArrayType []key<int>
         - Name: values
           Offset: 72
-          Type: 164 ArrayType []val<int>
+          Type: 159 ArrayType []val<int>
         - Name: overflow
           Offset: 136
           Type: 69 PointerType *bucket<int,int>
@@ -5745,13 +5699,13 @@ Types:
       RawFields:
         - Name: tophash
           Offset: 0
-          Type: 162 ArrayType [8]uint8
+          Type: 157 ArrayType [8]uint8
         - Name: keys
           Offset: 8
-          Type: 163 ArrayType []key<int>
+          Type: 158 ArrayType []key<int>
         - Name: values
           Offset: 72
-          Type: 180 ArrayType []val<uint8>
+          Type: 178 ArrayType []val<uint8>
         - Name: overflow
           Offset: 80
           Type: 108 PointerType *bucket<int,uint8>
@@ -5764,18 +5718,18 @@ Types:
       RawFields:
         - Name: tophash
           Offset: 0
-          Type: 162 ArrayType [8]uint8
+          Type: 157 ArrayType [8]uint8
         - Name: keys
           Offset: 8
-          Type: 169 ArrayType []key<string>
+          Type: 161 ArrayType []key<string>
         - Name: values
           Offset: 136
-          Type: 175 ArrayType []val<[]main.structWithMap>
+          Type: 171 ArrayType []val<[]main.structWithMap>
         - Name: overflow
           Offset: 328
           Type: 98 PointerType *bucket<string,[]main.structWithMap>
       KeyType: 11 GoStringHeaderType string
-      ValueType: 176 GoSliceHeaderType []main.structWithMap
+      ValueType: 172 GoSliceHeaderType []main.structWithMap
     - __kind: GoHMapBucketType
       ID: 87
       Name: bucket<string,[]string>
@@ -5783,13 +5737,13 @@ Types:
       RawFields:
         - Name: tophash
           Offset: 0
-          Type: 162 ArrayType [8]uint8
+          Type: 157 ArrayType [8]uint8
         - Name: keys
           Offset: 8
-          Type: 169 ArrayType []key<string>
+          Type: 161 ArrayType []key<string>
         - Name: values
           Offset: 136
-          Type: 171 ArrayType []val<[]string>
+          Type: 165 ArrayType []val<[]string>
         - Name: overflow
           Offset: 328
           Type: 86 PointerType *bucket<string,[]string>
@@ -5802,13 +5756,13 @@ Types:
       RawFields:
         - Name: tophash
           Offset: 0
-          Type: 162 ArrayType [8]uint8
+          Type: 157 ArrayType [8]uint8
         - Name: keys
           Offset: 8
-          Type: 169 ArrayType []key<string>
+          Type: 161 ArrayType []key<string>
         - Name: values
           Offset: 136
-          Type: 164 ArrayType []val<int>
+          Type: 159 ArrayType []val<int>
         - Name: overflow
           Offset: 200
           Type: 81 PointerType *bucket<string,int>
@@ -5821,13 +5775,13 @@ Types:
       RawFields:
         - Name: tophash
           Offset: 0
-          Type: 162 ArrayType [8]uint8
+          Type: 157 ArrayType [8]uint8
         - Name: keys
           Offset: 8
-          Type: 169 ArrayType []key<string>
+          Type: 161 ArrayType []key<string>
         - Name: values
           Offset: 136
-          Type: 170 ArrayType []val<main.nestedStruct>
+          Type: 162 ArrayType []val<main.nestedStruct>
         - Name: overflow
           Offset: 328
           Type: 76 PointerType *bucket<string,main.nestedStruct>
@@ -5840,10 +5794,10 @@ Types:
       RawFields:
         - Name: tophash
           Offset: 0
-          Type: 162 ArrayType [8]uint8
+          Type: 157 ArrayType [8]uint8
         - Name: keys
           Offset: 8
-          Type: 181 ArrayType []key<uint8>
+          Type: 180 ArrayType []key<uint8>
         - Name: values
           Offset: 16
           Type: 182 ArrayType []val<[4]int>
@@ -5859,13 +5813,13 @@ Types:
       RawFields:
         - Name: tophash
           Offset: 0
-          Type: 162 ArrayType [8]uint8
+          Type: 157 ArrayType [8]uint8
         - Name: keys
           Offset: 8
-          Type: 181 ArrayType []key<uint8>
+          Type: 180 ArrayType []key<uint8>
         - Name: values
           Offset: 16
-          Type: 180 ArrayType []val<uint8>
+          Type: 178 ArrayType []val<uint8>
         - Name: overflow
           Offset: 24
           Type: 113 PointerType *bucket<uint8,uint8>
@@ -5957,7 +5911,7 @@ Types:
           Offset: 40
           Type: 71 PointerType *runtime.mapextra
       BucketType: 129 GoHMapBucketType bucket<[4]int,[4]int>
-      BucketsType: 201 GoSliceDataType []bucket<[4]int,[4]int>.array
+      BucketsType: 187 GoSliceDataType []bucket<[4]int,[4]int>.array
     - __kind: GoHMapHeaderType
       ID: 122
       Name: hash<[4]int,uint8>
@@ -5991,7 +5945,7 @@ Types:
           Offset: 40
           Type: 71 PointerType *runtime.mapextra
       BucketType: 124 GoHMapBucketType bucket<[4]int,uint8>
-      BucketsType: 200 GoSliceDataType []bucket<[4]int,uint8>.array
+      BucketsType: 186 GoSliceDataType []bucket<[4]int,uint8>.array
     - __kind: GoHMapHeaderType
       ID: 90
       Name: hash<[4]string,[2]int>
@@ -6025,7 +5979,7 @@ Types:
           Offset: 40
           Type: 71 PointerType *runtime.mapextra
       BucketType: 92 GoHMapBucketType bucket<[4]string,[2]int>
-      BucketsType: 194 GoSliceDataType []bucket<[4]string,[2]int>.array
+      BucketsType: 170 GoSliceDataType []bucket<[4]string,[2]int>.array
     - __kind: GoHMapHeaderType
       ID: 102
       Name: hash<bool,main.node>
@@ -6059,7 +6013,7 @@ Types:
           Offset: 40
           Type: 71 PointerType *runtime.mapextra
       BucketType: 104 GoHMapBucketType bucket<bool,main.node>
-      BucketsType: 196 GoSliceDataType []bucket<bool,main.node>.array
+      BucketsType: 177 GoSliceDataType []bucket<bool,main.node>.array
     - __kind: GoHMapHeaderType
       ID: 68
       Name: hash<int,int>
@@ -6093,7 +6047,7 @@ Types:
           Offset: 40
           Type: 71 PointerType *runtime.mapextra
       BucketType: 70 GoHMapBucketType bucket<int,int>
-      BucketsType: 190 GoSliceDataType []bucket<int,int>.array
+      BucketsType: 160 GoSliceDataType []bucket<int,int>.array
     - __kind: GoHMapHeaderType
       ID: 107
       Name: hash<int,uint8>
@@ -6127,7 +6081,7 @@ Types:
           Offset: 40
           Type: 71 PointerType *runtime.mapextra
       BucketType: 109 GoHMapBucketType bucket<int,uint8>
-      BucketsType: 197 GoSliceDataType []bucket<int,uint8>.array
+      BucketsType: 179 GoSliceDataType []bucket<int,uint8>.array
     - __kind: GoHMapHeaderType
       ID: 97
       Name: hash<string,[]main.structWithMap>
@@ -6161,7 +6115,7 @@ Types:
           Offset: 40
           Type: 71 PointerType *runtime.mapextra
       BucketType: 99 GoHMapBucketType bucket<string,[]main.structWithMap>
-      BucketsType: 195 GoSliceDataType []bucket<string,[]main.structWithMap>.array
+      BucketsType: 174 GoSliceDataType []bucket<string,[]main.structWithMap>.array
     - __kind: GoHMapHeaderType
       ID: 85
       Name: hash<string,[]string>
@@ -6195,7 +6149,7 @@ Types:
           Offset: 40
           Type: 71 PointerType *runtime.mapextra
       BucketType: 87 GoHMapBucketType bucket<string,[]string>
-      BucketsType: 193 GoSliceDataType []bucket<string,[]string>.array
+      BucketsType: 166 GoSliceDataType []bucket<string,[]string>.array
     - __kind: GoHMapHeaderType
       ID: 80
       Name: hash<string,int>
@@ -6229,7 +6183,7 @@ Types:
           Offset: 40
           Type: 71 PointerType *runtime.mapextra
       BucketType: 82 GoHMapBucketType bucket<string,int>
-      BucketsType: 192 GoSliceDataType []bucket<string,int>.array
+      BucketsType: 164 GoSliceDataType []bucket<string,int>.array
     - __kind: GoHMapHeaderType
       ID: 75
       Name: hash<string,main.nestedStruct>
@@ -6263,7 +6217,7 @@ Types:
           Offset: 40
           Type: 71 PointerType *runtime.mapextra
       BucketType: 77 GoHMapBucketType bucket<string,main.nestedStruct>
-      BucketsType: 191 GoSliceDataType []bucket<string,main.nestedStruct>.array
+      BucketsType: 163 GoSliceDataType []bucket<string,main.nestedStruct>.array
     - __kind: GoHMapHeaderType
       ID: 117
       Name: hash<uint8,[4]int>
@@ -6297,7 +6251,7 @@ Types:
           Offset: 40
           Type: 71 PointerType *runtime.mapextra
       BucketType: 119 GoHMapBucketType bucket<uint8,[4]int>
-      BucketsType: 199 GoSliceDataType []bucket<uint8,[4]int>.array
+      BucketsType: 184 GoSliceDataType []bucket<uint8,[4]int>.array
     - __kind: GoHMapHeaderType
       ID: 112
       Name: hash<uint8,uint8>
@@ -6331,7 +6285,7 @@ Types:
           Offset: 40
           Type: 71 PointerType *runtime.mapextra
       BucketType: 114 GoHMapBucketType bucket<uint8,uint8>
-      BucketsType: 198 GoSliceDataType []bucket<uint8,uint8>.array
+      BucketsType: 181 GoSliceDataType []bucket<uint8,uint8>.array
     - __kind: BaseType
       ID: 9
       Name: int
@@ -6451,16 +6405,16 @@ Types:
           Type: 56 StructureType main.esotericStack
         - Name: mu
           Offset: 64
-          Type: 153 StructureType sync.Mutex
+          Type: 200 StructureType sync.Mutex
         - Name: once
           Offset: 72
-          Type: 154 StructureType sync.Once
+          Type: 201 StructureType sync.Once
         - Name: wg
           Offset: 88
-          Type: 157 StructureType sync.WaitGroup
+          Type: 204 StructureType sync.WaitGroup
         - Name: a
           Offset: 104
-          Type: 161 StructureType sync/atomic.Int32
+          Type: 208 StructureType sync/atomic.Int32
     - __kind: StructureType
       ID: 56
       Name: main.esotericStack
@@ -6579,16 +6533,16 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 185 PointerType **main.t
+          Type: 209 PointerType **main.t
         - Name: len
           Offset: 8
           Type: 9 BaseType int
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 202 GoSliceDataType main.t.array
+      Data: 210 GoSliceDataType main.t.array
     - __kind: GoSliceDataType
-      ID: 202
+      ID: 210
       Name: main.t.array
       ByteSize: 2048
       Element: 135 PointerType *main.t
@@ -6696,32 +6650,10 @@ Types:
       GoRuntimeType: 874816
       GoKind: 21
       HeaderType: 112 GoHMapHeaderType hash<uint8,uint8>
-    - __kind: StructureType
-      ID: 168
-      Name: runtime.bmap
-      ByteSize: 8
-      GoRuntimeType: 1.100768e+06
-      GoKind: 25
-      RawFields:
-        - Name: tophash
-          Offset: 0
-          Type: 162 ArrayType [8]uint8
-    - __kind: StructureType
+    - __kind: UnresolvedPointeeType
       ID: 72
       Name: runtime.mapextra
-      ByteSize: 24
-      GoRuntimeType: 1.417056e+06
-      GoKind: 25
-      RawFields:
-        - Name: overflow
-          Offset: 0
-          Type: 165 PointerType *[]*runtime.bmap
-        - Name: oldoverflow
-          Offset: 8
-          Type: 165 PointerType *[]*runtime.bmap
-        - Name: nextOverflow
-          Offset: 16
-          Type: 167 PointerType *runtime.bmap
+      ByteSize: 8
     - __kind: GoStringHeaderType
       ID: 11
       Name: string
@@ -6731,17 +6663,17 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 187 PointerType *string.str
+          Type: 154 PointerType *string.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 186 GoStringDataType string.str
+      Data: 153 GoStringDataType string.str
     - __kind: GoStringDataType
-      ID: 186
+      ID: 153
       Name: string.str
       ByteSize: 2048
     - __kind: StructureType
-      ID: 153
+      ID: 200
       Name: sync.Mutex
       ByteSize: 8
       GoRuntimeType: 1.271296e+06
@@ -6754,7 +6686,7 @@ Types:
           Offset: 4
           Type: 2 BaseType uint32
     - __kind: StructureType
-      ID: 154
+      ID: 201
       Name: sync.Once
       ByteSize: 12
       GoRuntimeType: 1.272416e+06
@@ -6762,12 +6694,12 @@ Types:
       RawFields:
         - Name: done
           Offset: 0
-          Type: 155 StructureType sync/atomic.Uint32
+          Type: 202 StructureType sync/atomic.Uint32
         - Name: m
           Offset: 4
-          Type: 153 StructureType sync.Mutex
+          Type: 200 StructureType sync.Mutex
     - __kind: StructureType
-      ID: 157
+      ID: 204
       Name: sync.WaitGroup
       ByteSize: 16
       GoRuntimeType: 1.411104e+06
@@ -6775,21 +6707,21 @@ Types:
       RawFields:
         - Name: noCopy
           Offset: 0
-          Type: 158 StructureType sync.noCopy
+          Type: 205 StructureType sync.noCopy
         - Name: state
           Offset: 0
-          Type: 159 StructureType sync/atomic.Uint64
+          Type: 206 StructureType sync/atomic.Uint64
         - Name: sema
           Offset: 8
           Type: 2 BaseType uint32
     - __kind: StructureType
-      ID: 158
+      ID: 205
       Name: sync.noCopy
       GoRuntimeType: 940512
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 161
+      ID: 208
       Name: sync/atomic.Int32
       ByteSize: 4
       GoRuntimeType: 1.272736e+06
@@ -6797,12 +6729,12 @@ Types:
       RawFields:
         - Name: _
           Offset: 0
-          Type: 156 StructureType sync/atomic.noCopy
+          Type: 203 StructureType sync/atomic.noCopy
         - Name: v
           Offset: 0
           Type: 12 BaseType int32
     - __kind: StructureType
-      ID: 155
+      ID: 202
       Name: sync/atomic.Uint32
       ByteSize: 4
       GoRuntimeType: 1.272896e+06
@@ -6810,12 +6742,12 @@ Types:
       RawFields:
         - Name: _
           Offset: 0
-          Type: 156 StructureType sync/atomic.noCopy
+          Type: 203 StructureType sync/atomic.noCopy
         - Name: v
           Offset: 0
           Type: 2 BaseType uint32
     - __kind: StructureType
-      ID: 159
+      ID: 206
       Name: sync/atomic.Uint64
       ByteSize: 8
       GoRuntimeType: 1.411488e+06
@@ -6823,21 +6755,21 @@ Types:
       RawFields:
         - Name: _
           Offset: 0
-          Type: 156 StructureType sync/atomic.noCopy
+          Type: 203 StructureType sync/atomic.noCopy
         - Name: _
           Offset: 0
-          Type: 160 StructureType sync/atomic.align64
+          Type: 207 StructureType sync/atomic.align64
         - Name: v
           Offset: 0
           Type: 10 BaseType uint64
     - __kind: StructureType
-      ID: 160
+      ID: 207
       Name: sync/atomic.align64
       GoRuntimeType: 940704
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 156
+      ID: 203
       Name: sync/atomic.noCopy
       GoRuntimeType: 940608
       GoKind: 25
@@ -6884,6 +6816,6 @@ Types:
       ByteSize: 8
       GoRuntimeType: 527936
       GoKind: 26
-MaxTypeID: 324
+MaxTypeID: 317
 Issues: []
 GoModuledataInfo: {FirstModuledataAddr: "0x1752740", TypesOffset: 296}

--- a/pkg/dyninst/irgen/testdata/snapshot/sample.arch=amd64,toolchain=go1.23.11.yaml
+++ b/pkg/dyninst/irgen/testdata/snapshot/sample.arch=amd64,toolchain=go1.23.11.yaml
@@ -3100,7 +3100,7 @@ Types:
       ByteSize: 8
       Pointee: 135 PointerType *main.t
     - __kind: PointerType
-      ID: 186
+      ID: 216
       Name: '**runtime.bmap'
       ByteSize: 8
       Pointee: 167 PointerType *runtime.bmap
@@ -3124,50 +3124,50 @@ Types:
       ByteSize: 8
       Pointee: 217 GoSliceDataType []*runtime.bmap.array
     - __kind: PointerType
-      ID: 190
+      ID: 189
       Name: '*[]*string.array'
       ByteSize: 8
-      Pointee: 189 GoSliceDataType []*string.array
+      Pointee: 188 GoSliceDataType []*string.array
     - __kind: PointerType
-      ID: 208
+      ID: 207
       Name: '*[][]uint.array'
       ByteSize: 8
-      Pointee: 207 GoSliceDataType [][]uint.array
+      Pointee: 206 GoSliceDataType [][]uint.array
     - __kind: PointerType
-      ID: 214
+      ID: 213
       Name: '*[]bool.array'
       ByteSize: 8
-      Pointee: 213 GoSliceDataType []bool.array
+      Pointee: 212 GoSliceDataType []bool.array
     - __kind: PointerType
       ID: 220
       Name: '*[]main.structWithMap.array'
       ByteSize: 8
       Pointee: 219 GoSliceDataType []main.structWithMap.array
     - __kind: PointerType
-      ID: 210
+      ID: 209
       Name: '*[]main.structWithNoStrings.array'
       ByteSize: 8
-      Pointee: 209 GoSliceDataType []main.structWithNoStrings.array
+      Pointee: 208 GoSliceDataType []main.structWithNoStrings.array
     - __kind: PointerType
-      ID: 212
+      ID: 211
       Name: '*[]string.array'
       ByteSize: 8
-      Pointee: 211 GoSliceDataType []string.array
+      Pointee: 210 GoSliceDataType []string.array
     - __kind: PointerType
       ID: 139
       Name: '*[]uint'
       ByteSize: 8
       Pointee: 137 GoSliceHeaderType []uint
     - __kind: PointerType
-      ID: 206
+      ID: 205
       Name: '*[]uint.array'
       ByteSize: 8
-      Pointee: 205 GoSliceDataType []uint.array
+      Pointee: 204 GoSliceDataType []uint.array
     - __kind: PointerType
-      ID: 216
+      ID: 215
       Name: '*[]uint16.array'
       ByteSize: 8
-      Pointee: 215 GoSliceDataType []uint16.array
+      Pointee: 214 GoSliceDataType []uint16.array
     - __kind: PointerType
       ID: 5
       Name: '*bool'
@@ -3396,10 +3396,10 @@ Types:
       GoKind: 22
       Pointee: 136 GoSliceHeaderType main.t
     - __kind: PointerType
-      ID: 204
+      ID: 203
       Name: '*main.t.array'
       ByteSize: 8
-      Pointee: 203 GoSliceDataType main.t.array
+      Pointee: 202 GoSliceDataType main.t.array
     - __kind: PointerType
       ID: 147
       Name: '*main.threeStringStruct'
@@ -3434,10 +3434,10 @@ Types:
       GoKind: 22
       Pointee: 11 GoStringHeaderType string
     - __kind: PointerType
-      ID: 188
+      ID: 187
       Name: '*string.str'
       ByteSize: 8
-      Pointee: 187 GoStringDataType string.str
+      Pointee: 186 GoStringDataType string.str
     - __kind: PointerType
       ID: 34
       Name: '*uint'
@@ -5292,7 +5292,7 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 186 PointerType **runtime.bmap
+          Type: 216 PointerType **runtime.bmap
         - Name: len
           Offset: 8
           Type: 9 BaseType int
@@ -5321,9 +5321,9 @@ Types:
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 189 GoSliceDataType []*string.array
+      Data: 188 GoSliceDataType []*string.array
     - __kind: GoSliceDataType
-      ID: 189
+      ID: 188
       Name: '[]*string.array'
       ByteSize: 2048
       Element: 22 PointerType *string
@@ -5342,9 +5342,9 @@ Types:
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 207 GoSliceDataType [][]uint.array
+      Data: 206 GoSliceDataType [][]uint.array
     - __kind: GoSliceDataType
-      ID: 207
+      ID: 206
       Name: '[][]uint.array'
       ByteSize: 2048
       Element: 137 GoSliceHeaderType []uint
@@ -5364,69 +5364,69 @@ Types:
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 213 GoSliceDataType []bool.array
+      Data: 212 GoSliceDataType []bool.array
     - __kind: GoSliceDataType
-      ID: 213
+      ID: 212
       Name: '[]bool.array'
       ByteSize: 2048
       Element: 4 BaseType bool
     - __kind: GoSliceDataType
-      ID: 202
+      ID: 201
       Name: '[]bucket<[4]int,[4]int>.array'
       ByteSize: 2048
       Element: 129 GoHMapBucketType bucket<[4]int,[4]int>
     - __kind: GoSliceDataType
-      ID: 201
+      ID: 200
       Name: '[]bucket<[4]int,uint8>.array'
       ByteSize: 2048
       Element: 124 GoHMapBucketType bucket<[4]int,uint8>
     - __kind: GoSliceDataType
-      ID: 195
+      ID: 194
       Name: '[]bucket<[4]string,[2]int>.array'
       ByteSize: 2048
       Element: 92 GoHMapBucketType bucket<[4]string,[2]int>
     - __kind: GoSliceDataType
-      ID: 197
+      ID: 196
       Name: '[]bucket<bool,main.node>.array'
       ByteSize: 2048
       Element: 104 GoHMapBucketType bucket<bool,main.node>
     - __kind: GoSliceDataType
-      ID: 191
+      ID: 190
       Name: '[]bucket<int,int>.array'
       ByteSize: 2048
       Element: 70 GoHMapBucketType bucket<int,int>
     - __kind: GoSliceDataType
-      ID: 198
+      ID: 197
       Name: '[]bucket<int,uint8>.array'
       ByteSize: 2048
       Element: 109 GoHMapBucketType bucket<int,uint8>
     - __kind: GoSliceDataType
-      ID: 196
+      ID: 195
       Name: '[]bucket<string,[]main.structWithMap>.array'
       ByteSize: 2048
       Element: 99 GoHMapBucketType bucket<string,[]main.structWithMap>
     - __kind: GoSliceDataType
-      ID: 194
+      ID: 193
       Name: '[]bucket<string,[]string>.array'
       ByteSize: 2048
       Element: 87 GoHMapBucketType bucket<string,[]string>
     - __kind: GoSliceDataType
-      ID: 193
+      ID: 192
       Name: '[]bucket<string,int>.array'
       ByteSize: 2048
       Element: 82 GoHMapBucketType bucket<string,int>
     - __kind: GoSliceDataType
-      ID: 192
+      ID: 191
       Name: '[]bucket<string,main.nestedStruct>.array'
       ByteSize: 2048
       Element: 77 GoHMapBucketType bucket<string,main.nestedStruct>
     - __kind: GoSliceDataType
-      ID: 200
+      ID: 199
       Name: '[]bucket<uint8,[4]int>.array'
       ByteSize: 2048
       Element: 119 GoHMapBucketType bucket<uint8,[4]int>
     - __kind: GoSliceDataType
-      ID: 199
+      ID: 198
       Name: '[]bucket<uint8,uint8>.array'
       ByteSize: 2048
       Element: 114 GoHMapBucketType bucket<uint8,uint8>
@@ -5509,9 +5509,9 @@ Types:
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 209 GoSliceDataType []main.structWithNoStrings.array
+      Data: 208 GoSliceDataType []main.structWithNoStrings.array
     - __kind: GoSliceDataType
-      ID: 209
+      ID: 208
       Name: '[]main.structWithNoStrings.array'
       ByteSize: 2048
       Element: 142 StructureType main.structWithNoStrings
@@ -5531,9 +5531,9 @@ Types:
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 211 GoSliceDataType []string.array
+      Data: 210 GoSliceDataType []string.array
     - __kind: GoSliceDataType
-      ID: 211
+      ID: 210
       Name: '[]string.array'
       ByteSize: 2048
       Element: 11 GoStringHeaderType string
@@ -5553,9 +5553,9 @@ Types:
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 205 GoSliceDataType []uint.array
+      Data: 204 GoSliceDataType []uint.array
     - __kind: GoSliceDataType
-      ID: 205
+      ID: 204
       Name: '[]uint.array'
       ByteSize: 2048
       Element: 15 BaseType uint
@@ -5575,9 +5575,9 @@ Types:
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 215 GoSliceDataType []uint16.array
+      Data: 214 GoSliceDataType []uint16.array
     - __kind: GoSliceDataType
-      ID: 215
+      ID: 214
       Name: '[]uint16.array'
       ByteSize: 2048
       Element: 7 BaseType uint16
@@ -5957,7 +5957,7 @@ Types:
           Offset: 40
           Type: 71 PointerType *runtime.mapextra
       BucketType: 129 GoHMapBucketType bucket<[4]int,[4]int>
-      BucketsType: 202 GoSliceDataType []bucket<[4]int,[4]int>.array
+      BucketsType: 201 GoSliceDataType []bucket<[4]int,[4]int>.array
     - __kind: GoHMapHeaderType
       ID: 122
       Name: hash<[4]int,uint8>
@@ -5991,7 +5991,7 @@ Types:
           Offset: 40
           Type: 71 PointerType *runtime.mapextra
       BucketType: 124 GoHMapBucketType bucket<[4]int,uint8>
-      BucketsType: 201 GoSliceDataType []bucket<[4]int,uint8>.array
+      BucketsType: 200 GoSliceDataType []bucket<[4]int,uint8>.array
     - __kind: GoHMapHeaderType
       ID: 90
       Name: hash<[4]string,[2]int>
@@ -6025,7 +6025,7 @@ Types:
           Offset: 40
           Type: 71 PointerType *runtime.mapextra
       BucketType: 92 GoHMapBucketType bucket<[4]string,[2]int>
-      BucketsType: 195 GoSliceDataType []bucket<[4]string,[2]int>.array
+      BucketsType: 194 GoSliceDataType []bucket<[4]string,[2]int>.array
     - __kind: GoHMapHeaderType
       ID: 102
       Name: hash<bool,main.node>
@@ -6059,7 +6059,7 @@ Types:
           Offset: 40
           Type: 71 PointerType *runtime.mapextra
       BucketType: 104 GoHMapBucketType bucket<bool,main.node>
-      BucketsType: 197 GoSliceDataType []bucket<bool,main.node>.array
+      BucketsType: 196 GoSliceDataType []bucket<bool,main.node>.array
     - __kind: GoHMapHeaderType
       ID: 68
       Name: hash<int,int>
@@ -6093,7 +6093,7 @@ Types:
           Offset: 40
           Type: 71 PointerType *runtime.mapextra
       BucketType: 70 GoHMapBucketType bucket<int,int>
-      BucketsType: 191 GoSliceDataType []bucket<int,int>.array
+      BucketsType: 190 GoSliceDataType []bucket<int,int>.array
     - __kind: GoHMapHeaderType
       ID: 107
       Name: hash<int,uint8>
@@ -6127,7 +6127,7 @@ Types:
           Offset: 40
           Type: 71 PointerType *runtime.mapextra
       BucketType: 109 GoHMapBucketType bucket<int,uint8>
-      BucketsType: 198 GoSliceDataType []bucket<int,uint8>.array
+      BucketsType: 197 GoSliceDataType []bucket<int,uint8>.array
     - __kind: GoHMapHeaderType
       ID: 97
       Name: hash<string,[]main.structWithMap>
@@ -6161,7 +6161,7 @@ Types:
           Offset: 40
           Type: 71 PointerType *runtime.mapextra
       BucketType: 99 GoHMapBucketType bucket<string,[]main.structWithMap>
-      BucketsType: 196 GoSliceDataType []bucket<string,[]main.structWithMap>.array
+      BucketsType: 195 GoSliceDataType []bucket<string,[]main.structWithMap>.array
     - __kind: GoHMapHeaderType
       ID: 85
       Name: hash<string,[]string>
@@ -6195,7 +6195,7 @@ Types:
           Offset: 40
           Type: 71 PointerType *runtime.mapextra
       BucketType: 87 GoHMapBucketType bucket<string,[]string>
-      BucketsType: 194 GoSliceDataType []bucket<string,[]string>.array
+      BucketsType: 193 GoSliceDataType []bucket<string,[]string>.array
     - __kind: GoHMapHeaderType
       ID: 80
       Name: hash<string,int>
@@ -6229,7 +6229,7 @@ Types:
           Offset: 40
           Type: 71 PointerType *runtime.mapextra
       BucketType: 82 GoHMapBucketType bucket<string,int>
-      BucketsType: 193 GoSliceDataType []bucket<string,int>.array
+      BucketsType: 192 GoSliceDataType []bucket<string,int>.array
     - __kind: GoHMapHeaderType
       ID: 75
       Name: hash<string,main.nestedStruct>
@@ -6263,7 +6263,7 @@ Types:
           Offset: 40
           Type: 71 PointerType *runtime.mapextra
       BucketType: 77 GoHMapBucketType bucket<string,main.nestedStruct>
-      BucketsType: 192 GoSliceDataType []bucket<string,main.nestedStruct>.array
+      BucketsType: 191 GoSliceDataType []bucket<string,main.nestedStruct>.array
     - __kind: GoHMapHeaderType
       ID: 117
       Name: hash<uint8,[4]int>
@@ -6297,7 +6297,7 @@ Types:
           Offset: 40
           Type: 71 PointerType *runtime.mapextra
       BucketType: 119 GoHMapBucketType bucket<uint8,[4]int>
-      BucketsType: 200 GoSliceDataType []bucket<uint8,[4]int>.array
+      BucketsType: 199 GoSliceDataType []bucket<uint8,[4]int>.array
     - __kind: GoHMapHeaderType
       ID: 112
       Name: hash<uint8,uint8>
@@ -6331,7 +6331,7 @@ Types:
           Offset: 40
           Type: 71 PointerType *runtime.mapextra
       BucketType: 114 GoHMapBucketType bucket<uint8,uint8>
-      BucketsType: 199 GoSliceDataType []bucket<uint8,uint8>.array
+      BucketsType: 198 GoSliceDataType []bucket<uint8,uint8>.array
     - __kind: BaseType
       ID: 9
       Name: int
@@ -6586,9 +6586,9 @@ Types:
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 203 GoSliceDataType main.t.array
+      Data: 202 GoSliceDataType main.t.array
     - __kind: GoSliceDataType
-      ID: 203
+      ID: 202
       Name: main.t.array
       ByteSize: 2048
       Element: 135 PointerType *main.t
@@ -6731,13 +6731,13 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 188 PointerType *string.str
+          Type: 187 PointerType *string.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 187 GoStringDataType string.str
+      Data: 186 GoStringDataType string.str
     - __kind: GoStringDataType
-      ID: 187
+      ID: 186
       Name: string.str
       ByteSize: 2048
     - __kind: StructureType

--- a/pkg/dyninst/irgen/testdata/snapshot/sample.arch=amd64,toolchain=go1.23.11.yaml
+++ b/pkg/dyninst/irgen/testdata/snapshot/sample.arch=amd64,toolchain=go1.23.11.yaml
@@ -8,11 +8,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 88}
+      subprogram: {subprogram: 96}
       events:
-        - ID: 88
-          Type: 301 EventRootType Probe[main.stackC]
-          InjectionPoints: [{PC: "0xd06f2a", Frameless: false}]
+        - ID: 96
+          Type: 404 EventRootType Probe[main.stackC]
+          InjectionPoints: [{PC: "0xd079aa", Frameless: false}]
           Condition: null
     - id: testAny
       version: 0
@@ -22,11 +22,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 45}
+      subprogram: {subprogram: 53}
       events:
-        - ID: 45
-          Type: 258 EventRootType Probe[main.testAny]
-          InjectionPoints: [{PC: "0xd0410a", Frameless: false}]
+        - ID: 53
+          Type: 361 EventRootType Probe[main.testAny]
+          InjectionPoints: [{PC: "0xd04b8a", Frameless: false}]
           Condition: null
     - id: testArrayOfArrays
       version: 0
@@ -39,8 +39,8 @@ Probes:
       subprogram: {subprogram: 15}
       events:
         - ID: 15
-          Type: 228 EventRootType Probe[main.testArrayOfArrays]
-          InjectionPoints: [{PC: "0xd02b40", Frameless: true}]
+          Type: 323 EventRootType Probe[main.testArrayOfArrays]
+          InjectionPoints: [{PC: "0xd02fa0", Frameless: true}]
           Condition: null
     - id: testArrayOfArraysOfArrays
       version: 0
@@ -53,8 +53,8 @@ Probes:
       subprogram: {subprogram: 17}
       events:
         - ID: 17
-          Type: 230 EventRootType Probe[main.testArrayOfArraysOfArrays]
-          InjectionPoints: [{PC: "0xd02b80", Frameless: true}]
+          Type: 325 EventRootType Probe[main.testArrayOfArraysOfArrays]
+          InjectionPoints: [{PC: "0xd02fe0", Frameless: true}]
           Condition: null
     - id: testArrayOfMaps
       version: 0
@@ -64,11 +64,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 53}
+      subprogram: {subprogram: 61}
       events:
-        - ID: 53
-          Type: 266 EventRootType Probe[main.testArrayOfMaps]
-          InjectionPoints: [{PC: "0xd046a0", Frameless: true}]
+        - ID: 61
+          Type: 369 EventRootType Probe[main.testArrayOfMaps]
+          InjectionPoints: [{PC: "0xd05120", Frameless: true}]
           Condition: null
     - id: testArrayOfStrings
       version: 0
@@ -81,8 +81,8 @@ Probes:
       subprogram: {subprogram: 16}
       events:
         - ID: 16
-          Type: 229 EventRootType Probe[main.testArrayOfStrings]
-          InjectionPoints: [{PC: "0xd02b60", Frameless: true}]
+          Type: 324 EventRootType Probe[main.testArrayOfStrings]
+          InjectionPoints: [{PC: "0xd02fc0", Frameless: true}]
           Condition: null
     - id: testBigStruct
       version: 0
@@ -95,8 +95,8 @@ Probes:
       subprogram: {subprogram: 35}
       events:
         - ID: 35
-          Type: 248 EventRootType Probe[main.testBigStruct]
-          InjectionPoints: [{PC: "0xd032a0", Frameless: true}]
+          Type: 343 EventRootType Probe[main.testBigStruct]
+          InjectionPoints: [{PC: "0xd03700", Frameless: true}]
           Condition: null
     - id: testBoolArray
       version: 0
@@ -109,8 +109,8 @@ Probes:
       subprogram: {subprogram: 4}
       events:
         - ID: 4
-          Type: 217 EventRootType Probe[main.testBoolArray]
-          InjectionPoints: [{PC: "0xd029e0", Frameless: true}]
+          Type: 312 EventRootType Probe[main.testBoolArray]
+          InjectionPoints: [{PC: "0xd02e40", Frameless: true}]
           Condition: null
     - id: testByteArray
       version: 0
@@ -123,8 +123,8 @@ Probes:
       subprogram: {subprogram: 1}
       events:
         - ID: 1
-          Type: 214 EventRootType Probe[main.testByteArray]
-          InjectionPoints: [{PC: "0xd02980", Frameless: true}]
+          Type: 309 EventRootType Probe[main.testByteArray]
+          InjectionPoints: [{PC: "0xd02de0", Frameless: true}]
           Condition: null
     - id: testChannel
       version: 0
@@ -134,11 +134,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 69}
+      subprogram: {subprogram: 77}
       events:
-        - ID: 69
-          Type: 282 EventRootType Probe[main.testChannel]
-          InjectionPoints: [{PC: "0xd061e0", Frameless: true}]
+        - ID: 77
+          Type: 385 EventRootType Probe[main.testChannel]
+          InjectionPoints: [{PC: "0xd06c60", Frameless: true}]
           Condition: null
     - id: testCombinedByte
       version: 0
@@ -148,11 +148,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 67}
+      subprogram: {subprogram: 75}
       events:
-        - ID: 67
-          Type: 280 EventRootType Probe[main.testCombinedByte]
-          InjectionPoints: [{PC: "0xd05e00", Frameless: true}]
+        - ID: 75
+          Type: 383 EventRootType Probe[main.testCombinedByte]
+          InjectionPoints: [{PC: "0xd06880", Frameless: true}]
           Condition: null
     - id: testCycle
       version: 0
@@ -162,11 +162,113 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 77}
+      subprogram: {subprogram: 85}
       events:
-        - ID: 77
-          Type: 290 EventRootType Probe[main.testCycle]
-          InjectionPoints: [{PC: "0xd065a0", Frameless: true}]
+        - ID: 85
+          Type: 393 EventRootType Probe[main.testCycle]
+          InjectionPoints: [{PC: "0xd07020", Frameless: true}]
+          Condition: null
+    - id: testDeepMap1
+      version: 0
+      type: LOG_PROBE
+      where: {methodName: main.testDeepMap1}
+      capture:
+        maxReferenceDepth: 1
+        maxFieldCount: 0
+        maxCollectionSize: 0
+      template: ""
+      segments: []
+      captureSnapshot: true
+      subprogram: {subprogram: 40}
+      events:
+        - ID: 40
+          Type: 348 EventRootType Probe[main.testDeepMap1]
+          InjectionPoints: [{PC: "0xd03ae0", Frameless: true}]
+          Condition: null
+    - id: testDeepMap7
+      version: 0
+      type: LOG_PROBE
+      where: {methodName: main.testDeepMap7}
+      capture:
+        maxReferenceDepth: 5
+        maxFieldCount: 0
+        maxCollectionSize: 0
+      template: ""
+      segments: []
+      captureSnapshot: true
+      subprogram: {subprogram: 41}
+      events:
+        - ID: 41
+          Type: 349 EventRootType Probe[main.testDeepMap7]
+          InjectionPoints: [{PC: "0xd03b00", Frameless: true}]
+          Condition: null
+    - id: testDeepPtr1
+      version: 0
+      type: LOG_PROBE
+      where: {methodName: main.testDeepPtr1}
+      capture:
+        maxReferenceDepth: 1
+        maxFieldCount: 0
+        maxCollectionSize: 0
+      template: ""
+      segments: []
+      captureSnapshot: true
+      subprogram: {subprogram: 36}
+      events:
+        - ID: 36
+          Type: 344 EventRootType Probe[main.testDeepPtr1]
+          InjectionPoints: [{PC: "0xd037c0", Frameless: true}]
+          Condition: null
+    - id: testDeepPtr7
+      version: 0
+      type: LOG_PROBE
+      where: {methodName: main.testDeepPtr7}
+      capture:
+        maxReferenceDepth: 5
+        maxFieldCount: 0
+        maxCollectionSize: 0
+      template: ""
+      segments: []
+      captureSnapshot: true
+      subprogram: {subprogram: 37}
+      events:
+        - ID: 37
+          Type: 345 EventRootType Probe[main.testDeepPtr7]
+          InjectionPoints: [{PC: "0xd037e0", Frameless: true}]
+          Condition: null
+    - id: testDeepSlice1
+      version: 0
+      type: LOG_PROBE
+      where: {methodName: main.testDeepSlice1}
+      capture:
+        maxReferenceDepth: 1
+        maxFieldCount: 0
+        maxCollectionSize: 0
+      template: ""
+      segments: []
+      captureSnapshot: true
+      subprogram: {subprogram: 38}
+      events:
+        - ID: 38
+          Type: 346 EventRootType Probe[main.testDeepSlice1]
+          InjectionPoints: [{PC: "0xd03960", Frameless: true}]
+          Condition: null
+    - id: testDeepSlice7
+      version: 0
+      type: LOG_PROBE
+      where: {methodName: main.testDeepSlice7}
+      capture:
+        maxReferenceDepth: 5
+        maxFieldCount: 0
+        maxCollectionSize: 0
+      template: ""
+      segments: []
+      captureSnapshot: true
+      subprogram: {subprogram: 39}
+      events:
+        - ID: 39
+          Type: 347 EventRootType Probe[main.testDeepSlice7]
+          InjectionPoints: [{PC: "0xd03980", Frameless: true}]
           Condition: null
     - id: testEmptySlice
       version: 0
@@ -176,11 +278,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 79}
+      subprogram: {subprogram: 87}
       events:
-        - ID: 79
-          Type: 292 EventRootType Probe[main.testEmptySlice]
-          InjectionPoints: [{PC: "0xd06ae0", Frameless: true}]
+        - ID: 87
+          Type: 395 EventRootType Probe[main.testEmptySlice]
+          InjectionPoints: [{PC: "0xd07560", Frameless: true}]
           Condition: null
     - id: testEmptySliceOfStructs
       version: 0
@@ -190,11 +292,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 82}
+      subprogram: {subprogram: 90}
       events:
-        - ID: 82
-          Type: 295 EventRootType Probe[main.testEmptySliceOfStructs]
-          InjectionPoints: [{PC: "0xd06b40", Frameless: true}]
+        - ID: 90
+          Type: 398 EventRootType Probe[main.testEmptySliceOfStructs]
+          InjectionPoints: [{PC: "0xd075c0", Frameless: true}]
           Condition: null
     - id: testEmptyString
       version: 0
@@ -204,11 +306,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 96}
+      subprogram: {subprogram: 104}
       events:
-        - ID: 96
-          Type: 309 EventRootType Probe[main.testEmptyString]
-          InjectionPoints: [{PC: "0xd07060", Frameless: true}]
+        - ID: 104
+          Type: 412 EventRootType Probe[main.testEmptyString]
+          InjectionPoints: [{PC: "0xd07ae0", Frameless: true}]
           Condition: null
     - id: testEmptyStruct
       version: 0
@@ -218,11 +320,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 98}
+      subprogram: {subprogram: 106}
       events:
-        - ID: 98
-          Type: 311 EventRootType Probe[main.testEmptyStruct]
-          InjectionPoints: [{PC: "0xd07460", Frameless: true}]
+        - ID: 106
+          Type: 414 EventRootType Probe[main.testEmptyStruct]
+          InjectionPoints: [{PC: "0xd07ee0", Frameless: true}]
           Condition: null
     - id: testError
       version: 0
@@ -232,11 +334,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 46}
+      subprogram: {subprogram: 54}
       events:
-        - ID: 46
-          Type: 259 EventRootType Probe[main.testError]
-          InjectionPoints: [{PC: "0xd04180", Frameless: true}]
+        - ID: 54
+          Type: 362 EventRootType Probe[main.testError]
+          InjectionPoints: [{PC: "0xd04c00", Frameless: true}]
           Condition: null
     - id: testEsotericHeap
       version: 0
@@ -246,11 +348,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 37}
+      subprogram: {subprogram: 45}
       events:
-        - ID: 37
-          Type: 250 EventRootType Probe[main.testEsotericHeap]
-          InjectionPoints: [{PC: "0xd0364a", Frameless: false}]
+        - ID: 45
+          Type: 353 EventRootType Probe[main.testEsotericHeap]
+          InjectionPoints: [{PC: "0xd040ca", Frameless: false}]
           Condition: null
     - id: testEsotericStack
       version: 0
@@ -260,11 +362,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 36}
+      subprogram: {subprogram: 44}
       events:
-        - ID: 36
-          Type: 249 EventRootType Probe[main.testEsotericStack]
-          InjectionPoints: [{PC: "0xd0352e", Frameless: false}]
+        - ID: 44
+          Type: 352 EventRootType Probe[main.testEsotericStack]
+          InjectionPoints: [{PC: "0xd03fae", Frameless: false}]
           Condition: null
     - id: testFrameless
       version: 0
@@ -274,11 +376,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 42}
+      subprogram: {subprogram: 50}
       events:
-        - ID: 42
-          Type: 255 EventRootType Probe[main.testFrameless]
-          InjectionPoints: [{PC: "0xd03da0", Frameless: true}]
+        - ID: 50
+          Type: 358 EventRootType Probe[main.testFrameless]
+          InjectionPoints: [{PC: "0xd04820", Frameless: true}]
           Condition: null
     - id: testFramelessArray
       version: 0
@@ -288,11 +390,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 43}
+      subprogram: {subprogram: 51}
       events:
-        - ID: 43
-          Type: 256 EventRootType Probe[main.testFramelessArray]
-          InjectionPoints: [{PC: "0xd03dc4", Frameless: false}]
+        - ID: 51
+          Type: 359 EventRootType Probe[main.testFramelessArray]
+          InjectionPoints: [{PC: "0xd04844", Frameless: false}]
           Condition: null
     - id: testInlinedBA
       version: 0
@@ -302,11 +404,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 38}
+      subprogram: {subprogram: 46}
       events:
-        - ID: 38
-          Type: 251 EventRootType Probe[main.testInlinedBA]
-          InjectionPoints: [{PC: "0xd03a8a", Frameless: false}]
+        - ID: 46
+          Type: 354 EventRootType Probe[main.testInlinedBA]
+          InjectionPoints: [{PC: "0xd0450a", Frameless: false}]
           Condition: null
     - id: testInlinedBB
       version: 0
@@ -316,11 +418,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 39}
+      subprogram: {subprogram: 47}
       events:
-        - ID: 39
-          Type: 252 EventRootType Probe[main.testInlinedBB]
-          InjectionPoints: [{PC: "0xd03b2e", Frameless: false}]
+        - ID: 47
+          Type: 355 EventRootType Probe[main.testInlinedBB]
+          InjectionPoints: [{PC: "0xd045ae", Frameless: false}]
           Condition: null
     - id: testInlinedBBA
       version: 0
@@ -330,11 +432,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 40}
+      subprogram: {subprogram: 48}
       events:
-        - ID: 40
-          Type: 253 EventRootType Probe[main.testInlinedBBA]
-          InjectionPoints: [{PC: "0xd03c0a", Frameless: false}]
+        - ID: 48
+          Type: 356 EventRootType Probe[main.testInlinedBBA]
+          InjectionPoints: [{PC: "0xd0468a", Frameless: false}]
           Condition: null
     - id: testInlinedBBB
       version: 0
@@ -344,11 +446,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 100}
+      subprogram: {subprogram: 108}
       events:
-        - ID: 100
-          Type: 313 EventRootType Probe[main.testInlinedBBB]
-          InjectionPoints: [{PC: "0xd03b86", Frameless: false}]
+        - ID: 108
+          Type: 416 EventRootType Probe[main.testInlinedBBB]
+          InjectionPoints: [{PC: "0xd04606", Frameless: false}]
           Condition: null
     - id: testInlinedBC
       version: 0
@@ -358,11 +460,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 41}
+      subprogram: {subprogram: 49}
       events:
-        - ID: 41
-          Type: 254 EventRootType Probe[main.testInlinedBC]
-          InjectionPoints: [{PC: "0xd03c8e", Frameless: false}]
+        - ID: 49
+          Type: 357 EventRootType Probe[main.testInlinedBC]
+          InjectionPoints: [{PC: "0xd0470e", Frameless: false}]
           Condition: null
     - id: testInlinedBCA
       version: 0
@@ -372,11 +474,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 101}
+      subprogram: {subprogram: 109}
       events:
-        - ID: 101
-          Type: 314 EventRootType Probe[main.testInlinedBCA]
-          InjectionPoints: [{PC: "0xd03c93", Frameless: false}]
+        - ID: 109
+          Type: 417 EventRootType Probe[main.testInlinedBCA]
+          InjectionPoints: [{PC: "0xd04713", Frameless: false}]
           Condition: null
     - id: testInlinedBCB
       version: 0
@@ -386,11 +488,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 102}
+      subprogram: {subprogram: 110}
       events:
-        - ID: 102
-          Type: 315 EventRootType Probe[main.testInlinedBCB]
-          InjectionPoints: [{PC: "0xd03d46", Frameless: false}]
+        - ID: 110
+          Type: 418 EventRootType Probe[main.testInlinedBCB]
+          InjectionPoints: [{PC: "0xd047c6", Frameless: false}]
           Condition: null
     - id: testInlinedPrint
       version: 0
@@ -401,20 +503,20 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 99}
+      subprogram: {subprogram: 107}
       events:
-        - ID: 99
-          Type: 312 EventRootType Probe[main.testInlinedPrint]
+        - ID: 107
+          Type: 415 EventRootType Probe[main.testInlinedPrint]
           InjectionPoints:
-            - PC: "0xd038ea"
+            - PC: "0xd0436a"
               Frameless: false
-            - PC: "0xd03971"
+            - PC: "0xd043f1"
               Frameless: false
-            - PC: "0xd03ab2"
+            - PC: "0xd04532"
               Frameless: false
-            - PC: "0xd03b3c"
+            - PC: "0xd045bc"
               Frameless: false
-            - PC: "0xd03c0f"
+            - PC: "0xd0468f"
               Frameless: false
           Condition: null
     - id: testInlinedSq
@@ -425,11 +527,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 103}
+      subprogram: {subprogram: 111}
       events:
-        - ID: 103
-          Type: 316 EventRootType Probe[main.testInlinedSq]
-          InjectionPoints: [{PC: "0xd03da1", Frameless: true}]
+        - ID: 111
+          Type: 419 EventRootType Probe[main.testInlinedSq]
+          InjectionPoints: [{PC: "0xd04821", Frameless: true}]
           Condition: null
     - id: testInlinedSumArray
       version: 0
@@ -440,14 +542,14 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 104}
+      subprogram: {subprogram: 112}
       events:
-        - ID: 104
-          Type: 317 EventRootType Probe[main.testInlinedSumArray]
+        - ID: 112
+          Type: 420 EventRootType Probe[main.testInlinedSumArray]
           InjectionPoints:
-            - PC: "0xd03de5"
+            - PC: "0xd04865"
               Frameless: false
-            - PC: "0xd03e85"
+            - PC: "0xd04905"
               Frameless: false
           Condition: null
     - id: testInt16Array
@@ -461,8 +563,8 @@ Probes:
       subprogram: {subprogram: 7}
       events:
         - ID: 7
-          Type: 220 EventRootType Probe[main.testInt16Array]
-          InjectionPoints: [{PC: "0xd02a40", Frameless: true}]
+          Type: 315 EventRootType Probe[main.testInt16Array]
+          InjectionPoints: [{PC: "0xd02ea0", Frameless: true}]
           Condition: null
     - id: testInt32Array
       version: 0
@@ -475,8 +577,8 @@ Probes:
       subprogram: {subprogram: 8}
       events:
         - ID: 8
-          Type: 221 EventRootType Probe[main.testInt32Array]
-          InjectionPoints: [{PC: "0xd02a60", Frameless: true}]
+          Type: 316 EventRootType Probe[main.testInt32Array]
+          InjectionPoints: [{PC: "0xd02ec0", Frameless: true}]
           Condition: null
     - id: testInt64Array
       version: 0
@@ -489,8 +591,8 @@ Probes:
       subprogram: {subprogram: 9}
       events:
         - ID: 9
-          Type: 222 EventRootType Probe[main.testInt64Array]
-          InjectionPoints: [{PC: "0xd02a80", Frameless: true}]
+          Type: 317 EventRootType Probe[main.testInt64Array]
+          InjectionPoints: [{PC: "0xd02ee0", Frameless: true}]
           Condition: null
     - id: testInt8Array
       version: 0
@@ -503,8 +605,8 @@ Probes:
       subprogram: {subprogram: 6}
       events:
         - ID: 6
-          Type: 219 EventRootType Probe[main.testInt8Array]
-          InjectionPoints: [{PC: "0xd02a20", Frameless: true}]
+          Type: 314 EventRootType Probe[main.testInt8Array]
+          InjectionPoints: [{PC: "0xd02e80", Frameless: true}]
           Condition: null
     - id: testIntArray
       version: 0
@@ -517,8 +619,8 @@ Probes:
       subprogram: {subprogram: 5}
       events:
         - ID: 5
-          Type: 218 EventRootType Probe[main.testIntArray]
-          InjectionPoints: [{PC: "0xd02a00", Frameless: true}]
+          Type: 313 EventRootType Probe[main.testIntArray]
+          InjectionPoints: [{PC: "0xd02e60", Frameless: true}]
           Condition: null
     - id: testInterface
       version: 0
@@ -528,11 +630,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 44}
+      subprogram: {subprogram: 52}
       events:
-        - ID: 44
-          Type: 257 EventRootType Probe[main.testInterface]
-          InjectionPoints: [{PC: "0xd040aa", Frameless: false}]
+        - ID: 52
+          Type: 360 EventRootType Probe[main.testInterface]
+          InjectionPoints: [{PC: "0xd04b2a", Frameless: false}]
           Condition: null
     - id: testLinkedList
       version: 0
@@ -542,11 +644,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 71}
+      subprogram: {subprogram: 79}
       events:
-        - ID: 71
-          Type: 284 EventRootType Probe[main.testLinkedList]
-          InjectionPoints: [{PC: "0xd063c0", Frameless: true}]
+        - ID: 79
+          Type: 387 EventRootType Probe[main.testLinkedList]
+          InjectionPoints: [{PC: "0xd06e40", Frameless: true}]
           Condition: null
     - id: testMapArrayToArray
       version: 0
@@ -556,11 +658,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 51}
+      subprogram: {subprogram: 59}
       events:
-        - ID: 51
-          Type: 264 EventRootType Probe[main.testMapArrayToArray]
-          InjectionPoints: [{PC: "0xd04660", Frameless: true}]
+        - ID: 59
+          Type: 367 EventRootType Probe[main.testMapArrayToArray]
+          InjectionPoints: [{PC: "0xd050e0", Frameless: true}]
           Condition: null
     - id: testMapEmbeddedMaps
       version: 0
@@ -570,11 +672,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 57}
+      subprogram: {subprogram: 65}
       events:
-        - ID: 57
-          Type: 270 EventRootType Probe[main.testMapEmbeddedMaps]
-          InjectionPoints: [{PC: "0xd04720", Frameless: true}]
+        - ID: 65
+          Type: 373 EventRootType Probe[main.testMapEmbeddedMaps]
+          InjectionPoints: [{PC: "0xd051a0", Frameless: true}]
           Condition: null
     - id: testMapIntToInt
       version: 0
@@ -584,11 +686,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 55}
+      subprogram: {subprogram: 63}
       events:
-        - ID: 55
-          Type: 268 EventRootType Probe[main.testMapIntToInt]
-          InjectionPoints: [{PC: "0xd046e0", Frameless: true}]
+        - ID: 63
+          Type: 371 EventRootType Probe[main.testMapIntToInt]
+          InjectionPoints: [{PC: "0xd05160", Frameless: true}]
           Condition: null
     - id: testMapLargeKeyLargeValue
       version: 0
@@ -598,11 +700,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 66}
+      subprogram: {subprogram: 74}
       events:
-        - ID: 66
-          Type: 279 EventRootType Probe[main.testMapLargeKeyLargeValue]
-          InjectionPoints: [{PC: "0xd04840", Frameless: true}]
+        - ID: 74
+          Type: 382 EventRootType Probe[main.testMapLargeKeyLargeValue]
+          InjectionPoints: [{PC: "0xd052c0", Frameless: true}]
           Condition: null
     - id: testMapLargeKeySmallValue
       version: 0
@@ -612,11 +714,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 65}
+      subprogram: {subprogram: 73}
       events:
-        - ID: 65
-          Type: 278 EventRootType Probe[main.testMapLargeKeySmallValue]
-          InjectionPoints: [{PC: "0xd04820", Frameless: true}]
+        - ID: 73
+          Type: 381 EventRootType Probe[main.testMapLargeKeySmallValue]
+          InjectionPoints: [{PC: "0xd052a0", Frameless: true}]
           Condition: null
     - id: testMapMassive
       version: 0
@@ -626,11 +728,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 56}
+      subprogram: {subprogram: 64}
       events:
-        - ID: 56
-          Type: 269 EventRootType Probe[main.testMapMassive]
-          InjectionPoints: [{PC: "0xd04700", Frameless: true}]
+        - ID: 64
+          Type: 372 EventRootType Probe[main.testMapMassive]
+          InjectionPoints: [{PC: "0xd05180", Frameless: true}]
           Condition: null
     - id: testMapSmallKeyLargeValue
       version: 0
@@ -640,11 +742,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 64}
+      subprogram: {subprogram: 72}
       events:
-        - ID: 64
-          Type: 277 EventRootType Probe[main.testMapSmallKeyLargeValue]
-          InjectionPoints: [{PC: "0xd04800", Frameless: true}]
+        - ID: 72
+          Type: 380 EventRootType Probe[main.testMapSmallKeyLargeValue]
+          InjectionPoints: [{PC: "0xd05280", Frameless: true}]
           Condition: null
     - id: testMapSmallKeySmallValue
       version: 0
@@ -654,11 +756,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 63}
+      subprogram: {subprogram: 71}
       events:
-        - ID: 63
-          Type: 276 EventRootType Probe[main.testMapSmallKeySmallValue]
-          InjectionPoints: [{PC: "0xd047e0", Frameless: true}]
+        - ID: 71
+          Type: 379 EventRootType Probe[main.testMapSmallKeySmallValue]
+          InjectionPoints: [{PC: "0xd05260", Frameless: true}]
           Condition: null
     - id: testMapStringToInt
       version: 0
@@ -668,11 +770,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 49}
+      subprogram: {subprogram: 57}
       events:
-        - ID: 49
-          Type: 262 EventRootType Probe[main.testMapStringToInt]
-          InjectionPoints: [{PC: "0xd04620", Frameless: true}]
+        - ID: 57
+          Type: 365 EventRootType Probe[main.testMapStringToInt]
+          InjectionPoints: [{PC: "0xd050a0", Frameless: true}]
           Condition: null
     - id: testMapStringToSlice
       version: 0
@@ -682,11 +784,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 50}
+      subprogram: {subprogram: 58}
       events:
-        - ID: 50
-          Type: 263 EventRootType Probe[main.testMapStringToSlice]
-          InjectionPoints: [{PC: "0xd04640", Frameless: true}]
+        - ID: 58
+          Type: 366 EventRootType Probe[main.testMapStringToSlice]
+          InjectionPoints: [{PC: "0xd050c0", Frameless: true}]
           Condition: null
     - id: testMapStringToStruct
       version: 0
@@ -696,11 +798,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 48}
+      subprogram: {subprogram: 56}
       events:
-        - ID: 48
-          Type: 261 EventRootType Probe[main.testMapStringToStruct]
-          InjectionPoints: [{PC: "0xd04600", Frameless: true}]
+        - ID: 56
+          Type: 364 EventRootType Probe[main.testMapStringToStruct]
+          InjectionPoints: [{PC: "0xd05080", Frameless: true}]
           Condition: null
     - id: testMapWithLinkedList
       version: 0
@@ -710,11 +812,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 58}
+      subprogram: {subprogram: 66}
       events:
-        - ID: 58
-          Type: 271 EventRootType Probe[main.testMapWithLinkedList]
-          InjectionPoints: [{PC: "0xd04740", Frameless: true}]
+        - ID: 66
+          Type: 374 EventRootType Probe[main.testMapWithLinkedList]
+          InjectionPoints: [{PC: "0xd051c0", Frameless: true}]
           Condition: null
     - id: testMapWithSmallKeyAndValue
       version: 0
@@ -724,11 +826,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 61}
+      subprogram: {subprogram: 69}
       events:
-        - ID: 61
-          Type: 274 EventRootType Probe[main.testMapWithSmallKeyAndValue]
-          InjectionPoints: [{PC: "0xd047a0", Frameless: true}]
+        - ID: 69
+          Type: 377 EventRootType Probe[main.testMapWithSmallKeyAndValue]
+          InjectionPoints: [{PC: "0xd05220", Frameless: true}]
           Condition: null
     - id: testMapWithSmallKeyAndValueMassive
       version: 0
@@ -738,11 +840,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 62}
+      subprogram: {subprogram: 70}
       events:
-        - ID: 62
-          Type: 275 EventRootType Probe[main.testMapWithSmallKeyAndValueMassive]
-          InjectionPoints: [{PC: "0xd047c0", Frameless: true}]
+        - ID: 70
+          Type: 378 EventRootType Probe[main.testMapWithSmallKeyAndValueMassive]
+          InjectionPoints: [{PC: "0xd05240", Frameless: true}]
           Condition: null
     - id: testMapWithSmallValue
       version: 0
@@ -752,11 +854,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 59}
+      subprogram: {subprogram: 67}
       events:
-        - ID: 59
-          Type: 272 EventRootType Probe[main.testMapWithSmallValue]
-          InjectionPoints: [{PC: "0xd04760", Frameless: true}]
+        - ID: 67
+          Type: 375 EventRootType Probe[main.testMapWithSmallValue]
+          InjectionPoints: [{PC: "0xd051e0", Frameless: true}]
           Condition: null
     - id: testMapWithSmallValueMassive
       version: 0
@@ -766,11 +868,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 60}
+      subprogram: {subprogram: 68}
       events:
-        - ID: 60
-          Type: 273 EventRootType Probe[main.testMapWithSmallValueMassive]
-          InjectionPoints: [{PC: "0xd04780", Frameless: true}]
+        - ID: 68
+          Type: 376 EventRootType Probe[main.testMapWithSmallValueMassive]
+          InjectionPoints: [{PC: "0xd05200", Frameless: true}]
           Condition: null
     - id: testMassiveString
       version: 0
@@ -780,11 +882,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 94}
+      subprogram: {subprogram: 102}
       events:
-        - ID: 94
-          Type: 307 EventRootType Probe[main.testMassiveString]
-          InjectionPoints: [{PC: "0xd07020", Frameless: true}]
+        - ID: 102
+          Type: 410 EventRootType Probe[main.testMassiveString]
+          InjectionPoints: [{PC: "0xd07aa0", Frameless: true}]
           Condition: null
     - id: testMultipleSimpleParams
       version: 0
@@ -794,11 +896,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 68}
+      subprogram: {subprogram: 76}
       events:
-        - ID: 68
-          Type: 281 EventRootType Probe[main.testMultipleSimpleParams]
-          InjectionPoints: [{PC: "0xd05fc0", Frameless: true}]
+        - ID: 76
+          Type: 384 EventRootType Probe[main.testMultipleSimpleParams]
+          InjectionPoints: [{PC: "0xd06a40", Frameless: true}]
           Condition: null
     - id: testNilPointer
       version: 0
@@ -808,11 +910,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 76}
+      subprogram: {subprogram: 84}
       events:
-        - ID: 76
-          Type: 289 EventRootType Probe[main.testNilPointer]
-          InjectionPoints: [{PC: "0xd06560", Frameless: true}]
+        - ID: 84
+          Type: 392 EventRootType Probe[main.testNilPointer]
+          InjectionPoints: [{PC: "0xd06fe0", Frameless: true}]
           Condition: null
     - id: testNilSlice
       version: 0
@@ -822,11 +924,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 86}
+      subprogram: {subprogram: 94}
       events:
-        - ID: 86
-          Type: 299 EventRootType Probe[main.testNilSlice]
-          InjectionPoints: [{PC: "0xd06bc0", Frameless: true}]
+        - ID: 94
+          Type: 402 EventRootType Probe[main.testNilSlice]
+          InjectionPoints: [{PC: "0xd07640", Frameless: true}]
           Condition: null
     - id: testNilSliceOfStructs
       version: 0
@@ -836,11 +938,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 83}
+      subprogram: {subprogram: 91}
       events:
-        - ID: 83
-          Type: 296 EventRootType Probe[main.testNilSliceOfStructs]
-          InjectionPoints: [{PC: "0xd06b60", Frameless: true}]
+        - ID: 91
+          Type: 399 EventRootType Probe[main.testNilSliceOfStructs]
+          InjectionPoints: [{PC: "0xd075e0", Frameless: true}]
           Condition: null
     - id: testNilSliceWithOtherParams
       version: 0
@@ -850,11 +952,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 85}
+      subprogram: {subprogram: 93}
       events:
-        - ID: 85
-          Type: 298 EventRootType Probe[main.testNilSliceWithOtherParams]
-          InjectionPoints: [{PC: "0xd06ba0", Frameless: true}]
+        - ID: 93
+          Type: 401 EventRootType Probe[main.testNilSliceWithOtherParams]
+          InjectionPoints: [{PC: "0xd07620", Frameless: true}]
           Condition: null
     - id: testOneStringInStructPointer
       version: 0
@@ -864,11 +966,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 93}
+      subprogram: {subprogram: 101}
       events:
-        - ID: 93
-          Type: 306 EventRootType Probe[main.testOneStringInStructPointer]
-          InjectionPoints: [{PC: "0xd07000", Frameless: true}]
+        - ID: 101
+          Type: 409 EventRootType Probe[main.testOneStringInStructPointer]
+          InjectionPoints: [{PC: "0xd07a80", Frameless: true}]
           Condition: null
     - id: testPointerLoop
       version: 0
@@ -878,11 +980,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 72}
+      subprogram: {subprogram: 80}
       events:
-        - ID: 72
-          Type: 285 EventRootType Probe[main.testPointerLoop]
-          InjectionPoints: [{PC: "0xd063e0", Frameless: true}]
+        - ID: 80
+          Type: 388 EventRootType Probe[main.testPointerLoop]
+          InjectionPoints: [{PC: "0xd06e60", Frameless: true}]
           Condition: null
     - id: testPointerToMap
       version: 0
@@ -892,11 +994,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 54}
+      subprogram: {subprogram: 62}
       events:
-        - ID: 54
-          Type: 267 EventRootType Probe[main.testPointerToMap]
-          InjectionPoints: [{PC: "0xd046c0", Frameless: true}]
+        - ID: 62
+          Type: 370 EventRootType Probe[main.testPointerToMap]
+          InjectionPoints: [{PC: "0xd05140", Frameless: true}]
           Condition: null
     - id: testPointerToSimpleStruct
       version: 0
@@ -906,11 +1008,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 70}
+      subprogram: {subprogram: 78}
       events:
-        - ID: 70
-          Type: 283 EventRootType Probe[main.testPointerToSimpleStruct]
-          InjectionPoints: [{PC: "0xd063a0", Frameless: true}]
+        - ID: 78
+          Type: 386 EventRootType Probe[main.testPointerToSimpleStruct]
+          InjectionPoints: [{PC: "0xd06e20", Frameless: true}]
           Condition: null
     - id: testRuneArray
       version: 0
@@ -923,8 +1025,8 @@ Probes:
       subprogram: {subprogram: 2}
       events:
         - ID: 2
-          Type: 215 EventRootType Probe[main.testRuneArray]
-          InjectionPoints: [{PC: "0xd029a0", Frameless: true}]
+          Type: 310 EventRootType Probe[main.testRuneArray]
+          InjectionPoints: [{PC: "0xd02e00", Frameless: true}]
           Condition: null
     - id: testSingleBool
       version: 0
@@ -937,8 +1039,8 @@ Probes:
       subprogram: {subprogram: 21}
       events:
         - ID: 21
-          Type: 234 EventRootType Probe[main.testSingleBool]
-          InjectionPoints: [{PC: "0xd02fa0", Frameless: true}]
+          Type: 329 EventRootType Probe[main.testSingleBool]
+          InjectionPoints: [{PC: "0xd03400", Frameless: true}]
           Condition: null
     - id: testSingleByte
       version: 0
@@ -951,8 +1053,8 @@ Probes:
       subprogram: {subprogram: 19}
       events:
         - ID: 19
-          Type: 232 EventRootType Probe[main.testSingleByte]
-          InjectionPoints: [{PC: "0xd02f60", Frameless: true}]
+          Type: 327 EventRootType Probe[main.testSingleByte]
+          InjectionPoints: [{PC: "0xd033c0", Frameless: true}]
           Condition: null
     - id: testSingleFloat32
       version: 0
@@ -965,8 +1067,8 @@ Probes:
       subprogram: {subprogram: 32}
       events:
         - ID: 32
-          Type: 245 EventRootType Probe[main.testSingleFloat32]
-          InjectionPoints: [{PC: "0xd03100", Frameless: true}]
+          Type: 340 EventRootType Probe[main.testSingleFloat32]
+          InjectionPoints: [{PC: "0xd03560", Frameless: true}]
           Condition: null
     - id: testSingleFloat64
       version: 0
@@ -979,8 +1081,8 @@ Probes:
       subprogram: {subprogram: 33}
       events:
         - ID: 33
-          Type: 246 EventRootType Probe[main.testSingleFloat64]
-          InjectionPoints: [{PC: "0xd03120", Frameless: true}]
+          Type: 341 EventRootType Probe[main.testSingleFloat64]
+          InjectionPoints: [{PC: "0xd03580", Frameless: true}]
           Condition: null
     - id: testSingleInt
       version: 0
@@ -993,8 +1095,8 @@ Probes:
       subprogram: {subprogram: 22}
       events:
         - ID: 22
-          Type: 235 EventRootType Probe[main.testSingleInt]
-          InjectionPoints: [{PC: "0xd02fc0", Frameless: true}]
+          Type: 330 EventRootType Probe[main.testSingleInt]
+          InjectionPoints: [{PC: "0xd03420", Frameless: true}]
           Condition: null
     - id: testSingleInt16
       version: 0
@@ -1007,8 +1109,8 @@ Probes:
       subprogram: {subprogram: 24}
       events:
         - ID: 24
-          Type: 237 EventRootType Probe[main.testSingleInt16]
-          InjectionPoints: [{PC: "0xd03000", Frameless: true}]
+          Type: 332 EventRootType Probe[main.testSingleInt16]
+          InjectionPoints: [{PC: "0xd03460", Frameless: true}]
           Condition: null
     - id: testSingleInt32
       version: 0
@@ -1021,8 +1123,8 @@ Probes:
       subprogram: {subprogram: 25}
       events:
         - ID: 25
-          Type: 238 EventRootType Probe[main.testSingleInt32]
-          InjectionPoints: [{PC: "0xd03020", Frameless: true}]
+          Type: 333 EventRootType Probe[main.testSingleInt32]
+          InjectionPoints: [{PC: "0xd03480", Frameless: true}]
           Condition: null
     - id: testSingleInt64
       version: 0
@@ -1035,8 +1137,8 @@ Probes:
       subprogram: {subprogram: 26}
       events:
         - ID: 26
-          Type: 239 EventRootType Probe[main.testSingleInt64]
-          InjectionPoints: [{PC: "0xd03040", Frameless: true}]
+          Type: 334 EventRootType Probe[main.testSingleInt64]
+          InjectionPoints: [{PC: "0xd034a0", Frameless: true}]
           Condition: null
     - id: testSingleInt8
       version: 0
@@ -1049,8 +1151,8 @@ Probes:
       subprogram: {subprogram: 23}
       events:
         - ID: 23
-          Type: 236 EventRootType Probe[main.testSingleInt8]
-          InjectionPoints: [{PC: "0xd02fe0", Frameless: true}]
+          Type: 331 EventRootType Probe[main.testSingleInt8]
+          InjectionPoints: [{PC: "0xd03440", Frameless: true}]
           Condition: null
     - id: testSingleRune
       version: 0
@@ -1063,8 +1165,8 @@ Probes:
       subprogram: {subprogram: 20}
       events:
         - ID: 20
-          Type: 233 EventRootType Probe[main.testSingleRune]
-          InjectionPoints: [{PC: "0xd02f80", Frameless: true}]
+          Type: 328 EventRootType Probe[main.testSingleRune]
+          InjectionPoints: [{PC: "0xd033e0", Frameless: true}]
           Condition: null
     - id: testSingleString
       version: 0
@@ -1074,11 +1176,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 89}
+      subprogram: {subprogram: 97}
       events:
-        - ID: 89
-          Type: 302 EventRootType Probe[main.testSingleString]
-          InjectionPoints: [{PC: "0xd06f80", Frameless: true}]
+        - ID: 97
+          Type: 405 EventRootType Probe[main.testSingleString]
+          InjectionPoints: [{PC: "0xd07a00", Frameless: true}]
           Condition: null
     - id: testSingleUint
       version: 0
@@ -1091,8 +1193,8 @@ Probes:
       subprogram: {subprogram: 27}
       events:
         - ID: 27
-          Type: 240 EventRootType Probe[main.testSingleUint]
-          InjectionPoints: [{PC: "0xd03060", Frameless: true}]
+          Type: 335 EventRootType Probe[main.testSingleUint]
+          InjectionPoints: [{PC: "0xd034c0", Frameless: true}]
           Condition: null
     - id: testSingleUint16
       version: 0
@@ -1105,8 +1207,8 @@ Probes:
       subprogram: {subprogram: 29}
       events:
         - ID: 29
-          Type: 242 EventRootType Probe[main.testSingleUint16]
-          InjectionPoints: [{PC: "0xd030a0", Frameless: true}]
+          Type: 337 EventRootType Probe[main.testSingleUint16]
+          InjectionPoints: [{PC: "0xd03500", Frameless: true}]
           Condition: null
     - id: testSingleUint32
       version: 0
@@ -1119,8 +1221,8 @@ Probes:
       subprogram: {subprogram: 30}
       events:
         - ID: 30
-          Type: 243 EventRootType Probe[main.testSingleUint32]
-          InjectionPoints: [{PC: "0xd030c0", Frameless: true}]
+          Type: 338 EventRootType Probe[main.testSingleUint32]
+          InjectionPoints: [{PC: "0xd03520", Frameless: true}]
           Condition: null
     - id: testSingleUint64
       version: 0
@@ -1133,8 +1235,8 @@ Probes:
       subprogram: {subprogram: 31}
       events:
         - ID: 31
-          Type: 244 EventRootType Probe[main.testSingleUint64]
-          InjectionPoints: [{PC: "0xd030e0", Frameless: true}]
+          Type: 339 EventRootType Probe[main.testSingleUint64]
+          InjectionPoints: [{PC: "0xd03540", Frameless: true}]
           Condition: null
     - id: testSingleUint8
       version: 0
@@ -1147,8 +1249,8 @@ Probes:
       subprogram: {subprogram: 28}
       events:
         - ID: 28
-          Type: 241 EventRootType Probe[main.testSingleUint8]
-          InjectionPoints: [{PC: "0xd03080", Frameless: true}]
+          Type: 336 EventRootType Probe[main.testSingleUint8]
+          InjectionPoints: [{PC: "0xd034e0", Frameless: true}]
           Condition: null
     - id: testSliceOfSlices
       version: 0
@@ -1158,11 +1260,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 80}
+      subprogram: {subprogram: 88}
       events:
-        - ID: 80
-          Type: 293 EventRootType Probe[main.testSliceOfSlices]
-          InjectionPoints: [{PC: "0xd06b00", Frameless: true}]
+        - ID: 88
+          Type: 396 EventRootType Probe[main.testSliceOfSlices]
+          InjectionPoints: [{PC: "0xd07580", Frameless: true}]
           Condition: null
     - id: testSmallMap
       version: 0
@@ -1172,11 +1274,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 52}
+      subprogram: {subprogram: 60}
       events:
-        - ID: 52
-          Type: 265 EventRootType Probe[main.testSmallMap]
-          InjectionPoints: [{PC: "0xd04680", Frameless: true}]
+        - ID: 60
+          Type: 368 EventRootType Probe[main.testSmallMap]
+          InjectionPoints: [{PC: "0xd05100", Frameless: true}]
           Condition: null
     - id: testStringArray
       version: 0
@@ -1189,8 +1291,8 @@ Probes:
       subprogram: {subprogram: 3}
       events:
         - ID: 3
-          Type: 216 EventRootType Probe[main.testStringArray]
-          InjectionPoints: [{PC: "0xd029c0", Frameless: true}]
+          Type: 311 EventRootType Probe[main.testStringArray]
+          InjectionPoints: [{PC: "0xd02e20", Frameless: true}]
           Condition: null
     - id: testStringPointer
       version: 0
@@ -1200,11 +1302,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 75}
+      subprogram: {subprogram: 83}
       events:
-        - ID: 75
-          Type: 288 EventRootType Probe[main.testStringPointer]
-          InjectionPoints: [{PC: "0xd06520", Frameless: true}]
+        - ID: 83
+          Type: 391 EventRootType Probe[main.testStringPointer]
+          InjectionPoints: [{PC: "0xd06fa0", Frameless: true}]
           Condition: null
     - id: testStringSlice
       version: 0
@@ -1214,11 +1316,45 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 84}
+      subprogram: {subprogram: 92}
       events:
-        - ID: 84
-          Type: 297 EventRootType Probe[main.testStringSlice]
-          InjectionPoints: [{PC: "0xd06b80", Frameless: true}]
+        - ID: 92
+          Type: 400 EventRootType Probe[main.testStringSlice]
+          InjectionPoints: [{PC: "0xd07600", Frameless: true}]
+          Condition: null
+    - id: testStringType1
+      version: 0
+      type: LOG_PROBE
+      where: {methodName: main.testStringType1}
+      capture:
+        maxReferenceDepth: 1
+        maxFieldCount: 0
+        maxCollectionSize: 0
+      template: ""
+      segments: []
+      captureSnapshot: true
+      subprogram: {subprogram: 42}
+      events:
+        - ID: 42
+          Type: 350 EventRootType Probe[main.testStringType1]
+          InjectionPoints: [{PC: "0xd03b20", Frameless: true}]
+          Condition: null
+    - id: testStringType2
+      version: 0
+      type: LOG_PROBE
+      where: {methodName: main.testStringType2}
+      capture:
+        maxReferenceDepth: 1
+        maxFieldCount: 0
+        maxCollectionSize: 0
+      template: ""
+      segments: []
+      captureSnapshot: true
+      subprogram: {subprogram: 43}
+      events:
+        - ID: 43
+          Type: 351 EventRootType Probe[main.testStringType2]
+          InjectionPoints: [{PC: "0xd03b40", Frameless: true}]
           Condition: null
     - id: testStruct
       version: 0
@@ -1228,11 +1364,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 97}
+      subprogram: {subprogram: 105}
       events:
-        - ID: 97
-          Type: 310 EventRootType Probe[main.testStruct]
-          InjectionPoints: [{PC: "0xd072e0", Frameless: true}]
+        - ID: 105
+          Type: 413 EventRootType Probe[main.testStruct]
+          InjectionPoints: [{PC: "0xd07d60", Frameless: true}]
           Condition: null
     - id: testStructSlice
       version: 0
@@ -1242,11 +1378,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 81}
+      subprogram: {subprogram: 89}
       events:
-        - ID: 81
-          Type: 294 EventRootType Probe[main.testStructSlice]
-          InjectionPoints: [{PC: "0xd06b20", Frameless: true}]
+        - ID: 89
+          Type: 397 EventRootType Probe[main.testStructSlice]
+          InjectionPoints: [{PC: "0xd075a0", Frameless: true}]
           Condition: null
     - id: testStructWithMap
       version: 0
@@ -1256,11 +1392,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 47}
+      subprogram: {subprogram: 55}
       events:
-        - ID: 47
-          Type: 260 EventRootType Probe[main.testStructWithMap]
-          InjectionPoints: [{PC: "0xd045e0", Frameless: true}]
+        - ID: 55
+          Type: 363 EventRootType Probe[main.testStructWithMap]
+          InjectionPoints: [{PC: "0xd05060", Frameless: true}]
           Condition: null
     - id: testThreeStrings
       version: 0
@@ -1270,11 +1406,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 90}
+      subprogram: {subprogram: 98}
       events:
-        - ID: 90
-          Type: 303 EventRootType Probe[main.testThreeStrings]
-          InjectionPoints: [{PC: "0xd06fa0", Frameless: true}]
+        - ID: 98
+          Type: 406 EventRootType Probe[main.testThreeStrings]
+          InjectionPoints: [{PC: "0xd07a20", Frameless: true}]
           Condition: null
     - id: testThreeStringsInStruct
       version: 0
@@ -1284,11 +1420,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 91}
+      subprogram: {subprogram: 99}
       events:
-        - ID: 91
-          Type: 304 EventRootType Probe[main.testThreeStringsInStruct]
-          InjectionPoints: [{PC: "0xd06fc0", Frameless: true}]
+        - ID: 99
+          Type: 407 EventRootType Probe[main.testThreeStringsInStruct]
+          InjectionPoints: [{PC: "0xd07a40", Frameless: true}]
           Condition: null
     - id: testThreeStringsInStructPointer
       version: 0
@@ -1298,11 +1434,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 92}
+      subprogram: {subprogram: 100}
       events:
-        - ID: 92
-          Type: 305 EventRootType Probe[main.testThreeStringsInStructPointer]
-          InjectionPoints: [{PC: "0xd06fe0", Frameless: true}]
+        - ID: 100
+          Type: 408 EventRootType Probe[main.testThreeStringsInStructPointer]
+          InjectionPoints: [{PC: "0xd07a60", Frameless: true}]
           Condition: null
     - id: testTypeAlias
       version: 0
@@ -1315,8 +1451,8 @@ Probes:
       subprogram: {subprogram: 34}
       events:
         - ID: 34
-          Type: 247 EventRootType Probe[main.testTypeAlias]
-          InjectionPoints: [{PC: "0xd03140", Frameless: true}]
+          Type: 342 EventRootType Probe[main.testTypeAlias]
+          InjectionPoints: [{PC: "0xd035a0", Frameless: true}]
           Condition: null
     - id: testUint16Array
       version: 0
@@ -1329,8 +1465,8 @@ Probes:
       subprogram: {subprogram: 12}
       events:
         - ID: 12
-          Type: 225 EventRootType Probe[main.testUint16Array]
-          InjectionPoints: [{PC: "0xd02ae0", Frameless: true}]
+          Type: 320 EventRootType Probe[main.testUint16Array]
+          InjectionPoints: [{PC: "0xd02f40", Frameless: true}]
           Condition: null
     - id: testUint32Array
       version: 0
@@ -1343,8 +1479,8 @@ Probes:
       subprogram: {subprogram: 13}
       events:
         - ID: 13
-          Type: 226 EventRootType Probe[main.testUint32Array]
-          InjectionPoints: [{PC: "0xd02b00", Frameless: true}]
+          Type: 321 EventRootType Probe[main.testUint32Array]
+          InjectionPoints: [{PC: "0xd02f60", Frameless: true}]
           Condition: null
     - id: testUint64Array
       version: 0
@@ -1357,8 +1493,8 @@ Probes:
       subprogram: {subprogram: 14}
       events:
         - ID: 14
-          Type: 227 EventRootType Probe[main.testUint64Array]
-          InjectionPoints: [{PC: "0xd02b20", Frameless: true}]
+          Type: 322 EventRootType Probe[main.testUint64Array]
+          InjectionPoints: [{PC: "0xd02f80", Frameless: true}]
           Condition: null
     - id: testUint8Array
       version: 0
@@ -1371,8 +1507,8 @@ Probes:
       subprogram: {subprogram: 11}
       events:
         - ID: 11
-          Type: 224 EventRootType Probe[main.testUint8Array]
-          InjectionPoints: [{PC: "0xd02ac0", Frameless: true}]
+          Type: 319 EventRootType Probe[main.testUint8Array]
+          InjectionPoints: [{PC: "0xd02f20", Frameless: true}]
           Condition: null
     - id: testUintArray
       version: 0
@@ -1385,8 +1521,8 @@ Probes:
       subprogram: {subprogram: 10}
       events:
         - ID: 10
-          Type: 223 EventRootType Probe[main.testUintArray]
-          InjectionPoints: [{PC: "0xd02aa0", Frameless: true}]
+          Type: 318 EventRootType Probe[main.testUintArray]
+          InjectionPoints: [{PC: "0xd02f00", Frameless: true}]
           Condition: null
     - id: testUintPointer
       version: 0
@@ -1396,11 +1532,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 74}
+      subprogram: {subprogram: 82}
       events:
-        - ID: 74
-          Type: 287 EventRootType Probe[main.testUintPointer]
-          InjectionPoints: [{PC: "0xd06440", Frameless: true}]
+        - ID: 82
+          Type: 390 EventRootType Probe[main.testUintPointer]
+          InjectionPoints: [{PC: "0xd06ec0", Frameless: true}]
           Condition: null
     - id: testUintSlice
       version: 0
@@ -1410,11 +1546,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 78}
+      subprogram: {subprogram: 86}
       events:
-        - ID: 78
-          Type: 291 EventRootType Probe[main.testUintSlice]
-          InjectionPoints: [{PC: "0xd06ac0", Frameless: true}]
+        - ID: 86
+          Type: 394 EventRootType Probe[main.testUintSlice]
+          InjectionPoints: [{PC: "0xd07540", Frameless: true}]
           Condition: null
     - id: testUnitializedString
       version: 0
@@ -1424,11 +1560,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 95}
+      subprogram: {subprogram: 103}
       events:
-        - ID: 95
-          Type: 308 EventRootType Probe[main.testUnitializedString]
-          InjectionPoints: [{PC: "0xd07040", Frameless: true}]
+        - ID: 103
+          Type: 411 EventRootType Probe[main.testUnitializedString]
+          InjectionPoints: [{PC: "0xd07ac0", Frameless: true}]
           Condition: null
     - id: testUnsafePointer
       version: 0
@@ -1438,11 +1574,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 73}
+      subprogram: {subprogram: 81}
       events:
-        - ID: 73
-          Type: 286 EventRootType Probe[main.testUnsafePointer]
-          InjectionPoints: [{PC: "0xd06400", Frameless: true}]
+        - ID: 81
+          Type: 389 EventRootType Probe[main.testUnsafePointer]
+          InjectionPoints: [{PC: "0xd06e80", Frameless: true}]
           Condition: null
     - id: testVeryLargeArray
       version: 0
@@ -1455,8 +1591,8 @@ Probes:
       subprogram: {subprogram: 18}
       events:
         - ID: 18
-          Type: 231 EventRootType Probe[main.testVeryLargeArray]
-          InjectionPoints: [{PC: "0xd02be0", Frameless: true}]
+          Type: 326 EventRootType Probe[main.testVeryLargeArray]
+          InjectionPoints: [{PC: "0xd03040", Frameless: true}]
           Condition: null
     - id: testVeryLargeSlice
       version: 0
@@ -1466,430 +1602,430 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 87}
+      subprogram: {subprogram: 95}
       events:
-        - ID: 87
-          Type: 300 EventRootType Probe[main.testVeryLargeSlice]
-          InjectionPoints: [{PC: "0xd06be0", Frameless: true}]
+        - ID: 95
+          Type: 403 EventRootType Probe[main.testVeryLargeSlice]
+          InjectionPoints: [{PC: "0xd07660", Frameless: true}]
           Condition: null
 Subprograms:
     - ID: 1
       Name: main.testByteArray
-      OutOfLinePCRanges: [0xd02980..0xd02981]
+      OutOfLinePCRanges: [0xd02de0..0xd02de1]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 36 ArrayType [2]uint8
           Locations:
-            - Range: 0xd02980..0xd02981
+            - Range: 0xd02de0..0xd02de1
               Pieces: [{Size: 2, Op: {CfaOffset: 0}}]
           IsParameter: true
           IsReturn: false
     - ID: 2
       Name: main.testRuneArray
-      OutOfLinePCRanges: [0xd029a0..0xd029a1]
+      OutOfLinePCRanges: [0xd02e00..0xd02e01]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 37 ArrayType [2]int32
           Locations:
-            - Range: 0xd029a0..0xd029a1
+            - Range: 0xd02e00..0xd02e01
               Pieces: [{Size: 8, Op: {CfaOffset: 0}}]
           IsParameter: true
           IsReturn: false
     - ID: 3
       Name: main.testStringArray
-      OutOfLinePCRanges: [0xd029c0..0xd029c1]
+      OutOfLinePCRanges: [0xd02e20..0xd02e21]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 38 ArrayType [2]string
           Locations:
-            - Range: 0xd029c0..0xd029c1
+            - Range: 0xd02e20..0xd02e21
               Pieces: [{Size: 32, Op: {CfaOffset: 0}}]
           IsParameter: true
           IsReturn: false
     - ID: 4
       Name: main.testBoolArray
-      OutOfLinePCRanges: [0xd029e0..0xd029e1]
+      OutOfLinePCRanges: [0xd02e40..0xd02e41]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 39 ArrayType [2]bool
           Locations:
-            - Range: 0xd029e0..0xd029e1
+            - Range: 0xd02e40..0xd02e41
               Pieces: [{Size: 2, Op: {CfaOffset: 0}}]
           IsParameter: true
           IsReturn: false
     - ID: 5
       Name: main.testIntArray
-      OutOfLinePCRanges: [0xd02a00..0xd02a01]
+      OutOfLinePCRanges: [0xd02e60..0xd02e61]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 40 ArrayType [2]int
           Locations:
-            - Range: 0xd02a00..0xd02a01
+            - Range: 0xd02e60..0xd02e61
               Pieces: [{Size: 16, Op: {CfaOffset: 0}}]
           IsParameter: true
           IsReturn: false
     - ID: 6
       Name: main.testInt8Array
-      OutOfLinePCRanges: [0xd02a20..0xd02a21]
+      OutOfLinePCRanges: [0xd02e80..0xd02e81]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 41 ArrayType [2]int8
           Locations:
-            - Range: 0xd02a20..0xd02a21
+            - Range: 0xd02e80..0xd02e81
               Pieces: [{Size: 2, Op: {CfaOffset: 0}}]
           IsParameter: true
           IsReturn: false
     - ID: 7
       Name: main.testInt16Array
-      OutOfLinePCRanges: [0xd02a40..0xd02a41]
+      OutOfLinePCRanges: [0xd02ea0..0xd02ea1]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 42 ArrayType [2]int16
           Locations:
-            - Range: 0xd02a40..0xd02a41
+            - Range: 0xd02ea0..0xd02ea1
               Pieces: [{Size: 4, Op: {CfaOffset: 0}}]
           IsParameter: true
           IsReturn: false
     - ID: 8
       Name: main.testInt32Array
-      OutOfLinePCRanges: [0xd02a60..0xd02a61]
+      OutOfLinePCRanges: [0xd02ec0..0xd02ec1]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 37 ArrayType [2]int32
           Locations:
-            - Range: 0xd02a60..0xd02a61
+            - Range: 0xd02ec0..0xd02ec1
               Pieces: [{Size: 8, Op: {CfaOffset: 0}}]
           IsParameter: true
           IsReturn: false
     - ID: 9
       Name: main.testInt64Array
-      OutOfLinePCRanges: [0xd02a80..0xd02a81]
+      OutOfLinePCRanges: [0xd02ee0..0xd02ee1]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 43 ArrayType [2]int64
           Locations:
-            - Range: 0xd02a80..0xd02a81
+            - Range: 0xd02ee0..0xd02ee1
               Pieces: [{Size: 16, Op: {CfaOffset: 0}}]
           IsParameter: true
           IsReturn: false
     - ID: 10
       Name: main.testUintArray
-      OutOfLinePCRanges: [0xd02aa0..0xd02aa1]
+      OutOfLinePCRanges: [0xd02f00..0xd02f01]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 44 ArrayType [2]uint
           Locations:
-            - Range: 0xd02aa0..0xd02aa1
+            - Range: 0xd02f00..0xd02f01
               Pieces: [{Size: 16, Op: {CfaOffset: 0}}]
           IsParameter: true
           IsReturn: false
     - ID: 11
       Name: main.testUint8Array
-      OutOfLinePCRanges: [0xd02ac0..0xd02ac1]
+      OutOfLinePCRanges: [0xd02f20..0xd02f21]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 36 ArrayType [2]uint8
           Locations:
-            - Range: 0xd02ac0..0xd02ac1
+            - Range: 0xd02f20..0xd02f21
               Pieces: [{Size: 2, Op: {CfaOffset: 0}}]
           IsParameter: true
           IsReturn: false
     - ID: 12
       Name: main.testUint16Array
-      OutOfLinePCRanges: [0xd02ae0..0xd02ae1]
+      OutOfLinePCRanges: [0xd02f40..0xd02f41]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 45 ArrayType [2]uint16
           Locations:
-            - Range: 0xd02ae0..0xd02ae1
+            - Range: 0xd02f40..0xd02f41
               Pieces: [{Size: 4, Op: {CfaOffset: 0}}]
           IsParameter: true
           IsReturn: false
     - ID: 13
       Name: main.testUint32Array
-      OutOfLinePCRanges: [0xd02b00..0xd02b01]
+      OutOfLinePCRanges: [0xd02f60..0xd02f61]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 46 ArrayType [2]uint32
           Locations:
-            - Range: 0xd02b00..0xd02b01
+            - Range: 0xd02f60..0xd02f61
               Pieces: [{Size: 8, Op: {CfaOffset: 0}}]
           IsParameter: true
           IsReturn: false
     - ID: 14
       Name: main.testUint64Array
-      OutOfLinePCRanges: [0xd02b20..0xd02b21]
+      OutOfLinePCRanges: [0xd02f80..0xd02f81]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 47 ArrayType [2]uint64
           Locations:
-            - Range: 0xd02b20..0xd02b21
+            - Range: 0xd02f80..0xd02f81
               Pieces: [{Size: 16, Op: {CfaOffset: 0}}]
           IsParameter: true
           IsReturn: false
     - ID: 15
       Name: main.testArrayOfArrays
-      OutOfLinePCRanges: [0xd02b40..0xd02b41]
+      OutOfLinePCRanges: [0xd02fa0..0xd02fa1]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 48 ArrayType [2][2]int
           Locations:
-            - Range: 0xd02b40..0xd02b41
+            - Range: 0xd02fa0..0xd02fa1
               Pieces: [{Size: 32, Op: {CfaOffset: 0}}]
           IsParameter: true
           IsReturn: false
     - ID: 16
       Name: main.testArrayOfStrings
-      OutOfLinePCRanges: [0xd02b60..0xd02b61]
+      OutOfLinePCRanges: [0xd02fc0..0xd02fc1]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 38 ArrayType [2]string
           Locations:
-            - Range: 0xd02b60..0xd02b61
+            - Range: 0xd02fc0..0xd02fc1
               Pieces: [{Size: 32, Op: {CfaOffset: 0}}]
           IsParameter: true
           IsReturn: false
     - ID: 17
       Name: main.testArrayOfArraysOfArrays
-      OutOfLinePCRanges: [0xd02b80..0xd02b81]
+      OutOfLinePCRanges: [0xd02fe0..0xd02fe1]
       InlinePCRanges: []
       Variables:
         - Name: b
           Type: 49 ArrayType [2][2][2]int
           Locations:
-            - Range: 0xd02b80..0xd02b81
+            - Range: 0xd02fe0..0xd02fe1
               Pieces: [{Size: 64, Op: {CfaOffset: 0}}]
           IsParameter: true
           IsReturn: false
     - ID: 18
       Name: main.testVeryLargeArray
-      OutOfLinePCRanges: [0xd02be0..0xd02be1]
+      OutOfLinePCRanges: [0xd03040..0xd03041]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 50 ArrayType [100]uint
           Locations:
-            - Range: 0xd02be0..0xd02be1
+            - Range: 0xd03040..0xd03041
               Pieces: [{Size: 800, Op: {CfaOffset: 0}}]
           IsParameter: true
           IsReturn: false
     - ID: 19
       Name: main.testSingleByte
-      OutOfLinePCRanges: [0xd02f60..0xd02f61]
+      OutOfLinePCRanges: [0xd033c0..0xd033c1]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 3 BaseType uint8
           Locations:
-            - Range: 0xd02f60..0xd02f61
+            - Range: 0xd033c0..0xd033c1
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
     - ID: 20
       Name: main.testSingleRune
-      OutOfLinePCRanges: [0xd02f80..0xd02f81]
+      OutOfLinePCRanges: [0xd033e0..0xd033e1]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 12 BaseType int32
           Locations:
-            - Range: 0xd02f80..0xd02f81
+            - Range: 0xd033e0..0xd033e1
               Pieces: [{Size: 4, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
     - ID: 21
       Name: main.testSingleBool
-      OutOfLinePCRanges: [0xd02fa0..0xd02fa1]
+      OutOfLinePCRanges: [0xd03400..0xd03401]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 4 BaseType bool
           Locations:
-            - Range: 0xd02fa0..0xd02fa1
+            - Range: 0xd03400..0xd03401
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
     - ID: 22
       Name: main.testSingleInt
-      OutOfLinePCRanges: [0xd02fc0..0xd02fc1]
+      OutOfLinePCRanges: [0xd03420..0xd03421]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 9 BaseType int
           Locations:
-            - Range: 0xd02fc0..0xd02fc1
+            - Range: 0xd03420..0xd03421
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
     - ID: 23
       Name: main.testSingleInt8
-      OutOfLinePCRanges: [0xd02fe0..0xd02fe1]
+      OutOfLinePCRanges: [0xd03440..0xd03441]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 14 BaseType int8
           Locations:
-            - Range: 0xd02fe0..0xd02fe1
+            - Range: 0xd03440..0xd03441
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
     - ID: 24
       Name: main.testSingleInt16
-      OutOfLinePCRanges: [0xd03000..0xd03001]
+      OutOfLinePCRanges: [0xd03460..0xd03461]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 31 BaseType int16
           Locations:
-            - Range: 0xd03000..0xd03001
+            - Range: 0xd03460..0xd03461
               Pieces: [{Size: 2, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
     - ID: 25
       Name: main.testSingleInt32
-      OutOfLinePCRanges: [0xd03020..0xd03021]
+      OutOfLinePCRanges: [0xd03480..0xd03481]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 12 BaseType int32
           Locations:
-            - Range: 0xd03020..0xd03021
+            - Range: 0xd03480..0xd03481
               Pieces: [{Size: 4, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
     - ID: 26
       Name: main.testSingleInt64
-      OutOfLinePCRanges: [0xd03040..0xd03041]
+      OutOfLinePCRanges: [0xd034a0..0xd034a1]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 13 BaseType int64
           Locations:
-            - Range: 0xd03040..0xd03041
+            - Range: 0xd034a0..0xd034a1
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
     - ID: 27
       Name: main.testSingleUint
-      OutOfLinePCRanges: [0xd03060..0xd03061]
+      OutOfLinePCRanges: [0xd034c0..0xd034c1]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 15 BaseType uint
           Locations:
-            - Range: 0xd03060..0xd03061
+            - Range: 0xd034c0..0xd034c1
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
     - ID: 28
       Name: main.testSingleUint8
-      OutOfLinePCRanges: [0xd03080..0xd03081]
+      OutOfLinePCRanges: [0xd034e0..0xd034e1]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 3 BaseType uint8
           Locations:
-            - Range: 0xd03080..0xd03081
+            - Range: 0xd034e0..0xd034e1
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
     - ID: 29
       Name: main.testSingleUint16
-      OutOfLinePCRanges: [0xd030a0..0xd030a1]
+      OutOfLinePCRanges: [0xd03500..0xd03501]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 7 BaseType uint16
           Locations:
-            - Range: 0xd030a0..0xd030a1
+            - Range: 0xd03500..0xd03501
               Pieces: [{Size: 2, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
     - ID: 30
       Name: main.testSingleUint32
-      OutOfLinePCRanges: [0xd030c0..0xd030c1]
+      OutOfLinePCRanges: [0xd03520..0xd03521]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 2 BaseType uint32
           Locations:
-            - Range: 0xd030c0..0xd030c1
+            - Range: 0xd03520..0xd03521
               Pieces: [{Size: 4, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
     - ID: 31
       Name: main.testSingleUint64
-      OutOfLinePCRanges: [0xd030e0..0xd030e1]
+      OutOfLinePCRanges: [0xd03540..0xd03541]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 10 BaseType uint64
           Locations:
-            - Range: 0xd030e0..0xd030e1
+            - Range: 0xd03540..0xd03541
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
     - ID: 32
       Name: main.testSingleFloat32
-      OutOfLinePCRanges: [0xd03100..0xd03101]
+      OutOfLinePCRanges: [0xd03560..0xd03561]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 16 BaseType float32
           Locations:
-            - Range: 0xd03100..0xd03101
+            - Range: 0xd03560..0xd03561
               Pieces: [{Size: 4, Op: {RegNo: 17, Shift: 0}}]
           IsParameter: true
           IsReturn: false
     - ID: 33
       Name: main.testSingleFloat64
-      OutOfLinePCRanges: [0xd03120..0xd03121]
+      OutOfLinePCRanges: [0xd03580..0xd03581]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 17 BaseType float64
           Locations:
-            - Range: 0xd03120..0xd03121
+            - Range: 0xd03580..0xd03581
               Pieces: [{Size: 8, Op: {RegNo: 17, Shift: 0}}]
           IsParameter: true
           IsReturn: false
     - ID: 34
       Name: main.testTypeAlias
-      OutOfLinePCRanges: [0xd03140..0xd03141]
+      OutOfLinePCRanges: [0xd035a0..0xd035a1]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 51 BaseType main.typeAlias
           Locations:
-            - Range: 0xd03140..0xd03141
+            - Range: 0xd035a0..0xd035a1
               Pieces: [{Size: 2, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
     - ID: 35
       Name: main.testBigStruct
-      OutOfLinePCRanges: [0xd032a0..0xd032bf]
+      OutOfLinePCRanges: [0xd03700..0xd0371f]
       InlinePCRanges: []
       Variables:
         - Name: b
           Type: 52 StructureType main.bigStruct
           Locations:
-            - Range: 0xd032a0..0xd032bf
+            - Range: 0xd03700..0xd0371f
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -1906,14 +2042,116 @@ Subprograms:
           IsParameter: true
           IsReturn: false
     - ID: 36
+      Name: main.testDeepPtr1
+      OutOfLinePCRanges: [0xd037c0..0xd037c1]
+      InlinePCRanges: []
+      Variables:
+        - Name: a
+          Type: 56 StructureType main.deepPtr1
+          Locations:
+            - Range: 0xd037c0..0xd037c1
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+          IsParameter: true
+          IsReturn: false
+    - ID: 37
+      Name: main.testDeepPtr7
+      OutOfLinePCRanges: [0xd037e0..0xd037e1]
+      InlinePCRanges: []
+      Variables:
+        - Name: a
+          Type: 59 PointerType *main.deepPtr7
+          Locations:
+            - Range: 0xd037e0..0xd037e1
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+          IsParameter: true
+          IsReturn: false
+    - ID: 38
+      Name: main.testDeepSlice1
+      OutOfLinePCRanges: [0xd03960..0xd03961]
+      InlinePCRanges: []
+      Variables:
+        - Name: a
+          Type: 61 StructureType main.deepSlice1
+          Locations:
+            - Range: 0xd03960..0xd03961
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 0, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 3, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 2, Shift: 0}
+          IsParameter: true
+          IsReturn: false
+    - ID: 39
+      Name: main.testDeepSlice7
+      OutOfLinePCRanges: [0xd03980..0xd03981]
+      InlinePCRanges: []
+      Variables:
+        - Name: a
+          Type: 65 PointerType *main.deepSlice7
+          Locations:
+            - Range: 0xd03980..0xd03981
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+          IsParameter: true
+          IsReturn: false
+    - ID: 40
+      Name: main.testDeepMap1
+      OutOfLinePCRanges: [0xd03ae0..0xd03ae1]
+      InlinePCRanges: []
+      Variables:
+        - Name: a
+          Type: 67 StructureType main.deepMap1
+          Locations:
+            - Range: 0xd03ae0..0xd03ae1
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+          IsParameter: true
+          IsReturn: false
+    - ID: 41
+      Name: main.testDeepMap7
+      OutOfLinePCRanges: [0xd03b00..0xd03b01]
+      InlinePCRanges: []
+      Variables:
+        - Name: a
+          Type: 75 PointerType *main.deepMap7
+          Locations:
+            - Range: 0xd03b00..0xd03b01
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+          IsParameter: true
+          IsReturn: false
+    - ID: 42
+      Name: main.testStringType1
+      OutOfLinePCRanges: [0xd03b20..0xd03b21]
+      InlinePCRanges: []
+      Variables:
+        - Name: a
+          Type: 77 PointerType *main.stringType1
+          Locations:
+            - Range: 0xd03b20..0xd03b21
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+          IsParameter: true
+          IsReturn: false
+    - ID: 43
+      Name: main.testStringType2
+      OutOfLinePCRanges: [0xd03b40..0xd03b41]
+      InlinePCRanges: []
+      Variables:
+        - Name: a
+          Type: 79 PointerType **main.stringType2
+          Locations:
+            - Range: 0xd03b40..0xd03b41
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+          IsParameter: true
+          IsReturn: false
+    - ID: 44
       Name: main.testEsotericStack
-      OutOfLinePCRanges: [0xd03520..0xd03625]
+      OutOfLinePCRanges: [0xd03fa0..0xd040a5]
       InlinePCRanges: []
       Variables:
         - Name: e
-          Type: 56 StructureType main.esotericStack
+          Type: 81 StructureType main.esotericStack
           Locations:
-            - Range: 0xd03520..0xd03573
+            - Range: 0xd03fa0..0xd03ff3
               Pieces:
                 - Size: 4
                   Op: {RegNo: 0, Shift: 0}
@@ -1933,7 +2171,7 @@ Subprograms:
                   Op: {RegNo: 10, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 11, Shift: 0}
-            - Range: 0xd03573..0xd03578
+            - Range: 0xd03ff3..0xd03ff8
               Pieces:
                 - Size: 4
                   Op: null
@@ -1953,7 +2191,7 @@ Subprograms:
                   Op: {RegNo: 10, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 11, Shift: 0}
-            - Range: 0xd03578..0xd0357d
+            - Range: 0xd03ff8..0xd03ffd
               Pieces:
                 - Size: 4
                   Op: null
@@ -1975,146 +2213,146 @@ Subprograms:
                   Op: {RegNo: 11, Shift: 0}
           IsParameter: true
           IsReturn: false
-    - ID: 37
+    - ID: 45
       Name: main.testEsotericHeap
-      OutOfLinePCRanges: [0xd03640..0xd036a3]
+      OutOfLinePCRanges: [0xd040c0..0xd04123]
       InlinePCRanges: []
       Variables:
         - Name: e
-          Type: 61 PointerType *main.esotericHeap
+          Type: 86 PointerType *main.esotericHeap
           Locations:
-            - Range: 0xd03640..0xd0366d
+            - Range: 0xd040c0..0xd040ed
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 38
+    - ID: 46
       Name: main.testInlinedBA
-      OutOfLinePCRanges: [0xd03a80..0xd03b08]
+      OutOfLinePCRanges: [0xd04500..0xd04588]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 9 BaseType int
           Locations:
-            - Range: 0xd03a80..0xd03a95
+            - Range: 0xd04500..0xd04515
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 39
+    - ID: 47
       Name: main.testInlinedBB
-      OutOfLinePCRanges: [0xd03b20..0xd03be5]
+      OutOfLinePCRanges: [0xd045a0..0xd04665]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 9 BaseType int
           Locations:
-            - Range: 0xd03b20..0xd03b36
+            - Range: 0xd045a0..0xd045b6
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
         - Name: y
           Type: 9 BaseType int
           Locations:
-            - Range: 0xd03b20..0xd03b47
+            - Range: 0xd045a0..0xd045c7
               Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
           IsParameter: true
           IsReturn: false
         - Name: z
           Type: 9 BaseType int
           Locations:
-            - Range: 0xd03b36..0xd03b47
+            - Range: 0xd045b6..0xd045c7
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xd03b47..0xd03be5
+            - Range: 0xd045c7..0xd04665
               Pieces: [{Size: 8, Op: {CfaOffset: -56}}]
           IsParameter: false
           IsReturn: false
-    - ID: 40
+    - ID: 48
       Name: main.testInlinedBBA
-      OutOfLinePCRanges: [0xd03c00..0xd03c62]
+      OutOfLinePCRanges: [0xd04680..0xd046e2]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 9 BaseType int
           Locations:
-            - Range: 0xd03c00..0xd03c1a
+            - Range: 0xd04680..0xd0469a
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 41
+    - ID: 49
       Name: main.testInlinedBC
-      OutOfLinePCRanges: [0xd03c80..0xd03d8e]
+      OutOfLinePCRanges: [0xd04700..0xd0480e]
       InlinePCRanges: []
       Variables:
         - Name: s
           Type: 9 BaseType int
           Locations:
-            - Range: 0xd03cdb..0xd03ce5
+            - Range: 0xd0475b..0xd04765
               Pieces: [{Size: 8, Op: {CfaOffset: -80}}]
-            - Range: 0xd03ce5..0xd03d00
+            - Range: 0xd04765..0xd04780
               Pieces: [{Size: 8, Op: {CfaOffset: -80}}]
-            - Range: 0xd03d00..0xd03d14
+            - Range: 0xd04780..0xd04794
               Pieces: [{Size: 8, Op: {RegNo: 2, Shift: 0}}]
           IsParameter: false
           IsReturn: false
         - Name: i
           Type: 9 BaseType int
           Locations:
-            - Range: 0xd03cd6..0xd03ce0
+            - Range: 0xd04756..0xd04760
               Pieces: [{Size: 8, Op: {CfaOffset: -72}}]
-            - Range: 0xd03ce0..0xd03d00
+            - Range: 0xd04760..0xd04780
               Pieces: [{Size: 8, Op: {CfaOffset: -72}}]
-            - Range: 0xd03d00..0xd03d0f
+            - Range: 0xd04780..0xd0478f
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: false
           IsReturn: false
-    - ID: 42
+    - ID: 50
       Name: main.testFrameless
-      OutOfLinePCRanges: [0xd03da0..0xd03da6]
+      OutOfLinePCRanges: [0xd04820..0xd04826]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 9 BaseType int
           Locations:
-            - Range: 0xd03da0..0xd03da5
+            - Range: 0xd04820..0xd04825
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
         - Name: ~r0
           Type: 9 BaseType int
-          Locations: [{Range: 0xd03da0..0xd03da6, Pieces: []}]
+          Locations: [{Range: 0xd04820..0xd04826, Pieces: []}]
           IsParameter: true
           IsReturn: true
-    - ID: 43
+    - ID: 51
       Name: main.testFramelessArray
-      OutOfLinePCRanges: [0xd03dc0..0xd03e03]
+      OutOfLinePCRanges: [0xd04840..0xd04883]
       InlinePCRanges: []
       Variables:
         - Name: a
-          Type: 63 ArrayType [5]int
+          Type: 88 ArrayType [5]int
           Locations:
-            - Range: 0xd03dc0..0xd03e03
+            - Range: 0xd04840..0xd04883
               Pieces: [{Size: 40, Op: {CfaOffset: 0}}]
           IsParameter: true
           IsReturn: false
         - Name: ~r0
           Type: 9 BaseType int
-          Locations: [{Range: 0xd03dc0..0xd03e03, Pieces: []}]
+          Locations: [{Range: 0xd04840..0xd04883, Pieces: []}]
           IsParameter: true
           IsReturn: true
-    - ID: 44
+    - ID: 52
       Name: main.testInterface
-      OutOfLinePCRanges: [0xd040a0..0xd040e3]
+      OutOfLinePCRanges: [0xd04b20..0xd04b63]
       InlinePCRanges: []
       Variables:
         - Name: b
-          Type: 64 GoInterfaceType main.behavior
+          Type: 89 GoInterfaceType main.behavior
           Locations:
-            - Range: 0xd040a0..0xd040bf
+            - Range: 0xd04b20..0xd04b3f
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0xd040bf..0xd040c2
+            - Range: 0xd04b3f..0xd04b42
               Pieces:
                 - Size: 8
                   Op: null
@@ -2124,24 +2362,24 @@ Subprograms:
           IsReturn: false
         - Name: ~r0
           Type: 11 GoStringHeaderType string
-          Locations: [{Range: 0xd040a0..0xd040e3, Pieces: []}]
+          Locations: [{Range: 0xd04b20..0xd04b63, Pieces: []}]
           IsParameter: true
           IsReturn: true
-    - ID: 45
+    - ID: 53
       Name: main.testAny
-      OutOfLinePCRanges: [0xd04100..0xd04166]
+      OutOfLinePCRanges: [0xd04b80..0xd04be6]
       InlinePCRanges: []
       Variables:
         - Name: a
-          Type: 58 GoEmptyInterfaceType interface {}
+          Type: 83 GoEmptyInterfaceType interface {}
           Locations:
-            - Range: 0xd04100..0xd04129
+            - Range: 0xd04b80..0xd04ba9
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0xd04129..0xd0412e
+            - Range: 0xd04ba9..0xd04bae
               Pieces:
                 - Size: 8
                   Op: null
@@ -2151,18 +2389,18 @@ Subprograms:
           IsReturn: false
         - Name: ~r0
           Type: 11 GoStringHeaderType string
-          Locations: [{Range: 0xd04100..0xd04166, Pieces: []}]
+          Locations: [{Range: 0xd04b80..0xd04be6, Pieces: []}]
           IsParameter: true
           IsReturn: true
-    - ID: 46
+    - ID: 54
       Name: main.testError
-      OutOfLinePCRanges: [0xd04180..0xd04181]
+      OutOfLinePCRanges: [0xd04c00..0xd04c01]
       InlinePCRanges: []
       Variables:
         - Name: e
           Type: 18 GoInterfaceType error
           Locations:
-            - Range: 0xd04180..0xd04181
+            - Range: 0xd04c00..0xd04c01
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -2170,309 +2408,309 @@ Subprograms:
                   Op: {RegNo: 3, Shift: 0}
           IsParameter: true
           IsReturn: false
-    - ID: 47
+    - ID: 55
       Name: main.testStructWithMap
-      OutOfLinePCRanges: [0xd045e0..0xd045e1]
+      OutOfLinePCRanges: [0xd05060..0xd05061]
       InlinePCRanges: []
       Variables:
         - Name: s
-          Type: 65 StructureType main.structWithMap
+          Type: 90 StructureType main.structWithMap
           Locations:
-            - Range: 0xd045e0..0xd045e1
-              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-          IsParameter: true
-          IsReturn: false
-    - ID: 48
-      Name: main.testMapStringToStruct
-      OutOfLinePCRanges: [0xd04600..0xd04601]
-      InlinePCRanges: []
-      Variables:
-        - Name: m
-          Type: 73 GoMapType map[string]main.nestedStruct
-          Locations:
-            - Range: 0xd04600..0xd04601
-              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-          IsParameter: true
-          IsReturn: false
-    - ID: 49
-      Name: main.testMapStringToInt
-      OutOfLinePCRanges: [0xd04620..0xd04621]
-      InlinePCRanges: []
-      Variables:
-        - Name: m
-          Type: 78 GoMapType map[string]int
-          Locations:
-            - Range: 0xd04620..0xd04621
-              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-          IsParameter: true
-          IsReturn: false
-    - ID: 50
-      Name: main.testMapStringToSlice
-      OutOfLinePCRanges: [0xd04640..0xd04641]
-      InlinePCRanges: []
-      Variables:
-        - Name: m
-          Type: 83 GoMapType map[string][]string
-          Locations:
-            - Range: 0xd04640..0xd04641
-              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-          IsParameter: true
-          IsReturn: false
-    - ID: 51
-      Name: main.testMapArrayToArray
-      OutOfLinePCRanges: [0xd04660..0xd04661]
-      InlinePCRanges: []
-      Variables:
-        - Name: m
-          Type: 88 GoMapType map[[4]string][2]int
-          Locations:
-            - Range: 0xd04660..0xd04661
-              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-          IsParameter: true
-          IsReturn: false
-    - ID: 52
-      Name: main.testSmallMap
-      OutOfLinePCRanges: [0xd04680..0xd04681]
-      InlinePCRanges: []
-      Variables:
-        - Name: m
-          Type: 78 GoMapType map[string]int
-          Locations:
-            - Range: 0xd04680..0xd04681
-              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-          IsParameter: true
-          IsReturn: false
-    - ID: 53
-      Name: main.testArrayOfMaps
-      OutOfLinePCRanges: [0xd046a0..0xd046a1]
-      InlinePCRanges: []
-      Variables:
-        - Name: m
-          Type: 93 ArrayType [2]map[string]int
-          Locations:
-            - Range: 0xd046a0..0xd046a1
-              Pieces: [{Size: 16, Op: {CfaOffset: 0}}]
-          IsParameter: true
-          IsReturn: false
-    - ID: 54
-      Name: main.testPointerToMap
-      OutOfLinePCRanges: [0xd046c0..0xd046c1]
-      InlinePCRanges: []
-      Variables:
-        - Name: m
-          Type: 94 PointerType *map[string]int
-          Locations:
-            - Range: 0xd046c0..0xd046c1
-              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-          IsParameter: true
-          IsReturn: false
-    - ID: 55
-      Name: main.testMapIntToInt
-      OutOfLinePCRanges: [0xd046e0..0xd046e1]
-      InlinePCRanges: []
-      Variables:
-        - Name: m
-          Type: 66 GoMapType map[int]int
-          Locations:
-            - Range: 0xd046e0..0xd046e1
+            - Range: 0xd05060..0xd05061
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
     - ID: 56
-      Name: main.testMapMassive
-      OutOfLinePCRanges: [0xd04700..0xd04701]
+      Name: main.testMapStringToStruct
+      OutOfLinePCRanges: [0xd05080..0xd05081]
       InlinePCRanges: []
       Variables:
-        - Name: redactMyEntries
-          Type: 95 GoMapType map[string][]main.structWithMap
+        - Name: m
+          Type: 96 GoMapType map[string]main.nestedStruct
           Locations:
-            - Range: 0xd04700..0xd04701
+            - Range: 0xd05080..0xd05081
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
     - ID: 57
-      Name: main.testMapEmbeddedMaps
-      OutOfLinePCRanges: [0xd04720..0xd04721]
+      Name: main.testMapStringToInt
+      OutOfLinePCRanges: [0xd050a0..0xd050a1]
       InlinePCRanges: []
       Variables:
         - Name: m
-          Type: 95 GoMapType map[string][]main.structWithMap
+          Type: 101 GoMapType map[string]int
           Locations:
-            - Range: 0xd04720..0xd04721
+            - Range: 0xd050a0..0xd050a1
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
     - ID: 58
-      Name: main.testMapWithLinkedList
-      OutOfLinePCRanges: [0xd04740..0xd04741]
+      Name: main.testMapStringToSlice
+      OutOfLinePCRanges: [0xd050c0..0xd050c1]
       InlinePCRanges: []
       Variables:
         - Name: m
-          Type: 100 GoMapType map[bool]main.node
+          Type: 106 GoMapType map[string][]string
           Locations:
-            - Range: 0xd04740..0xd04741
+            - Range: 0xd050c0..0xd050c1
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
     - ID: 59
-      Name: main.testMapWithSmallValue
-      OutOfLinePCRanges: [0xd04760..0xd04761]
+      Name: main.testMapArrayToArray
+      OutOfLinePCRanges: [0xd050e0..0xd050e1]
       InlinePCRanges: []
       Variables:
         - Name: m
-          Type: 105 GoMapType map[int]uint8
+          Type: 111 GoMapType map[[4]string][2]int
           Locations:
-            - Range: 0xd04760..0xd04761
+            - Range: 0xd050e0..0xd050e1
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
     - ID: 60
-      Name: main.testMapWithSmallValueMassive
-      OutOfLinePCRanges: [0xd04780..0xd04781]
+      Name: main.testSmallMap
+      OutOfLinePCRanges: [0xd05100..0xd05101]
       InlinePCRanges: []
       Variables:
-        - Name: redactMyEntries
-          Type: 105 GoMapType map[int]uint8
+        - Name: m
+          Type: 101 GoMapType map[string]int
           Locations:
-            - Range: 0xd04780..0xd04781
+            - Range: 0xd05100..0xd05101
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
     - ID: 61
-      Name: main.testMapWithSmallKeyAndValue
-      OutOfLinePCRanges: [0xd047a0..0xd047a1]
+      Name: main.testArrayOfMaps
+      OutOfLinePCRanges: [0xd05120..0xd05121]
       InlinePCRanges: []
       Variables:
         - Name: m
-          Type: 110 GoMapType map[uint8]uint8
+          Type: 116 ArrayType [2]map[string]int
           Locations:
-            - Range: 0xd047a0..0xd047a1
-              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+            - Range: 0xd05120..0xd05121
+              Pieces: [{Size: 16, Op: {CfaOffset: 0}}]
           IsParameter: true
           IsReturn: false
     - ID: 62
-      Name: main.testMapWithSmallKeyAndValueMassive
-      OutOfLinePCRanges: [0xd047c0..0xd047c1]
+      Name: main.testPointerToMap
+      OutOfLinePCRanges: [0xd05140..0xd05141]
       InlinePCRanges: []
       Variables:
         - Name: m
-          Type: 110 GoMapType map[uint8]uint8
+          Type: 117 PointerType *map[string]int
           Locations:
-            - Range: 0xd047c0..0xd047c1
+            - Range: 0xd05140..0xd05141
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
     - ID: 63
-      Name: main.testMapSmallKeySmallValue
-      OutOfLinePCRanges: [0xd047e0..0xd047e1]
+      Name: main.testMapIntToInt
+      OutOfLinePCRanges: [0xd05160..0xd05161]
       InlinePCRanges: []
       Variables:
         - Name: m
-          Type: 110 GoMapType map[uint8]uint8
+          Type: 91 GoMapType map[int]int
           Locations:
-            - Range: 0xd047e0..0xd047e1
+            - Range: 0xd05160..0xd05161
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
     - ID: 64
-      Name: main.testMapSmallKeyLargeValue
-      OutOfLinePCRanges: [0xd04800..0xd04801]
+      Name: main.testMapMassive
+      OutOfLinePCRanges: [0xd05180..0xd05181]
       InlinePCRanges: []
       Variables:
-        - Name: m
-          Type: 115 GoMapType map[uint8][4]int
+        - Name: redactMyEntries
+          Type: 118 GoMapType map[string][]main.structWithMap
           Locations:
-            - Range: 0xd04800..0xd04801
+            - Range: 0xd05180..0xd05181
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
     - ID: 65
-      Name: main.testMapLargeKeySmallValue
-      OutOfLinePCRanges: [0xd04820..0xd04821]
+      Name: main.testMapEmbeddedMaps
+      OutOfLinePCRanges: [0xd051a0..0xd051a1]
       InlinePCRanges: []
       Variables:
         - Name: m
-          Type: 120 GoMapType map[[4]int]uint8
+          Type: 118 GoMapType map[string][]main.structWithMap
           Locations:
-            - Range: 0xd04820..0xd04821
+            - Range: 0xd051a0..0xd051a1
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
     - ID: 66
-      Name: main.testMapLargeKeyLargeValue
-      OutOfLinePCRanges: [0xd04840..0xd04841]
+      Name: main.testMapWithLinkedList
+      OutOfLinePCRanges: [0xd051c0..0xd051c1]
       InlinePCRanges: []
       Variables:
         - Name: m
-          Type: 125 GoMapType map[[4]int][4]int
+          Type: 123 GoMapType map[bool]main.node
           Locations:
-            - Range: 0xd04840..0xd04841
+            - Range: 0xd051c0..0xd051c1
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
     - ID: 67
+      Name: main.testMapWithSmallValue
+      OutOfLinePCRanges: [0xd051e0..0xd051e1]
+      InlinePCRanges: []
+      Variables:
+        - Name: m
+          Type: 128 GoMapType map[int]uint8
+          Locations:
+            - Range: 0xd051e0..0xd051e1
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+          IsParameter: true
+          IsReturn: false
+    - ID: 68
+      Name: main.testMapWithSmallValueMassive
+      OutOfLinePCRanges: [0xd05200..0xd05201]
+      InlinePCRanges: []
+      Variables:
+        - Name: redactMyEntries
+          Type: 128 GoMapType map[int]uint8
+          Locations:
+            - Range: 0xd05200..0xd05201
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+          IsParameter: true
+          IsReturn: false
+    - ID: 69
+      Name: main.testMapWithSmallKeyAndValue
+      OutOfLinePCRanges: [0xd05220..0xd05221]
+      InlinePCRanges: []
+      Variables:
+        - Name: m
+          Type: 133 GoMapType map[uint8]uint8
+          Locations:
+            - Range: 0xd05220..0xd05221
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+          IsParameter: true
+          IsReturn: false
+    - ID: 70
+      Name: main.testMapWithSmallKeyAndValueMassive
+      OutOfLinePCRanges: [0xd05240..0xd05241]
+      InlinePCRanges: []
+      Variables:
+        - Name: m
+          Type: 133 GoMapType map[uint8]uint8
+          Locations:
+            - Range: 0xd05240..0xd05241
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+          IsParameter: true
+          IsReturn: false
+    - ID: 71
+      Name: main.testMapSmallKeySmallValue
+      OutOfLinePCRanges: [0xd05260..0xd05261]
+      InlinePCRanges: []
+      Variables:
+        - Name: m
+          Type: 133 GoMapType map[uint8]uint8
+          Locations:
+            - Range: 0xd05260..0xd05261
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+          IsParameter: true
+          IsReturn: false
+    - ID: 72
+      Name: main.testMapSmallKeyLargeValue
+      OutOfLinePCRanges: [0xd05280..0xd05281]
+      InlinePCRanges: []
+      Variables:
+        - Name: m
+          Type: 138 GoMapType map[uint8][4]int
+          Locations:
+            - Range: 0xd05280..0xd05281
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+          IsParameter: true
+          IsReturn: false
+    - ID: 73
+      Name: main.testMapLargeKeySmallValue
+      OutOfLinePCRanges: [0xd052a0..0xd052a1]
+      InlinePCRanges: []
+      Variables:
+        - Name: m
+          Type: 143 GoMapType map[[4]int]uint8
+          Locations:
+            - Range: 0xd052a0..0xd052a1
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+          IsParameter: true
+          IsReturn: false
+    - ID: 74
+      Name: main.testMapLargeKeyLargeValue
+      OutOfLinePCRanges: [0xd052c0..0xd052c1]
+      InlinePCRanges: []
+      Variables:
+        - Name: m
+          Type: 148 GoMapType map[[4]int][4]int
+          Locations:
+            - Range: 0xd052c0..0xd052c1
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+          IsParameter: true
+          IsReturn: false
+    - ID: 75
       Name: main.testCombinedByte
-      OutOfLinePCRanges: [0xd05e00..0xd05e01]
+      OutOfLinePCRanges: [0xd06880..0xd06881]
       InlinePCRanges: []
       Variables:
         - Name: w
           Type: 3 BaseType uint8
           Locations:
-            - Range: 0xd05e00..0xd05e01
+            - Range: 0xd06880..0xd06881
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
         - Name: x
           Type: 3 BaseType uint8
           Locations:
-            - Range: 0xd05e00..0xd05e01
+            - Range: 0xd06880..0xd06881
               Pieces: [{Size: 1, Op: {RegNo: 3, Shift: 0}}]
           IsParameter: true
           IsReturn: false
         - Name: y
           Type: 16 BaseType float32
           Locations:
-            - Range: 0xd05e00..0xd05e01
+            - Range: 0xd06880..0xd06881
               Pieces: [{Size: 4, Op: {RegNo: 17, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 68
+    - ID: 76
       Name: main.testMultipleSimpleParams
-      OutOfLinePCRanges: [0xd05fc0..0xd05fc1]
+      OutOfLinePCRanges: [0xd06a40..0xd06a41]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 4 BaseType bool
           Locations:
-            - Range: 0xd05fc0..0xd05fc1
+            - Range: 0xd06a40..0xd06a41
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
         - Name: b
           Type: 3 BaseType uint8
           Locations:
-            - Range: 0xd05fc0..0xd05fc1
+            - Range: 0xd06a40..0xd06a41
               Pieces: [{Size: 1, Op: {RegNo: 3, Shift: 0}}]
           IsParameter: true
           IsReturn: false
         - Name: c
           Type: 12 BaseType int32
           Locations:
-            - Range: 0xd05fc0..0xd05fc1
+            - Range: 0xd06a40..0xd06a41
               Pieces: [{Size: 4, Op: {RegNo: 2, Shift: 0}}]
           IsParameter: true
           IsReturn: false
         - Name: d
           Type: 15 BaseType uint
           Locations:
-            - Range: 0xd05fc0..0xd05fc1
+            - Range: 0xd06a40..0xd06a41
               Pieces: [{Size: 8, Op: {RegNo: 5, Shift: 0}}]
           IsParameter: true
           IsReturn: false
         - Name: e
           Type: 11 GoStringHeaderType string
           Locations:
-            - Range: 0xd05fc0..0xd05fc1
+            - Range: 0xd06a40..0xd06a41
               Pieces:
                 - Size: 8
                   Op: {RegNo: 4, Shift: 0}
@@ -2480,39 +2718,39 @@ Subprograms:
                   Op: {RegNo: 8, Shift: 0}
           IsParameter: true
           IsReturn: false
-    - ID: 69
+    - ID: 77
       Name: main.testChannel
-      OutOfLinePCRanges: [0xd061e0..0xd061e1]
+      OutOfLinePCRanges: [0xd06c60..0xd06c61]
       InlinePCRanges: []
       Variables:
         - Name: c
-          Type: 130 GoChannelType chan bool
+          Type: 153 GoChannelType chan bool
           Locations:
-            - Range: 0xd061e0..0xd061e1
+            - Range: 0xd06c60..0xd06c61
               Pieces: [{Size: 0, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 70
+    - ID: 78
       Name: main.testPointerToSimpleStruct
-      OutOfLinePCRanges: [0xd063a0..0xd063a1]
+      OutOfLinePCRanges: [0xd06e20..0xd06e21]
       InlinePCRanges: []
       Variables:
         - Name: a
-          Type: 131 PointerType *main.structWithTwoValues
+          Type: 154 PointerType *main.structWithTwoValues
           Locations:
-            - Range: 0xd063a0..0xd063a1
+            - Range: 0xd06e20..0xd06e21
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 71
+    - ID: 79
       Name: main.testLinkedList
-      OutOfLinePCRanges: [0xd063c0..0xd063c1]
+      OutOfLinePCRanges: [0xd06e40..0xd06e41]
       InlinePCRanges: []
       Variables:
         - Name: a
-          Type: 133 StructureType main.node
+          Type: 156 StructureType main.node
           Locations:
-            - Range: 0xd063c0..0xd063c1
+            - Range: 0xd06e40..0xd06e41
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -2520,273 +2758,94 @@ Subprograms:
                   Op: {RegNo: 3, Shift: 0}
           IsParameter: true
           IsReturn: false
-    - ID: 72
+    - ID: 80
       Name: main.testPointerLoop
-      OutOfLinePCRanges: [0xd063e0..0xd063e1]
+      OutOfLinePCRanges: [0xd06e60..0xd06e61]
       InlinePCRanges: []
       Variables:
         - Name: a
-          Type: 134 PointerType *main.node
+          Type: 157 PointerType *main.node
           Locations:
-            - Range: 0xd063e0..0xd063e1
+            - Range: 0xd06e60..0xd06e61
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 73
+    - ID: 81
       Name: main.testUnsafePointer
-      OutOfLinePCRanges: [0xd06400..0xd06401]
+      OutOfLinePCRanges: [0xd06e80..0xd06e81]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 19 VoidPointerType unsafe.Pointer
           Locations:
-            - Range: 0xd06400..0xd06401
+            - Range: 0xd06e80..0xd06e81
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 74
+    - ID: 82
       Name: main.testUintPointer
-      OutOfLinePCRanges: [0xd06440..0xd06441]
+      OutOfLinePCRanges: [0xd06ec0..0xd06ec1]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 34 PointerType *uint
           Locations:
-            - Range: 0xd06440..0xd06441
+            - Range: 0xd06ec0..0xd06ec1
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 75
+    - ID: 83
       Name: main.testStringPointer
-      OutOfLinePCRanges: [0xd06520..0xd06521]
+      OutOfLinePCRanges: [0xd06fa0..0xd06fa1]
       InlinePCRanges: []
       Variables:
         - Name: z
           Type: 22 PointerType *string
           Locations:
-            - Range: 0xd06520..0xd06521
+            - Range: 0xd06fa0..0xd06fa1
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 76
+    - ID: 84
       Name: main.testNilPointer
-      OutOfLinePCRanges: [0xd06560..0xd06561]
+      OutOfLinePCRanges: [0xd06fe0..0xd06fe1]
       InlinePCRanges: []
       Variables:
         - Name: z
           Type: 5 PointerType *bool
           Locations:
-            - Range: 0xd06560..0xd06561
+            - Range: 0xd06fe0..0xd06fe1
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
         - Name: a
           Type: 15 BaseType uint
           Locations:
-            - Range: 0xd06560..0xd06561
+            - Range: 0xd06fe0..0xd06fe1
               Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 77
+    - ID: 85
       Name: main.testCycle
-      OutOfLinePCRanges: [0xd065a0..0xd065a1]
+      OutOfLinePCRanges: [0xd07020..0xd07021]
       InlinePCRanges: []
       Variables:
         - Name: t
-          Type: 135 PointerType *main.t
+          Type: 158 PointerType *main.t
           Locations:
-            - Range: 0xd065a0..0xd065a1
+            - Range: 0xd07020..0xd07021
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 78
-      Name: main.testUintSlice
-      OutOfLinePCRanges: [0xd06ac0..0xd06ac1]
-      InlinePCRanges: []
-      Variables:
-        - Name: u
-          Type: 137 GoSliceHeaderType []uint
-          Locations:
-            - Range: 0xd06ac0..0xd06ac1
-              Pieces:
-                - Size: 8
-                  Op: {RegNo: 0, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 3, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 2, Shift: 0}
-          IsParameter: true
-          IsReturn: false
-    - ID: 79
-      Name: main.testEmptySlice
-      OutOfLinePCRanges: [0xd06ae0..0xd06ae1]
-      InlinePCRanges: []
-      Variables:
-        - Name: u
-          Type: 137 GoSliceHeaderType []uint
-          Locations:
-            - Range: 0xd06ae0..0xd06ae1
-              Pieces:
-                - Size: 8
-                  Op: {RegNo: 0, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 3, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 2, Shift: 0}
-          IsParameter: true
-          IsReturn: false
-    - ID: 80
-      Name: main.testSliceOfSlices
-      OutOfLinePCRanges: [0xd06b00..0xd06b01]
-      InlinePCRanges: []
-      Variables:
-        - Name: u
-          Type: 138 GoSliceHeaderType [][]uint
-          Locations:
-            - Range: 0xd06b00..0xd06b01
-              Pieces:
-                - Size: 8
-                  Op: {RegNo: 0, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 3, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 2, Shift: 0}
-          IsParameter: true
-          IsReturn: false
-    - ID: 81
-      Name: main.testStructSlice
-      OutOfLinePCRanges: [0xd06b20..0xd06b21]
-      InlinePCRanges: []
-      Variables:
-        - Name: xs
-          Type: 140 GoSliceHeaderType []main.structWithNoStrings
-          Locations:
-            - Range: 0xd06b20..0xd06b21
-              Pieces:
-                - Size: 8
-                  Op: {RegNo: 0, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 3, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 2, Shift: 0}
-          IsParameter: true
-          IsReturn: false
-        - Name: a
-          Type: 9 BaseType int
-          Locations:
-            - Range: 0xd06b20..0xd06b21
-              Pieces: [{Size: 8, Op: {RegNo: 5, Shift: 0}}]
-          IsParameter: true
-          IsReturn: false
-    - ID: 82
-      Name: main.testEmptySliceOfStructs
-      OutOfLinePCRanges: [0xd06b40..0xd06b41]
-      InlinePCRanges: []
-      Variables:
-        - Name: xs
-          Type: 140 GoSliceHeaderType []main.structWithNoStrings
-          Locations:
-            - Range: 0xd06b40..0xd06b41
-              Pieces:
-                - Size: 8
-                  Op: {RegNo: 0, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 3, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 2, Shift: 0}
-          IsParameter: true
-          IsReturn: false
-        - Name: a
-          Type: 9 BaseType int
-          Locations:
-            - Range: 0xd06b40..0xd06b41
-              Pieces: [{Size: 8, Op: {RegNo: 5, Shift: 0}}]
-          IsParameter: true
-          IsReturn: false
-    - ID: 83
-      Name: main.testNilSliceOfStructs
-      OutOfLinePCRanges: [0xd06b60..0xd06b61]
-      InlinePCRanges: []
-      Variables:
-        - Name: xs
-          Type: 140 GoSliceHeaderType []main.structWithNoStrings
-          Locations:
-            - Range: 0xd06b60..0xd06b61
-              Pieces:
-                - Size: 8
-                  Op: {RegNo: 0, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 3, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 2, Shift: 0}
-          IsParameter: true
-          IsReturn: false
-        - Name: a
-          Type: 9 BaseType int
-          Locations:
-            - Range: 0xd06b60..0xd06b61
-              Pieces: [{Size: 8, Op: {RegNo: 5, Shift: 0}}]
-          IsParameter: true
-          IsReturn: false
-    - ID: 84
-      Name: main.testStringSlice
-      OutOfLinePCRanges: [0xd06b80..0xd06b81]
-      InlinePCRanges: []
-      Variables:
-        - Name: s
-          Type: 143 GoSliceHeaderType []string
-          Locations:
-            - Range: 0xd06b80..0xd06b81
-              Pieces:
-                - Size: 8
-                  Op: {RegNo: 0, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 3, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 2, Shift: 0}
-          IsParameter: true
-          IsReturn: false
-    - ID: 85
-      Name: main.testNilSliceWithOtherParams
-      OutOfLinePCRanges: [0xd06ba0..0xd06ba1]
-      InlinePCRanges: []
-      Variables:
-        - Name: a
-          Type: 14 BaseType int8
-          Locations:
-            - Range: 0xd06ba0..0xd06ba1
-              Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
-          IsParameter: true
-          IsReturn: false
-        - Name: s
-          Type: 144 GoSliceHeaderType []bool
-          Locations:
-            - Range: 0xd06ba0..0xd06ba1
-              Pieces:
-                - Size: 8
-                  Op: {RegNo: 3, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 2, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 5, Shift: 0}
-          IsParameter: true
-          IsReturn: false
-        - Name: x
-          Type: 15 BaseType uint
-          Locations:
-            - Range: 0xd06ba0..0xd06ba1
-              Pieces: [{Size: 8, Op: {RegNo: 4, Shift: 0}}]
-          IsParameter: true
-          IsReturn: false
     - ID: 86
-      Name: main.testNilSlice
-      OutOfLinePCRanges: [0xd06bc0..0xd06bc1]
+      Name: main.testUintSlice
+      OutOfLinePCRanges: [0xd07540..0xd07541]
       InlinePCRanges: []
       Variables:
-        - Name: xs
-          Type: 145 GoSliceHeaderType []uint16
+        - Name: u
+          Type: 160 GoSliceHeaderType []uint
           Locations:
-            - Range: 0xd06bc0..0xd06bc1
+            - Range: 0xd07540..0xd07541
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -2797,14 +2856,14 @@ Subprograms:
           IsParameter: true
           IsReturn: false
     - ID: 87
-      Name: main.testVeryLargeSlice
-      OutOfLinePCRanges: [0xd06be0..0xd06be1]
+      Name: main.testEmptySlice
+      OutOfLinePCRanges: [0xd07560..0xd07561]
       InlinePCRanges: []
       Variables:
-        - Name: xs
-          Type: 137 GoSliceHeaderType []uint
+        - Name: u
+          Type: 160 GoSliceHeaderType []uint
           Locations:
-            - Range: 0xd06be0..0xd06be1
+            - Range: 0xd07560..0xd07561
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -2815,24 +2874,203 @@ Subprograms:
           IsParameter: true
           IsReturn: false
     - ID: 88
+      Name: main.testSliceOfSlices
+      OutOfLinePCRanges: [0xd07580..0xd07581]
+      InlinePCRanges: []
+      Variables:
+        - Name: u
+          Type: 161 GoSliceHeaderType [][]uint
+          Locations:
+            - Range: 0xd07580..0xd07581
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 0, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 3, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 2, Shift: 0}
+          IsParameter: true
+          IsReturn: false
+    - ID: 89
+      Name: main.testStructSlice
+      OutOfLinePCRanges: [0xd075a0..0xd075a1]
+      InlinePCRanges: []
+      Variables:
+        - Name: xs
+          Type: 163 GoSliceHeaderType []main.structWithNoStrings
+          Locations:
+            - Range: 0xd075a0..0xd075a1
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 0, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 3, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 2, Shift: 0}
+          IsParameter: true
+          IsReturn: false
+        - Name: a
+          Type: 9 BaseType int
+          Locations:
+            - Range: 0xd075a0..0xd075a1
+              Pieces: [{Size: 8, Op: {RegNo: 5, Shift: 0}}]
+          IsParameter: true
+          IsReturn: false
+    - ID: 90
+      Name: main.testEmptySliceOfStructs
+      OutOfLinePCRanges: [0xd075c0..0xd075c1]
+      InlinePCRanges: []
+      Variables:
+        - Name: xs
+          Type: 163 GoSliceHeaderType []main.structWithNoStrings
+          Locations:
+            - Range: 0xd075c0..0xd075c1
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 0, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 3, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 2, Shift: 0}
+          IsParameter: true
+          IsReturn: false
+        - Name: a
+          Type: 9 BaseType int
+          Locations:
+            - Range: 0xd075c0..0xd075c1
+              Pieces: [{Size: 8, Op: {RegNo: 5, Shift: 0}}]
+          IsParameter: true
+          IsReturn: false
+    - ID: 91
+      Name: main.testNilSliceOfStructs
+      OutOfLinePCRanges: [0xd075e0..0xd075e1]
+      InlinePCRanges: []
+      Variables:
+        - Name: xs
+          Type: 163 GoSliceHeaderType []main.structWithNoStrings
+          Locations:
+            - Range: 0xd075e0..0xd075e1
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 0, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 3, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 2, Shift: 0}
+          IsParameter: true
+          IsReturn: false
+        - Name: a
+          Type: 9 BaseType int
+          Locations:
+            - Range: 0xd075e0..0xd075e1
+              Pieces: [{Size: 8, Op: {RegNo: 5, Shift: 0}}]
+          IsParameter: true
+          IsReturn: false
+    - ID: 92
+      Name: main.testStringSlice
+      OutOfLinePCRanges: [0xd07600..0xd07601]
+      InlinePCRanges: []
+      Variables:
+        - Name: s
+          Type: 166 GoSliceHeaderType []string
+          Locations:
+            - Range: 0xd07600..0xd07601
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 0, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 3, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 2, Shift: 0}
+          IsParameter: true
+          IsReturn: false
+    - ID: 93
+      Name: main.testNilSliceWithOtherParams
+      OutOfLinePCRanges: [0xd07620..0xd07621]
+      InlinePCRanges: []
+      Variables:
+        - Name: a
+          Type: 14 BaseType int8
+          Locations:
+            - Range: 0xd07620..0xd07621
+              Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
+          IsParameter: true
+          IsReturn: false
+        - Name: s
+          Type: 167 GoSliceHeaderType []bool
+          Locations:
+            - Range: 0xd07620..0xd07621
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 3, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 2, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 5, Shift: 0}
+          IsParameter: true
+          IsReturn: false
+        - Name: x
+          Type: 15 BaseType uint
+          Locations:
+            - Range: 0xd07620..0xd07621
+              Pieces: [{Size: 8, Op: {RegNo: 4, Shift: 0}}]
+          IsParameter: true
+          IsReturn: false
+    - ID: 94
+      Name: main.testNilSlice
+      OutOfLinePCRanges: [0xd07640..0xd07641]
+      InlinePCRanges: []
+      Variables:
+        - Name: xs
+          Type: 168 GoSliceHeaderType []uint16
+          Locations:
+            - Range: 0xd07640..0xd07641
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 0, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 3, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 2, Shift: 0}
+          IsParameter: true
+          IsReturn: false
+    - ID: 95
+      Name: main.testVeryLargeSlice
+      OutOfLinePCRanges: [0xd07660..0xd07661]
+      InlinePCRanges: []
+      Variables:
+        - Name: xs
+          Type: 160 GoSliceHeaderType []uint
+          Locations:
+            - Range: 0xd07660..0xd07661
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 0, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 3, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 2, Shift: 0}
+          IsParameter: true
+          IsReturn: false
+    - ID: 96
       Name: main.stackC
-      OutOfLinePCRanges: [0xd06f20..0xd06f72]
+      OutOfLinePCRanges: [0xd079a0..0xd079f2]
       InlinePCRanges: []
       Variables:
         - Name: ~r0
           Type: 11 GoStringHeaderType string
-          Locations: [{Range: 0xd06f20..0xd06f72, Pieces: []}]
+          Locations: [{Range: 0xd079a0..0xd079f2, Pieces: []}]
           IsParameter: true
           IsReturn: true
-    - ID: 89
+    - ID: 97
       Name: main.testSingleString
-      OutOfLinePCRanges: [0xd06f80..0xd06f81]
+      OutOfLinePCRanges: [0xd07a00..0xd07a01]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 11 GoStringHeaderType string
           Locations:
-            - Range: 0xd06f80..0xd06f81
+            - Range: 0xd07a00..0xd07a01
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -2840,15 +3078,15 @@ Subprograms:
                   Op: {RegNo: 3, Shift: 0}
           IsParameter: true
           IsReturn: false
-    - ID: 90
+    - ID: 98
       Name: main.testThreeStrings
-      OutOfLinePCRanges: [0xd06fa0..0xd06fa1]
+      OutOfLinePCRanges: [0xd07a20..0xd07a21]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 11 GoStringHeaderType string
           Locations:
-            - Range: 0xd06fa0..0xd06fa1
+            - Range: 0xd07a20..0xd07a21
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -2859,7 +3097,7 @@ Subprograms:
         - Name: y
           Type: 11 GoStringHeaderType string
           Locations:
-            - Range: 0xd06fa0..0xd06fa1
+            - Range: 0xd07a20..0xd07a21
               Pieces:
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
@@ -2870,7 +3108,7 @@ Subprograms:
         - Name: z
           Type: 11 GoStringHeaderType string
           Locations:
-            - Range: 0xd06fa0..0xd06fa1
+            - Range: 0xd07a20..0xd07a21
               Pieces:
                 - Size: 8
                   Op: {RegNo: 4, Shift: 0}
@@ -2878,15 +3116,15 @@ Subprograms:
                   Op: {RegNo: 8, Shift: 0}
           IsParameter: true
           IsReturn: false
-    - ID: 91
+    - ID: 99
       Name: main.testThreeStringsInStruct
-      OutOfLinePCRanges: [0xd06fc0..0xd06fdf]
+      OutOfLinePCRanges: [0xd07a40..0xd07a5f]
       InlinePCRanges: []
       Variables:
         - Name: a
-          Type: 146 StructureType main.threeStringStruct
+          Type: 169 StructureType main.threeStringStruct
           Locations:
-            - Range: 0xd06fc0..0xd06fdf
+            - Range: 0xd07a40..0xd07a5f
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -2902,39 +3140,39 @@ Subprograms:
                   Op: {RegNo: 8, Shift: 0}
           IsParameter: true
           IsReturn: false
-    - ID: 92
+    - ID: 100
       Name: main.testThreeStringsInStructPointer
-      OutOfLinePCRanges: [0xd06fe0..0xd06fe1]
+      OutOfLinePCRanges: [0xd07a60..0xd07a61]
       InlinePCRanges: []
       Variables:
         - Name: a
-          Type: 147 PointerType *main.threeStringStruct
+          Type: 170 PointerType *main.threeStringStruct
           Locations:
-            - Range: 0xd06fe0..0xd06fe1
+            - Range: 0xd07a60..0xd07a61
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 93
+    - ID: 101
       Name: main.testOneStringInStructPointer
-      OutOfLinePCRanges: [0xd07000..0xd07001]
+      OutOfLinePCRanges: [0xd07a80..0xd07a81]
       InlinePCRanges: []
       Variables:
         - Name: a
-          Type: 148 PointerType *main.oneStringStruct
+          Type: 171 PointerType *main.oneStringStruct
           Locations:
-            - Range: 0xd07000..0xd07001
+            - Range: 0xd07a80..0xd07a81
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 94
+    - ID: 102
       Name: main.testMassiveString
-      OutOfLinePCRanges: [0xd07020..0xd07021]
+      OutOfLinePCRanges: [0xd07aa0..0xd07aa1]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 11 GoStringHeaderType string
           Locations:
-            - Range: 0xd07020..0xd07021
+            - Range: 0xd07aa0..0xd07aa1
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -2942,15 +3180,15 @@ Subprograms:
                   Op: {RegNo: 3, Shift: 0}
           IsParameter: true
           IsReturn: false
-    - ID: 95
+    - ID: 103
       Name: main.testUnitializedString
-      OutOfLinePCRanges: [0xd07040..0xd07041]
+      OutOfLinePCRanges: [0xd07ac0..0xd07ac1]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 11 GoStringHeaderType string
           Locations:
-            - Range: 0xd07040..0xd07041
+            - Range: 0xd07ac0..0xd07ac1
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -2958,15 +3196,15 @@ Subprograms:
                   Op: {RegNo: 3, Shift: 0}
           IsParameter: true
           IsReturn: false
-    - ID: 96
+    - ID: 104
       Name: main.testEmptyString
-      OutOfLinePCRanges: [0xd07060..0xd07061]
+      OutOfLinePCRanges: [0xd07ae0..0xd07ae1]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 11 GoStringHeaderType string
           Locations:
-            - Range: 0xd07060..0xd07061
+            - Range: 0xd07ae0..0xd07ae1
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -2974,15 +3212,15 @@ Subprograms:
                   Op: {RegNo: 3, Shift: 0}
           IsParameter: true
           IsReturn: false
-    - ID: 97
+    - ID: 105
       Name: main.testStruct
-      OutOfLinePCRanges: [0xd072e0..0xd07303]
+      OutOfLinePCRanges: [0xd07d60..0xd07d83]
       InlinePCRanges: []
       Variables:
         - Name: x
-          Type: 150 StructureType main.aStruct
+          Type: 173 StructureType main.aStruct
           Locations:
-            - Range: 0xd072e0..0xd07303
+            - Range: 0xd07d60..0xd07d83
               Pieces:
                 - Size: 1
                   Op: {RegNo: 0, Shift: 0}
@@ -3000,467 +3238,697 @@ Subprograms:
                   Op: {RegNo: 9, Shift: 0}
           IsParameter: true
           IsReturn: false
-    - ID: 98
+    - ID: 106
       Name: main.testEmptyStruct
-      OutOfLinePCRanges: [0xd07460..0xd07461]
+      OutOfLinePCRanges: [0xd07ee0..0xd07ee1]
       InlinePCRanges: []
       Variables:
         - Name: e
-          Type: 152 StructureType main.emptyStruct
-          Locations: [{Range: 0xd07460..0xd07461, Pieces: []}]
+          Type: 175 StructureType main.emptyStruct
+          Locations: [{Range: 0xd07ee0..0xd07ee1, Pieces: []}]
           IsParameter: true
           IsReturn: false
-    - ID: 99
+    - ID: 107
       Name: main.testInlinedPrint
-      OutOfLinePCRanges: [0xd038e0..0xd03942]
+      OutOfLinePCRanges: [0xd04360..0xd043c2]
       InlinePCRanges:
-        - Ranges: [0xd03971..0xd039ad]
-          RootRanges: [0xd03960..0xd039d1]
-        - Ranges: [0xd03ab2..0xd03aee]
-          RootRanges: [0xd03a80..0xd03b08]
-        - Ranges: [0xd03b3c..0xd03b78]
-          RootRanges: [0xd03b20..0xd03be5]
-        - Ranges: [0xd03c0f..0xd03c4b]
-          RootRanges: [0xd03c00..0xd03c62]
+        - Ranges: [0xd043f1..0xd0442d]
+          RootRanges: [0xd043e0..0xd04451]
+        - Ranges: [0xd04532..0xd0456e]
+          RootRanges: [0xd04500..0xd04588]
+        - Ranges: [0xd045bc..0xd045f8]
+          RootRanges: [0xd045a0..0xd04665]
+        - Ranges: [0xd0468f..0xd046cb]
+          RootRanges: [0xd04680..0xd046e2]
       Variables:
         - Name: x
           Type: 9 BaseType int
           Locations:
-            - Range: 0xd038e0..0xd038f9
+            - Range: 0xd04360..0xd04379
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xd03971..0xd0397c
+            - Range: 0xd043f1..0xd043fc
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xd03ab2..0xd03abd
+            - Range: 0xd04532..0xd0453d
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xd03b36..0xd03b47
+            - Range: 0xd045b6..0xd045c7
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xd03b47..0xd03be5
+            - Range: 0xd045c7..0xd04665
               Pieces: [{Size: 8, Op: {CfaOffset: -56}}]
-            - Range: 0xd03c00..0xd03c1a
+            - Range: 0xd04680..0xd0469a
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 100
+    - ID: 108
       Name: main.testInlinedBBB
       OutOfLinePCRanges: []
       InlinePCRanges:
-        - Ranges: [0xd03b86..0xd03bbe]
-          RootRanges: [0xd03b20..0xd03be5]
+        - Ranges: [0xd04606..0xd0463e]
+          RootRanges: [0xd045a0..0xd04665]
       Variables: []
-    - ID: 101
+    - ID: 109
       Name: main.testInlinedBCA
       OutOfLinePCRanges: []
       InlinePCRanges:
-        - Ranges: [0xd03c93..0xd03cd1]
-          RootRanges: [0xd03c80..0xd03d8e]
+        - Ranges: [0xd04713..0xd04751]
+          RootRanges: [0xd04700..0xd0480e]
       Variables: []
-    - ID: 102
+    - ID: 110
       Name: main.testInlinedBCB
       OutOfLinePCRanges: []
       InlinePCRanges:
-        - Ranges: [0xd03d46..0xd03d7e]
-          RootRanges: [0xd03c80..0xd03d8e]
+        - Ranges: [0xd047c6..0xd047fe]
+          RootRanges: [0xd04700..0xd0480e]
       Variables: []
-    - ID: 103
+    - ID: 111
       Name: main.testInlinedSq
       OutOfLinePCRanges: []
       InlinePCRanges:
-        - Ranges: [0xd03da1..0xd03da5]
-          RootRanges: [0xd03da0..0xd03da6]
+        - Ranges: [0xd04821..0xd04825]
+          RootRanges: [0xd04820..0xd04826]
       Variables:
         - Name: x
           Type: 9 BaseType int
           Locations:
-            - Range: 0xd03da0..0xd03da5
+            - Range: 0xd04820..0xd04825
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 104
+    - ID: 112
       Name: main.testInlinedSumArray
       OutOfLinePCRanges: []
       InlinePCRanges:
-        - Ranges: [0xd03de5..0xd03dfd]
-          RootRanges: [0xd03dc0..0xd03e03]
-        - Ranges: [0xd03e85..0xd03ea3]
-          RootRanges: [0xd03e20..0xd03fa5]
+        - Ranges: [0xd04865..0xd0487d]
+          RootRanges: [0xd04840..0xd04883]
+        - Ranges: [0xd04905..0xd04923]
+          RootRanges: [0xd048a0..0xd04a25]
       Variables:
         - Name: a
-          Type: 63 ArrayType [5]int
+          Type: 88 ArrayType [5]int
           Locations:
-            - Range: 0xd03dcd..0xd03e03
+            - Range: 0xd0484d..0xd04883
               Pieces: [{Size: 40, Op: {CfaOffset: -56}}]
-            - Range: 0xd03e6c..0xd03fa5
+            - Range: 0xd048ec..0xd04a25
               Pieces: [{Size: 40, Op: {CfaOffset: -128}}]
           IsParameter: true
           IsReturn: false
 Types:
     - __kind: PointerType
-      ID: 209
+      ID: 63
+      Name: '**main.deepSlice2'
+      ByteSize: 8
+      Pointee: 64 PointerType *main.deepSlice2
+    - __kind: PointerType
+      ID: 236
+      Name: '**main.deepSlice3'
+      ByteSize: 8
+      Pointee: 237 PointerType *main.deepSlice3
+    - __kind: PointerType
+      ID: 255
+      Name: '**main.deepSlice8'
+      ByteSize: 8
+      Pointee: 256 PointerType *main.deepSlice8
+    - __kind: PointerType
+      ID: 261
+      Name: '**main.deepSlice9'
+      ByteSize: 8
+      Pointee: 262 PointerType *main.deepSlice9
+    - __kind: PointerType
+      ID: 79
+      Name: '**main.stringType2'
+      ByteSize: 8
+      GoKind: 22
+      Pointee: 80 PointerType *main.stringType2
+    - __kind: PointerType
+      ID: 304
       Name: '**main.t'
       ByteSize: 8
-      Pointee: 135 PointerType *main.t
+      Pointee: 158 PointerType *main.t
     - __kind: PointerType
       ID: 54
       Name: '**string'
       ByteSize: 8
-      GoRuntimeType: 486016
+      GoRuntimeType: 490208
       GoKind: 22
       Pointee: 22 PointerType *string
     - __kind: PointerType
-      ID: 156
+      ID: 182
+      Name: '*[]*main.deepSlice2.array'
+      ByteSize: 8
+      Pointee: 181 GoSliceDataType []*main.deepSlice2.array
+    - __kind: PointerType
+      ID: 240
+      Name: '*[]*main.deepSlice3.array'
+      ByteSize: 8
+      Pointee: 239 GoSliceDataType []*main.deepSlice3.array
+    - __kind: PointerType
+      ID: 259
+      Name: '*[]*main.deepSlice8.array'
+      ByteSize: 8
+      Pointee: 258 GoSliceDataType []*main.deepSlice8.array
+    - __kind: PointerType
+      ID: 265
+      Name: '*[]*main.deepSlice9.array'
+      ByteSize: 8
+      Pointee: 264 GoSliceDataType []*main.deepSlice9.array
+    - __kind: PointerType
+      ID: 179
       Name: '*[]*string.array'
       ByteSize: 8
-      Pointee: 155 GoSliceDataType []*string.array
+      Pointee: 178 GoSliceDataType []*string.array
     - __kind: PointerType
-      ID: 191
+      ID: 221
       Name: '*[][]uint.array'
       ByteSize: 8
-      Pointee: 190 GoSliceDataType [][]uint.array
+      Pointee: 220 GoSliceDataType [][]uint.array
     - __kind: PointerType
-      ID: 197
+      ID: 227
       Name: '*[]bool.array'
       ByteSize: 8
-      Pointee: 196 GoSliceDataType []bool.array
+      Pointee: 226 GoSliceDataType []bool.array
     - __kind: PointerType
-      ID: 213
+      ID: 269
+      Name: '*[]interface {}.array'
+      ByteSize: 8
+      Pointee: 268 GoSliceDataType []interface {}.array
+    - __kind: PointerType
+      ID: 308
       Name: '*[]main.structWithMap.array'
       ByteSize: 8
-      Pointee: 212 GoSliceDataType []main.structWithMap.array
+      Pointee: 307 GoSliceDataType []main.structWithMap.array
     - __kind: PointerType
-      ID: 193
+      ID: 223
       Name: '*[]main.structWithNoStrings.array'
       ByteSize: 8
-      Pointee: 192 GoSliceDataType []main.structWithNoStrings.array
+      Pointee: 222 GoSliceDataType []main.structWithNoStrings.array
     - __kind: PointerType
-      ID: 195
+      ID: 225
       Name: '*[]string.array'
       ByteSize: 8
-      Pointee: 194 GoSliceDataType []string.array
+      Pointee: 224 GoSliceDataType []string.array
     - __kind: PointerType
-      ID: 139
+      ID: 162
       Name: '*[]uint'
       ByteSize: 8
-      Pointee: 137 GoSliceHeaderType []uint
+      Pointee: 160 GoSliceHeaderType []uint
     - __kind: PointerType
-      ID: 189
+      ID: 219
       Name: '*[]uint.array'
       ByteSize: 8
-      Pointee: 188 GoSliceDataType []uint.array
+      Pointee: 218 GoSliceDataType []uint.array
     - __kind: PointerType
-      ID: 199
+      ID: 229
       Name: '*[]uint16.array'
       ByteSize: 8
-      Pointee: 198 GoSliceDataType []uint16.array
+      Pointee: 228 GoSliceDataType []uint16.array
     - __kind: PointerType
       ID: 5
       Name: '*bool'
       ByteSize: 8
-      GoRuntimeType: 360224
+      GoRuntimeType: 363392
       GoKind: 22
       Pointee: 4 BaseType bool
     - __kind: PointerType
-      ID: 128
+      ID: 151
       Name: '*bucket<[4]int,[4]int>'
       ByteSize: 8
-      Pointee: 129 GoHMapBucketType bucket<[4]int,[4]int>
+      Pointee: 152 GoHMapBucketType bucket<[4]int,[4]int>
     - __kind: PointerType
-      ID: 123
+      ID: 146
       Name: '*bucket<[4]int,uint8>'
       ByteSize: 8
-      Pointee: 124 GoHMapBucketType bucket<[4]int,uint8>
+      Pointee: 147 GoHMapBucketType bucket<[4]int,uint8>
     - __kind: PointerType
-      ID: 91
+      ID: 114
       Name: '*bucket<[4]string,[2]int>'
       ByteSize: 8
-      Pointee: 92 GoHMapBucketType bucket<[4]string,[2]int>
+      Pointee: 115 GoHMapBucketType bucket<[4]string,[2]int>
     - __kind: PointerType
-      ID: 103
+      ID: 126
       Name: '*bucket<bool,main.node>'
       ByteSize: 8
-      Pointee: 104 GoHMapBucketType bucket<bool,main.node>
+      Pointee: 127 GoHMapBucketType bucket<bool,main.node>
     - __kind: PointerType
-      ID: 69
+      ID: 71
+      Name: '*bucket<int,*main.deepMap2>'
+      ByteSize: 8
+      Pointee: 72 GoHMapBucketType bucket<int,*main.deepMap2>
+    - __kind: PointerType
+      ID: 244
+      Name: '*bucket<int,*main.deepMap3>'
+      ByteSize: 8
+      Pointee: 245 GoHMapBucketType bucket<int,*main.deepMap3>
+    - __kind: PointerType
+      ID: 273
+      Name: '*bucket<int,*main.deepMap8>'
+      ByteSize: 8
+      Pointee: 274 GoHMapBucketType bucket<int,*main.deepMap8>
+    - __kind: PointerType
+      ID: 282
+      Name: '*bucket<int,*main.deepMap9>'
+      ByteSize: 8
+      Pointee: 283 GoHMapBucketType bucket<int,*main.deepMap9>
+    - __kind: PointerType
+      ID: 94
       Name: '*bucket<int,int>'
       ByteSize: 8
-      Pointee: 70 GoHMapBucketType bucket<int,int>
+      Pointee: 95 GoHMapBucketType bucket<int,int>
     - __kind: PointerType
-      ID: 108
+      ID: 291
+      Name: '*bucket<int,interface {}>'
+      ByteSize: 8
+      Pointee: 292 GoHMapBucketType bucket<int,interface {}>
+    - __kind: PointerType
+      ID: 131
       Name: '*bucket<int,uint8>'
       ByteSize: 8
-      Pointee: 109 GoHMapBucketType bucket<int,uint8>
+      Pointee: 132 GoHMapBucketType bucket<int,uint8>
     - __kind: PointerType
-      ID: 98
+      ID: 121
       Name: '*bucket<string,[]main.structWithMap>'
       ByteSize: 8
-      Pointee: 99 GoHMapBucketType bucket<string,[]main.structWithMap>
+      Pointee: 122 GoHMapBucketType bucket<string,[]main.structWithMap>
     - __kind: PointerType
-      ID: 86
+      ID: 109
       Name: '*bucket<string,[]string>'
       ByteSize: 8
-      Pointee: 87 GoHMapBucketType bucket<string,[]string>
+      Pointee: 110 GoHMapBucketType bucket<string,[]string>
     - __kind: PointerType
-      ID: 81
+      ID: 104
       Name: '*bucket<string,int>'
       ByteSize: 8
-      Pointee: 82 GoHMapBucketType bucket<string,int>
+      Pointee: 105 GoHMapBucketType bucket<string,int>
     - __kind: PointerType
-      ID: 76
+      ID: 99
       Name: '*bucket<string,main.nestedStruct>'
       ByteSize: 8
-      Pointee: 77 GoHMapBucketType bucket<string,main.nestedStruct>
+      Pointee: 100 GoHMapBucketType bucket<string,main.nestedStruct>
     - __kind: PointerType
-      ID: 118
+      ID: 141
       Name: '*bucket<uint8,[4]int>'
       ByteSize: 8
-      Pointee: 119 GoHMapBucketType bucket<uint8,[4]int>
+      Pointee: 142 GoHMapBucketType bucket<uint8,[4]int>
     - __kind: PointerType
-      ID: 113
+      ID: 136
       Name: '*bucket<uint8,uint8>'
       ByteSize: 8
-      Pointee: 114 GoHMapBucketType bucket<uint8,uint8>
+      Pointee: 137 GoHMapBucketType bucket<uint8,uint8>
     - __kind: PointerType
       ID: 33
       Name: '*error'
       ByteSize: 8
-      GoRuntimeType: 359136
+      GoRuntimeType: 362304
       GoKind: 22
       Pointee: 18 GoInterfaceType error
     - __kind: PointerType
       ID: 35
       Name: '*float32'
       ByteSize: 8
-      GoRuntimeType: 360096
+      GoRuntimeType: 363264
       GoKind: 22
       Pointee: 16 BaseType float32
     - __kind: PointerType
       ID: 25
       Name: '*float64'
       ByteSize: 8
-      GoRuntimeType: 360160
+      GoRuntimeType: 363328
       GoKind: 22
       Pointee: 17 BaseType float64
     - __kind: PointerType
-      ID: 126
+      ID: 149
       Name: '*hash<[4]int,[4]int>'
       ByteSize: 8
-      Pointee: 127 GoHMapHeaderType hash<[4]int,[4]int>
+      Pointee: 150 GoHMapHeaderType hash<[4]int,[4]int>
     - __kind: PointerType
-      ID: 121
+      ID: 144
       Name: '*hash<[4]int,uint8>'
       ByteSize: 8
-      Pointee: 122 GoHMapHeaderType hash<[4]int,uint8>
+      Pointee: 145 GoHMapHeaderType hash<[4]int,uint8>
     - __kind: PointerType
-      ID: 89
+      ID: 112
       Name: '*hash<[4]string,[2]int>'
       ByteSize: 8
-      Pointee: 90 GoHMapHeaderType hash<[4]string,[2]int>
+      Pointee: 113 GoHMapHeaderType hash<[4]string,[2]int>
     - __kind: PointerType
-      ID: 101
+      ID: 124
       Name: '*hash<bool,main.node>'
       ByteSize: 8
-      Pointee: 102 GoHMapHeaderType hash<bool,main.node>
+      Pointee: 125 GoHMapHeaderType hash<bool,main.node>
     - __kind: PointerType
-      ID: 67
+      ID: 69
+      Name: '*hash<int,*main.deepMap2>'
+      ByteSize: 8
+      Pointee: 70 GoHMapHeaderType hash<int,*main.deepMap2>
+    - __kind: PointerType
+      ID: 242
+      Name: '*hash<int,*main.deepMap3>'
+      ByteSize: 8
+      Pointee: 243 GoHMapHeaderType hash<int,*main.deepMap3>
+    - __kind: PointerType
+      ID: 271
+      Name: '*hash<int,*main.deepMap8>'
+      ByteSize: 8
+      Pointee: 272 GoHMapHeaderType hash<int,*main.deepMap8>
+    - __kind: PointerType
+      ID: 280
+      Name: '*hash<int,*main.deepMap9>'
+      ByteSize: 8
+      Pointee: 281 GoHMapHeaderType hash<int,*main.deepMap9>
+    - __kind: PointerType
+      ID: 92
       Name: '*hash<int,int>'
       ByteSize: 8
-      Pointee: 68 GoHMapHeaderType hash<int,int>
+      Pointee: 93 GoHMapHeaderType hash<int,int>
     - __kind: PointerType
-      ID: 106
+      ID: 289
+      Name: '*hash<int,interface {}>'
+      ByteSize: 8
+      Pointee: 290 GoHMapHeaderType hash<int,interface {}>
+    - __kind: PointerType
+      ID: 129
       Name: '*hash<int,uint8>'
       ByteSize: 8
-      Pointee: 107 GoHMapHeaderType hash<int,uint8>
+      Pointee: 130 GoHMapHeaderType hash<int,uint8>
     - __kind: PointerType
-      ID: 96
+      ID: 119
       Name: '*hash<string,[]main.structWithMap>'
       ByteSize: 8
-      Pointee: 97 GoHMapHeaderType hash<string,[]main.structWithMap>
+      Pointee: 120 GoHMapHeaderType hash<string,[]main.structWithMap>
     - __kind: PointerType
-      ID: 84
+      ID: 107
       Name: '*hash<string,[]string>'
       ByteSize: 8
-      Pointee: 85 GoHMapHeaderType hash<string,[]string>
+      Pointee: 108 GoHMapHeaderType hash<string,[]string>
     - __kind: PointerType
-      ID: 79
+      ID: 102
       Name: '*hash<string,int>'
       ByteSize: 8
-      Pointee: 80 GoHMapHeaderType hash<string,int>
+      Pointee: 103 GoHMapHeaderType hash<string,int>
     - __kind: PointerType
-      ID: 74
+      ID: 97
       Name: '*hash<string,main.nestedStruct>'
       ByteSize: 8
-      Pointee: 75 GoHMapHeaderType hash<string,main.nestedStruct>
+      Pointee: 98 GoHMapHeaderType hash<string,main.nestedStruct>
     - __kind: PointerType
-      ID: 116
+      ID: 139
       Name: '*hash<uint8,[4]int>'
       ByteSize: 8
-      Pointee: 117 GoHMapHeaderType hash<uint8,[4]int>
+      Pointee: 140 GoHMapHeaderType hash<uint8,[4]int>
     - __kind: PointerType
-      ID: 111
+      ID: 134
       Name: '*hash<uint8,uint8>'
       ByteSize: 8
-      Pointee: 112 GoHMapHeaderType hash<uint8,uint8>
+      Pointee: 135 GoHMapHeaderType hash<uint8,uint8>
     - __kind: PointerType
       ID: 27
       Name: '*int'
       ByteSize: 8
-      GoRuntimeType: 359776
+      GoRuntimeType: 362944
       GoKind: 22
       Pointee: 9 BaseType int
     - __kind: PointerType
       ID: 30
       Name: '*int16'
       ByteSize: 8
-      GoRuntimeType: 359392
+      GoRuntimeType: 362560
       GoKind: 22
       Pointee: 31 BaseType int16
     - __kind: PointerType
       ID: 20
       Name: '*int32'
       ByteSize: 8
-      GoRuntimeType: 359520
+      GoRuntimeType: 362688
       GoKind: 22
       Pointee: 12 BaseType int32
     - __kind: PointerType
       ID: 26
       Name: '*int64'
       ByteSize: 8
-      GoRuntimeType: 359648
+      GoRuntimeType: 362816
       GoKind: 22
       Pointee: 13 BaseType int64
     - __kind: PointerType
       ID: 32
       Name: '*int8'
       ByteSize: 8
-      GoRuntimeType: 359264
+      GoRuntimeType: 362432
       GoKind: 22
       Pointee: 14 BaseType int8
     - __kind: PointerType
-      ID: 61
+      ID: 267
+      Name: '*interface {}'
+      ByteSize: 8
+      GoRuntimeType: 363520
+      GoKind: 22
+      Pointee: 83 GoEmptyInterfaceType interface {}
+    - __kind: PointerType
+      ID: 186
+      Name: '*main.deepMap2'
+      ByteSize: 8
+      GoRuntimeType: 356032
+      GoKind: 22
+      Pointee: 187 StructureType main.deepMap2
+    - __kind: PointerType
+      ID: 247
+      Name: '*main.deepMap3'
+      ByteSize: 8
+      GoRuntimeType: 355968
+      GoKind: 22
+      Pointee: 248 UnresolvedPointeeType main.deepMap3
+    - __kind: PointerType
+      ID: 75
+      Name: '*main.deepMap7'
+      ByteSize: 8
+      GoRuntimeType: 355712
+      GoKind: 22
+      Pointee: 76 StructureType main.deepMap7
+    - __kind: PointerType
+      ID: 276
+      Name: '*main.deepMap8'
+      ByteSize: 8
+      GoRuntimeType: 355648
+      GoKind: 22
+      Pointee: 277 StructureType main.deepMap8
+    - __kind: PointerType
+      ID: 285
+      Name: '*main.deepMap9'
+      ByteSize: 8
+      GoRuntimeType: 355584
+      GoKind: 22
+      Pointee: 286 StructureType main.deepMap9
+    - __kind: PointerType
+      ID: 57
+      Name: '*main.deepPtr2'
+      ByteSize: 8
+      GoRuntimeType: 356608
+      GoKind: 22
+      Pointee: 58 StructureType main.deepPtr2
+    - __kind: PointerType
+      ID: 230
+      Name: '*main.deepPtr3'
+      ByteSize: 8
+      GoRuntimeType: 356544
+      GoKind: 22
+      Pointee: 231 UnresolvedPointeeType main.deepPtr3
+    - __kind: PointerType
+      ID: 59
+      Name: '*main.deepPtr7'
+      ByteSize: 8
+      GoRuntimeType: 356288
+      GoKind: 22
+      Pointee: 60 StructureType main.deepPtr7
+    - __kind: PointerType
+      ID: 250
+      Name: '*main.deepPtr8'
+      ByteSize: 8
+      GoRuntimeType: 356224
+      GoKind: 22
+      Pointee: 251 StructureType main.deepPtr8
+    - __kind: PointerType
+      ID: 252
+      Name: '*main.deepPtr9'
+      ByteSize: 8
+      GoRuntimeType: 356160
+      GoKind: 22
+      Pointee: 253 StructureType main.deepPtr9
+    - __kind: PointerType
+      ID: 64
+      Name: '*main.deepSlice2'
+      ByteSize: 8
+      GoRuntimeType: 357184
+      GoKind: 22
+      Pointee: 180 StructureType main.deepSlice2
+    - __kind: PointerType
+      ID: 237
+      Name: '*main.deepSlice3'
+      ByteSize: 8
+      GoRuntimeType: 357120
+      GoKind: 22
+      Pointee: 238 UnresolvedPointeeType main.deepSlice3
+    - __kind: PointerType
+      ID: 65
+      Name: '*main.deepSlice7'
+      ByteSize: 8
+      GoRuntimeType: 356864
+      GoKind: 22
+      Pointee: 66 StructureType main.deepSlice7
+    - __kind: PointerType
+      ID: 256
+      Name: '*main.deepSlice8'
+      ByteSize: 8
+      GoRuntimeType: 356800
+      GoKind: 22
+      Pointee: 257 StructureType main.deepSlice8
+    - __kind: PointerType
+      ID: 262
+      Name: '*main.deepSlice9'
+      ByteSize: 8
+      GoRuntimeType: 356736
+      GoKind: 22
+      Pointee: 263 StructureType main.deepSlice9
+    - __kind: PointerType
+      ID: 86
       Name: '*main.esotericHeap'
       ByteSize: 8
-      GoRuntimeType: 354144
+      GoRuntimeType: 357312
       GoKind: 22
-      Pointee: 62 StructureType main.esotericHeap
+      Pointee: 87 StructureType main.esotericHeap
     - __kind: PointerType
-      ID: 134
+      ID: 157
       Name: '*main.node'
       ByteSize: 8
-      GoRuntimeType: 354208
+      GoRuntimeType: 357376
       GoKind: 22
-      Pointee: 133 StructureType main.node
+      Pointee: 156 StructureType main.node
     - __kind: PointerType
-      ID: 148
+      ID: 171
       Name: '*main.oneStringStruct'
       ByteSize: 8
       GoKind: 22
-      Pointee: 149 StructureType main.oneStringStruct
+      Pointee: 172 StructureType main.oneStringStruct
     - __kind: PointerType
-      ID: 173
+      ID: 77
+      Name: '*main.stringType1'
+      ByteSize: 8
+      GoKind: 22
+      Pointee: 78 GoStringHeaderType main.stringType1
+    - __kind: PointerType
+      ID: 233
+      Name: '*main.stringType1.str'
+      ByteSize: 8
+      Pointee: 232 GoStringDataType main.stringType1.str
+    - __kind: PointerType
+      ID: 80
+      Name: '*main.stringType2'
+      ByteSize: 8
+      GoKind: 22
+      Pointee: 234 UnresolvedPointeeType main.stringType2
+    - __kind: PointerType
+      ID: 203
       Name: '*main.structWithMap'
       ByteSize: 8
-      GoRuntimeType: 354080
+      GoRuntimeType: 355520
       GoKind: 22
-      Pointee: 65 StructureType main.structWithMap
+      Pointee: 90 StructureType main.structWithMap
     - __kind: PointerType
-      ID: 141
+      ID: 164
       Name: '*main.structWithNoStrings'
       ByteSize: 8
-      Pointee: 142 StructureType main.structWithNoStrings
+      Pointee: 165 StructureType main.structWithNoStrings
     - __kind: PointerType
-      ID: 131
+      ID: 154
       Name: '*main.structWithTwoValues'
       ByteSize: 8
       GoKind: 22
-      Pointee: 132 StructureType main.structWithTwoValues
+      Pointee: 155 StructureType main.structWithTwoValues
     - __kind: PointerType
-      ID: 135
+      ID: 158
       Name: '*main.t'
       ByteSize: 8
       GoKind: 22
-      Pointee: 136 GoSliceHeaderType main.t
+      Pointee: 159 GoSliceHeaderType main.t
     - __kind: PointerType
-      ID: 211
+      ID: 306
       Name: '*main.t.array'
       ByteSize: 8
-      Pointee: 210 GoSliceDataType main.t.array
+      Pointee: 305 GoSliceDataType main.t.array
     - __kind: PointerType
-      ID: 147
+      ID: 170
       Name: '*main.threeStringStruct'
       ByteSize: 8
       GoKind: 22
-      Pointee: 146 StructureType main.threeStringStruct
+      Pointee: 169 StructureType main.threeStringStruct
     - __kind: PointerType
-      ID: 94
+      ID: 117
       Name: '*map[string]int'
       ByteSize: 8
       GoKind: 22
-      Pointee: 78 GoMapType map[string]int
+      Pointee: 101 GoMapType map[string]int
     - __kind: PointerType
-      ID: 71
+      ID: 73
       Name: '*runtime.mapextra'
       ByteSize: 8
-      GoRuntimeType: 363104
+      GoRuntimeType: 366272
       GoKind: 22
-      Pointee: 72 UnresolvedPointeeType runtime.mapextra
+      Pointee: 74 UnresolvedPointeeType runtime.mapextra
     - __kind: PointerType
       ID: 22
       Name: '*string'
       ByteSize: 8
-      GoRuntimeType: 359200
+      GoRuntimeType: 362368
       GoKind: 22
       Pointee: 11 GoStringHeaderType string
     - __kind: PointerType
-      ID: 154
+      ID: 177
       Name: '*string.str'
       ByteSize: 8
-      Pointee: 153 GoStringDataType string.str
+      Pointee: 176 GoStringDataType string.str
     - __kind: PointerType
       ID: 34
       Name: '*uint'
       ByteSize: 8
-      GoRuntimeType: 359840
+      GoRuntimeType: 363008
       GoKind: 22
       Pointee: 15 BaseType uint
     - __kind: PointerType
       ID: 29
       Name: '*uint16'
       ByteSize: 8
-      GoRuntimeType: 359456
+      GoRuntimeType: 362624
       GoKind: 22
       Pointee: 7 BaseType uint16
     - __kind: PointerType
       ID: 21
       Name: '*uint32'
       ByteSize: 8
-      GoRuntimeType: 359584
+      GoRuntimeType: 362752
       GoKind: 22
       Pointee: 2 BaseType uint32
     - __kind: PointerType
       ID: 28
       Name: '*uint64'
       ByteSize: 8
-      GoRuntimeType: 359712
+      GoRuntimeType: 362880
       GoKind: 22
       Pointee: 10 BaseType uint64
     - __kind: PointerType
       ID: 6
       Name: '*uint8'
       ByteSize: 8
-      GoRuntimeType: 359328
+      GoRuntimeType: 362496
       GoKind: 22
       Pointee: 3 BaseType uint8
     - __kind: PointerType
       ID: 8
       Name: '*uintptr'
       ByteSize: 8
-      GoRuntimeType: 359904
+      GoRuntimeType: 363072
       GoKind: 22
       Pointee: 1 BaseType uintptr
     - __kind: EventRootType
-      ID: 301
+      ID: 404
       Name: Probe[main.stackC]
     - __kind: EventRootType
-      ID: 258
+      ID: 361
       Name: Probe[main.testAny]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -3468,14 +3936,14 @@ Types:
         - Name: a
           Offset: 1
           Expression:
-            Type: 58 GoEmptyInterfaceType interface {}
+            Type: 83 GoEmptyInterfaceType interface {}
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 45, index: 0, name: a}
+                  Variable: {subprogram: 53, index: 0, name: a}
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 230
+      ID: 325
       Name: Probe[main.testArrayOfArraysOfArrays]
       ByteSize: 65
       PresenceBitsetSize: 1
@@ -3490,7 +3958,7 @@ Types:
                   Offset: 0
                   ByteSize: 64
     - __kind: EventRootType
-      ID: 228
+      ID: 323
       Name: Probe[main.testArrayOfArrays]
       ByteSize: 33
       PresenceBitsetSize: 1
@@ -3505,7 +3973,7 @@ Types:
                   Offset: 0
                   ByteSize: 32
     - __kind: EventRootType
-      ID: 266
+      ID: 369
       Name: Probe[main.testArrayOfMaps]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -3513,14 +3981,14 @@ Types:
         - Name: m
           Offset: 1
           Expression:
-            Type: 93 ArrayType [2]map[string]int
+            Type: 116 ArrayType [2]map[string]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 53, index: 0, name: m}
+                  Variable: {subprogram: 61, index: 0, name: m}
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 229
+      ID: 324
       Name: Probe[main.testArrayOfStrings]
       ByteSize: 33
       PresenceBitsetSize: 1
@@ -3535,7 +4003,7 @@ Types:
                   Offset: 0
                   ByteSize: 32
     - __kind: EventRootType
-      ID: 248
+      ID: 343
       Name: Probe[main.testBigStruct]
       ByteSize: 49
       PresenceBitsetSize: 1
@@ -3550,7 +4018,7 @@ Types:
                   Offset: 0
                   ByteSize: 48
     - __kind: EventRootType
-      ID: 217
+      ID: 312
       Name: Probe[main.testBoolArray]
       ByteSize: 3
       PresenceBitsetSize: 1
@@ -3565,7 +4033,7 @@ Types:
                   Offset: 0
                   ByteSize: 2
     - __kind: EventRootType
-      ID: 214
+      ID: 309
       Name: Probe[main.testByteArray]
       ByteSize: 3
       PresenceBitsetSize: 1
@@ -3580,7 +4048,7 @@ Types:
                   Offset: 0
                   ByteSize: 2
     - __kind: EventRootType
-      ID: 282
+      ID: 385
       Name: Probe[main.testChannel]
       ByteSize: 1
       PresenceBitsetSize: 1
@@ -3588,14 +4056,14 @@ Types:
         - Name: c
           Offset: 1
           Expression:
-            Type: 130 GoChannelType chan bool
+            Type: 153 GoChannelType chan bool
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 69, index: 0, name: c}
+                  Variable: {subprogram: 77, index: 0, name: c}
                   Offset: 0
                   ByteSize: 0
     - __kind: EventRootType
-      ID: 280
+      ID: 383
       Name: Probe[main.testCombinedByte]
       ByteSize: 7
       PresenceBitsetSize: 1
@@ -3606,7 +4074,7 @@ Types:
             Type: 3 BaseType uint8
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 67, index: 0, name: w}
+                  Variable: {subprogram: 75, index: 0, name: w}
                   Offset: 0
                   ByteSize: 1
         - Name: x
@@ -3615,7 +4083,7 @@ Types:
             Type: 3 BaseType uint8
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 67, index: 1, name: x}
+                  Variable: {subprogram: 75, index: 1, name: x}
                   Offset: 0
                   ByteSize: 1
         - Name: y
@@ -3624,11 +4092,11 @@ Types:
             Type: 16 BaseType float32
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 67, index: 2, name: y}
+                  Variable: {subprogram: 75, index: 2, name: y}
                   Offset: 0
                   ByteSize: 4
     - __kind: EventRootType
-      ID: 290
+      ID: 393
       Name: Probe[main.testCycle]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -3636,14 +4104,104 @@ Types:
         - Name: t
           Offset: 1
           Expression:
-            Type: 135 PointerType *main.t
+            Type: 158 PointerType *main.t
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 77, index: 0, name: t}
+                  Variable: {subprogram: 85, index: 0, name: t}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 295
+      ID: 348
+      Name: Probe[main.testDeepMap1]
+      ByteSize: 9
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: a
+          Offset: 1
+          Expression:
+            Type: 67 StructureType main.deepMap1
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 40, index: 0, name: a}
+                  Offset: 0
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 349
+      Name: Probe[main.testDeepMap7]
+      ByteSize: 9
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: a
+          Offset: 1
+          Expression:
+            Type: 75 PointerType *main.deepMap7
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 41, index: 0, name: a}
+                  Offset: 0
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 344
+      Name: Probe[main.testDeepPtr1]
+      ByteSize: 9
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: a
+          Offset: 1
+          Expression:
+            Type: 56 StructureType main.deepPtr1
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 36, index: 0, name: a}
+                  Offset: 0
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 345
+      Name: Probe[main.testDeepPtr7]
+      ByteSize: 9
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: a
+          Offset: 1
+          Expression:
+            Type: 59 PointerType *main.deepPtr7
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 37, index: 0, name: a}
+                  Offset: 0
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 346
+      Name: Probe[main.testDeepSlice1]
+      ByteSize: 25
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: a
+          Offset: 1
+          Expression:
+            Type: 61 StructureType main.deepSlice1
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 38, index: 0, name: a}
+                  Offset: 0
+                  ByteSize: 24
+    - __kind: EventRootType
+      ID: 347
+      Name: Probe[main.testDeepSlice7]
+      ByteSize: 9
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: a
+          Offset: 1
+          Expression:
+            Type: 65 PointerType *main.deepSlice7
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 39, index: 0, name: a}
+                  Offset: 0
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 398
       Name: Probe[main.testEmptySliceOfStructs]
       ByteSize: 33
       PresenceBitsetSize: 1
@@ -3651,10 +4209,10 @@ Types:
         - Name: xs
           Offset: 1
           Expression:
-            Type: 140 GoSliceHeaderType []main.structWithNoStrings
+            Type: 163 GoSliceHeaderType []main.structWithNoStrings
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 82, index: 0, name: xs}
+                  Variable: {subprogram: 90, index: 0, name: xs}
                   Offset: 0
                   ByteSize: 24
         - Name: a
@@ -3663,11 +4221,11 @@ Types:
             Type: 9 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 82, index: 1, name: a}
+                  Variable: {subprogram: 90, index: 1, name: a}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 292
+      ID: 395
       Name: Probe[main.testEmptySlice]
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -3675,14 +4233,14 @@ Types:
         - Name: u
           Offset: 1
           Expression:
-            Type: 137 GoSliceHeaderType []uint
+            Type: 160 GoSliceHeaderType []uint
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 79, index: 0, name: u}
+                  Variable: {subprogram: 87, index: 0, name: u}
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 309
+      ID: 412
       Name: Probe[main.testEmptyString]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -3693,11 +4251,11 @@ Types:
             Type: 11 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 96, index: 0, name: x}
+                  Variable: {subprogram: 104, index: 0, name: x}
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 311
+      ID: 414
       Name: Probe[main.testEmptyStruct]
       ByteSize: 1
       PresenceBitsetSize: 1
@@ -3705,14 +4263,14 @@ Types:
         - Name: e
           Offset: 1
           Expression:
-            Type: 152 StructureType main.emptyStruct
+            Type: 175 StructureType main.emptyStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 98, index: 0, name: e}
+                  Variable: {subprogram: 106, index: 0, name: e}
                   Offset: 0
                   ByteSize: 0
     - __kind: EventRootType
-      ID: 259
+      ID: 362
       Name: Probe[main.testError]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -3723,11 +4281,11 @@ Types:
             Type: 18 GoInterfaceType error
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 46, index: 0, name: e}
+                  Variable: {subprogram: 54, index: 0, name: e}
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 250
+      ID: 353
       Name: Probe[main.testEsotericHeap]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -3735,14 +4293,14 @@ Types:
         - Name: e
           Offset: 1
           Expression:
-            Type: 61 PointerType *main.esotericHeap
+            Type: 86 PointerType *main.esotericHeap
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 37, index: 0, name: e}
+                  Variable: {subprogram: 45, index: 0, name: e}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 249
+      ID: 352
       Name: Probe[main.testEsotericStack]
       ByteSize: 65
       PresenceBitsetSize: 1
@@ -3750,14 +4308,14 @@ Types:
         - Name: e
           Offset: 1
           Expression:
-            Type: 56 StructureType main.esotericStack
+            Type: 81 StructureType main.esotericStack
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 36, index: 0, name: e}
+                  Variable: {subprogram: 44, index: 0, name: e}
                   Offset: 0
                   ByteSize: 64
     - __kind: EventRootType
-      ID: 256
+      ID: 359
       Name: Probe[main.testFramelessArray]
       ByteSize: 41
       PresenceBitsetSize: 1
@@ -3765,14 +4323,14 @@ Types:
         - Name: a
           Offset: 1
           Expression:
-            Type: 63 ArrayType [5]int
+            Type: 88 ArrayType [5]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 43, index: 0, name: a}
+                  Variable: {subprogram: 51, index: 0, name: a}
                   Offset: 0
                   ByteSize: 40
     - __kind: EventRootType
-      ID: 255
+      ID: 358
       Name: Probe[main.testFrameless]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -3783,11 +4341,11 @@ Types:
             Type: 9 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 42, index: 0, name: x}
+                  Variable: {subprogram: 50, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 251
+      ID: 354
       Name: Probe[main.testInlinedBA]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -3798,11 +4356,11 @@ Types:
             Type: 9 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 38, index: 0, name: x}
+                  Variable: {subprogram: 46, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 253
+      ID: 356
       Name: Probe[main.testInlinedBBA]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -3813,14 +4371,14 @@ Types:
             Type: 9 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 40, index: 0, name: x}
+                  Variable: {subprogram: 48, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 313
+      ID: 416
       Name: Probe[main.testInlinedBBB]
     - __kind: EventRootType
-      ID: 252
+      ID: 355
       Name: Probe[main.testInlinedBB]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -3831,7 +4389,7 @@ Types:
             Type: 9 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 39, index: 0, name: x}
+                  Variable: {subprogram: 47, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
         - Name: y
@@ -3840,20 +4398,20 @@ Types:
             Type: 9 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 39, index: 1, name: y}
+                  Variable: {subprogram: 47, index: 1, name: y}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 314
+      ID: 417
       Name: Probe[main.testInlinedBCA]
     - __kind: EventRootType
-      ID: 315
+      ID: 418
       Name: Probe[main.testInlinedBCB]
     - __kind: EventRootType
-      ID: 254
+      ID: 357
       Name: Probe[main.testInlinedBC]
     - __kind: EventRootType
-      ID: 312
+      ID: 415
       Name: Probe[main.testInlinedPrint]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -3864,11 +4422,11 @@ Types:
             Type: 9 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 99, index: 0, name: x}
+                  Variable: {subprogram: 107, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 316
+      ID: 419
       Name: Probe[main.testInlinedSq]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -3879,11 +4437,11 @@ Types:
             Type: 9 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 103, index: 0, name: x}
+                  Variable: {subprogram: 111, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 317
+      ID: 420
       Name: Probe[main.testInlinedSumArray]
       ByteSize: 41
       PresenceBitsetSize: 1
@@ -3891,14 +4449,14 @@ Types:
         - Name: a
           Offset: 1
           Expression:
-            Type: 63 ArrayType [5]int
+            Type: 88 ArrayType [5]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 104, index: 0, name: a}
+                  Variable: {subprogram: 112, index: 0, name: a}
                   Offset: 0
                   ByteSize: 40
     - __kind: EventRootType
-      ID: 220
+      ID: 315
       Name: Probe[main.testInt16Array]
       ByteSize: 5
       PresenceBitsetSize: 1
@@ -3913,7 +4471,7 @@ Types:
                   Offset: 0
                   ByteSize: 4
     - __kind: EventRootType
-      ID: 221
+      ID: 316
       Name: Probe[main.testInt32Array]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -3928,7 +4486,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 222
+      ID: 317
       Name: Probe[main.testInt64Array]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -3943,7 +4501,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 219
+      ID: 314
       Name: Probe[main.testInt8Array]
       ByteSize: 3
       PresenceBitsetSize: 1
@@ -3958,7 +4516,7 @@ Types:
                   Offset: 0
                   ByteSize: 2
     - __kind: EventRootType
-      ID: 218
+      ID: 313
       Name: Probe[main.testIntArray]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -3973,7 +4531,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 257
+      ID: 360
       Name: Probe[main.testInterface]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -3981,14 +4539,14 @@ Types:
         - Name: b
           Offset: 1
           Expression:
-            Type: 64 GoInterfaceType main.behavior
+            Type: 89 GoInterfaceType main.behavior
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 44, index: 0, name: b}
+                  Variable: {subprogram: 52, index: 0, name: b}
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 284
+      ID: 387
       Name: Probe[main.testLinkedList]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -3996,14 +4554,14 @@ Types:
         - Name: a
           Offset: 1
           Expression:
-            Type: 133 StructureType main.node
+            Type: 156 StructureType main.node
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 71, index: 0, name: a}
+                  Variable: {subprogram: 79, index: 0, name: a}
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 264
+      ID: 367
       Name: Probe[main.testMapArrayToArray]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -4011,14 +4569,14 @@ Types:
         - Name: m
           Offset: 1
           Expression:
-            Type: 88 GoMapType map[[4]string][2]int
+            Type: 111 GoMapType map[[4]string][2]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 51, index: 0, name: m}
+                  Variable: {subprogram: 59, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 270
+      ID: 373
       Name: Probe[main.testMapEmbeddedMaps]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -4026,14 +4584,14 @@ Types:
         - Name: m
           Offset: 1
           Expression:
-            Type: 95 GoMapType map[string][]main.structWithMap
+            Type: 118 GoMapType map[string][]main.structWithMap
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 57, index: 0, name: m}
+                  Variable: {subprogram: 65, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 268
+      ID: 371
       Name: Probe[main.testMapIntToInt]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -4041,14 +4599,14 @@ Types:
         - Name: m
           Offset: 1
           Expression:
-            Type: 66 GoMapType map[int]int
+            Type: 91 GoMapType map[int]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 55, index: 0, name: m}
+                  Variable: {subprogram: 63, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 279
+      ID: 382
       Name: Probe[main.testMapLargeKeyLargeValue]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -4056,14 +4614,14 @@ Types:
         - Name: m
           Offset: 1
           Expression:
-            Type: 125 GoMapType map[[4]int][4]int
+            Type: 148 GoMapType map[[4]int][4]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 66, index: 0, name: m}
+                  Variable: {subprogram: 74, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 278
+      ID: 381
       Name: Probe[main.testMapLargeKeySmallValue]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -4071,14 +4629,14 @@ Types:
         - Name: m
           Offset: 1
           Expression:
-            Type: 120 GoMapType map[[4]int]uint8
+            Type: 143 GoMapType map[[4]int]uint8
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 65, index: 0, name: m}
+                  Variable: {subprogram: 73, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 269
+      ID: 372
       Name: Probe[main.testMapMassive]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -4086,14 +4644,14 @@ Types:
         - Name: redactMyEntries
           Offset: 1
           Expression:
-            Type: 95 GoMapType map[string][]main.structWithMap
+            Type: 118 GoMapType map[string][]main.structWithMap
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 56, index: 0, name: redactMyEntries}
+                  Variable: {subprogram: 64, index: 0, name: redactMyEntries}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 277
+      ID: 380
       Name: Probe[main.testMapSmallKeyLargeValue]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -4101,14 +4659,14 @@ Types:
         - Name: m
           Offset: 1
           Expression:
-            Type: 115 GoMapType map[uint8][4]int
+            Type: 138 GoMapType map[uint8][4]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 64, index: 0, name: m}
+                  Variable: {subprogram: 72, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 276
+      ID: 379
       Name: Probe[main.testMapSmallKeySmallValue]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -4116,14 +4674,14 @@ Types:
         - Name: m
           Offset: 1
           Expression:
-            Type: 110 GoMapType map[uint8]uint8
+            Type: 133 GoMapType map[uint8]uint8
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 63, index: 0, name: m}
+                  Variable: {subprogram: 71, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 262
+      ID: 365
       Name: Probe[main.testMapStringToInt]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -4131,14 +4689,14 @@ Types:
         - Name: m
           Offset: 1
           Expression:
-            Type: 78 GoMapType map[string]int
+            Type: 101 GoMapType map[string]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 49, index: 0, name: m}
+                  Variable: {subprogram: 57, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 263
+      ID: 366
       Name: Probe[main.testMapStringToSlice]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -4146,14 +4704,14 @@ Types:
         - Name: m
           Offset: 1
           Expression:
-            Type: 83 GoMapType map[string][]string
+            Type: 106 GoMapType map[string][]string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 50, index: 0, name: m}
+                  Variable: {subprogram: 58, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 261
+      ID: 364
       Name: Probe[main.testMapStringToStruct]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -4161,14 +4719,14 @@ Types:
         - Name: m
           Offset: 1
           Expression:
-            Type: 73 GoMapType map[string]main.nestedStruct
+            Type: 96 GoMapType map[string]main.nestedStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 48, index: 0, name: m}
+                  Variable: {subprogram: 56, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 271
+      ID: 374
       Name: Probe[main.testMapWithLinkedList]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -4176,14 +4734,14 @@ Types:
         - Name: m
           Offset: 1
           Expression:
-            Type: 100 GoMapType map[bool]main.node
+            Type: 123 GoMapType map[bool]main.node
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 58, index: 0, name: m}
+                  Variable: {subprogram: 66, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 275
+      ID: 378
       Name: Probe[main.testMapWithSmallKeyAndValueMassive]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -4191,14 +4749,14 @@ Types:
         - Name: m
           Offset: 1
           Expression:
-            Type: 110 GoMapType map[uint8]uint8
+            Type: 133 GoMapType map[uint8]uint8
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 62, index: 0, name: m}
+                  Variable: {subprogram: 70, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 274
+      ID: 377
       Name: Probe[main.testMapWithSmallKeyAndValue]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -4206,14 +4764,14 @@ Types:
         - Name: m
           Offset: 1
           Expression:
-            Type: 110 GoMapType map[uint8]uint8
+            Type: 133 GoMapType map[uint8]uint8
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 61, index: 0, name: m}
+                  Variable: {subprogram: 69, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 273
+      ID: 376
       Name: Probe[main.testMapWithSmallValueMassive]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -4221,14 +4779,14 @@ Types:
         - Name: redactMyEntries
           Offset: 1
           Expression:
-            Type: 105 GoMapType map[int]uint8
+            Type: 128 GoMapType map[int]uint8
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 60, index: 0, name: redactMyEntries}
+                  Variable: {subprogram: 68, index: 0, name: redactMyEntries}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 272
+      ID: 375
       Name: Probe[main.testMapWithSmallValue]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -4236,14 +4794,14 @@ Types:
         - Name: m
           Offset: 1
           Expression:
-            Type: 105 GoMapType map[int]uint8
+            Type: 128 GoMapType map[int]uint8
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 59, index: 0, name: m}
+                  Variable: {subprogram: 67, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 307
+      ID: 410
       Name: Probe[main.testMassiveString]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -4254,11 +4812,11 @@ Types:
             Type: 11 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 94, index: 0, name: x}
+                  Variable: {subprogram: 102, index: 0, name: x}
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 281
+      ID: 384
       Name: Probe[main.testMultipleSimpleParams]
       ByteSize: 31
       PresenceBitsetSize: 1
@@ -4269,7 +4827,7 @@ Types:
             Type: 4 BaseType bool
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 68, index: 0, name: a}
+                  Variable: {subprogram: 76, index: 0, name: a}
                   Offset: 0
                   ByteSize: 1
         - Name: b
@@ -4278,7 +4836,7 @@ Types:
             Type: 3 BaseType uint8
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 68, index: 1, name: b}
+                  Variable: {subprogram: 76, index: 1, name: b}
                   Offset: 0
                   ByteSize: 1
         - Name: c
@@ -4287,7 +4845,7 @@ Types:
             Type: 12 BaseType int32
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 68, index: 2, name: c}
+                  Variable: {subprogram: 76, index: 2, name: c}
                   Offset: 0
                   ByteSize: 4
         - Name: d
@@ -4296,7 +4854,7 @@ Types:
             Type: 15 BaseType uint
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 68, index: 3, name: d}
+                  Variable: {subprogram: 76, index: 3, name: d}
                   Offset: 0
                   ByteSize: 8
         - Name: e
@@ -4305,11 +4863,11 @@ Types:
             Type: 11 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 68, index: 4, name: e}
+                  Variable: {subprogram: 76, index: 4, name: e}
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 289
+      ID: 392
       Name: Probe[main.testNilPointer]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -4320,7 +4878,7 @@ Types:
             Type: 5 PointerType *bool
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 76, index: 0, name: z}
+                  Variable: {subprogram: 84, index: 0, name: z}
                   Offset: 0
                   ByteSize: 8
         - Name: a
@@ -4329,11 +4887,11 @@ Types:
             Type: 15 BaseType uint
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 76, index: 1, name: a}
+                  Variable: {subprogram: 84, index: 1, name: a}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 296
+      ID: 399
       Name: Probe[main.testNilSliceOfStructs]
       ByteSize: 33
       PresenceBitsetSize: 1
@@ -4341,10 +4899,10 @@ Types:
         - Name: xs
           Offset: 1
           Expression:
-            Type: 140 GoSliceHeaderType []main.structWithNoStrings
+            Type: 163 GoSliceHeaderType []main.structWithNoStrings
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 83, index: 0, name: xs}
+                  Variable: {subprogram: 91, index: 0, name: xs}
                   Offset: 0
                   ByteSize: 24
         - Name: a
@@ -4353,11 +4911,11 @@ Types:
             Type: 9 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 83, index: 1, name: a}
+                  Variable: {subprogram: 91, index: 1, name: a}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 298
+      ID: 401
       Name: Probe[main.testNilSliceWithOtherParams]
       ByteSize: 34
       PresenceBitsetSize: 1
@@ -4368,16 +4926,16 @@ Types:
             Type: 14 BaseType int8
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 85, index: 0, name: a}
+                  Variable: {subprogram: 93, index: 0, name: a}
                   Offset: 0
                   ByteSize: 1
         - Name: s
           Offset: 2
           Expression:
-            Type: 144 GoSliceHeaderType []bool
+            Type: 167 GoSliceHeaderType []bool
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 85, index: 1, name: s}
+                  Variable: {subprogram: 93, index: 1, name: s}
                   Offset: 0
                   ByteSize: 24
         - Name: x
@@ -4386,11 +4944,11 @@ Types:
             Type: 15 BaseType uint
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 85, index: 2, name: x}
+                  Variable: {subprogram: 93, index: 2, name: x}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 299
+      ID: 402
       Name: Probe[main.testNilSlice]
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -4398,14 +4956,14 @@ Types:
         - Name: xs
           Offset: 1
           Expression:
-            Type: 145 GoSliceHeaderType []uint16
+            Type: 168 GoSliceHeaderType []uint16
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 86, index: 0, name: xs}
+                  Variable: {subprogram: 94, index: 0, name: xs}
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 306
+      ID: 409
       Name: Probe[main.testOneStringInStructPointer]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -4413,14 +4971,14 @@ Types:
         - Name: a
           Offset: 1
           Expression:
-            Type: 148 PointerType *main.oneStringStruct
+            Type: 171 PointerType *main.oneStringStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 93, index: 0, name: a}
+                  Variable: {subprogram: 101, index: 0, name: a}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 285
+      ID: 388
       Name: Probe[main.testPointerLoop]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -4428,14 +4986,14 @@ Types:
         - Name: a
           Offset: 1
           Expression:
-            Type: 134 PointerType *main.node
+            Type: 157 PointerType *main.node
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 72, index: 0, name: a}
+                  Variable: {subprogram: 80, index: 0, name: a}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 267
+      ID: 370
       Name: Probe[main.testPointerToMap]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -4443,14 +5001,14 @@ Types:
         - Name: m
           Offset: 1
           Expression:
-            Type: 94 PointerType *map[string]int
+            Type: 117 PointerType *map[string]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 54, index: 0, name: m}
+                  Variable: {subprogram: 62, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 283
+      ID: 386
       Name: Probe[main.testPointerToSimpleStruct]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -4458,14 +5016,14 @@ Types:
         - Name: a
           Offset: 1
           Expression:
-            Type: 131 PointerType *main.structWithTwoValues
+            Type: 154 PointerType *main.structWithTwoValues
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 70, index: 0, name: a}
+                  Variable: {subprogram: 78, index: 0, name: a}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 215
+      ID: 310
       Name: Probe[main.testRuneArray]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -4480,7 +5038,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 234
+      ID: 329
       Name: Probe[main.testSingleBool]
       ByteSize: 2
       PresenceBitsetSize: 1
@@ -4495,7 +5053,7 @@ Types:
                   Offset: 0
                   ByteSize: 1
     - __kind: EventRootType
-      ID: 232
+      ID: 327
       Name: Probe[main.testSingleByte]
       ByteSize: 2
       PresenceBitsetSize: 1
@@ -4510,7 +5068,7 @@ Types:
                   Offset: 0
                   ByteSize: 1
     - __kind: EventRootType
-      ID: 245
+      ID: 340
       Name: Probe[main.testSingleFloat32]
       ByteSize: 5
       PresenceBitsetSize: 1
@@ -4525,7 +5083,7 @@ Types:
                   Offset: 0
                   ByteSize: 4
     - __kind: EventRootType
-      ID: 246
+      ID: 341
       Name: Probe[main.testSingleFloat64]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -4540,7 +5098,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 237
+      ID: 332
       Name: Probe[main.testSingleInt16]
       ByteSize: 3
       PresenceBitsetSize: 1
@@ -4555,7 +5113,7 @@ Types:
                   Offset: 0
                   ByteSize: 2
     - __kind: EventRootType
-      ID: 238
+      ID: 333
       Name: Probe[main.testSingleInt32]
       ByteSize: 5
       PresenceBitsetSize: 1
@@ -4570,7 +5128,7 @@ Types:
                   Offset: 0
                   ByteSize: 4
     - __kind: EventRootType
-      ID: 239
+      ID: 334
       Name: Probe[main.testSingleInt64]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -4585,7 +5143,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 236
+      ID: 331
       Name: Probe[main.testSingleInt8]
       ByteSize: 2
       PresenceBitsetSize: 1
@@ -4600,7 +5158,7 @@ Types:
                   Offset: 0
                   ByteSize: 1
     - __kind: EventRootType
-      ID: 235
+      ID: 330
       Name: Probe[main.testSingleInt]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -4615,7 +5173,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 233
+      ID: 328
       Name: Probe[main.testSingleRune]
       ByteSize: 5
       PresenceBitsetSize: 1
@@ -4630,7 +5188,7 @@ Types:
                   Offset: 0
                   ByteSize: 4
     - __kind: EventRootType
-      ID: 302
+      ID: 405
       Name: Probe[main.testSingleString]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -4641,11 +5199,11 @@ Types:
             Type: 11 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 89, index: 0, name: x}
+                  Variable: {subprogram: 97, index: 0, name: x}
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 242
+      ID: 337
       Name: Probe[main.testSingleUint16]
       ByteSize: 3
       PresenceBitsetSize: 1
@@ -4660,7 +5218,7 @@ Types:
                   Offset: 0
                   ByteSize: 2
     - __kind: EventRootType
-      ID: 243
+      ID: 338
       Name: Probe[main.testSingleUint32]
       ByteSize: 5
       PresenceBitsetSize: 1
@@ -4675,7 +5233,7 @@ Types:
                   Offset: 0
                   ByteSize: 4
     - __kind: EventRootType
-      ID: 244
+      ID: 339
       Name: Probe[main.testSingleUint64]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -4690,7 +5248,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 241
+      ID: 336
       Name: Probe[main.testSingleUint8]
       ByteSize: 2
       PresenceBitsetSize: 1
@@ -4705,7 +5263,7 @@ Types:
                   Offset: 0
                   ByteSize: 1
     - __kind: EventRootType
-      ID: 240
+      ID: 335
       Name: Probe[main.testSingleUint]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -4720,7 +5278,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 293
+      ID: 396
       Name: Probe[main.testSliceOfSlices]
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -4728,14 +5286,14 @@ Types:
         - Name: u
           Offset: 1
           Expression:
-            Type: 138 GoSliceHeaderType [][]uint
+            Type: 161 GoSliceHeaderType [][]uint
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 80, index: 0, name: u}
+                  Variable: {subprogram: 88, index: 0, name: u}
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 265
+      ID: 368
       Name: Probe[main.testSmallMap]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -4743,14 +5301,14 @@ Types:
         - Name: m
           Offset: 1
           Expression:
-            Type: 78 GoMapType map[string]int
+            Type: 101 GoMapType map[string]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 52, index: 0, name: m}
+                  Variable: {subprogram: 60, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 216
+      ID: 311
       Name: Probe[main.testStringArray]
       ByteSize: 33
       PresenceBitsetSize: 1
@@ -4765,7 +5323,7 @@ Types:
                   Offset: 0
                   ByteSize: 32
     - __kind: EventRootType
-      ID: 288
+      ID: 391
       Name: Probe[main.testStringPointer]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -4776,11 +5334,11 @@ Types:
             Type: 22 PointerType *string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 75, index: 0, name: z}
+                  Variable: {subprogram: 83, index: 0, name: z}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 297
+      ID: 400
       Name: Probe[main.testStringSlice]
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -4788,14 +5346,44 @@ Types:
         - Name: s
           Offset: 1
           Expression:
-            Type: 143 GoSliceHeaderType []string
+            Type: 166 GoSliceHeaderType []string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 84, index: 0, name: s}
+                  Variable: {subprogram: 92, index: 0, name: s}
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 294
+      ID: 350
+      Name: Probe[main.testStringType1]
+      ByteSize: 9
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: a
+          Offset: 1
+          Expression:
+            Type: 77 PointerType *main.stringType1
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 42, index: 0, name: a}
+                  Offset: 0
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 351
+      Name: Probe[main.testStringType2]
+      ByteSize: 9
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: a
+          Offset: 1
+          Expression:
+            Type: 79 PointerType **main.stringType2
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 43, index: 0, name: a}
+                  Offset: 0
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 397
       Name: Probe[main.testStructSlice]
       ByteSize: 33
       PresenceBitsetSize: 1
@@ -4803,10 +5391,10 @@ Types:
         - Name: xs
           Offset: 1
           Expression:
-            Type: 140 GoSliceHeaderType []main.structWithNoStrings
+            Type: 163 GoSliceHeaderType []main.structWithNoStrings
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 81, index: 0, name: xs}
+                  Variable: {subprogram: 89, index: 0, name: xs}
                   Offset: 0
                   ByteSize: 24
         - Name: a
@@ -4815,11 +5403,11 @@ Types:
             Type: 9 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 81, index: 1, name: a}
+                  Variable: {subprogram: 89, index: 1, name: a}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 260
+      ID: 363
       Name: Probe[main.testStructWithMap]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -4827,14 +5415,14 @@ Types:
         - Name: s
           Offset: 1
           Expression:
-            Type: 65 StructureType main.structWithMap
+            Type: 90 StructureType main.structWithMap
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 47, index: 0, name: s}
+                  Variable: {subprogram: 55, index: 0, name: s}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 310
+      ID: 413
       Name: Probe[main.testStruct]
       ByteSize: 57
       PresenceBitsetSize: 1
@@ -4842,14 +5430,14 @@ Types:
         - Name: x
           Offset: 1
           Expression:
-            Type: 150 StructureType main.aStruct
+            Type: 173 StructureType main.aStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 97, index: 0, name: x}
+                  Variable: {subprogram: 105, index: 0, name: x}
                   Offset: 0
                   ByteSize: 56
     - __kind: EventRootType
-      ID: 305
+      ID: 408
       Name: Probe[main.testThreeStringsInStructPointer]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -4857,14 +5445,14 @@ Types:
         - Name: a
           Offset: 1
           Expression:
-            Type: 147 PointerType *main.threeStringStruct
+            Type: 170 PointerType *main.threeStringStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 92, index: 0, name: a}
+                  Variable: {subprogram: 100, index: 0, name: a}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 304
+      ID: 407
       Name: Probe[main.testThreeStringsInStruct]
       ByteSize: 49
       PresenceBitsetSize: 1
@@ -4872,14 +5460,14 @@ Types:
         - Name: a
           Offset: 1
           Expression:
-            Type: 146 StructureType main.threeStringStruct
+            Type: 169 StructureType main.threeStringStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 91, index: 0, name: a}
+                  Variable: {subprogram: 99, index: 0, name: a}
                   Offset: 0
                   ByteSize: 48
     - __kind: EventRootType
-      ID: 303
+      ID: 406
       Name: Probe[main.testThreeStrings]
       ByteSize: 49
       PresenceBitsetSize: 1
@@ -4890,7 +5478,7 @@ Types:
             Type: 11 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 90, index: 0, name: x}
+                  Variable: {subprogram: 98, index: 0, name: x}
                   Offset: 0
                   ByteSize: 16
         - Name: y
@@ -4899,7 +5487,7 @@ Types:
             Type: 11 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 90, index: 1, name: y}
+                  Variable: {subprogram: 98, index: 1, name: y}
                   Offset: 0
                   ByteSize: 16
         - Name: z
@@ -4908,11 +5496,11 @@ Types:
             Type: 11 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 90, index: 2, name: z}
+                  Variable: {subprogram: 98, index: 2, name: z}
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 247
+      ID: 342
       Name: Probe[main.testTypeAlias]
       ByteSize: 3
       PresenceBitsetSize: 1
@@ -4927,7 +5515,7 @@ Types:
                   Offset: 0
                   ByteSize: 2
     - __kind: EventRootType
-      ID: 225
+      ID: 320
       Name: Probe[main.testUint16Array]
       ByteSize: 5
       PresenceBitsetSize: 1
@@ -4942,7 +5530,7 @@ Types:
                   Offset: 0
                   ByteSize: 4
     - __kind: EventRootType
-      ID: 226
+      ID: 321
       Name: Probe[main.testUint32Array]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -4957,7 +5545,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 227
+      ID: 322
       Name: Probe[main.testUint64Array]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -4972,7 +5560,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 224
+      ID: 319
       Name: Probe[main.testUint8Array]
       ByteSize: 3
       PresenceBitsetSize: 1
@@ -4987,7 +5575,7 @@ Types:
                   Offset: 0
                   ByteSize: 2
     - __kind: EventRootType
-      ID: 223
+      ID: 318
       Name: Probe[main.testUintArray]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -5002,7 +5590,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 287
+      ID: 390
       Name: Probe[main.testUintPointer]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -5013,11 +5601,11 @@ Types:
             Type: 34 PointerType *uint
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 74, index: 0, name: x}
+                  Variable: {subprogram: 82, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 291
+      ID: 394
       Name: Probe[main.testUintSlice]
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -5025,14 +5613,14 @@ Types:
         - Name: u
           Offset: 1
           Expression:
-            Type: 137 GoSliceHeaderType []uint
+            Type: 160 GoSliceHeaderType []uint
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 78, index: 0, name: u}
+                  Variable: {subprogram: 86, index: 0, name: u}
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 308
+      ID: 411
       Name: Probe[main.testUnitializedString]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -5043,11 +5631,11 @@ Types:
             Type: 11 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 95, index: 0, name: x}
+                  Variable: {subprogram: 103, index: 0, name: x}
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 286
+      ID: 389
       Name: Probe[main.testUnsafePointer]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -5058,11 +5646,11 @@ Types:
             Type: 19 VoidPointerType unsafe.Pointer
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 73, index: 0, name: x}
+                  Variable: {subprogram: 81, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 231
+      ID: 326
       Name: Probe[main.testVeryLargeArray]
       ByteSize: 801
       PresenceBitsetSize: 1
@@ -5077,7 +5665,7 @@ Types:
                   Offset: 0
                   ByteSize: 800
     - __kind: EventRootType
-      ID: 300
+      ID: 403
       Name: Probe[main.testVeryLargeSlice]
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -5085,10 +5673,10 @@ Types:
         - Name: xs
           Offset: 1
           Expression:
-            Type: 137 GoSliceHeaderType []uint
+            Type: 160 GoSliceHeaderType []uint
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 87, index: 0, name: xs}
+                  Variable: {subprogram: 95, index: 0, name: xs}
                   Offset: 0
                   ByteSize: 24
     - __kind: ArrayType
@@ -5127,7 +5715,7 @@ Types:
       ID: 40
       Name: '[2]int'
       ByteSize: 16
-      GoRuntimeType: 617728
+      GoRuntimeType: 622688
       GoKind: 17
       Count: 2
       HasCount: true
@@ -5144,7 +5732,7 @@ Types:
       ID: 37
       Name: '[2]int32'
       ByteSize: 8
-      GoRuntimeType: 618880
+      GoRuntimeType: 623840
       GoKind: 17
       Count: 2
       HasCount: true
@@ -5166,18 +5754,18 @@ Types:
       HasCount: true
       Element: 14 BaseType int8
     - __kind: ArrayType
-      ID: 93
+      ID: 116
       Name: '[2]map[string]int'
       ByteSize: 16
       GoKind: 17
       Count: 2
       HasCount: true
-      Element: 78 GoMapType map[string]int
+      Element: 101 GoMapType map[string]int
     - __kind: ArrayType
       ID: 38
       Name: '[2]string'
       ByteSize: 32
-      GoRuntimeType: 618976
+      GoRuntimeType: 623936
       GoKind: 17
       Count: 2
       HasCount: true
@@ -5210,7 +5798,7 @@ Types:
       ID: 47
       Name: '[2]uint64'
       ByteSize: 16
-      GoRuntimeType: 619072
+      GoRuntimeType: 624032
       GoKind: 17
       Count: 2
       HasCount: true
@@ -5219,31 +5807,31 @@ Types:
       ID: 36
       Name: '[2]uint8'
       ByteSize: 2
-      GoRuntimeType: 618784
+      GoRuntimeType: 623744
       GoKind: 17
       Count: 2
       HasCount: true
       Element: 3 BaseType uint8
     - __kind: ArrayType
-      ID: 183
+      ID: 213
       Name: '[4]int'
       ByteSize: 32
-      GoRuntimeType: 617344
+      GoRuntimeType: 622304
       GoKind: 17
       Count: 4
       HasCount: true
       Element: 9 BaseType int
     - __kind: ArrayType
-      ID: 168
+      ID: 198
       Name: '[4]string'
       ByteSize: 64
-      GoRuntimeType: 617632
+      GoRuntimeType: 622592
       GoKind: 17
       Count: 4
       HasCount: true
       Element: 11 GoStringHeaderType string
     - __kind: ArrayType
-      ID: 63
+      ID: 88
       Name: '[5]int'
       ByteSize: 40
       GoKind: 17
@@ -5251,19 +5839,107 @@ Types:
       HasCount: true
       Element: 9 BaseType int
     - __kind: ArrayType
-      ID: 157
+      ID: 183
       Name: '[8]uint8'
       ByteSize: 8
-      GoRuntimeType: 615424
+      GoRuntimeType: 619616
       GoKind: 17
       Count: 8
       HasCount: true
       Element: 3 BaseType uint8
     - __kind: GoSliceHeaderType
+      ID: 62
+      Name: '[]*main.deepSlice2'
+      ByteSize: 24
+      GoRuntimeType: 446656
+      GoKind: 23
+      RawFields:
+        - Name: array
+          Offset: 0
+          Type: 63 PointerType **main.deepSlice2
+        - Name: len
+          Offset: 8
+          Type: 9 BaseType int
+        - Name: cap
+          Offset: 16
+          Type: 9 BaseType int
+      Data: 181 GoSliceDataType []*main.deepSlice2.array
+    - __kind: GoSliceDataType
+      ID: 181
+      Name: '[]*main.deepSlice2.array'
+      ByteSize: 2048
+      Element: 64 PointerType *main.deepSlice2
+    - __kind: GoSliceHeaderType
+      ID: 235
+      Name: '[]*main.deepSlice3'
+      ByteSize: 24
+      GoRuntimeType: 446592
+      GoKind: 23
+      RawFields:
+        - Name: array
+          Offset: 0
+          Type: 236 PointerType **main.deepSlice3
+        - Name: len
+          Offset: 8
+          Type: 9 BaseType int
+        - Name: cap
+          Offset: 16
+          Type: 9 BaseType int
+      Data: 239 GoSliceDataType []*main.deepSlice3.array
+    - __kind: GoSliceDataType
+      ID: 239
+      Name: '[]*main.deepSlice3.array'
+      ByteSize: 2048
+      Element: 237 PointerType *main.deepSlice3
+    - __kind: GoSliceHeaderType
+      ID: 254
+      Name: '[]*main.deepSlice8'
+      ByteSize: 24
+      GoRuntimeType: 446272
+      GoKind: 23
+      RawFields:
+        - Name: array
+          Offset: 0
+          Type: 255 PointerType **main.deepSlice8
+        - Name: len
+          Offset: 8
+          Type: 9 BaseType int
+        - Name: cap
+          Offset: 16
+          Type: 9 BaseType int
+      Data: 258 GoSliceDataType []*main.deepSlice8.array
+    - __kind: GoSliceDataType
+      ID: 258
+      Name: '[]*main.deepSlice8.array'
+      ByteSize: 2048
+      Element: 256 PointerType *main.deepSlice8
+    - __kind: GoSliceHeaderType
+      ID: 260
+      Name: '[]*main.deepSlice9'
+      ByteSize: 24
+      GoRuntimeType: 446208
+      GoKind: 23
+      RawFields:
+        - Name: array
+          Offset: 0
+          Type: 261 PointerType **main.deepSlice9
+        - Name: len
+          Offset: 8
+          Type: 9 BaseType int
+        - Name: cap
+          Offset: 16
+          Type: 9 BaseType int
+      Data: 264 GoSliceDataType []*main.deepSlice9.array
+    - __kind: GoSliceDataType
+      ID: 264
+      Name: '[]*main.deepSlice9.array'
+      ByteSize: 2048
+      Element: 262 PointerType *main.deepSlice9
+    - __kind: GoSliceHeaderType
       ID: 53
       Name: '[]*string'
       ByteSize: 24
-      GoRuntimeType: 443232
+      GoRuntimeType: 447424
       GoKind: 23
       RawFields:
         - Name: array
@@ -5275,38 +5951,38 @@ Types:
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 155 GoSliceDataType []*string.array
+      Data: 178 GoSliceDataType []*string.array
     - __kind: GoSliceDataType
-      ID: 155
+      ID: 178
       Name: '[]*string.array'
       ByteSize: 2048
       Element: 22 PointerType *string
     - __kind: GoSliceHeaderType
-      ID: 138
+      ID: 161
       Name: '[][]uint'
       ByteSize: 24
       GoKind: 23
       RawFields:
         - Name: array
           Offset: 0
-          Type: 139 PointerType *[]uint
+          Type: 162 PointerType *[]uint
         - Name: len
           Offset: 8
           Type: 9 BaseType int
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 190 GoSliceDataType [][]uint.array
+      Data: 220 GoSliceDataType [][]uint.array
     - __kind: GoSliceDataType
-      ID: 190
+      ID: 220
       Name: '[][]uint.array'
       ByteSize: 2048
-      Element: 137 GoSliceHeaderType []uint
+      Element: 160 GoSliceHeaderType []uint
     - __kind: GoSliceHeaderType
-      ID: 144
+      ID: 167
       Name: '[]bool'
       ByteSize: 24
-      GoRuntimeType: 449760
+      GoRuntimeType: 453952
       GoKind: 23
       RawFields:
         - Name: array
@@ -5318,162 +5994,209 @@ Types:
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 196 GoSliceDataType []bool.array
+      Data: 226 GoSliceDataType []bool.array
     - __kind: GoSliceDataType
-      ID: 196
+      ID: 226
       Name: '[]bool.array'
       ByteSize: 2048
       Element: 4 BaseType bool
     - __kind: GoSliceDataType
-      ID: 187
+      ID: 217
       Name: '[]bucket<[4]int,[4]int>.array'
       ByteSize: 2048
-      Element: 129 GoHMapBucketType bucket<[4]int,[4]int>
+      Element: 152 GoHMapBucketType bucket<[4]int,[4]int>
     - __kind: GoSliceDataType
-      ID: 186
+      ID: 216
       Name: '[]bucket<[4]int,uint8>.array'
       ByteSize: 2048
-      Element: 124 GoHMapBucketType bucket<[4]int,uint8>
+      Element: 147 GoHMapBucketType bucket<[4]int,uint8>
     - __kind: GoSliceDataType
-      ID: 170
+      ID: 200
       Name: '[]bucket<[4]string,[2]int>.array'
       ByteSize: 2048
-      Element: 92 GoHMapBucketType bucket<[4]string,[2]int>
+      Element: 115 GoHMapBucketType bucket<[4]string,[2]int>
     - __kind: GoSliceDataType
-      ID: 177
+      ID: 207
       Name: '[]bucket<bool,main.node>.array'
       ByteSize: 2048
-      Element: 104 GoHMapBucketType bucket<bool,main.node>
+      Element: 127 GoHMapBucketType bucket<bool,main.node>
     - __kind: GoSliceDataType
-      ID: 160
+      ID: 188
+      Name: '[]bucket<int,*main.deepMap2>.array'
+      ByteSize: 2048
+      Element: 72 GoHMapBucketType bucket<int,*main.deepMap2>
+    - __kind: GoSliceDataType
+      ID: 249
+      Name: '[]bucket<int,*main.deepMap3>.array'
+      ByteSize: 2048
+      Element: 245 GoHMapBucketType bucket<int,*main.deepMap3>
+    - __kind: GoSliceDataType
+      ID: 278
+      Name: '[]bucket<int,*main.deepMap8>.array'
+      ByteSize: 2048
+      Element: 274 GoHMapBucketType bucket<int,*main.deepMap8>
+    - __kind: GoSliceDataType
+      ID: 287
+      Name: '[]bucket<int,*main.deepMap9>.array'
+      ByteSize: 2048
+      Element: 283 GoHMapBucketType bucket<int,*main.deepMap9>
+    - __kind: GoSliceDataType
+      ID: 190
       Name: '[]bucket<int,int>.array'
       ByteSize: 2048
-      Element: 70 GoHMapBucketType bucket<int,int>
+      Element: 95 GoHMapBucketType bucket<int,int>
     - __kind: GoSliceDataType
-      ID: 179
+      ID: 294
+      Name: '[]bucket<int,interface {}>.array'
+      ByteSize: 2048
+      Element: 292 GoHMapBucketType bucket<int,interface {}>
+    - __kind: GoSliceDataType
+      ID: 209
       Name: '[]bucket<int,uint8>.array'
       ByteSize: 2048
-      Element: 109 GoHMapBucketType bucket<int,uint8>
+      Element: 132 GoHMapBucketType bucket<int,uint8>
     - __kind: GoSliceDataType
-      ID: 174
+      ID: 204
       Name: '[]bucket<string,[]main.structWithMap>.array'
       ByteSize: 2048
-      Element: 99 GoHMapBucketType bucket<string,[]main.structWithMap>
+      Element: 122 GoHMapBucketType bucket<string,[]main.structWithMap>
     - __kind: GoSliceDataType
-      ID: 166
+      ID: 196
       Name: '[]bucket<string,[]string>.array'
       ByteSize: 2048
-      Element: 87 GoHMapBucketType bucket<string,[]string>
+      Element: 110 GoHMapBucketType bucket<string,[]string>
     - __kind: GoSliceDataType
-      ID: 164
+      ID: 194
       Name: '[]bucket<string,int>.array'
       ByteSize: 2048
-      Element: 82 GoHMapBucketType bucket<string,int>
+      Element: 105 GoHMapBucketType bucket<string,int>
     - __kind: GoSliceDataType
-      ID: 163
+      ID: 193
       Name: '[]bucket<string,main.nestedStruct>.array'
       ByteSize: 2048
-      Element: 77 GoHMapBucketType bucket<string,main.nestedStruct>
+      Element: 100 GoHMapBucketType bucket<string,main.nestedStruct>
     - __kind: GoSliceDataType
-      ID: 184
+      ID: 214
       Name: '[]bucket<uint8,[4]int>.array'
       ByteSize: 2048
-      Element: 119 GoHMapBucketType bucket<uint8,[4]int>
+      Element: 142 GoHMapBucketType bucket<uint8,[4]int>
     - __kind: GoSliceDataType
-      ID: 181
+      ID: 211
       Name: '[]bucket<uint8,uint8>.array'
       ByteSize: 2048
-      Element: 114 GoHMapBucketType bucket<uint8,uint8>
+      Element: 137 GoHMapBucketType bucket<uint8,uint8>
+    - __kind: GoSliceHeaderType
+      ID: 266
+      Name: '[]interface {}'
+      ByteSize: 24
+      GoRuntimeType: 454272
+      GoKind: 23
+      RawFields:
+        - Name: array
+          Offset: 0
+          Type: 267 PointerType *interface {}
+        - Name: len
+          Offset: 8
+          Type: 9 BaseType int
+        - Name: cap
+          Offset: 16
+          Type: 9 BaseType int
+      Data: 268 GoSliceDataType []interface {}.array
+    - __kind: GoSliceDataType
+      ID: 268
+      Name: '[]interface {}.array'
+      ByteSize: 2048
+      Element: 83 GoEmptyInterfaceType interface {}
     - __kind: ArrayType
-      ID: 185
+      ID: 215
       Name: '[]key<[4]int>'
       ByteSize: 256
       Count: 8
       HasCount: true
-      Element: 183 ArrayType [4]int
+      Element: 213 ArrayType [4]int
     - __kind: ArrayType
-      ID: 167
+      ID: 197
       Name: '[]key<[4]string>'
       ByteSize: 512
       Count: 8
       HasCount: true
-      Element: 168 ArrayType [4]string
+      Element: 198 ArrayType [4]string
     - __kind: ArrayType
-      ID: 175
+      ID: 205
       Name: '[]key<bool>'
       ByteSize: 8
       Count: 8
       HasCount: true
       Element: 4 BaseType bool
     - __kind: ArrayType
-      ID: 158
+      ID: 184
       Name: '[]key<int>'
       ByteSize: 64
       Count: 8
       HasCount: true
       Element: 9 BaseType int
     - __kind: ArrayType
-      ID: 161
+      ID: 191
       Name: '[]key<string>'
       ByteSize: 128
       Count: 8
       HasCount: true
       Element: 11 GoStringHeaderType string
     - __kind: ArrayType
-      ID: 180
+      ID: 210
       Name: '[]key<uint8>'
       ByteSize: 8
       Count: 8
       HasCount: true
       Element: 3 BaseType uint8
     - __kind: GoSliceHeaderType
-      ID: 172
+      ID: 202
       Name: '[]main.structWithMap'
       ByteSize: 24
-      GoRuntimeType: 442720
+      GoRuntimeType: 446912
       GoKind: 23
       RawFields:
         - Name: array
           Offset: 0
-          Type: 173 PointerType *main.structWithMap
+          Type: 203 PointerType *main.structWithMap
         - Name: len
           Offset: 8
           Type: 9 BaseType int
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 212 GoSliceDataType []main.structWithMap.array
+      Data: 307 GoSliceDataType []main.structWithMap.array
     - __kind: GoSliceDataType
-      ID: 212
+      ID: 307
       Name: '[]main.structWithMap.array'
       ByteSize: 2048
-      Element: 65 StructureType main.structWithMap
+      Element: 90 StructureType main.structWithMap
     - __kind: GoSliceHeaderType
-      ID: 140
+      ID: 163
       Name: '[]main.structWithNoStrings'
       ByteSize: 24
       GoKind: 23
       RawFields:
         - Name: array
           Offset: 0
-          Type: 141 PointerType *main.structWithNoStrings
+          Type: 164 PointerType *main.structWithNoStrings
         - Name: len
           Offset: 8
           Type: 9 BaseType int
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 192 GoSliceDataType []main.structWithNoStrings.array
+      Data: 222 GoSliceDataType []main.structWithNoStrings.array
     - __kind: GoSliceDataType
-      ID: 192
+      ID: 222
       Name: '[]main.structWithNoStrings.array'
       ByteSize: 2048
-      Element: 142 StructureType main.structWithNoStrings
+      Element: 165 StructureType main.structWithNoStrings
     - __kind: GoSliceHeaderType
-      ID: 143
+      ID: 166
       Name: '[]string'
       ByteSize: 24
-      GoRuntimeType: 449888
+      GoRuntimeType: 454080
       GoKind: 23
       RawFields:
         - Name: array
@@ -5485,17 +6208,17 @@ Types:
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 194 GoSliceDataType []string.array
+      Data: 224 GoSliceDataType []string.array
     - __kind: GoSliceDataType
-      ID: 194
+      ID: 224
       Name: '[]string.array'
       ByteSize: 2048
       Element: 11 GoStringHeaderType string
     - __kind: GoSliceHeaderType
-      ID: 137
+      ID: 160
       Name: '[]uint'
       ByteSize: 24
-      GoRuntimeType: 449376
+      GoRuntimeType: 453568
       GoKind: 23
       RawFields:
         - Name: array
@@ -5507,17 +6230,17 @@ Types:
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 188 GoSliceDataType []uint.array
+      Data: 218 GoSliceDataType []uint.array
     - __kind: GoSliceDataType
-      ID: 188
+      ID: 218
       Name: '[]uint.array'
       ByteSize: 2048
       Element: 15 BaseType uint
     - __kind: GoSliceHeaderType
-      ID: 145
+      ID: 168
       Name: '[]uint16'
       ByteSize: 24
-      GoRuntimeType: 448736
+      GoRuntimeType: 452928
       GoKind: 23
       RawFields:
         - Name: array
@@ -5529,63 +6252,98 @@ Types:
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 198 GoSliceDataType []uint16.array
+      Data: 228 GoSliceDataType []uint16.array
     - __kind: GoSliceDataType
-      ID: 198
+      ID: 228
       Name: '[]uint16.array'
       ByteSize: 2048
       Element: 7 BaseType uint16
     - __kind: ArrayType
-      ID: 169
+      ID: 185
+      Name: '[]val<*main.deepMap2>'
+      ByteSize: 64
+      Count: 8
+      HasCount: true
+      Element: 186 PointerType *main.deepMap2
+    - __kind: ArrayType
+      ID: 246
+      Name: '[]val<*main.deepMap3>'
+      ByteSize: 64
+      Count: 8
+      HasCount: true
+      Element: 247 PointerType *main.deepMap3
+    - __kind: ArrayType
+      ID: 275
+      Name: '[]val<*main.deepMap8>'
+      ByteSize: 64
+      Count: 8
+      HasCount: true
+      Element: 276 PointerType *main.deepMap8
+    - __kind: ArrayType
+      ID: 284
+      Name: '[]val<*main.deepMap9>'
+      ByteSize: 64
+      Count: 8
+      HasCount: true
+      Element: 285 PointerType *main.deepMap9
+    - __kind: ArrayType
+      ID: 199
       Name: '[]val<[2]int>'
       ByteSize: 128
       Count: 8
       HasCount: true
       Element: 40 ArrayType [2]int
     - __kind: ArrayType
-      ID: 182
+      ID: 212
       Name: '[]val<[4]int>'
       ByteSize: 256
       Count: 8
       HasCount: true
-      Element: 183 ArrayType [4]int
+      Element: 213 ArrayType [4]int
     - __kind: ArrayType
-      ID: 171
+      ID: 201
       Name: '[]val<[]main.structWithMap>'
       ByteSize: 192
       Count: 8
       HasCount: true
-      Element: 172 GoSliceHeaderType []main.structWithMap
+      Element: 202 GoSliceHeaderType []main.structWithMap
     - __kind: ArrayType
-      ID: 165
+      ID: 195
       Name: '[]val<[]string>'
       ByteSize: 192
       Count: 8
       HasCount: true
-      Element: 143 GoSliceHeaderType []string
+      Element: 166 GoSliceHeaderType []string
     - __kind: ArrayType
-      ID: 159
+      ID: 189
       Name: '[]val<int>'
       ByteSize: 64
       Count: 8
       HasCount: true
       Element: 9 BaseType int
     - __kind: ArrayType
-      ID: 162
+      ID: 293
+      Name: '[]val<interface {}>'
+      ByteSize: 128
+      Count: 8
+      HasCount: true
+      Element: 83 GoEmptyInterfaceType interface {}
+    - __kind: ArrayType
+      ID: 192
       Name: '[]val<main.nestedStruct>'
       ByteSize: 192
       Count: 8
       HasCount: true
-      Element: 151 StructureType main.nestedStruct
+      Element: 174 StructureType main.nestedStruct
     - __kind: ArrayType
-      ID: 176
+      ID: 206
       Name: '[]val<main.node>'
       ByteSize: 128
       Count: 8
       HasCount: true
-      Element: 133 StructureType main.node
+      Element: 156 StructureType main.node
     - __kind: ArrayType
-      ID: 178
+      ID: 208
       Name: '[]val<uint8>'
       ByteSize: 8
       Count: 8
@@ -5595,263 +6353,358 @@ Types:
       ID: 4
       Name: bool
       ByteSize: 1
-      GoRuntimeType: 527872
+      GoRuntimeType: 532064
       GoKind: 1
     - __kind: GoHMapBucketType
-      ID: 129
+      ID: 152
       Name: bucket<[4]int,[4]int>
       ByteSize: 528
       RawFields:
         - Name: tophash
           Offset: 0
-          Type: 157 ArrayType [8]uint8
+          Type: 183 ArrayType [8]uint8
         - Name: keys
           Offset: 8
-          Type: 185 ArrayType []key<[4]int>
+          Type: 215 ArrayType []key<[4]int>
         - Name: values
           Offset: 264
-          Type: 182 ArrayType []val<[4]int>
+          Type: 212 ArrayType []val<[4]int>
         - Name: overflow
           Offset: 520
-          Type: 128 PointerType *bucket<[4]int,[4]int>
-      KeyType: 183 ArrayType [4]int
-      ValueType: 183 ArrayType [4]int
+          Type: 151 PointerType *bucket<[4]int,[4]int>
+      KeyType: 213 ArrayType [4]int
+      ValueType: 213 ArrayType [4]int
     - __kind: GoHMapBucketType
-      ID: 124
+      ID: 147
       Name: bucket<[4]int,uint8>
       ByteSize: 280
       RawFields:
         - Name: tophash
           Offset: 0
-          Type: 157 ArrayType [8]uint8
+          Type: 183 ArrayType [8]uint8
         - Name: keys
           Offset: 8
-          Type: 185 ArrayType []key<[4]int>
+          Type: 215 ArrayType []key<[4]int>
         - Name: values
           Offset: 264
-          Type: 178 ArrayType []val<uint8>
+          Type: 208 ArrayType []val<uint8>
         - Name: overflow
           Offset: 272
-          Type: 123 PointerType *bucket<[4]int,uint8>
-      KeyType: 183 ArrayType [4]int
+          Type: 146 PointerType *bucket<[4]int,uint8>
+      KeyType: 213 ArrayType [4]int
       ValueType: 3 BaseType uint8
     - __kind: GoHMapBucketType
-      ID: 92
+      ID: 115
       Name: bucket<[4]string,[2]int>
       ByteSize: 656
       RawFields:
         - Name: tophash
           Offset: 0
-          Type: 157 ArrayType [8]uint8
+          Type: 183 ArrayType [8]uint8
         - Name: keys
           Offset: 8
-          Type: 167 ArrayType []key<[4]string>
+          Type: 197 ArrayType []key<[4]string>
         - Name: values
           Offset: 520
-          Type: 169 ArrayType []val<[2]int>
+          Type: 199 ArrayType []val<[2]int>
         - Name: overflow
           Offset: 648
-          Type: 91 PointerType *bucket<[4]string,[2]int>
-      KeyType: 168 ArrayType [4]string
+          Type: 114 PointerType *bucket<[4]string,[2]int>
+      KeyType: 198 ArrayType [4]string
       ValueType: 40 ArrayType [2]int
     - __kind: GoHMapBucketType
-      ID: 104
+      ID: 127
       Name: bucket<bool,main.node>
       ByteSize: 152
       RawFields:
         - Name: tophash
           Offset: 0
-          Type: 157 ArrayType [8]uint8
+          Type: 183 ArrayType [8]uint8
         - Name: keys
           Offset: 8
-          Type: 175 ArrayType []key<bool>
+          Type: 205 ArrayType []key<bool>
         - Name: values
           Offset: 16
-          Type: 176 ArrayType []val<main.node>
+          Type: 206 ArrayType []val<main.node>
         - Name: overflow
           Offset: 144
-          Type: 103 PointerType *bucket<bool,main.node>
+          Type: 126 PointerType *bucket<bool,main.node>
       KeyType: 4 BaseType bool
-      ValueType: 133 StructureType main.node
+      ValueType: 156 StructureType main.node
     - __kind: GoHMapBucketType
-      ID: 70
+      ID: 72
+      Name: bucket<int,*main.deepMap2>
+      ByteSize: 144
+      RawFields:
+        - Name: tophash
+          Offset: 0
+          Type: 183 ArrayType [8]uint8
+        - Name: keys
+          Offset: 8
+          Type: 184 ArrayType []key<int>
+        - Name: values
+          Offset: 72
+          Type: 185 ArrayType []val<*main.deepMap2>
+        - Name: overflow
+          Offset: 136
+          Type: 71 PointerType *bucket<int,*main.deepMap2>
+      KeyType: 9 BaseType int
+      ValueType: 186 PointerType *main.deepMap2
+    - __kind: GoHMapBucketType
+      ID: 245
+      Name: bucket<int,*main.deepMap3>
+      ByteSize: 144
+      RawFields:
+        - Name: tophash
+          Offset: 0
+          Type: 183 ArrayType [8]uint8
+        - Name: keys
+          Offset: 8
+          Type: 184 ArrayType []key<int>
+        - Name: values
+          Offset: 72
+          Type: 246 ArrayType []val<*main.deepMap3>
+        - Name: overflow
+          Offset: 136
+          Type: 244 PointerType *bucket<int,*main.deepMap3>
+      KeyType: 9 BaseType int
+      ValueType: 247 PointerType *main.deepMap3
+    - __kind: GoHMapBucketType
+      ID: 274
+      Name: bucket<int,*main.deepMap8>
+      ByteSize: 144
+      RawFields:
+        - Name: tophash
+          Offset: 0
+          Type: 183 ArrayType [8]uint8
+        - Name: keys
+          Offset: 8
+          Type: 184 ArrayType []key<int>
+        - Name: values
+          Offset: 72
+          Type: 275 ArrayType []val<*main.deepMap8>
+        - Name: overflow
+          Offset: 136
+          Type: 273 PointerType *bucket<int,*main.deepMap8>
+      KeyType: 9 BaseType int
+      ValueType: 276 PointerType *main.deepMap8
+    - __kind: GoHMapBucketType
+      ID: 283
+      Name: bucket<int,*main.deepMap9>
+      ByteSize: 144
+      RawFields:
+        - Name: tophash
+          Offset: 0
+          Type: 183 ArrayType [8]uint8
+        - Name: keys
+          Offset: 8
+          Type: 184 ArrayType []key<int>
+        - Name: values
+          Offset: 72
+          Type: 284 ArrayType []val<*main.deepMap9>
+        - Name: overflow
+          Offset: 136
+          Type: 282 PointerType *bucket<int,*main.deepMap9>
+      KeyType: 9 BaseType int
+      ValueType: 285 PointerType *main.deepMap9
+    - __kind: GoHMapBucketType
+      ID: 95
       Name: bucket<int,int>
       ByteSize: 144
       RawFields:
         - Name: tophash
           Offset: 0
-          Type: 157 ArrayType [8]uint8
+          Type: 183 ArrayType [8]uint8
         - Name: keys
           Offset: 8
-          Type: 158 ArrayType []key<int>
+          Type: 184 ArrayType []key<int>
         - Name: values
           Offset: 72
-          Type: 159 ArrayType []val<int>
+          Type: 189 ArrayType []val<int>
         - Name: overflow
           Offset: 136
-          Type: 69 PointerType *bucket<int,int>
+          Type: 94 PointerType *bucket<int,int>
       KeyType: 9 BaseType int
       ValueType: 9 BaseType int
     - __kind: GoHMapBucketType
-      ID: 109
+      ID: 292
+      Name: bucket<int,interface {}>
+      ByteSize: 208
+      RawFields:
+        - Name: tophash
+          Offset: 0
+          Type: 183 ArrayType [8]uint8
+        - Name: keys
+          Offset: 8
+          Type: 184 ArrayType []key<int>
+        - Name: values
+          Offset: 72
+          Type: 293 ArrayType []val<interface {}>
+        - Name: overflow
+          Offset: 200
+          Type: 291 PointerType *bucket<int,interface {}>
+      KeyType: 9 BaseType int
+      ValueType: 83 GoEmptyInterfaceType interface {}
+    - __kind: GoHMapBucketType
+      ID: 132
       Name: bucket<int,uint8>
       ByteSize: 88
       RawFields:
         - Name: tophash
           Offset: 0
-          Type: 157 ArrayType [8]uint8
+          Type: 183 ArrayType [8]uint8
         - Name: keys
           Offset: 8
-          Type: 158 ArrayType []key<int>
+          Type: 184 ArrayType []key<int>
         - Name: values
           Offset: 72
-          Type: 178 ArrayType []val<uint8>
+          Type: 208 ArrayType []val<uint8>
         - Name: overflow
           Offset: 80
-          Type: 108 PointerType *bucket<int,uint8>
+          Type: 131 PointerType *bucket<int,uint8>
       KeyType: 9 BaseType int
       ValueType: 3 BaseType uint8
     - __kind: GoHMapBucketType
-      ID: 99
+      ID: 122
       Name: bucket<string,[]main.structWithMap>
       ByteSize: 336
       RawFields:
         - Name: tophash
           Offset: 0
-          Type: 157 ArrayType [8]uint8
+          Type: 183 ArrayType [8]uint8
         - Name: keys
           Offset: 8
-          Type: 161 ArrayType []key<string>
+          Type: 191 ArrayType []key<string>
         - Name: values
           Offset: 136
-          Type: 171 ArrayType []val<[]main.structWithMap>
+          Type: 201 ArrayType []val<[]main.structWithMap>
         - Name: overflow
           Offset: 328
-          Type: 98 PointerType *bucket<string,[]main.structWithMap>
+          Type: 121 PointerType *bucket<string,[]main.structWithMap>
       KeyType: 11 GoStringHeaderType string
-      ValueType: 172 GoSliceHeaderType []main.structWithMap
+      ValueType: 202 GoSliceHeaderType []main.structWithMap
     - __kind: GoHMapBucketType
-      ID: 87
+      ID: 110
       Name: bucket<string,[]string>
       ByteSize: 336
       RawFields:
         - Name: tophash
           Offset: 0
-          Type: 157 ArrayType [8]uint8
+          Type: 183 ArrayType [8]uint8
         - Name: keys
           Offset: 8
-          Type: 161 ArrayType []key<string>
+          Type: 191 ArrayType []key<string>
         - Name: values
           Offset: 136
-          Type: 165 ArrayType []val<[]string>
+          Type: 195 ArrayType []val<[]string>
         - Name: overflow
           Offset: 328
-          Type: 86 PointerType *bucket<string,[]string>
+          Type: 109 PointerType *bucket<string,[]string>
       KeyType: 11 GoStringHeaderType string
-      ValueType: 143 GoSliceHeaderType []string
+      ValueType: 166 GoSliceHeaderType []string
     - __kind: GoHMapBucketType
-      ID: 82
+      ID: 105
       Name: bucket<string,int>
       ByteSize: 208
       RawFields:
         - Name: tophash
           Offset: 0
-          Type: 157 ArrayType [8]uint8
+          Type: 183 ArrayType [8]uint8
         - Name: keys
           Offset: 8
-          Type: 161 ArrayType []key<string>
+          Type: 191 ArrayType []key<string>
         - Name: values
           Offset: 136
-          Type: 159 ArrayType []val<int>
+          Type: 189 ArrayType []val<int>
         - Name: overflow
           Offset: 200
-          Type: 81 PointerType *bucket<string,int>
+          Type: 104 PointerType *bucket<string,int>
       KeyType: 11 GoStringHeaderType string
       ValueType: 9 BaseType int
     - __kind: GoHMapBucketType
-      ID: 77
+      ID: 100
       Name: bucket<string,main.nestedStruct>
       ByteSize: 336
       RawFields:
         - Name: tophash
           Offset: 0
-          Type: 157 ArrayType [8]uint8
+          Type: 183 ArrayType [8]uint8
         - Name: keys
           Offset: 8
-          Type: 161 ArrayType []key<string>
+          Type: 191 ArrayType []key<string>
         - Name: values
           Offset: 136
-          Type: 162 ArrayType []val<main.nestedStruct>
+          Type: 192 ArrayType []val<main.nestedStruct>
         - Name: overflow
           Offset: 328
-          Type: 76 PointerType *bucket<string,main.nestedStruct>
+          Type: 99 PointerType *bucket<string,main.nestedStruct>
       KeyType: 11 GoStringHeaderType string
-      ValueType: 151 StructureType main.nestedStruct
+      ValueType: 174 StructureType main.nestedStruct
     - __kind: GoHMapBucketType
-      ID: 119
+      ID: 142
       Name: bucket<uint8,[4]int>
       ByteSize: 280
       RawFields:
         - Name: tophash
           Offset: 0
-          Type: 157 ArrayType [8]uint8
+          Type: 183 ArrayType [8]uint8
         - Name: keys
           Offset: 8
-          Type: 180 ArrayType []key<uint8>
+          Type: 210 ArrayType []key<uint8>
         - Name: values
           Offset: 16
-          Type: 182 ArrayType []val<[4]int>
+          Type: 212 ArrayType []val<[4]int>
         - Name: overflow
           Offset: 272
-          Type: 118 PointerType *bucket<uint8,[4]int>
+          Type: 141 PointerType *bucket<uint8,[4]int>
       KeyType: 3 BaseType uint8
-      ValueType: 183 ArrayType [4]int
+      ValueType: 213 ArrayType [4]int
     - __kind: GoHMapBucketType
-      ID: 114
+      ID: 137
       Name: bucket<uint8,uint8>
       ByteSize: 32
       RawFields:
         - Name: tophash
           Offset: 0
-          Type: 157 ArrayType [8]uint8
+          Type: 183 ArrayType [8]uint8
         - Name: keys
           Offset: 8
-          Type: 180 ArrayType []key<uint8>
+          Type: 210 ArrayType []key<uint8>
         - Name: values
           Offset: 16
-          Type: 178 ArrayType []val<uint8>
+          Type: 208 ArrayType []val<uint8>
         - Name: overflow
           Offset: 24
-          Type: 113 PointerType *bucket<uint8,uint8>
+          Type: 136 PointerType *bucket<uint8,uint8>
       KeyType: 3 BaseType uint8
       ValueType: 3 BaseType uint8
     - __kind: GoChannelType
-      ID: 130
+      ID: 153
       Name: chan bool
-      GoRuntimeType: 539136
+      GoRuntimeType: 543328
       GoKind: 18
     - __kind: GoChannelType
-      ID: 57
+      ID: 82
       Name: chan struct {}
-      GoRuntimeType: 538048
+      GoRuntimeType: 542240
       GoKind: 18
     - __kind: BaseType
       ID: 24
       Name: complex128
       ByteSize: 16
-      GoRuntimeType: 527680
+      GoRuntimeType: 531872
       GoKind: 16
     - __kind: BaseType
       ID: 23
       Name: complex64
       ByteSize: 8
-      GoRuntimeType: 527616
+      GoRuntimeType: 531808
       GoKind: 15
     - __kind: GoInterfaceType
       ID: 18
       Name: error
       ByteSize: 16
-      GoRuntimeType: 977856
+      GoRuntimeType: 983680
       GoKind: 20
       RawFields:
         - Name: tab
@@ -5864,22 +6717,22 @@ Types:
       ID: 16
       Name: float32
       ByteSize: 4
-      GoRuntimeType: 527744
+      GoRuntimeType: 531936
       GoKind: 13
     - __kind: BaseType
       ID: 17
       Name: float64
       ByteSize: 8
-      GoRuntimeType: 527808
+      GoRuntimeType: 532000
       GoKind: 14
     - __kind: GoSubroutineType
-      ID: 60
+      ID: 85
       Name: func()
       ByteSize: 8
-      GoRuntimeType: 441824
+      GoRuntimeType: 444992
       GoKind: 19
     - __kind: GoHMapHeaderType
-      ID: 127
+      ID: 150
       Name: hash<[4]int,[4]int>
       ByteSize: 48
       RawFields:
@@ -5900,20 +6753,20 @@ Types:
           Type: 2 BaseType uint32
         - Name: buckets
           Offset: 16
-          Type: 128 PointerType *bucket<[4]int,[4]int>
+          Type: 151 PointerType *bucket<[4]int,[4]int>
         - Name: oldbuckets
           Offset: 24
-          Type: 128 PointerType *bucket<[4]int,[4]int>
+          Type: 151 PointerType *bucket<[4]int,[4]int>
         - Name: nevacuate
           Offset: 32
           Type: 1 BaseType uintptr
         - Name: extra
           Offset: 40
-          Type: 71 PointerType *runtime.mapextra
-      BucketType: 129 GoHMapBucketType bucket<[4]int,[4]int>
-      BucketsType: 187 GoSliceDataType []bucket<[4]int,[4]int>.array
+          Type: 73 PointerType *runtime.mapextra
+      BucketType: 152 GoHMapBucketType bucket<[4]int,[4]int>
+      BucketsType: 217 GoSliceDataType []bucket<[4]int,[4]int>.array
     - __kind: GoHMapHeaderType
-      ID: 122
+      ID: 145
       Name: hash<[4]int,uint8>
       ByteSize: 48
       RawFields:
@@ -5934,20 +6787,20 @@ Types:
           Type: 2 BaseType uint32
         - Name: buckets
           Offset: 16
-          Type: 123 PointerType *bucket<[4]int,uint8>
+          Type: 146 PointerType *bucket<[4]int,uint8>
         - Name: oldbuckets
           Offset: 24
-          Type: 123 PointerType *bucket<[4]int,uint8>
+          Type: 146 PointerType *bucket<[4]int,uint8>
         - Name: nevacuate
           Offset: 32
           Type: 1 BaseType uintptr
         - Name: extra
           Offset: 40
-          Type: 71 PointerType *runtime.mapextra
-      BucketType: 124 GoHMapBucketType bucket<[4]int,uint8>
-      BucketsType: 186 GoSliceDataType []bucket<[4]int,uint8>.array
+          Type: 73 PointerType *runtime.mapextra
+      BucketType: 147 GoHMapBucketType bucket<[4]int,uint8>
+      BucketsType: 216 GoSliceDataType []bucket<[4]int,uint8>.array
     - __kind: GoHMapHeaderType
-      ID: 90
+      ID: 113
       Name: hash<[4]string,[2]int>
       ByteSize: 48
       RawFields:
@@ -5968,20 +6821,20 @@ Types:
           Type: 2 BaseType uint32
         - Name: buckets
           Offset: 16
-          Type: 91 PointerType *bucket<[4]string,[2]int>
+          Type: 114 PointerType *bucket<[4]string,[2]int>
         - Name: oldbuckets
           Offset: 24
-          Type: 91 PointerType *bucket<[4]string,[2]int>
+          Type: 114 PointerType *bucket<[4]string,[2]int>
         - Name: nevacuate
           Offset: 32
           Type: 1 BaseType uintptr
         - Name: extra
           Offset: 40
-          Type: 71 PointerType *runtime.mapextra
-      BucketType: 92 GoHMapBucketType bucket<[4]string,[2]int>
-      BucketsType: 170 GoSliceDataType []bucket<[4]string,[2]int>.array
+          Type: 73 PointerType *runtime.mapextra
+      BucketType: 115 GoHMapBucketType bucket<[4]string,[2]int>
+      BucketsType: 200 GoSliceDataType []bucket<[4]string,[2]int>.array
     - __kind: GoHMapHeaderType
-      ID: 102
+      ID: 125
       Name: hash<bool,main.node>
       ByteSize: 48
       RawFields:
@@ -6002,20 +6855,156 @@ Types:
           Type: 2 BaseType uint32
         - Name: buckets
           Offset: 16
-          Type: 103 PointerType *bucket<bool,main.node>
+          Type: 126 PointerType *bucket<bool,main.node>
         - Name: oldbuckets
           Offset: 24
-          Type: 103 PointerType *bucket<bool,main.node>
+          Type: 126 PointerType *bucket<bool,main.node>
         - Name: nevacuate
           Offset: 32
           Type: 1 BaseType uintptr
         - Name: extra
           Offset: 40
-          Type: 71 PointerType *runtime.mapextra
-      BucketType: 104 GoHMapBucketType bucket<bool,main.node>
-      BucketsType: 177 GoSliceDataType []bucket<bool,main.node>.array
+          Type: 73 PointerType *runtime.mapextra
+      BucketType: 127 GoHMapBucketType bucket<bool,main.node>
+      BucketsType: 207 GoSliceDataType []bucket<bool,main.node>.array
     - __kind: GoHMapHeaderType
-      ID: 68
+      ID: 70
+      Name: hash<int,*main.deepMap2>
+      ByteSize: 48
+      RawFields:
+        - Name: count
+          Offset: 0
+          Type: 9 BaseType int
+        - Name: flags
+          Offset: 8
+          Type: 3 BaseType uint8
+        - Name: B
+          Offset: 9
+          Type: 3 BaseType uint8
+        - Name: noverflow
+          Offset: 10
+          Type: 7 BaseType uint16
+        - Name: hash0
+          Offset: 12
+          Type: 2 BaseType uint32
+        - Name: buckets
+          Offset: 16
+          Type: 71 PointerType *bucket<int,*main.deepMap2>
+        - Name: oldbuckets
+          Offset: 24
+          Type: 71 PointerType *bucket<int,*main.deepMap2>
+        - Name: nevacuate
+          Offset: 32
+          Type: 1 BaseType uintptr
+        - Name: extra
+          Offset: 40
+          Type: 73 PointerType *runtime.mapextra
+      BucketType: 72 GoHMapBucketType bucket<int,*main.deepMap2>
+      BucketsType: 188 GoSliceDataType []bucket<int,*main.deepMap2>.array
+    - __kind: GoHMapHeaderType
+      ID: 243
+      Name: hash<int,*main.deepMap3>
+      ByteSize: 48
+      RawFields:
+        - Name: count
+          Offset: 0
+          Type: 9 BaseType int
+        - Name: flags
+          Offset: 8
+          Type: 3 BaseType uint8
+        - Name: B
+          Offset: 9
+          Type: 3 BaseType uint8
+        - Name: noverflow
+          Offset: 10
+          Type: 7 BaseType uint16
+        - Name: hash0
+          Offset: 12
+          Type: 2 BaseType uint32
+        - Name: buckets
+          Offset: 16
+          Type: 244 PointerType *bucket<int,*main.deepMap3>
+        - Name: oldbuckets
+          Offset: 24
+          Type: 244 PointerType *bucket<int,*main.deepMap3>
+        - Name: nevacuate
+          Offset: 32
+          Type: 1 BaseType uintptr
+        - Name: extra
+          Offset: 40
+          Type: 73 PointerType *runtime.mapextra
+      BucketType: 245 GoHMapBucketType bucket<int,*main.deepMap3>
+      BucketsType: 249 GoSliceDataType []bucket<int,*main.deepMap3>.array
+    - __kind: GoHMapHeaderType
+      ID: 272
+      Name: hash<int,*main.deepMap8>
+      ByteSize: 48
+      RawFields:
+        - Name: count
+          Offset: 0
+          Type: 9 BaseType int
+        - Name: flags
+          Offset: 8
+          Type: 3 BaseType uint8
+        - Name: B
+          Offset: 9
+          Type: 3 BaseType uint8
+        - Name: noverflow
+          Offset: 10
+          Type: 7 BaseType uint16
+        - Name: hash0
+          Offset: 12
+          Type: 2 BaseType uint32
+        - Name: buckets
+          Offset: 16
+          Type: 273 PointerType *bucket<int,*main.deepMap8>
+        - Name: oldbuckets
+          Offset: 24
+          Type: 273 PointerType *bucket<int,*main.deepMap8>
+        - Name: nevacuate
+          Offset: 32
+          Type: 1 BaseType uintptr
+        - Name: extra
+          Offset: 40
+          Type: 73 PointerType *runtime.mapextra
+      BucketType: 274 GoHMapBucketType bucket<int,*main.deepMap8>
+      BucketsType: 278 GoSliceDataType []bucket<int,*main.deepMap8>.array
+    - __kind: GoHMapHeaderType
+      ID: 281
+      Name: hash<int,*main.deepMap9>
+      ByteSize: 48
+      RawFields:
+        - Name: count
+          Offset: 0
+          Type: 9 BaseType int
+        - Name: flags
+          Offset: 8
+          Type: 3 BaseType uint8
+        - Name: B
+          Offset: 9
+          Type: 3 BaseType uint8
+        - Name: noverflow
+          Offset: 10
+          Type: 7 BaseType uint16
+        - Name: hash0
+          Offset: 12
+          Type: 2 BaseType uint32
+        - Name: buckets
+          Offset: 16
+          Type: 282 PointerType *bucket<int,*main.deepMap9>
+        - Name: oldbuckets
+          Offset: 24
+          Type: 282 PointerType *bucket<int,*main.deepMap9>
+        - Name: nevacuate
+          Offset: 32
+          Type: 1 BaseType uintptr
+        - Name: extra
+          Offset: 40
+          Type: 73 PointerType *runtime.mapextra
+      BucketType: 283 GoHMapBucketType bucket<int,*main.deepMap9>
+      BucketsType: 287 GoSliceDataType []bucket<int,*main.deepMap9>.array
+    - __kind: GoHMapHeaderType
+      ID: 93
       Name: hash<int,int>
       ByteSize: 48
       RawFields:
@@ -6036,20 +7025,54 @@ Types:
           Type: 2 BaseType uint32
         - Name: buckets
           Offset: 16
-          Type: 69 PointerType *bucket<int,int>
+          Type: 94 PointerType *bucket<int,int>
         - Name: oldbuckets
           Offset: 24
-          Type: 69 PointerType *bucket<int,int>
+          Type: 94 PointerType *bucket<int,int>
         - Name: nevacuate
           Offset: 32
           Type: 1 BaseType uintptr
         - Name: extra
           Offset: 40
-          Type: 71 PointerType *runtime.mapextra
-      BucketType: 70 GoHMapBucketType bucket<int,int>
-      BucketsType: 160 GoSliceDataType []bucket<int,int>.array
+          Type: 73 PointerType *runtime.mapextra
+      BucketType: 95 GoHMapBucketType bucket<int,int>
+      BucketsType: 190 GoSliceDataType []bucket<int,int>.array
     - __kind: GoHMapHeaderType
-      ID: 107
+      ID: 290
+      Name: hash<int,interface {}>
+      ByteSize: 48
+      RawFields:
+        - Name: count
+          Offset: 0
+          Type: 9 BaseType int
+        - Name: flags
+          Offset: 8
+          Type: 3 BaseType uint8
+        - Name: B
+          Offset: 9
+          Type: 3 BaseType uint8
+        - Name: noverflow
+          Offset: 10
+          Type: 7 BaseType uint16
+        - Name: hash0
+          Offset: 12
+          Type: 2 BaseType uint32
+        - Name: buckets
+          Offset: 16
+          Type: 291 PointerType *bucket<int,interface {}>
+        - Name: oldbuckets
+          Offset: 24
+          Type: 291 PointerType *bucket<int,interface {}>
+        - Name: nevacuate
+          Offset: 32
+          Type: 1 BaseType uintptr
+        - Name: extra
+          Offset: 40
+          Type: 73 PointerType *runtime.mapextra
+      BucketType: 292 GoHMapBucketType bucket<int,interface {}>
+      BucketsType: 294 GoSliceDataType []bucket<int,interface {}>.array
+    - __kind: GoHMapHeaderType
+      ID: 130
       Name: hash<int,uint8>
       ByteSize: 48
       RawFields:
@@ -6070,20 +7093,20 @@ Types:
           Type: 2 BaseType uint32
         - Name: buckets
           Offset: 16
-          Type: 108 PointerType *bucket<int,uint8>
+          Type: 131 PointerType *bucket<int,uint8>
         - Name: oldbuckets
           Offset: 24
-          Type: 108 PointerType *bucket<int,uint8>
+          Type: 131 PointerType *bucket<int,uint8>
         - Name: nevacuate
           Offset: 32
           Type: 1 BaseType uintptr
         - Name: extra
           Offset: 40
-          Type: 71 PointerType *runtime.mapextra
-      BucketType: 109 GoHMapBucketType bucket<int,uint8>
-      BucketsType: 179 GoSliceDataType []bucket<int,uint8>.array
+          Type: 73 PointerType *runtime.mapextra
+      BucketType: 132 GoHMapBucketType bucket<int,uint8>
+      BucketsType: 209 GoSliceDataType []bucket<int,uint8>.array
     - __kind: GoHMapHeaderType
-      ID: 97
+      ID: 120
       Name: hash<string,[]main.structWithMap>
       ByteSize: 48
       RawFields:
@@ -6104,20 +7127,20 @@ Types:
           Type: 2 BaseType uint32
         - Name: buckets
           Offset: 16
-          Type: 98 PointerType *bucket<string,[]main.structWithMap>
+          Type: 121 PointerType *bucket<string,[]main.structWithMap>
         - Name: oldbuckets
           Offset: 24
-          Type: 98 PointerType *bucket<string,[]main.structWithMap>
+          Type: 121 PointerType *bucket<string,[]main.structWithMap>
         - Name: nevacuate
           Offset: 32
           Type: 1 BaseType uintptr
         - Name: extra
           Offset: 40
-          Type: 71 PointerType *runtime.mapextra
-      BucketType: 99 GoHMapBucketType bucket<string,[]main.structWithMap>
-      BucketsType: 174 GoSliceDataType []bucket<string,[]main.structWithMap>.array
+          Type: 73 PointerType *runtime.mapextra
+      BucketType: 122 GoHMapBucketType bucket<string,[]main.structWithMap>
+      BucketsType: 204 GoSliceDataType []bucket<string,[]main.structWithMap>.array
     - __kind: GoHMapHeaderType
-      ID: 85
+      ID: 108
       Name: hash<string,[]string>
       ByteSize: 48
       RawFields:
@@ -6138,20 +7161,20 @@ Types:
           Type: 2 BaseType uint32
         - Name: buckets
           Offset: 16
-          Type: 86 PointerType *bucket<string,[]string>
+          Type: 109 PointerType *bucket<string,[]string>
         - Name: oldbuckets
           Offset: 24
-          Type: 86 PointerType *bucket<string,[]string>
+          Type: 109 PointerType *bucket<string,[]string>
         - Name: nevacuate
           Offset: 32
           Type: 1 BaseType uintptr
         - Name: extra
           Offset: 40
-          Type: 71 PointerType *runtime.mapextra
-      BucketType: 87 GoHMapBucketType bucket<string,[]string>
-      BucketsType: 166 GoSliceDataType []bucket<string,[]string>.array
+          Type: 73 PointerType *runtime.mapextra
+      BucketType: 110 GoHMapBucketType bucket<string,[]string>
+      BucketsType: 196 GoSliceDataType []bucket<string,[]string>.array
     - __kind: GoHMapHeaderType
-      ID: 80
+      ID: 103
       Name: hash<string,int>
       ByteSize: 48
       RawFields:
@@ -6172,20 +7195,20 @@ Types:
           Type: 2 BaseType uint32
         - Name: buckets
           Offset: 16
-          Type: 81 PointerType *bucket<string,int>
+          Type: 104 PointerType *bucket<string,int>
         - Name: oldbuckets
           Offset: 24
-          Type: 81 PointerType *bucket<string,int>
+          Type: 104 PointerType *bucket<string,int>
         - Name: nevacuate
           Offset: 32
           Type: 1 BaseType uintptr
         - Name: extra
           Offset: 40
-          Type: 71 PointerType *runtime.mapextra
-      BucketType: 82 GoHMapBucketType bucket<string,int>
-      BucketsType: 164 GoSliceDataType []bucket<string,int>.array
+          Type: 73 PointerType *runtime.mapextra
+      BucketType: 105 GoHMapBucketType bucket<string,int>
+      BucketsType: 194 GoSliceDataType []bucket<string,int>.array
     - __kind: GoHMapHeaderType
-      ID: 75
+      ID: 98
       Name: hash<string,main.nestedStruct>
       ByteSize: 48
       RawFields:
@@ -6206,20 +7229,20 @@ Types:
           Type: 2 BaseType uint32
         - Name: buckets
           Offset: 16
-          Type: 76 PointerType *bucket<string,main.nestedStruct>
+          Type: 99 PointerType *bucket<string,main.nestedStruct>
         - Name: oldbuckets
           Offset: 24
-          Type: 76 PointerType *bucket<string,main.nestedStruct>
+          Type: 99 PointerType *bucket<string,main.nestedStruct>
         - Name: nevacuate
           Offset: 32
           Type: 1 BaseType uintptr
         - Name: extra
           Offset: 40
-          Type: 71 PointerType *runtime.mapextra
-      BucketType: 77 GoHMapBucketType bucket<string,main.nestedStruct>
-      BucketsType: 163 GoSliceDataType []bucket<string,main.nestedStruct>.array
+          Type: 73 PointerType *runtime.mapextra
+      BucketType: 100 GoHMapBucketType bucket<string,main.nestedStruct>
+      BucketsType: 193 GoSliceDataType []bucket<string,main.nestedStruct>.array
     - __kind: GoHMapHeaderType
-      ID: 117
+      ID: 140
       Name: hash<uint8,[4]int>
       ByteSize: 48
       RawFields:
@@ -6240,20 +7263,20 @@ Types:
           Type: 2 BaseType uint32
         - Name: buckets
           Offset: 16
-          Type: 118 PointerType *bucket<uint8,[4]int>
+          Type: 141 PointerType *bucket<uint8,[4]int>
         - Name: oldbuckets
           Offset: 24
-          Type: 118 PointerType *bucket<uint8,[4]int>
+          Type: 141 PointerType *bucket<uint8,[4]int>
         - Name: nevacuate
           Offset: 32
           Type: 1 BaseType uintptr
         - Name: extra
           Offset: 40
-          Type: 71 PointerType *runtime.mapextra
-      BucketType: 119 GoHMapBucketType bucket<uint8,[4]int>
-      BucketsType: 184 GoSliceDataType []bucket<uint8,[4]int>.array
+          Type: 73 PointerType *runtime.mapextra
+      BucketType: 142 GoHMapBucketType bucket<uint8,[4]int>
+      BucketsType: 214 GoSliceDataType []bucket<uint8,[4]int>.array
     - __kind: GoHMapHeaderType
-      ID: 112
+      ID: 135
       Name: hash<uint8,uint8>
       ByteSize: 48
       RawFields:
@@ -6274,53 +7297,53 @@ Types:
           Type: 2 BaseType uint32
         - Name: buckets
           Offset: 16
-          Type: 113 PointerType *bucket<uint8,uint8>
+          Type: 136 PointerType *bucket<uint8,uint8>
         - Name: oldbuckets
           Offset: 24
-          Type: 113 PointerType *bucket<uint8,uint8>
+          Type: 136 PointerType *bucket<uint8,uint8>
         - Name: nevacuate
           Offset: 32
           Type: 1 BaseType uintptr
         - Name: extra
           Offset: 40
-          Type: 71 PointerType *runtime.mapextra
-      BucketType: 114 GoHMapBucketType bucket<uint8,uint8>
-      BucketsType: 181 GoSliceDataType []bucket<uint8,uint8>.array
+          Type: 73 PointerType *runtime.mapextra
+      BucketType: 137 GoHMapBucketType bucket<uint8,uint8>
+      BucketsType: 211 GoSliceDataType []bucket<uint8,uint8>.array
     - __kind: BaseType
       ID: 9
       Name: int
       ByteSize: 8
-      GoRuntimeType: 527424
+      GoRuntimeType: 531616
       GoKind: 2
     - __kind: BaseType
       ID: 31
       Name: int16
       ByteSize: 2
-      GoRuntimeType: 527040
+      GoRuntimeType: 531232
       GoKind: 4
     - __kind: BaseType
       ID: 12
       Name: int32
       ByteSize: 4
-      GoRuntimeType: 527168
+      GoRuntimeType: 531360
       GoKind: 5
     - __kind: BaseType
       ID: 13
       Name: int64
       ByteSize: 8
-      GoRuntimeType: 527296
+      GoRuntimeType: 531488
       GoKind: 6
     - __kind: BaseType
       ID: 14
       Name: int8
       ByteSize: 1
-      GoRuntimeType: 526912
+      GoRuntimeType: 531104
       GoKind: 3
     - __kind: GoEmptyInterfaceType
-      ID: 58
+      ID: 83
       Name: interface {}
       ByteSize: 16
-      GoRuntimeType: 772384
+      GoRuntimeType: 777344
       GoKind: 20
       RawFields:
         - Name: _type
@@ -6333,7 +7356,7 @@ Types:
       ID: 55
       Name: io.Writer
       ByteSize: 16
-      GoRuntimeType: 973760
+      GoRuntimeType: 979584
       GoKind: 20
       RawFields:
         - Name: tab
@@ -6343,7 +7366,7 @@ Types:
           Offset: 8
           Type: 19 VoidPointerType unsafe.Pointer
     - __kind: StructureType
-      ID: 150
+      ID: 173
       Name: main.aStruct
       ByteSize: 56
       GoKind: 25
@@ -6359,12 +7382,12 @@ Types:
           Type: 9 BaseType int
         - Name: nested
           Offset: 32
-          Type: 151 StructureType main.nestedStruct
+          Type: 174 StructureType main.nestedStruct
     - __kind: GoInterfaceType
-      ID: 64
+      ID: 89
       Name: main.behavior
       ByteSize: 16
-      GoRuntimeType: 973376
+      GoRuntimeType: 979200
       GoKind: 20
       RawFields:
         - Name: tab
@@ -6389,37 +7412,199 @@ Types:
           Offset: 32
           Type: 55 GoInterfaceType io.Writer
     - __kind: StructureType
-      ID: 152
+      ID: 67
+      Name: main.deepMap1
+      ByteSize: 8
+      GoRuntimeType: 1.099424e+06
+      GoKind: 25
+      RawFields:
+        - Name: a
+          Offset: 0
+          Type: 68 GoMapType map[int]*main.deepMap2
+    - __kind: StructureType
+      ID: 187
+      Name: main.deepMap2
+      ByteSize: 8
+      GoRuntimeType: 1.099296e+06
+      GoKind: 25
+      RawFields:
+        - Name: a
+          Offset: 0
+          Type: 241 GoMapType map[int]*main.deepMap3
+    - __kind: UnresolvedPointeeType
+      ID: 248
+      Name: main.deepMap3
+      ByteSize: 8
+    - __kind: StructureType
+      ID: 76
+      Name: main.deepMap7
+      ByteSize: 8
+      GoRuntimeType: 1.098656e+06
+      GoKind: 25
+      RawFields:
+        - Name: a
+          Offset: 0
+          Type: 270 GoMapType map[int]*main.deepMap8
+    - __kind: StructureType
+      ID: 277
+      Name: main.deepMap8
+      ByteSize: 8
+      GoRuntimeType: 1.098528e+06
+      GoKind: 25
+      RawFields:
+        - Name: a
+          Offset: 0
+          Type: 279 GoMapType map[int]*main.deepMap9
+    - __kind: StructureType
+      ID: 286
+      Name: main.deepMap9
+      ByteSize: 8
+      GoRuntimeType: 1.0984e+06
+      GoKind: 25
+      RawFields:
+        - Name: a
+          Offset: 0
+          Type: 288 GoMapType map[int]interface {}
+    - __kind: StructureType
+      ID: 56
+      Name: main.deepPtr1
+      ByteSize: 8
+      GoRuntimeType: 1.100576e+06
+      GoKind: 25
+      RawFields:
+        - Name: a
+          Offset: 0
+          Type: 57 PointerType *main.deepPtr2
+    - __kind: StructureType
+      ID: 58
+      Name: main.deepPtr2
+      ByteSize: 8
+      GoRuntimeType: 1.100448e+06
+      GoKind: 25
+      RawFields:
+        - Name: a
+          Offset: 0
+          Type: 230 PointerType *main.deepPtr3
+    - __kind: UnresolvedPointeeType
+      ID: 231
+      Name: main.deepPtr3
+      ByteSize: 8
+    - __kind: StructureType
+      ID: 60
+      Name: main.deepPtr7
+      ByteSize: 8
+      GoRuntimeType: 1.099808e+06
+      GoKind: 25
+      RawFields:
+        - Name: a
+          Offset: 0
+          Type: 250 PointerType *main.deepPtr8
+    - __kind: StructureType
+      ID: 251
+      Name: main.deepPtr8
+      ByteSize: 8
+      GoRuntimeType: 1.09968e+06
+      GoKind: 25
+      RawFields:
+        - Name: a
+          Offset: 0
+          Type: 252 PointerType *main.deepPtr9
+    - __kind: StructureType
+      ID: 253
+      Name: main.deepPtr9
+      ByteSize: 16
+      GoRuntimeType: 1.099552e+06
+      GoKind: 25
+      RawFields:
+        - Name: a
+          Offset: 0
+          Type: 83 GoEmptyInterfaceType interface {}
+    - __kind: StructureType
+      ID: 61
+      Name: main.deepSlice1
+      ByteSize: 24
+      GoRuntimeType: 1.101728e+06
+      GoKind: 25
+      RawFields:
+        - Name: a
+          Offset: 0
+          Type: 62 GoSliceHeaderType []*main.deepSlice2
+    - __kind: StructureType
+      ID: 180
+      Name: main.deepSlice2
+      ByteSize: 24
+      GoRuntimeType: 1.1016e+06
+      GoKind: 25
+      RawFields:
+        - Name: a
+          Offset: 0
+          Type: 235 GoSliceHeaderType []*main.deepSlice3
+    - __kind: UnresolvedPointeeType
+      ID: 238
+      Name: main.deepSlice3
+      ByteSize: 8
+    - __kind: StructureType
+      ID: 66
+      Name: main.deepSlice7
+      ByteSize: 24
+      GoRuntimeType: 1.10096e+06
+      GoKind: 25
+      RawFields:
+        - Name: a
+          Offset: 0
+          Type: 254 GoSliceHeaderType []*main.deepSlice8
+    - __kind: StructureType
+      ID: 257
+      Name: main.deepSlice8
+      ByteSize: 24
+      GoRuntimeType: 1.100832e+06
+      GoKind: 25
+      RawFields:
+        - Name: a
+          Offset: 0
+          Type: 260 GoSliceHeaderType []*main.deepSlice9
+    - __kind: StructureType
+      ID: 263
+      Name: main.deepSlice9
+      ByteSize: 24
+      GoRuntimeType: 1.100704e+06
+      GoKind: 25
+      RawFields:
+        - Name: a
+          Offset: 0
+          Type: 266 GoSliceHeaderType []interface {}
+    - __kind: StructureType
+      ID: 175
       Name: main.emptyStruct
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 62
+      ID: 87
       Name: main.esotericHeap
       ByteSize: 112
-      GoRuntimeType: 1.692416e+06
+      GoRuntimeType: 1.703424e+06
       GoKind: 25
       RawFields:
         - Name: esotericStack
           Offset: 0
-          Type: 56 StructureType main.esotericStack
+          Type: 81 StructureType main.esotericStack
         - Name: mu
           Offset: 64
-          Type: 200 StructureType sync.Mutex
+          Type: 295 StructureType sync.Mutex
         - Name: once
           Offset: 72
-          Type: 201 StructureType sync.Once
+          Type: 296 StructureType sync.Once
         - Name: wg
           Offset: 88
-          Type: 204 StructureType sync.WaitGroup
+          Type: 299 StructureType sync.WaitGroup
         - Name: a
           Offset: 104
-          Type: 208 StructureType sync/atomic.Int32
+          Type: 303 StructureType sync/atomic.Int32
     - __kind: StructureType
-      ID: 56
+      ID: 81
       Name: main.esotericStack
       ByteSize: 64
-      GoRuntimeType: 1.81888e+06
+      GoRuntimeType: 1.829888e+06
       GoKind: 25
       RawFields:
         - Name: _
@@ -6430,24 +7615,24 @@ Types:
           Type: 12 BaseType int32
         - Name: c
           Offset: 8
-          Type: 57 GoChannelType chan struct {}
+          Type: 82 GoChannelType chan struct {}
         - Name: val
           Offset: 16
-          Type: 58 GoEmptyInterfaceType interface {}
+          Type: 83 GoEmptyInterfaceType interface {}
         - Name: _
           Offset: 32
           Type: 10 BaseType uint64
         - Name: work
           Offset: 40
-          Type: 59 GoInterfaceType main.something
+          Type: 84 GoInterfaceType main.something
         - Name: foo
           Offset: 56
-          Type: 60 GoSubroutineType func()
+          Type: 85 GoSubroutineType func()
     - __kind: StructureType
-      ID: 151
+      ID: 174
       Name: main.nestedStruct
       ByteSize: 24
-      GoRuntimeType: 1.270016e+06
+      GoRuntimeType: 1.279296e+06
       GoKind: 25
       RawFields:
         - Name: anotherInt
@@ -6457,10 +7642,10 @@ Types:
           Offset: 8
           Type: 11 GoStringHeaderType string
     - __kind: StructureType
-      ID: 133
+      ID: 156
       Name: main.node
       ByteSize: 16
-      GoRuntimeType: 1.269856e+06
+      GoRuntimeType: 1.279136e+06
       GoKind: 25
       RawFields:
         - Name: val
@@ -6468,9 +7653,9 @@ Types:
           Type: 9 BaseType int
         - Name: b
           Offset: 8
-          Type: 134 PointerType *main.node
+          Type: 157 PointerType *main.node
     - __kind: StructureType
-      ID: 149
+      ID: 172
       Name: main.oneStringStruct
       ByteSize: 16
       GoKind: 25
@@ -6479,10 +7664,10 @@ Types:
           Offset: 0
           Type: 11 GoStringHeaderType string
     - __kind: GoInterfaceType
-      ID: 59
+      ID: 84
       Name: main.something
       ByteSize: 16
-      GoRuntimeType: 973504
+      GoRuntimeType: 979328
       GoKind: 20
       RawFields:
         - Name: tab
@@ -6491,18 +7676,39 @@ Types:
         - Name: data
           Offset: 8
           Type: 19 VoidPointerType unsafe.Pointer
+    - __kind: GoStringHeaderType
+      ID: 78
+      Name: main.stringType1
+      ByteSize: 16
+      GoKind: 24
+      RawFields:
+        - Name: str
+          Offset: 0
+          Type: 233 PointerType *main.stringType1.str
+        - Name: len
+          Offset: 8
+          Type: 9 BaseType int
+      Data: 232 GoStringDataType main.stringType1.str
+    - __kind: GoStringDataType
+      ID: 232
+      Name: main.stringType1.str
+      ByteSize: 2048
+    - __kind: UnresolvedPointeeType
+      ID: 234
+      Name: main.stringType2
+      ByteSize: 8
     - __kind: StructureType
-      ID: 65
+      ID: 90
       Name: main.structWithMap
       ByteSize: 8
-      GoRuntimeType: 1.092448e+06
+      GoRuntimeType: 1.098272e+06
       GoKind: 25
       RawFields:
         - Name: m
           Offset: 0
-          Type: 66 GoMapType map[int]int
+          Type: 91 GoMapType map[int]int
     - __kind: StructureType
-      ID: 142
+      ID: 165
       Name: main.structWithNoStrings
       ByteSize: 2
       GoKind: 25
@@ -6514,7 +7720,7 @@ Types:
           Offset: 1
           Type: 4 BaseType bool
     - __kind: StructureType
-      ID: 132
+      ID: 155
       Name: main.structWithTwoValues
       ByteSize: 16
       GoKind: 25
@@ -6526,28 +7732,28 @@ Types:
           Offset: 8
           Type: 4 BaseType bool
     - __kind: GoSliceHeaderType
-      ID: 136
+      ID: 159
       Name: main.t
       ByteSize: 24
       GoKind: 23
       RawFields:
         - Name: array
           Offset: 0
-          Type: 209 PointerType **main.t
+          Type: 304 PointerType **main.t
         - Name: len
           Offset: 8
           Type: 9 BaseType int
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 210 GoSliceDataType main.t.array
+      Data: 305 GoSliceDataType main.t.array
     - __kind: GoSliceDataType
-      ID: 210
+      ID: 305
       Name: main.t.array
       ByteSize: 2048
-      Element: 135 PointerType *main.t
+      Element: 158 PointerType *main.t
     - __kind: StructureType
-      ID: 146
+      ID: 169
       Name: main.threeStringStruct
       ByteSize: 48
       GoKind: 25
@@ -6567,116 +7773,151 @@ Types:
       ByteSize: 2
       GoKind: 9
     - __kind: GoMapType
-      ID: 125
+      ID: 148
       Name: map[[4]int][4]int
       ByteSize: 8
-      GoRuntimeType: 873856
+      GoRuntimeType: 879680
       GoKind: 21
-      HeaderType: 127 GoHMapHeaderType hash<[4]int,[4]int>
+      HeaderType: 150 GoHMapHeaderType hash<[4]int,[4]int>
     - __kind: GoMapType
-      ID: 120
+      ID: 143
       Name: map[[4]int]uint8
       ByteSize: 8
-      GoRuntimeType: 873952
+      GoRuntimeType: 879776
       GoKind: 21
-      HeaderType: 122 GoHMapHeaderType hash<[4]int,uint8>
+      HeaderType: 145 GoHMapHeaderType hash<[4]int,uint8>
     - __kind: GoMapType
-      ID: 88
+      ID: 111
       Name: map[[4]string][2]int
       ByteSize: 8
-      GoRuntimeType: 874048
+      GoRuntimeType: 879872
       GoKind: 21
-      HeaderType: 90 GoHMapHeaderType hash<[4]string,[2]int>
+      HeaderType: 113 GoHMapHeaderType hash<[4]string,[2]int>
     - __kind: GoMapType
-      ID: 100
+      ID: 123
       Name: map[bool]main.node
       ByteSize: 8
-      GoRuntimeType: 874144
+      GoRuntimeType: 879968
       GoKind: 21
-      HeaderType: 102 GoHMapHeaderType hash<bool,main.node>
+      HeaderType: 125 GoHMapHeaderType hash<bool,main.node>
     - __kind: GoMapType
-      ID: 66
+      ID: 68
+      Name: map[int]*main.deepMap2
+      ByteSize: 8
+      GoRuntimeType: 879584
+      GoKind: 21
+      HeaderType: 70 GoHMapHeaderType hash<int,*main.deepMap2>
+    - __kind: GoMapType
+      ID: 241
+      Name: map[int]*main.deepMap3
+      ByteSize: 8
+      GoRuntimeType: 879488
+      GoKind: 21
+      HeaderType: 243 GoHMapHeaderType hash<int,*main.deepMap3>
+    - __kind: GoMapType
+      ID: 270
+      Name: map[int]*main.deepMap8
+      ByteSize: 8
+      GoRuntimeType: 879008
+      GoKind: 21
+      HeaderType: 272 GoHMapHeaderType hash<int,*main.deepMap8>
+    - __kind: GoMapType
+      ID: 279
+      Name: map[int]*main.deepMap9
+      ByteSize: 8
+      GoRuntimeType: 878912
+      GoKind: 21
+      HeaderType: 281 GoHMapHeaderType hash<int,*main.deepMap9>
+    - __kind: GoMapType
+      ID: 91
       Name: map[int]int
       ByteSize: 8
-      GoRuntimeType: 872896
+      GoRuntimeType: 877856
       GoKind: 21
-      HeaderType: 68 GoHMapHeaderType hash<int,int>
+      HeaderType: 93 GoHMapHeaderType hash<int,int>
     - __kind: GoMapType
-      ID: 105
+      ID: 288
+      Name: map[int]interface {}
+      ByteSize: 8
+      GoRuntimeType: 878816
+      GoKind: 21
+      HeaderType: 290 GoHMapHeaderType hash<int,interface {}>
+    - __kind: GoMapType
+      ID: 128
       Name: map[int]uint8
       ByteSize: 8
-      GoRuntimeType: 874240
+      GoRuntimeType: 880064
       GoKind: 21
-      HeaderType: 107 GoHMapHeaderType hash<int,uint8>
+      HeaderType: 130 GoHMapHeaderType hash<int,uint8>
     - __kind: GoMapType
-      ID: 95
+      ID: 118
       Name: map[string][]main.structWithMap
       ByteSize: 8
-      GoRuntimeType: 874336
+      GoRuntimeType: 880160
       GoKind: 21
-      HeaderType: 97 GoHMapHeaderType hash<string,[]main.structWithMap>
+      HeaderType: 120 GoHMapHeaderType hash<string,[]main.structWithMap>
     - __kind: GoMapType
-      ID: 83
+      ID: 106
       Name: map[string][]string
       ByteSize: 8
-      GoRuntimeType: 874432
+      GoRuntimeType: 880256
       GoKind: 21
-      HeaderType: 85 GoHMapHeaderType hash<string,[]string>
+      HeaderType: 108 GoHMapHeaderType hash<string,[]string>
     - __kind: GoMapType
-      ID: 78
+      ID: 101
       Name: map[string]int
       ByteSize: 8
-      GoRuntimeType: 874528
+      GoRuntimeType: 880352
       GoKind: 21
-      HeaderType: 80 GoHMapHeaderType hash<string,int>
+      HeaderType: 103 GoHMapHeaderType hash<string,int>
     - __kind: GoMapType
-      ID: 73
+      ID: 96
       Name: map[string]main.nestedStruct
       ByteSize: 8
-      GoRuntimeType: 874624
+      GoRuntimeType: 880448
       GoKind: 21
-      HeaderType: 75 GoHMapHeaderType hash<string,main.nestedStruct>
+      HeaderType: 98 GoHMapHeaderType hash<string,main.nestedStruct>
     - __kind: GoMapType
-      ID: 115
+      ID: 138
       Name: map[uint8][4]int
       ByteSize: 8
-      GoRuntimeType: 874720
+      GoRuntimeType: 880544
       GoKind: 21
-      HeaderType: 117 GoHMapHeaderType hash<uint8,[4]int>
+      HeaderType: 140 GoHMapHeaderType hash<uint8,[4]int>
     - __kind: GoMapType
-      ID: 110
+      ID: 133
       Name: map[uint8]uint8
       ByteSize: 8
-      GoRuntimeType: 874816
+      GoRuntimeType: 880640
       GoKind: 21
-      HeaderType: 112 GoHMapHeaderType hash<uint8,uint8>
+      HeaderType: 135 GoHMapHeaderType hash<uint8,uint8>
     - __kind: UnresolvedPointeeType
-      ID: 72
+      ID: 74
       Name: runtime.mapextra
       ByteSize: 8
     - __kind: GoStringHeaderType
       ID: 11
       Name: string
       ByteSize: 16
-      GoRuntimeType: 526848
+      GoRuntimeType: 531040
       GoKind: 24
       RawFields:
         - Name: str
           Offset: 0
-          Type: 154 PointerType *string.str
+          Type: 177 PointerType *string.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 153 GoStringDataType string.str
+      Data: 176 GoStringDataType string.str
     - __kind: GoStringDataType
-      ID: 153
+      ID: 176
       Name: string.str
       ByteSize: 2048
     - __kind: StructureType
-      ID: 200
+      ID: 295
       Name: sync.Mutex
       ByteSize: 8
-      GoRuntimeType: 1.271296e+06
+      GoRuntimeType: 1.280576e+06
       GoKind: 25
       RawFields:
         - Name: state
@@ -6686,136 +7927,136 @@ Types:
           Offset: 4
           Type: 2 BaseType uint32
     - __kind: StructureType
-      ID: 201
+      ID: 296
       Name: sync.Once
       ByteSize: 12
-      GoRuntimeType: 1.272416e+06
+      GoRuntimeType: 1.281696e+06
       GoKind: 25
       RawFields:
         - Name: done
           Offset: 0
-          Type: 202 StructureType sync/atomic.Uint32
+          Type: 297 StructureType sync/atomic.Uint32
         - Name: m
           Offset: 4
-          Type: 200 StructureType sync.Mutex
+          Type: 295 StructureType sync.Mutex
     - __kind: StructureType
-      ID: 204
+      ID: 299
       Name: sync.WaitGroup
       ByteSize: 16
-      GoRuntimeType: 1.411104e+06
+      GoRuntimeType: 1.420384e+06
       GoKind: 25
       RawFields:
         - Name: noCopy
           Offset: 0
-          Type: 205 StructureType sync.noCopy
+          Type: 300 StructureType sync.noCopy
         - Name: state
           Offset: 0
-          Type: 206 StructureType sync/atomic.Uint64
+          Type: 301 StructureType sync/atomic.Uint64
         - Name: sema
           Offset: 8
           Type: 2 BaseType uint32
     - __kind: StructureType
-      ID: 205
+      ID: 300
       Name: sync.noCopy
-      GoRuntimeType: 940512
+      GoRuntimeType: 946336
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 208
+      ID: 303
       Name: sync/atomic.Int32
       ByteSize: 4
-      GoRuntimeType: 1.272736e+06
+      GoRuntimeType: 1.282016e+06
       GoKind: 25
       RawFields:
         - Name: _
           Offset: 0
-          Type: 203 StructureType sync/atomic.noCopy
+          Type: 298 StructureType sync/atomic.noCopy
         - Name: v
           Offset: 0
           Type: 12 BaseType int32
     - __kind: StructureType
-      ID: 202
+      ID: 297
       Name: sync/atomic.Uint32
       ByteSize: 4
-      GoRuntimeType: 1.272896e+06
+      GoRuntimeType: 1.282176e+06
       GoKind: 25
       RawFields:
         - Name: _
           Offset: 0
-          Type: 203 StructureType sync/atomic.noCopy
+          Type: 298 StructureType sync/atomic.noCopy
         - Name: v
           Offset: 0
           Type: 2 BaseType uint32
     - __kind: StructureType
-      ID: 206
+      ID: 301
       Name: sync/atomic.Uint64
       ByteSize: 8
-      GoRuntimeType: 1.411488e+06
+      GoRuntimeType: 1.420768e+06
       GoKind: 25
       RawFields:
         - Name: _
           Offset: 0
-          Type: 203 StructureType sync/atomic.noCopy
+          Type: 298 StructureType sync/atomic.noCopy
         - Name: _
           Offset: 0
-          Type: 207 StructureType sync/atomic.align64
+          Type: 302 StructureType sync/atomic.align64
         - Name: v
           Offset: 0
           Type: 10 BaseType uint64
     - __kind: StructureType
-      ID: 207
+      ID: 302
       Name: sync/atomic.align64
-      GoRuntimeType: 940704
+      GoRuntimeType: 946528
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 203
+      ID: 298
       Name: sync/atomic.noCopy
-      GoRuntimeType: 940608
+      GoRuntimeType: 946432
       GoKind: 25
       RawFields: []
     - __kind: BaseType
       ID: 15
       Name: uint
       ByteSize: 8
-      GoRuntimeType: 527488
+      GoRuntimeType: 531680
       GoKind: 7
     - __kind: BaseType
       ID: 7
       Name: uint16
       ByteSize: 2
-      GoRuntimeType: 527104
+      GoRuntimeType: 531296
       GoKind: 9
     - __kind: BaseType
       ID: 2
       Name: uint32
       ByteSize: 4
-      GoRuntimeType: 527232
+      GoRuntimeType: 531424
       GoKind: 10
     - __kind: BaseType
       ID: 10
       Name: uint64
       ByteSize: 8
-      GoRuntimeType: 527360
+      GoRuntimeType: 531552
       GoKind: 11
     - __kind: BaseType
       ID: 3
       Name: uint8
       ByteSize: 1
-      GoRuntimeType: 526976
+      GoRuntimeType: 531168
       GoKind: 8
     - __kind: BaseType
       ID: 1
       Name: uintptr
       ByteSize: 8
-      GoRuntimeType: 527552
+      GoRuntimeType: 531744
       GoKind: 12
     - __kind: VoidPointerType
       ID: 19
       Name: unsafe.Pointer
       ByteSize: 8
-      GoRuntimeType: 527936
+      GoRuntimeType: 532128
       GoKind: 26
-MaxTypeID: 317
+MaxTypeID: 420
 Issues: []
-GoModuledataInfo: {FirstModuledataAddr: "0x1752740", TypesOffset: 296}
+GoModuledataInfo: {FirstModuledataAddr: "0x1755760", TypesOffset: 296}

--- a/pkg/dyninst/irgen/testdata/snapshot/sample.arch=amd64,toolchain=go1.23.11.yaml
+++ b/pkg/dyninst/irgen/testdata/snapshot/sample.arch=amd64,toolchain=go1.23.11.yaml
@@ -3094,275 +3094,16 @@ Subprograms:
           IsParameter: true
           IsReturn: false
 Types:
-    - __kind: BaseType
-      ID: 1
-      Name: int
-      ByteSize: 8
-      GoRuntimeType: 527424
-      GoKind: 2
-    - __kind: ArrayType
-      ID: 2
-      Name: '[5]int'
-      ByteSize: 40
-      GoKind: 17
-      Count: 5
-      HasCount: true
-      Element: 1 BaseType int
-    - __kind: ArrayType
-      ID: 3
-      Name: '[2]uint8'
-      ByteSize: 2
-      GoRuntimeType: 618784
-      GoKind: 17
-      Count: 2
-      HasCount: true
-      Element: 4 BaseType uint8
-    - __kind: BaseType
-      ID: 4
-      Name: uint8
-      ByteSize: 1
-      GoRuntimeType: 526976
-      GoKind: 8
-    - __kind: ArrayType
-      ID: 5
-      Name: '[2]int32'
-      ByteSize: 8
-      GoRuntimeType: 618880
-      GoKind: 17
-      Count: 2
-      HasCount: true
-      Element: 6 BaseType int32
-    - __kind: BaseType
-      ID: 6
-      Name: int32
-      ByteSize: 4
-      GoRuntimeType: 527168
-      GoKind: 5
-    - __kind: ArrayType
-      ID: 7
-      Name: '[2]string'
-      ByteSize: 32
-      GoRuntimeType: 618976
-      GoKind: 17
-      Count: 2
-      HasCount: true
-      Element: 8 GoStringHeaderType string
-    - __kind: GoStringHeaderType
-      ID: 8
-      Name: string
-      ByteSize: 16
-      GoRuntimeType: 526848
-      GoKind: 24
-      RawFields:
-        - Name: str
-          Offset: 0
-          Type: 188 PointerType *string.str
-        - Name: len
-          Offset: 8
-          Type: 1 BaseType int
-      Data: 187 GoStringDataType string.str
     - __kind: PointerType
-      ID: 9
-      Name: '*uint8'
+      ID: 158
+      Name: '**main.t'
       ByteSize: 8
-      GoRuntimeType: 359328
-      GoKind: 22
-      Pointee: 4 BaseType uint8
-    - __kind: ArrayType
-      ID: 10
-      Name: '[2]bool'
-      ByteSize: 2
-      GoKind: 17
-      Count: 2
-      HasCount: true
-      Element: 11 BaseType bool
-    - __kind: BaseType
-      ID: 11
-      Name: bool
-      ByteSize: 1
-      GoRuntimeType: 527872
-      GoKind: 1
-    - __kind: ArrayType
-      ID: 12
-      Name: '[2]int'
-      ByteSize: 16
-      GoRuntimeType: 617728
-      GoKind: 17
-      Count: 2
-      HasCount: true
-      Element: 1 BaseType int
-    - __kind: ArrayType
-      ID: 13
-      Name: '[2]int8'
-      ByteSize: 2
-      GoKind: 17
-      Count: 2
-      HasCount: true
-      Element: 14 BaseType int8
-    - __kind: BaseType
-      ID: 14
-      Name: int8
-      ByteSize: 1
-      GoRuntimeType: 526912
-      GoKind: 3
-    - __kind: ArrayType
-      ID: 15
-      Name: '[2]int16'
-      ByteSize: 4
-      GoKind: 17
-      Count: 2
-      HasCount: true
-      Element: 16 BaseType int16
-    - __kind: BaseType
-      ID: 16
-      Name: int16
-      ByteSize: 2
-      GoRuntimeType: 527040
-      GoKind: 4
-    - __kind: ArrayType
-      ID: 17
-      Name: '[2]int64'
-      ByteSize: 16
-      GoKind: 17
-      Count: 2
-      HasCount: true
-      Element: 18 BaseType int64
-    - __kind: BaseType
-      ID: 18
-      Name: int64
+      Pointee: 156 PointerType *main.t
+    - __kind: PointerType
+      ID: 71
+      Name: '**runtime.bmap'
       ByteSize: 8
-      GoRuntimeType: 527296
-      GoKind: 6
-    - __kind: ArrayType
-      ID: 19
-      Name: '[2]uint'
-      ByteSize: 16
-      GoKind: 17
-      Count: 2
-      HasCount: true
-      Element: 20 BaseType uint
-    - __kind: BaseType
-      ID: 20
-      Name: uint
-      ByteSize: 8
-      GoRuntimeType: 527488
-      GoKind: 7
-    - __kind: ArrayType
-      ID: 21
-      Name: '[2]uint16'
-      ByteSize: 4
-      GoKind: 17
-      Count: 2
-      HasCount: true
-      Element: 22 BaseType uint16
-    - __kind: BaseType
-      ID: 22
-      Name: uint16
-      ByteSize: 2
-      GoRuntimeType: 527104
-      GoKind: 9
-    - __kind: ArrayType
-      ID: 23
-      Name: '[2]uint32'
-      ByteSize: 8
-      GoKind: 17
-      Count: 2
-      HasCount: true
-      Element: 24 BaseType uint32
-    - __kind: BaseType
-      ID: 24
-      Name: uint32
-      ByteSize: 4
-      GoRuntimeType: 527232
-      GoKind: 10
-    - __kind: ArrayType
-      ID: 25
-      Name: '[2]uint64'
-      ByteSize: 16
-      GoRuntimeType: 619072
-      GoKind: 17
-      Count: 2
-      HasCount: true
-      Element: 26 BaseType uint64
-    - __kind: BaseType
-      ID: 26
-      Name: uint64
-      ByteSize: 8
-      GoRuntimeType: 527360
-      GoKind: 11
-    - __kind: ArrayType
-      ID: 27
-      Name: '[2][2]int'
-      ByteSize: 32
-      GoKind: 17
-      Count: 2
-      HasCount: true
-      Element: 12 ArrayType [2]int
-    - __kind: ArrayType
-      ID: 28
-      Name: '[2][2][2]int'
-      ByteSize: 64
-      GoKind: 17
-      Count: 2
-      HasCount: true
-      Element: 27 ArrayType [2][2]int
-    - __kind: ArrayType
-      ID: 29
-      Name: '[100]uint'
-      ByteSize: 800
-      GoKind: 17
-      Count: 100
-      HasCount: true
-      Element: 20 BaseType uint
-    - __kind: BaseType
-      ID: 30
-      Name: float32
-      ByteSize: 4
-      GoRuntimeType: 527744
-      GoKind: 13
-    - __kind: BaseType
-      ID: 31
-      Name: float64
-      ByteSize: 8
-      GoRuntimeType: 527808
-      GoKind: 14
-    - __kind: BaseType
-      ID: 32
-      Name: main.typeAlias
-      ByteSize: 2
-      GoKind: 9
-    - __kind: StructureType
-      ID: 33
-      Name: main.bigStruct
-      ByteSize: 48
-      GoKind: 25
-      RawFields:
-        - Name: x
-          Offset: 0
-          Type: 34 GoSliceHeaderType []*string
-        - Name: z
-          Offset: 24
-          Type: 1 BaseType int
-        - Name: writer
-          Offset: 32
-          Type: 37 GoInterfaceType io.Writer
-    - __kind: GoSliceHeaderType
-      ID: 34
-      Name: '[]*string'
-      ByteSize: 24
-      GoRuntimeType: 443232
-      GoKind: 23
-      RawFields:
-        - Name: array
-          Offset: 0
-          Type: 35 PointerType **string
-        - Name: len
-          Offset: 8
-          Type: 1 BaseType int
-        - Name: cap
-          Offset: 16
-          Type: 1 BaseType int
-      Data: 189 GoSliceDataType []*string.array
+      Pointee: 72 PointerType *runtime.bmap
     - __kind: PointerType
       ID: 35
       Name: '**string'
@@ -3371,1421 +3112,62 @@ Types:
       GoKind: 22
       Pointee: 36 PointerType *string
     - __kind: PointerType
-      ID: 36
-      Name: '*string'
-      ByteSize: 8
-      GoRuntimeType: 359200
-      GoKind: 22
-      Pointee: 8 GoStringHeaderType string
-    - __kind: GoInterfaceType
-      ID: 37
-      Name: io.Writer
-      ByteSize: 16
-      GoRuntimeType: 973760
-      GoKind: 20
-      RawFields:
-        - Name: tab
-          Offset: 0
-          Type: 38 VoidPointerType unsafe.Pointer
-        - Name: data
-          Offset: 8
-          Type: 38 VoidPointerType unsafe.Pointer
-    - __kind: VoidPointerType
-      ID: 38
-      Name: unsafe.Pointer
-      ByteSize: 8
-      GoRuntimeType: 527936
-      GoKind: 26
-    - __kind: StructureType
-      ID: 39
-      Name: main.esotericStack
-      ByteSize: 64
-      GoRuntimeType: 1.81888e+06
-      GoKind: 25
-      RawFields:
-        - Name: _
-          Offset: 0
-          Type: 6 BaseType int32
-        - Name: _valid
-          Offset: 4
-          Type: 6 BaseType int32
-        - Name: c
-          Offset: 8
-          Type: 40 GoChannelType chan struct {}
-        - Name: val
-          Offset: 16
-          Type: 41 GoEmptyInterfaceType interface {}
-        - Name: _
-          Offset: 32
-          Type: 26 BaseType uint64
-        - Name: work
-          Offset: 40
-          Type: 42 GoInterfaceType main.something
-        - Name: foo
-          Offset: 56
-          Type: 43 GoSubroutineType func()
-    - __kind: GoChannelType
-      ID: 40
-      Name: chan struct {}
-      GoRuntimeType: 538048
-      GoKind: 18
-    - __kind: GoEmptyInterfaceType
-      ID: 41
-      Name: interface {}
-      ByteSize: 16
-      GoRuntimeType: 772384
-      GoKind: 20
-      RawFields:
-        - Name: _type
-          Offset: 0
-          Type: 38 VoidPointerType unsafe.Pointer
-        - Name: data
-          Offset: 8
-          Type: 38 VoidPointerType unsafe.Pointer
-    - __kind: GoInterfaceType
-      ID: 42
-      Name: main.something
-      ByteSize: 16
-      GoRuntimeType: 973504
-      GoKind: 20
-      RawFields:
-        - Name: tab
-          Offset: 0
-          Type: 38 VoidPointerType unsafe.Pointer
-        - Name: data
-          Offset: 8
-          Type: 38 VoidPointerType unsafe.Pointer
-    - __kind: GoSubroutineType
-      ID: 43
-      Name: func()
-      ByteSize: 8
-      GoRuntimeType: 441824
-      GoKind: 19
-    - __kind: PointerType
-      ID: 44
-      Name: '*main.esotericHeap'
-      ByteSize: 8
-      GoRuntimeType: 354144
-      GoKind: 22
-      Pointee: 45 StructureType main.esotericHeap
-    - __kind: StructureType
-      ID: 45
-      Name: main.esotericHeap
-      ByteSize: 112
-      GoRuntimeType: 1.692416e+06
-      GoKind: 25
-      RawFields:
-        - Name: esotericStack
-          Offset: 0
-          Type: 39 StructureType main.esotericStack
-        - Name: mu
-          Offset: 64
-          Type: 46 StructureType sync.Mutex
-        - Name: once
-          Offset: 72
-          Type: 47 StructureType sync.Once
-        - Name: wg
-          Offset: 88
-          Type: 50 StructureType sync.WaitGroup
-        - Name: a
-          Offset: 104
-          Type: 54 StructureType sync/atomic.Int32
-    - __kind: StructureType
-      ID: 46
-      Name: sync.Mutex
-      ByteSize: 8
-      GoRuntimeType: 1.271296e+06
-      GoKind: 25
-      RawFields:
-        - Name: state
-          Offset: 0
-          Type: 6 BaseType int32
-        - Name: sema
-          Offset: 4
-          Type: 24 BaseType uint32
-    - __kind: StructureType
-      ID: 47
-      Name: sync.Once
-      ByteSize: 12
-      GoRuntimeType: 1.272416e+06
-      GoKind: 25
-      RawFields:
-        - Name: done
-          Offset: 0
-          Type: 48 StructureType sync/atomic.Uint32
-        - Name: m
-          Offset: 4
-          Type: 46 StructureType sync.Mutex
-    - __kind: StructureType
-      ID: 48
-      Name: sync/atomic.Uint32
-      ByteSize: 4
-      GoRuntimeType: 1.272896e+06
-      GoKind: 25
-      RawFields:
-        - Name: _
-          Offset: 0
-          Type: 49 StructureType sync/atomic.noCopy
-        - Name: v
-          Offset: 0
-          Type: 24 BaseType uint32
-    - __kind: StructureType
-      ID: 49
-      Name: sync/atomic.noCopy
-      GoRuntimeType: 940608
-      GoKind: 25
-      RawFields: []
-    - __kind: StructureType
-      ID: 50
-      Name: sync.WaitGroup
-      ByteSize: 16
-      GoRuntimeType: 1.411104e+06
-      GoKind: 25
-      RawFields:
-        - Name: noCopy
-          Offset: 0
-          Type: 51 StructureType sync.noCopy
-        - Name: state
-          Offset: 0
-          Type: 52 StructureType sync/atomic.Uint64
-        - Name: sema
-          Offset: 8
-          Type: 24 BaseType uint32
-    - __kind: StructureType
-      ID: 51
-      Name: sync.noCopy
-      GoRuntimeType: 940512
-      GoKind: 25
-      RawFields: []
-    - __kind: StructureType
-      ID: 52
-      Name: sync/atomic.Uint64
-      ByteSize: 8
-      GoRuntimeType: 1.411488e+06
-      GoKind: 25
-      RawFields:
-        - Name: _
-          Offset: 0
-          Type: 49 StructureType sync/atomic.noCopy
-        - Name: _
-          Offset: 0
-          Type: 53 StructureType sync/atomic.align64
-        - Name: v
-          Offset: 0
-          Type: 26 BaseType uint64
-    - __kind: StructureType
-      ID: 53
-      Name: sync/atomic.align64
-      GoRuntimeType: 940704
-      GoKind: 25
-      RawFields: []
-    - __kind: StructureType
-      ID: 54
-      Name: sync/atomic.Int32
-      ByteSize: 4
-      GoRuntimeType: 1.272736e+06
-      GoKind: 25
-      RawFields:
-        - Name: _
-          Offset: 0
-          Type: 49 StructureType sync/atomic.noCopy
-        - Name: v
-          Offset: 0
-          Type: 6 BaseType int32
-    - __kind: GoInterfaceType
-      ID: 55
-      Name: main.behavior
-      ByteSize: 16
-      GoRuntimeType: 973376
-      GoKind: 20
-      RawFields:
-        - Name: tab
-          Offset: 0
-          Type: 38 VoidPointerType unsafe.Pointer
-        - Name: data
-          Offset: 8
-          Type: 38 VoidPointerType unsafe.Pointer
-    - __kind: GoInterfaceType
-      ID: 56
-      Name: error
-      ByteSize: 16
-      GoRuntimeType: 977856
-      GoKind: 20
-      RawFields:
-        - Name: tab
-          Offset: 0
-          Type: 38 VoidPointerType unsafe.Pointer
-        - Name: data
-          Offset: 8
-          Type: 38 VoidPointerType unsafe.Pointer
-    - __kind: StructureType
-      ID: 57
-      Name: main.structWithMap
-      ByteSize: 8
-      GoRuntimeType: 1.092448e+06
-      GoKind: 25
-      RawFields:
-        - Name: m
-          Offset: 0
-          Type: 58 GoMapType map[int]int
-    - __kind: GoMapType
-      ID: 58
-      Name: map[int]int
-      ByteSize: 8
-      GoRuntimeType: 872896
-      GoKind: 21
-      HeaderType: 60 GoHMapHeaderType hash<int,int>
-    - __kind: PointerType
-      ID: 59
-      Name: '*hash<int,int>'
-      ByteSize: 8
-      Pointee: 60 GoHMapHeaderType hash<int,int>
-    - __kind: GoHMapHeaderType
-      ID: 60
-      Name: hash<int,int>
-      ByteSize: 48
-      RawFields:
-        - Name: count
-          Offset: 0
-          Type: 1 BaseType int
-        - Name: flags
-          Offset: 8
-          Type: 4 BaseType uint8
-        - Name: B
-          Offset: 9
-          Type: 4 BaseType uint8
-        - Name: noverflow
-          Offset: 10
-          Type: 22 BaseType uint16
-        - Name: hash0
-          Offset: 12
-          Type: 24 BaseType uint32
-        - Name: buckets
-          Offset: 16
-          Type: 61 PointerType *bucket<int,int>
-        - Name: oldbuckets
-          Offset: 24
-          Type: 61 PointerType *bucket<int,int>
-        - Name: nevacuate
-          Offset: 32
-          Type: 66 BaseType uintptr
-        - Name: extra
-          Offset: 40
-          Type: 67 PointerType *runtime.mapextra
-      BucketType: 62 GoHMapBucketType bucket<int,int>
-      BucketsType: 191 GoSliceDataType []bucket<int,int>.array
-    - __kind: PointerType
-      ID: 61
-      Name: '*bucket<int,int>'
-      ByteSize: 8
-      Pointee: 62 GoHMapBucketType bucket<int,int>
-    - __kind: GoHMapBucketType
-      ID: 62
-      Name: bucket<int,int>
-      ByteSize: 144
-      RawFields:
-        - Name: tophash
-          Offset: 0
-          Type: 63 ArrayType [8]uint8
-        - Name: keys
-          Offset: 8
-          Type: 64 ArrayType []key<int>
-        - Name: values
-          Offset: 72
-          Type: 65 ArrayType []val<int>
-        - Name: overflow
-          Offset: 136
-          Type: 61 PointerType *bucket<int,int>
-      KeyType: 1 BaseType int
-      ValueType: 1 BaseType int
-    - __kind: ArrayType
-      ID: 63
-      Name: '[8]uint8'
-      ByteSize: 8
-      GoRuntimeType: 615424
-      GoKind: 17
-      Count: 8
-      HasCount: true
-      Element: 4 BaseType uint8
-    - __kind: ArrayType
-      ID: 64
-      Name: '[]key<int>'
-      ByteSize: 64
-      Count: 8
-      HasCount: true
-      Element: 1 BaseType int
-    - __kind: ArrayType
-      ID: 65
-      Name: '[]val<int>'
-      ByteSize: 64
-      Count: 8
-      HasCount: true
-      Element: 1 BaseType int
-    - __kind: BaseType
-      ID: 66
-      Name: uintptr
-      ByteSize: 8
-      GoRuntimeType: 527552
-      GoKind: 12
-    - __kind: PointerType
-      ID: 67
-      Name: '*runtime.mapextra'
-      ByteSize: 8
-      GoRuntimeType: 363104
-      GoKind: 22
-      Pointee: 68 StructureType runtime.mapextra
-    - __kind: StructureType
-      ID: 68
-      Name: runtime.mapextra
-      ByteSize: 24
-      GoRuntimeType: 1.417056e+06
-      GoKind: 25
-      RawFields:
-        - Name: overflow
-          Offset: 0
-          Type: 69 PointerType *[]*runtime.bmap
-        - Name: oldoverflow
-          Offset: 8
-          Type: 69 PointerType *[]*runtime.bmap
-        - Name: nextOverflow
-          Offset: 16
-          Type: 72 PointerType *runtime.bmap
-    - __kind: PointerType
       ID: 69
       Name: '*[]*runtime.bmap'
       ByteSize: 8
       GoRuntimeType: 451680
       GoKind: 22
       Pointee: 70 GoSliceHeaderType []*runtime.bmap
-    - __kind: GoSliceHeaderType
-      ID: 70
-      Name: '[]*runtime.bmap'
-      ByteSize: 24
-      GoRuntimeType: 451616
-      GoKind: 23
-      RawFields:
-        - Name: array
-          Offset: 0
-          Type: 71 PointerType **runtime.bmap
-        - Name: len
-          Offset: 8
-          Type: 1 BaseType int
-        - Name: cap
-          Offset: 16
-          Type: 1 BaseType int
-      Data: 192 GoSliceDataType []*runtime.bmap.array
     - __kind: PointerType
-      ID: 71
-      Name: '**runtime.bmap'
+      ID: 193
+      Name: '*[]*runtime.bmap.array'
       ByteSize: 8
-      Pointee: 72 PointerType *runtime.bmap
+      Pointee: 192 GoSliceDataType []*runtime.bmap.array
     - __kind: PointerType
-      ID: 72
-      Name: '*runtime.bmap'
+      ID: 190
+      Name: '*[]*string.array'
       ByteSize: 8
-      GoRuntimeType: 1.100896e+06
-      GoKind: 22
-      Pointee: 73 StructureType runtime.bmap
-    - __kind: StructureType
-      ID: 73
-      Name: runtime.bmap
-      ByteSize: 8
-      GoRuntimeType: 1.100768e+06
-      GoKind: 25
-      RawFields:
-        - Name: tophash
-          Offset: 0
-          Type: 63 ArrayType [8]uint8
-    - __kind: GoMapType
-      ID: 74
-      Name: map[string]main.nestedStruct
-      ByteSize: 8
-      GoRuntimeType: 874624
-      GoKind: 21
-      HeaderType: 76 GoHMapHeaderType hash<string,main.nestedStruct>
+      Pointee: 189 GoSliceDataType []*string.array
     - __kind: PointerType
-      ID: 75
-      Name: '*hash<string,main.nestedStruct>'
+      ID: 214
+      Name: '*[][]uint.array'
       ByteSize: 8
-      Pointee: 76 GoHMapHeaderType hash<string,main.nestedStruct>
-    - __kind: GoHMapHeaderType
-      ID: 76
-      Name: hash<string,main.nestedStruct>
-      ByteSize: 48
-      RawFields:
-        - Name: count
-          Offset: 0
-          Type: 1 BaseType int
-        - Name: flags
-          Offset: 8
-          Type: 4 BaseType uint8
-        - Name: B
-          Offset: 9
-          Type: 4 BaseType uint8
-        - Name: noverflow
-          Offset: 10
-          Type: 22 BaseType uint16
-        - Name: hash0
-          Offset: 12
-          Type: 24 BaseType uint32
-        - Name: buckets
-          Offset: 16
-          Type: 77 PointerType *bucket<string,main.nestedStruct>
-        - Name: oldbuckets
-          Offset: 24
-          Type: 77 PointerType *bucket<string,main.nestedStruct>
-        - Name: nevacuate
-          Offset: 32
-          Type: 66 BaseType uintptr
-        - Name: extra
-          Offset: 40
-          Type: 67 PointerType *runtime.mapextra
-      BucketType: 78 GoHMapBucketType bucket<string,main.nestedStruct>
-      BucketsType: 194 GoSliceDataType []bucket<string,main.nestedStruct>.array
+      Pointee: 213 GoSliceDataType [][]uint.array
     - __kind: PointerType
-      ID: 77
-      Name: '*bucket<string,main.nestedStruct>'
+      ID: 218
+      Name: '*[]bool.array'
       ByteSize: 8
-      Pointee: 78 GoHMapBucketType bucket<string,main.nestedStruct>
-    - __kind: GoHMapBucketType
-      ID: 78
-      Name: bucket<string,main.nestedStruct>
-      ByteSize: 336
-      RawFields:
-        - Name: tophash
-          Offset: 0
-          Type: 63 ArrayType [8]uint8
-        - Name: keys
-          Offset: 8
-          Type: 79 ArrayType []key<string>
-        - Name: values
-          Offset: 136
-          Type: 80 ArrayType []val<main.nestedStruct>
-        - Name: overflow
-          Offset: 328
-          Type: 77 PointerType *bucket<string,main.nestedStruct>
-      KeyType: 8 GoStringHeaderType string
-      ValueType: 81 StructureType main.nestedStruct
-    - __kind: ArrayType
-      ID: 79
-      Name: '[]key<string>'
-      ByteSize: 128
-      Count: 8
-      HasCount: true
-      Element: 8 GoStringHeaderType string
-    - __kind: ArrayType
-      ID: 80
-      Name: '[]val<main.nestedStruct>'
-      ByteSize: 192
-      Count: 8
-      HasCount: true
-      Element: 81 StructureType main.nestedStruct
-    - __kind: StructureType
-      ID: 81
-      Name: main.nestedStruct
-      ByteSize: 24
-      GoRuntimeType: 1.270016e+06
-      GoKind: 25
-      RawFields:
-        - Name: anotherInt
-          Offset: 0
-          Type: 1 BaseType int
-        - Name: anotherString
-          Offset: 8
-          Type: 8 GoStringHeaderType string
-    - __kind: GoMapType
-      ID: 82
-      Name: map[string]int
-      ByteSize: 8
-      GoRuntimeType: 874528
-      GoKind: 21
-      HeaderType: 84 GoHMapHeaderType hash<string,int>
+      Pointee: 217 GoSliceDataType []bool.array
     - __kind: PointerType
-      ID: 83
-      Name: '*hash<string,int>'
+      ID: 202
+      Name: '*[]main.structWithMap.array'
       ByteSize: 8
-      Pointee: 84 GoHMapHeaderType hash<string,int>
-    - __kind: GoHMapHeaderType
-      ID: 84
-      Name: hash<string,int>
-      ByteSize: 48
-      RawFields:
-        - Name: count
-          Offset: 0
-          Type: 1 BaseType int
-        - Name: flags
-          Offset: 8
-          Type: 4 BaseType uint8
-        - Name: B
-          Offset: 9
-          Type: 4 BaseType uint8
-        - Name: noverflow
-          Offset: 10
-          Type: 22 BaseType uint16
-        - Name: hash0
-          Offset: 12
-          Type: 24 BaseType uint32
-        - Name: buckets
-          Offset: 16
-          Type: 85 PointerType *bucket<string,int>
-        - Name: oldbuckets
-          Offset: 24
-          Type: 85 PointerType *bucket<string,int>
-        - Name: nevacuate
-          Offset: 32
-          Type: 66 BaseType uintptr
-        - Name: extra
-          Offset: 40
-          Type: 67 PointerType *runtime.mapextra
-      BucketType: 86 GoHMapBucketType bucket<string,int>
-      BucketsType: 195 GoSliceDataType []bucket<string,int>.array
+      Pointee: 201 GoSliceDataType []main.structWithMap.array
     - __kind: PointerType
-      ID: 85
-      Name: '*bucket<string,int>'
+      ID: 216
+      Name: '*[]main.structWithNoStrings.array'
       ByteSize: 8
-      Pointee: 86 GoHMapBucketType bucket<string,int>
-    - __kind: GoHMapBucketType
-      ID: 86
-      Name: bucket<string,int>
-      ByteSize: 208
-      RawFields:
-        - Name: tophash
-          Offset: 0
-          Type: 63 ArrayType [8]uint8
-        - Name: keys
-          Offset: 8
-          Type: 79 ArrayType []key<string>
-        - Name: values
-          Offset: 136
-          Type: 65 ArrayType []val<int>
-        - Name: overflow
-          Offset: 200
-          Type: 85 PointerType *bucket<string,int>
-      KeyType: 8 GoStringHeaderType string
-      ValueType: 1 BaseType int
-    - __kind: GoMapType
-      ID: 87
-      Name: map[string][]string
-      ByteSize: 8
-      GoRuntimeType: 874432
-      GoKind: 21
-      HeaderType: 89 GoHMapHeaderType hash<string,[]string>
+      Pointee: 215 GoSliceDataType []main.structWithNoStrings.array
     - __kind: PointerType
-      ID: 88
-      Name: '*hash<string,[]string>'
+      ID: 198
+      Name: '*[]string.array'
       ByteSize: 8
-      Pointee: 89 GoHMapHeaderType hash<string,[]string>
-    - __kind: GoHMapHeaderType
-      ID: 89
-      Name: hash<string,[]string>
-      ByteSize: 48
-      RawFields:
-        - Name: count
-          Offset: 0
-          Type: 1 BaseType int
-        - Name: flags
-          Offset: 8
-          Type: 4 BaseType uint8
-        - Name: B
-          Offset: 9
-          Type: 4 BaseType uint8
-        - Name: noverflow
-          Offset: 10
-          Type: 22 BaseType uint16
-        - Name: hash0
-          Offset: 12
-          Type: 24 BaseType uint32
-        - Name: buckets
-          Offset: 16
-          Type: 90 PointerType *bucket<string,[]string>
-        - Name: oldbuckets
-          Offset: 24
-          Type: 90 PointerType *bucket<string,[]string>
-        - Name: nevacuate
-          Offset: 32
-          Type: 66 BaseType uintptr
-        - Name: extra
-          Offset: 40
-          Type: 67 PointerType *runtime.mapextra
-      BucketType: 91 GoHMapBucketType bucket<string,[]string>
-      BucketsType: 196 GoSliceDataType []bucket<string,[]string>.array
+      Pointee: 197 GoSliceDataType []string.array
     - __kind: PointerType
-      ID: 90
-      Name: '*bucket<string,[]string>'
+      ID: 161
+      Name: '*[]uint'
       ByteSize: 8
-      Pointee: 91 GoHMapBucketType bucket<string,[]string>
-    - __kind: GoHMapBucketType
-      ID: 91
-      Name: bucket<string,[]string>
-      ByteSize: 336
-      RawFields:
-        - Name: tophash
-          Offset: 0
-          Type: 63 ArrayType [8]uint8
-        - Name: keys
-          Offset: 8
-          Type: 79 ArrayType []key<string>
-        - Name: values
-          Offset: 136
-          Type: 92 ArrayType []val<[]string>
-        - Name: overflow
-          Offset: 328
-          Type: 90 PointerType *bucket<string,[]string>
-      KeyType: 8 GoStringHeaderType string
-      ValueType: 93 GoSliceHeaderType []string
-    - __kind: ArrayType
-      ID: 92
-      Name: '[]val<[]string>'
-      ByteSize: 192
-      Count: 8
-      HasCount: true
-      Element: 93 GoSliceHeaderType []string
-    - __kind: GoSliceHeaderType
-      ID: 93
-      Name: '[]string'
-      ByteSize: 24
-      GoRuntimeType: 449888
-      GoKind: 23
-      RawFields:
-        - Name: array
-          Offset: 0
-          Type: 36 PointerType *string
-        - Name: len
-          Offset: 8
-          Type: 1 BaseType int
-        - Name: cap
-          Offset: 16
-          Type: 1 BaseType int
-      Data: 197 GoSliceDataType []string.array
-    - __kind: GoMapType
-      ID: 94
-      Name: map[[4]string][2]int
-      ByteSize: 8
-      GoRuntimeType: 874048
-      GoKind: 21
-      HeaderType: 96 GoHMapHeaderType hash<[4]string,[2]int>
+      Pointee: 159 GoSliceHeaderType []uint
     - __kind: PointerType
-      ID: 95
-      Name: '*hash<[4]string,[2]int>'
+      ID: 212
+      Name: '*[]uint.array'
       ByteSize: 8
-      Pointee: 96 GoHMapHeaderType hash<[4]string,[2]int>
-    - __kind: GoHMapHeaderType
-      ID: 96
-      Name: hash<[4]string,[2]int>
-      ByteSize: 48
-      RawFields:
-        - Name: count
-          Offset: 0
-          Type: 1 BaseType int
-        - Name: flags
-          Offset: 8
-          Type: 4 BaseType uint8
-        - Name: B
-          Offset: 9
-          Type: 4 BaseType uint8
-        - Name: noverflow
-          Offset: 10
-          Type: 22 BaseType uint16
-        - Name: hash0
-          Offset: 12
-          Type: 24 BaseType uint32
-        - Name: buckets
-          Offset: 16
-          Type: 97 PointerType *bucket<[4]string,[2]int>
-        - Name: oldbuckets
-          Offset: 24
-          Type: 97 PointerType *bucket<[4]string,[2]int>
-        - Name: nevacuate
-          Offset: 32
-          Type: 66 BaseType uintptr
-        - Name: extra
-          Offset: 40
-          Type: 67 PointerType *runtime.mapextra
-      BucketType: 98 GoHMapBucketType bucket<[4]string,[2]int>
-      BucketsType: 199 GoSliceDataType []bucket<[4]string,[2]int>.array
+      Pointee: 211 GoSliceDataType []uint.array
     - __kind: PointerType
-      ID: 97
-      Name: '*bucket<[4]string,[2]int>'
+      ID: 220
+      Name: '*[]uint16.array'
       ByteSize: 8
-      Pointee: 98 GoHMapBucketType bucket<[4]string,[2]int>
-    - __kind: GoHMapBucketType
-      ID: 98
-      Name: bucket<[4]string,[2]int>
-      ByteSize: 656
-      RawFields:
-        - Name: tophash
-          Offset: 0
-          Type: 63 ArrayType [8]uint8
-        - Name: keys
-          Offset: 8
-          Type: 99 ArrayType []key<[4]string>
-        - Name: values
-          Offset: 520
-          Type: 101 ArrayType []val<[2]int>
-        - Name: overflow
-          Offset: 648
-          Type: 97 PointerType *bucket<[4]string,[2]int>
-      KeyType: 100 ArrayType [4]string
-      ValueType: 12 ArrayType [2]int
-    - __kind: ArrayType
-      ID: 99
-      Name: '[]key<[4]string>'
-      ByteSize: 512
-      Count: 8
-      HasCount: true
-      Element: 100 ArrayType [4]string
-    - __kind: ArrayType
-      ID: 100
-      Name: '[4]string'
-      ByteSize: 64
-      GoRuntimeType: 617632
-      GoKind: 17
-      Count: 4
-      HasCount: true
-      Element: 8 GoStringHeaderType string
-    - __kind: ArrayType
-      ID: 101
-      Name: '[]val<[2]int>'
-      ByteSize: 128
-      Count: 8
-      HasCount: true
-      Element: 12 ArrayType [2]int
-    - __kind: ArrayType
-      ID: 102
-      Name: '[2]map[string]int'
-      ByteSize: 16
-      GoKind: 17
-      Count: 2
-      HasCount: true
-      Element: 82 GoMapType map[string]int
-    - __kind: PointerType
-      ID: 103
-      Name: '*map[string]int'
-      ByteSize: 8
-      GoKind: 22
-      Pointee: 82 GoMapType map[string]int
-    - __kind: GoMapType
-      ID: 104
-      Name: map[string][]main.structWithMap
-      ByteSize: 8
-      GoRuntimeType: 874336
-      GoKind: 21
-      HeaderType: 106 GoHMapHeaderType hash<string,[]main.structWithMap>
-    - __kind: PointerType
-      ID: 105
-      Name: '*hash<string,[]main.structWithMap>'
-      ByteSize: 8
-      Pointee: 106 GoHMapHeaderType hash<string,[]main.structWithMap>
-    - __kind: GoHMapHeaderType
-      ID: 106
-      Name: hash<string,[]main.structWithMap>
-      ByteSize: 48
-      RawFields:
-        - Name: count
-          Offset: 0
-          Type: 1 BaseType int
-        - Name: flags
-          Offset: 8
-          Type: 4 BaseType uint8
-        - Name: B
-          Offset: 9
-          Type: 4 BaseType uint8
-        - Name: noverflow
-          Offset: 10
-          Type: 22 BaseType uint16
-        - Name: hash0
-          Offset: 12
-          Type: 24 BaseType uint32
-        - Name: buckets
-          Offset: 16
-          Type: 107 PointerType *bucket<string,[]main.structWithMap>
-        - Name: oldbuckets
-          Offset: 24
-          Type: 107 PointerType *bucket<string,[]main.structWithMap>
-        - Name: nevacuate
-          Offset: 32
-          Type: 66 BaseType uintptr
-        - Name: extra
-          Offset: 40
-          Type: 67 PointerType *runtime.mapextra
-      BucketType: 108 GoHMapBucketType bucket<string,[]main.structWithMap>
-      BucketsType: 200 GoSliceDataType []bucket<string,[]main.structWithMap>.array
-    - __kind: PointerType
-      ID: 107
-      Name: '*bucket<string,[]main.structWithMap>'
-      ByteSize: 8
-      Pointee: 108 GoHMapBucketType bucket<string,[]main.structWithMap>
-    - __kind: GoHMapBucketType
-      ID: 108
-      Name: bucket<string,[]main.structWithMap>
-      ByteSize: 336
-      RawFields:
-        - Name: tophash
-          Offset: 0
-          Type: 63 ArrayType [8]uint8
-        - Name: keys
-          Offset: 8
-          Type: 79 ArrayType []key<string>
-        - Name: values
-          Offset: 136
-          Type: 109 ArrayType []val<[]main.structWithMap>
-        - Name: overflow
-          Offset: 328
-          Type: 107 PointerType *bucket<string,[]main.structWithMap>
-      KeyType: 8 GoStringHeaderType string
-      ValueType: 110 GoSliceHeaderType []main.structWithMap
-    - __kind: ArrayType
-      ID: 109
-      Name: '[]val<[]main.structWithMap>'
-      ByteSize: 192
-      Count: 8
-      HasCount: true
-      Element: 110 GoSliceHeaderType []main.structWithMap
-    - __kind: GoSliceHeaderType
-      ID: 110
-      Name: '[]main.structWithMap'
-      ByteSize: 24
-      GoRuntimeType: 442720
-      GoKind: 23
-      RawFields:
-        - Name: array
-          Offset: 0
-          Type: 111 PointerType *main.structWithMap
-        - Name: len
-          Offset: 8
-          Type: 1 BaseType int
-        - Name: cap
-          Offset: 16
-          Type: 1 BaseType int
-      Data: 201 GoSliceDataType []main.structWithMap.array
-    - __kind: PointerType
-      ID: 111
-      Name: '*main.structWithMap'
-      ByteSize: 8
-      GoRuntimeType: 354080
-      GoKind: 22
-      Pointee: 57 StructureType main.structWithMap
-    - __kind: GoMapType
-      ID: 112
-      Name: map[bool]main.node
-      ByteSize: 8
-      GoRuntimeType: 874144
-      GoKind: 21
-      HeaderType: 114 GoHMapHeaderType hash<bool,main.node>
-    - __kind: PointerType
-      ID: 113
-      Name: '*hash<bool,main.node>'
-      ByteSize: 8
-      Pointee: 114 GoHMapHeaderType hash<bool,main.node>
-    - __kind: GoHMapHeaderType
-      ID: 114
-      Name: hash<bool,main.node>
-      ByteSize: 48
-      RawFields:
-        - Name: count
-          Offset: 0
-          Type: 1 BaseType int
-        - Name: flags
-          Offset: 8
-          Type: 4 BaseType uint8
-        - Name: B
-          Offset: 9
-          Type: 4 BaseType uint8
-        - Name: noverflow
-          Offset: 10
-          Type: 22 BaseType uint16
-        - Name: hash0
-          Offset: 12
-          Type: 24 BaseType uint32
-        - Name: buckets
-          Offset: 16
-          Type: 115 PointerType *bucket<bool,main.node>
-        - Name: oldbuckets
-          Offset: 24
-          Type: 115 PointerType *bucket<bool,main.node>
-        - Name: nevacuate
-          Offset: 32
-          Type: 66 BaseType uintptr
-        - Name: extra
-          Offset: 40
-          Type: 67 PointerType *runtime.mapextra
-      BucketType: 116 GoHMapBucketType bucket<bool,main.node>
-      BucketsType: 203 GoSliceDataType []bucket<bool,main.node>.array
-    - __kind: PointerType
-      ID: 115
-      Name: '*bucket<bool,main.node>'
-      ByteSize: 8
-      Pointee: 116 GoHMapBucketType bucket<bool,main.node>
-    - __kind: GoHMapBucketType
-      ID: 116
-      Name: bucket<bool,main.node>
-      ByteSize: 152
-      RawFields:
-        - Name: tophash
-          Offset: 0
-          Type: 63 ArrayType [8]uint8
-        - Name: keys
-          Offset: 8
-          Type: 117 ArrayType []key<bool>
-        - Name: values
-          Offset: 16
-          Type: 118 ArrayType []val<main.node>
-        - Name: overflow
-          Offset: 144
-          Type: 115 PointerType *bucket<bool,main.node>
-      KeyType: 11 BaseType bool
-      ValueType: 119 StructureType main.node
-    - __kind: ArrayType
-      ID: 117
-      Name: '[]key<bool>'
-      ByteSize: 8
-      Count: 8
-      HasCount: true
-      Element: 11 BaseType bool
-    - __kind: ArrayType
-      ID: 118
-      Name: '[]val<main.node>'
-      ByteSize: 128
-      Count: 8
-      HasCount: true
-      Element: 119 StructureType main.node
-    - __kind: StructureType
-      ID: 119
-      Name: main.node
-      ByteSize: 16
-      GoRuntimeType: 1.269856e+06
-      GoKind: 25
-      RawFields:
-        - Name: val
-          Offset: 0
-          Type: 1 BaseType int
-        - Name: b
-          Offset: 8
-          Type: 120 PointerType *main.node
-    - __kind: PointerType
-      ID: 120
-      Name: '*main.node'
-      ByteSize: 8
-      GoRuntimeType: 354208
-      GoKind: 22
-      Pointee: 119 StructureType main.node
-    - __kind: GoMapType
-      ID: 121
-      Name: map[int]uint8
-      ByteSize: 8
-      GoRuntimeType: 874240
-      GoKind: 21
-      HeaderType: 123 GoHMapHeaderType hash<int,uint8>
-    - __kind: PointerType
-      ID: 122
-      Name: '*hash<int,uint8>'
-      ByteSize: 8
-      Pointee: 123 GoHMapHeaderType hash<int,uint8>
-    - __kind: GoHMapHeaderType
-      ID: 123
-      Name: hash<int,uint8>
-      ByteSize: 48
-      RawFields:
-        - Name: count
-          Offset: 0
-          Type: 1 BaseType int
-        - Name: flags
-          Offset: 8
-          Type: 4 BaseType uint8
-        - Name: B
-          Offset: 9
-          Type: 4 BaseType uint8
-        - Name: noverflow
-          Offset: 10
-          Type: 22 BaseType uint16
-        - Name: hash0
-          Offset: 12
-          Type: 24 BaseType uint32
-        - Name: buckets
-          Offset: 16
-          Type: 124 PointerType *bucket<int,uint8>
-        - Name: oldbuckets
-          Offset: 24
-          Type: 124 PointerType *bucket<int,uint8>
-        - Name: nevacuate
-          Offset: 32
-          Type: 66 BaseType uintptr
-        - Name: extra
-          Offset: 40
-          Type: 67 PointerType *runtime.mapextra
-      BucketType: 125 GoHMapBucketType bucket<int,uint8>
-      BucketsType: 204 GoSliceDataType []bucket<int,uint8>.array
-    - __kind: PointerType
-      ID: 124
-      Name: '*bucket<int,uint8>'
-      ByteSize: 8
-      Pointee: 125 GoHMapBucketType bucket<int,uint8>
-    - __kind: GoHMapBucketType
-      ID: 125
-      Name: bucket<int,uint8>
-      ByteSize: 88
-      RawFields:
-        - Name: tophash
-          Offset: 0
-          Type: 63 ArrayType [8]uint8
-        - Name: keys
-          Offset: 8
-          Type: 64 ArrayType []key<int>
-        - Name: values
-          Offset: 72
-          Type: 126 ArrayType []val<uint8>
-        - Name: overflow
-          Offset: 80
-          Type: 124 PointerType *bucket<int,uint8>
-      KeyType: 1 BaseType int
-      ValueType: 4 BaseType uint8
-    - __kind: ArrayType
-      ID: 126
-      Name: '[]val<uint8>'
-      ByteSize: 8
-      Count: 8
-      HasCount: true
-      Element: 4 BaseType uint8
-    - __kind: GoMapType
-      ID: 127
-      Name: map[uint8]uint8
-      ByteSize: 8
-      GoRuntimeType: 874816
-      GoKind: 21
-      HeaderType: 129 GoHMapHeaderType hash<uint8,uint8>
-    - __kind: PointerType
-      ID: 128
-      Name: '*hash<uint8,uint8>'
-      ByteSize: 8
-      Pointee: 129 GoHMapHeaderType hash<uint8,uint8>
-    - __kind: GoHMapHeaderType
-      ID: 129
-      Name: hash<uint8,uint8>
-      ByteSize: 48
-      RawFields:
-        - Name: count
-          Offset: 0
-          Type: 1 BaseType int
-        - Name: flags
-          Offset: 8
-          Type: 4 BaseType uint8
-        - Name: B
-          Offset: 9
-          Type: 4 BaseType uint8
-        - Name: noverflow
-          Offset: 10
-          Type: 22 BaseType uint16
-        - Name: hash0
-          Offset: 12
-          Type: 24 BaseType uint32
-        - Name: buckets
-          Offset: 16
-          Type: 130 PointerType *bucket<uint8,uint8>
-        - Name: oldbuckets
-          Offset: 24
-          Type: 130 PointerType *bucket<uint8,uint8>
-        - Name: nevacuate
-          Offset: 32
-          Type: 66 BaseType uintptr
-        - Name: extra
-          Offset: 40
-          Type: 67 PointerType *runtime.mapextra
-      BucketType: 131 GoHMapBucketType bucket<uint8,uint8>
-      BucketsType: 205 GoSliceDataType []bucket<uint8,uint8>.array
-    - __kind: PointerType
-      ID: 130
-      Name: '*bucket<uint8,uint8>'
-      ByteSize: 8
-      Pointee: 131 GoHMapBucketType bucket<uint8,uint8>
-    - __kind: GoHMapBucketType
-      ID: 131
-      Name: bucket<uint8,uint8>
-      ByteSize: 32
-      RawFields:
-        - Name: tophash
-          Offset: 0
-          Type: 63 ArrayType [8]uint8
-        - Name: keys
-          Offset: 8
-          Type: 132 ArrayType []key<uint8>
-        - Name: values
-          Offset: 16
-          Type: 126 ArrayType []val<uint8>
-        - Name: overflow
-          Offset: 24
-          Type: 130 PointerType *bucket<uint8,uint8>
-      KeyType: 4 BaseType uint8
-      ValueType: 4 BaseType uint8
-    - __kind: ArrayType
-      ID: 132
-      Name: '[]key<uint8>'
-      ByteSize: 8
-      Count: 8
-      HasCount: true
-      Element: 4 BaseType uint8
-    - __kind: GoMapType
-      ID: 133
-      Name: map[uint8][4]int
-      ByteSize: 8
-      GoRuntimeType: 874720
-      GoKind: 21
-      HeaderType: 135 GoHMapHeaderType hash<uint8,[4]int>
-    - __kind: PointerType
-      ID: 134
-      Name: '*hash<uint8,[4]int>'
-      ByteSize: 8
-      Pointee: 135 GoHMapHeaderType hash<uint8,[4]int>
-    - __kind: GoHMapHeaderType
-      ID: 135
-      Name: hash<uint8,[4]int>
-      ByteSize: 48
-      RawFields:
-        - Name: count
-          Offset: 0
-          Type: 1 BaseType int
-        - Name: flags
-          Offset: 8
-          Type: 4 BaseType uint8
-        - Name: B
-          Offset: 9
-          Type: 4 BaseType uint8
-        - Name: noverflow
-          Offset: 10
-          Type: 22 BaseType uint16
-        - Name: hash0
-          Offset: 12
-          Type: 24 BaseType uint32
-        - Name: buckets
-          Offset: 16
-          Type: 136 PointerType *bucket<uint8,[4]int>
-        - Name: oldbuckets
-          Offset: 24
-          Type: 136 PointerType *bucket<uint8,[4]int>
-        - Name: nevacuate
-          Offset: 32
-          Type: 66 BaseType uintptr
-        - Name: extra
-          Offset: 40
-          Type: 67 PointerType *runtime.mapextra
-      BucketType: 137 GoHMapBucketType bucket<uint8,[4]int>
-      BucketsType: 206 GoSliceDataType []bucket<uint8,[4]int>.array
-    - __kind: PointerType
-      ID: 136
-      Name: '*bucket<uint8,[4]int>'
-      ByteSize: 8
-      Pointee: 137 GoHMapBucketType bucket<uint8,[4]int>
-    - __kind: GoHMapBucketType
-      ID: 137
-      Name: bucket<uint8,[4]int>
-      ByteSize: 280
-      RawFields:
-        - Name: tophash
-          Offset: 0
-          Type: 63 ArrayType [8]uint8
-        - Name: keys
-          Offset: 8
-          Type: 132 ArrayType []key<uint8>
-        - Name: values
-          Offset: 16
-          Type: 138 ArrayType []val<[4]int>
-        - Name: overflow
-          Offset: 272
-          Type: 136 PointerType *bucket<uint8,[4]int>
-      KeyType: 4 BaseType uint8
-      ValueType: 139 ArrayType [4]int
-    - __kind: ArrayType
-      ID: 138
-      Name: '[]val<[4]int>'
-      ByteSize: 256
-      Count: 8
-      HasCount: true
-      Element: 139 ArrayType [4]int
-    - __kind: ArrayType
-      ID: 139
-      Name: '[4]int'
-      ByteSize: 32
-      GoRuntimeType: 617344
-      GoKind: 17
-      Count: 4
-      HasCount: true
-      Element: 1 BaseType int
-    - __kind: GoMapType
-      ID: 140
-      Name: map[[4]int]uint8
-      ByteSize: 8
-      GoRuntimeType: 873952
-      GoKind: 21
-      HeaderType: 142 GoHMapHeaderType hash<[4]int,uint8>
-    - __kind: PointerType
-      ID: 141
-      Name: '*hash<[4]int,uint8>'
-      ByteSize: 8
-      Pointee: 142 GoHMapHeaderType hash<[4]int,uint8>
-    - __kind: GoHMapHeaderType
-      ID: 142
-      Name: hash<[4]int,uint8>
-      ByteSize: 48
-      RawFields:
-        - Name: count
-          Offset: 0
-          Type: 1 BaseType int
-        - Name: flags
-          Offset: 8
-          Type: 4 BaseType uint8
-        - Name: B
-          Offset: 9
-          Type: 4 BaseType uint8
-        - Name: noverflow
-          Offset: 10
-          Type: 22 BaseType uint16
-        - Name: hash0
-          Offset: 12
-          Type: 24 BaseType uint32
-        - Name: buckets
-          Offset: 16
-          Type: 143 PointerType *bucket<[4]int,uint8>
-        - Name: oldbuckets
-          Offset: 24
-          Type: 143 PointerType *bucket<[4]int,uint8>
-        - Name: nevacuate
-          Offset: 32
-          Type: 66 BaseType uintptr
-        - Name: extra
-          Offset: 40
-          Type: 67 PointerType *runtime.mapextra
-      BucketType: 144 GoHMapBucketType bucket<[4]int,uint8>
-      BucketsType: 207 GoSliceDataType []bucket<[4]int,uint8>.array
-    - __kind: PointerType
-      ID: 143
-      Name: '*bucket<[4]int,uint8>'
-      ByteSize: 8
-      Pointee: 144 GoHMapBucketType bucket<[4]int,uint8>
-    - __kind: GoHMapBucketType
-      ID: 144
-      Name: bucket<[4]int,uint8>
-      ByteSize: 280
-      RawFields:
-        - Name: tophash
-          Offset: 0
-          Type: 63 ArrayType [8]uint8
-        - Name: keys
-          Offset: 8
-          Type: 145 ArrayType []key<[4]int>
-        - Name: values
-          Offset: 264
-          Type: 126 ArrayType []val<uint8>
-        - Name: overflow
-          Offset: 272
-          Type: 143 PointerType *bucket<[4]int,uint8>
-      KeyType: 139 ArrayType [4]int
-      ValueType: 4 BaseType uint8
-    - __kind: ArrayType
-      ID: 145
-      Name: '[]key<[4]int>'
-      ByteSize: 256
-      Count: 8
-      HasCount: true
-      Element: 139 ArrayType [4]int
-    - __kind: GoMapType
-      ID: 146
-      Name: map[[4]int][4]int
-      ByteSize: 8
-      GoRuntimeType: 873856
-      GoKind: 21
-      HeaderType: 148 GoHMapHeaderType hash<[4]int,[4]int>
-    - __kind: PointerType
-      ID: 147
-      Name: '*hash<[4]int,[4]int>'
-      ByteSize: 8
-      Pointee: 148 GoHMapHeaderType hash<[4]int,[4]int>
-    - __kind: GoHMapHeaderType
-      ID: 148
-      Name: hash<[4]int,[4]int>
-      ByteSize: 48
-      RawFields:
-        - Name: count
-          Offset: 0
-          Type: 1 BaseType int
-        - Name: flags
-          Offset: 8
-          Type: 4 BaseType uint8
-        - Name: B
-          Offset: 9
-          Type: 4 BaseType uint8
-        - Name: noverflow
-          Offset: 10
-          Type: 22 BaseType uint16
-        - Name: hash0
-          Offset: 12
-          Type: 24 BaseType uint32
-        - Name: buckets
-          Offset: 16
-          Type: 149 PointerType *bucket<[4]int,[4]int>
-        - Name: oldbuckets
-          Offset: 24
-          Type: 149 PointerType *bucket<[4]int,[4]int>
-        - Name: nevacuate
-          Offset: 32
-          Type: 66 BaseType uintptr
-        - Name: extra
-          Offset: 40
-          Type: 67 PointerType *runtime.mapextra
-      BucketType: 150 GoHMapBucketType bucket<[4]int,[4]int>
-      BucketsType: 208 GoSliceDataType []bucket<[4]int,[4]int>.array
-    - __kind: PointerType
-      ID: 149
-      Name: '*bucket<[4]int,[4]int>'
-      ByteSize: 8
-      Pointee: 150 GoHMapBucketType bucket<[4]int,[4]int>
-    - __kind: GoHMapBucketType
-      ID: 150
-      Name: bucket<[4]int,[4]int>
-      ByteSize: 528
-      RawFields:
-        - Name: tophash
-          Offset: 0
-          Type: 63 ArrayType [8]uint8
-        - Name: keys
-          Offset: 8
-          Type: 145 ArrayType []key<[4]int>
-        - Name: values
-          Offset: 264
-          Type: 138 ArrayType []val<[4]int>
-        - Name: overflow
-          Offset: 520
-          Type: 149 PointerType *bucket<[4]int,[4]int>
-      KeyType: 139 ArrayType [4]int
-      ValueType: 139 ArrayType [4]int
-    - __kind: GoChannelType
-      ID: 151
-      Name: chan bool
-      GoRuntimeType: 539136
-      GoKind: 18
-    - __kind: PointerType
-      ID: 152
-      Name: '*main.structWithTwoValues'
-      ByteSize: 8
-      GoKind: 22
-      Pointee: 153 StructureType main.structWithTwoValues
-    - __kind: StructureType
-      ID: 153
-      Name: main.structWithTwoValues
-      ByteSize: 16
-      GoKind: 25
-      RawFields:
-        - Name: a
-          Offset: 0
-          Type: 20 BaseType uint
-        - Name: b
-          Offset: 8
-          Type: 11 BaseType bool
-    - __kind: PointerType
-      ID: 154
-      Name: '*uint'
-      ByteSize: 8
-      GoRuntimeType: 359840
-      GoKind: 22
-      Pointee: 20 BaseType uint
+      Pointee: 219 GoSliceDataType []uint16.array
     - __kind: PointerType
       ID: 155
       Name: '*bool'
@@ -4794,278 +3176,65 @@ Types:
       GoKind: 22
       Pointee: 11 BaseType bool
     - __kind: PointerType
-      ID: 156
-      Name: '*main.t'
+      ID: 149
+      Name: '*bucket<[4]int,[4]int>'
       ByteSize: 8
-      GoKind: 22
-      Pointee: 157 GoSliceHeaderType main.t
-    - __kind: GoSliceHeaderType
-      ID: 157
-      Name: main.t
-      ByteSize: 24
-      GoKind: 23
-      RawFields:
-        - Name: array
-          Offset: 0
-          Type: 158 PointerType **main.t
-        - Name: len
-          Offset: 8
-          Type: 1 BaseType int
-        - Name: cap
-          Offset: 16
-          Type: 1 BaseType int
-      Data: 209 GoSliceDataType main.t.array
+      Pointee: 150 GoHMapBucketType bucket<[4]int,[4]int>
     - __kind: PointerType
-      ID: 158
-      Name: '**main.t'
+      ID: 143
+      Name: '*bucket<[4]int,uint8>'
       ByteSize: 8
-      Pointee: 156 PointerType *main.t
-    - __kind: GoSliceHeaderType
-      ID: 159
-      Name: '[]uint'
-      ByteSize: 24
-      GoRuntimeType: 449376
-      GoKind: 23
-      RawFields:
-        - Name: array
-          Offset: 0
-          Type: 154 PointerType *uint
-        - Name: len
-          Offset: 8
-          Type: 1 BaseType int
-        - Name: cap
-          Offset: 16
-          Type: 1 BaseType int
-      Data: 211 GoSliceDataType []uint.array
-    - __kind: GoSliceHeaderType
-      ID: 160
-      Name: '[][]uint'
-      ByteSize: 24
-      GoKind: 23
-      RawFields:
-        - Name: array
-          Offset: 0
-          Type: 161 PointerType *[]uint
-        - Name: len
-          Offset: 8
-          Type: 1 BaseType int
-        - Name: cap
-          Offset: 16
-          Type: 1 BaseType int
-      Data: 213 GoSliceDataType [][]uint.array
+      Pointee: 144 GoHMapBucketType bucket<[4]int,uint8>
     - __kind: PointerType
-      ID: 161
-      Name: '*[]uint'
+      ID: 97
+      Name: '*bucket<[4]string,[2]int>'
       ByteSize: 8
-      Pointee: 159 GoSliceHeaderType []uint
-    - __kind: GoSliceHeaderType
-      ID: 162
-      Name: '[]main.structWithNoStrings'
-      ByteSize: 24
-      GoKind: 23
-      RawFields:
-        - Name: array
-          Offset: 0
-          Type: 163 PointerType *main.structWithNoStrings
-        - Name: len
-          Offset: 8
-          Type: 1 BaseType int
-        - Name: cap
-          Offset: 16
-          Type: 1 BaseType int
-      Data: 215 GoSliceDataType []main.structWithNoStrings.array
+      Pointee: 98 GoHMapBucketType bucket<[4]string,[2]int>
     - __kind: PointerType
-      ID: 163
-      Name: '*main.structWithNoStrings'
+      ID: 115
+      Name: '*bucket<bool,main.node>'
       ByteSize: 8
-      Pointee: 164 StructureType main.structWithNoStrings
-    - __kind: StructureType
-      ID: 164
-      Name: main.structWithNoStrings
-      ByteSize: 2
-      GoKind: 25
-      RawFields:
-        - Name: aUint8
-          Offset: 0
-          Type: 4 BaseType uint8
-        - Name: aBool
-          Offset: 1
-          Type: 11 BaseType bool
-    - __kind: GoSliceHeaderType
-      ID: 165
-      Name: '[]bool'
-      ByteSize: 24
-      GoRuntimeType: 449760
-      GoKind: 23
-      RawFields:
-        - Name: array
-          Offset: 0
-          Type: 155 PointerType *bool
-        - Name: len
-          Offset: 8
-          Type: 1 BaseType int
-        - Name: cap
-          Offset: 16
-          Type: 1 BaseType int
-      Data: 217 GoSliceDataType []bool.array
-    - __kind: GoSliceHeaderType
-      ID: 166
-      Name: '[]uint16'
-      ByteSize: 24
-      GoRuntimeType: 448736
-      GoKind: 23
-      RawFields:
-        - Name: array
-          Offset: 0
-          Type: 167 PointerType *uint16
-        - Name: len
-          Offset: 8
-          Type: 1 BaseType int
-        - Name: cap
-          Offset: 16
-          Type: 1 BaseType int
-      Data: 219 GoSliceDataType []uint16.array
+      Pointee: 116 GoHMapBucketType bucket<bool,main.node>
     - __kind: PointerType
-      ID: 167
-      Name: '*uint16'
+      ID: 61
+      Name: '*bucket<int,int>'
       ByteSize: 8
-      GoRuntimeType: 359456
-      GoKind: 22
-      Pointee: 22 BaseType uint16
-    - __kind: StructureType
-      ID: 168
-      Name: main.threeStringStruct
-      ByteSize: 48
-      GoKind: 25
-      RawFields:
-        - Name: a
-          Offset: 0
-          Type: 8 GoStringHeaderType string
-        - Name: b
-          Offset: 16
-          Type: 8 GoStringHeaderType string
-        - Name: c
-          Offset: 32
-          Type: 8 GoStringHeaderType string
+      Pointee: 62 GoHMapBucketType bucket<int,int>
     - __kind: PointerType
-      ID: 169
-      Name: '*main.threeStringStruct'
+      ID: 124
+      Name: '*bucket<int,uint8>'
       ByteSize: 8
-      GoKind: 22
-      Pointee: 168 StructureType main.threeStringStruct
+      Pointee: 125 GoHMapBucketType bucket<int,uint8>
     - __kind: PointerType
-      ID: 170
-      Name: '*main.oneStringStruct'
+      ID: 107
+      Name: '*bucket<string,[]main.structWithMap>'
       ByteSize: 8
-      GoKind: 22
-      Pointee: 171 StructureType main.oneStringStruct
-    - __kind: StructureType
-      ID: 171
-      Name: main.oneStringStruct
-      ByteSize: 16
-      GoKind: 25
-      RawFields:
-        - Name: a
-          Offset: 0
-          Type: 8 GoStringHeaderType string
-    - __kind: StructureType
-      ID: 172
-      Name: main.aStruct
-      ByteSize: 56
-      GoKind: 25
-      RawFields:
-        - Name: aBool
-          Offset: 0
-          Type: 11 BaseType bool
-        - Name: aString
-          Offset: 8
-          Type: 8 GoStringHeaderType string
-        - Name: aNumber
-          Offset: 24
-          Type: 1 BaseType int
-        - Name: nested
-          Offset: 32
-          Type: 81 StructureType main.nestedStruct
-    - __kind: StructureType
-      ID: 173
-      Name: main.emptyStruct
-      GoKind: 25
-      RawFields: []
+      Pointee: 108 GoHMapBucketType bucket<string,[]main.structWithMap>
     - __kind: PointerType
-      ID: 174
-      Name: '*uintptr'
+      ID: 90
+      Name: '*bucket<string,[]string>'
       ByteSize: 8
-      GoRuntimeType: 359904
-      GoKind: 22
-      Pointee: 66 BaseType uintptr
+      Pointee: 91 GoHMapBucketType bucket<string,[]string>
     - __kind: PointerType
-      ID: 175
-      Name: '*int32'
+      ID: 85
+      Name: '*bucket<string,int>'
       ByteSize: 8
-      GoRuntimeType: 359520
-      GoKind: 22
-      Pointee: 6 BaseType int32
+      Pointee: 86 GoHMapBucketType bucket<string,int>
     - __kind: PointerType
-      ID: 176
-      Name: '*uint32'
+      ID: 77
+      Name: '*bucket<string,main.nestedStruct>'
       ByteSize: 8
-      GoRuntimeType: 359584
-      GoKind: 22
-      Pointee: 24 BaseType uint32
-    - __kind: BaseType
-      ID: 177
-      Name: complex64
-      ByteSize: 8
-      GoRuntimeType: 527616
-      GoKind: 15
-    - __kind: BaseType
-      ID: 178
-      Name: complex128
-      ByteSize: 16
-      GoRuntimeType: 527680
-      GoKind: 16
+      Pointee: 78 GoHMapBucketType bucket<string,main.nestedStruct>
     - __kind: PointerType
-      ID: 179
-      Name: '*float64'
+      ID: 136
+      Name: '*bucket<uint8,[4]int>'
       ByteSize: 8
-      GoRuntimeType: 360160
-      GoKind: 22
-      Pointee: 31 BaseType float64
+      Pointee: 137 GoHMapBucketType bucket<uint8,[4]int>
     - __kind: PointerType
-      ID: 180
-      Name: '*int64'
+      ID: 130
+      Name: '*bucket<uint8,uint8>'
       ByteSize: 8
-      GoRuntimeType: 359648
-      GoKind: 22
-      Pointee: 18 BaseType int64
-    - __kind: PointerType
-      ID: 181
-      Name: '*int'
-      ByteSize: 8
-      GoRuntimeType: 359776
-      GoKind: 22
-      Pointee: 1 BaseType int
-    - __kind: PointerType
-      ID: 182
-      Name: '*uint64'
-      ByteSize: 8
-      GoRuntimeType: 359712
-      GoKind: 22
-      Pointee: 26 BaseType uint64
-    - __kind: PointerType
-      ID: 183
-      Name: '*int16'
-      ByteSize: 8
-      GoRuntimeType: 359392
-      GoKind: 22
-      Pointee: 16 BaseType int16
-    - __kind: PointerType
-      ID: 184
-      Name: '*int8'
-      ByteSize: 8
-      GoRuntimeType: 359264
-      GoKind: 22
-      Pointee: 14 BaseType int8
+      Pointee: 131 GoHMapBucketType bucket<uint8,uint8>
     - __kind: PointerType
       ID: 185
       Name: '*error'
@@ -5080,220 +3249,330 @@ Types:
       GoRuntimeType: 360096
       GoKind: 22
       Pointee: 30 BaseType float32
-    - __kind: GoStringDataType
-      ID: 187
-      Name: string.str
-      ByteSize: 2048
     - __kind: PointerType
-      ID: 188
-      Name: '*string.str'
+      ID: 179
+      Name: '*float64'
       ByteSize: 8
-      Pointee: 187 GoStringDataType string.str
-    - __kind: GoSliceDataType
-      ID: 189
-      Name: '[]*string.array'
-      ByteSize: 2048
-      Element: 36 PointerType *string
+      GoRuntimeType: 360160
+      GoKind: 22
+      Pointee: 31 BaseType float64
     - __kind: PointerType
-      ID: 190
-      Name: '*[]*string.array'
+      ID: 147
+      Name: '*hash<[4]int,[4]int>'
       ByteSize: 8
-      Pointee: 189 GoSliceDataType []*string.array
-    - __kind: GoSliceDataType
-      ID: 191
-      Name: '[]bucket<int,int>.array'
-      ByteSize: 2048
-      Element: 62 GoHMapBucketType bucket<int,int>
-    - __kind: GoSliceDataType
-      ID: 192
-      Name: '[]*runtime.bmap.array'
-      ByteSize: 2048
-      Element: 72 PointerType *runtime.bmap
+      Pointee: 148 GoHMapHeaderType hash<[4]int,[4]int>
     - __kind: PointerType
-      ID: 193
-      Name: '*[]*runtime.bmap.array'
+      ID: 141
+      Name: '*hash<[4]int,uint8>'
       ByteSize: 8
-      Pointee: 192 GoSliceDataType []*runtime.bmap.array
-    - __kind: GoSliceDataType
-      ID: 194
-      Name: '[]bucket<string,main.nestedStruct>.array'
-      ByteSize: 2048
-      Element: 78 GoHMapBucketType bucket<string,main.nestedStruct>
-    - __kind: GoSliceDataType
-      ID: 195
-      Name: '[]bucket<string,int>.array'
-      ByteSize: 2048
-      Element: 86 GoHMapBucketType bucket<string,int>
-    - __kind: GoSliceDataType
-      ID: 196
-      Name: '[]bucket<string,[]string>.array'
-      ByteSize: 2048
-      Element: 91 GoHMapBucketType bucket<string,[]string>
-    - __kind: GoSliceDataType
-      ID: 197
-      Name: '[]string.array'
-      ByteSize: 2048
-      Element: 8 GoStringHeaderType string
+      Pointee: 142 GoHMapHeaderType hash<[4]int,uint8>
     - __kind: PointerType
-      ID: 198
-      Name: '*[]string.array'
+      ID: 95
+      Name: '*hash<[4]string,[2]int>'
       ByteSize: 8
-      Pointee: 197 GoSliceDataType []string.array
-    - __kind: GoSliceDataType
-      ID: 199
-      Name: '[]bucket<[4]string,[2]int>.array'
-      ByteSize: 2048
-      Element: 98 GoHMapBucketType bucket<[4]string,[2]int>
-    - __kind: GoSliceDataType
-      ID: 200
-      Name: '[]bucket<string,[]main.structWithMap>.array'
-      ByteSize: 2048
-      Element: 108 GoHMapBucketType bucket<string,[]main.structWithMap>
-    - __kind: GoSliceDataType
-      ID: 201
-      Name: '[]main.structWithMap.array'
-      ByteSize: 2048
-      Element: 57 StructureType main.structWithMap
+      Pointee: 96 GoHMapHeaderType hash<[4]string,[2]int>
     - __kind: PointerType
-      ID: 202
-      Name: '*[]main.structWithMap.array'
+      ID: 113
+      Name: '*hash<bool,main.node>'
       ByteSize: 8
-      Pointee: 201 GoSliceDataType []main.structWithMap.array
-    - __kind: GoSliceDataType
-      ID: 203
-      Name: '[]bucket<bool,main.node>.array'
-      ByteSize: 2048
-      Element: 116 GoHMapBucketType bucket<bool,main.node>
-    - __kind: GoSliceDataType
-      ID: 204
-      Name: '[]bucket<int,uint8>.array'
-      ByteSize: 2048
-      Element: 125 GoHMapBucketType bucket<int,uint8>
-    - __kind: GoSliceDataType
-      ID: 205
-      Name: '[]bucket<uint8,uint8>.array'
-      ByteSize: 2048
-      Element: 131 GoHMapBucketType bucket<uint8,uint8>
-    - __kind: GoSliceDataType
-      ID: 206
-      Name: '[]bucket<uint8,[4]int>.array'
-      ByteSize: 2048
-      Element: 137 GoHMapBucketType bucket<uint8,[4]int>
-    - __kind: GoSliceDataType
-      ID: 207
-      Name: '[]bucket<[4]int,uint8>.array'
-      ByteSize: 2048
-      Element: 144 GoHMapBucketType bucket<[4]int,uint8>
-    - __kind: GoSliceDataType
-      ID: 208
-      Name: '[]bucket<[4]int,[4]int>.array'
-      ByteSize: 2048
-      Element: 150 GoHMapBucketType bucket<[4]int,[4]int>
-    - __kind: GoSliceDataType
-      ID: 209
-      Name: main.t.array
-      ByteSize: 2048
-      Element: 156 PointerType *main.t
+      Pointee: 114 GoHMapHeaderType hash<bool,main.node>
+    - __kind: PointerType
+      ID: 59
+      Name: '*hash<int,int>'
+      ByteSize: 8
+      Pointee: 60 GoHMapHeaderType hash<int,int>
+    - __kind: PointerType
+      ID: 122
+      Name: '*hash<int,uint8>'
+      ByteSize: 8
+      Pointee: 123 GoHMapHeaderType hash<int,uint8>
+    - __kind: PointerType
+      ID: 105
+      Name: '*hash<string,[]main.structWithMap>'
+      ByteSize: 8
+      Pointee: 106 GoHMapHeaderType hash<string,[]main.structWithMap>
+    - __kind: PointerType
+      ID: 88
+      Name: '*hash<string,[]string>'
+      ByteSize: 8
+      Pointee: 89 GoHMapHeaderType hash<string,[]string>
+    - __kind: PointerType
+      ID: 83
+      Name: '*hash<string,int>'
+      ByteSize: 8
+      Pointee: 84 GoHMapHeaderType hash<string,int>
+    - __kind: PointerType
+      ID: 75
+      Name: '*hash<string,main.nestedStruct>'
+      ByteSize: 8
+      Pointee: 76 GoHMapHeaderType hash<string,main.nestedStruct>
+    - __kind: PointerType
+      ID: 134
+      Name: '*hash<uint8,[4]int>'
+      ByteSize: 8
+      Pointee: 135 GoHMapHeaderType hash<uint8,[4]int>
+    - __kind: PointerType
+      ID: 128
+      Name: '*hash<uint8,uint8>'
+      ByteSize: 8
+      Pointee: 129 GoHMapHeaderType hash<uint8,uint8>
+    - __kind: PointerType
+      ID: 181
+      Name: '*int'
+      ByteSize: 8
+      GoRuntimeType: 359776
+      GoKind: 22
+      Pointee: 1 BaseType int
+    - __kind: PointerType
+      ID: 183
+      Name: '*int16'
+      ByteSize: 8
+      GoRuntimeType: 359392
+      GoKind: 22
+      Pointee: 16 BaseType int16
+    - __kind: PointerType
+      ID: 175
+      Name: '*int32'
+      ByteSize: 8
+      GoRuntimeType: 359520
+      GoKind: 22
+      Pointee: 6 BaseType int32
+    - __kind: PointerType
+      ID: 180
+      Name: '*int64'
+      ByteSize: 8
+      GoRuntimeType: 359648
+      GoKind: 22
+      Pointee: 18 BaseType int64
+    - __kind: PointerType
+      ID: 184
+      Name: '*int8'
+      ByteSize: 8
+      GoRuntimeType: 359264
+      GoKind: 22
+      Pointee: 14 BaseType int8
+    - __kind: PointerType
+      ID: 44
+      Name: '*main.esotericHeap'
+      ByteSize: 8
+      GoRuntimeType: 354144
+      GoKind: 22
+      Pointee: 45 StructureType main.esotericHeap
+    - __kind: PointerType
+      ID: 120
+      Name: '*main.node'
+      ByteSize: 8
+      GoRuntimeType: 354208
+      GoKind: 22
+      Pointee: 119 StructureType main.node
+    - __kind: PointerType
+      ID: 170
+      Name: '*main.oneStringStruct'
+      ByteSize: 8
+      GoKind: 22
+      Pointee: 171 StructureType main.oneStringStruct
+    - __kind: PointerType
+      ID: 111
+      Name: '*main.structWithMap'
+      ByteSize: 8
+      GoRuntimeType: 354080
+      GoKind: 22
+      Pointee: 57 StructureType main.structWithMap
+    - __kind: PointerType
+      ID: 163
+      Name: '*main.structWithNoStrings'
+      ByteSize: 8
+      Pointee: 164 StructureType main.structWithNoStrings
+    - __kind: PointerType
+      ID: 152
+      Name: '*main.structWithTwoValues'
+      ByteSize: 8
+      GoKind: 22
+      Pointee: 153 StructureType main.structWithTwoValues
+    - __kind: PointerType
+      ID: 156
+      Name: '*main.t'
+      ByteSize: 8
+      GoKind: 22
+      Pointee: 157 GoSliceHeaderType main.t
     - __kind: PointerType
       ID: 210
       Name: '*main.t.array'
       ByteSize: 8
       Pointee: 209 GoSliceDataType main.t.array
-    - __kind: GoSliceDataType
-      ID: 211
-      Name: '[]uint.array'
-      ByteSize: 2048
-      Element: 20 BaseType uint
     - __kind: PointerType
-      ID: 212
-      Name: '*[]uint.array'
+      ID: 169
+      Name: '*main.threeStringStruct'
       ByteSize: 8
-      Pointee: 211 GoSliceDataType []uint.array
-    - __kind: GoSliceDataType
-      ID: 213
-      Name: '[][]uint.array'
-      ByteSize: 2048
-      Element: 159 GoSliceHeaderType []uint
+      GoKind: 22
+      Pointee: 168 StructureType main.threeStringStruct
     - __kind: PointerType
-      ID: 214
-      Name: '*[][]uint.array'
+      ID: 103
+      Name: '*map[string]int'
       ByteSize: 8
-      Pointee: 213 GoSliceDataType [][]uint.array
-    - __kind: GoSliceDataType
-      ID: 215
-      Name: '[]main.structWithNoStrings.array'
-      ByteSize: 2048
-      Element: 164 StructureType main.structWithNoStrings
+      GoKind: 22
+      Pointee: 82 GoMapType map[string]int
     - __kind: PointerType
-      ID: 216
-      Name: '*[]main.structWithNoStrings.array'
+      ID: 72
+      Name: '*runtime.bmap'
       ByteSize: 8
-      Pointee: 215 GoSliceDataType []main.structWithNoStrings.array
-    - __kind: GoSliceDataType
-      ID: 217
-      Name: '[]bool.array'
-      ByteSize: 2048
-      Element: 11 BaseType bool
+      GoRuntimeType: 1.100896e+06
+      GoKind: 22
+      Pointee: 73 StructureType runtime.bmap
     - __kind: PointerType
-      ID: 218
-      Name: '*[]bool.array'
+      ID: 67
+      Name: '*runtime.mapextra'
       ByteSize: 8
-      Pointee: 217 GoSliceDataType []bool.array
-    - __kind: GoSliceDataType
-      ID: 219
-      Name: '[]uint16.array'
-      ByteSize: 2048
-      Element: 22 BaseType uint16
+      GoRuntimeType: 363104
+      GoKind: 22
+      Pointee: 68 StructureType runtime.mapextra
     - __kind: PointerType
-      ID: 220
-      Name: '*[]uint16.array'
+      ID: 36
+      Name: '*string'
       ByteSize: 8
-      Pointee: 219 GoSliceDataType []uint16.array
+      GoRuntimeType: 359200
+      GoKind: 22
+      Pointee: 8 GoStringHeaderType string
+    - __kind: PointerType
+      ID: 188
+      Name: '*string.str'
+      ByteSize: 8
+      Pointee: 187 GoStringDataType string.str
+    - __kind: PointerType
+      ID: 154
+      Name: '*uint'
+      ByteSize: 8
+      GoRuntimeType: 359840
+      GoKind: 22
+      Pointee: 20 BaseType uint
+    - __kind: PointerType
+      ID: 167
+      Name: '*uint16'
+      ByteSize: 8
+      GoRuntimeType: 359456
+      GoKind: 22
+      Pointee: 22 BaseType uint16
+    - __kind: PointerType
+      ID: 176
+      Name: '*uint32'
+      ByteSize: 8
+      GoRuntimeType: 359584
+      GoKind: 22
+      Pointee: 24 BaseType uint32
+    - __kind: PointerType
+      ID: 182
+      Name: '*uint64'
+      ByteSize: 8
+      GoRuntimeType: 359712
+      GoKind: 22
+      Pointee: 26 BaseType uint64
+    - __kind: PointerType
+      ID: 9
+      Name: '*uint8'
+      ByteSize: 8
+      GoRuntimeType: 359328
+      GoKind: 22
+      Pointee: 4 BaseType uint8
+    - __kind: PointerType
+      ID: 174
+      Name: '*uintptr'
+      ByteSize: 8
+      GoRuntimeType: 359904
+      GoKind: 22
+      Pointee: 66 BaseType uintptr
     - __kind: EventRootType
-      ID: 221
-      Name: Probe[main.testByteArray]
-      ByteSize: 3
+      ID: 308
+      Name: Probe[main.stackC]
+    - __kind: EventRootType
+      ID: 265
+      Name: Probe[main.testAny]
+      ByteSize: 17
       PresenceBitsetSize: 1
       Expressions:
-        - Name: x
+        - Name: a
           Offset: 1
           Expression:
-            Type: 3 ArrayType [2]uint8
+            Type: 41 GoEmptyInterfaceType interface {}
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 7, index: 0, name: x}
+                  Variable: {subprogram: 51, index: 0, name: a}
                   Offset: 0
-                  ByteSize: 2
+                  ByteSize: 16
     - __kind: EventRootType
-      ID: 222
-      Name: Probe[main.testRuneArray]
-      ByteSize: 9
+      ID: 237
+      Name: Probe[main.testArrayOfArraysOfArrays]
+      ByteSize: 65
       PresenceBitsetSize: 1
       Expressions:
-        - Name: x
+        - Name: b
           Offset: 1
           Expression:
-            Type: 5 ArrayType [2]int32
+            Type: 28 ArrayType [2][2][2]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 8, index: 0, name: x}
+                  Variable: {subprogram: 23, index: 0, name: b}
                   Offset: 0
-                  ByteSize: 8
+                  ByteSize: 64
     - __kind: EventRootType
-      ID: 223
-      Name: Probe[main.testStringArray]
+      ID: 235
+      Name: Probe[main.testArrayOfArrays]
       ByteSize: 33
       PresenceBitsetSize: 1
       Expressions:
-        - Name: x
+        - Name: a
+          Offset: 1
+          Expression:
+            Type: 27 ArrayType [2][2]int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 21, index: 0, name: a}
+                  Offset: 0
+                  ByteSize: 32
+    - __kind: EventRootType
+      ID: 273
+      Name: Probe[main.testArrayOfMaps]
+      ByteSize: 17
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: m
+          Offset: 1
+          Expression:
+            Type: 102 ArrayType [2]map[string]int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 59, index: 0, name: m}
+                  Offset: 0
+                  ByteSize: 16
+    - __kind: EventRootType
+      ID: 236
+      Name: Probe[main.testArrayOfStrings]
+      ByteSize: 33
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: a
           Offset: 1
           Expression:
             Type: 7 ArrayType [2]string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 9, index: 0, name: x}
+                  Variable: {subprogram: 22, index: 0, name: a}
                   Offset: 0
                   ByteSize: 32
+    - __kind: EventRootType
+      ID: 255
+      Name: Probe[main.testBigStruct]
+      ByteSize: 49
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: b
+          Offset: 1
+          Expression:
+            Type: 33 StructureType main.bigStruct
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 41, index: 0, name: b}
+                  Offset: 0
+                  ByteSize: 48
     - __kind: EventRootType
       ID: 224
       Name: Probe[main.testBoolArray]
@@ -5310,35 +3589,338 @@ Types:
                   Offset: 0
                   ByteSize: 2
     - __kind: EventRootType
-      ID: 225
-      Name: Probe[main.testIntArray]
-      ByteSize: 17
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: x
-          Offset: 1
-          Expression:
-            Type: 12 ArrayType [2]int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 11, index: 0, name: x}
-                  Offset: 0
-                  ByteSize: 16
-    - __kind: EventRootType
-      ID: 226
-      Name: Probe[main.testInt8Array]
+      ID: 221
+      Name: Probe[main.testByteArray]
       ByteSize: 3
       PresenceBitsetSize: 1
       Expressions:
         - Name: x
           Offset: 1
           Expression:
-            Type: 13 ArrayType [2]int8
+            Type: 3 ArrayType [2]uint8
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 12, index: 0, name: x}
+                  Variable: {subprogram: 7, index: 0, name: x}
                   Offset: 0
                   ByteSize: 2
+    - __kind: EventRootType
+      ID: 289
+      Name: Probe[main.testChannel]
+      ByteSize: 1
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: c
+          Offset: 1
+          Expression:
+            Type: 151 GoChannelType chan bool
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 75, index: 0, name: c}
+                  Offset: 0
+                  ByteSize: 0
+    - __kind: EventRootType
+      ID: 287
+      Name: Probe[main.testCombinedByte]
+      ByteSize: 7
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: w
+          Offset: 1
+          Expression:
+            Type: 4 BaseType uint8
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 73, index: 0, name: w}
+                  Offset: 0
+                  ByteSize: 1
+        - Name: x
+          Offset: 2
+          Expression:
+            Type: 4 BaseType uint8
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 73, index: 1, name: x}
+                  Offset: 0
+                  ByteSize: 1
+        - Name: y
+          Offset: 3
+          Expression:
+            Type: 30 BaseType float32
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 73, index: 2, name: y}
+                  Offset: 0
+                  ByteSize: 4
+    - __kind: EventRootType
+      ID: 297
+      Name: Probe[main.testCycle]
+      ByteSize: 9
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: t
+          Offset: 1
+          Expression:
+            Type: 156 PointerType *main.t
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 83, index: 0, name: t}
+                  Offset: 0
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 302
+      Name: Probe[main.testEmptySliceOfStructs]
+      ByteSize: 33
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: xs
+          Offset: 1
+          Expression:
+            Type: 162 GoSliceHeaderType []main.structWithNoStrings
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 88, index: 0, name: xs}
+                  Offset: 0
+                  ByteSize: 24
+        - Name: a
+          Offset: 25
+          Expression:
+            Type: 1 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 88, index: 1, name: a}
+                  Offset: 0
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 299
+      Name: Probe[main.testEmptySlice]
+      ByteSize: 25
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: u
+          Offset: 1
+          Expression:
+            Type: 159 GoSliceHeaderType []uint
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 85, index: 0, name: u}
+                  Offset: 0
+                  ByteSize: 24
+    - __kind: EventRootType
+      ID: 316
+      Name: Probe[main.testEmptyString]
+      ByteSize: 17
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: x
+          Offset: 1
+          Expression:
+            Type: 8 GoStringHeaderType string
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 102, index: 0, name: x}
+                  Offset: 0
+                  ByteSize: 16
+    - __kind: EventRootType
+      ID: 318
+      Name: Probe[main.testEmptyStruct]
+      ByteSize: 1
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: e
+          Offset: 1
+          Expression:
+            Type: 173 StructureType main.emptyStruct
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 104, index: 0, name: e}
+                  Offset: 0
+                  ByteSize: 0
+    - __kind: EventRootType
+      ID: 266
+      Name: Probe[main.testError]
+      ByteSize: 17
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: e
+          Offset: 1
+          Expression:
+            Type: 56 GoInterfaceType error
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 52, index: 0, name: e}
+                  Offset: 0
+                  ByteSize: 16
+    - __kind: EventRootType
+      ID: 257
+      Name: Probe[main.testEsotericHeap]
+      ByteSize: 9
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: e
+          Offset: 1
+          Expression:
+            Type: 44 PointerType *main.esotericHeap
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 43, index: 0, name: e}
+                  Offset: 0
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 256
+      Name: Probe[main.testEsotericStack]
+      ByteSize: 65
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: e
+          Offset: 1
+          Expression:
+            Type: 39 StructureType main.esotericStack
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 42, index: 0, name: e}
+                  Offset: 0
+                  ByteSize: 64
+    - __kind: EventRootType
+      ID: 263
+      Name: Probe[main.testFramelessArray]
+      ByteSize: 41
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: a
+          Offset: 1
+          Expression:
+            Type: 2 ArrayType [5]int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 49, index: 0, name: a}
+                  Offset: 0
+                  ByteSize: 40
+    - __kind: EventRootType
+      ID: 262
+      Name: Probe[main.testFrameless]
+      ByteSize: 9
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: x
+          Offset: 1
+          Expression:
+            Type: 1 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 48, index: 0, name: x}
+                  Offset: 0
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 258
+      Name: Probe[main.testInlinedBA]
+      ByteSize: 9
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: x
+          Offset: 1
+          Expression:
+            Type: 1 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 44, index: 0, name: x}
+                  Offset: 0
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 260
+      Name: Probe[main.testInlinedBBA]
+      ByteSize: 9
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: x
+          Offset: 1
+          Expression:
+            Type: 1 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 46, index: 0, name: x}
+                  Offset: 0
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 320
+      Name: Probe[main.testInlinedBBB]
+    - __kind: EventRootType
+      ID: 259
+      Name: Probe[main.testInlinedBB]
+      ByteSize: 17
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: x
+          Offset: 1
+          Expression:
+            Type: 1 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 45, index: 0, name: x}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: y
+          Offset: 9
+          Expression:
+            Type: 1 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 45, index: 1, name: y}
+                  Offset: 0
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 321
+      Name: Probe[main.testInlinedBCA]
+    - __kind: EventRootType
+      ID: 322
+      Name: Probe[main.testInlinedBCB]
+    - __kind: EventRootType
+      ID: 261
+      Name: Probe[main.testInlinedBC]
+    - __kind: EventRootType
+      ID: 319
+      Name: Probe[main.testInlinedPrint]
+      ByteSize: 9
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: x
+          Offset: 1
+          Expression:
+            Type: 1 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 1, index: 0, name: x}
+                  Offset: 0
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 323
+      Name: Probe[main.testInlinedSq]
+      ByteSize: 9
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: x
+          Offset: 1
+          Expression:
+            Type: 1 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 5, index: 0, name: x}
+                  Offset: 0
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 324
+      Name: Probe[main.testInlinedSumArray]
+      ByteSize: 41
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: a
+          Offset: 1
+          Expression:
+            Type: 2 ArrayType [5]int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 6, index: 0, name: a}
+                  Offset: 0
+                  ByteSize: 40
     - __kind: EventRootType
       ID: 227
       Name: Probe[main.testInt16Array]
@@ -5385,512 +3967,35 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 230
-      Name: Probe[main.testUintArray]
+      ID: 226
+      Name: Probe[main.testInt8Array]
+      ByteSize: 3
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: x
+          Offset: 1
+          Expression:
+            Type: 13 ArrayType [2]int8
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 12, index: 0, name: x}
+                  Offset: 0
+                  ByteSize: 2
+    - __kind: EventRootType
+      ID: 225
+      Name: Probe[main.testIntArray]
       ByteSize: 17
       PresenceBitsetSize: 1
       Expressions:
         - Name: x
           Offset: 1
           Expression:
-            Type: 19 ArrayType [2]uint
+            Type: 12 ArrayType [2]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 16, index: 0, name: x}
+                  Variable: {subprogram: 11, index: 0, name: x}
                   Offset: 0
                   ByteSize: 16
-    - __kind: EventRootType
-      ID: 231
-      Name: Probe[main.testUint8Array]
-      ByteSize: 3
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: x
-          Offset: 1
-          Expression:
-            Type: 3 ArrayType [2]uint8
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 17, index: 0, name: x}
-                  Offset: 0
-                  ByteSize: 2
-    - __kind: EventRootType
-      ID: 232
-      Name: Probe[main.testUint16Array]
-      ByteSize: 5
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: x
-          Offset: 1
-          Expression:
-            Type: 21 ArrayType [2]uint16
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 18, index: 0, name: x}
-                  Offset: 0
-                  ByteSize: 4
-    - __kind: EventRootType
-      ID: 233
-      Name: Probe[main.testUint32Array]
-      ByteSize: 9
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: x
-          Offset: 1
-          Expression:
-            Type: 23 ArrayType [2]uint32
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 19, index: 0, name: x}
-                  Offset: 0
-                  ByteSize: 8
-    - __kind: EventRootType
-      ID: 234
-      Name: Probe[main.testUint64Array]
-      ByteSize: 17
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: x
-          Offset: 1
-          Expression:
-            Type: 25 ArrayType [2]uint64
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 20, index: 0, name: x}
-                  Offset: 0
-                  ByteSize: 16
-    - __kind: EventRootType
-      ID: 235
-      Name: Probe[main.testArrayOfArrays]
-      ByteSize: 33
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: a
-          Offset: 1
-          Expression:
-            Type: 27 ArrayType [2][2]int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 21, index: 0, name: a}
-                  Offset: 0
-                  ByteSize: 32
-    - __kind: EventRootType
-      ID: 236
-      Name: Probe[main.testArrayOfStrings]
-      ByteSize: 33
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: a
-          Offset: 1
-          Expression:
-            Type: 7 ArrayType [2]string
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 22, index: 0, name: a}
-                  Offset: 0
-                  ByteSize: 32
-    - __kind: EventRootType
-      ID: 237
-      Name: Probe[main.testArrayOfArraysOfArrays]
-      ByteSize: 65
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: b
-          Offset: 1
-          Expression:
-            Type: 28 ArrayType [2][2][2]int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 23, index: 0, name: b}
-                  Offset: 0
-                  ByteSize: 64
-    - __kind: EventRootType
-      ID: 238
-      Name: Probe[main.testVeryLargeArray]
-      ByteSize: 801
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: a
-          Offset: 1
-          Expression:
-            Type: 29 ArrayType [100]uint
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 24, index: 0, name: a}
-                  Offset: 0
-                  ByteSize: 800
-    - __kind: EventRootType
-      ID: 239
-      Name: Probe[main.testSingleByte]
-      ByteSize: 2
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: x
-          Offset: 1
-          Expression:
-            Type: 4 BaseType uint8
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 25, index: 0, name: x}
-                  Offset: 0
-                  ByteSize: 1
-    - __kind: EventRootType
-      ID: 240
-      Name: Probe[main.testSingleRune]
-      ByteSize: 5
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: x
-          Offset: 1
-          Expression:
-            Type: 6 BaseType int32
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 26, index: 0, name: x}
-                  Offset: 0
-                  ByteSize: 4
-    - __kind: EventRootType
-      ID: 241
-      Name: Probe[main.testSingleBool]
-      ByteSize: 2
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: x
-          Offset: 1
-          Expression:
-            Type: 11 BaseType bool
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 27, index: 0, name: x}
-                  Offset: 0
-                  ByteSize: 1
-    - __kind: EventRootType
-      ID: 242
-      Name: Probe[main.testSingleInt]
-      ByteSize: 9
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: x
-          Offset: 1
-          Expression:
-            Type: 1 BaseType int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 28, index: 0, name: x}
-                  Offset: 0
-                  ByteSize: 8
-    - __kind: EventRootType
-      ID: 243
-      Name: Probe[main.testSingleInt8]
-      ByteSize: 2
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: x
-          Offset: 1
-          Expression:
-            Type: 14 BaseType int8
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 29, index: 0, name: x}
-                  Offset: 0
-                  ByteSize: 1
-    - __kind: EventRootType
-      ID: 244
-      Name: Probe[main.testSingleInt16]
-      ByteSize: 3
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: x
-          Offset: 1
-          Expression:
-            Type: 16 BaseType int16
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 30, index: 0, name: x}
-                  Offset: 0
-                  ByteSize: 2
-    - __kind: EventRootType
-      ID: 245
-      Name: Probe[main.testSingleInt32]
-      ByteSize: 5
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: x
-          Offset: 1
-          Expression:
-            Type: 6 BaseType int32
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 31, index: 0, name: x}
-                  Offset: 0
-                  ByteSize: 4
-    - __kind: EventRootType
-      ID: 246
-      Name: Probe[main.testSingleInt64]
-      ByteSize: 9
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: x
-          Offset: 1
-          Expression:
-            Type: 18 BaseType int64
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 32, index: 0, name: x}
-                  Offset: 0
-                  ByteSize: 8
-    - __kind: EventRootType
-      ID: 247
-      Name: Probe[main.testSingleUint]
-      ByteSize: 9
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: x
-          Offset: 1
-          Expression:
-            Type: 20 BaseType uint
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 33, index: 0, name: x}
-                  Offset: 0
-                  ByteSize: 8
-    - __kind: EventRootType
-      ID: 248
-      Name: Probe[main.testSingleUint8]
-      ByteSize: 2
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: x
-          Offset: 1
-          Expression:
-            Type: 4 BaseType uint8
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 34, index: 0, name: x}
-                  Offset: 0
-                  ByteSize: 1
-    - __kind: EventRootType
-      ID: 249
-      Name: Probe[main.testSingleUint16]
-      ByteSize: 3
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: x
-          Offset: 1
-          Expression:
-            Type: 22 BaseType uint16
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 35, index: 0, name: x}
-                  Offset: 0
-                  ByteSize: 2
-    - __kind: EventRootType
-      ID: 250
-      Name: Probe[main.testSingleUint32]
-      ByteSize: 5
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: x
-          Offset: 1
-          Expression:
-            Type: 24 BaseType uint32
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 36, index: 0, name: x}
-                  Offset: 0
-                  ByteSize: 4
-    - __kind: EventRootType
-      ID: 251
-      Name: Probe[main.testSingleUint64]
-      ByteSize: 9
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: x
-          Offset: 1
-          Expression:
-            Type: 26 BaseType uint64
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 37, index: 0, name: x}
-                  Offset: 0
-                  ByteSize: 8
-    - __kind: EventRootType
-      ID: 252
-      Name: Probe[main.testSingleFloat32]
-      ByteSize: 5
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: x
-          Offset: 1
-          Expression:
-            Type: 30 BaseType float32
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 38, index: 0, name: x}
-                  Offset: 0
-                  ByteSize: 4
-    - __kind: EventRootType
-      ID: 253
-      Name: Probe[main.testSingleFloat64]
-      ByteSize: 9
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: x
-          Offset: 1
-          Expression:
-            Type: 31 BaseType float64
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 39, index: 0, name: x}
-                  Offset: 0
-                  ByteSize: 8
-    - __kind: EventRootType
-      ID: 254
-      Name: Probe[main.testTypeAlias]
-      ByteSize: 3
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: x
-          Offset: 1
-          Expression:
-            Type: 32 BaseType main.typeAlias
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 40, index: 0, name: x}
-                  Offset: 0
-                  ByteSize: 2
-    - __kind: EventRootType
-      ID: 255
-      Name: Probe[main.testBigStruct]
-      ByteSize: 49
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: b
-          Offset: 1
-          Expression:
-            Type: 33 StructureType main.bigStruct
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 41, index: 0, name: b}
-                  Offset: 0
-                  ByteSize: 48
-    - __kind: EventRootType
-      ID: 256
-      Name: Probe[main.testEsotericStack]
-      ByteSize: 65
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: e
-          Offset: 1
-          Expression:
-            Type: 39 StructureType main.esotericStack
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 42, index: 0, name: e}
-                  Offset: 0
-                  ByteSize: 64
-    - __kind: EventRootType
-      ID: 257
-      Name: Probe[main.testEsotericHeap]
-      ByteSize: 9
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: e
-          Offset: 1
-          Expression:
-            Type: 44 PointerType *main.esotericHeap
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 43, index: 0, name: e}
-                  Offset: 0
-                  ByteSize: 8
-    - __kind: EventRootType
-      ID: 258
-      Name: Probe[main.testInlinedBA]
-      ByteSize: 9
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: x
-          Offset: 1
-          Expression:
-            Type: 1 BaseType int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 44, index: 0, name: x}
-                  Offset: 0
-                  ByteSize: 8
-    - __kind: EventRootType
-      ID: 259
-      Name: Probe[main.testInlinedBB]
-      ByteSize: 17
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: x
-          Offset: 1
-          Expression:
-            Type: 1 BaseType int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 45, index: 0, name: x}
-                  Offset: 0
-                  ByteSize: 8
-        - Name: y
-          Offset: 9
-          Expression:
-            Type: 1 BaseType int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 45, index: 1, name: y}
-                  Offset: 0
-                  ByteSize: 8
-    - __kind: EventRootType
-      ID: 260
-      Name: Probe[main.testInlinedBBA]
-      ByteSize: 9
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: x
-          Offset: 1
-          Expression:
-            Type: 1 BaseType int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 46, index: 0, name: x}
-                  Offset: 0
-                  ByteSize: 8
-    - __kind: EventRootType
-      ID: 261
-      Name: Probe[main.testInlinedBC]
-    - __kind: EventRootType
-      ID: 262
-      Name: Probe[main.testFrameless]
-      ByteSize: 9
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: x
-          Offset: 1
-          Expression:
-            Type: 1 BaseType int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 48, index: 0, name: x}
-                  Offset: 0
-                  ByteSize: 8
-    - __kind: EventRootType
-      ID: 263
-      Name: Probe[main.testFramelessArray]
-      ByteSize: 41
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: a
-          Offset: 1
-          Expression:
-            Type: 2 ArrayType [5]int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 49, index: 0, name: a}
-                  Offset: 0
-                  ByteSize: 40
     - __kind: EventRootType
       ID: 264
       Name: Probe[main.testInterface]
@@ -5907,63 +4012,138 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 265
-      Name: Probe[main.testAny]
+      ID: 291
+      Name: Probe[main.testLinkedList]
       ByteSize: 17
       PresenceBitsetSize: 1
       Expressions:
         - Name: a
           Offset: 1
           Expression:
-            Type: 41 GoEmptyInterfaceType interface {}
+            Type: 119 StructureType main.node
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 51, index: 0, name: a}
+                  Variable: {subprogram: 77, index: 0, name: a}
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 266
-      Name: Probe[main.testError]
-      ByteSize: 17
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: e
-          Offset: 1
-          Expression:
-            Type: 56 GoInterfaceType error
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 52, index: 0, name: e}
-                  Offset: 0
-                  ByteSize: 16
-    - __kind: EventRootType
-      ID: 267
-      Name: Probe[main.testStructWithMap]
-      ByteSize: 9
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: s
-          Offset: 1
-          Expression:
-            Type: 57 StructureType main.structWithMap
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 53, index: 0, name: s}
-                  Offset: 0
-                  ByteSize: 8
-    - __kind: EventRootType
-      ID: 268
-      Name: Probe[main.testMapStringToStruct]
+      ID: 271
+      Name: Probe[main.testMapArrayToArray]
       ByteSize: 9
       PresenceBitsetSize: 1
       Expressions:
         - Name: m
           Offset: 1
           Expression:
-            Type: 74 GoMapType map[string]main.nestedStruct
+            Type: 94 GoMapType map[[4]string][2]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 54, index: 0, name: m}
+                  Variable: {subprogram: 57, index: 0, name: m}
+                  Offset: 0
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 277
+      Name: Probe[main.testMapEmbeddedMaps]
+      ByteSize: 9
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: m
+          Offset: 1
+          Expression:
+            Type: 104 GoMapType map[string][]main.structWithMap
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 63, index: 0, name: m}
+                  Offset: 0
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 275
+      Name: Probe[main.testMapIntToInt]
+      ByteSize: 9
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: m
+          Offset: 1
+          Expression:
+            Type: 58 GoMapType map[int]int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 61, index: 0, name: m}
+                  Offset: 0
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 286
+      Name: Probe[main.testMapLargeKeyLargeValue]
+      ByteSize: 9
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: m
+          Offset: 1
+          Expression:
+            Type: 146 GoMapType map[[4]int][4]int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 72, index: 0, name: m}
+                  Offset: 0
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 285
+      Name: Probe[main.testMapLargeKeySmallValue]
+      ByteSize: 9
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: m
+          Offset: 1
+          Expression:
+            Type: 140 GoMapType map[[4]int]uint8
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 71, index: 0, name: m}
+                  Offset: 0
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 276
+      Name: Probe[main.testMapMassive]
+      ByteSize: 9
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: redactMyEntries
+          Offset: 1
+          Expression:
+            Type: 104 GoMapType map[string][]main.structWithMap
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 62, index: 0, name: redactMyEntries}
+                  Offset: 0
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 284
+      Name: Probe[main.testMapSmallKeyLargeValue]
+      ByteSize: 9
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: m
+          Offset: 1
+          Expression:
+            Type: 133 GoMapType map[uint8][4]int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 70, index: 0, name: m}
+                  Offset: 0
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 283
+      Name: Probe[main.testMapSmallKeySmallValue]
+      ByteSize: 9
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: m
+          Offset: 1
+          Expression:
+            Type: 127 GoMapType map[uint8]uint8
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 69, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
@@ -5997,108 +4177,18 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 271
-      Name: Probe[main.testMapArrayToArray]
+      ID: 268
+      Name: Probe[main.testMapStringToStruct]
       ByteSize: 9
       PresenceBitsetSize: 1
       Expressions:
         - Name: m
           Offset: 1
           Expression:
-            Type: 94 GoMapType map[[4]string][2]int
+            Type: 74 GoMapType map[string]main.nestedStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 57, index: 0, name: m}
-                  Offset: 0
-                  ByteSize: 8
-    - __kind: EventRootType
-      ID: 272
-      Name: Probe[main.testSmallMap]
-      ByteSize: 9
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: m
-          Offset: 1
-          Expression:
-            Type: 82 GoMapType map[string]int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 58, index: 0, name: m}
-                  Offset: 0
-                  ByteSize: 8
-    - __kind: EventRootType
-      ID: 273
-      Name: Probe[main.testArrayOfMaps]
-      ByteSize: 17
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: m
-          Offset: 1
-          Expression:
-            Type: 102 ArrayType [2]map[string]int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 59, index: 0, name: m}
-                  Offset: 0
-                  ByteSize: 16
-    - __kind: EventRootType
-      ID: 274
-      Name: Probe[main.testPointerToMap]
-      ByteSize: 9
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: m
-          Offset: 1
-          Expression:
-            Type: 103 PointerType *map[string]int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 60, index: 0, name: m}
-                  Offset: 0
-                  ByteSize: 8
-    - __kind: EventRootType
-      ID: 275
-      Name: Probe[main.testMapIntToInt]
-      ByteSize: 9
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: m
-          Offset: 1
-          Expression:
-            Type: 58 GoMapType map[int]int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 61, index: 0, name: m}
-                  Offset: 0
-                  ByteSize: 8
-    - __kind: EventRootType
-      ID: 276
-      Name: Probe[main.testMapMassive]
-      ByteSize: 9
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: redactMyEntries
-          Offset: 1
-          Expression:
-            Type: 104 GoMapType map[string][]main.structWithMap
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 62, index: 0, name: redactMyEntries}
-                  Offset: 0
-                  ByteSize: 8
-    - __kind: EventRootType
-      ID: 277
-      Name: Probe[main.testMapEmbeddedMaps]
-      ByteSize: 9
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: m
-          Offset: 1
-          Expression:
-            Type: 104 GoMapType map[string][]main.structWithMap
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 63, index: 0, name: m}
+                  Variable: {subprogram: 54, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
@@ -6117,33 +4207,18 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 279
-      Name: Probe[main.testMapWithSmallValue]
+      ID: 282
+      Name: Probe[main.testMapWithSmallKeyAndValueMassive]
       ByteSize: 9
       PresenceBitsetSize: 1
       Expressions:
         - Name: m
           Offset: 1
           Expression:
-            Type: 121 GoMapType map[int]uint8
+            Type: 127 GoMapType map[uint8]uint8
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 65, index: 0, name: m}
-                  Offset: 0
-                  ByteSize: 8
-    - __kind: EventRootType
-      ID: 280
-      Name: Probe[main.testMapWithSmallValueMassive]
-      ByteSize: 9
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: redactMyEntries
-          Offset: 1
-          Expression:
-            Type: 121 GoMapType map[int]uint8
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 66, index: 0, name: redactMyEntries}
+                  Variable: {subprogram: 68, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
@@ -6162,113 +4237,50 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 282
-      Name: Probe[main.testMapWithSmallKeyAndValueMassive]
+      ID: 280
+      Name: Probe[main.testMapWithSmallValueMassive]
+      ByteSize: 9
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: redactMyEntries
+          Offset: 1
+          Expression:
+            Type: 121 GoMapType map[int]uint8
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 66, index: 0, name: redactMyEntries}
+                  Offset: 0
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 279
+      Name: Probe[main.testMapWithSmallValue]
       ByteSize: 9
       PresenceBitsetSize: 1
       Expressions:
         - Name: m
           Offset: 1
           Expression:
-            Type: 127 GoMapType map[uint8]uint8
+            Type: 121 GoMapType map[int]uint8
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 68, index: 0, name: m}
+                  Variable: {subprogram: 65, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 283
-      Name: Probe[main.testMapSmallKeySmallValue]
-      ByteSize: 9
+      ID: 314
+      Name: Probe[main.testMassiveString]
+      ByteSize: 17
       PresenceBitsetSize: 1
       Expressions:
-        - Name: m
-          Offset: 1
-          Expression:
-            Type: 127 GoMapType map[uint8]uint8
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 69, index: 0, name: m}
-                  Offset: 0
-                  ByteSize: 8
-    - __kind: EventRootType
-      ID: 284
-      Name: Probe[main.testMapSmallKeyLargeValue]
-      ByteSize: 9
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: m
-          Offset: 1
-          Expression:
-            Type: 133 GoMapType map[uint8][4]int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 70, index: 0, name: m}
-                  Offset: 0
-                  ByteSize: 8
-    - __kind: EventRootType
-      ID: 285
-      Name: Probe[main.testMapLargeKeySmallValue]
-      ByteSize: 9
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: m
-          Offset: 1
-          Expression:
-            Type: 140 GoMapType map[[4]int]uint8
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 71, index: 0, name: m}
-                  Offset: 0
-                  ByteSize: 8
-    - __kind: EventRootType
-      ID: 286
-      Name: Probe[main.testMapLargeKeyLargeValue]
-      ByteSize: 9
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: m
-          Offset: 1
-          Expression:
-            Type: 146 GoMapType map[[4]int][4]int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 72, index: 0, name: m}
-                  Offset: 0
-                  ByteSize: 8
-    - __kind: EventRootType
-      ID: 287
-      Name: Probe[main.testCombinedByte]
-      ByteSize: 7
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: w
-          Offset: 1
-          Expression:
-            Type: 4 BaseType uint8
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 73, index: 0, name: w}
-                  Offset: 0
-                  ByteSize: 1
         - Name: x
-          Offset: 2
+          Offset: 1
           Expression:
-            Type: 4 BaseType uint8
+            Type: 8 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 73, index: 1, name: x}
+                  Variable: {subprogram: 100, index: 0, name: x}
                   Offset: 0
-                  ByteSize: 1
-        - Name: y
-          Offset: 3
-          Expression:
-            Type: 30 BaseType float32
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 73, index: 2, name: y}
-                  Offset: 0
-                  ByteSize: 4
+                  ByteSize: 16
     - __kind: EventRootType
       ID: 288
       Name: Probe[main.testMultipleSimpleParams]
@@ -6321,111 +4333,6 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 289
-      Name: Probe[main.testChannel]
-      ByteSize: 1
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: c
-          Offset: 1
-          Expression:
-            Type: 151 GoChannelType chan bool
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 75, index: 0, name: c}
-                  Offset: 0
-                  ByteSize: 0
-    - __kind: EventRootType
-      ID: 290
-      Name: Probe[main.testPointerToSimpleStruct]
-      ByteSize: 9
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: a
-          Offset: 1
-          Expression:
-            Type: 152 PointerType *main.structWithTwoValues
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 76, index: 0, name: a}
-                  Offset: 0
-                  ByteSize: 8
-    - __kind: EventRootType
-      ID: 291
-      Name: Probe[main.testLinkedList]
-      ByteSize: 17
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: a
-          Offset: 1
-          Expression:
-            Type: 119 StructureType main.node
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 77, index: 0, name: a}
-                  Offset: 0
-                  ByteSize: 16
-    - __kind: EventRootType
-      ID: 292
-      Name: Probe[main.testPointerLoop]
-      ByteSize: 9
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: a
-          Offset: 1
-          Expression:
-            Type: 120 PointerType *main.node
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 78, index: 0, name: a}
-                  Offset: 0
-                  ByteSize: 8
-    - __kind: EventRootType
-      ID: 293
-      Name: Probe[main.testUnsafePointer]
-      ByteSize: 9
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: x
-          Offset: 1
-          Expression:
-            Type: 38 VoidPointerType unsafe.Pointer
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 79, index: 0, name: x}
-                  Offset: 0
-                  ByteSize: 8
-    - __kind: EventRootType
-      ID: 294
-      Name: Probe[main.testUintPointer]
-      ByteSize: 9
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: x
-          Offset: 1
-          Expression:
-            Type: 154 PointerType *uint
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 80, index: 0, name: x}
-                  Offset: 0
-                  ByteSize: 8
-    - __kind: EventRootType
-      ID: 295
-      Name: Probe[main.testStringPointer]
-      ByteSize: 9
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: z
-          Offset: 1
-          Expression:
-            Type: 36 PointerType *string
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 81, index: 0, name: z}
-                  Offset: 0
-                  ByteSize: 8
-    - __kind: EventRootType
       ID: 296
       Name: Probe[main.testNilPointer]
       ByteSize: 17
@@ -6447,114 +4354,6 @@ Types:
             Operations:
                 - __kind: LocationOp
                   Variable: {subprogram: 82, index: 1, name: a}
-                  Offset: 0
-                  ByteSize: 8
-    - __kind: EventRootType
-      ID: 297
-      Name: Probe[main.testCycle]
-      ByteSize: 9
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: t
-          Offset: 1
-          Expression:
-            Type: 156 PointerType *main.t
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 83, index: 0, name: t}
-                  Offset: 0
-                  ByteSize: 8
-    - __kind: EventRootType
-      ID: 298
-      Name: Probe[main.testUintSlice]
-      ByteSize: 25
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: u
-          Offset: 1
-          Expression:
-            Type: 159 GoSliceHeaderType []uint
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 84, index: 0, name: u}
-                  Offset: 0
-                  ByteSize: 24
-    - __kind: EventRootType
-      ID: 299
-      Name: Probe[main.testEmptySlice]
-      ByteSize: 25
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: u
-          Offset: 1
-          Expression:
-            Type: 159 GoSliceHeaderType []uint
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 85, index: 0, name: u}
-                  Offset: 0
-                  ByteSize: 24
-    - __kind: EventRootType
-      ID: 300
-      Name: Probe[main.testSliceOfSlices]
-      ByteSize: 25
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: u
-          Offset: 1
-          Expression:
-            Type: 160 GoSliceHeaderType [][]uint
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 86, index: 0, name: u}
-                  Offset: 0
-                  ByteSize: 24
-    - __kind: EventRootType
-      ID: 301
-      Name: Probe[main.testStructSlice]
-      ByteSize: 33
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: xs
-          Offset: 1
-          Expression:
-            Type: 162 GoSliceHeaderType []main.structWithNoStrings
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 87, index: 0, name: xs}
-                  Offset: 0
-                  ByteSize: 24
-        - Name: a
-          Offset: 25
-          Expression:
-            Type: 1 BaseType int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 87, index: 1, name: a}
-                  Offset: 0
-                  ByteSize: 8
-    - __kind: EventRootType
-      ID: 302
-      Name: Probe[main.testEmptySliceOfStructs]
-      ByteSize: 33
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: xs
-          Offset: 1
-          Expression:
-            Type: 162 GoSliceHeaderType []main.structWithNoStrings
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 88, index: 0, name: xs}
-                  Offset: 0
-                  ByteSize: 24
-        - Name: a
-          Offset: 25
-          Expression:
-            Type: 1 BaseType int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 88, index: 1, name: a}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
@@ -6581,21 +4380,6 @@ Types:
                   Variable: {subprogram: 89, index: 1, name: a}
                   Offset: 0
                   ByteSize: 8
-    - __kind: EventRootType
-      ID: 304
-      Name: Probe[main.testStringSlice]
-      ByteSize: 25
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: s
-          Offset: 1
-          Expression:
-            Type: 93 GoSliceHeaderType []string
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 90, index: 0, name: s}
-                  Offset: 0
-                  ByteSize: 24
     - __kind: EventRootType
       ID: 305
       Name: Probe[main.testNilSliceWithOtherParams]
@@ -6645,23 +4429,230 @@ Types:
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 307
-      Name: Probe[main.testVeryLargeSlice]
-      ByteSize: 25
+      ID: 313
+      Name: Probe[main.testOneStringInStructPointer]
+      ByteSize: 9
       PresenceBitsetSize: 1
       Expressions:
-        - Name: xs
+        - Name: a
           Offset: 1
           Expression:
-            Type: 159 GoSliceHeaderType []uint
+            Type: 170 PointerType *main.oneStringStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 93, index: 0, name: xs}
+                  Variable: {subprogram: 99, index: 0, name: a}
                   Offset: 0
-                  ByteSize: 24
+                  ByteSize: 8
     - __kind: EventRootType
-      ID: 308
-      Name: Probe[main.stackC]
+      ID: 292
+      Name: Probe[main.testPointerLoop]
+      ByteSize: 9
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: a
+          Offset: 1
+          Expression:
+            Type: 120 PointerType *main.node
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 78, index: 0, name: a}
+                  Offset: 0
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 274
+      Name: Probe[main.testPointerToMap]
+      ByteSize: 9
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: m
+          Offset: 1
+          Expression:
+            Type: 103 PointerType *map[string]int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 60, index: 0, name: m}
+                  Offset: 0
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 290
+      Name: Probe[main.testPointerToSimpleStruct]
+      ByteSize: 9
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: a
+          Offset: 1
+          Expression:
+            Type: 152 PointerType *main.structWithTwoValues
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 76, index: 0, name: a}
+                  Offset: 0
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 222
+      Name: Probe[main.testRuneArray]
+      ByteSize: 9
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: x
+          Offset: 1
+          Expression:
+            Type: 5 ArrayType [2]int32
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 8, index: 0, name: x}
+                  Offset: 0
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 241
+      Name: Probe[main.testSingleBool]
+      ByteSize: 2
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: x
+          Offset: 1
+          Expression:
+            Type: 11 BaseType bool
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 27, index: 0, name: x}
+                  Offset: 0
+                  ByteSize: 1
+    - __kind: EventRootType
+      ID: 239
+      Name: Probe[main.testSingleByte]
+      ByteSize: 2
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: x
+          Offset: 1
+          Expression:
+            Type: 4 BaseType uint8
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 25, index: 0, name: x}
+                  Offset: 0
+                  ByteSize: 1
+    - __kind: EventRootType
+      ID: 252
+      Name: Probe[main.testSingleFloat32]
+      ByteSize: 5
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: x
+          Offset: 1
+          Expression:
+            Type: 30 BaseType float32
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 38, index: 0, name: x}
+                  Offset: 0
+                  ByteSize: 4
+    - __kind: EventRootType
+      ID: 253
+      Name: Probe[main.testSingleFloat64]
+      ByteSize: 9
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: x
+          Offset: 1
+          Expression:
+            Type: 31 BaseType float64
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 39, index: 0, name: x}
+                  Offset: 0
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 244
+      Name: Probe[main.testSingleInt16]
+      ByteSize: 3
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: x
+          Offset: 1
+          Expression:
+            Type: 16 BaseType int16
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 30, index: 0, name: x}
+                  Offset: 0
+                  ByteSize: 2
+    - __kind: EventRootType
+      ID: 245
+      Name: Probe[main.testSingleInt32]
+      ByteSize: 5
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: x
+          Offset: 1
+          Expression:
+            Type: 6 BaseType int32
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 31, index: 0, name: x}
+                  Offset: 0
+                  ByteSize: 4
+    - __kind: EventRootType
+      ID: 246
+      Name: Probe[main.testSingleInt64]
+      ByteSize: 9
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: x
+          Offset: 1
+          Expression:
+            Type: 18 BaseType int64
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 32, index: 0, name: x}
+                  Offset: 0
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 243
+      Name: Probe[main.testSingleInt8]
+      ByteSize: 2
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: x
+          Offset: 1
+          Expression:
+            Type: 14 BaseType int8
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 29, index: 0, name: x}
+                  Offset: 0
+                  ByteSize: 1
+    - __kind: EventRootType
+      ID: 242
+      Name: Probe[main.testSingleInt]
+      ByteSize: 9
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: x
+          Offset: 1
+          Expression:
+            Type: 1 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 28, index: 0, name: x}
+                  Offset: 0
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 240
+      Name: Probe[main.testSingleRune]
+      ByteSize: 5
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: x
+          Offset: 1
+          Expression:
+            Type: 6 BaseType int32
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 26, index: 0, name: x}
+                  Offset: 0
+                  ByteSize: 4
     - __kind: EventRootType
       ID: 309
       Name: Probe[main.testSingleString]
@@ -6677,6 +4668,240 @@ Types:
                   Variable: {subprogram: 95, index: 0, name: x}
                   Offset: 0
                   ByteSize: 16
+    - __kind: EventRootType
+      ID: 249
+      Name: Probe[main.testSingleUint16]
+      ByteSize: 3
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: x
+          Offset: 1
+          Expression:
+            Type: 22 BaseType uint16
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 35, index: 0, name: x}
+                  Offset: 0
+                  ByteSize: 2
+    - __kind: EventRootType
+      ID: 250
+      Name: Probe[main.testSingleUint32]
+      ByteSize: 5
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: x
+          Offset: 1
+          Expression:
+            Type: 24 BaseType uint32
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 36, index: 0, name: x}
+                  Offset: 0
+                  ByteSize: 4
+    - __kind: EventRootType
+      ID: 251
+      Name: Probe[main.testSingleUint64]
+      ByteSize: 9
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: x
+          Offset: 1
+          Expression:
+            Type: 26 BaseType uint64
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 37, index: 0, name: x}
+                  Offset: 0
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 248
+      Name: Probe[main.testSingleUint8]
+      ByteSize: 2
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: x
+          Offset: 1
+          Expression:
+            Type: 4 BaseType uint8
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 34, index: 0, name: x}
+                  Offset: 0
+                  ByteSize: 1
+    - __kind: EventRootType
+      ID: 247
+      Name: Probe[main.testSingleUint]
+      ByteSize: 9
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: x
+          Offset: 1
+          Expression:
+            Type: 20 BaseType uint
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 33, index: 0, name: x}
+                  Offset: 0
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 300
+      Name: Probe[main.testSliceOfSlices]
+      ByteSize: 25
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: u
+          Offset: 1
+          Expression:
+            Type: 160 GoSliceHeaderType [][]uint
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 86, index: 0, name: u}
+                  Offset: 0
+                  ByteSize: 24
+    - __kind: EventRootType
+      ID: 272
+      Name: Probe[main.testSmallMap]
+      ByteSize: 9
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: m
+          Offset: 1
+          Expression:
+            Type: 82 GoMapType map[string]int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 58, index: 0, name: m}
+                  Offset: 0
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 223
+      Name: Probe[main.testStringArray]
+      ByteSize: 33
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: x
+          Offset: 1
+          Expression:
+            Type: 7 ArrayType [2]string
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 9, index: 0, name: x}
+                  Offset: 0
+                  ByteSize: 32
+    - __kind: EventRootType
+      ID: 295
+      Name: Probe[main.testStringPointer]
+      ByteSize: 9
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: z
+          Offset: 1
+          Expression:
+            Type: 36 PointerType *string
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 81, index: 0, name: z}
+                  Offset: 0
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 304
+      Name: Probe[main.testStringSlice]
+      ByteSize: 25
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: s
+          Offset: 1
+          Expression:
+            Type: 93 GoSliceHeaderType []string
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 90, index: 0, name: s}
+                  Offset: 0
+                  ByteSize: 24
+    - __kind: EventRootType
+      ID: 301
+      Name: Probe[main.testStructSlice]
+      ByteSize: 33
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: xs
+          Offset: 1
+          Expression:
+            Type: 162 GoSliceHeaderType []main.structWithNoStrings
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 87, index: 0, name: xs}
+                  Offset: 0
+                  ByteSize: 24
+        - Name: a
+          Offset: 25
+          Expression:
+            Type: 1 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 87, index: 1, name: a}
+                  Offset: 0
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 267
+      Name: Probe[main.testStructWithMap]
+      ByteSize: 9
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: s
+          Offset: 1
+          Expression:
+            Type: 57 StructureType main.structWithMap
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 53, index: 0, name: s}
+                  Offset: 0
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 317
+      Name: Probe[main.testStruct]
+      ByteSize: 57
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: x
+          Offset: 1
+          Expression:
+            Type: 172 StructureType main.aStruct
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 103, index: 0, name: x}
+                  Offset: 0
+                  ByteSize: 56
+    - __kind: EventRootType
+      ID: 312
+      Name: Probe[main.testThreeStringsInStructPointer]
+      ByteSize: 9
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: a
+          Offset: 1
+          Expression:
+            Type: 169 PointerType *main.threeStringStruct
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 98, index: 0, name: a}
+                  Offset: 0
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 311
+      Name: Probe[main.testThreeStringsInStruct]
+      ByteSize: 49
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: a
+          Offset: 1
+          Expression:
+            Type: 168 StructureType main.threeStringStruct
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 97, index: 0, name: a}
+                  Offset: 0
+                  ByteSize: 48
     - __kind: EventRootType
       ID: 310
       Name: Probe[main.testThreeStrings]
@@ -6711,65 +4936,125 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 311
-      Name: Probe[main.testThreeStringsInStruct]
-      ByteSize: 49
+      ID: 254
+      Name: Probe[main.testTypeAlias]
+      ByteSize: 3
       PresenceBitsetSize: 1
       Expressions:
-        - Name: a
+        - Name: x
           Offset: 1
           Expression:
-            Type: 168 StructureType main.threeStringStruct
+            Type: 32 BaseType main.typeAlias
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 97, index: 0, name: a}
+                  Variable: {subprogram: 40, index: 0, name: x}
                   Offset: 0
-                  ByteSize: 48
+                  ByteSize: 2
     - __kind: EventRootType
-      ID: 312
-      Name: Probe[main.testThreeStringsInStructPointer]
+      ID: 232
+      Name: Probe[main.testUint16Array]
+      ByteSize: 5
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: x
+          Offset: 1
+          Expression:
+            Type: 21 ArrayType [2]uint16
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 18, index: 0, name: x}
+                  Offset: 0
+                  ByteSize: 4
+    - __kind: EventRootType
+      ID: 233
+      Name: Probe[main.testUint32Array]
       ByteSize: 9
       PresenceBitsetSize: 1
       Expressions:
-        - Name: a
+        - Name: x
           Offset: 1
           Expression:
-            Type: 169 PointerType *main.threeStringStruct
+            Type: 23 ArrayType [2]uint32
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 98, index: 0, name: a}
+                  Variable: {subprogram: 19, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 313
-      Name: Probe[main.testOneStringInStructPointer]
-      ByteSize: 9
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: a
-          Offset: 1
-          Expression:
-            Type: 170 PointerType *main.oneStringStruct
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 99, index: 0, name: a}
-                  Offset: 0
-                  ByteSize: 8
-    - __kind: EventRootType
-      ID: 314
-      Name: Probe[main.testMassiveString]
+      ID: 234
+      Name: Probe[main.testUint64Array]
       ByteSize: 17
       PresenceBitsetSize: 1
       Expressions:
         - Name: x
           Offset: 1
           Expression:
-            Type: 8 GoStringHeaderType string
+            Type: 25 ArrayType [2]uint64
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 100, index: 0, name: x}
+                  Variable: {subprogram: 20, index: 0, name: x}
                   Offset: 0
                   ByteSize: 16
+    - __kind: EventRootType
+      ID: 231
+      Name: Probe[main.testUint8Array]
+      ByteSize: 3
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: x
+          Offset: 1
+          Expression:
+            Type: 3 ArrayType [2]uint8
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 17, index: 0, name: x}
+                  Offset: 0
+                  ByteSize: 2
+    - __kind: EventRootType
+      ID: 230
+      Name: Probe[main.testUintArray]
+      ByteSize: 17
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: x
+          Offset: 1
+          Expression:
+            Type: 19 ArrayType [2]uint
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 16, index: 0, name: x}
+                  Offset: 0
+                  ByteSize: 16
+    - __kind: EventRootType
+      ID: 294
+      Name: Probe[main.testUintPointer]
+      ByteSize: 9
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: x
+          Offset: 1
+          Expression:
+            Type: 154 PointerType *uint
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 80, index: 0, name: x}
+                  Offset: 0
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 298
+      Name: Probe[main.testUintSlice]
+      ByteSize: 25
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: u
+          Offset: 1
+          Expression:
+            Type: 159 GoSliceHeaderType []uint
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 84, index: 0, name: u}
+                  Offset: 0
+                  ByteSize: 24
     - __kind: EventRootType
       ID: 315
       Name: Probe[main.testUnitializedString]
@@ -6786,104 +5071,1819 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 316
-      Name: Probe[main.testEmptyString]
-      ByteSize: 17
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: x
-          Offset: 1
-          Expression:
-            Type: 8 GoStringHeaderType string
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 102, index: 0, name: x}
-                  Offset: 0
-                  ByteSize: 16
-    - __kind: EventRootType
-      ID: 317
-      Name: Probe[main.testStruct]
-      ByteSize: 57
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: x
-          Offset: 1
-          Expression:
-            Type: 172 StructureType main.aStruct
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 103, index: 0, name: x}
-                  Offset: 0
-                  ByteSize: 56
-    - __kind: EventRootType
-      ID: 318
-      Name: Probe[main.testEmptyStruct]
-      ByteSize: 1
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: e
-          Offset: 1
-          Expression:
-            Type: 173 StructureType main.emptyStruct
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 104, index: 0, name: e}
-                  Offset: 0
-                  ByteSize: 0
-    - __kind: EventRootType
-      ID: 319
-      Name: Probe[main.testInlinedPrint]
+      ID: 293
+      Name: Probe[main.testUnsafePointer]
       ByteSize: 9
       PresenceBitsetSize: 1
       Expressions:
         - Name: x
           Offset: 1
           Expression:
-            Type: 1 BaseType int
+            Type: 38 VoidPointerType unsafe.Pointer
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 1, index: 0, name: x}
+                  Variable: {subprogram: 79, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 320
-      Name: Probe[main.testInlinedBBB]
-    - __kind: EventRootType
-      ID: 321
-      Name: Probe[main.testInlinedBCA]
-    - __kind: EventRootType
-      ID: 322
-      Name: Probe[main.testInlinedBCB]
-    - __kind: EventRootType
-      ID: 323
-      Name: Probe[main.testInlinedSq]
-      ByteSize: 9
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: x
-          Offset: 1
-          Expression:
-            Type: 1 BaseType int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 5, index: 0, name: x}
-                  Offset: 0
-                  ByteSize: 8
-    - __kind: EventRootType
-      ID: 324
-      Name: Probe[main.testInlinedSumArray]
-      ByteSize: 41
+      ID: 238
+      Name: Probe[main.testVeryLargeArray]
+      ByteSize: 801
       PresenceBitsetSize: 1
       Expressions:
         - Name: a
           Offset: 1
           Expression:
-            Type: 2 ArrayType [5]int
+            Type: 29 ArrayType [100]uint
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 6, index: 0, name: a}
+                  Variable: {subprogram: 24, index: 0, name: a}
                   Offset: 0
-                  ByteSize: 40
+                  ByteSize: 800
+    - __kind: EventRootType
+      ID: 307
+      Name: Probe[main.testVeryLargeSlice]
+      ByteSize: 25
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: xs
+          Offset: 1
+          Expression:
+            Type: 159 GoSliceHeaderType []uint
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 93, index: 0, name: xs}
+                  Offset: 0
+                  ByteSize: 24
+    - __kind: ArrayType
+      ID: 29
+      Name: '[100]uint'
+      ByteSize: 800
+      GoKind: 17
+      Count: 100
+      HasCount: true
+      Element: 20 BaseType uint
+    - __kind: ArrayType
+      ID: 28
+      Name: '[2][2][2]int'
+      ByteSize: 64
+      GoKind: 17
+      Count: 2
+      HasCount: true
+      Element: 27 ArrayType [2][2]int
+    - __kind: ArrayType
+      ID: 27
+      Name: '[2][2]int'
+      ByteSize: 32
+      GoKind: 17
+      Count: 2
+      HasCount: true
+      Element: 12 ArrayType [2]int
+    - __kind: ArrayType
+      ID: 10
+      Name: '[2]bool'
+      ByteSize: 2
+      GoKind: 17
+      Count: 2
+      HasCount: true
+      Element: 11 BaseType bool
+    - __kind: ArrayType
+      ID: 12
+      Name: '[2]int'
+      ByteSize: 16
+      GoRuntimeType: 617728
+      GoKind: 17
+      Count: 2
+      HasCount: true
+      Element: 1 BaseType int
+    - __kind: ArrayType
+      ID: 15
+      Name: '[2]int16'
+      ByteSize: 4
+      GoKind: 17
+      Count: 2
+      HasCount: true
+      Element: 16 BaseType int16
+    - __kind: ArrayType
+      ID: 5
+      Name: '[2]int32'
+      ByteSize: 8
+      GoRuntimeType: 618880
+      GoKind: 17
+      Count: 2
+      HasCount: true
+      Element: 6 BaseType int32
+    - __kind: ArrayType
+      ID: 17
+      Name: '[2]int64'
+      ByteSize: 16
+      GoKind: 17
+      Count: 2
+      HasCount: true
+      Element: 18 BaseType int64
+    - __kind: ArrayType
+      ID: 13
+      Name: '[2]int8'
+      ByteSize: 2
+      GoKind: 17
+      Count: 2
+      HasCount: true
+      Element: 14 BaseType int8
+    - __kind: ArrayType
+      ID: 102
+      Name: '[2]map[string]int'
+      ByteSize: 16
+      GoKind: 17
+      Count: 2
+      HasCount: true
+      Element: 82 GoMapType map[string]int
+    - __kind: ArrayType
+      ID: 7
+      Name: '[2]string'
+      ByteSize: 32
+      GoRuntimeType: 618976
+      GoKind: 17
+      Count: 2
+      HasCount: true
+      Element: 8 GoStringHeaderType string
+    - __kind: ArrayType
+      ID: 19
+      Name: '[2]uint'
+      ByteSize: 16
+      GoKind: 17
+      Count: 2
+      HasCount: true
+      Element: 20 BaseType uint
+    - __kind: ArrayType
+      ID: 21
+      Name: '[2]uint16'
+      ByteSize: 4
+      GoKind: 17
+      Count: 2
+      HasCount: true
+      Element: 22 BaseType uint16
+    - __kind: ArrayType
+      ID: 23
+      Name: '[2]uint32'
+      ByteSize: 8
+      GoKind: 17
+      Count: 2
+      HasCount: true
+      Element: 24 BaseType uint32
+    - __kind: ArrayType
+      ID: 25
+      Name: '[2]uint64'
+      ByteSize: 16
+      GoRuntimeType: 619072
+      GoKind: 17
+      Count: 2
+      HasCount: true
+      Element: 26 BaseType uint64
+    - __kind: ArrayType
+      ID: 3
+      Name: '[2]uint8'
+      ByteSize: 2
+      GoRuntimeType: 618784
+      GoKind: 17
+      Count: 2
+      HasCount: true
+      Element: 4 BaseType uint8
+    - __kind: ArrayType
+      ID: 139
+      Name: '[4]int'
+      ByteSize: 32
+      GoRuntimeType: 617344
+      GoKind: 17
+      Count: 4
+      HasCount: true
+      Element: 1 BaseType int
+    - __kind: ArrayType
+      ID: 100
+      Name: '[4]string'
+      ByteSize: 64
+      GoRuntimeType: 617632
+      GoKind: 17
+      Count: 4
+      HasCount: true
+      Element: 8 GoStringHeaderType string
+    - __kind: ArrayType
+      ID: 2
+      Name: '[5]int'
+      ByteSize: 40
+      GoKind: 17
+      Count: 5
+      HasCount: true
+      Element: 1 BaseType int
+    - __kind: ArrayType
+      ID: 63
+      Name: '[8]uint8'
+      ByteSize: 8
+      GoRuntimeType: 615424
+      GoKind: 17
+      Count: 8
+      HasCount: true
+      Element: 4 BaseType uint8
+    - __kind: GoSliceHeaderType
+      ID: 70
+      Name: '[]*runtime.bmap'
+      ByteSize: 24
+      GoRuntimeType: 451616
+      GoKind: 23
+      RawFields:
+        - Name: array
+          Offset: 0
+          Type: 71 PointerType **runtime.bmap
+        - Name: len
+          Offset: 8
+          Type: 1 BaseType int
+        - Name: cap
+          Offset: 16
+          Type: 1 BaseType int
+      Data: 192 GoSliceDataType []*runtime.bmap.array
+    - __kind: GoSliceDataType
+      ID: 192
+      Name: '[]*runtime.bmap.array'
+      ByteSize: 2048
+      Element: 72 PointerType *runtime.bmap
+    - __kind: GoSliceHeaderType
+      ID: 34
+      Name: '[]*string'
+      ByteSize: 24
+      GoRuntimeType: 443232
+      GoKind: 23
+      RawFields:
+        - Name: array
+          Offset: 0
+          Type: 35 PointerType **string
+        - Name: len
+          Offset: 8
+          Type: 1 BaseType int
+        - Name: cap
+          Offset: 16
+          Type: 1 BaseType int
+      Data: 189 GoSliceDataType []*string.array
+    - __kind: GoSliceDataType
+      ID: 189
+      Name: '[]*string.array'
+      ByteSize: 2048
+      Element: 36 PointerType *string
+    - __kind: GoSliceHeaderType
+      ID: 160
+      Name: '[][]uint'
+      ByteSize: 24
+      GoKind: 23
+      RawFields:
+        - Name: array
+          Offset: 0
+          Type: 161 PointerType *[]uint
+        - Name: len
+          Offset: 8
+          Type: 1 BaseType int
+        - Name: cap
+          Offset: 16
+          Type: 1 BaseType int
+      Data: 213 GoSliceDataType [][]uint.array
+    - __kind: GoSliceDataType
+      ID: 213
+      Name: '[][]uint.array'
+      ByteSize: 2048
+      Element: 159 GoSliceHeaderType []uint
+    - __kind: GoSliceHeaderType
+      ID: 165
+      Name: '[]bool'
+      ByteSize: 24
+      GoRuntimeType: 449760
+      GoKind: 23
+      RawFields:
+        - Name: array
+          Offset: 0
+          Type: 155 PointerType *bool
+        - Name: len
+          Offset: 8
+          Type: 1 BaseType int
+        - Name: cap
+          Offset: 16
+          Type: 1 BaseType int
+      Data: 217 GoSliceDataType []bool.array
+    - __kind: GoSliceDataType
+      ID: 217
+      Name: '[]bool.array'
+      ByteSize: 2048
+      Element: 11 BaseType bool
+    - __kind: GoSliceDataType
+      ID: 208
+      Name: '[]bucket<[4]int,[4]int>.array'
+      ByteSize: 2048
+      Element: 150 GoHMapBucketType bucket<[4]int,[4]int>
+    - __kind: GoSliceDataType
+      ID: 207
+      Name: '[]bucket<[4]int,uint8>.array'
+      ByteSize: 2048
+      Element: 144 GoHMapBucketType bucket<[4]int,uint8>
+    - __kind: GoSliceDataType
+      ID: 199
+      Name: '[]bucket<[4]string,[2]int>.array'
+      ByteSize: 2048
+      Element: 98 GoHMapBucketType bucket<[4]string,[2]int>
+    - __kind: GoSliceDataType
+      ID: 203
+      Name: '[]bucket<bool,main.node>.array'
+      ByteSize: 2048
+      Element: 116 GoHMapBucketType bucket<bool,main.node>
+    - __kind: GoSliceDataType
+      ID: 191
+      Name: '[]bucket<int,int>.array'
+      ByteSize: 2048
+      Element: 62 GoHMapBucketType bucket<int,int>
+    - __kind: GoSliceDataType
+      ID: 204
+      Name: '[]bucket<int,uint8>.array'
+      ByteSize: 2048
+      Element: 125 GoHMapBucketType bucket<int,uint8>
+    - __kind: GoSliceDataType
+      ID: 200
+      Name: '[]bucket<string,[]main.structWithMap>.array'
+      ByteSize: 2048
+      Element: 108 GoHMapBucketType bucket<string,[]main.structWithMap>
+    - __kind: GoSliceDataType
+      ID: 196
+      Name: '[]bucket<string,[]string>.array'
+      ByteSize: 2048
+      Element: 91 GoHMapBucketType bucket<string,[]string>
+    - __kind: GoSliceDataType
+      ID: 195
+      Name: '[]bucket<string,int>.array'
+      ByteSize: 2048
+      Element: 86 GoHMapBucketType bucket<string,int>
+    - __kind: GoSliceDataType
+      ID: 194
+      Name: '[]bucket<string,main.nestedStruct>.array'
+      ByteSize: 2048
+      Element: 78 GoHMapBucketType bucket<string,main.nestedStruct>
+    - __kind: GoSliceDataType
+      ID: 206
+      Name: '[]bucket<uint8,[4]int>.array'
+      ByteSize: 2048
+      Element: 137 GoHMapBucketType bucket<uint8,[4]int>
+    - __kind: GoSliceDataType
+      ID: 205
+      Name: '[]bucket<uint8,uint8>.array'
+      ByteSize: 2048
+      Element: 131 GoHMapBucketType bucket<uint8,uint8>
+    - __kind: ArrayType
+      ID: 145
+      Name: '[]key<[4]int>'
+      ByteSize: 256
+      Count: 8
+      HasCount: true
+      Element: 139 ArrayType [4]int
+    - __kind: ArrayType
+      ID: 99
+      Name: '[]key<[4]string>'
+      ByteSize: 512
+      Count: 8
+      HasCount: true
+      Element: 100 ArrayType [4]string
+    - __kind: ArrayType
+      ID: 117
+      Name: '[]key<bool>'
+      ByteSize: 8
+      Count: 8
+      HasCount: true
+      Element: 11 BaseType bool
+    - __kind: ArrayType
+      ID: 64
+      Name: '[]key<int>'
+      ByteSize: 64
+      Count: 8
+      HasCount: true
+      Element: 1 BaseType int
+    - __kind: ArrayType
+      ID: 79
+      Name: '[]key<string>'
+      ByteSize: 128
+      Count: 8
+      HasCount: true
+      Element: 8 GoStringHeaderType string
+    - __kind: ArrayType
+      ID: 132
+      Name: '[]key<uint8>'
+      ByteSize: 8
+      Count: 8
+      HasCount: true
+      Element: 4 BaseType uint8
+    - __kind: GoSliceHeaderType
+      ID: 110
+      Name: '[]main.structWithMap'
+      ByteSize: 24
+      GoRuntimeType: 442720
+      GoKind: 23
+      RawFields:
+        - Name: array
+          Offset: 0
+          Type: 111 PointerType *main.structWithMap
+        - Name: len
+          Offset: 8
+          Type: 1 BaseType int
+        - Name: cap
+          Offset: 16
+          Type: 1 BaseType int
+      Data: 201 GoSliceDataType []main.structWithMap.array
+    - __kind: GoSliceDataType
+      ID: 201
+      Name: '[]main.structWithMap.array'
+      ByteSize: 2048
+      Element: 57 StructureType main.structWithMap
+    - __kind: GoSliceHeaderType
+      ID: 162
+      Name: '[]main.structWithNoStrings'
+      ByteSize: 24
+      GoKind: 23
+      RawFields:
+        - Name: array
+          Offset: 0
+          Type: 163 PointerType *main.structWithNoStrings
+        - Name: len
+          Offset: 8
+          Type: 1 BaseType int
+        - Name: cap
+          Offset: 16
+          Type: 1 BaseType int
+      Data: 215 GoSliceDataType []main.structWithNoStrings.array
+    - __kind: GoSliceDataType
+      ID: 215
+      Name: '[]main.structWithNoStrings.array'
+      ByteSize: 2048
+      Element: 164 StructureType main.structWithNoStrings
+    - __kind: GoSliceHeaderType
+      ID: 93
+      Name: '[]string'
+      ByteSize: 24
+      GoRuntimeType: 449888
+      GoKind: 23
+      RawFields:
+        - Name: array
+          Offset: 0
+          Type: 36 PointerType *string
+        - Name: len
+          Offset: 8
+          Type: 1 BaseType int
+        - Name: cap
+          Offset: 16
+          Type: 1 BaseType int
+      Data: 197 GoSliceDataType []string.array
+    - __kind: GoSliceDataType
+      ID: 197
+      Name: '[]string.array'
+      ByteSize: 2048
+      Element: 8 GoStringHeaderType string
+    - __kind: GoSliceHeaderType
+      ID: 159
+      Name: '[]uint'
+      ByteSize: 24
+      GoRuntimeType: 449376
+      GoKind: 23
+      RawFields:
+        - Name: array
+          Offset: 0
+          Type: 154 PointerType *uint
+        - Name: len
+          Offset: 8
+          Type: 1 BaseType int
+        - Name: cap
+          Offset: 16
+          Type: 1 BaseType int
+      Data: 211 GoSliceDataType []uint.array
+    - __kind: GoSliceDataType
+      ID: 211
+      Name: '[]uint.array'
+      ByteSize: 2048
+      Element: 20 BaseType uint
+    - __kind: GoSliceHeaderType
+      ID: 166
+      Name: '[]uint16'
+      ByteSize: 24
+      GoRuntimeType: 448736
+      GoKind: 23
+      RawFields:
+        - Name: array
+          Offset: 0
+          Type: 167 PointerType *uint16
+        - Name: len
+          Offset: 8
+          Type: 1 BaseType int
+        - Name: cap
+          Offset: 16
+          Type: 1 BaseType int
+      Data: 219 GoSliceDataType []uint16.array
+    - __kind: GoSliceDataType
+      ID: 219
+      Name: '[]uint16.array'
+      ByteSize: 2048
+      Element: 22 BaseType uint16
+    - __kind: ArrayType
+      ID: 101
+      Name: '[]val<[2]int>'
+      ByteSize: 128
+      Count: 8
+      HasCount: true
+      Element: 12 ArrayType [2]int
+    - __kind: ArrayType
+      ID: 138
+      Name: '[]val<[4]int>'
+      ByteSize: 256
+      Count: 8
+      HasCount: true
+      Element: 139 ArrayType [4]int
+    - __kind: ArrayType
+      ID: 109
+      Name: '[]val<[]main.structWithMap>'
+      ByteSize: 192
+      Count: 8
+      HasCount: true
+      Element: 110 GoSliceHeaderType []main.structWithMap
+    - __kind: ArrayType
+      ID: 92
+      Name: '[]val<[]string>'
+      ByteSize: 192
+      Count: 8
+      HasCount: true
+      Element: 93 GoSliceHeaderType []string
+    - __kind: ArrayType
+      ID: 65
+      Name: '[]val<int>'
+      ByteSize: 64
+      Count: 8
+      HasCount: true
+      Element: 1 BaseType int
+    - __kind: ArrayType
+      ID: 80
+      Name: '[]val<main.nestedStruct>'
+      ByteSize: 192
+      Count: 8
+      HasCount: true
+      Element: 81 StructureType main.nestedStruct
+    - __kind: ArrayType
+      ID: 118
+      Name: '[]val<main.node>'
+      ByteSize: 128
+      Count: 8
+      HasCount: true
+      Element: 119 StructureType main.node
+    - __kind: ArrayType
+      ID: 126
+      Name: '[]val<uint8>'
+      ByteSize: 8
+      Count: 8
+      HasCount: true
+      Element: 4 BaseType uint8
+    - __kind: BaseType
+      ID: 11
+      Name: bool
+      ByteSize: 1
+      GoRuntimeType: 527872
+      GoKind: 1
+    - __kind: GoHMapBucketType
+      ID: 150
+      Name: bucket<[4]int,[4]int>
+      ByteSize: 528
+      RawFields:
+        - Name: tophash
+          Offset: 0
+          Type: 63 ArrayType [8]uint8
+        - Name: keys
+          Offset: 8
+          Type: 145 ArrayType []key<[4]int>
+        - Name: values
+          Offset: 264
+          Type: 138 ArrayType []val<[4]int>
+        - Name: overflow
+          Offset: 520
+          Type: 149 PointerType *bucket<[4]int,[4]int>
+      KeyType: 139 ArrayType [4]int
+      ValueType: 139 ArrayType [4]int
+    - __kind: GoHMapBucketType
+      ID: 144
+      Name: bucket<[4]int,uint8>
+      ByteSize: 280
+      RawFields:
+        - Name: tophash
+          Offset: 0
+          Type: 63 ArrayType [8]uint8
+        - Name: keys
+          Offset: 8
+          Type: 145 ArrayType []key<[4]int>
+        - Name: values
+          Offset: 264
+          Type: 126 ArrayType []val<uint8>
+        - Name: overflow
+          Offset: 272
+          Type: 143 PointerType *bucket<[4]int,uint8>
+      KeyType: 139 ArrayType [4]int
+      ValueType: 4 BaseType uint8
+    - __kind: GoHMapBucketType
+      ID: 98
+      Name: bucket<[4]string,[2]int>
+      ByteSize: 656
+      RawFields:
+        - Name: tophash
+          Offset: 0
+          Type: 63 ArrayType [8]uint8
+        - Name: keys
+          Offset: 8
+          Type: 99 ArrayType []key<[4]string>
+        - Name: values
+          Offset: 520
+          Type: 101 ArrayType []val<[2]int>
+        - Name: overflow
+          Offset: 648
+          Type: 97 PointerType *bucket<[4]string,[2]int>
+      KeyType: 100 ArrayType [4]string
+      ValueType: 12 ArrayType [2]int
+    - __kind: GoHMapBucketType
+      ID: 116
+      Name: bucket<bool,main.node>
+      ByteSize: 152
+      RawFields:
+        - Name: tophash
+          Offset: 0
+          Type: 63 ArrayType [8]uint8
+        - Name: keys
+          Offset: 8
+          Type: 117 ArrayType []key<bool>
+        - Name: values
+          Offset: 16
+          Type: 118 ArrayType []val<main.node>
+        - Name: overflow
+          Offset: 144
+          Type: 115 PointerType *bucket<bool,main.node>
+      KeyType: 11 BaseType bool
+      ValueType: 119 StructureType main.node
+    - __kind: GoHMapBucketType
+      ID: 62
+      Name: bucket<int,int>
+      ByteSize: 144
+      RawFields:
+        - Name: tophash
+          Offset: 0
+          Type: 63 ArrayType [8]uint8
+        - Name: keys
+          Offset: 8
+          Type: 64 ArrayType []key<int>
+        - Name: values
+          Offset: 72
+          Type: 65 ArrayType []val<int>
+        - Name: overflow
+          Offset: 136
+          Type: 61 PointerType *bucket<int,int>
+      KeyType: 1 BaseType int
+      ValueType: 1 BaseType int
+    - __kind: GoHMapBucketType
+      ID: 125
+      Name: bucket<int,uint8>
+      ByteSize: 88
+      RawFields:
+        - Name: tophash
+          Offset: 0
+          Type: 63 ArrayType [8]uint8
+        - Name: keys
+          Offset: 8
+          Type: 64 ArrayType []key<int>
+        - Name: values
+          Offset: 72
+          Type: 126 ArrayType []val<uint8>
+        - Name: overflow
+          Offset: 80
+          Type: 124 PointerType *bucket<int,uint8>
+      KeyType: 1 BaseType int
+      ValueType: 4 BaseType uint8
+    - __kind: GoHMapBucketType
+      ID: 108
+      Name: bucket<string,[]main.structWithMap>
+      ByteSize: 336
+      RawFields:
+        - Name: tophash
+          Offset: 0
+          Type: 63 ArrayType [8]uint8
+        - Name: keys
+          Offset: 8
+          Type: 79 ArrayType []key<string>
+        - Name: values
+          Offset: 136
+          Type: 109 ArrayType []val<[]main.structWithMap>
+        - Name: overflow
+          Offset: 328
+          Type: 107 PointerType *bucket<string,[]main.structWithMap>
+      KeyType: 8 GoStringHeaderType string
+      ValueType: 110 GoSliceHeaderType []main.structWithMap
+    - __kind: GoHMapBucketType
+      ID: 91
+      Name: bucket<string,[]string>
+      ByteSize: 336
+      RawFields:
+        - Name: tophash
+          Offset: 0
+          Type: 63 ArrayType [8]uint8
+        - Name: keys
+          Offset: 8
+          Type: 79 ArrayType []key<string>
+        - Name: values
+          Offset: 136
+          Type: 92 ArrayType []val<[]string>
+        - Name: overflow
+          Offset: 328
+          Type: 90 PointerType *bucket<string,[]string>
+      KeyType: 8 GoStringHeaderType string
+      ValueType: 93 GoSliceHeaderType []string
+    - __kind: GoHMapBucketType
+      ID: 86
+      Name: bucket<string,int>
+      ByteSize: 208
+      RawFields:
+        - Name: tophash
+          Offset: 0
+          Type: 63 ArrayType [8]uint8
+        - Name: keys
+          Offset: 8
+          Type: 79 ArrayType []key<string>
+        - Name: values
+          Offset: 136
+          Type: 65 ArrayType []val<int>
+        - Name: overflow
+          Offset: 200
+          Type: 85 PointerType *bucket<string,int>
+      KeyType: 8 GoStringHeaderType string
+      ValueType: 1 BaseType int
+    - __kind: GoHMapBucketType
+      ID: 78
+      Name: bucket<string,main.nestedStruct>
+      ByteSize: 336
+      RawFields:
+        - Name: tophash
+          Offset: 0
+          Type: 63 ArrayType [8]uint8
+        - Name: keys
+          Offset: 8
+          Type: 79 ArrayType []key<string>
+        - Name: values
+          Offset: 136
+          Type: 80 ArrayType []val<main.nestedStruct>
+        - Name: overflow
+          Offset: 328
+          Type: 77 PointerType *bucket<string,main.nestedStruct>
+      KeyType: 8 GoStringHeaderType string
+      ValueType: 81 StructureType main.nestedStruct
+    - __kind: GoHMapBucketType
+      ID: 137
+      Name: bucket<uint8,[4]int>
+      ByteSize: 280
+      RawFields:
+        - Name: tophash
+          Offset: 0
+          Type: 63 ArrayType [8]uint8
+        - Name: keys
+          Offset: 8
+          Type: 132 ArrayType []key<uint8>
+        - Name: values
+          Offset: 16
+          Type: 138 ArrayType []val<[4]int>
+        - Name: overflow
+          Offset: 272
+          Type: 136 PointerType *bucket<uint8,[4]int>
+      KeyType: 4 BaseType uint8
+      ValueType: 139 ArrayType [4]int
+    - __kind: GoHMapBucketType
+      ID: 131
+      Name: bucket<uint8,uint8>
+      ByteSize: 32
+      RawFields:
+        - Name: tophash
+          Offset: 0
+          Type: 63 ArrayType [8]uint8
+        - Name: keys
+          Offset: 8
+          Type: 132 ArrayType []key<uint8>
+        - Name: values
+          Offset: 16
+          Type: 126 ArrayType []val<uint8>
+        - Name: overflow
+          Offset: 24
+          Type: 130 PointerType *bucket<uint8,uint8>
+      KeyType: 4 BaseType uint8
+      ValueType: 4 BaseType uint8
+    - __kind: GoChannelType
+      ID: 151
+      Name: chan bool
+      GoRuntimeType: 539136
+      GoKind: 18
+    - __kind: GoChannelType
+      ID: 40
+      Name: chan struct {}
+      GoRuntimeType: 538048
+      GoKind: 18
+    - __kind: BaseType
+      ID: 178
+      Name: complex128
+      ByteSize: 16
+      GoRuntimeType: 527680
+      GoKind: 16
+    - __kind: BaseType
+      ID: 177
+      Name: complex64
+      ByteSize: 8
+      GoRuntimeType: 527616
+      GoKind: 15
+    - __kind: GoInterfaceType
+      ID: 56
+      Name: error
+      ByteSize: 16
+      GoRuntimeType: 977856
+      GoKind: 20
+      RawFields:
+        - Name: tab
+          Offset: 0
+          Type: 38 VoidPointerType unsafe.Pointer
+        - Name: data
+          Offset: 8
+          Type: 38 VoidPointerType unsafe.Pointer
+    - __kind: BaseType
+      ID: 30
+      Name: float32
+      ByteSize: 4
+      GoRuntimeType: 527744
+      GoKind: 13
+    - __kind: BaseType
+      ID: 31
+      Name: float64
+      ByteSize: 8
+      GoRuntimeType: 527808
+      GoKind: 14
+    - __kind: GoSubroutineType
+      ID: 43
+      Name: func()
+      ByteSize: 8
+      GoRuntimeType: 441824
+      GoKind: 19
+    - __kind: GoHMapHeaderType
+      ID: 148
+      Name: hash<[4]int,[4]int>
+      ByteSize: 48
+      RawFields:
+        - Name: count
+          Offset: 0
+          Type: 1 BaseType int
+        - Name: flags
+          Offset: 8
+          Type: 4 BaseType uint8
+        - Name: B
+          Offset: 9
+          Type: 4 BaseType uint8
+        - Name: noverflow
+          Offset: 10
+          Type: 22 BaseType uint16
+        - Name: hash0
+          Offset: 12
+          Type: 24 BaseType uint32
+        - Name: buckets
+          Offset: 16
+          Type: 149 PointerType *bucket<[4]int,[4]int>
+        - Name: oldbuckets
+          Offset: 24
+          Type: 149 PointerType *bucket<[4]int,[4]int>
+        - Name: nevacuate
+          Offset: 32
+          Type: 66 BaseType uintptr
+        - Name: extra
+          Offset: 40
+          Type: 67 PointerType *runtime.mapextra
+      BucketType: 150 GoHMapBucketType bucket<[4]int,[4]int>
+      BucketsType: 208 GoSliceDataType []bucket<[4]int,[4]int>.array
+    - __kind: GoHMapHeaderType
+      ID: 142
+      Name: hash<[4]int,uint8>
+      ByteSize: 48
+      RawFields:
+        - Name: count
+          Offset: 0
+          Type: 1 BaseType int
+        - Name: flags
+          Offset: 8
+          Type: 4 BaseType uint8
+        - Name: B
+          Offset: 9
+          Type: 4 BaseType uint8
+        - Name: noverflow
+          Offset: 10
+          Type: 22 BaseType uint16
+        - Name: hash0
+          Offset: 12
+          Type: 24 BaseType uint32
+        - Name: buckets
+          Offset: 16
+          Type: 143 PointerType *bucket<[4]int,uint8>
+        - Name: oldbuckets
+          Offset: 24
+          Type: 143 PointerType *bucket<[4]int,uint8>
+        - Name: nevacuate
+          Offset: 32
+          Type: 66 BaseType uintptr
+        - Name: extra
+          Offset: 40
+          Type: 67 PointerType *runtime.mapextra
+      BucketType: 144 GoHMapBucketType bucket<[4]int,uint8>
+      BucketsType: 207 GoSliceDataType []bucket<[4]int,uint8>.array
+    - __kind: GoHMapHeaderType
+      ID: 96
+      Name: hash<[4]string,[2]int>
+      ByteSize: 48
+      RawFields:
+        - Name: count
+          Offset: 0
+          Type: 1 BaseType int
+        - Name: flags
+          Offset: 8
+          Type: 4 BaseType uint8
+        - Name: B
+          Offset: 9
+          Type: 4 BaseType uint8
+        - Name: noverflow
+          Offset: 10
+          Type: 22 BaseType uint16
+        - Name: hash0
+          Offset: 12
+          Type: 24 BaseType uint32
+        - Name: buckets
+          Offset: 16
+          Type: 97 PointerType *bucket<[4]string,[2]int>
+        - Name: oldbuckets
+          Offset: 24
+          Type: 97 PointerType *bucket<[4]string,[2]int>
+        - Name: nevacuate
+          Offset: 32
+          Type: 66 BaseType uintptr
+        - Name: extra
+          Offset: 40
+          Type: 67 PointerType *runtime.mapextra
+      BucketType: 98 GoHMapBucketType bucket<[4]string,[2]int>
+      BucketsType: 199 GoSliceDataType []bucket<[4]string,[2]int>.array
+    - __kind: GoHMapHeaderType
+      ID: 114
+      Name: hash<bool,main.node>
+      ByteSize: 48
+      RawFields:
+        - Name: count
+          Offset: 0
+          Type: 1 BaseType int
+        - Name: flags
+          Offset: 8
+          Type: 4 BaseType uint8
+        - Name: B
+          Offset: 9
+          Type: 4 BaseType uint8
+        - Name: noverflow
+          Offset: 10
+          Type: 22 BaseType uint16
+        - Name: hash0
+          Offset: 12
+          Type: 24 BaseType uint32
+        - Name: buckets
+          Offset: 16
+          Type: 115 PointerType *bucket<bool,main.node>
+        - Name: oldbuckets
+          Offset: 24
+          Type: 115 PointerType *bucket<bool,main.node>
+        - Name: nevacuate
+          Offset: 32
+          Type: 66 BaseType uintptr
+        - Name: extra
+          Offset: 40
+          Type: 67 PointerType *runtime.mapextra
+      BucketType: 116 GoHMapBucketType bucket<bool,main.node>
+      BucketsType: 203 GoSliceDataType []bucket<bool,main.node>.array
+    - __kind: GoHMapHeaderType
+      ID: 60
+      Name: hash<int,int>
+      ByteSize: 48
+      RawFields:
+        - Name: count
+          Offset: 0
+          Type: 1 BaseType int
+        - Name: flags
+          Offset: 8
+          Type: 4 BaseType uint8
+        - Name: B
+          Offset: 9
+          Type: 4 BaseType uint8
+        - Name: noverflow
+          Offset: 10
+          Type: 22 BaseType uint16
+        - Name: hash0
+          Offset: 12
+          Type: 24 BaseType uint32
+        - Name: buckets
+          Offset: 16
+          Type: 61 PointerType *bucket<int,int>
+        - Name: oldbuckets
+          Offset: 24
+          Type: 61 PointerType *bucket<int,int>
+        - Name: nevacuate
+          Offset: 32
+          Type: 66 BaseType uintptr
+        - Name: extra
+          Offset: 40
+          Type: 67 PointerType *runtime.mapextra
+      BucketType: 62 GoHMapBucketType bucket<int,int>
+      BucketsType: 191 GoSliceDataType []bucket<int,int>.array
+    - __kind: GoHMapHeaderType
+      ID: 123
+      Name: hash<int,uint8>
+      ByteSize: 48
+      RawFields:
+        - Name: count
+          Offset: 0
+          Type: 1 BaseType int
+        - Name: flags
+          Offset: 8
+          Type: 4 BaseType uint8
+        - Name: B
+          Offset: 9
+          Type: 4 BaseType uint8
+        - Name: noverflow
+          Offset: 10
+          Type: 22 BaseType uint16
+        - Name: hash0
+          Offset: 12
+          Type: 24 BaseType uint32
+        - Name: buckets
+          Offset: 16
+          Type: 124 PointerType *bucket<int,uint8>
+        - Name: oldbuckets
+          Offset: 24
+          Type: 124 PointerType *bucket<int,uint8>
+        - Name: nevacuate
+          Offset: 32
+          Type: 66 BaseType uintptr
+        - Name: extra
+          Offset: 40
+          Type: 67 PointerType *runtime.mapextra
+      BucketType: 125 GoHMapBucketType bucket<int,uint8>
+      BucketsType: 204 GoSliceDataType []bucket<int,uint8>.array
+    - __kind: GoHMapHeaderType
+      ID: 106
+      Name: hash<string,[]main.structWithMap>
+      ByteSize: 48
+      RawFields:
+        - Name: count
+          Offset: 0
+          Type: 1 BaseType int
+        - Name: flags
+          Offset: 8
+          Type: 4 BaseType uint8
+        - Name: B
+          Offset: 9
+          Type: 4 BaseType uint8
+        - Name: noverflow
+          Offset: 10
+          Type: 22 BaseType uint16
+        - Name: hash0
+          Offset: 12
+          Type: 24 BaseType uint32
+        - Name: buckets
+          Offset: 16
+          Type: 107 PointerType *bucket<string,[]main.structWithMap>
+        - Name: oldbuckets
+          Offset: 24
+          Type: 107 PointerType *bucket<string,[]main.structWithMap>
+        - Name: nevacuate
+          Offset: 32
+          Type: 66 BaseType uintptr
+        - Name: extra
+          Offset: 40
+          Type: 67 PointerType *runtime.mapextra
+      BucketType: 108 GoHMapBucketType bucket<string,[]main.structWithMap>
+      BucketsType: 200 GoSliceDataType []bucket<string,[]main.structWithMap>.array
+    - __kind: GoHMapHeaderType
+      ID: 89
+      Name: hash<string,[]string>
+      ByteSize: 48
+      RawFields:
+        - Name: count
+          Offset: 0
+          Type: 1 BaseType int
+        - Name: flags
+          Offset: 8
+          Type: 4 BaseType uint8
+        - Name: B
+          Offset: 9
+          Type: 4 BaseType uint8
+        - Name: noverflow
+          Offset: 10
+          Type: 22 BaseType uint16
+        - Name: hash0
+          Offset: 12
+          Type: 24 BaseType uint32
+        - Name: buckets
+          Offset: 16
+          Type: 90 PointerType *bucket<string,[]string>
+        - Name: oldbuckets
+          Offset: 24
+          Type: 90 PointerType *bucket<string,[]string>
+        - Name: nevacuate
+          Offset: 32
+          Type: 66 BaseType uintptr
+        - Name: extra
+          Offset: 40
+          Type: 67 PointerType *runtime.mapextra
+      BucketType: 91 GoHMapBucketType bucket<string,[]string>
+      BucketsType: 196 GoSliceDataType []bucket<string,[]string>.array
+    - __kind: GoHMapHeaderType
+      ID: 84
+      Name: hash<string,int>
+      ByteSize: 48
+      RawFields:
+        - Name: count
+          Offset: 0
+          Type: 1 BaseType int
+        - Name: flags
+          Offset: 8
+          Type: 4 BaseType uint8
+        - Name: B
+          Offset: 9
+          Type: 4 BaseType uint8
+        - Name: noverflow
+          Offset: 10
+          Type: 22 BaseType uint16
+        - Name: hash0
+          Offset: 12
+          Type: 24 BaseType uint32
+        - Name: buckets
+          Offset: 16
+          Type: 85 PointerType *bucket<string,int>
+        - Name: oldbuckets
+          Offset: 24
+          Type: 85 PointerType *bucket<string,int>
+        - Name: nevacuate
+          Offset: 32
+          Type: 66 BaseType uintptr
+        - Name: extra
+          Offset: 40
+          Type: 67 PointerType *runtime.mapextra
+      BucketType: 86 GoHMapBucketType bucket<string,int>
+      BucketsType: 195 GoSliceDataType []bucket<string,int>.array
+    - __kind: GoHMapHeaderType
+      ID: 76
+      Name: hash<string,main.nestedStruct>
+      ByteSize: 48
+      RawFields:
+        - Name: count
+          Offset: 0
+          Type: 1 BaseType int
+        - Name: flags
+          Offset: 8
+          Type: 4 BaseType uint8
+        - Name: B
+          Offset: 9
+          Type: 4 BaseType uint8
+        - Name: noverflow
+          Offset: 10
+          Type: 22 BaseType uint16
+        - Name: hash0
+          Offset: 12
+          Type: 24 BaseType uint32
+        - Name: buckets
+          Offset: 16
+          Type: 77 PointerType *bucket<string,main.nestedStruct>
+        - Name: oldbuckets
+          Offset: 24
+          Type: 77 PointerType *bucket<string,main.nestedStruct>
+        - Name: nevacuate
+          Offset: 32
+          Type: 66 BaseType uintptr
+        - Name: extra
+          Offset: 40
+          Type: 67 PointerType *runtime.mapextra
+      BucketType: 78 GoHMapBucketType bucket<string,main.nestedStruct>
+      BucketsType: 194 GoSliceDataType []bucket<string,main.nestedStruct>.array
+    - __kind: GoHMapHeaderType
+      ID: 135
+      Name: hash<uint8,[4]int>
+      ByteSize: 48
+      RawFields:
+        - Name: count
+          Offset: 0
+          Type: 1 BaseType int
+        - Name: flags
+          Offset: 8
+          Type: 4 BaseType uint8
+        - Name: B
+          Offset: 9
+          Type: 4 BaseType uint8
+        - Name: noverflow
+          Offset: 10
+          Type: 22 BaseType uint16
+        - Name: hash0
+          Offset: 12
+          Type: 24 BaseType uint32
+        - Name: buckets
+          Offset: 16
+          Type: 136 PointerType *bucket<uint8,[4]int>
+        - Name: oldbuckets
+          Offset: 24
+          Type: 136 PointerType *bucket<uint8,[4]int>
+        - Name: nevacuate
+          Offset: 32
+          Type: 66 BaseType uintptr
+        - Name: extra
+          Offset: 40
+          Type: 67 PointerType *runtime.mapextra
+      BucketType: 137 GoHMapBucketType bucket<uint8,[4]int>
+      BucketsType: 206 GoSliceDataType []bucket<uint8,[4]int>.array
+    - __kind: GoHMapHeaderType
+      ID: 129
+      Name: hash<uint8,uint8>
+      ByteSize: 48
+      RawFields:
+        - Name: count
+          Offset: 0
+          Type: 1 BaseType int
+        - Name: flags
+          Offset: 8
+          Type: 4 BaseType uint8
+        - Name: B
+          Offset: 9
+          Type: 4 BaseType uint8
+        - Name: noverflow
+          Offset: 10
+          Type: 22 BaseType uint16
+        - Name: hash0
+          Offset: 12
+          Type: 24 BaseType uint32
+        - Name: buckets
+          Offset: 16
+          Type: 130 PointerType *bucket<uint8,uint8>
+        - Name: oldbuckets
+          Offset: 24
+          Type: 130 PointerType *bucket<uint8,uint8>
+        - Name: nevacuate
+          Offset: 32
+          Type: 66 BaseType uintptr
+        - Name: extra
+          Offset: 40
+          Type: 67 PointerType *runtime.mapextra
+      BucketType: 131 GoHMapBucketType bucket<uint8,uint8>
+      BucketsType: 205 GoSliceDataType []bucket<uint8,uint8>.array
+    - __kind: BaseType
+      ID: 1
+      Name: int
+      ByteSize: 8
+      GoRuntimeType: 527424
+      GoKind: 2
+    - __kind: BaseType
+      ID: 16
+      Name: int16
+      ByteSize: 2
+      GoRuntimeType: 527040
+      GoKind: 4
+    - __kind: BaseType
+      ID: 6
+      Name: int32
+      ByteSize: 4
+      GoRuntimeType: 527168
+      GoKind: 5
+    - __kind: BaseType
+      ID: 18
+      Name: int64
+      ByteSize: 8
+      GoRuntimeType: 527296
+      GoKind: 6
+    - __kind: BaseType
+      ID: 14
+      Name: int8
+      ByteSize: 1
+      GoRuntimeType: 526912
+      GoKind: 3
+    - __kind: GoEmptyInterfaceType
+      ID: 41
+      Name: interface {}
+      ByteSize: 16
+      GoRuntimeType: 772384
+      GoKind: 20
+      RawFields:
+        - Name: _type
+          Offset: 0
+          Type: 38 VoidPointerType unsafe.Pointer
+        - Name: data
+          Offset: 8
+          Type: 38 VoidPointerType unsafe.Pointer
+    - __kind: GoInterfaceType
+      ID: 37
+      Name: io.Writer
+      ByteSize: 16
+      GoRuntimeType: 973760
+      GoKind: 20
+      RawFields:
+        - Name: tab
+          Offset: 0
+          Type: 38 VoidPointerType unsafe.Pointer
+        - Name: data
+          Offset: 8
+          Type: 38 VoidPointerType unsafe.Pointer
+    - __kind: StructureType
+      ID: 172
+      Name: main.aStruct
+      ByteSize: 56
+      GoKind: 25
+      RawFields:
+        - Name: aBool
+          Offset: 0
+          Type: 11 BaseType bool
+        - Name: aString
+          Offset: 8
+          Type: 8 GoStringHeaderType string
+        - Name: aNumber
+          Offset: 24
+          Type: 1 BaseType int
+        - Name: nested
+          Offset: 32
+          Type: 81 StructureType main.nestedStruct
+    - __kind: GoInterfaceType
+      ID: 55
+      Name: main.behavior
+      ByteSize: 16
+      GoRuntimeType: 973376
+      GoKind: 20
+      RawFields:
+        - Name: tab
+          Offset: 0
+          Type: 38 VoidPointerType unsafe.Pointer
+        - Name: data
+          Offset: 8
+          Type: 38 VoidPointerType unsafe.Pointer
+    - __kind: StructureType
+      ID: 33
+      Name: main.bigStruct
+      ByteSize: 48
+      GoKind: 25
+      RawFields:
+        - Name: x
+          Offset: 0
+          Type: 34 GoSliceHeaderType []*string
+        - Name: z
+          Offset: 24
+          Type: 1 BaseType int
+        - Name: writer
+          Offset: 32
+          Type: 37 GoInterfaceType io.Writer
+    - __kind: StructureType
+      ID: 173
+      Name: main.emptyStruct
+      GoKind: 25
+      RawFields: []
+    - __kind: StructureType
+      ID: 45
+      Name: main.esotericHeap
+      ByteSize: 112
+      GoRuntimeType: 1.692416e+06
+      GoKind: 25
+      RawFields:
+        - Name: esotericStack
+          Offset: 0
+          Type: 39 StructureType main.esotericStack
+        - Name: mu
+          Offset: 64
+          Type: 46 StructureType sync.Mutex
+        - Name: once
+          Offset: 72
+          Type: 47 StructureType sync.Once
+        - Name: wg
+          Offset: 88
+          Type: 50 StructureType sync.WaitGroup
+        - Name: a
+          Offset: 104
+          Type: 54 StructureType sync/atomic.Int32
+    - __kind: StructureType
+      ID: 39
+      Name: main.esotericStack
+      ByteSize: 64
+      GoRuntimeType: 1.81888e+06
+      GoKind: 25
+      RawFields:
+        - Name: _
+          Offset: 0
+          Type: 6 BaseType int32
+        - Name: _valid
+          Offset: 4
+          Type: 6 BaseType int32
+        - Name: c
+          Offset: 8
+          Type: 40 GoChannelType chan struct {}
+        - Name: val
+          Offset: 16
+          Type: 41 GoEmptyInterfaceType interface {}
+        - Name: _
+          Offset: 32
+          Type: 26 BaseType uint64
+        - Name: work
+          Offset: 40
+          Type: 42 GoInterfaceType main.something
+        - Name: foo
+          Offset: 56
+          Type: 43 GoSubroutineType func()
+    - __kind: StructureType
+      ID: 81
+      Name: main.nestedStruct
+      ByteSize: 24
+      GoRuntimeType: 1.270016e+06
+      GoKind: 25
+      RawFields:
+        - Name: anotherInt
+          Offset: 0
+          Type: 1 BaseType int
+        - Name: anotherString
+          Offset: 8
+          Type: 8 GoStringHeaderType string
+    - __kind: StructureType
+      ID: 119
+      Name: main.node
+      ByteSize: 16
+      GoRuntimeType: 1.269856e+06
+      GoKind: 25
+      RawFields:
+        - Name: val
+          Offset: 0
+          Type: 1 BaseType int
+        - Name: b
+          Offset: 8
+          Type: 120 PointerType *main.node
+    - __kind: StructureType
+      ID: 171
+      Name: main.oneStringStruct
+      ByteSize: 16
+      GoKind: 25
+      RawFields:
+        - Name: a
+          Offset: 0
+          Type: 8 GoStringHeaderType string
+    - __kind: GoInterfaceType
+      ID: 42
+      Name: main.something
+      ByteSize: 16
+      GoRuntimeType: 973504
+      GoKind: 20
+      RawFields:
+        - Name: tab
+          Offset: 0
+          Type: 38 VoidPointerType unsafe.Pointer
+        - Name: data
+          Offset: 8
+          Type: 38 VoidPointerType unsafe.Pointer
+    - __kind: StructureType
+      ID: 57
+      Name: main.structWithMap
+      ByteSize: 8
+      GoRuntimeType: 1.092448e+06
+      GoKind: 25
+      RawFields:
+        - Name: m
+          Offset: 0
+          Type: 58 GoMapType map[int]int
+    - __kind: StructureType
+      ID: 164
+      Name: main.structWithNoStrings
+      ByteSize: 2
+      GoKind: 25
+      RawFields:
+        - Name: aUint8
+          Offset: 0
+          Type: 4 BaseType uint8
+        - Name: aBool
+          Offset: 1
+          Type: 11 BaseType bool
+    - __kind: StructureType
+      ID: 153
+      Name: main.structWithTwoValues
+      ByteSize: 16
+      GoKind: 25
+      RawFields:
+        - Name: a
+          Offset: 0
+          Type: 20 BaseType uint
+        - Name: b
+          Offset: 8
+          Type: 11 BaseType bool
+    - __kind: GoSliceHeaderType
+      ID: 157
+      Name: main.t
+      ByteSize: 24
+      GoKind: 23
+      RawFields:
+        - Name: array
+          Offset: 0
+          Type: 158 PointerType **main.t
+        - Name: len
+          Offset: 8
+          Type: 1 BaseType int
+        - Name: cap
+          Offset: 16
+          Type: 1 BaseType int
+      Data: 209 GoSliceDataType main.t.array
+    - __kind: GoSliceDataType
+      ID: 209
+      Name: main.t.array
+      ByteSize: 2048
+      Element: 156 PointerType *main.t
+    - __kind: StructureType
+      ID: 168
+      Name: main.threeStringStruct
+      ByteSize: 48
+      GoKind: 25
+      RawFields:
+        - Name: a
+          Offset: 0
+          Type: 8 GoStringHeaderType string
+        - Name: b
+          Offset: 16
+          Type: 8 GoStringHeaderType string
+        - Name: c
+          Offset: 32
+          Type: 8 GoStringHeaderType string
+    - __kind: BaseType
+      ID: 32
+      Name: main.typeAlias
+      ByteSize: 2
+      GoKind: 9
+    - __kind: GoMapType
+      ID: 146
+      Name: map[[4]int][4]int
+      ByteSize: 8
+      GoRuntimeType: 873856
+      GoKind: 21
+      HeaderType: 148 GoHMapHeaderType hash<[4]int,[4]int>
+    - __kind: GoMapType
+      ID: 140
+      Name: map[[4]int]uint8
+      ByteSize: 8
+      GoRuntimeType: 873952
+      GoKind: 21
+      HeaderType: 142 GoHMapHeaderType hash<[4]int,uint8>
+    - __kind: GoMapType
+      ID: 94
+      Name: map[[4]string][2]int
+      ByteSize: 8
+      GoRuntimeType: 874048
+      GoKind: 21
+      HeaderType: 96 GoHMapHeaderType hash<[4]string,[2]int>
+    - __kind: GoMapType
+      ID: 112
+      Name: map[bool]main.node
+      ByteSize: 8
+      GoRuntimeType: 874144
+      GoKind: 21
+      HeaderType: 114 GoHMapHeaderType hash<bool,main.node>
+    - __kind: GoMapType
+      ID: 58
+      Name: map[int]int
+      ByteSize: 8
+      GoRuntimeType: 872896
+      GoKind: 21
+      HeaderType: 60 GoHMapHeaderType hash<int,int>
+    - __kind: GoMapType
+      ID: 121
+      Name: map[int]uint8
+      ByteSize: 8
+      GoRuntimeType: 874240
+      GoKind: 21
+      HeaderType: 123 GoHMapHeaderType hash<int,uint8>
+    - __kind: GoMapType
+      ID: 104
+      Name: map[string][]main.structWithMap
+      ByteSize: 8
+      GoRuntimeType: 874336
+      GoKind: 21
+      HeaderType: 106 GoHMapHeaderType hash<string,[]main.structWithMap>
+    - __kind: GoMapType
+      ID: 87
+      Name: map[string][]string
+      ByteSize: 8
+      GoRuntimeType: 874432
+      GoKind: 21
+      HeaderType: 89 GoHMapHeaderType hash<string,[]string>
+    - __kind: GoMapType
+      ID: 82
+      Name: map[string]int
+      ByteSize: 8
+      GoRuntimeType: 874528
+      GoKind: 21
+      HeaderType: 84 GoHMapHeaderType hash<string,int>
+    - __kind: GoMapType
+      ID: 74
+      Name: map[string]main.nestedStruct
+      ByteSize: 8
+      GoRuntimeType: 874624
+      GoKind: 21
+      HeaderType: 76 GoHMapHeaderType hash<string,main.nestedStruct>
+    - __kind: GoMapType
+      ID: 133
+      Name: map[uint8][4]int
+      ByteSize: 8
+      GoRuntimeType: 874720
+      GoKind: 21
+      HeaderType: 135 GoHMapHeaderType hash<uint8,[4]int>
+    - __kind: GoMapType
+      ID: 127
+      Name: map[uint8]uint8
+      ByteSize: 8
+      GoRuntimeType: 874816
+      GoKind: 21
+      HeaderType: 129 GoHMapHeaderType hash<uint8,uint8>
+    - __kind: StructureType
+      ID: 73
+      Name: runtime.bmap
+      ByteSize: 8
+      GoRuntimeType: 1.100768e+06
+      GoKind: 25
+      RawFields:
+        - Name: tophash
+          Offset: 0
+          Type: 63 ArrayType [8]uint8
+    - __kind: StructureType
+      ID: 68
+      Name: runtime.mapextra
+      ByteSize: 24
+      GoRuntimeType: 1.417056e+06
+      GoKind: 25
+      RawFields:
+        - Name: overflow
+          Offset: 0
+          Type: 69 PointerType *[]*runtime.bmap
+        - Name: oldoverflow
+          Offset: 8
+          Type: 69 PointerType *[]*runtime.bmap
+        - Name: nextOverflow
+          Offset: 16
+          Type: 72 PointerType *runtime.bmap
+    - __kind: GoStringHeaderType
+      ID: 8
+      Name: string
+      ByteSize: 16
+      GoRuntimeType: 526848
+      GoKind: 24
+      RawFields:
+        - Name: str
+          Offset: 0
+          Type: 188 PointerType *string.str
+        - Name: len
+          Offset: 8
+          Type: 1 BaseType int
+      Data: 187 GoStringDataType string.str
+    - __kind: GoStringDataType
+      ID: 187
+      Name: string.str
+      ByteSize: 2048
+    - __kind: StructureType
+      ID: 46
+      Name: sync.Mutex
+      ByteSize: 8
+      GoRuntimeType: 1.271296e+06
+      GoKind: 25
+      RawFields:
+        - Name: state
+          Offset: 0
+          Type: 6 BaseType int32
+        - Name: sema
+          Offset: 4
+          Type: 24 BaseType uint32
+    - __kind: StructureType
+      ID: 47
+      Name: sync.Once
+      ByteSize: 12
+      GoRuntimeType: 1.272416e+06
+      GoKind: 25
+      RawFields:
+        - Name: done
+          Offset: 0
+          Type: 48 StructureType sync/atomic.Uint32
+        - Name: m
+          Offset: 4
+          Type: 46 StructureType sync.Mutex
+    - __kind: StructureType
+      ID: 50
+      Name: sync.WaitGroup
+      ByteSize: 16
+      GoRuntimeType: 1.411104e+06
+      GoKind: 25
+      RawFields:
+        - Name: noCopy
+          Offset: 0
+          Type: 51 StructureType sync.noCopy
+        - Name: state
+          Offset: 0
+          Type: 52 StructureType sync/atomic.Uint64
+        - Name: sema
+          Offset: 8
+          Type: 24 BaseType uint32
+    - __kind: StructureType
+      ID: 51
+      Name: sync.noCopy
+      GoRuntimeType: 940512
+      GoKind: 25
+      RawFields: []
+    - __kind: StructureType
+      ID: 54
+      Name: sync/atomic.Int32
+      ByteSize: 4
+      GoRuntimeType: 1.272736e+06
+      GoKind: 25
+      RawFields:
+        - Name: _
+          Offset: 0
+          Type: 49 StructureType sync/atomic.noCopy
+        - Name: v
+          Offset: 0
+          Type: 6 BaseType int32
+    - __kind: StructureType
+      ID: 48
+      Name: sync/atomic.Uint32
+      ByteSize: 4
+      GoRuntimeType: 1.272896e+06
+      GoKind: 25
+      RawFields:
+        - Name: _
+          Offset: 0
+          Type: 49 StructureType sync/atomic.noCopy
+        - Name: v
+          Offset: 0
+          Type: 24 BaseType uint32
+    - __kind: StructureType
+      ID: 52
+      Name: sync/atomic.Uint64
+      ByteSize: 8
+      GoRuntimeType: 1.411488e+06
+      GoKind: 25
+      RawFields:
+        - Name: _
+          Offset: 0
+          Type: 49 StructureType sync/atomic.noCopy
+        - Name: _
+          Offset: 0
+          Type: 53 StructureType sync/atomic.align64
+        - Name: v
+          Offset: 0
+          Type: 26 BaseType uint64
+    - __kind: StructureType
+      ID: 53
+      Name: sync/atomic.align64
+      GoRuntimeType: 940704
+      GoKind: 25
+      RawFields: []
+    - __kind: StructureType
+      ID: 49
+      Name: sync/atomic.noCopy
+      GoRuntimeType: 940608
+      GoKind: 25
+      RawFields: []
+    - __kind: BaseType
+      ID: 20
+      Name: uint
+      ByteSize: 8
+      GoRuntimeType: 527488
+      GoKind: 7
+    - __kind: BaseType
+      ID: 22
+      Name: uint16
+      ByteSize: 2
+      GoRuntimeType: 527104
+      GoKind: 9
+    - __kind: BaseType
+      ID: 24
+      Name: uint32
+      ByteSize: 4
+      GoRuntimeType: 527232
+      GoKind: 10
+    - __kind: BaseType
+      ID: 26
+      Name: uint64
+      ByteSize: 8
+      GoRuntimeType: 527360
+      GoKind: 11
+    - __kind: BaseType
+      ID: 4
+      Name: uint8
+      ByteSize: 1
+      GoRuntimeType: 526976
+      GoKind: 8
+    - __kind: BaseType
+      ID: 66
+      Name: uintptr
+      ByteSize: 8
+      GoRuntimeType: 527552
+      GoKind: 12
+    - __kind: VoidPointerType
+      ID: 38
+      Name: unsafe.Pointer
+      ByteSize: 8
+      GoRuntimeType: 527936
+      GoKind: 26
 MaxTypeID: 324
 Issues: []
 GoModuledataInfo: {FirstModuledataAddr: "0x1752740", TypesOffset: 296}

--- a/pkg/dyninst/irgen/testdata/snapshot/sample.arch=amd64,toolchain=go1.24.3.yaml
+++ b/pkg/dyninst/irgen/testdata/snapshot/sample.arch=amd64,toolchain=go1.24.3.yaml
@@ -8,11 +8,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 88}
+      subprogram: {subprogram: 96}
       events:
-        - ID: 88
-          Type: 369 EventRootType Probe[main.stackC]
-          InjectionPoints: [{PC: "0xcd83ca", Frameless: false}]
+        - ID: 96
+          Type: 502 EventRootType Probe[main.stackC]
+          InjectionPoints: [{PC: "0xcd8e4a", Frameless: false}]
           Condition: null
     - id: testAny
       version: 0
@@ -22,11 +22,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 45}
+      subprogram: {subprogram: 53}
       events:
-        - ID: 45
-          Type: 326 EventRootType Probe[main.testAny]
-          InjectionPoints: [{PC: "0xcd542a", Frameless: false}]
+        - ID: 53
+          Type: 459 EventRootType Probe[main.testAny]
+          InjectionPoints: [{PC: "0xcd5eaa", Frameless: false}]
           Condition: null
     - id: testArrayOfArrays
       version: 0
@@ -39,8 +39,8 @@ Probes:
       subprogram: {subprogram: 15}
       events:
         - ID: 15
-          Type: 296 EventRootType Probe[main.testArrayOfArrays]
-          InjectionPoints: [{PC: "0xcd3e60", Frameless: true}]
+          Type: 421 EventRootType Probe[main.testArrayOfArrays]
+          InjectionPoints: [{PC: "0xcd42c0", Frameless: true}]
           Condition: null
     - id: testArrayOfArraysOfArrays
       version: 0
@@ -53,8 +53,8 @@ Probes:
       subprogram: {subprogram: 17}
       events:
         - ID: 17
-          Type: 298 EventRootType Probe[main.testArrayOfArraysOfArrays]
-          InjectionPoints: [{PC: "0xcd3ea0", Frameless: true}]
+          Type: 423 EventRootType Probe[main.testArrayOfArraysOfArrays]
+          InjectionPoints: [{PC: "0xcd4300", Frameless: true}]
           Condition: null
     - id: testArrayOfMaps
       version: 0
@@ -64,11 +64,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 53}
+      subprogram: {subprogram: 61}
       events:
-        - ID: 53
-          Type: 334 EventRootType Probe[main.testArrayOfMaps]
-          InjectionPoints: [{PC: "0xcd59c0", Frameless: true}]
+        - ID: 61
+          Type: 467 EventRootType Probe[main.testArrayOfMaps]
+          InjectionPoints: [{PC: "0xcd6440", Frameless: true}]
           Condition: null
     - id: testArrayOfStrings
       version: 0
@@ -81,8 +81,8 @@ Probes:
       subprogram: {subprogram: 16}
       events:
         - ID: 16
-          Type: 297 EventRootType Probe[main.testArrayOfStrings]
-          InjectionPoints: [{PC: "0xcd3e80", Frameless: true}]
+          Type: 422 EventRootType Probe[main.testArrayOfStrings]
+          InjectionPoints: [{PC: "0xcd42e0", Frameless: true}]
           Condition: null
     - id: testBigStruct
       version: 0
@@ -95,8 +95,8 @@ Probes:
       subprogram: {subprogram: 35}
       events:
         - ID: 35
-          Type: 316 EventRootType Probe[main.testBigStruct]
-          InjectionPoints: [{PC: "0xcd45c0", Frameless: true}]
+          Type: 441 EventRootType Probe[main.testBigStruct]
+          InjectionPoints: [{PC: "0xcd4a20", Frameless: true}]
           Condition: null
     - id: testBoolArray
       version: 0
@@ -109,8 +109,8 @@ Probes:
       subprogram: {subprogram: 4}
       events:
         - ID: 4
-          Type: 285 EventRootType Probe[main.testBoolArray]
-          InjectionPoints: [{PC: "0xcd3d00", Frameless: true}]
+          Type: 410 EventRootType Probe[main.testBoolArray]
+          InjectionPoints: [{PC: "0xcd4160", Frameless: true}]
           Condition: null
     - id: testByteArray
       version: 0
@@ -123,8 +123,8 @@ Probes:
       subprogram: {subprogram: 1}
       events:
         - ID: 1
-          Type: 282 EventRootType Probe[main.testByteArray]
-          InjectionPoints: [{PC: "0xcd3ca0", Frameless: true}]
+          Type: 407 EventRootType Probe[main.testByteArray]
+          InjectionPoints: [{PC: "0xcd4100", Frameless: true}]
           Condition: null
     - id: testChannel
       version: 0
@@ -134,11 +134,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 69}
+      subprogram: {subprogram: 77}
       events:
-        - ID: 69
-          Type: 350 EventRootType Probe[main.testChannel]
-          InjectionPoints: [{PC: "0xcd7680", Frameless: true}]
+        - ID: 77
+          Type: 483 EventRootType Probe[main.testChannel]
+          InjectionPoints: [{PC: "0xcd8100", Frameless: true}]
           Condition: null
     - id: testCombinedByte
       version: 0
@@ -148,11 +148,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 67}
+      subprogram: {subprogram: 75}
       events:
-        - ID: 67
-          Type: 348 EventRootType Probe[main.testCombinedByte]
-          InjectionPoints: [{PC: "0xcd72a0", Frameless: true}]
+        - ID: 75
+          Type: 481 EventRootType Probe[main.testCombinedByte]
+          InjectionPoints: [{PC: "0xcd7d20", Frameless: true}]
           Condition: null
     - id: testCycle
       version: 0
@@ -162,11 +162,113 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 77}
+      subprogram: {subprogram: 85}
       events:
-        - ID: 77
-          Type: 358 EventRootType Probe[main.testCycle]
-          InjectionPoints: [{PC: "0xcd7a40", Frameless: true}]
+        - ID: 85
+          Type: 491 EventRootType Probe[main.testCycle]
+          InjectionPoints: [{PC: "0xcd84c0", Frameless: true}]
+          Condition: null
+    - id: testDeepMap1
+      version: 0
+      type: LOG_PROBE
+      where: {methodName: main.testDeepMap1}
+      capture:
+        maxReferenceDepth: 1
+        maxFieldCount: 0
+        maxCollectionSize: 0
+      template: ""
+      segments: []
+      captureSnapshot: true
+      subprogram: {subprogram: 40}
+      events:
+        - ID: 40
+          Type: 446 EventRootType Probe[main.testDeepMap1]
+          InjectionPoints: [{PC: "0xcd4e00", Frameless: true}]
+          Condition: null
+    - id: testDeepMap7
+      version: 0
+      type: LOG_PROBE
+      where: {methodName: main.testDeepMap7}
+      capture:
+        maxReferenceDepth: 5
+        maxFieldCount: 0
+        maxCollectionSize: 0
+      template: ""
+      segments: []
+      captureSnapshot: true
+      subprogram: {subprogram: 41}
+      events:
+        - ID: 41
+          Type: 447 EventRootType Probe[main.testDeepMap7]
+          InjectionPoints: [{PC: "0xcd4e20", Frameless: true}]
+          Condition: null
+    - id: testDeepPtr1
+      version: 0
+      type: LOG_PROBE
+      where: {methodName: main.testDeepPtr1}
+      capture:
+        maxReferenceDepth: 1
+        maxFieldCount: 0
+        maxCollectionSize: 0
+      template: ""
+      segments: []
+      captureSnapshot: true
+      subprogram: {subprogram: 36}
+      events:
+        - ID: 36
+          Type: 442 EventRootType Probe[main.testDeepPtr1]
+          InjectionPoints: [{PC: "0xcd4ae0", Frameless: true}]
+          Condition: null
+    - id: testDeepPtr7
+      version: 0
+      type: LOG_PROBE
+      where: {methodName: main.testDeepPtr7}
+      capture:
+        maxReferenceDepth: 5
+        maxFieldCount: 0
+        maxCollectionSize: 0
+      template: ""
+      segments: []
+      captureSnapshot: true
+      subprogram: {subprogram: 37}
+      events:
+        - ID: 37
+          Type: 443 EventRootType Probe[main.testDeepPtr7]
+          InjectionPoints: [{PC: "0xcd4b00", Frameless: true}]
+          Condition: null
+    - id: testDeepSlice1
+      version: 0
+      type: LOG_PROBE
+      where: {methodName: main.testDeepSlice1}
+      capture:
+        maxReferenceDepth: 1
+        maxFieldCount: 0
+        maxCollectionSize: 0
+      template: ""
+      segments: []
+      captureSnapshot: true
+      subprogram: {subprogram: 38}
+      events:
+        - ID: 38
+          Type: 444 EventRootType Probe[main.testDeepSlice1]
+          InjectionPoints: [{PC: "0xcd4c80", Frameless: true}]
+          Condition: null
+    - id: testDeepSlice7
+      version: 0
+      type: LOG_PROBE
+      where: {methodName: main.testDeepSlice7}
+      capture:
+        maxReferenceDepth: 5
+        maxFieldCount: 0
+        maxCollectionSize: 0
+      template: ""
+      segments: []
+      captureSnapshot: true
+      subprogram: {subprogram: 39}
+      events:
+        - ID: 39
+          Type: 445 EventRootType Probe[main.testDeepSlice7]
+          InjectionPoints: [{PC: "0xcd4ca0", Frameless: true}]
           Condition: null
     - id: testEmptySlice
       version: 0
@@ -176,11 +278,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 79}
+      subprogram: {subprogram: 87}
       events:
-        - ID: 79
-          Type: 360 EventRootType Probe[main.testEmptySlice]
-          InjectionPoints: [{PC: "0xcd7f80", Frameless: true}]
+        - ID: 87
+          Type: 493 EventRootType Probe[main.testEmptySlice]
+          InjectionPoints: [{PC: "0xcd8a00", Frameless: true}]
           Condition: null
     - id: testEmptySliceOfStructs
       version: 0
@@ -190,11 +292,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 82}
+      subprogram: {subprogram: 90}
       events:
-        - ID: 82
-          Type: 363 EventRootType Probe[main.testEmptySliceOfStructs]
-          InjectionPoints: [{PC: "0xcd7fe0", Frameless: true}]
+        - ID: 90
+          Type: 496 EventRootType Probe[main.testEmptySliceOfStructs]
+          InjectionPoints: [{PC: "0xcd8a60", Frameless: true}]
           Condition: null
     - id: testEmptyString
       version: 0
@@ -204,11 +306,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 96}
+      subprogram: {subprogram: 104}
       events:
-        - ID: 96
-          Type: 377 EventRootType Probe[main.testEmptyString]
-          InjectionPoints: [{PC: "0xcd8500", Frameless: true}]
+        - ID: 104
+          Type: 510 EventRootType Probe[main.testEmptyString]
+          InjectionPoints: [{PC: "0xcd8f80", Frameless: true}]
           Condition: null
     - id: testEmptyStruct
       version: 0
@@ -218,11 +320,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 98}
+      subprogram: {subprogram: 106}
       events:
-        - ID: 98
-          Type: 379 EventRootType Probe[main.testEmptyStruct]
-          InjectionPoints: [{PC: "0xcd8900", Frameless: true}]
+        - ID: 106
+          Type: 512 EventRootType Probe[main.testEmptyStruct]
+          InjectionPoints: [{PC: "0xcd9380", Frameless: true}]
           Condition: null
     - id: testError
       version: 0
@@ -232,11 +334,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 46}
+      subprogram: {subprogram: 54}
       events:
-        - ID: 46
-          Type: 327 EventRootType Probe[main.testError]
-          InjectionPoints: [{PC: "0xcd54a0", Frameless: true}]
+        - ID: 54
+          Type: 460 EventRootType Probe[main.testError]
+          InjectionPoints: [{PC: "0xcd5f20", Frameless: true}]
           Condition: null
     - id: testEsotericHeap
       version: 0
@@ -246,11 +348,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 37}
+      subprogram: {subprogram: 45}
       events:
-        - ID: 37
-          Type: 318 EventRootType Probe[main.testEsotericHeap]
-          InjectionPoints: [{PC: "0xcd496a", Frameless: false}]
+        - ID: 45
+          Type: 451 EventRootType Probe[main.testEsotericHeap]
+          InjectionPoints: [{PC: "0xcd53ea", Frameless: false}]
           Condition: null
     - id: testEsotericStack
       version: 0
@@ -260,11 +362,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 36}
+      subprogram: {subprogram: 44}
       events:
-        - ID: 36
-          Type: 317 EventRootType Probe[main.testEsotericStack]
-          InjectionPoints: [{PC: "0xcd484e", Frameless: false}]
+        - ID: 44
+          Type: 450 EventRootType Probe[main.testEsotericStack]
+          InjectionPoints: [{PC: "0xcd52ce", Frameless: false}]
           Condition: null
     - id: testFrameless
       version: 0
@@ -274,11 +376,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 42}
+      subprogram: {subprogram: 50}
       events:
-        - ID: 42
-          Type: 323 EventRootType Probe[main.testFrameless]
-          InjectionPoints: [{PC: "0xcd50c0", Frameless: true}]
+        - ID: 50
+          Type: 456 EventRootType Probe[main.testFrameless]
+          InjectionPoints: [{PC: "0xcd5b40", Frameless: true}]
           Condition: null
     - id: testFramelessArray
       version: 0
@@ -288,11 +390,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 43}
+      subprogram: {subprogram: 51}
       events:
-        - ID: 43
-          Type: 324 EventRootType Probe[main.testFramelessArray]
-          InjectionPoints: [{PC: "0xcd50e4", Frameless: false}]
+        - ID: 51
+          Type: 457 EventRootType Probe[main.testFramelessArray]
+          InjectionPoints: [{PC: "0xcd5b64", Frameless: false}]
           Condition: null
     - id: testInlinedBA
       version: 0
@@ -302,11 +404,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 38}
+      subprogram: {subprogram: 46}
       events:
-        - ID: 38
-          Type: 319 EventRootType Probe[main.testInlinedBA]
-          InjectionPoints: [{PC: "0xcd4daa", Frameless: false}]
+        - ID: 46
+          Type: 452 EventRootType Probe[main.testInlinedBA]
+          InjectionPoints: [{PC: "0xcd582a", Frameless: false}]
           Condition: null
     - id: testInlinedBB
       version: 0
@@ -316,11 +418,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 39}
+      subprogram: {subprogram: 47}
       events:
-        - ID: 39
-          Type: 320 EventRootType Probe[main.testInlinedBB]
-          InjectionPoints: [{PC: "0xcd4e4e", Frameless: false}]
+        - ID: 47
+          Type: 453 EventRootType Probe[main.testInlinedBB]
+          InjectionPoints: [{PC: "0xcd58ce", Frameless: false}]
           Condition: null
     - id: testInlinedBBA
       version: 0
@@ -330,11 +432,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 40}
+      subprogram: {subprogram: 48}
       events:
-        - ID: 40
-          Type: 321 EventRootType Probe[main.testInlinedBBA]
-          InjectionPoints: [{PC: "0xcd4f2a", Frameless: false}]
+        - ID: 48
+          Type: 454 EventRootType Probe[main.testInlinedBBA]
+          InjectionPoints: [{PC: "0xcd59aa", Frameless: false}]
           Condition: null
     - id: testInlinedBBB
       version: 0
@@ -344,11 +446,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 100}
+      subprogram: {subprogram: 108}
       events:
-        - ID: 100
-          Type: 381 EventRootType Probe[main.testInlinedBBB]
-          InjectionPoints: [{PC: "0xcd4ea6", Frameless: false}]
+        - ID: 108
+          Type: 514 EventRootType Probe[main.testInlinedBBB]
+          InjectionPoints: [{PC: "0xcd5926", Frameless: false}]
           Condition: null
     - id: testInlinedBC
       version: 0
@@ -358,11 +460,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 41}
+      subprogram: {subprogram: 49}
       events:
-        - ID: 41
-          Type: 322 EventRootType Probe[main.testInlinedBC]
-          InjectionPoints: [{PC: "0xcd4fae", Frameless: false}]
+        - ID: 49
+          Type: 455 EventRootType Probe[main.testInlinedBC]
+          InjectionPoints: [{PC: "0xcd5a2e", Frameless: false}]
           Condition: null
     - id: testInlinedBCA
       version: 0
@@ -372,11 +474,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 101}
+      subprogram: {subprogram: 109}
       events:
-        - ID: 101
-          Type: 382 EventRootType Probe[main.testInlinedBCA]
-          InjectionPoints: [{PC: "0xcd4fb3", Frameless: false}]
+        - ID: 109
+          Type: 515 EventRootType Probe[main.testInlinedBCA]
+          InjectionPoints: [{PC: "0xcd5a33", Frameless: false}]
           Condition: null
     - id: testInlinedBCB
       version: 0
@@ -386,11 +488,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 102}
+      subprogram: {subprogram: 110}
       events:
-        - ID: 102
-          Type: 383 EventRootType Probe[main.testInlinedBCB]
-          InjectionPoints: [{PC: "0xcd5066", Frameless: false}]
+        - ID: 110
+          Type: 516 EventRootType Probe[main.testInlinedBCB]
+          InjectionPoints: [{PC: "0xcd5ae6", Frameless: false}]
           Condition: null
     - id: testInlinedPrint
       version: 0
@@ -401,20 +503,20 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 99}
+      subprogram: {subprogram: 107}
       events:
-        - ID: 99
-          Type: 380 EventRootType Probe[main.testInlinedPrint]
+        - ID: 107
+          Type: 513 EventRootType Probe[main.testInlinedPrint]
           InjectionPoints:
-            - PC: "0xcd4c0a"
+            - PC: "0xcd568a"
               Frameless: false
-            - PC: "0xcd4c91"
+            - PC: "0xcd5711"
               Frameless: false
-            - PC: "0xcd4dd2"
+            - PC: "0xcd5852"
               Frameless: false
-            - PC: "0xcd4e5c"
+            - PC: "0xcd58dc"
               Frameless: false
-            - PC: "0xcd4f2f"
+            - PC: "0xcd59af"
               Frameless: false
           Condition: null
     - id: testInlinedSq
@@ -425,11 +527,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 103}
+      subprogram: {subprogram: 111}
       events:
-        - ID: 103
-          Type: 384 EventRootType Probe[main.testInlinedSq]
-          InjectionPoints: [{PC: "0xcd50c1", Frameless: true}]
+        - ID: 111
+          Type: 517 EventRootType Probe[main.testInlinedSq]
+          InjectionPoints: [{PC: "0xcd5b41", Frameless: true}]
           Condition: null
     - id: testInlinedSumArray
       version: 0
@@ -440,14 +542,14 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 104}
+      subprogram: {subprogram: 112}
       events:
-        - ID: 104
-          Type: 385 EventRootType Probe[main.testInlinedSumArray]
+        - ID: 112
+          Type: 518 EventRootType Probe[main.testInlinedSumArray]
           InjectionPoints:
-            - PC: "0xcd5105"
+            - PC: "0xcd5b85"
               Frameless: false
-            - PC: "0xcd51a5"
+            - PC: "0xcd5c25"
               Frameless: false
           Condition: null
     - id: testInt16Array
@@ -461,8 +563,8 @@ Probes:
       subprogram: {subprogram: 7}
       events:
         - ID: 7
-          Type: 288 EventRootType Probe[main.testInt16Array]
-          InjectionPoints: [{PC: "0xcd3d60", Frameless: true}]
+          Type: 413 EventRootType Probe[main.testInt16Array]
+          InjectionPoints: [{PC: "0xcd41c0", Frameless: true}]
           Condition: null
     - id: testInt32Array
       version: 0
@@ -475,8 +577,8 @@ Probes:
       subprogram: {subprogram: 8}
       events:
         - ID: 8
-          Type: 289 EventRootType Probe[main.testInt32Array]
-          InjectionPoints: [{PC: "0xcd3d80", Frameless: true}]
+          Type: 414 EventRootType Probe[main.testInt32Array]
+          InjectionPoints: [{PC: "0xcd41e0", Frameless: true}]
           Condition: null
     - id: testInt64Array
       version: 0
@@ -489,8 +591,8 @@ Probes:
       subprogram: {subprogram: 9}
       events:
         - ID: 9
-          Type: 290 EventRootType Probe[main.testInt64Array]
-          InjectionPoints: [{PC: "0xcd3da0", Frameless: true}]
+          Type: 415 EventRootType Probe[main.testInt64Array]
+          InjectionPoints: [{PC: "0xcd4200", Frameless: true}]
           Condition: null
     - id: testInt8Array
       version: 0
@@ -503,8 +605,8 @@ Probes:
       subprogram: {subprogram: 6}
       events:
         - ID: 6
-          Type: 287 EventRootType Probe[main.testInt8Array]
-          InjectionPoints: [{PC: "0xcd3d40", Frameless: true}]
+          Type: 412 EventRootType Probe[main.testInt8Array]
+          InjectionPoints: [{PC: "0xcd41a0", Frameless: true}]
           Condition: null
     - id: testIntArray
       version: 0
@@ -517,8 +619,8 @@ Probes:
       subprogram: {subprogram: 5}
       events:
         - ID: 5
-          Type: 286 EventRootType Probe[main.testIntArray]
-          InjectionPoints: [{PC: "0xcd3d20", Frameless: true}]
+          Type: 411 EventRootType Probe[main.testIntArray]
+          InjectionPoints: [{PC: "0xcd4180", Frameless: true}]
           Condition: null
     - id: testInterface
       version: 0
@@ -528,11 +630,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 44}
+      subprogram: {subprogram: 52}
       events:
-        - ID: 44
-          Type: 325 EventRootType Probe[main.testInterface]
-          InjectionPoints: [{PC: "0xcd53ca", Frameless: false}]
+        - ID: 52
+          Type: 458 EventRootType Probe[main.testInterface]
+          InjectionPoints: [{PC: "0xcd5e4a", Frameless: false}]
           Condition: null
     - id: testLinkedList
       version: 0
@@ -542,11 +644,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 71}
+      subprogram: {subprogram: 79}
       events:
-        - ID: 71
-          Type: 352 EventRootType Probe[main.testLinkedList]
-          InjectionPoints: [{PC: "0xcd7860", Frameless: true}]
+        - ID: 79
+          Type: 485 EventRootType Probe[main.testLinkedList]
+          InjectionPoints: [{PC: "0xcd82e0", Frameless: true}]
           Condition: null
     - id: testMapArrayToArray
       version: 0
@@ -556,11 +658,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 51}
+      subprogram: {subprogram: 59}
       events:
-        - ID: 51
-          Type: 332 EventRootType Probe[main.testMapArrayToArray]
-          InjectionPoints: [{PC: "0xcd5980", Frameless: true}]
+        - ID: 59
+          Type: 465 EventRootType Probe[main.testMapArrayToArray]
+          InjectionPoints: [{PC: "0xcd6400", Frameless: true}]
           Condition: null
     - id: testMapEmbeddedMaps
       version: 0
@@ -570,11 +672,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 57}
+      subprogram: {subprogram: 65}
       events:
-        - ID: 57
-          Type: 338 EventRootType Probe[main.testMapEmbeddedMaps]
-          InjectionPoints: [{PC: "0xcd5a40", Frameless: true}]
+        - ID: 65
+          Type: 471 EventRootType Probe[main.testMapEmbeddedMaps]
+          InjectionPoints: [{PC: "0xcd64c0", Frameless: true}]
           Condition: null
     - id: testMapIntToInt
       version: 0
@@ -584,11 +686,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 55}
+      subprogram: {subprogram: 63}
       events:
-        - ID: 55
-          Type: 336 EventRootType Probe[main.testMapIntToInt]
-          InjectionPoints: [{PC: "0xcd5a00", Frameless: true}]
+        - ID: 63
+          Type: 469 EventRootType Probe[main.testMapIntToInt]
+          InjectionPoints: [{PC: "0xcd6480", Frameless: true}]
           Condition: null
     - id: testMapLargeKeyLargeValue
       version: 0
@@ -598,11 +700,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 66}
+      subprogram: {subprogram: 74}
       events:
-        - ID: 66
-          Type: 347 EventRootType Probe[main.testMapLargeKeyLargeValue]
-          InjectionPoints: [{PC: "0xcd5b60", Frameless: true}]
+        - ID: 74
+          Type: 480 EventRootType Probe[main.testMapLargeKeyLargeValue]
+          InjectionPoints: [{PC: "0xcd65e0", Frameless: true}]
           Condition: null
     - id: testMapLargeKeySmallValue
       version: 0
@@ -612,11 +714,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 65}
+      subprogram: {subprogram: 73}
       events:
-        - ID: 65
-          Type: 346 EventRootType Probe[main.testMapLargeKeySmallValue]
-          InjectionPoints: [{PC: "0xcd5b40", Frameless: true}]
+        - ID: 73
+          Type: 479 EventRootType Probe[main.testMapLargeKeySmallValue]
+          InjectionPoints: [{PC: "0xcd65c0", Frameless: true}]
           Condition: null
     - id: testMapMassive
       version: 0
@@ -626,11 +728,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 56}
+      subprogram: {subprogram: 64}
       events:
-        - ID: 56
-          Type: 337 EventRootType Probe[main.testMapMassive]
-          InjectionPoints: [{PC: "0xcd5a20", Frameless: true}]
+        - ID: 64
+          Type: 470 EventRootType Probe[main.testMapMassive]
+          InjectionPoints: [{PC: "0xcd64a0", Frameless: true}]
           Condition: null
     - id: testMapSmallKeyLargeValue
       version: 0
@@ -640,11 +742,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 64}
+      subprogram: {subprogram: 72}
       events:
-        - ID: 64
-          Type: 345 EventRootType Probe[main.testMapSmallKeyLargeValue]
-          InjectionPoints: [{PC: "0xcd5b20", Frameless: true}]
+        - ID: 72
+          Type: 478 EventRootType Probe[main.testMapSmallKeyLargeValue]
+          InjectionPoints: [{PC: "0xcd65a0", Frameless: true}]
           Condition: null
     - id: testMapSmallKeySmallValue
       version: 0
@@ -654,11 +756,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 63}
+      subprogram: {subprogram: 71}
       events:
-        - ID: 63
-          Type: 344 EventRootType Probe[main.testMapSmallKeySmallValue]
-          InjectionPoints: [{PC: "0xcd5b00", Frameless: true}]
+        - ID: 71
+          Type: 477 EventRootType Probe[main.testMapSmallKeySmallValue]
+          InjectionPoints: [{PC: "0xcd6580", Frameless: true}]
           Condition: null
     - id: testMapStringToInt
       version: 0
@@ -668,11 +770,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 49}
+      subprogram: {subprogram: 57}
       events:
-        - ID: 49
-          Type: 330 EventRootType Probe[main.testMapStringToInt]
-          InjectionPoints: [{PC: "0xcd5940", Frameless: true}]
+        - ID: 57
+          Type: 463 EventRootType Probe[main.testMapStringToInt]
+          InjectionPoints: [{PC: "0xcd63c0", Frameless: true}]
           Condition: null
     - id: testMapStringToSlice
       version: 0
@@ -682,11 +784,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 50}
+      subprogram: {subprogram: 58}
       events:
-        - ID: 50
-          Type: 331 EventRootType Probe[main.testMapStringToSlice]
-          InjectionPoints: [{PC: "0xcd5960", Frameless: true}]
+        - ID: 58
+          Type: 464 EventRootType Probe[main.testMapStringToSlice]
+          InjectionPoints: [{PC: "0xcd63e0", Frameless: true}]
           Condition: null
     - id: testMapStringToStruct
       version: 0
@@ -696,11 +798,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 48}
+      subprogram: {subprogram: 56}
       events:
-        - ID: 48
-          Type: 329 EventRootType Probe[main.testMapStringToStruct]
-          InjectionPoints: [{PC: "0xcd5920", Frameless: true}]
+        - ID: 56
+          Type: 462 EventRootType Probe[main.testMapStringToStruct]
+          InjectionPoints: [{PC: "0xcd63a0", Frameless: true}]
           Condition: null
     - id: testMapWithLinkedList
       version: 0
@@ -710,11 +812,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 58}
+      subprogram: {subprogram: 66}
       events:
-        - ID: 58
-          Type: 339 EventRootType Probe[main.testMapWithLinkedList]
-          InjectionPoints: [{PC: "0xcd5a60", Frameless: true}]
+        - ID: 66
+          Type: 472 EventRootType Probe[main.testMapWithLinkedList]
+          InjectionPoints: [{PC: "0xcd64e0", Frameless: true}]
           Condition: null
     - id: testMapWithSmallKeyAndValue
       version: 0
@@ -724,11 +826,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 61}
+      subprogram: {subprogram: 69}
       events:
-        - ID: 61
-          Type: 342 EventRootType Probe[main.testMapWithSmallKeyAndValue]
-          InjectionPoints: [{PC: "0xcd5ac0", Frameless: true}]
+        - ID: 69
+          Type: 475 EventRootType Probe[main.testMapWithSmallKeyAndValue]
+          InjectionPoints: [{PC: "0xcd6540", Frameless: true}]
           Condition: null
     - id: testMapWithSmallKeyAndValueMassive
       version: 0
@@ -738,11 +840,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 62}
+      subprogram: {subprogram: 70}
       events:
-        - ID: 62
-          Type: 343 EventRootType Probe[main.testMapWithSmallKeyAndValueMassive]
-          InjectionPoints: [{PC: "0xcd5ae0", Frameless: true}]
+        - ID: 70
+          Type: 476 EventRootType Probe[main.testMapWithSmallKeyAndValueMassive]
+          InjectionPoints: [{PC: "0xcd6560", Frameless: true}]
           Condition: null
     - id: testMapWithSmallValue
       version: 0
@@ -752,11 +854,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 59}
+      subprogram: {subprogram: 67}
       events:
-        - ID: 59
-          Type: 340 EventRootType Probe[main.testMapWithSmallValue]
-          InjectionPoints: [{PC: "0xcd5a80", Frameless: true}]
+        - ID: 67
+          Type: 473 EventRootType Probe[main.testMapWithSmallValue]
+          InjectionPoints: [{PC: "0xcd6500", Frameless: true}]
           Condition: null
     - id: testMapWithSmallValueMassive
       version: 0
@@ -766,11 +868,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 60}
+      subprogram: {subprogram: 68}
       events:
-        - ID: 60
-          Type: 341 EventRootType Probe[main.testMapWithSmallValueMassive]
-          InjectionPoints: [{PC: "0xcd5aa0", Frameless: true}]
+        - ID: 68
+          Type: 474 EventRootType Probe[main.testMapWithSmallValueMassive]
+          InjectionPoints: [{PC: "0xcd6520", Frameless: true}]
           Condition: null
     - id: testMassiveString
       version: 0
@@ -780,11 +882,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 94}
+      subprogram: {subprogram: 102}
       events:
-        - ID: 94
-          Type: 375 EventRootType Probe[main.testMassiveString]
-          InjectionPoints: [{PC: "0xcd84c0", Frameless: true}]
+        - ID: 102
+          Type: 508 EventRootType Probe[main.testMassiveString]
+          InjectionPoints: [{PC: "0xcd8f40", Frameless: true}]
           Condition: null
     - id: testMultipleSimpleParams
       version: 0
@@ -794,11 +896,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 68}
+      subprogram: {subprogram: 76}
       events:
-        - ID: 68
-          Type: 349 EventRootType Probe[main.testMultipleSimpleParams]
-          InjectionPoints: [{PC: "0xcd7460", Frameless: true}]
+        - ID: 76
+          Type: 482 EventRootType Probe[main.testMultipleSimpleParams]
+          InjectionPoints: [{PC: "0xcd7ee0", Frameless: true}]
           Condition: null
     - id: testNilPointer
       version: 0
@@ -808,11 +910,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 76}
+      subprogram: {subprogram: 84}
       events:
-        - ID: 76
-          Type: 357 EventRootType Probe[main.testNilPointer]
-          InjectionPoints: [{PC: "0xcd7a00", Frameless: true}]
+        - ID: 84
+          Type: 490 EventRootType Probe[main.testNilPointer]
+          InjectionPoints: [{PC: "0xcd8480", Frameless: true}]
           Condition: null
     - id: testNilSlice
       version: 0
@@ -822,11 +924,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 86}
+      subprogram: {subprogram: 94}
       events:
-        - ID: 86
-          Type: 367 EventRootType Probe[main.testNilSlice]
-          InjectionPoints: [{PC: "0xcd8060", Frameless: true}]
+        - ID: 94
+          Type: 500 EventRootType Probe[main.testNilSlice]
+          InjectionPoints: [{PC: "0xcd8ae0", Frameless: true}]
           Condition: null
     - id: testNilSliceOfStructs
       version: 0
@@ -836,11 +938,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 83}
+      subprogram: {subprogram: 91}
       events:
-        - ID: 83
-          Type: 364 EventRootType Probe[main.testNilSliceOfStructs]
-          InjectionPoints: [{PC: "0xcd8000", Frameless: true}]
+        - ID: 91
+          Type: 497 EventRootType Probe[main.testNilSliceOfStructs]
+          InjectionPoints: [{PC: "0xcd8a80", Frameless: true}]
           Condition: null
     - id: testNilSliceWithOtherParams
       version: 0
@@ -850,11 +952,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 85}
+      subprogram: {subprogram: 93}
       events:
-        - ID: 85
-          Type: 366 EventRootType Probe[main.testNilSliceWithOtherParams]
-          InjectionPoints: [{PC: "0xcd8040", Frameless: true}]
+        - ID: 93
+          Type: 499 EventRootType Probe[main.testNilSliceWithOtherParams]
+          InjectionPoints: [{PC: "0xcd8ac0", Frameless: true}]
           Condition: null
     - id: testOneStringInStructPointer
       version: 0
@@ -864,11 +966,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 93}
+      subprogram: {subprogram: 101}
       events:
-        - ID: 93
-          Type: 374 EventRootType Probe[main.testOneStringInStructPointer]
-          InjectionPoints: [{PC: "0xcd84a0", Frameless: true}]
+        - ID: 101
+          Type: 507 EventRootType Probe[main.testOneStringInStructPointer]
+          InjectionPoints: [{PC: "0xcd8f20", Frameless: true}]
           Condition: null
     - id: testPointerLoop
       version: 0
@@ -878,11 +980,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 72}
+      subprogram: {subprogram: 80}
       events:
-        - ID: 72
-          Type: 353 EventRootType Probe[main.testPointerLoop]
-          InjectionPoints: [{PC: "0xcd7880", Frameless: true}]
+        - ID: 80
+          Type: 486 EventRootType Probe[main.testPointerLoop]
+          InjectionPoints: [{PC: "0xcd8300", Frameless: true}]
           Condition: null
     - id: testPointerToMap
       version: 0
@@ -892,11 +994,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 54}
+      subprogram: {subprogram: 62}
       events:
-        - ID: 54
-          Type: 335 EventRootType Probe[main.testPointerToMap]
-          InjectionPoints: [{PC: "0xcd59e0", Frameless: true}]
+        - ID: 62
+          Type: 468 EventRootType Probe[main.testPointerToMap]
+          InjectionPoints: [{PC: "0xcd6460", Frameless: true}]
           Condition: null
     - id: testPointerToSimpleStruct
       version: 0
@@ -906,11 +1008,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 70}
+      subprogram: {subprogram: 78}
       events:
-        - ID: 70
-          Type: 351 EventRootType Probe[main.testPointerToSimpleStruct]
-          InjectionPoints: [{PC: "0xcd7840", Frameless: true}]
+        - ID: 78
+          Type: 484 EventRootType Probe[main.testPointerToSimpleStruct]
+          InjectionPoints: [{PC: "0xcd82c0", Frameless: true}]
           Condition: null
     - id: testRuneArray
       version: 0
@@ -923,8 +1025,8 @@ Probes:
       subprogram: {subprogram: 2}
       events:
         - ID: 2
-          Type: 283 EventRootType Probe[main.testRuneArray]
-          InjectionPoints: [{PC: "0xcd3cc0", Frameless: true}]
+          Type: 408 EventRootType Probe[main.testRuneArray]
+          InjectionPoints: [{PC: "0xcd4120", Frameless: true}]
           Condition: null
     - id: testSingleBool
       version: 0
@@ -937,8 +1039,8 @@ Probes:
       subprogram: {subprogram: 21}
       events:
         - ID: 21
-          Type: 302 EventRootType Probe[main.testSingleBool]
-          InjectionPoints: [{PC: "0xcd42c0", Frameless: true}]
+          Type: 427 EventRootType Probe[main.testSingleBool]
+          InjectionPoints: [{PC: "0xcd4720", Frameless: true}]
           Condition: null
     - id: testSingleByte
       version: 0
@@ -951,8 +1053,8 @@ Probes:
       subprogram: {subprogram: 19}
       events:
         - ID: 19
-          Type: 300 EventRootType Probe[main.testSingleByte]
-          InjectionPoints: [{PC: "0xcd4280", Frameless: true}]
+          Type: 425 EventRootType Probe[main.testSingleByte]
+          InjectionPoints: [{PC: "0xcd46e0", Frameless: true}]
           Condition: null
     - id: testSingleFloat32
       version: 0
@@ -965,8 +1067,8 @@ Probes:
       subprogram: {subprogram: 32}
       events:
         - ID: 32
-          Type: 313 EventRootType Probe[main.testSingleFloat32]
-          InjectionPoints: [{PC: "0xcd4420", Frameless: true}]
+          Type: 438 EventRootType Probe[main.testSingleFloat32]
+          InjectionPoints: [{PC: "0xcd4880", Frameless: true}]
           Condition: null
     - id: testSingleFloat64
       version: 0
@@ -979,8 +1081,8 @@ Probes:
       subprogram: {subprogram: 33}
       events:
         - ID: 33
-          Type: 314 EventRootType Probe[main.testSingleFloat64]
-          InjectionPoints: [{PC: "0xcd4440", Frameless: true}]
+          Type: 439 EventRootType Probe[main.testSingleFloat64]
+          InjectionPoints: [{PC: "0xcd48a0", Frameless: true}]
           Condition: null
     - id: testSingleInt
       version: 0
@@ -993,8 +1095,8 @@ Probes:
       subprogram: {subprogram: 22}
       events:
         - ID: 22
-          Type: 303 EventRootType Probe[main.testSingleInt]
-          InjectionPoints: [{PC: "0xcd42e0", Frameless: true}]
+          Type: 428 EventRootType Probe[main.testSingleInt]
+          InjectionPoints: [{PC: "0xcd4740", Frameless: true}]
           Condition: null
     - id: testSingleInt16
       version: 0
@@ -1007,8 +1109,8 @@ Probes:
       subprogram: {subprogram: 24}
       events:
         - ID: 24
-          Type: 305 EventRootType Probe[main.testSingleInt16]
-          InjectionPoints: [{PC: "0xcd4320", Frameless: true}]
+          Type: 430 EventRootType Probe[main.testSingleInt16]
+          InjectionPoints: [{PC: "0xcd4780", Frameless: true}]
           Condition: null
     - id: testSingleInt32
       version: 0
@@ -1021,8 +1123,8 @@ Probes:
       subprogram: {subprogram: 25}
       events:
         - ID: 25
-          Type: 306 EventRootType Probe[main.testSingleInt32]
-          InjectionPoints: [{PC: "0xcd4340", Frameless: true}]
+          Type: 431 EventRootType Probe[main.testSingleInt32]
+          InjectionPoints: [{PC: "0xcd47a0", Frameless: true}]
           Condition: null
     - id: testSingleInt64
       version: 0
@@ -1035,8 +1137,8 @@ Probes:
       subprogram: {subprogram: 26}
       events:
         - ID: 26
-          Type: 307 EventRootType Probe[main.testSingleInt64]
-          InjectionPoints: [{PC: "0xcd4360", Frameless: true}]
+          Type: 432 EventRootType Probe[main.testSingleInt64]
+          InjectionPoints: [{PC: "0xcd47c0", Frameless: true}]
           Condition: null
     - id: testSingleInt8
       version: 0
@@ -1049,8 +1151,8 @@ Probes:
       subprogram: {subprogram: 23}
       events:
         - ID: 23
-          Type: 304 EventRootType Probe[main.testSingleInt8]
-          InjectionPoints: [{PC: "0xcd4300", Frameless: true}]
+          Type: 429 EventRootType Probe[main.testSingleInt8]
+          InjectionPoints: [{PC: "0xcd4760", Frameless: true}]
           Condition: null
     - id: testSingleRune
       version: 0
@@ -1063,8 +1165,8 @@ Probes:
       subprogram: {subprogram: 20}
       events:
         - ID: 20
-          Type: 301 EventRootType Probe[main.testSingleRune]
-          InjectionPoints: [{PC: "0xcd42a0", Frameless: true}]
+          Type: 426 EventRootType Probe[main.testSingleRune]
+          InjectionPoints: [{PC: "0xcd4700", Frameless: true}]
           Condition: null
     - id: testSingleString
       version: 0
@@ -1074,11 +1176,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 89}
+      subprogram: {subprogram: 97}
       events:
-        - ID: 89
-          Type: 370 EventRootType Probe[main.testSingleString]
-          InjectionPoints: [{PC: "0xcd8420", Frameless: true}]
+        - ID: 97
+          Type: 503 EventRootType Probe[main.testSingleString]
+          InjectionPoints: [{PC: "0xcd8ea0", Frameless: true}]
           Condition: null
     - id: testSingleUint
       version: 0
@@ -1091,8 +1193,8 @@ Probes:
       subprogram: {subprogram: 27}
       events:
         - ID: 27
-          Type: 308 EventRootType Probe[main.testSingleUint]
-          InjectionPoints: [{PC: "0xcd4380", Frameless: true}]
+          Type: 433 EventRootType Probe[main.testSingleUint]
+          InjectionPoints: [{PC: "0xcd47e0", Frameless: true}]
           Condition: null
     - id: testSingleUint16
       version: 0
@@ -1105,8 +1207,8 @@ Probes:
       subprogram: {subprogram: 29}
       events:
         - ID: 29
-          Type: 310 EventRootType Probe[main.testSingleUint16]
-          InjectionPoints: [{PC: "0xcd43c0", Frameless: true}]
+          Type: 435 EventRootType Probe[main.testSingleUint16]
+          InjectionPoints: [{PC: "0xcd4820", Frameless: true}]
           Condition: null
     - id: testSingleUint32
       version: 0
@@ -1119,8 +1221,8 @@ Probes:
       subprogram: {subprogram: 30}
       events:
         - ID: 30
-          Type: 311 EventRootType Probe[main.testSingleUint32]
-          InjectionPoints: [{PC: "0xcd43e0", Frameless: true}]
+          Type: 436 EventRootType Probe[main.testSingleUint32]
+          InjectionPoints: [{PC: "0xcd4840", Frameless: true}]
           Condition: null
     - id: testSingleUint64
       version: 0
@@ -1133,8 +1235,8 @@ Probes:
       subprogram: {subprogram: 31}
       events:
         - ID: 31
-          Type: 312 EventRootType Probe[main.testSingleUint64]
-          InjectionPoints: [{PC: "0xcd4400", Frameless: true}]
+          Type: 437 EventRootType Probe[main.testSingleUint64]
+          InjectionPoints: [{PC: "0xcd4860", Frameless: true}]
           Condition: null
     - id: testSingleUint8
       version: 0
@@ -1147,8 +1249,8 @@ Probes:
       subprogram: {subprogram: 28}
       events:
         - ID: 28
-          Type: 309 EventRootType Probe[main.testSingleUint8]
-          InjectionPoints: [{PC: "0xcd43a0", Frameless: true}]
+          Type: 434 EventRootType Probe[main.testSingleUint8]
+          InjectionPoints: [{PC: "0xcd4800", Frameless: true}]
           Condition: null
     - id: testSliceOfSlices
       version: 0
@@ -1158,11 +1260,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 80}
+      subprogram: {subprogram: 88}
       events:
-        - ID: 80
-          Type: 361 EventRootType Probe[main.testSliceOfSlices]
-          InjectionPoints: [{PC: "0xcd7fa0", Frameless: true}]
+        - ID: 88
+          Type: 494 EventRootType Probe[main.testSliceOfSlices]
+          InjectionPoints: [{PC: "0xcd8a20", Frameless: true}]
           Condition: null
     - id: testSmallMap
       version: 0
@@ -1172,11 +1274,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 52}
+      subprogram: {subprogram: 60}
       events:
-        - ID: 52
-          Type: 333 EventRootType Probe[main.testSmallMap]
-          InjectionPoints: [{PC: "0xcd59a0", Frameless: true}]
+        - ID: 60
+          Type: 466 EventRootType Probe[main.testSmallMap]
+          InjectionPoints: [{PC: "0xcd6420", Frameless: true}]
           Condition: null
     - id: testStringArray
       version: 0
@@ -1189,8 +1291,8 @@ Probes:
       subprogram: {subprogram: 3}
       events:
         - ID: 3
-          Type: 284 EventRootType Probe[main.testStringArray]
-          InjectionPoints: [{PC: "0xcd3ce0", Frameless: true}]
+          Type: 409 EventRootType Probe[main.testStringArray]
+          InjectionPoints: [{PC: "0xcd4140", Frameless: true}]
           Condition: null
     - id: testStringPointer
       version: 0
@@ -1200,11 +1302,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 75}
+      subprogram: {subprogram: 83}
       events:
-        - ID: 75
-          Type: 356 EventRootType Probe[main.testStringPointer]
-          InjectionPoints: [{PC: "0xcd79c0", Frameless: true}]
+        - ID: 83
+          Type: 489 EventRootType Probe[main.testStringPointer]
+          InjectionPoints: [{PC: "0xcd8440", Frameless: true}]
           Condition: null
     - id: testStringSlice
       version: 0
@@ -1214,11 +1316,45 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 84}
+      subprogram: {subprogram: 92}
       events:
-        - ID: 84
-          Type: 365 EventRootType Probe[main.testStringSlice]
-          InjectionPoints: [{PC: "0xcd8020", Frameless: true}]
+        - ID: 92
+          Type: 498 EventRootType Probe[main.testStringSlice]
+          InjectionPoints: [{PC: "0xcd8aa0", Frameless: true}]
+          Condition: null
+    - id: testStringType1
+      version: 0
+      type: LOG_PROBE
+      where: {methodName: main.testStringType1}
+      capture:
+        maxReferenceDepth: 1
+        maxFieldCount: 0
+        maxCollectionSize: 0
+      template: ""
+      segments: []
+      captureSnapshot: true
+      subprogram: {subprogram: 42}
+      events:
+        - ID: 42
+          Type: 448 EventRootType Probe[main.testStringType1]
+          InjectionPoints: [{PC: "0xcd4e40", Frameless: true}]
+          Condition: null
+    - id: testStringType2
+      version: 0
+      type: LOG_PROBE
+      where: {methodName: main.testStringType2}
+      capture:
+        maxReferenceDepth: 1
+        maxFieldCount: 0
+        maxCollectionSize: 0
+      template: ""
+      segments: []
+      captureSnapshot: true
+      subprogram: {subprogram: 43}
+      events:
+        - ID: 43
+          Type: 449 EventRootType Probe[main.testStringType2]
+          InjectionPoints: [{PC: "0xcd4e60", Frameless: true}]
           Condition: null
     - id: testStruct
       version: 0
@@ -1228,11 +1364,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 97}
+      subprogram: {subprogram: 105}
       events:
-        - ID: 97
-          Type: 378 EventRootType Probe[main.testStruct]
-          InjectionPoints: [{PC: "0xcd8780", Frameless: true}]
+        - ID: 105
+          Type: 511 EventRootType Probe[main.testStruct]
+          InjectionPoints: [{PC: "0xcd9200", Frameless: true}]
           Condition: null
     - id: testStructSlice
       version: 0
@@ -1242,11 +1378,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 81}
+      subprogram: {subprogram: 89}
       events:
-        - ID: 81
-          Type: 362 EventRootType Probe[main.testStructSlice]
-          InjectionPoints: [{PC: "0xcd7fc0", Frameless: true}]
+        - ID: 89
+          Type: 495 EventRootType Probe[main.testStructSlice]
+          InjectionPoints: [{PC: "0xcd8a40", Frameless: true}]
           Condition: null
     - id: testStructWithMap
       version: 0
@@ -1256,11 +1392,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 47}
+      subprogram: {subprogram: 55}
       events:
-        - ID: 47
-          Type: 328 EventRootType Probe[main.testStructWithMap]
-          InjectionPoints: [{PC: "0xcd5900", Frameless: true}]
+        - ID: 55
+          Type: 461 EventRootType Probe[main.testStructWithMap]
+          InjectionPoints: [{PC: "0xcd6380", Frameless: true}]
           Condition: null
     - id: testThreeStrings
       version: 0
@@ -1270,11 +1406,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 90}
+      subprogram: {subprogram: 98}
       events:
-        - ID: 90
-          Type: 371 EventRootType Probe[main.testThreeStrings]
-          InjectionPoints: [{PC: "0xcd8440", Frameless: true}]
+        - ID: 98
+          Type: 504 EventRootType Probe[main.testThreeStrings]
+          InjectionPoints: [{PC: "0xcd8ec0", Frameless: true}]
           Condition: null
     - id: testThreeStringsInStruct
       version: 0
@@ -1284,11 +1420,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 91}
+      subprogram: {subprogram: 99}
       events:
-        - ID: 91
-          Type: 372 EventRootType Probe[main.testThreeStringsInStruct]
-          InjectionPoints: [{PC: "0xcd8460", Frameless: true}]
+        - ID: 99
+          Type: 505 EventRootType Probe[main.testThreeStringsInStruct]
+          InjectionPoints: [{PC: "0xcd8ee0", Frameless: true}]
           Condition: null
     - id: testThreeStringsInStructPointer
       version: 0
@@ -1298,11 +1434,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 92}
+      subprogram: {subprogram: 100}
       events:
-        - ID: 92
-          Type: 373 EventRootType Probe[main.testThreeStringsInStructPointer]
-          InjectionPoints: [{PC: "0xcd8480", Frameless: true}]
+        - ID: 100
+          Type: 506 EventRootType Probe[main.testThreeStringsInStructPointer]
+          InjectionPoints: [{PC: "0xcd8f00", Frameless: true}]
           Condition: null
     - id: testTypeAlias
       version: 0
@@ -1315,8 +1451,8 @@ Probes:
       subprogram: {subprogram: 34}
       events:
         - ID: 34
-          Type: 315 EventRootType Probe[main.testTypeAlias]
-          InjectionPoints: [{PC: "0xcd4460", Frameless: true}]
+          Type: 440 EventRootType Probe[main.testTypeAlias]
+          InjectionPoints: [{PC: "0xcd48c0", Frameless: true}]
           Condition: null
     - id: testUint16Array
       version: 0
@@ -1329,8 +1465,8 @@ Probes:
       subprogram: {subprogram: 12}
       events:
         - ID: 12
-          Type: 293 EventRootType Probe[main.testUint16Array]
-          InjectionPoints: [{PC: "0xcd3e00", Frameless: true}]
+          Type: 418 EventRootType Probe[main.testUint16Array]
+          InjectionPoints: [{PC: "0xcd4260", Frameless: true}]
           Condition: null
     - id: testUint32Array
       version: 0
@@ -1343,8 +1479,8 @@ Probes:
       subprogram: {subprogram: 13}
       events:
         - ID: 13
-          Type: 294 EventRootType Probe[main.testUint32Array]
-          InjectionPoints: [{PC: "0xcd3e20", Frameless: true}]
+          Type: 419 EventRootType Probe[main.testUint32Array]
+          InjectionPoints: [{PC: "0xcd4280", Frameless: true}]
           Condition: null
     - id: testUint64Array
       version: 0
@@ -1357,8 +1493,8 @@ Probes:
       subprogram: {subprogram: 14}
       events:
         - ID: 14
-          Type: 295 EventRootType Probe[main.testUint64Array]
-          InjectionPoints: [{PC: "0xcd3e40", Frameless: true}]
+          Type: 420 EventRootType Probe[main.testUint64Array]
+          InjectionPoints: [{PC: "0xcd42a0", Frameless: true}]
           Condition: null
     - id: testUint8Array
       version: 0
@@ -1371,8 +1507,8 @@ Probes:
       subprogram: {subprogram: 11}
       events:
         - ID: 11
-          Type: 292 EventRootType Probe[main.testUint8Array]
-          InjectionPoints: [{PC: "0xcd3de0", Frameless: true}]
+          Type: 417 EventRootType Probe[main.testUint8Array]
+          InjectionPoints: [{PC: "0xcd4240", Frameless: true}]
           Condition: null
     - id: testUintArray
       version: 0
@@ -1385,8 +1521,8 @@ Probes:
       subprogram: {subprogram: 10}
       events:
         - ID: 10
-          Type: 291 EventRootType Probe[main.testUintArray]
-          InjectionPoints: [{PC: "0xcd3dc0", Frameless: true}]
+          Type: 416 EventRootType Probe[main.testUintArray]
+          InjectionPoints: [{PC: "0xcd4220", Frameless: true}]
           Condition: null
     - id: testUintPointer
       version: 0
@@ -1396,11 +1532,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 74}
+      subprogram: {subprogram: 82}
       events:
-        - ID: 74
-          Type: 355 EventRootType Probe[main.testUintPointer]
-          InjectionPoints: [{PC: "0xcd78e0", Frameless: true}]
+        - ID: 82
+          Type: 488 EventRootType Probe[main.testUintPointer]
+          InjectionPoints: [{PC: "0xcd8360", Frameless: true}]
           Condition: null
     - id: testUintSlice
       version: 0
@@ -1410,11 +1546,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 78}
+      subprogram: {subprogram: 86}
       events:
-        - ID: 78
-          Type: 359 EventRootType Probe[main.testUintSlice]
-          InjectionPoints: [{PC: "0xcd7f60", Frameless: true}]
+        - ID: 86
+          Type: 492 EventRootType Probe[main.testUintSlice]
+          InjectionPoints: [{PC: "0xcd89e0", Frameless: true}]
           Condition: null
     - id: testUnitializedString
       version: 0
@@ -1424,11 +1560,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 95}
+      subprogram: {subprogram: 103}
       events:
-        - ID: 95
-          Type: 376 EventRootType Probe[main.testUnitializedString]
-          InjectionPoints: [{PC: "0xcd84e0", Frameless: true}]
+        - ID: 103
+          Type: 509 EventRootType Probe[main.testUnitializedString]
+          InjectionPoints: [{PC: "0xcd8f60", Frameless: true}]
           Condition: null
     - id: testUnsafePointer
       version: 0
@@ -1438,11 +1574,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 73}
+      subprogram: {subprogram: 81}
       events:
-        - ID: 73
-          Type: 354 EventRootType Probe[main.testUnsafePointer]
-          InjectionPoints: [{PC: "0xcd78a0", Frameless: true}]
+        - ID: 81
+          Type: 487 EventRootType Probe[main.testUnsafePointer]
+          InjectionPoints: [{PC: "0xcd8320", Frameless: true}]
           Condition: null
     - id: testVeryLargeArray
       version: 0
@@ -1455,8 +1591,8 @@ Probes:
       subprogram: {subprogram: 18}
       events:
         - ID: 18
-          Type: 299 EventRootType Probe[main.testVeryLargeArray]
-          InjectionPoints: [{PC: "0xcd3f00", Frameless: true}]
+          Type: 424 EventRootType Probe[main.testVeryLargeArray]
+          InjectionPoints: [{PC: "0xcd4360", Frameless: true}]
           Condition: null
     - id: testVeryLargeSlice
       version: 0
@@ -1466,430 +1602,430 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 87}
+      subprogram: {subprogram: 95}
       events:
-        - ID: 87
-          Type: 368 EventRootType Probe[main.testVeryLargeSlice]
-          InjectionPoints: [{PC: "0xcd8080", Frameless: true}]
+        - ID: 95
+          Type: 501 EventRootType Probe[main.testVeryLargeSlice]
+          InjectionPoints: [{PC: "0xcd8b00", Frameless: true}]
           Condition: null
 Subprograms:
     - ID: 1
       Name: main.testByteArray
-      OutOfLinePCRanges: [0xcd3ca0..0xcd3ca1]
+      OutOfLinePCRanges: [0xcd4100..0xcd4101]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 36 ArrayType [2]uint8
           Locations:
-            - Range: 0xcd3ca0..0xcd3ca1
+            - Range: 0xcd4100..0xcd4101
               Pieces: [{Size: 2, Op: {CfaOffset: 0}}]
           IsParameter: true
           IsReturn: false
     - ID: 2
       Name: main.testRuneArray
-      OutOfLinePCRanges: [0xcd3cc0..0xcd3cc1]
+      OutOfLinePCRanges: [0xcd4120..0xcd4121]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 37 ArrayType [2]int32
           Locations:
-            - Range: 0xcd3cc0..0xcd3cc1
+            - Range: 0xcd4120..0xcd4121
               Pieces: [{Size: 8, Op: {CfaOffset: 0}}]
           IsParameter: true
           IsReturn: false
     - ID: 3
       Name: main.testStringArray
-      OutOfLinePCRanges: [0xcd3ce0..0xcd3ce1]
+      OutOfLinePCRanges: [0xcd4140..0xcd4141]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 38 ArrayType [2]string
           Locations:
-            - Range: 0xcd3ce0..0xcd3ce1
+            - Range: 0xcd4140..0xcd4141
               Pieces: [{Size: 32, Op: {CfaOffset: 0}}]
           IsParameter: true
           IsReturn: false
     - ID: 4
       Name: main.testBoolArray
-      OutOfLinePCRanges: [0xcd3d00..0xcd3d01]
+      OutOfLinePCRanges: [0xcd4160..0xcd4161]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 39 ArrayType [2]bool
           Locations:
-            - Range: 0xcd3d00..0xcd3d01
+            - Range: 0xcd4160..0xcd4161
               Pieces: [{Size: 2, Op: {CfaOffset: 0}}]
           IsParameter: true
           IsReturn: false
     - ID: 5
       Name: main.testIntArray
-      OutOfLinePCRanges: [0xcd3d20..0xcd3d21]
+      OutOfLinePCRanges: [0xcd4180..0xcd4181]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 40 ArrayType [2]int
           Locations:
-            - Range: 0xcd3d20..0xcd3d21
+            - Range: 0xcd4180..0xcd4181
               Pieces: [{Size: 16, Op: {CfaOffset: 0}}]
           IsParameter: true
           IsReturn: false
     - ID: 6
       Name: main.testInt8Array
-      OutOfLinePCRanges: [0xcd3d40..0xcd3d41]
+      OutOfLinePCRanges: [0xcd41a0..0xcd41a1]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 41 ArrayType [2]int8
           Locations:
-            - Range: 0xcd3d40..0xcd3d41
+            - Range: 0xcd41a0..0xcd41a1
               Pieces: [{Size: 2, Op: {CfaOffset: 0}}]
           IsParameter: true
           IsReturn: false
     - ID: 7
       Name: main.testInt16Array
-      OutOfLinePCRanges: [0xcd3d60..0xcd3d61]
+      OutOfLinePCRanges: [0xcd41c0..0xcd41c1]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 42 ArrayType [2]int16
           Locations:
-            - Range: 0xcd3d60..0xcd3d61
+            - Range: 0xcd41c0..0xcd41c1
               Pieces: [{Size: 4, Op: {CfaOffset: 0}}]
           IsParameter: true
           IsReturn: false
     - ID: 8
       Name: main.testInt32Array
-      OutOfLinePCRanges: [0xcd3d80..0xcd3d81]
+      OutOfLinePCRanges: [0xcd41e0..0xcd41e1]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 37 ArrayType [2]int32
           Locations:
-            - Range: 0xcd3d80..0xcd3d81
+            - Range: 0xcd41e0..0xcd41e1
               Pieces: [{Size: 8, Op: {CfaOffset: 0}}]
           IsParameter: true
           IsReturn: false
     - ID: 9
       Name: main.testInt64Array
-      OutOfLinePCRanges: [0xcd3da0..0xcd3da1]
+      OutOfLinePCRanges: [0xcd4200..0xcd4201]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 43 ArrayType [2]int64
           Locations:
-            - Range: 0xcd3da0..0xcd3da1
+            - Range: 0xcd4200..0xcd4201
               Pieces: [{Size: 16, Op: {CfaOffset: 0}}]
           IsParameter: true
           IsReturn: false
     - ID: 10
       Name: main.testUintArray
-      OutOfLinePCRanges: [0xcd3dc0..0xcd3dc1]
+      OutOfLinePCRanges: [0xcd4220..0xcd4221]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 44 ArrayType [2]uint
           Locations:
-            - Range: 0xcd3dc0..0xcd3dc1
+            - Range: 0xcd4220..0xcd4221
               Pieces: [{Size: 16, Op: {CfaOffset: 0}}]
           IsParameter: true
           IsReturn: false
     - ID: 11
       Name: main.testUint8Array
-      OutOfLinePCRanges: [0xcd3de0..0xcd3de1]
+      OutOfLinePCRanges: [0xcd4240..0xcd4241]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 36 ArrayType [2]uint8
           Locations:
-            - Range: 0xcd3de0..0xcd3de1
+            - Range: 0xcd4240..0xcd4241
               Pieces: [{Size: 2, Op: {CfaOffset: 0}}]
           IsParameter: true
           IsReturn: false
     - ID: 12
       Name: main.testUint16Array
-      OutOfLinePCRanges: [0xcd3e00..0xcd3e01]
+      OutOfLinePCRanges: [0xcd4260..0xcd4261]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 45 ArrayType [2]uint16
           Locations:
-            - Range: 0xcd3e00..0xcd3e01
+            - Range: 0xcd4260..0xcd4261
               Pieces: [{Size: 4, Op: {CfaOffset: 0}}]
           IsParameter: true
           IsReturn: false
     - ID: 13
       Name: main.testUint32Array
-      OutOfLinePCRanges: [0xcd3e20..0xcd3e21]
+      OutOfLinePCRanges: [0xcd4280..0xcd4281]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 46 ArrayType [2]uint32
           Locations:
-            - Range: 0xcd3e20..0xcd3e21
+            - Range: 0xcd4280..0xcd4281
               Pieces: [{Size: 8, Op: {CfaOffset: 0}}]
           IsParameter: true
           IsReturn: false
     - ID: 14
       Name: main.testUint64Array
-      OutOfLinePCRanges: [0xcd3e40..0xcd3e41]
+      OutOfLinePCRanges: [0xcd42a0..0xcd42a1]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 47 ArrayType [2]uint64
           Locations:
-            - Range: 0xcd3e40..0xcd3e41
+            - Range: 0xcd42a0..0xcd42a1
               Pieces: [{Size: 16, Op: {CfaOffset: 0}}]
           IsParameter: true
           IsReturn: false
     - ID: 15
       Name: main.testArrayOfArrays
-      OutOfLinePCRanges: [0xcd3e60..0xcd3e61]
+      OutOfLinePCRanges: [0xcd42c0..0xcd42c1]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 48 ArrayType [2][2]int
           Locations:
-            - Range: 0xcd3e60..0xcd3e61
+            - Range: 0xcd42c0..0xcd42c1
               Pieces: [{Size: 32, Op: {CfaOffset: 0}}]
           IsParameter: true
           IsReturn: false
     - ID: 16
       Name: main.testArrayOfStrings
-      OutOfLinePCRanges: [0xcd3e80..0xcd3e81]
+      OutOfLinePCRanges: [0xcd42e0..0xcd42e1]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 38 ArrayType [2]string
           Locations:
-            - Range: 0xcd3e80..0xcd3e81
+            - Range: 0xcd42e0..0xcd42e1
               Pieces: [{Size: 32, Op: {CfaOffset: 0}}]
           IsParameter: true
           IsReturn: false
     - ID: 17
       Name: main.testArrayOfArraysOfArrays
-      OutOfLinePCRanges: [0xcd3ea0..0xcd3ea1]
+      OutOfLinePCRanges: [0xcd4300..0xcd4301]
       InlinePCRanges: []
       Variables:
         - Name: b
           Type: 49 ArrayType [2][2][2]int
           Locations:
-            - Range: 0xcd3ea0..0xcd3ea1
+            - Range: 0xcd4300..0xcd4301
               Pieces: [{Size: 64, Op: {CfaOffset: 0}}]
           IsParameter: true
           IsReturn: false
     - ID: 18
       Name: main.testVeryLargeArray
-      OutOfLinePCRanges: [0xcd3f00..0xcd3f01]
+      OutOfLinePCRanges: [0xcd4360..0xcd4361]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 50 ArrayType [100]uint
           Locations:
-            - Range: 0xcd3f00..0xcd3f01
+            - Range: 0xcd4360..0xcd4361
               Pieces: [{Size: 800, Op: {CfaOffset: 0}}]
           IsParameter: true
           IsReturn: false
     - ID: 19
       Name: main.testSingleByte
-      OutOfLinePCRanges: [0xcd4280..0xcd4281]
+      OutOfLinePCRanges: [0xcd46e0..0xcd46e1]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 3 BaseType uint8
           Locations:
-            - Range: 0xcd4280..0xcd4281
+            - Range: 0xcd46e0..0xcd46e1
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
     - ID: 20
       Name: main.testSingleRune
-      OutOfLinePCRanges: [0xcd42a0..0xcd42a1]
+      OutOfLinePCRanges: [0xcd4700..0xcd4701]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 10 BaseType int32
           Locations:
-            - Range: 0xcd42a0..0xcd42a1
+            - Range: 0xcd4700..0xcd4701
               Pieces: [{Size: 4, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
     - ID: 21
       Name: main.testSingleBool
-      OutOfLinePCRanges: [0xcd42c0..0xcd42c1]
+      OutOfLinePCRanges: [0xcd4720..0xcd4721]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 4 BaseType bool
           Locations:
-            - Range: 0xcd42c0..0xcd42c1
+            - Range: 0xcd4720..0xcd4721
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
     - ID: 22
       Name: main.testSingleInt
-      OutOfLinePCRanges: [0xcd42e0..0xcd42e1]
+      OutOfLinePCRanges: [0xcd4740..0xcd4741]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 7 BaseType int
           Locations:
-            - Range: 0xcd42e0..0xcd42e1
+            - Range: 0xcd4740..0xcd4741
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
     - ID: 23
       Name: main.testSingleInt8
-      OutOfLinePCRanges: [0xcd4300..0xcd4301]
+      OutOfLinePCRanges: [0xcd4760..0xcd4761]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 15 BaseType int8
           Locations:
-            - Range: 0xcd4300..0xcd4301
+            - Range: 0xcd4760..0xcd4761
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
     - ID: 24
       Name: main.testSingleInt16
-      OutOfLinePCRanges: [0xcd4320..0xcd4321]
+      OutOfLinePCRanges: [0xcd4780..0xcd4781]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 31 BaseType int16
           Locations:
-            - Range: 0xcd4320..0xcd4321
+            - Range: 0xcd4780..0xcd4781
               Pieces: [{Size: 2, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
     - ID: 25
       Name: main.testSingleInt32
-      OutOfLinePCRanges: [0xcd4340..0xcd4341]
+      OutOfLinePCRanges: [0xcd47a0..0xcd47a1]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 10 BaseType int32
           Locations:
-            - Range: 0xcd4340..0xcd4341
+            - Range: 0xcd47a0..0xcd47a1
               Pieces: [{Size: 4, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
     - ID: 26
       Name: main.testSingleInt64
-      OutOfLinePCRanges: [0xcd4360..0xcd4361]
+      OutOfLinePCRanges: [0xcd47c0..0xcd47c1]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 12 BaseType int64
           Locations:
-            - Range: 0xcd4360..0xcd4361
+            - Range: 0xcd47c0..0xcd47c1
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
     - ID: 27
       Name: main.testSingleUint
-      OutOfLinePCRanges: [0xcd4380..0xcd4381]
+      OutOfLinePCRanges: [0xcd47e0..0xcd47e1]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 16 BaseType uint
           Locations:
-            - Range: 0xcd4380..0xcd4381
+            - Range: 0xcd47e0..0xcd47e1
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
     - ID: 28
       Name: main.testSingleUint8
-      OutOfLinePCRanges: [0xcd43a0..0xcd43a1]
+      OutOfLinePCRanges: [0xcd4800..0xcd4801]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 3 BaseType uint8
           Locations:
-            - Range: 0xcd43a0..0xcd43a1
+            - Range: 0xcd4800..0xcd4801
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
     - ID: 29
       Name: main.testSingleUint16
-      OutOfLinePCRanges: [0xcd43c0..0xcd43c1]
+      OutOfLinePCRanges: [0xcd4820..0xcd4821]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 6 BaseType uint16
           Locations:
-            - Range: 0xcd43c0..0xcd43c1
+            - Range: 0xcd4820..0xcd4821
               Pieces: [{Size: 2, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
     - ID: 30
       Name: main.testSingleUint32
-      OutOfLinePCRanges: [0xcd43e0..0xcd43e1]
+      OutOfLinePCRanges: [0xcd4840..0xcd4841]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 2 BaseType uint32
           Locations:
-            - Range: 0xcd43e0..0xcd43e1
+            - Range: 0xcd4840..0xcd4841
               Pieces: [{Size: 4, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
     - ID: 31
       Name: main.testSingleUint64
-      OutOfLinePCRanges: [0xcd4400..0xcd4401]
+      OutOfLinePCRanges: [0xcd4860..0xcd4861]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 8 BaseType uint64
           Locations:
-            - Range: 0xcd4400..0xcd4401
+            - Range: 0xcd4860..0xcd4861
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
     - ID: 32
       Name: main.testSingleFloat32
-      OutOfLinePCRanges: [0xcd4420..0xcd4421]
+      OutOfLinePCRanges: [0xcd4880..0xcd4881]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 17 BaseType float32
           Locations:
-            - Range: 0xcd4420..0xcd4421
+            - Range: 0xcd4880..0xcd4881
               Pieces: [{Size: 4, Op: {RegNo: 17, Shift: 0}}]
           IsParameter: true
           IsReturn: false
     - ID: 33
       Name: main.testSingleFloat64
-      OutOfLinePCRanges: [0xcd4440..0xcd4441]
+      OutOfLinePCRanges: [0xcd48a0..0xcd48a1]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 18 BaseType float64
           Locations:
-            - Range: 0xcd4440..0xcd4441
+            - Range: 0xcd48a0..0xcd48a1
               Pieces: [{Size: 8, Op: {RegNo: 17, Shift: 0}}]
           IsParameter: true
           IsReturn: false
     - ID: 34
       Name: main.testTypeAlias
-      OutOfLinePCRanges: [0xcd4460..0xcd4461]
+      OutOfLinePCRanges: [0xcd48c0..0xcd48c1]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 51 BaseType main.typeAlias
           Locations:
-            - Range: 0xcd4460..0xcd4461
+            - Range: 0xcd48c0..0xcd48c1
               Pieces: [{Size: 2, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
     - ID: 35
       Name: main.testBigStruct
-      OutOfLinePCRanges: [0xcd45c0..0xcd45df]
+      OutOfLinePCRanges: [0xcd4a20..0xcd4a3f]
       InlinePCRanges: []
       Variables:
         - Name: b
           Type: 52 StructureType main.bigStruct
           Locations:
-            - Range: 0xcd45c0..0xcd45df
+            - Range: 0xcd4a20..0xcd4a3f
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -1906,14 +2042,116 @@ Subprograms:
           IsParameter: true
           IsReturn: false
     - ID: 36
+      Name: main.testDeepPtr1
+      OutOfLinePCRanges: [0xcd4ae0..0xcd4ae1]
+      InlinePCRanges: []
+      Variables:
+        - Name: a
+          Type: 56 StructureType main.deepPtr1
+          Locations:
+            - Range: 0xcd4ae0..0xcd4ae1
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+          IsParameter: true
+          IsReturn: false
+    - ID: 37
+      Name: main.testDeepPtr7
+      OutOfLinePCRanges: [0xcd4b00..0xcd4b01]
+      InlinePCRanges: []
+      Variables:
+        - Name: a
+          Type: 59 PointerType *main.deepPtr7
+          Locations:
+            - Range: 0xcd4b00..0xcd4b01
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+          IsParameter: true
+          IsReturn: false
+    - ID: 38
+      Name: main.testDeepSlice1
+      OutOfLinePCRanges: [0xcd4c80..0xcd4c81]
+      InlinePCRanges: []
+      Variables:
+        - Name: a
+          Type: 61 StructureType main.deepSlice1
+          Locations:
+            - Range: 0xcd4c80..0xcd4c81
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 0, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 3, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 2, Shift: 0}
+          IsParameter: true
+          IsReturn: false
+    - ID: 39
+      Name: main.testDeepSlice7
+      OutOfLinePCRanges: [0xcd4ca0..0xcd4ca1]
+      InlinePCRanges: []
+      Variables:
+        - Name: a
+          Type: 65 PointerType *main.deepSlice7
+          Locations:
+            - Range: 0xcd4ca0..0xcd4ca1
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+          IsParameter: true
+          IsReturn: false
+    - ID: 40
+      Name: main.testDeepMap1
+      OutOfLinePCRanges: [0xcd4e00..0xcd4e01]
+      InlinePCRanges: []
+      Variables:
+        - Name: a
+          Type: 67 StructureType main.deepMap1
+          Locations:
+            - Range: 0xcd4e00..0xcd4e01
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+          IsParameter: true
+          IsReturn: false
+    - ID: 41
+      Name: main.testDeepMap7
+      OutOfLinePCRanges: [0xcd4e20..0xcd4e21]
+      InlinePCRanges: []
+      Variables:
+        - Name: a
+          Type: 73 PointerType *main.deepMap7
+          Locations:
+            - Range: 0xcd4e20..0xcd4e21
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+          IsParameter: true
+          IsReturn: false
+    - ID: 42
+      Name: main.testStringType1
+      OutOfLinePCRanges: [0xcd4e40..0xcd4e41]
+      InlinePCRanges: []
+      Variables:
+        - Name: a
+          Type: 75 PointerType *main.stringType1
+          Locations:
+            - Range: 0xcd4e40..0xcd4e41
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+          IsParameter: true
+          IsReturn: false
+    - ID: 43
+      Name: main.testStringType2
+      OutOfLinePCRanges: [0xcd4e60..0xcd4e61]
+      InlinePCRanges: []
+      Variables:
+        - Name: a
+          Type: 77 PointerType **main.stringType2
+          Locations:
+            - Range: 0xcd4e60..0xcd4e61
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+          IsParameter: true
+          IsReturn: false
+    - ID: 44
       Name: main.testEsotericStack
-      OutOfLinePCRanges: [0xcd4840..0xcd4945]
+      OutOfLinePCRanges: [0xcd52c0..0xcd53c5]
       InlinePCRanges: []
       Variables:
         - Name: e
-          Type: 56 StructureType main.esotericStack
+          Type: 79 StructureType main.esotericStack
           Locations:
-            - Range: 0xcd4840..0xcd4893
+            - Range: 0xcd52c0..0xcd5313
               Pieces:
                 - Size: 4
                   Op: {RegNo: 0, Shift: 0}
@@ -1933,7 +2171,7 @@ Subprograms:
                   Op: {RegNo: 10, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 11, Shift: 0}
-            - Range: 0xcd4893..0xcd4898
+            - Range: 0xcd5313..0xcd5318
               Pieces:
                 - Size: 4
                   Op: null
@@ -1953,7 +2191,7 @@ Subprograms:
                   Op: {RegNo: 10, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 11, Shift: 0}
-            - Range: 0xcd4898..0xcd489d
+            - Range: 0xcd5318..0xcd531d
               Pieces:
                 - Size: 4
                   Op: null
@@ -1975,146 +2213,146 @@ Subprograms:
                   Op: {RegNo: 11, Shift: 0}
           IsParameter: true
           IsReturn: false
-    - ID: 37
+    - ID: 45
       Name: main.testEsotericHeap
-      OutOfLinePCRanges: [0xcd4960..0xcd49c3]
+      OutOfLinePCRanges: [0xcd53e0..0xcd5443]
       InlinePCRanges: []
       Variables:
         - Name: e
-          Type: 61 PointerType *main.esotericHeap
+          Type: 84 PointerType *main.esotericHeap
           Locations:
-            - Range: 0xcd4960..0xcd498d
+            - Range: 0xcd53e0..0xcd540d
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 38
+    - ID: 46
       Name: main.testInlinedBA
-      OutOfLinePCRanges: [0xcd4da0..0xcd4e28]
+      OutOfLinePCRanges: [0xcd5820..0xcd58a8]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 7 BaseType int
           Locations:
-            - Range: 0xcd4da0..0xcd4db5
+            - Range: 0xcd5820..0xcd5835
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 39
+    - ID: 47
       Name: main.testInlinedBB
-      OutOfLinePCRanges: [0xcd4e40..0xcd4f05]
+      OutOfLinePCRanges: [0xcd58c0..0xcd5985]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 7 BaseType int
           Locations:
-            - Range: 0xcd4e40..0xcd4e56
+            - Range: 0xcd58c0..0xcd58d6
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
         - Name: y
           Type: 7 BaseType int
           Locations:
-            - Range: 0xcd4e40..0xcd4e67
+            - Range: 0xcd58c0..0xcd58e7
               Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
           IsParameter: true
           IsReturn: false
         - Name: z
           Type: 7 BaseType int
           Locations:
-            - Range: 0xcd4e56..0xcd4e67
+            - Range: 0xcd58d6..0xcd58e7
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xcd4e67..0xcd4f05
+            - Range: 0xcd58e7..0xcd5985
               Pieces: [{Size: 8, Op: {CfaOffset: -56}}]
           IsParameter: false
           IsReturn: false
-    - ID: 40
+    - ID: 48
       Name: main.testInlinedBBA
-      OutOfLinePCRanges: [0xcd4f20..0xcd4f82]
+      OutOfLinePCRanges: [0xcd59a0..0xcd5a02]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 7 BaseType int
           Locations:
-            - Range: 0xcd4f20..0xcd4f3a
+            - Range: 0xcd59a0..0xcd59ba
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 41
+    - ID: 49
       Name: main.testInlinedBC
-      OutOfLinePCRanges: [0xcd4fa0..0xcd50ae]
+      OutOfLinePCRanges: [0xcd5a20..0xcd5b2e]
       InlinePCRanges: []
       Variables:
         - Name: s
           Type: 7 BaseType int
           Locations:
-            - Range: 0xcd4ffb..0xcd5005
+            - Range: 0xcd5a7b..0xcd5a85
               Pieces: [{Size: 8, Op: {CfaOffset: -80}}]
-            - Range: 0xcd5005..0xcd5020
+            - Range: 0xcd5a85..0xcd5aa0
               Pieces: [{Size: 8, Op: {CfaOffset: -80}}]
-            - Range: 0xcd5020..0xcd5034
+            - Range: 0xcd5aa0..0xcd5ab4
               Pieces: [{Size: 8, Op: {RegNo: 2, Shift: 0}}]
           IsParameter: false
           IsReturn: false
         - Name: i
           Type: 7 BaseType int
           Locations:
-            - Range: 0xcd4ff6..0xcd5000
+            - Range: 0xcd5a76..0xcd5a80
               Pieces: [{Size: 8, Op: {CfaOffset: -72}}]
-            - Range: 0xcd5000..0xcd5020
+            - Range: 0xcd5a80..0xcd5aa0
               Pieces: [{Size: 8, Op: {CfaOffset: -72}}]
-            - Range: 0xcd5020..0xcd502f
+            - Range: 0xcd5aa0..0xcd5aaf
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: false
           IsReturn: false
-    - ID: 42
+    - ID: 50
       Name: main.testFrameless
-      OutOfLinePCRanges: [0xcd50c0..0xcd50c6]
+      OutOfLinePCRanges: [0xcd5b40..0xcd5b46]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 7 BaseType int
           Locations:
-            - Range: 0xcd50c0..0xcd50c5
+            - Range: 0xcd5b40..0xcd5b45
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
         - Name: ~r0
           Type: 7 BaseType int
-          Locations: [{Range: 0xcd50c0..0xcd50c6, Pieces: []}]
+          Locations: [{Range: 0xcd5b40..0xcd5b46, Pieces: []}]
           IsParameter: true
           IsReturn: true
-    - ID: 43
+    - ID: 51
       Name: main.testFramelessArray
-      OutOfLinePCRanges: [0xcd50e0..0xcd5123]
+      OutOfLinePCRanges: [0xcd5b60..0xcd5ba3]
       InlinePCRanges: []
       Variables:
         - Name: a
-          Type: 63 ArrayType [5]int
+          Type: 86 ArrayType [5]int
           Locations:
-            - Range: 0xcd50e0..0xcd5123
+            - Range: 0xcd5b60..0xcd5ba3
               Pieces: [{Size: 40, Op: {CfaOffset: 0}}]
           IsParameter: true
           IsReturn: false
         - Name: ~r0
           Type: 7 BaseType int
-          Locations: [{Range: 0xcd50e0..0xcd5123, Pieces: []}]
+          Locations: [{Range: 0xcd5b60..0xcd5ba3, Pieces: []}]
           IsParameter: true
           IsReturn: true
-    - ID: 44
+    - ID: 52
       Name: main.testInterface
-      OutOfLinePCRanges: [0xcd53c0..0xcd5403]
+      OutOfLinePCRanges: [0xcd5e40..0xcd5e83]
       InlinePCRanges: []
       Variables:
         - Name: b
-          Type: 64 GoInterfaceType main.behavior
+          Type: 87 GoInterfaceType main.behavior
           Locations:
-            - Range: 0xcd53c0..0xcd53df
+            - Range: 0xcd5e40..0xcd5e5f
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0xcd53df..0xcd53e2
+            - Range: 0xcd5e5f..0xcd5e62
               Pieces:
                 - Size: 8
                   Op: null
@@ -2124,24 +2362,24 @@ Subprograms:
           IsReturn: false
         - Name: ~r0
           Type: 9 GoStringHeaderType string
-          Locations: [{Range: 0xcd53c0..0xcd5403, Pieces: []}]
+          Locations: [{Range: 0xcd5e40..0xcd5e83, Pieces: []}]
           IsParameter: true
           IsReturn: true
-    - ID: 45
+    - ID: 53
       Name: main.testAny
-      OutOfLinePCRanges: [0xcd5420..0xcd5486]
+      OutOfLinePCRanges: [0xcd5ea0..0xcd5f06]
       InlinePCRanges: []
       Variables:
         - Name: a
-          Type: 58 GoEmptyInterfaceType interface {}
+          Type: 81 GoEmptyInterfaceType interface {}
           Locations:
-            - Range: 0xcd5420..0xcd5449
+            - Range: 0xcd5ea0..0xcd5ec9
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0xcd5449..0xcd544e
+            - Range: 0xcd5ec9..0xcd5ece
               Pieces:
                 - Size: 8
                   Op: null
@@ -2151,18 +2389,18 @@ Subprograms:
           IsReturn: false
         - Name: ~r0
           Type: 9 GoStringHeaderType string
-          Locations: [{Range: 0xcd5420..0xcd5486, Pieces: []}]
+          Locations: [{Range: 0xcd5ea0..0xcd5f06, Pieces: []}]
           IsParameter: true
           IsReturn: true
-    - ID: 46
+    - ID: 54
       Name: main.testError
-      OutOfLinePCRanges: [0xcd54a0..0xcd54a1]
+      OutOfLinePCRanges: [0xcd5f20..0xcd5f21]
       InlinePCRanges: []
       Variables:
         - Name: e
           Type: 13 GoInterfaceType error
           Locations:
-            - Range: 0xcd54a0..0xcd54a1
+            - Range: 0xcd5f20..0xcd5f21
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -2170,309 +2408,309 @@ Subprograms:
                   Op: {RegNo: 3, Shift: 0}
           IsParameter: true
           IsReturn: false
-    - ID: 47
+    - ID: 55
       Name: main.testStructWithMap
-      OutOfLinePCRanges: [0xcd5900..0xcd5901]
+      OutOfLinePCRanges: [0xcd6380..0xcd6381]
       InlinePCRanges: []
       Variables:
         - Name: s
-          Type: 65 StructureType main.structWithMap
+          Type: 88 StructureType main.structWithMap
           Locations:
-            - Range: 0xcd5900..0xcd5901
-              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-          IsParameter: true
-          IsReturn: false
-    - ID: 48
-      Name: main.testMapStringToStruct
-      OutOfLinePCRanges: [0xcd5920..0xcd5921]
-      InlinePCRanges: []
-      Variables:
-        - Name: m
-          Type: 71 GoMapType map[string]main.nestedStruct
-          Locations:
-            - Range: 0xcd5920..0xcd5921
-              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-          IsParameter: true
-          IsReturn: false
-    - ID: 49
-      Name: main.testMapStringToInt
-      OutOfLinePCRanges: [0xcd5940..0xcd5941]
-      InlinePCRanges: []
-      Variables:
-        - Name: m
-          Type: 76 GoMapType map[string]int
-          Locations:
-            - Range: 0xcd5940..0xcd5941
-              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-          IsParameter: true
-          IsReturn: false
-    - ID: 50
-      Name: main.testMapStringToSlice
-      OutOfLinePCRanges: [0xcd5960..0xcd5961]
-      InlinePCRanges: []
-      Variables:
-        - Name: m
-          Type: 81 GoMapType map[string][]string
-          Locations:
-            - Range: 0xcd5960..0xcd5961
-              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-          IsParameter: true
-          IsReturn: false
-    - ID: 51
-      Name: main.testMapArrayToArray
-      OutOfLinePCRanges: [0xcd5980..0xcd5981]
-      InlinePCRanges: []
-      Variables:
-        - Name: m
-          Type: 86 GoMapType map[[4]string][2]int
-          Locations:
-            - Range: 0xcd5980..0xcd5981
-              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-          IsParameter: true
-          IsReturn: false
-    - ID: 52
-      Name: main.testSmallMap
-      OutOfLinePCRanges: [0xcd59a0..0xcd59a1]
-      InlinePCRanges: []
-      Variables:
-        - Name: m
-          Type: 76 GoMapType map[string]int
-          Locations:
-            - Range: 0xcd59a0..0xcd59a1
-              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-          IsParameter: true
-          IsReturn: false
-    - ID: 53
-      Name: main.testArrayOfMaps
-      OutOfLinePCRanges: [0xcd59c0..0xcd59c1]
-      InlinePCRanges: []
-      Variables:
-        - Name: m
-          Type: 91 ArrayType [2]map[string]int
-          Locations:
-            - Range: 0xcd59c0..0xcd59c1
-              Pieces: [{Size: 16, Op: {CfaOffset: 0}}]
-          IsParameter: true
-          IsReturn: false
-    - ID: 54
-      Name: main.testPointerToMap
-      OutOfLinePCRanges: [0xcd59e0..0xcd59e1]
-      InlinePCRanges: []
-      Variables:
-        - Name: m
-          Type: 92 PointerType *map[string]int
-          Locations:
-            - Range: 0xcd59e0..0xcd59e1
-              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-          IsParameter: true
-          IsReturn: false
-    - ID: 55
-      Name: main.testMapIntToInt
-      OutOfLinePCRanges: [0xcd5a00..0xcd5a01]
-      InlinePCRanges: []
-      Variables:
-        - Name: m
-          Type: 66 GoMapType map[int]int
-          Locations:
-            - Range: 0xcd5a00..0xcd5a01
+            - Range: 0xcd6380..0xcd6381
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
     - ID: 56
-      Name: main.testMapMassive
-      OutOfLinePCRanges: [0xcd5a20..0xcd5a21]
+      Name: main.testMapStringToStruct
+      OutOfLinePCRanges: [0xcd63a0..0xcd63a1]
       InlinePCRanges: []
       Variables:
-        - Name: redactMyEntries
-          Type: 93 GoMapType map[string][]main.structWithMap
+        - Name: m
+          Type: 94 GoMapType map[string]main.nestedStruct
           Locations:
-            - Range: 0xcd5a20..0xcd5a21
+            - Range: 0xcd63a0..0xcd63a1
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
     - ID: 57
-      Name: main.testMapEmbeddedMaps
-      OutOfLinePCRanges: [0xcd5a40..0xcd5a41]
+      Name: main.testMapStringToInt
+      OutOfLinePCRanges: [0xcd63c0..0xcd63c1]
       InlinePCRanges: []
       Variables:
         - Name: m
-          Type: 93 GoMapType map[string][]main.structWithMap
+          Type: 99 GoMapType map[string]int
           Locations:
-            - Range: 0xcd5a40..0xcd5a41
+            - Range: 0xcd63c0..0xcd63c1
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
     - ID: 58
-      Name: main.testMapWithLinkedList
-      OutOfLinePCRanges: [0xcd5a60..0xcd5a61]
+      Name: main.testMapStringToSlice
+      OutOfLinePCRanges: [0xcd63e0..0xcd63e1]
       InlinePCRanges: []
       Variables:
         - Name: m
-          Type: 98 GoMapType map[bool]main.node
+          Type: 104 GoMapType map[string][]string
           Locations:
-            - Range: 0xcd5a60..0xcd5a61
+            - Range: 0xcd63e0..0xcd63e1
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
     - ID: 59
-      Name: main.testMapWithSmallValue
-      OutOfLinePCRanges: [0xcd5a80..0xcd5a81]
+      Name: main.testMapArrayToArray
+      OutOfLinePCRanges: [0xcd6400..0xcd6401]
       InlinePCRanges: []
       Variables:
         - Name: m
-          Type: 103 GoMapType map[int]uint8
+          Type: 109 GoMapType map[[4]string][2]int
           Locations:
-            - Range: 0xcd5a80..0xcd5a81
+            - Range: 0xcd6400..0xcd6401
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
     - ID: 60
-      Name: main.testMapWithSmallValueMassive
-      OutOfLinePCRanges: [0xcd5aa0..0xcd5aa1]
+      Name: main.testSmallMap
+      OutOfLinePCRanges: [0xcd6420..0xcd6421]
       InlinePCRanges: []
       Variables:
-        - Name: redactMyEntries
-          Type: 103 GoMapType map[int]uint8
+        - Name: m
+          Type: 99 GoMapType map[string]int
           Locations:
-            - Range: 0xcd5aa0..0xcd5aa1
+            - Range: 0xcd6420..0xcd6421
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
     - ID: 61
-      Name: main.testMapWithSmallKeyAndValue
-      OutOfLinePCRanges: [0xcd5ac0..0xcd5ac1]
+      Name: main.testArrayOfMaps
+      OutOfLinePCRanges: [0xcd6440..0xcd6441]
       InlinePCRanges: []
       Variables:
         - Name: m
-          Type: 108 GoMapType map[uint8]uint8
+          Type: 114 ArrayType [2]map[string]int
           Locations:
-            - Range: 0xcd5ac0..0xcd5ac1
-              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+            - Range: 0xcd6440..0xcd6441
+              Pieces: [{Size: 16, Op: {CfaOffset: 0}}]
           IsParameter: true
           IsReturn: false
     - ID: 62
-      Name: main.testMapWithSmallKeyAndValueMassive
-      OutOfLinePCRanges: [0xcd5ae0..0xcd5ae1]
+      Name: main.testPointerToMap
+      OutOfLinePCRanges: [0xcd6460..0xcd6461]
       InlinePCRanges: []
       Variables:
         - Name: m
-          Type: 108 GoMapType map[uint8]uint8
+          Type: 115 PointerType *map[string]int
           Locations:
-            - Range: 0xcd5ae0..0xcd5ae1
+            - Range: 0xcd6460..0xcd6461
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
     - ID: 63
-      Name: main.testMapSmallKeySmallValue
-      OutOfLinePCRanges: [0xcd5b00..0xcd5b01]
+      Name: main.testMapIntToInt
+      OutOfLinePCRanges: [0xcd6480..0xcd6481]
       InlinePCRanges: []
       Variables:
         - Name: m
-          Type: 108 GoMapType map[uint8]uint8
+          Type: 89 GoMapType map[int]int
           Locations:
-            - Range: 0xcd5b00..0xcd5b01
+            - Range: 0xcd6480..0xcd6481
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
     - ID: 64
-      Name: main.testMapSmallKeyLargeValue
-      OutOfLinePCRanges: [0xcd5b20..0xcd5b21]
+      Name: main.testMapMassive
+      OutOfLinePCRanges: [0xcd64a0..0xcd64a1]
       InlinePCRanges: []
       Variables:
-        - Name: m
-          Type: 113 GoMapType map[uint8][4]int
+        - Name: redactMyEntries
+          Type: 116 GoMapType map[string][]main.structWithMap
           Locations:
-            - Range: 0xcd5b20..0xcd5b21
+            - Range: 0xcd64a0..0xcd64a1
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
     - ID: 65
-      Name: main.testMapLargeKeySmallValue
-      OutOfLinePCRanges: [0xcd5b40..0xcd5b41]
+      Name: main.testMapEmbeddedMaps
+      OutOfLinePCRanges: [0xcd64c0..0xcd64c1]
       InlinePCRanges: []
       Variables:
         - Name: m
-          Type: 118 GoMapType map[[4]int]uint8
+          Type: 116 GoMapType map[string][]main.structWithMap
           Locations:
-            - Range: 0xcd5b40..0xcd5b41
+            - Range: 0xcd64c0..0xcd64c1
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
     - ID: 66
-      Name: main.testMapLargeKeyLargeValue
-      OutOfLinePCRanges: [0xcd5b60..0xcd5b61]
+      Name: main.testMapWithLinkedList
+      OutOfLinePCRanges: [0xcd64e0..0xcd64e1]
       InlinePCRanges: []
       Variables:
         - Name: m
-          Type: 123 GoMapType map[[4]int][4]int
+          Type: 121 GoMapType map[bool]main.node
           Locations:
-            - Range: 0xcd5b60..0xcd5b61
+            - Range: 0xcd64e0..0xcd64e1
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
     - ID: 67
+      Name: main.testMapWithSmallValue
+      OutOfLinePCRanges: [0xcd6500..0xcd6501]
+      InlinePCRanges: []
+      Variables:
+        - Name: m
+          Type: 126 GoMapType map[int]uint8
+          Locations:
+            - Range: 0xcd6500..0xcd6501
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+          IsParameter: true
+          IsReturn: false
+    - ID: 68
+      Name: main.testMapWithSmallValueMassive
+      OutOfLinePCRanges: [0xcd6520..0xcd6521]
+      InlinePCRanges: []
+      Variables:
+        - Name: redactMyEntries
+          Type: 126 GoMapType map[int]uint8
+          Locations:
+            - Range: 0xcd6520..0xcd6521
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+          IsParameter: true
+          IsReturn: false
+    - ID: 69
+      Name: main.testMapWithSmallKeyAndValue
+      OutOfLinePCRanges: [0xcd6540..0xcd6541]
+      InlinePCRanges: []
+      Variables:
+        - Name: m
+          Type: 131 GoMapType map[uint8]uint8
+          Locations:
+            - Range: 0xcd6540..0xcd6541
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+          IsParameter: true
+          IsReturn: false
+    - ID: 70
+      Name: main.testMapWithSmallKeyAndValueMassive
+      OutOfLinePCRanges: [0xcd6560..0xcd6561]
+      InlinePCRanges: []
+      Variables:
+        - Name: m
+          Type: 131 GoMapType map[uint8]uint8
+          Locations:
+            - Range: 0xcd6560..0xcd6561
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+          IsParameter: true
+          IsReturn: false
+    - ID: 71
+      Name: main.testMapSmallKeySmallValue
+      OutOfLinePCRanges: [0xcd6580..0xcd6581]
+      InlinePCRanges: []
+      Variables:
+        - Name: m
+          Type: 131 GoMapType map[uint8]uint8
+          Locations:
+            - Range: 0xcd6580..0xcd6581
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+          IsParameter: true
+          IsReturn: false
+    - ID: 72
+      Name: main.testMapSmallKeyLargeValue
+      OutOfLinePCRanges: [0xcd65a0..0xcd65a1]
+      InlinePCRanges: []
+      Variables:
+        - Name: m
+          Type: 136 GoMapType map[uint8][4]int
+          Locations:
+            - Range: 0xcd65a0..0xcd65a1
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+          IsParameter: true
+          IsReturn: false
+    - ID: 73
+      Name: main.testMapLargeKeySmallValue
+      OutOfLinePCRanges: [0xcd65c0..0xcd65c1]
+      InlinePCRanges: []
+      Variables:
+        - Name: m
+          Type: 141 GoMapType map[[4]int]uint8
+          Locations:
+            - Range: 0xcd65c0..0xcd65c1
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+          IsParameter: true
+          IsReturn: false
+    - ID: 74
+      Name: main.testMapLargeKeyLargeValue
+      OutOfLinePCRanges: [0xcd65e0..0xcd65e1]
+      InlinePCRanges: []
+      Variables:
+        - Name: m
+          Type: 146 GoMapType map[[4]int][4]int
+          Locations:
+            - Range: 0xcd65e0..0xcd65e1
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+          IsParameter: true
+          IsReturn: false
+    - ID: 75
       Name: main.testCombinedByte
-      OutOfLinePCRanges: [0xcd72a0..0xcd72a1]
+      OutOfLinePCRanges: [0xcd7d20..0xcd7d21]
       InlinePCRanges: []
       Variables:
         - Name: w
           Type: 3 BaseType uint8
           Locations:
-            - Range: 0xcd72a0..0xcd72a1
+            - Range: 0xcd7d20..0xcd7d21
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
         - Name: x
           Type: 3 BaseType uint8
           Locations:
-            - Range: 0xcd72a0..0xcd72a1
+            - Range: 0xcd7d20..0xcd7d21
               Pieces: [{Size: 1, Op: {RegNo: 3, Shift: 0}}]
           IsParameter: true
           IsReturn: false
         - Name: y
           Type: 17 BaseType float32
           Locations:
-            - Range: 0xcd72a0..0xcd72a1
+            - Range: 0xcd7d20..0xcd7d21
               Pieces: [{Size: 4, Op: {RegNo: 17, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 68
+    - ID: 76
       Name: main.testMultipleSimpleParams
-      OutOfLinePCRanges: [0xcd7460..0xcd7461]
+      OutOfLinePCRanges: [0xcd7ee0..0xcd7ee1]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 4 BaseType bool
           Locations:
-            - Range: 0xcd7460..0xcd7461
+            - Range: 0xcd7ee0..0xcd7ee1
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
         - Name: b
           Type: 3 BaseType uint8
           Locations:
-            - Range: 0xcd7460..0xcd7461
+            - Range: 0xcd7ee0..0xcd7ee1
               Pieces: [{Size: 1, Op: {RegNo: 3, Shift: 0}}]
           IsParameter: true
           IsReturn: false
         - Name: c
           Type: 10 BaseType int32
           Locations:
-            - Range: 0xcd7460..0xcd7461
+            - Range: 0xcd7ee0..0xcd7ee1
               Pieces: [{Size: 4, Op: {RegNo: 2, Shift: 0}}]
           IsParameter: true
           IsReturn: false
         - Name: d
           Type: 16 BaseType uint
           Locations:
-            - Range: 0xcd7460..0xcd7461
+            - Range: 0xcd7ee0..0xcd7ee1
               Pieces: [{Size: 8, Op: {RegNo: 5, Shift: 0}}]
           IsParameter: true
           IsReturn: false
         - Name: e
           Type: 9 GoStringHeaderType string
           Locations:
-            - Range: 0xcd7460..0xcd7461
+            - Range: 0xcd7ee0..0xcd7ee1
               Pieces:
                 - Size: 8
                   Op: {RegNo: 4, Shift: 0}
@@ -2480,39 +2718,39 @@ Subprograms:
                   Op: {RegNo: 8, Shift: 0}
           IsParameter: true
           IsReturn: false
-    - ID: 69
+    - ID: 77
       Name: main.testChannel
-      OutOfLinePCRanges: [0xcd7680..0xcd7681]
+      OutOfLinePCRanges: [0xcd8100..0xcd8101]
       InlinePCRanges: []
       Variables:
         - Name: c
-          Type: 128 GoChannelType chan bool
+          Type: 151 GoChannelType chan bool
           Locations:
-            - Range: 0xcd7680..0xcd7681
+            - Range: 0xcd8100..0xcd8101
               Pieces: [{Size: 0, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 70
+    - ID: 78
       Name: main.testPointerToSimpleStruct
-      OutOfLinePCRanges: [0xcd7840..0xcd7841]
+      OutOfLinePCRanges: [0xcd82c0..0xcd82c1]
       InlinePCRanges: []
       Variables:
         - Name: a
-          Type: 129 PointerType *main.structWithTwoValues
+          Type: 152 PointerType *main.structWithTwoValues
           Locations:
-            - Range: 0xcd7840..0xcd7841
+            - Range: 0xcd82c0..0xcd82c1
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 71
+    - ID: 79
       Name: main.testLinkedList
-      OutOfLinePCRanges: [0xcd7860..0xcd7861]
+      OutOfLinePCRanges: [0xcd82e0..0xcd82e1]
       InlinePCRanges: []
       Variables:
         - Name: a
-          Type: 131 StructureType main.node
+          Type: 154 StructureType main.node
           Locations:
-            - Range: 0xcd7860..0xcd7861
+            - Range: 0xcd82e0..0xcd82e1
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -2520,273 +2758,94 @@ Subprograms:
                   Op: {RegNo: 3, Shift: 0}
           IsParameter: true
           IsReturn: false
-    - ID: 72
+    - ID: 80
       Name: main.testPointerLoop
-      OutOfLinePCRanges: [0xcd7880..0xcd7881]
+      OutOfLinePCRanges: [0xcd8300..0xcd8301]
       InlinePCRanges: []
       Variables:
         - Name: a
-          Type: 132 PointerType *main.node
+          Type: 155 PointerType *main.node
           Locations:
-            - Range: 0xcd7880..0xcd7881
+            - Range: 0xcd8300..0xcd8301
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 73
+    - ID: 81
       Name: main.testUnsafePointer
-      OutOfLinePCRanges: [0xcd78a0..0xcd78a1]
+      OutOfLinePCRanges: [0xcd8320..0xcd8321]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 14 VoidPointerType unsafe.Pointer
           Locations:
-            - Range: 0xcd78a0..0xcd78a1
+            - Range: 0xcd8320..0xcd8321
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 74
+    - ID: 82
       Name: main.testUintPointer
-      OutOfLinePCRanges: [0xcd78e0..0xcd78e1]
+      OutOfLinePCRanges: [0xcd8360..0xcd8361]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 34 PointerType *uint
           Locations:
-            - Range: 0xcd78e0..0xcd78e1
+            - Range: 0xcd8360..0xcd8361
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 75
+    - ID: 83
       Name: main.testStringPointer
-      OutOfLinePCRanges: [0xcd79c0..0xcd79c1]
+      OutOfLinePCRanges: [0xcd8440..0xcd8441]
       InlinePCRanges: []
       Variables:
         - Name: z
           Type: 22 PointerType *string
           Locations:
-            - Range: 0xcd79c0..0xcd79c1
+            - Range: 0xcd8440..0xcd8441
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 76
+    - ID: 84
       Name: main.testNilPointer
-      OutOfLinePCRanges: [0xcd7a00..0xcd7a01]
+      OutOfLinePCRanges: [0xcd8480..0xcd8481]
       InlinePCRanges: []
       Variables:
         - Name: z
           Type: 11 PointerType *bool
           Locations:
-            - Range: 0xcd7a00..0xcd7a01
+            - Range: 0xcd8480..0xcd8481
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
         - Name: a
           Type: 16 BaseType uint
           Locations:
-            - Range: 0xcd7a00..0xcd7a01
+            - Range: 0xcd8480..0xcd8481
               Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 77
+    - ID: 85
       Name: main.testCycle
-      OutOfLinePCRanges: [0xcd7a40..0xcd7a41]
+      OutOfLinePCRanges: [0xcd84c0..0xcd84c1]
       InlinePCRanges: []
       Variables:
         - Name: t
-          Type: 133 PointerType *main.t
+          Type: 156 PointerType *main.t
           Locations:
-            - Range: 0xcd7a40..0xcd7a41
+            - Range: 0xcd84c0..0xcd84c1
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 78
-      Name: main.testUintSlice
-      OutOfLinePCRanges: [0xcd7f60..0xcd7f61]
-      InlinePCRanges: []
-      Variables:
-        - Name: u
-          Type: 135 GoSliceHeaderType []uint
-          Locations:
-            - Range: 0xcd7f60..0xcd7f61
-              Pieces:
-                - Size: 8
-                  Op: {RegNo: 0, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 3, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 2, Shift: 0}
-          IsParameter: true
-          IsReturn: false
-    - ID: 79
-      Name: main.testEmptySlice
-      OutOfLinePCRanges: [0xcd7f80..0xcd7f81]
-      InlinePCRanges: []
-      Variables:
-        - Name: u
-          Type: 135 GoSliceHeaderType []uint
-          Locations:
-            - Range: 0xcd7f80..0xcd7f81
-              Pieces:
-                - Size: 8
-                  Op: {RegNo: 0, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 3, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 2, Shift: 0}
-          IsParameter: true
-          IsReturn: false
-    - ID: 80
-      Name: main.testSliceOfSlices
-      OutOfLinePCRanges: [0xcd7fa0..0xcd7fa1]
-      InlinePCRanges: []
-      Variables:
-        - Name: u
-          Type: 136 GoSliceHeaderType [][]uint
-          Locations:
-            - Range: 0xcd7fa0..0xcd7fa1
-              Pieces:
-                - Size: 8
-                  Op: {RegNo: 0, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 3, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 2, Shift: 0}
-          IsParameter: true
-          IsReturn: false
-    - ID: 81
-      Name: main.testStructSlice
-      OutOfLinePCRanges: [0xcd7fc0..0xcd7fc1]
-      InlinePCRanges: []
-      Variables:
-        - Name: xs
-          Type: 138 GoSliceHeaderType []main.structWithNoStrings
-          Locations:
-            - Range: 0xcd7fc0..0xcd7fc1
-              Pieces:
-                - Size: 8
-                  Op: {RegNo: 0, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 3, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 2, Shift: 0}
-          IsParameter: true
-          IsReturn: false
-        - Name: a
-          Type: 7 BaseType int
-          Locations:
-            - Range: 0xcd7fc0..0xcd7fc1
-              Pieces: [{Size: 8, Op: {RegNo: 5, Shift: 0}}]
-          IsParameter: true
-          IsReturn: false
-    - ID: 82
-      Name: main.testEmptySliceOfStructs
-      OutOfLinePCRanges: [0xcd7fe0..0xcd7fe1]
-      InlinePCRanges: []
-      Variables:
-        - Name: xs
-          Type: 138 GoSliceHeaderType []main.structWithNoStrings
-          Locations:
-            - Range: 0xcd7fe0..0xcd7fe1
-              Pieces:
-                - Size: 8
-                  Op: {RegNo: 0, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 3, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 2, Shift: 0}
-          IsParameter: true
-          IsReturn: false
-        - Name: a
-          Type: 7 BaseType int
-          Locations:
-            - Range: 0xcd7fe0..0xcd7fe1
-              Pieces: [{Size: 8, Op: {RegNo: 5, Shift: 0}}]
-          IsParameter: true
-          IsReturn: false
-    - ID: 83
-      Name: main.testNilSliceOfStructs
-      OutOfLinePCRanges: [0xcd8000..0xcd8001]
-      InlinePCRanges: []
-      Variables:
-        - Name: xs
-          Type: 138 GoSliceHeaderType []main.structWithNoStrings
-          Locations:
-            - Range: 0xcd8000..0xcd8001
-              Pieces:
-                - Size: 8
-                  Op: {RegNo: 0, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 3, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 2, Shift: 0}
-          IsParameter: true
-          IsReturn: false
-        - Name: a
-          Type: 7 BaseType int
-          Locations:
-            - Range: 0xcd8000..0xcd8001
-              Pieces: [{Size: 8, Op: {RegNo: 5, Shift: 0}}]
-          IsParameter: true
-          IsReturn: false
-    - ID: 84
-      Name: main.testStringSlice
-      OutOfLinePCRanges: [0xcd8020..0xcd8021]
-      InlinePCRanges: []
-      Variables:
-        - Name: s
-          Type: 141 GoSliceHeaderType []string
-          Locations:
-            - Range: 0xcd8020..0xcd8021
-              Pieces:
-                - Size: 8
-                  Op: {RegNo: 0, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 3, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 2, Shift: 0}
-          IsParameter: true
-          IsReturn: false
-    - ID: 85
-      Name: main.testNilSliceWithOtherParams
-      OutOfLinePCRanges: [0xcd8040..0xcd8041]
-      InlinePCRanges: []
-      Variables:
-        - Name: a
-          Type: 15 BaseType int8
-          Locations:
-            - Range: 0xcd8040..0xcd8041
-              Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
-          IsParameter: true
-          IsReturn: false
-        - Name: s
-          Type: 142 GoSliceHeaderType []bool
-          Locations:
-            - Range: 0xcd8040..0xcd8041
-              Pieces:
-                - Size: 8
-                  Op: {RegNo: 3, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 2, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 5, Shift: 0}
-          IsParameter: true
-          IsReturn: false
-        - Name: x
-          Type: 16 BaseType uint
-          Locations:
-            - Range: 0xcd8040..0xcd8041
-              Pieces: [{Size: 8, Op: {RegNo: 4, Shift: 0}}]
-          IsParameter: true
-          IsReturn: false
     - ID: 86
-      Name: main.testNilSlice
-      OutOfLinePCRanges: [0xcd8060..0xcd8061]
+      Name: main.testUintSlice
+      OutOfLinePCRanges: [0xcd89e0..0xcd89e1]
       InlinePCRanges: []
       Variables:
-        - Name: xs
-          Type: 143 GoSliceHeaderType []uint16
+        - Name: u
+          Type: 158 GoSliceHeaderType []uint
           Locations:
-            - Range: 0xcd8060..0xcd8061
+            - Range: 0xcd89e0..0xcd89e1
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -2797,14 +2856,14 @@ Subprograms:
           IsParameter: true
           IsReturn: false
     - ID: 87
-      Name: main.testVeryLargeSlice
-      OutOfLinePCRanges: [0xcd8080..0xcd8081]
+      Name: main.testEmptySlice
+      OutOfLinePCRanges: [0xcd8a00..0xcd8a01]
       InlinePCRanges: []
       Variables:
-        - Name: xs
-          Type: 135 GoSliceHeaderType []uint
+        - Name: u
+          Type: 158 GoSliceHeaderType []uint
           Locations:
-            - Range: 0xcd8080..0xcd8081
+            - Range: 0xcd8a00..0xcd8a01
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -2815,24 +2874,203 @@ Subprograms:
           IsParameter: true
           IsReturn: false
     - ID: 88
+      Name: main.testSliceOfSlices
+      OutOfLinePCRanges: [0xcd8a20..0xcd8a21]
+      InlinePCRanges: []
+      Variables:
+        - Name: u
+          Type: 159 GoSliceHeaderType [][]uint
+          Locations:
+            - Range: 0xcd8a20..0xcd8a21
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 0, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 3, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 2, Shift: 0}
+          IsParameter: true
+          IsReturn: false
+    - ID: 89
+      Name: main.testStructSlice
+      OutOfLinePCRanges: [0xcd8a40..0xcd8a41]
+      InlinePCRanges: []
+      Variables:
+        - Name: xs
+          Type: 161 GoSliceHeaderType []main.structWithNoStrings
+          Locations:
+            - Range: 0xcd8a40..0xcd8a41
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 0, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 3, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 2, Shift: 0}
+          IsParameter: true
+          IsReturn: false
+        - Name: a
+          Type: 7 BaseType int
+          Locations:
+            - Range: 0xcd8a40..0xcd8a41
+              Pieces: [{Size: 8, Op: {RegNo: 5, Shift: 0}}]
+          IsParameter: true
+          IsReturn: false
+    - ID: 90
+      Name: main.testEmptySliceOfStructs
+      OutOfLinePCRanges: [0xcd8a60..0xcd8a61]
+      InlinePCRanges: []
+      Variables:
+        - Name: xs
+          Type: 161 GoSliceHeaderType []main.structWithNoStrings
+          Locations:
+            - Range: 0xcd8a60..0xcd8a61
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 0, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 3, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 2, Shift: 0}
+          IsParameter: true
+          IsReturn: false
+        - Name: a
+          Type: 7 BaseType int
+          Locations:
+            - Range: 0xcd8a60..0xcd8a61
+              Pieces: [{Size: 8, Op: {RegNo: 5, Shift: 0}}]
+          IsParameter: true
+          IsReturn: false
+    - ID: 91
+      Name: main.testNilSliceOfStructs
+      OutOfLinePCRanges: [0xcd8a80..0xcd8a81]
+      InlinePCRanges: []
+      Variables:
+        - Name: xs
+          Type: 161 GoSliceHeaderType []main.structWithNoStrings
+          Locations:
+            - Range: 0xcd8a80..0xcd8a81
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 0, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 3, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 2, Shift: 0}
+          IsParameter: true
+          IsReturn: false
+        - Name: a
+          Type: 7 BaseType int
+          Locations:
+            - Range: 0xcd8a80..0xcd8a81
+              Pieces: [{Size: 8, Op: {RegNo: 5, Shift: 0}}]
+          IsParameter: true
+          IsReturn: false
+    - ID: 92
+      Name: main.testStringSlice
+      OutOfLinePCRanges: [0xcd8aa0..0xcd8aa1]
+      InlinePCRanges: []
+      Variables:
+        - Name: s
+          Type: 164 GoSliceHeaderType []string
+          Locations:
+            - Range: 0xcd8aa0..0xcd8aa1
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 0, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 3, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 2, Shift: 0}
+          IsParameter: true
+          IsReturn: false
+    - ID: 93
+      Name: main.testNilSliceWithOtherParams
+      OutOfLinePCRanges: [0xcd8ac0..0xcd8ac1]
+      InlinePCRanges: []
+      Variables:
+        - Name: a
+          Type: 15 BaseType int8
+          Locations:
+            - Range: 0xcd8ac0..0xcd8ac1
+              Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
+          IsParameter: true
+          IsReturn: false
+        - Name: s
+          Type: 165 GoSliceHeaderType []bool
+          Locations:
+            - Range: 0xcd8ac0..0xcd8ac1
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 3, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 2, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 5, Shift: 0}
+          IsParameter: true
+          IsReturn: false
+        - Name: x
+          Type: 16 BaseType uint
+          Locations:
+            - Range: 0xcd8ac0..0xcd8ac1
+              Pieces: [{Size: 8, Op: {RegNo: 4, Shift: 0}}]
+          IsParameter: true
+          IsReturn: false
+    - ID: 94
+      Name: main.testNilSlice
+      OutOfLinePCRanges: [0xcd8ae0..0xcd8ae1]
+      InlinePCRanges: []
+      Variables:
+        - Name: xs
+          Type: 166 GoSliceHeaderType []uint16
+          Locations:
+            - Range: 0xcd8ae0..0xcd8ae1
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 0, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 3, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 2, Shift: 0}
+          IsParameter: true
+          IsReturn: false
+    - ID: 95
+      Name: main.testVeryLargeSlice
+      OutOfLinePCRanges: [0xcd8b00..0xcd8b01]
+      InlinePCRanges: []
+      Variables:
+        - Name: xs
+          Type: 158 GoSliceHeaderType []uint
+          Locations:
+            - Range: 0xcd8b00..0xcd8b01
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 0, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 3, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 2, Shift: 0}
+          IsParameter: true
+          IsReturn: false
+    - ID: 96
       Name: main.stackC
-      OutOfLinePCRanges: [0xcd83c0..0xcd8412]
+      OutOfLinePCRanges: [0xcd8e40..0xcd8e92]
       InlinePCRanges: []
       Variables:
         - Name: ~r0
           Type: 9 GoStringHeaderType string
-          Locations: [{Range: 0xcd83c0..0xcd8412, Pieces: []}]
+          Locations: [{Range: 0xcd8e40..0xcd8e92, Pieces: []}]
           IsParameter: true
           IsReturn: true
-    - ID: 89
+    - ID: 97
       Name: main.testSingleString
-      OutOfLinePCRanges: [0xcd8420..0xcd8421]
+      OutOfLinePCRanges: [0xcd8ea0..0xcd8ea1]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 9 GoStringHeaderType string
           Locations:
-            - Range: 0xcd8420..0xcd8421
+            - Range: 0xcd8ea0..0xcd8ea1
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -2840,15 +3078,15 @@ Subprograms:
                   Op: {RegNo: 3, Shift: 0}
           IsParameter: true
           IsReturn: false
-    - ID: 90
+    - ID: 98
       Name: main.testThreeStrings
-      OutOfLinePCRanges: [0xcd8440..0xcd8441]
+      OutOfLinePCRanges: [0xcd8ec0..0xcd8ec1]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 9 GoStringHeaderType string
           Locations:
-            - Range: 0xcd8440..0xcd8441
+            - Range: 0xcd8ec0..0xcd8ec1
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -2859,7 +3097,7 @@ Subprograms:
         - Name: y
           Type: 9 GoStringHeaderType string
           Locations:
-            - Range: 0xcd8440..0xcd8441
+            - Range: 0xcd8ec0..0xcd8ec1
               Pieces:
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
@@ -2870,7 +3108,7 @@ Subprograms:
         - Name: z
           Type: 9 GoStringHeaderType string
           Locations:
-            - Range: 0xcd8440..0xcd8441
+            - Range: 0xcd8ec0..0xcd8ec1
               Pieces:
                 - Size: 8
                   Op: {RegNo: 4, Shift: 0}
@@ -2878,15 +3116,15 @@ Subprograms:
                   Op: {RegNo: 8, Shift: 0}
           IsParameter: true
           IsReturn: false
-    - ID: 91
+    - ID: 99
       Name: main.testThreeStringsInStruct
-      OutOfLinePCRanges: [0xcd8460..0xcd847f]
+      OutOfLinePCRanges: [0xcd8ee0..0xcd8eff]
       InlinePCRanges: []
       Variables:
         - Name: a
-          Type: 144 StructureType main.threeStringStruct
+          Type: 167 StructureType main.threeStringStruct
           Locations:
-            - Range: 0xcd8460..0xcd847f
+            - Range: 0xcd8ee0..0xcd8eff
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -2902,39 +3140,39 @@ Subprograms:
                   Op: {RegNo: 8, Shift: 0}
           IsParameter: true
           IsReturn: false
-    - ID: 92
+    - ID: 100
       Name: main.testThreeStringsInStructPointer
-      OutOfLinePCRanges: [0xcd8480..0xcd8481]
+      OutOfLinePCRanges: [0xcd8f00..0xcd8f01]
       InlinePCRanges: []
       Variables:
         - Name: a
-          Type: 145 PointerType *main.threeStringStruct
+          Type: 168 PointerType *main.threeStringStruct
           Locations:
-            - Range: 0xcd8480..0xcd8481
+            - Range: 0xcd8f00..0xcd8f01
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 93
+    - ID: 101
       Name: main.testOneStringInStructPointer
-      OutOfLinePCRanges: [0xcd84a0..0xcd84a1]
+      OutOfLinePCRanges: [0xcd8f20..0xcd8f21]
       InlinePCRanges: []
       Variables:
         - Name: a
-          Type: 146 PointerType *main.oneStringStruct
+          Type: 169 PointerType *main.oneStringStruct
           Locations:
-            - Range: 0xcd84a0..0xcd84a1
+            - Range: 0xcd8f20..0xcd8f21
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 94
+    - ID: 102
       Name: main.testMassiveString
-      OutOfLinePCRanges: [0xcd84c0..0xcd84c1]
+      OutOfLinePCRanges: [0xcd8f40..0xcd8f41]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 9 GoStringHeaderType string
           Locations:
-            - Range: 0xcd84c0..0xcd84c1
+            - Range: 0xcd8f40..0xcd8f41
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -2942,15 +3180,15 @@ Subprograms:
                   Op: {RegNo: 3, Shift: 0}
           IsParameter: true
           IsReturn: false
-    - ID: 95
+    - ID: 103
       Name: main.testUnitializedString
-      OutOfLinePCRanges: [0xcd84e0..0xcd84e1]
+      OutOfLinePCRanges: [0xcd8f60..0xcd8f61]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 9 GoStringHeaderType string
           Locations:
-            - Range: 0xcd84e0..0xcd84e1
+            - Range: 0xcd8f60..0xcd8f61
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -2958,15 +3196,15 @@ Subprograms:
                   Op: {RegNo: 3, Shift: 0}
           IsParameter: true
           IsReturn: false
-    - ID: 96
+    - ID: 104
       Name: main.testEmptyString
-      OutOfLinePCRanges: [0xcd8500..0xcd8501]
+      OutOfLinePCRanges: [0xcd8f80..0xcd8f81]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 9 GoStringHeaderType string
           Locations:
-            - Range: 0xcd8500..0xcd8501
+            - Range: 0xcd8f80..0xcd8f81
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -2974,15 +3212,15 @@ Subprograms:
                   Op: {RegNo: 3, Shift: 0}
           IsParameter: true
           IsReturn: false
-    - ID: 97
+    - ID: 105
       Name: main.testStruct
-      OutOfLinePCRanges: [0xcd8780..0xcd87a3]
+      OutOfLinePCRanges: [0xcd9200..0xcd9223]
       InlinePCRanges: []
       Variables:
         - Name: x
-          Type: 148 StructureType main.aStruct
+          Type: 171 StructureType main.aStruct
           Locations:
-            - Range: 0xcd8780..0xcd87a3
+            - Range: 0xcd9200..0xcd9223
               Pieces:
                 - Size: 1
                   Op: {RegNo: 0, Shift: 0}
@@ -3000,580 +3238,860 @@ Subprograms:
                   Op: {RegNo: 9, Shift: 0}
           IsParameter: true
           IsReturn: false
-    - ID: 98
+    - ID: 106
       Name: main.testEmptyStruct
-      OutOfLinePCRanges: [0xcd8900..0xcd8901]
+      OutOfLinePCRanges: [0xcd9380..0xcd9381]
       InlinePCRanges: []
       Variables:
         - Name: e
-          Type: 150 StructureType main.emptyStruct
-          Locations: [{Range: 0xcd8900..0xcd8901, Pieces: []}]
+          Type: 173 StructureType main.emptyStruct
+          Locations: [{Range: 0xcd9380..0xcd9381, Pieces: []}]
           IsParameter: true
           IsReturn: false
-    - ID: 99
+    - ID: 107
       Name: main.testInlinedPrint
-      OutOfLinePCRanges: [0xcd4c00..0xcd4c62]
+      OutOfLinePCRanges: [0xcd5680..0xcd56e2]
       InlinePCRanges:
-        - Ranges: [0xcd4c91..0xcd4ccd]
-          RootRanges: [0xcd4c80..0xcd4cf1]
-        - Ranges: [0xcd4dd2..0xcd4e0e]
-          RootRanges: [0xcd4da0..0xcd4e28]
-        - Ranges: [0xcd4e5c..0xcd4e98]
-          RootRanges: [0xcd4e40..0xcd4f05]
-        - Ranges: [0xcd4f2f..0xcd4f6b]
-          RootRanges: [0xcd4f20..0xcd4f82]
+        - Ranges: [0xcd5711..0xcd574d]
+          RootRanges: [0xcd5700..0xcd5771]
+        - Ranges: [0xcd5852..0xcd588e]
+          RootRanges: [0xcd5820..0xcd58a8]
+        - Ranges: [0xcd58dc..0xcd5918]
+          RootRanges: [0xcd58c0..0xcd5985]
+        - Ranges: [0xcd59af..0xcd59eb]
+          RootRanges: [0xcd59a0..0xcd5a02]
       Variables:
         - Name: x
           Type: 7 BaseType int
           Locations:
-            - Range: 0xcd4c00..0xcd4c19
+            - Range: 0xcd5680..0xcd5699
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xcd4c91..0xcd4c9c
+            - Range: 0xcd5711..0xcd571c
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xcd4dd2..0xcd4ddd
+            - Range: 0xcd5852..0xcd585d
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xcd4e56..0xcd4e67
+            - Range: 0xcd58d6..0xcd58e7
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xcd4e67..0xcd4f05
+            - Range: 0xcd58e7..0xcd5985
               Pieces: [{Size: 8, Op: {CfaOffset: -56}}]
-            - Range: 0xcd4f20..0xcd4f3a
+            - Range: 0xcd59a0..0xcd59ba
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 100
+    - ID: 108
       Name: main.testInlinedBBB
       OutOfLinePCRanges: []
       InlinePCRanges:
-        - Ranges: [0xcd4ea6..0xcd4ede]
-          RootRanges: [0xcd4e40..0xcd4f05]
+        - Ranges: [0xcd5926..0xcd595e]
+          RootRanges: [0xcd58c0..0xcd5985]
       Variables: []
-    - ID: 101
+    - ID: 109
       Name: main.testInlinedBCA
       OutOfLinePCRanges: []
       InlinePCRanges:
-        - Ranges: [0xcd4fb3..0xcd4ff1]
-          RootRanges: [0xcd4fa0..0xcd50ae]
+        - Ranges: [0xcd5a33..0xcd5a71]
+          RootRanges: [0xcd5a20..0xcd5b2e]
       Variables: []
-    - ID: 102
+    - ID: 110
       Name: main.testInlinedBCB
       OutOfLinePCRanges: []
       InlinePCRanges:
-        - Ranges: [0xcd5066..0xcd509e]
-          RootRanges: [0xcd4fa0..0xcd50ae]
+        - Ranges: [0xcd5ae6..0xcd5b1e]
+          RootRanges: [0xcd5a20..0xcd5b2e]
       Variables: []
-    - ID: 103
+    - ID: 111
       Name: main.testInlinedSq
       OutOfLinePCRanges: []
       InlinePCRanges:
-        - Ranges: [0xcd50c1..0xcd50c5]
-          RootRanges: [0xcd50c0..0xcd50c6]
+        - Ranges: [0xcd5b41..0xcd5b45]
+          RootRanges: [0xcd5b40..0xcd5b46]
       Variables:
         - Name: x
           Type: 7 BaseType int
           Locations:
-            - Range: 0xcd50c0..0xcd50c5
+            - Range: 0xcd5b40..0xcd5b45
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 104
+    - ID: 112
       Name: main.testInlinedSumArray
       OutOfLinePCRanges: []
       InlinePCRanges:
-        - Ranges: [0xcd5105..0xcd511d]
-          RootRanges: [0xcd50e0..0xcd5123]
-        - Ranges: [0xcd51a5..0xcd51c3]
-          RootRanges: [0xcd5140..0xcd52c5]
+        - Ranges: [0xcd5b85..0xcd5b9d]
+          RootRanges: [0xcd5b60..0xcd5ba3]
+        - Ranges: [0xcd5c25..0xcd5c43]
+          RootRanges: [0xcd5bc0..0xcd5d45]
       Variables:
         - Name: a
-          Type: 63 ArrayType [5]int
+          Type: 86 ArrayType [5]int
           Locations:
-            - Range: 0xcd50ed..0xcd5123
+            - Range: 0xcd5b6d..0xcd5ba3
               Pieces: [{Size: 40, Op: {CfaOffset: -56}}]
-            - Range: 0xcd518c..0xcd52c5
+            - Range: 0xcd5c0c..0xcd5d45
               Pieces: [{Size: 40, Op: {CfaOffset: -128}}]
           IsParameter: true
           IsReturn: false
 Types:
     - __kind: PointerType
-      ID: 277
+      ID: 63
+      Name: '**main.deepSlice2'
+      ByteSize: 8
+      Pointee: 64 PointerType *main.deepSlice2
+    - __kind: PointerType
+      ID: 309
+      Name: '**main.deepSlice3'
+      ByteSize: 8
+      Pointee: 310 PointerType *main.deepSlice3
+    - __kind: PointerType
+      ID: 334
+      Name: '**main.deepSlice8'
+      ByteSize: 8
+      Pointee: 335 PointerType *main.deepSlice8
+    - __kind: PointerType
+      ID: 340
+      Name: '**main.deepSlice9'
+      ByteSize: 8
+      Pointee: 341 PointerType *main.deepSlice9
+    - __kind: PointerType
+      ID: 77
+      Name: '**main.stringType2'
+      ByteSize: 8
+      GoKind: 22
+      Pointee: 78 PointerType *main.stringType2
+    - __kind: PointerType
+      ID: 402
       Name: '**main.t'
       ByteSize: 8
-      Pointee: 133 PointerType *main.t
+      Pointee: 156 PointerType *main.t
     - __kind: PointerType
       ID: 54
       Name: '**string'
       ByteSize: 8
-      GoRuntimeType: 521056
+      GoRuntimeType: 526176
       GoKind: 22
       Pointee: 22 PointerType *string
     - __kind: PointerType
-      ID: 126
+      ID: 149
       Name: '**table<[4]int,[4]int>'
       ByteSize: 8
-      Pointee: 127 PointerType *table<[4]int,[4]int>
+      Pointee: 150 PointerType *table<[4]int,[4]int>
     - __kind: PointerType
-      ID: 121
+      ID: 144
       Name: '**table<[4]int,uint8>'
       ByteSize: 8
-      Pointee: 122 PointerType *table<[4]int,uint8>
+      Pointee: 145 PointerType *table<[4]int,uint8>
     - __kind: PointerType
-      ID: 89
+      ID: 112
       Name: '**table<[4]string,[2]int>'
       ByteSize: 8
-      Pointee: 90 PointerType *table<[4]string,[2]int>
+      Pointee: 113 PointerType *table<[4]string,[2]int>
     - __kind: PointerType
-      ID: 101
+      ID: 124
       Name: '**table<bool,main.node>'
       ByteSize: 8
-      Pointee: 102 PointerType *table<bool,main.node>
+      Pointee: 125 PointerType *table<bool,main.node>
     - __kind: PointerType
-      ID: 69
+      ID: 71
+      Name: '**table<int,*main.deepMap2>'
+      ByteSize: 8
+      Pointee: 72 PointerType *table<int,*main.deepMap2>
+    - __kind: PointerType
+      ID: 317
+      Name: '**table<int,*main.deepMap3>'
+      ByteSize: 8
+      Pointee: 318 PointerType *table<int,*main.deepMap3>
+    - __kind: PointerType
+      ID: 352
+      Name: '**table<int,*main.deepMap8>'
+      ByteSize: 8
+      Pointee: 353 PointerType *table<int,*main.deepMap8>
+    - __kind: PointerType
+      ID: 367
+      Name: '**table<int,*main.deepMap9>'
+      ByteSize: 8
+      Pointee: 368 PointerType *table<int,*main.deepMap9>
+    - __kind: PointerType
+      ID: 92
       Name: '**table<int,int>'
       ByteSize: 8
-      Pointee: 70 PointerType *table<int,int>
+      Pointee: 93 PointerType *table<int,int>
     - __kind: PointerType
-      ID: 106
+      ID: 382
+      Name: '**table<int,interface {}>'
+      ByteSize: 8
+      Pointee: 383 PointerType *table<int,interface {}>
+    - __kind: PointerType
+      ID: 129
       Name: '**table<int,uint8>'
       ByteSize: 8
-      Pointee: 107 PointerType *table<int,uint8>
+      Pointee: 130 PointerType *table<int,uint8>
     - __kind: PointerType
-      ID: 96
+      ID: 119
       Name: '**table<string,[]main.structWithMap>'
       ByteSize: 8
-      Pointee: 97 PointerType *table<string,[]main.structWithMap>
+      Pointee: 120 PointerType *table<string,[]main.structWithMap>
     - __kind: PointerType
-      ID: 84
+      ID: 107
       Name: '**table<string,[]string>'
       ByteSize: 8
-      Pointee: 85 PointerType *table<string,[]string>
+      Pointee: 108 PointerType *table<string,[]string>
     - __kind: PointerType
-      ID: 79
+      ID: 102
       Name: '**table<string,int>'
       ByteSize: 8
-      Pointee: 80 PointerType *table<string,int>
+      Pointee: 103 PointerType *table<string,int>
     - __kind: PointerType
-      ID: 74
+      ID: 97
       Name: '**table<string,main.nestedStruct>'
       ByteSize: 8
-      Pointee: 75 PointerType *table<string,main.nestedStruct>
+      Pointee: 98 PointerType *table<string,main.nestedStruct>
     - __kind: PointerType
-      ID: 116
+      ID: 139
       Name: '**table<uint8,[4]int>'
       ByteSize: 8
-      Pointee: 117 PointerType *table<uint8,[4]int>
+      Pointee: 140 PointerType *table<uint8,[4]int>
     - __kind: PointerType
-      ID: 111
+      ID: 134
       Name: '**table<uint8,uint8>'
       ByteSize: 8
-      Pointee: 112 PointerType *table<uint8,uint8>
+      Pointee: 135 PointerType *table<uint8,uint8>
     - __kind: PointerType
-      ID: 154
+      ID: 180
+      Name: '*[]*main.deepSlice2.array'
+      ByteSize: 8
+      Pointee: 179 GoSliceDataType []*main.deepSlice2.array
+    - __kind: PointerType
+      ID: 313
+      Name: '*[]*main.deepSlice3.array'
+      ByteSize: 8
+      Pointee: 312 GoSliceDataType []*main.deepSlice3.array
+    - __kind: PointerType
+      ID: 338
+      Name: '*[]*main.deepSlice8.array'
+      ByteSize: 8
+      Pointee: 337 GoSliceDataType []*main.deepSlice8.array
+    - __kind: PointerType
+      ID: 344
+      Name: '*[]*main.deepSlice9.array'
+      ByteSize: 8
+      Pointee: 343 GoSliceDataType []*main.deepSlice9.array
+    - __kind: PointerType
+      ID: 177
       Name: '*[]*string.array'
       ByteSize: 8
-      Pointee: 153 GoSliceDataType []*string.array
+      Pointee: 176 GoSliceDataType []*string.array
     - __kind: PointerType
-      ID: 258
+      ID: 294
       Name: '*[][]uint.array'
       ByteSize: 8
-      Pointee: 257 GoSliceDataType [][]uint.array
+      Pointee: 293 GoSliceDataType [][]uint.array
     - __kind: PointerType
-      ID: 264
+      ID: 300
       Name: '*[]bool.array'
       ByteSize: 8
-      Pointee: 263 GoSliceDataType []bool.array
+      Pointee: 299 GoSliceDataType []bool.array
     - __kind: PointerType
-      ID: 281
+      ID: 348
+      Name: '*[]interface {}.array'
+      ByteSize: 8
+      Pointee: 347 GoSliceDataType []interface {}.array
+    - __kind: PointerType
+      ID: 406
       Name: '*[]main.structWithMap.array'
       ByteSize: 8
-      Pointee: 280 GoSliceDataType []main.structWithMap.array
+      Pointee: 405 GoSliceDataType []main.structWithMap.array
     - __kind: PointerType
-      ID: 260
+      ID: 296
       Name: '*[]main.structWithNoStrings.array'
       ByteSize: 8
-      Pointee: 259 GoSliceDataType []main.structWithNoStrings.array
+      Pointee: 295 GoSliceDataType []main.structWithNoStrings.array
     - __kind: PointerType
-      ID: 262
+      ID: 298
       Name: '*[]string.array'
       ByteSize: 8
-      Pointee: 261 GoSliceDataType []string.array
+      Pointee: 297 GoSliceDataType []string.array
     - __kind: PointerType
-      ID: 137
+      ID: 160
       Name: '*[]uint'
       ByteSize: 8
-      Pointee: 135 GoSliceHeaderType []uint
+      Pointee: 158 GoSliceHeaderType []uint
     - __kind: PointerType
-      ID: 256
+      ID: 292
       Name: '*[]uint.array'
       ByteSize: 8
-      Pointee: 255 GoSliceDataType []uint.array
+      Pointee: 291 GoSliceDataType []uint.array
     - __kind: PointerType
-      ID: 266
+      ID: 302
       Name: '*[]uint16.array'
       ByteSize: 8
-      Pointee: 265 GoSliceDataType []uint16.array
+      Pointee: 301 GoSliceDataType []uint16.array
     - __kind: PointerType
       ID: 11
       Name: '*bool'
       ByteSize: 8
-      GoRuntimeType: 386240
+      GoRuntimeType: 390272
       GoKind: 22
       Pointee: 4 BaseType bool
     - __kind: PointerType
       ID: 33
       Name: '*error'
       ByteSize: 8
-      GoRuntimeType: 385152
+      GoRuntimeType: 389184
       GoKind: 22
       Pointee: 13 GoInterfaceType error
     - __kind: PointerType
       ID: 35
       Name: '*float32'
       ByteSize: 8
-      GoRuntimeType: 386112
+      GoRuntimeType: 390144
       GoKind: 22
       Pointee: 17 BaseType float32
     - __kind: PointerType
       ID: 25
       Name: '*float64'
       ByteSize: 8
-      GoRuntimeType: 386176
+      GoRuntimeType: 390208
       GoKind: 22
       Pointee: 18 BaseType float64
     - __kind: PointerType
       ID: 27
       Name: '*int'
       ByteSize: 8
-      GoRuntimeType: 385792
+      GoRuntimeType: 389824
       GoKind: 22
       Pointee: 7 BaseType int
     - __kind: PointerType
       ID: 30
       Name: '*int16'
       ByteSize: 8
-      GoRuntimeType: 385408
+      GoRuntimeType: 389440
       GoKind: 22
       Pointee: 31 BaseType int16
     - __kind: PointerType
       ID: 20
       Name: '*int32'
       ByteSize: 8
-      GoRuntimeType: 385536
+      GoRuntimeType: 389568
       GoKind: 22
       Pointee: 10 BaseType int32
     - __kind: PointerType
       ID: 26
       Name: '*int64'
       ByteSize: 8
-      GoRuntimeType: 385664
+      GoRuntimeType: 389696
       GoKind: 22
       Pointee: 12 BaseType int64
     - __kind: PointerType
       ID: 32
       Name: '*int8'
       ByteSize: 8
-      GoRuntimeType: 385280
+      GoRuntimeType: 389312
       GoKind: 22
       Pointee: 15 BaseType int8
     - __kind: PointerType
-      ID: 61
+      ID: 346
+      Name: '*interface {}'
+      ByteSize: 8
+      GoRuntimeType: 390400
+      GoKind: 22
+      Pointee: 81 GoEmptyInterfaceType interface {}
+    - __kind: PointerType
+      ID: 187
+      Name: '*main.deepMap2'
+      ByteSize: 8
+      GoRuntimeType: 382976
+      GoKind: 22
+      Pointee: 188 StructureType main.deepMap2
+    - __kind: PointerType
+      ID: 325
+      Name: '*main.deepMap3'
+      ByteSize: 8
+      GoRuntimeType: 382912
+      GoKind: 22
+      Pointee: 326 UnresolvedPointeeType main.deepMap3
+    - __kind: PointerType
+      ID: 73
+      Name: '*main.deepMap7'
+      ByteSize: 8
+      GoRuntimeType: 382656
+      GoKind: 22
+      Pointee: 74 StructureType main.deepMap7
+    - __kind: PointerType
+      ID: 360
+      Name: '*main.deepMap8'
+      ByteSize: 8
+      GoRuntimeType: 382592
+      GoKind: 22
+      Pointee: 361 StructureType main.deepMap8
+    - __kind: PointerType
+      ID: 375
+      Name: '*main.deepMap9'
+      ByteSize: 8
+      GoRuntimeType: 382528
+      GoKind: 22
+      Pointee: 376 StructureType main.deepMap9
+    - __kind: PointerType
+      ID: 57
+      Name: '*main.deepPtr2'
+      ByteSize: 8
+      GoRuntimeType: 383552
+      GoKind: 22
+      Pointee: 58 StructureType main.deepPtr2
+    - __kind: PointerType
+      ID: 303
+      Name: '*main.deepPtr3'
+      ByteSize: 8
+      GoRuntimeType: 383488
+      GoKind: 22
+      Pointee: 304 UnresolvedPointeeType main.deepPtr3
+    - __kind: PointerType
+      ID: 59
+      Name: '*main.deepPtr7'
+      ByteSize: 8
+      GoRuntimeType: 383232
+      GoKind: 22
+      Pointee: 60 StructureType main.deepPtr7
+    - __kind: PointerType
+      ID: 329
+      Name: '*main.deepPtr8'
+      ByteSize: 8
+      GoRuntimeType: 383168
+      GoKind: 22
+      Pointee: 330 StructureType main.deepPtr8
+    - __kind: PointerType
+      ID: 331
+      Name: '*main.deepPtr9'
+      ByteSize: 8
+      GoRuntimeType: 383104
+      GoKind: 22
+      Pointee: 332 StructureType main.deepPtr9
+    - __kind: PointerType
+      ID: 64
+      Name: '*main.deepSlice2'
+      ByteSize: 8
+      GoRuntimeType: 384128
+      GoKind: 22
+      Pointee: 178 StructureType main.deepSlice2
+    - __kind: PointerType
+      ID: 310
+      Name: '*main.deepSlice3'
+      ByteSize: 8
+      GoRuntimeType: 384064
+      GoKind: 22
+      Pointee: 311 UnresolvedPointeeType main.deepSlice3
+    - __kind: PointerType
+      ID: 65
+      Name: '*main.deepSlice7'
+      ByteSize: 8
+      GoRuntimeType: 383808
+      GoKind: 22
+      Pointee: 66 StructureType main.deepSlice7
+    - __kind: PointerType
+      ID: 335
+      Name: '*main.deepSlice8'
+      ByteSize: 8
+      GoRuntimeType: 383744
+      GoKind: 22
+      Pointee: 336 StructureType main.deepSlice8
+    - __kind: PointerType
+      ID: 341
+      Name: '*main.deepSlice9'
+      ByteSize: 8
+      GoRuntimeType: 383680
+      GoKind: 22
+      Pointee: 342 StructureType main.deepSlice9
+    - __kind: PointerType
+      ID: 84
       Name: '*main.esotericHeap'
       ByteSize: 8
-      GoRuntimeType: 380224
+      GoRuntimeType: 384256
       GoKind: 22
-      Pointee: 62 StructureType main.esotericHeap
+      Pointee: 85 StructureType main.esotericHeap
     - __kind: PointerType
-      ID: 132
+      ID: 155
       Name: '*main.node'
       ByteSize: 8
-      GoRuntimeType: 380288
+      GoRuntimeType: 384320
       GoKind: 22
-      Pointee: 131 StructureType main.node
+      Pointee: 154 StructureType main.node
     - __kind: PointerType
-      ID: 146
+      ID: 169
       Name: '*main.oneStringStruct'
       ByteSize: 8
       GoKind: 22
-      Pointee: 147 StructureType main.oneStringStruct
+      Pointee: 170 StructureType main.oneStringStruct
     - __kind: PointerType
-      ID: 203
+      ID: 75
+      Name: '*main.stringType1'
+      ByteSize: 8
+      GoKind: 22
+      Pointee: 76 GoStringHeaderType main.stringType1
+    - __kind: PointerType
+      ID: 306
+      Name: '*main.stringType1.str'
+      ByteSize: 8
+      Pointee: 305 GoStringDataType main.stringType1.str
+    - __kind: PointerType
+      ID: 78
+      Name: '*main.stringType2'
+      ByteSize: 8
+      GoKind: 22
+      Pointee: 307 UnresolvedPointeeType main.stringType2
+    - __kind: PointerType
+      ID: 239
       Name: '*main.structWithMap'
       ByteSize: 8
-      GoRuntimeType: 380160
+      GoRuntimeType: 382464
       GoKind: 22
-      Pointee: 65 StructureType main.structWithMap
+      Pointee: 88 StructureType main.structWithMap
     - __kind: PointerType
-      ID: 139
+      ID: 162
       Name: '*main.structWithNoStrings'
       ByteSize: 8
-      Pointee: 140 StructureType main.structWithNoStrings
+      Pointee: 163 StructureType main.structWithNoStrings
     - __kind: PointerType
-      ID: 129
+      ID: 152
       Name: '*main.structWithTwoValues'
       ByteSize: 8
       GoKind: 22
-      Pointee: 130 StructureType main.structWithTwoValues
+      Pointee: 153 StructureType main.structWithTwoValues
     - __kind: PointerType
-      ID: 133
+      ID: 156
       Name: '*main.t'
       ByteSize: 8
       GoKind: 22
-      Pointee: 134 GoSliceHeaderType main.t
+      Pointee: 157 GoSliceHeaderType main.t
     - __kind: PointerType
-      ID: 279
+      ID: 404
       Name: '*main.t.array'
       ByteSize: 8
-      Pointee: 278 GoSliceDataType main.t.array
+      Pointee: 403 GoSliceDataType main.t.array
     - __kind: PointerType
-      ID: 145
+      ID: 168
       Name: '*main.threeStringStruct'
       ByteSize: 8
       GoKind: 22
-      Pointee: 144 StructureType main.threeStringStruct
+      Pointee: 167 StructureType main.threeStringStruct
     - __kind: PointerType
-      ID: 124
+      ID: 147
       Name: '*map<[4]int,[4]int>'
       ByteSize: 8
-      Pointee: 125 GoSwissMapHeaderType map<[4]int,[4]int>
+      Pointee: 148 GoSwissMapHeaderType map<[4]int,[4]int>
     - __kind: PointerType
-      ID: 119
+      ID: 142
       Name: '*map<[4]int,uint8>'
       ByteSize: 8
-      Pointee: 120 GoSwissMapHeaderType map<[4]int,uint8>
+      Pointee: 143 GoSwissMapHeaderType map<[4]int,uint8>
     - __kind: PointerType
-      ID: 87
+      ID: 110
       Name: '*map<[4]string,[2]int>'
       ByteSize: 8
-      Pointee: 88 GoSwissMapHeaderType map<[4]string,[2]int>
+      Pointee: 111 GoSwissMapHeaderType map<[4]string,[2]int>
     - __kind: PointerType
-      ID: 99
+      ID: 122
       Name: '*map<bool,main.node>'
       ByteSize: 8
-      Pointee: 100 GoSwissMapHeaderType map<bool,main.node>
+      Pointee: 123 GoSwissMapHeaderType map<bool,main.node>
     - __kind: PointerType
-      ID: 67
+      ID: 69
+      Name: '*map<int,*main.deepMap2>'
+      ByteSize: 8
+      Pointee: 70 GoSwissMapHeaderType map<int,*main.deepMap2>
+    - __kind: PointerType
+      ID: 315
+      Name: '*map<int,*main.deepMap3>'
+      ByteSize: 8
+      Pointee: 316 GoSwissMapHeaderType map<int,*main.deepMap3>
+    - __kind: PointerType
+      ID: 350
+      Name: '*map<int,*main.deepMap8>'
+      ByteSize: 8
+      Pointee: 351 GoSwissMapHeaderType map<int,*main.deepMap8>
+    - __kind: PointerType
+      ID: 365
+      Name: '*map<int,*main.deepMap9>'
+      ByteSize: 8
+      Pointee: 366 GoSwissMapHeaderType map<int,*main.deepMap9>
+    - __kind: PointerType
+      ID: 90
       Name: '*map<int,int>'
       ByteSize: 8
-      Pointee: 68 GoSwissMapHeaderType map<int,int>
+      Pointee: 91 GoSwissMapHeaderType map<int,int>
     - __kind: PointerType
-      ID: 104
+      ID: 380
+      Name: '*map<int,interface {}>'
+      ByteSize: 8
+      Pointee: 381 GoSwissMapHeaderType map<int,interface {}>
+    - __kind: PointerType
+      ID: 127
       Name: '*map<int,uint8>'
       ByteSize: 8
-      Pointee: 105 GoSwissMapHeaderType map<int,uint8>
+      Pointee: 128 GoSwissMapHeaderType map<int,uint8>
     - __kind: PointerType
-      ID: 94
+      ID: 117
       Name: '*map<string,[]main.structWithMap>'
       ByteSize: 8
-      Pointee: 95 GoSwissMapHeaderType map<string,[]main.structWithMap>
+      Pointee: 118 GoSwissMapHeaderType map<string,[]main.structWithMap>
     - __kind: PointerType
-      ID: 82
+      ID: 105
       Name: '*map<string,[]string>'
       ByteSize: 8
-      Pointee: 83 GoSwissMapHeaderType map<string,[]string>
+      Pointee: 106 GoSwissMapHeaderType map<string,[]string>
     - __kind: PointerType
-      ID: 77
+      ID: 100
       Name: '*map<string,int>'
       ByteSize: 8
-      Pointee: 78 GoSwissMapHeaderType map<string,int>
+      Pointee: 101 GoSwissMapHeaderType map<string,int>
     - __kind: PointerType
-      ID: 72
+      ID: 95
       Name: '*map<string,main.nestedStruct>'
       ByteSize: 8
-      Pointee: 73 GoSwissMapHeaderType map<string,main.nestedStruct>
+      Pointee: 96 GoSwissMapHeaderType map<string,main.nestedStruct>
     - __kind: PointerType
-      ID: 114
+      ID: 137
       Name: '*map<uint8,[4]int>'
       ByteSize: 8
-      Pointee: 115 GoSwissMapHeaderType map<uint8,[4]int>
+      Pointee: 138 GoSwissMapHeaderType map<uint8,[4]int>
     - __kind: PointerType
-      ID: 109
+      ID: 132
       Name: '*map<uint8,uint8>'
       ByteSize: 8
-      Pointee: 110 GoSwissMapHeaderType map<uint8,uint8>
+      Pointee: 133 GoSwissMapHeaderType map<uint8,uint8>
     - __kind: PointerType
-      ID: 92
+      ID: 115
       Name: '*map[string]int'
       ByteSize: 8
       GoKind: 22
-      Pointee: 76 GoMapType map[string]int
+      Pointee: 99 GoMapType map[string]int
     - __kind: PointerType
-      ID: 249
+      ID: 285
       Name: '*noalg.map.group[[4]int][4]int'
       ByteSize: 8
-      Pointee: 250 StructureType noalg.map.group[[4]int][4]int
+      Pointee: 286 StructureType noalg.map.group[[4]int][4]int
     - __kind: PointerType
-      ID: 241
+      ID: 277
       Name: '*noalg.map.group[[4]int]uint8'
       ByteSize: 8
-      Pointee: 242 StructureType noalg.map.group[[4]int]uint8
+      Pointee: 278 StructureType noalg.map.group[[4]int]uint8
     - __kind: PointerType
-      ID: 189
+      ID: 225
       Name: '*noalg.map.group[[4]string][2]int'
       ByteSize: 8
-      Pointee: 190 StructureType noalg.map.group[[4]string][2]int
+      Pointee: 226 StructureType noalg.map.group[[4]string][2]int
     - __kind: PointerType
-      ID: 208
+      ID: 244
       Name: '*noalg.map.group[bool]main.node'
       ByteSize: 8
-      Pointee: 209 StructureType noalg.map.group[bool]main.node
+      Pointee: 245 StructureType noalg.map.group[bool]main.node
     - __kind: PointerType
-      ID: 157
+      ID: 183
+      Name: '*noalg.map.group[int]*main.deepMap2'
+      ByteSize: 8
+      Pointee: 184 StructureType noalg.map.group[int]*main.deepMap2
+    - __kind: PointerType
+      ID: 321
+      Name: '*noalg.map.group[int]*main.deepMap3'
+      ByteSize: 8
+      Pointee: 322 StructureType noalg.map.group[int]*main.deepMap3
+    - __kind: PointerType
+      ID: 356
+      Name: '*noalg.map.group[int]*main.deepMap8'
+      ByteSize: 8
+      Pointee: 357 StructureType noalg.map.group[int]*main.deepMap8
+    - __kind: PointerType
+      ID: 371
+      Name: '*noalg.map.group[int]*main.deepMap9'
+      ByteSize: 8
+      Pointee: 372 StructureType noalg.map.group[int]*main.deepMap9
+    - __kind: PointerType
+      ID: 193
       Name: '*noalg.map.group[int]int'
       ByteSize: 8
-      Pointee: 158 StructureType noalg.map.group[int]int
+      Pointee: 194 StructureType noalg.map.group[int]int
     - __kind: PointerType
-      ID: 216
+      ID: 386
+      Name: '*noalg.map.group[int]interface {}'
+      ByteSize: 8
+      Pointee: 387 StructureType noalg.map.group[int]interface {}
+    - __kind: PointerType
+      ID: 252
       Name: '*noalg.map.group[int]uint8'
       ByteSize: 8
-      Pointee: 217 StructureType noalg.map.group[int]uint8
+      Pointee: 253 StructureType noalg.map.group[int]uint8
     - __kind: PointerType
-      ID: 198
+      ID: 234
       Name: '*noalg.map.group[string][]main.structWithMap'
       ByteSize: 8
-      Pointee: 199 StructureType noalg.map.group[string][]main.structWithMap
+      Pointee: 235 StructureType noalg.map.group[string][]main.structWithMap
     - __kind: PointerType
-      ID: 181
+      ID: 217
       Name: '*noalg.map.group[string][]string'
       ByteSize: 8
-      Pointee: 182 StructureType noalg.map.group[string][]string
+      Pointee: 218 StructureType noalg.map.group[string][]string
     - __kind: PointerType
-      ID: 173
+      ID: 209
       Name: '*noalg.map.group[string]int'
       ByteSize: 8
-      Pointee: 174 StructureType noalg.map.group[string]int
+      Pointee: 210 StructureType noalg.map.group[string]int
     - __kind: PointerType
-      ID: 165
+      ID: 201
       Name: '*noalg.map.group[string]main.nestedStruct'
       ByteSize: 8
-      Pointee: 166 StructureType noalg.map.group[string]main.nestedStruct
+      Pointee: 202 StructureType noalg.map.group[string]main.nestedStruct
     - __kind: PointerType
-      ID: 232
+      ID: 268
       Name: '*noalg.map.group[uint8][4]int'
       ByteSize: 8
-      Pointee: 233 StructureType noalg.map.group[uint8][4]int
+      Pointee: 269 StructureType noalg.map.group[uint8][4]int
     - __kind: PointerType
-      ID: 224
+      ID: 260
       Name: '*noalg.map.group[uint8]uint8'
       ByteSize: 8
-      Pointee: 225 StructureType noalg.map.group[uint8]uint8
+      Pointee: 261 StructureType noalg.map.group[uint8]uint8
     - __kind: PointerType
       ID: 22
       Name: '*string'
       ByteSize: 8
-      GoRuntimeType: 385216
+      GoRuntimeType: 389248
       GoKind: 22
       Pointee: 9 GoStringHeaderType string
     - __kind: PointerType
-      ID: 152
+      ID: 175
       Name: '*string.str'
       ByteSize: 8
-      Pointee: 151 GoStringDataType string.str
+      Pointee: 174 GoStringDataType string.str
     - __kind: PointerType
-      ID: 127
+      ID: 150
       Name: '*table<[4]int,[4]int>'
       ByteSize: 8
-      Pointee: 247 StructureType table<[4]int,[4]int>
+      Pointee: 283 StructureType table<[4]int,[4]int>
     - __kind: PointerType
-      ID: 122
+      ID: 145
       Name: '*table<[4]int,uint8>'
       ByteSize: 8
-      Pointee: 239 StructureType table<[4]int,uint8>
+      Pointee: 275 StructureType table<[4]int,uint8>
     - __kind: PointerType
-      ID: 90
+      ID: 113
       Name: '*table<[4]string,[2]int>'
       ByteSize: 8
-      Pointee: 187 StructureType table<[4]string,[2]int>
+      Pointee: 223 StructureType table<[4]string,[2]int>
     - __kind: PointerType
-      ID: 102
+      ID: 125
       Name: '*table<bool,main.node>'
       ByteSize: 8
-      Pointee: 206 StructureType table<bool,main.node>
+      Pointee: 242 StructureType table<bool,main.node>
     - __kind: PointerType
-      ID: 70
+      ID: 72
+      Name: '*table<int,*main.deepMap2>'
+      ByteSize: 8
+      Pointee: 181 StructureType table<int,*main.deepMap2>
+    - __kind: PointerType
+      ID: 318
+      Name: '*table<int,*main.deepMap3>'
+      ByteSize: 8
+      Pointee: 319 StructureType table<int,*main.deepMap3>
+    - __kind: PointerType
+      ID: 353
+      Name: '*table<int,*main.deepMap8>'
+      ByteSize: 8
+      Pointee: 354 StructureType table<int,*main.deepMap8>
+    - __kind: PointerType
+      ID: 368
+      Name: '*table<int,*main.deepMap9>'
+      ByteSize: 8
+      Pointee: 369 StructureType table<int,*main.deepMap9>
+    - __kind: PointerType
+      ID: 93
       Name: '*table<int,int>'
       ByteSize: 8
-      Pointee: 155 StructureType table<int,int>
+      Pointee: 191 StructureType table<int,int>
     - __kind: PointerType
-      ID: 107
+      ID: 383
+      Name: '*table<int,interface {}>'
+      ByteSize: 8
+      Pointee: 384 StructureType table<int,interface {}>
+    - __kind: PointerType
+      ID: 130
       Name: '*table<int,uint8>'
       ByteSize: 8
-      Pointee: 214 StructureType table<int,uint8>
+      Pointee: 250 StructureType table<int,uint8>
     - __kind: PointerType
-      ID: 97
+      ID: 120
       Name: '*table<string,[]main.structWithMap>'
       ByteSize: 8
-      Pointee: 196 StructureType table<string,[]main.structWithMap>
+      Pointee: 232 StructureType table<string,[]main.structWithMap>
     - __kind: PointerType
-      ID: 85
+      ID: 108
       Name: '*table<string,[]string>'
       ByteSize: 8
-      Pointee: 179 StructureType table<string,[]string>
+      Pointee: 215 StructureType table<string,[]string>
     - __kind: PointerType
-      ID: 80
+      ID: 103
       Name: '*table<string,int>'
       ByteSize: 8
-      Pointee: 171 StructureType table<string,int>
+      Pointee: 207 StructureType table<string,int>
     - __kind: PointerType
-      ID: 75
+      ID: 98
       Name: '*table<string,main.nestedStruct>'
       ByteSize: 8
-      Pointee: 163 StructureType table<string,main.nestedStruct>
+      Pointee: 199 StructureType table<string,main.nestedStruct>
     - __kind: PointerType
-      ID: 117
+      ID: 140
       Name: '*table<uint8,[4]int>'
       ByteSize: 8
-      Pointee: 230 StructureType table<uint8,[4]int>
+      Pointee: 266 StructureType table<uint8,[4]int>
     - __kind: PointerType
-      ID: 112
+      ID: 135
       Name: '*table<uint8,uint8>'
       ByteSize: 8
-      Pointee: 222 StructureType table<uint8,uint8>
+      Pointee: 258 StructureType table<uint8,uint8>
     - __kind: PointerType
       ID: 34
       Name: '*uint'
       ByteSize: 8
-      GoRuntimeType: 385856
+      GoRuntimeType: 389888
       GoKind: 22
       Pointee: 16 BaseType uint
     - __kind: PointerType
       ID: 29
       Name: '*uint16'
       ByteSize: 8
-      GoRuntimeType: 385472
+      GoRuntimeType: 389504
       GoKind: 22
       Pointee: 6 BaseType uint16
     - __kind: PointerType
       ID: 21
       Name: '*uint32'
       ByteSize: 8
-      GoRuntimeType: 385600
+      GoRuntimeType: 389632
       GoKind: 22
       Pointee: 2 BaseType uint32
     - __kind: PointerType
       ID: 28
       Name: '*uint64'
       ByteSize: 8
-      GoRuntimeType: 385728
+      GoRuntimeType: 389760
       GoKind: 22
       Pointee: 8 BaseType uint64
     - __kind: PointerType
       ID: 5
       Name: '*uint8'
       ByteSize: 8
-      GoRuntimeType: 385344
+      GoRuntimeType: 389376
       GoKind: 22
       Pointee: 3 BaseType uint8
     - __kind: PointerType
       ID: 19
       Name: '*uintptr'
       ByteSize: 8
-      GoRuntimeType: 385920
+      GoRuntimeType: 389952
       GoKind: 22
       Pointee: 1 BaseType uintptr
     - __kind: EventRootType
-      ID: 369
+      ID: 502
       Name: Probe[main.stackC]
     - __kind: EventRootType
-      ID: 326
+      ID: 459
       Name: Probe[main.testAny]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -3581,14 +4099,14 @@ Types:
         - Name: a
           Offset: 1
           Expression:
-            Type: 58 GoEmptyInterfaceType interface {}
+            Type: 81 GoEmptyInterfaceType interface {}
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 45, index: 0, name: a}
+                  Variable: {subprogram: 53, index: 0, name: a}
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 298
+      ID: 423
       Name: Probe[main.testArrayOfArraysOfArrays]
       ByteSize: 65
       PresenceBitsetSize: 1
@@ -3603,7 +4121,7 @@ Types:
                   Offset: 0
                   ByteSize: 64
     - __kind: EventRootType
-      ID: 296
+      ID: 421
       Name: Probe[main.testArrayOfArrays]
       ByteSize: 33
       PresenceBitsetSize: 1
@@ -3618,7 +4136,7 @@ Types:
                   Offset: 0
                   ByteSize: 32
     - __kind: EventRootType
-      ID: 334
+      ID: 467
       Name: Probe[main.testArrayOfMaps]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -3626,14 +4144,14 @@ Types:
         - Name: m
           Offset: 1
           Expression:
-            Type: 91 ArrayType [2]map[string]int
+            Type: 114 ArrayType [2]map[string]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 53, index: 0, name: m}
+                  Variable: {subprogram: 61, index: 0, name: m}
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 297
+      ID: 422
       Name: Probe[main.testArrayOfStrings]
       ByteSize: 33
       PresenceBitsetSize: 1
@@ -3648,7 +4166,7 @@ Types:
                   Offset: 0
                   ByteSize: 32
     - __kind: EventRootType
-      ID: 316
+      ID: 441
       Name: Probe[main.testBigStruct]
       ByteSize: 49
       PresenceBitsetSize: 1
@@ -3663,7 +4181,7 @@ Types:
                   Offset: 0
                   ByteSize: 48
     - __kind: EventRootType
-      ID: 285
+      ID: 410
       Name: Probe[main.testBoolArray]
       ByteSize: 3
       PresenceBitsetSize: 1
@@ -3678,7 +4196,7 @@ Types:
                   Offset: 0
                   ByteSize: 2
     - __kind: EventRootType
-      ID: 282
+      ID: 407
       Name: Probe[main.testByteArray]
       ByteSize: 3
       PresenceBitsetSize: 1
@@ -3693,7 +4211,7 @@ Types:
                   Offset: 0
                   ByteSize: 2
     - __kind: EventRootType
-      ID: 350
+      ID: 483
       Name: Probe[main.testChannel]
       ByteSize: 1
       PresenceBitsetSize: 1
@@ -3701,14 +4219,14 @@ Types:
         - Name: c
           Offset: 1
           Expression:
-            Type: 128 GoChannelType chan bool
+            Type: 151 GoChannelType chan bool
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 69, index: 0, name: c}
+                  Variable: {subprogram: 77, index: 0, name: c}
                   Offset: 0
                   ByteSize: 0
     - __kind: EventRootType
-      ID: 348
+      ID: 481
       Name: Probe[main.testCombinedByte]
       ByteSize: 7
       PresenceBitsetSize: 1
@@ -3719,7 +4237,7 @@ Types:
             Type: 3 BaseType uint8
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 67, index: 0, name: w}
+                  Variable: {subprogram: 75, index: 0, name: w}
                   Offset: 0
                   ByteSize: 1
         - Name: x
@@ -3728,7 +4246,7 @@ Types:
             Type: 3 BaseType uint8
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 67, index: 1, name: x}
+                  Variable: {subprogram: 75, index: 1, name: x}
                   Offset: 0
                   ByteSize: 1
         - Name: y
@@ -3737,11 +4255,11 @@ Types:
             Type: 17 BaseType float32
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 67, index: 2, name: y}
+                  Variable: {subprogram: 75, index: 2, name: y}
                   Offset: 0
                   ByteSize: 4
     - __kind: EventRootType
-      ID: 358
+      ID: 491
       Name: Probe[main.testCycle]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -3749,14 +4267,104 @@ Types:
         - Name: t
           Offset: 1
           Expression:
-            Type: 133 PointerType *main.t
+            Type: 156 PointerType *main.t
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 77, index: 0, name: t}
+                  Variable: {subprogram: 85, index: 0, name: t}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 363
+      ID: 446
+      Name: Probe[main.testDeepMap1]
+      ByteSize: 9
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: a
+          Offset: 1
+          Expression:
+            Type: 67 StructureType main.deepMap1
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 40, index: 0, name: a}
+                  Offset: 0
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 447
+      Name: Probe[main.testDeepMap7]
+      ByteSize: 9
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: a
+          Offset: 1
+          Expression:
+            Type: 73 PointerType *main.deepMap7
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 41, index: 0, name: a}
+                  Offset: 0
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 442
+      Name: Probe[main.testDeepPtr1]
+      ByteSize: 9
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: a
+          Offset: 1
+          Expression:
+            Type: 56 StructureType main.deepPtr1
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 36, index: 0, name: a}
+                  Offset: 0
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 443
+      Name: Probe[main.testDeepPtr7]
+      ByteSize: 9
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: a
+          Offset: 1
+          Expression:
+            Type: 59 PointerType *main.deepPtr7
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 37, index: 0, name: a}
+                  Offset: 0
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 444
+      Name: Probe[main.testDeepSlice1]
+      ByteSize: 25
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: a
+          Offset: 1
+          Expression:
+            Type: 61 StructureType main.deepSlice1
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 38, index: 0, name: a}
+                  Offset: 0
+                  ByteSize: 24
+    - __kind: EventRootType
+      ID: 445
+      Name: Probe[main.testDeepSlice7]
+      ByteSize: 9
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: a
+          Offset: 1
+          Expression:
+            Type: 65 PointerType *main.deepSlice7
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 39, index: 0, name: a}
+                  Offset: 0
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 496
       Name: Probe[main.testEmptySliceOfStructs]
       ByteSize: 33
       PresenceBitsetSize: 1
@@ -3764,10 +4372,10 @@ Types:
         - Name: xs
           Offset: 1
           Expression:
-            Type: 138 GoSliceHeaderType []main.structWithNoStrings
+            Type: 161 GoSliceHeaderType []main.structWithNoStrings
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 82, index: 0, name: xs}
+                  Variable: {subprogram: 90, index: 0, name: xs}
                   Offset: 0
                   ByteSize: 24
         - Name: a
@@ -3776,11 +4384,11 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 82, index: 1, name: a}
+                  Variable: {subprogram: 90, index: 1, name: a}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 360
+      ID: 493
       Name: Probe[main.testEmptySlice]
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -3788,14 +4396,14 @@ Types:
         - Name: u
           Offset: 1
           Expression:
-            Type: 135 GoSliceHeaderType []uint
+            Type: 158 GoSliceHeaderType []uint
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 79, index: 0, name: u}
+                  Variable: {subprogram: 87, index: 0, name: u}
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 377
+      ID: 510
       Name: Probe[main.testEmptyString]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -3806,11 +4414,11 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 96, index: 0, name: x}
+                  Variable: {subprogram: 104, index: 0, name: x}
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 379
+      ID: 512
       Name: Probe[main.testEmptyStruct]
       ByteSize: 1
       PresenceBitsetSize: 1
@@ -3818,14 +4426,14 @@ Types:
         - Name: e
           Offset: 1
           Expression:
-            Type: 150 StructureType main.emptyStruct
+            Type: 173 StructureType main.emptyStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 98, index: 0, name: e}
+                  Variable: {subprogram: 106, index: 0, name: e}
                   Offset: 0
                   ByteSize: 0
     - __kind: EventRootType
-      ID: 327
+      ID: 460
       Name: Probe[main.testError]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -3836,11 +4444,11 @@ Types:
             Type: 13 GoInterfaceType error
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 46, index: 0, name: e}
+                  Variable: {subprogram: 54, index: 0, name: e}
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 318
+      ID: 451
       Name: Probe[main.testEsotericHeap]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -3848,14 +4456,14 @@ Types:
         - Name: e
           Offset: 1
           Expression:
-            Type: 61 PointerType *main.esotericHeap
+            Type: 84 PointerType *main.esotericHeap
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 37, index: 0, name: e}
+                  Variable: {subprogram: 45, index: 0, name: e}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 317
+      ID: 450
       Name: Probe[main.testEsotericStack]
       ByteSize: 65
       PresenceBitsetSize: 1
@@ -3863,14 +4471,14 @@ Types:
         - Name: e
           Offset: 1
           Expression:
-            Type: 56 StructureType main.esotericStack
+            Type: 79 StructureType main.esotericStack
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 36, index: 0, name: e}
+                  Variable: {subprogram: 44, index: 0, name: e}
                   Offset: 0
                   ByteSize: 64
     - __kind: EventRootType
-      ID: 324
+      ID: 457
       Name: Probe[main.testFramelessArray]
       ByteSize: 41
       PresenceBitsetSize: 1
@@ -3878,14 +4486,14 @@ Types:
         - Name: a
           Offset: 1
           Expression:
-            Type: 63 ArrayType [5]int
+            Type: 86 ArrayType [5]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 43, index: 0, name: a}
+                  Variable: {subprogram: 51, index: 0, name: a}
                   Offset: 0
                   ByteSize: 40
     - __kind: EventRootType
-      ID: 323
+      ID: 456
       Name: Probe[main.testFrameless]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -3896,11 +4504,11 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 42, index: 0, name: x}
+                  Variable: {subprogram: 50, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 319
+      ID: 452
       Name: Probe[main.testInlinedBA]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -3911,11 +4519,11 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 38, index: 0, name: x}
+                  Variable: {subprogram: 46, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 321
+      ID: 454
       Name: Probe[main.testInlinedBBA]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -3926,14 +4534,14 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 40, index: 0, name: x}
+                  Variable: {subprogram: 48, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 381
+      ID: 514
       Name: Probe[main.testInlinedBBB]
     - __kind: EventRootType
-      ID: 320
+      ID: 453
       Name: Probe[main.testInlinedBB]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -3944,7 +4552,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 39, index: 0, name: x}
+                  Variable: {subprogram: 47, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
         - Name: y
@@ -3953,20 +4561,20 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 39, index: 1, name: y}
+                  Variable: {subprogram: 47, index: 1, name: y}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 382
+      ID: 515
       Name: Probe[main.testInlinedBCA]
     - __kind: EventRootType
-      ID: 383
+      ID: 516
       Name: Probe[main.testInlinedBCB]
     - __kind: EventRootType
-      ID: 322
+      ID: 455
       Name: Probe[main.testInlinedBC]
     - __kind: EventRootType
-      ID: 380
+      ID: 513
       Name: Probe[main.testInlinedPrint]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -3977,11 +4585,11 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 99, index: 0, name: x}
+                  Variable: {subprogram: 107, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 384
+      ID: 517
       Name: Probe[main.testInlinedSq]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -3992,11 +4600,11 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 103, index: 0, name: x}
+                  Variable: {subprogram: 111, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 385
+      ID: 518
       Name: Probe[main.testInlinedSumArray]
       ByteSize: 41
       PresenceBitsetSize: 1
@@ -4004,14 +4612,14 @@ Types:
         - Name: a
           Offset: 1
           Expression:
-            Type: 63 ArrayType [5]int
+            Type: 86 ArrayType [5]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 104, index: 0, name: a}
+                  Variable: {subprogram: 112, index: 0, name: a}
                   Offset: 0
                   ByteSize: 40
     - __kind: EventRootType
-      ID: 288
+      ID: 413
       Name: Probe[main.testInt16Array]
       ByteSize: 5
       PresenceBitsetSize: 1
@@ -4026,7 +4634,7 @@ Types:
                   Offset: 0
                   ByteSize: 4
     - __kind: EventRootType
-      ID: 289
+      ID: 414
       Name: Probe[main.testInt32Array]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -4041,7 +4649,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 290
+      ID: 415
       Name: Probe[main.testInt64Array]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -4056,7 +4664,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 287
+      ID: 412
       Name: Probe[main.testInt8Array]
       ByteSize: 3
       PresenceBitsetSize: 1
@@ -4071,7 +4679,7 @@ Types:
                   Offset: 0
                   ByteSize: 2
     - __kind: EventRootType
-      ID: 286
+      ID: 411
       Name: Probe[main.testIntArray]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -4086,7 +4694,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 325
+      ID: 458
       Name: Probe[main.testInterface]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -4094,14 +4702,14 @@ Types:
         - Name: b
           Offset: 1
           Expression:
-            Type: 64 GoInterfaceType main.behavior
+            Type: 87 GoInterfaceType main.behavior
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 44, index: 0, name: b}
+                  Variable: {subprogram: 52, index: 0, name: b}
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 352
+      ID: 485
       Name: Probe[main.testLinkedList]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -4109,14 +4717,14 @@ Types:
         - Name: a
           Offset: 1
           Expression:
-            Type: 131 StructureType main.node
+            Type: 154 StructureType main.node
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 71, index: 0, name: a}
+                  Variable: {subprogram: 79, index: 0, name: a}
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 332
+      ID: 465
       Name: Probe[main.testMapArrayToArray]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -4124,14 +4732,14 @@ Types:
         - Name: m
           Offset: 1
           Expression:
-            Type: 86 GoMapType map[[4]string][2]int
+            Type: 109 GoMapType map[[4]string][2]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 51, index: 0, name: m}
+                  Variable: {subprogram: 59, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 338
+      ID: 471
       Name: Probe[main.testMapEmbeddedMaps]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -4139,14 +4747,14 @@ Types:
         - Name: m
           Offset: 1
           Expression:
-            Type: 93 GoMapType map[string][]main.structWithMap
+            Type: 116 GoMapType map[string][]main.structWithMap
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 57, index: 0, name: m}
+                  Variable: {subprogram: 65, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 336
+      ID: 469
       Name: Probe[main.testMapIntToInt]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -4154,14 +4762,14 @@ Types:
         - Name: m
           Offset: 1
           Expression:
-            Type: 66 GoMapType map[int]int
+            Type: 89 GoMapType map[int]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 55, index: 0, name: m}
+                  Variable: {subprogram: 63, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 347
+      ID: 480
       Name: Probe[main.testMapLargeKeyLargeValue]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -4169,14 +4777,14 @@ Types:
         - Name: m
           Offset: 1
           Expression:
-            Type: 123 GoMapType map[[4]int][4]int
+            Type: 146 GoMapType map[[4]int][4]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 66, index: 0, name: m}
+                  Variable: {subprogram: 74, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 346
+      ID: 479
       Name: Probe[main.testMapLargeKeySmallValue]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -4184,14 +4792,14 @@ Types:
         - Name: m
           Offset: 1
           Expression:
-            Type: 118 GoMapType map[[4]int]uint8
+            Type: 141 GoMapType map[[4]int]uint8
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 65, index: 0, name: m}
+                  Variable: {subprogram: 73, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 337
+      ID: 470
       Name: Probe[main.testMapMassive]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -4199,14 +4807,14 @@ Types:
         - Name: redactMyEntries
           Offset: 1
           Expression:
-            Type: 93 GoMapType map[string][]main.structWithMap
+            Type: 116 GoMapType map[string][]main.structWithMap
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 56, index: 0, name: redactMyEntries}
+                  Variable: {subprogram: 64, index: 0, name: redactMyEntries}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 345
+      ID: 478
       Name: Probe[main.testMapSmallKeyLargeValue]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -4214,14 +4822,14 @@ Types:
         - Name: m
           Offset: 1
           Expression:
-            Type: 113 GoMapType map[uint8][4]int
+            Type: 136 GoMapType map[uint8][4]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 64, index: 0, name: m}
+                  Variable: {subprogram: 72, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 344
+      ID: 477
       Name: Probe[main.testMapSmallKeySmallValue]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -4229,14 +4837,14 @@ Types:
         - Name: m
           Offset: 1
           Expression:
-            Type: 108 GoMapType map[uint8]uint8
+            Type: 131 GoMapType map[uint8]uint8
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 63, index: 0, name: m}
+                  Variable: {subprogram: 71, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 330
+      ID: 463
       Name: Probe[main.testMapStringToInt]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -4244,14 +4852,14 @@ Types:
         - Name: m
           Offset: 1
           Expression:
-            Type: 76 GoMapType map[string]int
+            Type: 99 GoMapType map[string]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 49, index: 0, name: m}
+                  Variable: {subprogram: 57, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 331
+      ID: 464
       Name: Probe[main.testMapStringToSlice]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -4259,14 +4867,14 @@ Types:
         - Name: m
           Offset: 1
           Expression:
-            Type: 81 GoMapType map[string][]string
+            Type: 104 GoMapType map[string][]string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 50, index: 0, name: m}
+                  Variable: {subprogram: 58, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 329
+      ID: 462
       Name: Probe[main.testMapStringToStruct]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -4274,14 +4882,14 @@ Types:
         - Name: m
           Offset: 1
           Expression:
-            Type: 71 GoMapType map[string]main.nestedStruct
+            Type: 94 GoMapType map[string]main.nestedStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 48, index: 0, name: m}
+                  Variable: {subprogram: 56, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 339
+      ID: 472
       Name: Probe[main.testMapWithLinkedList]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -4289,14 +4897,14 @@ Types:
         - Name: m
           Offset: 1
           Expression:
-            Type: 98 GoMapType map[bool]main.node
+            Type: 121 GoMapType map[bool]main.node
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 58, index: 0, name: m}
+                  Variable: {subprogram: 66, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 343
+      ID: 476
       Name: Probe[main.testMapWithSmallKeyAndValueMassive]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -4304,14 +4912,14 @@ Types:
         - Name: m
           Offset: 1
           Expression:
-            Type: 108 GoMapType map[uint8]uint8
+            Type: 131 GoMapType map[uint8]uint8
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 62, index: 0, name: m}
+                  Variable: {subprogram: 70, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 342
+      ID: 475
       Name: Probe[main.testMapWithSmallKeyAndValue]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -4319,14 +4927,14 @@ Types:
         - Name: m
           Offset: 1
           Expression:
-            Type: 108 GoMapType map[uint8]uint8
+            Type: 131 GoMapType map[uint8]uint8
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 61, index: 0, name: m}
+                  Variable: {subprogram: 69, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 341
+      ID: 474
       Name: Probe[main.testMapWithSmallValueMassive]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -4334,14 +4942,14 @@ Types:
         - Name: redactMyEntries
           Offset: 1
           Expression:
-            Type: 103 GoMapType map[int]uint8
+            Type: 126 GoMapType map[int]uint8
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 60, index: 0, name: redactMyEntries}
+                  Variable: {subprogram: 68, index: 0, name: redactMyEntries}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 340
+      ID: 473
       Name: Probe[main.testMapWithSmallValue]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -4349,14 +4957,14 @@ Types:
         - Name: m
           Offset: 1
           Expression:
-            Type: 103 GoMapType map[int]uint8
+            Type: 126 GoMapType map[int]uint8
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 59, index: 0, name: m}
+                  Variable: {subprogram: 67, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 375
+      ID: 508
       Name: Probe[main.testMassiveString]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -4367,11 +4975,11 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 94, index: 0, name: x}
+                  Variable: {subprogram: 102, index: 0, name: x}
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 349
+      ID: 482
       Name: Probe[main.testMultipleSimpleParams]
       ByteSize: 31
       PresenceBitsetSize: 1
@@ -4382,7 +4990,7 @@ Types:
             Type: 4 BaseType bool
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 68, index: 0, name: a}
+                  Variable: {subprogram: 76, index: 0, name: a}
                   Offset: 0
                   ByteSize: 1
         - Name: b
@@ -4391,7 +4999,7 @@ Types:
             Type: 3 BaseType uint8
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 68, index: 1, name: b}
+                  Variable: {subprogram: 76, index: 1, name: b}
                   Offset: 0
                   ByteSize: 1
         - Name: c
@@ -4400,7 +5008,7 @@ Types:
             Type: 10 BaseType int32
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 68, index: 2, name: c}
+                  Variable: {subprogram: 76, index: 2, name: c}
                   Offset: 0
                   ByteSize: 4
         - Name: d
@@ -4409,7 +5017,7 @@ Types:
             Type: 16 BaseType uint
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 68, index: 3, name: d}
+                  Variable: {subprogram: 76, index: 3, name: d}
                   Offset: 0
                   ByteSize: 8
         - Name: e
@@ -4418,11 +5026,11 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 68, index: 4, name: e}
+                  Variable: {subprogram: 76, index: 4, name: e}
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 357
+      ID: 490
       Name: Probe[main.testNilPointer]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -4433,7 +5041,7 @@ Types:
             Type: 11 PointerType *bool
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 76, index: 0, name: z}
+                  Variable: {subprogram: 84, index: 0, name: z}
                   Offset: 0
                   ByteSize: 8
         - Name: a
@@ -4442,11 +5050,11 @@ Types:
             Type: 16 BaseType uint
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 76, index: 1, name: a}
+                  Variable: {subprogram: 84, index: 1, name: a}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 364
+      ID: 497
       Name: Probe[main.testNilSliceOfStructs]
       ByteSize: 33
       PresenceBitsetSize: 1
@@ -4454,10 +5062,10 @@ Types:
         - Name: xs
           Offset: 1
           Expression:
-            Type: 138 GoSliceHeaderType []main.structWithNoStrings
+            Type: 161 GoSliceHeaderType []main.structWithNoStrings
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 83, index: 0, name: xs}
+                  Variable: {subprogram: 91, index: 0, name: xs}
                   Offset: 0
                   ByteSize: 24
         - Name: a
@@ -4466,11 +5074,11 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 83, index: 1, name: a}
+                  Variable: {subprogram: 91, index: 1, name: a}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 366
+      ID: 499
       Name: Probe[main.testNilSliceWithOtherParams]
       ByteSize: 34
       PresenceBitsetSize: 1
@@ -4481,16 +5089,16 @@ Types:
             Type: 15 BaseType int8
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 85, index: 0, name: a}
+                  Variable: {subprogram: 93, index: 0, name: a}
                   Offset: 0
                   ByteSize: 1
         - Name: s
           Offset: 2
           Expression:
-            Type: 142 GoSliceHeaderType []bool
+            Type: 165 GoSliceHeaderType []bool
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 85, index: 1, name: s}
+                  Variable: {subprogram: 93, index: 1, name: s}
                   Offset: 0
                   ByteSize: 24
         - Name: x
@@ -4499,11 +5107,11 @@ Types:
             Type: 16 BaseType uint
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 85, index: 2, name: x}
+                  Variable: {subprogram: 93, index: 2, name: x}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 367
+      ID: 500
       Name: Probe[main.testNilSlice]
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -4511,14 +5119,14 @@ Types:
         - Name: xs
           Offset: 1
           Expression:
-            Type: 143 GoSliceHeaderType []uint16
+            Type: 166 GoSliceHeaderType []uint16
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 86, index: 0, name: xs}
+                  Variable: {subprogram: 94, index: 0, name: xs}
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 374
+      ID: 507
       Name: Probe[main.testOneStringInStructPointer]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -4526,14 +5134,14 @@ Types:
         - Name: a
           Offset: 1
           Expression:
-            Type: 146 PointerType *main.oneStringStruct
+            Type: 169 PointerType *main.oneStringStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 93, index: 0, name: a}
+                  Variable: {subprogram: 101, index: 0, name: a}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 353
+      ID: 486
       Name: Probe[main.testPointerLoop]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -4541,14 +5149,14 @@ Types:
         - Name: a
           Offset: 1
           Expression:
-            Type: 132 PointerType *main.node
+            Type: 155 PointerType *main.node
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 72, index: 0, name: a}
+                  Variable: {subprogram: 80, index: 0, name: a}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 335
+      ID: 468
       Name: Probe[main.testPointerToMap]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -4556,14 +5164,14 @@ Types:
         - Name: m
           Offset: 1
           Expression:
-            Type: 92 PointerType *map[string]int
+            Type: 115 PointerType *map[string]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 54, index: 0, name: m}
+                  Variable: {subprogram: 62, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 351
+      ID: 484
       Name: Probe[main.testPointerToSimpleStruct]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -4571,14 +5179,14 @@ Types:
         - Name: a
           Offset: 1
           Expression:
-            Type: 129 PointerType *main.structWithTwoValues
+            Type: 152 PointerType *main.structWithTwoValues
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 70, index: 0, name: a}
+                  Variable: {subprogram: 78, index: 0, name: a}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 283
+      ID: 408
       Name: Probe[main.testRuneArray]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -4593,7 +5201,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 302
+      ID: 427
       Name: Probe[main.testSingleBool]
       ByteSize: 2
       PresenceBitsetSize: 1
@@ -4608,7 +5216,7 @@ Types:
                   Offset: 0
                   ByteSize: 1
     - __kind: EventRootType
-      ID: 300
+      ID: 425
       Name: Probe[main.testSingleByte]
       ByteSize: 2
       PresenceBitsetSize: 1
@@ -4623,7 +5231,7 @@ Types:
                   Offset: 0
                   ByteSize: 1
     - __kind: EventRootType
-      ID: 313
+      ID: 438
       Name: Probe[main.testSingleFloat32]
       ByteSize: 5
       PresenceBitsetSize: 1
@@ -4638,7 +5246,7 @@ Types:
                   Offset: 0
                   ByteSize: 4
     - __kind: EventRootType
-      ID: 314
+      ID: 439
       Name: Probe[main.testSingleFloat64]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -4653,7 +5261,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 305
+      ID: 430
       Name: Probe[main.testSingleInt16]
       ByteSize: 3
       PresenceBitsetSize: 1
@@ -4668,7 +5276,7 @@ Types:
                   Offset: 0
                   ByteSize: 2
     - __kind: EventRootType
-      ID: 306
+      ID: 431
       Name: Probe[main.testSingleInt32]
       ByteSize: 5
       PresenceBitsetSize: 1
@@ -4683,7 +5291,7 @@ Types:
                   Offset: 0
                   ByteSize: 4
     - __kind: EventRootType
-      ID: 307
+      ID: 432
       Name: Probe[main.testSingleInt64]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -4698,7 +5306,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 304
+      ID: 429
       Name: Probe[main.testSingleInt8]
       ByteSize: 2
       PresenceBitsetSize: 1
@@ -4713,7 +5321,7 @@ Types:
                   Offset: 0
                   ByteSize: 1
     - __kind: EventRootType
-      ID: 303
+      ID: 428
       Name: Probe[main.testSingleInt]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -4728,7 +5336,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 301
+      ID: 426
       Name: Probe[main.testSingleRune]
       ByteSize: 5
       PresenceBitsetSize: 1
@@ -4743,7 +5351,7 @@ Types:
                   Offset: 0
                   ByteSize: 4
     - __kind: EventRootType
-      ID: 370
+      ID: 503
       Name: Probe[main.testSingleString]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -4754,11 +5362,11 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 89, index: 0, name: x}
+                  Variable: {subprogram: 97, index: 0, name: x}
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 310
+      ID: 435
       Name: Probe[main.testSingleUint16]
       ByteSize: 3
       PresenceBitsetSize: 1
@@ -4773,7 +5381,7 @@ Types:
                   Offset: 0
                   ByteSize: 2
     - __kind: EventRootType
-      ID: 311
+      ID: 436
       Name: Probe[main.testSingleUint32]
       ByteSize: 5
       PresenceBitsetSize: 1
@@ -4788,7 +5396,7 @@ Types:
                   Offset: 0
                   ByteSize: 4
     - __kind: EventRootType
-      ID: 312
+      ID: 437
       Name: Probe[main.testSingleUint64]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -4803,7 +5411,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 309
+      ID: 434
       Name: Probe[main.testSingleUint8]
       ByteSize: 2
       PresenceBitsetSize: 1
@@ -4818,7 +5426,7 @@ Types:
                   Offset: 0
                   ByteSize: 1
     - __kind: EventRootType
-      ID: 308
+      ID: 433
       Name: Probe[main.testSingleUint]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -4833,7 +5441,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 361
+      ID: 494
       Name: Probe[main.testSliceOfSlices]
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -4841,14 +5449,14 @@ Types:
         - Name: u
           Offset: 1
           Expression:
-            Type: 136 GoSliceHeaderType [][]uint
+            Type: 159 GoSliceHeaderType [][]uint
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 80, index: 0, name: u}
+                  Variable: {subprogram: 88, index: 0, name: u}
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 333
+      ID: 466
       Name: Probe[main.testSmallMap]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -4856,14 +5464,14 @@ Types:
         - Name: m
           Offset: 1
           Expression:
-            Type: 76 GoMapType map[string]int
+            Type: 99 GoMapType map[string]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 52, index: 0, name: m}
+                  Variable: {subprogram: 60, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 284
+      ID: 409
       Name: Probe[main.testStringArray]
       ByteSize: 33
       PresenceBitsetSize: 1
@@ -4878,7 +5486,7 @@ Types:
                   Offset: 0
                   ByteSize: 32
     - __kind: EventRootType
-      ID: 356
+      ID: 489
       Name: Probe[main.testStringPointer]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -4889,11 +5497,11 @@ Types:
             Type: 22 PointerType *string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 75, index: 0, name: z}
+                  Variable: {subprogram: 83, index: 0, name: z}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 365
+      ID: 498
       Name: Probe[main.testStringSlice]
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -4901,14 +5509,44 @@ Types:
         - Name: s
           Offset: 1
           Expression:
-            Type: 141 GoSliceHeaderType []string
+            Type: 164 GoSliceHeaderType []string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 84, index: 0, name: s}
+                  Variable: {subprogram: 92, index: 0, name: s}
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 362
+      ID: 448
+      Name: Probe[main.testStringType1]
+      ByteSize: 9
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: a
+          Offset: 1
+          Expression:
+            Type: 75 PointerType *main.stringType1
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 42, index: 0, name: a}
+                  Offset: 0
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 449
+      Name: Probe[main.testStringType2]
+      ByteSize: 9
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: a
+          Offset: 1
+          Expression:
+            Type: 77 PointerType **main.stringType2
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 43, index: 0, name: a}
+                  Offset: 0
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 495
       Name: Probe[main.testStructSlice]
       ByteSize: 33
       PresenceBitsetSize: 1
@@ -4916,10 +5554,10 @@ Types:
         - Name: xs
           Offset: 1
           Expression:
-            Type: 138 GoSliceHeaderType []main.structWithNoStrings
+            Type: 161 GoSliceHeaderType []main.structWithNoStrings
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 81, index: 0, name: xs}
+                  Variable: {subprogram: 89, index: 0, name: xs}
                   Offset: 0
                   ByteSize: 24
         - Name: a
@@ -4928,11 +5566,11 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 81, index: 1, name: a}
+                  Variable: {subprogram: 89, index: 1, name: a}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 328
+      ID: 461
       Name: Probe[main.testStructWithMap]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -4940,14 +5578,14 @@ Types:
         - Name: s
           Offset: 1
           Expression:
-            Type: 65 StructureType main.structWithMap
+            Type: 88 StructureType main.structWithMap
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 47, index: 0, name: s}
+                  Variable: {subprogram: 55, index: 0, name: s}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 378
+      ID: 511
       Name: Probe[main.testStruct]
       ByteSize: 57
       PresenceBitsetSize: 1
@@ -4955,14 +5593,14 @@ Types:
         - Name: x
           Offset: 1
           Expression:
-            Type: 148 StructureType main.aStruct
+            Type: 171 StructureType main.aStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 97, index: 0, name: x}
+                  Variable: {subprogram: 105, index: 0, name: x}
                   Offset: 0
                   ByteSize: 56
     - __kind: EventRootType
-      ID: 373
+      ID: 506
       Name: Probe[main.testThreeStringsInStructPointer]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -4970,14 +5608,14 @@ Types:
         - Name: a
           Offset: 1
           Expression:
-            Type: 145 PointerType *main.threeStringStruct
+            Type: 168 PointerType *main.threeStringStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 92, index: 0, name: a}
+                  Variable: {subprogram: 100, index: 0, name: a}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 372
+      ID: 505
       Name: Probe[main.testThreeStringsInStruct]
       ByteSize: 49
       PresenceBitsetSize: 1
@@ -4985,14 +5623,14 @@ Types:
         - Name: a
           Offset: 1
           Expression:
-            Type: 144 StructureType main.threeStringStruct
+            Type: 167 StructureType main.threeStringStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 91, index: 0, name: a}
+                  Variable: {subprogram: 99, index: 0, name: a}
                   Offset: 0
                   ByteSize: 48
     - __kind: EventRootType
-      ID: 371
+      ID: 504
       Name: Probe[main.testThreeStrings]
       ByteSize: 49
       PresenceBitsetSize: 1
@@ -5003,7 +5641,7 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 90, index: 0, name: x}
+                  Variable: {subprogram: 98, index: 0, name: x}
                   Offset: 0
                   ByteSize: 16
         - Name: y
@@ -5012,7 +5650,7 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 90, index: 1, name: y}
+                  Variable: {subprogram: 98, index: 1, name: y}
                   Offset: 0
                   ByteSize: 16
         - Name: z
@@ -5021,11 +5659,11 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 90, index: 2, name: z}
+                  Variable: {subprogram: 98, index: 2, name: z}
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 315
+      ID: 440
       Name: Probe[main.testTypeAlias]
       ByteSize: 3
       PresenceBitsetSize: 1
@@ -5040,7 +5678,7 @@ Types:
                   Offset: 0
                   ByteSize: 2
     - __kind: EventRootType
-      ID: 293
+      ID: 418
       Name: Probe[main.testUint16Array]
       ByteSize: 5
       PresenceBitsetSize: 1
@@ -5055,7 +5693,7 @@ Types:
                   Offset: 0
                   ByteSize: 4
     - __kind: EventRootType
-      ID: 294
+      ID: 419
       Name: Probe[main.testUint32Array]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -5070,7 +5708,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 295
+      ID: 420
       Name: Probe[main.testUint64Array]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -5085,7 +5723,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 292
+      ID: 417
       Name: Probe[main.testUint8Array]
       ByteSize: 3
       PresenceBitsetSize: 1
@@ -5100,7 +5738,7 @@ Types:
                   Offset: 0
                   ByteSize: 2
     - __kind: EventRootType
-      ID: 291
+      ID: 416
       Name: Probe[main.testUintArray]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -5115,7 +5753,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 355
+      ID: 488
       Name: Probe[main.testUintPointer]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -5126,11 +5764,11 @@ Types:
             Type: 34 PointerType *uint
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 74, index: 0, name: x}
+                  Variable: {subprogram: 82, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 359
+      ID: 492
       Name: Probe[main.testUintSlice]
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -5138,14 +5776,14 @@ Types:
         - Name: u
           Offset: 1
           Expression:
-            Type: 135 GoSliceHeaderType []uint
+            Type: 158 GoSliceHeaderType []uint
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 78, index: 0, name: u}
+                  Variable: {subprogram: 86, index: 0, name: u}
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 376
+      ID: 509
       Name: Probe[main.testUnitializedString]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -5156,11 +5794,11 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 95, index: 0, name: x}
+                  Variable: {subprogram: 103, index: 0, name: x}
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 354
+      ID: 487
       Name: Probe[main.testUnsafePointer]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -5171,11 +5809,11 @@ Types:
             Type: 14 VoidPointerType unsafe.Pointer
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 73, index: 0, name: x}
+                  Variable: {subprogram: 81, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 299
+      ID: 424
       Name: Probe[main.testVeryLargeArray]
       ByteSize: 801
       PresenceBitsetSize: 1
@@ -5190,7 +5828,7 @@ Types:
                   Offset: 0
                   ByteSize: 800
     - __kind: EventRootType
-      ID: 368
+      ID: 501
       Name: Probe[main.testVeryLargeSlice]
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -5198,10 +5836,10 @@ Types:
         - Name: xs
           Offset: 1
           Expression:
-            Type: 135 GoSliceHeaderType []uint
+            Type: 158 GoSliceHeaderType []uint
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 87, index: 0, name: xs}
+                  Variable: {subprogram: 95, index: 0, name: xs}
                   Offset: 0
                   ByteSize: 24
     - __kind: ArrayType
@@ -5240,7 +5878,7 @@ Types:
       ID: 40
       Name: '[2]int'
       ByteSize: 16
-      GoRuntimeType: 673280
+      GoRuntimeType: 679264
       GoKind: 17
       Count: 2
       HasCount: true
@@ -5257,7 +5895,7 @@ Types:
       ID: 37
       Name: '[2]int32'
       ByteSize: 8
-      GoRuntimeType: 674624
+      GoRuntimeType: 680608
       GoKind: 17
       Count: 2
       HasCount: true
@@ -5279,18 +5917,18 @@ Types:
       HasCount: true
       Element: 15 BaseType int8
     - __kind: ArrayType
-      ID: 91
+      ID: 114
       Name: '[2]map[string]int'
       ByteSize: 16
       GoKind: 17
       Count: 2
       HasCount: true
-      Element: 76 GoMapType map[string]int
+      Element: 99 GoMapType map[string]int
     - __kind: ArrayType
       ID: 38
       Name: '[2]string'
       ByteSize: 32
-      GoRuntimeType: 674720
+      GoRuntimeType: 680704
       GoKind: 17
       Count: 2
       HasCount: true
@@ -5323,7 +5961,7 @@ Types:
       ID: 47
       Name: '[2]uint64'
       ByteSize: 16
-      GoRuntimeType: 674816
+      GoRuntimeType: 680800
       GoKind: 17
       Count: 2
       HasCount: true
@@ -5332,31 +5970,31 @@ Types:
       ID: 36
       Name: '[2]uint8'
       ByteSize: 2
-      GoRuntimeType: 674528
+      GoRuntimeType: 680512
       GoKind: 17
       Count: 2
       HasCount: true
       Element: 3 BaseType uint8
     - __kind: ArrayType
-      ID: 236
+      ID: 272
       Name: '[4]int'
       ByteSize: 32
-      GoRuntimeType: 672896
+      GoRuntimeType: 678880
       GoKind: 17
       Count: 4
       HasCount: true
       Element: 7 BaseType int
     - __kind: ArrayType
-      ID: 193
+      ID: 229
       Name: '[4]string'
       ByteSize: 64
-      GoRuntimeType: 673184
+      GoRuntimeType: 679168
       GoKind: 17
       Count: 4
       HasCount: true
       Element: 9 GoStringHeaderType string
     - __kind: ArrayType
-      ID: 63
+      ID: 86
       Name: '[5]int'
       ByteSize: 40
       GoKind: 17
@@ -5364,10 +6002,98 @@ Types:
       HasCount: true
       Element: 7 BaseType int
     - __kind: GoSliceHeaderType
+      ID: 62
+      Name: '[]*main.deepSlice2'
+      ByteSize: 24
+      GoRuntimeType: 474752
+      GoKind: 23
+      RawFields:
+        - Name: array
+          Offset: 0
+          Type: 63 PointerType **main.deepSlice2
+        - Name: len
+          Offset: 8
+          Type: 7 BaseType int
+        - Name: cap
+          Offset: 16
+          Type: 7 BaseType int
+      Data: 179 GoSliceDataType []*main.deepSlice2.array
+    - __kind: GoSliceDataType
+      ID: 179
+      Name: '[]*main.deepSlice2.array'
+      ByteSize: 2048
+      Element: 64 PointerType *main.deepSlice2
+    - __kind: GoSliceHeaderType
+      ID: 308
+      Name: '[]*main.deepSlice3'
+      ByteSize: 24
+      GoRuntimeType: 474688
+      GoKind: 23
+      RawFields:
+        - Name: array
+          Offset: 0
+          Type: 309 PointerType **main.deepSlice3
+        - Name: len
+          Offset: 8
+          Type: 7 BaseType int
+        - Name: cap
+          Offset: 16
+          Type: 7 BaseType int
+      Data: 312 GoSliceDataType []*main.deepSlice3.array
+    - __kind: GoSliceDataType
+      ID: 312
+      Name: '[]*main.deepSlice3.array'
+      ByteSize: 2048
+      Element: 310 PointerType *main.deepSlice3
+    - __kind: GoSliceHeaderType
+      ID: 333
+      Name: '[]*main.deepSlice8'
+      ByteSize: 24
+      GoRuntimeType: 474368
+      GoKind: 23
+      RawFields:
+        - Name: array
+          Offset: 0
+          Type: 334 PointerType **main.deepSlice8
+        - Name: len
+          Offset: 8
+          Type: 7 BaseType int
+        - Name: cap
+          Offset: 16
+          Type: 7 BaseType int
+      Data: 337 GoSliceDataType []*main.deepSlice8.array
+    - __kind: GoSliceDataType
+      ID: 337
+      Name: '[]*main.deepSlice8.array'
+      ByteSize: 2048
+      Element: 335 PointerType *main.deepSlice8
+    - __kind: GoSliceHeaderType
+      ID: 339
+      Name: '[]*main.deepSlice9'
+      ByteSize: 24
+      GoRuntimeType: 474304
+      GoKind: 23
+      RawFields:
+        - Name: array
+          Offset: 0
+          Type: 340 PointerType **main.deepSlice9
+        - Name: len
+          Offset: 8
+          Type: 7 BaseType int
+        - Name: cap
+          Offset: 16
+          Type: 7 BaseType int
+      Data: 343 GoSliceDataType []*main.deepSlice9.array
+    - __kind: GoSliceDataType
+      ID: 343
+      Name: '[]*main.deepSlice9.array'
+      ByteSize: 2048
+      Element: 341 PointerType *main.deepSlice9
+    - __kind: GoSliceHeaderType
       ID: 53
       Name: '[]*string'
       ByteSize: 24
-      GoRuntimeType: 470656
+      GoRuntimeType: 475776
       GoKind: 23
       RawFields:
         - Name: array
@@ -5379,98 +6105,123 @@ Types:
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 153 GoSliceDataType []*string.array
+      Data: 176 GoSliceDataType []*string.array
     - __kind: GoSliceDataType
-      ID: 153
+      ID: 176
       Name: '[]*string.array'
       ByteSize: 2048
       Element: 22 PointerType *string
     - __kind: GoSliceDataType
-      ID: 253
+      ID: 289
       Name: '[]*table<[4]int,[4]int>.array'
       ByteSize: 8192
-      Element: 127 PointerType *table<[4]int,[4]int>
+      Element: 150 PointerType *table<[4]int,[4]int>
     - __kind: GoSliceDataType
-      ID: 245
+      ID: 281
       Name: '[]*table<[4]int,uint8>.array'
       ByteSize: 8192
-      Element: 122 PointerType *table<[4]int,uint8>
+      Element: 145 PointerType *table<[4]int,uint8>
     - __kind: GoSliceDataType
-      ID: 194
+      ID: 230
       Name: '[]*table<[4]string,[2]int>.array'
       ByteSize: 8192
-      Element: 90 PointerType *table<[4]string,[2]int>
+      Element: 113 PointerType *table<[4]string,[2]int>
     - __kind: GoSliceDataType
-      ID: 212
+      ID: 248
       Name: '[]*table<bool,main.node>.array'
       ByteSize: 8192
-      Element: 102 PointerType *table<bool,main.node>
+      Element: 125 PointerType *table<bool,main.node>
     - __kind: GoSliceDataType
-      ID: 161
+      ID: 189
+      Name: '[]*table<int,*main.deepMap2>.array'
+      ByteSize: 8192
+      Element: 72 PointerType *table<int,*main.deepMap2>
+    - __kind: GoSliceDataType
+      ID: 327
+      Name: '[]*table<int,*main.deepMap3>.array'
+      ByteSize: 8192
+      Element: 318 PointerType *table<int,*main.deepMap3>
+    - __kind: GoSliceDataType
+      ID: 362
+      Name: '[]*table<int,*main.deepMap8>.array'
+      ByteSize: 8192
+      Element: 353 PointerType *table<int,*main.deepMap8>
+    - __kind: GoSliceDataType
+      ID: 377
+      Name: '[]*table<int,*main.deepMap9>.array'
+      ByteSize: 8192
+      Element: 368 PointerType *table<int,*main.deepMap9>
+    - __kind: GoSliceDataType
+      ID: 197
       Name: '[]*table<int,int>.array'
       ByteSize: 8192
-      Element: 70 PointerType *table<int,int>
+      Element: 93 PointerType *table<int,int>
     - __kind: GoSliceDataType
-      ID: 220
+      ID: 390
+      Name: '[]*table<int,interface {}>.array'
+      ByteSize: 8192
+      Element: 383 PointerType *table<int,interface {}>
+    - __kind: GoSliceDataType
+      ID: 256
       Name: '[]*table<int,uint8>.array'
       ByteSize: 8192
-      Element: 107 PointerType *table<int,uint8>
+      Element: 130 PointerType *table<int,uint8>
     - __kind: GoSliceDataType
-      ID: 204
+      ID: 240
       Name: '[]*table<string,[]main.structWithMap>.array'
       ByteSize: 8192
-      Element: 97 PointerType *table<string,[]main.structWithMap>
+      Element: 120 PointerType *table<string,[]main.structWithMap>
     - __kind: GoSliceDataType
-      ID: 185
+      ID: 221
       Name: '[]*table<string,[]string>.array'
       ByteSize: 8192
-      Element: 85 PointerType *table<string,[]string>
+      Element: 108 PointerType *table<string,[]string>
     - __kind: GoSliceDataType
-      ID: 177
+      ID: 213
       Name: '[]*table<string,int>.array'
       ByteSize: 8192
-      Element: 80 PointerType *table<string,int>
+      Element: 103 PointerType *table<string,int>
     - __kind: GoSliceDataType
-      ID: 169
+      ID: 205
       Name: '[]*table<string,main.nestedStruct>.array'
       ByteSize: 8192
-      Element: 75 PointerType *table<string,main.nestedStruct>
+      Element: 98 PointerType *table<string,main.nestedStruct>
     - __kind: GoSliceDataType
-      ID: 237
+      ID: 273
       Name: '[]*table<uint8,[4]int>.array'
       ByteSize: 8192
-      Element: 117 PointerType *table<uint8,[4]int>
+      Element: 140 PointerType *table<uint8,[4]int>
     - __kind: GoSliceDataType
-      ID: 228
+      ID: 264
       Name: '[]*table<uint8,uint8>.array'
       ByteSize: 8192
-      Element: 112 PointerType *table<uint8,uint8>
+      Element: 135 PointerType *table<uint8,uint8>
     - __kind: GoSliceHeaderType
-      ID: 136
+      ID: 159
       Name: '[][]uint'
       ByteSize: 24
       GoKind: 23
       RawFields:
         - Name: array
           Offset: 0
-          Type: 137 PointerType *[]uint
+          Type: 160 PointerType *[]uint
         - Name: len
           Offset: 8
           Type: 7 BaseType int
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 257 GoSliceDataType [][]uint.array
+      Data: 293 GoSliceDataType [][]uint.array
     - __kind: GoSliceDataType
-      ID: 257
+      ID: 293
       Name: '[][]uint.array'
       ByteSize: 2048
-      Element: 135 GoSliceHeaderType []uint
+      Element: 158 GoSliceHeaderType []uint
     - __kind: GoSliceHeaderType
-      ID: 142
+      ID: 165
       Name: '[]bool'
       ByteSize: 24
-      GoRuntimeType: 478528
+      GoRuntimeType: 483648
       GoKind: 23
       RawFields:
         - Name: array
@@ -5482,120 +6233,167 @@ Types:
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 263 GoSliceDataType []bool.array
+      Data: 299 GoSliceDataType []bool.array
     - __kind: GoSliceDataType
-      ID: 263
+      ID: 299
       Name: '[]bool.array'
       ByteSize: 2048
       Element: 4 BaseType bool
     - __kind: GoSliceHeaderType
-      ID: 202
-      Name: '[]main.structWithMap'
+      ID: 345
+      Name: '[]interface {}'
       ByteSize: 24
-      GoRuntimeType: 469888
+      GoRuntimeType: 483968
       GoKind: 23
       RawFields:
         - Name: array
           Offset: 0
-          Type: 203 PointerType *main.structWithMap
+          Type: 346 PointerType *interface {}
         - Name: len
           Offset: 8
           Type: 7 BaseType int
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 280 GoSliceDataType []main.structWithMap.array
+      Data: 347 GoSliceDataType []interface {}.array
     - __kind: GoSliceDataType
-      ID: 280
+      ID: 347
+      Name: '[]interface {}.array'
+      ByteSize: 2048
+      Element: 81 GoEmptyInterfaceType interface {}
+    - __kind: GoSliceHeaderType
+      ID: 238
+      Name: '[]main.structWithMap'
+      ByteSize: 24
+      GoRuntimeType: 475008
+      GoKind: 23
+      RawFields:
+        - Name: array
+          Offset: 0
+          Type: 239 PointerType *main.structWithMap
+        - Name: len
+          Offset: 8
+          Type: 7 BaseType int
+        - Name: cap
+          Offset: 16
+          Type: 7 BaseType int
+      Data: 405 GoSliceDataType []main.structWithMap.array
+    - __kind: GoSliceDataType
+      ID: 405
       Name: '[]main.structWithMap.array'
       ByteSize: 2048
-      Element: 65 StructureType main.structWithMap
+      Element: 88 StructureType main.structWithMap
     - __kind: GoSliceHeaderType
-      ID: 138
+      ID: 161
       Name: '[]main.structWithNoStrings'
       ByteSize: 24
       GoKind: 23
       RawFields:
         - Name: array
           Offset: 0
-          Type: 139 PointerType *main.structWithNoStrings
+          Type: 162 PointerType *main.structWithNoStrings
         - Name: len
           Offset: 8
           Type: 7 BaseType int
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 259 GoSliceDataType []main.structWithNoStrings.array
+      Data: 295 GoSliceDataType []main.structWithNoStrings.array
     - __kind: GoSliceDataType
-      ID: 259
+      ID: 295
       Name: '[]main.structWithNoStrings.array'
       ByteSize: 2048
-      Element: 140 StructureType main.structWithNoStrings
+      Element: 163 StructureType main.structWithNoStrings
     - __kind: GoSliceDataType
-      ID: 254
+      ID: 290
       Name: '[]noalg.map.group[[4]int][4]int.array'
       ByteSize: 2048
-      Element: 250 StructureType noalg.map.group[[4]int][4]int
+      Element: 286 StructureType noalg.map.group[[4]int][4]int
     - __kind: GoSliceDataType
-      ID: 246
+      ID: 282
       Name: '[]noalg.map.group[[4]int]uint8.array'
       ByteSize: 2048
-      Element: 242 StructureType noalg.map.group[[4]int]uint8
+      Element: 278 StructureType noalg.map.group[[4]int]uint8
     - __kind: GoSliceDataType
-      ID: 195
+      ID: 231
       Name: '[]noalg.map.group[[4]string][2]int.array'
       ByteSize: 2048
-      Element: 190 StructureType noalg.map.group[[4]string][2]int
+      Element: 226 StructureType noalg.map.group[[4]string][2]int
     - __kind: GoSliceDataType
-      ID: 213
+      ID: 249
       Name: '[]noalg.map.group[bool]main.node.array'
       ByteSize: 2048
-      Element: 209 StructureType noalg.map.group[bool]main.node
+      Element: 245 StructureType noalg.map.group[bool]main.node
     - __kind: GoSliceDataType
-      ID: 162
+      ID: 190
+      Name: '[]noalg.map.group[int]*main.deepMap2.array'
+      ByteSize: 2048
+      Element: 184 StructureType noalg.map.group[int]*main.deepMap2
+    - __kind: GoSliceDataType
+      ID: 328
+      Name: '[]noalg.map.group[int]*main.deepMap3.array'
+      ByteSize: 2048
+      Element: 322 StructureType noalg.map.group[int]*main.deepMap3
+    - __kind: GoSliceDataType
+      ID: 363
+      Name: '[]noalg.map.group[int]*main.deepMap8.array'
+      ByteSize: 2048
+      Element: 357 StructureType noalg.map.group[int]*main.deepMap8
+    - __kind: GoSliceDataType
+      ID: 378
+      Name: '[]noalg.map.group[int]*main.deepMap9.array'
+      ByteSize: 2048
+      Element: 372 StructureType noalg.map.group[int]*main.deepMap9
+    - __kind: GoSliceDataType
+      ID: 198
       Name: '[]noalg.map.group[int]int.array'
       ByteSize: 2048
-      Element: 158 StructureType noalg.map.group[int]int
+      Element: 194 StructureType noalg.map.group[int]int
     - __kind: GoSliceDataType
-      ID: 221
+      ID: 391
+      Name: '[]noalg.map.group[int]interface {}.array'
+      ByteSize: 2048
+      Element: 387 StructureType noalg.map.group[int]interface {}
+    - __kind: GoSliceDataType
+      ID: 257
       Name: '[]noalg.map.group[int]uint8.array'
       ByteSize: 2048
-      Element: 217 StructureType noalg.map.group[int]uint8
+      Element: 253 StructureType noalg.map.group[int]uint8
     - __kind: GoSliceDataType
-      ID: 205
+      ID: 241
       Name: '[]noalg.map.group[string][]main.structWithMap.array'
       ByteSize: 2048
-      Element: 199 StructureType noalg.map.group[string][]main.structWithMap
+      Element: 235 StructureType noalg.map.group[string][]main.structWithMap
     - __kind: GoSliceDataType
-      ID: 186
+      ID: 222
       Name: '[]noalg.map.group[string][]string.array'
       ByteSize: 2048
-      Element: 182 StructureType noalg.map.group[string][]string
+      Element: 218 StructureType noalg.map.group[string][]string
     - __kind: GoSliceDataType
-      ID: 178
+      ID: 214
       Name: '[]noalg.map.group[string]int.array'
       ByteSize: 2048
-      Element: 174 StructureType noalg.map.group[string]int
+      Element: 210 StructureType noalg.map.group[string]int
     - __kind: GoSliceDataType
-      ID: 170
+      ID: 206
       Name: '[]noalg.map.group[string]main.nestedStruct.array'
       ByteSize: 2048
-      Element: 166 StructureType noalg.map.group[string]main.nestedStruct
+      Element: 202 StructureType noalg.map.group[string]main.nestedStruct
     - __kind: GoSliceDataType
-      ID: 238
+      ID: 274
       Name: '[]noalg.map.group[uint8][4]int.array'
       ByteSize: 2048
-      Element: 233 StructureType noalg.map.group[uint8][4]int
+      Element: 269 StructureType noalg.map.group[uint8][4]int
     - __kind: GoSliceDataType
-      ID: 229
+      ID: 265
       Name: '[]noalg.map.group[uint8]uint8.array'
       ByteSize: 2048
-      Element: 225 StructureType noalg.map.group[uint8]uint8
+      Element: 261 StructureType noalg.map.group[uint8]uint8
     - __kind: GoSliceHeaderType
-      ID: 141
+      ID: 164
       Name: '[]string'
       ByteSize: 24
-      GoRuntimeType: 478656
+      GoRuntimeType: 483776
       GoKind: 23
       RawFields:
         - Name: array
@@ -5607,17 +6405,17 @@ Types:
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 261 GoSliceDataType []string.array
+      Data: 297 GoSliceDataType []string.array
     - __kind: GoSliceDataType
-      ID: 261
+      ID: 297
       Name: '[]string.array'
       ByteSize: 2048
       Element: 9 GoStringHeaderType string
     - __kind: GoSliceHeaderType
-      ID: 135
+      ID: 158
       Name: '[]uint'
       ByteSize: 24
-      GoRuntimeType: 478144
+      GoRuntimeType: 483264
       GoKind: 23
       RawFields:
         - Name: array
@@ -5629,17 +6427,17 @@ Types:
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 255 GoSliceDataType []uint.array
+      Data: 291 GoSliceDataType []uint.array
     - __kind: GoSliceDataType
-      ID: 255
+      ID: 291
       Name: '[]uint.array'
       ByteSize: 2048
       Element: 16 BaseType uint
     - __kind: GoSliceHeaderType
-      ID: 143
+      ID: 166
       Name: '[]uint16'
       ByteSize: 24
-      GoRuntimeType: 477504
+      GoRuntimeType: 482624
       GoKind: 23
       RawFields:
         - Name: array
@@ -5651,9 +6449,9 @@ Types:
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 265 GoSliceDataType []uint16.array
+      Data: 301 GoSliceDataType []uint16.array
     - __kind: GoSliceDataType
-      ID: 265
+      ID: 301
       Name: '[]uint16.array'
       ByteSize: 2048
       Element: 6 BaseType uint16
@@ -5661,35 +6459,35 @@ Types:
       ID: 4
       Name: bool
       ByteSize: 1
-      GoRuntimeType: 576032
+      GoRuntimeType: 581152
       GoKind: 1
     - __kind: GoChannelType
-      ID: 128
+      ID: 151
       Name: chan bool
-      GoRuntimeType: 587360
+      GoRuntimeType: 592480
       GoKind: 18
     - __kind: GoChannelType
-      ID: 57
+      ID: 80
       Name: chan struct {}
-      GoRuntimeType: 586272
+      GoRuntimeType: 591392
       GoKind: 18
     - __kind: BaseType
       ID: 24
       Name: complex128
       ByteSize: 16
-      GoRuntimeType: 575840
+      GoRuntimeType: 580960
       GoKind: 16
     - __kind: BaseType
       ID: 23
       Name: complex64
       ByteSize: 8
-      GoRuntimeType: 575776
+      GoRuntimeType: 580896
       GoKind: 15
     - __kind: GoInterfaceType
       ID: 13
       Name: error
       ByteSize: 16
-      GoRuntimeType: 1.016416e+06
+      GoRuntimeType: 1.0224e+06
       GoKind: 20
       RawFields:
         - Name: tab
@@ -5702,223 +6500,293 @@ Types:
       ID: 17
       Name: float32
       ByteSize: 4
-      GoRuntimeType: 575904
+      GoRuntimeType: 581024
       GoKind: 13
     - __kind: BaseType
       ID: 18
       Name: float64
       ByteSize: 8
-      GoRuntimeType: 575968
+      GoRuntimeType: 581088
       GoKind: 14
     - __kind: GoSubroutineType
-      ID: 60
+      ID: 83
       Name: func()
       ByteSize: 8
-      GoRuntimeType: 468928
+      GoRuntimeType: 472960
       GoKind: 19
     - __kind: GoSwissMapGroupsType
-      ID: 248
+      ID: 284
       Name: groupReference<[4]int,[4]int>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 249 PointerType *noalg.map.group[[4]int][4]int
+          Type: 285 PointerType *noalg.map.group[[4]int][4]int
         - Name: lengthMask
           Offset: 8
           Type: 8 BaseType uint64
-      GroupType: 250 StructureType noalg.map.group[[4]int][4]int
-      GroupSliceType: 254 GoSliceDataType []noalg.map.group[[4]int][4]int.array
+      GroupType: 286 StructureType noalg.map.group[[4]int][4]int
+      GroupSliceType: 290 GoSliceDataType []noalg.map.group[[4]int][4]int.array
     - __kind: GoSwissMapGroupsType
-      ID: 240
+      ID: 276
       Name: groupReference<[4]int,uint8>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 241 PointerType *noalg.map.group[[4]int]uint8
+          Type: 277 PointerType *noalg.map.group[[4]int]uint8
         - Name: lengthMask
           Offset: 8
           Type: 8 BaseType uint64
-      GroupType: 242 StructureType noalg.map.group[[4]int]uint8
-      GroupSliceType: 246 GoSliceDataType []noalg.map.group[[4]int]uint8.array
+      GroupType: 278 StructureType noalg.map.group[[4]int]uint8
+      GroupSliceType: 282 GoSliceDataType []noalg.map.group[[4]int]uint8.array
     - __kind: GoSwissMapGroupsType
-      ID: 188
+      ID: 224
       Name: groupReference<[4]string,[2]int>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 189 PointerType *noalg.map.group[[4]string][2]int
+          Type: 225 PointerType *noalg.map.group[[4]string][2]int
         - Name: lengthMask
           Offset: 8
           Type: 8 BaseType uint64
-      GroupType: 190 StructureType noalg.map.group[[4]string][2]int
-      GroupSliceType: 195 GoSliceDataType []noalg.map.group[[4]string][2]int.array
+      GroupType: 226 StructureType noalg.map.group[[4]string][2]int
+      GroupSliceType: 231 GoSliceDataType []noalg.map.group[[4]string][2]int.array
     - __kind: GoSwissMapGroupsType
-      ID: 207
+      ID: 243
       Name: groupReference<bool,main.node>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 208 PointerType *noalg.map.group[bool]main.node
+          Type: 244 PointerType *noalg.map.group[bool]main.node
         - Name: lengthMask
           Offset: 8
           Type: 8 BaseType uint64
-      GroupType: 209 StructureType noalg.map.group[bool]main.node
-      GroupSliceType: 213 GoSliceDataType []noalg.map.group[bool]main.node.array
+      GroupType: 245 StructureType noalg.map.group[bool]main.node
+      GroupSliceType: 249 GoSliceDataType []noalg.map.group[bool]main.node.array
     - __kind: GoSwissMapGroupsType
-      ID: 156
+      ID: 182
+      Name: groupReference<int,*main.deepMap2>
+      ByteSize: 16
+      GoKind: 25
+      RawFields:
+        - Name: data
+          Offset: 0
+          Type: 183 PointerType *noalg.map.group[int]*main.deepMap2
+        - Name: lengthMask
+          Offset: 8
+          Type: 8 BaseType uint64
+      GroupType: 184 StructureType noalg.map.group[int]*main.deepMap2
+      GroupSliceType: 190 GoSliceDataType []noalg.map.group[int]*main.deepMap2.array
+    - __kind: GoSwissMapGroupsType
+      ID: 320
+      Name: groupReference<int,*main.deepMap3>
+      ByteSize: 16
+      GoKind: 25
+      RawFields:
+        - Name: data
+          Offset: 0
+          Type: 321 PointerType *noalg.map.group[int]*main.deepMap3
+        - Name: lengthMask
+          Offset: 8
+          Type: 8 BaseType uint64
+      GroupType: 322 StructureType noalg.map.group[int]*main.deepMap3
+      GroupSliceType: 328 GoSliceDataType []noalg.map.group[int]*main.deepMap3.array
+    - __kind: GoSwissMapGroupsType
+      ID: 355
+      Name: groupReference<int,*main.deepMap8>
+      ByteSize: 16
+      GoKind: 25
+      RawFields:
+        - Name: data
+          Offset: 0
+          Type: 356 PointerType *noalg.map.group[int]*main.deepMap8
+        - Name: lengthMask
+          Offset: 8
+          Type: 8 BaseType uint64
+      GroupType: 357 StructureType noalg.map.group[int]*main.deepMap8
+      GroupSliceType: 363 GoSliceDataType []noalg.map.group[int]*main.deepMap8.array
+    - __kind: GoSwissMapGroupsType
+      ID: 370
+      Name: groupReference<int,*main.deepMap9>
+      ByteSize: 16
+      GoKind: 25
+      RawFields:
+        - Name: data
+          Offset: 0
+          Type: 371 PointerType *noalg.map.group[int]*main.deepMap9
+        - Name: lengthMask
+          Offset: 8
+          Type: 8 BaseType uint64
+      GroupType: 372 StructureType noalg.map.group[int]*main.deepMap9
+      GroupSliceType: 378 GoSliceDataType []noalg.map.group[int]*main.deepMap9.array
+    - __kind: GoSwissMapGroupsType
+      ID: 192
       Name: groupReference<int,int>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 157 PointerType *noalg.map.group[int]int
+          Type: 193 PointerType *noalg.map.group[int]int
         - Name: lengthMask
           Offset: 8
           Type: 8 BaseType uint64
-      GroupType: 158 StructureType noalg.map.group[int]int
-      GroupSliceType: 162 GoSliceDataType []noalg.map.group[int]int.array
+      GroupType: 194 StructureType noalg.map.group[int]int
+      GroupSliceType: 198 GoSliceDataType []noalg.map.group[int]int.array
     - __kind: GoSwissMapGroupsType
-      ID: 215
+      ID: 385
+      Name: groupReference<int,interface {}>
+      ByteSize: 16
+      GoKind: 25
+      RawFields:
+        - Name: data
+          Offset: 0
+          Type: 386 PointerType *noalg.map.group[int]interface {}
+        - Name: lengthMask
+          Offset: 8
+          Type: 8 BaseType uint64
+      GroupType: 387 StructureType noalg.map.group[int]interface {}
+      GroupSliceType: 391 GoSliceDataType []noalg.map.group[int]interface {}.array
+    - __kind: GoSwissMapGroupsType
+      ID: 251
       Name: groupReference<int,uint8>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 216 PointerType *noalg.map.group[int]uint8
+          Type: 252 PointerType *noalg.map.group[int]uint8
         - Name: lengthMask
           Offset: 8
           Type: 8 BaseType uint64
-      GroupType: 217 StructureType noalg.map.group[int]uint8
-      GroupSliceType: 221 GoSliceDataType []noalg.map.group[int]uint8.array
+      GroupType: 253 StructureType noalg.map.group[int]uint8
+      GroupSliceType: 257 GoSliceDataType []noalg.map.group[int]uint8.array
     - __kind: GoSwissMapGroupsType
-      ID: 197
+      ID: 233
       Name: groupReference<string,[]main.structWithMap>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 198 PointerType *noalg.map.group[string][]main.structWithMap
+          Type: 234 PointerType *noalg.map.group[string][]main.structWithMap
         - Name: lengthMask
           Offset: 8
           Type: 8 BaseType uint64
-      GroupType: 199 StructureType noalg.map.group[string][]main.structWithMap
-      GroupSliceType: 205 GoSliceDataType []noalg.map.group[string][]main.structWithMap.array
+      GroupType: 235 StructureType noalg.map.group[string][]main.structWithMap
+      GroupSliceType: 241 GoSliceDataType []noalg.map.group[string][]main.structWithMap.array
     - __kind: GoSwissMapGroupsType
-      ID: 180
+      ID: 216
       Name: groupReference<string,[]string>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 181 PointerType *noalg.map.group[string][]string
+          Type: 217 PointerType *noalg.map.group[string][]string
         - Name: lengthMask
           Offset: 8
           Type: 8 BaseType uint64
-      GroupType: 182 StructureType noalg.map.group[string][]string
-      GroupSliceType: 186 GoSliceDataType []noalg.map.group[string][]string.array
+      GroupType: 218 StructureType noalg.map.group[string][]string
+      GroupSliceType: 222 GoSliceDataType []noalg.map.group[string][]string.array
     - __kind: GoSwissMapGroupsType
-      ID: 172
+      ID: 208
       Name: groupReference<string,int>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 173 PointerType *noalg.map.group[string]int
+          Type: 209 PointerType *noalg.map.group[string]int
         - Name: lengthMask
           Offset: 8
           Type: 8 BaseType uint64
-      GroupType: 174 StructureType noalg.map.group[string]int
-      GroupSliceType: 178 GoSliceDataType []noalg.map.group[string]int.array
+      GroupType: 210 StructureType noalg.map.group[string]int
+      GroupSliceType: 214 GoSliceDataType []noalg.map.group[string]int.array
     - __kind: GoSwissMapGroupsType
-      ID: 164
+      ID: 200
       Name: groupReference<string,main.nestedStruct>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 165 PointerType *noalg.map.group[string]main.nestedStruct
+          Type: 201 PointerType *noalg.map.group[string]main.nestedStruct
         - Name: lengthMask
           Offset: 8
           Type: 8 BaseType uint64
-      GroupType: 166 StructureType noalg.map.group[string]main.nestedStruct
-      GroupSliceType: 170 GoSliceDataType []noalg.map.group[string]main.nestedStruct.array
+      GroupType: 202 StructureType noalg.map.group[string]main.nestedStruct
+      GroupSliceType: 206 GoSliceDataType []noalg.map.group[string]main.nestedStruct.array
     - __kind: GoSwissMapGroupsType
-      ID: 231
+      ID: 267
       Name: groupReference<uint8,[4]int>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 232 PointerType *noalg.map.group[uint8][4]int
+          Type: 268 PointerType *noalg.map.group[uint8][4]int
         - Name: lengthMask
           Offset: 8
           Type: 8 BaseType uint64
-      GroupType: 233 StructureType noalg.map.group[uint8][4]int
-      GroupSliceType: 238 GoSliceDataType []noalg.map.group[uint8][4]int.array
+      GroupType: 269 StructureType noalg.map.group[uint8][4]int
+      GroupSliceType: 274 GoSliceDataType []noalg.map.group[uint8][4]int.array
     - __kind: GoSwissMapGroupsType
-      ID: 223
+      ID: 259
       Name: groupReference<uint8,uint8>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 224 PointerType *noalg.map.group[uint8]uint8
+          Type: 260 PointerType *noalg.map.group[uint8]uint8
         - Name: lengthMask
           Offset: 8
           Type: 8 BaseType uint64
-      GroupType: 225 StructureType noalg.map.group[uint8]uint8
-      GroupSliceType: 229 GoSliceDataType []noalg.map.group[uint8]uint8.array
+      GroupType: 261 StructureType noalg.map.group[uint8]uint8
+      GroupSliceType: 265 GoSliceDataType []noalg.map.group[uint8]uint8.array
     - __kind: BaseType
       ID: 7
       Name: int
       ByteSize: 8
-      GoRuntimeType: 575584
+      GoRuntimeType: 580704
       GoKind: 2
     - __kind: BaseType
       ID: 31
       Name: int16
       ByteSize: 2
-      GoRuntimeType: 575200
+      GoRuntimeType: 580320
       GoKind: 4
     - __kind: BaseType
       ID: 10
       Name: int32
       ByteSize: 4
-      GoRuntimeType: 575328
+      GoRuntimeType: 580448
       GoKind: 5
     - __kind: BaseType
       ID: 12
       Name: int64
       ByteSize: 8
-      GoRuntimeType: 575456
+      GoRuntimeType: 580576
       GoKind: 6
     - __kind: BaseType
       ID: 15
       Name: int8
       ByteSize: 1
-      GoRuntimeType: 575072
+      GoRuntimeType: 580192
       GoKind: 3
     - __kind: GoEmptyInterfaceType
-      ID: 58
+      ID: 81
       Name: interface {}
       ByteSize: 16
-      GoRuntimeType: 838336
+      GoRuntimeType: 844320
       GoKind: 20
       RawFields:
         - Name: _type
@@ -5928,10 +6796,10 @@ Types:
           Offset: 8
           Type: 14 VoidPointerType unsafe.Pointer
     - __kind: StructureType
-      ID: 269
+      ID: 394
       Name: internal/sync.Mutex
       ByteSize: 8
-      GoRuntimeType: 1.454624e+06
+      GoRuntimeType: 1.46752e+06
       GoKind: 25
       RawFields:
         - Name: state
@@ -5944,7 +6812,7 @@ Types:
       ID: 55
       Name: io.Writer
       ByteSize: 16
-      GoRuntimeType: 1.012448e+06
+      GoRuntimeType: 1.018432e+06
       GoKind: 20
       RawFields:
         - Name: tab
@@ -5954,7 +6822,7 @@ Types:
           Offset: 8
           Type: 14 VoidPointerType unsafe.Pointer
     - __kind: StructureType
-      ID: 148
+      ID: 171
       Name: main.aStruct
       ByteSize: 56
       GoKind: 25
@@ -5970,12 +6838,12 @@ Types:
           Type: 7 BaseType int
         - Name: nested
           Offset: 32
-          Type: 149 StructureType main.nestedStruct
+          Type: 172 StructureType main.nestedStruct
     - __kind: GoInterfaceType
-      ID: 64
+      ID: 87
       Name: main.behavior
       ByteSize: 16
-      GoRuntimeType: 1.012064e+06
+      GoRuntimeType: 1.018048e+06
       GoKind: 20
       RawFields:
         - Name: tab
@@ -6000,37 +6868,199 @@ Types:
           Offset: 32
           Type: 55 GoInterfaceType io.Writer
     - __kind: StructureType
-      ID: 150
+      ID: 67
+      Name: main.deepMap1
+      ByteSize: 8
+      GoRuntimeType: 1.181792e+06
+      GoKind: 25
+      RawFields:
+        - Name: a
+          Offset: 0
+          Type: 68 GoMapType map[int]*main.deepMap2
+    - __kind: StructureType
+      ID: 188
+      Name: main.deepMap2
+      ByteSize: 8
+      GoRuntimeType: 1.181664e+06
+      GoKind: 25
+      RawFields:
+        - Name: a
+          Offset: 0
+          Type: 314 GoMapType map[int]*main.deepMap3
+    - __kind: UnresolvedPointeeType
+      ID: 326
+      Name: main.deepMap3
+      ByteSize: 8
+    - __kind: StructureType
+      ID: 74
+      Name: main.deepMap7
+      ByteSize: 8
+      GoRuntimeType: 1.181024e+06
+      GoKind: 25
+      RawFields:
+        - Name: a
+          Offset: 0
+          Type: 349 GoMapType map[int]*main.deepMap8
+    - __kind: StructureType
+      ID: 361
+      Name: main.deepMap8
+      ByteSize: 8
+      GoRuntimeType: 1.180896e+06
+      GoKind: 25
+      RawFields:
+        - Name: a
+          Offset: 0
+          Type: 364 GoMapType map[int]*main.deepMap9
+    - __kind: StructureType
+      ID: 376
+      Name: main.deepMap9
+      ByteSize: 8
+      GoRuntimeType: 1.180768e+06
+      GoKind: 25
+      RawFields:
+        - Name: a
+          Offset: 0
+          Type: 379 GoMapType map[int]interface {}
+    - __kind: StructureType
+      ID: 56
+      Name: main.deepPtr1
+      ByteSize: 8
+      GoRuntimeType: 1.182944e+06
+      GoKind: 25
+      RawFields:
+        - Name: a
+          Offset: 0
+          Type: 57 PointerType *main.deepPtr2
+    - __kind: StructureType
+      ID: 58
+      Name: main.deepPtr2
+      ByteSize: 8
+      GoRuntimeType: 1.182816e+06
+      GoKind: 25
+      RawFields:
+        - Name: a
+          Offset: 0
+          Type: 303 PointerType *main.deepPtr3
+    - __kind: UnresolvedPointeeType
+      ID: 304
+      Name: main.deepPtr3
+      ByteSize: 8
+    - __kind: StructureType
+      ID: 60
+      Name: main.deepPtr7
+      ByteSize: 8
+      GoRuntimeType: 1.182176e+06
+      GoKind: 25
+      RawFields:
+        - Name: a
+          Offset: 0
+          Type: 329 PointerType *main.deepPtr8
+    - __kind: StructureType
+      ID: 330
+      Name: main.deepPtr8
+      ByteSize: 8
+      GoRuntimeType: 1.182048e+06
+      GoKind: 25
+      RawFields:
+        - Name: a
+          Offset: 0
+          Type: 331 PointerType *main.deepPtr9
+    - __kind: StructureType
+      ID: 332
+      Name: main.deepPtr9
+      ByteSize: 16
+      GoRuntimeType: 1.18192e+06
+      GoKind: 25
+      RawFields:
+        - Name: a
+          Offset: 0
+          Type: 81 GoEmptyInterfaceType interface {}
+    - __kind: StructureType
+      ID: 61
+      Name: main.deepSlice1
+      ByteSize: 24
+      GoRuntimeType: 1.184096e+06
+      GoKind: 25
+      RawFields:
+        - Name: a
+          Offset: 0
+          Type: 62 GoSliceHeaderType []*main.deepSlice2
+    - __kind: StructureType
+      ID: 178
+      Name: main.deepSlice2
+      ByteSize: 24
+      GoRuntimeType: 1.183968e+06
+      GoKind: 25
+      RawFields:
+        - Name: a
+          Offset: 0
+          Type: 308 GoSliceHeaderType []*main.deepSlice3
+    - __kind: UnresolvedPointeeType
+      ID: 311
+      Name: main.deepSlice3
+      ByteSize: 8
+    - __kind: StructureType
+      ID: 66
+      Name: main.deepSlice7
+      ByteSize: 24
+      GoRuntimeType: 1.183328e+06
+      GoKind: 25
+      RawFields:
+        - Name: a
+          Offset: 0
+          Type: 333 GoSliceHeaderType []*main.deepSlice8
+    - __kind: StructureType
+      ID: 336
+      Name: main.deepSlice8
+      ByteSize: 24
+      GoRuntimeType: 1.1832e+06
+      GoKind: 25
+      RawFields:
+        - Name: a
+          Offset: 0
+          Type: 339 GoSliceHeaderType []*main.deepSlice9
+    - __kind: StructureType
+      ID: 342
+      Name: main.deepSlice9
+      ByteSize: 24
+      GoRuntimeType: 1.183072e+06
+      GoKind: 25
+      RawFields:
+        - Name: a
+          Offset: 0
+          Type: 345 GoSliceHeaderType []interface {}
+    - __kind: StructureType
+      ID: 173
       Name: main.emptyStruct
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 62
+      ID: 85
       Name: main.esotericHeap
       ByteSize: 112
-      GoRuntimeType: 1.81168e+06
+      GoRuntimeType: 1.824576e+06
       GoKind: 25
       RawFields:
         - Name: esotericStack
           Offset: 0
-          Type: 56 StructureType main.esotericStack
+          Type: 79 StructureType main.esotericStack
         - Name: mu
           Offset: 64
-          Type: 267 StructureType sync.Mutex
+          Type: 392 StructureType sync.Mutex
         - Name: once
           Offset: 72
-          Type: 270 StructureType sync.Once
+          Type: 395 StructureType sync.Once
         - Name: wg
           Offset: 88
-          Type: 273 StructureType sync.WaitGroup
+          Type: 398 StructureType sync.WaitGroup
         - Name: a
           Offset: 104
-          Type: 276 StructureType sync/atomic.Int32
+          Type: 401 StructureType sync/atomic.Int32
     - __kind: StructureType
-      ID: 56
+      ID: 79
       Name: main.esotericStack
       ByteSize: 64
-      GoRuntimeType: 1.945504e+06
+      GoRuntimeType: 1.9584e+06
       GoKind: 25
       RawFields:
         - Name: _
@@ -6041,24 +7071,24 @@ Types:
           Type: 10 BaseType int32
         - Name: c
           Offset: 8
-          Type: 57 GoChannelType chan struct {}
+          Type: 80 GoChannelType chan struct {}
         - Name: val
           Offset: 16
-          Type: 58 GoEmptyInterfaceType interface {}
+          Type: 81 GoEmptyInterfaceType interface {}
         - Name: _
           Offset: 32
           Type: 8 BaseType uint64
         - Name: work
           Offset: 40
-          Type: 59 GoInterfaceType main.something
+          Type: 82 GoInterfaceType main.something
         - Name: foo
           Offset: 56
-          Type: 60 GoSubroutineType func()
+          Type: 83 GoSubroutineType func()
     - __kind: StructureType
-      ID: 149
+      ID: 172
       Name: main.nestedStruct
       ByteSize: 24
-      GoRuntimeType: 1.444064e+06
+      GoRuntimeType: 1.45696e+06
       GoKind: 25
       RawFields:
         - Name: anotherInt
@@ -6068,10 +7098,10 @@ Types:
           Offset: 8
           Type: 9 GoStringHeaderType string
     - __kind: StructureType
-      ID: 131
+      ID: 154
       Name: main.node
       ByteSize: 16
-      GoRuntimeType: 1.443904e+06
+      GoRuntimeType: 1.4568e+06
       GoKind: 25
       RawFields:
         - Name: val
@@ -6079,9 +7109,9 @@ Types:
           Type: 7 BaseType int
         - Name: b
           Offset: 8
-          Type: 132 PointerType *main.node
+          Type: 155 PointerType *main.node
     - __kind: StructureType
-      ID: 147
+      ID: 170
       Name: main.oneStringStruct
       ByteSize: 16
       GoKind: 25
@@ -6090,10 +7120,10 @@ Types:
           Offset: 0
           Type: 9 GoStringHeaderType string
     - __kind: GoInterfaceType
-      ID: 59
+      ID: 82
       Name: main.something
       ByteSize: 16
-      GoRuntimeType: 1.012192e+06
+      GoRuntimeType: 1.018176e+06
       GoKind: 20
       RawFields:
         - Name: tab
@@ -6102,18 +7132,39 @@ Types:
         - Name: data
           Offset: 8
           Type: 14 VoidPointerType unsafe.Pointer
+    - __kind: GoStringHeaderType
+      ID: 76
+      Name: main.stringType1
+      ByteSize: 16
+      GoKind: 24
+      RawFields:
+        - Name: str
+          Offset: 0
+          Type: 306 PointerType *main.stringType1.str
+        - Name: len
+          Offset: 8
+          Type: 7 BaseType int
+      Data: 305 GoStringDataType main.stringType1.str
+    - __kind: GoStringDataType
+      ID: 305
+      Name: main.stringType1.str
+      ByteSize: 2048
+    - __kind: UnresolvedPointeeType
+      ID: 307
+      Name: main.stringType2
+      ByteSize: 8
     - __kind: StructureType
-      ID: 65
+      ID: 88
       Name: main.structWithMap
       ByteSize: 8
-      GoRuntimeType: 1.173504e+06
+      GoRuntimeType: 1.18064e+06
       GoKind: 25
       RawFields:
         - Name: m
           Offset: 0
-          Type: 66 GoMapType map[int]int
+          Type: 89 GoMapType map[int]int
     - __kind: StructureType
-      ID: 140
+      ID: 163
       Name: main.structWithNoStrings
       ByteSize: 2
       GoKind: 25
@@ -6125,7 +7176,7 @@ Types:
           Offset: 1
           Type: 4 BaseType bool
     - __kind: StructureType
-      ID: 130
+      ID: 153
       Name: main.structWithTwoValues
       ByteSize: 16
       GoKind: 25
@@ -6137,28 +7188,28 @@ Types:
           Offset: 8
           Type: 4 BaseType bool
     - __kind: GoSliceHeaderType
-      ID: 134
+      ID: 157
       Name: main.t
       ByteSize: 24
       GoKind: 23
       RawFields:
         - Name: array
           Offset: 0
-          Type: 277 PointerType **main.t
+          Type: 402 PointerType **main.t
         - Name: len
           Offset: 8
           Type: 7 BaseType int
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 278 GoSliceDataType main.t.array
+      Data: 403 GoSliceDataType main.t.array
     - __kind: GoSliceDataType
-      ID: 278
+      ID: 403
       Name: main.t.array
       ByteSize: 2048
-      Element: 133 PointerType *main.t
+      Element: 156 PointerType *main.t
     - __kind: StructureType
-      ID: 144
+      ID: 167
       Name: main.threeStringStruct
       ByteSize: 48
       GoKind: 25
@@ -6178,7 +7229,7 @@ Types:
       ByteSize: 2
       GoKind: 9
     - __kind: GoSwissMapHeaderType
-      ID: 125
+      ID: 148
       Name: map<[4]int,[4]int>
       ByteSize: 48
       GoKind: 25
@@ -6191,7 +7242,7 @@ Types:
           Type: 1 BaseType uintptr
         - Name: dirPtr
           Offset: 16
-          Type: 126 PointerType **table<[4]int,[4]int>
+          Type: 149 PointerType **table<[4]int,[4]int>
         - Name: dirLen
           Offset: 24
           Type: 7 BaseType int
@@ -6207,10 +7258,10 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 8 BaseType uint64
-      TablePtrSliceType: 253 GoSliceDataType []*table<[4]int,[4]int>.array
-      GroupType: 250 StructureType noalg.map.group[[4]int][4]int
+      TablePtrSliceType: 289 GoSliceDataType []*table<[4]int,[4]int>.array
+      GroupType: 286 StructureType noalg.map.group[[4]int][4]int
     - __kind: GoSwissMapHeaderType
-      ID: 120
+      ID: 143
       Name: map<[4]int,uint8>
       ByteSize: 48
       GoKind: 25
@@ -6223,7 +7274,7 @@ Types:
           Type: 1 BaseType uintptr
         - Name: dirPtr
           Offset: 16
-          Type: 121 PointerType **table<[4]int,uint8>
+          Type: 144 PointerType **table<[4]int,uint8>
         - Name: dirLen
           Offset: 24
           Type: 7 BaseType int
@@ -6239,10 +7290,10 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 8 BaseType uint64
-      TablePtrSliceType: 245 GoSliceDataType []*table<[4]int,uint8>.array
-      GroupType: 242 StructureType noalg.map.group[[4]int]uint8
+      TablePtrSliceType: 281 GoSliceDataType []*table<[4]int,uint8>.array
+      GroupType: 278 StructureType noalg.map.group[[4]int]uint8
     - __kind: GoSwissMapHeaderType
-      ID: 88
+      ID: 111
       Name: map<[4]string,[2]int>
       ByteSize: 48
       GoKind: 25
@@ -6255,7 +7306,7 @@ Types:
           Type: 1 BaseType uintptr
         - Name: dirPtr
           Offset: 16
-          Type: 89 PointerType **table<[4]string,[2]int>
+          Type: 112 PointerType **table<[4]string,[2]int>
         - Name: dirLen
           Offset: 24
           Type: 7 BaseType int
@@ -6271,10 +7322,10 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 8 BaseType uint64
-      TablePtrSliceType: 194 GoSliceDataType []*table<[4]string,[2]int>.array
-      GroupType: 190 StructureType noalg.map.group[[4]string][2]int
+      TablePtrSliceType: 230 GoSliceDataType []*table<[4]string,[2]int>.array
+      GroupType: 226 StructureType noalg.map.group[[4]string][2]int
     - __kind: GoSwissMapHeaderType
-      ID: 100
+      ID: 123
       Name: map<bool,main.node>
       ByteSize: 48
       GoKind: 25
@@ -6287,7 +7338,7 @@ Types:
           Type: 1 BaseType uintptr
         - Name: dirPtr
           Offset: 16
-          Type: 101 PointerType **table<bool,main.node>
+          Type: 124 PointerType **table<bool,main.node>
         - Name: dirLen
           Offset: 24
           Type: 7 BaseType int
@@ -6303,10 +7354,138 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 8 BaseType uint64
-      TablePtrSliceType: 212 GoSliceDataType []*table<bool,main.node>.array
-      GroupType: 209 StructureType noalg.map.group[bool]main.node
+      TablePtrSliceType: 248 GoSliceDataType []*table<bool,main.node>.array
+      GroupType: 245 StructureType noalg.map.group[bool]main.node
     - __kind: GoSwissMapHeaderType
-      ID: 68
+      ID: 70
+      Name: map<int,*main.deepMap2>
+      ByteSize: 48
+      GoKind: 25
+      RawFields:
+        - Name: used
+          Offset: 0
+          Type: 8 BaseType uint64
+        - Name: seed
+          Offset: 8
+          Type: 1 BaseType uintptr
+        - Name: dirPtr
+          Offset: 16
+          Type: 71 PointerType **table<int,*main.deepMap2>
+        - Name: dirLen
+          Offset: 24
+          Type: 7 BaseType int
+        - Name: globalDepth
+          Offset: 32
+          Type: 3 BaseType uint8
+        - Name: globalShift
+          Offset: 33
+          Type: 3 BaseType uint8
+        - Name: writing
+          Offset: 34
+          Type: 3 BaseType uint8
+        - Name: clearSeq
+          Offset: 40
+          Type: 8 BaseType uint64
+      TablePtrSliceType: 189 GoSliceDataType []*table<int,*main.deepMap2>.array
+      GroupType: 184 StructureType noalg.map.group[int]*main.deepMap2
+    - __kind: GoSwissMapHeaderType
+      ID: 316
+      Name: map<int,*main.deepMap3>
+      ByteSize: 48
+      GoKind: 25
+      RawFields:
+        - Name: used
+          Offset: 0
+          Type: 8 BaseType uint64
+        - Name: seed
+          Offset: 8
+          Type: 1 BaseType uintptr
+        - Name: dirPtr
+          Offset: 16
+          Type: 317 PointerType **table<int,*main.deepMap3>
+        - Name: dirLen
+          Offset: 24
+          Type: 7 BaseType int
+        - Name: globalDepth
+          Offset: 32
+          Type: 3 BaseType uint8
+        - Name: globalShift
+          Offset: 33
+          Type: 3 BaseType uint8
+        - Name: writing
+          Offset: 34
+          Type: 3 BaseType uint8
+        - Name: clearSeq
+          Offset: 40
+          Type: 8 BaseType uint64
+      TablePtrSliceType: 327 GoSliceDataType []*table<int,*main.deepMap3>.array
+      GroupType: 322 StructureType noalg.map.group[int]*main.deepMap3
+    - __kind: GoSwissMapHeaderType
+      ID: 351
+      Name: map<int,*main.deepMap8>
+      ByteSize: 48
+      GoKind: 25
+      RawFields:
+        - Name: used
+          Offset: 0
+          Type: 8 BaseType uint64
+        - Name: seed
+          Offset: 8
+          Type: 1 BaseType uintptr
+        - Name: dirPtr
+          Offset: 16
+          Type: 352 PointerType **table<int,*main.deepMap8>
+        - Name: dirLen
+          Offset: 24
+          Type: 7 BaseType int
+        - Name: globalDepth
+          Offset: 32
+          Type: 3 BaseType uint8
+        - Name: globalShift
+          Offset: 33
+          Type: 3 BaseType uint8
+        - Name: writing
+          Offset: 34
+          Type: 3 BaseType uint8
+        - Name: clearSeq
+          Offset: 40
+          Type: 8 BaseType uint64
+      TablePtrSliceType: 362 GoSliceDataType []*table<int,*main.deepMap8>.array
+      GroupType: 357 StructureType noalg.map.group[int]*main.deepMap8
+    - __kind: GoSwissMapHeaderType
+      ID: 366
+      Name: map<int,*main.deepMap9>
+      ByteSize: 48
+      GoKind: 25
+      RawFields:
+        - Name: used
+          Offset: 0
+          Type: 8 BaseType uint64
+        - Name: seed
+          Offset: 8
+          Type: 1 BaseType uintptr
+        - Name: dirPtr
+          Offset: 16
+          Type: 367 PointerType **table<int,*main.deepMap9>
+        - Name: dirLen
+          Offset: 24
+          Type: 7 BaseType int
+        - Name: globalDepth
+          Offset: 32
+          Type: 3 BaseType uint8
+        - Name: globalShift
+          Offset: 33
+          Type: 3 BaseType uint8
+        - Name: writing
+          Offset: 34
+          Type: 3 BaseType uint8
+        - Name: clearSeq
+          Offset: 40
+          Type: 8 BaseType uint64
+      TablePtrSliceType: 377 GoSliceDataType []*table<int,*main.deepMap9>.array
+      GroupType: 372 StructureType noalg.map.group[int]*main.deepMap9
+    - __kind: GoSwissMapHeaderType
+      ID: 91
       Name: map<int,int>
       ByteSize: 48
       GoKind: 25
@@ -6319,7 +7498,7 @@ Types:
           Type: 1 BaseType uintptr
         - Name: dirPtr
           Offset: 16
-          Type: 69 PointerType **table<int,int>
+          Type: 92 PointerType **table<int,int>
         - Name: dirLen
           Offset: 24
           Type: 7 BaseType int
@@ -6335,10 +7514,42 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 8 BaseType uint64
-      TablePtrSliceType: 161 GoSliceDataType []*table<int,int>.array
-      GroupType: 158 StructureType noalg.map.group[int]int
+      TablePtrSliceType: 197 GoSliceDataType []*table<int,int>.array
+      GroupType: 194 StructureType noalg.map.group[int]int
     - __kind: GoSwissMapHeaderType
-      ID: 105
+      ID: 381
+      Name: map<int,interface {}>
+      ByteSize: 48
+      GoKind: 25
+      RawFields:
+        - Name: used
+          Offset: 0
+          Type: 8 BaseType uint64
+        - Name: seed
+          Offset: 8
+          Type: 1 BaseType uintptr
+        - Name: dirPtr
+          Offset: 16
+          Type: 382 PointerType **table<int,interface {}>
+        - Name: dirLen
+          Offset: 24
+          Type: 7 BaseType int
+        - Name: globalDepth
+          Offset: 32
+          Type: 3 BaseType uint8
+        - Name: globalShift
+          Offset: 33
+          Type: 3 BaseType uint8
+        - Name: writing
+          Offset: 34
+          Type: 3 BaseType uint8
+        - Name: clearSeq
+          Offset: 40
+          Type: 8 BaseType uint64
+      TablePtrSliceType: 390 GoSliceDataType []*table<int,interface {}>.array
+      GroupType: 387 StructureType noalg.map.group[int]interface {}
+    - __kind: GoSwissMapHeaderType
+      ID: 128
       Name: map<int,uint8>
       ByteSize: 48
       GoKind: 25
@@ -6351,7 +7562,7 @@ Types:
           Type: 1 BaseType uintptr
         - Name: dirPtr
           Offset: 16
-          Type: 106 PointerType **table<int,uint8>
+          Type: 129 PointerType **table<int,uint8>
         - Name: dirLen
           Offset: 24
           Type: 7 BaseType int
@@ -6367,10 +7578,10 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 8 BaseType uint64
-      TablePtrSliceType: 220 GoSliceDataType []*table<int,uint8>.array
-      GroupType: 217 StructureType noalg.map.group[int]uint8
+      TablePtrSliceType: 256 GoSliceDataType []*table<int,uint8>.array
+      GroupType: 253 StructureType noalg.map.group[int]uint8
     - __kind: GoSwissMapHeaderType
-      ID: 95
+      ID: 118
       Name: map<string,[]main.structWithMap>
       ByteSize: 48
       GoKind: 25
@@ -6383,7 +7594,7 @@ Types:
           Type: 1 BaseType uintptr
         - Name: dirPtr
           Offset: 16
-          Type: 96 PointerType **table<string,[]main.structWithMap>
+          Type: 119 PointerType **table<string,[]main.structWithMap>
         - Name: dirLen
           Offset: 24
           Type: 7 BaseType int
@@ -6399,10 +7610,10 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 8 BaseType uint64
-      TablePtrSliceType: 204 GoSliceDataType []*table<string,[]main.structWithMap>.array
-      GroupType: 199 StructureType noalg.map.group[string][]main.structWithMap
+      TablePtrSliceType: 240 GoSliceDataType []*table<string,[]main.structWithMap>.array
+      GroupType: 235 StructureType noalg.map.group[string][]main.structWithMap
     - __kind: GoSwissMapHeaderType
-      ID: 83
+      ID: 106
       Name: map<string,[]string>
       ByteSize: 48
       GoKind: 25
@@ -6415,7 +7626,7 @@ Types:
           Type: 1 BaseType uintptr
         - Name: dirPtr
           Offset: 16
-          Type: 84 PointerType **table<string,[]string>
+          Type: 107 PointerType **table<string,[]string>
         - Name: dirLen
           Offset: 24
           Type: 7 BaseType int
@@ -6431,10 +7642,10 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 8 BaseType uint64
-      TablePtrSliceType: 185 GoSliceDataType []*table<string,[]string>.array
-      GroupType: 182 StructureType noalg.map.group[string][]string
+      TablePtrSliceType: 221 GoSliceDataType []*table<string,[]string>.array
+      GroupType: 218 StructureType noalg.map.group[string][]string
     - __kind: GoSwissMapHeaderType
-      ID: 78
+      ID: 101
       Name: map<string,int>
       ByteSize: 48
       GoKind: 25
@@ -6447,7 +7658,7 @@ Types:
           Type: 1 BaseType uintptr
         - Name: dirPtr
           Offset: 16
-          Type: 79 PointerType **table<string,int>
+          Type: 102 PointerType **table<string,int>
         - Name: dirLen
           Offset: 24
           Type: 7 BaseType int
@@ -6463,10 +7674,10 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 8 BaseType uint64
-      TablePtrSliceType: 177 GoSliceDataType []*table<string,int>.array
-      GroupType: 174 StructureType noalg.map.group[string]int
+      TablePtrSliceType: 213 GoSliceDataType []*table<string,int>.array
+      GroupType: 210 StructureType noalg.map.group[string]int
     - __kind: GoSwissMapHeaderType
-      ID: 73
+      ID: 96
       Name: map<string,main.nestedStruct>
       ByteSize: 48
       GoKind: 25
@@ -6479,7 +7690,7 @@ Types:
           Type: 1 BaseType uintptr
         - Name: dirPtr
           Offset: 16
-          Type: 74 PointerType **table<string,main.nestedStruct>
+          Type: 97 PointerType **table<string,main.nestedStruct>
         - Name: dirLen
           Offset: 24
           Type: 7 BaseType int
@@ -6495,10 +7706,10 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 8 BaseType uint64
-      TablePtrSliceType: 169 GoSliceDataType []*table<string,main.nestedStruct>.array
-      GroupType: 166 StructureType noalg.map.group[string]main.nestedStruct
+      TablePtrSliceType: 205 GoSliceDataType []*table<string,main.nestedStruct>.array
+      GroupType: 202 StructureType noalg.map.group[string]main.nestedStruct
     - __kind: GoSwissMapHeaderType
-      ID: 115
+      ID: 138
       Name: map<uint8,[4]int>
       ByteSize: 48
       GoKind: 25
@@ -6511,7 +7722,7 @@ Types:
           Type: 1 BaseType uintptr
         - Name: dirPtr
           Offset: 16
-          Type: 116 PointerType **table<uint8,[4]int>
+          Type: 139 PointerType **table<uint8,[4]int>
         - Name: dirLen
           Offset: 24
           Type: 7 BaseType int
@@ -6527,10 +7738,10 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 8 BaseType uint64
-      TablePtrSliceType: 237 GoSliceDataType []*table<uint8,[4]int>.array
-      GroupType: 233 StructureType noalg.map.group[uint8][4]int
+      TablePtrSliceType: 273 GoSliceDataType []*table<uint8,[4]int>.array
+      GroupType: 269 StructureType noalg.map.group[uint8][4]int
     - __kind: GoSwissMapHeaderType
-      ID: 110
+      ID: 133
       Name: map<uint8,uint8>
       ByteSize: 48
       GoKind: 25
@@ -6543,7 +7754,7 @@ Types:
           Type: 1 BaseType uintptr
         - Name: dirPtr
           Offset: 16
-          Type: 111 PointerType **table<uint8,uint8>
+          Type: 134 PointerType **table<uint8,uint8>
         - Name: dirLen
           Offset: 24
           Type: 7 BaseType int
@@ -6559,205 +7770,285 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 8 BaseType uint64
-      TablePtrSliceType: 228 GoSliceDataType []*table<uint8,uint8>.array
-      GroupType: 225 StructureType noalg.map.group[uint8]uint8
+      TablePtrSliceType: 264 GoSliceDataType []*table<uint8,uint8>.array
+      GroupType: 261 StructureType noalg.map.group[uint8]uint8
     - __kind: GoMapType
-      ID: 123
+      ID: 146
       Name: map[[4]int][4]int
       ByteSize: 8
-      GoRuntimeType: 1.117568e+06
+      GoRuntimeType: 1.124704e+06
       GoKind: 21
-      HeaderType: 125 GoSwissMapHeaderType map<[4]int,[4]int>
+      HeaderType: 148 GoSwissMapHeaderType map<[4]int,[4]int>
     - __kind: GoMapType
-      ID: 118
+      ID: 141
       Name: map[[4]int]uint8
       ByteSize: 8
-      GoRuntimeType: 1.117696e+06
+      GoRuntimeType: 1.124832e+06
       GoKind: 21
-      HeaderType: 120 GoSwissMapHeaderType map<[4]int,uint8>
+      HeaderType: 143 GoSwissMapHeaderType map<[4]int,uint8>
     - __kind: GoMapType
-      ID: 86
+      ID: 109
       Name: map[[4]string][2]int
       ByteSize: 8
-      GoRuntimeType: 1.117824e+06
+      GoRuntimeType: 1.12496e+06
       GoKind: 21
-      HeaderType: 88 GoSwissMapHeaderType map<[4]string,[2]int>
+      HeaderType: 111 GoSwissMapHeaderType map<[4]string,[2]int>
     - __kind: GoMapType
-      ID: 98
+      ID: 121
       Name: map[bool]main.node
       ByteSize: 8
-      GoRuntimeType: 1.117952e+06
+      GoRuntimeType: 1.125088e+06
       GoKind: 21
-      HeaderType: 100 GoSwissMapHeaderType map<bool,main.node>
+      HeaderType: 123 GoSwissMapHeaderType map<bool,main.node>
     - __kind: GoMapType
-      ID: 66
+      ID: 68
+      Name: map[int]*main.deepMap2
+      ByteSize: 8
+      GoRuntimeType: 1.124576e+06
+      GoKind: 21
+      HeaderType: 70 GoSwissMapHeaderType map<int,*main.deepMap2>
+    - __kind: GoMapType
+      ID: 314
+      Name: map[int]*main.deepMap3
+      ByteSize: 8
+      GoRuntimeType: 1.124448e+06
+      GoKind: 21
+      HeaderType: 316 GoSwissMapHeaderType map<int,*main.deepMap3>
+    - __kind: GoMapType
+      ID: 349
+      Name: map[int]*main.deepMap8
+      ByteSize: 8
+      GoRuntimeType: 1.123808e+06
+      GoKind: 21
+      HeaderType: 351 GoSwissMapHeaderType map<int,*main.deepMap8>
+    - __kind: GoMapType
+      ID: 364
+      Name: map[int]*main.deepMap9
+      ByteSize: 8
+      GoRuntimeType: 1.12368e+06
+      GoKind: 21
+      HeaderType: 366 GoSwissMapHeaderType map<int,*main.deepMap9>
+    - __kind: GoMapType
+      ID: 89
       Name: map[int]int
       ByteSize: 8
-      GoRuntimeType: 1.117184e+06
+      GoRuntimeType: 1.123168e+06
       GoKind: 21
-      HeaderType: 68 GoSwissMapHeaderType map<int,int>
+      HeaderType: 91 GoSwissMapHeaderType map<int,int>
     - __kind: GoMapType
-      ID: 103
+      ID: 379
+      Name: map[int]interface {}
+      ByteSize: 8
+      GoRuntimeType: 1.123552e+06
+      GoKind: 21
+      HeaderType: 381 GoSwissMapHeaderType map<int,interface {}>
+    - __kind: GoMapType
+      ID: 126
       Name: map[int]uint8
       ByteSize: 8
-      GoRuntimeType: 1.11808e+06
+      GoRuntimeType: 1.125216e+06
       GoKind: 21
-      HeaderType: 105 GoSwissMapHeaderType map<int,uint8>
+      HeaderType: 128 GoSwissMapHeaderType map<int,uint8>
     - __kind: GoMapType
-      ID: 93
+      ID: 116
       Name: map[string][]main.structWithMap
       ByteSize: 8
-      GoRuntimeType: 1.118208e+06
+      GoRuntimeType: 1.125344e+06
       GoKind: 21
-      HeaderType: 95 GoSwissMapHeaderType map<string,[]main.structWithMap>
+      HeaderType: 118 GoSwissMapHeaderType map<string,[]main.structWithMap>
     - __kind: GoMapType
-      ID: 81
+      ID: 104
       Name: map[string][]string
       ByteSize: 8
-      GoRuntimeType: 1.118336e+06
+      GoRuntimeType: 1.125472e+06
       GoKind: 21
-      HeaderType: 83 GoSwissMapHeaderType map<string,[]string>
+      HeaderType: 106 GoSwissMapHeaderType map<string,[]string>
     - __kind: GoMapType
-      ID: 76
+      ID: 99
       Name: map[string]int
       ByteSize: 8
-      GoRuntimeType: 1.118464e+06
+      GoRuntimeType: 1.1256e+06
       GoKind: 21
-      HeaderType: 78 GoSwissMapHeaderType map<string,int>
+      HeaderType: 101 GoSwissMapHeaderType map<string,int>
     - __kind: GoMapType
-      ID: 71
+      ID: 94
       Name: map[string]main.nestedStruct
       ByteSize: 8
-      GoRuntimeType: 1.118592e+06
+      GoRuntimeType: 1.125728e+06
       GoKind: 21
-      HeaderType: 73 GoSwissMapHeaderType map<string,main.nestedStruct>
+      HeaderType: 96 GoSwissMapHeaderType map<string,main.nestedStruct>
     - __kind: GoMapType
-      ID: 113
+      ID: 136
       Name: map[uint8][4]int
       ByteSize: 8
-      GoRuntimeType: 1.11872e+06
+      GoRuntimeType: 1.125856e+06
       GoKind: 21
-      HeaderType: 115 GoSwissMapHeaderType map<uint8,[4]int>
+      HeaderType: 138 GoSwissMapHeaderType map<uint8,[4]int>
     - __kind: GoMapType
-      ID: 108
+      ID: 131
       Name: map[uint8]uint8
       ByteSize: 8
-      GoRuntimeType: 1.118848e+06
+      GoRuntimeType: 1.125984e+06
       GoKind: 21
-      HeaderType: 110 GoSwissMapHeaderType map<uint8,uint8>
+      HeaderType: 133 GoSwissMapHeaderType map<uint8,uint8>
     - __kind: ArrayType
-      ID: 251
+      ID: 287
       Name: noalg.[8]struct { key [4]int; elem [4]int }
       ByteSize: 512
-      GoRuntimeType: 672992
+      GoRuntimeType: 678976
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 252 StructureType noalg.struct { key [4]int; elem [4]int }
+      Element: 288 StructureType noalg.struct { key [4]int; elem [4]int }
     - __kind: ArrayType
-      ID: 243
+      ID: 279
       Name: noalg.[8]struct { key [4]int; elem uint8 }
       ByteSize: 320
-      GoRuntimeType: 673088
+      GoRuntimeType: 679072
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 244 StructureType noalg.struct { key [4]int; elem uint8 }
+      Element: 280 StructureType noalg.struct { key [4]int; elem uint8 }
     - __kind: ArrayType
-      ID: 191
+      ID: 227
       Name: noalg.[8]struct { key [4]string; elem [2]int }
       ByteSize: 640
-      GoRuntimeType: 673376
+      GoRuntimeType: 679360
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 192 StructureType noalg.struct { key [4]string; elem [2]int }
+      Element: 228 StructureType noalg.struct { key [4]string; elem [2]int }
     - __kind: ArrayType
-      ID: 210
+      ID: 246
       Name: noalg.[8]struct { key bool; elem main.node }
       ByteSize: 192
-      GoRuntimeType: 673472
+      GoRuntimeType: 679456
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 211 StructureType noalg.struct { key bool; elem main.node }
+      Element: 247 StructureType noalg.struct { key bool; elem main.node }
     - __kind: ArrayType
-      ID: 159
+      ID: 185
+      Name: noalg.[8]struct { key int; elem *main.deepMap2 }
+      ByteSize: 128
+      GoRuntimeType: 678304
+      GoKind: 17
+      Count: 8
+      HasCount: true
+      Element: 186 StructureType noalg.struct { key int; elem *main.deepMap2 }
+    - __kind: ArrayType
+      ID: 323
+      Name: noalg.[8]struct { key int; elem *main.deepMap3 }
+      ByteSize: 128
+      GoRuntimeType: 678208
+      GoKind: 17
+      Count: 8
+      HasCount: true
+      Element: 324 StructureType noalg.struct { key int; elem *main.deepMap3 }
+    - __kind: ArrayType
+      ID: 358
+      Name: noalg.[8]struct { key int; elem *main.deepMap8 }
+      ByteSize: 128
+      GoRuntimeType: 677728
+      GoKind: 17
+      Count: 8
+      HasCount: true
+      Element: 359 StructureType noalg.struct { key int; elem *main.deepMap8 }
+    - __kind: ArrayType
+      ID: 373
+      Name: noalg.[8]struct { key int; elem *main.deepMap9 }
+      ByteSize: 128
+      GoRuntimeType: 677632
+      GoKind: 17
+      Count: 8
+      HasCount: true
+      Element: 374 StructureType noalg.struct { key int; elem *main.deepMap9 }
+    - __kind: ArrayType
+      ID: 195
       Name: noalg.[8]struct { key int; elem int }
       ByteSize: 128
-      GoRuntimeType: 671264
+      GoRuntimeType: 676384
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 160 StructureType noalg.struct { key int; elem int }
+      Element: 196 StructureType noalg.struct { key int; elem int }
     - __kind: ArrayType
-      ID: 218
+      ID: 388
+      Name: noalg.[8]struct { key int; elem interface {} }
+      ByteSize: 192
+      GoRuntimeType: 677536
+      GoKind: 17
+      Count: 8
+      HasCount: true
+      Element: 389 StructureType noalg.struct { key int; elem interface {} }
+    - __kind: ArrayType
+      ID: 254
       Name: noalg.[8]struct { key int; elem uint8 }
       ByteSize: 128
-      GoRuntimeType: 673568
+      GoRuntimeType: 679552
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 219 StructureType noalg.struct { key int; elem uint8 }
+      Element: 255 StructureType noalg.struct { key int; elem uint8 }
     - __kind: ArrayType
-      ID: 200
+      ID: 236
       Name: noalg.[8]struct { key string; elem []main.structWithMap }
       ByteSize: 320
-      GoRuntimeType: 673664
+      GoRuntimeType: 679648
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 201 StructureType noalg.struct { key string; elem []main.structWithMap }
+      Element: 237 StructureType noalg.struct { key string; elem []main.structWithMap }
     - __kind: ArrayType
-      ID: 183
+      ID: 219
       Name: noalg.[8]struct { key string; elem []string }
       ByteSize: 320
-      GoRuntimeType: 673760
+      GoRuntimeType: 679744
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 184 StructureType noalg.struct { key string; elem []string }
+      Element: 220 StructureType noalg.struct { key string; elem []string }
     - __kind: ArrayType
-      ID: 175
+      ID: 211
       Name: noalg.[8]struct { key string; elem int }
       ByteSize: 192
-      GoRuntimeType: 673856
+      GoRuntimeType: 679840
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 176 StructureType noalg.struct { key string; elem int }
+      Element: 212 StructureType noalg.struct { key string; elem int }
     - __kind: ArrayType
-      ID: 167
+      ID: 203
       Name: noalg.[8]struct { key string; elem main.nestedStruct }
       ByteSize: 320
-      GoRuntimeType: 673952
+      GoRuntimeType: 679936
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 168 StructureType noalg.struct { key string; elem main.nestedStruct }
+      Element: 204 StructureType noalg.struct { key string; elem main.nestedStruct }
     - __kind: ArrayType
-      ID: 234
+      ID: 270
       Name: noalg.[8]struct { key uint8; elem [4]int }
       ByteSize: 320
-      GoRuntimeType: 674048
+      GoRuntimeType: 680032
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 235 StructureType noalg.struct { key uint8; elem [4]int }
+      Element: 271 StructureType noalg.struct { key uint8; elem [4]int }
     - __kind: ArrayType
-      ID: 226
+      ID: 262
       Name: noalg.[8]struct { key uint8; elem uint8 }
       ByteSize: 16
-      GoRuntimeType: 674144
+      GoRuntimeType: 680128
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 227 StructureType noalg.struct { key uint8; elem uint8 }
+      Element: 263 StructureType noalg.struct { key uint8; elem uint8 }
     - __kind: StructureType
-      ID: 250
+      ID: 286
       Name: noalg.map.group[[4]int][4]int
       ByteSize: 520
-      GoRuntimeType: 1.277248e+06
+      GoRuntimeType: 1.290144e+06
       GoKind: 25
       RawFields:
         - Name: ctrl
@@ -6765,12 +8056,12 @@ Types:
           Type: 8 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 251 ArrayType noalg.[8]struct { key [4]int; elem [4]int }
+          Type: 287 ArrayType noalg.[8]struct { key [4]int; elem [4]int }
     - __kind: StructureType
-      ID: 242
+      ID: 278
       Name: noalg.map.group[[4]int]uint8
       ByteSize: 328
-      GoRuntimeType: 1.277504e+06
+      GoRuntimeType: 1.2904e+06
       GoKind: 25
       RawFields:
         - Name: ctrl
@@ -6778,12 +8069,12 @@ Types:
           Type: 8 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 243 ArrayType noalg.[8]struct { key [4]int; elem uint8 }
+          Type: 279 ArrayType noalg.[8]struct { key [4]int; elem uint8 }
     - __kind: StructureType
-      ID: 190
+      ID: 226
       Name: noalg.map.group[[4]string][2]int
       ByteSize: 648
-      GoRuntimeType: 1.27776e+06
+      GoRuntimeType: 1.290656e+06
       GoKind: 25
       RawFields:
         - Name: ctrl
@@ -6791,12 +8082,12 @@ Types:
           Type: 8 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 191 ArrayType noalg.[8]struct { key [4]string; elem [2]int }
+          Type: 227 ArrayType noalg.[8]struct { key [4]string; elem [2]int }
     - __kind: StructureType
-      ID: 209
+      ID: 245
       Name: noalg.map.group[bool]main.node
       ByteSize: 200
-      GoRuntimeType: 1.278016e+06
+      GoRuntimeType: 1.290912e+06
       GoKind: 25
       RawFields:
         - Name: ctrl
@@ -6804,12 +8095,64 @@ Types:
           Type: 8 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 210 ArrayType noalg.[8]struct { key bool; elem main.node }
+          Type: 246 ArrayType noalg.[8]struct { key bool; elem main.node }
     - __kind: StructureType
-      ID: 158
+      ID: 184
+      Name: noalg.map.group[int]*main.deepMap2
+      ByteSize: 136
+      GoRuntimeType: 1.289888e+06
+      GoKind: 25
+      RawFields:
+        - Name: ctrl
+          Offset: 0
+          Type: 8 BaseType uint64
+        - Name: slots
+          Offset: 8
+          Type: 185 ArrayType noalg.[8]struct { key int; elem *main.deepMap2 }
+    - __kind: StructureType
+      ID: 322
+      Name: noalg.map.group[int]*main.deepMap3
+      ByteSize: 136
+      GoRuntimeType: 1.289632e+06
+      GoKind: 25
+      RawFields:
+        - Name: ctrl
+          Offset: 0
+          Type: 8 BaseType uint64
+        - Name: slots
+          Offset: 8
+          Type: 323 ArrayType noalg.[8]struct { key int; elem *main.deepMap3 }
+    - __kind: StructureType
+      ID: 357
+      Name: noalg.map.group[int]*main.deepMap8
+      ByteSize: 136
+      GoRuntimeType: 1.288352e+06
+      GoKind: 25
+      RawFields:
+        - Name: ctrl
+          Offset: 0
+          Type: 8 BaseType uint64
+        - Name: slots
+          Offset: 8
+          Type: 358 ArrayType noalg.[8]struct { key int; elem *main.deepMap8 }
+    - __kind: StructureType
+      ID: 372
+      Name: noalg.map.group[int]*main.deepMap9
+      ByteSize: 136
+      GoRuntimeType: 1.288096e+06
+      GoKind: 25
+      RawFields:
+        - Name: ctrl
+          Offset: 0
+          Type: 8 BaseType uint64
+        - Name: slots
+          Offset: 8
+          Type: 373 ArrayType noalg.[8]struct { key int; elem *main.deepMap9 }
+    - __kind: StructureType
+      ID: 194
       Name: noalg.map.group[int]int
       ByteSize: 136
-      GoRuntimeType: 1.27648e+06
+      GoRuntimeType: 1.287072e+06
       GoKind: 25
       RawFields:
         - Name: ctrl
@@ -6817,12 +8160,25 @@ Types:
           Type: 8 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 159 ArrayType noalg.[8]struct { key int; elem int }
+          Type: 195 ArrayType noalg.[8]struct { key int; elem int }
     - __kind: StructureType
-      ID: 217
+      ID: 387
+      Name: noalg.map.group[int]interface {}
+      ByteSize: 200
+      GoRuntimeType: 1.28784e+06
+      GoKind: 25
+      RawFields:
+        - Name: ctrl
+          Offset: 0
+          Type: 8 BaseType uint64
+        - Name: slots
+          Offset: 8
+          Type: 388 ArrayType noalg.[8]struct { key int; elem interface {} }
+    - __kind: StructureType
+      ID: 253
       Name: noalg.map.group[int]uint8
       ByteSize: 136
-      GoRuntimeType: 1.278272e+06
+      GoRuntimeType: 1.291168e+06
       GoKind: 25
       RawFields:
         - Name: ctrl
@@ -6830,12 +8186,12 @@ Types:
           Type: 8 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 218 ArrayType noalg.[8]struct { key int; elem uint8 }
+          Type: 254 ArrayType noalg.[8]struct { key int; elem uint8 }
     - __kind: StructureType
-      ID: 199
+      ID: 235
       Name: noalg.map.group[string][]main.structWithMap
       ByteSize: 328
-      GoRuntimeType: 1.278528e+06
+      GoRuntimeType: 1.291424e+06
       GoKind: 25
       RawFields:
         - Name: ctrl
@@ -6843,12 +8199,12 @@ Types:
           Type: 8 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 200 ArrayType noalg.[8]struct { key string; elem []main.structWithMap }
+          Type: 236 ArrayType noalg.[8]struct { key string; elem []main.structWithMap }
     - __kind: StructureType
-      ID: 182
+      ID: 218
       Name: noalg.map.group[string][]string
       ByteSize: 328
-      GoRuntimeType: 1.278784e+06
+      GoRuntimeType: 1.29168e+06
       GoKind: 25
       RawFields:
         - Name: ctrl
@@ -6856,12 +8212,12 @@ Types:
           Type: 8 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 183 ArrayType noalg.[8]struct { key string; elem []string }
+          Type: 219 ArrayType noalg.[8]struct { key string; elem []string }
     - __kind: StructureType
-      ID: 174
+      ID: 210
       Name: noalg.map.group[string]int
       ByteSize: 200
-      GoRuntimeType: 1.27904e+06
+      GoRuntimeType: 1.291936e+06
       GoKind: 25
       RawFields:
         - Name: ctrl
@@ -6869,12 +8225,12 @@ Types:
           Type: 8 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 175 ArrayType noalg.[8]struct { key string; elem int }
+          Type: 211 ArrayType noalg.[8]struct { key string; elem int }
     - __kind: StructureType
-      ID: 166
+      ID: 202
       Name: noalg.map.group[string]main.nestedStruct
       ByteSize: 328
-      GoRuntimeType: 1.279296e+06
+      GoRuntimeType: 1.292192e+06
       GoKind: 25
       RawFields:
         - Name: ctrl
@@ -6882,12 +8238,12 @@ Types:
           Type: 8 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 167 ArrayType noalg.[8]struct { key string; elem main.nestedStruct }
+          Type: 203 ArrayType noalg.[8]struct { key string; elem main.nestedStruct }
     - __kind: StructureType
-      ID: 233
+      ID: 269
       Name: noalg.map.group[uint8][4]int
       ByteSize: 328
-      GoRuntimeType: 1.279552e+06
+      GoRuntimeType: 1.292448e+06
       GoKind: 25
       RawFields:
         - Name: ctrl
@@ -6895,12 +8251,12 @@ Types:
           Type: 8 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 234 ArrayType noalg.[8]struct { key uint8; elem [4]int }
+          Type: 270 ArrayType noalg.[8]struct { key uint8; elem [4]int }
     - __kind: StructureType
-      ID: 225
+      ID: 261
       Name: noalg.map.group[uint8]uint8
       ByteSize: 24
-      GoRuntimeType: 1.279808e+06
+      GoRuntimeType: 1.292704e+06
       GoKind: 25
       RawFields:
         - Name: ctrl
@@ -6908,51 +8264,51 @@ Types:
           Type: 8 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 226 ArrayType noalg.[8]struct { key uint8; elem uint8 }
+          Type: 262 ArrayType noalg.[8]struct { key uint8; elem uint8 }
     - __kind: StructureType
-      ID: 252
+      ID: 288
       Name: noalg.struct { key [4]int; elem [4]int }
       ByteSize: 64
-      GoRuntimeType: 1.27712e+06
+      GoRuntimeType: 1.290016e+06
       GoKind: 25
       RawFields:
         - Name: key
           Offset: 0
-          Type: 236 ArrayType [4]int
+          Type: 272 ArrayType [4]int
         - Name: elem
           Offset: 32
-          Type: 236 ArrayType [4]int
+          Type: 272 ArrayType [4]int
     - __kind: StructureType
-      ID: 244
+      ID: 280
       Name: noalg.struct { key [4]int; elem uint8 }
       ByteSize: 40
-      GoRuntimeType: 1.277376e+06
+      GoRuntimeType: 1.290272e+06
       GoKind: 25
       RawFields:
         - Name: key
           Offset: 0
-          Type: 236 ArrayType [4]int
+          Type: 272 ArrayType [4]int
         - Name: elem
           Offset: 32
           Type: 3 BaseType uint8
     - __kind: StructureType
-      ID: 192
+      ID: 228
       Name: noalg.struct { key [4]string; elem [2]int }
       ByteSize: 80
-      GoRuntimeType: 1.277632e+06
+      GoRuntimeType: 1.290528e+06
       GoKind: 25
       RawFields:
         - Name: key
           Offset: 0
-          Type: 193 ArrayType [4]string
+          Type: 229 ArrayType [4]string
         - Name: elem
           Offset: 64
           Type: 40 ArrayType [2]int
     - __kind: StructureType
-      ID: 211
+      ID: 247
       Name: noalg.struct { key bool; elem main.node }
       ByteSize: 24
-      GoRuntimeType: 1.277888e+06
+      GoRuntimeType: 1.290784e+06
       GoKind: 25
       RawFields:
         - Name: key
@@ -6960,12 +8316,64 @@ Types:
           Type: 4 BaseType bool
         - Name: elem
           Offset: 8
-          Type: 131 StructureType main.node
+          Type: 154 StructureType main.node
     - __kind: StructureType
-      ID: 160
+      ID: 186
+      Name: noalg.struct { key int; elem *main.deepMap2 }
+      ByteSize: 16
+      GoRuntimeType: 1.28976e+06
+      GoKind: 25
+      RawFields:
+        - Name: key
+          Offset: 0
+          Type: 7 BaseType int
+        - Name: elem
+          Offset: 8
+          Type: 187 PointerType *main.deepMap2
+    - __kind: StructureType
+      ID: 324
+      Name: noalg.struct { key int; elem *main.deepMap3 }
+      ByteSize: 16
+      GoRuntimeType: 1.289504e+06
+      GoKind: 25
+      RawFields:
+        - Name: key
+          Offset: 0
+          Type: 7 BaseType int
+        - Name: elem
+          Offset: 8
+          Type: 325 PointerType *main.deepMap3
+    - __kind: StructureType
+      ID: 359
+      Name: noalg.struct { key int; elem *main.deepMap8 }
+      ByteSize: 16
+      GoRuntimeType: 1.288224e+06
+      GoKind: 25
+      RawFields:
+        - Name: key
+          Offset: 0
+          Type: 7 BaseType int
+        - Name: elem
+          Offset: 8
+          Type: 360 PointerType *main.deepMap8
+    - __kind: StructureType
+      ID: 374
+      Name: noalg.struct { key int; elem *main.deepMap9 }
+      ByteSize: 16
+      GoRuntimeType: 1.287968e+06
+      GoKind: 25
+      RawFields:
+        - Name: key
+          Offset: 0
+          Type: 7 BaseType int
+        - Name: elem
+          Offset: 8
+          Type: 375 PointerType *main.deepMap9
+    - __kind: StructureType
+      ID: 196
       Name: noalg.struct { key int; elem int }
       ByteSize: 16
-      GoRuntimeType: 1.276352e+06
+      GoRuntimeType: 1.286944e+06
       GoKind: 25
       RawFields:
         - Name: key
@@ -6975,10 +8383,23 @@ Types:
           Offset: 8
           Type: 7 BaseType int
     - __kind: StructureType
-      ID: 219
+      ID: 389
+      Name: noalg.struct { key int; elem interface {} }
+      ByteSize: 24
+      GoRuntimeType: 1.287712e+06
+      GoKind: 25
+      RawFields:
+        - Name: key
+          Offset: 0
+          Type: 7 BaseType int
+        - Name: elem
+          Offset: 8
+          Type: 81 GoEmptyInterfaceType interface {}
+    - __kind: StructureType
+      ID: 255
       Name: noalg.struct { key int; elem uint8 }
       ByteSize: 16
-      GoRuntimeType: 1.278144e+06
+      GoRuntimeType: 1.29104e+06
       GoKind: 25
       RawFields:
         - Name: key
@@ -6988,10 +8409,10 @@ Types:
           Offset: 8
           Type: 3 BaseType uint8
     - __kind: StructureType
-      ID: 201
+      ID: 237
       Name: noalg.struct { key string; elem []main.structWithMap }
       ByteSize: 40
-      GoRuntimeType: 1.2784e+06
+      GoRuntimeType: 1.291296e+06
       GoKind: 25
       RawFields:
         - Name: key
@@ -6999,12 +8420,12 @@ Types:
           Type: 9 GoStringHeaderType string
         - Name: elem
           Offset: 16
-          Type: 202 GoSliceHeaderType []main.structWithMap
+          Type: 238 GoSliceHeaderType []main.structWithMap
     - __kind: StructureType
-      ID: 184
+      ID: 220
       Name: noalg.struct { key string; elem []string }
       ByteSize: 40
-      GoRuntimeType: 1.278656e+06
+      GoRuntimeType: 1.291552e+06
       GoKind: 25
       RawFields:
         - Name: key
@@ -7012,12 +8433,12 @@ Types:
           Type: 9 GoStringHeaderType string
         - Name: elem
           Offset: 16
-          Type: 141 GoSliceHeaderType []string
+          Type: 164 GoSliceHeaderType []string
     - __kind: StructureType
-      ID: 176
+      ID: 212
       Name: noalg.struct { key string; elem int }
       ByteSize: 24
-      GoRuntimeType: 1.278912e+06
+      GoRuntimeType: 1.291808e+06
       GoKind: 25
       RawFields:
         - Name: key
@@ -7027,10 +8448,10 @@ Types:
           Offset: 16
           Type: 7 BaseType int
     - __kind: StructureType
-      ID: 168
+      ID: 204
       Name: noalg.struct { key string; elem main.nestedStruct }
       ByteSize: 40
-      GoRuntimeType: 1.279168e+06
+      GoRuntimeType: 1.292064e+06
       GoKind: 25
       RawFields:
         - Name: key
@@ -7038,12 +8459,12 @@ Types:
           Type: 9 GoStringHeaderType string
         - Name: elem
           Offset: 16
-          Type: 149 StructureType main.nestedStruct
+          Type: 172 StructureType main.nestedStruct
     - __kind: StructureType
-      ID: 235
+      ID: 271
       Name: noalg.struct { key uint8; elem [4]int }
       ByteSize: 40
-      GoRuntimeType: 1.279424e+06
+      GoRuntimeType: 1.29232e+06
       GoKind: 25
       RawFields:
         - Name: key
@@ -7051,12 +8472,12 @@ Types:
           Type: 3 BaseType uint8
         - Name: elem
           Offset: 8
-          Type: 236 ArrayType [4]int
+          Type: 272 ArrayType [4]int
     - __kind: StructureType
-      ID: 227
+      ID: 263
       Name: noalg.struct { key uint8; elem uint8 }
       ByteSize: 2
-      GoRuntimeType: 1.27968e+06
+      GoRuntimeType: 1.292576e+06
       GoKind: 25
       RawFields:
         - Name: key
@@ -7069,127 +8490,127 @@ Types:
       ID: 9
       Name: string
       ByteSize: 16
-      GoRuntimeType: 575008
+      GoRuntimeType: 580128
       GoKind: 24
       RawFields:
         - Name: str
           Offset: 0
-          Type: 152 PointerType *string.str
+          Type: 175 PointerType *string.str
         - Name: len
           Offset: 8
           Type: 7 BaseType int
-      Data: 151 GoStringDataType string.str
+      Data: 174 GoStringDataType string.str
     - __kind: GoStringDataType
-      ID: 151
+      ID: 174
       Name: string.str
       ByteSize: 2048
     - __kind: StructureType
-      ID: 267
+      ID: 392
       Name: sync.Mutex
       ByteSize: 8
-      GoRuntimeType: 1.445344e+06
+      GoRuntimeType: 1.45824e+06
       GoKind: 25
       RawFields:
         - Name: _
           Offset: 0
-          Type: 268 StructureType sync.noCopy
+          Type: 393 StructureType sync.noCopy
         - Name: mu
           Offset: 0
-          Type: 269 StructureType internal/sync.Mutex
+          Type: 394 StructureType internal/sync.Mutex
     - __kind: StructureType
-      ID: 270
+      ID: 395
       Name: sync.Once
       ByteSize: 12
-      GoRuntimeType: 1.593696e+06
+      GoRuntimeType: 1.606592e+06
       GoKind: 25
       RawFields:
         - Name: _
           Offset: 0
-          Type: 268 StructureType sync.noCopy
+          Type: 393 StructureType sync.noCopy
         - Name: done
           Offset: 0
-          Type: 271 StructureType sync/atomic.Uint32
+          Type: 396 StructureType sync/atomic.Uint32
         - Name: m
           Offset: 4
-          Type: 267 StructureType sync.Mutex
+          Type: 392 StructureType sync.Mutex
     - __kind: StructureType
-      ID: 273
+      ID: 398
       Name: sync.WaitGroup
       ByteSize: 16
-      GoRuntimeType: 1.593888e+06
+      GoRuntimeType: 1.606784e+06
       GoKind: 25
       RawFields:
         - Name: noCopy
           Offset: 0
-          Type: 268 StructureType sync.noCopy
+          Type: 393 StructureType sync.noCopy
         - Name: state
           Offset: 0
-          Type: 274 StructureType sync/atomic.Uint64
+          Type: 399 StructureType sync/atomic.Uint64
         - Name: sema
           Offset: 8
           Type: 2 BaseType uint32
     - __kind: StructureType
-      ID: 268
+      ID: 393
       Name: sync.noCopy
-      GoRuntimeType: 977728
+      GoRuntimeType: 983712
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 276
+      ID: 401
       Name: sync/atomic.Int32
       ByteSize: 4
-      GoRuntimeType: 1.446624e+06
+      GoRuntimeType: 1.45952e+06
       GoKind: 25
       RawFields:
         - Name: _
           Offset: 0
-          Type: 272 StructureType sync/atomic.noCopy
+          Type: 397 StructureType sync/atomic.noCopy
         - Name: v
           Offset: 0
           Type: 10 BaseType int32
     - __kind: StructureType
-      ID: 271
+      ID: 396
       Name: sync/atomic.Uint32
       ByteSize: 4
-      GoRuntimeType: 1.446784e+06
+      GoRuntimeType: 1.45968e+06
       GoKind: 25
       RawFields:
         - Name: _
           Offset: 0
-          Type: 272 StructureType sync/atomic.noCopy
+          Type: 397 StructureType sync/atomic.noCopy
         - Name: v
           Offset: 0
           Type: 2 BaseType uint32
     - __kind: StructureType
-      ID: 274
+      ID: 399
       Name: sync/atomic.Uint64
       ByteSize: 8
-      GoRuntimeType: 1.594272e+06
+      GoRuntimeType: 1.607168e+06
       GoKind: 25
       RawFields:
         - Name: _
           Offset: 0
-          Type: 272 StructureType sync/atomic.noCopy
+          Type: 397 StructureType sync/atomic.noCopy
         - Name: _
           Offset: 0
-          Type: 275 StructureType sync/atomic.align64
+          Type: 400 StructureType sync/atomic.align64
         - Name: v
           Offset: 0
           Type: 8 BaseType uint64
     - __kind: StructureType
-      ID: 275
+      ID: 400
       Name: sync/atomic.align64
-      GoRuntimeType: 977920
+      GoRuntimeType: 983904
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 272
+      ID: 397
       Name: sync/atomic.noCopy
-      GoRuntimeType: 977824
+      GoRuntimeType: 983808
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 247
+      ID: 283
       Name: table<[4]int,[4]int>
       ByteSize: 32
       GoKind: 25
@@ -7211,9 +8632,9 @@ Types:
           Type: 7 BaseType int
         - Name: groups
           Offset: 16
-          Type: 248 GoSwissMapGroupsType groupReference<[4]int,[4]int>
+          Type: 284 GoSwissMapGroupsType groupReference<[4]int,[4]int>
     - __kind: StructureType
-      ID: 239
+      ID: 275
       Name: table<[4]int,uint8>
       ByteSize: 32
       GoKind: 25
@@ -7235,9 +8656,9 @@ Types:
           Type: 7 BaseType int
         - Name: groups
           Offset: 16
-          Type: 240 GoSwissMapGroupsType groupReference<[4]int,uint8>
+          Type: 276 GoSwissMapGroupsType groupReference<[4]int,uint8>
     - __kind: StructureType
-      ID: 187
+      ID: 223
       Name: table<[4]string,[2]int>
       ByteSize: 32
       GoKind: 25
@@ -7259,9 +8680,9 @@ Types:
           Type: 7 BaseType int
         - Name: groups
           Offset: 16
-          Type: 188 GoSwissMapGroupsType groupReference<[4]string,[2]int>
+          Type: 224 GoSwissMapGroupsType groupReference<[4]string,[2]int>
     - __kind: StructureType
-      ID: 206
+      ID: 242
       Name: table<bool,main.node>
       ByteSize: 32
       GoKind: 25
@@ -7283,9 +8704,105 @@ Types:
           Type: 7 BaseType int
         - Name: groups
           Offset: 16
-          Type: 207 GoSwissMapGroupsType groupReference<bool,main.node>
+          Type: 243 GoSwissMapGroupsType groupReference<bool,main.node>
     - __kind: StructureType
-      ID: 155
+      ID: 181
+      Name: table<int,*main.deepMap2>
+      ByteSize: 32
+      GoKind: 25
+      RawFields:
+        - Name: used
+          Offset: 0
+          Type: 6 BaseType uint16
+        - Name: capacity
+          Offset: 2
+          Type: 6 BaseType uint16
+        - Name: growthLeft
+          Offset: 4
+          Type: 6 BaseType uint16
+        - Name: localDepth
+          Offset: 6
+          Type: 3 BaseType uint8
+        - Name: index
+          Offset: 8
+          Type: 7 BaseType int
+        - Name: groups
+          Offset: 16
+          Type: 182 GoSwissMapGroupsType groupReference<int,*main.deepMap2>
+    - __kind: StructureType
+      ID: 319
+      Name: table<int,*main.deepMap3>
+      ByteSize: 32
+      GoKind: 25
+      RawFields:
+        - Name: used
+          Offset: 0
+          Type: 6 BaseType uint16
+        - Name: capacity
+          Offset: 2
+          Type: 6 BaseType uint16
+        - Name: growthLeft
+          Offset: 4
+          Type: 6 BaseType uint16
+        - Name: localDepth
+          Offset: 6
+          Type: 3 BaseType uint8
+        - Name: index
+          Offset: 8
+          Type: 7 BaseType int
+        - Name: groups
+          Offset: 16
+          Type: 320 GoSwissMapGroupsType groupReference<int,*main.deepMap3>
+    - __kind: StructureType
+      ID: 354
+      Name: table<int,*main.deepMap8>
+      ByteSize: 32
+      GoKind: 25
+      RawFields:
+        - Name: used
+          Offset: 0
+          Type: 6 BaseType uint16
+        - Name: capacity
+          Offset: 2
+          Type: 6 BaseType uint16
+        - Name: growthLeft
+          Offset: 4
+          Type: 6 BaseType uint16
+        - Name: localDepth
+          Offset: 6
+          Type: 3 BaseType uint8
+        - Name: index
+          Offset: 8
+          Type: 7 BaseType int
+        - Name: groups
+          Offset: 16
+          Type: 355 GoSwissMapGroupsType groupReference<int,*main.deepMap8>
+    - __kind: StructureType
+      ID: 369
+      Name: table<int,*main.deepMap9>
+      ByteSize: 32
+      GoKind: 25
+      RawFields:
+        - Name: used
+          Offset: 0
+          Type: 6 BaseType uint16
+        - Name: capacity
+          Offset: 2
+          Type: 6 BaseType uint16
+        - Name: growthLeft
+          Offset: 4
+          Type: 6 BaseType uint16
+        - Name: localDepth
+          Offset: 6
+          Type: 3 BaseType uint8
+        - Name: index
+          Offset: 8
+          Type: 7 BaseType int
+        - Name: groups
+          Offset: 16
+          Type: 370 GoSwissMapGroupsType groupReference<int,*main.deepMap9>
+    - __kind: StructureType
+      ID: 191
       Name: table<int,int>
       ByteSize: 32
       GoKind: 25
@@ -7307,9 +8824,33 @@ Types:
           Type: 7 BaseType int
         - Name: groups
           Offset: 16
-          Type: 156 GoSwissMapGroupsType groupReference<int,int>
+          Type: 192 GoSwissMapGroupsType groupReference<int,int>
     - __kind: StructureType
-      ID: 214
+      ID: 384
+      Name: table<int,interface {}>
+      ByteSize: 32
+      GoKind: 25
+      RawFields:
+        - Name: used
+          Offset: 0
+          Type: 6 BaseType uint16
+        - Name: capacity
+          Offset: 2
+          Type: 6 BaseType uint16
+        - Name: growthLeft
+          Offset: 4
+          Type: 6 BaseType uint16
+        - Name: localDepth
+          Offset: 6
+          Type: 3 BaseType uint8
+        - Name: index
+          Offset: 8
+          Type: 7 BaseType int
+        - Name: groups
+          Offset: 16
+          Type: 385 GoSwissMapGroupsType groupReference<int,interface {}>
+    - __kind: StructureType
+      ID: 250
       Name: table<int,uint8>
       ByteSize: 32
       GoKind: 25
@@ -7331,9 +8872,9 @@ Types:
           Type: 7 BaseType int
         - Name: groups
           Offset: 16
-          Type: 215 GoSwissMapGroupsType groupReference<int,uint8>
+          Type: 251 GoSwissMapGroupsType groupReference<int,uint8>
     - __kind: StructureType
-      ID: 196
+      ID: 232
       Name: table<string,[]main.structWithMap>
       ByteSize: 32
       GoKind: 25
@@ -7355,9 +8896,9 @@ Types:
           Type: 7 BaseType int
         - Name: groups
           Offset: 16
-          Type: 197 GoSwissMapGroupsType groupReference<string,[]main.structWithMap>
+          Type: 233 GoSwissMapGroupsType groupReference<string,[]main.structWithMap>
     - __kind: StructureType
-      ID: 179
+      ID: 215
       Name: table<string,[]string>
       ByteSize: 32
       GoKind: 25
@@ -7379,9 +8920,9 @@ Types:
           Type: 7 BaseType int
         - Name: groups
           Offset: 16
-          Type: 180 GoSwissMapGroupsType groupReference<string,[]string>
+          Type: 216 GoSwissMapGroupsType groupReference<string,[]string>
     - __kind: StructureType
-      ID: 171
+      ID: 207
       Name: table<string,int>
       ByteSize: 32
       GoKind: 25
@@ -7403,9 +8944,9 @@ Types:
           Type: 7 BaseType int
         - Name: groups
           Offset: 16
-          Type: 172 GoSwissMapGroupsType groupReference<string,int>
+          Type: 208 GoSwissMapGroupsType groupReference<string,int>
     - __kind: StructureType
-      ID: 163
+      ID: 199
       Name: table<string,main.nestedStruct>
       ByteSize: 32
       GoKind: 25
@@ -7427,9 +8968,9 @@ Types:
           Type: 7 BaseType int
         - Name: groups
           Offset: 16
-          Type: 164 GoSwissMapGroupsType groupReference<string,main.nestedStruct>
+          Type: 200 GoSwissMapGroupsType groupReference<string,main.nestedStruct>
     - __kind: StructureType
-      ID: 230
+      ID: 266
       Name: table<uint8,[4]int>
       ByteSize: 32
       GoKind: 25
@@ -7451,9 +8992,9 @@ Types:
           Type: 7 BaseType int
         - Name: groups
           Offset: 16
-          Type: 231 GoSwissMapGroupsType groupReference<uint8,[4]int>
+          Type: 267 GoSwissMapGroupsType groupReference<uint8,[4]int>
     - __kind: StructureType
-      ID: 222
+      ID: 258
       Name: table<uint8,uint8>
       ByteSize: 32
       GoKind: 25
@@ -7475,49 +9016,49 @@ Types:
           Type: 7 BaseType int
         - Name: groups
           Offset: 16
-          Type: 223 GoSwissMapGroupsType groupReference<uint8,uint8>
+          Type: 259 GoSwissMapGroupsType groupReference<uint8,uint8>
     - __kind: BaseType
       ID: 16
       Name: uint
       ByteSize: 8
-      GoRuntimeType: 575648
+      GoRuntimeType: 580768
       GoKind: 7
     - __kind: BaseType
       ID: 6
       Name: uint16
       ByteSize: 2
-      GoRuntimeType: 575264
+      GoRuntimeType: 580384
       GoKind: 9
     - __kind: BaseType
       ID: 2
       Name: uint32
       ByteSize: 4
-      GoRuntimeType: 575392
+      GoRuntimeType: 580512
       GoKind: 10
     - __kind: BaseType
       ID: 8
       Name: uint64
       ByteSize: 8
-      GoRuntimeType: 575520
+      GoRuntimeType: 580640
       GoKind: 11
     - __kind: BaseType
       ID: 3
       Name: uint8
       ByteSize: 1
-      GoRuntimeType: 575136
+      GoRuntimeType: 580256
       GoKind: 8
     - __kind: BaseType
       ID: 1
       Name: uintptr
       ByteSize: 8
-      GoRuntimeType: 575712
+      GoRuntimeType: 580832
       GoKind: 12
     - __kind: VoidPointerType
       ID: 14
       Name: unsafe.Pointer
       ByteSize: 8
-      GoRuntimeType: 576096
+      GoRuntimeType: 581216
       GoKind: 26
-MaxTypeID: 385
+MaxTypeID: 518
 Issues: []
-GoModuledataInfo: {FirstModuledataAddr: "0x17f5360", TypesOffset: 296}
+GoModuledataInfo: {FirstModuledataAddr: "0x17f93a0", TypesOffset: 296}

--- a/pkg/dyninst/irgen/testdata/snapshot/sample.arch=amd64,toolchain=go1.24.3.yaml
+++ b/pkg/dyninst/irgen/testdata/snapshot/sample.arch=amd64,toolchain=go1.24.3.yaml
@@ -3095,7 +3095,7 @@ Subprograms:
           IsReturn: false
 Types:
     - __kind: PointerType
-      ID: 173
+      ID: 277
       Name: '**main.t'
       ByteSize: 8
       Pointee: 133 PointerType *main.t
@@ -3167,50 +3167,50 @@ Types:
       ByteSize: 8
       Pointee: 112 PointerType *table<uint8,uint8>
     - __kind: PointerType
-      ID: 177
+      ID: 154
       Name: '*[]*string.array'
       ByteSize: 8
-      Pointee: 176 GoSliceDataType []*string.array
+      Pointee: 153 GoSliceDataType []*string.array
     - __kind: PointerType
-      ID: 271
+      ID: 258
       Name: '*[][]uint.array'
       ByteSize: 8
-      Pointee: 270 GoSliceDataType [][]uint.array
+      Pointee: 257 GoSliceDataType [][]uint.array
     - __kind: PointerType
-      ID: 277
+      ID: 264
       Name: '*[]bool.array'
       ByteSize: 8
-      Pointee: 276 GoSliceDataType []bool.array
+      Pointee: 263 GoSliceDataType []bool.array
     - __kind: PointerType
       ID: 281
       Name: '*[]main.structWithMap.array'
       ByteSize: 8
       Pointee: 280 GoSliceDataType []main.structWithMap.array
     - __kind: PointerType
-      ID: 273
+      ID: 260
       Name: '*[]main.structWithNoStrings.array'
       ByteSize: 8
-      Pointee: 272 GoSliceDataType []main.structWithNoStrings.array
+      Pointee: 259 GoSliceDataType []main.structWithNoStrings.array
     - __kind: PointerType
-      ID: 275
+      ID: 262
       Name: '*[]string.array'
       ByteSize: 8
-      Pointee: 274 GoSliceDataType []string.array
+      Pointee: 261 GoSliceDataType []string.array
     - __kind: PointerType
       ID: 137
       Name: '*[]uint'
       ByteSize: 8
       Pointee: 135 GoSliceHeaderType []uint
     - __kind: PointerType
-      ID: 269
+      ID: 256
       Name: '*[]uint.array'
       ByteSize: 8
-      Pointee: 268 GoSliceDataType []uint.array
+      Pointee: 255 GoSliceDataType []uint.array
     - __kind: PointerType
-      ID: 279
+      ID: 266
       Name: '*[]uint16.array'
       ByteSize: 8
-      Pointee: 278 GoSliceDataType []uint16.array
+      Pointee: 265 GoSliceDataType []uint16.array
     - __kind: PointerType
       ID: 11
       Name: '*bool'
@@ -3295,7 +3295,7 @@ Types:
       GoKind: 22
       Pointee: 147 StructureType main.oneStringStruct
     - __kind: PointerType
-      ID: 220
+      ID: 203
       Name: '*main.structWithMap'
       ByteSize: 8
       GoRuntimeType: 380160
@@ -3319,10 +3319,10 @@ Types:
       GoKind: 22
       Pointee: 134 GoSliceHeaderType main.t
     - __kind: PointerType
-      ID: 267
+      ID: 279
       Name: '*main.t.array'
       ByteSize: 8
-      Pointee: 266 GoSliceDataType main.t.array
+      Pointee: 278 GoSliceDataType main.t.array
     - __kind: PointerType
       ID: 145
       Name: '*main.threeStringStruct'
@@ -3396,65 +3396,65 @@ Types:
       GoKind: 22
       Pointee: 76 GoMapType map[string]int
     - __kind: PointerType
-      ID: 260
+      ID: 249
       Name: '*noalg.map.group[[4]int][4]int'
       ByteSize: 8
-      Pointee: 261 StructureType noalg.map.group[[4]int][4]int
+      Pointee: 250 StructureType noalg.map.group[[4]int][4]int
     - __kind: PointerType
-      ID: 253
+      ID: 241
       Name: '*noalg.map.group[[4]int]uint8'
       ByteSize: 8
-      Pointee: 254 StructureType noalg.map.group[[4]int]uint8
+      Pointee: 242 StructureType noalg.map.group[[4]int]uint8
     - __kind: PointerType
-      ID: 207
+      ID: 189
       Name: '*noalg.map.group[[4]string][2]int'
       ByteSize: 8
-      Pointee: 208 StructureType noalg.map.group[[4]string][2]int
+      Pointee: 190 StructureType noalg.map.group[[4]string][2]int
     - __kind: PointerType
-      ID: 224
+      ID: 208
       Name: '*noalg.map.group[bool]main.node'
       ByteSize: 8
-      Pointee: 225 StructureType noalg.map.group[bool]main.node
+      Pointee: 209 StructureType noalg.map.group[bool]main.node
     - __kind: PointerType
-      ID: 179
+      ID: 157
       Name: '*noalg.map.group[int]int'
       ByteSize: 8
-      Pointee: 180 StructureType noalg.map.group[int]int
+      Pointee: 158 StructureType noalg.map.group[int]int
     - __kind: PointerType
-      ID: 231
+      ID: 216
       Name: '*noalg.map.group[int]uint8'
       ByteSize: 8
-      Pointee: 232 StructureType noalg.map.group[int]uint8
+      Pointee: 217 StructureType noalg.map.group[int]uint8
     - __kind: PointerType
-      ID: 215
+      ID: 198
       Name: '*noalg.map.group[string][]main.structWithMap'
       ByteSize: 8
-      Pointee: 216 StructureType noalg.map.group[string][]main.structWithMap
+      Pointee: 199 StructureType noalg.map.group[string][]main.structWithMap
     - __kind: PointerType
-      ID: 200
+      ID: 181
       Name: '*noalg.map.group[string][]string'
       ByteSize: 8
-      Pointee: 201 StructureType noalg.map.group[string][]string
+      Pointee: 182 StructureType noalg.map.group[string][]string
     - __kind: PointerType
-      ID: 193
+      ID: 173
       Name: '*noalg.map.group[string]int'
       ByteSize: 8
-      Pointee: 194 StructureType noalg.map.group[string]int
+      Pointee: 174 StructureType noalg.map.group[string]int
     - __kind: PointerType
-      ID: 186
+      ID: 165
       Name: '*noalg.map.group[string]main.nestedStruct'
       ByteSize: 8
-      Pointee: 187 StructureType noalg.map.group[string]main.nestedStruct
+      Pointee: 166 StructureType noalg.map.group[string]main.nestedStruct
     - __kind: PointerType
-      ID: 245
+      ID: 232
       Name: '*noalg.map.group[uint8][4]int'
       ByteSize: 8
-      Pointee: 246 StructureType noalg.map.group[uint8][4]int
+      Pointee: 233 StructureType noalg.map.group[uint8][4]int
     - __kind: PointerType
-      ID: 238
+      ID: 224
       Name: '*noalg.map.group[uint8]uint8'
       ByteSize: 8
-      Pointee: 239 StructureType noalg.map.group[uint8]uint8
+      Pointee: 225 StructureType noalg.map.group[uint8]uint8
     - __kind: PointerType
       ID: 22
       Name: '*string'
@@ -3463,70 +3463,70 @@ Types:
       GoKind: 22
       Pointee: 9 GoStringHeaderType string
     - __kind: PointerType
-      ID: 175
+      ID: 152
       Name: '*string.str'
       ByteSize: 8
-      Pointee: 174 GoStringDataType string.str
+      Pointee: 151 GoStringDataType string.str
     - __kind: PointerType
       ID: 127
       Name: '*table<[4]int,[4]int>'
       ByteSize: 8
-      Pointee: 172 StructureType table<[4]int,[4]int>
+      Pointee: 247 StructureType table<[4]int,[4]int>
     - __kind: PointerType
       ID: 122
       Name: '*table<[4]int,uint8>'
       ByteSize: 8
-      Pointee: 171 StructureType table<[4]int,uint8>
+      Pointee: 239 StructureType table<[4]int,uint8>
     - __kind: PointerType
       ID: 90
       Name: '*table<[4]string,[2]int>'
       ByteSize: 8
-      Pointee: 165 StructureType table<[4]string,[2]int>
+      Pointee: 187 StructureType table<[4]string,[2]int>
     - __kind: PointerType
       ID: 102
       Name: '*table<bool,main.node>'
       ByteSize: 8
-      Pointee: 167 StructureType table<bool,main.node>
+      Pointee: 206 StructureType table<bool,main.node>
     - __kind: PointerType
       ID: 70
       Name: '*table<int,int>'
       ByteSize: 8
-      Pointee: 161 StructureType table<int,int>
+      Pointee: 155 StructureType table<int,int>
     - __kind: PointerType
       ID: 107
       Name: '*table<int,uint8>'
       ByteSize: 8
-      Pointee: 168 StructureType table<int,uint8>
+      Pointee: 214 StructureType table<int,uint8>
     - __kind: PointerType
       ID: 97
       Name: '*table<string,[]main.structWithMap>'
       ByteSize: 8
-      Pointee: 166 StructureType table<string,[]main.structWithMap>
+      Pointee: 196 StructureType table<string,[]main.structWithMap>
     - __kind: PointerType
       ID: 85
       Name: '*table<string,[]string>'
       ByteSize: 8
-      Pointee: 164 StructureType table<string,[]string>
+      Pointee: 179 StructureType table<string,[]string>
     - __kind: PointerType
       ID: 80
       Name: '*table<string,int>'
       ByteSize: 8
-      Pointee: 163 StructureType table<string,int>
+      Pointee: 171 StructureType table<string,int>
     - __kind: PointerType
       ID: 75
       Name: '*table<string,main.nestedStruct>'
       ByteSize: 8
-      Pointee: 162 StructureType table<string,main.nestedStruct>
+      Pointee: 163 StructureType table<string,main.nestedStruct>
     - __kind: PointerType
       ID: 117
       Name: '*table<uint8,[4]int>'
       ByteSize: 8
-      Pointee: 170 StructureType table<uint8,[4]int>
+      Pointee: 230 StructureType table<uint8,[4]int>
     - __kind: PointerType
       ID: 112
       Name: '*table<uint8,uint8>'
       ByteSize: 8
-      Pointee: 169 StructureType table<uint8,uint8>
+      Pointee: 222 StructureType table<uint8,uint8>
     - __kind: PointerType
       ID: 34
       Name: '*uint'
@@ -5338,7 +5338,7 @@ Types:
       HasCount: true
       Element: 3 BaseType uint8
     - __kind: ArrayType
-      ID: 249
+      ID: 236
       Name: '[4]int'
       ByteSize: 32
       GoRuntimeType: 672896
@@ -5347,7 +5347,7 @@ Types:
       HasCount: true
       Element: 7 BaseType int
     - __kind: ArrayType
-      ID: 211
+      ID: 193
       Name: '[4]string'
       ByteSize: 64
       GoRuntimeType: 673184
@@ -5379,69 +5379,69 @@ Types:
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 176 GoSliceDataType []*string.array
+      Data: 153 GoSliceDataType []*string.array
     - __kind: GoSliceDataType
-      ID: 176
+      ID: 153
       Name: '[]*string.array'
       ByteSize: 2048
       Element: 22 PointerType *string
     - __kind: GoSliceDataType
-      ID: 264
+      ID: 253
       Name: '[]*table<[4]int,[4]int>.array'
       ByteSize: 8192
       Element: 127 PointerType *table<[4]int,[4]int>
     - __kind: GoSliceDataType
-      ID: 257
+      ID: 245
       Name: '[]*table<[4]int,uint8>.array'
       ByteSize: 8192
       Element: 122 PointerType *table<[4]int,uint8>
     - __kind: GoSliceDataType
-      ID: 212
+      ID: 194
       Name: '[]*table<[4]string,[2]int>.array'
       ByteSize: 8192
       Element: 90 PointerType *table<[4]string,[2]int>
     - __kind: GoSliceDataType
-      ID: 228
+      ID: 212
       Name: '[]*table<bool,main.node>.array'
       ByteSize: 8192
       Element: 102 PointerType *table<bool,main.node>
     - __kind: GoSliceDataType
-      ID: 183
+      ID: 161
       Name: '[]*table<int,int>.array'
       ByteSize: 8192
       Element: 70 PointerType *table<int,int>
     - __kind: GoSliceDataType
-      ID: 235
+      ID: 220
       Name: '[]*table<int,uint8>.array'
       ByteSize: 8192
       Element: 107 PointerType *table<int,uint8>
     - __kind: GoSliceDataType
-      ID: 221
+      ID: 204
       Name: '[]*table<string,[]main.structWithMap>.array'
       ByteSize: 8192
       Element: 97 PointerType *table<string,[]main.structWithMap>
     - __kind: GoSliceDataType
-      ID: 204
+      ID: 185
       Name: '[]*table<string,[]string>.array'
       ByteSize: 8192
       Element: 85 PointerType *table<string,[]string>
     - __kind: GoSliceDataType
-      ID: 197
+      ID: 177
       Name: '[]*table<string,int>.array'
       ByteSize: 8192
       Element: 80 PointerType *table<string,int>
     - __kind: GoSliceDataType
-      ID: 190
+      ID: 169
       Name: '[]*table<string,main.nestedStruct>.array'
       ByteSize: 8192
       Element: 75 PointerType *table<string,main.nestedStruct>
     - __kind: GoSliceDataType
-      ID: 250
+      ID: 237
       Name: '[]*table<uint8,[4]int>.array'
       ByteSize: 8192
       Element: 117 PointerType *table<uint8,[4]int>
     - __kind: GoSliceDataType
-      ID: 242
+      ID: 228
       Name: '[]*table<uint8,uint8>.array'
       ByteSize: 8192
       Element: 112 PointerType *table<uint8,uint8>
@@ -5460,9 +5460,9 @@ Types:
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 270 GoSliceDataType [][]uint.array
+      Data: 257 GoSliceDataType [][]uint.array
     - __kind: GoSliceDataType
-      ID: 270
+      ID: 257
       Name: '[][]uint.array'
       ByteSize: 2048
       Element: 135 GoSliceHeaderType []uint
@@ -5482,14 +5482,14 @@ Types:
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 276 GoSliceDataType []bool.array
+      Data: 263 GoSliceDataType []bool.array
     - __kind: GoSliceDataType
-      ID: 276
+      ID: 263
       Name: '[]bool.array'
       ByteSize: 2048
       Element: 4 BaseType bool
     - __kind: GoSliceHeaderType
-      ID: 219
+      ID: 202
       Name: '[]main.structWithMap'
       ByteSize: 24
       GoRuntimeType: 469888
@@ -5497,7 +5497,7 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 220 PointerType *main.structWithMap
+          Type: 203 PointerType *main.structWithMap
         - Name: len
           Offset: 8
           Type: 7 BaseType int
@@ -5525,72 +5525,72 @@ Types:
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 272 GoSliceDataType []main.structWithNoStrings.array
+      Data: 259 GoSliceDataType []main.structWithNoStrings.array
     - __kind: GoSliceDataType
-      ID: 272
+      ID: 259
       Name: '[]main.structWithNoStrings.array'
       ByteSize: 2048
       Element: 140 StructureType main.structWithNoStrings
     - __kind: GoSliceDataType
-      ID: 265
+      ID: 254
       Name: '[]noalg.map.group[[4]int][4]int.array'
       ByteSize: 2048
-      Element: 261 StructureType noalg.map.group[[4]int][4]int
+      Element: 250 StructureType noalg.map.group[[4]int][4]int
     - __kind: GoSliceDataType
-      ID: 258
+      ID: 246
       Name: '[]noalg.map.group[[4]int]uint8.array'
       ByteSize: 2048
-      Element: 254 StructureType noalg.map.group[[4]int]uint8
+      Element: 242 StructureType noalg.map.group[[4]int]uint8
     - __kind: GoSliceDataType
-      ID: 213
+      ID: 195
       Name: '[]noalg.map.group[[4]string][2]int.array'
       ByteSize: 2048
-      Element: 208 StructureType noalg.map.group[[4]string][2]int
+      Element: 190 StructureType noalg.map.group[[4]string][2]int
     - __kind: GoSliceDataType
-      ID: 229
+      ID: 213
       Name: '[]noalg.map.group[bool]main.node.array'
       ByteSize: 2048
-      Element: 225 StructureType noalg.map.group[bool]main.node
+      Element: 209 StructureType noalg.map.group[bool]main.node
     - __kind: GoSliceDataType
-      ID: 184
+      ID: 162
       Name: '[]noalg.map.group[int]int.array'
       ByteSize: 2048
-      Element: 180 StructureType noalg.map.group[int]int
+      Element: 158 StructureType noalg.map.group[int]int
     - __kind: GoSliceDataType
-      ID: 236
+      ID: 221
       Name: '[]noalg.map.group[int]uint8.array'
       ByteSize: 2048
-      Element: 232 StructureType noalg.map.group[int]uint8
-    - __kind: GoSliceDataType
-      ID: 222
-      Name: '[]noalg.map.group[string][]main.structWithMap.array'
-      ByteSize: 2048
-      Element: 216 StructureType noalg.map.group[string][]main.structWithMap
+      Element: 217 StructureType noalg.map.group[int]uint8
     - __kind: GoSliceDataType
       ID: 205
+      Name: '[]noalg.map.group[string][]main.structWithMap.array'
+      ByteSize: 2048
+      Element: 199 StructureType noalg.map.group[string][]main.structWithMap
+    - __kind: GoSliceDataType
+      ID: 186
       Name: '[]noalg.map.group[string][]string.array'
       ByteSize: 2048
-      Element: 201 StructureType noalg.map.group[string][]string
+      Element: 182 StructureType noalg.map.group[string][]string
     - __kind: GoSliceDataType
-      ID: 198
+      ID: 178
       Name: '[]noalg.map.group[string]int.array'
       ByteSize: 2048
-      Element: 194 StructureType noalg.map.group[string]int
+      Element: 174 StructureType noalg.map.group[string]int
     - __kind: GoSliceDataType
-      ID: 191
+      ID: 170
       Name: '[]noalg.map.group[string]main.nestedStruct.array'
       ByteSize: 2048
-      Element: 187 StructureType noalg.map.group[string]main.nestedStruct
+      Element: 166 StructureType noalg.map.group[string]main.nestedStruct
     - __kind: GoSliceDataType
-      ID: 251
+      ID: 238
       Name: '[]noalg.map.group[uint8][4]int.array'
       ByteSize: 2048
-      Element: 246 StructureType noalg.map.group[uint8][4]int
+      Element: 233 StructureType noalg.map.group[uint8][4]int
     - __kind: GoSliceDataType
-      ID: 243
+      ID: 229
       Name: '[]noalg.map.group[uint8]uint8.array'
       ByteSize: 2048
-      Element: 239 StructureType noalg.map.group[uint8]uint8
+      Element: 225 StructureType noalg.map.group[uint8]uint8
     - __kind: GoSliceHeaderType
       ID: 141
       Name: '[]string'
@@ -5607,9 +5607,9 @@ Types:
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 274 GoSliceDataType []string.array
+      Data: 261 GoSliceDataType []string.array
     - __kind: GoSliceDataType
-      ID: 274
+      ID: 261
       Name: '[]string.array'
       ByteSize: 2048
       Element: 9 GoStringHeaderType string
@@ -5629,9 +5629,9 @@ Types:
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 268 GoSliceDataType []uint.array
+      Data: 255 GoSliceDataType []uint.array
     - __kind: GoSliceDataType
-      ID: 268
+      ID: 255
       Name: '[]uint.array'
       ByteSize: 2048
       Element: 16 BaseType uint
@@ -5651,9 +5651,9 @@ Types:
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 278 GoSliceDataType []uint16.array
+      Data: 265 GoSliceDataType []uint16.array
     - __kind: GoSliceDataType
-      ID: 278
+      ID: 265
       Name: '[]uint16.array'
       ByteSize: 2048
       Element: 6 BaseType uint16
@@ -5717,173 +5717,173 @@ Types:
       GoRuntimeType: 468928
       GoKind: 19
     - __kind: GoSwissMapGroupsType
-      ID: 259
+      ID: 248
       Name: groupReference<[4]int,[4]int>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 260 PointerType *noalg.map.group[[4]int][4]int
+          Type: 249 PointerType *noalg.map.group[[4]int][4]int
         - Name: lengthMask
           Offset: 8
           Type: 8 BaseType uint64
-      GroupType: 261 StructureType noalg.map.group[[4]int][4]int
-      GroupSliceType: 265 GoSliceDataType []noalg.map.group[[4]int][4]int.array
+      GroupType: 250 StructureType noalg.map.group[[4]int][4]int
+      GroupSliceType: 254 GoSliceDataType []noalg.map.group[[4]int][4]int.array
     - __kind: GoSwissMapGroupsType
-      ID: 252
+      ID: 240
       Name: groupReference<[4]int,uint8>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 253 PointerType *noalg.map.group[[4]int]uint8
+          Type: 241 PointerType *noalg.map.group[[4]int]uint8
         - Name: lengthMask
           Offset: 8
           Type: 8 BaseType uint64
-      GroupType: 254 StructureType noalg.map.group[[4]int]uint8
-      GroupSliceType: 258 GoSliceDataType []noalg.map.group[[4]int]uint8.array
+      GroupType: 242 StructureType noalg.map.group[[4]int]uint8
+      GroupSliceType: 246 GoSliceDataType []noalg.map.group[[4]int]uint8.array
     - __kind: GoSwissMapGroupsType
-      ID: 206
+      ID: 188
       Name: groupReference<[4]string,[2]int>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 207 PointerType *noalg.map.group[[4]string][2]int
+          Type: 189 PointerType *noalg.map.group[[4]string][2]int
         - Name: lengthMask
           Offset: 8
           Type: 8 BaseType uint64
-      GroupType: 208 StructureType noalg.map.group[[4]string][2]int
-      GroupSliceType: 213 GoSliceDataType []noalg.map.group[[4]string][2]int.array
+      GroupType: 190 StructureType noalg.map.group[[4]string][2]int
+      GroupSliceType: 195 GoSliceDataType []noalg.map.group[[4]string][2]int.array
     - __kind: GoSwissMapGroupsType
-      ID: 223
+      ID: 207
       Name: groupReference<bool,main.node>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 224 PointerType *noalg.map.group[bool]main.node
+          Type: 208 PointerType *noalg.map.group[bool]main.node
         - Name: lengthMask
           Offset: 8
           Type: 8 BaseType uint64
-      GroupType: 225 StructureType noalg.map.group[bool]main.node
-      GroupSliceType: 229 GoSliceDataType []noalg.map.group[bool]main.node.array
+      GroupType: 209 StructureType noalg.map.group[bool]main.node
+      GroupSliceType: 213 GoSliceDataType []noalg.map.group[bool]main.node.array
     - __kind: GoSwissMapGroupsType
-      ID: 178
+      ID: 156
       Name: groupReference<int,int>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 179 PointerType *noalg.map.group[int]int
+          Type: 157 PointerType *noalg.map.group[int]int
         - Name: lengthMask
           Offset: 8
           Type: 8 BaseType uint64
-      GroupType: 180 StructureType noalg.map.group[int]int
-      GroupSliceType: 184 GoSliceDataType []noalg.map.group[int]int.array
+      GroupType: 158 StructureType noalg.map.group[int]int
+      GroupSliceType: 162 GoSliceDataType []noalg.map.group[int]int.array
     - __kind: GoSwissMapGroupsType
-      ID: 230
+      ID: 215
       Name: groupReference<int,uint8>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 231 PointerType *noalg.map.group[int]uint8
+          Type: 216 PointerType *noalg.map.group[int]uint8
         - Name: lengthMask
           Offset: 8
           Type: 8 BaseType uint64
-      GroupType: 232 StructureType noalg.map.group[int]uint8
-      GroupSliceType: 236 GoSliceDataType []noalg.map.group[int]uint8.array
+      GroupType: 217 StructureType noalg.map.group[int]uint8
+      GroupSliceType: 221 GoSliceDataType []noalg.map.group[int]uint8.array
     - __kind: GoSwissMapGroupsType
-      ID: 214
+      ID: 197
       Name: groupReference<string,[]main.structWithMap>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 215 PointerType *noalg.map.group[string][]main.structWithMap
+          Type: 198 PointerType *noalg.map.group[string][]main.structWithMap
         - Name: lengthMask
           Offset: 8
           Type: 8 BaseType uint64
-      GroupType: 216 StructureType noalg.map.group[string][]main.structWithMap
-      GroupSliceType: 222 GoSliceDataType []noalg.map.group[string][]main.structWithMap.array
+      GroupType: 199 StructureType noalg.map.group[string][]main.structWithMap
+      GroupSliceType: 205 GoSliceDataType []noalg.map.group[string][]main.structWithMap.array
     - __kind: GoSwissMapGroupsType
-      ID: 199
+      ID: 180
       Name: groupReference<string,[]string>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 200 PointerType *noalg.map.group[string][]string
+          Type: 181 PointerType *noalg.map.group[string][]string
         - Name: lengthMask
           Offset: 8
           Type: 8 BaseType uint64
-      GroupType: 201 StructureType noalg.map.group[string][]string
-      GroupSliceType: 205 GoSliceDataType []noalg.map.group[string][]string.array
+      GroupType: 182 StructureType noalg.map.group[string][]string
+      GroupSliceType: 186 GoSliceDataType []noalg.map.group[string][]string.array
     - __kind: GoSwissMapGroupsType
-      ID: 192
+      ID: 172
       Name: groupReference<string,int>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 193 PointerType *noalg.map.group[string]int
+          Type: 173 PointerType *noalg.map.group[string]int
         - Name: lengthMask
           Offset: 8
           Type: 8 BaseType uint64
-      GroupType: 194 StructureType noalg.map.group[string]int
-      GroupSliceType: 198 GoSliceDataType []noalg.map.group[string]int.array
+      GroupType: 174 StructureType noalg.map.group[string]int
+      GroupSliceType: 178 GoSliceDataType []noalg.map.group[string]int.array
     - __kind: GoSwissMapGroupsType
-      ID: 185
+      ID: 164
       Name: groupReference<string,main.nestedStruct>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 186 PointerType *noalg.map.group[string]main.nestedStruct
+          Type: 165 PointerType *noalg.map.group[string]main.nestedStruct
         - Name: lengthMask
           Offset: 8
           Type: 8 BaseType uint64
-      GroupType: 187 StructureType noalg.map.group[string]main.nestedStruct
-      GroupSliceType: 191 GoSliceDataType []noalg.map.group[string]main.nestedStruct.array
+      GroupType: 166 StructureType noalg.map.group[string]main.nestedStruct
+      GroupSliceType: 170 GoSliceDataType []noalg.map.group[string]main.nestedStruct.array
     - __kind: GoSwissMapGroupsType
-      ID: 244
+      ID: 231
       Name: groupReference<uint8,[4]int>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 245 PointerType *noalg.map.group[uint8][4]int
+          Type: 232 PointerType *noalg.map.group[uint8][4]int
         - Name: lengthMask
           Offset: 8
           Type: 8 BaseType uint64
-      GroupType: 246 StructureType noalg.map.group[uint8][4]int
-      GroupSliceType: 251 GoSliceDataType []noalg.map.group[uint8][4]int.array
+      GroupType: 233 StructureType noalg.map.group[uint8][4]int
+      GroupSliceType: 238 GoSliceDataType []noalg.map.group[uint8][4]int.array
     - __kind: GoSwissMapGroupsType
-      ID: 237
+      ID: 223
       Name: groupReference<uint8,uint8>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 238 PointerType *noalg.map.group[uint8]uint8
+          Type: 224 PointerType *noalg.map.group[uint8]uint8
         - Name: lengthMask
           Offset: 8
           Type: 8 BaseType uint64
-      GroupType: 239 StructureType noalg.map.group[uint8]uint8
-      GroupSliceType: 243 GoSliceDataType []noalg.map.group[uint8]uint8.array
+      GroupType: 225 StructureType noalg.map.group[uint8]uint8
+      GroupSliceType: 229 GoSliceDataType []noalg.map.group[uint8]uint8.array
     - __kind: BaseType
       ID: 7
       Name: int
@@ -5928,7 +5928,7 @@ Types:
           Offset: 8
           Type: 14 VoidPointerType unsafe.Pointer
     - __kind: StructureType
-      ID: 153
+      ID: 269
       Name: internal/sync.Mutex
       ByteSize: 8
       GoRuntimeType: 1.454624e+06
@@ -6016,16 +6016,16 @@ Types:
           Type: 56 StructureType main.esotericStack
         - Name: mu
           Offset: 64
-          Type: 151 StructureType sync.Mutex
+          Type: 267 StructureType sync.Mutex
         - Name: once
           Offset: 72
-          Type: 154 StructureType sync.Once
+          Type: 270 StructureType sync.Once
         - Name: wg
           Offset: 88
-          Type: 157 StructureType sync.WaitGroup
+          Type: 273 StructureType sync.WaitGroup
         - Name: a
           Offset: 104
-          Type: 160 StructureType sync/atomic.Int32
+          Type: 276 StructureType sync/atomic.Int32
     - __kind: StructureType
       ID: 56
       Name: main.esotericStack
@@ -6144,16 +6144,16 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 173 PointerType **main.t
+          Type: 277 PointerType **main.t
         - Name: len
           Offset: 8
           Type: 7 BaseType int
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 266 GoSliceDataType main.t.array
+      Data: 278 GoSliceDataType main.t.array
     - __kind: GoSliceDataType
-      ID: 266
+      ID: 278
       Name: main.t.array
       ByteSize: 2048
       Element: 133 PointerType *main.t
@@ -6207,8 +6207,8 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 8 BaseType uint64
-      TablePtrSliceType: 264 GoSliceDataType []*table<[4]int,[4]int>.array
-      GroupType: 261 StructureType noalg.map.group[[4]int][4]int
+      TablePtrSliceType: 253 GoSliceDataType []*table<[4]int,[4]int>.array
+      GroupType: 250 StructureType noalg.map.group[[4]int][4]int
     - __kind: GoSwissMapHeaderType
       ID: 120
       Name: map<[4]int,uint8>
@@ -6239,8 +6239,8 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 8 BaseType uint64
-      TablePtrSliceType: 257 GoSliceDataType []*table<[4]int,uint8>.array
-      GroupType: 254 StructureType noalg.map.group[[4]int]uint8
+      TablePtrSliceType: 245 GoSliceDataType []*table<[4]int,uint8>.array
+      GroupType: 242 StructureType noalg.map.group[[4]int]uint8
     - __kind: GoSwissMapHeaderType
       ID: 88
       Name: map<[4]string,[2]int>
@@ -6271,8 +6271,8 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 8 BaseType uint64
-      TablePtrSliceType: 212 GoSliceDataType []*table<[4]string,[2]int>.array
-      GroupType: 208 StructureType noalg.map.group[[4]string][2]int
+      TablePtrSliceType: 194 GoSliceDataType []*table<[4]string,[2]int>.array
+      GroupType: 190 StructureType noalg.map.group[[4]string][2]int
     - __kind: GoSwissMapHeaderType
       ID: 100
       Name: map<bool,main.node>
@@ -6303,8 +6303,8 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 8 BaseType uint64
-      TablePtrSliceType: 228 GoSliceDataType []*table<bool,main.node>.array
-      GroupType: 225 StructureType noalg.map.group[bool]main.node
+      TablePtrSliceType: 212 GoSliceDataType []*table<bool,main.node>.array
+      GroupType: 209 StructureType noalg.map.group[bool]main.node
     - __kind: GoSwissMapHeaderType
       ID: 68
       Name: map<int,int>
@@ -6335,8 +6335,8 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 8 BaseType uint64
-      TablePtrSliceType: 183 GoSliceDataType []*table<int,int>.array
-      GroupType: 180 StructureType noalg.map.group[int]int
+      TablePtrSliceType: 161 GoSliceDataType []*table<int,int>.array
+      GroupType: 158 StructureType noalg.map.group[int]int
     - __kind: GoSwissMapHeaderType
       ID: 105
       Name: map<int,uint8>
@@ -6367,8 +6367,8 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 8 BaseType uint64
-      TablePtrSliceType: 235 GoSliceDataType []*table<int,uint8>.array
-      GroupType: 232 StructureType noalg.map.group[int]uint8
+      TablePtrSliceType: 220 GoSliceDataType []*table<int,uint8>.array
+      GroupType: 217 StructureType noalg.map.group[int]uint8
     - __kind: GoSwissMapHeaderType
       ID: 95
       Name: map<string,[]main.structWithMap>
@@ -6399,8 +6399,8 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 8 BaseType uint64
-      TablePtrSliceType: 221 GoSliceDataType []*table<string,[]main.structWithMap>.array
-      GroupType: 216 StructureType noalg.map.group[string][]main.structWithMap
+      TablePtrSliceType: 204 GoSliceDataType []*table<string,[]main.structWithMap>.array
+      GroupType: 199 StructureType noalg.map.group[string][]main.structWithMap
     - __kind: GoSwissMapHeaderType
       ID: 83
       Name: map<string,[]string>
@@ -6431,8 +6431,8 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 8 BaseType uint64
-      TablePtrSliceType: 204 GoSliceDataType []*table<string,[]string>.array
-      GroupType: 201 StructureType noalg.map.group[string][]string
+      TablePtrSliceType: 185 GoSliceDataType []*table<string,[]string>.array
+      GroupType: 182 StructureType noalg.map.group[string][]string
     - __kind: GoSwissMapHeaderType
       ID: 78
       Name: map<string,int>
@@ -6463,8 +6463,8 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 8 BaseType uint64
-      TablePtrSliceType: 197 GoSliceDataType []*table<string,int>.array
-      GroupType: 194 StructureType noalg.map.group[string]int
+      TablePtrSliceType: 177 GoSliceDataType []*table<string,int>.array
+      GroupType: 174 StructureType noalg.map.group[string]int
     - __kind: GoSwissMapHeaderType
       ID: 73
       Name: map<string,main.nestedStruct>
@@ -6495,8 +6495,8 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 8 BaseType uint64
-      TablePtrSliceType: 190 GoSliceDataType []*table<string,main.nestedStruct>.array
-      GroupType: 187 StructureType noalg.map.group[string]main.nestedStruct
+      TablePtrSliceType: 169 GoSliceDataType []*table<string,main.nestedStruct>.array
+      GroupType: 166 StructureType noalg.map.group[string]main.nestedStruct
     - __kind: GoSwissMapHeaderType
       ID: 115
       Name: map<uint8,[4]int>
@@ -6527,8 +6527,8 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 8 BaseType uint64
-      TablePtrSliceType: 250 GoSliceDataType []*table<uint8,[4]int>.array
-      GroupType: 246 StructureType noalg.map.group[uint8][4]int
+      TablePtrSliceType: 237 GoSliceDataType []*table<uint8,[4]int>.array
+      GroupType: 233 StructureType noalg.map.group[uint8][4]int
     - __kind: GoSwissMapHeaderType
       ID: 110
       Name: map<uint8,uint8>
@@ -6559,8 +6559,8 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 8 BaseType uint64
-      TablePtrSliceType: 242 GoSliceDataType []*table<uint8,uint8>.array
-      GroupType: 239 StructureType noalg.map.group[uint8]uint8
+      TablePtrSliceType: 228 GoSliceDataType []*table<uint8,uint8>.array
+      GroupType: 225 StructureType noalg.map.group[uint8]uint8
     - __kind: GoMapType
       ID: 123
       Name: map[[4]int][4]int
@@ -6646,115 +6646,115 @@ Types:
       GoKind: 21
       HeaderType: 110 GoSwissMapHeaderType map<uint8,uint8>
     - __kind: ArrayType
-      ID: 262
+      ID: 251
       Name: noalg.[8]struct { key [4]int; elem [4]int }
       ByteSize: 512
       GoRuntimeType: 672992
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 263 StructureType noalg.struct { key [4]int; elem [4]int }
+      Element: 252 StructureType noalg.struct { key [4]int; elem [4]int }
     - __kind: ArrayType
-      ID: 255
+      ID: 243
       Name: noalg.[8]struct { key [4]int; elem uint8 }
       ByteSize: 320
       GoRuntimeType: 673088
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 256 StructureType noalg.struct { key [4]int; elem uint8 }
+      Element: 244 StructureType noalg.struct { key [4]int; elem uint8 }
     - __kind: ArrayType
-      ID: 209
+      ID: 191
       Name: noalg.[8]struct { key [4]string; elem [2]int }
       ByteSize: 640
       GoRuntimeType: 673376
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 210 StructureType noalg.struct { key [4]string; elem [2]int }
+      Element: 192 StructureType noalg.struct { key [4]string; elem [2]int }
     - __kind: ArrayType
-      ID: 226
+      ID: 210
       Name: noalg.[8]struct { key bool; elem main.node }
       ByteSize: 192
       GoRuntimeType: 673472
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 227 StructureType noalg.struct { key bool; elem main.node }
+      Element: 211 StructureType noalg.struct { key bool; elem main.node }
     - __kind: ArrayType
-      ID: 181
+      ID: 159
       Name: noalg.[8]struct { key int; elem int }
       ByteSize: 128
       GoRuntimeType: 671264
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 182 StructureType noalg.struct { key int; elem int }
+      Element: 160 StructureType noalg.struct { key int; elem int }
     - __kind: ArrayType
-      ID: 233
+      ID: 218
       Name: noalg.[8]struct { key int; elem uint8 }
       ByteSize: 128
       GoRuntimeType: 673568
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 234 StructureType noalg.struct { key int; elem uint8 }
+      Element: 219 StructureType noalg.struct { key int; elem uint8 }
     - __kind: ArrayType
-      ID: 217
+      ID: 200
       Name: noalg.[8]struct { key string; elem []main.structWithMap }
       ByteSize: 320
       GoRuntimeType: 673664
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 218 StructureType noalg.struct { key string; elem []main.structWithMap }
+      Element: 201 StructureType noalg.struct { key string; elem []main.structWithMap }
     - __kind: ArrayType
-      ID: 202
+      ID: 183
       Name: noalg.[8]struct { key string; elem []string }
       ByteSize: 320
       GoRuntimeType: 673760
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 203 StructureType noalg.struct { key string; elem []string }
+      Element: 184 StructureType noalg.struct { key string; elem []string }
     - __kind: ArrayType
-      ID: 195
+      ID: 175
       Name: noalg.[8]struct { key string; elem int }
       ByteSize: 192
       GoRuntimeType: 673856
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 196 StructureType noalg.struct { key string; elem int }
+      Element: 176 StructureType noalg.struct { key string; elem int }
     - __kind: ArrayType
-      ID: 188
+      ID: 167
       Name: noalg.[8]struct { key string; elem main.nestedStruct }
       ByteSize: 320
       GoRuntimeType: 673952
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 189 StructureType noalg.struct { key string; elem main.nestedStruct }
+      Element: 168 StructureType noalg.struct { key string; elem main.nestedStruct }
     - __kind: ArrayType
-      ID: 247
+      ID: 234
       Name: noalg.[8]struct { key uint8; elem [4]int }
       ByteSize: 320
       GoRuntimeType: 674048
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 248 StructureType noalg.struct { key uint8; elem [4]int }
+      Element: 235 StructureType noalg.struct { key uint8; elem [4]int }
     - __kind: ArrayType
-      ID: 240
+      ID: 226
       Name: noalg.[8]struct { key uint8; elem uint8 }
       ByteSize: 16
       GoRuntimeType: 674144
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 241 StructureType noalg.struct { key uint8; elem uint8 }
+      Element: 227 StructureType noalg.struct { key uint8; elem uint8 }
     - __kind: StructureType
-      ID: 261
+      ID: 250
       Name: noalg.map.group[[4]int][4]int
       ByteSize: 520
       GoRuntimeType: 1.277248e+06
@@ -6765,9 +6765,9 @@ Types:
           Type: 8 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 262 ArrayType noalg.[8]struct { key [4]int; elem [4]int }
+          Type: 251 ArrayType noalg.[8]struct { key [4]int; elem [4]int }
     - __kind: StructureType
-      ID: 254
+      ID: 242
       Name: noalg.map.group[[4]int]uint8
       ByteSize: 328
       GoRuntimeType: 1.277504e+06
@@ -6778,9 +6778,9 @@ Types:
           Type: 8 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 255 ArrayType noalg.[8]struct { key [4]int; elem uint8 }
+          Type: 243 ArrayType noalg.[8]struct { key [4]int; elem uint8 }
     - __kind: StructureType
-      ID: 208
+      ID: 190
       Name: noalg.map.group[[4]string][2]int
       ByteSize: 648
       GoRuntimeType: 1.27776e+06
@@ -6791,9 +6791,9 @@ Types:
           Type: 8 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 209 ArrayType noalg.[8]struct { key [4]string; elem [2]int }
+          Type: 191 ArrayType noalg.[8]struct { key [4]string; elem [2]int }
     - __kind: StructureType
-      ID: 225
+      ID: 209
       Name: noalg.map.group[bool]main.node
       ByteSize: 200
       GoRuntimeType: 1.278016e+06
@@ -6804,9 +6804,9 @@ Types:
           Type: 8 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 226 ArrayType noalg.[8]struct { key bool; elem main.node }
+          Type: 210 ArrayType noalg.[8]struct { key bool; elem main.node }
     - __kind: StructureType
-      ID: 180
+      ID: 158
       Name: noalg.map.group[int]int
       ByteSize: 136
       GoRuntimeType: 1.27648e+06
@@ -6817,9 +6817,9 @@ Types:
           Type: 8 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 181 ArrayType noalg.[8]struct { key int; elem int }
+          Type: 159 ArrayType noalg.[8]struct { key int; elem int }
     - __kind: StructureType
-      ID: 232
+      ID: 217
       Name: noalg.map.group[int]uint8
       ByteSize: 136
       GoRuntimeType: 1.278272e+06
@@ -6830,9 +6830,9 @@ Types:
           Type: 8 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 233 ArrayType noalg.[8]struct { key int; elem uint8 }
+          Type: 218 ArrayType noalg.[8]struct { key int; elem uint8 }
     - __kind: StructureType
-      ID: 216
+      ID: 199
       Name: noalg.map.group[string][]main.structWithMap
       ByteSize: 328
       GoRuntimeType: 1.278528e+06
@@ -6843,9 +6843,9 @@ Types:
           Type: 8 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 217 ArrayType noalg.[8]struct { key string; elem []main.structWithMap }
+          Type: 200 ArrayType noalg.[8]struct { key string; elem []main.structWithMap }
     - __kind: StructureType
-      ID: 201
+      ID: 182
       Name: noalg.map.group[string][]string
       ByteSize: 328
       GoRuntimeType: 1.278784e+06
@@ -6856,9 +6856,9 @@ Types:
           Type: 8 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 202 ArrayType noalg.[8]struct { key string; elem []string }
+          Type: 183 ArrayType noalg.[8]struct { key string; elem []string }
     - __kind: StructureType
-      ID: 194
+      ID: 174
       Name: noalg.map.group[string]int
       ByteSize: 200
       GoRuntimeType: 1.27904e+06
@@ -6869,9 +6869,9 @@ Types:
           Type: 8 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 195 ArrayType noalg.[8]struct { key string; elem int }
+          Type: 175 ArrayType noalg.[8]struct { key string; elem int }
     - __kind: StructureType
-      ID: 187
+      ID: 166
       Name: noalg.map.group[string]main.nestedStruct
       ByteSize: 328
       GoRuntimeType: 1.279296e+06
@@ -6882,9 +6882,9 @@ Types:
           Type: 8 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 188 ArrayType noalg.[8]struct { key string; elem main.nestedStruct }
+          Type: 167 ArrayType noalg.[8]struct { key string; elem main.nestedStruct }
     - __kind: StructureType
-      ID: 246
+      ID: 233
       Name: noalg.map.group[uint8][4]int
       ByteSize: 328
       GoRuntimeType: 1.279552e+06
@@ -6895,9 +6895,9 @@ Types:
           Type: 8 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 247 ArrayType noalg.[8]struct { key uint8; elem [4]int }
+          Type: 234 ArrayType noalg.[8]struct { key uint8; elem [4]int }
     - __kind: StructureType
-      ID: 239
+      ID: 225
       Name: noalg.map.group[uint8]uint8
       ByteSize: 24
       GoRuntimeType: 1.279808e+06
@@ -6908,9 +6908,9 @@ Types:
           Type: 8 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 240 ArrayType noalg.[8]struct { key uint8; elem uint8 }
+          Type: 226 ArrayType noalg.[8]struct { key uint8; elem uint8 }
     - __kind: StructureType
-      ID: 263
+      ID: 252
       Name: noalg.struct { key [4]int; elem [4]int }
       ByteSize: 64
       GoRuntimeType: 1.27712e+06
@@ -6918,12 +6918,12 @@ Types:
       RawFields:
         - Name: key
           Offset: 0
-          Type: 249 ArrayType [4]int
+          Type: 236 ArrayType [4]int
         - Name: elem
           Offset: 32
-          Type: 249 ArrayType [4]int
+          Type: 236 ArrayType [4]int
     - __kind: StructureType
-      ID: 256
+      ID: 244
       Name: noalg.struct { key [4]int; elem uint8 }
       ByteSize: 40
       GoRuntimeType: 1.277376e+06
@@ -6931,12 +6931,12 @@ Types:
       RawFields:
         - Name: key
           Offset: 0
-          Type: 249 ArrayType [4]int
+          Type: 236 ArrayType [4]int
         - Name: elem
           Offset: 32
           Type: 3 BaseType uint8
     - __kind: StructureType
-      ID: 210
+      ID: 192
       Name: noalg.struct { key [4]string; elem [2]int }
       ByteSize: 80
       GoRuntimeType: 1.277632e+06
@@ -6944,12 +6944,12 @@ Types:
       RawFields:
         - Name: key
           Offset: 0
-          Type: 211 ArrayType [4]string
+          Type: 193 ArrayType [4]string
         - Name: elem
           Offset: 64
           Type: 40 ArrayType [2]int
     - __kind: StructureType
-      ID: 227
+      ID: 211
       Name: noalg.struct { key bool; elem main.node }
       ByteSize: 24
       GoRuntimeType: 1.277888e+06
@@ -6962,7 +6962,7 @@ Types:
           Offset: 8
           Type: 131 StructureType main.node
     - __kind: StructureType
-      ID: 182
+      ID: 160
       Name: noalg.struct { key int; elem int }
       ByteSize: 16
       GoRuntimeType: 1.276352e+06
@@ -6975,7 +6975,7 @@ Types:
           Offset: 8
           Type: 7 BaseType int
     - __kind: StructureType
-      ID: 234
+      ID: 219
       Name: noalg.struct { key int; elem uint8 }
       ByteSize: 16
       GoRuntimeType: 1.278144e+06
@@ -6988,7 +6988,7 @@ Types:
           Offset: 8
           Type: 3 BaseType uint8
     - __kind: StructureType
-      ID: 218
+      ID: 201
       Name: noalg.struct { key string; elem []main.structWithMap }
       ByteSize: 40
       GoRuntimeType: 1.2784e+06
@@ -6999,9 +6999,9 @@ Types:
           Type: 9 GoStringHeaderType string
         - Name: elem
           Offset: 16
-          Type: 219 GoSliceHeaderType []main.structWithMap
+          Type: 202 GoSliceHeaderType []main.structWithMap
     - __kind: StructureType
-      ID: 203
+      ID: 184
       Name: noalg.struct { key string; elem []string }
       ByteSize: 40
       GoRuntimeType: 1.278656e+06
@@ -7014,7 +7014,7 @@ Types:
           Offset: 16
           Type: 141 GoSliceHeaderType []string
     - __kind: StructureType
-      ID: 196
+      ID: 176
       Name: noalg.struct { key string; elem int }
       ByteSize: 24
       GoRuntimeType: 1.278912e+06
@@ -7027,7 +7027,7 @@ Types:
           Offset: 16
           Type: 7 BaseType int
     - __kind: StructureType
-      ID: 189
+      ID: 168
       Name: noalg.struct { key string; elem main.nestedStruct }
       ByteSize: 40
       GoRuntimeType: 1.279168e+06
@@ -7040,7 +7040,7 @@ Types:
           Offset: 16
           Type: 149 StructureType main.nestedStruct
     - __kind: StructureType
-      ID: 248
+      ID: 235
       Name: noalg.struct { key uint8; elem [4]int }
       ByteSize: 40
       GoRuntimeType: 1.279424e+06
@@ -7051,9 +7051,9 @@ Types:
           Type: 3 BaseType uint8
         - Name: elem
           Offset: 8
-          Type: 249 ArrayType [4]int
+          Type: 236 ArrayType [4]int
     - __kind: StructureType
-      ID: 241
+      ID: 227
       Name: noalg.struct { key uint8; elem uint8 }
       ByteSize: 2
       GoRuntimeType: 1.27968e+06
@@ -7074,17 +7074,17 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 175 PointerType *string.str
+          Type: 152 PointerType *string.str
         - Name: len
           Offset: 8
           Type: 7 BaseType int
-      Data: 174 GoStringDataType string.str
+      Data: 151 GoStringDataType string.str
     - __kind: GoStringDataType
-      ID: 174
+      ID: 151
       Name: string.str
       ByteSize: 2048
     - __kind: StructureType
-      ID: 151
+      ID: 267
       Name: sync.Mutex
       ByteSize: 8
       GoRuntimeType: 1.445344e+06
@@ -7092,12 +7092,12 @@ Types:
       RawFields:
         - Name: _
           Offset: 0
-          Type: 152 StructureType sync.noCopy
+          Type: 268 StructureType sync.noCopy
         - Name: mu
           Offset: 0
-          Type: 153 StructureType internal/sync.Mutex
+          Type: 269 StructureType internal/sync.Mutex
     - __kind: StructureType
-      ID: 154
+      ID: 270
       Name: sync.Once
       ByteSize: 12
       GoRuntimeType: 1.593696e+06
@@ -7105,15 +7105,15 @@ Types:
       RawFields:
         - Name: _
           Offset: 0
-          Type: 152 StructureType sync.noCopy
+          Type: 268 StructureType sync.noCopy
         - Name: done
           Offset: 0
-          Type: 155 StructureType sync/atomic.Uint32
+          Type: 271 StructureType sync/atomic.Uint32
         - Name: m
           Offset: 4
-          Type: 151 StructureType sync.Mutex
+          Type: 267 StructureType sync.Mutex
     - __kind: StructureType
-      ID: 157
+      ID: 273
       Name: sync.WaitGroup
       ByteSize: 16
       GoRuntimeType: 1.593888e+06
@@ -7121,21 +7121,21 @@ Types:
       RawFields:
         - Name: noCopy
           Offset: 0
-          Type: 152 StructureType sync.noCopy
+          Type: 268 StructureType sync.noCopy
         - Name: state
           Offset: 0
-          Type: 158 StructureType sync/atomic.Uint64
+          Type: 274 StructureType sync/atomic.Uint64
         - Name: sema
           Offset: 8
           Type: 2 BaseType uint32
     - __kind: StructureType
-      ID: 152
+      ID: 268
       Name: sync.noCopy
       GoRuntimeType: 977728
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 160
+      ID: 276
       Name: sync/atomic.Int32
       ByteSize: 4
       GoRuntimeType: 1.446624e+06
@@ -7143,12 +7143,12 @@ Types:
       RawFields:
         - Name: _
           Offset: 0
-          Type: 156 StructureType sync/atomic.noCopy
+          Type: 272 StructureType sync/atomic.noCopy
         - Name: v
           Offset: 0
           Type: 10 BaseType int32
     - __kind: StructureType
-      ID: 155
+      ID: 271
       Name: sync/atomic.Uint32
       ByteSize: 4
       GoRuntimeType: 1.446784e+06
@@ -7156,12 +7156,12 @@ Types:
       RawFields:
         - Name: _
           Offset: 0
-          Type: 156 StructureType sync/atomic.noCopy
+          Type: 272 StructureType sync/atomic.noCopy
         - Name: v
           Offset: 0
           Type: 2 BaseType uint32
     - __kind: StructureType
-      ID: 158
+      ID: 274
       Name: sync/atomic.Uint64
       ByteSize: 8
       GoRuntimeType: 1.594272e+06
@@ -7169,27 +7169,27 @@ Types:
       RawFields:
         - Name: _
           Offset: 0
-          Type: 156 StructureType sync/atomic.noCopy
+          Type: 272 StructureType sync/atomic.noCopy
         - Name: _
           Offset: 0
-          Type: 159 StructureType sync/atomic.align64
+          Type: 275 StructureType sync/atomic.align64
         - Name: v
           Offset: 0
           Type: 8 BaseType uint64
     - __kind: StructureType
-      ID: 159
+      ID: 275
       Name: sync/atomic.align64
       GoRuntimeType: 977920
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 156
+      ID: 272
       Name: sync/atomic.noCopy
       GoRuntimeType: 977824
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 172
+      ID: 247
       Name: table<[4]int,[4]int>
       ByteSize: 32
       GoKind: 25
@@ -7211,9 +7211,9 @@ Types:
           Type: 7 BaseType int
         - Name: groups
           Offset: 16
-          Type: 259 GoSwissMapGroupsType groupReference<[4]int,[4]int>
+          Type: 248 GoSwissMapGroupsType groupReference<[4]int,[4]int>
     - __kind: StructureType
-      ID: 171
+      ID: 239
       Name: table<[4]int,uint8>
       ByteSize: 32
       GoKind: 25
@@ -7235,9 +7235,9 @@ Types:
           Type: 7 BaseType int
         - Name: groups
           Offset: 16
-          Type: 252 GoSwissMapGroupsType groupReference<[4]int,uint8>
+          Type: 240 GoSwissMapGroupsType groupReference<[4]int,uint8>
     - __kind: StructureType
-      ID: 165
+      ID: 187
       Name: table<[4]string,[2]int>
       ByteSize: 32
       GoKind: 25
@@ -7259,9 +7259,9 @@ Types:
           Type: 7 BaseType int
         - Name: groups
           Offset: 16
-          Type: 206 GoSwissMapGroupsType groupReference<[4]string,[2]int>
+          Type: 188 GoSwissMapGroupsType groupReference<[4]string,[2]int>
     - __kind: StructureType
-      ID: 167
+      ID: 206
       Name: table<bool,main.node>
       ByteSize: 32
       GoKind: 25
@@ -7283,9 +7283,9 @@ Types:
           Type: 7 BaseType int
         - Name: groups
           Offset: 16
-          Type: 223 GoSwissMapGroupsType groupReference<bool,main.node>
+          Type: 207 GoSwissMapGroupsType groupReference<bool,main.node>
     - __kind: StructureType
-      ID: 161
+      ID: 155
       Name: table<int,int>
       ByteSize: 32
       GoKind: 25
@@ -7307,9 +7307,9 @@ Types:
           Type: 7 BaseType int
         - Name: groups
           Offset: 16
-          Type: 178 GoSwissMapGroupsType groupReference<int,int>
+          Type: 156 GoSwissMapGroupsType groupReference<int,int>
     - __kind: StructureType
-      ID: 168
+      ID: 214
       Name: table<int,uint8>
       ByteSize: 32
       GoKind: 25
@@ -7331,9 +7331,9 @@ Types:
           Type: 7 BaseType int
         - Name: groups
           Offset: 16
-          Type: 230 GoSwissMapGroupsType groupReference<int,uint8>
+          Type: 215 GoSwissMapGroupsType groupReference<int,uint8>
     - __kind: StructureType
-      ID: 166
+      ID: 196
       Name: table<string,[]main.structWithMap>
       ByteSize: 32
       GoKind: 25
@@ -7355,9 +7355,9 @@ Types:
           Type: 7 BaseType int
         - Name: groups
           Offset: 16
-          Type: 214 GoSwissMapGroupsType groupReference<string,[]main.structWithMap>
+          Type: 197 GoSwissMapGroupsType groupReference<string,[]main.structWithMap>
     - __kind: StructureType
-      ID: 164
+      ID: 179
       Name: table<string,[]string>
       ByteSize: 32
       GoKind: 25
@@ -7379,9 +7379,9 @@ Types:
           Type: 7 BaseType int
         - Name: groups
           Offset: 16
-          Type: 199 GoSwissMapGroupsType groupReference<string,[]string>
+          Type: 180 GoSwissMapGroupsType groupReference<string,[]string>
     - __kind: StructureType
-      ID: 163
+      ID: 171
       Name: table<string,int>
       ByteSize: 32
       GoKind: 25
@@ -7403,9 +7403,9 @@ Types:
           Type: 7 BaseType int
         - Name: groups
           Offset: 16
-          Type: 192 GoSwissMapGroupsType groupReference<string,int>
+          Type: 172 GoSwissMapGroupsType groupReference<string,int>
     - __kind: StructureType
-      ID: 162
+      ID: 163
       Name: table<string,main.nestedStruct>
       ByteSize: 32
       GoKind: 25
@@ -7427,9 +7427,9 @@ Types:
           Type: 7 BaseType int
         - Name: groups
           Offset: 16
-          Type: 185 GoSwissMapGroupsType groupReference<string,main.nestedStruct>
+          Type: 164 GoSwissMapGroupsType groupReference<string,main.nestedStruct>
     - __kind: StructureType
-      ID: 170
+      ID: 230
       Name: table<uint8,[4]int>
       ByteSize: 32
       GoKind: 25
@@ -7451,9 +7451,9 @@ Types:
           Type: 7 BaseType int
         - Name: groups
           Offset: 16
-          Type: 244 GoSwissMapGroupsType groupReference<uint8,[4]int>
+          Type: 231 GoSwissMapGroupsType groupReference<uint8,[4]int>
     - __kind: StructureType
-      ID: 169
+      ID: 222
       Name: table<uint8,uint8>
       ByteSize: 32
       GoKind: 25
@@ -7475,7 +7475,7 @@ Types:
           Type: 7 BaseType int
         - Name: groups
           Offset: 16
-          Type: 237 GoSwissMapGroupsType groupReference<uint8,uint8>
+          Type: 223 GoSwissMapGroupsType groupReference<uint8,uint8>
     - __kind: BaseType
       ID: 16
       Name: uint

--- a/pkg/dyninst/irgen/testdata/snapshot/sample.arch=amd64,toolchain=go1.24.3.yaml
+++ b/pkg/dyninst/irgen/testdata/snapshot/sample.arch=amd64,toolchain=go1.24.3.yaml
@@ -8,7 +8,7 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 94}
+      subprogram: {subprogram: 88}
       events:
         - ID: 88
           Type: 369 EventRootType Probe[main.stackC]
@@ -22,7 +22,7 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 51}
+      subprogram: {subprogram: 45}
       events:
         - ID: 45
           Type: 326 EventRootType Probe[main.testAny]
@@ -36,7 +36,7 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 21}
+      subprogram: {subprogram: 15}
       events:
         - ID: 15
           Type: 296 EventRootType Probe[main.testArrayOfArrays]
@@ -50,7 +50,7 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 23}
+      subprogram: {subprogram: 17}
       events:
         - ID: 17
           Type: 298 EventRootType Probe[main.testArrayOfArraysOfArrays]
@@ -64,7 +64,7 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 59}
+      subprogram: {subprogram: 53}
       events:
         - ID: 53
           Type: 334 EventRootType Probe[main.testArrayOfMaps]
@@ -78,7 +78,7 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 22}
+      subprogram: {subprogram: 16}
       events:
         - ID: 16
           Type: 297 EventRootType Probe[main.testArrayOfStrings]
@@ -92,7 +92,7 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 41}
+      subprogram: {subprogram: 35}
       events:
         - ID: 35
           Type: 316 EventRootType Probe[main.testBigStruct]
@@ -106,7 +106,7 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 10}
+      subprogram: {subprogram: 4}
       events:
         - ID: 4
           Type: 285 EventRootType Probe[main.testBoolArray]
@@ -120,7 +120,7 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 7}
+      subprogram: {subprogram: 1}
       events:
         - ID: 1
           Type: 282 EventRootType Probe[main.testByteArray]
@@ -134,7 +134,7 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 75}
+      subprogram: {subprogram: 69}
       events:
         - ID: 69
           Type: 350 EventRootType Probe[main.testChannel]
@@ -148,7 +148,7 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 73}
+      subprogram: {subprogram: 67}
       events:
         - ID: 67
           Type: 348 EventRootType Probe[main.testCombinedByte]
@@ -162,7 +162,7 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 83}
+      subprogram: {subprogram: 77}
       events:
         - ID: 77
           Type: 358 EventRootType Probe[main.testCycle]
@@ -176,7 +176,7 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 85}
+      subprogram: {subprogram: 79}
       events:
         - ID: 79
           Type: 360 EventRootType Probe[main.testEmptySlice]
@@ -190,7 +190,7 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 88}
+      subprogram: {subprogram: 82}
       events:
         - ID: 82
           Type: 363 EventRootType Probe[main.testEmptySliceOfStructs]
@@ -204,7 +204,7 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 102}
+      subprogram: {subprogram: 96}
       events:
         - ID: 96
           Type: 377 EventRootType Probe[main.testEmptyString]
@@ -218,7 +218,7 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 104}
+      subprogram: {subprogram: 98}
       events:
         - ID: 98
           Type: 379 EventRootType Probe[main.testEmptyStruct]
@@ -232,7 +232,7 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 52}
+      subprogram: {subprogram: 46}
       events:
         - ID: 46
           Type: 327 EventRootType Probe[main.testError]
@@ -246,7 +246,7 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 43}
+      subprogram: {subprogram: 37}
       events:
         - ID: 37
           Type: 318 EventRootType Probe[main.testEsotericHeap]
@@ -260,7 +260,7 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 42}
+      subprogram: {subprogram: 36}
       events:
         - ID: 36
           Type: 317 EventRootType Probe[main.testEsotericStack]
@@ -274,7 +274,7 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 48}
+      subprogram: {subprogram: 42}
       events:
         - ID: 42
           Type: 323 EventRootType Probe[main.testFrameless]
@@ -288,7 +288,7 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 49}
+      subprogram: {subprogram: 43}
       events:
         - ID: 43
           Type: 324 EventRootType Probe[main.testFramelessArray]
@@ -302,7 +302,7 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 44}
+      subprogram: {subprogram: 38}
       events:
         - ID: 38
           Type: 319 EventRootType Probe[main.testInlinedBA]
@@ -316,7 +316,7 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 45}
+      subprogram: {subprogram: 39}
       events:
         - ID: 39
           Type: 320 EventRootType Probe[main.testInlinedBB]
@@ -330,7 +330,7 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 46}
+      subprogram: {subprogram: 40}
       events:
         - ID: 40
           Type: 321 EventRootType Probe[main.testInlinedBBA]
@@ -344,7 +344,7 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 2}
+      subprogram: {subprogram: 100}
       events:
         - ID: 100
           Type: 381 EventRootType Probe[main.testInlinedBBB]
@@ -358,7 +358,7 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 47}
+      subprogram: {subprogram: 41}
       events:
         - ID: 41
           Type: 322 EventRootType Probe[main.testInlinedBC]
@@ -372,7 +372,7 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 3}
+      subprogram: {subprogram: 101}
       events:
         - ID: 101
           Type: 382 EventRootType Probe[main.testInlinedBCA]
@@ -386,7 +386,7 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 4}
+      subprogram: {subprogram: 102}
       events:
         - ID: 102
           Type: 383 EventRootType Probe[main.testInlinedBCB]
@@ -401,7 +401,7 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 1}
+      subprogram: {subprogram: 99}
       events:
         - ID: 99
           Type: 380 EventRootType Probe[main.testInlinedPrint]
@@ -425,7 +425,7 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 5}
+      subprogram: {subprogram: 103}
       events:
         - ID: 103
           Type: 384 EventRootType Probe[main.testInlinedSq]
@@ -440,7 +440,7 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 6}
+      subprogram: {subprogram: 104}
       events:
         - ID: 104
           Type: 385 EventRootType Probe[main.testInlinedSumArray]
@@ -458,7 +458,7 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 13}
+      subprogram: {subprogram: 7}
       events:
         - ID: 7
           Type: 288 EventRootType Probe[main.testInt16Array]
@@ -472,7 +472,7 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 14}
+      subprogram: {subprogram: 8}
       events:
         - ID: 8
           Type: 289 EventRootType Probe[main.testInt32Array]
@@ -486,7 +486,7 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 15}
+      subprogram: {subprogram: 9}
       events:
         - ID: 9
           Type: 290 EventRootType Probe[main.testInt64Array]
@@ -500,7 +500,7 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 12}
+      subprogram: {subprogram: 6}
       events:
         - ID: 6
           Type: 287 EventRootType Probe[main.testInt8Array]
@@ -514,7 +514,7 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 11}
+      subprogram: {subprogram: 5}
       events:
         - ID: 5
           Type: 286 EventRootType Probe[main.testIntArray]
@@ -528,7 +528,7 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 50}
+      subprogram: {subprogram: 44}
       events:
         - ID: 44
           Type: 325 EventRootType Probe[main.testInterface]
@@ -542,7 +542,7 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 77}
+      subprogram: {subprogram: 71}
       events:
         - ID: 71
           Type: 352 EventRootType Probe[main.testLinkedList]
@@ -556,7 +556,7 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 57}
+      subprogram: {subprogram: 51}
       events:
         - ID: 51
           Type: 332 EventRootType Probe[main.testMapArrayToArray]
@@ -570,7 +570,7 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 63}
+      subprogram: {subprogram: 57}
       events:
         - ID: 57
           Type: 338 EventRootType Probe[main.testMapEmbeddedMaps]
@@ -584,7 +584,7 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 61}
+      subprogram: {subprogram: 55}
       events:
         - ID: 55
           Type: 336 EventRootType Probe[main.testMapIntToInt]
@@ -598,7 +598,7 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 72}
+      subprogram: {subprogram: 66}
       events:
         - ID: 66
           Type: 347 EventRootType Probe[main.testMapLargeKeyLargeValue]
@@ -612,7 +612,7 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 71}
+      subprogram: {subprogram: 65}
       events:
         - ID: 65
           Type: 346 EventRootType Probe[main.testMapLargeKeySmallValue]
@@ -626,7 +626,7 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 62}
+      subprogram: {subprogram: 56}
       events:
         - ID: 56
           Type: 337 EventRootType Probe[main.testMapMassive]
@@ -640,7 +640,7 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 70}
+      subprogram: {subprogram: 64}
       events:
         - ID: 64
           Type: 345 EventRootType Probe[main.testMapSmallKeyLargeValue]
@@ -654,7 +654,7 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 69}
+      subprogram: {subprogram: 63}
       events:
         - ID: 63
           Type: 344 EventRootType Probe[main.testMapSmallKeySmallValue]
@@ -668,7 +668,7 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 55}
+      subprogram: {subprogram: 49}
       events:
         - ID: 49
           Type: 330 EventRootType Probe[main.testMapStringToInt]
@@ -682,7 +682,7 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 56}
+      subprogram: {subprogram: 50}
       events:
         - ID: 50
           Type: 331 EventRootType Probe[main.testMapStringToSlice]
@@ -696,7 +696,7 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 54}
+      subprogram: {subprogram: 48}
       events:
         - ID: 48
           Type: 329 EventRootType Probe[main.testMapStringToStruct]
@@ -710,7 +710,7 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 64}
+      subprogram: {subprogram: 58}
       events:
         - ID: 58
           Type: 339 EventRootType Probe[main.testMapWithLinkedList]
@@ -724,7 +724,7 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 67}
+      subprogram: {subprogram: 61}
       events:
         - ID: 61
           Type: 342 EventRootType Probe[main.testMapWithSmallKeyAndValue]
@@ -738,7 +738,7 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 68}
+      subprogram: {subprogram: 62}
       events:
         - ID: 62
           Type: 343 EventRootType Probe[main.testMapWithSmallKeyAndValueMassive]
@@ -752,7 +752,7 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 65}
+      subprogram: {subprogram: 59}
       events:
         - ID: 59
           Type: 340 EventRootType Probe[main.testMapWithSmallValue]
@@ -766,7 +766,7 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 66}
+      subprogram: {subprogram: 60}
       events:
         - ID: 60
           Type: 341 EventRootType Probe[main.testMapWithSmallValueMassive]
@@ -780,7 +780,7 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 100}
+      subprogram: {subprogram: 94}
       events:
         - ID: 94
           Type: 375 EventRootType Probe[main.testMassiveString]
@@ -794,7 +794,7 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 74}
+      subprogram: {subprogram: 68}
       events:
         - ID: 68
           Type: 349 EventRootType Probe[main.testMultipleSimpleParams]
@@ -808,7 +808,7 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 82}
+      subprogram: {subprogram: 76}
       events:
         - ID: 76
           Type: 357 EventRootType Probe[main.testNilPointer]
@@ -822,7 +822,7 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 92}
+      subprogram: {subprogram: 86}
       events:
         - ID: 86
           Type: 367 EventRootType Probe[main.testNilSlice]
@@ -836,7 +836,7 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 89}
+      subprogram: {subprogram: 83}
       events:
         - ID: 83
           Type: 364 EventRootType Probe[main.testNilSliceOfStructs]
@@ -850,7 +850,7 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 91}
+      subprogram: {subprogram: 85}
       events:
         - ID: 85
           Type: 366 EventRootType Probe[main.testNilSliceWithOtherParams]
@@ -864,7 +864,7 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 99}
+      subprogram: {subprogram: 93}
       events:
         - ID: 93
           Type: 374 EventRootType Probe[main.testOneStringInStructPointer]
@@ -878,7 +878,7 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 78}
+      subprogram: {subprogram: 72}
       events:
         - ID: 72
           Type: 353 EventRootType Probe[main.testPointerLoop]
@@ -892,7 +892,7 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 60}
+      subprogram: {subprogram: 54}
       events:
         - ID: 54
           Type: 335 EventRootType Probe[main.testPointerToMap]
@@ -906,7 +906,7 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 76}
+      subprogram: {subprogram: 70}
       events:
         - ID: 70
           Type: 351 EventRootType Probe[main.testPointerToSimpleStruct]
@@ -920,7 +920,7 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 8}
+      subprogram: {subprogram: 2}
       events:
         - ID: 2
           Type: 283 EventRootType Probe[main.testRuneArray]
@@ -934,7 +934,7 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 27}
+      subprogram: {subprogram: 21}
       events:
         - ID: 21
           Type: 302 EventRootType Probe[main.testSingleBool]
@@ -948,7 +948,7 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 25}
+      subprogram: {subprogram: 19}
       events:
         - ID: 19
           Type: 300 EventRootType Probe[main.testSingleByte]
@@ -962,7 +962,7 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 38}
+      subprogram: {subprogram: 32}
       events:
         - ID: 32
           Type: 313 EventRootType Probe[main.testSingleFloat32]
@@ -976,7 +976,7 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 39}
+      subprogram: {subprogram: 33}
       events:
         - ID: 33
           Type: 314 EventRootType Probe[main.testSingleFloat64]
@@ -990,7 +990,7 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 28}
+      subprogram: {subprogram: 22}
       events:
         - ID: 22
           Type: 303 EventRootType Probe[main.testSingleInt]
@@ -1004,7 +1004,7 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 30}
+      subprogram: {subprogram: 24}
       events:
         - ID: 24
           Type: 305 EventRootType Probe[main.testSingleInt16]
@@ -1018,7 +1018,7 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 31}
+      subprogram: {subprogram: 25}
       events:
         - ID: 25
           Type: 306 EventRootType Probe[main.testSingleInt32]
@@ -1032,7 +1032,7 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 32}
+      subprogram: {subprogram: 26}
       events:
         - ID: 26
           Type: 307 EventRootType Probe[main.testSingleInt64]
@@ -1046,7 +1046,7 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 29}
+      subprogram: {subprogram: 23}
       events:
         - ID: 23
           Type: 304 EventRootType Probe[main.testSingleInt8]
@@ -1060,7 +1060,7 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 26}
+      subprogram: {subprogram: 20}
       events:
         - ID: 20
           Type: 301 EventRootType Probe[main.testSingleRune]
@@ -1074,7 +1074,7 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 95}
+      subprogram: {subprogram: 89}
       events:
         - ID: 89
           Type: 370 EventRootType Probe[main.testSingleString]
@@ -1088,7 +1088,7 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 33}
+      subprogram: {subprogram: 27}
       events:
         - ID: 27
           Type: 308 EventRootType Probe[main.testSingleUint]
@@ -1102,7 +1102,7 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 35}
+      subprogram: {subprogram: 29}
       events:
         - ID: 29
           Type: 310 EventRootType Probe[main.testSingleUint16]
@@ -1116,7 +1116,7 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 36}
+      subprogram: {subprogram: 30}
       events:
         - ID: 30
           Type: 311 EventRootType Probe[main.testSingleUint32]
@@ -1130,7 +1130,7 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 37}
+      subprogram: {subprogram: 31}
       events:
         - ID: 31
           Type: 312 EventRootType Probe[main.testSingleUint64]
@@ -1144,7 +1144,7 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 34}
+      subprogram: {subprogram: 28}
       events:
         - ID: 28
           Type: 309 EventRootType Probe[main.testSingleUint8]
@@ -1158,7 +1158,7 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 86}
+      subprogram: {subprogram: 80}
       events:
         - ID: 80
           Type: 361 EventRootType Probe[main.testSliceOfSlices]
@@ -1172,7 +1172,7 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 58}
+      subprogram: {subprogram: 52}
       events:
         - ID: 52
           Type: 333 EventRootType Probe[main.testSmallMap]
@@ -1186,7 +1186,7 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 9}
+      subprogram: {subprogram: 3}
       events:
         - ID: 3
           Type: 284 EventRootType Probe[main.testStringArray]
@@ -1200,7 +1200,7 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 81}
+      subprogram: {subprogram: 75}
       events:
         - ID: 75
           Type: 356 EventRootType Probe[main.testStringPointer]
@@ -1214,7 +1214,7 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 90}
+      subprogram: {subprogram: 84}
       events:
         - ID: 84
           Type: 365 EventRootType Probe[main.testStringSlice]
@@ -1228,7 +1228,7 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 103}
+      subprogram: {subprogram: 97}
       events:
         - ID: 97
           Type: 378 EventRootType Probe[main.testStruct]
@@ -1242,7 +1242,7 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 87}
+      subprogram: {subprogram: 81}
       events:
         - ID: 81
           Type: 362 EventRootType Probe[main.testStructSlice]
@@ -1256,7 +1256,7 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 53}
+      subprogram: {subprogram: 47}
       events:
         - ID: 47
           Type: 328 EventRootType Probe[main.testStructWithMap]
@@ -1270,7 +1270,7 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 96}
+      subprogram: {subprogram: 90}
       events:
         - ID: 90
           Type: 371 EventRootType Probe[main.testThreeStrings]
@@ -1284,7 +1284,7 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 97}
+      subprogram: {subprogram: 91}
       events:
         - ID: 91
           Type: 372 EventRootType Probe[main.testThreeStringsInStruct]
@@ -1298,7 +1298,7 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 98}
+      subprogram: {subprogram: 92}
       events:
         - ID: 92
           Type: 373 EventRootType Probe[main.testThreeStringsInStructPointer]
@@ -1312,7 +1312,7 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 40}
+      subprogram: {subprogram: 34}
       events:
         - ID: 34
           Type: 315 EventRootType Probe[main.testTypeAlias]
@@ -1326,7 +1326,7 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 18}
+      subprogram: {subprogram: 12}
       events:
         - ID: 12
           Type: 293 EventRootType Probe[main.testUint16Array]
@@ -1340,7 +1340,7 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 19}
+      subprogram: {subprogram: 13}
       events:
         - ID: 13
           Type: 294 EventRootType Probe[main.testUint32Array]
@@ -1354,7 +1354,7 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 20}
+      subprogram: {subprogram: 14}
       events:
         - ID: 14
           Type: 295 EventRootType Probe[main.testUint64Array]
@@ -1368,7 +1368,7 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 17}
+      subprogram: {subprogram: 11}
       events:
         - ID: 11
           Type: 292 EventRootType Probe[main.testUint8Array]
@@ -1382,7 +1382,7 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 16}
+      subprogram: {subprogram: 10}
       events:
         - ID: 10
           Type: 291 EventRootType Probe[main.testUintArray]
@@ -1396,7 +1396,7 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 80}
+      subprogram: {subprogram: 74}
       events:
         - ID: 74
           Type: 355 EventRootType Probe[main.testUintPointer]
@@ -1410,7 +1410,7 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 84}
+      subprogram: {subprogram: 78}
       events:
         - ID: 78
           Type: 359 EventRootType Probe[main.testUintSlice]
@@ -1424,7 +1424,7 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 101}
+      subprogram: {subprogram: 95}
       events:
         - ID: 95
           Type: 376 EventRootType Probe[main.testUnitializedString]
@@ -1438,7 +1438,7 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 79}
+      subprogram: {subprogram: 73}
       events:
         - ID: 73
           Type: 354 EventRootType Probe[main.testUnsafePointer]
@@ -1452,7 +1452,7 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 24}
+      subprogram: {subprogram: 18}
       events:
         - ID: 18
           Type: 299 EventRootType Probe[main.testVeryLargeArray]
@@ -1466,428 +1466,428 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 93}
+      subprogram: {subprogram: 87}
       events:
         - ID: 87
           Type: 368 EventRootType Probe[main.testVeryLargeSlice]
           InjectionPoints: [{PC: "0xcd8080", Frameless: true}]
           Condition: null
 Subprograms:
-    - ID: 7
+    - ID: 1
       Name: main.testByteArray
       OutOfLinePCRanges: [0xcd3ca0..0xcd3ca1]
       InlinePCRanges: []
       Variables:
         - Name: x
-          Type: 3 ArrayType [2]uint8
+          Type: 36 ArrayType [2]uint8
           Locations:
             - Range: 0xcd3ca0..0xcd3ca1
               Pieces: [{Size: 2, Op: {CfaOffset: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 8
+    - ID: 2
       Name: main.testRuneArray
       OutOfLinePCRanges: [0xcd3cc0..0xcd3cc1]
       InlinePCRanges: []
       Variables:
         - Name: x
-          Type: 5 ArrayType [2]int32
+          Type: 37 ArrayType [2]int32
           Locations:
             - Range: 0xcd3cc0..0xcd3cc1
               Pieces: [{Size: 8, Op: {CfaOffset: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 9
+    - ID: 3
       Name: main.testStringArray
       OutOfLinePCRanges: [0xcd3ce0..0xcd3ce1]
       InlinePCRanges: []
       Variables:
         - Name: x
-          Type: 7 ArrayType [2]string
+          Type: 38 ArrayType [2]string
           Locations:
             - Range: 0xcd3ce0..0xcd3ce1
               Pieces: [{Size: 32, Op: {CfaOffset: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 10
+    - ID: 4
       Name: main.testBoolArray
       OutOfLinePCRanges: [0xcd3d00..0xcd3d01]
       InlinePCRanges: []
       Variables:
         - Name: x
-          Type: 10 ArrayType [2]bool
+          Type: 39 ArrayType [2]bool
           Locations:
             - Range: 0xcd3d00..0xcd3d01
               Pieces: [{Size: 2, Op: {CfaOffset: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 11
+    - ID: 5
       Name: main.testIntArray
       OutOfLinePCRanges: [0xcd3d20..0xcd3d21]
       InlinePCRanges: []
       Variables:
         - Name: x
-          Type: 12 ArrayType [2]int
+          Type: 40 ArrayType [2]int
           Locations:
             - Range: 0xcd3d20..0xcd3d21
               Pieces: [{Size: 16, Op: {CfaOffset: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 12
+    - ID: 6
       Name: main.testInt8Array
       OutOfLinePCRanges: [0xcd3d40..0xcd3d41]
       InlinePCRanges: []
       Variables:
         - Name: x
-          Type: 13 ArrayType [2]int8
+          Type: 41 ArrayType [2]int8
           Locations:
             - Range: 0xcd3d40..0xcd3d41
               Pieces: [{Size: 2, Op: {CfaOffset: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 13
+    - ID: 7
       Name: main.testInt16Array
       OutOfLinePCRanges: [0xcd3d60..0xcd3d61]
       InlinePCRanges: []
       Variables:
         - Name: x
-          Type: 15 ArrayType [2]int16
+          Type: 42 ArrayType [2]int16
           Locations:
             - Range: 0xcd3d60..0xcd3d61
               Pieces: [{Size: 4, Op: {CfaOffset: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 14
+    - ID: 8
       Name: main.testInt32Array
       OutOfLinePCRanges: [0xcd3d80..0xcd3d81]
       InlinePCRanges: []
       Variables:
         - Name: x
-          Type: 5 ArrayType [2]int32
+          Type: 37 ArrayType [2]int32
           Locations:
             - Range: 0xcd3d80..0xcd3d81
               Pieces: [{Size: 8, Op: {CfaOffset: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 15
+    - ID: 9
       Name: main.testInt64Array
       OutOfLinePCRanges: [0xcd3da0..0xcd3da1]
       InlinePCRanges: []
       Variables:
         - Name: x
-          Type: 17 ArrayType [2]int64
+          Type: 43 ArrayType [2]int64
           Locations:
             - Range: 0xcd3da0..0xcd3da1
               Pieces: [{Size: 16, Op: {CfaOffset: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 16
+    - ID: 10
       Name: main.testUintArray
       OutOfLinePCRanges: [0xcd3dc0..0xcd3dc1]
       InlinePCRanges: []
       Variables:
         - Name: x
-          Type: 19 ArrayType [2]uint
+          Type: 44 ArrayType [2]uint
           Locations:
             - Range: 0xcd3dc0..0xcd3dc1
               Pieces: [{Size: 16, Op: {CfaOffset: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 17
+    - ID: 11
       Name: main.testUint8Array
       OutOfLinePCRanges: [0xcd3de0..0xcd3de1]
       InlinePCRanges: []
       Variables:
         - Name: x
-          Type: 3 ArrayType [2]uint8
+          Type: 36 ArrayType [2]uint8
           Locations:
             - Range: 0xcd3de0..0xcd3de1
               Pieces: [{Size: 2, Op: {CfaOffset: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 18
+    - ID: 12
       Name: main.testUint16Array
       OutOfLinePCRanges: [0xcd3e00..0xcd3e01]
       InlinePCRanges: []
       Variables:
         - Name: x
-          Type: 21 ArrayType [2]uint16
+          Type: 45 ArrayType [2]uint16
           Locations:
             - Range: 0xcd3e00..0xcd3e01
               Pieces: [{Size: 4, Op: {CfaOffset: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 19
+    - ID: 13
       Name: main.testUint32Array
       OutOfLinePCRanges: [0xcd3e20..0xcd3e21]
       InlinePCRanges: []
       Variables:
         - Name: x
-          Type: 23 ArrayType [2]uint32
+          Type: 46 ArrayType [2]uint32
           Locations:
             - Range: 0xcd3e20..0xcd3e21
               Pieces: [{Size: 8, Op: {CfaOffset: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 20
+    - ID: 14
       Name: main.testUint64Array
       OutOfLinePCRanges: [0xcd3e40..0xcd3e41]
       InlinePCRanges: []
       Variables:
         - Name: x
-          Type: 25 ArrayType [2]uint64
+          Type: 47 ArrayType [2]uint64
           Locations:
             - Range: 0xcd3e40..0xcd3e41
               Pieces: [{Size: 16, Op: {CfaOffset: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 21
+    - ID: 15
       Name: main.testArrayOfArrays
       OutOfLinePCRanges: [0xcd3e60..0xcd3e61]
       InlinePCRanges: []
       Variables:
         - Name: a
-          Type: 27 ArrayType [2][2]int
+          Type: 48 ArrayType [2][2]int
           Locations:
             - Range: 0xcd3e60..0xcd3e61
               Pieces: [{Size: 32, Op: {CfaOffset: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 22
+    - ID: 16
       Name: main.testArrayOfStrings
       OutOfLinePCRanges: [0xcd3e80..0xcd3e81]
       InlinePCRanges: []
       Variables:
         - Name: a
-          Type: 7 ArrayType [2]string
+          Type: 38 ArrayType [2]string
           Locations:
             - Range: 0xcd3e80..0xcd3e81
               Pieces: [{Size: 32, Op: {CfaOffset: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 23
+    - ID: 17
       Name: main.testArrayOfArraysOfArrays
       OutOfLinePCRanges: [0xcd3ea0..0xcd3ea1]
       InlinePCRanges: []
       Variables:
         - Name: b
-          Type: 28 ArrayType [2][2][2]int
+          Type: 49 ArrayType [2][2][2]int
           Locations:
             - Range: 0xcd3ea0..0xcd3ea1
               Pieces: [{Size: 64, Op: {CfaOffset: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 24
+    - ID: 18
       Name: main.testVeryLargeArray
       OutOfLinePCRanges: [0xcd3f00..0xcd3f01]
       InlinePCRanges: []
       Variables:
         - Name: a
-          Type: 29 ArrayType [100]uint
+          Type: 50 ArrayType [100]uint
           Locations:
             - Range: 0xcd3f00..0xcd3f01
               Pieces: [{Size: 800, Op: {CfaOffset: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 25
+    - ID: 19
       Name: main.testSingleByte
       OutOfLinePCRanges: [0xcd4280..0xcd4281]
       InlinePCRanges: []
       Variables:
         - Name: x
-          Type: 4 BaseType uint8
+          Type: 3 BaseType uint8
           Locations:
             - Range: 0xcd4280..0xcd4281
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 26
+    - ID: 20
       Name: main.testSingleRune
       OutOfLinePCRanges: [0xcd42a0..0xcd42a1]
       InlinePCRanges: []
       Variables:
         - Name: x
-          Type: 6 BaseType int32
+          Type: 10 BaseType int32
           Locations:
             - Range: 0xcd42a0..0xcd42a1
               Pieces: [{Size: 4, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 27
+    - ID: 21
       Name: main.testSingleBool
       OutOfLinePCRanges: [0xcd42c0..0xcd42c1]
       InlinePCRanges: []
       Variables:
         - Name: x
-          Type: 11 BaseType bool
+          Type: 4 BaseType bool
           Locations:
             - Range: 0xcd42c0..0xcd42c1
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 28
+    - ID: 22
       Name: main.testSingleInt
       OutOfLinePCRanges: [0xcd42e0..0xcd42e1]
       InlinePCRanges: []
       Variables:
         - Name: x
-          Type: 1 BaseType int
+          Type: 7 BaseType int
           Locations:
             - Range: 0xcd42e0..0xcd42e1
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 29
+    - ID: 23
       Name: main.testSingleInt8
       OutOfLinePCRanges: [0xcd4300..0xcd4301]
       InlinePCRanges: []
       Variables:
         - Name: x
-          Type: 14 BaseType int8
+          Type: 15 BaseType int8
           Locations:
             - Range: 0xcd4300..0xcd4301
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 30
+    - ID: 24
       Name: main.testSingleInt16
       OutOfLinePCRanges: [0xcd4320..0xcd4321]
       InlinePCRanges: []
       Variables:
         - Name: x
-          Type: 16 BaseType int16
+          Type: 31 BaseType int16
           Locations:
             - Range: 0xcd4320..0xcd4321
               Pieces: [{Size: 2, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 31
+    - ID: 25
       Name: main.testSingleInt32
       OutOfLinePCRanges: [0xcd4340..0xcd4341]
       InlinePCRanges: []
       Variables:
         - Name: x
-          Type: 6 BaseType int32
+          Type: 10 BaseType int32
           Locations:
             - Range: 0xcd4340..0xcd4341
               Pieces: [{Size: 4, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 32
+    - ID: 26
       Name: main.testSingleInt64
       OutOfLinePCRanges: [0xcd4360..0xcd4361]
       InlinePCRanges: []
       Variables:
         - Name: x
-          Type: 18 BaseType int64
+          Type: 12 BaseType int64
           Locations:
             - Range: 0xcd4360..0xcd4361
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 33
+    - ID: 27
       Name: main.testSingleUint
       OutOfLinePCRanges: [0xcd4380..0xcd4381]
       InlinePCRanges: []
       Variables:
         - Name: x
-          Type: 20 BaseType uint
+          Type: 16 BaseType uint
           Locations:
             - Range: 0xcd4380..0xcd4381
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 34
+    - ID: 28
       Name: main.testSingleUint8
       OutOfLinePCRanges: [0xcd43a0..0xcd43a1]
       InlinePCRanges: []
       Variables:
         - Name: x
-          Type: 4 BaseType uint8
+          Type: 3 BaseType uint8
           Locations:
             - Range: 0xcd43a0..0xcd43a1
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 35
+    - ID: 29
       Name: main.testSingleUint16
       OutOfLinePCRanges: [0xcd43c0..0xcd43c1]
       InlinePCRanges: []
       Variables:
         - Name: x
-          Type: 22 BaseType uint16
+          Type: 6 BaseType uint16
           Locations:
             - Range: 0xcd43c0..0xcd43c1
               Pieces: [{Size: 2, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 36
+    - ID: 30
       Name: main.testSingleUint32
       OutOfLinePCRanges: [0xcd43e0..0xcd43e1]
       InlinePCRanges: []
       Variables:
         - Name: x
-          Type: 24 BaseType uint32
+          Type: 2 BaseType uint32
           Locations:
             - Range: 0xcd43e0..0xcd43e1
               Pieces: [{Size: 4, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 37
+    - ID: 31
       Name: main.testSingleUint64
       OutOfLinePCRanges: [0xcd4400..0xcd4401]
       InlinePCRanges: []
       Variables:
         - Name: x
-          Type: 26 BaseType uint64
+          Type: 8 BaseType uint64
           Locations:
             - Range: 0xcd4400..0xcd4401
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 38
+    - ID: 32
       Name: main.testSingleFloat32
       OutOfLinePCRanges: [0xcd4420..0xcd4421]
       InlinePCRanges: []
       Variables:
         - Name: x
-          Type: 30 BaseType float32
+          Type: 17 BaseType float32
           Locations:
             - Range: 0xcd4420..0xcd4421
               Pieces: [{Size: 4, Op: {RegNo: 17, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 39
+    - ID: 33
       Name: main.testSingleFloat64
       OutOfLinePCRanges: [0xcd4440..0xcd4441]
       InlinePCRanges: []
       Variables:
         - Name: x
-          Type: 31 BaseType float64
+          Type: 18 BaseType float64
           Locations:
             - Range: 0xcd4440..0xcd4441
               Pieces: [{Size: 8, Op: {RegNo: 17, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 40
+    - ID: 34
       Name: main.testTypeAlias
       OutOfLinePCRanges: [0xcd4460..0xcd4461]
       InlinePCRanges: []
       Variables:
         - Name: x
-          Type: 32 BaseType main.typeAlias
+          Type: 51 BaseType main.typeAlias
           Locations:
             - Range: 0xcd4460..0xcd4461
               Pieces: [{Size: 2, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 41
+    - ID: 35
       Name: main.testBigStruct
       OutOfLinePCRanges: [0xcd45c0..0xcd45df]
       InlinePCRanges: []
       Variables:
         - Name: b
-          Type: 33 StructureType main.bigStruct
+          Type: 52 StructureType main.bigStruct
           Locations:
             - Range: 0xcd45c0..0xcd45df
               Pieces:
@@ -1905,13 +1905,13 @@ Subprograms:
                   Op: {RegNo: 8, Shift: 0}
           IsParameter: true
           IsReturn: false
-    - ID: 42
+    - ID: 36
       Name: main.testEsotericStack
       OutOfLinePCRanges: [0xcd4840..0xcd4945]
       InlinePCRanges: []
       Variables:
         - Name: e
-          Type: 39 StructureType main.esotericStack
+          Type: 56 StructureType main.esotericStack
           Locations:
             - Range: 0xcd4840..0xcd4893
               Pieces:
@@ -1975,51 +1975,51 @@ Subprograms:
                   Op: {RegNo: 11, Shift: 0}
           IsParameter: true
           IsReturn: false
-    - ID: 43
+    - ID: 37
       Name: main.testEsotericHeap
       OutOfLinePCRanges: [0xcd4960..0xcd49c3]
       InlinePCRanges: []
       Variables:
         - Name: e
-          Type: 44 PointerType *main.esotericHeap
+          Type: 61 PointerType *main.esotericHeap
           Locations:
             - Range: 0xcd4960..0xcd498d
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 44
+    - ID: 38
       Name: main.testInlinedBA
       OutOfLinePCRanges: [0xcd4da0..0xcd4e28]
       InlinePCRanges: []
       Variables:
         - Name: x
-          Type: 1 BaseType int
+          Type: 7 BaseType int
           Locations:
             - Range: 0xcd4da0..0xcd4db5
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 45
+    - ID: 39
       Name: main.testInlinedBB
       OutOfLinePCRanges: [0xcd4e40..0xcd4f05]
       InlinePCRanges: []
       Variables:
         - Name: x
-          Type: 1 BaseType int
+          Type: 7 BaseType int
           Locations:
             - Range: 0xcd4e40..0xcd4e56
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
         - Name: y
-          Type: 1 BaseType int
+          Type: 7 BaseType int
           Locations:
             - Range: 0xcd4e40..0xcd4e67
               Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
           IsParameter: true
           IsReturn: false
         - Name: z
-          Type: 1 BaseType int
+          Type: 7 BaseType int
           Locations:
             - Range: 0xcd4e56..0xcd4e67
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
@@ -2027,25 +2027,25 @@ Subprograms:
               Pieces: [{Size: 8, Op: {CfaOffset: -56}}]
           IsParameter: false
           IsReturn: false
-    - ID: 46
+    - ID: 40
       Name: main.testInlinedBBA
       OutOfLinePCRanges: [0xcd4f20..0xcd4f82]
       InlinePCRanges: []
       Variables:
         - Name: x
-          Type: 1 BaseType int
+          Type: 7 BaseType int
           Locations:
             - Range: 0xcd4f20..0xcd4f3a
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 47
+    - ID: 41
       Name: main.testInlinedBC
       OutOfLinePCRanges: [0xcd4fa0..0xcd50ae]
       InlinePCRanges: []
       Variables:
         - Name: s
-          Type: 1 BaseType int
+          Type: 7 BaseType int
           Locations:
             - Range: 0xcd4ffb..0xcd5005
               Pieces: [{Size: 8, Op: {CfaOffset: -80}}]
@@ -2056,7 +2056,7 @@ Subprograms:
           IsParameter: false
           IsReturn: false
         - Name: i
-          Type: 1 BaseType int
+          Type: 7 BaseType int
           Locations:
             - Range: 0xcd4ff6..0xcd5000
               Pieces: [{Size: 8, Op: {CfaOffset: -72}}]
@@ -2066,47 +2066,47 @@ Subprograms:
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: false
           IsReturn: false
-    - ID: 48
+    - ID: 42
       Name: main.testFrameless
       OutOfLinePCRanges: [0xcd50c0..0xcd50c6]
       InlinePCRanges: []
       Variables:
         - Name: x
-          Type: 1 BaseType int
+          Type: 7 BaseType int
           Locations:
             - Range: 0xcd50c0..0xcd50c5
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
         - Name: ~r0
-          Type: 1 BaseType int
+          Type: 7 BaseType int
           Locations: [{Range: 0xcd50c0..0xcd50c6, Pieces: []}]
           IsParameter: true
           IsReturn: true
-    - ID: 49
+    - ID: 43
       Name: main.testFramelessArray
       OutOfLinePCRanges: [0xcd50e0..0xcd5123]
       InlinePCRanges: []
       Variables:
         - Name: a
-          Type: 2 ArrayType [5]int
+          Type: 73 ArrayType [5]int
           Locations:
             - Range: 0xcd50e0..0xcd5123
               Pieces: [{Size: 40, Op: {CfaOffset: 0}}]
           IsParameter: true
           IsReturn: false
         - Name: ~r0
-          Type: 1 BaseType int
+          Type: 7 BaseType int
           Locations: [{Range: 0xcd50e0..0xcd5123, Pieces: []}]
           IsParameter: true
           IsReturn: true
-    - ID: 50
+    - ID: 44
       Name: main.testInterface
       OutOfLinePCRanges: [0xcd53c0..0xcd5403]
       InlinePCRanges: []
       Variables:
         - Name: b
-          Type: 56 GoInterfaceType main.behavior
+          Type: 74 GoInterfaceType main.behavior
           Locations:
             - Range: 0xcd53c0..0xcd53df
               Pieces:
@@ -2123,17 +2123,17 @@ Subprograms:
           IsParameter: true
           IsReturn: false
         - Name: ~r0
-          Type: 8 GoStringHeaderType string
+          Type: 9 GoStringHeaderType string
           Locations: [{Range: 0xcd53c0..0xcd5403, Pieces: []}]
           IsParameter: true
           IsReturn: true
-    - ID: 51
+    - ID: 45
       Name: main.testAny
       OutOfLinePCRanges: [0xcd5420..0xcd5486]
       InlinePCRanges: []
       Variables:
         - Name: a
-          Type: 41 GoEmptyInterfaceType interface {}
+          Type: 58 GoEmptyInterfaceType interface {}
           Locations:
             - Range: 0xcd5420..0xcd5449
               Pieces:
@@ -2150,17 +2150,17 @@ Subprograms:
           IsParameter: true
           IsReturn: false
         - Name: ~r0
-          Type: 8 GoStringHeaderType string
+          Type: 9 GoStringHeaderType string
           Locations: [{Range: 0xcd5420..0xcd5486, Pieces: []}]
           IsParameter: true
           IsReturn: true
-    - ID: 52
+    - ID: 46
       Name: main.testError
       OutOfLinePCRanges: [0xcd54a0..0xcd54a1]
       InlinePCRanges: []
       Variables:
         - Name: e
-          Type: 57 GoInterfaceType error
+          Type: 13 GoInterfaceType error
           Locations:
             - Range: 0xcd54a0..0xcd54a1
               Pieces:
@@ -2170,307 +2170,307 @@ Subprograms:
                   Op: {RegNo: 3, Shift: 0}
           IsParameter: true
           IsReturn: false
-    - ID: 53
+    - ID: 47
       Name: main.testStructWithMap
       OutOfLinePCRanges: [0xcd5900..0xcd5901]
       InlinePCRanges: []
       Variables:
         - Name: s
-          Type: 58 StructureType main.structWithMap
+          Type: 75 StructureType main.structWithMap
           Locations:
             - Range: 0xcd5900..0xcd5901
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 54
+    - ID: 48
       Name: main.testMapStringToStruct
       OutOfLinePCRanges: [0xcd5920..0xcd5921]
       InlinePCRanges: []
       Variables:
         - Name: m
-          Type: 71 GoMapType map[string]main.nestedStruct
+          Type: 87 GoMapType map[string]main.nestedStruct
           Locations:
             - Range: 0xcd5920..0xcd5921
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 55
+    - ID: 49
       Name: main.testMapStringToInt
       OutOfLinePCRanges: [0xcd5940..0xcd5941]
       InlinePCRanges: []
       Variables:
         - Name: m
-          Type: 83 GoMapType map[string]int
+          Type: 99 GoMapType map[string]int
           Locations:
             - Range: 0xcd5940..0xcd5941
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 56
+    - ID: 50
       Name: main.testMapStringToSlice
       OutOfLinePCRanges: [0xcd5960..0xcd5961]
       InlinePCRanges: []
       Variables:
         - Name: m
-          Type: 94 GoMapType map[string][]string
+          Type: 110 GoMapType map[string][]string
           Locations:
             - Range: 0xcd5960..0xcd5961
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 57
+    - ID: 51
       Name: main.testMapArrayToArray
       OutOfLinePCRanges: [0xcd5980..0xcd5981]
       InlinePCRanges: []
       Variables:
         - Name: m
-          Type: 106 GoMapType map[[4]string][2]int
+          Type: 122 GoMapType map[[4]string][2]int
           Locations:
             - Range: 0xcd5980..0xcd5981
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 58
+    - ID: 52
       Name: main.testSmallMap
       OutOfLinePCRanges: [0xcd59a0..0xcd59a1]
       InlinePCRanges: []
       Variables:
         - Name: m
-          Type: 83 GoMapType map[string]int
+          Type: 99 GoMapType map[string]int
           Locations:
             - Range: 0xcd59a0..0xcd59a1
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 59
+    - ID: 53
       Name: main.testArrayOfMaps
       OutOfLinePCRanges: [0xcd59c0..0xcd59c1]
       InlinePCRanges: []
       Variables:
         - Name: m
-          Type: 118 ArrayType [2]map[string]int
+          Type: 134 ArrayType [2]map[string]int
           Locations:
             - Range: 0xcd59c0..0xcd59c1
               Pieces: [{Size: 16, Op: {CfaOffset: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 60
+    - ID: 54
       Name: main.testPointerToMap
       OutOfLinePCRanges: [0xcd59e0..0xcd59e1]
       InlinePCRanges: []
       Variables:
         - Name: m
-          Type: 119 PointerType *map[string]int
+          Type: 135 PointerType *map[string]int
           Locations:
             - Range: 0xcd59e0..0xcd59e1
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 61
+    - ID: 55
       Name: main.testMapIntToInt
       OutOfLinePCRanges: [0xcd5a00..0xcd5a01]
       InlinePCRanges: []
       Variables:
         - Name: m
-          Type: 59 GoMapType map[int]int
+          Type: 76 GoMapType map[int]int
           Locations:
             - Range: 0xcd5a00..0xcd5a01
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 62
+    - ID: 56
       Name: main.testMapMassive
       OutOfLinePCRanges: [0xcd5a20..0xcd5a21]
       InlinePCRanges: []
       Variables:
         - Name: redactMyEntries
-          Type: 120 GoMapType map[string][]main.structWithMap
+          Type: 136 GoMapType map[string][]main.structWithMap
           Locations:
             - Range: 0xcd5a20..0xcd5a21
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 63
+    - ID: 57
       Name: main.testMapEmbeddedMaps
       OutOfLinePCRanges: [0xcd5a40..0xcd5a41]
       InlinePCRanges: []
       Variables:
         - Name: m
-          Type: 120 GoMapType map[string][]main.structWithMap
+          Type: 136 GoMapType map[string][]main.structWithMap
           Locations:
             - Range: 0xcd5a40..0xcd5a41
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 64
+    - ID: 58
       Name: main.testMapWithLinkedList
       OutOfLinePCRanges: [0xcd5a60..0xcd5a61]
       InlinePCRanges: []
       Variables:
         - Name: m
-          Type: 133 GoMapType map[bool]main.node
+          Type: 149 GoMapType map[bool]main.node
           Locations:
             - Range: 0xcd5a60..0xcd5a61
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 65
+    - ID: 59
       Name: main.testMapWithSmallValue
       OutOfLinePCRanges: [0xcd5a80..0xcd5a81]
       InlinePCRanges: []
       Variables:
         - Name: m
-          Type: 146 GoMapType map[int]uint8
+          Type: 162 GoMapType map[int]uint8
           Locations:
             - Range: 0xcd5a80..0xcd5a81
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 66
+    - ID: 60
       Name: main.testMapWithSmallValueMassive
       OutOfLinePCRanges: [0xcd5aa0..0xcd5aa1]
       InlinePCRanges: []
       Variables:
         - Name: redactMyEntries
-          Type: 146 GoMapType map[int]uint8
+          Type: 162 GoMapType map[int]uint8
           Locations:
             - Range: 0xcd5aa0..0xcd5aa1
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 67
+    - ID: 61
       Name: main.testMapWithSmallKeyAndValue
       OutOfLinePCRanges: [0xcd5ac0..0xcd5ac1]
       InlinePCRanges: []
       Variables:
         - Name: m
-          Type: 157 GoMapType map[uint8]uint8
+          Type: 173 GoMapType map[uint8]uint8
           Locations:
             - Range: 0xcd5ac0..0xcd5ac1
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 68
+    - ID: 62
       Name: main.testMapWithSmallKeyAndValueMassive
       OutOfLinePCRanges: [0xcd5ae0..0xcd5ae1]
       InlinePCRanges: []
       Variables:
         - Name: m
-          Type: 157 GoMapType map[uint8]uint8
+          Type: 173 GoMapType map[uint8]uint8
           Locations:
             - Range: 0xcd5ae0..0xcd5ae1
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 69
+    - ID: 63
       Name: main.testMapSmallKeySmallValue
       OutOfLinePCRanges: [0xcd5b00..0xcd5b01]
       InlinePCRanges: []
       Variables:
         - Name: m
-          Type: 157 GoMapType map[uint8]uint8
+          Type: 173 GoMapType map[uint8]uint8
           Locations:
             - Range: 0xcd5b00..0xcd5b01
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 70
+    - ID: 64
       Name: main.testMapSmallKeyLargeValue
       OutOfLinePCRanges: [0xcd5b20..0xcd5b21]
       InlinePCRanges: []
       Variables:
         - Name: m
-          Type: 168 GoMapType map[uint8][4]int
+          Type: 184 GoMapType map[uint8][4]int
           Locations:
             - Range: 0xcd5b20..0xcd5b21
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 71
+    - ID: 65
       Name: main.testMapLargeKeySmallValue
       OutOfLinePCRanges: [0xcd5b40..0xcd5b41]
       InlinePCRanges: []
       Variables:
         - Name: m
-          Type: 180 GoMapType map[[4]int]uint8
+          Type: 196 GoMapType map[[4]int]uint8
           Locations:
             - Range: 0xcd5b40..0xcd5b41
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 72
+    - ID: 66
       Name: main.testMapLargeKeyLargeValue
       OutOfLinePCRanges: [0xcd5b60..0xcd5b61]
       InlinePCRanges: []
       Variables:
         - Name: m
-          Type: 191 GoMapType map[[4]int][4]int
+          Type: 207 GoMapType map[[4]int][4]int
           Locations:
             - Range: 0xcd5b60..0xcd5b61
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 73
+    - ID: 67
       Name: main.testCombinedByte
       OutOfLinePCRanges: [0xcd72a0..0xcd72a1]
       InlinePCRanges: []
       Variables:
         - Name: w
-          Type: 4 BaseType uint8
+          Type: 3 BaseType uint8
           Locations:
             - Range: 0xcd72a0..0xcd72a1
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
         - Name: x
-          Type: 4 BaseType uint8
+          Type: 3 BaseType uint8
           Locations:
             - Range: 0xcd72a0..0xcd72a1
               Pieces: [{Size: 1, Op: {RegNo: 3, Shift: 0}}]
           IsParameter: true
           IsReturn: false
         - Name: y
-          Type: 30 BaseType float32
+          Type: 17 BaseType float32
           Locations:
             - Range: 0xcd72a0..0xcd72a1
               Pieces: [{Size: 4, Op: {RegNo: 17, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 74
+    - ID: 68
       Name: main.testMultipleSimpleParams
       OutOfLinePCRanges: [0xcd7460..0xcd7461]
       InlinePCRanges: []
       Variables:
         - Name: a
-          Type: 11 BaseType bool
+          Type: 4 BaseType bool
           Locations:
             - Range: 0xcd7460..0xcd7461
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
         - Name: b
-          Type: 4 BaseType uint8
+          Type: 3 BaseType uint8
           Locations:
             - Range: 0xcd7460..0xcd7461
               Pieces: [{Size: 1, Op: {RegNo: 3, Shift: 0}}]
           IsParameter: true
           IsReturn: false
         - Name: c
-          Type: 6 BaseType int32
+          Type: 10 BaseType int32
           Locations:
             - Range: 0xcd7460..0xcd7461
               Pieces: [{Size: 4, Op: {RegNo: 2, Shift: 0}}]
           IsParameter: true
           IsReturn: false
         - Name: d
-          Type: 20 BaseType uint
+          Type: 16 BaseType uint
           Locations:
             - Range: 0xcd7460..0xcd7461
               Pieces: [{Size: 8, Op: {RegNo: 5, Shift: 0}}]
           IsParameter: true
           IsReturn: false
         - Name: e
-          Type: 8 GoStringHeaderType string
+          Type: 9 GoStringHeaderType string
           Locations:
             - Range: 0xcd7460..0xcd7461
               Pieces:
@@ -2480,37 +2480,37 @@ Subprograms:
                   Op: {RegNo: 8, Shift: 0}
           IsParameter: true
           IsReturn: false
-    - ID: 75
+    - ID: 69
       Name: main.testChannel
       OutOfLinePCRanges: [0xcd7680..0xcd7681]
       InlinePCRanges: []
       Variables:
         - Name: c
-          Type: 202 GoChannelType chan bool
+          Type: 218 GoChannelType chan bool
           Locations:
             - Range: 0xcd7680..0xcd7681
               Pieces: [{Size: 0, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 76
+    - ID: 70
       Name: main.testPointerToSimpleStruct
       OutOfLinePCRanges: [0xcd7840..0xcd7841]
       InlinePCRanges: []
       Variables:
         - Name: a
-          Type: 203 PointerType *main.structWithTwoValues
+          Type: 219 PointerType *main.structWithTwoValues
           Locations:
             - Range: 0xcd7840..0xcd7841
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 77
+    - ID: 71
       Name: main.testLinkedList
       OutOfLinePCRanges: [0xcd7860..0xcd7861]
       InlinePCRanges: []
       Variables:
         - Name: a
-          Type: 144 StructureType main.node
+          Type: 160 StructureType main.node
           Locations:
             - Range: 0xcd7860..0xcd7861
               Pieces:
@@ -2520,92 +2520,92 @@ Subprograms:
                   Op: {RegNo: 3, Shift: 0}
           IsParameter: true
           IsReturn: false
-    - ID: 78
+    - ID: 72
       Name: main.testPointerLoop
       OutOfLinePCRanges: [0xcd7880..0xcd7881]
       InlinePCRanges: []
       Variables:
         - Name: a
-          Type: 145 PointerType *main.node
+          Type: 161 PointerType *main.node
           Locations:
             - Range: 0xcd7880..0xcd7881
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 79
+    - ID: 73
       Name: main.testUnsafePointer
       OutOfLinePCRanges: [0xcd78a0..0xcd78a1]
       InlinePCRanges: []
       Variables:
         - Name: x
-          Type: 38 VoidPointerType unsafe.Pointer
+          Type: 14 VoidPointerType unsafe.Pointer
           Locations:
             - Range: 0xcd78a0..0xcd78a1
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 80
+    - ID: 74
       Name: main.testUintPointer
       OutOfLinePCRanges: [0xcd78e0..0xcd78e1]
       InlinePCRanges: []
       Variables:
         - Name: x
-          Type: 205 PointerType *uint
+          Type: 34 PointerType *uint
           Locations:
             - Range: 0xcd78e0..0xcd78e1
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 81
+    - ID: 75
       Name: main.testStringPointer
       OutOfLinePCRanges: [0xcd79c0..0xcd79c1]
       InlinePCRanges: []
       Variables:
         - Name: z
-          Type: 36 PointerType *string
+          Type: 22 PointerType *string
           Locations:
             - Range: 0xcd79c0..0xcd79c1
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 82
+    - ID: 76
       Name: main.testNilPointer
       OutOfLinePCRanges: [0xcd7a00..0xcd7a01]
       InlinePCRanges: []
       Variables:
         - Name: z
-          Type: 206 PointerType *bool
+          Type: 11 PointerType *bool
           Locations:
             - Range: 0xcd7a00..0xcd7a01
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
         - Name: a
-          Type: 20 BaseType uint
+          Type: 16 BaseType uint
           Locations:
             - Range: 0xcd7a00..0xcd7a01
               Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 83
+    - ID: 77
       Name: main.testCycle
       OutOfLinePCRanges: [0xcd7a40..0xcd7a41]
       InlinePCRanges: []
       Variables:
         - Name: t
-          Type: 207 PointerType *main.t
+          Type: 221 PointerType *main.t
           Locations:
             - Range: 0xcd7a40..0xcd7a41
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 84
+    - ID: 78
       Name: main.testUintSlice
       OutOfLinePCRanges: [0xcd7f60..0xcd7f61]
       InlinePCRanges: []
       Variables:
         - Name: u
-          Type: 210 GoSliceHeaderType []uint
+          Type: 224 GoSliceHeaderType []uint
           Locations:
             - Range: 0xcd7f60..0xcd7f61
               Pieces:
@@ -2617,13 +2617,13 @@ Subprograms:
                   Op: {RegNo: 2, Shift: 0}
           IsParameter: true
           IsReturn: false
-    - ID: 85
+    - ID: 79
       Name: main.testEmptySlice
       OutOfLinePCRanges: [0xcd7f80..0xcd7f81]
       InlinePCRanges: []
       Variables:
         - Name: u
-          Type: 210 GoSliceHeaderType []uint
+          Type: 224 GoSliceHeaderType []uint
           Locations:
             - Range: 0xcd7f80..0xcd7f81
               Pieces:
@@ -2635,13 +2635,13 @@ Subprograms:
                   Op: {RegNo: 2, Shift: 0}
           IsParameter: true
           IsReturn: false
-    - ID: 86
+    - ID: 80
       Name: main.testSliceOfSlices
       OutOfLinePCRanges: [0xcd7fa0..0xcd7fa1]
       InlinePCRanges: []
       Variables:
         - Name: u
-          Type: 211 GoSliceHeaderType [][]uint
+          Type: 225 GoSliceHeaderType [][]uint
           Locations:
             - Range: 0xcd7fa0..0xcd7fa1
               Pieces:
@@ -2653,13 +2653,13 @@ Subprograms:
                   Op: {RegNo: 2, Shift: 0}
           IsParameter: true
           IsReturn: false
-    - ID: 87
+    - ID: 81
       Name: main.testStructSlice
       OutOfLinePCRanges: [0xcd7fc0..0xcd7fc1]
       InlinePCRanges: []
       Variables:
         - Name: xs
-          Type: 213 GoSliceHeaderType []main.structWithNoStrings
+          Type: 227 GoSliceHeaderType []main.structWithNoStrings
           Locations:
             - Range: 0xcd7fc0..0xcd7fc1
               Pieces:
@@ -2672,19 +2672,19 @@ Subprograms:
           IsParameter: true
           IsReturn: false
         - Name: a
-          Type: 1 BaseType int
+          Type: 7 BaseType int
           Locations:
             - Range: 0xcd7fc0..0xcd7fc1
               Pieces: [{Size: 8, Op: {RegNo: 5, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 88
+    - ID: 82
       Name: main.testEmptySliceOfStructs
       OutOfLinePCRanges: [0xcd7fe0..0xcd7fe1]
       InlinePCRanges: []
       Variables:
         - Name: xs
-          Type: 213 GoSliceHeaderType []main.structWithNoStrings
+          Type: 227 GoSliceHeaderType []main.structWithNoStrings
           Locations:
             - Range: 0xcd7fe0..0xcd7fe1
               Pieces:
@@ -2697,19 +2697,19 @@ Subprograms:
           IsParameter: true
           IsReturn: false
         - Name: a
-          Type: 1 BaseType int
+          Type: 7 BaseType int
           Locations:
             - Range: 0xcd7fe0..0xcd7fe1
               Pieces: [{Size: 8, Op: {RegNo: 5, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 89
+    - ID: 83
       Name: main.testNilSliceOfStructs
       OutOfLinePCRanges: [0xcd8000..0xcd8001]
       InlinePCRanges: []
       Variables:
         - Name: xs
-          Type: 213 GoSliceHeaderType []main.structWithNoStrings
+          Type: 227 GoSliceHeaderType []main.structWithNoStrings
           Locations:
             - Range: 0xcd8000..0xcd8001
               Pieces:
@@ -2722,19 +2722,19 @@ Subprograms:
           IsParameter: true
           IsReturn: false
         - Name: a
-          Type: 1 BaseType int
+          Type: 7 BaseType int
           Locations:
             - Range: 0xcd8000..0xcd8001
               Pieces: [{Size: 8, Op: {RegNo: 5, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 90
+    - ID: 84
       Name: main.testStringSlice
       OutOfLinePCRanges: [0xcd8020..0xcd8021]
       InlinePCRanges: []
       Variables:
         - Name: s
-          Type: 105 GoSliceHeaderType []string
+          Type: 121 GoSliceHeaderType []string
           Locations:
             - Range: 0xcd8020..0xcd8021
               Pieces:
@@ -2746,20 +2746,20 @@ Subprograms:
                   Op: {RegNo: 2, Shift: 0}
           IsParameter: true
           IsReturn: false
-    - ID: 91
+    - ID: 85
       Name: main.testNilSliceWithOtherParams
       OutOfLinePCRanges: [0xcd8040..0xcd8041]
       InlinePCRanges: []
       Variables:
         - Name: a
-          Type: 14 BaseType int8
+          Type: 15 BaseType int8
           Locations:
             - Range: 0xcd8040..0xcd8041
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
         - Name: s
-          Type: 216 GoSliceHeaderType []bool
+          Type: 230 GoSliceHeaderType []bool
           Locations:
             - Range: 0xcd8040..0xcd8041
               Pieces:
@@ -2772,19 +2772,19 @@ Subprograms:
           IsParameter: true
           IsReturn: false
         - Name: x
-          Type: 20 BaseType uint
+          Type: 16 BaseType uint
           Locations:
             - Range: 0xcd8040..0xcd8041
               Pieces: [{Size: 8, Op: {RegNo: 4, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 92
+    - ID: 86
       Name: main.testNilSlice
       OutOfLinePCRanges: [0xcd8060..0xcd8061]
       InlinePCRanges: []
       Variables:
         - Name: xs
-          Type: 217 GoSliceHeaderType []uint16
+          Type: 231 GoSliceHeaderType []uint16
           Locations:
             - Range: 0xcd8060..0xcd8061
               Pieces:
@@ -2796,13 +2796,13 @@ Subprograms:
                   Op: {RegNo: 2, Shift: 0}
           IsParameter: true
           IsReturn: false
-    - ID: 93
+    - ID: 87
       Name: main.testVeryLargeSlice
       OutOfLinePCRanges: [0xcd8080..0xcd8081]
       InlinePCRanges: []
       Variables:
         - Name: xs
-          Type: 210 GoSliceHeaderType []uint
+          Type: 224 GoSliceHeaderType []uint
           Locations:
             - Range: 0xcd8080..0xcd8081
               Pieces:
@@ -2814,23 +2814,23 @@ Subprograms:
                   Op: {RegNo: 2, Shift: 0}
           IsParameter: true
           IsReturn: false
-    - ID: 94
+    - ID: 88
       Name: main.stackC
       OutOfLinePCRanges: [0xcd83c0..0xcd8412]
       InlinePCRanges: []
       Variables:
         - Name: ~r0
-          Type: 8 GoStringHeaderType string
+          Type: 9 GoStringHeaderType string
           Locations: [{Range: 0xcd83c0..0xcd8412, Pieces: []}]
           IsParameter: true
           IsReturn: true
-    - ID: 95
+    - ID: 89
       Name: main.testSingleString
       OutOfLinePCRanges: [0xcd8420..0xcd8421]
       InlinePCRanges: []
       Variables:
         - Name: x
-          Type: 8 GoStringHeaderType string
+          Type: 9 GoStringHeaderType string
           Locations:
             - Range: 0xcd8420..0xcd8421
               Pieces:
@@ -2840,13 +2840,13 @@ Subprograms:
                   Op: {RegNo: 3, Shift: 0}
           IsParameter: true
           IsReturn: false
-    - ID: 96
+    - ID: 90
       Name: main.testThreeStrings
       OutOfLinePCRanges: [0xcd8440..0xcd8441]
       InlinePCRanges: []
       Variables:
         - Name: x
-          Type: 8 GoStringHeaderType string
+          Type: 9 GoStringHeaderType string
           Locations:
             - Range: 0xcd8440..0xcd8441
               Pieces:
@@ -2857,7 +2857,7 @@ Subprograms:
           IsParameter: true
           IsReturn: false
         - Name: y
-          Type: 8 GoStringHeaderType string
+          Type: 9 GoStringHeaderType string
           Locations:
             - Range: 0xcd8440..0xcd8441
               Pieces:
@@ -2868,7 +2868,7 @@ Subprograms:
           IsParameter: true
           IsReturn: false
         - Name: z
-          Type: 8 GoStringHeaderType string
+          Type: 9 GoStringHeaderType string
           Locations:
             - Range: 0xcd8440..0xcd8441
               Pieces:
@@ -2878,13 +2878,13 @@ Subprograms:
                   Op: {RegNo: 8, Shift: 0}
           IsParameter: true
           IsReturn: false
-    - ID: 97
+    - ID: 91
       Name: main.testThreeStringsInStruct
       OutOfLinePCRanges: [0xcd8460..0xcd847f]
       InlinePCRanges: []
       Variables:
         - Name: a
-          Type: 219 StructureType main.threeStringStruct
+          Type: 232 StructureType main.threeStringStruct
           Locations:
             - Range: 0xcd8460..0xcd847f
               Pieces:
@@ -2902,37 +2902,37 @@ Subprograms:
                   Op: {RegNo: 8, Shift: 0}
           IsParameter: true
           IsReturn: false
-    - ID: 98
+    - ID: 92
       Name: main.testThreeStringsInStructPointer
       OutOfLinePCRanges: [0xcd8480..0xcd8481]
       InlinePCRanges: []
       Variables:
         - Name: a
-          Type: 220 PointerType *main.threeStringStruct
+          Type: 233 PointerType *main.threeStringStruct
           Locations:
             - Range: 0xcd8480..0xcd8481
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 99
+    - ID: 93
       Name: main.testOneStringInStructPointer
       OutOfLinePCRanges: [0xcd84a0..0xcd84a1]
       InlinePCRanges: []
       Variables:
         - Name: a
-          Type: 221 PointerType *main.oneStringStruct
+          Type: 234 PointerType *main.oneStringStruct
           Locations:
             - Range: 0xcd84a0..0xcd84a1
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 100
+    - ID: 94
       Name: main.testMassiveString
       OutOfLinePCRanges: [0xcd84c0..0xcd84c1]
       InlinePCRanges: []
       Variables:
         - Name: x
-          Type: 8 GoStringHeaderType string
+          Type: 9 GoStringHeaderType string
           Locations:
             - Range: 0xcd84c0..0xcd84c1
               Pieces:
@@ -2942,13 +2942,13 @@ Subprograms:
                   Op: {RegNo: 3, Shift: 0}
           IsParameter: true
           IsReturn: false
-    - ID: 101
+    - ID: 95
       Name: main.testUnitializedString
       OutOfLinePCRanges: [0xcd84e0..0xcd84e1]
       InlinePCRanges: []
       Variables:
         - Name: x
-          Type: 8 GoStringHeaderType string
+          Type: 9 GoStringHeaderType string
           Locations:
             - Range: 0xcd84e0..0xcd84e1
               Pieces:
@@ -2958,13 +2958,13 @@ Subprograms:
                   Op: {RegNo: 3, Shift: 0}
           IsParameter: true
           IsReturn: false
-    - ID: 102
+    - ID: 96
       Name: main.testEmptyString
       OutOfLinePCRanges: [0xcd8500..0xcd8501]
       InlinePCRanges: []
       Variables:
         - Name: x
-          Type: 8 GoStringHeaderType string
+          Type: 9 GoStringHeaderType string
           Locations:
             - Range: 0xcd8500..0xcd8501
               Pieces:
@@ -2974,13 +2974,13 @@ Subprograms:
                   Op: {RegNo: 3, Shift: 0}
           IsParameter: true
           IsReturn: false
-    - ID: 103
+    - ID: 97
       Name: main.testStruct
       OutOfLinePCRanges: [0xcd8780..0xcd87a3]
       InlinePCRanges: []
       Variables:
         - Name: x
-          Type: 223 StructureType main.aStruct
+          Type: 236 StructureType main.aStruct
           Locations:
             - Range: 0xcd8780..0xcd87a3
               Pieces:
@@ -3000,17 +3000,17 @@ Subprograms:
                   Op: {RegNo: 9, Shift: 0}
           IsParameter: true
           IsReturn: false
-    - ID: 104
+    - ID: 98
       Name: main.testEmptyStruct
       OutOfLinePCRanges: [0xcd8900..0xcd8901]
       InlinePCRanges: []
       Variables:
         - Name: e
-          Type: 224 StructureType main.emptyStruct
+          Type: 237 StructureType main.emptyStruct
           Locations: [{Range: 0xcd8900..0xcd8901, Pieces: []}]
           IsParameter: true
           IsReturn: false
-    - ID: 1
+    - ID: 99
       Name: main.testInlinedPrint
       OutOfLinePCRanges: [0xcd4c00..0xcd4c62]
       InlinePCRanges:
@@ -3024,7 +3024,7 @@ Subprograms:
           RootRanges: [0xcd4f20..0xcd4f82]
       Variables:
         - Name: x
-          Type: 1 BaseType int
+          Type: 7 BaseType int
           Locations:
             - Range: 0xcd4c00..0xcd4c19
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
@@ -3040,28 +3040,28 @@ Subprograms:
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 2
+    - ID: 100
       Name: main.testInlinedBBB
       OutOfLinePCRanges: []
       InlinePCRanges:
         - Ranges: [0xcd4ea6..0xcd4ede]
           RootRanges: [0xcd4e40..0xcd4f05]
       Variables: []
-    - ID: 3
+    - ID: 101
       Name: main.testInlinedBCA
       OutOfLinePCRanges: []
       InlinePCRanges:
         - Ranges: [0xcd4fb3..0xcd4ff1]
           RootRanges: [0xcd4fa0..0xcd50ae]
       Variables: []
-    - ID: 4
+    - ID: 102
       Name: main.testInlinedBCB
       OutOfLinePCRanges: []
       InlinePCRanges:
         - Ranges: [0xcd5066..0xcd509e]
           RootRanges: [0xcd4fa0..0xcd50ae]
       Variables: []
-    - ID: 5
+    - ID: 103
       Name: main.testInlinedSq
       OutOfLinePCRanges: []
       InlinePCRanges:
@@ -3069,13 +3069,13 @@ Subprograms:
           RootRanges: [0xcd50c0..0xcd50c6]
       Variables:
         - Name: x
-          Type: 1 BaseType int
+          Type: 7 BaseType int
           Locations:
             - Range: 0xcd50c0..0xcd50c5
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 6
+    - ID: 104
       Name: main.testInlinedSumArray
       OutOfLinePCRanges: []
       InlinePCRanges:
@@ -3085,7 +3085,7 @@ Subprograms:
           RootRanges: [0xcd5140..0xcd52c5]
       Variables:
         - Name: a
-          Type: 2 ArrayType [5]int
+          Type: 73 ArrayType [5]int
           Locations:
             - Range: 0xcd50ed..0xcd5123
               Pieces: [{Size: 40, Op: {CfaOffset: -56}}]
@@ -3095,77 +3095,77 @@ Subprograms:
           IsReturn: false
 Types:
     - __kind: PointerType
-      ID: 209
+      ID: 223
       Name: '**main.t'
       ByteSize: 8
-      Pointee: 207 PointerType *main.t
+      Pointee: 221 PointerType *main.t
     - __kind: PointerType
-      ID: 35
+      ID: 54
       Name: '**string'
       ByteSize: 8
       GoRuntimeType: 521056
       GoKind: 22
-      Pointee: 36 PointerType *string
+      Pointee: 22 PointerType *string
     - __kind: PointerType
-      ID: 194
+      ID: 210
       Name: '**table<[4]int,[4]int>'
       ByteSize: 8
-      Pointee: 195 PointerType *table<[4]int,[4]int>
+      Pointee: 211 PointerType *table<[4]int,[4]int>
     - __kind: PointerType
-      ID: 183
+      ID: 199
       Name: '**table<[4]int,uint8>'
       ByteSize: 8
-      Pointee: 184 PointerType *table<[4]int,uint8>
+      Pointee: 200 PointerType *table<[4]int,uint8>
     - __kind: PointerType
-      ID: 109
+      ID: 125
       Name: '**table<[4]string,[2]int>'
       ByteSize: 8
-      Pointee: 110 PointerType *table<[4]string,[2]int>
+      Pointee: 126 PointerType *table<[4]string,[2]int>
     - __kind: PointerType
-      ID: 136
+      ID: 152
       Name: '**table<bool,main.node>'
       ByteSize: 8
-      Pointee: 137 PointerType *table<bool,main.node>
+      Pointee: 153 PointerType *table<bool,main.node>
     - __kind: PointerType
-      ID: 63
+      ID: 79
       Name: '**table<int,int>'
       ByteSize: 8
-      Pointee: 64 PointerType *table<int,int>
+      Pointee: 80 PointerType *table<int,int>
     - __kind: PointerType
-      ID: 149
+      ID: 165
       Name: '**table<int,uint8>'
       ByteSize: 8
-      Pointee: 150 PointerType *table<int,uint8>
+      Pointee: 166 PointerType *table<int,uint8>
     - __kind: PointerType
-      ID: 123
+      ID: 139
       Name: '**table<string,[]main.structWithMap>'
       ByteSize: 8
-      Pointee: 124 PointerType *table<string,[]main.structWithMap>
+      Pointee: 140 PointerType *table<string,[]main.structWithMap>
     - __kind: PointerType
-      ID: 97
+      ID: 113
       Name: '**table<string,[]string>'
       ByteSize: 8
-      Pointee: 98 PointerType *table<string,[]string>
+      Pointee: 114 PointerType *table<string,[]string>
     - __kind: PointerType
-      ID: 86
+      ID: 102
       Name: '**table<string,int>'
       ByteSize: 8
-      Pointee: 87 PointerType *table<string,int>
+      Pointee: 103 PointerType *table<string,int>
     - __kind: PointerType
-      ID: 74
+      ID: 90
       Name: '**table<string,main.nestedStruct>'
       ByteSize: 8
-      Pointee: 75 PointerType *table<string,main.nestedStruct>
+      Pointee: 91 PointerType *table<string,main.nestedStruct>
     - __kind: PointerType
-      ID: 171
+      ID: 187
       Name: '**table<uint8,[4]int>'
       ByteSize: 8
-      Pointee: 172 PointerType *table<uint8,[4]int>
+      Pointee: 188 PointerType *table<uint8,[4]int>
     - __kind: PointerType
-      ID: 160
+      ID: 176
       Name: '**table<uint8,uint8>'
       ByteSize: 8
-      Pointee: 161 PointerType *table<uint8,uint8>
+      Pointee: 177 PointerType *table<uint8,uint8>
     - __kind: PointerType
       ID: 241
       Name: '*[]*string.array'
@@ -3197,10 +3197,10 @@ Types:
       ByteSize: 8
       Pointee: 250 GoSliceDataType []string.array
     - __kind: PointerType
-      ID: 212
+      ID: 226
       Name: '*[]uint'
       ByteSize: 8
-      Pointee: 210 GoSliceHeaderType []uint
+      Pointee: 224 GoSliceHeaderType []uint
     - __kind: PointerType
       ID: 273
       Name: '*[]uint.array'
@@ -3212,363 +3212,363 @@ Types:
       ByteSize: 8
       Pointee: 280 GoSliceDataType []uint16.array
     - __kind: PointerType
-      ID: 206
+      ID: 11
       Name: '*bool'
       ByteSize: 8
       GoRuntimeType: 386240
       GoKind: 22
-      Pointee: 11 BaseType bool
+      Pointee: 4 BaseType bool
     - __kind: PointerType
-      ID: 236
+      ID: 33
       Name: '*error'
       ByteSize: 8
       GoRuntimeType: 385152
       GoKind: 22
-      Pointee: 57 GoInterfaceType error
+      Pointee: 13 GoInterfaceType error
     - __kind: PointerType
-      ID: 237
+      ID: 35
       Name: '*float32'
       ByteSize: 8
       GoRuntimeType: 386112
       GoKind: 22
-      Pointee: 30 BaseType float32
+      Pointee: 17 BaseType float32
     - __kind: PointerType
-      ID: 230
+      ID: 25
       Name: '*float64'
       ByteSize: 8
       GoRuntimeType: 386176
       GoKind: 22
-      Pointee: 31 BaseType float64
+      Pointee: 18 BaseType float64
     - __kind: PointerType
-      ID: 232
+      ID: 27
       Name: '*int'
       ByteSize: 8
       GoRuntimeType: 385792
       GoKind: 22
-      Pointee: 1 BaseType int
+      Pointee: 7 BaseType int
     - __kind: PointerType
-      ID: 234
+      ID: 30
       Name: '*int16'
       ByteSize: 8
       GoRuntimeType: 385408
       GoKind: 22
-      Pointee: 16 BaseType int16
+      Pointee: 31 BaseType int16
     - __kind: PointerType
-      ID: 226
+      ID: 20
       Name: '*int32'
       ByteSize: 8
       GoRuntimeType: 385536
       GoKind: 22
-      Pointee: 6 BaseType int32
+      Pointee: 10 BaseType int32
     - __kind: PointerType
-      ID: 231
+      ID: 26
       Name: '*int64'
       ByteSize: 8
       GoRuntimeType: 385664
       GoKind: 22
-      Pointee: 18 BaseType int64
+      Pointee: 12 BaseType int64
     - __kind: PointerType
-      ID: 235
+      ID: 32
       Name: '*int8'
       ByteSize: 8
       GoRuntimeType: 385280
       GoKind: 22
-      Pointee: 14 BaseType int8
+      Pointee: 15 BaseType int8
     - __kind: PointerType
-      ID: 44
+      ID: 61
       Name: '*main.esotericHeap'
       ByteSize: 8
       GoRuntimeType: 380224
       GoKind: 22
-      Pointee: 45 StructureType main.esotericHeap
+      Pointee: 62 StructureType main.esotericHeap
     - __kind: PointerType
-      ID: 145
+      ID: 161
       Name: '*main.node'
       ByteSize: 8
       GoRuntimeType: 380288
       GoKind: 22
-      Pointee: 144 StructureType main.node
+      Pointee: 160 StructureType main.node
     - __kind: PointerType
-      ID: 221
+      ID: 234
       Name: '*main.oneStringStruct'
       ByteSize: 8
       GoKind: 22
-      Pointee: 222 StructureType main.oneStringStruct
+      Pointee: 235 StructureType main.oneStringStruct
     - __kind: PointerType
-      ID: 132
+      ID: 148
       Name: '*main.structWithMap'
       ByteSize: 8
       GoRuntimeType: 380160
       GoKind: 22
-      Pointee: 58 StructureType main.structWithMap
+      Pointee: 75 StructureType main.structWithMap
     - __kind: PointerType
-      ID: 214
+      ID: 228
       Name: '*main.structWithNoStrings'
       ByteSize: 8
-      Pointee: 215 StructureType main.structWithNoStrings
+      Pointee: 229 StructureType main.structWithNoStrings
     - __kind: PointerType
-      ID: 203
+      ID: 219
       Name: '*main.structWithTwoValues'
       ByteSize: 8
       GoKind: 22
-      Pointee: 204 StructureType main.structWithTwoValues
+      Pointee: 220 StructureType main.structWithTwoValues
     - __kind: PointerType
-      ID: 207
+      ID: 221
       Name: '*main.t'
       ByteSize: 8
       GoKind: 22
-      Pointee: 208 GoSliceHeaderType main.t
+      Pointee: 222 GoSliceHeaderType main.t
     - __kind: PointerType
       ID: 271
       Name: '*main.t.array'
       ByteSize: 8
       Pointee: 270 GoSliceDataType main.t.array
     - __kind: PointerType
-      ID: 220
+      ID: 233
       Name: '*main.threeStringStruct'
       ByteSize: 8
       GoKind: 22
-      Pointee: 219 StructureType main.threeStringStruct
+      Pointee: 232 StructureType main.threeStringStruct
     - __kind: PointerType
-      ID: 192
+      ID: 208
       Name: '*map<[4]int,[4]int>'
       ByteSize: 8
-      Pointee: 193 GoSwissMapHeaderType map<[4]int,[4]int>
+      Pointee: 209 GoSwissMapHeaderType map<[4]int,[4]int>
     - __kind: PointerType
-      ID: 181
+      ID: 197
       Name: '*map<[4]int,uint8>'
       ByteSize: 8
-      Pointee: 182 GoSwissMapHeaderType map<[4]int,uint8>
+      Pointee: 198 GoSwissMapHeaderType map<[4]int,uint8>
     - __kind: PointerType
-      ID: 107
+      ID: 123
       Name: '*map<[4]string,[2]int>'
       ByteSize: 8
-      Pointee: 108 GoSwissMapHeaderType map<[4]string,[2]int>
+      Pointee: 124 GoSwissMapHeaderType map<[4]string,[2]int>
     - __kind: PointerType
-      ID: 134
+      ID: 150
       Name: '*map<bool,main.node>'
       ByteSize: 8
-      Pointee: 135 GoSwissMapHeaderType map<bool,main.node>
+      Pointee: 151 GoSwissMapHeaderType map<bool,main.node>
     - __kind: PointerType
-      ID: 60
+      ID: 77
       Name: '*map<int,int>'
       ByteSize: 8
-      Pointee: 61 GoSwissMapHeaderType map<int,int>
+      Pointee: 78 GoSwissMapHeaderType map<int,int>
     - __kind: PointerType
-      ID: 147
+      ID: 163
       Name: '*map<int,uint8>'
       ByteSize: 8
-      Pointee: 148 GoSwissMapHeaderType map<int,uint8>
+      Pointee: 164 GoSwissMapHeaderType map<int,uint8>
     - __kind: PointerType
-      ID: 121
+      ID: 137
       Name: '*map<string,[]main.structWithMap>'
       ByteSize: 8
-      Pointee: 122 GoSwissMapHeaderType map<string,[]main.structWithMap>
+      Pointee: 138 GoSwissMapHeaderType map<string,[]main.structWithMap>
     - __kind: PointerType
-      ID: 95
+      ID: 111
       Name: '*map<string,[]string>'
       ByteSize: 8
-      Pointee: 96 GoSwissMapHeaderType map<string,[]string>
+      Pointee: 112 GoSwissMapHeaderType map<string,[]string>
     - __kind: PointerType
-      ID: 84
+      ID: 100
       Name: '*map<string,int>'
       ByteSize: 8
-      Pointee: 85 GoSwissMapHeaderType map<string,int>
+      Pointee: 101 GoSwissMapHeaderType map<string,int>
     - __kind: PointerType
-      ID: 72
+      ID: 88
       Name: '*map<string,main.nestedStruct>'
       ByteSize: 8
-      Pointee: 73 GoSwissMapHeaderType map<string,main.nestedStruct>
+      Pointee: 89 GoSwissMapHeaderType map<string,main.nestedStruct>
     - __kind: PointerType
-      ID: 169
+      ID: 185
       Name: '*map<uint8,[4]int>'
       ByteSize: 8
-      Pointee: 170 GoSwissMapHeaderType map<uint8,[4]int>
+      Pointee: 186 GoSwissMapHeaderType map<uint8,[4]int>
     - __kind: PointerType
-      ID: 158
+      ID: 174
       Name: '*map<uint8,uint8>'
       ByteSize: 8
-      Pointee: 159 GoSwissMapHeaderType map<uint8,uint8>
+      Pointee: 175 GoSwissMapHeaderType map<uint8,uint8>
     - __kind: PointerType
-      ID: 119
+      ID: 135
       Name: '*map[string]int'
       ByteSize: 8
       GoKind: 22
-      Pointee: 83 GoMapType map[string]int
+      Pointee: 99 GoMapType map[string]int
     - __kind: PointerType
-      ID: 198
+      ID: 214
       Name: '*noalg.map.group[[4]int][4]int'
       ByteSize: 8
-      Pointee: 199 StructureType noalg.map.group[[4]int][4]int
+      Pointee: 215 StructureType noalg.map.group[[4]int][4]int
     - __kind: PointerType
-      ID: 187
+      ID: 203
       Name: '*noalg.map.group[[4]int]uint8'
       ByteSize: 8
-      Pointee: 188 StructureType noalg.map.group[[4]int]uint8
+      Pointee: 204 StructureType noalg.map.group[[4]int]uint8
     - __kind: PointerType
-      ID: 113
+      ID: 129
       Name: '*noalg.map.group[[4]string][2]int'
       ByteSize: 8
-      Pointee: 114 StructureType noalg.map.group[[4]string][2]int
+      Pointee: 130 StructureType noalg.map.group[[4]string][2]int
     - __kind: PointerType
-      ID: 140
+      ID: 156
       Name: '*noalg.map.group[bool]main.node'
       ByteSize: 8
-      Pointee: 141 StructureType noalg.map.group[bool]main.node
+      Pointee: 157 StructureType noalg.map.group[bool]main.node
     - __kind: PointerType
-      ID: 67
+      ID: 83
       Name: '*noalg.map.group[int]int'
       ByteSize: 8
-      Pointee: 68 StructureType noalg.map.group[int]int
+      Pointee: 84 StructureType noalg.map.group[int]int
     - __kind: PointerType
-      ID: 153
+      ID: 169
       Name: '*noalg.map.group[int]uint8'
       ByteSize: 8
-      Pointee: 154 StructureType noalg.map.group[int]uint8
+      Pointee: 170 StructureType noalg.map.group[int]uint8
     - __kind: PointerType
-      ID: 127
+      ID: 143
       Name: '*noalg.map.group[string][]main.structWithMap'
       ByteSize: 8
-      Pointee: 128 StructureType noalg.map.group[string][]main.structWithMap
+      Pointee: 144 StructureType noalg.map.group[string][]main.structWithMap
     - __kind: PointerType
-      ID: 101
+      ID: 117
       Name: '*noalg.map.group[string][]string'
       ByteSize: 8
-      Pointee: 102 StructureType noalg.map.group[string][]string
+      Pointee: 118 StructureType noalg.map.group[string][]string
     - __kind: PointerType
-      ID: 90
+      ID: 106
       Name: '*noalg.map.group[string]int'
       ByteSize: 8
-      Pointee: 91 StructureType noalg.map.group[string]int
+      Pointee: 107 StructureType noalg.map.group[string]int
     - __kind: PointerType
-      ID: 78
+      ID: 94
       Name: '*noalg.map.group[string]main.nestedStruct'
       ByteSize: 8
-      Pointee: 79 StructureType noalg.map.group[string]main.nestedStruct
+      Pointee: 95 StructureType noalg.map.group[string]main.nestedStruct
     - __kind: PointerType
-      ID: 175
+      ID: 191
       Name: '*noalg.map.group[uint8][4]int'
       ByteSize: 8
-      Pointee: 176 StructureType noalg.map.group[uint8][4]int
+      Pointee: 192 StructureType noalg.map.group[uint8][4]int
     - __kind: PointerType
-      ID: 164
+      ID: 180
       Name: '*noalg.map.group[uint8]uint8'
       ByteSize: 8
-      Pointee: 165 StructureType noalg.map.group[uint8]uint8
+      Pointee: 181 StructureType noalg.map.group[uint8]uint8
     - __kind: PointerType
-      ID: 36
+      ID: 22
       Name: '*string'
       ByteSize: 8
       GoRuntimeType: 385216
       GoKind: 22
-      Pointee: 8 GoStringHeaderType string
+      Pointee: 9 GoStringHeaderType string
     - __kind: PointerType
       ID: 239
       Name: '*string.str'
       ByteSize: 8
       Pointee: 238 GoStringDataType string.str
     - __kind: PointerType
-      ID: 195
+      ID: 211
       Name: '*table<[4]int,[4]int>'
       ByteSize: 8
-      Pointee: 196 StructureType table<[4]int,[4]int>
+      Pointee: 212 StructureType table<[4]int,[4]int>
     - __kind: PointerType
-      ID: 184
+      ID: 200
       Name: '*table<[4]int,uint8>'
       ByteSize: 8
-      Pointee: 185 StructureType table<[4]int,uint8>
+      Pointee: 201 StructureType table<[4]int,uint8>
     - __kind: PointerType
-      ID: 110
+      ID: 126
       Name: '*table<[4]string,[2]int>'
       ByteSize: 8
-      Pointee: 111 StructureType table<[4]string,[2]int>
+      Pointee: 127 StructureType table<[4]string,[2]int>
     - __kind: PointerType
-      ID: 137
+      ID: 153
       Name: '*table<bool,main.node>'
       ByteSize: 8
-      Pointee: 138 StructureType table<bool,main.node>
+      Pointee: 154 StructureType table<bool,main.node>
     - __kind: PointerType
-      ID: 64
+      ID: 80
       Name: '*table<int,int>'
       ByteSize: 8
-      Pointee: 65 StructureType table<int,int>
+      Pointee: 81 StructureType table<int,int>
     - __kind: PointerType
-      ID: 150
+      ID: 166
       Name: '*table<int,uint8>'
       ByteSize: 8
-      Pointee: 151 StructureType table<int,uint8>
+      Pointee: 167 StructureType table<int,uint8>
     - __kind: PointerType
-      ID: 124
+      ID: 140
       Name: '*table<string,[]main.structWithMap>'
       ByteSize: 8
-      Pointee: 125 StructureType table<string,[]main.structWithMap>
+      Pointee: 141 StructureType table<string,[]main.structWithMap>
     - __kind: PointerType
-      ID: 98
+      ID: 114
       Name: '*table<string,[]string>'
       ByteSize: 8
-      Pointee: 99 StructureType table<string,[]string>
+      Pointee: 115 StructureType table<string,[]string>
     - __kind: PointerType
-      ID: 87
+      ID: 103
       Name: '*table<string,int>'
       ByteSize: 8
-      Pointee: 88 StructureType table<string,int>
+      Pointee: 104 StructureType table<string,int>
     - __kind: PointerType
-      ID: 75
+      ID: 91
       Name: '*table<string,main.nestedStruct>'
       ByteSize: 8
-      Pointee: 76 StructureType table<string,main.nestedStruct>
+      Pointee: 92 StructureType table<string,main.nestedStruct>
     - __kind: PointerType
-      ID: 172
+      ID: 188
       Name: '*table<uint8,[4]int>'
       ByteSize: 8
-      Pointee: 173 StructureType table<uint8,[4]int>
+      Pointee: 189 StructureType table<uint8,[4]int>
     - __kind: PointerType
-      ID: 161
+      ID: 177
       Name: '*table<uint8,uint8>'
       ByteSize: 8
-      Pointee: 162 StructureType table<uint8,uint8>
+      Pointee: 178 StructureType table<uint8,uint8>
     - __kind: PointerType
-      ID: 205
+      ID: 34
       Name: '*uint'
       ByteSize: 8
       GoRuntimeType: 385856
       GoKind: 22
-      Pointee: 20 BaseType uint
+      Pointee: 16 BaseType uint
     - __kind: PointerType
-      ID: 218
+      ID: 29
       Name: '*uint16'
       ByteSize: 8
       GoRuntimeType: 385472
       GoKind: 22
-      Pointee: 22 BaseType uint16
+      Pointee: 6 BaseType uint16
     - __kind: PointerType
-      ID: 227
+      ID: 21
       Name: '*uint32'
       ByteSize: 8
       GoRuntimeType: 385600
       GoKind: 22
-      Pointee: 24 BaseType uint32
+      Pointee: 2 BaseType uint32
     - __kind: PointerType
-      ID: 233
+      ID: 28
       Name: '*uint64'
       ByteSize: 8
       GoRuntimeType: 385728
       GoKind: 22
-      Pointee: 26 BaseType uint64
+      Pointee: 8 BaseType uint64
     - __kind: PointerType
-      ID: 9
+      ID: 5
       Name: '*uint8'
       ByteSize: 8
       GoRuntimeType: 385344
       GoKind: 22
-      Pointee: 4 BaseType uint8
+      Pointee: 3 BaseType uint8
     - __kind: PointerType
-      ID: 225
+      ID: 19
       Name: '*uintptr'
       ByteSize: 8
       GoRuntimeType: 385920
       GoKind: 22
-      Pointee: 62 BaseType uintptr
+      Pointee: 1 BaseType uintptr
     - __kind: EventRootType
       ID: 369
       Name: Probe[main.stackC]
@@ -3581,10 +3581,10 @@ Types:
         - Name: a
           Offset: 1
           Expression:
-            Type: 41 GoEmptyInterfaceType interface {}
+            Type: 58 GoEmptyInterfaceType interface {}
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 51, index: 0, name: a}
+                  Variable: {subprogram: 45, index: 0, name: a}
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
@@ -3596,10 +3596,10 @@ Types:
         - Name: b
           Offset: 1
           Expression:
-            Type: 28 ArrayType [2][2][2]int
+            Type: 49 ArrayType [2][2][2]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 23, index: 0, name: b}
+                  Variable: {subprogram: 17, index: 0, name: b}
                   Offset: 0
                   ByteSize: 64
     - __kind: EventRootType
@@ -3611,10 +3611,10 @@ Types:
         - Name: a
           Offset: 1
           Expression:
-            Type: 27 ArrayType [2][2]int
+            Type: 48 ArrayType [2][2]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 21, index: 0, name: a}
+                  Variable: {subprogram: 15, index: 0, name: a}
                   Offset: 0
                   ByteSize: 32
     - __kind: EventRootType
@@ -3626,10 +3626,10 @@ Types:
         - Name: m
           Offset: 1
           Expression:
-            Type: 118 ArrayType [2]map[string]int
+            Type: 134 ArrayType [2]map[string]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 59, index: 0, name: m}
+                  Variable: {subprogram: 53, index: 0, name: m}
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
@@ -3641,10 +3641,10 @@ Types:
         - Name: a
           Offset: 1
           Expression:
-            Type: 7 ArrayType [2]string
+            Type: 38 ArrayType [2]string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 22, index: 0, name: a}
+                  Variable: {subprogram: 16, index: 0, name: a}
                   Offset: 0
                   ByteSize: 32
     - __kind: EventRootType
@@ -3656,10 +3656,10 @@ Types:
         - Name: b
           Offset: 1
           Expression:
-            Type: 33 StructureType main.bigStruct
+            Type: 52 StructureType main.bigStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 41, index: 0, name: b}
+                  Variable: {subprogram: 35, index: 0, name: b}
                   Offset: 0
                   ByteSize: 48
     - __kind: EventRootType
@@ -3671,10 +3671,10 @@ Types:
         - Name: x
           Offset: 1
           Expression:
-            Type: 10 ArrayType [2]bool
+            Type: 39 ArrayType [2]bool
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 10, index: 0, name: x}
+                  Variable: {subprogram: 4, index: 0, name: x}
                   Offset: 0
                   ByteSize: 2
     - __kind: EventRootType
@@ -3686,10 +3686,10 @@ Types:
         - Name: x
           Offset: 1
           Expression:
-            Type: 3 ArrayType [2]uint8
+            Type: 36 ArrayType [2]uint8
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 7, index: 0, name: x}
+                  Variable: {subprogram: 1, index: 0, name: x}
                   Offset: 0
                   ByteSize: 2
     - __kind: EventRootType
@@ -3701,10 +3701,10 @@ Types:
         - Name: c
           Offset: 1
           Expression:
-            Type: 202 GoChannelType chan bool
+            Type: 218 GoChannelType chan bool
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 75, index: 0, name: c}
+                  Variable: {subprogram: 69, index: 0, name: c}
                   Offset: 0
                   ByteSize: 0
     - __kind: EventRootType
@@ -3716,28 +3716,28 @@ Types:
         - Name: w
           Offset: 1
           Expression:
-            Type: 4 BaseType uint8
+            Type: 3 BaseType uint8
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 73, index: 0, name: w}
+                  Variable: {subprogram: 67, index: 0, name: w}
                   Offset: 0
                   ByteSize: 1
         - Name: x
           Offset: 2
           Expression:
-            Type: 4 BaseType uint8
+            Type: 3 BaseType uint8
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 73, index: 1, name: x}
+                  Variable: {subprogram: 67, index: 1, name: x}
                   Offset: 0
                   ByteSize: 1
         - Name: y
           Offset: 3
           Expression:
-            Type: 30 BaseType float32
+            Type: 17 BaseType float32
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 73, index: 2, name: y}
+                  Variable: {subprogram: 67, index: 2, name: y}
                   Offset: 0
                   ByteSize: 4
     - __kind: EventRootType
@@ -3749,10 +3749,10 @@ Types:
         - Name: t
           Offset: 1
           Expression:
-            Type: 207 PointerType *main.t
+            Type: 221 PointerType *main.t
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 83, index: 0, name: t}
+                  Variable: {subprogram: 77, index: 0, name: t}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
@@ -3764,19 +3764,19 @@ Types:
         - Name: xs
           Offset: 1
           Expression:
-            Type: 213 GoSliceHeaderType []main.structWithNoStrings
+            Type: 227 GoSliceHeaderType []main.structWithNoStrings
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 88, index: 0, name: xs}
+                  Variable: {subprogram: 82, index: 0, name: xs}
                   Offset: 0
                   ByteSize: 24
         - Name: a
           Offset: 25
           Expression:
-            Type: 1 BaseType int
+            Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 88, index: 1, name: a}
+                  Variable: {subprogram: 82, index: 1, name: a}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
@@ -3788,10 +3788,10 @@ Types:
         - Name: u
           Offset: 1
           Expression:
-            Type: 210 GoSliceHeaderType []uint
+            Type: 224 GoSliceHeaderType []uint
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 85, index: 0, name: u}
+                  Variable: {subprogram: 79, index: 0, name: u}
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
@@ -3803,10 +3803,10 @@ Types:
         - Name: x
           Offset: 1
           Expression:
-            Type: 8 GoStringHeaderType string
+            Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 102, index: 0, name: x}
+                  Variable: {subprogram: 96, index: 0, name: x}
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
@@ -3818,10 +3818,10 @@ Types:
         - Name: e
           Offset: 1
           Expression:
-            Type: 224 StructureType main.emptyStruct
+            Type: 237 StructureType main.emptyStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 104, index: 0, name: e}
+                  Variable: {subprogram: 98, index: 0, name: e}
                   Offset: 0
                   ByteSize: 0
     - __kind: EventRootType
@@ -3833,10 +3833,10 @@ Types:
         - Name: e
           Offset: 1
           Expression:
-            Type: 57 GoInterfaceType error
+            Type: 13 GoInterfaceType error
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 52, index: 0, name: e}
+                  Variable: {subprogram: 46, index: 0, name: e}
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
@@ -3848,10 +3848,10 @@ Types:
         - Name: e
           Offset: 1
           Expression:
-            Type: 44 PointerType *main.esotericHeap
+            Type: 61 PointerType *main.esotericHeap
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 43, index: 0, name: e}
+                  Variable: {subprogram: 37, index: 0, name: e}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
@@ -3863,10 +3863,10 @@ Types:
         - Name: e
           Offset: 1
           Expression:
-            Type: 39 StructureType main.esotericStack
+            Type: 56 StructureType main.esotericStack
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 42, index: 0, name: e}
+                  Variable: {subprogram: 36, index: 0, name: e}
                   Offset: 0
                   ByteSize: 64
     - __kind: EventRootType
@@ -3878,10 +3878,10 @@ Types:
         - Name: a
           Offset: 1
           Expression:
-            Type: 2 ArrayType [5]int
+            Type: 73 ArrayType [5]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 49, index: 0, name: a}
+                  Variable: {subprogram: 43, index: 0, name: a}
                   Offset: 0
                   ByteSize: 40
     - __kind: EventRootType
@@ -3893,10 +3893,10 @@ Types:
         - Name: x
           Offset: 1
           Expression:
-            Type: 1 BaseType int
+            Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 48, index: 0, name: x}
+                  Variable: {subprogram: 42, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
@@ -3908,10 +3908,10 @@ Types:
         - Name: x
           Offset: 1
           Expression:
-            Type: 1 BaseType int
+            Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 44, index: 0, name: x}
+                  Variable: {subprogram: 38, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
@@ -3923,10 +3923,10 @@ Types:
         - Name: x
           Offset: 1
           Expression:
-            Type: 1 BaseType int
+            Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 46, index: 0, name: x}
+                  Variable: {subprogram: 40, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
@@ -3941,19 +3941,19 @@ Types:
         - Name: x
           Offset: 1
           Expression:
-            Type: 1 BaseType int
+            Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 45, index: 0, name: x}
+                  Variable: {subprogram: 39, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
         - Name: y
           Offset: 9
           Expression:
-            Type: 1 BaseType int
+            Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 45, index: 1, name: y}
+                  Variable: {subprogram: 39, index: 1, name: y}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
@@ -3974,10 +3974,10 @@ Types:
         - Name: x
           Offset: 1
           Expression:
-            Type: 1 BaseType int
+            Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 1, index: 0, name: x}
+                  Variable: {subprogram: 99, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
@@ -3989,10 +3989,10 @@ Types:
         - Name: x
           Offset: 1
           Expression:
-            Type: 1 BaseType int
+            Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 5, index: 0, name: x}
+                  Variable: {subprogram: 103, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
@@ -4004,10 +4004,10 @@ Types:
         - Name: a
           Offset: 1
           Expression:
-            Type: 2 ArrayType [5]int
+            Type: 73 ArrayType [5]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 6, index: 0, name: a}
+                  Variable: {subprogram: 104, index: 0, name: a}
                   Offset: 0
                   ByteSize: 40
     - __kind: EventRootType
@@ -4019,10 +4019,10 @@ Types:
         - Name: x
           Offset: 1
           Expression:
-            Type: 15 ArrayType [2]int16
+            Type: 42 ArrayType [2]int16
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 13, index: 0, name: x}
+                  Variable: {subprogram: 7, index: 0, name: x}
                   Offset: 0
                   ByteSize: 4
     - __kind: EventRootType
@@ -4034,10 +4034,10 @@ Types:
         - Name: x
           Offset: 1
           Expression:
-            Type: 5 ArrayType [2]int32
+            Type: 37 ArrayType [2]int32
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 14, index: 0, name: x}
+                  Variable: {subprogram: 8, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
@@ -4049,10 +4049,10 @@ Types:
         - Name: x
           Offset: 1
           Expression:
-            Type: 17 ArrayType [2]int64
+            Type: 43 ArrayType [2]int64
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 15, index: 0, name: x}
+                  Variable: {subprogram: 9, index: 0, name: x}
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
@@ -4064,10 +4064,10 @@ Types:
         - Name: x
           Offset: 1
           Expression:
-            Type: 13 ArrayType [2]int8
+            Type: 41 ArrayType [2]int8
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 12, index: 0, name: x}
+                  Variable: {subprogram: 6, index: 0, name: x}
                   Offset: 0
                   ByteSize: 2
     - __kind: EventRootType
@@ -4079,10 +4079,10 @@ Types:
         - Name: x
           Offset: 1
           Expression:
-            Type: 12 ArrayType [2]int
+            Type: 40 ArrayType [2]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 11, index: 0, name: x}
+                  Variable: {subprogram: 5, index: 0, name: x}
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
@@ -4094,10 +4094,10 @@ Types:
         - Name: b
           Offset: 1
           Expression:
-            Type: 56 GoInterfaceType main.behavior
+            Type: 74 GoInterfaceType main.behavior
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 50, index: 0, name: b}
+                  Variable: {subprogram: 44, index: 0, name: b}
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
@@ -4109,10 +4109,10 @@ Types:
         - Name: a
           Offset: 1
           Expression:
-            Type: 144 StructureType main.node
+            Type: 160 StructureType main.node
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 77, index: 0, name: a}
+                  Variable: {subprogram: 71, index: 0, name: a}
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
@@ -4124,10 +4124,10 @@ Types:
         - Name: m
           Offset: 1
           Expression:
-            Type: 106 GoMapType map[[4]string][2]int
+            Type: 122 GoMapType map[[4]string][2]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 57, index: 0, name: m}
+                  Variable: {subprogram: 51, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
@@ -4139,10 +4139,10 @@ Types:
         - Name: m
           Offset: 1
           Expression:
-            Type: 120 GoMapType map[string][]main.structWithMap
+            Type: 136 GoMapType map[string][]main.structWithMap
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 63, index: 0, name: m}
+                  Variable: {subprogram: 57, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
@@ -4154,10 +4154,10 @@ Types:
         - Name: m
           Offset: 1
           Expression:
-            Type: 59 GoMapType map[int]int
+            Type: 76 GoMapType map[int]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 61, index: 0, name: m}
+                  Variable: {subprogram: 55, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
@@ -4169,10 +4169,10 @@ Types:
         - Name: m
           Offset: 1
           Expression:
-            Type: 191 GoMapType map[[4]int][4]int
+            Type: 207 GoMapType map[[4]int][4]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 72, index: 0, name: m}
+                  Variable: {subprogram: 66, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
@@ -4184,10 +4184,10 @@ Types:
         - Name: m
           Offset: 1
           Expression:
-            Type: 180 GoMapType map[[4]int]uint8
+            Type: 196 GoMapType map[[4]int]uint8
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 71, index: 0, name: m}
+                  Variable: {subprogram: 65, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
@@ -4199,10 +4199,10 @@ Types:
         - Name: redactMyEntries
           Offset: 1
           Expression:
-            Type: 120 GoMapType map[string][]main.structWithMap
+            Type: 136 GoMapType map[string][]main.structWithMap
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 62, index: 0, name: redactMyEntries}
+                  Variable: {subprogram: 56, index: 0, name: redactMyEntries}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
@@ -4214,10 +4214,10 @@ Types:
         - Name: m
           Offset: 1
           Expression:
-            Type: 168 GoMapType map[uint8][4]int
+            Type: 184 GoMapType map[uint8][4]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 70, index: 0, name: m}
+                  Variable: {subprogram: 64, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
@@ -4229,10 +4229,10 @@ Types:
         - Name: m
           Offset: 1
           Expression:
-            Type: 157 GoMapType map[uint8]uint8
+            Type: 173 GoMapType map[uint8]uint8
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 69, index: 0, name: m}
+                  Variable: {subprogram: 63, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
@@ -4244,10 +4244,10 @@ Types:
         - Name: m
           Offset: 1
           Expression:
-            Type: 83 GoMapType map[string]int
+            Type: 99 GoMapType map[string]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 55, index: 0, name: m}
+                  Variable: {subprogram: 49, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
@@ -4259,10 +4259,10 @@ Types:
         - Name: m
           Offset: 1
           Expression:
-            Type: 94 GoMapType map[string][]string
+            Type: 110 GoMapType map[string][]string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 56, index: 0, name: m}
+                  Variable: {subprogram: 50, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
@@ -4274,10 +4274,10 @@ Types:
         - Name: m
           Offset: 1
           Expression:
-            Type: 71 GoMapType map[string]main.nestedStruct
+            Type: 87 GoMapType map[string]main.nestedStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 54, index: 0, name: m}
+                  Variable: {subprogram: 48, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
@@ -4289,10 +4289,10 @@ Types:
         - Name: m
           Offset: 1
           Expression:
-            Type: 133 GoMapType map[bool]main.node
+            Type: 149 GoMapType map[bool]main.node
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 64, index: 0, name: m}
+                  Variable: {subprogram: 58, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
@@ -4304,10 +4304,10 @@ Types:
         - Name: m
           Offset: 1
           Expression:
-            Type: 157 GoMapType map[uint8]uint8
+            Type: 173 GoMapType map[uint8]uint8
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 68, index: 0, name: m}
+                  Variable: {subprogram: 62, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
@@ -4319,10 +4319,10 @@ Types:
         - Name: m
           Offset: 1
           Expression:
-            Type: 157 GoMapType map[uint8]uint8
+            Type: 173 GoMapType map[uint8]uint8
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 67, index: 0, name: m}
+                  Variable: {subprogram: 61, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
@@ -4334,10 +4334,10 @@ Types:
         - Name: redactMyEntries
           Offset: 1
           Expression:
-            Type: 146 GoMapType map[int]uint8
+            Type: 162 GoMapType map[int]uint8
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 66, index: 0, name: redactMyEntries}
+                  Variable: {subprogram: 60, index: 0, name: redactMyEntries}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
@@ -4349,10 +4349,10 @@ Types:
         - Name: m
           Offset: 1
           Expression:
-            Type: 146 GoMapType map[int]uint8
+            Type: 162 GoMapType map[int]uint8
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 65, index: 0, name: m}
+                  Variable: {subprogram: 59, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
@@ -4364,10 +4364,10 @@ Types:
         - Name: x
           Offset: 1
           Expression:
-            Type: 8 GoStringHeaderType string
+            Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 100, index: 0, name: x}
+                  Variable: {subprogram: 94, index: 0, name: x}
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
@@ -4379,46 +4379,46 @@ Types:
         - Name: a
           Offset: 1
           Expression:
-            Type: 11 BaseType bool
+            Type: 4 BaseType bool
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 74, index: 0, name: a}
+                  Variable: {subprogram: 68, index: 0, name: a}
                   Offset: 0
                   ByteSize: 1
         - Name: b
           Offset: 2
           Expression:
-            Type: 4 BaseType uint8
+            Type: 3 BaseType uint8
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 74, index: 1, name: b}
+                  Variable: {subprogram: 68, index: 1, name: b}
                   Offset: 0
                   ByteSize: 1
         - Name: c
           Offset: 3
           Expression:
-            Type: 6 BaseType int32
+            Type: 10 BaseType int32
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 74, index: 2, name: c}
+                  Variable: {subprogram: 68, index: 2, name: c}
                   Offset: 0
                   ByteSize: 4
         - Name: d
           Offset: 7
           Expression:
-            Type: 20 BaseType uint
+            Type: 16 BaseType uint
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 74, index: 3, name: d}
+                  Variable: {subprogram: 68, index: 3, name: d}
                   Offset: 0
                   ByteSize: 8
         - Name: e
           Offset: 15
           Expression:
-            Type: 8 GoStringHeaderType string
+            Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 74, index: 4, name: e}
+                  Variable: {subprogram: 68, index: 4, name: e}
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
@@ -4430,19 +4430,19 @@ Types:
         - Name: z
           Offset: 1
           Expression:
-            Type: 206 PointerType *bool
+            Type: 11 PointerType *bool
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 82, index: 0, name: z}
+                  Variable: {subprogram: 76, index: 0, name: z}
                   Offset: 0
                   ByteSize: 8
         - Name: a
           Offset: 9
           Expression:
-            Type: 20 BaseType uint
+            Type: 16 BaseType uint
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 82, index: 1, name: a}
+                  Variable: {subprogram: 76, index: 1, name: a}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
@@ -4454,19 +4454,19 @@ Types:
         - Name: xs
           Offset: 1
           Expression:
-            Type: 213 GoSliceHeaderType []main.structWithNoStrings
+            Type: 227 GoSliceHeaderType []main.structWithNoStrings
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 89, index: 0, name: xs}
+                  Variable: {subprogram: 83, index: 0, name: xs}
                   Offset: 0
                   ByteSize: 24
         - Name: a
           Offset: 25
           Expression:
-            Type: 1 BaseType int
+            Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 89, index: 1, name: a}
+                  Variable: {subprogram: 83, index: 1, name: a}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
@@ -4478,28 +4478,28 @@ Types:
         - Name: a
           Offset: 1
           Expression:
-            Type: 14 BaseType int8
+            Type: 15 BaseType int8
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 91, index: 0, name: a}
+                  Variable: {subprogram: 85, index: 0, name: a}
                   Offset: 0
                   ByteSize: 1
         - Name: s
           Offset: 2
           Expression:
-            Type: 216 GoSliceHeaderType []bool
+            Type: 230 GoSliceHeaderType []bool
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 91, index: 1, name: s}
+                  Variable: {subprogram: 85, index: 1, name: s}
                   Offset: 0
                   ByteSize: 24
         - Name: x
           Offset: 26
           Expression:
-            Type: 20 BaseType uint
+            Type: 16 BaseType uint
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 91, index: 2, name: x}
+                  Variable: {subprogram: 85, index: 2, name: x}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
@@ -4511,10 +4511,10 @@ Types:
         - Name: xs
           Offset: 1
           Expression:
-            Type: 217 GoSliceHeaderType []uint16
+            Type: 231 GoSliceHeaderType []uint16
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 92, index: 0, name: xs}
+                  Variable: {subprogram: 86, index: 0, name: xs}
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
@@ -4526,10 +4526,10 @@ Types:
         - Name: a
           Offset: 1
           Expression:
-            Type: 221 PointerType *main.oneStringStruct
+            Type: 234 PointerType *main.oneStringStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 99, index: 0, name: a}
+                  Variable: {subprogram: 93, index: 0, name: a}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
@@ -4541,10 +4541,10 @@ Types:
         - Name: a
           Offset: 1
           Expression:
-            Type: 145 PointerType *main.node
+            Type: 161 PointerType *main.node
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 78, index: 0, name: a}
+                  Variable: {subprogram: 72, index: 0, name: a}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
@@ -4556,10 +4556,10 @@ Types:
         - Name: m
           Offset: 1
           Expression:
-            Type: 119 PointerType *map[string]int
+            Type: 135 PointerType *map[string]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 60, index: 0, name: m}
+                  Variable: {subprogram: 54, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
@@ -4571,10 +4571,10 @@ Types:
         - Name: a
           Offset: 1
           Expression:
-            Type: 203 PointerType *main.structWithTwoValues
+            Type: 219 PointerType *main.structWithTwoValues
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 76, index: 0, name: a}
+                  Variable: {subprogram: 70, index: 0, name: a}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
@@ -4586,10 +4586,10 @@ Types:
         - Name: x
           Offset: 1
           Expression:
-            Type: 5 ArrayType [2]int32
+            Type: 37 ArrayType [2]int32
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 8, index: 0, name: x}
+                  Variable: {subprogram: 2, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
@@ -4601,10 +4601,10 @@ Types:
         - Name: x
           Offset: 1
           Expression:
-            Type: 11 BaseType bool
+            Type: 4 BaseType bool
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 27, index: 0, name: x}
+                  Variable: {subprogram: 21, index: 0, name: x}
                   Offset: 0
                   ByteSize: 1
     - __kind: EventRootType
@@ -4616,10 +4616,10 @@ Types:
         - Name: x
           Offset: 1
           Expression:
-            Type: 4 BaseType uint8
+            Type: 3 BaseType uint8
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 25, index: 0, name: x}
+                  Variable: {subprogram: 19, index: 0, name: x}
                   Offset: 0
                   ByteSize: 1
     - __kind: EventRootType
@@ -4631,10 +4631,10 @@ Types:
         - Name: x
           Offset: 1
           Expression:
-            Type: 30 BaseType float32
+            Type: 17 BaseType float32
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 38, index: 0, name: x}
+                  Variable: {subprogram: 32, index: 0, name: x}
                   Offset: 0
                   ByteSize: 4
     - __kind: EventRootType
@@ -4646,10 +4646,10 @@ Types:
         - Name: x
           Offset: 1
           Expression:
-            Type: 31 BaseType float64
+            Type: 18 BaseType float64
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 39, index: 0, name: x}
+                  Variable: {subprogram: 33, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
@@ -4661,10 +4661,10 @@ Types:
         - Name: x
           Offset: 1
           Expression:
-            Type: 16 BaseType int16
+            Type: 31 BaseType int16
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 30, index: 0, name: x}
+                  Variable: {subprogram: 24, index: 0, name: x}
                   Offset: 0
                   ByteSize: 2
     - __kind: EventRootType
@@ -4676,10 +4676,10 @@ Types:
         - Name: x
           Offset: 1
           Expression:
-            Type: 6 BaseType int32
+            Type: 10 BaseType int32
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 31, index: 0, name: x}
+                  Variable: {subprogram: 25, index: 0, name: x}
                   Offset: 0
                   ByteSize: 4
     - __kind: EventRootType
@@ -4691,10 +4691,10 @@ Types:
         - Name: x
           Offset: 1
           Expression:
-            Type: 18 BaseType int64
+            Type: 12 BaseType int64
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 32, index: 0, name: x}
+                  Variable: {subprogram: 26, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
@@ -4706,10 +4706,10 @@ Types:
         - Name: x
           Offset: 1
           Expression:
-            Type: 14 BaseType int8
+            Type: 15 BaseType int8
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 29, index: 0, name: x}
+                  Variable: {subprogram: 23, index: 0, name: x}
                   Offset: 0
                   ByteSize: 1
     - __kind: EventRootType
@@ -4721,10 +4721,10 @@ Types:
         - Name: x
           Offset: 1
           Expression:
-            Type: 1 BaseType int
+            Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 28, index: 0, name: x}
+                  Variable: {subprogram: 22, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
@@ -4736,10 +4736,10 @@ Types:
         - Name: x
           Offset: 1
           Expression:
-            Type: 6 BaseType int32
+            Type: 10 BaseType int32
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 26, index: 0, name: x}
+                  Variable: {subprogram: 20, index: 0, name: x}
                   Offset: 0
                   ByteSize: 4
     - __kind: EventRootType
@@ -4751,10 +4751,10 @@ Types:
         - Name: x
           Offset: 1
           Expression:
-            Type: 8 GoStringHeaderType string
+            Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 95, index: 0, name: x}
+                  Variable: {subprogram: 89, index: 0, name: x}
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
@@ -4766,10 +4766,10 @@ Types:
         - Name: x
           Offset: 1
           Expression:
-            Type: 22 BaseType uint16
+            Type: 6 BaseType uint16
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 35, index: 0, name: x}
+                  Variable: {subprogram: 29, index: 0, name: x}
                   Offset: 0
                   ByteSize: 2
     - __kind: EventRootType
@@ -4781,10 +4781,10 @@ Types:
         - Name: x
           Offset: 1
           Expression:
-            Type: 24 BaseType uint32
+            Type: 2 BaseType uint32
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 36, index: 0, name: x}
+                  Variable: {subprogram: 30, index: 0, name: x}
                   Offset: 0
                   ByteSize: 4
     - __kind: EventRootType
@@ -4796,10 +4796,10 @@ Types:
         - Name: x
           Offset: 1
           Expression:
-            Type: 26 BaseType uint64
+            Type: 8 BaseType uint64
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 37, index: 0, name: x}
+                  Variable: {subprogram: 31, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
@@ -4811,10 +4811,10 @@ Types:
         - Name: x
           Offset: 1
           Expression:
-            Type: 4 BaseType uint8
+            Type: 3 BaseType uint8
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 34, index: 0, name: x}
+                  Variable: {subprogram: 28, index: 0, name: x}
                   Offset: 0
                   ByteSize: 1
     - __kind: EventRootType
@@ -4826,10 +4826,10 @@ Types:
         - Name: x
           Offset: 1
           Expression:
-            Type: 20 BaseType uint
+            Type: 16 BaseType uint
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 33, index: 0, name: x}
+                  Variable: {subprogram: 27, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
@@ -4841,10 +4841,10 @@ Types:
         - Name: u
           Offset: 1
           Expression:
-            Type: 211 GoSliceHeaderType [][]uint
+            Type: 225 GoSliceHeaderType [][]uint
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 86, index: 0, name: u}
+                  Variable: {subprogram: 80, index: 0, name: u}
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
@@ -4856,10 +4856,10 @@ Types:
         - Name: m
           Offset: 1
           Expression:
-            Type: 83 GoMapType map[string]int
+            Type: 99 GoMapType map[string]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 58, index: 0, name: m}
+                  Variable: {subprogram: 52, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
@@ -4871,10 +4871,10 @@ Types:
         - Name: x
           Offset: 1
           Expression:
-            Type: 7 ArrayType [2]string
+            Type: 38 ArrayType [2]string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 9, index: 0, name: x}
+                  Variable: {subprogram: 3, index: 0, name: x}
                   Offset: 0
                   ByteSize: 32
     - __kind: EventRootType
@@ -4886,10 +4886,10 @@ Types:
         - Name: z
           Offset: 1
           Expression:
-            Type: 36 PointerType *string
+            Type: 22 PointerType *string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 81, index: 0, name: z}
+                  Variable: {subprogram: 75, index: 0, name: z}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
@@ -4901,10 +4901,10 @@ Types:
         - Name: s
           Offset: 1
           Expression:
-            Type: 105 GoSliceHeaderType []string
+            Type: 121 GoSliceHeaderType []string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 90, index: 0, name: s}
+                  Variable: {subprogram: 84, index: 0, name: s}
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
@@ -4916,19 +4916,19 @@ Types:
         - Name: xs
           Offset: 1
           Expression:
-            Type: 213 GoSliceHeaderType []main.structWithNoStrings
+            Type: 227 GoSliceHeaderType []main.structWithNoStrings
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 87, index: 0, name: xs}
+                  Variable: {subprogram: 81, index: 0, name: xs}
                   Offset: 0
                   ByteSize: 24
         - Name: a
           Offset: 25
           Expression:
-            Type: 1 BaseType int
+            Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 87, index: 1, name: a}
+                  Variable: {subprogram: 81, index: 1, name: a}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
@@ -4940,10 +4940,10 @@ Types:
         - Name: s
           Offset: 1
           Expression:
-            Type: 58 StructureType main.structWithMap
+            Type: 75 StructureType main.structWithMap
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 53, index: 0, name: s}
+                  Variable: {subprogram: 47, index: 0, name: s}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
@@ -4955,10 +4955,10 @@ Types:
         - Name: x
           Offset: 1
           Expression:
-            Type: 223 StructureType main.aStruct
+            Type: 236 StructureType main.aStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 103, index: 0, name: x}
+                  Variable: {subprogram: 97, index: 0, name: x}
                   Offset: 0
                   ByteSize: 56
     - __kind: EventRootType
@@ -4970,10 +4970,10 @@ Types:
         - Name: a
           Offset: 1
           Expression:
-            Type: 220 PointerType *main.threeStringStruct
+            Type: 233 PointerType *main.threeStringStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 98, index: 0, name: a}
+                  Variable: {subprogram: 92, index: 0, name: a}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
@@ -4985,10 +4985,10 @@ Types:
         - Name: a
           Offset: 1
           Expression:
-            Type: 219 StructureType main.threeStringStruct
+            Type: 232 StructureType main.threeStringStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 97, index: 0, name: a}
+                  Variable: {subprogram: 91, index: 0, name: a}
                   Offset: 0
                   ByteSize: 48
     - __kind: EventRootType
@@ -5000,28 +5000,28 @@ Types:
         - Name: x
           Offset: 1
           Expression:
-            Type: 8 GoStringHeaderType string
+            Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 96, index: 0, name: x}
+                  Variable: {subprogram: 90, index: 0, name: x}
                   Offset: 0
                   ByteSize: 16
         - Name: y
           Offset: 17
           Expression:
-            Type: 8 GoStringHeaderType string
+            Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 96, index: 1, name: y}
+                  Variable: {subprogram: 90, index: 1, name: y}
                   Offset: 0
                   ByteSize: 16
         - Name: z
           Offset: 33
           Expression:
-            Type: 8 GoStringHeaderType string
+            Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 96, index: 2, name: z}
+                  Variable: {subprogram: 90, index: 2, name: z}
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
@@ -5033,10 +5033,10 @@ Types:
         - Name: x
           Offset: 1
           Expression:
-            Type: 32 BaseType main.typeAlias
+            Type: 51 BaseType main.typeAlias
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 40, index: 0, name: x}
+                  Variable: {subprogram: 34, index: 0, name: x}
                   Offset: 0
                   ByteSize: 2
     - __kind: EventRootType
@@ -5048,10 +5048,10 @@ Types:
         - Name: x
           Offset: 1
           Expression:
-            Type: 21 ArrayType [2]uint16
+            Type: 45 ArrayType [2]uint16
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 18, index: 0, name: x}
+                  Variable: {subprogram: 12, index: 0, name: x}
                   Offset: 0
                   ByteSize: 4
     - __kind: EventRootType
@@ -5063,10 +5063,10 @@ Types:
         - Name: x
           Offset: 1
           Expression:
-            Type: 23 ArrayType [2]uint32
+            Type: 46 ArrayType [2]uint32
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 19, index: 0, name: x}
+                  Variable: {subprogram: 13, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
@@ -5078,10 +5078,10 @@ Types:
         - Name: x
           Offset: 1
           Expression:
-            Type: 25 ArrayType [2]uint64
+            Type: 47 ArrayType [2]uint64
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 20, index: 0, name: x}
+                  Variable: {subprogram: 14, index: 0, name: x}
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
@@ -5093,10 +5093,10 @@ Types:
         - Name: x
           Offset: 1
           Expression:
-            Type: 3 ArrayType [2]uint8
+            Type: 36 ArrayType [2]uint8
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 17, index: 0, name: x}
+                  Variable: {subprogram: 11, index: 0, name: x}
                   Offset: 0
                   ByteSize: 2
     - __kind: EventRootType
@@ -5108,10 +5108,10 @@ Types:
         - Name: x
           Offset: 1
           Expression:
-            Type: 19 ArrayType [2]uint
+            Type: 44 ArrayType [2]uint
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 16, index: 0, name: x}
+                  Variable: {subprogram: 10, index: 0, name: x}
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
@@ -5123,10 +5123,10 @@ Types:
         - Name: x
           Offset: 1
           Expression:
-            Type: 205 PointerType *uint
+            Type: 34 PointerType *uint
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 80, index: 0, name: x}
+                  Variable: {subprogram: 74, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
@@ -5138,10 +5138,10 @@ Types:
         - Name: u
           Offset: 1
           Expression:
-            Type: 210 GoSliceHeaderType []uint
+            Type: 224 GoSliceHeaderType []uint
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 84, index: 0, name: u}
+                  Variable: {subprogram: 78, index: 0, name: u}
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
@@ -5153,10 +5153,10 @@ Types:
         - Name: x
           Offset: 1
           Expression:
-            Type: 8 GoStringHeaderType string
+            Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 101, index: 0, name: x}
+                  Variable: {subprogram: 95, index: 0, name: x}
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
@@ -5168,10 +5168,10 @@ Types:
         - Name: x
           Offset: 1
           Expression:
-            Type: 38 VoidPointerType unsafe.Pointer
+            Type: 14 VoidPointerType unsafe.Pointer
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 79, index: 0, name: x}
+                  Variable: {subprogram: 73, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
@@ -5183,10 +5183,10 @@ Types:
         - Name: a
           Offset: 1
           Expression:
-            Type: 29 ArrayType [100]uint
+            Type: 50 ArrayType [100]uint
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 24, index: 0, name: a}
+                  Variable: {subprogram: 18, index: 0, name: a}
                   Offset: 0
                   ByteSize: 800
     - __kind: EventRootType
@@ -5198,173 +5198,173 @@ Types:
         - Name: xs
           Offset: 1
           Expression:
-            Type: 210 GoSliceHeaderType []uint
+            Type: 224 GoSliceHeaderType []uint
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 93, index: 0, name: xs}
+                  Variable: {subprogram: 87, index: 0, name: xs}
                   Offset: 0
                   ByteSize: 24
     - __kind: ArrayType
-      ID: 29
+      ID: 50
       Name: '[100]uint'
       ByteSize: 800
       GoKind: 17
       Count: 100
       HasCount: true
-      Element: 20 BaseType uint
+      Element: 16 BaseType uint
     - __kind: ArrayType
-      ID: 28
+      ID: 49
       Name: '[2][2][2]int'
       ByteSize: 64
       GoKind: 17
       Count: 2
       HasCount: true
-      Element: 27 ArrayType [2][2]int
+      Element: 48 ArrayType [2][2]int
     - __kind: ArrayType
-      ID: 27
+      ID: 48
       Name: '[2][2]int'
       ByteSize: 32
       GoKind: 17
       Count: 2
       HasCount: true
-      Element: 12 ArrayType [2]int
+      Element: 40 ArrayType [2]int
     - __kind: ArrayType
-      ID: 10
+      ID: 39
       Name: '[2]bool'
       ByteSize: 2
       GoKind: 17
       Count: 2
       HasCount: true
-      Element: 11 BaseType bool
+      Element: 4 BaseType bool
     - __kind: ArrayType
-      ID: 12
+      ID: 40
       Name: '[2]int'
       ByteSize: 16
       GoRuntimeType: 673280
       GoKind: 17
       Count: 2
       HasCount: true
-      Element: 1 BaseType int
+      Element: 7 BaseType int
     - __kind: ArrayType
-      ID: 15
+      ID: 42
       Name: '[2]int16'
       ByteSize: 4
       GoKind: 17
       Count: 2
       HasCount: true
-      Element: 16 BaseType int16
+      Element: 31 BaseType int16
     - __kind: ArrayType
-      ID: 5
+      ID: 37
       Name: '[2]int32'
       ByteSize: 8
       GoRuntimeType: 674624
       GoKind: 17
       Count: 2
       HasCount: true
-      Element: 6 BaseType int32
+      Element: 10 BaseType int32
     - __kind: ArrayType
-      ID: 17
+      ID: 43
       Name: '[2]int64'
       ByteSize: 16
       GoKind: 17
       Count: 2
       HasCount: true
-      Element: 18 BaseType int64
+      Element: 12 BaseType int64
     - __kind: ArrayType
-      ID: 13
+      ID: 41
       Name: '[2]int8'
       ByteSize: 2
       GoKind: 17
       Count: 2
       HasCount: true
-      Element: 14 BaseType int8
+      Element: 15 BaseType int8
     - __kind: ArrayType
-      ID: 118
+      ID: 134
       Name: '[2]map[string]int'
       ByteSize: 16
       GoKind: 17
       Count: 2
       HasCount: true
-      Element: 83 GoMapType map[string]int
+      Element: 99 GoMapType map[string]int
     - __kind: ArrayType
-      ID: 7
+      ID: 38
       Name: '[2]string'
       ByteSize: 32
       GoRuntimeType: 674720
       GoKind: 17
       Count: 2
       HasCount: true
-      Element: 8 GoStringHeaderType string
+      Element: 9 GoStringHeaderType string
     - __kind: ArrayType
-      ID: 19
+      ID: 44
       Name: '[2]uint'
       ByteSize: 16
       GoKind: 17
       Count: 2
       HasCount: true
-      Element: 20 BaseType uint
+      Element: 16 BaseType uint
     - __kind: ArrayType
-      ID: 21
+      ID: 45
       Name: '[2]uint16'
       ByteSize: 4
       GoKind: 17
       Count: 2
       HasCount: true
-      Element: 22 BaseType uint16
+      Element: 6 BaseType uint16
     - __kind: ArrayType
-      ID: 23
+      ID: 46
       Name: '[2]uint32'
       ByteSize: 8
       GoKind: 17
       Count: 2
       HasCount: true
-      Element: 24 BaseType uint32
+      Element: 2 BaseType uint32
     - __kind: ArrayType
-      ID: 25
+      ID: 47
       Name: '[2]uint64'
       ByteSize: 16
       GoRuntimeType: 674816
       GoKind: 17
       Count: 2
       HasCount: true
-      Element: 26 BaseType uint64
+      Element: 8 BaseType uint64
     - __kind: ArrayType
-      ID: 3
+      ID: 36
       Name: '[2]uint8'
       ByteSize: 2
       GoRuntimeType: 674528
       GoKind: 17
       Count: 2
       HasCount: true
-      Element: 4 BaseType uint8
+      Element: 3 BaseType uint8
     - __kind: ArrayType
-      ID: 179
+      ID: 195
       Name: '[4]int'
       ByteSize: 32
       GoRuntimeType: 672896
       GoKind: 17
       Count: 4
       HasCount: true
-      Element: 1 BaseType int
+      Element: 7 BaseType int
     - __kind: ArrayType
-      ID: 117
+      ID: 133
       Name: '[4]string'
       ByteSize: 64
       GoRuntimeType: 673184
       GoKind: 17
       Count: 4
       HasCount: true
-      Element: 8 GoStringHeaderType string
+      Element: 9 GoStringHeaderType string
     - __kind: ArrayType
-      ID: 2
+      ID: 73
       Name: '[5]int'
       ByteSize: 40
       GoKind: 17
       Count: 5
       HasCount: true
-      Element: 1 BaseType int
+      Element: 7 BaseType int
     - __kind: GoSliceHeaderType
-      ID: 34
+      ID: 53
       Name: '[]*string'
       ByteSize: 24
       GoRuntimeType: 470656
@@ -5372,102 +5372,102 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 35 PointerType **string
+          Type: 54 PointerType **string
         - Name: len
           Offset: 8
-          Type: 1 BaseType int
+          Type: 7 BaseType int
         - Name: cap
           Offset: 16
-          Type: 1 BaseType int
+          Type: 7 BaseType int
       Data: 240 GoSliceDataType []*string.array
     - __kind: GoSliceDataType
       ID: 240
       Name: '[]*string.array'
       ByteSize: 2048
-      Element: 36 PointerType *string
+      Element: 22 PointerType *string
     - __kind: GoSliceDataType
       ID: 268
       Name: '[]*table<[4]int,[4]int>.array'
       ByteSize: 8192
-      Element: 195 PointerType *table<[4]int,[4]int>
+      Element: 211 PointerType *table<[4]int,[4]int>
     - __kind: GoSliceDataType
       ID: 266
       Name: '[]*table<[4]int,uint8>.array'
       ByteSize: 8192
-      Element: 184 PointerType *table<[4]int,uint8>
+      Element: 200 PointerType *table<[4]int,uint8>
     - __kind: GoSliceDataType
       ID: 252
       Name: '[]*table<[4]string,[2]int>.array'
       ByteSize: 8192
-      Element: 110 PointerType *table<[4]string,[2]int>
+      Element: 126 PointerType *table<[4]string,[2]int>
     - __kind: GoSliceDataType
       ID: 258
       Name: '[]*table<bool,main.node>.array'
       ByteSize: 8192
-      Element: 137 PointerType *table<bool,main.node>
+      Element: 153 PointerType *table<bool,main.node>
     - __kind: GoSliceDataType
       ID: 242
       Name: '[]*table<int,int>.array'
       ByteSize: 8192
-      Element: 64 PointerType *table<int,int>
+      Element: 80 PointerType *table<int,int>
     - __kind: GoSliceDataType
       ID: 260
       Name: '[]*table<int,uint8>.array'
       ByteSize: 8192
-      Element: 150 PointerType *table<int,uint8>
+      Element: 166 PointerType *table<int,uint8>
     - __kind: GoSliceDataType
       ID: 254
       Name: '[]*table<string,[]main.structWithMap>.array'
       ByteSize: 8192
-      Element: 124 PointerType *table<string,[]main.structWithMap>
+      Element: 140 PointerType *table<string,[]main.structWithMap>
     - __kind: GoSliceDataType
       ID: 248
       Name: '[]*table<string,[]string>.array'
       ByteSize: 8192
-      Element: 98 PointerType *table<string,[]string>
+      Element: 114 PointerType *table<string,[]string>
     - __kind: GoSliceDataType
       ID: 246
       Name: '[]*table<string,int>.array'
       ByteSize: 8192
-      Element: 87 PointerType *table<string,int>
+      Element: 103 PointerType *table<string,int>
     - __kind: GoSliceDataType
       ID: 244
       Name: '[]*table<string,main.nestedStruct>.array'
       ByteSize: 8192
-      Element: 75 PointerType *table<string,main.nestedStruct>
+      Element: 91 PointerType *table<string,main.nestedStruct>
     - __kind: GoSliceDataType
       ID: 264
       Name: '[]*table<uint8,[4]int>.array'
       ByteSize: 8192
-      Element: 172 PointerType *table<uint8,[4]int>
+      Element: 188 PointerType *table<uint8,[4]int>
     - __kind: GoSliceDataType
       ID: 262
       Name: '[]*table<uint8,uint8>.array'
       ByteSize: 8192
-      Element: 161 PointerType *table<uint8,uint8>
+      Element: 177 PointerType *table<uint8,uint8>
     - __kind: GoSliceHeaderType
-      ID: 211
+      ID: 225
       Name: '[][]uint'
       ByteSize: 24
       GoKind: 23
       RawFields:
         - Name: array
           Offset: 0
-          Type: 212 PointerType *[]uint
+          Type: 226 PointerType *[]uint
         - Name: len
           Offset: 8
-          Type: 1 BaseType int
+          Type: 7 BaseType int
         - Name: cap
           Offset: 16
-          Type: 1 BaseType int
+          Type: 7 BaseType int
       Data: 274 GoSliceDataType [][]uint.array
     - __kind: GoSliceDataType
       ID: 274
       Name: '[][]uint.array'
       ByteSize: 2048
-      Element: 210 GoSliceHeaderType []uint
+      Element: 224 GoSliceHeaderType []uint
     - __kind: GoSliceHeaderType
-      ID: 216
+      ID: 230
       Name: '[]bool'
       ByteSize: 24
       GoRuntimeType: 478528
@@ -5475,21 +5475,21 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 206 PointerType *bool
+          Type: 11 PointerType *bool
         - Name: len
           Offset: 8
-          Type: 1 BaseType int
+          Type: 7 BaseType int
         - Name: cap
           Offset: 16
-          Type: 1 BaseType int
+          Type: 7 BaseType int
       Data: 278 GoSliceDataType []bool.array
     - __kind: GoSliceDataType
       ID: 278
       Name: '[]bool.array'
       ByteSize: 2048
-      Element: 11 BaseType bool
+      Element: 4 BaseType bool
     - __kind: GoSliceHeaderType
-      ID: 131
+      ID: 147
       Name: '[]main.structWithMap'
       ByteSize: 24
       GoRuntimeType: 469888
@@ -5497,102 +5497,102 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 132 PointerType *main.structWithMap
+          Type: 148 PointerType *main.structWithMap
         - Name: len
           Offset: 8
-          Type: 1 BaseType int
+          Type: 7 BaseType int
         - Name: cap
           Offset: 16
-          Type: 1 BaseType int
+          Type: 7 BaseType int
       Data: 256 GoSliceDataType []main.structWithMap.array
     - __kind: GoSliceDataType
       ID: 256
       Name: '[]main.structWithMap.array'
       ByteSize: 2048
-      Element: 58 StructureType main.structWithMap
+      Element: 75 StructureType main.structWithMap
     - __kind: GoSliceHeaderType
-      ID: 213
+      ID: 227
       Name: '[]main.structWithNoStrings'
       ByteSize: 24
       GoKind: 23
       RawFields:
         - Name: array
           Offset: 0
-          Type: 214 PointerType *main.structWithNoStrings
+          Type: 228 PointerType *main.structWithNoStrings
         - Name: len
           Offset: 8
-          Type: 1 BaseType int
+          Type: 7 BaseType int
         - Name: cap
           Offset: 16
-          Type: 1 BaseType int
+          Type: 7 BaseType int
       Data: 276 GoSliceDataType []main.structWithNoStrings.array
     - __kind: GoSliceDataType
       ID: 276
       Name: '[]main.structWithNoStrings.array'
       ByteSize: 2048
-      Element: 215 StructureType main.structWithNoStrings
+      Element: 229 StructureType main.structWithNoStrings
     - __kind: GoSliceDataType
       ID: 269
       Name: '[]noalg.map.group[[4]int][4]int.array'
       ByteSize: 2048
-      Element: 199 StructureType noalg.map.group[[4]int][4]int
+      Element: 215 StructureType noalg.map.group[[4]int][4]int
     - __kind: GoSliceDataType
       ID: 267
       Name: '[]noalg.map.group[[4]int]uint8.array'
       ByteSize: 2048
-      Element: 188 StructureType noalg.map.group[[4]int]uint8
+      Element: 204 StructureType noalg.map.group[[4]int]uint8
     - __kind: GoSliceDataType
       ID: 253
       Name: '[]noalg.map.group[[4]string][2]int.array'
       ByteSize: 2048
-      Element: 114 StructureType noalg.map.group[[4]string][2]int
+      Element: 130 StructureType noalg.map.group[[4]string][2]int
     - __kind: GoSliceDataType
       ID: 259
       Name: '[]noalg.map.group[bool]main.node.array'
       ByteSize: 2048
-      Element: 141 StructureType noalg.map.group[bool]main.node
+      Element: 157 StructureType noalg.map.group[bool]main.node
     - __kind: GoSliceDataType
       ID: 243
       Name: '[]noalg.map.group[int]int.array'
       ByteSize: 2048
-      Element: 68 StructureType noalg.map.group[int]int
+      Element: 84 StructureType noalg.map.group[int]int
     - __kind: GoSliceDataType
       ID: 261
       Name: '[]noalg.map.group[int]uint8.array'
       ByteSize: 2048
-      Element: 154 StructureType noalg.map.group[int]uint8
+      Element: 170 StructureType noalg.map.group[int]uint8
     - __kind: GoSliceDataType
       ID: 255
       Name: '[]noalg.map.group[string][]main.structWithMap.array'
       ByteSize: 2048
-      Element: 128 StructureType noalg.map.group[string][]main.structWithMap
+      Element: 144 StructureType noalg.map.group[string][]main.structWithMap
     - __kind: GoSliceDataType
       ID: 249
       Name: '[]noalg.map.group[string][]string.array'
       ByteSize: 2048
-      Element: 102 StructureType noalg.map.group[string][]string
+      Element: 118 StructureType noalg.map.group[string][]string
     - __kind: GoSliceDataType
       ID: 247
       Name: '[]noalg.map.group[string]int.array'
       ByteSize: 2048
-      Element: 91 StructureType noalg.map.group[string]int
+      Element: 107 StructureType noalg.map.group[string]int
     - __kind: GoSliceDataType
       ID: 245
       Name: '[]noalg.map.group[string]main.nestedStruct.array'
       ByteSize: 2048
-      Element: 79 StructureType noalg.map.group[string]main.nestedStruct
+      Element: 95 StructureType noalg.map.group[string]main.nestedStruct
     - __kind: GoSliceDataType
       ID: 265
       Name: '[]noalg.map.group[uint8][4]int.array'
       ByteSize: 2048
-      Element: 176 StructureType noalg.map.group[uint8][4]int
+      Element: 192 StructureType noalg.map.group[uint8][4]int
     - __kind: GoSliceDataType
       ID: 263
       Name: '[]noalg.map.group[uint8]uint8.array'
       ByteSize: 2048
-      Element: 165 StructureType noalg.map.group[uint8]uint8
+      Element: 181 StructureType noalg.map.group[uint8]uint8
     - __kind: GoSliceHeaderType
-      ID: 105
+      ID: 121
       Name: '[]string'
       ByteSize: 24
       GoRuntimeType: 478656
@@ -5600,21 +5600,21 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 36 PointerType *string
+          Type: 22 PointerType *string
         - Name: len
           Offset: 8
-          Type: 1 BaseType int
+          Type: 7 BaseType int
         - Name: cap
           Offset: 16
-          Type: 1 BaseType int
+          Type: 7 BaseType int
       Data: 250 GoSliceDataType []string.array
     - __kind: GoSliceDataType
       ID: 250
       Name: '[]string.array'
       ByteSize: 2048
-      Element: 8 GoStringHeaderType string
+      Element: 9 GoStringHeaderType string
     - __kind: GoSliceHeaderType
-      ID: 210
+      ID: 224
       Name: '[]uint'
       ByteSize: 24
       GoRuntimeType: 478144
@@ -5622,21 +5622,21 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 205 PointerType *uint
+          Type: 34 PointerType *uint
         - Name: len
           Offset: 8
-          Type: 1 BaseType int
+          Type: 7 BaseType int
         - Name: cap
           Offset: 16
-          Type: 1 BaseType int
+          Type: 7 BaseType int
       Data: 272 GoSliceDataType []uint.array
     - __kind: GoSliceDataType
       ID: 272
       Name: '[]uint.array'
       ByteSize: 2048
-      Element: 20 BaseType uint
+      Element: 16 BaseType uint
     - __kind: GoSliceHeaderType
-      ID: 217
+      ID: 231
       Name: '[]uint16'
       ByteSize: 24
       GoRuntimeType: 477504
@@ -5644,49 +5644,49 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 218 PointerType *uint16
+          Type: 29 PointerType *uint16
         - Name: len
           Offset: 8
-          Type: 1 BaseType int
+          Type: 7 BaseType int
         - Name: cap
           Offset: 16
-          Type: 1 BaseType int
+          Type: 7 BaseType int
       Data: 280 GoSliceDataType []uint16.array
     - __kind: GoSliceDataType
       ID: 280
       Name: '[]uint16.array'
       ByteSize: 2048
-      Element: 22 BaseType uint16
+      Element: 6 BaseType uint16
     - __kind: BaseType
-      ID: 11
+      ID: 4
       Name: bool
       ByteSize: 1
       GoRuntimeType: 576032
       GoKind: 1
     - __kind: GoChannelType
-      ID: 202
+      ID: 218
       Name: chan bool
       GoRuntimeType: 587360
       GoKind: 18
     - __kind: GoChannelType
-      ID: 40
+      ID: 57
       Name: chan struct {}
       GoRuntimeType: 586272
       GoKind: 18
     - __kind: BaseType
-      ID: 229
+      ID: 24
       Name: complex128
       ByteSize: 16
       GoRuntimeType: 575840
       GoKind: 16
     - __kind: BaseType
-      ID: 228
+      ID: 23
       Name: complex64
       ByteSize: 8
       GoRuntimeType: 575776
       GoKind: 15
     - __kind: GoInterfaceType
-      ID: 57
+      ID: 13
       Name: error
       ByteSize: 16
       GoRuntimeType: 1.016416e+06
@@ -5694,228 +5694,228 @@ Types:
       RawFields:
         - Name: tab
           Offset: 0
-          Type: 38 VoidPointerType unsafe.Pointer
+          Type: 14 VoidPointerType unsafe.Pointer
         - Name: data
           Offset: 8
-          Type: 38 VoidPointerType unsafe.Pointer
+          Type: 14 VoidPointerType unsafe.Pointer
     - __kind: BaseType
-      ID: 30
+      ID: 17
       Name: float32
       ByteSize: 4
       GoRuntimeType: 575904
       GoKind: 13
     - __kind: BaseType
-      ID: 31
+      ID: 18
       Name: float64
       ByteSize: 8
       GoRuntimeType: 575968
       GoKind: 14
     - __kind: GoSubroutineType
-      ID: 43
+      ID: 60
       Name: func()
       ByteSize: 8
       GoRuntimeType: 468928
       GoKind: 19
     - __kind: GoSwissMapGroupsType
-      ID: 197
+      ID: 213
       Name: groupReference<[4]int,[4]int>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 198 PointerType *noalg.map.group[[4]int][4]int
+          Type: 214 PointerType *noalg.map.group[[4]int][4]int
         - Name: lengthMask
           Offset: 8
-          Type: 26 BaseType uint64
-      GroupType: 199 StructureType noalg.map.group[[4]int][4]int
+          Type: 8 BaseType uint64
+      GroupType: 215 StructureType noalg.map.group[[4]int][4]int
       GroupSliceType: 269 GoSliceDataType []noalg.map.group[[4]int][4]int.array
     - __kind: GoSwissMapGroupsType
-      ID: 186
+      ID: 202
       Name: groupReference<[4]int,uint8>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 187 PointerType *noalg.map.group[[4]int]uint8
+          Type: 203 PointerType *noalg.map.group[[4]int]uint8
         - Name: lengthMask
           Offset: 8
-          Type: 26 BaseType uint64
-      GroupType: 188 StructureType noalg.map.group[[4]int]uint8
+          Type: 8 BaseType uint64
+      GroupType: 204 StructureType noalg.map.group[[4]int]uint8
       GroupSliceType: 267 GoSliceDataType []noalg.map.group[[4]int]uint8.array
     - __kind: GoSwissMapGroupsType
-      ID: 112
+      ID: 128
       Name: groupReference<[4]string,[2]int>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 113 PointerType *noalg.map.group[[4]string][2]int
+          Type: 129 PointerType *noalg.map.group[[4]string][2]int
         - Name: lengthMask
           Offset: 8
-          Type: 26 BaseType uint64
-      GroupType: 114 StructureType noalg.map.group[[4]string][2]int
+          Type: 8 BaseType uint64
+      GroupType: 130 StructureType noalg.map.group[[4]string][2]int
       GroupSliceType: 253 GoSliceDataType []noalg.map.group[[4]string][2]int.array
     - __kind: GoSwissMapGroupsType
-      ID: 139
+      ID: 155
       Name: groupReference<bool,main.node>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 140 PointerType *noalg.map.group[bool]main.node
+          Type: 156 PointerType *noalg.map.group[bool]main.node
         - Name: lengthMask
           Offset: 8
-          Type: 26 BaseType uint64
-      GroupType: 141 StructureType noalg.map.group[bool]main.node
+          Type: 8 BaseType uint64
+      GroupType: 157 StructureType noalg.map.group[bool]main.node
       GroupSliceType: 259 GoSliceDataType []noalg.map.group[bool]main.node.array
     - __kind: GoSwissMapGroupsType
-      ID: 66
+      ID: 82
       Name: groupReference<int,int>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 67 PointerType *noalg.map.group[int]int
+          Type: 83 PointerType *noalg.map.group[int]int
         - Name: lengthMask
           Offset: 8
-          Type: 26 BaseType uint64
-      GroupType: 68 StructureType noalg.map.group[int]int
+          Type: 8 BaseType uint64
+      GroupType: 84 StructureType noalg.map.group[int]int
       GroupSliceType: 243 GoSliceDataType []noalg.map.group[int]int.array
     - __kind: GoSwissMapGroupsType
-      ID: 152
+      ID: 168
       Name: groupReference<int,uint8>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 153 PointerType *noalg.map.group[int]uint8
+          Type: 169 PointerType *noalg.map.group[int]uint8
         - Name: lengthMask
           Offset: 8
-          Type: 26 BaseType uint64
-      GroupType: 154 StructureType noalg.map.group[int]uint8
+          Type: 8 BaseType uint64
+      GroupType: 170 StructureType noalg.map.group[int]uint8
       GroupSliceType: 261 GoSliceDataType []noalg.map.group[int]uint8.array
     - __kind: GoSwissMapGroupsType
-      ID: 126
+      ID: 142
       Name: groupReference<string,[]main.structWithMap>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 127 PointerType *noalg.map.group[string][]main.structWithMap
+          Type: 143 PointerType *noalg.map.group[string][]main.structWithMap
         - Name: lengthMask
           Offset: 8
-          Type: 26 BaseType uint64
-      GroupType: 128 StructureType noalg.map.group[string][]main.structWithMap
+          Type: 8 BaseType uint64
+      GroupType: 144 StructureType noalg.map.group[string][]main.structWithMap
       GroupSliceType: 255 GoSliceDataType []noalg.map.group[string][]main.structWithMap.array
     - __kind: GoSwissMapGroupsType
-      ID: 100
+      ID: 116
       Name: groupReference<string,[]string>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 101 PointerType *noalg.map.group[string][]string
+          Type: 117 PointerType *noalg.map.group[string][]string
         - Name: lengthMask
           Offset: 8
-          Type: 26 BaseType uint64
-      GroupType: 102 StructureType noalg.map.group[string][]string
+          Type: 8 BaseType uint64
+      GroupType: 118 StructureType noalg.map.group[string][]string
       GroupSliceType: 249 GoSliceDataType []noalg.map.group[string][]string.array
     - __kind: GoSwissMapGroupsType
-      ID: 89
+      ID: 105
       Name: groupReference<string,int>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 90 PointerType *noalg.map.group[string]int
+          Type: 106 PointerType *noalg.map.group[string]int
         - Name: lengthMask
           Offset: 8
-          Type: 26 BaseType uint64
-      GroupType: 91 StructureType noalg.map.group[string]int
+          Type: 8 BaseType uint64
+      GroupType: 107 StructureType noalg.map.group[string]int
       GroupSliceType: 247 GoSliceDataType []noalg.map.group[string]int.array
     - __kind: GoSwissMapGroupsType
-      ID: 77
+      ID: 93
       Name: groupReference<string,main.nestedStruct>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 78 PointerType *noalg.map.group[string]main.nestedStruct
+          Type: 94 PointerType *noalg.map.group[string]main.nestedStruct
         - Name: lengthMask
           Offset: 8
-          Type: 26 BaseType uint64
-      GroupType: 79 StructureType noalg.map.group[string]main.nestedStruct
+          Type: 8 BaseType uint64
+      GroupType: 95 StructureType noalg.map.group[string]main.nestedStruct
       GroupSliceType: 245 GoSliceDataType []noalg.map.group[string]main.nestedStruct.array
     - __kind: GoSwissMapGroupsType
-      ID: 174
+      ID: 190
       Name: groupReference<uint8,[4]int>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 175 PointerType *noalg.map.group[uint8][4]int
+          Type: 191 PointerType *noalg.map.group[uint8][4]int
         - Name: lengthMask
           Offset: 8
-          Type: 26 BaseType uint64
-      GroupType: 176 StructureType noalg.map.group[uint8][4]int
+          Type: 8 BaseType uint64
+      GroupType: 192 StructureType noalg.map.group[uint8][4]int
       GroupSliceType: 265 GoSliceDataType []noalg.map.group[uint8][4]int.array
     - __kind: GoSwissMapGroupsType
-      ID: 163
+      ID: 179
       Name: groupReference<uint8,uint8>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 164 PointerType *noalg.map.group[uint8]uint8
+          Type: 180 PointerType *noalg.map.group[uint8]uint8
         - Name: lengthMask
           Offset: 8
-          Type: 26 BaseType uint64
-      GroupType: 165 StructureType noalg.map.group[uint8]uint8
+          Type: 8 BaseType uint64
+      GroupType: 181 StructureType noalg.map.group[uint8]uint8
       GroupSliceType: 263 GoSliceDataType []noalg.map.group[uint8]uint8.array
     - __kind: BaseType
-      ID: 1
+      ID: 7
       Name: int
       ByteSize: 8
       GoRuntimeType: 575584
       GoKind: 2
     - __kind: BaseType
-      ID: 16
+      ID: 31
       Name: int16
       ByteSize: 2
       GoRuntimeType: 575200
       GoKind: 4
     - __kind: BaseType
-      ID: 6
+      ID: 10
       Name: int32
       ByteSize: 4
       GoRuntimeType: 575328
       GoKind: 5
     - __kind: BaseType
-      ID: 18
+      ID: 12
       Name: int64
       ByteSize: 8
       GoRuntimeType: 575456
       GoKind: 6
     - __kind: BaseType
-      ID: 14
+      ID: 15
       Name: int8
       ByteSize: 1
       GoRuntimeType: 575072
       GoKind: 3
     - __kind: GoEmptyInterfaceType
-      ID: 41
+      ID: 58
       Name: interface {}
       ByteSize: 16
       GoRuntimeType: 838336
@@ -5923,12 +5923,12 @@ Types:
       RawFields:
         - Name: _type
           Offset: 0
-          Type: 38 VoidPointerType unsafe.Pointer
+          Type: 14 VoidPointerType unsafe.Pointer
         - Name: data
           Offset: 8
-          Type: 38 VoidPointerType unsafe.Pointer
+          Type: 14 VoidPointerType unsafe.Pointer
     - __kind: StructureType
-      ID: 48
+      ID: 65
       Name: internal/sync.Mutex
       ByteSize: 8
       GoRuntimeType: 1.454624e+06
@@ -5936,12 +5936,12 @@ Types:
       RawFields:
         - Name: state
           Offset: 0
-          Type: 6 BaseType int32
+          Type: 10 BaseType int32
         - Name: sema
           Offset: 4
-          Type: 24 BaseType uint32
+          Type: 2 BaseType uint32
     - __kind: GoInterfaceType
-      ID: 37
+      ID: 55
       Name: io.Writer
       ByteSize: 16
       GoRuntimeType: 1.012448e+06
@@ -5949,30 +5949,30 @@ Types:
       RawFields:
         - Name: tab
           Offset: 0
-          Type: 38 VoidPointerType unsafe.Pointer
+          Type: 14 VoidPointerType unsafe.Pointer
         - Name: data
           Offset: 8
-          Type: 38 VoidPointerType unsafe.Pointer
+          Type: 14 VoidPointerType unsafe.Pointer
     - __kind: StructureType
-      ID: 223
+      ID: 236
       Name: main.aStruct
       ByteSize: 56
       GoKind: 25
       RawFields:
         - Name: aBool
           Offset: 0
-          Type: 11 BaseType bool
+          Type: 4 BaseType bool
         - Name: aString
           Offset: 8
-          Type: 8 GoStringHeaderType string
+          Type: 9 GoStringHeaderType string
         - Name: aNumber
           Offset: 24
-          Type: 1 BaseType int
+          Type: 7 BaseType int
         - Name: nested
           Offset: 32
-          Type: 82 StructureType main.nestedStruct
+          Type: 98 StructureType main.nestedStruct
     - __kind: GoInterfaceType
-      ID: 56
+      ID: 74
       Name: main.behavior
       ByteSize: 16
       GoRuntimeType: 1.012064e+06
@@ -5980,32 +5980,32 @@ Types:
       RawFields:
         - Name: tab
           Offset: 0
-          Type: 38 VoidPointerType unsafe.Pointer
+          Type: 14 VoidPointerType unsafe.Pointer
         - Name: data
           Offset: 8
-          Type: 38 VoidPointerType unsafe.Pointer
+          Type: 14 VoidPointerType unsafe.Pointer
     - __kind: StructureType
-      ID: 33
+      ID: 52
       Name: main.bigStruct
       ByteSize: 48
       GoKind: 25
       RawFields:
         - Name: x
           Offset: 0
-          Type: 34 GoSliceHeaderType []*string
+          Type: 53 GoSliceHeaderType []*string
         - Name: z
           Offset: 24
-          Type: 1 BaseType int
+          Type: 7 BaseType int
         - Name: writer
           Offset: 32
-          Type: 37 GoInterfaceType io.Writer
+          Type: 55 GoInterfaceType io.Writer
     - __kind: StructureType
-      ID: 224
+      ID: 237
       Name: main.emptyStruct
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 45
+      ID: 62
       Name: main.esotericHeap
       ByteSize: 112
       GoRuntimeType: 1.81168e+06
@@ -6013,21 +6013,21 @@ Types:
       RawFields:
         - Name: esotericStack
           Offset: 0
-          Type: 39 StructureType main.esotericStack
+          Type: 56 StructureType main.esotericStack
         - Name: mu
           Offset: 64
-          Type: 46 StructureType sync.Mutex
+          Type: 63 StructureType sync.Mutex
         - Name: once
           Offset: 72
-          Type: 49 StructureType sync.Once
+          Type: 66 StructureType sync.Once
         - Name: wg
           Offset: 88
-          Type: 52 StructureType sync.WaitGroup
+          Type: 69 StructureType sync.WaitGroup
         - Name: a
           Offset: 104
-          Type: 55 StructureType sync/atomic.Int32
+          Type: 72 StructureType sync/atomic.Int32
     - __kind: StructureType
-      ID: 39
+      ID: 56
       Name: main.esotericStack
       ByteSize: 64
       GoRuntimeType: 1.945504e+06
@@ -6035,27 +6035,27 @@ Types:
       RawFields:
         - Name: _
           Offset: 0
-          Type: 6 BaseType int32
+          Type: 10 BaseType int32
         - Name: _valid
           Offset: 4
-          Type: 6 BaseType int32
+          Type: 10 BaseType int32
         - Name: c
           Offset: 8
-          Type: 40 GoChannelType chan struct {}
+          Type: 57 GoChannelType chan struct {}
         - Name: val
           Offset: 16
-          Type: 41 GoEmptyInterfaceType interface {}
+          Type: 58 GoEmptyInterfaceType interface {}
         - Name: _
           Offset: 32
-          Type: 26 BaseType uint64
+          Type: 8 BaseType uint64
         - Name: work
           Offset: 40
-          Type: 42 GoInterfaceType main.something
+          Type: 59 GoInterfaceType main.something
         - Name: foo
           Offset: 56
-          Type: 43 GoSubroutineType func()
+          Type: 60 GoSubroutineType func()
     - __kind: StructureType
-      ID: 82
+      ID: 98
       Name: main.nestedStruct
       ByteSize: 24
       GoRuntimeType: 1.444064e+06
@@ -6063,12 +6063,12 @@ Types:
       RawFields:
         - Name: anotherInt
           Offset: 0
-          Type: 1 BaseType int
+          Type: 7 BaseType int
         - Name: anotherString
           Offset: 8
-          Type: 8 GoStringHeaderType string
+          Type: 9 GoStringHeaderType string
     - __kind: StructureType
-      ID: 144
+      ID: 160
       Name: main.node
       ByteSize: 16
       GoRuntimeType: 1.443904e+06
@@ -6076,21 +6076,21 @@ Types:
       RawFields:
         - Name: val
           Offset: 0
-          Type: 1 BaseType int
+          Type: 7 BaseType int
         - Name: b
           Offset: 8
-          Type: 145 PointerType *main.node
+          Type: 161 PointerType *main.node
     - __kind: StructureType
-      ID: 222
+      ID: 235
       Name: main.oneStringStruct
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: a
           Offset: 0
-          Type: 8 GoStringHeaderType string
+          Type: 9 GoStringHeaderType string
     - __kind: GoInterfaceType
-      ID: 42
+      ID: 59
       Name: main.something
       ByteSize: 16
       GoRuntimeType: 1.012192e+06
@@ -6098,12 +6098,12 @@ Types:
       RawFields:
         - Name: tab
           Offset: 0
-          Type: 38 VoidPointerType unsafe.Pointer
+          Type: 14 VoidPointerType unsafe.Pointer
         - Name: data
           Offset: 8
-          Type: 38 VoidPointerType unsafe.Pointer
+          Type: 14 VoidPointerType unsafe.Pointer
     - __kind: StructureType
-      ID: 58
+      ID: 75
       Name: main.structWithMap
       ByteSize: 8
       GoRuntimeType: 1.173504e+06
@@ -6111,650 +6111,650 @@ Types:
       RawFields:
         - Name: m
           Offset: 0
-          Type: 59 GoMapType map[int]int
+          Type: 76 GoMapType map[int]int
     - __kind: StructureType
-      ID: 215
+      ID: 229
       Name: main.structWithNoStrings
       ByteSize: 2
       GoKind: 25
       RawFields:
         - Name: aUint8
           Offset: 0
-          Type: 4 BaseType uint8
+          Type: 3 BaseType uint8
         - Name: aBool
           Offset: 1
-          Type: 11 BaseType bool
+          Type: 4 BaseType bool
     - __kind: StructureType
-      ID: 204
+      ID: 220
       Name: main.structWithTwoValues
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: a
           Offset: 0
-          Type: 20 BaseType uint
+          Type: 16 BaseType uint
         - Name: b
           Offset: 8
-          Type: 11 BaseType bool
+          Type: 4 BaseType bool
     - __kind: GoSliceHeaderType
-      ID: 208
+      ID: 222
       Name: main.t
       ByteSize: 24
       GoKind: 23
       RawFields:
         - Name: array
           Offset: 0
-          Type: 209 PointerType **main.t
+          Type: 223 PointerType **main.t
         - Name: len
           Offset: 8
-          Type: 1 BaseType int
+          Type: 7 BaseType int
         - Name: cap
           Offset: 16
-          Type: 1 BaseType int
+          Type: 7 BaseType int
       Data: 270 GoSliceDataType main.t.array
     - __kind: GoSliceDataType
       ID: 270
       Name: main.t.array
       ByteSize: 2048
-      Element: 207 PointerType *main.t
+      Element: 221 PointerType *main.t
     - __kind: StructureType
-      ID: 219
+      ID: 232
       Name: main.threeStringStruct
       ByteSize: 48
       GoKind: 25
       RawFields:
         - Name: a
           Offset: 0
-          Type: 8 GoStringHeaderType string
+          Type: 9 GoStringHeaderType string
         - Name: b
           Offset: 16
-          Type: 8 GoStringHeaderType string
+          Type: 9 GoStringHeaderType string
         - Name: c
           Offset: 32
-          Type: 8 GoStringHeaderType string
+          Type: 9 GoStringHeaderType string
     - __kind: BaseType
-      ID: 32
+      ID: 51
       Name: main.typeAlias
       ByteSize: 2
       GoKind: 9
     - __kind: GoSwissMapHeaderType
-      ID: 193
+      ID: 209
       Name: map<[4]int,[4]int>
       ByteSize: 48
       GoKind: 25
       RawFields:
         - Name: used
           Offset: 0
-          Type: 26 BaseType uint64
+          Type: 8 BaseType uint64
         - Name: seed
           Offset: 8
-          Type: 62 BaseType uintptr
+          Type: 1 BaseType uintptr
         - Name: dirPtr
           Offset: 16
-          Type: 194 PointerType **table<[4]int,[4]int>
+          Type: 210 PointerType **table<[4]int,[4]int>
         - Name: dirLen
           Offset: 24
-          Type: 1 BaseType int
+          Type: 7 BaseType int
         - Name: globalDepth
           Offset: 32
-          Type: 4 BaseType uint8
+          Type: 3 BaseType uint8
         - Name: globalShift
           Offset: 33
-          Type: 4 BaseType uint8
+          Type: 3 BaseType uint8
         - Name: writing
           Offset: 34
-          Type: 4 BaseType uint8
+          Type: 3 BaseType uint8
         - Name: clearSeq
           Offset: 40
-          Type: 26 BaseType uint64
+          Type: 8 BaseType uint64
       TablePtrSliceType: 268 GoSliceDataType []*table<[4]int,[4]int>.array
-      GroupType: 199 StructureType noalg.map.group[[4]int][4]int
+      GroupType: 215 StructureType noalg.map.group[[4]int][4]int
     - __kind: GoSwissMapHeaderType
-      ID: 182
+      ID: 198
       Name: map<[4]int,uint8>
       ByteSize: 48
       GoKind: 25
       RawFields:
         - Name: used
           Offset: 0
-          Type: 26 BaseType uint64
+          Type: 8 BaseType uint64
         - Name: seed
           Offset: 8
-          Type: 62 BaseType uintptr
+          Type: 1 BaseType uintptr
         - Name: dirPtr
           Offset: 16
-          Type: 183 PointerType **table<[4]int,uint8>
+          Type: 199 PointerType **table<[4]int,uint8>
         - Name: dirLen
           Offset: 24
-          Type: 1 BaseType int
+          Type: 7 BaseType int
         - Name: globalDepth
           Offset: 32
-          Type: 4 BaseType uint8
+          Type: 3 BaseType uint8
         - Name: globalShift
           Offset: 33
-          Type: 4 BaseType uint8
+          Type: 3 BaseType uint8
         - Name: writing
           Offset: 34
-          Type: 4 BaseType uint8
+          Type: 3 BaseType uint8
         - Name: clearSeq
           Offset: 40
-          Type: 26 BaseType uint64
+          Type: 8 BaseType uint64
       TablePtrSliceType: 266 GoSliceDataType []*table<[4]int,uint8>.array
-      GroupType: 188 StructureType noalg.map.group[[4]int]uint8
+      GroupType: 204 StructureType noalg.map.group[[4]int]uint8
     - __kind: GoSwissMapHeaderType
-      ID: 108
+      ID: 124
       Name: map<[4]string,[2]int>
       ByteSize: 48
       GoKind: 25
       RawFields:
         - Name: used
           Offset: 0
-          Type: 26 BaseType uint64
+          Type: 8 BaseType uint64
         - Name: seed
           Offset: 8
-          Type: 62 BaseType uintptr
+          Type: 1 BaseType uintptr
         - Name: dirPtr
           Offset: 16
-          Type: 109 PointerType **table<[4]string,[2]int>
+          Type: 125 PointerType **table<[4]string,[2]int>
         - Name: dirLen
           Offset: 24
-          Type: 1 BaseType int
+          Type: 7 BaseType int
         - Name: globalDepth
           Offset: 32
-          Type: 4 BaseType uint8
+          Type: 3 BaseType uint8
         - Name: globalShift
           Offset: 33
-          Type: 4 BaseType uint8
+          Type: 3 BaseType uint8
         - Name: writing
           Offset: 34
-          Type: 4 BaseType uint8
+          Type: 3 BaseType uint8
         - Name: clearSeq
           Offset: 40
-          Type: 26 BaseType uint64
+          Type: 8 BaseType uint64
       TablePtrSliceType: 252 GoSliceDataType []*table<[4]string,[2]int>.array
-      GroupType: 114 StructureType noalg.map.group[[4]string][2]int
+      GroupType: 130 StructureType noalg.map.group[[4]string][2]int
     - __kind: GoSwissMapHeaderType
-      ID: 135
+      ID: 151
       Name: map<bool,main.node>
       ByteSize: 48
       GoKind: 25
       RawFields:
         - Name: used
           Offset: 0
-          Type: 26 BaseType uint64
+          Type: 8 BaseType uint64
         - Name: seed
           Offset: 8
-          Type: 62 BaseType uintptr
+          Type: 1 BaseType uintptr
         - Name: dirPtr
           Offset: 16
-          Type: 136 PointerType **table<bool,main.node>
+          Type: 152 PointerType **table<bool,main.node>
         - Name: dirLen
           Offset: 24
-          Type: 1 BaseType int
+          Type: 7 BaseType int
         - Name: globalDepth
           Offset: 32
-          Type: 4 BaseType uint8
+          Type: 3 BaseType uint8
         - Name: globalShift
           Offset: 33
-          Type: 4 BaseType uint8
+          Type: 3 BaseType uint8
         - Name: writing
           Offset: 34
-          Type: 4 BaseType uint8
+          Type: 3 BaseType uint8
         - Name: clearSeq
           Offset: 40
-          Type: 26 BaseType uint64
+          Type: 8 BaseType uint64
       TablePtrSliceType: 258 GoSliceDataType []*table<bool,main.node>.array
-      GroupType: 141 StructureType noalg.map.group[bool]main.node
+      GroupType: 157 StructureType noalg.map.group[bool]main.node
     - __kind: GoSwissMapHeaderType
-      ID: 61
+      ID: 78
       Name: map<int,int>
       ByteSize: 48
       GoKind: 25
       RawFields:
         - Name: used
           Offset: 0
-          Type: 26 BaseType uint64
+          Type: 8 BaseType uint64
         - Name: seed
           Offset: 8
-          Type: 62 BaseType uintptr
+          Type: 1 BaseType uintptr
         - Name: dirPtr
           Offset: 16
-          Type: 63 PointerType **table<int,int>
+          Type: 79 PointerType **table<int,int>
         - Name: dirLen
           Offset: 24
-          Type: 1 BaseType int
+          Type: 7 BaseType int
         - Name: globalDepth
           Offset: 32
-          Type: 4 BaseType uint8
+          Type: 3 BaseType uint8
         - Name: globalShift
           Offset: 33
-          Type: 4 BaseType uint8
+          Type: 3 BaseType uint8
         - Name: writing
           Offset: 34
-          Type: 4 BaseType uint8
+          Type: 3 BaseType uint8
         - Name: clearSeq
           Offset: 40
-          Type: 26 BaseType uint64
+          Type: 8 BaseType uint64
       TablePtrSliceType: 242 GoSliceDataType []*table<int,int>.array
-      GroupType: 68 StructureType noalg.map.group[int]int
+      GroupType: 84 StructureType noalg.map.group[int]int
     - __kind: GoSwissMapHeaderType
-      ID: 148
+      ID: 164
       Name: map<int,uint8>
       ByteSize: 48
       GoKind: 25
       RawFields:
         - Name: used
           Offset: 0
-          Type: 26 BaseType uint64
+          Type: 8 BaseType uint64
         - Name: seed
           Offset: 8
-          Type: 62 BaseType uintptr
+          Type: 1 BaseType uintptr
         - Name: dirPtr
           Offset: 16
-          Type: 149 PointerType **table<int,uint8>
+          Type: 165 PointerType **table<int,uint8>
         - Name: dirLen
           Offset: 24
-          Type: 1 BaseType int
+          Type: 7 BaseType int
         - Name: globalDepth
           Offset: 32
-          Type: 4 BaseType uint8
+          Type: 3 BaseType uint8
         - Name: globalShift
           Offset: 33
-          Type: 4 BaseType uint8
+          Type: 3 BaseType uint8
         - Name: writing
           Offset: 34
-          Type: 4 BaseType uint8
+          Type: 3 BaseType uint8
         - Name: clearSeq
           Offset: 40
-          Type: 26 BaseType uint64
+          Type: 8 BaseType uint64
       TablePtrSliceType: 260 GoSliceDataType []*table<int,uint8>.array
-      GroupType: 154 StructureType noalg.map.group[int]uint8
+      GroupType: 170 StructureType noalg.map.group[int]uint8
     - __kind: GoSwissMapHeaderType
-      ID: 122
+      ID: 138
       Name: map<string,[]main.structWithMap>
       ByteSize: 48
       GoKind: 25
       RawFields:
         - Name: used
           Offset: 0
-          Type: 26 BaseType uint64
+          Type: 8 BaseType uint64
         - Name: seed
           Offset: 8
-          Type: 62 BaseType uintptr
+          Type: 1 BaseType uintptr
         - Name: dirPtr
           Offset: 16
-          Type: 123 PointerType **table<string,[]main.structWithMap>
+          Type: 139 PointerType **table<string,[]main.structWithMap>
         - Name: dirLen
           Offset: 24
-          Type: 1 BaseType int
+          Type: 7 BaseType int
         - Name: globalDepth
           Offset: 32
-          Type: 4 BaseType uint8
+          Type: 3 BaseType uint8
         - Name: globalShift
           Offset: 33
-          Type: 4 BaseType uint8
+          Type: 3 BaseType uint8
         - Name: writing
           Offset: 34
-          Type: 4 BaseType uint8
+          Type: 3 BaseType uint8
         - Name: clearSeq
           Offset: 40
-          Type: 26 BaseType uint64
+          Type: 8 BaseType uint64
       TablePtrSliceType: 254 GoSliceDataType []*table<string,[]main.structWithMap>.array
-      GroupType: 128 StructureType noalg.map.group[string][]main.structWithMap
+      GroupType: 144 StructureType noalg.map.group[string][]main.structWithMap
     - __kind: GoSwissMapHeaderType
-      ID: 96
+      ID: 112
       Name: map<string,[]string>
       ByteSize: 48
       GoKind: 25
       RawFields:
         - Name: used
           Offset: 0
-          Type: 26 BaseType uint64
+          Type: 8 BaseType uint64
         - Name: seed
           Offset: 8
-          Type: 62 BaseType uintptr
+          Type: 1 BaseType uintptr
         - Name: dirPtr
           Offset: 16
-          Type: 97 PointerType **table<string,[]string>
+          Type: 113 PointerType **table<string,[]string>
         - Name: dirLen
           Offset: 24
-          Type: 1 BaseType int
+          Type: 7 BaseType int
         - Name: globalDepth
           Offset: 32
-          Type: 4 BaseType uint8
+          Type: 3 BaseType uint8
         - Name: globalShift
           Offset: 33
-          Type: 4 BaseType uint8
+          Type: 3 BaseType uint8
         - Name: writing
           Offset: 34
-          Type: 4 BaseType uint8
+          Type: 3 BaseType uint8
         - Name: clearSeq
           Offset: 40
-          Type: 26 BaseType uint64
+          Type: 8 BaseType uint64
       TablePtrSliceType: 248 GoSliceDataType []*table<string,[]string>.array
-      GroupType: 102 StructureType noalg.map.group[string][]string
+      GroupType: 118 StructureType noalg.map.group[string][]string
     - __kind: GoSwissMapHeaderType
-      ID: 85
+      ID: 101
       Name: map<string,int>
       ByteSize: 48
       GoKind: 25
       RawFields:
         - Name: used
           Offset: 0
-          Type: 26 BaseType uint64
+          Type: 8 BaseType uint64
         - Name: seed
           Offset: 8
-          Type: 62 BaseType uintptr
+          Type: 1 BaseType uintptr
         - Name: dirPtr
           Offset: 16
-          Type: 86 PointerType **table<string,int>
+          Type: 102 PointerType **table<string,int>
         - Name: dirLen
           Offset: 24
-          Type: 1 BaseType int
+          Type: 7 BaseType int
         - Name: globalDepth
           Offset: 32
-          Type: 4 BaseType uint8
+          Type: 3 BaseType uint8
         - Name: globalShift
           Offset: 33
-          Type: 4 BaseType uint8
+          Type: 3 BaseType uint8
         - Name: writing
           Offset: 34
-          Type: 4 BaseType uint8
+          Type: 3 BaseType uint8
         - Name: clearSeq
           Offset: 40
-          Type: 26 BaseType uint64
+          Type: 8 BaseType uint64
       TablePtrSliceType: 246 GoSliceDataType []*table<string,int>.array
-      GroupType: 91 StructureType noalg.map.group[string]int
+      GroupType: 107 StructureType noalg.map.group[string]int
     - __kind: GoSwissMapHeaderType
-      ID: 73
+      ID: 89
       Name: map<string,main.nestedStruct>
       ByteSize: 48
       GoKind: 25
       RawFields:
         - Name: used
           Offset: 0
-          Type: 26 BaseType uint64
+          Type: 8 BaseType uint64
         - Name: seed
           Offset: 8
-          Type: 62 BaseType uintptr
+          Type: 1 BaseType uintptr
         - Name: dirPtr
           Offset: 16
-          Type: 74 PointerType **table<string,main.nestedStruct>
+          Type: 90 PointerType **table<string,main.nestedStruct>
         - Name: dirLen
           Offset: 24
-          Type: 1 BaseType int
+          Type: 7 BaseType int
         - Name: globalDepth
           Offset: 32
-          Type: 4 BaseType uint8
+          Type: 3 BaseType uint8
         - Name: globalShift
           Offset: 33
-          Type: 4 BaseType uint8
+          Type: 3 BaseType uint8
         - Name: writing
           Offset: 34
-          Type: 4 BaseType uint8
+          Type: 3 BaseType uint8
         - Name: clearSeq
           Offset: 40
-          Type: 26 BaseType uint64
+          Type: 8 BaseType uint64
       TablePtrSliceType: 244 GoSliceDataType []*table<string,main.nestedStruct>.array
-      GroupType: 79 StructureType noalg.map.group[string]main.nestedStruct
+      GroupType: 95 StructureType noalg.map.group[string]main.nestedStruct
     - __kind: GoSwissMapHeaderType
-      ID: 170
+      ID: 186
       Name: map<uint8,[4]int>
       ByteSize: 48
       GoKind: 25
       RawFields:
         - Name: used
           Offset: 0
-          Type: 26 BaseType uint64
+          Type: 8 BaseType uint64
         - Name: seed
           Offset: 8
-          Type: 62 BaseType uintptr
+          Type: 1 BaseType uintptr
         - Name: dirPtr
           Offset: 16
-          Type: 171 PointerType **table<uint8,[4]int>
+          Type: 187 PointerType **table<uint8,[4]int>
         - Name: dirLen
           Offset: 24
-          Type: 1 BaseType int
+          Type: 7 BaseType int
         - Name: globalDepth
           Offset: 32
-          Type: 4 BaseType uint8
+          Type: 3 BaseType uint8
         - Name: globalShift
           Offset: 33
-          Type: 4 BaseType uint8
+          Type: 3 BaseType uint8
         - Name: writing
           Offset: 34
-          Type: 4 BaseType uint8
+          Type: 3 BaseType uint8
         - Name: clearSeq
           Offset: 40
-          Type: 26 BaseType uint64
+          Type: 8 BaseType uint64
       TablePtrSliceType: 264 GoSliceDataType []*table<uint8,[4]int>.array
-      GroupType: 176 StructureType noalg.map.group[uint8][4]int
+      GroupType: 192 StructureType noalg.map.group[uint8][4]int
     - __kind: GoSwissMapHeaderType
-      ID: 159
+      ID: 175
       Name: map<uint8,uint8>
       ByteSize: 48
       GoKind: 25
       RawFields:
         - Name: used
           Offset: 0
-          Type: 26 BaseType uint64
+          Type: 8 BaseType uint64
         - Name: seed
           Offset: 8
-          Type: 62 BaseType uintptr
+          Type: 1 BaseType uintptr
         - Name: dirPtr
           Offset: 16
-          Type: 160 PointerType **table<uint8,uint8>
+          Type: 176 PointerType **table<uint8,uint8>
         - Name: dirLen
           Offset: 24
-          Type: 1 BaseType int
+          Type: 7 BaseType int
         - Name: globalDepth
           Offset: 32
-          Type: 4 BaseType uint8
+          Type: 3 BaseType uint8
         - Name: globalShift
           Offset: 33
-          Type: 4 BaseType uint8
+          Type: 3 BaseType uint8
         - Name: writing
           Offset: 34
-          Type: 4 BaseType uint8
+          Type: 3 BaseType uint8
         - Name: clearSeq
           Offset: 40
-          Type: 26 BaseType uint64
+          Type: 8 BaseType uint64
       TablePtrSliceType: 262 GoSliceDataType []*table<uint8,uint8>.array
-      GroupType: 165 StructureType noalg.map.group[uint8]uint8
+      GroupType: 181 StructureType noalg.map.group[uint8]uint8
     - __kind: GoMapType
-      ID: 191
+      ID: 207
       Name: map[[4]int][4]int
       ByteSize: 8
       GoRuntimeType: 1.117568e+06
       GoKind: 21
-      HeaderType: 193 GoSwissMapHeaderType map<[4]int,[4]int>
+      HeaderType: 209 GoSwissMapHeaderType map<[4]int,[4]int>
     - __kind: GoMapType
-      ID: 180
+      ID: 196
       Name: map[[4]int]uint8
       ByteSize: 8
       GoRuntimeType: 1.117696e+06
       GoKind: 21
-      HeaderType: 182 GoSwissMapHeaderType map<[4]int,uint8>
+      HeaderType: 198 GoSwissMapHeaderType map<[4]int,uint8>
     - __kind: GoMapType
-      ID: 106
+      ID: 122
       Name: map[[4]string][2]int
       ByteSize: 8
       GoRuntimeType: 1.117824e+06
       GoKind: 21
-      HeaderType: 108 GoSwissMapHeaderType map<[4]string,[2]int>
+      HeaderType: 124 GoSwissMapHeaderType map<[4]string,[2]int>
     - __kind: GoMapType
-      ID: 133
+      ID: 149
       Name: map[bool]main.node
       ByteSize: 8
       GoRuntimeType: 1.117952e+06
       GoKind: 21
-      HeaderType: 135 GoSwissMapHeaderType map<bool,main.node>
+      HeaderType: 151 GoSwissMapHeaderType map<bool,main.node>
     - __kind: GoMapType
-      ID: 59
+      ID: 76
       Name: map[int]int
       ByteSize: 8
       GoRuntimeType: 1.117184e+06
       GoKind: 21
-      HeaderType: 61 GoSwissMapHeaderType map<int,int>
+      HeaderType: 78 GoSwissMapHeaderType map<int,int>
     - __kind: GoMapType
-      ID: 146
+      ID: 162
       Name: map[int]uint8
       ByteSize: 8
       GoRuntimeType: 1.11808e+06
       GoKind: 21
-      HeaderType: 148 GoSwissMapHeaderType map<int,uint8>
+      HeaderType: 164 GoSwissMapHeaderType map<int,uint8>
     - __kind: GoMapType
-      ID: 120
+      ID: 136
       Name: map[string][]main.structWithMap
       ByteSize: 8
       GoRuntimeType: 1.118208e+06
       GoKind: 21
-      HeaderType: 122 GoSwissMapHeaderType map<string,[]main.structWithMap>
+      HeaderType: 138 GoSwissMapHeaderType map<string,[]main.structWithMap>
     - __kind: GoMapType
-      ID: 94
+      ID: 110
       Name: map[string][]string
       ByteSize: 8
       GoRuntimeType: 1.118336e+06
       GoKind: 21
-      HeaderType: 96 GoSwissMapHeaderType map<string,[]string>
+      HeaderType: 112 GoSwissMapHeaderType map<string,[]string>
     - __kind: GoMapType
-      ID: 83
+      ID: 99
       Name: map[string]int
       ByteSize: 8
       GoRuntimeType: 1.118464e+06
       GoKind: 21
-      HeaderType: 85 GoSwissMapHeaderType map<string,int>
+      HeaderType: 101 GoSwissMapHeaderType map<string,int>
     - __kind: GoMapType
-      ID: 71
+      ID: 87
       Name: map[string]main.nestedStruct
       ByteSize: 8
       GoRuntimeType: 1.118592e+06
       GoKind: 21
-      HeaderType: 73 GoSwissMapHeaderType map<string,main.nestedStruct>
+      HeaderType: 89 GoSwissMapHeaderType map<string,main.nestedStruct>
     - __kind: GoMapType
-      ID: 168
+      ID: 184
       Name: map[uint8][4]int
       ByteSize: 8
       GoRuntimeType: 1.11872e+06
       GoKind: 21
-      HeaderType: 170 GoSwissMapHeaderType map<uint8,[4]int>
+      HeaderType: 186 GoSwissMapHeaderType map<uint8,[4]int>
     - __kind: GoMapType
-      ID: 157
+      ID: 173
       Name: map[uint8]uint8
       ByteSize: 8
       GoRuntimeType: 1.118848e+06
       GoKind: 21
-      HeaderType: 159 GoSwissMapHeaderType map<uint8,uint8>
+      HeaderType: 175 GoSwissMapHeaderType map<uint8,uint8>
     - __kind: ArrayType
-      ID: 200
+      ID: 216
       Name: noalg.[8]struct { key [4]int; elem [4]int }
       ByteSize: 512
       GoRuntimeType: 672992
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 201 StructureType noalg.struct { key [4]int; elem [4]int }
+      Element: 217 StructureType noalg.struct { key [4]int; elem [4]int }
     - __kind: ArrayType
-      ID: 189
+      ID: 205
       Name: noalg.[8]struct { key [4]int; elem uint8 }
       ByteSize: 320
       GoRuntimeType: 673088
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 190 StructureType noalg.struct { key [4]int; elem uint8 }
+      Element: 206 StructureType noalg.struct { key [4]int; elem uint8 }
     - __kind: ArrayType
-      ID: 115
+      ID: 131
       Name: noalg.[8]struct { key [4]string; elem [2]int }
       ByteSize: 640
       GoRuntimeType: 673376
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 116 StructureType noalg.struct { key [4]string; elem [2]int }
+      Element: 132 StructureType noalg.struct { key [4]string; elem [2]int }
     - __kind: ArrayType
-      ID: 142
+      ID: 158
       Name: noalg.[8]struct { key bool; elem main.node }
       ByteSize: 192
       GoRuntimeType: 673472
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 143 StructureType noalg.struct { key bool; elem main.node }
+      Element: 159 StructureType noalg.struct { key bool; elem main.node }
     - __kind: ArrayType
-      ID: 69
+      ID: 85
       Name: noalg.[8]struct { key int; elem int }
       ByteSize: 128
       GoRuntimeType: 671264
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 70 StructureType noalg.struct { key int; elem int }
+      Element: 86 StructureType noalg.struct { key int; elem int }
     - __kind: ArrayType
-      ID: 155
+      ID: 171
       Name: noalg.[8]struct { key int; elem uint8 }
       ByteSize: 128
       GoRuntimeType: 673568
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 156 StructureType noalg.struct { key int; elem uint8 }
+      Element: 172 StructureType noalg.struct { key int; elem uint8 }
     - __kind: ArrayType
-      ID: 129
+      ID: 145
       Name: noalg.[8]struct { key string; elem []main.structWithMap }
       ByteSize: 320
       GoRuntimeType: 673664
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 130 StructureType noalg.struct { key string; elem []main.structWithMap }
+      Element: 146 StructureType noalg.struct { key string; elem []main.structWithMap }
     - __kind: ArrayType
-      ID: 103
+      ID: 119
       Name: noalg.[8]struct { key string; elem []string }
       ByteSize: 320
       GoRuntimeType: 673760
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 104 StructureType noalg.struct { key string; elem []string }
+      Element: 120 StructureType noalg.struct { key string; elem []string }
     - __kind: ArrayType
-      ID: 92
+      ID: 108
       Name: noalg.[8]struct { key string; elem int }
       ByteSize: 192
       GoRuntimeType: 673856
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 93 StructureType noalg.struct { key string; elem int }
+      Element: 109 StructureType noalg.struct { key string; elem int }
     - __kind: ArrayType
-      ID: 80
+      ID: 96
       Name: noalg.[8]struct { key string; elem main.nestedStruct }
       ByteSize: 320
       GoRuntimeType: 673952
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 81 StructureType noalg.struct { key string; elem main.nestedStruct }
+      Element: 97 StructureType noalg.struct { key string; elem main.nestedStruct }
     - __kind: ArrayType
-      ID: 177
+      ID: 193
       Name: noalg.[8]struct { key uint8; elem [4]int }
       ByteSize: 320
       GoRuntimeType: 674048
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 178 StructureType noalg.struct { key uint8; elem [4]int }
+      Element: 194 StructureType noalg.struct { key uint8; elem [4]int }
     - __kind: ArrayType
-      ID: 166
+      ID: 182
       Name: noalg.[8]struct { key uint8; elem uint8 }
       ByteSize: 16
       GoRuntimeType: 674144
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 167 StructureType noalg.struct { key uint8; elem uint8 }
+      Element: 183 StructureType noalg.struct { key uint8; elem uint8 }
     - __kind: StructureType
-      ID: 199
+      ID: 215
       Name: noalg.map.group[[4]int][4]int
       ByteSize: 520
       GoRuntimeType: 1.277248e+06
@@ -6762,12 +6762,12 @@ Types:
       RawFields:
         - Name: ctrl
           Offset: 0
-          Type: 26 BaseType uint64
+          Type: 8 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 200 ArrayType noalg.[8]struct { key [4]int; elem [4]int }
+          Type: 216 ArrayType noalg.[8]struct { key [4]int; elem [4]int }
     - __kind: StructureType
-      ID: 188
+      ID: 204
       Name: noalg.map.group[[4]int]uint8
       ByteSize: 328
       GoRuntimeType: 1.277504e+06
@@ -6775,12 +6775,12 @@ Types:
       RawFields:
         - Name: ctrl
           Offset: 0
-          Type: 26 BaseType uint64
+          Type: 8 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 189 ArrayType noalg.[8]struct { key [4]int; elem uint8 }
+          Type: 205 ArrayType noalg.[8]struct { key [4]int; elem uint8 }
     - __kind: StructureType
-      ID: 114
+      ID: 130
       Name: noalg.map.group[[4]string][2]int
       ByteSize: 648
       GoRuntimeType: 1.27776e+06
@@ -6788,12 +6788,12 @@ Types:
       RawFields:
         - Name: ctrl
           Offset: 0
-          Type: 26 BaseType uint64
+          Type: 8 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 115 ArrayType noalg.[8]struct { key [4]string; elem [2]int }
+          Type: 131 ArrayType noalg.[8]struct { key [4]string; elem [2]int }
     - __kind: StructureType
-      ID: 141
+      ID: 157
       Name: noalg.map.group[bool]main.node
       ByteSize: 200
       GoRuntimeType: 1.278016e+06
@@ -6801,12 +6801,12 @@ Types:
       RawFields:
         - Name: ctrl
           Offset: 0
-          Type: 26 BaseType uint64
+          Type: 8 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 142 ArrayType noalg.[8]struct { key bool; elem main.node }
+          Type: 158 ArrayType noalg.[8]struct { key bool; elem main.node }
     - __kind: StructureType
-      ID: 68
+      ID: 84
       Name: noalg.map.group[int]int
       ByteSize: 136
       GoRuntimeType: 1.27648e+06
@@ -6814,12 +6814,12 @@ Types:
       RawFields:
         - Name: ctrl
           Offset: 0
-          Type: 26 BaseType uint64
+          Type: 8 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 69 ArrayType noalg.[8]struct { key int; elem int }
+          Type: 85 ArrayType noalg.[8]struct { key int; elem int }
     - __kind: StructureType
-      ID: 154
+      ID: 170
       Name: noalg.map.group[int]uint8
       ByteSize: 136
       GoRuntimeType: 1.278272e+06
@@ -6827,12 +6827,12 @@ Types:
       RawFields:
         - Name: ctrl
           Offset: 0
-          Type: 26 BaseType uint64
+          Type: 8 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 155 ArrayType noalg.[8]struct { key int; elem uint8 }
+          Type: 171 ArrayType noalg.[8]struct { key int; elem uint8 }
     - __kind: StructureType
-      ID: 128
+      ID: 144
       Name: noalg.map.group[string][]main.structWithMap
       ByteSize: 328
       GoRuntimeType: 1.278528e+06
@@ -6840,12 +6840,12 @@ Types:
       RawFields:
         - Name: ctrl
           Offset: 0
-          Type: 26 BaseType uint64
+          Type: 8 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 129 ArrayType noalg.[8]struct { key string; elem []main.structWithMap }
+          Type: 145 ArrayType noalg.[8]struct { key string; elem []main.structWithMap }
     - __kind: StructureType
-      ID: 102
+      ID: 118
       Name: noalg.map.group[string][]string
       ByteSize: 328
       GoRuntimeType: 1.278784e+06
@@ -6853,12 +6853,12 @@ Types:
       RawFields:
         - Name: ctrl
           Offset: 0
-          Type: 26 BaseType uint64
+          Type: 8 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 103 ArrayType noalg.[8]struct { key string; elem []string }
+          Type: 119 ArrayType noalg.[8]struct { key string; elem []string }
     - __kind: StructureType
-      ID: 91
+      ID: 107
       Name: noalg.map.group[string]int
       ByteSize: 200
       GoRuntimeType: 1.27904e+06
@@ -6866,12 +6866,12 @@ Types:
       RawFields:
         - Name: ctrl
           Offset: 0
-          Type: 26 BaseType uint64
+          Type: 8 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 92 ArrayType noalg.[8]struct { key string; elem int }
+          Type: 108 ArrayType noalg.[8]struct { key string; elem int }
     - __kind: StructureType
-      ID: 79
+      ID: 95
       Name: noalg.map.group[string]main.nestedStruct
       ByteSize: 328
       GoRuntimeType: 1.279296e+06
@@ -6879,12 +6879,12 @@ Types:
       RawFields:
         - Name: ctrl
           Offset: 0
-          Type: 26 BaseType uint64
+          Type: 8 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 80 ArrayType noalg.[8]struct { key string; elem main.nestedStruct }
+          Type: 96 ArrayType noalg.[8]struct { key string; elem main.nestedStruct }
     - __kind: StructureType
-      ID: 176
+      ID: 192
       Name: noalg.map.group[uint8][4]int
       ByteSize: 328
       GoRuntimeType: 1.279552e+06
@@ -6892,12 +6892,12 @@ Types:
       RawFields:
         - Name: ctrl
           Offset: 0
-          Type: 26 BaseType uint64
+          Type: 8 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 177 ArrayType noalg.[8]struct { key uint8; elem [4]int }
+          Type: 193 ArrayType noalg.[8]struct { key uint8; elem [4]int }
     - __kind: StructureType
-      ID: 165
+      ID: 181
       Name: noalg.map.group[uint8]uint8
       ByteSize: 24
       GoRuntimeType: 1.279808e+06
@@ -6905,12 +6905,12 @@ Types:
       RawFields:
         - Name: ctrl
           Offset: 0
-          Type: 26 BaseType uint64
+          Type: 8 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 166 ArrayType noalg.[8]struct { key uint8; elem uint8 }
+          Type: 182 ArrayType noalg.[8]struct { key uint8; elem uint8 }
     - __kind: StructureType
-      ID: 201
+      ID: 217
       Name: noalg.struct { key [4]int; elem [4]int }
       ByteSize: 64
       GoRuntimeType: 1.27712e+06
@@ -6918,12 +6918,12 @@ Types:
       RawFields:
         - Name: key
           Offset: 0
-          Type: 179 ArrayType [4]int
+          Type: 195 ArrayType [4]int
         - Name: elem
           Offset: 32
-          Type: 179 ArrayType [4]int
+          Type: 195 ArrayType [4]int
     - __kind: StructureType
-      ID: 190
+      ID: 206
       Name: noalg.struct { key [4]int; elem uint8 }
       ByteSize: 40
       GoRuntimeType: 1.277376e+06
@@ -6931,12 +6931,12 @@ Types:
       RawFields:
         - Name: key
           Offset: 0
-          Type: 179 ArrayType [4]int
+          Type: 195 ArrayType [4]int
         - Name: elem
           Offset: 32
-          Type: 4 BaseType uint8
+          Type: 3 BaseType uint8
     - __kind: StructureType
-      ID: 116
+      ID: 132
       Name: noalg.struct { key [4]string; elem [2]int }
       ByteSize: 80
       GoRuntimeType: 1.277632e+06
@@ -6944,12 +6944,12 @@ Types:
       RawFields:
         - Name: key
           Offset: 0
-          Type: 117 ArrayType [4]string
+          Type: 133 ArrayType [4]string
         - Name: elem
           Offset: 64
-          Type: 12 ArrayType [2]int
+          Type: 40 ArrayType [2]int
     - __kind: StructureType
-      ID: 143
+      ID: 159
       Name: noalg.struct { key bool; elem main.node }
       ByteSize: 24
       GoRuntimeType: 1.277888e+06
@@ -6957,12 +6957,12 @@ Types:
       RawFields:
         - Name: key
           Offset: 0
-          Type: 11 BaseType bool
+          Type: 4 BaseType bool
         - Name: elem
           Offset: 8
-          Type: 144 StructureType main.node
+          Type: 160 StructureType main.node
     - __kind: StructureType
-      ID: 70
+      ID: 86
       Name: noalg.struct { key int; elem int }
       ByteSize: 16
       GoRuntimeType: 1.276352e+06
@@ -6970,12 +6970,12 @@ Types:
       RawFields:
         - Name: key
           Offset: 0
-          Type: 1 BaseType int
+          Type: 7 BaseType int
         - Name: elem
           Offset: 8
-          Type: 1 BaseType int
+          Type: 7 BaseType int
     - __kind: StructureType
-      ID: 156
+      ID: 172
       Name: noalg.struct { key int; elem uint8 }
       ByteSize: 16
       GoRuntimeType: 1.278144e+06
@@ -6983,12 +6983,12 @@ Types:
       RawFields:
         - Name: key
           Offset: 0
-          Type: 1 BaseType int
+          Type: 7 BaseType int
         - Name: elem
           Offset: 8
-          Type: 4 BaseType uint8
+          Type: 3 BaseType uint8
     - __kind: StructureType
-      ID: 130
+      ID: 146
       Name: noalg.struct { key string; elem []main.structWithMap }
       ByteSize: 40
       GoRuntimeType: 1.2784e+06
@@ -6996,12 +6996,12 @@ Types:
       RawFields:
         - Name: key
           Offset: 0
-          Type: 8 GoStringHeaderType string
+          Type: 9 GoStringHeaderType string
         - Name: elem
           Offset: 16
-          Type: 131 GoSliceHeaderType []main.structWithMap
+          Type: 147 GoSliceHeaderType []main.structWithMap
     - __kind: StructureType
-      ID: 104
+      ID: 120
       Name: noalg.struct { key string; elem []string }
       ByteSize: 40
       GoRuntimeType: 1.278656e+06
@@ -7009,12 +7009,12 @@ Types:
       RawFields:
         - Name: key
           Offset: 0
-          Type: 8 GoStringHeaderType string
+          Type: 9 GoStringHeaderType string
         - Name: elem
           Offset: 16
-          Type: 105 GoSliceHeaderType []string
+          Type: 121 GoSliceHeaderType []string
     - __kind: StructureType
-      ID: 93
+      ID: 109
       Name: noalg.struct { key string; elem int }
       ByteSize: 24
       GoRuntimeType: 1.278912e+06
@@ -7022,12 +7022,12 @@ Types:
       RawFields:
         - Name: key
           Offset: 0
-          Type: 8 GoStringHeaderType string
+          Type: 9 GoStringHeaderType string
         - Name: elem
           Offset: 16
-          Type: 1 BaseType int
+          Type: 7 BaseType int
     - __kind: StructureType
-      ID: 81
+      ID: 97
       Name: noalg.struct { key string; elem main.nestedStruct }
       ByteSize: 40
       GoRuntimeType: 1.279168e+06
@@ -7035,12 +7035,12 @@ Types:
       RawFields:
         - Name: key
           Offset: 0
-          Type: 8 GoStringHeaderType string
+          Type: 9 GoStringHeaderType string
         - Name: elem
           Offset: 16
-          Type: 82 StructureType main.nestedStruct
+          Type: 98 StructureType main.nestedStruct
     - __kind: StructureType
-      ID: 178
+      ID: 194
       Name: noalg.struct { key uint8; elem [4]int }
       ByteSize: 40
       GoRuntimeType: 1.279424e+06
@@ -7048,12 +7048,12 @@ Types:
       RawFields:
         - Name: key
           Offset: 0
-          Type: 4 BaseType uint8
+          Type: 3 BaseType uint8
         - Name: elem
           Offset: 8
-          Type: 179 ArrayType [4]int
+          Type: 195 ArrayType [4]int
     - __kind: StructureType
-      ID: 167
+      ID: 183
       Name: noalg.struct { key uint8; elem uint8 }
       ByteSize: 2
       GoRuntimeType: 1.27968e+06
@@ -7061,12 +7061,12 @@ Types:
       RawFields:
         - Name: key
           Offset: 0
-          Type: 4 BaseType uint8
+          Type: 3 BaseType uint8
         - Name: elem
           Offset: 1
-          Type: 4 BaseType uint8
+          Type: 3 BaseType uint8
     - __kind: GoStringHeaderType
-      ID: 8
+      ID: 9
       Name: string
       ByteSize: 16
       GoRuntimeType: 575008
@@ -7077,14 +7077,14 @@ Types:
           Type: 239 PointerType *string.str
         - Name: len
           Offset: 8
-          Type: 1 BaseType int
+          Type: 7 BaseType int
       Data: 238 GoStringDataType string.str
     - __kind: GoStringDataType
       ID: 238
       Name: string.str
       ByteSize: 2048
     - __kind: StructureType
-      ID: 46
+      ID: 63
       Name: sync.Mutex
       ByteSize: 8
       GoRuntimeType: 1.445344e+06
@@ -7092,12 +7092,12 @@ Types:
       RawFields:
         - Name: _
           Offset: 0
-          Type: 47 StructureType sync.noCopy
+          Type: 64 StructureType sync.noCopy
         - Name: mu
           Offset: 0
-          Type: 48 StructureType internal/sync.Mutex
+          Type: 65 StructureType internal/sync.Mutex
     - __kind: StructureType
-      ID: 49
+      ID: 66
       Name: sync.Once
       ByteSize: 12
       GoRuntimeType: 1.593696e+06
@@ -7105,15 +7105,15 @@ Types:
       RawFields:
         - Name: _
           Offset: 0
-          Type: 47 StructureType sync.noCopy
+          Type: 64 StructureType sync.noCopy
         - Name: done
           Offset: 0
-          Type: 50 StructureType sync/atomic.Uint32
+          Type: 67 StructureType sync/atomic.Uint32
         - Name: m
           Offset: 4
-          Type: 46 StructureType sync.Mutex
+          Type: 63 StructureType sync.Mutex
     - __kind: StructureType
-      ID: 52
+      ID: 69
       Name: sync.WaitGroup
       ByteSize: 16
       GoRuntimeType: 1.593888e+06
@@ -7121,21 +7121,21 @@ Types:
       RawFields:
         - Name: noCopy
           Offset: 0
-          Type: 47 StructureType sync.noCopy
+          Type: 64 StructureType sync.noCopy
         - Name: state
           Offset: 0
-          Type: 53 StructureType sync/atomic.Uint64
+          Type: 70 StructureType sync/atomic.Uint64
         - Name: sema
           Offset: 8
-          Type: 24 BaseType uint32
+          Type: 2 BaseType uint32
     - __kind: StructureType
-      ID: 47
+      ID: 64
       Name: sync.noCopy
       GoRuntimeType: 977728
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 55
+      ID: 72
       Name: sync/atomic.Int32
       ByteSize: 4
       GoRuntimeType: 1.446624e+06
@@ -7143,12 +7143,12 @@ Types:
       RawFields:
         - Name: _
           Offset: 0
-          Type: 51 StructureType sync/atomic.noCopy
+          Type: 68 StructureType sync/atomic.noCopy
         - Name: v
           Offset: 0
-          Type: 6 BaseType int32
+          Type: 10 BaseType int32
     - __kind: StructureType
-      ID: 50
+      ID: 67
       Name: sync/atomic.Uint32
       ByteSize: 4
       GoRuntimeType: 1.446784e+06
@@ -7156,12 +7156,12 @@ Types:
       RawFields:
         - Name: _
           Offset: 0
-          Type: 51 StructureType sync/atomic.noCopy
+          Type: 68 StructureType sync/atomic.noCopy
         - Name: v
           Offset: 0
-          Type: 24 BaseType uint32
+          Type: 2 BaseType uint32
     - __kind: StructureType
-      ID: 53
+      ID: 70
       Name: sync/atomic.Uint64
       ByteSize: 8
       GoRuntimeType: 1.594272e+06
@@ -7169,351 +7169,351 @@ Types:
       RawFields:
         - Name: _
           Offset: 0
-          Type: 51 StructureType sync/atomic.noCopy
+          Type: 68 StructureType sync/atomic.noCopy
         - Name: _
           Offset: 0
-          Type: 54 StructureType sync/atomic.align64
+          Type: 71 StructureType sync/atomic.align64
         - Name: v
           Offset: 0
-          Type: 26 BaseType uint64
+          Type: 8 BaseType uint64
     - __kind: StructureType
-      ID: 54
+      ID: 71
       Name: sync/atomic.align64
       GoRuntimeType: 977920
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 51
+      ID: 68
       Name: sync/atomic.noCopy
       GoRuntimeType: 977824
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 196
+      ID: 212
       Name: table<[4]int,[4]int>
       ByteSize: 32
       GoKind: 25
       RawFields:
         - Name: used
           Offset: 0
-          Type: 22 BaseType uint16
+          Type: 6 BaseType uint16
         - Name: capacity
           Offset: 2
-          Type: 22 BaseType uint16
+          Type: 6 BaseType uint16
         - Name: growthLeft
           Offset: 4
-          Type: 22 BaseType uint16
+          Type: 6 BaseType uint16
         - Name: localDepth
           Offset: 6
-          Type: 4 BaseType uint8
+          Type: 3 BaseType uint8
         - Name: index
           Offset: 8
-          Type: 1 BaseType int
+          Type: 7 BaseType int
         - Name: groups
           Offset: 16
-          Type: 197 GoSwissMapGroupsType groupReference<[4]int,[4]int>
+          Type: 213 GoSwissMapGroupsType groupReference<[4]int,[4]int>
     - __kind: StructureType
-      ID: 185
+      ID: 201
       Name: table<[4]int,uint8>
       ByteSize: 32
       GoKind: 25
       RawFields:
         - Name: used
           Offset: 0
-          Type: 22 BaseType uint16
+          Type: 6 BaseType uint16
         - Name: capacity
           Offset: 2
-          Type: 22 BaseType uint16
+          Type: 6 BaseType uint16
         - Name: growthLeft
           Offset: 4
-          Type: 22 BaseType uint16
+          Type: 6 BaseType uint16
         - Name: localDepth
           Offset: 6
-          Type: 4 BaseType uint8
+          Type: 3 BaseType uint8
         - Name: index
           Offset: 8
-          Type: 1 BaseType int
+          Type: 7 BaseType int
         - Name: groups
           Offset: 16
-          Type: 186 GoSwissMapGroupsType groupReference<[4]int,uint8>
+          Type: 202 GoSwissMapGroupsType groupReference<[4]int,uint8>
     - __kind: StructureType
-      ID: 111
+      ID: 127
       Name: table<[4]string,[2]int>
       ByteSize: 32
       GoKind: 25
       RawFields:
         - Name: used
           Offset: 0
-          Type: 22 BaseType uint16
+          Type: 6 BaseType uint16
         - Name: capacity
           Offset: 2
-          Type: 22 BaseType uint16
+          Type: 6 BaseType uint16
         - Name: growthLeft
           Offset: 4
-          Type: 22 BaseType uint16
+          Type: 6 BaseType uint16
         - Name: localDepth
           Offset: 6
-          Type: 4 BaseType uint8
+          Type: 3 BaseType uint8
         - Name: index
           Offset: 8
-          Type: 1 BaseType int
+          Type: 7 BaseType int
         - Name: groups
           Offset: 16
-          Type: 112 GoSwissMapGroupsType groupReference<[4]string,[2]int>
+          Type: 128 GoSwissMapGroupsType groupReference<[4]string,[2]int>
     - __kind: StructureType
-      ID: 138
+      ID: 154
       Name: table<bool,main.node>
       ByteSize: 32
       GoKind: 25
       RawFields:
         - Name: used
           Offset: 0
-          Type: 22 BaseType uint16
+          Type: 6 BaseType uint16
         - Name: capacity
           Offset: 2
-          Type: 22 BaseType uint16
+          Type: 6 BaseType uint16
         - Name: growthLeft
           Offset: 4
-          Type: 22 BaseType uint16
+          Type: 6 BaseType uint16
         - Name: localDepth
           Offset: 6
-          Type: 4 BaseType uint8
+          Type: 3 BaseType uint8
         - Name: index
           Offset: 8
-          Type: 1 BaseType int
+          Type: 7 BaseType int
         - Name: groups
           Offset: 16
-          Type: 139 GoSwissMapGroupsType groupReference<bool,main.node>
+          Type: 155 GoSwissMapGroupsType groupReference<bool,main.node>
     - __kind: StructureType
-      ID: 65
+      ID: 81
       Name: table<int,int>
       ByteSize: 32
       GoKind: 25
       RawFields:
         - Name: used
           Offset: 0
-          Type: 22 BaseType uint16
+          Type: 6 BaseType uint16
         - Name: capacity
           Offset: 2
-          Type: 22 BaseType uint16
+          Type: 6 BaseType uint16
         - Name: growthLeft
           Offset: 4
-          Type: 22 BaseType uint16
+          Type: 6 BaseType uint16
         - Name: localDepth
           Offset: 6
-          Type: 4 BaseType uint8
+          Type: 3 BaseType uint8
         - Name: index
           Offset: 8
-          Type: 1 BaseType int
+          Type: 7 BaseType int
         - Name: groups
           Offset: 16
-          Type: 66 GoSwissMapGroupsType groupReference<int,int>
+          Type: 82 GoSwissMapGroupsType groupReference<int,int>
     - __kind: StructureType
-      ID: 151
+      ID: 167
       Name: table<int,uint8>
       ByteSize: 32
       GoKind: 25
       RawFields:
         - Name: used
           Offset: 0
-          Type: 22 BaseType uint16
+          Type: 6 BaseType uint16
         - Name: capacity
           Offset: 2
-          Type: 22 BaseType uint16
+          Type: 6 BaseType uint16
         - Name: growthLeft
           Offset: 4
-          Type: 22 BaseType uint16
+          Type: 6 BaseType uint16
         - Name: localDepth
           Offset: 6
-          Type: 4 BaseType uint8
+          Type: 3 BaseType uint8
         - Name: index
           Offset: 8
-          Type: 1 BaseType int
+          Type: 7 BaseType int
         - Name: groups
           Offset: 16
-          Type: 152 GoSwissMapGroupsType groupReference<int,uint8>
+          Type: 168 GoSwissMapGroupsType groupReference<int,uint8>
     - __kind: StructureType
-      ID: 125
+      ID: 141
       Name: table<string,[]main.structWithMap>
       ByteSize: 32
       GoKind: 25
       RawFields:
         - Name: used
           Offset: 0
-          Type: 22 BaseType uint16
+          Type: 6 BaseType uint16
         - Name: capacity
           Offset: 2
-          Type: 22 BaseType uint16
+          Type: 6 BaseType uint16
         - Name: growthLeft
           Offset: 4
-          Type: 22 BaseType uint16
+          Type: 6 BaseType uint16
         - Name: localDepth
           Offset: 6
-          Type: 4 BaseType uint8
+          Type: 3 BaseType uint8
         - Name: index
           Offset: 8
-          Type: 1 BaseType int
+          Type: 7 BaseType int
         - Name: groups
           Offset: 16
-          Type: 126 GoSwissMapGroupsType groupReference<string,[]main.structWithMap>
+          Type: 142 GoSwissMapGroupsType groupReference<string,[]main.structWithMap>
     - __kind: StructureType
-      ID: 99
+      ID: 115
       Name: table<string,[]string>
       ByteSize: 32
       GoKind: 25
       RawFields:
         - Name: used
           Offset: 0
-          Type: 22 BaseType uint16
+          Type: 6 BaseType uint16
         - Name: capacity
           Offset: 2
-          Type: 22 BaseType uint16
+          Type: 6 BaseType uint16
         - Name: growthLeft
           Offset: 4
-          Type: 22 BaseType uint16
+          Type: 6 BaseType uint16
         - Name: localDepth
           Offset: 6
-          Type: 4 BaseType uint8
+          Type: 3 BaseType uint8
         - Name: index
           Offset: 8
-          Type: 1 BaseType int
+          Type: 7 BaseType int
         - Name: groups
           Offset: 16
-          Type: 100 GoSwissMapGroupsType groupReference<string,[]string>
+          Type: 116 GoSwissMapGroupsType groupReference<string,[]string>
     - __kind: StructureType
-      ID: 88
+      ID: 104
       Name: table<string,int>
       ByteSize: 32
       GoKind: 25
       RawFields:
         - Name: used
           Offset: 0
-          Type: 22 BaseType uint16
+          Type: 6 BaseType uint16
         - Name: capacity
           Offset: 2
-          Type: 22 BaseType uint16
+          Type: 6 BaseType uint16
         - Name: growthLeft
           Offset: 4
-          Type: 22 BaseType uint16
+          Type: 6 BaseType uint16
         - Name: localDepth
           Offset: 6
-          Type: 4 BaseType uint8
+          Type: 3 BaseType uint8
         - Name: index
           Offset: 8
-          Type: 1 BaseType int
+          Type: 7 BaseType int
         - Name: groups
           Offset: 16
-          Type: 89 GoSwissMapGroupsType groupReference<string,int>
+          Type: 105 GoSwissMapGroupsType groupReference<string,int>
     - __kind: StructureType
-      ID: 76
+      ID: 92
       Name: table<string,main.nestedStruct>
       ByteSize: 32
       GoKind: 25
       RawFields:
         - Name: used
           Offset: 0
-          Type: 22 BaseType uint16
+          Type: 6 BaseType uint16
         - Name: capacity
           Offset: 2
-          Type: 22 BaseType uint16
+          Type: 6 BaseType uint16
         - Name: growthLeft
           Offset: 4
-          Type: 22 BaseType uint16
+          Type: 6 BaseType uint16
         - Name: localDepth
           Offset: 6
-          Type: 4 BaseType uint8
+          Type: 3 BaseType uint8
         - Name: index
           Offset: 8
-          Type: 1 BaseType int
+          Type: 7 BaseType int
         - Name: groups
           Offset: 16
-          Type: 77 GoSwissMapGroupsType groupReference<string,main.nestedStruct>
+          Type: 93 GoSwissMapGroupsType groupReference<string,main.nestedStruct>
     - __kind: StructureType
-      ID: 173
+      ID: 189
       Name: table<uint8,[4]int>
       ByteSize: 32
       GoKind: 25
       RawFields:
         - Name: used
           Offset: 0
-          Type: 22 BaseType uint16
+          Type: 6 BaseType uint16
         - Name: capacity
           Offset: 2
-          Type: 22 BaseType uint16
+          Type: 6 BaseType uint16
         - Name: growthLeft
           Offset: 4
-          Type: 22 BaseType uint16
+          Type: 6 BaseType uint16
         - Name: localDepth
           Offset: 6
-          Type: 4 BaseType uint8
+          Type: 3 BaseType uint8
         - Name: index
           Offset: 8
-          Type: 1 BaseType int
+          Type: 7 BaseType int
         - Name: groups
           Offset: 16
-          Type: 174 GoSwissMapGroupsType groupReference<uint8,[4]int>
+          Type: 190 GoSwissMapGroupsType groupReference<uint8,[4]int>
     - __kind: StructureType
-      ID: 162
+      ID: 178
       Name: table<uint8,uint8>
       ByteSize: 32
       GoKind: 25
       RawFields:
         - Name: used
           Offset: 0
-          Type: 22 BaseType uint16
+          Type: 6 BaseType uint16
         - Name: capacity
           Offset: 2
-          Type: 22 BaseType uint16
+          Type: 6 BaseType uint16
         - Name: growthLeft
           Offset: 4
-          Type: 22 BaseType uint16
+          Type: 6 BaseType uint16
         - Name: localDepth
           Offset: 6
-          Type: 4 BaseType uint8
+          Type: 3 BaseType uint8
         - Name: index
           Offset: 8
-          Type: 1 BaseType int
+          Type: 7 BaseType int
         - Name: groups
           Offset: 16
-          Type: 163 GoSwissMapGroupsType groupReference<uint8,uint8>
+          Type: 179 GoSwissMapGroupsType groupReference<uint8,uint8>
     - __kind: BaseType
-      ID: 20
+      ID: 16
       Name: uint
       ByteSize: 8
       GoRuntimeType: 575648
       GoKind: 7
     - __kind: BaseType
-      ID: 22
+      ID: 6
       Name: uint16
       ByteSize: 2
       GoRuntimeType: 575264
       GoKind: 9
     - __kind: BaseType
-      ID: 24
+      ID: 2
       Name: uint32
       ByteSize: 4
       GoRuntimeType: 575392
       GoKind: 10
     - __kind: BaseType
-      ID: 26
+      ID: 8
       Name: uint64
       ByteSize: 8
       GoRuntimeType: 575520
       GoKind: 11
     - __kind: BaseType
-      ID: 4
+      ID: 3
       Name: uint8
       ByteSize: 1
       GoRuntimeType: 575136
       GoKind: 8
     - __kind: BaseType
-      ID: 62
+      ID: 1
       Name: uintptr
       ByteSize: 8
       GoRuntimeType: 575712
       GoKind: 12
     - __kind: VoidPointerType
-      ID: 38
+      ID: 14
       Name: unsafe.Pointer
       ByteSize: 8
       GoRuntimeType: 576096

--- a/pkg/dyninst/irgen/testdata/snapshot/sample.arch=amd64,toolchain=go1.24.3.yaml
+++ b/pkg/dyninst/irgen/testdata/snapshot/sample.arch=amd64,toolchain=go1.24.3.yaml
@@ -2089,7 +2089,7 @@ Subprograms:
       InlinePCRanges: []
       Variables:
         - Name: a
-          Type: 73 ArrayType [5]int
+          Type: 63 ArrayType [5]int
           Locations:
             - Range: 0xcd50e0..0xcd5123
               Pieces: [{Size: 40, Op: {CfaOffset: 0}}]
@@ -2106,7 +2106,7 @@ Subprograms:
       InlinePCRanges: []
       Variables:
         - Name: b
-          Type: 74 GoInterfaceType main.behavior
+          Type: 64 GoInterfaceType main.behavior
           Locations:
             - Range: 0xcd53c0..0xcd53df
               Pieces:
@@ -2176,7 +2176,7 @@ Subprograms:
       InlinePCRanges: []
       Variables:
         - Name: s
-          Type: 75 StructureType main.structWithMap
+          Type: 65 StructureType main.structWithMap
           Locations:
             - Range: 0xcd5900..0xcd5901
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
@@ -2188,7 +2188,7 @@ Subprograms:
       InlinePCRanges: []
       Variables:
         - Name: m
-          Type: 87 GoMapType map[string]main.nestedStruct
+          Type: 71 GoMapType map[string]main.nestedStruct
           Locations:
             - Range: 0xcd5920..0xcd5921
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
@@ -2200,7 +2200,7 @@ Subprograms:
       InlinePCRanges: []
       Variables:
         - Name: m
-          Type: 99 GoMapType map[string]int
+          Type: 76 GoMapType map[string]int
           Locations:
             - Range: 0xcd5940..0xcd5941
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
@@ -2212,7 +2212,7 @@ Subprograms:
       InlinePCRanges: []
       Variables:
         - Name: m
-          Type: 110 GoMapType map[string][]string
+          Type: 81 GoMapType map[string][]string
           Locations:
             - Range: 0xcd5960..0xcd5961
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
@@ -2224,7 +2224,7 @@ Subprograms:
       InlinePCRanges: []
       Variables:
         - Name: m
-          Type: 122 GoMapType map[[4]string][2]int
+          Type: 86 GoMapType map[[4]string][2]int
           Locations:
             - Range: 0xcd5980..0xcd5981
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
@@ -2236,7 +2236,7 @@ Subprograms:
       InlinePCRanges: []
       Variables:
         - Name: m
-          Type: 99 GoMapType map[string]int
+          Type: 76 GoMapType map[string]int
           Locations:
             - Range: 0xcd59a0..0xcd59a1
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
@@ -2248,7 +2248,7 @@ Subprograms:
       InlinePCRanges: []
       Variables:
         - Name: m
-          Type: 134 ArrayType [2]map[string]int
+          Type: 91 ArrayType [2]map[string]int
           Locations:
             - Range: 0xcd59c0..0xcd59c1
               Pieces: [{Size: 16, Op: {CfaOffset: 0}}]
@@ -2260,7 +2260,7 @@ Subprograms:
       InlinePCRanges: []
       Variables:
         - Name: m
-          Type: 135 PointerType *map[string]int
+          Type: 92 PointerType *map[string]int
           Locations:
             - Range: 0xcd59e0..0xcd59e1
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
@@ -2272,7 +2272,7 @@ Subprograms:
       InlinePCRanges: []
       Variables:
         - Name: m
-          Type: 76 GoMapType map[int]int
+          Type: 66 GoMapType map[int]int
           Locations:
             - Range: 0xcd5a00..0xcd5a01
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
@@ -2284,7 +2284,7 @@ Subprograms:
       InlinePCRanges: []
       Variables:
         - Name: redactMyEntries
-          Type: 136 GoMapType map[string][]main.structWithMap
+          Type: 93 GoMapType map[string][]main.structWithMap
           Locations:
             - Range: 0xcd5a20..0xcd5a21
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
@@ -2296,7 +2296,7 @@ Subprograms:
       InlinePCRanges: []
       Variables:
         - Name: m
-          Type: 136 GoMapType map[string][]main.structWithMap
+          Type: 93 GoMapType map[string][]main.structWithMap
           Locations:
             - Range: 0xcd5a40..0xcd5a41
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
@@ -2308,7 +2308,7 @@ Subprograms:
       InlinePCRanges: []
       Variables:
         - Name: m
-          Type: 149 GoMapType map[bool]main.node
+          Type: 98 GoMapType map[bool]main.node
           Locations:
             - Range: 0xcd5a60..0xcd5a61
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
@@ -2320,7 +2320,7 @@ Subprograms:
       InlinePCRanges: []
       Variables:
         - Name: m
-          Type: 162 GoMapType map[int]uint8
+          Type: 103 GoMapType map[int]uint8
           Locations:
             - Range: 0xcd5a80..0xcd5a81
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
@@ -2332,7 +2332,7 @@ Subprograms:
       InlinePCRanges: []
       Variables:
         - Name: redactMyEntries
-          Type: 162 GoMapType map[int]uint8
+          Type: 103 GoMapType map[int]uint8
           Locations:
             - Range: 0xcd5aa0..0xcd5aa1
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
@@ -2344,7 +2344,7 @@ Subprograms:
       InlinePCRanges: []
       Variables:
         - Name: m
-          Type: 173 GoMapType map[uint8]uint8
+          Type: 108 GoMapType map[uint8]uint8
           Locations:
             - Range: 0xcd5ac0..0xcd5ac1
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
@@ -2356,7 +2356,7 @@ Subprograms:
       InlinePCRanges: []
       Variables:
         - Name: m
-          Type: 173 GoMapType map[uint8]uint8
+          Type: 108 GoMapType map[uint8]uint8
           Locations:
             - Range: 0xcd5ae0..0xcd5ae1
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
@@ -2368,7 +2368,7 @@ Subprograms:
       InlinePCRanges: []
       Variables:
         - Name: m
-          Type: 173 GoMapType map[uint8]uint8
+          Type: 108 GoMapType map[uint8]uint8
           Locations:
             - Range: 0xcd5b00..0xcd5b01
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
@@ -2380,7 +2380,7 @@ Subprograms:
       InlinePCRanges: []
       Variables:
         - Name: m
-          Type: 184 GoMapType map[uint8][4]int
+          Type: 113 GoMapType map[uint8][4]int
           Locations:
             - Range: 0xcd5b20..0xcd5b21
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
@@ -2392,7 +2392,7 @@ Subprograms:
       InlinePCRanges: []
       Variables:
         - Name: m
-          Type: 196 GoMapType map[[4]int]uint8
+          Type: 118 GoMapType map[[4]int]uint8
           Locations:
             - Range: 0xcd5b40..0xcd5b41
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
@@ -2404,7 +2404,7 @@ Subprograms:
       InlinePCRanges: []
       Variables:
         - Name: m
-          Type: 207 GoMapType map[[4]int][4]int
+          Type: 123 GoMapType map[[4]int][4]int
           Locations:
             - Range: 0xcd5b60..0xcd5b61
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
@@ -2486,7 +2486,7 @@ Subprograms:
       InlinePCRanges: []
       Variables:
         - Name: c
-          Type: 218 GoChannelType chan bool
+          Type: 128 GoChannelType chan bool
           Locations:
             - Range: 0xcd7680..0xcd7681
               Pieces: [{Size: 0, Op: {RegNo: 0, Shift: 0}}]
@@ -2498,7 +2498,7 @@ Subprograms:
       InlinePCRanges: []
       Variables:
         - Name: a
-          Type: 219 PointerType *main.structWithTwoValues
+          Type: 129 PointerType *main.structWithTwoValues
           Locations:
             - Range: 0xcd7840..0xcd7841
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
@@ -2510,7 +2510,7 @@ Subprograms:
       InlinePCRanges: []
       Variables:
         - Name: a
-          Type: 160 StructureType main.node
+          Type: 131 StructureType main.node
           Locations:
             - Range: 0xcd7860..0xcd7861
               Pieces:
@@ -2526,7 +2526,7 @@ Subprograms:
       InlinePCRanges: []
       Variables:
         - Name: a
-          Type: 161 PointerType *main.node
+          Type: 132 PointerType *main.node
           Locations:
             - Range: 0xcd7880..0xcd7881
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
@@ -2593,7 +2593,7 @@ Subprograms:
       InlinePCRanges: []
       Variables:
         - Name: t
-          Type: 221 PointerType *main.t
+          Type: 133 PointerType *main.t
           Locations:
             - Range: 0xcd7a40..0xcd7a41
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
@@ -2605,7 +2605,7 @@ Subprograms:
       InlinePCRanges: []
       Variables:
         - Name: u
-          Type: 224 GoSliceHeaderType []uint
+          Type: 135 GoSliceHeaderType []uint
           Locations:
             - Range: 0xcd7f60..0xcd7f61
               Pieces:
@@ -2623,7 +2623,7 @@ Subprograms:
       InlinePCRanges: []
       Variables:
         - Name: u
-          Type: 224 GoSliceHeaderType []uint
+          Type: 135 GoSliceHeaderType []uint
           Locations:
             - Range: 0xcd7f80..0xcd7f81
               Pieces:
@@ -2641,7 +2641,7 @@ Subprograms:
       InlinePCRanges: []
       Variables:
         - Name: u
-          Type: 225 GoSliceHeaderType [][]uint
+          Type: 136 GoSliceHeaderType [][]uint
           Locations:
             - Range: 0xcd7fa0..0xcd7fa1
               Pieces:
@@ -2659,7 +2659,7 @@ Subprograms:
       InlinePCRanges: []
       Variables:
         - Name: xs
-          Type: 227 GoSliceHeaderType []main.structWithNoStrings
+          Type: 138 GoSliceHeaderType []main.structWithNoStrings
           Locations:
             - Range: 0xcd7fc0..0xcd7fc1
               Pieces:
@@ -2684,7 +2684,7 @@ Subprograms:
       InlinePCRanges: []
       Variables:
         - Name: xs
-          Type: 227 GoSliceHeaderType []main.structWithNoStrings
+          Type: 138 GoSliceHeaderType []main.structWithNoStrings
           Locations:
             - Range: 0xcd7fe0..0xcd7fe1
               Pieces:
@@ -2709,7 +2709,7 @@ Subprograms:
       InlinePCRanges: []
       Variables:
         - Name: xs
-          Type: 227 GoSliceHeaderType []main.structWithNoStrings
+          Type: 138 GoSliceHeaderType []main.structWithNoStrings
           Locations:
             - Range: 0xcd8000..0xcd8001
               Pieces:
@@ -2734,7 +2734,7 @@ Subprograms:
       InlinePCRanges: []
       Variables:
         - Name: s
-          Type: 121 GoSliceHeaderType []string
+          Type: 141 GoSliceHeaderType []string
           Locations:
             - Range: 0xcd8020..0xcd8021
               Pieces:
@@ -2759,7 +2759,7 @@ Subprograms:
           IsParameter: true
           IsReturn: false
         - Name: s
-          Type: 230 GoSliceHeaderType []bool
+          Type: 142 GoSliceHeaderType []bool
           Locations:
             - Range: 0xcd8040..0xcd8041
               Pieces:
@@ -2784,7 +2784,7 @@ Subprograms:
       InlinePCRanges: []
       Variables:
         - Name: xs
-          Type: 231 GoSliceHeaderType []uint16
+          Type: 143 GoSliceHeaderType []uint16
           Locations:
             - Range: 0xcd8060..0xcd8061
               Pieces:
@@ -2802,7 +2802,7 @@ Subprograms:
       InlinePCRanges: []
       Variables:
         - Name: xs
-          Type: 224 GoSliceHeaderType []uint
+          Type: 135 GoSliceHeaderType []uint
           Locations:
             - Range: 0xcd8080..0xcd8081
               Pieces:
@@ -2884,7 +2884,7 @@ Subprograms:
       InlinePCRanges: []
       Variables:
         - Name: a
-          Type: 232 StructureType main.threeStringStruct
+          Type: 144 StructureType main.threeStringStruct
           Locations:
             - Range: 0xcd8460..0xcd847f
               Pieces:
@@ -2908,7 +2908,7 @@ Subprograms:
       InlinePCRanges: []
       Variables:
         - Name: a
-          Type: 233 PointerType *main.threeStringStruct
+          Type: 145 PointerType *main.threeStringStruct
           Locations:
             - Range: 0xcd8480..0xcd8481
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
@@ -2920,7 +2920,7 @@ Subprograms:
       InlinePCRanges: []
       Variables:
         - Name: a
-          Type: 234 PointerType *main.oneStringStruct
+          Type: 146 PointerType *main.oneStringStruct
           Locations:
             - Range: 0xcd84a0..0xcd84a1
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
@@ -2980,7 +2980,7 @@ Subprograms:
       InlinePCRanges: []
       Variables:
         - Name: x
-          Type: 236 StructureType main.aStruct
+          Type: 148 StructureType main.aStruct
           Locations:
             - Range: 0xcd8780..0xcd87a3
               Pieces:
@@ -3006,7 +3006,7 @@ Subprograms:
       InlinePCRanges: []
       Variables:
         - Name: e
-          Type: 237 StructureType main.emptyStruct
+          Type: 150 StructureType main.emptyStruct
           Locations: [{Range: 0xcd8900..0xcd8901, Pieces: []}]
           IsParameter: true
           IsReturn: false
@@ -3085,7 +3085,7 @@ Subprograms:
           RootRanges: [0xcd5140..0xcd52c5]
       Variables:
         - Name: a
-          Type: 73 ArrayType [5]int
+          Type: 63 ArrayType [5]int
           Locations:
             - Range: 0xcd50ed..0xcd5123
               Pieces: [{Size: 40, Op: {CfaOffset: -56}}]
@@ -3095,10 +3095,10 @@ Subprograms:
           IsReturn: false
 Types:
     - __kind: PointerType
-      ID: 223
+      ID: 173
       Name: '**main.t'
       ByteSize: 8
-      Pointee: 221 PointerType *main.t
+      Pointee: 133 PointerType *main.t
     - __kind: PointerType
       ID: 54
       Name: '**string'
@@ -3107,110 +3107,110 @@ Types:
       GoKind: 22
       Pointee: 22 PointerType *string
     - __kind: PointerType
-      ID: 210
+      ID: 126
       Name: '**table<[4]int,[4]int>'
       ByteSize: 8
-      Pointee: 211 PointerType *table<[4]int,[4]int>
+      Pointee: 127 PointerType *table<[4]int,[4]int>
     - __kind: PointerType
-      ID: 199
+      ID: 121
       Name: '**table<[4]int,uint8>'
       ByteSize: 8
-      Pointee: 200 PointerType *table<[4]int,uint8>
+      Pointee: 122 PointerType *table<[4]int,uint8>
     - __kind: PointerType
-      ID: 125
+      ID: 89
       Name: '**table<[4]string,[2]int>'
       ByteSize: 8
-      Pointee: 126 PointerType *table<[4]string,[2]int>
+      Pointee: 90 PointerType *table<[4]string,[2]int>
     - __kind: PointerType
-      ID: 152
+      ID: 101
       Name: '**table<bool,main.node>'
       ByteSize: 8
-      Pointee: 153 PointerType *table<bool,main.node>
+      Pointee: 102 PointerType *table<bool,main.node>
     - __kind: PointerType
-      ID: 79
+      ID: 69
       Name: '**table<int,int>'
       ByteSize: 8
-      Pointee: 80 PointerType *table<int,int>
+      Pointee: 70 PointerType *table<int,int>
     - __kind: PointerType
-      ID: 165
+      ID: 106
       Name: '**table<int,uint8>'
       ByteSize: 8
-      Pointee: 166 PointerType *table<int,uint8>
+      Pointee: 107 PointerType *table<int,uint8>
     - __kind: PointerType
-      ID: 139
+      ID: 96
       Name: '**table<string,[]main.structWithMap>'
       ByteSize: 8
-      Pointee: 140 PointerType *table<string,[]main.structWithMap>
+      Pointee: 97 PointerType *table<string,[]main.structWithMap>
     - __kind: PointerType
-      ID: 113
+      ID: 84
       Name: '**table<string,[]string>'
       ByteSize: 8
-      Pointee: 114 PointerType *table<string,[]string>
+      Pointee: 85 PointerType *table<string,[]string>
     - __kind: PointerType
-      ID: 102
+      ID: 79
       Name: '**table<string,int>'
       ByteSize: 8
-      Pointee: 103 PointerType *table<string,int>
+      Pointee: 80 PointerType *table<string,int>
     - __kind: PointerType
-      ID: 90
+      ID: 74
       Name: '**table<string,main.nestedStruct>'
       ByteSize: 8
-      Pointee: 91 PointerType *table<string,main.nestedStruct>
+      Pointee: 75 PointerType *table<string,main.nestedStruct>
     - __kind: PointerType
-      ID: 187
+      ID: 116
       Name: '**table<uint8,[4]int>'
       ByteSize: 8
-      Pointee: 188 PointerType *table<uint8,[4]int>
+      Pointee: 117 PointerType *table<uint8,[4]int>
     - __kind: PointerType
-      ID: 176
+      ID: 111
       Name: '**table<uint8,uint8>'
       ByteSize: 8
-      Pointee: 177 PointerType *table<uint8,uint8>
+      Pointee: 112 PointerType *table<uint8,uint8>
     - __kind: PointerType
       ID: 241
       Name: '*[]*string.array'
       ByteSize: 8
       Pointee: 240 GoSliceDataType []*string.array
     - __kind: PointerType
-      ID: 275
+      ID: 271
       Name: '*[][]uint.array'
       ByteSize: 8
-      Pointee: 274 GoSliceDataType [][]uint.array
-    - __kind: PointerType
-      ID: 279
-      Name: '*[]bool.array'
-      ByteSize: 8
-      Pointee: 278 GoSliceDataType []bool.array
-    - __kind: PointerType
-      ID: 257
-      Name: '*[]main.structWithMap.array'
-      ByteSize: 8
-      Pointee: 256 GoSliceDataType []main.structWithMap.array
+      Pointee: 270 GoSliceDataType [][]uint.array
     - __kind: PointerType
       ID: 277
-      Name: '*[]main.structWithNoStrings.array'
+      Name: '*[]bool.array'
       ByteSize: 8
-      Pointee: 276 GoSliceDataType []main.structWithNoStrings.array
-    - __kind: PointerType
-      ID: 251
-      Name: '*[]string.array'
-      ByteSize: 8
-      Pointee: 250 GoSliceDataType []string.array
-    - __kind: PointerType
-      ID: 226
-      Name: '*[]uint'
-      ByteSize: 8
-      Pointee: 224 GoSliceHeaderType []uint
-    - __kind: PointerType
-      ID: 273
-      Name: '*[]uint.array'
-      ByteSize: 8
-      Pointee: 272 GoSliceDataType []uint.array
+      Pointee: 276 GoSliceDataType []bool.array
     - __kind: PointerType
       ID: 281
+      Name: '*[]main.structWithMap.array'
+      ByteSize: 8
+      Pointee: 280 GoSliceDataType []main.structWithMap.array
+    - __kind: PointerType
+      ID: 273
+      Name: '*[]main.structWithNoStrings.array'
+      ByteSize: 8
+      Pointee: 272 GoSliceDataType []main.structWithNoStrings.array
+    - __kind: PointerType
+      ID: 275
+      Name: '*[]string.array'
+      ByteSize: 8
+      Pointee: 274 GoSliceDataType []string.array
+    - __kind: PointerType
+      ID: 137
+      Name: '*[]uint'
+      ByteSize: 8
+      Pointee: 135 GoSliceHeaderType []uint
+    - __kind: PointerType
+      ID: 269
+      Name: '*[]uint.array'
+      ByteSize: 8
+      Pointee: 268 GoSliceDataType []uint.array
+    - __kind: PointerType
+      ID: 279
       Name: '*[]uint16.array'
       ByteSize: 8
-      Pointee: 280 GoSliceDataType []uint16.array
+      Pointee: 278 GoSliceDataType []uint16.array
     - __kind: PointerType
       ID: 11
       Name: '*bool'
@@ -3282,179 +3282,179 @@ Types:
       GoKind: 22
       Pointee: 62 StructureType main.esotericHeap
     - __kind: PointerType
-      ID: 161
+      ID: 132
       Name: '*main.node'
       ByteSize: 8
       GoRuntimeType: 380288
       GoKind: 22
-      Pointee: 160 StructureType main.node
+      Pointee: 131 StructureType main.node
     - __kind: PointerType
-      ID: 234
+      ID: 146
       Name: '*main.oneStringStruct'
       ByteSize: 8
       GoKind: 22
-      Pointee: 235 StructureType main.oneStringStruct
+      Pointee: 147 StructureType main.oneStringStruct
     - __kind: PointerType
-      ID: 148
+      ID: 224
       Name: '*main.structWithMap'
       ByteSize: 8
       GoRuntimeType: 380160
       GoKind: 22
-      Pointee: 75 StructureType main.structWithMap
+      Pointee: 65 StructureType main.structWithMap
     - __kind: PointerType
-      ID: 228
+      ID: 139
       Name: '*main.structWithNoStrings'
       ByteSize: 8
-      Pointee: 229 StructureType main.structWithNoStrings
+      Pointee: 140 StructureType main.structWithNoStrings
     - __kind: PointerType
-      ID: 219
+      ID: 129
       Name: '*main.structWithTwoValues'
       ByteSize: 8
       GoKind: 22
-      Pointee: 220 StructureType main.structWithTwoValues
+      Pointee: 130 StructureType main.structWithTwoValues
     - __kind: PointerType
-      ID: 221
+      ID: 133
       Name: '*main.t'
       ByteSize: 8
       GoKind: 22
-      Pointee: 222 GoSliceHeaderType main.t
+      Pointee: 134 GoSliceHeaderType main.t
     - __kind: PointerType
-      ID: 271
+      ID: 267
       Name: '*main.t.array'
       ByteSize: 8
-      Pointee: 270 GoSliceDataType main.t.array
+      Pointee: 266 GoSliceDataType main.t.array
     - __kind: PointerType
-      ID: 233
+      ID: 145
       Name: '*main.threeStringStruct'
       ByteSize: 8
       GoKind: 22
-      Pointee: 232 StructureType main.threeStringStruct
+      Pointee: 144 StructureType main.threeStringStruct
     - __kind: PointerType
-      ID: 208
+      ID: 124
       Name: '*map<[4]int,[4]int>'
       ByteSize: 8
-      Pointee: 209 GoSwissMapHeaderType map<[4]int,[4]int>
+      Pointee: 125 GoSwissMapHeaderType map<[4]int,[4]int>
     - __kind: PointerType
-      ID: 197
+      ID: 119
       Name: '*map<[4]int,uint8>'
       ByteSize: 8
-      Pointee: 198 GoSwissMapHeaderType map<[4]int,uint8>
+      Pointee: 120 GoSwissMapHeaderType map<[4]int,uint8>
     - __kind: PointerType
-      ID: 123
+      ID: 87
       Name: '*map<[4]string,[2]int>'
       ByteSize: 8
-      Pointee: 124 GoSwissMapHeaderType map<[4]string,[2]int>
+      Pointee: 88 GoSwissMapHeaderType map<[4]string,[2]int>
     - __kind: PointerType
-      ID: 150
+      ID: 99
       Name: '*map<bool,main.node>'
       ByteSize: 8
-      Pointee: 151 GoSwissMapHeaderType map<bool,main.node>
+      Pointee: 100 GoSwissMapHeaderType map<bool,main.node>
     - __kind: PointerType
-      ID: 77
+      ID: 67
       Name: '*map<int,int>'
       ByteSize: 8
-      Pointee: 78 GoSwissMapHeaderType map<int,int>
+      Pointee: 68 GoSwissMapHeaderType map<int,int>
     - __kind: PointerType
-      ID: 163
+      ID: 104
       Name: '*map<int,uint8>'
       ByteSize: 8
-      Pointee: 164 GoSwissMapHeaderType map<int,uint8>
+      Pointee: 105 GoSwissMapHeaderType map<int,uint8>
     - __kind: PointerType
-      ID: 137
+      ID: 94
       Name: '*map<string,[]main.structWithMap>'
       ByteSize: 8
-      Pointee: 138 GoSwissMapHeaderType map<string,[]main.structWithMap>
+      Pointee: 95 GoSwissMapHeaderType map<string,[]main.structWithMap>
     - __kind: PointerType
-      ID: 111
+      ID: 82
       Name: '*map<string,[]string>'
       ByteSize: 8
-      Pointee: 112 GoSwissMapHeaderType map<string,[]string>
+      Pointee: 83 GoSwissMapHeaderType map<string,[]string>
     - __kind: PointerType
-      ID: 100
+      ID: 77
       Name: '*map<string,int>'
       ByteSize: 8
-      Pointee: 101 GoSwissMapHeaderType map<string,int>
+      Pointee: 78 GoSwissMapHeaderType map<string,int>
     - __kind: PointerType
-      ID: 88
+      ID: 72
       Name: '*map<string,main.nestedStruct>'
       ByteSize: 8
-      Pointee: 89 GoSwissMapHeaderType map<string,main.nestedStruct>
+      Pointee: 73 GoSwissMapHeaderType map<string,main.nestedStruct>
     - __kind: PointerType
-      ID: 185
+      ID: 114
       Name: '*map<uint8,[4]int>'
       ByteSize: 8
-      Pointee: 186 GoSwissMapHeaderType map<uint8,[4]int>
+      Pointee: 115 GoSwissMapHeaderType map<uint8,[4]int>
     - __kind: PointerType
-      ID: 174
+      ID: 109
       Name: '*map<uint8,uint8>'
       ByteSize: 8
-      Pointee: 175 GoSwissMapHeaderType map<uint8,uint8>
+      Pointee: 110 GoSwissMapHeaderType map<uint8,uint8>
     - __kind: PointerType
-      ID: 135
+      ID: 92
       Name: '*map[string]int'
       ByteSize: 8
       GoKind: 22
-      Pointee: 99 GoMapType map[string]int
+      Pointee: 76 GoMapType map[string]int
     - __kind: PointerType
-      ID: 214
+      ID: 208
       Name: '*noalg.map.group[[4]int][4]int'
       ByteSize: 8
-      Pointee: 215 StructureType noalg.map.group[[4]int][4]int
+      Pointee: 209 StructureType noalg.map.group[[4]int][4]int
     - __kind: PointerType
-      ID: 203
+      ID: 205
       Name: '*noalg.map.group[[4]int]uint8'
       ByteSize: 8
-      Pointee: 204 StructureType noalg.map.group[[4]int]uint8
+      Pointee: 206 StructureType noalg.map.group[[4]int]uint8
     - __kind: PointerType
-      ID: 129
+      ID: 187
       Name: '*noalg.map.group[[4]string][2]int'
       ByteSize: 8
-      Pointee: 130 StructureType noalg.map.group[[4]string][2]int
+      Pointee: 188 StructureType noalg.map.group[[4]string][2]int
     - __kind: PointerType
-      ID: 156
+      ID: 193
       Name: '*noalg.map.group[bool]main.node'
       ByteSize: 8
-      Pointee: 157 StructureType noalg.map.group[bool]main.node
+      Pointee: 194 StructureType noalg.map.group[bool]main.node
     - __kind: PointerType
-      ID: 83
+      ID: 175
       Name: '*noalg.map.group[int]int'
       ByteSize: 8
-      Pointee: 84 StructureType noalg.map.group[int]int
+      Pointee: 176 StructureType noalg.map.group[int]int
     - __kind: PointerType
-      ID: 169
+      ID: 196
       Name: '*noalg.map.group[int]uint8'
       ByteSize: 8
-      Pointee: 170 StructureType noalg.map.group[int]uint8
+      Pointee: 197 StructureType noalg.map.group[int]uint8
     - __kind: PointerType
-      ID: 143
+      ID: 190
       Name: '*noalg.map.group[string][]main.structWithMap'
       ByteSize: 8
-      Pointee: 144 StructureType noalg.map.group[string][]main.structWithMap
+      Pointee: 191 StructureType noalg.map.group[string][]main.structWithMap
     - __kind: PointerType
-      ID: 117
+      ID: 184
       Name: '*noalg.map.group[string][]string'
       ByteSize: 8
-      Pointee: 118 StructureType noalg.map.group[string][]string
+      Pointee: 185 StructureType noalg.map.group[string][]string
     - __kind: PointerType
-      ID: 106
+      ID: 181
       Name: '*noalg.map.group[string]int'
       ByteSize: 8
-      Pointee: 107 StructureType noalg.map.group[string]int
+      Pointee: 182 StructureType noalg.map.group[string]int
     - __kind: PointerType
-      ID: 94
+      ID: 178
       Name: '*noalg.map.group[string]main.nestedStruct'
       ByteSize: 8
-      Pointee: 95 StructureType noalg.map.group[string]main.nestedStruct
+      Pointee: 179 StructureType noalg.map.group[string]main.nestedStruct
     - __kind: PointerType
-      ID: 191
+      ID: 202
       Name: '*noalg.map.group[uint8][4]int'
       ByteSize: 8
-      Pointee: 192 StructureType noalg.map.group[uint8][4]int
+      Pointee: 203 StructureType noalg.map.group[uint8][4]int
     - __kind: PointerType
-      ID: 180
+      ID: 199
       Name: '*noalg.map.group[uint8]uint8'
       ByteSize: 8
-      Pointee: 181 StructureType noalg.map.group[uint8]uint8
+      Pointee: 200 StructureType noalg.map.group[uint8]uint8
     - __kind: PointerType
       ID: 22
       Name: '*string'
@@ -3468,65 +3468,65 @@ Types:
       ByteSize: 8
       Pointee: 238 GoStringDataType string.str
     - __kind: PointerType
-      ID: 211
+      ID: 127
       Name: '*table<[4]int,[4]int>'
       ByteSize: 8
-      Pointee: 212 StructureType table<[4]int,[4]int>
+      Pointee: 172 StructureType table<[4]int,[4]int>
     - __kind: PointerType
-      ID: 200
+      ID: 122
       Name: '*table<[4]int,uint8>'
       ByteSize: 8
-      Pointee: 201 StructureType table<[4]int,uint8>
+      Pointee: 171 StructureType table<[4]int,uint8>
     - __kind: PointerType
-      ID: 126
+      ID: 90
       Name: '*table<[4]string,[2]int>'
       ByteSize: 8
-      Pointee: 127 StructureType table<[4]string,[2]int>
+      Pointee: 165 StructureType table<[4]string,[2]int>
     - __kind: PointerType
-      ID: 153
+      ID: 102
       Name: '*table<bool,main.node>'
       ByteSize: 8
-      Pointee: 154 StructureType table<bool,main.node>
+      Pointee: 167 StructureType table<bool,main.node>
     - __kind: PointerType
-      ID: 80
+      ID: 70
       Name: '*table<int,int>'
       ByteSize: 8
-      Pointee: 81 StructureType table<int,int>
+      Pointee: 161 StructureType table<int,int>
     - __kind: PointerType
-      ID: 166
+      ID: 107
       Name: '*table<int,uint8>'
       ByteSize: 8
-      Pointee: 167 StructureType table<int,uint8>
+      Pointee: 168 StructureType table<int,uint8>
     - __kind: PointerType
-      ID: 140
+      ID: 97
       Name: '*table<string,[]main.structWithMap>'
       ByteSize: 8
-      Pointee: 141 StructureType table<string,[]main.structWithMap>
+      Pointee: 166 StructureType table<string,[]main.structWithMap>
     - __kind: PointerType
-      ID: 114
+      ID: 85
       Name: '*table<string,[]string>'
       ByteSize: 8
-      Pointee: 115 StructureType table<string,[]string>
+      Pointee: 164 StructureType table<string,[]string>
     - __kind: PointerType
-      ID: 103
+      ID: 80
       Name: '*table<string,int>'
       ByteSize: 8
-      Pointee: 104 StructureType table<string,int>
+      Pointee: 163 StructureType table<string,int>
     - __kind: PointerType
-      ID: 91
+      ID: 75
       Name: '*table<string,main.nestedStruct>'
       ByteSize: 8
-      Pointee: 92 StructureType table<string,main.nestedStruct>
+      Pointee: 162 StructureType table<string,main.nestedStruct>
     - __kind: PointerType
-      ID: 188
+      ID: 117
       Name: '*table<uint8,[4]int>'
       ByteSize: 8
-      Pointee: 189 StructureType table<uint8,[4]int>
+      Pointee: 170 StructureType table<uint8,[4]int>
     - __kind: PointerType
-      ID: 177
+      ID: 112
       Name: '*table<uint8,uint8>'
       ByteSize: 8
-      Pointee: 178 StructureType table<uint8,uint8>
+      Pointee: 169 StructureType table<uint8,uint8>
     - __kind: PointerType
       ID: 34
       Name: '*uint'
@@ -3626,7 +3626,7 @@ Types:
         - Name: m
           Offset: 1
           Expression:
-            Type: 134 ArrayType [2]map[string]int
+            Type: 91 ArrayType [2]map[string]int
             Operations:
                 - __kind: LocationOp
                   Variable: {subprogram: 53, index: 0, name: m}
@@ -3701,7 +3701,7 @@ Types:
         - Name: c
           Offset: 1
           Expression:
-            Type: 218 GoChannelType chan bool
+            Type: 128 GoChannelType chan bool
             Operations:
                 - __kind: LocationOp
                   Variable: {subprogram: 69, index: 0, name: c}
@@ -3749,7 +3749,7 @@ Types:
         - Name: t
           Offset: 1
           Expression:
-            Type: 221 PointerType *main.t
+            Type: 133 PointerType *main.t
             Operations:
                 - __kind: LocationOp
                   Variable: {subprogram: 77, index: 0, name: t}
@@ -3764,7 +3764,7 @@ Types:
         - Name: xs
           Offset: 1
           Expression:
-            Type: 227 GoSliceHeaderType []main.structWithNoStrings
+            Type: 138 GoSliceHeaderType []main.structWithNoStrings
             Operations:
                 - __kind: LocationOp
                   Variable: {subprogram: 82, index: 0, name: xs}
@@ -3788,7 +3788,7 @@ Types:
         - Name: u
           Offset: 1
           Expression:
-            Type: 224 GoSliceHeaderType []uint
+            Type: 135 GoSliceHeaderType []uint
             Operations:
                 - __kind: LocationOp
                   Variable: {subprogram: 79, index: 0, name: u}
@@ -3818,7 +3818,7 @@ Types:
         - Name: e
           Offset: 1
           Expression:
-            Type: 237 StructureType main.emptyStruct
+            Type: 150 StructureType main.emptyStruct
             Operations:
                 - __kind: LocationOp
                   Variable: {subprogram: 98, index: 0, name: e}
@@ -3878,7 +3878,7 @@ Types:
         - Name: a
           Offset: 1
           Expression:
-            Type: 73 ArrayType [5]int
+            Type: 63 ArrayType [5]int
             Operations:
                 - __kind: LocationOp
                   Variable: {subprogram: 43, index: 0, name: a}
@@ -4004,7 +4004,7 @@ Types:
         - Name: a
           Offset: 1
           Expression:
-            Type: 73 ArrayType [5]int
+            Type: 63 ArrayType [5]int
             Operations:
                 - __kind: LocationOp
                   Variable: {subprogram: 104, index: 0, name: a}
@@ -4094,7 +4094,7 @@ Types:
         - Name: b
           Offset: 1
           Expression:
-            Type: 74 GoInterfaceType main.behavior
+            Type: 64 GoInterfaceType main.behavior
             Operations:
                 - __kind: LocationOp
                   Variable: {subprogram: 44, index: 0, name: b}
@@ -4109,7 +4109,7 @@ Types:
         - Name: a
           Offset: 1
           Expression:
-            Type: 160 StructureType main.node
+            Type: 131 StructureType main.node
             Operations:
                 - __kind: LocationOp
                   Variable: {subprogram: 71, index: 0, name: a}
@@ -4124,7 +4124,7 @@ Types:
         - Name: m
           Offset: 1
           Expression:
-            Type: 122 GoMapType map[[4]string][2]int
+            Type: 86 GoMapType map[[4]string][2]int
             Operations:
                 - __kind: LocationOp
                   Variable: {subprogram: 51, index: 0, name: m}
@@ -4139,7 +4139,7 @@ Types:
         - Name: m
           Offset: 1
           Expression:
-            Type: 136 GoMapType map[string][]main.structWithMap
+            Type: 93 GoMapType map[string][]main.structWithMap
             Operations:
                 - __kind: LocationOp
                   Variable: {subprogram: 57, index: 0, name: m}
@@ -4154,7 +4154,7 @@ Types:
         - Name: m
           Offset: 1
           Expression:
-            Type: 76 GoMapType map[int]int
+            Type: 66 GoMapType map[int]int
             Operations:
                 - __kind: LocationOp
                   Variable: {subprogram: 55, index: 0, name: m}
@@ -4169,7 +4169,7 @@ Types:
         - Name: m
           Offset: 1
           Expression:
-            Type: 207 GoMapType map[[4]int][4]int
+            Type: 123 GoMapType map[[4]int][4]int
             Operations:
                 - __kind: LocationOp
                   Variable: {subprogram: 66, index: 0, name: m}
@@ -4184,7 +4184,7 @@ Types:
         - Name: m
           Offset: 1
           Expression:
-            Type: 196 GoMapType map[[4]int]uint8
+            Type: 118 GoMapType map[[4]int]uint8
             Operations:
                 - __kind: LocationOp
                   Variable: {subprogram: 65, index: 0, name: m}
@@ -4199,7 +4199,7 @@ Types:
         - Name: redactMyEntries
           Offset: 1
           Expression:
-            Type: 136 GoMapType map[string][]main.structWithMap
+            Type: 93 GoMapType map[string][]main.structWithMap
             Operations:
                 - __kind: LocationOp
                   Variable: {subprogram: 56, index: 0, name: redactMyEntries}
@@ -4214,7 +4214,7 @@ Types:
         - Name: m
           Offset: 1
           Expression:
-            Type: 184 GoMapType map[uint8][4]int
+            Type: 113 GoMapType map[uint8][4]int
             Operations:
                 - __kind: LocationOp
                   Variable: {subprogram: 64, index: 0, name: m}
@@ -4229,7 +4229,7 @@ Types:
         - Name: m
           Offset: 1
           Expression:
-            Type: 173 GoMapType map[uint8]uint8
+            Type: 108 GoMapType map[uint8]uint8
             Operations:
                 - __kind: LocationOp
                   Variable: {subprogram: 63, index: 0, name: m}
@@ -4244,7 +4244,7 @@ Types:
         - Name: m
           Offset: 1
           Expression:
-            Type: 99 GoMapType map[string]int
+            Type: 76 GoMapType map[string]int
             Operations:
                 - __kind: LocationOp
                   Variable: {subprogram: 49, index: 0, name: m}
@@ -4259,7 +4259,7 @@ Types:
         - Name: m
           Offset: 1
           Expression:
-            Type: 110 GoMapType map[string][]string
+            Type: 81 GoMapType map[string][]string
             Operations:
                 - __kind: LocationOp
                   Variable: {subprogram: 50, index: 0, name: m}
@@ -4274,7 +4274,7 @@ Types:
         - Name: m
           Offset: 1
           Expression:
-            Type: 87 GoMapType map[string]main.nestedStruct
+            Type: 71 GoMapType map[string]main.nestedStruct
             Operations:
                 - __kind: LocationOp
                   Variable: {subprogram: 48, index: 0, name: m}
@@ -4289,7 +4289,7 @@ Types:
         - Name: m
           Offset: 1
           Expression:
-            Type: 149 GoMapType map[bool]main.node
+            Type: 98 GoMapType map[bool]main.node
             Operations:
                 - __kind: LocationOp
                   Variable: {subprogram: 58, index: 0, name: m}
@@ -4304,7 +4304,7 @@ Types:
         - Name: m
           Offset: 1
           Expression:
-            Type: 173 GoMapType map[uint8]uint8
+            Type: 108 GoMapType map[uint8]uint8
             Operations:
                 - __kind: LocationOp
                   Variable: {subprogram: 62, index: 0, name: m}
@@ -4319,7 +4319,7 @@ Types:
         - Name: m
           Offset: 1
           Expression:
-            Type: 173 GoMapType map[uint8]uint8
+            Type: 108 GoMapType map[uint8]uint8
             Operations:
                 - __kind: LocationOp
                   Variable: {subprogram: 61, index: 0, name: m}
@@ -4334,7 +4334,7 @@ Types:
         - Name: redactMyEntries
           Offset: 1
           Expression:
-            Type: 162 GoMapType map[int]uint8
+            Type: 103 GoMapType map[int]uint8
             Operations:
                 - __kind: LocationOp
                   Variable: {subprogram: 60, index: 0, name: redactMyEntries}
@@ -4349,7 +4349,7 @@ Types:
         - Name: m
           Offset: 1
           Expression:
-            Type: 162 GoMapType map[int]uint8
+            Type: 103 GoMapType map[int]uint8
             Operations:
                 - __kind: LocationOp
                   Variable: {subprogram: 59, index: 0, name: m}
@@ -4454,7 +4454,7 @@ Types:
         - Name: xs
           Offset: 1
           Expression:
-            Type: 227 GoSliceHeaderType []main.structWithNoStrings
+            Type: 138 GoSliceHeaderType []main.structWithNoStrings
             Operations:
                 - __kind: LocationOp
                   Variable: {subprogram: 83, index: 0, name: xs}
@@ -4487,7 +4487,7 @@ Types:
         - Name: s
           Offset: 2
           Expression:
-            Type: 230 GoSliceHeaderType []bool
+            Type: 142 GoSliceHeaderType []bool
             Operations:
                 - __kind: LocationOp
                   Variable: {subprogram: 85, index: 1, name: s}
@@ -4511,7 +4511,7 @@ Types:
         - Name: xs
           Offset: 1
           Expression:
-            Type: 231 GoSliceHeaderType []uint16
+            Type: 143 GoSliceHeaderType []uint16
             Operations:
                 - __kind: LocationOp
                   Variable: {subprogram: 86, index: 0, name: xs}
@@ -4526,7 +4526,7 @@ Types:
         - Name: a
           Offset: 1
           Expression:
-            Type: 234 PointerType *main.oneStringStruct
+            Type: 146 PointerType *main.oneStringStruct
             Operations:
                 - __kind: LocationOp
                   Variable: {subprogram: 93, index: 0, name: a}
@@ -4541,7 +4541,7 @@ Types:
         - Name: a
           Offset: 1
           Expression:
-            Type: 161 PointerType *main.node
+            Type: 132 PointerType *main.node
             Operations:
                 - __kind: LocationOp
                   Variable: {subprogram: 72, index: 0, name: a}
@@ -4556,7 +4556,7 @@ Types:
         - Name: m
           Offset: 1
           Expression:
-            Type: 135 PointerType *map[string]int
+            Type: 92 PointerType *map[string]int
             Operations:
                 - __kind: LocationOp
                   Variable: {subprogram: 54, index: 0, name: m}
@@ -4571,7 +4571,7 @@ Types:
         - Name: a
           Offset: 1
           Expression:
-            Type: 219 PointerType *main.structWithTwoValues
+            Type: 129 PointerType *main.structWithTwoValues
             Operations:
                 - __kind: LocationOp
                   Variable: {subprogram: 70, index: 0, name: a}
@@ -4841,7 +4841,7 @@ Types:
         - Name: u
           Offset: 1
           Expression:
-            Type: 225 GoSliceHeaderType [][]uint
+            Type: 136 GoSliceHeaderType [][]uint
             Operations:
                 - __kind: LocationOp
                   Variable: {subprogram: 80, index: 0, name: u}
@@ -4856,7 +4856,7 @@ Types:
         - Name: m
           Offset: 1
           Expression:
-            Type: 99 GoMapType map[string]int
+            Type: 76 GoMapType map[string]int
             Operations:
                 - __kind: LocationOp
                   Variable: {subprogram: 52, index: 0, name: m}
@@ -4901,7 +4901,7 @@ Types:
         - Name: s
           Offset: 1
           Expression:
-            Type: 121 GoSliceHeaderType []string
+            Type: 141 GoSliceHeaderType []string
             Operations:
                 - __kind: LocationOp
                   Variable: {subprogram: 84, index: 0, name: s}
@@ -4916,7 +4916,7 @@ Types:
         - Name: xs
           Offset: 1
           Expression:
-            Type: 227 GoSliceHeaderType []main.structWithNoStrings
+            Type: 138 GoSliceHeaderType []main.structWithNoStrings
             Operations:
                 - __kind: LocationOp
                   Variable: {subprogram: 81, index: 0, name: xs}
@@ -4940,7 +4940,7 @@ Types:
         - Name: s
           Offset: 1
           Expression:
-            Type: 75 StructureType main.structWithMap
+            Type: 65 StructureType main.structWithMap
             Operations:
                 - __kind: LocationOp
                   Variable: {subprogram: 47, index: 0, name: s}
@@ -4955,7 +4955,7 @@ Types:
         - Name: x
           Offset: 1
           Expression:
-            Type: 236 StructureType main.aStruct
+            Type: 148 StructureType main.aStruct
             Operations:
                 - __kind: LocationOp
                   Variable: {subprogram: 97, index: 0, name: x}
@@ -4970,7 +4970,7 @@ Types:
         - Name: a
           Offset: 1
           Expression:
-            Type: 233 PointerType *main.threeStringStruct
+            Type: 145 PointerType *main.threeStringStruct
             Operations:
                 - __kind: LocationOp
                   Variable: {subprogram: 92, index: 0, name: a}
@@ -4985,7 +4985,7 @@ Types:
         - Name: a
           Offset: 1
           Expression:
-            Type: 232 StructureType main.threeStringStruct
+            Type: 144 StructureType main.threeStringStruct
             Operations:
                 - __kind: LocationOp
                   Variable: {subprogram: 91, index: 0, name: a}
@@ -5138,7 +5138,7 @@ Types:
         - Name: u
           Offset: 1
           Expression:
-            Type: 224 GoSliceHeaderType []uint
+            Type: 135 GoSliceHeaderType []uint
             Operations:
                 - __kind: LocationOp
                   Variable: {subprogram: 78, index: 0, name: u}
@@ -5198,7 +5198,7 @@ Types:
         - Name: xs
           Offset: 1
           Expression:
-            Type: 224 GoSliceHeaderType []uint
+            Type: 135 GoSliceHeaderType []uint
             Operations:
                 - __kind: LocationOp
                   Variable: {subprogram: 87, index: 0, name: xs}
@@ -5279,13 +5279,13 @@ Types:
       HasCount: true
       Element: 15 BaseType int8
     - __kind: ArrayType
-      ID: 134
+      ID: 91
       Name: '[2]map[string]int'
       ByteSize: 16
       GoKind: 17
       Count: 2
       HasCount: true
-      Element: 99 GoMapType map[string]int
+      Element: 76 GoMapType map[string]int
     - __kind: ArrayType
       ID: 38
       Name: '[2]string'
@@ -5338,7 +5338,7 @@ Types:
       HasCount: true
       Element: 3 BaseType uint8
     - __kind: ArrayType
-      ID: 195
+      ID: 233
       Name: '[4]int'
       ByteSize: 32
       GoRuntimeType: 672896
@@ -5347,7 +5347,7 @@ Types:
       HasCount: true
       Element: 7 BaseType int
     - __kind: ArrayType
-      ID: 133
+      ID: 220
       Name: '[4]string'
       ByteSize: 64
       GoRuntimeType: 673184
@@ -5356,7 +5356,7 @@ Types:
       HasCount: true
       Element: 9 GoStringHeaderType string
     - __kind: ArrayType
-      ID: 73
+      ID: 63
       Name: '[5]int'
       ByteSize: 40
       GoKind: 17
@@ -5386,88 +5386,88 @@ Types:
       ByteSize: 2048
       Element: 22 PointerType *string
     - __kind: GoSliceDataType
-      ID: 268
+      ID: 264
       Name: '[]*table<[4]int,[4]int>.array'
       ByteSize: 8192
-      Element: 211 PointerType *table<[4]int,[4]int>
+      Element: 127 PointerType *table<[4]int,[4]int>
     - __kind: GoSliceDataType
-      ID: 266
+      ID: 262
       Name: '[]*table<[4]int,uint8>.array'
       ByteSize: 8192
-      Element: 200 PointerType *table<[4]int,uint8>
+      Element: 122 PointerType *table<[4]int,uint8>
     - __kind: GoSliceDataType
-      ID: 252
+      ID: 250
       Name: '[]*table<[4]string,[2]int>.array'
       ByteSize: 8192
-      Element: 126 PointerType *table<[4]string,[2]int>
+      Element: 90 PointerType *table<[4]string,[2]int>
     - __kind: GoSliceDataType
-      ID: 258
+      ID: 254
       Name: '[]*table<bool,main.node>.array'
       ByteSize: 8192
-      Element: 153 PointerType *table<bool,main.node>
+      Element: 102 PointerType *table<bool,main.node>
     - __kind: GoSliceDataType
       ID: 242
       Name: '[]*table<int,int>.array'
       ByteSize: 8192
-      Element: 80 PointerType *table<int,int>
+      Element: 70 PointerType *table<int,int>
     - __kind: GoSliceDataType
-      ID: 260
+      ID: 256
       Name: '[]*table<int,uint8>.array'
       ByteSize: 8192
-      Element: 166 PointerType *table<int,uint8>
+      Element: 107 PointerType *table<int,uint8>
     - __kind: GoSliceDataType
-      ID: 254
+      ID: 252
       Name: '[]*table<string,[]main.structWithMap>.array'
       ByteSize: 8192
-      Element: 140 PointerType *table<string,[]main.structWithMap>
+      Element: 97 PointerType *table<string,[]main.structWithMap>
     - __kind: GoSliceDataType
       ID: 248
       Name: '[]*table<string,[]string>.array'
       ByteSize: 8192
-      Element: 114 PointerType *table<string,[]string>
+      Element: 85 PointerType *table<string,[]string>
     - __kind: GoSliceDataType
       ID: 246
       Name: '[]*table<string,int>.array'
       ByteSize: 8192
-      Element: 103 PointerType *table<string,int>
+      Element: 80 PointerType *table<string,int>
     - __kind: GoSliceDataType
       ID: 244
       Name: '[]*table<string,main.nestedStruct>.array'
       ByteSize: 8192
-      Element: 91 PointerType *table<string,main.nestedStruct>
+      Element: 75 PointerType *table<string,main.nestedStruct>
     - __kind: GoSliceDataType
-      ID: 264
+      ID: 260
       Name: '[]*table<uint8,[4]int>.array'
       ByteSize: 8192
-      Element: 188 PointerType *table<uint8,[4]int>
+      Element: 117 PointerType *table<uint8,[4]int>
     - __kind: GoSliceDataType
-      ID: 262
+      ID: 258
       Name: '[]*table<uint8,uint8>.array'
       ByteSize: 8192
-      Element: 177 PointerType *table<uint8,uint8>
+      Element: 112 PointerType *table<uint8,uint8>
     - __kind: GoSliceHeaderType
-      ID: 225
+      ID: 136
       Name: '[][]uint'
       ByteSize: 24
       GoKind: 23
       RawFields:
         - Name: array
           Offset: 0
-          Type: 226 PointerType *[]uint
+          Type: 137 PointerType *[]uint
         - Name: len
           Offset: 8
           Type: 7 BaseType int
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 274 GoSliceDataType [][]uint.array
+      Data: 270 GoSliceDataType [][]uint.array
     - __kind: GoSliceDataType
-      ID: 274
+      ID: 270
       Name: '[][]uint.array'
       ByteSize: 2048
-      Element: 224 GoSliceHeaderType []uint
+      Element: 135 GoSliceHeaderType []uint
     - __kind: GoSliceHeaderType
-      ID: 230
+      ID: 142
       Name: '[]bool'
       ByteSize: 24
       GoRuntimeType: 478528
@@ -5482,14 +5482,14 @@ Types:
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 278 GoSliceDataType []bool.array
+      Data: 276 GoSliceDataType []bool.array
     - __kind: GoSliceDataType
-      ID: 278
+      ID: 276
       Name: '[]bool.array'
       ByteSize: 2048
       Element: 4 BaseType bool
     - __kind: GoSliceHeaderType
-      ID: 147
+      ID: 223
       Name: '[]main.structWithMap'
       ByteSize: 24
       GoRuntimeType: 469888
@@ -5497,102 +5497,102 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 148 PointerType *main.structWithMap
+          Type: 224 PointerType *main.structWithMap
         - Name: len
           Offset: 8
           Type: 7 BaseType int
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 256 GoSliceDataType []main.structWithMap.array
+      Data: 280 GoSliceDataType []main.structWithMap.array
     - __kind: GoSliceDataType
-      ID: 256
+      ID: 280
       Name: '[]main.structWithMap.array'
       ByteSize: 2048
-      Element: 75 StructureType main.structWithMap
+      Element: 65 StructureType main.structWithMap
     - __kind: GoSliceHeaderType
-      ID: 227
+      ID: 138
       Name: '[]main.structWithNoStrings'
       ByteSize: 24
       GoKind: 23
       RawFields:
         - Name: array
           Offset: 0
-          Type: 228 PointerType *main.structWithNoStrings
+          Type: 139 PointerType *main.structWithNoStrings
         - Name: len
           Offset: 8
           Type: 7 BaseType int
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 276 GoSliceDataType []main.structWithNoStrings.array
+      Data: 272 GoSliceDataType []main.structWithNoStrings.array
     - __kind: GoSliceDataType
-      ID: 276
+      ID: 272
       Name: '[]main.structWithNoStrings.array'
       ByteSize: 2048
-      Element: 229 StructureType main.structWithNoStrings
+      Element: 140 StructureType main.structWithNoStrings
     - __kind: GoSliceDataType
-      ID: 269
+      ID: 265
       Name: '[]noalg.map.group[[4]int][4]int.array'
       ByteSize: 2048
-      Element: 215 StructureType noalg.map.group[[4]int][4]int
+      Element: 209 StructureType noalg.map.group[[4]int][4]int
     - __kind: GoSliceDataType
-      ID: 267
+      ID: 263
       Name: '[]noalg.map.group[[4]int]uint8.array'
       ByteSize: 2048
-      Element: 204 StructureType noalg.map.group[[4]int]uint8
+      Element: 206 StructureType noalg.map.group[[4]int]uint8
     - __kind: GoSliceDataType
-      ID: 253
+      ID: 251
       Name: '[]noalg.map.group[[4]string][2]int.array'
       ByteSize: 2048
-      Element: 130 StructureType noalg.map.group[[4]string][2]int
+      Element: 188 StructureType noalg.map.group[[4]string][2]int
     - __kind: GoSliceDataType
-      ID: 259
+      ID: 255
       Name: '[]noalg.map.group[bool]main.node.array'
       ByteSize: 2048
-      Element: 157 StructureType noalg.map.group[bool]main.node
+      Element: 194 StructureType noalg.map.group[bool]main.node
     - __kind: GoSliceDataType
       ID: 243
       Name: '[]noalg.map.group[int]int.array'
       ByteSize: 2048
-      Element: 84 StructureType noalg.map.group[int]int
+      Element: 176 StructureType noalg.map.group[int]int
     - __kind: GoSliceDataType
-      ID: 261
+      ID: 257
       Name: '[]noalg.map.group[int]uint8.array'
       ByteSize: 2048
-      Element: 170 StructureType noalg.map.group[int]uint8
+      Element: 197 StructureType noalg.map.group[int]uint8
     - __kind: GoSliceDataType
-      ID: 255
+      ID: 253
       Name: '[]noalg.map.group[string][]main.structWithMap.array'
       ByteSize: 2048
-      Element: 144 StructureType noalg.map.group[string][]main.structWithMap
+      Element: 191 StructureType noalg.map.group[string][]main.structWithMap
     - __kind: GoSliceDataType
       ID: 249
       Name: '[]noalg.map.group[string][]string.array'
       ByteSize: 2048
-      Element: 118 StructureType noalg.map.group[string][]string
+      Element: 185 StructureType noalg.map.group[string][]string
     - __kind: GoSliceDataType
       ID: 247
       Name: '[]noalg.map.group[string]int.array'
       ByteSize: 2048
-      Element: 107 StructureType noalg.map.group[string]int
+      Element: 182 StructureType noalg.map.group[string]int
     - __kind: GoSliceDataType
       ID: 245
       Name: '[]noalg.map.group[string]main.nestedStruct.array'
       ByteSize: 2048
-      Element: 95 StructureType noalg.map.group[string]main.nestedStruct
+      Element: 179 StructureType noalg.map.group[string]main.nestedStruct
     - __kind: GoSliceDataType
-      ID: 265
+      ID: 261
       Name: '[]noalg.map.group[uint8][4]int.array'
       ByteSize: 2048
-      Element: 192 StructureType noalg.map.group[uint8][4]int
+      Element: 203 StructureType noalg.map.group[uint8][4]int
     - __kind: GoSliceDataType
-      ID: 263
+      ID: 259
       Name: '[]noalg.map.group[uint8]uint8.array'
       ByteSize: 2048
-      Element: 181 StructureType noalg.map.group[uint8]uint8
+      Element: 200 StructureType noalg.map.group[uint8]uint8
     - __kind: GoSliceHeaderType
-      ID: 121
+      ID: 141
       Name: '[]string'
       ByteSize: 24
       GoRuntimeType: 478656
@@ -5607,14 +5607,14 @@ Types:
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 250 GoSliceDataType []string.array
+      Data: 274 GoSliceDataType []string.array
     - __kind: GoSliceDataType
-      ID: 250
+      ID: 274
       Name: '[]string.array'
       ByteSize: 2048
       Element: 9 GoStringHeaderType string
     - __kind: GoSliceHeaderType
-      ID: 224
+      ID: 135
       Name: '[]uint'
       ByteSize: 24
       GoRuntimeType: 478144
@@ -5629,14 +5629,14 @@ Types:
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 272 GoSliceDataType []uint.array
+      Data: 268 GoSliceDataType []uint.array
     - __kind: GoSliceDataType
-      ID: 272
+      ID: 268
       Name: '[]uint.array'
       ByteSize: 2048
       Element: 16 BaseType uint
     - __kind: GoSliceHeaderType
-      ID: 231
+      ID: 143
       Name: '[]uint16'
       ByteSize: 24
       GoRuntimeType: 477504
@@ -5651,9 +5651,9 @@ Types:
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 280 GoSliceDataType []uint16.array
+      Data: 278 GoSliceDataType []uint16.array
     - __kind: GoSliceDataType
-      ID: 280
+      ID: 278
       Name: '[]uint16.array'
       ByteSize: 2048
       Element: 6 BaseType uint16
@@ -5664,7 +5664,7 @@ Types:
       GoRuntimeType: 576032
       GoKind: 1
     - __kind: GoChannelType
-      ID: 218
+      ID: 128
       Name: chan bool
       GoRuntimeType: 587360
       GoKind: 18
@@ -5717,173 +5717,173 @@ Types:
       GoRuntimeType: 468928
       GoKind: 19
     - __kind: GoSwissMapGroupsType
-      ID: 213
+      ID: 207
       Name: groupReference<[4]int,[4]int>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 214 PointerType *noalg.map.group[[4]int][4]int
+          Type: 208 PointerType *noalg.map.group[[4]int][4]int
         - Name: lengthMask
           Offset: 8
           Type: 8 BaseType uint64
-      GroupType: 215 StructureType noalg.map.group[[4]int][4]int
-      GroupSliceType: 269 GoSliceDataType []noalg.map.group[[4]int][4]int.array
+      GroupType: 209 StructureType noalg.map.group[[4]int][4]int
+      GroupSliceType: 265 GoSliceDataType []noalg.map.group[[4]int][4]int.array
     - __kind: GoSwissMapGroupsType
-      ID: 202
+      ID: 204
       Name: groupReference<[4]int,uint8>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 203 PointerType *noalg.map.group[[4]int]uint8
+          Type: 205 PointerType *noalg.map.group[[4]int]uint8
         - Name: lengthMask
           Offset: 8
           Type: 8 BaseType uint64
-      GroupType: 204 StructureType noalg.map.group[[4]int]uint8
-      GroupSliceType: 267 GoSliceDataType []noalg.map.group[[4]int]uint8.array
+      GroupType: 206 StructureType noalg.map.group[[4]int]uint8
+      GroupSliceType: 263 GoSliceDataType []noalg.map.group[[4]int]uint8.array
     - __kind: GoSwissMapGroupsType
-      ID: 128
+      ID: 186
       Name: groupReference<[4]string,[2]int>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 129 PointerType *noalg.map.group[[4]string][2]int
+          Type: 187 PointerType *noalg.map.group[[4]string][2]int
         - Name: lengthMask
           Offset: 8
           Type: 8 BaseType uint64
-      GroupType: 130 StructureType noalg.map.group[[4]string][2]int
-      GroupSliceType: 253 GoSliceDataType []noalg.map.group[[4]string][2]int.array
+      GroupType: 188 StructureType noalg.map.group[[4]string][2]int
+      GroupSliceType: 251 GoSliceDataType []noalg.map.group[[4]string][2]int.array
     - __kind: GoSwissMapGroupsType
-      ID: 155
+      ID: 192
       Name: groupReference<bool,main.node>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 156 PointerType *noalg.map.group[bool]main.node
+          Type: 193 PointerType *noalg.map.group[bool]main.node
         - Name: lengthMask
           Offset: 8
           Type: 8 BaseType uint64
-      GroupType: 157 StructureType noalg.map.group[bool]main.node
-      GroupSliceType: 259 GoSliceDataType []noalg.map.group[bool]main.node.array
+      GroupType: 194 StructureType noalg.map.group[bool]main.node
+      GroupSliceType: 255 GoSliceDataType []noalg.map.group[bool]main.node.array
     - __kind: GoSwissMapGroupsType
-      ID: 82
+      ID: 174
       Name: groupReference<int,int>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 83 PointerType *noalg.map.group[int]int
+          Type: 175 PointerType *noalg.map.group[int]int
         - Name: lengthMask
           Offset: 8
           Type: 8 BaseType uint64
-      GroupType: 84 StructureType noalg.map.group[int]int
+      GroupType: 176 StructureType noalg.map.group[int]int
       GroupSliceType: 243 GoSliceDataType []noalg.map.group[int]int.array
     - __kind: GoSwissMapGroupsType
-      ID: 168
+      ID: 195
       Name: groupReference<int,uint8>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 169 PointerType *noalg.map.group[int]uint8
+          Type: 196 PointerType *noalg.map.group[int]uint8
         - Name: lengthMask
           Offset: 8
           Type: 8 BaseType uint64
-      GroupType: 170 StructureType noalg.map.group[int]uint8
-      GroupSliceType: 261 GoSliceDataType []noalg.map.group[int]uint8.array
+      GroupType: 197 StructureType noalg.map.group[int]uint8
+      GroupSliceType: 257 GoSliceDataType []noalg.map.group[int]uint8.array
     - __kind: GoSwissMapGroupsType
-      ID: 142
+      ID: 189
       Name: groupReference<string,[]main.structWithMap>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 143 PointerType *noalg.map.group[string][]main.structWithMap
+          Type: 190 PointerType *noalg.map.group[string][]main.structWithMap
         - Name: lengthMask
           Offset: 8
           Type: 8 BaseType uint64
-      GroupType: 144 StructureType noalg.map.group[string][]main.structWithMap
-      GroupSliceType: 255 GoSliceDataType []noalg.map.group[string][]main.structWithMap.array
+      GroupType: 191 StructureType noalg.map.group[string][]main.structWithMap
+      GroupSliceType: 253 GoSliceDataType []noalg.map.group[string][]main.structWithMap.array
     - __kind: GoSwissMapGroupsType
-      ID: 116
+      ID: 183
       Name: groupReference<string,[]string>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 117 PointerType *noalg.map.group[string][]string
+          Type: 184 PointerType *noalg.map.group[string][]string
         - Name: lengthMask
           Offset: 8
           Type: 8 BaseType uint64
-      GroupType: 118 StructureType noalg.map.group[string][]string
+      GroupType: 185 StructureType noalg.map.group[string][]string
       GroupSliceType: 249 GoSliceDataType []noalg.map.group[string][]string.array
     - __kind: GoSwissMapGroupsType
-      ID: 105
+      ID: 180
       Name: groupReference<string,int>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 106 PointerType *noalg.map.group[string]int
+          Type: 181 PointerType *noalg.map.group[string]int
         - Name: lengthMask
           Offset: 8
           Type: 8 BaseType uint64
-      GroupType: 107 StructureType noalg.map.group[string]int
+      GroupType: 182 StructureType noalg.map.group[string]int
       GroupSliceType: 247 GoSliceDataType []noalg.map.group[string]int.array
     - __kind: GoSwissMapGroupsType
-      ID: 93
+      ID: 177
       Name: groupReference<string,main.nestedStruct>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 94 PointerType *noalg.map.group[string]main.nestedStruct
+          Type: 178 PointerType *noalg.map.group[string]main.nestedStruct
         - Name: lengthMask
           Offset: 8
           Type: 8 BaseType uint64
-      GroupType: 95 StructureType noalg.map.group[string]main.nestedStruct
+      GroupType: 179 StructureType noalg.map.group[string]main.nestedStruct
       GroupSliceType: 245 GoSliceDataType []noalg.map.group[string]main.nestedStruct.array
     - __kind: GoSwissMapGroupsType
-      ID: 190
+      ID: 201
       Name: groupReference<uint8,[4]int>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 191 PointerType *noalg.map.group[uint8][4]int
+          Type: 202 PointerType *noalg.map.group[uint8][4]int
         - Name: lengthMask
           Offset: 8
           Type: 8 BaseType uint64
-      GroupType: 192 StructureType noalg.map.group[uint8][4]int
-      GroupSliceType: 265 GoSliceDataType []noalg.map.group[uint8][4]int.array
+      GroupType: 203 StructureType noalg.map.group[uint8][4]int
+      GroupSliceType: 261 GoSliceDataType []noalg.map.group[uint8][4]int.array
     - __kind: GoSwissMapGroupsType
-      ID: 179
+      ID: 198
       Name: groupReference<uint8,uint8>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 180 PointerType *noalg.map.group[uint8]uint8
+          Type: 199 PointerType *noalg.map.group[uint8]uint8
         - Name: lengthMask
           Offset: 8
           Type: 8 BaseType uint64
-      GroupType: 181 StructureType noalg.map.group[uint8]uint8
-      GroupSliceType: 263 GoSliceDataType []noalg.map.group[uint8]uint8.array
+      GroupType: 200 StructureType noalg.map.group[uint8]uint8
+      GroupSliceType: 259 GoSliceDataType []noalg.map.group[uint8]uint8.array
     - __kind: BaseType
       ID: 7
       Name: int
@@ -5928,7 +5928,7 @@ Types:
           Offset: 8
           Type: 14 VoidPointerType unsafe.Pointer
     - __kind: StructureType
-      ID: 65
+      ID: 153
       Name: internal/sync.Mutex
       ByteSize: 8
       GoRuntimeType: 1.454624e+06
@@ -5954,7 +5954,7 @@ Types:
           Offset: 8
           Type: 14 VoidPointerType unsafe.Pointer
     - __kind: StructureType
-      ID: 236
+      ID: 148
       Name: main.aStruct
       ByteSize: 56
       GoKind: 25
@@ -5970,9 +5970,9 @@ Types:
           Type: 7 BaseType int
         - Name: nested
           Offset: 32
-          Type: 98 StructureType main.nestedStruct
+          Type: 149 StructureType main.nestedStruct
     - __kind: GoInterfaceType
-      ID: 74
+      ID: 64
       Name: main.behavior
       ByteSize: 16
       GoRuntimeType: 1.012064e+06
@@ -6000,7 +6000,7 @@ Types:
           Offset: 32
           Type: 55 GoInterfaceType io.Writer
     - __kind: StructureType
-      ID: 237
+      ID: 150
       Name: main.emptyStruct
       GoKind: 25
       RawFields: []
@@ -6016,16 +6016,16 @@ Types:
           Type: 56 StructureType main.esotericStack
         - Name: mu
           Offset: 64
-          Type: 63 StructureType sync.Mutex
+          Type: 151 StructureType sync.Mutex
         - Name: once
           Offset: 72
-          Type: 66 StructureType sync.Once
+          Type: 154 StructureType sync.Once
         - Name: wg
           Offset: 88
-          Type: 69 StructureType sync.WaitGroup
+          Type: 157 StructureType sync.WaitGroup
         - Name: a
           Offset: 104
-          Type: 72 StructureType sync/atomic.Int32
+          Type: 160 StructureType sync/atomic.Int32
     - __kind: StructureType
       ID: 56
       Name: main.esotericStack
@@ -6055,7 +6055,7 @@ Types:
           Offset: 56
           Type: 60 GoSubroutineType func()
     - __kind: StructureType
-      ID: 98
+      ID: 149
       Name: main.nestedStruct
       ByteSize: 24
       GoRuntimeType: 1.444064e+06
@@ -6068,7 +6068,7 @@ Types:
           Offset: 8
           Type: 9 GoStringHeaderType string
     - __kind: StructureType
-      ID: 160
+      ID: 131
       Name: main.node
       ByteSize: 16
       GoRuntimeType: 1.443904e+06
@@ -6079,9 +6079,9 @@ Types:
           Type: 7 BaseType int
         - Name: b
           Offset: 8
-          Type: 161 PointerType *main.node
+          Type: 132 PointerType *main.node
     - __kind: StructureType
-      ID: 235
+      ID: 147
       Name: main.oneStringStruct
       ByteSize: 16
       GoKind: 25
@@ -6103,7 +6103,7 @@ Types:
           Offset: 8
           Type: 14 VoidPointerType unsafe.Pointer
     - __kind: StructureType
-      ID: 75
+      ID: 65
       Name: main.structWithMap
       ByteSize: 8
       GoRuntimeType: 1.173504e+06
@@ -6111,9 +6111,9 @@ Types:
       RawFields:
         - Name: m
           Offset: 0
-          Type: 76 GoMapType map[int]int
+          Type: 66 GoMapType map[int]int
     - __kind: StructureType
-      ID: 229
+      ID: 140
       Name: main.structWithNoStrings
       ByteSize: 2
       GoKind: 25
@@ -6125,7 +6125,7 @@ Types:
           Offset: 1
           Type: 4 BaseType bool
     - __kind: StructureType
-      ID: 220
+      ID: 130
       Name: main.structWithTwoValues
       ByteSize: 16
       GoKind: 25
@@ -6137,28 +6137,28 @@ Types:
           Offset: 8
           Type: 4 BaseType bool
     - __kind: GoSliceHeaderType
-      ID: 222
+      ID: 134
       Name: main.t
       ByteSize: 24
       GoKind: 23
       RawFields:
         - Name: array
           Offset: 0
-          Type: 223 PointerType **main.t
+          Type: 173 PointerType **main.t
         - Name: len
           Offset: 8
           Type: 7 BaseType int
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 270 GoSliceDataType main.t.array
+      Data: 266 GoSliceDataType main.t.array
     - __kind: GoSliceDataType
-      ID: 270
+      ID: 266
       Name: main.t.array
       ByteSize: 2048
-      Element: 221 PointerType *main.t
+      Element: 133 PointerType *main.t
     - __kind: StructureType
-      ID: 232
+      ID: 144
       Name: main.threeStringStruct
       ByteSize: 48
       GoKind: 25
@@ -6178,7 +6178,7 @@ Types:
       ByteSize: 2
       GoKind: 9
     - __kind: GoSwissMapHeaderType
-      ID: 209
+      ID: 125
       Name: map<[4]int,[4]int>
       ByteSize: 48
       GoKind: 25
@@ -6191,7 +6191,7 @@ Types:
           Type: 1 BaseType uintptr
         - Name: dirPtr
           Offset: 16
-          Type: 210 PointerType **table<[4]int,[4]int>
+          Type: 126 PointerType **table<[4]int,[4]int>
         - Name: dirLen
           Offset: 24
           Type: 7 BaseType int
@@ -6207,10 +6207,10 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 8 BaseType uint64
-      TablePtrSliceType: 268 GoSliceDataType []*table<[4]int,[4]int>.array
-      GroupType: 215 StructureType noalg.map.group[[4]int][4]int
+      TablePtrSliceType: 264 GoSliceDataType []*table<[4]int,[4]int>.array
+      GroupType: 209 StructureType noalg.map.group[[4]int][4]int
     - __kind: GoSwissMapHeaderType
-      ID: 198
+      ID: 120
       Name: map<[4]int,uint8>
       ByteSize: 48
       GoKind: 25
@@ -6223,7 +6223,7 @@ Types:
           Type: 1 BaseType uintptr
         - Name: dirPtr
           Offset: 16
-          Type: 199 PointerType **table<[4]int,uint8>
+          Type: 121 PointerType **table<[4]int,uint8>
         - Name: dirLen
           Offset: 24
           Type: 7 BaseType int
@@ -6239,10 +6239,10 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 8 BaseType uint64
-      TablePtrSliceType: 266 GoSliceDataType []*table<[4]int,uint8>.array
-      GroupType: 204 StructureType noalg.map.group[[4]int]uint8
+      TablePtrSliceType: 262 GoSliceDataType []*table<[4]int,uint8>.array
+      GroupType: 206 StructureType noalg.map.group[[4]int]uint8
     - __kind: GoSwissMapHeaderType
-      ID: 124
+      ID: 88
       Name: map<[4]string,[2]int>
       ByteSize: 48
       GoKind: 25
@@ -6255,7 +6255,7 @@ Types:
           Type: 1 BaseType uintptr
         - Name: dirPtr
           Offset: 16
-          Type: 125 PointerType **table<[4]string,[2]int>
+          Type: 89 PointerType **table<[4]string,[2]int>
         - Name: dirLen
           Offset: 24
           Type: 7 BaseType int
@@ -6271,10 +6271,10 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 8 BaseType uint64
-      TablePtrSliceType: 252 GoSliceDataType []*table<[4]string,[2]int>.array
-      GroupType: 130 StructureType noalg.map.group[[4]string][2]int
+      TablePtrSliceType: 250 GoSliceDataType []*table<[4]string,[2]int>.array
+      GroupType: 188 StructureType noalg.map.group[[4]string][2]int
     - __kind: GoSwissMapHeaderType
-      ID: 151
+      ID: 100
       Name: map<bool,main.node>
       ByteSize: 48
       GoKind: 25
@@ -6287,7 +6287,7 @@ Types:
           Type: 1 BaseType uintptr
         - Name: dirPtr
           Offset: 16
-          Type: 152 PointerType **table<bool,main.node>
+          Type: 101 PointerType **table<bool,main.node>
         - Name: dirLen
           Offset: 24
           Type: 7 BaseType int
@@ -6303,10 +6303,10 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 8 BaseType uint64
-      TablePtrSliceType: 258 GoSliceDataType []*table<bool,main.node>.array
-      GroupType: 157 StructureType noalg.map.group[bool]main.node
+      TablePtrSliceType: 254 GoSliceDataType []*table<bool,main.node>.array
+      GroupType: 194 StructureType noalg.map.group[bool]main.node
     - __kind: GoSwissMapHeaderType
-      ID: 78
+      ID: 68
       Name: map<int,int>
       ByteSize: 48
       GoKind: 25
@@ -6319,7 +6319,7 @@ Types:
           Type: 1 BaseType uintptr
         - Name: dirPtr
           Offset: 16
-          Type: 79 PointerType **table<int,int>
+          Type: 69 PointerType **table<int,int>
         - Name: dirLen
           Offset: 24
           Type: 7 BaseType int
@@ -6336,9 +6336,9 @@ Types:
           Offset: 40
           Type: 8 BaseType uint64
       TablePtrSliceType: 242 GoSliceDataType []*table<int,int>.array
-      GroupType: 84 StructureType noalg.map.group[int]int
+      GroupType: 176 StructureType noalg.map.group[int]int
     - __kind: GoSwissMapHeaderType
-      ID: 164
+      ID: 105
       Name: map<int,uint8>
       ByteSize: 48
       GoKind: 25
@@ -6351,7 +6351,7 @@ Types:
           Type: 1 BaseType uintptr
         - Name: dirPtr
           Offset: 16
-          Type: 165 PointerType **table<int,uint8>
+          Type: 106 PointerType **table<int,uint8>
         - Name: dirLen
           Offset: 24
           Type: 7 BaseType int
@@ -6367,10 +6367,10 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 8 BaseType uint64
-      TablePtrSliceType: 260 GoSliceDataType []*table<int,uint8>.array
-      GroupType: 170 StructureType noalg.map.group[int]uint8
+      TablePtrSliceType: 256 GoSliceDataType []*table<int,uint8>.array
+      GroupType: 197 StructureType noalg.map.group[int]uint8
     - __kind: GoSwissMapHeaderType
-      ID: 138
+      ID: 95
       Name: map<string,[]main.structWithMap>
       ByteSize: 48
       GoKind: 25
@@ -6383,7 +6383,7 @@ Types:
           Type: 1 BaseType uintptr
         - Name: dirPtr
           Offset: 16
-          Type: 139 PointerType **table<string,[]main.structWithMap>
+          Type: 96 PointerType **table<string,[]main.structWithMap>
         - Name: dirLen
           Offset: 24
           Type: 7 BaseType int
@@ -6399,10 +6399,10 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 8 BaseType uint64
-      TablePtrSliceType: 254 GoSliceDataType []*table<string,[]main.structWithMap>.array
-      GroupType: 144 StructureType noalg.map.group[string][]main.structWithMap
+      TablePtrSliceType: 252 GoSliceDataType []*table<string,[]main.structWithMap>.array
+      GroupType: 191 StructureType noalg.map.group[string][]main.structWithMap
     - __kind: GoSwissMapHeaderType
-      ID: 112
+      ID: 83
       Name: map<string,[]string>
       ByteSize: 48
       GoKind: 25
@@ -6415,7 +6415,7 @@ Types:
           Type: 1 BaseType uintptr
         - Name: dirPtr
           Offset: 16
-          Type: 113 PointerType **table<string,[]string>
+          Type: 84 PointerType **table<string,[]string>
         - Name: dirLen
           Offset: 24
           Type: 7 BaseType int
@@ -6432,9 +6432,9 @@ Types:
           Offset: 40
           Type: 8 BaseType uint64
       TablePtrSliceType: 248 GoSliceDataType []*table<string,[]string>.array
-      GroupType: 118 StructureType noalg.map.group[string][]string
+      GroupType: 185 StructureType noalg.map.group[string][]string
     - __kind: GoSwissMapHeaderType
-      ID: 101
+      ID: 78
       Name: map<string,int>
       ByteSize: 48
       GoKind: 25
@@ -6447,7 +6447,7 @@ Types:
           Type: 1 BaseType uintptr
         - Name: dirPtr
           Offset: 16
-          Type: 102 PointerType **table<string,int>
+          Type: 79 PointerType **table<string,int>
         - Name: dirLen
           Offset: 24
           Type: 7 BaseType int
@@ -6464,9 +6464,9 @@ Types:
           Offset: 40
           Type: 8 BaseType uint64
       TablePtrSliceType: 246 GoSliceDataType []*table<string,int>.array
-      GroupType: 107 StructureType noalg.map.group[string]int
+      GroupType: 182 StructureType noalg.map.group[string]int
     - __kind: GoSwissMapHeaderType
-      ID: 89
+      ID: 73
       Name: map<string,main.nestedStruct>
       ByteSize: 48
       GoKind: 25
@@ -6479,7 +6479,7 @@ Types:
           Type: 1 BaseType uintptr
         - Name: dirPtr
           Offset: 16
-          Type: 90 PointerType **table<string,main.nestedStruct>
+          Type: 74 PointerType **table<string,main.nestedStruct>
         - Name: dirLen
           Offset: 24
           Type: 7 BaseType int
@@ -6496,9 +6496,9 @@ Types:
           Offset: 40
           Type: 8 BaseType uint64
       TablePtrSliceType: 244 GoSliceDataType []*table<string,main.nestedStruct>.array
-      GroupType: 95 StructureType noalg.map.group[string]main.nestedStruct
+      GroupType: 179 StructureType noalg.map.group[string]main.nestedStruct
     - __kind: GoSwissMapHeaderType
-      ID: 186
+      ID: 115
       Name: map<uint8,[4]int>
       ByteSize: 48
       GoKind: 25
@@ -6511,7 +6511,7 @@ Types:
           Type: 1 BaseType uintptr
         - Name: dirPtr
           Offset: 16
-          Type: 187 PointerType **table<uint8,[4]int>
+          Type: 116 PointerType **table<uint8,[4]int>
         - Name: dirLen
           Offset: 24
           Type: 7 BaseType int
@@ -6527,10 +6527,10 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 8 BaseType uint64
-      TablePtrSliceType: 264 GoSliceDataType []*table<uint8,[4]int>.array
-      GroupType: 192 StructureType noalg.map.group[uint8][4]int
+      TablePtrSliceType: 260 GoSliceDataType []*table<uint8,[4]int>.array
+      GroupType: 203 StructureType noalg.map.group[uint8][4]int
     - __kind: GoSwissMapHeaderType
-      ID: 175
+      ID: 110
       Name: map<uint8,uint8>
       ByteSize: 48
       GoKind: 25
@@ -6543,7 +6543,7 @@ Types:
           Type: 1 BaseType uintptr
         - Name: dirPtr
           Offset: 16
-          Type: 176 PointerType **table<uint8,uint8>
+          Type: 111 PointerType **table<uint8,uint8>
         - Name: dirLen
           Offset: 24
           Type: 7 BaseType int
@@ -6559,202 +6559,202 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 8 BaseType uint64
-      TablePtrSliceType: 262 GoSliceDataType []*table<uint8,uint8>.array
-      GroupType: 181 StructureType noalg.map.group[uint8]uint8
+      TablePtrSliceType: 258 GoSliceDataType []*table<uint8,uint8>.array
+      GroupType: 200 StructureType noalg.map.group[uint8]uint8
     - __kind: GoMapType
-      ID: 207
+      ID: 123
       Name: map[[4]int][4]int
       ByteSize: 8
       GoRuntimeType: 1.117568e+06
       GoKind: 21
-      HeaderType: 209 GoSwissMapHeaderType map<[4]int,[4]int>
+      HeaderType: 125 GoSwissMapHeaderType map<[4]int,[4]int>
     - __kind: GoMapType
-      ID: 196
+      ID: 118
       Name: map[[4]int]uint8
       ByteSize: 8
       GoRuntimeType: 1.117696e+06
       GoKind: 21
-      HeaderType: 198 GoSwissMapHeaderType map<[4]int,uint8>
+      HeaderType: 120 GoSwissMapHeaderType map<[4]int,uint8>
     - __kind: GoMapType
-      ID: 122
+      ID: 86
       Name: map[[4]string][2]int
       ByteSize: 8
       GoRuntimeType: 1.117824e+06
       GoKind: 21
-      HeaderType: 124 GoSwissMapHeaderType map<[4]string,[2]int>
+      HeaderType: 88 GoSwissMapHeaderType map<[4]string,[2]int>
     - __kind: GoMapType
-      ID: 149
+      ID: 98
       Name: map[bool]main.node
       ByteSize: 8
       GoRuntimeType: 1.117952e+06
       GoKind: 21
-      HeaderType: 151 GoSwissMapHeaderType map<bool,main.node>
+      HeaderType: 100 GoSwissMapHeaderType map<bool,main.node>
     - __kind: GoMapType
-      ID: 76
+      ID: 66
       Name: map[int]int
       ByteSize: 8
       GoRuntimeType: 1.117184e+06
       GoKind: 21
-      HeaderType: 78 GoSwissMapHeaderType map<int,int>
+      HeaderType: 68 GoSwissMapHeaderType map<int,int>
     - __kind: GoMapType
-      ID: 162
+      ID: 103
       Name: map[int]uint8
       ByteSize: 8
       GoRuntimeType: 1.11808e+06
       GoKind: 21
-      HeaderType: 164 GoSwissMapHeaderType map<int,uint8>
+      HeaderType: 105 GoSwissMapHeaderType map<int,uint8>
     - __kind: GoMapType
-      ID: 136
+      ID: 93
       Name: map[string][]main.structWithMap
       ByteSize: 8
       GoRuntimeType: 1.118208e+06
       GoKind: 21
-      HeaderType: 138 GoSwissMapHeaderType map<string,[]main.structWithMap>
+      HeaderType: 95 GoSwissMapHeaderType map<string,[]main.structWithMap>
     - __kind: GoMapType
-      ID: 110
+      ID: 81
       Name: map[string][]string
       ByteSize: 8
       GoRuntimeType: 1.118336e+06
       GoKind: 21
-      HeaderType: 112 GoSwissMapHeaderType map<string,[]string>
+      HeaderType: 83 GoSwissMapHeaderType map<string,[]string>
     - __kind: GoMapType
-      ID: 99
+      ID: 76
       Name: map[string]int
       ByteSize: 8
       GoRuntimeType: 1.118464e+06
       GoKind: 21
-      HeaderType: 101 GoSwissMapHeaderType map<string,int>
+      HeaderType: 78 GoSwissMapHeaderType map<string,int>
     - __kind: GoMapType
-      ID: 87
+      ID: 71
       Name: map[string]main.nestedStruct
       ByteSize: 8
       GoRuntimeType: 1.118592e+06
       GoKind: 21
-      HeaderType: 89 GoSwissMapHeaderType map<string,main.nestedStruct>
+      HeaderType: 73 GoSwissMapHeaderType map<string,main.nestedStruct>
     - __kind: GoMapType
-      ID: 184
+      ID: 113
       Name: map[uint8][4]int
       ByteSize: 8
       GoRuntimeType: 1.11872e+06
       GoKind: 21
-      HeaderType: 186 GoSwissMapHeaderType map<uint8,[4]int>
+      HeaderType: 115 GoSwissMapHeaderType map<uint8,[4]int>
     - __kind: GoMapType
-      ID: 173
+      ID: 108
       Name: map[uint8]uint8
       ByteSize: 8
       GoRuntimeType: 1.118848e+06
       GoKind: 21
-      HeaderType: 175 GoSwissMapHeaderType map<uint8,uint8>
+      HeaderType: 110 GoSwissMapHeaderType map<uint8,uint8>
     - __kind: ArrayType
-      ID: 216
+      ID: 236
       Name: noalg.[8]struct { key [4]int; elem [4]int }
       ByteSize: 512
       GoRuntimeType: 672992
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 217 StructureType noalg.struct { key [4]int; elem [4]int }
+      Element: 237 StructureType noalg.struct { key [4]int; elem [4]int }
     - __kind: ArrayType
-      ID: 205
+      ID: 234
       Name: noalg.[8]struct { key [4]int; elem uint8 }
       ByteSize: 320
       GoRuntimeType: 673088
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 206 StructureType noalg.struct { key [4]int; elem uint8 }
+      Element: 235 StructureType noalg.struct { key [4]int; elem uint8 }
     - __kind: ArrayType
-      ID: 131
+      ID: 218
       Name: noalg.[8]struct { key [4]string; elem [2]int }
       ByteSize: 640
       GoRuntimeType: 673376
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 132 StructureType noalg.struct { key [4]string; elem [2]int }
+      Element: 219 StructureType noalg.struct { key [4]string; elem [2]int }
     - __kind: ArrayType
-      ID: 158
+      ID: 225
       Name: noalg.[8]struct { key bool; elem main.node }
       ByteSize: 192
       GoRuntimeType: 673472
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 159 StructureType noalg.struct { key bool; elem main.node }
+      Element: 226 StructureType noalg.struct { key bool; elem main.node }
     - __kind: ArrayType
-      ID: 85
+      ID: 210
       Name: noalg.[8]struct { key int; elem int }
       ByteSize: 128
       GoRuntimeType: 671264
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 86 StructureType noalg.struct { key int; elem int }
+      Element: 211 StructureType noalg.struct { key int; elem int }
     - __kind: ArrayType
-      ID: 171
+      ID: 227
       Name: noalg.[8]struct { key int; elem uint8 }
       ByteSize: 128
       GoRuntimeType: 673568
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 172 StructureType noalg.struct { key int; elem uint8 }
+      Element: 228 StructureType noalg.struct { key int; elem uint8 }
     - __kind: ArrayType
-      ID: 145
+      ID: 221
       Name: noalg.[8]struct { key string; elem []main.structWithMap }
       ByteSize: 320
       GoRuntimeType: 673664
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 146 StructureType noalg.struct { key string; elem []main.structWithMap }
+      Element: 222 StructureType noalg.struct { key string; elem []main.structWithMap }
     - __kind: ArrayType
-      ID: 119
+      ID: 216
       Name: noalg.[8]struct { key string; elem []string }
       ByteSize: 320
       GoRuntimeType: 673760
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 120 StructureType noalg.struct { key string; elem []string }
+      Element: 217 StructureType noalg.struct { key string; elem []string }
     - __kind: ArrayType
-      ID: 108
+      ID: 214
       Name: noalg.[8]struct { key string; elem int }
       ByteSize: 192
       GoRuntimeType: 673856
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 109 StructureType noalg.struct { key string; elem int }
+      Element: 215 StructureType noalg.struct { key string; elem int }
     - __kind: ArrayType
-      ID: 96
+      ID: 212
       Name: noalg.[8]struct { key string; elem main.nestedStruct }
       ByteSize: 320
       GoRuntimeType: 673952
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 97 StructureType noalg.struct { key string; elem main.nestedStruct }
+      Element: 213 StructureType noalg.struct { key string; elem main.nestedStruct }
     - __kind: ArrayType
-      ID: 193
+      ID: 231
       Name: noalg.[8]struct { key uint8; elem [4]int }
       ByteSize: 320
       GoRuntimeType: 674048
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 194 StructureType noalg.struct { key uint8; elem [4]int }
+      Element: 232 StructureType noalg.struct { key uint8; elem [4]int }
     - __kind: ArrayType
-      ID: 182
+      ID: 229
       Name: noalg.[8]struct { key uint8; elem uint8 }
       ByteSize: 16
       GoRuntimeType: 674144
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 183 StructureType noalg.struct { key uint8; elem uint8 }
+      Element: 230 StructureType noalg.struct { key uint8; elem uint8 }
     - __kind: StructureType
-      ID: 215
+      ID: 209
       Name: noalg.map.group[[4]int][4]int
       ByteSize: 520
       GoRuntimeType: 1.277248e+06
@@ -6765,9 +6765,9 @@ Types:
           Type: 8 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 216 ArrayType noalg.[8]struct { key [4]int; elem [4]int }
+          Type: 236 ArrayType noalg.[8]struct { key [4]int; elem [4]int }
     - __kind: StructureType
-      ID: 204
+      ID: 206
       Name: noalg.map.group[[4]int]uint8
       ByteSize: 328
       GoRuntimeType: 1.277504e+06
@@ -6778,9 +6778,9 @@ Types:
           Type: 8 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 205 ArrayType noalg.[8]struct { key [4]int; elem uint8 }
+          Type: 234 ArrayType noalg.[8]struct { key [4]int; elem uint8 }
     - __kind: StructureType
-      ID: 130
+      ID: 188
       Name: noalg.map.group[[4]string][2]int
       ByteSize: 648
       GoRuntimeType: 1.27776e+06
@@ -6791,9 +6791,9 @@ Types:
           Type: 8 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 131 ArrayType noalg.[8]struct { key [4]string; elem [2]int }
+          Type: 218 ArrayType noalg.[8]struct { key [4]string; elem [2]int }
     - __kind: StructureType
-      ID: 157
+      ID: 194
       Name: noalg.map.group[bool]main.node
       ByteSize: 200
       GoRuntimeType: 1.278016e+06
@@ -6804,9 +6804,9 @@ Types:
           Type: 8 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 158 ArrayType noalg.[8]struct { key bool; elem main.node }
+          Type: 225 ArrayType noalg.[8]struct { key bool; elem main.node }
     - __kind: StructureType
-      ID: 84
+      ID: 176
       Name: noalg.map.group[int]int
       ByteSize: 136
       GoRuntimeType: 1.27648e+06
@@ -6817,9 +6817,9 @@ Types:
           Type: 8 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 85 ArrayType noalg.[8]struct { key int; elem int }
+          Type: 210 ArrayType noalg.[8]struct { key int; elem int }
     - __kind: StructureType
-      ID: 170
+      ID: 197
       Name: noalg.map.group[int]uint8
       ByteSize: 136
       GoRuntimeType: 1.278272e+06
@@ -6830,9 +6830,9 @@ Types:
           Type: 8 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 171 ArrayType noalg.[8]struct { key int; elem uint8 }
+          Type: 227 ArrayType noalg.[8]struct { key int; elem uint8 }
     - __kind: StructureType
-      ID: 144
+      ID: 191
       Name: noalg.map.group[string][]main.structWithMap
       ByteSize: 328
       GoRuntimeType: 1.278528e+06
@@ -6843,9 +6843,9 @@ Types:
           Type: 8 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 145 ArrayType noalg.[8]struct { key string; elem []main.structWithMap }
+          Type: 221 ArrayType noalg.[8]struct { key string; elem []main.structWithMap }
     - __kind: StructureType
-      ID: 118
+      ID: 185
       Name: noalg.map.group[string][]string
       ByteSize: 328
       GoRuntimeType: 1.278784e+06
@@ -6856,9 +6856,9 @@ Types:
           Type: 8 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 119 ArrayType noalg.[8]struct { key string; elem []string }
+          Type: 216 ArrayType noalg.[8]struct { key string; elem []string }
     - __kind: StructureType
-      ID: 107
+      ID: 182
       Name: noalg.map.group[string]int
       ByteSize: 200
       GoRuntimeType: 1.27904e+06
@@ -6869,9 +6869,9 @@ Types:
           Type: 8 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 108 ArrayType noalg.[8]struct { key string; elem int }
+          Type: 214 ArrayType noalg.[8]struct { key string; elem int }
     - __kind: StructureType
-      ID: 95
+      ID: 179
       Name: noalg.map.group[string]main.nestedStruct
       ByteSize: 328
       GoRuntimeType: 1.279296e+06
@@ -6882,9 +6882,9 @@ Types:
           Type: 8 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 96 ArrayType noalg.[8]struct { key string; elem main.nestedStruct }
+          Type: 212 ArrayType noalg.[8]struct { key string; elem main.nestedStruct }
     - __kind: StructureType
-      ID: 192
+      ID: 203
       Name: noalg.map.group[uint8][4]int
       ByteSize: 328
       GoRuntimeType: 1.279552e+06
@@ -6895,9 +6895,9 @@ Types:
           Type: 8 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 193 ArrayType noalg.[8]struct { key uint8; elem [4]int }
+          Type: 231 ArrayType noalg.[8]struct { key uint8; elem [4]int }
     - __kind: StructureType
-      ID: 181
+      ID: 200
       Name: noalg.map.group[uint8]uint8
       ByteSize: 24
       GoRuntimeType: 1.279808e+06
@@ -6908,9 +6908,9 @@ Types:
           Type: 8 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 182 ArrayType noalg.[8]struct { key uint8; elem uint8 }
+          Type: 229 ArrayType noalg.[8]struct { key uint8; elem uint8 }
     - __kind: StructureType
-      ID: 217
+      ID: 237
       Name: noalg.struct { key [4]int; elem [4]int }
       ByteSize: 64
       GoRuntimeType: 1.27712e+06
@@ -6918,12 +6918,12 @@ Types:
       RawFields:
         - Name: key
           Offset: 0
-          Type: 195 ArrayType [4]int
+          Type: 233 ArrayType [4]int
         - Name: elem
           Offset: 32
-          Type: 195 ArrayType [4]int
+          Type: 233 ArrayType [4]int
     - __kind: StructureType
-      ID: 206
+      ID: 235
       Name: noalg.struct { key [4]int; elem uint8 }
       ByteSize: 40
       GoRuntimeType: 1.277376e+06
@@ -6931,12 +6931,12 @@ Types:
       RawFields:
         - Name: key
           Offset: 0
-          Type: 195 ArrayType [4]int
+          Type: 233 ArrayType [4]int
         - Name: elem
           Offset: 32
           Type: 3 BaseType uint8
     - __kind: StructureType
-      ID: 132
+      ID: 219
       Name: noalg.struct { key [4]string; elem [2]int }
       ByteSize: 80
       GoRuntimeType: 1.277632e+06
@@ -6944,12 +6944,12 @@ Types:
       RawFields:
         - Name: key
           Offset: 0
-          Type: 133 ArrayType [4]string
+          Type: 220 ArrayType [4]string
         - Name: elem
           Offset: 64
           Type: 40 ArrayType [2]int
     - __kind: StructureType
-      ID: 159
+      ID: 226
       Name: noalg.struct { key bool; elem main.node }
       ByteSize: 24
       GoRuntimeType: 1.277888e+06
@@ -6960,9 +6960,9 @@ Types:
           Type: 4 BaseType bool
         - Name: elem
           Offset: 8
-          Type: 160 StructureType main.node
+          Type: 131 StructureType main.node
     - __kind: StructureType
-      ID: 86
+      ID: 211
       Name: noalg.struct { key int; elem int }
       ByteSize: 16
       GoRuntimeType: 1.276352e+06
@@ -6975,7 +6975,7 @@ Types:
           Offset: 8
           Type: 7 BaseType int
     - __kind: StructureType
-      ID: 172
+      ID: 228
       Name: noalg.struct { key int; elem uint8 }
       ByteSize: 16
       GoRuntimeType: 1.278144e+06
@@ -6988,7 +6988,7 @@ Types:
           Offset: 8
           Type: 3 BaseType uint8
     - __kind: StructureType
-      ID: 146
+      ID: 222
       Name: noalg.struct { key string; elem []main.structWithMap }
       ByteSize: 40
       GoRuntimeType: 1.2784e+06
@@ -6999,9 +6999,9 @@ Types:
           Type: 9 GoStringHeaderType string
         - Name: elem
           Offset: 16
-          Type: 147 GoSliceHeaderType []main.structWithMap
+          Type: 223 GoSliceHeaderType []main.structWithMap
     - __kind: StructureType
-      ID: 120
+      ID: 217
       Name: noalg.struct { key string; elem []string }
       ByteSize: 40
       GoRuntimeType: 1.278656e+06
@@ -7012,9 +7012,9 @@ Types:
           Type: 9 GoStringHeaderType string
         - Name: elem
           Offset: 16
-          Type: 121 GoSliceHeaderType []string
+          Type: 141 GoSliceHeaderType []string
     - __kind: StructureType
-      ID: 109
+      ID: 215
       Name: noalg.struct { key string; elem int }
       ByteSize: 24
       GoRuntimeType: 1.278912e+06
@@ -7027,7 +7027,7 @@ Types:
           Offset: 16
           Type: 7 BaseType int
     - __kind: StructureType
-      ID: 97
+      ID: 213
       Name: noalg.struct { key string; elem main.nestedStruct }
       ByteSize: 40
       GoRuntimeType: 1.279168e+06
@@ -7038,9 +7038,9 @@ Types:
           Type: 9 GoStringHeaderType string
         - Name: elem
           Offset: 16
-          Type: 98 StructureType main.nestedStruct
+          Type: 149 StructureType main.nestedStruct
     - __kind: StructureType
-      ID: 194
+      ID: 232
       Name: noalg.struct { key uint8; elem [4]int }
       ByteSize: 40
       GoRuntimeType: 1.279424e+06
@@ -7051,9 +7051,9 @@ Types:
           Type: 3 BaseType uint8
         - Name: elem
           Offset: 8
-          Type: 195 ArrayType [4]int
+          Type: 233 ArrayType [4]int
     - __kind: StructureType
-      ID: 183
+      ID: 230
       Name: noalg.struct { key uint8; elem uint8 }
       ByteSize: 2
       GoRuntimeType: 1.27968e+06
@@ -7084,7 +7084,7 @@ Types:
       Name: string.str
       ByteSize: 2048
     - __kind: StructureType
-      ID: 63
+      ID: 151
       Name: sync.Mutex
       ByteSize: 8
       GoRuntimeType: 1.445344e+06
@@ -7092,12 +7092,12 @@ Types:
       RawFields:
         - Name: _
           Offset: 0
-          Type: 64 StructureType sync.noCopy
+          Type: 152 StructureType sync.noCopy
         - Name: mu
           Offset: 0
-          Type: 65 StructureType internal/sync.Mutex
+          Type: 153 StructureType internal/sync.Mutex
     - __kind: StructureType
-      ID: 66
+      ID: 154
       Name: sync.Once
       ByteSize: 12
       GoRuntimeType: 1.593696e+06
@@ -7105,15 +7105,15 @@ Types:
       RawFields:
         - Name: _
           Offset: 0
-          Type: 64 StructureType sync.noCopy
+          Type: 152 StructureType sync.noCopy
         - Name: done
           Offset: 0
-          Type: 67 StructureType sync/atomic.Uint32
+          Type: 155 StructureType sync/atomic.Uint32
         - Name: m
           Offset: 4
-          Type: 63 StructureType sync.Mutex
+          Type: 151 StructureType sync.Mutex
     - __kind: StructureType
-      ID: 69
+      ID: 157
       Name: sync.WaitGroup
       ByteSize: 16
       GoRuntimeType: 1.593888e+06
@@ -7121,21 +7121,21 @@ Types:
       RawFields:
         - Name: noCopy
           Offset: 0
-          Type: 64 StructureType sync.noCopy
+          Type: 152 StructureType sync.noCopy
         - Name: state
           Offset: 0
-          Type: 70 StructureType sync/atomic.Uint64
+          Type: 158 StructureType sync/atomic.Uint64
         - Name: sema
           Offset: 8
           Type: 2 BaseType uint32
     - __kind: StructureType
-      ID: 64
+      ID: 152
       Name: sync.noCopy
       GoRuntimeType: 977728
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 72
+      ID: 160
       Name: sync/atomic.Int32
       ByteSize: 4
       GoRuntimeType: 1.446624e+06
@@ -7143,12 +7143,12 @@ Types:
       RawFields:
         - Name: _
           Offset: 0
-          Type: 68 StructureType sync/atomic.noCopy
+          Type: 156 StructureType sync/atomic.noCopy
         - Name: v
           Offset: 0
           Type: 10 BaseType int32
     - __kind: StructureType
-      ID: 67
+      ID: 155
       Name: sync/atomic.Uint32
       ByteSize: 4
       GoRuntimeType: 1.446784e+06
@@ -7156,12 +7156,12 @@ Types:
       RawFields:
         - Name: _
           Offset: 0
-          Type: 68 StructureType sync/atomic.noCopy
+          Type: 156 StructureType sync/atomic.noCopy
         - Name: v
           Offset: 0
           Type: 2 BaseType uint32
     - __kind: StructureType
-      ID: 70
+      ID: 158
       Name: sync/atomic.Uint64
       ByteSize: 8
       GoRuntimeType: 1.594272e+06
@@ -7169,27 +7169,27 @@ Types:
       RawFields:
         - Name: _
           Offset: 0
-          Type: 68 StructureType sync/atomic.noCopy
+          Type: 156 StructureType sync/atomic.noCopy
         - Name: _
           Offset: 0
-          Type: 71 StructureType sync/atomic.align64
+          Type: 159 StructureType sync/atomic.align64
         - Name: v
           Offset: 0
           Type: 8 BaseType uint64
     - __kind: StructureType
-      ID: 71
+      ID: 159
       Name: sync/atomic.align64
       GoRuntimeType: 977920
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 68
+      ID: 156
       Name: sync/atomic.noCopy
       GoRuntimeType: 977824
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 212
+      ID: 172
       Name: table<[4]int,[4]int>
       ByteSize: 32
       GoKind: 25
@@ -7211,9 +7211,9 @@ Types:
           Type: 7 BaseType int
         - Name: groups
           Offset: 16
-          Type: 213 GoSwissMapGroupsType groupReference<[4]int,[4]int>
+          Type: 207 GoSwissMapGroupsType groupReference<[4]int,[4]int>
     - __kind: StructureType
-      ID: 201
+      ID: 171
       Name: table<[4]int,uint8>
       ByteSize: 32
       GoKind: 25
@@ -7235,9 +7235,9 @@ Types:
           Type: 7 BaseType int
         - Name: groups
           Offset: 16
-          Type: 202 GoSwissMapGroupsType groupReference<[4]int,uint8>
+          Type: 204 GoSwissMapGroupsType groupReference<[4]int,uint8>
     - __kind: StructureType
-      ID: 127
+      ID: 165
       Name: table<[4]string,[2]int>
       ByteSize: 32
       GoKind: 25
@@ -7259,9 +7259,9 @@ Types:
           Type: 7 BaseType int
         - Name: groups
           Offset: 16
-          Type: 128 GoSwissMapGroupsType groupReference<[4]string,[2]int>
+          Type: 186 GoSwissMapGroupsType groupReference<[4]string,[2]int>
     - __kind: StructureType
-      ID: 154
+      ID: 167
       Name: table<bool,main.node>
       ByteSize: 32
       GoKind: 25
@@ -7283,9 +7283,9 @@ Types:
           Type: 7 BaseType int
         - Name: groups
           Offset: 16
-          Type: 155 GoSwissMapGroupsType groupReference<bool,main.node>
+          Type: 192 GoSwissMapGroupsType groupReference<bool,main.node>
     - __kind: StructureType
-      ID: 81
+      ID: 161
       Name: table<int,int>
       ByteSize: 32
       GoKind: 25
@@ -7307,9 +7307,9 @@ Types:
           Type: 7 BaseType int
         - Name: groups
           Offset: 16
-          Type: 82 GoSwissMapGroupsType groupReference<int,int>
+          Type: 174 GoSwissMapGroupsType groupReference<int,int>
     - __kind: StructureType
-      ID: 167
+      ID: 168
       Name: table<int,uint8>
       ByteSize: 32
       GoKind: 25
@@ -7331,9 +7331,9 @@ Types:
           Type: 7 BaseType int
         - Name: groups
           Offset: 16
-          Type: 168 GoSwissMapGroupsType groupReference<int,uint8>
+          Type: 195 GoSwissMapGroupsType groupReference<int,uint8>
     - __kind: StructureType
-      ID: 141
+      ID: 166
       Name: table<string,[]main.structWithMap>
       ByteSize: 32
       GoKind: 25
@@ -7355,9 +7355,9 @@ Types:
           Type: 7 BaseType int
         - Name: groups
           Offset: 16
-          Type: 142 GoSwissMapGroupsType groupReference<string,[]main.structWithMap>
+          Type: 189 GoSwissMapGroupsType groupReference<string,[]main.structWithMap>
     - __kind: StructureType
-      ID: 115
+      ID: 164
       Name: table<string,[]string>
       ByteSize: 32
       GoKind: 25
@@ -7379,9 +7379,9 @@ Types:
           Type: 7 BaseType int
         - Name: groups
           Offset: 16
-          Type: 116 GoSwissMapGroupsType groupReference<string,[]string>
+          Type: 183 GoSwissMapGroupsType groupReference<string,[]string>
     - __kind: StructureType
-      ID: 104
+      ID: 163
       Name: table<string,int>
       ByteSize: 32
       GoKind: 25
@@ -7403,9 +7403,9 @@ Types:
           Type: 7 BaseType int
         - Name: groups
           Offset: 16
-          Type: 105 GoSwissMapGroupsType groupReference<string,int>
+          Type: 180 GoSwissMapGroupsType groupReference<string,int>
     - __kind: StructureType
-      ID: 92
+      ID: 162
       Name: table<string,main.nestedStruct>
       ByteSize: 32
       GoKind: 25
@@ -7427,9 +7427,9 @@ Types:
           Type: 7 BaseType int
         - Name: groups
           Offset: 16
-          Type: 93 GoSwissMapGroupsType groupReference<string,main.nestedStruct>
+          Type: 177 GoSwissMapGroupsType groupReference<string,main.nestedStruct>
     - __kind: StructureType
-      ID: 189
+      ID: 170
       Name: table<uint8,[4]int>
       ByteSize: 32
       GoKind: 25
@@ -7451,9 +7451,9 @@ Types:
           Type: 7 BaseType int
         - Name: groups
           Offset: 16
-          Type: 190 GoSwissMapGroupsType groupReference<uint8,[4]int>
+          Type: 201 GoSwissMapGroupsType groupReference<uint8,[4]int>
     - __kind: StructureType
-      ID: 178
+      ID: 169
       Name: table<uint8,uint8>
       ByteSize: 32
       GoKind: 25
@@ -7475,7 +7475,7 @@ Types:
           Type: 7 BaseType int
         - Name: groups
           Offset: 16
-          Type: 179 GoSwissMapGroupsType groupReference<uint8,uint8>
+          Type: 198 GoSwissMapGroupsType groupReference<uint8,uint8>
     - __kind: BaseType
       ID: 16
       Name: uint

--- a/pkg/dyninst/irgen/testdata/snapshot/sample.arch=amd64,toolchain=go1.24.3.yaml
+++ b/pkg/dyninst/irgen/testdata/snapshot/sample.arch=amd64,toolchain=go1.24.3.yaml
@@ -3167,10 +3167,10 @@ Types:
       ByteSize: 8
       Pointee: 112 PointerType *table<uint8,uint8>
     - __kind: PointerType
-      ID: 241
+      ID: 177
       Name: '*[]*string.array'
       ByteSize: 8
-      Pointee: 240 GoSliceDataType []*string.array
+      Pointee: 176 GoSliceDataType []*string.array
     - __kind: PointerType
       ID: 271
       Name: '*[][]uint.array'
@@ -3295,7 +3295,7 @@ Types:
       GoKind: 22
       Pointee: 147 StructureType main.oneStringStruct
     - __kind: PointerType
-      ID: 224
+      ID: 220
       Name: '*main.structWithMap'
       ByteSize: 8
       GoRuntimeType: 380160
@@ -3396,65 +3396,65 @@ Types:
       GoKind: 22
       Pointee: 76 GoMapType map[string]int
     - __kind: PointerType
-      ID: 208
+      ID: 260
       Name: '*noalg.map.group[[4]int][4]int'
       ByteSize: 8
-      Pointee: 209 StructureType noalg.map.group[[4]int][4]int
+      Pointee: 261 StructureType noalg.map.group[[4]int][4]int
     - __kind: PointerType
-      ID: 205
+      ID: 253
       Name: '*noalg.map.group[[4]int]uint8'
       ByteSize: 8
-      Pointee: 206 StructureType noalg.map.group[[4]int]uint8
+      Pointee: 254 StructureType noalg.map.group[[4]int]uint8
     - __kind: PointerType
-      ID: 187
+      ID: 207
       Name: '*noalg.map.group[[4]string][2]int'
       ByteSize: 8
-      Pointee: 188 StructureType noalg.map.group[[4]string][2]int
+      Pointee: 208 StructureType noalg.map.group[[4]string][2]int
     - __kind: PointerType
-      ID: 193
+      ID: 224
       Name: '*noalg.map.group[bool]main.node'
       ByteSize: 8
-      Pointee: 194 StructureType noalg.map.group[bool]main.node
+      Pointee: 225 StructureType noalg.map.group[bool]main.node
     - __kind: PointerType
-      ID: 175
+      ID: 179
       Name: '*noalg.map.group[int]int'
       ByteSize: 8
-      Pointee: 176 StructureType noalg.map.group[int]int
+      Pointee: 180 StructureType noalg.map.group[int]int
     - __kind: PointerType
-      ID: 196
+      ID: 231
       Name: '*noalg.map.group[int]uint8'
       ByteSize: 8
-      Pointee: 197 StructureType noalg.map.group[int]uint8
+      Pointee: 232 StructureType noalg.map.group[int]uint8
     - __kind: PointerType
-      ID: 190
+      ID: 215
       Name: '*noalg.map.group[string][]main.structWithMap'
       ByteSize: 8
-      Pointee: 191 StructureType noalg.map.group[string][]main.structWithMap
+      Pointee: 216 StructureType noalg.map.group[string][]main.structWithMap
     - __kind: PointerType
-      ID: 184
+      ID: 200
       Name: '*noalg.map.group[string][]string'
       ByteSize: 8
-      Pointee: 185 StructureType noalg.map.group[string][]string
+      Pointee: 201 StructureType noalg.map.group[string][]string
     - __kind: PointerType
-      ID: 181
+      ID: 193
       Name: '*noalg.map.group[string]int'
       ByteSize: 8
-      Pointee: 182 StructureType noalg.map.group[string]int
+      Pointee: 194 StructureType noalg.map.group[string]int
     - __kind: PointerType
-      ID: 178
+      ID: 186
       Name: '*noalg.map.group[string]main.nestedStruct'
       ByteSize: 8
-      Pointee: 179 StructureType noalg.map.group[string]main.nestedStruct
+      Pointee: 187 StructureType noalg.map.group[string]main.nestedStruct
     - __kind: PointerType
-      ID: 202
+      ID: 245
       Name: '*noalg.map.group[uint8][4]int'
       ByteSize: 8
-      Pointee: 203 StructureType noalg.map.group[uint8][4]int
+      Pointee: 246 StructureType noalg.map.group[uint8][4]int
     - __kind: PointerType
-      ID: 199
+      ID: 238
       Name: '*noalg.map.group[uint8]uint8'
       ByteSize: 8
-      Pointee: 200 StructureType noalg.map.group[uint8]uint8
+      Pointee: 239 StructureType noalg.map.group[uint8]uint8
     - __kind: PointerType
       ID: 22
       Name: '*string'
@@ -3463,10 +3463,10 @@ Types:
       GoKind: 22
       Pointee: 9 GoStringHeaderType string
     - __kind: PointerType
-      ID: 239
+      ID: 175
       Name: '*string.str'
       ByteSize: 8
-      Pointee: 238 GoStringDataType string.str
+      Pointee: 174 GoStringDataType string.str
     - __kind: PointerType
       ID: 127
       Name: '*table<[4]int,[4]int>'
@@ -5338,7 +5338,7 @@ Types:
       HasCount: true
       Element: 3 BaseType uint8
     - __kind: ArrayType
-      ID: 233
+      ID: 249
       Name: '[4]int'
       ByteSize: 32
       GoRuntimeType: 672896
@@ -5347,7 +5347,7 @@ Types:
       HasCount: true
       Element: 7 BaseType int
     - __kind: ArrayType
-      ID: 220
+      ID: 211
       Name: '[4]string'
       ByteSize: 64
       GoRuntimeType: 673184
@@ -5379,9 +5379,9 @@ Types:
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 240 GoSliceDataType []*string.array
+      Data: 176 GoSliceDataType []*string.array
     - __kind: GoSliceDataType
-      ID: 240
+      ID: 176
       Name: '[]*string.array'
       ByteSize: 2048
       Element: 22 PointerType *string
@@ -5391,57 +5391,57 @@ Types:
       ByteSize: 8192
       Element: 127 PointerType *table<[4]int,[4]int>
     - __kind: GoSliceDataType
-      ID: 262
+      ID: 257
       Name: '[]*table<[4]int,uint8>.array'
       ByteSize: 8192
       Element: 122 PointerType *table<[4]int,uint8>
     - __kind: GoSliceDataType
-      ID: 250
+      ID: 212
       Name: '[]*table<[4]string,[2]int>.array'
       ByteSize: 8192
       Element: 90 PointerType *table<[4]string,[2]int>
     - __kind: GoSliceDataType
-      ID: 254
+      ID: 228
       Name: '[]*table<bool,main.node>.array'
       ByteSize: 8192
       Element: 102 PointerType *table<bool,main.node>
     - __kind: GoSliceDataType
-      ID: 242
+      ID: 183
       Name: '[]*table<int,int>.array'
       ByteSize: 8192
       Element: 70 PointerType *table<int,int>
     - __kind: GoSliceDataType
-      ID: 256
+      ID: 235
       Name: '[]*table<int,uint8>.array'
       ByteSize: 8192
       Element: 107 PointerType *table<int,uint8>
     - __kind: GoSliceDataType
-      ID: 252
+      ID: 221
       Name: '[]*table<string,[]main.structWithMap>.array'
       ByteSize: 8192
       Element: 97 PointerType *table<string,[]main.structWithMap>
     - __kind: GoSliceDataType
-      ID: 248
+      ID: 204
       Name: '[]*table<string,[]string>.array'
       ByteSize: 8192
       Element: 85 PointerType *table<string,[]string>
     - __kind: GoSliceDataType
-      ID: 246
+      ID: 197
       Name: '[]*table<string,int>.array'
       ByteSize: 8192
       Element: 80 PointerType *table<string,int>
     - __kind: GoSliceDataType
-      ID: 244
+      ID: 190
       Name: '[]*table<string,main.nestedStruct>.array'
       ByteSize: 8192
       Element: 75 PointerType *table<string,main.nestedStruct>
     - __kind: GoSliceDataType
-      ID: 260
+      ID: 250
       Name: '[]*table<uint8,[4]int>.array'
       ByteSize: 8192
       Element: 117 PointerType *table<uint8,[4]int>
     - __kind: GoSliceDataType
-      ID: 258
+      ID: 242
       Name: '[]*table<uint8,uint8>.array'
       ByteSize: 8192
       Element: 112 PointerType *table<uint8,uint8>
@@ -5489,7 +5489,7 @@ Types:
       ByteSize: 2048
       Element: 4 BaseType bool
     - __kind: GoSliceHeaderType
-      ID: 223
+      ID: 219
       Name: '[]main.structWithMap'
       ByteSize: 24
       GoRuntimeType: 469888
@@ -5497,7 +5497,7 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 224 PointerType *main.structWithMap
+          Type: 220 PointerType *main.structWithMap
         - Name: len
           Offset: 8
           Type: 7 BaseType int
@@ -5535,62 +5535,62 @@ Types:
       ID: 265
       Name: '[]noalg.map.group[[4]int][4]int.array'
       ByteSize: 2048
-      Element: 209 StructureType noalg.map.group[[4]int][4]int
+      Element: 261 StructureType noalg.map.group[[4]int][4]int
     - __kind: GoSliceDataType
-      ID: 263
+      ID: 258
       Name: '[]noalg.map.group[[4]int]uint8.array'
       ByteSize: 2048
-      Element: 206 StructureType noalg.map.group[[4]int]uint8
+      Element: 254 StructureType noalg.map.group[[4]int]uint8
     - __kind: GoSliceDataType
-      ID: 251
+      ID: 213
       Name: '[]noalg.map.group[[4]string][2]int.array'
       ByteSize: 2048
-      Element: 188 StructureType noalg.map.group[[4]string][2]int
+      Element: 208 StructureType noalg.map.group[[4]string][2]int
     - __kind: GoSliceDataType
-      ID: 255
+      ID: 229
       Name: '[]noalg.map.group[bool]main.node.array'
       ByteSize: 2048
-      Element: 194 StructureType noalg.map.group[bool]main.node
+      Element: 225 StructureType noalg.map.group[bool]main.node
     - __kind: GoSliceDataType
-      ID: 243
+      ID: 184
       Name: '[]noalg.map.group[int]int.array'
       ByteSize: 2048
-      Element: 176 StructureType noalg.map.group[int]int
+      Element: 180 StructureType noalg.map.group[int]int
     - __kind: GoSliceDataType
-      ID: 257
+      ID: 236
       Name: '[]noalg.map.group[int]uint8.array'
       ByteSize: 2048
-      Element: 197 StructureType noalg.map.group[int]uint8
+      Element: 232 StructureType noalg.map.group[int]uint8
     - __kind: GoSliceDataType
-      ID: 253
+      ID: 222
       Name: '[]noalg.map.group[string][]main.structWithMap.array'
       ByteSize: 2048
-      Element: 191 StructureType noalg.map.group[string][]main.structWithMap
+      Element: 216 StructureType noalg.map.group[string][]main.structWithMap
     - __kind: GoSliceDataType
-      ID: 249
+      ID: 205
       Name: '[]noalg.map.group[string][]string.array'
       ByteSize: 2048
-      Element: 185 StructureType noalg.map.group[string][]string
+      Element: 201 StructureType noalg.map.group[string][]string
     - __kind: GoSliceDataType
-      ID: 247
+      ID: 198
       Name: '[]noalg.map.group[string]int.array'
       ByteSize: 2048
-      Element: 182 StructureType noalg.map.group[string]int
+      Element: 194 StructureType noalg.map.group[string]int
     - __kind: GoSliceDataType
-      ID: 245
+      ID: 191
       Name: '[]noalg.map.group[string]main.nestedStruct.array'
       ByteSize: 2048
-      Element: 179 StructureType noalg.map.group[string]main.nestedStruct
+      Element: 187 StructureType noalg.map.group[string]main.nestedStruct
     - __kind: GoSliceDataType
-      ID: 261
+      ID: 251
       Name: '[]noalg.map.group[uint8][4]int.array'
       ByteSize: 2048
-      Element: 203 StructureType noalg.map.group[uint8][4]int
+      Element: 246 StructureType noalg.map.group[uint8][4]int
     - __kind: GoSliceDataType
-      ID: 259
+      ID: 243
       Name: '[]noalg.map.group[uint8]uint8.array'
       ByteSize: 2048
-      Element: 200 StructureType noalg.map.group[uint8]uint8
+      Element: 239 StructureType noalg.map.group[uint8]uint8
     - __kind: GoSliceHeaderType
       ID: 141
       Name: '[]string'
@@ -5717,173 +5717,173 @@ Types:
       GoRuntimeType: 468928
       GoKind: 19
     - __kind: GoSwissMapGroupsType
-      ID: 207
+      ID: 259
       Name: groupReference<[4]int,[4]int>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 208 PointerType *noalg.map.group[[4]int][4]int
+          Type: 260 PointerType *noalg.map.group[[4]int][4]int
         - Name: lengthMask
           Offset: 8
           Type: 8 BaseType uint64
-      GroupType: 209 StructureType noalg.map.group[[4]int][4]int
+      GroupType: 261 StructureType noalg.map.group[[4]int][4]int
       GroupSliceType: 265 GoSliceDataType []noalg.map.group[[4]int][4]int.array
     - __kind: GoSwissMapGroupsType
-      ID: 204
+      ID: 252
       Name: groupReference<[4]int,uint8>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 205 PointerType *noalg.map.group[[4]int]uint8
+          Type: 253 PointerType *noalg.map.group[[4]int]uint8
         - Name: lengthMask
           Offset: 8
           Type: 8 BaseType uint64
-      GroupType: 206 StructureType noalg.map.group[[4]int]uint8
-      GroupSliceType: 263 GoSliceDataType []noalg.map.group[[4]int]uint8.array
+      GroupType: 254 StructureType noalg.map.group[[4]int]uint8
+      GroupSliceType: 258 GoSliceDataType []noalg.map.group[[4]int]uint8.array
     - __kind: GoSwissMapGroupsType
-      ID: 186
+      ID: 206
       Name: groupReference<[4]string,[2]int>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 187 PointerType *noalg.map.group[[4]string][2]int
+          Type: 207 PointerType *noalg.map.group[[4]string][2]int
         - Name: lengthMask
           Offset: 8
           Type: 8 BaseType uint64
-      GroupType: 188 StructureType noalg.map.group[[4]string][2]int
-      GroupSliceType: 251 GoSliceDataType []noalg.map.group[[4]string][2]int.array
+      GroupType: 208 StructureType noalg.map.group[[4]string][2]int
+      GroupSliceType: 213 GoSliceDataType []noalg.map.group[[4]string][2]int.array
     - __kind: GoSwissMapGroupsType
-      ID: 192
+      ID: 223
       Name: groupReference<bool,main.node>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 193 PointerType *noalg.map.group[bool]main.node
+          Type: 224 PointerType *noalg.map.group[bool]main.node
         - Name: lengthMask
           Offset: 8
           Type: 8 BaseType uint64
-      GroupType: 194 StructureType noalg.map.group[bool]main.node
-      GroupSliceType: 255 GoSliceDataType []noalg.map.group[bool]main.node.array
+      GroupType: 225 StructureType noalg.map.group[bool]main.node
+      GroupSliceType: 229 GoSliceDataType []noalg.map.group[bool]main.node.array
     - __kind: GoSwissMapGroupsType
-      ID: 174
+      ID: 178
       Name: groupReference<int,int>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 175 PointerType *noalg.map.group[int]int
+          Type: 179 PointerType *noalg.map.group[int]int
         - Name: lengthMask
           Offset: 8
           Type: 8 BaseType uint64
-      GroupType: 176 StructureType noalg.map.group[int]int
-      GroupSliceType: 243 GoSliceDataType []noalg.map.group[int]int.array
+      GroupType: 180 StructureType noalg.map.group[int]int
+      GroupSliceType: 184 GoSliceDataType []noalg.map.group[int]int.array
     - __kind: GoSwissMapGroupsType
-      ID: 195
+      ID: 230
       Name: groupReference<int,uint8>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 196 PointerType *noalg.map.group[int]uint8
+          Type: 231 PointerType *noalg.map.group[int]uint8
         - Name: lengthMask
           Offset: 8
           Type: 8 BaseType uint64
-      GroupType: 197 StructureType noalg.map.group[int]uint8
-      GroupSliceType: 257 GoSliceDataType []noalg.map.group[int]uint8.array
+      GroupType: 232 StructureType noalg.map.group[int]uint8
+      GroupSliceType: 236 GoSliceDataType []noalg.map.group[int]uint8.array
     - __kind: GoSwissMapGroupsType
-      ID: 189
+      ID: 214
       Name: groupReference<string,[]main.structWithMap>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 190 PointerType *noalg.map.group[string][]main.structWithMap
+          Type: 215 PointerType *noalg.map.group[string][]main.structWithMap
         - Name: lengthMask
           Offset: 8
           Type: 8 BaseType uint64
-      GroupType: 191 StructureType noalg.map.group[string][]main.structWithMap
-      GroupSliceType: 253 GoSliceDataType []noalg.map.group[string][]main.structWithMap.array
+      GroupType: 216 StructureType noalg.map.group[string][]main.structWithMap
+      GroupSliceType: 222 GoSliceDataType []noalg.map.group[string][]main.structWithMap.array
     - __kind: GoSwissMapGroupsType
-      ID: 183
+      ID: 199
       Name: groupReference<string,[]string>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 184 PointerType *noalg.map.group[string][]string
+          Type: 200 PointerType *noalg.map.group[string][]string
         - Name: lengthMask
           Offset: 8
           Type: 8 BaseType uint64
-      GroupType: 185 StructureType noalg.map.group[string][]string
-      GroupSliceType: 249 GoSliceDataType []noalg.map.group[string][]string.array
+      GroupType: 201 StructureType noalg.map.group[string][]string
+      GroupSliceType: 205 GoSliceDataType []noalg.map.group[string][]string.array
     - __kind: GoSwissMapGroupsType
-      ID: 180
+      ID: 192
       Name: groupReference<string,int>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 181 PointerType *noalg.map.group[string]int
+          Type: 193 PointerType *noalg.map.group[string]int
         - Name: lengthMask
           Offset: 8
           Type: 8 BaseType uint64
-      GroupType: 182 StructureType noalg.map.group[string]int
-      GroupSliceType: 247 GoSliceDataType []noalg.map.group[string]int.array
+      GroupType: 194 StructureType noalg.map.group[string]int
+      GroupSliceType: 198 GoSliceDataType []noalg.map.group[string]int.array
     - __kind: GoSwissMapGroupsType
-      ID: 177
+      ID: 185
       Name: groupReference<string,main.nestedStruct>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 178 PointerType *noalg.map.group[string]main.nestedStruct
+          Type: 186 PointerType *noalg.map.group[string]main.nestedStruct
         - Name: lengthMask
           Offset: 8
           Type: 8 BaseType uint64
-      GroupType: 179 StructureType noalg.map.group[string]main.nestedStruct
-      GroupSliceType: 245 GoSliceDataType []noalg.map.group[string]main.nestedStruct.array
+      GroupType: 187 StructureType noalg.map.group[string]main.nestedStruct
+      GroupSliceType: 191 GoSliceDataType []noalg.map.group[string]main.nestedStruct.array
     - __kind: GoSwissMapGroupsType
-      ID: 201
+      ID: 244
       Name: groupReference<uint8,[4]int>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 202 PointerType *noalg.map.group[uint8][4]int
+          Type: 245 PointerType *noalg.map.group[uint8][4]int
         - Name: lengthMask
           Offset: 8
           Type: 8 BaseType uint64
-      GroupType: 203 StructureType noalg.map.group[uint8][4]int
-      GroupSliceType: 261 GoSliceDataType []noalg.map.group[uint8][4]int.array
+      GroupType: 246 StructureType noalg.map.group[uint8][4]int
+      GroupSliceType: 251 GoSliceDataType []noalg.map.group[uint8][4]int.array
     - __kind: GoSwissMapGroupsType
-      ID: 198
+      ID: 237
       Name: groupReference<uint8,uint8>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 199 PointerType *noalg.map.group[uint8]uint8
+          Type: 238 PointerType *noalg.map.group[uint8]uint8
         - Name: lengthMask
           Offset: 8
           Type: 8 BaseType uint64
-      GroupType: 200 StructureType noalg.map.group[uint8]uint8
-      GroupSliceType: 259 GoSliceDataType []noalg.map.group[uint8]uint8.array
+      GroupType: 239 StructureType noalg.map.group[uint8]uint8
+      GroupSliceType: 243 GoSliceDataType []noalg.map.group[uint8]uint8.array
     - __kind: BaseType
       ID: 7
       Name: int
@@ -6208,7 +6208,7 @@ Types:
           Offset: 40
           Type: 8 BaseType uint64
       TablePtrSliceType: 264 GoSliceDataType []*table<[4]int,[4]int>.array
-      GroupType: 209 StructureType noalg.map.group[[4]int][4]int
+      GroupType: 261 StructureType noalg.map.group[[4]int][4]int
     - __kind: GoSwissMapHeaderType
       ID: 120
       Name: map<[4]int,uint8>
@@ -6239,8 +6239,8 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 8 BaseType uint64
-      TablePtrSliceType: 262 GoSliceDataType []*table<[4]int,uint8>.array
-      GroupType: 206 StructureType noalg.map.group[[4]int]uint8
+      TablePtrSliceType: 257 GoSliceDataType []*table<[4]int,uint8>.array
+      GroupType: 254 StructureType noalg.map.group[[4]int]uint8
     - __kind: GoSwissMapHeaderType
       ID: 88
       Name: map<[4]string,[2]int>
@@ -6271,8 +6271,8 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 8 BaseType uint64
-      TablePtrSliceType: 250 GoSliceDataType []*table<[4]string,[2]int>.array
-      GroupType: 188 StructureType noalg.map.group[[4]string][2]int
+      TablePtrSliceType: 212 GoSliceDataType []*table<[4]string,[2]int>.array
+      GroupType: 208 StructureType noalg.map.group[[4]string][2]int
     - __kind: GoSwissMapHeaderType
       ID: 100
       Name: map<bool,main.node>
@@ -6303,8 +6303,8 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 8 BaseType uint64
-      TablePtrSliceType: 254 GoSliceDataType []*table<bool,main.node>.array
-      GroupType: 194 StructureType noalg.map.group[bool]main.node
+      TablePtrSliceType: 228 GoSliceDataType []*table<bool,main.node>.array
+      GroupType: 225 StructureType noalg.map.group[bool]main.node
     - __kind: GoSwissMapHeaderType
       ID: 68
       Name: map<int,int>
@@ -6335,8 +6335,8 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 8 BaseType uint64
-      TablePtrSliceType: 242 GoSliceDataType []*table<int,int>.array
-      GroupType: 176 StructureType noalg.map.group[int]int
+      TablePtrSliceType: 183 GoSliceDataType []*table<int,int>.array
+      GroupType: 180 StructureType noalg.map.group[int]int
     - __kind: GoSwissMapHeaderType
       ID: 105
       Name: map<int,uint8>
@@ -6367,8 +6367,8 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 8 BaseType uint64
-      TablePtrSliceType: 256 GoSliceDataType []*table<int,uint8>.array
-      GroupType: 197 StructureType noalg.map.group[int]uint8
+      TablePtrSliceType: 235 GoSliceDataType []*table<int,uint8>.array
+      GroupType: 232 StructureType noalg.map.group[int]uint8
     - __kind: GoSwissMapHeaderType
       ID: 95
       Name: map<string,[]main.structWithMap>
@@ -6399,8 +6399,8 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 8 BaseType uint64
-      TablePtrSliceType: 252 GoSliceDataType []*table<string,[]main.structWithMap>.array
-      GroupType: 191 StructureType noalg.map.group[string][]main.structWithMap
+      TablePtrSliceType: 221 GoSliceDataType []*table<string,[]main.structWithMap>.array
+      GroupType: 216 StructureType noalg.map.group[string][]main.structWithMap
     - __kind: GoSwissMapHeaderType
       ID: 83
       Name: map<string,[]string>
@@ -6431,8 +6431,8 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 8 BaseType uint64
-      TablePtrSliceType: 248 GoSliceDataType []*table<string,[]string>.array
-      GroupType: 185 StructureType noalg.map.group[string][]string
+      TablePtrSliceType: 204 GoSliceDataType []*table<string,[]string>.array
+      GroupType: 201 StructureType noalg.map.group[string][]string
     - __kind: GoSwissMapHeaderType
       ID: 78
       Name: map<string,int>
@@ -6463,8 +6463,8 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 8 BaseType uint64
-      TablePtrSliceType: 246 GoSliceDataType []*table<string,int>.array
-      GroupType: 182 StructureType noalg.map.group[string]int
+      TablePtrSliceType: 197 GoSliceDataType []*table<string,int>.array
+      GroupType: 194 StructureType noalg.map.group[string]int
     - __kind: GoSwissMapHeaderType
       ID: 73
       Name: map<string,main.nestedStruct>
@@ -6495,8 +6495,8 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 8 BaseType uint64
-      TablePtrSliceType: 244 GoSliceDataType []*table<string,main.nestedStruct>.array
-      GroupType: 179 StructureType noalg.map.group[string]main.nestedStruct
+      TablePtrSliceType: 190 GoSliceDataType []*table<string,main.nestedStruct>.array
+      GroupType: 187 StructureType noalg.map.group[string]main.nestedStruct
     - __kind: GoSwissMapHeaderType
       ID: 115
       Name: map<uint8,[4]int>
@@ -6527,8 +6527,8 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 8 BaseType uint64
-      TablePtrSliceType: 260 GoSliceDataType []*table<uint8,[4]int>.array
-      GroupType: 203 StructureType noalg.map.group[uint8][4]int
+      TablePtrSliceType: 250 GoSliceDataType []*table<uint8,[4]int>.array
+      GroupType: 246 StructureType noalg.map.group[uint8][4]int
     - __kind: GoSwissMapHeaderType
       ID: 110
       Name: map<uint8,uint8>
@@ -6559,8 +6559,8 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 8 BaseType uint64
-      TablePtrSliceType: 258 GoSliceDataType []*table<uint8,uint8>.array
-      GroupType: 200 StructureType noalg.map.group[uint8]uint8
+      TablePtrSliceType: 242 GoSliceDataType []*table<uint8,uint8>.array
+      GroupType: 239 StructureType noalg.map.group[uint8]uint8
     - __kind: GoMapType
       ID: 123
       Name: map[[4]int][4]int
@@ -6646,115 +6646,115 @@ Types:
       GoKind: 21
       HeaderType: 110 GoSwissMapHeaderType map<uint8,uint8>
     - __kind: ArrayType
-      ID: 236
+      ID: 262
       Name: noalg.[8]struct { key [4]int; elem [4]int }
       ByteSize: 512
       GoRuntimeType: 672992
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 237 StructureType noalg.struct { key [4]int; elem [4]int }
+      Element: 263 StructureType noalg.struct { key [4]int; elem [4]int }
     - __kind: ArrayType
-      ID: 234
+      ID: 255
       Name: noalg.[8]struct { key [4]int; elem uint8 }
       ByteSize: 320
       GoRuntimeType: 673088
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 235 StructureType noalg.struct { key [4]int; elem uint8 }
+      Element: 256 StructureType noalg.struct { key [4]int; elem uint8 }
     - __kind: ArrayType
-      ID: 218
+      ID: 209
       Name: noalg.[8]struct { key [4]string; elem [2]int }
       ByteSize: 640
       GoRuntimeType: 673376
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 219 StructureType noalg.struct { key [4]string; elem [2]int }
+      Element: 210 StructureType noalg.struct { key [4]string; elem [2]int }
     - __kind: ArrayType
-      ID: 225
+      ID: 226
       Name: noalg.[8]struct { key bool; elem main.node }
       ByteSize: 192
       GoRuntimeType: 673472
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 226 StructureType noalg.struct { key bool; elem main.node }
+      Element: 227 StructureType noalg.struct { key bool; elem main.node }
     - __kind: ArrayType
-      ID: 210
+      ID: 181
       Name: noalg.[8]struct { key int; elem int }
       ByteSize: 128
       GoRuntimeType: 671264
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 211 StructureType noalg.struct { key int; elem int }
+      Element: 182 StructureType noalg.struct { key int; elem int }
     - __kind: ArrayType
-      ID: 227
+      ID: 233
       Name: noalg.[8]struct { key int; elem uint8 }
       ByteSize: 128
       GoRuntimeType: 673568
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 228 StructureType noalg.struct { key int; elem uint8 }
+      Element: 234 StructureType noalg.struct { key int; elem uint8 }
     - __kind: ArrayType
-      ID: 221
+      ID: 217
       Name: noalg.[8]struct { key string; elem []main.structWithMap }
       ByteSize: 320
       GoRuntimeType: 673664
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 222 StructureType noalg.struct { key string; elem []main.structWithMap }
+      Element: 218 StructureType noalg.struct { key string; elem []main.structWithMap }
     - __kind: ArrayType
-      ID: 216
+      ID: 202
       Name: noalg.[8]struct { key string; elem []string }
       ByteSize: 320
       GoRuntimeType: 673760
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 217 StructureType noalg.struct { key string; elem []string }
+      Element: 203 StructureType noalg.struct { key string; elem []string }
     - __kind: ArrayType
-      ID: 214
+      ID: 195
       Name: noalg.[8]struct { key string; elem int }
       ByteSize: 192
       GoRuntimeType: 673856
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 215 StructureType noalg.struct { key string; elem int }
+      Element: 196 StructureType noalg.struct { key string; elem int }
     - __kind: ArrayType
-      ID: 212
+      ID: 188
       Name: noalg.[8]struct { key string; elem main.nestedStruct }
       ByteSize: 320
       GoRuntimeType: 673952
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 213 StructureType noalg.struct { key string; elem main.nestedStruct }
+      Element: 189 StructureType noalg.struct { key string; elem main.nestedStruct }
     - __kind: ArrayType
-      ID: 231
+      ID: 247
       Name: noalg.[8]struct { key uint8; elem [4]int }
       ByteSize: 320
       GoRuntimeType: 674048
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 232 StructureType noalg.struct { key uint8; elem [4]int }
+      Element: 248 StructureType noalg.struct { key uint8; elem [4]int }
     - __kind: ArrayType
-      ID: 229
+      ID: 240
       Name: noalg.[8]struct { key uint8; elem uint8 }
       ByteSize: 16
       GoRuntimeType: 674144
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 230 StructureType noalg.struct { key uint8; elem uint8 }
+      Element: 241 StructureType noalg.struct { key uint8; elem uint8 }
     - __kind: StructureType
-      ID: 209
+      ID: 261
       Name: noalg.map.group[[4]int][4]int
       ByteSize: 520
       GoRuntimeType: 1.277248e+06
@@ -6765,9 +6765,9 @@ Types:
           Type: 8 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 236 ArrayType noalg.[8]struct { key [4]int; elem [4]int }
+          Type: 262 ArrayType noalg.[8]struct { key [4]int; elem [4]int }
     - __kind: StructureType
-      ID: 206
+      ID: 254
       Name: noalg.map.group[[4]int]uint8
       ByteSize: 328
       GoRuntimeType: 1.277504e+06
@@ -6778,9 +6778,9 @@ Types:
           Type: 8 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 234 ArrayType noalg.[8]struct { key [4]int; elem uint8 }
+          Type: 255 ArrayType noalg.[8]struct { key [4]int; elem uint8 }
     - __kind: StructureType
-      ID: 188
+      ID: 208
       Name: noalg.map.group[[4]string][2]int
       ByteSize: 648
       GoRuntimeType: 1.27776e+06
@@ -6791,9 +6791,9 @@ Types:
           Type: 8 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 218 ArrayType noalg.[8]struct { key [4]string; elem [2]int }
+          Type: 209 ArrayType noalg.[8]struct { key [4]string; elem [2]int }
     - __kind: StructureType
-      ID: 194
+      ID: 225
       Name: noalg.map.group[bool]main.node
       ByteSize: 200
       GoRuntimeType: 1.278016e+06
@@ -6804,9 +6804,9 @@ Types:
           Type: 8 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 225 ArrayType noalg.[8]struct { key bool; elem main.node }
+          Type: 226 ArrayType noalg.[8]struct { key bool; elem main.node }
     - __kind: StructureType
-      ID: 176
+      ID: 180
       Name: noalg.map.group[int]int
       ByteSize: 136
       GoRuntimeType: 1.27648e+06
@@ -6817,9 +6817,9 @@ Types:
           Type: 8 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 210 ArrayType noalg.[8]struct { key int; elem int }
+          Type: 181 ArrayType noalg.[8]struct { key int; elem int }
     - __kind: StructureType
-      ID: 197
+      ID: 232
       Name: noalg.map.group[int]uint8
       ByteSize: 136
       GoRuntimeType: 1.278272e+06
@@ -6830,9 +6830,9 @@ Types:
           Type: 8 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 227 ArrayType noalg.[8]struct { key int; elem uint8 }
+          Type: 233 ArrayType noalg.[8]struct { key int; elem uint8 }
     - __kind: StructureType
-      ID: 191
+      ID: 216
       Name: noalg.map.group[string][]main.structWithMap
       ByteSize: 328
       GoRuntimeType: 1.278528e+06
@@ -6843,9 +6843,9 @@ Types:
           Type: 8 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 221 ArrayType noalg.[8]struct { key string; elem []main.structWithMap }
+          Type: 217 ArrayType noalg.[8]struct { key string; elem []main.structWithMap }
     - __kind: StructureType
-      ID: 185
+      ID: 201
       Name: noalg.map.group[string][]string
       ByteSize: 328
       GoRuntimeType: 1.278784e+06
@@ -6856,9 +6856,9 @@ Types:
           Type: 8 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 216 ArrayType noalg.[8]struct { key string; elem []string }
+          Type: 202 ArrayType noalg.[8]struct { key string; elem []string }
     - __kind: StructureType
-      ID: 182
+      ID: 194
       Name: noalg.map.group[string]int
       ByteSize: 200
       GoRuntimeType: 1.27904e+06
@@ -6869,9 +6869,9 @@ Types:
           Type: 8 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 214 ArrayType noalg.[8]struct { key string; elem int }
+          Type: 195 ArrayType noalg.[8]struct { key string; elem int }
     - __kind: StructureType
-      ID: 179
+      ID: 187
       Name: noalg.map.group[string]main.nestedStruct
       ByteSize: 328
       GoRuntimeType: 1.279296e+06
@@ -6882,9 +6882,9 @@ Types:
           Type: 8 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 212 ArrayType noalg.[8]struct { key string; elem main.nestedStruct }
+          Type: 188 ArrayType noalg.[8]struct { key string; elem main.nestedStruct }
     - __kind: StructureType
-      ID: 203
+      ID: 246
       Name: noalg.map.group[uint8][4]int
       ByteSize: 328
       GoRuntimeType: 1.279552e+06
@@ -6895,9 +6895,9 @@ Types:
           Type: 8 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 231 ArrayType noalg.[8]struct { key uint8; elem [4]int }
+          Type: 247 ArrayType noalg.[8]struct { key uint8; elem [4]int }
     - __kind: StructureType
-      ID: 200
+      ID: 239
       Name: noalg.map.group[uint8]uint8
       ByteSize: 24
       GoRuntimeType: 1.279808e+06
@@ -6908,9 +6908,9 @@ Types:
           Type: 8 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 229 ArrayType noalg.[8]struct { key uint8; elem uint8 }
+          Type: 240 ArrayType noalg.[8]struct { key uint8; elem uint8 }
     - __kind: StructureType
-      ID: 237
+      ID: 263
       Name: noalg.struct { key [4]int; elem [4]int }
       ByteSize: 64
       GoRuntimeType: 1.27712e+06
@@ -6918,12 +6918,12 @@ Types:
       RawFields:
         - Name: key
           Offset: 0
-          Type: 233 ArrayType [4]int
+          Type: 249 ArrayType [4]int
         - Name: elem
           Offset: 32
-          Type: 233 ArrayType [4]int
+          Type: 249 ArrayType [4]int
     - __kind: StructureType
-      ID: 235
+      ID: 256
       Name: noalg.struct { key [4]int; elem uint8 }
       ByteSize: 40
       GoRuntimeType: 1.277376e+06
@@ -6931,12 +6931,12 @@ Types:
       RawFields:
         - Name: key
           Offset: 0
-          Type: 233 ArrayType [4]int
+          Type: 249 ArrayType [4]int
         - Name: elem
           Offset: 32
           Type: 3 BaseType uint8
     - __kind: StructureType
-      ID: 219
+      ID: 210
       Name: noalg.struct { key [4]string; elem [2]int }
       ByteSize: 80
       GoRuntimeType: 1.277632e+06
@@ -6944,12 +6944,12 @@ Types:
       RawFields:
         - Name: key
           Offset: 0
-          Type: 220 ArrayType [4]string
+          Type: 211 ArrayType [4]string
         - Name: elem
           Offset: 64
           Type: 40 ArrayType [2]int
     - __kind: StructureType
-      ID: 226
+      ID: 227
       Name: noalg.struct { key bool; elem main.node }
       ByteSize: 24
       GoRuntimeType: 1.277888e+06
@@ -6962,7 +6962,7 @@ Types:
           Offset: 8
           Type: 131 StructureType main.node
     - __kind: StructureType
-      ID: 211
+      ID: 182
       Name: noalg.struct { key int; elem int }
       ByteSize: 16
       GoRuntimeType: 1.276352e+06
@@ -6975,7 +6975,7 @@ Types:
           Offset: 8
           Type: 7 BaseType int
     - __kind: StructureType
-      ID: 228
+      ID: 234
       Name: noalg.struct { key int; elem uint8 }
       ByteSize: 16
       GoRuntimeType: 1.278144e+06
@@ -6988,7 +6988,7 @@ Types:
           Offset: 8
           Type: 3 BaseType uint8
     - __kind: StructureType
-      ID: 222
+      ID: 218
       Name: noalg.struct { key string; elem []main.structWithMap }
       ByteSize: 40
       GoRuntimeType: 1.2784e+06
@@ -6999,9 +6999,9 @@ Types:
           Type: 9 GoStringHeaderType string
         - Name: elem
           Offset: 16
-          Type: 223 GoSliceHeaderType []main.structWithMap
+          Type: 219 GoSliceHeaderType []main.structWithMap
     - __kind: StructureType
-      ID: 217
+      ID: 203
       Name: noalg.struct { key string; elem []string }
       ByteSize: 40
       GoRuntimeType: 1.278656e+06
@@ -7014,7 +7014,7 @@ Types:
           Offset: 16
           Type: 141 GoSliceHeaderType []string
     - __kind: StructureType
-      ID: 215
+      ID: 196
       Name: noalg.struct { key string; elem int }
       ByteSize: 24
       GoRuntimeType: 1.278912e+06
@@ -7027,7 +7027,7 @@ Types:
           Offset: 16
           Type: 7 BaseType int
     - __kind: StructureType
-      ID: 213
+      ID: 189
       Name: noalg.struct { key string; elem main.nestedStruct }
       ByteSize: 40
       GoRuntimeType: 1.279168e+06
@@ -7040,7 +7040,7 @@ Types:
           Offset: 16
           Type: 149 StructureType main.nestedStruct
     - __kind: StructureType
-      ID: 232
+      ID: 248
       Name: noalg.struct { key uint8; elem [4]int }
       ByteSize: 40
       GoRuntimeType: 1.279424e+06
@@ -7051,9 +7051,9 @@ Types:
           Type: 3 BaseType uint8
         - Name: elem
           Offset: 8
-          Type: 233 ArrayType [4]int
+          Type: 249 ArrayType [4]int
     - __kind: StructureType
-      ID: 230
+      ID: 241
       Name: noalg.struct { key uint8; elem uint8 }
       ByteSize: 2
       GoRuntimeType: 1.27968e+06
@@ -7074,13 +7074,13 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 239 PointerType *string.str
+          Type: 175 PointerType *string.str
         - Name: len
           Offset: 8
           Type: 7 BaseType int
-      Data: 238 GoStringDataType string.str
+      Data: 174 GoStringDataType string.str
     - __kind: GoStringDataType
-      ID: 238
+      ID: 174
       Name: string.str
       ByteSize: 2048
     - __kind: StructureType
@@ -7211,7 +7211,7 @@ Types:
           Type: 7 BaseType int
         - Name: groups
           Offset: 16
-          Type: 207 GoSwissMapGroupsType groupReference<[4]int,[4]int>
+          Type: 259 GoSwissMapGroupsType groupReference<[4]int,[4]int>
     - __kind: StructureType
       ID: 171
       Name: table<[4]int,uint8>
@@ -7235,7 +7235,7 @@ Types:
           Type: 7 BaseType int
         - Name: groups
           Offset: 16
-          Type: 204 GoSwissMapGroupsType groupReference<[4]int,uint8>
+          Type: 252 GoSwissMapGroupsType groupReference<[4]int,uint8>
     - __kind: StructureType
       ID: 165
       Name: table<[4]string,[2]int>
@@ -7259,7 +7259,7 @@ Types:
           Type: 7 BaseType int
         - Name: groups
           Offset: 16
-          Type: 186 GoSwissMapGroupsType groupReference<[4]string,[2]int>
+          Type: 206 GoSwissMapGroupsType groupReference<[4]string,[2]int>
     - __kind: StructureType
       ID: 167
       Name: table<bool,main.node>
@@ -7283,7 +7283,7 @@ Types:
           Type: 7 BaseType int
         - Name: groups
           Offset: 16
-          Type: 192 GoSwissMapGroupsType groupReference<bool,main.node>
+          Type: 223 GoSwissMapGroupsType groupReference<bool,main.node>
     - __kind: StructureType
       ID: 161
       Name: table<int,int>
@@ -7307,7 +7307,7 @@ Types:
           Type: 7 BaseType int
         - Name: groups
           Offset: 16
-          Type: 174 GoSwissMapGroupsType groupReference<int,int>
+          Type: 178 GoSwissMapGroupsType groupReference<int,int>
     - __kind: StructureType
       ID: 168
       Name: table<int,uint8>
@@ -7331,7 +7331,7 @@ Types:
           Type: 7 BaseType int
         - Name: groups
           Offset: 16
-          Type: 195 GoSwissMapGroupsType groupReference<int,uint8>
+          Type: 230 GoSwissMapGroupsType groupReference<int,uint8>
     - __kind: StructureType
       ID: 166
       Name: table<string,[]main.structWithMap>
@@ -7355,7 +7355,7 @@ Types:
           Type: 7 BaseType int
         - Name: groups
           Offset: 16
-          Type: 189 GoSwissMapGroupsType groupReference<string,[]main.structWithMap>
+          Type: 214 GoSwissMapGroupsType groupReference<string,[]main.structWithMap>
     - __kind: StructureType
       ID: 164
       Name: table<string,[]string>
@@ -7379,7 +7379,7 @@ Types:
           Type: 7 BaseType int
         - Name: groups
           Offset: 16
-          Type: 183 GoSwissMapGroupsType groupReference<string,[]string>
+          Type: 199 GoSwissMapGroupsType groupReference<string,[]string>
     - __kind: StructureType
       ID: 163
       Name: table<string,int>
@@ -7403,7 +7403,7 @@ Types:
           Type: 7 BaseType int
         - Name: groups
           Offset: 16
-          Type: 180 GoSwissMapGroupsType groupReference<string,int>
+          Type: 192 GoSwissMapGroupsType groupReference<string,int>
     - __kind: StructureType
       ID: 162
       Name: table<string,main.nestedStruct>
@@ -7427,7 +7427,7 @@ Types:
           Type: 7 BaseType int
         - Name: groups
           Offset: 16
-          Type: 177 GoSwissMapGroupsType groupReference<string,main.nestedStruct>
+          Type: 185 GoSwissMapGroupsType groupReference<string,main.nestedStruct>
     - __kind: StructureType
       ID: 170
       Name: table<uint8,[4]int>
@@ -7451,7 +7451,7 @@ Types:
           Type: 7 BaseType int
         - Name: groups
           Offset: 16
-          Type: 201 GoSwissMapGroupsType groupReference<uint8,[4]int>
+          Type: 244 GoSwissMapGroupsType groupReference<uint8,[4]int>
     - __kind: StructureType
       ID: 169
       Name: table<uint8,uint8>
@@ -7475,7 +7475,7 @@ Types:
           Type: 7 BaseType int
         - Name: groups
           Offset: 16
-          Type: 198 GoSwissMapGroupsType groupReference<uint8,uint8>
+          Type: 237 GoSwissMapGroupsType groupReference<uint8,uint8>
     - __kind: BaseType
       ID: 16
       Name: uint

--- a/pkg/dyninst/irgen/testdata/snapshot/sample.arch=amd64,toolchain=go1.24.3.yaml
+++ b/pkg/dyninst/irgen/testdata/snapshot/sample.arch=amd64,toolchain=go1.24.3.yaml
@@ -3094,275 +3094,11 @@ Subprograms:
           IsParameter: true
           IsReturn: false
 Types:
-    - __kind: BaseType
-      ID: 1
-      Name: int
-      ByteSize: 8
-      GoRuntimeType: 575584
-      GoKind: 2
-    - __kind: ArrayType
-      ID: 2
-      Name: '[5]int'
-      ByteSize: 40
-      GoKind: 17
-      Count: 5
-      HasCount: true
-      Element: 1 BaseType int
-    - __kind: ArrayType
-      ID: 3
-      Name: '[2]uint8'
-      ByteSize: 2
-      GoRuntimeType: 674528
-      GoKind: 17
-      Count: 2
-      HasCount: true
-      Element: 4 BaseType uint8
-    - __kind: BaseType
-      ID: 4
-      Name: uint8
-      ByteSize: 1
-      GoRuntimeType: 575136
-      GoKind: 8
-    - __kind: ArrayType
-      ID: 5
-      Name: '[2]int32'
-      ByteSize: 8
-      GoRuntimeType: 674624
-      GoKind: 17
-      Count: 2
-      HasCount: true
-      Element: 6 BaseType int32
-    - __kind: BaseType
-      ID: 6
-      Name: int32
-      ByteSize: 4
-      GoRuntimeType: 575328
-      GoKind: 5
-    - __kind: ArrayType
-      ID: 7
-      Name: '[2]string'
-      ByteSize: 32
-      GoRuntimeType: 674720
-      GoKind: 17
-      Count: 2
-      HasCount: true
-      Element: 8 GoStringHeaderType string
-    - __kind: GoStringHeaderType
-      ID: 8
-      Name: string
-      ByteSize: 16
-      GoRuntimeType: 575008
-      GoKind: 24
-      RawFields:
-        - Name: str
-          Offset: 0
-          Type: 239 PointerType *string.str
-        - Name: len
-          Offset: 8
-          Type: 1 BaseType int
-      Data: 238 GoStringDataType string.str
     - __kind: PointerType
-      ID: 9
-      Name: '*uint8'
+      ID: 209
+      Name: '**main.t'
       ByteSize: 8
-      GoRuntimeType: 385344
-      GoKind: 22
-      Pointee: 4 BaseType uint8
-    - __kind: ArrayType
-      ID: 10
-      Name: '[2]bool'
-      ByteSize: 2
-      GoKind: 17
-      Count: 2
-      HasCount: true
-      Element: 11 BaseType bool
-    - __kind: BaseType
-      ID: 11
-      Name: bool
-      ByteSize: 1
-      GoRuntimeType: 576032
-      GoKind: 1
-    - __kind: ArrayType
-      ID: 12
-      Name: '[2]int'
-      ByteSize: 16
-      GoRuntimeType: 673280
-      GoKind: 17
-      Count: 2
-      HasCount: true
-      Element: 1 BaseType int
-    - __kind: ArrayType
-      ID: 13
-      Name: '[2]int8'
-      ByteSize: 2
-      GoKind: 17
-      Count: 2
-      HasCount: true
-      Element: 14 BaseType int8
-    - __kind: BaseType
-      ID: 14
-      Name: int8
-      ByteSize: 1
-      GoRuntimeType: 575072
-      GoKind: 3
-    - __kind: ArrayType
-      ID: 15
-      Name: '[2]int16'
-      ByteSize: 4
-      GoKind: 17
-      Count: 2
-      HasCount: true
-      Element: 16 BaseType int16
-    - __kind: BaseType
-      ID: 16
-      Name: int16
-      ByteSize: 2
-      GoRuntimeType: 575200
-      GoKind: 4
-    - __kind: ArrayType
-      ID: 17
-      Name: '[2]int64'
-      ByteSize: 16
-      GoKind: 17
-      Count: 2
-      HasCount: true
-      Element: 18 BaseType int64
-    - __kind: BaseType
-      ID: 18
-      Name: int64
-      ByteSize: 8
-      GoRuntimeType: 575456
-      GoKind: 6
-    - __kind: ArrayType
-      ID: 19
-      Name: '[2]uint'
-      ByteSize: 16
-      GoKind: 17
-      Count: 2
-      HasCount: true
-      Element: 20 BaseType uint
-    - __kind: BaseType
-      ID: 20
-      Name: uint
-      ByteSize: 8
-      GoRuntimeType: 575648
-      GoKind: 7
-    - __kind: ArrayType
-      ID: 21
-      Name: '[2]uint16'
-      ByteSize: 4
-      GoKind: 17
-      Count: 2
-      HasCount: true
-      Element: 22 BaseType uint16
-    - __kind: BaseType
-      ID: 22
-      Name: uint16
-      ByteSize: 2
-      GoRuntimeType: 575264
-      GoKind: 9
-    - __kind: ArrayType
-      ID: 23
-      Name: '[2]uint32'
-      ByteSize: 8
-      GoKind: 17
-      Count: 2
-      HasCount: true
-      Element: 24 BaseType uint32
-    - __kind: BaseType
-      ID: 24
-      Name: uint32
-      ByteSize: 4
-      GoRuntimeType: 575392
-      GoKind: 10
-    - __kind: ArrayType
-      ID: 25
-      Name: '[2]uint64'
-      ByteSize: 16
-      GoRuntimeType: 674816
-      GoKind: 17
-      Count: 2
-      HasCount: true
-      Element: 26 BaseType uint64
-    - __kind: BaseType
-      ID: 26
-      Name: uint64
-      ByteSize: 8
-      GoRuntimeType: 575520
-      GoKind: 11
-    - __kind: ArrayType
-      ID: 27
-      Name: '[2][2]int'
-      ByteSize: 32
-      GoKind: 17
-      Count: 2
-      HasCount: true
-      Element: 12 ArrayType [2]int
-    - __kind: ArrayType
-      ID: 28
-      Name: '[2][2][2]int'
-      ByteSize: 64
-      GoKind: 17
-      Count: 2
-      HasCount: true
-      Element: 27 ArrayType [2][2]int
-    - __kind: ArrayType
-      ID: 29
-      Name: '[100]uint'
-      ByteSize: 800
-      GoKind: 17
-      Count: 100
-      HasCount: true
-      Element: 20 BaseType uint
-    - __kind: BaseType
-      ID: 30
-      Name: float32
-      ByteSize: 4
-      GoRuntimeType: 575904
-      GoKind: 13
-    - __kind: BaseType
-      ID: 31
-      Name: float64
-      ByteSize: 8
-      GoRuntimeType: 575968
-      GoKind: 14
-    - __kind: BaseType
-      ID: 32
-      Name: main.typeAlias
-      ByteSize: 2
-      GoKind: 9
-    - __kind: StructureType
-      ID: 33
-      Name: main.bigStruct
-      ByteSize: 48
-      GoKind: 25
-      RawFields:
-        - Name: x
-          Offset: 0
-          Type: 34 GoSliceHeaderType []*string
-        - Name: z
-          Offset: 24
-          Type: 1 BaseType int
-        - Name: writer
-          Offset: 32
-          Type: 37 GoInterfaceType io.Writer
-    - __kind: GoSliceHeaderType
-      ID: 34
-      Name: '[]*string'
-      ByteSize: 24
-      GoRuntimeType: 470656
-      GoKind: 23
-      RawFields:
-        - Name: array
-          Offset: 0
-          Type: 35 PointerType **string
-        - Name: len
-          Offset: 8
-          Type: 1 BaseType int
-        - Name: cap
-          Offset: 16
-          Type: 1 BaseType int
-      Data: 240 GoSliceDataType []*string.array
+      Pointee: 207 PointerType *main.t
     - __kind: PointerType
       ID: 35
       Name: '**string'
@@ -3371,2005 +3107,110 @@ Types:
       GoKind: 22
       Pointee: 36 PointerType *string
     - __kind: PointerType
-      ID: 36
-      Name: '*string'
+      ID: 194
+      Name: '**table<[4]int,[4]int>'
       ByteSize: 8
-      GoRuntimeType: 385216
-      GoKind: 22
-      Pointee: 8 GoStringHeaderType string
-    - __kind: GoInterfaceType
-      ID: 37
-      Name: io.Writer
-      ByteSize: 16
-      GoRuntimeType: 1.012448e+06
-      GoKind: 20
-      RawFields:
-        - Name: tab
-          Offset: 0
-          Type: 38 VoidPointerType unsafe.Pointer
-        - Name: data
-          Offset: 8
-          Type: 38 VoidPointerType unsafe.Pointer
-    - __kind: VoidPointerType
-      ID: 38
-      Name: unsafe.Pointer
-      ByteSize: 8
-      GoRuntimeType: 576096
-      GoKind: 26
-    - __kind: StructureType
-      ID: 39
-      Name: main.esotericStack
-      ByteSize: 64
-      GoRuntimeType: 1.945504e+06
-      GoKind: 25
-      RawFields:
-        - Name: _
-          Offset: 0
-          Type: 6 BaseType int32
-        - Name: _valid
-          Offset: 4
-          Type: 6 BaseType int32
-        - Name: c
-          Offset: 8
-          Type: 40 GoChannelType chan struct {}
-        - Name: val
-          Offset: 16
-          Type: 41 GoEmptyInterfaceType interface {}
-        - Name: _
-          Offset: 32
-          Type: 26 BaseType uint64
-        - Name: work
-          Offset: 40
-          Type: 42 GoInterfaceType main.something
-        - Name: foo
-          Offset: 56
-          Type: 43 GoSubroutineType func()
-    - __kind: GoChannelType
-      ID: 40
-      Name: chan struct {}
-      GoRuntimeType: 586272
-      GoKind: 18
-    - __kind: GoEmptyInterfaceType
-      ID: 41
-      Name: interface {}
-      ByteSize: 16
-      GoRuntimeType: 838336
-      GoKind: 20
-      RawFields:
-        - Name: _type
-          Offset: 0
-          Type: 38 VoidPointerType unsafe.Pointer
-        - Name: data
-          Offset: 8
-          Type: 38 VoidPointerType unsafe.Pointer
-    - __kind: GoInterfaceType
-      ID: 42
-      Name: main.something
-      ByteSize: 16
-      GoRuntimeType: 1.012192e+06
-      GoKind: 20
-      RawFields:
-        - Name: tab
-          Offset: 0
-          Type: 38 VoidPointerType unsafe.Pointer
-        - Name: data
-          Offset: 8
-          Type: 38 VoidPointerType unsafe.Pointer
-    - __kind: GoSubroutineType
-      ID: 43
-      Name: func()
-      ByteSize: 8
-      GoRuntimeType: 468928
-      GoKind: 19
-    - __kind: PointerType
-      ID: 44
-      Name: '*main.esotericHeap'
-      ByteSize: 8
-      GoRuntimeType: 380224
-      GoKind: 22
-      Pointee: 45 StructureType main.esotericHeap
-    - __kind: StructureType
-      ID: 45
-      Name: main.esotericHeap
-      ByteSize: 112
-      GoRuntimeType: 1.81168e+06
-      GoKind: 25
-      RawFields:
-        - Name: esotericStack
-          Offset: 0
-          Type: 39 StructureType main.esotericStack
-        - Name: mu
-          Offset: 64
-          Type: 46 StructureType sync.Mutex
-        - Name: once
-          Offset: 72
-          Type: 49 StructureType sync.Once
-        - Name: wg
-          Offset: 88
-          Type: 52 StructureType sync.WaitGroup
-        - Name: a
-          Offset: 104
-          Type: 55 StructureType sync/atomic.Int32
-    - __kind: StructureType
-      ID: 46
-      Name: sync.Mutex
-      ByteSize: 8
-      GoRuntimeType: 1.445344e+06
-      GoKind: 25
-      RawFields:
-        - Name: _
-          Offset: 0
-          Type: 47 StructureType sync.noCopy
-        - Name: mu
-          Offset: 0
-          Type: 48 StructureType internal/sync.Mutex
-    - __kind: StructureType
-      ID: 47
-      Name: sync.noCopy
-      GoRuntimeType: 977728
-      GoKind: 25
-      RawFields: []
-    - __kind: StructureType
-      ID: 48
-      Name: internal/sync.Mutex
-      ByteSize: 8
-      GoRuntimeType: 1.454624e+06
-      GoKind: 25
-      RawFields:
-        - Name: state
-          Offset: 0
-          Type: 6 BaseType int32
-        - Name: sema
-          Offset: 4
-          Type: 24 BaseType uint32
-    - __kind: StructureType
-      ID: 49
-      Name: sync.Once
-      ByteSize: 12
-      GoRuntimeType: 1.593696e+06
-      GoKind: 25
-      RawFields:
-        - Name: _
-          Offset: 0
-          Type: 47 StructureType sync.noCopy
-        - Name: done
-          Offset: 0
-          Type: 50 StructureType sync/atomic.Uint32
-        - Name: m
-          Offset: 4
-          Type: 46 StructureType sync.Mutex
-    - __kind: StructureType
-      ID: 50
-      Name: sync/atomic.Uint32
-      ByteSize: 4
-      GoRuntimeType: 1.446784e+06
-      GoKind: 25
-      RawFields:
-        - Name: _
-          Offset: 0
-          Type: 51 StructureType sync/atomic.noCopy
-        - Name: v
-          Offset: 0
-          Type: 24 BaseType uint32
-    - __kind: StructureType
-      ID: 51
-      Name: sync/atomic.noCopy
-      GoRuntimeType: 977824
-      GoKind: 25
-      RawFields: []
-    - __kind: StructureType
-      ID: 52
-      Name: sync.WaitGroup
-      ByteSize: 16
-      GoRuntimeType: 1.593888e+06
-      GoKind: 25
-      RawFields:
-        - Name: noCopy
-          Offset: 0
-          Type: 47 StructureType sync.noCopy
-        - Name: state
-          Offset: 0
-          Type: 53 StructureType sync/atomic.Uint64
-        - Name: sema
-          Offset: 8
-          Type: 24 BaseType uint32
-    - __kind: StructureType
-      ID: 53
-      Name: sync/atomic.Uint64
-      ByteSize: 8
-      GoRuntimeType: 1.594272e+06
-      GoKind: 25
-      RawFields:
-        - Name: _
-          Offset: 0
-          Type: 51 StructureType sync/atomic.noCopy
-        - Name: _
-          Offset: 0
-          Type: 54 StructureType sync/atomic.align64
-        - Name: v
-          Offset: 0
-          Type: 26 BaseType uint64
-    - __kind: StructureType
-      ID: 54
-      Name: sync/atomic.align64
-      GoRuntimeType: 977920
-      GoKind: 25
-      RawFields: []
-    - __kind: StructureType
-      ID: 55
-      Name: sync/atomic.Int32
-      ByteSize: 4
-      GoRuntimeType: 1.446624e+06
-      GoKind: 25
-      RawFields:
-        - Name: _
-          Offset: 0
-          Type: 51 StructureType sync/atomic.noCopy
-        - Name: v
-          Offset: 0
-          Type: 6 BaseType int32
-    - __kind: GoInterfaceType
-      ID: 56
-      Name: main.behavior
-      ByteSize: 16
-      GoRuntimeType: 1.012064e+06
-      GoKind: 20
-      RawFields:
-        - Name: tab
-          Offset: 0
-          Type: 38 VoidPointerType unsafe.Pointer
-        - Name: data
-          Offset: 8
-          Type: 38 VoidPointerType unsafe.Pointer
-    - __kind: GoInterfaceType
-      ID: 57
-      Name: error
-      ByteSize: 16
-      GoRuntimeType: 1.016416e+06
-      GoKind: 20
-      RawFields:
-        - Name: tab
-          Offset: 0
-          Type: 38 VoidPointerType unsafe.Pointer
-        - Name: data
-          Offset: 8
-          Type: 38 VoidPointerType unsafe.Pointer
-    - __kind: StructureType
-      ID: 58
-      Name: main.structWithMap
-      ByteSize: 8
-      GoRuntimeType: 1.173504e+06
-      GoKind: 25
-      RawFields:
-        - Name: m
-          Offset: 0
-          Type: 59 GoMapType map[int]int
-    - __kind: GoMapType
-      ID: 59
-      Name: map[int]int
-      ByteSize: 8
-      GoRuntimeType: 1.117184e+06
-      GoKind: 21
-      HeaderType: 61 GoSwissMapHeaderType map<int,int>
-    - __kind: PointerType
-      ID: 60
-      Name: '*map<int,int>'
-      ByteSize: 8
-      Pointee: 61 GoSwissMapHeaderType map<int,int>
-    - __kind: GoSwissMapHeaderType
-      ID: 61
-      Name: map<int,int>
-      ByteSize: 48
-      GoKind: 25
-      RawFields:
-        - Name: used
-          Offset: 0
-          Type: 26 BaseType uint64
-        - Name: seed
-          Offset: 8
-          Type: 62 BaseType uintptr
-        - Name: dirPtr
-          Offset: 16
-          Type: 63 PointerType **table<int,int>
-        - Name: dirLen
-          Offset: 24
-          Type: 1 BaseType int
-        - Name: globalDepth
-          Offset: 32
-          Type: 4 BaseType uint8
-        - Name: globalShift
-          Offset: 33
-          Type: 4 BaseType uint8
-        - Name: writing
-          Offset: 34
-          Type: 4 BaseType uint8
-        - Name: clearSeq
-          Offset: 40
-          Type: 26 BaseType uint64
-      TablePtrSliceType: 242 GoSliceDataType []*table<int,int>.array
-      GroupType: 68 StructureType noalg.map.group[int]int
-    - __kind: BaseType
-      ID: 62
-      Name: uintptr
-      ByteSize: 8
-      GoRuntimeType: 575712
-      GoKind: 12
-    - __kind: PointerType
-      ID: 63
-      Name: '**table<int,int>'
-      ByteSize: 8
-      Pointee: 64 PointerType *table<int,int>
-    - __kind: PointerType
-      ID: 64
-      Name: '*table<int,int>'
-      ByteSize: 8
-      Pointee: 65 StructureType table<int,int>
-    - __kind: StructureType
-      ID: 65
-      Name: table<int,int>
-      ByteSize: 32
-      GoKind: 25
-      RawFields:
-        - Name: used
-          Offset: 0
-          Type: 22 BaseType uint16
-        - Name: capacity
-          Offset: 2
-          Type: 22 BaseType uint16
-        - Name: growthLeft
-          Offset: 4
-          Type: 22 BaseType uint16
-        - Name: localDepth
-          Offset: 6
-          Type: 4 BaseType uint8
-        - Name: index
-          Offset: 8
-          Type: 1 BaseType int
-        - Name: groups
-          Offset: 16
-          Type: 66 GoSwissMapGroupsType groupReference<int,int>
-    - __kind: GoSwissMapGroupsType
-      ID: 66
-      Name: groupReference<int,int>
-      ByteSize: 16
-      GoKind: 25
-      RawFields:
-        - Name: data
-          Offset: 0
-          Type: 67 PointerType *noalg.map.group[int]int
-        - Name: lengthMask
-          Offset: 8
-          Type: 26 BaseType uint64
-      GroupType: 68 StructureType noalg.map.group[int]int
-      GroupSliceType: 243 GoSliceDataType []noalg.map.group[int]int.array
-    - __kind: PointerType
-      ID: 67
-      Name: '*noalg.map.group[int]int'
-      ByteSize: 8
-      Pointee: 68 StructureType noalg.map.group[int]int
-    - __kind: StructureType
-      ID: 68
-      Name: noalg.map.group[int]int
-      ByteSize: 136
-      GoRuntimeType: 1.27648e+06
-      GoKind: 25
-      RawFields:
-        - Name: ctrl
-          Offset: 0
-          Type: 26 BaseType uint64
-        - Name: slots
-          Offset: 8
-          Type: 69 ArrayType noalg.[8]struct { key int; elem int }
-    - __kind: ArrayType
-      ID: 69
-      Name: noalg.[8]struct { key int; elem int }
-      ByteSize: 128
-      GoRuntimeType: 671264
-      GoKind: 17
-      Count: 8
-      HasCount: true
-      Element: 70 StructureType noalg.struct { key int; elem int }
-    - __kind: StructureType
-      ID: 70
-      Name: noalg.struct { key int; elem int }
-      ByteSize: 16
-      GoRuntimeType: 1.276352e+06
-      GoKind: 25
-      RawFields:
-        - Name: key
-          Offset: 0
-          Type: 1 BaseType int
-        - Name: elem
-          Offset: 8
-          Type: 1 BaseType int
-    - __kind: GoMapType
-      ID: 71
-      Name: map[string]main.nestedStruct
-      ByteSize: 8
-      GoRuntimeType: 1.118592e+06
-      GoKind: 21
-      HeaderType: 73 GoSwissMapHeaderType map<string,main.nestedStruct>
-    - __kind: PointerType
-      ID: 72
-      Name: '*map<string,main.nestedStruct>'
-      ByteSize: 8
-      Pointee: 73 GoSwissMapHeaderType map<string,main.nestedStruct>
-    - __kind: GoSwissMapHeaderType
-      ID: 73
-      Name: map<string,main.nestedStruct>
-      ByteSize: 48
-      GoKind: 25
-      RawFields:
-        - Name: used
-          Offset: 0
-          Type: 26 BaseType uint64
-        - Name: seed
-          Offset: 8
-          Type: 62 BaseType uintptr
-        - Name: dirPtr
-          Offset: 16
-          Type: 74 PointerType **table<string,main.nestedStruct>
-        - Name: dirLen
-          Offset: 24
-          Type: 1 BaseType int
-        - Name: globalDepth
-          Offset: 32
-          Type: 4 BaseType uint8
-        - Name: globalShift
-          Offset: 33
-          Type: 4 BaseType uint8
-        - Name: writing
-          Offset: 34
-          Type: 4 BaseType uint8
-        - Name: clearSeq
-          Offset: 40
-          Type: 26 BaseType uint64
-      TablePtrSliceType: 244 GoSliceDataType []*table<string,main.nestedStruct>.array
-      GroupType: 79 StructureType noalg.map.group[string]main.nestedStruct
-    - __kind: PointerType
-      ID: 74
-      Name: '**table<string,main.nestedStruct>'
-      ByteSize: 8
-      Pointee: 75 PointerType *table<string,main.nestedStruct>
-    - __kind: PointerType
-      ID: 75
-      Name: '*table<string,main.nestedStruct>'
-      ByteSize: 8
-      Pointee: 76 StructureType table<string,main.nestedStruct>
-    - __kind: StructureType
-      ID: 76
-      Name: table<string,main.nestedStruct>
-      ByteSize: 32
-      GoKind: 25
-      RawFields:
-        - Name: used
-          Offset: 0
-          Type: 22 BaseType uint16
-        - Name: capacity
-          Offset: 2
-          Type: 22 BaseType uint16
-        - Name: growthLeft
-          Offset: 4
-          Type: 22 BaseType uint16
-        - Name: localDepth
-          Offset: 6
-          Type: 4 BaseType uint8
-        - Name: index
-          Offset: 8
-          Type: 1 BaseType int
-        - Name: groups
-          Offset: 16
-          Type: 77 GoSwissMapGroupsType groupReference<string,main.nestedStruct>
-    - __kind: GoSwissMapGroupsType
-      ID: 77
-      Name: groupReference<string,main.nestedStruct>
-      ByteSize: 16
-      GoKind: 25
-      RawFields:
-        - Name: data
-          Offset: 0
-          Type: 78 PointerType *noalg.map.group[string]main.nestedStruct
-        - Name: lengthMask
-          Offset: 8
-          Type: 26 BaseType uint64
-      GroupType: 79 StructureType noalg.map.group[string]main.nestedStruct
-      GroupSliceType: 245 GoSliceDataType []noalg.map.group[string]main.nestedStruct.array
-    - __kind: PointerType
-      ID: 78
-      Name: '*noalg.map.group[string]main.nestedStruct'
-      ByteSize: 8
-      Pointee: 79 StructureType noalg.map.group[string]main.nestedStruct
-    - __kind: StructureType
-      ID: 79
-      Name: noalg.map.group[string]main.nestedStruct
-      ByteSize: 328
-      GoRuntimeType: 1.279296e+06
-      GoKind: 25
-      RawFields:
-        - Name: ctrl
-          Offset: 0
-          Type: 26 BaseType uint64
-        - Name: slots
-          Offset: 8
-          Type: 80 ArrayType noalg.[8]struct { key string; elem main.nestedStruct }
-    - __kind: ArrayType
-      ID: 80
-      Name: noalg.[8]struct { key string; elem main.nestedStruct }
-      ByteSize: 320
-      GoRuntimeType: 673952
-      GoKind: 17
-      Count: 8
-      HasCount: true
-      Element: 81 StructureType noalg.struct { key string; elem main.nestedStruct }
-    - __kind: StructureType
-      ID: 81
-      Name: noalg.struct { key string; elem main.nestedStruct }
-      ByteSize: 40
-      GoRuntimeType: 1.279168e+06
-      GoKind: 25
-      RawFields:
-        - Name: key
-          Offset: 0
-          Type: 8 GoStringHeaderType string
-        - Name: elem
-          Offset: 16
-          Type: 82 StructureType main.nestedStruct
-    - __kind: StructureType
-      ID: 82
-      Name: main.nestedStruct
-      ByteSize: 24
-      GoRuntimeType: 1.444064e+06
-      GoKind: 25
-      RawFields:
-        - Name: anotherInt
-          Offset: 0
-          Type: 1 BaseType int
-        - Name: anotherString
-          Offset: 8
-          Type: 8 GoStringHeaderType string
-    - __kind: GoMapType
-      ID: 83
-      Name: map[string]int
-      ByteSize: 8
-      GoRuntimeType: 1.118464e+06
-      GoKind: 21
-      HeaderType: 85 GoSwissMapHeaderType map<string,int>
-    - __kind: PointerType
-      ID: 84
-      Name: '*map<string,int>'
-      ByteSize: 8
-      Pointee: 85 GoSwissMapHeaderType map<string,int>
-    - __kind: GoSwissMapHeaderType
-      ID: 85
-      Name: map<string,int>
-      ByteSize: 48
-      GoKind: 25
-      RawFields:
-        - Name: used
-          Offset: 0
-          Type: 26 BaseType uint64
-        - Name: seed
-          Offset: 8
-          Type: 62 BaseType uintptr
-        - Name: dirPtr
-          Offset: 16
-          Type: 86 PointerType **table<string,int>
-        - Name: dirLen
-          Offset: 24
-          Type: 1 BaseType int
-        - Name: globalDepth
-          Offset: 32
-          Type: 4 BaseType uint8
-        - Name: globalShift
-          Offset: 33
-          Type: 4 BaseType uint8
-        - Name: writing
-          Offset: 34
-          Type: 4 BaseType uint8
-        - Name: clearSeq
-          Offset: 40
-          Type: 26 BaseType uint64
-      TablePtrSliceType: 246 GoSliceDataType []*table<string,int>.array
-      GroupType: 91 StructureType noalg.map.group[string]int
-    - __kind: PointerType
-      ID: 86
-      Name: '**table<string,int>'
-      ByteSize: 8
-      Pointee: 87 PointerType *table<string,int>
-    - __kind: PointerType
-      ID: 87
-      Name: '*table<string,int>'
-      ByteSize: 8
-      Pointee: 88 StructureType table<string,int>
-    - __kind: StructureType
-      ID: 88
-      Name: table<string,int>
-      ByteSize: 32
-      GoKind: 25
-      RawFields:
-        - Name: used
-          Offset: 0
-          Type: 22 BaseType uint16
-        - Name: capacity
-          Offset: 2
-          Type: 22 BaseType uint16
-        - Name: growthLeft
-          Offset: 4
-          Type: 22 BaseType uint16
-        - Name: localDepth
-          Offset: 6
-          Type: 4 BaseType uint8
-        - Name: index
-          Offset: 8
-          Type: 1 BaseType int
-        - Name: groups
-          Offset: 16
-          Type: 89 GoSwissMapGroupsType groupReference<string,int>
-    - __kind: GoSwissMapGroupsType
-      ID: 89
-      Name: groupReference<string,int>
-      ByteSize: 16
-      GoKind: 25
-      RawFields:
-        - Name: data
-          Offset: 0
-          Type: 90 PointerType *noalg.map.group[string]int
-        - Name: lengthMask
-          Offset: 8
-          Type: 26 BaseType uint64
-      GroupType: 91 StructureType noalg.map.group[string]int
-      GroupSliceType: 247 GoSliceDataType []noalg.map.group[string]int.array
-    - __kind: PointerType
-      ID: 90
-      Name: '*noalg.map.group[string]int'
-      ByteSize: 8
-      Pointee: 91 StructureType noalg.map.group[string]int
-    - __kind: StructureType
-      ID: 91
-      Name: noalg.map.group[string]int
-      ByteSize: 200
-      GoRuntimeType: 1.27904e+06
-      GoKind: 25
-      RawFields:
-        - Name: ctrl
-          Offset: 0
-          Type: 26 BaseType uint64
-        - Name: slots
-          Offset: 8
-          Type: 92 ArrayType noalg.[8]struct { key string; elem int }
-    - __kind: ArrayType
-      ID: 92
-      Name: noalg.[8]struct { key string; elem int }
-      ByteSize: 192
-      GoRuntimeType: 673856
-      GoKind: 17
-      Count: 8
-      HasCount: true
-      Element: 93 StructureType noalg.struct { key string; elem int }
-    - __kind: StructureType
-      ID: 93
-      Name: noalg.struct { key string; elem int }
-      ByteSize: 24
-      GoRuntimeType: 1.278912e+06
-      GoKind: 25
-      RawFields:
-        - Name: key
-          Offset: 0
-          Type: 8 GoStringHeaderType string
-        - Name: elem
-          Offset: 16
-          Type: 1 BaseType int
-    - __kind: GoMapType
-      ID: 94
-      Name: map[string][]string
-      ByteSize: 8
-      GoRuntimeType: 1.118336e+06
-      GoKind: 21
-      HeaderType: 96 GoSwissMapHeaderType map<string,[]string>
-    - __kind: PointerType
-      ID: 95
-      Name: '*map<string,[]string>'
-      ByteSize: 8
-      Pointee: 96 GoSwissMapHeaderType map<string,[]string>
-    - __kind: GoSwissMapHeaderType
-      ID: 96
-      Name: map<string,[]string>
-      ByteSize: 48
-      GoKind: 25
-      RawFields:
-        - Name: used
-          Offset: 0
-          Type: 26 BaseType uint64
-        - Name: seed
-          Offset: 8
-          Type: 62 BaseType uintptr
-        - Name: dirPtr
-          Offset: 16
-          Type: 97 PointerType **table<string,[]string>
-        - Name: dirLen
-          Offset: 24
-          Type: 1 BaseType int
-        - Name: globalDepth
-          Offset: 32
-          Type: 4 BaseType uint8
-        - Name: globalShift
-          Offset: 33
-          Type: 4 BaseType uint8
-        - Name: writing
-          Offset: 34
-          Type: 4 BaseType uint8
-        - Name: clearSeq
-          Offset: 40
-          Type: 26 BaseType uint64
-      TablePtrSliceType: 248 GoSliceDataType []*table<string,[]string>.array
-      GroupType: 102 StructureType noalg.map.group[string][]string
-    - __kind: PointerType
-      ID: 97
-      Name: '**table<string,[]string>'
-      ByteSize: 8
-      Pointee: 98 PointerType *table<string,[]string>
-    - __kind: PointerType
-      ID: 98
-      Name: '*table<string,[]string>'
-      ByteSize: 8
-      Pointee: 99 StructureType table<string,[]string>
-    - __kind: StructureType
-      ID: 99
-      Name: table<string,[]string>
-      ByteSize: 32
-      GoKind: 25
-      RawFields:
-        - Name: used
-          Offset: 0
-          Type: 22 BaseType uint16
-        - Name: capacity
-          Offset: 2
-          Type: 22 BaseType uint16
-        - Name: growthLeft
-          Offset: 4
-          Type: 22 BaseType uint16
-        - Name: localDepth
-          Offset: 6
-          Type: 4 BaseType uint8
-        - Name: index
-          Offset: 8
-          Type: 1 BaseType int
-        - Name: groups
-          Offset: 16
-          Type: 100 GoSwissMapGroupsType groupReference<string,[]string>
-    - __kind: GoSwissMapGroupsType
-      ID: 100
-      Name: groupReference<string,[]string>
-      ByteSize: 16
-      GoKind: 25
-      RawFields:
-        - Name: data
-          Offset: 0
-          Type: 101 PointerType *noalg.map.group[string][]string
-        - Name: lengthMask
-          Offset: 8
-          Type: 26 BaseType uint64
-      GroupType: 102 StructureType noalg.map.group[string][]string
-      GroupSliceType: 249 GoSliceDataType []noalg.map.group[string][]string.array
-    - __kind: PointerType
-      ID: 101
-      Name: '*noalg.map.group[string][]string'
-      ByteSize: 8
-      Pointee: 102 StructureType noalg.map.group[string][]string
-    - __kind: StructureType
-      ID: 102
-      Name: noalg.map.group[string][]string
-      ByteSize: 328
-      GoRuntimeType: 1.278784e+06
-      GoKind: 25
-      RawFields:
-        - Name: ctrl
-          Offset: 0
-          Type: 26 BaseType uint64
-        - Name: slots
-          Offset: 8
-          Type: 103 ArrayType noalg.[8]struct { key string; elem []string }
-    - __kind: ArrayType
-      ID: 103
-      Name: noalg.[8]struct { key string; elem []string }
-      ByteSize: 320
-      GoRuntimeType: 673760
-      GoKind: 17
-      Count: 8
-      HasCount: true
-      Element: 104 StructureType noalg.struct { key string; elem []string }
-    - __kind: StructureType
-      ID: 104
-      Name: noalg.struct { key string; elem []string }
-      ByteSize: 40
-      GoRuntimeType: 1.278656e+06
-      GoKind: 25
-      RawFields:
-        - Name: key
-          Offset: 0
-          Type: 8 GoStringHeaderType string
-        - Name: elem
-          Offset: 16
-          Type: 105 GoSliceHeaderType []string
-    - __kind: GoSliceHeaderType
-      ID: 105
-      Name: '[]string'
-      ByteSize: 24
-      GoRuntimeType: 478656
-      GoKind: 23
-      RawFields:
-        - Name: array
-          Offset: 0
-          Type: 36 PointerType *string
-        - Name: len
-          Offset: 8
-          Type: 1 BaseType int
-        - Name: cap
-          Offset: 16
-          Type: 1 BaseType int
-      Data: 250 GoSliceDataType []string.array
-    - __kind: GoMapType
-      ID: 106
-      Name: map[[4]string][2]int
-      ByteSize: 8
-      GoRuntimeType: 1.117824e+06
-      GoKind: 21
-      HeaderType: 108 GoSwissMapHeaderType map<[4]string,[2]int>
-    - __kind: PointerType
-      ID: 107
-      Name: '*map<[4]string,[2]int>'
-      ByteSize: 8
-      Pointee: 108 GoSwissMapHeaderType map<[4]string,[2]int>
-    - __kind: GoSwissMapHeaderType
-      ID: 108
-      Name: map<[4]string,[2]int>
-      ByteSize: 48
-      GoKind: 25
-      RawFields:
-        - Name: used
-          Offset: 0
-          Type: 26 BaseType uint64
-        - Name: seed
-          Offset: 8
-          Type: 62 BaseType uintptr
-        - Name: dirPtr
-          Offset: 16
-          Type: 109 PointerType **table<[4]string,[2]int>
-        - Name: dirLen
-          Offset: 24
-          Type: 1 BaseType int
-        - Name: globalDepth
-          Offset: 32
-          Type: 4 BaseType uint8
-        - Name: globalShift
-          Offset: 33
-          Type: 4 BaseType uint8
-        - Name: writing
-          Offset: 34
-          Type: 4 BaseType uint8
-        - Name: clearSeq
-          Offset: 40
-          Type: 26 BaseType uint64
-      TablePtrSliceType: 252 GoSliceDataType []*table<[4]string,[2]int>.array
-      GroupType: 114 StructureType noalg.map.group[[4]string][2]int
-    - __kind: PointerType
-      ID: 109
-      Name: '**table<[4]string,[2]int>'
-      ByteSize: 8
-      Pointee: 110 PointerType *table<[4]string,[2]int>
-    - __kind: PointerType
-      ID: 110
-      Name: '*table<[4]string,[2]int>'
-      ByteSize: 8
-      Pointee: 111 StructureType table<[4]string,[2]int>
-    - __kind: StructureType
-      ID: 111
-      Name: table<[4]string,[2]int>
-      ByteSize: 32
-      GoKind: 25
-      RawFields:
-        - Name: used
-          Offset: 0
-          Type: 22 BaseType uint16
-        - Name: capacity
-          Offset: 2
-          Type: 22 BaseType uint16
-        - Name: growthLeft
-          Offset: 4
-          Type: 22 BaseType uint16
-        - Name: localDepth
-          Offset: 6
-          Type: 4 BaseType uint8
-        - Name: index
-          Offset: 8
-          Type: 1 BaseType int
-        - Name: groups
-          Offset: 16
-          Type: 112 GoSwissMapGroupsType groupReference<[4]string,[2]int>
-    - __kind: GoSwissMapGroupsType
-      ID: 112
-      Name: groupReference<[4]string,[2]int>
-      ByteSize: 16
-      GoKind: 25
-      RawFields:
-        - Name: data
-          Offset: 0
-          Type: 113 PointerType *noalg.map.group[[4]string][2]int
-        - Name: lengthMask
-          Offset: 8
-          Type: 26 BaseType uint64
-      GroupType: 114 StructureType noalg.map.group[[4]string][2]int
-      GroupSliceType: 253 GoSliceDataType []noalg.map.group[[4]string][2]int.array
-    - __kind: PointerType
-      ID: 113
-      Name: '*noalg.map.group[[4]string][2]int'
-      ByteSize: 8
-      Pointee: 114 StructureType noalg.map.group[[4]string][2]int
-    - __kind: StructureType
-      ID: 114
-      Name: noalg.map.group[[4]string][2]int
-      ByteSize: 648
-      GoRuntimeType: 1.27776e+06
-      GoKind: 25
-      RawFields:
-        - Name: ctrl
-          Offset: 0
-          Type: 26 BaseType uint64
-        - Name: slots
-          Offset: 8
-          Type: 115 ArrayType noalg.[8]struct { key [4]string; elem [2]int }
-    - __kind: ArrayType
-      ID: 115
-      Name: noalg.[8]struct { key [4]string; elem [2]int }
-      ByteSize: 640
-      GoRuntimeType: 673376
-      GoKind: 17
-      Count: 8
-      HasCount: true
-      Element: 116 StructureType noalg.struct { key [4]string; elem [2]int }
-    - __kind: StructureType
-      ID: 116
-      Name: noalg.struct { key [4]string; elem [2]int }
-      ByteSize: 80
-      GoRuntimeType: 1.277632e+06
-      GoKind: 25
-      RawFields:
-        - Name: key
-          Offset: 0
-          Type: 117 ArrayType [4]string
-        - Name: elem
-          Offset: 64
-          Type: 12 ArrayType [2]int
-    - __kind: ArrayType
-      ID: 117
-      Name: '[4]string'
-      ByteSize: 64
-      GoRuntimeType: 673184
-      GoKind: 17
-      Count: 4
-      HasCount: true
-      Element: 8 GoStringHeaderType string
-    - __kind: ArrayType
-      ID: 118
-      Name: '[2]map[string]int'
-      ByteSize: 16
-      GoKind: 17
-      Count: 2
-      HasCount: true
-      Element: 83 GoMapType map[string]int
-    - __kind: PointerType
-      ID: 119
-      Name: '*map[string]int'
-      ByteSize: 8
-      GoKind: 22
-      Pointee: 83 GoMapType map[string]int
-    - __kind: GoMapType
-      ID: 120
-      Name: map[string][]main.structWithMap
-      ByteSize: 8
-      GoRuntimeType: 1.118208e+06
-      GoKind: 21
-      HeaderType: 122 GoSwissMapHeaderType map<string,[]main.structWithMap>
-    - __kind: PointerType
-      ID: 121
-      Name: '*map<string,[]main.structWithMap>'
-      ByteSize: 8
-      Pointee: 122 GoSwissMapHeaderType map<string,[]main.structWithMap>
-    - __kind: GoSwissMapHeaderType
-      ID: 122
-      Name: map<string,[]main.structWithMap>
-      ByteSize: 48
-      GoKind: 25
-      RawFields:
-        - Name: used
-          Offset: 0
-          Type: 26 BaseType uint64
-        - Name: seed
-          Offset: 8
-          Type: 62 BaseType uintptr
-        - Name: dirPtr
-          Offset: 16
-          Type: 123 PointerType **table<string,[]main.structWithMap>
-        - Name: dirLen
-          Offset: 24
-          Type: 1 BaseType int
-        - Name: globalDepth
-          Offset: 32
-          Type: 4 BaseType uint8
-        - Name: globalShift
-          Offset: 33
-          Type: 4 BaseType uint8
-        - Name: writing
-          Offset: 34
-          Type: 4 BaseType uint8
-        - Name: clearSeq
-          Offset: 40
-          Type: 26 BaseType uint64
-      TablePtrSliceType: 254 GoSliceDataType []*table<string,[]main.structWithMap>.array
-      GroupType: 128 StructureType noalg.map.group[string][]main.structWithMap
-    - __kind: PointerType
-      ID: 123
-      Name: '**table<string,[]main.structWithMap>'
-      ByteSize: 8
-      Pointee: 124 PointerType *table<string,[]main.structWithMap>
-    - __kind: PointerType
-      ID: 124
-      Name: '*table<string,[]main.structWithMap>'
-      ByteSize: 8
-      Pointee: 125 StructureType table<string,[]main.structWithMap>
-    - __kind: StructureType
-      ID: 125
-      Name: table<string,[]main.structWithMap>
-      ByteSize: 32
-      GoKind: 25
-      RawFields:
-        - Name: used
-          Offset: 0
-          Type: 22 BaseType uint16
-        - Name: capacity
-          Offset: 2
-          Type: 22 BaseType uint16
-        - Name: growthLeft
-          Offset: 4
-          Type: 22 BaseType uint16
-        - Name: localDepth
-          Offset: 6
-          Type: 4 BaseType uint8
-        - Name: index
-          Offset: 8
-          Type: 1 BaseType int
-        - Name: groups
-          Offset: 16
-          Type: 126 GoSwissMapGroupsType groupReference<string,[]main.structWithMap>
-    - __kind: GoSwissMapGroupsType
-      ID: 126
-      Name: groupReference<string,[]main.structWithMap>
-      ByteSize: 16
-      GoKind: 25
-      RawFields:
-        - Name: data
-          Offset: 0
-          Type: 127 PointerType *noalg.map.group[string][]main.structWithMap
-        - Name: lengthMask
-          Offset: 8
-          Type: 26 BaseType uint64
-      GroupType: 128 StructureType noalg.map.group[string][]main.structWithMap
-      GroupSliceType: 255 GoSliceDataType []noalg.map.group[string][]main.structWithMap.array
-    - __kind: PointerType
-      ID: 127
-      Name: '*noalg.map.group[string][]main.structWithMap'
-      ByteSize: 8
-      Pointee: 128 StructureType noalg.map.group[string][]main.structWithMap
-    - __kind: StructureType
-      ID: 128
-      Name: noalg.map.group[string][]main.structWithMap
-      ByteSize: 328
-      GoRuntimeType: 1.278528e+06
-      GoKind: 25
-      RawFields:
-        - Name: ctrl
-          Offset: 0
-          Type: 26 BaseType uint64
-        - Name: slots
-          Offset: 8
-          Type: 129 ArrayType noalg.[8]struct { key string; elem []main.structWithMap }
-    - __kind: ArrayType
-      ID: 129
-      Name: noalg.[8]struct { key string; elem []main.structWithMap }
-      ByteSize: 320
-      GoRuntimeType: 673664
-      GoKind: 17
-      Count: 8
-      HasCount: true
-      Element: 130 StructureType noalg.struct { key string; elem []main.structWithMap }
-    - __kind: StructureType
-      ID: 130
-      Name: noalg.struct { key string; elem []main.structWithMap }
-      ByteSize: 40
-      GoRuntimeType: 1.2784e+06
-      GoKind: 25
-      RawFields:
-        - Name: key
-          Offset: 0
-          Type: 8 GoStringHeaderType string
-        - Name: elem
-          Offset: 16
-          Type: 131 GoSliceHeaderType []main.structWithMap
-    - __kind: GoSliceHeaderType
-      ID: 131
-      Name: '[]main.structWithMap'
-      ByteSize: 24
-      GoRuntimeType: 469888
-      GoKind: 23
-      RawFields:
-        - Name: array
-          Offset: 0
-          Type: 132 PointerType *main.structWithMap
-        - Name: len
-          Offset: 8
-          Type: 1 BaseType int
-        - Name: cap
-          Offset: 16
-          Type: 1 BaseType int
-      Data: 256 GoSliceDataType []main.structWithMap.array
-    - __kind: PointerType
-      ID: 132
-      Name: '*main.structWithMap'
-      ByteSize: 8
-      GoRuntimeType: 380160
-      GoKind: 22
-      Pointee: 58 StructureType main.structWithMap
-    - __kind: GoMapType
-      ID: 133
-      Name: map[bool]main.node
-      ByteSize: 8
-      GoRuntimeType: 1.117952e+06
-      GoKind: 21
-      HeaderType: 135 GoSwissMapHeaderType map<bool,main.node>
-    - __kind: PointerType
-      ID: 134
-      Name: '*map<bool,main.node>'
-      ByteSize: 8
-      Pointee: 135 GoSwissMapHeaderType map<bool,main.node>
-    - __kind: GoSwissMapHeaderType
-      ID: 135
-      Name: map<bool,main.node>
-      ByteSize: 48
-      GoKind: 25
-      RawFields:
-        - Name: used
-          Offset: 0
-          Type: 26 BaseType uint64
-        - Name: seed
-          Offset: 8
-          Type: 62 BaseType uintptr
-        - Name: dirPtr
-          Offset: 16
-          Type: 136 PointerType **table<bool,main.node>
-        - Name: dirLen
-          Offset: 24
-          Type: 1 BaseType int
-        - Name: globalDepth
-          Offset: 32
-          Type: 4 BaseType uint8
-        - Name: globalShift
-          Offset: 33
-          Type: 4 BaseType uint8
-        - Name: writing
-          Offset: 34
-          Type: 4 BaseType uint8
-        - Name: clearSeq
-          Offset: 40
-          Type: 26 BaseType uint64
-      TablePtrSliceType: 258 GoSliceDataType []*table<bool,main.node>.array
-      GroupType: 141 StructureType noalg.map.group[bool]main.node
-    - __kind: PointerType
-      ID: 136
-      Name: '**table<bool,main.node>'
-      ByteSize: 8
-      Pointee: 137 PointerType *table<bool,main.node>
-    - __kind: PointerType
-      ID: 137
-      Name: '*table<bool,main.node>'
-      ByteSize: 8
-      Pointee: 138 StructureType table<bool,main.node>
-    - __kind: StructureType
-      ID: 138
-      Name: table<bool,main.node>
-      ByteSize: 32
-      GoKind: 25
-      RawFields:
-        - Name: used
-          Offset: 0
-          Type: 22 BaseType uint16
-        - Name: capacity
-          Offset: 2
-          Type: 22 BaseType uint16
-        - Name: growthLeft
-          Offset: 4
-          Type: 22 BaseType uint16
-        - Name: localDepth
-          Offset: 6
-          Type: 4 BaseType uint8
-        - Name: index
-          Offset: 8
-          Type: 1 BaseType int
-        - Name: groups
-          Offset: 16
-          Type: 139 GoSwissMapGroupsType groupReference<bool,main.node>
-    - __kind: GoSwissMapGroupsType
-      ID: 139
-      Name: groupReference<bool,main.node>
-      ByteSize: 16
-      GoKind: 25
-      RawFields:
-        - Name: data
-          Offset: 0
-          Type: 140 PointerType *noalg.map.group[bool]main.node
-        - Name: lengthMask
-          Offset: 8
-          Type: 26 BaseType uint64
-      GroupType: 141 StructureType noalg.map.group[bool]main.node
-      GroupSliceType: 259 GoSliceDataType []noalg.map.group[bool]main.node.array
-    - __kind: PointerType
-      ID: 140
-      Name: '*noalg.map.group[bool]main.node'
-      ByteSize: 8
-      Pointee: 141 StructureType noalg.map.group[bool]main.node
-    - __kind: StructureType
-      ID: 141
-      Name: noalg.map.group[bool]main.node
-      ByteSize: 200
-      GoRuntimeType: 1.278016e+06
-      GoKind: 25
-      RawFields:
-        - Name: ctrl
-          Offset: 0
-          Type: 26 BaseType uint64
-        - Name: slots
-          Offset: 8
-          Type: 142 ArrayType noalg.[8]struct { key bool; elem main.node }
-    - __kind: ArrayType
-      ID: 142
-      Name: noalg.[8]struct { key bool; elem main.node }
-      ByteSize: 192
-      GoRuntimeType: 673472
-      GoKind: 17
-      Count: 8
-      HasCount: true
-      Element: 143 StructureType noalg.struct { key bool; elem main.node }
-    - __kind: StructureType
-      ID: 143
-      Name: noalg.struct { key bool; elem main.node }
-      ByteSize: 24
-      GoRuntimeType: 1.277888e+06
-      GoKind: 25
-      RawFields:
-        - Name: key
-          Offset: 0
-          Type: 11 BaseType bool
-        - Name: elem
-          Offset: 8
-          Type: 144 StructureType main.node
-    - __kind: StructureType
-      ID: 144
-      Name: main.node
-      ByteSize: 16
-      GoRuntimeType: 1.443904e+06
-      GoKind: 25
-      RawFields:
-        - Name: val
-          Offset: 0
-          Type: 1 BaseType int
-        - Name: b
-          Offset: 8
-          Type: 145 PointerType *main.node
-    - __kind: PointerType
-      ID: 145
-      Name: '*main.node'
-      ByteSize: 8
-      GoRuntimeType: 380288
-      GoKind: 22
-      Pointee: 144 StructureType main.node
-    - __kind: GoMapType
-      ID: 146
-      Name: map[int]uint8
-      ByteSize: 8
-      GoRuntimeType: 1.11808e+06
-      GoKind: 21
-      HeaderType: 148 GoSwissMapHeaderType map<int,uint8>
-    - __kind: PointerType
-      ID: 147
-      Name: '*map<int,uint8>'
-      ByteSize: 8
-      Pointee: 148 GoSwissMapHeaderType map<int,uint8>
-    - __kind: GoSwissMapHeaderType
-      ID: 148
-      Name: map<int,uint8>
-      ByteSize: 48
-      GoKind: 25
-      RawFields:
-        - Name: used
-          Offset: 0
-          Type: 26 BaseType uint64
-        - Name: seed
-          Offset: 8
-          Type: 62 BaseType uintptr
-        - Name: dirPtr
-          Offset: 16
-          Type: 149 PointerType **table<int,uint8>
-        - Name: dirLen
-          Offset: 24
-          Type: 1 BaseType int
-        - Name: globalDepth
-          Offset: 32
-          Type: 4 BaseType uint8
-        - Name: globalShift
-          Offset: 33
-          Type: 4 BaseType uint8
-        - Name: writing
-          Offset: 34
-          Type: 4 BaseType uint8
-        - Name: clearSeq
-          Offset: 40
-          Type: 26 BaseType uint64
-      TablePtrSliceType: 260 GoSliceDataType []*table<int,uint8>.array
-      GroupType: 154 StructureType noalg.map.group[int]uint8
-    - __kind: PointerType
-      ID: 149
-      Name: '**table<int,uint8>'
-      ByteSize: 8
-      Pointee: 150 PointerType *table<int,uint8>
-    - __kind: PointerType
-      ID: 150
-      Name: '*table<int,uint8>'
-      ByteSize: 8
-      Pointee: 151 StructureType table<int,uint8>
-    - __kind: StructureType
-      ID: 151
-      Name: table<int,uint8>
-      ByteSize: 32
-      GoKind: 25
-      RawFields:
-        - Name: used
-          Offset: 0
-          Type: 22 BaseType uint16
-        - Name: capacity
-          Offset: 2
-          Type: 22 BaseType uint16
-        - Name: growthLeft
-          Offset: 4
-          Type: 22 BaseType uint16
-        - Name: localDepth
-          Offset: 6
-          Type: 4 BaseType uint8
-        - Name: index
-          Offset: 8
-          Type: 1 BaseType int
-        - Name: groups
-          Offset: 16
-          Type: 152 GoSwissMapGroupsType groupReference<int,uint8>
-    - __kind: GoSwissMapGroupsType
-      ID: 152
-      Name: groupReference<int,uint8>
-      ByteSize: 16
-      GoKind: 25
-      RawFields:
-        - Name: data
-          Offset: 0
-          Type: 153 PointerType *noalg.map.group[int]uint8
-        - Name: lengthMask
-          Offset: 8
-          Type: 26 BaseType uint64
-      GroupType: 154 StructureType noalg.map.group[int]uint8
-      GroupSliceType: 261 GoSliceDataType []noalg.map.group[int]uint8.array
-    - __kind: PointerType
-      ID: 153
-      Name: '*noalg.map.group[int]uint8'
-      ByteSize: 8
-      Pointee: 154 StructureType noalg.map.group[int]uint8
-    - __kind: StructureType
-      ID: 154
-      Name: noalg.map.group[int]uint8
-      ByteSize: 136
-      GoRuntimeType: 1.278272e+06
-      GoKind: 25
-      RawFields:
-        - Name: ctrl
-          Offset: 0
-          Type: 26 BaseType uint64
-        - Name: slots
-          Offset: 8
-          Type: 155 ArrayType noalg.[8]struct { key int; elem uint8 }
-    - __kind: ArrayType
-      ID: 155
-      Name: noalg.[8]struct { key int; elem uint8 }
-      ByteSize: 128
-      GoRuntimeType: 673568
-      GoKind: 17
-      Count: 8
-      HasCount: true
-      Element: 156 StructureType noalg.struct { key int; elem uint8 }
-    - __kind: StructureType
-      ID: 156
-      Name: noalg.struct { key int; elem uint8 }
-      ByteSize: 16
-      GoRuntimeType: 1.278144e+06
-      GoKind: 25
-      RawFields:
-        - Name: key
-          Offset: 0
-          Type: 1 BaseType int
-        - Name: elem
-          Offset: 8
-          Type: 4 BaseType uint8
-    - __kind: GoMapType
-      ID: 157
-      Name: map[uint8]uint8
-      ByteSize: 8
-      GoRuntimeType: 1.118848e+06
-      GoKind: 21
-      HeaderType: 159 GoSwissMapHeaderType map<uint8,uint8>
-    - __kind: PointerType
-      ID: 158
-      Name: '*map<uint8,uint8>'
-      ByteSize: 8
-      Pointee: 159 GoSwissMapHeaderType map<uint8,uint8>
-    - __kind: GoSwissMapHeaderType
-      ID: 159
-      Name: map<uint8,uint8>
-      ByteSize: 48
-      GoKind: 25
-      RawFields:
-        - Name: used
-          Offset: 0
-          Type: 26 BaseType uint64
-        - Name: seed
-          Offset: 8
-          Type: 62 BaseType uintptr
-        - Name: dirPtr
-          Offset: 16
-          Type: 160 PointerType **table<uint8,uint8>
-        - Name: dirLen
-          Offset: 24
-          Type: 1 BaseType int
-        - Name: globalDepth
-          Offset: 32
-          Type: 4 BaseType uint8
-        - Name: globalShift
-          Offset: 33
-          Type: 4 BaseType uint8
-        - Name: writing
-          Offset: 34
-          Type: 4 BaseType uint8
-        - Name: clearSeq
-          Offset: 40
-          Type: 26 BaseType uint64
-      TablePtrSliceType: 262 GoSliceDataType []*table<uint8,uint8>.array
-      GroupType: 165 StructureType noalg.map.group[uint8]uint8
-    - __kind: PointerType
-      ID: 160
-      Name: '**table<uint8,uint8>'
-      ByteSize: 8
-      Pointee: 161 PointerType *table<uint8,uint8>
-    - __kind: PointerType
-      ID: 161
-      Name: '*table<uint8,uint8>'
-      ByteSize: 8
-      Pointee: 162 StructureType table<uint8,uint8>
-    - __kind: StructureType
-      ID: 162
-      Name: table<uint8,uint8>
-      ByteSize: 32
-      GoKind: 25
-      RawFields:
-        - Name: used
-          Offset: 0
-          Type: 22 BaseType uint16
-        - Name: capacity
-          Offset: 2
-          Type: 22 BaseType uint16
-        - Name: growthLeft
-          Offset: 4
-          Type: 22 BaseType uint16
-        - Name: localDepth
-          Offset: 6
-          Type: 4 BaseType uint8
-        - Name: index
-          Offset: 8
-          Type: 1 BaseType int
-        - Name: groups
-          Offset: 16
-          Type: 163 GoSwissMapGroupsType groupReference<uint8,uint8>
-    - __kind: GoSwissMapGroupsType
-      ID: 163
-      Name: groupReference<uint8,uint8>
-      ByteSize: 16
-      GoKind: 25
-      RawFields:
-        - Name: data
-          Offset: 0
-          Type: 164 PointerType *noalg.map.group[uint8]uint8
-        - Name: lengthMask
-          Offset: 8
-          Type: 26 BaseType uint64
-      GroupType: 165 StructureType noalg.map.group[uint8]uint8
-      GroupSliceType: 263 GoSliceDataType []noalg.map.group[uint8]uint8.array
-    - __kind: PointerType
-      ID: 164
-      Name: '*noalg.map.group[uint8]uint8'
-      ByteSize: 8
-      Pointee: 165 StructureType noalg.map.group[uint8]uint8
-    - __kind: StructureType
-      ID: 165
-      Name: noalg.map.group[uint8]uint8
-      ByteSize: 24
-      GoRuntimeType: 1.279808e+06
-      GoKind: 25
-      RawFields:
-        - Name: ctrl
-          Offset: 0
-          Type: 26 BaseType uint64
-        - Name: slots
-          Offset: 8
-          Type: 166 ArrayType noalg.[8]struct { key uint8; elem uint8 }
-    - __kind: ArrayType
-      ID: 166
-      Name: noalg.[8]struct { key uint8; elem uint8 }
-      ByteSize: 16
-      GoRuntimeType: 674144
-      GoKind: 17
-      Count: 8
-      HasCount: true
-      Element: 167 StructureType noalg.struct { key uint8; elem uint8 }
-    - __kind: StructureType
-      ID: 167
-      Name: noalg.struct { key uint8; elem uint8 }
-      ByteSize: 2
-      GoRuntimeType: 1.27968e+06
-      GoKind: 25
-      RawFields:
-        - Name: key
-          Offset: 0
-          Type: 4 BaseType uint8
-        - Name: elem
-          Offset: 1
-          Type: 4 BaseType uint8
-    - __kind: GoMapType
-      ID: 168
-      Name: map[uint8][4]int
-      ByteSize: 8
-      GoRuntimeType: 1.11872e+06
-      GoKind: 21
-      HeaderType: 170 GoSwissMapHeaderType map<uint8,[4]int>
-    - __kind: PointerType
-      ID: 169
-      Name: '*map<uint8,[4]int>'
-      ByteSize: 8
-      Pointee: 170 GoSwissMapHeaderType map<uint8,[4]int>
-    - __kind: GoSwissMapHeaderType
-      ID: 170
-      Name: map<uint8,[4]int>
-      ByteSize: 48
-      GoKind: 25
-      RawFields:
-        - Name: used
-          Offset: 0
-          Type: 26 BaseType uint64
-        - Name: seed
-          Offset: 8
-          Type: 62 BaseType uintptr
-        - Name: dirPtr
-          Offset: 16
-          Type: 171 PointerType **table<uint8,[4]int>
-        - Name: dirLen
-          Offset: 24
-          Type: 1 BaseType int
-        - Name: globalDepth
-          Offset: 32
-          Type: 4 BaseType uint8
-        - Name: globalShift
-          Offset: 33
-          Type: 4 BaseType uint8
-        - Name: writing
-          Offset: 34
-          Type: 4 BaseType uint8
-        - Name: clearSeq
-          Offset: 40
-          Type: 26 BaseType uint64
-      TablePtrSliceType: 264 GoSliceDataType []*table<uint8,[4]int>.array
-      GroupType: 176 StructureType noalg.map.group[uint8][4]int
-    - __kind: PointerType
-      ID: 171
-      Name: '**table<uint8,[4]int>'
-      ByteSize: 8
-      Pointee: 172 PointerType *table<uint8,[4]int>
-    - __kind: PointerType
-      ID: 172
-      Name: '*table<uint8,[4]int>'
-      ByteSize: 8
-      Pointee: 173 StructureType table<uint8,[4]int>
-    - __kind: StructureType
-      ID: 173
-      Name: table<uint8,[4]int>
-      ByteSize: 32
-      GoKind: 25
-      RawFields:
-        - Name: used
-          Offset: 0
-          Type: 22 BaseType uint16
-        - Name: capacity
-          Offset: 2
-          Type: 22 BaseType uint16
-        - Name: growthLeft
-          Offset: 4
-          Type: 22 BaseType uint16
-        - Name: localDepth
-          Offset: 6
-          Type: 4 BaseType uint8
-        - Name: index
-          Offset: 8
-          Type: 1 BaseType int
-        - Name: groups
-          Offset: 16
-          Type: 174 GoSwissMapGroupsType groupReference<uint8,[4]int>
-    - __kind: GoSwissMapGroupsType
-      ID: 174
-      Name: groupReference<uint8,[4]int>
-      ByteSize: 16
-      GoKind: 25
-      RawFields:
-        - Name: data
-          Offset: 0
-          Type: 175 PointerType *noalg.map.group[uint8][4]int
-        - Name: lengthMask
-          Offset: 8
-          Type: 26 BaseType uint64
-      GroupType: 176 StructureType noalg.map.group[uint8][4]int
-      GroupSliceType: 265 GoSliceDataType []noalg.map.group[uint8][4]int.array
-    - __kind: PointerType
-      ID: 175
-      Name: '*noalg.map.group[uint8][4]int'
-      ByteSize: 8
-      Pointee: 176 StructureType noalg.map.group[uint8][4]int
-    - __kind: StructureType
-      ID: 176
-      Name: noalg.map.group[uint8][4]int
-      ByteSize: 328
-      GoRuntimeType: 1.279552e+06
-      GoKind: 25
-      RawFields:
-        - Name: ctrl
-          Offset: 0
-          Type: 26 BaseType uint64
-        - Name: slots
-          Offset: 8
-          Type: 177 ArrayType noalg.[8]struct { key uint8; elem [4]int }
-    - __kind: ArrayType
-      ID: 177
-      Name: noalg.[8]struct { key uint8; elem [4]int }
-      ByteSize: 320
-      GoRuntimeType: 674048
-      GoKind: 17
-      Count: 8
-      HasCount: true
-      Element: 178 StructureType noalg.struct { key uint8; elem [4]int }
-    - __kind: StructureType
-      ID: 178
-      Name: noalg.struct { key uint8; elem [4]int }
-      ByteSize: 40
-      GoRuntimeType: 1.279424e+06
-      GoKind: 25
-      RawFields:
-        - Name: key
-          Offset: 0
-          Type: 4 BaseType uint8
-        - Name: elem
-          Offset: 8
-          Type: 179 ArrayType [4]int
-    - __kind: ArrayType
-      ID: 179
-      Name: '[4]int'
-      ByteSize: 32
-      GoRuntimeType: 672896
-      GoKind: 17
-      Count: 4
-      HasCount: true
-      Element: 1 BaseType int
-    - __kind: GoMapType
-      ID: 180
-      Name: map[[4]int]uint8
-      ByteSize: 8
-      GoRuntimeType: 1.117696e+06
-      GoKind: 21
-      HeaderType: 182 GoSwissMapHeaderType map<[4]int,uint8>
-    - __kind: PointerType
-      ID: 181
-      Name: '*map<[4]int,uint8>'
-      ByteSize: 8
-      Pointee: 182 GoSwissMapHeaderType map<[4]int,uint8>
-    - __kind: GoSwissMapHeaderType
-      ID: 182
-      Name: map<[4]int,uint8>
-      ByteSize: 48
-      GoKind: 25
-      RawFields:
-        - Name: used
-          Offset: 0
-          Type: 26 BaseType uint64
-        - Name: seed
-          Offset: 8
-          Type: 62 BaseType uintptr
-        - Name: dirPtr
-          Offset: 16
-          Type: 183 PointerType **table<[4]int,uint8>
-        - Name: dirLen
-          Offset: 24
-          Type: 1 BaseType int
-        - Name: globalDepth
-          Offset: 32
-          Type: 4 BaseType uint8
-        - Name: globalShift
-          Offset: 33
-          Type: 4 BaseType uint8
-        - Name: writing
-          Offset: 34
-          Type: 4 BaseType uint8
-        - Name: clearSeq
-          Offset: 40
-          Type: 26 BaseType uint64
-      TablePtrSliceType: 266 GoSliceDataType []*table<[4]int,uint8>.array
-      GroupType: 188 StructureType noalg.map.group[[4]int]uint8
+      Pointee: 195 PointerType *table<[4]int,[4]int>
     - __kind: PointerType
       ID: 183
       Name: '**table<[4]int,uint8>'
       ByteSize: 8
       Pointee: 184 PointerType *table<[4]int,uint8>
     - __kind: PointerType
-      ID: 184
-      Name: '*table<[4]int,uint8>'
+      ID: 109
+      Name: '**table<[4]string,[2]int>'
       ByteSize: 8
-      Pointee: 185 StructureType table<[4]int,uint8>
-    - __kind: StructureType
-      ID: 185
-      Name: table<[4]int,uint8>
-      ByteSize: 32
-      GoKind: 25
-      RawFields:
-        - Name: used
-          Offset: 0
-          Type: 22 BaseType uint16
-        - Name: capacity
-          Offset: 2
-          Type: 22 BaseType uint16
-        - Name: growthLeft
-          Offset: 4
-          Type: 22 BaseType uint16
-        - Name: localDepth
-          Offset: 6
-          Type: 4 BaseType uint8
-        - Name: index
-          Offset: 8
-          Type: 1 BaseType int
-        - Name: groups
-          Offset: 16
-          Type: 186 GoSwissMapGroupsType groupReference<[4]int,uint8>
-    - __kind: GoSwissMapGroupsType
-      ID: 186
-      Name: groupReference<[4]int,uint8>
-      ByteSize: 16
-      GoKind: 25
-      RawFields:
-        - Name: data
-          Offset: 0
-          Type: 187 PointerType *noalg.map.group[[4]int]uint8
-        - Name: lengthMask
-          Offset: 8
-          Type: 26 BaseType uint64
-      GroupType: 188 StructureType noalg.map.group[[4]int]uint8
-      GroupSliceType: 267 GoSliceDataType []noalg.map.group[[4]int]uint8.array
+      Pointee: 110 PointerType *table<[4]string,[2]int>
     - __kind: PointerType
-      ID: 187
-      Name: '*noalg.map.group[[4]int]uint8'
+      ID: 136
+      Name: '**table<bool,main.node>'
       ByteSize: 8
-      Pointee: 188 StructureType noalg.map.group[[4]int]uint8
-    - __kind: StructureType
-      ID: 188
-      Name: noalg.map.group[[4]int]uint8
-      ByteSize: 328
-      GoRuntimeType: 1.277504e+06
-      GoKind: 25
-      RawFields:
-        - Name: ctrl
-          Offset: 0
-          Type: 26 BaseType uint64
-        - Name: slots
-          Offset: 8
-          Type: 189 ArrayType noalg.[8]struct { key [4]int; elem uint8 }
-    - __kind: ArrayType
-      ID: 189
-      Name: noalg.[8]struct { key [4]int; elem uint8 }
-      ByteSize: 320
-      GoRuntimeType: 673088
-      GoKind: 17
-      Count: 8
-      HasCount: true
-      Element: 190 StructureType noalg.struct { key [4]int; elem uint8 }
-    - __kind: StructureType
-      ID: 190
-      Name: noalg.struct { key [4]int; elem uint8 }
-      ByteSize: 40
-      GoRuntimeType: 1.277376e+06
-      GoKind: 25
-      RawFields:
-        - Name: key
-          Offset: 0
-          Type: 179 ArrayType [4]int
-        - Name: elem
-          Offset: 32
-          Type: 4 BaseType uint8
-    - __kind: GoMapType
-      ID: 191
-      Name: map[[4]int][4]int
-      ByteSize: 8
-      GoRuntimeType: 1.117568e+06
-      GoKind: 21
-      HeaderType: 193 GoSwissMapHeaderType map<[4]int,[4]int>
+      Pointee: 137 PointerType *table<bool,main.node>
     - __kind: PointerType
-      ID: 192
-      Name: '*map<[4]int,[4]int>'
+      ID: 63
+      Name: '**table<int,int>'
       ByteSize: 8
-      Pointee: 193 GoSwissMapHeaderType map<[4]int,[4]int>
-    - __kind: GoSwissMapHeaderType
-      ID: 193
-      Name: map<[4]int,[4]int>
-      ByteSize: 48
-      GoKind: 25
-      RawFields:
-        - Name: used
-          Offset: 0
-          Type: 26 BaseType uint64
-        - Name: seed
-          Offset: 8
-          Type: 62 BaseType uintptr
-        - Name: dirPtr
-          Offset: 16
-          Type: 194 PointerType **table<[4]int,[4]int>
-        - Name: dirLen
-          Offset: 24
-          Type: 1 BaseType int
-        - Name: globalDepth
-          Offset: 32
-          Type: 4 BaseType uint8
-        - Name: globalShift
-          Offset: 33
-          Type: 4 BaseType uint8
-        - Name: writing
-          Offset: 34
-          Type: 4 BaseType uint8
-        - Name: clearSeq
-          Offset: 40
-          Type: 26 BaseType uint64
-      TablePtrSliceType: 268 GoSliceDataType []*table<[4]int,[4]int>.array
-      GroupType: 199 StructureType noalg.map.group[[4]int][4]int
+      Pointee: 64 PointerType *table<int,int>
     - __kind: PointerType
-      ID: 194
-      Name: '**table<[4]int,[4]int>'
+      ID: 149
+      Name: '**table<int,uint8>'
       ByteSize: 8
-      Pointee: 195 PointerType *table<[4]int,[4]int>
+      Pointee: 150 PointerType *table<int,uint8>
     - __kind: PointerType
-      ID: 195
-      Name: '*table<[4]int,[4]int>'
+      ID: 123
+      Name: '**table<string,[]main.structWithMap>'
       ByteSize: 8
-      Pointee: 196 StructureType table<[4]int,[4]int>
-    - __kind: StructureType
-      ID: 196
-      Name: table<[4]int,[4]int>
-      ByteSize: 32
-      GoKind: 25
-      RawFields:
-        - Name: used
-          Offset: 0
-          Type: 22 BaseType uint16
-        - Name: capacity
-          Offset: 2
-          Type: 22 BaseType uint16
-        - Name: growthLeft
-          Offset: 4
-          Type: 22 BaseType uint16
-        - Name: localDepth
-          Offset: 6
-          Type: 4 BaseType uint8
-        - Name: index
-          Offset: 8
-          Type: 1 BaseType int
-        - Name: groups
-          Offset: 16
-          Type: 197 GoSwissMapGroupsType groupReference<[4]int,[4]int>
-    - __kind: GoSwissMapGroupsType
-      ID: 197
-      Name: groupReference<[4]int,[4]int>
-      ByteSize: 16
-      GoKind: 25
-      RawFields:
-        - Name: data
-          Offset: 0
-          Type: 198 PointerType *noalg.map.group[[4]int][4]int
-        - Name: lengthMask
-          Offset: 8
-          Type: 26 BaseType uint64
-      GroupType: 199 StructureType noalg.map.group[[4]int][4]int
-      GroupSliceType: 269 GoSliceDataType []noalg.map.group[[4]int][4]int.array
+      Pointee: 124 PointerType *table<string,[]main.structWithMap>
     - __kind: PointerType
-      ID: 198
-      Name: '*noalg.map.group[[4]int][4]int'
+      ID: 97
+      Name: '**table<string,[]string>'
       ByteSize: 8
-      Pointee: 199 StructureType noalg.map.group[[4]int][4]int
-    - __kind: StructureType
-      ID: 199
-      Name: noalg.map.group[[4]int][4]int
-      ByteSize: 520
-      GoRuntimeType: 1.277248e+06
-      GoKind: 25
-      RawFields:
-        - Name: ctrl
-          Offset: 0
-          Type: 26 BaseType uint64
-        - Name: slots
-          Offset: 8
-          Type: 200 ArrayType noalg.[8]struct { key [4]int; elem [4]int }
-    - __kind: ArrayType
-      ID: 200
-      Name: noalg.[8]struct { key [4]int; elem [4]int }
-      ByteSize: 512
-      GoRuntimeType: 672992
-      GoKind: 17
-      Count: 8
-      HasCount: true
-      Element: 201 StructureType noalg.struct { key [4]int; elem [4]int }
-    - __kind: StructureType
-      ID: 201
-      Name: noalg.struct { key [4]int; elem [4]int }
-      ByteSize: 64
-      GoRuntimeType: 1.27712e+06
-      GoKind: 25
-      RawFields:
-        - Name: key
-          Offset: 0
-          Type: 179 ArrayType [4]int
-        - Name: elem
-          Offset: 32
-          Type: 179 ArrayType [4]int
-    - __kind: GoChannelType
-      ID: 202
-      Name: chan bool
-      GoRuntimeType: 587360
-      GoKind: 18
+      Pointee: 98 PointerType *table<string,[]string>
     - __kind: PointerType
-      ID: 203
-      Name: '*main.structWithTwoValues'
+      ID: 86
+      Name: '**table<string,int>'
       ByteSize: 8
-      GoKind: 22
-      Pointee: 204 StructureType main.structWithTwoValues
-    - __kind: StructureType
-      ID: 204
-      Name: main.structWithTwoValues
-      ByteSize: 16
-      GoKind: 25
-      RawFields:
-        - Name: a
-          Offset: 0
-          Type: 20 BaseType uint
-        - Name: b
-          Offset: 8
-          Type: 11 BaseType bool
+      Pointee: 87 PointerType *table<string,int>
     - __kind: PointerType
-      ID: 205
-      Name: '*uint'
+      ID: 74
+      Name: '**table<string,main.nestedStruct>'
       ByteSize: 8
-      GoRuntimeType: 385856
-      GoKind: 22
-      Pointee: 20 BaseType uint
+      Pointee: 75 PointerType *table<string,main.nestedStruct>
+    - __kind: PointerType
+      ID: 171
+      Name: '**table<uint8,[4]int>'
+      ByteSize: 8
+      Pointee: 172 PointerType *table<uint8,[4]int>
+    - __kind: PointerType
+      ID: 160
+      Name: '**table<uint8,uint8>'
+      ByteSize: 8
+      Pointee: 161 PointerType *table<uint8,uint8>
+    - __kind: PointerType
+      ID: 241
+      Name: '*[]*string.array'
+      ByteSize: 8
+      Pointee: 240 GoSliceDataType []*string.array
+    - __kind: PointerType
+      ID: 275
+      Name: '*[][]uint.array'
+      ByteSize: 8
+      Pointee: 274 GoSliceDataType [][]uint.array
+    - __kind: PointerType
+      ID: 279
+      Name: '*[]bool.array'
+      ByteSize: 8
+      Pointee: 278 GoSliceDataType []bool.array
+    - __kind: PointerType
+      ID: 257
+      Name: '*[]main.structWithMap.array'
+      ByteSize: 8
+      Pointee: 256 GoSliceDataType []main.structWithMap.array
+    - __kind: PointerType
+      ID: 277
+      Name: '*[]main.structWithNoStrings.array'
+      ByteSize: 8
+      Pointee: 276 GoSliceDataType []main.structWithNoStrings.array
+    - __kind: PointerType
+      ID: 251
+      Name: '*[]string.array'
+      ByteSize: 8
+      Pointee: 250 GoSliceDataType []string.array
+    - __kind: PointerType
+      ID: 212
+      Name: '*[]uint'
+      ByteSize: 8
+      Pointee: 210 GoSliceHeaderType []uint
+    - __kind: PointerType
+      ID: 273
+      Name: '*[]uint.array'
+      ByteSize: 8
+      Pointee: 272 GoSliceDataType []uint.array
+    - __kind: PointerType
+      ID: 281
+      Name: '*[]uint16.array'
+      ByteSize: 8
+      Pointee: 280 GoSliceDataType []uint16.array
     - __kind: PointerType
       ID: 206
       Name: '*bool'
@@ -5377,279 +3218,6 @@ Types:
       GoRuntimeType: 386240
       GoKind: 22
       Pointee: 11 BaseType bool
-    - __kind: PointerType
-      ID: 207
-      Name: '*main.t'
-      ByteSize: 8
-      GoKind: 22
-      Pointee: 208 GoSliceHeaderType main.t
-    - __kind: GoSliceHeaderType
-      ID: 208
-      Name: main.t
-      ByteSize: 24
-      GoKind: 23
-      RawFields:
-        - Name: array
-          Offset: 0
-          Type: 209 PointerType **main.t
-        - Name: len
-          Offset: 8
-          Type: 1 BaseType int
-        - Name: cap
-          Offset: 16
-          Type: 1 BaseType int
-      Data: 270 GoSliceDataType main.t.array
-    - __kind: PointerType
-      ID: 209
-      Name: '**main.t'
-      ByteSize: 8
-      Pointee: 207 PointerType *main.t
-    - __kind: GoSliceHeaderType
-      ID: 210
-      Name: '[]uint'
-      ByteSize: 24
-      GoRuntimeType: 478144
-      GoKind: 23
-      RawFields:
-        - Name: array
-          Offset: 0
-          Type: 205 PointerType *uint
-        - Name: len
-          Offset: 8
-          Type: 1 BaseType int
-        - Name: cap
-          Offset: 16
-          Type: 1 BaseType int
-      Data: 272 GoSliceDataType []uint.array
-    - __kind: GoSliceHeaderType
-      ID: 211
-      Name: '[][]uint'
-      ByteSize: 24
-      GoKind: 23
-      RawFields:
-        - Name: array
-          Offset: 0
-          Type: 212 PointerType *[]uint
-        - Name: len
-          Offset: 8
-          Type: 1 BaseType int
-        - Name: cap
-          Offset: 16
-          Type: 1 BaseType int
-      Data: 274 GoSliceDataType [][]uint.array
-    - __kind: PointerType
-      ID: 212
-      Name: '*[]uint'
-      ByteSize: 8
-      Pointee: 210 GoSliceHeaderType []uint
-    - __kind: GoSliceHeaderType
-      ID: 213
-      Name: '[]main.structWithNoStrings'
-      ByteSize: 24
-      GoKind: 23
-      RawFields:
-        - Name: array
-          Offset: 0
-          Type: 214 PointerType *main.structWithNoStrings
-        - Name: len
-          Offset: 8
-          Type: 1 BaseType int
-        - Name: cap
-          Offset: 16
-          Type: 1 BaseType int
-      Data: 276 GoSliceDataType []main.structWithNoStrings.array
-    - __kind: PointerType
-      ID: 214
-      Name: '*main.structWithNoStrings'
-      ByteSize: 8
-      Pointee: 215 StructureType main.structWithNoStrings
-    - __kind: StructureType
-      ID: 215
-      Name: main.structWithNoStrings
-      ByteSize: 2
-      GoKind: 25
-      RawFields:
-        - Name: aUint8
-          Offset: 0
-          Type: 4 BaseType uint8
-        - Name: aBool
-          Offset: 1
-          Type: 11 BaseType bool
-    - __kind: GoSliceHeaderType
-      ID: 216
-      Name: '[]bool'
-      ByteSize: 24
-      GoRuntimeType: 478528
-      GoKind: 23
-      RawFields:
-        - Name: array
-          Offset: 0
-          Type: 206 PointerType *bool
-        - Name: len
-          Offset: 8
-          Type: 1 BaseType int
-        - Name: cap
-          Offset: 16
-          Type: 1 BaseType int
-      Data: 278 GoSliceDataType []bool.array
-    - __kind: GoSliceHeaderType
-      ID: 217
-      Name: '[]uint16'
-      ByteSize: 24
-      GoRuntimeType: 477504
-      GoKind: 23
-      RawFields:
-        - Name: array
-          Offset: 0
-          Type: 218 PointerType *uint16
-        - Name: len
-          Offset: 8
-          Type: 1 BaseType int
-        - Name: cap
-          Offset: 16
-          Type: 1 BaseType int
-      Data: 280 GoSliceDataType []uint16.array
-    - __kind: PointerType
-      ID: 218
-      Name: '*uint16'
-      ByteSize: 8
-      GoRuntimeType: 385472
-      GoKind: 22
-      Pointee: 22 BaseType uint16
-    - __kind: StructureType
-      ID: 219
-      Name: main.threeStringStruct
-      ByteSize: 48
-      GoKind: 25
-      RawFields:
-        - Name: a
-          Offset: 0
-          Type: 8 GoStringHeaderType string
-        - Name: b
-          Offset: 16
-          Type: 8 GoStringHeaderType string
-        - Name: c
-          Offset: 32
-          Type: 8 GoStringHeaderType string
-    - __kind: PointerType
-      ID: 220
-      Name: '*main.threeStringStruct'
-      ByteSize: 8
-      GoKind: 22
-      Pointee: 219 StructureType main.threeStringStruct
-    - __kind: PointerType
-      ID: 221
-      Name: '*main.oneStringStruct'
-      ByteSize: 8
-      GoKind: 22
-      Pointee: 222 StructureType main.oneStringStruct
-    - __kind: StructureType
-      ID: 222
-      Name: main.oneStringStruct
-      ByteSize: 16
-      GoKind: 25
-      RawFields:
-        - Name: a
-          Offset: 0
-          Type: 8 GoStringHeaderType string
-    - __kind: StructureType
-      ID: 223
-      Name: main.aStruct
-      ByteSize: 56
-      GoKind: 25
-      RawFields:
-        - Name: aBool
-          Offset: 0
-          Type: 11 BaseType bool
-        - Name: aString
-          Offset: 8
-          Type: 8 GoStringHeaderType string
-        - Name: aNumber
-          Offset: 24
-          Type: 1 BaseType int
-        - Name: nested
-          Offset: 32
-          Type: 82 StructureType main.nestedStruct
-    - __kind: StructureType
-      ID: 224
-      Name: main.emptyStruct
-      GoKind: 25
-      RawFields: []
-    - __kind: PointerType
-      ID: 225
-      Name: '*uintptr'
-      ByteSize: 8
-      GoRuntimeType: 385920
-      GoKind: 22
-      Pointee: 62 BaseType uintptr
-    - __kind: PointerType
-      ID: 226
-      Name: '*int32'
-      ByteSize: 8
-      GoRuntimeType: 385536
-      GoKind: 22
-      Pointee: 6 BaseType int32
-    - __kind: PointerType
-      ID: 227
-      Name: '*uint32'
-      ByteSize: 8
-      GoRuntimeType: 385600
-      GoKind: 22
-      Pointee: 24 BaseType uint32
-    - __kind: BaseType
-      ID: 228
-      Name: complex64
-      ByteSize: 8
-      GoRuntimeType: 575776
-      GoKind: 15
-    - __kind: BaseType
-      ID: 229
-      Name: complex128
-      ByteSize: 16
-      GoRuntimeType: 575840
-      GoKind: 16
-    - __kind: PointerType
-      ID: 230
-      Name: '*float64'
-      ByteSize: 8
-      GoRuntimeType: 386176
-      GoKind: 22
-      Pointee: 31 BaseType float64
-    - __kind: PointerType
-      ID: 231
-      Name: '*int64'
-      ByteSize: 8
-      GoRuntimeType: 385664
-      GoKind: 22
-      Pointee: 18 BaseType int64
-    - __kind: PointerType
-      ID: 232
-      Name: '*int'
-      ByteSize: 8
-      GoRuntimeType: 385792
-      GoKind: 22
-      Pointee: 1 BaseType int
-    - __kind: PointerType
-      ID: 233
-      Name: '*uint64'
-      ByteSize: 8
-      GoRuntimeType: 385728
-      GoKind: 22
-      Pointee: 26 BaseType uint64
-    - __kind: PointerType
-      ID: 234
-      Name: '*int16'
-      ByteSize: 8
-      GoRuntimeType: 385408
-      GoKind: 22
-      Pointee: 16 BaseType int16
-    - __kind: PointerType
-      ID: 235
-      Name: '*int8'
-      ByteSize: 8
-      GoRuntimeType: 385280
-      GoKind: 22
-      Pointee: 14 BaseType int8
     - __kind: PointerType
       ID: 236
       Name: '*error'
@@ -5664,270 +3232,436 @@ Types:
       GoRuntimeType: 386112
       GoKind: 22
       Pointee: 30 BaseType float32
-    - __kind: GoStringDataType
-      ID: 238
-      Name: string.str
-      ByteSize: 2048
     - __kind: PointerType
-      ID: 239
-      Name: '*string.str'
+      ID: 230
+      Name: '*float64'
       ByteSize: 8
-      Pointee: 238 GoStringDataType string.str
-    - __kind: GoSliceDataType
-      ID: 240
-      Name: '[]*string.array'
-      ByteSize: 2048
-      Element: 36 PointerType *string
+      GoRuntimeType: 386176
+      GoKind: 22
+      Pointee: 31 BaseType float64
     - __kind: PointerType
-      ID: 241
-      Name: '*[]*string.array'
+      ID: 232
+      Name: '*int'
       ByteSize: 8
-      Pointee: 240 GoSliceDataType []*string.array
-    - __kind: GoSliceDataType
-      ID: 242
-      Name: '[]*table<int,int>.array'
-      ByteSize: 8192
-      Element: 64 PointerType *table<int,int>
-    - __kind: GoSliceDataType
-      ID: 243
-      Name: '[]noalg.map.group[int]int.array'
-      ByteSize: 2048
-      Element: 68 StructureType noalg.map.group[int]int
-    - __kind: GoSliceDataType
-      ID: 244
-      Name: '[]*table<string,main.nestedStruct>.array'
-      ByteSize: 8192
-      Element: 75 PointerType *table<string,main.nestedStruct>
-    - __kind: GoSliceDataType
-      ID: 245
-      Name: '[]noalg.map.group[string]main.nestedStruct.array'
-      ByteSize: 2048
-      Element: 79 StructureType noalg.map.group[string]main.nestedStruct
-    - __kind: GoSliceDataType
-      ID: 246
-      Name: '[]*table<string,int>.array'
-      ByteSize: 8192
-      Element: 87 PointerType *table<string,int>
-    - __kind: GoSliceDataType
-      ID: 247
-      Name: '[]noalg.map.group[string]int.array'
-      ByteSize: 2048
-      Element: 91 StructureType noalg.map.group[string]int
-    - __kind: GoSliceDataType
-      ID: 248
-      Name: '[]*table<string,[]string>.array'
-      ByteSize: 8192
-      Element: 98 PointerType *table<string,[]string>
-    - __kind: GoSliceDataType
-      ID: 249
-      Name: '[]noalg.map.group[string][]string.array'
-      ByteSize: 2048
-      Element: 102 StructureType noalg.map.group[string][]string
-    - __kind: GoSliceDataType
-      ID: 250
-      Name: '[]string.array'
-      ByteSize: 2048
-      Element: 8 GoStringHeaderType string
+      GoRuntimeType: 385792
+      GoKind: 22
+      Pointee: 1 BaseType int
     - __kind: PointerType
-      ID: 251
-      Name: '*[]string.array'
+      ID: 234
+      Name: '*int16'
       ByteSize: 8
-      Pointee: 250 GoSliceDataType []string.array
-    - __kind: GoSliceDataType
-      ID: 252
-      Name: '[]*table<[4]string,[2]int>.array'
-      ByteSize: 8192
-      Element: 110 PointerType *table<[4]string,[2]int>
-    - __kind: GoSliceDataType
-      ID: 253
-      Name: '[]noalg.map.group[[4]string][2]int.array'
-      ByteSize: 2048
-      Element: 114 StructureType noalg.map.group[[4]string][2]int
-    - __kind: GoSliceDataType
-      ID: 254
-      Name: '[]*table<string,[]main.structWithMap>.array'
-      ByteSize: 8192
-      Element: 124 PointerType *table<string,[]main.structWithMap>
-    - __kind: GoSliceDataType
-      ID: 255
-      Name: '[]noalg.map.group[string][]main.structWithMap.array'
-      ByteSize: 2048
-      Element: 128 StructureType noalg.map.group[string][]main.structWithMap
-    - __kind: GoSliceDataType
-      ID: 256
-      Name: '[]main.structWithMap.array'
-      ByteSize: 2048
-      Element: 58 StructureType main.structWithMap
+      GoRuntimeType: 385408
+      GoKind: 22
+      Pointee: 16 BaseType int16
     - __kind: PointerType
-      ID: 257
-      Name: '*[]main.structWithMap.array'
+      ID: 226
+      Name: '*int32'
       ByteSize: 8
-      Pointee: 256 GoSliceDataType []main.structWithMap.array
-    - __kind: GoSliceDataType
-      ID: 258
-      Name: '[]*table<bool,main.node>.array'
-      ByteSize: 8192
-      Element: 137 PointerType *table<bool,main.node>
-    - __kind: GoSliceDataType
-      ID: 259
-      Name: '[]noalg.map.group[bool]main.node.array'
-      ByteSize: 2048
-      Element: 141 StructureType noalg.map.group[bool]main.node
-    - __kind: GoSliceDataType
-      ID: 260
-      Name: '[]*table<int,uint8>.array'
-      ByteSize: 8192
-      Element: 150 PointerType *table<int,uint8>
-    - __kind: GoSliceDataType
-      ID: 261
-      Name: '[]noalg.map.group[int]uint8.array'
-      ByteSize: 2048
-      Element: 154 StructureType noalg.map.group[int]uint8
-    - __kind: GoSliceDataType
-      ID: 262
-      Name: '[]*table<uint8,uint8>.array'
-      ByteSize: 8192
-      Element: 161 PointerType *table<uint8,uint8>
-    - __kind: GoSliceDataType
-      ID: 263
-      Name: '[]noalg.map.group[uint8]uint8.array'
-      ByteSize: 2048
-      Element: 165 StructureType noalg.map.group[uint8]uint8
-    - __kind: GoSliceDataType
-      ID: 264
-      Name: '[]*table<uint8,[4]int>.array'
-      ByteSize: 8192
-      Element: 172 PointerType *table<uint8,[4]int>
-    - __kind: GoSliceDataType
-      ID: 265
-      Name: '[]noalg.map.group[uint8][4]int.array'
-      ByteSize: 2048
-      Element: 176 StructureType noalg.map.group[uint8][4]int
-    - __kind: GoSliceDataType
-      ID: 266
-      Name: '[]*table<[4]int,uint8>.array'
-      ByteSize: 8192
-      Element: 184 PointerType *table<[4]int,uint8>
-    - __kind: GoSliceDataType
-      ID: 267
-      Name: '[]noalg.map.group[[4]int]uint8.array'
-      ByteSize: 2048
-      Element: 188 StructureType noalg.map.group[[4]int]uint8
-    - __kind: GoSliceDataType
-      ID: 268
-      Name: '[]*table<[4]int,[4]int>.array'
-      ByteSize: 8192
-      Element: 195 PointerType *table<[4]int,[4]int>
-    - __kind: GoSliceDataType
-      ID: 269
-      Name: '[]noalg.map.group[[4]int][4]int.array'
-      ByteSize: 2048
-      Element: 199 StructureType noalg.map.group[[4]int][4]int
-    - __kind: GoSliceDataType
-      ID: 270
-      Name: main.t.array
-      ByteSize: 2048
-      Element: 207 PointerType *main.t
+      GoRuntimeType: 385536
+      GoKind: 22
+      Pointee: 6 BaseType int32
+    - __kind: PointerType
+      ID: 231
+      Name: '*int64'
+      ByteSize: 8
+      GoRuntimeType: 385664
+      GoKind: 22
+      Pointee: 18 BaseType int64
+    - __kind: PointerType
+      ID: 235
+      Name: '*int8'
+      ByteSize: 8
+      GoRuntimeType: 385280
+      GoKind: 22
+      Pointee: 14 BaseType int8
+    - __kind: PointerType
+      ID: 44
+      Name: '*main.esotericHeap'
+      ByteSize: 8
+      GoRuntimeType: 380224
+      GoKind: 22
+      Pointee: 45 StructureType main.esotericHeap
+    - __kind: PointerType
+      ID: 145
+      Name: '*main.node'
+      ByteSize: 8
+      GoRuntimeType: 380288
+      GoKind: 22
+      Pointee: 144 StructureType main.node
+    - __kind: PointerType
+      ID: 221
+      Name: '*main.oneStringStruct'
+      ByteSize: 8
+      GoKind: 22
+      Pointee: 222 StructureType main.oneStringStruct
+    - __kind: PointerType
+      ID: 132
+      Name: '*main.structWithMap'
+      ByteSize: 8
+      GoRuntimeType: 380160
+      GoKind: 22
+      Pointee: 58 StructureType main.structWithMap
+    - __kind: PointerType
+      ID: 214
+      Name: '*main.structWithNoStrings'
+      ByteSize: 8
+      Pointee: 215 StructureType main.structWithNoStrings
+    - __kind: PointerType
+      ID: 203
+      Name: '*main.structWithTwoValues'
+      ByteSize: 8
+      GoKind: 22
+      Pointee: 204 StructureType main.structWithTwoValues
+    - __kind: PointerType
+      ID: 207
+      Name: '*main.t'
+      ByteSize: 8
+      GoKind: 22
+      Pointee: 208 GoSliceHeaderType main.t
     - __kind: PointerType
       ID: 271
       Name: '*main.t.array'
       ByteSize: 8
       Pointee: 270 GoSliceDataType main.t.array
-    - __kind: GoSliceDataType
-      ID: 272
-      Name: '[]uint.array'
-      ByteSize: 2048
-      Element: 20 BaseType uint
     - __kind: PointerType
-      ID: 273
-      Name: '*[]uint.array'
+      ID: 220
+      Name: '*main.threeStringStruct'
       ByteSize: 8
-      Pointee: 272 GoSliceDataType []uint.array
-    - __kind: GoSliceDataType
-      ID: 274
-      Name: '[][]uint.array'
-      ByteSize: 2048
-      Element: 210 GoSliceHeaderType []uint
+      GoKind: 22
+      Pointee: 219 StructureType main.threeStringStruct
     - __kind: PointerType
-      ID: 275
-      Name: '*[][]uint.array'
+      ID: 192
+      Name: '*map<[4]int,[4]int>'
       ByteSize: 8
-      Pointee: 274 GoSliceDataType [][]uint.array
-    - __kind: GoSliceDataType
-      ID: 276
-      Name: '[]main.structWithNoStrings.array'
-      ByteSize: 2048
-      Element: 215 StructureType main.structWithNoStrings
+      Pointee: 193 GoSwissMapHeaderType map<[4]int,[4]int>
     - __kind: PointerType
-      ID: 277
-      Name: '*[]main.structWithNoStrings.array'
+      ID: 181
+      Name: '*map<[4]int,uint8>'
       ByteSize: 8
-      Pointee: 276 GoSliceDataType []main.structWithNoStrings.array
-    - __kind: GoSliceDataType
-      ID: 278
-      Name: '[]bool.array'
-      ByteSize: 2048
-      Element: 11 BaseType bool
+      Pointee: 182 GoSwissMapHeaderType map<[4]int,uint8>
     - __kind: PointerType
-      ID: 279
-      Name: '*[]bool.array'
+      ID: 107
+      Name: '*map<[4]string,[2]int>'
       ByteSize: 8
-      Pointee: 278 GoSliceDataType []bool.array
-    - __kind: GoSliceDataType
-      ID: 280
-      Name: '[]uint16.array'
-      ByteSize: 2048
-      Element: 22 BaseType uint16
+      Pointee: 108 GoSwissMapHeaderType map<[4]string,[2]int>
     - __kind: PointerType
-      ID: 281
-      Name: '*[]uint16.array'
+      ID: 134
+      Name: '*map<bool,main.node>'
       ByteSize: 8
-      Pointee: 280 GoSliceDataType []uint16.array
+      Pointee: 135 GoSwissMapHeaderType map<bool,main.node>
+    - __kind: PointerType
+      ID: 60
+      Name: '*map<int,int>'
+      ByteSize: 8
+      Pointee: 61 GoSwissMapHeaderType map<int,int>
+    - __kind: PointerType
+      ID: 147
+      Name: '*map<int,uint8>'
+      ByteSize: 8
+      Pointee: 148 GoSwissMapHeaderType map<int,uint8>
+    - __kind: PointerType
+      ID: 121
+      Name: '*map<string,[]main.structWithMap>'
+      ByteSize: 8
+      Pointee: 122 GoSwissMapHeaderType map<string,[]main.structWithMap>
+    - __kind: PointerType
+      ID: 95
+      Name: '*map<string,[]string>'
+      ByteSize: 8
+      Pointee: 96 GoSwissMapHeaderType map<string,[]string>
+    - __kind: PointerType
+      ID: 84
+      Name: '*map<string,int>'
+      ByteSize: 8
+      Pointee: 85 GoSwissMapHeaderType map<string,int>
+    - __kind: PointerType
+      ID: 72
+      Name: '*map<string,main.nestedStruct>'
+      ByteSize: 8
+      Pointee: 73 GoSwissMapHeaderType map<string,main.nestedStruct>
+    - __kind: PointerType
+      ID: 169
+      Name: '*map<uint8,[4]int>'
+      ByteSize: 8
+      Pointee: 170 GoSwissMapHeaderType map<uint8,[4]int>
+    - __kind: PointerType
+      ID: 158
+      Name: '*map<uint8,uint8>'
+      ByteSize: 8
+      Pointee: 159 GoSwissMapHeaderType map<uint8,uint8>
+    - __kind: PointerType
+      ID: 119
+      Name: '*map[string]int'
+      ByteSize: 8
+      GoKind: 22
+      Pointee: 83 GoMapType map[string]int
+    - __kind: PointerType
+      ID: 198
+      Name: '*noalg.map.group[[4]int][4]int'
+      ByteSize: 8
+      Pointee: 199 StructureType noalg.map.group[[4]int][4]int
+    - __kind: PointerType
+      ID: 187
+      Name: '*noalg.map.group[[4]int]uint8'
+      ByteSize: 8
+      Pointee: 188 StructureType noalg.map.group[[4]int]uint8
+    - __kind: PointerType
+      ID: 113
+      Name: '*noalg.map.group[[4]string][2]int'
+      ByteSize: 8
+      Pointee: 114 StructureType noalg.map.group[[4]string][2]int
+    - __kind: PointerType
+      ID: 140
+      Name: '*noalg.map.group[bool]main.node'
+      ByteSize: 8
+      Pointee: 141 StructureType noalg.map.group[bool]main.node
+    - __kind: PointerType
+      ID: 67
+      Name: '*noalg.map.group[int]int'
+      ByteSize: 8
+      Pointee: 68 StructureType noalg.map.group[int]int
+    - __kind: PointerType
+      ID: 153
+      Name: '*noalg.map.group[int]uint8'
+      ByteSize: 8
+      Pointee: 154 StructureType noalg.map.group[int]uint8
+    - __kind: PointerType
+      ID: 127
+      Name: '*noalg.map.group[string][]main.structWithMap'
+      ByteSize: 8
+      Pointee: 128 StructureType noalg.map.group[string][]main.structWithMap
+    - __kind: PointerType
+      ID: 101
+      Name: '*noalg.map.group[string][]string'
+      ByteSize: 8
+      Pointee: 102 StructureType noalg.map.group[string][]string
+    - __kind: PointerType
+      ID: 90
+      Name: '*noalg.map.group[string]int'
+      ByteSize: 8
+      Pointee: 91 StructureType noalg.map.group[string]int
+    - __kind: PointerType
+      ID: 78
+      Name: '*noalg.map.group[string]main.nestedStruct'
+      ByteSize: 8
+      Pointee: 79 StructureType noalg.map.group[string]main.nestedStruct
+    - __kind: PointerType
+      ID: 175
+      Name: '*noalg.map.group[uint8][4]int'
+      ByteSize: 8
+      Pointee: 176 StructureType noalg.map.group[uint8][4]int
+    - __kind: PointerType
+      ID: 164
+      Name: '*noalg.map.group[uint8]uint8'
+      ByteSize: 8
+      Pointee: 165 StructureType noalg.map.group[uint8]uint8
+    - __kind: PointerType
+      ID: 36
+      Name: '*string'
+      ByteSize: 8
+      GoRuntimeType: 385216
+      GoKind: 22
+      Pointee: 8 GoStringHeaderType string
+    - __kind: PointerType
+      ID: 239
+      Name: '*string.str'
+      ByteSize: 8
+      Pointee: 238 GoStringDataType string.str
+    - __kind: PointerType
+      ID: 195
+      Name: '*table<[4]int,[4]int>'
+      ByteSize: 8
+      Pointee: 196 StructureType table<[4]int,[4]int>
+    - __kind: PointerType
+      ID: 184
+      Name: '*table<[4]int,uint8>'
+      ByteSize: 8
+      Pointee: 185 StructureType table<[4]int,uint8>
+    - __kind: PointerType
+      ID: 110
+      Name: '*table<[4]string,[2]int>'
+      ByteSize: 8
+      Pointee: 111 StructureType table<[4]string,[2]int>
+    - __kind: PointerType
+      ID: 137
+      Name: '*table<bool,main.node>'
+      ByteSize: 8
+      Pointee: 138 StructureType table<bool,main.node>
+    - __kind: PointerType
+      ID: 64
+      Name: '*table<int,int>'
+      ByteSize: 8
+      Pointee: 65 StructureType table<int,int>
+    - __kind: PointerType
+      ID: 150
+      Name: '*table<int,uint8>'
+      ByteSize: 8
+      Pointee: 151 StructureType table<int,uint8>
+    - __kind: PointerType
+      ID: 124
+      Name: '*table<string,[]main.structWithMap>'
+      ByteSize: 8
+      Pointee: 125 StructureType table<string,[]main.structWithMap>
+    - __kind: PointerType
+      ID: 98
+      Name: '*table<string,[]string>'
+      ByteSize: 8
+      Pointee: 99 StructureType table<string,[]string>
+    - __kind: PointerType
+      ID: 87
+      Name: '*table<string,int>'
+      ByteSize: 8
+      Pointee: 88 StructureType table<string,int>
+    - __kind: PointerType
+      ID: 75
+      Name: '*table<string,main.nestedStruct>'
+      ByteSize: 8
+      Pointee: 76 StructureType table<string,main.nestedStruct>
+    - __kind: PointerType
+      ID: 172
+      Name: '*table<uint8,[4]int>'
+      ByteSize: 8
+      Pointee: 173 StructureType table<uint8,[4]int>
+    - __kind: PointerType
+      ID: 161
+      Name: '*table<uint8,uint8>'
+      ByteSize: 8
+      Pointee: 162 StructureType table<uint8,uint8>
+    - __kind: PointerType
+      ID: 205
+      Name: '*uint'
+      ByteSize: 8
+      GoRuntimeType: 385856
+      GoKind: 22
+      Pointee: 20 BaseType uint
+    - __kind: PointerType
+      ID: 218
+      Name: '*uint16'
+      ByteSize: 8
+      GoRuntimeType: 385472
+      GoKind: 22
+      Pointee: 22 BaseType uint16
+    - __kind: PointerType
+      ID: 227
+      Name: '*uint32'
+      ByteSize: 8
+      GoRuntimeType: 385600
+      GoKind: 22
+      Pointee: 24 BaseType uint32
+    - __kind: PointerType
+      ID: 233
+      Name: '*uint64'
+      ByteSize: 8
+      GoRuntimeType: 385728
+      GoKind: 22
+      Pointee: 26 BaseType uint64
+    - __kind: PointerType
+      ID: 9
+      Name: '*uint8'
+      ByteSize: 8
+      GoRuntimeType: 385344
+      GoKind: 22
+      Pointee: 4 BaseType uint8
+    - __kind: PointerType
+      ID: 225
+      Name: '*uintptr'
+      ByteSize: 8
+      GoRuntimeType: 385920
+      GoKind: 22
+      Pointee: 62 BaseType uintptr
     - __kind: EventRootType
-      ID: 282
-      Name: Probe[main.testByteArray]
-      ByteSize: 3
+      ID: 369
+      Name: Probe[main.stackC]
+    - __kind: EventRootType
+      ID: 326
+      Name: Probe[main.testAny]
+      ByteSize: 17
       PresenceBitsetSize: 1
       Expressions:
-        - Name: x
+        - Name: a
           Offset: 1
           Expression:
-            Type: 3 ArrayType [2]uint8
+            Type: 41 GoEmptyInterfaceType interface {}
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 7, index: 0, name: x}
+                  Variable: {subprogram: 51, index: 0, name: a}
                   Offset: 0
-                  ByteSize: 2
+                  ByteSize: 16
     - __kind: EventRootType
-      ID: 283
-      Name: Probe[main.testRuneArray]
-      ByteSize: 9
+      ID: 298
+      Name: Probe[main.testArrayOfArraysOfArrays]
+      ByteSize: 65
       PresenceBitsetSize: 1
       Expressions:
-        - Name: x
+        - Name: b
           Offset: 1
           Expression:
-            Type: 5 ArrayType [2]int32
+            Type: 28 ArrayType [2][2][2]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 8, index: 0, name: x}
+                  Variable: {subprogram: 23, index: 0, name: b}
                   Offset: 0
-                  ByteSize: 8
+                  ByteSize: 64
     - __kind: EventRootType
-      ID: 284
-      Name: Probe[main.testStringArray]
+      ID: 296
+      Name: Probe[main.testArrayOfArrays]
       ByteSize: 33
       PresenceBitsetSize: 1
       Expressions:
-        - Name: x
+        - Name: a
+          Offset: 1
+          Expression:
+            Type: 27 ArrayType [2][2]int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 21, index: 0, name: a}
+                  Offset: 0
+                  ByteSize: 32
+    - __kind: EventRootType
+      ID: 334
+      Name: Probe[main.testArrayOfMaps]
+      ByteSize: 17
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: m
+          Offset: 1
+          Expression:
+            Type: 118 ArrayType [2]map[string]int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 59, index: 0, name: m}
+                  Offset: 0
+                  ByteSize: 16
+    - __kind: EventRootType
+      ID: 297
+      Name: Probe[main.testArrayOfStrings]
+      ByteSize: 33
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: a
           Offset: 1
           Expression:
             Type: 7 ArrayType [2]string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 9, index: 0, name: x}
+                  Variable: {subprogram: 22, index: 0, name: a}
                   Offset: 0
                   ByteSize: 32
+    - __kind: EventRootType
+      ID: 316
+      Name: Probe[main.testBigStruct]
+      ByteSize: 49
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: b
+          Offset: 1
+          Expression:
+            Type: 33 StructureType main.bigStruct
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 41, index: 0, name: b}
+                  Offset: 0
+                  ByteSize: 48
     - __kind: EventRootType
       ID: 285
       Name: Probe[main.testBoolArray]
@@ -5944,35 +3678,338 @@ Types:
                   Offset: 0
                   ByteSize: 2
     - __kind: EventRootType
-      ID: 286
-      Name: Probe[main.testIntArray]
-      ByteSize: 17
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: x
-          Offset: 1
-          Expression:
-            Type: 12 ArrayType [2]int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 11, index: 0, name: x}
-                  Offset: 0
-                  ByteSize: 16
-    - __kind: EventRootType
-      ID: 287
-      Name: Probe[main.testInt8Array]
+      ID: 282
+      Name: Probe[main.testByteArray]
       ByteSize: 3
       PresenceBitsetSize: 1
       Expressions:
         - Name: x
           Offset: 1
           Expression:
-            Type: 13 ArrayType [2]int8
+            Type: 3 ArrayType [2]uint8
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 12, index: 0, name: x}
+                  Variable: {subprogram: 7, index: 0, name: x}
                   Offset: 0
                   ByteSize: 2
+    - __kind: EventRootType
+      ID: 350
+      Name: Probe[main.testChannel]
+      ByteSize: 1
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: c
+          Offset: 1
+          Expression:
+            Type: 202 GoChannelType chan bool
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 75, index: 0, name: c}
+                  Offset: 0
+                  ByteSize: 0
+    - __kind: EventRootType
+      ID: 348
+      Name: Probe[main.testCombinedByte]
+      ByteSize: 7
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: w
+          Offset: 1
+          Expression:
+            Type: 4 BaseType uint8
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 73, index: 0, name: w}
+                  Offset: 0
+                  ByteSize: 1
+        - Name: x
+          Offset: 2
+          Expression:
+            Type: 4 BaseType uint8
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 73, index: 1, name: x}
+                  Offset: 0
+                  ByteSize: 1
+        - Name: y
+          Offset: 3
+          Expression:
+            Type: 30 BaseType float32
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 73, index: 2, name: y}
+                  Offset: 0
+                  ByteSize: 4
+    - __kind: EventRootType
+      ID: 358
+      Name: Probe[main.testCycle]
+      ByteSize: 9
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: t
+          Offset: 1
+          Expression:
+            Type: 207 PointerType *main.t
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 83, index: 0, name: t}
+                  Offset: 0
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 363
+      Name: Probe[main.testEmptySliceOfStructs]
+      ByteSize: 33
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: xs
+          Offset: 1
+          Expression:
+            Type: 213 GoSliceHeaderType []main.structWithNoStrings
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 88, index: 0, name: xs}
+                  Offset: 0
+                  ByteSize: 24
+        - Name: a
+          Offset: 25
+          Expression:
+            Type: 1 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 88, index: 1, name: a}
+                  Offset: 0
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 360
+      Name: Probe[main.testEmptySlice]
+      ByteSize: 25
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: u
+          Offset: 1
+          Expression:
+            Type: 210 GoSliceHeaderType []uint
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 85, index: 0, name: u}
+                  Offset: 0
+                  ByteSize: 24
+    - __kind: EventRootType
+      ID: 377
+      Name: Probe[main.testEmptyString]
+      ByteSize: 17
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: x
+          Offset: 1
+          Expression:
+            Type: 8 GoStringHeaderType string
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 102, index: 0, name: x}
+                  Offset: 0
+                  ByteSize: 16
+    - __kind: EventRootType
+      ID: 379
+      Name: Probe[main.testEmptyStruct]
+      ByteSize: 1
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: e
+          Offset: 1
+          Expression:
+            Type: 224 StructureType main.emptyStruct
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 104, index: 0, name: e}
+                  Offset: 0
+                  ByteSize: 0
+    - __kind: EventRootType
+      ID: 327
+      Name: Probe[main.testError]
+      ByteSize: 17
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: e
+          Offset: 1
+          Expression:
+            Type: 57 GoInterfaceType error
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 52, index: 0, name: e}
+                  Offset: 0
+                  ByteSize: 16
+    - __kind: EventRootType
+      ID: 318
+      Name: Probe[main.testEsotericHeap]
+      ByteSize: 9
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: e
+          Offset: 1
+          Expression:
+            Type: 44 PointerType *main.esotericHeap
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 43, index: 0, name: e}
+                  Offset: 0
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 317
+      Name: Probe[main.testEsotericStack]
+      ByteSize: 65
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: e
+          Offset: 1
+          Expression:
+            Type: 39 StructureType main.esotericStack
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 42, index: 0, name: e}
+                  Offset: 0
+                  ByteSize: 64
+    - __kind: EventRootType
+      ID: 324
+      Name: Probe[main.testFramelessArray]
+      ByteSize: 41
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: a
+          Offset: 1
+          Expression:
+            Type: 2 ArrayType [5]int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 49, index: 0, name: a}
+                  Offset: 0
+                  ByteSize: 40
+    - __kind: EventRootType
+      ID: 323
+      Name: Probe[main.testFrameless]
+      ByteSize: 9
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: x
+          Offset: 1
+          Expression:
+            Type: 1 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 48, index: 0, name: x}
+                  Offset: 0
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 319
+      Name: Probe[main.testInlinedBA]
+      ByteSize: 9
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: x
+          Offset: 1
+          Expression:
+            Type: 1 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 44, index: 0, name: x}
+                  Offset: 0
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 321
+      Name: Probe[main.testInlinedBBA]
+      ByteSize: 9
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: x
+          Offset: 1
+          Expression:
+            Type: 1 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 46, index: 0, name: x}
+                  Offset: 0
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 381
+      Name: Probe[main.testInlinedBBB]
+    - __kind: EventRootType
+      ID: 320
+      Name: Probe[main.testInlinedBB]
+      ByteSize: 17
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: x
+          Offset: 1
+          Expression:
+            Type: 1 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 45, index: 0, name: x}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: y
+          Offset: 9
+          Expression:
+            Type: 1 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 45, index: 1, name: y}
+                  Offset: 0
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 382
+      Name: Probe[main.testInlinedBCA]
+    - __kind: EventRootType
+      ID: 383
+      Name: Probe[main.testInlinedBCB]
+    - __kind: EventRootType
+      ID: 322
+      Name: Probe[main.testInlinedBC]
+    - __kind: EventRootType
+      ID: 380
+      Name: Probe[main.testInlinedPrint]
+      ByteSize: 9
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: x
+          Offset: 1
+          Expression:
+            Type: 1 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 1, index: 0, name: x}
+                  Offset: 0
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 384
+      Name: Probe[main.testInlinedSq]
+      ByteSize: 9
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: x
+          Offset: 1
+          Expression:
+            Type: 1 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 5, index: 0, name: x}
+                  Offset: 0
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 385
+      Name: Probe[main.testInlinedSumArray]
+      ByteSize: 41
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: a
+          Offset: 1
+          Expression:
+            Type: 2 ArrayType [5]int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 6, index: 0, name: a}
+                  Offset: 0
+                  ByteSize: 40
     - __kind: EventRootType
       ID: 288
       Name: Probe[main.testInt16Array]
@@ -6019,512 +4056,35 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 291
-      Name: Probe[main.testUintArray]
+      ID: 287
+      Name: Probe[main.testInt8Array]
+      ByteSize: 3
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: x
+          Offset: 1
+          Expression:
+            Type: 13 ArrayType [2]int8
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 12, index: 0, name: x}
+                  Offset: 0
+                  ByteSize: 2
+    - __kind: EventRootType
+      ID: 286
+      Name: Probe[main.testIntArray]
       ByteSize: 17
       PresenceBitsetSize: 1
       Expressions:
         - Name: x
           Offset: 1
           Expression:
-            Type: 19 ArrayType [2]uint
+            Type: 12 ArrayType [2]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 16, index: 0, name: x}
+                  Variable: {subprogram: 11, index: 0, name: x}
                   Offset: 0
                   ByteSize: 16
-    - __kind: EventRootType
-      ID: 292
-      Name: Probe[main.testUint8Array]
-      ByteSize: 3
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: x
-          Offset: 1
-          Expression:
-            Type: 3 ArrayType [2]uint8
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 17, index: 0, name: x}
-                  Offset: 0
-                  ByteSize: 2
-    - __kind: EventRootType
-      ID: 293
-      Name: Probe[main.testUint16Array]
-      ByteSize: 5
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: x
-          Offset: 1
-          Expression:
-            Type: 21 ArrayType [2]uint16
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 18, index: 0, name: x}
-                  Offset: 0
-                  ByteSize: 4
-    - __kind: EventRootType
-      ID: 294
-      Name: Probe[main.testUint32Array]
-      ByteSize: 9
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: x
-          Offset: 1
-          Expression:
-            Type: 23 ArrayType [2]uint32
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 19, index: 0, name: x}
-                  Offset: 0
-                  ByteSize: 8
-    - __kind: EventRootType
-      ID: 295
-      Name: Probe[main.testUint64Array]
-      ByteSize: 17
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: x
-          Offset: 1
-          Expression:
-            Type: 25 ArrayType [2]uint64
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 20, index: 0, name: x}
-                  Offset: 0
-                  ByteSize: 16
-    - __kind: EventRootType
-      ID: 296
-      Name: Probe[main.testArrayOfArrays]
-      ByteSize: 33
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: a
-          Offset: 1
-          Expression:
-            Type: 27 ArrayType [2][2]int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 21, index: 0, name: a}
-                  Offset: 0
-                  ByteSize: 32
-    - __kind: EventRootType
-      ID: 297
-      Name: Probe[main.testArrayOfStrings]
-      ByteSize: 33
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: a
-          Offset: 1
-          Expression:
-            Type: 7 ArrayType [2]string
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 22, index: 0, name: a}
-                  Offset: 0
-                  ByteSize: 32
-    - __kind: EventRootType
-      ID: 298
-      Name: Probe[main.testArrayOfArraysOfArrays]
-      ByteSize: 65
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: b
-          Offset: 1
-          Expression:
-            Type: 28 ArrayType [2][2][2]int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 23, index: 0, name: b}
-                  Offset: 0
-                  ByteSize: 64
-    - __kind: EventRootType
-      ID: 299
-      Name: Probe[main.testVeryLargeArray]
-      ByteSize: 801
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: a
-          Offset: 1
-          Expression:
-            Type: 29 ArrayType [100]uint
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 24, index: 0, name: a}
-                  Offset: 0
-                  ByteSize: 800
-    - __kind: EventRootType
-      ID: 300
-      Name: Probe[main.testSingleByte]
-      ByteSize: 2
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: x
-          Offset: 1
-          Expression:
-            Type: 4 BaseType uint8
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 25, index: 0, name: x}
-                  Offset: 0
-                  ByteSize: 1
-    - __kind: EventRootType
-      ID: 301
-      Name: Probe[main.testSingleRune]
-      ByteSize: 5
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: x
-          Offset: 1
-          Expression:
-            Type: 6 BaseType int32
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 26, index: 0, name: x}
-                  Offset: 0
-                  ByteSize: 4
-    - __kind: EventRootType
-      ID: 302
-      Name: Probe[main.testSingleBool]
-      ByteSize: 2
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: x
-          Offset: 1
-          Expression:
-            Type: 11 BaseType bool
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 27, index: 0, name: x}
-                  Offset: 0
-                  ByteSize: 1
-    - __kind: EventRootType
-      ID: 303
-      Name: Probe[main.testSingleInt]
-      ByteSize: 9
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: x
-          Offset: 1
-          Expression:
-            Type: 1 BaseType int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 28, index: 0, name: x}
-                  Offset: 0
-                  ByteSize: 8
-    - __kind: EventRootType
-      ID: 304
-      Name: Probe[main.testSingleInt8]
-      ByteSize: 2
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: x
-          Offset: 1
-          Expression:
-            Type: 14 BaseType int8
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 29, index: 0, name: x}
-                  Offset: 0
-                  ByteSize: 1
-    - __kind: EventRootType
-      ID: 305
-      Name: Probe[main.testSingleInt16]
-      ByteSize: 3
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: x
-          Offset: 1
-          Expression:
-            Type: 16 BaseType int16
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 30, index: 0, name: x}
-                  Offset: 0
-                  ByteSize: 2
-    - __kind: EventRootType
-      ID: 306
-      Name: Probe[main.testSingleInt32]
-      ByteSize: 5
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: x
-          Offset: 1
-          Expression:
-            Type: 6 BaseType int32
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 31, index: 0, name: x}
-                  Offset: 0
-                  ByteSize: 4
-    - __kind: EventRootType
-      ID: 307
-      Name: Probe[main.testSingleInt64]
-      ByteSize: 9
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: x
-          Offset: 1
-          Expression:
-            Type: 18 BaseType int64
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 32, index: 0, name: x}
-                  Offset: 0
-                  ByteSize: 8
-    - __kind: EventRootType
-      ID: 308
-      Name: Probe[main.testSingleUint]
-      ByteSize: 9
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: x
-          Offset: 1
-          Expression:
-            Type: 20 BaseType uint
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 33, index: 0, name: x}
-                  Offset: 0
-                  ByteSize: 8
-    - __kind: EventRootType
-      ID: 309
-      Name: Probe[main.testSingleUint8]
-      ByteSize: 2
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: x
-          Offset: 1
-          Expression:
-            Type: 4 BaseType uint8
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 34, index: 0, name: x}
-                  Offset: 0
-                  ByteSize: 1
-    - __kind: EventRootType
-      ID: 310
-      Name: Probe[main.testSingleUint16]
-      ByteSize: 3
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: x
-          Offset: 1
-          Expression:
-            Type: 22 BaseType uint16
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 35, index: 0, name: x}
-                  Offset: 0
-                  ByteSize: 2
-    - __kind: EventRootType
-      ID: 311
-      Name: Probe[main.testSingleUint32]
-      ByteSize: 5
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: x
-          Offset: 1
-          Expression:
-            Type: 24 BaseType uint32
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 36, index: 0, name: x}
-                  Offset: 0
-                  ByteSize: 4
-    - __kind: EventRootType
-      ID: 312
-      Name: Probe[main.testSingleUint64]
-      ByteSize: 9
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: x
-          Offset: 1
-          Expression:
-            Type: 26 BaseType uint64
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 37, index: 0, name: x}
-                  Offset: 0
-                  ByteSize: 8
-    - __kind: EventRootType
-      ID: 313
-      Name: Probe[main.testSingleFloat32]
-      ByteSize: 5
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: x
-          Offset: 1
-          Expression:
-            Type: 30 BaseType float32
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 38, index: 0, name: x}
-                  Offset: 0
-                  ByteSize: 4
-    - __kind: EventRootType
-      ID: 314
-      Name: Probe[main.testSingleFloat64]
-      ByteSize: 9
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: x
-          Offset: 1
-          Expression:
-            Type: 31 BaseType float64
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 39, index: 0, name: x}
-                  Offset: 0
-                  ByteSize: 8
-    - __kind: EventRootType
-      ID: 315
-      Name: Probe[main.testTypeAlias]
-      ByteSize: 3
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: x
-          Offset: 1
-          Expression:
-            Type: 32 BaseType main.typeAlias
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 40, index: 0, name: x}
-                  Offset: 0
-                  ByteSize: 2
-    - __kind: EventRootType
-      ID: 316
-      Name: Probe[main.testBigStruct]
-      ByteSize: 49
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: b
-          Offset: 1
-          Expression:
-            Type: 33 StructureType main.bigStruct
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 41, index: 0, name: b}
-                  Offset: 0
-                  ByteSize: 48
-    - __kind: EventRootType
-      ID: 317
-      Name: Probe[main.testEsotericStack]
-      ByteSize: 65
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: e
-          Offset: 1
-          Expression:
-            Type: 39 StructureType main.esotericStack
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 42, index: 0, name: e}
-                  Offset: 0
-                  ByteSize: 64
-    - __kind: EventRootType
-      ID: 318
-      Name: Probe[main.testEsotericHeap]
-      ByteSize: 9
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: e
-          Offset: 1
-          Expression:
-            Type: 44 PointerType *main.esotericHeap
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 43, index: 0, name: e}
-                  Offset: 0
-                  ByteSize: 8
-    - __kind: EventRootType
-      ID: 319
-      Name: Probe[main.testInlinedBA]
-      ByteSize: 9
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: x
-          Offset: 1
-          Expression:
-            Type: 1 BaseType int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 44, index: 0, name: x}
-                  Offset: 0
-                  ByteSize: 8
-    - __kind: EventRootType
-      ID: 320
-      Name: Probe[main.testInlinedBB]
-      ByteSize: 17
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: x
-          Offset: 1
-          Expression:
-            Type: 1 BaseType int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 45, index: 0, name: x}
-                  Offset: 0
-                  ByteSize: 8
-        - Name: y
-          Offset: 9
-          Expression:
-            Type: 1 BaseType int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 45, index: 1, name: y}
-                  Offset: 0
-                  ByteSize: 8
-    - __kind: EventRootType
-      ID: 321
-      Name: Probe[main.testInlinedBBA]
-      ByteSize: 9
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: x
-          Offset: 1
-          Expression:
-            Type: 1 BaseType int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 46, index: 0, name: x}
-                  Offset: 0
-                  ByteSize: 8
-    - __kind: EventRootType
-      ID: 322
-      Name: Probe[main.testInlinedBC]
-    - __kind: EventRootType
-      ID: 323
-      Name: Probe[main.testFrameless]
-      ByteSize: 9
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: x
-          Offset: 1
-          Expression:
-            Type: 1 BaseType int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 48, index: 0, name: x}
-                  Offset: 0
-                  ByteSize: 8
-    - __kind: EventRootType
-      ID: 324
-      Name: Probe[main.testFramelessArray]
-      ByteSize: 41
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: a
-          Offset: 1
-          Expression:
-            Type: 2 ArrayType [5]int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 49, index: 0, name: a}
-                  Offset: 0
-                  ByteSize: 40
     - __kind: EventRootType
       ID: 325
       Name: Probe[main.testInterface]
@@ -6541,63 +4101,138 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 326
-      Name: Probe[main.testAny]
+      ID: 352
+      Name: Probe[main.testLinkedList]
       ByteSize: 17
       PresenceBitsetSize: 1
       Expressions:
         - Name: a
           Offset: 1
           Expression:
-            Type: 41 GoEmptyInterfaceType interface {}
+            Type: 144 StructureType main.node
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 51, index: 0, name: a}
+                  Variable: {subprogram: 77, index: 0, name: a}
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 327
-      Name: Probe[main.testError]
-      ByteSize: 17
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: e
-          Offset: 1
-          Expression:
-            Type: 57 GoInterfaceType error
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 52, index: 0, name: e}
-                  Offset: 0
-                  ByteSize: 16
-    - __kind: EventRootType
-      ID: 328
-      Name: Probe[main.testStructWithMap]
-      ByteSize: 9
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: s
-          Offset: 1
-          Expression:
-            Type: 58 StructureType main.structWithMap
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 53, index: 0, name: s}
-                  Offset: 0
-                  ByteSize: 8
-    - __kind: EventRootType
-      ID: 329
-      Name: Probe[main.testMapStringToStruct]
+      ID: 332
+      Name: Probe[main.testMapArrayToArray]
       ByteSize: 9
       PresenceBitsetSize: 1
       Expressions:
         - Name: m
           Offset: 1
           Expression:
-            Type: 71 GoMapType map[string]main.nestedStruct
+            Type: 106 GoMapType map[[4]string][2]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 54, index: 0, name: m}
+                  Variable: {subprogram: 57, index: 0, name: m}
+                  Offset: 0
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 338
+      Name: Probe[main.testMapEmbeddedMaps]
+      ByteSize: 9
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: m
+          Offset: 1
+          Expression:
+            Type: 120 GoMapType map[string][]main.structWithMap
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 63, index: 0, name: m}
+                  Offset: 0
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 336
+      Name: Probe[main.testMapIntToInt]
+      ByteSize: 9
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: m
+          Offset: 1
+          Expression:
+            Type: 59 GoMapType map[int]int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 61, index: 0, name: m}
+                  Offset: 0
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 347
+      Name: Probe[main.testMapLargeKeyLargeValue]
+      ByteSize: 9
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: m
+          Offset: 1
+          Expression:
+            Type: 191 GoMapType map[[4]int][4]int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 72, index: 0, name: m}
+                  Offset: 0
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 346
+      Name: Probe[main.testMapLargeKeySmallValue]
+      ByteSize: 9
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: m
+          Offset: 1
+          Expression:
+            Type: 180 GoMapType map[[4]int]uint8
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 71, index: 0, name: m}
+                  Offset: 0
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 337
+      Name: Probe[main.testMapMassive]
+      ByteSize: 9
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: redactMyEntries
+          Offset: 1
+          Expression:
+            Type: 120 GoMapType map[string][]main.structWithMap
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 62, index: 0, name: redactMyEntries}
+                  Offset: 0
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 345
+      Name: Probe[main.testMapSmallKeyLargeValue]
+      ByteSize: 9
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: m
+          Offset: 1
+          Expression:
+            Type: 168 GoMapType map[uint8][4]int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 70, index: 0, name: m}
+                  Offset: 0
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 344
+      Name: Probe[main.testMapSmallKeySmallValue]
+      ByteSize: 9
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: m
+          Offset: 1
+          Expression:
+            Type: 157 GoMapType map[uint8]uint8
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 69, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
@@ -6631,108 +4266,18 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 332
-      Name: Probe[main.testMapArrayToArray]
+      ID: 329
+      Name: Probe[main.testMapStringToStruct]
       ByteSize: 9
       PresenceBitsetSize: 1
       Expressions:
         - Name: m
           Offset: 1
           Expression:
-            Type: 106 GoMapType map[[4]string][2]int
+            Type: 71 GoMapType map[string]main.nestedStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 57, index: 0, name: m}
-                  Offset: 0
-                  ByteSize: 8
-    - __kind: EventRootType
-      ID: 333
-      Name: Probe[main.testSmallMap]
-      ByteSize: 9
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: m
-          Offset: 1
-          Expression:
-            Type: 83 GoMapType map[string]int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 58, index: 0, name: m}
-                  Offset: 0
-                  ByteSize: 8
-    - __kind: EventRootType
-      ID: 334
-      Name: Probe[main.testArrayOfMaps]
-      ByteSize: 17
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: m
-          Offset: 1
-          Expression:
-            Type: 118 ArrayType [2]map[string]int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 59, index: 0, name: m}
-                  Offset: 0
-                  ByteSize: 16
-    - __kind: EventRootType
-      ID: 335
-      Name: Probe[main.testPointerToMap]
-      ByteSize: 9
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: m
-          Offset: 1
-          Expression:
-            Type: 119 PointerType *map[string]int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 60, index: 0, name: m}
-                  Offset: 0
-                  ByteSize: 8
-    - __kind: EventRootType
-      ID: 336
-      Name: Probe[main.testMapIntToInt]
-      ByteSize: 9
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: m
-          Offset: 1
-          Expression:
-            Type: 59 GoMapType map[int]int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 61, index: 0, name: m}
-                  Offset: 0
-                  ByteSize: 8
-    - __kind: EventRootType
-      ID: 337
-      Name: Probe[main.testMapMassive]
-      ByteSize: 9
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: redactMyEntries
-          Offset: 1
-          Expression:
-            Type: 120 GoMapType map[string][]main.structWithMap
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 62, index: 0, name: redactMyEntries}
-                  Offset: 0
-                  ByteSize: 8
-    - __kind: EventRootType
-      ID: 338
-      Name: Probe[main.testMapEmbeddedMaps]
-      ByteSize: 9
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: m
-          Offset: 1
-          Expression:
-            Type: 120 GoMapType map[string][]main.structWithMap
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 63, index: 0, name: m}
+                  Variable: {subprogram: 54, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
@@ -6751,33 +4296,18 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 340
-      Name: Probe[main.testMapWithSmallValue]
+      ID: 343
+      Name: Probe[main.testMapWithSmallKeyAndValueMassive]
       ByteSize: 9
       PresenceBitsetSize: 1
       Expressions:
         - Name: m
           Offset: 1
           Expression:
-            Type: 146 GoMapType map[int]uint8
+            Type: 157 GoMapType map[uint8]uint8
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 65, index: 0, name: m}
-                  Offset: 0
-                  ByteSize: 8
-    - __kind: EventRootType
-      ID: 341
-      Name: Probe[main.testMapWithSmallValueMassive]
-      ByteSize: 9
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: redactMyEntries
-          Offset: 1
-          Expression:
-            Type: 146 GoMapType map[int]uint8
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 66, index: 0, name: redactMyEntries}
+                  Variable: {subprogram: 68, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
@@ -6796,113 +4326,50 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 343
-      Name: Probe[main.testMapWithSmallKeyAndValueMassive]
+      ID: 341
+      Name: Probe[main.testMapWithSmallValueMassive]
+      ByteSize: 9
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: redactMyEntries
+          Offset: 1
+          Expression:
+            Type: 146 GoMapType map[int]uint8
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 66, index: 0, name: redactMyEntries}
+                  Offset: 0
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 340
+      Name: Probe[main.testMapWithSmallValue]
       ByteSize: 9
       PresenceBitsetSize: 1
       Expressions:
         - Name: m
           Offset: 1
           Expression:
-            Type: 157 GoMapType map[uint8]uint8
+            Type: 146 GoMapType map[int]uint8
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 68, index: 0, name: m}
+                  Variable: {subprogram: 65, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 344
-      Name: Probe[main.testMapSmallKeySmallValue]
-      ByteSize: 9
+      ID: 375
+      Name: Probe[main.testMassiveString]
+      ByteSize: 17
       PresenceBitsetSize: 1
       Expressions:
-        - Name: m
-          Offset: 1
-          Expression:
-            Type: 157 GoMapType map[uint8]uint8
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 69, index: 0, name: m}
-                  Offset: 0
-                  ByteSize: 8
-    - __kind: EventRootType
-      ID: 345
-      Name: Probe[main.testMapSmallKeyLargeValue]
-      ByteSize: 9
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: m
-          Offset: 1
-          Expression:
-            Type: 168 GoMapType map[uint8][4]int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 70, index: 0, name: m}
-                  Offset: 0
-                  ByteSize: 8
-    - __kind: EventRootType
-      ID: 346
-      Name: Probe[main.testMapLargeKeySmallValue]
-      ByteSize: 9
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: m
-          Offset: 1
-          Expression:
-            Type: 180 GoMapType map[[4]int]uint8
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 71, index: 0, name: m}
-                  Offset: 0
-                  ByteSize: 8
-    - __kind: EventRootType
-      ID: 347
-      Name: Probe[main.testMapLargeKeyLargeValue]
-      ByteSize: 9
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: m
-          Offset: 1
-          Expression:
-            Type: 191 GoMapType map[[4]int][4]int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 72, index: 0, name: m}
-                  Offset: 0
-                  ByteSize: 8
-    - __kind: EventRootType
-      ID: 348
-      Name: Probe[main.testCombinedByte]
-      ByteSize: 7
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: w
-          Offset: 1
-          Expression:
-            Type: 4 BaseType uint8
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 73, index: 0, name: w}
-                  Offset: 0
-                  ByteSize: 1
         - Name: x
-          Offset: 2
+          Offset: 1
           Expression:
-            Type: 4 BaseType uint8
+            Type: 8 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 73, index: 1, name: x}
+                  Variable: {subprogram: 100, index: 0, name: x}
                   Offset: 0
-                  ByteSize: 1
-        - Name: y
-          Offset: 3
-          Expression:
-            Type: 30 BaseType float32
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 73, index: 2, name: y}
-                  Offset: 0
-                  ByteSize: 4
+                  ByteSize: 16
     - __kind: EventRootType
       ID: 349
       Name: Probe[main.testMultipleSimpleParams]
@@ -6955,111 +4422,6 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 350
-      Name: Probe[main.testChannel]
-      ByteSize: 1
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: c
-          Offset: 1
-          Expression:
-            Type: 202 GoChannelType chan bool
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 75, index: 0, name: c}
-                  Offset: 0
-                  ByteSize: 0
-    - __kind: EventRootType
-      ID: 351
-      Name: Probe[main.testPointerToSimpleStruct]
-      ByteSize: 9
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: a
-          Offset: 1
-          Expression:
-            Type: 203 PointerType *main.structWithTwoValues
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 76, index: 0, name: a}
-                  Offset: 0
-                  ByteSize: 8
-    - __kind: EventRootType
-      ID: 352
-      Name: Probe[main.testLinkedList]
-      ByteSize: 17
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: a
-          Offset: 1
-          Expression:
-            Type: 144 StructureType main.node
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 77, index: 0, name: a}
-                  Offset: 0
-                  ByteSize: 16
-    - __kind: EventRootType
-      ID: 353
-      Name: Probe[main.testPointerLoop]
-      ByteSize: 9
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: a
-          Offset: 1
-          Expression:
-            Type: 145 PointerType *main.node
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 78, index: 0, name: a}
-                  Offset: 0
-                  ByteSize: 8
-    - __kind: EventRootType
-      ID: 354
-      Name: Probe[main.testUnsafePointer]
-      ByteSize: 9
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: x
-          Offset: 1
-          Expression:
-            Type: 38 VoidPointerType unsafe.Pointer
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 79, index: 0, name: x}
-                  Offset: 0
-                  ByteSize: 8
-    - __kind: EventRootType
-      ID: 355
-      Name: Probe[main.testUintPointer]
-      ByteSize: 9
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: x
-          Offset: 1
-          Expression:
-            Type: 205 PointerType *uint
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 80, index: 0, name: x}
-                  Offset: 0
-                  ByteSize: 8
-    - __kind: EventRootType
-      ID: 356
-      Name: Probe[main.testStringPointer]
-      ByteSize: 9
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: z
-          Offset: 1
-          Expression:
-            Type: 36 PointerType *string
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 81, index: 0, name: z}
-                  Offset: 0
-                  ByteSize: 8
-    - __kind: EventRootType
       ID: 357
       Name: Probe[main.testNilPointer]
       ByteSize: 17
@@ -7081,114 +4443,6 @@ Types:
             Operations:
                 - __kind: LocationOp
                   Variable: {subprogram: 82, index: 1, name: a}
-                  Offset: 0
-                  ByteSize: 8
-    - __kind: EventRootType
-      ID: 358
-      Name: Probe[main.testCycle]
-      ByteSize: 9
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: t
-          Offset: 1
-          Expression:
-            Type: 207 PointerType *main.t
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 83, index: 0, name: t}
-                  Offset: 0
-                  ByteSize: 8
-    - __kind: EventRootType
-      ID: 359
-      Name: Probe[main.testUintSlice]
-      ByteSize: 25
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: u
-          Offset: 1
-          Expression:
-            Type: 210 GoSliceHeaderType []uint
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 84, index: 0, name: u}
-                  Offset: 0
-                  ByteSize: 24
-    - __kind: EventRootType
-      ID: 360
-      Name: Probe[main.testEmptySlice]
-      ByteSize: 25
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: u
-          Offset: 1
-          Expression:
-            Type: 210 GoSliceHeaderType []uint
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 85, index: 0, name: u}
-                  Offset: 0
-                  ByteSize: 24
-    - __kind: EventRootType
-      ID: 361
-      Name: Probe[main.testSliceOfSlices]
-      ByteSize: 25
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: u
-          Offset: 1
-          Expression:
-            Type: 211 GoSliceHeaderType [][]uint
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 86, index: 0, name: u}
-                  Offset: 0
-                  ByteSize: 24
-    - __kind: EventRootType
-      ID: 362
-      Name: Probe[main.testStructSlice]
-      ByteSize: 33
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: xs
-          Offset: 1
-          Expression:
-            Type: 213 GoSliceHeaderType []main.structWithNoStrings
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 87, index: 0, name: xs}
-                  Offset: 0
-                  ByteSize: 24
-        - Name: a
-          Offset: 25
-          Expression:
-            Type: 1 BaseType int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 87, index: 1, name: a}
-                  Offset: 0
-                  ByteSize: 8
-    - __kind: EventRootType
-      ID: 363
-      Name: Probe[main.testEmptySliceOfStructs]
-      ByteSize: 33
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: xs
-          Offset: 1
-          Expression:
-            Type: 213 GoSliceHeaderType []main.structWithNoStrings
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 88, index: 0, name: xs}
-                  Offset: 0
-                  ByteSize: 24
-        - Name: a
-          Offset: 25
-          Expression:
-            Type: 1 BaseType int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 88, index: 1, name: a}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
@@ -7215,21 +4469,6 @@ Types:
                   Variable: {subprogram: 89, index: 1, name: a}
                   Offset: 0
                   ByteSize: 8
-    - __kind: EventRootType
-      ID: 365
-      Name: Probe[main.testStringSlice]
-      ByteSize: 25
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: s
-          Offset: 1
-          Expression:
-            Type: 105 GoSliceHeaderType []string
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 90, index: 0, name: s}
-                  Offset: 0
-                  ByteSize: 24
     - __kind: EventRootType
       ID: 366
       Name: Probe[main.testNilSliceWithOtherParams]
@@ -7279,23 +4518,230 @@ Types:
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 368
-      Name: Probe[main.testVeryLargeSlice]
-      ByteSize: 25
+      ID: 374
+      Name: Probe[main.testOneStringInStructPointer]
+      ByteSize: 9
       PresenceBitsetSize: 1
       Expressions:
-        - Name: xs
+        - Name: a
           Offset: 1
           Expression:
-            Type: 210 GoSliceHeaderType []uint
+            Type: 221 PointerType *main.oneStringStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 93, index: 0, name: xs}
+                  Variable: {subprogram: 99, index: 0, name: a}
                   Offset: 0
-                  ByteSize: 24
+                  ByteSize: 8
     - __kind: EventRootType
-      ID: 369
-      Name: Probe[main.stackC]
+      ID: 353
+      Name: Probe[main.testPointerLoop]
+      ByteSize: 9
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: a
+          Offset: 1
+          Expression:
+            Type: 145 PointerType *main.node
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 78, index: 0, name: a}
+                  Offset: 0
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 335
+      Name: Probe[main.testPointerToMap]
+      ByteSize: 9
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: m
+          Offset: 1
+          Expression:
+            Type: 119 PointerType *map[string]int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 60, index: 0, name: m}
+                  Offset: 0
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 351
+      Name: Probe[main.testPointerToSimpleStruct]
+      ByteSize: 9
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: a
+          Offset: 1
+          Expression:
+            Type: 203 PointerType *main.structWithTwoValues
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 76, index: 0, name: a}
+                  Offset: 0
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 283
+      Name: Probe[main.testRuneArray]
+      ByteSize: 9
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: x
+          Offset: 1
+          Expression:
+            Type: 5 ArrayType [2]int32
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 8, index: 0, name: x}
+                  Offset: 0
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 302
+      Name: Probe[main.testSingleBool]
+      ByteSize: 2
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: x
+          Offset: 1
+          Expression:
+            Type: 11 BaseType bool
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 27, index: 0, name: x}
+                  Offset: 0
+                  ByteSize: 1
+    - __kind: EventRootType
+      ID: 300
+      Name: Probe[main.testSingleByte]
+      ByteSize: 2
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: x
+          Offset: 1
+          Expression:
+            Type: 4 BaseType uint8
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 25, index: 0, name: x}
+                  Offset: 0
+                  ByteSize: 1
+    - __kind: EventRootType
+      ID: 313
+      Name: Probe[main.testSingleFloat32]
+      ByteSize: 5
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: x
+          Offset: 1
+          Expression:
+            Type: 30 BaseType float32
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 38, index: 0, name: x}
+                  Offset: 0
+                  ByteSize: 4
+    - __kind: EventRootType
+      ID: 314
+      Name: Probe[main.testSingleFloat64]
+      ByteSize: 9
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: x
+          Offset: 1
+          Expression:
+            Type: 31 BaseType float64
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 39, index: 0, name: x}
+                  Offset: 0
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 305
+      Name: Probe[main.testSingleInt16]
+      ByteSize: 3
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: x
+          Offset: 1
+          Expression:
+            Type: 16 BaseType int16
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 30, index: 0, name: x}
+                  Offset: 0
+                  ByteSize: 2
+    - __kind: EventRootType
+      ID: 306
+      Name: Probe[main.testSingleInt32]
+      ByteSize: 5
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: x
+          Offset: 1
+          Expression:
+            Type: 6 BaseType int32
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 31, index: 0, name: x}
+                  Offset: 0
+                  ByteSize: 4
+    - __kind: EventRootType
+      ID: 307
+      Name: Probe[main.testSingleInt64]
+      ByteSize: 9
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: x
+          Offset: 1
+          Expression:
+            Type: 18 BaseType int64
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 32, index: 0, name: x}
+                  Offset: 0
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 304
+      Name: Probe[main.testSingleInt8]
+      ByteSize: 2
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: x
+          Offset: 1
+          Expression:
+            Type: 14 BaseType int8
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 29, index: 0, name: x}
+                  Offset: 0
+                  ByteSize: 1
+    - __kind: EventRootType
+      ID: 303
+      Name: Probe[main.testSingleInt]
+      ByteSize: 9
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: x
+          Offset: 1
+          Expression:
+            Type: 1 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 28, index: 0, name: x}
+                  Offset: 0
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 301
+      Name: Probe[main.testSingleRune]
+      ByteSize: 5
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: x
+          Offset: 1
+          Expression:
+            Type: 6 BaseType int32
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 26, index: 0, name: x}
+                  Offset: 0
+                  ByteSize: 4
     - __kind: EventRootType
       ID: 370
       Name: Probe[main.testSingleString]
@@ -7311,6 +4757,240 @@ Types:
                   Variable: {subprogram: 95, index: 0, name: x}
                   Offset: 0
                   ByteSize: 16
+    - __kind: EventRootType
+      ID: 310
+      Name: Probe[main.testSingleUint16]
+      ByteSize: 3
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: x
+          Offset: 1
+          Expression:
+            Type: 22 BaseType uint16
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 35, index: 0, name: x}
+                  Offset: 0
+                  ByteSize: 2
+    - __kind: EventRootType
+      ID: 311
+      Name: Probe[main.testSingleUint32]
+      ByteSize: 5
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: x
+          Offset: 1
+          Expression:
+            Type: 24 BaseType uint32
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 36, index: 0, name: x}
+                  Offset: 0
+                  ByteSize: 4
+    - __kind: EventRootType
+      ID: 312
+      Name: Probe[main.testSingleUint64]
+      ByteSize: 9
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: x
+          Offset: 1
+          Expression:
+            Type: 26 BaseType uint64
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 37, index: 0, name: x}
+                  Offset: 0
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 309
+      Name: Probe[main.testSingleUint8]
+      ByteSize: 2
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: x
+          Offset: 1
+          Expression:
+            Type: 4 BaseType uint8
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 34, index: 0, name: x}
+                  Offset: 0
+                  ByteSize: 1
+    - __kind: EventRootType
+      ID: 308
+      Name: Probe[main.testSingleUint]
+      ByteSize: 9
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: x
+          Offset: 1
+          Expression:
+            Type: 20 BaseType uint
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 33, index: 0, name: x}
+                  Offset: 0
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 361
+      Name: Probe[main.testSliceOfSlices]
+      ByteSize: 25
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: u
+          Offset: 1
+          Expression:
+            Type: 211 GoSliceHeaderType [][]uint
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 86, index: 0, name: u}
+                  Offset: 0
+                  ByteSize: 24
+    - __kind: EventRootType
+      ID: 333
+      Name: Probe[main.testSmallMap]
+      ByteSize: 9
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: m
+          Offset: 1
+          Expression:
+            Type: 83 GoMapType map[string]int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 58, index: 0, name: m}
+                  Offset: 0
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 284
+      Name: Probe[main.testStringArray]
+      ByteSize: 33
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: x
+          Offset: 1
+          Expression:
+            Type: 7 ArrayType [2]string
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 9, index: 0, name: x}
+                  Offset: 0
+                  ByteSize: 32
+    - __kind: EventRootType
+      ID: 356
+      Name: Probe[main.testStringPointer]
+      ByteSize: 9
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: z
+          Offset: 1
+          Expression:
+            Type: 36 PointerType *string
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 81, index: 0, name: z}
+                  Offset: 0
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 365
+      Name: Probe[main.testStringSlice]
+      ByteSize: 25
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: s
+          Offset: 1
+          Expression:
+            Type: 105 GoSliceHeaderType []string
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 90, index: 0, name: s}
+                  Offset: 0
+                  ByteSize: 24
+    - __kind: EventRootType
+      ID: 362
+      Name: Probe[main.testStructSlice]
+      ByteSize: 33
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: xs
+          Offset: 1
+          Expression:
+            Type: 213 GoSliceHeaderType []main.structWithNoStrings
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 87, index: 0, name: xs}
+                  Offset: 0
+                  ByteSize: 24
+        - Name: a
+          Offset: 25
+          Expression:
+            Type: 1 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 87, index: 1, name: a}
+                  Offset: 0
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 328
+      Name: Probe[main.testStructWithMap]
+      ByteSize: 9
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: s
+          Offset: 1
+          Expression:
+            Type: 58 StructureType main.structWithMap
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 53, index: 0, name: s}
+                  Offset: 0
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 378
+      Name: Probe[main.testStruct]
+      ByteSize: 57
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: x
+          Offset: 1
+          Expression:
+            Type: 223 StructureType main.aStruct
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 103, index: 0, name: x}
+                  Offset: 0
+                  ByteSize: 56
+    - __kind: EventRootType
+      ID: 373
+      Name: Probe[main.testThreeStringsInStructPointer]
+      ByteSize: 9
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: a
+          Offset: 1
+          Expression:
+            Type: 220 PointerType *main.threeStringStruct
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 98, index: 0, name: a}
+                  Offset: 0
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 372
+      Name: Probe[main.testThreeStringsInStruct]
+      ByteSize: 49
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: a
+          Offset: 1
+          Expression:
+            Type: 219 StructureType main.threeStringStruct
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 97, index: 0, name: a}
+                  Offset: 0
+                  ByteSize: 48
     - __kind: EventRootType
       ID: 371
       Name: Probe[main.testThreeStrings]
@@ -7345,65 +5025,125 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 372
-      Name: Probe[main.testThreeStringsInStruct]
-      ByteSize: 49
+      ID: 315
+      Name: Probe[main.testTypeAlias]
+      ByteSize: 3
       PresenceBitsetSize: 1
       Expressions:
-        - Name: a
+        - Name: x
           Offset: 1
           Expression:
-            Type: 219 StructureType main.threeStringStruct
+            Type: 32 BaseType main.typeAlias
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 97, index: 0, name: a}
+                  Variable: {subprogram: 40, index: 0, name: x}
                   Offset: 0
-                  ByteSize: 48
+                  ByteSize: 2
     - __kind: EventRootType
-      ID: 373
-      Name: Probe[main.testThreeStringsInStructPointer]
+      ID: 293
+      Name: Probe[main.testUint16Array]
+      ByteSize: 5
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: x
+          Offset: 1
+          Expression:
+            Type: 21 ArrayType [2]uint16
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 18, index: 0, name: x}
+                  Offset: 0
+                  ByteSize: 4
+    - __kind: EventRootType
+      ID: 294
+      Name: Probe[main.testUint32Array]
       ByteSize: 9
       PresenceBitsetSize: 1
       Expressions:
-        - Name: a
+        - Name: x
           Offset: 1
           Expression:
-            Type: 220 PointerType *main.threeStringStruct
+            Type: 23 ArrayType [2]uint32
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 98, index: 0, name: a}
+                  Variable: {subprogram: 19, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 374
-      Name: Probe[main.testOneStringInStructPointer]
-      ByteSize: 9
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: a
-          Offset: 1
-          Expression:
-            Type: 221 PointerType *main.oneStringStruct
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 99, index: 0, name: a}
-                  Offset: 0
-                  ByteSize: 8
-    - __kind: EventRootType
-      ID: 375
-      Name: Probe[main.testMassiveString]
+      ID: 295
+      Name: Probe[main.testUint64Array]
       ByteSize: 17
       PresenceBitsetSize: 1
       Expressions:
         - Name: x
           Offset: 1
           Expression:
-            Type: 8 GoStringHeaderType string
+            Type: 25 ArrayType [2]uint64
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 100, index: 0, name: x}
+                  Variable: {subprogram: 20, index: 0, name: x}
                   Offset: 0
                   ByteSize: 16
+    - __kind: EventRootType
+      ID: 292
+      Name: Probe[main.testUint8Array]
+      ByteSize: 3
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: x
+          Offset: 1
+          Expression:
+            Type: 3 ArrayType [2]uint8
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 17, index: 0, name: x}
+                  Offset: 0
+                  ByteSize: 2
+    - __kind: EventRootType
+      ID: 291
+      Name: Probe[main.testUintArray]
+      ByteSize: 17
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: x
+          Offset: 1
+          Expression:
+            Type: 19 ArrayType [2]uint
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 16, index: 0, name: x}
+                  Offset: 0
+                  ByteSize: 16
+    - __kind: EventRootType
+      ID: 355
+      Name: Probe[main.testUintPointer]
+      ByteSize: 9
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: x
+          Offset: 1
+          Expression:
+            Type: 205 PointerType *uint
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 80, index: 0, name: x}
+                  Offset: 0
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 359
+      Name: Probe[main.testUintSlice]
+      ByteSize: 25
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: u
+          Offset: 1
+          Expression:
+            Type: 210 GoSliceHeaderType []uint
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 84, index: 0, name: u}
+                  Offset: 0
+                  ByteSize: 24
     - __kind: EventRootType
       ID: 376
       Name: Probe[main.testUnitializedString]
@@ -7420,104 +5160,2364 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 377
-      Name: Probe[main.testEmptyString]
-      ByteSize: 17
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: x
-          Offset: 1
-          Expression:
-            Type: 8 GoStringHeaderType string
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 102, index: 0, name: x}
-                  Offset: 0
-                  ByteSize: 16
-    - __kind: EventRootType
-      ID: 378
-      Name: Probe[main.testStruct]
-      ByteSize: 57
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: x
-          Offset: 1
-          Expression:
-            Type: 223 StructureType main.aStruct
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 103, index: 0, name: x}
-                  Offset: 0
-                  ByteSize: 56
-    - __kind: EventRootType
-      ID: 379
-      Name: Probe[main.testEmptyStruct]
-      ByteSize: 1
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: e
-          Offset: 1
-          Expression:
-            Type: 224 StructureType main.emptyStruct
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 104, index: 0, name: e}
-                  Offset: 0
-                  ByteSize: 0
-    - __kind: EventRootType
-      ID: 380
-      Name: Probe[main.testInlinedPrint]
+      ID: 354
+      Name: Probe[main.testUnsafePointer]
       ByteSize: 9
       PresenceBitsetSize: 1
       Expressions:
         - Name: x
           Offset: 1
           Expression:
-            Type: 1 BaseType int
+            Type: 38 VoidPointerType unsafe.Pointer
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 1, index: 0, name: x}
+                  Variable: {subprogram: 79, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 381
-      Name: Probe[main.testInlinedBBB]
-    - __kind: EventRootType
-      ID: 382
-      Name: Probe[main.testInlinedBCA]
-    - __kind: EventRootType
-      ID: 383
-      Name: Probe[main.testInlinedBCB]
-    - __kind: EventRootType
-      ID: 384
-      Name: Probe[main.testInlinedSq]
-      ByteSize: 9
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: x
-          Offset: 1
-          Expression:
-            Type: 1 BaseType int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 5, index: 0, name: x}
-                  Offset: 0
-                  ByteSize: 8
-    - __kind: EventRootType
-      ID: 385
-      Name: Probe[main.testInlinedSumArray]
-      ByteSize: 41
+      ID: 299
+      Name: Probe[main.testVeryLargeArray]
+      ByteSize: 801
       PresenceBitsetSize: 1
       Expressions:
         - Name: a
           Offset: 1
           Expression:
-            Type: 2 ArrayType [5]int
+            Type: 29 ArrayType [100]uint
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 6, index: 0, name: a}
+                  Variable: {subprogram: 24, index: 0, name: a}
                   Offset: 0
-                  ByteSize: 40
+                  ByteSize: 800
+    - __kind: EventRootType
+      ID: 368
+      Name: Probe[main.testVeryLargeSlice]
+      ByteSize: 25
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: xs
+          Offset: 1
+          Expression:
+            Type: 210 GoSliceHeaderType []uint
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 93, index: 0, name: xs}
+                  Offset: 0
+                  ByteSize: 24
+    - __kind: ArrayType
+      ID: 29
+      Name: '[100]uint'
+      ByteSize: 800
+      GoKind: 17
+      Count: 100
+      HasCount: true
+      Element: 20 BaseType uint
+    - __kind: ArrayType
+      ID: 28
+      Name: '[2][2][2]int'
+      ByteSize: 64
+      GoKind: 17
+      Count: 2
+      HasCount: true
+      Element: 27 ArrayType [2][2]int
+    - __kind: ArrayType
+      ID: 27
+      Name: '[2][2]int'
+      ByteSize: 32
+      GoKind: 17
+      Count: 2
+      HasCount: true
+      Element: 12 ArrayType [2]int
+    - __kind: ArrayType
+      ID: 10
+      Name: '[2]bool'
+      ByteSize: 2
+      GoKind: 17
+      Count: 2
+      HasCount: true
+      Element: 11 BaseType bool
+    - __kind: ArrayType
+      ID: 12
+      Name: '[2]int'
+      ByteSize: 16
+      GoRuntimeType: 673280
+      GoKind: 17
+      Count: 2
+      HasCount: true
+      Element: 1 BaseType int
+    - __kind: ArrayType
+      ID: 15
+      Name: '[2]int16'
+      ByteSize: 4
+      GoKind: 17
+      Count: 2
+      HasCount: true
+      Element: 16 BaseType int16
+    - __kind: ArrayType
+      ID: 5
+      Name: '[2]int32'
+      ByteSize: 8
+      GoRuntimeType: 674624
+      GoKind: 17
+      Count: 2
+      HasCount: true
+      Element: 6 BaseType int32
+    - __kind: ArrayType
+      ID: 17
+      Name: '[2]int64'
+      ByteSize: 16
+      GoKind: 17
+      Count: 2
+      HasCount: true
+      Element: 18 BaseType int64
+    - __kind: ArrayType
+      ID: 13
+      Name: '[2]int8'
+      ByteSize: 2
+      GoKind: 17
+      Count: 2
+      HasCount: true
+      Element: 14 BaseType int8
+    - __kind: ArrayType
+      ID: 118
+      Name: '[2]map[string]int'
+      ByteSize: 16
+      GoKind: 17
+      Count: 2
+      HasCount: true
+      Element: 83 GoMapType map[string]int
+    - __kind: ArrayType
+      ID: 7
+      Name: '[2]string'
+      ByteSize: 32
+      GoRuntimeType: 674720
+      GoKind: 17
+      Count: 2
+      HasCount: true
+      Element: 8 GoStringHeaderType string
+    - __kind: ArrayType
+      ID: 19
+      Name: '[2]uint'
+      ByteSize: 16
+      GoKind: 17
+      Count: 2
+      HasCount: true
+      Element: 20 BaseType uint
+    - __kind: ArrayType
+      ID: 21
+      Name: '[2]uint16'
+      ByteSize: 4
+      GoKind: 17
+      Count: 2
+      HasCount: true
+      Element: 22 BaseType uint16
+    - __kind: ArrayType
+      ID: 23
+      Name: '[2]uint32'
+      ByteSize: 8
+      GoKind: 17
+      Count: 2
+      HasCount: true
+      Element: 24 BaseType uint32
+    - __kind: ArrayType
+      ID: 25
+      Name: '[2]uint64'
+      ByteSize: 16
+      GoRuntimeType: 674816
+      GoKind: 17
+      Count: 2
+      HasCount: true
+      Element: 26 BaseType uint64
+    - __kind: ArrayType
+      ID: 3
+      Name: '[2]uint8'
+      ByteSize: 2
+      GoRuntimeType: 674528
+      GoKind: 17
+      Count: 2
+      HasCount: true
+      Element: 4 BaseType uint8
+    - __kind: ArrayType
+      ID: 179
+      Name: '[4]int'
+      ByteSize: 32
+      GoRuntimeType: 672896
+      GoKind: 17
+      Count: 4
+      HasCount: true
+      Element: 1 BaseType int
+    - __kind: ArrayType
+      ID: 117
+      Name: '[4]string'
+      ByteSize: 64
+      GoRuntimeType: 673184
+      GoKind: 17
+      Count: 4
+      HasCount: true
+      Element: 8 GoStringHeaderType string
+    - __kind: ArrayType
+      ID: 2
+      Name: '[5]int'
+      ByteSize: 40
+      GoKind: 17
+      Count: 5
+      HasCount: true
+      Element: 1 BaseType int
+    - __kind: GoSliceHeaderType
+      ID: 34
+      Name: '[]*string'
+      ByteSize: 24
+      GoRuntimeType: 470656
+      GoKind: 23
+      RawFields:
+        - Name: array
+          Offset: 0
+          Type: 35 PointerType **string
+        - Name: len
+          Offset: 8
+          Type: 1 BaseType int
+        - Name: cap
+          Offset: 16
+          Type: 1 BaseType int
+      Data: 240 GoSliceDataType []*string.array
+    - __kind: GoSliceDataType
+      ID: 240
+      Name: '[]*string.array'
+      ByteSize: 2048
+      Element: 36 PointerType *string
+    - __kind: GoSliceDataType
+      ID: 268
+      Name: '[]*table<[4]int,[4]int>.array'
+      ByteSize: 8192
+      Element: 195 PointerType *table<[4]int,[4]int>
+    - __kind: GoSliceDataType
+      ID: 266
+      Name: '[]*table<[4]int,uint8>.array'
+      ByteSize: 8192
+      Element: 184 PointerType *table<[4]int,uint8>
+    - __kind: GoSliceDataType
+      ID: 252
+      Name: '[]*table<[4]string,[2]int>.array'
+      ByteSize: 8192
+      Element: 110 PointerType *table<[4]string,[2]int>
+    - __kind: GoSliceDataType
+      ID: 258
+      Name: '[]*table<bool,main.node>.array'
+      ByteSize: 8192
+      Element: 137 PointerType *table<bool,main.node>
+    - __kind: GoSliceDataType
+      ID: 242
+      Name: '[]*table<int,int>.array'
+      ByteSize: 8192
+      Element: 64 PointerType *table<int,int>
+    - __kind: GoSliceDataType
+      ID: 260
+      Name: '[]*table<int,uint8>.array'
+      ByteSize: 8192
+      Element: 150 PointerType *table<int,uint8>
+    - __kind: GoSliceDataType
+      ID: 254
+      Name: '[]*table<string,[]main.structWithMap>.array'
+      ByteSize: 8192
+      Element: 124 PointerType *table<string,[]main.structWithMap>
+    - __kind: GoSliceDataType
+      ID: 248
+      Name: '[]*table<string,[]string>.array'
+      ByteSize: 8192
+      Element: 98 PointerType *table<string,[]string>
+    - __kind: GoSliceDataType
+      ID: 246
+      Name: '[]*table<string,int>.array'
+      ByteSize: 8192
+      Element: 87 PointerType *table<string,int>
+    - __kind: GoSliceDataType
+      ID: 244
+      Name: '[]*table<string,main.nestedStruct>.array'
+      ByteSize: 8192
+      Element: 75 PointerType *table<string,main.nestedStruct>
+    - __kind: GoSliceDataType
+      ID: 264
+      Name: '[]*table<uint8,[4]int>.array'
+      ByteSize: 8192
+      Element: 172 PointerType *table<uint8,[4]int>
+    - __kind: GoSliceDataType
+      ID: 262
+      Name: '[]*table<uint8,uint8>.array'
+      ByteSize: 8192
+      Element: 161 PointerType *table<uint8,uint8>
+    - __kind: GoSliceHeaderType
+      ID: 211
+      Name: '[][]uint'
+      ByteSize: 24
+      GoKind: 23
+      RawFields:
+        - Name: array
+          Offset: 0
+          Type: 212 PointerType *[]uint
+        - Name: len
+          Offset: 8
+          Type: 1 BaseType int
+        - Name: cap
+          Offset: 16
+          Type: 1 BaseType int
+      Data: 274 GoSliceDataType [][]uint.array
+    - __kind: GoSliceDataType
+      ID: 274
+      Name: '[][]uint.array'
+      ByteSize: 2048
+      Element: 210 GoSliceHeaderType []uint
+    - __kind: GoSliceHeaderType
+      ID: 216
+      Name: '[]bool'
+      ByteSize: 24
+      GoRuntimeType: 478528
+      GoKind: 23
+      RawFields:
+        - Name: array
+          Offset: 0
+          Type: 206 PointerType *bool
+        - Name: len
+          Offset: 8
+          Type: 1 BaseType int
+        - Name: cap
+          Offset: 16
+          Type: 1 BaseType int
+      Data: 278 GoSliceDataType []bool.array
+    - __kind: GoSliceDataType
+      ID: 278
+      Name: '[]bool.array'
+      ByteSize: 2048
+      Element: 11 BaseType bool
+    - __kind: GoSliceHeaderType
+      ID: 131
+      Name: '[]main.structWithMap'
+      ByteSize: 24
+      GoRuntimeType: 469888
+      GoKind: 23
+      RawFields:
+        - Name: array
+          Offset: 0
+          Type: 132 PointerType *main.structWithMap
+        - Name: len
+          Offset: 8
+          Type: 1 BaseType int
+        - Name: cap
+          Offset: 16
+          Type: 1 BaseType int
+      Data: 256 GoSliceDataType []main.structWithMap.array
+    - __kind: GoSliceDataType
+      ID: 256
+      Name: '[]main.structWithMap.array'
+      ByteSize: 2048
+      Element: 58 StructureType main.structWithMap
+    - __kind: GoSliceHeaderType
+      ID: 213
+      Name: '[]main.structWithNoStrings'
+      ByteSize: 24
+      GoKind: 23
+      RawFields:
+        - Name: array
+          Offset: 0
+          Type: 214 PointerType *main.structWithNoStrings
+        - Name: len
+          Offset: 8
+          Type: 1 BaseType int
+        - Name: cap
+          Offset: 16
+          Type: 1 BaseType int
+      Data: 276 GoSliceDataType []main.structWithNoStrings.array
+    - __kind: GoSliceDataType
+      ID: 276
+      Name: '[]main.structWithNoStrings.array'
+      ByteSize: 2048
+      Element: 215 StructureType main.structWithNoStrings
+    - __kind: GoSliceDataType
+      ID: 269
+      Name: '[]noalg.map.group[[4]int][4]int.array'
+      ByteSize: 2048
+      Element: 199 StructureType noalg.map.group[[4]int][4]int
+    - __kind: GoSliceDataType
+      ID: 267
+      Name: '[]noalg.map.group[[4]int]uint8.array'
+      ByteSize: 2048
+      Element: 188 StructureType noalg.map.group[[4]int]uint8
+    - __kind: GoSliceDataType
+      ID: 253
+      Name: '[]noalg.map.group[[4]string][2]int.array'
+      ByteSize: 2048
+      Element: 114 StructureType noalg.map.group[[4]string][2]int
+    - __kind: GoSliceDataType
+      ID: 259
+      Name: '[]noalg.map.group[bool]main.node.array'
+      ByteSize: 2048
+      Element: 141 StructureType noalg.map.group[bool]main.node
+    - __kind: GoSliceDataType
+      ID: 243
+      Name: '[]noalg.map.group[int]int.array'
+      ByteSize: 2048
+      Element: 68 StructureType noalg.map.group[int]int
+    - __kind: GoSliceDataType
+      ID: 261
+      Name: '[]noalg.map.group[int]uint8.array'
+      ByteSize: 2048
+      Element: 154 StructureType noalg.map.group[int]uint8
+    - __kind: GoSliceDataType
+      ID: 255
+      Name: '[]noalg.map.group[string][]main.structWithMap.array'
+      ByteSize: 2048
+      Element: 128 StructureType noalg.map.group[string][]main.structWithMap
+    - __kind: GoSliceDataType
+      ID: 249
+      Name: '[]noalg.map.group[string][]string.array'
+      ByteSize: 2048
+      Element: 102 StructureType noalg.map.group[string][]string
+    - __kind: GoSliceDataType
+      ID: 247
+      Name: '[]noalg.map.group[string]int.array'
+      ByteSize: 2048
+      Element: 91 StructureType noalg.map.group[string]int
+    - __kind: GoSliceDataType
+      ID: 245
+      Name: '[]noalg.map.group[string]main.nestedStruct.array'
+      ByteSize: 2048
+      Element: 79 StructureType noalg.map.group[string]main.nestedStruct
+    - __kind: GoSliceDataType
+      ID: 265
+      Name: '[]noalg.map.group[uint8][4]int.array'
+      ByteSize: 2048
+      Element: 176 StructureType noalg.map.group[uint8][4]int
+    - __kind: GoSliceDataType
+      ID: 263
+      Name: '[]noalg.map.group[uint8]uint8.array'
+      ByteSize: 2048
+      Element: 165 StructureType noalg.map.group[uint8]uint8
+    - __kind: GoSliceHeaderType
+      ID: 105
+      Name: '[]string'
+      ByteSize: 24
+      GoRuntimeType: 478656
+      GoKind: 23
+      RawFields:
+        - Name: array
+          Offset: 0
+          Type: 36 PointerType *string
+        - Name: len
+          Offset: 8
+          Type: 1 BaseType int
+        - Name: cap
+          Offset: 16
+          Type: 1 BaseType int
+      Data: 250 GoSliceDataType []string.array
+    - __kind: GoSliceDataType
+      ID: 250
+      Name: '[]string.array'
+      ByteSize: 2048
+      Element: 8 GoStringHeaderType string
+    - __kind: GoSliceHeaderType
+      ID: 210
+      Name: '[]uint'
+      ByteSize: 24
+      GoRuntimeType: 478144
+      GoKind: 23
+      RawFields:
+        - Name: array
+          Offset: 0
+          Type: 205 PointerType *uint
+        - Name: len
+          Offset: 8
+          Type: 1 BaseType int
+        - Name: cap
+          Offset: 16
+          Type: 1 BaseType int
+      Data: 272 GoSliceDataType []uint.array
+    - __kind: GoSliceDataType
+      ID: 272
+      Name: '[]uint.array'
+      ByteSize: 2048
+      Element: 20 BaseType uint
+    - __kind: GoSliceHeaderType
+      ID: 217
+      Name: '[]uint16'
+      ByteSize: 24
+      GoRuntimeType: 477504
+      GoKind: 23
+      RawFields:
+        - Name: array
+          Offset: 0
+          Type: 218 PointerType *uint16
+        - Name: len
+          Offset: 8
+          Type: 1 BaseType int
+        - Name: cap
+          Offset: 16
+          Type: 1 BaseType int
+      Data: 280 GoSliceDataType []uint16.array
+    - __kind: GoSliceDataType
+      ID: 280
+      Name: '[]uint16.array'
+      ByteSize: 2048
+      Element: 22 BaseType uint16
+    - __kind: BaseType
+      ID: 11
+      Name: bool
+      ByteSize: 1
+      GoRuntimeType: 576032
+      GoKind: 1
+    - __kind: GoChannelType
+      ID: 202
+      Name: chan bool
+      GoRuntimeType: 587360
+      GoKind: 18
+    - __kind: GoChannelType
+      ID: 40
+      Name: chan struct {}
+      GoRuntimeType: 586272
+      GoKind: 18
+    - __kind: BaseType
+      ID: 229
+      Name: complex128
+      ByteSize: 16
+      GoRuntimeType: 575840
+      GoKind: 16
+    - __kind: BaseType
+      ID: 228
+      Name: complex64
+      ByteSize: 8
+      GoRuntimeType: 575776
+      GoKind: 15
+    - __kind: GoInterfaceType
+      ID: 57
+      Name: error
+      ByteSize: 16
+      GoRuntimeType: 1.016416e+06
+      GoKind: 20
+      RawFields:
+        - Name: tab
+          Offset: 0
+          Type: 38 VoidPointerType unsafe.Pointer
+        - Name: data
+          Offset: 8
+          Type: 38 VoidPointerType unsafe.Pointer
+    - __kind: BaseType
+      ID: 30
+      Name: float32
+      ByteSize: 4
+      GoRuntimeType: 575904
+      GoKind: 13
+    - __kind: BaseType
+      ID: 31
+      Name: float64
+      ByteSize: 8
+      GoRuntimeType: 575968
+      GoKind: 14
+    - __kind: GoSubroutineType
+      ID: 43
+      Name: func()
+      ByteSize: 8
+      GoRuntimeType: 468928
+      GoKind: 19
+    - __kind: GoSwissMapGroupsType
+      ID: 197
+      Name: groupReference<[4]int,[4]int>
+      ByteSize: 16
+      GoKind: 25
+      RawFields:
+        - Name: data
+          Offset: 0
+          Type: 198 PointerType *noalg.map.group[[4]int][4]int
+        - Name: lengthMask
+          Offset: 8
+          Type: 26 BaseType uint64
+      GroupType: 199 StructureType noalg.map.group[[4]int][4]int
+      GroupSliceType: 269 GoSliceDataType []noalg.map.group[[4]int][4]int.array
+    - __kind: GoSwissMapGroupsType
+      ID: 186
+      Name: groupReference<[4]int,uint8>
+      ByteSize: 16
+      GoKind: 25
+      RawFields:
+        - Name: data
+          Offset: 0
+          Type: 187 PointerType *noalg.map.group[[4]int]uint8
+        - Name: lengthMask
+          Offset: 8
+          Type: 26 BaseType uint64
+      GroupType: 188 StructureType noalg.map.group[[4]int]uint8
+      GroupSliceType: 267 GoSliceDataType []noalg.map.group[[4]int]uint8.array
+    - __kind: GoSwissMapGroupsType
+      ID: 112
+      Name: groupReference<[4]string,[2]int>
+      ByteSize: 16
+      GoKind: 25
+      RawFields:
+        - Name: data
+          Offset: 0
+          Type: 113 PointerType *noalg.map.group[[4]string][2]int
+        - Name: lengthMask
+          Offset: 8
+          Type: 26 BaseType uint64
+      GroupType: 114 StructureType noalg.map.group[[4]string][2]int
+      GroupSliceType: 253 GoSliceDataType []noalg.map.group[[4]string][2]int.array
+    - __kind: GoSwissMapGroupsType
+      ID: 139
+      Name: groupReference<bool,main.node>
+      ByteSize: 16
+      GoKind: 25
+      RawFields:
+        - Name: data
+          Offset: 0
+          Type: 140 PointerType *noalg.map.group[bool]main.node
+        - Name: lengthMask
+          Offset: 8
+          Type: 26 BaseType uint64
+      GroupType: 141 StructureType noalg.map.group[bool]main.node
+      GroupSliceType: 259 GoSliceDataType []noalg.map.group[bool]main.node.array
+    - __kind: GoSwissMapGroupsType
+      ID: 66
+      Name: groupReference<int,int>
+      ByteSize: 16
+      GoKind: 25
+      RawFields:
+        - Name: data
+          Offset: 0
+          Type: 67 PointerType *noalg.map.group[int]int
+        - Name: lengthMask
+          Offset: 8
+          Type: 26 BaseType uint64
+      GroupType: 68 StructureType noalg.map.group[int]int
+      GroupSliceType: 243 GoSliceDataType []noalg.map.group[int]int.array
+    - __kind: GoSwissMapGroupsType
+      ID: 152
+      Name: groupReference<int,uint8>
+      ByteSize: 16
+      GoKind: 25
+      RawFields:
+        - Name: data
+          Offset: 0
+          Type: 153 PointerType *noalg.map.group[int]uint8
+        - Name: lengthMask
+          Offset: 8
+          Type: 26 BaseType uint64
+      GroupType: 154 StructureType noalg.map.group[int]uint8
+      GroupSliceType: 261 GoSliceDataType []noalg.map.group[int]uint8.array
+    - __kind: GoSwissMapGroupsType
+      ID: 126
+      Name: groupReference<string,[]main.structWithMap>
+      ByteSize: 16
+      GoKind: 25
+      RawFields:
+        - Name: data
+          Offset: 0
+          Type: 127 PointerType *noalg.map.group[string][]main.structWithMap
+        - Name: lengthMask
+          Offset: 8
+          Type: 26 BaseType uint64
+      GroupType: 128 StructureType noalg.map.group[string][]main.structWithMap
+      GroupSliceType: 255 GoSliceDataType []noalg.map.group[string][]main.structWithMap.array
+    - __kind: GoSwissMapGroupsType
+      ID: 100
+      Name: groupReference<string,[]string>
+      ByteSize: 16
+      GoKind: 25
+      RawFields:
+        - Name: data
+          Offset: 0
+          Type: 101 PointerType *noalg.map.group[string][]string
+        - Name: lengthMask
+          Offset: 8
+          Type: 26 BaseType uint64
+      GroupType: 102 StructureType noalg.map.group[string][]string
+      GroupSliceType: 249 GoSliceDataType []noalg.map.group[string][]string.array
+    - __kind: GoSwissMapGroupsType
+      ID: 89
+      Name: groupReference<string,int>
+      ByteSize: 16
+      GoKind: 25
+      RawFields:
+        - Name: data
+          Offset: 0
+          Type: 90 PointerType *noalg.map.group[string]int
+        - Name: lengthMask
+          Offset: 8
+          Type: 26 BaseType uint64
+      GroupType: 91 StructureType noalg.map.group[string]int
+      GroupSliceType: 247 GoSliceDataType []noalg.map.group[string]int.array
+    - __kind: GoSwissMapGroupsType
+      ID: 77
+      Name: groupReference<string,main.nestedStruct>
+      ByteSize: 16
+      GoKind: 25
+      RawFields:
+        - Name: data
+          Offset: 0
+          Type: 78 PointerType *noalg.map.group[string]main.nestedStruct
+        - Name: lengthMask
+          Offset: 8
+          Type: 26 BaseType uint64
+      GroupType: 79 StructureType noalg.map.group[string]main.nestedStruct
+      GroupSliceType: 245 GoSliceDataType []noalg.map.group[string]main.nestedStruct.array
+    - __kind: GoSwissMapGroupsType
+      ID: 174
+      Name: groupReference<uint8,[4]int>
+      ByteSize: 16
+      GoKind: 25
+      RawFields:
+        - Name: data
+          Offset: 0
+          Type: 175 PointerType *noalg.map.group[uint8][4]int
+        - Name: lengthMask
+          Offset: 8
+          Type: 26 BaseType uint64
+      GroupType: 176 StructureType noalg.map.group[uint8][4]int
+      GroupSliceType: 265 GoSliceDataType []noalg.map.group[uint8][4]int.array
+    - __kind: GoSwissMapGroupsType
+      ID: 163
+      Name: groupReference<uint8,uint8>
+      ByteSize: 16
+      GoKind: 25
+      RawFields:
+        - Name: data
+          Offset: 0
+          Type: 164 PointerType *noalg.map.group[uint8]uint8
+        - Name: lengthMask
+          Offset: 8
+          Type: 26 BaseType uint64
+      GroupType: 165 StructureType noalg.map.group[uint8]uint8
+      GroupSliceType: 263 GoSliceDataType []noalg.map.group[uint8]uint8.array
+    - __kind: BaseType
+      ID: 1
+      Name: int
+      ByteSize: 8
+      GoRuntimeType: 575584
+      GoKind: 2
+    - __kind: BaseType
+      ID: 16
+      Name: int16
+      ByteSize: 2
+      GoRuntimeType: 575200
+      GoKind: 4
+    - __kind: BaseType
+      ID: 6
+      Name: int32
+      ByteSize: 4
+      GoRuntimeType: 575328
+      GoKind: 5
+    - __kind: BaseType
+      ID: 18
+      Name: int64
+      ByteSize: 8
+      GoRuntimeType: 575456
+      GoKind: 6
+    - __kind: BaseType
+      ID: 14
+      Name: int8
+      ByteSize: 1
+      GoRuntimeType: 575072
+      GoKind: 3
+    - __kind: GoEmptyInterfaceType
+      ID: 41
+      Name: interface {}
+      ByteSize: 16
+      GoRuntimeType: 838336
+      GoKind: 20
+      RawFields:
+        - Name: _type
+          Offset: 0
+          Type: 38 VoidPointerType unsafe.Pointer
+        - Name: data
+          Offset: 8
+          Type: 38 VoidPointerType unsafe.Pointer
+    - __kind: StructureType
+      ID: 48
+      Name: internal/sync.Mutex
+      ByteSize: 8
+      GoRuntimeType: 1.454624e+06
+      GoKind: 25
+      RawFields:
+        - Name: state
+          Offset: 0
+          Type: 6 BaseType int32
+        - Name: sema
+          Offset: 4
+          Type: 24 BaseType uint32
+    - __kind: GoInterfaceType
+      ID: 37
+      Name: io.Writer
+      ByteSize: 16
+      GoRuntimeType: 1.012448e+06
+      GoKind: 20
+      RawFields:
+        - Name: tab
+          Offset: 0
+          Type: 38 VoidPointerType unsafe.Pointer
+        - Name: data
+          Offset: 8
+          Type: 38 VoidPointerType unsafe.Pointer
+    - __kind: StructureType
+      ID: 223
+      Name: main.aStruct
+      ByteSize: 56
+      GoKind: 25
+      RawFields:
+        - Name: aBool
+          Offset: 0
+          Type: 11 BaseType bool
+        - Name: aString
+          Offset: 8
+          Type: 8 GoStringHeaderType string
+        - Name: aNumber
+          Offset: 24
+          Type: 1 BaseType int
+        - Name: nested
+          Offset: 32
+          Type: 82 StructureType main.nestedStruct
+    - __kind: GoInterfaceType
+      ID: 56
+      Name: main.behavior
+      ByteSize: 16
+      GoRuntimeType: 1.012064e+06
+      GoKind: 20
+      RawFields:
+        - Name: tab
+          Offset: 0
+          Type: 38 VoidPointerType unsafe.Pointer
+        - Name: data
+          Offset: 8
+          Type: 38 VoidPointerType unsafe.Pointer
+    - __kind: StructureType
+      ID: 33
+      Name: main.bigStruct
+      ByteSize: 48
+      GoKind: 25
+      RawFields:
+        - Name: x
+          Offset: 0
+          Type: 34 GoSliceHeaderType []*string
+        - Name: z
+          Offset: 24
+          Type: 1 BaseType int
+        - Name: writer
+          Offset: 32
+          Type: 37 GoInterfaceType io.Writer
+    - __kind: StructureType
+      ID: 224
+      Name: main.emptyStruct
+      GoKind: 25
+      RawFields: []
+    - __kind: StructureType
+      ID: 45
+      Name: main.esotericHeap
+      ByteSize: 112
+      GoRuntimeType: 1.81168e+06
+      GoKind: 25
+      RawFields:
+        - Name: esotericStack
+          Offset: 0
+          Type: 39 StructureType main.esotericStack
+        - Name: mu
+          Offset: 64
+          Type: 46 StructureType sync.Mutex
+        - Name: once
+          Offset: 72
+          Type: 49 StructureType sync.Once
+        - Name: wg
+          Offset: 88
+          Type: 52 StructureType sync.WaitGroup
+        - Name: a
+          Offset: 104
+          Type: 55 StructureType sync/atomic.Int32
+    - __kind: StructureType
+      ID: 39
+      Name: main.esotericStack
+      ByteSize: 64
+      GoRuntimeType: 1.945504e+06
+      GoKind: 25
+      RawFields:
+        - Name: _
+          Offset: 0
+          Type: 6 BaseType int32
+        - Name: _valid
+          Offset: 4
+          Type: 6 BaseType int32
+        - Name: c
+          Offset: 8
+          Type: 40 GoChannelType chan struct {}
+        - Name: val
+          Offset: 16
+          Type: 41 GoEmptyInterfaceType interface {}
+        - Name: _
+          Offset: 32
+          Type: 26 BaseType uint64
+        - Name: work
+          Offset: 40
+          Type: 42 GoInterfaceType main.something
+        - Name: foo
+          Offset: 56
+          Type: 43 GoSubroutineType func()
+    - __kind: StructureType
+      ID: 82
+      Name: main.nestedStruct
+      ByteSize: 24
+      GoRuntimeType: 1.444064e+06
+      GoKind: 25
+      RawFields:
+        - Name: anotherInt
+          Offset: 0
+          Type: 1 BaseType int
+        - Name: anotherString
+          Offset: 8
+          Type: 8 GoStringHeaderType string
+    - __kind: StructureType
+      ID: 144
+      Name: main.node
+      ByteSize: 16
+      GoRuntimeType: 1.443904e+06
+      GoKind: 25
+      RawFields:
+        - Name: val
+          Offset: 0
+          Type: 1 BaseType int
+        - Name: b
+          Offset: 8
+          Type: 145 PointerType *main.node
+    - __kind: StructureType
+      ID: 222
+      Name: main.oneStringStruct
+      ByteSize: 16
+      GoKind: 25
+      RawFields:
+        - Name: a
+          Offset: 0
+          Type: 8 GoStringHeaderType string
+    - __kind: GoInterfaceType
+      ID: 42
+      Name: main.something
+      ByteSize: 16
+      GoRuntimeType: 1.012192e+06
+      GoKind: 20
+      RawFields:
+        - Name: tab
+          Offset: 0
+          Type: 38 VoidPointerType unsafe.Pointer
+        - Name: data
+          Offset: 8
+          Type: 38 VoidPointerType unsafe.Pointer
+    - __kind: StructureType
+      ID: 58
+      Name: main.structWithMap
+      ByteSize: 8
+      GoRuntimeType: 1.173504e+06
+      GoKind: 25
+      RawFields:
+        - Name: m
+          Offset: 0
+          Type: 59 GoMapType map[int]int
+    - __kind: StructureType
+      ID: 215
+      Name: main.structWithNoStrings
+      ByteSize: 2
+      GoKind: 25
+      RawFields:
+        - Name: aUint8
+          Offset: 0
+          Type: 4 BaseType uint8
+        - Name: aBool
+          Offset: 1
+          Type: 11 BaseType bool
+    - __kind: StructureType
+      ID: 204
+      Name: main.structWithTwoValues
+      ByteSize: 16
+      GoKind: 25
+      RawFields:
+        - Name: a
+          Offset: 0
+          Type: 20 BaseType uint
+        - Name: b
+          Offset: 8
+          Type: 11 BaseType bool
+    - __kind: GoSliceHeaderType
+      ID: 208
+      Name: main.t
+      ByteSize: 24
+      GoKind: 23
+      RawFields:
+        - Name: array
+          Offset: 0
+          Type: 209 PointerType **main.t
+        - Name: len
+          Offset: 8
+          Type: 1 BaseType int
+        - Name: cap
+          Offset: 16
+          Type: 1 BaseType int
+      Data: 270 GoSliceDataType main.t.array
+    - __kind: GoSliceDataType
+      ID: 270
+      Name: main.t.array
+      ByteSize: 2048
+      Element: 207 PointerType *main.t
+    - __kind: StructureType
+      ID: 219
+      Name: main.threeStringStruct
+      ByteSize: 48
+      GoKind: 25
+      RawFields:
+        - Name: a
+          Offset: 0
+          Type: 8 GoStringHeaderType string
+        - Name: b
+          Offset: 16
+          Type: 8 GoStringHeaderType string
+        - Name: c
+          Offset: 32
+          Type: 8 GoStringHeaderType string
+    - __kind: BaseType
+      ID: 32
+      Name: main.typeAlias
+      ByteSize: 2
+      GoKind: 9
+    - __kind: GoSwissMapHeaderType
+      ID: 193
+      Name: map<[4]int,[4]int>
+      ByteSize: 48
+      GoKind: 25
+      RawFields:
+        - Name: used
+          Offset: 0
+          Type: 26 BaseType uint64
+        - Name: seed
+          Offset: 8
+          Type: 62 BaseType uintptr
+        - Name: dirPtr
+          Offset: 16
+          Type: 194 PointerType **table<[4]int,[4]int>
+        - Name: dirLen
+          Offset: 24
+          Type: 1 BaseType int
+        - Name: globalDepth
+          Offset: 32
+          Type: 4 BaseType uint8
+        - Name: globalShift
+          Offset: 33
+          Type: 4 BaseType uint8
+        - Name: writing
+          Offset: 34
+          Type: 4 BaseType uint8
+        - Name: clearSeq
+          Offset: 40
+          Type: 26 BaseType uint64
+      TablePtrSliceType: 268 GoSliceDataType []*table<[4]int,[4]int>.array
+      GroupType: 199 StructureType noalg.map.group[[4]int][4]int
+    - __kind: GoSwissMapHeaderType
+      ID: 182
+      Name: map<[4]int,uint8>
+      ByteSize: 48
+      GoKind: 25
+      RawFields:
+        - Name: used
+          Offset: 0
+          Type: 26 BaseType uint64
+        - Name: seed
+          Offset: 8
+          Type: 62 BaseType uintptr
+        - Name: dirPtr
+          Offset: 16
+          Type: 183 PointerType **table<[4]int,uint8>
+        - Name: dirLen
+          Offset: 24
+          Type: 1 BaseType int
+        - Name: globalDepth
+          Offset: 32
+          Type: 4 BaseType uint8
+        - Name: globalShift
+          Offset: 33
+          Type: 4 BaseType uint8
+        - Name: writing
+          Offset: 34
+          Type: 4 BaseType uint8
+        - Name: clearSeq
+          Offset: 40
+          Type: 26 BaseType uint64
+      TablePtrSliceType: 266 GoSliceDataType []*table<[4]int,uint8>.array
+      GroupType: 188 StructureType noalg.map.group[[4]int]uint8
+    - __kind: GoSwissMapHeaderType
+      ID: 108
+      Name: map<[4]string,[2]int>
+      ByteSize: 48
+      GoKind: 25
+      RawFields:
+        - Name: used
+          Offset: 0
+          Type: 26 BaseType uint64
+        - Name: seed
+          Offset: 8
+          Type: 62 BaseType uintptr
+        - Name: dirPtr
+          Offset: 16
+          Type: 109 PointerType **table<[4]string,[2]int>
+        - Name: dirLen
+          Offset: 24
+          Type: 1 BaseType int
+        - Name: globalDepth
+          Offset: 32
+          Type: 4 BaseType uint8
+        - Name: globalShift
+          Offset: 33
+          Type: 4 BaseType uint8
+        - Name: writing
+          Offset: 34
+          Type: 4 BaseType uint8
+        - Name: clearSeq
+          Offset: 40
+          Type: 26 BaseType uint64
+      TablePtrSliceType: 252 GoSliceDataType []*table<[4]string,[2]int>.array
+      GroupType: 114 StructureType noalg.map.group[[4]string][2]int
+    - __kind: GoSwissMapHeaderType
+      ID: 135
+      Name: map<bool,main.node>
+      ByteSize: 48
+      GoKind: 25
+      RawFields:
+        - Name: used
+          Offset: 0
+          Type: 26 BaseType uint64
+        - Name: seed
+          Offset: 8
+          Type: 62 BaseType uintptr
+        - Name: dirPtr
+          Offset: 16
+          Type: 136 PointerType **table<bool,main.node>
+        - Name: dirLen
+          Offset: 24
+          Type: 1 BaseType int
+        - Name: globalDepth
+          Offset: 32
+          Type: 4 BaseType uint8
+        - Name: globalShift
+          Offset: 33
+          Type: 4 BaseType uint8
+        - Name: writing
+          Offset: 34
+          Type: 4 BaseType uint8
+        - Name: clearSeq
+          Offset: 40
+          Type: 26 BaseType uint64
+      TablePtrSliceType: 258 GoSliceDataType []*table<bool,main.node>.array
+      GroupType: 141 StructureType noalg.map.group[bool]main.node
+    - __kind: GoSwissMapHeaderType
+      ID: 61
+      Name: map<int,int>
+      ByteSize: 48
+      GoKind: 25
+      RawFields:
+        - Name: used
+          Offset: 0
+          Type: 26 BaseType uint64
+        - Name: seed
+          Offset: 8
+          Type: 62 BaseType uintptr
+        - Name: dirPtr
+          Offset: 16
+          Type: 63 PointerType **table<int,int>
+        - Name: dirLen
+          Offset: 24
+          Type: 1 BaseType int
+        - Name: globalDepth
+          Offset: 32
+          Type: 4 BaseType uint8
+        - Name: globalShift
+          Offset: 33
+          Type: 4 BaseType uint8
+        - Name: writing
+          Offset: 34
+          Type: 4 BaseType uint8
+        - Name: clearSeq
+          Offset: 40
+          Type: 26 BaseType uint64
+      TablePtrSliceType: 242 GoSliceDataType []*table<int,int>.array
+      GroupType: 68 StructureType noalg.map.group[int]int
+    - __kind: GoSwissMapHeaderType
+      ID: 148
+      Name: map<int,uint8>
+      ByteSize: 48
+      GoKind: 25
+      RawFields:
+        - Name: used
+          Offset: 0
+          Type: 26 BaseType uint64
+        - Name: seed
+          Offset: 8
+          Type: 62 BaseType uintptr
+        - Name: dirPtr
+          Offset: 16
+          Type: 149 PointerType **table<int,uint8>
+        - Name: dirLen
+          Offset: 24
+          Type: 1 BaseType int
+        - Name: globalDepth
+          Offset: 32
+          Type: 4 BaseType uint8
+        - Name: globalShift
+          Offset: 33
+          Type: 4 BaseType uint8
+        - Name: writing
+          Offset: 34
+          Type: 4 BaseType uint8
+        - Name: clearSeq
+          Offset: 40
+          Type: 26 BaseType uint64
+      TablePtrSliceType: 260 GoSliceDataType []*table<int,uint8>.array
+      GroupType: 154 StructureType noalg.map.group[int]uint8
+    - __kind: GoSwissMapHeaderType
+      ID: 122
+      Name: map<string,[]main.structWithMap>
+      ByteSize: 48
+      GoKind: 25
+      RawFields:
+        - Name: used
+          Offset: 0
+          Type: 26 BaseType uint64
+        - Name: seed
+          Offset: 8
+          Type: 62 BaseType uintptr
+        - Name: dirPtr
+          Offset: 16
+          Type: 123 PointerType **table<string,[]main.structWithMap>
+        - Name: dirLen
+          Offset: 24
+          Type: 1 BaseType int
+        - Name: globalDepth
+          Offset: 32
+          Type: 4 BaseType uint8
+        - Name: globalShift
+          Offset: 33
+          Type: 4 BaseType uint8
+        - Name: writing
+          Offset: 34
+          Type: 4 BaseType uint8
+        - Name: clearSeq
+          Offset: 40
+          Type: 26 BaseType uint64
+      TablePtrSliceType: 254 GoSliceDataType []*table<string,[]main.structWithMap>.array
+      GroupType: 128 StructureType noalg.map.group[string][]main.structWithMap
+    - __kind: GoSwissMapHeaderType
+      ID: 96
+      Name: map<string,[]string>
+      ByteSize: 48
+      GoKind: 25
+      RawFields:
+        - Name: used
+          Offset: 0
+          Type: 26 BaseType uint64
+        - Name: seed
+          Offset: 8
+          Type: 62 BaseType uintptr
+        - Name: dirPtr
+          Offset: 16
+          Type: 97 PointerType **table<string,[]string>
+        - Name: dirLen
+          Offset: 24
+          Type: 1 BaseType int
+        - Name: globalDepth
+          Offset: 32
+          Type: 4 BaseType uint8
+        - Name: globalShift
+          Offset: 33
+          Type: 4 BaseType uint8
+        - Name: writing
+          Offset: 34
+          Type: 4 BaseType uint8
+        - Name: clearSeq
+          Offset: 40
+          Type: 26 BaseType uint64
+      TablePtrSliceType: 248 GoSliceDataType []*table<string,[]string>.array
+      GroupType: 102 StructureType noalg.map.group[string][]string
+    - __kind: GoSwissMapHeaderType
+      ID: 85
+      Name: map<string,int>
+      ByteSize: 48
+      GoKind: 25
+      RawFields:
+        - Name: used
+          Offset: 0
+          Type: 26 BaseType uint64
+        - Name: seed
+          Offset: 8
+          Type: 62 BaseType uintptr
+        - Name: dirPtr
+          Offset: 16
+          Type: 86 PointerType **table<string,int>
+        - Name: dirLen
+          Offset: 24
+          Type: 1 BaseType int
+        - Name: globalDepth
+          Offset: 32
+          Type: 4 BaseType uint8
+        - Name: globalShift
+          Offset: 33
+          Type: 4 BaseType uint8
+        - Name: writing
+          Offset: 34
+          Type: 4 BaseType uint8
+        - Name: clearSeq
+          Offset: 40
+          Type: 26 BaseType uint64
+      TablePtrSliceType: 246 GoSliceDataType []*table<string,int>.array
+      GroupType: 91 StructureType noalg.map.group[string]int
+    - __kind: GoSwissMapHeaderType
+      ID: 73
+      Name: map<string,main.nestedStruct>
+      ByteSize: 48
+      GoKind: 25
+      RawFields:
+        - Name: used
+          Offset: 0
+          Type: 26 BaseType uint64
+        - Name: seed
+          Offset: 8
+          Type: 62 BaseType uintptr
+        - Name: dirPtr
+          Offset: 16
+          Type: 74 PointerType **table<string,main.nestedStruct>
+        - Name: dirLen
+          Offset: 24
+          Type: 1 BaseType int
+        - Name: globalDepth
+          Offset: 32
+          Type: 4 BaseType uint8
+        - Name: globalShift
+          Offset: 33
+          Type: 4 BaseType uint8
+        - Name: writing
+          Offset: 34
+          Type: 4 BaseType uint8
+        - Name: clearSeq
+          Offset: 40
+          Type: 26 BaseType uint64
+      TablePtrSliceType: 244 GoSliceDataType []*table<string,main.nestedStruct>.array
+      GroupType: 79 StructureType noalg.map.group[string]main.nestedStruct
+    - __kind: GoSwissMapHeaderType
+      ID: 170
+      Name: map<uint8,[4]int>
+      ByteSize: 48
+      GoKind: 25
+      RawFields:
+        - Name: used
+          Offset: 0
+          Type: 26 BaseType uint64
+        - Name: seed
+          Offset: 8
+          Type: 62 BaseType uintptr
+        - Name: dirPtr
+          Offset: 16
+          Type: 171 PointerType **table<uint8,[4]int>
+        - Name: dirLen
+          Offset: 24
+          Type: 1 BaseType int
+        - Name: globalDepth
+          Offset: 32
+          Type: 4 BaseType uint8
+        - Name: globalShift
+          Offset: 33
+          Type: 4 BaseType uint8
+        - Name: writing
+          Offset: 34
+          Type: 4 BaseType uint8
+        - Name: clearSeq
+          Offset: 40
+          Type: 26 BaseType uint64
+      TablePtrSliceType: 264 GoSliceDataType []*table<uint8,[4]int>.array
+      GroupType: 176 StructureType noalg.map.group[uint8][4]int
+    - __kind: GoSwissMapHeaderType
+      ID: 159
+      Name: map<uint8,uint8>
+      ByteSize: 48
+      GoKind: 25
+      RawFields:
+        - Name: used
+          Offset: 0
+          Type: 26 BaseType uint64
+        - Name: seed
+          Offset: 8
+          Type: 62 BaseType uintptr
+        - Name: dirPtr
+          Offset: 16
+          Type: 160 PointerType **table<uint8,uint8>
+        - Name: dirLen
+          Offset: 24
+          Type: 1 BaseType int
+        - Name: globalDepth
+          Offset: 32
+          Type: 4 BaseType uint8
+        - Name: globalShift
+          Offset: 33
+          Type: 4 BaseType uint8
+        - Name: writing
+          Offset: 34
+          Type: 4 BaseType uint8
+        - Name: clearSeq
+          Offset: 40
+          Type: 26 BaseType uint64
+      TablePtrSliceType: 262 GoSliceDataType []*table<uint8,uint8>.array
+      GroupType: 165 StructureType noalg.map.group[uint8]uint8
+    - __kind: GoMapType
+      ID: 191
+      Name: map[[4]int][4]int
+      ByteSize: 8
+      GoRuntimeType: 1.117568e+06
+      GoKind: 21
+      HeaderType: 193 GoSwissMapHeaderType map<[4]int,[4]int>
+    - __kind: GoMapType
+      ID: 180
+      Name: map[[4]int]uint8
+      ByteSize: 8
+      GoRuntimeType: 1.117696e+06
+      GoKind: 21
+      HeaderType: 182 GoSwissMapHeaderType map<[4]int,uint8>
+    - __kind: GoMapType
+      ID: 106
+      Name: map[[4]string][2]int
+      ByteSize: 8
+      GoRuntimeType: 1.117824e+06
+      GoKind: 21
+      HeaderType: 108 GoSwissMapHeaderType map<[4]string,[2]int>
+    - __kind: GoMapType
+      ID: 133
+      Name: map[bool]main.node
+      ByteSize: 8
+      GoRuntimeType: 1.117952e+06
+      GoKind: 21
+      HeaderType: 135 GoSwissMapHeaderType map<bool,main.node>
+    - __kind: GoMapType
+      ID: 59
+      Name: map[int]int
+      ByteSize: 8
+      GoRuntimeType: 1.117184e+06
+      GoKind: 21
+      HeaderType: 61 GoSwissMapHeaderType map<int,int>
+    - __kind: GoMapType
+      ID: 146
+      Name: map[int]uint8
+      ByteSize: 8
+      GoRuntimeType: 1.11808e+06
+      GoKind: 21
+      HeaderType: 148 GoSwissMapHeaderType map<int,uint8>
+    - __kind: GoMapType
+      ID: 120
+      Name: map[string][]main.structWithMap
+      ByteSize: 8
+      GoRuntimeType: 1.118208e+06
+      GoKind: 21
+      HeaderType: 122 GoSwissMapHeaderType map<string,[]main.structWithMap>
+    - __kind: GoMapType
+      ID: 94
+      Name: map[string][]string
+      ByteSize: 8
+      GoRuntimeType: 1.118336e+06
+      GoKind: 21
+      HeaderType: 96 GoSwissMapHeaderType map<string,[]string>
+    - __kind: GoMapType
+      ID: 83
+      Name: map[string]int
+      ByteSize: 8
+      GoRuntimeType: 1.118464e+06
+      GoKind: 21
+      HeaderType: 85 GoSwissMapHeaderType map<string,int>
+    - __kind: GoMapType
+      ID: 71
+      Name: map[string]main.nestedStruct
+      ByteSize: 8
+      GoRuntimeType: 1.118592e+06
+      GoKind: 21
+      HeaderType: 73 GoSwissMapHeaderType map<string,main.nestedStruct>
+    - __kind: GoMapType
+      ID: 168
+      Name: map[uint8][4]int
+      ByteSize: 8
+      GoRuntimeType: 1.11872e+06
+      GoKind: 21
+      HeaderType: 170 GoSwissMapHeaderType map<uint8,[4]int>
+    - __kind: GoMapType
+      ID: 157
+      Name: map[uint8]uint8
+      ByteSize: 8
+      GoRuntimeType: 1.118848e+06
+      GoKind: 21
+      HeaderType: 159 GoSwissMapHeaderType map<uint8,uint8>
+    - __kind: ArrayType
+      ID: 200
+      Name: noalg.[8]struct { key [4]int; elem [4]int }
+      ByteSize: 512
+      GoRuntimeType: 672992
+      GoKind: 17
+      Count: 8
+      HasCount: true
+      Element: 201 StructureType noalg.struct { key [4]int; elem [4]int }
+    - __kind: ArrayType
+      ID: 189
+      Name: noalg.[8]struct { key [4]int; elem uint8 }
+      ByteSize: 320
+      GoRuntimeType: 673088
+      GoKind: 17
+      Count: 8
+      HasCount: true
+      Element: 190 StructureType noalg.struct { key [4]int; elem uint8 }
+    - __kind: ArrayType
+      ID: 115
+      Name: noalg.[8]struct { key [4]string; elem [2]int }
+      ByteSize: 640
+      GoRuntimeType: 673376
+      GoKind: 17
+      Count: 8
+      HasCount: true
+      Element: 116 StructureType noalg.struct { key [4]string; elem [2]int }
+    - __kind: ArrayType
+      ID: 142
+      Name: noalg.[8]struct { key bool; elem main.node }
+      ByteSize: 192
+      GoRuntimeType: 673472
+      GoKind: 17
+      Count: 8
+      HasCount: true
+      Element: 143 StructureType noalg.struct { key bool; elem main.node }
+    - __kind: ArrayType
+      ID: 69
+      Name: noalg.[8]struct { key int; elem int }
+      ByteSize: 128
+      GoRuntimeType: 671264
+      GoKind: 17
+      Count: 8
+      HasCount: true
+      Element: 70 StructureType noalg.struct { key int; elem int }
+    - __kind: ArrayType
+      ID: 155
+      Name: noalg.[8]struct { key int; elem uint8 }
+      ByteSize: 128
+      GoRuntimeType: 673568
+      GoKind: 17
+      Count: 8
+      HasCount: true
+      Element: 156 StructureType noalg.struct { key int; elem uint8 }
+    - __kind: ArrayType
+      ID: 129
+      Name: noalg.[8]struct { key string; elem []main.structWithMap }
+      ByteSize: 320
+      GoRuntimeType: 673664
+      GoKind: 17
+      Count: 8
+      HasCount: true
+      Element: 130 StructureType noalg.struct { key string; elem []main.structWithMap }
+    - __kind: ArrayType
+      ID: 103
+      Name: noalg.[8]struct { key string; elem []string }
+      ByteSize: 320
+      GoRuntimeType: 673760
+      GoKind: 17
+      Count: 8
+      HasCount: true
+      Element: 104 StructureType noalg.struct { key string; elem []string }
+    - __kind: ArrayType
+      ID: 92
+      Name: noalg.[8]struct { key string; elem int }
+      ByteSize: 192
+      GoRuntimeType: 673856
+      GoKind: 17
+      Count: 8
+      HasCount: true
+      Element: 93 StructureType noalg.struct { key string; elem int }
+    - __kind: ArrayType
+      ID: 80
+      Name: noalg.[8]struct { key string; elem main.nestedStruct }
+      ByteSize: 320
+      GoRuntimeType: 673952
+      GoKind: 17
+      Count: 8
+      HasCount: true
+      Element: 81 StructureType noalg.struct { key string; elem main.nestedStruct }
+    - __kind: ArrayType
+      ID: 177
+      Name: noalg.[8]struct { key uint8; elem [4]int }
+      ByteSize: 320
+      GoRuntimeType: 674048
+      GoKind: 17
+      Count: 8
+      HasCount: true
+      Element: 178 StructureType noalg.struct { key uint8; elem [4]int }
+    - __kind: ArrayType
+      ID: 166
+      Name: noalg.[8]struct { key uint8; elem uint8 }
+      ByteSize: 16
+      GoRuntimeType: 674144
+      GoKind: 17
+      Count: 8
+      HasCount: true
+      Element: 167 StructureType noalg.struct { key uint8; elem uint8 }
+    - __kind: StructureType
+      ID: 199
+      Name: noalg.map.group[[4]int][4]int
+      ByteSize: 520
+      GoRuntimeType: 1.277248e+06
+      GoKind: 25
+      RawFields:
+        - Name: ctrl
+          Offset: 0
+          Type: 26 BaseType uint64
+        - Name: slots
+          Offset: 8
+          Type: 200 ArrayType noalg.[8]struct { key [4]int; elem [4]int }
+    - __kind: StructureType
+      ID: 188
+      Name: noalg.map.group[[4]int]uint8
+      ByteSize: 328
+      GoRuntimeType: 1.277504e+06
+      GoKind: 25
+      RawFields:
+        - Name: ctrl
+          Offset: 0
+          Type: 26 BaseType uint64
+        - Name: slots
+          Offset: 8
+          Type: 189 ArrayType noalg.[8]struct { key [4]int; elem uint8 }
+    - __kind: StructureType
+      ID: 114
+      Name: noalg.map.group[[4]string][2]int
+      ByteSize: 648
+      GoRuntimeType: 1.27776e+06
+      GoKind: 25
+      RawFields:
+        - Name: ctrl
+          Offset: 0
+          Type: 26 BaseType uint64
+        - Name: slots
+          Offset: 8
+          Type: 115 ArrayType noalg.[8]struct { key [4]string; elem [2]int }
+    - __kind: StructureType
+      ID: 141
+      Name: noalg.map.group[bool]main.node
+      ByteSize: 200
+      GoRuntimeType: 1.278016e+06
+      GoKind: 25
+      RawFields:
+        - Name: ctrl
+          Offset: 0
+          Type: 26 BaseType uint64
+        - Name: slots
+          Offset: 8
+          Type: 142 ArrayType noalg.[8]struct { key bool; elem main.node }
+    - __kind: StructureType
+      ID: 68
+      Name: noalg.map.group[int]int
+      ByteSize: 136
+      GoRuntimeType: 1.27648e+06
+      GoKind: 25
+      RawFields:
+        - Name: ctrl
+          Offset: 0
+          Type: 26 BaseType uint64
+        - Name: slots
+          Offset: 8
+          Type: 69 ArrayType noalg.[8]struct { key int; elem int }
+    - __kind: StructureType
+      ID: 154
+      Name: noalg.map.group[int]uint8
+      ByteSize: 136
+      GoRuntimeType: 1.278272e+06
+      GoKind: 25
+      RawFields:
+        - Name: ctrl
+          Offset: 0
+          Type: 26 BaseType uint64
+        - Name: slots
+          Offset: 8
+          Type: 155 ArrayType noalg.[8]struct { key int; elem uint8 }
+    - __kind: StructureType
+      ID: 128
+      Name: noalg.map.group[string][]main.structWithMap
+      ByteSize: 328
+      GoRuntimeType: 1.278528e+06
+      GoKind: 25
+      RawFields:
+        - Name: ctrl
+          Offset: 0
+          Type: 26 BaseType uint64
+        - Name: slots
+          Offset: 8
+          Type: 129 ArrayType noalg.[8]struct { key string; elem []main.structWithMap }
+    - __kind: StructureType
+      ID: 102
+      Name: noalg.map.group[string][]string
+      ByteSize: 328
+      GoRuntimeType: 1.278784e+06
+      GoKind: 25
+      RawFields:
+        - Name: ctrl
+          Offset: 0
+          Type: 26 BaseType uint64
+        - Name: slots
+          Offset: 8
+          Type: 103 ArrayType noalg.[8]struct { key string; elem []string }
+    - __kind: StructureType
+      ID: 91
+      Name: noalg.map.group[string]int
+      ByteSize: 200
+      GoRuntimeType: 1.27904e+06
+      GoKind: 25
+      RawFields:
+        - Name: ctrl
+          Offset: 0
+          Type: 26 BaseType uint64
+        - Name: slots
+          Offset: 8
+          Type: 92 ArrayType noalg.[8]struct { key string; elem int }
+    - __kind: StructureType
+      ID: 79
+      Name: noalg.map.group[string]main.nestedStruct
+      ByteSize: 328
+      GoRuntimeType: 1.279296e+06
+      GoKind: 25
+      RawFields:
+        - Name: ctrl
+          Offset: 0
+          Type: 26 BaseType uint64
+        - Name: slots
+          Offset: 8
+          Type: 80 ArrayType noalg.[8]struct { key string; elem main.nestedStruct }
+    - __kind: StructureType
+      ID: 176
+      Name: noalg.map.group[uint8][4]int
+      ByteSize: 328
+      GoRuntimeType: 1.279552e+06
+      GoKind: 25
+      RawFields:
+        - Name: ctrl
+          Offset: 0
+          Type: 26 BaseType uint64
+        - Name: slots
+          Offset: 8
+          Type: 177 ArrayType noalg.[8]struct { key uint8; elem [4]int }
+    - __kind: StructureType
+      ID: 165
+      Name: noalg.map.group[uint8]uint8
+      ByteSize: 24
+      GoRuntimeType: 1.279808e+06
+      GoKind: 25
+      RawFields:
+        - Name: ctrl
+          Offset: 0
+          Type: 26 BaseType uint64
+        - Name: slots
+          Offset: 8
+          Type: 166 ArrayType noalg.[8]struct { key uint8; elem uint8 }
+    - __kind: StructureType
+      ID: 201
+      Name: noalg.struct { key [4]int; elem [4]int }
+      ByteSize: 64
+      GoRuntimeType: 1.27712e+06
+      GoKind: 25
+      RawFields:
+        - Name: key
+          Offset: 0
+          Type: 179 ArrayType [4]int
+        - Name: elem
+          Offset: 32
+          Type: 179 ArrayType [4]int
+    - __kind: StructureType
+      ID: 190
+      Name: noalg.struct { key [4]int; elem uint8 }
+      ByteSize: 40
+      GoRuntimeType: 1.277376e+06
+      GoKind: 25
+      RawFields:
+        - Name: key
+          Offset: 0
+          Type: 179 ArrayType [4]int
+        - Name: elem
+          Offset: 32
+          Type: 4 BaseType uint8
+    - __kind: StructureType
+      ID: 116
+      Name: noalg.struct { key [4]string; elem [2]int }
+      ByteSize: 80
+      GoRuntimeType: 1.277632e+06
+      GoKind: 25
+      RawFields:
+        - Name: key
+          Offset: 0
+          Type: 117 ArrayType [4]string
+        - Name: elem
+          Offset: 64
+          Type: 12 ArrayType [2]int
+    - __kind: StructureType
+      ID: 143
+      Name: noalg.struct { key bool; elem main.node }
+      ByteSize: 24
+      GoRuntimeType: 1.277888e+06
+      GoKind: 25
+      RawFields:
+        - Name: key
+          Offset: 0
+          Type: 11 BaseType bool
+        - Name: elem
+          Offset: 8
+          Type: 144 StructureType main.node
+    - __kind: StructureType
+      ID: 70
+      Name: noalg.struct { key int; elem int }
+      ByteSize: 16
+      GoRuntimeType: 1.276352e+06
+      GoKind: 25
+      RawFields:
+        - Name: key
+          Offset: 0
+          Type: 1 BaseType int
+        - Name: elem
+          Offset: 8
+          Type: 1 BaseType int
+    - __kind: StructureType
+      ID: 156
+      Name: noalg.struct { key int; elem uint8 }
+      ByteSize: 16
+      GoRuntimeType: 1.278144e+06
+      GoKind: 25
+      RawFields:
+        - Name: key
+          Offset: 0
+          Type: 1 BaseType int
+        - Name: elem
+          Offset: 8
+          Type: 4 BaseType uint8
+    - __kind: StructureType
+      ID: 130
+      Name: noalg.struct { key string; elem []main.structWithMap }
+      ByteSize: 40
+      GoRuntimeType: 1.2784e+06
+      GoKind: 25
+      RawFields:
+        - Name: key
+          Offset: 0
+          Type: 8 GoStringHeaderType string
+        - Name: elem
+          Offset: 16
+          Type: 131 GoSliceHeaderType []main.structWithMap
+    - __kind: StructureType
+      ID: 104
+      Name: noalg.struct { key string; elem []string }
+      ByteSize: 40
+      GoRuntimeType: 1.278656e+06
+      GoKind: 25
+      RawFields:
+        - Name: key
+          Offset: 0
+          Type: 8 GoStringHeaderType string
+        - Name: elem
+          Offset: 16
+          Type: 105 GoSliceHeaderType []string
+    - __kind: StructureType
+      ID: 93
+      Name: noalg.struct { key string; elem int }
+      ByteSize: 24
+      GoRuntimeType: 1.278912e+06
+      GoKind: 25
+      RawFields:
+        - Name: key
+          Offset: 0
+          Type: 8 GoStringHeaderType string
+        - Name: elem
+          Offset: 16
+          Type: 1 BaseType int
+    - __kind: StructureType
+      ID: 81
+      Name: noalg.struct { key string; elem main.nestedStruct }
+      ByteSize: 40
+      GoRuntimeType: 1.279168e+06
+      GoKind: 25
+      RawFields:
+        - Name: key
+          Offset: 0
+          Type: 8 GoStringHeaderType string
+        - Name: elem
+          Offset: 16
+          Type: 82 StructureType main.nestedStruct
+    - __kind: StructureType
+      ID: 178
+      Name: noalg.struct { key uint8; elem [4]int }
+      ByteSize: 40
+      GoRuntimeType: 1.279424e+06
+      GoKind: 25
+      RawFields:
+        - Name: key
+          Offset: 0
+          Type: 4 BaseType uint8
+        - Name: elem
+          Offset: 8
+          Type: 179 ArrayType [4]int
+    - __kind: StructureType
+      ID: 167
+      Name: noalg.struct { key uint8; elem uint8 }
+      ByteSize: 2
+      GoRuntimeType: 1.27968e+06
+      GoKind: 25
+      RawFields:
+        - Name: key
+          Offset: 0
+          Type: 4 BaseType uint8
+        - Name: elem
+          Offset: 1
+          Type: 4 BaseType uint8
+    - __kind: GoStringHeaderType
+      ID: 8
+      Name: string
+      ByteSize: 16
+      GoRuntimeType: 575008
+      GoKind: 24
+      RawFields:
+        - Name: str
+          Offset: 0
+          Type: 239 PointerType *string.str
+        - Name: len
+          Offset: 8
+          Type: 1 BaseType int
+      Data: 238 GoStringDataType string.str
+    - __kind: GoStringDataType
+      ID: 238
+      Name: string.str
+      ByteSize: 2048
+    - __kind: StructureType
+      ID: 46
+      Name: sync.Mutex
+      ByteSize: 8
+      GoRuntimeType: 1.445344e+06
+      GoKind: 25
+      RawFields:
+        - Name: _
+          Offset: 0
+          Type: 47 StructureType sync.noCopy
+        - Name: mu
+          Offset: 0
+          Type: 48 StructureType internal/sync.Mutex
+    - __kind: StructureType
+      ID: 49
+      Name: sync.Once
+      ByteSize: 12
+      GoRuntimeType: 1.593696e+06
+      GoKind: 25
+      RawFields:
+        - Name: _
+          Offset: 0
+          Type: 47 StructureType sync.noCopy
+        - Name: done
+          Offset: 0
+          Type: 50 StructureType sync/atomic.Uint32
+        - Name: m
+          Offset: 4
+          Type: 46 StructureType sync.Mutex
+    - __kind: StructureType
+      ID: 52
+      Name: sync.WaitGroup
+      ByteSize: 16
+      GoRuntimeType: 1.593888e+06
+      GoKind: 25
+      RawFields:
+        - Name: noCopy
+          Offset: 0
+          Type: 47 StructureType sync.noCopy
+        - Name: state
+          Offset: 0
+          Type: 53 StructureType sync/atomic.Uint64
+        - Name: sema
+          Offset: 8
+          Type: 24 BaseType uint32
+    - __kind: StructureType
+      ID: 47
+      Name: sync.noCopy
+      GoRuntimeType: 977728
+      GoKind: 25
+      RawFields: []
+    - __kind: StructureType
+      ID: 55
+      Name: sync/atomic.Int32
+      ByteSize: 4
+      GoRuntimeType: 1.446624e+06
+      GoKind: 25
+      RawFields:
+        - Name: _
+          Offset: 0
+          Type: 51 StructureType sync/atomic.noCopy
+        - Name: v
+          Offset: 0
+          Type: 6 BaseType int32
+    - __kind: StructureType
+      ID: 50
+      Name: sync/atomic.Uint32
+      ByteSize: 4
+      GoRuntimeType: 1.446784e+06
+      GoKind: 25
+      RawFields:
+        - Name: _
+          Offset: 0
+          Type: 51 StructureType sync/atomic.noCopy
+        - Name: v
+          Offset: 0
+          Type: 24 BaseType uint32
+    - __kind: StructureType
+      ID: 53
+      Name: sync/atomic.Uint64
+      ByteSize: 8
+      GoRuntimeType: 1.594272e+06
+      GoKind: 25
+      RawFields:
+        - Name: _
+          Offset: 0
+          Type: 51 StructureType sync/atomic.noCopy
+        - Name: _
+          Offset: 0
+          Type: 54 StructureType sync/atomic.align64
+        - Name: v
+          Offset: 0
+          Type: 26 BaseType uint64
+    - __kind: StructureType
+      ID: 54
+      Name: sync/atomic.align64
+      GoRuntimeType: 977920
+      GoKind: 25
+      RawFields: []
+    - __kind: StructureType
+      ID: 51
+      Name: sync/atomic.noCopy
+      GoRuntimeType: 977824
+      GoKind: 25
+      RawFields: []
+    - __kind: StructureType
+      ID: 196
+      Name: table<[4]int,[4]int>
+      ByteSize: 32
+      GoKind: 25
+      RawFields:
+        - Name: used
+          Offset: 0
+          Type: 22 BaseType uint16
+        - Name: capacity
+          Offset: 2
+          Type: 22 BaseType uint16
+        - Name: growthLeft
+          Offset: 4
+          Type: 22 BaseType uint16
+        - Name: localDepth
+          Offset: 6
+          Type: 4 BaseType uint8
+        - Name: index
+          Offset: 8
+          Type: 1 BaseType int
+        - Name: groups
+          Offset: 16
+          Type: 197 GoSwissMapGroupsType groupReference<[4]int,[4]int>
+    - __kind: StructureType
+      ID: 185
+      Name: table<[4]int,uint8>
+      ByteSize: 32
+      GoKind: 25
+      RawFields:
+        - Name: used
+          Offset: 0
+          Type: 22 BaseType uint16
+        - Name: capacity
+          Offset: 2
+          Type: 22 BaseType uint16
+        - Name: growthLeft
+          Offset: 4
+          Type: 22 BaseType uint16
+        - Name: localDepth
+          Offset: 6
+          Type: 4 BaseType uint8
+        - Name: index
+          Offset: 8
+          Type: 1 BaseType int
+        - Name: groups
+          Offset: 16
+          Type: 186 GoSwissMapGroupsType groupReference<[4]int,uint8>
+    - __kind: StructureType
+      ID: 111
+      Name: table<[4]string,[2]int>
+      ByteSize: 32
+      GoKind: 25
+      RawFields:
+        - Name: used
+          Offset: 0
+          Type: 22 BaseType uint16
+        - Name: capacity
+          Offset: 2
+          Type: 22 BaseType uint16
+        - Name: growthLeft
+          Offset: 4
+          Type: 22 BaseType uint16
+        - Name: localDepth
+          Offset: 6
+          Type: 4 BaseType uint8
+        - Name: index
+          Offset: 8
+          Type: 1 BaseType int
+        - Name: groups
+          Offset: 16
+          Type: 112 GoSwissMapGroupsType groupReference<[4]string,[2]int>
+    - __kind: StructureType
+      ID: 138
+      Name: table<bool,main.node>
+      ByteSize: 32
+      GoKind: 25
+      RawFields:
+        - Name: used
+          Offset: 0
+          Type: 22 BaseType uint16
+        - Name: capacity
+          Offset: 2
+          Type: 22 BaseType uint16
+        - Name: growthLeft
+          Offset: 4
+          Type: 22 BaseType uint16
+        - Name: localDepth
+          Offset: 6
+          Type: 4 BaseType uint8
+        - Name: index
+          Offset: 8
+          Type: 1 BaseType int
+        - Name: groups
+          Offset: 16
+          Type: 139 GoSwissMapGroupsType groupReference<bool,main.node>
+    - __kind: StructureType
+      ID: 65
+      Name: table<int,int>
+      ByteSize: 32
+      GoKind: 25
+      RawFields:
+        - Name: used
+          Offset: 0
+          Type: 22 BaseType uint16
+        - Name: capacity
+          Offset: 2
+          Type: 22 BaseType uint16
+        - Name: growthLeft
+          Offset: 4
+          Type: 22 BaseType uint16
+        - Name: localDepth
+          Offset: 6
+          Type: 4 BaseType uint8
+        - Name: index
+          Offset: 8
+          Type: 1 BaseType int
+        - Name: groups
+          Offset: 16
+          Type: 66 GoSwissMapGroupsType groupReference<int,int>
+    - __kind: StructureType
+      ID: 151
+      Name: table<int,uint8>
+      ByteSize: 32
+      GoKind: 25
+      RawFields:
+        - Name: used
+          Offset: 0
+          Type: 22 BaseType uint16
+        - Name: capacity
+          Offset: 2
+          Type: 22 BaseType uint16
+        - Name: growthLeft
+          Offset: 4
+          Type: 22 BaseType uint16
+        - Name: localDepth
+          Offset: 6
+          Type: 4 BaseType uint8
+        - Name: index
+          Offset: 8
+          Type: 1 BaseType int
+        - Name: groups
+          Offset: 16
+          Type: 152 GoSwissMapGroupsType groupReference<int,uint8>
+    - __kind: StructureType
+      ID: 125
+      Name: table<string,[]main.structWithMap>
+      ByteSize: 32
+      GoKind: 25
+      RawFields:
+        - Name: used
+          Offset: 0
+          Type: 22 BaseType uint16
+        - Name: capacity
+          Offset: 2
+          Type: 22 BaseType uint16
+        - Name: growthLeft
+          Offset: 4
+          Type: 22 BaseType uint16
+        - Name: localDepth
+          Offset: 6
+          Type: 4 BaseType uint8
+        - Name: index
+          Offset: 8
+          Type: 1 BaseType int
+        - Name: groups
+          Offset: 16
+          Type: 126 GoSwissMapGroupsType groupReference<string,[]main.structWithMap>
+    - __kind: StructureType
+      ID: 99
+      Name: table<string,[]string>
+      ByteSize: 32
+      GoKind: 25
+      RawFields:
+        - Name: used
+          Offset: 0
+          Type: 22 BaseType uint16
+        - Name: capacity
+          Offset: 2
+          Type: 22 BaseType uint16
+        - Name: growthLeft
+          Offset: 4
+          Type: 22 BaseType uint16
+        - Name: localDepth
+          Offset: 6
+          Type: 4 BaseType uint8
+        - Name: index
+          Offset: 8
+          Type: 1 BaseType int
+        - Name: groups
+          Offset: 16
+          Type: 100 GoSwissMapGroupsType groupReference<string,[]string>
+    - __kind: StructureType
+      ID: 88
+      Name: table<string,int>
+      ByteSize: 32
+      GoKind: 25
+      RawFields:
+        - Name: used
+          Offset: 0
+          Type: 22 BaseType uint16
+        - Name: capacity
+          Offset: 2
+          Type: 22 BaseType uint16
+        - Name: growthLeft
+          Offset: 4
+          Type: 22 BaseType uint16
+        - Name: localDepth
+          Offset: 6
+          Type: 4 BaseType uint8
+        - Name: index
+          Offset: 8
+          Type: 1 BaseType int
+        - Name: groups
+          Offset: 16
+          Type: 89 GoSwissMapGroupsType groupReference<string,int>
+    - __kind: StructureType
+      ID: 76
+      Name: table<string,main.nestedStruct>
+      ByteSize: 32
+      GoKind: 25
+      RawFields:
+        - Name: used
+          Offset: 0
+          Type: 22 BaseType uint16
+        - Name: capacity
+          Offset: 2
+          Type: 22 BaseType uint16
+        - Name: growthLeft
+          Offset: 4
+          Type: 22 BaseType uint16
+        - Name: localDepth
+          Offset: 6
+          Type: 4 BaseType uint8
+        - Name: index
+          Offset: 8
+          Type: 1 BaseType int
+        - Name: groups
+          Offset: 16
+          Type: 77 GoSwissMapGroupsType groupReference<string,main.nestedStruct>
+    - __kind: StructureType
+      ID: 173
+      Name: table<uint8,[4]int>
+      ByteSize: 32
+      GoKind: 25
+      RawFields:
+        - Name: used
+          Offset: 0
+          Type: 22 BaseType uint16
+        - Name: capacity
+          Offset: 2
+          Type: 22 BaseType uint16
+        - Name: growthLeft
+          Offset: 4
+          Type: 22 BaseType uint16
+        - Name: localDepth
+          Offset: 6
+          Type: 4 BaseType uint8
+        - Name: index
+          Offset: 8
+          Type: 1 BaseType int
+        - Name: groups
+          Offset: 16
+          Type: 174 GoSwissMapGroupsType groupReference<uint8,[4]int>
+    - __kind: StructureType
+      ID: 162
+      Name: table<uint8,uint8>
+      ByteSize: 32
+      GoKind: 25
+      RawFields:
+        - Name: used
+          Offset: 0
+          Type: 22 BaseType uint16
+        - Name: capacity
+          Offset: 2
+          Type: 22 BaseType uint16
+        - Name: growthLeft
+          Offset: 4
+          Type: 22 BaseType uint16
+        - Name: localDepth
+          Offset: 6
+          Type: 4 BaseType uint8
+        - Name: index
+          Offset: 8
+          Type: 1 BaseType int
+        - Name: groups
+          Offset: 16
+          Type: 163 GoSwissMapGroupsType groupReference<uint8,uint8>
+    - __kind: BaseType
+      ID: 20
+      Name: uint
+      ByteSize: 8
+      GoRuntimeType: 575648
+      GoKind: 7
+    - __kind: BaseType
+      ID: 22
+      Name: uint16
+      ByteSize: 2
+      GoRuntimeType: 575264
+      GoKind: 9
+    - __kind: BaseType
+      ID: 24
+      Name: uint32
+      ByteSize: 4
+      GoRuntimeType: 575392
+      GoKind: 10
+    - __kind: BaseType
+      ID: 26
+      Name: uint64
+      ByteSize: 8
+      GoRuntimeType: 575520
+      GoKind: 11
+    - __kind: BaseType
+      ID: 4
+      Name: uint8
+      ByteSize: 1
+      GoRuntimeType: 575136
+      GoKind: 8
+    - __kind: BaseType
+      ID: 62
+      Name: uintptr
+      ByteSize: 8
+      GoRuntimeType: 575712
+      GoKind: 12
+    - __kind: VoidPointerType
+      ID: 38
+      Name: unsafe.Pointer
+      ByteSize: 8
+      GoRuntimeType: 576096
+      GoKind: 26
 MaxTypeID: 385
 Issues: []
 GoModuledataInfo: {FirstModuledataAddr: "0x17f5360", TypesOffset: 296}

--- a/pkg/dyninst/irgen/testdata/snapshot/sample.arch=amd64,toolchain=go1.25.0.yaml
+++ b/pkg/dyninst/irgen/testdata/snapshot/sample.arch=amd64,toolchain=go1.25.0.yaml
@@ -8,7 +8,7 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 94}
+      subprogram: {subprogram: 88}
       events:
         - ID: 88
           Type: 369 EventRootType Probe[main.stackC]
@@ -22,7 +22,7 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 51}
+      subprogram: {subprogram: 45}
       events:
         - ID: 45
           Type: 326 EventRootType Probe[main.testAny]
@@ -36,7 +36,7 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 21}
+      subprogram: {subprogram: 15}
       events:
         - ID: 15
           Type: 296 EventRootType Probe[main.testArrayOfArrays]
@@ -50,7 +50,7 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 23}
+      subprogram: {subprogram: 17}
       events:
         - ID: 17
           Type: 298 EventRootType Probe[main.testArrayOfArraysOfArrays]
@@ -64,7 +64,7 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 59}
+      subprogram: {subprogram: 53}
       events:
         - ID: 53
           Type: 334 EventRootType Probe[main.testArrayOfMaps]
@@ -78,7 +78,7 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 22}
+      subprogram: {subprogram: 16}
       events:
         - ID: 16
           Type: 297 EventRootType Probe[main.testArrayOfStrings]
@@ -92,7 +92,7 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 41}
+      subprogram: {subprogram: 35}
       events:
         - ID: 35
           Type: 316 EventRootType Probe[main.testBigStruct]
@@ -106,7 +106,7 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 10}
+      subprogram: {subprogram: 4}
       events:
         - ID: 4
           Type: 285 EventRootType Probe[main.testBoolArray]
@@ -120,7 +120,7 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 7}
+      subprogram: {subprogram: 1}
       events:
         - ID: 1
           Type: 282 EventRootType Probe[main.testByteArray]
@@ -134,7 +134,7 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 75}
+      subprogram: {subprogram: 69}
       events:
         - ID: 69
           Type: 350 EventRootType Probe[main.testChannel]
@@ -148,7 +148,7 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 73}
+      subprogram: {subprogram: 67}
       events:
         - ID: 67
           Type: 348 EventRootType Probe[main.testCombinedByte]
@@ -162,7 +162,7 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 83}
+      subprogram: {subprogram: 77}
       events:
         - ID: 77
           Type: 358 EventRootType Probe[main.testCycle]
@@ -176,7 +176,7 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 85}
+      subprogram: {subprogram: 79}
       events:
         - ID: 79
           Type: 360 EventRootType Probe[main.testEmptySlice]
@@ -190,7 +190,7 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 88}
+      subprogram: {subprogram: 82}
       events:
         - ID: 82
           Type: 363 EventRootType Probe[main.testEmptySliceOfStructs]
@@ -204,7 +204,7 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 102}
+      subprogram: {subprogram: 96}
       events:
         - ID: 96
           Type: 377 EventRootType Probe[main.testEmptyString]
@@ -218,7 +218,7 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 104}
+      subprogram: {subprogram: 98}
       events:
         - ID: 98
           Type: 379 EventRootType Probe[main.testEmptyStruct]
@@ -232,7 +232,7 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 52}
+      subprogram: {subprogram: 46}
       events:
         - ID: 46
           Type: 327 EventRootType Probe[main.testError]
@@ -246,7 +246,7 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 43}
+      subprogram: {subprogram: 37}
       events:
         - ID: 37
           Type: 318 EventRootType Probe[main.testEsotericHeap]
@@ -260,7 +260,7 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 42}
+      subprogram: {subprogram: 36}
       events:
         - ID: 36
           Type: 317 EventRootType Probe[main.testEsotericStack]
@@ -274,7 +274,7 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 48}
+      subprogram: {subprogram: 42}
       events:
         - ID: 42
           Type: 323 EventRootType Probe[main.testFrameless]
@@ -288,7 +288,7 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 49}
+      subprogram: {subprogram: 43}
       events:
         - ID: 43
           Type: 324 EventRootType Probe[main.testFramelessArray]
@@ -302,7 +302,7 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 44}
+      subprogram: {subprogram: 38}
       events:
         - ID: 38
           Type: 319 EventRootType Probe[main.testInlinedBA]
@@ -316,7 +316,7 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 45}
+      subprogram: {subprogram: 39}
       events:
         - ID: 39
           Type: 320 EventRootType Probe[main.testInlinedBB]
@@ -330,7 +330,7 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 46}
+      subprogram: {subprogram: 40}
       events:
         - ID: 40
           Type: 321 EventRootType Probe[main.testInlinedBBA]
@@ -344,7 +344,7 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 2}
+      subprogram: {subprogram: 100}
       events:
         - ID: 100
           Type: 381 EventRootType Probe[main.testInlinedBBB]
@@ -358,7 +358,7 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 47}
+      subprogram: {subprogram: 41}
       events:
         - ID: 41
           Type: 322 EventRootType Probe[main.testInlinedBC]
@@ -372,7 +372,7 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 3}
+      subprogram: {subprogram: 101}
       events:
         - ID: 101
           Type: 382 EventRootType Probe[main.testInlinedBCA]
@@ -386,7 +386,7 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 4}
+      subprogram: {subprogram: 102}
       events:
         - ID: 102
           Type: 383 EventRootType Probe[main.testInlinedBCB]
@@ -401,7 +401,7 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 1}
+      subprogram: {subprogram: 99}
       events:
         - ID: 99
           Type: 380 EventRootType Probe[main.testInlinedPrint]
@@ -425,7 +425,7 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 5}
+      subprogram: {subprogram: 103}
       events:
         - ID: 103
           Type: 384 EventRootType Probe[main.testInlinedSq]
@@ -440,7 +440,7 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 6}
+      subprogram: {subprogram: 104}
       events:
         - ID: 104
           Type: 385 EventRootType Probe[main.testInlinedSumArray]
@@ -458,7 +458,7 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 13}
+      subprogram: {subprogram: 7}
       events:
         - ID: 7
           Type: 288 EventRootType Probe[main.testInt16Array]
@@ -472,7 +472,7 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 14}
+      subprogram: {subprogram: 8}
       events:
         - ID: 8
           Type: 289 EventRootType Probe[main.testInt32Array]
@@ -486,7 +486,7 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 15}
+      subprogram: {subprogram: 9}
       events:
         - ID: 9
           Type: 290 EventRootType Probe[main.testInt64Array]
@@ -500,7 +500,7 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 12}
+      subprogram: {subprogram: 6}
       events:
         - ID: 6
           Type: 287 EventRootType Probe[main.testInt8Array]
@@ -514,7 +514,7 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 11}
+      subprogram: {subprogram: 5}
       events:
         - ID: 5
           Type: 286 EventRootType Probe[main.testIntArray]
@@ -528,7 +528,7 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 50}
+      subprogram: {subprogram: 44}
       events:
         - ID: 44
           Type: 325 EventRootType Probe[main.testInterface]
@@ -542,7 +542,7 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 77}
+      subprogram: {subprogram: 71}
       events:
         - ID: 71
           Type: 352 EventRootType Probe[main.testLinkedList]
@@ -556,7 +556,7 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 57}
+      subprogram: {subprogram: 51}
       events:
         - ID: 51
           Type: 332 EventRootType Probe[main.testMapArrayToArray]
@@ -570,7 +570,7 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 63}
+      subprogram: {subprogram: 57}
       events:
         - ID: 57
           Type: 338 EventRootType Probe[main.testMapEmbeddedMaps]
@@ -584,7 +584,7 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 61}
+      subprogram: {subprogram: 55}
       events:
         - ID: 55
           Type: 336 EventRootType Probe[main.testMapIntToInt]
@@ -598,7 +598,7 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 72}
+      subprogram: {subprogram: 66}
       events:
         - ID: 66
           Type: 347 EventRootType Probe[main.testMapLargeKeyLargeValue]
@@ -612,7 +612,7 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 71}
+      subprogram: {subprogram: 65}
       events:
         - ID: 65
           Type: 346 EventRootType Probe[main.testMapLargeKeySmallValue]
@@ -626,7 +626,7 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 62}
+      subprogram: {subprogram: 56}
       events:
         - ID: 56
           Type: 337 EventRootType Probe[main.testMapMassive]
@@ -640,7 +640,7 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 70}
+      subprogram: {subprogram: 64}
       events:
         - ID: 64
           Type: 345 EventRootType Probe[main.testMapSmallKeyLargeValue]
@@ -654,7 +654,7 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 69}
+      subprogram: {subprogram: 63}
       events:
         - ID: 63
           Type: 344 EventRootType Probe[main.testMapSmallKeySmallValue]
@@ -668,7 +668,7 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 55}
+      subprogram: {subprogram: 49}
       events:
         - ID: 49
           Type: 330 EventRootType Probe[main.testMapStringToInt]
@@ -682,7 +682,7 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 56}
+      subprogram: {subprogram: 50}
       events:
         - ID: 50
           Type: 331 EventRootType Probe[main.testMapStringToSlice]
@@ -696,7 +696,7 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 54}
+      subprogram: {subprogram: 48}
       events:
         - ID: 48
           Type: 329 EventRootType Probe[main.testMapStringToStruct]
@@ -710,7 +710,7 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 64}
+      subprogram: {subprogram: 58}
       events:
         - ID: 58
           Type: 339 EventRootType Probe[main.testMapWithLinkedList]
@@ -724,7 +724,7 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 67}
+      subprogram: {subprogram: 61}
       events:
         - ID: 61
           Type: 342 EventRootType Probe[main.testMapWithSmallKeyAndValue]
@@ -738,7 +738,7 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 68}
+      subprogram: {subprogram: 62}
       events:
         - ID: 62
           Type: 343 EventRootType Probe[main.testMapWithSmallKeyAndValueMassive]
@@ -752,7 +752,7 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 65}
+      subprogram: {subprogram: 59}
       events:
         - ID: 59
           Type: 340 EventRootType Probe[main.testMapWithSmallValue]
@@ -766,7 +766,7 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 66}
+      subprogram: {subprogram: 60}
       events:
         - ID: 60
           Type: 341 EventRootType Probe[main.testMapWithSmallValueMassive]
@@ -780,7 +780,7 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 100}
+      subprogram: {subprogram: 94}
       events:
         - ID: 94
           Type: 375 EventRootType Probe[main.testMassiveString]
@@ -794,7 +794,7 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 74}
+      subprogram: {subprogram: 68}
       events:
         - ID: 68
           Type: 349 EventRootType Probe[main.testMultipleSimpleParams]
@@ -808,7 +808,7 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 82}
+      subprogram: {subprogram: 76}
       events:
         - ID: 76
           Type: 357 EventRootType Probe[main.testNilPointer]
@@ -822,7 +822,7 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 92}
+      subprogram: {subprogram: 86}
       events:
         - ID: 86
           Type: 367 EventRootType Probe[main.testNilSlice]
@@ -836,7 +836,7 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 89}
+      subprogram: {subprogram: 83}
       events:
         - ID: 83
           Type: 364 EventRootType Probe[main.testNilSliceOfStructs]
@@ -850,7 +850,7 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 91}
+      subprogram: {subprogram: 85}
       events:
         - ID: 85
           Type: 366 EventRootType Probe[main.testNilSliceWithOtherParams]
@@ -864,7 +864,7 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 99}
+      subprogram: {subprogram: 93}
       events:
         - ID: 93
           Type: 374 EventRootType Probe[main.testOneStringInStructPointer]
@@ -878,7 +878,7 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 78}
+      subprogram: {subprogram: 72}
       events:
         - ID: 72
           Type: 353 EventRootType Probe[main.testPointerLoop]
@@ -892,7 +892,7 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 60}
+      subprogram: {subprogram: 54}
       events:
         - ID: 54
           Type: 335 EventRootType Probe[main.testPointerToMap]
@@ -906,7 +906,7 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 76}
+      subprogram: {subprogram: 70}
       events:
         - ID: 70
           Type: 351 EventRootType Probe[main.testPointerToSimpleStruct]
@@ -920,7 +920,7 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 8}
+      subprogram: {subprogram: 2}
       events:
         - ID: 2
           Type: 283 EventRootType Probe[main.testRuneArray]
@@ -934,7 +934,7 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 27}
+      subprogram: {subprogram: 21}
       events:
         - ID: 21
           Type: 302 EventRootType Probe[main.testSingleBool]
@@ -948,7 +948,7 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 25}
+      subprogram: {subprogram: 19}
       events:
         - ID: 19
           Type: 300 EventRootType Probe[main.testSingleByte]
@@ -962,7 +962,7 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 38}
+      subprogram: {subprogram: 32}
       events:
         - ID: 32
           Type: 313 EventRootType Probe[main.testSingleFloat32]
@@ -976,7 +976,7 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 39}
+      subprogram: {subprogram: 33}
       events:
         - ID: 33
           Type: 314 EventRootType Probe[main.testSingleFloat64]
@@ -990,7 +990,7 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 28}
+      subprogram: {subprogram: 22}
       events:
         - ID: 22
           Type: 303 EventRootType Probe[main.testSingleInt]
@@ -1004,7 +1004,7 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 30}
+      subprogram: {subprogram: 24}
       events:
         - ID: 24
           Type: 305 EventRootType Probe[main.testSingleInt16]
@@ -1018,7 +1018,7 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 31}
+      subprogram: {subprogram: 25}
       events:
         - ID: 25
           Type: 306 EventRootType Probe[main.testSingleInt32]
@@ -1032,7 +1032,7 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 32}
+      subprogram: {subprogram: 26}
       events:
         - ID: 26
           Type: 307 EventRootType Probe[main.testSingleInt64]
@@ -1046,7 +1046,7 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 29}
+      subprogram: {subprogram: 23}
       events:
         - ID: 23
           Type: 304 EventRootType Probe[main.testSingleInt8]
@@ -1060,7 +1060,7 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 26}
+      subprogram: {subprogram: 20}
       events:
         - ID: 20
           Type: 301 EventRootType Probe[main.testSingleRune]
@@ -1074,7 +1074,7 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 95}
+      subprogram: {subprogram: 89}
       events:
         - ID: 89
           Type: 370 EventRootType Probe[main.testSingleString]
@@ -1088,7 +1088,7 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 33}
+      subprogram: {subprogram: 27}
       events:
         - ID: 27
           Type: 308 EventRootType Probe[main.testSingleUint]
@@ -1102,7 +1102,7 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 35}
+      subprogram: {subprogram: 29}
       events:
         - ID: 29
           Type: 310 EventRootType Probe[main.testSingleUint16]
@@ -1116,7 +1116,7 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 36}
+      subprogram: {subprogram: 30}
       events:
         - ID: 30
           Type: 311 EventRootType Probe[main.testSingleUint32]
@@ -1130,7 +1130,7 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 37}
+      subprogram: {subprogram: 31}
       events:
         - ID: 31
           Type: 312 EventRootType Probe[main.testSingleUint64]
@@ -1144,7 +1144,7 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 34}
+      subprogram: {subprogram: 28}
       events:
         - ID: 28
           Type: 309 EventRootType Probe[main.testSingleUint8]
@@ -1158,7 +1158,7 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 86}
+      subprogram: {subprogram: 80}
       events:
         - ID: 80
           Type: 361 EventRootType Probe[main.testSliceOfSlices]
@@ -1172,7 +1172,7 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 58}
+      subprogram: {subprogram: 52}
       events:
         - ID: 52
           Type: 333 EventRootType Probe[main.testSmallMap]
@@ -1186,7 +1186,7 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 9}
+      subprogram: {subprogram: 3}
       events:
         - ID: 3
           Type: 284 EventRootType Probe[main.testStringArray]
@@ -1200,7 +1200,7 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 81}
+      subprogram: {subprogram: 75}
       events:
         - ID: 75
           Type: 356 EventRootType Probe[main.testStringPointer]
@@ -1214,7 +1214,7 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 90}
+      subprogram: {subprogram: 84}
       events:
         - ID: 84
           Type: 365 EventRootType Probe[main.testStringSlice]
@@ -1228,7 +1228,7 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 103}
+      subprogram: {subprogram: 97}
       events:
         - ID: 97
           Type: 378 EventRootType Probe[main.testStruct]
@@ -1242,7 +1242,7 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 87}
+      subprogram: {subprogram: 81}
       events:
         - ID: 81
           Type: 362 EventRootType Probe[main.testStructSlice]
@@ -1256,7 +1256,7 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 53}
+      subprogram: {subprogram: 47}
       events:
         - ID: 47
           Type: 328 EventRootType Probe[main.testStructWithMap]
@@ -1270,7 +1270,7 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 96}
+      subprogram: {subprogram: 90}
       events:
         - ID: 90
           Type: 371 EventRootType Probe[main.testThreeStrings]
@@ -1284,7 +1284,7 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 97}
+      subprogram: {subprogram: 91}
       events:
         - ID: 91
           Type: 372 EventRootType Probe[main.testThreeStringsInStruct]
@@ -1298,7 +1298,7 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 98}
+      subprogram: {subprogram: 92}
       events:
         - ID: 92
           Type: 373 EventRootType Probe[main.testThreeStringsInStructPointer]
@@ -1312,7 +1312,7 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 40}
+      subprogram: {subprogram: 34}
       events:
         - ID: 34
           Type: 315 EventRootType Probe[main.testTypeAlias]
@@ -1326,7 +1326,7 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 18}
+      subprogram: {subprogram: 12}
       events:
         - ID: 12
           Type: 293 EventRootType Probe[main.testUint16Array]
@@ -1340,7 +1340,7 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 19}
+      subprogram: {subprogram: 13}
       events:
         - ID: 13
           Type: 294 EventRootType Probe[main.testUint32Array]
@@ -1354,7 +1354,7 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 20}
+      subprogram: {subprogram: 14}
       events:
         - ID: 14
           Type: 295 EventRootType Probe[main.testUint64Array]
@@ -1368,7 +1368,7 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 17}
+      subprogram: {subprogram: 11}
       events:
         - ID: 11
           Type: 292 EventRootType Probe[main.testUint8Array]
@@ -1382,7 +1382,7 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 16}
+      subprogram: {subprogram: 10}
       events:
         - ID: 10
           Type: 291 EventRootType Probe[main.testUintArray]
@@ -1396,7 +1396,7 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 80}
+      subprogram: {subprogram: 74}
       events:
         - ID: 74
           Type: 355 EventRootType Probe[main.testUintPointer]
@@ -1410,7 +1410,7 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 84}
+      subprogram: {subprogram: 78}
       events:
         - ID: 78
           Type: 359 EventRootType Probe[main.testUintSlice]
@@ -1424,7 +1424,7 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 101}
+      subprogram: {subprogram: 95}
       events:
         - ID: 95
           Type: 376 EventRootType Probe[main.testUnitializedString]
@@ -1438,7 +1438,7 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 79}
+      subprogram: {subprogram: 73}
       events:
         - ID: 73
           Type: 354 EventRootType Probe[main.testUnsafePointer]
@@ -1452,7 +1452,7 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 24}
+      subprogram: {subprogram: 18}
       events:
         - ID: 18
           Type: 299 EventRootType Probe[main.testVeryLargeArray]
@@ -1466,428 +1466,428 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 93}
+      subprogram: {subprogram: 87}
       events:
         - ID: 87
           Type: 368 EventRootType Probe[main.testVeryLargeSlice]
           InjectionPoints: [{PC: "0xcdc920", Frameless: true}]
           Condition: null
 Subprograms:
-    - ID: 7
+    - ID: 1
       Name: main.testByteArray
       OutOfLinePCRanges: [0xcd85c0..0xcd85c1]
       InlinePCRanges: []
       Variables:
         - Name: x
-          Type: 3 ArrayType [2]uint8
+          Type: 36 ArrayType [2]uint8
           Locations:
             - Range: 0xcd85c0..0xcd85c1
               Pieces: [{Size: 2, Op: {CfaOffset: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 8
+    - ID: 2
       Name: main.testRuneArray
       OutOfLinePCRanges: [0xcd85e0..0xcd85e1]
       InlinePCRanges: []
       Variables:
         - Name: x
-          Type: 5 ArrayType [2]int32
+          Type: 37 ArrayType [2]int32
           Locations:
             - Range: 0xcd85e0..0xcd85e1
               Pieces: [{Size: 8, Op: {CfaOffset: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 9
+    - ID: 3
       Name: main.testStringArray
       OutOfLinePCRanges: [0xcd8600..0xcd8601]
       InlinePCRanges: []
       Variables:
         - Name: x
-          Type: 7 ArrayType [2]string
+          Type: 38 ArrayType [2]string
           Locations:
             - Range: 0xcd8600..0xcd8601
               Pieces: [{Size: 32, Op: {CfaOffset: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 10
+    - ID: 4
       Name: main.testBoolArray
       OutOfLinePCRanges: [0xcd8620..0xcd8621]
       InlinePCRanges: []
       Variables:
         - Name: x
-          Type: 10 ArrayType [2]bool
+          Type: 39 ArrayType [2]bool
           Locations:
             - Range: 0xcd8620..0xcd8621
               Pieces: [{Size: 2, Op: {CfaOffset: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 11
+    - ID: 5
       Name: main.testIntArray
       OutOfLinePCRanges: [0xcd8640..0xcd8641]
       InlinePCRanges: []
       Variables:
         - Name: x
-          Type: 12 ArrayType [2]int
+          Type: 40 ArrayType [2]int
           Locations:
             - Range: 0xcd8640..0xcd8641
               Pieces: [{Size: 16, Op: {CfaOffset: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 12
+    - ID: 6
       Name: main.testInt8Array
       OutOfLinePCRanges: [0xcd8660..0xcd8661]
       InlinePCRanges: []
       Variables:
         - Name: x
-          Type: 13 ArrayType [2]int8
+          Type: 41 ArrayType [2]int8
           Locations:
             - Range: 0xcd8660..0xcd8661
               Pieces: [{Size: 2, Op: {CfaOffset: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 13
+    - ID: 7
       Name: main.testInt16Array
       OutOfLinePCRanges: [0xcd8680..0xcd8681]
       InlinePCRanges: []
       Variables:
         - Name: x
-          Type: 15 ArrayType [2]int16
+          Type: 42 ArrayType [2]int16
           Locations:
             - Range: 0xcd8680..0xcd8681
               Pieces: [{Size: 4, Op: {CfaOffset: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 14
+    - ID: 8
       Name: main.testInt32Array
       OutOfLinePCRanges: [0xcd86a0..0xcd86a1]
       InlinePCRanges: []
       Variables:
         - Name: x
-          Type: 5 ArrayType [2]int32
+          Type: 37 ArrayType [2]int32
           Locations:
             - Range: 0xcd86a0..0xcd86a1
               Pieces: [{Size: 8, Op: {CfaOffset: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 15
+    - ID: 9
       Name: main.testInt64Array
       OutOfLinePCRanges: [0xcd86c0..0xcd86c1]
       InlinePCRanges: []
       Variables:
         - Name: x
-          Type: 17 ArrayType [2]int64
+          Type: 43 ArrayType [2]int64
           Locations:
             - Range: 0xcd86c0..0xcd86c1
               Pieces: [{Size: 16, Op: {CfaOffset: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 16
+    - ID: 10
       Name: main.testUintArray
       OutOfLinePCRanges: [0xcd86e0..0xcd86e1]
       InlinePCRanges: []
       Variables:
         - Name: x
-          Type: 19 ArrayType [2]uint
+          Type: 44 ArrayType [2]uint
           Locations:
             - Range: 0xcd86e0..0xcd86e1
               Pieces: [{Size: 16, Op: {CfaOffset: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 17
+    - ID: 11
       Name: main.testUint8Array
       OutOfLinePCRanges: [0xcd8700..0xcd8701]
       InlinePCRanges: []
       Variables:
         - Name: x
-          Type: 3 ArrayType [2]uint8
+          Type: 36 ArrayType [2]uint8
           Locations:
             - Range: 0xcd8700..0xcd8701
               Pieces: [{Size: 2, Op: {CfaOffset: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 18
+    - ID: 12
       Name: main.testUint16Array
       OutOfLinePCRanges: [0xcd8720..0xcd8721]
       InlinePCRanges: []
       Variables:
         - Name: x
-          Type: 21 ArrayType [2]uint16
+          Type: 45 ArrayType [2]uint16
           Locations:
             - Range: 0xcd8720..0xcd8721
               Pieces: [{Size: 4, Op: {CfaOffset: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 19
+    - ID: 13
       Name: main.testUint32Array
       OutOfLinePCRanges: [0xcd8740..0xcd8741]
       InlinePCRanges: []
       Variables:
         - Name: x
-          Type: 23 ArrayType [2]uint32
+          Type: 46 ArrayType [2]uint32
           Locations:
             - Range: 0xcd8740..0xcd8741
               Pieces: [{Size: 8, Op: {CfaOffset: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 20
+    - ID: 14
       Name: main.testUint64Array
       OutOfLinePCRanges: [0xcd8760..0xcd8761]
       InlinePCRanges: []
       Variables:
         - Name: x
-          Type: 25 ArrayType [2]uint64
+          Type: 47 ArrayType [2]uint64
           Locations:
             - Range: 0xcd8760..0xcd8761
               Pieces: [{Size: 16, Op: {CfaOffset: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 21
+    - ID: 15
       Name: main.testArrayOfArrays
       OutOfLinePCRanges: [0xcd8780..0xcd8781]
       InlinePCRanges: []
       Variables:
         - Name: a
-          Type: 27 ArrayType [2][2]int
+          Type: 48 ArrayType [2][2]int
           Locations:
             - Range: 0xcd8780..0xcd8781
               Pieces: [{Size: 32, Op: {CfaOffset: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 22
+    - ID: 16
       Name: main.testArrayOfStrings
       OutOfLinePCRanges: [0xcd87a0..0xcd87a1]
       InlinePCRanges: []
       Variables:
         - Name: a
-          Type: 7 ArrayType [2]string
+          Type: 38 ArrayType [2]string
           Locations:
             - Range: 0xcd87a0..0xcd87a1
               Pieces: [{Size: 32, Op: {CfaOffset: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 23
+    - ID: 17
       Name: main.testArrayOfArraysOfArrays
       OutOfLinePCRanges: [0xcd87c0..0xcd87c1]
       InlinePCRanges: []
       Variables:
         - Name: b
-          Type: 28 ArrayType [2][2][2]int
+          Type: 49 ArrayType [2][2][2]int
           Locations:
             - Range: 0xcd87c0..0xcd87c1
               Pieces: [{Size: 64, Op: {CfaOffset: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 24
+    - ID: 18
       Name: main.testVeryLargeArray
       OutOfLinePCRanges: [0xcd8820..0xcd8821]
       InlinePCRanges: []
       Variables:
         - Name: a
-          Type: 29 ArrayType [100]uint
+          Type: 50 ArrayType [100]uint
           Locations:
             - Range: 0xcd8820..0xcd8821
               Pieces: [{Size: 800, Op: {CfaOffset: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 25
+    - ID: 19
       Name: main.testSingleByte
       OutOfLinePCRanges: [0xcd8ba0..0xcd8ba1]
       InlinePCRanges: []
       Variables:
         - Name: x
-          Type: 4 BaseType uint8
+          Type: 3 BaseType uint8
           Locations:
             - Range: 0xcd8ba0..0xcd8ba1
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 26
+    - ID: 20
       Name: main.testSingleRune
       OutOfLinePCRanges: [0xcd8bc0..0xcd8bc1]
       InlinePCRanges: []
       Variables:
         - Name: x
-          Type: 6 BaseType int32
+          Type: 10 BaseType int32
           Locations:
             - Range: 0xcd8bc0..0xcd8bc1
               Pieces: [{Size: 4, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 27
+    - ID: 21
       Name: main.testSingleBool
       OutOfLinePCRanges: [0xcd8be0..0xcd8be1]
       InlinePCRanges: []
       Variables:
         - Name: x
-          Type: 11 BaseType bool
+          Type: 4 BaseType bool
           Locations:
             - Range: 0xcd8be0..0xcd8be1
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 28
+    - ID: 22
       Name: main.testSingleInt
       OutOfLinePCRanges: [0xcd8c00..0xcd8c01]
       InlinePCRanges: []
       Variables:
         - Name: x
-          Type: 1 BaseType int
+          Type: 7 BaseType int
           Locations:
             - Range: 0xcd8c00..0xcd8c01
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 29
+    - ID: 23
       Name: main.testSingleInt8
       OutOfLinePCRanges: [0xcd8c20..0xcd8c21]
       InlinePCRanges: []
       Variables:
         - Name: x
-          Type: 14 BaseType int8
+          Type: 16 BaseType int8
           Locations:
             - Range: 0xcd8c20..0xcd8c21
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 30
+    - ID: 24
       Name: main.testSingleInt16
       OutOfLinePCRanges: [0xcd8c40..0xcd8c41]
       InlinePCRanges: []
       Variables:
         - Name: x
-          Type: 16 BaseType int16
+          Type: 31 BaseType int16
           Locations:
             - Range: 0xcd8c40..0xcd8c41
               Pieces: [{Size: 2, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 31
+    - ID: 25
       Name: main.testSingleInt32
       OutOfLinePCRanges: [0xcd8c60..0xcd8c61]
       InlinePCRanges: []
       Variables:
         - Name: x
-          Type: 6 BaseType int32
+          Type: 10 BaseType int32
           Locations:
             - Range: 0xcd8c60..0xcd8c61
               Pieces: [{Size: 4, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 32
+    - ID: 26
       Name: main.testSingleInt64
       OutOfLinePCRanges: [0xcd8c80..0xcd8c81]
       InlinePCRanges: []
       Variables:
         - Name: x
-          Type: 18 BaseType int64
+          Type: 12 BaseType int64
           Locations:
             - Range: 0xcd8c80..0xcd8c81
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 33
+    - ID: 27
       Name: main.testSingleUint
       OutOfLinePCRanges: [0xcd8ca0..0xcd8ca1]
       InlinePCRanges: []
       Variables:
         - Name: x
-          Type: 20 BaseType uint
+          Type: 17 BaseType uint
           Locations:
             - Range: 0xcd8ca0..0xcd8ca1
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 34
+    - ID: 28
       Name: main.testSingleUint8
       OutOfLinePCRanges: [0xcd8cc0..0xcd8cc1]
       InlinePCRanges: []
       Variables:
         - Name: x
-          Type: 4 BaseType uint8
+          Type: 3 BaseType uint8
           Locations:
             - Range: 0xcd8cc0..0xcd8cc1
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 35
+    - ID: 29
       Name: main.testSingleUint16
       OutOfLinePCRanges: [0xcd8ce0..0xcd8ce1]
       InlinePCRanges: []
       Variables:
         - Name: x
-          Type: 22 BaseType uint16
+          Type: 6 BaseType uint16
           Locations:
             - Range: 0xcd8ce0..0xcd8ce1
               Pieces: [{Size: 2, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 36
+    - ID: 30
       Name: main.testSingleUint32
       OutOfLinePCRanges: [0xcd8d00..0xcd8d01]
       InlinePCRanges: []
       Variables:
         - Name: x
-          Type: 24 BaseType uint32
+          Type: 2 BaseType uint32
           Locations:
             - Range: 0xcd8d00..0xcd8d01
               Pieces: [{Size: 4, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 37
+    - ID: 31
       Name: main.testSingleUint64
       OutOfLinePCRanges: [0xcd8d20..0xcd8d21]
       InlinePCRanges: []
       Variables:
         - Name: x
-          Type: 26 BaseType uint64
+          Type: 8 BaseType uint64
           Locations:
             - Range: 0xcd8d20..0xcd8d21
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 38
+    - ID: 32
       Name: main.testSingleFloat32
       OutOfLinePCRanges: [0xcd8d40..0xcd8d41]
       InlinePCRanges: []
       Variables:
         - Name: x
-          Type: 30 BaseType float32
+          Type: 18 BaseType float32
           Locations:
             - Range: 0xcd8d40..0xcd8d41
               Pieces: [{Size: 4, Op: {RegNo: 17, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 39
+    - ID: 33
       Name: main.testSingleFloat64
       OutOfLinePCRanges: [0xcd8d60..0xcd8d61]
       InlinePCRanges: []
       Variables:
         - Name: x
-          Type: 31 BaseType float64
+          Type: 15 BaseType float64
           Locations:
             - Range: 0xcd8d60..0xcd8d61
               Pieces: [{Size: 8, Op: {RegNo: 17, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 40
+    - ID: 34
       Name: main.testTypeAlias
       OutOfLinePCRanges: [0xcd8d80..0xcd8d81]
       InlinePCRanges: []
       Variables:
         - Name: x
-          Type: 32 BaseType main.typeAlias
+          Type: 51 BaseType main.typeAlias
           Locations:
             - Range: 0xcd8d80..0xcd8d81
               Pieces: [{Size: 2, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 41
+    - ID: 35
       Name: main.testBigStruct
       OutOfLinePCRanges: [0xcd8ee0..0xcd8eff]
       InlinePCRanges: []
       Variables:
         - Name: b
-          Type: 33 StructureType main.bigStruct
+          Type: 52 StructureType main.bigStruct
           Locations:
             - Range: 0xcd8ee0..0xcd8eff
               Pieces:
@@ -1905,13 +1905,13 @@ Subprograms:
                   Op: {RegNo: 8, Shift: 0}
           IsParameter: true
           IsReturn: false
-    - ID: 42
+    - ID: 36
       Name: main.testEsotericStack
       OutOfLinePCRanges: [0xcd9160..0xcd9265]
       InlinePCRanges: []
       Variables:
         - Name: e
-          Type: 39 StructureType main.esotericStack
+          Type: 56 StructureType main.esotericStack
           Locations:
             - Range: 0xcd9160..0xcd91b3
               Pieces:
@@ -1975,51 +1975,51 @@ Subprograms:
                   Op: {RegNo: 11, Shift: 0}
           IsParameter: true
           IsReturn: false
-    - ID: 43
+    - ID: 37
       Name: main.testEsotericHeap
       OutOfLinePCRanges: [0xcd9280..0xcd92e3]
       InlinePCRanges: []
       Variables:
         - Name: e
-          Type: 44 PointerType *main.esotericHeap
+          Type: 61 PointerType *main.esotericHeap
           Locations:
             - Range: 0xcd9280..0xcd92ad
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 44
+    - ID: 38
       Name: main.testInlinedBA
       OutOfLinePCRanges: [0xcd96c0..0xcd9748]
       InlinePCRanges: []
       Variables:
         - Name: x
-          Type: 1 BaseType int
+          Type: 7 BaseType int
           Locations:
             - Range: 0xcd96c0..0xcd96d5
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 45
+    - ID: 39
       Name: main.testInlinedBB
       OutOfLinePCRanges: [0xcd9760..0xcd9825]
       InlinePCRanges: []
       Variables:
         - Name: x
-          Type: 1 BaseType int
+          Type: 7 BaseType int
           Locations:
             - Range: 0xcd9760..0xcd9776
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
         - Name: y
-          Type: 1 BaseType int
+          Type: 7 BaseType int
           Locations:
             - Range: 0xcd9760..0xcd9787
               Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
           IsParameter: true
           IsReturn: false
         - Name: z
-          Type: 1 BaseType int
+          Type: 7 BaseType int
           Locations:
             - Range: 0xcd9776..0xcd9787
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
@@ -2027,25 +2027,25 @@ Subprograms:
               Pieces: [{Size: 8, Op: {CfaOffset: -56}}]
           IsParameter: false
           IsReturn: false
-    - ID: 46
+    - ID: 40
       Name: main.testInlinedBBA
       OutOfLinePCRanges: [0xcd9840..0xcd98a2]
       InlinePCRanges: []
       Variables:
         - Name: x
-          Type: 1 BaseType int
+          Type: 7 BaseType int
           Locations:
             - Range: 0xcd9840..0xcd985a
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 47
+    - ID: 41
       Name: main.testInlinedBC
       OutOfLinePCRanges: [0xcd98c0..0xcd99c5]
       InlinePCRanges: []
       Variables:
         - Name: s
-          Type: 1 BaseType int
+          Type: 7 BaseType int
           Locations:
             - Range: 0xcd991b..0xcd9925
               Pieces: [{Size: 8, Op: {CfaOffset: -80}}]
@@ -2056,7 +2056,7 @@ Subprograms:
           IsParameter: false
           IsReturn: false
         - Name: i
-          Type: 1 BaseType int
+          Type: 7 BaseType int
           Locations:
             - Range: 0xcd9916..0xcd9920
               Pieces: [{Size: 8, Op: {CfaOffset: -72}}]
@@ -2066,47 +2066,47 @@ Subprograms:
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: false
           IsReturn: false
-    - ID: 48
+    - ID: 42
       Name: main.testFrameless
       OutOfLinePCRanges: [0xcd99e0..0xcd99e6]
       InlinePCRanges: []
       Variables:
         - Name: x
-          Type: 1 BaseType int
+          Type: 7 BaseType int
           Locations:
             - Range: 0xcd99e0..0xcd99e5
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
         - Name: ~r0
-          Type: 1 BaseType int
+          Type: 7 BaseType int
           Locations: [{Range: 0xcd99e0..0xcd99e6, Pieces: []}]
           IsParameter: true
           IsReturn: true
-    - ID: 49
+    - ID: 43
       Name: main.testFramelessArray
       OutOfLinePCRanges: [0xcd9a00..0xcd9a43]
       InlinePCRanges: []
       Variables:
         - Name: a
-          Type: 2 ArrayType [5]int
+          Type: 73 ArrayType [5]int
           Locations:
             - Range: 0xcd9a00..0xcd9a43
               Pieces: [{Size: 40, Op: {CfaOffset: 0}}]
           IsParameter: true
           IsReturn: false
         - Name: ~r0
-          Type: 1 BaseType int
+          Type: 7 BaseType int
           Locations: [{Range: 0xcd9a00..0xcd9a43, Pieces: []}]
           IsParameter: true
           IsReturn: true
-    - ID: 50
+    - ID: 44
       Name: main.testInterface
       OutOfLinePCRanges: [0xcd9ce0..0xcd9d23]
       InlinePCRanges: []
       Variables:
         - Name: b
-          Type: 56 GoInterfaceType main.behavior
+          Type: 74 GoInterfaceType main.behavior
           Locations:
             - Range: 0xcd9ce0..0xcd9cff
               Pieces:
@@ -2123,17 +2123,17 @@ Subprograms:
           IsParameter: true
           IsReturn: false
         - Name: ~r0
-          Type: 8 GoStringHeaderType string
+          Type: 9 GoStringHeaderType string
           Locations: [{Range: 0xcd9ce0..0xcd9d23, Pieces: []}]
           IsParameter: true
           IsReturn: true
-    - ID: 51
+    - ID: 45
       Name: main.testAny
       OutOfLinePCRanges: [0xcd9d40..0xcd9da6]
       InlinePCRanges: []
       Variables:
         - Name: a
-          Type: 41 GoEmptyInterfaceType interface {}
+          Type: 58 GoEmptyInterfaceType interface {}
           Locations:
             - Range: 0xcd9d40..0xcd9d69
               Pieces:
@@ -2150,17 +2150,17 @@ Subprograms:
           IsParameter: true
           IsReturn: false
         - Name: ~r0
-          Type: 8 GoStringHeaderType string
+          Type: 9 GoStringHeaderType string
           Locations: [{Range: 0xcd9d40..0xcd9da6, Pieces: []}]
           IsParameter: true
           IsReturn: true
-    - ID: 52
+    - ID: 46
       Name: main.testError
       OutOfLinePCRanges: [0xcd9dc0..0xcd9dc1]
       InlinePCRanges: []
       Variables:
         - Name: e
-          Type: 57 GoInterfaceType error
+          Type: 13 GoInterfaceType error
           Locations:
             - Range: 0xcd9dc0..0xcd9dc1
               Pieces:
@@ -2170,307 +2170,307 @@ Subprograms:
                   Op: {RegNo: 3, Shift: 0}
           IsParameter: true
           IsReturn: false
-    - ID: 53
+    - ID: 47
       Name: main.testStructWithMap
       OutOfLinePCRanges: [0xcda1c0..0xcda1c1]
       InlinePCRanges: []
       Variables:
         - Name: s
-          Type: 58 StructureType main.structWithMap
+          Type: 75 StructureType main.structWithMap
           Locations:
             - Range: 0xcda1c0..0xcda1c1
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 54
+    - ID: 48
       Name: main.testMapStringToStruct
       OutOfLinePCRanges: [0xcda1e0..0xcda1e1]
       InlinePCRanges: []
       Variables:
         - Name: m
-          Type: 71 GoMapType map[string]main.nestedStruct
+          Type: 87 GoMapType map[string]main.nestedStruct
           Locations:
             - Range: 0xcda1e0..0xcda1e1
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 55
+    - ID: 49
       Name: main.testMapStringToInt
       OutOfLinePCRanges: [0xcda200..0xcda201]
       InlinePCRanges: []
       Variables:
         - Name: m
-          Type: 83 GoMapType map[string]int
+          Type: 99 GoMapType map[string]int
           Locations:
             - Range: 0xcda200..0xcda201
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 56
+    - ID: 50
       Name: main.testMapStringToSlice
       OutOfLinePCRanges: [0xcda220..0xcda221]
       InlinePCRanges: []
       Variables:
         - Name: m
-          Type: 94 GoMapType map[string][]string
+          Type: 110 GoMapType map[string][]string
           Locations:
             - Range: 0xcda220..0xcda221
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 57
+    - ID: 51
       Name: main.testMapArrayToArray
       OutOfLinePCRanges: [0xcda240..0xcda241]
       InlinePCRanges: []
       Variables:
         - Name: m
-          Type: 106 GoMapType map[[4]string][2]int
+          Type: 122 GoMapType map[[4]string][2]int
           Locations:
             - Range: 0xcda240..0xcda241
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 58
+    - ID: 52
       Name: main.testSmallMap
       OutOfLinePCRanges: [0xcda260..0xcda261]
       InlinePCRanges: []
       Variables:
         - Name: m
-          Type: 83 GoMapType map[string]int
+          Type: 99 GoMapType map[string]int
           Locations:
             - Range: 0xcda260..0xcda261
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 59
+    - ID: 53
       Name: main.testArrayOfMaps
       OutOfLinePCRanges: [0xcda280..0xcda281]
       InlinePCRanges: []
       Variables:
         - Name: m
-          Type: 118 ArrayType [2]map[string]int
+          Type: 134 ArrayType [2]map[string]int
           Locations:
             - Range: 0xcda280..0xcda281
               Pieces: [{Size: 16, Op: {CfaOffset: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 60
+    - ID: 54
       Name: main.testPointerToMap
       OutOfLinePCRanges: [0xcda2a0..0xcda2a1]
       InlinePCRanges: []
       Variables:
         - Name: m
-          Type: 119 PointerType *map[string]int
+          Type: 135 PointerType *map[string]int
           Locations:
             - Range: 0xcda2a0..0xcda2a1
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 61
+    - ID: 55
       Name: main.testMapIntToInt
       OutOfLinePCRanges: [0xcda2c0..0xcda2c1]
       InlinePCRanges: []
       Variables:
         - Name: m
-          Type: 59 GoMapType map[int]int
+          Type: 76 GoMapType map[int]int
           Locations:
             - Range: 0xcda2c0..0xcda2c1
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 62
+    - ID: 56
       Name: main.testMapMassive
       OutOfLinePCRanges: [0xcda2e0..0xcda2e1]
       InlinePCRanges: []
       Variables:
         - Name: redactMyEntries
-          Type: 120 GoMapType map[string][]main.structWithMap
+          Type: 136 GoMapType map[string][]main.structWithMap
           Locations:
             - Range: 0xcda2e0..0xcda2e1
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 63
+    - ID: 57
       Name: main.testMapEmbeddedMaps
       OutOfLinePCRanges: [0xcda300..0xcda301]
       InlinePCRanges: []
       Variables:
         - Name: m
-          Type: 120 GoMapType map[string][]main.structWithMap
+          Type: 136 GoMapType map[string][]main.structWithMap
           Locations:
             - Range: 0xcda300..0xcda301
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 64
+    - ID: 58
       Name: main.testMapWithLinkedList
       OutOfLinePCRanges: [0xcda320..0xcda321]
       InlinePCRanges: []
       Variables:
         - Name: m
-          Type: 133 GoMapType map[bool]main.node
+          Type: 149 GoMapType map[bool]main.node
           Locations:
             - Range: 0xcda320..0xcda321
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 65
+    - ID: 59
       Name: main.testMapWithSmallValue
       OutOfLinePCRanges: [0xcda340..0xcda341]
       InlinePCRanges: []
       Variables:
         - Name: m
-          Type: 146 GoMapType map[int]uint8
+          Type: 162 GoMapType map[int]uint8
           Locations:
             - Range: 0xcda340..0xcda341
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 66
+    - ID: 60
       Name: main.testMapWithSmallValueMassive
       OutOfLinePCRanges: [0xcda360..0xcda361]
       InlinePCRanges: []
       Variables:
         - Name: redactMyEntries
-          Type: 146 GoMapType map[int]uint8
+          Type: 162 GoMapType map[int]uint8
           Locations:
             - Range: 0xcda360..0xcda361
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 67
+    - ID: 61
       Name: main.testMapWithSmallKeyAndValue
       OutOfLinePCRanges: [0xcda380..0xcda381]
       InlinePCRanges: []
       Variables:
         - Name: m
-          Type: 157 GoMapType map[uint8]uint8
+          Type: 173 GoMapType map[uint8]uint8
           Locations:
             - Range: 0xcda380..0xcda381
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 68
+    - ID: 62
       Name: main.testMapWithSmallKeyAndValueMassive
       OutOfLinePCRanges: [0xcda3a0..0xcda3a1]
       InlinePCRanges: []
       Variables:
         - Name: m
-          Type: 157 GoMapType map[uint8]uint8
+          Type: 173 GoMapType map[uint8]uint8
           Locations:
             - Range: 0xcda3a0..0xcda3a1
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 69
+    - ID: 63
       Name: main.testMapSmallKeySmallValue
       OutOfLinePCRanges: [0xcda3c0..0xcda3c1]
       InlinePCRanges: []
       Variables:
         - Name: m
-          Type: 157 GoMapType map[uint8]uint8
+          Type: 173 GoMapType map[uint8]uint8
           Locations:
             - Range: 0xcda3c0..0xcda3c1
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 70
+    - ID: 64
       Name: main.testMapSmallKeyLargeValue
       OutOfLinePCRanges: [0xcda3e0..0xcda3e1]
       InlinePCRanges: []
       Variables:
         - Name: m
-          Type: 168 GoMapType map[uint8][4]int
+          Type: 184 GoMapType map[uint8][4]int
           Locations:
             - Range: 0xcda3e0..0xcda3e1
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 71
+    - ID: 65
       Name: main.testMapLargeKeySmallValue
       OutOfLinePCRanges: [0xcda400..0xcda401]
       InlinePCRanges: []
       Variables:
         - Name: m
-          Type: 180 GoMapType map[[4]int]uint8
+          Type: 196 GoMapType map[[4]int]uint8
           Locations:
             - Range: 0xcda400..0xcda401
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 72
+    - ID: 66
       Name: main.testMapLargeKeyLargeValue
       OutOfLinePCRanges: [0xcda420..0xcda421]
       InlinePCRanges: []
       Variables:
         - Name: m
-          Type: 191 GoMapType map[[4]int][4]int
+          Type: 207 GoMapType map[[4]int][4]int
           Locations:
             - Range: 0xcda420..0xcda421
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 73
+    - ID: 67
       Name: main.testCombinedByte
       OutOfLinePCRanges: [0xcdbb60..0xcdbb61]
       InlinePCRanges: []
       Variables:
         - Name: w
-          Type: 4 BaseType uint8
+          Type: 3 BaseType uint8
           Locations:
             - Range: 0xcdbb60..0xcdbb61
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
         - Name: x
-          Type: 4 BaseType uint8
+          Type: 3 BaseType uint8
           Locations:
             - Range: 0xcdbb60..0xcdbb61
               Pieces: [{Size: 1, Op: {RegNo: 3, Shift: 0}}]
           IsParameter: true
           IsReturn: false
         - Name: y
-          Type: 30 BaseType float32
+          Type: 18 BaseType float32
           Locations:
             - Range: 0xcdbb60..0xcdbb61
               Pieces: [{Size: 4, Op: {RegNo: 17, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 74
+    - ID: 68
       Name: main.testMultipleSimpleParams
       OutOfLinePCRanges: [0xcdbd20..0xcdbd21]
       InlinePCRanges: []
       Variables:
         - Name: a
-          Type: 11 BaseType bool
+          Type: 4 BaseType bool
           Locations:
             - Range: 0xcdbd20..0xcdbd21
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
         - Name: b
-          Type: 4 BaseType uint8
+          Type: 3 BaseType uint8
           Locations:
             - Range: 0xcdbd20..0xcdbd21
               Pieces: [{Size: 1, Op: {RegNo: 3, Shift: 0}}]
           IsParameter: true
           IsReturn: false
         - Name: c
-          Type: 6 BaseType int32
+          Type: 10 BaseType int32
           Locations:
             - Range: 0xcdbd20..0xcdbd21
               Pieces: [{Size: 4, Op: {RegNo: 2, Shift: 0}}]
           IsParameter: true
           IsReturn: false
         - Name: d
-          Type: 20 BaseType uint
+          Type: 17 BaseType uint
           Locations:
             - Range: 0xcdbd20..0xcdbd21
               Pieces: [{Size: 8, Op: {RegNo: 5, Shift: 0}}]
           IsParameter: true
           IsReturn: false
         - Name: e
-          Type: 8 GoStringHeaderType string
+          Type: 9 GoStringHeaderType string
           Locations:
             - Range: 0xcdbd20..0xcdbd21
               Pieces:
@@ -2480,37 +2480,37 @@ Subprograms:
                   Op: {RegNo: 8, Shift: 0}
           IsParameter: true
           IsReturn: false
-    - ID: 75
+    - ID: 69
       Name: main.testChannel
       OutOfLinePCRanges: [0xcdbf40..0xcdbf41]
       InlinePCRanges: []
       Variables:
         - Name: c
-          Type: 202 GoChannelType chan bool
+          Type: 218 GoChannelType chan bool
           Locations:
             - Range: 0xcdbf40..0xcdbf41
               Pieces: [{Size: 0, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 76
+    - ID: 70
       Name: main.testPointerToSimpleStruct
       OutOfLinePCRanges: [0xcdc0e0..0xcdc0e1]
       InlinePCRanges: []
       Variables:
         - Name: a
-          Type: 203 PointerType *main.structWithTwoValues
+          Type: 219 PointerType *main.structWithTwoValues
           Locations:
             - Range: 0xcdc0e0..0xcdc0e1
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 77
+    - ID: 71
       Name: main.testLinkedList
       OutOfLinePCRanges: [0xcdc100..0xcdc101]
       InlinePCRanges: []
       Variables:
         - Name: a
-          Type: 144 StructureType main.node
+          Type: 160 StructureType main.node
           Locations:
             - Range: 0xcdc100..0xcdc101
               Pieces:
@@ -2520,92 +2520,92 @@ Subprograms:
                   Op: {RegNo: 3, Shift: 0}
           IsParameter: true
           IsReturn: false
-    - ID: 78
+    - ID: 72
       Name: main.testPointerLoop
       OutOfLinePCRanges: [0xcdc120..0xcdc121]
       InlinePCRanges: []
       Variables:
         - Name: a
-          Type: 145 PointerType *main.node
+          Type: 161 PointerType *main.node
           Locations:
             - Range: 0xcdc120..0xcdc121
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 79
+    - ID: 73
       Name: main.testUnsafePointer
       OutOfLinePCRanges: [0xcdc140..0xcdc141]
       InlinePCRanges: []
       Variables:
         - Name: x
-          Type: 38 VoidPointerType unsafe.Pointer
+          Type: 14 VoidPointerType unsafe.Pointer
           Locations:
             - Range: 0xcdc140..0xcdc141
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 80
+    - ID: 74
       Name: main.testUintPointer
       OutOfLinePCRanges: [0xcdc180..0xcdc181]
       InlinePCRanges: []
       Variables:
         - Name: x
-          Type: 205 PointerType *uint
+          Type: 34 PointerType *uint
           Locations:
             - Range: 0xcdc180..0xcdc181
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 81
+    - ID: 75
       Name: main.testStringPointer
       OutOfLinePCRanges: [0xcdc260..0xcdc261]
       InlinePCRanges: []
       Variables:
         - Name: z
-          Type: 36 PointerType *string
+          Type: 22 PointerType *string
           Locations:
             - Range: 0xcdc260..0xcdc261
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 82
+    - ID: 76
       Name: main.testNilPointer
       OutOfLinePCRanges: [0xcdc2a0..0xcdc2a1]
       InlinePCRanges: []
       Variables:
         - Name: z
-          Type: 206 PointerType *bool
+          Type: 11 PointerType *bool
           Locations:
             - Range: 0xcdc2a0..0xcdc2a1
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
         - Name: a
-          Type: 20 BaseType uint
+          Type: 17 BaseType uint
           Locations:
             - Range: 0xcdc2a0..0xcdc2a1
               Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 83
+    - ID: 77
       Name: main.testCycle
       OutOfLinePCRanges: [0xcdc2e0..0xcdc2e1]
       InlinePCRanges: []
       Variables:
         - Name: t
-          Type: 207 PointerType *main.t
+          Type: 221 PointerType *main.t
           Locations:
             - Range: 0xcdc2e0..0xcdc2e1
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 84
+    - ID: 78
       Name: main.testUintSlice
       OutOfLinePCRanges: [0xcdc800..0xcdc801]
       InlinePCRanges: []
       Variables:
         - Name: u
-          Type: 210 GoSliceHeaderType []uint
+          Type: 224 GoSliceHeaderType []uint
           Locations:
             - Range: 0xcdc800..0xcdc801
               Pieces:
@@ -2617,13 +2617,13 @@ Subprograms:
                   Op: {RegNo: 2, Shift: 0}
           IsParameter: true
           IsReturn: false
-    - ID: 85
+    - ID: 79
       Name: main.testEmptySlice
       OutOfLinePCRanges: [0xcdc820..0xcdc821]
       InlinePCRanges: []
       Variables:
         - Name: u
-          Type: 210 GoSliceHeaderType []uint
+          Type: 224 GoSliceHeaderType []uint
           Locations:
             - Range: 0xcdc820..0xcdc821
               Pieces:
@@ -2635,13 +2635,13 @@ Subprograms:
                   Op: {RegNo: 2, Shift: 0}
           IsParameter: true
           IsReturn: false
-    - ID: 86
+    - ID: 80
       Name: main.testSliceOfSlices
       OutOfLinePCRanges: [0xcdc840..0xcdc841]
       InlinePCRanges: []
       Variables:
         - Name: u
-          Type: 211 GoSliceHeaderType [][]uint
+          Type: 225 GoSliceHeaderType [][]uint
           Locations:
             - Range: 0xcdc840..0xcdc841
               Pieces:
@@ -2653,13 +2653,13 @@ Subprograms:
                   Op: {RegNo: 2, Shift: 0}
           IsParameter: true
           IsReturn: false
-    - ID: 87
+    - ID: 81
       Name: main.testStructSlice
       OutOfLinePCRanges: [0xcdc860..0xcdc861]
       InlinePCRanges: []
       Variables:
         - Name: xs
-          Type: 213 GoSliceHeaderType []main.structWithNoStrings
+          Type: 227 GoSliceHeaderType []main.structWithNoStrings
           Locations:
             - Range: 0xcdc860..0xcdc861
               Pieces:
@@ -2672,19 +2672,19 @@ Subprograms:
           IsParameter: true
           IsReturn: false
         - Name: a
-          Type: 1 BaseType int
+          Type: 7 BaseType int
           Locations:
             - Range: 0xcdc860..0xcdc861
               Pieces: [{Size: 8, Op: {RegNo: 5, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 88
+    - ID: 82
       Name: main.testEmptySliceOfStructs
       OutOfLinePCRanges: [0xcdc880..0xcdc881]
       InlinePCRanges: []
       Variables:
         - Name: xs
-          Type: 213 GoSliceHeaderType []main.structWithNoStrings
+          Type: 227 GoSliceHeaderType []main.structWithNoStrings
           Locations:
             - Range: 0xcdc880..0xcdc881
               Pieces:
@@ -2697,19 +2697,19 @@ Subprograms:
           IsParameter: true
           IsReturn: false
         - Name: a
-          Type: 1 BaseType int
+          Type: 7 BaseType int
           Locations:
             - Range: 0xcdc880..0xcdc881
               Pieces: [{Size: 8, Op: {RegNo: 5, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 89
+    - ID: 83
       Name: main.testNilSliceOfStructs
       OutOfLinePCRanges: [0xcdc8a0..0xcdc8a1]
       InlinePCRanges: []
       Variables:
         - Name: xs
-          Type: 213 GoSliceHeaderType []main.structWithNoStrings
+          Type: 227 GoSliceHeaderType []main.structWithNoStrings
           Locations:
             - Range: 0xcdc8a0..0xcdc8a1
               Pieces:
@@ -2722,19 +2722,19 @@ Subprograms:
           IsParameter: true
           IsReturn: false
         - Name: a
-          Type: 1 BaseType int
+          Type: 7 BaseType int
           Locations:
             - Range: 0xcdc8a0..0xcdc8a1
               Pieces: [{Size: 8, Op: {RegNo: 5, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 90
+    - ID: 84
       Name: main.testStringSlice
       OutOfLinePCRanges: [0xcdc8c0..0xcdc8c1]
       InlinePCRanges: []
       Variables:
         - Name: s
-          Type: 105 GoSliceHeaderType []string
+          Type: 121 GoSliceHeaderType []string
           Locations:
             - Range: 0xcdc8c0..0xcdc8c1
               Pieces:
@@ -2746,20 +2746,20 @@ Subprograms:
                   Op: {RegNo: 2, Shift: 0}
           IsParameter: true
           IsReturn: false
-    - ID: 91
+    - ID: 85
       Name: main.testNilSliceWithOtherParams
       OutOfLinePCRanges: [0xcdc8e0..0xcdc8e1]
       InlinePCRanges: []
       Variables:
         - Name: a
-          Type: 14 BaseType int8
+          Type: 16 BaseType int8
           Locations:
             - Range: 0xcdc8e0..0xcdc8e1
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
         - Name: s
-          Type: 216 GoSliceHeaderType []bool
+          Type: 230 GoSliceHeaderType []bool
           Locations:
             - Range: 0xcdc8e0..0xcdc8e1
               Pieces:
@@ -2772,19 +2772,19 @@ Subprograms:
           IsParameter: true
           IsReturn: false
         - Name: x
-          Type: 20 BaseType uint
+          Type: 17 BaseType uint
           Locations:
             - Range: 0xcdc8e0..0xcdc8e1
               Pieces: [{Size: 8, Op: {RegNo: 4, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 92
+    - ID: 86
       Name: main.testNilSlice
       OutOfLinePCRanges: [0xcdc900..0xcdc901]
       InlinePCRanges: []
       Variables:
         - Name: xs
-          Type: 217 GoSliceHeaderType []uint16
+          Type: 231 GoSliceHeaderType []uint16
           Locations:
             - Range: 0xcdc900..0xcdc901
               Pieces:
@@ -2796,13 +2796,13 @@ Subprograms:
                   Op: {RegNo: 2, Shift: 0}
           IsParameter: true
           IsReturn: false
-    - ID: 93
+    - ID: 87
       Name: main.testVeryLargeSlice
       OutOfLinePCRanges: [0xcdc920..0xcdc921]
       InlinePCRanges: []
       Variables:
         - Name: xs
-          Type: 210 GoSliceHeaderType []uint
+          Type: 224 GoSliceHeaderType []uint
           Locations:
             - Range: 0xcdc920..0xcdc921
               Pieces:
@@ -2814,23 +2814,23 @@ Subprograms:
                   Op: {RegNo: 2, Shift: 0}
           IsParameter: true
           IsReturn: false
-    - ID: 94
+    - ID: 88
       Name: main.stackC
       OutOfLinePCRanges: [0xcdcc60..0xcdccb2]
       InlinePCRanges: []
       Variables:
         - Name: ~r0
-          Type: 8 GoStringHeaderType string
+          Type: 9 GoStringHeaderType string
           Locations: [{Range: 0xcdcc60..0xcdccb2, Pieces: []}]
           IsParameter: true
           IsReturn: true
-    - ID: 95
+    - ID: 89
       Name: main.testSingleString
       OutOfLinePCRanges: [0xcdccc0..0xcdccc1]
       InlinePCRanges: []
       Variables:
         - Name: x
-          Type: 8 GoStringHeaderType string
+          Type: 9 GoStringHeaderType string
           Locations:
             - Range: 0xcdccc0..0xcdccc1
               Pieces:
@@ -2840,13 +2840,13 @@ Subprograms:
                   Op: {RegNo: 3, Shift: 0}
           IsParameter: true
           IsReturn: false
-    - ID: 96
+    - ID: 90
       Name: main.testThreeStrings
       OutOfLinePCRanges: [0xcdcce0..0xcdcce1]
       InlinePCRanges: []
       Variables:
         - Name: x
-          Type: 8 GoStringHeaderType string
+          Type: 9 GoStringHeaderType string
           Locations:
             - Range: 0xcdcce0..0xcdcce1
               Pieces:
@@ -2857,7 +2857,7 @@ Subprograms:
           IsParameter: true
           IsReturn: false
         - Name: y
-          Type: 8 GoStringHeaderType string
+          Type: 9 GoStringHeaderType string
           Locations:
             - Range: 0xcdcce0..0xcdcce1
               Pieces:
@@ -2868,7 +2868,7 @@ Subprograms:
           IsParameter: true
           IsReturn: false
         - Name: z
-          Type: 8 GoStringHeaderType string
+          Type: 9 GoStringHeaderType string
           Locations:
             - Range: 0xcdcce0..0xcdcce1
               Pieces:
@@ -2878,13 +2878,13 @@ Subprograms:
                   Op: {RegNo: 8, Shift: 0}
           IsParameter: true
           IsReturn: false
-    - ID: 97
+    - ID: 91
       Name: main.testThreeStringsInStruct
       OutOfLinePCRanges: [0xcdcd00..0xcdcd1f]
       InlinePCRanges: []
       Variables:
         - Name: a
-          Type: 219 StructureType main.threeStringStruct
+          Type: 232 StructureType main.threeStringStruct
           Locations:
             - Range: 0xcdcd00..0xcdcd1f
               Pieces:
@@ -2902,37 +2902,37 @@ Subprograms:
                   Op: {RegNo: 8, Shift: 0}
           IsParameter: true
           IsReturn: false
-    - ID: 98
+    - ID: 92
       Name: main.testThreeStringsInStructPointer
       OutOfLinePCRanges: [0xcdcd20..0xcdcd21]
       InlinePCRanges: []
       Variables:
         - Name: a
-          Type: 220 PointerType *main.threeStringStruct
+          Type: 233 PointerType *main.threeStringStruct
           Locations:
             - Range: 0xcdcd20..0xcdcd21
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 99
+    - ID: 93
       Name: main.testOneStringInStructPointer
       OutOfLinePCRanges: [0xcdcd40..0xcdcd41]
       InlinePCRanges: []
       Variables:
         - Name: a
-          Type: 221 PointerType *main.oneStringStruct
+          Type: 234 PointerType *main.oneStringStruct
           Locations:
             - Range: 0xcdcd40..0xcdcd41
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 100
+    - ID: 94
       Name: main.testMassiveString
       OutOfLinePCRanges: [0xcdcd60..0xcdcd61]
       InlinePCRanges: []
       Variables:
         - Name: x
-          Type: 8 GoStringHeaderType string
+          Type: 9 GoStringHeaderType string
           Locations:
             - Range: 0xcdcd60..0xcdcd61
               Pieces:
@@ -2942,13 +2942,13 @@ Subprograms:
                   Op: {RegNo: 3, Shift: 0}
           IsParameter: true
           IsReturn: false
-    - ID: 101
+    - ID: 95
       Name: main.testUnitializedString
       OutOfLinePCRanges: [0xcdcd80..0xcdcd81]
       InlinePCRanges: []
       Variables:
         - Name: x
-          Type: 8 GoStringHeaderType string
+          Type: 9 GoStringHeaderType string
           Locations:
             - Range: 0xcdcd80..0xcdcd81
               Pieces:
@@ -2958,13 +2958,13 @@ Subprograms:
                   Op: {RegNo: 3, Shift: 0}
           IsParameter: true
           IsReturn: false
-    - ID: 102
+    - ID: 96
       Name: main.testEmptyString
       OutOfLinePCRanges: [0xcdcda0..0xcdcda1]
       InlinePCRanges: []
       Variables:
         - Name: x
-          Type: 8 GoStringHeaderType string
+          Type: 9 GoStringHeaderType string
           Locations:
             - Range: 0xcdcda0..0xcdcda1
               Pieces:
@@ -2974,13 +2974,13 @@ Subprograms:
                   Op: {RegNo: 3, Shift: 0}
           IsParameter: true
           IsReturn: false
-    - ID: 103
+    - ID: 97
       Name: main.testStruct
       OutOfLinePCRanges: [0xcdd020..0xcdd043]
       InlinePCRanges: []
       Variables:
         - Name: x
-          Type: 223 StructureType main.aStruct
+          Type: 236 StructureType main.aStruct
           Locations:
             - Range: 0xcdd020..0xcdd043
               Pieces:
@@ -3000,17 +3000,17 @@ Subprograms:
                   Op: {RegNo: 9, Shift: 0}
           IsParameter: true
           IsReturn: false
-    - ID: 104
+    - ID: 98
       Name: main.testEmptyStruct
       OutOfLinePCRanges: [0xcdd1a0..0xcdd1a1]
       InlinePCRanges: []
       Variables:
         - Name: e
-          Type: 224 StructureType main.emptyStruct
+          Type: 237 StructureType main.emptyStruct
           Locations: [{Range: 0xcdd1a0..0xcdd1a1, Pieces: []}]
           IsParameter: true
           IsReturn: false
-    - ID: 1
+    - ID: 99
       Name: main.testInlinedPrint
       OutOfLinePCRanges: [0xcd9520..0xcd9582]
       InlinePCRanges:
@@ -3024,7 +3024,7 @@ Subprograms:
           RootRanges: [0xcd9840..0xcd98a2]
       Variables:
         - Name: x
-          Type: 1 BaseType int
+          Type: 7 BaseType int
           Locations:
             - Range: 0xcd9520..0xcd9539
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
@@ -3040,28 +3040,28 @@ Subprograms:
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 2
+    - ID: 100
       Name: main.testInlinedBBB
       OutOfLinePCRanges: []
       InlinePCRanges:
         - Ranges: [0xcd97c6..0xcd97fe]
           RootRanges: [0xcd9760..0xcd9825]
       Variables: []
-    - ID: 3
+    - ID: 101
       Name: main.testInlinedBCA
       OutOfLinePCRanges: []
       InlinePCRanges:
         - Ranges: [0xcd98d3..0xcd9911]
           RootRanges: [0xcd98c0..0xcd99c5]
       Variables: []
-    - ID: 4
+    - ID: 102
       Name: main.testInlinedBCB
       OutOfLinePCRanges: []
       InlinePCRanges:
         - Ranges: [0xcd997b..0xcd99b3]
           RootRanges: [0xcd98c0..0xcd99c5]
       Variables: []
-    - ID: 5
+    - ID: 103
       Name: main.testInlinedSq
       OutOfLinePCRanges: []
       InlinePCRanges:
@@ -3069,13 +3069,13 @@ Subprograms:
           RootRanges: [0xcd99e0..0xcd99e6]
       Variables:
         - Name: x
-          Type: 1 BaseType int
+          Type: 7 BaseType int
           Locations:
             - Range: 0xcd99e0..0xcd99e5
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 6
+    - ID: 104
       Name: main.testInlinedSumArray
       OutOfLinePCRanges: []
       InlinePCRanges:
@@ -3085,7 +3085,7 @@ Subprograms:
           RootRanges: [0xcd9a60..0xcd9be5]
       Variables:
         - Name: a
-          Type: 2 ArrayType [5]int
+          Type: 73 ArrayType [5]int
           Locations:
             - Range: 0xcd9a0d..0xcd9a43
               Pieces: [{Size: 40, Op: {CfaOffset: -56}}]
@@ -3095,77 +3095,77 @@ Subprograms:
           IsReturn: false
 Types:
     - __kind: PointerType
-      ID: 209
+      ID: 223
       Name: '**main.t'
       ByteSize: 8
-      Pointee: 207 PointerType *main.t
+      Pointee: 221 PointerType *main.t
     - __kind: PointerType
-      ID: 35
+      ID: 54
       Name: '**string'
       ByteSize: 8
       GoRuntimeType: 525440
       GoKind: 22
-      Pointee: 36 PointerType *string
+      Pointee: 22 PointerType *string
     - __kind: PointerType
-      ID: 194
+      ID: 210
       Name: '**table<[4]int,[4]int>'
       ByteSize: 8
-      Pointee: 195 PointerType *table<[4]int,[4]int>
+      Pointee: 211 PointerType *table<[4]int,[4]int>
     - __kind: PointerType
-      ID: 183
+      ID: 199
       Name: '**table<[4]int,uint8>'
       ByteSize: 8
-      Pointee: 184 PointerType *table<[4]int,uint8>
+      Pointee: 200 PointerType *table<[4]int,uint8>
     - __kind: PointerType
-      ID: 109
+      ID: 125
       Name: '**table<[4]string,[2]int>'
       ByteSize: 8
-      Pointee: 110 PointerType *table<[4]string,[2]int>
+      Pointee: 126 PointerType *table<[4]string,[2]int>
     - __kind: PointerType
-      ID: 136
+      ID: 152
       Name: '**table<bool,main.node>'
       ByteSize: 8
-      Pointee: 137 PointerType *table<bool,main.node>
+      Pointee: 153 PointerType *table<bool,main.node>
     - __kind: PointerType
-      ID: 63
+      ID: 79
       Name: '**table<int,int>'
       ByteSize: 8
-      Pointee: 64 PointerType *table<int,int>
+      Pointee: 80 PointerType *table<int,int>
     - __kind: PointerType
-      ID: 149
+      ID: 165
       Name: '**table<int,uint8>'
       ByteSize: 8
-      Pointee: 150 PointerType *table<int,uint8>
+      Pointee: 166 PointerType *table<int,uint8>
     - __kind: PointerType
-      ID: 123
+      ID: 139
       Name: '**table<string,[]main.structWithMap>'
       ByteSize: 8
-      Pointee: 124 PointerType *table<string,[]main.structWithMap>
+      Pointee: 140 PointerType *table<string,[]main.structWithMap>
     - __kind: PointerType
-      ID: 97
+      ID: 113
       Name: '**table<string,[]string>'
       ByteSize: 8
-      Pointee: 98 PointerType *table<string,[]string>
+      Pointee: 114 PointerType *table<string,[]string>
     - __kind: PointerType
-      ID: 86
+      ID: 102
       Name: '**table<string,int>'
       ByteSize: 8
-      Pointee: 87 PointerType *table<string,int>
+      Pointee: 103 PointerType *table<string,int>
     - __kind: PointerType
-      ID: 74
+      ID: 90
       Name: '**table<string,main.nestedStruct>'
       ByteSize: 8
-      Pointee: 75 PointerType *table<string,main.nestedStruct>
+      Pointee: 91 PointerType *table<string,main.nestedStruct>
     - __kind: PointerType
-      ID: 171
+      ID: 187
       Name: '**table<uint8,[4]int>'
       ByteSize: 8
-      Pointee: 172 PointerType *table<uint8,[4]int>
+      Pointee: 188 PointerType *table<uint8,[4]int>
     - __kind: PointerType
-      ID: 160
+      ID: 176
       Name: '**table<uint8,uint8>'
       ByteSize: 8
-      Pointee: 161 PointerType *table<uint8,uint8>
+      Pointee: 177 PointerType *table<uint8,uint8>
     - __kind: PointerType
       ID: 241
       Name: '*[]*string.array'
@@ -3197,10 +3197,10 @@ Types:
       ByteSize: 8
       Pointee: 250 GoSliceDataType []string.array
     - __kind: PointerType
-      ID: 212
+      ID: 226
       Name: '*[]uint'
       ByteSize: 8
-      Pointee: 210 GoSliceHeaderType []uint
+      Pointee: 224 GoSliceHeaderType []uint
     - __kind: PointerType
       ID: 273
       Name: '*[]uint.array'
@@ -3212,363 +3212,363 @@ Types:
       ByteSize: 8
       Pointee: 280 GoSliceDataType []uint16.array
     - __kind: PointerType
-      ID: 206
+      ID: 11
       Name: '*bool'
       ByteSize: 8
       GoRuntimeType: 388992
       GoKind: 22
-      Pointee: 11 BaseType bool
+      Pointee: 4 BaseType bool
     - __kind: PointerType
-      ID: 236
+      ID: 33
       Name: '*error'
       ByteSize: 8
       GoRuntimeType: 387904
       GoKind: 22
-      Pointee: 57 GoInterfaceType error
+      Pointee: 13 GoInterfaceType error
     - __kind: PointerType
-      ID: 237
+      ID: 35
       Name: '*float32'
       ByteSize: 8
       GoRuntimeType: 388864
       GoKind: 22
-      Pointee: 30 BaseType float32
+      Pointee: 18 BaseType float32
     - __kind: PointerType
-      ID: 230
+      ID: 25
       Name: '*float64'
       ByteSize: 8
       GoRuntimeType: 388928
       GoKind: 22
-      Pointee: 31 BaseType float64
+      Pointee: 15 BaseType float64
     - __kind: PointerType
-      ID: 231
+      ID: 26
       Name: '*int'
       ByteSize: 8
       GoRuntimeType: 388544
       GoKind: 22
-      Pointee: 1 BaseType int
+      Pointee: 7 BaseType int
     - __kind: PointerType
-      ID: 234
+      ID: 30
       Name: '*int16'
       ByteSize: 8
       GoRuntimeType: 388160
       GoKind: 22
-      Pointee: 16 BaseType int16
+      Pointee: 31 BaseType int16
     - __kind: PointerType
-      ID: 226
+      ID: 20
       Name: '*int32'
       ByteSize: 8
       GoRuntimeType: 388288
       GoKind: 22
-      Pointee: 6 BaseType int32
+      Pointee: 10 BaseType int32
     - __kind: PointerType
-      ID: 232
+      ID: 27
       Name: '*int64'
       ByteSize: 8
       GoRuntimeType: 388416
       GoKind: 22
-      Pointee: 18 BaseType int64
+      Pointee: 12 BaseType int64
     - __kind: PointerType
-      ID: 235
+      ID: 32
       Name: '*int8'
       ByteSize: 8
       GoRuntimeType: 388032
       GoKind: 22
-      Pointee: 14 BaseType int8
+      Pointee: 16 BaseType int8
     - __kind: PointerType
-      ID: 44
+      ID: 61
       Name: '*main.esotericHeap'
       ByteSize: 8
       GoRuntimeType: 383040
       GoKind: 22
-      Pointee: 45 StructureType main.esotericHeap
+      Pointee: 62 StructureType main.esotericHeap
     - __kind: PointerType
-      ID: 145
+      ID: 161
       Name: '*main.node'
       ByteSize: 8
       GoRuntimeType: 383104
       GoKind: 22
-      Pointee: 144 StructureType main.node
+      Pointee: 160 StructureType main.node
     - __kind: PointerType
-      ID: 221
+      ID: 234
       Name: '*main.oneStringStruct'
       ByteSize: 8
       GoKind: 22
-      Pointee: 222 StructureType main.oneStringStruct
+      Pointee: 235 StructureType main.oneStringStruct
     - __kind: PointerType
-      ID: 132
+      ID: 148
       Name: '*main.structWithMap'
       ByteSize: 8
       GoRuntimeType: 382976
       GoKind: 22
-      Pointee: 58 StructureType main.structWithMap
+      Pointee: 75 StructureType main.structWithMap
     - __kind: PointerType
-      ID: 214
+      ID: 228
       Name: '*main.structWithNoStrings'
       ByteSize: 8
-      Pointee: 215 StructureType main.structWithNoStrings
+      Pointee: 229 StructureType main.structWithNoStrings
     - __kind: PointerType
-      ID: 203
+      ID: 219
       Name: '*main.structWithTwoValues'
       ByteSize: 8
       GoKind: 22
-      Pointee: 204 StructureType main.structWithTwoValues
+      Pointee: 220 StructureType main.structWithTwoValues
     - __kind: PointerType
-      ID: 207
+      ID: 221
       Name: '*main.t'
       ByteSize: 8
       GoKind: 22
-      Pointee: 208 GoSliceHeaderType main.t
+      Pointee: 222 GoSliceHeaderType main.t
     - __kind: PointerType
       ID: 271
       Name: '*main.t.array'
       ByteSize: 8
       Pointee: 270 GoSliceDataType main.t.array
     - __kind: PointerType
-      ID: 220
+      ID: 233
       Name: '*main.threeStringStruct'
       ByteSize: 8
       GoKind: 22
-      Pointee: 219 StructureType main.threeStringStruct
+      Pointee: 232 StructureType main.threeStringStruct
     - __kind: PointerType
-      ID: 192
+      ID: 208
       Name: '*map<[4]int,[4]int>'
       ByteSize: 8
-      Pointee: 193 GoSwissMapHeaderType map<[4]int,[4]int>
+      Pointee: 209 GoSwissMapHeaderType map<[4]int,[4]int>
     - __kind: PointerType
-      ID: 181
+      ID: 197
       Name: '*map<[4]int,uint8>'
       ByteSize: 8
-      Pointee: 182 GoSwissMapHeaderType map<[4]int,uint8>
+      Pointee: 198 GoSwissMapHeaderType map<[4]int,uint8>
     - __kind: PointerType
-      ID: 107
+      ID: 123
       Name: '*map<[4]string,[2]int>'
       ByteSize: 8
-      Pointee: 108 GoSwissMapHeaderType map<[4]string,[2]int>
+      Pointee: 124 GoSwissMapHeaderType map<[4]string,[2]int>
     - __kind: PointerType
-      ID: 134
+      ID: 150
       Name: '*map<bool,main.node>'
       ByteSize: 8
-      Pointee: 135 GoSwissMapHeaderType map<bool,main.node>
+      Pointee: 151 GoSwissMapHeaderType map<bool,main.node>
     - __kind: PointerType
-      ID: 60
+      ID: 77
       Name: '*map<int,int>'
       ByteSize: 8
-      Pointee: 61 GoSwissMapHeaderType map<int,int>
+      Pointee: 78 GoSwissMapHeaderType map<int,int>
     - __kind: PointerType
-      ID: 147
+      ID: 163
       Name: '*map<int,uint8>'
       ByteSize: 8
-      Pointee: 148 GoSwissMapHeaderType map<int,uint8>
+      Pointee: 164 GoSwissMapHeaderType map<int,uint8>
     - __kind: PointerType
-      ID: 121
+      ID: 137
       Name: '*map<string,[]main.structWithMap>'
       ByteSize: 8
-      Pointee: 122 GoSwissMapHeaderType map<string,[]main.structWithMap>
+      Pointee: 138 GoSwissMapHeaderType map<string,[]main.structWithMap>
     - __kind: PointerType
-      ID: 95
+      ID: 111
       Name: '*map<string,[]string>'
       ByteSize: 8
-      Pointee: 96 GoSwissMapHeaderType map<string,[]string>
+      Pointee: 112 GoSwissMapHeaderType map<string,[]string>
     - __kind: PointerType
-      ID: 84
+      ID: 100
       Name: '*map<string,int>'
       ByteSize: 8
-      Pointee: 85 GoSwissMapHeaderType map<string,int>
+      Pointee: 101 GoSwissMapHeaderType map<string,int>
     - __kind: PointerType
-      ID: 72
+      ID: 88
       Name: '*map<string,main.nestedStruct>'
       ByteSize: 8
-      Pointee: 73 GoSwissMapHeaderType map<string,main.nestedStruct>
+      Pointee: 89 GoSwissMapHeaderType map<string,main.nestedStruct>
     - __kind: PointerType
-      ID: 169
+      ID: 185
       Name: '*map<uint8,[4]int>'
       ByteSize: 8
-      Pointee: 170 GoSwissMapHeaderType map<uint8,[4]int>
+      Pointee: 186 GoSwissMapHeaderType map<uint8,[4]int>
     - __kind: PointerType
-      ID: 158
+      ID: 174
       Name: '*map<uint8,uint8>'
       ByteSize: 8
-      Pointee: 159 GoSwissMapHeaderType map<uint8,uint8>
+      Pointee: 175 GoSwissMapHeaderType map<uint8,uint8>
     - __kind: PointerType
-      ID: 119
+      ID: 135
       Name: '*map[string]int'
       ByteSize: 8
       GoKind: 22
-      Pointee: 83 GoMapType map[string]int
+      Pointee: 99 GoMapType map[string]int
     - __kind: PointerType
-      ID: 198
+      ID: 214
       Name: '*noalg.map.group[[4]int][4]int'
       ByteSize: 8
-      Pointee: 199 StructureType noalg.map.group[[4]int][4]int
+      Pointee: 215 StructureType noalg.map.group[[4]int][4]int
     - __kind: PointerType
-      ID: 187
+      ID: 203
       Name: '*noalg.map.group[[4]int]uint8'
       ByteSize: 8
-      Pointee: 188 StructureType noalg.map.group[[4]int]uint8
+      Pointee: 204 StructureType noalg.map.group[[4]int]uint8
     - __kind: PointerType
-      ID: 113
+      ID: 129
       Name: '*noalg.map.group[[4]string][2]int'
       ByteSize: 8
-      Pointee: 114 StructureType noalg.map.group[[4]string][2]int
+      Pointee: 130 StructureType noalg.map.group[[4]string][2]int
     - __kind: PointerType
-      ID: 140
+      ID: 156
       Name: '*noalg.map.group[bool]main.node'
       ByteSize: 8
-      Pointee: 141 StructureType noalg.map.group[bool]main.node
+      Pointee: 157 StructureType noalg.map.group[bool]main.node
     - __kind: PointerType
-      ID: 67
+      ID: 83
       Name: '*noalg.map.group[int]int'
       ByteSize: 8
-      Pointee: 68 StructureType noalg.map.group[int]int
+      Pointee: 84 StructureType noalg.map.group[int]int
     - __kind: PointerType
-      ID: 153
+      ID: 169
       Name: '*noalg.map.group[int]uint8'
       ByteSize: 8
-      Pointee: 154 StructureType noalg.map.group[int]uint8
+      Pointee: 170 StructureType noalg.map.group[int]uint8
     - __kind: PointerType
-      ID: 127
+      ID: 143
       Name: '*noalg.map.group[string][]main.structWithMap'
       ByteSize: 8
-      Pointee: 128 StructureType noalg.map.group[string][]main.structWithMap
+      Pointee: 144 StructureType noalg.map.group[string][]main.structWithMap
     - __kind: PointerType
-      ID: 101
+      ID: 117
       Name: '*noalg.map.group[string][]string'
       ByteSize: 8
-      Pointee: 102 StructureType noalg.map.group[string][]string
+      Pointee: 118 StructureType noalg.map.group[string][]string
     - __kind: PointerType
-      ID: 90
+      ID: 106
       Name: '*noalg.map.group[string]int'
       ByteSize: 8
-      Pointee: 91 StructureType noalg.map.group[string]int
+      Pointee: 107 StructureType noalg.map.group[string]int
     - __kind: PointerType
-      ID: 78
+      ID: 94
       Name: '*noalg.map.group[string]main.nestedStruct'
       ByteSize: 8
-      Pointee: 79 StructureType noalg.map.group[string]main.nestedStruct
+      Pointee: 95 StructureType noalg.map.group[string]main.nestedStruct
     - __kind: PointerType
-      ID: 175
+      ID: 191
       Name: '*noalg.map.group[uint8][4]int'
       ByteSize: 8
-      Pointee: 176 StructureType noalg.map.group[uint8][4]int
+      Pointee: 192 StructureType noalg.map.group[uint8][4]int
     - __kind: PointerType
-      ID: 164
+      ID: 180
       Name: '*noalg.map.group[uint8]uint8'
       ByteSize: 8
-      Pointee: 165 StructureType noalg.map.group[uint8]uint8
+      Pointee: 181 StructureType noalg.map.group[uint8]uint8
     - __kind: PointerType
-      ID: 36
+      ID: 22
       Name: '*string'
       ByteSize: 8
       GoRuntimeType: 387968
       GoKind: 22
-      Pointee: 8 GoStringHeaderType string
+      Pointee: 9 GoStringHeaderType string
     - __kind: PointerType
       ID: 239
       Name: '*string.str'
       ByteSize: 8
       Pointee: 238 GoStringDataType string.str
     - __kind: PointerType
-      ID: 195
+      ID: 211
       Name: '*table<[4]int,[4]int>'
       ByteSize: 8
-      Pointee: 196 StructureType table<[4]int,[4]int>
+      Pointee: 212 StructureType table<[4]int,[4]int>
     - __kind: PointerType
-      ID: 184
+      ID: 200
       Name: '*table<[4]int,uint8>'
       ByteSize: 8
-      Pointee: 185 StructureType table<[4]int,uint8>
+      Pointee: 201 StructureType table<[4]int,uint8>
     - __kind: PointerType
-      ID: 110
+      ID: 126
       Name: '*table<[4]string,[2]int>'
       ByteSize: 8
-      Pointee: 111 StructureType table<[4]string,[2]int>
+      Pointee: 127 StructureType table<[4]string,[2]int>
     - __kind: PointerType
-      ID: 137
+      ID: 153
       Name: '*table<bool,main.node>'
       ByteSize: 8
-      Pointee: 138 StructureType table<bool,main.node>
+      Pointee: 154 StructureType table<bool,main.node>
     - __kind: PointerType
-      ID: 64
+      ID: 80
       Name: '*table<int,int>'
       ByteSize: 8
-      Pointee: 65 StructureType table<int,int>
+      Pointee: 81 StructureType table<int,int>
     - __kind: PointerType
-      ID: 150
+      ID: 166
       Name: '*table<int,uint8>'
       ByteSize: 8
-      Pointee: 151 StructureType table<int,uint8>
+      Pointee: 167 StructureType table<int,uint8>
     - __kind: PointerType
-      ID: 124
+      ID: 140
       Name: '*table<string,[]main.structWithMap>'
       ByteSize: 8
-      Pointee: 125 StructureType table<string,[]main.structWithMap>
+      Pointee: 141 StructureType table<string,[]main.structWithMap>
     - __kind: PointerType
-      ID: 98
+      ID: 114
       Name: '*table<string,[]string>'
       ByteSize: 8
-      Pointee: 99 StructureType table<string,[]string>
+      Pointee: 115 StructureType table<string,[]string>
     - __kind: PointerType
-      ID: 87
+      ID: 103
       Name: '*table<string,int>'
       ByteSize: 8
-      Pointee: 88 StructureType table<string,int>
+      Pointee: 104 StructureType table<string,int>
     - __kind: PointerType
-      ID: 75
+      ID: 91
       Name: '*table<string,main.nestedStruct>'
       ByteSize: 8
-      Pointee: 76 StructureType table<string,main.nestedStruct>
+      Pointee: 92 StructureType table<string,main.nestedStruct>
     - __kind: PointerType
-      ID: 172
+      ID: 188
       Name: '*table<uint8,[4]int>'
       ByteSize: 8
-      Pointee: 173 StructureType table<uint8,[4]int>
+      Pointee: 189 StructureType table<uint8,[4]int>
     - __kind: PointerType
-      ID: 161
+      ID: 177
       Name: '*table<uint8,uint8>'
       ByteSize: 8
-      Pointee: 162 StructureType table<uint8,uint8>
+      Pointee: 178 StructureType table<uint8,uint8>
     - __kind: PointerType
-      ID: 205
+      ID: 34
       Name: '*uint'
       ByteSize: 8
       GoRuntimeType: 388608
       GoKind: 22
-      Pointee: 20 BaseType uint
+      Pointee: 17 BaseType uint
     - __kind: PointerType
-      ID: 218
+      ID: 29
       Name: '*uint16'
       ByteSize: 8
       GoRuntimeType: 388224
       GoKind: 22
-      Pointee: 22 BaseType uint16
+      Pointee: 6 BaseType uint16
     - __kind: PointerType
-      ID: 227
+      ID: 21
       Name: '*uint32'
       ByteSize: 8
       GoRuntimeType: 388352
       GoKind: 22
-      Pointee: 24 BaseType uint32
+      Pointee: 2 BaseType uint32
     - __kind: PointerType
-      ID: 233
+      ID: 28
       Name: '*uint64'
       ByteSize: 8
       GoRuntimeType: 388480
       GoKind: 22
-      Pointee: 26 BaseType uint64
+      Pointee: 8 BaseType uint64
     - __kind: PointerType
-      ID: 9
+      ID: 5
       Name: '*uint8'
       ByteSize: 8
       GoRuntimeType: 388096
       GoKind: 22
-      Pointee: 4 BaseType uint8
+      Pointee: 3 BaseType uint8
     - __kind: PointerType
-      ID: 225
+      ID: 19
       Name: '*uintptr'
       ByteSize: 8
       GoRuntimeType: 388672
       GoKind: 22
-      Pointee: 62 BaseType uintptr
+      Pointee: 1 BaseType uintptr
     - __kind: EventRootType
       ID: 369
       Name: Probe[main.stackC]
@@ -3581,10 +3581,10 @@ Types:
         - Name: a
           Offset: 1
           Expression:
-            Type: 41 GoEmptyInterfaceType interface {}
+            Type: 58 GoEmptyInterfaceType interface {}
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 51, index: 0, name: a}
+                  Variable: {subprogram: 45, index: 0, name: a}
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
@@ -3596,10 +3596,10 @@ Types:
         - Name: b
           Offset: 1
           Expression:
-            Type: 28 ArrayType [2][2][2]int
+            Type: 49 ArrayType [2][2][2]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 23, index: 0, name: b}
+                  Variable: {subprogram: 17, index: 0, name: b}
                   Offset: 0
                   ByteSize: 64
     - __kind: EventRootType
@@ -3611,10 +3611,10 @@ Types:
         - Name: a
           Offset: 1
           Expression:
-            Type: 27 ArrayType [2][2]int
+            Type: 48 ArrayType [2][2]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 21, index: 0, name: a}
+                  Variable: {subprogram: 15, index: 0, name: a}
                   Offset: 0
                   ByteSize: 32
     - __kind: EventRootType
@@ -3626,10 +3626,10 @@ Types:
         - Name: m
           Offset: 1
           Expression:
-            Type: 118 ArrayType [2]map[string]int
+            Type: 134 ArrayType [2]map[string]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 59, index: 0, name: m}
+                  Variable: {subprogram: 53, index: 0, name: m}
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
@@ -3641,10 +3641,10 @@ Types:
         - Name: a
           Offset: 1
           Expression:
-            Type: 7 ArrayType [2]string
+            Type: 38 ArrayType [2]string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 22, index: 0, name: a}
+                  Variable: {subprogram: 16, index: 0, name: a}
                   Offset: 0
                   ByteSize: 32
     - __kind: EventRootType
@@ -3656,10 +3656,10 @@ Types:
         - Name: b
           Offset: 1
           Expression:
-            Type: 33 StructureType main.bigStruct
+            Type: 52 StructureType main.bigStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 41, index: 0, name: b}
+                  Variable: {subprogram: 35, index: 0, name: b}
                   Offset: 0
                   ByteSize: 48
     - __kind: EventRootType
@@ -3671,10 +3671,10 @@ Types:
         - Name: x
           Offset: 1
           Expression:
-            Type: 10 ArrayType [2]bool
+            Type: 39 ArrayType [2]bool
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 10, index: 0, name: x}
+                  Variable: {subprogram: 4, index: 0, name: x}
                   Offset: 0
                   ByteSize: 2
     - __kind: EventRootType
@@ -3686,10 +3686,10 @@ Types:
         - Name: x
           Offset: 1
           Expression:
-            Type: 3 ArrayType [2]uint8
+            Type: 36 ArrayType [2]uint8
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 7, index: 0, name: x}
+                  Variable: {subprogram: 1, index: 0, name: x}
                   Offset: 0
                   ByteSize: 2
     - __kind: EventRootType
@@ -3701,10 +3701,10 @@ Types:
         - Name: c
           Offset: 1
           Expression:
-            Type: 202 GoChannelType chan bool
+            Type: 218 GoChannelType chan bool
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 75, index: 0, name: c}
+                  Variable: {subprogram: 69, index: 0, name: c}
                   Offset: 0
                   ByteSize: 0
     - __kind: EventRootType
@@ -3716,28 +3716,28 @@ Types:
         - Name: w
           Offset: 1
           Expression:
-            Type: 4 BaseType uint8
+            Type: 3 BaseType uint8
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 73, index: 0, name: w}
+                  Variable: {subprogram: 67, index: 0, name: w}
                   Offset: 0
                   ByteSize: 1
         - Name: x
           Offset: 2
           Expression:
-            Type: 4 BaseType uint8
+            Type: 3 BaseType uint8
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 73, index: 1, name: x}
+                  Variable: {subprogram: 67, index: 1, name: x}
                   Offset: 0
                   ByteSize: 1
         - Name: y
           Offset: 3
           Expression:
-            Type: 30 BaseType float32
+            Type: 18 BaseType float32
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 73, index: 2, name: y}
+                  Variable: {subprogram: 67, index: 2, name: y}
                   Offset: 0
                   ByteSize: 4
     - __kind: EventRootType
@@ -3749,10 +3749,10 @@ Types:
         - Name: t
           Offset: 1
           Expression:
-            Type: 207 PointerType *main.t
+            Type: 221 PointerType *main.t
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 83, index: 0, name: t}
+                  Variable: {subprogram: 77, index: 0, name: t}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
@@ -3764,19 +3764,19 @@ Types:
         - Name: xs
           Offset: 1
           Expression:
-            Type: 213 GoSliceHeaderType []main.structWithNoStrings
+            Type: 227 GoSliceHeaderType []main.structWithNoStrings
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 88, index: 0, name: xs}
+                  Variable: {subprogram: 82, index: 0, name: xs}
                   Offset: 0
                   ByteSize: 24
         - Name: a
           Offset: 25
           Expression:
-            Type: 1 BaseType int
+            Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 88, index: 1, name: a}
+                  Variable: {subprogram: 82, index: 1, name: a}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
@@ -3788,10 +3788,10 @@ Types:
         - Name: u
           Offset: 1
           Expression:
-            Type: 210 GoSliceHeaderType []uint
+            Type: 224 GoSliceHeaderType []uint
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 85, index: 0, name: u}
+                  Variable: {subprogram: 79, index: 0, name: u}
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
@@ -3803,10 +3803,10 @@ Types:
         - Name: x
           Offset: 1
           Expression:
-            Type: 8 GoStringHeaderType string
+            Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 102, index: 0, name: x}
+                  Variable: {subprogram: 96, index: 0, name: x}
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
@@ -3818,10 +3818,10 @@ Types:
         - Name: e
           Offset: 1
           Expression:
-            Type: 224 StructureType main.emptyStruct
+            Type: 237 StructureType main.emptyStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 104, index: 0, name: e}
+                  Variable: {subprogram: 98, index: 0, name: e}
                   Offset: 0
                   ByteSize: 0
     - __kind: EventRootType
@@ -3833,10 +3833,10 @@ Types:
         - Name: e
           Offset: 1
           Expression:
-            Type: 57 GoInterfaceType error
+            Type: 13 GoInterfaceType error
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 52, index: 0, name: e}
+                  Variable: {subprogram: 46, index: 0, name: e}
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
@@ -3848,10 +3848,10 @@ Types:
         - Name: e
           Offset: 1
           Expression:
-            Type: 44 PointerType *main.esotericHeap
+            Type: 61 PointerType *main.esotericHeap
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 43, index: 0, name: e}
+                  Variable: {subprogram: 37, index: 0, name: e}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
@@ -3863,10 +3863,10 @@ Types:
         - Name: e
           Offset: 1
           Expression:
-            Type: 39 StructureType main.esotericStack
+            Type: 56 StructureType main.esotericStack
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 42, index: 0, name: e}
+                  Variable: {subprogram: 36, index: 0, name: e}
                   Offset: 0
                   ByteSize: 64
     - __kind: EventRootType
@@ -3878,10 +3878,10 @@ Types:
         - Name: a
           Offset: 1
           Expression:
-            Type: 2 ArrayType [5]int
+            Type: 73 ArrayType [5]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 49, index: 0, name: a}
+                  Variable: {subprogram: 43, index: 0, name: a}
                   Offset: 0
                   ByteSize: 40
     - __kind: EventRootType
@@ -3893,10 +3893,10 @@ Types:
         - Name: x
           Offset: 1
           Expression:
-            Type: 1 BaseType int
+            Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 48, index: 0, name: x}
+                  Variable: {subprogram: 42, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
@@ -3908,10 +3908,10 @@ Types:
         - Name: x
           Offset: 1
           Expression:
-            Type: 1 BaseType int
+            Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 44, index: 0, name: x}
+                  Variable: {subprogram: 38, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
@@ -3923,10 +3923,10 @@ Types:
         - Name: x
           Offset: 1
           Expression:
-            Type: 1 BaseType int
+            Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 46, index: 0, name: x}
+                  Variable: {subprogram: 40, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
@@ -3941,19 +3941,19 @@ Types:
         - Name: x
           Offset: 1
           Expression:
-            Type: 1 BaseType int
+            Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 45, index: 0, name: x}
+                  Variable: {subprogram: 39, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
         - Name: y
           Offset: 9
           Expression:
-            Type: 1 BaseType int
+            Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 45, index: 1, name: y}
+                  Variable: {subprogram: 39, index: 1, name: y}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
@@ -3974,10 +3974,10 @@ Types:
         - Name: x
           Offset: 1
           Expression:
-            Type: 1 BaseType int
+            Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 1, index: 0, name: x}
+                  Variable: {subprogram: 99, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
@@ -3989,10 +3989,10 @@ Types:
         - Name: x
           Offset: 1
           Expression:
-            Type: 1 BaseType int
+            Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 5, index: 0, name: x}
+                  Variable: {subprogram: 103, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
@@ -4004,10 +4004,10 @@ Types:
         - Name: a
           Offset: 1
           Expression:
-            Type: 2 ArrayType [5]int
+            Type: 73 ArrayType [5]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 6, index: 0, name: a}
+                  Variable: {subprogram: 104, index: 0, name: a}
                   Offset: 0
                   ByteSize: 40
     - __kind: EventRootType
@@ -4019,10 +4019,10 @@ Types:
         - Name: x
           Offset: 1
           Expression:
-            Type: 15 ArrayType [2]int16
+            Type: 42 ArrayType [2]int16
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 13, index: 0, name: x}
+                  Variable: {subprogram: 7, index: 0, name: x}
                   Offset: 0
                   ByteSize: 4
     - __kind: EventRootType
@@ -4034,10 +4034,10 @@ Types:
         - Name: x
           Offset: 1
           Expression:
-            Type: 5 ArrayType [2]int32
+            Type: 37 ArrayType [2]int32
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 14, index: 0, name: x}
+                  Variable: {subprogram: 8, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
@@ -4049,10 +4049,10 @@ Types:
         - Name: x
           Offset: 1
           Expression:
-            Type: 17 ArrayType [2]int64
+            Type: 43 ArrayType [2]int64
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 15, index: 0, name: x}
+                  Variable: {subprogram: 9, index: 0, name: x}
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
@@ -4064,10 +4064,10 @@ Types:
         - Name: x
           Offset: 1
           Expression:
-            Type: 13 ArrayType [2]int8
+            Type: 41 ArrayType [2]int8
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 12, index: 0, name: x}
+                  Variable: {subprogram: 6, index: 0, name: x}
                   Offset: 0
                   ByteSize: 2
     - __kind: EventRootType
@@ -4079,10 +4079,10 @@ Types:
         - Name: x
           Offset: 1
           Expression:
-            Type: 12 ArrayType [2]int
+            Type: 40 ArrayType [2]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 11, index: 0, name: x}
+                  Variable: {subprogram: 5, index: 0, name: x}
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
@@ -4094,10 +4094,10 @@ Types:
         - Name: b
           Offset: 1
           Expression:
-            Type: 56 GoInterfaceType main.behavior
+            Type: 74 GoInterfaceType main.behavior
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 50, index: 0, name: b}
+                  Variable: {subprogram: 44, index: 0, name: b}
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
@@ -4109,10 +4109,10 @@ Types:
         - Name: a
           Offset: 1
           Expression:
-            Type: 144 StructureType main.node
+            Type: 160 StructureType main.node
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 77, index: 0, name: a}
+                  Variable: {subprogram: 71, index: 0, name: a}
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
@@ -4124,10 +4124,10 @@ Types:
         - Name: m
           Offset: 1
           Expression:
-            Type: 106 GoMapType map[[4]string][2]int
+            Type: 122 GoMapType map[[4]string][2]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 57, index: 0, name: m}
+                  Variable: {subprogram: 51, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
@@ -4139,10 +4139,10 @@ Types:
         - Name: m
           Offset: 1
           Expression:
-            Type: 120 GoMapType map[string][]main.structWithMap
+            Type: 136 GoMapType map[string][]main.structWithMap
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 63, index: 0, name: m}
+                  Variable: {subprogram: 57, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
@@ -4154,10 +4154,10 @@ Types:
         - Name: m
           Offset: 1
           Expression:
-            Type: 59 GoMapType map[int]int
+            Type: 76 GoMapType map[int]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 61, index: 0, name: m}
+                  Variable: {subprogram: 55, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
@@ -4169,10 +4169,10 @@ Types:
         - Name: m
           Offset: 1
           Expression:
-            Type: 191 GoMapType map[[4]int][4]int
+            Type: 207 GoMapType map[[4]int][4]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 72, index: 0, name: m}
+                  Variable: {subprogram: 66, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
@@ -4184,10 +4184,10 @@ Types:
         - Name: m
           Offset: 1
           Expression:
-            Type: 180 GoMapType map[[4]int]uint8
+            Type: 196 GoMapType map[[4]int]uint8
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 71, index: 0, name: m}
+                  Variable: {subprogram: 65, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
@@ -4199,10 +4199,10 @@ Types:
         - Name: redactMyEntries
           Offset: 1
           Expression:
-            Type: 120 GoMapType map[string][]main.structWithMap
+            Type: 136 GoMapType map[string][]main.structWithMap
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 62, index: 0, name: redactMyEntries}
+                  Variable: {subprogram: 56, index: 0, name: redactMyEntries}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
@@ -4214,10 +4214,10 @@ Types:
         - Name: m
           Offset: 1
           Expression:
-            Type: 168 GoMapType map[uint8][4]int
+            Type: 184 GoMapType map[uint8][4]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 70, index: 0, name: m}
+                  Variable: {subprogram: 64, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
@@ -4229,10 +4229,10 @@ Types:
         - Name: m
           Offset: 1
           Expression:
-            Type: 157 GoMapType map[uint8]uint8
+            Type: 173 GoMapType map[uint8]uint8
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 69, index: 0, name: m}
+                  Variable: {subprogram: 63, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
@@ -4244,10 +4244,10 @@ Types:
         - Name: m
           Offset: 1
           Expression:
-            Type: 83 GoMapType map[string]int
+            Type: 99 GoMapType map[string]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 55, index: 0, name: m}
+                  Variable: {subprogram: 49, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
@@ -4259,10 +4259,10 @@ Types:
         - Name: m
           Offset: 1
           Expression:
-            Type: 94 GoMapType map[string][]string
+            Type: 110 GoMapType map[string][]string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 56, index: 0, name: m}
+                  Variable: {subprogram: 50, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
@@ -4274,10 +4274,10 @@ Types:
         - Name: m
           Offset: 1
           Expression:
-            Type: 71 GoMapType map[string]main.nestedStruct
+            Type: 87 GoMapType map[string]main.nestedStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 54, index: 0, name: m}
+                  Variable: {subprogram: 48, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
@@ -4289,10 +4289,10 @@ Types:
         - Name: m
           Offset: 1
           Expression:
-            Type: 133 GoMapType map[bool]main.node
+            Type: 149 GoMapType map[bool]main.node
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 64, index: 0, name: m}
+                  Variable: {subprogram: 58, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
@@ -4304,10 +4304,10 @@ Types:
         - Name: m
           Offset: 1
           Expression:
-            Type: 157 GoMapType map[uint8]uint8
+            Type: 173 GoMapType map[uint8]uint8
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 68, index: 0, name: m}
+                  Variable: {subprogram: 62, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
@@ -4319,10 +4319,10 @@ Types:
         - Name: m
           Offset: 1
           Expression:
-            Type: 157 GoMapType map[uint8]uint8
+            Type: 173 GoMapType map[uint8]uint8
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 67, index: 0, name: m}
+                  Variable: {subprogram: 61, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
@@ -4334,10 +4334,10 @@ Types:
         - Name: redactMyEntries
           Offset: 1
           Expression:
-            Type: 146 GoMapType map[int]uint8
+            Type: 162 GoMapType map[int]uint8
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 66, index: 0, name: redactMyEntries}
+                  Variable: {subprogram: 60, index: 0, name: redactMyEntries}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
@@ -4349,10 +4349,10 @@ Types:
         - Name: m
           Offset: 1
           Expression:
-            Type: 146 GoMapType map[int]uint8
+            Type: 162 GoMapType map[int]uint8
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 65, index: 0, name: m}
+                  Variable: {subprogram: 59, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
@@ -4364,10 +4364,10 @@ Types:
         - Name: x
           Offset: 1
           Expression:
-            Type: 8 GoStringHeaderType string
+            Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 100, index: 0, name: x}
+                  Variable: {subprogram: 94, index: 0, name: x}
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
@@ -4379,46 +4379,46 @@ Types:
         - Name: a
           Offset: 1
           Expression:
-            Type: 11 BaseType bool
+            Type: 4 BaseType bool
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 74, index: 0, name: a}
+                  Variable: {subprogram: 68, index: 0, name: a}
                   Offset: 0
                   ByteSize: 1
         - Name: b
           Offset: 2
           Expression:
-            Type: 4 BaseType uint8
+            Type: 3 BaseType uint8
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 74, index: 1, name: b}
+                  Variable: {subprogram: 68, index: 1, name: b}
                   Offset: 0
                   ByteSize: 1
         - Name: c
           Offset: 3
           Expression:
-            Type: 6 BaseType int32
+            Type: 10 BaseType int32
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 74, index: 2, name: c}
+                  Variable: {subprogram: 68, index: 2, name: c}
                   Offset: 0
                   ByteSize: 4
         - Name: d
           Offset: 7
           Expression:
-            Type: 20 BaseType uint
+            Type: 17 BaseType uint
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 74, index: 3, name: d}
+                  Variable: {subprogram: 68, index: 3, name: d}
                   Offset: 0
                   ByteSize: 8
         - Name: e
           Offset: 15
           Expression:
-            Type: 8 GoStringHeaderType string
+            Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 74, index: 4, name: e}
+                  Variable: {subprogram: 68, index: 4, name: e}
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
@@ -4430,19 +4430,19 @@ Types:
         - Name: z
           Offset: 1
           Expression:
-            Type: 206 PointerType *bool
+            Type: 11 PointerType *bool
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 82, index: 0, name: z}
+                  Variable: {subprogram: 76, index: 0, name: z}
                   Offset: 0
                   ByteSize: 8
         - Name: a
           Offset: 9
           Expression:
-            Type: 20 BaseType uint
+            Type: 17 BaseType uint
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 82, index: 1, name: a}
+                  Variable: {subprogram: 76, index: 1, name: a}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
@@ -4454,19 +4454,19 @@ Types:
         - Name: xs
           Offset: 1
           Expression:
-            Type: 213 GoSliceHeaderType []main.structWithNoStrings
+            Type: 227 GoSliceHeaderType []main.structWithNoStrings
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 89, index: 0, name: xs}
+                  Variable: {subprogram: 83, index: 0, name: xs}
                   Offset: 0
                   ByteSize: 24
         - Name: a
           Offset: 25
           Expression:
-            Type: 1 BaseType int
+            Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 89, index: 1, name: a}
+                  Variable: {subprogram: 83, index: 1, name: a}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
@@ -4478,28 +4478,28 @@ Types:
         - Name: a
           Offset: 1
           Expression:
-            Type: 14 BaseType int8
+            Type: 16 BaseType int8
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 91, index: 0, name: a}
+                  Variable: {subprogram: 85, index: 0, name: a}
                   Offset: 0
                   ByteSize: 1
         - Name: s
           Offset: 2
           Expression:
-            Type: 216 GoSliceHeaderType []bool
+            Type: 230 GoSliceHeaderType []bool
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 91, index: 1, name: s}
+                  Variable: {subprogram: 85, index: 1, name: s}
                   Offset: 0
                   ByteSize: 24
         - Name: x
           Offset: 26
           Expression:
-            Type: 20 BaseType uint
+            Type: 17 BaseType uint
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 91, index: 2, name: x}
+                  Variable: {subprogram: 85, index: 2, name: x}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
@@ -4511,10 +4511,10 @@ Types:
         - Name: xs
           Offset: 1
           Expression:
-            Type: 217 GoSliceHeaderType []uint16
+            Type: 231 GoSliceHeaderType []uint16
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 92, index: 0, name: xs}
+                  Variable: {subprogram: 86, index: 0, name: xs}
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
@@ -4526,10 +4526,10 @@ Types:
         - Name: a
           Offset: 1
           Expression:
-            Type: 221 PointerType *main.oneStringStruct
+            Type: 234 PointerType *main.oneStringStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 99, index: 0, name: a}
+                  Variable: {subprogram: 93, index: 0, name: a}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
@@ -4541,10 +4541,10 @@ Types:
         - Name: a
           Offset: 1
           Expression:
-            Type: 145 PointerType *main.node
+            Type: 161 PointerType *main.node
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 78, index: 0, name: a}
+                  Variable: {subprogram: 72, index: 0, name: a}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
@@ -4556,10 +4556,10 @@ Types:
         - Name: m
           Offset: 1
           Expression:
-            Type: 119 PointerType *map[string]int
+            Type: 135 PointerType *map[string]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 60, index: 0, name: m}
+                  Variable: {subprogram: 54, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
@@ -4571,10 +4571,10 @@ Types:
         - Name: a
           Offset: 1
           Expression:
-            Type: 203 PointerType *main.structWithTwoValues
+            Type: 219 PointerType *main.structWithTwoValues
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 76, index: 0, name: a}
+                  Variable: {subprogram: 70, index: 0, name: a}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
@@ -4586,10 +4586,10 @@ Types:
         - Name: x
           Offset: 1
           Expression:
-            Type: 5 ArrayType [2]int32
+            Type: 37 ArrayType [2]int32
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 8, index: 0, name: x}
+                  Variable: {subprogram: 2, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
@@ -4601,10 +4601,10 @@ Types:
         - Name: x
           Offset: 1
           Expression:
-            Type: 11 BaseType bool
+            Type: 4 BaseType bool
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 27, index: 0, name: x}
+                  Variable: {subprogram: 21, index: 0, name: x}
                   Offset: 0
                   ByteSize: 1
     - __kind: EventRootType
@@ -4616,10 +4616,10 @@ Types:
         - Name: x
           Offset: 1
           Expression:
-            Type: 4 BaseType uint8
+            Type: 3 BaseType uint8
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 25, index: 0, name: x}
+                  Variable: {subprogram: 19, index: 0, name: x}
                   Offset: 0
                   ByteSize: 1
     - __kind: EventRootType
@@ -4631,10 +4631,10 @@ Types:
         - Name: x
           Offset: 1
           Expression:
-            Type: 30 BaseType float32
+            Type: 18 BaseType float32
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 38, index: 0, name: x}
+                  Variable: {subprogram: 32, index: 0, name: x}
                   Offset: 0
                   ByteSize: 4
     - __kind: EventRootType
@@ -4646,10 +4646,10 @@ Types:
         - Name: x
           Offset: 1
           Expression:
-            Type: 31 BaseType float64
+            Type: 15 BaseType float64
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 39, index: 0, name: x}
+                  Variable: {subprogram: 33, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
@@ -4661,10 +4661,10 @@ Types:
         - Name: x
           Offset: 1
           Expression:
-            Type: 16 BaseType int16
+            Type: 31 BaseType int16
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 30, index: 0, name: x}
+                  Variable: {subprogram: 24, index: 0, name: x}
                   Offset: 0
                   ByteSize: 2
     - __kind: EventRootType
@@ -4676,10 +4676,10 @@ Types:
         - Name: x
           Offset: 1
           Expression:
-            Type: 6 BaseType int32
+            Type: 10 BaseType int32
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 31, index: 0, name: x}
+                  Variable: {subprogram: 25, index: 0, name: x}
                   Offset: 0
                   ByteSize: 4
     - __kind: EventRootType
@@ -4691,10 +4691,10 @@ Types:
         - Name: x
           Offset: 1
           Expression:
-            Type: 18 BaseType int64
+            Type: 12 BaseType int64
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 32, index: 0, name: x}
+                  Variable: {subprogram: 26, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
@@ -4706,10 +4706,10 @@ Types:
         - Name: x
           Offset: 1
           Expression:
-            Type: 14 BaseType int8
+            Type: 16 BaseType int8
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 29, index: 0, name: x}
+                  Variable: {subprogram: 23, index: 0, name: x}
                   Offset: 0
                   ByteSize: 1
     - __kind: EventRootType
@@ -4721,10 +4721,10 @@ Types:
         - Name: x
           Offset: 1
           Expression:
-            Type: 1 BaseType int
+            Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 28, index: 0, name: x}
+                  Variable: {subprogram: 22, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
@@ -4736,10 +4736,10 @@ Types:
         - Name: x
           Offset: 1
           Expression:
-            Type: 6 BaseType int32
+            Type: 10 BaseType int32
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 26, index: 0, name: x}
+                  Variable: {subprogram: 20, index: 0, name: x}
                   Offset: 0
                   ByteSize: 4
     - __kind: EventRootType
@@ -4751,10 +4751,10 @@ Types:
         - Name: x
           Offset: 1
           Expression:
-            Type: 8 GoStringHeaderType string
+            Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 95, index: 0, name: x}
+                  Variable: {subprogram: 89, index: 0, name: x}
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
@@ -4766,10 +4766,10 @@ Types:
         - Name: x
           Offset: 1
           Expression:
-            Type: 22 BaseType uint16
+            Type: 6 BaseType uint16
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 35, index: 0, name: x}
+                  Variable: {subprogram: 29, index: 0, name: x}
                   Offset: 0
                   ByteSize: 2
     - __kind: EventRootType
@@ -4781,10 +4781,10 @@ Types:
         - Name: x
           Offset: 1
           Expression:
-            Type: 24 BaseType uint32
+            Type: 2 BaseType uint32
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 36, index: 0, name: x}
+                  Variable: {subprogram: 30, index: 0, name: x}
                   Offset: 0
                   ByteSize: 4
     - __kind: EventRootType
@@ -4796,10 +4796,10 @@ Types:
         - Name: x
           Offset: 1
           Expression:
-            Type: 26 BaseType uint64
+            Type: 8 BaseType uint64
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 37, index: 0, name: x}
+                  Variable: {subprogram: 31, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
@@ -4811,10 +4811,10 @@ Types:
         - Name: x
           Offset: 1
           Expression:
-            Type: 4 BaseType uint8
+            Type: 3 BaseType uint8
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 34, index: 0, name: x}
+                  Variable: {subprogram: 28, index: 0, name: x}
                   Offset: 0
                   ByteSize: 1
     - __kind: EventRootType
@@ -4826,10 +4826,10 @@ Types:
         - Name: x
           Offset: 1
           Expression:
-            Type: 20 BaseType uint
+            Type: 17 BaseType uint
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 33, index: 0, name: x}
+                  Variable: {subprogram: 27, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
@@ -4841,10 +4841,10 @@ Types:
         - Name: u
           Offset: 1
           Expression:
-            Type: 211 GoSliceHeaderType [][]uint
+            Type: 225 GoSliceHeaderType [][]uint
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 86, index: 0, name: u}
+                  Variable: {subprogram: 80, index: 0, name: u}
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
@@ -4856,10 +4856,10 @@ Types:
         - Name: m
           Offset: 1
           Expression:
-            Type: 83 GoMapType map[string]int
+            Type: 99 GoMapType map[string]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 58, index: 0, name: m}
+                  Variable: {subprogram: 52, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
@@ -4871,10 +4871,10 @@ Types:
         - Name: x
           Offset: 1
           Expression:
-            Type: 7 ArrayType [2]string
+            Type: 38 ArrayType [2]string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 9, index: 0, name: x}
+                  Variable: {subprogram: 3, index: 0, name: x}
                   Offset: 0
                   ByteSize: 32
     - __kind: EventRootType
@@ -4886,10 +4886,10 @@ Types:
         - Name: z
           Offset: 1
           Expression:
-            Type: 36 PointerType *string
+            Type: 22 PointerType *string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 81, index: 0, name: z}
+                  Variable: {subprogram: 75, index: 0, name: z}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
@@ -4901,10 +4901,10 @@ Types:
         - Name: s
           Offset: 1
           Expression:
-            Type: 105 GoSliceHeaderType []string
+            Type: 121 GoSliceHeaderType []string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 90, index: 0, name: s}
+                  Variable: {subprogram: 84, index: 0, name: s}
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
@@ -4916,19 +4916,19 @@ Types:
         - Name: xs
           Offset: 1
           Expression:
-            Type: 213 GoSliceHeaderType []main.structWithNoStrings
+            Type: 227 GoSliceHeaderType []main.structWithNoStrings
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 87, index: 0, name: xs}
+                  Variable: {subprogram: 81, index: 0, name: xs}
                   Offset: 0
                   ByteSize: 24
         - Name: a
           Offset: 25
           Expression:
-            Type: 1 BaseType int
+            Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 87, index: 1, name: a}
+                  Variable: {subprogram: 81, index: 1, name: a}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
@@ -4940,10 +4940,10 @@ Types:
         - Name: s
           Offset: 1
           Expression:
-            Type: 58 StructureType main.structWithMap
+            Type: 75 StructureType main.structWithMap
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 53, index: 0, name: s}
+                  Variable: {subprogram: 47, index: 0, name: s}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
@@ -4955,10 +4955,10 @@ Types:
         - Name: x
           Offset: 1
           Expression:
-            Type: 223 StructureType main.aStruct
+            Type: 236 StructureType main.aStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 103, index: 0, name: x}
+                  Variable: {subprogram: 97, index: 0, name: x}
                   Offset: 0
                   ByteSize: 56
     - __kind: EventRootType
@@ -4970,10 +4970,10 @@ Types:
         - Name: a
           Offset: 1
           Expression:
-            Type: 220 PointerType *main.threeStringStruct
+            Type: 233 PointerType *main.threeStringStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 98, index: 0, name: a}
+                  Variable: {subprogram: 92, index: 0, name: a}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
@@ -4985,10 +4985,10 @@ Types:
         - Name: a
           Offset: 1
           Expression:
-            Type: 219 StructureType main.threeStringStruct
+            Type: 232 StructureType main.threeStringStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 97, index: 0, name: a}
+                  Variable: {subprogram: 91, index: 0, name: a}
                   Offset: 0
                   ByteSize: 48
     - __kind: EventRootType
@@ -5000,28 +5000,28 @@ Types:
         - Name: x
           Offset: 1
           Expression:
-            Type: 8 GoStringHeaderType string
+            Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 96, index: 0, name: x}
+                  Variable: {subprogram: 90, index: 0, name: x}
                   Offset: 0
                   ByteSize: 16
         - Name: y
           Offset: 17
           Expression:
-            Type: 8 GoStringHeaderType string
+            Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 96, index: 1, name: y}
+                  Variable: {subprogram: 90, index: 1, name: y}
                   Offset: 0
                   ByteSize: 16
         - Name: z
           Offset: 33
           Expression:
-            Type: 8 GoStringHeaderType string
+            Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 96, index: 2, name: z}
+                  Variable: {subprogram: 90, index: 2, name: z}
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
@@ -5033,10 +5033,10 @@ Types:
         - Name: x
           Offset: 1
           Expression:
-            Type: 32 BaseType main.typeAlias
+            Type: 51 BaseType main.typeAlias
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 40, index: 0, name: x}
+                  Variable: {subprogram: 34, index: 0, name: x}
                   Offset: 0
                   ByteSize: 2
     - __kind: EventRootType
@@ -5048,10 +5048,10 @@ Types:
         - Name: x
           Offset: 1
           Expression:
-            Type: 21 ArrayType [2]uint16
+            Type: 45 ArrayType [2]uint16
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 18, index: 0, name: x}
+                  Variable: {subprogram: 12, index: 0, name: x}
                   Offset: 0
                   ByteSize: 4
     - __kind: EventRootType
@@ -5063,10 +5063,10 @@ Types:
         - Name: x
           Offset: 1
           Expression:
-            Type: 23 ArrayType [2]uint32
+            Type: 46 ArrayType [2]uint32
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 19, index: 0, name: x}
+                  Variable: {subprogram: 13, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
@@ -5078,10 +5078,10 @@ Types:
         - Name: x
           Offset: 1
           Expression:
-            Type: 25 ArrayType [2]uint64
+            Type: 47 ArrayType [2]uint64
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 20, index: 0, name: x}
+                  Variable: {subprogram: 14, index: 0, name: x}
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
@@ -5093,10 +5093,10 @@ Types:
         - Name: x
           Offset: 1
           Expression:
-            Type: 3 ArrayType [2]uint8
+            Type: 36 ArrayType [2]uint8
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 17, index: 0, name: x}
+                  Variable: {subprogram: 11, index: 0, name: x}
                   Offset: 0
                   ByteSize: 2
     - __kind: EventRootType
@@ -5108,10 +5108,10 @@ Types:
         - Name: x
           Offset: 1
           Expression:
-            Type: 19 ArrayType [2]uint
+            Type: 44 ArrayType [2]uint
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 16, index: 0, name: x}
+                  Variable: {subprogram: 10, index: 0, name: x}
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
@@ -5123,10 +5123,10 @@ Types:
         - Name: x
           Offset: 1
           Expression:
-            Type: 205 PointerType *uint
+            Type: 34 PointerType *uint
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 80, index: 0, name: x}
+                  Variable: {subprogram: 74, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
@@ -5138,10 +5138,10 @@ Types:
         - Name: u
           Offset: 1
           Expression:
-            Type: 210 GoSliceHeaderType []uint
+            Type: 224 GoSliceHeaderType []uint
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 84, index: 0, name: u}
+                  Variable: {subprogram: 78, index: 0, name: u}
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
@@ -5153,10 +5153,10 @@ Types:
         - Name: x
           Offset: 1
           Expression:
-            Type: 8 GoStringHeaderType string
+            Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 101, index: 0, name: x}
+                  Variable: {subprogram: 95, index: 0, name: x}
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
@@ -5168,10 +5168,10 @@ Types:
         - Name: x
           Offset: 1
           Expression:
-            Type: 38 VoidPointerType unsafe.Pointer
+            Type: 14 VoidPointerType unsafe.Pointer
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 79, index: 0, name: x}
+                  Variable: {subprogram: 73, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
@@ -5183,10 +5183,10 @@ Types:
         - Name: a
           Offset: 1
           Expression:
-            Type: 29 ArrayType [100]uint
+            Type: 50 ArrayType [100]uint
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 24, index: 0, name: a}
+                  Variable: {subprogram: 18, index: 0, name: a}
                   Offset: 0
                   ByteSize: 800
     - __kind: EventRootType
@@ -5198,173 +5198,173 @@ Types:
         - Name: xs
           Offset: 1
           Expression:
-            Type: 210 GoSliceHeaderType []uint
+            Type: 224 GoSliceHeaderType []uint
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 93, index: 0, name: xs}
+                  Variable: {subprogram: 87, index: 0, name: xs}
                   Offset: 0
                   ByteSize: 24
     - __kind: ArrayType
-      ID: 29
+      ID: 50
       Name: '[100]uint'
       ByteSize: 800
       GoKind: 17
       Count: 100
       HasCount: true
-      Element: 20 BaseType uint
+      Element: 17 BaseType uint
     - __kind: ArrayType
-      ID: 28
+      ID: 49
       Name: '[2][2][2]int'
       ByteSize: 64
       GoKind: 17
       Count: 2
       HasCount: true
-      Element: 27 ArrayType [2][2]int
+      Element: 48 ArrayType [2][2]int
     - __kind: ArrayType
-      ID: 27
+      ID: 48
       Name: '[2][2]int'
       ByteSize: 32
       GoKind: 17
       Count: 2
       HasCount: true
-      Element: 12 ArrayType [2]int
+      Element: 40 ArrayType [2]int
     - __kind: ArrayType
-      ID: 10
+      ID: 39
       Name: '[2]bool'
       ByteSize: 2
       GoKind: 17
       Count: 2
       HasCount: true
-      Element: 11 BaseType bool
+      Element: 4 BaseType bool
     - __kind: ArrayType
-      ID: 12
+      ID: 40
       Name: '[2]int'
       ByteSize: 16
       GoRuntimeType: 677024
       GoKind: 17
       Count: 2
       HasCount: true
-      Element: 1 BaseType int
+      Element: 7 BaseType int
     - __kind: ArrayType
-      ID: 15
+      ID: 42
       Name: '[2]int16'
       ByteSize: 4
       GoKind: 17
       Count: 2
       HasCount: true
-      Element: 16 BaseType int16
+      Element: 31 BaseType int16
     - __kind: ArrayType
-      ID: 5
+      ID: 37
       Name: '[2]int32'
       ByteSize: 8
       GoRuntimeType: 678368
       GoKind: 17
       Count: 2
       HasCount: true
-      Element: 6 BaseType int32
+      Element: 10 BaseType int32
     - __kind: ArrayType
-      ID: 17
+      ID: 43
       Name: '[2]int64'
       ByteSize: 16
       GoKind: 17
       Count: 2
       HasCount: true
-      Element: 18 BaseType int64
+      Element: 12 BaseType int64
     - __kind: ArrayType
-      ID: 13
+      ID: 41
       Name: '[2]int8'
       ByteSize: 2
       GoKind: 17
       Count: 2
       HasCount: true
-      Element: 14 BaseType int8
+      Element: 16 BaseType int8
     - __kind: ArrayType
-      ID: 118
+      ID: 134
       Name: '[2]map[string]int'
       ByteSize: 16
       GoKind: 17
       Count: 2
       HasCount: true
-      Element: 83 GoMapType map[string]int
+      Element: 99 GoMapType map[string]int
     - __kind: ArrayType
-      ID: 7
+      ID: 38
       Name: '[2]string'
       ByteSize: 32
       GoRuntimeType: 678464
       GoKind: 17
       Count: 2
       HasCount: true
-      Element: 8 GoStringHeaderType string
+      Element: 9 GoStringHeaderType string
     - __kind: ArrayType
-      ID: 19
+      ID: 44
       Name: '[2]uint'
       ByteSize: 16
       GoKind: 17
       Count: 2
       HasCount: true
-      Element: 20 BaseType uint
+      Element: 17 BaseType uint
     - __kind: ArrayType
-      ID: 21
+      ID: 45
       Name: '[2]uint16'
       ByteSize: 4
       GoKind: 17
       Count: 2
       HasCount: true
-      Element: 22 BaseType uint16
+      Element: 6 BaseType uint16
     - __kind: ArrayType
-      ID: 23
+      ID: 46
       Name: '[2]uint32'
       ByteSize: 8
       GoKind: 17
       Count: 2
       HasCount: true
-      Element: 24 BaseType uint32
+      Element: 2 BaseType uint32
     - __kind: ArrayType
-      ID: 25
+      ID: 47
       Name: '[2]uint64'
       ByteSize: 16
       GoRuntimeType: 678560
       GoKind: 17
       Count: 2
       HasCount: true
-      Element: 26 BaseType uint64
+      Element: 8 BaseType uint64
     - __kind: ArrayType
-      ID: 3
+      ID: 36
       Name: '[2]uint8'
       ByteSize: 2
       GoRuntimeType: 678272
       GoKind: 17
       Count: 2
       HasCount: true
-      Element: 4 BaseType uint8
+      Element: 3 BaseType uint8
     - __kind: ArrayType
-      ID: 179
+      ID: 195
       Name: '[4]int'
       ByteSize: 32
       GoRuntimeType: 676640
       GoKind: 17
       Count: 4
       HasCount: true
-      Element: 1 BaseType int
+      Element: 7 BaseType int
     - __kind: ArrayType
-      ID: 117
+      ID: 133
       Name: '[4]string'
       ByteSize: 64
       GoRuntimeType: 676928
       GoKind: 17
       Count: 4
       HasCount: true
-      Element: 8 GoStringHeaderType string
+      Element: 9 GoStringHeaderType string
     - __kind: ArrayType
-      ID: 2
+      ID: 73
       Name: '[5]int'
       ByteSize: 40
       GoKind: 17
       Count: 5
       HasCount: true
-      Element: 1 BaseType int
+      Element: 7 BaseType int
     - __kind: GoSliceHeaderType
-      ID: 34
+      ID: 53
       Name: '[]*string'
       ByteSize: 24
       GoRuntimeType: 473536
@@ -5372,102 +5372,102 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 35 PointerType **string
+          Type: 54 PointerType **string
         - Name: len
           Offset: 8
-          Type: 1 BaseType int
+          Type: 7 BaseType int
         - Name: cap
           Offset: 16
-          Type: 1 BaseType int
+          Type: 7 BaseType int
       Data: 240 GoSliceDataType []*string.array
     - __kind: GoSliceDataType
       ID: 240
       Name: '[]*string.array'
       ByteSize: 2048
-      Element: 36 PointerType *string
+      Element: 22 PointerType *string
     - __kind: GoSliceDataType
       ID: 268
       Name: '[]*table<[4]int,[4]int>.array'
       ByteSize: 8192
-      Element: 195 PointerType *table<[4]int,[4]int>
+      Element: 211 PointerType *table<[4]int,[4]int>
     - __kind: GoSliceDataType
       ID: 266
       Name: '[]*table<[4]int,uint8>.array'
       ByteSize: 8192
-      Element: 184 PointerType *table<[4]int,uint8>
+      Element: 200 PointerType *table<[4]int,uint8>
     - __kind: GoSliceDataType
       ID: 252
       Name: '[]*table<[4]string,[2]int>.array'
       ByteSize: 8192
-      Element: 110 PointerType *table<[4]string,[2]int>
+      Element: 126 PointerType *table<[4]string,[2]int>
     - __kind: GoSliceDataType
       ID: 258
       Name: '[]*table<bool,main.node>.array'
       ByteSize: 8192
-      Element: 137 PointerType *table<bool,main.node>
+      Element: 153 PointerType *table<bool,main.node>
     - __kind: GoSliceDataType
       ID: 242
       Name: '[]*table<int,int>.array'
       ByteSize: 8192
-      Element: 64 PointerType *table<int,int>
+      Element: 80 PointerType *table<int,int>
     - __kind: GoSliceDataType
       ID: 260
       Name: '[]*table<int,uint8>.array'
       ByteSize: 8192
-      Element: 150 PointerType *table<int,uint8>
+      Element: 166 PointerType *table<int,uint8>
     - __kind: GoSliceDataType
       ID: 254
       Name: '[]*table<string,[]main.structWithMap>.array'
       ByteSize: 8192
-      Element: 124 PointerType *table<string,[]main.structWithMap>
+      Element: 140 PointerType *table<string,[]main.structWithMap>
     - __kind: GoSliceDataType
       ID: 248
       Name: '[]*table<string,[]string>.array'
       ByteSize: 8192
-      Element: 98 PointerType *table<string,[]string>
+      Element: 114 PointerType *table<string,[]string>
     - __kind: GoSliceDataType
       ID: 246
       Name: '[]*table<string,int>.array'
       ByteSize: 8192
-      Element: 87 PointerType *table<string,int>
+      Element: 103 PointerType *table<string,int>
     - __kind: GoSliceDataType
       ID: 244
       Name: '[]*table<string,main.nestedStruct>.array'
       ByteSize: 8192
-      Element: 75 PointerType *table<string,main.nestedStruct>
+      Element: 91 PointerType *table<string,main.nestedStruct>
     - __kind: GoSliceDataType
       ID: 264
       Name: '[]*table<uint8,[4]int>.array'
       ByteSize: 8192
-      Element: 172 PointerType *table<uint8,[4]int>
+      Element: 188 PointerType *table<uint8,[4]int>
     - __kind: GoSliceDataType
       ID: 262
       Name: '[]*table<uint8,uint8>.array'
       ByteSize: 8192
-      Element: 161 PointerType *table<uint8,uint8>
+      Element: 177 PointerType *table<uint8,uint8>
     - __kind: GoSliceHeaderType
-      ID: 211
+      ID: 225
       Name: '[][]uint'
       ByteSize: 24
       GoKind: 23
       RawFields:
         - Name: array
           Offset: 0
-          Type: 212 PointerType *[]uint
+          Type: 226 PointerType *[]uint
         - Name: len
           Offset: 8
-          Type: 1 BaseType int
+          Type: 7 BaseType int
         - Name: cap
           Offset: 16
-          Type: 1 BaseType int
+          Type: 7 BaseType int
       Data: 274 GoSliceDataType [][]uint.array
     - __kind: GoSliceDataType
       ID: 274
       Name: '[][]uint.array'
       ByteSize: 2048
-      Element: 210 GoSliceHeaderType []uint
+      Element: 224 GoSliceHeaderType []uint
     - __kind: GoSliceHeaderType
-      ID: 216
+      ID: 230
       Name: '[]bool'
       ByteSize: 24
       GoRuntimeType: 481856
@@ -5475,21 +5475,21 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 206 PointerType *bool
+          Type: 11 PointerType *bool
         - Name: len
           Offset: 8
-          Type: 1 BaseType int
+          Type: 7 BaseType int
         - Name: cap
           Offset: 16
-          Type: 1 BaseType int
+          Type: 7 BaseType int
       Data: 278 GoSliceDataType []bool.array
     - __kind: GoSliceDataType
       ID: 278
       Name: '[]bool.array'
       ByteSize: 2048
-      Element: 11 BaseType bool
+      Element: 4 BaseType bool
     - __kind: GoSliceHeaderType
-      ID: 131
+      ID: 147
       Name: '[]main.structWithMap'
       ByteSize: 24
       GoRuntimeType: 472768
@@ -5497,102 +5497,102 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 132 PointerType *main.structWithMap
+          Type: 148 PointerType *main.structWithMap
         - Name: len
           Offset: 8
-          Type: 1 BaseType int
+          Type: 7 BaseType int
         - Name: cap
           Offset: 16
-          Type: 1 BaseType int
+          Type: 7 BaseType int
       Data: 256 GoSliceDataType []main.structWithMap.array
     - __kind: GoSliceDataType
       ID: 256
       Name: '[]main.structWithMap.array'
       ByteSize: 2048
-      Element: 58 StructureType main.structWithMap
+      Element: 75 StructureType main.structWithMap
     - __kind: GoSliceHeaderType
-      ID: 213
+      ID: 227
       Name: '[]main.structWithNoStrings'
       ByteSize: 24
       GoKind: 23
       RawFields:
         - Name: array
           Offset: 0
-          Type: 214 PointerType *main.structWithNoStrings
+          Type: 228 PointerType *main.structWithNoStrings
         - Name: len
           Offset: 8
-          Type: 1 BaseType int
+          Type: 7 BaseType int
         - Name: cap
           Offset: 16
-          Type: 1 BaseType int
+          Type: 7 BaseType int
       Data: 276 GoSliceDataType []main.structWithNoStrings.array
     - __kind: GoSliceDataType
       ID: 276
       Name: '[]main.structWithNoStrings.array'
       ByteSize: 2048
-      Element: 215 StructureType main.structWithNoStrings
+      Element: 229 StructureType main.structWithNoStrings
     - __kind: GoSliceDataType
       ID: 269
       Name: '[]noalg.map.group[[4]int][4]int.array'
       ByteSize: 2048
-      Element: 199 StructureType noalg.map.group[[4]int][4]int
+      Element: 215 StructureType noalg.map.group[[4]int][4]int
     - __kind: GoSliceDataType
       ID: 267
       Name: '[]noalg.map.group[[4]int]uint8.array'
       ByteSize: 2048
-      Element: 188 StructureType noalg.map.group[[4]int]uint8
+      Element: 204 StructureType noalg.map.group[[4]int]uint8
     - __kind: GoSliceDataType
       ID: 253
       Name: '[]noalg.map.group[[4]string][2]int.array'
       ByteSize: 2048
-      Element: 114 StructureType noalg.map.group[[4]string][2]int
+      Element: 130 StructureType noalg.map.group[[4]string][2]int
     - __kind: GoSliceDataType
       ID: 259
       Name: '[]noalg.map.group[bool]main.node.array'
       ByteSize: 2048
-      Element: 141 StructureType noalg.map.group[bool]main.node
+      Element: 157 StructureType noalg.map.group[bool]main.node
     - __kind: GoSliceDataType
       ID: 243
       Name: '[]noalg.map.group[int]int.array'
       ByteSize: 2048
-      Element: 68 StructureType noalg.map.group[int]int
+      Element: 84 StructureType noalg.map.group[int]int
     - __kind: GoSliceDataType
       ID: 261
       Name: '[]noalg.map.group[int]uint8.array'
       ByteSize: 2048
-      Element: 154 StructureType noalg.map.group[int]uint8
+      Element: 170 StructureType noalg.map.group[int]uint8
     - __kind: GoSliceDataType
       ID: 255
       Name: '[]noalg.map.group[string][]main.structWithMap.array'
       ByteSize: 2048
-      Element: 128 StructureType noalg.map.group[string][]main.structWithMap
+      Element: 144 StructureType noalg.map.group[string][]main.structWithMap
     - __kind: GoSliceDataType
       ID: 249
       Name: '[]noalg.map.group[string][]string.array'
       ByteSize: 2048
-      Element: 102 StructureType noalg.map.group[string][]string
+      Element: 118 StructureType noalg.map.group[string][]string
     - __kind: GoSliceDataType
       ID: 247
       Name: '[]noalg.map.group[string]int.array'
       ByteSize: 2048
-      Element: 91 StructureType noalg.map.group[string]int
+      Element: 107 StructureType noalg.map.group[string]int
     - __kind: GoSliceDataType
       ID: 245
       Name: '[]noalg.map.group[string]main.nestedStruct.array'
       ByteSize: 2048
-      Element: 79 StructureType noalg.map.group[string]main.nestedStruct
+      Element: 95 StructureType noalg.map.group[string]main.nestedStruct
     - __kind: GoSliceDataType
       ID: 265
       Name: '[]noalg.map.group[uint8][4]int.array'
       ByteSize: 2048
-      Element: 176 StructureType noalg.map.group[uint8][4]int
+      Element: 192 StructureType noalg.map.group[uint8][4]int
     - __kind: GoSliceDataType
       ID: 263
       Name: '[]noalg.map.group[uint8]uint8.array'
       ByteSize: 2048
-      Element: 165 StructureType noalg.map.group[uint8]uint8
+      Element: 181 StructureType noalg.map.group[uint8]uint8
     - __kind: GoSliceHeaderType
-      ID: 105
+      ID: 121
       Name: '[]string'
       ByteSize: 24
       GoRuntimeType: 481984
@@ -5600,21 +5600,21 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 36 PointerType *string
+          Type: 22 PointerType *string
         - Name: len
           Offset: 8
-          Type: 1 BaseType int
+          Type: 7 BaseType int
         - Name: cap
           Offset: 16
-          Type: 1 BaseType int
+          Type: 7 BaseType int
       Data: 250 GoSliceDataType []string.array
     - __kind: GoSliceDataType
       ID: 250
       Name: '[]string.array'
       ByteSize: 2048
-      Element: 8 GoStringHeaderType string
+      Element: 9 GoStringHeaderType string
     - __kind: GoSliceHeaderType
-      ID: 210
+      ID: 224
       Name: '[]uint'
       ByteSize: 24
       GoRuntimeType: 481472
@@ -5622,21 +5622,21 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 205 PointerType *uint
+          Type: 34 PointerType *uint
         - Name: len
           Offset: 8
-          Type: 1 BaseType int
+          Type: 7 BaseType int
         - Name: cap
           Offset: 16
-          Type: 1 BaseType int
+          Type: 7 BaseType int
       Data: 272 GoSliceDataType []uint.array
     - __kind: GoSliceDataType
       ID: 272
       Name: '[]uint.array'
       ByteSize: 2048
-      Element: 20 BaseType uint
+      Element: 17 BaseType uint
     - __kind: GoSliceHeaderType
-      ID: 217
+      ID: 231
       Name: '[]uint16'
       ByteSize: 24
       GoRuntimeType: 480832
@@ -5644,49 +5644,49 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 218 PointerType *uint16
+          Type: 29 PointerType *uint16
         - Name: len
           Offset: 8
-          Type: 1 BaseType int
+          Type: 7 BaseType int
         - Name: cap
           Offset: 16
-          Type: 1 BaseType int
+          Type: 7 BaseType int
       Data: 280 GoSliceDataType []uint16.array
     - __kind: GoSliceDataType
       ID: 280
       Name: '[]uint16.array'
       ByteSize: 2048
-      Element: 22 BaseType uint16
+      Element: 6 BaseType uint16
     - __kind: BaseType
-      ID: 11
+      ID: 4
       Name: bool
       ByteSize: 1
       GoRuntimeType: 579808
       GoKind: 1
     - __kind: GoChannelType
-      ID: 202
+      ID: 218
       Name: chan bool
       GoRuntimeType: 591136
       GoKind: 18
     - __kind: GoChannelType
-      ID: 40
+      ID: 57
       Name: chan struct {}
       GoRuntimeType: 590048
       GoKind: 18
     - __kind: BaseType
-      ID: 229
+      ID: 24
       Name: complex128
       ByteSize: 16
       GoRuntimeType: 579616
       GoKind: 16
     - __kind: BaseType
-      ID: 228
+      ID: 23
       Name: complex64
       ByteSize: 8
       GoRuntimeType: 579552
       GoKind: 15
     - __kind: GoInterfaceType
-      ID: 57
+      ID: 13
       Name: error
       ByteSize: 16
       GoRuntimeType: 1.020704e+06
@@ -5694,228 +5694,228 @@ Types:
       RawFields:
         - Name: tab
           Offset: 0
-          Type: 38 VoidPointerType unsafe.Pointer
+          Type: 14 VoidPointerType unsafe.Pointer
         - Name: data
           Offset: 8
-          Type: 38 VoidPointerType unsafe.Pointer
+          Type: 14 VoidPointerType unsafe.Pointer
     - __kind: BaseType
-      ID: 30
+      ID: 18
       Name: float32
       ByteSize: 4
       GoRuntimeType: 579680
       GoKind: 13
     - __kind: BaseType
-      ID: 31
+      ID: 15
       Name: float64
       ByteSize: 8
       GoRuntimeType: 579744
       GoKind: 14
     - __kind: GoSubroutineType
-      ID: 43
+      ID: 60
       Name: func()
       ByteSize: 8
       GoRuntimeType: 471744
       GoKind: 19
     - __kind: GoSwissMapGroupsType
-      ID: 197
+      ID: 213
       Name: groupReference<[4]int,[4]int>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 198 PointerType *noalg.map.group[[4]int][4]int
+          Type: 214 PointerType *noalg.map.group[[4]int][4]int
         - Name: lengthMask
           Offset: 8
-          Type: 26 BaseType uint64
-      GroupType: 199 StructureType noalg.map.group[[4]int][4]int
+          Type: 8 BaseType uint64
+      GroupType: 215 StructureType noalg.map.group[[4]int][4]int
       GroupSliceType: 269 GoSliceDataType []noalg.map.group[[4]int][4]int.array
     - __kind: GoSwissMapGroupsType
-      ID: 186
+      ID: 202
       Name: groupReference<[4]int,uint8>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 187 PointerType *noalg.map.group[[4]int]uint8
+          Type: 203 PointerType *noalg.map.group[[4]int]uint8
         - Name: lengthMask
           Offset: 8
-          Type: 26 BaseType uint64
-      GroupType: 188 StructureType noalg.map.group[[4]int]uint8
+          Type: 8 BaseType uint64
+      GroupType: 204 StructureType noalg.map.group[[4]int]uint8
       GroupSliceType: 267 GoSliceDataType []noalg.map.group[[4]int]uint8.array
     - __kind: GoSwissMapGroupsType
-      ID: 112
+      ID: 128
       Name: groupReference<[4]string,[2]int>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 113 PointerType *noalg.map.group[[4]string][2]int
+          Type: 129 PointerType *noalg.map.group[[4]string][2]int
         - Name: lengthMask
           Offset: 8
-          Type: 26 BaseType uint64
-      GroupType: 114 StructureType noalg.map.group[[4]string][2]int
+          Type: 8 BaseType uint64
+      GroupType: 130 StructureType noalg.map.group[[4]string][2]int
       GroupSliceType: 253 GoSliceDataType []noalg.map.group[[4]string][2]int.array
     - __kind: GoSwissMapGroupsType
-      ID: 139
+      ID: 155
       Name: groupReference<bool,main.node>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 140 PointerType *noalg.map.group[bool]main.node
+          Type: 156 PointerType *noalg.map.group[bool]main.node
         - Name: lengthMask
           Offset: 8
-          Type: 26 BaseType uint64
-      GroupType: 141 StructureType noalg.map.group[bool]main.node
+          Type: 8 BaseType uint64
+      GroupType: 157 StructureType noalg.map.group[bool]main.node
       GroupSliceType: 259 GoSliceDataType []noalg.map.group[bool]main.node.array
     - __kind: GoSwissMapGroupsType
-      ID: 66
+      ID: 82
       Name: groupReference<int,int>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 67 PointerType *noalg.map.group[int]int
+          Type: 83 PointerType *noalg.map.group[int]int
         - Name: lengthMask
           Offset: 8
-          Type: 26 BaseType uint64
-      GroupType: 68 StructureType noalg.map.group[int]int
+          Type: 8 BaseType uint64
+      GroupType: 84 StructureType noalg.map.group[int]int
       GroupSliceType: 243 GoSliceDataType []noalg.map.group[int]int.array
     - __kind: GoSwissMapGroupsType
-      ID: 152
+      ID: 168
       Name: groupReference<int,uint8>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 153 PointerType *noalg.map.group[int]uint8
+          Type: 169 PointerType *noalg.map.group[int]uint8
         - Name: lengthMask
           Offset: 8
-          Type: 26 BaseType uint64
-      GroupType: 154 StructureType noalg.map.group[int]uint8
+          Type: 8 BaseType uint64
+      GroupType: 170 StructureType noalg.map.group[int]uint8
       GroupSliceType: 261 GoSliceDataType []noalg.map.group[int]uint8.array
     - __kind: GoSwissMapGroupsType
-      ID: 126
+      ID: 142
       Name: groupReference<string,[]main.structWithMap>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 127 PointerType *noalg.map.group[string][]main.structWithMap
+          Type: 143 PointerType *noalg.map.group[string][]main.structWithMap
         - Name: lengthMask
           Offset: 8
-          Type: 26 BaseType uint64
-      GroupType: 128 StructureType noalg.map.group[string][]main.structWithMap
+          Type: 8 BaseType uint64
+      GroupType: 144 StructureType noalg.map.group[string][]main.structWithMap
       GroupSliceType: 255 GoSliceDataType []noalg.map.group[string][]main.structWithMap.array
     - __kind: GoSwissMapGroupsType
-      ID: 100
+      ID: 116
       Name: groupReference<string,[]string>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 101 PointerType *noalg.map.group[string][]string
+          Type: 117 PointerType *noalg.map.group[string][]string
         - Name: lengthMask
           Offset: 8
-          Type: 26 BaseType uint64
-      GroupType: 102 StructureType noalg.map.group[string][]string
+          Type: 8 BaseType uint64
+      GroupType: 118 StructureType noalg.map.group[string][]string
       GroupSliceType: 249 GoSliceDataType []noalg.map.group[string][]string.array
     - __kind: GoSwissMapGroupsType
-      ID: 89
+      ID: 105
       Name: groupReference<string,int>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 90 PointerType *noalg.map.group[string]int
+          Type: 106 PointerType *noalg.map.group[string]int
         - Name: lengthMask
           Offset: 8
-          Type: 26 BaseType uint64
-      GroupType: 91 StructureType noalg.map.group[string]int
+          Type: 8 BaseType uint64
+      GroupType: 107 StructureType noalg.map.group[string]int
       GroupSliceType: 247 GoSliceDataType []noalg.map.group[string]int.array
     - __kind: GoSwissMapGroupsType
-      ID: 77
+      ID: 93
       Name: groupReference<string,main.nestedStruct>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 78 PointerType *noalg.map.group[string]main.nestedStruct
+          Type: 94 PointerType *noalg.map.group[string]main.nestedStruct
         - Name: lengthMask
           Offset: 8
-          Type: 26 BaseType uint64
-      GroupType: 79 StructureType noalg.map.group[string]main.nestedStruct
+          Type: 8 BaseType uint64
+      GroupType: 95 StructureType noalg.map.group[string]main.nestedStruct
       GroupSliceType: 245 GoSliceDataType []noalg.map.group[string]main.nestedStruct.array
     - __kind: GoSwissMapGroupsType
-      ID: 174
+      ID: 190
       Name: groupReference<uint8,[4]int>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 175 PointerType *noalg.map.group[uint8][4]int
+          Type: 191 PointerType *noalg.map.group[uint8][4]int
         - Name: lengthMask
           Offset: 8
-          Type: 26 BaseType uint64
-      GroupType: 176 StructureType noalg.map.group[uint8][4]int
+          Type: 8 BaseType uint64
+      GroupType: 192 StructureType noalg.map.group[uint8][4]int
       GroupSliceType: 265 GoSliceDataType []noalg.map.group[uint8][4]int.array
     - __kind: GoSwissMapGroupsType
-      ID: 163
+      ID: 179
       Name: groupReference<uint8,uint8>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 164 PointerType *noalg.map.group[uint8]uint8
+          Type: 180 PointerType *noalg.map.group[uint8]uint8
         - Name: lengthMask
           Offset: 8
-          Type: 26 BaseType uint64
-      GroupType: 165 StructureType noalg.map.group[uint8]uint8
+          Type: 8 BaseType uint64
+      GroupType: 181 StructureType noalg.map.group[uint8]uint8
       GroupSliceType: 263 GoSliceDataType []noalg.map.group[uint8]uint8.array
     - __kind: BaseType
-      ID: 1
+      ID: 7
       Name: int
       ByteSize: 8
       GoRuntimeType: 579360
       GoKind: 2
     - __kind: BaseType
-      ID: 16
+      ID: 31
       Name: int16
       ByteSize: 2
       GoRuntimeType: 578976
       GoKind: 4
     - __kind: BaseType
-      ID: 6
+      ID: 10
       Name: int32
       ByteSize: 4
       GoRuntimeType: 579104
       GoKind: 5
     - __kind: BaseType
-      ID: 18
+      ID: 12
       Name: int64
       ByteSize: 8
       GoRuntimeType: 579232
       GoKind: 6
     - __kind: BaseType
-      ID: 14
+      ID: 16
       Name: int8
       ByteSize: 1
       GoRuntimeType: 578848
       GoKind: 3
     - __kind: GoEmptyInterfaceType
-      ID: 41
+      ID: 58
       Name: interface {}
       ByteSize: 16
       GoRuntimeType: 841856
@@ -5923,12 +5923,12 @@ Types:
       RawFields:
         - Name: _type
           Offset: 0
-          Type: 38 VoidPointerType unsafe.Pointer
+          Type: 14 VoidPointerType unsafe.Pointer
         - Name: data
           Offset: 8
-          Type: 38 VoidPointerType unsafe.Pointer
+          Type: 14 VoidPointerType unsafe.Pointer
     - __kind: StructureType
-      ID: 48
+      ID: 65
       Name: internal/sync.Mutex
       ByteSize: 8
       GoRuntimeType: 1.46e+06
@@ -5936,12 +5936,12 @@ Types:
       RawFields:
         - Name: state
           Offset: 0
-          Type: 6 BaseType int32
+          Type: 10 BaseType int32
         - Name: sema
           Offset: 4
-          Type: 24 BaseType uint32
+          Type: 2 BaseType uint32
     - __kind: GoInterfaceType
-      ID: 37
+      ID: 55
       Name: io.Writer
       ByteSize: 16
       GoRuntimeType: 1.016736e+06
@@ -5949,30 +5949,30 @@ Types:
       RawFields:
         - Name: tab
           Offset: 0
-          Type: 38 VoidPointerType unsafe.Pointer
+          Type: 14 VoidPointerType unsafe.Pointer
         - Name: data
           Offset: 8
-          Type: 38 VoidPointerType unsafe.Pointer
+          Type: 14 VoidPointerType unsafe.Pointer
     - __kind: StructureType
-      ID: 223
+      ID: 236
       Name: main.aStruct
       ByteSize: 56
       GoKind: 25
       RawFields:
         - Name: aBool
           Offset: 0
-          Type: 11 BaseType bool
+          Type: 4 BaseType bool
         - Name: aString
           Offset: 8
-          Type: 8 GoStringHeaderType string
+          Type: 9 GoStringHeaderType string
         - Name: aNumber
           Offset: 24
-          Type: 1 BaseType int
+          Type: 7 BaseType int
         - Name: nested
           Offset: 32
-          Type: 82 StructureType main.nestedStruct
+          Type: 98 StructureType main.nestedStruct
     - __kind: GoInterfaceType
-      ID: 56
+      ID: 74
       Name: main.behavior
       ByteSize: 16
       GoRuntimeType: 1.016352e+06
@@ -5980,32 +5980,32 @@ Types:
       RawFields:
         - Name: tab
           Offset: 0
-          Type: 38 VoidPointerType unsafe.Pointer
+          Type: 14 VoidPointerType unsafe.Pointer
         - Name: data
           Offset: 8
-          Type: 38 VoidPointerType unsafe.Pointer
+          Type: 14 VoidPointerType unsafe.Pointer
     - __kind: StructureType
-      ID: 33
+      ID: 52
       Name: main.bigStruct
       ByteSize: 48
       GoKind: 25
       RawFields:
         - Name: x
           Offset: 0
-          Type: 34 GoSliceHeaderType []*string
+          Type: 53 GoSliceHeaderType []*string
         - Name: z
           Offset: 24
-          Type: 1 BaseType int
+          Type: 7 BaseType int
         - Name: writer
           Offset: 32
-          Type: 37 GoInterfaceType io.Writer
+          Type: 55 GoInterfaceType io.Writer
     - __kind: StructureType
-      ID: 224
+      ID: 237
       Name: main.emptyStruct
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 45
+      ID: 62
       Name: main.esotericHeap
       ByteSize: 112
       GoRuntimeType: 1.82096e+06
@@ -6013,21 +6013,21 @@ Types:
       RawFields:
         - Name: esotericStack
           Offset: 0
-          Type: 39 StructureType main.esotericStack
+          Type: 56 StructureType main.esotericStack
         - Name: mu
           Offset: 64
-          Type: 46 StructureType sync.Mutex
+          Type: 63 StructureType sync.Mutex
         - Name: once
           Offset: 72
-          Type: 49 StructureType sync.Once
+          Type: 66 StructureType sync.Once
         - Name: wg
           Offset: 88
-          Type: 52 StructureType sync.WaitGroup
+          Type: 69 StructureType sync.WaitGroup
         - Name: a
           Offset: 104
-          Type: 55 StructureType sync/atomic.Int32
+          Type: 72 StructureType sync/atomic.Int32
     - __kind: StructureType
-      ID: 39
+      ID: 56
       Name: main.esotericStack
       ByteSize: 64
       GoRuntimeType: 1.954272e+06
@@ -6035,27 +6035,27 @@ Types:
       RawFields:
         - Name: _
           Offset: 0
-          Type: 6 BaseType int32
+          Type: 10 BaseType int32
         - Name: _valid
           Offset: 4
-          Type: 6 BaseType int32
+          Type: 10 BaseType int32
         - Name: c
           Offset: 8
-          Type: 40 GoChannelType chan struct {}
+          Type: 57 GoChannelType chan struct {}
         - Name: val
           Offset: 16
-          Type: 41 GoEmptyInterfaceType interface {}
+          Type: 58 GoEmptyInterfaceType interface {}
         - Name: _
           Offset: 32
-          Type: 26 BaseType uint64
+          Type: 8 BaseType uint64
         - Name: work
           Offset: 40
-          Type: 42 GoInterfaceType main.something
+          Type: 59 GoInterfaceType main.something
         - Name: foo
           Offset: 56
-          Type: 43 GoSubroutineType func()
+          Type: 60 GoSubroutineType func()
     - __kind: StructureType
-      ID: 82
+      ID: 98
       Name: main.nestedStruct
       ByteSize: 24
       GoRuntimeType: 1.44864e+06
@@ -6063,12 +6063,12 @@ Types:
       RawFields:
         - Name: anotherInt
           Offset: 0
-          Type: 1 BaseType int
+          Type: 7 BaseType int
         - Name: anotherString
           Offset: 8
-          Type: 8 GoStringHeaderType string
+          Type: 9 GoStringHeaderType string
     - __kind: StructureType
-      ID: 144
+      ID: 160
       Name: main.node
       ByteSize: 16
       GoRuntimeType: 1.44848e+06
@@ -6076,21 +6076,21 @@ Types:
       RawFields:
         - Name: val
           Offset: 0
-          Type: 1 BaseType int
+          Type: 7 BaseType int
         - Name: b
           Offset: 8
-          Type: 145 PointerType *main.node
+          Type: 161 PointerType *main.node
     - __kind: StructureType
-      ID: 222
+      ID: 235
       Name: main.oneStringStruct
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: a
           Offset: 0
-          Type: 8 GoStringHeaderType string
+          Type: 9 GoStringHeaderType string
     - __kind: GoInterfaceType
-      ID: 42
+      ID: 59
       Name: main.something
       ByteSize: 16
       GoRuntimeType: 1.01648e+06
@@ -6098,12 +6098,12 @@ Types:
       RawFields:
         - Name: tab
           Offset: 0
-          Type: 38 VoidPointerType unsafe.Pointer
+          Type: 14 VoidPointerType unsafe.Pointer
         - Name: data
           Offset: 8
-          Type: 38 VoidPointerType unsafe.Pointer
+          Type: 14 VoidPointerType unsafe.Pointer
     - __kind: StructureType
-      ID: 58
+      ID: 75
       Name: main.structWithMap
       ByteSize: 8
       GoRuntimeType: 1.177504e+06
@@ -6111,686 +6111,686 @@ Types:
       RawFields:
         - Name: m
           Offset: 0
-          Type: 59 GoMapType map[int]int
+          Type: 76 GoMapType map[int]int
     - __kind: StructureType
-      ID: 215
+      ID: 229
       Name: main.structWithNoStrings
       ByteSize: 2
       GoKind: 25
       RawFields:
         - Name: aUint8
           Offset: 0
-          Type: 4 BaseType uint8
+          Type: 3 BaseType uint8
         - Name: aBool
           Offset: 1
-          Type: 11 BaseType bool
+          Type: 4 BaseType bool
     - __kind: StructureType
-      ID: 204
+      ID: 220
       Name: main.structWithTwoValues
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: a
           Offset: 0
-          Type: 20 BaseType uint
+          Type: 17 BaseType uint
         - Name: b
           Offset: 8
-          Type: 11 BaseType bool
+          Type: 4 BaseType bool
     - __kind: GoSliceHeaderType
-      ID: 208
+      ID: 222
       Name: main.t
       ByteSize: 24
       GoKind: 23
       RawFields:
         - Name: array
           Offset: 0
-          Type: 209 PointerType **main.t
+          Type: 223 PointerType **main.t
         - Name: len
           Offset: 8
-          Type: 1 BaseType int
+          Type: 7 BaseType int
         - Name: cap
           Offset: 16
-          Type: 1 BaseType int
+          Type: 7 BaseType int
       Data: 270 GoSliceDataType main.t.array
     - __kind: GoSliceDataType
       ID: 270
       Name: main.t.array
       ByteSize: 2048
-      Element: 207 PointerType *main.t
+      Element: 221 PointerType *main.t
     - __kind: StructureType
-      ID: 219
+      ID: 232
       Name: main.threeStringStruct
       ByteSize: 48
       GoKind: 25
       RawFields:
         - Name: a
           Offset: 0
-          Type: 8 GoStringHeaderType string
+          Type: 9 GoStringHeaderType string
         - Name: b
           Offset: 16
-          Type: 8 GoStringHeaderType string
+          Type: 9 GoStringHeaderType string
         - Name: c
           Offset: 32
-          Type: 8 GoStringHeaderType string
+          Type: 9 GoStringHeaderType string
     - __kind: BaseType
-      ID: 32
+      ID: 51
       Name: main.typeAlias
       ByteSize: 2
       GoKind: 9
     - __kind: GoSwissMapHeaderType
-      ID: 193
+      ID: 209
       Name: map<[4]int,[4]int>
       ByteSize: 48
       GoKind: 25
       RawFields:
         - Name: used
           Offset: 0
-          Type: 26 BaseType uint64
+          Type: 8 BaseType uint64
         - Name: seed
           Offset: 8
-          Type: 62 BaseType uintptr
+          Type: 1 BaseType uintptr
         - Name: dirPtr
           Offset: 16
-          Type: 194 PointerType **table<[4]int,[4]int>
+          Type: 210 PointerType **table<[4]int,[4]int>
         - Name: dirLen
           Offset: 24
-          Type: 1 BaseType int
+          Type: 7 BaseType int
         - Name: globalDepth
           Offset: 32
-          Type: 4 BaseType uint8
+          Type: 3 BaseType uint8
         - Name: globalShift
           Offset: 33
-          Type: 4 BaseType uint8
+          Type: 3 BaseType uint8
         - Name: writing
           Offset: 34
-          Type: 4 BaseType uint8
+          Type: 3 BaseType uint8
         - Name: tombstonePossible
           Offset: 35
-          Type: 11 BaseType bool
+          Type: 4 BaseType bool
         - Name: clearSeq
           Offset: 40
-          Type: 26 BaseType uint64
+          Type: 8 BaseType uint64
       TablePtrSliceType: 268 GoSliceDataType []*table<[4]int,[4]int>.array
-      GroupType: 199 StructureType noalg.map.group[[4]int][4]int
+      GroupType: 215 StructureType noalg.map.group[[4]int][4]int
     - __kind: GoSwissMapHeaderType
-      ID: 182
+      ID: 198
       Name: map<[4]int,uint8>
       ByteSize: 48
       GoKind: 25
       RawFields:
         - Name: used
           Offset: 0
-          Type: 26 BaseType uint64
+          Type: 8 BaseType uint64
         - Name: seed
           Offset: 8
-          Type: 62 BaseType uintptr
+          Type: 1 BaseType uintptr
         - Name: dirPtr
           Offset: 16
-          Type: 183 PointerType **table<[4]int,uint8>
+          Type: 199 PointerType **table<[4]int,uint8>
         - Name: dirLen
           Offset: 24
-          Type: 1 BaseType int
+          Type: 7 BaseType int
         - Name: globalDepth
           Offset: 32
-          Type: 4 BaseType uint8
+          Type: 3 BaseType uint8
         - Name: globalShift
           Offset: 33
-          Type: 4 BaseType uint8
+          Type: 3 BaseType uint8
         - Name: writing
           Offset: 34
-          Type: 4 BaseType uint8
+          Type: 3 BaseType uint8
         - Name: tombstonePossible
           Offset: 35
-          Type: 11 BaseType bool
+          Type: 4 BaseType bool
         - Name: clearSeq
           Offset: 40
-          Type: 26 BaseType uint64
+          Type: 8 BaseType uint64
       TablePtrSliceType: 266 GoSliceDataType []*table<[4]int,uint8>.array
-      GroupType: 188 StructureType noalg.map.group[[4]int]uint8
+      GroupType: 204 StructureType noalg.map.group[[4]int]uint8
     - __kind: GoSwissMapHeaderType
-      ID: 108
+      ID: 124
       Name: map<[4]string,[2]int>
       ByteSize: 48
       GoKind: 25
       RawFields:
         - Name: used
           Offset: 0
-          Type: 26 BaseType uint64
+          Type: 8 BaseType uint64
         - Name: seed
           Offset: 8
-          Type: 62 BaseType uintptr
+          Type: 1 BaseType uintptr
         - Name: dirPtr
           Offset: 16
-          Type: 109 PointerType **table<[4]string,[2]int>
+          Type: 125 PointerType **table<[4]string,[2]int>
         - Name: dirLen
           Offset: 24
-          Type: 1 BaseType int
+          Type: 7 BaseType int
         - Name: globalDepth
           Offset: 32
-          Type: 4 BaseType uint8
+          Type: 3 BaseType uint8
         - Name: globalShift
           Offset: 33
-          Type: 4 BaseType uint8
+          Type: 3 BaseType uint8
         - Name: writing
           Offset: 34
-          Type: 4 BaseType uint8
+          Type: 3 BaseType uint8
         - Name: tombstonePossible
           Offset: 35
-          Type: 11 BaseType bool
+          Type: 4 BaseType bool
         - Name: clearSeq
           Offset: 40
-          Type: 26 BaseType uint64
+          Type: 8 BaseType uint64
       TablePtrSliceType: 252 GoSliceDataType []*table<[4]string,[2]int>.array
-      GroupType: 114 StructureType noalg.map.group[[4]string][2]int
+      GroupType: 130 StructureType noalg.map.group[[4]string][2]int
     - __kind: GoSwissMapHeaderType
-      ID: 135
+      ID: 151
       Name: map<bool,main.node>
       ByteSize: 48
       GoKind: 25
       RawFields:
         - Name: used
           Offset: 0
-          Type: 26 BaseType uint64
+          Type: 8 BaseType uint64
         - Name: seed
           Offset: 8
-          Type: 62 BaseType uintptr
+          Type: 1 BaseType uintptr
         - Name: dirPtr
           Offset: 16
-          Type: 136 PointerType **table<bool,main.node>
+          Type: 152 PointerType **table<bool,main.node>
         - Name: dirLen
           Offset: 24
-          Type: 1 BaseType int
+          Type: 7 BaseType int
         - Name: globalDepth
           Offset: 32
-          Type: 4 BaseType uint8
+          Type: 3 BaseType uint8
         - Name: globalShift
           Offset: 33
-          Type: 4 BaseType uint8
+          Type: 3 BaseType uint8
         - Name: writing
           Offset: 34
-          Type: 4 BaseType uint8
+          Type: 3 BaseType uint8
         - Name: tombstonePossible
           Offset: 35
-          Type: 11 BaseType bool
+          Type: 4 BaseType bool
         - Name: clearSeq
           Offset: 40
-          Type: 26 BaseType uint64
+          Type: 8 BaseType uint64
       TablePtrSliceType: 258 GoSliceDataType []*table<bool,main.node>.array
-      GroupType: 141 StructureType noalg.map.group[bool]main.node
+      GroupType: 157 StructureType noalg.map.group[bool]main.node
     - __kind: GoSwissMapHeaderType
-      ID: 61
+      ID: 78
       Name: map<int,int>
       ByteSize: 48
       GoKind: 25
       RawFields:
         - Name: used
           Offset: 0
-          Type: 26 BaseType uint64
+          Type: 8 BaseType uint64
         - Name: seed
           Offset: 8
-          Type: 62 BaseType uintptr
+          Type: 1 BaseType uintptr
         - Name: dirPtr
           Offset: 16
-          Type: 63 PointerType **table<int,int>
+          Type: 79 PointerType **table<int,int>
         - Name: dirLen
           Offset: 24
-          Type: 1 BaseType int
+          Type: 7 BaseType int
         - Name: globalDepth
           Offset: 32
-          Type: 4 BaseType uint8
+          Type: 3 BaseType uint8
         - Name: globalShift
           Offset: 33
-          Type: 4 BaseType uint8
+          Type: 3 BaseType uint8
         - Name: writing
           Offset: 34
-          Type: 4 BaseType uint8
+          Type: 3 BaseType uint8
         - Name: tombstonePossible
           Offset: 35
-          Type: 11 BaseType bool
+          Type: 4 BaseType bool
         - Name: clearSeq
           Offset: 40
-          Type: 26 BaseType uint64
+          Type: 8 BaseType uint64
       TablePtrSliceType: 242 GoSliceDataType []*table<int,int>.array
-      GroupType: 68 StructureType noalg.map.group[int]int
+      GroupType: 84 StructureType noalg.map.group[int]int
     - __kind: GoSwissMapHeaderType
-      ID: 148
+      ID: 164
       Name: map<int,uint8>
       ByteSize: 48
       GoKind: 25
       RawFields:
         - Name: used
           Offset: 0
-          Type: 26 BaseType uint64
+          Type: 8 BaseType uint64
         - Name: seed
           Offset: 8
-          Type: 62 BaseType uintptr
+          Type: 1 BaseType uintptr
         - Name: dirPtr
           Offset: 16
-          Type: 149 PointerType **table<int,uint8>
+          Type: 165 PointerType **table<int,uint8>
         - Name: dirLen
           Offset: 24
-          Type: 1 BaseType int
+          Type: 7 BaseType int
         - Name: globalDepth
           Offset: 32
-          Type: 4 BaseType uint8
+          Type: 3 BaseType uint8
         - Name: globalShift
           Offset: 33
-          Type: 4 BaseType uint8
+          Type: 3 BaseType uint8
         - Name: writing
           Offset: 34
-          Type: 4 BaseType uint8
+          Type: 3 BaseType uint8
         - Name: tombstonePossible
           Offset: 35
-          Type: 11 BaseType bool
+          Type: 4 BaseType bool
         - Name: clearSeq
           Offset: 40
-          Type: 26 BaseType uint64
+          Type: 8 BaseType uint64
       TablePtrSliceType: 260 GoSliceDataType []*table<int,uint8>.array
-      GroupType: 154 StructureType noalg.map.group[int]uint8
+      GroupType: 170 StructureType noalg.map.group[int]uint8
     - __kind: GoSwissMapHeaderType
-      ID: 122
+      ID: 138
       Name: map<string,[]main.structWithMap>
       ByteSize: 48
       GoKind: 25
       RawFields:
         - Name: used
           Offset: 0
-          Type: 26 BaseType uint64
+          Type: 8 BaseType uint64
         - Name: seed
           Offset: 8
-          Type: 62 BaseType uintptr
+          Type: 1 BaseType uintptr
         - Name: dirPtr
           Offset: 16
-          Type: 123 PointerType **table<string,[]main.structWithMap>
+          Type: 139 PointerType **table<string,[]main.structWithMap>
         - Name: dirLen
           Offset: 24
-          Type: 1 BaseType int
+          Type: 7 BaseType int
         - Name: globalDepth
           Offset: 32
-          Type: 4 BaseType uint8
+          Type: 3 BaseType uint8
         - Name: globalShift
           Offset: 33
-          Type: 4 BaseType uint8
+          Type: 3 BaseType uint8
         - Name: writing
           Offset: 34
-          Type: 4 BaseType uint8
+          Type: 3 BaseType uint8
         - Name: tombstonePossible
           Offset: 35
-          Type: 11 BaseType bool
+          Type: 4 BaseType bool
         - Name: clearSeq
           Offset: 40
-          Type: 26 BaseType uint64
+          Type: 8 BaseType uint64
       TablePtrSliceType: 254 GoSliceDataType []*table<string,[]main.structWithMap>.array
-      GroupType: 128 StructureType noalg.map.group[string][]main.structWithMap
+      GroupType: 144 StructureType noalg.map.group[string][]main.structWithMap
     - __kind: GoSwissMapHeaderType
-      ID: 96
+      ID: 112
       Name: map<string,[]string>
       ByteSize: 48
       GoKind: 25
       RawFields:
         - Name: used
           Offset: 0
-          Type: 26 BaseType uint64
+          Type: 8 BaseType uint64
         - Name: seed
           Offset: 8
-          Type: 62 BaseType uintptr
+          Type: 1 BaseType uintptr
         - Name: dirPtr
           Offset: 16
-          Type: 97 PointerType **table<string,[]string>
+          Type: 113 PointerType **table<string,[]string>
         - Name: dirLen
           Offset: 24
-          Type: 1 BaseType int
+          Type: 7 BaseType int
         - Name: globalDepth
           Offset: 32
-          Type: 4 BaseType uint8
+          Type: 3 BaseType uint8
         - Name: globalShift
           Offset: 33
-          Type: 4 BaseType uint8
+          Type: 3 BaseType uint8
         - Name: writing
           Offset: 34
-          Type: 4 BaseType uint8
+          Type: 3 BaseType uint8
         - Name: tombstonePossible
           Offset: 35
-          Type: 11 BaseType bool
+          Type: 4 BaseType bool
         - Name: clearSeq
           Offset: 40
-          Type: 26 BaseType uint64
+          Type: 8 BaseType uint64
       TablePtrSliceType: 248 GoSliceDataType []*table<string,[]string>.array
-      GroupType: 102 StructureType noalg.map.group[string][]string
+      GroupType: 118 StructureType noalg.map.group[string][]string
     - __kind: GoSwissMapHeaderType
-      ID: 85
+      ID: 101
       Name: map<string,int>
       ByteSize: 48
       GoKind: 25
       RawFields:
         - Name: used
           Offset: 0
-          Type: 26 BaseType uint64
+          Type: 8 BaseType uint64
         - Name: seed
           Offset: 8
-          Type: 62 BaseType uintptr
+          Type: 1 BaseType uintptr
         - Name: dirPtr
           Offset: 16
-          Type: 86 PointerType **table<string,int>
+          Type: 102 PointerType **table<string,int>
         - Name: dirLen
           Offset: 24
-          Type: 1 BaseType int
+          Type: 7 BaseType int
         - Name: globalDepth
           Offset: 32
-          Type: 4 BaseType uint8
+          Type: 3 BaseType uint8
         - Name: globalShift
           Offset: 33
-          Type: 4 BaseType uint8
+          Type: 3 BaseType uint8
         - Name: writing
           Offset: 34
-          Type: 4 BaseType uint8
+          Type: 3 BaseType uint8
         - Name: tombstonePossible
           Offset: 35
-          Type: 11 BaseType bool
+          Type: 4 BaseType bool
         - Name: clearSeq
           Offset: 40
-          Type: 26 BaseType uint64
+          Type: 8 BaseType uint64
       TablePtrSliceType: 246 GoSliceDataType []*table<string,int>.array
-      GroupType: 91 StructureType noalg.map.group[string]int
+      GroupType: 107 StructureType noalg.map.group[string]int
     - __kind: GoSwissMapHeaderType
-      ID: 73
+      ID: 89
       Name: map<string,main.nestedStruct>
       ByteSize: 48
       GoKind: 25
       RawFields:
         - Name: used
           Offset: 0
-          Type: 26 BaseType uint64
+          Type: 8 BaseType uint64
         - Name: seed
           Offset: 8
-          Type: 62 BaseType uintptr
+          Type: 1 BaseType uintptr
         - Name: dirPtr
           Offset: 16
-          Type: 74 PointerType **table<string,main.nestedStruct>
+          Type: 90 PointerType **table<string,main.nestedStruct>
         - Name: dirLen
           Offset: 24
-          Type: 1 BaseType int
+          Type: 7 BaseType int
         - Name: globalDepth
           Offset: 32
-          Type: 4 BaseType uint8
+          Type: 3 BaseType uint8
         - Name: globalShift
           Offset: 33
-          Type: 4 BaseType uint8
+          Type: 3 BaseType uint8
         - Name: writing
           Offset: 34
-          Type: 4 BaseType uint8
+          Type: 3 BaseType uint8
         - Name: tombstonePossible
           Offset: 35
-          Type: 11 BaseType bool
+          Type: 4 BaseType bool
         - Name: clearSeq
           Offset: 40
-          Type: 26 BaseType uint64
+          Type: 8 BaseType uint64
       TablePtrSliceType: 244 GoSliceDataType []*table<string,main.nestedStruct>.array
-      GroupType: 79 StructureType noalg.map.group[string]main.nestedStruct
+      GroupType: 95 StructureType noalg.map.group[string]main.nestedStruct
     - __kind: GoSwissMapHeaderType
-      ID: 170
+      ID: 186
       Name: map<uint8,[4]int>
       ByteSize: 48
       GoKind: 25
       RawFields:
         - Name: used
           Offset: 0
-          Type: 26 BaseType uint64
+          Type: 8 BaseType uint64
         - Name: seed
           Offset: 8
-          Type: 62 BaseType uintptr
+          Type: 1 BaseType uintptr
         - Name: dirPtr
           Offset: 16
-          Type: 171 PointerType **table<uint8,[4]int>
+          Type: 187 PointerType **table<uint8,[4]int>
         - Name: dirLen
           Offset: 24
-          Type: 1 BaseType int
+          Type: 7 BaseType int
         - Name: globalDepth
           Offset: 32
-          Type: 4 BaseType uint8
+          Type: 3 BaseType uint8
         - Name: globalShift
           Offset: 33
-          Type: 4 BaseType uint8
+          Type: 3 BaseType uint8
         - Name: writing
           Offset: 34
-          Type: 4 BaseType uint8
+          Type: 3 BaseType uint8
         - Name: tombstonePossible
           Offset: 35
-          Type: 11 BaseType bool
+          Type: 4 BaseType bool
         - Name: clearSeq
           Offset: 40
-          Type: 26 BaseType uint64
+          Type: 8 BaseType uint64
       TablePtrSliceType: 264 GoSliceDataType []*table<uint8,[4]int>.array
-      GroupType: 176 StructureType noalg.map.group[uint8][4]int
+      GroupType: 192 StructureType noalg.map.group[uint8][4]int
     - __kind: GoSwissMapHeaderType
-      ID: 159
+      ID: 175
       Name: map<uint8,uint8>
       ByteSize: 48
       GoKind: 25
       RawFields:
         - Name: used
           Offset: 0
-          Type: 26 BaseType uint64
+          Type: 8 BaseType uint64
         - Name: seed
           Offset: 8
-          Type: 62 BaseType uintptr
+          Type: 1 BaseType uintptr
         - Name: dirPtr
           Offset: 16
-          Type: 160 PointerType **table<uint8,uint8>
+          Type: 176 PointerType **table<uint8,uint8>
         - Name: dirLen
           Offset: 24
-          Type: 1 BaseType int
+          Type: 7 BaseType int
         - Name: globalDepth
           Offset: 32
-          Type: 4 BaseType uint8
+          Type: 3 BaseType uint8
         - Name: globalShift
           Offset: 33
-          Type: 4 BaseType uint8
+          Type: 3 BaseType uint8
         - Name: writing
           Offset: 34
-          Type: 4 BaseType uint8
+          Type: 3 BaseType uint8
         - Name: tombstonePossible
           Offset: 35
-          Type: 11 BaseType bool
+          Type: 4 BaseType bool
         - Name: clearSeq
           Offset: 40
-          Type: 26 BaseType uint64
+          Type: 8 BaseType uint64
       TablePtrSliceType: 262 GoSliceDataType []*table<uint8,uint8>.array
-      GroupType: 165 StructureType noalg.map.group[uint8]uint8
+      GroupType: 181 StructureType noalg.map.group[uint8]uint8
     - __kind: GoMapType
-      ID: 191
+      ID: 207
       Name: map[[4]int][4]int
       ByteSize: 8
       GoRuntimeType: 1.1224e+06
       GoKind: 21
-      HeaderType: 193 GoSwissMapHeaderType map<[4]int,[4]int>
+      HeaderType: 209 GoSwissMapHeaderType map<[4]int,[4]int>
     - __kind: GoMapType
-      ID: 180
+      ID: 196
       Name: map[[4]int]uint8
       ByteSize: 8
       GoRuntimeType: 1.122528e+06
       GoKind: 21
-      HeaderType: 182 GoSwissMapHeaderType map<[4]int,uint8>
+      HeaderType: 198 GoSwissMapHeaderType map<[4]int,uint8>
     - __kind: GoMapType
-      ID: 106
+      ID: 122
       Name: map[[4]string][2]int
       ByteSize: 8
       GoRuntimeType: 1.122656e+06
       GoKind: 21
-      HeaderType: 108 GoSwissMapHeaderType map<[4]string,[2]int>
+      HeaderType: 124 GoSwissMapHeaderType map<[4]string,[2]int>
     - __kind: GoMapType
-      ID: 133
+      ID: 149
       Name: map[bool]main.node
       ByteSize: 8
       GoRuntimeType: 1.122784e+06
       GoKind: 21
-      HeaderType: 135 GoSwissMapHeaderType map<bool,main.node>
+      HeaderType: 151 GoSwissMapHeaderType map<bool,main.node>
     - __kind: GoMapType
-      ID: 59
+      ID: 76
       Name: map[int]int
       ByteSize: 8
       GoRuntimeType: 1.122016e+06
       GoKind: 21
-      HeaderType: 61 GoSwissMapHeaderType map<int,int>
+      HeaderType: 78 GoSwissMapHeaderType map<int,int>
     - __kind: GoMapType
-      ID: 146
+      ID: 162
       Name: map[int]uint8
       ByteSize: 8
       GoRuntimeType: 1.122912e+06
       GoKind: 21
-      HeaderType: 148 GoSwissMapHeaderType map<int,uint8>
+      HeaderType: 164 GoSwissMapHeaderType map<int,uint8>
     - __kind: GoMapType
-      ID: 120
+      ID: 136
       Name: map[string][]main.structWithMap
       ByteSize: 8
       GoRuntimeType: 1.12304e+06
       GoKind: 21
-      HeaderType: 122 GoSwissMapHeaderType map<string,[]main.structWithMap>
+      HeaderType: 138 GoSwissMapHeaderType map<string,[]main.structWithMap>
     - __kind: GoMapType
-      ID: 94
+      ID: 110
       Name: map[string][]string
       ByteSize: 8
       GoRuntimeType: 1.123168e+06
       GoKind: 21
-      HeaderType: 96 GoSwissMapHeaderType map<string,[]string>
+      HeaderType: 112 GoSwissMapHeaderType map<string,[]string>
     - __kind: GoMapType
-      ID: 83
+      ID: 99
       Name: map[string]int
       ByteSize: 8
       GoRuntimeType: 1.123296e+06
       GoKind: 21
-      HeaderType: 85 GoSwissMapHeaderType map<string,int>
+      HeaderType: 101 GoSwissMapHeaderType map<string,int>
     - __kind: GoMapType
-      ID: 71
+      ID: 87
       Name: map[string]main.nestedStruct
       ByteSize: 8
       GoRuntimeType: 1.123424e+06
       GoKind: 21
-      HeaderType: 73 GoSwissMapHeaderType map<string,main.nestedStruct>
+      HeaderType: 89 GoSwissMapHeaderType map<string,main.nestedStruct>
     - __kind: GoMapType
-      ID: 168
+      ID: 184
       Name: map[uint8][4]int
       ByteSize: 8
       GoRuntimeType: 1.123552e+06
       GoKind: 21
-      HeaderType: 170 GoSwissMapHeaderType map<uint8,[4]int>
+      HeaderType: 186 GoSwissMapHeaderType map<uint8,[4]int>
     - __kind: GoMapType
-      ID: 157
+      ID: 173
       Name: map[uint8]uint8
       ByteSize: 8
       GoRuntimeType: 1.12368e+06
       GoKind: 21
-      HeaderType: 159 GoSwissMapHeaderType map<uint8,uint8>
+      HeaderType: 175 GoSwissMapHeaderType map<uint8,uint8>
     - __kind: ArrayType
-      ID: 200
+      ID: 216
       Name: noalg.[8]struct { key [4]int; elem [4]int }
       ByteSize: 512
       GoRuntimeType: 676736
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 201 StructureType noalg.struct { key [4]int; elem [4]int }
+      Element: 217 StructureType noalg.struct { key [4]int; elem [4]int }
     - __kind: ArrayType
-      ID: 189
+      ID: 205
       Name: noalg.[8]struct { key [4]int; elem uint8 }
       ByteSize: 320
       GoRuntimeType: 676832
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 190 StructureType noalg.struct { key [4]int; elem uint8 }
+      Element: 206 StructureType noalg.struct { key [4]int; elem uint8 }
     - __kind: ArrayType
-      ID: 115
+      ID: 131
       Name: noalg.[8]struct { key [4]string; elem [2]int }
       ByteSize: 640
       GoRuntimeType: 677120
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 116 StructureType noalg.struct { key [4]string; elem [2]int }
+      Element: 132 StructureType noalg.struct { key [4]string; elem [2]int }
     - __kind: ArrayType
-      ID: 142
+      ID: 158
       Name: noalg.[8]struct { key bool; elem main.node }
       ByteSize: 192
       GoRuntimeType: 677216
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 143 StructureType noalg.struct { key bool; elem main.node }
+      Element: 159 StructureType noalg.struct { key bool; elem main.node }
     - __kind: ArrayType
-      ID: 69
+      ID: 85
       Name: noalg.[8]struct { key int; elem int }
       ByteSize: 128
       GoRuntimeType: 675008
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 70 StructureType noalg.struct { key int; elem int }
+      Element: 86 StructureType noalg.struct { key int; elem int }
     - __kind: ArrayType
-      ID: 155
+      ID: 171
       Name: noalg.[8]struct { key int; elem uint8 }
       ByteSize: 128
       GoRuntimeType: 677312
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 156 StructureType noalg.struct { key int; elem uint8 }
+      Element: 172 StructureType noalg.struct { key int; elem uint8 }
     - __kind: ArrayType
-      ID: 129
+      ID: 145
       Name: noalg.[8]struct { key string; elem []main.structWithMap }
       ByteSize: 320
       GoRuntimeType: 677408
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 130 StructureType noalg.struct { key string; elem []main.structWithMap }
+      Element: 146 StructureType noalg.struct { key string; elem []main.structWithMap }
     - __kind: ArrayType
-      ID: 103
+      ID: 119
       Name: noalg.[8]struct { key string; elem []string }
       ByteSize: 320
       GoRuntimeType: 677504
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 104 StructureType noalg.struct { key string; elem []string }
+      Element: 120 StructureType noalg.struct { key string; elem []string }
     - __kind: ArrayType
-      ID: 92
+      ID: 108
       Name: noalg.[8]struct { key string; elem int }
       ByteSize: 192
       GoRuntimeType: 677600
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 93 StructureType noalg.struct { key string; elem int }
+      Element: 109 StructureType noalg.struct { key string; elem int }
     - __kind: ArrayType
-      ID: 80
+      ID: 96
       Name: noalg.[8]struct { key string; elem main.nestedStruct }
       ByteSize: 320
       GoRuntimeType: 677696
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 81 StructureType noalg.struct { key string; elem main.nestedStruct }
+      Element: 97 StructureType noalg.struct { key string; elem main.nestedStruct }
     - __kind: ArrayType
-      ID: 177
+      ID: 193
       Name: noalg.[8]struct { key uint8; elem [4]int }
       ByteSize: 320
       GoRuntimeType: 677792
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 178 StructureType noalg.struct { key uint8; elem [4]int }
+      Element: 194 StructureType noalg.struct { key uint8; elem [4]int }
     - __kind: ArrayType
-      ID: 166
+      ID: 182
       Name: noalg.[8]struct { key uint8; elem uint8 }
       ByteSize: 16
       GoRuntimeType: 677888
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 167 StructureType noalg.struct { key uint8; elem uint8 }
+      Element: 183 StructureType noalg.struct { key uint8; elem uint8 }
     - __kind: StructureType
-      ID: 199
+      ID: 215
       Name: noalg.map.group[[4]int][4]int
       ByteSize: 520
       GoRuntimeType: 1.28176e+06
@@ -6798,12 +6798,12 @@ Types:
       RawFields:
         - Name: ctrl
           Offset: 0
-          Type: 26 BaseType uint64
+          Type: 8 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 200 ArrayType noalg.[8]struct { key [4]int; elem [4]int }
+          Type: 216 ArrayType noalg.[8]struct { key [4]int; elem [4]int }
     - __kind: StructureType
-      ID: 188
+      ID: 204
       Name: noalg.map.group[[4]int]uint8
       ByteSize: 328
       GoRuntimeType: 1.282016e+06
@@ -6811,12 +6811,12 @@ Types:
       RawFields:
         - Name: ctrl
           Offset: 0
-          Type: 26 BaseType uint64
+          Type: 8 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 189 ArrayType noalg.[8]struct { key [4]int; elem uint8 }
+          Type: 205 ArrayType noalg.[8]struct { key [4]int; elem uint8 }
     - __kind: StructureType
-      ID: 114
+      ID: 130
       Name: noalg.map.group[[4]string][2]int
       ByteSize: 648
       GoRuntimeType: 1.282272e+06
@@ -6824,12 +6824,12 @@ Types:
       RawFields:
         - Name: ctrl
           Offset: 0
-          Type: 26 BaseType uint64
+          Type: 8 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 115 ArrayType noalg.[8]struct { key [4]string; elem [2]int }
+          Type: 131 ArrayType noalg.[8]struct { key [4]string; elem [2]int }
     - __kind: StructureType
-      ID: 141
+      ID: 157
       Name: noalg.map.group[bool]main.node
       ByteSize: 200
       GoRuntimeType: 1.282528e+06
@@ -6837,12 +6837,12 @@ Types:
       RawFields:
         - Name: ctrl
           Offset: 0
-          Type: 26 BaseType uint64
+          Type: 8 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 142 ArrayType noalg.[8]struct { key bool; elem main.node }
+          Type: 158 ArrayType noalg.[8]struct { key bool; elem main.node }
     - __kind: StructureType
-      ID: 68
+      ID: 84
       Name: noalg.map.group[int]int
       ByteSize: 136
       GoRuntimeType: 1.280992e+06
@@ -6850,12 +6850,12 @@ Types:
       RawFields:
         - Name: ctrl
           Offset: 0
-          Type: 26 BaseType uint64
+          Type: 8 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 69 ArrayType noalg.[8]struct { key int; elem int }
+          Type: 85 ArrayType noalg.[8]struct { key int; elem int }
     - __kind: StructureType
-      ID: 154
+      ID: 170
       Name: noalg.map.group[int]uint8
       ByteSize: 136
       GoRuntimeType: 1.282784e+06
@@ -6863,12 +6863,12 @@ Types:
       RawFields:
         - Name: ctrl
           Offset: 0
-          Type: 26 BaseType uint64
+          Type: 8 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 155 ArrayType noalg.[8]struct { key int; elem uint8 }
+          Type: 171 ArrayType noalg.[8]struct { key int; elem uint8 }
     - __kind: StructureType
-      ID: 128
+      ID: 144
       Name: noalg.map.group[string][]main.structWithMap
       ByteSize: 328
       GoRuntimeType: 1.28304e+06
@@ -6876,12 +6876,12 @@ Types:
       RawFields:
         - Name: ctrl
           Offset: 0
-          Type: 26 BaseType uint64
+          Type: 8 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 129 ArrayType noalg.[8]struct { key string; elem []main.structWithMap }
+          Type: 145 ArrayType noalg.[8]struct { key string; elem []main.structWithMap }
     - __kind: StructureType
-      ID: 102
+      ID: 118
       Name: noalg.map.group[string][]string
       ByteSize: 328
       GoRuntimeType: 1.283296e+06
@@ -6889,12 +6889,12 @@ Types:
       RawFields:
         - Name: ctrl
           Offset: 0
-          Type: 26 BaseType uint64
+          Type: 8 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 103 ArrayType noalg.[8]struct { key string; elem []string }
+          Type: 119 ArrayType noalg.[8]struct { key string; elem []string }
     - __kind: StructureType
-      ID: 91
+      ID: 107
       Name: noalg.map.group[string]int
       ByteSize: 200
       GoRuntimeType: 1.283552e+06
@@ -6902,12 +6902,12 @@ Types:
       RawFields:
         - Name: ctrl
           Offset: 0
-          Type: 26 BaseType uint64
+          Type: 8 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 92 ArrayType noalg.[8]struct { key string; elem int }
+          Type: 108 ArrayType noalg.[8]struct { key string; elem int }
     - __kind: StructureType
-      ID: 79
+      ID: 95
       Name: noalg.map.group[string]main.nestedStruct
       ByteSize: 328
       GoRuntimeType: 1.283808e+06
@@ -6915,12 +6915,12 @@ Types:
       RawFields:
         - Name: ctrl
           Offset: 0
-          Type: 26 BaseType uint64
+          Type: 8 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 80 ArrayType noalg.[8]struct { key string; elem main.nestedStruct }
+          Type: 96 ArrayType noalg.[8]struct { key string; elem main.nestedStruct }
     - __kind: StructureType
-      ID: 176
+      ID: 192
       Name: noalg.map.group[uint8][4]int
       ByteSize: 328
       GoRuntimeType: 1.284064e+06
@@ -6928,12 +6928,12 @@ Types:
       RawFields:
         - Name: ctrl
           Offset: 0
-          Type: 26 BaseType uint64
+          Type: 8 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 177 ArrayType noalg.[8]struct { key uint8; elem [4]int }
+          Type: 193 ArrayType noalg.[8]struct { key uint8; elem [4]int }
     - __kind: StructureType
-      ID: 165
+      ID: 181
       Name: noalg.map.group[uint8]uint8
       ByteSize: 24
       GoRuntimeType: 1.28432e+06
@@ -6941,12 +6941,12 @@ Types:
       RawFields:
         - Name: ctrl
           Offset: 0
-          Type: 26 BaseType uint64
+          Type: 8 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 166 ArrayType noalg.[8]struct { key uint8; elem uint8 }
+          Type: 182 ArrayType noalg.[8]struct { key uint8; elem uint8 }
     - __kind: StructureType
-      ID: 201
+      ID: 217
       Name: noalg.struct { key [4]int; elem [4]int }
       ByteSize: 64
       GoRuntimeType: 1.281632e+06
@@ -6954,12 +6954,12 @@ Types:
       RawFields:
         - Name: key
           Offset: 0
-          Type: 179 ArrayType [4]int
+          Type: 195 ArrayType [4]int
         - Name: elem
           Offset: 32
-          Type: 179 ArrayType [4]int
+          Type: 195 ArrayType [4]int
     - __kind: StructureType
-      ID: 190
+      ID: 206
       Name: noalg.struct { key [4]int; elem uint8 }
       ByteSize: 40
       GoRuntimeType: 1.281888e+06
@@ -6967,12 +6967,12 @@ Types:
       RawFields:
         - Name: key
           Offset: 0
-          Type: 179 ArrayType [4]int
+          Type: 195 ArrayType [4]int
         - Name: elem
           Offset: 32
-          Type: 4 BaseType uint8
+          Type: 3 BaseType uint8
     - __kind: StructureType
-      ID: 116
+      ID: 132
       Name: noalg.struct { key [4]string; elem [2]int }
       ByteSize: 80
       GoRuntimeType: 1.282144e+06
@@ -6980,12 +6980,12 @@ Types:
       RawFields:
         - Name: key
           Offset: 0
-          Type: 117 ArrayType [4]string
+          Type: 133 ArrayType [4]string
         - Name: elem
           Offset: 64
-          Type: 12 ArrayType [2]int
+          Type: 40 ArrayType [2]int
     - __kind: StructureType
-      ID: 143
+      ID: 159
       Name: noalg.struct { key bool; elem main.node }
       ByteSize: 24
       GoRuntimeType: 1.2824e+06
@@ -6993,12 +6993,12 @@ Types:
       RawFields:
         - Name: key
           Offset: 0
-          Type: 11 BaseType bool
+          Type: 4 BaseType bool
         - Name: elem
           Offset: 8
-          Type: 144 StructureType main.node
+          Type: 160 StructureType main.node
     - __kind: StructureType
-      ID: 70
+      ID: 86
       Name: noalg.struct { key int; elem int }
       ByteSize: 16
       GoRuntimeType: 1.280864e+06
@@ -7006,12 +7006,12 @@ Types:
       RawFields:
         - Name: key
           Offset: 0
-          Type: 1 BaseType int
+          Type: 7 BaseType int
         - Name: elem
           Offset: 8
-          Type: 1 BaseType int
+          Type: 7 BaseType int
     - __kind: StructureType
-      ID: 156
+      ID: 172
       Name: noalg.struct { key int; elem uint8 }
       ByteSize: 16
       GoRuntimeType: 1.282656e+06
@@ -7019,12 +7019,12 @@ Types:
       RawFields:
         - Name: key
           Offset: 0
-          Type: 1 BaseType int
+          Type: 7 BaseType int
         - Name: elem
           Offset: 8
-          Type: 4 BaseType uint8
+          Type: 3 BaseType uint8
     - __kind: StructureType
-      ID: 130
+      ID: 146
       Name: noalg.struct { key string; elem []main.structWithMap }
       ByteSize: 40
       GoRuntimeType: 1.282912e+06
@@ -7032,12 +7032,12 @@ Types:
       RawFields:
         - Name: key
           Offset: 0
-          Type: 8 GoStringHeaderType string
+          Type: 9 GoStringHeaderType string
         - Name: elem
           Offset: 16
-          Type: 131 GoSliceHeaderType []main.structWithMap
+          Type: 147 GoSliceHeaderType []main.structWithMap
     - __kind: StructureType
-      ID: 104
+      ID: 120
       Name: noalg.struct { key string; elem []string }
       ByteSize: 40
       GoRuntimeType: 1.283168e+06
@@ -7045,12 +7045,12 @@ Types:
       RawFields:
         - Name: key
           Offset: 0
-          Type: 8 GoStringHeaderType string
+          Type: 9 GoStringHeaderType string
         - Name: elem
           Offset: 16
-          Type: 105 GoSliceHeaderType []string
+          Type: 121 GoSliceHeaderType []string
     - __kind: StructureType
-      ID: 93
+      ID: 109
       Name: noalg.struct { key string; elem int }
       ByteSize: 24
       GoRuntimeType: 1.283424e+06
@@ -7058,12 +7058,12 @@ Types:
       RawFields:
         - Name: key
           Offset: 0
-          Type: 8 GoStringHeaderType string
+          Type: 9 GoStringHeaderType string
         - Name: elem
           Offset: 16
-          Type: 1 BaseType int
+          Type: 7 BaseType int
     - __kind: StructureType
-      ID: 81
+      ID: 97
       Name: noalg.struct { key string; elem main.nestedStruct }
       ByteSize: 40
       GoRuntimeType: 1.28368e+06
@@ -7071,12 +7071,12 @@ Types:
       RawFields:
         - Name: key
           Offset: 0
-          Type: 8 GoStringHeaderType string
+          Type: 9 GoStringHeaderType string
         - Name: elem
           Offset: 16
-          Type: 82 StructureType main.nestedStruct
+          Type: 98 StructureType main.nestedStruct
     - __kind: StructureType
-      ID: 178
+      ID: 194
       Name: noalg.struct { key uint8; elem [4]int }
       ByteSize: 40
       GoRuntimeType: 1.283936e+06
@@ -7084,12 +7084,12 @@ Types:
       RawFields:
         - Name: key
           Offset: 0
-          Type: 4 BaseType uint8
+          Type: 3 BaseType uint8
         - Name: elem
           Offset: 8
-          Type: 179 ArrayType [4]int
+          Type: 195 ArrayType [4]int
     - __kind: StructureType
-      ID: 167
+      ID: 183
       Name: noalg.struct { key uint8; elem uint8 }
       ByteSize: 2
       GoRuntimeType: 1.284192e+06
@@ -7097,12 +7097,12 @@ Types:
       RawFields:
         - Name: key
           Offset: 0
-          Type: 4 BaseType uint8
+          Type: 3 BaseType uint8
         - Name: elem
           Offset: 1
-          Type: 4 BaseType uint8
+          Type: 3 BaseType uint8
     - __kind: GoStringHeaderType
-      ID: 8
+      ID: 9
       Name: string
       ByteSize: 16
       GoRuntimeType: 578784
@@ -7113,14 +7113,14 @@ Types:
           Type: 239 PointerType *string.str
         - Name: len
           Offset: 8
-          Type: 1 BaseType int
+          Type: 7 BaseType int
       Data: 238 GoStringDataType string.str
     - __kind: GoStringDataType
       ID: 238
       Name: string.str
       ByteSize: 2048
     - __kind: StructureType
-      ID: 46
+      ID: 63
       Name: sync.Mutex
       ByteSize: 8
       GoRuntimeType: 1.44992e+06
@@ -7128,12 +7128,12 @@ Types:
       RawFields:
         - Name: _
           Offset: 0
-          Type: 47 StructureType sync.noCopy
+          Type: 64 StructureType sync.noCopy
         - Name: mu
           Offset: 0
-          Type: 48 StructureType internal/sync.Mutex
+          Type: 65 StructureType internal/sync.Mutex
     - __kind: StructureType
-      ID: 49
+      ID: 66
       Name: sync.Once
       ByteSize: 12
       GoRuntimeType: 1.598816e+06
@@ -7141,15 +7141,15 @@ Types:
       RawFields:
         - Name: _
           Offset: 0
-          Type: 47 StructureType sync.noCopy
+          Type: 64 StructureType sync.noCopy
         - Name: done
           Offset: 0
-          Type: 50 StructureType sync/atomic.Bool
+          Type: 67 StructureType sync/atomic.Bool
         - Name: m
           Offset: 4
-          Type: 46 StructureType sync.Mutex
+          Type: 63 StructureType sync.Mutex
     - __kind: StructureType
-      ID: 52
+      ID: 69
       Name: sync.WaitGroup
       ByteSize: 16
       GoRuntimeType: 1.598624e+06
@@ -7157,21 +7157,21 @@ Types:
       RawFields:
         - Name: noCopy
           Offset: 0
-          Type: 47 StructureType sync.noCopy
+          Type: 64 StructureType sync.noCopy
         - Name: state
           Offset: 0
-          Type: 53 StructureType sync/atomic.Uint64
+          Type: 70 StructureType sync/atomic.Uint64
         - Name: sema
           Offset: 8
-          Type: 24 BaseType uint32
+          Type: 2 BaseType uint32
     - __kind: StructureType
-      ID: 47
+      ID: 64
       Name: sync.noCopy
       GoRuntimeType: 982144
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 50
+      ID: 67
       Name: sync/atomic.Bool
       ByteSize: 4
       GoRuntimeType: 1.45104e+06
@@ -7179,12 +7179,12 @@ Types:
       RawFields:
         - Name: _
           Offset: 0
-          Type: 51 StructureType sync/atomic.noCopy
+          Type: 68 StructureType sync/atomic.noCopy
         - Name: v
           Offset: 0
-          Type: 24 BaseType uint32
+          Type: 2 BaseType uint32
     - __kind: StructureType
-      ID: 55
+      ID: 72
       Name: sync/atomic.Int32
       ByteSize: 4
       GoRuntimeType: 1.4512e+06
@@ -7192,12 +7192,12 @@ Types:
       RawFields:
         - Name: _
           Offset: 0
-          Type: 51 StructureType sync/atomic.noCopy
+          Type: 68 StructureType sync/atomic.noCopy
         - Name: v
           Offset: 0
-          Type: 6 BaseType int32
+          Type: 10 BaseType int32
     - __kind: StructureType
-      ID: 53
+      ID: 70
       Name: sync/atomic.Uint64
       ByteSize: 8
       GoRuntimeType: 1.5992e+06
@@ -7205,351 +7205,351 @@ Types:
       RawFields:
         - Name: _
           Offset: 0
-          Type: 51 StructureType sync/atomic.noCopy
+          Type: 68 StructureType sync/atomic.noCopy
         - Name: _
           Offset: 0
-          Type: 54 StructureType sync/atomic.align64
+          Type: 71 StructureType sync/atomic.align64
         - Name: v
           Offset: 0
-          Type: 26 BaseType uint64
+          Type: 8 BaseType uint64
     - __kind: StructureType
-      ID: 54
+      ID: 71
       Name: sync/atomic.align64
       GoRuntimeType: 982336
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 51
+      ID: 68
       Name: sync/atomic.noCopy
       GoRuntimeType: 982240
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 196
+      ID: 212
       Name: table<[4]int,[4]int>
       ByteSize: 32
       GoKind: 25
       RawFields:
         - Name: used
           Offset: 0
-          Type: 22 BaseType uint16
+          Type: 6 BaseType uint16
         - Name: capacity
           Offset: 2
-          Type: 22 BaseType uint16
+          Type: 6 BaseType uint16
         - Name: growthLeft
           Offset: 4
-          Type: 22 BaseType uint16
+          Type: 6 BaseType uint16
         - Name: localDepth
           Offset: 6
-          Type: 4 BaseType uint8
+          Type: 3 BaseType uint8
         - Name: index
           Offset: 8
-          Type: 1 BaseType int
+          Type: 7 BaseType int
         - Name: groups
           Offset: 16
-          Type: 197 GoSwissMapGroupsType groupReference<[4]int,[4]int>
+          Type: 213 GoSwissMapGroupsType groupReference<[4]int,[4]int>
     - __kind: StructureType
-      ID: 185
+      ID: 201
       Name: table<[4]int,uint8>
       ByteSize: 32
       GoKind: 25
       RawFields:
         - Name: used
           Offset: 0
-          Type: 22 BaseType uint16
+          Type: 6 BaseType uint16
         - Name: capacity
           Offset: 2
-          Type: 22 BaseType uint16
+          Type: 6 BaseType uint16
         - Name: growthLeft
           Offset: 4
-          Type: 22 BaseType uint16
+          Type: 6 BaseType uint16
         - Name: localDepth
           Offset: 6
-          Type: 4 BaseType uint8
+          Type: 3 BaseType uint8
         - Name: index
           Offset: 8
-          Type: 1 BaseType int
+          Type: 7 BaseType int
         - Name: groups
           Offset: 16
-          Type: 186 GoSwissMapGroupsType groupReference<[4]int,uint8>
+          Type: 202 GoSwissMapGroupsType groupReference<[4]int,uint8>
     - __kind: StructureType
-      ID: 111
+      ID: 127
       Name: table<[4]string,[2]int>
       ByteSize: 32
       GoKind: 25
       RawFields:
         - Name: used
           Offset: 0
-          Type: 22 BaseType uint16
+          Type: 6 BaseType uint16
         - Name: capacity
           Offset: 2
-          Type: 22 BaseType uint16
+          Type: 6 BaseType uint16
         - Name: growthLeft
           Offset: 4
-          Type: 22 BaseType uint16
+          Type: 6 BaseType uint16
         - Name: localDepth
           Offset: 6
-          Type: 4 BaseType uint8
+          Type: 3 BaseType uint8
         - Name: index
           Offset: 8
-          Type: 1 BaseType int
+          Type: 7 BaseType int
         - Name: groups
           Offset: 16
-          Type: 112 GoSwissMapGroupsType groupReference<[4]string,[2]int>
+          Type: 128 GoSwissMapGroupsType groupReference<[4]string,[2]int>
     - __kind: StructureType
-      ID: 138
+      ID: 154
       Name: table<bool,main.node>
       ByteSize: 32
       GoKind: 25
       RawFields:
         - Name: used
           Offset: 0
-          Type: 22 BaseType uint16
+          Type: 6 BaseType uint16
         - Name: capacity
           Offset: 2
-          Type: 22 BaseType uint16
+          Type: 6 BaseType uint16
         - Name: growthLeft
           Offset: 4
-          Type: 22 BaseType uint16
+          Type: 6 BaseType uint16
         - Name: localDepth
           Offset: 6
-          Type: 4 BaseType uint8
+          Type: 3 BaseType uint8
         - Name: index
           Offset: 8
-          Type: 1 BaseType int
+          Type: 7 BaseType int
         - Name: groups
           Offset: 16
-          Type: 139 GoSwissMapGroupsType groupReference<bool,main.node>
+          Type: 155 GoSwissMapGroupsType groupReference<bool,main.node>
     - __kind: StructureType
-      ID: 65
+      ID: 81
       Name: table<int,int>
       ByteSize: 32
       GoKind: 25
       RawFields:
         - Name: used
           Offset: 0
-          Type: 22 BaseType uint16
+          Type: 6 BaseType uint16
         - Name: capacity
           Offset: 2
-          Type: 22 BaseType uint16
+          Type: 6 BaseType uint16
         - Name: growthLeft
           Offset: 4
-          Type: 22 BaseType uint16
+          Type: 6 BaseType uint16
         - Name: localDepth
           Offset: 6
-          Type: 4 BaseType uint8
+          Type: 3 BaseType uint8
         - Name: index
           Offset: 8
-          Type: 1 BaseType int
+          Type: 7 BaseType int
         - Name: groups
           Offset: 16
-          Type: 66 GoSwissMapGroupsType groupReference<int,int>
+          Type: 82 GoSwissMapGroupsType groupReference<int,int>
     - __kind: StructureType
-      ID: 151
+      ID: 167
       Name: table<int,uint8>
       ByteSize: 32
       GoKind: 25
       RawFields:
         - Name: used
           Offset: 0
-          Type: 22 BaseType uint16
+          Type: 6 BaseType uint16
         - Name: capacity
           Offset: 2
-          Type: 22 BaseType uint16
+          Type: 6 BaseType uint16
         - Name: growthLeft
           Offset: 4
-          Type: 22 BaseType uint16
+          Type: 6 BaseType uint16
         - Name: localDepth
           Offset: 6
-          Type: 4 BaseType uint8
+          Type: 3 BaseType uint8
         - Name: index
           Offset: 8
-          Type: 1 BaseType int
+          Type: 7 BaseType int
         - Name: groups
           Offset: 16
-          Type: 152 GoSwissMapGroupsType groupReference<int,uint8>
+          Type: 168 GoSwissMapGroupsType groupReference<int,uint8>
     - __kind: StructureType
-      ID: 125
+      ID: 141
       Name: table<string,[]main.structWithMap>
       ByteSize: 32
       GoKind: 25
       RawFields:
         - Name: used
           Offset: 0
-          Type: 22 BaseType uint16
+          Type: 6 BaseType uint16
         - Name: capacity
           Offset: 2
-          Type: 22 BaseType uint16
+          Type: 6 BaseType uint16
         - Name: growthLeft
           Offset: 4
-          Type: 22 BaseType uint16
+          Type: 6 BaseType uint16
         - Name: localDepth
           Offset: 6
-          Type: 4 BaseType uint8
+          Type: 3 BaseType uint8
         - Name: index
           Offset: 8
-          Type: 1 BaseType int
+          Type: 7 BaseType int
         - Name: groups
           Offset: 16
-          Type: 126 GoSwissMapGroupsType groupReference<string,[]main.structWithMap>
+          Type: 142 GoSwissMapGroupsType groupReference<string,[]main.structWithMap>
     - __kind: StructureType
-      ID: 99
+      ID: 115
       Name: table<string,[]string>
       ByteSize: 32
       GoKind: 25
       RawFields:
         - Name: used
           Offset: 0
-          Type: 22 BaseType uint16
+          Type: 6 BaseType uint16
         - Name: capacity
           Offset: 2
-          Type: 22 BaseType uint16
+          Type: 6 BaseType uint16
         - Name: growthLeft
           Offset: 4
-          Type: 22 BaseType uint16
+          Type: 6 BaseType uint16
         - Name: localDepth
           Offset: 6
-          Type: 4 BaseType uint8
+          Type: 3 BaseType uint8
         - Name: index
           Offset: 8
-          Type: 1 BaseType int
+          Type: 7 BaseType int
         - Name: groups
           Offset: 16
-          Type: 100 GoSwissMapGroupsType groupReference<string,[]string>
+          Type: 116 GoSwissMapGroupsType groupReference<string,[]string>
     - __kind: StructureType
-      ID: 88
+      ID: 104
       Name: table<string,int>
       ByteSize: 32
       GoKind: 25
       RawFields:
         - Name: used
           Offset: 0
-          Type: 22 BaseType uint16
+          Type: 6 BaseType uint16
         - Name: capacity
           Offset: 2
-          Type: 22 BaseType uint16
+          Type: 6 BaseType uint16
         - Name: growthLeft
           Offset: 4
-          Type: 22 BaseType uint16
+          Type: 6 BaseType uint16
         - Name: localDepth
           Offset: 6
-          Type: 4 BaseType uint8
+          Type: 3 BaseType uint8
         - Name: index
           Offset: 8
-          Type: 1 BaseType int
+          Type: 7 BaseType int
         - Name: groups
           Offset: 16
-          Type: 89 GoSwissMapGroupsType groupReference<string,int>
+          Type: 105 GoSwissMapGroupsType groupReference<string,int>
     - __kind: StructureType
-      ID: 76
+      ID: 92
       Name: table<string,main.nestedStruct>
       ByteSize: 32
       GoKind: 25
       RawFields:
         - Name: used
           Offset: 0
-          Type: 22 BaseType uint16
+          Type: 6 BaseType uint16
         - Name: capacity
           Offset: 2
-          Type: 22 BaseType uint16
+          Type: 6 BaseType uint16
         - Name: growthLeft
           Offset: 4
-          Type: 22 BaseType uint16
+          Type: 6 BaseType uint16
         - Name: localDepth
           Offset: 6
-          Type: 4 BaseType uint8
+          Type: 3 BaseType uint8
         - Name: index
           Offset: 8
-          Type: 1 BaseType int
+          Type: 7 BaseType int
         - Name: groups
           Offset: 16
-          Type: 77 GoSwissMapGroupsType groupReference<string,main.nestedStruct>
+          Type: 93 GoSwissMapGroupsType groupReference<string,main.nestedStruct>
     - __kind: StructureType
-      ID: 173
+      ID: 189
       Name: table<uint8,[4]int>
       ByteSize: 32
       GoKind: 25
       RawFields:
         - Name: used
           Offset: 0
-          Type: 22 BaseType uint16
+          Type: 6 BaseType uint16
         - Name: capacity
           Offset: 2
-          Type: 22 BaseType uint16
+          Type: 6 BaseType uint16
         - Name: growthLeft
           Offset: 4
-          Type: 22 BaseType uint16
+          Type: 6 BaseType uint16
         - Name: localDepth
           Offset: 6
-          Type: 4 BaseType uint8
+          Type: 3 BaseType uint8
         - Name: index
           Offset: 8
-          Type: 1 BaseType int
+          Type: 7 BaseType int
         - Name: groups
           Offset: 16
-          Type: 174 GoSwissMapGroupsType groupReference<uint8,[4]int>
+          Type: 190 GoSwissMapGroupsType groupReference<uint8,[4]int>
     - __kind: StructureType
-      ID: 162
+      ID: 178
       Name: table<uint8,uint8>
       ByteSize: 32
       GoKind: 25
       RawFields:
         - Name: used
           Offset: 0
-          Type: 22 BaseType uint16
+          Type: 6 BaseType uint16
         - Name: capacity
           Offset: 2
-          Type: 22 BaseType uint16
+          Type: 6 BaseType uint16
         - Name: growthLeft
           Offset: 4
-          Type: 22 BaseType uint16
+          Type: 6 BaseType uint16
         - Name: localDepth
           Offset: 6
-          Type: 4 BaseType uint8
+          Type: 3 BaseType uint8
         - Name: index
           Offset: 8
-          Type: 1 BaseType int
+          Type: 7 BaseType int
         - Name: groups
           Offset: 16
-          Type: 163 GoSwissMapGroupsType groupReference<uint8,uint8>
+          Type: 179 GoSwissMapGroupsType groupReference<uint8,uint8>
     - __kind: BaseType
-      ID: 20
+      ID: 17
       Name: uint
       ByteSize: 8
       GoRuntimeType: 579424
       GoKind: 7
     - __kind: BaseType
-      ID: 22
+      ID: 6
       Name: uint16
       ByteSize: 2
       GoRuntimeType: 579040
       GoKind: 9
     - __kind: BaseType
-      ID: 24
+      ID: 2
       Name: uint32
       ByteSize: 4
       GoRuntimeType: 579168
       GoKind: 10
     - __kind: BaseType
-      ID: 26
+      ID: 8
       Name: uint64
       ByteSize: 8
       GoRuntimeType: 579296
       GoKind: 11
     - __kind: BaseType
-      ID: 4
+      ID: 3
       Name: uint8
       ByteSize: 1
       GoRuntimeType: 578912
       GoKind: 8
     - __kind: BaseType
-      ID: 62
+      ID: 1
       Name: uintptr
       ByteSize: 8
       GoRuntimeType: 579488
       GoKind: 12
     - __kind: VoidPointerType
-      ID: 38
+      ID: 14
       Name: unsafe.Pointer
       ByteSize: 8
       GoRuntimeType: 579872

--- a/pkg/dyninst/irgen/testdata/snapshot/sample.arch=amd64,toolchain=go1.25.0.yaml
+++ b/pkg/dyninst/irgen/testdata/snapshot/sample.arch=amd64,toolchain=go1.25.0.yaml
@@ -3094,275 +3094,11 @@ Subprograms:
           IsParameter: true
           IsReturn: false
 Types:
-    - __kind: BaseType
-      ID: 1
-      Name: int
-      ByteSize: 8
-      GoRuntimeType: 579360
-      GoKind: 2
-    - __kind: ArrayType
-      ID: 2
-      Name: '[5]int'
-      ByteSize: 40
-      GoKind: 17
-      Count: 5
-      HasCount: true
-      Element: 1 BaseType int
-    - __kind: ArrayType
-      ID: 3
-      Name: '[2]uint8'
-      ByteSize: 2
-      GoRuntimeType: 678272
-      GoKind: 17
-      Count: 2
-      HasCount: true
-      Element: 4 BaseType uint8
-    - __kind: BaseType
-      ID: 4
-      Name: uint8
-      ByteSize: 1
-      GoRuntimeType: 578912
-      GoKind: 8
-    - __kind: ArrayType
-      ID: 5
-      Name: '[2]int32'
-      ByteSize: 8
-      GoRuntimeType: 678368
-      GoKind: 17
-      Count: 2
-      HasCount: true
-      Element: 6 BaseType int32
-    - __kind: BaseType
-      ID: 6
-      Name: int32
-      ByteSize: 4
-      GoRuntimeType: 579104
-      GoKind: 5
-    - __kind: ArrayType
-      ID: 7
-      Name: '[2]string'
-      ByteSize: 32
-      GoRuntimeType: 678464
-      GoKind: 17
-      Count: 2
-      HasCount: true
-      Element: 8 GoStringHeaderType string
-    - __kind: GoStringHeaderType
-      ID: 8
-      Name: string
-      ByteSize: 16
-      GoRuntimeType: 578784
-      GoKind: 24
-      RawFields:
-        - Name: str
-          Offset: 0
-          Type: 239 PointerType *string.str
-        - Name: len
-          Offset: 8
-          Type: 1 BaseType int
-      Data: 238 GoStringDataType string.str
     - __kind: PointerType
-      ID: 9
-      Name: '*uint8'
+      ID: 209
+      Name: '**main.t'
       ByteSize: 8
-      GoRuntimeType: 388096
-      GoKind: 22
-      Pointee: 4 BaseType uint8
-    - __kind: ArrayType
-      ID: 10
-      Name: '[2]bool'
-      ByteSize: 2
-      GoKind: 17
-      Count: 2
-      HasCount: true
-      Element: 11 BaseType bool
-    - __kind: BaseType
-      ID: 11
-      Name: bool
-      ByteSize: 1
-      GoRuntimeType: 579808
-      GoKind: 1
-    - __kind: ArrayType
-      ID: 12
-      Name: '[2]int'
-      ByteSize: 16
-      GoRuntimeType: 677024
-      GoKind: 17
-      Count: 2
-      HasCount: true
-      Element: 1 BaseType int
-    - __kind: ArrayType
-      ID: 13
-      Name: '[2]int8'
-      ByteSize: 2
-      GoKind: 17
-      Count: 2
-      HasCount: true
-      Element: 14 BaseType int8
-    - __kind: BaseType
-      ID: 14
-      Name: int8
-      ByteSize: 1
-      GoRuntimeType: 578848
-      GoKind: 3
-    - __kind: ArrayType
-      ID: 15
-      Name: '[2]int16'
-      ByteSize: 4
-      GoKind: 17
-      Count: 2
-      HasCount: true
-      Element: 16 BaseType int16
-    - __kind: BaseType
-      ID: 16
-      Name: int16
-      ByteSize: 2
-      GoRuntimeType: 578976
-      GoKind: 4
-    - __kind: ArrayType
-      ID: 17
-      Name: '[2]int64'
-      ByteSize: 16
-      GoKind: 17
-      Count: 2
-      HasCount: true
-      Element: 18 BaseType int64
-    - __kind: BaseType
-      ID: 18
-      Name: int64
-      ByteSize: 8
-      GoRuntimeType: 579232
-      GoKind: 6
-    - __kind: ArrayType
-      ID: 19
-      Name: '[2]uint'
-      ByteSize: 16
-      GoKind: 17
-      Count: 2
-      HasCount: true
-      Element: 20 BaseType uint
-    - __kind: BaseType
-      ID: 20
-      Name: uint
-      ByteSize: 8
-      GoRuntimeType: 579424
-      GoKind: 7
-    - __kind: ArrayType
-      ID: 21
-      Name: '[2]uint16'
-      ByteSize: 4
-      GoKind: 17
-      Count: 2
-      HasCount: true
-      Element: 22 BaseType uint16
-    - __kind: BaseType
-      ID: 22
-      Name: uint16
-      ByteSize: 2
-      GoRuntimeType: 579040
-      GoKind: 9
-    - __kind: ArrayType
-      ID: 23
-      Name: '[2]uint32'
-      ByteSize: 8
-      GoKind: 17
-      Count: 2
-      HasCount: true
-      Element: 24 BaseType uint32
-    - __kind: BaseType
-      ID: 24
-      Name: uint32
-      ByteSize: 4
-      GoRuntimeType: 579168
-      GoKind: 10
-    - __kind: ArrayType
-      ID: 25
-      Name: '[2]uint64'
-      ByteSize: 16
-      GoRuntimeType: 678560
-      GoKind: 17
-      Count: 2
-      HasCount: true
-      Element: 26 BaseType uint64
-    - __kind: BaseType
-      ID: 26
-      Name: uint64
-      ByteSize: 8
-      GoRuntimeType: 579296
-      GoKind: 11
-    - __kind: ArrayType
-      ID: 27
-      Name: '[2][2]int'
-      ByteSize: 32
-      GoKind: 17
-      Count: 2
-      HasCount: true
-      Element: 12 ArrayType [2]int
-    - __kind: ArrayType
-      ID: 28
-      Name: '[2][2][2]int'
-      ByteSize: 64
-      GoKind: 17
-      Count: 2
-      HasCount: true
-      Element: 27 ArrayType [2][2]int
-    - __kind: ArrayType
-      ID: 29
-      Name: '[100]uint'
-      ByteSize: 800
-      GoKind: 17
-      Count: 100
-      HasCount: true
-      Element: 20 BaseType uint
-    - __kind: BaseType
-      ID: 30
-      Name: float32
-      ByteSize: 4
-      GoRuntimeType: 579680
-      GoKind: 13
-    - __kind: BaseType
-      ID: 31
-      Name: float64
-      ByteSize: 8
-      GoRuntimeType: 579744
-      GoKind: 14
-    - __kind: BaseType
-      ID: 32
-      Name: main.typeAlias
-      ByteSize: 2
-      GoKind: 9
-    - __kind: StructureType
-      ID: 33
-      Name: main.bigStruct
-      ByteSize: 48
-      GoKind: 25
-      RawFields:
-        - Name: x
-          Offset: 0
-          Type: 34 GoSliceHeaderType []*string
-        - Name: z
-          Offset: 24
-          Type: 1 BaseType int
-        - Name: writer
-          Offset: 32
-          Type: 37 GoInterfaceType io.Writer
-    - __kind: GoSliceHeaderType
-      ID: 34
-      Name: '[]*string'
-      ByteSize: 24
-      GoRuntimeType: 473536
-      GoKind: 23
-      RawFields:
-        - Name: array
-          Offset: 0
-          Type: 35 PointerType **string
-        - Name: len
-          Offset: 8
-          Type: 1 BaseType int
-        - Name: cap
-          Offset: 16
-          Type: 1 BaseType int
-      Data: 240 GoSliceDataType []*string.array
+      Pointee: 207 PointerType *main.t
     - __kind: PointerType
       ID: 35
       Name: '**string'
@@ -3371,2041 +3107,110 @@ Types:
       GoKind: 22
       Pointee: 36 PointerType *string
     - __kind: PointerType
-      ID: 36
-      Name: '*string'
+      ID: 194
+      Name: '**table<[4]int,[4]int>'
       ByteSize: 8
-      GoRuntimeType: 387968
-      GoKind: 22
-      Pointee: 8 GoStringHeaderType string
-    - __kind: GoInterfaceType
-      ID: 37
-      Name: io.Writer
-      ByteSize: 16
-      GoRuntimeType: 1.016736e+06
-      GoKind: 20
-      RawFields:
-        - Name: tab
-          Offset: 0
-          Type: 38 VoidPointerType unsafe.Pointer
-        - Name: data
-          Offset: 8
-          Type: 38 VoidPointerType unsafe.Pointer
-    - __kind: VoidPointerType
-      ID: 38
-      Name: unsafe.Pointer
-      ByteSize: 8
-      GoRuntimeType: 579872
-      GoKind: 26
-    - __kind: StructureType
-      ID: 39
-      Name: main.esotericStack
-      ByteSize: 64
-      GoRuntimeType: 1.954272e+06
-      GoKind: 25
-      RawFields:
-        - Name: _
-          Offset: 0
-          Type: 6 BaseType int32
-        - Name: _valid
-          Offset: 4
-          Type: 6 BaseType int32
-        - Name: c
-          Offset: 8
-          Type: 40 GoChannelType chan struct {}
-        - Name: val
-          Offset: 16
-          Type: 41 GoEmptyInterfaceType interface {}
-        - Name: _
-          Offset: 32
-          Type: 26 BaseType uint64
-        - Name: work
-          Offset: 40
-          Type: 42 GoInterfaceType main.something
-        - Name: foo
-          Offset: 56
-          Type: 43 GoSubroutineType func()
-    - __kind: GoChannelType
-      ID: 40
-      Name: chan struct {}
-      GoRuntimeType: 590048
-      GoKind: 18
-    - __kind: GoEmptyInterfaceType
-      ID: 41
-      Name: interface {}
-      ByteSize: 16
-      GoRuntimeType: 841856
-      GoKind: 20
-      RawFields:
-        - Name: _type
-          Offset: 0
-          Type: 38 VoidPointerType unsafe.Pointer
-        - Name: data
-          Offset: 8
-          Type: 38 VoidPointerType unsafe.Pointer
-    - __kind: GoInterfaceType
-      ID: 42
-      Name: main.something
-      ByteSize: 16
-      GoRuntimeType: 1.01648e+06
-      GoKind: 20
-      RawFields:
-        - Name: tab
-          Offset: 0
-          Type: 38 VoidPointerType unsafe.Pointer
-        - Name: data
-          Offset: 8
-          Type: 38 VoidPointerType unsafe.Pointer
-    - __kind: GoSubroutineType
-      ID: 43
-      Name: func()
-      ByteSize: 8
-      GoRuntimeType: 471744
-      GoKind: 19
-    - __kind: PointerType
-      ID: 44
-      Name: '*main.esotericHeap'
-      ByteSize: 8
-      GoRuntimeType: 383040
-      GoKind: 22
-      Pointee: 45 StructureType main.esotericHeap
-    - __kind: StructureType
-      ID: 45
-      Name: main.esotericHeap
-      ByteSize: 112
-      GoRuntimeType: 1.82096e+06
-      GoKind: 25
-      RawFields:
-        - Name: esotericStack
-          Offset: 0
-          Type: 39 StructureType main.esotericStack
-        - Name: mu
-          Offset: 64
-          Type: 46 StructureType sync.Mutex
-        - Name: once
-          Offset: 72
-          Type: 49 StructureType sync.Once
-        - Name: wg
-          Offset: 88
-          Type: 52 StructureType sync.WaitGroup
-        - Name: a
-          Offset: 104
-          Type: 55 StructureType sync/atomic.Int32
-    - __kind: StructureType
-      ID: 46
-      Name: sync.Mutex
-      ByteSize: 8
-      GoRuntimeType: 1.44992e+06
-      GoKind: 25
-      RawFields:
-        - Name: _
-          Offset: 0
-          Type: 47 StructureType sync.noCopy
-        - Name: mu
-          Offset: 0
-          Type: 48 StructureType internal/sync.Mutex
-    - __kind: StructureType
-      ID: 47
-      Name: sync.noCopy
-      GoRuntimeType: 982144
-      GoKind: 25
-      RawFields: []
-    - __kind: StructureType
-      ID: 48
-      Name: internal/sync.Mutex
-      ByteSize: 8
-      GoRuntimeType: 1.46e+06
-      GoKind: 25
-      RawFields:
-        - Name: state
-          Offset: 0
-          Type: 6 BaseType int32
-        - Name: sema
-          Offset: 4
-          Type: 24 BaseType uint32
-    - __kind: StructureType
-      ID: 49
-      Name: sync.Once
-      ByteSize: 12
-      GoRuntimeType: 1.598816e+06
-      GoKind: 25
-      RawFields:
-        - Name: _
-          Offset: 0
-          Type: 47 StructureType sync.noCopy
-        - Name: done
-          Offset: 0
-          Type: 50 StructureType sync/atomic.Bool
-        - Name: m
-          Offset: 4
-          Type: 46 StructureType sync.Mutex
-    - __kind: StructureType
-      ID: 50
-      Name: sync/atomic.Bool
-      ByteSize: 4
-      GoRuntimeType: 1.45104e+06
-      GoKind: 25
-      RawFields:
-        - Name: _
-          Offset: 0
-          Type: 51 StructureType sync/atomic.noCopy
-        - Name: v
-          Offset: 0
-          Type: 24 BaseType uint32
-    - __kind: StructureType
-      ID: 51
-      Name: sync/atomic.noCopy
-      GoRuntimeType: 982240
-      GoKind: 25
-      RawFields: []
-    - __kind: StructureType
-      ID: 52
-      Name: sync.WaitGroup
-      ByteSize: 16
-      GoRuntimeType: 1.598624e+06
-      GoKind: 25
-      RawFields:
-        - Name: noCopy
-          Offset: 0
-          Type: 47 StructureType sync.noCopy
-        - Name: state
-          Offset: 0
-          Type: 53 StructureType sync/atomic.Uint64
-        - Name: sema
-          Offset: 8
-          Type: 24 BaseType uint32
-    - __kind: StructureType
-      ID: 53
-      Name: sync/atomic.Uint64
-      ByteSize: 8
-      GoRuntimeType: 1.5992e+06
-      GoKind: 25
-      RawFields:
-        - Name: _
-          Offset: 0
-          Type: 51 StructureType sync/atomic.noCopy
-        - Name: _
-          Offset: 0
-          Type: 54 StructureType sync/atomic.align64
-        - Name: v
-          Offset: 0
-          Type: 26 BaseType uint64
-    - __kind: StructureType
-      ID: 54
-      Name: sync/atomic.align64
-      GoRuntimeType: 982336
-      GoKind: 25
-      RawFields: []
-    - __kind: StructureType
-      ID: 55
-      Name: sync/atomic.Int32
-      ByteSize: 4
-      GoRuntimeType: 1.4512e+06
-      GoKind: 25
-      RawFields:
-        - Name: _
-          Offset: 0
-          Type: 51 StructureType sync/atomic.noCopy
-        - Name: v
-          Offset: 0
-          Type: 6 BaseType int32
-    - __kind: GoInterfaceType
-      ID: 56
-      Name: main.behavior
-      ByteSize: 16
-      GoRuntimeType: 1.016352e+06
-      GoKind: 20
-      RawFields:
-        - Name: tab
-          Offset: 0
-          Type: 38 VoidPointerType unsafe.Pointer
-        - Name: data
-          Offset: 8
-          Type: 38 VoidPointerType unsafe.Pointer
-    - __kind: GoInterfaceType
-      ID: 57
-      Name: error
-      ByteSize: 16
-      GoRuntimeType: 1.020704e+06
-      GoKind: 20
-      RawFields:
-        - Name: tab
-          Offset: 0
-          Type: 38 VoidPointerType unsafe.Pointer
-        - Name: data
-          Offset: 8
-          Type: 38 VoidPointerType unsafe.Pointer
-    - __kind: StructureType
-      ID: 58
-      Name: main.structWithMap
-      ByteSize: 8
-      GoRuntimeType: 1.177504e+06
-      GoKind: 25
-      RawFields:
-        - Name: m
-          Offset: 0
-          Type: 59 GoMapType map[int]int
-    - __kind: GoMapType
-      ID: 59
-      Name: map[int]int
-      ByteSize: 8
-      GoRuntimeType: 1.122016e+06
-      GoKind: 21
-      HeaderType: 61 GoSwissMapHeaderType map<int,int>
-    - __kind: PointerType
-      ID: 60
-      Name: '*map<int,int>'
-      ByteSize: 8
-      Pointee: 61 GoSwissMapHeaderType map<int,int>
-    - __kind: GoSwissMapHeaderType
-      ID: 61
-      Name: map<int,int>
-      ByteSize: 48
-      GoKind: 25
-      RawFields:
-        - Name: used
-          Offset: 0
-          Type: 26 BaseType uint64
-        - Name: seed
-          Offset: 8
-          Type: 62 BaseType uintptr
-        - Name: dirPtr
-          Offset: 16
-          Type: 63 PointerType **table<int,int>
-        - Name: dirLen
-          Offset: 24
-          Type: 1 BaseType int
-        - Name: globalDepth
-          Offset: 32
-          Type: 4 BaseType uint8
-        - Name: globalShift
-          Offset: 33
-          Type: 4 BaseType uint8
-        - Name: writing
-          Offset: 34
-          Type: 4 BaseType uint8
-        - Name: tombstonePossible
-          Offset: 35
-          Type: 11 BaseType bool
-        - Name: clearSeq
-          Offset: 40
-          Type: 26 BaseType uint64
-      TablePtrSliceType: 242 GoSliceDataType []*table<int,int>.array
-      GroupType: 68 StructureType noalg.map.group[int]int
-    - __kind: BaseType
-      ID: 62
-      Name: uintptr
-      ByteSize: 8
-      GoRuntimeType: 579488
-      GoKind: 12
-    - __kind: PointerType
-      ID: 63
-      Name: '**table<int,int>'
-      ByteSize: 8
-      Pointee: 64 PointerType *table<int,int>
-    - __kind: PointerType
-      ID: 64
-      Name: '*table<int,int>'
-      ByteSize: 8
-      Pointee: 65 StructureType table<int,int>
-    - __kind: StructureType
-      ID: 65
-      Name: table<int,int>
-      ByteSize: 32
-      GoKind: 25
-      RawFields:
-        - Name: used
-          Offset: 0
-          Type: 22 BaseType uint16
-        - Name: capacity
-          Offset: 2
-          Type: 22 BaseType uint16
-        - Name: growthLeft
-          Offset: 4
-          Type: 22 BaseType uint16
-        - Name: localDepth
-          Offset: 6
-          Type: 4 BaseType uint8
-        - Name: index
-          Offset: 8
-          Type: 1 BaseType int
-        - Name: groups
-          Offset: 16
-          Type: 66 GoSwissMapGroupsType groupReference<int,int>
-    - __kind: GoSwissMapGroupsType
-      ID: 66
-      Name: groupReference<int,int>
-      ByteSize: 16
-      GoKind: 25
-      RawFields:
-        - Name: data
-          Offset: 0
-          Type: 67 PointerType *noalg.map.group[int]int
-        - Name: lengthMask
-          Offset: 8
-          Type: 26 BaseType uint64
-      GroupType: 68 StructureType noalg.map.group[int]int
-      GroupSliceType: 243 GoSliceDataType []noalg.map.group[int]int.array
-    - __kind: PointerType
-      ID: 67
-      Name: '*noalg.map.group[int]int'
-      ByteSize: 8
-      Pointee: 68 StructureType noalg.map.group[int]int
-    - __kind: StructureType
-      ID: 68
-      Name: noalg.map.group[int]int
-      ByteSize: 136
-      GoRuntimeType: 1.280992e+06
-      GoKind: 25
-      RawFields:
-        - Name: ctrl
-          Offset: 0
-          Type: 26 BaseType uint64
-        - Name: slots
-          Offset: 8
-          Type: 69 ArrayType noalg.[8]struct { key int; elem int }
-    - __kind: ArrayType
-      ID: 69
-      Name: noalg.[8]struct { key int; elem int }
-      ByteSize: 128
-      GoRuntimeType: 675008
-      GoKind: 17
-      Count: 8
-      HasCount: true
-      Element: 70 StructureType noalg.struct { key int; elem int }
-    - __kind: StructureType
-      ID: 70
-      Name: noalg.struct { key int; elem int }
-      ByteSize: 16
-      GoRuntimeType: 1.280864e+06
-      GoKind: 25
-      RawFields:
-        - Name: key
-          Offset: 0
-          Type: 1 BaseType int
-        - Name: elem
-          Offset: 8
-          Type: 1 BaseType int
-    - __kind: GoMapType
-      ID: 71
-      Name: map[string]main.nestedStruct
-      ByteSize: 8
-      GoRuntimeType: 1.123424e+06
-      GoKind: 21
-      HeaderType: 73 GoSwissMapHeaderType map<string,main.nestedStruct>
-    - __kind: PointerType
-      ID: 72
-      Name: '*map<string,main.nestedStruct>'
-      ByteSize: 8
-      Pointee: 73 GoSwissMapHeaderType map<string,main.nestedStruct>
-    - __kind: GoSwissMapHeaderType
-      ID: 73
-      Name: map<string,main.nestedStruct>
-      ByteSize: 48
-      GoKind: 25
-      RawFields:
-        - Name: used
-          Offset: 0
-          Type: 26 BaseType uint64
-        - Name: seed
-          Offset: 8
-          Type: 62 BaseType uintptr
-        - Name: dirPtr
-          Offset: 16
-          Type: 74 PointerType **table<string,main.nestedStruct>
-        - Name: dirLen
-          Offset: 24
-          Type: 1 BaseType int
-        - Name: globalDepth
-          Offset: 32
-          Type: 4 BaseType uint8
-        - Name: globalShift
-          Offset: 33
-          Type: 4 BaseType uint8
-        - Name: writing
-          Offset: 34
-          Type: 4 BaseType uint8
-        - Name: tombstonePossible
-          Offset: 35
-          Type: 11 BaseType bool
-        - Name: clearSeq
-          Offset: 40
-          Type: 26 BaseType uint64
-      TablePtrSliceType: 244 GoSliceDataType []*table<string,main.nestedStruct>.array
-      GroupType: 79 StructureType noalg.map.group[string]main.nestedStruct
-    - __kind: PointerType
-      ID: 74
-      Name: '**table<string,main.nestedStruct>'
-      ByteSize: 8
-      Pointee: 75 PointerType *table<string,main.nestedStruct>
-    - __kind: PointerType
-      ID: 75
-      Name: '*table<string,main.nestedStruct>'
-      ByteSize: 8
-      Pointee: 76 StructureType table<string,main.nestedStruct>
-    - __kind: StructureType
-      ID: 76
-      Name: table<string,main.nestedStruct>
-      ByteSize: 32
-      GoKind: 25
-      RawFields:
-        - Name: used
-          Offset: 0
-          Type: 22 BaseType uint16
-        - Name: capacity
-          Offset: 2
-          Type: 22 BaseType uint16
-        - Name: growthLeft
-          Offset: 4
-          Type: 22 BaseType uint16
-        - Name: localDepth
-          Offset: 6
-          Type: 4 BaseType uint8
-        - Name: index
-          Offset: 8
-          Type: 1 BaseType int
-        - Name: groups
-          Offset: 16
-          Type: 77 GoSwissMapGroupsType groupReference<string,main.nestedStruct>
-    - __kind: GoSwissMapGroupsType
-      ID: 77
-      Name: groupReference<string,main.nestedStruct>
-      ByteSize: 16
-      GoKind: 25
-      RawFields:
-        - Name: data
-          Offset: 0
-          Type: 78 PointerType *noalg.map.group[string]main.nestedStruct
-        - Name: lengthMask
-          Offset: 8
-          Type: 26 BaseType uint64
-      GroupType: 79 StructureType noalg.map.group[string]main.nestedStruct
-      GroupSliceType: 245 GoSliceDataType []noalg.map.group[string]main.nestedStruct.array
-    - __kind: PointerType
-      ID: 78
-      Name: '*noalg.map.group[string]main.nestedStruct'
-      ByteSize: 8
-      Pointee: 79 StructureType noalg.map.group[string]main.nestedStruct
-    - __kind: StructureType
-      ID: 79
-      Name: noalg.map.group[string]main.nestedStruct
-      ByteSize: 328
-      GoRuntimeType: 1.283808e+06
-      GoKind: 25
-      RawFields:
-        - Name: ctrl
-          Offset: 0
-          Type: 26 BaseType uint64
-        - Name: slots
-          Offset: 8
-          Type: 80 ArrayType noalg.[8]struct { key string; elem main.nestedStruct }
-    - __kind: ArrayType
-      ID: 80
-      Name: noalg.[8]struct { key string; elem main.nestedStruct }
-      ByteSize: 320
-      GoRuntimeType: 677696
-      GoKind: 17
-      Count: 8
-      HasCount: true
-      Element: 81 StructureType noalg.struct { key string; elem main.nestedStruct }
-    - __kind: StructureType
-      ID: 81
-      Name: noalg.struct { key string; elem main.nestedStruct }
-      ByteSize: 40
-      GoRuntimeType: 1.28368e+06
-      GoKind: 25
-      RawFields:
-        - Name: key
-          Offset: 0
-          Type: 8 GoStringHeaderType string
-        - Name: elem
-          Offset: 16
-          Type: 82 StructureType main.nestedStruct
-    - __kind: StructureType
-      ID: 82
-      Name: main.nestedStruct
-      ByteSize: 24
-      GoRuntimeType: 1.44864e+06
-      GoKind: 25
-      RawFields:
-        - Name: anotherInt
-          Offset: 0
-          Type: 1 BaseType int
-        - Name: anotherString
-          Offset: 8
-          Type: 8 GoStringHeaderType string
-    - __kind: GoMapType
-      ID: 83
-      Name: map[string]int
-      ByteSize: 8
-      GoRuntimeType: 1.123296e+06
-      GoKind: 21
-      HeaderType: 85 GoSwissMapHeaderType map<string,int>
-    - __kind: PointerType
-      ID: 84
-      Name: '*map<string,int>'
-      ByteSize: 8
-      Pointee: 85 GoSwissMapHeaderType map<string,int>
-    - __kind: GoSwissMapHeaderType
-      ID: 85
-      Name: map<string,int>
-      ByteSize: 48
-      GoKind: 25
-      RawFields:
-        - Name: used
-          Offset: 0
-          Type: 26 BaseType uint64
-        - Name: seed
-          Offset: 8
-          Type: 62 BaseType uintptr
-        - Name: dirPtr
-          Offset: 16
-          Type: 86 PointerType **table<string,int>
-        - Name: dirLen
-          Offset: 24
-          Type: 1 BaseType int
-        - Name: globalDepth
-          Offset: 32
-          Type: 4 BaseType uint8
-        - Name: globalShift
-          Offset: 33
-          Type: 4 BaseType uint8
-        - Name: writing
-          Offset: 34
-          Type: 4 BaseType uint8
-        - Name: tombstonePossible
-          Offset: 35
-          Type: 11 BaseType bool
-        - Name: clearSeq
-          Offset: 40
-          Type: 26 BaseType uint64
-      TablePtrSliceType: 246 GoSliceDataType []*table<string,int>.array
-      GroupType: 91 StructureType noalg.map.group[string]int
-    - __kind: PointerType
-      ID: 86
-      Name: '**table<string,int>'
-      ByteSize: 8
-      Pointee: 87 PointerType *table<string,int>
-    - __kind: PointerType
-      ID: 87
-      Name: '*table<string,int>'
-      ByteSize: 8
-      Pointee: 88 StructureType table<string,int>
-    - __kind: StructureType
-      ID: 88
-      Name: table<string,int>
-      ByteSize: 32
-      GoKind: 25
-      RawFields:
-        - Name: used
-          Offset: 0
-          Type: 22 BaseType uint16
-        - Name: capacity
-          Offset: 2
-          Type: 22 BaseType uint16
-        - Name: growthLeft
-          Offset: 4
-          Type: 22 BaseType uint16
-        - Name: localDepth
-          Offset: 6
-          Type: 4 BaseType uint8
-        - Name: index
-          Offset: 8
-          Type: 1 BaseType int
-        - Name: groups
-          Offset: 16
-          Type: 89 GoSwissMapGroupsType groupReference<string,int>
-    - __kind: GoSwissMapGroupsType
-      ID: 89
-      Name: groupReference<string,int>
-      ByteSize: 16
-      GoKind: 25
-      RawFields:
-        - Name: data
-          Offset: 0
-          Type: 90 PointerType *noalg.map.group[string]int
-        - Name: lengthMask
-          Offset: 8
-          Type: 26 BaseType uint64
-      GroupType: 91 StructureType noalg.map.group[string]int
-      GroupSliceType: 247 GoSliceDataType []noalg.map.group[string]int.array
-    - __kind: PointerType
-      ID: 90
-      Name: '*noalg.map.group[string]int'
-      ByteSize: 8
-      Pointee: 91 StructureType noalg.map.group[string]int
-    - __kind: StructureType
-      ID: 91
-      Name: noalg.map.group[string]int
-      ByteSize: 200
-      GoRuntimeType: 1.283552e+06
-      GoKind: 25
-      RawFields:
-        - Name: ctrl
-          Offset: 0
-          Type: 26 BaseType uint64
-        - Name: slots
-          Offset: 8
-          Type: 92 ArrayType noalg.[8]struct { key string; elem int }
-    - __kind: ArrayType
-      ID: 92
-      Name: noalg.[8]struct { key string; elem int }
-      ByteSize: 192
-      GoRuntimeType: 677600
-      GoKind: 17
-      Count: 8
-      HasCount: true
-      Element: 93 StructureType noalg.struct { key string; elem int }
-    - __kind: StructureType
-      ID: 93
-      Name: noalg.struct { key string; elem int }
-      ByteSize: 24
-      GoRuntimeType: 1.283424e+06
-      GoKind: 25
-      RawFields:
-        - Name: key
-          Offset: 0
-          Type: 8 GoStringHeaderType string
-        - Name: elem
-          Offset: 16
-          Type: 1 BaseType int
-    - __kind: GoMapType
-      ID: 94
-      Name: map[string][]string
-      ByteSize: 8
-      GoRuntimeType: 1.123168e+06
-      GoKind: 21
-      HeaderType: 96 GoSwissMapHeaderType map<string,[]string>
-    - __kind: PointerType
-      ID: 95
-      Name: '*map<string,[]string>'
-      ByteSize: 8
-      Pointee: 96 GoSwissMapHeaderType map<string,[]string>
-    - __kind: GoSwissMapHeaderType
-      ID: 96
-      Name: map<string,[]string>
-      ByteSize: 48
-      GoKind: 25
-      RawFields:
-        - Name: used
-          Offset: 0
-          Type: 26 BaseType uint64
-        - Name: seed
-          Offset: 8
-          Type: 62 BaseType uintptr
-        - Name: dirPtr
-          Offset: 16
-          Type: 97 PointerType **table<string,[]string>
-        - Name: dirLen
-          Offset: 24
-          Type: 1 BaseType int
-        - Name: globalDepth
-          Offset: 32
-          Type: 4 BaseType uint8
-        - Name: globalShift
-          Offset: 33
-          Type: 4 BaseType uint8
-        - Name: writing
-          Offset: 34
-          Type: 4 BaseType uint8
-        - Name: tombstonePossible
-          Offset: 35
-          Type: 11 BaseType bool
-        - Name: clearSeq
-          Offset: 40
-          Type: 26 BaseType uint64
-      TablePtrSliceType: 248 GoSliceDataType []*table<string,[]string>.array
-      GroupType: 102 StructureType noalg.map.group[string][]string
-    - __kind: PointerType
-      ID: 97
-      Name: '**table<string,[]string>'
-      ByteSize: 8
-      Pointee: 98 PointerType *table<string,[]string>
-    - __kind: PointerType
-      ID: 98
-      Name: '*table<string,[]string>'
-      ByteSize: 8
-      Pointee: 99 StructureType table<string,[]string>
-    - __kind: StructureType
-      ID: 99
-      Name: table<string,[]string>
-      ByteSize: 32
-      GoKind: 25
-      RawFields:
-        - Name: used
-          Offset: 0
-          Type: 22 BaseType uint16
-        - Name: capacity
-          Offset: 2
-          Type: 22 BaseType uint16
-        - Name: growthLeft
-          Offset: 4
-          Type: 22 BaseType uint16
-        - Name: localDepth
-          Offset: 6
-          Type: 4 BaseType uint8
-        - Name: index
-          Offset: 8
-          Type: 1 BaseType int
-        - Name: groups
-          Offset: 16
-          Type: 100 GoSwissMapGroupsType groupReference<string,[]string>
-    - __kind: GoSwissMapGroupsType
-      ID: 100
-      Name: groupReference<string,[]string>
-      ByteSize: 16
-      GoKind: 25
-      RawFields:
-        - Name: data
-          Offset: 0
-          Type: 101 PointerType *noalg.map.group[string][]string
-        - Name: lengthMask
-          Offset: 8
-          Type: 26 BaseType uint64
-      GroupType: 102 StructureType noalg.map.group[string][]string
-      GroupSliceType: 249 GoSliceDataType []noalg.map.group[string][]string.array
-    - __kind: PointerType
-      ID: 101
-      Name: '*noalg.map.group[string][]string'
-      ByteSize: 8
-      Pointee: 102 StructureType noalg.map.group[string][]string
-    - __kind: StructureType
-      ID: 102
-      Name: noalg.map.group[string][]string
-      ByteSize: 328
-      GoRuntimeType: 1.283296e+06
-      GoKind: 25
-      RawFields:
-        - Name: ctrl
-          Offset: 0
-          Type: 26 BaseType uint64
-        - Name: slots
-          Offset: 8
-          Type: 103 ArrayType noalg.[8]struct { key string; elem []string }
-    - __kind: ArrayType
-      ID: 103
-      Name: noalg.[8]struct { key string; elem []string }
-      ByteSize: 320
-      GoRuntimeType: 677504
-      GoKind: 17
-      Count: 8
-      HasCount: true
-      Element: 104 StructureType noalg.struct { key string; elem []string }
-    - __kind: StructureType
-      ID: 104
-      Name: noalg.struct { key string; elem []string }
-      ByteSize: 40
-      GoRuntimeType: 1.283168e+06
-      GoKind: 25
-      RawFields:
-        - Name: key
-          Offset: 0
-          Type: 8 GoStringHeaderType string
-        - Name: elem
-          Offset: 16
-          Type: 105 GoSliceHeaderType []string
-    - __kind: GoSliceHeaderType
-      ID: 105
-      Name: '[]string'
-      ByteSize: 24
-      GoRuntimeType: 481984
-      GoKind: 23
-      RawFields:
-        - Name: array
-          Offset: 0
-          Type: 36 PointerType *string
-        - Name: len
-          Offset: 8
-          Type: 1 BaseType int
-        - Name: cap
-          Offset: 16
-          Type: 1 BaseType int
-      Data: 250 GoSliceDataType []string.array
-    - __kind: GoMapType
-      ID: 106
-      Name: map[[4]string][2]int
-      ByteSize: 8
-      GoRuntimeType: 1.122656e+06
-      GoKind: 21
-      HeaderType: 108 GoSwissMapHeaderType map<[4]string,[2]int>
-    - __kind: PointerType
-      ID: 107
-      Name: '*map<[4]string,[2]int>'
-      ByteSize: 8
-      Pointee: 108 GoSwissMapHeaderType map<[4]string,[2]int>
-    - __kind: GoSwissMapHeaderType
-      ID: 108
-      Name: map<[4]string,[2]int>
-      ByteSize: 48
-      GoKind: 25
-      RawFields:
-        - Name: used
-          Offset: 0
-          Type: 26 BaseType uint64
-        - Name: seed
-          Offset: 8
-          Type: 62 BaseType uintptr
-        - Name: dirPtr
-          Offset: 16
-          Type: 109 PointerType **table<[4]string,[2]int>
-        - Name: dirLen
-          Offset: 24
-          Type: 1 BaseType int
-        - Name: globalDepth
-          Offset: 32
-          Type: 4 BaseType uint8
-        - Name: globalShift
-          Offset: 33
-          Type: 4 BaseType uint8
-        - Name: writing
-          Offset: 34
-          Type: 4 BaseType uint8
-        - Name: tombstonePossible
-          Offset: 35
-          Type: 11 BaseType bool
-        - Name: clearSeq
-          Offset: 40
-          Type: 26 BaseType uint64
-      TablePtrSliceType: 252 GoSliceDataType []*table<[4]string,[2]int>.array
-      GroupType: 114 StructureType noalg.map.group[[4]string][2]int
-    - __kind: PointerType
-      ID: 109
-      Name: '**table<[4]string,[2]int>'
-      ByteSize: 8
-      Pointee: 110 PointerType *table<[4]string,[2]int>
-    - __kind: PointerType
-      ID: 110
-      Name: '*table<[4]string,[2]int>'
-      ByteSize: 8
-      Pointee: 111 StructureType table<[4]string,[2]int>
-    - __kind: StructureType
-      ID: 111
-      Name: table<[4]string,[2]int>
-      ByteSize: 32
-      GoKind: 25
-      RawFields:
-        - Name: used
-          Offset: 0
-          Type: 22 BaseType uint16
-        - Name: capacity
-          Offset: 2
-          Type: 22 BaseType uint16
-        - Name: growthLeft
-          Offset: 4
-          Type: 22 BaseType uint16
-        - Name: localDepth
-          Offset: 6
-          Type: 4 BaseType uint8
-        - Name: index
-          Offset: 8
-          Type: 1 BaseType int
-        - Name: groups
-          Offset: 16
-          Type: 112 GoSwissMapGroupsType groupReference<[4]string,[2]int>
-    - __kind: GoSwissMapGroupsType
-      ID: 112
-      Name: groupReference<[4]string,[2]int>
-      ByteSize: 16
-      GoKind: 25
-      RawFields:
-        - Name: data
-          Offset: 0
-          Type: 113 PointerType *noalg.map.group[[4]string][2]int
-        - Name: lengthMask
-          Offset: 8
-          Type: 26 BaseType uint64
-      GroupType: 114 StructureType noalg.map.group[[4]string][2]int
-      GroupSliceType: 253 GoSliceDataType []noalg.map.group[[4]string][2]int.array
-    - __kind: PointerType
-      ID: 113
-      Name: '*noalg.map.group[[4]string][2]int'
-      ByteSize: 8
-      Pointee: 114 StructureType noalg.map.group[[4]string][2]int
-    - __kind: StructureType
-      ID: 114
-      Name: noalg.map.group[[4]string][2]int
-      ByteSize: 648
-      GoRuntimeType: 1.282272e+06
-      GoKind: 25
-      RawFields:
-        - Name: ctrl
-          Offset: 0
-          Type: 26 BaseType uint64
-        - Name: slots
-          Offset: 8
-          Type: 115 ArrayType noalg.[8]struct { key [4]string; elem [2]int }
-    - __kind: ArrayType
-      ID: 115
-      Name: noalg.[8]struct { key [4]string; elem [2]int }
-      ByteSize: 640
-      GoRuntimeType: 677120
-      GoKind: 17
-      Count: 8
-      HasCount: true
-      Element: 116 StructureType noalg.struct { key [4]string; elem [2]int }
-    - __kind: StructureType
-      ID: 116
-      Name: noalg.struct { key [4]string; elem [2]int }
-      ByteSize: 80
-      GoRuntimeType: 1.282144e+06
-      GoKind: 25
-      RawFields:
-        - Name: key
-          Offset: 0
-          Type: 117 ArrayType [4]string
-        - Name: elem
-          Offset: 64
-          Type: 12 ArrayType [2]int
-    - __kind: ArrayType
-      ID: 117
-      Name: '[4]string'
-      ByteSize: 64
-      GoRuntimeType: 676928
-      GoKind: 17
-      Count: 4
-      HasCount: true
-      Element: 8 GoStringHeaderType string
-    - __kind: ArrayType
-      ID: 118
-      Name: '[2]map[string]int'
-      ByteSize: 16
-      GoKind: 17
-      Count: 2
-      HasCount: true
-      Element: 83 GoMapType map[string]int
-    - __kind: PointerType
-      ID: 119
-      Name: '*map[string]int'
-      ByteSize: 8
-      GoKind: 22
-      Pointee: 83 GoMapType map[string]int
-    - __kind: GoMapType
-      ID: 120
-      Name: map[string][]main.structWithMap
-      ByteSize: 8
-      GoRuntimeType: 1.12304e+06
-      GoKind: 21
-      HeaderType: 122 GoSwissMapHeaderType map<string,[]main.structWithMap>
-    - __kind: PointerType
-      ID: 121
-      Name: '*map<string,[]main.structWithMap>'
-      ByteSize: 8
-      Pointee: 122 GoSwissMapHeaderType map<string,[]main.structWithMap>
-    - __kind: GoSwissMapHeaderType
-      ID: 122
-      Name: map<string,[]main.structWithMap>
-      ByteSize: 48
-      GoKind: 25
-      RawFields:
-        - Name: used
-          Offset: 0
-          Type: 26 BaseType uint64
-        - Name: seed
-          Offset: 8
-          Type: 62 BaseType uintptr
-        - Name: dirPtr
-          Offset: 16
-          Type: 123 PointerType **table<string,[]main.structWithMap>
-        - Name: dirLen
-          Offset: 24
-          Type: 1 BaseType int
-        - Name: globalDepth
-          Offset: 32
-          Type: 4 BaseType uint8
-        - Name: globalShift
-          Offset: 33
-          Type: 4 BaseType uint8
-        - Name: writing
-          Offset: 34
-          Type: 4 BaseType uint8
-        - Name: tombstonePossible
-          Offset: 35
-          Type: 11 BaseType bool
-        - Name: clearSeq
-          Offset: 40
-          Type: 26 BaseType uint64
-      TablePtrSliceType: 254 GoSliceDataType []*table<string,[]main.structWithMap>.array
-      GroupType: 128 StructureType noalg.map.group[string][]main.structWithMap
-    - __kind: PointerType
-      ID: 123
-      Name: '**table<string,[]main.structWithMap>'
-      ByteSize: 8
-      Pointee: 124 PointerType *table<string,[]main.structWithMap>
-    - __kind: PointerType
-      ID: 124
-      Name: '*table<string,[]main.structWithMap>'
-      ByteSize: 8
-      Pointee: 125 StructureType table<string,[]main.structWithMap>
-    - __kind: StructureType
-      ID: 125
-      Name: table<string,[]main.structWithMap>
-      ByteSize: 32
-      GoKind: 25
-      RawFields:
-        - Name: used
-          Offset: 0
-          Type: 22 BaseType uint16
-        - Name: capacity
-          Offset: 2
-          Type: 22 BaseType uint16
-        - Name: growthLeft
-          Offset: 4
-          Type: 22 BaseType uint16
-        - Name: localDepth
-          Offset: 6
-          Type: 4 BaseType uint8
-        - Name: index
-          Offset: 8
-          Type: 1 BaseType int
-        - Name: groups
-          Offset: 16
-          Type: 126 GoSwissMapGroupsType groupReference<string,[]main.structWithMap>
-    - __kind: GoSwissMapGroupsType
-      ID: 126
-      Name: groupReference<string,[]main.structWithMap>
-      ByteSize: 16
-      GoKind: 25
-      RawFields:
-        - Name: data
-          Offset: 0
-          Type: 127 PointerType *noalg.map.group[string][]main.structWithMap
-        - Name: lengthMask
-          Offset: 8
-          Type: 26 BaseType uint64
-      GroupType: 128 StructureType noalg.map.group[string][]main.structWithMap
-      GroupSliceType: 255 GoSliceDataType []noalg.map.group[string][]main.structWithMap.array
-    - __kind: PointerType
-      ID: 127
-      Name: '*noalg.map.group[string][]main.structWithMap'
-      ByteSize: 8
-      Pointee: 128 StructureType noalg.map.group[string][]main.structWithMap
-    - __kind: StructureType
-      ID: 128
-      Name: noalg.map.group[string][]main.structWithMap
-      ByteSize: 328
-      GoRuntimeType: 1.28304e+06
-      GoKind: 25
-      RawFields:
-        - Name: ctrl
-          Offset: 0
-          Type: 26 BaseType uint64
-        - Name: slots
-          Offset: 8
-          Type: 129 ArrayType noalg.[8]struct { key string; elem []main.structWithMap }
-    - __kind: ArrayType
-      ID: 129
-      Name: noalg.[8]struct { key string; elem []main.structWithMap }
-      ByteSize: 320
-      GoRuntimeType: 677408
-      GoKind: 17
-      Count: 8
-      HasCount: true
-      Element: 130 StructureType noalg.struct { key string; elem []main.structWithMap }
-    - __kind: StructureType
-      ID: 130
-      Name: noalg.struct { key string; elem []main.structWithMap }
-      ByteSize: 40
-      GoRuntimeType: 1.282912e+06
-      GoKind: 25
-      RawFields:
-        - Name: key
-          Offset: 0
-          Type: 8 GoStringHeaderType string
-        - Name: elem
-          Offset: 16
-          Type: 131 GoSliceHeaderType []main.structWithMap
-    - __kind: GoSliceHeaderType
-      ID: 131
-      Name: '[]main.structWithMap'
-      ByteSize: 24
-      GoRuntimeType: 472768
-      GoKind: 23
-      RawFields:
-        - Name: array
-          Offset: 0
-          Type: 132 PointerType *main.structWithMap
-        - Name: len
-          Offset: 8
-          Type: 1 BaseType int
-        - Name: cap
-          Offset: 16
-          Type: 1 BaseType int
-      Data: 256 GoSliceDataType []main.structWithMap.array
-    - __kind: PointerType
-      ID: 132
-      Name: '*main.structWithMap'
-      ByteSize: 8
-      GoRuntimeType: 382976
-      GoKind: 22
-      Pointee: 58 StructureType main.structWithMap
-    - __kind: GoMapType
-      ID: 133
-      Name: map[bool]main.node
-      ByteSize: 8
-      GoRuntimeType: 1.122784e+06
-      GoKind: 21
-      HeaderType: 135 GoSwissMapHeaderType map<bool,main.node>
-    - __kind: PointerType
-      ID: 134
-      Name: '*map<bool,main.node>'
-      ByteSize: 8
-      Pointee: 135 GoSwissMapHeaderType map<bool,main.node>
-    - __kind: GoSwissMapHeaderType
-      ID: 135
-      Name: map<bool,main.node>
-      ByteSize: 48
-      GoKind: 25
-      RawFields:
-        - Name: used
-          Offset: 0
-          Type: 26 BaseType uint64
-        - Name: seed
-          Offset: 8
-          Type: 62 BaseType uintptr
-        - Name: dirPtr
-          Offset: 16
-          Type: 136 PointerType **table<bool,main.node>
-        - Name: dirLen
-          Offset: 24
-          Type: 1 BaseType int
-        - Name: globalDepth
-          Offset: 32
-          Type: 4 BaseType uint8
-        - Name: globalShift
-          Offset: 33
-          Type: 4 BaseType uint8
-        - Name: writing
-          Offset: 34
-          Type: 4 BaseType uint8
-        - Name: tombstonePossible
-          Offset: 35
-          Type: 11 BaseType bool
-        - Name: clearSeq
-          Offset: 40
-          Type: 26 BaseType uint64
-      TablePtrSliceType: 258 GoSliceDataType []*table<bool,main.node>.array
-      GroupType: 141 StructureType noalg.map.group[bool]main.node
-    - __kind: PointerType
-      ID: 136
-      Name: '**table<bool,main.node>'
-      ByteSize: 8
-      Pointee: 137 PointerType *table<bool,main.node>
-    - __kind: PointerType
-      ID: 137
-      Name: '*table<bool,main.node>'
-      ByteSize: 8
-      Pointee: 138 StructureType table<bool,main.node>
-    - __kind: StructureType
-      ID: 138
-      Name: table<bool,main.node>
-      ByteSize: 32
-      GoKind: 25
-      RawFields:
-        - Name: used
-          Offset: 0
-          Type: 22 BaseType uint16
-        - Name: capacity
-          Offset: 2
-          Type: 22 BaseType uint16
-        - Name: growthLeft
-          Offset: 4
-          Type: 22 BaseType uint16
-        - Name: localDepth
-          Offset: 6
-          Type: 4 BaseType uint8
-        - Name: index
-          Offset: 8
-          Type: 1 BaseType int
-        - Name: groups
-          Offset: 16
-          Type: 139 GoSwissMapGroupsType groupReference<bool,main.node>
-    - __kind: GoSwissMapGroupsType
-      ID: 139
-      Name: groupReference<bool,main.node>
-      ByteSize: 16
-      GoKind: 25
-      RawFields:
-        - Name: data
-          Offset: 0
-          Type: 140 PointerType *noalg.map.group[bool]main.node
-        - Name: lengthMask
-          Offset: 8
-          Type: 26 BaseType uint64
-      GroupType: 141 StructureType noalg.map.group[bool]main.node
-      GroupSliceType: 259 GoSliceDataType []noalg.map.group[bool]main.node.array
-    - __kind: PointerType
-      ID: 140
-      Name: '*noalg.map.group[bool]main.node'
-      ByteSize: 8
-      Pointee: 141 StructureType noalg.map.group[bool]main.node
-    - __kind: StructureType
-      ID: 141
-      Name: noalg.map.group[bool]main.node
-      ByteSize: 200
-      GoRuntimeType: 1.282528e+06
-      GoKind: 25
-      RawFields:
-        - Name: ctrl
-          Offset: 0
-          Type: 26 BaseType uint64
-        - Name: slots
-          Offset: 8
-          Type: 142 ArrayType noalg.[8]struct { key bool; elem main.node }
-    - __kind: ArrayType
-      ID: 142
-      Name: noalg.[8]struct { key bool; elem main.node }
-      ByteSize: 192
-      GoRuntimeType: 677216
-      GoKind: 17
-      Count: 8
-      HasCount: true
-      Element: 143 StructureType noalg.struct { key bool; elem main.node }
-    - __kind: StructureType
-      ID: 143
-      Name: noalg.struct { key bool; elem main.node }
-      ByteSize: 24
-      GoRuntimeType: 1.2824e+06
-      GoKind: 25
-      RawFields:
-        - Name: key
-          Offset: 0
-          Type: 11 BaseType bool
-        - Name: elem
-          Offset: 8
-          Type: 144 StructureType main.node
-    - __kind: StructureType
-      ID: 144
-      Name: main.node
-      ByteSize: 16
-      GoRuntimeType: 1.44848e+06
-      GoKind: 25
-      RawFields:
-        - Name: val
-          Offset: 0
-          Type: 1 BaseType int
-        - Name: b
-          Offset: 8
-          Type: 145 PointerType *main.node
-    - __kind: PointerType
-      ID: 145
-      Name: '*main.node'
-      ByteSize: 8
-      GoRuntimeType: 383104
-      GoKind: 22
-      Pointee: 144 StructureType main.node
-    - __kind: GoMapType
-      ID: 146
-      Name: map[int]uint8
-      ByteSize: 8
-      GoRuntimeType: 1.122912e+06
-      GoKind: 21
-      HeaderType: 148 GoSwissMapHeaderType map<int,uint8>
-    - __kind: PointerType
-      ID: 147
-      Name: '*map<int,uint8>'
-      ByteSize: 8
-      Pointee: 148 GoSwissMapHeaderType map<int,uint8>
-    - __kind: GoSwissMapHeaderType
-      ID: 148
-      Name: map<int,uint8>
-      ByteSize: 48
-      GoKind: 25
-      RawFields:
-        - Name: used
-          Offset: 0
-          Type: 26 BaseType uint64
-        - Name: seed
-          Offset: 8
-          Type: 62 BaseType uintptr
-        - Name: dirPtr
-          Offset: 16
-          Type: 149 PointerType **table<int,uint8>
-        - Name: dirLen
-          Offset: 24
-          Type: 1 BaseType int
-        - Name: globalDepth
-          Offset: 32
-          Type: 4 BaseType uint8
-        - Name: globalShift
-          Offset: 33
-          Type: 4 BaseType uint8
-        - Name: writing
-          Offset: 34
-          Type: 4 BaseType uint8
-        - Name: tombstonePossible
-          Offset: 35
-          Type: 11 BaseType bool
-        - Name: clearSeq
-          Offset: 40
-          Type: 26 BaseType uint64
-      TablePtrSliceType: 260 GoSliceDataType []*table<int,uint8>.array
-      GroupType: 154 StructureType noalg.map.group[int]uint8
-    - __kind: PointerType
-      ID: 149
-      Name: '**table<int,uint8>'
-      ByteSize: 8
-      Pointee: 150 PointerType *table<int,uint8>
-    - __kind: PointerType
-      ID: 150
-      Name: '*table<int,uint8>'
-      ByteSize: 8
-      Pointee: 151 StructureType table<int,uint8>
-    - __kind: StructureType
-      ID: 151
-      Name: table<int,uint8>
-      ByteSize: 32
-      GoKind: 25
-      RawFields:
-        - Name: used
-          Offset: 0
-          Type: 22 BaseType uint16
-        - Name: capacity
-          Offset: 2
-          Type: 22 BaseType uint16
-        - Name: growthLeft
-          Offset: 4
-          Type: 22 BaseType uint16
-        - Name: localDepth
-          Offset: 6
-          Type: 4 BaseType uint8
-        - Name: index
-          Offset: 8
-          Type: 1 BaseType int
-        - Name: groups
-          Offset: 16
-          Type: 152 GoSwissMapGroupsType groupReference<int,uint8>
-    - __kind: GoSwissMapGroupsType
-      ID: 152
-      Name: groupReference<int,uint8>
-      ByteSize: 16
-      GoKind: 25
-      RawFields:
-        - Name: data
-          Offset: 0
-          Type: 153 PointerType *noalg.map.group[int]uint8
-        - Name: lengthMask
-          Offset: 8
-          Type: 26 BaseType uint64
-      GroupType: 154 StructureType noalg.map.group[int]uint8
-      GroupSliceType: 261 GoSliceDataType []noalg.map.group[int]uint8.array
-    - __kind: PointerType
-      ID: 153
-      Name: '*noalg.map.group[int]uint8'
-      ByteSize: 8
-      Pointee: 154 StructureType noalg.map.group[int]uint8
-    - __kind: StructureType
-      ID: 154
-      Name: noalg.map.group[int]uint8
-      ByteSize: 136
-      GoRuntimeType: 1.282784e+06
-      GoKind: 25
-      RawFields:
-        - Name: ctrl
-          Offset: 0
-          Type: 26 BaseType uint64
-        - Name: slots
-          Offset: 8
-          Type: 155 ArrayType noalg.[8]struct { key int; elem uint8 }
-    - __kind: ArrayType
-      ID: 155
-      Name: noalg.[8]struct { key int; elem uint8 }
-      ByteSize: 128
-      GoRuntimeType: 677312
-      GoKind: 17
-      Count: 8
-      HasCount: true
-      Element: 156 StructureType noalg.struct { key int; elem uint8 }
-    - __kind: StructureType
-      ID: 156
-      Name: noalg.struct { key int; elem uint8 }
-      ByteSize: 16
-      GoRuntimeType: 1.282656e+06
-      GoKind: 25
-      RawFields:
-        - Name: key
-          Offset: 0
-          Type: 1 BaseType int
-        - Name: elem
-          Offset: 8
-          Type: 4 BaseType uint8
-    - __kind: GoMapType
-      ID: 157
-      Name: map[uint8]uint8
-      ByteSize: 8
-      GoRuntimeType: 1.12368e+06
-      GoKind: 21
-      HeaderType: 159 GoSwissMapHeaderType map<uint8,uint8>
-    - __kind: PointerType
-      ID: 158
-      Name: '*map<uint8,uint8>'
-      ByteSize: 8
-      Pointee: 159 GoSwissMapHeaderType map<uint8,uint8>
-    - __kind: GoSwissMapHeaderType
-      ID: 159
-      Name: map<uint8,uint8>
-      ByteSize: 48
-      GoKind: 25
-      RawFields:
-        - Name: used
-          Offset: 0
-          Type: 26 BaseType uint64
-        - Name: seed
-          Offset: 8
-          Type: 62 BaseType uintptr
-        - Name: dirPtr
-          Offset: 16
-          Type: 160 PointerType **table<uint8,uint8>
-        - Name: dirLen
-          Offset: 24
-          Type: 1 BaseType int
-        - Name: globalDepth
-          Offset: 32
-          Type: 4 BaseType uint8
-        - Name: globalShift
-          Offset: 33
-          Type: 4 BaseType uint8
-        - Name: writing
-          Offset: 34
-          Type: 4 BaseType uint8
-        - Name: tombstonePossible
-          Offset: 35
-          Type: 11 BaseType bool
-        - Name: clearSeq
-          Offset: 40
-          Type: 26 BaseType uint64
-      TablePtrSliceType: 262 GoSliceDataType []*table<uint8,uint8>.array
-      GroupType: 165 StructureType noalg.map.group[uint8]uint8
-    - __kind: PointerType
-      ID: 160
-      Name: '**table<uint8,uint8>'
-      ByteSize: 8
-      Pointee: 161 PointerType *table<uint8,uint8>
-    - __kind: PointerType
-      ID: 161
-      Name: '*table<uint8,uint8>'
-      ByteSize: 8
-      Pointee: 162 StructureType table<uint8,uint8>
-    - __kind: StructureType
-      ID: 162
-      Name: table<uint8,uint8>
-      ByteSize: 32
-      GoKind: 25
-      RawFields:
-        - Name: used
-          Offset: 0
-          Type: 22 BaseType uint16
-        - Name: capacity
-          Offset: 2
-          Type: 22 BaseType uint16
-        - Name: growthLeft
-          Offset: 4
-          Type: 22 BaseType uint16
-        - Name: localDepth
-          Offset: 6
-          Type: 4 BaseType uint8
-        - Name: index
-          Offset: 8
-          Type: 1 BaseType int
-        - Name: groups
-          Offset: 16
-          Type: 163 GoSwissMapGroupsType groupReference<uint8,uint8>
-    - __kind: GoSwissMapGroupsType
-      ID: 163
-      Name: groupReference<uint8,uint8>
-      ByteSize: 16
-      GoKind: 25
-      RawFields:
-        - Name: data
-          Offset: 0
-          Type: 164 PointerType *noalg.map.group[uint8]uint8
-        - Name: lengthMask
-          Offset: 8
-          Type: 26 BaseType uint64
-      GroupType: 165 StructureType noalg.map.group[uint8]uint8
-      GroupSliceType: 263 GoSliceDataType []noalg.map.group[uint8]uint8.array
-    - __kind: PointerType
-      ID: 164
-      Name: '*noalg.map.group[uint8]uint8'
-      ByteSize: 8
-      Pointee: 165 StructureType noalg.map.group[uint8]uint8
-    - __kind: StructureType
-      ID: 165
-      Name: noalg.map.group[uint8]uint8
-      ByteSize: 24
-      GoRuntimeType: 1.28432e+06
-      GoKind: 25
-      RawFields:
-        - Name: ctrl
-          Offset: 0
-          Type: 26 BaseType uint64
-        - Name: slots
-          Offset: 8
-          Type: 166 ArrayType noalg.[8]struct { key uint8; elem uint8 }
-    - __kind: ArrayType
-      ID: 166
-      Name: noalg.[8]struct { key uint8; elem uint8 }
-      ByteSize: 16
-      GoRuntimeType: 677888
-      GoKind: 17
-      Count: 8
-      HasCount: true
-      Element: 167 StructureType noalg.struct { key uint8; elem uint8 }
-    - __kind: StructureType
-      ID: 167
-      Name: noalg.struct { key uint8; elem uint8 }
-      ByteSize: 2
-      GoRuntimeType: 1.284192e+06
-      GoKind: 25
-      RawFields:
-        - Name: key
-          Offset: 0
-          Type: 4 BaseType uint8
-        - Name: elem
-          Offset: 1
-          Type: 4 BaseType uint8
-    - __kind: GoMapType
-      ID: 168
-      Name: map[uint8][4]int
-      ByteSize: 8
-      GoRuntimeType: 1.123552e+06
-      GoKind: 21
-      HeaderType: 170 GoSwissMapHeaderType map<uint8,[4]int>
-    - __kind: PointerType
-      ID: 169
-      Name: '*map<uint8,[4]int>'
-      ByteSize: 8
-      Pointee: 170 GoSwissMapHeaderType map<uint8,[4]int>
-    - __kind: GoSwissMapHeaderType
-      ID: 170
-      Name: map<uint8,[4]int>
-      ByteSize: 48
-      GoKind: 25
-      RawFields:
-        - Name: used
-          Offset: 0
-          Type: 26 BaseType uint64
-        - Name: seed
-          Offset: 8
-          Type: 62 BaseType uintptr
-        - Name: dirPtr
-          Offset: 16
-          Type: 171 PointerType **table<uint8,[4]int>
-        - Name: dirLen
-          Offset: 24
-          Type: 1 BaseType int
-        - Name: globalDepth
-          Offset: 32
-          Type: 4 BaseType uint8
-        - Name: globalShift
-          Offset: 33
-          Type: 4 BaseType uint8
-        - Name: writing
-          Offset: 34
-          Type: 4 BaseType uint8
-        - Name: tombstonePossible
-          Offset: 35
-          Type: 11 BaseType bool
-        - Name: clearSeq
-          Offset: 40
-          Type: 26 BaseType uint64
-      TablePtrSliceType: 264 GoSliceDataType []*table<uint8,[4]int>.array
-      GroupType: 176 StructureType noalg.map.group[uint8][4]int
-    - __kind: PointerType
-      ID: 171
-      Name: '**table<uint8,[4]int>'
-      ByteSize: 8
-      Pointee: 172 PointerType *table<uint8,[4]int>
-    - __kind: PointerType
-      ID: 172
-      Name: '*table<uint8,[4]int>'
-      ByteSize: 8
-      Pointee: 173 StructureType table<uint8,[4]int>
-    - __kind: StructureType
-      ID: 173
-      Name: table<uint8,[4]int>
-      ByteSize: 32
-      GoKind: 25
-      RawFields:
-        - Name: used
-          Offset: 0
-          Type: 22 BaseType uint16
-        - Name: capacity
-          Offset: 2
-          Type: 22 BaseType uint16
-        - Name: growthLeft
-          Offset: 4
-          Type: 22 BaseType uint16
-        - Name: localDepth
-          Offset: 6
-          Type: 4 BaseType uint8
-        - Name: index
-          Offset: 8
-          Type: 1 BaseType int
-        - Name: groups
-          Offset: 16
-          Type: 174 GoSwissMapGroupsType groupReference<uint8,[4]int>
-    - __kind: GoSwissMapGroupsType
-      ID: 174
-      Name: groupReference<uint8,[4]int>
-      ByteSize: 16
-      GoKind: 25
-      RawFields:
-        - Name: data
-          Offset: 0
-          Type: 175 PointerType *noalg.map.group[uint8][4]int
-        - Name: lengthMask
-          Offset: 8
-          Type: 26 BaseType uint64
-      GroupType: 176 StructureType noalg.map.group[uint8][4]int
-      GroupSliceType: 265 GoSliceDataType []noalg.map.group[uint8][4]int.array
-    - __kind: PointerType
-      ID: 175
-      Name: '*noalg.map.group[uint8][4]int'
-      ByteSize: 8
-      Pointee: 176 StructureType noalg.map.group[uint8][4]int
-    - __kind: StructureType
-      ID: 176
-      Name: noalg.map.group[uint8][4]int
-      ByteSize: 328
-      GoRuntimeType: 1.284064e+06
-      GoKind: 25
-      RawFields:
-        - Name: ctrl
-          Offset: 0
-          Type: 26 BaseType uint64
-        - Name: slots
-          Offset: 8
-          Type: 177 ArrayType noalg.[8]struct { key uint8; elem [4]int }
-    - __kind: ArrayType
-      ID: 177
-      Name: noalg.[8]struct { key uint8; elem [4]int }
-      ByteSize: 320
-      GoRuntimeType: 677792
-      GoKind: 17
-      Count: 8
-      HasCount: true
-      Element: 178 StructureType noalg.struct { key uint8; elem [4]int }
-    - __kind: StructureType
-      ID: 178
-      Name: noalg.struct { key uint8; elem [4]int }
-      ByteSize: 40
-      GoRuntimeType: 1.283936e+06
-      GoKind: 25
-      RawFields:
-        - Name: key
-          Offset: 0
-          Type: 4 BaseType uint8
-        - Name: elem
-          Offset: 8
-          Type: 179 ArrayType [4]int
-    - __kind: ArrayType
-      ID: 179
-      Name: '[4]int'
-      ByteSize: 32
-      GoRuntimeType: 676640
-      GoKind: 17
-      Count: 4
-      HasCount: true
-      Element: 1 BaseType int
-    - __kind: GoMapType
-      ID: 180
-      Name: map[[4]int]uint8
-      ByteSize: 8
-      GoRuntimeType: 1.122528e+06
-      GoKind: 21
-      HeaderType: 182 GoSwissMapHeaderType map<[4]int,uint8>
-    - __kind: PointerType
-      ID: 181
-      Name: '*map<[4]int,uint8>'
-      ByteSize: 8
-      Pointee: 182 GoSwissMapHeaderType map<[4]int,uint8>
-    - __kind: GoSwissMapHeaderType
-      ID: 182
-      Name: map<[4]int,uint8>
-      ByteSize: 48
-      GoKind: 25
-      RawFields:
-        - Name: used
-          Offset: 0
-          Type: 26 BaseType uint64
-        - Name: seed
-          Offset: 8
-          Type: 62 BaseType uintptr
-        - Name: dirPtr
-          Offset: 16
-          Type: 183 PointerType **table<[4]int,uint8>
-        - Name: dirLen
-          Offset: 24
-          Type: 1 BaseType int
-        - Name: globalDepth
-          Offset: 32
-          Type: 4 BaseType uint8
-        - Name: globalShift
-          Offset: 33
-          Type: 4 BaseType uint8
-        - Name: writing
-          Offset: 34
-          Type: 4 BaseType uint8
-        - Name: tombstonePossible
-          Offset: 35
-          Type: 11 BaseType bool
-        - Name: clearSeq
-          Offset: 40
-          Type: 26 BaseType uint64
-      TablePtrSliceType: 266 GoSliceDataType []*table<[4]int,uint8>.array
-      GroupType: 188 StructureType noalg.map.group[[4]int]uint8
+      Pointee: 195 PointerType *table<[4]int,[4]int>
     - __kind: PointerType
       ID: 183
       Name: '**table<[4]int,uint8>'
       ByteSize: 8
       Pointee: 184 PointerType *table<[4]int,uint8>
     - __kind: PointerType
-      ID: 184
-      Name: '*table<[4]int,uint8>'
+      ID: 109
+      Name: '**table<[4]string,[2]int>'
       ByteSize: 8
-      Pointee: 185 StructureType table<[4]int,uint8>
-    - __kind: StructureType
-      ID: 185
-      Name: table<[4]int,uint8>
-      ByteSize: 32
-      GoKind: 25
-      RawFields:
-        - Name: used
-          Offset: 0
-          Type: 22 BaseType uint16
-        - Name: capacity
-          Offset: 2
-          Type: 22 BaseType uint16
-        - Name: growthLeft
-          Offset: 4
-          Type: 22 BaseType uint16
-        - Name: localDepth
-          Offset: 6
-          Type: 4 BaseType uint8
-        - Name: index
-          Offset: 8
-          Type: 1 BaseType int
-        - Name: groups
-          Offset: 16
-          Type: 186 GoSwissMapGroupsType groupReference<[4]int,uint8>
-    - __kind: GoSwissMapGroupsType
-      ID: 186
-      Name: groupReference<[4]int,uint8>
-      ByteSize: 16
-      GoKind: 25
-      RawFields:
-        - Name: data
-          Offset: 0
-          Type: 187 PointerType *noalg.map.group[[4]int]uint8
-        - Name: lengthMask
-          Offset: 8
-          Type: 26 BaseType uint64
-      GroupType: 188 StructureType noalg.map.group[[4]int]uint8
-      GroupSliceType: 267 GoSliceDataType []noalg.map.group[[4]int]uint8.array
+      Pointee: 110 PointerType *table<[4]string,[2]int>
     - __kind: PointerType
-      ID: 187
-      Name: '*noalg.map.group[[4]int]uint8'
+      ID: 136
+      Name: '**table<bool,main.node>'
       ByteSize: 8
-      Pointee: 188 StructureType noalg.map.group[[4]int]uint8
-    - __kind: StructureType
-      ID: 188
-      Name: noalg.map.group[[4]int]uint8
-      ByteSize: 328
-      GoRuntimeType: 1.282016e+06
-      GoKind: 25
-      RawFields:
-        - Name: ctrl
-          Offset: 0
-          Type: 26 BaseType uint64
-        - Name: slots
-          Offset: 8
-          Type: 189 ArrayType noalg.[8]struct { key [4]int; elem uint8 }
-    - __kind: ArrayType
-      ID: 189
-      Name: noalg.[8]struct { key [4]int; elem uint8 }
-      ByteSize: 320
-      GoRuntimeType: 676832
-      GoKind: 17
-      Count: 8
-      HasCount: true
-      Element: 190 StructureType noalg.struct { key [4]int; elem uint8 }
-    - __kind: StructureType
-      ID: 190
-      Name: noalg.struct { key [4]int; elem uint8 }
-      ByteSize: 40
-      GoRuntimeType: 1.281888e+06
-      GoKind: 25
-      RawFields:
-        - Name: key
-          Offset: 0
-          Type: 179 ArrayType [4]int
-        - Name: elem
-          Offset: 32
-          Type: 4 BaseType uint8
-    - __kind: GoMapType
-      ID: 191
-      Name: map[[4]int][4]int
-      ByteSize: 8
-      GoRuntimeType: 1.1224e+06
-      GoKind: 21
-      HeaderType: 193 GoSwissMapHeaderType map<[4]int,[4]int>
+      Pointee: 137 PointerType *table<bool,main.node>
     - __kind: PointerType
-      ID: 192
-      Name: '*map<[4]int,[4]int>'
+      ID: 63
+      Name: '**table<int,int>'
       ByteSize: 8
-      Pointee: 193 GoSwissMapHeaderType map<[4]int,[4]int>
-    - __kind: GoSwissMapHeaderType
-      ID: 193
-      Name: map<[4]int,[4]int>
-      ByteSize: 48
-      GoKind: 25
-      RawFields:
-        - Name: used
-          Offset: 0
-          Type: 26 BaseType uint64
-        - Name: seed
-          Offset: 8
-          Type: 62 BaseType uintptr
-        - Name: dirPtr
-          Offset: 16
-          Type: 194 PointerType **table<[4]int,[4]int>
-        - Name: dirLen
-          Offset: 24
-          Type: 1 BaseType int
-        - Name: globalDepth
-          Offset: 32
-          Type: 4 BaseType uint8
-        - Name: globalShift
-          Offset: 33
-          Type: 4 BaseType uint8
-        - Name: writing
-          Offset: 34
-          Type: 4 BaseType uint8
-        - Name: tombstonePossible
-          Offset: 35
-          Type: 11 BaseType bool
-        - Name: clearSeq
-          Offset: 40
-          Type: 26 BaseType uint64
-      TablePtrSliceType: 268 GoSliceDataType []*table<[4]int,[4]int>.array
-      GroupType: 199 StructureType noalg.map.group[[4]int][4]int
+      Pointee: 64 PointerType *table<int,int>
     - __kind: PointerType
-      ID: 194
-      Name: '**table<[4]int,[4]int>'
+      ID: 149
+      Name: '**table<int,uint8>'
       ByteSize: 8
-      Pointee: 195 PointerType *table<[4]int,[4]int>
+      Pointee: 150 PointerType *table<int,uint8>
     - __kind: PointerType
-      ID: 195
-      Name: '*table<[4]int,[4]int>'
+      ID: 123
+      Name: '**table<string,[]main.structWithMap>'
       ByteSize: 8
-      Pointee: 196 StructureType table<[4]int,[4]int>
-    - __kind: StructureType
-      ID: 196
-      Name: table<[4]int,[4]int>
-      ByteSize: 32
-      GoKind: 25
-      RawFields:
-        - Name: used
-          Offset: 0
-          Type: 22 BaseType uint16
-        - Name: capacity
-          Offset: 2
-          Type: 22 BaseType uint16
-        - Name: growthLeft
-          Offset: 4
-          Type: 22 BaseType uint16
-        - Name: localDepth
-          Offset: 6
-          Type: 4 BaseType uint8
-        - Name: index
-          Offset: 8
-          Type: 1 BaseType int
-        - Name: groups
-          Offset: 16
-          Type: 197 GoSwissMapGroupsType groupReference<[4]int,[4]int>
-    - __kind: GoSwissMapGroupsType
-      ID: 197
-      Name: groupReference<[4]int,[4]int>
-      ByteSize: 16
-      GoKind: 25
-      RawFields:
-        - Name: data
-          Offset: 0
-          Type: 198 PointerType *noalg.map.group[[4]int][4]int
-        - Name: lengthMask
-          Offset: 8
-          Type: 26 BaseType uint64
-      GroupType: 199 StructureType noalg.map.group[[4]int][4]int
-      GroupSliceType: 269 GoSliceDataType []noalg.map.group[[4]int][4]int.array
+      Pointee: 124 PointerType *table<string,[]main.structWithMap>
     - __kind: PointerType
-      ID: 198
-      Name: '*noalg.map.group[[4]int][4]int'
+      ID: 97
+      Name: '**table<string,[]string>'
       ByteSize: 8
-      Pointee: 199 StructureType noalg.map.group[[4]int][4]int
-    - __kind: StructureType
-      ID: 199
-      Name: noalg.map.group[[4]int][4]int
-      ByteSize: 520
-      GoRuntimeType: 1.28176e+06
-      GoKind: 25
-      RawFields:
-        - Name: ctrl
-          Offset: 0
-          Type: 26 BaseType uint64
-        - Name: slots
-          Offset: 8
-          Type: 200 ArrayType noalg.[8]struct { key [4]int; elem [4]int }
-    - __kind: ArrayType
-      ID: 200
-      Name: noalg.[8]struct { key [4]int; elem [4]int }
-      ByteSize: 512
-      GoRuntimeType: 676736
-      GoKind: 17
-      Count: 8
-      HasCount: true
-      Element: 201 StructureType noalg.struct { key [4]int; elem [4]int }
-    - __kind: StructureType
-      ID: 201
-      Name: noalg.struct { key [4]int; elem [4]int }
-      ByteSize: 64
-      GoRuntimeType: 1.281632e+06
-      GoKind: 25
-      RawFields:
-        - Name: key
-          Offset: 0
-          Type: 179 ArrayType [4]int
-        - Name: elem
-          Offset: 32
-          Type: 179 ArrayType [4]int
-    - __kind: GoChannelType
-      ID: 202
-      Name: chan bool
-      GoRuntimeType: 591136
-      GoKind: 18
+      Pointee: 98 PointerType *table<string,[]string>
     - __kind: PointerType
-      ID: 203
-      Name: '*main.structWithTwoValues'
+      ID: 86
+      Name: '**table<string,int>'
       ByteSize: 8
-      GoKind: 22
-      Pointee: 204 StructureType main.structWithTwoValues
-    - __kind: StructureType
-      ID: 204
-      Name: main.structWithTwoValues
-      ByteSize: 16
-      GoKind: 25
-      RawFields:
-        - Name: a
-          Offset: 0
-          Type: 20 BaseType uint
-        - Name: b
-          Offset: 8
-          Type: 11 BaseType bool
+      Pointee: 87 PointerType *table<string,int>
     - __kind: PointerType
-      ID: 205
-      Name: '*uint'
+      ID: 74
+      Name: '**table<string,main.nestedStruct>'
       ByteSize: 8
-      GoRuntimeType: 388608
-      GoKind: 22
-      Pointee: 20 BaseType uint
+      Pointee: 75 PointerType *table<string,main.nestedStruct>
+    - __kind: PointerType
+      ID: 171
+      Name: '**table<uint8,[4]int>'
+      ByteSize: 8
+      Pointee: 172 PointerType *table<uint8,[4]int>
+    - __kind: PointerType
+      ID: 160
+      Name: '**table<uint8,uint8>'
+      ByteSize: 8
+      Pointee: 161 PointerType *table<uint8,uint8>
+    - __kind: PointerType
+      ID: 241
+      Name: '*[]*string.array'
+      ByteSize: 8
+      Pointee: 240 GoSliceDataType []*string.array
+    - __kind: PointerType
+      ID: 275
+      Name: '*[][]uint.array'
+      ByteSize: 8
+      Pointee: 274 GoSliceDataType [][]uint.array
+    - __kind: PointerType
+      ID: 279
+      Name: '*[]bool.array'
+      ByteSize: 8
+      Pointee: 278 GoSliceDataType []bool.array
+    - __kind: PointerType
+      ID: 257
+      Name: '*[]main.structWithMap.array'
+      ByteSize: 8
+      Pointee: 256 GoSliceDataType []main.structWithMap.array
+    - __kind: PointerType
+      ID: 277
+      Name: '*[]main.structWithNoStrings.array'
+      ByteSize: 8
+      Pointee: 276 GoSliceDataType []main.structWithNoStrings.array
+    - __kind: PointerType
+      ID: 251
+      Name: '*[]string.array'
+      ByteSize: 8
+      Pointee: 250 GoSliceDataType []string.array
+    - __kind: PointerType
+      ID: 212
+      Name: '*[]uint'
+      ByteSize: 8
+      Pointee: 210 GoSliceHeaderType []uint
+    - __kind: PointerType
+      ID: 273
+      Name: '*[]uint.array'
+      ByteSize: 8
+      Pointee: 272 GoSliceDataType []uint.array
+    - __kind: PointerType
+      ID: 281
+      Name: '*[]uint16.array'
+      ByteSize: 8
+      Pointee: 280 GoSliceDataType []uint16.array
     - __kind: PointerType
       ID: 206
       Name: '*bool'
@@ -5414,236 +3219,19 @@ Types:
       GoKind: 22
       Pointee: 11 BaseType bool
     - __kind: PointerType
-      ID: 207
-      Name: '*main.t'
+      ID: 236
+      Name: '*error'
       ByteSize: 8
+      GoRuntimeType: 387904
       GoKind: 22
-      Pointee: 208 GoSliceHeaderType main.t
-    - __kind: GoSliceHeaderType
-      ID: 208
-      Name: main.t
-      ByteSize: 24
-      GoKind: 23
-      RawFields:
-        - Name: array
-          Offset: 0
-          Type: 209 PointerType **main.t
-        - Name: len
-          Offset: 8
-          Type: 1 BaseType int
-        - Name: cap
-          Offset: 16
-          Type: 1 BaseType int
-      Data: 270 GoSliceDataType main.t.array
+      Pointee: 57 GoInterfaceType error
     - __kind: PointerType
-      ID: 209
-      Name: '**main.t'
+      ID: 237
+      Name: '*float32'
       ByteSize: 8
-      Pointee: 207 PointerType *main.t
-    - __kind: GoSliceHeaderType
-      ID: 210
-      Name: '[]uint'
-      ByteSize: 24
-      GoRuntimeType: 481472
-      GoKind: 23
-      RawFields:
-        - Name: array
-          Offset: 0
-          Type: 205 PointerType *uint
-        - Name: len
-          Offset: 8
-          Type: 1 BaseType int
-        - Name: cap
-          Offset: 16
-          Type: 1 BaseType int
-      Data: 272 GoSliceDataType []uint.array
-    - __kind: GoSliceHeaderType
-      ID: 211
-      Name: '[][]uint'
-      ByteSize: 24
-      GoKind: 23
-      RawFields:
-        - Name: array
-          Offset: 0
-          Type: 212 PointerType *[]uint
-        - Name: len
-          Offset: 8
-          Type: 1 BaseType int
-        - Name: cap
-          Offset: 16
-          Type: 1 BaseType int
-      Data: 274 GoSliceDataType [][]uint.array
-    - __kind: PointerType
-      ID: 212
-      Name: '*[]uint'
-      ByteSize: 8
-      Pointee: 210 GoSliceHeaderType []uint
-    - __kind: GoSliceHeaderType
-      ID: 213
-      Name: '[]main.structWithNoStrings'
-      ByteSize: 24
-      GoKind: 23
-      RawFields:
-        - Name: array
-          Offset: 0
-          Type: 214 PointerType *main.structWithNoStrings
-        - Name: len
-          Offset: 8
-          Type: 1 BaseType int
-        - Name: cap
-          Offset: 16
-          Type: 1 BaseType int
-      Data: 276 GoSliceDataType []main.structWithNoStrings.array
-    - __kind: PointerType
-      ID: 214
-      Name: '*main.structWithNoStrings'
-      ByteSize: 8
-      Pointee: 215 StructureType main.structWithNoStrings
-    - __kind: StructureType
-      ID: 215
-      Name: main.structWithNoStrings
-      ByteSize: 2
-      GoKind: 25
-      RawFields:
-        - Name: aUint8
-          Offset: 0
-          Type: 4 BaseType uint8
-        - Name: aBool
-          Offset: 1
-          Type: 11 BaseType bool
-    - __kind: GoSliceHeaderType
-      ID: 216
-      Name: '[]bool'
-      ByteSize: 24
-      GoRuntimeType: 481856
-      GoKind: 23
-      RawFields:
-        - Name: array
-          Offset: 0
-          Type: 206 PointerType *bool
-        - Name: len
-          Offset: 8
-          Type: 1 BaseType int
-        - Name: cap
-          Offset: 16
-          Type: 1 BaseType int
-      Data: 278 GoSliceDataType []bool.array
-    - __kind: GoSliceHeaderType
-      ID: 217
-      Name: '[]uint16'
-      ByteSize: 24
-      GoRuntimeType: 480832
-      GoKind: 23
-      RawFields:
-        - Name: array
-          Offset: 0
-          Type: 218 PointerType *uint16
-        - Name: len
-          Offset: 8
-          Type: 1 BaseType int
-        - Name: cap
-          Offset: 16
-          Type: 1 BaseType int
-      Data: 280 GoSliceDataType []uint16.array
-    - __kind: PointerType
-      ID: 218
-      Name: '*uint16'
-      ByteSize: 8
-      GoRuntimeType: 388224
+      GoRuntimeType: 388864
       GoKind: 22
-      Pointee: 22 BaseType uint16
-    - __kind: StructureType
-      ID: 219
-      Name: main.threeStringStruct
-      ByteSize: 48
-      GoKind: 25
-      RawFields:
-        - Name: a
-          Offset: 0
-          Type: 8 GoStringHeaderType string
-        - Name: b
-          Offset: 16
-          Type: 8 GoStringHeaderType string
-        - Name: c
-          Offset: 32
-          Type: 8 GoStringHeaderType string
-    - __kind: PointerType
-      ID: 220
-      Name: '*main.threeStringStruct'
-      ByteSize: 8
-      GoKind: 22
-      Pointee: 219 StructureType main.threeStringStruct
-    - __kind: PointerType
-      ID: 221
-      Name: '*main.oneStringStruct'
-      ByteSize: 8
-      GoKind: 22
-      Pointee: 222 StructureType main.oneStringStruct
-    - __kind: StructureType
-      ID: 222
-      Name: main.oneStringStruct
-      ByteSize: 16
-      GoKind: 25
-      RawFields:
-        - Name: a
-          Offset: 0
-          Type: 8 GoStringHeaderType string
-    - __kind: StructureType
-      ID: 223
-      Name: main.aStruct
-      ByteSize: 56
-      GoKind: 25
-      RawFields:
-        - Name: aBool
-          Offset: 0
-          Type: 11 BaseType bool
-        - Name: aString
-          Offset: 8
-          Type: 8 GoStringHeaderType string
-        - Name: aNumber
-          Offset: 24
-          Type: 1 BaseType int
-        - Name: nested
-          Offset: 32
-          Type: 82 StructureType main.nestedStruct
-    - __kind: StructureType
-      ID: 224
-      Name: main.emptyStruct
-      GoKind: 25
-      RawFields: []
-    - __kind: PointerType
-      ID: 225
-      Name: '*uintptr'
-      ByteSize: 8
-      GoRuntimeType: 388672
-      GoKind: 22
-      Pointee: 62 BaseType uintptr
-    - __kind: PointerType
-      ID: 226
-      Name: '*int32'
-      ByteSize: 8
-      GoRuntimeType: 388288
-      GoKind: 22
-      Pointee: 6 BaseType int32
-    - __kind: PointerType
-      ID: 227
-      Name: '*uint32'
-      ByteSize: 8
-      GoRuntimeType: 388352
-      GoKind: 22
-      Pointee: 24 BaseType uint32
-    - __kind: BaseType
-      ID: 228
-      Name: complex64
-      ByteSize: 8
-      GoRuntimeType: 579552
-      GoKind: 15
-    - __kind: BaseType
-      ID: 229
-      Name: complex128
-      ByteSize: 16
-      GoRuntimeType: 579616
-      GoKind: 16
+      Pointee: 30 BaseType float32
     - __kind: PointerType
       ID: 230
       Name: '*float64'
@@ -5659,26 +3247,26 @@ Types:
       GoKind: 22
       Pointee: 1 BaseType int
     - __kind: PointerType
-      ID: 232
-      Name: '*int64'
-      ByteSize: 8
-      GoRuntimeType: 388416
-      GoKind: 22
-      Pointee: 18 BaseType int64
-    - __kind: PointerType
-      ID: 233
-      Name: '*uint64'
-      ByteSize: 8
-      GoRuntimeType: 388480
-      GoKind: 22
-      Pointee: 26 BaseType uint64
-    - __kind: PointerType
       ID: 234
       Name: '*int16'
       ByteSize: 8
       GoRuntimeType: 388160
       GoKind: 22
       Pointee: 16 BaseType int16
+    - __kind: PointerType
+      ID: 226
+      Name: '*int32'
+      ByteSize: 8
+      GoRuntimeType: 388288
+      GoKind: 22
+      Pointee: 6 BaseType int32
+    - __kind: PointerType
+      ID: 232
+      Name: '*int64'
+      ByteSize: 8
+      GoRuntimeType: 388416
+      GoKind: 22
+      Pointee: 18 BaseType int64
     - __kind: PointerType
       ID: 235
       Name: '*int8'
@@ -5687,283 +3275,393 @@ Types:
       GoKind: 22
       Pointee: 14 BaseType int8
     - __kind: PointerType
-      ID: 236
-      Name: '*error'
+      ID: 44
+      Name: '*main.esotericHeap'
       ByteSize: 8
-      GoRuntimeType: 387904
+      GoRuntimeType: 383040
       GoKind: 22
-      Pointee: 57 GoInterfaceType error
+      Pointee: 45 StructureType main.esotericHeap
     - __kind: PointerType
-      ID: 237
-      Name: '*float32'
+      ID: 145
+      Name: '*main.node'
       ByteSize: 8
-      GoRuntimeType: 388864
+      GoRuntimeType: 383104
       GoKind: 22
-      Pointee: 30 BaseType float32
-    - __kind: GoStringDataType
-      ID: 238
-      Name: string.str
-      ByteSize: 2048
+      Pointee: 144 StructureType main.node
     - __kind: PointerType
-      ID: 239
-      Name: '*string.str'
+      ID: 221
+      Name: '*main.oneStringStruct'
       ByteSize: 8
-      Pointee: 238 GoStringDataType string.str
-    - __kind: GoSliceDataType
-      ID: 240
-      Name: '[]*string.array'
-      ByteSize: 2048
-      Element: 36 PointerType *string
+      GoKind: 22
+      Pointee: 222 StructureType main.oneStringStruct
     - __kind: PointerType
-      ID: 241
-      Name: '*[]*string.array'
+      ID: 132
+      Name: '*main.structWithMap'
       ByteSize: 8
-      Pointee: 240 GoSliceDataType []*string.array
-    - __kind: GoSliceDataType
-      ID: 242
-      Name: '[]*table<int,int>.array'
-      ByteSize: 8192
-      Element: 64 PointerType *table<int,int>
-    - __kind: GoSliceDataType
-      ID: 243
-      Name: '[]noalg.map.group[int]int.array'
-      ByteSize: 2048
-      Element: 68 StructureType noalg.map.group[int]int
-    - __kind: GoSliceDataType
-      ID: 244
-      Name: '[]*table<string,main.nestedStruct>.array'
-      ByteSize: 8192
-      Element: 75 PointerType *table<string,main.nestedStruct>
-    - __kind: GoSliceDataType
-      ID: 245
-      Name: '[]noalg.map.group[string]main.nestedStruct.array'
-      ByteSize: 2048
-      Element: 79 StructureType noalg.map.group[string]main.nestedStruct
-    - __kind: GoSliceDataType
-      ID: 246
-      Name: '[]*table<string,int>.array'
-      ByteSize: 8192
-      Element: 87 PointerType *table<string,int>
-    - __kind: GoSliceDataType
-      ID: 247
-      Name: '[]noalg.map.group[string]int.array'
-      ByteSize: 2048
-      Element: 91 StructureType noalg.map.group[string]int
-    - __kind: GoSliceDataType
-      ID: 248
-      Name: '[]*table<string,[]string>.array'
-      ByteSize: 8192
-      Element: 98 PointerType *table<string,[]string>
-    - __kind: GoSliceDataType
-      ID: 249
-      Name: '[]noalg.map.group[string][]string.array'
-      ByteSize: 2048
-      Element: 102 StructureType noalg.map.group[string][]string
-    - __kind: GoSliceDataType
-      ID: 250
-      Name: '[]string.array'
-      ByteSize: 2048
-      Element: 8 GoStringHeaderType string
+      GoRuntimeType: 382976
+      GoKind: 22
+      Pointee: 58 StructureType main.structWithMap
     - __kind: PointerType
-      ID: 251
-      Name: '*[]string.array'
+      ID: 214
+      Name: '*main.structWithNoStrings'
       ByteSize: 8
-      Pointee: 250 GoSliceDataType []string.array
-    - __kind: GoSliceDataType
-      ID: 252
-      Name: '[]*table<[4]string,[2]int>.array'
-      ByteSize: 8192
-      Element: 110 PointerType *table<[4]string,[2]int>
-    - __kind: GoSliceDataType
-      ID: 253
-      Name: '[]noalg.map.group[[4]string][2]int.array'
-      ByteSize: 2048
-      Element: 114 StructureType noalg.map.group[[4]string][2]int
-    - __kind: GoSliceDataType
-      ID: 254
-      Name: '[]*table<string,[]main.structWithMap>.array'
-      ByteSize: 8192
-      Element: 124 PointerType *table<string,[]main.structWithMap>
-    - __kind: GoSliceDataType
-      ID: 255
-      Name: '[]noalg.map.group[string][]main.structWithMap.array'
-      ByteSize: 2048
-      Element: 128 StructureType noalg.map.group[string][]main.structWithMap
-    - __kind: GoSliceDataType
-      ID: 256
-      Name: '[]main.structWithMap.array'
-      ByteSize: 2048
-      Element: 58 StructureType main.structWithMap
+      Pointee: 215 StructureType main.structWithNoStrings
     - __kind: PointerType
-      ID: 257
-      Name: '*[]main.structWithMap.array'
+      ID: 203
+      Name: '*main.structWithTwoValues'
       ByteSize: 8
-      Pointee: 256 GoSliceDataType []main.structWithMap.array
-    - __kind: GoSliceDataType
-      ID: 258
-      Name: '[]*table<bool,main.node>.array'
-      ByteSize: 8192
-      Element: 137 PointerType *table<bool,main.node>
-    - __kind: GoSliceDataType
-      ID: 259
-      Name: '[]noalg.map.group[bool]main.node.array'
-      ByteSize: 2048
-      Element: 141 StructureType noalg.map.group[bool]main.node
-    - __kind: GoSliceDataType
-      ID: 260
-      Name: '[]*table<int,uint8>.array'
-      ByteSize: 8192
-      Element: 150 PointerType *table<int,uint8>
-    - __kind: GoSliceDataType
-      ID: 261
-      Name: '[]noalg.map.group[int]uint8.array'
-      ByteSize: 2048
-      Element: 154 StructureType noalg.map.group[int]uint8
-    - __kind: GoSliceDataType
-      ID: 262
-      Name: '[]*table<uint8,uint8>.array'
-      ByteSize: 8192
-      Element: 161 PointerType *table<uint8,uint8>
-    - __kind: GoSliceDataType
-      ID: 263
-      Name: '[]noalg.map.group[uint8]uint8.array'
-      ByteSize: 2048
-      Element: 165 StructureType noalg.map.group[uint8]uint8
-    - __kind: GoSliceDataType
-      ID: 264
-      Name: '[]*table<uint8,[4]int>.array'
-      ByteSize: 8192
-      Element: 172 PointerType *table<uint8,[4]int>
-    - __kind: GoSliceDataType
-      ID: 265
-      Name: '[]noalg.map.group[uint8][4]int.array'
-      ByteSize: 2048
-      Element: 176 StructureType noalg.map.group[uint8][4]int
-    - __kind: GoSliceDataType
-      ID: 266
-      Name: '[]*table<[4]int,uint8>.array'
-      ByteSize: 8192
-      Element: 184 PointerType *table<[4]int,uint8>
-    - __kind: GoSliceDataType
-      ID: 267
-      Name: '[]noalg.map.group[[4]int]uint8.array'
-      ByteSize: 2048
-      Element: 188 StructureType noalg.map.group[[4]int]uint8
-    - __kind: GoSliceDataType
-      ID: 268
-      Name: '[]*table<[4]int,[4]int>.array'
-      ByteSize: 8192
-      Element: 195 PointerType *table<[4]int,[4]int>
-    - __kind: GoSliceDataType
-      ID: 269
-      Name: '[]noalg.map.group[[4]int][4]int.array'
-      ByteSize: 2048
-      Element: 199 StructureType noalg.map.group[[4]int][4]int
-    - __kind: GoSliceDataType
-      ID: 270
-      Name: main.t.array
-      ByteSize: 2048
-      Element: 207 PointerType *main.t
+      GoKind: 22
+      Pointee: 204 StructureType main.structWithTwoValues
+    - __kind: PointerType
+      ID: 207
+      Name: '*main.t'
+      ByteSize: 8
+      GoKind: 22
+      Pointee: 208 GoSliceHeaderType main.t
     - __kind: PointerType
       ID: 271
       Name: '*main.t.array'
       ByteSize: 8
       Pointee: 270 GoSliceDataType main.t.array
-    - __kind: GoSliceDataType
-      ID: 272
-      Name: '[]uint.array'
-      ByteSize: 2048
-      Element: 20 BaseType uint
     - __kind: PointerType
-      ID: 273
-      Name: '*[]uint.array'
+      ID: 220
+      Name: '*main.threeStringStruct'
       ByteSize: 8
-      Pointee: 272 GoSliceDataType []uint.array
-    - __kind: GoSliceDataType
-      ID: 274
-      Name: '[][]uint.array'
-      ByteSize: 2048
-      Element: 210 GoSliceHeaderType []uint
+      GoKind: 22
+      Pointee: 219 StructureType main.threeStringStruct
     - __kind: PointerType
-      ID: 275
-      Name: '*[][]uint.array'
+      ID: 192
+      Name: '*map<[4]int,[4]int>'
       ByteSize: 8
-      Pointee: 274 GoSliceDataType [][]uint.array
-    - __kind: GoSliceDataType
-      ID: 276
-      Name: '[]main.structWithNoStrings.array'
-      ByteSize: 2048
-      Element: 215 StructureType main.structWithNoStrings
+      Pointee: 193 GoSwissMapHeaderType map<[4]int,[4]int>
     - __kind: PointerType
-      ID: 277
-      Name: '*[]main.structWithNoStrings.array'
+      ID: 181
+      Name: '*map<[4]int,uint8>'
       ByteSize: 8
-      Pointee: 276 GoSliceDataType []main.structWithNoStrings.array
-    - __kind: GoSliceDataType
-      ID: 278
-      Name: '[]bool.array'
-      ByteSize: 2048
-      Element: 11 BaseType bool
+      Pointee: 182 GoSwissMapHeaderType map<[4]int,uint8>
     - __kind: PointerType
-      ID: 279
-      Name: '*[]bool.array'
+      ID: 107
+      Name: '*map<[4]string,[2]int>'
       ByteSize: 8
-      Pointee: 278 GoSliceDataType []bool.array
-    - __kind: GoSliceDataType
-      ID: 280
-      Name: '[]uint16.array'
-      ByteSize: 2048
-      Element: 22 BaseType uint16
+      Pointee: 108 GoSwissMapHeaderType map<[4]string,[2]int>
     - __kind: PointerType
-      ID: 281
-      Name: '*[]uint16.array'
+      ID: 134
+      Name: '*map<bool,main.node>'
       ByteSize: 8
-      Pointee: 280 GoSliceDataType []uint16.array
+      Pointee: 135 GoSwissMapHeaderType map<bool,main.node>
+    - __kind: PointerType
+      ID: 60
+      Name: '*map<int,int>'
+      ByteSize: 8
+      Pointee: 61 GoSwissMapHeaderType map<int,int>
+    - __kind: PointerType
+      ID: 147
+      Name: '*map<int,uint8>'
+      ByteSize: 8
+      Pointee: 148 GoSwissMapHeaderType map<int,uint8>
+    - __kind: PointerType
+      ID: 121
+      Name: '*map<string,[]main.structWithMap>'
+      ByteSize: 8
+      Pointee: 122 GoSwissMapHeaderType map<string,[]main.structWithMap>
+    - __kind: PointerType
+      ID: 95
+      Name: '*map<string,[]string>'
+      ByteSize: 8
+      Pointee: 96 GoSwissMapHeaderType map<string,[]string>
+    - __kind: PointerType
+      ID: 84
+      Name: '*map<string,int>'
+      ByteSize: 8
+      Pointee: 85 GoSwissMapHeaderType map<string,int>
+    - __kind: PointerType
+      ID: 72
+      Name: '*map<string,main.nestedStruct>'
+      ByteSize: 8
+      Pointee: 73 GoSwissMapHeaderType map<string,main.nestedStruct>
+    - __kind: PointerType
+      ID: 169
+      Name: '*map<uint8,[4]int>'
+      ByteSize: 8
+      Pointee: 170 GoSwissMapHeaderType map<uint8,[4]int>
+    - __kind: PointerType
+      ID: 158
+      Name: '*map<uint8,uint8>'
+      ByteSize: 8
+      Pointee: 159 GoSwissMapHeaderType map<uint8,uint8>
+    - __kind: PointerType
+      ID: 119
+      Name: '*map[string]int'
+      ByteSize: 8
+      GoKind: 22
+      Pointee: 83 GoMapType map[string]int
+    - __kind: PointerType
+      ID: 198
+      Name: '*noalg.map.group[[4]int][4]int'
+      ByteSize: 8
+      Pointee: 199 StructureType noalg.map.group[[4]int][4]int
+    - __kind: PointerType
+      ID: 187
+      Name: '*noalg.map.group[[4]int]uint8'
+      ByteSize: 8
+      Pointee: 188 StructureType noalg.map.group[[4]int]uint8
+    - __kind: PointerType
+      ID: 113
+      Name: '*noalg.map.group[[4]string][2]int'
+      ByteSize: 8
+      Pointee: 114 StructureType noalg.map.group[[4]string][2]int
+    - __kind: PointerType
+      ID: 140
+      Name: '*noalg.map.group[bool]main.node'
+      ByteSize: 8
+      Pointee: 141 StructureType noalg.map.group[bool]main.node
+    - __kind: PointerType
+      ID: 67
+      Name: '*noalg.map.group[int]int'
+      ByteSize: 8
+      Pointee: 68 StructureType noalg.map.group[int]int
+    - __kind: PointerType
+      ID: 153
+      Name: '*noalg.map.group[int]uint8'
+      ByteSize: 8
+      Pointee: 154 StructureType noalg.map.group[int]uint8
+    - __kind: PointerType
+      ID: 127
+      Name: '*noalg.map.group[string][]main.structWithMap'
+      ByteSize: 8
+      Pointee: 128 StructureType noalg.map.group[string][]main.structWithMap
+    - __kind: PointerType
+      ID: 101
+      Name: '*noalg.map.group[string][]string'
+      ByteSize: 8
+      Pointee: 102 StructureType noalg.map.group[string][]string
+    - __kind: PointerType
+      ID: 90
+      Name: '*noalg.map.group[string]int'
+      ByteSize: 8
+      Pointee: 91 StructureType noalg.map.group[string]int
+    - __kind: PointerType
+      ID: 78
+      Name: '*noalg.map.group[string]main.nestedStruct'
+      ByteSize: 8
+      Pointee: 79 StructureType noalg.map.group[string]main.nestedStruct
+    - __kind: PointerType
+      ID: 175
+      Name: '*noalg.map.group[uint8][4]int'
+      ByteSize: 8
+      Pointee: 176 StructureType noalg.map.group[uint8][4]int
+    - __kind: PointerType
+      ID: 164
+      Name: '*noalg.map.group[uint8]uint8'
+      ByteSize: 8
+      Pointee: 165 StructureType noalg.map.group[uint8]uint8
+    - __kind: PointerType
+      ID: 36
+      Name: '*string'
+      ByteSize: 8
+      GoRuntimeType: 387968
+      GoKind: 22
+      Pointee: 8 GoStringHeaderType string
+    - __kind: PointerType
+      ID: 239
+      Name: '*string.str'
+      ByteSize: 8
+      Pointee: 238 GoStringDataType string.str
+    - __kind: PointerType
+      ID: 195
+      Name: '*table<[4]int,[4]int>'
+      ByteSize: 8
+      Pointee: 196 StructureType table<[4]int,[4]int>
+    - __kind: PointerType
+      ID: 184
+      Name: '*table<[4]int,uint8>'
+      ByteSize: 8
+      Pointee: 185 StructureType table<[4]int,uint8>
+    - __kind: PointerType
+      ID: 110
+      Name: '*table<[4]string,[2]int>'
+      ByteSize: 8
+      Pointee: 111 StructureType table<[4]string,[2]int>
+    - __kind: PointerType
+      ID: 137
+      Name: '*table<bool,main.node>'
+      ByteSize: 8
+      Pointee: 138 StructureType table<bool,main.node>
+    - __kind: PointerType
+      ID: 64
+      Name: '*table<int,int>'
+      ByteSize: 8
+      Pointee: 65 StructureType table<int,int>
+    - __kind: PointerType
+      ID: 150
+      Name: '*table<int,uint8>'
+      ByteSize: 8
+      Pointee: 151 StructureType table<int,uint8>
+    - __kind: PointerType
+      ID: 124
+      Name: '*table<string,[]main.structWithMap>'
+      ByteSize: 8
+      Pointee: 125 StructureType table<string,[]main.structWithMap>
+    - __kind: PointerType
+      ID: 98
+      Name: '*table<string,[]string>'
+      ByteSize: 8
+      Pointee: 99 StructureType table<string,[]string>
+    - __kind: PointerType
+      ID: 87
+      Name: '*table<string,int>'
+      ByteSize: 8
+      Pointee: 88 StructureType table<string,int>
+    - __kind: PointerType
+      ID: 75
+      Name: '*table<string,main.nestedStruct>'
+      ByteSize: 8
+      Pointee: 76 StructureType table<string,main.nestedStruct>
+    - __kind: PointerType
+      ID: 172
+      Name: '*table<uint8,[4]int>'
+      ByteSize: 8
+      Pointee: 173 StructureType table<uint8,[4]int>
+    - __kind: PointerType
+      ID: 161
+      Name: '*table<uint8,uint8>'
+      ByteSize: 8
+      Pointee: 162 StructureType table<uint8,uint8>
+    - __kind: PointerType
+      ID: 205
+      Name: '*uint'
+      ByteSize: 8
+      GoRuntimeType: 388608
+      GoKind: 22
+      Pointee: 20 BaseType uint
+    - __kind: PointerType
+      ID: 218
+      Name: '*uint16'
+      ByteSize: 8
+      GoRuntimeType: 388224
+      GoKind: 22
+      Pointee: 22 BaseType uint16
+    - __kind: PointerType
+      ID: 227
+      Name: '*uint32'
+      ByteSize: 8
+      GoRuntimeType: 388352
+      GoKind: 22
+      Pointee: 24 BaseType uint32
+    - __kind: PointerType
+      ID: 233
+      Name: '*uint64'
+      ByteSize: 8
+      GoRuntimeType: 388480
+      GoKind: 22
+      Pointee: 26 BaseType uint64
+    - __kind: PointerType
+      ID: 9
+      Name: '*uint8'
+      ByteSize: 8
+      GoRuntimeType: 388096
+      GoKind: 22
+      Pointee: 4 BaseType uint8
+    - __kind: PointerType
+      ID: 225
+      Name: '*uintptr'
+      ByteSize: 8
+      GoRuntimeType: 388672
+      GoKind: 22
+      Pointee: 62 BaseType uintptr
     - __kind: EventRootType
-      ID: 282
-      Name: Probe[main.testByteArray]
-      ByteSize: 3
+      ID: 369
+      Name: Probe[main.stackC]
+    - __kind: EventRootType
+      ID: 326
+      Name: Probe[main.testAny]
+      ByteSize: 17
       PresenceBitsetSize: 1
       Expressions:
-        - Name: x
+        - Name: a
           Offset: 1
           Expression:
-            Type: 3 ArrayType [2]uint8
+            Type: 41 GoEmptyInterfaceType interface {}
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 7, index: 0, name: x}
+                  Variable: {subprogram: 51, index: 0, name: a}
                   Offset: 0
-                  ByteSize: 2
+                  ByteSize: 16
     - __kind: EventRootType
-      ID: 283
-      Name: Probe[main.testRuneArray]
-      ByteSize: 9
+      ID: 298
+      Name: Probe[main.testArrayOfArraysOfArrays]
+      ByteSize: 65
       PresenceBitsetSize: 1
       Expressions:
-        - Name: x
+        - Name: b
           Offset: 1
           Expression:
-            Type: 5 ArrayType [2]int32
+            Type: 28 ArrayType [2][2][2]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 8, index: 0, name: x}
+                  Variable: {subprogram: 23, index: 0, name: b}
                   Offset: 0
-                  ByteSize: 8
+                  ByteSize: 64
     - __kind: EventRootType
-      ID: 284
-      Name: Probe[main.testStringArray]
+      ID: 296
+      Name: Probe[main.testArrayOfArrays]
       ByteSize: 33
       PresenceBitsetSize: 1
       Expressions:
-        - Name: x
+        - Name: a
+          Offset: 1
+          Expression:
+            Type: 27 ArrayType [2][2]int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 21, index: 0, name: a}
+                  Offset: 0
+                  ByteSize: 32
+    - __kind: EventRootType
+      ID: 334
+      Name: Probe[main.testArrayOfMaps]
+      ByteSize: 17
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: m
+          Offset: 1
+          Expression:
+            Type: 118 ArrayType [2]map[string]int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 59, index: 0, name: m}
+                  Offset: 0
+                  ByteSize: 16
+    - __kind: EventRootType
+      ID: 297
+      Name: Probe[main.testArrayOfStrings]
+      ByteSize: 33
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: a
           Offset: 1
           Expression:
             Type: 7 ArrayType [2]string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 9, index: 0, name: x}
+                  Variable: {subprogram: 22, index: 0, name: a}
                   Offset: 0
                   ByteSize: 32
+    - __kind: EventRootType
+      ID: 316
+      Name: Probe[main.testBigStruct]
+      ByteSize: 49
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: b
+          Offset: 1
+          Expression:
+            Type: 33 StructureType main.bigStruct
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 41, index: 0, name: b}
+                  Offset: 0
+                  ByteSize: 48
     - __kind: EventRootType
       ID: 285
       Name: Probe[main.testBoolArray]
@@ -5980,35 +3678,338 @@ Types:
                   Offset: 0
                   ByteSize: 2
     - __kind: EventRootType
-      ID: 286
-      Name: Probe[main.testIntArray]
-      ByteSize: 17
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: x
-          Offset: 1
-          Expression:
-            Type: 12 ArrayType [2]int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 11, index: 0, name: x}
-                  Offset: 0
-                  ByteSize: 16
-    - __kind: EventRootType
-      ID: 287
-      Name: Probe[main.testInt8Array]
+      ID: 282
+      Name: Probe[main.testByteArray]
       ByteSize: 3
       PresenceBitsetSize: 1
       Expressions:
         - Name: x
           Offset: 1
           Expression:
-            Type: 13 ArrayType [2]int8
+            Type: 3 ArrayType [2]uint8
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 12, index: 0, name: x}
+                  Variable: {subprogram: 7, index: 0, name: x}
                   Offset: 0
                   ByteSize: 2
+    - __kind: EventRootType
+      ID: 350
+      Name: Probe[main.testChannel]
+      ByteSize: 1
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: c
+          Offset: 1
+          Expression:
+            Type: 202 GoChannelType chan bool
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 75, index: 0, name: c}
+                  Offset: 0
+                  ByteSize: 0
+    - __kind: EventRootType
+      ID: 348
+      Name: Probe[main.testCombinedByte]
+      ByteSize: 7
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: w
+          Offset: 1
+          Expression:
+            Type: 4 BaseType uint8
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 73, index: 0, name: w}
+                  Offset: 0
+                  ByteSize: 1
+        - Name: x
+          Offset: 2
+          Expression:
+            Type: 4 BaseType uint8
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 73, index: 1, name: x}
+                  Offset: 0
+                  ByteSize: 1
+        - Name: y
+          Offset: 3
+          Expression:
+            Type: 30 BaseType float32
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 73, index: 2, name: y}
+                  Offset: 0
+                  ByteSize: 4
+    - __kind: EventRootType
+      ID: 358
+      Name: Probe[main.testCycle]
+      ByteSize: 9
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: t
+          Offset: 1
+          Expression:
+            Type: 207 PointerType *main.t
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 83, index: 0, name: t}
+                  Offset: 0
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 363
+      Name: Probe[main.testEmptySliceOfStructs]
+      ByteSize: 33
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: xs
+          Offset: 1
+          Expression:
+            Type: 213 GoSliceHeaderType []main.structWithNoStrings
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 88, index: 0, name: xs}
+                  Offset: 0
+                  ByteSize: 24
+        - Name: a
+          Offset: 25
+          Expression:
+            Type: 1 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 88, index: 1, name: a}
+                  Offset: 0
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 360
+      Name: Probe[main.testEmptySlice]
+      ByteSize: 25
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: u
+          Offset: 1
+          Expression:
+            Type: 210 GoSliceHeaderType []uint
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 85, index: 0, name: u}
+                  Offset: 0
+                  ByteSize: 24
+    - __kind: EventRootType
+      ID: 377
+      Name: Probe[main.testEmptyString]
+      ByteSize: 17
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: x
+          Offset: 1
+          Expression:
+            Type: 8 GoStringHeaderType string
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 102, index: 0, name: x}
+                  Offset: 0
+                  ByteSize: 16
+    - __kind: EventRootType
+      ID: 379
+      Name: Probe[main.testEmptyStruct]
+      ByteSize: 1
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: e
+          Offset: 1
+          Expression:
+            Type: 224 StructureType main.emptyStruct
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 104, index: 0, name: e}
+                  Offset: 0
+                  ByteSize: 0
+    - __kind: EventRootType
+      ID: 327
+      Name: Probe[main.testError]
+      ByteSize: 17
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: e
+          Offset: 1
+          Expression:
+            Type: 57 GoInterfaceType error
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 52, index: 0, name: e}
+                  Offset: 0
+                  ByteSize: 16
+    - __kind: EventRootType
+      ID: 318
+      Name: Probe[main.testEsotericHeap]
+      ByteSize: 9
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: e
+          Offset: 1
+          Expression:
+            Type: 44 PointerType *main.esotericHeap
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 43, index: 0, name: e}
+                  Offset: 0
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 317
+      Name: Probe[main.testEsotericStack]
+      ByteSize: 65
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: e
+          Offset: 1
+          Expression:
+            Type: 39 StructureType main.esotericStack
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 42, index: 0, name: e}
+                  Offset: 0
+                  ByteSize: 64
+    - __kind: EventRootType
+      ID: 324
+      Name: Probe[main.testFramelessArray]
+      ByteSize: 41
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: a
+          Offset: 1
+          Expression:
+            Type: 2 ArrayType [5]int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 49, index: 0, name: a}
+                  Offset: 0
+                  ByteSize: 40
+    - __kind: EventRootType
+      ID: 323
+      Name: Probe[main.testFrameless]
+      ByteSize: 9
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: x
+          Offset: 1
+          Expression:
+            Type: 1 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 48, index: 0, name: x}
+                  Offset: 0
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 319
+      Name: Probe[main.testInlinedBA]
+      ByteSize: 9
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: x
+          Offset: 1
+          Expression:
+            Type: 1 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 44, index: 0, name: x}
+                  Offset: 0
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 321
+      Name: Probe[main.testInlinedBBA]
+      ByteSize: 9
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: x
+          Offset: 1
+          Expression:
+            Type: 1 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 46, index: 0, name: x}
+                  Offset: 0
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 381
+      Name: Probe[main.testInlinedBBB]
+    - __kind: EventRootType
+      ID: 320
+      Name: Probe[main.testInlinedBB]
+      ByteSize: 17
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: x
+          Offset: 1
+          Expression:
+            Type: 1 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 45, index: 0, name: x}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: y
+          Offset: 9
+          Expression:
+            Type: 1 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 45, index: 1, name: y}
+                  Offset: 0
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 382
+      Name: Probe[main.testInlinedBCA]
+    - __kind: EventRootType
+      ID: 383
+      Name: Probe[main.testInlinedBCB]
+    - __kind: EventRootType
+      ID: 322
+      Name: Probe[main.testInlinedBC]
+    - __kind: EventRootType
+      ID: 380
+      Name: Probe[main.testInlinedPrint]
+      ByteSize: 9
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: x
+          Offset: 1
+          Expression:
+            Type: 1 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 1, index: 0, name: x}
+                  Offset: 0
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 384
+      Name: Probe[main.testInlinedSq]
+      ByteSize: 9
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: x
+          Offset: 1
+          Expression:
+            Type: 1 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 5, index: 0, name: x}
+                  Offset: 0
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 385
+      Name: Probe[main.testInlinedSumArray]
+      ByteSize: 41
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: a
+          Offset: 1
+          Expression:
+            Type: 2 ArrayType [5]int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 6, index: 0, name: a}
+                  Offset: 0
+                  ByteSize: 40
     - __kind: EventRootType
       ID: 288
       Name: Probe[main.testInt16Array]
@@ -6055,512 +4056,35 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 291
-      Name: Probe[main.testUintArray]
+      ID: 287
+      Name: Probe[main.testInt8Array]
+      ByteSize: 3
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: x
+          Offset: 1
+          Expression:
+            Type: 13 ArrayType [2]int8
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 12, index: 0, name: x}
+                  Offset: 0
+                  ByteSize: 2
+    - __kind: EventRootType
+      ID: 286
+      Name: Probe[main.testIntArray]
       ByteSize: 17
       PresenceBitsetSize: 1
       Expressions:
         - Name: x
           Offset: 1
           Expression:
-            Type: 19 ArrayType [2]uint
+            Type: 12 ArrayType [2]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 16, index: 0, name: x}
+                  Variable: {subprogram: 11, index: 0, name: x}
                   Offset: 0
                   ByteSize: 16
-    - __kind: EventRootType
-      ID: 292
-      Name: Probe[main.testUint8Array]
-      ByteSize: 3
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: x
-          Offset: 1
-          Expression:
-            Type: 3 ArrayType [2]uint8
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 17, index: 0, name: x}
-                  Offset: 0
-                  ByteSize: 2
-    - __kind: EventRootType
-      ID: 293
-      Name: Probe[main.testUint16Array]
-      ByteSize: 5
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: x
-          Offset: 1
-          Expression:
-            Type: 21 ArrayType [2]uint16
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 18, index: 0, name: x}
-                  Offset: 0
-                  ByteSize: 4
-    - __kind: EventRootType
-      ID: 294
-      Name: Probe[main.testUint32Array]
-      ByteSize: 9
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: x
-          Offset: 1
-          Expression:
-            Type: 23 ArrayType [2]uint32
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 19, index: 0, name: x}
-                  Offset: 0
-                  ByteSize: 8
-    - __kind: EventRootType
-      ID: 295
-      Name: Probe[main.testUint64Array]
-      ByteSize: 17
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: x
-          Offset: 1
-          Expression:
-            Type: 25 ArrayType [2]uint64
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 20, index: 0, name: x}
-                  Offset: 0
-                  ByteSize: 16
-    - __kind: EventRootType
-      ID: 296
-      Name: Probe[main.testArrayOfArrays]
-      ByteSize: 33
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: a
-          Offset: 1
-          Expression:
-            Type: 27 ArrayType [2][2]int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 21, index: 0, name: a}
-                  Offset: 0
-                  ByteSize: 32
-    - __kind: EventRootType
-      ID: 297
-      Name: Probe[main.testArrayOfStrings]
-      ByteSize: 33
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: a
-          Offset: 1
-          Expression:
-            Type: 7 ArrayType [2]string
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 22, index: 0, name: a}
-                  Offset: 0
-                  ByteSize: 32
-    - __kind: EventRootType
-      ID: 298
-      Name: Probe[main.testArrayOfArraysOfArrays]
-      ByteSize: 65
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: b
-          Offset: 1
-          Expression:
-            Type: 28 ArrayType [2][2][2]int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 23, index: 0, name: b}
-                  Offset: 0
-                  ByteSize: 64
-    - __kind: EventRootType
-      ID: 299
-      Name: Probe[main.testVeryLargeArray]
-      ByteSize: 801
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: a
-          Offset: 1
-          Expression:
-            Type: 29 ArrayType [100]uint
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 24, index: 0, name: a}
-                  Offset: 0
-                  ByteSize: 800
-    - __kind: EventRootType
-      ID: 300
-      Name: Probe[main.testSingleByte]
-      ByteSize: 2
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: x
-          Offset: 1
-          Expression:
-            Type: 4 BaseType uint8
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 25, index: 0, name: x}
-                  Offset: 0
-                  ByteSize: 1
-    - __kind: EventRootType
-      ID: 301
-      Name: Probe[main.testSingleRune]
-      ByteSize: 5
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: x
-          Offset: 1
-          Expression:
-            Type: 6 BaseType int32
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 26, index: 0, name: x}
-                  Offset: 0
-                  ByteSize: 4
-    - __kind: EventRootType
-      ID: 302
-      Name: Probe[main.testSingleBool]
-      ByteSize: 2
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: x
-          Offset: 1
-          Expression:
-            Type: 11 BaseType bool
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 27, index: 0, name: x}
-                  Offset: 0
-                  ByteSize: 1
-    - __kind: EventRootType
-      ID: 303
-      Name: Probe[main.testSingleInt]
-      ByteSize: 9
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: x
-          Offset: 1
-          Expression:
-            Type: 1 BaseType int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 28, index: 0, name: x}
-                  Offset: 0
-                  ByteSize: 8
-    - __kind: EventRootType
-      ID: 304
-      Name: Probe[main.testSingleInt8]
-      ByteSize: 2
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: x
-          Offset: 1
-          Expression:
-            Type: 14 BaseType int8
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 29, index: 0, name: x}
-                  Offset: 0
-                  ByteSize: 1
-    - __kind: EventRootType
-      ID: 305
-      Name: Probe[main.testSingleInt16]
-      ByteSize: 3
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: x
-          Offset: 1
-          Expression:
-            Type: 16 BaseType int16
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 30, index: 0, name: x}
-                  Offset: 0
-                  ByteSize: 2
-    - __kind: EventRootType
-      ID: 306
-      Name: Probe[main.testSingleInt32]
-      ByteSize: 5
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: x
-          Offset: 1
-          Expression:
-            Type: 6 BaseType int32
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 31, index: 0, name: x}
-                  Offset: 0
-                  ByteSize: 4
-    - __kind: EventRootType
-      ID: 307
-      Name: Probe[main.testSingleInt64]
-      ByteSize: 9
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: x
-          Offset: 1
-          Expression:
-            Type: 18 BaseType int64
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 32, index: 0, name: x}
-                  Offset: 0
-                  ByteSize: 8
-    - __kind: EventRootType
-      ID: 308
-      Name: Probe[main.testSingleUint]
-      ByteSize: 9
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: x
-          Offset: 1
-          Expression:
-            Type: 20 BaseType uint
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 33, index: 0, name: x}
-                  Offset: 0
-                  ByteSize: 8
-    - __kind: EventRootType
-      ID: 309
-      Name: Probe[main.testSingleUint8]
-      ByteSize: 2
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: x
-          Offset: 1
-          Expression:
-            Type: 4 BaseType uint8
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 34, index: 0, name: x}
-                  Offset: 0
-                  ByteSize: 1
-    - __kind: EventRootType
-      ID: 310
-      Name: Probe[main.testSingleUint16]
-      ByteSize: 3
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: x
-          Offset: 1
-          Expression:
-            Type: 22 BaseType uint16
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 35, index: 0, name: x}
-                  Offset: 0
-                  ByteSize: 2
-    - __kind: EventRootType
-      ID: 311
-      Name: Probe[main.testSingleUint32]
-      ByteSize: 5
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: x
-          Offset: 1
-          Expression:
-            Type: 24 BaseType uint32
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 36, index: 0, name: x}
-                  Offset: 0
-                  ByteSize: 4
-    - __kind: EventRootType
-      ID: 312
-      Name: Probe[main.testSingleUint64]
-      ByteSize: 9
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: x
-          Offset: 1
-          Expression:
-            Type: 26 BaseType uint64
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 37, index: 0, name: x}
-                  Offset: 0
-                  ByteSize: 8
-    - __kind: EventRootType
-      ID: 313
-      Name: Probe[main.testSingleFloat32]
-      ByteSize: 5
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: x
-          Offset: 1
-          Expression:
-            Type: 30 BaseType float32
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 38, index: 0, name: x}
-                  Offset: 0
-                  ByteSize: 4
-    - __kind: EventRootType
-      ID: 314
-      Name: Probe[main.testSingleFloat64]
-      ByteSize: 9
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: x
-          Offset: 1
-          Expression:
-            Type: 31 BaseType float64
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 39, index: 0, name: x}
-                  Offset: 0
-                  ByteSize: 8
-    - __kind: EventRootType
-      ID: 315
-      Name: Probe[main.testTypeAlias]
-      ByteSize: 3
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: x
-          Offset: 1
-          Expression:
-            Type: 32 BaseType main.typeAlias
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 40, index: 0, name: x}
-                  Offset: 0
-                  ByteSize: 2
-    - __kind: EventRootType
-      ID: 316
-      Name: Probe[main.testBigStruct]
-      ByteSize: 49
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: b
-          Offset: 1
-          Expression:
-            Type: 33 StructureType main.bigStruct
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 41, index: 0, name: b}
-                  Offset: 0
-                  ByteSize: 48
-    - __kind: EventRootType
-      ID: 317
-      Name: Probe[main.testEsotericStack]
-      ByteSize: 65
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: e
-          Offset: 1
-          Expression:
-            Type: 39 StructureType main.esotericStack
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 42, index: 0, name: e}
-                  Offset: 0
-                  ByteSize: 64
-    - __kind: EventRootType
-      ID: 318
-      Name: Probe[main.testEsotericHeap]
-      ByteSize: 9
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: e
-          Offset: 1
-          Expression:
-            Type: 44 PointerType *main.esotericHeap
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 43, index: 0, name: e}
-                  Offset: 0
-                  ByteSize: 8
-    - __kind: EventRootType
-      ID: 319
-      Name: Probe[main.testInlinedBA]
-      ByteSize: 9
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: x
-          Offset: 1
-          Expression:
-            Type: 1 BaseType int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 44, index: 0, name: x}
-                  Offset: 0
-                  ByteSize: 8
-    - __kind: EventRootType
-      ID: 320
-      Name: Probe[main.testInlinedBB]
-      ByteSize: 17
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: x
-          Offset: 1
-          Expression:
-            Type: 1 BaseType int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 45, index: 0, name: x}
-                  Offset: 0
-                  ByteSize: 8
-        - Name: y
-          Offset: 9
-          Expression:
-            Type: 1 BaseType int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 45, index: 1, name: y}
-                  Offset: 0
-                  ByteSize: 8
-    - __kind: EventRootType
-      ID: 321
-      Name: Probe[main.testInlinedBBA]
-      ByteSize: 9
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: x
-          Offset: 1
-          Expression:
-            Type: 1 BaseType int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 46, index: 0, name: x}
-                  Offset: 0
-                  ByteSize: 8
-    - __kind: EventRootType
-      ID: 322
-      Name: Probe[main.testInlinedBC]
-    - __kind: EventRootType
-      ID: 323
-      Name: Probe[main.testFrameless]
-      ByteSize: 9
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: x
-          Offset: 1
-          Expression:
-            Type: 1 BaseType int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 48, index: 0, name: x}
-                  Offset: 0
-                  ByteSize: 8
-    - __kind: EventRootType
-      ID: 324
-      Name: Probe[main.testFramelessArray]
-      ByteSize: 41
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: a
-          Offset: 1
-          Expression:
-            Type: 2 ArrayType [5]int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 49, index: 0, name: a}
-                  Offset: 0
-                  ByteSize: 40
     - __kind: EventRootType
       ID: 325
       Name: Probe[main.testInterface]
@@ -6577,63 +4101,138 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 326
-      Name: Probe[main.testAny]
+      ID: 352
+      Name: Probe[main.testLinkedList]
       ByteSize: 17
       PresenceBitsetSize: 1
       Expressions:
         - Name: a
           Offset: 1
           Expression:
-            Type: 41 GoEmptyInterfaceType interface {}
+            Type: 144 StructureType main.node
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 51, index: 0, name: a}
+                  Variable: {subprogram: 77, index: 0, name: a}
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 327
-      Name: Probe[main.testError]
-      ByteSize: 17
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: e
-          Offset: 1
-          Expression:
-            Type: 57 GoInterfaceType error
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 52, index: 0, name: e}
-                  Offset: 0
-                  ByteSize: 16
-    - __kind: EventRootType
-      ID: 328
-      Name: Probe[main.testStructWithMap]
-      ByteSize: 9
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: s
-          Offset: 1
-          Expression:
-            Type: 58 StructureType main.structWithMap
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 53, index: 0, name: s}
-                  Offset: 0
-                  ByteSize: 8
-    - __kind: EventRootType
-      ID: 329
-      Name: Probe[main.testMapStringToStruct]
+      ID: 332
+      Name: Probe[main.testMapArrayToArray]
       ByteSize: 9
       PresenceBitsetSize: 1
       Expressions:
         - Name: m
           Offset: 1
           Expression:
-            Type: 71 GoMapType map[string]main.nestedStruct
+            Type: 106 GoMapType map[[4]string][2]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 54, index: 0, name: m}
+                  Variable: {subprogram: 57, index: 0, name: m}
+                  Offset: 0
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 338
+      Name: Probe[main.testMapEmbeddedMaps]
+      ByteSize: 9
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: m
+          Offset: 1
+          Expression:
+            Type: 120 GoMapType map[string][]main.structWithMap
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 63, index: 0, name: m}
+                  Offset: 0
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 336
+      Name: Probe[main.testMapIntToInt]
+      ByteSize: 9
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: m
+          Offset: 1
+          Expression:
+            Type: 59 GoMapType map[int]int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 61, index: 0, name: m}
+                  Offset: 0
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 347
+      Name: Probe[main.testMapLargeKeyLargeValue]
+      ByteSize: 9
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: m
+          Offset: 1
+          Expression:
+            Type: 191 GoMapType map[[4]int][4]int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 72, index: 0, name: m}
+                  Offset: 0
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 346
+      Name: Probe[main.testMapLargeKeySmallValue]
+      ByteSize: 9
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: m
+          Offset: 1
+          Expression:
+            Type: 180 GoMapType map[[4]int]uint8
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 71, index: 0, name: m}
+                  Offset: 0
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 337
+      Name: Probe[main.testMapMassive]
+      ByteSize: 9
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: redactMyEntries
+          Offset: 1
+          Expression:
+            Type: 120 GoMapType map[string][]main.structWithMap
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 62, index: 0, name: redactMyEntries}
+                  Offset: 0
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 345
+      Name: Probe[main.testMapSmallKeyLargeValue]
+      ByteSize: 9
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: m
+          Offset: 1
+          Expression:
+            Type: 168 GoMapType map[uint8][4]int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 70, index: 0, name: m}
+                  Offset: 0
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 344
+      Name: Probe[main.testMapSmallKeySmallValue]
+      ByteSize: 9
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: m
+          Offset: 1
+          Expression:
+            Type: 157 GoMapType map[uint8]uint8
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 69, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
@@ -6667,108 +4266,18 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 332
-      Name: Probe[main.testMapArrayToArray]
+      ID: 329
+      Name: Probe[main.testMapStringToStruct]
       ByteSize: 9
       PresenceBitsetSize: 1
       Expressions:
         - Name: m
           Offset: 1
           Expression:
-            Type: 106 GoMapType map[[4]string][2]int
+            Type: 71 GoMapType map[string]main.nestedStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 57, index: 0, name: m}
-                  Offset: 0
-                  ByteSize: 8
-    - __kind: EventRootType
-      ID: 333
-      Name: Probe[main.testSmallMap]
-      ByteSize: 9
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: m
-          Offset: 1
-          Expression:
-            Type: 83 GoMapType map[string]int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 58, index: 0, name: m}
-                  Offset: 0
-                  ByteSize: 8
-    - __kind: EventRootType
-      ID: 334
-      Name: Probe[main.testArrayOfMaps]
-      ByteSize: 17
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: m
-          Offset: 1
-          Expression:
-            Type: 118 ArrayType [2]map[string]int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 59, index: 0, name: m}
-                  Offset: 0
-                  ByteSize: 16
-    - __kind: EventRootType
-      ID: 335
-      Name: Probe[main.testPointerToMap]
-      ByteSize: 9
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: m
-          Offset: 1
-          Expression:
-            Type: 119 PointerType *map[string]int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 60, index: 0, name: m}
-                  Offset: 0
-                  ByteSize: 8
-    - __kind: EventRootType
-      ID: 336
-      Name: Probe[main.testMapIntToInt]
-      ByteSize: 9
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: m
-          Offset: 1
-          Expression:
-            Type: 59 GoMapType map[int]int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 61, index: 0, name: m}
-                  Offset: 0
-                  ByteSize: 8
-    - __kind: EventRootType
-      ID: 337
-      Name: Probe[main.testMapMassive]
-      ByteSize: 9
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: redactMyEntries
-          Offset: 1
-          Expression:
-            Type: 120 GoMapType map[string][]main.structWithMap
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 62, index: 0, name: redactMyEntries}
-                  Offset: 0
-                  ByteSize: 8
-    - __kind: EventRootType
-      ID: 338
-      Name: Probe[main.testMapEmbeddedMaps]
-      ByteSize: 9
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: m
-          Offset: 1
-          Expression:
-            Type: 120 GoMapType map[string][]main.structWithMap
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 63, index: 0, name: m}
+                  Variable: {subprogram: 54, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
@@ -6787,33 +4296,18 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 340
-      Name: Probe[main.testMapWithSmallValue]
+      ID: 343
+      Name: Probe[main.testMapWithSmallKeyAndValueMassive]
       ByteSize: 9
       PresenceBitsetSize: 1
       Expressions:
         - Name: m
           Offset: 1
           Expression:
-            Type: 146 GoMapType map[int]uint8
+            Type: 157 GoMapType map[uint8]uint8
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 65, index: 0, name: m}
-                  Offset: 0
-                  ByteSize: 8
-    - __kind: EventRootType
-      ID: 341
-      Name: Probe[main.testMapWithSmallValueMassive]
-      ByteSize: 9
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: redactMyEntries
-          Offset: 1
-          Expression:
-            Type: 146 GoMapType map[int]uint8
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 66, index: 0, name: redactMyEntries}
+                  Variable: {subprogram: 68, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
@@ -6832,113 +4326,50 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 343
-      Name: Probe[main.testMapWithSmallKeyAndValueMassive]
+      ID: 341
+      Name: Probe[main.testMapWithSmallValueMassive]
+      ByteSize: 9
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: redactMyEntries
+          Offset: 1
+          Expression:
+            Type: 146 GoMapType map[int]uint8
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 66, index: 0, name: redactMyEntries}
+                  Offset: 0
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 340
+      Name: Probe[main.testMapWithSmallValue]
       ByteSize: 9
       PresenceBitsetSize: 1
       Expressions:
         - Name: m
           Offset: 1
           Expression:
-            Type: 157 GoMapType map[uint8]uint8
+            Type: 146 GoMapType map[int]uint8
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 68, index: 0, name: m}
+                  Variable: {subprogram: 65, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 344
-      Name: Probe[main.testMapSmallKeySmallValue]
-      ByteSize: 9
+      ID: 375
+      Name: Probe[main.testMassiveString]
+      ByteSize: 17
       PresenceBitsetSize: 1
       Expressions:
-        - Name: m
-          Offset: 1
-          Expression:
-            Type: 157 GoMapType map[uint8]uint8
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 69, index: 0, name: m}
-                  Offset: 0
-                  ByteSize: 8
-    - __kind: EventRootType
-      ID: 345
-      Name: Probe[main.testMapSmallKeyLargeValue]
-      ByteSize: 9
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: m
-          Offset: 1
-          Expression:
-            Type: 168 GoMapType map[uint8][4]int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 70, index: 0, name: m}
-                  Offset: 0
-                  ByteSize: 8
-    - __kind: EventRootType
-      ID: 346
-      Name: Probe[main.testMapLargeKeySmallValue]
-      ByteSize: 9
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: m
-          Offset: 1
-          Expression:
-            Type: 180 GoMapType map[[4]int]uint8
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 71, index: 0, name: m}
-                  Offset: 0
-                  ByteSize: 8
-    - __kind: EventRootType
-      ID: 347
-      Name: Probe[main.testMapLargeKeyLargeValue]
-      ByteSize: 9
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: m
-          Offset: 1
-          Expression:
-            Type: 191 GoMapType map[[4]int][4]int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 72, index: 0, name: m}
-                  Offset: 0
-                  ByteSize: 8
-    - __kind: EventRootType
-      ID: 348
-      Name: Probe[main.testCombinedByte]
-      ByteSize: 7
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: w
-          Offset: 1
-          Expression:
-            Type: 4 BaseType uint8
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 73, index: 0, name: w}
-                  Offset: 0
-                  ByteSize: 1
         - Name: x
-          Offset: 2
+          Offset: 1
           Expression:
-            Type: 4 BaseType uint8
+            Type: 8 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 73, index: 1, name: x}
+                  Variable: {subprogram: 100, index: 0, name: x}
                   Offset: 0
-                  ByteSize: 1
-        - Name: y
-          Offset: 3
-          Expression:
-            Type: 30 BaseType float32
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 73, index: 2, name: y}
-                  Offset: 0
-                  ByteSize: 4
+                  ByteSize: 16
     - __kind: EventRootType
       ID: 349
       Name: Probe[main.testMultipleSimpleParams]
@@ -6991,111 +4422,6 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 350
-      Name: Probe[main.testChannel]
-      ByteSize: 1
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: c
-          Offset: 1
-          Expression:
-            Type: 202 GoChannelType chan bool
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 75, index: 0, name: c}
-                  Offset: 0
-                  ByteSize: 0
-    - __kind: EventRootType
-      ID: 351
-      Name: Probe[main.testPointerToSimpleStruct]
-      ByteSize: 9
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: a
-          Offset: 1
-          Expression:
-            Type: 203 PointerType *main.structWithTwoValues
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 76, index: 0, name: a}
-                  Offset: 0
-                  ByteSize: 8
-    - __kind: EventRootType
-      ID: 352
-      Name: Probe[main.testLinkedList]
-      ByteSize: 17
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: a
-          Offset: 1
-          Expression:
-            Type: 144 StructureType main.node
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 77, index: 0, name: a}
-                  Offset: 0
-                  ByteSize: 16
-    - __kind: EventRootType
-      ID: 353
-      Name: Probe[main.testPointerLoop]
-      ByteSize: 9
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: a
-          Offset: 1
-          Expression:
-            Type: 145 PointerType *main.node
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 78, index: 0, name: a}
-                  Offset: 0
-                  ByteSize: 8
-    - __kind: EventRootType
-      ID: 354
-      Name: Probe[main.testUnsafePointer]
-      ByteSize: 9
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: x
-          Offset: 1
-          Expression:
-            Type: 38 VoidPointerType unsafe.Pointer
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 79, index: 0, name: x}
-                  Offset: 0
-                  ByteSize: 8
-    - __kind: EventRootType
-      ID: 355
-      Name: Probe[main.testUintPointer]
-      ByteSize: 9
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: x
-          Offset: 1
-          Expression:
-            Type: 205 PointerType *uint
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 80, index: 0, name: x}
-                  Offset: 0
-                  ByteSize: 8
-    - __kind: EventRootType
-      ID: 356
-      Name: Probe[main.testStringPointer]
-      ByteSize: 9
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: z
-          Offset: 1
-          Expression:
-            Type: 36 PointerType *string
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 81, index: 0, name: z}
-                  Offset: 0
-                  ByteSize: 8
-    - __kind: EventRootType
       ID: 357
       Name: Probe[main.testNilPointer]
       ByteSize: 17
@@ -7117,114 +4443,6 @@ Types:
             Operations:
                 - __kind: LocationOp
                   Variable: {subprogram: 82, index: 1, name: a}
-                  Offset: 0
-                  ByteSize: 8
-    - __kind: EventRootType
-      ID: 358
-      Name: Probe[main.testCycle]
-      ByteSize: 9
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: t
-          Offset: 1
-          Expression:
-            Type: 207 PointerType *main.t
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 83, index: 0, name: t}
-                  Offset: 0
-                  ByteSize: 8
-    - __kind: EventRootType
-      ID: 359
-      Name: Probe[main.testUintSlice]
-      ByteSize: 25
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: u
-          Offset: 1
-          Expression:
-            Type: 210 GoSliceHeaderType []uint
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 84, index: 0, name: u}
-                  Offset: 0
-                  ByteSize: 24
-    - __kind: EventRootType
-      ID: 360
-      Name: Probe[main.testEmptySlice]
-      ByteSize: 25
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: u
-          Offset: 1
-          Expression:
-            Type: 210 GoSliceHeaderType []uint
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 85, index: 0, name: u}
-                  Offset: 0
-                  ByteSize: 24
-    - __kind: EventRootType
-      ID: 361
-      Name: Probe[main.testSliceOfSlices]
-      ByteSize: 25
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: u
-          Offset: 1
-          Expression:
-            Type: 211 GoSliceHeaderType [][]uint
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 86, index: 0, name: u}
-                  Offset: 0
-                  ByteSize: 24
-    - __kind: EventRootType
-      ID: 362
-      Name: Probe[main.testStructSlice]
-      ByteSize: 33
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: xs
-          Offset: 1
-          Expression:
-            Type: 213 GoSliceHeaderType []main.structWithNoStrings
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 87, index: 0, name: xs}
-                  Offset: 0
-                  ByteSize: 24
-        - Name: a
-          Offset: 25
-          Expression:
-            Type: 1 BaseType int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 87, index: 1, name: a}
-                  Offset: 0
-                  ByteSize: 8
-    - __kind: EventRootType
-      ID: 363
-      Name: Probe[main.testEmptySliceOfStructs]
-      ByteSize: 33
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: xs
-          Offset: 1
-          Expression:
-            Type: 213 GoSliceHeaderType []main.structWithNoStrings
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 88, index: 0, name: xs}
-                  Offset: 0
-                  ByteSize: 24
-        - Name: a
-          Offset: 25
-          Expression:
-            Type: 1 BaseType int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 88, index: 1, name: a}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
@@ -7251,21 +4469,6 @@ Types:
                   Variable: {subprogram: 89, index: 1, name: a}
                   Offset: 0
                   ByteSize: 8
-    - __kind: EventRootType
-      ID: 365
-      Name: Probe[main.testStringSlice]
-      ByteSize: 25
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: s
-          Offset: 1
-          Expression:
-            Type: 105 GoSliceHeaderType []string
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 90, index: 0, name: s}
-                  Offset: 0
-                  ByteSize: 24
     - __kind: EventRootType
       ID: 366
       Name: Probe[main.testNilSliceWithOtherParams]
@@ -7315,23 +4518,230 @@ Types:
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 368
-      Name: Probe[main.testVeryLargeSlice]
-      ByteSize: 25
+      ID: 374
+      Name: Probe[main.testOneStringInStructPointer]
+      ByteSize: 9
       PresenceBitsetSize: 1
       Expressions:
-        - Name: xs
+        - Name: a
           Offset: 1
           Expression:
-            Type: 210 GoSliceHeaderType []uint
+            Type: 221 PointerType *main.oneStringStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 93, index: 0, name: xs}
+                  Variable: {subprogram: 99, index: 0, name: a}
                   Offset: 0
-                  ByteSize: 24
+                  ByteSize: 8
     - __kind: EventRootType
-      ID: 369
-      Name: Probe[main.stackC]
+      ID: 353
+      Name: Probe[main.testPointerLoop]
+      ByteSize: 9
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: a
+          Offset: 1
+          Expression:
+            Type: 145 PointerType *main.node
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 78, index: 0, name: a}
+                  Offset: 0
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 335
+      Name: Probe[main.testPointerToMap]
+      ByteSize: 9
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: m
+          Offset: 1
+          Expression:
+            Type: 119 PointerType *map[string]int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 60, index: 0, name: m}
+                  Offset: 0
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 351
+      Name: Probe[main.testPointerToSimpleStruct]
+      ByteSize: 9
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: a
+          Offset: 1
+          Expression:
+            Type: 203 PointerType *main.structWithTwoValues
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 76, index: 0, name: a}
+                  Offset: 0
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 283
+      Name: Probe[main.testRuneArray]
+      ByteSize: 9
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: x
+          Offset: 1
+          Expression:
+            Type: 5 ArrayType [2]int32
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 8, index: 0, name: x}
+                  Offset: 0
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 302
+      Name: Probe[main.testSingleBool]
+      ByteSize: 2
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: x
+          Offset: 1
+          Expression:
+            Type: 11 BaseType bool
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 27, index: 0, name: x}
+                  Offset: 0
+                  ByteSize: 1
+    - __kind: EventRootType
+      ID: 300
+      Name: Probe[main.testSingleByte]
+      ByteSize: 2
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: x
+          Offset: 1
+          Expression:
+            Type: 4 BaseType uint8
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 25, index: 0, name: x}
+                  Offset: 0
+                  ByteSize: 1
+    - __kind: EventRootType
+      ID: 313
+      Name: Probe[main.testSingleFloat32]
+      ByteSize: 5
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: x
+          Offset: 1
+          Expression:
+            Type: 30 BaseType float32
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 38, index: 0, name: x}
+                  Offset: 0
+                  ByteSize: 4
+    - __kind: EventRootType
+      ID: 314
+      Name: Probe[main.testSingleFloat64]
+      ByteSize: 9
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: x
+          Offset: 1
+          Expression:
+            Type: 31 BaseType float64
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 39, index: 0, name: x}
+                  Offset: 0
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 305
+      Name: Probe[main.testSingleInt16]
+      ByteSize: 3
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: x
+          Offset: 1
+          Expression:
+            Type: 16 BaseType int16
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 30, index: 0, name: x}
+                  Offset: 0
+                  ByteSize: 2
+    - __kind: EventRootType
+      ID: 306
+      Name: Probe[main.testSingleInt32]
+      ByteSize: 5
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: x
+          Offset: 1
+          Expression:
+            Type: 6 BaseType int32
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 31, index: 0, name: x}
+                  Offset: 0
+                  ByteSize: 4
+    - __kind: EventRootType
+      ID: 307
+      Name: Probe[main.testSingleInt64]
+      ByteSize: 9
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: x
+          Offset: 1
+          Expression:
+            Type: 18 BaseType int64
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 32, index: 0, name: x}
+                  Offset: 0
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 304
+      Name: Probe[main.testSingleInt8]
+      ByteSize: 2
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: x
+          Offset: 1
+          Expression:
+            Type: 14 BaseType int8
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 29, index: 0, name: x}
+                  Offset: 0
+                  ByteSize: 1
+    - __kind: EventRootType
+      ID: 303
+      Name: Probe[main.testSingleInt]
+      ByteSize: 9
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: x
+          Offset: 1
+          Expression:
+            Type: 1 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 28, index: 0, name: x}
+                  Offset: 0
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 301
+      Name: Probe[main.testSingleRune]
+      ByteSize: 5
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: x
+          Offset: 1
+          Expression:
+            Type: 6 BaseType int32
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 26, index: 0, name: x}
+                  Offset: 0
+                  ByteSize: 4
     - __kind: EventRootType
       ID: 370
       Name: Probe[main.testSingleString]
@@ -7347,6 +4757,240 @@ Types:
                   Variable: {subprogram: 95, index: 0, name: x}
                   Offset: 0
                   ByteSize: 16
+    - __kind: EventRootType
+      ID: 310
+      Name: Probe[main.testSingleUint16]
+      ByteSize: 3
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: x
+          Offset: 1
+          Expression:
+            Type: 22 BaseType uint16
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 35, index: 0, name: x}
+                  Offset: 0
+                  ByteSize: 2
+    - __kind: EventRootType
+      ID: 311
+      Name: Probe[main.testSingleUint32]
+      ByteSize: 5
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: x
+          Offset: 1
+          Expression:
+            Type: 24 BaseType uint32
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 36, index: 0, name: x}
+                  Offset: 0
+                  ByteSize: 4
+    - __kind: EventRootType
+      ID: 312
+      Name: Probe[main.testSingleUint64]
+      ByteSize: 9
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: x
+          Offset: 1
+          Expression:
+            Type: 26 BaseType uint64
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 37, index: 0, name: x}
+                  Offset: 0
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 309
+      Name: Probe[main.testSingleUint8]
+      ByteSize: 2
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: x
+          Offset: 1
+          Expression:
+            Type: 4 BaseType uint8
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 34, index: 0, name: x}
+                  Offset: 0
+                  ByteSize: 1
+    - __kind: EventRootType
+      ID: 308
+      Name: Probe[main.testSingleUint]
+      ByteSize: 9
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: x
+          Offset: 1
+          Expression:
+            Type: 20 BaseType uint
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 33, index: 0, name: x}
+                  Offset: 0
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 361
+      Name: Probe[main.testSliceOfSlices]
+      ByteSize: 25
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: u
+          Offset: 1
+          Expression:
+            Type: 211 GoSliceHeaderType [][]uint
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 86, index: 0, name: u}
+                  Offset: 0
+                  ByteSize: 24
+    - __kind: EventRootType
+      ID: 333
+      Name: Probe[main.testSmallMap]
+      ByteSize: 9
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: m
+          Offset: 1
+          Expression:
+            Type: 83 GoMapType map[string]int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 58, index: 0, name: m}
+                  Offset: 0
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 284
+      Name: Probe[main.testStringArray]
+      ByteSize: 33
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: x
+          Offset: 1
+          Expression:
+            Type: 7 ArrayType [2]string
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 9, index: 0, name: x}
+                  Offset: 0
+                  ByteSize: 32
+    - __kind: EventRootType
+      ID: 356
+      Name: Probe[main.testStringPointer]
+      ByteSize: 9
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: z
+          Offset: 1
+          Expression:
+            Type: 36 PointerType *string
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 81, index: 0, name: z}
+                  Offset: 0
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 365
+      Name: Probe[main.testStringSlice]
+      ByteSize: 25
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: s
+          Offset: 1
+          Expression:
+            Type: 105 GoSliceHeaderType []string
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 90, index: 0, name: s}
+                  Offset: 0
+                  ByteSize: 24
+    - __kind: EventRootType
+      ID: 362
+      Name: Probe[main.testStructSlice]
+      ByteSize: 33
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: xs
+          Offset: 1
+          Expression:
+            Type: 213 GoSliceHeaderType []main.structWithNoStrings
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 87, index: 0, name: xs}
+                  Offset: 0
+                  ByteSize: 24
+        - Name: a
+          Offset: 25
+          Expression:
+            Type: 1 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 87, index: 1, name: a}
+                  Offset: 0
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 328
+      Name: Probe[main.testStructWithMap]
+      ByteSize: 9
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: s
+          Offset: 1
+          Expression:
+            Type: 58 StructureType main.structWithMap
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 53, index: 0, name: s}
+                  Offset: 0
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 378
+      Name: Probe[main.testStruct]
+      ByteSize: 57
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: x
+          Offset: 1
+          Expression:
+            Type: 223 StructureType main.aStruct
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 103, index: 0, name: x}
+                  Offset: 0
+                  ByteSize: 56
+    - __kind: EventRootType
+      ID: 373
+      Name: Probe[main.testThreeStringsInStructPointer]
+      ByteSize: 9
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: a
+          Offset: 1
+          Expression:
+            Type: 220 PointerType *main.threeStringStruct
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 98, index: 0, name: a}
+                  Offset: 0
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 372
+      Name: Probe[main.testThreeStringsInStruct]
+      ByteSize: 49
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: a
+          Offset: 1
+          Expression:
+            Type: 219 StructureType main.threeStringStruct
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 97, index: 0, name: a}
+                  Offset: 0
+                  ByteSize: 48
     - __kind: EventRootType
       ID: 371
       Name: Probe[main.testThreeStrings]
@@ -7381,65 +5025,125 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 372
-      Name: Probe[main.testThreeStringsInStruct]
-      ByteSize: 49
+      ID: 315
+      Name: Probe[main.testTypeAlias]
+      ByteSize: 3
       PresenceBitsetSize: 1
       Expressions:
-        - Name: a
+        - Name: x
           Offset: 1
           Expression:
-            Type: 219 StructureType main.threeStringStruct
+            Type: 32 BaseType main.typeAlias
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 97, index: 0, name: a}
+                  Variable: {subprogram: 40, index: 0, name: x}
                   Offset: 0
-                  ByteSize: 48
+                  ByteSize: 2
     - __kind: EventRootType
-      ID: 373
-      Name: Probe[main.testThreeStringsInStructPointer]
+      ID: 293
+      Name: Probe[main.testUint16Array]
+      ByteSize: 5
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: x
+          Offset: 1
+          Expression:
+            Type: 21 ArrayType [2]uint16
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 18, index: 0, name: x}
+                  Offset: 0
+                  ByteSize: 4
+    - __kind: EventRootType
+      ID: 294
+      Name: Probe[main.testUint32Array]
       ByteSize: 9
       PresenceBitsetSize: 1
       Expressions:
-        - Name: a
+        - Name: x
           Offset: 1
           Expression:
-            Type: 220 PointerType *main.threeStringStruct
+            Type: 23 ArrayType [2]uint32
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 98, index: 0, name: a}
+                  Variable: {subprogram: 19, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 374
-      Name: Probe[main.testOneStringInStructPointer]
-      ByteSize: 9
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: a
-          Offset: 1
-          Expression:
-            Type: 221 PointerType *main.oneStringStruct
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 99, index: 0, name: a}
-                  Offset: 0
-                  ByteSize: 8
-    - __kind: EventRootType
-      ID: 375
-      Name: Probe[main.testMassiveString]
+      ID: 295
+      Name: Probe[main.testUint64Array]
       ByteSize: 17
       PresenceBitsetSize: 1
       Expressions:
         - Name: x
           Offset: 1
           Expression:
-            Type: 8 GoStringHeaderType string
+            Type: 25 ArrayType [2]uint64
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 100, index: 0, name: x}
+                  Variable: {subprogram: 20, index: 0, name: x}
                   Offset: 0
                   ByteSize: 16
+    - __kind: EventRootType
+      ID: 292
+      Name: Probe[main.testUint8Array]
+      ByteSize: 3
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: x
+          Offset: 1
+          Expression:
+            Type: 3 ArrayType [2]uint8
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 17, index: 0, name: x}
+                  Offset: 0
+                  ByteSize: 2
+    - __kind: EventRootType
+      ID: 291
+      Name: Probe[main.testUintArray]
+      ByteSize: 17
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: x
+          Offset: 1
+          Expression:
+            Type: 19 ArrayType [2]uint
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 16, index: 0, name: x}
+                  Offset: 0
+                  ByteSize: 16
+    - __kind: EventRootType
+      ID: 355
+      Name: Probe[main.testUintPointer]
+      ByteSize: 9
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: x
+          Offset: 1
+          Expression:
+            Type: 205 PointerType *uint
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 80, index: 0, name: x}
+                  Offset: 0
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 359
+      Name: Probe[main.testUintSlice]
+      ByteSize: 25
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: u
+          Offset: 1
+          Expression:
+            Type: 210 GoSliceHeaderType []uint
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 84, index: 0, name: u}
+                  Offset: 0
+                  ByteSize: 24
     - __kind: EventRootType
       ID: 376
       Name: Probe[main.testUnitializedString]
@@ -7456,104 +5160,2400 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 377
-      Name: Probe[main.testEmptyString]
-      ByteSize: 17
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: x
-          Offset: 1
-          Expression:
-            Type: 8 GoStringHeaderType string
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 102, index: 0, name: x}
-                  Offset: 0
-                  ByteSize: 16
-    - __kind: EventRootType
-      ID: 378
-      Name: Probe[main.testStruct]
-      ByteSize: 57
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: x
-          Offset: 1
-          Expression:
-            Type: 223 StructureType main.aStruct
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 103, index: 0, name: x}
-                  Offset: 0
-                  ByteSize: 56
-    - __kind: EventRootType
-      ID: 379
-      Name: Probe[main.testEmptyStruct]
-      ByteSize: 1
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: e
-          Offset: 1
-          Expression:
-            Type: 224 StructureType main.emptyStruct
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 104, index: 0, name: e}
-                  Offset: 0
-                  ByteSize: 0
-    - __kind: EventRootType
-      ID: 380
-      Name: Probe[main.testInlinedPrint]
+      ID: 354
+      Name: Probe[main.testUnsafePointer]
       ByteSize: 9
       PresenceBitsetSize: 1
       Expressions:
         - Name: x
           Offset: 1
           Expression:
-            Type: 1 BaseType int
+            Type: 38 VoidPointerType unsafe.Pointer
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 1, index: 0, name: x}
+                  Variable: {subprogram: 79, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 381
-      Name: Probe[main.testInlinedBBB]
-    - __kind: EventRootType
-      ID: 382
-      Name: Probe[main.testInlinedBCA]
-    - __kind: EventRootType
-      ID: 383
-      Name: Probe[main.testInlinedBCB]
-    - __kind: EventRootType
-      ID: 384
-      Name: Probe[main.testInlinedSq]
-      ByteSize: 9
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: x
-          Offset: 1
-          Expression:
-            Type: 1 BaseType int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 5, index: 0, name: x}
-                  Offset: 0
-                  ByteSize: 8
-    - __kind: EventRootType
-      ID: 385
-      Name: Probe[main.testInlinedSumArray]
-      ByteSize: 41
+      ID: 299
+      Name: Probe[main.testVeryLargeArray]
+      ByteSize: 801
       PresenceBitsetSize: 1
       Expressions:
         - Name: a
           Offset: 1
           Expression:
-            Type: 2 ArrayType [5]int
+            Type: 29 ArrayType [100]uint
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 6, index: 0, name: a}
+                  Variable: {subprogram: 24, index: 0, name: a}
                   Offset: 0
-                  ByteSize: 40
+                  ByteSize: 800
+    - __kind: EventRootType
+      ID: 368
+      Name: Probe[main.testVeryLargeSlice]
+      ByteSize: 25
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: xs
+          Offset: 1
+          Expression:
+            Type: 210 GoSliceHeaderType []uint
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 93, index: 0, name: xs}
+                  Offset: 0
+                  ByteSize: 24
+    - __kind: ArrayType
+      ID: 29
+      Name: '[100]uint'
+      ByteSize: 800
+      GoKind: 17
+      Count: 100
+      HasCount: true
+      Element: 20 BaseType uint
+    - __kind: ArrayType
+      ID: 28
+      Name: '[2][2][2]int'
+      ByteSize: 64
+      GoKind: 17
+      Count: 2
+      HasCount: true
+      Element: 27 ArrayType [2][2]int
+    - __kind: ArrayType
+      ID: 27
+      Name: '[2][2]int'
+      ByteSize: 32
+      GoKind: 17
+      Count: 2
+      HasCount: true
+      Element: 12 ArrayType [2]int
+    - __kind: ArrayType
+      ID: 10
+      Name: '[2]bool'
+      ByteSize: 2
+      GoKind: 17
+      Count: 2
+      HasCount: true
+      Element: 11 BaseType bool
+    - __kind: ArrayType
+      ID: 12
+      Name: '[2]int'
+      ByteSize: 16
+      GoRuntimeType: 677024
+      GoKind: 17
+      Count: 2
+      HasCount: true
+      Element: 1 BaseType int
+    - __kind: ArrayType
+      ID: 15
+      Name: '[2]int16'
+      ByteSize: 4
+      GoKind: 17
+      Count: 2
+      HasCount: true
+      Element: 16 BaseType int16
+    - __kind: ArrayType
+      ID: 5
+      Name: '[2]int32'
+      ByteSize: 8
+      GoRuntimeType: 678368
+      GoKind: 17
+      Count: 2
+      HasCount: true
+      Element: 6 BaseType int32
+    - __kind: ArrayType
+      ID: 17
+      Name: '[2]int64'
+      ByteSize: 16
+      GoKind: 17
+      Count: 2
+      HasCount: true
+      Element: 18 BaseType int64
+    - __kind: ArrayType
+      ID: 13
+      Name: '[2]int8'
+      ByteSize: 2
+      GoKind: 17
+      Count: 2
+      HasCount: true
+      Element: 14 BaseType int8
+    - __kind: ArrayType
+      ID: 118
+      Name: '[2]map[string]int'
+      ByteSize: 16
+      GoKind: 17
+      Count: 2
+      HasCount: true
+      Element: 83 GoMapType map[string]int
+    - __kind: ArrayType
+      ID: 7
+      Name: '[2]string'
+      ByteSize: 32
+      GoRuntimeType: 678464
+      GoKind: 17
+      Count: 2
+      HasCount: true
+      Element: 8 GoStringHeaderType string
+    - __kind: ArrayType
+      ID: 19
+      Name: '[2]uint'
+      ByteSize: 16
+      GoKind: 17
+      Count: 2
+      HasCount: true
+      Element: 20 BaseType uint
+    - __kind: ArrayType
+      ID: 21
+      Name: '[2]uint16'
+      ByteSize: 4
+      GoKind: 17
+      Count: 2
+      HasCount: true
+      Element: 22 BaseType uint16
+    - __kind: ArrayType
+      ID: 23
+      Name: '[2]uint32'
+      ByteSize: 8
+      GoKind: 17
+      Count: 2
+      HasCount: true
+      Element: 24 BaseType uint32
+    - __kind: ArrayType
+      ID: 25
+      Name: '[2]uint64'
+      ByteSize: 16
+      GoRuntimeType: 678560
+      GoKind: 17
+      Count: 2
+      HasCount: true
+      Element: 26 BaseType uint64
+    - __kind: ArrayType
+      ID: 3
+      Name: '[2]uint8'
+      ByteSize: 2
+      GoRuntimeType: 678272
+      GoKind: 17
+      Count: 2
+      HasCount: true
+      Element: 4 BaseType uint8
+    - __kind: ArrayType
+      ID: 179
+      Name: '[4]int'
+      ByteSize: 32
+      GoRuntimeType: 676640
+      GoKind: 17
+      Count: 4
+      HasCount: true
+      Element: 1 BaseType int
+    - __kind: ArrayType
+      ID: 117
+      Name: '[4]string'
+      ByteSize: 64
+      GoRuntimeType: 676928
+      GoKind: 17
+      Count: 4
+      HasCount: true
+      Element: 8 GoStringHeaderType string
+    - __kind: ArrayType
+      ID: 2
+      Name: '[5]int'
+      ByteSize: 40
+      GoKind: 17
+      Count: 5
+      HasCount: true
+      Element: 1 BaseType int
+    - __kind: GoSliceHeaderType
+      ID: 34
+      Name: '[]*string'
+      ByteSize: 24
+      GoRuntimeType: 473536
+      GoKind: 23
+      RawFields:
+        - Name: array
+          Offset: 0
+          Type: 35 PointerType **string
+        - Name: len
+          Offset: 8
+          Type: 1 BaseType int
+        - Name: cap
+          Offset: 16
+          Type: 1 BaseType int
+      Data: 240 GoSliceDataType []*string.array
+    - __kind: GoSliceDataType
+      ID: 240
+      Name: '[]*string.array'
+      ByteSize: 2048
+      Element: 36 PointerType *string
+    - __kind: GoSliceDataType
+      ID: 268
+      Name: '[]*table<[4]int,[4]int>.array'
+      ByteSize: 8192
+      Element: 195 PointerType *table<[4]int,[4]int>
+    - __kind: GoSliceDataType
+      ID: 266
+      Name: '[]*table<[4]int,uint8>.array'
+      ByteSize: 8192
+      Element: 184 PointerType *table<[4]int,uint8>
+    - __kind: GoSliceDataType
+      ID: 252
+      Name: '[]*table<[4]string,[2]int>.array'
+      ByteSize: 8192
+      Element: 110 PointerType *table<[4]string,[2]int>
+    - __kind: GoSliceDataType
+      ID: 258
+      Name: '[]*table<bool,main.node>.array'
+      ByteSize: 8192
+      Element: 137 PointerType *table<bool,main.node>
+    - __kind: GoSliceDataType
+      ID: 242
+      Name: '[]*table<int,int>.array'
+      ByteSize: 8192
+      Element: 64 PointerType *table<int,int>
+    - __kind: GoSliceDataType
+      ID: 260
+      Name: '[]*table<int,uint8>.array'
+      ByteSize: 8192
+      Element: 150 PointerType *table<int,uint8>
+    - __kind: GoSliceDataType
+      ID: 254
+      Name: '[]*table<string,[]main.structWithMap>.array'
+      ByteSize: 8192
+      Element: 124 PointerType *table<string,[]main.structWithMap>
+    - __kind: GoSliceDataType
+      ID: 248
+      Name: '[]*table<string,[]string>.array'
+      ByteSize: 8192
+      Element: 98 PointerType *table<string,[]string>
+    - __kind: GoSliceDataType
+      ID: 246
+      Name: '[]*table<string,int>.array'
+      ByteSize: 8192
+      Element: 87 PointerType *table<string,int>
+    - __kind: GoSliceDataType
+      ID: 244
+      Name: '[]*table<string,main.nestedStruct>.array'
+      ByteSize: 8192
+      Element: 75 PointerType *table<string,main.nestedStruct>
+    - __kind: GoSliceDataType
+      ID: 264
+      Name: '[]*table<uint8,[4]int>.array'
+      ByteSize: 8192
+      Element: 172 PointerType *table<uint8,[4]int>
+    - __kind: GoSliceDataType
+      ID: 262
+      Name: '[]*table<uint8,uint8>.array'
+      ByteSize: 8192
+      Element: 161 PointerType *table<uint8,uint8>
+    - __kind: GoSliceHeaderType
+      ID: 211
+      Name: '[][]uint'
+      ByteSize: 24
+      GoKind: 23
+      RawFields:
+        - Name: array
+          Offset: 0
+          Type: 212 PointerType *[]uint
+        - Name: len
+          Offset: 8
+          Type: 1 BaseType int
+        - Name: cap
+          Offset: 16
+          Type: 1 BaseType int
+      Data: 274 GoSliceDataType [][]uint.array
+    - __kind: GoSliceDataType
+      ID: 274
+      Name: '[][]uint.array'
+      ByteSize: 2048
+      Element: 210 GoSliceHeaderType []uint
+    - __kind: GoSliceHeaderType
+      ID: 216
+      Name: '[]bool'
+      ByteSize: 24
+      GoRuntimeType: 481856
+      GoKind: 23
+      RawFields:
+        - Name: array
+          Offset: 0
+          Type: 206 PointerType *bool
+        - Name: len
+          Offset: 8
+          Type: 1 BaseType int
+        - Name: cap
+          Offset: 16
+          Type: 1 BaseType int
+      Data: 278 GoSliceDataType []bool.array
+    - __kind: GoSliceDataType
+      ID: 278
+      Name: '[]bool.array'
+      ByteSize: 2048
+      Element: 11 BaseType bool
+    - __kind: GoSliceHeaderType
+      ID: 131
+      Name: '[]main.structWithMap'
+      ByteSize: 24
+      GoRuntimeType: 472768
+      GoKind: 23
+      RawFields:
+        - Name: array
+          Offset: 0
+          Type: 132 PointerType *main.structWithMap
+        - Name: len
+          Offset: 8
+          Type: 1 BaseType int
+        - Name: cap
+          Offset: 16
+          Type: 1 BaseType int
+      Data: 256 GoSliceDataType []main.structWithMap.array
+    - __kind: GoSliceDataType
+      ID: 256
+      Name: '[]main.structWithMap.array'
+      ByteSize: 2048
+      Element: 58 StructureType main.structWithMap
+    - __kind: GoSliceHeaderType
+      ID: 213
+      Name: '[]main.structWithNoStrings'
+      ByteSize: 24
+      GoKind: 23
+      RawFields:
+        - Name: array
+          Offset: 0
+          Type: 214 PointerType *main.structWithNoStrings
+        - Name: len
+          Offset: 8
+          Type: 1 BaseType int
+        - Name: cap
+          Offset: 16
+          Type: 1 BaseType int
+      Data: 276 GoSliceDataType []main.structWithNoStrings.array
+    - __kind: GoSliceDataType
+      ID: 276
+      Name: '[]main.structWithNoStrings.array'
+      ByteSize: 2048
+      Element: 215 StructureType main.structWithNoStrings
+    - __kind: GoSliceDataType
+      ID: 269
+      Name: '[]noalg.map.group[[4]int][4]int.array'
+      ByteSize: 2048
+      Element: 199 StructureType noalg.map.group[[4]int][4]int
+    - __kind: GoSliceDataType
+      ID: 267
+      Name: '[]noalg.map.group[[4]int]uint8.array'
+      ByteSize: 2048
+      Element: 188 StructureType noalg.map.group[[4]int]uint8
+    - __kind: GoSliceDataType
+      ID: 253
+      Name: '[]noalg.map.group[[4]string][2]int.array'
+      ByteSize: 2048
+      Element: 114 StructureType noalg.map.group[[4]string][2]int
+    - __kind: GoSliceDataType
+      ID: 259
+      Name: '[]noalg.map.group[bool]main.node.array'
+      ByteSize: 2048
+      Element: 141 StructureType noalg.map.group[bool]main.node
+    - __kind: GoSliceDataType
+      ID: 243
+      Name: '[]noalg.map.group[int]int.array'
+      ByteSize: 2048
+      Element: 68 StructureType noalg.map.group[int]int
+    - __kind: GoSliceDataType
+      ID: 261
+      Name: '[]noalg.map.group[int]uint8.array'
+      ByteSize: 2048
+      Element: 154 StructureType noalg.map.group[int]uint8
+    - __kind: GoSliceDataType
+      ID: 255
+      Name: '[]noalg.map.group[string][]main.structWithMap.array'
+      ByteSize: 2048
+      Element: 128 StructureType noalg.map.group[string][]main.structWithMap
+    - __kind: GoSliceDataType
+      ID: 249
+      Name: '[]noalg.map.group[string][]string.array'
+      ByteSize: 2048
+      Element: 102 StructureType noalg.map.group[string][]string
+    - __kind: GoSliceDataType
+      ID: 247
+      Name: '[]noalg.map.group[string]int.array'
+      ByteSize: 2048
+      Element: 91 StructureType noalg.map.group[string]int
+    - __kind: GoSliceDataType
+      ID: 245
+      Name: '[]noalg.map.group[string]main.nestedStruct.array'
+      ByteSize: 2048
+      Element: 79 StructureType noalg.map.group[string]main.nestedStruct
+    - __kind: GoSliceDataType
+      ID: 265
+      Name: '[]noalg.map.group[uint8][4]int.array'
+      ByteSize: 2048
+      Element: 176 StructureType noalg.map.group[uint8][4]int
+    - __kind: GoSliceDataType
+      ID: 263
+      Name: '[]noalg.map.group[uint8]uint8.array'
+      ByteSize: 2048
+      Element: 165 StructureType noalg.map.group[uint8]uint8
+    - __kind: GoSliceHeaderType
+      ID: 105
+      Name: '[]string'
+      ByteSize: 24
+      GoRuntimeType: 481984
+      GoKind: 23
+      RawFields:
+        - Name: array
+          Offset: 0
+          Type: 36 PointerType *string
+        - Name: len
+          Offset: 8
+          Type: 1 BaseType int
+        - Name: cap
+          Offset: 16
+          Type: 1 BaseType int
+      Data: 250 GoSliceDataType []string.array
+    - __kind: GoSliceDataType
+      ID: 250
+      Name: '[]string.array'
+      ByteSize: 2048
+      Element: 8 GoStringHeaderType string
+    - __kind: GoSliceHeaderType
+      ID: 210
+      Name: '[]uint'
+      ByteSize: 24
+      GoRuntimeType: 481472
+      GoKind: 23
+      RawFields:
+        - Name: array
+          Offset: 0
+          Type: 205 PointerType *uint
+        - Name: len
+          Offset: 8
+          Type: 1 BaseType int
+        - Name: cap
+          Offset: 16
+          Type: 1 BaseType int
+      Data: 272 GoSliceDataType []uint.array
+    - __kind: GoSliceDataType
+      ID: 272
+      Name: '[]uint.array'
+      ByteSize: 2048
+      Element: 20 BaseType uint
+    - __kind: GoSliceHeaderType
+      ID: 217
+      Name: '[]uint16'
+      ByteSize: 24
+      GoRuntimeType: 480832
+      GoKind: 23
+      RawFields:
+        - Name: array
+          Offset: 0
+          Type: 218 PointerType *uint16
+        - Name: len
+          Offset: 8
+          Type: 1 BaseType int
+        - Name: cap
+          Offset: 16
+          Type: 1 BaseType int
+      Data: 280 GoSliceDataType []uint16.array
+    - __kind: GoSliceDataType
+      ID: 280
+      Name: '[]uint16.array'
+      ByteSize: 2048
+      Element: 22 BaseType uint16
+    - __kind: BaseType
+      ID: 11
+      Name: bool
+      ByteSize: 1
+      GoRuntimeType: 579808
+      GoKind: 1
+    - __kind: GoChannelType
+      ID: 202
+      Name: chan bool
+      GoRuntimeType: 591136
+      GoKind: 18
+    - __kind: GoChannelType
+      ID: 40
+      Name: chan struct {}
+      GoRuntimeType: 590048
+      GoKind: 18
+    - __kind: BaseType
+      ID: 229
+      Name: complex128
+      ByteSize: 16
+      GoRuntimeType: 579616
+      GoKind: 16
+    - __kind: BaseType
+      ID: 228
+      Name: complex64
+      ByteSize: 8
+      GoRuntimeType: 579552
+      GoKind: 15
+    - __kind: GoInterfaceType
+      ID: 57
+      Name: error
+      ByteSize: 16
+      GoRuntimeType: 1.020704e+06
+      GoKind: 20
+      RawFields:
+        - Name: tab
+          Offset: 0
+          Type: 38 VoidPointerType unsafe.Pointer
+        - Name: data
+          Offset: 8
+          Type: 38 VoidPointerType unsafe.Pointer
+    - __kind: BaseType
+      ID: 30
+      Name: float32
+      ByteSize: 4
+      GoRuntimeType: 579680
+      GoKind: 13
+    - __kind: BaseType
+      ID: 31
+      Name: float64
+      ByteSize: 8
+      GoRuntimeType: 579744
+      GoKind: 14
+    - __kind: GoSubroutineType
+      ID: 43
+      Name: func()
+      ByteSize: 8
+      GoRuntimeType: 471744
+      GoKind: 19
+    - __kind: GoSwissMapGroupsType
+      ID: 197
+      Name: groupReference<[4]int,[4]int>
+      ByteSize: 16
+      GoKind: 25
+      RawFields:
+        - Name: data
+          Offset: 0
+          Type: 198 PointerType *noalg.map.group[[4]int][4]int
+        - Name: lengthMask
+          Offset: 8
+          Type: 26 BaseType uint64
+      GroupType: 199 StructureType noalg.map.group[[4]int][4]int
+      GroupSliceType: 269 GoSliceDataType []noalg.map.group[[4]int][4]int.array
+    - __kind: GoSwissMapGroupsType
+      ID: 186
+      Name: groupReference<[4]int,uint8>
+      ByteSize: 16
+      GoKind: 25
+      RawFields:
+        - Name: data
+          Offset: 0
+          Type: 187 PointerType *noalg.map.group[[4]int]uint8
+        - Name: lengthMask
+          Offset: 8
+          Type: 26 BaseType uint64
+      GroupType: 188 StructureType noalg.map.group[[4]int]uint8
+      GroupSliceType: 267 GoSliceDataType []noalg.map.group[[4]int]uint8.array
+    - __kind: GoSwissMapGroupsType
+      ID: 112
+      Name: groupReference<[4]string,[2]int>
+      ByteSize: 16
+      GoKind: 25
+      RawFields:
+        - Name: data
+          Offset: 0
+          Type: 113 PointerType *noalg.map.group[[4]string][2]int
+        - Name: lengthMask
+          Offset: 8
+          Type: 26 BaseType uint64
+      GroupType: 114 StructureType noalg.map.group[[4]string][2]int
+      GroupSliceType: 253 GoSliceDataType []noalg.map.group[[4]string][2]int.array
+    - __kind: GoSwissMapGroupsType
+      ID: 139
+      Name: groupReference<bool,main.node>
+      ByteSize: 16
+      GoKind: 25
+      RawFields:
+        - Name: data
+          Offset: 0
+          Type: 140 PointerType *noalg.map.group[bool]main.node
+        - Name: lengthMask
+          Offset: 8
+          Type: 26 BaseType uint64
+      GroupType: 141 StructureType noalg.map.group[bool]main.node
+      GroupSliceType: 259 GoSliceDataType []noalg.map.group[bool]main.node.array
+    - __kind: GoSwissMapGroupsType
+      ID: 66
+      Name: groupReference<int,int>
+      ByteSize: 16
+      GoKind: 25
+      RawFields:
+        - Name: data
+          Offset: 0
+          Type: 67 PointerType *noalg.map.group[int]int
+        - Name: lengthMask
+          Offset: 8
+          Type: 26 BaseType uint64
+      GroupType: 68 StructureType noalg.map.group[int]int
+      GroupSliceType: 243 GoSliceDataType []noalg.map.group[int]int.array
+    - __kind: GoSwissMapGroupsType
+      ID: 152
+      Name: groupReference<int,uint8>
+      ByteSize: 16
+      GoKind: 25
+      RawFields:
+        - Name: data
+          Offset: 0
+          Type: 153 PointerType *noalg.map.group[int]uint8
+        - Name: lengthMask
+          Offset: 8
+          Type: 26 BaseType uint64
+      GroupType: 154 StructureType noalg.map.group[int]uint8
+      GroupSliceType: 261 GoSliceDataType []noalg.map.group[int]uint8.array
+    - __kind: GoSwissMapGroupsType
+      ID: 126
+      Name: groupReference<string,[]main.structWithMap>
+      ByteSize: 16
+      GoKind: 25
+      RawFields:
+        - Name: data
+          Offset: 0
+          Type: 127 PointerType *noalg.map.group[string][]main.structWithMap
+        - Name: lengthMask
+          Offset: 8
+          Type: 26 BaseType uint64
+      GroupType: 128 StructureType noalg.map.group[string][]main.structWithMap
+      GroupSliceType: 255 GoSliceDataType []noalg.map.group[string][]main.structWithMap.array
+    - __kind: GoSwissMapGroupsType
+      ID: 100
+      Name: groupReference<string,[]string>
+      ByteSize: 16
+      GoKind: 25
+      RawFields:
+        - Name: data
+          Offset: 0
+          Type: 101 PointerType *noalg.map.group[string][]string
+        - Name: lengthMask
+          Offset: 8
+          Type: 26 BaseType uint64
+      GroupType: 102 StructureType noalg.map.group[string][]string
+      GroupSliceType: 249 GoSliceDataType []noalg.map.group[string][]string.array
+    - __kind: GoSwissMapGroupsType
+      ID: 89
+      Name: groupReference<string,int>
+      ByteSize: 16
+      GoKind: 25
+      RawFields:
+        - Name: data
+          Offset: 0
+          Type: 90 PointerType *noalg.map.group[string]int
+        - Name: lengthMask
+          Offset: 8
+          Type: 26 BaseType uint64
+      GroupType: 91 StructureType noalg.map.group[string]int
+      GroupSliceType: 247 GoSliceDataType []noalg.map.group[string]int.array
+    - __kind: GoSwissMapGroupsType
+      ID: 77
+      Name: groupReference<string,main.nestedStruct>
+      ByteSize: 16
+      GoKind: 25
+      RawFields:
+        - Name: data
+          Offset: 0
+          Type: 78 PointerType *noalg.map.group[string]main.nestedStruct
+        - Name: lengthMask
+          Offset: 8
+          Type: 26 BaseType uint64
+      GroupType: 79 StructureType noalg.map.group[string]main.nestedStruct
+      GroupSliceType: 245 GoSliceDataType []noalg.map.group[string]main.nestedStruct.array
+    - __kind: GoSwissMapGroupsType
+      ID: 174
+      Name: groupReference<uint8,[4]int>
+      ByteSize: 16
+      GoKind: 25
+      RawFields:
+        - Name: data
+          Offset: 0
+          Type: 175 PointerType *noalg.map.group[uint8][4]int
+        - Name: lengthMask
+          Offset: 8
+          Type: 26 BaseType uint64
+      GroupType: 176 StructureType noalg.map.group[uint8][4]int
+      GroupSliceType: 265 GoSliceDataType []noalg.map.group[uint8][4]int.array
+    - __kind: GoSwissMapGroupsType
+      ID: 163
+      Name: groupReference<uint8,uint8>
+      ByteSize: 16
+      GoKind: 25
+      RawFields:
+        - Name: data
+          Offset: 0
+          Type: 164 PointerType *noalg.map.group[uint8]uint8
+        - Name: lengthMask
+          Offset: 8
+          Type: 26 BaseType uint64
+      GroupType: 165 StructureType noalg.map.group[uint8]uint8
+      GroupSliceType: 263 GoSliceDataType []noalg.map.group[uint8]uint8.array
+    - __kind: BaseType
+      ID: 1
+      Name: int
+      ByteSize: 8
+      GoRuntimeType: 579360
+      GoKind: 2
+    - __kind: BaseType
+      ID: 16
+      Name: int16
+      ByteSize: 2
+      GoRuntimeType: 578976
+      GoKind: 4
+    - __kind: BaseType
+      ID: 6
+      Name: int32
+      ByteSize: 4
+      GoRuntimeType: 579104
+      GoKind: 5
+    - __kind: BaseType
+      ID: 18
+      Name: int64
+      ByteSize: 8
+      GoRuntimeType: 579232
+      GoKind: 6
+    - __kind: BaseType
+      ID: 14
+      Name: int8
+      ByteSize: 1
+      GoRuntimeType: 578848
+      GoKind: 3
+    - __kind: GoEmptyInterfaceType
+      ID: 41
+      Name: interface {}
+      ByteSize: 16
+      GoRuntimeType: 841856
+      GoKind: 20
+      RawFields:
+        - Name: _type
+          Offset: 0
+          Type: 38 VoidPointerType unsafe.Pointer
+        - Name: data
+          Offset: 8
+          Type: 38 VoidPointerType unsafe.Pointer
+    - __kind: StructureType
+      ID: 48
+      Name: internal/sync.Mutex
+      ByteSize: 8
+      GoRuntimeType: 1.46e+06
+      GoKind: 25
+      RawFields:
+        - Name: state
+          Offset: 0
+          Type: 6 BaseType int32
+        - Name: sema
+          Offset: 4
+          Type: 24 BaseType uint32
+    - __kind: GoInterfaceType
+      ID: 37
+      Name: io.Writer
+      ByteSize: 16
+      GoRuntimeType: 1.016736e+06
+      GoKind: 20
+      RawFields:
+        - Name: tab
+          Offset: 0
+          Type: 38 VoidPointerType unsafe.Pointer
+        - Name: data
+          Offset: 8
+          Type: 38 VoidPointerType unsafe.Pointer
+    - __kind: StructureType
+      ID: 223
+      Name: main.aStruct
+      ByteSize: 56
+      GoKind: 25
+      RawFields:
+        - Name: aBool
+          Offset: 0
+          Type: 11 BaseType bool
+        - Name: aString
+          Offset: 8
+          Type: 8 GoStringHeaderType string
+        - Name: aNumber
+          Offset: 24
+          Type: 1 BaseType int
+        - Name: nested
+          Offset: 32
+          Type: 82 StructureType main.nestedStruct
+    - __kind: GoInterfaceType
+      ID: 56
+      Name: main.behavior
+      ByteSize: 16
+      GoRuntimeType: 1.016352e+06
+      GoKind: 20
+      RawFields:
+        - Name: tab
+          Offset: 0
+          Type: 38 VoidPointerType unsafe.Pointer
+        - Name: data
+          Offset: 8
+          Type: 38 VoidPointerType unsafe.Pointer
+    - __kind: StructureType
+      ID: 33
+      Name: main.bigStruct
+      ByteSize: 48
+      GoKind: 25
+      RawFields:
+        - Name: x
+          Offset: 0
+          Type: 34 GoSliceHeaderType []*string
+        - Name: z
+          Offset: 24
+          Type: 1 BaseType int
+        - Name: writer
+          Offset: 32
+          Type: 37 GoInterfaceType io.Writer
+    - __kind: StructureType
+      ID: 224
+      Name: main.emptyStruct
+      GoKind: 25
+      RawFields: []
+    - __kind: StructureType
+      ID: 45
+      Name: main.esotericHeap
+      ByteSize: 112
+      GoRuntimeType: 1.82096e+06
+      GoKind: 25
+      RawFields:
+        - Name: esotericStack
+          Offset: 0
+          Type: 39 StructureType main.esotericStack
+        - Name: mu
+          Offset: 64
+          Type: 46 StructureType sync.Mutex
+        - Name: once
+          Offset: 72
+          Type: 49 StructureType sync.Once
+        - Name: wg
+          Offset: 88
+          Type: 52 StructureType sync.WaitGroup
+        - Name: a
+          Offset: 104
+          Type: 55 StructureType sync/atomic.Int32
+    - __kind: StructureType
+      ID: 39
+      Name: main.esotericStack
+      ByteSize: 64
+      GoRuntimeType: 1.954272e+06
+      GoKind: 25
+      RawFields:
+        - Name: _
+          Offset: 0
+          Type: 6 BaseType int32
+        - Name: _valid
+          Offset: 4
+          Type: 6 BaseType int32
+        - Name: c
+          Offset: 8
+          Type: 40 GoChannelType chan struct {}
+        - Name: val
+          Offset: 16
+          Type: 41 GoEmptyInterfaceType interface {}
+        - Name: _
+          Offset: 32
+          Type: 26 BaseType uint64
+        - Name: work
+          Offset: 40
+          Type: 42 GoInterfaceType main.something
+        - Name: foo
+          Offset: 56
+          Type: 43 GoSubroutineType func()
+    - __kind: StructureType
+      ID: 82
+      Name: main.nestedStruct
+      ByteSize: 24
+      GoRuntimeType: 1.44864e+06
+      GoKind: 25
+      RawFields:
+        - Name: anotherInt
+          Offset: 0
+          Type: 1 BaseType int
+        - Name: anotherString
+          Offset: 8
+          Type: 8 GoStringHeaderType string
+    - __kind: StructureType
+      ID: 144
+      Name: main.node
+      ByteSize: 16
+      GoRuntimeType: 1.44848e+06
+      GoKind: 25
+      RawFields:
+        - Name: val
+          Offset: 0
+          Type: 1 BaseType int
+        - Name: b
+          Offset: 8
+          Type: 145 PointerType *main.node
+    - __kind: StructureType
+      ID: 222
+      Name: main.oneStringStruct
+      ByteSize: 16
+      GoKind: 25
+      RawFields:
+        - Name: a
+          Offset: 0
+          Type: 8 GoStringHeaderType string
+    - __kind: GoInterfaceType
+      ID: 42
+      Name: main.something
+      ByteSize: 16
+      GoRuntimeType: 1.01648e+06
+      GoKind: 20
+      RawFields:
+        - Name: tab
+          Offset: 0
+          Type: 38 VoidPointerType unsafe.Pointer
+        - Name: data
+          Offset: 8
+          Type: 38 VoidPointerType unsafe.Pointer
+    - __kind: StructureType
+      ID: 58
+      Name: main.structWithMap
+      ByteSize: 8
+      GoRuntimeType: 1.177504e+06
+      GoKind: 25
+      RawFields:
+        - Name: m
+          Offset: 0
+          Type: 59 GoMapType map[int]int
+    - __kind: StructureType
+      ID: 215
+      Name: main.structWithNoStrings
+      ByteSize: 2
+      GoKind: 25
+      RawFields:
+        - Name: aUint8
+          Offset: 0
+          Type: 4 BaseType uint8
+        - Name: aBool
+          Offset: 1
+          Type: 11 BaseType bool
+    - __kind: StructureType
+      ID: 204
+      Name: main.structWithTwoValues
+      ByteSize: 16
+      GoKind: 25
+      RawFields:
+        - Name: a
+          Offset: 0
+          Type: 20 BaseType uint
+        - Name: b
+          Offset: 8
+          Type: 11 BaseType bool
+    - __kind: GoSliceHeaderType
+      ID: 208
+      Name: main.t
+      ByteSize: 24
+      GoKind: 23
+      RawFields:
+        - Name: array
+          Offset: 0
+          Type: 209 PointerType **main.t
+        - Name: len
+          Offset: 8
+          Type: 1 BaseType int
+        - Name: cap
+          Offset: 16
+          Type: 1 BaseType int
+      Data: 270 GoSliceDataType main.t.array
+    - __kind: GoSliceDataType
+      ID: 270
+      Name: main.t.array
+      ByteSize: 2048
+      Element: 207 PointerType *main.t
+    - __kind: StructureType
+      ID: 219
+      Name: main.threeStringStruct
+      ByteSize: 48
+      GoKind: 25
+      RawFields:
+        - Name: a
+          Offset: 0
+          Type: 8 GoStringHeaderType string
+        - Name: b
+          Offset: 16
+          Type: 8 GoStringHeaderType string
+        - Name: c
+          Offset: 32
+          Type: 8 GoStringHeaderType string
+    - __kind: BaseType
+      ID: 32
+      Name: main.typeAlias
+      ByteSize: 2
+      GoKind: 9
+    - __kind: GoSwissMapHeaderType
+      ID: 193
+      Name: map<[4]int,[4]int>
+      ByteSize: 48
+      GoKind: 25
+      RawFields:
+        - Name: used
+          Offset: 0
+          Type: 26 BaseType uint64
+        - Name: seed
+          Offset: 8
+          Type: 62 BaseType uintptr
+        - Name: dirPtr
+          Offset: 16
+          Type: 194 PointerType **table<[4]int,[4]int>
+        - Name: dirLen
+          Offset: 24
+          Type: 1 BaseType int
+        - Name: globalDepth
+          Offset: 32
+          Type: 4 BaseType uint8
+        - Name: globalShift
+          Offset: 33
+          Type: 4 BaseType uint8
+        - Name: writing
+          Offset: 34
+          Type: 4 BaseType uint8
+        - Name: tombstonePossible
+          Offset: 35
+          Type: 11 BaseType bool
+        - Name: clearSeq
+          Offset: 40
+          Type: 26 BaseType uint64
+      TablePtrSliceType: 268 GoSliceDataType []*table<[4]int,[4]int>.array
+      GroupType: 199 StructureType noalg.map.group[[4]int][4]int
+    - __kind: GoSwissMapHeaderType
+      ID: 182
+      Name: map<[4]int,uint8>
+      ByteSize: 48
+      GoKind: 25
+      RawFields:
+        - Name: used
+          Offset: 0
+          Type: 26 BaseType uint64
+        - Name: seed
+          Offset: 8
+          Type: 62 BaseType uintptr
+        - Name: dirPtr
+          Offset: 16
+          Type: 183 PointerType **table<[4]int,uint8>
+        - Name: dirLen
+          Offset: 24
+          Type: 1 BaseType int
+        - Name: globalDepth
+          Offset: 32
+          Type: 4 BaseType uint8
+        - Name: globalShift
+          Offset: 33
+          Type: 4 BaseType uint8
+        - Name: writing
+          Offset: 34
+          Type: 4 BaseType uint8
+        - Name: tombstonePossible
+          Offset: 35
+          Type: 11 BaseType bool
+        - Name: clearSeq
+          Offset: 40
+          Type: 26 BaseType uint64
+      TablePtrSliceType: 266 GoSliceDataType []*table<[4]int,uint8>.array
+      GroupType: 188 StructureType noalg.map.group[[4]int]uint8
+    - __kind: GoSwissMapHeaderType
+      ID: 108
+      Name: map<[4]string,[2]int>
+      ByteSize: 48
+      GoKind: 25
+      RawFields:
+        - Name: used
+          Offset: 0
+          Type: 26 BaseType uint64
+        - Name: seed
+          Offset: 8
+          Type: 62 BaseType uintptr
+        - Name: dirPtr
+          Offset: 16
+          Type: 109 PointerType **table<[4]string,[2]int>
+        - Name: dirLen
+          Offset: 24
+          Type: 1 BaseType int
+        - Name: globalDepth
+          Offset: 32
+          Type: 4 BaseType uint8
+        - Name: globalShift
+          Offset: 33
+          Type: 4 BaseType uint8
+        - Name: writing
+          Offset: 34
+          Type: 4 BaseType uint8
+        - Name: tombstonePossible
+          Offset: 35
+          Type: 11 BaseType bool
+        - Name: clearSeq
+          Offset: 40
+          Type: 26 BaseType uint64
+      TablePtrSliceType: 252 GoSliceDataType []*table<[4]string,[2]int>.array
+      GroupType: 114 StructureType noalg.map.group[[4]string][2]int
+    - __kind: GoSwissMapHeaderType
+      ID: 135
+      Name: map<bool,main.node>
+      ByteSize: 48
+      GoKind: 25
+      RawFields:
+        - Name: used
+          Offset: 0
+          Type: 26 BaseType uint64
+        - Name: seed
+          Offset: 8
+          Type: 62 BaseType uintptr
+        - Name: dirPtr
+          Offset: 16
+          Type: 136 PointerType **table<bool,main.node>
+        - Name: dirLen
+          Offset: 24
+          Type: 1 BaseType int
+        - Name: globalDepth
+          Offset: 32
+          Type: 4 BaseType uint8
+        - Name: globalShift
+          Offset: 33
+          Type: 4 BaseType uint8
+        - Name: writing
+          Offset: 34
+          Type: 4 BaseType uint8
+        - Name: tombstonePossible
+          Offset: 35
+          Type: 11 BaseType bool
+        - Name: clearSeq
+          Offset: 40
+          Type: 26 BaseType uint64
+      TablePtrSliceType: 258 GoSliceDataType []*table<bool,main.node>.array
+      GroupType: 141 StructureType noalg.map.group[bool]main.node
+    - __kind: GoSwissMapHeaderType
+      ID: 61
+      Name: map<int,int>
+      ByteSize: 48
+      GoKind: 25
+      RawFields:
+        - Name: used
+          Offset: 0
+          Type: 26 BaseType uint64
+        - Name: seed
+          Offset: 8
+          Type: 62 BaseType uintptr
+        - Name: dirPtr
+          Offset: 16
+          Type: 63 PointerType **table<int,int>
+        - Name: dirLen
+          Offset: 24
+          Type: 1 BaseType int
+        - Name: globalDepth
+          Offset: 32
+          Type: 4 BaseType uint8
+        - Name: globalShift
+          Offset: 33
+          Type: 4 BaseType uint8
+        - Name: writing
+          Offset: 34
+          Type: 4 BaseType uint8
+        - Name: tombstonePossible
+          Offset: 35
+          Type: 11 BaseType bool
+        - Name: clearSeq
+          Offset: 40
+          Type: 26 BaseType uint64
+      TablePtrSliceType: 242 GoSliceDataType []*table<int,int>.array
+      GroupType: 68 StructureType noalg.map.group[int]int
+    - __kind: GoSwissMapHeaderType
+      ID: 148
+      Name: map<int,uint8>
+      ByteSize: 48
+      GoKind: 25
+      RawFields:
+        - Name: used
+          Offset: 0
+          Type: 26 BaseType uint64
+        - Name: seed
+          Offset: 8
+          Type: 62 BaseType uintptr
+        - Name: dirPtr
+          Offset: 16
+          Type: 149 PointerType **table<int,uint8>
+        - Name: dirLen
+          Offset: 24
+          Type: 1 BaseType int
+        - Name: globalDepth
+          Offset: 32
+          Type: 4 BaseType uint8
+        - Name: globalShift
+          Offset: 33
+          Type: 4 BaseType uint8
+        - Name: writing
+          Offset: 34
+          Type: 4 BaseType uint8
+        - Name: tombstonePossible
+          Offset: 35
+          Type: 11 BaseType bool
+        - Name: clearSeq
+          Offset: 40
+          Type: 26 BaseType uint64
+      TablePtrSliceType: 260 GoSliceDataType []*table<int,uint8>.array
+      GroupType: 154 StructureType noalg.map.group[int]uint8
+    - __kind: GoSwissMapHeaderType
+      ID: 122
+      Name: map<string,[]main.structWithMap>
+      ByteSize: 48
+      GoKind: 25
+      RawFields:
+        - Name: used
+          Offset: 0
+          Type: 26 BaseType uint64
+        - Name: seed
+          Offset: 8
+          Type: 62 BaseType uintptr
+        - Name: dirPtr
+          Offset: 16
+          Type: 123 PointerType **table<string,[]main.structWithMap>
+        - Name: dirLen
+          Offset: 24
+          Type: 1 BaseType int
+        - Name: globalDepth
+          Offset: 32
+          Type: 4 BaseType uint8
+        - Name: globalShift
+          Offset: 33
+          Type: 4 BaseType uint8
+        - Name: writing
+          Offset: 34
+          Type: 4 BaseType uint8
+        - Name: tombstonePossible
+          Offset: 35
+          Type: 11 BaseType bool
+        - Name: clearSeq
+          Offset: 40
+          Type: 26 BaseType uint64
+      TablePtrSliceType: 254 GoSliceDataType []*table<string,[]main.structWithMap>.array
+      GroupType: 128 StructureType noalg.map.group[string][]main.structWithMap
+    - __kind: GoSwissMapHeaderType
+      ID: 96
+      Name: map<string,[]string>
+      ByteSize: 48
+      GoKind: 25
+      RawFields:
+        - Name: used
+          Offset: 0
+          Type: 26 BaseType uint64
+        - Name: seed
+          Offset: 8
+          Type: 62 BaseType uintptr
+        - Name: dirPtr
+          Offset: 16
+          Type: 97 PointerType **table<string,[]string>
+        - Name: dirLen
+          Offset: 24
+          Type: 1 BaseType int
+        - Name: globalDepth
+          Offset: 32
+          Type: 4 BaseType uint8
+        - Name: globalShift
+          Offset: 33
+          Type: 4 BaseType uint8
+        - Name: writing
+          Offset: 34
+          Type: 4 BaseType uint8
+        - Name: tombstonePossible
+          Offset: 35
+          Type: 11 BaseType bool
+        - Name: clearSeq
+          Offset: 40
+          Type: 26 BaseType uint64
+      TablePtrSliceType: 248 GoSliceDataType []*table<string,[]string>.array
+      GroupType: 102 StructureType noalg.map.group[string][]string
+    - __kind: GoSwissMapHeaderType
+      ID: 85
+      Name: map<string,int>
+      ByteSize: 48
+      GoKind: 25
+      RawFields:
+        - Name: used
+          Offset: 0
+          Type: 26 BaseType uint64
+        - Name: seed
+          Offset: 8
+          Type: 62 BaseType uintptr
+        - Name: dirPtr
+          Offset: 16
+          Type: 86 PointerType **table<string,int>
+        - Name: dirLen
+          Offset: 24
+          Type: 1 BaseType int
+        - Name: globalDepth
+          Offset: 32
+          Type: 4 BaseType uint8
+        - Name: globalShift
+          Offset: 33
+          Type: 4 BaseType uint8
+        - Name: writing
+          Offset: 34
+          Type: 4 BaseType uint8
+        - Name: tombstonePossible
+          Offset: 35
+          Type: 11 BaseType bool
+        - Name: clearSeq
+          Offset: 40
+          Type: 26 BaseType uint64
+      TablePtrSliceType: 246 GoSliceDataType []*table<string,int>.array
+      GroupType: 91 StructureType noalg.map.group[string]int
+    - __kind: GoSwissMapHeaderType
+      ID: 73
+      Name: map<string,main.nestedStruct>
+      ByteSize: 48
+      GoKind: 25
+      RawFields:
+        - Name: used
+          Offset: 0
+          Type: 26 BaseType uint64
+        - Name: seed
+          Offset: 8
+          Type: 62 BaseType uintptr
+        - Name: dirPtr
+          Offset: 16
+          Type: 74 PointerType **table<string,main.nestedStruct>
+        - Name: dirLen
+          Offset: 24
+          Type: 1 BaseType int
+        - Name: globalDepth
+          Offset: 32
+          Type: 4 BaseType uint8
+        - Name: globalShift
+          Offset: 33
+          Type: 4 BaseType uint8
+        - Name: writing
+          Offset: 34
+          Type: 4 BaseType uint8
+        - Name: tombstonePossible
+          Offset: 35
+          Type: 11 BaseType bool
+        - Name: clearSeq
+          Offset: 40
+          Type: 26 BaseType uint64
+      TablePtrSliceType: 244 GoSliceDataType []*table<string,main.nestedStruct>.array
+      GroupType: 79 StructureType noalg.map.group[string]main.nestedStruct
+    - __kind: GoSwissMapHeaderType
+      ID: 170
+      Name: map<uint8,[4]int>
+      ByteSize: 48
+      GoKind: 25
+      RawFields:
+        - Name: used
+          Offset: 0
+          Type: 26 BaseType uint64
+        - Name: seed
+          Offset: 8
+          Type: 62 BaseType uintptr
+        - Name: dirPtr
+          Offset: 16
+          Type: 171 PointerType **table<uint8,[4]int>
+        - Name: dirLen
+          Offset: 24
+          Type: 1 BaseType int
+        - Name: globalDepth
+          Offset: 32
+          Type: 4 BaseType uint8
+        - Name: globalShift
+          Offset: 33
+          Type: 4 BaseType uint8
+        - Name: writing
+          Offset: 34
+          Type: 4 BaseType uint8
+        - Name: tombstonePossible
+          Offset: 35
+          Type: 11 BaseType bool
+        - Name: clearSeq
+          Offset: 40
+          Type: 26 BaseType uint64
+      TablePtrSliceType: 264 GoSliceDataType []*table<uint8,[4]int>.array
+      GroupType: 176 StructureType noalg.map.group[uint8][4]int
+    - __kind: GoSwissMapHeaderType
+      ID: 159
+      Name: map<uint8,uint8>
+      ByteSize: 48
+      GoKind: 25
+      RawFields:
+        - Name: used
+          Offset: 0
+          Type: 26 BaseType uint64
+        - Name: seed
+          Offset: 8
+          Type: 62 BaseType uintptr
+        - Name: dirPtr
+          Offset: 16
+          Type: 160 PointerType **table<uint8,uint8>
+        - Name: dirLen
+          Offset: 24
+          Type: 1 BaseType int
+        - Name: globalDepth
+          Offset: 32
+          Type: 4 BaseType uint8
+        - Name: globalShift
+          Offset: 33
+          Type: 4 BaseType uint8
+        - Name: writing
+          Offset: 34
+          Type: 4 BaseType uint8
+        - Name: tombstonePossible
+          Offset: 35
+          Type: 11 BaseType bool
+        - Name: clearSeq
+          Offset: 40
+          Type: 26 BaseType uint64
+      TablePtrSliceType: 262 GoSliceDataType []*table<uint8,uint8>.array
+      GroupType: 165 StructureType noalg.map.group[uint8]uint8
+    - __kind: GoMapType
+      ID: 191
+      Name: map[[4]int][4]int
+      ByteSize: 8
+      GoRuntimeType: 1.1224e+06
+      GoKind: 21
+      HeaderType: 193 GoSwissMapHeaderType map<[4]int,[4]int>
+    - __kind: GoMapType
+      ID: 180
+      Name: map[[4]int]uint8
+      ByteSize: 8
+      GoRuntimeType: 1.122528e+06
+      GoKind: 21
+      HeaderType: 182 GoSwissMapHeaderType map<[4]int,uint8>
+    - __kind: GoMapType
+      ID: 106
+      Name: map[[4]string][2]int
+      ByteSize: 8
+      GoRuntimeType: 1.122656e+06
+      GoKind: 21
+      HeaderType: 108 GoSwissMapHeaderType map<[4]string,[2]int>
+    - __kind: GoMapType
+      ID: 133
+      Name: map[bool]main.node
+      ByteSize: 8
+      GoRuntimeType: 1.122784e+06
+      GoKind: 21
+      HeaderType: 135 GoSwissMapHeaderType map<bool,main.node>
+    - __kind: GoMapType
+      ID: 59
+      Name: map[int]int
+      ByteSize: 8
+      GoRuntimeType: 1.122016e+06
+      GoKind: 21
+      HeaderType: 61 GoSwissMapHeaderType map<int,int>
+    - __kind: GoMapType
+      ID: 146
+      Name: map[int]uint8
+      ByteSize: 8
+      GoRuntimeType: 1.122912e+06
+      GoKind: 21
+      HeaderType: 148 GoSwissMapHeaderType map<int,uint8>
+    - __kind: GoMapType
+      ID: 120
+      Name: map[string][]main.structWithMap
+      ByteSize: 8
+      GoRuntimeType: 1.12304e+06
+      GoKind: 21
+      HeaderType: 122 GoSwissMapHeaderType map<string,[]main.structWithMap>
+    - __kind: GoMapType
+      ID: 94
+      Name: map[string][]string
+      ByteSize: 8
+      GoRuntimeType: 1.123168e+06
+      GoKind: 21
+      HeaderType: 96 GoSwissMapHeaderType map<string,[]string>
+    - __kind: GoMapType
+      ID: 83
+      Name: map[string]int
+      ByteSize: 8
+      GoRuntimeType: 1.123296e+06
+      GoKind: 21
+      HeaderType: 85 GoSwissMapHeaderType map<string,int>
+    - __kind: GoMapType
+      ID: 71
+      Name: map[string]main.nestedStruct
+      ByteSize: 8
+      GoRuntimeType: 1.123424e+06
+      GoKind: 21
+      HeaderType: 73 GoSwissMapHeaderType map<string,main.nestedStruct>
+    - __kind: GoMapType
+      ID: 168
+      Name: map[uint8][4]int
+      ByteSize: 8
+      GoRuntimeType: 1.123552e+06
+      GoKind: 21
+      HeaderType: 170 GoSwissMapHeaderType map<uint8,[4]int>
+    - __kind: GoMapType
+      ID: 157
+      Name: map[uint8]uint8
+      ByteSize: 8
+      GoRuntimeType: 1.12368e+06
+      GoKind: 21
+      HeaderType: 159 GoSwissMapHeaderType map<uint8,uint8>
+    - __kind: ArrayType
+      ID: 200
+      Name: noalg.[8]struct { key [4]int; elem [4]int }
+      ByteSize: 512
+      GoRuntimeType: 676736
+      GoKind: 17
+      Count: 8
+      HasCount: true
+      Element: 201 StructureType noalg.struct { key [4]int; elem [4]int }
+    - __kind: ArrayType
+      ID: 189
+      Name: noalg.[8]struct { key [4]int; elem uint8 }
+      ByteSize: 320
+      GoRuntimeType: 676832
+      GoKind: 17
+      Count: 8
+      HasCount: true
+      Element: 190 StructureType noalg.struct { key [4]int; elem uint8 }
+    - __kind: ArrayType
+      ID: 115
+      Name: noalg.[8]struct { key [4]string; elem [2]int }
+      ByteSize: 640
+      GoRuntimeType: 677120
+      GoKind: 17
+      Count: 8
+      HasCount: true
+      Element: 116 StructureType noalg.struct { key [4]string; elem [2]int }
+    - __kind: ArrayType
+      ID: 142
+      Name: noalg.[8]struct { key bool; elem main.node }
+      ByteSize: 192
+      GoRuntimeType: 677216
+      GoKind: 17
+      Count: 8
+      HasCount: true
+      Element: 143 StructureType noalg.struct { key bool; elem main.node }
+    - __kind: ArrayType
+      ID: 69
+      Name: noalg.[8]struct { key int; elem int }
+      ByteSize: 128
+      GoRuntimeType: 675008
+      GoKind: 17
+      Count: 8
+      HasCount: true
+      Element: 70 StructureType noalg.struct { key int; elem int }
+    - __kind: ArrayType
+      ID: 155
+      Name: noalg.[8]struct { key int; elem uint8 }
+      ByteSize: 128
+      GoRuntimeType: 677312
+      GoKind: 17
+      Count: 8
+      HasCount: true
+      Element: 156 StructureType noalg.struct { key int; elem uint8 }
+    - __kind: ArrayType
+      ID: 129
+      Name: noalg.[8]struct { key string; elem []main.structWithMap }
+      ByteSize: 320
+      GoRuntimeType: 677408
+      GoKind: 17
+      Count: 8
+      HasCount: true
+      Element: 130 StructureType noalg.struct { key string; elem []main.structWithMap }
+    - __kind: ArrayType
+      ID: 103
+      Name: noalg.[8]struct { key string; elem []string }
+      ByteSize: 320
+      GoRuntimeType: 677504
+      GoKind: 17
+      Count: 8
+      HasCount: true
+      Element: 104 StructureType noalg.struct { key string; elem []string }
+    - __kind: ArrayType
+      ID: 92
+      Name: noalg.[8]struct { key string; elem int }
+      ByteSize: 192
+      GoRuntimeType: 677600
+      GoKind: 17
+      Count: 8
+      HasCount: true
+      Element: 93 StructureType noalg.struct { key string; elem int }
+    - __kind: ArrayType
+      ID: 80
+      Name: noalg.[8]struct { key string; elem main.nestedStruct }
+      ByteSize: 320
+      GoRuntimeType: 677696
+      GoKind: 17
+      Count: 8
+      HasCount: true
+      Element: 81 StructureType noalg.struct { key string; elem main.nestedStruct }
+    - __kind: ArrayType
+      ID: 177
+      Name: noalg.[8]struct { key uint8; elem [4]int }
+      ByteSize: 320
+      GoRuntimeType: 677792
+      GoKind: 17
+      Count: 8
+      HasCount: true
+      Element: 178 StructureType noalg.struct { key uint8; elem [4]int }
+    - __kind: ArrayType
+      ID: 166
+      Name: noalg.[8]struct { key uint8; elem uint8 }
+      ByteSize: 16
+      GoRuntimeType: 677888
+      GoKind: 17
+      Count: 8
+      HasCount: true
+      Element: 167 StructureType noalg.struct { key uint8; elem uint8 }
+    - __kind: StructureType
+      ID: 199
+      Name: noalg.map.group[[4]int][4]int
+      ByteSize: 520
+      GoRuntimeType: 1.28176e+06
+      GoKind: 25
+      RawFields:
+        - Name: ctrl
+          Offset: 0
+          Type: 26 BaseType uint64
+        - Name: slots
+          Offset: 8
+          Type: 200 ArrayType noalg.[8]struct { key [4]int; elem [4]int }
+    - __kind: StructureType
+      ID: 188
+      Name: noalg.map.group[[4]int]uint8
+      ByteSize: 328
+      GoRuntimeType: 1.282016e+06
+      GoKind: 25
+      RawFields:
+        - Name: ctrl
+          Offset: 0
+          Type: 26 BaseType uint64
+        - Name: slots
+          Offset: 8
+          Type: 189 ArrayType noalg.[8]struct { key [4]int; elem uint8 }
+    - __kind: StructureType
+      ID: 114
+      Name: noalg.map.group[[4]string][2]int
+      ByteSize: 648
+      GoRuntimeType: 1.282272e+06
+      GoKind: 25
+      RawFields:
+        - Name: ctrl
+          Offset: 0
+          Type: 26 BaseType uint64
+        - Name: slots
+          Offset: 8
+          Type: 115 ArrayType noalg.[8]struct { key [4]string; elem [2]int }
+    - __kind: StructureType
+      ID: 141
+      Name: noalg.map.group[bool]main.node
+      ByteSize: 200
+      GoRuntimeType: 1.282528e+06
+      GoKind: 25
+      RawFields:
+        - Name: ctrl
+          Offset: 0
+          Type: 26 BaseType uint64
+        - Name: slots
+          Offset: 8
+          Type: 142 ArrayType noalg.[8]struct { key bool; elem main.node }
+    - __kind: StructureType
+      ID: 68
+      Name: noalg.map.group[int]int
+      ByteSize: 136
+      GoRuntimeType: 1.280992e+06
+      GoKind: 25
+      RawFields:
+        - Name: ctrl
+          Offset: 0
+          Type: 26 BaseType uint64
+        - Name: slots
+          Offset: 8
+          Type: 69 ArrayType noalg.[8]struct { key int; elem int }
+    - __kind: StructureType
+      ID: 154
+      Name: noalg.map.group[int]uint8
+      ByteSize: 136
+      GoRuntimeType: 1.282784e+06
+      GoKind: 25
+      RawFields:
+        - Name: ctrl
+          Offset: 0
+          Type: 26 BaseType uint64
+        - Name: slots
+          Offset: 8
+          Type: 155 ArrayType noalg.[8]struct { key int; elem uint8 }
+    - __kind: StructureType
+      ID: 128
+      Name: noalg.map.group[string][]main.structWithMap
+      ByteSize: 328
+      GoRuntimeType: 1.28304e+06
+      GoKind: 25
+      RawFields:
+        - Name: ctrl
+          Offset: 0
+          Type: 26 BaseType uint64
+        - Name: slots
+          Offset: 8
+          Type: 129 ArrayType noalg.[8]struct { key string; elem []main.structWithMap }
+    - __kind: StructureType
+      ID: 102
+      Name: noalg.map.group[string][]string
+      ByteSize: 328
+      GoRuntimeType: 1.283296e+06
+      GoKind: 25
+      RawFields:
+        - Name: ctrl
+          Offset: 0
+          Type: 26 BaseType uint64
+        - Name: slots
+          Offset: 8
+          Type: 103 ArrayType noalg.[8]struct { key string; elem []string }
+    - __kind: StructureType
+      ID: 91
+      Name: noalg.map.group[string]int
+      ByteSize: 200
+      GoRuntimeType: 1.283552e+06
+      GoKind: 25
+      RawFields:
+        - Name: ctrl
+          Offset: 0
+          Type: 26 BaseType uint64
+        - Name: slots
+          Offset: 8
+          Type: 92 ArrayType noalg.[8]struct { key string; elem int }
+    - __kind: StructureType
+      ID: 79
+      Name: noalg.map.group[string]main.nestedStruct
+      ByteSize: 328
+      GoRuntimeType: 1.283808e+06
+      GoKind: 25
+      RawFields:
+        - Name: ctrl
+          Offset: 0
+          Type: 26 BaseType uint64
+        - Name: slots
+          Offset: 8
+          Type: 80 ArrayType noalg.[8]struct { key string; elem main.nestedStruct }
+    - __kind: StructureType
+      ID: 176
+      Name: noalg.map.group[uint8][4]int
+      ByteSize: 328
+      GoRuntimeType: 1.284064e+06
+      GoKind: 25
+      RawFields:
+        - Name: ctrl
+          Offset: 0
+          Type: 26 BaseType uint64
+        - Name: slots
+          Offset: 8
+          Type: 177 ArrayType noalg.[8]struct { key uint8; elem [4]int }
+    - __kind: StructureType
+      ID: 165
+      Name: noalg.map.group[uint8]uint8
+      ByteSize: 24
+      GoRuntimeType: 1.28432e+06
+      GoKind: 25
+      RawFields:
+        - Name: ctrl
+          Offset: 0
+          Type: 26 BaseType uint64
+        - Name: slots
+          Offset: 8
+          Type: 166 ArrayType noalg.[8]struct { key uint8; elem uint8 }
+    - __kind: StructureType
+      ID: 201
+      Name: noalg.struct { key [4]int; elem [4]int }
+      ByteSize: 64
+      GoRuntimeType: 1.281632e+06
+      GoKind: 25
+      RawFields:
+        - Name: key
+          Offset: 0
+          Type: 179 ArrayType [4]int
+        - Name: elem
+          Offset: 32
+          Type: 179 ArrayType [4]int
+    - __kind: StructureType
+      ID: 190
+      Name: noalg.struct { key [4]int; elem uint8 }
+      ByteSize: 40
+      GoRuntimeType: 1.281888e+06
+      GoKind: 25
+      RawFields:
+        - Name: key
+          Offset: 0
+          Type: 179 ArrayType [4]int
+        - Name: elem
+          Offset: 32
+          Type: 4 BaseType uint8
+    - __kind: StructureType
+      ID: 116
+      Name: noalg.struct { key [4]string; elem [2]int }
+      ByteSize: 80
+      GoRuntimeType: 1.282144e+06
+      GoKind: 25
+      RawFields:
+        - Name: key
+          Offset: 0
+          Type: 117 ArrayType [4]string
+        - Name: elem
+          Offset: 64
+          Type: 12 ArrayType [2]int
+    - __kind: StructureType
+      ID: 143
+      Name: noalg.struct { key bool; elem main.node }
+      ByteSize: 24
+      GoRuntimeType: 1.2824e+06
+      GoKind: 25
+      RawFields:
+        - Name: key
+          Offset: 0
+          Type: 11 BaseType bool
+        - Name: elem
+          Offset: 8
+          Type: 144 StructureType main.node
+    - __kind: StructureType
+      ID: 70
+      Name: noalg.struct { key int; elem int }
+      ByteSize: 16
+      GoRuntimeType: 1.280864e+06
+      GoKind: 25
+      RawFields:
+        - Name: key
+          Offset: 0
+          Type: 1 BaseType int
+        - Name: elem
+          Offset: 8
+          Type: 1 BaseType int
+    - __kind: StructureType
+      ID: 156
+      Name: noalg.struct { key int; elem uint8 }
+      ByteSize: 16
+      GoRuntimeType: 1.282656e+06
+      GoKind: 25
+      RawFields:
+        - Name: key
+          Offset: 0
+          Type: 1 BaseType int
+        - Name: elem
+          Offset: 8
+          Type: 4 BaseType uint8
+    - __kind: StructureType
+      ID: 130
+      Name: noalg.struct { key string; elem []main.structWithMap }
+      ByteSize: 40
+      GoRuntimeType: 1.282912e+06
+      GoKind: 25
+      RawFields:
+        - Name: key
+          Offset: 0
+          Type: 8 GoStringHeaderType string
+        - Name: elem
+          Offset: 16
+          Type: 131 GoSliceHeaderType []main.structWithMap
+    - __kind: StructureType
+      ID: 104
+      Name: noalg.struct { key string; elem []string }
+      ByteSize: 40
+      GoRuntimeType: 1.283168e+06
+      GoKind: 25
+      RawFields:
+        - Name: key
+          Offset: 0
+          Type: 8 GoStringHeaderType string
+        - Name: elem
+          Offset: 16
+          Type: 105 GoSliceHeaderType []string
+    - __kind: StructureType
+      ID: 93
+      Name: noalg.struct { key string; elem int }
+      ByteSize: 24
+      GoRuntimeType: 1.283424e+06
+      GoKind: 25
+      RawFields:
+        - Name: key
+          Offset: 0
+          Type: 8 GoStringHeaderType string
+        - Name: elem
+          Offset: 16
+          Type: 1 BaseType int
+    - __kind: StructureType
+      ID: 81
+      Name: noalg.struct { key string; elem main.nestedStruct }
+      ByteSize: 40
+      GoRuntimeType: 1.28368e+06
+      GoKind: 25
+      RawFields:
+        - Name: key
+          Offset: 0
+          Type: 8 GoStringHeaderType string
+        - Name: elem
+          Offset: 16
+          Type: 82 StructureType main.nestedStruct
+    - __kind: StructureType
+      ID: 178
+      Name: noalg.struct { key uint8; elem [4]int }
+      ByteSize: 40
+      GoRuntimeType: 1.283936e+06
+      GoKind: 25
+      RawFields:
+        - Name: key
+          Offset: 0
+          Type: 4 BaseType uint8
+        - Name: elem
+          Offset: 8
+          Type: 179 ArrayType [4]int
+    - __kind: StructureType
+      ID: 167
+      Name: noalg.struct { key uint8; elem uint8 }
+      ByteSize: 2
+      GoRuntimeType: 1.284192e+06
+      GoKind: 25
+      RawFields:
+        - Name: key
+          Offset: 0
+          Type: 4 BaseType uint8
+        - Name: elem
+          Offset: 1
+          Type: 4 BaseType uint8
+    - __kind: GoStringHeaderType
+      ID: 8
+      Name: string
+      ByteSize: 16
+      GoRuntimeType: 578784
+      GoKind: 24
+      RawFields:
+        - Name: str
+          Offset: 0
+          Type: 239 PointerType *string.str
+        - Name: len
+          Offset: 8
+          Type: 1 BaseType int
+      Data: 238 GoStringDataType string.str
+    - __kind: GoStringDataType
+      ID: 238
+      Name: string.str
+      ByteSize: 2048
+    - __kind: StructureType
+      ID: 46
+      Name: sync.Mutex
+      ByteSize: 8
+      GoRuntimeType: 1.44992e+06
+      GoKind: 25
+      RawFields:
+        - Name: _
+          Offset: 0
+          Type: 47 StructureType sync.noCopy
+        - Name: mu
+          Offset: 0
+          Type: 48 StructureType internal/sync.Mutex
+    - __kind: StructureType
+      ID: 49
+      Name: sync.Once
+      ByteSize: 12
+      GoRuntimeType: 1.598816e+06
+      GoKind: 25
+      RawFields:
+        - Name: _
+          Offset: 0
+          Type: 47 StructureType sync.noCopy
+        - Name: done
+          Offset: 0
+          Type: 50 StructureType sync/atomic.Bool
+        - Name: m
+          Offset: 4
+          Type: 46 StructureType sync.Mutex
+    - __kind: StructureType
+      ID: 52
+      Name: sync.WaitGroup
+      ByteSize: 16
+      GoRuntimeType: 1.598624e+06
+      GoKind: 25
+      RawFields:
+        - Name: noCopy
+          Offset: 0
+          Type: 47 StructureType sync.noCopy
+        - Name: state
+          Offset: 0
+          Type: 53 StructureType sync/atomic.Uint64
+        - Name: sema
+          Offset: 8
+          Type: 24 BaseType uint32
+    - __kind: StructureType
+      ID: 47
+      Name: sync.noCopy
+      GoRuntimeType: 982144
+      GoKind: 25
+      RawFields: []
+    - __kind: StructureType
+      ID: 50
+      Name: sync/atomic.Bool
+      ByteSize: 4
+      GoRuntimeType: 1.45104e+06
+      GoKind: 25
+      RawFields:
+        - Name: _
+          Offset: 0
+          Type: 51 StructureType sync/atomic.noCopy
+        - Name: v
+          Offset: 0
+          Type: 24 BaseType uint32
+    - __kind: StructureType
+      ID: 55
+      Name: sync/atomic.Int32
+      ByteSize: 4
+      GoRuntimeType: 1.4512e+06
+      GoKind: 25
+      RawFields:
+        - Name: _
+          Offset: 0
+          Type: 51 StructureType sync/atomic.noCopy
+        - Name: v
+          Offset: 0
+          Type: 6 BaseType int32
+    - __kind: StructureType
+      ID: 53
+      Name: sync/atomic.Uint64
+      ByteSize: 8
+      GoRuntimeType: 1.5992e+06
+      GoKind: 25
+      RawFields:
+        - Name: _
+          Offset: 0
+          Type: 51 StructureType sync/atomic.noCopy
+        - Name: _
+          Offset: 0
+          Type: 54 StructureType sync/atomic.align64
+        - Name: v
+          Offset: 0
+          Type: 26 BaseType uint64
+    - __kind: StructureType
+      ID: 54
+      Name: sync/atomic.align64
+      GoRuntimeType: 982336
+      GoKind: 25
+      RawFields: []
+    - __kind: StructureType
+      ID: 51
+      Name: sync/atomic.noCopy
+      GoRuntimeType: 982240
+      GoKind: 25
+      RawFields: []
+    - __kind: StructureType
+      ID: 196
+      Name: table<[4]int,[4]int>
+      ByteSize: 32
+      GoKind: 25
+      RawFields:
+        - Name: used
+          Offset: 0
+          Type: 22 BaseType uint16
+        - Name: capacity
+          Offset: 2
+          Type: 22 BaseType uint16
+        - Name: growthLeft
+          Offset: 4
+          Type: 22 BaseType uint16
+        - Name: localDepth
+          Offset: 6
+          Type: 4 BaseType uint8
+        - Name: index
+          Offset: 8
+          Type: 1 BaseType int
+        - Name: groups
+          Offset: 16
+          Type: 197 GoSwissMapGroupsType groupReference<[4]int,[4]int>
+    - __kind: StructureType
+      ID: 185
+      Name: table<[4]int,uint8>
+      ByteSize: 32
+      GoKind: 25
+      RawFields:
+        - Name: used
+          Offset: 0
+          Type: 22 BaseType uint16
+        - Name: capacity
+          Offset: 2
+          Type: 22 BaseType uint16
+        - Name: growthLeft
+          Offset: 4
+          Type: 22 BaseType uint16
+        - Name: localDepth
+          Offset: 6
+          Type: 4 BaseType uint8
+        - Name: index
+          Offset: 8
+          Type: 1 BaseType int
+        - Name: groups
+          Offset: 16
+          Type: 186 GoSwissMapGroupsType groupReference<[4]int,uint8>
+    - __kind: StructureType
+      ID: 111
+      Name: table<[4]string,[2]int>
+      ByteSize: 32
+      GoKind: 25
+      RawFields:
+        - Name: used
+          Offset: 0
+          Type: 22 BaseType uint16
+        - Name: capacity
+          Offset: 2
+          Type: 22 BaseType uint16
+        - Name: growthLeft
+          Offset: 4
+          Type: 22 BaseType uint16
+        - Name: localDepth
+          Offset: 6
+          Type: 4 BaseType uint8
+        - Name: index
+          Offset: 8
+          Type: 1 BaseType int
+        - Name: groups
+          Offset: 16
+          Type: 112 GoSwissMapGroupsType groupReference<[4]string,[2]int>
+    - __kind: StructureType
+      ID: 138
+      Name: table<bool,main.node>
+      ByteSize: 32
+      GoKind: 25
+      RawFields:
+        - Name: used
+          Offset: 0
+          Type: 22 BaseType uint16
+        - Name: capacity
+          Offset: 2
+          Type: 22 BaseType uint16
+        - Name: growthLeft
+          Offset: 4
+          Type: 22 BaseType uint16
+        - Name: localDepth
+          Offset: 6
+          Type: 4 BaseType uint8
+        - Name: index
+          Offset: 8
+          Type: 1 BaseType int
+        - Name: groups
+          Offset: 16
+          Type: 139 GoSwissMapGroupsType groupReference<bool,main.node>
+    - __kind: StructureType
+      ID: 65
+      Name: table<int,int>
+      ByteSize: 32
+      GoKind: 25
+      RawFields:
+        - Name: used
+          Offset: 0
+          Type: 22 BaseType uint16
+        - Name: capacity
+          Offset: 2
+          Type: 22 BaseType uint16
+        - Name: growthLeft
+          Offset: 4
+          Type: 22 BaseType uint16
+        - Name: localDepth
+          Offset: 6
+          Type: 4 BaseType uint8
+        - Name: index
+          Offset: 8
+          Type: 1 BaseType int
+        - Name: groups
+          Offset: 16
+          Type: 66 GoSwissMapGroupsType groupReference<int,int>
+    - __kind: StructureType
+      ID: 151
+      Name: table<int,uint8>
+      ByteSize: 32
+      GoKind: 25
+      RawFields:
+        - Name: used
+          Offset: 0
+          Type: 22 BaseType uint16
+        - Name: capacity
+          Offset: 2
+          Type: 22 BaseType uint16
+        - Name: growthLeft
+          Offset: 4
+          Type: 22 BaseType uint16
+        - Name: localDepth
+          Offset: 6
+          Type: 4 BaseType uint8
+        - Name: index
+          Offset: 8
+          Type: 1 BaseType int
+        - Name: groups
+          Offset: 16
+          Type: 152 GoSwissMapGroupsType groupReference<int,uint8>
+    - __kind: StructureType
+      ID: 125
+      Name: table<string,[]main.structWithMap>
+      ByteSize: 32
+      GoKind: 25
+      RawFields:
+        - Name: used
+          Offset: 0
+          Type: 22 BaseType uint16
+        - Name: capacity
+          Offset: 2
+          Type: 22 BaseType uint16
+        - Name: growthLeft
+          Offset: 4
+          Type: 22 BaseType uint16
+        - Name: localDepth
+          Offset: 6
+          Type: 4 BaseType uint8
+        - Name: index
+          Offset: 8
+          Type: 1 BaseType int
+        - Name: groups
+          Offset: 16
+          Type: 126 GoSwissMapGroupsType groupReference<string,[]main.structWithMap>
+    - __kind: StructureType
+      ID: 99
+      Name: table<string,[]string>
+      ByteSize: 32
+      GoKind: 25
+      RawFields:
+        - Name: used
+          Offset: 0
+          Type: 22 BaseType uint16
+        - Name: capacity
+          Offset: 2
+          Type: 22 BaseType uint16
+        - Name: growthLeft
+          Offset: 4
+          Type: 22 BaseType uint16
+        - Name: localDepth
+          Offset: 6
+          Type: 4 BaseType uint8
+        - Name: index
+          Offset: 8
+          Type: 1 BaseType int
+        - Name: groups
+          Offset: 16
+          Type: 100 GoSwissMapGroupsType groupReference<string,[]string>
+    - __kind: StructureType
+      ID: 88
+      Name: table<string,int>
+      ByteSize: 32
+      GoKind: 25
+      RawFields:
+        - Name: used
+          Offset: 0
+          Type: 22 BaseType uint16
+        - Name: capacity
+          Offset: 2
+          Type: 22 BaseType uint16
+        - Name: growthLeft
+          Offset: 4
+          Type: 22 BaseType uint16
+        - Name: localDepth
+          Offset: 6
+          Type: 4 BaseType uint8
+        - Name: index
+          Offset: 8
+          Type: 1 BaseType int
+        - Name: groups
+          Offset: 16
+          Type: 89 GoSwissMapGroupsType groupReference<string,int>
+    - __kind: StructureType
+      ID: 76
+      Name: table<string,main.nestedStruct>
+      ByteSize: 32
+      GoKind: 25
+      RawFields:
+        - Name: used
+          Offset: 0
+          Type: 22 BaseType uint16
+        - Name: capacity
+          Offset: 2
+          Type: 22 BaseType uint16
+        - Name: growthLeft
+          Offset: 4
+          Type: 22 BaseType uint16
+        - Name: localDepth
+          Offset: 6
+          Type: 4 BaseType uint8
+        - Name: index
+          Offset: 8
+          Type: 1 BaseType int
+        - Name: groups
+          Offset: 16
+          Type: 77 GoSwissMapGroupsType groupReference<string,main.nestedStruct>
+    - __kind: StructureType
+      ID: 173
+      Name: table<uint8,[4]int>
+      ByteSize: 32
+      GoKind: 25
+      RawFields:
+        - Name: used
+          Offset: 0
+          Type: 22 BaseType uint16
+        - Name: capacity
+          Offset: 2
+          Type: 22 BaseType uint16
+        - Name: growthLeft
+          Offset: 4
+          Type: 22 BaseType uint16
+        - Name: localDepth
+          Offset: 6
+          Type: 4 BaseType uint8
+        - Name: index
+          Offset: 8
+          Type: 1 BaseType int
+        - Name: groups
+          Offset: 16
+          Type: 174 GoSwissMapGroupsType groupReference<uint8,[4]int>
+    - __kind: StructureType
+      ID: 162
+      Name: table<uint8,uint8>
+      ByteSize: 32
+      GoKind: 25
+      RawFields:
+        - Name: used
+          Offset: 0
+          Type: 22 BaseType uint16
+        - Name: capacity
+          Offset: 2
+          Type: 22 BaseType uint16
+        - Name: growthLeft
+          Offset: 4
+          Type: 22 BaseType uint16
+        - Name: localDepth
+          Offset: 6
+          Type: 4 BaseType uint8
+        - Name: index
+          Offset: 8
+          Type: 1 BaseType int
+        - Name: groups
+          Offset: 16
+          Type: 163 GoSwissMapGroupsType groupReference<uint8,uint8>
+    - __kind: BaseType
+      ID: 20
+      Name: uint
+      ByteSize: 8
+      GoRuntimeType: 579424
+      GoKind: 7
+    - __kind: BaseType
+      ID: 22
+      Name: uint16
+      ByteSize: 2
+      GoRuntimeType: 579040
+      GoKind: 9
+    - __kind: BaseType
+      ID: 24
+      Name: uint32
+      ByteSize: 4
+      GoRuntimeType: 579168
+      GoKind: 10
+    - __kind: BaseType
+      ID: 26
+      Name: uint64
+      ByteSize: 8
+      GoRuntimeType: 579296
+      GoKind: 11
+    - __kind: BaseType
+      ID: 4
+      Name: uint8
+      ByteSize: 1
+      GoRuntimeType: 578912
+      GoKind: 8
+    - __kind: BaseType
+      ID: 62
+      Name: uintptr
+      ByteSize: 8
+      GoRuntimeType: 579488
+      GoKind: 12
+    - __kind: VoidPointerType
+      ID: 38
+      Name: unsafe.Pointer
+      ByteSize: 8
+      GoRuntimeType: 579872
+      GoKind: 26
 MaxTypeID: 385
 Issues: []
 GoModuledataInfo: {FirstModuledataAddr: "0x17fa4e0", TypesOffset: 296}

--- a/pkg/dyninst/irgen/testdata/snapshot/sample.arch=amd64,toolchain=go1.25.0.yaml
+++ b/pkg/dyninst/irgen/testdata/snapshot/sample.arch=amd64,toolchain=go1.25.0.yaml
@@ -3095,7 +3095,7 @@ Subprograms:
           IsReturn: false
 Types:
     - __kind: PointerType
-      ID: 173
+      ID: 277
       Name: '**main.t'
       ByteSize: 8
       Pointee: 133 PointerType *main.t
@@ -3167,50 +3167,50 @@ Types:
       ByteSize: 8
       Pointee: 112 PointerType *table<uint8,uint8>
     - __kind: PointerType
-      ID: 177
+      ID: 154
       Name: '*[]*string.array'
       ByteSize: 8
-      Pointee: 176 GoSliceDataType []*string.array
+      Pointee: 153 GoSliceDataType []*string.array
     - __kind: PointerType
-      ID: 271
+      ID: 258
       Name: '*[][]uint.array'
       ByteSize: 8
-      Pointee: 270 GoSliceDataType [][]uint.array
+      Pointee: 257 GoSliceDataType [][]uint.array
     - __kind: PointerType
-      ID: 277
+      ID: 264
       Name: '*[]bool.array'
       ByteSize: 8
-      Pointee: 276 GoSliceDataType []bool.array
+      Pointee: 263 GoSliceDataType []bool.array
     - __kind: PointerType
       ID: 281
       Name: '*[]main.structWithMap.array'
       ByteSize: 8
       Pointee: 280 GoSliceDataType []main.structWithMap.array
     - __kind: PointerType
-      ID: 273
+      ID: 260
       Name: '*[]main.structWithNoStrings.array'
       ByteSize: 8
-      Pointee: 272 GoSliceDataType []main.structWithNoStrings.array
+      Pointee: 259 GoSliceDataType []main.structWithNoStrings.array
     - __kind: PointerType
-      ID: 275
+      ID: 262
       Name: '*[]string.array'
       ByteSize: 8
-      Pointee: 274 GoSliceDataType []string.array
+      Pointee: 261 GoSliceDataType []string.array
     - __kind: PointerType
       ID: 137
       Name: '*[]uint'
       ByteSize: 8
       Pointee: 135 GoSliceHeaderType []uint
     - __kind: PointerType
-      ID: 269
+      ID: 256
       Name: '*[]uint.array'
       ByteSize: 8
-      Pointee: 268 GoSliceDataType []uint.array
+      Pointee: 255 GoSliceDataType []uint.array
     - __kind: PointerType
-      ID: 279
+      ID: 266
       Name: '*[]uint16.array'
       ByteSize: 8
-      Pointee: 278 GoSliceDataType []uint16.array
+      Pointee: 265 GoSliceDataType []uint16.array
     - __kind: PointerType
       ID: 11
       Name: '*bool'
@@ -3295,7 +3295,7 @@ Types:
       GoKind: 22
       Pointee: 147 StructureType main.oneStringStruct
     - __kind: PointerType
-      ID: 220
+      ID: 203
       Name: '*main.structWithMap'
       ByteSize: 8
       GoRuntimeType: 382976
@@ -3319,10 +3319,10 @@ Types:
       GoKind: 22
       Pointee: 134 GoSliceHeaderType main.t
     - __kind: PointerType
-      ID: 267
+      ID: 279
       Name: '*main.t.array'
       ByteSize: 8
-      Pointee: 266 GoSliceDataType main.t.array
+      Pointee: 278 GoSliceDataType main.t.array
     - __kind: PointerType
       ID: 145
       Name: '*main.threeStringStruct'
@@ -3396,65 +3396,65 @@ Types:
       GoKind: 22
       Pointee: 76 GoMapType map[string]int
     - __kind: PointerType
-      ID: 260
+      ID: 249
       Name: '*noalg.map.group[[4]int][4]int'
       ByteSize: 8
-      Pointee: 261 StructureType noalg.map.group[[4]int][4]int
+      Pointee: 250 StructureType noalg.map.group[[4]int][4]int
     - __kind: PointerType
-      ID: 253
+      ID: 241
       Name: '*noalg.map.group[[4]int]uint8'
       ByteSize: 8
-      Pointee: 254 StructureType noalg.map.group[[4]int]uint8
+      Pointee: 242 StructureType noalg.map.group[[4]int]uint8
     - __kind: PointerType
-      ID: 207
+      ID: 189
       Name: '*noalg.map.group[[4]string][2]int'
       ByteSize: 8
-      Pointee: 208 StructureType noalg.map.group[[4]string][2]int
+      Pointee: 190 StructureType noalg.map.group[[4]string][2]int
     - __kind: PointerType
-      ID: 224
+      ID: 208
       Name: '*noalg.map.group[bool]main.node'
       ByteSize: 8
-      Pointee: 225 StructureType noalg.map.group[bool]main.node
+      Pointee: 209 StructureType noalg.map.group[bool]main.node
     - __kind: PointerType
-      ID: 179
+      ID: 157
       Name: '*noalg.map.group[int]int'
       ByteSize: 8
-      Pointee: 180 StructureType noalg.map.group[int]int
+      Pointee: 158 StructureType noalg.map.group[int]int
     - __kind: PointerType
-      ID: 231
+      ID: 216
       Name: '*noalg.map.group[int]uint8'
       ByteSize: 8
-      Pointee: 232 StructureType noalg.map.group[int]uint8
+      Pointee: 217 StructureType noalg.map.group[int]uint8
     - __kind: PointerType
-      ID: 215
+      ID: 198
       Name: '*noalg.map.group[string][]main.structWithMap'
       ByteSize: 8
-      Pointee: 216 StructureType noalg.map.group[string][]main.structWithMap
+      Pointee: 199 StructureType noalg.map.group[string][]main.structWithMap
     - __kind: PointerType
-      ID: 200
+      ID: 181
       Name: '*noalg.map.group[string][]string'
       ByteSize: 8
-      Pointee: 201 StructureType noalg.map.group[string][]string
+      Pointee: 182 StructureType noalg.map.group[string][]string
     - __kind: PointerType
-      ID: 193
+      ID: 173
       Name: '*noalg.map.group[string]int'
       ByteSize: 8
-      Pointee: 194 StructureType noalg.map.group[string]int
+      Pointee: 174 StructureType noalg.map.group[string]int
     - __kind: PointerType
-      ID: 186
+      ID: 165
       Name: '*noalg.map.group[string]main.nestedStruct'
       ByteSize: 8
-      Pointee: 187 StructureType noalg.map.group[string]main.nestedStruct
+      Pointee: 166 StructureType noalg.map.group[string]main.nestedStruct
     - __kind: PointerType
-      ID: 245
+      ID: 232
       Name: '*noalg.map.group[uint8][4]int'
       ByteSize: 8
-      Pointee: 246 StructureType noalg.map.group[uint8][4]int
+      Pointee: 233 StructureType noalg.map.group[uint8][4]int
     - __kind: PointerType
-      ID: 238
+      ID: 224
       Name: '*noalg.map.group[uint8]uint8'
       ByteSize: 8
-      Pointee: 239 StructureType noalg.map.group[uint8]uint8
+      Pointee: 225 StructureType noalg.map.group[uint8]uint8
     - __kind: PointerType
       ID: 22
       Name: '*string'
@@ -3463,70 +3463,70 @@ Types:
       GoKind: 22
       Pointee: 9 GoStringHeaderType string
     - __kind: PointerType
-      ID: 175
+      ID: 152
       Name: '*string.str'
       ByteSize: 8
-      Pointee: 174 GoStringDataType string.str
+      Pointee: 151 GoStringDataType string.str
     - __kind: PointerType
       ID: 127
       Name: '*table<[4]int,[4]int>'
       ByteSize: 8
-      Pointee: 172 StructureType table<[4]int,[4]int>
+      Pointee: 247 StructureType table<[4]int,[4]int>
     - __kind: PointerType
       ID: 122
       Name: '*table<[4]int,uint8>'
       ByteSize: 8
-      Pointee: 171 StructureType table<[4]int,uint8>
+      Pointee: 239 StructureType table<[4]int,uint8>
     - __kind: PointerType
       ID: 90
       Name: '*table<[4]string,[2]int>'
       ByteSize: 8
-      Pointee: 165 StructureType table<[4]string,[2]int>
+      Pointee: 187 StructureType table<[4]string,[2]int>
     - __kind: PointerType
       ID: 102
       Name: '*table<bool,main.node>'
       ByteSize: 8
-      Pointee: 167 StructureType table<bool,main.node>
+      Pointee: 206 StructureType table<bool,main.node>
     - __kind: PointerType
       ID: 70
       Name: '*table<int,int>'
       ByteSize: 8
-      Pointee: 161 StructureType table<int,int>
+      Pointee: 155 StructureType table<int,int>
     - __kind: PointerType
       ID: 107
       Name: '*table<int,uint8>'
       ByteSize: 8
-      Pointee: 168 StructureType table<int,uint8>
+      Pointee: 214 StructureType table<int,uint8>
     - __kind: PointerType
       ID: 97
       Name: '*table<string,[]main.structWithMap>'
       ByteSize: 8
-      Pointee: 166 StructureType table<string,[]main.structWithMap>
+      Pointee: 196 StructureType table<string,[]main.structWithMap>
     - __kind: PointerType
       ID: 85
       Name: '*table<string,[]string>'
       ByteSize: 8
-      Pointee: 164 StructureType table<string,[]string>
+      Pointee: 179 StructureType table<string,[]string>
     - __kind: PointerType
       ID: 80
       Name: '*table<string,int>'
       ByteSize: 8
-      Pointee: 163 StructureType table<string,int>
+      Pointee: 171 StructureType table<string,int>
     - __kind: PointerType
       ID: 75
       Name: '*table<string,main.nestedStruct>'
       ByteSize: 8
-      Pointee: 162 StructureType table<string,main.nestedStruct>
+      Pointee: 163 StructureType table<string,main.nestedStruct>
     - __kind: PointerType
       ID: 117
       Name: '*table<uint8,[4]int>'
       ByteSize: 8
-      Pointee: 170 StructureType table<uint8,[4]int>
+      Pointee: 230 StructureType table<uint8,[4]int>
     - __kind: PointerType
       ID: 112
       Name: '*table<uint8,uint8>'
       ByteSize: 8
-      Pointee: 169 StructureType table<uint8,uint8>
+      Pointee: 222 StructureType table<uint8,uint8>
     - __kind: PointerType
       ID: 34
       Name: '*uint'
@@ -5338,7 +5338,7 @@ Types:
       HasCount: true
       Element: 3 BaseType uint8
     - __kind: ArrayType
-      ID: 249
+      ID: 236
       Name: '[4]int'
       ByteSize: 32
       GoRuntimeType: 676640
@@ -5347,7 +5347,7 @@ Types:
       HasCount: true
       Element: 7 BaseType int
     - __kind: ArrayType
-      ID: 211
+      ID: 193
       Name: '[4]string'
       ByteSize: 64
       GoRuntimeType: 676928
@@ -5379,69 +5379,69 @@ Types:
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 176 GoSliceDataType []*string.array
+      Data: 153 GoSliceDataType []*string.array
     - __kind: GoSliceDataType
-      ID: 176
+      ID: 153
       Name: '[]*string.array'
       ByteSize: 2048
       Element: 22 PointerType *string
     - __kind: GoSliceDataType
-      ID: 264
+      ID: 253
       Name: '[]*table<[4]int,[4]int>.array'
       ByteSize: 8192
       Element: 127 PointerType *table<[4]int,[4]int>
     - __kind: GoSliceDataType
-      ID: 257
+      ID: 245
       Name: '[]*table<[4]int,uint8>.array'
       ByteSize: 8192
       Element: 122 PointerType *table<[4]int,uint8>
     - __kind: GoSliceDataType
-      ID: 212
+      ID: 194
       Name: '[]*table<[4]string,[2]int>.array'
       ByteSize: 8192
       Element: 90 PointerType *table<[4]string,[2]int>
     - __kind: GoSliceDataType
-      ID: 228
+      ID: 212
       Name: '[]*table<bool,main.node>.array'
       ByteSize: 8192
       Element: 102 PointerType *table<bool,main.node>
     - __kind: GoSliceDataType
-      ID: 183
+      ID: 161
       Name: '[]*table<int,int>.array'
       ByteSize: 8192
       Element: 70 PointerType *table<int,int>
     - __kind: GoSliceDataType
-      ID: 235
+      ID: 220
       Name: '[]*table<int,uint8>.array'
       ByteSize: 8192
       Element: 107 PointerType *table<int,uint8>
     - __kind: GoSliceDataType
-      ID: 221
+      ID: 204
       Name: '[]*table<string,[]main.structWithMap>.array'
       ByteSize: 8192
       Element: 97 PointerType *table<string,[]main.structWithMap>
     - __kind: GoSliceDataType
-      ID: 204
+      ID: 185
       Name: '[]*table<string,[]string>.array'
       ByteSize: 8192
       Element: 85 PointerType *table<string,[]string>
     - __kind: GoSliceDataType
-      ID: 197
+      ID: 177
       Name: '[]*table<string,int>.array'
       ByteSize: 8192
       Element: 80 PointerType *table<string,int>
     - __kind: GoSliceDataType
-      ID: 190
+      ID: 169
       Name: '[]*table<string,main.nestedStruct>.array'
       ByteSize: 8192
       Element: 75 PointerType *table<string,main.nestedStruct>
     - __kind: GoSliceDataType
-      ID: 250
+      ID: 237
       Name: '[]*table<uint8,[4]int>.array'
       ByteSize: 8192
       Element: 117 PointerType *table<uint8,[4]int>
     - __kind: GoSliceDataType
-      ID: 242
+      ID: 228
       Name: '[]*table<uint8,uint8>.array'
       ByteSize: 8192
       Element: 112 PointerType *table<uint8,uint8>
@@ -5460,9 +5460,9 @@ Types:
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 270 GoSliceDataType [][]uint.array
+      Data: 257 GoSliceDataType [][]uint.array
     - __kind: GoSliceDataType
-      ID: 270
+      ID: 257
       Name: '[][]uint.array'
       ByteSize: 2048
       Element: 135 GoSliceHeaderType []uint
@@ -5482,14 +5482,14 @@ Types:
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 276 GoSliceDataType []bool.array
+      Data: 263 GoSliceDataType []bool.array
     - __kind: GoSliceDataType
-      ID: 276
+      ID: 263
       Name: '[]bool.array'
       ByteSize: 2048
       Element: 4 BaseType bool
     - __kind: GoSliceHeaderType
-      ID: 219
+      ID: 202
       Name: '[]main.structWithMap'
       ByteSize: 24
       GoRuntimeType: 472768
@@ -5497,7 +5497,7 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 220 PointerType *main.structWithMap
+          Type: 203 PointerType *main.structWithMap
         - Name: len
           Offset: 8
           Type: 7 BaseType int
@@ -5525,72 +5525,72 @@ Types:
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 272 GoSliceDataType []main.structWithNoStrings.array
+      Data: 259 GoSliceDataType []main.structWithNoStrings.array
     - __kind: GoSliceDataType
-      ID: 272
+      ID: 259
       Name: '[]main.structWithNoStrings.array'
       ByteSize: 2048
       Element: 140 StructureType main.structWithNoStrings
     - __kind: GoSliceDataType
-      ID: 265
+      ID: 254
       Name: '[]noalg.map.group[[4]int][4]int.array'
       ByteSize: 2048
-      Element: 261 StructureType noalg.map.group[[4]int][4]int
+      Element: 250 StructureType noalg.map.group[[4]int][4]int
     - __kind: GoSliceDataType
-      ID: 258
+      ID: 246
       Name: '[]noalg.map.group[[4]int]uint8.array'
       ByteSize: 2048
-      Element: 254 StructureType noalg.map.group[[4]int]uint8
+      Element: 242 StructureType noalg.map.group[[4]int]uint8
     - __kind: GoSliceDataType
-      ID: 213
+      ID: 195
       Name: '[]noalg.map.group[[4]string][2]int.array'
       ByteSize: 2048
-      Element: 208 StructureType noalg.map.group[[4]string][2]int
+      Element: 190 StructureType noalg.map.group[[4]string][2]int
     - __kind: GoSliceDataType
-      ID: 229
+      ID: 213
       Name: '[]noalg.map.group[bool]main.node.array'
       ByteSize: 2048
-      Element: 225 StructureType noalg.map.group[bool]main.node
+      Element: 209 StructureType noalg.map.group[bool]main.node
     - __kind: GoSliceDataType
-      ID: 184
+      ID: 162
       Name: '[]noalg.map.group[int]int.array'
       ByteSize: 2048
-      Element: 180 StructureType noalg.map.group[int]int
+      Element: 158 StructureType noalg.map.group[int]int
     - __kind: GoSliceDataType
-      ID: 236
+      ID: 221
       Name: '[]noalg.map.group[int]uint8.array'
       ByteSize: 2048
-      Element: 232 StructureType noalg.map.group[int]uint8
-    - __kind: GoSliceDataType
-      ID: 222
-      Name: '[]noalg.map.group[string][]main.structWithMap.array'
-      ByteSize: 2048
-      Element: 216 StructureType noalg.map.group[string][]main.structWithMap
+      Element: 217 StructureType noalg.map.group[int]uint8
     - __kind: GoSliceDataType
       ID: 205
+      Name: '[]noalg.map.group[string][]main.structWithMap.array'
+      ByteSize: 2048
+      Element: 199 StructureType noalg.map.group[string][]main.structWithMap
+    - __kind: GoSliceDataType
+      ID: 186
       Name: '[]noalg.map.group[string][]string.array'
       ByteSize: 2048
-      Element: 201 StructureType noalg.map.group[string][]string
+      Element: 182 StructureType noalg.map.group[string][]string
     - __kind: GoSliceDataType
-      ID: 198
+      ID: 178
       Name: '[]noalg.map.group[string]int.array'
       ByteSize: 2048
-      Element: 194 StructureType noalg.map.group[string]int
+      Element: 174 StructureType noalg.map.group[string]int
     - __kind: GoSliceDataType
-      ID: 191
+      ID: 170
       Name: '[]noalg.map.group[string]main.nestedStruct.array'
       ByteSize: 2048
-      Element: 187 StructureType noalg.map.group[string]main.nestedStruct
+      Element: 166 StructureType noalg.map.group[string]main.nestedStruct
     - __kind: GoSliceDataType
-      ID: 251
+      ID: 238
       Name: '[]noalg.map.group[uint8][4]int.array'
       ByteSize: 2048
-      Element: 246 StructureType noalg.map.group[uint8][4]int
+      Element: 233 StructureType noalg.map.group[uint8][4]int
     - __kind: GoSliceDataType
-      ID: 243
+      ID: 229
       Name: '[]noalg.map.group[uint8]uint8.array'
       ByteSize: 2048
-      Element: 239 StructureType noalg.map.group[uint8]uint8
+      Element: 225 StructureType noalg.map.group[uint8]uint8
     - __kind: GoSliceHeaderType
       ID: 141
       Name: '[]string'
@@ -5607,9 +5607,9 @@ Types:
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 274 GoSliceDataType []string.array
+      Data: 261 GoSliceDataType []string.array
     - __kind: GoSliceDataType
-      ID: 274
+      ID: 261
       Name: '[]string.array'
       ByteSize: 2048
       Element: 9 GoStringHeaderType string
@@ -5629,9 +5629,9 @@ Types:
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 268 GoSliceDataType []uint.array
+      Data: 255 GoSliceDataType []uint.array
     - __kind: GoSliceDataType
-      ID: 268
+      ID: 255
       Name: '[]uint.array'
       ByteSize: 2048
       Element: 17 BaseType uint
@@ -5651,9 +5651,9 @@ Types:
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 278 GoSliceDataType []uint16.array
+      Data: 265 GoSliceDataType []uint16.array
     - __kind: GoSliceDataType
-      ID: 278
+      ID: 265
       Name: '[]uint16.array'
       ByteSize: 2048
       Element: 6 BaseType uint16
@@ -5717,173 +5717,173 @@ Types:
       GoRuntimeType: 471744
       GoKind: 19
     - __kind: GoSwissMapGroupsType
-      ID: 259
+      ID: 248
       Name: groupReference<[4]int,[4]int>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 260 PointerType *noalg.map.group[[4]int][4]int
+          Type: 249 PointerType *noalg.map.group[[4]int][4]int
         - Name: lengthMask
           Offset: 8
           Type: 8 BaseType uint64
-      GroupType: 261 StructureType noalg.map.group[[4]int][4]int
-      GroupSliceType: 265 GoSliceDataType []noalg.map.group[[4]int][4]int.array
+      GroupType: 250 StructureType noalg.map.group[[4]int][4]int
+      GroupSliceType: 254 GoSliceDataType []noalg.map.group[[4]int][4]int.array
     - __kind: GoSwissMapGroupsType
-      ID: 252
+      ID: 240
       Name: groupReference<[4]int,uint8>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 253 PointerType *noalg.map.group[[4]int]uint8
+          Type: 241 PointerType *noalg.map.group[[4]int]uint8
         - Name: lengthMask
           Offset: 8
           Type: 8 BaseType uint64
-      GroupType: 254 StructureType noalg.map.group[[4]int]uint8
-      GroupSliceType: 258 GoSliceDataType []noalg.map.group[[4]int]uint8.array
+      GroupType: 242 StructureType noalg.map.group[[4]int]uint8
+      GroupSliceType: 246 GoSliceDataType []noalg.map.group[[4]int]uint8.array
     - __kind: GoSwissMapGroupsType
-      ID: 206
+      ID: 188
       Name: groupReference<[4]string,[2]int>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 207 PointerType *noalg.map.group[[4]string][2]int
+          Type: 189 PointerType *noalg.map.group[[4]string][2]int
         - Name: lengthMask
           Offset: 8
           Type: 8 BaseType uint64
-      GroupType: 208 StructureType noalg.map.group[[4]string][2]int
-      GroupSliceType: 213 GoSliceDataType []noalg.map.group[[4]string][2]int.array
+      GroupType: 190 StructureType noalg.map.group[[4]string][2]int
+      GroupSliceType: 195 GoSliceDataType []noalg.map.group[[4]string][2]int.array
     - __kind: GoSwissMapGroupsType
-      ID: 223
+      ID: 207
       Name: groupReference<bool,main.node>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 224 PointerType *noalg.map.group[bool]main.node
+          Type: 208 PointerType *noalg.map.group[bool]main.node
         - Name: lengthMask
           Offset: 8
           Type: 8 BaseType uint64
-      GroupType: 225 StructureType noalg.map.group[bool]main.node
-      GroupSliceType: 229 GoSliceDataType []noalg.map.group[bool]main.node.array
+      GroupType: 209 StructureType noalg.map.group[bool]main.node
+      GroupSliceType: 213 GoSliceDataType []noalg.map.group[bool]main.node.array
     - __kind: GoSwissMapGroupsType
-      ID: 178
+      ID: 156
       Name: groupReference<int,int>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 179 PointerType *noalg.map.group[int]int
+          Type: 157 PointerType *noalg.map.group[int]int
         - Name: lengthMask
           Offset: 8
           Type: 8 BaseType uint64
-      GroupType: 180 StructureType noalg.map.group[int]int
-      GroupSliceType: 184 GoSliceDataType []noalg.map.group[int]int.array
+      GroupType: 158 StructureType noalg.map.group[int]int
+      GroupSliceType: 162 GoSliceDataType []noalg.map.group[int]int.array
     - __kind: GoSwissMapGroupsType
-      ID: 230
+      ID: 215
       Name: groupReference<int,uint8>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 231 PointerType *noalg.map.group[int]uint8
+          Type: 216 PointerType *noalg.map.group[int]uint8
         - Name: lengthMask
           Offset: 8
           Type: 8 BaseType uint64
-      GroupType: 232 StructureType noalg.map.group[int]uint8
-      GroupSliceType: 236 GoSliceDataType []noalg.map.group[int]uint8.array
+      GroupType: 217 StructureType noalg.map.group[int]uint8
+      GroupSliceType: 221 GoSliceDataType []noalg.map.group[int]uint8.array
     - __kind: GoSwissMapGroupsType
-      ID: 214
+      ID: 197
       Name: groupReference<string,[]main.structWithMap>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 215 PointerType *noalg.map.group[string][]main.structWithMap
+          Type: 198 PointerType *noalg.map.group[string][]main.structWithMap
         - Name: lengthMask
           Offset: 8
           Type: 8 BaseType uint64
-      GroupType: 216 StructureType noalg.map.group[string][]main.structWithMap
-      GroupSliceType: 222 GoSliceDataType []noalg.map.group[string][]main.structWithMap.array
+      GroupType: 199 StructureType noalg.map.group[string][]main.structWithMap
+      GroupSliceType: 205 GoSliceDataType []noalg.map.group[string][]main.structWithMap.array
     - __kind: GoSwissMapGroupsType
-      ID: 199
+      ID: 180
       Name: groupReference<string,[]string>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 200 PointerType *noalg.map.group[string][]string
+          Type: 181 PointerType *noalg.map.group[string][]string
         - Name: lengthMask
           Offset: 8
           Type: 8 BaseType uint64
-      GroupType: 201 StructureType noalg.map.group[string][]string
-      GroupSliceType: 205 GoSliceDataType []noalg.map.group[string][]string.array
+      GroupType: 182 StructureType noalg.map.group[string][]string
+      GroupSliceType: 186 GoSliceDataType []noalg.map.group[string][]string.array
     - __kind: GoSwissMapGroupsType
-      ID: 192
+      ID: 172
       Name: groupReference<string,int>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 193 PointerType *noalg.map.group[string]int
+          Type: 173 PointerType *noalg.map.group[string]int
         - Name: lengthMask
           Offset: 8
           Type: 8 BaseType uint64
-      GroupType: 194 StructureType noalg.map.group[string]int
-      GroupSliceType: 198 GoSliceDataType []noalg.map.group[string]int.array
+      GroupType: 174 StructureType noalg.map.group[string]int
+      GroupSliceType: 178 GoSliceDataType []noalg.map.group[string]int.array
     - __kind: GoSwissMapGroupsType
-      ID: 185
+      ID: 164
       Name: groupReference<string,main.nestedStruct>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 186 PointerType *noalg.map.group[string]main.nestedStruct
+          Type: 165 PointerType *noalg.map.group[string]main.nestedStruct
         - Name: lengthMask
           Offset: 8
           Type: 8 BaseType uint64
-      GroupType: 187 StructureType noalg.map.group[string]main.nestedStruct
-      GroupSliceType: 191 GoSliceDataType []noalg.map.group[string]main.nestedStruct.array
+      GroupType: 166 StructureType noalg.map.group[string]main.nestedStruct
+      GroupSliceType: 170 GoSliceDataType []noalg.map.group[string]main.nestedStruct.array
     - __kind: GoSwissMapGroupsType
-      ID: 244
+      ID: 231
       Name: groupReference<uint8,[4]int>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 245 PointerType *noalg.map.group[uint8][4]int
+          Type: 232 PointerType *noalg.map.group[uint8][4]int
         - Name: lengthMask
           Offset: 8
           Type: 8 BaseType uint64
-      GroupType: 246 StructureType noalg.map.group[uint8][4]int
-      GroupSliceType: 251 GoSliceDataType []noalg.map.group[uint8][4]int.array
+      GroupType: 233 StructureType noalg.map.group[uint8][4]int
+      GroupSliceType: 238 GoSliceDataType []noalg.map.group[uint8][4]int.array
     - __kind: GoSwissMapGroupsType
-      ID: 237
+      ID: 223
       Name: groupReference<uint8,uint8>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 238 PointerType *noalg.map.group[uint8]uint8
+          Type: 224 PointerType *noalg.map.group[uint8]uint8
         - Name: lengthMask
           Offset: 8
           Type: 8 BaseType uint64
-      GroupType: 239 StructureType noalg.map.group[uint8]uint8
-      GroupSliceType: 243 GoSliceDataType []noalg.map.group[uint8]uint8.array
+      GroupType: 225 StructureType noalg.map.group[uint8]uint8
+      GroupSliceType: 229 GoSliceDataType []noalg.map.group[uint8]uint8.array
     - __kind: BaseType
       ID: 7
       Name: int
@@ -5928,7 +5928,7 @@ Types:
           Offset: 8
           Type: 14 VoidPointerType unsafe.Pointer
     - __kind: StructureType
-      ID: 153
+      ID: 269
       Name: internal/sync.Mutex
       ByteSize: 8
       GoRuntimeType: 1.46e+06
@@ -6016,16 +6016,16 @@ Types:
           Type: 56 StructureType main.esotericStack
         - Name: mu
           Offset: 64
-          Type: 151 StructureType sync.Mutex
+          Type: 267 StructureType sync.Mutex
         - Name: once
           Offset: 72
-          Type: 154 StructureType sync.Once
+          Type: 270 StructureType sync.Once
         - Name: wg
           Offset: 88
-          Type: 157 StructureType sync.WaitGroup
+          Type: 273 StructureType sync.WaitGroup
         - Name: a
           Offset: 104
-          Type: 160 StructureType sync/atomic.Int32
+          Type: 276 StructureType sync/atomic.Int32
     - __kind: StructureType
       ID: 56
       Name: main.esotericStack
@@ -6144,16 +6144,16 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 173 PointerType **main.t
+          Type: 277 PointerType **main.t
         - Name: len
           Offset: 8
           Type: 7 BaseType int
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 266 GoSliceDataType main.t.array
+      Data: 278 GoSliceDataType main.t.array
     - __kind: GoSliceDataType
-      ID: 266
+      ID: 278
       Name: main.t.array
       ByteSize: 2048
       Element: 133 PointerType *main.t
@@ -6210,8 +6210,8 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 8 BaseType uint64
-      TablePtrSliceType: 264 GoSliceDataType []*table<[4]int,[4]int>.array
-      GroupType: 261 StructureType noalg.map.group[[4]int][4]int
+      TablePtrSliceType: 253 GoSliceDataType []*table<[4]int,[4]int>.array
+      GroupType: 250 StructureType noalg.map.group[[4]int][4]int
     - __kind: GoSwissMapHeaderType
       ID: 120
       Name: map<[4]int,uint8>
@@ -6245,8 +6245,8 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 8 BaseType uint64
-      TablePtrSliceType: 257 GoSliceDataType []*table<[4]int,uint8>.array
-      GroupType: 254 StructureType noalg.map.group[[4]int]uint8
+      TablePtrSliceType: 245 GoSliceDataType []*table<[4]int,uint8>.array
+      GroupType: 242 StructureType noalg.map.group[[4]int]uint8
     - __kind: GoSwissMapHeaderType
       ID: 88
       Name: map<[4]string,[2]int>
@@ -6280,8 +6280,8 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 8 BaseType uint64
-      TablePtrSliceType: 212 GoSliceDataType []*table<[4]string,[2]int>.array
-      GroupType: 208 StructureType noalg.map.group[[4]string][2]int
+      TablePtrSliceType: 194 GoSliceDataType []*table<[4]string,[2]int>.array
+      GroupType: 190 StructureType noalg.map.group[[4]string][2]int
     - __kind: GoSwissMapHeaderType
       ID: 100
       Name: map<bool,main.node>
@@ -6315,8 +6315,8 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 8 BaseType uint64
-      TablePtrSliceType: 228 GoSliceDataType []*table<bool,main.node>.array
-      GroupType: 225 StructureType noalg.map.group[bool]main.node
+      TablePtrSliceType: 212 GoSliceDataType []*table<bool,main.node>.array
+      GroupType: 209 StructureType noalg.map.group[bool]main.node
     - __kind: GoSwissMapHeaderType
       ID: 68
       Name: map<int,int>
@@ -6350,8 +6350,8 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 8 BaseType uint64
-      TablePtrSliceType: 183 GoSliceDataType []*table<int,int>.array
-      GroupType: 180 StructureType noalg.map.group[int]int
+      TablePtrSliceType: 161 GoSliceDataType []*table<int,int>.array
+      GroupType: 158 StructureType noalg.map.group[int]int
     - __kind: GoSwissMapHeaderType
       ID: 105
       Name: map<int,uint8>
@@ -6385,8 +6385,8 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 8 BaseType uint64
-      TablePtrSliceType: 235 GoSliceDataType []*table<int,uint8>.array
-      GroupType: 232 StructureType noalg.map.group[int]uint8
+      TablePtrSliceType: 220 GoSliceDataType []*table<int,uint8>.array
+      GroupType: 217 StructureType noalg.map.group[int]uint8
     - __kind: GoSwissMapHeaderType
       ID: 95
       Name: map<string,[]main.structWithMap>
@@ -6420,8 +6420,8 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 8 BaseType uint64
-      TablePtrSliceType: 221 GoSliceDataType []*table<string,[]main.structWithMap>.array
-      GroupType: 216 StructureType noalg.map.group[string][]main.structWithMap
+      TablePtrSliceType: 204 GoSliceDataType []*table<string,[]main.structWithMap>.array
+      GroupType: 199 StructureType noalg.map.group[string][]main.structWithMap
     - __kind: GoSwissMapHeaderType
       ID: 83
       Name: map<string,[]string>
@@ -6455,8 +6455,8 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 8 BaseType uint64
-      TablePtrSliceType: 204 GoSliceDataType []*table<string,[]string>.array
-      GroupType: 201 StructureType noalg.map.group[string][]string
+      TablePtrSliceType: 185 GoSliceDataType []*table<string,[]string>.array
+      GroupType: 182 StructureType noalg.map.group[string][]string
     - __kind: GoSwissMapHeaderType
       ID: 78
       Name: map<string,int>
@@ -6490,8 +6490,8 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 8 BaseType uint64
-      TablePtrSliceType: 197 GoSliceDataType []*table<string,int>.array
-      GroupType: 194 StructureType noalg.map.group[string]int
+      TablePtrSliceType: 177 GoSliceDataType []*table<string,int>.array
+      GroupType: 174 StructureType noalg.map.group[string]int
     - __kind: GoSwissMapHeaderType
       ID: 73
       Name: map<string,main.nestedStruct>
@@ -6525,8 +6525,8 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 8 BaseType uint64
-      TablePtrSliceType: 190 GoSliceDataType []*table<string,main.nestedStruct>.array
-      GroupType: 187 StructureType noalg.map.group[string]main.nestedStruct
+      TablePtrSliceType: 169 GoSliceDataType []*table<string,main.nestedStruct>.array
+      GroupType: 166 StructureType noalg.map.group[string]main.nestedStruct
     - __kind: GoSwissMapHeaderType
       ID: 115
       Name: map<uint8,[4]int>
@@ -6560,8 +6560,8 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 8 BaseType uint64
-      TablePtrSliceType: 250 GoSliceDataType []*table<uint8,[4]int>.array
-      GroupType: 246 StructureType noalg.map.group[uint8][4]int
+      TablePtrSliceType: 237 GoSliceDataType []*table<uint8,[4]int>.array
+      GroupType: 233 StructureType noalg.map.group[uint8][4]int
     - __kind: GoSwissMapHeaderType
       ID: 110
       Name: map<uint8,uint8>
@@ -6595,8 +6595,8 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 8 BaseType uint64
-      TablePtrSliceType: 242 GoSliceDataType []*table<uint8,uint8>.array
-      GroupType: 239 StructureType noalg.map.group[uint8]uint8
+      TablePtrSliceType: 228 GoSliceDataType []*table<uint8,uint8>.array
+      GroupType: 225 StructureType noalg.map.group[uint8]uint8
     - __kind: GoMapType
       ID: 123
       Name: map[[4]int][4]int
@@ -6682,115 +6682,115 @@ Types:
       GoKind: 21
       HeaderType: 110 GoSwissMapHeaderType map<uint8,uint8>
     - __kind: ArrayType
-      ID: 262
+      ID: 251
       Name: noalg.[8]struct { key [4]int; elem [4]int }
       ByteSize: 512
       GoRuntimeType: 676736
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 263 StructureType noalg.struct { key [4]int; elem [4]int }
+      Element: 252 StructureType noalg.struct { key [4]int; elem [4]int }
     - __kind: ArrayType
-      ID: 255
+      ID: 243
       Name: noalg.[8]struct { key [4]int; elem uint8 }
       ByteSize: 320
       GoRuntimeType: 676832
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 256 StructureType noalg.struct { key [4]int; elem uint8 }
+      Element: 244 StructureType noalg.struct { key [4]int; elem uint8 }
     - __kind: ArrayType
-      ID: 209
+      ID: 191
       Name: noalg.[8]struct { key [4]string; elem [2]int }
       ByteSize: 640
       GoRuntimeType: 677120
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 210 StructureType noalg.struct { key [4]string; elem [2]int }
+      Element: 192 StructureType noalg.struct { key [4]string; elem [2]int }
     - __kind: ArrayType
-      ID: 226
+      ID: 210
       Name: noalg.[8]struct { key bool; elem main.node }
       ByteSize: 192
       GoRuntimeType: 677216
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 227 StructureType noalg.struct { key bool; elem main.node }
+      Element: 211 StructureType noalg.struct { key bool; elem main.node }
     - __kind: ArrayType
-      ID: 181
+      ID: 159
       Name: noalg.[8]struct { key int; elem int }
       ByteSize: 128
       GoRuntimeType: 675008
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 182 StructureType noalg.struct { key int; elem int }
+      Element: 160 StructureType noalg.struct { key int; elem int }
     - __kind: ArrayType
-      ID: 233
+      ID: 218
       Name: noalg.[8]struct { key int; elem uint8 }
       ByteSize: 128
       GoRuntimeType: 677312
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 234 StructureType noalg.struct { key int; elem uint8 }
+      Element: 219 StructureType noalg.struct { key int; elem uint8 }
     - __kind: ArrayType
-      ID: 217
+      ID: 200
       Name: noalg.[8]struct { key string; elem []main.structWithMap }
       ByteSize: 320
       GoRuntimeType: 677408
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 218 StructureType noalg.struct { key string; elem []main.structWithMap }
+      Element: 201 StructureType noalg.struct { key string; elem []main.structWithMap }
     - __kind: ArrayType
-      ID: 202
+      ID: 183
       Name: noalg.[8]struct { key string; elem []string }
       ByteSize: 320
       GoRuntimeType: 677504
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 203 StructureType noalg.struct { key string; elem []string }
+      Element: 184 StructureType noalg.struct { key string; elem []string }
     - __kind: ArrayType
-      ID: 195
+      ID: 175
       Name: noalg.[8]struct { key string; elem int }
       ByteSize: 192
       GoRuntimeType: 677600
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 196 StructureType noalg.struct { key string; elem int }
+      Element: 176 StructureType noalg.struct { key string; elem int }
     - __kind: ArrayType
-      ID: 188
+      ID: 167
       Name: noalg.[8]struct { key string; elem main.nestedStruct }
       ByteSize: 320
       GoRuntimeType: 677696
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 189 StructureType noalg.struct { key string; elem main.nestedStruct }
+      Element: 168 StructureType noalg.struct { key string; elem main.nestedStruct }
     - __kind: ArrayType
-      ID: 247
+      ID: 234
       Name: noalg.[8]struct { key uint8; elem [4]int }
       ByteSize: 320
       GoRuntimeType: 677792
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 248 StructureType noalg.struct { key uint8; elem [4]int }
+      Element: 235 StructureType noalg.struct { key uint8; elem [4]int }
     - __kind: ArrayType
-      ID: 240
+      ID: 226
       Name: noalg.[8]struct { key uint8; elem uint8 }
       ByteSize: 16
       GoRuntimeType: 677888
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 241 StructureType noalg.struct { key uint8; elem uint8 }
+      Element: 227 StructureType noalg.struct { key uint8; elem uint8 }
     - __kind: StructureType
-      ID: 261
+      ID: 250
       Name: noalg.map.group[[4]int][4]int
       ByteSize: 520
       GoRuntimeType: 1.28176e+06
@@ -6801,9 +6801,9 @@ Types:
           Type: 8 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 262 ArrayType noalg.[8]struct { key [4]int; elem [4]int }
+          Type: 251 ArrayType noalg.[8]struct { key [4]int; elem [4]int }
     - __kind: StructureType
-      ID: 254
+      ID: 242
       Name: noalg.map.group[[4]int]uint8
       ByteSize: 328
       GoRuntimeType: 1.282016e+06
@@ -6814,9 +6814,9 @@ Types:
           Type: 8 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 255 ArrayType noalg.[8]struct { key [4]int; elem uint8 }
+          Type: 243 ArrayType noalg.[8]struct { key [4]int; elem uint8 }
     - __kind: StructureType
-      ID: 208
+      ID: 190
       Name: noalg.map.group[[4]string][2]int
       ByteSize: 648
       GoRuntimeType: 1.282272e+06
@@ -6827,9 +6827,9 @@ Types:
           Type: 8 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 209 ArrayType noalg.[8]struct { key [4]string; elem [2]int }
+          Type: 191 ArrayType noalg.[8]struct { key [4]string; elem [2]int }
     - __kind: StructureType
-      ID: 225
+      ID: 209
       Name: noalg.map.group[bool]main.node
       ByteSize: 200
       GoRuntimeType: 1.282528e+06
@@ -6840,9 +6840,9 @@ Types:
           Type: 8 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 226 ArrayType noalg.[8]struct { key bool; elem main.node }
+          Type: 210 ArrayType noalg.[8]struct { key bool; elem main.node }
     - __kind: StructureType
-      ID: 180
+      ID: 158
       Name: noalg.map.group[int]int
       ByteSize: 136
       GoRuntimeType: 1.280992e+06
@@ -6853,9 +6853,9 @@ Types:
           Type: 8 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 181 ArrayType noalg.[8]struct { key int; elem int }
+          Type: 159 ArrayType noalg.[8]struct { key int; elem int }
     - __kind: StructureType
-      ID: 232
+      ID: 217
       Name: noalg.map.group[int]uint8
       ByteSize: 136
       GoRuntimeType: 1.282784e+06
@@ -6866,9 +6866,9 @@ Types:
           Type: 8 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 233 ArrayType noalg.[8]struct { key int; elem uint8 }
+          Type: 218 ArrayType noalg.[8]struct { key int; elem uint8 }
     - __kind: StructureType
-      ID: 216
+      ID: 199
       Name: noalg.map.group[string][]main.structWithMap
       ByteSize: 328
       GoRuntimeType: 1.28304e+06
@@ -6879,9 +6879,9 @@ Types:
           Type: 8 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 217 ArrayType noalg.[8]struct { key string; elem []main.structWithMap }
+          Type: 200 ArrayType noalg.[8]struct { key string; elem []main.structWithMap }
     - __kind: StructureType
-      ID: 201
+      ID: 182
       Name: noalg.map.group[string][]string
       ByteSize: 328
       GoRuntimeType: 1.283296e+06
@@ -6892,9 +6892,9 @@ Types:
           Type: 8 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 202 ArrayType noalg.[8]struct { key string; elem []string }
+          Type: 183 ArrayType noalg.[8]struct { key string; elem []string }
     - __kind: StructureType
-      ID: 194
+      ID: 174
       Name: noalg.map.group[string]int
       ByteSize: 200
       GoRuntimeType: 1.283552e+06
@@ -6905,9 +6905,9 @@ Types:
           Type: 8 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 195 ArrayType noalg.[8]struct { key string; elem int }
+          Type: 175 ArrayType noalg.[8]struct { key string; elem int }
     - __kind: StructureType
-      ID: 187
+      ID: 166
       Name: noalg.map.group[string]main.nestedStruct
       ByteSize: 328
       GoRuntimeType: 1.283808e+06
@@ -6918,9 +6918,9 @@ Types:
           Type: 8 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 188 ArrayType noalg.[8]struct { key string; elem main.nestedStruct }
+          Type: 167 ArrayType noalg.[8]struct { key string; elem main.nestedStruct }
     - __kind: StructureType
-      ID: 246
+      ID: 233
       Name: noalg.map.group[uint8][4]int
       ByteSize: 328
       GoRuntimeType: 1.284064e+06
@@ -6931,9 +6931,9 @@ Types:
           Type: 8 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 247 ArrayType noalg.[8]struct { key uint8; elem [4]int }
+          Type: 234 ArrayType noalg.[8]struct { key uint8; elem [4]int }
     - __kind: StructureType
-      ID: 239
+      ID: 225
       Name: noalg.map.group[uint8]uint8
       ByteSize: 24
       GoRuntimeType: 1.28432e+06
@@ -6944,9 +6944,9 @@ Types:
           Type: 8 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 240 ArrayType noalg.[8]struct { key uint8; elem uint8 }
+          Type: 226 ArrayType noalg.[8]struct { key uint8; elem uint8 }
     - __kind: StructureType
-      ID: 263
+      ID: 252
       Name: noalg.struct { key [4]int; elem [4]int }
       ByteSize: 64
       GoRuntimeType: 1.281632e+06
@@ -6954,12 +6954,12 @@ Types:
       RawFields:
         - Name: key
           Offset: 0
-          Type: 249 ArrayType [4]int
+          Type: 236 ArrayType [4]int
         - Name: elem
           Offset: 32
-          Type: 249 ArrayType [4]int
+          Type: 236 ArrayType [4]int
     - __kind: StructureType
-      ID: 256
+      ID: 244
       Name: noalg.struct { key [4]int; elem uint8 }
       ByteSize: 40
       GoRuntimeType: 1.281888e+06
@@ -6967,12 +6967,12 @@ Types:
       RawFields:
         - Name: key
           Offset: 0
-          Type: 249 ArrayType [4]int
+          Type: 236 ArrayType [4]int
         - Name: elem
           Offset: 32
           Type: 3 BaseType uint8
     - __kind: StructureType
-      ID: 210
+      ID: 192
       Name: noalg.struct { key [4]string; elem [2]int }
       ByteSize: 80
       GoRuntimeType: 1.282144e+06
@@ -6980,12 +6980,12 @@ Types:
       RawFields:
         - Name: key
           Offset: 0
-          Type: 211 ArrayType [4]string
+          Type: 193 ArrayType [4]string
         - Name: elem
           Offset: 64
           Type: 40 ArrayType [2]int
     - __kind: StructureType
-      ID: 227
+      ID: 211
       Name: noalg.struct { key bool; elem main.node }
       ByteSize: 24
       GoRuntimeType: 1.2824e+06
@@ -6998,7 +6998,7 @@ Types:
           Offset: 8
           Type: 131 StructureType main.node
     - __kind: StructureType
-      ID: 182
+      ID: 160
       Name: noalg.struct { key int; elem int }
       ByteSize: 16
       GoRuntimeType: 1.280864e+06
@@ -7011,7 +7011,7 @@ Types:
           Offset: 8
           Type: 7 BaseType int
     - __kind: StructureType
-      ID: 234
+      ID: 219
       Name: noalg.struct { key int; elem uint8 }
       ByteSize: 16
       GoRuntimeType: 1.282656e+06
@@ -7024,7 +7024,7 @@ Types:
           Offset: 8
           Type: 3 BaseType uint8
     - __kind: StructureType
-      ID: 218
+      ID: 201
       Name: noalg.struct { key string; elem []main.structWithMap }
       ByteSize: 40
       GoRuntimeType: 1.282912e+06
@@ -7035,9 +7035,9 @@ Types:
           Type: 9 GoStringHeaderType string
         - Name: elem
           Offset: 16
-          Type: 219 GoSliceHeaderType []main.structWithMap
+          Type: 202 GoSliceHeaderType []main.structWithMap
     - __kind: StructureType
-      ID: 203
+      ID: 184
       Name: noalg.struct { key string; elem []string }
       ByteSize: 40
       GoRuntimeType: 1.283168e+06
@@ -7050,7 +7050,7 @@ Types:
           Offset: 16
           Type: 141 GoSliceHeaderType []string
     - __kind: StructureType
-      ID: 196
+      ID: 176
       Name: noalg.struct { key string; elem int }
       ByteSize: 24
       GoRuntimeType: 1.283424e+06
@@ -7063,7 +7063,7 @@ Types:
           Offset: 16
           Type: 7 BaseType int
     - __kind: StructureType
-      ID: 189
+      ID: 168
       Name: noalg.struct { key string; elem main.nestedStruct }
       ByteSize: 40
       GoRuntimeType: 1.28368e+06
@@ -7076,7 +7076,7 @@ Types:
           Offset: 16
           Type: 149 StructureType main.nestedStruct
     - __kind: StructureType
-      ID: 248
+      ID: 235
       Name: noalg.struct { key uint8; elem [4]int }
       ByteSize: 40
       GoRuntimeType: 1.283936e+06
@@ -7087,9 +7087,9 @@ Types:
           Type: 3 BaseType uint8
         - Name: elem
           Offset: 8
-          Type: 249 ArrayType [4]int
+          Type: 236 ArrayType [4]int
     - __kind: StructureType
-      ID: 241
+      ID: 227
       Name: noalg.struct { key uint8; elem uint8 }
       ByteSize: 2
       GoRuntimeType: 1.284192e+06
@@ -7110,17 +7110,17 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 175 PointerType *string.str
+          Type: 152 PointerType *string.str
         - Name: len
           Offset: 8
           Type: 7 BaseType int
-      Data: 174 GoStringDataType string.str
+      Data: 151 GoStringDataType string.str
     - __kind: GoStringDataType
-      ID: 174
+      ID: 151
       Name: string.str
       ByteSize: 2048
     - __kind: StructureType
-      ID: 151
+      ID: 267
       Name: sync.Mutex
       ByteSize: 8
       GoRuntimeType: 1.44992e+06
@@ -7128,12 +7128,12 @@ Types:
       RawFields:
         - Name: _
           Offset: 0
-          Type: 152 StructureType sync.noCopy
+          Type: 268 StructureType sync.noCopy
         - Name: mu
           Offset: 0
-          Type: 153 StructureType internal/sync.Mutex
+          Type: 269 StructureType internal/sync.Mutex
     - __kind: StructureType
-      ID: 154
+      ID: 270
       Name: sync.Once
       ByteSize: 12
       GoRuntimeType: 1.598816e+06
@@ -7141,15 +7141,15 @@ Types:
       RawFields:
         - Name: _
           Offset: 0
-          Type: 152 StructureType sync.noCopy
+          Type: 268 StructureType sync.noCopy
         - Name: done
           Offset: 0
-          Type: 155 StructureType sync/atomic.Bool
+          Type: 271 StructureType sync/atomic.Bool
         - Name: m
           Offset: 4
-          Type: 151 StructureType sync.Mutex
+          Type: 267 StructureType sync.Mutex
     - __kind: StructureType
-      ID: 157
+      ID: 273
       Name: sync.WaitGroup
       ByteSize: 16
       GoRuntimeType: 1.598624e+06
@@ -7157,21 +7157,21 @@ Types:
       RawFields:
         - Name: noCopy
           Offset: 0
-          Type: 152 StructureType sync.noCopy
+          Type: 268 StructureType sync.noCopy
         - Name: state
           Offset: 0
-          Type: 158 StructureType sync/atomic.Uint64
+          Type: 274 StructureType sync/atomic.Uint64
         - Name: sema
           Offset: 8
           Type: 2 BaseType uint32
     - __kind: StructureType
-      ID: 152
+      ID: 268
       Name: sync.noCopy
       GoRuntimeType: 982144
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 155
+      ID: 271
       Name: sync/atomic.Bool
       ByteSize: 4
       GoRuntimeType: 1.45104e+06
@@ -7179,12 +7179,12 @@ Types:
       RawFields:
         - Name: _
           Offset: 0
-          Type: 156 StructureType sync/atomic.noCopy
+          Type: 272 StructureType sync/atomic.noCopy
         - Name: v
           Offset: 0
           Type: 2 BaseType uint32
     - __kind: StructureType
-      ID: 160
+      ID: 276
       Name: sync/atomic.Int32
       ByteSize: 4
       GoRuntimeType: 1.4512e+06
@@ -7192,12 +7192,12 @@ Types:
       RawFields:
         - Name: _
           Offset: 0
-          Type: 156 StructureType sync/atomic.noCopy
+          Type: 272 StructureType sync/atomic.noCopy
         - Name: v
           Offset: 0
           Type: 10 BaseType int32
     - __kind: StructureType
-      ID: 158
+      ID: 274
       Name: sync/atomic.Uint64
       ByteSize: 8
       GoRuntimeType: 1.5992e+06
@@ -7205,27 +7205,27 @@ Types:
       RawFields:
         - Name: _
           Offset: 0
-          Type: 156 StructureType sync/atomic.noCopy
+          Type: 272 StructureType sync/atomic.noCopy
         - Name: _
           Offset: 0
-          Type: 159 StructureType sync/atomic.align64
+          Type: 275 StructureType sync/atomic.align64
         - Name: v
           Offset: 0
           Type: 8 BaseType uint64
     - __kind: StructureType
-      ID: 159
+      ID: 275
       Name: sync/atomic.align64
       GoRuntimeType: 982336
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 156
+      ID: 272
       Name: sync/atomic.noCopy
       GoRuntimeType: 982240
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 172
+      ID: 247
       Name: table<[4]int,[4]int>
       ByteSize: 32
       GoKind: 25
@@ -7247,9 +7247,9 @@ Types:
           Type: 7 BaseType int
         - Name: groups
           Offset: 16
-          Type: 259 GoSwissMapGroupsType groupReference<[4]int,[4]int>
+          Type: 248 GoSwissMapGroupsType groupReference<[4]int,[4]int>
     - __kind: StructureType
-      ID: 171
+      ID: 239
       Name: table<[4]int,uint8>
       ByteSize: 32
       GoKind: 25
@@ -7271,9 +7271,9 @@ Types:
           Type: 7 BaseType int
         - Name: groups
           Offset: 16
-          Type: 252 GoSwissMapGroupsType groupReference<[4]int,uint8>
+          Type: 240 GoSwissMapGroupsType groupReference<[4]int,uint8>
     - __kind: StructureType
-      ID: 165
+      ID: 187
       Name: table<[4]string,[2]int>
       ByteSize: 32
       GoKind: 25
@@ -7295,9 +7295,9 @@ Types:
           Type: 7 BaseType int
         - Name: groups
           Offset: 16
-          Type: 206 GoSwissMapGroupsType groupReference<[4]string,[2]int>
+          Type: 188 GoSwissMapGroupsType groupReference<[4]string,[2]int>
     - __kind: StructureType
-      ID: 167
+      ID: 206
       Name: table<bool,main.node>
       ByteSize: 32
       GoKind: 25
@@ -7319,9 +7319,9 @@ Types:
           Type: 7 BaseType int
         - Name: groups
           Offset: 16
-          Type: 223 GoSwissMapGroupsType groupReference<bool,main.node>
+          Type: 207 GoSwissMapGroupsType groupReference<bool,main.node>
     - __kind: StructureType
-      ID: 161
+      ID: 155
       Name: table<int,int>
       ByteSize: 32
       GoKind: 25
@@ -7343,9 +7343,9 @@ Types:
           Type: 7 BaseType int
         - Name: groups
           Offset: 16
-          Type: 178 GoSwissMapGroupsType groupReference<int,int>
+          Type: 156 GoSwissMapGroupsType groupReference<int,int>
     - __kind: StructureType
-      ID: 168
+      ID: 214
       Name: table<int,uint8>
       ByteSize: 32
       GoKind: 25
@@ -7367,9 +7367,9 @@ Types:
           Type: 7 BaseType int
         - Name: groups
           Offset: 16
-          Type: 230 GoSwissMapGroupsType groupReference<int,uint8>
+          Type: 215 GoSwissMapGroupsType groupReference<int,uint8>
     - __kind: StructureType
-      ID: 166
+      ID: 196
       Name: table<string,[]main.structWithMap>
       ByteSize: 32
       GoKind: 25
@@ -7391,9 +7391,9 @@ Types:
           Type: 7 BaseType int
         - Name: groups
           Offset: 16
-          Type: 214 GoSwissMapGroupsType groupReference<string,[]main.structWithMap>
+          Type: 197 GoSwissMapGroupsType groupReference<string,[]main.structWithMap>
     - __kind: StructureType
-      ID: 164
+      ID: 179
       Name: table<string,[]string>
       ByteSize: 32
       GoKind: 25
@@ -7415,9 +7415,9 @@ Types:
           Type: 7 BaseType int
         - Name: groups
           Offset: 16
-          Type: 199 GoSwissMapGroupsType groupReference<string,[]string>
+          Type: 180 GoSwissMapGroupsType groupReference<string,[]string>
     - __kind: StructureType
-      ID: 163
+      ID: 171
       Name: table<string,int>
       ByteSize: 32
       GoKind: 25
@@ -7439,9 +7439,9 @@ Types:
           Type: 7 BaseType int
         - Name: groups
           Offset: 16
-          Type: 192 GoSwissMapGroupsType groupReference<string,int>
+          Type: 172 GoSwissMapGroupsType groupReference<string,int>
     - __kind: StructureType
-      ID: 162
+      ID: 163
       Name: table<string,main.nestedStruct>
       ByteSize: 32
       GoKind: 25
@@ -7463,9 +7463,9 @@ Types:
           Type: 7 BaseType int
         - Name: groups
           Offset: 16
-          Type: 185 GoSwissMapGroupsType groupReference<string,main.nestedStruct>
+          Type: 164 GoSwissMapGroupsType groupReference<string,main.nestedStruct>
     - __kind: StructureType
-      ID: 170
+      ID: 230
       Name: table<uint8,[4]int>
       ByteSize: 32
       GoKind: 25
@@ -7487,9 +7487,9 @@ Types:
           Type: 7 BaseType int
         - Name: groups
           Offset: 16
-          Type: 244 GoSwissMapGroupsType groupReference<uint8,[4]int>
+          Type: 231 GoSwissMapGroupsType groupReference<uint8,[4]int>
     - __kind: StructureType
-      ID: 169
+      ID: 222
       Name: table<uint8,uint8>
       ByteSize: 32
       GoKind: 25
@@ -7511,7 +7511,7 @@ Types:
           Type: 7 BaseType int
         - Name: groups
           Offset: 16
-          Type: 237 GoSwissMapGroupsType groupReference<uint8,uint8>
+          Type: 223 GoSwissMapGroupsType groupReference<uint8,uint8>
     - __kind: BaseType
       ID: 17
       Name: uint

--- a/pkg/dyninst/irgen/testdata/snapshot/sample.arch=amd64,toolchain=go1.25.0.yaml
+++ b/pkg/dyninst/irgen/testdata/snapshot/sample.arch=amd64,toolchain=go1.25.0.yaml
@@ -3167,10 +3167,10 @@ Types:
       ByteSize: 8
       Pointee: 112 PointerType *table<uint8,uint8>
     - __kind: PointerType
-      ID: 241
+      ID: 177
       Name: '*[]*string.array'
       ByteSize: 8
-      Pointee: 240 GoSliceDataType []*string.array
+      Pointee: 176 GoSliceDataType []*string.array
     - __kind: PointerType
       ID: 271
       Name: '*[][]uint.array'
@@ -3295,7 +3295,7 @@ Types:
       GoKind: 22
       Pointee: 147 StructureType main.oneStringStruct
     - __kind: PointerType
-      ID: 224
+      ID: 220
       Name: '*main.structWithMap'
       ByteSize: 8
       GoRuntimeType: 382976
@@ -3396,65 +3396,65 @@ Types:
       GoKind: 22
       Pointee: 76 GoMapType map[string]int
     - __kind: PointerType
-      ID: 208
+      ID: 260
       Name: '*noalg.map.group[[4]int][4]int'
       ByteSize: 8
-      Pointee: 209 StructureType noalg.map.group[[4]int][4]int
+      Pointee: 261 StructureType noalg.map.group[[4]int][4]int
     - __kind: PointerType
-      ID: 205
+      ID: 253
       Name: '*noalg.map.group[[4]int]uint8'
       ByteSize: 8
-      Pointee: 206 StructureType noalg.map.group[[4]int]uint8
+      Pointee: 254 StructureType noalg.map.group[[4]int]uint8
     - __kind: PointerType
-      ID: 187
+      ID: 207
       Name: '*noalg.map.group[[4]string][2]int'
       ByteSize: 8
-      Pointee: 188 StructureType noalg.map.group[[4]string][2]int
+      Pointee: 208 StructureType noalg.map.group[[4]string][2]int
     - __kind: PointerType
-      ID: 193
+      ID: 224
       Name: '*noalg.map.group[bool]main.node'
       ByteSize: 8
-      Pointee: 194 StructureType noalg.map.group[bool]main.node
+      Pointee: 225 StructureType noalg.map.group[bool]main.node
     - __kind: PointerType
-      ID: 175
+      ID: 179
       Name: '*noalg.map.group[int]int'
       ByteSize: 8
-      Pointee: 176 StructureType noalg.map.group[int]int
+      Pointee: 180 StructureType noalg.map.group[int]int
     - __kind: PointerType
-      ID: 196
+      ID: 231
       Name: '*noalg.map.group[int]uint8'
       ByteSize: 8
-      Pointee: 197 StructureType noalg.map.group[int]uint8
+      Pointee: 232 StructureType noalg.map.group[int]uint8
     - __kind: PointerType
-      ID: 190
+      ID: 215
       Name: '*noalg.map.group[string][]main.structWithMap'
       ByteSize: 8
-      Pointee: 191 StructureType noalg.map.group[string][]main.structWithMap
+      Pointee: 216 StructureType noalg.map.group[string][]main.structWithMap
     - __kind: PointerType
-      ID: 184
+      ID: 200
       Name: '*noalg.map.group[string][]string'
       ByteSize: 8
-      Pointee: 185 StructureType noalg.map.group[string][]string
+      Pointee: 201 StructureType noalg.map.group[string][]string
     - __kind: PointerType
-      ID: 181
+      ID: 193
       Name: '*noalg.map.group[string]int'
       ByteSize: 8
-      Pointee: 182 StructureType noalg.map.group[string]int
+      Pointee: 194 StructureType noalg.map.group[string]int
     - __kind: PointerType
-      ID: 178
+      ID: 186
       Name: '*noalg.map.group[string]main.nestedStruct'
       ByteSize: 8
-      Pointee: 179 StructureType noalg.map.group[string]main.nestedStruct
+      Pointee: 187 StructureType noalg.map.group[string]main.nestedStruct
     - __kind: PointerType
-      ID: 202
+      ID: 245
       Name: '*noalg.map.group[uint8][4]int'
       ByteSize: 8
-      Pointee: 203 StructureType noalg.map.group[uint8][4]int
+      Pointee: 246 StructureType noalg.map.group[uint8][4]int
     - __kind: PointerType
-      ID: 199
+      ID: 238
       Name: '*noalg.map.group[uint8]uint8'
       ByteSize: 8
-      Pointee: 200 StructureType noalg.map.group[uint8]uint8
+      Pointee: 239 StructureType noalg.map.group[uint8]uint8
     - __kind: PointerType
       ID: 22
       Name: '*string'
@@ -3463,10 +3463,10 @@ Types:
       GoKind: 22
       Pointee: 9 GoStringHeaderType string
     - __kind: PointerType
-      ID: 239
+      ID: 175
       Name: '*string.str'
       ByteSize: 8
-      Pointee: 238 GoStringDataType string.str
+      Pointee: 174 GoStringDataType string.str
     - __kind: PointerType
       ID: 127
       Name: '*table<[4]int,[4]int>'
@@ -5338,7 +5338,7 @@ Types:
       HasCount: true
       Element: 3 BaseType uint8
     - __kind: ArrayType
-      ID: 233
+      ID: 249
       Name: '[4]int'
       ByteSize: 32
       GoRuntimeType: 676640
@@ -5347,7 +5347,7 @@ Types:
       HasCount: true
       Element: 7 BaseType int
     - __kind: ArrayType
-      ID: 220
+      ID: 211
       Name: '[4]string'
       ByteSize: 64
       GoRuntimeType: 676928
@@ -5379,9 +5379,9 @@ Types:
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 240 GoSliceDataType []*string.array
+      Data: 176 GoSliceDataType []*string.array
     - __kind: GoSliceDataType
-      ID: 240
+      ID: 176
       Name: '[]*string.array'
       ByteSize: 2048
       Element: 22 PointerType *string
@@ -5391,57 +5391,57 @@ Types:
       ByteSize: 8192
       Element: 127 PointerType *table<[4]int,[4]int>
     - __kind: GoSliceDataType
-      ID: 262
+      ID: 257
       Name: '[]*table<[4]int,uint8>.array'
       ByteSize: 8192
       Element: 122 PointerType *table<[4]int,uint8>
     - __kind: GoSliceDataType
-      ID: 250
+      ID: 212
       Name: '[]*table<[4]string,[2]int>.array'
       ByteSize: 8192
       Element: 90 PointerType *table<[4]string,[2]int>
     - __kind: GoSliceDataType
-      ID: 254
+      ID: 228
       Name: '[]*table<bool,main.node>.array'
       ByteSize: 8192
       Element: 102 PointerType *table<bool,main.node>
     - __kind: GoSliceDataType
-      ID: 242
+      ID: 183
       Name: '[]*table<int,int>.array'
       ByteSize: 8192
       Element: 70 PointerType *table<int,int>
     - __kind: GoSliceDataType
-      ID: 256
+      ID: 235
       Name: '[]*table<int,uint8>.array'
       ByteSize: 8192
       Element: 107 PointerType *table<int,uint8>
     - __kind: GoSliceDataType
-      ID: 252
+      ID: 221
       Name: '[]*table<string,[]main.structWithMap>.array'
       ByteSize: 8192
       Element: 97 PointerType *table<string,[]main.structWithMap>
     - __kind: GoSliceDataType
-      ID: 248
+      ID: 204
       Name: '[]*table<string,[]string>.array'
       ByteSize: 8192
       Element: 85 PointerType *table<string,[]string>
     - __kind: GoSliceDataType
-      ID: 246
+      ID: 197
       Name: '[]*table<string,int>.array'
       ByteSize: 8192
       Element: 80 PointerType *table<string,int>
     - __kind: GoSliceDataType
-      ID: 244
+      ID: 190
       Name: '[]*table<string,main.nestedStruct>.array'
       ByteSize: 8192
       Element: 75 PointerType *table<string,main.nestedStruct>
     - __kind: GoSliceDataType
-      ID: 260
+      ID: 250
       Name: '[]*table<uint8,[4]int>.array'
       ByteSize: 8192
       Element: 117 PointerType *table<uint8,[4]int>
     - __kind: GoSliceDataType
-      ID: 258
+      ID: 242
       Name: '[]*table<uint8,uint8>.array'
       ByteSize: 8192
       Element: 112 PointerType *table<uint8,uint8>
@@ -5489,7 +5489,7 @@ Types:
       ByteSize: 2048
       Element: 4 BaseType bool
     - __kind: GoSliceHeaderType
-      ID: 223
+      ID: 219
       Name: '[]main.structWithMap'
       ByteSize: 24
       GoRuntimeType: 472768
@@ -5497,7 +5497,7 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 224 PointerType *main.structWithMap
+          Type: 220 PointerType *main.structWithMap
         - Name: len
           Offset: 8
           Type: 7 BaseType int
@@ -5535,62 +5535,62 @@ Types:
       ID: 265
       Name: '[]noalg.map.group[[4]int][4]int.array'
       ByteSize: 2048
-      Element: 209 StructureType noalg.map.group[[4]int][4]int
+      Element: 261 StructureType noalg.map.group[[4]int][4]int
     - __kind: GoSliceDataType
-      ID: 263
+      ID: 258
       Name: '[]noalg.map.group[[4]int]uint8.array'
       ByteSize: 2048
-      Element: 206 StructureType noalg.map.group[[4]int]uint8
+      Element: 254 StructureType noalg.map.group[[4]int]uint8
     - __kind: GoSliceDataType
-      ID: 251
+      ID: 213
       Name: '[]noalg.map.group[[4]string][2]int.array'
       ByteSize: 2048
-      Element: 188 StructureType noalg.map.group[[4]string][2]int
+      Element: 208 StructureType noalg.map.group[[4]string][2]int
     - __kind: GoSliceDataType
-      ID: 255
+      ID: 229
       Name: '[]noalg.map.group[bool]main.node.array'
       ByteSize: 2048
-      Element: 194 StructureType noalg.map.group[bool]main.node
+      Element: 225 StructureType noalg.map.group[bool]main.node
     - __kind: GoSliceDataType
-      ID: 243
+      ID: 184
       Name: '[]noalg.map.group[int]int.array'
       ByteSize: 2048
-      Element: 176 StructureType noalg.map.group[int]int
+      Element: 180 StructureType noalg.map.group[int]int
     - __kind: GoSliceDataType
-      ID: 257
+      ID: 236
       Name: '[]noalg.map.group[int]uint8.array'
       ByteSize: 2048
-      Element: 197 StructureType noalg.map.group[int]uint8
+      Element: 232 StructureType noalg.map.group[int]uint8
     - __kind: GoSliceDataType
-      ID: 253
+      ID: 222
       Name: '[]noalg.map.group[string][]main.structWithMap.array'
       ByteSize: 2048
-      Element: 191 StructureType noalg.map.group[string][]main.structWithMap
+      Element: 216 StructureType noalg.map.group[string][]main.structWithMap
     - __kind: GoSliceDataType
-      ID: 249
+      ID: 205
       Name: '[]noalg.map.group[string][]string.array'
       ByteSize: 2048
-      Element: 185 StructureType noalg.map.group[string][]string
+      Element: 201 StructureType noalg.map.group[string][]string
     - __kind: GoSliceDataType
-      ID: 247
+      ID: 198
       Name: '[]noalg.map.group[string]int.array'
       ByteSize: 2048
-      Element: 182 StructureType noalg.map.group[string]int
+      Element: 194 StructureType noalg.map.group[string]int
     - __kind: GoSliceDataType
-      ID: 245
+      ID: 191
       Name: '[]noalg.map.group[string]main.nestedStruct.array'
       ByteSize: 2048
-      Element: 179 StructureType noalg.map.group[string]main.nestedStruct
+      Element: 187 StructureType noalg.map.group[string]main.nestedStruct
     - __kind: GoSliceDataType
-      ID: 261
+      ID: 251
       Name: '[]noalg.map.group[uint8][4]int.array'
       ByteSize: 2048
-      Element: 203 StructureType noalg.map.group[uint8][4]int
+      Element: 246 StructureType noalg.map.group[uint8][4]int
     - __kind: GoSliceDataType
-      ID: 259
+      ID: 243
       Name: '[]noalg.map.group[uint8]uint8.array'
       ByteSize: 2048
-      Element: 200 StructureType noalg.map.group[uint8]uint8
+      Element: 239 StructureType noalg.map.group[uint8]uint8
     - __kind: GoSliceHeaderType
       ID: 141
       Name: '[]string'
@@ -5717,173 +5717,173 @@ Types:
       GoRuntimeType: 471744
       GoKind: 19
     - __kind: GoSwissMapGroupsType
-      ID: 207
+      ID: 259
       Name: groupReference<[4]int,[4]int>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 208 PointerType *noalg.map.group[[4]int][4]int
+          Type: 260 PointerType *noalg.map.group[[4]int][4]int
         - Name: lengthMask
           Offset: 8
           Type: 8 BaseType uint64
-      GroupType: 209 StructureType noalg.map.group[[4]int][4]int
+      GroupType: 261 StructureType noalg.map.group[[4]int][4]int
       GroupSliceType: 265 GoSliceDataType []noalg.map.group[[4]int][4]int.array
     - __kind: GoSwissMapGroupsType
-      ID: 204
+      ID: 252
       Name: groupReference<[4]int,uint8>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 205 PointerType *noalg.map.group[[4]int]uint8
+          Type: 253 PointerType *noalg.map.group[[4]int]uint8
         - Name: lengthMask
           Offset: 8
           Type: 8 BaseType uint64
-      GroupType: 206 StructureType noalg.map.group[[4]int]uint8
-      GroupSliceType: 263 GoSliceDataType []noalg.map.group[[4]int]uint8.array
+      GroupType: 254 StructureType noalg.map.group[[4]int]uint8
+      GroupSliceType: 258 GoSliceDataType []noalg.map.group[[4]int]uint8.array
     - __kind: GoSwissMapGroupsType
-      ID: 186
+      ID: 206
       Name: groupReference<[4]string,[2]int>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 187 PointerType *noalg.map.group[[4]string][2]int
+          Type: 207 PointerType *noalg.map.group[[4]string][2]int
         - Name: lengthMask
           Offset: 8
           Type: 8 BaseType uint64
-      GroupType: 188 StructureType noalg.map.group[[4]string][2]int
-      GroupSliceType: 251 GoSliceDataType []noalg.map.group[[4]string][2]int.array
+      GroupType: 208 StructureType noalg.map.group[[4]string][2]int
+      GroupSliceType: 213 GoSliceDataType []noalg.map.group[[4]string][2]int.array
     - __kind: GoSwissMapGroupsType
-      ID: 192
+      ID: 223
       Name: groupReference<bool,main.node>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 193 PointerType *noalg.map.group[bool]main.node
+          Type: 224 PointerType *noalg.map.group[bool]main.node
         - Name: lengthMask
           Offset: 8
           Type: 8 BaseType uint64
-      GroupType: 194 StructureType noalg.map.group[bool]main.node
-      GroupSliceType: 255 GoSliceDataType []noalg.map.group[bool]main.node.array
+      GroupType: 225 StructureType noalg.map.group[bool]main.node
+      GroupSliceType: 229 GoSliceDataType []noalg.map.group[bool]main.node.array
     - __kind: GoSwissMapGroupsType
-      ID: 174
+      ID: 178
       Name: groupReference<int,int>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 175 PointerType *noalg.map.group[int]int
+          Type: 179 PointerType *noalg.map.group[int]int
         - Name: lengthMask
           Offset: 8
           Type: 8 BaseType uint64
-      GroupType: 176 StructureType noalg.map.group[int]int
-      GroupSliceType: 243 GoSliceDataType []noalg.map.group[int]int.array
+      GroupType: 180 StructureType noalg.map.group[int]int
+      GroupSliceType: 184 GoSliceDataType []noalg.map.group[int]int.array
     - __kind: GoSwissMapGroupsType
-      ID: 195
+      ID: 230
       Name: groupReference<int,uint8>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 196 PointerType *noalg.map.group[int]uint8
+          Type: 231 PointerType *noalg.map.group[int]uint8
         - Name: lengthMask
           Offset: 8
           Type: 8 BaseType uint64
-      GroupType: 197 StructureType noalg.map.group[int]uint8
-      GroupSliceType: 257 GoSliceDataType []noalg.map.group[int]uint8.array
+      GroupType: 232 StructureType noalg.map.group[int]uint8
+      GroupSliceType: 236 GoSliceDataType []noalg.map.group[int]uint8.array
     - __kind: GoSwissMapGroupsType
-      ID: 189
+      ID: 214
       Name: groupReference<string,[]main.structWithMap>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 190 PointerType *noalg.map.group[string][]main.structWithMap
+          Type: 215 PointerType *noalg.map.group[string][]main.structWithMap
         - Name: lengthMask
           Offset: 8
           Type: 8 BaseType uint64
-      GroupType: 191 StructureType noalg.map.group[string][]main.structWithMap
-      GroupSliceType: 253 GoSliceDataType []noalg.map.group[string][]main.structWithMap.array
+      GroupType: 216 StructureType noalg.map.group[string][]main.structWithMap
+      GroupSliceType: 222 GoSliceDataType []noalg.map.group[string][]main.structWithMap.array
     - __kind: GoSwissMapGroupsType
-      ID: 183
+      ID: 199
       Name: groupReference<string,[]string>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 184 PointerType *noalg.map.group[string][]string
+          Type: 200 PointerType *noalg.map.group[string][]string
         - Name: lengthMask
           Offset: 8
           Type: 8 BaseType uint64
-      GroupType: 185 StructureType noalg.map.group[string][]string
-      GroupSliceType: 249 GoSliceDataType []noalg.map.group[string][]string.array
+      GroupType: 201 StructureType noalg.map.group[string][]string
+      GroupSliceType: 205 GoSliceDataType []noalg.map.group[string][]string.array
     - __kind: GoSwissMapGroupsType
-      ID: 180
+      ID: 192
       Name: groupReference<string,int>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 181 PointerType *noalg.map.group[string]int
+          Type: 193 PointerType *noalg.map.group[string]int
         - Name: lengthMask
           Offset: 8
           Type: 8 BaseType uint64
-      GroupType: 182 StructureType noalg.map.group[string]int
-      GroupSliceType: 247 GoSliceDataType []noalg.map.group[string]int.array
+      GroupType: 194 StructureType noalg.map.group[string]int
+      GroupSliceType: 198 GoSliceDataType []noalg.map.group[string]int.array
     - __kind: GoSwissMapGroupsType
-      ID: 177
+      ID: 185
       Name: groupReference<string,main.nestedStruct>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 178 PointerType *noalg.map.group[string]main.nestedStruct
+          Type: 186 PointerType *noalg.map.group[string]main.nestedStruct
         - Name: lengthMask
           Offset: 8
           Type: 8 BaseType uint64
-      GroupType: 179 StructureType noalg.map.group[string]main.nestedStruct
-      GroupSliceType: 245 GoSliceDataType []noalg.map.group[string]main.nestedStruct.array
+      GroupType: 187 StructureType noalg.map.group[string]main.nestedStruct
+      GroupSliceType: 191 GoSliceDataType []noalg.map.group[string]main.nestedStruct.array
     - __kind: GoSwissMapGroupsType
-      ID: 201
+      ID: 244
       Name: groupReference<uint8,[4]int>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 202 PointerType *noalg.map.group[uint8][4]int
+          Type: 245 PointerType *noalg.map.group[uint8][4]int
         - Name: lengthMask
           Offset: 8
           Type: 8 BaseType uint64
-      GroupType: 203 StructureType noalg.map.group[uint8][4]int
-      GroupSliceType: 261 GoSliceDataType []noalg.map.group[uint8][4]int.array
+      GroupType: 246 StructureType noalg.map.group[uint8][4]int
+      GroupSliceType: 251 GoSliceDataType []noalg.map.group[uint8][4]int.array
     - __kind: GoSwissMapGroupsType
-      ID: 198
+      ID: 237
       Name: groupReference<uint8,uint8>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 199 PointerType *noalg.map.group[uint8]uint8
+          Type: 238 PointerType *noalg.map.group[uint8]uint8
         - Name: lengthMask
           Offset: 8
           Type: 8 BaseType uint64
-      GroupType: 200 StructureType noalg.map.group[uint8]uint8
-      GroupSliceType: 259 GoSliceDataType []noalg.map.group[uint8]uint8.array
+      GroupType: 239 StructureType noalg.map.group[uint8]uint8
+      GroupSliceType: 243 GoSliceDataType []noalg.map.group[uint8]uint8.array
     - __kind: BaseType
       ID: 7
       Name: int
@@ -6211,7 +6211,7 @@ Types:
           Offset: 40
           Type: 8 BaseType uint64
       TablePtrSliceType: 264 GoSliceDataType []*table<[4]int,[4]int>.array
-      GroupType: 209 StructureType noalg.map.group[[4]int][4]int
+      GroupType: 261 StructureType noalg.map.group[[4]int][4]int
     - __kind: GoSwissMapHeaderType
       ID: 120
       Name: map<[4]int,uint8>
@@ -6245,8 +6245,8 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 8 BaseType uint64
-      TablePtrSliceType: 262 GoSliceDataType []*table<[4]int,uint8>.array
-      GroupType: 206 StructureType noalg.map.group[[4]int]uint8
+      TablePtrSliceType: 257 GoSliceDataType []*table<[4]int,uint8>.array
+      GroupType: 254 StructureType noalg.map.group[[4]int]uint8
     - __kind: GoSwissMapHeaderType
       ID: 88
       Name: map<[4]string,[2]int>
@@ -6280,8 +6280,8 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 8 BaseType uint64
-      TablePtrSliceType: 250 GoSliceDataType []*table<[4]string,[2]int>.array
-      GroupType: 188 StructureType noalg.map.group[[4]string][2]int
+      TablePtrSliceType: 212 GoSliceDataType []*table<[4]string,[2]int>.array
+      GroupType: 208 StructureType noalg.map.group[[4]string][2]int
     - __kind: GoSwissMapHeaderType
       ID: 100
       Name: map<bool,main.node>
@@ -6315,8 +6315,8 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 8 BaseType uint64
-      TablePtrSliceType: 254 GoSliceDataType []*table<bool,main.node>.array
-      GroupType: 194 StructureType noalg.map.group[bool]main.node
+      TablePtrSliceType: 228 GoSliceDataType []*table<bool,main.node>.array
+      GroupType: 225 StructureType noalg.map.group[bool]main.node
     - __kind: GoSwissMapHeaderType
       ID: 68
       Name: map<int,int>
@@ -6350,8 +6350,8 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 8 BaseType uint64
-      TablePtrSliceType: 242 GoSliceDataType []*table<int,int>.array
-      GroupType: 176 StructureType noalg.map.group[int]int
+      TablePtrSliceType: 183 GoSliceDataType []*table<int,int>.array
+      GroupType: 180 StructureType noalg.map.group[int]int
     - __kind: GoSwissMapHeaderType
       ID: 105
       Name: map<int,uint8>
@@ -6385,8 +6385,8 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 8 BaseType uint64
-      TablePtrSliceType: 256 GoSliceDataType []*table<int,uint8>.array
-      GroupType: 197 StructureType noalg.map.group[int]uint8
+      TablePtrSliceType: 235 GoSliceDataType []*table<int,uint8>.array
+      GroupType: 232 StructureType noalg.map.group[int]uint8
     - __kind: GoSwissMapHeaderType
       ID: 95
       Name: map<string,[]main.structWithMap>
@@ -6420,8 +6420,8 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 8 BaseType uint64
-      TablePtrSliceType: 252 GoSliceDataType []*table<string,[]main.structWithMap>.array
-      GroupType: 191 StructureType noalg.map.group[string][]main.structWithMap
+      TablePtrSliceType: 221 GoSliceDataType []*table<string,[]main.structWithMap>.array
+      GroupType: 216 StructureType noalg.map.group[string][]main.structWithMap
     - __kind: GoSwissMapHeaderType
       ID: 83
       Name: map<string,[]string>
@@ -6455,8 +6455,8 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 8 BaseType uint64
-      TablePtrSliceType: 248 GoSliceDataType []*table<string,[]string>.array
-      GroupType: 185 StructureType noalg.map.group[string][]string
+      TablePtrSliceType: 204 GoSliceDataType []*table<string,[]string>.array
+      GroupType: 201 StructureType noalg.map.group[string][]string
     - __kind: GoSwissMapHeaderType
       ID: 78
       Name: map<string,int>
@@ -6490,8 +6490,8 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 8 BaseType uint64
-      TablePtrSliceType: 246 GoSliceDataType []*table<string,int>.array
-      GroupType: 182 StructureType noalg.map.group[string]int
+      TablePtrSliceType: 197 GoSliceDataType []*table<string,int>.array
+      GroupType: 194 StructureType noalg.map.group[string]int
     - __kind: GoSwissMapHeaderType
       ID: 73
       Name: map<string,main.nestedStruct>
@@ -6525,8 +6525,8 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 8 BaseType uint64
-      TablePtrSliceType: 244 GoSliceDataType []*table<string,main.nestedStruct>.array
-      GroupType: 179 StructureType noalg.map.group[string]main.nestedStruct
+      TablePtrSliceType: 190 GoSliceDataType []*table<string,main.nestedStruct>.array
+      GroupType: 187 StructureType noalg.map.group[string]main.nestedStruct
     - __kind: GoSwissMapHeaderType
       ID: 115
       Name: map<uint8,[4]int>
@@ -6560,8 +6560,8 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 8 BaseType uint64
-      TablePtrSliceType: 260 GoSliceDataType []*table<uint8,[4]int>.array
-      GroupType: 203 StructureType noalg.map.group[uint8][4]int
+      TablePtrSliceType: 250 GoSliceDataType []*table<uint8,[4]int>.array
+      GroupType: 246 StructureType noalg.map.group[uint8][4]int
     - __kind: GoSwissMapHeaderType
       ID: 110
       Name: map<uint8,uint8>
@@ -6595,8 +6595,8 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 8 BaseType uint64
-      TablePtrSliceType: 258 GoSliceDataType []*table<uint8,uint8>.array
-      GroupType: 200 StructureType noalg.map.group[uint8]uint8
+      TablePtrSliceType: 242 GoSliceDataType []*table<uint8,uint8>.array
+      GroupType: 239 StructureType noalg.map.group[uint8]uint8
     - __kind: GoMapType
       ID: 123
       Name: map[[4]int][4]int
@@ -6682,115 +6682,115 @@ Types:
       GoKind: 21
       HeaderType: 110 GoSwissMapHeaderType map<uint8,uint8>
     - __kind: ArrayType
-      ID: 236
+      ID: 262
       Name: noalg.[8]struct { key [4]int; elem [4]int }
       ByteSize: 512
       GoRuntimeType: 676736
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 237 StructureType noalg.struct { key [4]int; elem [4]int }
+      Element: 263 StructureType noalg.struct { key [4]int; elem [4]int }
     - __kind: ArrayType
-      ID: 234
+      ID: 255
       Name: noalg.[8]struct { key [4]int; elem uint8 }
       ByteSize: 320
       GoRuntimeType: 676832
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 235 StructureType noalg.struct { key [4]int; elem uint8 }
+      Element: 256 StructureType noalg.struct { key [4]int; elem uint8 }
     - __kind: ArrayType
-      ID: 218
+      ID: 209
       Name: noalg.[8]struct { key [4]string; elem [2]int }
       ByteSize: 640
       GoRuntimeType: 677120
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 219 StructureType noalg.struct { key [4]string; elem [2]int }
+      Element: 210 StructureType noalg.struct { key [4]string; elem [2]int }
     - __kind: ArrayType
-      ID: 225
+      ID: 226
       Name: noalg.[8]struct { key bool; elem main.node }
       ByteSize: 192
       GoRuntimeType: 677216
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 226 StructureType noalg.struct { key bool; elem main.node }
+      Element: 227 StructureType noalg.struct { key bool; elem main.node }
     - __kind: ArrayType
-      ID: 210
+      ID: 181
       Name: noalg.[8]struct { key int; elem int }
       ByteSize: 128
       GoRuntimeType: 675008
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 211 StructureType noalg.struct { key int; elem int }
+      Element: 182 StructureType noalg.struct { key int; elem int }
     - __kind: ArrayType
-      ID: 227
+      ID: 233
       Name: noalg.[8]struct { key int; elem uint8 }
       ByteSize: 128
       GoRuntimeType: 677312
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 228 StructureType noalg.struct { key int; elem uint8 }
+      Element: 234 StructureType noalg.struct { key int; elem uint8 }
     - __kind: ArrayType
-      ID: 221
+      ID: 217
       Name: noalg.[8]struct { key string; elem []main.structWithMap }
       ByteSize: 320
       GoRuntimeType: 677408
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 222 StructureType noalg.struct { key string; elem []main.structWithMap }
+      Element: 218 StructureType noalg.struct { key string; elem []main.structWithMap }
     - __kind: ArrayType
-      ID: 216
+      ID: 202
       Name: noalg.[8]struct { key string; elem []string }
       ByteSize: 320
       GoRuntimeType: 677504
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 217 StructureType noalg.struct { key string; elem []string }
+      Element: 203 StructureType noalg.struct { key string; elem []string }
     - __kind: ArrayType
-      ID: 214
+      ID: 195
       Name: noalg.[8]struct { key string; elem int }
       ByteSize: 192
       GoRuntimeType: 677600
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 215 StructureType noalg.struct { key string; elem int }
+      Element: 196 StructureType noalg.struct { key string; elem int }
     - __kind: ArrayType
-      ID: 212
+      ID: 188
       Name: noalg.[8]struct { key string; elem main.nestedStruct }
       ByteSize: 320
       GoRuntimeType: 677696
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 213 StructureType noalg.struct { key string; elem main.nestedStruct }
+      Element: 189 StructureType noalg.struct { key string; elem main.nestedStruct }
     - __kind: ArrayType
-      ID: 231
+      ID: 247
       Name: noalg.[8]struct { key uint8; elem [4]int }
       ByteSize: 320
       GoRuntimeType: 677792
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 232 StructureType noalg.struct { key uint8; elem [4]int }
+      Element: 248 StructureType noalg.struct { key uint8; elem [4]int }
     - __kind: ArrayType
-      ID: 229
+      ID: 240
       Name: noalg.[8]struct { key uint8; elem uint8 }
       ByteSize: 16
       GoRuntimeType: 677888
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 230 StructureType noalg.struct { key uint8; elem uint8 }
+      Element: 241 StructureType noalg.struct { key uint8; elem uint8 }
     - __kind: StructureType
-      ID: 209
+      ID: 261
       Name: noalg.map.group[[4]int][4]int
       ByteSize: 520
       GoRuntimeType: 1.28176e+06
@@ -6801,9 +6801,9 @@ Types:
           Type: 8 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 236 ArrayType noalg.[8]struct { key [4]int; elem [4]int }
+          Type: 262 ArrayType noalg.[8]struct { key [4]int; elem [4]int }
     - __kind: StructureType
-      ID: 206
+      ID: 254
       Name: noalg.map.group[[4]int]uint8
       ByteSize: 328
       GoRuntimeType: 1.282016e+06
@@ -6814,9 +6814,9 @@ Types:
           Type: 8 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 234 ArrayType noalg.[8]struct { key [4]int; elem uint8 }
+          Type: 255 ArrayType noalg.[8]struct { key [4]int; elem uint8 }
     - __kind: StructureType
-      ID: 188
+      ID: 208
       Name: noalg.map.group[[4]string][2]int
       ByteSize: 648
       GoRuntimeType: 1.282272e+06
@@ -6827,9 +6827,9 @@ Types:
           Type: 8 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 218 ArrayType noalg.[8]struct { key [4]string; elem [2]int }
+          Type: 209 ArrayType noalg.[8]struct { key [4]string; elem [2]int }
     - __kind: StructureType
-      ID: 194
+      ID: 225
       Name: noalg.map.group[bool]main.node
       ByteSize: 200
       GoRuntimeType: 1.282528e+06
@@ -6840,9 +6840,9 @@ Types:
           Type: 8 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 225 ArrayType noalg.[8]struct { key bool; elem main.node }
+          Type: 226 ArrayType noalg.[8]struct { key bool; elem main.node }
     - __kind: StructureType
-      ID: 176
+      ID: 180
       Name: noalg.map.group[int]int
       ByteSize: 136
       GoRuntimeType: 1.280992e+06
@@ -6853,9 +6853,9 @@ Types:
           Type: 8 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 210 ArrayType noalg.[8]struct { key int; elem int }
+          Type: 181 ArrayType noalg.[8]struct { key int; elem int }
     - __kind: StructureType
-      ID: 197
+      ID: 232
       Name: noalg.map.group[int]uint8
       ByteSize: 136
       GoRuntimeType: 1.282784e+06
@@ -6866,9 +6866,9 @@ Types:
           Type: 8 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 227 ArrayType noalg.[8]struct { key int; elem uint8 }
+          Type: 233 ArrayType noalg.[8]struct { key int; elem uint8 }
     - __kind: StructureType
-      ID: 191
+      ID: 216
       Name: noalg.map.group[string][]main.structWithMap
       ByteSize: 328
       GoRuntimeType: 1.28304e+06
@@ -6879,9 +6879,9 @@ Types:
           Type: 8 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 221 ArrayType noalg.[8]struct { key string; elem []main.structWithMap }
+          Type: 217 ArrayType noalg.[8]struct { key string; elem []main.structWithMap }
     - __kind: StructureType
-      ID: 185
+      ID: 201
       Name: noalg.map.group[string][]string
       ByteSize: 328
       GoRuntimeType: 1.283296e+06
@@ -6892,9 +6892,9 @@ Types:
           Type: 8 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 216 ArrayType noalg.[8]struct { key string; elem []string }
+          Type: 202 ArrayType noalg.[8]struct { key string; elem []string }
     - __kind: StructureType
-      ID: 182
+      ID: 194
       Name: noalg.map.group[string]int
       ByteSize: 200
       GoRuntimeType: 1.283552e+06
@@ -6905,9 +6905,9 @@ Types:
           Type: 8 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 214 ArrayType noalg.[8]struct { key string; elem int }
+          Type: 195 ArrayType noalg.[8]struct { key string; elem int }
     - __kind: StructureType
-      ID: 179
+      ID: 187
       Name: noalg.map.group[string]main.nestedStruct
       ByteSize: 328
       GoRuntimeType: 1.283808e+06
@@ -6918,9 +6918,9 @@ Types:
           Type: 8 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 212 ArrayType noalg.[8]struct { key string; elem main.nestedStruct }
+          Type: 188 ArrayType noalg.[8]struct { key string; elem main.nestedStruct }
     - __kind: StructureType
-      ID: 203
+      ID: 246
       Name: noalg.map.group[uint8][4]int
       ByteSize: 328
       GoRuntimeType: 1.284064e+06
@@ -6931,9 +6931,9 @@ Types:
           Type: 8 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 231 ArrayType noalg.[8]struct { key uint8; elem [4]int }
+          Type: 247 ArrayType noalg.[8]struct { key uint8; elem [4]int }
     - __kind: StructureType
-      ID: 200
+      ID: 239
       Name: noalg.map.group[uint8]uint8
       ByteSize: 24
       GoRuntimeType: 1.28432e+06
@@ -6944,9 +6944,9 @@ Types:
           Type: 8 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 229 ArrayType noalg.[8]struct { key uint8; elem uint8 }
+          Type: 240 ArrayType noalg.[8]struct { key uint8; elem uint8 }
     - __kind: StructureType
-      ID: 237
+      ID: 263
       Name: noalg.struct { key [4]int; elem [4]int }
       ByteSize: 64
       GoRuntimeType: 1.281632e+06
@@ -6954,12 +6954,12 @@ Types:
       RawFields:
         - Name: key
           Offset: 0
-          Type: 233 ArrayType [4]int
+          Type: 249 ArrayType [4]int
         - Name: elem
           Offset: 32
-          Type: 233 ArrayType [4]int
+          Type: 249 ArrayType [4]int
     - __kind: StructureType
-      ID: 235
+      ID: 256
       Name: noalg.struct { key [4]int; elem uint8 }
       ByteSize: 40
       GoRuntimeType: 1.281888e+06
@@ -6967,12 +6967,12 @@ Types:
       RawFields:
         - Name: key
           Offset: 0
-          Type: 233 ArrayType [4]int
+          Type: 249 ArrayType [4]int
         - Name: elem
           Offset: 32
           Type: 3 BaseType uint8
     - __kind: StructureType
-      ID: 219
+      ID: 210
       Name: noalg.struct { key [4]string; elem [2]int }
       ByteSize: 80
       GoRuntimeType: 1.282144e+06
@@ -6980,12 +6980,12 @@ Types:
       RawFields:
         - Name: key
           Offset: 0
-          Type: 220 ArrayType [4]string
+          Type: 211 ArrayType [4]string
         - Name: elem
           Offset: 64
           Type: 40 ArrayType [2]int
     - __kind: StructureType
-      ID: 226
+      ID: 227
       Name: noalg.struct { key bool; elem main.node }
       ByteSize: 24
       GoRuntimeType: 1.2824e+06
@@ -6998,7 +6998,7 @@ Types:
           Offset: 8
           Type: 131 StructureType main.node
     - __kind: StructureType
-      ID: 211
+      ID: 182
       Name: noalg.struct { key int; elem int }
       ByteSize: 16
       GoRuntimeType: 1.280864e+06
@@ -7011,7 +7011,7 @@ Types:
           Offset: 8
           Type: 7 BaseType int
     - __kind: StructureType
-      ID: 228
+      ID: 234
       Name: noalg.struct { key int; elem uint8 }
       ByteSize: 16
       GoRuntimeType: 1.282656e+06
@@ -7024,7 +7024,7 @@ Types:
           Offset: 8
           Type: 3 BaseType uint8
     - __kind: StructureType
-      ID: 222
+      ID: 218
       Name: noalg.struct { key string; elem []main.structWithMap }
       ByteSize: 40
       GoRuntimeType: 1.282912e+06
@@ -7035,9 +7035,9 @@ Types:
           Type: 9 GoStringHeaderType string
         - Name: elem
           Offset: 16
-          Type: 223 GoSliceHeaderType []main.structWithMap
+          Type: 219 GoSliceHeaderType []main.structWithMap
     - __kind: StructureType
-      ID: 217
+      ID: 203
       Name: noalg.struct { key string; elem []string }
       ByteSize: 40
       GoRuntimeType: 1.283168e+06
@@ -7050,7 +7050,7 @@ Types:
           Offset: 16
           Type: 141 GoSliceHeaderType []string
     - __kind: StructureType
-      ID: 215
+      ID: 196
       Name: noalg.struct { key string; elem int }
       ByteSize: 24
       GoRuntimeType: 1.283424e+06
@@ -7063,7 +7063,7 @@ Types:
           Offset: 16
           Type: 7 BaseType int
     - __kind: StructureType
-      ID: 213
+      ID: 189
       Name: noalg.struct { key string; elem main.nestedStruct }
       ByteSize: 40
       GoRuntimeType: 1.28368e+06
@@ -7076,7 +7076,7 @@ Types:
           Offset: 16
           Type: 149 StructureType main.nestedStruct
     - __kind: StructureType
-      ID: 232
+      ID: 248
       Name: noalg.struct { key uint8; elem [4]int }
       ByteSize: 40
       GoRuntimeType: 1.283936e+06
@@ -7087,9 +7087,9 @@ Types:
           Type: 3 BaseType uint8
         - Name: elem
           Offset: 8
-          Type: 233 ArrayType [4]int
+          Type: 249 ArrayType [4]int
     - __kind: StructureType
-      ID: 230
+      ID: 241
       Name: noalg.struct { key uint8; elem uint8 }
       ByteSize: 2
       GoRuntimeType: 1.284192e+06
@@ -7110,13 +7110,13 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 239 PointerType *string.str
+          Type: 175 PointerType *string.str
         - Name: len
           Offset: 8
           Type: 7 BaseType int
-      Data: 238 GoStringDataType string.str
+      Data: 174 GoStringDataType string.str
     - __kind: GoStringDataType
-      ID: 238
+      ID: 174
       Name: string.str
       ByteSize: 2048
     - __kind: StructureType
@@ -7247,7 +7247,7 @@ Types:
           Type: 7 BaseType int
         - Name: groups
           Offset: 16
-          Type: 207 GoSwissMapGroupsType groupReference<[4]int,[4]int>
+          Type: 259 GoSwissMapGroupsType groupReference<[4]int,[4]int>
     - __kind: StructureType
       ID: 171
       Name: table<[4]int,uint8>
@@ -7271,7 +7271,7 @@ Types:
           Type: 7 BaseType int
         - Name: groups
           Offset: 16
-          Type: 204 GoSwissMapGroupsType groupReference<[4]int,uint8>
+          Type: 252 GoSwissMapGroupsType groupReference<[4]int,uint8>
     - __kind: StructureType
       ID: 165
       Name: table<[4]string,[2]int>
@@ -7295,7 +7295,7 @@ Types:
           Type: 7 BaseType int
         - Name: groups
           Offset: 16
-          Type: 186 GoSwissMapGroupsType groupReference<[4]string,[2]int>
+          Type: 206 GoSwissMapGroupsType groupReference<[4]string,[2]int>
     - __kind: StructureType
       ID: 167
       Name: table<bool,main.node>
@@ -7319,7 +7319,7 @@ Types:
           Type: 7 BaseType int
         - Name: groups
           Offset: 16
-          Type: 192 GoSwissMapGroupsType groupReference<bool,main.node>
+          Type: 223 GoSwissMapGroupsType groupReference<bool,main.node>
     - __kind: StructureType
       ID: 161
       Name: table<int,int>
@@ -7343,7 +7343,7 @@ Types:
           Type: 7 BaseType int
         - Name: groups
           Offset: 16
-          Type: 174 GoSwissMapGroupsType groupReference<int,int>
+          Type: 178 GoSwissMapGroupsType groupReference<int,int>
     - __kind: StructureType
       ID: 168
       Name: table<int,uint8>
@@ -7367,7 +7367,7 @@ Types:
           Type: 7 BaseType int
         - Name: groups
           Offset: 16
-          Type: 195 GoSwissMapGroupsType groupReference<int,uint8>
+          Type: 230 GoSwissMapGroupsType groupReference<int,uint8>
     - __kind: StructureType
       ID: 166
       Name: table<string,[]main.structWithMap>
@@ -7391,7 +7391,7 @@ Types:
           Type: 7 BaseType int
         - Name: groups
           Offset: 16
-          Type: 189 GoSwissMapGroupsType groupReference<string,[]main.structWithMap>
+          Type: 214 GoSwissMapGroupsType groupReference<string,[]main.structWithMap>
     - __kind: StructureType
       ID: 164
       Name: table<string,[]string>
@@ -7415,7 +7415,7 @@ Types:
           Type: 7 BaseType int
         - Name: groups
           Offset: 16
-          Type: 183 GoSwissMapGroupsType groupReference<string,[]string>
+          Type: 199 GoSwissMapGroupsType groupReference<string,[]string>
     - __kind: StructureType
       ID: 163
       Name: table<string,int>
@@ -7439,7 +7439,7 @@ Types:
           Type: 7 BaseType int
         - Name: groups
           Offset: 16
-          Type: 180 GoSwissMapGroupsType groupReference<string,int>
+          Type: 192 GoSwissMapGroupsType groupReference<string,int>
     - __kind: StructureType
       ID: 162
       Name: table<string,main.nestedStruct>
@@ -7463,7 +7463,7 @@ Types:
           Type: 7 BaseType int
         - Name: groups
           Offset: 16
-          Type: 177 GoSwissMapGroupsType groupReference<string,main.nestedStruct>
+          Type: 185 GoSwissMapGroupsType groupReference<string,main.nestedStruct>
     - __kind: StructureType
       ID: 170
       Name: table<uint8,[4]int>
@@ -7487,7 +7487,7 @@ Types:
           Type: 7 BaseType int
         - Name: groups
           Offset: 16
-          Type: 201 GoSwissMapGroupsType groupReference<uint8,[4]int>
+          Type: 244 GoSwissMapGroupsType groupReference<uint8,[4]int>
     - __kind: StructureType
       ID: 169
       Name: table<uint8,uint8>
@@ -7511,7 +7511,7 @@ Types:
           Type: 7 BaseType int
         - Name: groups
           Offset: 16
-          Type: 198 GoSwissMapGroupsType groupReference<uint8,uint8>
+          Type: 237 GoSwissMapGroupsType groupReference<uint8,uint8>
     - __kind: BaseType
       ID: 17
       Name: uint

--- a/pkg/dyninst/irgen/testdata/snapshot/sample.arch=amd64,toolchain=go1.25.0.yaml
+++ b/pkg/dyninst/irgen/testdata/snapshot/sample.arch=amd64,toolchain=go1.25.0.yaml
@@ -8,11 +8,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 88}
+      subprogram: {subprogram: 96}
       events:
-        - ID: 88
-          Type: 369 EventRootType Probe[main.stackC]
-          InjectionPoints: [{PC: "0xcdcc6a", Frameless: false}]
+        - ID: 96
+          Type: 502 EventRootType Probe[main.stackC]
+          InjectionPoints: [{PC: "0xcdd6aa", Frameless: false}]
           Condition: null
     - id: testAny
       version: 0
@@ -22,11 +22,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 45}
+      subprogram: {subprogram: 53}
       events:
-        - ID: 45
-          Type: 326 EventRootType Probe[main.testAny]
-          InjectionPoints: [{PC: "0xcd9d4a", Frameless: false}]
+        - ID: 53
+          Type: 459 EventRootType Probe[main.testAny]
+          InjectionPoints: [{PC: "0xcda78a", Frameless: false}]
           Condition: null
     - id: testArrayOfArrays
       version: 0
@@ -39,8 +39,8 @@ Probes:
       subprogram: {subprogram: 15}
       events:
         - ID: 15
-          Type: 296 EventRootType Probe[main.testArrayOfArrays]
-          InjectionPoints: [{PC: "0xcd8780", Frameless: true}]
+          Type: 421 EventRootType Probe[main.testArrayOfArrays]
+          InjectionPoints: [{PC: "0xcd8bc0", Frameless: true}]
           Condition: null
     - id: testArrayOfArraysOfArrays
       version: 0
@@ -53,8 +53,8 @@ Probes:
       subprogram: {subprogram: 17}
       events:
         - ID: 17
-          Type: 298 EventRootType Probe[main.testArrayOfArraysOfArrays]
-          InjectionPoints: [{PC: "0xcd87c0", Frameless: true}]
+          Type: 423 EventRootType Probe[main.testArrayOfArraysOfArrays]
+          InjectionPoints: [{PC: "0xcd8c00", Frameless: true}]
           Condition: null
     - id: testArrayOfMaps
       version: 0
@@ -64,11 +64,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 53}
+      subprogram: {subprogram: 61}
       events:
-        - ID: 53
-          Type: 334 EventRootType Probe[main.testArrayOfMaps]
-          InjectionPoints: [{PC: "0xcda280", Frameless: true}]
+        - ID: 61
+          Type: 467 EventRootType Probe[main.testArrayOfMaps]
+          InjectionPoints: [{PC: "0xcdacc0", Frameless: true}]
           Condition: null
     - id: testArrayOfStrings
       version: 0
@@ -81,8 +81,8 @@ Probes:
       subprogram: {subprogram: 16}
       events:
         - ID: 16
-          Type: 297 EventRootType Probe[main.testArrayOfStrings]
-          InjectionPoints: [{PC: "0xcd87a0", Frameless: true}]
+          Type: 422 EventRootType Probe[main.testArrayOfStrings]
+          InjectionPoints: [{PC: "0xcd8be0", Frameless: true}]
           Condition: null
     - id: testBigStruct
       version: 0
@@ -95,8 +95,8 @@ Probes:
       subprogram: {subprogram: 35}
       events:
         - ID: 35
-          Type: 316 EventRootType Probe[main.testBigStruct]
-          InjectionPoints: [{PC: "0xcd8ee0", Frameless: true}]
+          Type: 441 EventRootType Probe[main.testBigStruct]
+          InjectionPoints: [{PC: "0xcd9320", Frameless: true}]
           Condition: null
     - id: testBoolArray
       version: 0
@@ -109,8 +109,8 @@ Probes:
       subprogram: {subprogram: 4}
       events:
         - ID: 4
-          Type: 285 EventRootType Probe[main.testBoolArray]
-          InjectionPoints: [{PC: "0xcd8620", Frameless: true}]
+          Type: 410 EventRootType Probe[main.testBoolArray]
+          InjectionPoints: [{PC: "0xcd8a60", Frameless: true}]
           Condition: null
     - id: testByteArray
       version: 0
@@ -123,8 +123,8 @@ Probes:
       subprogram: {subprogram: 1}
       events:
         - ID: 1
-          Type: 282 EventRootType Probe[main.testByteArray]
-          InjectionPoints: [{PC: "0xcd85c0", Frameless: true}]
+          Type: 407 EventRootType Probe[main.testByteArray]
+          InjectionPoints: [{PC: "0xcd8a00", Frameless: true}]
           Condition: null
     - id: testChannel
       version: 0
@@ -134,11 +134,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 69}
+      subprogram: {subprogram: 77}
       events:
-        - ID: 69
-          Type: 350 EventRootType Probe[main.testChannel]
-          InjectionPoints: [{PC: "0xcdbf40", Frameless: true}]
+        - ID: 77
+          Type: 483 EventRootType Probe[main.testChannel]
+          InjectionPoints: [{PC: "0xcdc980", Frameless: true}]
           Condition: null
     - id: testCombinedByte
       version: 0
@@ -148,11 +148,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 67}
+      subprogram: {subprogram: 75}
       events:
-        - ID: 67
-          Type: 348 EventRootType Probe[main.testCombinedByte]
-          InjectionPoints: [{PC: "0xcdbb60", Frameless: true}]
+        - ID: 75
+          Type: 481 EventRootType Probe[main.testCombinedByte]
+          InjectionPoints: [{PC: "0xcdc5a0", Frameless: true}]
           Condition: null
     - id: testCycle
       version: 0
@@ -162,11 +162,113 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 77}
+      subprogram: {subprogram: 85}
       events:
-        - ID: 77
-          Type: 358 EventRootType Probe[main.testCycle]
-          InjectionPoints: [{PC: "0xcdc2e0", Frameless: true}]
+        - ID: 85
+          Type: 491 EventRootType Probe[main.testCycle]
+          InjectionPoints: [{PC: "0xcdcd20", Frameless: true}]
+          Condition: null
+    - id: testDeepMap1
+      version: 0
+      type: LOG_PROBE
+      where: {methodName: main.testDeepMap1}
+      capture:
+        maxReferenceDepth: 1
+        maxFieldCount: 0
+        maxCollectionSize: 0
+      template: ""
+      segments: []
+      captureSnapshot: true
+      subprogram: {subprogram: 40}
+      events:
+        - ID: 40
+          Type: 446 EventRootType Probe[main.testDeepMap1]
+          InjectionPoints: [{PC: "0xcd9700", Frameless: true}]
+          Condition: null
+    - id: testDeepMap7
+      version: 0
+      type: LOG_PROBE
+      where: {methodName: main.testDeepMap7}
+      capture:
+        maxReferenceDepth: 5
+        maxFieldCount: 0
+        maxCollectionSize: 0
+      template: ""
+      segments: []
+      captureSnapshot: true
+      subprogram: {subprogram: 41}
+      events:
+        - ID: 41
+          Type: 447 EventRootType Probe[main.testDeepMap7]
+          InjectionPoints: [{PC: "0xcd9720", Frameless: true}]
+          Condition: null
+    - id: testDeepPtr1
+      version: 0
+      type: LOG_PROBE
+      where: {methodName: main.testDeepPtr1}
+      capture:
+        maxReferenceDepth: 1
+        maxFieldCount: 0
+        maxCollectionSize: 0
+      template: ""
+      segments: []
+      captureSnapshot: true
+      subprogram: {subprogram: 36}
+      events:
+        - ID: 36
+          Type: 442 EventRootType Probe[main.testDeepPtr1]
+          InjectionPoints: [{PC: "0xcd93e0", Frameless: true}]
+          Condition: null
+    - id: testDeepPtr7
+      version: 0
+      type: LOG_PROBE
+      where: {methodName: main.testDeepPtr7}
+      capture:
+        maxReferenceDepth: 5
+        maxFieldCount: 0
+        maxCollectionSize: 0
+      template: ""
+      segments: []
+      captureSnapshot: true
+      subprogram: {subprogram: 37}
+      events:
+        - ID: 37
+          Type: 443 EventRootType Probe[main.testDeepPtr7]
+          InjectionPoints: [{PC: "0xcd9400", Frameless: true}]
+          Condition: null
+    - id: testDeepSlice1
+      version: 0
+      type: LOG_PROBE
+      where: {methodName: main.testDeepSlice1}
+      capture:
+        maxReferenceDepth: 1
+        maxFieldCount: 0
+        maxCollectionSize: 0
+      template: ""
+      segments: []
+      captureSnapshot: true
+      subprogram: {subprogram: 38}
+      events:
+        - ID: 38
+          Type: 444 EventRootType Probe[main.testDeepSlice1]
+          InjectionPoints: [{PC: "0xcd9580", Frameless: true}]
+          Condition: null
+    - id: testDeepSlice7
+      version: 0
+      type: LOG_PROBE
+      where: {methodName: main.testDeepSlice7}
+      capture:
+        maxReferenceDepth: 5
+        maxFieldCount: 0
+        maxCollectionSize: 0
+      template: ""
+      segments: []
+      captureSnapshot: true
+      subprogram: {subprogram: 39}
+      events:
+        - ID: 39
+          Type: 445 EventRootType Probe[main.testDeepSlice7]
+          InjectionPoints: [{PC: "0xcd95a0", Frameless: true}]
           Condition: null
     - id: testEmptySlice
       version: 0
@@ -176,11 +278,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 79}
+      subprogram: {subprogram: 87}
       events:
-        - ID: 79
-          Type: 360 EventRootType Probe[main.testEmptySlice]
-          InjectionPoints: [{PC: "0xcdc820", Frameless: true}]
+        - ID: 87
+          Type: 493 EventRootType Probe[main.testEmptySlice]
+          InjectionPoints: [{PC: "0xcdd260", Frameless: true}]
           Condition: null
     - id: testEmptySliceOfStructs
       version: 0
@@ -190,11 +292,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 82}
+      subprogram: {subprogram: 90}
       events:
-        - ID: 82
-          Type: 363 EventRootType Probe[main.testEmptySliceOfStructs]
-          InjectionPoints: [{PC: "0xcdc880", Frameless: true}]
+        - ID: 90
+          Type: 496 EventRootType Probe[main.testEmptySliceOfStructs]
+          InjectionPoints: [{PC: "0xcdd2c0", Frameless: true}]
           Condition: null
     - id: testEmptyString
       version: 0
@@ -204,11 +306,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 96}
+      subprogram: {subprogram: 104}
       events:
-        - ID: 96
-          Type: 377 EventRootType Probe[main.testEmptyString]
-          InjectionPoints: [{PC: "0xcdcda0", Frameless: true}]
+        - ID: 104
+          Type: 510 EventRootType Probe[main.testEmptyString]
+          InjectionPoints: [{PC: "0xcdd7e0", Frameless: true}]
           Condition: null
     - id: testEmptyStruct
       version: 0
@@ -218,11 +320,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 98}
+      subprogram: {subprogram: 106}
       events:
-        - ID: 98
-          Type: 379 EventRootType Probe[main.testEmptyStruct]
-          InjectionPoints: [{PC: "0xcdd1a0", Frameless: true}]
+        - ID: 106
+          Type: 512 EventRootType Probe[main.testEmptyStruct]
+          InjectionPoints: [{PC: "0xcddbe0", Frameless: true}]
           Condition: null
     - id: testError
       version: 0
@@ -232,11 +334,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 46}
+      subprogram: {subprogram: 54}
       events:
-        - ID: 46
-          Type: 327 EventRootType Probe[main.testError]
-          InjectionPoints: [{PC: "0xcd9dc0", Frameless: true}]
+        - ID: 54
+          Type: 460 EventRootType Probe[main.testError]
+          InjectionPoints: [{PC: "0xcda800", Frameless: true}]
           Condition: null
     - id: testEsotericHeap
       version: 0
@@ -246,11 +348,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 37}
+      subprogram: {subprogram: 45}
       events:
-        - ID: 37
-          Type: 318 EventRootType Probe[main.testEsotericHeap]
-          InjectionPoints: [{PC: "0xcd928a", Frameless: false}]
+        - ID: 45
+          Type: 451 EventRootType Probe[main.testEsotericHeap]
+          InjectionPoints: [{PC: "0xcd9cca", Frameless: false}]
           Condition: null
     - id: testEsotericStack
       version: 0
@@ -260,11 +362,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 36}
+      subprogram: {subprogram: 44}
       events:
-        - ID: 36
-          Type: 317 EventRootType Probe[main.testEsotericStack]
-          InjectionPoints: [{PC: "0xcd916e", Frameless: false}]
+        - ID: 44
+          Type: 450 EventRootType Probe[main.testEsotericStack]
+          InjectionPoints: [{PC: "0xcd9bae", Frameless: false}]
           Condition: null
     - id: testFrameless
       version: 0
@@ -274,11 +376,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 42}
+      subprogram: {subprogram: 50}
       events:
-        - ID: 42
-          Type: 323 EventRootType Probe[main.testFrameless]
-          InjectionPoints: [{PC: "0xcd99e0", Frameless: true}]
+        - ID: 50
+          Type: 456 EventRootType Probe[main.testFrameless]
+          InjectionPoints: [{PC: "0xcda420", Frameless: true}]
           Condition: null
     - id: testFramelessArray
       version: 0
@@ -288,11 +390,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 43}
+      subprogram: {subprogram: 51}
       events:
-        - ID: 43
-          Type: 324 EventRootType Probe[main.testFramelessArray]
-          InjectionPoints: [{PC: "0xcd9a04", Frameless: false}]
+        - ID: 51
+          Type: 457 EventRootType Probe[main.testFramelessArray]
+          InjectionPoints: [{PC: "0xcda444", Frameless: false}]
           Condition: null
     - id: testInlinedBA
       version: 0
@@ -302,11 +404,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 38}
+      subprogram: {subprogram: 46}
       events:
-        - ID: 38
-          Type: 319 EventRootType Probe[main.testInlinedBA]
-          InjectionPoints: [{PC: "0xcd96ca", Frameless: false}]
+        - ID: 46
+          Type: 452 EventRootType Probe[main.testInlinedBA]
+          InjectionPoints: [{PC: "0xcda10a", Frameless: false}]
           Condition: null
     - id: testInlinedBB
       version: 0
@@ -316,11 +418,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 39}
+      subprogram: {subprogram: 47}
       events:
-        - ID: 39
-          Type: 320 EventRootType Probe[main.testInlinedBB]
-          InjectionPoints: [{PC: "0xcd976e", Frameless: false}]
+        - ID: 47
+          Type: 453 EventRootType Probe[main.testInlinedBB]
+          InjectionPoints: [{PC: "0xcda1ae", Frameless: false}]
           Condition: null
     - id: testInlinedBBA
       version: 0
@@ -330,11 +432,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 40}
+      subprogram: {subprogram: 48}
       events:
-        - ID: 40
-          Type: 321 EventRootType Probe[main.testInlinedBBA]
-          InjectionPoints: [{PC: "0xcd984a", Frameless: false}]
+        - ID: 48
+          Type: 454 EventRootType Probe[main.testInlinedBBA]
+          InjectionPoints: [{PC: "0xcda28a", Frameless: false}]
           Condition: null
     - id: testInlinedBBB
       version: 0
@@ -344,11 +446,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 100}
+      subprogram: {subprogram: 108}
       events:
-        - ID: 100
-          Type: 381 EventRootType Probe[main.testInlinedBBB]
-          InjectionPoints: [{PC: "0xcd97c6", Frameless: false}]
+        - ID: 108
+          Type: 514 EventRootType Probe[main.testInlinedBBB]
+          InjectionPoints: [{PC: "0xcda206", Frameless: false}]
           Condition: null
     - id: testInlinedBC
       version: 0
@@ -358,11 +460,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 41}
+      subprogram: {subprogram: 49}
       events:
-        - ID: 41
-          Type: 322 EventRootType Probe[main.testInlinedBC]
-          InjectionPoints: [{PC: "0xcd98ce", Frameless: false}]
+        - ID: 49
+          Type: 455 EventRootType Probe[main.testInlinedBC]
+          InjectionPoints: [{PC: "0xcda30e", Frameless: false}]
           Condition: null
     - id: testInlinedBCA
       version: 0
@@ -372,11 +474,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 101}
+      subprogram: {subprogram: 109}
       events:
-        - ID: 101
-          Type: 382 EventRootType Probe[main.testInlinedBCA]
-          InjectionPoints: [{PC: "0xcd98d3", Frameless: false}]
+        - ID: 109
+          Type: 515 EventRootType Probe[main.testInlinedBCA]
+          InjectionPoints: [{PC: "0xcda313", Frameless: false}]
           Condition: null
     - id: testInlinedBCB
       version: 0
@@ -386,11 +488,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 102}
+      subprogram: {subprogram: 110}
       events:
-        - ID: 102
-          Type: 383 EventRootType Probe[main.testInlinedBCB]
-          InjectionPoints: [{PC: "0xcd997b", Frameless: false}]
+        - ID: 110
+          Type: 516 EventRootType Probe[main.testInlinedBCB]
+          InjectionPoints: [{PC: "0xcda3bb", Frameless: false}]
           Condition: null
     - id: testInlinedPrint
       version: 0
@@ -401,20 +503,20 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 99}
+      subprogram: {subprogram: 107}
       events:
-        - ID: 99
-          Type: 380 EventRootType Probe[main.testInlinedPrint]
+        - ID: 107
+          Type: 513 EventRootType Probe[main.testInlinedPrint]
           InjectionPoints:
-            - PC: "0xcd952a"
+            - PC: "0xcd9f6a"
               Frameless: false
-            - PC: "0xcd95b1"
+            - PC: "0xcd9ff1"
               Frameless: false
-            - PC: "0xcd96f2"
+            - PC: "0xcda132"
               Frameless: false
-            - PC: "0xcd977c"
+            - PC: "0xcda1bc"
               Frameless: false
-            - PC: "0xcd984f"
+            - PC: "0xcda28f"
               Frameless: false
           Condition: null
     - id: testInlinedSq
@@ -425,11 +527,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 103}
+      subprogram: {subprogram: 111}
       events:
-        - ID: 103
-          Type: 384 EventRootType Probe[main.testInlinedSq]
-          InjectionPoints: [{PC: "0xcd99e1", Frameless: true}]
+        - ID: 111
+          Type: 517 EventRootType Probe[main.testInlinedSq]
+          InjectionPoints: [{PC: "0xcda421", Frameless: true}]
           Condition: null
     - id: testInlinedSumArray
       version: 0
@@ -440,14 +542,14 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 104}
+      subprogram: {subprogram: 112}
       events:
-        - ID: 104
-          Type: 385 EventRootType Probe[main.testInlinedSumArray]
+        - ID: 112
+          Type: 518 EventRootType Probe[main.testInlinedSumArray]
           InjectionPoints:
-            - PC: "0xcd9a25"
+            - PC: "0xcda465"
               Frameless: false
-            - PC: "0xcd9ac5"
+            - PC: "0xcda505"
               Frameless: false
           Condition: null
     - id: testInt16Array
@@ -461,8 +563,8 @@ Probes:
       subprogram: {subprogram: 7}
       events:
         - ID: 7
-          Type: 288 EventRootType Probe[main.testInt16Array]
-          InjectionPoints: [{PC: "0xcd8680", Frameless: true}]
+          Type: 413 EventRootType Probe[main.testInt16Array]
+          InjectionPoints: [{PC: "0xcd8ac0", Frameless: true}]
           Condition: null
     - id: testInt32Array
       version: 0
@@ -475,8 +577,8 @@ Probes:
       subprogram: {subprogram: 8}
       events:
         - ID: 8
-          Type: 289 EventRootType Probe[main.testInt32Array]
-          InjectionPoints: [{PC: "0xcd86a0", Frameless: true}]
+          Type: 414 EventRootType Probe[main.testInt32Array]
+          InjectionPoints: [{PC: "0xcd8ae0", Frameless: true}]
           Condition: null
     - id: testInt64Array
       version: 0
@@ -489,8 +591,8 @@ Probes:
       subprogram: {subprogram: 9}
       events:
         - ID: 9
-          Type: 290 EventRootType Probe[main.testInt64Array]
-          InjectionPoints: [{PC: "0xcd86c0", Frameless: true}]
+          Type: 415 EventRootType Probe[main.testInt64Array]
+          InjectionPoints: [{PC: "0xcd8b00", Frameless: true}]
           Condition: null
     - id: testInt8Array
       version: 0
@@ -503,8 +605,8 @@ Probes:
       subprogram: {subprogram: 6}
       events:
         - ID: 6
-          Type: 287 EventRootType Probe[main.testInt8Array]
-          InjectionPoints: [{PC: "0xcd8660", Frameless: true}]
+          Type: 412 EventRootType Probe[main.testInt8Array]
+          InjectionPoints: [{PC: "0xcd8aa0", Frameless: true}]
           Condition: null
     - id: testIntArray
       version: 0
@@ -517,8 +619,8 @@ Probes:
       subprogram: {subprogram: 5}
       events:
         - ID: 5
-          Type: 286 EventRootType Probe[main.testIntArray]
-          InjectionPoints: [{PC: "0xcd8640", Frameless: true}]
+          Type: 411 EventRootType Probe[main.testIntArray]
+          InjectionPoints: [{PC: "0xcd8a80", Frameless: true}]
           Condition: null
     - id: testInterface
       version: 0
@@ -528,11 +630,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 44}
+      subprogram: {subprogram: 52}
       events:
-        - ID: 44
-          Type: 325 EventRootType Probe[main.testInterface]
-          InjectionPoints: [{PC: "0xcd9cea", Frameless: false}]
+        - ID: 52
+          Type: 458 EventRootType Probe[main.testInterface]
+          InjectionPoints: [{PC: "0xcda72a", Frameless: false}]
           Condition: null
     - id: testLinkedList
       version: 0
@@ -542,11 +644,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 71}
+      subprogram: {subprogram: 79}
       events:
-        - ID: 71
-          Type: 352 EventRootType Probe[main.testLinkedList]
-          InjectionPoints: [{PC: "0xcdc100", Frameless: true}]
+        - ID: 79
+          Type: 485 EventRootType Probe[main.testLinkedList]
+          InjectionPoints: [{PC: "0xcdcb40", Frameless: true}]
           Condition: null
     - id: testMapArrayToArray
       version: 0
@@ -556,11 +658,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 51}
+      subprogram: {subprogram: 59}
       events:
-        - ID: 51
-          Type: 332 EventRootType Probe[main.testMapArrayToArray]
-          InjectionPoints: [{PC: "0xcda240", Frameless: true}]
+        - ID: 59
+          Type: 465 EventRootType Probe[main.testMapArrayToArray]
+          InjectionPoints: [{PC: "0xcdac80", Frameless: true}]
           Condition: null
     - id: testMapEmbeddedMaps
       version: 0
@@ -570,11 +672,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 57}
+      subprogram: {subprogram: 65}
       events:
-        - ID: 57
-          Type: 338 EventRootType Probe[main.testMapEmbeddedMaps]
-          InjectionPoints: [{PC: "0xcda300", Frameless: true}]
+        - ID: 65
+          Type: 471 EventRootType Probe[main.testMapEmbeddedMaps]
+          InjectionPoints: [{PC: "0xcdad40", Frameless: true}]
           Condition: null
     - id: testMapIntToInt
       version: 0
@@ -584,11 +686,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 55}
+      subprogram: {subprogram: 63}
       events:
-        - ID: 55
-          Type: 336 EventRootType Probe[main.testMapIntToInt]
-          InjectionPoints: [{PC: "0xcda2c0", Frameless: true}]
+        - ID: 63
+          Type: 469 EventRootType Probe[main.testMapIntToInt]
+          InjectionPoints: [{PC: "0xcdad00", Frameless: true}]
           Condition: null
     - id: testMapLargeKeyLargeValue
       version: 0
@@ -598,11 +700,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 66}
+      subprogram: {subprogram: 74}
       events:
-        - ID: 66
-          Type: 347 EventRootType Probe[main.testMapLargeKeyLargeValue]
-          InjectionPoints: [{PC: "0xcda420", Frameless: true}]
+        - ID: 74
+          Type: 480 EventRootType Probe[main.testMapLargeKeyLargeValue]
+          InjectionPoints: [{PC: "0xcdae60", Frameless: true}]
           Condition: null
     - id: testMapLargeKeySmallValue
       version: 0
@@ -612,11 +714,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 65}
+      subprogram: {subprogram: 73}
       events:
-        - ID: 65
-          Type: 346 EventRootType Probe[main.testMapLargeKeySmallValue]
-          InjectionPoints: [{PC: "0xcda400", Frameless: true}]
+        - ID: 73
+          Type: 479 EventRootType Probe[main.testMapLargeKeySmallValue]
+          InjectionPoints: [{PC: "0xcdae40", Frameless: true}]
           Condition: null
     - id: testMapMassive
       version: 0
@@ -626,11 +728,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 56}
+      subprogram: {subprogram: 64}
       events:
-        - ID: 56
-          Type: 337 EventRootType Probe[main.testMapMassive]
-          InjectionPoints: [{PC: "0xcda2e0", Frameless: true}]
+        - ID: 64
+          Type: 470 EventRootType Probe[main.testMapMassive]
+          InjectionPoints: [{PC: "0xcdad20", Frameless: true}]
           Condition: null
     - id: testMapSmallKeyLargeValue
       version: 0
@@ -640,11 +742,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 64}
+      subprogram: {subprogram: 72}
       events:
-        - ID: 64
-          Type: 345 EventRootType Probe[main.testMapSmallKeyLargeValue]
-          InjectionPoints: [{PC: "0xcda3e0", Frameless: true}]
+        - ID: 72
+          Type: 478 EventRootType Probe[main.testMapSmallKeyLargeValue]
+          InjectionPoints: [{PC: "0xcdae20", Frameless: true}]
           Condition: null
     - id: testMapSmallKeySmallValue
       version: 0
@@ -654,11 +756,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 63}
+      subprogram: {subprogram: 71}
       events:
-        - ID: 63
-          Type: 344 EventRootType Probe[main.testMapSmallKeySmallValue]
-          InjectionPoints: [{PC: "0xcda3c0", Frameless: true}]
+        - ID: 71
+          Type: 477 EventRootType Probe[main.testMapSmallKeySmallValue]
+          InjectionPoints: [{PC: "0xcdae00", Frameless: true}]
           Condition: null
     - id: testMapStringToInt
       version: 0
@@ -668,11 +770,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 49}
+      subprogram: {subprogram: 57}
       events:
-        - ID: 49
-          Type: 330 EventRootType Probe[main.testMapStringToInt]
-          InjectionPoints: [{PC: "0xcda200", Frameless: true}]
+        - ID: 57
+          Type: 463 EventRootType Probe[main.testMapStringToInt]
+          InjectionPoints: [{PC: "0xcdac40", Frameless: true}]
           Condition: null
     - id: testMapStringToSlice
       version: 0
@@ -682,11 +784,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 50}
+      subprogram: {subprogram: 58}
       events:
-        - ID: 50
-          Type: 331 EventRootType Probe[main.testMapStringToSlice]
-          InjectionPoints: [{PC: "0xcda220", Frameless: true}]
+        - ID: 58
+          Type: 464 EventRootType Probe[main.testMapStringToSlice]
+          InjectionPoints: [{PC: "0xcdac60", Frameless: true}]
           Condition: null
     - id: testMapStringToStruct
       version: 0
@@ -696,11 +798,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 48}
+      subprogram: {subprogram: 56}
       events:
-        - ID: 48
-          Type: 329 EventRootType Probe[main.testMapStringToStruct]
-          InjectionPoints: [{PC: "0xcda1e0", Frameless: true}]
+        - ID: 56
+          Type: 462 EventRootType Probe[main.testMapStringToStruct]
+          InjectionPoints: [{PC: "0xcdac20", Frameless: true}]
           Condition: null
     - id: testMapWithLinkedList
       version: 0
@@ -710,11 +812,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 58}
+      subprogram: {subprogram: 66}
       events:
-        - ID: 58
-          Type: 339 EventRootType Probe[main.testMapWithLinkedList]
-          InjectionPoints: [{PC: "0xcda320", Frameless: true}]
+        - ID: 66
+          Type: 472 EventRootType Probe[main.testMapWithLinkedList]
+          InjectionPoints: [{PC: "0xcdad60", Frameless: true}]
           Condition: null
     - id: testMapWithSmallKeyAndValue
       version: 0
@@ -724,11 +826,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 61}
+      subprogram: {subprogram: 69}
       events:
-        - ID: 61
-          Type: 342 EventRootType Probe[main.testMapWithSmallKeyAndValue]
-          InjectionPoints: [{PC: "0xcda380", Frameless: true}]
+        - ID: 69
+          Type: 475 EventRootType Probe[main.testMapWithSmallKeyAndValue]
+          InjectionPoints: [{PC: "0xcdadc0", Frameless: true}]
           Condition: null
     - id: testMapWithSmallKeyAndValueMassive
       version: 0
@@ -738,11 +840,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 62}
+      subprogram: {subprogram: 70}
       events:
-        - ID: 62
-          Type: 343 EventRootType Probe[main.testMapWithSmallKeyAndValueMassive]
-          InjectionPoints: [{PC: "0xcda3a0", Frameless: true}]
+        - ID: 70
+          Type: 476 EventRootType Probe[main.testMapWithSmallKeyAndValueMassive]
+          InjectionPoints: [{PC: "0xcdade0", Frameless: true}]
           Condition: null
     - id: testMapWithSmallValue
       version: 0
@@ -752,11 +854,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 59}
+      subprogram: {subprogram: 67}
       events:
-        - ID: 59
-          Type: 340 EventRootType Probe[main.testMapWithSmallValue]
-          InjectionPoints: [{PC: "0xcda340", Frameless: true}]
+        - ID: 67
+          Type: 473 EventRootType Probe[main.testMapWithSmallValue]
+          InjectionPoints: [{PC: "0xcdad80", Frameless: true}]
           Condition: null
     - id: testMapWithSmallValueMassive
       version: 0
@@ -766,11 +868,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 60}
+      subprogram: {subprogram: 68}
       events:
-        - ID: 60
-          Type: 341 EventRootType Probe[main.testMapWithSmallValueMassive]
-          InjectionPoints: [{PC: "0xcda360", Frameless: true}]
+        - ID: 68
+          Type: 474 EventRootType Probe[main.testMapWithSmallValueMassive]
+          InjectionPoints: [{PC: "0xcdada0", Frameless: true}]
           Condition: null
     - id: testMassiveString
       version: 0
@@ -780,11 +882,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 94}
+      subprogram: {subprogram: 102}
       events:
-        - ID: 94
-          Type: 375 EventRootType Probe[main.testMassiveString]
-          InjectionPoints: [{PC: "0xcdcd60", Frameless: true}]
+        - ID: 102
+          Type: 508 EventRootType Probe[main.testMassiveString]
+          InjectionPoints: [{PC: "0xcdd7a0", Frameless: true}]
           Condition: null
     - id: testMultipleSimpleParams
       version: 0
@@ -794,11 +896,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 68}
+      subprogram: {subprogram: 76}
       events:
-        - ID: 68
-          Type: 349 EventRootType Probe[main.testMultipleSimpleParams]
-          InjectionPoints: [{PC: "0xcdbd20", Frameless: true}]
+        - ID: 76
+          Type: 482 EventRootType Probe[main.testMultipleSimpleParams]
+          InjectionPoints: [{PC: "0xcdc760", Frameless: true}]
           Condition: null
     - id: testNilPointer
       version: 0
@@ -808,11 +910,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 76}
+      subprogram: {subprogram: 84}
       events:
-        - ID: 76
-          Type: 357 EventRootType Probe[main.testNilPointer]
-          InjectionPoints: [{PC: "0xcdc2a0", Frameless: true}]
+        - ID: 84
+          Type: 490 EventRootType Probe[main.testNilPointer]
+          InjectionPoints: [{PC: "0xcdcce0", Frameless: true}]
           Condition: null
     - id: testNilSlice
       version: 0
@@ -822,11 +924,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 86}
+      subprogram: {subprogram: 94}
       events:
-        - ID: 86
-          Type: 367 EventRootType Probe[main.testNilSlice]
-          InjectionPoints: [{PC: "0xcdc900", Frameless: true}]
+        - ID: 94
+          Type: 500 EventRootType Probe[main.testNilSlice]
+          InjectionPoints: [{PC: "0xcdd340", Frameless: true}]
           Condition: null
     - id: testNilSliceOfStructs
       version: 0
@@ -836,11 +938,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 83}
+      subprogram: {subprogram: 91}
       events:
-        - ID: 83
-          Type: 364 EventRootType Probe[main.testNilSliceOfStructs]
-          InjectionPoints: [{PC: "0xcdc8a0", Frameless: true}]
+        - ID: 91
+          Type: 497 EventRootType Probe[main.testNilSliceOfStructs]
+          InjectionPoints: [{PC: "0xcdd2e0", Frameless: true}]
           Condition: null
     - id: testNilSliceWithOtherParams
       version: 0
@@ -850,11 +952,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 85}
+      subprogram: {subprogram: 93}
       events:
-        - ID: 85
-          Type: 366 EventRootType Probe[main.testNilSliceWithOtherParams]
-          InjectionPoints: [{PC: "0xcdc8e0", Frameless: true}]
+        - ID: 93
+          Type: 499 EventRootType Probe[main.testNilSliceWithOtherParams]
+          InjectionPoints: [{PC: "0xcdd320", Frameless: true}]
           Condition: null
     - id: testOneStringInStructPointer
       version: 0
@@ -864,11 +966,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 93}
+      subprogram: {subprogram: 101}
       events:
-        - ID: 93
-          Type: 374 EventRootType Probe[main.testOneStringInStructPointer]
-          InjectionPoints: [{PC: "0xcdcd40", Frameless: true}]
+        - ID: 101
+          Type: 507 EventRootType Probe[main.testOneStringInStructPointer]
+          InjectionPoints: [{PC: "0xcdd780", Frameless: true}]
           Condition: null
     - id: testPointerLoop
       version: 0
@@ -878,11 +980,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 72}
+      subprogram: {subprogram: 80}
       events:
-        - ID: 72
-          Type: 353 EventRootType Probe[main.testPointerLoop]
-          InjectionPoints: [{PC: "0xcdc120", Frameless: true}]
+        - ID: 80
+          Type: 486 EventRootType Probe[main.testPointerLoop]
+          InjectionPoints: [{PC: "0xcdcb60", Frameless: true}]
           Condition: null
     - id: testPointerToMap
       version: 0
@@ -892,11 +994,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 54}
+      subprogram: {subprogram: 62}
       events:
-        - ID: 54
-          Type: 335 EventRootType Probe[main.testPointerToMap]
-          InjectionPoints: [{PC: "0xcda2a0", Frameless: true}]
+        - ID: 62
+          Type: 468 EventRootType Probe[main.testPointerToMap]
+          InjectionPoints: [{PC: "0xcdace0", Frameless: true}]
           Condition: null
     - id: testPointerToSimpleStruct
       version: 0
@@ -906,11 +1008,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 70}
+      subprogram: {subprogram: 78}
       events:
-        - ID: 70
-          Type: 351 EventRootType Probe[main.testPointerToSimpleStruct]
-          InjectionPoints: [{PC: "0xcdc0e0", Frameless: true}]
+        - ID: 78
+          Type: 484 EventRootType Probe[main.testPointerToSimpleStruct]
+          InjectionPoints: [{PC: "0xcdcb20", Frameless: true}]
           Condition: null
     - id: testRuneArray
       version: 0
@@ -923,8 +1025,8 @@ Probes:
       subprogram: {subprogram: 2}
       events:
         - ID: 2
-          Type: 283 EventRootType Probe[main.testRuneArray]
-          InjectionPoints: [{PC: "0xcd85e0", Frameless: true}]
+          Type: 408 EventRootType Probe[main.testRuneArray]
+          InjectionPoints: [{PC: "0xcd8a20", Frameless: true}]
           Condition: null
     - id: testSingleBool
       version: 0
@@ -937,8 +1039,8 @@ Probes:
       subprogram: {subprogram: 21}
       events:
         - ID: 21
-          Type: 302 EventRootType Probe[main.testSingleBool]
-          InjectionPoints: [{PC: "0xcd8be0", Frameless: true}]
+          Type: 427 EventRootType Probe[main.testSingleBool]
+          InjectionPoints: [{PC: "0xcd9020", Frameless: true}]
           Condition: null
     - id: testSingleByte
       version: 0
@@ -951,8 +1053,8 @@ Probes:
       subprogram: {subprogram: 19}
       events:
         - ID: 19
-          Type: 300 EventRootType Probe[main.testSingleByte]
-          InjectionPoints: [{PC: "0xcd8ba0", Frameless: true}]
+          Type: 425 EventRootType Probe[main.testSingleByte]
+          InjectionPoints: [{PC: "0xcd8fe0", Frameless: true}]
           Condition: null
     - id: testSingleFloat32
       version: 0
@@ -965,8 +1067,8 @@ Probes:
       subprogram: {subprogram: 32}
       events:
         - ID: 32
-          Type: 313 EventRootType Probe[main.testSingleFloat32]
-          InjectionPoints: [{PC: "0xcd8d40", Frameless: true}]
+          Type: 438 EventRootType Probe[main.testSingleFloat32]
+          InjectionPoints: [{PC: "0xcd9180", Frameless: true}]
           Condition: null
     - id: testSingleFloat64
       version: 0
@@ -979,8 +1081,8 @@ Probes:
       subprogram: {subprogram: 33}
       events:
         - ID: 33
-          Type: 314 EventRootType Probe[main.testSingleFloat64]
-          InjectionPoints: [{PC: "0xcd8d60", Frameless: true}]
+          Type: 439 EventRootType Probe[main.testSingleFloat64]
+          InjectionPoints: [{PC: "0xcd91a0", Frameless: true}]
           Condition: null
     - id: testSingleInt
       version: 0
@@ -993,8 +1095,8 @@ Probes:
       subprogram: {subprogram: 22}
       events:
         - ID: 22
-          Type: 303 EventRootType Probe[main.testSingleInt]
-          InjectionPoints: [{PC: "0xcd8c00", Frameless: true}]
+          Type: 428 EventRootType Probe[main.testSingleInt]
+          InjectionPoints: [{PC: "0xcd9040", Frameless: true}]
           Condition: null
     - id: testSingleInt16
       version: 0
@@ -1007,8 +1109,8 @@ Probes:
       subprogram: {subprogram: 24}
       events:
         - ID: 24
-          Type: 305 EventRootType Probe[main.testSingleInt16]
-          InjectionPoints: [{PC: "0xcd8c40", Frameless: true}]
+          Type: 430 EventRootType Probe[main.testSingleInt16]
+          InjectionPoints: [{PC: "0xcd9080", Frameless: true}]
           Condition: null
     - id: testSingleInt32
       version: 0
@@ -1021,8 +1123,8 @@ Probes:
       subprogram: {subprogram: 25}
       events:
         - ID: 25
-          Type: 306 EventRootType Probe[main.testSingleInt32]
-          InjectionPoints: [{PC: "0xcd8c60", Frameless: true}]
+          Type: 431 EventRootType Probe[main.testSingleInt32]
+          InjectionPoints: [{PC: "0xcd90a0", Frameless: true}]
           Condition: null
     - id: testSingleInt64
       version: 0
@@ -1035,8 +1137,8 @@ Probes:
       subprogram: {subprogram: 26}
       events:
         - ID: 26
-          Type: 307 EventRootType Probe[main.testSingleInt64]
-          InjectionPoints: [{PC: "0xcd8c80", Frameless: true}]
+          Type: 432 EventRootType Probe[main.testSingleInt64]
+          InjectionPoints: [{PC: "0xcd90c0", Frameless: true}]
           Condition: null
     - id: testSingleInt8
       version: 0
@@ -1049,8 +1151,8 @@ Probes:
       subprogram: {subprogram: 23}
       events:
         - ID: 23
-          Type: 304 EventRootType Probe[main.testSingleInt8]
-          InjectionPoints: [{PC: "0xcd8c20", Frameless: true}]
+          Type: 429 EventRootType Probe[main.testSingleInt8]
+          InjectionPoints: [{PC: "0xcd9060", Frameless: true}]
           Condition: null
     - id: testSingleRune
       version: 0
@@ -1063,8 +1165,8 @@ Probes:
       subprogram: {subprogram: 20}
       events:
         - ID: 20
-          Type: 301 EventRootType Probe[main.testSingleRune]
-          InjectionPoints: [{PC: "0xcd8bc0", Frameless: true}]
+          Type: 426 EventRootType Probe[main.testSingleRune]
+          InjectionPoints: [{PC: "0xcd9000", Frameless: true}]
           Condition: null
     - id: testSingleString
       version: 0
@@ -1074,11 +1176,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 89}
+      subprogram: {subprogram: 97}
       events:
-        - ID: 89
-          Type: 370 EventRootType Probe[main.testSingleString]
-          InjectionPoints: [{PC: "0xcdccc0", Frameless: true}]
+        - ID: 97
+          Type: 503 EventRootType Probe[main.testSingleString]
+          InjectionPoints: [{PC: "0xcdd700", Frameless: true}]
           Condition: null
     - id: testSingleUint
       version: 0
@@ -1091,8 +1193,8 @@ Probes:
       subprogram: {subprogram: 27}
       events:
         - ID: 27
-          Type: 308 EventRootType Probe[main.testSingleUint]
-          InjectionPoints: [{PC: "0xcd8ca0", Frameless: true}]
+          Type: 433 EventRootType Probe[main.testSingleUint]
+          InjectionPoints: [{PC: "0xcd90e0", Frameless: true}]
           Condition: null
     - id: testSingleUint16
       version: 0
@@ -1105,8 +1207,8 @@ Probes:
       subprogram: {subprogram: 29}
       events:
         - ID: 29
-          Type: 310 EventRootType Probe[main.testSingleUint16]
-          InjectionPoints: [{PC: "0xcd8ce0", Frameless: true}]
+          Type: 435 EventRootType Probe[main.testSingleUint16]
+          InjectionPoints: [{PC: "0xcd9120", Frameless: true}]
           Condition: null
     - id: testSingleUint32
       version: 0
@@ -1119,8 +1221,8 @@ Probes:
       subprogram: {subprogram: 30}
       events:
         - ID: 30
-          Type: 311 EventRootType Probe[main.testSingleUint32]
-          InjectionPoints: [{PC: "0xcd8d00", Frameless: true}]
+          Type: 436 EventRootType Probe[main.testSingleUint32]
+          InjectionPoints: [{PC: "0xcd9140", Frameless: true}]
           Condition: null
     - id: testSingleUint64
       version: 0
@@ -1133,8 +1235,8 @@ Probes:
       subprogram: {subprogram: 31}
       events:
         - ID: 31
-          Type: 312 EventRootType Probe[main.testSingleUint64]
-          InjectionPoints: [{PC: "0xcd8d20", Frameless: true}]
+          Type: 437 EventRootType Probe[main.testSingleUint64]
+          InjectionPoints: [{PC: "0xcd9160", Frameless: true}]
           Condition: null
     - id: testSingleUint8
       version: 0
@@ -1147,8 +1249,8 @@ Probes:
       subprogram: {subprogram: 28}
       events:
         - ID: 28
-          Type: 309 EventRootType Probe[main.testSingleUint8]
-          InjectionPoints: [{PC: "0xcd8cc0", Frameless: true}]
+          Type: 434 EventRootType Probe[main.testSingleUint8]
+          InjectionPoints: [{PC: "0xcd9100", Frameless: true}]
           Condition: null
     - id: testSliceOfSlices
       version: 0
@@ -1158,11 +1260,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 80}
+      subprogram: {subprogram: 88}
       events:
-        - ID: 80
-          Type: 361 EventRootType Probe[main.testSliceOfSlices]
-          InjectionPoints: [{PC: "0xcdc840", Frameless: true}]
+        - ID: 88
+          Type: 494 EventRootType Probe[main.testSliceOfSlices]
+          InjectionPoints: [{PC: "0xcdd280", Frameless: true}]
           Condition: null
     - id: testSmallMap
       version: 0
@@ -1172,11 +1274,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 52}
+      subprogram: {subprogram: 60}
       events:
-        - ID: 52
-          Type: 333 EventRootType Probe[main.testSmallMap]
-          InjectionPoints: [{PC: "0xcda260", Frameless: true}]
+        - ID: 60
+          Type: 466 EventRootType Probe[main.testSmallMap]
+          InjectionPoints: [{PC: "0xcdaca0", Frameless: true}]
           Condition: null
     - id: testStringArray
       version: 0
@@ -1189,8 +1291,8 @@ Probes:
       subprogram: {subprogram: 3}
       events:
         - ID: 3
-          Type: 284 EventRootType Probe[main.testStringArray]
-          InjectionPoints: [{PC: "0xcd8600", Frameless: true}]
+          Type: 409 EventRootType Probe[main.testStringArray]
+          InjectionPoints: [{PC: "0xcd8a40", Frameless: true}]
           Condition: null
     - id: testStringPointer
       version: 0
@@ -1200,11 +1302,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 75}
+      subprogram: {subprogram: 83}
       events:
-        - ID: 75
-          Type: 356 EventRootType Probe[main.testStringPointer]
-          InjectionPoints: [{PC: "0xcdc260", Frameless: true}]
+        - ID: 83
+          Type: 489 EventRootType Probe[main.testStringPointer]
+          InjectionPoints: [{PC: "0xcdcca0", Frameless: true}]
           Condition: null
     - id: testStringSlice
       version: 0
@@ -1214,11 +1316,45 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 84}
+      subprogram: {subprogram: 92}
       events:
-        - ID: 84
-          Type: 365 EventRootType Probe[main.testStringSlice]
-          InjectionPoints: [{PC: "0xcdc8c0", Frameless: true}]
+        - ID: 92
+          Type: 498 EventRootType Probe[main.testStringSlice]
+          InjectionPoints: [{PC: "0xcdd300", Frameless: true}]
+          Condition: null
+    - id: testStringType1
+      version: 0
+      type: LOG_PROBE
+      where: {methodName: main.testStringType1}
+      capture:
+        maxReferenceDepth: 1
+        maxFieldCount: 0
+        maxCollectionSize: 0
+      template: ""
+      segments: []
+      captureSnapshot: true
+      subprogram: {subprogram: 42}
+      events:
+        - ID: 42
+          Type: 448 EventRootType Probe[main.testStringType1]
+          InjectionPoints: [{PC: "0xcd9740", Frameless: true}]
+          Condition: null
+    - id: testStringType2
+      version: 0
+      type: LOG_PROBE
+      where: {methodName: main.testStringType2}
+      capture:
+        maxReferenceDepth: 1
+        maxFieldCount: 0
+        maxCollectionSize: 0
+      template: ""
+      segments: []
+      captureSnapshot: true
+      subprogram: {subprogram: 43}
+      events:
+        - ID: 43
+          Type: 449 EventRootType Probe[main.testStringType2]
+          InjectionPoints: [{PC: "0xcd9760", Frameless: true}]
           Condition: null
     - id: testStruct
       version: 0
@@ -1228,11 +1364,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 97}
+      subprogram: {subprogram: 105}
       events:
-        - ID: 97
-          Type: 378 EventRootType Probe[main.testStruct]
-          InjectionPoints: [{PC: "0xcdd020", Frameless: true}]
+        - ID: 105
+          Type: 511 EventRootType Probe[main.testStruct]
+          InjectionPoints: [{PC: "0xcdda60", Frameless: true}]
           Condition: null
     - id: testStructSlice
       version: 0
@@ -1242,11 +1378,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 81}
+      subprogram: {subprogram: 89}
       events:
-        - ID: 81
-          Type: 362 EventRootType Probe[main.testStructSlice]
-          InjectionPoints: [{PC: "0xcdc860", Frameless: true}]
+        - ID: 89
+          Type: 495 EventRootType Probe[main.testStructSlice]
+          InjectionPoints: [{PC: "0xcdd2a0", Frameless: true}]
           Condition: null
     - id: testStructWithMap
       version: 0
@@ -1256,11 +1392,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 47}
+      subprogram: {subprogram: 55}
       events:
-        - ID: 47
-          Type: 328 EventRootType Probe[main.testStructWithMap]
-          InjectionPoints: [{PC: "0xcda1c0", Frameless: true}]
+        - ID: 55
+          Type: 461 EventRootType Probe[main.testStructWithMap]
+          InjectionPoints: [{PC: "0xcdac00", Frameless: true}]
           Condition: null
     - id: testThreeStrings
       version: 0
@@ -1270,11 +1406,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 90}
+      subprogram: {subprogram: 98}
       events:
-        - ID: 90
-          Type: 371 EventRootType Probe[main.testThreeStrings]
-          InjectionPoints: [{PC: "0xcdcce0", Frameless: true}]
+        - ID: 98
+          Type: 504 EventRootType Probe[main.testThreeStrings]
+          InjectionPoints: [{PC: "0xcdd720", Frameless: true}]
           Condition: null
     - id: testThreeStringsInStruct
       version: 0
@@ -1284,11 +1420,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 91}
+      subprogram: {subprogram: 99}
       events:
-        - ID: 91
-          Type: 372 EventRootType Probe[main.testThreeStringsInStruct]
-          InjectionPoints: [{PC: "0xcdcd00", Frameless: true}]
+        - ID: 99
+          Type: 505 EventRootType Probe[main.testThreeStringsInStruct]
+          InjectionPoints: [{PC: "0xcdd740", Frameless: true}]
           Condition: null
     - id: testThreeStringsInStructPointer
       version: 0
@@ -1298,11 +1434,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 92}
+      subprogram: {subprogram: 100}
       events:
-        - ID: 92
-          Type: 373 EventRootType Probe[main.testThreeStringsInStructPointer]
-          InjectionPoints: [{PC: "0xcdcd20", Frameless: true}]
+        - ID: 100
+          Type: 506 EventRootType Probe[main.testThreeStringsInStructPointer]
+          InjectionPoints: [{PC: "0xcdd760", Frameless: true}]
           Condition: null
     - id: testTypeAlias
       version: 0
@@ -1315,8 +1451,8 @@ Probes:
       subprogram: {subprogram: 34}
       events:
         - ID: 34
-          Type: 315 EventRootType Probe[main.testTypeAlias]
-          InjectionPoints: [{PC: "0xcd8d80", Frameless: true}]
+          Type: 440 EventRootType Probe[main.testTypeAlias]
+          InjectionPoints: [{PC: "0xcd91c0", Frameless: true}]
           Condition: null
     - id: testUint16Array
       version: 0
@@ -1329,8 +1465,8 @@ Probes:
       subprogram: {subprogram: 12}
       events:
         - ID: 12
-          Type: 293 EventRootType Probe[main.testUint16Array]
-          InjectionPoints: [{PC: "0xcd8720", Frameless: true}]
+          Type: 418 EventRootType Probe[main.testUint16Array]
+          InjectionPoints: [{PC: "0xcd8b60", Frameless: true}]
           Condition: null
     - id: testUint32Array
       version: 0
@@ -1343,8 +1479,8 @@ Probes:
       subprogram: {subprogram: 13}
       events:
         - ID: 13
-          Type: 294 EventRootType Probe[main.testUint32Array]
-          InjectionPoints: [{PC: "0xcd8740", Frameless: true}]
+          Type: 419 EventRootType Probe[main.testUint32Array]
+          InjectionPoints: [{PC: "0xcd8b80", Frameless: true}]
           Condition: null
     - id: testUint64Array
       version: 0
@@ -1357,8 +1493,8 @@ Probes:
       subprogram: {subprogram: 14}
       events:
         - ID: 14
-          Type: 295 EventRootType Probe[main.testUint64Array]
-          InjectionPoints: [{PC: "0xcd8760", Frameless: true}]
+          Type: 420 EventRootType Probe[main.testUint64Array]
+          InjectionPoints: [{PC: "0xcd8ba0", Frameless: true}]
           Condition: null
     - id: testUint8Array
       version: 0
@@ -1371,8 +1507,8 @@ Probes:
       subprogram: {subprogram: 11}
       events:
         - ID: 11
-          Type: 292 EventRootType Probe[main.testUint8Array]
-          InjectionPoints: [{PC: "0xcd8700", Frameless: true}]
+          Type: 417 EventRootType Probe[main.testUint8Array]
+          InjectionPoints: [{PC: "0xcd8b40", Frameless: true}]
           Condition: null
     - id: testUintArray
       version: 0
@@ -1385,8 +1521,8 @@ Probes:
       subprogram: {subprogram: 10}
       events:
         - ID: 10
-          Type: 291 EventRootType Probe[main.testUintArray]
-          InjectionPoints: [{PC: "0xcd86e0", Frameless: true}]
+          Type: 416 EventRootType Probe[main.testUintArray]
+          InjectionPoints: [{PC: "0xcd8b20", Frameless: true}]
           Condition: null
     - id: testUintPointer
       version: 0
@@ -1396,11 +1532,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 74}
+      subprogram: {subprogram: 82}
       events:
-        - ID: 74
-          Type: 355 EventRootType Probe[main.testUintPointer]
-          InjectionPoints: [{PC: "0xcdc180", Frameless: true}]
+        - ID: 82
+          Type: 488 EventRootType Probe[main.testUintPointer]
+          InjectionPoints: [{PC: "0xcdcbc0", Frameless: true}]
           Condition: null
     - id: testUintSlice
       version: 0
@@ -1410,11 +1546,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 78}
+      subprogram: {subprogram: 86}
       events:
-        - ID: 78
-          Type: 359 EventRootType Probe[main.testUintSlice]
-          InjectionPoints: [{PC: "0xcdc800", Frameless: true}]
+        - ID: 86
+          Type: 492 EventRootType Probe[main.testUintSlice]
+          InjectionPoints: [{PC: "0xcdd240", Frameless: true}]
           Condition: null
     - id: testUnitializedString
       version: 0
@@ -1424,11 +1560,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 95}
+      subprogram: {subprogram: 103}
       events:
-        - ID: 95
-          Type: 376 EventRootType Probe[main.testUnitializedString]
-          InjectionPoints: [{PC: "0xcdcd80", Frameless: true}]
+        - ID: 103
+          Type: 509 EventRootType Probe[main.testUnitializedString]
+          InjectionPoints: [{PC: "0xcdd7c0", Frameless: true}]
           Condition: null
     - id: testUnsafePointer
       version: 0
@@ -1438,11 +1574,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 73}
+      subprogram: {subprogram: 81}
       events:
-        - ID: 73
-          Type: 354 EventRootType Probe[main.testUnsafePointer]
-          InjectionPoints: [{PC: "0xcdc140", Frameless: true}]
+        - ID: 81
+          Type: 487 EventRootType Probe[main.testUnsafePointer]
+          InjectionPoints: [{PC: "0xcdcb80", Frameless: true}]
           Condition: null
     - id: testVeryLargeArray
       version: 0
@@ -1455,8 +1591,8 @@ Probes:
       subprogram: {subprogram: 18}
       events:
         - ID: 18
-          Type: 299 EventRootType Probe[main.testVeryLargeArray]
-          InjectionPoints: [{PC: "0xcd8820", Frameless: true}]
+          Type: 424 EventRootType Probe[main.testVeryLargeArray]
+          InjectionPoints: [{PC: "0xcd8c60", Frameless: true}]
           Condition: null
     - id: testVeryLargeSlice
       version: 0
@@ -1466,430 +1602,430 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 87}
+      subprogram: {subprogram: 95}
       events:
-        - ID: 87
-          Type: 368 EventRootType Probe[main.testVeryLargeSlice]
-          InjectionPoints: [{PC: "0xcdc920", Frameless: true}]
+        - ID: 95
+          Type: 501 EventRootType Probe[main.testVeryLargeSlice]
+          InjectionPoints: [{PC: "0xcdd360", Frameless: true}]
           Condition: null
 Subprograms:
     - ID: 1
       Name: main.testByteArray
-      OutOfLinePCRanges: [0xcd85c0..0xcd85c1]
+      OutOfLinePCRanges: [0xcd8a00..0xcd8a01]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 36 ArrayType [2]uint8
           Locations:
-            - Range: 0xcd85c0..0xcd85c1
+            - Range: 0xcd8a00..0xcd8a01
               Pieces: [{Size: 2, Op: {CfaOffset: 0}}]
           IsParameter: true
           IsReturn: false
     - ID: 2
       Name: main.testRuneArray
-      OutOfLinePCRanges: [0xcd85e0..0xcd85e1]
+      OutOfLinePCRanges: [0xcd8a20..0xcd8a21]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 37 ArrayType [2]int32
           Locations:
-            - Range: 0xcd85e0..0xcd85e1
+            - Range: 0xcd8a20..0xcd8a21
               Pieces: [{Size: 8, Op: {CfaOffset: 0}}]
           IsParameter: true
           IsReturn: false
     - ID: 3
       Name: main.testStringArray
-      OutOfLinePCRanges: [0xcd8600..0xcd8601]
+      OutOfLinePCRanges: [0xcd8a40..0xcd8a41]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 38 ArrayType [2]string
           Locations:
-            - Range: 0xcd8600..0xcd8601
+            - Range: 0xcd8a40..0xcd8a41
               Pieces: [{Size: 32, Op: {CfaOffset: 0}}]
           IsParameter: true
           IsReturn: false
     - ID: 4
       Name: main.testBoolArray
-      OutOfLinePCRanges: [0xcd8620..0xcd8621]
+      OutOfLinePCRanges: [0xcd8a60..0xcd8a61]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 39 ArrayType [2]bool
           Locations:
-            - Range: 0xcd8620..0xcd8621
+            - Range: 0xcd8a60..0xcd8a61
               Pieces: [{Size: 2, Op: {CfaOffset: 0}}]
           IsParameter: true
           IsReturn: false
     - ID: 5
       Name: main.testIntArray
-      OutOfLinePCRanges: [0xcd8640..0xcd8641]
+      OutOfLinePCRanges: [0xcd8a80..0xcd8a81]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 40 ArrayType [2]int
           Locations:
-            - Range: 0xcd8640..0xcd8641
+            - Range: 0xcd8a80..0xcd8a81
               Pieces: [{Size: 16, Op: {CfaOffset: 0}}]
           IsParameter: true
           IsReturn: false
     - ID: 6
       Name: main.testInt8Array
-      OutOfLinePCRanges: [0xcd8660..0xcd8661]
+      OutOfLinePCRanges: [0xcd8aa0..0xcd8aa1]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 41 ArrayType [2]int8
           Locations:
-            - Range: 0xcd8660..0xcd8661
+            - Range: 0xcd8aa0..0xcd8aa1
               Pieces: [{Size: 2, Op: {CfaOffset: 0}}]
           IsParameter: true
           IsReturn: false
     - ID: 7
       Name: main.testInt16Array
-      OutOfLinePCRanges: [0xcd8680..0xcd8681]
+      OutOfLinePCRanges: [0xcd8ac0..0xcd8ac1]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 42 ArrayType [2]int16
           Locations:
-            - Range: 0xcd8680..0xcd8681
+            - Range: 0xcd8ac0..0xcd8ac1
               Pieces: [{Size: 4, Op: {CfaOffset: 0}}]
           IsParameter: true
           IsReturn: false
     - ID: 8
       Name: main.testInt32Array
-      OutOfLinePCRanges: [0xcd86a0..0xcd86a1]
+      OutOfLinePCRanges: [0xcd8ae0..0xcd8ae1]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 37 ArrayType [2]int32
           Locations:
-            - Range: 0xcd86a0..0xcd86a1
+            - Range: 0xcd8ae0..0xcd8ae1
               Pieces: [{Size: 8, Op: {CfaOffset: 0}}]
           IsParameter: true
           IsReturn: false
     - ID: 9
       Name: main.testInt64Array
-      OutOfLinePCRanges: [0xcd86c0..0xcd86c1]
+      OutOfLinePCRanges: [0xcd8b00..0xcd8b01]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 43 ArrayType [2]int64
           Locations:
-            - Range: 0xcd86c0..0xcd86c1
+            - Range: 0xcd8b00..0xcd8b01
               Pieces: [{Size: 16, Op: {CfaOffset: 0}}]
           IsParameter: true
           IsReturn: false
     - ID: 10
       Name: main.testUintArray
-      OutOfLinePCRanges: [0xcd86e0..0xcd86e1]
+      OutOfLinePCRanges: [0xcd8b20..0xcd8b21]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 44 ArrayType [2]uint
           Locations:
-            - Range: 0xcd86e0..0xcd86e1
+            - Range: 0xcd8b20..0xcd8b21
               Pieces: [{Size: 16, Op: {CfaOffset: 0}}]
           IsParameter: true
           IsReturn: false
     - ID: 11
       Name: main.testUint8Array
-      OutOfLinePCRanges: [0xcd8700..0xcd8701]
+      OutOfLinePCRanges: [0xcd8b40..0xcd8b41]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 36 ArrayType [2]uint8
           Locations:
-            - Range: 0xcd8700..0xcd8701
+            - Range: 0xcd8b40..0xcd8b41
               Pieces: [{Size: 2, Op: {CfaOffset: 0}}]
           IsParameter: true
           IsReturn: false
     - ID: 12
       Name: main.testUint16Array
-      OutOfLinePCRanges: [0xcd8720..0xcd8721]
+      OutOfLinePCRanges: [0xcd8b60..0xcd8b61]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 45 ArrayType [2]uint16
           Locations:
-            - Range: 0xcd8720..0xcd8721
+            - Range: 0xcd8b60..0xcd8b61
               Pieces: [{Size: 4, Op: {CfaOffset: 0}}]
           IsParameter: true
           IsReturn: false
     - ID: 13
       Name: main.testUint32Array
-      OutOfLinePCRanges: [0xcd8740..0xcd8741]
+      OutOfLinePCRanges: [0xcd8b80..0xcd8b81]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 46 ArrayType [2]uint32
           Locations:
-            - Range: 0xcd8740..0xcd8741
+            - Range: 0xcd8b80..0xcd8b81
               Pieces: [{Size: 8, Op: {CfaOffset: 0}}]
           IsParameter: true
           IsReturn: false
     - ID: 14
       Name: main.testUint64Array
-      OutOfLinePCRanges: [0xcd8760..0xcd8761]
+      OutOfLinePCRanges: [0xcd8ba0..0xcd8ba1]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 47 ArrayType [2]uint64
           Locations:
-            - Range: 0xcd8760..0xcd8761
+            - Range: 0xcd8ba0..0xcd8ba1
               Pieces: [{Size: 16, Op: {CfaOffset: 0}}]
           IsParameter: true
           IsReturn: false
     - ID: 15
       Name: main.testArrayOfArrays
-      OutOfLinePCRanges: [0xcd8780..0xcd8781]
+      OutOfLinePCRanges: [0xcd8bc0..0xcd8bc1]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 48 ArrayType [2][2]int
           Locations:
-            - Range: 0xcd8780..0xcd8781
+            - Range: 0xcd8bc0..0xcd8bc1
               Pieces: [{Size: 32, Op: {CfaOffset: 0}}]
           IsParameter: true
           IsReturn: false
     - ID: 16
       Name: main.testArrayOfStrings
-      OutOfLinePCRanges: [0xcd87a0..0xcd87a1]
+      OutOfLinePCRanges: [0xcd8be0..0xcd8be1]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 38 ArrayType [2]string
           Locations:
-            - Range: 0xcd87a0..0xcd87a1
+            - Range: 0xcd8be0..0xcd8be1
               Pieces: [{Size: 32, Op: {CfaOffset: 0}}]
           IsParameter: true
           IsReturn: false
     - ID: 17
       Name: main.testArrayOfArraysOfArrays
-      OutOfLinePCRanges: [0xcd87c0..0xcd87c1]
+      OutOfLinePCRanges: [0xcd8c00..0xcd8c01]
       InlinePCRanges: []
       Variables:
         - Name: b
           Type: 49 ArrayType [2][2][2]int
           Locations:
-            - Range: 0xcd87c0..0xcd87c1
+            - Range: 0xcd8c00..0xcd8c01
               Pieces: [{Size: 64, Op: {CfaOffset: 0}}]
           IsParameter: true
           IsReturn: false
     - ID: 18
       Name: main.testVeryLargeArray
-      OutOfLinePCRanges: [0xcd8820..0xcd8821]
+      OutOfLinePCRanges: [0xcd8c60..0xcd8c61]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 50 ArrayType [100]uint
           Locations:
-            - Range: 0xcd8820..0xcd8821
+            - Range: 0xcd8c60..0xcd8c61
               Pieces: [{Size: 800, Op: {CfaOffset: 0}}]
           IsParameter: true
           IsReturn: false
     - ID: 19
       Name: main.testSingleByte
-      OutOfLinePCRanges: [0xcd8ba0..0xcd8ba1]
+      OutOfLinePCRanges: [0xcd8fe0..0xcd8fe1]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 3 BaseType uint8
           Locations:
-            - Range: 0xcd8ba0..0xcd8ba1
+            - Range: 0xcd8fe0..0xcd8fe1
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
     - ID: 20
       Name: main.testSingleRune
-      OutOfLinePCRanges: [0xcd8bc0..0xcd8bc1]
+      OutOfLinePCRanges: [0xcd9000..0xcd9001]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 10 BaseType int32
           Locations:
-            - Range: 0xcd8bc0..0xcd8bc1
+            - Range: 0xcd9000..0xcd9001
               Pieces: [{Size: 4, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
     - ID: 21
       Name: main.testSingleBool
-      OutOfLinePCRanges: [0xcd8be0..0xcd8be1]
+      OutOfLinePCRanges: [0xcd9020..0xcd9021]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 4 BaseType bool
           Locations:
-            - Range: 0xcd8be0..0xcd8be1
+            - Range: 0xcd9020..0xcd9021
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
     - ID: 22
       Name: main.testSingleInt
-      OutOfLinePCRanges: [0xcd8c00..0xcd8c01]
+      OutOfLinePCRanges: [0xcd9040..0xcd9041]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 7 BaseType int
           Locations:
-            - Range: 0xcd8c00..0xcd8c01
+            - Range: 0xcd9040..0xcd9041
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
     - ID: 23
       Name: main.testSingleInt8
-      OutOfLinePCRanges: [0xcd8c20..0xcd8c21]
+      OutOfLinePCRanges: [0xcd9060..0xcd9061]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 16 BaseType int8
           Locations:
-            - Range: 0xcd8c20..0xcd8c21
+            - Range: 0xcd9060..0xcd9061
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
     - ID: 24
       Name: main.testSingleInt16
-      OutOfLinePCRanges: [0xcd8c40..0xcd8c41]
+      OutOfLinePCRanges: [0xcd9080..0xcd9081]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 31 BaseType int16
           Locations:
-            - Range: 0xcd8c40..0xcd8c41
+            - Range: 0xcd9080..0xcd9081
               Pieces: [{Size: 2, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
     - ID: 25
       Name: main.testSingleInt32
-      OutOfLinePCRanges: [0xcd8c60..0xcd8c61]
+      OutOfLinePCRanges: [0xcd90a0..0xcd90a1]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 10 BaseType int32
           Locations:
-            - Range: 0xcd8c60..0xcd8c61
+            - Range: 0xcd90a0..0xcd90a1
               Pieces: [{Size: 4, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
     - ID: 26
       Name: main.testSingleInt64
-      OutOfLinePCRanges: [0xcd8c80..0xcd8c81]
+      OutOfLinePCRanges: [0xcd90c0..0xcd90c1]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 12 BaseType int64
           Locations:
-            - Range: 0xcd8c80..0xcd8c81
+            - Range: 0xcd90c0..0xcd90c1
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
     - ID: 27
       Name: main.testSingleUint
-      OutOfLinePCRanges: [0xcd8ca0..0xcd8ca1]
+      OutOfLinePCRanges: [0xcd90e0..0xcd90e1]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 17 BaseType uint
           Locations:
-            - Range: 0xcd8ca0..0xcd8ca1
+            - Range: 0xcd90e0..0xcd90e1
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
     - ID: 28
       Name: main.testSingleUint8
-      OutOfLinePCRanges: [0xcd8cc0..0xcd8cc1]
+      OutOfLinePCRanges: [0xcd9100..0xcd9101]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 3 BaseType uint8
           Locations:
-            - Range: 0xcd8cc0..0xcd8cc1
+            - Range: 0xcd9100..0xcd9101
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
     - ID: 29
       Name: main.testSingleUint16
-      OutOfLinePCRanges: [0xcd8ce0..0xcd8ce1]
+      OutOfLinePCRanges: [0xcd9120..0xcd9121]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 6 BaseType uint16
           Locations:
-            - Range: 0xcd8ce0..0xcd8ce1
+            - Range: 0xcd9120..0xcd9121
               Pieces: [{Size: 2, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
     - ID: 30
       Name: main.testSingleUint32
-      OutOfLinePCRanges: [0xcd8d00..0xcd8d01]
+      OutOfLinePCRanges: [0xcd9140..0xcd9141]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 2 BaseType uint32
           Locations:
-            - Range: 0xcd8d00..0xcd8d01
+            - Range: 0xcd9140..0xcd9141
               Pieces: [{Size: 4, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
     - ID: 31
       Name: main.testSingleUint64
-      OutOfLinePCRanges: [0xcd8d20..0xcd8d21]
+      OutOfLinePCRanges: [0xcd9160..0xcd9161]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 8 BaseType uint64
           Locations:
-            - Range: 0xcd8d20..0xcd8d21
+            - Range: 0xcd9160..0xcd9161
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
     - ID: 32
       Name: main.testSingleFloat32
-      OutOfLinePCRanges: [0xcd8d40..0xcd8d41]
+      OutOfLinePCRanges: [0xcd9180..0xcd9181]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 18 BaseType float32
           Locations:
-            - Range: 0xcd8d40..0xcd8d41
+            - Range: 0xcd9180..0xcd9181
               Pieces: [{Size: 4, Op: {RegNo: 17, Shift: 0}}]
           IsParameter: true
           IsReturn: false
     - ID: 33
       Name: main.testSingleFloat64
-      OutOfLinePCRanges: [0xcd8d60..0xcd8d61]
+      OutOfLinePCRanges: [0xcd91a0..0xcd91a1]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 15 BaseType float64
           Locations:
-            - Range: 0xcd8d60..0xcd8d61
+            - Range: 0xcd91a0..0xcd91a1
               Pieces: [{Size: 8, Op: {RegNo: 17, Shift: 0}}]
           IsParameter: true
           IsReturn: false
     - ID: 34
       Name: main.testTypeAlias
-      OutOfLinePCRanges: [0xcd8d80..0xcd8d81]
+      OutOfLinePCRanges: [0xcd91c0..0xcd91c1]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 51 BaseType main.typeAlias
           Locations:
-            - Range: 0xcd8d80..0xcd8d81
+            - Range: 0xcd91c0..0xcd91c1
               Pieces: [{Size: 2, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
     - ID: 35
       Name: main.testBigStruct
-      OutOfLinePCRanges: [0xcd8ee0..0xcd8eff]
+      OutOfLinePCRanges: [0xcd9320..0xcd933f]
       InlinePCRanges: []
       Variables:
         - Name: b
           Type: 52 StructureType main.bigStruct
           Locations:
-            - Range: 0xcd8ee0..0xcd8eff
+            - Range: 0xcd9320..0xcd933f
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -1906,14 +2042,116 @@ Subprograms:
           IsParameter: true
           IsReturn: false
     - ID: 36
+      Name: main.testDeepPtr1
+      OutOfLinePCRanges: [0xcd93e0..0xcd93e1]
+      InlinePCRanges: []
+      Variables:
+        - Name: a
+          Type: 56 StructureType main.deepPtr1
+          Locations:
+            - Range: 0xcd93e0..0xcd93e1
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+          IsParameter: true
+          IsReturn: false
+    - ID: 37
+      Name: main.testDeepPtr7
+      OutOfLinePCRanges: [0xcd9400..0xcd9401]
+      InlinePCRanges: []
+      Variables:
+        - Name: a
+          Type: 59 PointerType *main.deepPtr7
+          Locations:
+            - Range: 0xcd9400..0xcd9401
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+          IsParameter: true
+          IsReturn: false
+    - ID: 38
+      Name: main.testDeepSlice1
+      OutOfLinePCRanges: [0xcd9580..0xcd9581]
+      InlinePCRanges: []
+      Variables:
+        - Name: a
+          Type: 61 StructureType main.deepSlice1
+          Locations:
+            - Range: 0xcd9580..0xcd9581
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 0, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 3, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 2, Shift: 0}
+          IsParameter: true
+          IsReturn: false
+    - ID: 39
+      Name: main.testDeepSlice7
+      OutOfLinePCRanges: [0xcd95a0..0xcd95a1]
+      InlinePCRanges: []
+      Variables:
+        - Name: a
+          Type: 65 PointerType *main.deepSlice7
+          Locations:
+            - Range: 0xcd95a0..0xcd95a1
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+          IsParameter: true
+          IsReturn: false
+    - ID: 40
+      Name: main.testDeepMap1
+      OutOfLinePCRanges: [0xcd9700..0xcd9701]
+      InlinePCRanges: []
+      Variables:
+        - Name: a
+          Type: 67 StructureType main.deepMap1
+          Locations:
+            - Range: 0xcd9700..0xcd9701
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+          IsParameter: true
+          IsReturn: false
+    - ID: 41
+      Name: main.testDeepMap7
+      OutOfLinePCRanges: [0xcd9720..0xcd9721]
+      InlinePCRanges: []
+      Variables:
+        - Name: a
+          Type: 73 PointerType *main.deepMap7
+          Locations:
+            - Range: 0xcd9720..0xcd9721
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+          IsParameter: true
+          IsReturn: false
+    - ID: 42
+      Name: main.testStringType1
+      OutOfLinePCRanges: [0xcd9740..0xcd9741]
+      InlinePCRanges: []
+      Variables:
+        - Name: a
+          Type: 75 PointerType *main.stringType1
+          Locations:
+            - Range: 0xcd9740..0xcd9741
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+          IsParameter: true
+          IsReturn: false
+    - ID: 43
+      Name: main.testStringType2
+      OutOfLinePCRanges: [0xcd9760..0xcd9761]
+      InlinePCRanges: []
+      Variables:
+        - Name: a
+          Type: 77 PointerType **main.stringType2
+          Locations:
+            - Range: 0xcd9760..0xcd9761
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+          IsParameter: true
+          IsReturn: false
+    - ID: 44
       Name: main.testEsotericStack
-      OutOfLinePCRanges: [0xcd9160..0xcd9265]
+      OutOfLinePCRanges: [0xcd9ba0..0xcd9ca5]
       InlinePCRanges: []
       Variables:
         - Name: e
-          Type: 56 StructureType main.esotericStack
+          Type: 79 StructureType main.esotericStack
           Locations:
-            - Range: 0xcd9160..0xcd91b3
+            - Range: 0xcd9ba0..0xcd9bf3
               Pieces:
                 - Size: 4
                   Op: {RegNo: 0, Shift: 0}
@@ -1933,7 +2171,7 @@ Subprograms:
                   Op: {RegNo: 10, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 11, Shift: 0}
-            - Range: 0xcd91b3..0xcd91b8
+            - Range: 0xcd9bf3..0xcd9bf8
               Pieces:
                 - Size: 4
                   Op: null
@@ -1953,7 +2191,7 @@ Subprograms:
                   Op: {RegNo: 10, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 11, Shift: 0}
-            - Range: 0xcd91b8..0xcd91bd
+            - Range: 0xcd9bf8..0xcd9bfd
               Pieces:
                 - Size: 4
                   Op: null
@@ -1975,146 +2213,146 @@ Subprograms:
                   Op: {RegNo: 11, Shift: 0}
           IsParameter: true
           IsReturn: false
-    - ID: 37
+    - ID: 45
       Name: main.testEsotericHeap
-      OutOfLinePCRanges: [0xcd9280..0xcd92e3]
+      OutOfLinePCRanges: [0xcd9cc0..0xcd9d23]
       InlinePCRanges: []
       Variables:
         - Name: e
-          Type: 61 PointerType *main.esotericHeap
+          Type: 84 PointerType *main.esotericHeap
           Locations:
-            - Range: 0xcd9280..0xcd92ad
+            - Range: 0xcd9cc0..0xcd9ced
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 38
+    - ID: 46
       Name: main.testInlinedBA
-      OutOfLinePCRanges: [0xcd96c0..0xcd9748]
+      OutOfLinePCRanges: [0xcda100..0xcda188]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 7 BaseType int
           Locations:
-            - Range: 0xcd96c0..0xcd96d5
+            - Range: 0xcda100..0xcda115
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 39
+    - ID: 47
       Name: main.testInlinedBB
-      OutOfLinePCRanges: [0xcd9760..0xcd9825]
+      OutOfLinePCRanges: [0xcda1a0..0xcda265]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 7 BaseType int
           Locations:
-            - Range: 0xcd9760..0xcd9776
+            - Range: 0xcda1a0..0xcda1b6
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
         - Name: y
           Type: 7 BaseType int
           Locations:
-            - Range: 0xcd9760..0xcd9787
+            - Range: 0xcda1a0..0xcda1c7
               Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
           IsParameter: true
           IsReturn: false
         - Name: z
           Type: 7 BaseType int
           Locations:
-            - Range: 0xcd9776..0xcd9787
+            - Range: 0xcda1b6..0xcda1c7
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xcd9787..0xcd9825
+            - Range: 0xcda1c7..0xcda265
               Pieces: [{Size: 8, Op: {CfaOffset: -56}}]
           IsParameter: false
           IsReturn: false
-    - ID: 40
+    - ID: 48
       Name: main.testInlinedBBA
-      OutOfLinePCRanges: [0xcd9840..0xcd98a2]
+      OutOfLinePCRanges: [0xcda280..0xcda2e2]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 7 BaseType int
           Locations:
-            - Range: 0xcd9840..0xcd985a
+            - Range: 0xcda280..0xcda29a
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 41
+    - ID: 49
       Name: main.testInlinedBC
-      OutOfLinePCRanges: [0xcd98c0..0xcd99c5]
+      OutOfLinePCRanges: [0xcda300..0xcda405]
       InlinePCRanges: []
       Variables:
         - Name: s
           Type: 7 BaseType int
           Locations:
-            - Range: 0xcd991b..0xcd9925
+            - Range: 0xcda35b..0xcda365
               Pieces: [{Size: 8, Op: {CfaOffset: -80}}]
-            - Range: 0xcd9925..0xcd9935
+            - Range: 0xcda365..0xcda375
               Pieces: [{Size: 8, Op: {CfaOffset: -80}}]
-            - Range: 0xcd9935..0xcd9949
+            - Range: 0xcda375..0xcda389
               Pieces: [{Size: 8, Op: {RegNo: 2, Shift: 0}}]
           IsParameter: false
           IsReturn: false
         - Name: i
           Type: 7 BaseType int
           Locations:
-            - Range: 0xcd9916..0xcd9920
+            - Range: 0xcda356..0xcda360
               Pieces: [{Size: 8, Op: {CfaOffset: -72}}]
-            - Range: 0xcd9920..0xcd9935
+            - Range: 0xcda360..0xcda375
               Pieces: [{Size: 8, Op: {CfaOffset: -72}}]
-            - Range: 0xcd9935..0xcd9944
+            - Range: 0xcda375..0xcda384
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: false
           IsReturn: false
-    - ID: 42
+    - ID: 50
       Name: main.testFrameless
-      OutOfLinePCRanges: [0xcd99e0..0xcd99e6]
+      OutOfLinePCRanges: [0xcda420..0xcda426]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 7 BaseType int
           Locations:
-            - Range: 0xcd99e0..0xcd99e5
+            - Range: 0xcda420..0xcda425
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
         - Name: ~r0
           Type: 7 BaseType int
-          Locations: [{Range: 0xcd99e0..0xcd99e6, Pieces: []}]
+          Locations: [{Range: 0xcda420..0xcda426, Pieces: []}]
           IsParameter: true
           IsReturn: true
-    - ID: 43
+    - ID: 51
       Name: main.testFramelessArray
-      OutOfLinePCRanges: [0xcd9a00..0xcd9a43]
+      OutOfLinePCRanges: [0xcda440..0xcda483]
       InlinePCRanges: []
       Variables:
         - Name: a
-          Type: 63 ArrayType [5]int
+          Type: 86 ArrayType [5]int
           Locations:
-            - Range: 0xcd9a00..0xcd9a43
+            - Range: 0xcda440..0xcda483
               Pieces: [{Size: 40, Op: {CfaOffset: 0}}]
           IsParameter: true
           IsReturn: false
         - Name: ~r0
           Type: 7 BaseType int
-          Locations: [{Range: 0xcd9a00..0xcd9a43, Pieces: []}]
+          Locations: [{Range: 0xcda440..0xcda483, Pieces: []}]
           IsParameter: true
           IsReturn: true
-    - ID: 44
+    - ID: 52
       Name: main.testInterface
-      OutOfLinePCRanges: [0xcd9ce0..0xcd9d23]
+      OutOfLinePCRanges: [0xcda720..0xcda763]
       InlinePCRanges: []
       Variables:
         - Name: b
-          Type: 64 GoInterfaceType main.behavior
+          Type: 87 GoInterfaceType main.behavior
           Locations:
-            - Range: 0xcd9ce0..0xcd9cff
+            - Range: 0xcda720..0xcda73f
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0xcd9cff..0xcd9d02
+            - Range: 0xcda73f..0xcda742
               Pieces:
                 - Size: 8
                   Op: null
@@ -2124,24 +2362,24 @@ Subprograms:
           IsReturn: false
         - Name: ~r0
           Type: 9 GoStringHeaderType string
-          Locations: [{Range: 0xcd9ce0..0xcd9d23, Pieces: []}]
+          Locations: [{Range: 0xcda720..0xcda763, Pieces: []}]
           IsParameter: true
           IsReturn: true
-    - ID: 45
+    - ID: 53
       Name: main.testAny
-      OutOfLinePCRanges: [0xcd9d40..0xcd9da6]
+      OutOfLinePCRanges: [0xcda780..0xcda7e6]
       InlinePCRanges: []
       Variables:
         - Name: a
-          Type: 58 GoEmptyInterfaceType interface {}
+          Type: 81 GoEmptyInterfaceType interface {}
           Locations:
-            - Range: 0xcd9d40..0xcd9d69
+            - Range: 0xcda780..0xcda7a9
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0xcd9d69..0xcd9d6e
+            - Range: 0xcda7a9..0xcda7ae
               Pieces:
                 - Size: 8
                   Op: null
@@ -2151,18 +2389,18 @@ Subprograms:
           IsReturn: false
         - Name: ~r0
           Type: 9 GoStringHeaderType string
-          Locations: [{Range: 0xcd9d40..0xcd9da6, Pieces: []}]
+          Locations: [{Range: 0xcda780..0xcda7e6, Pieces: []}]
           IsParameter: true
           IsReturn: true
-    - ID: 46
+    - ID: 54
       Name: main.testError
-      OutOfLinePCRanges: [0xcd9dc0..0xcd9dc1]
+      OutOfLinePCRanges: [0xcda800..0xcda801]
       InlinePCRanges: []
       Variables:
         - Name: e
           Type: 13 GoInterfaceType error
           Locations:
-            - Range: 0xcd9dc0..0xcd9dc1
+            - Range: 0xcda800..0xcda801
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -2170,309 +2408,309 @@ Subprograms:
                   Op: {RegNo: 3, Shift: 0}
           IsParameter: true
           IsReturn: false
-    - ID: 47
+    - ID: 55
       Name: main.testStructWithMap
-      OutOfLinePCRanges: [0xcda1c0..0xcda1c1]
+      OutOfLinePCRanges: [0xcdac00..0xcdac01]
       InlinePCRanges: []
       Variables:
         - Name: s
-          Type: 65 StructureType main.structWithMap
+          Type: 88 StructureType main.structWithMap
           Locations:
-            - Range: 0xcda1c0..0xcda1c1
-              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-          IsParameter: true
-          IsReturn: false
-    - ID: 48
-      Name: main.testMapStringToStruct
-      OutOfLinePCRanges: [0xcda1e0..0xcda1e1]
-      InlinePCRanges: []
-      Variables:
-        - Name: m
-          Type: 71 GoMapType map[string]main.nestedStruct
-          Locations:
-            - Range: 0xcda1e0..0xcda1e1
-              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-          IsParameter: true
-          IsReturn: false
-    - ID: 49
-      Name: main.testMapStringToInt
-      OutOfLinePCRanges: [0xcda200..0xcda201]
-      InlinePCRanges: []
-      Variables:
-        - Name: m
-          Type: 76 GoMapType map[string]int
-          Locations:
-            - Range: 0xcda200..0xcda201
-              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-          IsParameter: true
-          IsReturn: false
-    - ID: 50
-      Name: main.testMapStringToSlice
-      OutOfLinePCRanges: [0xcda220..0xcda221]
-      InlinePCRanges: []
-      Variables:
-        - Name: m
-          Type: 81 GoMapType map[string][]string
-          Locations:
-            - Range: 0xcda220..0xcda221
-              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-          IsParameter: true
-          IsReturn: false
-    - ID: 51
-      Name: main.testMapArrayToArray
-      OutOfLinePCRanges: [0xcda240..0xcda241]
-      InlinePCRanges: []
-      Variables:
-        - Name: m
-          Type: 86 GoMapType map[[4]string][2]int
-          Locations:
-            - Range: 0xcda240..0xcda241
-              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-          IsParameter: true
-          IsReturn: false
-    - ID: 52
-      Name: main.testSmallMap
-      OutOfLinePCRanges: [0xcda260..0xcda261]
-      InlinePCRanges: []
-      Variables:
-        - Name: m
-          Type: 76 GoMapType map[string]int
-          Locations:
-            - Range: 0xcda260..0xcda261
-              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-          IsParameter: true
-          IsReturn: false
-    - ID: 53
-      Name: main.testArrayOfMaps
-      OutOfLinePCRanges: [0xcda280..0xcda281]
-      InlinePCRanges: []
-      Variables:
-        - Name: m
-          Type: 91 ArrayType [2]map[string]int
-          Locations:
-            - Range: 0xcda280..0xcda281
-              Pieces: [{Size: 16, Op: {CfaOffset: 0}}]
-          IsParameter: true
-          IsReturn: false
-    - ID: 54
-      Name: main.testPointerToMap
-      OutOfLinePCRanges: [0xcda2a0..0xcda2a1]
-      InlinePCRanges: []
-      Variables:
-        - Name: m
-          Type: 92 PointerType *map[string]int
-          Locations:
-            - Range: 0xcda2a0..0xcda2a1
-              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-          IsParameter: true
-          IsReturn: false
-    - ID: 55
-      Name: main.testMapIntToInt
-      OutOfLinePCRanges: [0xcda2c0..0xcda2c1]
-      InlinePCRanges: []
-      Variables:
-        - Name: m
-          Type: 66 GoMapType map[int]int
-          Locations:
-            - Range: 0xcda2c0..0xcda2c1
+            - Range: 0xcdac00..0xcdac01
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
     - ID: 56
-      Name: main.testMapMassive
-      OutOfLinePCRanges: [0xcda2e0..0xcda2e1]
+      Name: main.testMapStringToStruct
+      OutOfLinePCRanges: [0xcdac20..0xcdac21]
       InlinePCRanges: []
       Variables:
-        - Name: redactMyEntries
-          Type: 93 GoMapType map[string][]main.structWithMap
+        - Name: m
+          Type: 94 GoMapType map[string]main.nestedStruct
           Locations:
-            - Range: 0xcda2e0..0xcda2e1
+            - Range: 0xcdac20..0xcdac21
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
     - ID: 57
-      Name: main.testMapEmbeddedMaps
-      OutOfLinePCRanges: [0xcda300..0xcda301]
+      Name: main.testMapStringToInt
+      OutOfLinePCRanges: [0xcdac40..0xcdac41]
       InlinePCRanges: []
       Variables:
         - Name: m
-          Type: 93 GoMapType map[string][]main.structWithMap
+          Type: 99 GoMapType map[string]int
           Locations:
-            - Range: 0xcda300..0xcda301
+            - Range: 0xcdac40..0xcdac41
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
     - ID: 58
-      Name: main.testMapWithLinkedList
-      OutOfLinePCRanges: [0xcda320..0xcda321]
+      Name: main.testMapStringToSlice
+      OutOfLinePCRanges: [0xcdac60..0xcdac61]
       InlinePCRanges: []
       Variables:
         - Name: m
-          Type: 98 GoMapType map[bool]main.node
+          Type: 104 GoMapType map[string][]string
           Locations:
-            - Range: 0xcda320..0xcda321
+            - Range: 0xcdac60..0xcdac61
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
     - ID: 59
-      Name: main.testMapWithSmallValue
-      OutOfLinePCRanges: [0xcda340..0xcda341]
+      Name: main.testMapArrayToArray
+      OutOfLinePCRanges: [0xcdac80..0xcdac81]
       InlinePCRanges: []
       Variables:
         - Name: m
-          Type: 103 GoMapType map[int]uint8
+          Type: 109 GoMapType map[[4]string][2]int
           Locations:
-            - Range: 0xcda340..0xcda341
+            - Range: 0xcdac80..0xcdac81
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
     - ID: 60
-      Name: main.testMapWithSmallValueMassive
-      OutOfLinePCRanges: [0xcda360..0xcda361]
+      Name: main.testSmallMap
+      OutOfLinePCRanges: [0xcdaca0..0xcdaca1]
       InlinePCRanges: []
       Variables:
-        - Name: redactMyEntries
-          Type: 103 GoMapType map[int]uint8
+        - Name: m
+          Type: 99 GoMapType map[string]int
           Locations:
-            - Range: 0xcda360..0xcda361
+            - Range: 0xcdaca0..0xcdaca1
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
     - ID: 61
-      Name: main.testMapWithSmallKeyAndValue
-      OutOfLinePCRanges: [0xcda380..0xcda381]
+      Name: main.testArrayOfMaps
+      OutOfLinePCRanges: [0xcdacc0..0xcdacc1]
       InlinePCRanges: []
       Variables:
         - Name: m
-          Type: 108 GoMapType map[uint8]uint8
+          Type: 114 ArrayType [2]map[string]int
           Locations:
-            - Range: 0xcda380..0xcda381
-              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+            - Range: 0xcdacc0..0xcdacc1
+              Pieces: [{Size: 16, Op: {CfaOffset: 0}}]
           IsParameter: true
           IsReturn: false
     - ID: 62
-      Name: main.testMapWithSmallKeyAndValueMassive
-      OutOfLinePCRanges: [0xcda3a0..0xcda3a1]
+      Name: main.testPointerToMap
+      OutOfLinePCRanges: [0xcdace0..0xcdace1]
       InlinePCRanges: []
       Variables:
         - Name: m
-          Type: 108 GoMapType map[uint8]uint8
+          Type: 115 PointerType *map[string]int
           Locations:
-            - Range: 0xcda3a0..0xcda3a1
+            - Range: 0xcdace0..0xcdace1
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
     - ID: 63
-      Name: main.testMapSmallKeySmallValue
-      OutOfLinePCRanges: [0xcda3c0..0xcda3c1]
+      Name: main.testMapIntToInt
+      OutOfLinePCRanges: [0xcdad00..0xcdad01]
       InlinePCRanges: []
       Variables:
         - Name: m
-          Type: 108 GoMapType map[uint8]uint8
+          Type: 89 GoMapType map[int]int
           Locations:
-            - Range: 0xcda3c0..0xcda3c1
+            - Range: 0xcdad00..0xcdad01
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
     - ID: 64
-      Name: main.testMapSmallKeyLargeValue
-      OutOfLinePCRanges: [0xcda3e0..0xcda3e1]
+      Name: main.testMapMassive
+      OutOfLinePCRanges: [0xcdad20..0xcdad21]
       InlinePCRanges: []
       Variables:
-        - Name: m
-          Type: 113 GoMapType map[uint8][4]int
+        - Name: redactMyEntries
+          Type: 116 GoMapType map[string][]main.structWithMap
           Locations:
-            - Range: 0xcda3e0..0xcda3e1
+            - Range: 0xcdad20..0xcdad21
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
     - ID: 65
-      Name: main.testMapLargeKeySmallValue
-      OutOfLinePCRanges: [0xcda400..0xcda401]
+      Name: main.testMapEmbeddedMaps
+      OutOfLinePCRanges: [0xcdad40..0xcdad41]
       InlinePCRanges: []
       Variables:
         - Name: m
-          Type: 118 GoMapType map[[4]int]uint8
+          Type: 116 GoMapType map[string][]main.structWithMap
           Locations:
-            - Range: 0xcda400..0xcda401
+            - Range: 0xcdad40..0xcdad41
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
     - ID: 66
-      Name: main.testMapLargeKeyLargeValue
-      OutOfLinePCRanges: [0xcda420..0xcda421]
+      Name: main.testMapWithLinkedList
+      OutOfLinePCRanges: [0xcdad60..0xcdad61]
       InlinePCRanges: []
       Variables:
         - Name: m
-          Type: 123 GoMapType map[[4]int][4]int
+          Type: 121 GoMapType map[bool]main.node
           Locations:
-            - Range: 0xcda420..0xcda421
+            - Range: 0xcdad60..0xcdad61
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
     - ID: 67
+      Name: main.testMapWithSmallValue
+      OutOfLinePCRanges: [0xcdad80..0xcdad81]
+      InlinePCRanges: []
+      Variables:
+        - Name: m
+          Type: 126 GoMapType map[int]uint8
+          Locations:
+            - Range: 0xcdad80..0xcdad81
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+          IsParameter: true
+          IsReturn: false
+    - ID: 68
+      Name: main.testMapWithSmallValueMassive
+      OutOfLinePCRanges: [0xcdada0..0xcdada1]
+      InlinePCRanges: []
+      Variables:
+        - Name: redactMyEntries
+          Type: 126 GoMapType map[int]uint8
+          Locations:
+            - Range: 0xcdada0..0xcdada1
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+          IsParameter: true
+          IsReturn: false
+    - ID: 69
+      Name: main.testMapWithSmallKeyAndValue
+      OutOfLinePCRanges: [0xcdadc0..0xcdadc1]
+      InlinePCRanges: []
+      Variables:
+        - Name: m
+          Type: 131 GoMapType map[uint8]uint8
+          Locations:
+            - Range: 0xcdadc0..0xcdadc1
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+          IsParameter: true
+          IsReturn: false
+    - ID: 70
+      Name: main.testMapWithSmallKeyAndValueMassive
+      OutOfLinePCRanges: [0xcdade0..0xcdade1]
+      InlinePCRanges: []
+      Variables:
+        - Name: m
+          Type: 131 GoMapType map[uint8]uint8
+          Locations:
+            - Range: 0xcdade0..0xcdade1
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+          IsParameter: true
+          IsReturn: false
+    - ID: 71
+      Name: main.testMapSmallKeySmallValue
+      OutOfLinePCRanges: [0xcdae00..0xcdae01]
+      InlinePCRanges: []
+      Variables:
+        - Name: m
+          Type: 131 GoMapType map[uint8]uint8
+          Locations:
+            - Range: 0xcdae00..0xcdae01
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+          IsParameter: true
+          IsReturn: false
+    - ID: 72
+      Name: main.testMapSmallKeyLargeValue
+      OutOfLinePCRanges: [0xcdae20..0xcdae21]
+      InlinePCRanges: []
+      Variables:
+        - Name: m
+          Type: 136 GoMapType map[uint8][4]int
+          Locations:
+            - Range: 0xcdae20..0xcdae21
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+          IsParameter: true
+          IsReturn: false
+    - ID: 73
+      Name: main.testMapLargeKeySmallValue
+      OutOfLinePCRanges: [0xcdae40..0xcdae41]
+      InlinePCRanges: []
+      Variables:
+        - Name: m
+          Type: 141 GoMapType map[[4]int]uint8
+          Locations:
+            - Range: 0xcdae40..0xcdae41
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+          IsParameter: true
+          IsReturn: false
+    - ID: 74
+      Name: main.testMapLargeKeyLargeValue
+      OutOfLinePCRanges: [0xcdae60..0xcdae61]
+      InlinePCRanges: []
+      Variables:
+        - Name: m
+          Type: 146 GoMapType map[[4]int][4]int
+          Locations:
+            - Range: 0xcdae60..0xcdae61
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+          IsParameter: true
+          IsReturn: false
+    - ID: 75
       Name: main.testCombinedByte
-      OutOfLinePCRanges: [0xcdbb60..0xcdbb61]
+      OutOfLinePCRanges: [0xcdc5a0..0xcdc5a1]
       InlinePCRanges: []
       Variables:
         - Name: w
           Type: 3 BaseType uint8
           Locations:
-            - Range: 0xcdbb60..0xcdbb61
+            - Range: 0xcdc5a0..0xcdc5a1
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
         - Name: x
           Type: 3 BaseType uint8
           Locations:
-            - Range: 0xcdbb60..0xcdbb61
+            - Range: 0xcdc5a0..0xcdc5a1
               Pieces: [{Size: 1, Op: {RegNo: 3, Shift: 0}}]
           IsParameter: true
           IsReturn: false
         - Name: y
           Type: 18 BaseType float32
           Locations:
-            - Range: 0xcdbb60..0xcdbb61
+            - Range: 0xcdc5a0..0xcdc5a1
               Pieces: [{Size: 4, Op: {RegNo: 17, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 68
+    - ID: 76
       Name: main.testMultipleSimpleParams
-      OutOfLinePCRanges: [0xcdbd20..0xcdbd21]
+      OutOfLinePCRanges: [0xcdc760..0xcdc761]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 4 BaseType bool
           Locations:
-            - Range: 0xcdbd20..0xcdbd21
+            - Range: 0xcdc760..0xcdc761
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
         - Name: b
           Type: 3 BaseType uint8
           Locations:
-            - Range: 0xcdbd20..0xcdbd21
+            - Range: 0xcdc760..0xcdc761
               Pieces: [{Size: 1, Op: {RegNo: 3, Shift: 0}}]
           IsParameter: true
           IsReturn: false
         - Name: c
           Type: 10 BaseType int32
           Locations:
-            - Range: 0xcdbd20..0xcdbd21
+            - Range: 0xcdc760..0xcdc761
               Pieces: [{Size: 4, Op: {RegNo: 2, Shift: 0}}]
           IsParameter: true
           IsReturn: false
         - Name: d
           Type: 17 BaseType uint
           Locations:
-            - Range: 0xcdbd20..0xcdbd21
+            - Range: 0xcdc760..0xcdc761
               Pieces: [{Size: 8, Op: {RegNo: 5, Shift: 0}}]
           IsParameter: true
           IsReturn: false
         - Name: e
           Type: 9 GoStringHeaderType string
           Locations:
-            - Range: 0xcdbd20..0xcdbd21
+            - Range: 0xcdc760..0xcdc761
               Pieces:
                 - Size: 8
                   Op: {RegNo: 4, Shift: 0}
@@ -2480,39 +2718,39 @@ Subprograms:
                   Op: {RegNo: 8, Shift: 0}
           IsParameter: true
           IsReturn: false
-    - ID: 69
+    - ID: 77
       Name: main.testChannel
-      OutOfLinePCRanges: [0xcdbf40..0xcdbf41]
+      OutOfLinePCRanges: [0xcdc980..0xcdc981]
       InlinePCRanges: []
       Variables:
         - Name: c
-          Type: 128 GoChannelType chan bool
+          Type: 151 GoChannelType chan bool
           Locations:
-            - Range: 0xcdbf40..0xcdbf41
+            - Range: 0xcdc980..0xcdc981
               Pieces: [{Size: 0, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 70
+    - ID: 78
       Name: main.testPointerToSimpleStruct
-      OutOfLinePCRanges: [0xcdc0e0..0xcdc0e1]
+      OutOfLinePCRanges: [0xcdcb20..0xcdcb21]
       InlinePCRanges: []
       Variables:
         - Name: a
-          Type: 129 PointerType *main.structWithTwoValues
+          Type: 152 PointerType *main.structWithTwoValues
           Locations:
-            - Range: 0xcdc0e0..0xcdc0e1
+            - Range: 0xcdcb20..0xcdcb21
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 71
+    - ID: 79
       Name: main.testLinkedList
-      OutOfLinePCRanges: [0xcdc100..0xcdc101]
+      OutOfLinePCRanges: [0xcdcb40..0xcdcb41]
       InlinePCRanges: []
       Variables:
         - Name: a
-          Type: 131 StructureType main.node
+          Type: 154 StructureType main.node
           Locations:
-            - Range: 0xcdc100..0xcdc101
+            - Range: 0xcdcb40..0xcdcb41
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -2520,273 +2758,94 @@ Subprograms:
                   Op: {RegNo: 3, Shift: 0}
           IsParameter: true
           IsReturn: false
-    - ID: 72
+    - ID: 80
       Name: main.testPointerLoop
-      OutOfLinePCRanges: [0xcdc120..0xcdc121]
+      OutOfLinePCRanges: [0xcdcb60..0xcdcb61]
       InlinePCRanges: []
       Variables:
         - Name: a
-          Type: 132 PointerType *main.node
+          Type: 155 PointerType *main.node
           Locations:
-            - Range: 0xcdc120..0xcdc121
+            - Range: 0xcdcb60..0xcdcb61
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 73
+    - ID: 81
       Name: main.testUnsafePointer
-      OutOfLinePCRanges: [0xcdc140..0xcdc141]
+      OutOfLinePCRanges: [0xcdcb80..0xcdcb81]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 14 VoidPointerType unsafe.Pointer
           Locations:
-            - Range: 0xcdc140..0xcdc141
+            - Range: 0xcdcb80..0xcdcb81
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 74
+    - ID: 82
       Name: main.testUintPointer
-      OutOfLinePCRanges: [0xcdc180..0xcdc181]
+      OutOfLinePCRanges: [0xcdcbc0..0xcdcbc1]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 34 PointerType *uint
           Locations:
-            - Range: 0xcdc180..0xcdc181
+            - Range: 0xcdcbc0..0xcdcbc1
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 75
+    - ID: 83
       Name: main.testStringPointer
-      OutOfLinePCRanges: [0xcdc260..0xcdc261]
+      OutOfLinePCRanges: [0xcdcca0..0xcdcca1]
       InlinePCRanges: []
       Variables:
         - Name: z
           Type: 22 PointerType *string
           Locations:
-            - Range: 0xcdc260..0xcdc261
+            - Range: 0xcdcca0..0xcdcca1
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 76
+    - ID: 84
       Name: main.testNilPointer
-      OutOfLinePCRanges: [0xcdc2a0..0xcdc2a1]
+      OutOfLinePCRanges: [0xcdcce0..0xcdcce1]
       InlinePCRanges: []
       Variables:
         - Name: z
           Type: 11 PointerType *bool
           Locations:
-            - Range: 0xcdc2a0..0xcdc2a1
+            - Range: 0xcdcce0..0xcdcce1
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
         - Name: a
           Type: 17 BaseType uint
           Locations:
-            - Range: 0xcdc2a0..0xcdc2a1
+            - Range: 0xcdcce0..0xcdcce1
               Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 77
+    - ID: 85
       Name: main.testCycle
-      OutOfLinePCRanges: [0xcdc2e0..0xcdc2e1]
+      OutOfLinePCRanges: [0xcdcd20..0xcdcd21]
       InlinePCRanges: []
       Variables:
         - Name: t
-          Type: 133 PointerType *main.t
+          Type: 156 PointerType *main.t
           Locations:
-            - Range: 0xcdc2e0..0xcdc2e1
+            - Range: 0xcdcd20..0xcdcd21
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 78
-      Name: main.testUintSlice
-      OutOfLinePCRanges: [0xcdc800..0xcdc801]
-      InlinePCRanges: []
-      Variables:
-        - Name: u
-          Type: 135 GoSliceHeaderType []uint
-          Locations:
-            - Range: 0xcdc800..0xcdc801
-              Pieces:
-                - Size: 8
-                  Op: {RegNo: 0, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 3, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 2, Shift: 0}
-          IsParameter: true
-          IsReturn: false
-    - ID: 79
-      Name: main.testEmptySlice
-      OutOfLinePCRanges: [0xcdc820..0xcdc821]
-      InlinePCRanges: []
-      Variables:
-        - Name: u
-          Type: 135 GoSliceHeaderType []uint
-          Locations:
-            - Range: 0xcdc820..0xcdc821
-              Pieces:
-                - Size: 8
-                  Op: {RegNo: 0, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 3, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 2, Shift: 0}
-          IsParameter: true
-          IsReturn: false
-    - ID: 80
-      Name: main.testSliceOfSlices
-      OutOfLinePCRanges: [0xcdc840..0xcdc841]
-      InlinePCRanges: []
-      Variables:
-        - Name: u
-          Type: 136 GoSliceHeaderType [][]uint
-          Locations:
-            - Range: 0xcdc840..0xcdc841
-              Pieces:
-                - Size: 8
-                  Op: {RegNo: 0, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 3, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 2, Shift: 0}
-          IsParameter: true
-          IsReturn: false
-    - ID: 81
-      Name: main.testStructSlice
-      OutOfLinePCRanges: [0xcdc860..0xcdc861]
-      InlinePCRanges: []
-      Variables:
-        - Name: xs
-          Type: 138 GoSliceHeaderType []main.structWithNoStrings
-          Locations:
-            - Range: 0xcdc860..0xcdc861
-              Pieces:
-                - Size: 8
-                  Op: {RegNo: 0, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 3, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 2, Shift: 0}
-          IsParameter: true
-          IsReturn: false
-        - Name: a
-          Type: 7 BaseType int
-          Locations:
-            - Range: 0xcdc860..0xcdc861
-              Pieces: [{Size: 8, Op: {RegNo: 5, Shift: 0}}]
-          IsParameter: true
-          IsReturn: false
-    - ID: 82
-      Name: main.testEmptySliceOfStructs
-      OutOfLinePCRanges: [0xcdc880..0xcdc881]
-      InlinePCRanges: []
-      Variables:
-        - Name: xs
-          Type: 138 GoSliceHeaderType []main.structWithNoStrings
-          Locations:
-            - Range: 0xcdc880..0xcdc881
-              Pieces:
-                - Size: 8
-                  Op: {RegNo: 0, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 3, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 2, Shift: 0}
-          IsParameter: true
-          IsReturn: false
-        - Name: a
-          Type: 7 BaseType int
-          Locations:
-            - Range: 0xcdc880..0xcdc881
-              Pieces: [{Size: 8, Op: {RegNo: 5, Shift: 0}}]
-          IsParameter: true
-          IsReturn: false
-    - ID: 83
-      Name: main.testNilSliceOfStructs
-      OutOfLinePCRanges: [0xcdc8a0..0xcdc8a1]
-      InlinePCRanges: []
-      Variables:
-        - Name: xs
-          Type: 138 GoSliceHeaderType []main.structWithNoStrings
-          Locations:
-            - Range: 0xcdc8a0..0xcdc8a1
-              Pieces:
-                - Size: 8
-                  Op: {RegNo: 0, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 3, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 2, Shift: 0}
-          IsParameter: true
-          IsReturn: false
-        - Name: a
-          Type: 7 BaseType int
-          Locations:
-            - Range: 0xcdc8a0..0xcdc8a1
-              Pieces: [{Size: 8, Op: {RegNo: 5, Shift: 0}}]
-          IsParameter: true
-          IsReturn: false
-    - ID: 84
-      Name: main.testStringSlice
-      OutOfLinePCRanges: [0xcdc8c0..0xcdc8c1]
-      InlinePCRanges: []
-      Variables:
-        - Name: s
-          Type: 141 GoSliceHeaderType []string
-          Locations:
-            - Range: 0xcdc8c0..0xcdc8c1
-              Pieces:
-                - Size: 8
-                  Op: {RegNo: 0, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 3, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 2, Shift: 0}
-          IsParameter: true
-          IsReturn: false
-    - ID: 85
-      Name: main.testNilSliceWithOtherParams
-      OutOfLinePCRanges: [0xcdc8e0..0xcdc8e1]
-      InlinePCRanges: []
-      Variables:
-        - Name: a
-          Type: 16 BaseType int8
-          Locations:
-            - Range: 0xcdc8e0..0xcdc8e1
-              Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
-          IsParameter: true
-          IsReturn: false
-        - Name: s
-          Type: 142 GoSliceHeaderType []bool
-          Locations:
-            - Range: 0xcdc8e0..0xcdc8e1
-              Pieces:
-                - Size: 8
-                  Op: {RegNo: 3, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 2, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 5, Shift: 0}
-          IsParameter: true
-          IsReturn: false
-        - Name: x
-          Type: 17 BaseType uint
-          Locations:
-            - Range: 0xcdc8e0..0xcdc8e1
-              Pieces: [{Size: 8, Op: {RegNo: 4, Shift: 0}}]
-          IsParameter: true
-          IsReturn: false
     - ID: 86
-      Name: main.testNilSlice
-      OutOfLinePCRanges: [0xcdc900..0xcdc901]
+      Name: main.testUintSlice
+      OutOfLinePCRanges: [0xcdd240..0xcdd241]
       InlinePCRanges: []
       Variables:
-        - Name: xs
-          Type: 143 GoSliceHeaderType []uint16
+        - Name: u
+          Type: 158 GoSliceHeaderType []uint
           Locations:
-            - Range: 0xcdc900..0xcdc901
+            - Range: 0xcdd240..0xcdd241
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -2797,14 +2856,14 @@ Subprograms:
           IsParameter: true
           IsReturn: false
     - ID: 87
-      Name: main.testVeryLargeSlice
-      OutOfLinePCRanges: [0xcdc920..0xcdc921]
+      Name: main.testEmptySlice
+      OutOfLinePCRanges: [0xcdd260..0xcdd261]
       InlinePCRanges: []
       Variables:
-        - Name: xs
-          Type: 135 GoSliceHeaderType []uint
+        - Name: u
+          Type: 158 GoSliceHeaderType []uint
           Locations:
-            - Range: 0xcdc920..0xcdc921
+            - Range: 0xcdd260..0xcdd261
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -2815,24 +2874,203 @@ Subprograms:
           IsParameter: true
           IsReturn: false
     - ID: 88
+      Name: main.testSliceOfSlices
+      OutOfLinePCRanges: [0xcdd280..0xcdd281]
+      InlinePCRanges: []
+      Variables:
+        - Name: u
+          Type: 159 GoSliceHeaderType [][]uint
+          Locations:
+            - Range: 0xcdd280..0xcdd281
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 0, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 3, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 2, Shift: 0}
+          IsParameter: true
+          IsReturn: false
+    - ID: 89
+      Name: main.testStructSlice
+      OutOfLinePCRanges: [0xcdd2a0..0xcdd2a1]
+      InlinePCRanges: []
+      Variables:
+        - Name: xs
+          Type: 161 GoSliceHeaderType []main.structWithNoStrings
+          Locations:
+            - Range: 0xcdd2a0..0xcdd2a1
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 0, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 3, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 2, Shift: 0}
+          IsParameter: true
+          IsReturn: false
+        - Name: a
+          Type: 7 BaseType int
+          Locations:
+            - Range: 0xcdd2a0..0xcdd2a1
+              Pieces: [{Size: 8, Op: {RegNo: 5, Shift: 0}}]
+          IsParameter: true
+          IsReturn: false
+    - ID: 90
+      Name: main.testEmptySliceOfStructs
+      OutOfLinePCRanges: [0xcdd2c0..0xcdd2c1]
+      InlinePCRanges: []
+      Variables:
+        - Name: xs
+          Type: 161 GoSliceHeaderType []main.structWithNoStrings
+          Locations:
+            - Range: 0xcdd2c0..0xcdd2c1
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 0, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 3, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 2, Shift: 0}
+          IsParameter: true
+          IsReturn: false
+        - Name: a
+          Type: 7 BaseType int
+          Locations:
+            - Range: 0xcdd2c0..0xcdd2c1
+              Pieces: [{Size: 8, Op: {RegNo: 5, Shift: 0}}]
+          IsParameter: true
+          IsReturn: false
+    - ID: 91
+      Name: main.testNilSliceOfStructs
+      OutOfLinePCRanges: [0xcdd2e0..0xcdd2e1]
+      InlinePCRanges: []
+      Variables:
+        - Name: xs
+          Type: 161 GoSliceHeaderType []main.structWithNoStrings
+          Locations:
+            - Range: 0xcdd2e0..0xcdd2e1
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 0, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 3, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 2, Shift: 0}
+          IsParameter: true
+          IsReturn: false
+        - Name: a
+          Type: 7 BaseType int
+          Locations:
+            - Range: 0xcdd2e0..0xcdd2e1
+              Pieces: [{Size: 8, Op: {RegNo: 5, Shift: 0}}]
+          IsParameter: true
+          IsReturn: false
+    - ID: 92
+      Name: main.testStringSlice
+      OutOfLinePCRanges: [0xcdd300..0xcdd301]
+      InlinePCRanges: []
+      Variables:
+        - Name: s
+          Type: 164 GoSliceHeaderType []string
+          Locations:
+            - Range: 0xcdd300..0xcdd301
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 0, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 3, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 2, Shift: 0}
+          IsParameter: true
+          IsReturn: false
+    - ID: 93
+      Name: main.testNilSliceWithOtherParams
+      OutOfLinePCRanges: [0xcdd320..0xcdd321]
+      InlinePCRanges: []
+      Variables:
+        - Name: a
+          Type: 16 BaseType int8
+          Locations:
+            - Range: 0xcdd320..0xcdd321
+              Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
+          IsParameter: true
+          IsReturn: false
+        - Name: s
+          Type: 165 GoSliceHeaderType []bool
+          Locations:
+            - Range: 0xcdd320..0xcdd321
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 3, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 2, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 5, Shift: 0}
+          IsParameter: true
+          IsReturn: false
+        - Name: x
+          Type: 17 BaseType uint
+          Locations:
+            - Range: 0xcdd320..0xcdd321
+              Pieces: [{Size: 8, Op: {RegNo: 4, Shift: 0}}]
+          IsParameter: true
+          IsReturn: false
+    - ID: 94
+      Name: main.testNilSlice
+      OutOfLinePCRanges: [0xcdd340..0xcdd341]
+      InlinePCRanges: []
+      Variables:
+        - Name: xs
+          Type: 166 GoSliceHeaderType []uint16
+          Locations:
+            - Range: 0xcdd340..0xcdd341
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 0, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 3, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 2, Shift: 0}
+          IsParameter: true
+          IsReturn: false
+    - ID: 95
+      Name: main.testVeryLargeSlice
+      OutOfLinePCRanges: [0xcdd360..0xcdd361]
+      InlinePCRanges: []
+      Variables:
+        - Name: xs
+          Type: 158 GoSliceHeaderType []uint
+          Locations:
+            - Range: 0xcdd360..0xcdd361
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 0, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 3, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 2, Shift: 0}
+          IsParameter: true
+          IsReturn: false
+    - ID: 96
       Name: main.stackC
-      OutOfLinePCRanges: [0xcdcc60..0xcdccb2]
+      OutOfLinePCRanges: [0xcdd6a0..0xcdd6f2]
       InlinePCRanges: []
       Variables:
         - Name: ~r0
           Type: 9 GoStringHeaderType string
-          Locations: [{Range: 0xcdcc60..0xcdccb2, Pieces: []}]
+          Locations: [{Range: 0xcdd6a0..0xcdd6f2, Pieces: []}]
           IsParameter: true
           IsReturn: true
-    - ID: 89
+    - ID: 97
       Name: main.testSingleString
-      OutOfLinePCRanges: [0xcdccc0..0xcdccc1]
+      OutOfLinePCRanges: [0xcdd700..0xcdd701]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 9 GoStringHeaderType string
           Locations:
-            - Range: 0xcdccc0..0xcdccc1
+            - Range: 0xcdd700..0xcdd701
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -2840,15 +3078,15 @@ Subprograms:
                   Op: {RegNo: 3, Shift: 0}
           IsParameter: true
           IsReturn: false
-    - ID: 90
+    - ID: 98
       Name: main.testThreeStrings
-      OutOfLinePCRanges: [0xcdcce0..0xcdcce1]
+      OutOfLinePCRanges: [0xcdd720..0xcdd721]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 9 GoStringHeaderType string
           Locations:
-            - Range: 0xcdcce0..0xcdcce1
+            - Range: 0xcdd720..0xcdd721
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -2859,7 +3097,7 @@ Subprograms:
         - Name: y
           Type: 9 GoStringHeaderType string
           Locations:
-            - Range: 0xcdcce0..0xcdcce1
+            - Range: 0xcdd720..0xcdd721
               Pieces:
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
@@ -2870,7 +3108,7 @@ Subprograms:
         - Name: z
           Type: 9 GoStringHeaderType string
           Locations:
-            - Range: 0xcdcce0..0xcdcce1
+            - Range: 0xcdd720..0xcdd721
               Pieces:
                 - Size: 8
                   Op: {RegNo: 4, Shift: 0}
@@ -2878,15 +3116,15 @@ Subprograms:
                   Op: {RegNo: 8, Shift: 0}
           IsParameter: true
           IsReturn: false
-    - ID: 91
+    - ID: 99
       Name: main.testThreeStringsInStruct
-      OutOfLinePCRanges: [0xcdcd00..0xcdcd1f]
+      OutOfLinePCRanges: [0xcdd740..0xcdd75f]
       InlinePCRanges: []
       Variables:
         - Name: a
-          Type: 144 StructureType main.threeStringStruct
+          Type: 167 StructureType main.threeStringStruct
           Locations:
-            - Range: 0xcdcd00..0xcdcd1f
+            - Range: 0xcdd740..0xcdd75f
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -2902,39 +3140,39 @@ Subprograms:
                   Op: {RegNo: 8, Shift: 0}
           IsParameter: true
           IsReturn: false
-    - ID: 92
+    - ID: 100
       Name: main.testThreeStringsInStructPointer
-      OutOfLinePCRanges: [0xcdcd20..0xcdcd21]
+      OutOfLinePCRanges: [0xcdd760..0xcdd761]
       InlinePCRanges: []
       Variables:
         - Name: a
-          Type: 145 PointerType *main.threeStringStruct
+          Type: 168 PointerType *main.threeStringStruct
           Locations:
-            - Range: 0xcdcd20..0xcdcd21
+            - Range: 0xcdd760..0xcdd761
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 93
+    - ID: 101
       Name: main.testOneStringInStructPointer
-      OutOfLinePCRanges: [0xcdcd40..0xcdcd41]
+      OutOfLinePCRanges: [0xcdd780..0xcdd781]
       InlinePCRanges: []
       Variables:
         - Name: a
-          Type: 146 PointerType *main.oneStringStruct
+          Type: 169 PointerType *main.oneStringStruct
           Locations:
-            - Range: 0xcdcd40..0xcdcd41
+            - Range: 0xcdd780..0xcdd781
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 94
+    - ID: 102
       Name: main.testMassiveString
-      OutOfLinePCRanges: [0xcdcd60..0xcdcd61]
+      OutOfLinePCRanges: [0xcdd7a0..0xcdd7a1]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 9 GoStringHeaderType string
           Locations:
-            - Range: 0xcdcd60..0xcdcd61
+            - Range: 0xcdd7a0..0xcdd7a1
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -2942,15 +3180,15 @@ Subprograms:
                   Op: {RegNo: 3, Shift: 0}
           IsParameter: true
           IsReturn: false
-    - ID: 95
+    - ID: 103
       Name: main.testUnitializedString
-      OutOfLinePCRanges: [0xcdcd80..0xcdcd81]
+      OutOfLinePCRanges: [0xcdd7c0..0xcdd7c1]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 9 GoStringHeaderType string
           Locations:
-            - Range: 0xcdcd80..0xcdcd81
+            - Range: 0xcdd7c0..0xcdd7c1
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -2958,15 +3196,15 @@ Subprograms:
                   Op: {RegNo: 3, Shift: 0}
           IsParameter: true
           IsReturn: false
-    - ID: 96
+    - ID: 104
       Name: main.testEmptyString
-      OutOfLinePCRanges: [0xcdcda0..0xcdcda1]
+      OutOfLinePCRanges: [0xcdd7e0..0xcdd7e1]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 9 GoStringHeaderType string
           Locations:
-            - Range: 0xcdcda0..0xcdcda1
+            - Range: 0xcdd7e0..0xcdd7e1
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -2974,15 +3212,15 @@ Subprograms:
                   Op: {RegNo: 3, Shift: 0}
           IsParameter: true
           IsReturn: false
-    - ID: 97
+    - ID: 105
       Name: main.testStruct
-      OutOfLinePCRanges: [0xcdd020..0xcdd043]
+      OutOfLinePCRanges: [0xcdda60..0xcdda83]
       InlinePCRanges: []
       Variables:
         - Name: x
-          Type: 148 StructureType main.aStruct
+          Type: 171 StructureType main.aStruct
           Locations:
-            - Range: 0xcdd020..0xcdd043
+            - Range: 0xcdda60..0xcdda83
               Pieces:
                 - Size: 1
                   Op: {RegNo: 0, Shift: 0}
@@ -3000,580 +3238,860 @@ Subprograms:
                   Op: {RegNo: 9, Shift: 0}
           IsParameter: true
           IsReturn: false
-    - ID: 98
+    - ID: 106
       Name: main.testEmptyStruct
-      OutOfLinePCRanges: [0xcdd1a0..0xcdd1a1]
+      OutOfLinePCRanges: [0xcddbe0..0xcddbe1]
       InlinePCRanges: []
       Variables:
         - Name: e
-          Type: 150 StructureType main.emptyStruct
-          Locations: [{Range: 0xcdd1a0..0xcdd1a1, Pieces: []}]
+          Type: 173 StructureType main.emptyStruct
+          Locations: [{Range: 0xcddbe0..0xcddbe1, Pieces: []}]
           IsParameter: true
           IsReturn: false
-    - ID: 99
+    - ID: 107
       Name: main.testInlinedPrint
-      OutOfLinePCRanges: [0xcd9520..0xcd9582]
+      OutOfLinePCRanges: [0xcd9f60..0xcd9fc2]
       InlinePCRanges:
-        - Ranges: [0xcd95b1..0xcd95ed]
-          RootRanges: [0xcd95a0..0xcd9611]
-        - Ranges: [0xcd96f2..0xcd972e]
-          RootRanges: [0xcd96c0..0xcd9748]
-        - Ranges: [0xcd977c..0xcd97b8]
-          RootRanges: [0xcd9760..0xcd9825]
-        - Ranges: [0xcd984f..0xcd988b]
-          RootRanges: [0xcd9840..0xcd98a2]
+        - Ranges: [0xcd9ff1..0xcda02d]
+          RootRanges: [0xcd9fe0..0xcda051]
+        - Ranges: [0xcda132..0xcda16e]
+          RootRanges: [0xcda100..0xcda188]
+        - Ranges: [0xcda1bc..0xcda1f8]
+          RootRanges: [0xcda1a0..0xcda265]
+        - Ranges: [0xcda28f..0xcda2cb]
+          RootRanges: [0xcda280..0xcda2e2]
       Variables:
         - Name: x
           Type: 7 BaseType int
           Locations:
-            - Range: 0xcd9520..0xcd9539
+            - Range: 0xcd9f60..0xcd9f79
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xcd95b1..0xcd95bc
+            - Range: 0xcd9ff1..0xcd9ffc
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xcd96f2..0xcd96fd
+            - Range: 0xcda132..0xcda13d
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xcd9776..0xcd9787
+            - Range: 0xcda1b6..0xcda1c7
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xcd9787..0xcd9825
+            - Range: 0xcda1c7..0xcda265
               Pieces: [{Size: 8, Op: {CfaOffset: -56}}]
-            - Range: 0xcd9840..0xcd985a
+            - Range: 0xcda280..0xcda29a
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 100
+    - ID: 108
       Name: main.testInlinedBBB
       OutOfLinePCRanges: []
       InlinePCRanges:
-        - Ranges: [0xcd97c6..0xcd97fe]
-          RootRanges: [0xcd9760..0xcd9825]
+        - Ranges: [0xcda206..0xcda23e]
+          RootRanges: [0xcda1a0..0xcda265]
       Variables: []
-    - ID: 101
+    - ID: 109
       Name: main.testInlinedBCA
       OutOfLinePCRanges: []
       InlinePCRanges:
-        - Ranges: [0xcd98d3..0xcd9911]
-          RootRanges: [0xcd98c0..0xcd99c5]
+        - Ranges: [0xcda313..0xcda351]
+          RootRanges: [0xcda300..0xcda405]
       Variables: []
-    - ID: 102
+    - ID: 110
       Name: main.testInlinedBCB
       OutOfLinePCRanges: []
       InlinePCRanges:
-        - Ranges: [0xcd997b..0xcd99b3]
-          RootRanges: [0xcd98c0..0xcd99c5]
+        - Ranges: [0xcda3bb..0xcda3f3]
+          RootRanges: [0xcda300..0xcda405]
       Variables: []
-    - ID: 103
+    - ID: 111
       Name: main.testInlinedSq
       OutOfLinePCRanges: []
       InlinePCRanges:
-        - Ranges: [0xcd99e1..0xcd99e5]
-          RootRanges: [0xcd99e0..0xcd99e6]
+        - Ranges: [0xcda421..0xcda425]
+          RootRanges: [0xcda420..0xcda426]
       Variables:
         - Name: x
           Type: 7 BaseType int
           Locations:
-            - Range: 0xcd99e0..0xcd99e5
+            - Range: 0xcda420..0xcda425
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 104
+    - ID: 112
       Name: main.testInlinedSumArray
       OutOfLinePCRanges: []
       InlinePCRanges:
-        - Ranges: [0xcd9a25..0xcd9a3d]
-          RootRanges: [0xcd9a00..0xcd9a43]
-        - Ranges: [0xcd9ac5..0xcd9ae3]
-          RootRanges: [0xcd9a60..0xcd9be5]
+        - Ranges: [0xcda465..0xcda47d]
+          RootRanges: [0xcda440..0xcda483]
+        - Ranges: [0xcda505..0xcda523]
+          RootRanges: [0xcda4a0..0xcda625]
       Variables:
         - Name: a
-          Type: 63 ArrayType [5]int
+          Type: 86 ArrayType [5]int
           Locations:
-            - Range: 0xcd9a0d..0xcd9a43
+            - Range: 0xcda44d..0xcda483
               Pieces: [{Size: 40, Op: {CfaOffset: -56}}]
-            - Range: 0xcd9aac..0xcd9be5
+            - Range: 0xcda4ec..0xcda625
               Pieces: [{Size: 40, Op: {CfaOffset: -128}}]
           IsParameter: true
           IsReturn: false
 Types:
     - __kind: PointerType
-      ID: 277
+      ID: 63
+      Name: '**main.deepSlice2'
+      ByteSize: 8
+      Pointee: 64 PointerType *main.deepSlice2
+    - __kind: PointerType
+      ID: 309
+      Name: '**main.deepSlice3'
+      ByteSize: 8
+      Pointee: 310 PointerType *main.deepSlice3
+    - __kind: PointerType
+      ID: 334
+      Name: '**main.deepSlice8'
+      ByteSize: 8
+      Pointee: 335 PointerType *main.deepSlice8
+    - __kind: PointerType
+      ID: 340
+      Name: '**main.deepSlice9'
+      ByteSize: 8
+      Pointee: 341 PointerType *main.deepSlice9
+    - __kind: PointerType
+      ID: 77
+      Name: '**main.stringType2'
+      ByteSize: 8
+      GoKind: 22
+      Pointee: 78 PointerType *main.stringType2
+    - __kind: PointerType
+      ID: 402
       Name: '**main.t'
       ByteSize: 8
-      Pointee: 133 PointerType *main.t
+      Pointee: 156 PointerType *main.t
     - __kind: PointerType
       ID: 54
       Name: '**string'
       ByteSize: 8
-      GoRuntimeType: 525440
+      GoRuntimeType: 530560
       GoKind: 22
       Pointee: 22 PointerType *string
     - __kind: PointerType
-      ID: 126
+      ID: 149
       Name: '**table<[4]int,[4]int>'
       ByteSize: 8
-      Pointee: 127 PointerType *table<[4]int,[4]int>
+      Pointee: 150 PointerType *table<[4]int,[4]int>
     - __kind: PointerType
-      ID: 121
+      ID: 144
       Name: '**table<[4]int,uint8>'
       ByteSize: 8
-      Pointee: 122 PointerType *table<[4]int,uint8>
+      Pointee: 145 PointerType *table<[4]int,uint8>
     - __kind: PointerType
-      ID: 89
+      ID: 112
       Name: '**table<[4]string,[2]int>'
       ByteSize: 8
-      Pointee: 90 PointerType *table<[4]string,[2]int>
+      Pointee: 113 PointerType *table<[4]string,[2]int>
     - __kind: PointerType
-      ID: 101
+      ID: 124
       Name: '**table<bool,main.node>'
       ByteSize: 8
-      Pointee: 102 PointerType *table<bool,main.node>
+      Pointee: 125 PointerType *table<bool,main.node>
     - __kind: PointerType
-      ID: 69
+      ID: 71
+      Name: '**table<int,*main.deepMap2>'
+      ByteSize: 8
+      Pointee: 72 PointerType *table<int,*main.deepMap2>
+    - __kind: PointerType
+      ID: 317
+      Name: '**table<int,*main.deepMap3>'
+      ByteSize: 8
+      Pointee: 318 PointerType *table<int,*main.deepMap3>
+    - __kind: PointerType
+      ID: 352
+      Name: '**table<int,*main.deepMap8>'
+      ByteSize: 8
+      Pointee: 353 PointerType *table<int,*main.deepMap8>
+    - __kind: PointerType
+      ID: 367
+      Name: '**table<int,*main.deepMap9>'
+      ByteSize: 8
+      Pointee: 368 PointerType *table<int,*main.deepMap9>
+    - __kind: PointerType
+      ID: 92
       Name: '**table<int,int>'
       ByteSize: 8
-      Pointee: 70 PointerType *table<int,int>
+      Pointee: 93 PointerType *table<int,int>
     - __kind: PointerType
-      ID: 106
+      ID: 382
+      Name: '**table<int,interface {}>'
+      ByteSize: 8
+      Pointee: 383 PointerType *table<int,interface {}>
+    - __kind: PointerType
+      ID: 129
       Name: '**table<int,uint8>'
       ByteSize: 8
-      Pointee: 107 PointerType *table<int,uint8>
+      Pointee: 130 PointerType *table<int,uint8>
     - __kind: PointerType
-      ID: 96
+      ID: 119
       Name: '**table<string,[]main.structWithMap>'
       ByteSize: 8
-      Pointee: 97 PointerType *table<string,[]main.structWithMap>
+      Pointee: 120 PointerType *table<string,[]main.structWithMap>
     - __kind: PointerType
-      ID: 84
+      ID: 107
       Name: '**table<string,[]string>'
       ByteSize: 8
-      Pointee: 85 PointerType *table<string,[]string>
+      Pointee: 108 PointerType *table<string,[]string>
     - __kind: PointerType
-      ID: 79
+      ID: 102
       Name: '**table<string,int>'
       ByteSize: 8
-      Pointee: 80 PointerType *table<string,int>
+      Pointee: 103 PointerType *table<string,int>
     - __kind: PointerType
-      ID: 74
+      ID: 97
       Name: '**table<string,main.nestedStruct>'
       ByteSize: 8
-      Pointee: 75 PointerType *table<string,main.nestedStruct>
+      Pointee: 98 PointerType *table<string,main.nestedStruct>
     - __kind: PointerType
-      ID: 116
+      ID: 139
       Name: '**table<uint8,[4]int>'
       ByteSize: 8
-      Pointee: 117 PointerType *table<uint8,[4]int>
+      Pointee: 140 PointerType *table<uint8,[4]int>
     - __kind: PointerType
-      ID: 111
+      ID: 134
       Name: '**table<uint8,uint8>'
       ByteSize: 8
-      Pointee: 112 PointerType *table<uint8,uint8>
+      Pointee: 135 PointerType *table<uint8,uint8>
     - __kind: PointerType
-      ID: 154
+      ID: 180
+      Name: '*[]*main.deepSlice2.array'
+      ByteSize: 8
+      Pointee: 179 GoSliceDataType []*main.deepSlice2.array
+    - __kind: PointerType
+      ID: 313
+      Name: '*[]*main.deepSlice3.array'
+      ByteSize: 8
+      Pointee: 312 GoSliceDataType []*main.deepSlice3.array
+    - __kind: PointerType
+      ID: 338
+      Name: '*[]*main.deepSlice8.array'
+      ByteSize: 8
+      Pointee: 337 GoSliceDataType []*main.deepSlice8.array
+    - __kind: PointerType
+      ID: 344
+      Name: '*[]*main.deepSlice9.array'
+      ByteSize: 8
+      Pointee: 343 GoSliceDataType []*main.deepSlice9.array
+    - __kind: PointerType
+      ID: 177
       Name: '*[]*string.array'
       ByteSize: 8
-      Pointee: 153 GoSliceDataType []*string.array
+      Pointee: 176 GoSliceDataType []*string.array
     - __kind: PointerType
-      ID: 258
+      ID: 294
       Name: '*[][]uint.array'
       ByteSize: 8
-      Pointee: 257 GoSliceDataType [][]uint.array
+      Pointee: 293 GoSliceDataType [][]uint.array
     - __kind: PointerType
-      ID: 264
+      ID: 300
       Name: '*[]bool.array'
       ByteSize: 8
-      Pointee: 263 GoSliceDataType []bool.array
+      Pointee: 299 GoSliceDataType []bool.array
     - __kind: PointerType
-      ID: 281
+      ID: 348
+      Name: '*[]interface {}.array'
+      ByteSize: 8
+      Pointee: 347 GoSliceDataType []interface {}.array
+    - __kind: PointerType
+      ID: 406
       Name: '*[]main.structWithMap.array'
       ByteSize: 8
-      Pointee: 280 GoSliceDataType []main.structWithMap.array
+      Pointee: 405 GoSliceDataType []main.structWithMap.array
     - __kind: PointerType
-      ID: 260
+      ID: 296
       Name: '*[]main.structWithNoStrings.array'
       ByteSize: 8
-      Pointee: 259 GoSliceDataType []main.structWithNoStrings.array
+      Pointee: 295 GoSliceDataType []main.structWithNoStrings.array
     - __kind: PointerType
-      ID: 262
+      ID: 298
       Name: '*[]string.array'
       ByteSize: 8
-      Pointee: 261 GoSliceDataType []string.array
+      Pointee: 297 GoSliceDataType []string.array
     - __kind: PointerType
-      ID: 137
+      ID: 160
       Name: '*[]uint'
       ByteSize: 8
-      Pointee: 135 GoSliceHeaderType []uint
+      Pointee: 158 GoSliceHeaderType []uint
     - __kind: PointerType
-      ID: 256
+      ID: 292
       Name: '*[]uint.array'
       ByteSize: 8
-      Pointee: 255 GoSliceDataType []uint.array
+      Pointee: 291 GoSliceDataType []uint.array
     - __kind: PointerType
-      ID: 266
+      ID: 302
       Name: '*[]uint16.array'
       ByteSize: 8
-      Pointee: 265 GoSliceDataType []uint16.array
+      Pointee: 301 GoSliceDataType []uint16.array
     - __kind: PointerType
       ID: 11
       Name: '*bool'
       ByteSize: 8
-      GoRuntimeType: 388992
+      GoRuntimeType: 393024
       GoKind: 22
       Pointee: 4 BaseType bool
     - __kind: PointerType
       ID: 33
       Name: '*error'
       ByteSize: 8
-      GoRuntimeType: 387904
+      GoRuntimeType: 391936
       GoKind: 22
       Pointee: 13 GoInterfaceType error
     - __kind: PointerType
       ID: 35
       Name: '*float32'
       ByteSize: 8
-      GoRuntimeType: 388864
+      GoRuntimeType: 392896
       GoKind: 22
       Pointee: 18 BaseType float32
     - __kind: PointerType
       ID: 25
       Name: '*float64'
       ByteSize: 8
-      GoRuntimeType: 388928
+      GoRuntimeType: 392960
       GoKind: 22
       Pointee: 15 BaseType float64
     - __kind: PointerType
       ID: 26
       Name: '*int'
       ByteSize: 8
-      GoRuntimeType: 388544
+      GoRuntimeType: 392576
       GoKind: 22
       Pointee: 7 BaseType int
     - __kind: PointerType
       ID: 30
       Name: '*int16'
       ByteSize: 8
-      GoRuntimeType: 388160
+      GoRuntimeType: 392192
       GoKind: 22
       Pointee: 31 BaseType int16
     - __kind: PointerType
       ID: 20
       Name: '*int32'
       ByteSize: 8
-      GoRuntimeType: 388288
+      GoRuntimeType: 392320
       GoKind: 22
       Pointee: 10 BaseType int32
     - __kind: PointerType
       ID: 27
       Name: '*int64'
       ByteSize: 8
-      GoRuntimeType: 388416
+      GoRuntimeType: 392448
       GoKind: 22
       Pointee: 12 BaseType int64
     - __kind: PointerType
       ID: 32
       Name: '*int8'
       ByteSize: 8
-      GoRuntimeType: 388032
+      GoRuntimeType: 392064
       GoKind: 22
       Pointee: 16 BaseType int8
     - __kind: PointerType
-      ID: 61
+      ID: 346
+      Name: '*interface {}'
+      ByteSize: 8
+      GoRuntimeType: 393152
+      GoKind: 22
+      Pointee: 81 GoEmptyInterfaceType interface {}
+    - __kind: PointerType
+      ID: 187
+      Name: '*main.deepMap2'
+      ByteSize: 8
+      GoRuntimeType: 385792
+      GoKind: 22
+      Pointee: 188 StructureType main.deepMap2
+    - __kind: PointerType
+      ID: 325
+      Name: '*main.deepMap3'
+      ByteSize: 8
+      GoRuntimeType: 385728
+      GoKind: 22
+      Pointee: 326 UnresolvedPointeeType main.deepMap3
+    - __kind: PointerType
+      ID: 73
+      Name: '*main.deepMap7'
+      ByteSize: 8
+      GoRuntimeType: 385472
+      GoKind: 22
+      Pointee: 74 StructureType main.deepMap7
+    - __kind: PointerType
+      ID: 360
+      Name: '*main.deepMap8'
+      ByteSize: 8
+      GoRuntimeType: 385408
+      GoKind: 22
+      Pointee: 361 StructureType main.deepMap8
+    - __kind: PointerType
+      ID: 375
+      Name: '*main.deepMap9'
+      ByteSize: 8
+      GoRuntimeType: 385344
+      GoKind: 22
+      Pointee: 376 StructureType main.deepMap9
+    - __kind: PointerType
+      ID: 57
+      Name: '*main.deepPtr2'
+      ByteSize: 8
+      GoRuntimeType: 386368
+      GoKind: 22
+      Pointee: 58 StructureType main.deepPtr2
+    - __kind: PointerType
+      ID: 303
+      Name: '*main.deepPtr3'
+      ByteSize: 8
+      GoRuntimeType: 386304
+      GoKind: 22
+      Pointee: 304 UnresolvedPointeeType main.deepPtr3
+    - __kind: PointerType
+      ID: 59
+      Name: '*main.deepPtr7'
+      ByteSize: 8
+      GoRuntimeType: 386048
+      GoKind: 22
+      Pointee: 60 StructureType main.deepPtr7
+    - __kind: PointerType
+      ID: 329
+      Name: '*main.deepPtr8'
+      ByteSize: 8
+      GoRuntimeType: 385984
+      GoKind: 22
+      Pointee: 330 StructureType main.deepPtr8
+    - __kind: PointerType
+      ID: 331
+      Name: '*main.deepPtr9'
+      ByteSize: 8
+      GoRuntimeType: 385920
+      GoKind: 22
+      Pointee: 332 StructureType main.deepPtr9
+    - __kind: PointerType
+      ID: 64
+      Name: '*main.deepSlice2'
+      ByteSize: 8
+      GoRuntimeType: 386944
+      GoKind: 22
+      Pointee: 178 StructureType main.deepSlice2
+    - __kind: PointerType
+      ID: 310
+      Name: '*main.deepSlice3'
+      ByteSize: 8
+      GoRuntimeType: 386880
+      GoKind: 22
+      Pointee: 311 UnresolvedPointeeType main.deepSlice3
+    - __kind: PointerType
+      ID: 65
+      Name: '*main.deepSlice7'
+      ByteSize: 8
+      GoRuntimeType: 386624
+      GoKind: 22
+      Pointee: 66 StructureType main.deepSlice7
+    - __kind: PointerType
+      ID: 335
+      Name: '*main.deepSlice8'
+      ByteSize: 8
+      GoRuntimeType: 386560
+      GoKind: 22
+      Pointee: 336 StructureType main.deepSlice8
+    - __kind: PointerType
+      ID: 341
+      Name: '*main.deepSlice9'
+      ByteSize: 8
+      GoRuntimeType: 386496
+      GoKind: 22
+      Pointee: 342 StructureType main.deepSlice9
+    - __kind: PointerType
+      ID: 84
       Name: '*main.esotericHeap'
       ByteSize: 8
-      GoRuntimeType: 383040
+      GoRuntimeType: 387072
       GoKind: 22
-      Pointee: 62 StructureType main.esotericHeap
+      Pointee: 85 StructureType main.esotericHeap
     - __kind: PointerType
-      ID: 132
+      ID: 155
       Name: '*main.node'
       ByteSize: 8
-      GoRuntimeType: 383104
+      GoRuntimeType: 387136
       GoKind: 22
-      Pointee: 131 StructureType main.node
+      Pointee: 154 StructureType main.node
     - __kind: PointerType
-      ID: 146
+      ID: 169
       Name: '*main.oneStringStruct'
       ByteSize: 8
       GoKind: 22
-      Pointee: 147 StructureType main.oneStringStruct
+      Pointee: 170 StructureType main.oneStringStruct
     - __kind: PointerType
-      ID: 203
+      ID: 75
+      Name: '*main.stringType1'
+      ByteSize: 8
+      GoKind: 22
+      Pointee: 76 GoStringHeaderType main.stringType1
+    - __kind: PointerType
+      ID: 306
+      Name: '*main.stringType1.str'
+      ByteSize: 8
+      Pointee: 305 GoStringDataType main.stringType1.str
+    - __kind: PointerType
+      ID: 78
+      Name: '*main.stringType2'
+      ByteSize: 8
+      GoKind: 22
+      Pointee: 307 UnresolvedPointeeType main.stringType2
+    - __kind: PointerType
+      ID: 239
       Name: '*main.structWithMap'
       ByteSize: 8
-      GoRuntimeType: 382976
+      GoRuntimeType: 385280
       GoKind: 22
-      Pointee: 65 StructureType main.structWithMap
+      Pointee: 88 StructureType main.structWithMap
     - __kind: PointerType
-      ID: 139
+      ID: 162
       Name: '*main.structWithNoStrings'
       ByteSize: 8
-      Pointee: 140 StructureType main.structWithNoStrings
+      Pointee: 163 StructureType main.structWithNoStrings
     - __kind: PointerType
-      ID: 129
+      ID: 152
       Name: '*main.structWithTwoValues'
       ByteSize: 8
       GoKind: 22
-      Pointee: 130 StructureType main.structWithTwoValues
+      Pointee: 153 StructureType main.structWithTwoValues
     - __kind: PointerType
-      ID: 133
+      ID: 156
       Name: '*main.t'
       ByteSize: 8
       GoKind: 22
-      Pointee: 134 GoSliceHeaderType main.t
+      Pointee: 157 GoSliceHeaderType main.t
     - __kind: PointerType
-      ID: 279
+      ID: 404
       Name: '*main.t.array'
       ByteSize: 8
-      Pointee: 278 GoSliceDataType main.t.array
+      Pointee: 403 GoSliceDataType main.t.array
     - __kind: PointerType
-      ID: 145
+      ID: 168
       Name: '*main.threeStringStruct'
       ByteSize: 8
       GoKind: 22
-      Pointee: 144 StructureType main.threeStringStruct
+      Pointee: 167 StructureType main.threeStringStruct
     - __kind: PointerType
-      ID: 124
+      ID: 147
       Name: '*map<[4]int,[4]int>'
       ByteSize: 8
-      Pointee: 125 GoSwissMapHeaderType map<[4]int,[4]int>
+      Pointee: 148 GoSwissMapHeaderType map<[4]int,[4]int>
     - __kind: PointerType
-      ID: 119
+      ID: 142
       Name: '*map<[4]int,uint8>'
       ByteSize: 8
-      Pointee: 120 GoSwissMapHeaderType map<[4]int,uint8>
+      Pointee: 143 GoSwissMapHeaderType map<[4]int,uint8>
     - __kind: PointerType
-      ID: 87
+      ID: 110
       Name: '*map<[4]string,[2]int>'
       ByteSize: 8
-      Pointee: 88 GoSwissMapHeaderType map<[4]string,[2]int>
+      Pointee: 111 GoSwissMapHeaderType map<[4]string,[2]int>
     - __kind: PointerType
-      ID: 99
+      ID: 122
       Name: '*map<bool,main.node>'
       ByteSize: 8
-      Pointee: 100 GoSwissMapHeaderType map<bool,main.node>
+      Pointee: 123 GoSwissMapHeaderType map<bool,main.node>
     - __kind: PointerType
-      ID: 67
+      ID: 69
+      Name: '*map<int,*main.deepMap2>'
+      ByteSize: 8
+      Pointee: 70 GoSwissMapHeaderType map<int,*main.deepMap2>
+    - __kind: PointerType
+      ID: 315
+      Name: '*map<int,*main.deepMap3>'
+      ByteSize: 8
+      Pointee: 316 GoSwissMapHeaderType map<int,*main.deepMap3>
+    - __kind: PointerType
+      ID: 350
+      Name: '*map<int,*main.deepMap8>'
+      ByteSize: 8
+      Pointee: 351 GoSwissMapHeaderType map<int,*main.deepMap8>
+    - __kind: PointerType
+      ID: 365
+      Name: '*map<int,*main.deepMap9>'
+      ByteSize: 8
+      Pointee: 366 GoSwissMapHeaderType map<int,*main.deepMap9>
+    - __kind: PointerType
+      ID: 90
       Name: '*map<int,int>'
       ByteSize: 8
-      Pointee: 68 GoSwissMapHeaderType map<int,int>
+      Pointee: 91 GoSwissMapHeaderType map<int,int>
     - __kind: PointerType
-      ID: 104
+      ID: 380
+      Name: '*map<int,interface {}>'
+      ByteSize: 8
+      Pointee: 381 GoSwissMapHeaderType map<int,interface {}>
+    - __kind: PointerType
+      ID: 127
       Name: '*map<int,uint8>'
       ByteSize: 8
-      Pointee: 105 GoSwissMapHeaderType map<int,uint8>
+      Pointee: 128 GoSwissMapHeaderType map<int,uint8>
     - __kind: PointerType
-      ID: 94
+      ID: 117
       Name: '*map<string,[]main.structWithMap>'
       ByteSize: 8
-      Pointee: 95 GoSwissMapHeaderType map<string,[]main.structWithMap>
+      Pointee: 118 GoSwissMapHeaderType map<string,[]main.structWithMap>
     - __kind: PointerType
-      ID: 82
+      ID: 105
       Name: '*map<string,[]string>'
       ByteSize: 8
-      Pointee: 83 GoSwissMapHeaderType map<string,[]string>
+      Pointee: 106 GoSwissMapHeaderType map<string,[]string>
     - __kind: PointerType
-      ID: 77
+      ID: 100
       Name: '*map<string,int>'
       ByteSize: 8
-      Pointee: 78 GoSwissMapHeaderType map<string,int>
+      Pointee: 101 GoSwissMapHeaderType map<string,int>
     - __kind: PointerType
-      ID: 72
+      ID: 95
       Name: '*map<string,main.nestedStruct>'
       ByteSize: 8
-      Pointee: 73 GoSwissMapHeaderType map<string,main.nestedStruct>
+      Pointee: 96 GoSwissMapHeaderType map<string,main.nestedStruct>
     - __kind: PointerType
-      ID: 114
+      ID: 137
       Name: '*map<uint8,[4]int>'
       ByteSize: 8
-      Pointee: 115 GoSwissMapHeaderType map<uint8,[4]int>
+      Pointee: 138 GoSwissMapHeaderType map<uint8,[4]int>
     - __kind: PointerType
-      ID: 109
+      ID: 132
       Name: '*map<uint8,uint8>'
       ByteSize: 8
-      Pointee: 110 GoSwissMapHeaderType map<uint8,uint8>
+      Pointee: 133 GoSwissMapHeaderType map<uint8,uint8>
     - __kind: PointerType
-      ID: 92
+      ID: 115
       Name: '*map[string]int'
       ByteSize: 8
       GoKind: 22
-      Pointee: 76 GoMapType map[string]int
+      Pointee: 99 GoMapType map[string]int
     - __kind: PointerType
-      ID: 249
+      ID: 285
       Name: '*noalg.map.group[[4]int][4]int'
       ByteSize: 8
-      Pointee: 250 StructureType noalg.map.group[[4]int][4]int
+      Pointee: 286 StructureType noalg.map.group[[4]int][4]int
     - __kind: PointerType
-      ID: 241
+      ID: 277
       Name: '*noalg.map.group[[4]int]uint8'
       ByteSize: 8
-      Pointee: 242 StructureType noalg.map.group[[4]int]uint8
+      Pointee: 278 StructureType noalg.map.group[[4]int]uint8
     - __kind: PointerType
-      ID: 189
+      ID: 225
       Name: '*noalg.map.group[[4]string][2]int'
       ByteSize: 8
-      Pointee: 190 StructureType noalg.map.group[[4]string][2]int
+      Pointee: 226 StructureType noalg.map.group[[4]string][2]int
     - __kind: PointerType
-      ID: 208
+      ID: 244
       Name: '*noalg.map.group[bool]main.node'
       ByteSize: 8
-      Pointee: 209 StructureType noalg.map.group[bool]main.node
+      Pointee: 245 StructureType noalg.map.group[bool]main.node
     - __kind: PointerType
-      ID: 157
+      ID: 183
+      Name: '*noalg.map.group[int]*main.deepMap2'
+      ByteSize: 8
+      Pointee: 184 StructureType noalg.map.group[int]*main.deepMap2
+    - __kind: PointerType
+      ID: 321
+      Name: '*noalg.map.group[int]*main.deepMap3'
+      ByteSize: 8
+      Pointee: 322 StructureType noalg.map.group[int]*main.deepMap3
+    - __kind: PointerType
+      ID: 356
+      Name: '*noalg.map.group[int]*main.deepMap8'
+      ByteSize: 8
+      Pointee: 357 StructureType noalg.map.group[int]*main.deepMap8
+    - __kind: PointerType
+      ID: 371
+      Name: '*noalg.map.group[int]*main.deepMap9'
+      ByteSize: 8
+      Pointee: 372 StructureType noalg.map.group[int]*main.deepMap9
+    - __kind: PointerType
+      ID: 193
       Name: '*noalg.map.group[int]int'
       ByteSize: 8
-      Pointee: 158 StructureType noalg.map.group[int]int
+      Pointee: 194 StructureType noalg.map.group[int]int
     - __kind: PointerType
-      ID: 216
+      ID: 386
+      Name: '*noalg.map.group[int]interface {}'
+      ByteSize: 8
+      Pointee: 387 StructureType noalg.map.group[int]interface {}
+    - __kind: PointerType
+      ID: 252
       Name: '*noalg.map.group[int]uint8'
       ByteSize: 8
-      Pointee: 217 StructureType noalg.map.group[int]uint8
+      Pointee: 253 StructureType noalg.map.group[int]uint8
     - __kind: PointerType
-      ID: 198
+      ID: 234
       Name: '*noalg.map.group[string][]main.structWithMap'
       ByteSize: 8
-      Pointee: 199 StructureType noalg.map.group[string][]main.structWithMap
+      Pointee: 235 StructureType noalg.map.group[string][]main.structWithMap
     - __kind: PointerType
-      ID: 181
+      ID: 217
       Name: '*noalg.map.group[string][]string'
       ByteSize: 8
-      Pointee: 182 StructureType noalg.map.group[string][]string
+      Pointee: 218 StructureType noalg.map.group[string][]string
     - __kind: PointerType
-      ID: 173
+      ID: 209
       Name: '*noalg.map.group[string]int'
       ByteSize: 8
-      Pointee: 174 StructureType noalg.map.group[string]int
+      Pointee: 210 StructureType noalg.map.group[string]int
     - __kind: PointerType
-      ID: 165
+      ID: 201
       Name: '*noalg.map.group[string]main.nestedStruct'
       ByteSize: 8
-      Pointee: 166 StructureType noalg.map.group[string]main.nestedStruct
+      Pointee: 202 StructureType noalg.map.group[string]main.nestedStruct
     - __kind: PointerType
-      ID: 232
+      ID: 268
       Name: '*noalg.map.group[uint8][4]int'
       ByteSize: 8
-      Pointee: 233 StructureType noalg.map.group[uint8][4]int
+      Pointee: 269 StructureType noalg.map.group[uint8][4]int
     - __kind: PointerType
-      ID: 224
+      ID: 260
       Name: '*noalg.map.group[uint8]uint8'
       ByteSize: 8
-      Pointee: 225 StructureType noalg.map.group[uint8]uint8
+      Pointee: 261 StructureType noalg.map.group[uint8]uint8
     - __kind: PointerType
       ID: 22
       Name: '*string'
       ByteSize: 8
-      GoRuntimeType: 387968
+      GoRuntimeType: 392000
       GoKind: 22
       Pointee: 9 GoStringHeaderType string
     - __kind: PointerType
-      ID: 152
+      ID: 175
       Name: '*string.str'
       ByteSize: 8
-      Pointee: 151 GoStringDataType string.str
+      Pointee: 174 GoStringDataType string.str
     - __kind: PointerType
-      ID: 127
+      ID: 150
       Name: '*table<[4]int,[4]int>'
       ByteSize: 8
-      Pointee: 247 StructureType table<[4]int,[4]int>
+      Pointee: 283 StructureType table<[4]int,[4]int>
     - __kind: PointerType
-      ID: 122
+      ID: 145
       Name: '*table<[4]int,uint8>'
       ByteSize: 8
-      Pointee: 239 StructureType table<[4]int,uint8>
+      Pointee: 275 StructureType table<[4]int,uint8>
     - __kind: PointerType
-      ID: 90
+      ID: 113
       Name: '*table<[4]string,[2]int>'
       ByteSize: 8
-      Pointee: 187 StructureType table<[4]string,[2]int>
+      Pointee: 223 StructureType table<[4]string,[2]int>
     - __kind: PointerType
-      ID: 102
+      ID: 125
       Name: '*table<bool,main.node>'
       ByteSize: 8
-      Pointee: 206 StructureType table<bool,main.node>
+      Pointee: 242 StructureType table<bool,main.node>
     - __kind: PointerType
-      ID: 70
+      ID: 72
+      Name: '*table<int,*main.deepMap2>'
+      ByteSize: 8
+      Pointee: 181 StructureType table<int,*main.deepMap2>
+    - __kind: PointerType
+      ID: 318
+      Name: '*table<int,*main.deepMap3>'
+      ByteSize: 8
+      Pointee: 319 StructureType table<int,*main.deepMap3>
+    - __kind: PointerType
+      ID: 353
+      Name: '*table<int,*main.deepMap8>'
+      ByteSize: 8
+      Pointee: 354 StructureType table<int,*main.deepMap8>
+    - __kind: PointerType
+      ID: 368
+      Name: '*table<int,*main.deepMap9>'
+      ByteSize: 8
+      Pointee: 369 StructureType table<int,*main.deepMap9>
+    - __kind: PointerType
+      ID: 93
       Name: '*table<int,int>'
       ByteSize: 8
-      Pointee: 155 StructureType table<int,int>
+      Pointee: 191 StructureType table<int,int>
     - __kind: PointerType
-      ID: 107
+      ID: 383
+      Name: '*table<int,interface {}>'
+      ByteSize: 8
+      Pointee: 384 StructureType table<int,interface {}>
+    - __kind: PointerType
+      ID: 130
       Name: '*table<int,uint8>'
       ByteSize: 8
-      Pointee: 214 StructureType table<int,uint8>
+      Pointee: 250 StructureType table<int,uint8>
     - __kind: PointerType
-      ID: 97
+      ID: 120
       Name: '*table<string,[]main.structWithMap>'
       ByteSize: 8
-      Pointee: 196 StructureType table<string,[]main.structWithMap>
+      Pointee: 232 StructureType table<string,[]main.structWithMap>
     - __kind: PointerType
-      ID: 85
+      ID: 108
       Name: '*table<string,[]string>'
       ByteSize: 8
-      Pointee: 179 StructureType table<string,[]string>
+      Pointee: 215 StructureType table<string,[]string>
     - __kind: PointerType
-      ID: 80
+      ID: 103
       Name: '*table<string,int>'
       ByteSize: 8
-      Pointee: 171 StructureType table<string,int>
+      Pointee: 207 StructureType table<string,int>
     - __kind: PointerType
-      ID: 75
+      ID: 98
       Name: '*table<string,main.nestedStruct>'
       ByteSize: 8
-      Pointee: 163 StructureType table<string,main.nestedStruct>
+      Pointee: 199 StructureType table<string,main.nestedStruct>
     - __kind: PointerType
-      ID: 117
+      ID: 140
       Name: '*table<uint8,[4]int>'
       ByteSize: 8
-      Pointee: 230 StructureType table<uint8,[4]int>
+      Pointee: 266 StructureType table<uint8,[4]int>
     - __kind: PointerType
-      ID: 112
+      ID: 135
       Name: '*table<uint8,uint8>'
       ByteSize: 8
-      Pointee: 222 StructureType table<uint8,uint8>
+      Pointee: 258 StructureType table<uint8,uint8>
     - __kind: PointerType
       ID: 34
       Name: '*uint'
       ByteSize: 8
-      GoRuntimeType: 388608
+      GoRuntimeType: 392640
       GoKind: 22
       Pointee: 17 BaseType uint
     - __kind: PointerType
       ID: 29
       Name: '*uint16'
       ByteSize: 8
-      GoRuntimeType: 388224
+      GoRuntimeType: 392256
       GoKind: 22
       Pointee: 6 BaseType uint16
     - __kind: PointerType
       ID: 21
       Name: '*uint32'
       ByteSize: 8
-      GoRuntimeType: 388352
+      GoRuntimeType: 392384
       GoKind: 22
       Pointee: 2 BaseType uint32
     - __kind: PointerType
       ID: 28
       Name: '*uint64'
       ByteSize: 8
-      GoRuntimeType: 388480
+      GoRuntimeType: 392512
       GoKind: 22
       Pointee: 8 BaseType uint64
     - __kind: PointerType
       ID: 5
       Name: '*uint8'
       ByteSize: 8
-      GoRuntimeType: 388096
+      GoRuntimeType: 392128
       GoKind: 22
       Pointee: 3 BaseType uint8
     - __kind: PointerType
       ID: 19
       Name: '*uintptr'
       ByteSize: 8
-      GoRuntimeType: 388672
+      GoRuntimeType: 392704
       GoKind: 22
       Pointee: 1 BaseType uintptr
     - __kind: EventRootType
-      ID: 369
+      ID: 502
       Name: Probe[main.stackC]
     - __kind: EventRootType
-      ID: 326
+      ID: 459
       Name: Probe[main.testAny]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -3581,14 +4099,14 @@ Types:
         - Name: a
           Offset: 1
           Expression:
-            Type: 58 GoEmptyInterfaceType interface {}
+            Type: 81 GoEmptyInterfaceType interface {}
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 45, index: 0, name: a}
+                  Variable: {subprogram: 53, index: 0, name: a}
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 298
+      ID: 423
       Name: Probe[main.testArrayOfArraysOfArrays]
       ByteSize: 65
       PresenceBitsetSize: 1
@@ -3603,7 +4121,7 @@ Types:
                   Offset: 0
                   ByteSize: 64
     - __kind: EventRootType
-      ID: 296
+      ID: 421
       Name: Probe[main.testArrayOfArrays]
       ByteSize: 33
       PresenceBitsetSize: 1
@@ -3618,7 +4136,7 @@ Types:
                   Offset: 0
                   ByteSize: 32
     - __kind: EventRootType
-      ID: 334
+      ID: 467
       Name: Probe[main.testArrayOfMaps]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -3626,14 +4144,14 @@ Types:
         - Name: m
           Offset: 1
           Expression:
-            Type: 91 ArrayType [2]map[string]int
+            Type: 114 ArrayType [2]map[string]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 53, index: 0, name: m}
+                  Variable: {subprogram: 61, index: 0, name: m}
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 297
+      ID: 422
       Name: Probe[main.testArrayOfStrings]
       ByteSize: 33
       PresenceBitsetSize: 1
@@ -3648,7 +4166,7 @@ Types:
                   Offset: 0
                   ByteSize: 32
     - __kind: EventRootType
-      ID: 316
+      ID: 441
       Name: Probe[main.testBigStruct]
       ByteSize: 49
       PresenceBitsetSize: 1
@@ -3663,7 +4181,7 @@ Types:
                   Offset: 0
                   ByteSize: 48
     - __kind: EventRootType
-      ID: 285
+      ID: 410
       Name: Probe[main.testBoolArray]
       ByteSize: 3
       PresenceBitsetSize: 1
@@ -3678,7 +4196,7 @@ Types:
                   Offset: 0
                   ByteSize: 2
     - __kind: EventRootType
-      ID: 282
+      ID: 407
       Name: Probe[main.testByteArray]
       ByteSize: 3
       PresenceBitsetSize: 1
@@ -3693,7 +4211,7 @@ Types:
                   Offset: 0
                   ByteSize: 2
     - __kind: EventRootType
-      ID: 350
+      ID: 483
       Name: Probe[main.testChannel]
       ByteSize: 1
       PresenceBitsetSize: 1
@@ -3701,14 +4219,14 @@ Types:
         - Name: c
           Offset: 1
           Expression:
-            Type: 128 GoChannelType chan bool
+            Type: 151 GoChannelType chan bool
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 69, index: 0, name: c}
+                  Variable: {subprogram: 77, index: 0, name: c}
                   Offset: 0
                   ByteSize: 0
     - __kind: EventRootType
-      ID: 348
+      ID: 481
       Name: Probe[main.testCombinedByte]
       ByteSize: 7
       PresenceBitsetSize: 1
@@ -3719,7 +4237,7 @@ Types:
             Type: 3 BaseType uint8
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 67, index: 0, name: w}
+                  Variable: {subprogram: 75, index: 0, name: w}
                   Offset: 0
                   ByteSize: 1
         - Name: x
@@ -3728,7 +4246,7 @@ Types:
             Type: 3 BaseType uint8
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 67, index: 1, name: x}
+                  Variable: {subprogram: 75, index: 1, name: x}
                   Offset: 0
                   ByteSize: 1
         - Name: y
@@ -3737,11 +4255,11 @@ Types:
             Type: 18 BaseType float32
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 67, index: 2, name: y}
+                  Variable: {subprogram: 75, index: 2, name: y}
                   Offset: 0
                   ByteSize: 4
     - __kind: EventRootType
-      ID: 358
+      ID: 491
       Name: Probe[main.testCycle]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -3749,14 +4267,104 @@ Types:
         - Name: t
           Offset: 1
           Expression:
-            Type: 133 PointerType *main.t
+            Type: 156 PointerType *main.t
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 77, index: 0, name: t}
+                  Variable: {subprogram: 85, index: 0, name: t}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 363
+      ID: 446
+      Name: Probe[main.testDeepMap1]
+      ByteSize: 9
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: a
+          Offset: 1
+          Expression:
+            Type: 67 StructureType main.deepMap1
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 40, index: 0, name: a}
+                  Offset: 0
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 447
+      Name: Probe[main.testDeepMap7]
+      ByteSize: 9
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: a
+          Offset: 1
+          Expression:
+            Type: 73 PointerType *main.deepMap7
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 41, index: 0, name: a}
+                  Offset: 0
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 442
+      Name: Probe[main.testDeepPtr1]
+      ByteSize: 9
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: a
+          Offset: 1
+          Expression:
+            Type: 56 StructureType main.deepPtr1
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 36, index: 0, name: a}
+                  Offset: 0
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 443
+      Name: Probe[main.testDeepPtr7]
+      ByteSize: 9
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: a
+          Offset: 1
+          Expression:
+            Type: 59 PointerType *main.deepPtr7
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 37, index: 0, name: a}
+                  Offset: 0
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 444
+      Name: Probe[main.testDeepSlice1]
+      ByteSize: 25
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: a
+          Offset: 1
+          Expression:
+            Type: 61 StructureType main.deepSlice1
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 38, index: 0, name: a}
+                  Offset: 0
+                  ByteSize: 24
+    - __kind: EventRootType
+      ID: 445
+      Name: Probe[main.testDeepSlice7]
+      ByteSize: 9
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: a
+          Offset: 1
+          Expression:
+            Type: 65 PointerType *main.deepSlice7
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 39, index: 0, name: a}
+                  Offset: 0
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 496
       Name: Probe[main.testEmptySliceOfStructs]
       ByteSize: 33
       PresenceBitsetSize: 1
@@ -3764,10 +4372,10 @@ Types:
         - Name: xs
           Offset: 1
           Expression:
-            Type: 138 GoSliceHeaderType []main.structWithNoStrings
+            Type: 161 GoSliceHeaderType []main.structWithNoStrings
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 82, index: 0, name: xs}
+                  Variable: {subprogram: 90, index: 0, name: xs}
                   Offset: 0
                   ByteSize: 24
         - Name: a
@@ -3776,11 +4384,11 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 82, index: 1, name: a}
+                  Variable: {subprogram: 90, index: 1, name: a}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 360
+      ID: 493
       Name: Probe[main.testEmptySlice]
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -3788,14 +4396,14 @@ Types:
         - Name: u
           Offset: 1
           Expression:
-            Type: 135 GoSliceHeaderType []uint
+            Type: 158 GoSliceHeaderType []uint
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 79, index: 0, name: u}
+                  Variable: {subprogram: 87, index: 0, name: u}
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 377
+      ID: 510
       Name: Probe[main.testEmptyString]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -3806,11 +4414,11 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 96, index: 0, name: x}
+                  Variable: {subprogram: 104, index: 0, name: x}
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 379
+      ID: 512
       Name: Probe[main.testEmptyStruct]
       ByteSize: 1
       PresenceBitsetSize: 1
@@ -3818,14 +4426,14 @@ Types:
         - Name: e
           Offset: 1
           Expression:
-            Type: 150 StructureType main.emptyStruct
+            Type: 173 StructureType main.emptyStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 98, index: 0, name: e}
+                  Variable: {subprogram: 106, index: 0, name: e}
                   Offset: 0
                   ByteSize: 0
     - __kind: EventRootType
-      ID: 327
+      ID: 460
       Name: Probe[main.testError]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -3836,11 +4444,11 @@ Types:
             Type: 13 GoInterfaceType error
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 46, index: 0, name: e}
+                  Variable: {subprogram: 54, index: 0, name: e}
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 318
+      ID: 451
       Name: Probe[main.testEsotericHeap]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -3848,14 +4456,14 @@ Types:
         - Name: e
           Offset: 1
           Expression:
-            Type: 61 PointerType *main.esotericHeap
+            Type: 84 PointerType *main.esotericHeap
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 37, index: 0, name: e}
+                  Variable: {subprogram: 45, index: 0, name: e}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 317
+      ID: 450
       Name: Probe[main.testEsotericStack]
       ByteSize: 65
       PresenceBitsetSize: 1
@@ -3863,14 +4471,14 @@ Types:
         - Name: e
           Offset: 1
           Expression:
-            Type: 56 StructureType main.esotericStack
+            Type: 79 StructureType main.esotericStack
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 36, index: 0, name: e}
+                  Variable: {subprogram: 44, index: 0, name: e}
                   Offset: 0
                   ByteSize: 64
     - __kind: EventRootType
-      ID: 324
+      ID: 457
       Name: Probe[main.testFramelessArray]
       ByteSize: 41
       PresenceBitsetSize: 1
@@ -3878,14 +4486,14 @@ Types:
         - Name: a
           Offset: 1
           Expression:
-            Type: 63 ArrayType [5]int
+            Type: 86 ArrayType [5]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 43, index: 0, name: a}
+                  Variable: {subprogram: 51, index: 0, name: a}
                   Offset: 0
                   ByteSize: 40
     - __kind: EventRootType
-      ID: 323
+      ID: 456
       Name: Probe[main.testFrameless]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -3896,11 +4504,11 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 42, index: 0, name: x}
+                  Variable: {subprogram: 50, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 319
+      ID: 452
       Name: Probe[main.testInlinedBA]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -3911,11 +4519,11 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 38, index: 0, name: x}
+                  Variable: {subprogram: 46, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 321
+      ID: 454
       Name: Probe[main.testInlinedBBA]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -3926,14 +4534,14 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 40, index: 0, name: x}
+                  Variable: {subprogram: 48, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 381
+      ID: 514
       Name: Probe[main.testInlinedBBB]
     - __kind: EventRootType
-      ID: 320
+      ID: 453
       Name: Probe[main.testInlinedBB]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -3944,7 +4552,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 39, index: 0, name: x}
+                  Variable: {subprogram: 47, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
         - Name: y
@@ -3953,20 +4561,20 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 39, index: 1, name: y}
+                  Variable: {subprogram: 47, index: 1, name: y}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 382
+      ID: 515
       Name: Probe[main.testInlinedBCA]
     - __kind: EventRootType
-      ID: 383
+      ID: 516
       Name: Probe[main.testInlinedBCB]
     - __kind: EventRootType
-      ID: 322
+      ID: 455
       Name: Probe[main.testInlinedBC]
     - __kind: EventRootType
-      ID: 380
+      ID: 513
       Name: Probe[main.testInlinedPrint]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -3977,11 +4585,11 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 99, index: 0, name: x}
+                  Variable: {subprogram: 107, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 384
+      ID: 517
       Name: Probe[main.testInlinedSq]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -3992,11 +4600,11 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 103, index: 0, name: x}
+                  Variable: {subprogram: 111, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 385
+      ID: 518
       Name: Probe[main.testInlinedSumArray]
       ByteSize: 41
       PresenceBitsetSize: 1
@@ -4004,14 +4612,14 @@ Types:
         - Name: a
           Offset: 1
           Expression:
-            Type: 63 ArrayType [5]int
+            Type: 86 ArrayType [5]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 104, index: 0, name: a}
+                  Variable: {subprogram: 112, index: 0, name: a}
                   Offset: 0
                   ByteSize: 40
     - __kind: EventRootType
-      ID: 288
+      ID: 413
       Name: Probe[main.testInt16Array]
       ByteSize: 5
       PresenceBitsetSize: 1
@@ -4026,7 +4634,7 @@ Types:
                   Offset: 0
                   ByteSize: 4
     - __kind: EventRootType
-      ID: 289
+      ID: 414
       Name: Probe[main.testInt32Array]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -4041,7 +4649,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 290
+      ID: 415
       Name: Probe[main.testInt64Array]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -4056,7 +4664,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 287
+      ID: 412
       Name: Probe[main.testInt8Array]
       ByteSize: 3
       PresenceBitsetSize: 1
@@ -4071,7 +4679,7 @@ Types:
                   Offset: 0
                   ByteSize: 2
     - __kind: EventRootType
-      ID: 286
+      ID: 411
       Name: Probe[main.testIntArray]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -4086,7 +4694,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 325
+      ID: 458
       Name: Probe[main.testInterface]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -4094,14 +4702,14 @@ Types:
         - Name: b
           Offset: 1
           Expression:
-            Type: 64 GoInterfaceType main.behavior
+            Type: 87 GoInterfaceType main.behavior
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 44, index: 0, name: b}
+                  Variable: {subprogram: 52, index: 0, name: b}
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 352
+      ID: 485
       Name: Probe[main.testLinkedList]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -4109,14 +4717,14 @@ Types:
         - Name: a
           Offset: 1
           Expression:
-            Type: 131 StructureType main.node
+            Type: 154 StructureType main.node
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 71, index: 0, name: a}
+                  Variable: {subprogram: 79, index: 0, name: a}
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 332
+      ID: 465
       Name: Probe[main.testMapArrayToArray]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -4124,14 +4732,14 @@ Types:
         - Name: m
           Offset: 1
           Expression:
-            Type: 86 GoMapType map[[4]string][2]int
+            Type: 109 GoMapType map[[4]string][2]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 51, index: 0, name: m}
+                  Variable: {subprogram: 59, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 338
+      ID: 471
       Name: Probe[main.testMapEmbeddedMaps]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -4139,14 +4747,14 @@ Types:
         - Name: m
           Offset: 1
           Expression:
-            Type: 93 GoMapType map[string][]main.structWithMap
+            Type: 116 GoMapType map[string][]main.structWithMap
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 57, index: 0, name: m}
+                  Variable: {subprogram: 65, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 336
+      ID: 469
       Name: Probe[main.testMapIntToInt]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -4154,14 +4762,14 @@ Types:
         - Name: m
           Offset: 1
           Expression:
-            Type: 66 GoMapType map[int]int
+            Type: 89 GoMapType map[int]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 55, index: 0, name: m}
+                  Variable: {subprogram: 63, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 347
+      ID: 480
       Name: Probe[main.testMapLargeKeyLargeValue]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -4169,14 +4777,14 @@ Types:
         - Name: m
           Offset: 1
           Expression:
-            Type: 123 GoMapType map[[4]int][4]int
+            Type: 146 GoMapType map[[4]int][4]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 66, index: 0, name: m}
+                  Variable: {subprogram: 74, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 346
+      ID: 479
       Name: Probe[main.testMapLargeKeySmallValue]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -4184,14 +4792,14 @@ Types:
         - Name: m
           Offset: 1
           Expression:
-            Type: 118 GoMapType map[[4]int]uint8
+            Type: 141 GoMapType map[[4]int]uint8
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 65, index: 0, name: m}
+                  Variable: {subprogram: 73, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 337
+      ID: 470
       Name: Probe[main.testMapMassive]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -4199,14 +4807,14 @@ Types:
         - Name: redactMyEntries
           Offset: 1
           Expression:
-            Type: 93 GoMapType map[string][]main.structWithMap
+            Type: 116 GoMapType map[string][]main.structWithMap
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 56, index: 0, name: redactMyEntries}
+                  Variable: {subprogram: 64, index: 0, name: redactMyEntries}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 345
+      ID: 478
       Name: Probe[main.testMapSmallKeyLargeValue]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -4214,14 +4822,14 @@ Types:
         - Name: m
           Offset: 1
           Expression:
-            Type: 113 GoMapType map[uint8][4]int
+            Type: 136 GoMapType map[uint8][4]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 64, index: 0, name: m}
+                  Variable: {subprogram: 72, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 344
+      ID: 477
       Name: Probe[main.testMapSmallKeySmallValue]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -4229,14 +4837,14 @@ Types:
         - Name: m
           Offset: 1
           Expression:
-            Type: 108 GoMapType map[uint8]uint8
+            Type: 131 GoMapType map[uint8]uint8
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 63, index: 0, name: m}
+                  Variable: {subprogram: 71, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 330
+      ID: 463
       Name: Probe[main.testMapStringToInt]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -4244,14 +4852,14 @@ Types:
         - Name: m
           Offset: 1
           Expression:
-            Type: 76 GoMapType map[string]int
+            Type: 99 GoMapType map[string]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 49, index: 0, name: m}
+                  Variable: {subprogram: 57, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 331
+      ID: 464
       Name: Probe[main.testMapStringToSlice]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -4259,14 +4867,14 @@ Types:
         - Name: m
           Offset: 1
           Expression:
-            Type: 81 GoMapType map[string][]string
+            Type: 104 GoMapType map[string][]string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 50, index: 0, name: m}
+                  Variable: {subprogram: 58, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 329
+      ID: 462
       Name: Probe[main.testMapStringToStruct]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -4274,14 +4882,14 @@ Types:
         - Name: m
           Offset: 1
           Expression:
-            Type: 71 GoMapType map[string]main.nestedStruct
+            Type: 94 GoMapType map[string]main.nestedStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 48, index: 0, name: m}
+                  Variable: {subprogram: 56, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 339
+      ID: 472
       Name: Probe[main.testMapWithLinkedList]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -4289,14 +4897,14 @@ Types:
         - Name: m
           Offset: 1
           Expression:
-            Type: 98 GoMapType map[bool]main.node
+            Type: 121 GoMapType map[bool]main.node
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 58, index: 0, name: m}
+                  Variable: {subprogram: 66, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 343
+      ID: 476
       Name: Probe[main.testMapWithSmallKeyAndValueMassive]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -4304,14 +4912,14 @@ Types:
         - Name: m
           Offset: 1
           Expression:
-            Type: 108 GoMapType map[uint8]uint8
+            Type: 131 GoMapType map[uint8]uint8
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 62, index: 0, name: m}
+                  Variable: {subprogram: 70, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 342
+      ID: 475
       Name: Probe[main.testMapWithSmallKeyAndValue]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -4319,14 +4927,14 @@ Types:
         - Name: m
           Offset: 1
           Expression:
-            Type: 108 GoMapType map[uint8]uint8
+            Type: 131 GoMapType map[uint8]uint8
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 61, index: 0, name: m}
+                  Variable: {subprogram: 69, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 341
+      ID: 474
       Name: Probe[main.testMapWithSmallValueMassive]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -4334,14 +4942,14 @@ Types:
         - Name: redactMyEntries
           Offset: 1
           Expression:
-            Type: 103 GoMapType map[int]uint8
+            Type: 126 GoMapType map[int]uint8
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 60, index: 0, name: redactMyEntries}
+                  Variable: {subprogram: 68, index: 0, name: redactMyEntries}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 340
+      ID: 473
       Name: Probe[main.testMapWithSmallValue]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -4349,14 +4957,14 @@ Types:
         - Name: m
           Offset: 1
           Expression:
-            Type: 103 GoMapType map[int]uint8
+            Type: 126 GoMapType map[int]uint8
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 59, index: 0, name: m}
+                  Variable: {subprogram: 67, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 375
+      ID: 508
       Name: Probe[main.testMassiveString]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -4367,11 +4975,11 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 94, index: 0, name: x}
+                  Variable: {subprogram: 102, index: 0, name: x}
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 349
+      ID: 482
       Name: Probe[main.testMultipleSimpleParams]
       ByteSize: 31
       PresenceBitsetSize: 1
@@ -4382,7 +4990,7 @@ Types:
             Type: 4 BaseType bool
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 68, index: 0, name: a}
+                  Variable: {subprogram: 76, index: 0, name: a}
                   Offset: 0
                   ByteSize: 1
         - Name: b
@@ -4391,7 +4999,7 @@ Types:
             Type: 3 BaseType uint8
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 68, index: 1, name: b}
+                  Variable: {subprogram: 76, index: 1, name: b}
                   Offset: 0
                   ByteSize: 1
         - Name: c
@@ -4400,7 +5008,7 @@ Types:
             Type: 10 BaseType int32
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 68, index: 2, name: c}
+                  Variable: {subprogram: 76, index: 2, name: c}
                   Offset: 0
                   ByteSize: 4
         - Name: d
@@ -4409,7 +5017,7 @@ Types:
             Type: 17 BaseType uint
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 68, index: 3, name: d}
+                  Variable: {subprogram: 76, index: 3, name: d}
                   Offset: 0
                   ByteSize: 8
         - Name: e
@@ -4418,11 +5026,11 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 68, index: 4, name: e}
+                  Variable: {subprogram: 76, index: 4, name: e}
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 357
+      ID: 490
       Name: Probe[main.testNilPointer]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -4433,7 +5041,7 @@ Types:
             Type: 11 PointerType *bool
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 76, index: 0, name: z}
+                  Variable: {subprogram: 84, index: 0, name: z}
                   Offset: 0
                   ByteSize: 8
         - Name: a
@@ -4442,11 +5050,11 @@ Types:
             Type: 17 BaseType uint
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 76, index: 1, name: a}
+                  Variable: {subprogram: 84, index: 1, name: a}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 364
+      ID: 497
       Name: Probe[main.testNilSliceOfStructs]
       ByteSize: 33
       PresenceBitsetSize: 1
@@ -4454,10 +5062,10 @@ Types:
         - Name: xs
           Offset: 1
           Expression:
-            Type: 138 GoSliceHeaderType []main.structWithNoStrings
+            Type: 161 GoSliceHeaderType []main.structWithNoStrings
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 83, index: 0, name: xs}
+                  Variable: {subprogram: 91, index: 0, name: xs}
                   Offset: 0
                   ByteSize: 24
         - Name: a
@@ -4466,11 +5074,11 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 83, index: 1, name: a}
+                  Variable: {subprogram: 91, index: 1, name: a}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 366
+      ID: 499
       Name: Probe[main.testNilSliceWithOtherParams]
       ByteSize: 34
       PresenceBitsetSize: 1
@@ -4481,16 +5089,16 @@ Types:
             Type: 16 BaseType int8
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 85, index: 0, name: a}
+                  Variable: {subprogram: 93, index: 0, name: a}
                   Offset: 0
                   ByteSize: 1
         - Name: s
           Offset: 2
           Expression:
-            Type: 142 GoSliceHeaderType []bool
+            Type: 165 GoSliceHeaderType []bool
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 85, index: 1, name: s}
+                  Variable: {subprogram: 93, index: 1, name: s}
                   Offset: 0
                   ByteSize: 24
         - Name: x
@@ -4499,11 +5107,11 @@ Types:
             Type: 17 BaseType uint
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 85, index: 2, name: x}
+                  Variable: {subprogram: 93, index: 2, name: x}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 367
+      ID: 500
       Name: Probe[main.testNilSlice]
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -4511,14 +5119,14 @@ Types:
         - Name: xs
           Offset: 1
           Expression:
-            Type: 143 GoSliceHeaderType []uint16
+            Type: 166 GoSliceHeaderType []uint16
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 86, index: 0, name: xs}
+                  Variable: {subprogram: 94, index: 0, name: xs}
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 374
+      ID: 507
       Name: Probe[main.testOneStringInStructPointer]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -4526,14 +5134,14 @@ Types:
         - Name: a
           Offset: 1
           Expression:
-            Type: 146 PointerType *main.oneStringStruct
+            Type: 169 PointerType *main.oneStringStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 93, index: 0, name: a}
+                  Variable: {subprogram: 101, index: 0, name: a}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 353
+      ID: 486
       Name: Probe[main.testPointerLoop]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -4541,14 +5149,14 @@ Types:
         - Name: a
           Offset: 1
           Expression:
-            Type: 132 PointerType *main.node
+            Type: 155 PointerType *main.node
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 72, index: 0, name: a}
+                  Variable: {subprogram: 80, index: 0, name: a}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 335
+      ID: 468
       Name: Probe[main.testPointerToMap]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -4556,14 +5164,14 @@ Types:
         - Name: m
           Offset: 1
           Expression:
-            Type: 92 PointerType *map[string]int
+            Type: 115 PointerType *map[string]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 54, index: 0, name: m}
+                  Variable: {subprogram: 62, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 351
+      ID: 484
       Name: Probe[main.testPointerToSimpleStruct]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -4571,14 +5179,14 @@ Types:
         - Name: a
           Offset: 1
           Expression:
-            Type: 129 PointerType *main.structWithTwoValues
+            Type: 152 PointerType *main.structWithTwoValues
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 70, index: 0, name: a}
+                  Variable: {subprogram: 78, index: 0, name: a}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 283
+      ID: 408
       Name: Probe[main.testRuneArray]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -4593,7 +5201,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 302
+      ID: 427
       Name: Probe[main.testSingleBool]
       ByteSize: 2
       PresenceBitsetSize: 1
@@ -4608,7 +5216,7 @@ Types:
                   Offset: 0
                   ByteSize: 1
     - __kind: EventRootType
-      ID: 300
+      ID: 425
       Name: Probe[main.testSingleByte]
       ByteSize: 2
       PresenceBitsetSize: 1
@@ -4623,7 +5231,7 @@ Types:
                   Offset: 0
                   ByteSize: 1
     - __kind: EventRootType
-      ID: 313
+      ID: 438
       Name: Probe[main.testSingleFloat32]
       ByteSize: 5
       PresenceBitsetSize: 1
@@ -4638,7 +5246,7 @@ Types:
                   Offset: 0
                   ByteSize: 4
     - __kind: EventRootType
-      ID: 314
+      ID: 439
       Name: Probe[main.testSingleFloat64]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -4653,7 +5261,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 305
+      ID: 430
       Name: Probe[main.testSingleInt16]
       ByteSize: 3
       PresenceBitsetSize: 1
@@ -4668,7 +5276,7 @@ Types:
                   Offset: 0
                   ByteSize: 2
     - __kind: EventRootType
-      ID: 306
+      ID: 431
       Name: Probe[main.testSingleInt32]
       ByteSize: 5
       PresenceBitsetSize: 1
@@ -4683,7 +5291,7 @@ Types:
                   Offset: 0
                   ByteSize: 4
     - __kind: EventRootType
-      ID: 307
+      ID: 432
       Name: Probe[main.testSingleInt64]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -4698,7 +5306,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 304
+      ID: 429
       Name: Probe[main.testSingleInt8]
       ByteSize: 2
       PresenceBitsetSize: 1
@@ -4713,7 +5321,7 @@ Types:
                   Offset: 0
                   ByteSize: 1
     - __kind: EventRootType
-      ID: 303
+      ID: 428
       Name: Probe[main.testSingleInt]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -4728,7 +5336,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 301
+      ID: 426
       Name: Probe[main.testSingleRune]
       ByteSize: 5
       PresenceBitsetSize: 1
@@ -4743,7 +5351,7 @@ Types:
                   Offset: 0
                   ByteSize: 4
     - __kind: EventRootType
-      ID: 370
+      ID: 503
       Name: Probe[main.testSingleString]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -4754,11 +5362,11 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 89, index: 0, name: x}
+                  Variable: {subprogram: 97, index: 0, name: x}
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 310
+      ID: 435
       Name: Probe[main.testSingleUint16]
       ByteSize: 3
       PresenceBitsetSize: 1
@@ -4773,7 +5381,7 @@ Types:
                   Offset: 0
                   ByteSize: 2
     - __kind: EventRootType
-      ID: 311
+      ID: 436
       Name: Probe[main.testSingleUint32]
       ByteSize: 5
       PresenceBitsetSize: 1
@@ -4788,7 +5396,7 @@ Types:
                   Offset: 0
                   ByteSize: 4
     - __kind: EventRootType
-      ID: 312
+      ID: 437
       Name: Probe[main.testSingleUint64]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -4803,7 +5411,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 309
+      ID: 434
       Name: Probe[main.testSingleUint8]
       ByteSize: 2
       PresenceBitsetSize: 1
@@ -4818,7 +5426,7 @@ Types:
                   Offset: 0
                   ByteSize: 1
     - __kind: EventRootType
-      ID: 308
+      ID: 433
       Name: Probe[main.testSingleUint]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -4833,7 +5441,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 361
+      ID: 494
       Name: Probe[main.testSliceOfSlices]
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -4841,14 +5449,14 @@ Types:
         - Name: u
           Offset: 1
           Expression:
-            Type: 136 GoSliceHeaderType [][]uint
+            Type: 159 GoSliceHeaderType [][]uint
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 80, index: 0, name: u}
+                  Variable: {subprogram: 88, index: 0, name: u}
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 333
+      ID: 466
       Name: Probe[main.testSmallMap]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -4856,14 +5464,14 @@ Types:
         - Name: m
           Offset: 1
           Expression:
-            Type: 76 GoMapType map[string]int
+            Type: 99 GoMapType map[string]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 52, index: 0, name: m}
+                  Variable: {subprogram: 60, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 284
+      ID: 409
       Name: Probe[main.testStringArray]
       ByteSize: 33
       PresenceBitsetSize: 1
@@ -4878,7 +5486,7 @@ Types:
                   Offset: 0
                   ByteSize: 32
     - __kind: EventRootType
-      ID: 356
+      ID: 489
       Name: Probe[main.testStringPointer]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -4889,11 +5497,11 @@ Types:
             Type: 22 PointerType *string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 75, index: 0, name: z}
+                  Variable: {subprogram: 83, index: 0, name: z}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 365
+      ID: 498
       Name: Probe[main.testStringSlice]
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -4901,14 +5509,44 @@ Types:
         - Name: s
           Offset: 1
           Expression:
-            Type: 141 GoSliceHeaderType []string
+            Type: 164 GoSliceHeaderType []string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 84, index: 0, name: s}
+                  Variable: {subprogram: 92, index: 0, name: s}
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 362
+      ID: 448
+      Name: Probe[main.testStringType1]
+      ByteSize: 9
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: a
+          Offset: 1
+          Expression:
+            Type: 75 PointerType *main.stringType1
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 42, index: 0, name: a}
+                  Offset: 0
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 449
+      Name: Probe[main.testStringType2]
+      ByteSize: 9
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: a
+          Offset: 1
+          Expression:
+            Type: 77 PointerType **main.stringType2
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 43, index: 0, name: a}
+                  Offset: 0
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 495
       Name: Probe[main.testStructSlice]
       ByteSize: 33
       PresenceBitsetSize: 1
@@ -4916,10 +5554,10 @@ Types:
         - Name: xs
           Offset: 1
           Expression:
-            Type: 138 GoSliceHeaderType []main.structWithNoStrings
+            Type: 161 GoSliceHeaderType []main.structWithNoStrings
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 81, index: 0, name: xs}
+                  Variable: {subprogram: 89, index: 0, name: xs}
                   Offset: 0
                   ByteSize: 24
         - Name: a
@@ -4928,11 +5566,11 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 81, index: 1, name: a}
+                  Variable: {subprogram: 89, index: 1, name: a}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 328
+      ID: 461
       Name: Probe[main.testStructWithMap]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -4940,14 +5578,14 @@ Types:
         - Name: s
           Offset: 1
           Expression:
-            Type: 65 StructureType main.structWithMap
+            Type: 88 StructureType main.structWithMap
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 47, index: 0, name: s}
+                  Variable: {subprogram: 55, index: 0, name: s}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 378
+      ID: 511
       Name: Probe[main.testStruct]
       ByteSize: 57
       PresenceBitsetSize: 1
@@ -4955,14 +5593,14 @@ Types:
         - Name: x
           Offset: 1
           Expression:
-            Type: 148 StructureType main.aStruct
+            Type: 171 StructureType main.aStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 97, index: 0, name: x}
+                  Variable: {subprogram: 105, index: 0, name: x}
                   Offset: 0
                   ByteSize: 56
     - __kind: EventRootType
-      ID: 373
+      ID: 506
       Name: Probe[main.testThreeStringsInStructPointer]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -4970,14 +5608,14 @@ Types:
         - Name: a
           Offset: 1
           Expression:
-            Type: 145 PointerType *main.threeStringStruct
+            Type: 168 PointerType *main.threeStringStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 92, index: 0, name: a}
+                  Variable: {subprogram: 100, index: 0, name: a}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 372
+      ID: 505
       Name: Probe[main.testThreeStringsInStruct]
       ByteSize: 49
       PresenceBitsetSize: 1
@@ -4985,14 +5623,14 @@ Types:
         - Name: a
           Offset: 1
           Expression:
-            Type: 144 StructureType main.threeStringStruct
+            Type: 167 StructureType main.threeStringStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 91, index: 0, name: a}
+                  Variable: {subprogram: 99, index: 0, name: a}
                   Offset: 0
                   ByteSize: 48
     - __kind: EventRootType
-      ID: 371
+      ID: 504
       Name: Probe[main.testThreeStrings]
       ByteSize: 49
       PresenceBitsetSize: 1
@@ -5003,7 +5641,7 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 90, index: 0, name: x}
+                  Variable: {subprogram: 98, index: 0, name: x}
                   Offset: 0
                   ByteSize: 16
         - Name: y
@@ -5012,7 +5650,7 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 90, index: 1, name: y}
+                  Variable: {subprogram: 98, index: 1, name: y}
                   Offset: 0
                   ByteSize: 16
         - Name: z
@@ -5021,11 +5659,11 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 90, index: 2, name: z}
+                  Variable: {subprogram: 98, index: 2, name: z}
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 315
+      ID: 440
       Name: Probe[main.testTypeAlias]
       ByteSize: 3
       PresenceBitsetSize: 1
@@ -5040,7 +5678,7 @@ Types:
                   Offset: 0
                   ByteSize: 2
     - __kind: EventRootType
-      ID: 293
+      ID: 418
       Name: Probe[main.testUint16Array]
       ByteSize: 5
       PresenceBitsetSize: 1
@@ -5055,7 +5693,7 @@ Types:
                   Offset: 0
                   ByteSize: 4
     - __kind: EventRootType
-      ID: 294
+      ID: 419
       Name: Probe[main.testUint32Array]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -5070,7 +5708,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 295
+      ID: 420
       Name: Probe[main.testUint64Array]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -5085,7 +5723,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 292
+      ID: 417
       Name: Probe[main.testUint8Array]
       ByteSize: 3
       PresenceBitsetSize: 1
@@ -5100,7 +5738,7 @@ Types:
                   Offset: 0
                   ByteSize: 2
     - __kind: EventRootType
-      ID: 291
+      ID: 416
       Name: Probe[main.testUintArray]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -5115,7 +5753,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 355
+      ID: 488
       Name: Probe[main.testUintPointer]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -5126,11 +5764,11 @@ Types:
             Type: 34 PointerType *uint
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 74, index: 0, name: x}
+                  Variable: {subprogram: 82, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 359
+      ID: 492
       Name: Probe[main.testUintSlice]
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -5138,14 +5776,14 @@ Types:
         - Name: u
           Offset: 1
           Expression:
-            Type: 135 GoSliceHeaderType []uint
+            Type: 158 GoSliceHeaderType []uint
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 78, index: 0, name: u}
+                  Variable: {subprogram: 86, index: 0, name: u}
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 376
+      ID: 509
       Name: Probe[main.testUnitializedString]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -5156,11 +5794,11 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 95, index: 0, name: x}
+                  Variable: {subprogram: 103, index: 0, name: x}
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 354
+      ID: 487
       Name: Probe[main.testUnsafePointer]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -5171,11 +5809,11 @@ Types:
             Type: 14 VoidPointerType unsafe.Pointer
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 73, index: 0, name: x}
+                  Variable: {subprogram: 81, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 299
+      ID: 424
       Name: Probe[main.testVeryLargeArray]
       ByteSize: 801
       PresenceBitsetSize: 1
@@ -5190,7 +5828,7 @@ Types:
                   Offset: 0
                   ByteSize: 800
     - __kind: EventRootType
-      ID: 368
+      ID: 501
       Name: Probe[main.testVeryLargeSlice]
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -5198,10 +5836,10 @@ Types:
         - Name: xs
           Offset: 1
           Expression:
-            Type: 135 GoSliceHeaderType []uint
+            Type: 158 GoSliceHeaderType []uint
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 87, index: 0, name: xs}
+                  Variable: {subprogram: 95, index: 0, name: xs}
                   Offset: 0
                   ByteSize: 24
     - __kind: ArrayType
@@ -5240,7 +5878,7 @@ Types:
       ID: 40
       Name: '[2]int'
       ByteSize: 16
-      GoRuntimeType: 677024
+      GoRuntimeType: 683008
       GoKind: 17
       Count: 2
       HasCount: true
@@ -5257,7 +5895,7 @@ Types:
       ID: 37
       Name: '[2]int32'
       ByteSize: 8
-      GoRuntimeType: 678368
+      GoRuntimeType: 684352
       GoKind: 17
       Count: 2
       HasCount: true
@@ -5279,18 +5917,18 @@ Types:
       HasCount: true
       Element: 16 BaseType int8
     - __kind: ArrayType
-      ID: 91
+      ID: 114
       Name: '[2]map[string]int'
       ByteSize: 16
       GoKind: 17
       Count: 2
       HasCount: true
-      Element: 76 GoMapType map[string]int
+      Element: 99 GoMapType map[string]int
     - __kind: ArrayType
       ID: 38
       Name: '[2]string'
       ByteSize: 32
-      GoRuntimeType: 678464
+      GoRuntimeType: 684448
       GoKind: 17
       Count: 2
       HasCount: true
@@ -5323,7 +5961,7 @@ Types:
       ID: 47
       Name: '[2]uint64'
       ByteSize: 16
-      GoRuntimeType: 678560
+      GoRuntimeType: 684544
       GoKind: 17
       Count: 2
       HasCount: true
@@ -5332,31 +5970,31 @@ Types:
       ID: 36
       Name: '[2]uint8'
       ByteSize: 2
-      GoRuntimeType: 678272
+      GoRuntimeType: 684256
       GoKind: 17
       Count: 2
       HasCount: true
       Element: 3 BaseType uint8
     - __kind: ArrayType
-      ID: 236
+      ID: 272
       Name: '[4]int'
       ByteSize: 32
-      GoRuntimeType: 676640
+      GoRuntimeType: 682624
       GoKind: 17
       Count: 4
       HasCount: true
       Element: 7 BaseType int
     - __kind: ArrayType
-      ID: 193
+      ID: 229
       Name: '[4]string'
       ByteSize: 64
-      GoRuntimeType: 676928
+      GoRuntimeType: 682912
       GoKind: 17
       Count: 4
       HasCount: true
       Element: 9 GoStringHeaderType string
     - __kind: ArrayType
-      ID: 63
+      ID: 86
       Name: '[5]int'
       ByteSize: 40
       GoKind: 17
@@ -5364,10 +6002,98 @@ Types:
       HasCount: true
       Element: 7 BaseType int
     - __kind: GoSliceHeaderType
+      ID: 62
+      Name: '[]*main.deepSlice2'
+      ByteSize: 24
+      GoRuntimeType: 477632
+      GoKind: 23
+      RawFields:
+        - Name: array
+          Offset: 0
+          Type: 63 PointerType **main.deepSlice2
+        - Name: len
+          Offset: 8
+          Type: 7 BaseType int
+        - Name: cap
+          Offset: 16
+          Type: 7 BaseType int
+      Data: 179 GoSliceDataType []*main.deepSlice2.array
+    - __kind: GoSliceDataType
+      ID: 179
+      Name: '[]*main.deepSlice2.array'
+      ByteSize: 2048
+      Element: 64 PointerType *main.deepSlice2
+    - __kind: GoSliceHeaderType
+      ID: 308
+      Name: '[]*main.deepSlice3'
+      ByteSize: 24
+      GoRuntimeType: 477568
+      GoKind: 23
+      RawFields:
+        - Name: array
+          Offset: 0
+          Type: 309 PointerType **main.deepSlice3
+        - Name: len
+          Offset: 8
+          Type: 7 BaseType int
+        - Name: cap
+          Offset: 16
+          Type: 7 BaseType int
+      Data: 312 GoSliceDataType []*main.deepSlice3.array
+    - __kind: GoSliceDataType
+      ID: 312
+      Name: '[]*main.deepSlice3.array'
+      ByteSize: 2048
+      Element: 310 PointerType *main.deepSlice3
+    - __kind: GoSliceHeaderType
+      ID: 333
+      Name: '[]*main.deepSlice8'
+      ByteSize: 24
+      GoRuntimeType: 477248
+      GoKind: 23
+      RawFields:
+        - Name: array
+          Offset: 0
+          Type: 334 PointerType **main.deepSlice8
+        - Name: len
+          Offset: 8
+          Type: 7 BaseType int
+        - Name: cap
+          Offset: 16
+          Type: 7 BaseType int
+      Data: 337 GoSliceDataType []*main.deepSlice8.array
+    - __kind: GoSliceDataType
+      ID: 337
+      Name: '[]*main.deepSlice8.array'
+      ByteSize: 2048
+      Element: 335 PointerType *main.deepSlice8
+    - __kind: GoSliceHeaderType
+      ID: 339
+      Name: '[]*main.deepSlice9'
+      ByteSize: 24
+      GoRuntimeType: 477184
+      GoKind: 23
+      RawFields:
+        - Name: array
+          Offset: 0
+          Type: 340 PointerType **main.deepSlice9
+        - Name: len
+          Offset: 8
+          Type: 7 BaseType int
+        - Name: cap
+          Offset: 16
+          Type: 7 BaseType int
+      Data: 343 GoSliceDataType []*main.deepSlice9.array
+    - __kind: GoSliceDataType
+      ID: 343
+      Name: '[]*main.deepSlice9.array'
+      ByteSize: 2048
+      Element: 341 PointerType *main.deepSlice9
+    - __kind: GoSliceHeaderType
       ID: 53
       Name: '[]*string'
       ByteSize: 24
-      GoRuntimeType: 473536
+      GoRuntimeType: 478656
       GoKind: 23
       RawFields:
         - Name: array
@@ -5379,98 +6105,123 @@ Types:
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 153 GoSliceDataType []*string.array
+      Data: 176 GoSliceDataType []*string.array
     - __kind: GoSliceDataType
-      ID: 153
+      ID: 176
       Name: '[]*string.array'
       ByteSize: 2048
       Element: 22 PointerType *string
     - __kind: GoSliceDataType
-      ID: 253
+      ID: 289
       Name: '[]*table<[4]int,[4]int>.array'
       ByteSize: 8192
-      Element: 127 PointerType *table<[4]int,[4]int>
+      Element: 150 PointerType *table<[4]int,[4]int>
     - __kind: GoSliceDataType
-      ID: 245
+      ID: 281
       Name: '[]*table<[4]int,uint8>.array'
       ByteSize: 8192
-      Element: 122 PointerType *table<[4]int,uint8>
+      Element: 145 PointerType *table<[4]int,uint8>
     - __kind: GoSliceDataType
-      ID: 194
+      ID: 230
       Name: '[]*table<[4]string,[2]int>.array'
       ByteSize: 8192
-      Element: 90 PointerType *table<[4]string,[2]int>
+      Element: 113 PointerType *table<[4]string,[2]int>
     - __kind: GoSliceDataType
-      ID: 212
+      ID: 248
       Name: '[]*table<bool,main.node>.array'
       ByteSize: 8192
-      Element: 102 PointerType *table<bool,main.node>
+      Element: 125 PointerType *table<bool,main.node>
     - __kind: GoSliceDataType
-      ID: 161
+      ID: 189
+      Name: '[]*table<int,*main.deepMap2>.array'
+      ByteSize: 8192
+      Element: 72 PointerType *table<int,*main.deepMap2>
+    - __kind: GoSliceDataType
+      ID: 327
+      Name: '[]*table<int,*main.deepMap3>.array'
+      ByteSize: 8192
+      Element: 318 PointerType *table<int,*main.deepMap3>
+    - __kind: GoSliceDataType
+      ID: 362
+      Name: '[]*table<int,*main.deepMap8>.array'
+      ByteSize: 8192
+      Element: 353 PointerType *table<int,*main.deepMap8>
+    - __kind: GoSliceDataType
+      ID: 377
+      Name: '[]*table<int,*main.deepMap9>.array'
+      ByteSize: 8192
+      Element: 368 PointerType *table<int,*main.deepMap9>
+    - __kind: GoSliceDataType
+      ID: 197
       Name: '[]*table<int,int>.array'
       ByteSize: 8192
-      Element: 70 PointerType *table<int,int>
+      Element: 93 PointerType *table<int,int>
     - __kind: GoSliceDataType
-      ID: 220
+      ID: 390
+      Name: '[]*table<int,interface {}>.array'
+      ByteSize: 8192
+      Element: 383 PointerType *table<int,interface {}>
+    - __kind: GoSliceDataType
+      ID: 256
       Name: '[]*table<int,uint8>.array'
       ByteSize: 8192
-      Element: 107 PointerType *table<int,uint8>
+      Element: 130 PointerType *table<int,uint8>
     - __kind: GoSliceDataType
-      ID: 204
+      ID: 240
       Name: '[]*table<string,[]main.structWithMap>.array'
       ByteSize: 8192
-      Element: 97 PointerType *table<string,[]main.structWithMap>
+      Element: 120 PointerType *table<string,[]main.structWithMap>
     - __kind: GoSliceDataType
-      ID: 185
+      ID: 221
       Name: '[]*table<string,[]string>.array'
       ByteSize: 8192
-      Element: 85 PointerType *table<string,[]string>
+      Element: 108 PointerType *table<string,[]string>
     - __kind: GoSliceDataType
-      ID: 177
+      ID: 213
       Name: '[]*table<string,int>.array'
       ByteSize: 8192
-      Element: 80 PointerType *table<string,int>
+      Element: 103 PointerType *table<string,int>
     - __kind: GoSliceDataType
-      ID: 169
+      ID: 205
       Name: '[]*table<string,main.nestedStruct>.array'
       ByteSize: 8192
-      Element: 75 PointerType *table<string,main.nestedStruct>
+      Element: 98 PointerType *table<string,main.nestedStruct>
     - __kind: GoSliceDataType
-      ID: 237
+      ID: 273
       Name: '[]*table<uint8,[4]int>.array'
       ByteSize: 8192
-      Element: 117 PointerType *table<uint8,[4]int>
+      Element: 140 PointerType *table<uint8,[4]int>
     - __kind: GoSliceDataType
-      ID: 228
+      ID: 264
       Name: '[]*table<uint8,uint8>.array'
       ByteSize: 8192
-      Element: 112 PointerType *table<uint8,uint8>
+      Element: 135 PointerType *table<uint8,uint8>
     - __kind: GoSliceHeaderType
-      ID: 136
+      ID: 159
       Name: '[][]uint'
       ByteSize: 24
       GoKind: 23
       RawFields:
         - Name: array
           Offset: 0
-          Type: 137 PointerType *[]uint
+          Type: 160 PointerType *[]uint
         - Name: len
           Offset: 8
           Type: 7 BaseType int
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 257 GoSliceDataType [][]uint.array
+      Data: 293 GoSliceDataType [][]uint.array
     - __kind: GoSliceDataType
-      ID: 257
+      ID: 293
       Name: '[][]uint.array'
       ByteSize: 2048
-      Element: 135 GoSliceHeaderType []uint
+      Element: 158 GoSliceHeaderType []uint
     - __kind: GoSliceHeaderType
-      ID: 142
+      ID: 165
       Name: '[]bool'
       ByteSize: 24
-      GoRuntimeType: 481856
+      GoRuntimeType: 486976
       GoKind: 23
       RawFields:
         - Name: array
@@ -5482,120 +6233,167 @@ Types:
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 263 GoSliceDataType []bool.array
+      Data: 299 GoSliceDataType []bool.array
     - __kind: GoSliceDataType
-      ID: 263
+      ID: 299
       Name: '[]bool.array'
       ByteSize: 2048
       Element: 4 BaseType bool
     - __kind: GoSliceHeaderType
-      ID: 202
-      Name: '[]main.structWithMap'
+      ID: 345
+      Name: '[]interface {}'
       ByteSize: 24
-      GoRuntimeType: 472768
+      GoRuntimeType: 487296
       GoKind: 23
       RawFields:
         - Name: array
           Offset: 0
-          Type: 203 PointerType *main.structWithMap
+          Type: 346 PointerType *interface {}
         - Name: len
           Offset: 8
           Type: 7 BaseType int
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 280 GoSliceDataType []main.structWithMap.array
+      Data: 347 GoSliceDataType []interface {}.array
     - __kind: GoSliceDataType
-      ID: 280
+      ID: 347
+      Name: '[]interface {}.array'
+      ByteSize: 2048
+      Element: 81 GoEmptyInterfaceType interface {}
+    - __kind: GoSliceHeaderType
+      ID: 238
+      Name: '[]main.structWithMap'
+      ByteSize: 24
+      GoRuntimeType: 477888
+      GoKind: 23
+      RawFields:
+        - Name: array
+          Offset: 0
+          Type: 239 PointerType *main.structWithMap
+        - Name: len
+          Offset: 8
+          Type: 7 BaseType int
+        - Name: cap
+          Offset: 16
+          Type: 7 BaseType int
+      Data: 405 GoSliceDataType []main.structWithMap.array
+    - __kind: GoSliceDataType
+      ID: 405
       Name: '[]main.structWithMap.array'
       ByteSize: 2048
-      Element: 65 StructureType main.structWithMap
+      Element: 88 StructureType main.structWithMap
     - __kind: GoSliceHeaderType
-      ID: 138
+      ID: 161
       Name: '[]main.structWithNoStrings'
       ByteSize: 24
       GoKind: 23
       RawFields:
         - Name: array
           Offset: 0
-          Type: 139 PointerType *main.structWithNoStrings
+          Type: 162 PointerType *main.structWithNoStrings
         - Name: len
           Offset: 8
           Type: 7 BaseType int
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 259 GoSliceDataType []main.structWithNoStrings.array
+      Data: 295 GoSliceDataType []main.structWithNoStrings.array
     - __kind: GoSliceDataType
-      ID: 259
+      ID: 295
       Name: '[]main.structWithNoStrings.array'
       ByteSize: 2048
-      Element: 140 StructureType main.structWithNoStrings
+      Element: 163 StructureType main.structWithNoStrings
     - __kind: GoSliceDataType
-      ID: 254
+      ID: 290
       Name: '[]noalg.map.group[[4]int][4]int.array'
       ByteSize: 2048
-      Element: 250 StructureType noalg.map.group[[4]int][4]int
+      Element: 286 StructureType noalg.map.group[[4]int][4]int
     - __kind: GoSliceDataType
-      ID: 246
+      ID: 282
       Name: '[]noalg.map.group[[4]int]uint8.array'
       ByteSize: 2048
-      Element: 242 StructureType noalg.map.group[[4]int]uint8
+      Element: 278 StructureType noalg.map.group[[4]int]uint8
     - __kind: GoSliceDataType
-      ID: 195
+      ID: 231
       Name: '[]noalg.map.group[[4]string][2]int.array'
       ByteSize: 2048
-      Element: 190 StructureType noalg.map.group[[4]string][2]int
+      Element: 226 StructureType noalg.map.group[[4]string][2]int
     - __kind: GoSliceDataType
-      ID: 213
+      ID: 249
       Name: '[]noalg.map.group[bool]main.node.array'
       ByteSize: 2048
-      Element: 209 StructureType noalg.map.group[bool]main.node
+      Element: 245 StructureType noalg.map.group[bool]main.node
     - __kind: GoSliceDataType
-      ID: 162
+      ID: 190
+      Name: '[]noalg.map.group[int]*main.deepMap2.array'
+      ByteSize: 2048
+      Element: 184 StructureType noalg.map.group[int]*main.deepMap2
+    - __kind: GoSliceDataType
+      ID: 328
+      Name: '[]noalg.map.group[int]*main.deepMap3.array'
+      ByteSize: 2048
+      Element: 322 StructureType noalg.map.group[int]*main.deepMap3
+    - __kind: GoSliceDataType
+      ID: 363
+      Name: '[]noalg.map.group[int]*main.deepMap8.array'
+      ByteSize: 2048
+      Element: 357 StructureType noalg.map.group[int]*main.deepMap8
+    - __kind: GoSliceDataType
+      ID: 378
+      Name: '[]noalg.map.group[int]*main.deepMap9.array'
+      ByteSize: 2048
+      Element: 372 StructureType noalg.map.group[int]*main.deepMap9
+    - __kind: GoSliceDataType
+      ID: 198
       Name: '[]noalg.map.group[int]int.array'
       ByteSize: 2048
-      Element: 158 StructureType noalg.map.group[int]int
+      Element: 194 StructureType noalg.map.group[int]int
     - __kind: GoSliceDataType
-      ID: 221
+      ID: 391
+      Name: '[]noalg.map.group[int]interface {}.array'
+      ByteSize: 2048
+      Element: 387 StructureType noalg.map.group[int]interface {}
+    - __kind: GoSliceDataType
+      ID: 257
       Name: '[]noalg.map.group[int]uint8.array'
       ByteSize: 2048
-      Element: 217 StructureType noalg.map.group[int]uint8
+      Element: 253 StructureType noalg.map.group[int]uint8
     - __kind: GoSliceDataType
-      ID: 205
+      ID: 241
       Name: '[]noalg.map.group[string][]main.structWithMap.array'
       ByteSize: 2048
-      Element: 199 StructureType noalg.map.group[string][]main.structWithMap
+      Element: 235 StructureType noalg.map.group[string][]main.structWithMap
     - __kind: GoSliceDataType
-      ID: 186
+      ID: 222
       Name: '[]noalg.map.group[string][]string.array'
       ByteSize: 2048
-      Element: 182 StructureType noalg.map.group[string][]string
+      Element: 218 StructureType noalg.map.group[string][]string
     - __kind: GoSliceDataType
-      ID: 178
+      ID: 214
       Name: '[]noalg.map.group[string]int.array'
       ByteSize: 2048
-      Element: 174 StructureType noalg.map.group[string]int
+      Element: 210 StructureType noalg.map.group[string]int
     - __kind: GoSliceDataType
-      ID: 170
+      ID: 206
       Name: '[]noalg.map.group[string]main.nestedStruct.array'
       ByteSize: 2048
-      Element: 166 StructureType noalg.map.group[string]main.nestedStruct
+      Element: 202 StructureType noalg.map.group[string]main.nestedStruct
     - __kind: GoSliceDataType
-      ID: 238
+      ID: 274
       Name: '[]noalg.map.group[uint8][4]int.array'
       ByteSize: 2048
-      Element: 233 StructureType noalg.map.group[uint8][4]int
+      Element: 269 StructureType noalg.map.group[uint8][4]int
     - __kind: GoSliceDataType
-      ID: 229
+      ID: 265
       Name: '[]noalg.map.group[uint8]uint8.array'
       ByteSize: 2048
-      Element: 225 StructureType noalg.map.group[uint8]uint8
+      Element: 261 StructureType noalg.map.group[uint8]uint8
     - __kind: GoSliceHeaderType
-      ID: 141
+      ID: 164
       Name: '[]string'
       ByteSize: 24
-      GoRuntimeType: 481984
+      GoRuntimeType: 487104
       GoKind: 23
       RawFields:
         - Name: array
@@ -5607,17 +6405,17 @@ Types:
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 261 GoSliceDataType []string.array
+      Data: 297 GoSliceDataType []string.array
     - __kind: GoSliceDataType
-      ID: 261
+      ID: 297
       Name: '[]string.array'
       ByteSize: 2048
       Element: 9 GoStringHeaderType string
     - __kind: GoSliceHeaderType
-      ID: 135
+      ID: 158
       Name: '[]uint'
       ByteSize: 24
-      GoRuntimeType: 481472
+      GoRuntimeType: 486592
       GoKind: 23
       RawFields:
         - Name: array
@@ -5629,17 +6427,17 @@ Types:
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 255 GoSliceDataType []uint.array
+      Data: 291 GoSliceDataType []uint.array
     - __kind: GoSliceDataType
-      ID: 255
+      ID: 291
       Name: '[]uint.array'
       ByteSize: 2048
       Element: 17 BaseType uint
     - __kind: GoSliceHeaderType
-      ID: 143
+      ID: 166
       Name: '[]uint16'
       ByteSize: 24
-      GoRuntimeType: 480832
+      GoRuntimeType: 485952
       GoKind: 23
       RawFields:
         - Name: array
@@ -5651,9 +6449,9 @@ Types:
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 265 GoSliceDataType []uint16.array
+      Data: 301 GoSliceDataType []uint16.array
     - __kind: GoSliceDataType
-      ID: 265
+      ID: 301
       Name: '[]uint16.array'
       ByteSize: 2048
       Element: 6 BaseType uint16
@@ -5661,35 +6459,35 @@ Types:
       ID: 4
       Name: bool
       ByteSize: 1
-      GoRuntimeType: 579808
+      GoRuntimeType: 584928
       GoKind: 1
     - __kind: GoChannelType
-      ID: 128
+      ID: 151
       Name: chan bool
-      GoRuntimeType: 591136
+      GoRuntimeType: 596256
       GoKind: 18
     - __kind: GoChannelType
-      ID: 57
+      ID: 80
       Name: chan struct {}
-      GoRuntimeType: 590048
+      GoRuntimeType: 595168
       GoKind: 18
     - __kind: BaseType
       ID: 24
       Name: complex128
       ByteSize: 16
-      GoRuntimeType: 579616
+      GoRuntimeType: 584736
       GoKind: 16
     - __kind: BaseType
       ID: 23
       Name: complex64
       ByteSize: 8
-      GoRuntimeType: 579552
+      GoRuntimeType: 584672
       GoKind: 15
     - __kind: GoInterfaceType
       ID: 13
       Name: error
       ByteSize: 16
-      GoRuntimeType: 1.020704e+06
+      GoRuntimeType: 1.026688e+06
       GoKind: 20
       RawFields:
         - Name: tab
@@ -5702,223 +6500,293 @@ Types:
       ID: 18
       Name: float32
       ByteSize: 4
-      GoRuntimeType: 579680
+      GoRuntimeType: 584800
       GoKind: 13
     - __kind: BaseType
       ID: 15
       Name: float64
       ByteSize: 8
-      GoRuntimeType: 579744
+      GoRuntimeType: 584864
       GoKind: 14
     - __kind: GoSubroutineType
-      ID: 60
+      ID: 83
       Name: func()
       ByteSize: 8
-      GoRuntimeType: 471744
+      GoRuntimeType: 475776
       GoKind: 19
     - __kind: GoSwissMapGroupsType
-      ID: 248
+      ID: 284
       Name: groupReference<[4]int,[4]int>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 249 PointerType *noalg.map.group[[4]int][4]int
+          Type: 285 PointerType *noalg.map.group[[4]int][4]int
         - Name: lengthMask
           Offset: 8
           Type: 8 BaseType uint64
-      GroupType: 250 StructureType noalg.map.group[[4]int][4]int
-      GroupSliceType: 254 GoSliceDataType []noalg.map.group[[4]int][4]int.array
+      GroupType: 286 StructureType noalg.map.group[[4]int][4]int
+      GroupSliceType: 290 GoSliceDataType []noalg.map.group[[4]int][4]int.array
     - __kind: GoSwissMapGroupsType
-      ID: 240
+      ID: 276
       Name: groupReference<[4]int,uint8>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 241 PointerType *noalg.map.group[[4]int]uint8
+          Type: 277 PointerType *noalg.map.group[[4]int]uint8
         - Name: lengthMask
           Offset: 8
           Type: 8 BaseType uint64
-      GroupType: 242 StructureType noalg.map.group[[4]int]uint8
-      GroupSliceType: 246 GoSliceDataType []noalg.map.group[[4]int]uint8.array
+      GroupType: 278 StructureType noalg.map.group[[4]int]uint8
+      GroupSliceType: 282 GoSliceDataType []noalg.map.group[[4]int]uint8.array
     - __kind: GoSwissMapGroupsType
-      ID: 188
+      ID: 224
       Name: groupReference<[4]string,[2]int>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 189 PointerType *noalg.map.group[[4]string][2]int
+          Type: 225 PointerType *noalg.map.group[[4]string][2]int
         - Name: lengthMask
           Offset: 8
           Type: 8 BaseType uint64
-      GroupType: 190 StructureType noalg.map.group[[4]string][2]int
-      GroupSliceType: 195 GoSliceDataType []noalg.map.group[[4]string][2]int.array
+      GroupType: 226 StructureType noalg.map.group[[4]string][2]int
+      GroupSliceType: 231 GoSliceDataType []noalg.map.group[[4]string][2]int.array
     - __kind: GoSwissMapGroupsType
-      ID: 207
+      ID: 243
       Name: groupReference<bool,main.node>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 208 PointerType *noalg.map.group[bool]main.node
+          Type: 244 PointerType *noalg.map.group[bool]main.node
         - Name: lengthMask
           Offset: 8
           Type: 8 BaseType uint64
-      GroupType: 209 StructureType noalg.map.group[bool]main.node
-      GroupSliceType: 213 GoSliceDataType []noalg.map.group[bool]main.node.array
+      GroupType: 245 StructureType noalg.map.group[bool]main.node
+      GroupSliceType: 249 GoSliceDataType []noalg.map.group[bool]main.node.array
     - __kind: GoSwissMapGroupsType
-      ID: 156
+      ID: 182
+      Name: groupReference<int,*main.deepMap2>
+      ByteSize: 16
+      GoKind: 25
+      RawFields:
+        - Name: data
+          Offset: 0
+          Type: 183 PointerType *noalg.map.group[int]*main.deepMap2
+        - Name: lengthMask
+          Offset: 8
+          Type: 8 BaseType uint64
+      GroupType: 184 StructureType noalg.map.group[int]*main.deepMap2
+      GroupSliceType: 190 GoSliceDataType []noalg.map.group[int]*main.deepMap2.array
+    - __kind: GoSwissMapGroupsType
+      ID: 320
+      Name: groupReference<int,*main.deepMap3>
+      ByteSize: 16
+      GoKind: 25
+      RawFields:
+        - Name: data
+          Offset: 0
+          Type: 321 PointerType *noalg.map.group[int]*main.deepMap3
+        - Name: lengthMask
+          Offset: 8
+          Type: 8 BaseType uint64
+      GroupType: 322 StructureType noalg.map.group[int]*main.deepMap3
+      GroupSliceType: 328 GoSliceDataType []noalg.map.group[int]*main.deepMap3.array
+    - __kind: GoSwissMapGroupsType
+      ID: 355
+      Name: groupReference<int,*main.deepMap8>
+      ByteSize: 16
+      GoKind: 25
+      RawFields:
+        - Name: data
+          Offset: 0
+          Type: 356 PointerType *noalg.map.group[int]*main.deepMap8
+        - Name: lengthMask
+          Offset: 8
+          Type: 8 BaseType uint64
+      GroupType: 357 StructureType noalg.map.group[int]*main.deepMap8
+      GroupSliceType: 363 GoSliceDataType []noalg.map.group[int]*main.deepMap8.array
+    - __kind: GoSwissMapGroupsType
+      ID: 370
+      Name: groupReference<int,*main.deepMap9>
+      ByteSize: 16
+      GoKind: 25
+      RawFields:
+        - Name: data
+          Offset: 0
+          Type: 371 PointerType *noalg.map.group[int]*main.deepMap9
+        - Name: lengthMask
+          Offset: 8
+          Type: 8 BaseType uint64
+      GroupType: 372 StructureType noalg.map.group[int]*main.deepMap9
+      GroupSliceType: 378 GoSliceDataType []noalg.map.group[int]*main.deepMap9.array
+    - __kind: GoSwissMapGroupsType
+      ID: 192
       Name: groupReference<int,int>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 157 PointerType *noalg.map.group[int]int
+          Type: 193 PointerType *noalg.map.group[int]int
         - Name: lengthMask
           Offset: 8
           Type: 8 BaseType uint64
-      GroupType: 158 StructureType noalg.map.group[int]int
-      GroupSliceType: 162 GoSliceDataType []noalg.map.group[int]int.array
+      GroupType: 194 StructureType noalg.map.group[int]int
+      GroupSliceType: 198 GoSliceDataType []noalg.map.group[int]int.array
     - __kind: GoSwissMapGroupsType
-      ID: 215
+      ID: 385
+      Name: groupReference<int,interface {}>
+      ByteSize: 16
+      GoKind: 25
+      RawFields:
+        - Name: data
+          Offset: 0
+          Type: 386 PointerType *noalg.map.group[int]interface {}
+        - Name: lengthMask
+          Offset: 8
+          Type: 8 BaseType uint64
+      GroupType: 387 StructureType noalg.map.group[int]interface {}
+      GroupSliceType: 391 GoSliceDataType []noalg.map.group[int]interface {}.array
+    - __kind: GoSwissMapGroupsType
+      ID: 251
       Name: groupReference<int,uint8>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 216 PointerType *noalg.map.group[int]uint8
+          Type: 252 PointerType *noalg.map.group[int]uint8
         - Name: lengthMask
           Offset: 8
           Type: 8 BaseType uint64
-      GroupType: 217 StructureType noalg.map.group[int]uint8
-      GroupSliceType: 221 GoSliceDataType []noalg.map.group[int]uint8.array
+      GroupType: 253 StructureType noalg.map.group[int]uint8
+      GroupSliceType: 257 GoSliceDataType []noalg.map.group[int]uint8.array
     - __kind: GoSwissMapGroupsType
-      ID: 197
+      ID: 233
       Name: groupReference<string,[]main.structWithMap>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 198 PointerType *noalg.map.group[string][]main.structWithMap
+          Type: 234 PointerType *noalg.map.group[string][]main.structWithMap
         - Name: lengthMask
           Offset: 8
           Type: 8 BaseType uint64
-      GroupType: 199 StructureType noalg.map.group[string][]main.structWithMap
-      GroupSliceType: 205 GoSliceDataType []noalg.map.group[string][]main.structWithMap.array
+      GroupType: 235 StructureType noalg.map.group[string][]main.structWithMap
+      GroupSliceType: 241 GoSliceDataType []noalg.map.group[string][]main.structWithMap.array
     - __kind: GoSwissMapGroupsType
-      ID: 180
+      ID: 216
       Name: groupReference<string,[]string>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 181 PointerType *noalg.map.group[string][]string
+          Type: 217 PointerType *noalg.map.group[string][]string
         - Name: lengthMask
           Offset: 8
           Type: 8 BaseType uint64
-      GroupType: 182 StructureType noalg.map.group[string][]string
-      GroupSliceType: 186 GoSliceDataType []noalg.map.group[string][]string.array
+      GroupType: 218 StructureType noalg.map.group[string][]string
+      GroupSliceType: 222 GoSliceDataType []noalg.map.group[string][]string.array
     - __kind: GoSwissMapGroupsType
-      ID: 172
+      ID: 208
       Name: groupReference<string,int>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 173 PointerType *noalg.map.group[string]int
+          Type: 209 PointerType *noalg.map.group[string]int
         - Name: lengthMask
           Offset: 8
           Type: 8 BaseType uint64
-      GroupType: 174 StructureType noalg.map.group[string]int
-      GroupSliceType: 178 GoSliceDataType []noalg.map.group[string]int.array
+      GroupType: 210 StructureType noalg.map.group[string]int
+      GroupSliceType: 214 GoSliceDataType []noalg.map.group[string]int.array
     - __kind: GoSwissMapGroupsType
-      ID: 164
+      ID: 200
       Name: groupReference<string,main.nestedStruct>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 165 PointerType *noalg.map.group[string]main.nestedStruct
+          Type: 201 PointerType *noalg.map.group[string]main.nestedStruct
         - Name: lengthMask
           Offset: 8
           Type: 8 BaseType uint64
-      GroupType: 166 StructureType noalg.map.group[string]main.nestedStruct
-      GroupSliceType: 170 GoSliceDataType []noalg.map.group[string]main.nestedStruct.array
+      GroupType: 202 StructureType noalg.map.group[string]main.nestedStruct
+      GroupSliceType: 206 GoSliceDataType []noalg.map.group[string]main.nestedStruct.array
     - __kind: GoSwissMapGroupsType
-      ID: 231
+      ID: 267
       Name: groupReference<uint8,[4]int>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 232 PointerType *noalg.map.group[uint8][4]int
+          Type: 268 PointerType *noalg.map.group[uint8][4]int
         - Name: lengthMask
           Offset: 8
           Type: 8 BaseType uint64
-      GroupType: 233 StructureType noalg.map.group[uint8][4]int
-      GroupSliceType: 238 GoSliceDataType []noalg.map.group[uint8][4]int.array
+      GroupType: 269 StructureType noalg.map.group[uint8][4]int
+      GroupSliceType: 274 GoSliceDataType []noalg.map.group[uint8][4]int.array
     - __kind: GoSwissMapGroupsType
-      ID: 223
+      ID: 259
       Name: groupReference<uint8,uint8>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 224 PointerType *noalg.map.group[uint8]uint8
+          Type: 260 PointerType *noalg.map.group[uint8]uint8
         - Name: lengthMask
           Offset: 8
           Type: 8 BaseType uint64
-      GroupType: 225 StructureType noalg.map.group[uint8]uint8
-      GroupSliceType: 229 GoSliceDataType []noalg.map.group[uint8]uint8.array
+      GroupType: 261 StructureType noalg.map.group[uint8]uint8
+      GroupSliceType: 265 GoSliceDataType []noalg.map.group[uint8]uint8.array
     - __kind: BaseType
       ID: 7
       Name: int
       ByteSize: 8
-      GoRuntimeType: 579360
+      GoRuntimeType: 584480
       GoKind: 2
     - __kind: BaseType
       ID: 31
       Name: int16
       ByteSize: 2
-      GoRuntimeType: 578976
+      GoRuntimeType: 584096
       GoKind: 4
     - __kind: BaseType
       ID: 10
       Name: int32
       ByteSize: 4
-      GoRuntimeType: 579104
+      GoRuntimeType: 584224
       GoKind: 5
     - __kind: BaseType
       ID: 12
       Name: int64
       ByteSize: 8
-      GoRuntimeType: 579232
+      GoRuntimeType: 584352
       GoKind: 6
     - __kind: BaseType
       ID: 16
       Name: int8
       ByteSize: 1
-      GoRuntimeType: 578848
+      GoRuntimeType: 583968
       GoKind: 3
     - __kind: GoEmptyInterfaceType
-      ID: 58
+      ID: 81
       Name: interface {}
       ByteSize: 16
-      GoRuntimeType: 841856
+      GoRuntimeType: 847840
       GoKind: 20
       RawFields:
         - Name: _type
@@ -5928,10 +6796,10 @@ Types:
           Offset: 8
           Type: 14 VoidPointerType unsafe.Pointer
     - __kind: StructureType
-      ID: 269
+      ID: 394
       Name: internal/sync.Mutex
       ByteSize: 8
-      GoRuntimeType: 1.46e+06
+      GoRuntimeType: 1.472896e+06
       GoKind: 25
       RawFields:
         - Name: state
@@ -5944,7 +6812,7 @@ Types:
       ID: 55
       Name: io.Writer
       ByteSize: 16
-      GoRuntimeType: 1.016736e+06
+      GoRuntimeType: 1.02272e+06
       GoKind: 20
       RawFields:
         - Name: tab
@@ -5954,7 +6822,7 @@ Types:
           Offset: 8
           Type: 14 VoidPointerType unsafe.Pointer
     - __kind: StructureType
-      ID: 148
+      ID: 171
       Name: main.aStruct
       ByteSize: 56
       GoKind: 25
@@ -5970,12 +6838,12 @@ Types:
           Type: 7 BaseType int
         - Name: nested
           Offset: 32
-          Type: 149 StructureType main.nestedStruct
+          Type: 172 StructureType main.nestedStruct
     - __kind: GoInterfaceType
-      ID: 64
+      ID: 87
       Name: main.behavior
       ByteSize: 16
-      GoRuntimeType: 1.016352e+06
+      GoRuntimeType: 1.022336e+06
       GoKind: 20
       RawFields:
         - Name: tab
@@ -6000,37 +6868,199 @@ Types:
           Offset: 32
           Type: 55 GoInterfaceType io.Writer
     - __kind: StructureType
-      ID: 150
+      ID: 67
+      Name: main.deepMap1
+      ByteSize: 8
+      GoRuntimeType: 1.185792e+06
+      GoKind: 25
+      RawFields:
+        - Name: a
+          Offset: 0
+          Type: 68 GoMapType map[int]*main.deepMap2
+    - __kind: StructureType
+      ID: 188
+      Name: main.deepMap2
+      ByteSize: 8
+      GoRuntimeType: 1.185664e+06
+      GoKind: 25
+      RawFields:
+        - Name: a
+          Offset: 0
+          Type: 314 GoMapType map[int]*main.deepMap3
+    - __kind: UnresolvedPointeeType
+      ID: 326
+      Name: main.deepMap3
+      ByteSize: 8
+    - __kind: StructureType
+      ID: 74
+      Name: main.deepMap7
+      ByteSize: 8
+      GoRuntimeType: 1.185024e+06
+      GoKind: 25
+      RawFields:
+        - Name: a
+          Offset: 0
+          Type: 349 GoMapType map[int]*main.deepMap8
+    - __kind: StructureType
+      ID: 361
+      Name: main.deepMap8
+      ByteSize: 8
+      GoRuntimeType: 1.184896e+06
+      GoKind: 25
+      RawFields:
+        - Name: a
+          Offset: 0
+          Type: 364 GoMapType map[int]*main.deepMap9
+    - __kind: StructureType
+      ID: 376
+      Name: main.deepMap9
+      ByteSize: 8
+      GoRuntimeType: 1.184768e+06
+      GoKind: 25
+      RawFields:
+        - Name: a
+          Offset: 0
+          Type: 379 GoMapType map[int]interface {}
+    - __kind: StructureType
+      ID: 56
+      Name: main.deepPtr1
+      ByteSize: 8
+      GoRuntimeType: 1.186944e+06
+      GoKind: 25
+      RawFields:
+        - Name: a
+          Offset: 0
+          Type: 57 PointerType *main.deepPtr2
+    - __kind: StructureType
+      ID: 58
+      Name: main.deepPtr2
+      ByteSize: 8
+      GoRuntimeType: 1.186816e+06
+      GoKind: 25
+      RawFields:
+        - Name: a
+          Offset: 0
+          Type: 303 PointerType *main.deepPtr3
+    - __kind: UnresolvedPointeeType
+      ID: 304
+      Name: main.deepPtr3
+      ByteSize: 8
+    - __kind: StructureType
+      ID: 60
+      Name: main.deepPtr7
+      ByteSize: 8
+      GoRuntimeType: 1.186176e+06
+      GoKind: 25
+      RawFields:
+        - Name: a
+          Offset: 0
+          Type: 329 PointerType *main.deepPtr8
+    - __kind: StructureType
+      ID: 330
+      Name: main.deepPtr8
+      ByteSize: 8
+      GoRuntimeType: 1.186048e+06
+      GoKind: 25
+      RawFields:
+        - Name: a
+          Offset: 0
+          Type: 331 PointerType *main.deepPtr9
+    - __kind: StructureType
+      ID: 332
+      Name: main.deepPtr9
+      ByteSize: 16
+      GoRuntimeType: 1.18592e+06
+      GoKind: 25
+      RawFields:
+        - Name: a
+          Offset: 0
+          Type: 81 GoEmptyInterfaceType interface {}
+    - __kind: StructureType
+      ID: 61
+      Name: main.deepSlice1
+      ByteSize: 24
+      GoRuntimeType: 1.188096e+06
+      GoKind: 25
+      RawFields:
+        - Name: a
+          Offset: 0
+          Type: 62 GoSliceHeaderType []*main.deepSlice2
+    - __kind: StructureType
+      ID: 178
+      Name: main.deepSlice2
+      ByteSize: 24
+      GoRuntimeType: 1.187968e+06
+      GoKind: 25
+      RawFields:
+        - Name: a
+          Offset: 0
+          Type: 308 GoSliceHeaderType []*main.deepSlice3
+    - __kind: UnresolvedPointeeType
+      ID: 311
+      Name: main.deepSlice3
+      ByteSize: 8
+    - __kind: StructureType
+      ID: 66
+      Name: main.deepSlice7
+      ByteSize: 24
+      GoRuntimeType: 1.187328e+06
+      GoKind: 25
+      RawFields:
+        - Name: a
+          Offset: 0
+          Type: 333 GoSliceHeaderType []*main.deepSlice8
+    - __kind: StructureType
+      ID: 336
+      Name: main.deepSlice8
+      ByteSize: 24
+      GoRuntimeType: 1.1872e+06
+      GoKind: 25
+      RawFields:
+        - Name: a
+          Offset: 0
+          Type: 339 GoSliceHeaderType []*main.deepSlice9
+    - __kind: StructureType
+      ID: 342
+      Name: main.deepSlice9
+      ByteSize: 24
+      GoRuntimeType: 1.187072e+06
+      GoKind: 25
+      RawFields:
+        - Name: a
+          Offset: 0
+          Type: 345 GoSliceHeaderType []interface {}
+    - __kind: StructureType
+      ID: 173
       Name: main.emptyStruct
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 62
+      ID: 85
       Name: main.esotericHeap
       ByteSize: 112
-      GoRuntimeType: 1.82096e+06
+      GoRuntimeType: 1.833856e+06
       GoKind: 25
       RawFields:
         - Name: esotericStack
           Offset: 0
-          Type: 56 StructureType main.esotericStack
+          Type: 79 StructureType main.esotericStack
         - Name: mu
           Offset: 64
-          Type: 267 StructureType sync.Mutex
+          Type: 392 StructureType sync.Mutex
         - Name: once
           Offset: 72
-          Type: 270 StructureType sync.Once
+          Type: 395 StructureType sync.Once
         - Name: wg
           Offset: 88
-          Type: 273 StructureType sync.WaitGroup
+          Type: 398 StructureType sync.WaitGroup
         - Name: a
           Offset: 104
-          Type: 276 StructureType sync/atomic.Int32
+          Type: 401 StructureType sync/atomic.Int32
     - __kind: StructureType
-      ID: 56
+      ID: 79
       Name: main.esotericStack
       ByteSize: 64
-      GoRuntimeType: 1.954272e+06
+      GoRuntimeType: 1.967168e+06
       GoKind: 25
       RawFields:
         - Name: _
@@ -6041,24 +7071,24 @@ Types:
           Type: 10 BaseType int32
         - Name: c
           Offset: 8
-          Type: 57 GoChannelType chan struct {}
+          Type: 80 GoChannelType chan struct {}
         - Name: val
           Offset: 16
-          Type: 58 GoEmptyInterfaceType interface {}
+          Type: 81 GoEmptyInterfaceType interface {}
         - Name: _
           Offset: 32
           Type: 8 BaseType uint64
         - Name: work
           Offset: 40
-          Type: 59 GoInterfaceType main.something
+          Type: 82 GoInterfaceType main.something
         - Name: foo
           Offset: 56
-          Type: 60 GoSubroutineType func()
+          Type: 83 GoSubroutineType func()
     - __kind: StructureType
-      ID: 149
+      ID: 172
       Name: main.nestedStruct
       ByteSize: 24
-      GoRuntimeType: 1.44864e+06
+      GoRuntimeType: 1.461536e+06
       GoKind: 25
       RawFields:
         - Name: anotherInt
@@ -6068,10 +7098,10 @@ Types:
           Offset: 8
           Type: 9 GoStringHeaderType string
     - __kind: StructureType
-      ID: 131
+      ID: 154
       Name: main.node
       ByteSize: 16
-      GoRuntimeType: 1.44848e+06
+      GoRuntimeType: 1.461376e+06
       GoKind: 25
       RawFields:
         - Name: val
@@ -6079,9 +7109,9 @@ Types:
           Type: 7 BaseType int
         - Name: b
           Offset: 8
-          Type: 132 PointerType *main.node
+          Type: 155 PointerType *main.node
     - __kind: StructureType
-      ID: 147
+      ID: 170
       Name: main.oneStringStruct
       ByteSize: 16
       GoKind: 25
@@ -6090,10 +7120,10 @@ Types:
           Offset: 0
           Type: 9 GoStringHeaderType string
     - __kind: GoInterfaceType
-      ID: 59
+      ID: 82
       Name: main.something
       ByteSize: 16
-      GoRuntimeType: 1.01648e+06
+      GoRuntimeType: 1.022464e+06
       GoKind: 20
       RawFields:
         - Name: tab
@@ -6102,18 +7132,39 @@ Types:
         - Name: data
           Offset: 8
           Type: 14 VoidPointerType unsafe.Pointer
+    - __kind: GoStringHeaderType
+      ID: 76
+      Name: main.stringType1
+      ByteSize: 16
+      GoKind: 24
+      RawFields:
+        - Name: str
+          Offset: 0
+          Type: 306 PointerType *main.stringType1.str
+        - Name: len
+          Offset: 8
+          Type: 7 BaseType int
+      Data: 305 GoStringDataType main.stringType1.str
+    - __kind: GoStringDataType
+      ID: 305
+      Name: main.stringType1.str
+      ByteSize: 2048
+    - __kind: UnresolvedPointeeType
+      ID: 307
+      Name: main.stringType2
+      ByteSize: 8
     - __kind: StructureType
-      ID: 65
+      ID: 88
       Name: main.structWithMap
       ByteSize: 8
-      GoRuntimeType: 1.177504e+06
+      GoRuntimeType: 1.18464e+06
       GoKind: 25
       RawFields:
         - Name: m
           Offset: 0
-          Type: 66 GoMapType map[int]int
+          Type: 89 GoMapType map[int]int
     - __kind: StructureType
-      ID: 140
+      ID: 163
       Name: main.structWithNoStrings
       ByteSize: 2
       GoKind: 25
@@ -6125,7 +7176,7 @@ Types:
           Offset: 1
           Type: 4 BaseType bool
     - __kind: StructureType
-      ID: 130
+      ID: 153
       Name: main.structWithTwoValues
       ByteSize: 16
       GoKind: 25
@@ -6137,28 +7188,28 @@ Types:
           Offset: 8
           Type: 4 BaseType bool
     - __kind: GoSliceHeaderType
-      ID: 134
+      ID: 157
       Name: main.t
       ByteSize: 24
       GoKind: 23
       RawFields:
         - Name: array
           Offset: 0
-          Type: 277 PointerType **main.t
+          Type: 402 PointerType **main.t
         - Name: len
           Offset: 8
           Type: 7 BaseType int
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 278 GoSliceDataType main.t.array
+      Data: 403 GoSliceDataType main.t.array
     - __kind: GoSliceDataType
-      ID: 278
+      ID: 403
       Name: main.t.array
       ByteSize: 2048
-      Element: 133 PointerType *main.t
+      Element: 156 PointerType *main.t
     - __kind: StructureType
-      ID: 144
+      ID: 167
       Name: main.threeStringStruct
       ByteSize: 48
       GoKind: 25
@@ -6178,7 +7229,7 @@ Types:
       ByteSize: 2
       GoKind: 9
     - __kind: GoSwissMapHeaderType
-      ID: 125
+      ID: 148
       Name: map<[4]int,[4]int>
       ByteSize: 48
       GoKind: 25
@@ -6191,7 +7242,7 @@ Types:
           Type: 1 BaseType uintptr
         - Name: dirPtr
           Offset: 16
-          Type: 126 PointerType **table<[4]int,[4]int>
+          Type: 149 PointerType **table<[4]int,[4]int>
         - Name: dirLen
           Offset: 24
           Type: 7 BaseType int
@@ -6210,10 +7261,10 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 8 BaseType uint64
-      TablePtrSliceType: 253 GoSliceDataType []*table<[4]int,[4]int>.array
-      GroupType: 250 StructureType noalg.map.group[[4]int][4]int
+      TablePtrSliceType: 289 GoSliceDataType []*table<[4]int,[4]int>.array
+      GroupType: 286 StructureType noalg.map.group[[4]int][4]int
     - __kind: GoSwissMapHeaderType
-      ID: 120
+      ID: 143
       Name: map<[4]int,uint8>
       ByteSize: 48
       GoKind: 25
@@ -6226,7 +7277,7 @@ Types:
           Type: 1 BaseType uintptr
         - Name: dirPtr
           Offset: 16
-          Type: 121 PointerType **table<[4]int,uint8>
+          Type: 144 PointerType **table<[4]int,uint8>
         - Name: dirLen
           Offset: 24
           Type: 7 BaseType int
@@ -6245,10 +7296,10 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 8 BaseType uint64
-      TablePtrSliceType: 245 GoSliceDataType []*table<[4]int,uint8>.array
-      GroupType: 242 StructureType noalg.map.group[[4]int]uint8
+      TablePtrSliceType: 281 GoSliceDataType []*table<[4]int,uint8>.array
+      GroupType: 278 StructureType noalg.map.group[[4]int]uint8
     - __kind: GoSwissMapHeaderType
-      ID: 88
+      ID: 111
       Name: map<[4]string,[2]int>
       ByteSize: 48
       GoKind: 25
@@ -6261,7 +7312,7 @@ Types:
           Type: 1 BaseType uintptr
         - Name: dirPtr
           Offset: 16
-          Type: 89 PointerType **table<[4]string,[2]int>
+          Type: 112 PointerType **table<[4]string,[2]int>
         - Name: dirLen
           Offset: 24
           Type: 7 BaseType int
@@ -6280,10 +7331,10 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 8 BaseType uint64
-      TablePtrSliceType: 194 GoSliceDataType []*table<[4]string,[2]int>.array
-      GroupType: 190 StructureType noalg.map.group[[4]string][2]int
+      TablePtrSliceType: 230 GoSliceDataType []*table<[4]string,[2]int>.array
+      GroupType: 226 StructureType noalg.map.group[[4]string][2]int
     - __kind: GoSwissMapHeaderType
-      ID: 100
+      ID: 123
       Name: map<bool,main.node>
       ByteSize: 48
       GoKind: 25
@@ -6296,7 +7347,7 @@ Types:
           Type: 1 BaseType uintptr
         - Name: dirPtr
           Offset: 16
-          Type: 101 PointerType **table<bool,main.node>
+          Type: 124 PointerType **table<bool,main.node>
         - Name: dirLen
           Offset: 24
           Type: 7 BaseType int
@@ -6315,10 +7366,150 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 8 BaseType uint64
-      TablePtrSliceType: 212 GoSliceDataType []*table<bool,main.node>.array
-      GroupType: 209 StructureType noalg.map.group[bool]main.node
+      TablePtrSliceType: 248 GoSliceDataType []*table<bool,main.node>.array
+      GroupType: 245 StructureType noalg.map.group[bool]main.node
     - __kind: GoSwissMapHeaderType
-      ID: 68
+      ID: 70
+      Name: map<int,*main.deepMap2>
+      ByteSize: 48
+      GoKind: 25
+      RawFields:
+        - Name: used
+          Offset: 0
+          Type: 8 BaseType uint64
+        - Name: seed
+          Offset: 8
+          Type: 1 BaseType uintptr
+        - Name: dirPtr
+          Offset: 16
+          Type: 71 PointerType **table<int,*main.deepMap2>
+        - Name: dirLen
+          Offset: 24
+          Type: 7 BaseType int
+        - Name: globalDepth
+          Offset: 32
+          Type: 3 BaseType uint8
+        - Name: globalShift
+          Offset: 33
+          Type: 3 BaseType uint8
+        - Name: writing
+          Offset: 34
+          Type: 3 BaseType uint8
+        - Name: tombstonePossible
+          Offset: 35
+          Type: 4 BaseType bool
+        - Name: clearSeq
+          Offset: 40
+          Type: 8 BaseType uint64
+      TablePtrSliceType: 189 GoSliceDataType []*table<int,*main.deepMap2>.array
+      GroupType: 184 StructureType noalg.map.group[int]*main.deepMap2
+    - __kind: GoSwissMapHeaderType
+      ID: 316
+      Name: map<int,*main.deepMap3>
+      ByteSize: 48
+      GoKind: 25
+      RawFields:
+        - Name: used
+          Offset: 0
+          Type: 8 BaseType uint64
+        - Name: seed
+          Offset: 8
+          Type: 1 BaseType uintptr
+        - Name: dirPtr
+          Offset: 16
+          Type: 317 PointerType **table<int,*main.deepMap3>
+        - Name: dirLen
+          Offset: 24
+          Type: 7 BaseType int
+        - Name: globalDepth
+          Offset: 32
+          Type: 3 BaseType uint8
+        - Name: globalShift
+          Offset: 33
+          Type: 3 BaseType uint8
+        - Name: writing
+          Offset: 34
+          Type: 3 BaseType uint8
+        - Name: tombstonePossible
+          Offset: 35
+          Type: 4 BaseType bool
+        - Name: clearSeq
+          Offset: 40
+          Type: 8 BaseType uint64
+      TablePtrSliceType: 327 GoSliceDataType []*table<int,*main.deepMap3>.array
+      GroupType: 322 StructureType noalg.map.group[int]*main.deepMap3
+    - __kind: GoSwissMapHeaderType
+      ID: 351
+      Name: map<int,*main.deepMap8>
+      ByteSize: 48
+      GoKind: 25
+      RawFields:
+        - Name: used
+          Offset: 0
+          Type: 8 BaseType uint64
+        - Name: seed
+          Offset: 8
+          Type: 1 BaseType uintptr
+        - Name: dirPtr
+          Offset: 16
+          Type: 352 PointerType **table<int,*main.deepMap8>
+        - Name: dirLen
+          Offset: 24
+          Type: 7 BaseType int
+        - Name: globalDepth
+          Offset: 32
+          Type: 3 BaseType uint8
+        - Name: globalShift
+          Offset: 33
+          Type: 3 BaseType uint8
+        - Name: writing
+          Offset: 34
+          Type: 3 BaseType uint8
+        - Name: tombstonePossible
+          Offset: 35
+          Type: 4 BaseType bool
+        - Name: clearSeq
+          Offset: 40
+          Type: 8 BaseType uint64
+      TablePtrSliceType: 362 GoSliceDataType []*table<int,*main.deepMap8>.array
+      GroupType: 357 StructureType noalg.map.group[int]*main.deepMap8
+    - __kind: GoSwissMapHeaderType
+      ID: 366
+      Name: map<int,*main.deepMap9>
+      ByteSize: 48
+      GoKind: 25
+      RawFields:
+        - Name: used
+          Offset: 0
+          Type: 8 BaseType uint64
+        - Name: seed
+          Offset: 8
+          Type: 1 BaseType uintptr
+        - Name: dirPtr
+          Offset: 16
+          Type: 367 PointerType **table<int,*main.deepMap9>
+        - Name: dirLen
+          Offset: 24
+          Type: 7 BaseType int
+        - Name: globalDepth
+          Offset: 32
+          Type: 3 BaseType uint8
+        - Name: globalShift
+          Offset: 33
+          Type: 3 BaseType uint8
+        - Name: writing
+          Offset: 34
+          Type: 3 BaseType uint8
+        - Name: tombstonePossible
+          Offset: 35
+          Type: 4 BaseType bool
+        - Name: clearSeq
+          Offset: 40
+          Type: 8 BaseType uint64
+      TablePtrSliceType: 377 GoSliceDataType []*table<int,*main.deepMap9>.array
+      GroupType: 372 StructureType noalg.map.group[int]*main.deepMap9
+    - __kind: GoSwissMapHeaderType
+      ID: 91
       Name: map<int,int>
       ByteSize: 48
       GoKind: 25
@@ -6331,7 +7522,7 @@ Types:
           Type: 1 BaseType uintptr
         - Name: dirPtr
           Offset: 16
-          Type: 69 PointerType **table<int,int>
+          Type: 92 PointerType **table<int,int>
         - Name: dirLen
           Offset: 24
           Type: 7 BaseType int
@@ -6350,10 +7541,45 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 8 BaseType uint64
-      TablePtrSliceType: 161 GoSliceDataType []*table<int,int>.array
-      GroupType: 158 StructureType noalg.map.group[int]int
+      TablePtrSliceType: 197 GoSliceDataType []*table<int,int>.array
+      GroupType: 194 StructureType noalg.map.group[int]int
     - __kind: GoSwissMapHeaderType
-      ID: 105
+      ID: 381
+      Name: map<int,interface {}>
+      ByteSize: 48
+      GoKind: 25
+      RawFields:
+        - Name: used
+          Offset: 0
+          Type: 8 BaseType uint64
+        - Name: seed
+          Offset: 8
+          Type: 1 BaseType uintptr
+        - Name: dirPtr
+          Offset: 16
+          Type: 382 PointerType **table<int,interface {}>
+        - Name: dirLen
+          Offset: 24
+          Type: 7 BaseType int
+        - Name: globalDepth
+          Offset: 32
+          Type: 3 BaseType uint8
+        - Name: globalShift
+          Offset: 33
+          Type: 3 BaseType uint8
+        - Name: writing
+          Offset: 34
+          Type: 3 BaseType uint8
+        - Name: tombstonePossible
+          Offset: 35
+          Type: 4 BaseType bool
+        - Name: clearSeq
+          Offset: 40
+          Type: 8 BaseType uint64
+      TablePtrSliceType: 390 GoSliceDataType []*table<int,interface {}>.array
+      GroupType: 387 StructureType noalg.map.group[int]interface {}
+    - __kind: GoSwissMapHeaderType
+      ID: 128
       Name: map<int,uint8>
       ByteSize: 48
       GoKind: 25
@@ -6366,7 +7592,7 @@ Types:
           Type: 1 BaseType uintptr
         - Name: dirPtr
           Offset: 16
-          Type: 106 PointerType **table<int,uint8>
+          Type: 129 PointerType **table<int,uint8>
         - Name: dirLen
           Offset: 24
           Type: 7 BaseType int
@@ -6385,10 +7611,10 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 8 BaseType uint64
-      TablePtrSliceType: 220 GoSliceDataType []*table<int,uint8>.array
-      GroupType: 217 StructureType noalg.map.group[int]uint8
+      TablePtrSliceType: 256 GoSliceDataType []*table<int,uint8>.array
+      GroupType: 253 StructureType noalg.map.group[int]uint8
     - __kind: GoSwissMapHeaderType
-      ID: 95
+      ID: 118
       Name: map<string,[]main.structWithMap>
       ByteSize: 48
       GoKind: 25
@@ -6401,7 +7627,7 @@ Types:
           Type: 1 BaseType uintptr
         - Name: dirPtr
           Offset: 16
-          Type: 96 PointerType **table<string,[]main.structWithMap>
+          Type: 119 PointerType **table<string,[]main.structWithMap>
         - Name: dirLen
           Offset: 24
           Type: 7 BaseType int
@@ -6420,10 +7646,10 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 8 BaseType uint64
-      TablePtrSliceType: 204 GoSliceDataType []*table<string,[]main.structWithMap>.array
-      GroupType: 199 StructureType noalg.map.group[string][]main.structWithMap
+      TablePtrSliceType: 240 GoSliceDataType []*table<string,[]main.structWithMap>.array
+      GroupType: 235 StructureType noalg.map.group[string][]main.structWithMap
     - __kind: GoSwissMapHeaderType
-      ID: 83
+      ID: 106
       Name: map<string,[]string>
       ByteSize: 48
       GoKind: 25
@@ -6436,7 +7662,7 @@ Types:
           Type: 1 BaseType uintptr
         - Name: dirPtr
           Offset: 16
-          Type: 84 PointerType **table<string,[]string>
+          Type: 107 PointerType **table<string,[]string>
         - Name: dirLen
           Offset: 24
           Type: 7 BaseType int
@@ -6455,10 +7681,10 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 8 BaseType uint64
-      TablePtrSliceType: 185 GoSliceDataType []*table<string,[]string>.array
-      GroupType: 182 StructureType noalg.map.group[string][]string
+      TablePtrSliceType: 221 GoSliceDataType []*table<string,[]string>.array
+      GroupType: 218 StructureType noalg.map.group[string][]string
     - __kind: GoSwissMapHeaderType
-      ID: 78
+      ID: 101
       Name: map<string,int>
       ByteSize: 48
       GoKind: 25
@@ -6471,7 +7697,7 @@ Types:
           Type: 1 BaseType uintptr
         - Name: dirPtr
           Offset: 16
-          Type: 79 PointerType **table<string,int>
+          Type: 102 PointerType **table<string,int>
         - Name: dirLen
           Offset: 24
           Type: 7 BaseType int
@@ -6490,10 +7716,10 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 8 BaseType uint64
-      TablePtrSliceType: 177 GoSliceDataType []*table<string,int>.array
-      GroupType: 174 StructureType noalg.map.group[string]int
+      TablePtrSliceType: 213 GoSliceDataType []*table<string,int>.array
+      GroupType: 210 StructureType noalg.map.group[string]int
     - __kind: GoSwissMapHeaderType
-      ID: 73
+      ID: 96
       Name: map<string,main.nestedStruct>
       ByteSize: 48
       GoKind: 25
@@ -6506,7 +7732,7 @@ Types:
           Type: 1 BaseType uintptr
         - Name: dirPtr
           Offset: 16
-          Type: 74 PointerType **table<string,main.nestedStruct>
+          Type: 97 PointerType **table<string,main.nestedStruct>
         - Name: dirLen
           Offset: 24
           Type: 7 BaseType int
@@ -6525,10 +7751,10 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 8 BaseType uint64
-      TablePtrSliceType: 169 GoSliceDataType []*table<string,main.nestedStruct>.array
-      GroupType: 166 StructureType noalg.map.group[string]main.nestedStruct
+      TablePtrSliceType: 205 GoSliceDataType []*table<string,main.nestedStruct>.array
+      GroupType: 202 StructureType noalg.map.group[string]main.nestedStruct
     - __kind: GoSwissMapHeaderType
-      ID: 115
+      ID: 138
       Name: map<uint8,[4]int>
       ByteSize: 48
       GoKind: 25
@@ -6541,7 +7767,7 @@ Types:
           Type: 1 BaseType uintptr
         - Name: dirPtr
           Offset: 16
-          Type: 116 PointerType **table<uint8,[4]int>
+          Type: 139 PointerType **table<uint8,[4]int>
         - Name: dirLen
           Offset: 24
           Type: 7 BaseType int
@@ -6560,10 +7786,10 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 8 BaseType uint64
-      TablePtrSliceType: 237 GoSliceDataType []*table<uint8,[4]int>.array
-      GroupType: 233 StructureType noalg.map.group[uint8][4]int
+      TablePtrSliceType: 273 GoSliceDataType []*table<uint8,[4]int>.array
+      GroupType: 269 StructureType noalg.map.group[uint8][4]int
     - __kind: GoSwissMapHeaderType
-      ID: 110
+      ID: 133
       Name: map<uint8,uint8>
       ByteSize: 48
       GoKind: 25
@@ -6576,7 +7802,7 @@ Types:
           Type: 1 BaseType uintptr
         - Name: dirPtr
           Offset: 16
-          Type: 111 PointerType **table<uint8,uint8>
+          Type: 134 PointerType **table<uint8,uint8>
         - Name: dirLen
           Offset: 24
           Type: 7 BaseType int
@@ -6595,205 +7821,285 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 8 BaseType uint64
-      TablePtrSliceType: 228 GoSliceDataType []*table<uint8,uint8>.array
-      GroupType: 225 StructureType noalg.map.group[uint8]uint8
+      TablePtrSliceType: 264 GoSliceDataType []*table<uint8,uint8>.array
+      GroupType: 261 StructureType noalg.map.group[uint8]uint8
     - __kind: GoMapType
-      ID: 123
+      ID: 146
       Name: map[[4]int][4]int
       ByteSize: 8
-      GoRuntimeType: 1.1224e+06
+      GoRuntimeType: 1.129536e+06
       GoKind: 21
-      HeaderType: 125 GoSwissMapHeaderType map<[4]int,[4]int>
+      HeaderType: 148 GoSwissMapHeaderType map<[4]int,[4]int>
     - __kind: GoMapType
-      ID: 118
+      ID: 141
       Name: map[[4]int]uint8
       ByteSize: 8
-      GoRuntimeType: 1.122528e+06
+      GoRuntimeType: 1.129664e+06
       GoKind: 21
-      HeaderType: 120 GoSwissMapHeaderType map<[4]int,uint8>
+      HeaderType: 143 GoSwissMapHeaderType map<[4]int,uint8>
     - __kind: GoMapType
-      ID: 86
+      ID: 109
       Name: map[[4]string][2]int
       ByteSize: 8
-      GoRuntimeType: 1.122656e+06
+      GoRuntimeType: 1.129792e+06
       GoKind: 21
-      HeaderType: 88 GoSwissMapHeaderType map<[4]string,[2]int>
+      HeaderType: 111 GoSwissMapHeaderType map<[4]string,[2]int>
     - __kind: GoMapType
-      ID: 98
+      ID: 121
       Name: map[bool]main.node
       ByteSize: 8
-      GoRuntimeType: 1.122784e+06
+      GoRuntimeType: 1.12992e+06
       GoKind: 21
-      HeaderType: 100 GoSwissMapHeaderType map<bool,main.node>
+      HeaderType: 123 GoSwissMapHeaderType map<bool,main.node>
     - __kind: GoMapType
-      ID: 66
+      ID: 68
+      Name: map[int]*main.deepMap2
+      ByteSize: 8
+      GoRuntimeType: 1.129408e+06
+      GoKind: 21
+      HeaderType: 70 GoSwissMapHeaderType map<int,*main.deepMap2>
+    - __kind: GoMapType
+      ID: 314
+      Name: map[int]*main.deepMap3
+      ByteSize: 8
+      GoRuntimeType: 1.12928e+06
+      GoKind: 21
+      HeaderType: 316 GoSwissMapHeaderType map<int,*main.deepMap3>
+    - __kind: GoMapType
+      ID: 349
+      Name: map[int]*main.deepMap8
+      ByteSize: 8
+      GoRuntimeType: 1.12864e+06
+      GoKind: 21
+      HeaderType: 351 GoSwissMapHeaderType map<int,*main.deepMap8>
+    - __kind: GoMapType
+      ID: 364
+      Name: map[int]*main.deepMap9
+      ByteSize: 8
+      GoRuntimeType: 1.128512e+06
+      GoKind: 21
+      HeaderType: 366 GoSwissMapHeaderType map<int,*main.deepMap9>
+    - __kind: GoMapType
+      ID: 89
       Name: map[int]int
       ByteSize: 8
-      GoRuntimeType: 1.122016e+06
+      GoRuntimeType: 1.128e+06
       GoKind: 21
-      HeaderType: 68 GoSwissMapHeaderType map<int,int>
+      HeaderType: 91 GoSwissMapHeaderType map<int,int>
     - __kind: GoMapType
-      ID: 103
+      ID: 379
+      Name: map[int]interface {}
+      ByteSize: 8
+      GoRuntimeType: 1.128384e+06
+      GoKind: 21
+      HeaderType: 381 GoSwissMapHeaderType map<int,interface {}>
+    - __kind: GoMapType
+      ID: 126
       Name: map[int]uint8
       ByteSize: 8
-      GoRuntimeType: 1.122912e+06
+      GoRuntimeType: 1.130048e+06
       GoKind: 21
-      HeaderType: 105 GoSwissMapHeaderType map<int,uint8>
+      HeaderType: 128 GoSwissMapHeaderType map<int,uint8>
     - __kind: GoMapType
-      ID: 93
+      ID: 116
       Name: map[string][]main.structWithMap
       ByteSize: 8
-      GoRuntimeType: 1.12304e+06
+      GoRuntimeType: 1.130176e+06
       GoKind: 21
-      HeaderType: 95 GoSwissMapHeaderType map<string,[]main.structWithMap>
+      HeaderType: 118 GoSwissMapHeaderType map<string,[]main.structWithMap>
     - __kind: GoMapType
-      ID: 81
+      ID: 104
       Name: map[string][]string
       ByteSize: 8
-      GoRuntimeType: 1.123168e+06
+      GoRuntimeType: 1.130304e+06
       GoKind: 21
-      HeaderType: 83 GoSwissMapHeaderType map<string,[]string>
+      HeaderType: 106 GoSwissMapHeaderType map<string,[]string>
     - __kind: GoMapType
-      ID: 76
+      ID: 99
       Name: map[string]int
       ByteSize: 8
-      GoRuntimeType: 1.123296e+06
+      GoRuntimeType: 1.130432e+06
       GoKind: 21
-      HeaderType: 78 GoSwissMapHeaderType map<string,int>
+      HeaderType: 101 GoSwissMapHeaderType map<string,int>
     - __kind: GoMapType
-      ID: 71
+      ID: 94
       Name: map[string]main.nestedStruct
       ByteSize: 8
-      GoRuntimeType: 1.123424e+06
+      GoRuntimeType: 1.13056e+06
       GoKind: 21
-      HeaderType: 73 GoSwissMapHeaderType map<string,main.nestedStruct>
+      HeaderType: 96 GoSwissMapHeaderType map<string,main.nestedStruct>
     - __kind: GoMapType
-      ID: 113
+      ID: 136
       Name: map[uint8][4]int
       ByteSize: 8
-      GoRuntimeType: 1.123552e+06
+      GoRuntimeType: 1.130688e+06
       GoKind: 21
-      HeaderType: 115 GoSwissMapHeaderType map<uint8,[4]int>
+      HeaderType: 138 GoSwissMapHeaderType map<uint8,[4]int>
     - __kind: GoMapType
-      ID: 108
+      ID: 131
       Name: map[uint8]uint8
       ByteSize: 8
-      GoRuntimeType: 1.12368e+06
+      GoRuntimeType: 1.130816e+06
       GoKind: 21
-      HeaderType: 110 GoSwissMapHeaderType map<uint8,uint8>
+      HeaderType: 133 GoSwissMapHeaderType map<uint8,uint8>
     - __kind: ArrayType
-      ID: 251
+      ID: 287
       Name: noalg.[8]struct { key [4]int; elem [4]int }
       ByteSize: 512
-      GoRuntimeType: 676736
+      GoRuntimeType: 682720
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 252 StructureType noalg.struct { key [4]int; elem [4]int }
+      Element: 288 StructureType noalg.struct { key [4]int; elem [4]int }
     - __kind: ArrayType
-      ID: 243
+      ID: 279
       Name: noalg.[8]struct { key [4]int; elem uint8 }
       ByteSize: 320
-      GoRuntimeType: 676832
+      GoRuntimeType: 682816
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 244 StructureType noalg.struct { key [4]int; elem uint8 }
+      Element: 280 StructureType noalg.struct { key [4]int; elem uint8 }
     - __kind: ArrayType
-      ID: 191
+      ID: 227
       Name: noalg.[8]struct { key [4]string; elem [2]int }
       ByteSize: 640
-      GoRuntimeType: 677120
+      GoRuntimeType: 683104
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 192 StructureType noalg.struct { key [4]string; elem [2]int }
+      Element: 228 StructureType noalg.struct { key [4]string; elem [2]int }
     - __kind: ArrayType
-      ID: 210
+      ID: 246
       Name: noalg.[8]struct { key bool; elem main.node }
       ByteSize: 192
-      GoRuntimeType: 677216
+      GoRuntimeType: 683200
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 211 StructureType noalg.struct { key bool; elem main.node }
+      Element: 247 StructureType noalg.struct { key bool; elem main.node }
     - __kind: ArrayType
-      ID: 159
+      ID: 185
+      Name: noalg.[8]struct { key int; elem *main.deepMap2 }
+      ByteSize: 128
+      GoRuntimeType: 682048
+      GoKind: 17
+      Count: 8
+      HasCount: true
+      Element: 186 StructureType noalg.struct { key int; elem *main.deepMap2 }
+    - __kind: ArrayType
+      ID: 323
+      Name: noalg.[8]struct { key int; elem *main.deepMap3 }
+      ByteSize: 128
+      GoRuntimeType: 681952
+      GoKind: 17
+      Count: 8
+      HasCount: true
+      Element: 324 StructureType noalg.struct { key int; elem *main.deepMap3 }
+    - __kind: ArrayType
+      ID: 358
+      Name: noalg.[8]struct { key int; elem *main.deepMap8 }
+      ByteSize: 128
+      GoRuntimeType: 681472
+      GoKind: 17
+      Count: 8
+      HasCount: true
+      Element: 359 StructureType noalg.struct { key int; elem *main.deepMap8 }
+    - __kind: ArrayType
+      ID: 373
+      Name: noalg.[8]struct { key int; elem *main.deepMap9 }
+      ByteSize: 128
+      GoRuntimeType: 681376
+      GoKind: 17
+      Count: 8
+      HasCount: true
+      Element: 374 StructureType noalg.struct { key int; elem *main.deepMap9 }
+    - __kind: ArrayType
+      ID: 195
       Name: noalg.[8]struct { key int; elem int }
       ByteSize: 128
-      GoRuntimeType: 675008
+      GoRuntimeType: 680128
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 160 StructureType noalg.struct { key int; elem int }
+      Element: 196 StructureType noalg.struct { key int; elem int }
     - __kind: ArrayType
-      ID: 218
+      ID: 388
+      Name: noalg.[8]struct { key int; elem interface {} }
+      ByteSize: 192
+      GoRuntimeType: 681280
+      GoKind: 17
+      Count: 8
+      HasCount: true
+      Element: 389 StructureType noalg.struct { key int; elem interface {} }
+    - __kind: ArrayType
+      ID: 254
       Name: noalg.[8]struct { key int; elem uint8 }
       ByteSize: 128
-      GoRuntimeType: 677312
+      GoRuntimeType: 683296
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 219 StructureType noalg.struct { key int; elem uint8 }
+      Element: 255 StructureType noalg.struct { key int; elem uint8 }
     - __kind: ArrayType
-      ID: 200
+      ID: 236
       Name: noalg.[8]struct { key string; elem []main.structWithMap }
       ByteSize: 320
-      GoRuntimeType: 677408
+      GoRuntimeType: 683392
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 201 StructureType noalg.struct { key string; elem []main.structWithMap }
+      Element: 237 StructureType noalg.struct { key string; elem []main.structWithMap }
     - __kind: ArrayType
-      ID: 183
+      ID: 219
       Name: noalg.[8]struct { key string; elem []string }
       ByteSize: 320
-      GoRuntimeType: 677504
+      GoRuntimeType: 683488
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 184 StructureType noalg.struct { key string; elem []string }
+      Element: 220 StructureType noalg.struct { key string; elem []string }
     - __kind: ArrayType
-      ID: 175
+      ID: 211
       Name: noalg.[8]struct { key string; elem int }
       ByteSize: 192
-      GoRuntimeType: 677600
+      GoRuntimeType: 683584
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 176 StructureType noalg.struct { key string; elem int }
+      Element: 212 StructureType noalg.struct { key string; elem int }
     - __kind: ArrayType
-      ID: 167
+      ID: 203
       Name: noalg.[8]struct { key string; elem main.nestedStruct }
       ByteSize: 320
-      GoRuntimeType: 677696
+      GoRuntimeType: 683680
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 168 StructureType noalg.struct { key string; elem main.nestedStruct }
+      Element: 204 StructureType noalg.struct { key string; elem main.nestedStruct }
     - __kind: ArrayType
-      ID: 234
+      ID: 270
       Name: noalg.[8]struct { key uint8; elem [4]int }
       ByteSize: 320
-      GoRuntimeType: 677792
+      GoRuntimeType: 683776
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 235 StructureType noalg.struct { key uint8; elem [4]int }
+      Element: 271 StructureType noalg.struct { key uint8; elem [4]int }
     - __kind: ArrayType
-      ID: 226
+      ID: 262
       Name: noalg.[8]struct { key uint8; elem uint8 }
       ByteSize: 16
-      GoRuntimeType: 677888
+      GoRuntimeType: 683872
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 227 StructureType noalg.struct { key uint8; elem uint8 }
+      Element: 263 StructureType noalg.struct { key uint8; elem uint8 }
     - __kind: StructureType
-      ID: 250
+      ID: 286
       Name: noalg.map.group[[4]int][4]int
       ByteSize: 520
-      GoRuntimeType: 1.28176e+06
+      GoRuntimeType: 1.294656e+06
       GoKind: 25
       RawFields:
         - Name: ctrl
@@ -6801,12 +8107,12 @@ Types:
           Type: 8 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 251 ArrayType noalg.[8]struct { key [4]int; elem [4]int }
+          Type: 287 ArrayType noalg.[8]struct { key [4]int; elem [4]int }
     - __kind: StructureType
-      ID: 242
+      ID: 278
       Name: noalg.map.group[[4]int]uint8
       ByteSize: 328
-      GoRuntimeType: 1.282016e+06
+      GoRuntimeType: 1.294912e+06
       GoKind: 25
       RawFields:
         - Name: ctrl
@@ -6814,12 +8120,12 @@ Types:
           Type: 8 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 243 ArrayType noalg.[8]struct { key [4]int; elem uint8 }
+          Type: 279 ArrayType noalg.[8]struct { key [4]int; elem uint8 }
     - __kind: StructureType
-      ID: 190
+      ID: 226
       Name: noalg.map.group[[4]string][2]int
       ByteSize: 648
-      GoRuntimeType: 1.282272e+06
+      GoRuntimeType: 1.295168e+06
       GoKind: 25
       RawFields:
         - Name: ctrl
@@ -6827,12 +8133,12 @@ Types:
           Type: 8 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 191 ArrayType noalg.[8]struct { key [4]string; elem [2]int }
+          Type: 227 ArrayType noalg.[8]struct { key [4]string; elem [2]int }
     - __kind: StructureType
-      ID: 209
+      ID: 245
       Name: noalg.map.group[bool]main.node
       ByteSize: 200
-      GoRuntimeType: 1.282528e+06
+      GoRuntimeType: 1.295424e+06
       GoKind: 25
       RawFields:
         - Name: ctrl
@@ -6840,12 +8146,64 @@ Types:
           Type: 8 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 210 ArrayType noalg.[8]struct { key bool; elem main.node }
+          Type: 246 ArrayType noalg.[8]struct { key bool; elem main.node }
     - __kind: StructureType
-      ID: 158
+      ID: 184
+      Name: noalg.map.group[int]*main.deepMap2
+      ByteSize: 136
+      GoRuntimeType: 1.2944e+06
+      GoKind: 25
+      RawFields:
+        - Name: ctrl
+          Offset: 0
+          Type: 8 BaseType uint64
+        - Name: slots
+          Offset: 8
+          Type: 185 ArrayType noalg.[8]struct { key int; elem *main.deepMap2 }
+    - __kind: StructureType
+      ID: 322
+      Name: noalg.map.group[int]*main.deepMap3
+      ByteSize: 136
+      GoRuntimeType: 1.294144e+06
+      GoKind: 25
+      RawFields:
+        - Name: ctrl
+          Offset: 0
+          Type: 8 BaseType uint64
+        - Name: slots
+          Offset: 8
+          Type: 323 ArrayType noalg.[8]struct { key int; elem *main.deepMap3 }
+    - __kind: StructureType
+      ID: 357
+      Name: noalg.map.group[int]*main.deepMap8
+      ByteSize: 136
+      GoRuntimeType: 1.292864e+06
+      GoKind: 25
+      RawFields:
+        - Name: ctrl
+          Offset: 0
+          Type: 8 BaseType uint64
+        - Name: slots
+          Offset: 8
+          Type: 358 ArrayType noalg.[8]struct { key int; elem *main.deepMap8 }
+    - __kind: StructureType
+      ID: 372
+      Name: noalg.map.group[int]*main.deepMap9
+      ByteSize: 136
+      GoRuntimeType: 1.292608e+06
+      GoKind: 25
+      RawFields:
+        - Name: ctrl
+          Offset: 0
+          Type: 8 BaseType uint64
+        - Name: slots
+          Offset: 8
+          Type: 373 ArrayType noalg.[8]struct { key int; elem *main.deepMap9 }
+    - __kind: StructureType
+      ID: 194
       Name: noalg.map.group[int]int
       ByteSize: 136
-      GoRuntimeType: 1.280992e+06
+      GoRuntimeType: 1.291584e+06
       GoKind: 25
       RawFields:
         - Name: ctrl
@@ -6853,12 +8211,25 @@ Types:
           Type: 8 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 159 ArrayType noalg.[8]struct { key int; elem int }
+          Type: 195 ArrayType noalg.[8]struct { key int; elem int }
     - __kind: StructureType
-      ID: 217
+      ID: 387
+      Name: noalg.map.group[int]interface {}
+      ByteSize: 200
+      GoRuntimeType: 1.292352e+06
+      GoKind: 25
+      RawFields:
+        - Name: ctrl
+          Offset: 0
+          Type: 8 BaseType uint64
+        - Name: slots
+          Offset: 8
+          Type: 388 ArrayType noalg.[8]struct { key int; elem interface {} }
+    - __kind: StructureType
+      ID: 253
       Name: noalg.map.group[int]uint8
       ByteSize: 136
-      GoRuntimeType: 1.282784e+06
+      GoRuntimeType: 1.29568e+06
       GoKind: 25
       RawFields:
         - Name: ctrl
@@ -6866,12 +8237,12 @@ Types:
           Type: 8 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 218 ArrayType noalg.[8]struct { key int; elem uint8 }
+          Type: 254 ArrayType noalg.[8]struct { key int; elem uint8 }
     - __kind: StructureType
-      ID: 199
+      ID: 235
       Name: noalg.map.group[string][]main.structWithMap
       ByteSize: 328
-      GoRuntimeType: 1.28304e+06
+      GoRuntimeType: 1.295936e+06
       GoKind: 25
       RawFields:
         - Name: ctrl
@@ -6879,12 +8250,12 @@ Types:
           Type: 8 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 200 ArrayType noalg.[8]struct { key string; elem []main.structWithMap }
+          Type: 236 ArrayType noalg.[8]struct { key string; elem []main.structWithMap }
     - __kind: StructureType
-      ID: 182
+      ID: 218
       Name: noalg.map.group[string][]string
       ByteSize: 328
-      GoRuntimeType: 1.283296e+06
+      GoRuntimeType: 1.296192e+06
       GoKind: 25
       RawFields:
         - Name: ctrl
@@ -6892,12 +8263,12 @@ Types:
           Type: 8 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 183 ArrayType noalg.[8]struct { key string; elem []string }
+          Type: 219 ArrayType noalg.[8]struct { key string; elem []string }
     - __kind: StructureType
-      ID: 174
+      ID: 210
       Name: noalg.map.group[string]int
       ByteSize: 200
-      GoRuntimeType: 1.283552e+06
+      GoRuntimeType: 1.296448e+06
       GoKind: 25
       RawFields:
         - Name: ctrl
@@ -6905,12 +8276,12 @@ Types:
           Type: 8 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 175 ArrayType noalg.[8]struct { key string; elem int }
+          Type: 211 ArrayType noalg.[8]struct { key string; elem int }
     - __kind: StructureType
-      ID: 166
+      ID: 202
       Name: noalg.map.group[string]main.nestedStruct
       ByteSize: 328
-      GoRuntimeType: 1.283808e+06
+      GoRuntimeType: 1.296704e+06
       GoKind: 25
       RawFields:
         - Name: ctrl
@@ -6918,12 +8289,12 @@ Types:
           Type: 8 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 167 ArrayType noalg.[8]struct { key string; elem main.nestedStruct }
+          Type: 203 ArrayType noalg.[8]struct { key string; elem main.nestedStruct }
     - __kind: StructureType
-      ID: 233
+      ID: 269
       Name: noalg.map.group[uint8][4]int
       ByteSize: 328
-      GoRuntimeType: 1.284064e+06
+      GoRuntimeType: 1.29696e+06
       GoKind: 25
       RawFields:
         - Name: ctrl
@@ -6931,12 +8302,12 @@ Types:
           Type: 8 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 234 ArrayType noalg.[8]struct { key uint8; elem [4]int }
+          Type: 270 ArrayType noalg.[8]struct { key uint8; elem [4]int }
     - __kind: StructureType
-      ID: 225
+      ID: 261
       Name: noalg.map.group[uint8]uint8
       ByteSize: 24
-      GoRuntimeType: 1.28432e+06
+      GoRuntimeType: 1.297216e+06
       GoKind: 25
       RawFields:
         - Name: ctrl
@@ -6944,51 +8315,51 @@ Types:
           Type: 8 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 226 ArrayType noalg.[8]struct { key uint8; elem uint8 }
+          Type: 262 ArrayType noalg.[8]struct { key uint8; elem uint8 }
     - __kind: StructureType
-      ID: 252
+      ID: 288
       Name: noalg.struct { key [4]int; elem [4]int }
       ByteSize: 64
-      GoRuntimeType: 1.281632e+06
+      GoRuntimeType: 1.294528e+06
       GoKind: 25
       RawFields:
         - Name: key
           Offset: 0
-          Type: 236 ArrayType [4]int
+          Type: 272 ArrayType [4]int
         - Name: elem
           Offset: 32
-          Type: 236 ArrayType [4]int
+          Type: 272 ArrayType [4]int
     - __kind: StructureType
-      ID: 244
+      ID: 280
       Name: noalg.struct { key [4]int; elem uint8 }
       ByteSize: 40
-      GoRuntimeType: 1.281888e+06
+      GoRuntimeType: 1.294784e+06
       GoKind: 25
       RawFields:
         - Name: key
           Offset: 0
-          Type: 236 ArrayType [4]int
+          Type: 272 ArrayType [4]int
         - Name: elem
           Offset: 32
           Type: 3 BaseType uint8
     - __kind: StructureType
-      ID: 192
+      ID: 228
       Name: noalg.struct { key [4]string; elem [2]int }
       ByteSize: 80
-      GoRuntimeType: 1.282144e+06
+      GoRuntimeType: 1.29504e+06
       GoKind: 25
       RawFields:
         - Name: key
           Offset: 0
-          Type: 193 ArrayType [4]string
+          Type: 229 ArrayType [4]string
         - Name: elem
           Offset: 64
           Type: 40 ArrayType [2]int
     - __kind: StructureType
-      ID: 211
+      ID: 247
       Name: noalg.struct { key bool; elem main.node }
       ByteSize: 24
-      GoRuntimeType: 1.2824e+06
+      GoRuntimeType: 1.295296e+06
       GoKind: 25
       RawFields:
         - Name: key
@@ -6996,12 +8367,64 @@ Types:
           Type: 4 BaseType bool
         - Name: elem
           Offset: 8
-          Type: 131 StructureType main.node
+          Type: 154 StructureType main.node
     - __kind: StructureType
-      ID: 160
+      ID: 186
+      Name: noalg.struct { key int; elem *main.deepMap2 }
+      ByteSize: 16
+      GoRuntimeType: 1.294272e+06
+      GoKind: 25
+      RawFields:
+        - Name: key
+          Offset: 0
+          Type: 7 BaseType int
+        - Name: elem
+          Offset: 8
+          Type: 187 PointerType *main.deepMap2
+    - __kind: StructureType
+      ID: 324
+      Name: noalg.struct { key int; elem *main.deepMap3 }
+      ByteSize: 16
+      GoRuntimeType: 1.294016e+06
+      GoKind: 25
+      RawFields:
+        - Name: key
+          Offset: 0
+          Type: 7 BaseType int
+        - Name: elem
+          Offset: 8
+          Type: 325 PointerType *main.deepMap3
+    - __kind: StructureType
+      ID: 359
+      Name: noalg.struct { key int; elem *main.deepMap8 }
+      ByteSize: 16
+      GoRuntimeType: 1.292736e+06
+      GoKind: 25
+      RawFields:
+        - Name: key
+          Offset: 0
+          Type: 7 BaseType int
+        - Name: elem
+          Offset: 8
+          Type: 360 PointerType *main.deepMap8
+    - __kind: StructureType
+      ID: 374
+      Name: noalg.struct { key int; elem *main.deepMap9 }
+      ByteSize: 16
+      GoRuntimeType: 1.29248e+06
+      GoKind: 25
+      RawFields:
+        - Name: key
+          Offset: 0
+          Type: 7 BaseType int
+        - Name: elem
+          Offset: 8
+          Type: 375 PointerType *main.deepMap9
+    - __kind: StructureType
+      ID: 196
       Name: noalg.struct { key int; elem int }
       ByteSize: 16
-      GoRuntimeType: 1.280864e+06
+      GoRuntimeType: 1.291456e+06
       GoKind: 25
       RawFields:
         - Name: key
@@ -7011,10 +8434,23 @@ Types:
           Offset: 8
           Type: 7 BaseType int
     - __kind: StructureType
-      ID: 219
+      ID: 389
+      Name: noalg.struct { key int; elem interface {} }
+      ByteSize: 24
+      GoRuntimeType: 1.292224e+06
+      GoKind: 25
+      RawFields:
+        - Name: key
+          Offset: 0
+          Type: 7 BaseType int
+        - Name: elem
+          Offset: 8
+          Type: 81 GoEmptyInterfaceType interface {}
+    - __kind: StructureType
+      ID: 255
       Name: noalg.struct { key int; elem uint8 }
       ByteSize: 16
-      GoRuntimeType: 1.282656e+06
+      GoRuntimeType: 1.295552e+06
       GoKind: 25
       RawFields:
         - Name: key
@@ -7024,10 +8460,10 @@ Types:
           Offset: 8
           Type: 3 BaseType uint8
     - __kind: StructureType
-      ID: 201
+      ID: 237
       Name: noalg.struct { key string; elem []main.structWithMap }
       ByteSize: 40
-      GoRuntimeType: 1.282912e+06
+      GoRuntimeType: 1.295808e+06
       GoKind: 25
       RawFields:
         - Name: key
@@ -7035,12 +8471,12 @@ Types:
           Type: 9 GoStringHeaderType string
         - Name: elem
           Offset: 16
-          Type: 202 GoSliceHeaderType []main.structWithMap
+          Type: 238 GoSliceHeaderType []main.structWithMap
     - __kind: StructureType
-      ID: 184
+      ID: 220
       Name: noalg.struct { key string; elem []string }
       ByteSize: 40
-      GoRuntimeType: 1.283168e+06
+      GoRuntimeType: 1.296064e+06
       GoKind: 25
       RawFields:
         - Name: key
@@ -7048,12 +8484,12 @@ Types:
           Type: 9 GoStringHeaderType string
         - Name: elem
           Offset: 16
-          Type: 141 GoSliceHeaderType []string
+          Type: 164 GoSliceHeaderType []string
     - __kind: StructureType
-      ID: 176
+      ID: 212
       Name: noalg.struct { key string; elem int }
       ByteSize: 24
-      GoRuntimeType: 1.283424e+06
+      GoRuntimeType: 1.29632e+06
       GoKind: 25
       RawFields:
         - Name: key
@@ -7063,10 +8499,10 @@ Types:
           Offset: 16
           Type: 7 BaseType int
     - __kind: StructureType
-      ID: 168
+      ID: 204
       Name: noalg.struct { key string; elem main.nestedStruct }
       ByteSize: 40
-      GoRuntimeType: 1.28368e+06
+      GoRuntimeType: 1.296576e+06
       GoKind: 25
       RawFields:
         - Name: key
@@ -7074,12 +8510,12 @@ Types:
           Type: 9 GoStringHeaderType string
         - Name: elem
           Offset: 16
-          Type: 149 StructureType main.nestedStruct
+          Type: 172 StructureType main.nestedStruct
     - __kind: StructureType
-      ID: 235
+      ID: 271
       Name: noalg.struct { key uint8; elem [4]int }
       ByteSize: 40
-      GoRuntimeType: 1.283936e+06
+      GoRuntimeType: 1.296832e+06
       GoKind: 25
       RawFields:
         - Name: key
@@ -7087,12 +8523,12 @@ Types:
           Type: 3 BaseType uint8
         - Name: elem
           Offset: 8
-          Type: 236 ArrayType [4]int
+          Type: 272 ArrayType [4]int
     - __kind: StructureType
-      ID: 227
+      ID: 263
       Name: noalg.struct { key uint8; elem uint8 }
       ByteSize: 2
-      GoRuntimeType: 1.284192e+06
+      GoRuntimeType: 1.297088e+06
       GoKind: 25
       RawFields:
         - Name: key
@@ -7105,127 +8541,127 @@ Types:
       ID: 9
       Name: string
       ByteSize: 16
-      GoRuntimeType: 578784
+      GoRuntimeType: 583904
       GoKind: 24
       RawFields:
         - Name: str
           Offset: 0
-          Type: 152 PointerType *string.str
+          Type: 175 PointerType *string.str
         - Name: len
           Offset: 8
           Type: 7 BaseType int
-      Data: 151 GoStringDataType string.str
+      Data: 174 GoStringDataType string.str
     - __kind: GoStringDataType
-      ID: 151
+      ID: 174
       Name: string.str
       ByteSize: 2048
     - __kind: StructureType
-      ID: 267
+      ID: 392
       Name: sync.Mutex
       ByteSize: 8
-      GoRuntimeType: 1.44992e+06
+      GoRuntimeType: 1.462816e+06
       GoKind: 25
       RawFields:
         - Name: _
           Offset: 0
-          Type: 268 StructureType sync.noCopy
+          Type: 393 StructureType sync.noCopy
         - Name: mu
           Offset: 0
-          Type: 269 StructureType internal/sync.Mutex
+          Type: 394 StructureType internal/sync.Mutex
     - __kind: StructureType
-      ID: 270
+      ID: 395
       Name: sync.Once
       ByteSize: 12
-      GoRuntimeType: 1.598816e+06
+      GoRuntimeType: 1.611712e+06
       GoKind: 25
       RawFields:
         - Name: _
           Offset: 0
-          Type: 268 StructureType sync.noCopy
+          Type: 393 StructureType sync.noCopy
         - Name: done
           Offset: 0
-          Type: 271 StructureType sync/atomic.Bool
+          Type: 396 StructureType sync/atomic.Bool
         - Name: m
           Offset: 4
-          Type: 267 StructureType sync.Mutex
+          Type: 392 StructureType sync.Mutex
     - __kind: StructureType
-      ID: 273
+      ID: 398
       Name: sync.WaitGroup
       ByteSize: 16
-      GoRuntimeType: 1.598624e+06
+      GoRuntimeType: 1.61152e+06
       GoKind: 25
       RawFields:
         - Name: noCopy
           Offset: 0
-          Type: 268 StructureType sync.noCopy
+          Type: 393 StructureType sync.noCopy
         - Name: state
           Offset: 0
-          Type: 274 StructureType sync/atomic.Uint64
+          Type: 399 StructureType sync/atomic.Uint64
         - Name: sema
           Offset: 8
           Type: 2 BaseType uint32
     - __kind: StructureType
-      ID: 268
+      ID: 393
       Name: sync.noCopy
-      GoRuntimeType: 982144
+      GoRuntimeType: 988128
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 271
+      ID: 396
       Name: sync/atomic.Bool
       ByteSize: 4
-      GoRuntimeType: 1.45104e+06
+      GoRuntimeType: 1.463936e+06
       GoKind: 25
       RawFields:
         - Name: _
           Offset: 0
-          Type: 272 StructureType sync/atomic.noCopy
+          Type: 397 StructureType sync/atomic.noCopy
         - Name: v
           Offset: 0
           Type: 2 BaseType uint32
     - __kind: StructureType
-      ID: 276
+      ID: 401
       Name: sync/atomic.Int32
       ByteSize: 4
-      GoRuntimeType: 1.4512e+06
+      GoRuntimeType: 1.464096e+06
       GoKind: 25
       RawFields:
         - Name: _
           Offset: 0
-          Type: 272 StructureType sync/atomic.noCopy
+          Type: 397 StructureType sync/atomic.noCopy
         - Name: v
           Offset: 0
           Type: 10 BaseType int32
     - __kind: StructureType
-      ID: 274
+      ID: 399
       Name: sync/atomic.Uint64
       ByteSize: 8
-      GoRuntimeType: 1.5992e+06
+      GoRuntimeType: 1.612096e+06
       GoKind: 25
       RawFields:
         - Name: _
           Offset: 0
-          Type: 272 StructureType sync/atomic.noCopy
+          Type: 397 StructureType sync/atomic.noCopy
         - Name: _
           Offset: 0
-          Type: 275 StructureType sync/atomic.align64
+          Type: 400 StructureType sync/atomic.align64
         - Name: v
           Offset: 0
           Type: 8 BaseType uint64
     - __kind: StructureType
-      ID: 275
+      ID: 400
       Name: sync/atomic.align64
-      GoRuntimeType: 982336
+      GoRuntimeType: 988320
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 272
+      ID: 397
       Name: sync/atomic.noCopy
-      GoRuntimeType: 982240
+      GoRuntimeType: 988224
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 247
+      ID: 283
       Name: table<[4]int,[4]int>
       ByteSize: 32
       GoKind: 25
@@ -7247,9 +8683,9 @@ Types:
           Type: 7 BaseType int
         - Name: groups
           Offset: 16
-          Type: 248 GoSwissMapGroupsType groupReference<[4]int,[4]int>
+          Type: 284 GoSwissMapGroupsType groupReference<[4]int,[4]int>
     - __kind: StructureType
-      ID: 239
+      ID: 275
       Name: table<[4]int,uint8>
       ByteSize: 32
       GoKind: 25
@@ -7271,9 +8707,9 @@ Types:
           Type: 7 BaseType int
         - Name: groups
           Offset: 16
-          Type: 240 GoSwissMapGroupsType groupReference<[4]int,uint8>
+          Type: 276 GoSwissMapGroupsType groupReference<[4]int,uint8>
     - __kind: StructureType
-      ID: 187
+      ID: 223
       Name: table<[4]string,[2]int>
       ByteSize: 32
       GoKind: 25
@@ -7295,9 +8731,9 @@ Types:
           Type: 7 BaseType int
         - Name: groups
           Offset: 16
-          Type: 188 GoSwissMapGroupsType groupReference<[4]string,[2]int>
+          Type: 224 GoSwissMapGroupsType groupReference<[4]string,[2]int>
     - __kind: StructureType
-      ID: 206
+      ID: 242
       Name: table<bool,main.node>
       ByteSize: 32
       GoKind: 25
@@ -7319,9 +8755,105 @@ Types:
           Type: 7 BaseType int
         - Name: groups
           Offset: 16
-          Type: 207 GoSwissMapGroupsType groupReference<bool,main.node>
+          Type: 243 GoSwissMapGroupsType groupReference<bool,main.node>
     - __kind: StructureType
-      ID: 155
+      ID: 181
+      Name: table<int,*main.deepMap2>
+      ByteSize: 32
+      GoKind: 25
+      RawFields:
+        - Name: used
+          Offset: 0
+          Type: 6 BaseType uint16
+        - Name: capacity
+          Offset: 2
+          Type: 6 BaseType uint16
+        - Name: growthLeft
+          Offset: 4
+          Type: 6 BaseType uint16
+        - Name: localDepth
+          Offset: 6
+          Type: 3 BaseType uint8
+        - Name: index
+          Offset: 8
+          Type: 7 BaseType int
+        - Name: groups
+          Offset: 16
+          Type: 182 GoSwissMapGroupsType groupReference<int,*main.deepMap2>
+    - __kind: StructureType
+      ID: 319
+      Name: table<int,*main.deepMap3>
+      ByteSize: 32
+      GoKind: 25
+      RawFields:
+        - Name: used
+          Offset: 0
+          Type: 6 BaseType uint16
+        - Name: capacity
+          Offset: 2
+          Type: 6 BaseType uint16
+        - Name: growthLeft
+          Offset: 4
+          Type: 6 BaseType uint16
+        - Name: localDepth
+          Offset: 6
+          Type: 3 BaseType uint8
+        - Name: index
+          Offset: 8
+          Type: 7 BaseType int
+        - Name: groups
+          Offset: 16
+          Type: 320 GoSwissMapGroupsType groupReference<int,*main.deepMap3>
+    - __kind: StructureType
+      ID: 354
+      Name: table<int,*main.deepMap8>
+      ByteSize: 32
+      GoKind: 25
+      RawFields:
+        - Name: used
+          Offset: 0
+          Type: 6 BaseType uint16
+        - Name: capacity
+          Offset: 2
+          Type: 6 BaseType uint16
+        - Name: growthLeft
+          Offset: 4
+          Type: 6 BaseType uint16
+        - Name: localDepth
+          Offset: 6
+          Type: 3 BaseType uint8
+        - Name: index
+          Offset: 8
+          Type: 7 BaseType int
+        - Name: groups
+          Offset: 16
+          Type: 355 GoSwissMapGroupsType groupReference<int,*main.deepMap8>
+    - __kind: StructureType
+      ID: 369
+      Name: table<int,*main.deepMap9>
+      ByteSize: 32
+      GoKind: 25
+      RawFields:
+        - Name: used
+          Offset: 0
+          Type: 6 BaseType uint16
+        - Name: capacity
+          Offset: 2
+          Type: 6 BaseType uint16
+        - Name: growthLeft
+          Offset: 4
+          Type: 6 BaseType uint16
+        - Name: localDepth
+          Offset: 6
+          Type: 3 BaseType uint8
+        - Name: index
+          Offset: 8
+          Type: 7 BaseType int
+        - Name: groups
+          Offset: 16
+          Type: 370 GoSwissMapGroupsType groupReference<int,*main.deepMap9>
+    - __kind: StructureType
+      ID: 191
       Name: table<int,int>
       ByteSize: 32
       GoKind: 25
@@ -7343,9 +8875,33 @@ Types:
           Type: 7 BaseType int
         - Name: groups
           Offset: 16
-          Type: 156 GoSwissMapGroupsType groupReference<int,int>
+          Type: 192 GoSwissMapGroupsType groupReference<int,int>
     - __kind: StructureType
-      ID: 214
+      ID: 384
+      Name: table<int,interface {}>
+      ByteSize: 32
+      GoKind: 25
+      RawFields:
+        - Name: used
+          Offset: 0
+          Type: 6 BaseType uint16
+        - Name: capacity
+          Offset: 2
+          Type: 6 BaseType uint16
+        - Name: growthLeft
+          Offset: 4
+          Type: 6 BaseType uint16
+        - Name: localDepth
+          Offset: 6
+          Type: 3 BaseType uint8
+        - Name: index
+          Offset: 8
+          Type: 7 BaseType int
+        - Name: groups
+          Offset: 16
+          Type: 385 GoSwissMapGroupsType groupReference<int,interface {}>
+    - __kind: StructureType
+      ID: 250
       Name: table<int,uint8>
       ByteSize: 32
       GoKind: 25
@@ -7367,9 +8923,9 @@ Types:
           Type: 7 BaseType int
         - Name: groups
           Offset: 16
-          Type: 215 GoSwissMapGroupsType groupReference<int,uint8>
+          Type: 251 GoSwissMapGroupsType groupReference<int,uint8>
     - __kind: StructureType
-      ID: 196
+      ID: 232
       Name: table<string,[]main.structWithMap>
       ByteSize: 32
       GoKind: 25
@@ -7391,9 +8947,9 @@ Types:
           Type: 7 BaseType int
         - Name: groups
           Offset: 16
-          Type: 197 GoSwissMapGroupsType groupReference<string,[]main.structWithMap>
+          Type: 233 GoSwissMapGroupsType groupReference<string,[]main.structWithMap>
     - __kind: StructureType
-      ID: 179
+      ID: 215
       Name: table<string,[]string>
       ByteSize: 32
       GoKind: 25
@@ -7415,9 +8971,9 @@ Types:
           Type: 7 BaseType int
         - Name: groups
           Offset: 16
-          Type: 180 GoSwissMapGroupsType groupReference<string,[]string>
+          Type: 216 GoSwissMapGroupsType groupReference<string,[]string>
     - __kind: StructureType
-      ID: 171
+      ID: 207
       Name: table<string,int>
       ByteSize: 32
       GoKind: 25
@@ -7439,9 +8995,9 @@ Types:
           Type: 7 BaseType int
         - Name: groups
           Offset: 16
-          Type: 172 GoSwissMapGroupsType groupReference<string,int>
+          Type: 208 GoSwissMapGroupsType groupReference<string,int>
     - __kind: StructureType
-      ID: 163
+      ID: 199
       Name: table<string,main.nestedStruct>
       ByteSize: 32
       GoKind: 25
@@ -7463,9 +9019,9 @@ Types:
           Type: 7 BaseType int
         - Name: groups
           Offset: 16
-          Type: 164 GoSwissMapGroupsType groupReference<string,main.nestedStruct>
+          Type: 200 GoSwissMapGroupsType groupReference<string,main.nestedStruct>
     - __kind: StructureType
-      ID: 230
+      ID: 266
       Name: table<uint8,[4]int>
       ByteSize: 32
       GoKind: 25
@@ -7487,9 +9043,9 @@ Types:
           Type: 7 BaseType int
         - Name: groups
           Offset: 16
-          Type: 231 GoSwissMapGroupsType groupReference<uint8,[4]int>
+          Type: 267 GoSwissMapGroupsType groupReference<uint8,[4]int>
     - __kind: StructureType
-      ID: 222
+      ID: 258
       Name: table<uint8,uint8>
       ByteSize: 32
       GoKind: 25
@@ -7511,49 +9067,49 @@ Types:
           Type: 7 BaseType int
         - Name: groups
           Offset: 16
-          Type: 223 GoSwissMapGroupsType groupReference<uint8,uint8>
+          Type: 259 GoSwissMapGroupsType groupReference<uint8,uint8>
     - __kind: BaseType
       ID: 17
       Name: uint
       ByteSize: 8
-      GoRuntimeType: 579424
+      GoRuntimeType: 584544
       GoKind: 7
     - __kind: BaseType
       ID: 6
       Name: uint16
       ByteSize: 2
-      GoRuntimeType: 579040
+      GoRuntimeType: 584160
       GoKind: 9
     - __kind: BaseType
       ID: 2
       Name: uint32
       ByteSize: 4
-      GoRuntimeType: 579168
+      GoRuntimeType: 584288
       GoKind: 10
     - __kind: BaseType
       ID: 8
       Name: uint64
       ByteSize: 8
-      GoRuntimeType: 579296
+      GoRuntimeType: 584416
       GoKind: 11
     - __kind: BaseType
       ID: 3
       Name: uint8
       ByteSize: 1
-      GoRuntimeType: 578912
+      GoRuntimeType: 584032
       GoKind: 8
     - __kind: BaseType
       ID: 1
       Name: uintptr
       ByteSize: 8
-      GoRuntimeType: 579488
+      GoRuntimeType: 584608
       GoKind: 12
     - __kind: VoidPointerType
       ID: 14
       Name: unsafe.Pointer
       ByteSize: 8
-      GoRuntimeType: 579872
+      GoRuntimeType: 584992
       GoKind: 26
-MaxTypeID: 385
+MaxTypeID: 518
 Issues: []
-GoModuledataInfo: {FirstModuledataAddr: "0x17fa4e0", TypesOffset: 296}
+GoModuledataInfo: {FirstModuledataAddr: "0x17fe520", TypesOffset: 296}

--- a/pkg/dyninst/irgen/testdata/snapshot/sample.arch=amd64,toolchain=go1.25.0.yaml
+++ b/pkg/dyninst/irgen/testdata/snapshot/sample.arch=amd64,toolchain=go1.25.0.yaml
@@ -2089,7 +2089,7 @@ Subprograms:
       InlinePCRanges: []
       Variables:
         - Name: a
-          Type: 73 ArrayType [5]int
+          Type: 63 ArrayType [5]int
           Locations:
             - Range: 0xcd9a00..0xcd9a43
               Pieces: [{Size: 40, Op: {CfaOffset: 0}}]
@@ -2106,7 +2106,7 @@ Subprograms:
       InlinePCRanges: []
       Variables:
         - Name: b
-          Type: 74 GoInterfaceType main.behavior
+          Type: 64 GoInterfaceType main.behavior
           Locations:
             - Range: 0xcd9ce0..0xcd9cff
               Pieces:
@@ -2176,7 +2176,7 @@ Subprograms:
       InlinePCRanges: []
       Variables:
         - Name: s
-          Type: 75 StructureType main.structWithMap
+          Type: 65 StructureType main.structWithMap
           Locations:
             - Range: 0xcda1c0..0xcda1c1
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
@@ -2188,7 +2188,7 @@ Subprograms:
       InlinePCRanges: []
       Variables:
         - Name: m
-          Type: 87 GoMapType map[string]main.nestedStruct
+          Type: 71 GoMapType map[string]main.nestedStruct
           Locations:
             - Range: 0xcda1e0..0xcda1e1
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
@@ -2200,7 +2200,7 @@ Subprograms:
       InlinePCRanges: []
       Variables:
         - Name: m
-          Type: 99 GoMapType map[string]int
+          Type: 76 GoMapType map[string]int
           Locations:
             - Range: 0xcda200..0xcda201
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
@@ -2212,7 +2212,7 @@ Subprograms:
       InlinePCRanges: []
       Variables:
         - Name: m
-          Type: 110 GoMapType map[string][]string
+          Type: 81 GoMapType map[string][]string
           Locations:
             - Range: 0xcda220..0xcda221
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
@@ -2224,7 +2224,7 @@ Subprograms:
       InlinePCRanges: []
       Variables:
         - Name: m
-          Type: 122 GoMapType map[[4]string][2]int
+          Type: 86 GoMapType map[[4]string][2]int
           Locations:
             - Range: 0xcda240..0xcda241
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
@@ -2236,7 +2236,7 @@ Subprograms:
       InlinePCRanges: []
       Variables:
         - Name: m
-          Type: 99 GoMapType map[string]int
+          Type: 76 GoMapType map[string]int
           Locations:
             - Range: 0xcda260..0xcda261
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
@@ -2248,7 +2248,7 @@ Subprograms:
       InlinePCRanges: []
       Variables:
         - Name: m
-          Type: 134 ArrayType [2]map[string]int
+          Type: 91 ArrayType [2]map[string]int
           Locations:
             - Range: 0xcda280..0xcda281
               Pieces: [{Size: 16, Op: {CfaOffset: 0}}]
@@ -2260,7 +2260,7 @@ Subprograms:
       InlinePCRanges: []
       Variables:
         - Name: m
-          Type: 135 PointerType *map[string]int
+          Type: 92 PointerType *map[string]int
           Locations:
             - Range: 0xcda2a0..0xcda2a1
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
@@ -2272,7 +2272,7 @@ Subprograms:
       InlinePCRanges: []
       Variables:
         - Name: m
-          Type: 76 GoMapType map[int]int
+          Type: 66 GoMapType map[int]int
           Locations:
             - Range: 0xcda2c0..0xcda2c1
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
@@ -2284,7 +2284,7 @@ Subprograms:
       InlinePCRanges: []
       Variables:
         - Name: redactMyEntries
-          Type: 136 GoMapType map[string][]main.structWithMap
+          Type: 93 GoMapType map[string][]main.structWithMap
           Locations:
             - Range: 0xcda2e0..0xcda2e1
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
@@ -2296,7 +2296,7 @@ Subprograms:
       InlinePCRanges: []
       Variables:
         - Name: m
-          Type: 136 GoMapType map[string][]main.structWithMap
+          Type: 93 GoMapType map[string][]main.structWithMap
           Locations:
             - Range: 0xcda300..0xcda301
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
@@ -2308,7 +2308,7 @@ Subprograms:
       InlinePCRanges: []
       Variables:
         - Name: m
-          Type: 149 GoMapType map[bool]main.node
+          Type: 98 GoMapType map[bool]main.node
           Locations:
             - Range: 0xcda320..0xcda321
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
@@ -2320,7 +2320,7 @@ Subprograms:
       InlinePCRanges: []
       Variables:
         - Name: m
-          Type: 162 GoMapType map[int]uint8
+          Type: 103 GoMapType map[int]uint8
           Locations:
             - Range: 0xcda340..0xcda341
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
@@ -2332,7 +2332,7 @@ Subprograms:
       InlinePCRanges: []
       Variables:
         - Name: redactMyEntries
-          Type: 162 GoMapType map[int]uint8
+          Type: 103 GoMapType map[int]uint8
           Locations:
             - Range: 0xcda360..0xcda361
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
@@ -2344,7 +2344,7 @@ Subprograms:
       InlinePCRanges: []
       Variables:
         - Name: m
-          Type: 173 GoMapType map[uint8]uint8
+          Type: 108 GoMapType map[uint8]uint8
           Locations:
             - Range: 0xcda380..0xcda381
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
@@ -2356,7 +2356,7 @@ Subprograms:
       InlinePCRanges: []
       Variables:
         - Name: m
-          Type: 173 GoMapType map[uint8]uint8
+          Type: 108 GoMapType map[uint8]uint8
           Locations:
             - Range: 0xcda3a0..0xcda3a1
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
@@ -2368,7 +2368,7 @@ Subprograms:
       InlinePCRanges: []
       Variables:
         - Name: m
-          Type: 173 GoMapType map[uint8]uint8
+          Type: 108 GoMapType map[uint8]uint8
           Locations:
             - Range: 0xcda3c0..0xcda3c1
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
@@ -2380,7 +2380,7 @@ Subprograms:
       InlinePCRanges: []
       Variables:
         - Name: m
-          Type: 184 GoMapType map[uint8][4]int
+          Type: 113 GoMapType map[uint8][4]int
           Locations:
             - Range: 0xcda3e0..0xcda3e1
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
@@ -2392,7 +2392,7 @@ Subprograms:
       InlinePCRanges: []
       Variables:
         - Name: m
-          Type: 196 GoMapType map[[4]int]uint8
+          Type: 118 GoMapType map[[4]int]uint8
           Locations:
             - Range: 0xcda400..0xcda401
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
@@ -2404,7 +2404,7 @@ Subprograms:
       InlinePCRanges: []
       Variables:
         - Name: m
-          Type: 207 GoMapType map[[4]int][4]int
+          Type: 123 GoMapType map[[4]int][4]int
           Locations:
             - Range: 0xcda420..0xcda421
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
@@ -2486,7 +2486,7 @@ Subprograms:
       InlinePCRanges: []
       Variables:
         - Name: c
-          Type: 218 GoChannelType chan bool
+          Type: 128 GoChannelType chan bool
           Locations:
             - Range: 0xcdbf40..0xcdbf41
               Pieces: [{Size: 0, Op: {RegNo: 0, Shift: 0}}]
@@ -2498,7 +2498,7 @@ Subprograms:
       InlinePCRanges: []
       Variables:
         - Name: a
-          Type: 219 PointerType *main.structWithTwoValues
+          Type: 129 PointerType *main.structWithTwoValues
           Locations:
             - Range: 0xcdc0e0..0xcdc0e1
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
@@ -2510,7 +2510,7 @@ Subprograms:
       InlinePCRanges: []
       Variables:
         - Name: a
-          Type: 160 StructureType main.node
+          Type: 131 StructureType main.node
           Locations:
             - Range: 0xcdc100..0xcdc101
               Pieces:
@@ -2526,7 +2526,7 @@ Subprograms:
       InlinePCRanges: []
       Variables:
         - Name: a
-          Type: 161 PointerType *main.node
+          Type: 132 PointerType *main.node
           Locations:
             - Range: 0xcdc120..0xcdc121
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
@@ -2593,7 +2593,7 @@ Subprograms:
       InlinePCRanges: []
       Variables:
         - Name: t
-          Type: 221 PointerType *main.t
+          Type: 133 PointerType *main.t
           Locations:
             - Range: 0xcdc2e0..0xcdc2e1
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
@@ -2605,7 +2605,7 @@ Subprograms:
       InlinePCRanges: []
       Variables:
         - Name: u
-          Type: 224 GoSliceHeaderType []uint
+          Type: 135 GoSliceHeaderType []uint
           Locations:
             - Range: 0xcdc800..0xcdc801
               Pieces:
@@ -2623,7 +2623,7 @@ Subprograms:
       InlinePCRanges: []
       Variables:
         - Name: u
-          Type: 224 GoSliceHeaderType []uint
+          Type: 135 GoSliceHeaderType []uint
           Locations:
             - Range: 0xcdc820..0xcdc821
               Pieces:
@@ -2641,7 +2641,7 @@ Subprograms:
       InlinePCRanges: []
       Variables:
         - Name: u
-          Type: 225 GoSliceHeaderType [][]uint
+          Type: 136 GoSliceHeaderType [][]uint
           Locations:
             - Range: 0xcdc840..0xcdc841
               Pieces:
@@ -2659,7 +2659,7 @@ Subprograms:
       InlinePCRanges: []
       Variables:
         - Name: xs
-          Type: 227 GoSliceHeaderType []main.structWithNoStrings
+          Type: 138 GoSliceHeaderType []main.structWithNoStrings
           Locations:
             - Range: 0xcdc860..0xcdc861
               Pieces:
@@ -2684,7 +2684,7 @@ Subprograms:
       InlinePCRanges: []
       Variables:
         - Name: xs
-          Type: 227 GoSliceHeaderType []main.structWithNoStrings
+          Type: 138 GoSliceHeaderType []main.structWithNoStrings
           Locations:
             - Range: 0xcdc880..0xcdc881
               Pieces:
@@ -2709,7 +2709,7 @@ Subprograms:
       InlinePCRanges: []
       Variables:
         - Name: xs
-          Type: 227 GoSliceHeaderType []main.structWithNoStrings
+          Type: 138 GoSliceHeaderType []main.structWithNoStrings
           Locations:
             - Range: 0xcdc8a0..0xcdc8a1
               Pieces:
@@ -2734,7 +2734,7 @@ Subprograms:
       InlinePCRanges: []
       Variables:
         - Name: s
-          Type: 121 GoSliceHeaderType []string
+          Type: 141 GoSliceHeaderType []string
           Locations:
             - Range: 0xcdc8c0..0xcdc8c1
               Pieces:
@@ -2759,7 +2759,7 @@ Subprograms:
           IsParameter: true
           IsReturn: false
         - Name: s
-          Type: 230 GoSliceHeaderType []bool
+          Type: 142 GoSliceHeaderType []bool
           Locations:
             - Range: 0xcdc8e0..0xcdc8e1
               Pieces:
@@ -2784,7 +2784,7 @@ Subprograms:
       InlinePCRanges: []
       Variables:
         - Name: xs
-          Type: 231 GoSliceHeaderType []uint16
+          Type: 143 GoSliceHeaderType []uint16
           Locations:
             - Range: 0xcdc900..0xcdc901
               Pieces:
@@ -2802,7 +2802,7 @@ Subprograms:
       InlinePCRanges: []
       Variables:
         - Name: xs
-          Type: 224 GoSliceHeaderType []uint
+          Type: 135 GoSliceHeaderType []uint
           Locations:
             - Range: 0xcdc920..0xcdc921
               Pieces:
@@ -2884,7 +2884,7 @@ Subprograms:
       InlinePCRanges: []
       Variables:
         - Name: a
-          Type: 232 StructureType main.threeStringStruct
+          Type: 144 StructureType main.threeStringStruct
           Locations:
             - Range: 0xcdcd00..0xcdcd1f
               Pieces:
@@ -2908,7 +2908,7 @@ Subprograms:
       InlinePCRanges: []
       Variables:
         - Name: a
-          Type: 233 PointerType *main.threeStringStruct
+          Type: 145 PointerType *main.threeStringStruct
           Locations:
             - Range: 0xcdcd20..0xcdcd21
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
@@ -2920,7 +2920,7 @@ Subprograms:
       InlinePCRanges: []
       Variables:
         - Name: a
-          Type: 234 PointerType *main.oneStringStruct
+          Type: 146 PointerType *main.oneStringStruct
           Locations:
             - Range: 0xcdcd40..0xcdcd41
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
@@ -2980,7 +2980,7 @@ Subprograms:
       InlinePCRanges: []
       Variables:
         - Name: x
-          Type: 236 StructureType main.aStruct
+          Type: 148 StructureType main.aStruct
           Locations:
             - Range: 0xcdd020..0xcdd043
               Pieces:
@@ -3006,7 +3006,7 @@ Subprograms:
       InlinePCRanges: []
       Variables:
         - Name: e
-          Type: 237 StructureType main.emptyStruct
+          Type: 150 StructureType main.emptyStruct
           Locations: [{Range: 0xcdd1a0..0xcdd1a1, Pieces: []}]
           IsParameter: true
           IsReturn: false
@@ -3085,7 +3085,7 @@ Subprograms:
           RootRanges: [0xcd9a60..0xcd9be5]
       Variables:
         - Name: a
-          Type: 73 ArrayType [5]int
+          Type: 63 ArrayType [5]int
           Locations:
             - Range: 0xcd9a0d..0xcd9a43
               Pieces: [{Size: 40, Op: {CfaOffset: -56}}]
@@ -3095,10 +3095,10 @@ Subprograms:
           IsReturn: false
 Types:
     - __kind: PointerType
-      ID: 223
+      ID: 173
       Name: '**main.t'
       ByteSize: 8
-      Pointee: 221 PointerType *main.t
+      Pointee: 133 PointerType *main.t
     - __kind: PointerType
       ID: 54
       Name: '**string'
@@ -3107,110 +3107,110 @@ Types:
       GoKind: 22
       Pointee: 22 PointerType *string
     - __kind: PointerType
-      ID: 210
+      ID: 126
       Name: '**table<[4]int,[4]int>'
       ByteSize: 8
-      Pointee: 211 PointerType *table<[4]int,[4]int>
+      Pointee: 127 PointerType *table<[4]int,[4]int>
     - __kind: PointerType
-      ID: 199
+      ID: 121
       Name: '**table<[4]int,uint8>'
       ByteSize: 8
-      Pointee: 200 PointerType *table<[4]int,uint8>
+      Pointee: 122 PointerType *table<[4]int,uint8>
     - __kind: PointerType
-      ID: 125
+      ID: 89
       Name: '**table<[4]string,[2]int>'
       ByteSize: 8
-      Pointee: 126 PointerType *table<[4]string,[2]int>
+      Pointee: 90 PointerType *table<[4]string,[2]int>
     - __kind: PointerType
-      ID: 152
+      ID: 101
       Name: '**table<bool,main.node>'
       ByteSize: 8
-      Pointee: 153 PointerType *table<bool,main.node>
+      Pointee: 102 PointerType *table<bool,main.node>
     - __kind: PointerType
-      ID: 79
+      ID: 69
       Name: '**table<int,int>'
       ByteSize: 8
-      Pointee: 80 PointerType *table<int,int>
+      Pointee: 70 PointerType *table<int,int>
     - __kind: PointerType
-      ID: 165
+      ID: 106
       Name: '**table<int,uint8>'
       ByteSize: 8
-      Pointee: 166 PointerType *table<int,uint8>
+      Pointee: 107 PointerType *table<int,uint8>
     - __kind: PointerType
-      ID: 139
+      ID: 96
       Name: '**table<string,[]main.structWithMap>'
       ByteSize: 8
-      Pointee: 140 PointerType *table<string,[]main.structWithMap>
+      Pointee: 97 PointerType *table<string,[]main.structWithMap>
     - __kind: PointerType
-      ID: 113
+      ID: 84
       Name: '**table<string,[]string>'
       ByteSize: 8
-      Pointee: 114 PointerType *table<string,[]string>
+      Pointee: 85 PointerType *table<string,[]string>
     - __kind: PointerType
-      ID: 102
+      ID: 79
       Name: '**table<string,int>'
       ByteSize: 8
-      Pointee: 103 PointerType *table<string,int>
+      Pointee: 80 PointerType *table<string,int>
     - __kind: PointerType
-      ID: 90
+      ID: 74
       Name: '**table<string,main.nestedStruct>'
       ByteSize: 8
-      Pointee: 91 PointerType *table<string,main.nestedStruct>
+      Pointee: 75 PointerType *table<string,main.nestedStruct>
     - __kind: PointerType
-      ID: 187
+      ID: 116
       Name: '**table<uint8,[4]int>'
       ByteSize: 8
-      Pointee: 188 PointerType *table<uint8,[4]int>
+      Pointee: 117 PointerType *table<uint8,[4]int>
     - __kind: PointerType
-      ID: 176
+      ID: 111
       Name: '**table<uint8,uint8>'
       ByteSize: 8
-      Pointee: 177 PointerType *table<uint8,uint8>
+      Pointee: 112 PointerType *table<uint8,uint8>
     - __kind: PointerType
       ID: 241
       Name: '*[]*string.array'
       ByteSize: 8
       Pointee: 240 GoSliceDataType []*string.array
     - __kind: PointerType
-      ID: 275
+      ID: 271
       Name: '*[][]uint.array'
       ByteSize: 8
-      Pointee: 274 GoSliceDataType [][]uint.array
-    - __kind: PointerType
-      ID: 279
-      Name: '*[]bool.array'
-      ByteSize: 8
-      Pointee: 278 GoSliceDataType []bool.array
-    - __kind: PointerType
-      ID: 257
-      Name: '*[]main.structWithMap.array'
-      ByteSize: 8
-      Pointee: 256 GoSliceDataType []main.structWithMap.array
+      Pointee: 270 GoSliceDataType [][]uint.array
     - __kind: PointerType
       ID: 277
-      Name: '*[]main.structWithNoStrings.array'
+      Name: '*[]bool.array'
       ByteSize: 8
-      Pointee: 276 GoSliceDataType []main.structWithNoStrings.array
-    - __kind: PointerType
-      ID: 251
-      Name: '*[]string.array'
-      ByteSize: 8
-      Pointee: 250 GoSliceDataType []string.array
-    - __kind: PointerType
-      ID: 226
-      Name: '*[]uint'
-      ByteSize: 8
-      Pointee: 224 GoSliceHeaderType []uint
-    - __kind: PointerType
-      ID: 273
-      Name: '*[]uint.array'
-      ByteSize: 8
-      Pointee: 272 GoSliceDataType []uint.array
+      Pointee: 276 GoSliceDataType []bool.array
     - __kind: PointerType
       ID: 281
+      Name: '*[]main.structWithMap.array'
+      ByteSize: 8
+      Pointee: 280 GoSliceDataType []main.structWithMap.array
+    - __kind: PointerType
+      ID: 273
+      Name: '*[]main.structWithNoStrings.array'
+      ByteSize: 8
+      Pointee: 272 GoSliceDataType []main.structWithNoStrings.array
+    - __kind: PointerType
+      ID: 275
+      Name: '*[]string.array'
+      ByteSize: 8
+      Pointee: 274 GoSliceDataType []string.array
+    - __kind: PointerType
+      ID: 137
+      Name: '*[]uint'
+      ByteSize: 8
+      Pointee: 135 GoSliceHeaderType []uint
+    - __kind: PointerType
+      ID: 269
+      Name: '*[]uint.array'
+      ByteSize: 8
+      Pointee: 268 GoSliceDataType []uint.array
+    - __kind: PointerType
+      ID: 279
       Name: '*[]uint16.array'
       ByteSize: 8
-      Pointee: 280 GoSliceDataType []uint16.array
+      Pointee: 278 GoSliceDataType []uint16.array
     - __kind: PointerType
       ID: 11
       Name: '*bool'
@@ -3282,179 +3282,179 @@ Types:
       GoKind: 22
       Pointee: 62 StructureType main.esotericHeap
     - __kind: PointerType
-      ID: 161
+      ID: 132
       Name: '*main.node'
       ByteSize: 8
       GoRuntimeType: 383104
       GoKind: 22
-      Pointee: 160 StructureType main.node
+      Pointee: 131 StructureType main.node
     - __kind: PointerType
-      ID: 234
+      ID: 146
       Name: '*main.oneStringStruct'
       ByteSize: 8
       GoKind: 22
-      Pointee: 235 StructureType main.oneStringStruct
+      Pointee: 147 StructureType main.oneStringStruct
     - __kind: PointerType
-      ID: 148
+      ID: 224
       Name: '*main.structWithMap'
       ByteSize: 8
       GoRuntimeType: 382976
       GoKind: 22
-      Pointee: 75 StructureType main.structWithMap
+      Pointee: 65 StructureType main.structWithMap
     - __kind: PointerType
-      ID: 228
+      ID: 139
       Name: '*main.structWithNoStrings'
       ByteSize: 8
-      Pointee: 229 StructureType main.structWithNoStrings
+      Pointee: 140 StructureType main.structWithNoStrings
     - __kind: PointerType
-      ID: 219
+      ID: 129
       Name: '*main.structWithTwoValues'
       ByteSize: 8
       GoKind: 22
-      Pointee: 220 StructureType main.structWithTwoValues
+      Pointee: 130 StructureType main.structWithTwoValues
     - __kind: PointerType
-      ID: 221
+      ID: 133
       Name: '*main.t'
       ByteSize: 8
       GoKind: 22
-      Pointee: 222 GoSliceHeaderType main.t
+      Pointee: 134 GoSliceHeaderType main.t
     - __kind: PointerType
-      ID: 271
+      ID: 267
       Name: '*main.t.array'
       ByteSize: 8
-      Pointee: 270 GoSliceDataType main.t.array
+      Pointee: 266 GoSliceDataType main.t.array
     - __kind: PointerType
-      ID: 233
+      ID: 145
       Name: '*main.threeStringStruct'
       ByteSize: 8
       GoKind: 22
-      Pointee: 232 StructureType main.threeStringStruct
+      Pointee: 144 StructureType main.threeStringStruct
     - __kind: PointerType
-      ID: 208
+      ID: 124
       Name: '*map<[4]int,[4]int>'
       ByteSize: 8
-      Pointee: 209 GoSwissMapHeaderType map<[4]int,[4]int>
+      Pointee: 125 GoSwissMapHeaderType map<[4]int,[4]int>
     - __kind: PointerType
-      ID: 197
+      ID: 119
       Name: '*map<[4]int,uint8>'
       ByteSize: 8
-      Pointee: 198 GoSwissMapHeaderType map<[4]int,uint8>
+      Pointee: 120 GoSwissMapHeaderType map<[4]int,uint8>
     - __kind: PointerType
-      ID: 123
+      ID: 87
       Name: '*map<[4]string,[2]int>'
       ByteSize: 8
-      Pointee: 124 GoSwissMapHeaderType map<[4]string,[2]int>
+      Pointee: 88 GoSwissMapHeaderType map<[4]string,[2]int>
     - __kind: PointerType
-      ID: 150
+      ID: 99
       Name: '*map<bool,main.node>'
       ByteSize: 8
-      Pointee: 151 GoSwissMapHeaderType map<bool,main.node>
+      Pointee: 100 GoSwissMapHeaderType map<bool,main.node>
     - __kind: PointerType
-      ID: 77
+      ID: 67
       Name: '*map<int,int>'
       ByteSize: 8
-      Pointee: 78 GoSwissMapHeaderType map<int,int>
+      Pointee: 68 GoSwissMapHeaderType map<int,int>
     - __kind: PointerType
-      ID: 163
+      ID: 104
       Name: '*map<int,uint8>'
       ByteSize: 8
-      Pointee: 164 GoSwissMapHeaderType map<int,uint8>
+      Pointee: 105 GoSwissMapHeaderType map<int,uint8>
     - __kind: PointerType
-      ID: 137
+      ID: 94
       Name: '*map<string,[]main.structWithMap>'
       ByteSize: 8
-      Pointee: 138 GoSwissMapHeaderType map<string,[]main.structWithMap>
+      Pointee: 95 GoSwissMapHeaderType map<string,[]main.structWithMap>
     - __kind: PointerType
-      ID: 111
+      ID: 82
       Name: '*map<string,[]string>'
       ByteSize: 8
-      Pointee: 112 GoSwissMapHeaderType map<string,[]string>
+      Pointee: 83 GoSwissMapHeaderType map<string,[]string>
     - __kind: PointerType
-      ID: 100
+      ID: 77
       Name: '*map<string,int>'
       ByteSize: 8
-      Pointee: 101 GoSwissMapHeaderType map<string,int>
+      Pointee: 78 GoSwissMapHeaderType map<string,int>
     - __kind: PointerType
-      ID: 88
+      ID: 72
       Name: '*map<string,main.nestedStruct>'
       ByteSize: 8
-      Pointee: 89 GoSwissMapHeaderType map<string,main.nestedStruct>
+      Pointee: 73 GoSwissMapHeaderType map<string,main.nestedStruct>
     - __kind: PointerType
-      ID: 185
+      ID: 114
       Name: '*map<uint8,[4]int>'
       ByteSize: 8
-      Pointee: 186 GoSwissMapHeaderType map<uint8,[4]int>
+      Pointee: 115 GoSwissMapHeaderType map<uint8,[4]int>
     - __kind: PointerType
-      ID: 174
+      ID: 109
       Name: '*map<uint8,uint8>'
       ByteSize: 8
-      Pointee: 175 GoSwissMapHeaderType map<uint8,uint8>
+      Pointee: 110 GoSwissMapHeaderType map<uint8,uint8>
     - __kind: PointerType
-      ID: 135
+      ID: 92
       Name: '*map[string]int'
       ByteSize: 8
       GoKind: 22
-      Pointee: 99 GoMapType map[string]int
+      Pointee: 76 GoMapType map[string]int
     - __kind: PointerType
-      ID: 214
+      ID: 208
       Name: '*noalg.map.group[[4]int][4]int'
       ByteSize: 8
-      Pointee: 215 StructureType noalg.map.group[[4]int][4]int
+      Pointee: 209 StructureType noalg.map.group[[4]int][4]int
     - __kind: PointerType
-      ID: 203
+      ID: 205
       Name: '*noalg.map.group[[4]int]uint8'
       ByteSize: 8
-      Pointee: 204 StructureType noalg.map.group[[4]int]uint8
+      Pointee: 206 StructureType noalg.map.group[[4]int]uint8
     - __kind: PointerType
-      ID: 129
+      ID: 187
       Name: '*noalg.map.group[[4]string][2]int'
       ByteSize: 8
-      Pointee: 130 StructureType noalg.map.group[[4]string][2]int
+      Pointee: 188 StructureType noalg.map.group[[4]string][2]int
     - __kind: PointerType
-      ID: 156
+      ID: 193
       Name: '*noalg.map.group[bool]main.node'
       ByteSize: 8
-      Pointee: 157 StructureType noalg.map.group[bool]main.node
+      Pointee: 194 StructureType noalg.map.group[bool]main.node
     - __kind: PointerType
-      ID: 83
+      ID: 175
       Name: '*noalg.map.group[int]int'
       ByteSize: 8
-      Pointee: 84 StructureType noalg.map.group[int]int
+      Pointee: 176 StructureType noalg.map.group[int]int
     - __kind: PointerType
-      ID: 169
+      ID: 196
       Name: '*noalg.map.group[int]uint8'
       ByteSize: 8
-      Pointee: 170 StructureType noalg.map.group[int]uint8
+      Pointee: 197 StructureType noalg.map.group[int]uint8
     - __kind: PointerType
-      ID: 143
+      ID: 190
       Name: '*noalg.map.group[string][]main.structWithMap'
       ByteSize: 8
-      Pointee: 144 StructureType noalg.map.group[string][]main.structWithMap
+      Pointee: 191 StructureType noalg.map.group[string][]main.structWithMap
     - __kind: PointerType
-      ID: 117
+      ID: 184
       Name: '*noalg.map.group[string][]string'
       ByteSize: 8
-      Pointee: 118 StructureType noalg.map.group[string][]string
+      Pointee: 185 StructureType noalg.map.group[string][]string
     - __kind: PointerType
-      ID: 106
+      ID: 181
       Name: '*noalg.map.group[string]int'
       ByteSize: 8
-      Pointee: 107 StructureType noalg.map.group[string]int
+      Pointee: 182 StructureType noalg.map.group[string]int
     - __kind: PointerType
-      ID: 94
+      ID: 178
       Name: '*noalg.map.group[string]main.nestedStruct'
       ByteSize: 8
-      Pointee: 95 StructureType noalg.map.group[string]main.nestedStruct
+      Pointee: 179 StructureType noalg.map.group[string]main.nestedStruct
     - __kind: PointerType
-      ID: 191
+      ID: 202
       Name: '*noalg.map.group[uint8][4]int'
       ByteSize: 8
-      Pointee: 192 StructureType noalg.map.group[uint8][4]int
+      Pointee: 203 StructureType noalg.map.group[uint8][4]int
     - __kind: PointerType
-      ID: 180
+      ID: 199
       Name: '*noalg.map.group[uint8]uint8'
       ByteSize: 8
-      Pointee: 181 StructureType noalg.map.group[uint8]uint8
+      Pointee: 200 StructureType noalg.map.group[uint8]uint8
     - __kind: PointerType
       ID: 22
       Name: '*string'
@@ -3468,65 +3468,65 @@ Types:
       ByteSize: 8
       Pointee: 238 GoStringDataType string.str
     - __kind: PointerType
-      ID: 211
+      ID: 127
       Name: '*table<[4]int,[4]int>'
       ByteSize: 8
-      Pointee: 212 StructureType table<[4]int,[4]int>
+      Pointee: 172 StructureType table<[4]int,[4]int>
     - __kind: PointerType
-      ID: 200
+      ID: 122
       Name: '*table<[4]int,uint8>'
       ByteSize: 8
-      Pointee: 201 StructureType table<[4]int,uint8>
+      Pointee: 171 StructureType table<[4]int,uint8>
     - __kind: PointerType
-      ID: 126
+      ID: 90
       Name: '*table<[4]string,[2]int>'
       ByteSize: 8
-      Pointee: 127 StructureType table<[4]string,[2]int>
+      Pointee: 165 StructureType table<[4]string,[2]int>
     - __kind: PointerType
-      ID: 153
+      ID: 102
       Name: '*table<bool,main.node>'
       ByteSize: 8
-      Pointee: 154 StructureType table<bool,main.node>
+      Pointee: 167 StructureType table<bool,main.node>
     - __kind: PointerType
-      ID: 80
+      ID: 70
       Name: '*table<int,int>'
       ByteSize: 8
-      Pointee: 81 StructureType table<int,int>
+      Pointee: 161 StructureType table<int,int>
     - __kind: PointerType
-      ID: 166
+      ID: 107
       Name: '*table<int,uint8>'
       ByteSize: 8
-      Pointee: 167 StructureType table<int,uint8>
+      Pointee: 168 StructureType table<int,uint8>
     - __kind: PointerType
-      ID: 140
+      ID: 97
       Name: '*table<string,[]main.structWithMap>'
       ByteSize: 8
-      Pointee: 141 StructureType table<string,[]main.structWithMap>
+      Pointee: 166 StructureType table<string,[]main.structWithMap>
     - __kind: PointerType
-      ID: 114
+      ID: 85
       Name: '*table<string,[]string>'
       ByteSize: 8
-      Pointee: 115 StructureType table<string,[]string>
+      Pointee: 164 StructureType table<string,[]string>
     - __kind: PointerType
-      ID: 103
+      ID: 80
       Name: '*table<string,int>'
       ByteSize: 8
-      Pointee: 104 StructureType table<string,int>
+      Pointee: 163 StructureType table<string,int>
     - __kind: PointerType
-      ID: 91
+      ID: 75
       Name: '*table<string,main.nestedStruct>'
       ByteSize: 8
-      Pointee: 92 StructureType table<string,main.nestedStruct>
+      Pointee: 162 StructureType table<string,main.nestedStruct>
     - __kind: PointerType
-      ID: 188
+      ID: 117
       Name: '*table<uint8,[4]int>'
       ByteSize: 8
-      Pointee: 189 StructureType table<uint8,[4]int>
+      Pointee: 170 StructureType table<uint8,[4]int>
     - __kind: PointerType
-      ID: 177
+      ID: 112
       Name: '*table<uint8,uint8>'
       ByteSize: 8
-      Pointee: 178 StructureType table<uint8,uint8>
+      Pointee: 169 StructureType table<uint8,uint8>
     - __kind: PointerType
       ID: 34
       Name: '*uint'
@@ -3626,7 +3626,7 @@ Types:
         - Name: m
           Offset: 1
           Expression:
-            Type: 134 ArrayType [2]map[string]int
+            Type: 91 ArrayType [2]map[string]int
             Operations:
                 - __kind: LocationOp
                   Variable: {subprogram: 53, index: 0, name: m}
@@ -3701,7 +3701,7 @@ Types:
         - Name: c
           Offset: 1
           Expression:
-            Type: 218 GoChannelType chan bool
+            Type: 128 GoChannelType chan bool
             Operations:
                 - __kind: LocationOp
                   Variable: {subprogram: 69, index: 0, name: c}
@@ -3749,7 +3749,7 @@ Types:
         - Name: t
           Offset: 1
           Expression:
-            Type: 221 PointerType *main.t
+            Type: 133 PointerType *main.t
             Operations:
                 - __kind: LocationOp
                   Variable: {subprogram: 77, index: 0, name: t}
@@ -3764,7 +3764,7 @@ Types:
         - Name: xs
           Offset: 1
           Expression:
-            Type: 227 GoSliceHeaderType []main.structWithNoStrings
+            Type: 138 GoSliceHeaderType []main.structWithNoStrings
             Operations:
                 - __kind: LocationOp
                   Variable: {subprogram: 82, index: 0, name: xs}
@@ -3788,7 +3788,7 @@ Types:
         - Name: u
           Offset: 1
           Expression:
-            Type: 224 GoSliceHeaderType []uint
+            Type: 135 GoSliceHeaderType []uint
             Operations:
                 - __kind: LocationOp
                   Variable: {subprogram: 79, index: 0, name: u}
@@ -3818,7 +3818,7 @@ Types:
         - Name: e
           Offset: 1
           Expression:
-            Type: 237 StructureType main.emptyStruct
+            Type: 150 StructureType main.emptyStruct
             Operations:
                 - __kind: LocationOp
                   Variable: {subprogram: 98, index: 0, name: e}
@@ -3878,7 +3878,7 @@ Types:
         - Name: a
           Offset: 1
           Expression:
-            Type: 73 ArrayType [5]int
+            Type: 63 ArrayType [5]int
             Operations:
                 - __kind: LocationOp
                   Variable: {subprogram: 43, index: 0, name: a}
@@ -4004,7 +4004,7 @@ Types:
         - Name: a
           Offset: 1
           Expression:
-            Type: 73 ArrayType [5]int
+            Type: 63 ArrayType [5]int
             Operations:
                 - __kind: LocationOp
                   Variable: {subprogram: 104, index: 0, name: a}
@@ -4094,7 +4094,7 @@ Types:
         - Name: b
           Offset: 1
           Expression:
-            Type: 74 GoInterfaceType main.behavior
+            Type: 64 GoInterfaceType main.behavior
             Operations:
                 - __kind: LocationOp
                   Variable: {subprogram: 44, index: 0, name: b}
@@ -4109,7 +4109,7 @@ Types:
         - Name: a
           Offset: 1
           Expression:
-            Type: 160 StructureType main.node
+            Type: 131 StructureType main.node
             Operations:
                 - __kind: LocationOp
                   Variable: {subprogram: 71, index: 0, name: a}
@@ -4124,7 +4124,7 @@ Types:
         - Name: m
           Offset: 1
           Expression:
-            Type: 122 GoMapType map[[4]string][2]int
+            Type: 86 GoMapType map[[4]string][2]int
             Operations:
                 - __kind: LocationOp
                   Variable: {subprogram: 51, index: 0, name: m}
@@ -4139,7 +4139,7 @@ Types:
         - Name: m
           Offset: 1
           Expression:
-            Type: 136 GoMapType map[string][]main.structWithMap
+            Type: 93 GoMapType map[string][]main.structWithMap
             Operations:
                 - __kind: LocationOp
                   Variable: {subprogram: 57, index: 0, name: m}
@@ -4154,7 +4154,7 @@ Types:
         - Name: m
           Offset: 1
           Expression:
-            Type: 76 GoMapType map[int]int
+            Type: 66 GoMapType map[int]int
             Operations:
                 - __kind: LocationOp
                   Variable: {subprogram: 55, index: 0, name: m}
@@ -4169,7 +4169,7 @@ Types:
         - Name: m
           Offset: 1
           Expression:
-            Type: 207 GoMapType map[[4]int][4]int
+            Type: 123 GoMapType map[[4]int][4]int
             Operations:
                 - __kind: LocationOp
                   Variable: {subprogram: 66, index: 0, name: m}
@@ -4184,7 +4184,7 @@ Types:
         - Name: m
           Offset: 1
           Expression:
-            Type: 196 GoMapType map[[4]int]uint8
+            Type: 118 GoMapType map[[4]int]uint8
             Operations:
                 - __kind: LocationOp
                   Variable: {subprogram: 65, index: 0, name: m}
@@ -4199,7 +4199,7 @@ Types:
         - Name: redactMyEntries
           Offset: 1
           Expression:
-            Type: 136 GoMapType map[string][]main.structWithMap
+            Type: 93 GoMapType map[string][]main.structWithMap
             Operations:
                 - __kind: LocationOp
                   Variable: {subprogram: 56, index: 0, name: redactMyEntries}
@@ -4214,7 +4214,7 @@ Types:
         - Name: m
           Offset: 1
           Expression:
-            Type: 184 GoMapType map[uint8][4]int
+            Type: 113 GoMapType map[uint8][4]int
             Operations:
                 - __kind: LocationOp
                   Variable: {subprogram: 64, index: 0, name: m}
@@ -4229,7 +4229,7 @@ Types:
         - Name: m
           Offset: 1
           Expression:
-            Type: 173 GoMapType map[uint8]uint8
+            Type: 108 GoMapType map[uint8]uint8
             Operations:
                 - __kind: LocationOp
                   Variable: {subprogram: 63, index: 0, name: m}
@@ -4244,7 +4244,7 @@ Types:
         - Name: m
           Offset: 1
           Expression:
-            Type: 99 GoMapType map[string]int
+            Type: 76 GoMapType map[string]int
             Operations:
                 - __kind: LocationOp
                   Variable: {subprogram: 49, index: 0, name: m}
@@ -4259,7 +4259,7 @@ Types:
         - Name: m
           Offset: 1
           Expression:
-            Type: 110 GoMapType map[string][]string
+            Type: 81 GoMapType map[string][]string
             Operations:
                 - __kind: LocationOp
                   Variable: {subprogram: 50, index: 0, name: m}
@@ -4274,7 +4274,7 @@ Types:
         - Name: m
           Offset: 1
           Expression:
-            Type: 87 GoMapType map[string]main.nestedStruct
+            Type: 71 GoMapType map[string]main.nestedStruct
             Operations:
                 - __kind: LocationOp
                   Variable: {subprogram: 48, index: 0, name: m}
@@ -4289,7 +4289,7 @@ Types:
         - Name: m
           Offset: 1
           Expression:
-            Type: 149 GoMapType map[bool]main.node
+            Type: 98 GoMapType map[bool]main.node
             Operations:
                 - __kind: LocationOp
                   Variable: {subprogram: 58, index: 0, name: m}
@@ -4304,7 +4304,7 @@ Types:
         - Name: m
           Offset: 1
           Expression:
-            Type: 173 GoMapType map[uint8]uint8
+            Type: 108 GoMapType map[uint8]uint8
             Operations:
                 - __kind: LocationOp
                   Variable: {subprogram: 62, index: 0, name: m}
@@ -4319,7 +4319,7 @@ Types:
         - Name: m
           Offset: 1
           Expression:
-            Type: 173 GoMapType map[uint8]uint8
+            Type: 108 GoMapType map[uint8]uint8
             Operations:
                 - __kind: LocationOp
                   Variable: {subprogram: 61, index: 0, name: m}
@@ -4334,7 +4334,7 @@ Types:
         - Name: redactMyEntries
           Offset: 1
           Expression:
-            Type: 162 GoMapType map[int]uint8
+            Type: 103 GoMapType map[int]uint8
             Operations:
                 - __kind: LocationOp
                   Variable: {subprogram: 60, index: 0, name: redactMyEntries}
@@ -4349,7 +4349,7 @@ Types:
         - Name: m
           Offset: 1
           Expression:
-            Type: 162 GoMapType map[int]uint8
+            Type: 103 GoMapType map[int]uint8
             Operations:
                 - __kind: LocationOp
                   Variable: {subprogram: 59, index: 0, name: m}
@@ -4454,7 +4454,7 @@ Types:
         - Name: xs
           Offset: 1
           Expression:
-            Type: 227 GoSliceHeaderType []main.structWithNoStrings
+            Type: 138 GoSliceHeaderType []main.structWithNoStrings
             Operations:
                 - __kind: LocationOp
                   Variable: {subprogram: 83, index: 0, name: xs}
@@ -4487,7 +4487,7 @@ Types:
         - Name: s
           Offset: 2
           Expression:
-            Type: 230 GoSliceHeaderType []bool
+            Type: 142 GoSliceHeaderType []bool
             Operations:
                 - __kind: LocationOp
                   Variable: {subprogram: 85, index: 1, name: s}
@@ -4511,7 +4511,7 @@ Types:
         - Name: xs
           Offset: 1
           Expression:
-            Type: 231 GoSliceHeaderType []uint16
+            Type: 143 GoSliceHeaderType []uint16
             Operations:
                 - __kind: LocationOp
                   Variable: {subprogram: 86, index: 0, name: xs}
@@ -4526,7 +4526,7 @@ Types:
         - Name: a
           Offset: 1
           Expression:
-            Type: 234 PointerType *main.oneStringStruct
+            Type: 146 PointerType *main.oneStringStruct
             Operations:
                 - __kind: LocationOp
                   Variable: {subprogram: 93, index: 0, name: a}
@@ -4541,7 +4541,7 @@ Types:
         - Name: a
           Offset: 1
           Expression:
-            Type: 161 PointerType *main.node
+            Type: 132 PointerType *main.node
             Operations:
                 - __kind: LocationOp
                   Variable: {subprogram: 72, index: 0, name: a}
@@ -4556,7 +4556,7 @@ Types:
         - Name: m
           Offset: 1
           Expression:
-            Type: 135 PointerType *map[string]int
+            Type: 92 PointerType *map[string]int
             Operations:
                 - __kind: LocationOp
                   Variable: {subprogram: 54, index: 0, name: m}
@@ -4571,7 +4571,7 @@ Types:
         - Name: a
           Offset: 1
           Expression:
-            Type: 219 PointerType *main.structWithTwoValues
+            Type: 129 PointerType *main.structWithTwoValues
             Operations:
                 - __kind: LocationOp
                   Variable: {subprogram: 70, index: 0, name: a}
@@ -4841,7 +4841,7 @@ Types:
         - Name: u
           Offset: 1
           Expression:
-            Type: 225 GoSliceHeaderType [][]uint
+            Type: 136 GoSliceHeaderType [][]uint
             Operations:
                 - __kind: LocationOp
                   Variable: {subprogram: 80, index: 0, name: u}
@@ -4856,7 +4856,7 @@ Types:
         - Name: m
           Offset: 1
           Expression:
-            Type: 99 GoMapType map[string]int
+            Type: 76 GoMapType map[string]int
             Operations:
                 - __kind: LocationOp
                   Variable: {subprogram: 52, index: 0, name: m}
@@ -4901,7 +4901,7 @@ Types:
         - Name: s
           Offset: 1
           Expression:
-            Type: 121 GoSliceHeaderType []string
+            Type: 141 GoSliceHeaderType []string
             Operations:
                 - __kind: LocationOp
                   Variable: {subprogram: 84, index: 0, name: s}
@@ -4916,7 +4916,7 @@ Types:
         - Name: xs
           Offset: 1
           Expression:
-            Type: 227 GoSliceHeaderType []main.structWithNoStrings
+            Type: 138 GoSliceHeaderType []main.structWithNoStrings
             Operations:
                 - __kind: LocationOp
                   Variable: {subprogram: 81, index: 0, name: xs}
@@ -4940,7 +4940,7 @@ Types:
         - Name: s
           Offset: 1
           Expression:
-            Type: 75 StructureType main.structWithMap
+            Type: 65 StructureType main.structWithMap
             Operations:
                 - __kind: LocationOp
                   Variable: {subprogram: 47, index: 0, name: s}
@@ -4955,7 +4955,7 @@ Types:
         - Name: x
           Offset: 1
           Expression:
-            Type: 236 StructureType main.aStruct
+            Type: 148 StructureType main.aStruct
             Operations:
                 - __kind: LocationOp
                   Variable: {subprogram: 97, index: 0, name: x}
@@ -4970,7 +4970,7 @@ Types:
         - Name: a
           Offset: 1
           Expression:
-            Type: 233 PointerType *main.threeStringStruct
+            Type: 145 PointerType *main.threeStringStruct
             Operations:
                 - __kind: LocationOp
                   Variable: {subprogram: 92, index: 0, name: a}
@@ -4985,7 +4985,7 @@ Types:
         - Name: a
           Offset: 1
           Expression:
-            Type: 232 StructureType main.threeStringStruct
+            Type: 144 StructureType main.threeStringStruct
             Operations:
                 - __kind: LocationOp
                   Variable: {subprogram: 91, index: 0, name: a}
@@ -5138,7 +5138,7 @@ Types:
         - Name: u
           Offset: 1
           Expression:
-            Type: 224 GoSliceHeaderType []uint
+            Type: 135 GoSliceHeaderType []uint
             Operations:
                 - __kind: LocationOp
                   Variable: {subprogram: 78, index: 0, name: u}
@@ -5198,7 +5198,7 @@ Types:
         - Name: xs
           Offset: 1
           Expression:
-            Type: 224 GoSliceHeaderType []uint
+            Type: 135 GoSliceHeaderType []uint
             Operations:
                 - __kind: LocationOp
                   Variable: {subprogram: 87, index: 0, name: xs}
@@ -5279,13 +5279,13 @@ Types:
       HasCount: true
       Element: 16 BaseType int8
     - __kind: ArrayType
-      ID: 134
+      ID: 91
       Name: '[2]map[string]int'
       ByteSize: 16
       GoKind: 17
       Count: 2
       HasCount: true
-      Element: 99 GoMapType map[string]int
+      Element: 76 GoMapType map[string]int
     - __kind: ArrayType
       ID: 38
       Name: '[2]string'
@@ -5338,7 +5338,7 @@ Types:
       HasCount: true
       Element: 3 BaseType uint8
     - __kind: ArrayType
-      ID: 195
+      ID: 233
       Name: '[4]int'
       ByteSize: 32
       GoRuntimeType: 676640
@@ -5347,7 +5347,7 @@ Types:
       HasCount: true
       Element: 7 BaseType int
     - __kind: ArrayType
-      ID: 133
+      ID: 220
       Name: '[4]string'
       ByteSize: 64
       GoRuntimeType: 676928
@@ -5356,7 +5356,7 @@ Types:
       HasCount: true
       Element: 9 GoStringHeaderType string
     - __kind: ArrayType
-      ID: 73
+      ID: 63
       Name: '[5]int'
       ByteSize: 40
       GoKind: 17
@@ -5386,88 +5386,88 @@ Types:
       ByteSize: 2048
       Element: 22 PointerType *string
     - __kind: GoSliceDataType
-      ID: 268
+      ID: 264
       Name: '[]*table<[4]int,[4]int>.array'
       ByteSize: 8192
-      Element: 211 PointerType *table<[4]int,[4]int>
+      Element: 127 PointerType *table<[4]int,[4]int>
     - __kind: GoSliceDataType
-      ID: 266
+      ID: 262
       Name: '[]*table<[4]int,uint8>.array'
       ByteSize: 8192
-      Element: 200 PointerType *table<[4]int,uint8>
+      Element: 122 PointerType *table<[4]int,uint8>
     - __kind: GoSliceDataType
-      ID: 252
+      ID: 250
       Name: '[]*table<[4]string,[2]int>.array'
       ByteSize: 8192
-      Element: 126 PointerType *table<[4]string,[2]int>
+      Element: 90 PointerType *table<[4]string,[2]int>
     - __kind: GoSliceDataType
-      ID: 258
+      ID: 254
       Name: '[]*table<bool,main.node>.array'
       ByteSize: 8192
-      Element: 153 PointerType *table<bool,main.node>
+      Element: 102 PointerType *table<bool,main.node>
     - __kind: GoSliceDataType
       ID: 242
       Name: '[]*table<int,int>.array'
       ByteSize: 8192
-      Element: 80 PointerType *table<int,int>
+      Element: 70 PointerType *table<int,int>
     - __kind: GoSliceDataType
-      ID: 260
+      ID: 256
       Name: '[]*table<int,uint8>.array'
       ByteSize: 8192
-      Element: 166 PointerType *table<int,uint8>
+      Element: 107 PointerType *table<int,uint8>
     - __kind: GoSliceDataType
-      ID: 254
+      ID: 252
       Name: '[]*table<string,[]main.structWithMap>.array'
       ByteSize: 8192
-      Element: 140 PointerType *table<string,[]main.structWithMap>
+      Element: 97 PointerType *table<string,[]main.structWithMap>
     - __kind: GoSliceDataType
       ID: 248
       Name: '[]*table<string,[]string>.array'
       ByteSize: 8192
-      Element: 114 PointerType *table<string,[]string>
+      Element: 85 PointerType *table<string,[]string>
     - __kind: GoSliceDataType
       ID: 246
       Name: '[]*table<string,int>.array'
       ByteSize: 8192
-      Element: 103 PointerType *table<string,int>
+      Element: 80 PointerType *table<string,int>
     - __kind: GoSliceDataType
       ID: 244
       Name: '[]*table<string,main.nestedStruct>.array'
       ByteSize: 8192
-      Element: 91 PointerType *table<string,main.nestedStruct>
+      Element: 75 PointerType *table<string,main.nestedStruct>
     - __kind: GoSliceDataType
-      ID: 264
+      ID: 260
       Name: '[]*table<uint8,[4]int>.array'
       ByteSize: 8192
-      Element: 188 PointerType *table<uint8,[4]int>
+      Element: 117 PointerType *table<uint8,[4]int>
     - __kind: GoSliceDataType
-      ID: 262
+      ID: 258
       Name: '[]*table<uint8,uint8>.array'
       ByteSize: 8192
-      Element: 177 PointerType *table<uint8,uint8>
+      Element: 112 PointerType *table<uint8,uint8>
     - __kind: GoSliceHeaderType
-      ID: 225
+      ID: 136
       Name: '[][]uint'
       ByteSize: 24
       GoKind: 23
       RawFields:
         - Name: array
           Offset: 0
-          Type: 226 PointerType *[]uint
+          Type: 137 PointerType *[]uint
         - Name: len
           Offset: 8
           Type: 7 BaseType int
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 274 GoSliceDataType [][]uint.array
+      Data: 270 GoSliceDataType [][]uint.array
     - __kind: GoSliceDataType
-      ID: 274
+      ID: 270
       Name: '[][]uint.array'
       ByteSize: 2048
-      Element: 224 GoSliceHeaderType []uint
+      Element: 135 GoSliceHeaderType []uint
     - __kind: GoSliceHeaderType
-      ID: 230
+      ID: 142
       Name: '[]bool'
       ByteSize: 24
       GoRuntimeType: 481856
@@ -5482,14 +5482,14 @@ Types:
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 278 GoSliceDataType []bool.array
+      Data: 276 GoSliceDataType []bool.array
     - __kind: GoSliceDataType
-      ID: 278
+      ID: 276
       Name: '[]bool.array'
       ByteSize: 2048
       Element: 4 BaseType bool
     - __kind: GoSliceHeaderType
-      ID: 147
+      ID: 223
       Name: '[]main.structWithMap'
       ByteSize: 24
       GoRuntimeType: 472768
@@ -5497,102 +5497,102 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 148 PointerType *main.structWithMap
+          Type: 224 PointerType *main.structWithMap
         - Name: len
           Offset: 8
           Type: 7 BaseType int
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 256 GoSliceDataType []main.structWithMap.array
+      Data: 280 GoSliceDataType []main.structWithMap.array
     - __kind: GoSliceDataType
-      ID: 256
+      ID: 280
       Name: '[]main.structWithMap.array'
       ByteSize: 2048
-      Element: 75 StructureType main.structWithMap
+      Element: 65 StructureType main.structWithMap
     - __kind: GoSliceHeaderType
-      ID: 227
+      ID: 138
       Name: '[]main.structWithNoStrings'
       ByteSize: 24
       GoKind: 23
       RawFields:
         - Name: array
           Offset: 0
-          Type: 228 PointerType *main.structWithNoStrings
+          Type: 139 PointerType *main.structWithNoStrings
         - Name: len
           Offset: 8
           Type: 7 BaseType int
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 276 GoSliceDataType []main.structWithNoStrings.array
+      Data: 272 GoSliceDataType []main.structWithNoStrings.array
     - __kind: GoSliceDataType
-      ID: 276
+      ID: 272
       Name: '[]main.structWithNoStrings.array'
       ByteSize: 2048
-      Element: 229 StructureType main.structWithNoStrings
+      Element: 140 StructureType main.structWithNoStrings
     - __kind: GoSliceDataType
-      ID: 269
+      ID: 265
       Name: '[]noalg.map.group[[4]int][4]int.array'
       ByteSize: 2048
-      Element: 215 StructureType noalg.map.group[[4]int][4]int
+      Element: 209 StructureType noalg.map.group[[4]int][4]int
     - __kind: GoSliceDataType
-      ID: 267
+      ID: 263
       Name: '[]noalg.map.group[[4]int]uint8.array'
       ByteSize: 2048
-      Element: 204 StructureType noalg.map.group[[4]int]uint8
+      Element: 206 StructureType noalg.map.group[[4]int]uint8
     - __kind: GoSliceDataType
-      ID: 253
+      ID: 251
       Name: '[]noalg.map.group[[4]string][2]int.array'
       ByteSize: 2048
-      Element: 130 StructureType noalg.map.group[[4]string][2]int
+      Element: 188 StructureType noalg.map.group[[4]string][2]int
     - __kind: GoSliceDataType
-      ID: 259
+      ID: 255
       Name: '[]noalg.map.group[bool]main.node.array'
       ByteSize: 2048
-      Element: 157 StructureType noalg.map.group[bool]main.node
+      Element: 194 StructureType noalg.map.group[bool]main.node
     - __kind: GoSliceDataType
       ID: 243
       Name: '[]noalg.map.group[int]int.array'
       ByteSize: 2048
-      Element: 84 StructureType noalg.map.group[int]int
+      Element: 176 StructureType noalg.map.group[int]int
     - __kind: GoSliceDataType
-      ID: 261
+      ID: 257
       Name: '[]noalg.map.group[int]uint8.array'
       ByteSize: 2048
-      Element: 170 StructureType noalg.map.group[int]uint8
+      Element: 197 StructureType noalg.map.group[int]uint8
     - __kind: GoSliceDataType
-      ID: 255
+      ID: 253
       Name: '[]noalg.map.group[string][]main.structWithMap.array'
       ByteSize: 2048
-      Element: 144 StructureType noalg.map.group[string][]main.structWithMap
+      Element: 191 StructureType noalg.map.group[string][]main.structWithMap
     - __kind: GoSliceDataType
       ID: 249
       Name: '[]noalg.map.group[string][]string.array'
       ByteSize: 2048
-      Element: 118 StructureType noalg.map.group[string][]string
+      Element: 185 StructureType noalg.map.group[string][]string
     - __kind: GoSliceDataType
       ID: 247
       Name: '[]noalg.map.group[string]int.array'
       ByteSize: 2048
-      Element: 107 StructureType noalg.map.group[string]int
+      Element: 182 StructureType noalg.map.group[string]int
     - __kind: GoSliceDataType
       ID: 245
       Name: '[]noalg.map.group[string]main.nestedStruct.array'
       ByteSize: 2048
-      Element: 95 StructureType noalg.map.group[string]main.nestedStruct
+      Element: 179 StructureType noalg.map.group[string]main.nestedStruct
     - __kind: GoSliceDataType
-      ID: 265
+      ID: 261
       Name: '[]noalg.map.group[uint8][4]int.array'
       ByteSize: 2048
-      Element: 192 StructureType noalg.map.group[uint8][4]int
+      Element: 203 StructureType noalg.map.group[uint8][4]int
     - __kind: GoSliceDataType
-      ID: 263
+      ID: 259
       Name: '[]noalg.map.group[uint8]uint8.array'
       ByteSize: 2048
-      Element: 181 StructureType noalg.map.group[uint8]uint8
+      Element: 200 StructureType noalg.map.group[uint8]uint8
     - __kind: GoSliceHeaderType
-      ID: 121
+      ID: 141
       Name: '[]string'
       ByteSize: 24
       GoRuntimeType: 481984
@@ -5607,14 +5607,14 @@ Types:
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 250 GoSliceDataType []string.array
+      Data: 274 GoSliceDataType []string.array
     - __kind: GoSliceDataType
-      ID: 250
+      ID: 274
       Name: '[]string.array'
       ByteSize: 2048
       Element: 9 GoStringHeaderType string
     - __kind: GoSliceHeaderType
-      ID: 224
+      ID: 135
       Name: '[]uint'
       ByteSize: 24
       GoRuntimeType: 481472
@@ -5629,14 +5629,14 @@ Types:
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 272 GoSliceDataType []uint.array
+      Data: 268 GoSliceDataType []uint.array
     - __kind: GoSliceDataType
-      ID: 272
+      ID: 268
       Name: '[]uint.array'
       ByteSize: 2048
       Element: 17 BaseType uint
     - __kind: GoSliceHeaderType
-      ID: 231
+      ID: 143
       Name: '[]uint16'
       ByteSize: 24
       GoRuntimeType: 480832
@@ -5651,9 +5651,9 @@ Types:
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 280 GoSliceDataType []uint16.array
+      Data: 278 GoSliceDataType []uint16.array
     - __kind: GoSliceDataType
-      ID: 280
+      ID: 278
       Name: '[]uint16.array'
       ByteSize: 2048
       Element: 6 BaseType uint16
@@ -5664,7 +5664,7 @@ Types:
       GoRuntimeType: 579808
       GoKind: 1
     - __kind: GoChannelType
-      ID: 218
+      ID: 128
       Name: chan bool
       GoRuntimeType: 591136
       GoKind: 18
@@ -5717,173 +5717,173 @@ Types:
       GoRuntimeType: 471744
       GoKind: 19
     - __kind: GoSwissMapGroupsType
-      ID: 213
+      ID: 207
       Name: groupReference<[4]int,[4]int>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 214 PointerType *noalg.map.group[[4]int][4]int
+          Type: 208 PointerType *noalg.map.group[[4]int][4]int
         - Name: lengthMask
           Offset: 8
           Type: 8 BaseType uint64
-      GroupType: 215 StructureType noalg.map.group[[4]int][4]int
-      GroupSliceType: 269 GoSliceDataType []noalg.map.group[[4]int][4]int.array
+      GroupType: 209 StructureType noalg.map.group[[4]int][4]int
+      GroupSliceType: 265 GoSliceDataType []noalg.map.group[[4]int][4]int.array
     - __kind: GoSwissMapGroupsType
-      ID: 202
+      ID: 204
       Name: groupReference<[4]int,uint8>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 203 PointerType *noalg.map.group[[4]int]uint8
+          Type: 205 PointerType *noalg.map.group[[4]int]uint8
         - Name: lengthMask
           Offset: 8
           Type: 8 BaseType uint64
-      GroupType: 204 StructureType noalg.map.group[[4]int]uint8
-      GroupSliceType: 267 GoSliceDataType []noalg.map.group[[4]int]uint8.array
+      GroupType: 206 StructureType noalg.map.group[[4]int]uint8
+      GroupSliceType: 263 GoSliceDataType []noalg.map.group[[4]int]uint8.array
     - __kind: GoSwissMapGroupsType
-      ID: 128
+      ID: 186
       Name: groupReference<[4]string,[2]int>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 129 PointerType *noalg.map.group[[4]string][2]int
+          Type: 187 PointerType *noalg.map.group[[4]string][2]int
         - Name: lengthMask
           Offset: 8
           Type: 8 BaseType uint64
-      GroupType: 130 StructureType noalg.map.group[[4]string][2]int
-      GroupSliceType: 253 GoSliceDataType []noalg.map.group[[4]string][2]int.array
+      GroupType: 188 StructureType noalg.map.group[[4]string][2]int
+      GroupSliceType: 251 GoSliceDataType []noalg.map.group[[4]string][2]int.array
     - __kind: GoSwissMapGroupsType
-      ID: 155
+      ID: 192
       Name: groupReference<bool,main.node>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 156 PointerType *noalg.map.group[bool]main.node
+          Type: 193 PointerType *noalg.map.group[bool]main.node
         - Name: lengthMask
           Offset: 8
           Type: 8 BaseType uint64
-      GroupType: 157 StructureType noalg.map.group[bool]main.node
-      GroupSliceType: 259 GoSliceDataType []noalg.map.group[bool]main.node.array
+      GroupType: 194 StructureType noalg.map.group[bool]main.node
+      GroupSliceType: 255 GoSliceDataType []noalg.map.group[bool]main.node.array
     - __kind: GoSwissMapGroupsType
-      ID: 82
+      ID: 174
       Name: groupReference<int,int>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 83 PointerType *noalg.map.group[int]int
+          Type: 175 PointerType *noalg.map.group[int]int
         - Name: lengthMask
           Offset: 8
           Type: 8 BaseType uint64
-      GroupType: 84 StructureType noalg.map.group[int]int
+      GroupType: 176 StructureType noalg.map.group[int]int
       GroupSliceType: 243 GoSliceDataType []noalg.map.group[int]int.array
     - __kind: GoSwissMapGroupsType
-      ID: 168
+      ID: 195
       Name: groupReference<int,uint8>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 169 PointerType *noalg.map.group[int]uint8
+          Type: 196 PointerType *noalg.map.group[int]uint8
         - Name: lengthMask
           Offset: 8
           Type: 8 BaseType uint64
-      GroupType: 170 StructureType noalg.map.group[int]uint8
-      GroupSliceType: 261 GoSliceDataType []noalg.map.group[int]uint8.array
+      GroupType: 197 StructureType noalg.map.group[int]uint8
+      GroupSliceType: 257 GoSliceDataType []noalg.map.group[int]uint8.array
     - __kind: GoSwissMapGroupsType
-      ID: 142
+      ID: 189
       Name: groupReference<string,[]main.structWithMap>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 143 PointerType *noalg.map.group[string][]main.structWithMap
+          Type: 190 PointerType *noalg.map.group[string][]main.structWithMap
         - Name: lengthMask
           Offset: 8
           Type: 8 BaseType uint64
-      GroupType: 144 StructureType noalg.map.group[string][]main.structWithMap
-      GroupSliceType: 255 GoSliceDataType []noalg.map.group[string][]main.structWithMap.array
+      GroupType: 191 StructureType noalg.map.group[string][]main.structWithMap
+      GroupSliceType: 253 GoSliceDataType []noalg.map.group[string][]main.structWithMap.array
     - __kind: GoSwissMapGroupsType
-      ID: 116
+      ID: 183
       Name: groupReference<string,[]string>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 117 PointerType *noalg.map.group[string][]string
+          Type: 184 PointerType *noalg.map.group[string][]string
         - Name: lengthMask
           Offset: 8
           Type: 8 BaseType uint64
-      GroupType: 118 StructureType noalg.map.group[string][]string
+      GroupType: 185 StructureType noalg.map.group[string][]string
       GroupSliceType: 249 GoSliceDataType []noalg.map.group[string][]string.array
     - __kind: GoSwissMapGroupsType
-      ID: 105
+      ID: 180
       Name: groupReference<string,int>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 106 PointerType *noalg.map.group[string]int
+          Type: 181 PointerType *noalg.map.group[string]int
         - Name: lengthMask
           Offset: 8
           Type: 8 BaseType uint64
-      GroupType: 107 StructureType noalg.map.group[string]int
+      GroupType: 182 StructureType noalg.map.group[string]int
       GroupSliceType: 247 GoSliceDataType []noalg.map.group[string]int.array
     - __kind: GoSwissMapGroupsType
-      ID: 93
+      ID: 177
       Name: groupReference<string,main.nestedStruct>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 94 PointerType *noalg.map.group[string]main.nestedStruct
+          Type: 178 PointerType *noalg.map.group[string]main.nestedStruct
         - Name: lengthMask
           Offset: 8
           Type: 8 BaseType uint64
-      GroupType: 95 StructureType noalg.map.group[string]main.nestedStruct
+      GroupType: 179 StructureType noalg.map.group[string]main.nestedStruct
       GroupSliceType: 245 GoSliceDataType []noalg.map.group[string]main.nestedStruct.array
     - __kind: GoSwissMapGroupsType
-      ID: 190
+      ID: 201
       Name: groupReference<uint8,[4]int>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 191 PointerType *noalg.map.group[uint8][4]int
+          Type: 202 PointerType *noalg.map.group[uint8][4]int
         - Name: lengthMask
           Offset: 8
           Type: 8 BaseType uint64
-      GroupType: 192 StructureType noalg.map.group[uint8][4]int
-      GroupSliceType: 265 GoSliceDataType []noalg.map.group[uint8][4]int.array
+      GroupType: 203 StructureType noalg.map.group[uint8][4]int
+      GroupSliceType: 261 GoSliceDataType []noalg.map.group[uint8][4]int.array
     - __kind: GoSwissMapGroupsType
-      ID: 179
+      ID: 198
       Name: groupReference<uint8,uint8>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 180 PointerType *noalg.map.group[uint8]uint8
+          Type: 199 PointerType *noalg.map.group[uint8]uint8
         - Name: lengthMask
           Offset: 8
           Type: 8 BaseType uint64
-      GroupType: 181 StructureType noalg.map.group[uint8]uint8
-      GroupSliceType: 263 GoSliceDataType []noalg.map.group[uint8]uint8.array
+      GroupType: 200 StructureType noalg.map.group[uint8]uint8
+      GroupSliceType: 259 GoSliceDataType []noalg.map.group[uint8]uint8.array
     - __kind: BaseType
       ID: 7
       Name: int
@@ -5928,7 +5928,7 @@ Types:
           Offset: 8
           Type: 14 VoidPointerType unsafe.Pointer
     - __kind: StructureType
-      ID: 65
+      ID: 153
       Name: internal/sync.Mutex
       ByteSize: 8
       GoRuntimeType: 1.46e+06
@@ -5954,7 +5954,7 @@ Types:
           Offset: 8
           Type: 14 VoidPointerType unsafe.Pointer
     - __kind: StructureType
-      ID: 236
+      ID: 148
       Name: main.aStruct
       ByteSize: 56
       GoKind: 25
@@ -5970,9 +5970,9 @@ Types:
           Type: 7 BaseType int
         - Name: nested
           Offset: 32
-          Type: 98 StructureType main.nestedStruct
+          Type: 149 StructureType main.nestedStruct
     - __kind: GoInterfaceType
-      ID: 74
+      ID: 64
       Name: main.behavior
       ByteSize: 16
       GoRuntimeType: 1.016352e+06
@@ -6000,7 +6000,7 @@ Types:
           Offset: 32
           Type: 55 GoInterfaceType io.Writer
     - __kind: StructureType
-      ID: 237
+      ID: 150
       Name: main.emptyStruct
       GoKind: 25
       RawFields: []
@@ -6016,16 +6016,16 @@ Types:
           Type: 56 StructureType main.esotericStack
         - Name: mu
           Offset: 64
-          Type: 63 StructureType sync.Mutex
+          Type: 151 StructureType sync.Mutex
         - Name: once
           Offset: 72
-          Type: 66 StructureType sync.Once
+          Type: 154 StructureType sync.Once
         - Name: wg
           Offset: 88
-          Type: 69 StructureType sync.WaitGroup
+          Type: 157 StructureType sync.WaitGroup
         - Name: a
           Offset: 104
-          Type: 72 StructureType sync/atomic.Int32
+          Type: 160 StructureType sync/atomic.Int32
     - __kind: StructureType
       ID: 56
       Name: main.esotericStack
@@ -6055,7 +6055,7 @@ Types:
           Offset: 56
           Type: 60 GoSubroutineType func()
     - __kind: StructureType
-      ID: 98
+      ID: 149
       Name: main.nestedStruct
       ByteSize: 24
       GoRuntimeType: 1.44864e+06
@@ -6068,7 +6068,7 @@ Types:
           Offset: 8
           Type: 9 GoStringHeaderType string
     - __kind: StructureType
-      ID: 160
+      ID: 131
       Name: main.node
       ByteSize: 16
       GoRuntimeType: 1.44848e+06
@@ -6079,9 +6079,9 @@ Types:
           Type: 7 BaseType int
         - Name: b
           Offset: 8
-          Type: 161 PointerType *main.node
+          Type: 132 PointerType *main.node
     - __kind: StructureType
-      ID: 235
+      ID: 147
       Name: main.oneStringStruct
       ByteSize: 16
       GoKind: 25
@@ -6103,7 +6103,7 @@ Types:
           Offset: 8
           Type: 14 VoidPointerType unsafe.Pointer
     - __kind: StructureType
-      ID: 75
+      ID: 65
       Name: main.structWithMap
       ByteSize: 8
       GoRuntimeType: 1.177504e+06
@@ -6111,9 +6111,9 @@ Types:
       RawFields:
         - Name: m
           Offset: 0
-          Type: 76 GoMapType map[int]int
+          Type: 66 GoMapType map[int]int
     - __kind: StructureType
-      ID: 229
+      ID: 140
       Name: main.structWithNoStrings
       ByteSize: 2
       GoKind: 25
@@ -6125,7 +6125,7 @@ Types:
           Offset: 1
           Type: 4 BaseType bool
     - __kind: StructureType
-      ID: 220
+      ID: 130
       Name: main.structWithTwoValues
       ByteSize: 16
       GoKind: 25
@@ -6137,28 +6137,28 @@ Types:
           Offset: 8
           Type: 4 BaseType bool
     - __kind: GoSliceHeaderType
-      ID: 222
+      ID: 134
       Name: main.t
       ByteSize: 24
       GoKind: 23
       RawFields:
         - Name: array
           Offset: 0
-          Type: 223 PointerType **main.t
+          Type: 173 PointerType **main.t
         - Name: len
           Offset: 8
           Type: 7 BaseType int
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 270 GoSliceDataType main.t.array
+      Data: 266 GoSliceDataType main.t.array
     - __kind: GoSliceDataType
-      ID: 270
+      ID: 266
       Name: main.t.array
       ByteSize: 2048
-      Element: 221 PointerType *main.t
+      Element: 133 PointerType *main.t
     - __kind: StructureType
-      ID: 232
+      ID: 144
       Name: main.threeStringStruct
       ByteSize: 48
       GoKind: 25
@@ -6178,7 +6178,7 @@ Types:
       ByteSize: 2
       GoKind: 9
     - __kind: GoSwissMapHeaderType
-      ID: 209
+      ID: 125
       Name: map<[4]int,[4]int>
       ByteSize: 48
       GoKind: 25
@@ -6191,7 +6191,7 @@ Types:
           Type: 1 BaseType uintptr
         - Name: dirPtr
           Offset: 16
-          Type: 210 PointerType **table<[4]int,[4]int>
+          Type: 126 PointerType **table<[4]int,[4]int>
         - Name: dirLen
           Offset: 24
           Type: 7 BaseType int
@@ -6210,10 +6210,10 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 8 BaseType uint64
-      TablePtrSliceType: 268 GoSliceDataType []*table<[4]int,[4]int>.array
-      GroupType: 215 StructureType noalg.map.group[[4]int][4]int
+      TablePtrSliceType: 264 GoSliceDataType []*table<[4]int,[4]int>.array
+      GroupType: 209 StructureType noalg.map.group[[4]int][4]int
     - __kind: GoSwissMapHeaderType
-      ID: 198
+      ID: 120
       Name: map<[4]int,uint8>
       ByteSize: 48
       GoKind: 25
@@ -6226,7 +6226,7 @@ Types:
           Type: 1 BaseType uintptr
         - Name: dirPtr
           Offset: 16
-          Type: 199 PointerType **table<[4]int,uint8>
+          Type: 121 PointerType **table<[4]int,uint8>
         - Name: dirLen
           Offset: 24
           Type: 7 BaseType int
@@ -6245,10 +6245,10 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 8 BaseType uint64
-      TablePtrSliceType: 266 GoSliceDataType []*table<[4]int,uint8>.array
-      GroupType: 204 StructureType noalg.map.group[[4]int]uint8
+      TablePtrSliceType: 262 GoSliceDataType []*table<[4]int,uint8>.array
+      GroupType: 206 StructureType noalg.map.group[[4]int]uint8
     - __kind: GoSwissMapHeaderType
-      ID: 124
+      ID: 88
       Name: map<[4]string,[2]int>
       ByteSize: 48
       GoKind: 25
@@ -6261,7 +6261,7 @@ Types:
           Type: 1 BaseType uintptr
         - Name: dirPtr
           Offset: 16
-          Type: 125 PointerType **table<[4]string,[2]int>
+          Type: 89 PointerType **table<[4]string,[2]int>
         - Name: dirLen
           Offset: 24
           Type: 7 BaseType int
@@ -6280,10 +6280,10 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 8 BaseType uint64
-      TablePtrSliceType: 252 GoSliceDataType []*table<[4]string,[2]int>.array
-      GroupType: 130 StructureType noalg.map.group[[4]string][2]int
+      TablePtrSliceType: 250 GoSliceDataType []*table<[4]string,[2]int>.array
+      GroupType: 188 StructureType noalg.map.group[[4]string][2]int
     - __kind: GoSwissMapHeaderType
-      ID: 151
+      ID: 100
       Name: map<bool,main.node>
       ByteSize: 48
       GoKind: 25
@@ -6296,7 +6296,7 @@ Types:
           Type: 1 BaseType uintptr
         - Name: dirPtr
           Offset: 16
-          Type: 152 PointerType **table<bool,main.node>
+          Type: 101 PointerType **table<bool,main.node>
         - Name: dirLen
           Offset: 24
           Type: 7 BaseType int
@@ -6315,10 +6315,10 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 8 BaseType uint64
-      TablePtrSliceType: 258 GoSliceDataType []*table<bool,main.node>.array
-      GroupType: 157 StructureType noalg.map.group[bool]main.node
+      TablePtrSliceType: 254 GoSliceDataType []*table<bool,main.node>.array
+      GroupType: 194 StructureType noalg.map.group[bool]main.node
     - __kind: GoSwissMapHeaderType
-      ID: 78
+      ID: 68
       Name: map<int,int>
       ByteSize: 48
       GoKind: 25
@@ -6331,7 +6331,7 @@ Types:
           Type: 1 BaseType uintptr
         - Name: dirPtr
           Offset: 16
-          Type: 79 PointerType **table<int,int>
+          Type: 69 PointerType **table<int,int>
         - Name: dirLen
           Offset: 24
           Type: 7 BaseType int
@@ -6351,9 +6351,9 @@ Types:
           Offset: 40
           Type: 8 BaseType uint64
       TablePtrSliceType: 242 GoSliceDataType []*table<int,int>.array
-      GroupType: 84 StructureType noalg.map.group[int]int
+      GroupType: 176 StructureType noalg.map.group[int]int
     - __kind: GoSwissMapHeaderType
-      ID: 164
+      ID: 105
       Name: map<int,uint8>
       ByteSize: 48
       GoKind: 25
@@ -6366,7 +6366,7 @@ Types:
           Type: 1 BaseType uintptr
         - Name: dirPtr
           Offset: 16
-          Type: 165 PointerType **table<int,uint8>
+          Type: 106 PointerType **table<int,uint8>
         - Name: dirLen
           Offset: 24
           Type: 7 BaseType int
@@ -6385,10 +6385,10 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 8 BaseType uint64
-      TablePtrSliceType: 260 GoSliceDataType []*table<int,uint8>.array
-      GroupType: 170 StructureType noalg.map.group[int]uint8
+      TablePtrSliceType: 256 GoSliceDataType []*table<int,uint8>.array
+      GroupType: 197 StructureType noalg.map.group[int]uint8
     - __kind: GoSwissMapHeaderType
-      ID: 138
+      ID: 95
       Name: map<string,[]main.structWithMap>
       ByteSize: 48
       GoKind: 25
@@ -6401,7 +6401,7 @@ Types:
           Type: 1 BaseType uintptr
         - Name: dirPtr
           Offset: 16
-          Type: 139 PointerType **table<string,[]main.structWithMap>
+          Type: 96 PointerType **table<string,[]main.structWithMap>
         - Name: dirLen
           Offset: 24
           Type: 7 BaseType int
@@ -6420,10 +6420,10 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 8 BaseType uint64
-      TablePtrSliceType: 254 GoSliceDataType []*table<string,[]main.structWithMap>.array
-      GroupType: 144 StructureType noalg.map.group[string][]main.structWithMap
+      TablePtrSliceType: 252 GoSliceDataType []*table<string,[]main.structWithMap>.array
+      GroupType: 191 StructureType noalg.map.group[string][]main.structWithMap
     - __kind: GoSwissMapHeaderType
-      ID: 112
+      ID: 83
       Name: map<string,[]string>
       ByteSize: 48
       GoKind: 25
@@ -6436,7 +6436,7 @@ Types:
           Type: 1 BaseType uintptr
         - Name: dirPtr
           Offset: 16
-          Type: 113 PointerType **table<string,[]string>
+          Type: 84 PointerType **table<string,[]string>
         - Name: dirLen
           Offset: 24
           Type: 7 BaseType int
@@ -6456,9 +6456,9 @@ Types:
           Offset: 40
           Type: 8 BaseType uint64
       TablePtrSliceType: 248 GoSliceDataType []*table<string,[]string>.array
-      GroupType: 118 StructureType noalg.map.group[string][]string
+      GroupType: 185 StructureType noalg.map.group[string][]string
     - __kind: GoSwissMapHeaderType
-      ID: 101
+      ID: 78
       Name: map<string,int>
       ByteSize: 48
       GoKind: 25
@@ -6471,7 +6471,7 @@ Types:
           Type: 1 BaseType uintptr
         - Name: dirPtr
           Offset: 16
-          Type: 102 PointerType **table<string,int>
+          Type: 79 PointerType **table<string,int>
         - Name: dirLen
           Offset: 24
           Type: 7 BaseType int
@@ -6491,9 +6491,9 @@ Types:
           Offset: 40
           Type: 8 BaseType uint64
       TablePtrSliceType: 246 GoSliceDataType []*table<string,int>.array
-      GroupType: 107 StructureType noalg.map.group[string]int
+      GroupType: 182 StructureType noalg.map.group[string]int
     - __kind: GoSwissMapHeaderType
-      ID: 89
+      ID: 73
       Name: map<string,main.nestedStruct>
       ByteSize: 48
       GoKind: 25
@@ -6506,7 +6506,7 @@ Types:
           Type: 1 BaseType uintptr
         - Name: dirPtr
           Offset: 16
-          Type: 90 PointerType **table<string,main.nestedStruct>
+          Type: 74 PointerType **table<string,main.nestedStruct>
         - Name: dirLen
           Offset: 24
           Type: 7 BaseType int
@@ -6526,9 +6526,9 @@ Types:
           Offset: 40
           Type: 8 BaseType uint64
       TablePtrSliceType: 244 GoSliceDataType []*table<string,main.nestedStruct>.array
-      GroupType: 95 StructureType noalg.map.group[string]main.nestedStruct
+      GroupType: 179 StructureType noalg.map.group[string]main.nestedStruct
     - __kind: GoSwissMapHeaderType
-      ID: 186
+      ID: 115
       Name: map<uint8,[4]int>
       ByteSize: 48
       GoKind: 25
@@ -6541,7 +6541,7 @@ Types:
           Type: 1 BaseType uintptr
         - Name: dirPtr
           Offset: 16
-          Type: 187 PointerType **table<uint8,[4]int>
+          Type: 116 PointerType **table<uint8,[4]int>
         - Name: dirLen
           Offset: 24
           Type: 7 BaseType int
@@ -6560,10 +6560,10 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 8 BaseType uint64
-      TablePtrSliceType: 264 GoSliceDataType []*table<uint8,[4]int>.array
-      GroupType: 192 StructureType noalg.map.group[uint8][4]int
+      TablePtrSliceType: 260 GoSliceDataType []*table<uint8,[4]int>.array
+      GroupType: 203 StructureType noalg.map.group[uint8][4]int
     - __kind: GoSwissMapHeaderType
-      ID: 175
+      ID: 110
       Name: map<uint8,uint8>
       ByteSize: 48
       GoKind: 25
@@ -6576,7 +6576,7 @@ Types:
           Type: 1 BaseType uintptr
         - Name: dirPtr
           Offset: 16
-          Type: 176 PointerType **table<uint8,uint8>
+          Type: 111 PointerType **table<uint8,uint8>
         - Name: dirLen
           Offset: 24
           Type: 7 BaseType int
@@ -6595,202 +6595,202 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 8 BaseType uint64
-      TablePtrSliceType: 262 GoSliceDataType []*table<uint8,uint8>.array
-      GroupType: 181 StructureType noalg.map.group[uint8]uint8
+      TablePtrSliceType: 258 GoSliceDataType []*table<uint8,uint8>.array
+      GroupType: 200 StructureType noalg.map.group[uint8]uint8
     - __kind: GoMapType
-      ID: 207
+      ID: 123
       Name: map[[4]int][4]int
       ByteSize: 8
       GoRuntimeType: 1.1224e+06
       GoKind: 21
-      HeaderType: 209 GoSwissMapHeaderType map<[4]int,[4]int>
+      HeaderType: 125 GoSwissMapHeaderType map<[4]int,[4]int>
     - __kind: GoMapType
-      ID: 196
+      ID: 118
       Name: map[[4]int]uint8
       ByteSize: 8
       GoRuntimeType: 1.122528e+06
       GoKind: 21
-      HeaderType: 198 GoSwissMapHeaderType map<[4]int,uint8>
+      HeaderType: 120 GoSwissMapHeaderType map<[4]int,uint8>
     - __kind: GoMapType
-      ID: 122
+      ID: 86
       Name: map[[4]string][2]int
       ByteSize: 8
       GoRuntimeType: 1.122656e+06
       GoKind: 21
-      HeaderType: 124 GoSwissMapHeaderType map<[4]string,[2]int>
+      HeaderType: 88 GoSwissMapHeaderType map<[4]string,[2]int>
     - __kind: GoMapType
-      ID: 149
+      ID: 98
       Name: map[bool]main.node
       ByteSize: 8
       GoRuntimeType: 1.122784e+06
       GoKind: 21
-      HeaderType: 151 GoSwissMapHeaderType map<bool,main.node>
+      HeaderType: 100 GoSwissMapHeaderType map<bool,main.node>
     - __kind: GoMapType
-      ID: 76
+      ID: 66
       Name: map[int]int
       ByteSize: 8
       GoRuntimeType: 1.122016e+06
       GoKind: 21
-      HeaderType: 78 GoSwissMapHeaderType map<int,int>
+      HeaderType: 68 GoSwissMapHeaderType map<int,int>
     - __kind: GoMapType
-      ID: 162
+      ID: 103
       Name: map[int]uint8
       ByteSize: 8
       GoRuntimeType: 1.122912e+06
       GoKind: 21
-      HeaderType: 164 GoSwissMapHeaderType map<int,uint8>
+      HeaderType: 105 GoSwissMapHeaderType map<int,uint8>
     - __kind: GoMapType
-      ID: 136
+      ID: 93
       Name: map[string][]main.structWithMap
       ByteSize: 8
       GoRuntimeType: 1.12304e+06
       GoKind: 21
-      HeaderType: 138 GoSwissMapHeaderType map<string,[]main.structWithMap>
+      HeaderType: 95 GoSwissMapHeaderType map<string,[]main.structWithMap>
     - __kind: GoMapType
-      ID: 110
+      ID: 81
       Name: map[string][]string
       ByteSize: 8
       GoRuntimeType: 1.123168e+06
       GoKind: 21
-      HeaderType: 112 GoSwissMapHeaderType map<string,[]string>
+      HeaderType: 83 GoSwissMapHeaderType map<string,[]string>
     - __kind: GoMapType
-      ID: 99
+      ID: 76
       Name: map[string]int
       ByteSize: 8
       GoRuntimeType: 1.123296e+06
       GoKind: 21
-      HeaderType: 101 GoSwissMapHeaderType map<string,int>
+      HeaderType: 78 GoSwissMapHeaderType map<string,int>
     - __kind: GoMapType
-      ID: 87
+      ID: 71
       Name: map[string]main.nestedStruct
       ByteSize: 8
       GoRuntimeType: 1.123424e+06
       GoKind: 21
-      HeaderType: 89 GoSwissMapHeaderType map<string,main.nestedStruct>
+      HeaderType: 73 GoSwissMapHeaderType map<string,main.nestedStruct>
     - __kind: GoMapType
-      ID: 184
+      ID: 113
       Name: map[uint8][4]int
       ByteSize: 8
       GoRuntimeType: 1.123552e+06
       GoKind: 21
-      HeaderType: 186 GoSwissMapHeaderType map<uint8,[4]int>
+      HeaderType: 115 GoSwissMapHeaderType map<uint8,[4]int>
     - __kind: GoMapType
-      ID: 173
+      ID: 108
       Name: map[uint8]uint8
       ByteSize: 8
       GoRuntimeType: 1.12368e+06
       GoKind: 21
-      HeaderType: 175 GoSwissMapHeaderType map<uint8,uint8>
+      HeaderType: 110 GoSwissMapHeaderType map<uint8,uint8>
     - __kind: ArrayType
-      ID: 216
+      ID: 236
       Name: noalg.[8]struct { key [4]int; elem [4]int }
       ByteSize: 512
       GoRuntimeType: 676736
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 217 StructureType noalg.struct { key [4]int; elem [4]int }
+      Element: 237 StructureType noalg.struct { key [4]int; elem [4]int }
     - __kind: ArrayType
-      ID: 205
+      ID: 234
       Name: noalg.[8]struct { key [4]int; elem uint8 }
       ByteSize: 320
       GoRuntimeType: 676832
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 206 StructureType noalg.struct { key [4]int; elem uint8 }
+      Element: 235 StructureType noalg.struct { key [4]int; elem uint8 }
     - __kind: ArrayType
-      ID: 131
+      ID: 218
       Name: noalg.[8]struct { key [4]string; elem [2]int }
       ByteSize: 640
       GoRuntimeType: 677120
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 132 StructureType noalg.struct { key [4]string; elem [2]int }
+      Element: 219 StructureType noalg.struct { key [4]string; elem [2]int }
     - __kind: ArrayType
-      ID: 158
+      ID: 225
       Name: noalg.[8]struct { key bool; elem main.node }
       ByteSize: 192
       GoRuntimeType: 677216
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 159 StructureType noalg.struct { key bool; elem main.node }
+      Element: 226 StructureType noalg.struct { key bool; elem main.node }
     - __kind: ArrayType
-      ID: 85
+      ID: 210
       Name: noalg.[8]struct { key int; elem int }
       ByteSize: 128
       GoRuntimeType: 675008
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 86 StructureType noalg.struct { key int; elem int }
+      Element: 211 StructureType noalg.struct { key int; elem int }
     - __kind: ArrayType
-      ID: 171
+      ID: 227
       Name: noalg.[8]struct { key int; elem uint8 }
       ByteSize: 128
       GoRuntimeType: 677312
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 172 StructureType noalg.struct { key int; elem uint8 }
+      Element: 228 StructureType noalg.struct { key int; elem uint8 }
     - __kind: ArrayType
-      ID: 145
+      ID: 221
       Name: noalg.[8]struct { key string; elem []main.structWithMap }
       ByteSize: 320
       GoRuntimeType: 677408
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 146 StructureType noalg.struct { key string; elem []main.structWithMap }
+      Element: 222 StructureType noalg.struct { key string; elem []main.structWithMap }
     - __kind: ArrayType
-      ID: 119
+      ID: 216
       Name: noalg.[8]struct { key string; elem []string }
       ByteSize: 320
       GoRuntimeType: 677504
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 120 StructureType noalg.struct { key string; elem []string }
+      Element: 217 StructureType noalg.struct { key string; elem []string }
     - __kind: ArrayType
-      ID: 108
+      ID: 214
       Name: noalg.[8]struct { key string; elem int }
       ByteSize: 192
       GoRuntimeType: 677600
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 109 StructureType noalg.struct { key string; elem int }
+      Element: 215 StructureType noalg.struct { key string; elem int }
     - __kind: ArrayType
-      ID: 96
+      ID: 212
       Name: noalg.[8]struct { key string; elem main.nestedStruct }
       ByteSize: 320
       GoRuntimeType: 677696
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 97 StructureType noalg.struct { key string; elem main.nestedStruct }
+      Element: 213 StructureType noalg.struct { key string; elem main.nestedStruct }
     - __kind: ArrayType
-      ID: 193
+      ID: 231
       Name: noalg.[8]struct { key uint8; elem [4]int }
       ByteSize: 320
       GoRuntimeType: 677792
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 194 StructureType noalg.struct { key uint8; elem [4]int }
+      Element: 232 StructureType noalg.struct { key uint8; elem [4]int }
     - __kind: ArrayType
-      ID: 182
+      ID: 229
       Name: noalg.[8]struct { key uint8; elem uint8 }
       ByteSize: 16
       GoRuntimeType: 677888
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 183 StructureType noalg.struct { key uint8; elem uint8 }
+      Element: 230 StructureType noalg.struct { key uint8; elem uint8 }
     - __kind: StructureType
-      ID: 215
+      ID: 209
       Name: noalg.map.group[[4]int][4]int
       ByteSize: 520
       GoRuntimeType: 1.28176e+06
@@ -6801,9 +6801,9 @@ Types:
           Type: 8 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 216 ArrayType noalg.[8]struct { key [4]int; elem [4]int }
+          Type: 236 ArrayType noalg.[8]struct { key [4]int; elem [4]int }
     - __kind: StructureType
-      ID: 204
+      ID: 206
       Name: noalg.map.group[[4]int]uint8
       ByteSize: 328
       GoRuntimeType: 1.282016e+06
@@ -6814,9 +6814,9 @@ Types:
           Type: 8 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 205 ArrayType noalg.[8]struct { key [4]int; elem uint8 }
+          Type: 234 ArrayType noalg.[8]struct { key [4]int; elem uint8 }
     - __kind: StructureType
-      ID: 130
+      ID: 188
       Name: noalg.map.group[[4]string][2]int
       ByteSize: 648
       GoRuntimeType: 1.282272e+06
@@ -6827,9 +6827,9 @@ Types:
           Type: 8 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 131 ArrayType noalg.[8]struct { key [4]string; elem [2]int }
+          Type: 218 ArrayType noalg.[8]struct { key [4]string; elem [2]int }
     - __kind: StructureType
-      ID: 157
+      ID: 194
       Name: noalg.map.group[bool]main.node
       ByteSize: 200
       GoRuntimeType: 1.282528e+06
@@ -6840,9 +6840,9 @@ Types:
           Type: 8 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 158 ArrayType noalg.[8]struct { key bool; elem main.node }
+          Type: 225 ArrayType noalg.[8]struct { key bool; elem main.node }
     - __kind: StructureType
-      ID: 84
+      ID: 176
       Name: noalg.map.group[int]int
       ByteSize: 136
       GoRuntimeType: 1.280992e+06
@@ -6853,9 +6853,9 @@ Types:
           Type: 8 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 85 ArrayType noalg.[8]struct { key int; elem int }
+          Type: 210 ArrayType noalg.[8]struct { key int; elem int }
     - __kind: StructureType
-      ID: 170
+      ID: 197
       Name: noalg.map.group[int]uint8
       ByteSize: 136
       GoRuntimeType: 1.282784e+06
@@ -6866,9 +6866,9 @@ Types:
           Type: 8 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 171 ArrayType noalg.[8]struct { key int; elem uint8 }
+          Type: 227 ArrayType noalg.[8]struct { key int; elem uint8 }
     - __kind: StructureType
-      ID: 144
+      ID: 191
       Name: noalg.map.group[string][]main.structWithMap
       ByteSize: 328
       GoRuntimeType: 1.28304e+06
@@ -6879,9 +6879,9 @@ Types:
           Type: 8 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 145 ArrayType noalg.[8]struct { key string; elem []main.structWithMap }
+          Type: 221 ArrayType noalg.[8]struct { key string; elem []main.structWithMap }
     - __kind: StructureType
-      ID: 118
+      ID: 185
       Name: noalg.map.group[string][]string
       ByteSize: 328
       GoRuntimeType: 1.283296e+06
@@ -6892,9 +6892,9 @@ Types:
           Type: 8 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 119 ArrayType noalg.[8]struct { key string; elem []string }
+          Type: 216 ArrayType noalg.[8]struct { key string; elem []string }
     - __kind: StructureType
-      ID: 107
+      ID: 182
       Name: noalg.map.group[string]int
       ByteSize: 200
       GoRuntimeType: 1.283552e+06
@@ -6905,9 +6905,9 @@ Types:
           Type: 8 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 108 ArrayType noalg.[8]struct { key string; elem int }
+          Type: 214 ArrayType noalg.[8]struct { key string; elem int }
     - __kind: StructureType
-      ID: 95
+      ID: 179
       Name: noalg.map.group[string]main.nestedStruct
       ByteSize: 328
       GoRuntimeType: 1.283808e+06
@@ -6918,9 +6918,9 @@ Types:
           Type: 8 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 96 ArrayType noalg.[8]struct { key string; elem main.nestedStruct }
+          Type: 212 ArrayType noalg.[8]struct { key string; elem main.nestedStruct }
     - __kind: StructureType
-      ID: 192
+      ID: 203
       Name: noalg.map.group[uint8][4]int
       ByteSize: 328
       GoRuntimeType: 1.284064e+06
@@ -6931,9 +6931,9 @@ Types:
           Type: 8 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 193 ArrayType noalg.[8]struct { key uint8; elem [4]int }
+          Type: 231 ArrayType noalg.[8]struct { key uint8; elem [4]int }
     - __kind: StructureType
-      ID: 181
+      ID: 200
       Name: noalg.map.group[uint8]uint8
       ByteSize: 24
       GoRuntimeType: 1.28432e+06
@@ -6944,9 +6944,9 @@ Types:
           Type: 8 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 182 ArrayType noalg.[8]struct { key uint8; elem uint8 }
+          Type: 229 ArrayType noalg.[8]struct { key uint8; elem uint8 }
     - __kind: StructureType
-      ID: 217
+      ID: 237
       Name: noalg.struct { key [4]int; elem [4]int }
       ByteSize: 64
       GoRuntimeType: 1.281632e+06
@@ -6954,12 +6954,12 @@ Types:
       RawFields:
         - Name: key
           Offset: 0
-          Type: 195 ArrayType [4]int
+          Type: 233 ArrayType [4]int
         - Name: elem
           Offset: 32
-          Type: 195 ArrayType [4]int
+          Type: 233 ArrayType [4]int
     - __kind: StructureType
-      ID: 206
+      ID: 235
       Name: noalg.struct { key [4]int; elem uint8 }
       ByteSize: 40
       GoRuntimeType: 1.281888e+06
@@ -6967,12 +6967,12 @@ Types:
       RawFields:
         - Name: key
           Offset: 0
-          Type: 195 ArrayType [4]int
+          Type: 233 ArrayType [4]int
         - Name: elem
           Offset: 32
           Type: 3 BaseType uint8
     - __kind: StructureType
-      ID: 132
+      ID: 219
       Name: noalg.struct { key [4]string; elem [2]int }
       ByteSize: 80
       GoRuntimeType: 1.282144e+06
@@ -6980,12 +6980,12 @@ Types:
       RawFields:
         - Name: key
           Offset: 0
-          Type: 133 ArrayType [4]string
+          Type: 220 ArrayType [4]string
         - Name: elem
           Offset: 64
           Type: 40 ArrayType [2]int
     - __kind: StructureType
-      ID: 159
+      ID: 226
       Name: noalg.struct { key bool; elem main.node }
       ByteSize: 24
       GoRuntimeType: 1.2824e+06
@@ -6996,9 +6996,9 @@ Types:
           Type: 4 BaseType bool
         - Name: elem
           Offset: 8
-          Type: 160 StructureType main.node
+          Type: 131 StructureType main.node
     - __kind: StructureType
-      ID: 86
+      ID: 211
       Name: noalg.struct { key int; elem int }
       ByteSize: 16
       GoRuntimeType: 1.280864e+06
@@ -7011,7 +7011,7 @@ Types:
           Offset: 8
           Type: 7 BaseType int
     - __kind: StructureType
-      ID: 172
+      ID: 228
       Name: noalg.struct { key int; elem uint8 }
       ByteSize: 16
       GoRuntimeType: 1.282656e+06
@@ -7024,7 +7024,7 @@ Types:
           Offset: 8
           Type: 3 BaseType uint8
     - __kind: StructureType
-      ID: 146
+      ID: 222
       Name: noalg.struct { key string; elem []main.structWithMap }
       ByteSize: 40
       GoRuntimeType: 1.282912e+06
@@ -7035,9 +7035,9 @@ Types:
           Type: 9 GoStringHeaderType string
         - Name: elem
           Offset: 16
-          Type: 147 GoSliceHeaderType []main.structWithMap
+          Type: 223 GoSliceHeaderType []main.structWithMap
     - __kind: StructureType
-      ID: 120
+      ID: 217
       Name: noalg.struct { key string; elem []string }
       ByteSize: 40
       GoRuntimeType: 1.283168e+06
@@ -7048,9 +7048,9 @@ Types:
           Type: 9 GoStringHeaderType string
         - Name: elem
           Offset: 16
-          Type: 121 GoSliceHeaderType []string
+          Type: 141 GoSliceHeaderType []string
     - __kind: StructureType
-      ID: 109
+      ID: 215
       Name: noalg.struct { key string; elem int }
       ByteSize: 24
       GoRuntimeType: 1.283424e+06
@@ -7063,7 +7063,7 @@ Types:
           Offset: 16
           Type: 7 BaseType int
     - __kind: StructureType
-      ID: 97
+      ID: 213
       Name: noalg.struct { key string; elem main.nestedStruct }
       ByteSize: 40
       GoRuntimeType: 1.28368e+06
@@ -7074,9 +7074,9 @@ Types:
           Type: 9 GoStringHeaderType string
         - Name: elem
           Offset: 16
-          Type: 98 StructureType main.nestedStruct
+          Type: 149 StructureType main.nestedStruct
     - __kind: StructureType
-      ID: 194
+      ID: 232
       Name: noalg.struct { key uint8; elem [4]int }
       ByteSize: 40
       GoRuntimeType: 1.283936e+06
@@ -7087,9 +7087,9 @@ Types:
           Type: 3 BaseType uint8
         - Name: elem
           Offset: 8
-          Type: 195 ArrayType [4]int
+          Type: 233 ArrayType [4]int
     - __kind: StructureType
-      ID: 183
+      ID: 230
       Name: noalg.struct { key uint8; elem uint8 }
       ByteSize: 2
       GoRuntimeType: 1.284192e+06
@@ -7120,7 +7120,7 @@ Types:
       Name: string.str
       ByteSize: 2048
     - __kind: StructureType
-      ID: 63
+      ID: 151
       Name: sync.Mutex
       ByteSize: 8
       GoRuntimeType: 1.44992e+06
@@ -7128,12 +7128,12 @@ Types:
       RawFields:
         - Name: _
           Offset: 0
-          Type: 64 StructureType sync.noCopy
+          Type: 152 StructureType sync.noCopy
         - Name: mu
           Offset: 0
-          Type: 65 StructureType internal/sync.Mutex
+          Type: 153 StructureType internal/sync.Mutex
     - __kind: StructureType
-      ID: 66
+      ID: 154
       Name: sync.Once
       ByteSize: 12
       GoRuntimeType: 1.598816e+06
@@ -7141,15 +7141,15 @@ Types:
       RawFields:
         - Name: _
           Offset: 0
-          Type: 64 StructureType sync.noCopy
+          Type: 152 StructureType sync.noCopy
         - Name: done
           Offset: 0
-          Type: 67 StructureType sync/atomic.Bool
+          Type: 155 StructureType sync/atomic.Bool
         - Name: m
           Offset: 4
-          Type: 63 StructureType sync.Mutex
+          Type: 151 StructureType sync.Mutex
     - __kind: StructureType
-      ID: 69
+      ID: 157
       Name: sync.WaitGroup
       ByteSize: 16
       GoRuntimeType: 1.598624e+06
@@ -7157,21 +7157,21 @@ Types:
       RawFields:
         - Name: noCopy
           Offset: 0
-          Type: 64 StructureType sync.noCopy
+          Type: 152 StructureType sync.noCopy
         - Name: state
           Offset: 0
-          Type: 70 StructureType sync/atomic.Uint64
+          Type: 158 StructureType sync/atomic.Uint64
         - Name: sema
           Offset: 8
           Type: 2 BaseType uint32
     - __kind: StructureType
-      ID: 64
+      ID: 152
       Name: sync.noCopy
       GoRuntimeType: 982144
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 67
+      ID: 155
       Name: sync/atomic.Bool
       ByteSize: 4
       GoRuntimeType: 1.45104e+06
@@ -7179,12 +7179,12 @@ Types:
       RawFields:
         - Name: _
           Offset: 0
-          Type: 68 StructureType sync/atomic.noCopy
+          Type: 156 StructureType sync/atomic.noCopy
         - Name: v
           Offset: 0
           Type: 2 BaseType uint32
     - __kind: StructureType
-      ID: 72
+      ID: 160
       Name: sync/atomic.Int32
       ByteSize: 4
       GoRuntimeType: 1.4512e+06
@@ -7192,12 +7192,12 @@ Types:
       RawFields:
         - Name: _
           Offset: 0
-          Type: 68 StructureType sync/atomic.noCopy
+          Type: 156 StructureType sync/atomic.noCopy
         - Name: v
           Offset: 0
           Type: 10 BaseType int32
     - __kind: StructureType
-      ID: 70
+      ID: 158
       Name: sync/atomic.Uint64
       ByteSize: 8
       GoRuntimeType: 1.5992e+06
@@ -7205,27 +7205,27 @@ Types:
       RawFields:
         - Name: _
           Offset: 0
-          Type: 68 StructureType sync/atomic.noCopy
+          Type: 156 StructureType sync/atomic.noCopy
         - Name: _
           Offset: 0
-          Type: 71 StructureType sync/atomic.align64
+          Type: 159 StructureType sync/atomic.align64
         - Name: v
           Offset: 0
           Type: 8 BaseType uint64
     - __kind: StructureType
-      ID: 71
+      ID: 159
       Name: sync/atomic.align64
       GoRuntimeType: 982336
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 68
+      ID: 156
       Name: sync/atomic.noCopy
       GoRuntimeType: 982240
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 212
+      ID: 172
       Name: table<[4]int,[4]int>
       ByteSize: 32
       GoKind: 25
@@ -7247,9 +7247,9 @@ Types:
           Type: 7 BaseType int
         - Name: groups
           Offset: 16
-          Type: 213 GoSwissMapGroupsType groupReference<[4]int,[4]int>
+          Type: 207 GoSwissMapGroupsType groupReference<[4]int,[4]int>
     - __kind: StructureType
-      ID: 201
+      ID: 171
       Name: table<[4]int,uint8>
       ByteSize: 32
       GoKind: 25
@@ -7271,9 +7271,9 @@ Types:
           Type: 7 BaseType int
         - Name: groups
           Offset: 16
-          Type: 202 GoSwissMapGroupsType groupReference<[4]int,uint8>
+          Type: 204 GoSwissMapGroupsType groupReference<[4]int,uint8>
     - __kind: StructureType
-      ID: 127
+      ID: 165
       Name: table<[4]string,[2]int>
       ByteSize: 32
       GoKind: 25
@@ -7295,9 +7295,9 @@ Types:
           Type: 7 BaseType int
         - Name: groups
           Offset: 16
-          Type: 128 GoSwissMapGroupsType groupReference<[4]string,[2]int>
+          Type: 186 GoSwissMapGroupsType groupReference<[4]string,[2]int>
     - __kind: StructureType
-      ID: 154
+      ID: 167
       Name: table<bool,main.node>
       ByteSize: 32
       GoKind: 25
@@ -7319,9 +7319,9 @@ Types:
           Type: 7 BaseType int
         - Name: groups
           Offset: 16
-          Type: 155 GoSwissMapGroupsType groupReference<bool,main.node>
+          Type: 192 GoSwissMapGroupsType groupReference<bool,main.node>
     - __kind: StructureType
-      ID: 81
+      ID: 161
       Name: table<int,int>
       ByteSize: 32
       GoKind: 25
@@ -7343,9 +7343,9 @@ Types:
           Type: 7 BaseType int
         - Name: groups
           Offset: 16
-          Type: 82 GoSwissMapGroupsType groupReference<int,int>
+          Type: 174 GoSwissMapGroupsType groupReference<int,int>
     - __kind: StructureType
-      ID: 167
+      ID: 168
       Name: table<int,uint8>
       ByteSize: 32
       GoKind: 25
@@ -7367,9 +7367,9 @@ Types:
           Type: 7 BaseType int
         - Name: groups
           Offset: 16
-          Type: 168 GoSwissMapGroupsType groupReference<int,uint8>
+          Type: 195 GoSwissMapGroupsType groupReference<int,uint8>
     - __kind: StructureType
-      ID: 141
+      ID: 166
       Name: table<string,[]main.structWithMap>
       ByteSize: 32
       GoKind: 25
@@ -7391,9 +7391,9 @@ Types:
           Type: 7 BaseType int
         - Name: groups
           Offset: 16
-          Type: 142 GoSwissMapGroupsType groupReference<string,[]main.structWithMap>
+          Type: 189 GoSwissMapGroupsType groupReference<string,[]main.structWithMap>
     - __kind: StructureType
-      ID: 115
+      ID: 164
       Name: table<string,[]string>
       ByteSize: 32
       GoKind: 25
@@ -7415,9 +7415,9 @@ Types:
           Type: 7 BaseType int
         - Name: groups
           Offset: 16
-          Type: 116 GoSwissMapGroupsType groupReference<string,[]string>
+          Type: 183 GoSwissMapGroupsType groupReference<string,[]string>
     - __kind: StructureType
-      ID: 104
+      ID: 163
       Name: table<string,int>
       ByteSize: 32
       GoKind: 25
@@ -7439,9 +7439,9 @@ Types:
           Type: 7 BaseType int
         - Name: groups
           Offset: 16
-          Type: 105 GoSwissMapGroupsType groupReference<string,int>
+          Type: 180 GoSwissMapGroupsType groupReference<string,int>
     - __kind: StructureType
-      ID: 92
+      ID: 162
       Name: table<string,main.nestedStruct>
       ByteSize: 32
       GoKind: 25
@@ -7463,9 +7463,9 @@ Types:
           Type: 7 BaseType int
         - Name: groups
           Offset: 16
-          Type: 93 GoSwissMapGroupsType groupReference<string,main.nestedStruct>
+          Type: 177 GoSwissMapGroupsType groupReference<string,main.nestedStruct>
     - __kind: StructureType
-      ID: 189
+      ID: 170
       Name: table<uint8,[4]int>
       ByteSize: 32
       GoKind: 25
@@ -7487,9 +7487,9 @@ Types:
           Type: 7 BaseType int
         - Name: groups
           Offset: 16
-          Type: 190 GoSwissMapGroupsType groupReference<uint8,[4]int>
+          Type: 201 GoSwissMapGroupsType groupReference<uint8,[4]int>
     - __kind: StructureType
-      ID: 178
+      ID: 169
       Name: table<uint8,uint8>
       ByteSize: 32
       GoKind: 25
@@ -7511,7 +7511,7 @@ Types:
           Type: 7 BaseType int
         - Name: groups
           Offset: 16
-          Type: 179 GoSwissMapGroupsType groupReference<uint8,uint8>
+          Type: 198 GoSwissMapGroupsType groupReference<uint8,uint8>
     - __kind: BaseType
       ID: 17
       Name: uint

--- a/pkg/dyninst/irgen/testdata/snapshot/sample.arch=arm64,toolchain=go1.23.11.yaml
+++ b/pkg/dyninst/irgen/testdata/snapshot/sample.arch=arm64,toolchain=go1.23.11.yaml
@@ -2089,7 +2089,7 @@ Subprograms:
       InlinePCRanges: []
       Variables:
         - Name: a
-          Type: 72 ArrayType [5]int
+          Type: 63 ArrayType [5]int
           Locations:
             - Range: 0x88ce60..0x88cec0
               Pieces: [{Size: 40, Op: {CfaOffset: 8}}]
@@ -2106,7 +2106,7 @@ Subprograms:
       InlinePCRanges: []
       Variables:
         - Name: b
-          Type: 73 GoInterfaceType main.behavior
+          Type: 64 GoInterfaceType main.behavior
           Locations:
             - Range: 0x88d100..0x88d128
               Pieces:
@@ -2176,7 +2176,7 @@ Subprograms:
       InlinePCRanges: []
       Variables:
         - Name: s
-          Type: 74 StructureType main.structWithMap
+          Type: 65 StructureType main.structWithMap
           Locations:
             - Range: 0x88d5f0..0x88d600
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
@@ -2188,7 +2188,7 @@ Subprograms:
       InlinePCRanges: []
       Variables:
         - Name: m
-          Type: 90 GoMapType map[string]main.nestedStruct
+          Type: 73 GoMapType map[string]main.nestedStruct
           Locations:
             - Range: 0x88d600..0x88d610
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
@@ -2200,7 +2200,7 @@ Subprograms:
       InlinePCRanges: []
       Variables:
         - Name: m
-          Type: 98 GoMapType map[string]int
+          Type: 78 GoMapType map[string]int
           Locations:
             - Range: 0x88d610..0x88d620
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
@@ -2212,7 +2212,7 @@ Subprograms:
       InlinePCRanges: []
       Variables:
         - Name: m
-          Type: 103 GoMapType map[string][]string
+          Type: 83 GoMapType map[string][]string
           Locations:
             - Range: 0x88d620..0x88d630
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
@@ -2224,7 +2224,7 @@ Subprograms:
       InlinePCRanges: []
       Variables:
         - Name: m
-          Type: 110 GoMapType map[[4]string][2]int
+          Type: 88 GoMapType map[[4]string][2]int
           Locations:
             - Range: 0x88d630..0x88d640
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
@@ -2236,7 +2236,7 @@ Subprograms:
       InlinePCRanges: []
       Variables:
         - Name: m
-          Type: 98 GoMapType map[string]int
+          Type: 78 GoMapType map[string]int
           Locations:
             - Range: 0x88d640..0x88d650
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
@@ -2248,7 +2248,7 @@ Subprograms:
       InlinePCRanges: []
       Variables:
         - Name: m
-          Type: 118 ArrayType [2]map[string]int
+          Type: 93 ArrayType [2]map[string]int
           Locations:
             - Range: 0x88d650..0x88d660
               Pieces: [{Size: 16, Op: {CfaOffset: 8}}]
@@ -2260,7 +2260,7 @@ Subprograms:
       InlinePCRanges: []
       Variables:
         - Name: m
-          Type: 119 PointerType *map[string]int
+          Type: 94 PointerType *map[string]int
           Locations:
             - Range: 0x88d660..0x88d670
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
@@ -2272,7 +2272,7 @@ Subprograms:
       InlinePCRanges: []
       Variables:
         - Name: m
-          Type: 75 GoMapType map[int]int
+          Type: 66 GoMapType map[int]int
           Locations:
             - Range: 0x88d670..0x88d680
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
@@ -2284,7 +2284,7 @@ Subprograms:
       InlinePCRanges: []
       Variables:
         - Name: redactMyEntries
-          Type: 120 GoMapType map[string][]main.structWithMap
+          Type: 95 GoMapType map[string][]main.structWithMap
           Locations:
             - Range: 0x88d680..0x88d690
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
@@ -2296,7 +2296,7 @@ Subprograms:
       InlinePCRanges: []
       Variables:
         - Name: m
-          Type: 120 GoMapType map[string][]main.structWithMap
+          Type: 95 GoMapType map[string][]main.structWithMap
           Locations:
             - Range: 0x88d690..0x88d6a0
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
@@ -2308,7 +2308,7 @@ Subprograms:
       InlinePCRanges: []
       Variables:
         - Name: m
-          Type: 128 GoMapType map[bool]main.node
+          Type: 100 GoMapType map[bool]main.node
           Locations:
             - Range: 0x88d6a0..0x88d6b0
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
@@ -2320,7 +2320,7 @@ Subprograms:
       InlinePCRanges: []
       Variables:
         - Name: m
-          Type: 137 GoMapType map[int]uint8
+          Type: 105 GoMapType map[int]uint8
           Locations:
             - Range: 0x88d6b0..0x88d6c0
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
@@ -2332,7 +2332,7 @@ Subprograms:
       InlinePCRanges: []
       Variables:
         - Name: redactMyEntries
-          Type: 137 GoMapType map[int]uint8
+          Type: 105 GoMapType map[int]uint8
           Locations:
             - Range: 0x88d6c0..0x88d6d0
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
@@ -2344,7 +2344,7 @@ Subprograms:
       InlinePCRanges: []
       Variables:
         - Name: m
-          Type: 143 GoMapType map[uint8]uint8
+          Type: 110 GoMapType map[uint8]uint8
           Locations:
             - Range: 0x88d6d0..0x88d6e0
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
@@ -2356,7 +2356,7 @@ Subprograms:
       InlinePCRanges: []
       Variables:
         - Name: m
-          Type: 143 GoMapType map[uint8]uint8
+          Type: 110 GoMapType map[uint8]uint8
           Locations:
             - Range: 0x88d6e0..0x88d6f0
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
@@ -2368,7 +2368,7 @@ Subprograms:
       InlinePCRanges: []
       Variables:
         - Name: m
-          Type: 143 GoMapType map[uint8]uint8
+          Type: 110 GoMapType map[uint8]uint8
           Locations:
             - Range: 0x88d6f0..0x88d700
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
@@ -2380,7 +2380,7 @@ Subprograms:
       InlinePCRanges: []
       Variables:
         - Name: m
-          Type: 149 GoMapType map[uint8][4]int
+          Type: 115 GoMapType map[uint8][4]int
           Locations:
             - Range: 0x88d700..0x88d710
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
@@ -2392,7 +2392,7 @@ Subprograms:
       InlinePCRanges: []
       Variables:
         - Name: m
-          Type: 156 GoMapType map[[4]int]uint8
+          Type: 120 GoMapType map[[4]int]uint8
           Locations:
             - Range: 0x88d710..0x88d720
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
@@ -2404,7 +2404,7 @@ Subprograms:
       InlinePCRanges: []
       Variables:
         - Name: m
-          Type: 162 GoMapType map[[4]int][4]int
+          Type: 125 GoMapType map[[4]int][4]int
           Locations:
             - Range: 0x88d720..0x88d730
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
@@ -2486,7 +2486,7 @@ Subprograms:
       InlinePCRanges: []
       Variables:
         - Name: c
-          Type: 167 GoChannelType chan bool
+          Type: 130 GoChannelType chan bool
           Locations:
             - Range: 0x88ec00..0x88ec10
               Pieces: [{Size: 0, Op: {RegNo: 0, Shift: 0}}]
@@ -2498,7 +2498,7 @@ Subprograms:
       InlinePCRanges: []
       Variables:
         - Name: a
-          Type: 168 PointerType *main.structWithTwoValues
+          Type: 131 PointerType *main.structWithTwoValues
           Locations:
             - Range: 0x88eda0..0x88edb0
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
@@ -2510,7 +2510,7 @@ Subprograms:
       InlinePCRanges: []
       Variables:
         - Name: a
-          Type: 135 StructureType main.node
+          Type: 133 StructureType main.node
           Locations:
             - Range: 0x88edb0..0x88edc0
               Pieces:
@@ -2526,7 +2526,7 @@ Subprograms:
       InlinePCRanges: []
       Variables:
         - Name: a
-          Type: 136 PointerType *main.node
+          Type: 134 PointerType *main.node
           Locations:
             - Range: 0x88edc0..0x88edd0
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
@@ -2593,7 +2593,7 @@ Subprograms:
       InlinePCRanges: []
       Variables:
         - Name: t
-          Type: 170 PointerType *main.t
+          Type: 135 PointerType *main.t
           Locations:
             - Range: 0x88eea0..0x88eeb0
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
@@ -2605,7 +2605,7 @@ Subprograms:
       InlinePCRanges: []
       Variables:
         - Name: u
-          Type: 173 GoSliceHeaderType []uint
+          Type: 137 GoSliceHeaderType []uint
           Locations:
             - Range: 0x88f290..0x88f2a0
               Pieces:
@@ -2623,7 +2623,7 @@ Subprograms:
       InlinePCRanges: []
       Variables:
         - Name: u
-          Type: 173 GoSliceHeaderType []uint
+          Type: 137 GoSliceHeaderType []uint
           Locations:
             - Range: 0x88f2a0..0x88f2b0
               Pieces:
@@ -2641,7 +2641,7 @@ Subprograms:
       InlinePCRanges: []
       Variables:
         - Name: u
-          Type: 174 GoSliceHeaderType [][]uint
+          Type: 138 GoSliceHeaderType [][]uint
           Locations:
             - Range: 0x88f2b0..0x88f2c0
               Pieces:
@@ -2659,7 +2659,7 @@ Subprograms:
       InlinePCRanges: []
       Variables:
         - Name: xs
-          Type: 176 GoSliceHeaderType []main.structWithNoStrings
+          Type: 140 GoSliceHeaderType []main.structWithNoStrings
           Locations:
             - Range: 0x88f2c0..0x88f2d0
               Pieces:
@@ -2684,7 +2684,7 @@ Subprograms:
       InlinePCRanges: []
       Variables:
         - Name: xs
-          Type: 176 GoSliceHeaderType []main.structWithNoStrings
+          Type: 140 GoSliceHeaderType []main.structWithNoStrings
           Locations:
             - Range: 0x88f2d0..0x88f2e0
               Pieces:
@@ -2709,7 +2709,7 @@ Subprograms:
       InlinePCRanges: []
       Variables:
         - Name: xs
-          Type: 176 GoSliceHeaderType []main.structWithNoStrings
+          Type: 140 GoSliceHeaderType []main.structWithNoStrings
           Locations:
             - Range: 0x88f2e0..0x88f2f0
               Pieces:
@@ -2734,7 +2734,7 @@ Subprograms:
       InlinePCRanges: []
       Variables:
         - Name: s
-          Type: 109 GoSliceHeaderType []string
+          Type: 143 GoSliceHeaderType []string
           Locations:
             - Range: 0x88f2f0..0x88f300
               Pieces:
@@ -2759,7 +2759,7 @@ Subprograms:
           IsParameter: true
           IsReturn: false
         - Name: s
-          Type: 179 GoSliceHeaderType []bool
+          Type: 144 GoSliceHeaderType []bool
           Locations:
             - Range: 0x88f300..0x88f310
               Pieces:
@@ -2784,7 +2784,7 @@ Subprograms:
       InlinePCRanges: []
       Variables:
         - Name: xs
-          Type: 180 GoSliceHeaderType []uint16
+          Type: 145 GoSliceHeaderType []uint16
           Locations:
             - Range: 0x88f310..0x88f320
               Pieces:
@@ -2802,7 +2802,7 @@ Subprograms:
       InlinePCRanges: []
       Variables:
         - Name: xs
-          Type: 173 GoSliceHeaderType []uint
+          Type: 137 GoSliceHeaderType []uint
           Locations:
             - Range: 0x88f320..0x88f330
               Pieces:
@@ -2884,7 +2884,7 @@ Subprograms:
       InlinePCRanges: []
       Variables:
         - Name: a
-          Type: 181 StructureType main.threeStringStruct
+          Type: 146 StructureType main.threeStringStruct
           Locations:
             - Range: 0x88f680..0x88f6a0
               Pieces:
@@ -2908,7 +2908,7 @@ Subprograms:
       InlinePCRanges: []
       Variables:
         - Name: a
-          Type: 182 PointerType *main.threeStringStruct
+          Type: 147 PointerType *main.threeStringStruct
           Locations:
             - Range: 0x88f6a0..0x88f6b0
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
@@ -2920,7 +2920,7 @@ Subprograms:
       InlinePCRanges: []
       Variables:
         - Name: a
-          Type: 183 PointerType *main.oneStringStruct
+          Type: 148 PointerType *main.oneStringStruct
           Locations:
             - Range: 0x88f6b0..0x88f6c0
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
@@ -2980,7 +2980,7 @@ Subprograms:
       InlinePCRanges: []
       Variables:
         - Name: x
-          Type: 185 StructureType main.aStruct
+          Type: 150 StructureType main.aStruct
           Locations:
             - Range: 0x88f8f0..0x88f910
               Pieces:
@@ -3006,7 +3006,7 @@ Subprograms:
       InlinePCRanges: []
       Variables:
         - Name: e
-          Type: 186 StructureType main.emptyStruct
+          Type: 152 StructureType main.emptyStruct
           Locations: [{Range: 0x88f9f0..0x88fa00, Pieces: []}]
           IsParameter: true
           IsReturn: false
@@ -3085,7 +3085,7 @@ Subprograms:
           RootRanges: [0x88cec0..0x88d010]
       Variables:
         - Name: a
-          Type: 72 ArrayType [5]int
+          Type: 63 ArrayType [5]int
           Locations:
             - Range: 0x88ce70..0x88cec0
               Pieces: [{Size: 40, Op: {CfaOffset: -48}}]
@@ -3095,15 +3095,15 @@ Subprograms:
           IsReturn: false
 Types:
     - __kind: PointerType
-      ID: 172
+      ID: 185
       Name: '**main.t'
       ByteSize: 8
-      Pointee: 170 PointerType *main.t
+      Pointee: 135 PointerType *main.t
     - __kind: PointerType
-      ID: 87
+      ID: 186
       Name: '**runtime.bmap'
       ByteSize: 8
-      Pointee: 88 PointerType *runtime.bmap
+      Pointee: 167 PointerType *runtime.bmap
     - __kind: PointerType
       ID: 54
       Name: '**string'
@@ -3112,62 +3112,62 @@ Types:
       GoKind: 22
       Pointee: 22 PointerType *string
     - __kind: PointerType
-      ID: 85
+      ID: 165
       Name: '*[]*runtime.bmap'
       ByteSize: 8
       GoRuntimeType: 451808
       GoKind: 22
-      Pointee: 86 GoSliceHeaderType []*runtime.bmap
+      Pointee: 166 GoSliceHeaderType []*runtime.bmap
     - __kind: PointerType
-      ID: 193
+      ID: 218
       Name: '*[]*runtime.bmap.array'
       ByteSize: 8
-      Pointee: 192 GoSliceDataType []*runtime.bmap.array
+      Pointee: 217 GoSliceDataType []*runtime.bmap.array
     - __kind: PointerType
       ID: 190
       Name: '*[]*string.array'
       ByteSize: 8
       Pointee: 189 GoSliceDataType []*string.array
     - __kind: PointerType
-      ID: 214
+      ID: 208
       Name: '*[][]uint.array'
       ByteSize: 8
-      Pointee: 213 GoSliceDataType [][]uint.array
+      Pointee: 207 GoSliceDataType [][]uint.array
     - __kind: PointerType
-      ID: 218
+      ID: 214
       Name: '*[]bool.array'
       ByteSize: 8
-      Pointee: 217 GoSliceDataType []bool.array
-    - __kind: PointerType
-      ID: 202
-      Name: '*[]main.structWithMap.array'
-      ByteSize: 8
-      Pointee: 201 GoSliceDataType []main.structWithMap.array
-    - __kind: PointerType
-      ID: 216
-      Name: '*[]main.structWithNoStrings.array'
-      ByteSize: 8
-      Pointee: 215 GoSliceDataType []main.structWithNoStrings.array
-    - __kind: PointerType
-      ID: 198
-      Name: '*[]string.array'
-      ByteSize: 8
-      Pointee: 197 GoSliceDataType []string.array
-    - __kind: PointerType
-      ID: 175
-      Name: '*[]uint'
-      ByteSize: 8
-      Pointee: 173 GoSliceHeaderType []uint
-    - __kind: PointerType
-      ID: 212
-      Name: '*[]uint.array'
-      ByteSize: 8
-      Pointee: 211 GoSliceDataType []uint.array
+      Pointee: 213 GoSliceDataType []bool.array
     - __kind: PointerType
       ID: 220
+      Name: '*[]main.structWithMap.array'
+      ByteSize: 8
+      Pointee: 219 GoSliceDataType []main.structWithMap.array
+    - __kind: PointerType
+      ID: 210
+      Name: '*[]main.structWithNoStrings.array'
+      ByteSize: 8
+      Pointee: 209 GoSliceDataType []main.structWithNoStrings.array
+    - __kind: PointerType
+      ID: 212
+      Name: '*[]string.array'
+      ByteSize: 8
+      Pointee: 211 GoSliceDataType []string.array
+    - __kind: PointerType
+      ID: 139
+      Name: '*[]uint'
+      ByteSize: 8
+      Pointee: 137 GoSliceHeaderType []uint
+    - __kind: PointerType
+      ID: 206
+      Name: '*[]uint.array'
+      ByteSize: 8
+      Pointee: 205 GoSliceDataType []uint.array
+    - __kind: PointerType
+      ID: 216
       Name: '*[]uint16.array'
       ByteSize: 8
-      Pointee: 219 GoSliceDataType []uint16.array
+      Pointee: 215 GoSliceDataType []uint16.array
     - __kind: PointerType
       ID: 5
       Name: '*bool'
@@ -3176,65 +3176,65 @@ Types:
       GoKind: 22
       Pointee: 4 BaseType bool
     - __kind: PointerType
-      ID: 165
+      ID: 128
       Name: '*bucket<[4]int,[4]int>'
       ByteSize: 8
-      Pointee: 166 GoHMapBucketType bucket<[4]int,[4]int>
-    - __kind: PointerType
-      ID: 159
-      Name: '*bucket<[4]int,uint8>'
-      ByteSize: 8
-      Pointee: 160 GoHMapBucketType bucket<[4]int,uint8>
-    - __kind: PointerType
-      ID: 113
-      Name: '*bucket<[4]string,[2]int>'
-      ByteSize: 8
-      Pointee: 114 GoHMapBucketType bucket<[4]string,[2]int>
-    - __kind: PointerType
-      ID: 131
-      Name: '*bucket<bool,main.node>'
-      ByteSize: 8
-      Pointee: 132 GoHMapBucketType bucket<bool,main.node>
-    - __kind: PointerType
-      ID: 78
-      Name: '*bucket<int,int>'
-      ByteSize: 8
-      Pointee: 79 GoHMapBucketType bucket<int,int>
-    - __kind: PointerType
-      ID: 140
-      Name: '*bucket<int,uint8>'
-      ByteSize: 8
-      Pointee: 141 GoHMapBucketType bucket<int,uint8>
+      Pointee: 129 GoHMapBucketType bucket<[4]int,[4]int>
     - __kind: PointerType
       ID: 123
+      Name: '*bucket<[4]int,uint8>'
+      ByteSize: 8
+      Pointee: 124 GoHMapBucketType bucket<[4]int,uint8>
+    - __kind: PointerType
+      ID: 91
+      Name: '*bucket<[4]string,[2]int>'
+      ByteSize: 8
+      Pointee: 92 GoHMapBucketType bucket<[4]string,[2]int>
+    - __kind: PointerType
+      ID: 103
+      Name: '*bucket<bool,main.node>'
+      ByteSize: 8
+      Pointee: 104 GoHMapBucketType bucket<bool,main.node>
+    - __kind: PointerType
+      ID: 69
+      Name: '*bucket<int,int>'
+      ByteSize: 8
+      Pointee: 70 GoHMapBucketType bucket<int,int>
+    - __kind: PointerType
+      ID: 108
+      Name: '*bucket<int,uint8>'
+      ByteSize: 8
+      Pointee: 109 GoHMapBucketType bucket<int,uint8>
+    - __kind: PointerType
+      ID: 98
       Name: '*bucket<string,[]main.structWithMap>'
       ByteSize: 8
-      Pointee: 124 GoHMapBucketType bucket<string,[]main.structWithMap>
+      Pointee: 99 GoHMapBucketType bucket<string,[]main.structWithMap>
     - __kind: PointerType
-      ID: 106
+      ID: 86
       Name: '*bucket<string,[]string>'
       ByteSize: 8
-      Pointee: 107 GoHMapBucketType bucket<string,[]string>
+      Pointee: 87 GoHMapBucketType bucket<string,[]string>
     - __kind: PointerType
-      ID: 101
+      ID: 81
       Name: '*bucket<string,int>'
       ByteSize: 8
-      Pointee: 102 GoHMapBucketType bucket<string,int>
+      Pointee: 82 GoHMapBucketType bucket<string,int>
     - __kind: PointerType
-      ID: 93
+      ID: 76
       Name: '*bucket<string,main.nestedStruct>'
       ByteSize: 8
-      Pointee: 94 GoHMapBucketType bucket<string,main.nestedStruct>
+      Pointee: 77 GoHMapBucketType bucket<string,main.nestedStruct>
     - __kind: PointerType
-      ID: 152
+      ID: 118
       Name: '*bucket<uint8,[4]int>'
       ByteSize: 8
-      Pointee: 153 GoHMapBucketType bucket<uint8,[4]int>
+      Pointee: 119 GoHMapBucketType bucket<uint8,[4]int>
     - __kind: PointerType
-      ID: 146
+      ID: 113
       Name: '*bucket<uint8,uint8>'
       ByteSize: 8
-      Pointee: 147 GoHMapBucketType bucket<uint8,uint8>
+      Pointee: 114 GoHMapBucketType bucket<uint8,uint8>
     - __kind: PointerType
       ID: 33
       Name: '*error'
@@ -3257,65 +3257,65 @@ Types:
       GoKind: 22
       Pointee: 17 BaseType float64
     - __kind: PointerType
-      ID: 163
+      ID: 126
       Name: '*hash<[4]int,[4]int>'
       ByteSize: 8
-      Pointee: 164 GoHMapHeaderType hash<[4]int,[4]int>
-    - __kind: PointerType
-      ID: 157
-      Name: '*hash<[4]int,uint8>'
-      ByteSize: 8
-      Pointee: 158 GoHMapHeaderType hash<[4]int,uint8>
-    - __kind: PointerType
-      ID: 111
-      Name: '*hash<[4]string,[2]int>'
-      ByteSize: 8
-      Pointee: 112 GoHMapHeaderType hash<[4]string,[2]int>
-    - __kind: PointerType
-      ID: 129
-      Name: '*hash<bool,main.node>'
-      ByteSize: 8
-      Pointee: 130 GoHMapHeaderType hash<bool,main.node>
-    - __kind: PointerType
-      ID: 76
-      Name: '*hash<int,int>'
-      ByteSize: 8
-      Pointee: 77 GoHMapHeaderType hash<int,int>
-    - __kind: PointerType
-      ID: 138
-      Name: '*hash<int,uint8>'
-      ByteSize: 8
-      Pointee: 139 GoHMapHeaderType hash<int,uint8>
+      Pointee: 127 GoHMapHeaderType hash<[4]int,[4]int>
     - __kind: PointerType
       ID: 121
+      Name: '*hash<[4]int,uint8>'
+      ByteSize: 8
+      Pointee: 122 GoHMapHeaderType hash<[4]int,uint8>
+    - __kind: PointerType
+      ID: 89
+      Name: '*hash<[4]string,[2]int>'
+      ByteSize: 8
+      Pointee: 90 GoHMapHeaderType hash<[4]string,[2]int>
+    - __kind: PointerType
+      ID: 101
+      Name: '*hash<bool,main.node>'
+      ByteSize: 8
+      Pointee: 102 GoHMapHeaderType hash<bool,main.node>
+    - __kind: PointerType
+      ID: 67
+      Name: '*hash<int,int>'
+      ByteSize: 8
+      Pointee: 68 GoHMapHeaderType hash<int,int>
+    - __kind: PointerType
+      ID: 106
+      Name: '*hash<int,uint8>'
+      ByteSize: 8
+      Pointee: 107 GoHMapHeaderType hash<int,uint8>
+    - __kind: PointerType
+      ID: 96
       Name: '*hash<string,[]main.structWithMap>'
       ByteSize: 8
-      Pointee: 122 GoHMapHeaderType hash<string,[]main.structWithMap>
+      Pointee: 97 GoHMapHeaderType hash<string,[]main.structWithMap>
     - __kind: PointerType
-      ID: 104
+      ID: 84
       Name: '*hash<string,[]string>'
       ByteSize: 8
-      Pointee: 105 GoHMapHeaderType hash<string,[]string>
+      Pointee: 85 GoHMapHeaderType hash<string,[]string>
     - __kind: PointerType
-      ID: 99
+      ID: 79
       Name: '*hash<string,int>'
       ByteSize: 8
-      Pointee: 100 GoHMapHeaderType hash<string,int>
+      Pointee: 80 GoHMapHeaderType hash<string,int>
     - __kind: PointerType
-      ID: 91
+      ID: 74
       Name: '*hash<string,main.nestedStruct>'
       ByteSize: 8
-      Pointee: 92 GoHMapHeaderType hash<string,main.nestedStruct>
+      Pointee: 75 GoHMapHeaderType hash<string,main.nestedStruct>
     - __kind: PointerType
-      ID: 150
+      ID: 116
       Name: '*hash<uint8,[4]int>'
       ByteSize: 8
-      Pointee: 151 GoHMapHeaderType hash<uint8,[4]int>
+      Pointee: 117 GoHMapHeaderType hash<uint8,[4]int>
     - __kind: PointerType
-      ID: 144
+      ID: 111
       Name: '*hash<uint8,uint8>'
       ByteSize: 8
-      Pointee: 145 GoHMapHeaderType hash<uint8,uint8>
+      Pointee: 112 GoHMapHeaderType hash<uint8,uint8>
     - __kind: PointerType
       ID: 28
       Name: '*int'
@@ -3359,73 +3359,73 @@ Types:
       GoKind: 22
       Pointee: 62 StructureType main.esotericHeap
     - __kind: PointerType
-      ID: 136
+      ID: 134
       Name: '*main.node'
       ByteSize: 8
       GoRuntimeType: 354272
       GoKind: 22
-      Pointee: 135 StructureType main.node
+      Pointee: 133 StructureType main.node
     - __kind: PointerType
-      ID: 183
+      ID: 148
       Name: '*main.oneStringStruct'
       ByteSize: 8
       GoKind: 22
-      Pointee: 184 StructureType main.oneStringStruct
+      Pointee: 149 StructureType main.oneStringStruct
     - __kind: PointerType
-      ID: 127
+      ID: 177
       Name: '*main.structWithMap'
       ByteSize: 8
       GoRuntimeType: 354144
       GoKind: 22
-      Pointee: 74 StructureType main.structWithMap
+      Pointee: 65 StructureType main.structWithMap
     - __kind: PointerType
-      ID: 177
+      ID: 141
       Name: '*main.structWithNoStrings'
       ByteSize: 8
-      Pointee: 178 StructureType main.structWithNoStrings
+      Pointee: 142 StructureType main.structWithNoStrings
     - __kind: PointerType
-      ID: 168
+      ID: 131
       Name: '*main.structWithTwoValues'
       ByteSize: 8
       GoKind: 22
-      Pointee: 169 StructureType main.structWithTwoValues
+      Pointee: 132 StructureType main.structWithTwoValues
     - __kind: PointerType
-      ID: 170
+      ID: 135
       Name: '*main.t'
       ByteSize: 8
       GoKind: 22
-      Pointee: 171 GoSliceHeaderType main.t
+      Pointee: 136 GoSliceHeaderType main.t
     - __kind: PointerType
-      ID: 210
+      ID: 204
       Name: '*main.t.array'
       ByteSize: 8
-      Pointee: 209 GoSliceDataType main.t.array
+      Pointee: 203 GoSliceDataType main.t.array
     - __kind: PointerType
-      ID: 182
+      ID: 147
       Name: '*main.threeStringStruct'
       ByteSize: 8
       GoKind: 22
-      Pointee: 181 StructureType main.threeStringStruct
+      Pointee: 146 StructureType main.threeStringStruct
     - __kind: PointerType
-      ID: 119
+      ID: 94
       Name: '*map[string]int'
       ByteSize: 8
       GoKind: 22
-      Pointee: 98 GoMapType map[string]int
+      Pointee: 78 GoMapType map[string]int
     - __kind: PointerType
-      ID: 88
+      ID: 167
       Name: '*runtime.bmap'
       ByteSize: 8
       GoRuntimeType: 1.101088e+06
       GoKind: 22
-      Pointee: 89 StructureType runtime.bmap
+      Pointee: 168 StructureType runtime.bmap
     - __kind: PointerType
-      ID: 83
+      ID: 71
       Name: '*runtime.mapextra'
       ByteSize: 8
       GoRuntimeType: 363168
       GoKind: 22
-      Pointee: 84 StructureType runtime.mapextra
+      Pointee: 72 StructureType runtime.mapextra
     - __kind: PointerType
       ID: 22
       Name: '*string'
@@ -3537,7 +3537,7 @@ Types:
         - Name: m
           Offset: 1
           Expression:
-            Type: 118 ArrayType [2]map[string]int
+            Type: 93 ArrayType [2]map[string]int
             Operations:
                 - __kind: LocationOp
                   Variable: {subprogram: 53, index: 0, name: m}
@@ -3612,7 +3612,7 @@ Types:
         - Name: c
           Offset: 1
           Expression:
-            Type: 167 GoChannelType chan bool
+            Type: 130 GoChannelType chan bool
             Operations:
                 - __kind: LocationOp
                   Variable: {subprogram: 69, index: 0, name: c}
@@ -3660,7 +3660,7 @@ Types:
         - Name: t
           Offset: 1
           Expression:
-            Type: 170 PointerType *main.t
+            Type: 135 PointerType *main.t
             Operations:
                 - __kind: LocationOp
                   Variable: {subprogram: 77, index: 0, name: t}
@@ -3675,7 +3675,7 @@ Types:
         - Name: xs
           Offset: 1
           Expression:
-            Type: 176 GoSliceHeaderType []main.structWithNoStrings
+            Type: 140 GoSliceHeaderType []main.structWithNoStrings
             Operations:
                 - __kind: LocationOp
                   Variable: {subprogram: 82, index: 0, name: xs}
@@ -3699,7 +3699,7 @@ Types:
         - Name: u
           Offset: 1
           Expression:
-            Type: 173 GoSliceHeaderType []uint
+            Type: 137 GoSliceHeaderType []uint
             Operations:
                 - __kind: LocationOp
                   Variable: {subprogram: 79, index: 0, name: u}
@@ -3729,7 +3729,7 @@ Types:
         - Name: e
           Offset: 1
           Expression:
-            Type: 186 StructureType main.emptyStruct
+            Type: 152 StructureType main.emptyStruct
             Operations:
                 - __kind: LocationOp
                   Variable: {subprogram: 98, index: 0, name: e}
@@ -3789,7 +3789,7 @@ Types:
         - Name: a
           Offset: 1
           Expression:
-            Type: 72 ArrayType [5]int
+            Type: 63 ArrayType [5]int
             Operations:
                 - __kind: LocationOp
                   Variable: {subprogram: 43, index: 0, name: a}
@@ -3915,7 +3915,7 @@ Types:
         - Name: a
           Offset: 1
           Expression:
-            Type: 72 ArrayType [5]int
+            Type: 63 ArrayType [5]int
             Operations:
                 - __kind: LocationOp
                   Variable: {subprogram: 104, index: 0, name: a}
@@ -4005,7 +4005,7 @@ Types:
         - Name: b
           Offset: 1
           Expression:
-            Type: 73 GoInterfaceType main.behavior
+            Type: 64 GoInterfaceType main.behavior
             Operations:
                 - __kind: LocationOp
                   Variable: {subprogram: 44, index: 0, name: b}
@@ -4020,7 +4020,7 @@ Types:
         - Name: a
           Offset: 1
           Expression:
-            Type: 135 StructureType main.node
+            Type: 133 StructureType main.node
             Operations:
                 - __kind: LocationOp
                   Variable: {subprogram: 71, index: 0, name: a}
@@ -4035,7 +4035,7 @@ Types:
         - Name: m
           Offset: 1
           Expression:
-            Type: 110 GoMapType map[[4]string][2]int
+            Type: 88 GoMapType map[[4]string][2]int
             Operations:
                 - __kind: LocationOp
                   Variable: {subprogram: 51, index: 0, name: m}
@@ -4050,7 +4050,7 @@ Types:
         - Name: m
           Offset: 1
           Expression:
-            Type: 120 GoMapType map[string][]main.structWithMap
+            Type: 95 GoMapType map[string][]main.structWithMap
             Operations:
                 - __kind: LocationOp
                   Variable: {subprogram: 57, index: 0, name: m}
@@ -4065,7 +4065,7 @@ Types:
         - Name: m
           Offset: 1
           Expression:
-            Type: 75 GoMapType map[int]int
+            Type: 66 GoMapType map[int]int
             Operations:
                 - __kind: LocationOp
                   Variable: {subprogram: 55, index: 0, name: m}
@@ -4080,7 +4080,7 @@ Types:
         - Name: m
           Offset: 1
           Expression:
-            Type: 162 GoMapType map[[4]int][4]int
+            Type: 125 GoMapType map[[4]int][4]int
             Operations:
                 - __kind: LocationOp
                   Variable: {subprogram: 66, index: 0, name: m}
@@ -4095,7 +4095,7 @@ Types:
         - Name: m
           Offset: 1
           Expression:
-            Type: 156 GoMapType map[[4]int]uint8
+            Type: 120 GoMapType map[[4]int]uint8
             Operations:
                 - __kind: LocationOp
                   Variable: {subprogram: 65, index: 0, name: m}
@@ -4110,7 +4110,7 @@ Types:
         - Name: redactMyEntries
           Offset: 1
           Expression:
-            Type: 120 GoMapType map[string][]main.structWithMap
+            Type: 95 GoMapType map[string][]main.structWithMap
             Operations:
                 - __kind: LocationOp
                   Variable: {subprogram: 56, index: 0, name: redactMyEntries}
@@ -4125,7 +4125,7 @@ Types:
         - Name: m
           Offset: 1
           Expression:
-            Type: 149 GoMapType map[uint8][4]int
+            Type: 115 GoMapType map[uint8][4]int
             Operations:
                 - __kind: LocationOp
                   Variable: {subprogram: 64, index: 0, name: m}
@@ -4140,7 +4140,7 @@ Types:
         - Name: m
           Offset: 1
           Expression:
-            Type: 143 GoMapType map[uint8]uint8
+            Type: 110 GoMapType map[uint8]uint8
             Operations:
                 - __kind: LocationOp
                   Variable: {subprogram: 63, index: 0, name: m}
@@ -4155,7 +4155,7 @@ Types:
         - Name: m
           Offset: 1
           Expression:
-            Type: 98 GoMapType map[string]int
+            Type: 78 GoMapType map[string]int
             Operations:
                 - __kind: LocationOp
                   Variable: {subprogram: 49, index: 0, name: m}
@@ -4170,7 +4170,7 @@ Types:
         - Name: m
           Offset: 1
           Expression:
-            Type: 103 GoMapType map[string][]string
+            Type: 83 GoMapType map[string][]string
             Operations:
                 - __kind: LocationOp
                   Variable: {subprogram: 50, index: 0, name: m}
@@ -4185,7 +4185,7 @@ Types:
         - Name: m
           Offset: 1
           Expression:
-            Type: 90 GoMapType map[string]main.nestedStruct
+            Type: 73 GoMapType map[string]main.nestedStruct
             Operations:
                 - __kind: LocationOp
                   Variable: {subprogram: 48, index: 0, name: m}
@@ -4200,7 +4200,7 @@ Types:
         - Name: m
           Offset: 1
           Expression:
-            Type: 128 GoMapType map[bool]main.node
+            Type: 100 GoMapType map[bool]main.node
             Operations:
                 - __kind: LocationOp
                   Variable: {subprogram: 58, index: 0, name: m}
@@ -4215,7 +4215,7 @@ Types:
         - Name: m
           Offset: 1
           Expression:
-            Type: 143 GoMapType map[uint8]uint8
+            Type: 110 GoMapType map[uint8]uint8
             Operations:
                 - __kind: LocationOp
                   Variable: {subprogram: 62, index: 0, name: m}
@@ -4230,7 +4230,7 @@ Types:
         - Name: m
           Offset: 1
           Expression:
-            Type: 143 GoMapType map[uint8]uint8
+            Type: 110 GoMapType map[uint8]uint8
             Operations:
                 - __kind: LocationOp
                   Variable: {subprogram: 61, index: 0, name: m}
@@ -4245,7 +4245,7 @@ Types:
         - Name: redactMyEntries
           Offset: 1
           Expression:
-            Type: 137 GoMapType map[int]uint8
+            Type: 105 GoMapType map[int]uint8
             Operations:
                 - __kind: LocationOp
                   Variable: {subprogram: 60, index: 0, name: redactMyEntries}
@@ -4260,7 +4260,7 @@ Types:
         - Name: m
           Offset: 1
           Expression:
-            Type: 137 GoMapType map[int]uint8
+            Type: 105 GoMapType map[int]uint8
             Operations:
                 - __kind: LocationOp
                   Variable: {subprogram: 59, index: 0, name: m}
@@ -4365,7 +4365,7 @@ Types:
         - Name: xs
           Offset: 1
           Expression:
-            Type: 176 GoSliceHeaderType []main.structWithNoStrings
+            Type: 140 GoSliceHeaderType []main.structWithNoStrings
             Operations:
                 - __kind: LocationOp
                   Variable: {subprogram: 83, index: 0, name: xs}
@@ -4398,7 +4398,7 @@ Types:
         - Name: s
           Offset: 2
           Expression:
-            Type: 179 GoSliceHeaderType []bool
+            Type: 144 GoSliceHeaderType []bool
             Operations:
                 - __kind: LocationOp
                   Variable: {subprogram: 85, index: 1, name: s}
@@ -4422,7 +4422,7 @@ Types:
         - Name: xs
           Offset: 1
           Expression:
-            Type: 180 GoSliceHeaderType []uint16
+            Type: 145 GoSliceHeaderType []uint16
             Operations:
                 - __kind: LocationOp
                   Variable: {subprogram: 86, index: 0, name: xs}
@@ -4437,7 +4437,7 @@ Types:
         - Name: a
           Offset: 1
           Expression:
-            Type: 183 PointerType *main.oneStringStruct
+            Type: 148 PointerType *main.oneStringStruct
             Operations:
                 - __kind: LocationOp
                   Variable: {subprogram: 93, index: 0, name: a}
@@ -4452,7 +4452,7 @@ Types:
         - Name: a
           Offset: 1
           Expression:
-            Type: 136 PointerType *main.node
+            Type: 134 PointerType *main.node
             Operations:
                 - __kind: LocationOp
                   Variable: {subprogram: 72, index: 0, name: a}
@@ -4467,7 +4467,7 @@ Types:
         - Name: m
           Offset: 1
           Expression:
-            Type: 119 PointerType *map[string]int
+            Type: 94 PointerType *map[string]int
             Operations:
                 - __kind: LocationOp
                   Variable: {subprogram: 54, index: 0, name: m}
@@ -4482,7 +4482,7 @@ Types:
         - Name: a
           Offset: 1
           Expression:
-            Type: 168 PointerType *main.structWithTwoValues
+            Type: 131 PointerType *main.structWithTwoValues
             Operations:
                 - __kind: LocationOp
                   Variable: {subprogram: 70, index: 0, name: a}
@@ -4752,7 +4752,7 @@ Types:
         - Name: u
           Offset: 1
           Expression:
-            Type: 174 GoSliceHeaderType [][]uint
+            Type: 138 GoSliceHeaderType [][]uint
             Operations:
                 - __kind: LocationOp
                   Variable: {subprogram: 80, index: 0, name: u}
@@ -4767,7 +4767,7 @@ Types:
         - Name: m
           Offset: 1
           Expression:
-            Type: 98 GoMapType map[string]int
+            Type: 78 GoMapType map[string]int
             Operations:
                 - __kind: LocationOp
                   Variable: {subprogram: 52, index: 0, name: m}
@@ -4812,7 +4812,7 @@ Types:
         - Name: s
           Offset: 1
           Expression:
-            Type: 109 GoSliceHeaderType []string
+            Type: 143 GoSliceHeaderType []string
             Operations:
                 - __kind: LocationOp
                   Variable: {subprogram: 84, index: 0, name: s}
@@ -4827,7 +4827,7 @@ Types:
         - Name: xs
           Offset: 1
           Expression:
-            Type: 176 GoSliceHeaderType []main.structWithNoStrings
+            Type: 140 GoSliceHeaderType []main.structWithNoStrings
             Operations:
                 - __kind: LocationOp
                   Variable: {subprogram: 81, index: 0, name: xs}
@@ -4851,7 +4851,7 @@ Types:
         - Name: s
           Offset: 1
           Expression:
-            Type: 74 StructureType main.structWithMap
+            Type: 65 StructureType main.structWithMap
             Operations:
                 - __kind: LocationOp
                   Variable: {subprogram: 47, index: 0, name: s}
@@ -4866,7 +4866,7 @@ Types:
         - Name: x
           Offset: 1
           Expression:
-            Type: 185 StructureType main.aStruct
+            Type: 150 StructureType main.aStruct
             Operations:
                 - __kind: LocationOp
                   Variable: {subprogram: 97, index: 0, name: x}
@@ -4881,7 +4881,7 @@ Types:
         - Name: a
           Offset: 1
           Expression:
-            Type: 182 PointerType *main.threeStringStruct
+            Type: 147 PointerType *main.threeStringStruct
             Operations:
                 - __kind: LocationOp
                   Variable: {subprogram: 92, index: 0, name: a}
@@ -4896,7 +4896,7 @@ Types:
         - Name: a
           Offset: 1
           Expression:
-            Type: 181 StructureType main.threeStringStruct
+            Type: 146 StructureType main.threeStringStruct
             Operations:
                 - __kind: LocationOp
                   Variable: {subprogram: 91, index: 0, name: a}
@@ -5049,7 +5049,7 @@ Types:
         - Name: u
           Offset: 1
           Expression:
-            Type: 173 GoSliceHeaderType []uint
+            Type: 137 GoSliceHeaderType []uint
             Operations:
                 - __kind: LocationOp
                   Variable: {subprogram: 78, index: 0, name: u}
@@ -5109,7 +5109,7 @@ Types:
         - Name: xs
           Offset: 1
           Expression:
-            Type: 173 GoSliceHeaderType []uint
+            Type: 137 GoSliceHeaderType []uint
             Operations:
                 - __kind: LocationOp
                   Variable: {subprogram: 87, index: 0, name: xs}
@@ -5190,13 +5190,13 @@ Types:
       HasCount: true
       Element: 15 BaseType int8
     - __kind: ArrayType
-      ID: 118
+      ID: 93
       Name: '[2]map[string]int'
       ByteSize: 16
       GoKind: 17
       Count: 2
       HasCount: true
-      Element: 98 GoMapType map[string]int
+      Element: 78 GoMapType map[string]int
     - __kind: ArrayType
       ID: 38
       Name: '[2]string'
@@ -5249,7 +5249,7 @@ Types:
       HasCount: true
       Element: 3 BaseType uint8
     - __kind: ArrayType
-      ID: 155
+      ID: 183
       Name: '[4]int'
       ByteSize: 32
       GoRuntimeType: 617536
@@ -5258,7 +5258,7 @@ Types:
       HasCount: true
       Element: 9 BaseType int
     - __kind: ArrayType
-      ID: 116
+      ID: 173
       Name: '[4]string'
       ByteSize: 64
       GoRuntimeType: 617824
@@ -5267,7 +5267,7 @@ Types:
       HasCount: true
       Element: 11 GoStringHeaderType string
     - __kind: ArrayType
-      ID: 72
+      ID: 63
       Name: '[5]int'
       ByteSize: 40
       GoKind: 17
@@ -5275,7 +5275,7 @@ Types:
       HasCount: true
       Element: 9 BaseType int
     - __kind: ArrayType
-      ID: 80
+      ID: 162
       Name: '[8]uint8'
       ByteSize: 8
       GoRuntimeType: 615616
@@ -5284,7 +5284,7 @@ Types:
       HasCount: true
       Element: 3 BaseType uint8
     - __kind: GoSliceHeaderType
-      ID: 86
+      ID: 166
       Name: '[]*runtime.bmap'
       ByteSize: 24
       GoRuntimeType: 451744
@@ -5292,19 +5292,19 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 87 PointerType **runtime.bmap
+          Type: 186 PointerType **runtime.bmap
         - Name: len
           Offset: 8
           Type: 9 BaseType int
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 192 GoSliceDataType []*runtime.bmap.array
+      Data: 217 GoSliceDataType []*runtime.bmap.array
     - __kind: GoSliceDataType
-      ID: 192
+      ID: 217
       Name: '[]*runtime.bmap.array'
       ByteSize: 2048
-      Element: 88 PointerType *runtime.bmap
+      Element: 167 PointerType *runtime.bmap
     - __kind: GoSliceHeaderType
       ID: 53
       Name: '[]*string'
@@ -5328,28 +5328,28 @@ Types:
       ByteSize: 2048
       Element: 22 PointerType *string
     - __kind: GoSliceHeaderType
-      ID: 174
+      ID: 138
       Name: '[][]uint'
       ByteSize: 24
       GoKind: 23
       RawFields:
         - Name: array
           Offset: 0
-          Type: 175 PointerType *[]uint
+          Type: 139 PointerType *[]uint
         - Name: len
           Offset: 8
           Type: 9 BaseType int
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 213 GoSliceDataType [][]uint.array
+      Data: 207 GoSliceDataType [][]uint.array
     - __kind: GoSliceDataType
-      ID: 213
+      ID: 207
       Name: '[][]uint.array'
       ByteSize: 2048
-      Element: 173 GoSliceHeaderType []uint
+      Element: 137 GoSliceHeaderType []uint
     - __kind: GoSliceHeaderType
-      ID: 179
+      ID: 144
       Name: '[]bool'
       ByteSize: 24
       GoRuntimeType: 449888
@@ -5364,116 +5364,116 @@ Types:
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 217 GoSliceDataType []bool.array
+      Data: 213 GoSliceDataType []bool.array
     - __kind: GoSliceDataType
-      ID: 217
+      ID: 213
       Name: '[]bool.array'
       ByteSize: 2048
       Element: 4 BaseType bool
     - __kind: GoSliceDataType
-      ID: 208
+      ID: 202
       Name: '[]bucket<[4]int,[4]int>.array'
       ByteSize: 2048
-      Element: 166 GoHMapBucketType bucket<[4]int,[4]int>
+      Element: 129 GoHMapBucketType bucket<[4]int,[4]int>
     - __kind: GoSliceDataType
-      ID: 207
+      ID: 201
       Name: '[]bucket<[4]int,uint8>.array'
       ByteSize: 2048
-      Element: 160 GoHMapBucketType bucket<[4]int,uint8>
+      Element: 124 GoHMapBucketType bucket<[4]int,uint8>
     - __kind: GoSliceDataType
-      ID: 199
+      ID: 195
       Name: '[]bucket<[4]string,[2]int>.array'
       ByteSize: 2048
-      Element: 114 GoHMapBucketType bucket<[4]string,[2]int>
+      Element: 92 GoHMapBucketType bucket<[4]string,[2]int>
     - __kind: GoSliceDataType
-      ID: 203
+      ID: 197
       Name: '[]bucket<bool,main.node>.array'
       ByteSize: 2048
-      Element: 132 GoHMapBucketType bucket<bool,main.node>
+      Element: 104 GoHMapBucketType bucket<bool,main.node>
     - __kind: GoSliceDataType
       ID: 191
       Name: '[]bucket<int,int>.array'
       ByteSize: 2048
-      Element: 79 GoHMapBucketType bucket<int,int>
+      Element: 70 GoHMapBucketType bucket<int,int>
     - __kind: GoSliceDataType
-      ID: 204
+      ID: 198
       Name: '[]bucket<int,uint8>.array'
       ByteSize: 2048
-      Element: 141 GoHMapBucketType bucket<int,uint8>
-    - __kind: GoSliceDataType
-      ID: 200
-      Name: '[]bucket<string,[]main.structWithMap>.array'
-      ByteSize: 2048
-      Element: 124 GoHMapBucketType bucket<string,[]main.structWithMap>
+      Element: 109 GoHMapBucketType bucket<int,uint8>
     - __kind: GoSliceDataType
       ID: 196
-      Name: '[]bucket<string,[]string>.array'
+      Name: '[]bucket<string,[]main.structWithMap>.array'
       ByteSize: 2048
-      Element: 107 GoHMapBucketType bucket<string,[]string>
-    - __kind: GoSliceDataType
-      ID: 195
-      Name: '[]bucket<string,int>.array'
-      ByteSize: 2048
-      Element: 102 GoHMapBucketType bucket<string,int>
+      Element: 99 GoHMapBucketType bucket<string,[]main.structWithMap>
     - __kind: GoSliceDataType
       ID: 194
+      Name: '[]bucket<string,[]string>.array'
+      ByteSize: 2048
+      Element: 87 GoHMapBucketType bucket<string,[]string>
+    - __kind: GoSliceDataType
+      ID: 193
+      Name: '[]bucket<string,int>.array'
+      ByteSize: 2048
+      Element: 82 GoHMapBucketType bucket<string,int>
+    - __kind: GoSliceDataType
+      ID: 192
       Name: '[]bucket<string,main.nestedStruct>.array'
       ByteSize: 2048
-      Element: 94 GoHMapBucketType bucket<string,main.nestedStruct>
+      Element: 77 GoHMapBucketType bucket<string,main.nestedStruct>
     - __kind: GoSliceDataType
-      ID: 206
+      ID: 200
       Name: '[]bucket<uint8,[4]int>.array'
       ByteSize: 2048
-      Element: 153 GoHMapBucketType bucket<uint8,[4]int>
+      Element: 119 GoHMapBucketType bucket<uint8,[4]int>
     - __kind: GoSliceDataType
-      ID: 205
+      ID: 199
       Name: '[]bucket<uint8,uint8>.array'
       ByteSize: 2048
-      Element: 147 GoHMapBucketType bucket<uint8,uint8>
+      Element: 114 GoHMapBucketType bucket<uint8,uint8>
     - __kind: ArrayType
-      ID: 161
+      ID: 184
       Name: '[]key<[4]int>'
       ByteSize: 256
       Count: 8
       HasCount: true
-      Element: 155 ArrayType [4]int
+      Element: 183 ArrayType [4]int
     - __kind: ArrayType
-      ID: 115
+      ID: 172
       Name: '[]key<[4]string>'
       ByteSize: 512
       Count: 8
       HasCount: true
-      Element: 116 ArrayType [4]string
+      Element: 173 ArrayType [4]string
     - __kind: ArrayType
-      ID: 133
+      ID: 178
       Name: '[]key<bool>'
       ByteSize: 8
       Count: 8
       HasCount: true
       Element: 4 BaseType bool
     - __kind: ArrayType
-      ID: 81
+      ID: 163
       Name: '[]key<int>'
       ByteSize: 64
       Count: 8
       HasCount: true
       Element: 9 BaseType int
     - __kind: ArrayType
-      ID: 95
+      ID: 169
       Name: '[]key<string>'
       ByteSize: 128
       Count: 8
       HasCount: true
       Element: 11 GoStringHeaderType string
     - __kind: ArrayType
-      ID: 148
+      ID: 181
       Name: '[]key<uint8>'
       ByteSize: 8
       Count: 8
       HasCount: true
       Element: 3 BaseType uint8
     - __kind: GoSliceHeaderType
-      ID: 126
+      ID: 176
       Name: '[]main.structWithMap'
       ByteSize: 24
       GoRuntimeType: 442848
@@ -5481,42 +5481,42 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 127 PointerType *main.structWithMap
+          Type: 177 PointerType *main.structWithMap
         - Name: len
           Offset: 8
           Type: 9 BaseType int
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 201 GoSliceDataType []main.structWithMap.array
+      Data: 219 GoSliceDataType []main.structWithMap.array
     - __kind: GoSliceDataType
-      ID: 201
+      ID: 219
       Name: '[]main.structWithMap.array'
       ByteSize: 2048
-      Element: 74 StructureType main.structWithMap
+      Element: 65 StructureType main.structWithMap
     - __kind: GoSliceHeaderType
-      ID: 176
+      ID: 140
       Name: '[]main.structWithNoStrings'
       ByteSize: 24
       GoKind: 23
       RawFields:
         - Name: array
           Offset: 0
-          Type: 177 PointerType *main.structWithNoStrings
+          Type: 141 PointerType *main.structWithNoStrings
         - Name: len
           Offset: 8
           Type: 9 BaseType int
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 215 GoSliceDataType []main.structWithNoStrings.array
+      Data: 209 GoSliceDataType []main.structWithNoStrings.array
     - __kind: GoSliceDataType
-      ID: 215
+      ID: 209
       Name: '[]main.structWithNoStrings.array'
       ByteSize: 2048
-      Element: 178 StructureType main.structWithNoStrings
+      Element: 142 StructureType main.structWithNoStrings
     - __kind: GoSliceHeaderType
-      ID: 109
+      ID: 143
       Name: '[]string'
       ByteSize: 24
       GoRuntimeType: 450016
@@ -5531,14 +5531,14 @@ Types:
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 197 GoSliceDataType []string.array
+      Data: 211 GoSliceDataType []string.array
     - __kind: GoSliceDataType
-      ID: 197
+      ID: 211
       Name: '[]string.array'
       ByteSize: 2048
       Element: 11 GoStringHeaderType string
     - __kind: GoSliceHeaderType
-      ID: 173
+      ID: 137
       Name: '[]uint'
       ByteSize: 24
       GoRuntimeType: 449504
@@ -5553,14 +5553,14 @@ Types:
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 211 GoSliceDataType []uint.array
+      Data: 205 GoSliceDataType []uint.array
     - __kind: GoSliceDataType
-      ID: 211
+      ID: 205
       Name: '[]uint.array'
       ByteSize: 2048
       Element: 12 BaseType uint
     - __kind: GoSliceHeaderType
-      ID: 180
+      ID: 145
       Name: '[]uint16'
       ByteSize: 24
       GoRuntimeType: 448864
@@ -5575,63 +5575,63 @@ Types:
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 219 GoSliceDataType []uint16.array
+      Data: 215 GoSliceDataType []uint16.array
     - __kind: GoSliceDataType
-      ID: 219
+      ID: 215
       Name: '[]uint16.array'
       ByteSize: 2048
       Element: 7 BaseType uint16
     - __kind: ArrayType
-      ID: 117
+      ID: 174
       Name: '[]val<[2]int>'
       ByteSize: 128
       Count: 8
       HasCount: true
       Element: 40 ArrayType [2]int
     - __kind: ArrayType
-      ID: 154
+      ID: 182
       Name: '[]val<[4]int>'
       ByteSize: 256
       Count: 8
       HasCount: true
-      Element: 155 ArrayType [4]int
+      Element: 183 ArrayType [4]int
     - __kind: ArrayType
-      ID: 125
+      ID: 175
       Name: '[]val<[]main.structWithMap>'
       ByteSize: 192
       Count: 8
       HasCount: true
-      Element: 126 GoSliceHeaderType []main.structWithMap
+      Element: 176 GoSliceHeaderType []main.structWithMap
     - __kind: ArrayType
-      ID: 108
+      ID: 171
       Name: '[]val<[]string>'
       ByteSize: 192
       Count: 8
       HasCount: true
-      Element: 109 GoSliceHeaderType []string
+      Element: 143 GoSliceHeaderType []string
     - __kind: ArrayType
-      ID: 82
+      ID: 164
       Name: '[]val<int>'
       ByteSize: 64
       Count: 8
       HasCount: true
       Element: 9 BaseType int
     - __kind: ArrayType
-      ID: 96
+      ID: 170
       Name: '[]val<main.nestedStruct>'
       ByteSize: 192
       Count: 8
       HasCount: true
-      Element: 97 StructureType main.nestedStruct
+      Element: 151 StructureType main.nestedStruct
     - __kind: ArrayType
-      ID: 134
+      ID: 179
       Name: '[]val<main.node>'
       ByteSize: 128
       Count: 8
       HasCount: true
-      Element: 135 StructureType main.node
+      Element: 133 StructureType main.node
     - __kind: ArrayType
-      ID: 142
+      ID: 180
       Name: '[]val<uint8>'
       ByteSize: 8
       Count: 8
@@ -5644,235 +5644,235 @@ Types:
       GoRuntimeType: 528064
       GoKind: 1
     - __kind: GoHMapBucketType
-      ID: 166
+      ID: 129
       Name: bucket<[4]int,[4]int>
       ByteSize: 528
       RawFields:
         - Name: tophash
           Offset: 0
-          Type: 80 ArrayType [8]uint8
+          Type: 162 ArrayType [8]uint8
         - Name: keys
           Offset: 8
-          Type: 161 ArrayType []key<[4]int>
+          Type: 184 ArrayType []key<[4]int>
         - Name: values
           Offset: 264
-          Type: 154 ArrayType []val<[4]int>
+          Type: 182 ArrayType []val<[4]int>
         - Name: overflow
           Offset: 520
-          Type: 165 PointerType *bucket<[4]int,[4]int>
-      KeyType: 155 ArrayType [4]int
-      ValueType: 155 ArrayType [4]int
+          Type: 128 PointerType *bucket<[4]int,[4]int>
+      KeyType: 183 ArrayType [4]int
+      ValueType: 183 ArrayType [4]int
     - __kind: GoHMapBucketType
-      ID: 160
+      ID: 124
       Name: bucket<[4]int,uint8>
       ByteSize: 280
       RawFields:
         - Name: tophash
           Offset: 0
-          Type: 80 ArrayType [8]uint8
+          Type: 162 ArrayType [8]uint8
         - Name: keys
           Offset: 8
-          Type: 161 ArrayType []key<[4]int>
+          Type: 184 ArrayType []key<[4]int>
         - Name: values
           Offset: 264
-          Type: 142 ArrayType []val<uint8>
+          Type: 180 ArrayType []val<uint8>
         - Name: overflow
           Offset: 272
-          Type: 159 PointerType *bucket<[4]int,uint8>
-      KeyType: 155 ArrayType [4]int
+          Type: 123 PointerType *bucket<[4]int,uint8>
+      KeyType: 183 ArrayType [4]int
       ValueType: 3 BaseType uint8
     - __kind: GoHMapBucketType
-      ID: 114
+      ID: 92
       Name: bucket<[4]string,[2]int>
       ByteSize: 656
       RawFields:
         - Name: tophash
           Offset: 0
-          Type: 80 ArrayType [8]uint8
+          Type: 162 ArrayType [8]uint8
         - Name: keys
           Offset: 8
-          Type: 115 ArrayType []key<[4]string>
+          Type: 172 ArrayType []key<[4]string>
         - Name: values
           Offset: 520
-          Type: 117 ArrayType []val<[2]int>
+          Type: 174 ArrayType []val<[2]int>
         - Name: overflow
           Offset: 648
-          Type: 113 PointerType *bucket<[4]string,[2]int>
-      KeyType: 116 ArrayType [4]string
+          Type: 91 PointerType *bucket<[4]string,[2]int>
+      KeyType: 173 ArrayType [4]string
       ValueType: 40 ArrayType [2]int
     - __kind: GoHMapBucketType
-      ID: 132
+      ID: 104
       Name: bucket<bool,main.node>
       ByteSize: 152
       RawFields:
         - Name: tophash
           Offset: 0
-          Type: 80 ArrayType [8]uint8
+          Type: 162 ArrayType [8]uint8
         - Name: keys
           Offset: 8
-          Type: 133 ArrayType []key<bool>
+          Type: 178 ArrayType []key<bool>
         - Name: values
           Offset: 16
-          Type: 134 ArrayType []val<main.node>
+          Type: 179 ArrayType []val<main.node>
         - Name: overflow
           Offset: 144
-          Type: 131 PointerType *bucket<bool,main.node>
+          Type: 103 PointerType *bucket<bool,main.node>
       KeyType: 4 BaseType bool
-      ValueType: 135 StructureType main.node
+      ValueType: 133 StructureType main.node
     - __kind: GoHMapBucketType
-      ID: 79
+      ID: 70
       Name: bucket<int,int>
       ByteSize: 144
       RawFields:
         - Name: tophash
           Offset: 0
-          Type: 80 ArrayType [8]uint8
+          Type: 162 ArrayType [8]uint8
         - Name: keys
           Offset: 8
-          Type: 81 ArrayType []key<int>
+          Type: 163 ArrayType []key<int>
         - Name: values
           Offset: 72
-          Type: 82 ArrayType []val<int>
+          Type: 164 ArrayType []val<int>
         - Name: overflow
           Offset: 136
-          Type: 78 PointerType *bucket<int,int>
+          Type: 69 PointerType *bucket<int,int>
       KeyType: 9 BaseType int
       ValueType: 9 BaseType int
     - __kind: GoHMapBucketType
-      ID: 141
+      ID: 109
       Name: bucket<int,uint8>
       ByteSize: 88
       RawFields:
         - Name: tophash
           Offset: 0
-          Type: 80 ArrayType [8]uint8
+          Type: 162 ArrayType [8]uint8
         - Name: keys
           Offset: 8
-          Type: 81 ArrayType []key<int>
+          Type: 163 ArrayType []key<int>
         - Name: values
           Offset: 72
-          Type: 142 ArrayType []val<uint8>
+          Type: 180 ArrayType []val<uint8>
         - Name: overflow
           Offset: 80
-          Type: 140 PointerType *bucket<int,uint8>
+          Type: 108 PointerType *bucket<int,uint8>
       KeyType: 9 BaseType int
       ValueType: 3 BaseType uint8
     - __kind: GoHMapBucketType
-      ID: 124
+      ID: 99
       Name: bucket<string,[]main.structWithMap>
       ByteSize: 336
       RawFields:
         - Name: tophash
           Offset: 0
-          Type: 80 ArrayType [8]uint8
+          Type: 162 ArrayType [8]uint8
         - Name: keys
           Offset: 8
-          Type: 95 ArrayType []key<string>
+          Type: 169 ArrayType []key<string>
         - Name: values
           Offset: 136
-          Type: 125 ArrayType []val<[]main.structWithMap>
+          Type: 175 ArrayType []val<[]main.structWithMap>
         - Name: overflow
           Offset: 328
-          Type: 123 PointerType *bucket<string,[]main.structWithMap>
+          Type: 98 PointerType *bucket<string,[]main.structWithMap>
       KeyType: 11 GoStringHeaderType string
-      ValueType: 126 GoSliceHeaderType []main.structWithMap
+      ValueType: 176 GoSliceHeaderType []main.structWithMap
     - __kind: GoHMapBucketType
-      ID: 107
+      ID: 87
       Name: bucket<string,[]string>
       ByteSize: 336
       RawFields:
         - Name: tophash
           Offset: 0
-          Type: 80 ArrayType [8]uint8
+          Type: 162 ArrayType [8]uint8
         - Name: keys
           Offset: 8
-          Type: 95 ArrayType []key<string>
+          Type: 169 ArrayType []key<string>
         - Name: values
           Offset: 136
-          Type: 108 ArrayType []val<[]string>
+          Type: 171 ArrayType []val<[]string>
         - Name: overflow
           Offset: 328
-          Type: 106 PointerType *bucket<string,[]string>
+          Type: 86 PointerType *bucket<string,[]string>
       KeyType: 11 GoStringHeaderType string
-      ValueType: 109 GoSliceHeaderType []string
+      ValueType: 143 GoSliceHeaderType []string
     - __kind: GoHMapBucketType
-      ID: 102
+      ID: 82
       Name: bucket<string,int>
       ByteSize: 208
       RawFields:
         - Name: tophash
           Offset: 0
-          Type: 80 ArrayType [8]uint8
+          Type: 162 ArrayType [8]uint8
         - Name: keys
           Offset: 8
-          Type: 95 ArrayType []key<string>
+          Type: 169 ArrayType []key<string>
         - Name: values
           Offset: 136
-          Type: 82 ArrayType []val<int>
+          Type: 164 ArrayType []val<int>
         - Name: overflow
           Offset: 200
-          Type: 101 PointerType *bucket<string,int>
+          Type: 81 PointerType *bucket<string,int>
       KeyType: 11 GoStringHeaderType string
       ValueType: 9 BaseType int
     - __kind: GoHMapBucketType
-      ID: 94
+      ID: 77
       Name: bucket<string,main.nestedStruct>
       ByteSize: 336
       RawFields:
         - Name: tophash
           Offset: 0
-          Type: 80 ArrayType [8]uint8
+          Type: 162 ArrayType [8]uint8
         - Name: keys
           Offset: 8
-          Type: 95 ArrayType []key<string>
+          Type: 169 ArrayType []key<string>
         - Name: values
           Offset: 136
-          Type: 96 ArrayType []val<main.nestedStruct>
+          Type: 170 ArrayType []val<main.nestedStruct>
         - Name: overflow
           Offset: 328
-          Type: 93 PointerType *bucket<string,main.nestedStruct>
+          Type: 76 PointerType *bucket<string,main.nestedStruct>
       KeyType: 11 GoStringHeaderType string
-      ValueType: 97 StructureType main.nestedStruct
+      ValueType: 151 StructureType main.nestedStruct
     - __kind: GoHMapBucketType
-      ID: 153
+      ID: 119
       Name: bucket<uint8,[4]int>
       ByteSize: 280
       RawFields:
         - Name: tophash
           Offset: 0
-          Type: 80 ArrayType [8]uint8
+          Type: 162 ArrayType [8]uint8
         - Name: keys
           Offset: 8
-          Type: 148 ArrayType []key<uint8>
+          Type: 181 ArrayType []key<uint8>
         - Name: values
           Offset: 16
-          Type: 154 ArrayType []val<[4]int>
+          Type: 182 ArrayType []val<[4]int>
         - Name: overflow
           Offset: 272
-          Type: 152 PointerType *bucket<uint8,[4]int>
+          Type: 118 PointerType *bucket<uint8,[4]int>
       KeyType: 3 BaseType uint8
-      ValueType: 155 ArrayType [4]int
+      ValueType: 183 ArrayType [4]int
     - __kind: GoHMapBucketType
-      ID: 147
+      ID: 114
       Name: bucket<uint8,uint8>
       ByteSize: 32
       RawFields:
         - Name: tophash
           Offset: 0
-          Type: 80 ArrayType [8]uint8
+          Type: 162 ArrayType [8]uint8
         - Name: keys
           Offset: 8
-          Type: 148 ArrayType []key<uint8>
+          Type: 181 ArrayType []key<uint8>
         - Name: values
           Offset: 16
-          Type: 142 ArrayType []val<uint8>
+          Type: 180 ArrayType []val<uint8>
         - Name: overflow
           Offset: 24
-          Type: 146 PointerType *bucket<uint8,uint8>
+          Type: 113 PointerType *bucket<uint8,uint8>
       KeyType: 3 BaseType uint8
       ValueType: 3 BaseType uint8
     - __kind: GoChannelType
-      ID: 167
+      ID: 130
       Name: chan bool
       GoRuntimeType: 539328
       GoKind: 18
@@ -5925,7 +5925,7 @@ Types:
       GoRuntimeType: 441952
       GoKind: 19
     - __kind: GoHMapHeaderType
-      ID: 164
+      ID: 127
       Name: hash<[4]int,[4]int>
       ByteSize: 48
       RawFields:
@@ -5946,20 +5946,20 @@ Types:
           Type: 2 BaseType uint32
         - Name: buckets
           Offset: 16
-          Type: 165 PointerType *bucket<[4]int,[4]int>
+          Type: 128 PointerType *bucket<[4]int,[4]int>
         - Name: oldbuckets
           Offset: 24
-          Type: 165 PointerType *bucket<[4]int,[4]int>
+          Type: 128 PointerType *bucket<[4]int,[4]int>
         - Name: nevacuate
           Offset: 32
           Type: 1 BaseType uintptr
         - Name: extra
           Offset: 40
-          Type: 83 PointerType *runtime.mapextra
-      BucketType: 166 GoHMapBucketType bucket<[4]int,[4]int>
-      BucketsType: 208 GoSliceDataType []bucket<[4]int,[4]int>.array
+          Type: 71 PointerType *runtime.mapextra
+      BucketType: 129 GoHMapBucketType bucket<[4]int,[4]int>
+      BucketsType: 202 GoSliceDataType []bucket<[4]int,[4]int>.array
     - __kind: GoHMapHeaderType
-      ID: 158
+      ID: 122
       Name: hash<[4]int,uint8>
       ByteSize: 48
       RawFields:
@@ -5980,20 +5980,20 @@ Types:
           Type: 2 BaseType uint32
         - Name: buckets
           Offset: 16
-          Type: 159 PointerType *bucket<[4]int,uint8>
+          Type: 123 PointerType *bucket<[4]int,uint8>
         - Name: oldbuckets
           Offset: 24
-          Type: 159 PointerType *bucket<[4]int,uint8>
+          Type: 123 PointerType *bucket<[4]int,uint8>
         - Name: nevacuate
           Offset: 32
           Type: 1 BaseType uintptr
         - Name: extra
           Offset: 40
-          Type: 83 PointerType *runtime.mapextra
-      BucketType: 160 GoHMapBucketType bucket<[4]int,uint8>
-      BucketsType: 207 GoSliceDataType []bucket<[4]int,uint8>.array
+          Type: 71 PointerType *runtime.mapextra
+      BucketType: 124 GoHMapBucketType bucket<[4]int,uint8>
+      BucketsType: 201 GoSliceDataType []bucket<[4]int,uint8>.array
     - __kind: GoHMapHeaderType
-      ID: 112
+      ID: 90
       Name: hash<[4]string,[2]int>
       ByteSize: 48
       RawFields:
@@ -6014,20 +6014,20 @@ Types:
           Type: 2 BaseType uint32
         - Name: buckets
           Offset: 16
-          Type: 113 PointerType *bucket<[4]string,[2]int>
+          Type: 91 PointerType *bucket<[4]string,[2]int>
         - Name: oldbuckets
           Offset: 24
-          Type: 113 PointerType *bucket<[4]string,[2]int>
+          Type: 91 PointerType *bucket<[4]string,[2]int>
         - Name: nevacuate
           Offset: 32
           Type: 1 BaseType uintptr
         - Name: extra
           Offset: 40
-          Type: 83 PointerType *runtime.mapextra
-      BucketType: 114 GoHMapBucketType bucket<[4]string,[2]int>
-      BucketsType: 199 GoSliceDataType []bucket<[4]string,[2]int>.array
+          Type: 71 PointerType *runtime.mapextra
+      BucketType: 92 GoHMapBucketType bucket<[4]string,[2]int>
+      BucketsType: 195 GoSliceDataType []bucket<[4]string,[2]int>.array
     - __kind: GoHMapHeaderType
-      ID: 130
+      ID: 102
       Name: hash<bool,main.node>
       ByteSize: 48
       RawFields:
@@ -6048,20 +6048,20 @@ Types:
           Type: 2 BaseType uint32
         - Name: buckets
           Offset: 16
-          Type: 131 PointerType *bucket<bool,main.node>
+          Type: 103 PointerType *bucket<bool,main.node>
         - Name: oldbuckets
           Offset: 24
-          Type: 131 PointerType *bucket<bool,main.node>
+          Type: 103 PointerType *bucket<bool,main.node>
         - Name: nevacuate
           Offset: 32
           Type: 1 BaseType uintptr
         - Name: extra
           Offset: 40
-          Type: 83 PointerType *runtime.mapextra
-      BucketType: 132 GoHMapBucketType bucket<bool,main.node>
-      BucketsType: 203 GoSliceDataType []bucket<bool,main.node>.array
+          Type: 71 PointerType *runtime.mapextra
+      BucketType: 104 GoHMapBucketType bucket<bool,main.node>
+      BucketsType: 197 GoSliceDataType []bucket<bool,main.node>.array
     - __kind: GoHMapHeaderType
-      ID: 77
+      ID: 68
       Name: hash<int,int>
       ByteSize: 48
       RawFields:
@@ -6082,20 +6082,20 @@ Types:
           Type: 2 BaseType uint32
         - Name: buckets
           Offset: 16
-          Type: 78 PointerType *bucket<int,int>
+          Type: 69 PointerType *bucket<int,int>
         - Name: oldbuckets
           Offset: 24
-          Type: 78 PointerType *bucket<int,int>
+          Type: 69 PointerType *bucket<int,int>
         - Name: nevacuate
           Offset: 32
           Type: 1 BaseType uintptr
         - Name: extra
           Offset: 40
-          Type: 83 PointerType *runtime.mapextra
-      BucketType: 79 GoHMapBucketType bucket<int,int>
+          Type: 71 PointerType *runtime.mapextra
+      BucketType: 70 GoHMapBucketType bucket<int,int>
       BucketsType: 191 GoSliceDataType []bucket<int,int>.array
     - __kind: GoHMapHeaderType
-      ID: 139
+      ID: 107
       Name: hash<int,uint8>
       ByteSize: 48
       RawFields:
@@ -6116,20 +6116,20 @@ Types:
           Type: 2 BaseType uint32
         - Name: buckets
           Offset: 16
-          Type: 140 PointerType *bucket<int,uint8>
+          Type: 108 PointerType *bucket<int,uint8>
         - Name: oldbuckets
           Offset: 24
-          Type: 140 PointerType *bucket<int,uint8>
+          Type: 108 PointerType *bucket<int,uint8>
         - Name: nevacuate
           Offset: 32
           Type: 1 BaseType uintptr
         - Name: extra
           Offset: 40
-          Type: 83 PointerType *runtime.mapextra
-      BucketType: 141 GoHMapBucketType bucket<int,uint8>
-      BucketsType: 204 GoSliceDataType []bucket<int,uint8>.array
+          Type: 71 PointerType *runtime.mapextra
+      BucketType: 109 GoHMapBucketType bucket<int,uint8>
+      BucketsType: 198 GoSliceDataType []bucket<int,uint8>.array
     - __kind: GoHMapHeaderType
-      ID: 122
+      ID: 97
       Name: hash<string,[]main.structWithMap>
       ByteSize: 48
       RawFields:
@@ -6150,20 +6150,20 @@ Types:
           Type: 2 BaseType uint32
         - Name: buckets
           Offset: 16
-          Type: 123 PointerType *bucket<string,[]main.structWithMap>
+          Type: 98 PointerType *bucket<string,[]main.structWithMap>
         - Name: oldbuckets
           Offset: 24
-          Type: 123 PointerType *bucket<string,[]main.structWithMap>
+          Type: 98 PointerType *bucket<string,[]main.structWithMap>
         - Name: nevacuate
           Offset: 32
           Type: 1 BaseType uintptr
         - Name: extra
           Offset: 40
-          Type: 83 PointerType *runtime.mapextra
-      BucketType: 124 GoHMapBucketType bucket<string,[]main.structWithMap>
-      BucketsType: 200 GoSliceDataType []bucket<string,[]main.structWithMap>.array
+          Type: 71 PointerType *runtime.mapextra
+      BucketType: 99 GoHMapBucketType bucket<string,[]main.structWithMap>
+      BucketsType: 196 GoSliceDataType []bucket<string,[]main.structWithMap>.array
     - __kind: GoHMapHeaderType
-      ID: 105
+      ID: 85
       Name: hash<string,[]string>
       ByteSize: 48
       RawFields:
@@ -6184,20 +6184,20 @@ Types:
           Type: 2 BaseType uint32
         - Name: buckets
           Offset: 16
-          Type: 106 PointerType *bucket<string,[]string>
+          Type: 86 PointerType *bucket<string,[]string>
         - Name: oldbuckets
           Offset: 24
-          Type: 106 PointerType *bucket<string,[]string>
+          Type: 86 PointerType *bucket<string,[]string>
         - Name: nevacuate
           Offset: 32
           Type: 1 BaseType uintptr
         - Name: extra
           Offset: 40
-          Type: 83 PointerType *runtime.mapextra
-      BucketType: 107 GoHMapBucketType bucket<string,[]string>
-      BucketsType: 196 GoSliceDataType []bucket<string,[]string>.array
+          Type: 71 PointerType *runtime.mapextra
+      BucketType: 87 GoHMapBucketType bucket<string,[]string>
+      BucketsType: 194 GoSliceDataType []bucket<string,[]string>.array
     - __kind: GoHMapHeaderType
-      ID: 100
+      ID: 80
       Name: hash<string,int>
       ByteSize: 48
       RawFields:
@@ -6218,20 +6218,20 @@ Types:
           Type: 2 BaseType uint32
         - Name: buckets
           Offset: 16
-          Type: 101 PointerType *bucket<string,int>
+          Type: 81 PointerType *bucket<string,int>
         - Name: oldbuckets
           Offset: 24
-          Type: 101 PointerType *bucket<string,int>
+          Type: 81 PointerType *bucket<string,int>
         - Name: nevacuate
           Offset: 32
           Type: 1 BaseType uintptr
         - Name: extra
           Offset: 40
-          Type: 83 PointerType *runtime.mapextra
-      BucketType: 102 GoHMapBucketType bucket<string,int>
-      BucketsType: 195 GoSliceDataType []bucket<string,int>.array
+          Type: 71 PointerType *runtime.mapextra
+      BucketType: 82 GoHMapBucketType bucket<string,int>
+      BucketsType: 193 GoSliceDataType []bucket<string,int>.array
     - __kind: GoHMapHeaderType
-      ID: 92
+      ID: 75
       Name: hash<string,main.nestedStruct>
       ByteSize: 48
       RawFields:
@@ -6252,20 +6252,20 @@ Types:
           Type: 2 BaseType uint32
         - Name: buckets
           Offset: 16
-          Type: 93 PointerType *bucket<string,main.nestedStruct>
+          Type: 76 PointerType *bucket<string,main.nestedStruct>
         - Name: oldbuckets
           Offset: 24
-          Type: 93 PointerType *bucket<string,main.nestedStruct>
+          Type: 76 PointerType *bucket<string,main.nestedStruct>
         - Name: nevacuate
           Offset: 32
           Type: 1 BaseType uintptr
         - Name: extra
           Offset: 40
-          Type: 83 PointerType *runtime.mapextra
-      BucketType: 94 GoHMapBucketType bucket<string,main.nestedStruct>
-      BucketsType: 194 GoSliceDataType []bucket<string,main.nestedStruct>.array
+          Type: 71 PointerType *runtime.mapextra
+      BucketType: 77 GoHMapBucketType bucket<string,main.nestedStruct>
+      BucketsType: 192 GoSliceDataType []bucket<string,main.nestedStruct>.array
     - __kind: GoHMapHeaderType
-      ID: 151
+      ID: 117
       Name: hash<uint8,[4]int>
       ByteSize: 48
       RawFields:
@@ -6286,20 +6286,20 @@ Types:
           Type: 2 BaseType uint32
         - Name: buckets
           Offset: 16
-          Type: 152 PointerType *bucket<uint8,[4]int>
+          Type: 118 PointerType *bucket<uint8,[4]int>
         - Name: oldbuckets
           Offset: 24
-          Type: 152 PointerType *bucket<uint8,[4]int>
+          Type: 118 PointerType *bucket<uint8,[4]int>
         - Name: nevacuate
           Offset: 32
           Type: 1 BaseType uintptr
         - Name: extra
           Offset: 40
-          Type: 83 PointerType *runtime.mapextra
-      BucketType: 153 GoHMapBucketType bucket<uint8,[4]int>
-      BucketsType: 206 GoSliceDataType []bucket<uint8,[4]int>.array
+          Type: 71 PointerType *runtime.mapextra
+      BucketType: 119 GoHMapBucketType bucket<uint8,[4]int>
+      BucketsType: 200 GoSliceDataType []bucket<uint8,[4]int>.array
     - __kind: GoHMapHeaderType
-      ID: 145
+      ID: 112
       Name: hash<uint8,uint8>
       ByteSize: 48
       RawFields:
@@ -6320,18 +6320,18 @@ Types:
           Type: 2 BaseType uint32
         - Name: buckets
           Offset: 16
-          Type: 146 PointerType *bucket<uint8,uint8>
+          Type: 113 PointerType *bucket<uint8,uint8>
         - Name: oldbuckets
           Offset: 24
-          Type: 146 PointerType *bucket<uint8,uint8>
+          Type: 113 PointerType *bucket<uint8,uint8>
         - Name: nevacuate
           Offset: 32
           Type: 1 BaseType uintptr
         - Name: extra
           Offset: 40
-          Type: 83 PointerType *runtime.mapextra
-      BucketType: 147 GoHMapBucketType bucket<uint8,uint8>
-      BucketsType: 205 GoSliceDataType []bucket<uint8,uint8>.array
+          Type: 71 PointerType *runtime.mapextra
+      BucketType: 114 GoHMapBucketType bucket<uint8,uint8>
+      BucketsType: 199 GoSliceDataType []bucket<uint8,uint8>.array
     - __kind: BaseType
       ID: 9
       Name: int
@@ -6389,7 +6389,7 @@ Types:
           Offset: 8
           Type: 19 VoidPointerType unsafe.Pointer
     - __kind: StructureType
-      ID: 185
+      ID: 150
       Name: main.aStruct
       ByteSize: 56
       GoKind: 25
@@ -6405,9 +6405,9 @@ Types:
           Type: 9 BaseType int
         - Name: nested
           Offset: 32
-          Type: 97 StructureType main.nestedStruct
+          Type: 151 StructureType main.nestedStruct
     - __kind: GoInterfaceType
-      ID: 73
+      ID: 64
       Name: main.behavior
       ByteSize: 16
       GoRuntimeType: 973568
@@ -6435,7 +6435,7 @@ Types:
           Offset: 32
           Type: 55 GoInterfaceType io.Writer
     - __kind: StructureType
-      ID: 186
+      ID: 152
       Name: main.emptyStruct
       GoKind: 25
       RawFields: []
@@ -6451,16 +6451,16 @@ Types:
           Type: 56 StructureType main.esotericStack
         - Name: mu
           Offset: 64
-          Type: 63 StructureType sync.Mutex
+          Type: 153 StructureType sync.Mutex
         - Name: once
           Offset: 72
-          Type: 64 StructureType sync.Once
+          Type: 154 StructureType sync.Once
         - Name: wg
           Offset: 88
-          Type: 67 StructureType sync.WaitGroup
+          Type: 157 StructureType sync.WaitGroup
         - Name: a
           Offset: 104
-          Type: 71 StructureType sync/atomic.Int32
+          Type: 161 StructureType sync/atomic.Int32
     - __kind: StructureType
       ID: 56
       Name: main.esotericStack
@@ -6490,7 +6490,7 @@ Types:
           Offset: 56
           Type: 60 GoSubroutineType func()
     - __kind: StructureType
-      ID: 97
+      ID: 151
       Name: main.nestedStruct
       ByteSize: 24
       GoRuntimeType: 1.270208e+06
@@ -6503,7 +6503,7 @@ Types:
           Offset: 8
           Type: 11 GoStringHeaderType string
     - __kind: StructureType
-      ID: 135
+      ID: 133
       Name: main.node
       ByteSize: 16
       GoRuntimeType: 1.270048e+06
@@ -6514,9 +6514,9 @@ Types:
           Type: 9 BaseType int
         - Name: b
           Offset: 8
-          Type: 136 PointerType *main.node
+          Type: 134 PointerType *main.node
     - __kind: StructureType
-      ID: 184
+      ID: 149
       Name: main.oneStringStruct
       ByteSize: 16
       GoKind: 25
@@ -6538,7 +6538,7 @@ Types:
           Offset: 8
           Type: 19 VoidPointerType unsafe.Pointer
     - __kind: StructureType
-      ID: 74
+      ID: 65
       Name: main.structWithMap
       ByteSize: 8
       GoRuntimeType: 1.09264e+06
@@ -6546,9 +6546,9 @@ Types:
       RawFields:
         - Name: m
           Offset: 0
-          Type: 75 GoMapType map[int]int
+          Type: 66 GoMapType map[int]int
     - __kind: StructureType
-      ID: 178
+      ID: 142
       Name: main.structWithNoStrings
       ByteSize: 2
       GoKind: 25
@@ -6560,7 +6560,7 @@ Types:
           Offset: 1
           Type: 4 BaseType bool
     - __kind: StructureType
-      ID: 169
+      ID: 132
       Name: main.structWithTwoValues
       ByteSize: 16
       GoKind: 25
@@ -6572,28 +6572,28 @@ Types:
           Offset: 8
           Type: 4 BaseType bool
     - __kind: GoSliceHeaderType
-      ID: 171
+      ID: 136
       Name: main.t
       ByteSize: 24
       GoKind: 23
       RawFields:
         - Name: array
           Offset: 0
-          Type: 172 PointerType **main.t
+          Type: 185 PointerType **main.t
         - Name: len
           Offset: 8
           Type: 9 BaseType int
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 209 GoSliceDataType main.t.array
+      Data: 203 GoSliceDataType main.t.array
     - __kind: GoSliceDataType
-      ID: 209
+      ID: 203
       Name: main.t.array
       ByteSize: 2048
-      Element: 170 PointerType *main.t
+      Element: 135 PointerType *main.t
     - __kind: StructureType
-      ID: 181
+      ID: 146
       Name: main.threeStringStruct
       ByteSize: 48
       GoKind: 25
@@ -6613,91 +6613,91 @@ Types:
       ByteSize: 2
       GoKind: 9
     - __kind: GoMapType
-      ID: 162
+      ID: 125
       Name: map[[4]int][4]int
       ByteSize: 8
       GoRuntimeType: 873952
       GoKind: 21
-      HeaderType: 164 GoHMapHeaderType hash<[4]int,[4]int>
+      HeaderType: 127 GoHMapHeaderType hash<[4]int,[4]int>
     - __kind: GoMapType
-      ID: 156
+      ID: 120
       Name: map[[4]int]uint8
       ByteSize: 8
       GoRuntimeType: 874048
       GoKind: 21
-      HeaderType: 158 GoHMapHeaderType hash<[4]int,uint8>
+      HeaderType: 122 GoHMapHeaderType hash<[4]int,uint8>
     - __kind: GoMapType
-      ID: 110
+      ID: 88
       Name: map[[4]string][2]int
       ByteSize: 8
       GoRuntimeType: 874144
       GoKind: 21
-      HeaderType: 112 GoHMapHeaderType hash<[4]string,[2]int>
+      HeaderType: 90 GoHMapHeaderType hash<[4]string,[2]int>
     - __kind: GoMapType
-      ID: 128
+      ID: 100
       Name: map[bool]main.node
       ByteSize: 8
       GoRuntimeType: 874240
       GoKind: 21
-      HeaderType: 130 GoHMapHeaderType hash<bool,main.node>
+      HeaderType: 102 GoHMapHeaderType hash<bool,main.node>
     - __kind: GoMapType
-      ID: 75
+      ID: 66
       Name: map[int]int
       ByteSize: 8
       GoRuntimeType: 872992
       GoKind: 21
-      HeaderType: 77 GoHMapHeaderType hash<int,int>
+      HeaderType: 68 GoHMapHeaderType hash<int,int>
     - __kind: GoMapType
-      ID: 137
+      ID: 105
       Name: map[int]uint8
       ByteSize: 8
       GoRuntimeType: 874336
       GoKind: 21
-      HeaderType: 139 GoHMapHeaderType hash<int,uint8>
+      HeaderType: 107 GoHMapHeaderType hash<int,uint8>
     - __kind: GoMapType
-      ID: 120
+      ID: 95
       Name: map[string][]main.structWithMap
       ByteSize: 8
       GoRuntimeType: 874432
       GoKind: 21
-      HeaderType: 122 GoHMapHeaderType hash<string,[]main.structWithMap>
+      HeaderType: 97 GoHMapHeaderType hash<string,[]main.structWithMap>
     - __kind: GoMapType
-      ID: 103
+      ID: 83
       Name: map[string][]string
       ByteSize: 8
       GoRuntimeType: 874528
       GoKind: 21
-      HeaderType: 105 GoHMapHeaderType hash<string,[]string>
+      HeaderType: 85 GoHMapHeaderType hash<string,[]string>
     - __kind: GoMapType
-      ID: 98
+      ID: 78
       Name: map[string]int
       ByteSize: 8
       GoRuntimeType: 874624
       GoKind: 21
-      HeaderType: 100 GoHMapHeaderType hash<string,int>
+      HeaderType: 80 GoHMapHeaderType hash<string,int>
     - __kind: GoMapType
-      ID: 90
+      ID: 73
       Name: map[string]main.nestedStruct
       ByteSize: 8
       GoRuntimeType: 874720
       GoKind: 21
-      HeaderType: 92 GoHMapHeaderType hash<string,main.nestedStruct>
+      HeaderType: 75 GoHMapHeaderType hash<string,main.nestedStruct>
     - __kind: GoMapType
-      ID: 149
+      ID: 115
       Name: map[uint8][4]int
       ByteSize: 8
       GoRuntimeType: 874816
       GoKind: 21
-      HeaderType: 151 GoHMapHeaderType hash<uint8,[4]int>
+      HeaderType: 117 GoHMapHeaderType hash<uint8,[4]int>
     - __kind: GoMapType
-      ID: 143
+      ID: 110
       Name: map[uint8]uint8
       ByteSize: 8
       GoRuntimeType: 874912
       GoKind: 21
-      HeaderType: 145 GoHMapHeaderType hash<uint8,uint8>
+      HeaderType: 112 GoHMapHeaderType hash<uint8,uint8>
     - __kind: StructureType
-      ID: 89
+      ID: 168
       Name: runtime.bmap
       ByteSize: 8
       GoRuntimeType: 1.10096e+06
@@ -6705,9 +6705,9 @@ Types:
       RawFields:
         - Name: tophash
           Offset: 0
-          Type: 80 ArrayType [8]uint8
+          Type: 162 ArrayType [8]uint8
     - __kind: StructureType
-      ID: 84
+      ID: 72
       Name: runtime.mapextra
       ByteSize: 24
       GoRuntimeType: 1.417408e+06
@@ -6715,13 +6715,13 @@ Types:
       RawFields:
         - Name: overflow
           Offset: 0
-          Type: 85 PointerType *[]*runtime.bmap
+          Type: 165 PointerType *[]*runtime.bmap
         - Name: oldoverflow
           Offset: 8
-          Type: 85 PointerType *[]*runtime.bmap
+          Type: 165 PointerType *[]*runtime.bmap
         - Name: nextOverflow
           Offset: 16
-          Type: 88 PointerType *runtime.bmap
+          Type: 167 PointerType *runtime.bmap
     - __kind: GoStringHeaderType
       ID: 11
       Name: string
@@ -6741,7 +6741,7 @@ Types:
       Name: string.str
       ByteSize: 2048
     - __kind: StructureType
-      ID: 63
+      ID: 153
       Name: sync.Mutex
       ByteSize: 8
       GoRuntimeType: 1.271488e+06
@@ -6754,7 +6754,7 @@ Types:
           Offset: 4
           Type: 2 BaseType uint32
     - __kind: StructureType
-      ID: 64
+      ID: 154
       Name: sync.Once
       ByteSize: 12
       GoRuntimeType: 1.272608e+06
@@ -6762,12 +6762,12 @@ Types:
       RawFields:
         - Name: done
           Offset: 0
-          Type: 65 StructureType sync/atomic.Uint32
+          Type: 155 StructureType sync/atomic.Uint32
         - Name: m
           Offset: 4
-          Type: 63 StructureType sync.Mutex
+          Type: 153 StructureType sync.Mutex
     - __kind: StructureType
-      ID: 67
+      ID: 157
       Name: sync.WaitGroup
       ByteSize: 16
       GoRuntimeType: 1.411456e+06
@@ -6775,21 +6775,21 @@ Types:
       RawFields:
         - Name: noCopy
           Offset: 0
-          Type: 68 StructureType sync.noCopy
+          Type: 158 StructureType sync.noCopy
         - Name: state
           Offset: 0
-          Type: 69 StructureType sync/atomic.Uint64
+          Type: 159 StructureType sync/atomic.Uint64
         - Name: sema
           Offset: 8
           Type: 2 BaseType uint32
     - __kind: StructureType
-      ID: 68
+      ID: 158
       Name: sync.noCopy
       GoRuntimeType: 940704
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 71
+      ID: 161
       Name: sync/atomic.Int32
       ByteSize: 4
       GoRuntimeType: 1.272928e+06
@@ -6797,12 +6797,12 @@ Types:
       RawFields:
         - Name: _
           Offset: 0
-          Type: 66 StructureType sync/atomic.noCopy
+          Type: 156 StructureType sync/atomic.noCopy
         - Name: v
           Offset: 0
           Type: 13 BaseType int32
     - __kind: StructureType
-      ID: 65
+      ID: 155
       Name: sync/atomic.Uint32
       ByteSize: 4
       GoRuntimeType: 1.273088e+06
@@ -6810,12 +6810,12 @@ Types:
       RawFields:
         - Name: _
           Offset: 0
-          Type: 66 StructureType sync/atomic.noCopy
+          Type: 156 StructureType sync/atomic.noCopy
         - Name: v
           Offset: 0
           Type: 2 BaseType uint32
     - __kind: StructureType
-      ID: 69
+      ID: 159
       Name: sync/atomic.Uint64
       ByteSize: 8
       GoRuntimeType: 1.41184e+06
@@ -6823,21 +6823,21 @@ Types:
       RawFields:
         - Name: _
           Offset: 0
-          Type: 66 StructureType sync/atomic.noCopy
+          Type: 156 StructureType sync/atomic.noCopy
         - Name: _
           Offset: 0
-          Type: 70 StructureType sync/atomic.align64
+          Type: 160 StructureType sync/atomic.align64
         - Name: v
           Offset: 0
           Type: 10 BaseType uint64
     - __kind: StructureType
-      ID: 70
+      ID: 160
       Name: sync/atomic.align64
       GoRuntimeType: 940896
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 66
+      ID: 156
       Name: sync/atomic.noCopy
       GoRuntimeType: 940800
       GoKind: 25

--- a/pkg/dyninst/irgen/testdata/snapshot/sample.arch=arm64,toolchain=go1.23.11.yaml
+++ b/pkg/dyninst/irgen/testdata/snapshot/sample.arch=arm64,toolchain=go1.23.11.yaml
@@ -3094,275 +3094,16 @@ Subprograms:
           IsParameter: true
           IsReturn: false
 Types:
-    - __kind: BaseType
-      ID: 1
-      Name: int
-      ByteSize: 8
-      GoRuntimeType: 527616
-      GoKind: 2
-    - __kind: ArrayType
-      ID: 2
-      Name: '[5]int'
-      ByteSize: 40
-      GoKind: 17
-      Count: 5
-      HasCount: true
-      Element: 1 BaseType int
-    - __kind: ArrayType
-      ID: 3
-      Name: '[2]uint8'
-      ByteSize: 2
-      GoRuntimeType: 618976
-      GoKind: 17
-      Count: 2
-      HasCount: true
-      Element: 4 BaseType uint8
-    - __kind: BaseType
-      ID: 4
-      Name: uint8
-      ByteSize: 1
-      GoRuntimeType: 527168
-      GoKind: 8
-    - __kind: ArrayType
-      ID: 5
-      Name: '[2]int32'
-      ByteSize: 8
-      GoRuntimeType: 619072
-      GoKind: 17
-      Count: 2
-      HasCount: true
-      Element: 6 BaseType int32
-    - __kind: BaseType
-      ID: 6
-      Name: int32
-      ByteSize: 4
-      GoRuntimeType: 527360
-      GoKind: 5
-    - __kind: ArrayType
-      ID: 7
-      Name: '[2]string'
-      ByteSize: 32
-      GoRuntimeType: 619168
-      GoKind: 17
-      Count: 2
-      HasCount: true
-      Element: 8 GoStringHeaderType string
-    - __kind: GoStringHeaderType
-      ID: 8
-      Name: string
-      ByteSize: 16
-      GoRuntimeType: 527040
-      GoKind: 24
-      RawFields:
-        - Name: str
-          Offset: 0
-          Type: 188 PointerType *string.str
-        - Name: len
-          Offset: 8
-          Type: 1 BaseType int
-      Data: 187 GoStringDataType string.str
     - __kind: PointerType
-      ID: 9
-      Name: '*uint8'
+      ID: 158
+      Name: '**main.t'
       ByteSize: 8
-      GoRuntimeType: 359392
-      GoKind: 22
-      Pointee: 4 BaseType uint8
-    - __kind: ArrayType
-      ID: 10
-      Name: '[2]bool'
-      ByteSize: 2
-      GoKind: 17
-      Count: 2
-      HasCount: true
-      Element: 11 BaseType bool
-    - __kind: BaseType
-      ID: 11
-      Name: bool
-      ByteSize: 1
-      GoRuntimeType: 528064
-      GoKind: 1
-    - __kind: ArrayType
-      ID: 12
-      Name: '[2]int'
-      ByteSize: 16
-      GoRuntimeType: 617920
-      GoKind: 17
-      Count: 2
-      HasCount: true
-      Element: 1 BaseType int
-    - __kind: ArrayType
-      ID: 13
-      Name: '[2]int8'
-      ByteSize: 2
-      GoKind: 17
-      Count: 2
-      HasCount: true
-      Element: 14 BaseType int8
-    - __kind: BaseType
-      ID: 14
-      Name: int8
-      ByteSize: 1
-      GoRuntimeType: 527104
-      GoKind: 3
-    - __kind: ArrayType
-      ID: 15
-      Name: '[2]int16'
-      ByteSize: 4
-      GoKind: 17
-      Count: 2
-      HasCount: true
-      Element: 16 BaseType int16
-    - __kind: BaseType
-      ID: 16
-      Name: int16
-      ByteSize: 2
-      GoRuntimeType: 527232
-      GoKind: 4
-    - __kind: ArrayType
-      ID: 17
-      Name: '[2]int64'
-      ByteSize: 16
-      GoKind: 17
-      Count: 2
-      HasCount: true
-      Element: 18 BaseType int64
-    - __kind: BaseType
-      ID: 18
-      Name: int64
+      Pointee: 156 PointerType *main.t
+    - __kind: PointerType
+      ID: 71
+      Name: '**runtime.bmap'
       ByteSize: 8
-      GoRuntimeType: 527488
-      GoKind: 6
-    - __kind: ArrayType
-      ID: 19
-      Name: '[2]uint'
-      ByteSize: 16
-      GoKind: 17
-      Count: 2
-      HasCount: true
-      Element: 20 BaseType uint
-    - __kind: BaseType
-      ID: 20
-      Name: uint
-      ByteSize: 8
-      GoRuntimeType: 527680
-      GoKind: 7
-    - __kind: ArrayType
-      ID: 21
-      Name: '[2]uint16'
-      ByteSize: 4
-      GoKind: 17
-      Count: 2
-      HasCount: true
-      Element: 22 BaseType uint16
-    - __kind: BaseType
-      ID: 22
-      Name: uint16
-      ByteSize: 2
-      GoRuntimeType: 527296
-      GoKind: 9
-    - __kind: ArrayType
-      ID: 23
-      Name: '[2]uint32'
-      ByteSize: 8
-      GoKind: 17
-      Count: 2
-      HasCount: true
-      Element: 24 BaseType uint32
-    - __kind: BaseType
-      ID: 24
-      Name: uint32
-      ByteSize: 4
-      GoRuntimeType: 527424
-      GoKind: 10
-    - __kind: ArrayType
-      ID: 25
-      Name: '[2]uint64'
-      ByteSize: 16
-      GoRuntimeType: 619264
-      GoKind: 17
-      Count: 2
-      HasCount: true
-      Element: 26 BaseType uint64
-    - __kind: BaseType
-      ID: 26
-      Name: uint64
-      ByteSize: 8
-      GoRuntimeType: 527552
-      GoKind: 11
-    - __kind: ArrayType
-      ID: 27
-      Name: '[2][2]int'
-      ByteSize: 32
-      GoKind: 17
-      Count: 2
-      HasCount: true
-      Element: 12 ArrayType [2]int
-    - __kind: ArrayType
-      ID: 28
-      Name: '[2][2][2]int'
-      ByteSize: 64
-      GoKind: 17
-      Count: 2
-      HasCount: true
-      Element: 27 ArrayType [2][2]int
-    - __kind: ArrayType
-      ID: 29
-      Name: '[100]uint'
-      ByteSize: 800
-      GoKind: 17
-      Count: 100
-      HasCount: true
-      Element: 20 BaseType uint
-    - __kind: BaseType
-      ID: 30
-      Name: float32
-      ByteSize: 4
-      GoRuntimeType: 527936
-      GoKind: 13
-    - __kind: BaseType
-      ID: 31
-      Name: float64
-      ByteSize: 8
-      GoRuntimeType: 528000
-      GoKind: 14
-    - __kind: BaseType
-      ID: 32
-      Name: main.typeAlias
-      ByteSize: 2
-      GoKind: 9
-    - __kind: StructureType
-      ID: 33
-      Name: main.bigStruct
-      ByteSize: 48
-      GoKind: 25
-      RawFields:
-        - Name: x
-          Offset: 0
-          Type: 34 GoSliceHeaderType []*string
-        - Name: z
-          Offset: 24
-          Type: 1 BaseType int
-        - Name: writer
-          Offset: 32
-          Type: 37 GoInterfaceType io.Writer
-    - __kind: GoSliceHeaderType
-      ID: 34
-      Name: '[]*string'
-      ByteSize: 24
-      GoRuntimeType: 443360
-      GoKind: 23
-      RawFields:
-        - Name: array
-          Offset: 0
-          Type: 35 PointerType **string
-        - Name: len
-          Offset: 8
-          Type: 1 BaseType int
-        - Name: cap
-          Offset: 16
-          Type: 1 BaseType int
-      Data: 189 GoSliceDataType []*string.array
+      Pointee: 72 PointerType *runtime.bmap
     - __kind: PointerType
       ID: 35
       Name: '**string'
@@ -3371,1421 +3112,62 @@ Types:
       GoKind: 22
       Pointee: 36 PointerType *string
     - __kind: PointerType
-      ID: 36
-      Name: '*string'
-      ByteSize: 8
-      GoRuntimeType: 359264
-      GoKind: 22
-      Pointee: 8 GoStringHeaderType string
-    - __kind: GoInterfaceType
-      ID: 37
-      Name: io.Writer
-      ByteSize: 16
-      GoRuntimeType: 973952
-      GoKind: 20
-      RawFields:
-        - Name: tab
-          Offset: 0
-          Type: 38 VoidPointerType unsafe.Pointer
-        - Name: data
-          Offset: 8
-          Type: 38 VoidPointerType unsafe.Pointer
-    - __kind: VoidPointerType
-      ID: 38
-      Name: unsafe.Pointer
-      ByteSize: 8
-      GoRuntimeType: 528128
-      GoKind: 26
-    - __kind: StructureType
-      ID: 39
-      Name: main.esotericStack
-      ByteSize: 64
-      GoRuntimeType: 1.819424e+06
-      GoKind: 25
-      RawFields:
-        - Name: _
-          Offset: 0
-          Type: 6 BaseType int32
-        - Name: _valid
-          Offset: 4
-          Type: 6 BaseType int32
-        - Name: c
-          Offset: 8
-          Type: 40 GoChannelType chan struct {}
-        - Name: val
-          Offset: 16
-          Type: 41 GoEmptyInterfaceType interface {}
-        - Name: _
-          Offset: 32
-          Type: 26 BaseType uint64
-        - Name: work
-          Offset: 40
-          Type: 42 GoInterfaceType main.something
-        - Name: foo
-          Offset: 56
-          Type: 43 GoSubroutineType func()
-    - __kind: GoChannelType
-      ID: 40
-      Name: chan struct {}
-      GoRuntimeType: 538240
-      GoKind: 18
-    - __kind: GoEmptyInterfaceType
-      ID: 41
-      Name: interface {}
-      ByteSize: 16
-      GoRuntimeType: 772480
-      GoKind: 20
-      RawFields:
-        - Name: _type
-          Offset: 0
-          Type: 38 VoidPointerType unsafe.Pointer
-        - Name: data
-          Offset: 8
-          Type: 38 VoidPointerType unsafe.Pointer
-    - __kind: GoInterfaceType
-      ID: 42
-      Name: main.something
-      ByteSize: 16
-      GoRuntimeType: 973696
-      GoKind: 20
-      RawFields:
-        - Name: tab
-          Offset: 0
-          Type: 38 VoidPointerType unsafe.Pointer
-        - Name: data
-          Offset: 8
-          Type: 38 VoidPointerType unsafe.Pointer
-    - __kind: GoSubroutineType
-      ID: 43
-      Name: func()
-      ByteSize: 8
-      GoRuntimeType: 441952
-      GoKind: 19
-    - __kind: PointerType
-      ID: 44
-      Name: '*main.esotericHeap'
-      ByteSize: 8
-      GoRuntimeType: 354208
-      GoKind: 22
-      Pointee: 45 StructureType main.esotericHeap
-    - __kind: StructureType
-      ID: 45
-      Name: main.esotericHeap
-      ByteSize: 112
-      GoRuntimeType: 1.69296e+06
-      GoKind: 25
-      RawFields:
-        - Name: esotericStack
-          Offset: 0
-          Type: 39 StructureType main.esotericStack
-        - Name: mu
-          Offset: 64
-          Type: 46 StructureType sync.Mutex
-        - Name: once
-          Offset: 72
-          Type: 47 StructureType sync.Once
-        - Name: wg
-          Offset: 88
-          Type: 50 StructureType sync.WaitGroup
-        - Name: a
-          Offset: 104
-          Type: 54 StructureType sync/atomic.Int32
-    - __kind: StructureType
-      ID: 46
-      Name: sync.Mutex
-      ByteSize: 8
-      GoRuntimeType: 1.271488e+06
-      GoKind: 25
-      RawFields:
-        - Name: state
-          Offset: 0
-          Type: 6 BaseType int32
-        - Name: sema
-          Offset: 4
-          Type: 24 BaseType uint32
-    - __kind: StructureType
-      ID: 47
-      Name: sync.Once
-      ByteSize: 12
-      GoRuntimeType: 1.272608e+06
-      GoKind: 25
-      RawFields:
-        - Name: done
-          Offset: 0
-          Type: 48 StructureType sync/atomic.Uint32
-        - Name: m
-          Offset: 4
-          Type: 46 StructureType sync.Mutex
-    - __kind: StructureType
-      ID: 48
-      Name: sync/atomic.Uint32
-      ByteSize: 4
-      GoRuntimeType: 1.273088e+06
-      GoKind: 25
-      RawFields:
-        - Name: _
-          Offset: 0
-          Type: 49 StructureType sync/atomic.noCopy
-        - Name: v
-          Offset: 0
-          Type: 24 BaseType uint32
-    - __kind: StructureType
-      ID: 49
-      Name: sync/atomic.noCopy
-      GoRuntimeType: 940800
-      GoKind: 25
-      RawFields: []
-    - __kind: StructureType
-      ID: 50
-      Name: sync.WaitGroup
-      ByteSize: 16
-      GoRuntimeType: 1.411456e+06
-      GoKind: 25
-      RawFields:
-        - Name: noCopy
-          Offset: 0
-          Type: 51 StructureType sync.noCopy
-        - Name: state
-          Offset: 0
-          Type: 52 StructureType sync/atomic.Uint64
-        - Name: sema
-          Offset: 8
-          Type: 24 BaseType uint32
-    - __kind: StructureType
-      ID: 51
-      Name: sync.noCopy
-      GoRuntimeType: 940704
-      GoKind: 25
-      RawFields: []
-    - __kind: StructureType
-      ID: 52
-      Name: sync/atomic.Uint64
-      ByteSize: 8
-      GoRuntimeType: 1.41184e+06
-      GoKind: 25
-      RawFields:
-        - Name: _
-          Offset: 0
-          Type: 49 StructureType sync/atomic.noCopy
-        - Name: _
-          Offset: 0
-          Type: 53 StructureType sync/atomic.align64
-        - Name: v
-          Offset: 0
-          Type: 26 BaseType uint64
-    - __kind: StructureType
-      ID: 53
-      Name: sync/atomic.align64
-      GoRuntimeType: 940896
-      GoKind: 25
-      RawFields: []
-    - __kind: StructureType
-      ID: 54
-      Name: sync/atomic.Int32
-      ByteSize: 4
-      GoRuntimeType: 1.272928e+06
-      GoKind: 25
-      RawFields:
-        - Name: _
-          Offset: 0
-          Type: 49 StructureType sync/atomic.noCopy
-        - Name: v
-          Offset: 0
-          Type: 6 BaseType int32
-    - __kind: GoInterfaceType
-      ID: 55
-      Name: main.behavior
-      ByteSize: 16
-      GoRuntimeType: 973568
-      GoKind: 20
-      RawFields:
-        - Name: tab
-          Offset: 0
-          Type: 38 VoidPointerType unsafe.Pointer
-        - Name: data
-          Offset: 8
-          Type: 38 VoidPointerType unsafe.Pointer
-    - __kind: GoInterfaceType
-      ID: 56
-      Name: error
-      ByteSize: 16
-      GoRuntimeType: 978048
-      GoKind: 20
-      RawFields:
-        - Name: tab
-          Offset: 0
-          Type: 38 VoidPointerType unsafe.Pointer
-        - Name: data
-          Offset: 8
-          Type: 38 VoidPointerType unsafe.Pointer
-    - __kind: StructureType
-      ID: 57
-      Name: main.structWithMap
-      ByteSize: 8
-      GoRuntimeType: 1.09264e+06
-      GoKind: 25
-      RawFields:
-        - Name: m
-          Offset: 0
-          Type: 58 GoMapType map[int]int
-    - __kind: GoMapType
-      ID: 58
-      Name: map[int]int
-      ByteSize: 8
-      GoRuntimeType: 872992
-      GoKind: 21
-      HeaderType: 60 GoHMapHeaderType hash<int,int>
-    - __kind: PointerType
-      ID: 59
-      Name: '*hash<int,int>'
-      ByteSize: 8
-      Pointee: 60 GoHMapHeaderType hash<int,int>
-    - __kind: GoHMapHeaderType
-      ID: 60
-      Name: hash<int,int>
-      ByteSize: 48
-      RawFields:
-        - Name: count
-          Offset: 0
-          Type: 1 BaseType int
-        - Name: flags
-          Offset: 8
-          Type: 4 BaseType uint8
-        - Name: B
-          Offset: 9
-          Type: 4 BaseType uint8
-        - Name: noverflow
-          Offset: 10
-          Type: 22 BaseType uint16
-        - Name: hash0
-          Offset: 12
-          Type: 24 BaseType uint32
-        - Name: buckets
-          Offset: 16
-          Type: 61 PointerType *bucket<int,int>
-        - Name: oldbuckets
-          Offset: 24
-          Type: 61 PointerType *bucket<int,int>
-        - Name: nevacuate
-          Offset: 32
-          Type: 66 BaseType uintptr
-        - Name: extra
-          Offset: 40
-          Type: 67 PointerType *runtime.mapextra
-      BucketType: 62 GoHMapBucketType bucket<int,int>
-      BucketsType: 191 GoSliceDataType []bucket<int,int>.array
-    - __kind: PointerType
-      ID: 61
-      Name: '*bucket<int,int>'
-      ByteSize: 8
-      Pointee: 62 GoHMapBucketType bucket<int,int>
-    - __kind: GoHMapBucketType
-      ID: 62
-      Name: bucket<int,int>
-      ByteSize: 144
-      RawFields:
-        - Name: tophash
-          Offset: 0
-          Type: 63 ArrayType [8]uint8
-        - Name: keys
-          Offset: 8
-          Type: 64 ArrayType []key<int>
-        - Name: values
-          Offset: 72
-          Type: 65 ArrayType []val<int>
-        - Name: overflow
-          Offset: 136
-          Type: 61 PointerType *bucket<int,int>
-      KeyType: 1 BaseType int
-      ValueType: 1 BaseType int
-    - __kind: ArrayType
-      ID: 63
-      Name: '[8]uint8'
-      ByteSize: 8
-      GoRuntimeType: 615616
-      GoKind: 17
-      Count: 8
-      HasCount: true
-      Element: 4 BaseType uint8
-    - __kind: ArrayType
-      ID: 64
-      Name: '[]key<int>'
-      ByteSize: 64
-      Count: 8
-      HasCount: true
-      Element: 1 BaseType int
-    - __kind: ArrayType
-      ID: 65
-      Name: '[]val<int>'
-      ByteSize: 64
-      Count: 8
-      HasCount: true
-      Element: 1 BaseType int
-    - __kind: BaseType
-      ID: 66
-      Name: uintptr
-      ByteSize: 8
-      GoRuntimeType: 527744
-      GoKind: 12
-    - __kind: PointerType
-      ID: 67
-      Name: '*runtime.mapextra'
-      ByteSize: 8
-      GoRuntimeType: 363168
-      GoKind: 22
-      Pointee: 68 StructureType runtime.mapextra
-    - __kind: StructureType
-      ID: 68
-      Name: runtime.mapextra
-      ByteSize: 24
-      GoRuntimeType: 1.417408e+06
-      GoKind: 25
-      RawFields:
-        - Name: overflow
-          Offset: 0
-          Type: 69 PointerType *[]*runtime.bmap
-        - Name: oldoverflow
-          Offset: 8
-          Type: 69 PointerType *[]*runtime.bmap
-        - Name: nextOverflow
-          Offset: 16
-          Type: 72 PointerType *runtime.bmap
-    - __kind: PointerType
       ID: 69
       Name: '*[]*runtime.bmap'
       ByteSize: 8
       GoRuntimeType: 451808
       GoKind: 22
       Pointee: 70 GoSliceHeaderType []*runtime.bmap
-    - __kind: GoSliceHeaderType
-      ID: 70
-      Name: '[]*runtime.bmap'
-      ByteSize: 24
-      GoRuntimeType: 451744
-      GoKind: 23
-      RawFields:
-        - Name: array
-          Offset: 0
-          Type: 71 PointerType **runtime.bmap
-        - Name: len
-          Offset: 8
-          Type: 1 BaseType int
-        - Name: cap
-          Offset: 16
-          Type: 1 BaseType int
-      Data: 192 GoSliceDataType []*runtime.bmap.array
     - __kind: PointerType
-      ID: 71
-      Name: '**runtime.bmap'
+      ID: 193
+      Name: '*[]*runtime.bmap.array'
       ByteSize: 8
-      Pointee: 72 PointerType *runtime.bmap
+      Pointee: 192 GoSliceDataType []*runtime.bmap.array
     - __kind: PointerType
-      ID: 72
-      Name: '*runtime.bmap'
+      ID: 190
+      Name: '*[]*string.array'
       ByteSize: 8
-      GoRuntimeType: 1.101088e+06
-      GoKind: 22
-      Pointee: 73 StructureType runtime.bmap
-    - __kind: StructureType
-      ID: 73
-      Name: runtime.bmap
-      ByteSize: 8
-      GoRuntimeType: 1.10096e+06
-      GoKind: 25
-      RawFields:
-        - Name: tophash
-          Offset: 0
-          Type: 63 ArrayType [8]uint8
-    - __kind: GoMapType
-      ID: 74
-      Name: map[string]main.nestedStruct
-      ByteSize: 8
-      GoRuntimeType: 874720
-      GoKind: 21
-      HeaderType: 76 GoHMapHeaderType hash<string,main.nestedStruct>
+      Pointee: 189 GoSliceDataType []*string.array
     - __kind: PointerType
-      ID: 75
-      Name: '*hash<string,main.nestedStruct>'
+      ID: 214
+      Name: '*[][]uint.array'
       ByteSize: 8
-      Pointee: 76 GoHMapHeaderType hash<string,main.nestedStruct>
-    - __kind: GoHMapHeaderType
-      ID: 76
-      Name: hash<string,main.nestedStruct>
-      ByteSize: 48
-      RawFields:
-        - Name: count
-          Offset: 0
-          Type: 1 BaseType int
-        - Name: flags
-          Offset: 8
-          Type: 4 BaseType uint8
-        - Name: B
-          Offset: 9
-          Type: 4 BaseType uint8
-        - Name: noverflow
-          Offset: 10
-          Type: 22 BaseType uint16
-        - Name: hash0
-          Offset: 12
-          Type: 24 BaseType uint32
-        - Name: buckets
-          Offset: 16
-          Type: 77 PointerType *bucket<string,main.nestedStruct>
-        - Name: oldbuckets
-          Offset: 24
-          Type: 77 PointerType *bucket<string,main.nestedStruct>
-        - Name: nevacuate
-          Offset: 32
-          Type: 66 BaseType uintptr
-        - Name: extra
-          Offset: 40
-          Type: 67 PointerType *runtime.mapextra
-      BucketType: 78 GoHMapBucketType bucket<string,main.nestedStruct>
-      BucketsType: 194 GoSliceDataType []bucket<string,main.nestedStruct>.array
+      Pointee: 213 GoSliceDataType [][]uint.array
     - __kind: PointerType
-      ID: 77
-      Name: '*bucket<string,main.nestedStruct>'
+      ID: 218
+      Name: '*[]bool.array'
       ByteSize: 8
-      Pointee: 78 GoHMapBucketType bucket<string,main.nestedStruct>
-    - __kind: GoHMapBucketType
-      ID: 78
-      Name: bucket<string,main.nestedStruct>
-      ByteSize: 336
-      RawFields:
-        - Name: tophash
-          Offset: 0
-          Type: 63 ArrayType [8]uint8
-        - Name: keys
-          Offset: 8
-          Type: 79 ArrayType []key<string>
-        - Name: values
-          Offset: 136
-          Type: 80 ArrayType []val<main.nestedStruct>
-        - Name: overflow
-          Offset: 328
-          Type: 77 PointerType *bucket<string,main.nestedStruct>
-      KeyType: 8 GoStringHeaderType string
-      ValueType: 81 StructureType main.nestedStruct
-    - __kind: ArrayType
-      ID: 79
-      Name: '[]key<string>'
-      ByteSize: 128
-      Count: 8
-      HasCount: true
-      Element: 8 GoStringHeaderType string
-    - __kind: ArrayType
-      ID: 80
-      Name: '[]val<main.nestedStruct>'
-      ByteSize: 192
-      Count: 8
-      HasCount: true
-      Element: 81 StructureType main.nestedStruct
-    - __kind: StructureType
-      ID: 81
-      Name: main.nestedStruct
-      ByteSize: 24
-      GoRuntimeType: 1.270208e+06
-      GoKind: 25
-      RawFields:
-        - Name: anotherInt
-          Offset: 0
-          Type: 1 BaseType int
-        - Name: anotherString
-          Offset: 8
-          Type: 8 GoStringHeaderType string
-    - __kind: GoMapType
-      ID: 82
-      Name: map[string]int
-      ByteSize: 8
-      GoRuntimeType: 874624
-      GoKind: 21
-      HeaderType: 84 GoHMapHeaderType hash<string,int>
+      Pointee: 217 GoSliceDataType []bool.array
     - __kind: PointerType
-      ID: 83
-      Name: '*hash<string,int>'
+      ID: 202
+      Name: '*[]main.structWithMap.array'
       ByteSize: 8
-      Pointee: 84 GoHMapHeaderType hash<string,int>
-    - __kind: GoHMapHeaderType
-      ID: 84
-      Name: hash<string,int>
-      ByteSize: 48
-      RawFields:
-        - Name: count
-          Offset: 0
-          Type: 1 BaseType int
-        - Name: flags
-          Offset: 8
-          Type: 4 BaseType uint8
-        - Name: B
-          Offset: 9
-          Type: 4 BaseType uint8
-        - Name: noverflow
-          Offset: 10
-          Type: 22 BaseType uint16
-        - Name: hash0
-          Offset: 12
-          Type: 24 BaseType uint32
-        - Name: buckets
-          Offset: 16
-          Type: 85 PointerType *bucket<string,int>
-        - Name: oldbuckets
-          Offset: 24
-          Type: 85 PointerType *bucket<string,int>
-        - Name: nevacuate
-          Offset: 32
-          Type: 66 BaseType uintptr
-        - Name: extra
-          Offset: 40
-          Type: 67 PointerType *runtime.mapextra
-      BucketType: 86 GoHMapBucketType bucket<string,int>
-      BucketsType: 195 GoSliceDataType []bucket<string,int>.array
+      Pointee: 201 GoSliceDataType []main.structWithMap.array
     - __kind: PointerType
-      ID: 85
-      Name: '*bucket<string,int>'
+      ID: 216
+      Name: '*[]main.structWithNoStrings.array'
       ByteSize: 8
-      Pointee: 86 GoHMapBucketType bucket<string,int>
-    - __kind: GoHMapBucketType
-      ID: 86
-      Name: bucket<string,int>
-      ByteSize: 208
-      RawFields:
-        - Name: tophash
-          Offset: 0
-          Type: 63 ArrayType [8]uint8
-        - Name: keys
-          Offset: 8
-          Type: 79 ArrayType []key<string>
-        - Name: values
-          Offset: 136
-          Type: 65 ArrayType []val<int>
-        - Name: overflow
-          Offset: 200
-          Type: 85 PointerType *bucket<string,int>
-      KeyType: 8 GoStringHeaderType string
-      ValueType: 1 BaseType int
-    - __kind: GoMapType
-      ID: 87
-      Name: map[string][]string
-      ByteSize: 8
-      GoRuntimeType: 874528
-      GoKind: 21
-      HeaderType: 89 GoHMapHeaderType hash<string,[]string>
+      Pointee: 215 GoSliceDataType []main.structWithNoStrings.array
     - __kind: PointerType
-      ID: 88
-      Name: '*hash<string,[]string>'
+      ID: 198
+      Name: '*[]string.array'
       ByteSize: 8
-      Pointee: 89 GoHMapHeaderType hash<string,[]string>
-    - __kind: GoHMapHeaderType
-      ID: 89
-      Name: hash<string,[]string>
-      ByteSize: 48
-      RawFields:
-        - Name: count
-          Offset: 0
-          Type: 1 BaseType int
-        - Name: flags
-          Offset: 8
-          Type: 4 BaseType uint8
-        - Name: B
-          Offset: 9
-          Type: 4 BaseType uint8
-        - Name: noverflow
-          Offset: 10
-          Type: 22 BaseType uint16
-        - Name: hash0
-          Offset: 12
-          Type: 24 BaseType uint32
-        - Name: buckets
-          Offset: 16
-          Type: 90 PointerType *bucket<string,[]string>
-        - Name: oldbuckets
-          Offset: 24
-          Type: 90 PointerType *bucket<string,[]string>
-        - Name: nevacuate
-          Offset: 32
-          Type: 66 BaseType uintptr
-        - Name: extra
-          Offset: 40
-          Type: 67 PointerType *runtime.mapextra
-      BucketType: 91 GoHMapBucketType bucket<string,[]string>
-      BucketsType: 196 GoSliceDataType []bucket<string,[]string>.array
+      Pointee: 197 GoSliceDataType []string.array
     - __kind: PointerType
-      ID: 90
-      Name: '*bucket<string,[]string>'
+      ID: 161
+      Name: '*[]uint'
       ByteSize: 8
-      Pointee: 91 GoHMapBucketType bucket<string,[]string>
-    - __kind: GoHMapBucketType
-      ID: 91
-      Name: bucket<string,[]string>
-      ByteSize: 336
-      RawFields:
-        - Name: tophash
-          Offset: 0
-          Type: 63 ArrayType [8]uint8
-        - Name: keys
-          Offset: 8
-          Type: 79 ArrayType []key<string>
-        - Name: values
-          Offset: 136
-          Type: 92 ArrayType []val<[]string>
-        - Name: overflow
-          Offset: 328
-          Type: 90 PointerType *bucket<string,[]string>
-      KeyType: 8 GoStringHeaderType string
-      ValueType: 93 GoSliceHeaderType []string
-    - __kind: ArrayType
-      ID: 92
-      Name: '[]val<[]string>'
-      ByteSize: 192
-      Count: 8
-      HasCount: true
-      Element: 93 GoSliceHeaderType []string
-    - __kind: GoSliceHeaderType
-      ID: 93
-      Name: '[]string'
-      ByteSize: 24
-      GoRuntimeType: 450016
-      GoKind: 23
-      RawFields:
-        - Name: array
-          Offset: 0
-          Type: 36 PointerType *string
-        - Name: len
-          Offset: 8
-          Type: 1 BaseType int
-        - Name: cap
-          Offset: 16
-          Type: 1 BaseType int
-      Data: 197 GoSliceDataType []string.array
-    - __kind: GoMapType
-      ID: 94
-      Name: map[[4]string][2]int
-      ByteSize: 8
-      GoRuntimeType: 874144
-      GoKind: 21
-      HeaderType: 96 GoHMapHeaderType hash<[4]string,[2]int>
+      Pointee: 159 GoSliceHeaderType []uint
     - __kind: PointerType
-      ID: 95
-      Name: '*hash<[4]string,[2]int>'
+      ID: 212
+      Name: '*[]uint.array'
       ByteSize: 8
-      Pointee: 96 GoHMapHeaderType hash<[4]string,[2]int>
-    - __kind: GoHMapHeaderType
-      ID: 96
-      Name: hash<[4]string,[2]int>
-      ByteSize: 48
-      RawFields:
-        - Name: count
-          Offset: 0
-          Type: 1 BaseType int
-        - Name: flags
-          Offset: 8
-          Type: 4 BaseType uint8
-        - Name: B
-          Offset: 9
-          Type: 4 BaseType uint8
-        - Name: noverflow
-          Offset: 10
-          Type: 22 BaseType uint16
-        - Name: hash0
-          Offset: 12
-          Type: 24 BaseType uint32
-        - Name: buckets
-          Offset: 16
-          Type: 97 PointerType *bucket<[4]string,[2]int>
-        - Name: oldbuckets
-          Offset: 24
-          Type: 97 PointerType *bucket<[4]string,[2]int>
-        - Name: nevacuate
-          Offset: 32
-          Type: 66 BaseType uintptr
-        - Name: extra
-          Offset: 40
-          Type: 67 PointerType *runtime.mapextra
-      BucketType: 98 GoHMapBucketType bucket<[4]string,[2]int>
-      BucketsType: 199 GoSliceDataType []bucket<[4]string,[2]int>.array
+      Pointee: 211 GoSliceDataType []uint.array
     - __kind: PointerType
-      ID: 97
-      Name: '*bucket<[4]string,[2]int>'
+      ID: 220
+      Name: '*[]uint16.array'
       ByteSize: 8
-      Pointee: 98 GoHMapBucketType bucket<[4]string,[2]int>
-    - __kind: GoHMapBucketType
-      ID: 98
-      Name: bucket<[4]string,[2]int>
-      ByteSize: 656
-      RawFields:
-        - Name: tophash
-          Offset: 0
-          Type: 63 ArrayType [8]uint8
-        - Name: keys
-          Offset: 8
-          Type: 99 ArrayType []key<[4]string>
-        - Name: values
-          Offset: 520
-          Type: 101 ArrayType []val<[2]int>
-        - Name: overflow
-          Offset: 648
-          Type: 97 PointerType *bucket<[4]string,[2]int>
-      KeyType: 100 ArrayType [4]string
-      ValueType: 12 ArrayType [2]int
-    - __kind: ArrayType
-      ID: 99
-      Name: '[]key<[4]string>'
-      ByteSize: 512
-      Count: 8
-      HasCount: true
-      Element: 100 ArrayType [4]string
-    - __kind: ArrayType
-      ID: 100
-      Name: '[4]string'
-      ByteSize: 64
-      GoRuntimeType: 617824
-      GoKind: 17
-      Count: 4
-      HasCount: true
-      Element: 8 GoStringHeaderType string
-    - __kind: ArrayType
-      ID: 101
-      Name: '[]val<[2]int>'
-      ByteSize: 128
-      Count: 8
-      HasCount: true
-      Element: 12 ArrayType [2]int
-    - __kind: ArrayType
-      ID: 102
-      Name: '[2]map[string]int'
-      ByteSize: 16
-      GoKind: 17
-      Count: 2
-      HasCount: true
-      Element: 82 GoMapType map[string]int
-    - __kind: PointerType
-      ID: 103
-      Name: '*map[string]int'
-      ByteSize: 8
-      GoKind: 22
-      Pointee: 82 GoMapType map[string]int
-    - __kind: GoMapType
-      ID: 104
-      Name: map[string][]main.structWithMap
-      ByteSize: 8
-      GoRuntimeType: 874432
-      GoKind: 21
-      HeaderType: 106 GoHMapHeaderType hash<string,[]main.structWithMap>
-    - __kind: PointerType
-      ID: 105
-      Name: '*hash<string,[]main.structWithMap>'
-      ByteSize: 8
-      Pointee: 106 GoHMapHeaderType hash<string,[]main.structWithMap>
-    - __kind: GoHMapHeaderType
-      ID: 106
-      Name: hash<string,[]main.structWithMap>
-      ByteSize: 48
-      RawFields:
-        - Name: count
-          Offset: 0
-          Type: 1 BaseType int
-        - Name: flags
-          Offset: 8
-          Type: 4 BaseType uint8
-        - Name: B
-          Offset: 9
-          Type: 4 BaseType uint8
-        - Name: noverflow
-          Offset: 10
-          Type: 22 BaseType uint16
-        - Name: hash0
-          Offset: 12
-          Type: 24 BaseType uint32
-        - Name: buckets
-          Offset: 16
-          Type: 107 PointerType *bucket<string,[]main.structWithMap>
-        - Name: oldbuckets
-          Offset: 24
-          Type: 107 PointerType *bucket<string,[]main.structWithMap>
-        - Name: nevacuate
-          Offset: 32
-          Type: 66 BaseType uintptr
-        - Name: extra
-          Offset: 40
-          Type: 67 PointerType *runtime.mapextra
-      BucketType: 108 GoHMapBucketType bucket<string,[]main.structWithMap>
-      BucketsType: 200 GoSliceDataType []bucket<string,[]main.structWithMap>.array
-    - __kind: PointerType
-      ID: 107
-      Name: '*bucket<string,[]main.structWithMap>'
-      ByteSize: 8
-      Pointee: 108 GoHMapBucketType bucket<string,[]main.structWithMap>
-    - __kind: GoHMapBucketType
-      ID: 108
-      Name: bucket<string,[]main.structWithMap>
-      ByteSize: 336
-      RawFields:
-        - Name: tophash
-          Offset: 0
-          Type: 63 ArrayType [8]uint8
-        - Name: keys
-          Offset: 8
-          Type: 79 ArrayType []key<string>
-        - Name: values
-          Offset: 136
-          Type: 109 ArrayType []val<[]main.structWithMap>
-        - Name: overflow
-          Offset: 328
-          Type: 107 PointerType *bucket<string,[]main.structWithMap>
-      KeyType: 8 GoStringHeaderType string
-      ValueType: 110 GoSliceHeaderType []main.structWithMap
-    - __kind: ArrayType
-      ID: 109
-      Name: '[]val<[]main.structWithMap>'
-      ByteSize: 192
-      Count: 8
-      HasCount: true
-      Element: 110 GoSliceHeaderType []main.structWithMap
-    - __kind: GoSliceHeaderType
-      ID: 110
-      Name: '[]main.structWithMap'
-      ByteSize: 24
-      GoRuntimeType: 442848
-      GoKind: 23
-      RawFields:
-        - Name: array
-          Offset: 0
-          Type: 111 PointerType *main.structWithMap
-        - Name: len
-          Offset: 8
-          Type: 1 BaseType int
-        - Name: cap
-          Offset: 16
-          Type: 1 BaseType int
-      Data: 201 GoSliceDataType []main.structWithMap.array
-    - __kind: PointerType
-      ID: 111
-      Name: '*main.structWithMap'
-      ByteSize: 8
-      GoRuntimeType: 354144
-      GoKind: 22
-      Pointee: 57 StructureType main.structWithMap
-    - __kind: GoMapType
-      ID: 112
-      Name: map[bool]main.node
-      ByteSize: 8
-      GoRuntimeType: 874240
-      GoKind: 21
-      HeaderType: 114 GoHMapHeaderType hash<bool,main.node>
-    - __kind: PointerType
-      ID: 113
-      Name: '*hash<bool,main.node>'
-      ByteSize: 8
-      Pointee: 114 GoHMapHeaderType hash<bool,main.node>
-    - __kind: GoHMapHeaderType
-      ID: 114
-      Name: hash<bool,main.node>
-      ByteSize: 48
-      RawFields:
-        - Name: count
-          Offset: 0
-          Type: 1 BaseType int
-        - Name: flags
-          Offset: 8
-          Type: 4 BaseType uint8
-        - Name: B
-          Offset: 9
-          Type: 4 BaseType uint8
-        - Name: noverflow
-          Offset: 10
-          Type: 22 BaseType uint16
-        - Name: hash0
-          Offset: 12
-          Type: 24 BaseType uint32
-        - Name: buckets
-          Offset: 16
-          Type: 115 PointerType *bucket<bool,main.node>
-        - Name: oldbuckets
-          Offset: 24
-          Type: 115 PointerType *bucket<bool,main.node>
-        - Name: nevacuate
-          Offset: 32
-          Type: 66 BaseType uintptr
-        - Name: extra
-          Offset: 40
-          Type: 67 PointerType *runtime.mapextra
-      BucketType: 116 GoHMapBucketType bucket<bool,main.node>
-      BucketsType: 203 GoSliceDataType []bucket<bool,main.node>.array
-    - __kind: PointerType
-      ID: 115
-      Name: '*bucket<bool,main.node>'
-      ByteSize: 8
-      Pointee: 116 GoHMapBucketType bucket<bool,main.node>
-    - __kind: GoHMapBucketType
-      ID: 116
-      Name: bucket<bool,main.node>
-      ByteSize: 152
-      RawFields:
-        - Name: tophash
-          Offset: 0
-          Type: 63 ArrayType [8]uint8
-        - Name: keys
-          Offset: 8
-          Type: 117 ArrayType []key<bool>
-        - Name: values
-          Offset: 16
-          Type: 118 ArrayType []val<main.node>
-        - Name: overflow
-          Offset: 144
-          Type: 115 PointerType *bucket<bool,main.node>
-      KeyType: 11 BaseType bool
-      ValueType: 119 StructureType main.node
-    - __kind: ArrayType
-      ID: 117
-      Name: '[]key<bool>'
-      ByteSize: 8
-      Count: 8
-      HasCount: true
-      Element: 11 BaseType bool
-    - __kind: ArrayType
-      ID: 118
-      Name: '[]val<main.node>'
-      ByteSize: 128
-      Count: 8
-      HasCount: true
-      Element: 119 StructureType main.node
-    - __kind: StructureType
-      ID: 119
-      Name: main.node
-      ByteSize: 16
-      GoRuntimeType: 1.270048e+06
-      GoKind: 25
-      RawFields:
-        - Name: val
-          Offset: 0
-          Type: 1 BaseType int
-        - Name: b
-          Offset: 8
-          Type: 120 PointerType *main.node
-    - __kind: PointerType
-      ID: 120
-      Name: '*main.node'
-      ByteSize: 8
-      GoRuntimeType: 354272
-      GoKind: 22
-      Pointee: 119 StructureType main.node
-    - __kind: GoMapType
-      ID: 121
-      Name: map[int]uint8
-      ByteSize: 8
-      GoRuntimeType: 874336
-      GoKind: 21
-      HeaderType: 123 GoHMapHeaderType hash<int,uint8>
-    - __kind: PointerType
-      ID: 122
-      Name: '*hash<int,uint8>'
-      ByteSize: 8
-      Pointee: 123 GoHMapHeaderType hash<int,uint8>
-    - __kind: GoHMapHeaderType
-      ID: 123
-      Name: hash<int,uint8>
-      ByteSize: 48
-      RawFields:
-        - Name: count
-          Offset: 0
-          Type: 1 BaseType int
-        - Name: flags
-          Offset: 8
-          Type: 4 BaseType uint8
-        - Name: B
-          Offset: 9
-          Type: 4 BaseType uint8
-        - Name: noverflow
-          Offset: 10
-          Type: 22 BaseType uint16
-        - Name: hash0
-          Offset: 12
-          Type: 24 BaseType uint32
-        - Name: buckets
-          Offset: 16
-          Type: 124 PointerType *bucket<int,uint8>
-        - Name: oldbuckets
-          Offset: 24
-          Type: 124 PointerType *bucket<int,uint8>
-        - Name: nevacuate
-          Offset: 32
-          Type: 66 BaseType uintptr
-        - Name: extra
-          Offset: 40
-          Type: 67 PointerType *runtime.mapextra
-      BucketType: 125 GoHMapBucketType bucket<int,uint8>
-      BucketsType: 204 GoSliceDataType []bucket<int,uint8>.array
-    - __kind: PointerType
-      ID: 124
-      Name: '*bucket<int,uint8>'
-      ByteSize: 8
-      Pointee: 125 GoHMapBucketType bucket<int,uint8>
-    - __kind: GoHMapBucketType
-      ID: 125
-      Name: bucket<int,uint8>
-      ByteSize: 88
-      RawFields:
-        - Name: tophash
-          Offset: 0
-          Type: 63 ArrayType [8]uint8
-        - Name: keys
-          Offset: 8
-          Type: 64 ArrayType []key<int>
-        - Name: values
-          Offset: 72
-          Type: 126 ArrayType []val<uint8>
-        - Name: overflow
-          Offset: 80
-          Type: 124 PointerType *bucket<int,uint8>
-      KeyType: 1 BaseType int
-      ValueType: 4 BaseType uint8
-    - __kind: ArrayType
-      ID: 126
-      Name: '[]val<uint8>'
-      ByteSize: 8
-      Count: 8
-      HasCount: true
-      Element: 4 BaseType uint8
-    - __kind: GoMapType
-      ID: 127
-      Name: map[uint8]uint8
-      ByteSize: 8
-      GoRuntimeType: 874912
-      GoKind: 21
-      HeaderType: 129 GoHMapHeaderType hash<uint8,uint8>
-    - __kind: PointerType
-      ID: 128
-      Name: '*hash<uint8,uint8>'
-      ByteSize: 8
-      Pointee: 129 GoHMapHeaderType hash<uint8,uint8>
-    - __kind: GoHMapHeaderType
-      ID: 129
-      Name: hash<uint8,uint8>
-      ByteSize: 48
-      RawFields:
-        - Name: count
-          Offset: 0
-          Type: 1 BaseType int
-        - Name: flags
-          Offset: 8
-          Type: 4 BaseType uint8
-        - Name: B
-          Offset: 9
-          Type: 4 BaseType uint8
-        - Name: noverflow
-          Offset: 10
-          Type: 22 BaseType uint16
-        - Name: hash0
-          Offset: 12
-          Type: 24 BaseType uint32
-        - Name: buckets
-          Offset: 16
-          Type: 130 PointerType *bucket<uint8,uint8>
-        - Name: oldbuckets
-          Offset: 24
-          Type: 130 PointerType *bucket<uint8,uint8>
-        - Name: nevacuate
-          Offset: 32
-          Type: 66 BaseType uintptr
-        - Name: extra
-          Offset: 40
-          Type: 67 PointerType *runtime.mapextra
-      BucketType: 131 GoHMapBucketType bucket<uint8,uint8>
-      BucketsType: 205 GoSliceDataType []bucket<uint8,uint8>.array
-    - __kind: PointerType
-      ID: 130
-      Name: '*bucket<uint8,uint8>'
-      ByteSize: 8
-      Pointee: 131 GoHMapBucketType bucket<uint8,uint8>
-    - __kind: GoHMapBucketType
-      ID: 131
-      Name: bucket<uint8,uint8>
-      ByteSize: 32
-      RawFields:
-        - Name: tophash
-          Offset: 0
-          Type: 63 ArrayType [8]uint8
-        - Name: keys
-          Offset: 8
-          Type: 132 ArrayType []key<uint8>
-        - Name: values
-          Offset: 16
-          Type: 126 ArrayType []val<uint8>
-        - Name: overflow
-          Offset: 24
-          Type: 130 PointerType *bucket<uint8,uint8>
-      KeyType: 4 BaseType uint8
-      ValueType: 4 BaseType uint8
-    - __kind: ArrayType
-      ID: 132
-      Name: '[]key<uint8>'
-      ByteSize: 8
-      Count: 8
-      HasCount: true
-      Element: 4 BaseType uint8
-    - __kind: GoMapType
-      ID: 133
-      Name: map[uint8][4]int
-      ByteSize: 8
-      GoRuntimeType: 874816
-      GoKind: 21
-      HeaderType: 135 GoHMapHeaderType hash<uint8,[4]int>
-    - __kind: PointerType
-      ID: 134
-      Name: '*hash<uint8,[4]int>'
-      ByteSize: 8
-      Pointee: 135 GoHMapHeaderType hash<uint8,[4]int>
-    - __kind: GoHMapHeaderType
-      ID: 135
-      Name: hash<uint8,[4]int>
-      ByteSize: 48
-      RawFields:
-        - Name: count
-          Offset: 0
-          Type: 1 BaseType int
-        - Name: flags
-          Offset: 8
-          Type: 4 BaseType uint8
-        - Name: B
-          Offset: 9
-          Type: 4 BaseType uint8
-        - Name: noverflow
-          Offset: 10
-          Type: 22 BaseType uint16
-        - Name: hash0
-          Offset: 12
-          Type: 24 BaseType uint32
-        - Name: buckets
-          Offset: 16
-          Type: 136 PointerType *bucket<uint8,[4]int>
-        - Name: oldbuckets
-          Offset: 24
-          Type: 136 PointerType *bucket<uint8,[4]int>
-        - Name: nevacuate
-          Offset: 32
-          Type: 66 BaseType uintptr
-        - Name: extra
-          Offset: 40
-          Type: 67 PointerType *runtime.mapextra
-      BucketType: 137 GoHMapBucketType bucket<uint8,[4]int>
-      BucketsType: 206 GoSliceDataType []bucket<uint8,[4]int>.array
-    - __kind: PointerType
-      ID: 136
-      Name: '*bucket<uint8,[4]int>'
-      ByteSize: 8
-      Pointee: 137 GoHMapBucketType bucket<uint8,[4]int>
-    - __kind: GoHMapBucketType
-      ID: 137
-      Name: bucket<uint8,[4]int>
-      ByteSize: 280
-      RawFields:
-        - Name: tophash
-          Offset: 0
-          Type: 63 ArrayType [8]uint8
-        - Name: keys
-          Offset: 8
-          Type: 132 ArrayType []key<uint8>
-        - Name: values
-          Offset: 16
-          Type: 138 ArrayType []val<[4]int>
-        - Name: overflow
-          Offset: 272
-          Type: 136 PointerType *bucket<uint8,[4]int>
-      KeyType: 4 BaseType uint8
-      ValueType: 139 ArrayType [4]int
-    - __kind: ArrayType
-      ID: 138
-      Name: '[]val<[4]int>'
-      ByteSize: 256
-      Count: 8
-      HasCount: true
-      Element: 139 ArrayType [4]int
-    - __kind: ArrayType
-      ID: 139
-      Name: '[4]int'
-      ByteSize: 32
-      GoRuntimeType: 617536
-      GoKind: 17
-      Count: 4
-      HasCount: true
-      Element: 1 BaseType int
-    - __kind: GoMapType
-      ID: 140
-      Name: map[[4]int]uint8
-      ByteSize: 8
-      GoRuntimeType: 874048
-      GoKind: 21
-      HeaderType: 142 GoHMapHeaderType hash<[4]int,uint8>
-    - __kind: PointerType
-      ID: 141
-      Name: '*hash<[4]int,uint8>'
-      ByteSize: 8
-      Pointee: 142 GoHMapHeaderType hash<[4]int,uint8>
-    - __kind: GoHMapHeaderType
-      ID: 142
-      Name: hash<[4]int,uint8>
-      ByteSize: 48
-      RawFields:
-        - Name: count
-          Offset: 0
-          Type: 1 BaseType int
-        - Name: flags
-          Offset: 8
-          Type: 4 BaseType uint8
-        - Name: B
-          Offset: 9
-          Type: 4 BaseType uint8
-        - Name: noverflow
-          Offset: 10
-          Type: 22 BaseType uint16
-        - Name: hash0
-          Offset: 12
-          Type: 24 BaseType uint32
-        - Name: buckets
-          Offset: 16
-          Type: 143 PointerType *bucket<[4]int,uint8>
-        - Name: oldbuckets
-          Offset: 24
-          Type: 143 PointerType *bucket<[4]int,uint8>
-        - Name: nevacuate
-          Offset: 32
-          Type: 66 BaseType uintptr
-        - Name: extra
-          Offset: 40
-          Type: 67 PointerType *runtime.mapextra
-      BucketType: 144 GoHMapBucketType bucket<[4]int,uint8>
-      BucketsType: 207 GoSliceDataType []bucket<[4]int,uint8>.array
-    - __kind: PointerType
-      ID: 143
-      Name: '*bucket<[4]int,uint8>'
-      ByteSize: 8
-      Pointee: 144 GoHMapBucketType bucket<[4]int,uint8>
-    - __kind: GoHMapBucketType
-      ID: 144
-      Name: bucket<[4]int,uint8>
-      ByteSize: 280
-      RawFields:
-        - Name: tophash
-          Offset: 0
-          Type: 63 ArrayType [8]uint8
-        - Name: keys
-          Offset: 8
-          Type: 145 ArrayType []key<[4]int>
-        - Name: values
-          Offset: 264
-          Type: 126 ArrayType []val<uint8>
-        - Name: overflow
-          Offset: 272
-          Type: 143 PointerType *bucket<[4]int,uint8>
-      KeyType: 139 ArrayType [4]int
-      ValueType: 4 BaseType uint8
-    - __kind: ArrayType
-      ID: 145
-      Name: '[]key<[4]int>'
-      ByteSize: 256
-      Count: 8
-      HasCount: true
-      Element: 139 ArrayType [4]int
-    - __kind: GoMapType
-      ID: 146
-      Name: map[[4]int][4]int
-      ByteSize: 8
-      GoRuntimeType: 873952
-      GoKind: 21
-      HeaderType: 148 GoHMapHeaderType hash<[4]int,[4]int>
-    - __kind: PointerType
-      ID: 147
-      Name: '*hash<[4]int,[4]int>'
-      ByteSize: 8
-      Pointee: 148 GoHMapHeaderType hash<[4]int,[4]int>
-    - __kind: GoHMapHeaderType
-      ID: 148
-      Name: hash<[4]int,[4]int>
-      ByteSize: 48
-      RawFields:
-        - Name: count
-          Offset: 0
-          Type: 1 BaseType int
-        - Name: flags
-          Offset: 8
-          Type: 4 BaseType uint8
-        - Name: B
-          Offset: 9
-          Type: 4 BaseType uint8
-        - Name: noverflow
-          Offset: 10
-          Type: 22 BaseType uint16
-        - Name: hash0
-          Offset: 12
-          Type: 24 BaseType uint32
-        - Name: buckets
-          Offset: 16
-          Type: 149 PointerType *bucket<[4]int,[4]int>
-        - Name: oldbuckets
-          Offset: 24
-          Type: 149 PointerType *bucket<[4]int,[4]int>
-        - Name: nevacuate
-          Offset: 32
-          Type: 66 BaseType uintptr
-        - Name: extra
-          Offset: 40
-          Type: 67 PointerType *runtime.mapextra
-      BucketType: 150 GoHMapBucketType bucket<[4]int,[4]int>
-      BucketsType: 208 GoSliceDataType []bucket<[4]int,[4]int>.array
-    - __kind: PointerType
-      ID: 149
-      Name: '*bucket<[4]int,[4]int>'
-      ByteSize: 8
-      Pointee: 150 GoHMapBucketType bucket<[4]int,[4]int>
-    - __kind: GoHMapBucketType
-      ID: 150
-      Name: bucket<[4]int,[4]int>
-      ByteSize: 528
-      RawFields:
-        - Name: tophash
-          Offset: 0
-          Type: 63 ArrayType [8]uint8
-        - Name: keys
-          Offset: 8
-          Type: 145 ArrayType []key<[4]int>
-        - Name: values
-          Offset: 264
-          Type: 138 ArrayType []val<[4]int>
-        - Name: overflow
-          Offset: 520
-          Type: 149 PointerType *bucket<[4]int,[4]int>
-      KeyType: 139 ArrayType [4]int
-      ValueType: 139 ArrayType [4]int
-    - __kind: GoChannelType
-      ID: 151
-      Name: chan bool
-      GoRuntimeType: 539328
-      GoKind: 18
-    - __kind: PointerType
-      ID: 152
-      Name: '*main.structWithTwoValues'
-      ByteSize: 8
-      GoKind: 22
-      Pointee: 153 StructureType main.structWithTwoValues
-    - __kind: StructureType
-      ID: 153
-      Name: main.structWithTwoValues
-      ByteSize: 16
-      GoKind: 25
-      RawFields:
-        - Name: a
-          Offset: 0
-          Type: 20 BaseType uint
-        - Name: b
-          Offset: 8
-          Type: 11 BaseType bool
-    - __kind: PointerType
-      ID: 154
-      Name: '*uint'
-      ByteSize: 8
-      GoRuntimeType: 359904
-      GoKind: 22
-      Pointee: 20 BaseType uint
+      Pointee: 219 GoSliceDataType []uint16.array
     - __kind: PointerType
       ID: 155
       Name: '*bool'
@@ -4794,278 +3176,65 @@ Types:
       GoKind: 22
       Pointee: 11 BaseType bool
     - __kind: PointerType
-      ID: 156
-      Name: '*main.t'
+      ID: 149
+      Name: '*bucket<[4]int,[4]int>'
       ByteSize: 8
-      GoKind: 22
-      Pointee: 157 GoSliceHeaderType main.t
-    - __kind: GoSliceHeaderType
-      ID: 157
-      Name: main.t
-      ByteSize: 24
-      GoKind: 23
-      RawFields:
-        - Name: array
-          Offset: 0
-          Type: 158 PointerType **main.t
-        - Name: len
-          Offset: 8
-          Type: 1 BaseType int
-        - Name: cap
-          Offset: 16
-          Type: 1 BaseType int
-      Data: 209 GoSliceDataType main.t.array
+      Pointee: 150 GoHMapBucketType bucket<[4]int,[4]int>
     - __kind: PointerType
-      ID: 158
-      Name: '**main.t'
+      ID: 143
+      Name: '*bucket<[4]int,uint8>'
       ByteSize: 8
-      Pointee: 156 PointerType *main.t
-    - __kind: GoSliceHeaderType
-      ID: 159
-      Name: '[]uint'
-      ByteSize: 24
-      GoRuntimeType: 449504
-      GoKind: 23
-      RawFields:
-        - Name: array
-          Offset: 0
-          Type: 154 PointerType *uint
-        - Name: len
-          Offset: 8
-          Type: 1 BaseType int
-        - Name: cap
-          Offset: 16
-          Type: 1 BaseType int
-      Data: 211 GoSliceDataType []uint.array
-    - __kind: GoSliceHeaderType
-      ID: 160
-      Name: '[][]uint'
-      ByteSize: 24
-      GoKind: 23
-      RawFields:
-        - Name: array
-          Offset: 0
-          Type: 161 PointerType *[]uint
-        - Name: len
-          Offset: 8
-          Type: 1 BaseType int
-        - Name: cap
-          Offset: 16
-          Type: 1 BaseType int
-      Data: 213 GoSliceDataType [][]uint.array
+      Pointee: 144 GoHMapBucketType bucket<[4]int,uint8>
     - __kind: PointerType
-      ID: 161
-      Name: '*[]uint'
+      ID: 97
+      Name: '*bucket<[4]string,[2]int>'
       ByteSize: 8
-      Pointee: 159 GoSliceHeaderType []uint
-    - __kind: GoSliceHeaderType
-      ID: 162
-      Name: '[]main.structWithNoStrings'
-      ByteSize: 24
-      GoKind: 23
-      RawFields:
-        - Name: array
-          Offset: 0
-          Type: 163 PointerType *main.structWithNoStrings
-        - Name: len
-          Offset: 8
-          Type: 1 BaseType int
-        - Name: cap
-          Offset: 16
-          Type: 1 BaseType int
-      Data: 215 GoSliceDataType []main.structWithNoStrings.array
+      Pointee: 98 GoHMapBucketType bucket<[4]string,[2]int>
     - __kind: PointerType
-      ID: 163
-      Name: '*main.structWithNoStrings'
+      ID: 115
+      Name: '*bucket<bool,main.node>'
       ByteSize: 8
-      Pointee: 164 StructureType main.structWithNoStrings
-    - __kind: StructureType
-      ID: 164
-      Name: main.structWithNoStrings
-      ByteSize: 2
-      GoKind: 25
-      RawFields:
-        - Name: aUint8
-          Offset: 0
-          Type: 4 BaseType uint8
-        - Name: aBool
-          Offset: 1
-          Type: 11 BaseType bool
-    - __kind: GoSliceHeaderType
-      ID: 165
-      Name: '[]bool'
-      ByteSize: 24
-      GoRuntimeType: 449888
-      GoKind: 23
-      RawFields:
-        - Name: array
-          Offset: 0
-          Type: 155 PointerType *bool
-        - Name: len
-          Offset: 8
-          Type: 1 BaseType int
-        - Name: cap
-          Offset: 16
-          Type: 1 BaseType int
-      Data: 217 GoSliceDataType []bool.array
-    - __kind: GoSliceHeaderType
-      ID: 166
-      Name: '[]uint16'
-      ByteSize: 24
-      GoRuntimeType: 448864
-      GoKind: 23
-      RawFields:
-        - Name: array
-          Offset: 0
-          Type: 167 PointerType *uint16
-        - Name: len
-          Offset: 8
-          Type: 1 BaseType int
-        - Name: cap
-          Offset: 16
-          Type: 1 BaseType int
-      Data: 219 GoSliceDataType []uint16.array
+      Pointee: 116 GoHMapBucketType bucket<bool,main.node>
     - __kind: PointerType
-      ID: 167
-      Name: '*uint16'
+      ID: 61
+      Name: '*bucket<int,int>'
       ByteSize: 8
-      GoRuntimeType: 359520
-      GoKind: 22
-      Pointee: 22 BaseType uint16
-    - __kind: StructureType
-      ID: 168
-      Name: main.threeStringStruct
-      ByteSize: 48
-      GoKind: 25
-      RawFields:
-        - Name: a
-          Offset: 0
-          Type: 8 GoStringHeaderType string
-        - Name: b
-          Offset: 16
-          Type: 8 GoStringHeaderType string
-        - Name: c
-          Offset: 32
-          Type: 8 GoStringHeaderType string
+      Pointee: 62 GoHMapBucketType bucket<int,int>
     - __kind: PointerType
-      ID: 169
-      Name: '*main.threeStringStruct'
+      ID: 124
+      Name: '*bucket<int,uint8>'
       ByteSize: 8
-      GoKind: 22
-      Pointee: 168 StructureType main.threeStringStruct
+      Pointee: 125 GoHMapBucketType bucket<int,uint8>
     - __kind: PointerType
-      ID: 170
-      Name: '*main.oneStringStruct'
+      ID: 107
+      Name: '*bucket<string,[]main.structWithMap>'
       ByteSize: 8
-      GoKind: 22
-      Pointee: 171 StructureType main.oneStringStruct
-    - __kind: StructureType
-      ID: 171
-      Name: main.oneStringStruct
-      ByteSize: 16
-      GoKind: 25
-      RawFields:
-        - Name: a
-          Offset: 0
-          Type: 8 GoStringHeaderType string
-    - __kind: StructureType
-      ID: 172
-      Name: main.aStruct
-      ByteSize: 56
-      GoKind: 25
-      RawFields:
-        - Name: aBool
-          Offset: 0
-          Type: 11 BaseType bool
-        - Name: aString
-          Offset: 8
-          Type: 8 GoStringHeaderType string
-        - Name: aNumber
-          Offset: 24
-          Type: 1 BaseType int
-        - Name: nested
-          Offset: 32
-          Type: 81 StructureType main.nestedStruct
-    - __kind: StructureType
-      ID: 173
-      Name: main.emptyStruct
-      GoKind: 25
-      RawFields: []
+      Pointee: 108 GoHMapBucketType bucket<string,[]main.structWithMap>
     - __kind: PointerType
-      ID: 174
-      Name: '*uintptr'
+      ID: 90
+      Name: '*bucket<string,[]string>'
       ByteSize: 8
-      GoRuntimeType: 359968
-      GoKind: 22
-      Pointee: 66 BaseType uintptr
+      Pointee: 91 GoHMapBucketType bucket<string,[]string>
     - __kind: PointerType
-      ID: 175
-      Name: '*int32'
+      ID: 85
+      Name: '*bucket<string,int>'
       ByteSize: 8
-      GoRuntimeType: 359584
-      GoKind: 22
-      Pointee: 6 BaseType int32
+      Pointee: 86 GoHMapBucketType bucket<string,int>
     - __kind: PointerType
-      ID: 176
-      Name: '*uint32'
+      ID: 77
+      Name: '*bucket<string,main.nestedStruct>'
       ByteSize: 8
-      GoRuntimeType: 359648
-      GoKind: 22
-      Pointee: 24 BaseType uint32
-    - __kind: BaseType
-      ID: 177
-      Name: complex64
-      ByteSize: 8
-      GoRuntimeType: 527808
-      GoKind: 15
-    - __kind: BaseType
-      ID: 178
-      Name: complex128
-      ByteSize: 16
-      GoRuntimeType: 527872
-      GoKind: 16
+      Pointee: 78 GoHMapBucketType bucket<string,main.nestedStruct>
     - __kind: PointerType
-      ID: 179
-      Name: '*float64'
+      ID: 136
+      Name: '*bucket<uint8,[4]int>'
       ByteSize: 8
-      GoRuntimeType: 360224
-      GoKind: 22
-      Pointee: 31 BaseType float64
+      Pointee: 137 GoHMapBucketType bucket<uint8,[4]int>
     - __kind: PointerType
-      ID: 180
-      Name: '*int64'
+      ID: 130
+      Name: '*bucket<uint8,uint8>'
       ByteSize: 8
-      GoRuntimeType: 359712
-      GoKind: 22
-      Pointee: 18 BaseType int64
-    - __kind: PointerType
-      ID: 181
-      Name: '*int'
-      ByteSize: 8
-      GoRuntimeType: 359840
-      GoKind: 22
-      Pointee: 1 BaseType int
-    - __kind: PointerType
-      ID: 182
-      Name: '*uint64'
-      ByteSize: 8
-      GoRuntimeType: 359776
-      GoKind: 22
-      Pointee: 26 BaseType uint64
-    - __kind: PointerType
-      ID: 183
-      Name: '*int16'
-      ByteSize: 8
-      GoRuntimeType: 359456
-      GoKind: 22
-      Pointee: 16 BaseType int16
-    - __kind: PointerType
-      ID: 184
-      Name: '*int8'
-      ByteSize: 8
-      GoRuntimeType: 359328
-      GoKind: 22
-      Pointee: 14 BaseType int8
+      Pointee: 131 GoHMapBucketType bucket<uint8,uint8>
     - __kind: PointerType
       ID: 185
       Name: '*error'
@@ -5080,220 +3249,330 @@ Types:
       GoRuntimeType: 360160
       GoKind: 22
       Pointee: 30 BaseType float32
-    - __kind: GoStringDataType
-      ID: 187
-      Name: string.str
-      ByteSize: 2048
     - __kind: PointerType
-      ID: 188
-      Name: '*string.str'
+      ID: 179
+      Name: '*float64'
       ByteSize: 8
-      Pointee: 187 GoStringDataType string.str
-    - __kind: GoSliceDataType
-      ID: 189
-      Name: '[]*string.array'
-      ByteSize: 2048
-      Element: 36 PointerType *string
+      GoRuntimeType: 360224
+      GoKind: 22
+      Pointee: 31 BaseType float64
     - __kind: PointerType
-      ID: 190
-      Name: '*[]*string.array'
+      ID: 147
+      Name: '*hash<[4]int,[4]int>'
       ByteSize: 8
-      Pointee: 189 GoSliceDataType []*string.array
-    - __kind: GoSliceDataType
-      ID: 191
-      Name: '[]bucket<int,int>.array'
-      ByteSize: 2048
-      Element: 62 GoHMapBucketType bucket<int,int>
-    - __kind: GoSliceDataType
-      ID: 192
-      Name: '[]*runtime.bmap.array'
-      ByteSize: 2048
-      Element: 72 PointerType *runtime.bmap
+      Pointee: 148 GoHMapHeaderType hash<[4]int,[4]int>
     - __kind: PointerType
-      ID: 193
-      Name: '*[]*runtime.bmap.array'
+      ID: 141
+      Name: '*hash<[4]int,uint8>'
       ByteSize: 8
-      Pointee: 192 GoSliceDataType []*runtime.bmap.array
-    - __kind: GoSliceDataType
-      ID: 194
-      Name: '[]bucket<string,main.nestedStruct>.array'
-      ByteSize: 2048
-      Element: 78 GoHMapBucketType bucket<string,main.nestedStruct>
-    - __kind: GoSliceDataType
-      ID: 195
-      Name: '[]bucket<string,int>.array'
-      ByteSize: 2048
-      Element: 86 GoHMapBucketType bucket<string,int>
-    - __kind: GoSliceDataType
-      ID: 196
-      Name: '[]bucket<string,[]string>.array'
-      ByteSize: 2048
-      Element: 91 GoHMapBucketType bucket<string,[]string>
-    - __kind: GoSliceDataType
-      ID: 197
-      Name: '[]string.array'
-      ByteSize: 2048
-      Element: 8 GoStringHeaderType string
+      Pointee: 142 GoHMapHeaderType hash<[4]int,uint8>
     - __kind: PointerType
-      ID: 198
-      Name: '*[]string.array'
+      ID: 95
+      Name: '*hash<[4]string,[2]int>'
       ByteSize: 8
-      Pointee: 197 GoSliceDataType []string.array
-    - __kind: GoSliceDataType
-      ID: 199
-      Name: '[]bucket<[4]string,[2]int>.array'
-      ByteSize: 2048
-      Element: 98 GoHMapBucketType bucket<[4]string,[2]int>
-    - __kind: GoSliceDataType
-      ID: 200
-      Name: '[]bucket<string,[]main.structWithMap>.array'
-      ByteSize: 2048
-      Element: 108 GoHMapBucketType bucket<string,[]main.structWithMap>
-    - __kind: GoSliceDataType
-      ID: 201
-      Name: '[]main.structWithMap.array'
-      ByteSize: 2048
-      Element: 57 StructureType main.structWithMap
+      Pointee: 96 GoHMapHeaderType hash<[4]string,[2]int>
     - __kind: PointerType
-      ID: 202
-      Name: '*[]main.structWithMap.array'
+      ID: 113
+      Name: '*hash<bool,main.node>'
       ByteSize: 8
-      Pointee: 201 GoSliceDataType []main.structWithMap.array
-    - __kind: GoSliceDataType
-      ID: 203
-      Name: '[]bucket<bool,main.node>.array'
-      ByteSize: 2048
-      Element: 116 GoHMapBucketType bucket<bool,main.node>
-    - __kind: GoSliceDataType
-      ID: 204
-      Name: '[]bucket<int,uint8>.array'
-      ByteSize: 2048
-      Element: 125 GoHMapBucketType bucket<int,uint8>
-    - __kind: GoSliceDataType
-      ID: 205
-      Name: '[]bucket<uint8,uint8>.array'
-      ByteSize: 2048
-      Element: 131 GoHMapBucketType bucket<uint8,uint8>
-    - __kind: GoSliceDataType
-      ID: 206
-      Name: '[]bucket<uint8,[4]int>.array'
-      ByteSize: 2048
-      Element: 137 GoHMapBucketType bucket<uint8,[4]int>
-    - __kind: GoSliceDataType
-      ID: 207
-      Name: '[]bucket<[4]int,uint8>.array'
-      ByteSize: 2048
-      Element: 144 GoHMapBucketType bucket<[4]int,uint8>
-    - __kind: GoSliceDataType
-      ID: 208
-      Name: '[]bucket<[4]int,[4]int>.array'
-      ByteSize: 2048
-      Element: 150 GoHMapBucketType bucket<[4]int,[4]int>
-    - __kind: GoSliceDataType
-      ID: 209
-      Name: main.t.array
-      ByteSize: 2048
-      Element: 156 PointerType *main.t
+      Pointee: 114 GoHMapHeaderType hash<bool,main.node>
+    - __kind: PointerType
+      ID: 59
+      Name: '*hash<int,int>'
+      ByteSize: 8
+      Pointee: 60 GoHMapHeaderType hash<int,int>
+    - __kind: PointerType
+      ID: 122
+      Name: '*hash<int,uint8>'
+      ByteSize: 8
+      Pointee: 123 GoHMapHeaderType hash<int,uint8>
+    - __kind: PointerType
+      ID: 105
+      Name: '*hash<string,[]main.structWithMap>'
+      ByteSize: 8
+      Pointee: 106 GoHMapHeaderType hash<string,[]main.structWithMap>
+    - __kind: PointerType
+      ID: 88
+      Name: '*hash<string,[]string>'
+      ByteSize: 8
+      Pointee: 89 GoHMapHeaderType hash<string,[]string>
+    - __kind: PointerType
+      ID: 83
+      Name: '*hash<string,int>'
+      ByteSize: 8
+      Pointee: 84 GoHMapHeaderType hash<string,int>
+    - __kind: PointerType
+      ID: 75
+      Name: '*hash<string,main.nestedStruct>'
+      ByteSize: 8
+      Pointee: 76 GoHMapHeaderType hash<string,main.nestedStruct>
+    - __kind: PointerType
+      ID: 134
+      Name: '*hash<uint8,[4]int>'
+      ByteSize: 8
+      Pointee: 135 GoHMapHeaderType hash<uint8,[4]int>
+    - __kind: PointerType
+      ID: 128
+      Name: '*hash<uint8,uint8>'
+      ByteSize: 8
+      Pointee: 129 GoHMapHeaderType hash<uint8,uint8>
+    - __kind: PointerType
+      ID: 181
+      Name: '*int'
+      ByteSize: 8
+      GoRuntimeType: 359840
+      GoKind: 22
+      Pointee: 1 BaseType int
+    - __kind: PointerType
+      ID: 183
+      Name: '*int16'
+      ByteSize: 8
+      GoRuntimeType: 359456
+      GoKind: 22
+      Pointee: 16 BaseType int16
+    - __kind: PointerType
+      ID: 175
+      Name: '*int32'
+      ByteSize: 8
+      GoRuntimeType: 359584
+      GoKind: 22
+      Pointee: 6 BaseType int32
+    - __kind: PointerType
+      ID: 180
+      Name: '*int64'
+      ByteSize: 8
+      GoRuntimeType: 359712
+      GoKind: 22
+      Pointee: 18 BaseType int64
+    - __kind: PointerType
+      ID: 184
+      Name: '*int8'
+      ByteSize: 8
+      GoRuntimeType: 359328
+      GoKind: 22
+      Pointee: 14 BaseType int8
+    - __kind: PointerType
+      ID: 44
+      Name: '*main.esotericHeap'
+      ByteSize: 8
+      GoRuntimeType: 354208
+      GoKind: 22
+      Pointee: 45 StructureType main.esotericHeap
+    - __kind: PointerType
+      ID: 120
+      Name: '*main.node'
+      ByteSize: 8
+      GoRuntimeType: 354272
+      GoKind: 22
+      Pointee: 119 StructureType main.node
+    - __kind: PointerType
+      ID: 170
+      Name: '*main.oneStringStruct'
+      ByteSize: 8
+      GoKind: 22
+      Pointee: 171 StructureType main.oneStringStruct
+    - __kind: PointerType
+      ID: 111
+      Name: '*main.structWithMap'
+      ByteSize: 8
+      GoRuntimeType: 354144
+      GoKind: 22
+      Pointee: 57 StructureType main.structWithMap
+    - __kind: PointerType
+      ID: 163
+      Name: '*main.structWithNoStrings'
+      ByteSize: 8
+      Pointee: 164 StructureType main.structWithNoStrings
+    - __kind: PointerType
+      ID: 152
+      Name: '*main.structWithTwoValues'
+      ByteSize: 8
+      GoKind: 22
+      Pointee: 153 StructureType main.structWithTwoValues
+    - __kind: PointerType
+      ID: 156
+      Name: '*main.t'
+      ByteSize: 8
+      GoKind: 22
+      Pointee: 157 GoSliceHeaderType main.t
     - __kind: PointerType
       ID: 210
       Name: '*main.t.array'
       ByteSize: 8
       Pointee: 209 GoSliceDataType main.t.array
-    - __kind: GoSliceDataType
-      ID: 211
-      Name: '[]uint.array'
-      ByteSize: 2048
-      Element: 20 BaseType uint
     - __kind: PointerType
-      ID: 212
-      Name: '*[]uint.array'
+      ID: 169
+      Name: '*main.threeStringStruct'
       ByteSize: 8
-      Pointee: 211 GoSliceDataType []uint.array
-    - __kind: GoSliceDataType
-      ID: 213
-      Name: '[][]uint.array'
-      ByteSize: 2048
-      Element: 159 GoSliceHeaderType []uint
+      GoKind: 22
+      Pointee: 168 StructureType main.threeStringStruct
     - __kind: PointerType
-      ID: 214
-      Name: '*[][]uint.array'
+      ID: 103
+      Name: '*map[string]int'
       ByteSize: 8
-      Pointee: 213 GoSliceDataType [][]uint.array
-    - __kind: GoSliceDataType
-      ID: 215
-      Name: '[]main.structWithNoStrings.array'
-      ByteSize: 2048
-      Element: 164 StructureType main.structWithNoStrings
+      GoKind: 22
+      Pointee: 82 GoMapType map[string]int
     - __kind: PointerType
-      ID: 216
-      Name: '*[]main.structWithNoStrings.array'
+      ID: 72
+      Name: '*runtime.bmap'
       ByteSize: 8
-      Pointee: 215 GoSliceDataType []main.structWithNoStrings.array
-    - __kind: GoSliceDataType
-      ID: 217
-      Name: '[]bool.array'
-      ByteSize: 2048
-      Element: 11 BaseType bool
+      GoRuntimeType: 1.101088e+06
+      GoKind: 22
+      Pointee: 73 StructureType runtime.bmap
     - __kind: PointerType
-      ID: 218
-      Name: '*[]bool.array'
+      ID: 67
+      Name: '*runtime.mapextra'
       ByteSize: 8
-      Pointee: 217 GoSliceDataType []bool.array
-    - __kind: GoSliceDataType
-      ID: 219
-      Name: '[]uint16.array'
-      ByteSize: 2048
-      Element: 22 BaseType uint16
+      GoRuntimeType: 363168
+      GoKind: 22
+      Pointee: 68 StructureType runtime.mapextra
     - __kind: PointerType
-      ID: 220
-      Name: '*[]uint16.array'
+      ID: 36
+      Name: '*string'
       ByteSize: 8
-      Pointee: 219 GoSliceDataType []uint16.array
+      GoRuntimeType: 359264
+      GoKind: 22
+      Pointee: 8 GoStringHeaderType string
+    - __kind: PointerType
+      ID: 188
+      Name: '*string.str'
+      ByteSize: 8
+      Pointee: 187 GoStringDataType string.str
+    - __kind: PointerType
+      ID: 154
+      Name: '*uint'
+      ByteSize: 8
+      GoRuntimeType: 359904
+      GoKind: 22
+      Pointee: 20 BaseType uint
+    - __kind: PointerType
+      ID: 167
+      Name: '*uint16'
+      ByteSize: 8
+      GoRuntimeType: 359520
+      GoKind: 22
+      Pointee: 22 BaseType uint16
+    - __kind: PointerType
+      ID: 176
+      Name: '*uint32'
+      ByteSize: 8
+      GoRuntimeType: 359648
+      GoKind: 22
+      Pointee: 24 BaseType uint32
+    - __kind: PointerType
+      ID: 182
+      Name: '*uint64'
+      ByteSize: 8
+      GoRuntimeType: 359776
+      GoKind: 22
+      Pointee: 26 BaseType uint64
+    - __kind: PointerType
+      ID: 9
+      Name: '*uint8'
+      ByteSize: 8
+      GoRuntimeType: 359392
+      GoKind: 22
+      Pointee: 4 BaseType uint8
+    - __kind: PointerType
+      ID: 174
+      Name: '*uintptr'
+      ByteSize: 8
+      GoRuntimeType: 359968
+      GoKind: 22
+      Pointee: 66 BaseType uintptr
     - __kind: EventRootType
-      ID: 221
-      Name: Probe[main.testByteArray]
-      ByteSize: 3
+      ID: 308
+      Name: Probe[main.stackC]
+    - __kind: EventRootType
+      ID: 265
+      Name: Probe[main.testAny]
+      ByteSize: 17
       PresenceBitsetSize: 1
       Expressions:
-        - Name: x
+        - Name: a
           Offset: 1
           Expression:
-            Type: 3 ArrayType [2]uint8
+            Type: 41 GoEmptyInterfaceType interface {}
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 7, index: 0, name: x}
+                  Variable: {subprogram: 51, index: 0, name: a}
                   Offset: 0
-                  ByteSize: 2
+                  ByteSize: 16
     - __kind: EventRootType
-      ID: 222
-      Name: Probe[main.testRuneArray]
-      ByteSize: 9
+      ID: 237
+      Name: Probe[main.testArrayOfArraysOfArrays]
+      ByteSize: 65
       PresenceBitsetSize: 1
       Expressions:
-        - Name: x
+        - Name: b
           Offset: 1
           Expression:
-            Type: 5 ArrayType [2]int32
+            Type: 28 ArrayType [2][2][2]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 8, index: 0, name: x}
+                  Variable: {subprogram: 23, index: 0, name: b}
                   Offset: 0
-                  ByteSize: 8
+                  ByteSize: 64
     - __kind: EventRootType
-      ID: 223
-      Name: Probe[main.testStringArray]
+      ID: 235
+      Name: Probe[main.testArrayOfArrays]
       ByteSize: 33
       PresenceBitsetSize: 1
       Expressions:
-        - Name: x
+        - Name: a
+          Offset: 1
+          Expression:
+            Type: 27 ArrayType [2][2]int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 21, index: 0, name: a}
+                  Offset: 0
+                  ByteSize: 32
+    - __kind: EventRootType
+      ID: 273
+      Name: Probe[main.testArrayOfMaps]
+      ByteSize: 17
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: m
+          Offset: 1
+          Expression:
+            Type: 102 ArrayType [2]map[string]int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 59, index: 0, name: m}
+                  Offset: 0
+                  ByteSize: 16
+    - __kind: EventRootType
+      ID: 236
+      Name: Probe[main.testArrayOfStrings]
+      ByteSize: 33
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: a
           Offset: 1
           Expression:
             Type: 7 ArrayType [2]string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 9, index: 0, name: x}
+                  Variable: {subprogram: 22, index: 0, name: a}
                   Offset: 0
                   ByteSize: 32
+    - __kind: EventRootType
+      ID: 255
+      Name: Probe[main.testBigStruct]
+      ByteSize: 49
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: b
+          Offset: 1
+          Expression:
+            Type: 33 StructureType main.bigStruct
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 41, index: 0, name: b}
+                  Offset: 0
+                  ByteSize: 48
     - __kind: EventRootType
       ID: 224
       Name: Probe[main.testBoolArray]
@@ -5310,35 +3589,338 @@ Types:
                   Offset: 0
                   ByteSize: 2
     - __kind: EventRootType
-      ID: 225
-      Name: Probe[main.testIntArray]
-      ByteSize: 17
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: x
-          Offset: 1
-          Expression:
-            Type: 12 ArrayType [2]int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 11, index: 0, name: x}
-                  Offset: 0
-                  ByteSize: 16
-    - __kind: EventRootType
-      ID: 226
-      Name: Probe[main.testInt8Array]
+      ID: 221
+      Name: Probe[main.testByteArray]
       ByteSize: 3
       PresenceBitsetSize: 1
       Expressions:
         - Name: x
           Offset: 1
           Expression:
-            Type: 13 ArrayType [2]int8
+            Type: 3 ArrayType [2]uint8
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 12, index: 0, name: x}
+                  Variable: {subprogram: 7, index: 0, name: x}
                   Offset: 0
                   ByteSize: 2
+    - __kind: EventRootType
+      ID: 289
+      Name: Probe[main.testChannel]
+      ByteSize: 1
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: c
+          Offset: 1
+          Expression:
+            Type: 151 GoChannelType chan bool
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 75, index: 0, name: c}
+                  Offset: 0
+                  ByteSize: 0
+    - __kind: EventRootType
+      ID: 287
+      Name: Probe[main.testCombinedByte]
+      ByteSize: 7
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: w
+          Offset: 1
+          Expression:
+            Type: 4 BaseType uint8
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 73, index: 0, name: w}
+                  Offset: 0
+                  ByteSize: 1
+        - Name: x
+          Offset: 2
+          Expression:
+            Type: 4 BaseType uint8
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 73, index: 1, name: x}
+                  Offset: 0
+                  ByteSize: 1
+        - Name: y
+          Offset: 3
+          Expression:
+            Type: 30 BaseType float32
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 73, index: 2, name: y}
+                  Offset: 0
+                  ByteSize: 4
+    - __kind: EventRootType
+      ID: 297
+      Name: Probe[main.testCycle]
+      ByteSize: 9
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: t
+          Offset: 1
+          Expression:
+            Type: 156 PointerType *main.t
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 83, index: 0, name: t}
+                  Offset: 0
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 302
+      Name: Probe[main.testEmptySliceOfStructs]
+      ByteSize: 33
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: xs
+          Offset: 1
+          Expression:
+            Type: 162 GoSliceHeaderType []main.structWithNoStrings
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 88, index: 0, name: xs}
+                  Offset: 0
+                  ByteSize: 24
+        - Name: a
+          Offset: 25
+          Expression:
+            Type: 1 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 88, index: 1, name: a}
+                  Offset: 0
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 299
+      Name: Probe[main.testEmptySlice]
+      ByteSize: 25
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: u
+          Offset: 1
+          Expression:
+            Type: 159 GoSliceHeaderType []uint
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 85, index: 0, name: u}
+                  Offset: 0
+                  ByteSize: 24
+    - __kind: EventRootType
+      ID: 316
+      Name: Probe[main.testEmptyString]
+      ByteSize: 17
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: x
+          Offset: 1
+          Expression:
+            Type: 8 GoStringHeaderType string
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 102, index: 0, name: x}
+                  Offset: 0
+                  ByteSize: 16
+    - __kind: EventRootType
+      ID: 318
+      Name: Probe[main.testEmptyStruct]
+      ByteSize: 1
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: e
+          Offset: 1
+          Expression:
+            Type: 173 StructureType main.emptyStruct
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 104, index: 0, name: e}
+                  Offset: 0
+                  ByteSize: 0
+    - __kind: EventRootType
+      ID: 266
+      Name: Probe[main.testError]
+      ByteSize: 17
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: e
+          Offset: 1
+          Expression:
+            Type: 56 GoInterfaceType error
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 52, index: 0, name: e}
+                  Offset: 0
+                  ByteSize: 16
+    - __kind: EventRootType
+      ID: 257
+      Name: Probe[main.testEsotericHeap]
+      ByteSize: 9
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: e
+          Offset: 1
+          Expression:
+            Type: 44 PointerType *main.esotericHeap
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 43, index: 0, name: e}
+                  Offset: 0
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 256
+      Name: Probe[main.testEsotericStack]
+      ByteSize: 65
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: e
+          Offset: 1
+          Expression:
+            Type: 39 StructureType main.esotericStack
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 42, index: 0, name: e}
+                  Offset: 0
+                  ByteSize: 64
+    - __kind: EventRootType
+      ID: 263
+      Name: Probe[main.testFramelessArray]
+      ByteSize: 41
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: a
+          Offset: 1
+          Expression:
+            Type: 2 ArrayType [5]int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 49, index: 0, name: a}
+                  Offset: 0
+                  ByteSize: 40
+    - __kind: EventRootType
+      ID: 262
+      Name: Probe[main.testFrameless]
+      ByteSize: 9
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: x
+          Offset: 1
+          Expression:
+            Type: 1 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 48, index: 0, name: x}
+                  Offset: 0
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 258
+      Name: Probe[main.testInlinedBA]
+      ByteSize: 9
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: x
+          Offset: 1
+          Expression:
+            Type: 1 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 44, index: 0, name: x}
+                  Offset: 0
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 260
+      Name: Probe[main.testInlinedBBA]
+      ByteSize: 9
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: x
+          Offset: 1
+          Expression:
+            Type: 1 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 46, index: 0, name: x}
+                  Offset: 0
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 320
+      Name: Probe[main.testInlinedBBB]
+    - __kind: EventRootType
+      ID: 259
+      Name: Probe[main.testInlinedBB]
+      ByteSize: 17
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: x
+          Offset: 1
+          Expression:
+            Type: 1 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 45, index: 0, name: x}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: y
+          Offset: 9
+          Expression:
+            Type: 1 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 45, index: 1, name: y}
+                  Offset: 0
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 321
+      Name: Probe[main.testInlinedBCA]
+    - __kind: EventRootType
+      ID: 322
+      Name: Probe[main.testInlinedBCB]
+    - __kind: EventRootType
+      ID: 261
+      Name: Probe[main.testInlinedBC]
+    - __kind: EventRootType
+      ID: 319
+      Name: Probe[main.testInlinedPrint]
+      ByteSize: 9
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: x
+          Offset: 1
+          Expression:
+            Type: 1 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 1, index: 0, name: x}
+                  Offset: 0
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 323
+      Name: Probe[main.testInlinedSq]
+      ByteSize: 9
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: x
+          Offset: 1
+          Expression:
+            Type: 1 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 5, index: 0, name: x}
+                  Offset: 0
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 324
+      Name: Probe[main.testInlinedSumArray]
+      ByteSize: 41
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: a
+          Offset: 1
+          Expression:
+            Type: 2 ArrayType [5]int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 6, index: 0, name: a}
+                  Offset: 0
+                  ByteSize: 40
     - __kind: EventRootType
       ID: 227
       Name: Probe[main.testInt16Array]
@@ -5385,512 +3967,35 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 230
-      Name: Probe[main.testUintArray]
+      ID: 226
+      Name: Probe[main.testInt8Array]
+      ByteSize: 3
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: x
+          Offset: 1
+          Expression:
+            Type: 13 ArrayType [2]int8
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 12, index: 0, name: x}
+                  Offset: 0
+                  ByteSize: 2
+    - __kind: EventRootType
+      ID: 225
+      Name: Probe[main.testIntArray]
       ByteSize: 17
       PresenceBitsetSize: 1
       Expressions:
         - Name: x
           Offset: 1
           Expression:
-            Type: 19 ArrayType [2]uint
+            Type: 12 ArrayType [2]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 16, index: 0, name: x}
+                  Variable: {subprogram: 11, index: 0, name: x}
                   Offset: 0
                   ByteSize: 16
-    - __kind: EventRootType
-      ID: 231
-      Name: Probe[main.testUint8Array]
-      ByteSize: 3
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: x
-          Offset: 1
-          Expression:
-            Type: 3 ArrayType [2]uint8
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 17, index: 0, name: x}
-                  Offset: 0
-                  ByteSize: 2
-    - __kind: EventRootType
-      ID: 232
-      Name: Probe[main.testUint16Array]
-      ByteSize: 5
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: x
-          Offset: 1
-          Expression:
-            Type: 21 ArrayType [2]uint16
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 18, index: 0, name: x}
-                  Offset: 0
-                  ByteSize: 4
-    - __kind: EventRootType
-      ID: 233
-      Name: Probe[main.testUint32Array]
-      ByteSize: 9
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: x
-          Offset: 1
-          Expression:
-            Type: 23 ArrayType [2]uint32
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 19, index: 0, name: x}
-                  Offset: 0
-                  ByteSize: 8
-    - __kind: EventRootType
-      ID: 234
-      Name: Probe[main.testUint64Array]
-      ByteSize: 17
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: x
-          Offset: 1
-          Expression:
-            Type: 25 ArrayType [2]uint64
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 20, index: 0, name: x}
-                  Offset: 0
-                  ByteSize: 16
-    - __kind: EventRootType
-      ID: 235
-      Name: Probe[main.testArrayOfArrays]
-      ByteSize: 33
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: a
-          Offset: 1
-          Expression:
-            Type: 27 ArrayType [2][2]int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 21, index: 0, name: a}
-                  Offset: 0
-                  ByteSize: 32
-    - __kind: EventRootType
-      ID: 236
-      Name: Probe[main.testArrayOfStrings]
-      ByteSize: 33
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: a
-          Offset: 1
-          Expression:
-            Type: 7 ArrayType [2]string
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 22, index: 0, name: a}
-                  Offset: 0
-                  ByteSize: 32
-    - __kind: EventRootType
-      ID: 237
-      Name: Probe[main.testArrayOfArraysOfArrays]
-      ByteSize: 65
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: b
-          Offset: 1
-          Expression:
-            Type: 28 ArrayType [2][2][2]int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 23, index: 0, name: b}
-                  Offset: 0
-                  ByteSize: 64
-    - __kind: EventRootType
-      ID: 238
-      Name: Probe[main.testVeryLargeArray]
-      ByteSize: 801
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: a
-          Offset: 1
-          Expression:
-            Type: 29 ArrayType [100]uint
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 24, index: 0, name: a}
-                  Offset: 0
-                  ByteSize: 800
-    - __kind: EventRootType
-      ID: 239
-      Name: Probe[main.testSingleByte]
-      ByteSize: 2
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: x
-          Offset: 1
-          Expression:
-            Type: 4 BaseType uint8
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 25, index: 0, name: x}
-                  Offset: 0
-                  ByteSize: 1
-    - __kind: EventRootType
-      ID: 240
-      Name: Probe[main.testSingleRune]
-      ByteSize: 5
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: x
-          Offset: 1
-          Expression:
-            Type: 6 BaseType int32
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 26, index: 0, name: x}
-                  Offset: 0
-                  ByteSize: 4
-    - __kind: EventRootType
-      ID: 241
-      Name: Probe[main.testSingleBool]
-      ByteSize: 2
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: x
-          Offset: 1
-          Expression:
-            Type: 11 BaseType bool
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 27, index: 0, name: x}
-                  Offset: 0
-                  ByteSize: 1
-    - __kind: EventRootType
-      ID: 242
-      Name: Probe[main.testSingleInt]
-      ByteSize: 9
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: x
-          Offset: 1
-          Expression:
-            Type: 1 BaseType int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 28, index: 0, name: x}
-                  Offset: 0
-                  ByteSize: 8
-    - __kind: EventRootType
-      ID: 243
-      Name: Probe[main.testSingleInt8]
-      ByteSize: 2
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: x
-          Offset: 1
-          Expression:
-            Type: 14 BaseType int8
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 29, index: 0, name: x}
-                  Offset: 0
-                  ByteSize: 1
-    - __kind: EventRootType
-      ID: 244
-      Name: Probe[main.testSingleInt16]
-      ByteSize: 3
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: x
-          Offset: 1
-          Expression:
-            Type: 16 BaseType int16
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 30, index: 0, name: x}
-                  Offset: 0
-                  ByteSize: 2
-    - __kind: EventRootType
-      ID: 245
-      Name: Probe[main.testSingleInt32]
-      ByteSize: 5
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: x
-          Offset: 1
-          Expression:
-            Type: 6 BaseType int32
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 31, index: 0, name: x}
-                  Offset: 0
-                  ByteSize: 4
-    - __kind: EventRootType
-      ID: 246
-      Name: Probe[main.testSingleInt64]
-      ByteSize: 9
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: x
-          Offset: 1
-          Expression:
-            Type: 18 BaseType int64
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 32, index: 0, name: x}
-                  Offset: 0
-                  ByteSize: 8
-    - __kind: EventRootType
-      ID: 247
-      Name: Probe[main.testSingleUint]
-      ByteSize: 9
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: x
-          Offset: 1
-          Expression:
-            Type: 20 BaseType uint
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 33, index: 0, name: x}
-                  Offset: 0
-                  ByteSize: 8
-    - __kind: EventRootType
-      ID: 248
-      Name: Probe[main.testSingleUint8]
-      ByteSize: 2
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: x
-          Offset: 1
-          Expression:
-            Type: 4 BaseType uint8
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 34, index: 0, name: x}
-                  Offset: 0
-                  ByteSize: 1
-    - __kind: EventRootType
-      ID: 249
-      Name: Probe[main.testSingleUint16]
-      ByteSize: 3
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: x
-          Offset: 1
-          Expression:
-            Type: 22 BaseType uint16
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 35, index: 0, name: x}
-                  Offset: 0
-                  ByteSize: 2
-    - __kind: EventRootType
-      ID: 250
-      Name: Probe[main.testSingleUint32]
-      ByteSize: 5
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: x
-          Offset: 1
-          Expression:
-            Type: 24 BaseType uint32
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 36, index: 0, name: x}
-                  Offset: 0
-                  ByteSize: 4
-    - __kind: EventRootType
-      ID: 251
-      Name: Probe[main.testSingleUint64]
-      ByteSize: 9
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: x
-          Offset: 1
-          Expression:
-            Type: 26 BaseType uint64
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 37, index: 0, name: x}
-                  Offset: 0
-                  ByteSize: 8
-    - __kind: EventRootType
-      ID: 252
-      Name: Probe[main.testSingleFloat32]
-      ByteSize: 5
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: x
-          Offset: 1
-          Expression:
-            Type: 30 BaseType float32
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 38, index: 0, name: x}
-                  Offset: 0
-                  ByteSize: 4
-    - __kind: EventRootType
-      ID: 253
-      Name: Probe[main.testSingleFloat64]
-      ByteSize: 9
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: x
-          Offset: 1
-          Expression:
-            Type: 31 BaseType float64
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 39, index: 0, name: x}
-                  Offset: 0
-                  ByteSize: 8
-    - __kind: EventRootType
-      ID: 254
-      Name: Probe[main.testTypeAlias]
-      ByteSize: 3
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: x
-          Offset: 1
-          Expression:
-            Type: 32 BaseType main.typeAlias
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 40, index: 0, name: x}
-                  Offset: 0
-                  ByteSize: 2
-    - __kind: EventRootType
-      ID: 255
-      Name: Probe[main.testBigStruct]
-      ByteSize: 49
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: b
-          Offset: 1
-          Expression:
-            Type: 33 StructureType main.bigStruct
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 41, index: 0, name: b}
-                  Offset: 0
-                  ByteSize: 48
-    - __kind: EventRootType
-      ID: 256
-      Name: Probe[main.testEsotericStack]
-      ByteSize: 65
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: e
-          Offset: 1
-          Expression:
-            Type: 39 StructureType main.esotericStack
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 42, index: 0, name: e}
-                  Offset: 0
-                  ByteSize: 64
-    - __kind: EventRootType
-      ID: 257
-      Name: Probe[main.testEsotericHeap]
-      ByteSize: 9
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: e
-          Offset: 1
-          Expression:
-            Type: 44 PointerType *main.esotericHeap
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 43, index: 0, name: e}
-                  Offset: 0
-                  ByteSize: 8
-    - __kind: EventRootType
-      ID: 258
-      Name: Probe[main.testInlinedBA]
-      ByteSize: 9
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: x
-          Offset: 1
-          Expression:
-            Type: 1 BaseType int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 44, index: 0, name: x}
-                  Offset: 0
-                  ByteSize: 8
-    - __kind: EventRootType
-      ID: 259
-      Name: Probe[main.testInlinedBB]
-      ByteSize: 17
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: x
-          Offset: 1
-          Expression:
-            Type: 1 BaseType int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 45, index: 0, name: x}
-                  Offset: 0
-                  ByteSize: 8
-        - Name: y
-          Offset: 9
-          Expression:
-            Type: 1 BaseType int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 45, index: 1, name: y}
-                  Offset: 0
-                  ByteSize: 8
-    - __kind: EventRootType
-      ID: 260
-      Name: Probe[main.testInlinedBBA]
-      ByteSize: 9
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: x
-          Offset: 1
-          Expression:
-            Type: 1 BaseType int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 46, index: 0, name: x}
-                  Offset: 0
-                  ByteSize: 8
-    - __kind: EventRootType
-      ID: 261
-      Name: Probe[main.testInlinedBC]
-    - __kind: EventRootType
-      ID: 262
-      Name: Probe[main.testFrameless]
-      ByteSize: 9
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: x
-          Offset: 1
-          Expression:
-            Type: 1 BaseType int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 48, index: 0, name: x}
-                  Offset: 0
-                  ByteSize: 8
-    - __kind: EventRootType
-      ID: 263
-      Name: Probe[main.testFramelessArray]
-      ByteSize: 41
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: a
-          Offset: 1
-          Expression:
-            Type: 2 ArrayType [5]int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 49, index: 0, name: a}
-                  Offset: 0
-                  ByteSize: 40
     - __kind: EventRootType
       ID: 264
       Name: Probe[main.testInterface]
@@ -5907,63 +4012,138 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 265
-      Name: Probe[main.testAny]
+      ID: 291
+      Name: Probe[main.testLinkedList]
       ByteSize: 17
       PresenceBitsetSize: 1
       Expressions:
         - Name: a
           Offset: 1
           Expression:
-            Type: 41 GoEmptyInterfaceType interface {}
+            Type: 119 StructureType main.node
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 51, index: 0, name: a}
+                  Variable: {subprogram: 77, index: 0, name: a}
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 266
-      Name: Probe[main.testError]
-      ByteSize: 17
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: e
-          Offset: 1
-          Expression:
-            Type: 56 GoInterfaceType error
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 52, index: 0, name: e}
-                  Offset: 0
-                  ByteSize: 16
-    - __kind: EventRootType
-      ID: 267
-      Name: Probe[main.testStructWithMap]
-      ByteSize: 9
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: s
-          Offset: 1
-          Expression:
-            Type: 57 StructureType main.structWithMap
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 53, index: 0, name: s}
-                  Offset: 0
-                  ByteSize: 8
-    - __kind: EventRootType
-      ID: 268
-      Name: Probe[main.testMapStringToStruct]
+      ID: 271
+      Name: Probe[main.testMapArrayToArray]
       ByteSize: 9
       PresenceBitsetSize: 1
       Expressions:
         - Name: m
           Offset: 1
           Expression:
-            Type: 74 GoMapType map[string]main.nestedStruct
+            Type: 94 GoMapType map[[4]string][2]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 54, index: 0, name: m}
+                  Variable: {subprogram: 57, index: 0, name: m}
+                  Offset: 0
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 277
+      Name: Probe[main.testMapEmbeddedMaps]
+      ByteSize: 9
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: m
+          Offset: 1
+          Expression:
+            Type: 104 GoMapType map[string][]main.structWithMap
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 63, index: 0, name: m}
+                  Offset: 0
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 275
+      Name: Probe[main.testMapIntToInt]
+      ByteSize: 9
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: m
+          Offset: 1
+          Expression:
+            Type: 58 GoMapType map[int]int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 61, index: 0, name: m}
+                  Offset: 0
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 286
+      Name: Probe[main.testMapLargeKeyLargeValue]
+      ByteSize: 9
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: m
+          Offset: 1
+          Expression:
+            Type: 146 GoMapType map[[4]int][4]int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 72, index: 0, name: m}
+                  Offset: 0
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 285
+      Name: Probe[main.testMapLargeKeySmallValue]
+      ByteSize: 9
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: m
+          Offset: 1
+          Expression:
+            Type: 140 GoMapType map[[4]int]uint8
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 71, index: 0, name: m}
+                  Offset: 0
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 276
+      Name: Probe[main.testMapMassive]
+      ByteSize: 9
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: redactMyEntries
+          Offset: 1
+          Expression:
+            Type: 104 GoMapType map[string][]main.structWithMap
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 62, index: 0, name: redactMyEntries}
+                  Offset: 0
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 284
+      Name: Probe[main.testMapSmallKeyLargeValue]
+      ByteSize: 9
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: m
+          Offset: 1
+          Expression:
+            Type: 133 GoMapType map[uint8][4]int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 70, index: 0, name: m}
+                  Offset: 0
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 283
+      Name: Probe[main.testMapSmallKeySmallValue]
+      ByteSize: 9
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: m
+          Offset: 1
+          Expression:
+            Type: 127 GoMapType map[uint8]uint8
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 69, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
@@ -5997,108 +4177,18 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 271
-      Name: Probe[main.testMapArrayToArray]
+      ID: 268
+      Name: Probe[main.testMapStringToStruct]
       ByteSize: 9
       PresenceBitsetSize: 1
       Expressions:
         - Name: m
           Offset: 1
           Expression:
-            Type: 94 GoMapType map[[4]string][2]int
+            Type: 74 GoMapType map[string]main.nestedStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 57, index: 0, name: m}
-                  Offset: 0
-                  ByteSize: 8
-    - __kind: EventRootType
-      ID: 272
-      Name: Probe[main.testSmallMap]
-      ByteSize: 9
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: m
-          Offset: 1
-          Expression:
-            Type: 82 GoMapType map[string]int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 58, index: 0, name: m}
-                  Offset: 0
-                  ByteSize: 8
-    - __kind: EventRootType
-      ID: 273
-      Name: Probe[main.testArrayOfMaps]
-      ByteSize: 17
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: m
-          Offset: 1
-          Expression:
-            Type: 102 ArrayType [2]map[string]int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 59, index: 0, name: m}
-                  Offset: 0
-                  ByteSize: 16
-    - __kind: EventRootType
-      ID: 274
-      Name: Probe[main.testPointerToMap]
-      ByteSize: 9
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: m
-          Offset: 1
-          Expression:
-            Type: 103 PointerType *map[string]int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 60, index: 0, name: m}
-                  Offset: 0
-                  ByteSize: 8
-    - __kind: EventRootType
-      ID: 275
-      Name: Probe[main.testMapIntToInt]
-      ByteSize: 9
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: m
-          Offset: 1
-          Expression:
-            Type: 58 GoMapType map[int]int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 61, index: 0, name: m}
-                  Offset: 0
-                  ByteSize: 8
-    - __kind: EventRootType
-      ID: 276
-      Name: Probe[main.testMapMassive]
-      ByteSize: 9
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: redactMyEntries
-          Offset: 1
-          Expression:
-            Type: 104 GoMapType map[string][]main.structWithMap
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 62, index: 0, name: redactMyEntries}
-                  Offset: 0
-                  ByteSize: 8
-    - __kind: EventRootType
-      ID: 277
-      Name: Probe[main.testMapEmbeddedMaps]
-      ByteSize: 9
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: m
-          Offset: 1
-          Expression:
-            Type: 104 GoMapType map[string][]main.structWithMap
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 63, index: 0, name: m}
+                  Variable: {subprogram: 54, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
@@ -6117,33 +4207,18 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 279
-      Name: Probe[main.testMapWithSmallValue]
+      ID: 282
+      Name: Probe[main.testMapWithSmallKeyAndValueMassive]
       ByteSize: 9
       PresenceBitsetSize: 1
       Expressions:
         - Name: m
           Offset: 1
           Expression:
-            Type: 121 GoMapType map[int]uint8
+            Type: 127 GoMapType map[uint8]uint8
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 65, index: 0, name: m}
-                  Offset: 0
-                  ByteSize: 8
-    - __kind: EventRootType
-      ID: 280
-      Name: Probe[main.testMapWithSmallValueMassive]
-      ByteSize: 9
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: redactMyEntries
-          Offset: 1
-          Expression:
-            Type: 121 GoMapType map[int]uint8
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 66, index: 0, name: redactMyEntries}
+                  Variable: {subprogram: 68, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
@@ -6162,113 +4237,50 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 282
-      Name: Probe[main.testMapWithSmallKeyAndValueMassive]
+      ID: 280
+      Name: Probe[main.testMapWithSmallValueMassive]
+      ByteSize: 9
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: redactMyEntries
+          Offset: 1
+          Expression:
+            Type: 121 GoMapType map[int]uint8
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 66, index: 0, name: redactMyEntries}
+                  Offset: 0
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 279
+      Name: Probe[main.testMapWithSmallValue]
       ByteSize: 9
       PresenceBitsetSize: 1
       Expressions:
         - Name: m
           Offset: 1
           Expression:
-            Type: 127 GoMapType map[uint8]uint8
+            Type: 121 GoMapType map[int]uint8
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 68, index: 0, name: m}
+                  Variable: {subprogram: 65, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 283
-      Name: Probe[main.testMapSmallKeySmallValue]
-      ByteSize: 9
+      ID: 314
+      Name: Probe[main.testMassiveString]
+      ByteSize: 17
       PresenceBitsetSize: 1
       Expressions:
-        - Name: m
-          Offset: 1
-          Expression:
-            Type: 127 GoMapType map[uint8]uint8
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 69, index: 0, name: m}
-                  Offset: 0
-                  ByteSize: 8
-    - __kind: EventRootType
-      ID: 284
-      Name: Probe[main.testMapSmallKeyLargeValue]
-      ByteSize: 9
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: m
-          Offset: 1
-          Expression:
-            Type: 133 GoMapType map[uint8][4]int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 70, index: 0, name: m}
-                  Offset: 0
-                  ByteSize: 8
-    - __kind: EventRootType
-      ID: 285
-      Name: Probe[main.testMapLargeKeySmallValue]
-      ByteSize: 9
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: m
-          Offset: 1
-          Expression:
-            Type: 140 GoMapType map[[4]int]uint8
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 71, index: 0, name: m}
-                  Offset: 0
-                  ByteSize: 8
-    - __kind: EventRootType
-      ID: 286
-      Name: Probe[main.testMapLargeKeyLargeValue]
-      ByteSize: 9
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: m
-          Offset: 1
-          Expression:
-            Type: 146 GoMapType map[[4]int][4]int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 72, index: 0, name: m}
-                  Offset: 0
-                  ByteSize: 8
-    - __kind: EventRootType
-      ID: 287
-      Name: Probe[main.testCombinedByte]
-      ByteSize: 7
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: w
-          Offset: 1
-          Expression:
-            Type: 4 BaseType uint8
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 73, index: 0, name: w}
-                  Offset: 0
-                  ByteSize: 1
         - Name: x
-          Offset: 2
+          Offset: 1
           Expression:
-            Type: 4 BaseType uint8
+            Type: 8 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 73, index: 1, name: x}
+                  Variable: {subprogram: 100, index: 0, name: x}
                   Offset: 0
-                  ByteSize: 1
-        - Name: y
-          Offset: 3
-          Expression:
-            Type: 30 BaseType float32
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 73, index: 2, name: y}
-                  Offset: 0
-                  ByteSize: 4
+                  ByteSize: 16
     - __kind: EventRootType
       ID: 288
       Name: Probe[main.testMultipleSimpleParams]
@@ -6321,111 +4333,6 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 289
-      Name: Probe[main.testChannel]
-      ByteSize: 1
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: c
-          Offset: 1
-          Expression:
-            Type: 151 GoChannelType chan bool
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 75, index: 0, name: c}
-                  Offset: 0
-                  ByteSize: 0
-    - __kind: EventRootType
-      ID: 290
-      Name: Probe[main.testPointerToSimpleStruct]
-      ByteSize: 9
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: a
-          Offset: 1
-          Expression:
-            Type: 152 PointerType *main.structWithTwoValues
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 76, index: 0, name: a}
-                  Offset: 0
-                  ByteSize: 8
-    - __kind: EventRootType
-      ID: 291
-      Name: Probe[main.testLinkedList]
-      ByteSize: 17
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: a
-          Offset: 1
-          Expression:
-            Type: 119 StructureType main.node
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 77, index: 0, name: a}
-                  Offset: 0
-                  ByteSize: 16
-    - __kind: EventRootType
-      ID: 292
-      Name: Probe[main.testPointerLoop]
-      ByteSize: 9
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: a
-          Offset: 1
-          Expression:
-            Type: 120 PointerType *main.node
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 78, index: 0, name: a}
-                  Offset: 0
-                  ByteSize: 8
-    - __kind: EventRootType
-      ID: 293
-      Name: Probe[main.testUnsafePointer]
-      ByteSize: 9
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: x
-          Offset: 1
-          Expression:
-            Type: 38 VoidPointerType unsafe.Pointer
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 79, index: 0, name: x}
-                  Offset: 0
-                  ByteSize: 8
-    - __kind: EventRootType
-      ID: 294
-      Name: Probe[main.testUintPointer]
-      ByteSize: 9
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: x
-          Offset: 1
-          Expression:
-            Type: 154 PointerType *uint
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 80, index: 0, name: x}
-                  Offset: 0
-                  ByteSize: 8
-    - __kind: EventRootType
-      ID: 295
-      Name: Probe[main.testStringPointer]
-      ByteSize: 9
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: z
-          Offset: 1
-          Expression:
-            Type: 36 PointerType *string
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 81, index: 0, name: z}
-                  Offset: 0
-                  ByteSize: 8
-    - __kind: EventRootType
       ID: 296
       Name: Probe[main.testNilPointer]
       ByteSize: 17
@@ -6447,114 +4354,6 @@ Types:
             Operations:
                 - __kind: LocationOp
                   Variable: {subprogram: 82, index: 1, name: a}
-                  Offset: 0
-                  ByteSize: 8
-    - __kind: EventRootType
-      ID: 297
-      Name: Probe[main.testCycle]
-      ByteSize: 9
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: t
-          Offset: 1
-          Expression:
-            Type: 156 PointerType *main.t
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 83, index: 0, name: t}
-                  Offset: 0
-                  ByteSize: 8
-    - __kind: EventRootType
-      ID: 298
-      Name: Probe[main.testUintSlice]
-      ByteSize: 25
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: u
-          Offset: 1
-          Expression:
-            Type: 159 GoSliceHeaderType []uint
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 84, index: 0, name: u}
-                  Offset: 0
-                  ByteSize: 24
-    - __kind: EventRootType
-      ID: 299
-      Name: Probe[main.testEmptySlice]
-      ByteSize: 25
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: u
-          Offset: 1
-          Expression:
-            Type: 159 GoSliceHeaderType []uint
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 85, index: 0, name: u}
-                  Offset: 0
-                  ByteSize: 24
-    - __kind: EventRootType
-      ID: 300
-      Name: Probe[main.testSliceOfSlices]
-      ByteSize: 25
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: u
-          Offset: 1
-          Expression:
-            Type: 160 GoSliceHeaderType [][]uint
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 86, index: 0, name: u}
-                  Offset: 0
-                  ByteSize: 24
-    - __kind: EventRootType
-      ID: 301
-      Name: Probe[main.testStructSlice]
-      ByteSize: 33
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: xs
-          Offset: 1
-          Expression:
-            Type: 162 GoSliceHeaderType []main.structWithNoStrings
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 87, index: 0, name: xs}
-                  Offset: 0
-                  ByteSize: 24
-        - Name: a
-          Offset: 25
-          Expression:
-            Type: 1 BaseType int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 87, index: 1, name: a}
-                  Offset: 0
-                  ByteSize: 8
-    - __kind: EventRootType
-      ID: 302
-      Name: Probe[main.testEmptySliceOfStructs]
-      ByteSize: 33
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: xs
-          Offset: 1
-          Expression:
-            Type: 162 GoSliceHeaderType []main.structWithNoStrings
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 88, index: 0, name: xs}
-                  Offset: 0
-                  ByteSize: 24
-        - Name: a
-          Offset: 25
-          Expression:
-            Type: 1 BaseType int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 88, index: 1, name: a}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
@@ -6581,21 +4380,6 @@ Types:
                   Variable: {subprogram: 89, index: 1, name: a}
                   Offset: 0
                   ByteSize: 8
-    - __kind: EventRootType
-      ID: 304
-      Name: Probe[main.testStringSlice]
-      ByteSize: 25
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: s
-          Offset: 1
-          Expression:
-            Type: 93 GoSliceHeaderType []string
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 90, index: 0, name: s}
-                  Offset: 0
-                  ByteSize: 24
     - __kind: EventRootType
       ID: 305
       Name: Probe[main.testNilSliceWithOtherParams]
@@ -6645,23 +4429,230 @@ Types:
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 307
-      Name: Probe[main.testVeryLargeSlice]
-      ByteSize: 25
+      ID: 313
+      Name: Probe[main.testOneStringInStructPointer]
+      ByteSize: 9
       PresenceBitsetSize: 1
       Expressions:
-        - Name: xs
+        - Name: a
           Offset: 1
           Expression:
-            Type: 159 GoSliceHeaderType []uint
+            Type: 170 PointerType *main.oneStringStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 93, index: 0, name: xs}
+                  Variable: {subprogram: 99, index: 0, name: a}
                   Offset: 0
-                  ByteSize: 24
+                  ByteSize: 8
     - __kind: EventRootType
-      ID: 308
-      Name: Probe[main.stackC]
+      ID: 292
+      Name: Probe[main.testPointerLoop]
+      ByteSize: 9
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: a
+          Offset: 1
+          Expression:
+            Type: 120 PointerType *main.node
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 78, index: 0, name: a}
+                  Offset: 0
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 274
+      Name: Probe[main.testPointerToMap]
+      ByteSize: 9
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: m
+          Offset: 1
+          Expression:
+            Type: 103 PointerType *map[string]int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 60, index: 0, name: m}
+                  Offset: 0
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 290
+      Name: Probe[main.testPointerToSimpleStruct]
+      ByteSize: 9
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: a
+          Offset: 1
+          Expression:
+            Type: 152 PointerType *main.structWithTwoValues
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 76, index: 0, name: a}
+                  Offset: 0
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 222
+      Name: Probe[main.testRuneArray]
+      ByteSize: 9
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: x
+          Offset: 1
+          Expression:
+            Type: 5 ArrayType [2]int32
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 8, index: 0, name: x}
+                  Offset: 0
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 241
+      Name: Probe[main.testSingleBool]
+      ByteSize: 2
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: x
+          Offset: 1
+          Expression:
+            Type: 11 BaseType bool
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 27, index: 0, name: x}
+                  Offset: 0
+                  ByteSize: 1
+    - __kind: EventRootType
+      ID: 239
+      Name: Probe[main.testSingleByte]
+      ByteSize: 2
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: x
+          Offset: 1
+          Expression:
+            Type: 4 BaseType uint8
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 25, index: 0, name: x}
+                  Offset: 0
+                  ByteSize: 1
+    - __kind: EventRootType
+      ID: 252
+      Name: Probe[main.testSingleFloat32]
+      ByteSize: 5
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: x
+          Offset: 1
+          Expression:
+            Type: 30 BaseType float32
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 38, index: 0, name: x}
+                  Offset: 0
+                  ByteSize: 4
+    - __kind: EventRootType
+      ID: 253
+      Name: Probe[main.testSingleFloat64]
+      ByteSize: 9
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: x
+          Offset: 1
+          Expression:
+            Type: 31 BaseType float64
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 39, index: 0, name: x}
+                  Offset: 0
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 244
+      Name: Probe[main.testSingleInt16]
+      ByteSize: 3
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: x
+          Offset: 1
+          Expression:
+            Type: 16 BaseType int16
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 30, index: 0, name: x}
+                  Offset: 0
+                  ByteSize: 2
+    - __kind: EventRootType
+      ID: 245
+      Name: Probe[main.testSingleInt32]
+      ByteSize: 5
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: x
+          Offset: 1
+          Expression:
+            Type: 6 BaseType int32
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 31, index: 0, name: x}
+                  Offset: 0
+                  ByteSize: 4
+    - __kind: EventRootType
+      ID: 246
+      Name: Probe[main.testSingleInt64]
+      ByteSize: 9
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: x
+          Offset: 1
+          Expression:
+            Type: 18 BaseType int64
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 32, index: 0, name: x}
+                  Offset: 0
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 243
+      Name: Probe[main.testSingleInt8]
+      ByteSize: 2
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: x
+          Offset: 1
+          Expression:
+            Type: 14 BaseType int8
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 29, index: 0, name: x}
+                  Offset: 0
+                  ByteSize: 1
+    - __kind: EventRootType
+      ID: 242
+      Name: Probe[main.testSingleInt]
+      ByteSize: 9
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: x
+          Offset: 1
+          Expression:
+            Type: 1 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 28, index: 0, name: x}
+                  Offset: 0
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 240
+      Name: Probe[main.testSingleRune]
+      ByteSize: 5
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: x
+          Offset: 1
+          Expression:
+            Type: 6 BaseType int32
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 26, index: 0, name: x}
+                  Offset: 0
+                  ByteSize: 4
     - __kind: EventRootType
       ID: 309
       Name: Probe[main.testSingleString]
@@ -6677,6 +4668,240 @@ Types:
                   Variable: {subprogram: 95, index: 0, name: x}
                   Offset: 0
                   ByteSize: 16
+    - __kind: EventRootType
+      ID: 249
+      Name: Probe[main.testSingleUint16]
+      ByteSize: 3
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: x
+          Offset: 1
+          Expression:
+            Type: 22 BaseType uint16
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 35, index: 0, name: x}
+                  Offset: 0
+                  ByteSize: 2
+    - __kind: EventRootType
+      ID: 250
+      Name: Probe[main.testSingleUint32]
+      ByteSize: 5
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: x
+          Offset: 1
+          Expression:
+            Type: 24 BaseType uint32
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 36, index: 0, name: x}
+                  Offset: 0
+                  ByteSize: 4
+    - __kind: EventRootType
+      ID: 251
+      Name: Probe[main.testSingleUint64]
+      ByteSize: 9
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: x
+          Offset: 1
+          Expression:
+            Type: 26 BaseType uint64
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 37, index: 0, name: x}
+                  Offset: 0
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 248
+      Name: Probe[main.testSingleUint8]
+      ByteSize: 2
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: x
+          Offset: 1
+          Expression:
+            Type: 4 BaseType uint8
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 34, index: 0, name: x}
+                  Offset: 0
+                  ByteSize: 1
+    - __kind: EventRootType
+      ID: 247
+      Name: Probe[main.testSingleUint]
+      ByteSize: 9
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: x
+          Offset: 1
+          Expression:
+            Type: 20 BaseType uint
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 33, index: 0, name: x}
+                  Offset: 0
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 300
+      Name: Probe[main.testSliceOfSlices]
+      ByteSize: 25
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: u
+          Offset: 1
+          Expression:
+            Type: 160 GoSliceHeaderType [][]uint
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 86, index: 0, name: u}
+                  Offset: 0
+                  ByteSize: 24
+    - __kind: EventRootType
+      ID: 272
+      Name: Probe[main.testSmallMap]
+      ByteSize: 9
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: m
+          Offset: 1
+          Expression:
+            Type: 82 GoMapType map[string]int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 58, index: 0, name: m}
+                  Offset: 0
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 223
+      Name: Probe[main.testStringArray]
+      ByteSize: 33
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: x
+          Offset: 1
+          Expression:
+            Type: 7 ArrayType [2]string
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 9, index: 0, name: x}
+                  Offset: 0
+                  ByteSize: 32
+    - __kind: EventRootType
+      ID: 295
+      Name: Probe[main.testStringPointer]
+      ByteSize: 9
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: z
+          Offset: 1
+          Expression:
+            Type: 36 PointerType *string
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 81, index: 0, name: z}
+                  Offset: 0
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 304
+      Name: Probe[main.testStringSlice]
+      ByteSize: 25
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: s
+          Offset: 1
+          Expression:
+            Type: 93 GoSliceHeaderType []string
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 90, index: 0, name: s}
+                  Offset: 0
+                  ByteSize: 24
+    - __kind: EventRootType
+      ID: 301
+      Name: Probe[main.testStructSlice]
+      ByteSize: 33
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: xs
+          Offset: 1
+          Expression:
+            Type: 162 GoSliceHeaderType []main.structWithNoStrings
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 87, index: 0, name: xs}
+                  Offset: 0
+                  ByteSize: 24
+        - Name: a
+          Offset: 25
+          Expression:
+            Type: 1 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 87, index: 1, name: a}
+                  Offset: 0
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 267
+      Name: Probe[main.testStructWithMap]
+      ByteSize: 9
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: s
+          Offset: 1
+          Expression:
+            Type: 57 StructureType main.structWithMap
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 53, index: 0, name: s}
+                  Offset: 0
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 317
+      Name: Probe[main.testStruct]
+      ByteSize: 57
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: x
+          Offset: 1
+          Expression:
+            Type: 172 StructureType main.aStruct
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 103, index: 0, name: x}
+                  Offset: 0
+                  ByteSize: 56
+    - __kind: EventRootType
+      ID: 312
+      Name: Probe[main.testThreeStringsInStructPointer]
+      ByteSize: 9
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: a
+          Offset: 1
+          Expression:
+            Type: 169 PointerType *main.threeStringStruct
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 98, index: 0, name: a}
+                  Offset: 0
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 311
+      Name: Probe[main.testThreeStringsInStruct]
+      ByteSize: 49
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: a
+          Offset: 1
+          Expression:
+            Type: 168 StructureType main.threeStringStruct
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 97, index: 0, name: a}
+                  Offset: 0
+                  ByteSize: 48
     - __kind: EventRootType
       ID: 310
       Name: Probe[main.testThreeStrings]
@@ -6711,65 +4936,125 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 311
-      Name: Probe[main.testThreeStringsInStruct]
-      ByteSize: 49
+      ID: 254
+      Name: Probe[main.testTypeAlias]
+      ByteSize: 3
       PresenceBitsetSize: 1
       Expressions:
-        - Name: a
+        - Name: x
           Offset: 1
           Expression:
-            Type: 168 StructureType main.threeStringStruct
+            Type: 32 BaseType main.typeAlias
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 97, index: 0, name: a}
+                  Variable: {subprogram: 40, index: 0, name: x}
                   Offset: 0
-                  ByteSize: 48
+                  ByteSize: 2
     - __kind: EventRootType
-      ID: 312
-      Name: Probe[main.testThreeStringsInStructPointer]
+      ID: 232
+      Name: Probe[main.testUint16Array]
+      ByteSize: 5
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: x
+          Offset: 1
+          Expression:
+            Type: 21 ArrayType [2]uint16
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 18, index: 0, name: x}
+                  Offset: 0
+                  ByteSize: 4
+    - __kind: EventRootType
+      ID: 233
+      Name: Probe[main.testUint32Array]
       ByteSize: 9
       PresenceBitsetSize: 1
       Expressions:
-        - Name: a
+        - Name: x
           Offset: 1
           Expression:
-            Type: 169 PointerType *main.threeStringStruct
+            Type: 23 ArrayType [2]uint32
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 98, index: 0, name: a}
+                  Variable: {subprogram: 19, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 313
-      Name: Probe[main.testOneStringInStructPointer]
-      ByteSize: 9
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: a
-          Offset: 1
-          Expression:
-            Type: 170 PointerType *main.oneStringStruct
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 99, index: 0, name: a}
-                  Offset: 0
-                  ByteSize: 8
-    - __kind: EventRootType
-      ID: 314
-      Name: Probe[main.testMassiveString]
+      ID: 234
+      Name: Probe[main.testUint64Array]
       ByteSize: 17
       PresenceBitsetSize: 1
       Expressions:
         - Name: x
           Offset: 1
           Expression:
-            Type: 8 GoStringHeaderType string
+            Type: 25 ArrayType [2]uint64
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 100, index: 0, name: x}
+                  Variable: {subprogram: 20, index: 0, name: x}
                   Offset: 0
                   ByteSize: 16
+    - __kind: EventRootType
+      ID: 231
+      Name: Probe[main.testUint8Array]
+      ByteSize: 3
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: x
+          Offset: 1
+          Expression:
+            Type: 3 ArrayType [2]uint8
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 17, index: 0, name: x}
+                  Offset: 0
+                  ByteSize: 2
+    - __kind: EventRootType
+      ID: 230
+      Name: Probe[main.testUintArray]
+      ByteSize: 17
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: x
+          Offset: 1
+          Expression:
+            Type: 19 ArrayType [2]uint
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 16, index: 0, name: x}
+                  Offset: 0
+                  ByteSize: 16
+    - __kind: EventRootType
+      ID: 294
+      Name: Probe[main.testUintPointer]
+      ByteSize: 9
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: x
+          Offset: 1
+          Expression:
+            Type: 154 PointerType *uint
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 80, index: 0, name: x}
+                  Offset: 0
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 298
+      Name: Probe[main.testUintSlice]
+      ByteSize: 25
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: u
+          Offset: 1
+          Expression:
+            Type: 159 GoSliceHeaderType []uint
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 84, index: 0, name: u}
+                  Offset: 0
+                  ByteSize: 24
     - __kind: EventRootType
       ID: 315
       Name: Probe[main.testUnitializedString]
@@ -6786,104 +5071,1819 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 316
-      Name: Probe[main.testEmptyString]
-      ByteSize: 17
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: x
-          Offset: 1
-          Expression:
-            Type: 8 GoStringHeaderType string
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 102, index: 0, name: x}
-                  Offset: 0
-                  ByteSize: 16
-    - __kind: EventRootType
-      ID: 317
-      Name: Probe[main.testStruct]
-      ByteSize: 57
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: x
-          Offset: 1
-          Expression:
-            Type: 172 StructureType main.aStruct
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 103, index: 0, name: x}
-                  Offset: 0
-                  ByteSize: 56
-    - __kind: EventRootType
-      ID: 318
-      Name: Probe[main.testEmptyStruct]
-      ByteSize: 1
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: e
-          Offset: 1
-          Expression:
-            Type: 173 StructureType main.emptyStruct
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 104, index: 0, name: e}
-                  Offset: 0
-                  ByteSize: 0
-    - __kind: EventRootType
-      ID: 319
-      Name: Probe[main.testInlinedPrint]
+      ID: 293
+      Name: Probe[main.testUnsafePointer]
       ByteSize: 9
       PresenceBitsetSize: 1
       Expressions:
         - Name: x
           Offset: 1
           Expression:
-            Type: 1 BaseType int
+            Type: 38 VoidPointerType unsafe.Pointer
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 1, index: 0, name: x}
+                  Variable: {subprogram: 79, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 320
-      Name: Probe[main.testInlinedBBB]
-    - __kind: EventRootType
-      ID: 321
-      Name: Probe[main.testInlinedBCA]
-    - __kind: EventRootType
-      ID: 322
-      Name: Probe[main.testInlinedBCB]
-    - __kind: EventRootType
-      ID: 323
-      Name: Probe[main.testInlinedSq]
-      ByteSize: 9
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: x
-          Offset: 1
-          Expression:
-            Type: 1 BaseType int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 5, index: 0, name: x}
-                  Offset: 0
-                  ByteSize: 8
-    - __kind: EventRootType
-      ID: 324
-      Name: Probe[main.testInlinedSumArray]
-      ByteSize: 41
+      ID: 238
+      Name: Probe[main.testVeryLargeArray]
+      ByteSize: 801
       PresenceBitsetSize: 1
       Expressions:
         - Name: a
           Offset: 1
           Expression:
-            Type: 2 ArrayType [5]int
+            Type: 29 ArrayType [100]uint
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 6, index: 0, name: a}
+                  Variable: {subprogram: 24, index: 0, name: a}
                   Offset: 0
-                  ByteSize: 40
+                  ByteSize: 800
+    - __kind: EventRootType
+      ID: 307
+      Name: Probe[main.testVeryLargeSlice]
+      ByteSize: 25
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: xs
+          Offset: 1
+          Expression:
+            Type: 159 GoSliceHeaderType []uint
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 93, index: 0, name: xs}
+                  Offset: 0
+                  ByteSize: 24
+    - __kind: ArrayType
+      ID: 29
+      Name: '[100]uint'
+      ByteSize: 800
+      GoKind: 17
+      Count: 100
+      HasCount: true
+      Element: 20 BaseType uint
+    - __kind: ArrayType
+      ID: 28
+      Name: '[2][2][2]int'
+      ByteSize: 64
+      GoKind: 17
+      Count: 2
+      HasCount: true
+      Element: 27 ArrayType [2][2]int
+    - __kind: ArrayType
+      ID: 27
+      Name: '[2][2]int'
+      ByteSize: 32
+      GoKind: 17
+      Count: 2
+      HasCount: true
+      Element: 12 ArrayType [2]int
+    - __kind: ArrayType
+      ID: 10
+      Name: '[2]bool'
+      ByteSize: 2
+      GoKind: 17
+      Count: 2
+      HasCount: true
+      Element: 11 BaseType bool
+    - __kind: ArrayType
+      ID: 12
+      Name: '[2]int'
+      ByteSize: 16
+      GoRuntimeType: 617920
+      GoKind: 17
+      Count: 2
+      HasCount: true
+      Element: 1 BaseType int
+    - __kind: ArrayType
+      ID: 15
+      Name: '[2]int16'
+      ByteSize: 4
+      GoKind: 17
+      Count: 2
+      HasCount: true
+      Element: 16 BaseType int16
+    - __kind: ArrayType
+      ID: 5
+      Name: '[2]int32'
+      ByteSize: 8
+      GoRuntimeType: 619072
+      GoKind: 17
+      Count: 2
+      HasCount: true
+      Element: 6 BaseType int32
+    - __kind: ArrayType
+      ID: 17
+      Name: '[2]int64'
+      ByteSize: 16
+      GoKind: 17
+      Count: 2
+      HasCount: true
+      Element: 18 BaseType int64
+    - __kind: ArrayType
+      ID: 13
+      Name: '[2]int8'
+      ByteSize: 2
+      GoKind: 17
+      Count: 2
+      HasCount: true
+      Element: 14 BaseType int8
+    - __kind: ArrayType
+      ID: 102
+      Name: '[2]map[string]int'
+      ByteSize: 16
+      GoKind: 17
+      Count: 2
+      HasCount: true
+      Element: 82 GoMapType map[string]int
+    - __kind: ArrayType
+      ID: 7
+      Name: '[2]string'
+      ByteSize: 32
+      GoRuntimeType: 619168
+      GoKind: 17
+      Count: 2
+      HasCount: true
+      Element: 8 GoStringHeaderType string
+    - __kind: ArrayType
+      ID: 19
+      Name: '[2]uint'
+      ByteSize: 16
+      GoKind: 17
+      Count: 2
+      HasCount: true
+      Element: 20 BaseType uint
+    - __kind: ArrayType
+      ID: 21
+      Name: '[2]uint16'
+      ByteSize: 4
+      GoKind: 17
+      Count: 2
+      HasCount: true
+      Element: 22 BaseType uint16
+    - __kind: ArrayType
+      ID: 23
+      Name: '[2]uint32'
+      ByteSize: 8
+      GoKind: 17
+      Count: 2
+      HasCount: true
+      Element: 24 BaseType uint32
+    - __kind: ArrayType
+      ID: 25
+      Name: '[2]uint64'
+      ByteSize: 16
+      GoRuntimeType: 619264
+      GoKind: 17
+      Count: 2
+      HasCount: true
+      Element: 26 BaseType uint64
+    - __kind: ArrayType
+      ID: 3
+      Name: '[2]uint8'
+      ByteSize: 2
+      GoRuntimeType: 618976
+      GoKind: 17
+      Count: 2
+      HasCount: true
+      Element: 4 BaseType uint8
+    - __kind: ArrayType
+      ID: 139
+      Name: '[4]int'
+      ByteSize: 32
+      GoRuntimeType: 617536
+      GoKind: 17
+      Count: 4
+      HasCount: true
+      Element: 1 BaseType int
+    - __kind: ArrayType
+      ID: 100
+      Name: '[4]string'
+      ByteSize: 64
+      GoRuntimeType: 617824
+      GoKind: 17
+      Count: 4
+      HasCount: true
+      Element: 8 GoStringHeaderType string
+    - __kind: ArrayType
+      ID: 2
+      Name: '[5]int'
+      ByteSize: 40
+      GoKind: 17
+      Count: 5
+      HasCount: true
+      Element: 1 BaseType int
+    - __kind: ArrayType
+      ID: 63
+      Name: '[8]uint8'
+      ByteSize: 8
+      GoRuntimeType: 615616
+      GoKind: 17
+      Count: 8
+      HasCount: true
+      Element: 4 BaseType uint8
+    - __kind: GoSliceHeaderType
+      ID: 70
+      Name: '[]*runtime.bmap'
+      ByteSize: 24
+      GoRuntimeType: 451744
+      GoKind: 23
+      RawFields:
+        - Name: array
+          Offset: 0
+          Type: 71 PointerType **runtime.bmap
+        - Name: len
+          Offset: 8
+          Type: 1 BaseType int
+        - Name: cap
+          Offset: 16
+          Type: 1 BaseType int
+      Data: 192 GoSliceDataType []*runtime.bmap.array
+    - __kind: GoSliceDataType
+      ID: 192
+      Name: '[]*runtime.bmap.array'
+      ByteSize: 2048
+      Element: 72 PointerType *runtime.bmap
+    - __kind: GoSliceHeaderType
+      ID: 34
+      Name: '[]*string'
+      ByteSize: 24
+      GoRuntimeType: 443360
+      GoKind: 23
+      RawFields:
+        - Name: array
+          Offset: 0
+          Type: 35 PointerType **string
+        - Name: len
+          Offset: 8
+          Type: 1 BaseType int
+        - Name: cap
+          Offset: 16
+          Type: 1 BaseType int
+      Data: 189 GoSliceDataType []*string.array
+    - __kind: GoSliceDataType
+      ID: 189
+      Name: '[]*string.array'
+      ByteSize: 2048
+      Element: 36 PointerType *string
+    - __kind: GoSliceHeaderType
+      ID: 160
+      Name: '[][]uint'
+      ByteSize: 24
+      GoKind: 23
+      RawFields:
+        - Name: array
+          Offset: 0
+          Type: 161 PointerType *[]uint
+        - Name: len
+          Offset: 8
+          Type: 1 BaseType int
+        - Name: cap
+          Offset: 16
+          Type: 1 BaseType int
+      Data: 213 GoSliceDataType [][]uint.array
+    - __kind: GoSliceDataType
+      ID: 213
+      Name: '[][]uint.array'
+      ByteSize: 2048
+      Element: 159 GoSliceHeaderType []uint
+    - __kind: GoSliceHeaderType
+      ID: 165
+      Name: '[]bool'
+      ByteSize: 24
+      GoRuntimeType: 449888
+      GoKind: 23
+      RawFields:
+        - Name: array
+          Offset: 0
+          Type: 155 PointerType *bool
+        - Name: len
+          Offset: 8
+          Type: 1 BaseType int
+        - Name: cap
+          Offset: 16
+          Type: 1 BaseType int
+      Data: 217 GoSliceDataType []bool.array
+    - __kind: GoSliceDataType
+      ID: 217
+      Name: '[]bool.array'
+      ByteSize: 2048
+      Element: 11 BaseType bool
+    - __kind: GoSliceDataType
+      ID: 208
+      Name: '[]bucket<[4]int,[4]int>.array'
+      ByteSize: 2048
+      Element: 150 GoHMapBucketType bucket<[4]int,[4]int>
+    - __kind: GoSliceDataType
+      ID: 207
+      Name: '[]bucket<[4]int,uint8>.array'
+      ByteSize: 2048
+      Element: 144 GoHMapBucketType bucket<[4]int,uint8>
+    - __kind: GoSliceDataType
+      ID: 199
+      Name: '[]bucket<[4]string,[2]int>.array'
+      ByteSize: 2048
+      Element: 98 GoHMapBucketType bucket<[4]string,[2]int>
+    - __kind: GoSliceDataType
+      ID: 203
+      Name: '[]bucket<bool,main.node>.array'
+      ByteSize: 2048
+      Element: 116 GoHMapBucketType bucket<bool,main.node>
+    - __kind: GoSliceDataType
+      ID: 191
+      Name: '[]bucket<int,int>.array'
+      ByteSize: 2048
+      Element: 62 GoHMapBucketType bucket<int,int>
+    - __kind: GoSliceDataType
+      ID: 204
+      Name: '[]bucket<int,uint8>.array'
+      ByteSize: 2048
+      Element: 125 GoHMapBucketType bucket<int,uint8>
+    - __kind: GoSliceDataType
+      ID: 200
+      Name: '[]bucket<string,[]main.structWithMap>.array'
+      ByteSize: 2048
+      Element: 108 GoHMapBucketType bucket<string,[]main.structWithMap>
+    - __kind: GoSliceDataType
+      ID: 196
+      Name: '[]bucket<string,[]string>.array'
+      ByteSize: 2048
+      Element: 91 GoHMapBucketType bucket<string,[]string>
+    - __kind: GoSliceDataType
+      ID: 195
+      Name: '[]bucket<string,int>.array'
+      ByteSize: 2048
+      Element: 86 GoHMapBucketType bucket<string,int>
+    - __kind: GoSliceDataType
+      ID: 194
+      Name: '[]bucket<string,main.nestedStruct>.array'
+      ByteSize: 2048
+      Element: 78 GoHMapBucketType bucket<string,main.nestedStruct>
+    - __kind: GoSliceDataType
+      ID: 206
+      Name: '[]bucket<uint8,[4]int>.array'
+      ByteSize: 2048
+      Element: 137 GoHMapBucketType bucket<uint8,[4]int>
+    - __kind: GoSliceDataType
+      ID: 205
+      Name: '[]bucket<uint8,uint8>.array'
+      ByteSize: 2048
+      Element: 131 GoHMapBucketType bucket<uint8,uint8>
+    - __kind: ArrayType
+      ID: 145
+      Name: '[]key<[4]int>'
+      ByteSize: 256
+      Count: 8
+      HasCount: true
+      Element: 139 ArrayType [4]int
+    - __kind: ArrayType
+      ID: 99
+      Name: '[]key<[4]string>'
+      ByteSize: 512
+      Count: 8
+      HasCount: true
+      Element: 100 ArrayType [4]string
+    - __kind: ArrayType
+      ID: 117
+      Name: '[]key<bool>'
+      ByteSize: 8
+      Count: 8
+      HasCount: true
+      Element: 11 BaseType bool
+    - __kind: ArrayType
+      ID: 64
+      Name: '[]key<int>'
+      ByteSize: 64
+      Count: 8
+      HasCount: true
+      Element: 1 BaseType int
+    - __kind: ArrayType
+      ID: 79
+      Name: '[]key<string>'
+      ByteSize: 128
+      Count: 8
+      HasCount: true
+      Element: 8 GoStringHeaderType string
+    - __kind: ArrayType
+      ID: 132
+      Name: '[]key<uint8>'
+      ByteSize: 8
+      Count: 8
+      HasCount: true
+      Element: 4 BaseType uint8
+    - __kind: GoSliceHeaderType
+      ID: 110
+      Name: '[]main.structWithMap'
+      ByteSize: 24
+      GoRuntimeType: 442848
+      GoKind: 23
+      RawFields:
+        - Name: array
+          Offset: 0
+          Type: 111 PointerType *main.structWithMap
+        - Name: len
+          Offset: 8
+          Type: 1 BaseType int
+        - Name: cap
+          Offset: 16
+          Type: 1 BaseType int
+      Data: 201 GoSliceDataType []main.structWithMap.array
+    - __kind: GoSliceDataType
+      ID: 201
+      Name: '[]main.structWithMap.array'
+      ByteSize: 2048
+      Element: 57 StructureType main.structWithMap
+    - __kind: GoSliceHeaderType
+      ID: 162
+      Name: '[]main.structWithNoStrings'
+      ByteSize: 24
+      GoKind: 23
+      RawFields:
+        - Name: array
+          Offset: 0
+          Type: 163 PointerType *main.structWithNoStrings
+        - Name: len
+          Offset: 8
+          Type: 1 BaseType int
+        - Name: cap
+          Offset: 16
+          Type: 1 BaseType int
+      Data: 215 GoSliceDataType []main.structWithNoStrings.array
+    - __kind: GoSliceDataType
+      ID: 215
+      Name: '[]main.structWithNoStrings.array'
+      ByteSize: 2048
+      Element: 164 StructureType main.structWithNoStrings
+    - __kind: GoSliceHeaderType
+      ID: 93
+      Name: '[]string'
+      ByteSize: 24
+      GoRuntimeType: 450016
+      GoKind: 23
+      RawFields:
+        - Name: array
+          Offset: 0
+          Type: 36 PointerType *string
+        - Name: len
+          Offset: 8
+          Type: 1 BaseType int
+        - Name: cap
+          Offset: 16
+          Type: 1 BaseType int
+      Data: 197 GoSliceDataType []string.array
+    - __kind: GoSliceDataType
+      ID: 197
+      Name: '[]string.array'
+      ByteSize: 2048
+      Element: 8 GoStringHeaderType string
+    - __kind: GoSliceHeaderType
+      ID: 159
+      Name: '[]uint'
+      ByteSize: 24
+      GoRuntimeType: 449504
+      GoKind: 23
+      RawFields:
+        - Name: array
+          Offset: 0
+          Type: 154 PointerType *uint
+        - Name: len
+          Offset: 8
+          Type: 1 BaseType int
+        - Name: cap
+          Offset: 16
+          Type: 1 BaseType int
+      Data: 211 GoSliceDataType []uint.array
+    - __kind: GoSliceDataType
+      ID: 211
+      Name: '[]uint.array'
+      ByteSize: 2048
+      Element: 20 BaseType uint
+    - __kind: GoSliceHeaderType
+      ID: 166
+      Name: '[]uint16'
+      ByteSize: 24
+      GoRuntimeType: 448864
+      GoKind: 23
+      RawFields:
+        - Name: array
+          Offset: 0
+          Type: 167 PointerType *uint16
+        - Name: len
+          Offset: 8
+          Type: 1 BaseType int
+        - Name: cap
+          Offset: 16
+          Type: 1 BaseType int
+      Data: 219 GoSliceDataType []uint16.array
+    - __kind: GoSliceDataType
+      ID: 219
+      Name: '[]uint16.array'
+      ByteSize: 2048
+      Element: 22 BaseType uint16
+    - __kind: ArrayType
+      ID: 101
+      Name: '[]val<[2]int>'
+      ByteSize: 128
+      Count: 8
+      HasCount: true
+      Element: 12 ArrayType [2]int
+    - __kind: ArrayType
+      ID: 138
+      Name: '[]val<[4]int>'
+      ByteSize: 256
+      Count: 8
+      HasCount: true
+      Element: 139 ArrayType [4]int
+    - __kind: ArrayType
+      ID: 109
+      Name: '[]val<[]main.structWithMap>'
+      ByteSize: 192
+      Count: 8
+      HasCount: true
+      Element: 110 GoSliceHeaderType []main.structWithMap
+    - __kind: ArrayType
+      ID: 92
+      Name: '[]val<[]string>'
+      ByteSize: 192
+      Count: 8
+      HasCount: true
+      Element: 93 GoSliceHeaderType []string
+    - __kind: ArrayType
+      ID: 65
+      Name: '[]val<int>'
+      ByteSize: 64
+      Count: 8
+      HasCount: true
+      Element: 1 BaseType int
+    - __kind: ArrayType
+      ID: 80
+      Name: '[]val<main.nestedStruct>'
+      ByteSize: 192
+      Count: 8
+      HasCount: true
+      Element: 81 StructureType main.nestedStruct
+    - __kind: ArrayType
+      ID: 118
+      Name: '[]val<main.node>'
+      ByteSize: 128
+      Count: 8
+      HasCount: true
+      Element: 119 StructureType main.node
+    - __kind: ArrayType
+      ID: 126
+      Name: '[]val<uint8>'
+      ByteSize: 8
+      Count: 8
+      HasCount: true
+      Element: 4 BaseType uint8
+    - __kind: BaseType
+      ID: 11
+      Name: bool
+      ByteSize: 1
+      GoRuntimeType: 528064
+      GoKind: 1
+    - __kind: GoHMapBucketType
+      ID: 150
+      Name: bucket<[4]int,[4]int>
+      ByteSize: 528
+      RawFields:
+        - Name: tophash
+          Offset: 0
+          Type: 63 ArrayType [8]uint8
+        - Name: keys
+          Offset: 8
+          Type: 145 ArrayType []key<[4]int>
+        - Name: values
+          Offset: 264
+          Type: 138 ArrayType []val<[4]int>
+        - Name: overflow
+          Offset: 520
+          Type: 149 PointerType *bucket<[4]int,[4]int>
+      KeyType: 139 ArrayType [4]int
+      ValueType: 139 ArrayType [4]int
+    - __kind: GoHMapBucketType
+      ID: 144
+      Name: bucket<[4]int,uint8>
+      ByteSize: 280
+      RawFields:
+        - Name: tophash
+          Offset: 0
+          Type: 63 ArrayType [8]uint8
+        - Name: keys
+          Offset: 8
+          Type: 145 ArrayType []key<[4]int>
+        - Name: values
+          Offset: 264
+          Type: 126 ArrayType []val<uint8>
+        - Name: overflow
+          Offset: 272
+          Type: 143 PointerType *bucket<[4]int,uint8>
+      KeyType: 139 ArrayType [4]int
+      ValueType: 4 BaseType uint8
+    - __kind: GoHMapBucketType
+      ID: 98
+      Name: bucket<[4]string,[2]int>
+      ByteSize: 656
+      RawFields:
+        - Name: tophash
+          Offset: 0
+          Type: 63 ArrayType [8]uint8
+        - Name: keys
+          Offset: 8
+          Type: 99 ArrayType []key<[4]string>
+        - Name: values
+          Offset: 520
+          Type: 101 ArrayType []val<[2]int>
+        - Name: overflow
+          Offset: 648
+          Type: 97 PointerType *bucket<[4]string,[2]int>
+      KeyType: 100 ArrayType [4]string
+      ValueType: 12 ArrayType [2]int
+    - __kind: GoHMapBucketType
+      ID: 116
+      Name: bucket<bool,main.node>
+      ByteSize: 152
+      RawFields:
+        - Name: tophash
+          Offset: 0
+          Type: 63 ArrayType [8]uint8
+        - Name: keys
+          Offset: 8
+          Type: 117 ArrayType []key<bool>
+        - Name: values
+          Offset: 16
+          Type: 118 ArrayType []val<main.node>
+        - Name: overflow
+          Offset: 144
+          Type: 115 PointerType *bucket<bool,main.node>
+      KeyType: 11 BaseType bool
+      ValueType: 119 StructureType main.node
+    - __kind: GoHMapBucketType
+      ID: 62
+      Name: bucket<int,int>
+      ByteSize: 144
+      RawFields:
+        - Name: tophash
+          Offset: 0
+          Type: 63 ArrayType [8]uint8
+        - Name: keys
+          Offset: 8
+          Type: 64 ArrayType []key<int>
+        - Name: values
+          Offset: 72
+          Type: 65 ArrayType []val<int>
+        - Name: overflow
+          Offset: 136
+          Type: 61 PointerType *bucket<int,int>
+      KeyType: 1 BaseType int
+      ValueType: 1 BaseType int
+    - __kind: GoHMapBucketType
+      ID: 125
+      Name: bucket<int,uint8>
+      ByteSize: 88
+      RawFields:
+        - Name: tophash
+          Offset: 0
+          Type: 63 ArrayType [8]uint8
+        - Name: keys
+          Offset: 8
+          Type: 64 ArrayType []key<int>
+        - Name: values
+          Offset: 72
+          Type: 126 ArrayType []val<uint8>
+        - Name: overflow
+          Offset: 80
+          Type: 124 PointerType *bucket<int,uint8>
+      KeyType: 1 BaseType int
+      ValueType: 4 BaseType uint8
+    - __kind: GoHMapBucketType
+      ID: 108
+      Name: bucket<string,[]main.structWithMap>
+      ByteSize: 336
+      RawFields:
+        - Name: tophash
+          Offset: 0
+          Type: 63 ArrayType [8]uint8
+        - Name: keys
+          Offset: 8
+          Type: 79 ArrayType []key<string>
+        - Name: values
+          Offset: 136
+          Type: 109 ArrayType []val<[]main.structWithMap>
+        - Name: overflow
+          Offset: 328
+          Type: 107 PointerType *bucket<string,[]main.structWithMap>
+      KeyType: 8 GoStringHeaderType string
+      ValueType: 110 GoSliceHeaderType []main.structWithMap
+    - __kind: GoHMapBucketType
+      ID: 91
+      Name: bucket<string,[]string>
+      ByteSize: 336
+      RawFields:
+        - Name: tophash
+          Offset: 0
+          Type: 63 ArrayType [8]uint8
+        - Name: keys
+          Offset: 8
+          Type: 79 ArrayType []key<string>
+        - Name: values
+          Offset: 136
+          Type: 92 ArrayType []val<[]string>
+        - Name: overflow
+          Offset: 328
+          Type: 90 PointerType *bucket<string,[]string>
+      KeyType: 8 GoStringHeaderType string
+      ValueType: 93 GoSliceHeaderType []string
+    - __kind: GoHMapBucketType
+      ID: 86
+      Name: bucket<string,int>
+      ByteSize: 208
+      RawFields:
+        - Name: tophash
+          Offset: 0
+          Type: 63 ArrayType [8]uint8
+        - Name: keys
+          Offset: 8
+          Type: 79 ArrayType []key<string>
+        - Name: values
+          Offset: 136
+          Type: 65 ArrayType []val<int>
+        - Name: overflow
+          Offset: 200
+          Type: 85 PointerType *bucket<string,int>
+      KeyType: 8 GoStringHeaderType string
+      ValueType: 1 BaseType int
+    - __kind: GoHMapBucketType
+      ID: 78
+      Name: bucket<string,main.nestedStruct>
+      ByteSize: 336
+      RawFields:
+        - Name: tophash
+          Offset: 0
+          Type: 63 ArrayType [8]uint8
+        - Name: keys
+          Offset: 8
+          Type: 79 ArrayType []key<string>
+        - Name: values
+          Offset: 136
+          Type: 80 ArrayType []val<main.nestedStruct>
+        - Name: overflow
+          Offset: 328
+          Type: 77 PointerType *bucket<string,main.nestedStruct>
+      KeyType: 8 GoStringHeaderType string
+      ValueType: 81 StructureType main.nestedStruct
+    - __kind: GoHMapBucketType
+      ID: 137
+      Name: bucket<uint8,[4]int>
+      ByteSize: 280
+      RawFields:
+        - Name: tophash
+          Offset: 0
+          Type: 63 ArrayType [8]uint8
+        - Name: keys
+          Offset: 8
+          Type: 132 ArrayType []key<uint8>
+        - Name: values
+          Offset: 16
+          Type: 138 ArrayType []val<[4]int>
+        - Name: overflow
+          Offset: 272
+          Type: 136 PointerType *bucket<uint8,[4]int>
+      KeyType: 4 BaseType uint8
+      ValueType: 139 ArrayType [4]int
+    - __kind: GoHMapBucketType
+      ID: 131
+      Name: bucket<uint8,uint8>
+      ByteSize: 32
+      RawFields:
+        - Name: tophash
+          Offset: 0
+          Type: 63 ArrayType [8]uint8
+        - Name: keys
+          Offset: 8
+          Type: 132 ArrayType []key<uint8>
+        - Name: values
+          Offset: 16
+          Type: 126 ArrayType []val<uint8>
+        - Name: overflow
+          Offset: 24
+          Type: 130 PointerType *bucket<uint8,uint8>
+      KeyType: 4 BaseType uint8
+      ValueType: 4 BaseType uint8
+    - __kind: GoChannelType
+      ID: 151
+      Name: chan bool
+      GoRuntimeType: 539328
+      GoKind: 18
+    - __kind: GoChannelType
+      ID: 40
+      Name: chan struct {}
+      GoRuntimeType: 538240
+      GoKind: 18
+    - __kind: BaseType
+      ID: 178
+      Name: complex128
+      ByteSize: 16
+      GoRuntimeType: 527872
+      GoKind: 16
+    - __kind: BaseType
+      ID: 177
+      Name: complex64
+      ByteSize: 8
+      GoRuntimeType: 527808
+      GoKind: 15
+    - __kind: GoInterfaceType
+      ID: 56
+      Name: error
+      ByteSize: 16
+      GoRuntimeType: 978048
+      GoKind: 20
+      RawFields:
+        - Name: tab
+          Offset: 0
+          Type: 38 VoidPointerType unsafe.Pointer
+        - Name: data
+          Offset: 8
+          Type: 38 VoidPointerType unsafe.Pointer
+    - __kind: BaseType
+      ID: 30
+      Name: float32
+      ByteSize: 4
+      GoRuntimeType: 527936
+      GoKind: 13
+    - __kind: BaseType
+      ID: 31
+      Name: float64
+      ByteSize: 8
+      GoRuntimeType: 528000
+      GoKind: 14
+    - __kind: GoSubroutineType
+      ID: 43
+      Name: func()
+      ByteSize: 8
+      GoRuntimeType: 441952
+      GoKind: 19
+    - __kind: GoHMapHeaderType
+      ID: 148
+      Name: hash<[4]int,[4]int>
+      ByteSize: 48
+      RawFields:
+        - Name: count
+          Offset: 0
+          Type: 1 BaseType int
+        - Name: flags
+          Offset: 8
+          Type: 4 BaseType uint8
+        - Name: B
+          Offset: 9
+          Type: 4 BaseType uint8
+        - Name: noverflow
+          Offset: 10
+          Type: 22 BaseType uint16
+        - Name: hash0
+          Offset: 12
+          Type: 24 BaseType uint32
+        - Name: buckets
+          Offset: 16
+          Type: 149 PointerType *bucket<[4]int,[4]int>
+        - Name: oldbuckets
+          Offset: 24
+          Type: 149 PointerType *bucket<[4]int,[4]int>
+        - Name: nevacuate
+          Offset: 32
+          Type: 66 BaseType uintptr
+        - Name: extra
+          Offset: 40
+          Type: 67 PointerType *runtime.mapextra
+      BucketType: 150 GoHMapBucketType bucket<[4]int,[4]int>
+      BucketsType: 208 GoSliceDataType []bucket<[4]int,[4]int>.array
+    - __kind: GoHMapHeaderType
+      ID: 142
+      Name: hash<[4]int,uint8>
+      ByteSize: 48
+      RawFields:
+        - Name: count
+          Offset: 0
+          Type: 1 BaseType int
+        - Name: flags
+          Offset: 8
+          Type: 4 BaseType uint8
+        - Name: B
+          Offset: 9
+          Type: 4 BaseType uint8
+        - Name: noverflow
+          Offset: 10
+          Type: 22 BaseType uint16
+        - Name: hash0
+          Offset: 12
+          Type: 24 BaseType uint32
+        - Name: buckets
+          Offset: 16
+          Type: 143 PointerType *bucket<[4]int,uint8>
+        - Name: oldbuckets
+          Offset: 24
+          Type: 143 PointerType *bucket<[4]int,uint8>
+        - Name: nevacuate
+          Offset: 32
+          Type: 66 BaseType uintptr
+        - Name: extra
+          Offset: 40
+          Type: 67 PointerType *runtime.mapextra
+      BucketType: 144 GoHMapBucketType bucket<[4]int,uint8>
+      BucketsType: 207 GoSliceDataType []bucket<[4]int,uint8>.array
+    - __kind: GoHMapHeaderType
+      ID: 96
+      Name: hash<[4]string,[2]int>
+      ByteSize: 48
+      RawFields:
+        - Name: count
+          Offset: 0
+          Type: 1 BaseType int
+        - Name: flags
+          Offset: 8
+          Type: 4 BaseType uint8
+        - Name: B
+          Offset: 9
+          Type: 4 BaseType uint8
+        - Name: noverflow
+          Offset: 10
+          Type: 22 BaseType uint16
+        - Name: hash0
+          Offset: 12
+          Type: 24 BaseType uint32
+        - Name: buckets
+          Offset: 16
+          Type: 97 PointerType *bucket<[4]string,[2]int>
+        - Name: oldbuckets
+          Offset: 24
+          Type: 97 PointerType *bucket<[4]string,[2]int>
+        - Name: nevacuate
+          Offset: 32
+          Type: 66 BaseType uintptr
+        - Name: extra
+          Offset: 40
+          Type: 67 PointerType *runtime.mapextra
+      BucketType: 98 GoHMapBucketType bucket<[4]string,[2]int>
+      BucketsType: 199 GoSliceDataType []bucket<[4]string,[2]int>.array
+    - __kind: GoHMapHeaderType
+      ID: 114
+      Name: hash<bool,main.node>
+      ByteSize: 48
+      RawFields:
+        - Name: count
+          Offset: 0
+          Type: 1 BaseType int
+        - Name: flags
+          Offset: 8
+          Type: 4 BaseType uint8
+        - Name: B
+          Offset: 9
+          Type: 4 BaseType uint8
+        - Name: noverflow
+          Offset: 10
+          Type: 22 BaseType uint16
+        - Name: hash0
+          Offset: 12
+          Type: 24 BaseType uint32
+        - Name: buckets
+          Offset: 16
+          Type: 115 PointerType *bucket<bool,main.node>
+        - Name: oldbuckets
+          Offset: 24
+          Type: 115 PointerType *bucket<bool,main.node>
+        - Name: nevacuate
+          Offset: 32
+          Type: 66 BaseType uintptr
+        - Name: extra
+          Offset: 40
+          Type: 67 PointerType *runtime.mapextra
+      BucketType: 116 GoHMapBucketType bucket<bool,main.node>
+      BucketsType: 203 GoSliceDataType []bucket<bool,main.node>.array
+    - __kind: GoHMapHeaderType
+      ID: 60
+      Name: hash<int,int>
+      ByteSize: 48
+      RawFields:
+        - Name: count
+          Offset: 0
+          Type: 1 BaseType int
+        - Name: flags
+          Offset: 8
+          Type: 4 BaseType uint8
+        - Name: B
+          Offset: 9
+          Type: 4 BaseType uint8
+        - Name: noverflow
+          Offset: 10
+          Type: 22 BaseType uint16
+        - Name: hash0
+          Offset: 12
+          Type: 24 BaseType uint32
+        - Name: buckets
+          Offset: 16
+          Type: 61 PointerType *bucket<int,int>
+        - Name: oldbuckets
+          Offset: 24
+          Type: 61 PointerType *bucket<int,int>
+        - Name: nevacuate
+          Offset: 32
+          Type: 66 BaseType uintptr
+        - Name: extra
+          Offset: 40
+          Type: 67 PointerType *runtime.mapextra
+      BucketType: 62 GoHMapBucketType bucket<int,int>
+      BucketsType: 191 GoSliceDataType []bucket<int,int>.array
+    - __kind: GoHMapHeaderType
+      ID: 123
+      Name: hash<int,uint8>
+      ByteSize: 48
+      RawFields:
+        - Name: count
+          Offset: 0
+          Type: 1 BaseType int
+        - Name: flags
+          Offset: 8
+          Type: 4 BaseType uint8
+        - Name: B
+          Offset: 9
+          Type: 4 BaseType uint8
+        - Name: noverflow
+          Offset: 10
+          Type: 22 BaseType uint16
+        - Name: hash0
+          Offset: 12
+          Type: 24 BaseType uint32
+        - Name: buckets
+          Offset: 16
+          Type: 124 PointerType *bucket<int,uint8>
+        - Name: oldbuckets
+          Offset: 24
+          Type: 124 PointerType *bucket<int,uint8>
+        - Name: nevacuate
+          Offset: 32
+          Type: 66 BaseType uintptr
+        - Name: extra
+          Offset: 40
+          Type: 67 PointerType *runtime.mapextra
+      BucketType: 125 GoHMapBucketType bucket<int,uint8>
+      BucketsType: 204 GoSliceDataType []bucket<int,uint8>.array
+    - __kind: GoHMapHeaderType
+      ID: 106
+      Name: hash<string,[]main.structWithMap>
+      ByteSize: 48
+      RawFields:
+        - Name: count
+          Offset: 0
+          Type: 1 BaseType int
+        - Name: flags
+          Offset: 8
+          Type: 4 BaseType uint8
+        - Name: B
+          Offset: 9
+          Type: 4 BaseType uint8
+        - Name: noverflow
+          Offset: 10
+          Type: 22 BaseType uint16
+        - Name: hash0
+          Offset: 12
+          Type: 24 BaseType uint32
+        - Name: buckets
+          Offset: 16
+          Type: 107 PointerType *bucket<string,[]main.structWithMap>
+        - Name: oldbuckets
+          Offset: 24
+          Type: 107 PointerType *bucket<string,[]main.structWithMap>
+        - Name: nevacuate
+          Offset: 32
+          Type: 66 BaseType uintptr
+        - Name: extra
+          Offset: 40
+          Type: 67 PointerType *runtime.mapextra
+      BucketType: 108 GoHMapBucketType bucket<string,[]main.structWithMap>
+      BucketsType: 200 GoSliceDataType []bucket<string,[]main.structWithMap>.array
+    - __kind: GoHMapHeaderType
+      ID: 89
+      Name: hash<string,[]string>
+      ByteSize: 48
+      RawFields:
+        - Name: count
+          Offset: 0
+          Type: 1 BaseType int
+        - Name: flags
+          Offset: 8
+          Type: 4 BaseType uint8
+        - Name: B
+          Offset: 9
+          Type: 4 BaseType uint8
+        - Name: noverflow
+          Offset: 10
+          Type: 22 BaseType uint16
+        - Name: hash0
+          Offset: 12
+          Type: 24 BaseType uint32
+        - Name: buckets
+          Offset: 16
+          Type: 90 PointerType *bucket<string,[]string>
+        - Name: oldbuckets
+          Offset: 24
+          Type: 90 PointerType *bucket<string,[]string>
+        - Name: nevacuate
+          Offset: 32
+          Type: 66 BaseType uintptr
+        - Name: extra
+          Offset: 40
+          Type: 67 PointerType *runtime.mapextra
+      BucketType: 91 GoHMapBucketType bucket<string,[]string>
+      BucketsType: 196 GoSliceDataType []bucket<string,[]string>.array
+    - __kind: GoHMapHeaderType
+      ID: 84
+      Name: hash<string,int>
+      ByteSize: 48
+      RawFields:
+        - Name: count
+          Offset: 0
+          Type: 1 BaseType int
+        - Name: flags
+          Offset: 8
+          Type: 4 BaseType uint8
+        - Name: B
+          Offset: 9
+          Type: 4 BaseType uint8
+        - Name: noverflow
+          Offset: 10
+          Type: 22 BaseType uint16
+        - Name: hash0
+          Offset: 12
+          Type: 24 BaseType uint32
+        - Name: buckets
+          Offset: 16
+          Type: 85 PointerType *bucket<string,int>
+        - Name: oldbuckets
+          Offset: 24
+          Type: 85 PointerType *bucket<string,int>
+        - Name: nevacuate
+          Offset: 32
+          Type: 66 BaseType uintptr
+        - Name: extra
+          Offset: 40
+          Type: 67 PointerType *runtime.mapextra
+      BucketType: 86 GoHMapBucketType bucket<string,int>
+      BucketsType: 195 GoSliceDataType []bucket<string,int>.array
+    - __kind: GoHMapHeaderType
+      ID: 76
+      Name: hash<string,main.nestedStruct>
+      ByteSize: 48
+      RawFields:
+        - Name: count
+          Offset: 0
+          Type: 1 BaseType int
+        - Name: flags
+          Offset: 8
+          Type: 4 BaseType uint8
+        - Name: B
+          Offset: 9
+          Type: 4 BaseType uint8
+        - Name: noverflow
+          Offset: 10
+          Type: 22 BaseType uint16
+        - Name: hash0
+          Offset: 12
+          Type: 24 BaseType uint32
+        - Name: buckets
+          Offset: 16
+          Type: 77 PointerType *bucket<string,main.nestedStruct>
+        - Name: oldbuckets
+          Offset: 24
+          Type: 77 PointerType *bucket<string,main.nestedStruct>
+        - Name: nevacuate
+          Offset: 32
+          Type: 66 BaseType uintptr
+        - Name: extra
+          Offset: 40
+          Type: 67 PointerType *runtime.mapextra
+      BucketType: 78 GoHMapBucketType bucket<string,main.nestedStruct>
+      BucketsType: 194 GoSliceDataType []bucket<string,main.nestedStruct>.array
+    - __kind: GoHMapHeaderType
+      ID: 135
+      Name: hash<uint8,[4]int>
+      ByteSize: 48
+      RawFields:
+        - Name: count
+          Offset: 0
+          Type: 1 BaseType int
+        - Name: flags
+          Offset: 8
+          Type: 4 BaseType uint8
+        - Name: B
+          Offset: 9
+          Type: 4 BaseType uint8
+        - Name: noverflow
+          Offset: 10
+          Type: 22 BaseType uint16
+        - Name: hash0
+          Offset: 12
+          Type: 24 BaseType uint32
+        - Name: buckets
+          Offset: 16
+          Type: 136 PointerType *bucket<uint8,[4]int>
+        - Name: oldbuckets
+          Offset: 24
+          Type: 136 PointerType *bucket<uint8,[4]int>
+        - Name: nevacuate
+          Offset: 32
+          Type: 66 BaseType uintptr
+        - Name: extra
+          Offset: 40
+          Type: 67 PointerType *runtime.mapextra
+      BucketType: 137 GoHMapBucketType bucket<uint8,[4]int>
+      BucketsType: 206 GoSliceDataType []bucket<uint8,[4]int>.array
+    - __kind: GoHMapHeaderType
+      ID: 129
+      Name: hash<uint8,uint8>
+      ByteSize: 48
+      RawFields:
+        - Name: count
+          Offset: 0
+          Type: 1 BaseType int
+        - Name: flags
+          Offset: 8
+          Type: 4 BaseType uint8
+        - Name: B
+          Offset: 9
+          Type: 4 BaseType uint8
+        - Name: noverflow
+          Offset: 10
+          Type: 22 BaseType uint16
+        - Name: hash0
+          Offset: 12
+          Type: 24 BaseType uint32
+        - Name: buckets
+          Offset: 16
+          Type: 130 PointerType *bucket<uint8,uint8>
+        - Name: oldbuckets
+          Offset: 24
+          Type: 130 PointerType *bucket<uint8,uint8>
+        - Name: nevacuate
+          Offset: 32
+          Type: 66 BaseType uintptr
+        - Name: extra
+          Offset: 40
+          Type: 67 PointerType *runtime.mapextra
+      BucketType: 131 GoHMapBucketType bucket<uint8,uint8>
+      BucketsType: 205 GoSliceDataType []bucket<uint8,uint8>.array
+    - __kind: BaseType
+      ID: 1
+      Name: int
+      ByteSize: 8
+      GoRuntimeType: 527616
+      GoKind: 2
+    - __kind: BaseType
+      ID: 16
+      Name: int16
+      ByteSize: 2
+      GoRuntimeType: 527232
+      GoKind: 4
+    - __kind: BaseType
+      ID: 6
+      Name: int32
+      ByteSize: 4
+      GoRuntimeType: 527360
+      GoKind: 5
+    - __kind: BaseType
+      ID: 18
+      Name: int64
+      ByteSize: 8
+      GoRuntimeType: 527488
+      GoKind: 6
+    - __kind: BaseType
+      ID: 14
+      Name: int8
+      ByteSize: 1
+      GoRuntimeType: 527104
+      GoKind: 3
+    - __kind: GoEmptyInterfaceType
+      ID: 41
+      Name: interface {}
+      ByteSize: 16
+      GoRuntimeType: 772480
+      GoKind: 20
+      RawFields:
+        - Name: _type
+          Offset: 0
+          Type: 38 VoidPointerType unsafe.Pointer
+        - Name: data
+          Offset: 8
+          Type: 38 VoidPointerType unsafe.Pointer
+    - __kind: GoInterfaceType
+      ID: 37
+      Name: io.Writer
+      ByteSize: 16
+      GoRuntimeType: 973952
+      GoKind: 20
+      RawFields:
+        - Name: tab
+          Offset: 0
+          Type: 38 VoidPointerType unsafe.Pointer
+        - Name: data
+          Offset: 8
+          Type: 38 VoidPointerType unsafe.Pointer
+    - __kind: StructureType
+      ID: 172
+      Name: main.aStruct
+      ByteSize: 56
+      GoKind: 25
+      RawFields:
+        - Name: aBool
+          Offset: 0
+          Type: 11 BaseType bool
+        - Name: aString
+          Offset: 8
+          Type: 8 GoStringHeaderType string
+        - Name: aNumber
+          Offset: 24
+          Type: 1 BaseType int
+        - Name: nested
+          Offset: 32
+          Type: 81 StructureType main.nestedStruct
+    - __kind: GoInterfaceType
+      ID: 55
+      Name: main.behavior
+      ByteSize: 16
+      GoRuntimeType: 973568
+      GoKind: 20
+      RawFields:
+        - Name: tab
+          Offset: 0
+          Type: 38 VoidPointerType unsafe.Pointer
+        - Name: data
+          Offset: 8
+          Type: 38 VoidPointerType unsafe.Pointer
+    - __kind: StructureType
+      ID: 33
+      Name: main.bigStruct
+      ByteSize: 48
+      GoKind: 25
+      RawFields:
+        - Name: x
+          Offset: 0
+          Type: 34 GoSliceHeaderType []*string
+        - Name: z
+          Offset: 24
+          Type: 1 BaseType int
+        - Name: writer
+          Offset: 32
+          Type: 37 GoInterfaceType io.Writer
+    - __kind: StructureType
+      ID: 173
+      Name: main.emptyStruct
+      GoKind: 25
+      RawFields: []
+    - __kind: StructureType
+      ID: 45
+      Name: main.esotericHeap
+      ByteSize: 112
+      GoRuntimeType: 1.69296e+06
+      GoKind: 25
+      RawFields:
+        - Name: esotericStack
+          Offset: 0
+          Type: 39 StructureType main.esotericStack
+        - Name: mu
+          Offset: 64
+          Type: 46 StructureType sync.Mutex
+        - Name: once
+          Offset: 72
+          Type: 47 StructureType sync.Once
+        - Name: wg
+          Offset: 88
+          Type: 50 StructureType sync.WaitGroup
+        - Name: a
+          Offset: 104
+          Type: 54 StructureType sync/atomic.Int32
+    - __kind: StructureType
+      ID: 39
+      Name: main.esotericStack
+      ByteSize: 64
+      GoRuntimeType: 1.819424e+06
+      GoKind: 25
+      RawFields:
+        - Name: _
+          Offset: 0
+          Type: 6 BaseType int32
+        - Name: _valid
+          Offset: 4
+          Type: 6 BaseType int32
+        - Name: c
+          Offset: 8
+          Type: 40 GoChannelType chan struct {}
+        - Name: val
+          Offset: 16
+          Type: 41 GoEmptyInterfaceType interface {}
+        - Name: _
+          Offset: 32
+          Type: 26 BaseType uint64
+        - Name: work
+          Offset: 40
+          Type: 42 GoInterfaceType main.something
+        - Name: foo
+          Offset: 56
+          Type: 43 GoSubroutineType func()
+    - __kind: StructureType
+      ID: 81
+      Name: main.nestedStruct
+      ByteSize: 24
+      GoRuntimeType: 1.270208e+06
+      GoKind: 25
+      RawFields:
+        - Name: anotherInt
+          Offset: 0
+          Type: 1 BaseType int
+        - Name: anotherString
+          Offset: 8
+          Type: 8 GoStringHeaderType string
+    - __kind: StructureType
+      ID: 119
+      Name: main.node
+      ByteSize: 16
+      GoRuntimeType: 1.270048e+06
+      GoKind: 25
+      RawFields:
+        - Name: val
+          Offset: 0
+          Type: 1 BaseType int
+        - Name: b
+          Offset: 8
+          Type: 120 PointerType *main.node
+    - __kind: StructureType
+      ID: 171
+      Name: main.oneStringStruct
+      ByteSize: 16
+      GoKind: 25
+      RawFields:
+        - Name: a
+          Offset: 0
+          Type: 8 GoStringHeaderType string
+    - __kind: GoInterfaceType
+      ID: 42
+      Name: main.something
+      ByteSize: 16
+      GoRuntimeType: 973696
+      GoKind: 20
+      RawFields:
+        - Name: tab
+          Offset: 0
+          Type: 38 VoidPointerType unsafe.Pointer
+        - Name: data
+          Offset: 8
+          Type: 38 VoidPointerType unsafe.Pointer
+    - __kind: StructureType
+      ID: 57
+      Name: main.structWithMap
+      ByteSize: 8
+      GoRuntimeType: 1.09264e+06
+      GoKind: 25
+      RawFields:
+        - Name: m
+          Offset: 0
+          Type: 58 GoMapType map[int]int
+    - __kind: StructureType
+      ID: 164
+      Name: main.structWithNoStrings
+      ByteSize: 2
+      GoKind: 25
+      RawFields:
+        - Name: aUint8
+          Offset: 0
+          Type: 4 BaseType uint8
+        - Name: aBool
+          Offset: 1
+          Type: 11 BaseType bool
+    - __kind: StructureType
+      ID: 153
+      Name: main.structWithTwoValues
+      ByteSize: 16
+      GoKind: 25
+      RawFields:
+        - Name: a
+          Offset: 0
+          Type: 20 BaseType uint
+        - Name: b
+          Offset: 8
+          Type: 11 BaseType bool
+    - __kind: GoSliceHeaderType
+      ID: 157
+      Name: main.t
+      ByteSize: 24
+      GoKind: 23
+      RawFields:
+        - Name: array
+          Offset: 0
+          Type: 158 PointerType **main.t
+        - Name: len
+          Offset: 8
+          Type: 1 BaseType int
+        - Name: cap
+          Offset: 16
+          Type: 1 BaseType int
+      Data: 209 GoSliceDataType main.t.array
+    - __kind: GoSliceDataType
+      ID: 209
+      Name: main.t.array
+      ByteSize: 2048
+      Element: 156 PointerType *main.t
+    - __kind: StructureType
+      ID: 168
+      Name: main.threeStringStruct
+      ByteSize: 48
+      GoKind: 25
+      RawFields:
+        - Name: a
+          Offset: 0
+          Type: 8 GoStringHeaderType string
+        - Name: b
+          Offset: 16
+          Type: 8 GoStringHeaderType string
+        - Name: c
+          Offset: 32
+          Type: 8 GoStringHeaderType string
+    - __kind: BaseType
+      ID: 32
+      Name: main.typeAlias
+      ByteSize: 2
+      GoKind: 9
+    - __kind: GoMapType
+      ID: 146
+      Name: map[[4]int][4]int
+      ByteSize: 8
+      GoRuntimeType: 873952
+      GoKind: 21
+      HeaderType: 148 GoHMapHeaderType hash<[4]int,[4]int>
+    - __kind: GoMapType
+      ID: 140
+      Name: map[[4]int]uint8
+      ByteSize: 8
+      GoRuntimeType: 874048
+      GoKind: 21
+      HeaderType: 142 GoHMapHeaderType hash<[4]int,uint8>
+    - __kind: GoMapType
+      ID: 94
+      Name: map[[4]string][2]int
+      ByteSize: 8
+      GoRuntimeType: 874144
+      GoKind: 21
+      HeaderType: 96 GoHMapHeaderType hash<[4]string,[2]int>
+    - __kind: GoMapType
+      ID: 112
+      Name: map[bool]main.node
+      ByteSize: 8
+      GoRuntimeType: 874240
+      GoKind: 21
+      HeaderType: 114 GoHMapHeaderType hash<bool,main.node>
+    - __kind: GoMapType
+      ID: 58
+      Name: map[int]int
+      ByteSize: 8
+      GoRuntimeType: 872992
+      GoKind: 21
+      HeaderType: 60 GoHMapHeaderType hash<int,int>
+    - __kind: GoMapType
+      ID: 121
+      Name: map[int]uint8
+      ByteSize: 8
+      GoRuntimeType: 874336
+      GoKind: 21
+      HeaderType: 123 GoHMapHeaderType hash<int,uint8>
+    - __kind: GoMapType
+      ID: 104
+      Name: map[string][]main.structWithMap
+      ByteSize: 8
+      GoRuntimeType: 874432
+      GoKind: 21
+      HeaderType: 106 GoHMapHeaderType hash<string,[]main.structWithMap>
+    - __kind: GoMapType
+      ID: 87
+      Name: map[string][]string
+      ByteSize: 8
+      GoRuntimeType: 874528
+      GoKind: 21
+      HeaderType: 89 GoHMapHeaderType hash<string,[]string>
+    - __kind: GoMapType
+      ID: 82
+      Name: map[string]int
+      ByteSize: 8
+      GoRuntimeType: 874624
+      GoKind: 21
+      HeaderType: 84 GoHMapHeaderType hash<string,int>
+    - __kind: GoMapType
+      ID: 74
+      Name: map[string]main.nestedStruct
+      ByteSize: 8
+      GoRuntimeType: 874720
+      GoKind: 21
+      HeaderType: 76 GoHMapHeaderType hash<string,main.nestedStruct>
+    - __kind: GoMapType
+      ID: 133
+      Name: map[uint8][4]int
+      ByteSize: 8
+      GoRuntimeType: 874816
+      GoKind: 21
+      HeaderType: 135 GoHMapHeaderType hash<uint8,[4]int>
+    - __kind: GoMapType
+      ID: 127
+      Name: map[uint8]uint8
+      ByteSize: 8
+      GoRuntimeType: 874912
+      GoKind: 21
+      HeaderType: 129 GoHMapHeaderType hash<uint8,uint8>
+    - __kind: StructureType
+      ID: 73
+      Name: runtime.bmap
+      ByteSize: 8
+      GoRuntimeType: 1.10096e+06
+      GoKind: 25
+      RawFields:
+        - Name: tophash
+          Offset: 0
+          Type: 63 ArrayType [8]uint8
+    - __kind: StructureType
+      ID: 68
+      Name: runtime.mapextra
+      ByteSize: 24
+      GoRuntimeType: 1.417408e+06
+      GoKind: 25
+      RawFields:
+        - Name: overflow
+          Offset: 0
+          Type: 69 PointerType *[]*runtime.bmap
+        - Name: oldoverflow
+          Offset: 8
+          Type: 69 PointerType *[]*runtime.bmap
+        - Name: nextOverflow
+          Offset: 16
+          Type: 72 PointerType *runtime.bmap
+    - __kind: GoStringHeaderType
+      ID: 8
+      Name: string
+      ByteSize: 16
+      GoRuntimeType: 527040
+      GoKind: 24
+      RawFields:
+        - Name: str
+          Offset: 0
+          Type: 188 PointerType *string.str
+        - Name: len
+          Offset: 8
+          Type: 1 BaseType int
+      Data: 187 GoStringDataType string.str
+    - __kind: GoStringDataType
+      ID: 187
+      Name: string.str
+      ByteSize: 2048
+    - __kind: StructureType
+      ID: 46
+      Name: sync.Mutex
+      ByteSize: 8
+      GoRuntimeType: 1.271488e+06
+      GoKind: 25
+      RawFields:
+        - Name: state
+          Offset: 0
+          Type: 6 BaseType int32
+        - Name: sema
+          Offset: 4
+          Type: 24 BaseType uint32
+    - __kind: StructureType
+      ID: 47
+      Name: sync.Once
+      ByteSize: 12
+      GoRuntimeType: 1.272608e+06
+      GoKind: 25
+      RawFields:
+        - Name: done
+          Offset: 0
+          Type: 48 StructureType sync/atomic.Uint32
+        - Name: m
+          Offset: 4
+          Type: 46 StructureType sync.Mutex
+    - __kind: StructureType
+      ID: 50
+      Name: sync.WaitGroup
+      ByteSize: 16
+      GoRuntimeType: 1.411456e+06
+      GoKind: 25
+      RawFields:
+        - Name: noCopy
+          Offset: 0
+          Type: 51 StructureType sync.noCopy
+        - Name: state
+          Offset: 0
+          Type: 52 StructureType sync/atomic.Uint64
+        - Name: sema
+          Offset: 8
+          Type: 24 BaseType uint32
+    - __kind: StructureType
+      ID: 51
+      Name: sync.noCopy
+      GoRuntimeType: 940704
+      GoKind: 25
+      RawFields: []
+    - __kind: StructureType
+      ID: 54
+      Name: sync/atomic.Int32
+      ByteSize: 4
+      GoRuntimeType: 1.272928e+06
+      GoKind: 25
+      RawFields:
+        - Name: _
+          Offset: 0
+          Type: 49 StructureType sync/atomic.noCopy
+        - Name: v
+          Offset: 0
+          Type: 6 BaseType int32
+    - __kind: StructureType
+      ID: 48
+      Name: sync/atomic.Uint32
+      ByteSize: 4
+      GoRuntimeType: 1.273088e+06
+      GoKind: 25
+      RawFields:
+        - Name: _
+          Offset: 0
+          Type: 49 StructureType sync/atomic.noCopy
+        - Name: v
+          Offset: 0
+          Type: 24 BaseType uint32
+    - __kind: StructureType
+      ID: 52
+      Name: sync/atomic.Uint64
+      ByteSize: 8
+      GoRuntimeType: 1.41184e+06
+      GoKind: 25
+      RawFields:
+        - Name: _
+          Offset: 0
+          Type: 49 StructureType sync/atomic.noCopy
+        - Name: _
+          Offset: 0
+          Type: 53 StructureType sync/atomic.align64
+        - Name: v
+          Offset: 0
+          Type: 26 BaseType uint64
+    - __kind: StructureType
+      ID: 53
+      Name: sync/atomic.align64
+      GoRuntimeType: 940896
+      GoKind: 25
+      RawFields: []
+    - __kind: StructureType
+      ID: 49
+      Name: sync/atomic.noCopy
+      GoRuntimeType: 940800
+      GoKind: 25
+      RawFields: []
+    - __kind: BaseType
+      ID: 20
+      Name: uint
+      ByteSize: 8
+      GoRuntimeType: 527680
+      GoKind: 7
+    - __kind: BaseType
+      ID: 22
+      Name: uint16
+      ByteSize: 2
+      GoRuntimeType: 527296
+      GoKind: 9
+    - __kind: BaseType
+      ID: 24
+      Name: uint32
+      ByteSize: 4
+      GoRuntimeType: 527424
+      GoKind: 10
+    - __kind: BaseType
+      ID: 26
+      Name: uint64
+      ByteSize: 8
+      GoRuntimeType: 527552
+      GoKind: 11
+    - __kind: BaseType
+      ID: 4
+      Name: uint8
+      ByteSize: 1
+      GoRuntimeType: 527168
+      GoKind: 8
+    - __kind: BaseType
+      ID: 66
+      Name: uintptr
+      ByteSize: 8
+      GoRuntimeType: 527744
+      GoKind: 12
+    - __kind: VoidPointerType
+      ID: 38
+      Name: unsafe.Pointer
+      ByteSize: 8
+      GoRuntimeType: 528128
+      GoKind: 26
 MaxTypeID: 324
 Issues: []
 GoModuledataInfo: {FirstModuledataAddr: "0x12cd8a0", TypesOffset: 296}

--- a/pkg/dyninst/irgen/testdata/snapshot/sample.arch=arm64,toolchain=go1.23.11.yaml
+++ b/pkg/dyninst/irgen/testdata/snapshot/sample.arch=arm64,toolchain=go1.23.11.yaml
@@ -11,7 +11,7 @@ Probes:
       subprogram: {subprogram: 88}
       events:
         - ID: 88
-          Type: 308 EventRootType Probe[main.stackC]
+          Type: 301 EventRootType Probe[main.stackC]
           InjectionPoints: [{PC: "0x88f5fc", Frameless: true}]
           Condition: null
     - id: testAny
@@ -25,7 +25,7 @@ Probes:
       subprogram: {subprogram: 45}
       events:
         - ID: 45
-          Type: 265 EventRootType Probe[main.testAny]
+          Type: 258 EventRootType Probe[main.testAny]
           InjectionPoints: [{PC: "0x88d16c", Frameless: true}]
           Condition: null
     - id: testArrayOfArrays
@@ -39,7 +39,7 @@ Probes:
       subprogram: {subprogram: 15}
       events:
         - ID: 15
-          Type: 235 EventRootType Probe[main.testArrayOfArrays]
+          Type: 228 EventRootType Probe[main.testArrayOfArrays]
           InjectionPoints: [{PC: "0x88bee0", Frameless: true}]
           Condition: null
     - id: testArrayOfArraysOfArrays
@@ -53,7 +53,7 @@ Probes:
       subprogram: {subprogram: 17}
       events:
         - ID: 17
-          Type: 237 EventRootType Probe[main.testArrayOfArraysOfArrays]
+          Type: 230 EventRootType Probe[main.testArrayOfArraysOfArrays]
           InjectionPoints: [{PC: "0x88bf00", Frameless: true}]
           Condition: null
     - id: testArrayOfMaps
@@ -67,7 +67,7 @@ Probes:
       subprogram: {subprogram: 53}
       events:
         - ID: 53
-          Type: 273 EventRootType Probe[main.testArrayOfMaps]
+          Type: 266 EventRootType Probe[main.testArrayOfMaps]
           InjectionPoints: [{PC: "0x88d650", Frameless: true}]
           Condition: null
     - id: testArrayOfStrings
@@ -81,7 +81,7 @@ Probes:
       subprogram: {subprogram: 16}
       events:
         - ID: 16
-          Type: 236 EventRootType Probe[main.testArrayOfStrings]
+          Type: 229 EventRootType Probe[main.testArrayOfStrings]
           InjectionPoints: [{PC: "0x88bef0", Frameless: true}]
           Condition: null
     - id: testBigStruct
@@ -95,7 +95,7 @@ Probes:
       subprogram: {subprogram: 35}
       events:
         - ID: 35
-          Type: 255 EventRootType Probe[main.testBigStruct]
+          Type: 248 EventRootType Probe[main.testBigStruct]
           InjectionPoints: [{PC: "0x88c460", Frameless: true}]
           Condition: null
     - id: testBoolArray
@@ -109,7 +109,7 @@ Probes:
       subprogram: {subprogram: 4}
       events:
         - ID: 4
-          Type: 224 EventRootType Probe[main.testBoolArray]
+          Type: 217 EventRootType Probe[main.testBoolArray]
           InjectionPoints: [{PC: "0x88be30", Frameless: true}]
           Condition: null
     - id: testByteArray
@@ -123,7 +123,7 @@ Probes:
       subprogram: {subprogram: 1}
       events:
         - ID: 1
-          Type: 221 EventRootType Probe[main.testByteArray]
+          Type: 214 EventRootType Probe[main.testByteArray]
           InjectionPoints: [{PC: "0x88be00", Frameless: true}]
           Condition: null
     - id: testChannel
@@ -137,7 +137,7 @@ Probes:
       subprogram: {subprogram: 69}
       events:
         - ID: 69
-          Type: 289 EventRootType Probe[main.testChannel]
+          Type: 282 EventRootType Probe[main.testChannel]
           InjectionPoints: [{PC: "0x88ec00", Frameless: true}]
           Condition: null
     - id: testCombinedByte
@@ -151,7 +151,7 @@ Probes:
       subprogram: {subprogram: 67}
       events:
         - ID: 67
-          Type: 287 EventRootType Probe[main.testCombinedByte]
+          Type: 280 EventRootType Probe[main.testCombinedByte]
           InjectionPoints: [{PC: "0x88e980", Frameless: true}]
           Condition: null
     - id: testCycle
@@ -165,7 +165,7 @@ Probes:
       subprogram: {subprogram: 77}
       events:
         - ID: 77
-          Type: 297 EventRootType Probe[main.testCycle]
+          Type: 290 EventRootType Probe[main.testCycle]
           InjectionPoints: [{PC: "0x88eea0", Frameless: true}]
           Condition: null
     - id: testEmptySlice
@@ -179,7 +179,7 @@ Probes:
       subprogram: {subprogram: 79}
       events:
         - ID: 79
-          Type: 299 EventRootType Probe[main.testEmptySlice]
+          Type: 292 EventRootType Probe[main.testEmptySlice]
           InjectionPoints: [{PC: "0x88f2a0", Frameless: true}]
           Condition: null
     - id: testEmptySliceOfStructs
@@ -193,7 +193,7 @@ Probes:
       subprogram: {subprogram: 82}
       events:
         - ID: 82
-          Type: 302 EventRootType Probe[main.testEmptySliceOfStructs]
+          Type: 295 EventRootType Probe[main.testEmptySliceOfStructs]
           InjectionPoints: [{PC: "0x88f2d0", Frameless: true}]
           Condition: null
     - id: testEmptyString
@@ -207,7 +207,7 @@ Probes:
       subprogram: {subprogram: 96}
       events:
         - ID: 96
-          Type: 316 EventRootType Probe[main.testEmptyString]
+          Type: 309 EventRootType Probe[main.testEmptyString]
           InjectionPoints: [{PC: "0x88f6e0", Frameless: true}]
           Condition: null
     - id: testEmptyStruct
@@ -221,7 +221,7 @@ Probes:
       subprogram: {subprogram: 98}
       events:
         - ID: 98
-          Type: 318 EventRootType Probe[main.testEmptyStruct]
+          Type: 311 EventRootType Probe[main.testEmptyStruct]
           InjectionPoints: [{PC: "0x88f9f0", Frameless: true}]
           Condition: null
     - id: testError
@@ -235,7 +235,7 @@ Probes:
       subprogram: {subprogram: 46}
       events:
         - ID: 46
-          Type: 266 EventRootType Probe[main.testError]
+          Type: 259 EventRootType Probe[main.testError]
           InjectionPoints: [{PC: "0x88d1d0", Frameless: true}]
           Condition: null
     - id: testEsotericHeap
@@ -249,7 +249,7 @@ Probes:
       subprogram: {subprogram: 37}
       events:
         - ID: 37
-          Type: 257 EventRootType Probe[main.testEsotericHeap]
+          Type: 250 EventRootType Probe[main.testEsotericHeap]
           InjectionPoints: [{PC: "0x88c71c", Frameless: true}]
           Condition: null
     - id: testEsotericStack
@@ -263,7 +263,7 @@ Probes:
       subprogram: {subprogram: 36}
       events:
         - ID: 36
-          Type: 256 EventRootType Probe[main.testEsotericStack]
+          Type: 249 EventRootType Probe[main.testEsotericStack]
           InjectionPoints: [{PC: "0x88c62c", Frameless: true}]
           Condition: null
     - id: testFrameless
@@ -277,7 +277,7 @@ Probes:
       subprogram: {subprogram: 42}
       events:
         - ID: 42
-          Type: 262 EventRootType Probe[main.testFrameless]
+          Type: 255 EventRootType Probe[main.testFrameless]
           InjectionPoints: [{PC: "0x88ce50", Frameless: true}]
           Condition: null
     - id: testFramelessArray
@@ -291,7 +291,7 @@ Probes:
       subprogram: {subprogram: 43}
       events:
         - ID: 43
-          Type: 263 EventRootType Probe[main.testFramelessArray]
+          Type: 256 EventRootType Probe[main.testFramelessArray]
           InjectionPoints: [{PC: "0x88ce60", Frameless: true}]
           Condition: null
     - id: testInlinedBA
@@ -305,7 +305,7 @@ Probes:
       subprogram: {subprogram: 38}
       events:
         - ID: 38
-          Type: 258 EventRootType Probe[main.testInlinedBA]
+          Type: 251 EventRootType Probe[main.testInlinedBA]
           InjectionPoints: [{PC: "0x88cb5c", Frameless: true}]
           Condition: null
     - id: testInlinedBB
@@ -319,7 +319,7 @@ Probes:
       subprogram: {subprogram: 39}
       events:
         - ID: 39
-          Type: 259 EventRootType Probe[main.testInlinedBB]
+          Type: 252 EventRootType Probe[main.testInlinedBB]
           InjectionPoints: [{PC: "0x88cbec", Frameless: true}]
           Condition: null
     - id: testInlinedBBA
@@ -333,7 +333,7 @@ Probes:
       subprogram: {subprogram: 40}
       events:
         - ID: 40
-          Type: 260 EventRootType Probe[main.testInlinedBBA]
+          Type: 253 EventRootType Probe[main.testInlinedBBA]
           InjectionPoints: [{PC: "0x88ccbc", Frameless: true}]
           Condition: null
     - id: testInlinedBBB
@@ -347,7 +347,7 @@ Probes:
       subprogram: {subprogram: 100}
       events:
         - ID: 100
-          Type: 320 EventRootType Probe[main.testInlinedBBB]
+          Type: 313 EventRootType Probe[main.testInlinedBBB]
           InjectionPoints: [{PC: "0x88cc48", Frameless: false}]
           Condition: null
     - id: testInlinedBC
@@ -361,7 +361,7 @@ Probes:
       subprogram: {subprogram: 41}
       events:
         - ID: 41
-          Type: 261 EventRootType Probe[main.testInlinedBC]
+          Type: 254 EventRootType Probe[main.testInlinedBC]
           InjectionPoints: [{PC: "0x88cd3c", Frameless: true}]
           Condition: null
     - id: testInlinedBCA
@@ -375,7 +375,7 @@ Probes:
       subprogram: {subprogram: 101}
       events:
         - ID: 101
-          Type: 321 EventRootType Probe[main.testInlinedBCA]
+          Type: 314 EventRootType Probe[main.testInlinedBCA]
           InjectionPoints: [{PC: "0x88cd4c", Frameless: false}]
           Condition: null
     - id: testInlinedBCB
@@ -389,7 +389,7 @@ Probes:
       subprogram: {subprogram: 102}
       events:
         - ID: 102
-          Type: 322 EventRootType Probe[main.testInlinedBCB]
+          Type: 315 EventRootType Probe[main.testInlinedBCB]
           InjectionPoints: [{PC: "0x88ce00", Frameless: false}]
           Condition: null
     - id: testInlinedPrint
@@ -404,7 +404,7 @@ Probes:
       subprogram: {subprogram: 99}
       events:
         - ID: 99
-          Type: 319 EventRootType Probe[main.testInlinedPrint]
+          Type: 312 EventRootType Probe[main.testInlinedPrint]
           InjectionPoints:
             - PC: "0x88c9bc"
               Frameless: true
@@ -428,7 +428,7 @@ Probes:
       subprogram: {subprogram: 103}
       events:
         - ID: 103
-          Type: 323 EventRootType Probe[main.testInlinedSq]
+          Type: 316 EventRootType Probe[main.testInlinedSq]
           InjectionPoints: [{PC: "0x88ce54", Frameless: true}]
           Condition: null
     - id: testInlinedSumArray
@@ -443,7 +443,7 @@ Probes:
       subprogram: {subprogram: 104}
       events:
         - ID: 104
-          Type: 324 EventRootType Probe[main.testInlinedSumArray]
+          Type: 317 EventRootType Probe[main.testInlinedSumArray]
           InjectionPoints:
             - PC: "0x88ce84"
               Frameless: false
@@ -461,7 +461,7 @@ Probes:
       subprogram: {subprogram: 7}
       events:
         - ID: 7
-          Type: 227 EventRootType Probe[main.testInt16Array]
+          Type: 220 EventRootType Probe[main.testInt16Array]
           InjectionPoints: [{PC: "0x88be60", Frameless: true}]
           Condition: null
     - id: testInt32Array
@@ -475,7 +475,7 @@ Probes:
       subprogram: {subprogram: 8}
       events:
         - ID: 8
-          Type: 228 EventRootType Probe[main.testInt32Array]
+          Type: 221 EventRootType Probe[main.testInt32Array]
           InjectionPoints: [{PC: "0x88be70", Frameless: true}]
           Condition: null
     - id: testInt64Array
@@ -489,7 +489,7 @@ Probes:
       subprogram: {subprogram: 9}
       events:
         - ID: 9
-          Type: 229 EventRootType Probe[main.testInt64Array]
+          Type: 222 EventRootType Probe[main.testInt64Array]
           InjectionPoints: [{PC: "0x88be80", Frameless: true}]
           Condition: null
     - id: testInt8Array
@@ -503,7 +503,7 @@ Probes:
       subprogram: {subprogram: 6}
       events:
         - ID: 6
-          Type: 226 EventRootType Probe[main.testInt8Array]
+          Type: 219 EventRootType Probe[main.testInt8Array]
           InjectionPoints: [{PC: "0x88be50", Frameless: true}]
           Condition: null
     - id: testIntArray
@@ -517,7 +517,7 @@ Probes:
       subprogram: {subprogram: 5}
       events:
         - ID: 5
-          Type: 225 EventRootType Probe[main.testIntArray]
+          Type: 218 EventRootType Probe[main.testIntArray]
           InjectionPoints: [{PC: "0x88be40", Frameless: true}]
           Condition: null
     - id: testInterface
@@ -531,7 +531,7 @@ Probes:
       subprogram: {subprogram: 44}
       events:
         - ID: 44
-          Type: 264 EventRootType Probe[main.testInterface]
+          Type: 257 EventRootType Probe[main.testInterface]
           InjectionPoints: [{PC: "0x88d10c", Frameless: true}]
           Condition: null
     - id: testLinkedList
@@ -545,7 +545,7 @@ Probes:
       subprogram: {subprogram: 71}
       events:
         - ID: 71
-          Type: 291 EventRootType Probe[main.testLinkedList]
+          Type: 284 EventRootType Probe[main.testLinkedList]
           InjectionPoints: [{PC: "0x88edb0", Frameless: true}]
           Condition: null
     - id: testMapArrayToArray
@@ -559,7 +559,7 @@ Probes:
       subprogram: {subprogram: 51}
       events:
         - ID: 51
-          Type: 271 EventRootType Probe[main.testMapArrayToArray]
+          Type: 264 EventRootType Probe[main.testMapArrayToArray]
           InjectionPoints: [{PC: "0x88d630", Frameless: true}]
           Condition: null
     - id: testMapEmbeddedMaps
@@ -573,7 +573,7 @@ Probes:
       subprogram: {subprogram: 57}
       events:
         - ID: 57
-          Type: 277 EventRootType Probe[main.testMapEmbeddedMaps]
+          Type: 270 EventRootType Probe[main.testMapEmbeddedMaps]
           InjectionPoints: [{PC: "0x88d690", Frameless: true}]
           Condition: null
     - id: testMapIntToInt
@@ -587,7 +587,7 @@ Probes:
       subprogram: {subprogram: 55}
       events:
         - ID: 55
-          Type: 275 EventRootType Probe[main.testMapIntToInt]
+          Type: 268 EventRootType Probe[main.testMapIntToInt]
           InjectionPoints: [{PC: "0x88d670", Frameless: true}]
           Condition: null
     - id: testMapLargeKeyLargeValue
@@ -601,7 +601,7 @@ Probes:
       subprogram: {subprogram: 66}
       events:
         - ID: 66
-          Type: 286 EventRootType Probe[main.testMapLargeKeyLargeValue]
+          Type: 279 EventRootType Probe[main.testMapLargeKeyLargeValue]
           InjectionPoints: [{PC: "0x88d720", Frameless: true}]
           Condition: null
     - id: testMapLargeKeySmallValue
@@ -615,7 +615,7 @@ Probes:
       subprogram: {subprogram: 65}
       events:
         - ID: 65
-          Type: 285 EventRootType Probe[main.testMapLargeKeySmallValue]
+          Type: 278 EventRootType Probe[main.testMapLargeKeySmallValue]
           InjectionPoints: [{PC: "0x88d710", Frameless: true}]
           Condition: null
     - id: testMapMassive
@@ -629,7 +629,7 @@ Probes:
       subprogram: {subprogram: 56}
       events:
         - ID: 56
-          Type: 276 EventRootType Probe[main.testMapMassive]
+          Type: 269 EventRootType Probe[main.testMapMassive]
           InjectionPoints: [{PC: "0x88d680", Frameless: true}]
           Condition: null
     - id: testMapSmallKeyLargeValue
@@ -643,7 +643,7 @@ Probes:
       subprogram: {subprogram: 64}
       events:
         - ID: 64
-          Type: 284 EventRootType Probe[main.testMapSmallKeyLargeValue]
+          Type: 277 EventRootType Probe[main.testMapSmallKeyLargeValue]
           InjectionPoints: [{PC: "0x88d700", Frameless: true}]
           Condition: null
     - id: testMapSmallKeySmallValue
@@ -657,7 +657,7 @@ Probes:
       subprogram: {subprogram: 63}
       events:
         - ID: 63
-          Type: 283 EventRootType Probe[main.testMapSmallKeySmallValue]
+          Type: 276 EventRootType Probe[main.testMapSmallKeySmallValue]
           InjectionPoints: [{PC: "0x88d6f0", Frameless: true}]
           Condition: null
     - id: testMapStringToInt
@@ -671,7 +671,7 @@ Probes:
       subprogram: {subprogram: 49}
       events:
         - ID: 49
-          Type: 269 EventRootType Probe[main.testMapStringToInt]
+          Type: 262 EventRootType Probe[main.testMapStringToInt]
           InjectionPoints: [{PC: "0x88d610", Frameless: true}]
           Condition: null
     - id: testMapStringToSlice
@@ -685,7 +685,7 @@ Probes:
       subprogram: {subprogram: 50}
       events:
         - ID: 50
-          Type: 270 EventRootType Probe[main.testMapStringToSlice]
+          Type: 263 EventRootType Probe[main.testMapStringToSlice]
           InjectionPoints: [{PC: "0x88d620", Frameless: true}]
           Condition: null
     - id: testMapStringToStruct
@@ -699,7 +699,7 @@ Probes:
       subprogram: {subprogram: 48}
       events:
         - ID: 48
-          Type: 268 EventRootType Probe[main.testMapStringToStruct]
+          Type: 261 EventRootType Probe[main.testMapStringToStruct]
           InjectionPoints: [{PC: "0x88d600", Frameless: true}]
           Condition: null
     - id: testMapWithLinkedList
@@ -713,7 +713,7 @@ Probes:
       subprogram: {subprogram: 58}
       events:
         - ID: 58
-          Type: 278 EventRootType Probe[main.testMapWithLinkedList]
+          Type: 271 EventRootType Probe[main.testMapWithLinkedList]
           InjectionPoints: [{PC: "0x88d6a0", Frameless: true}]
           Condition: null
     - id: testMapWithSmallKeyAndValue
@@ -727,7 +727,7 @@ Probes:
       subprogram: {subprogram: 61}
       events:
         - ID: 61
-          Type: 281 EventRootType Probe[main.testMapWithSmallKeyAndValue]
+          Type: 274 EventRootType Probe[main.testMapWithSmallKeyAndValue]
           InjectionPoints: [{PC: "0x88d6d0", Frameless: true}]
           Condition: null
     - id: testMapWithSmallKeyAndValueMassive
@@ -741,7 +741,7 @@ Probes:
       subprogram: {subprogram: 62}
       events:
         - ID: 62
-          Type: 282 EventRootType Probe[main.testMapWithSmallKeyAndValueMassive]
+          Type: 275 EventRootType Probe[main.testMapWithSmallKeyAndValueMassive]
           InjectionPoints: [{PC: "0x88d6e0", Frameless: true}]
           Condition: null
     - id: testMapWithSmallValue
@@ -755,7 +755,7 @@ Probes:
       subprogram: {subprogram: 59}
       events:
         - ID: 59
-          Type: 279 EventRootType Probe[main.testMapWithSmallValue]
+          Type: 272 EventRootType Probe[main.testMapWithSmallValue]
           InjectionPoints: [{PC: "0x88d6b0", Frameless: true}]
           Condition: null
     - id: testMapWithSmallValueMassive
@@ -769,7 +769,7 @@ Probes:
       subprogram: {subprogram: 60}
       events:
         - ID: 60
-          Type: 280 EventRootType Probe[main.testMapWithSmallValueMassive]
+          Type: 273 EventRootType Probe[main.testMapWithSmallValueMassive]
           InjectionPoints: [{PC: "0x88d6c0", Frameless: true}]
           Condition: null
     - id: testMassiveString
@@ -783,7 +783,7 @@ Probes:
       subprogram: {subprogram: 94}
       events:
         - ID: 94
-          Type: 314 EventRootType Probe[main.testMassiveString]
+          Type: 307 EventRootType Probe[main.testMassiveString]
           InjectionPoints: [{PC: "0x88f6c0", Frameless: true}]
           Condition: null
     - id: testMultipleSimpleParams
@@ -797,7 +797,7 @@ Probes:
       subprogram: {subprogram: 68}
       events:
         - ID: 68
-          Type: 288 EventRootType Probe[main.testMultipleSimpleParams]
+          Type: 281 EventRootType Probe[main.testMultipleSimpleParams]
           InjectionPoints: [{PC: "0x88ea60", Frameless: true}]
           Condition: null
     - id: testNilPointer
@@ -811,7 +811,7 @@ Probes:
       subprogram: {subprogram: 76}
       events:
         - ID: 76
-          Type: 296 EventRootType Probe[main.testNilPointer]
+          Type: 289 EventRootType Probe[main.testNilPointer]
           InjectionPoints: [{PC: "0x88ee80", Frameless: true}]
           Condition: null
     - id: testNilSlice
@@ -825,7 +825,7 @@ Probes:
       subprogram: {subprogram: 86}
       events:
         - ID: 86
-          Type: 306 EventRootType Probe[main.testNilSlice]
+          Type: 299 EventRootType Probe[main.testNilSlice]
           InjectionPoints: [{PC: "0x88f310", Frameless: true}]
           Condition: null
     - id: testNilSliceOfStructs
@@ -839,7 +839,7 @@ Probes:
       subprogram: {subprogram: 83}
       events:
         - ID: 83
-          Type: 303 EventRootType Probe[main.testNilSliceOfStructs]
+          Type: 296 EventRootType Probe[main.testNilSliceOfStructs]
           InjectionPoints: [{PC: "0x88f2e0", Frameless: true}]
           Condition: null
     - id: testNilSliceWithOtherParams
@@ -853,7 +853,7 @@ Probes:
       subprogram: {subprogram: 85}
       events:
         - ID: 85
-          Type: 305 EventRootType Probe[main.testNilSliceWithOtherParams]
+          Type: 298 EventRootType Probe[main.testNilSliceWithOtherParams]
           InjectionPoints: [{PC: "0x88f300", Frameless: true}]
           Condition: null
     - id: testOneStringInStructPointer
@@ -867,7 +867,7 @@ Probes:
       subprogram: {subprogram: 93}
       events:
         - ID: 93
-          Type: 313 EventRootType Probe[main.testOneStringInStructPointer]
+          Type: 306 EventRootType Probe[main.testOneStringInStructPointer]
           InjectionPoints: [{PC: "0x88f6b0", Frameless: true}]
           Condition: null
     - id: testPointerLoop
@@ -881,7 +881,7 @@ Probes:
       subprogram: {subprogram: 72}
       events:
         - ID: 72
-          Type: 292 EventRootType Probe[main.testPointerLoop]
+          Type: 285 EventRootType Probe[main.testPointerLoop]
           InjectionPoints: [{PC: "0x88edc0", Frameless: true}]
           Condition: null
     - id: testPointerToMap
@@ -895,7 +895,7 @@ Probes:
       subprogram: {subprogram: 54}
       events:
         - ID: 54
-          Type: 274 EventRootType Probe[main.testPointerToMap]
+          Type: 267 EventRootType Probe[main.testPointerToMap]
           InjectionPoints: [{PC: "0x88d660", Frameless: true}]
           Condition: null
     - id: testPointerToSimpleStruct
@@ -909,7 +909,7 @@ Probes:
       subprogram: {subprogram: 70}
       events:
         - ID: 70
-          Type: 290 EventRootType Probe[main.testPointerToSimpleStruct]
+          Type: 283 EventRootType Probe[main.testPointerToSimpleStruct]
           InjectionPoints: [{PC: "0x88eda0", Frameless: true}]
           Condition: null
     - id: testRuneArray
@@ -923,7 +923,7 @@ Probes:
       subprogram: {subprogram: 2}
       events:
         - ID: 2
-          Type: 222 EventRootType Probe[main.testRuneArray]
+          Type: 215 EventRootType Probe[main.testRuneArray]
           InjectionPoints: [{PC: "0x88be10", Frameless: true}]
           Condition: null
     - id: testSingleBool
@@ -937,7 +937,7 @@ Probes:
       subprogram: {subprogram: 21}
       events:
         - ID: 21
-          Type: 241 EventRootType Probe[main.testSingleBool]
+          Type: 234 EventRootType Probe[main.testSingleBool]
           InjectionPoints: [{PC: "0x88c280", Frameless: true}]
           Condition: null
     - id: testSingleByte
@@ -951,7 +951,7 @@ Probes:
       subprogram: {subprogram: 19}
       events:
         - ID: 19
-          Type: 239 EventRootType Probe[main.testSingleByte]
+          Type: 232 EventRootType Probe[main.testSingleByte]
           InjectionPoints: [{PC: "0x88c260", Frameless: true}]
           Condition: null
     - id: testSingleFloat32
@@ -965,7 +965,7 @@ Probes:
       subprogram: {subprogram: 32}
       events:
         - ID: 32
-          Type: 252 EventRootType Probe[main.testSingleFloat32]
+          Type: 245 EventRootType Probe[main.testSingleFloat32]
           InjectionPoints: [{PC: "0x88c330", Frameless: true}]
           Condition: null
     - id: testSingleFloat64
@@ -979,7 +979,7 @@ Probes:
       subprogram: {subprogram: 33}
       events:
         - ID: 33
-          Type: 253 EventRootType Probe[main.testSingleFloat64]
+          Type: 246 EventRootType Probe[main.testSingleFloat64]
           InjectionPoints: [{PC: "0x88c340", Frameless: true}]
           Condition: null
     - id: testSingleInt
@@ -993,7 +993,7 @@ Probes:
       subprogram: {subprogram: 22}
       events:
         - ID: 22
-          Type: 242 EventRootType Probe[main.testSingleInt]
+          Type: 235 EventRootType Probe[main.testSingleInt]
           InjectionPoints: [{PC: "0x88c290", Frameless: true}]
           Condition: null
     - id: testSingleInt16
@@ -1007,7 +1007,7 @@ Probes:
       subprogram: {subprogram: 24}
       events:
         - ID: 24
-          Type: 244 EventRootType Probe[main.testSingleInt16]
+          Type: 237 EventRootType Probe[main.testSingleInt16]
           InjectionPoints: [{PC: "0x88c2b0", Frameless: true}]
           Condition: null
     - id: testSingleInt32
@@ -1021,7 +1021,7 @@ Probes:
       subprogram: {subprogram: 25}
       events:
         - ID: 25
-          Type: 245 EventRootType Probe[main.testSingleInt32]
+          Type: 238 EventRootType Probe[main.testSingleInt32]
           InjectionPoints: [{PC: "0x88c2c0", Frameless: true}]
           Condition: null
     - id: testSingleInt64
@@ -1035,7 +1035,7 @@ Probes:
       subprogram: {subprogram: 26}
       events:
         - ID: 26
-          Type: 246 EventRootType Probe[main.testSingleInt64]
+          Type: 239 EventRootType Probe[main.testSingleInt64]
           InjectionPoints: [{PC: "0x88c2d0", Frameless: true}]
           Condition: null
     - id: testSingleInt8
@@ -1049,7 +1049,7 @@ Probes:
       subprogram: {subprogram: 23}
       events:
         - ID: 23
-          Type: 243 EventRootType Probe[main.testSingleInt8]
+          Type: 236 EventRootType Probe[main.testSingleInt8]
           InjectionPoints: [{PC: "0x88c2a0", Frameless: true}]
           Condition: null
     - id: testSingleRune
@@ -1063,7 +1063,7 @@ Probes:
       subprogram: {subprogram: 20}
       events:
         - ID: 20
-          Type: 240 EventRootType Probe[main.testSingleRune]
+          Type: 233 EventRootType Probe[main.testSingleRune]
           InjectionPoints: [{PC: "0x88c270", Frameless: true}]
           Condition: null
     - id: testSingleString
@@ -1077,7 +1077,7 @@ Probes:
       subprogram: {subprogram: 89}
       events:
         - ID: 89
-          Type: 309 EventRootType Probe[main.testSingleString]
+          Type: 302 EventRootType Probe[main.testSingleString]
           InjectionPoints: [{PC: "0x88f660", Frameless: true}]
           Condition: null
     - id: testSingleUint
@@ -1091,7 +1091,7 @@ Probes:
       subprogram: {subprogram: 27}
       events:
         - ID: 27
-          Type: 247 EventRootType Probe[main.testSingleUint]
+          Type: 240 EventRootType Probe[main.testSingleUint]
           InjectionPoints: [{PC: "0x88c2e0", Frameless: true}]
           Condition: null
     - id: testSingleUint16
@@ -1105,7 +1105,7 @@ Probes:
       subprogram: {subprogram: 29}
       events:
         - ID: 29
-          Type: 249 EventRootType Probe[main.testSingleUint16]
+          Type: 242 EventRootType Probe[main.testSingleUint16]
           InjectionPoints: [{PC: "0x88c300", Frameless: true}]
           Condition: null
     - id: testSingleUint32
@@ -1119,7 +1119,7 @@ Probes:
       subprogram: {subprogram: 30}
       events:
         - ID: 30
-          Type: 250 EventRootType Probe[main.testSingleUint32]
+          Type: 243 EventRootType Probe[main.testSingleUint32]
           InjectionPoints: [{PC: "0x88c310", Frameless: true}]
           Condition: null
     - id: testSingleUint64
@@ -1133,7 +1133,7 @@ Probes:
       subprogram: {subprogram: 31}
       events:
         - ID: 31
-          Type: 251 EventRootType Probe[main.testSingleUint64]
+          Type: 244 EventRootType Probe[main.testSingleUint64]
           InjectionPoints: [{PC: "0x88c320", Frameless: true}]
           Condition: null
     - id: testSingleUint8
@@ -1147,7 +1147,7 @@ Probes:
       subprogram: {subprogram: 28}
       events:
         - ID: 28
-          Type: 248 EventRootType Probe[main.testSingleUint8]
+          Type: 241 EventRootType Probe[main.testSingleUint8]
           InjectionPoints: [{PC: "0x88c2f0", Frameless: true}]
           Condition: null
     - id: testSliceOfSlices
@@ -1161,7 +1161,7 @@ Probes:
       subprogram: {subprogram: 80}
       events:
         - ID: 80
-          Type: 300 EventRootType Probe[main.testSliceOfSlices]
+          Type: 293 EventRootType Probe[main.testSliceOfSlices]
           InjectionPoints: [{PC: "0x88f2b0", Frameless: true}]
           Condition: null
     - id: testSmallMap
@@ -1175,7 +1175,7 @@ Probes:
       subprogram: {subprogram: 52}
       events:
         - ID: 52
-          Type: 272 EventRootType Probe[main.testSmallMap]
+          Type: 265 EventRootType Probe[main.testSmallMap]
           InjectionPoints: [{PC: "0x88d640", Frameless: true}]
           Condition: null
     - id: testStringArray
@@ -1189,7 +1189,7 @@ Probes:
       subprogram: {subprogram: 3}
       events:
         - ID: 3
-          Type: 223 EventRootType Probe[main.testStringArray]
+          Type: 216 EventRootType Probe[main.testStringArray]
           InjectionPoints: [{PC: "0x88be20", Frameless: true}]
           Condition: null
     - id: testStringPointer
@@ -1203,7 +1203,7 @@ Probes:
       subprogram: {subprogram: 75}
       events:
         - ID: 75
-          Type: 295 EventRootType Probe[main.testStringPointer]
+          Type: 288 EventRootType Probe[main.testStringPointer]
           InjectionPoints: [{PC: "0x88ee60", Frameless: true}]
           Condition: null
     - id: testStringSlice
@@ -1217,7 +1217,7 @@ Probes:
       subprogram: {subprogram: 84}
       events:
         - ID: 84
-          Type: 304 EventRootType Probe[main.testStringSlice]
+          Type: 297 EventRootType Probe[main.testStringSlice]
           InjectionPoints: [{PC: "0x88f2f0", Frameless: true}]
           Condition: null
     - id: testStruct
@@ -1231,7 +1231,7 @@ Probes:
       subprogram: {subprogram: 97}
       events:
         - ID: 97
-          Type: 317 EventRootType Probe[main.testStruct]
+          Type: 310 EventRootType Probe[main.testStruct]
           InjectionPoints: [{PC: "0x88f8f0", Frameless: true}]
           Condition: null
     - id: testStructSlice
@@ -1245,7 +1245,7 @@ Probes:
       subprogram: {subprogram: 81}
       events:
         - ID: 81
-          Type: 301 EventRootType Probe[main.testStructSlice]
+          Type: 294 EventRootType Probe[main.testStructSlice]
           InjectionPoints: [{PC: "0x88f2c0", Frameless: true}]
           Condition: null
     - id: testStructWithMap
@@ -1259,7 +1259,7 @@ Probes:
       subprogram: {subprogram: 47}
       events:
         - ID: 47
-          Type: 267 EventRootType Probe[main.testStructWithMap]
+          Type: 260 EventRootType Probe[main.testStructWithMap]
           InjectionPoints: [{PC: "0x88d5f0", Frameless: true}]
           Condition: null
     - id: testThreeStrings
@@ -1273,7 +1273,7 @@ Probes:
       subprogram: {subprogram: 90}
       events:
         - ID: 90
-          Type: 310 EventRootType Probe[main.testThreeStrings]
+          Type: 303 EventRootType Probe[main.testThreeStrings]
           InjectionPoints: [{PC: "0x88f670", Frameless: true}]
           Condition: null
     - id: testThreeStringsInStruct
@@ -1287,7 +1287,7 @@ Probes:
       subprogram: {subprogram: 91}
       events:
         - ID: 91
-          Type: 311 EventRootType Probe[main.testThreeStringsInStruct]
+          Type: 304 EventRootType Probe[main.testThreeStringsInStruct]
           InjectionPoints: [{PC: "0x88f680", Frameless: true}]
           Condition: null
     - id: testThreeStringsInStructPointer
@@ -1301,7 +1301,7 @@ Probes:
       subprogram: {subprogram: 92}
       events:
         - ID: 92
-          Type: 312 EventRootType Probe[main.testThreeStringsInStructPointer]
+          Type: 305 EventRootType Probe[main.testThreeStringsInStructPointer]
           InjectionPoints: [{PC: "0x88f6a0", Frameless: true}]
           Condition: null
     - id: testTypeAlias
@@ -1315,7 +1315,7 @@ Probes:
       subprogram: {subprogram: 34}
       events:
         - ID: 34
-          Type: 254 EventRootType Probe[main.testTypeAlias]
+          Type: 247 EventRootType Probe[main.testTypeAlias]
           InjectionPoints: [{PC: "0x88c350", Frameless: true}]
           Condition: null
     - id: testUint16Array
@@ -1329,7 +1329,7 @@ Probes:
       subprogram: {subprogram: 12}
       events:
         - ID: 12
-          Type: 232 EventRootType Probe[main.testUint16Array]
+          Type: 225 EventRootType Probe[main.testUint16Array]
           InjectionPoints: [{PC: "0x88beb0", Frameless: true}]
           Condition: null
     - id: testUint32Array
@@ -1343,7 +1343,7 @@ Probes:
       subprogram: {subprogram: 13}
       events:
         - ID: 13
-          Type: 233 EventRootType Probe[main.testUint32Array]
+          Type: 226 EventRootType Probe[main.testUint32Array]
           InjectionPoints: [{PC: "0x88bec0", Frameless: true}]
           Condition: null
     - id: testUint64Array
@@ -1357,7 +1357,7 @@ Probes:
       subprogram: {subprogram: 14}
       events:
         - ID: 14
-          Type: 234 EventRootType Probe[main.testUint64Array]
+          Type: 227 EventRootType Probe[main.testUint64Array]
           InjectionPoints: [{PC: "0x88bed0", Frameless: true}]
           Condition: null
     - id: testUint8Array
@@ -1371,7 +1371,7 @@ Probes:
       subprogram: {subprogram: 11}
       events:
         - ID: 11
-          Type: 231 EventRootType Probe[main.testUint8Array]
+          Type: 224 EventRootType Probe[main.testUint8Array]
           InjectionPoints: [{PC: "0x88bea0", Frameless: true}]
           Condition: null
     - id: testUintArray
@@ -1385,7 +1385,7 @@ Probes:
       subprogram: {subprogram: 10}
       events:
         - ID: 10
-          Type: 230 EventRootType Probe[main.testUintArray]
+          Type: 223 EventRootType Probe[main.testUintArray]
           InjectionPoints: [{PC: "0x88be90", Frameless: true}]
           Condition: null
     - id: testUintPointer
@@ -1399,7 +1399,7 @@ Probes:
       subprogram: {subprogram: 74}
       events:
         - ID: 74
-          Type: 294 EventRootType Probe[main.testUintPointer]
+          Type: 287 EventRootType Probe[main.testUintPointer]
           InjectionPoints: [{PC: "0x88edf0", Frameless: true}]
           Condition: null
     - id: testUintSlice
@@ -1413,7 +1413,7 @@ Probes:
       subprogram: {subprogram: 78}
       events:
         - ID: 78
-          Type: 298 EventRootType Probe[main.testUintSlice]
+          Type: 291 EventRootType Probe[main.testUintSlice]
           InjectionPoints: [{PC: "0x88f290", Frameless: true}]
           Condition: null
     - id: testUnitializedString
@@ -1427,7 +1427,7 @@ Probes:
       subprogram: {subprogram: 95}
       events:
         - ID: 95
-          Type: 315 EventRootType Probe[main.testUnitializedString]
+          Type: 308 EventRootType Probe[main.testUnitializedString]
           InjectionPoints: [{PC: "0x88f6d0", Frameless: true}]
           Condition: null
     - id: testUnsafePointer
@@ -1441,7 +1441,7 @@ Probes:
       subprogram: {subprogram: 73}
       events:
         - ID: 73
-          Type: 293 EventRootType Probe[main.testUnsafePointer]
+          Type: 286 EventRootType Probe[main.testUnsafePointer]
           InjectionPoints: [{PC: "0x88edd0", Frameless: true}]
           Condition: null
     - id: testVeryLargeArray
@@ -1455,7 +1455,7 @@ Probes:
       subprogram: {subprogram: 18}
       events:
         - ID: 18
-          Type: 238 EventRootType Probe[main.testVeryLargeArray]
+          Type: 231 EventRootType Probe[main.testVeryLargeArray]
           InjectionPoints: [{PC: "0x88bf30", Frameless: true}]
           Condition: null
     - id: testVeryLargeSlice
@@ -1469,7 +1469,7 @@ Probes:
       subprogram: {subprogram: 87}
       events:
         - ID: 87
-          Type: 307 EventRootType Probe[main.testVeryLargeSlice]
+          Type: 300 EventRootType Probe[main.testVeryLargeSlice]
           InjectionPoints: [{PC: "0x88f320", Frameless: true}]
           Condition: null
 Subprograms:
@@ -3095,15 +3095,10 @@ Subprograms:
           IsReturn: false
 Types:
     - __kind: PointerType
-      ID: 185
+      ID: 209
       Name: '**main.t'
       ByteSize: 8
       Pointee: 135 PointerType *main.t
-    - __kind: PointerType
-      ID: 216
-      Name: '**runtime.bmap'
-      ByteSize: 8
-      Pointee: 167 PointerType *runtime.bmap
     - __kind: PointerType
       ID: 54
       Name: '**string'
@@ -3112,62 +3107,50 @@ Types:
       GoKind: 22
       Pointee: 22 PointerType *string
     - __kind: PointerType
-      ID: 165
-      Name: '*[]*runtime.bmap'
-      ByteSize: 8
-      GoRuntimeType: 451808
-      GoKind: 22
-      Pointee: 166 GoSliceHeaderType []*runtime.bmap
-    - __kind: PointerType
-      ID: 218
-      Name: '*[]*runtime.bmap.array'
-      ByteSize: 8
-      Pointee: 217 GoSliceDataType []*runtime.bmap.array
-    - __kind: PointerType
-      ID: 189
+      ID: 156
       Name: '*[]*string.array'
       ByteSize: 8
-      Pointee: 188 GoSliceDataType []*string.array
+      Pointee: 155 GoSliceDataType []*string.array
     - __kind: PointerType
-      ID: 207
+      ID: 191
       Name: '*[][]uint.array'
       ByteSize: 8
-      Pointee: 206 GoSliceDataType [][]uint.array
+      Pointee: 190 GoSliceDataType [][]uint.array
     - __kind: PointerType
-      ID: 213
+      ID: 197
       Name: '*[]bool.array'
       ByteSize: 8
-      Pointee: 212 GoSliceDataType []bool.array
+      Pointee: 196 GoSliceDataType []bool.array
     - __kind: PointerType
-      ID: 220
+      ID: 213
       Name: '*[]main.structWithMap.array'
       ByteSize: 8
-      Pointee: 219 GoSliceDataType []main.structWithMap.array
+      Pointee: 212 GoSliceDataType []main.structWithMap.array
     - __kind: PointerType
-      ID: 209
+      ID: 193
       Name: '*[]main.structWithNoStrings.array'
       ByteSize: 8
-      Pointee: 208 GoSliceDataType []main.structWithNoStrings.array
+      Pointee: 192 GoSliceDataType []main.structWithNoStrings.array
     - __kind: PointerType
-      ID: 211
+      ID: 195
       Name: '*[]string.array'
       ByteSize: 8
-      Pointee: 210 GoSliceDataType []string.array
+      Pointee: 194 GoSliceDataType []string.array
     - __kind: PointerType
       ID: 139
       Name: '*[]uint'
       ByteSize: 8
       Pointee: 137 GoSliceHeaderType []uint
     - __kind: PointerType
-      ID: 205
+      ID: 189
       Name: '*[]uint.array'
       ByteSize: 8
-      Pointee: 204 GoSliceDataType []uint.array
+      Pointee: 188 GoSliceDataType []uint.array
     - __kind: PointerType
-      ID: 215
+      ID: 199
       Name: '*[]uint16.array'
       ByteSize: 8
-      Pointee: 214 GoSliceDataType []uint16.array
+      Pointee: 198 GoSliceDataType []uint16.array
     - __kind: PointerType
       ID: 5
       Name: '*bool'
@@ -3372,7 +3355,7 @@ Types:
       GoKind: 22
       Pointee: 149 StructureType main.oneStringStruct
     - __kind: PointerType
-      ID: 177
+      ID: 173
       Name: '*main.structWithMap'
       ByteSize: 8
       GoRuntimeType: 354144
@@ -3396,10 +3379,10 @@ Types:
       GoKind: 22
       Pointee: 136 GoSliceHeaderType main.t
     - __kind: PointerType
-      ID: 203
+      ID: 211
       Name: '*main.t.array'
       ByteSize: 8
-      Pointee: 202 GoSliceDataType main.t.array
+      Pointee: 210 GoSliceDataType main.t.array
     - __kind: PointerType
       ID: 147
       Name: '*main.threeStringStruct'
@@ -3413,19 +3396,12 @@ Types:
       GoKind: 22
       Pointee: 78 GoMapType map[string]int
     - __kind: PointerType
-      ID: 167
-      Name: '*runtime.bmap'
-      ByteSize: 8
-      GoRuntimeType: 1.101088e+06
-      GoKind: 22
-      Pointee: 168 StructureType runtime.bmap
-    - __kind: PointerType
       ID: 71
       Name: '*runtime.mapextra'
       ByteSize: 8
       GoRuntimeType: 363168
       GoKind: 22
-      Pointee: 72 StructureType runtime.mapextra
+      Pointee: 72 UnresolvedPointeeType runtime.mapextra
     - __kind: PointerType
       ID: 22
       Name: '*string'
@@ -3434,10 +3410,10 @@ Types:
       GoKind: 22
       Pointee: 11 GoStringHeaderType string
     - __kind: PointerType
-      ID: 187
+      ID: 154
       Name: '*string.str'
       ByteSize: 8
-      Pointee: 186 GoStringDataType string.str
+      Pointee: 153 GoStringDataType string.str
     - __kind: PointerType
       ID: 34
       Name: '*uint'
@@ -3481,10 +3457,10 @@ Types:
       GoKind: 22
       Pointee: 1 BaseType uintptr
     - __kind: EventRootType
-      ID: 308
+      ID: 301
       Name: Probe[main.stackC]
     - __kind: EventRootType
-      ID: 265
+      ID: 258
       Name: Probe[main.testAny]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -3499,7 +3475,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 237
+      ID: 230
       Name: Probe[main.testArrayOfArraysOfArrays]
       ByteSize: 65
       PresenceBitsetSize: 1
@@ -3514,7 +3490,7 @@ Types:
                   Offset: 0
                   ByteSize: 64
     - __kind: EventRootType
-      ID: 235
+      ID: 228
       Name: Probe[main.testArrayOfArrays]
       ByteSize: 33
       PresenceBitsetSize: 1
@@ -3529,7 +3505,7 @@ Types:
                   Offset: 0
                   ByteSize: 32
     - __kind: EventRootType
-      ID: 273
+      ID: 266
       Name: Probe[main.testArrayOfMaps]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -3544,7 +3520,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 236
+      ID: 229
       Name: Probe[main.testArrayOfStrings]
       ByteSize: 33
       PresenceBitsetSize: 1
@@ -3559,7 +3535,7 @@ Types:
                   Offset: 0
                   ByteSize: 32
     - __kind: EventRootType
-      ID: 255
+      ID: 248
       Name: Probe[main.testBigStruct]
       ByteSize: 49
       PresenceBitsetSize: 1
@@ -3574,7 +3550,7 @@ Types:
                   Offset: 0
                   ByteSize: 48
     - __kind: EventRootType
-      ID: 224
+      ID: 217
       Name: Probe[main.testBoolArray]
       ByteSize: 3
       PresenceBitsetSize: 1
@@ -3589,7 +3565,7 @@ Types:
                   Offset: 0
                   ByteSize: 2
     - __kind: EventRootType
-      ID: 221
+      ID: 214
       Name: Probe[main.testByteArray]
       ByteSize: 3
       PresenceBitsetSize: 1
@@ -3604,7 +3580,7 @@ Types:
                   Offset: 0
                   ByteSize: 2
     - __kind: EventRootType
-      ID: 289
+      ID: 282
       Name: Probe[main.testChannel]
       ByteSize: 1
       PresenceBitsetSize: 1
@@ -3619,7 +3595,7 @@ Types:
                   Offset: 0
                   ByteSize: 0
     - __kind: EventRootType
-      ID: 287
+      ID: 280
       Name: Probe[main.testCombinedByte]
       ByteSize: 7
       PresenceBitsetSize: 1
@@ -3652,7 +3628,7 @@ Types:
                   Offset: 0
                   ByteSize: 4
     - __kind: EventRootType
-      ID: 297
+      ID: 290
       Name: Probe[main.testCycle]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -3667,7 +3643,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 302
+      ID: 295
       Name: Probe[main.testEmptySliceOfStructs]
       ByteSize: 33
       PresenceBitsetSize: 1
@@ -3691,7 +3667,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 299
+      ID: 292
       Name: Probe[main.testEmptySlice]
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -3706,7 +3682,7 @@ Types:
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 316
+      ID: 309
       Name: Probe[main.testEmptyString]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -3721,7 +3697,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 318
+      ID: 311
       Name: Probe[main.testEmptyStruct]
       ByteSize: 1
       PresenceBitsetSize: 1
@@ -3736,7 +3712,7 @@ Types:
                   Offset: 0
                   ByteSize: 0
     - __kind: EventRootType
-      ID: 266
+      ID: 259
       Name: Probe[main.testError]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -3751,7 +3727,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 257
+      ID: 250
       Name: Probe[main.testEsotericHeap]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -3766,7 +3742,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 256
+      ID: 249
       Name: Probe[main.testEsotericStack]
       ByteSize: 65
       PresenceBitsetSize: 1
@@ -3781,7 +3757,7 @@ Types:
                   Offset: 0
                   ByteSize: 64
     - __kind: EventRootType
-      ID: 263
+      ID: 256
       Name: Probe[main.testFramelessArray]
       ByteSize: 41
       PresenceBitsetSize: 1
@@ -3796,7 +3772,7 @@ Types:
                   Offset: 0
                   ByteSize: 40
     - __kind: EventRootType
-      ID: 262
+      ID: 255
       Name: Probe[main.testFrameless]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -3811,7 +3787,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 258
+      ID: 251
       Name: Probe[main.testInlinedBA]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -3826,7 +3802,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 260
+      ID: 253
       Name: Probe[main.testInlinedBBA]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -3841,10 +3817,10 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 320
+      ID: 313
       Name: Probe[main.testInlinedBBB]
     - __kind: EventRootType
-      ID: 259
+      ID: 252
       Name: Probe[main.testInlinedBB]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -3868,16 +3844,16 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 321
+      ID: 314
       Name: Probe[main.testInlinedBCA]
     - __kind: EventRootType
-      ID: 322
+      ID: 315
       Name: Probe[main.testInlinedBCB]
     - __kind: EventRootType
-      ID: 261
+      ID: 254
       Name: Probe[main.testInlinedBC]
     - __kind: EventRootType
-      ID: 319
+      ID: 312
       Name: Probe[main.testInlinedPrint]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -3892,7 +3868,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 323
+      ID: 316
       Name: Probe[main.testInlinedSq]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -3907,7 +3883,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 324
+      ID: 317
       Name: Probe[main.testInlinedSumArray]
       ByteSize: 41
       PresenceBitsetSize: 1
@@ -3922,7 +3898,7 @@ Types:
                   Offset: 0
                   ByteSize: 40
     - __kind: EventRootType
-      ID: 227
+      ID: 220
       Name: Probe[main.testInt16Array]
       ByteSize: 5
       PresenceBitsetSize: 1
@@ -3937,7 +3913,7 @@ Types:
                   Offset: 0
                   ByteSize: 4
     - __kind: EventRootType
-      ID: 228
+      ID: 221
       Name: Probe[main.testInt32Array]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -3952,7 +3928,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 229
+      ID: 222
       Name: Probe[main.testInt64Array]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -3967,7 +3943,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 226
+      ID: 219
       Name: Probe[main.testInt8Array]
       ByteSize: 3
       PresenceBitsetSize: 1
@@ -3982,7 +3958,7 @@ Types:
                   Offset: 0
                   ByteSize: 2
     - __kind: EventRootType
-      ID: 225
+      ID: 218
       Name: Probe[main.testIntArray]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -3997,7 +3973,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 264
+      ID: 257
       Name: Probe[main.testInterface]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -4012,7 +3988,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 291
+      ID: 284
       Name: Probe[main.testLinkedList]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -4027,7 +4003,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 271
+      ID: 264
       Name: Probe[main.testMapArrayToArray]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -4042,7 +4018,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 277
+      ID: 270
       Name: Probe[main.testMapEmbeddedMaps]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -4057,7 +4033,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 275
+      ID: 268
       Name: Probe[main.testMapIntToInt]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -4072,7 +4048,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 286
+      ID: 279
       Name: Probe[main.testMapLargeKeyLargeValue]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -4087,7 +4063,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 285
+      ID: 278
       Name: Probe[main.testMapLargeKeySmallValue]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -4102,7 +4078,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 276
+      ID: 269
       Name: Probe[main.testMapMassive]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -4117,7 +4093,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 284
+      ID: 277
       Name: Probe[main.testMapSmallKeyLargeValue]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -4132,7 +4108,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 283
+      ID: 276
       Name: Probe[main.testMapSmallKeySmallValue]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -4147,7 +4123,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 269
+      ID: 262
       Name: Probe[main.testMapStringToInt]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -4162,7 +4138,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 270
+      ID: 263
       Name: Probe[main.testMapStringToSlice]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -4177,7 +4153,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 268
+      ID: 261
       Name: Probe[main.testMapStringToStruct]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -4192,7 +4168,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 278
+      ID: 271
       Name: Probe[main.testMapWithLinkedList]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -4207,7 +4183,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 282
+      ID: 275
       Name: Probe[main.testMapWithSmallKeyAndValueMassive]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -4222,7 +4198,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 281
+      ID: 274
       Name: Probe[main.testMapWithSmallKeyAndValue]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -4237,7 +4213,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 280
+      ID: 273
       Name: Probe[main.testMapWithSmallValueMassive]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -4252,7 +4228,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 279
+      ID: 272
       Name: Probe[main.testMapWithSmallValue]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -4267,7 +4243,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 314
+      ID: 307
       Name: Probe[main.testMassiveString]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -4282,7 +4258,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 288
+      ID: 281
       Name: Probe[main.testMultipleSimpleParams]
       ByteSize: 31
       PresenceBitsetSize: 1
@@ -4333,7 +4309,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 296
+      ID: 289
       Name: Probe[main.testNilPointer]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -4357,7 +4333,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 303
+      ID: 296
       Name: Probe[main.testNilSliceOfStructs]
       ByteSize: 33
       PresenceBitsetSize: 1
@@ -4381,7 +4357,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 305
+      ID: 298
       Name: Probe[main.testNilSliceWithOtherParams]
       ByteSize: 34
       PresenceBitsetSize: 1
@@ -4414,7 +4390,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 306
+      ID: 299
       Name: Probe[main.testNilSlice]
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -4429,7 +4405,7 @@ Types:
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 313
+      ID: 306
       Name: Probe[main.testOneStringInStructPointer]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -4444,7 +4420,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 292
+      ID: 285
       Name: Probe[main.testPointerLoop]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -4459,7 +4435,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 274
+      ID: 267
       Name: Probe[main.testPointerToMap]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -4474,7 +4450,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 290
+      ID: 283
       Name: Probe[main.testPointerToSimpleStruct]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -4489,7 +4465,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 222
+      ID: 215
       Name: Probe[main.testRuneArray]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -4504,7 +4480,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 241
+      ID: 234
       Name: Probe[main.testSingleBool]
       ByteSize: 2
       PresenceBitsetSize: 1
@@ -4519,7 +4495,7 @@ Types:
                   Offset: 0
                   ByteSize: 1
     - __kind: EventRootType
-      ID: 239
+      ID: 232
       Name: Probe[main.testSingleByte]
       ByteSize: 2
       PresenceBitsetSize: 1
@@ -4534,7 +4510,7 @@ Types:
                   Offset: 0
                   ByteSize: 1
     - __kind: EventRootType
-      ID: 252
+      ID: 245
       Name: Probe[main.testSingleFloat32]
       ByteSize: 5
       PresenceBitsetSize: 1
@@ -4549,7 +4525,7 @@ Types:
                   Offset: 0
                   ByteSize: 4
     - __kind: EventRootType
-      ID: 253
+      ID: 246
       Name: Probe[main.testSingleFloat64]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -4564,7 +4540,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 244
+      ID: 237
       Name: Probe[main.testSingleInt16]
       ByteSize: 3
       PresenceBitsetSize: 1
@@ -4579,7 +4555,7 @@ Types:
                   Offset: 0
                   ByteSize: 2
     - __kind: EventRootType
-      ID: 245
+      ID: 238
       Name: Probe[main.testSingleInt32]
       ByteSize: 5
       PresenceBitsetSize: 1
@@ -4594,7 +4570,7 @@ Types:
                   Offset: 0
                   ByteSize: 4
     - __kind: EventRootType
-      ID: 246
+      ID: 239
       Name: Probe[main.testSingleInt64]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -4609,7 +4585,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 243
+      ID: 236
       Name: Probe[main.testSingleInt8]
       ByteSize: 2
       PresenceBitsetSize: 1
@@ -4624,7 +4600,7 @@ Types:
                   Offset: 0
                   ByteSize: 1
     - __kind: EventRootType
-      ID: 242
+      ID: 235
       Name: Probe[main.testSingleInt]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -4639,7 +4615,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 240
+      ID: 233
       Name: Probe[main.testSingleRune]
       ByteSize: 5
       PresenceBitsetSize: 1
@@ -4654,7 +4630,7 @@ Types:
                   Offset: 0
                   ByteSize: 4
     - __kind: EventRootType
-      ID: 309
+      ID: 302
       Name: Probe[main.testSingleString]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -4669,7 +4645,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 249
+      ID: 242
       Name: Probe[main.testSingleUint16]
       ByteSize: 3
       PresenceBitsetSize: 1
@@ -4684,7 +4660,7 @@ Types:
                   Offset: 0
                   ByteSize: 2
     - __kind: EventRootType
-      ID: 250
+      ID: 243
       Name: Probe[main.testSingleUint32]
       ByteSize: 5
       PresenceBitsetSize: 1
@@ -4699,7 +4675,7 @@ Types:
                   Offset: 0
                   ByteSize: 4
     - __kind: EventRootType
-      ID: 251
+      ID: 244
       Name: Probe[main.testSingleUint64]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -4714,7 +4690,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 248
+      ID: 241
       Name: Probe[main.testSingleUint8]
       ByteSize: 2
       PresenceBitsetSize: 1
@@ -4729,7 +4705,7 @@ Types:
                   Offset: 0
                   ByteSize: 1
     - __kind: EventRootType
-      ID: 247
+      ID: 240
       Name: Probe[main.testSingleUint]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -4744,7 +4720,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 300
+      ID: 293
       Name: Probe[main.testSliceOfSlices]
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -4759,7 +4735,7 @@ Types:
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 272
+      ID: 265
       Name: Probe[main.testSmallMap]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -4774,7 +4750,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 223
+      ID: 216
       Name: Probe[main.testStringArray]
       ByteSize: 33
       PresenceBitsetSize: 1
@@ -4789,7 +4765,7 @@ Types:
                   Offset: 0
                   ByteSize: 32
     - __kind: EventRootType
-      ID: 295
+      ID: 288
       Name: Probe[main.testStringPointer]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -4804,7 +4780,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 304
+      ID: 297
       Name: Probe[main.testStringSlice]
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -4819,7 +4795,7 @@ Types:
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 301
+      ID: 294
       Name: Probe[main.testStructSlice]
       ByteSize: 33
       PresenceBitsetSize: 1
@@ -4843,7 +4819,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 267
+      ID: 260
       Name: Probe[main.testStructWithMap]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -4858,7 +4834,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 317
+      ID: 310
       Name: Probe[main.testStruct]
       ByteSize: 57
       PresenceBitsetSize: 1
@@ -4873,7 +4849,7 @@ Types:
                   Offset: 0
                   ByteSize: 56
     - __kind: EventRootType
-      ID: 312
+      ID: 305
       Name: Probe[main.testThreeStringsInStructPointer]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -4888,7 +4864,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 311
+      ID: 304
       Name: Probe[main.testThreeStringsInStruct]
       ByteSize: 49
       PresenceBitsetSize: 1
@@ -4903,7 +4879,7 @@ Types:
                   Offset: 0
                   ByteSize: 48
     - __kind: EventRootType
-      ID: 310
+      ID: 303
       Name: Probe[main.testThreeStrings]
       ByteSize: 49
       PresenceBitsetSize: 1
@@ -4936,7 +4912,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 254
+      ID: 247
       Name: Probe[main.testTypeAlias]
       ByteSize: 3
       PresenceBitsetSize: 1
@@ -4951,7 +4927,7 @@ Types:
                   Offset: 0
                   ByteSize: 2
     - __kind: EventRootType
-      ID: 232
+      ID: 225
       Name: Probe[main.testUint16Array]
       ByteSize: 5
       PresenceBitsetSize: 1
@@ -4966,7 +4942,7 @@ Types:
                   Offset: 0
                   ByteSize: 4
     - __kind: EventRootType
-      ID: 233
+      ID: 226
       Name: Probe[main.testUint32Array]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -4981,7 +4957,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 234
+      ID: 227
       Name: Probe[main.testUint64Array]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -4996,7 +4972,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 231
+      ID: 224
       Name: Probe[main.testUint8Array]
       ByteSize: 3
       PresenceBitsetSize: 1
@@ -5011,7 +4987,7 @@ Types:
                   Offset: 0
                   ByteSize: 2
     - __kind: EventRootType
-      ID: 230
+      ID: 223
       Name: Probe[main.testUintArray]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -5026,7 +5002,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 294
+      ID: 287
       Name: Probe[main.testUintPointer]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -5041,7 +5017,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 298
+      ID: 291
       Name: Probe[main.testUintSlice]
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -5056,7 +5032,7 @@ Types:
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 315
+      ID: 308
       Name: Probe[main.testUnitializedString]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -5071,7 +5047,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 293
+      ID: 286
       Name: Probe[main.testUnsafePointer]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -5086,7 +5062,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 238
+      ID: 231
       Name: Probe[main.testVeryLargeArray]
       ByteSize: 801
       PresenceBitsetSize: 1
@@ -5101,7 +5077,7 @@ Types:
                   Offset: 0
                   ByteSize: 800
     - __kind: EventRootType
-      ID: 307
+      ID: 300
       Name: Probe[main.testVeryLargeSlice]
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -5258,7 +5234,7 @@ Types:
       HasCount: true
       Element: 9 BaseType int
     - __kind: ArrayType
-      ID: 173
+      ID: 168
       Name: '[4]string'
       ByteSize: 64
       GoRuntimeType: 617824
@@ -5275,7 +5251,7 @@ Types:
       HasCount: true
       Element: 9 BaseType int
     - __kind: ArrayType
-      ID: 162
+      ID: 157
       Name: '[8]uint8'
       ByteSize: 8
       GoRuntimeType: 615616
@@ -5283,28 +5259,6 @@ Types:
       Count: 8
       HasCount: true
       Element: 3 BaseType uint8
-    - __kind: GoSliceHeaderType
-      ID: 166
-      Name: '[]*runtime.bmap'
-      ByteSize: 24
-      GoRuntimeType: 451744
-      GoKind: 23
-      RawFields:
-        - Name: array
-          Offset: 0
-          Type: 216 PointerType **runtime.bmap
-        - Name: len
-          Offset: 8
-          Type: 9 BaseType int
-        - Name: cap
-          Offset: 16
-          Type: 9 BaseType int
-      Data: 217 GoSliceDataType []*runtime.bmap.array
-    - __kind: GoSliceDataType
-      ID: 217
-      Name: '[]*runtime.bmap.array'
-      ByteSize: 2048
-      Element: 167 PointerType *runtime.bmap
     - __kind: GoSliceHeaderType
       ID: 53
       Name: '[]*string'
@@ -5321,9 +5275,9 @@ Types:
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 188 GoSliceDataType []*string.array
+      Data: 155 GoSliceDataType []*string.array
     - __kind: GoSliceDataType
-      ID: 188
+      ID: 155
       Name: '[]*string.array'
       ByteSize: 2048
       Element: 22 PointerType *string
@@ -5342,9 +5296,9 @@ Types:
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 206 GoSliceDataType [][]uint.array
+      Data: 190 GoSliceDataType [][]uint.array
     - __kind: GoSliceDataType
-      ID: 206
+      ID: 190
       Name: '[][]uint.array'
       ByteSize: 2048
       Element: 137 GoSliceHeaderType []uint
@@ -5364,116 +5318,116 @@ Types:
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 212 GoSliceDataType []bool.array
+      Data: 196 GoSliceDataType []bool.array
     - __kind: GoSliceDataType
-      ID: 212
+      ID: 196
       Name: '[]bool.array'
       ByteSize: 2048
       Element: 4 BaseType bool
     - __kind: GoSliceDataType
-      ID: 201
+      ID: 187
       Name: '[]bucket<[4]int,[4]int>.array'
       ByteSize: 2048
       Element: 129 GoHMapBucketType bucket<[4]int,[4]int>
     - __kind: GoSliceDataType
-      ID: 200
+      ID: 186
       Name: '[]bucket<[4]int,uint8>.array'
       ByteSize: 2048
       Element: 124 GoHMapBucketType bucket<[4]int,uint8>
     - __kind: GoSliceDataType
-      ID: 194
+      ID: 170
       Name: '[]bucket<[4]string,[2]int>.array'
       ByteSize: 2048
       Element: 92 GoHMapBucketType bucket<[4]string,[2]int>
     - __kind: GoSliceDataType
-      ID: 196
+      ID: 177
       Name: '[]bucket<bool,main.node>.array'
       ByteSize: 2048
       Element: 104 GoHMapBucketType bucket<bool,main.node>
     - __kind: GoSliceDataType
-      ID: 190
+      ID: 160
       Name: '[]bucket<int,int>.array'
       ByteSize: 2048
       Element: 70 GoHMapBucketType bucket<int,int>
     - __kind: GoSliceDataType
-      ID: 197
+      ID: 179
       Name: '[]bucket<int,uint8>.array'
       ByteSize: 2048
       Element: 109 GoHMapBucketType bucket<int,uint8>
     - __kind: GoSliceDataType
-      ID: 195
+      ID: 174
       Name: '[]bucket<string,[]main.structWithMap>.array'
       ByteSize: 2048
       Element: 99 GoHMapBucketType bucket<string,[]main.structWithMap>
     - __kind: GoSliceDataType
-      ID: 193
+      ID: 166
       Name: '[]bucket<string,[]string>.array'
       ByteSize: 2048
       Element: 87 GoHMapBucketType bucket<string,[]string>
     - __kind: GoSliceDataType
-      ID: 192
+      ID: 164
       Name: '[]bucket<string,int>.array'
       ByteSize: 2048
       Element: 82 GoHMapBucketType bucket<string,int>
     - __kind: GoSliceDataType
-      ID: 191
+      ID: 163
       Name: '[]bucket<string,main.nestedStruct>.array'
       ByteSize: 2048
       Element: 77 GoHMapBucketType bucket<string,main.nestedStruct>
     - __kind: GoSliceDataType
-      ID: 199
+      ID: 184
       Name: '[]bucket<uint8,[4]int>.array'
       ByteSize: 2048
       Element: 119 GoHMapBucketType bucket<uint8,[4]int>
     - __kind: GoSliceDataType
-      ID: 198
+      ID: 181
       Name: '[]bucket<uint8,uint8>.array'
       ByteSize: 2048
       Element: 114 GoHMapBucketType bucket<uint8,uint8>
     - __kind: ArrayType
-      ID: 184
+      ID: 185
       Name: '[]key<[4]int>'
       ByteSize: 256
       Count: 8
       HasCount: true
       Element: 183 ArrayType [4]int
     - __kind: ArrayType
-      ID: 172
+      ID: 167
       Name: '[]key<[4]string>'
       ByteSize: 512
       Count: 8
       HasCount: true
-      Element: 173 ArrayType [4]string
+      Element: 168 ArrayType [4]string
     - __kind: ArrayType
-      ID: 178
+      ID: 175
       Name: '[]key<bool>'
       ByteSize: 8
       Count: 8
       HasCount: true
       Element: 4 BaseType bool
     - __kind: ArrayType
-      ID: 163
+      ID: 158
       Name: '[]key<int>'
       ByteSize: 64
       Count: 8
       HasCount: true
       Element: 9 BaseType int
     - __kind: ArrayType
-      ID: 169
+      ID: 161
       Name: '[]key<string>'
       ByteSize: 128
       Count: 8
       HasCount: true
       Element: 11 GoStringHeaderType string
     - __kind: ArrayType
-      ID: 181
+      ID: 180
       Name: '[]key<uint8>'
       ByteSize: 8
       Count: 8
       HasCount: true
       Element: 3 BaseType uint8
     - __kind: GoSliceHeaderType
-      ID: 176
+      ID: 172
       Name: '[]main.structWithMap'
       ByteSize: 24
       GoRuntimeType: 442848
@@ -5481,16 +5435,16 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 177 PointerType *main.structWithMap
+          Type: 173 PointerType *main.structWithMap
         - Name: len
           Offset: 8
           Type: 9 BaseType int
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 219 GoSliceDataType []main.structWithMap.array
+      Data: 212 GoSliceDataType []main.structWithMap.array
     - __kind: GoSliceDataType
-      ID: 219
+      ID: 212
       Name: '[]main.structWithMap.array'
       ByteSize: 2048
       Element: 65 StructureType main.structWithMap
@@ -5509,9 +5463,9 @@ Types:
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 208 GoSliceDataType []main.structWithNoStrings.array
+      Data: 192 GoSliceDataType []main.structWithNoStrings.array
     - __kind: GoSliceDataType
-      ID: 208
+      ID: 192
       Name: '[]main.structWithNoStrings.array'
       ByteSize: 2048
       Element: 142 StructureType main.structWithNoStrings
@@ -5531,9 +5485,9 @@ Types:
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 210 GoSliceDataType []string.array
+      Data: 194 GoSliceDataType []string.array
     - __kind: GoSliceDataType
-      ID: 210
+      ID: 194
       Name: '[]string.array'
       ByteSize: 2048
       Element: 11 GoStringHeaderType string
@@ -5553,9 +5507,9 @@ Types:
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 204 GoSliceDataType []uint.array
+      Data: 188 GoSliceDataType []uint.array
     - __kind: GoSliceDataType
-      ID: 204
+      ID: 188
       Name: '[]uint.array'
       ByteSize: 2048
       Element: 12 BaseType uint
@@ -5575,14 +5529,14 @@ Types:
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 214 GoSliceDataType []uint16.array
+      Data: 198 GoSliceDataType []uint16.array
     - __kind: GoSliceDataType
-      ID: 214
+      ID: 198
       Name: '[]uint16.array'
       ByteSize: 2048
       Element: 7 BaseType uint16
     - __kind: ArrayType
-      ID: 174
+      ID: 169
       Name: '[]val<[2]int>'
       ByteSize: 128
       Count: 8
@@ -5596,42 +5550,42 @@ Types:
       HasCount: true
       Element: 183 ArrayType [4]int
     - __kind: ArrayType
-      ID: 175
+      ID: 171
       Name: '[]val<[]main.structWithMap>'
       ByteSize: 192
       Count: 8
       HasCount: true
-      Element: 176 GoSliceHeaderType []main.structWithMap
+      Element: 172 GoSliceHeaderType []main.structWithMap
     - __kind: ArrayType
-      ID: 171
+      ID: 165
       Name: '[]val<[]string>'
       ByteSize: 192
       Count: 8
       HasCount: true
       Element: 143 GoSliceHeaderType []string
     - __kind: ArrayType
-      ID: 164
+      ID: 159
       Name: '[]val<int>'
       ByteSize: 64
       Count: 8
       HasCount: true
       Element: 9 BaseType int
     - __kind: ArrayType
-      ID: 170
+      ID: 162
       Name: '[]val<main.nestedStruct>'
       ByteSize: 192
       Count: 8
       HasCount: true
       Element: 151 StructureType main.nestedStruct
     - __kind: ArrayType
-      ID: 179
+      ID: 176
       Name: '[]val<main.node>'
       ByteSize: 128
       Count: 8
       HasCount: true
       Element: 133 StructureType main.node
     - __kind: ArrayType
-      ID: 180
+      ID: 178
       Name: '[]val<uint8>'
       ByteSize: 8
       Count: 8
@@ -5650,10 +5604,10 @@ Types:
       RawFields:
         - Name: tophash
           Offset: 0
-          Type: 162 ArrayType [8]uint8
+          Type: 157 ArrayType [8]uint8
         - Name: keys
           Offset: 8
-          Type: 184 ArrayType []key<[4]int>
+          Type: 185 ArrayType []key<[4]int>
         - Name: values
           Offset: 264
           Type: 182 ArrayType []val<[4]int>
@@ -5669,13 +5623,13 @@ Types:
       RawFields:
         - Name: tophash
           Offset: 0
-          Type: 162 ArrayType [8]uint8
+          Type: 157 ArrayType [8]uint8
         - Name: keys
           Offset: 8
-          Type: 184 ArrayType []key<[4]int>
+          Type: 185 ArrayType []key<[4]int>
         - Name: values
           Offset: 264
-          Type: 180 ArrayType []val<uint8>
+          Type: 178 ArrayType []val<uint8>
         - Name: overflow
           Offset: 272
           Type: 123 PointerType *bucket<[4]int,uint8>
@@ -5688,17 +5642,17 @@ Types:
       RawFields:
         - Name: tophash
           Offset: 0
-          Type: 162 ArrayType [8]uint8
+          Type: 157 ArrayType [8]uint8
         - Name: keys
           Offset: 8
-          Type: 172 ArrayType []key<[4]string>
+          Type: 167 ArrayType []key<[4]string>
         - Name: values
           Offset: 520
-          Type: 174 ArrayType []val<[2]int>
+          Type: 169 ArrayType []val<[2]int>
         - Name: overflow
           Offset: 648
           Type: 91 PointerType *bucket<[4]string,[2]int>
-      KeyType: 173 ArrayType [4]string
+      KeyType: 168 ArrayType [4]string
       ValueType: 40 ArrayType [2]int
     - __kind: GoHMapBucketType
       ID: 104
@@ -5707,13 +5661,13 @@ Types:
       RawFields:
         - Name: tophash
           Offset: 0
-          Type: 162 ArrayType [8]uint8
+          Type: 157 ArrayType [8]uint8
         - Name: keys
           Offset: 8
-          Type: 178 ArrayType []key<bool>
+          Type: 175 ArrayType []key<bool>
         - Name: values
           Offset: 16
-          Type: 179 ArrayType []val<main.node>
+          Type: 176 ArrayType []val<main.node>
         - Name: overflow
           Offset: 144
           Type: 103 PointerType *bucket<bool,main.node>
@@ -5726,13 +5680,13 @@ Types:
       RawFields:
         - Name: tophash
           Offset: 0
-          Type: 162 ArrayType [8]uint8
+          Type: 157 ArrayType [8]uint8
         - Name: keys
           Offset: 8
-          Type: 163 ArrayType []key<int>
+          Type: 158 ArrayType []key<int>
         - Name: values
           Offset: 72
-          Type: 164 ArrayType []val<int>
+          Type: 159 ArrayType []val<int>
         - Name: overflow
           Offset: 136
           Type: 69 PointerType *bucket<int,int>
@@ -5745,13 +5699,13 @@ Types:
       RawFields:
         - Name: tophash
           Offset: 0
-          Type: 162 ArrayType [8]uint8
+          Type: 157 ArrayType [8]uint8
         - Name: keys
           Offset: 8
-          Type: 163 ArrayType []key<int>
+          Type: 158 ArrayType []key<int>
         - Name: values
           Offset: 72
-          Type: 180 ArrayType []val<uint8>
+          Type: 178 ArrayType []val<uint8>
         - Name: overflow
           Offset: 80
           Type: 108 PointerType *bucket<int,uint8>
@@ -5764,18 +5718,18 @@ Types:
       RawFields:
         - Name: tophash
           Offset: 0
-          Type: 162 ArrayType [8]uint8
+          Type: 157 ArrayType [8]uint8
         - Name: keys
           Offset: 8
-          Type: 169 ArrayType []key<string>
+          Type: 161 ArrayType []key<string>
         - Name: values
           Offset: 136
-          Type: 175 ArrayType []val<[]main.structWithMap>
+          Type: 171 ArrayType []val<[]main.structWithMap>
         - Name: overflow
           Offset: 328
           Type: 98 PointerType *bucket<string,[]main.structWithMap>
       KeyType: 11 GoStringHeaderType string
-      ValueType: 176 GoSliceHeaderType []main.structWithMap
+      ValueType: 172 GoSliceHeaderType []main.structWithMap
     - __kind: GoHMapBucketType
       ID: 87
       Name: bucket<string,[]string>
@@ -5783,13 +5737,13 @@ Types:
       RawFields:
         - Name: tophash
           Offset: 0
-          Type: 162 ArrayType [8]uint8
+          Type: 157 ArrayType [8]uint8
         - Name: keys
           Offset: 8
-          Type: 169 ArrayType []key<string>
+          Type: 161 ArrayType []key<string>
         - Name: values
           Offset: 136
-          Type: 171 ArrayType []val<[]string>
+          Type: 165 ArrayType []val<[]string>
         - Name: overflow
           Offset: 328
           Type: 86 PointerType *bucket<string,[]string>
@@ -5802,13 +5756,13 @@ Types:
       RawFields:
         - Name: tophash
           Offset: 0
-          Type: 162 ArrayType [8]uint8
+          Type: 157 ArrayType [8]uint8
         - Name: keys
           Offset: 8
-          Type: 169 ArrayType []key<string>
+          Type: 161 ArrayType []key<string>
         - Name: values
           Offset: 136
-          Type: 164 ArrayType []val<int>
+          Type: 159 ArrayType []val<int>
         - Name: overflow
           Offset: 200
           Type: 81 PointerType *bucket<string,int>
@@ -5821,13 +5775,13 @@ Types:
       RawFields:
         - Name: tophash
           Offset: 0
-          Type: 162 ArrayType [8]uint8
+          Type: 157 ArrayType [8]uint8
         - Name: keys
           Offset: 8
-          Type: 169 ArrayType []key<string>
+          Type: 161 ArrayType []key<string>
         - Name: values
           Offset: 136
-          Type: 170 ArrayType []val<main.nestedStruct>
+          Type: 162 ArrayType []val<main.nestedStruct>
         - Name: overflow
           Offset: 328
           Type: 76 PointerType *bucket<string,main.nestedStruct>
@@ -5840,10 +5794,10 @@ Types:
       RawFields:
         - Name: tophash
           Offset: 0
-          Type: 162 ArrayType [8]uint8
+          Type: 157 ArrayType [8]uint8
         - Name: keys
           Offset: 8
-          Type: 181 ArrayType []key<uint8>
+          Type: 180 ArrayType []key<uint8>
         - Name: values
           Offset: 16
           Type: 182 ArrayType []val<[4]int>
@@ -5859,13 +5813,13 @@ Types:
       RawFields:
         - Name: tophash
           Offset: 0
-          Type: 162 ArrayType [8]uint8
+          Type: 157 ArrayType [8]uint8
         - Name: keys
           Offset: 8
-          Type: 181 ArrayType []key<uint8>
+          Type: 180 ArrayType []key<uint8>
         - Name: values
           Offset: 16
-          Type: 180 ArrayType []val<uint8>
+          Type: 178 ArrayType []val<uint8>
         - Name: overflow
           Offset: 24
           Type: 113 PointerType *bucket<uint8,uint8>
@@ -5957,7 +5911,7 @@ Types:
           Offset: 40
           Type: 71 PointerType *runtime.mapextra
       BucketType: 129 GoHMapBucketType bucket<[4]int,[4]int>
-      BucketsType: 201 GoSliceDataType []bucket<[4]int,[4]int>.array
+      BucketsType: 187 GoSliceDataType []bucket<[4]int,[4]int>.array
     - __kind: GoHMapHeaderType
       ID: 122
       Name: hash<[4]int,uint8>
@@ -5991,7 +5945,7 @@ Types:
           Offset: 40
           Type: 71 PointerType *runtime.mapextra
       BucketType: 124 GoHMapBucketType bucket<[4]int,uint8>
-      BucketsType: 200 GoSliceDataType []bucket<[4]int,uint8>.array
+      BucketsType: 186 GoSliceDataType []bucket<[4]int,uint8>.array
     - __kind: GoHMapHeaderType
       ID: 90
       Name: hash<[4]string,[2]int>
@@ -6025,7 +5979,7 @@ Types:
           Offset: 40
           Type: 71 PointerType *runtime.mapextra
       BucketType: 92 GoHMapBucketType bucket<[4]string,[2]int>
-      BucketsType: 194 GoSliceDataType []bucket<[4]string,[2]int>.array
+      BucketsType: 170 GoSliceDataType []bucket<[4]string,[2]int>.array
     - __kind: GoHMapHeaderType
       ID: 102
       Name: hash<bool,main.node>
@@ -6059,7 +6013,7 @@ Types:
           Offset: 40
           Type: 71 PointerType *runtime.mapextra
       BucketType: 104 GoHMapBucketType bucket<bool,main.node>
-      BucketsType: 196 GoSliceDataType []bucket<bool,main.node>.array
+      BucketsType: 177 GoSliceDataType []bucket<bool,main.node>.array
     - __kind: GoHMapHeaderType
       ID: 68
       Name: hash<int,int>
@@ -6093,7 +6047,7 @@ Types:
           Offset: 40
           Type: 71 PointerType *runtime.mapextra
       BucketType: 70 GoHMapBucketType bucket<int,int>
-      BucketsType: 190 GoSliceDataType []bucket<int,int>.array
+      BucketsType: 160 GoSliceDataType []bucket<int,int>.array
     - __kind: GoHMapHeaderType
       ID: 107
       Name: hash<int,uint8>
@@ -6127,7 +6081,7 @@ Types:
           Offset: 40
           Type: 71 PointerType *runtime.mapextra
       BucketType: 109 GoHMapBucketType bucket<int,uint8>
-      BucketsType: 197 GoSliceDataType []bucket<int,uint8>.array
+      BucketsType: 179 GoSliceDataType []bucket<int,uint8>.array
     - __kind: GoHMapHeaderType
       ID: 97
       Name: hash<string,[]main.structWithMap>
@@ -6161,7 +6115,7 @@ Types:
           Offset: 40
           Type: 71 PointerType *runtime.mapextra
       BucketType: 99 GoHMapBucketType bucket<string,[]main.structWithMap>
-      BucketsType: 195 GoSliceDataType []bucket<string,[]main.structWithMap>.array
+      BucketsType: 174 GoSliceDataType []bucket<string,[]main.structWithMap>.array
     - __kind: GoHMapHeaderType
       ID: 85
       Name: hash<string,[]string>
@@ -6195,7 +6149,7 @@ Types:
           Offset: 40
           Type: 71 PointerType *runtime.mapextra
       BucketType: 87 GoHMapBucketType bucket<string,[]string>
-      BucketsType: 193 GoSliceDataType []bucket<string,[]string>.array
+      BucketsType: 166 GoSliceDataType []bucket<string,[]string>.array
     - __kind: GoHMapHeaderType
       ID: 80
       Name: hash<string,int>
@@ -6229,7 +6183,7 @@ Types:
           Offset: 40
           Type: 71 PointerType *runtime.mapextra
       BucketType: 82 GoHMapBucketType bucket<string,int>
-      BucketsType: 192 GoSliceDataType []bucket<string,int>.array
+      BucketsType: 164 GoSliceDataType []bucket<string,int>.array
     - __kind: GoHMapHeaderType
       ID: 75
       Name: hash<string,main.nestedStruct>
@@ -6263,7 +6217,7 @@ Types:
           Offset: 40
           Type: 71 PointerType *runtime.mapextra
       BucketType: 77 GoHMapBucketType bucket<string,main.nestedStruct>
-      BucketsType: 191 GoSliceDataType []bucket<string,main.nestedStruct>.array
+      BucketsType: 163 GoSliceDataType []bucket<string,main.nestedStruct>.array
     - __kind: GoHMapHeaderType
       ID: 117
       Name: hash<uint8,[4]int>
@@ -6297,7 +6251,7 @@ Types:
           Offset: 40
           Type: 71 PointerType *runtime.mapextra
       BucketType: 119 GoHMapBucketType bucket<uint8,[4]int>
-      BucketsType: 199 GoSliceDataType []bucket<uint8,[4]int>.array
+      BucketsType: 184 GoSliceDataType []bucket<uint8,[4]int>.array
     - __kind: GoHMapHeaderType
       ID: 112
       Name: hash<uint8,uint8>
@@ -6331,7 +6285,7 @@ Types:
           Offset: 40
           Type: 71 PointerType *runtime.mapextra
       BucketType: 114 GoHMapBucketType bucket<uint8,uint8>
-      BucketsType: 198 GoSliceDataType []bucket<uint8,uint8>.array
+      BucketsType: 181 GoSliceDataType []bucket<uint8,uint8>.array
     - __kind: BaseType
       ID: 9
       Name: int
@@ -6451,16 +6405,16 @@ Types:
           Type: 56 StructureType main.esotericStack
         - Name: mu
           Offset: 64
-          Type: 153 StructureType sync.Mutex
+          Type: 200 StructureType sync.Mutex
         - Name: once
           Offset: 72
-          Type: 154 StructureType sync.Once
+          Type: 201 StructureType sync.Once
         - Name: wg
           Offset: 88
-          Type: 157 StructureType sync.WaitGroup
+          Type: 204 StructureType sync.WaitGroup
         - Name: a
           Offset: 104
-          Type: 161 StructureType sync/atomic.Int32
+          Type: 208 StructureType sync/atomic.Int32
     - __kind: StructureType
       ID: 56
       Name: main.esotericStack
@@ -6579,16 +6533,16 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 185 PointerType **main.t
+          Type: 209 PointerType **main.t
         - Name: len
           Offset: 8
           Type: 9 BaseType int
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 202 GoSliceDataType main.t.array
+      Data: 210 GoSliceDataType main.t.array
     - __kind: GoSliceDataType
-      ID: 202
+      ID: 210
       Name: main.t.array
       ByteSize: 2048
       Element: 135 PointerType *main.t
@@ -6696,32 +6650,10 @@ Types:
       GoRuntimeType: 874912
       GoKind: 21
       HeaderType: 112 GoHMapHeaderType hash<uint8,uint8>
-    - __kind: StructureType
-      ID: 168
-      Name: runtime.bmap
-      ByteSize: 8
-      GoRuntimeType: 1.10096e+06
-      GoKind: 25
-      RawFields:
-        - Name: tophash
-          Offset: 0
-          Type: 162 ArrayType [8]uint8
-    - __kind: StructureType
+    - __kind: UnresolvedPointeeType
       ID: 72
       Name: runtime.mapextra
-      ByteSize: 24
-      GoRuntimeType: 1.417408e+06
-      GoKind: 25
-      RawFields:
-        - Name: overflow
-          Offset: 0
-          Type: 165 PointerType *[]*runtime.bmap
-        - Name: oldoverflow
-          Offset: 8
-          Type: 165 PointerType *[]*runtime.bmap
-        - Name: nextOverflow
-          Offset: 16
-          Type: 167 PointerType *runtime.bmap
+      ByteSize: 8
     - __kind: GoStringHeaderType
       ID: 11
       Name: string
@@ -6731,17 +6663,17 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 187 PointerType *string.str
+          Type: 154 PointerType *string.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 186 GoStringDataType string.str
+      Data: 153 GoStringDataType string.str
     - __kind: GoStringDataType
-      ID: 186
+      ID: 153
       Name: string.str
       ByteSize: 2048
     - __kind: StructureType
-      ID: 153
+      ID: 200
       Name: sync.Mutex
       ByteSize: 8
       GoRuntimeType: 1.271488e+06
@@ -6754,7 +6686,7 @@ Types:
           Offset: 4
           Type: 2 BaseType uint32
     - __kind: StructureType
-      ID: 154
+      ID: 201
       Name: sync.Once
       ByteSize: 12
       GoRuntimeType: 1.272608e+06
@@ -6762,12 +6694,12 @@ Types:
       RawFields:
         - Name: done
           Offset: 0
-          Type: 155 StructureType sync/atomic.Uint32
+          Type: 202 StructureType sync/atomic.Uint32
         - Name: m
           Offset: 4
-          Type: 153 StructureType sync.Mutex
+          Type: 200 StructureType sync.Mutex
     - __kind: StructureType
-      ID: 157
+      ID: 204
       Name: sync.WaitGroup
       ByteSize: 16
       GoRuntimeType: 1.411456e+06
@@ -6775,21 +6707,21 @@ Types:
       RawFields:
         - Name: noCopy
           Offset: 0
-          Type: 158 StructureType sync.noCopy
+          Type: 205 StructureType sync.noCopy
         - Name: state
           Offset: 0
-          Type: 159 StructureType sync/atomic.Uint64
+          Type: 206 StructureType sync/atomic.Uint64
         - Name: sema
           Offset: 8
           Type: 2 BaseType uint32
     - __kind: StructureType
-      ID: 158
+      ID: 205
       Name: sync.noCopy
       GoRuntimeType: 940704
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 161
+      ID: 208
       Name: sync/atomic.Int32
       ByteSize: 4
       GoRuntimeType: 1.272928e+06
@@ -6797,12 +6729,12 @@ Types:
       RawFields:
         - Name: _
           Offset: 0
-          Type: 156 StructureType sync/atomic.noCopy
+          Type: 203 StructureType sync/atomic.noCopy
         - Name: v
           Offset: 0
           Type: 13 BaseType int32
     - __kind: StructureType
-      ID: 155
+      ID: 202
       Name: sync/atomic.Uint32
       ByteSize: 4
       GoRuntimeType: 1.273088e+06
@@ -6810,12 +6742,12 @@ Types:
       RawFields:
         - Name: _
           Offset: 0
-          Type: 156 StructureType sync/atomic.noCopy
+          Type: 203 StructureType sync/atomic.noCopy
         - Name: v
           Offset: 0
           Type: 2 BaseType uint32
     - __kind: StructureType
-      ID: 159
+      ID: 206
       Name: sync/atomic.Uint64
       ByteSize: 8
       GoRuntimeType: 1.41184e+06
@@ -6823,21 +6755,21 @@ Types:
       RawFields:
         - Name: _
           Offset: 0
-          Type: 156 StructureType sync/atomic.noCopy
+          Type: 203 StructureType sync/atomic.noCopy
         - Name: _
           Offset: 0
-          Type: 160 StructureType sync/atomic.align64
+          Type: 207 StructureType sync/atomic.align64
         - Name: v
           Offset: 0
           Type: 10 BaseType uint64
     - __kind: StructureType
-      ID: 160
+      ID: 207
       Name: sync/atomic.align64
       GoRuntimeType: 940896
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 156
+      ID: 203
       Name: sync/atomic.noCopy
       GoRuntimeType: 940800
       GoKind: 25
@@ -6884,6 +6816,6 @@ Types:
       ByteSize: 8
       GoRuntimeType: 528128
       GoKind: 26
-MaxTypeID: 324
+MaxTypeID: 317
 Issues: []
 GoModuledataInfo: {FirstModuledataAddr: "0x12cd8a0", TypesOffset: 296}

--- a/pkg/dyninst/irgen/testdata/snapshot/sample.arch=arm64,toolchain=go1.23.11.yaml
+++ b/pkg/dyninst/irgen/testdata/snapshot/sample.arch=arm64,toolchain=go1.23.11.yaml
@@ -3100,7 +3100,7 @@ Types:
       ByteSize: 8
       Pointee: 135 PointerType *main.t
     - __kind: PointerType
-      ID: 186
+      ID: 216
       Name: '**runtime.bmap'
       ByteSize: 8
       Pointee: 167 PointerType *runtime.bmap
@@ -3124,50 +3124,50 @@ Types:
       ByteSize: 8
       Pointee: 217 GoSliceDataType []*runtime.bmap.array
     - __kind: PointerType
-      ID: 190
+      ID: 189
       Name: '*[]*string.array'
       ByteSize: 8
-      Pointee: 189 GoSliceDataType []*string.array
+      Pointee: 188 GoSliceDataType []*string.array
     - __kind: PointerType
-      ID: 208
+      ID: 207
       Name: '*[][]uint.array'
       ByteSize: 8
-      Pointee: 207 GoSliceDataType [][]uint.array
+      Pointee: 206 GoSliceDataType [][]uint.array
     - __kind: PointerType
-      ID: 214
+      ID: 213
       Name: '*[]bool.array'
       ByteSize: 8
-      Pointee: 213 GoSliceDataType []bool.array
+      Pointee: 212 GoSliceDataType []bool.array
     - __kind: PointerType
       ID: 220
       Name: '*[]main.structWithMap.array'
       ByteSize: 8
       Pointee: 219 GoSliceDataType []main.structWithMap.array
     - __kind: PointerType
-      ID: 210
+      ID: 209
       Name: '*[]main.structWithNoStrings.array'
       ByteSize: 8
-      Pointee: 209 GoSliceDataType []main.structWithNoStrings.array
+      Pointee: 208 GoSliceDataType []main.structWithNoStrings.array
     - __kind: PointerType
-      ID: 212
+      ID: 211
       Name: '*[]string.array'
       ByteSize: 8
-      Pointee: 211 GoSliceDataType []string.array
+      Pointee: 210 GoSliceDataType []string.array
     - __kind: PointerType
       ID: 139
       Name: '*[]uint'
       ByteSize: 8
       Pointee: 137 GoSliceHeaderType []uint
     - __kind: PointerType
-      ID: 206
+      ID: 205
       Name: '*[]uint.array'
       ByteSize: 8
-      Pointee: 205 GoSliceDataType []uint.array
+      Pointee: 204 GoSliceDataType []uint.array
     - __kind: PointerType
-      ID: 216
+      ID: 215
       Name: '*[]uint16.array'
       ByteSize: 8
-      Pointee: 215 GoSliceDataType []uint16.array
+      Pointee: 214 GoSliceDataType []uint16.array
     - __kind: PointerType
       ID: 5
       Name: '*bool'
@@ -3396,10 +3396,10 @@ Types:
       GoKind: 22
       Pointee: 136 GoSliceHeaderType main.t
     - __kind: PointerType
-      ID: 204
+      ID: 203
       Name: '*main.t.array'
       ByteSize: 8
-      Pointee: 203 GoSliceDataType main.t.array
+      Pointee: 202 GoSliceDataType main.t.array
     - __kind: PointerType
       ID: 147
       Name: '*main.threeStringStruct'
@@ -3434,10 +3434,10 @@ Types:
       GoKind: 22
       Pointee: 11 GoStringHeaderType string
     - __kind: PointerType
-      ID: 188
+      ID: 187
       Name: '*string.str'
       ByteSize: 8
-      Pointee: 187 GoStringDataType string.str
+      Pointee: 186 GoStringDataType string.str
     - __kind: PointerType
       ID: 34
       Name: '*uint'
@@ -5292,7 +5292,7 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 186 PointerType **runtime.bmap
+          Type: 216 PointerType **runtime.bmap
         - Name: len
           Offset: 8
           Type: 9 BaseType int
@@ -5321,9 +5321,9 @@ Types:
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 189 GoSliceDataType []*string.array
+      Data: 188 GoSliceDataType []*string.array
     - __kind: GoSliceDataType
-      ID: 189
+      ID: 188
       Name: '[]*string.array'
       ByteSize: 2048
       Element: 22 PointerType *string
@@ -5342,9 +5342,9 @@ Types:
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 207 GoSliceDataType [][]uint.array
+      Data: 206 GoSliceDataType [][]uint.array
     - __kind: GoSliceDataType
-      ID: 207
+      ID: 206
       Name: '[][]uint.array'
       ByteSize: 2048
       Element: 137 GoSliceHeaderType []uint
@@ -5364,69 +5364,69 @@ Types:
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 213 GoSliceDataType []bool.array
+      Data: 212 GoSliceDataType []bool.array
     - __kind: GoSliceDataType
-      ID: 213
+      ID: 212
       Name: '[]bool.array'
       ByteSize: 2048
       Element: 4 BaseType bool
     - __kind: GoSliceDataType
-      ID: 202
+      ID: 201
       Name: '[]bucket<[4]int,[4]int>.array'
       ByteSize: 2048
       Element: 129 GoHMapBucketType bucket<[4]int,[4]int>
     - __kind: GoSliceDataType
-      ID: 201
+      ID: 200
       Name: '[]bucket<[4]int,uint8>.array'
       ByteSize: 2048
       Element: 124 GoHMapBucketType bucket<[4]int,uint8>
     - __kind: GoSliceDataType
-      ID: 195
+      ID: 194
       Name: '[]bucket<[4]string,[2]int>.array'
       ByteSize: 2048
       Element: 92 GoHMapBucketType bucket<[4]string,[2]int>
     - __kind: GoSliceDataType
-      ID: 197
+      ID: 196
       Name: '[]bucket<bool,main.node>.array'
       ByteSize: 2048
       Element: 104 GoHMapBucketType bucket<bool,main.node>
     - __kind: GoSliceDataType
-      ID: 191
+      ID: 190
       Name: '[]bucket<int,int>.array'
       ByteSize: 2048
       Element: 70 GoHMapBucketType bucket<int,int>
     - __kind: GoSliceDataType
-      ID: 198
+      ID: 197
       Name: '[]bucket<int,uint8>.array'
       ByteSize: 2048
       Element: 109 GoHMapBucketType bucket<int,uint8>
     - __kind: GoSliceDataType
-      ID: 196
+      ID: 195
       Name: '[]bucket<string,[]main.structWithMap>.array'
       ByteSize: 2048
       Element: 99 GoHMapBucketType bucket<string,[]main.structWithMap>
     - __kind: GoSliceDataType
-      ID: 194
+      ID: 193
       Name: '[]bucket<string,[]string>.array'
       ByteSize: 2048
       Element: 87 GoHMapBucketType bucket<string,[]string>
     - __kind: GoSliceDataType
-      ID: 193
+      ID: 192
       Name: '[]bucket<string,int>.array'
       ByteSize: 2048
       Element: 82 GoHMapBucketType bucket<string,int>
     - __kind: GoSliceDataType
-      ID: 192
+      ID: 191
       Name: '[]bucket<string,main.nestedStruct>.array'
       ByteSize: 2048
       Element: 77 GoHMapBucketType bucket<string,main.nestedStruct>
     - __kind: GoSliceDataType
-      ID: 200
+      ID: 199
       Name: '[]bucket<uint8,[4]int>.array'
       ByteSize: 2048
       Element: 119 GoHMapBucketType bucket<uint8,[4]int>
     - __kind: GoSliceDataType
-      ID: 199
+      ID: 198
       Name: '[]bucket<uint8,uint8>.array'
       ByteSize: 2048
       Element: 114 GoHMapBucketType bucket<uint8,uint8>
@@ -5509,9 +5509,9 @@ Types:
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 209 GoSliceDataType []main.structWithNoStrings.array
+      Data: 208 GoSliceDataType []main.structWithNoStrings.array
     - __kind: GoSliceDataType
-      ID: 209
+      ID: 208
       Name: '[]main.structWithNoStrings.array'
       ByteSize: 2048
       Element: 142 StructureType main.structWithNoStrings
@@ -5531,9 +5531,9 @@ Types:
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 211 GoSliceDataType []string.array
+      Data: 210 GoSliceDataType []string.array
     - __kind: GoSliceDataType
-      ID: 211
+      ID: 210
       Name: '[]string.array'
       ByteSize: 2048
       Element: 11 GoStringHeaderType string
@@ -5553,9 +5553,9 @@ Types:
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 205 GoSliceDataType []uint.array
+      Data: 204 GoSliceDataType []uint.array
     - __kind: GoSliceDataType
-      ID: 205
+      ID: 204
       Name: '[]uint.array'
       ByteSize: 2048
       Element: 12 BaseType uint
@@ -5575,9 +5575,9 @@ Types:
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 215 GoSliceDataType []uint16.array
+      Data: 214 GoSliceDataType []uint16.array
     - __kind: GoSliceDataType
-      ID: 215
+      ID: 214
       Name: '[]uint16.array'
       ByteSize: 2048
       Element: 7 BaseType uint16
@@ -5957,7 +5957,7 @@ Types:
           Offset: 40
           Type: 71 PointerType *runtime.mapextra
       BucketType: 129 GoHMapBucketType bucket<[4]int,[4]int>
-      BucketsType: 202 GoSliceDataType []bucket<[4]int,[4]int>.array
+      BucketsType: 201 GoSliceDataType []bucket<[4]int,[4]int>.array
     - __kind: GoHMapHeaderType
       ID: 122
       Name: hash<[4]int,uint8>
@@ -5991,7 +5991,7 @@ Types:
           Offset: 40
           Type: 71 PointerType *runtime.mapextra
       BucketType: 124 GoHMapBucketType bucket<[4]int,uint8>
-      BucketsType: 201 GoSliceDataType []bucket<[4]int,uint8>.array
+      BucketsType: 200 GoSliceDataType []bucket<[4]int,uint8>.array
     - __kind: GoHMapHeaderType
       ID: 90
       Name: hash<[4]string,[2]int>
@@ -6025,7 +6025,7 @@ Types:
           Offset: 40
           Type: 71 PointerType *runtime.mapextra
       BucketType: 92 GoHMapBucketType bucket<[4]string,[2]int>
-      BucketsType: 195 GoSliceDataType []bucket<[4]string,[2]int>.array
+      BucketsType: 194 GoSliceDataType []bucket<[4]string,[2]int>.array
     - __kind: GoHMapHeaderType
       ID: 102
       Name: hash<bool,main.node>
@@ -6059,7 +6059,7 @@ Types:
           Offset: 40
           Type: 71 PointerType *runtime.mapextra
       BucketType: 104 GoHMapBucketType bucket<bool,main.node>
-      BucketsType: 197 GoSliceDataType []bucket<bool,main.node>.array
+      BucketsType: 196 GoSliceDataType []bucket<bool,main.node>.array
     - __kind: GoHMapHeaderType
       ID: 68
       Name: hash<int,int>
@@ -6093,7 +6093,7 @@ Types:
           Offset: 40
           Type: 71 PointerType *runtime.mapextra
       BucketType: 70 GoHMapBucketType bucket<int,int>
-      BucketsType: 191 GoSliceDataType []bucket<int,int>.array
+      BucketsType: 190 GoSliceDataType []bucket<int,int>.array
     - __kind: GoHMapHeaderType
       ID: 107
       Name: hash<int,uint8>
@@ -6127,7 +6127,7 @@ Types:
           Offset: 40
           Type: 71 PointerType *runtime.mapextra
       BucketType: 109 GoHMapBucketType bucket<int,uint8>
-      BucketsType: 198 GoSliceDataType []bucket<int,uint8>.array
+      BucketsType: 197 GoSliceDataType []bucket<int,uint8>.array
     - __kind: GoHMapHeaderType
       ID: 97
       Name: hash<string,[]main.structWithMap>
@@ -6161,7 +6161,7 @@ Types:
           Offset: 40
           Type: 71 PointerType *runtime.mapextra
       BucketType: 99 GoHMapBucketType bucket<string,[]main.structWithMap>
-      BucketsType: 196 GoSliceDataType []bucket<string,[]main.structWithMap>.array
+      BucketsType: 195 GoSliceDataType []bucket<string,[]main.structWithMap>.array
     - __kind: GoHMapHeaderType
       ID: 85
       Name: hash<string,[]string>
@@ -6195,7 +6195,7 @@ Types:
           Offset: 40
           Type: 71 PointerType *runtime.mapextra
       BucketType: 87 GoHMapBucketType bucket<string,[]string>
-      BucketsType: 194 GoSliceDataType []bucket<string,[]string>.array
+      BucketsType: 193 GoSliceDataType []bucket<string,[]string>.array
     - __kind: GoHMapHeaderType
       ID: 80
       Name: hash<string,int>
@@ -6229,7 +6229,7 @@ Types:
           Offset: 40
           Type: 71 PointerType *runtime.mapextra
       BucketType: 82 GoHMapBucketType bucket<string,int>
-      BucketsType: 193 GoSliceDataType []bucket<string,int>.array
+      BucketsType: 192 GoSliceDataType []bucket<string,int>.array
     - __kind: GoHMapHeaderType
       ID: 75
       Name: hash<string,main.nestedStruct>
@@ -6263,7 +6263,7 @@ Types:
           Offset: 40
           Type: 71 PointerType *runtime.mapextra
       BucketType: 77 GoHMapBucketType bucket<string,main.nestedStruct>
-      BucketsType: 192 GoSliceDataType []bucket<string,main.nestedStruct>.array
+      BucketsType: 191 GoSliceDataType []bucket<string,main.nestedStruct>.array
     - __kind: GoHMapHeaderType
       ID: 117
       Name: hash<uint8,[4]int>
@@ -6297,7 +6297,7 @@ Types:
           Offset: 40
           Type: 71 PointerType *runtime.mapextra
       BucketType: 119 GoHMapBucketType bucket<uint8,[4]int>
-      BucketsType: 200 GoSliceDataType []bucket<uint8,[4]int>.array
+      BucketsType: 199 GoSliceDataType []bucket<uint8,[4]int>.array
     - __kind: GoHMapHeaderType
       ID: 112
       Name: hash<uint8,uint8>
@@ -6331,7 +6331,7 @@ Types:
           Offset: 40
           Type: 71 PointerType *runtime.mapextra
       BucketType: 114 GoHMapBucketType bucket<uint8,uint8>
-      BucketsType: 199 GoSliceDataType []bucket<uint8,uint8>.array
+      BucketsType: 198 GoSliceDataType []bucket<uint8,uint8>.array
     - __kind: BaseType
       ID: 9
       Name: int
@@ -6586,9 +6586,9 @@ Types:
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 203 GoSliceDataType main.t.array
+      Data: 202 GoSliceDataType main.t.array
     - __kind: GoSliceDataType
-      ID: 203
+      ID: 202
       Name: main.t.array
       ByteSize: 2048
       Element: 135 PointerType *main.t
@@ -6731,13 +6731,13 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 188 PointerType *string.str
+          Type: 187 PointerType *string.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 187 GoStringDataType string.str
+      Data: 186 GoStringDataType string.str
     - __kind: GoStringDataType
-      ID: 187
+      ID: 186
       Name: string.str
       ByteSize: 2048
     - __kind: StructureType

--- a/pkg/dyninst/irgen/testdata/snapshot/sample.arch=arm64,toolchain=go1.23.11.yaml
+++ b/pkg/dyninst/irgen/testdata/snapshot/sample.arch=arm64,toolchain=go1.23.11.yaml
@@ -8,7 +8,7 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 94}
+      subprogram: {subprogram: 88}
       events:
         - ID: 88
           Type: 308 EventRootType Probe[main.stackC]
@@ -22,7 +22,7 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 51}
+      subprogram: {subprogram: 45}
       events:
         - ID: 45
           Type: 265 EventRootType Probe[main.testAny]
@@ -36,7 +36,7 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 21}
+      subprogram: {subprogram: 15}
       events:
         - ID: 15
           Type: 235 EventRootType Probe[main.testArrayOfArrays]
@@ -50,7 +50,7 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 23}
+      subprogram: {subprogram: 17}
       events:
         - ID: 17
           Type: 237 EventRootType Probe[main.testArrayOfArraysOfArrays]
@@ -64,7 +64,7 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 59}
+      subprogram: {subprogram: 53}
       events:
         - ID: 53
           Type: 273 EventRootType Probe[main.testArrayOfMaps]
@@ -78,7 +78,7 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 22}
+      subprogram: {subprogram: 16}
       events:
         - ID: 16
           Type: 236 EventRootType Probe[main.testArrayOfStrings]
@@ -92,7 +92,7 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 41}
+      subprogram: {subprogram: 35}
       events:
         - ID: 35
           Type: 255 EventRootType Probe[main.testBigStruct]
@@ -106,7 +106,7 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 10}
+      subprogram: {subprogram: 4}
       events:
         - ID: 4
           Type: 224 EventRootType Probe[main.testBoolArray]
@@ -120,7 +120,7 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 7}
+      subprogram: {subprogram: 1}
       events:
         - ID: 1
           Type: 221 EventRootType Probe[main.testByteArray]
@@ -134,7 +134,7 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 75}
+      subprogram: {subprogram: 69}
       events:
         - ID: 69
           Type: 289 EventRootType Probe[main.testChannel]
@@ -148,7 +148,7 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 73}
+      subprogram: {subprogram: 67}
       events:
         - ID: 67
           Type: 287 EventRootType Probe[main.testCombinedByte]
@@ -162,7 +162,7 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 83}
+      subprogram: {subprogram: 77}
       events:
         - ID: 77
           Type: 297 EventRootType Probe[main.testCycle]
@@ -176,7 +176,7 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 85}
+      subprogram: {subprogram: 79}
       events:
         - ID: 79
           Type: 299 EventRootType Probe[main.testEmptySlice]
@@ -190,7 +190,7 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 88}
+      subprogram: {subprogram: 82}
       events:
         - ID: 82
           Type: 302 EventRootType Probe[main.testEmptySliceOfStructs]
@@ -204,7 +204,7 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 102}
+      subprogram: {subprogram: 96}
       events:
         - ID: 96
           Type: 316 EventRootType Probe[main.testEmptyString]
@@ -218,7 +218,7 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 104}
+      subprogram: {subprogram: 98}
       events:
         - ID: 98
           Type: 318 EventRootType Probe[main.testEmptyStruct]
@@ -232,7 +232,7 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 52}
+      subprogram: {subprogram: 46}
       events:
         - ID: 46
           Type: 266 EventRootType Probe[main.testError]
@@ -246,7 +246,7 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 43}
+      subprogram: {subprogram: 37}
       events:
         - ID: 37
           Type: 257 EventRootType Probe[main.testEsotericHeap]
@@ -260,7 +260,7 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 42}
+      subprogram: {subprogram: 36}
       events:
         - ID: 36
           Type: 256 EventRootType Probe[main.testEsotericStack]
@@ -274,7 +274,7 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 48}
+      subprogram: {subprogram: 42}
       events:
         - ID: 42
           Type: 262 EventRootType Probe[main.testFrameless]
@@ -288,7 +288,7 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 49}
+      subprogram: {subprogram: 43}
       events:
         - ID: 43
           Type: 263 EventRootType Probe[main.testFramelessArray]
@@ -302,7 +302,7 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 44}
+      subprogram: {subprogram: 38}
       events:
         - ID: 38
           Type: 258 EventRootType Probe[main.testInlinedBA]
@@ -316,7 +316,7 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 45}
+      subprogram: {subprogram: 39}
       events:
         - ID: 39
           Type: 259 EventRootType Probe[main.testInlinedBB]
@@ -330,7 +330,7 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 46}
+      subprogram: {subprogram: 40}
       events:
         - ID: 40
           Type: 260 EventRootType Probe[main.testInlinedBBA]
@@ -344,7 +344,7 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 2}
+      subprogram: {subprogram: 100}
       events:
         - ID: 100
           Type: 320 EventRootType Probe[main.testInlinedBBB]
@@ -358,7 +358,7 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 47}
+      subprogram: {subprogram: 41}
       events:
         - ID: 41
           Type: 261 EventRootType Probe[main.testInlinedBC]
@@ -372,7 +372,7 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 3}
+      subprogram: {subprogram: 101}
       events:
         - ID: 101
           Type: 321 EventRootType Probe[main.testInlinedBCA]
@@ -386,7 +386,7 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 4}
+      subprogram: {subprogram: 102}
       events:
         - ID: 102
           Type: 322 EventRootType Probe[main.testInlinedBCB]
@@ -401,7 +401,7 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 1}
+      subprogram: {subprogram: 99}
       events:
         - ID: 99
           Type: 319 EventRootType Probe[main.testInlinedPrint]
@@ -425,7 +425,7 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 5}
+      subprogram: {subprogram: 103}
       events:
         - ID: 103
           Type: 323 EventRootType Probe[main.testInlinedSq]
@@ -440,7 +440,7 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 6}
+      subprogram: {subprogram: 104}
       events:
         - ID: 104
           Type: 324 EventRootType Probe[main.testInlinedSumArray]
@@ -458,7 +458,7 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 13}
+      subprogram: {subprogram: 7}
       events:
         - ID: 7
           Type: 227 EventRootType Probe[main.testInt16Array]
@@ -472,7 +472,7 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 14}
+      subprogram: {subprogram: 8}
       events:
         - ID: 8
           Type: 228 EventRootType Probe[main.testInt32Array]
@@ -486,7 +486,7 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 15}
+      subprogram: {subprogram: 9}
       events:
         - ID: 9
           Type: 229 EventRootType Probe[main.testInt64Array]
@@ -500,7 +500,7 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 12}
+      subprogram: {subprogram: 6}
       events:
         - ID: 6
           Type: 226 EventRootType Probe[main.testInt8Array]
@@ -514,7 +514,7 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 11}
+      subprogram: {subprogram: 5}
       events:
         - ID: 5
           Type: 225 EventRootType Probe[main.testIntArray]
@@ -528,7 +528,7 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 50}
+      subprogram: {subprogram: 44}
       events:
         - ID: 44
           Type: 264 EventRootType Probe[main.testInterface]
@@ -542,7 +542,7 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 77}
+      subprogram: {subprogram: 71}
       events:
         - ID: 71
           Type: 291 EventRootType Probe[main.testLinkedList]
@@ -556,7 +556,7 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 57}
+      subprogram: {subprogram: 51}
       events:
         - ID: 51
           Type: 271 EventRootType Probe[main.testMapArrayToArray]
@@ -570,7 +570,7 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 63}
+      subprogram: {subprogram: 57}
       events:
         - ID: 57
           Type: 277 EventRootType Probe[main.testMapEmbeddedMaps]
@@ -584,7 +584,7 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 61}
+      subprogram: {subprogram: 55}
       events:
         - ID: 55
           Type: 275 EventRootType Probe[main.testMapIntToInt]
@@ -598,7 +598,7 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 72}
+      subprogram: {subprogram: 66}
       events:
         - ID: 66
           Type: 286 EventRootType Probe[main.testMapLargeKeyLargeValue]
@@ -612,7 +612,7 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 71}
+      subprogram: {subprogram: 65}
       events:
         - ID: 65
           Type: 285 EventRootType Probe[main.testMapLargeKeySmallValue]
@@ -626,7 +626,7 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 62}
+      subprogram: {subprogram: 56}
       events:
         - ID: 56
           Type: 276 EventRootType Probe[main.testMapMassive]
@@ -640,7 +640,7 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 70}
+      subprogram: {subprogram: 64}
       events:
         - ID: 64
           Type: 284 EventRootType Probe[main.testMapSmallKeyLargeValue]
@@ -654,7 +654,7 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 69}
+      subprogram: {subprogram: 63}
       events:
         - ID: 63
           Type: 283 EventRootType Probe[main.testMapSmallKeySmallValue]
@@ -668,7 +668,7 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 55}
+      subprogram: {subprogram: 49}
       events:
         - ID: 49
           Type: 269 EventRootType Probe[main.testMapStringToInt]
@@ -682,7 +682,7 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 56}
+      subprogram: {subprogram: 50}
       events:
         - ID: 50
           Type: 270 EventRootType Probe[main.testMapStringToSlice]
@@ -696,7 +696,7 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 54}
+      subprogram: {subprogram: 48}
       events:
         - ID: 48
           Type: 268 EventRootType Probe[main.testMapStringToStruct]
@@ -710,7 +710,7 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 64}
+      subprogram: {subprogram: 58}
       events:
         - ID: 58
           Type: 278 EventRootType Probe[main.testMapWithLinkedList]
@@ -724,7 +724,7 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 67}
+      subprogram: {subprogram: 61}
       events:
         - ID: 61
           Type: 281 EventRootType Probe[main.testMapWithSmallKeyAndValue]
@@ -738,7 +738,7 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 68}
+      subprogram: {subprogram: 62}
       events:
         - ID: 62
           Type: 282 EventRootType Probe[main.testMapWithSmallKeyAndValueMassive]
@@ -752,7 +752,7 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 65}
+      subprogram: {subprogram: 59}
       events:
         - ID: 59
           Type: 279 EventRootType Probe[main.testMapWithSmallValue]
@@ -766,7 +766,7 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 66}
+      subprogram: {subprogram: 60}
       events:
         - ID: 60
           Type: 280 EventRootType Probe[main.testMapWithSmallValueMassive]
@@ -780,7 +780,7 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 100}
+      subprogram: {subprogram: 94}
       events:
         - ID: 94
           Type: 314 EventRootType Probe[main.testMassiveString]
@@ -794,7 +794,7 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 74}
+      subprogram: {subprogram: 68}
       events:
         - ID: 68
           Type: 288 EventRootType Probe[main.testMultipleSimpleParams]
@@ -808,7 +808,7 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 82}
+      subprogram: {subprogram: 76}
       events:
         - ID: 76
           Type: 296 EventRootType Probe[main.testNilPointer]
@@ -822,7 +822,7 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 92}
+      subprogram: {subprogram: 86}
       events:
         - ID: 86
           Type: 306 EventRootType Probe[main.testNilSlice]
@@ -836,7 +836,7 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 89}
+      subprogram: {subprogram: 83}
       events:
         - ID: 83
           Type: 303 EventRootType Probe[main.testNilSliceOfStructs]
@@ -850,7 +850,7 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 91}
+      subprogram: {subprogram: 85}
       events:
         - ID: 85
           Type: 305 EventRootType Probe[main.testNilSliceWithOtherParams]
@@ -864,7 +864,7 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 99}
+      subprogram: {subprogram: 93}
       events:
         - ID: 93
           Type: 313 EventRootType Probe[main.testOneStringInStructPointer]
@@ -878,7 +878,7 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 78}
+      subprogram: {subprogram: 72}
       events:
         - ID: 72
           Type: 292 EventRootType Probe[main.testPointerLoop]
@@ -892,7 +892,7 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 60}
+      subprogram: {subprogram: 54}
       events:
         - ID: 54
           Type: 274 EventRootType Probe[main.testPointerToMap]
@@ -906,7 +906,7 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 76}
+      subprogram: {subprogram: 70}
       events:
         - ID: 70
           Type: 290 EventRootType Probe[main.testPointerToSimpleStruct]
@@ -920,7 +920,7 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 8}
+      subprogram: {subprogram: 2}
       events:
         - ID: 2
           Type: 222 EventRootType Probe[main.testRuneArray]
@@ -934,7 +934,7 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 27}
+      subprogram: {subprogram: 21}
       events:
         - ID: 21
           Type: 241 EventRootType Probe[main.testSingleBool]
@@ -948,7 +948,7 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 25}
+      subprogram: {subprogram: 19}
       events:
         - ID: 19
           Type: 239 EventRootType Probe[main.testSingleByte]
@@ -962,7 +962,7 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 38}
+      subprogram: {subprogram: 32}
       events:
         - ID: 32
           Type: 252 EventRootType Probe[main.testSingleFloat32]
@@ -976,7 +976,7 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 39}
+      subprogram: {subprogram: 33}
       events:
         - ID: 33
           Type: 253 EventRootType Probe[main.testSingleFloat64]
@@ -990,7 +990,7 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 28}
+      subprogram: {subprogram: 22}
       events:
         - ID: 22
           Type: 242 EventRootType Probe[main.testSingleInt]
@@ -1004,7 +1004,7 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 30}
+      subprogram: {subprogram: 24}
       events:
         - ID: 24
           Type: 244 EventRootType Probe[main.testSingleInt16]
@@ -1018,7 +1018,7 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 31}
+      subprogram: {subprogram: 25}
       events:
         - ID: 25
           Type: 245 EventRootType Probe[main.testSingleInt32]
@@ -1032,7 +1032,7 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 32}
+      subprogram: {subprogram: 26}
       events:
         - ID: 26
           Type: 246 EventRootType Probe[main.testSingleInt64]
@@ -1046,7 +1046,7 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 29}
+      subprogram: {subprogram: 23}
       events:
         - ID: 23
           Type: 243 EventRootType Probe[main.testSingleInt8]
@@ -1060,7 +1060,7 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 26}
+      subprogram: {subprogram: 20}
       events:
         - ID: 20
           Type: 240 EventRootType Probe[main.testSingleRune]
@@ -1074,7 +1074,7 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 95}
+      subprogram: {subprogram: 89}
       events:
         - ID: 89
           Type: 309 EventRootType Probe[main.testSingleString]
@@ -1088,7 +1088,7 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 33}
+      subprogram: {subprogram: 27}
       events:
         - ID: 27
           Type: 247 EventRootType Probe[main.testSingleUint]
@@ -1102,7 +1102,7 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 35}
+      subprogram: {subprogram: 29}
       events:
         - ID: 29
           Type: 249 EventRootType Probe[main.testSingleUint16]
@@ -1116,7 +1116,7 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 36}
+      subprogram: {subprogram: 30}
       events:
         - ID: 30
           Type: 250 EventRootType Probe[main.testSingleUint32]
@@ -1130,7 +1130,7 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 37}
+      subprogram: {subprogram: 31}
       events:
         - ID: 31
           Type: 251 EventRootType Probe[main.testSingleUint64]
@@ -1144,7 +1144,7 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 34}
+      subprogram: {subprogram: 28}
       events:
         - ID: 28
           Type: 248 EventRootType Probe[main.testSingleUint8]
@@ -1158,7 +1158,7 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 86}
+      subprogram: {subprogram: 80}
       events:
         - ID: 80
           Type: 300 EventRootType Probe[main.testSliceOfSlices]
@@ -1172,7 +1172,7 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 58}
+      subprogram: {subprogram: 52}
       events:
         - ID: 52
           Type: 272 EventRootType Probe[main.testSmallMap]
@@ -1186,7 +1186,7 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 9}
+      subprogram: {subprogram: 3}
       events:
         - ID: 3
           Type: 223 EventRootType Probe[main.testStringArray]
@@ -1200,7 +1200,7 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 81}
+      subprogram: {subprogram: 75}
       events:
         - ID: 75
           Type: 295 EventRootType Probe[main.testStringPointer]
@@ -1214,7 +1214,7 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 90}
+      subprogram: {subprogram: 84}
       events:
         - ID: 84
           Type: 304 EventRootType Probe[main.testStringSlice]
@@ -1228,7 +1228,7 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 103}
+      subprogram: {subprogram: 97}
       events:
         - ID: 97
           Type: 317 EventRootType Probe[main.testStruct]
@@ -1242,7 +1242,7 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 87}
+      subprogram: {subprogram: 81}
       events:
         - ID: 81
           Type: 301 EventRootType Probe[main.testStructSlice]
@@ -1256,7 +1256,7 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 53}
+      subprogram: {subprogram: 47}
       events:
         - ID: 47
           Type: 267 EventRootType Probe[main.testStructWithMap]
@@ -1270,7 +1270,7 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 96}
+      subprogram: {subprogram: 90}
       events:
         - ID: 90
           Type: 310 EventRootType Probe[main.testThreeStrings]
@@ -1284,7 +1284,7 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 97}
+      subprogram: {subprogram: 91}
       events:
         - ID: 91
           Type: 311 EventRootType Probe[main.testThreeStringsInStruct]
@@ -1298,7 +1298,7 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 98}
+      subprogram: {subprogram: 92}
       events:
         - ID: 92
           Type: 312 EventRootType Probe[main.testThreeStringsInStructPointer]
@@ -1312,7 +1312,7 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 40}
+      subprogram: {subprogram: 34}
       events:
         - ID: 34
           Type: 254 EventRootType Probe[main.testTypeAlias]
@@ -1326,7 +1326,7 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 18}
+      subprogram: {subprogram: 12}
       events:
         - ID: 12
           Type: 232 EventRootType Probe[main.testUint16Array]
@@ -1340,7 +1340,7 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 19}
+      subprogram: {subprogram: 13}
       events:
         - ID: 13
           Type: 233 EventRootType Probe[main.testUint32Array]
@@ -1354,7 +1354,7 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 20}
+      subprogram: {subprogram: 14}
       events:
         - ID: 14
           Type: 234 EventRootType Probe[main.testUint64Array]
@@ -1368,7 +1368,7 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 17}
+      subprogram: {subprogram: 11}
       events:
         - ID: 11
           Type: 231 EventRootType Probe[main.testUint8Array]
@@ -1382,7 +1382,7 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 16}
+      subprogram: {subprogram: 10}
       events:
         - ID: 10
           Type: 230 EventRootType Probe[main.testUintArray]
@@ -1396,7 +1396,7 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 80}
+      subprogram: {subprogram: 74}
       events:
         - ID: 74
           Type: 294 EventRootType Probe[main.testUintPointer]
@@ -1410,7 +1410,7 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 84}
+      subprogram: {subprogram: 78}
       events:
         - ID: 78
           Type: 298 EventRootType Probe[main.testUintSlice]
@@ -1424,7 +1424,7 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 101}
+      subprogram: {subprogram: 95}
       events:
         - ID: 95
           Type: 315 EventRootType Probe[main.testUnitializedString]
@@ -1438,7 +1438,7 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 79}
+      subprogram: {subprogram: 73}
       events:
         - ID: 73
           Type: 293 EventRootType Probe[main.testUnsafePointer]
@@ -1452,7 +1452,7 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 24}
+      subprogram: {subprogram: 18}
       events:
         - ID: 18
           Type: 238 EventRootType Probe[main.testVeryLargeArray]
@@ -1466,428 +1466,428 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 93}
+      subprogram: {subprogram: 87}
       events:
         - ID: 87
           Type: 307 EventRootType Probe[main.testVeryLargeSlice]
           InjectionPoints: [{PC: "0x88f320", Frameless: true}]
           Condition: null
 Subprograms:
-    - ID: 7
+    - ID: 1
       Name: main.testByteArray
       OutOfLinePCRanges: [0x88be00..0x88be10]
       InlinePCRanges: []
       Variables:
         - Name: x
-          Type: 3 ArrayType [2]uint8
+          Type: 36 ArrayType [2]uint8
           Locations:
             - Range: 0x88be00..0x88be10
               Pieces: [{Size: 2, Op: {CfaOffset: 8}}]
           IsParameter: true
           IsReturn: false
-    - ID: 8
+    - ID: 2
       Name: main.testRuneArray
       OutOfLinePCRanges: [0x88be10..0x88be20]
       InlinePCRanges: []
       Variables:
         - Name: x
-          Type: 5 ArrayType [2]int32
+          Type: 37 ArrayType [2]int32
           Locations:
             - Range: 0x88be10..0x88be20
               Pieces: [{Size: 8, Op: {CfaOffset: 8}}]
           IsParameter: true
           IsReturn: false
-    - ID: 9
+    - ID: 3
       Name: main.testStringArray
       OutOfLinePCRanges: [0x88be20..0x88be30]
       InlinePCRanges: []
       Variables:
         - Name: x
-          Type: 7 ArrayType [2]string
+          Type: 38 ArrayType [2]string
           Locations:
             - Range: 0x88be20..0x88be30
               Pieces: [{Size: 32, Op: {CfaOffset: 8}}]
           IsParameter: true
           IsReturn: false
-    - ID: 10
+    - ID: 4
       Name: main.testBoolArray
       OutOfLinePCRanges: [0x88be30..0x88be40]
       InlinePCRanges: []
       Variables:
         - Name: x
-          Type: 10 ArrayType [2]bool
+          Type: 39 ArrayType [2]bool
           Locations:
             - Range: 0x88be30..0x88be40
               Pieces: [{Size: 2, Op: {CfaOffset: 8}}]
           IsParameter: true
           IsReturn: false
-    - ID: 11
+    - ID: 5
       Name: main.testIntArray
       OutOfLinePCRanges: [0x88be40..0x88be50]
       InlinePCRanges: []
       Variables:
         - Name: x
-          Type: 12 ArrayType [2]int
+          Type: 40 ArrayType [2]int
           Locations:
             - Range: 0x88be40..0x88be50
               Pieces: [{Size: 16, Op: {CfaOffset: 8}}]
           IsParameter: true
           IsReturn: false
-    - ID: 12
+    - ID: 6
       Name: main.testInt8Array
       OutOfLinePCRanges: [0x88be50..0x88be60]
       InlinePCRanges: []
       Variables:
         - Name: x
-          Type: 13 ArrayType [2]int8
+          Type: 41 ArrayType [2]int8
           Locations:
             - Range: 0x88be50..0x88be60
               Pieces: [{Size: 2, Op: {CfaOffset: 8}}]
           IsParameter: true
           IsReturn: false
-    - ID: 13
+    - ID: 7
       Name: main.testInt16Array
       OutOfLinePCRanges: [0x88be60..0x88be70]
       InlinePCRanges: []
       Variables:
         - Name: x
-          Type: 15 ArrayType [2]int16
+          Type: 42 ArrayType [2]int16
           Locations:
             - Range: 0x88be60..0x88be70
               Pieces: [{Size: 4, Op: {CfaOffset: 8}}]
           IsParameter: true
           IsReturn: false
-    - ID: 14
+    - ID: 8
       Name: main.testInt32Array
       OutOfLinePCRanges: [0x88be70..0x88be80]
       InlinePCRanges: []
       Variables:
         - Name: x
-          Type: 5 ArrayType [2]int32
+          Type: 37 ArrayType [2]int32
           Locations:
             - Range: 0x88be70..0x88be80
               Pieces: [{Size: 8, Op: {CfaOffset: 8}}]
           IsParameter: true
           IsReturn: false
-    - ID: 15
+    - ID: 9
       Name: main.testInt64Array
       OutOfLinePCRanges: [0x88be80..0x88be90]
       InlinePCRanges: []
       Variables:
         - Name: x
-          Type: 17 ArrayType [2]int64
+          Type: 43 ArrayType [2]int64
           Locations:
             - Range: 0x88be80..0x88be90
               Pieces: [{Size: 16, Op: {CfaOffset: 8}}]
           IsParameter: true
           IsReturn: false
-    - ID: 16
+    - ID: 10
       Name: main.testUintArray
       OutOfLinePCRanges: [0x88be90..0x88bea0]
       InlinePCRanges: []
       Variables:
         - Name: x
-          Type: 19 ArrayType [2]uint
+          Type: 44 ArrayType [2]uint
           Locations:
             - Range: 0x88be90..0x88bea0
               Pieces: [{Size: 16, Op: {CfaOffset: 8}}]
           IsParameter: true
           IsReturn: false
-    - ID: 17
+    - ID: 11
       Name: main.testUint8Array
       OutOfLinePCRanges: [0x88bea0..0x88beb0]
       InlinePCRanges: []
       Variables:
         - Name: x
-          Type: 3 ArrayType [2]uint8
+          Type: 36 ArrayType [2]uint8
           Locations:
             - Range: 0x88bea0..0x88beb0
               Pieces: [{Size: 2, Op: {CfaOffset: 8}}]
           IsParameter: true
           IsReturn: false
-    - ID: 18
+    - ID: 12
       Name: main.testUint16Array
       OutOfLinePCRanges: [0x88beb0..0x88bec0]
       InlinePCRanges: []
       Variables:
         - Name: x
-          Type: 21 ArrayType [2]uint16
+          Type: 45 ArrayType [2]uint16
           Locations:
             - Range: 0x88beb0..0x88bec0
               Pieces: [{Size: 4, Op: {CfaOffset: 8}}]
           IsParameter: true
           IsReturn: false
-    - ID: 19
+    - ID: 13
       Name: main.testUint32Array
       OutOfLinePCRanges: [0x88bec0..0x88bed0]
       InlinePCRanges: []
       Variables:
         - Name: x
-          Type: 23 ArrayType [2]uint32
+          Type: 46 ArrayType [2]uint32
           Locations:
             - Range: 0x88bec0..0x88bed0
               Pieces: [{Size: 8, Op: {CfaOffset: 8}}]
           IsParameter: true
           IsReturn: false
-    - ID: 20
+    - ID: 14
       Name: main.testUint64Array
       OutOfLinePCRanges: [0x88bed0..0x88bee0]
       InlinePCRanges: []
       Variables:
         - Name: x
-          Type: 25 ArrayType [2]uint64
+          Type: 47 ArrayType [2]uint64
           Locations:
             - Range: 0x88bed0..0x88bee0
               Pieces: [{Size: 16, Op: {CfaOffset: 8}}]
           IsParameter: true
           IsReturn: false
-    - ID: 21
+    - ID: 15
       Name: main.testArrayOfArrays
       OutOfLinePCRanges: [0x88bee0..0x88bef0]
       InlinePCRanges: []
       Variables:
         - Name: a
-          Type: 27 ArrayType [2][2]int
+          Type: 48 ArrayType [2][2]int
           Locations:
             - Range: 0x88bee0..0x88bef0
               Pieces: [{Size: 32, Op: {CfaOffset: 8}}]
           IsParameter: true
           IsReturn: false
-    - ID: 22
+    - ID: 16
       Name: main.testArrayOfStrings
       OutOfLinePCRanges: [0x88bef0..0x88bf00]
       InlinePCRanges: []
       Variables:
         - Name: a
-          Type: 7 ArrayType [2]string
+          Type: 38 ArrayType [2]string
           Locations:
             - Range: 0x88bef0..0x88bf00
               Pieces: [{Size: 32, Op: {CfaOffset: 8}}]
           IsParameter: true
           IsReturn: false
-    - ID: 23
+    - ID: 17
       Name: main.testArrayOfArraysOfArrays
       OutOfLinePCRanges: [0x88bf00..0x88bf10]
       InlinePCRanges: []
       Variables:
         - Name: b
-          Type: 28 ArrayType [2][2][2]int
+          Type: 49 ArrayType [2][2][2]int
           Locations:
             - Range: 0x88bf00..0x88bf10
               Pieces: [{Size: 64, Op: {CfaOffset: 8}}]
           IsParameter: true
           IsReturn: false
-    - ID: 24
+    - ID: 18
       Name: main.testVeryLargeArray
       OutOfLinePCRanges: [0x88bf30..0x88bf40]
       InlinePCRanges: []
       Variables:
         - Name: a
-          Type: 29 ArrayType [100]uint
+          Type: 50 ArrayType [100]uint
           Locations:
             - Range: 0x88bf30..0x88bf40
               Pieces: [{Size: 800, Op: {CfaOffset: 8}}]
           IsParameter: true
           IsReturn: false
-    - ID: 25
+    - ID: 19
       Name: main.testSingleByte
       OutOfLinePCRanges: [0x88c260..0x88c270]
       InlinePCRanges: []
       Variables:
         - Name: x
-          Type: 4 BaseType uint8
+          Type: 3 BaseType uint8
           Locations:
             - Range: 0x88c260..0x88c270
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 26
+    - ID: 20
       Name: main.testSingleRune
       OutOfLinePCRanges: [0x88c270..0x88c280]
       InlinePCRanges: []
       Variables:
         - Name: x
-          Type: 6 BaseType int32
+          Type: 13 BaseType int32
           Locations:
             - Range: 0x88c270..0x88c280
               Pieces: [{Size: 4, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 27
+    - ID: 21
       Name: main.testSingleBool
       OutOfLinePCRanges: [0x88c280..0x88c290]
       InlinePCRanges: []
       Variables:
         - Name: x
-          Type: 11 BaseType bool
+          Type: 4 BaseType bool
           Locations:
             - Range: 0x88c280..0x88c290
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 28
+    - ID: 22
       Name: main.testSingleInt
       OutOfLinePCRanges: [0x88c290..0x88c2a0]
       InlinePCRanges: []
       Variables:
         - Name: x
-          Type: 1 BaseType int
+          Type: 9 BaseType int
           Locations:
             - Range: 0x88c290..0x88c2a0
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 29
+    - ID: 23
       Name: main.testSingleInt8
       OutOfLinePCRanges: [0x88c2a0..0x88c2b0]
       InlinePCRanges: []
       Variables:
         - Name: x
-          Type: 14 BaseType int8
+          Type: 15 BaseType int8
           Locations:
             - Range: 0x88c2a0..0x88c2b0
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 30
+    - ID: 24
       Name: main.testSingleInt16
       OutOfLinePCRanges: [0x88c2b0..0x88c2c0]
       InlinePCRanges: []
       Variables:
         - Name: x
-          Type: 16 BaseType int16
+          Type: 23 BaseType int16
           Locations:
             - Range: 0x88c2b0..0x88c2c0
               Pieces: [{Size: 2, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 31
+    - ID: 25
       Name: main.testSingleInt32
       OutOfLinePCRanges: [0x88c2c0..0x88c2d0]
       InlinePCRanges: []
       Variables:
         - Name: x
-          Type: 6 BaseType int32
+          Type: 13 BaseType int32
           Locations:
             - Range: 0x88c2c0..0x88c2d0
               Pieces: [{Size: 4, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 32
+    - ID: 26
       Name: main.testSingleInt64
       OutOfLinePCRanges: [0x88c2d0..0x88c2e0]
       InlinePCRanges: []
       Variables:
         - Name: x
-          Type: 18 BaseType int64
+          Type: 14 BaseType int64
           Locations:
             - Range: 0x88c2d0..0x88c2e0
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 33
+    - ID: 27
       Name: main.testSingleUint
       OutOfLinePCRanges: [0x88c2e0..0x88c2f0]
       InlinePCRanges: []
       Variables:
         - Name: x
-          Type: 20 BaseType uint
+          Type: 12 BaseType uint
           Locations:
             - Range: 0x88c2e0..0x88c2f0
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 34
+    - ID: 28
       Name: main.testSingleUint8
       OutOfLinePCRanges: [0x88c2f0..0x88c300]
       InlinePCRanges: []
       Variables:
         - Name: x
-          Type: 4 BaseType uint8
+          Type: 3 BaseType uint8
           Locations:
             - Range: 0x88c2f0..0x88c300
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 35
+    - ID: 29
       Name: main.testSingleUint16
       OutOfLinePCRanges: [0x88c300..0x88c310]
       InlinePCRanges: []
       Variables:
         - Name: x
-          Type: 22 BaseType uint16
+          Type: 7 BaseType uint16
           Locations:
             - Range: 0x88c300..0x88c310
               Pieces: [{Size: 2, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 36
+    - ID: 30
       Name: main.testSingleUint32
       OutOfLinePCRanges: [0x88c310..0x88c320]
       InlinePCRanges: []
       Variables:
         - Name: x
-          Type: 24 BaseType uint32
+          Type: 2 BaseType uint32
           Locations:
             - Range: 0x88c310..0x88c320
               Pieces: [{Size: 4, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 37
+    - ID: 31
       Name: main.testSingleUint64
       OutOfLinePCRanges: [0x88c320..0x88c330]
       InlinePCRanges: []
       Variables:
         - Name: x
-          Type: 26 BaseType uint64
+          Type: 10 BaseType uint64
           Locations:
             - Range: 0x88c320..0x88c330
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 38
+    - ID: 32
       Name: main.testSingleFloat32
       OutOfLinePCRanges: [0x88c330..0x88c340]
       InlinePCRanges: []
       Variables:
         - Name: x
-          Type: 30 BaseType float32
+          Type: 16 BaseType float32
           Locations:
             - Range: 0x88c330..0x88c340
               Pieces: [{Size: 4, Op: {RegNo: 64, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 39
+    - ID: 33
       Name: main.testSingleFloat64
       OutOfLinePCRanges: [0x88c340..0x88c350]
       InlinePCRanges: []
       Variables:
         - Name: x
-          Type: 31 BaseType float64
+          Type: 17 BaseType float64
           Locations:
             - Range: 0x88c340..0x88c350
               Pieces: [{Size: 8, Op: {RegNo: 64, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 40
+    - ID: 34
       Name: main.testTypeAlias
       OutOfLinePCRanges: [0x88c350..0x88c360]
       InlinePCRanges: []
       Variables:
         - Name: x
-          Type: 32 BaseType main.typeAlias
+          Type: 51 BaseType main.typeAlias
           Locations:
             - Range: 0x88c350..0x88c360
               Pieces: [{Size: 2, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 41
+    - ID: 35
       Name: main.testBigStruct
       OutOfLinePCRanges: [0x88c460..0x88c480]
       InlinePCRanges: []
       Variables:
         - Name: b
-          Type: 33 StructureType main.bigStruct
+          Type: 52 StructureType main.bigStruct
           Locations:
             - Range: 0x88c460..0x88c480
               Pieces:
@@ -1905,13 +1905,13 @@ Subprograms:
                   Op: {RegNo: 5, Shift: 0}
           IsParameter: true
           IsReturn: false
-    - ID: 42
+    - ID: 36
       Name: main.testEsotericStack
       OutOfLinePCRanges: [0x88c620..0x88c710]
       InlinePCRanges: []
       Variables:
         - Name: e
-          Type: 39 StructureType main.esotericStack
+          Type: 56 StructureType main.esotericStack
           Locations:
             - Range: 0x88c620..0x88c668
               Pieces:
@@ -1975,51 +1975,51 @@ Subprograms:
                   Op: {RegNo: 8, Shift: 0}
           IsParameter: true
           IsReturn: false
-    - ID: 43
+    - ID: 37
       Name: main.testEsotericHeap
       OutOfLinePCRanges: [0x88c710..0x88c790]
       InlinePCRanges: []
       Variables:
         - Name: e
-          Type: 44 PointerType *main.esotericHeap
+          Type: 61 PointerType *main.esotericHeap
           Locations:
             - Range: 0x88c710..0x88c748
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 44
+    - ID: 38
       Name: main.testInlinedBA
       OutOfLinePCRanges: [0x88cb50..0x88cbe0]
       InlinePCRanges: []
       Variables:
         - Name: x
-          Type: 1 BaseType int
+          Type: 9 BaseType int
           Locations:
             - Range: 0x88cb50..0x88cb88
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 45
+    - ID: 39
       Name: main.testInlinedBB
       OutOfLinePCRanges: [0x88cbe0..0x88ccb0]
       InlinePCRanges: []
       Variables:
         - Name: x
-          Type: 1 BaseType int
+          Type: 9 BaseType int
           Locations:
             - Range: 0x88cbe0..0x88cbfc
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
         - Name: y
-          Type: 1 BaseType int
+          Type: 9 BaseType int
           Locations:
             - Range: 0x88cbe0..0x88cc0c
               Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
           IsParameter: true
           IsReturn: false
         - Name: z
-          Type: 1 BaseType int
+          Type: 9 BaseType int
           Locations:
             - Range: 0x88cbfc..0x88cc0c
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
@@ -2027,25 +2027,25 @@ Subprograms:
               Pieces: [{Size: 8, Op: {CfaOffset: -48}}]
           IsParameter: false
           IsReturn: false
-    - ID: 46
+    - ID: 40
       Name: main.testInlinedBBA
       OutOfLinePCRanges: [0x88ccb0..0x88cd30]
       InlinePCRanges: []
       Variables:
         - Name: x
-          Type: 1 BaseType int
+          Type: 9 BaseType int
           Locations:
             - Range: 0x88ccb0..0x88ccd4
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 47
+    - ID: 41
       Name: main.testInlinedBC
       OutOfLinePCRanges: [0x88cd30..0x88ce50]
       InlinePCRanges: []
       Variables:
         - Name: s
-          Type: 1 BaseType int
+          Type: 9 BaseType int
           Locations:
             - Range: 0x88cd98..0x88cda0
               Pieces: [{Size: 8, Op: {CfaOffset: -72}}]
@@ -2056,7 +2056,7 @@ Subprograms:
           IsParameter: false
           IsReturn: false
         - Name: i
-          Type: 1 BaseType int
+          Type: 9 BaseType int
           Locations:
             - Range: 0x88cd94..0x88cd9c
               Pieces: [{Size: 8, Op: {CfaOffset: -64}}]
@@ -2066,47 +2066,47 @@ Subprograms:
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: false
           IsReturn: false
-    - ID: 48
+    - ID: 42
       Name: main.testFrameless
       OutOfLinePCRanges: [0x88ce50..0x88ce60]
       InlinePCRanges: []
       Variables:
         - Name: x
-          Type: 1 BaseType int
+          Type: 9 BaseType int
           Locations:
             - Range: 0x88ce50..0x88ce58
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
         - Name: ~r0
-          Type: 1 BaseType int
+          Type: 9 BaseType int
           Locations: [{Range: 0x88ce50..0x88ce60, Pieces: []}]
           IsParameter: true
           IsReturn: true
-    - ID: 49
+    - ID: 43
       Name: main.testFramelessArray
       OutOfLinePCRanges: [0x88ce60..0x88cec0]
       InlinePCRanges: []
       Variables:
         - Name: a
-          Type: 2 ArrayType [5]int
+          Type: 72 ArrayType [5]int
           Locations:
             - Range: 0x88ce60..0x88cec0
               Pieces: [{Size: 40, Op: {CfaOffset: 8}}]
           IsParameter: true
           IsReturn: false
         - Name: ~r0
-          Type: 1 BaseType int
+          Type: 9 BaseType int
           Locations: [{Range: 0x88ce60..0x88cec0, Pieces: []}]
           IsParameter: true
           IsReturn: true
-    - ID: 50
+    - ID: 44
       Name: main.testInterface
       OutOfLinePCRanges: [0x88d100..0x88d160]
       InlinePCRanges: []
       Variables:
         - Name: b
-          Type: 55 GoInterfaceType main.behavior
+          Type: 73 GoInterfaceType main.behavior
           Locations:
             - Range: 0x88d100..0x88d128
               Pieces:
@@ -2123,17 +2123,17 @@ Subprograms:
           IsParameter: true
           IsReturn: false
         - Name: ~r0
-          Type: 8 GoStringHeaderType string
+          Type: 11 GoStringHeaderType string
           Locations: [{Range: 0x88d100..0x88d160, Pieces: []}]
           IsParameter: true
           IsReturn: true
-    - ID: 51
+    - ID: 45
       Name: main.testAny
       OutOfLinePCRanges: [0x88d160..0x88d1d0]
       InlinePCRanges: []
       Variables:
         - Name: a
-          Type: 41 GoEmptyInterfaceType interface {}
+          Type: 58 GoEmptyInterfaceType interface {}
           Locations:
             - Range: 0x88d160..0x88d190
               Pieces:
@@ -2150,17 +2150,17 @@ Subprograms:
           IsParameter: true
           IsReturn: false
         - Name: ~r0
-          Type: 8 GoStringHeaderType string
+          Type: 11 GoStringHeaderType string
           Locations: [{Range: 0x88d160..0x88d1d0, Pieces: []}]
           IsParameter: true
           IsReturn: true
-    - ID: 52
+    - ID: 46
       Name: main.testError
       OutOfLinePCRanges: [0x88d1d0..0x88d1e0]
       InlinePCRanges: []
       Variables:
         - Name: e
-          Type: 56 GoInterfaceType error
+          Type: 18 GoInterfaceType error
           Locations:
             - Range: 0x88d1d0..0x88d1e0
               Pieces:
@@ -2170,307 +2170,307 @@ Subprograms:
                   Op: {RegNo: 1, Shift: 0}
           IsParameter: true
           IsReturn: false
-    - ID: 53
+    - ID: 47
       Name: main.testStructWithMap
       OutOfLinePCRanges: [0x88d5f0..0x88d600]
       InlinePCRanges: []
       Variables:
         - Name: s
-          Type: 57 StructureType main.structWithMap
+          Type: 74 StructureType main.structWithMap
           Locations:
             - Range: 0x88d5f0..0x88d600
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 54
+    - ID: 48
       Name: main.testMapStringToStruct
       OutOfLinePCRanges: [0x88d600..0x88d610]
       InlinePCRanges: []
       Variables:
         - Name: m
-          Type: 74 GoMapType map[string]main.nestedStruct
+          Type: 90 GoMapType map[string]main.nestedStruct
           Locations:
             - Range: 0x88d600..0x88d610
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 55
+    - ID: 49
       Name: main.testMapStringToInt
       OutOfLinePCRanges: [0x88d610..0x88d620]
       InlinePCRanges: []
       Variables:
         - Name: m
-          Type: 82 GoMapType map[string]int
+          Type: 98 GoMapType map[string]int
           Locations:
             - Range: 0x88d610..0x88d620
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 56
+    - ID: 50
       Name: main.testMapStringToSlice
       OutOfLinePCRanges: [0x88d620..0x88d630]
       InlinePCRanges: []
       Variables:
         - Name: m
-          Type: 87 GoMapType map[string][]string
+          Type: 103 GoMapType map[string][]string
           Locations:
             - Range: 0x88d620..0x88d630
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 57
+    - ID: 51
       Name: main.testMapArrayToArray
       OutOfLinePCRanges: [0x88d630..0x88d640]
       InlinePCRanges: []
       Variables:
         - Name: m
-          Type: 94 GoMapType map[[4]string][2]int
+          Type: 110 GoMapType map[[4]string][2]int
           Locations:
             - Range: 0x88d630..0x88d640
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 58
+    - ID: 52
       Name: main.testSmallMap
       OutOfLinePCRanges: [0x88d640..0x88d650]
       InlinePCRanges: []
       Variables:
         - Name: m
-          Type: 82 GoMapType map[string]int
+          Type: 98 GoMapType map[string]int
           Locations:
             - Range: 0x88d640..0x88d650
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 59
+    - ID: 53
       Name: main.testArrayOfMaps
       OutOfLinePCRanges: [0x88d650..0x88d660]
       InlinePCRanges: []
       Variables:
         - Name: m
-          Type: 102 ArrayType [2]map[string]int
+          Type: 118 ArrayType [2]map[string]int
           Locations:
             - Range: 0x88d650..0x88d660
               Pieces: [{Size: 16, Op: {CfaOffset: 8}}]
           IsParameter: true
           IsReturn: false
-    - ID: 60
+    - ID: 54
       Name: main.testPointerToMap
       OutOfLinePCRanges: [0x88d660..0x88d670]
       InlinePCRanges: []
       Variables:
         - Name: m
-          Type: 103 PointerType *map[string]int
+          Type: 119 PointerType *map[string]int
           Locations:
             - Range: 0x88d660..0x88d670
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 61
+    - ID: 55
       Name: main.testMapIntToInt
       OutOfLinePCRanges: [0x88d670..0x88d680]
       InlinePCRanges: []
       Variables:
         - Name: m
-          Type: 58 GoMapType map[int]int
+          Type: 75 GoMapType map[int]int
           Locations:
             - Range: 0x88d670..0x88d680
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 62
+    - ID: 56
       Name: main.testMapMassive
       OutOfLinePCRanges: [0x88d680..0x88d690]
       InlinePCRanges: []
       Variables:
         - Name: redactMyEntries
-          Type: 104 GoMapType map[string][]main.structWithMap
+          Type: 120 GoMapType map[string][]main.structWithMap
           Locations:
             - Range: 0x88d680..0x88d690
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 63
+    - ID: 57
       Name: main.testMapEmbeddedMaps
       OutOfLinePCRanges: [0x88d690..0x88d6a0]
       InlinePCRanges: []
       Variables:
         - Name: m
-          Type: 104 GoMapType map[string][]main.structWithMap
+          Type: 120 GoMapType map[string][]main.structWithMap
           Locations:
             - Range: 0x88d690..0x88d6a0
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 64
+    - ID: 58
       Name: main.testMapWithLinkedList
       OutOfLinePCRanges: [0x88d6a0..0x88d6b0]
       InlinePCRanges: []
       Variables:
         - Name: m
-          Type: 112 GoMapType map[bool]main.node
+          Type: 128 GoMapType map[bool]main.node
           Locations:
             - Range: 0x88d6a0..0x88d6b0
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 65
+    - ID: 59
       Name: main.testMapWithSmallValue
       OutOfLinePCRanges: [0x88d6b0..0x88d6c0]
       InlinePCRanges: []
       Variables:
         - Name: m
-          Type: 121 GoMapType map[int]uint8
+          Type: 137 GoMapType map[int]uint8
           Locations:
             - Range: 0x88d6b0..0x88d6c0
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 66
+    - ID: 60
       Name: main.testMapWithSmallValueMassive
       OutOfLinePCRanges: [0x88d6c0..0x88d6d0]
       InlinePCRanges: []
       Variables:
         - Name: redactMyEntries
-          Type: 121 GoMapType map[int]uint8
+          Type: 137 GoMapType map[int]uint8
           Locations:
             - Range: 0x88d6c0..0x88d6d0
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 67
+    - ID: 61
       Name: main.testMapWithSmallKeyAndValue
       OutOfLinePCRanges: [0x88d6d0..0x88d6e0]
       InlinePCRanges: []
       Variables:
         - Name: m
-          Type: 127 GoMapType map[uint8]uint8
+          Type: 143 GoMapType map[uint8]uint8
           Locations:
             - Range: 0x88d6d0..0x88d6e0
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 68
+    - ID: 62
       Name: main.testMapWithSmallKeyAndValueMassive
       OutOfLinePCRanges: [0x88d6e0..0x88d6f0]
       InlinePCRanges: []
       Variables:
         - Name: m
-          Type: 127 GoMapType map[uint8]uint8
+          Type: 143 GoMapType map[uint8]uint8
           Locations:
             - Range: 0x88d6e0..0x88d6f0
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 69
+    - ID: 63
       Name: main.testMapSmallKeySmallValue
       OutOfLinePCRanges: [0x88d6f0..0x88d700]
       InlinePCRanges: []
       Variables:
         - Name: m
-          Type: 127 GoMapType map[uint8]uint8
+          Type: 143 GoMapType map[uint8]uint8
           Locations:
             - Range: 0x88d6f0..0x88d700
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 70
+    - ID: 64
       Name: main.testMapSmallKeyLargeValue
       OutOfLinePCRanges: [0x88d700..0x88d710]
       InlinePCRanges: []
       Variables:
         - Name: m
-          Type: 133 GoMapType map[uint8][4]int
+          Type: 149 GoMapType map[uint8][4]int
           Locations:
             - Range: 0x88d700..0x88d710
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 71
+    - ID: 65
       Name: main.testMapLargeKeySmallValue
       OutOfLinePCRanges: [0x88d710..0x88d720]
       InlinePCRanges: []
       Variables:
         - Name: m
-          Type: 140 GoMapType map[[4]int]uint8
+          Type: 156 GoMapType map[[4]int]uint8
           Locations:
             - Range: 0x88d710..0x88d720
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 72
+    - ID: 66
       Name: main.testMapLargeKeyLargeValue
       OutOfLinePCRanges: [0x88d720..0x88d730]
       InlinePCRanges: []
       Variables:
         - Name: m
-          Type: 146 GoMapType map[[4]int][4]int
+          Type: 162 GoMapType map[[4]int][4]int
           Locations:
             - Range: 0x88d720..0x88d730
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 73
+    - ID: 67
       Name: main.testCombinedByte
       OutOfLinePCRanges: [0x88e980..0x88e990]
       InlinePCRanges: []
       Variables:
         - Name: w
-          Type: 4 BaseType uint8
+          Type: 3 BaseType uint8
           Locations:
             - Range: 0x88e980..0x88e990
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
         - Name: x
-          Type: 4 BaseType uint8
+          Type: 3 BaseType uint8
           Locations:
             - Range: 0x88e980..0x88e990
               Pieces: [{Size: 1, Op: {RegNo: 1, Shift: 0}}]
           IsParameter: true
           IsReturn: false
         - Name: y
-          Type: 30 BaseType float32
+          Type: 16 BaseType float32
           Locations:
             - Range: 0x88e980..0x88e990
               Pieces: [{Size: 4, Op: {RegNo: 64, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 74
+    - ID: 68
       Name: main.testMultipleSimpleParams
       OutOfLinePCRanges: [0x88ea60..0x88ea70]
       InlinePCRanges: []
       Variables:
         - Name: a
-          Type: 11 BaseType bool
+          Type: 4 BaseType bool
           Locations:
             - Range: 0x88ea60..0x88ea70
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
         - Name: b
-          Type: 4 BaseType uint8
+          Type: 3 BaseType uint8
           Locations:
             - Range: 0x88ea60..0x88ea70
               Pieces: [{Size: 1, Op: {RegNo: 1, Shift: 0}}]
           IsParameter: true
           IsReturn: false
         - Name: c
-          Type: 6 BaseType int32
+          Type: 13 BaseType int32
           Locations:
             - Range: 0x88ea60..0x88ea70
               Pieces: [{Size: 4, Op: {RegNo: 2, Shift: 0}}]
           IsParameter: true
           IsReturn: false
         - Name: d
-          Type: 20 BaseType uint
+          Type: 12 BaseType uint
           Locations:
             - Range: 0x88ea60..0x88ea70
               Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
           IsParameter: true
           IsReturn: false
         - Name: e
-          Type: 8 GoStringHeaderType string
+          Type: 11 GoStringHeaderType string
           Locations:
             - Range: 0x88ea60..0x88ea70
               Pieces:
@@ -2480,37 +2480,37 @@ Subprograms:
                   Op: {RegNo: 5, Shift: 0}
           IsParameter: true
           IsReturn: false
-    - ID: 75
+    - ID: 69
       Name: main.testChannel
       OutOfLinePCRanges: [0x88ec00..0x88ec10]
       InlinePCRanges: []
       Variables:
         - Name: c
-          Type: 151 GoChannelType chan bool
+          Type: 167 GoChannelType chan bool
           Locations:
             - Range: 0x88ec00..0x88ec10
               Pieces: [{Size: 0, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 76
+    - ID: 70
       Name: main.testPointerToSimpleStruct
       OutOfLinePCRanges: [0x88eda0..0x88edb0]
       InlinePCRanges: []
       Variables:
         - Name: a
-          Type: 152 PointerType *main.structWithTwoValues
+          Type: 168 PointerType *main.structWithTwoValues
           Locations:
             - Range: 0x88eda0..0x88edb0
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 77
+    - ID: 71
       Name: main.testLinkedList
       OutOfLinePCRanges: [0x88edb0..0x88edc0]
       InlinePCRanges: []
       Variables:
         - Name: a
-          Type: 119 StructureType main.node
+          Type: 135 StructureType main.node
           Locations:
             - Range: 0x88edb0..0x88edc0
               Pieces:
@@ -2520,92 +2520,92 @@ Subprograms:
                   Op: {RegNo: 1, Shift: 0}
           IsParameter: true
           IsReturn: false
-    - ID: 78
+    - ID: 72
       Name: main.testPointerLoop
       OutOfLinePCRanges: [0x88edc0..0x88edd0]
       InlinePCRanges: []
       Variables:
         - Name: a
-          Type: 120 PointerType *main.node
+          Type: 136 PointerType *main.node
           Locations:
             - Range: 0x88edc0..0x88edd0
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 79
+    - ID: 73
       Name: main.testUnsafePointer
       OutOfLinePCRanges: [0x88edd0..0x88ede0]
       InlinePCRanges: []
       Variables:
         - Name: x
-          Type: 38 VoidPointerType unsafe.Pointer
+          Type: 19 VoidPointerType unsafe.Pointer
           Locations:
             - Range: 0x88edd0..0x88ede0
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 80
+    - ID: 74
       Name: main.testUintPointer
       OutOfLinePCRanges: [0x88edf0..0x88ee00]
       InlinePCRanges: []
       Variables:
         - Name: x
-          Type: 154 PointerType *uint
+          Type: 34 PointerType *uint
           Locations:
             - Range: 0x88edf0..0x88ee00
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 81
+    - ID: 75
       Name: main.testStringPointer
       OutOfLinePCRanges: [0x88ee60..0x88ee70]
       InlinePCRanges: []
       Variables:
         - Name: z
-          Type: 36 PointerType *string
+          Type: 22 PointerType *string
           Locations:
             - Range: 0x88ee60..0x88ee70
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 82
+    - ID: 76
       Name: main.testNilPointer
       OutOfLinePCRanges: [0x88ee80..0x88ee90]
       InlinePCRanges: []
       Variables:
         - Name: z
-          Type: 155 PointerType *bool
+          Type: 5 PointerType *bool
           Locations:
             - Range: 0x88ee80..0x88ee90
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
         - Name: a
-          Type: 20 BaseType uint
+          Type: 12 BaseType uint
           Locations:
             - Range: 0x88ee80..0x88ee90
               Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 83
+    - ID: 77
       Name: main.testCycle
       OutOfLinePCRanges: [0x88eea0..0x88eeb0]
       InlinePCRanges: []
       Variables:
         - Name: t
-          Type: 156 PointerType *main.t
+          Type: 170 PointerType *main.t
           Locations:
             - Range: 0x88eea0..0x88eeb0
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 84
+    - ID: 78
       Name: main.testUintSlice
       OutOfLinePCRanges: [0x88f290..0x88f2a0]
       InlinePCRanges: []
       Variables:
         - Name: u
-          Type: 159 GoSliceHeaderType []uint
+          Type: 173 GoSliceHeaderType []uint
           Locations:
             - Range: 0x88f290..0x88f2a0
               Pieces:
@@ -2617,13 +2617,13 @@ Subprograms:
                   Op: {RegNo: 2, Shift: 0}
           IsParameter: true
           IsReturn: false
-    - ID: 85
+    - ID: 79
       Name: main.testEmptySlice
       OutOfLinePCRanges: [0x88f2a0..0x88f2b0]
       InlinePCRanges: []
       Variables:
         - Name: u
-          Type: 159 GoSliceHeaderType []uint
+          Type: 173 GoSliceHeaderType []uint
           Locations:
             - Range: 0x88f2a0..0x88f2b0
               Pieces:
@@ -2635,13 +2635,13 @@ Subprograms:
                   Op: {RegNo: 2, Shift: 0}
           IsParameter: true
           IsReturn: false
-    - ID: 86
+    - ID: 80
       Name: main.testSliceOfSlices
       OutOfLinePCRanges: [0x88f2b0..0x88f2c0]
       InlinePCRanges: []
       Variables:
         - Name: u
-          Type: 160 GoSliceHeaderType [][]uint
+          Type: 174 GoSliceHeaderType [][]uint
           Locations:
             - Range: 0x88f2b0..0x88f2c0
               Pieces:
@@ -2653,13 +2653,13 @@ Subprograms:
                   Op: {RegNo: 2, Shift: 0}
           IsParameter: true
           IsReturn: false
-    - ID: 87
+    - ID: 81
       Name: main.testStructSlice
       OutOfLinePCRanges: [0x88f2c0..0x88f2d0]
       InlinePCRanges: []
       Variables:
         - Name: xs
-          Type: 162 GoSliceHeaderType []main.structWithNoStrings
+          Type: 176 GoSliceHeaderType []main.structWithNoStrings
           Locations:
             - Range: 0x88f2c0..0x88f2d0
               Pieces:
@@ -2672,19 +2672,19 @@ Subprograms:
           IsParameter: true
           IsReturn: false
         - Name: a
-          Type: 1 BaseType int
+          Type: 9 BaseType int
           Locations:
             - Range: 0x88f2c0..0x88f2d0
               Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 88
+    - ID: 82
       Name: main.testEmptySliceOfStructs
       OutOfLinePCRanges: [0x88f2d0..0x88f2e0]
       InlinePCRanges: []
       Variables:
         - Name: xs
-          Type: 162 GoSliceHeaderType []main.structWithNoStrings
+          Type: 176 GoSliceHeaderType []main.structWithNoStrings
           Locations:
             - Range: 0x88f2d0..0x88f2e0
               Pieces:
@@ -2697,19 +2697,19 @@ Subprograms:
           IsParameter: true
           IsReturn: false
         - Name: a
-          Type: 1 BaseType int
+          Type: 9 BaseType int
           Locations:
             - Range: 0x88f2d0..0x88f2e0
               Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 89
+    - ID: 83
       Name: main.testNilSliceOfStructs
       OutOfLinePCRanges: [0x88f2e0..0x88f2f0]
       InlinePCRanges: []
       Variables:
         - Name: xs
-          Type: 162 GoSliceHeaderType []main.structWithNoStrings
+          Type: 176 GoSliceHeaderType []main.structWithNoStrings
           Locations:
             - Range: 0x88f2e0..0x88f2f0
               Pieces:
@@ -2722,19 +2722,19 @@ Subprograms:
           IsParameter: true
           IsReturn: false
         - Name: a
-          Type: 1 BaseType int
+          Type: 9 BaseType int
           Locations:
             - Range: 0x88f2e0..0x88f2f0
               Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 90
+    - ID: 84
       Name: main.testStringSlice
       OutOfLinePCRanges: [0x88f2f0..0x88f300]
       InlinePCRanges: []
       Variables:
         - Name: s
-          Type: 93 GoSliceHeaderType []string
+          Type: 109 GoSliceHeaderType []string
           Locations:
             - Range: 0x88f2f0..0x88f300
               Pieces:
@@ -2746,20 +2746,20 @@ Subprograms:
                   Op: {RegNo: 2, Shift: 0}
           IsParameter: true
           IsReturn: false
-    - ID: 91
+    - ID: 85
       Name: main.testNilSliceWithOtherParams
       OutOfLinePCRanges: [0x88f300..0x88f310]
       InlinePCRanges: []
       Variables:
         - Name: a
-          Type: 14 BaseType int8
+          Type: 15 BaseType int8
           Locations:
             - Range: 0x88f300..0x88f310
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
         - Name: s
-          Type: 165 GoSliceHeaderType []bool
+          Type: 179 GoSliceHeaderType []bool
           Locations:
             - Range: 0x88f300..0x88f310
               Pieces:
@@ -2772,19 +2772,19 @@ Subprograms:
           IsParameter: true
           IsReturn: false
         - Name: x
-          Type: 20 BaseType uint
+          Type: 12 BaseType uint
           Locations:
             - Range: 0x88f300..0x88f310
               Pieces: [{Size: 8, Op: {RegNo: 4, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 92
+    - ID: 86
       Name: main.testNilSlice
       OutOfLinePCRanges: [0x88f310..0x88f320]
       InlinePCRanges: []
       Variables:
         - Name: xs
-          Type: 166 GoSliceHeaderType []uint16
+          Type: 180 GoSliceHeaderType []uint16
           Locations:
             - Range: 0x88f310..0x88f320
               Pieces:
@@ -2796,13 +2796,13 @@ Subprograms:
                   Op: {RegNo: 2, Shift: 0}
           IsParameter: true
           IsReturn: false
-    - ID: 93
+    - ID: 87
       Name: main.testVeryLargeSlice
       OutOfLinePCRanges: [0x88f320..0x88f330]
       InlinePCRanges: []
       Variables:
         - Name: xs
-          Type: 159 GoSliceHeaderType []uint
+          Type: 173 GoSliceHeaderType []uint
           Locations:
             - Range: 0x88f320..0x88f330
               Pieces:
@@ -2814,23 +2814,23 @@ Subprograms:
                   Op: {RegNo: 2, Shift: 0}
           IsParameter: true
           IsReturn: false
-    - ID: 94
+    - ID: 88
       Name: main.stackC
       OutOfLinePCRanges: [0x88f5f0..0x88f660]
       InlinePCRanges: []
       Variables:
         - Name: ~r0
-          Type: 8 GoStringHeaderType string
+          Type: 11 GoStringHeaderType string
           Locations: [{Range: 0x88f5f0..0x88f660, Pieces: []}]
           IsParameter: true
           IsReturn: true
-    - ID: 95
+    - ID: 89
       Name: main.testSingleString
       OutOfLinePCRanges: [0x88f660..0x88f670]
       InlinePCRanges: []
       Variables:
         - Name: x
-          Type: 8 GoStringHeaderType string
+          Type: 11 GoStringHeaderType string
           Locations:
             - Range: 0x88f660..0x88f670
               Pieces:
@@ -2840,13 +2840,13 @@ Subprograms:
                   Op: {RegNo: 1, Shift: 0}
           IsParameter: true
           IsReturn: false
-    - ID: 96
+    - ID: 90
       Name: main.testThreeStrings
       OutOfLinePCRanges: [0x88f670..0x88f680]
       InlinePCRanges: []
       Variables:
         - Name: x
-          Type: 8 GoStringHeaderType string
+          Type: 11 GoStringHeaderType string
           Locations:
             - Range: 0x88f670..0x88f680
               Pieces:
@@ -2857,7 +2857,7 @@ Subprograms:
           IsParameter: true
           IsReturn: false
         - Name: y
-          Type: 8 GoStringHeaderType string
+          Type: 11 GoStringHeaderType string
           Locations:
             - Range: 0x88f670..0x88f680
               Pieces:
@@ -2868,7 +2868,7 @@ Subprograms:
           IsParameter: true
           IsReturn: false
         - Name: z
-          Type: 8 GoStringHeaderType string
+          Type: 11 GoStringHeaderType string
           Locations:
             - Range: 0x88f670..0x88f680
               Pieces:
@@ -2878,13 +2878,13 @@ Subprograms:
                   Op: {RegNo: 5, Shift: 0}
           IsParameter: true
           IsReturn: false
-    - ID: 97
+    - ID: 91
       Name: main.testThreeStringsInStruct
       OutOfLinePCRanges: [0x88f680..0x88f6a0]
       InlinePCRanges: []
       Variables:
         - Name: a
-          Type: 168 StructureType main.threeStringStruct
+          Type: 181 StructureType main.threeStringStruct
           Locations:
             - Range: 0x88f680..0x88f6a0
               Pieces:
@@ -2902,37 +2902,37 @@ Subprograms:
                   Op: {RegNo: 5, Shift: 0}
           IsParameter: true
           IsReturn: false
-    - ID: 98
+    - ID: 92
       Name: main.testThreeStringsInStructPointer
       OutOfLinePCRanges: [0x88f6a0..0x88f6b0]
       InlinePCRanges: []
       Variables:
         - Name: a
-          Type: 169 PointerType *main.threeStringStruct
+          Type: 182 PointerType *main.threeStringStruct
           Locations:
             - Range: 0x88f6a0..0x88f6b0
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 99
+    - ID: 93
       Name: main.testOneStringInStructPointer
       OutOfLinePCRanges: [0x88f6b0..0x88f6c0]
       InlinePCRanges: []
       Variables:
         - Name: a
-          Type: 170 PointerType *main.oneStringStruct
+          Type: 183 PointerType *main.oneStringStruct
           Locations:
             - Range: 0x88f6b0..0x88f6c0
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 100
+    - ID: 94
       Name: main.testMassiveString
       OutOfLinePCRanges: [0x88f6c0..0x88f6d0]
       InlinePCRanges: []
       Variables:
         - Name: x
-          Type: 8 GoStringHeaderType string
+          Type: 11 GoStringHeaderType string
           Locations:
             - Range: 0x88f6c0..0x88f6d0
               Pieces:
@@ -2942,13 +2942,13 @@ Subprograms:
                   Op: {RegNo: 1, Shift: 0}
           IsParameter: true
           IsReturn: false
-    - ID: 101
+    - ID: 95
       Name: main.testUnitializedString
       OutOfLinePCRanges: [0x88f6d0..0x88f6e0]
       InlinePCRanges: []
       Variables:
         - Name: x
-          Type: 8 GoStringHeaderType string
+          Type: 11 GoStringHeaderType string
           Locations:
             - Range: 0x88f6d0..0x88f6e0
               Pieces:
@@ -2958,13 +2958,13 @@ Subprograms:
                   Op: {RegNo: 1, Shift: 0}
           IsParameter: true
           IsReturn: false
-    - ID: 102
+    - ID: 96
       Name: main.testEmptyString
       OutOfLinePCRanges: [0x88f6e0..0x88f6f0]
       InlinePCRanges: []
       Variables:
         - Name: x
-          Type: 8 GoStringHeaderType string
+          Type: 11 GoStringHeaderType string
           Locations:
             - Range: 0x88f6e0..0x88f6f0
               Pieces:
@@ -2974,13 +2974,13 @@ Subprograms:
                   Op: {RegNo: 1, Shift: 0}
           IsParameter: true
           IsReturn: false
-    - ID: 103
+    - ID: 97
       Name: main.testStruct
       OutOfLinePCRanges: [0x88f8f0..0x88f910]
       InlinePCRanges: []
       Variables:
         - Name: x
-          Type: 172 StructureType main.aStruct
+          Type: 185 StructureType main.aStruct
           Locations:
             - Range: 0x88f8f0..0x88f910
               Pieces:
@@ -3000,17 +3000,17 @@ Subprograms:
                   Op: {RegNo: 6, Shift: 0}
           IsParameter: true
           IsReturn: false
-    - ID: 104
+    - ID: 98
       Name: main.testEmptyStruct
       OutOfLinePCRanges: [0x88f9f0..0x88fa00]
       InlinePCRanges: []
       Variables:
         - Name: e
-          Type: 173 StructureType main.emptyStruct
+          Type: 186 StructureType main.emptyStruct
           Locations: [{Range: 0x88f9f0..0x88fa00, Pieces: []}]
           IsParameter: true
           IsReturn: false
-    - ID: 1
+    - ID: 99
       Name: main.testInlinedPrint
       OutOfLinePCRanges: [0x88c9b0..0x88ca20]
       InlinePCRanges:
@@ -3024,7 +3024,7 @@ Subprograms:
           RootRanges: [0x88ccb0..0x88cd30]
       Variables:
         - Name: x
-          Type: 1 BaseType int
+          Type: 9 BaseType int
           Locations:
             - Range: 0x88c9b0..0x88c9d0
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
@@ -3040,28 +3040,28 @@ Subprograms:
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 2
+    - ID: 100
       Name: main.testInlinedBBB
       OutOfLinePCRanges: []
       InlinePCRanges:
         - Ranges: [0x88cc48..0x88cc80]
           RootRanges: [0x88cbe0..0x88ccb0]
       Variables: []
-    - ID: 3
+    - ID: 101
       Name: main.testInlinedBCA
       OutOfLinePCRanges: []
       InlinePCRanges:
         - Ranges: [0x88cd4c..0x88cd90]
           RootRanges: [0x88cd30..0x88ce50]
       Variables: []
-    - ID: 4
+    - ID: 102
       Name: main.testInlinedBCB
       OutOfLinePCRanges: []
       InlinePCRanges:
         - Ranges: [0x88ce00..0x88ce38]
           RootRanges: [0x88cd30..0x88ce50]
       Variables: []
-    - ID: 5
+    - ID: 103
       Name: main.testInlinedSq
       OutOfLinePCRanges: []
       InlinePCRanges:
@@ -3069,13 +3069,13 @@ Subprograms:
           RootRanges: [0x88ce50..0x88ce60]
       Variables:
         - Name: x
-          Type: 1 BaseType int
+          Type: 9 BaseType int
           Locations:
             - Range: 0x88ce50..0x88ce58
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 6
+    - ID: 104
       Name: main.testInlinedSumArray
       OutOfLinePCRanges: []
       InlinePCRanges:
@@ -3085,7 +3085,7 @@ Subprograms:
           RootRanges: [0x88cec0..0x88d010]
       Variables:
         - Name: a
-          Type: 2 ArrayType [5]int
+          Type: 72 ArrayType [5]int
           Locations:
             - Range: 0x88ce70..0x88cec0
               Pieces: [{Size: 40, Op: {CfaOffset: -48}}]
@@ -3095,29 +3095,29 @@ Subprograms:
           IsReturn: false
 Types:
     - __kind: PointerType
-      ID: 158
+      ID: 172
       Name: '**main.t'
       ByteSize: 8
-      Pointee: 156 PointerType *main.t
+      Pointee: 170 PointerType *main.t
     - __kind: PointerType
-      ID: 71
+      ID: 87
       Name: '**runtime.bmap'
       ByteSize: 8
-      Pointee: 72 PointerType *runtime.bmap
+      Pointee: 88 PointerType *runtime.bmap
     - __kind: PointerType
-      ID: 35
+      ID: 54
       Name: '**string'
       ByteSize: 8
       GoRuntimeType: 486144
       GoKind: 22
-      Pointee: 36 PointerType *string
+      Pointee: 22 PointerType *string
     - __kind: PointerType
-      ID: 69
+      ID: 85
       Name: '*[]*runtime.bmap'
       ByteSize: 8
       GoRuntimeType: 451808
       GoKind: 22
-      Pointee: 70 GoSliceHeaderType []*runtime.bmap
+      Pointee: 86 GoSliceHeaderType []*runtime.bmap
     - __kind: PointerType
       ID: 193
       Name: '*[]*runtime.bmap.array'
@@ -3154,10 +3154,10 @@ Types:
       ByteSize: 8
       Pointee: 197 GoSliceDataType []string.array
     - __kind: PointerType
-      ID: 161
+      ID: 175
       Name: '*[]uint'
       ByteSize: 8
-      Pointee: 159 GoSliceHeaderType []uint
+      Pointee: 173 GoSliceHeaderType []uint
     - __kind: PointerType
       ID: 212
       Name: '*[]uint.array'
@@ -3169,317 +3169,317 @@ Types:
       ByteSize: 8
       Pointee: 219 GoSliceDataType []uint16.array
     - __kind: PointerType
-      ID: 155
+      ID: 5
       Name: '*bool'
       ByteSize: 8
       GoRuntimeType: 360288
       GoKind: 22
-      Pointee: 11 BaseType bool
+      Pointee: 4 BaseType bool
     - __kind: PointerType
-      ID: 149
+      ID: 165
       Name: '*bucket<[4]int,[4]int>'
       ByteSize: 8
-      Pointee: 150 GoHMapBucketType bucket<[4]int,[4]int>
+      Pointee: 166 GoHMapBucketType bucket<[4]int,[4]int>
     - __kind: PointerType
-      ID: 143
+      ID: 159
       Name: '*bucket<[4]int,uint8>'
       ByteSize: 8
-      Pointee: 144 GoHMapBucketType bucket<[4]int,uint8>
+      Pointee: 160 GoHMapBucketType bucket<[4]int,uint8>
     - __kind: PointerType
-      ID: 97
+      ID: 113
       Name: '*bucket<[4]string,[2]int>'
       ByteSize: 8
-      Pointee: 98 GoHMapBucketType bucket<[4]string,[2]int>
+      Pointee: 114 GoHMapBucketType bucket<[4]string,[2]int>
     - __kind: PointerType
-      ID: 115
+      ID: 131
       Name: '*bucket<bool,main.node>'
       ByteSize: 8
-      Pointee: 116 GoHMapBucketType bucket<bool,main.node>
+      Pointee: 132 GoHMapBucketType bucket<bool,main.node>
     - __kind: PointerType
-      ID: 61
+      ID: 78
       Name: '*bucket<int,int>'
       ByteSize: 8
-      Pointee: 62 GoHMapBucketType bucket<int,int>
+      Pointee: 79 GoHMapBucketType bucket<int,int>
     - __kind: PointerType
-      ID: 124
+      ID: 140
       Name: '*bucket<int,uint8>'
       ByteSize: 8
-      Pointee: 125 GoHMapBucketType bucket<int,uint8>
+      Pointee: 141 GoHMapBucketType bucket<int,uint8>
     - __kind: PointerType
-      ID: 107
+      ID: 123
       Name: '*bucket<string,[]main.structWithMap>'
       ByteSize: 8
-      Pointee: 108 GoHMapBucketType bucket<string,[]main.structWithMap>
+      Pointee: 124 GoHMapBucketType bucket<string,[]main.structWithMap>
     - __kind: PointerType
-      ID: 90
+      ID: 106
       Name: '*bucket<string,[]string>'
       ByteSize: 8
-      Pointee: 91 GoHMapBucketType bucket<string,[]string>
+      Pointee: 107 GoHMapBucketType bucket<string,[]string>
     - __kind: PointerType
-      ID: 85
+      ID: 101
       Name: '*bucket<string,int>'
       ByteSize: 8
-      Pointee: 86 GoHMapBucketType bucket<string,int>
+      Pointee: 102 GoHMapBucketType bucket<string,int>
     - __kind: PointerType
-      ID: 77
+      ID: 93
       Name: '*bucket<string,main.nestedStruct>'
       ByteSize: 8
-      Pointee: 78 GoHMapBucketType bucket<string,main.nestedStruct>
+      Pointee: 94 GoHMapBucketType bucket<string,main.nestedStruct>
     - __kind: PointerType
-      ID: 136
+      ID: 152
       Name: '*bucket<uint8,[4]int>'
       ByteSize: 8
-      Pointee: 137 GoHMapBucketType bucket<uint8,[4]int>
+      Pointee: 153 GoHMapBucketType bucket<uint8,[4]int>
     - __kind: PointerType
-      ID: 130
+      ID: 146
       Name: '*bucket<uint8,uint8>'
       ByteSize: 8
-      Pointee: 131 GoHMapBucketType bucket<uint8,uint8>
+      Pointee: 147 GoHMapBucketType bucket<uint8,uint8>
     - __kind: PointerType
-      ID: 185
+      ID: 33
       Name: '*error'
       ByteSize: 8
       GoRuntimeType: 359200
       GoKind: 22
-      Pointee: 56 GoInterfaceType error
+      Pointee: 18 GoInterfaceType error
     - __kind: PointerType
-      ID: 186
+      ID: 35
       Name: '*float32'
       ByteSize: 8
       GoRuntimeType: 360160
       GoKind: 22
-      Pointee: 30 BaseType float32
+      Pointee: 16 BaseType float32
     - __kind: PointerType
-      ID: 179
+      ID: 26
       Name: '*float64'
       ByteSize: 8
       GoRuntimeType: 360224
       GoKind: 22
-      Pointee: 31 BaseType float64
+      Pointee: 17 BaseType float64
     - __kind: PointerType
-      ID: 147
+      ID: 163
       Name: '*hash<[4]int,[4]int>'
       ByteSize: 8
-      Pointee: 148 GoHMapHeaderType hash<[4]int,[4]int>
+      Pointee: 164 GoHMapHeaderType hash<[4]int,[4]int>
     - __kind: PointerType
-      ID: 141
+      ID: 157
       Name: '*hash<[4]int,uint8>'
       ByteSize: 8
-      Pointee: 142 GoHMapHeaderType hash<[4]int,uint8>
+      Pointee: 158 GoHMapHeaderType hash<[4]int,uint8>
     - __kind: PointerType
-      ID: 95
+      ID: 111
       Name: '*hash<[4]string,[2]int>'
       ByteSize: 8
-      Pointee: 96 GoHMapHeaderType hash<[4]string,[2]int>
+      Pointee: 112 GoHMapHeaderType hash<[4]string,[2]int>
     - __kind: PointerType
-      ID: 113
+      ID: 129
       Name: '*hash<bool,main.node>'
       ByteSize: 8
-      Pointee: 114 GoHMapHeaderType hash<bool,main.node>
+      Pointee: 130 GoHMapHeaderType hash<bool,main.node>
     - __kind: PointerType
-      ID: 59
+      ID: 76
       Name: '*hash<int,int>'
       ByteSize: 8
-      Pointee: 60 GoHMapHeaderType hash<int,int>
+      Pointee: 77 GoHMapHeaderType hash<int,int>
     - __kind: PointerType
-      ID: 122
+      ID: 138
       Name: '*hash<int,uint8>'
       ByteSize: 8
-      Pointee: 123 GoHMapHeaderType hash<int,uint8>
+      Pointee: 139 GoHMapHeaderType hash<int,uint8>
     - __kind: PointerType
-      ID: 105
+      ID: 121
       Name: '*hash<string,[]main.structWithMap>'
       ByteSize: 8
-      Pointee: 106 GoHMapHeaderType hash<string,[]main.structWithMap>
+      Pointee: 122 GoHMapHeaderType hash<string,[]main.structWithMap>
     - __kind: PointerType
-      ID: 88
+      ID: 104
       Name: '*hash<string,[]string>'
       ByteSize: 8
-      Pointee: 89 GoHMapHeaderType hash<string,[]string>
+      Pointee: 105 GoHMapHeaderType hash<string,[]string>
     - __kind: PointerType
-      ID: 83
+      ID: 99
       Name: '*hash<string,int>'
       ByteSize: 8
-      Pointee: 84 GoHMapHeaderType hash<string,int>
+      Pointee: 100 GoHMapHeaderType hash<string,int>
     - __kind: PointerType
-      ID: 75
+      ID: 91
       Name: '*hash<string,main.nestedStruct>'
       ByteSize: 8
-      Pointee: 76 GoHMapHeaderType hash<string,main.nestedStruct>
+      Pointee: 92 GoHMapHeaderType hash<string,main.nestedStruct>
     - __kind: PointerType
-      ID: 134
+      ID: 150
       Name: '*hash<uint8,[4]int>'
       ByteSize: 8
-      Pointee: 135 GoHMapHeaderType hash<uint8,[4]int>
+      Pointee: 151 GoHMapHeaderType hash<uint8,[4]int>
     - __kind: PointerType
-      ID: 128
+      ID: 144
       Name: '*hash<uint8,uint8>'
       ByteSize: 8
-      Pointee: 129 GoHMapHeaderType hash<uint8,uint8>
+      Pointee: 145 GoHMapHeaderType hash<uint8,uint8>
     - __kind: PointerType
-      ID: 181
+      ID: 28
       Name: '*int'
       ByteSize: 8
       GoRuntimeType: 359840
       GoKind: 22
-      Pointee: 1 BaseType int
+      Pointee: 9 BaseType int
     - __kind: PointerType
-      ID: 183
+      ID: 31
       Name: '*int16'
       ByteSize: 8
       GoRuntimeType: 359456
       GoKind: 22
-      Pointee: 16 BaseType int16
+      Pointee: 23 BaseType int16
     - __kind: PointerType
-      ID: 175
+      ID: 20
       Name: '*int32'
       ByteSize: 8
       GoRuntimeType: 359584
       GoKind: 22
-      Pointee: 6 BaseType int32
+      Pointee: 13 BaseType int32
     - __kind: PointerType
-      ID: 180
+      ID: 27
       Name: '*int64'
       ByteSize: 8
       GoRuntimeType: 359712
       GoKind: 22
-      Pointee: 18 BaseType int64
+      Pointee: 14 BaseType int64
     - __kind: PointerType
-      ID: 184
+      ID: 32
       Name: '*int8'
       ByteSize: 8
       GoRuntimeType: 359328
       GoKind: 22
-      Pointee: 14 BaseType int8
+      Pointee: 15 BaseType int8
     - __kind: PointerType
-      ID: 44
+      ID: 61
       Name: '*main.esotericHeap'
       ByteSize: 8
       GoRuntimeType: 354208
       GoKind: 22
-      Pointee: 45 StructureType main.esotericHeap
+      Pointee: 62 StructureType main.esotericHeap
     - __kind: PointerType
-      ID: 120
+      ID: 136
       Name: '*main.node'
       ByteSize: 8
       GoRuntimeType: 354272
       GoKind: 22
-      Pointee: 119 StructureType main.node
+      Pointee: 135 StructureType main.node
     - __kind: PointerType
-      ID: 170
+      ID: 183
       Name: '*main.oneStringStruct'
       ByteSize: 8
       GoKind: 22
-      Pointee: 171 StructureType main.oneStringStruct
+      Pointee: 184 StructureType main.oneStringStruct
     - __kind: PointerType
-      ID: 111
+      ID: 127
       Name: '*main.structWithMap'
       ByteSize: 8
       GoRuntimeType: 354144
       GoKind: 22
-      Pointee: 57 StructureType main.structWithMap
+      Pointee: 74 StructureType main.structWithMap
     - __kind: PointerType
-      ID: 163
+      ID: 177
       Name: '*main.structWithNoStrings'
       ByteSize: 8
-      Pointee: 164 StructureType main.structWithNoStrings
+      Pointee: 178 StructureType main.structWithNoStrings
     - __kind: PointerType
-      ID: 152
+      ID: 168
       Name: '*main.structWithTwoValues'
       ByteSize: 8
       GoKind: 22
-      Pointee: 153 StructureType main.structWithTwoValues
+      Pointee: 169 StructureType main.structWithTwoValues
     - __kind: PointerType
-      ID: 156
+      ID: 170
       Name: '*main.t'
       ByteSize: 8
       GoKind: 22
-      Pointee: 157 GoSliceHeaderType main.t
+      Pointee: 171 GoSliceHeaderType main.t
     - __kind: PointerType
       ID: 210
       Name: '*main.t.array'
       ByteSize: 8
       Pointee: 209 GoSliceDataType main.t.array
     - __kind: PointerType
-      ID: 169
+      ID: 182
       Name: '*main.threeStringStruct'
       ByteSize: 8
       GoKind: 22
-      Pointee: 168 StructureType main.threeStringStruct
+      Pointee: 181 StructureType main.threeStringStruct
     - __kind: PointerType
-      ID: 103
+      ID: 119
       Name: '*map[string]int'
       ByteSize: 8
       GoKind: 22
-      Pointee: 82 GoMapType map[string]int
+      Pointee: 98 GoMapType map[string]int
     - __kind: PointerType
-      ID: 72
+      ID: 88
       Name: '*runtime.bmap'
       ByteSize: 8
       GoRuntimeType: 1.101088e+06
       GoKind: 22
-      Pointee: 73 StructureType runtime.bmap
+      Pointee: 89 StructureType runtime.bmap
     - __kind: PointerType
-      ID: 67
+      ID: 83
       Name: '*runtime.mapextra'
       ByteSize: 8
       GoRuntimeType: 363168
       GoKind: 22
-      Pointee: 68 StructureType runtime.mapextra
+      Pointee: 84 StructureType runtime.mapextra
     - __kind: PointerType
-      ID: 36
+      ID: 22
       Name: '*string'
       ByteSize: 8
       GoRuntimeType: 359264
       GoKind: 22
-      Pointee: 8 GoStringHeaderType string
+      Pointee: 11 GoStringHeaderType string
     - __kind: PointerType
       ID: 188
       Name: '*string.str'
       ByteSize: 8
       Pointee: 187 GoStringDataType string.str
     - __kind: PointerType
-      ID: 154
+      ID: 34
       Name: '*uint'
       ByteSize: 8
       GoRuntimeType: 359904
       GoKind: 22
-      Pointee: 20 BaseType uint
+      Pointee: 12 BaseType uint
     - __kind: PointerType
-      ID: 167
+      ID: 30
       Name: '*uint16'
       ByteSize: 8
       GoRuntimeType: 359520
       GoKind: 22
-      Pointee: 22 BaseType uint16
+      Pointee: 7 BaseType uint16
     - __kind: PointerType
-      ID: 176
+      ID: 21
       Name: '*uint32'
       ByteSize: 8
       GoRuntimeType: 359648
       GoKind: 22
-      Pointee: 24 BaseType uint32
+      Pointee: 2 BaseType uint32
     - __kind: PointerType
-      ID: 182
+      ID: 29
       Name: '*uint64'
       ByteSize: 8
       GoRuntimeType: 359776
       GoKind: 22
-      Pointee: 26 BaseType uint64
+      Pointee: 10 BaseType uint64
     - __kind: PointerType
-      ID: 9
+      ID: 6
       Name: '*uint8'
       ByteSize: 8
       GoRuntimeType: 359392
       GoKind: 22
-      Pointee: 4 BaseType uint8
+      Pointee: 3 BaseType uint8
     - __kind: PointerType
-      ID: 174
+      ID: 8
       Name: '*uintptr'
       ByteSize: 8
       GoRuntimeType: 359968
       GoKind: 22
-      Pointee: 66 BaseType uintptr
+      Pointee: 1 BaseType uintptr
     - __kind: EventRootType
       ID: 308
       Name: Probe[main.stackC]
@@ -3492,10 +3492,10 @@ Types:
         - Name: a
           Offset: 1
           Expression:
-            Type: 41 GoEmptyInterfaceType interface {}
+            Type: 58 GoEmptyInterfaceType interface {}
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 51, index: 0, name: a}
+                  Variable: {subprogram: 45, index: 0, name: a}
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
@@ -3507,10 +3507,10 @@ Types:
         - Name: b
           Offset: 1
           Expression:
-            Type: 28 ArrayType [2][2][2]int
+            Type: 49 ArrayType [2][2][2]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 23, index: 0, name: b}
+                  Variable: {subprogram: 17, index: 0, name: b}
                   Offset: 0
                   ByteSize: 64
     - __kind: EventRootType
@@ -3522,10 +3522,10 @@ Types:
         - Name: a
           Offset: 1
           Expression:
-            Type: 27 ArrayType [2][2]int
+            Type: 48 ArrayType [2][2]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 21, index: 0, name: a}
+                  Variable: {subprogram: 15, index: 0, name: a}
                   Offset: 0
                   ByteSize: 32
     - __kind: EventRootType
@@ -3537,10 +3537,10 @@ Types:
         - Name: m
           Offset: 1
           Expression:
-            Type: 102 ArrayType [2]map[string]int
+            Type: 118 ArrayType [2]map[string]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 59, index: 0, name: m}
+                  Variable: {subprogram: 53, index: 0, name: m}
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
@@ -3552,10 +3552,10 @@ Types:
         - Name: a
           Offset: 1
           Expression:
-            Type: 7 ArrayType [2]string
+            Type: 38 ArrayType [2]string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 22, index: 0, name: a}
+                  Variable: {subprogram: 16, index: 0, name: a}
                   Offset: 0
                   ByteSize: 32
     - __kind: EventRootType
@@ -3567,10 +3567,10 @@ Types:
         - Name: b
           Offset: 1
           Expression:
-            Type: 33 StructureType main.bigStruct
+            Type: 52 StructureType main.bigStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 41, index: 0, name: b}
+                  Variable: {subprogram: 35, index: 0, name: b}
                   Offset: 0
                   ByteSize: 48
     - __kind: EventRootType
@@ -3582,10 +3582,10 @@ Types:
         - Name: x
           Offset: 1
           Expression:
-            Type: 10 ArrayType [2]bool
+            Type: 39 ArrayType [2]bool
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 10, index: 0, name: x}
+                  Variable: {subprogram: 4, index: 0, name: x}
                   Offset: 0
                   ByteSize: 2
     - __kind: EventRootType
@@ -3597,10 +3597,10 @@ Types:
         - Name: x
           Offset: 1
           Expression:
-            Type: 3 ArrayType [2]uint8
+            Type: 36 ArrayType [2]uint8
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 7, index: 0, name: x}
+                  Variable: {subprogram: 1, index: 0, name: x}
                   Offset: 0
                   ByteSize: 2
     - __kind: EventRootType
@@ -3612,10 +3612,10 @@ Types:
         - Name: c
           Offset: 1
           Expression:
-            Type: 151 GoChannelType chan bool
+            Type: 167 GoChannelType chan bool
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 75, index: 0, name: c}
+                  Variable: {subprogram: 69, index: 0, name: c}
                   Offset: 0
                   ByteSize: 0
     - __kind: EventRootType
@@ -3627,28 +3627,28 @@ Types:
         - Name: w
           Offset: 1
           Expression:
-            Type: 4 BaseType uint8
+            Type: 3 BaseType uint8
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 73, index: 0, name: w}
+                  Variable: {subprogram: 67, index: 0, name: w}
                   Offset: 0
                   ByteSize: 1
         - Name: x
           Offset: 2
           Expression:
-            Type: 4 BaseType uint8
+            Type: 3 BaseType uint8
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 73, index: 1, name: x}
+                  Variable: {subprogram: 67, index: 1, name: x}
                   Offset: 0
                   ByteSize: 1
         - Name: y
           Offset: 3
           Expression:
-            Type: 30 BaseType float32
+            Type: 16 BaseType float32
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 73, index: 2, name: y}
+                  Variable: {subprogram: 67, index: 2, name: y}
                   Offset: 0
                   ByteSize: 4
     - __kind: EventRootType
@@ -3660,10 +3660,10 @@ Types:
         - Name: t
           Offset: 1
           Expression:
-            Type: 156 PointerType *main.t
+            Type: 170 PointerType *main.t
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 83, index: 0, name: t}
+                  Variable: {subprogram: 77, index: 0, name: t}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
@@ -3675,19 +3675,19 @@ Types:
         - Name: xs
           Offset: 1
           Expression:
-            Type: 162 GoSliceHeaderType []main.structWithNoStrings
+            Type: 176 GoSliceHeaderType []main.structWithNoStrings
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 88, index: 0, name: xs}
+                  Variable: {subprogram: 82, index: 0, name: xs}
                   Offset: 0
                   ByteSize: 24
         - Name: a
           Offset: 25
           Expression:
-            Type: 1 BaseType int
+            Type: 9 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 88, index: 1, name: a}
+                  Variable: {subprogram: 82, index: 1, name: a}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
@@ -3699,10 +3699,10 @@ Types:
         - Name: u
           Offset: 1
           Expression:
-            Type: 159 GoSliceHeaderType []uint
+            Type: 173 GoSliceHeaderType []uint
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 85, index: 0, name: u}
+                  Variable: {subprogram: 79, index: 0, name: u}
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
@@ -3714,10 +3714,10 @@ Types:
         - Name: x
           Offset: 1
           Expression:
-            Type: 8 GoStringHeaderType string
+            Type: 11 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 102, index: 0, name: x}
+                  Variable: {subprogram: 96, index: 0, name: x}
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
@@ -3729,10 +3729,10 @@ Types:
         - Name: e
           Offset: 1
           Expression:
-            Type: 173 StructureType main.emptyStruct
+            Type: 186 StructureType main.emptyStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 104, index: 0, name: e}
+                  Variable: {subprogram: 98, index: 0, name: e}
                   Offset: 0
                   ByteSize: 0
     - __kind: EventRootType
@@ -3744,10 +3744,10 @@ Types:
         - Name: e
           Offset: 1
           Expression:
-            Type: 56 GoInterfaceType error
+            Type: 18 GoInterfaceType error
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 52, index: 0, name: e}
+                  Variable: {subprogram: 46, index: 0, name: e}
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
@@ -3759,10 +3759,10 @@ Types:
         - Name: e
           Offset: 1
           Expression:
-            Type: 44 PointerType *main.esotericHeap
+            Type: 61 PointerType *main.esotericHeap
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 43, index: 0, name: e}
+                  Variable: {subprogram: 37, index: 0, name: e}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
@@ -3774,10 +3774,10 @@ Types:
         - Name: e
           Offset: 1
           Expression:
-            Type: 39 StructureType main.esotericStack
+            Type: 56 StructureType main.esotericStack
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 42, index: 0, name: e}
+                  Variable: {subprogram: 36, index: 0, name: e}
                   Offset: 0
                   ByteSize: 64
     - __kind: EventRootType
@@ -3789,10 +3789,10 @@ Types:
         - Name: a
           Offset: 1
           Expression:
-            Type: 2 ArrayType [5]int
+            Type: 72 ArrayType [5]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 49, index: 0, name: a}
+                  Variable: {subprogram: 43, index: 0, name: a}
                   Offset: 0
                   ByteSize: 40
     - __kind: EventRootType
@@ -3804,10 +3804,10 @@ Types:
         - Name: x
           Offset: 1
           Expression:
-            Type: 1 BaseType int
+            Type: 9 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 48, index: 0, name: x}
+                  Variable: {subprogram: 42, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
@@ -3819,10 +3819,10 @@ Types:
         - Name: x
           Offset: 1
           Expression:
-            Type: 1 BaseType int
+            Type: 9 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 44, index: 0, name: x}
+                  Variable: {subprogram: 38, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
@@ -3834,10 +3834,10 @@ Types:
         - Name: x
           Offset: 1
           Expression:
-            Type: 1 BaseType int
+            Type: 9 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 46, index: 0, name: x}
+                  Variable: {subprogram: 40, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
@@ -3852,19 +3852,19 @@ Types:
         - Name: x
           Offset: 1
           Expression:
-            Type: 1 BaseType int
+            Type: 9 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 45, index: 0, name: x}
+                  Variable: {subprogram: 39, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
         - Name: y
           Offset: 9
           Expression:
-            Type: 1 BaseType int
+            Type: 9 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 45, index: 1, name: y}
+                  Variable: {subprogram: 39, index: 1, name: y}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
@@ -3885,10 +3885,10 @@ Types:
         - Name: x
           Offset: 1
           Expression:
-            Type: 1 BaseType int
+            Type: 9 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 1, index: 0, name: x}
+                  Variable: {subprogram: 99, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
@@ -3900,10 +3900,10 @@ Types:
         - Name: x
           Offset: 1
           Expression:
-            Type: 1 BaseType int
+            Type: 9 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 5, index: 0, name: x}
+                  Variable: {subprogram: 103, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
@@ -3915,10 +3915,10 @@ Types:
         - Name: a
           Offset: 1
           Expression:
-            Type: 2 ArrayType [5]int
+            Type: 72 ArrayType [5]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 6, index: 0, name: a}
+                  Variable: {subprogram: 104, index: 0, name: a}
                   Offset: 0
                   ByteSize: 40
     - __kind: EventRootType
@@ -3930,10 +3930,10 @@ Types:
         - Name: x
           Offset: 1
           Expression:
-            Type: 15 ArrayType [2]int16
+            Type: 42 ArrayType [2]int16
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 13, index: 0, name: x}
+                  Variable: {subprogram: 7, index: 0, name: x}
                   Offset: 0
                   ByteSize: 4
     - __kind: EventRootType
@@ -3945,10 +3945,10 @@ Types:
         - Name: x
           Offset: 1
           Expression:
-            Type: 5 ArrayType [2]int32
+            Type: 37 ArrayType [2]int32
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 14, index: 0, name: x}
+                  Variable: {subprogram: 8, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
@@ -3960,10 +3960,10 @@ Types:
         - Name: x
           Offset: 1
           Expression:
-            Type: 17 ArrayType [2]int64
+            Type: 43 ArrayType [2]int64
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 15, index: 0, name: x}
+                  Variable: {subprogram: 9, index: 0, name: x}
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
@@ -3975,10 +3975,10 @@ Types:
         - Name: x
           Offset: 1
           Expression:
-            Type: 13 ArrayType [2]int8
+            Type: 41 ArrayType [2]int8
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 12, index: 0, name: x}
+                  Variable: {subprogram: 6, index: 0, name: x}
                   Offset: 0
                   ByteSize: 2
     - __kind: EventRootType
@@ -3990,10 +3990,10 @@ Types:
         - Name: x
           Offset: 1
           Expression:
-            Type: 12 ArrayType [2]int
+            Type: 40 ArrayType [2]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 11, index: 0, name: x}
+                  Variable: {subprogram: 5, index: 0, name: x}
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
@@ -4005,10 +4005,10 @@ Types:
         - Name: b
           Offset: 1
           Expression:
-            Type: 55 GoInterfaceType main.behavior
+            Type: 73 GoInterfaceType main.behavior
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 50, index: 0, name: b}
+                  Variable: {subprogram: 44, index: 0, name: b}
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
@@ -4020,10 +4020,10 @@ Types:
         - Name: a
           Offset: 1
           Expression:
-            Type: 119 StructureType main.node
+            Type: 135 StructureType main.node
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 77, index: 0, name: a}
+                  Variable: {subprogram: 71, index: 0, name: a}
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
@@ -4035,10 +4035,10 @@ Types:
         - Name: m
           Offset: 1
           Expression:
-            Type: 94 GoMapType map[[4]string][2]int
+            Type: 110 GoMapType map[[4]string][2]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 57, index: 0, name: m}
+                  Variable: {subprogram: 51, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
@@ -4050,10 +4050,10 @@ Types:
         - Name: m
           Offset: 1
           Expression:
-            Type: 104 GoMapType map[string][]main.structWithMap
+            Type: 120 GoMapType map[string][]main.structWithMap
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 63, index: 0, name: m}
+                  Variable: {subprogram: 57, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
@@ -4065,10 +4065,10 @@ Types:
         - Name: m
           Offset: 1
           Expression:
-            Type: 58 GoMapType map[int]int
+            Type: 75 GoMapType map[int]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 61, index: 0, name: m}
+                  Variable: {subprogram: 55, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
@@ -4080,10 +4080,10 @@ Types:
         - Name: m
           Offset: 1
           Expression:
-            Type: 146 GoMapType map[[4]int][4]int
+            Type: 162 GoMapType map[[4]int][4]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 72, index: 0, name: m}
+                  Variable: {subprogram: 66, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
@@ -4095,10 +4095,10 @@ Types:
         - Name: m
           Offset: 1
           Expression:
-            Type: 140 GoMapType map[[4]int]uint8
+            Type: 156 GoMapType map[[4]int]uint8
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 71, index: 0, name: m}
+                  Variable: {subprogram: 65, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
@@ -4110,10 +4110,10 @@ Types:
         - Name: redactMyEntries
           Offset: 1
           Expression:
-            Type: 104 GoMapType map[string][]main.structWithMap
+            Type: 120 GoMapType map[string][]main.structWithMap
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 62, index: 0, name: redactMyEntries}
+                  Variable: {subprogram: 56, index: 0, name: redactMyEntries}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
@@ -4125,10 +4125,10 @@ Types:
         - Name: m
           Offset: 1
           Expression:
-            Type: 133 GoMapType map[uint8][4]int
+            Type: 149 GoMapType map[uint8][4]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 70, index: 0, name: m}
+                  Variable: {subprogram: 64, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
@@ -4140,10 +4140,10 @@ Types:
         - Name: m
           Offset: 1
           Expression:
-            Type: 127 GoMapType map[uint8]uint8
+            Type: 143 GoMapType map[uint8]uint8
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 69, index: 0, name: m}
+                  Variable: {subprogram: 63, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
@@ -4155,10 +4155,10 @@ Types:
         - Name: m
           Offset: 1
           Expression:
-            Type: 82 GoMapType map[string]int
+            Type: 98 GoMapType map[string]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 55, index: 0, name: m}
+                  Variable: {subprogram: 49, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
@@ -4170,10 +4170,10 @@ Types:
         - Name: m
           Offset: 1
           Expression:
-            Type: 87 GoMapType map[string][]string
+            Type: 103 GoMapType map[string][]string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 56, index: 0, name: m}
+                  Variable: {subprogram: 50, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
@@ -4185,10 +4185,10 @@ Types:
         - Name: m
           Offset: 1
           Expression:
-            Type: 74 GoMapType map[string]main.nestedStruct
+            Type: 90 GoMapType map[string]main.nestedStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 54, index: 0, name: m}
+                  Variable: {subprogram: 48, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
@@ -4200,10 +4200,10 @@ Types:
         - Name: m
           Offset: 1
           Expression:
-            Type: 112 GoMapType map[bool]main.node
+            Type: 128 GoMapType map[bool]main.node
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 64, index: 0, name: m}
+                  Variable: {subprogram: 58, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
@@ -4215,10 +4215,10 @@ Types:
         - Name: m
           Offset: 1
           Expression:
-            Type: 127 GoMapType map[uint8]uint8
+            Type: 143 GoMapType map[uint8]uint8
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 68, index: 0, name: m}
+                  Variable: {subprogram: 62, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
@@ -4230,10 +4230,10 @@ Types:
         - Name: m
           Offset: 1
           Expression:
-            Type: 127 GoMapType map[uint8]uint8
+            Type: 143 GoMapType map[uint8]uint8
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 67, index: 0, name: m}
+                  Variable: {subprogram: 61, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
@@ -4245,10 +4245,10 @@ Types:
         - Name: redactMyEntries
           Offset: 1
           Expression:
-            Type: 121 GoMapType map[int]uint8
+            Type: 137 GoMapType map[int]uint8
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 66, index: 0, name: redactMyEntries}
+                  Variable: {subprogram: 60, index: 0, name: redactMyEntries}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
@@ -4260,10 +4260,10 @@ Types:
         - Name: m
           Offset: 1
           Expression:
-            Type: 121 GoMapType map[int]uint8
+            Type: 137 GoMapType map[int]uint8
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 65, index: 0, name: m}
+                  Variable: {subprogram: 59, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
@@ -4275,10 +4275,10 @@ Types:
         - Name: x
           Offset: 1
           Expression:
-            Type: 8 GoStringHeaderType string
+            Type: 11 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 100, index: 0, name: x}
+                  Variable: {subprogram: 94, index: 0, name: x}
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
@@ -4290,46 +4290,46 @@ Types:
         - Name: a
           Offset: 1
           Expression:
-            Type: 11 BaseType bool
+            Type: 4 BaseType bool
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 74, index: 0, name: a}
+                  Variable: {subprogram: 68, index: 0, name: a}
                   Offset: 0
                   ByteSize: 1
         - Name: b
           Offset: 2
           Expression:
-            Type: 4 BaseType uint8
+            Type: 3 BaseType uint8
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 74, index: 1, name: b}
+                  Variable: {subprogram: 68, index: 1, name: b}
                   Offset: 0
                   ByteSize: 1
         - Name: c
           Offset: 3
           Expression:
-            Type: 6 BaseType int32
+            Type: 13 BaseType int32
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 74, index: 2, name: c}
+                  Variable: {subprogram: 68, index: 2, name: c}
                   Offset: 0
                   ByteSize: 4
         - Name: d
           Offset: 7
           Expression:
-            Type: 20 BaseType uint
+            Type: 12 BaseType uint
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 74, index: 3, name: d}
+                  Variable: {subprogram: 68, index: 3, name: d}
                   Offset: 0
                   ByteSize: 8
         - Name: e
           Offset: 15
           Expression:
-            Type: 8 GoStringHeaderType string
+            Type: 11 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 74, index: 4, name: e}
+                  Variable: {subprogram: 68, index: 4, name: e}
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
@@ -4341,19 +4341,19 @@ Types:
         - Name: z
           Offset: 1
           Expression:
-            Type: 155 PointerType *bool
+            Type: 5 PointerType *bool
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 82, index: 0, name: z}
+                  Variable: {subprogram: 76, index: 0, name: z}
                   Offset: 0
                   ByteSize: 8
         - Name: a
           Offset: 9
           Expression:
-            Type: 20 BaseType uint
+            Type: 12 BaseType uint
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 82, index: 1, name: a}
+                  Variable: {subprogram: 76, index: 1, name: a}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
@@ -4365,19 +4365,19 @@ Types:
         - Name: xs
           Offset: 1
           Expression:
-            Type: 162 GoSliceHeaderType []main.structWithNoStrings
+            Type: 176 GoSliceHeaderType []main.structWithNoStrings
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 89, index: 0, name: xs}
+                  Variable: {subprogram: 83, index: 0, name: xs}
                   Offset: 0
                   ByteSize: 24
         - Name: a
           Offset: 25
           Expression:
-            Type: 1 BaseType int
+            Type: 9 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 89, index: 1, name: a}
+                  Variable: {subprogram: 83, index: 1, name: a}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
@@ -4389,28 +4389,28 @@ Types:
         - Name: a
           Offset: 1
           Expression:
-            Type: 14 BaseType int8
+            Type: 15 BaseType int8
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 91, index: 0, name: a}
+                  Variable: {subprogram: 85, index: 0, name: a}
                   Offset: 0
                   ByteSize: 1
         - Name: s
           Offset: 2
           Expression:
-            Type: 165 GoSliceHeaderType []bool
+            Type: 179 GoSliceHeaderType []bool
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 91, index: 1, name: s}
+                  Variable: {subprogram: 85, index: 1, name: s}
                   Offset: 0
                   ByteSize: 24
         - Name: x
           Offset: 26
           Expression:
-            Type: 20 BaseType uint
+            Type: 12 BaseType uint
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 91, index: 2, name: x}
+                  Variable: {subprogram: 85, index: 2, name: x}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
@@ -4422,10 +4422,10 @@ Types:
         - Name: xs
           Offset: 1
           Expression:
-            Type: 166 GoSliceHeaderType []uint16
+            Type: 180 GoSliceHeaderType []uint16
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 92, index: 0, name: xs}
+                  Variable: {subprogram: 86, index: 0, name: xs}
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
@@ -4437,10 +4437,10 @@ Types:
         - Name: a
           Offset: 1
           Expression:
-            Type: 170 PointerType *main.oneStringStruct
+            Type: 183 PointerType *main.oneStringStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 99, index: 0, name: a}
+                  Variable: {subprogram: 93, index: 0, name: a}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
@@ -4452,10 +4452,10 @@ Types:
         - Name: a
           Offset: 1
           Expression:
-            Type: 120 PointerType *main.node
+            Type: 136 PointerType *main.node
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 78, index: 0, name: a}
+                  Variable: {subprogram: 72, index: 0, name: a}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
@@ -4467,10 +4467,10 @@ Types:
         - Name: m
           Offset: 1
           Expression:
-            Type: 103 PointerType *map[string]int
+            Type: 119 PointerType *map[string]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 60, index: 0, name: m}
+                  Variable: {subprogram: 54, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
@@ -4482,10 +4482,10 @@ Types:
         - Name: a
           Offset: 1
           Expression:
-            Type: 152 PointerType *main.structWithTwoValues
+            Type: 168 PointerType *main.structWithTwoValues
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 76, index: 0, name: a}
+                  Variable: {subprogram: 70, index: 0, name: a}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
@@ -4497,10 +4497,10 @@ Types:
         - Name: x
           Offset: 1
           Expression:
-            Type: 5 ArrayType [2]int32
+            Type: 37 ArrayType [2]int32
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 8, index: 0, name: x}
+                  Variable: {subprogram: 2, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
@@ -4512,10 +4512,10 @@ Types:
         - Name: x
           Offset: 1
           Expression:
-            Type: 11 BaseType bool
+            Type: 4 BaseType bool
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 27, index: 0, name: x}
+                  Variable: {subprogram: 21, index: 0, name: x}
                   Offset: 0
                   ByteSize: 1
     - __kind: EventRootType
@@ -4527,10 +4527,10 @@ Types:
         - Name: x
           Offset: 1
           Expression:
-            Type: 4 BaseType uint8
+            Type: 3 BaseType uint8
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 25, index: 0, name: x}
+                  Variable: {subprogram: 19, index: 0, name: x}
                   Offset: 0
                   ByteSize: 1
     - __kind: EventRootType
@@ -4542,10 +4542,10 @@ Types:
         - Name: x
           Offset: 1
           Expression:
-            Type: 30 BaseType float32
+            Type: 16 BaseType float32
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 38, index: 0, name: x}
+                  Variable: {subprogram: 32, index: 0, name: x}
                   Offset: 0
                   ByteSize: 4
     - __kind: EventRootType
@@ -4557,10 +4557,10 @@ Types:
         - Name: x
           Offset: 1
           Expression:
-            Type: 31 BaseType float64
+            Type: 17 BaseType float64
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 39, index: 0, name: x}
+                  Variable: {subprogram: 33, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
@@ -4572,10 +4572,10 @@ Types:
         - Name: x
           Offset: 1
           Expression:
-            Type: 16 BaseType int16
+            Type: 23 BaseType int16
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 30, index: 0, name: x}
+                  Variable: {subprogram: 24, index: 0, name: x}
                   Offset: 0
                   ByteSize: 2
     - __kind: EventRootType
@@ -4587,10 +4587,10 @@ Types:
         - Name: x
           Offset: 1
           Expression:
-            Type: 6 BaseType int32
+            Type: 13 BaseType int32
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 31, index: 0, name: x}
+                  Variable: {subprogram: 25, index: 0, name: x}
                   Offset: 0
                   ByteSize: 4
     - __kind: EventRootType
@@ -4602,10 +4602,10 @@ Types:
         - Name: x
           Offset: 1
           Expression:
-            Type: 18 BaseType int64
+            Type: 14 BaseType int64
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 32, index: 0, name: x}
+                  Variable: {subprogram: 26, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
@@ -4617,10 +4617,10 @@ Types:
         - Name: x
           Offset: 1
           Expression:
-            Type: 14 BaseType int8
+            Type: 15 BaseType int8
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 29, index: 0, name: x}
+                  Variable: {subprogram: 23, index: 0, name: x}
                   Offset: 0
                   ByteSize: 1
     - __kind: EventRootType
@@ -4632,10 +4632,10 @@ Types:
         - Name: x
           Offset: 1
           Expression:
-            Type: 1 BaseType int
+            Type: 9 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 28, index: 0, name: x}
+                  Variable: {subprogram: 22, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
@@ -4647,10 +4647,10 @@ Types:
         - Name: x
           Offset: 1
           Expression:
-            Type: 6 BaseType int32
+            Type: 13 BaseType int32
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 26, index: 0, name: x}
+                  Variable: {subprogram: 20, index: 0, name: x}
                   Offset: 0
                   ByteSize: 4
     - __kind: EventRootType
@@ -4662,10 +4662,10 @@ Types:
         - Name: x
           Offset: 1
           Expression:
-            Type: 8 GoStringHeaderType string
+            Type: 11 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 95, index: 0, name: x}
+                  Variable: {subprogram: 89, index: 0, name: x}
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
@@ -4677,10 +4677,10 @@ Types:
         - Name: x
           Offset: 1
           Expression:
-            Type: 22 BaseType uint16
+            Type: 7 BaseType uint16
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 35, index: 0, name: x}
+                  Variable: {subprogram: 29, index: 0, name: x}
                   Offset: 0
                   ByteSize: 2
     - __kind: EventRootType
@@ -4692,10 +4692,10 @@ Types:
         - Name: x
           Offset: 1
           Expression:
-            Type: 24 BaseType uint32
+            Type: 2 BaseType uint32
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 36, index: 0, name: x}
+                  Variable: {subprogram: 30, index: 0, name: x}
                   Offset: 0
                   ByteSize: 4
     - __kind: EventRootType
@@ -4707,10 +4707,10 @@ Types:
         - Name: x
           Offset: 1
           Expression:
-            Type: 26 BaseType uint64
+            Type: 10 BaseType uint64
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 37, index: 0, name: x}
+                  Variable: {subprogram: 31, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
@@ -4722,10 +4722,10 @@ Types:
         - Name: x
           Offset: 1
           Expression:
-            Type: 4 BaseType uint8
+            Type: 3 BaseType uint8
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 34, index: 0, name: x}
+                  Variable: {subprogram: 28, index: 0, name: x}
                   Offset: 0
                   ByteSize: 1
     - __kind: EventRootType
@@ -4737,10 +4737,10 @@ Types:
         - Name: x
           Offset: 1
           Expression:
-            Type: 20 BaseType uint
+            Type: 12 BaseType uint
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 33, index: 0, name: x}
+                  Variable: {subprogram: 27, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
@@ -4752,10 +4752,10 @@ Types:
         - Name: u
           Offset: 1
           Expression:
-            Type: 160 GoSliceHeaderType [][]uint
+            Type: 174 GoSliceHeaderType [][]uint
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 86, index: 0, name: u}
+                  Variable: {subprogram: 80, index: 0, name: u}
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
@@ -4767,10 +4767,10 @@ Types:
         - Name: m
           Offset: 1
           Expression:
-            Type: 82 GoMapType map[string]int
+            Type: 98 GoMapType map[string]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 58, index: 0, name: m}
+                  Variable: {subprogram: 52, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
@@ -4782,10 +4782,10 @@ Types:
         - Name: x
           Offset: 1
           Expression:
-            Type: 7 ArrayType [2]string
+            Type: 38 ArrayType [2]string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 9, index: 0, name: x}
+                  Variable: {subprogram: 3, index: 0, name: x}
                   Offset: 0
                   ByteSize: 32
     - __kind: EventRootType
@@ -4797,10 +4797,10 @@ Types:
         - Name: z
           Offset: 1
           Expression:
-            Type: 36 PointerType *string
+            Type: 22 PointerType *string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 81, index: 0, name: z}
+                  Variable: {subprogram: 75, index: 0, name: z}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
@@ -4812,10 +4812,10 @@ Types:
         - Name: s
           Offset: 1
           Expression:
-            Type: 93 GoSliceHeaderType []string
+            Type: 109 GoSliceHeaderType []string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 90, index: 0, name: s}
+                  Variable: {subprogram: 84, index: 0, name: s}
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
@@ -4827,19 +4827,19 @@ Types:
         - Name: xs
           Offset: 1
           Expression:
-            Type: 162 GoSliceHeaderType []main.structWithNoStrings
+            Type: 176 GoSliceHeaderType []main.structWithNoStrings
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 87, index: 0, name: xs}
+                  Variable: {subprogram: 81, index: 0, name: xs}
                   Offset: 0
                   ByteSize: 24
         - Name: a
           Offset: 25
           Expression:
-            Type: 1 BaseType int
+            Type: 9 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 87, index: 1, name: a}
+                  Variable: {subprogram: 81, index: 1, name: a}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
@@ -4851,10 +4851,10 @@ Types:
         - Name: s
           Offset: 1
           Expression:
-            Type: 57 StructureType main.structWithMap
+            Type: 74 StructureType main.structWithMap
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 53, index: 0, name: s}
+                  Variable: {subprogram: 47, index: 0, name: s}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
@@ -4866,10 +4866,10 @@ Types:
         - Name: x
           Offset: 1
           Expression:
-            Type: 172 StructureType main.aStruct
+            Type: 185 StructureType main.aStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 103, index: 0, name: x}
+                  Variable: {subprogram: 97, index: 0, name: x}
                   Offset: 0
                   ByteSize: 56
     - __kind: EventRootType
@@ -4881,10 +4881,10 @@ Types:
         - Name: a
           Offset: 1
           Expression:
-            Type: 169 PointerType *main.threeStringStruct
+            Type: 182 PointerType *main.threeStringStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 98, index: 0, name: a}
+                  Variable: {subprogram: 92, index: 0, name: a}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
@@ -4896,10 +4896,10 @@ Types:
         - Name: a
           Offset: 1
           Expression:
-            Type: 168 StructureType main.threeStringStruct
+            Type: 181 StructureType main.threeStringStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 97, index: 0, name: a}
+                  Variable: {subprogram: 91, index: 0, name: a}
                   Offset: 0
                   ByteSize: 48
     - __kind: EventRootType
@@ -4911,28 +4911,28 @@ Types:
         - Name: x
           Offset: 1
           Expression:
-            Type: 8 GoStringHeaderType string
+            Type: 11 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 96, index: 0, name: x}
+                  Variable: {subprogram: 90, index: 0, name: x}
                   Offset: 0
                   ByteSize: 16
         - Name: y
           Offset: 17
           Expression:
-            Type: 8 GoStringHeaderType string
+            Type: 11 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 96, index: 1, name: y}
+                  Variable: {subprogram: 90, index: 1, name: y}
                   Offset: 0
                   ByteSize: 16
         - Name: z
           Offset: 33
           Expression:
-            Type: 8 GoStringHeaderType string
+            Type: 11 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 96, index: 2, name: z}
+                  Variable: {subprogram: 90, index: 2, name: z}
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
@@ -4944,10 +4944,10 @@ Types:
         - Name: x
           Offset: 1
           Expression:
-            Type: 32 BaseType main.typeAlias
+            Type: 51 BaseType main.typeAlias
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 40, index: 0, name: x}
+                  Variable: {subprogram: 34, index: 0, name: x}
                   Offset: 0
                   ByteSize: 2
     - __kind: EventRootType
@@ -4959,10 +4959,10 @@ Types:
         - Name: x
           Offset: 1
           Expression:
-            Type: 21 ArrayType [2]uint16
+            Type: 45 ArrayType [2]uint16
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 18, index: 0, name: x}
+                  Variable: {subprogram: 12, index: 0, name: x}
                   Offset: 0
                   ByteSize: 4
     - __kind: EventRootType
@@ -4974,10 +4974,10 @@ Types:
         - Name: x
           Offset: 1
           Expression:
-            Type: 23 ArrayType [2]uint32
+            Type: 46 ArrayType [2]uint32
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 19, index: 0, name: x}
+                  Variable: {subprogram: 13, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
@@ -4989,10 +4989,10 @@ Types:
         - Name: x
           Offset: 1
           Expression:
-            Type: 25 ArrayType [2]uint64
+            Type: 47 ArrayType [2]uint64
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 20, index: 0, name: x}
+                  Variable: {subprogram: 14, index: 0, name: x}
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
@@ -5004,10 +5004,10 @@ Types:
         - Name: x
           Offset: 1
           Expression:
-            Type: 3 ArrayType [2]uint8
+            Type: 36 ArrayType [2]uint8
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 17, index: 0, name: x}
+                  Variable: {subprogram: 11, index: 0, name: x}
                   Offset: 0
                   ByteSize: 2
     - __kind: EventRootType
@@ -5019,10 +5019,10 @@ Types:
         - Name: x
           Offset: 1
           Expression:
-            Type: 19 ArrayType [2]uint
+            Type: 44 ArrayType [2]uint
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 16, index: 0, name: x}
+                  Variable: {subprogram: 10, index: 0, name: x}
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
@@ -5034,10 +5034,10 @@ Types:
         - Name: x
           Offset: 1
           Expression:
-            Type: 154 PointerType *uint
+            Type: 34 PointerType *uint
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 80, index: 0, name: x}
+                  Variable: {subprogram: 74, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
@@ -5049,10 +5049,10 @@ Types:
         - Name: u
           Offset: 1
           Expression:
-            Type: 159 GoSliceHeaderType []uint
+            Type: 173 GoSliceHeaderType []uint
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 84, index: 0, name: u}
+                  Variable: {subprogram: 78, index: 0, name: u}
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
@@ -5064,10 +5064,10 @@ Types:
         - Name: x
           Offset: 1
           Expression:
-            Type: 8 GoStringHeaderType string
+            Type: 11 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 101, index: 0, name: x}
+                  Variable: {subprogram: 95, index: 0, name: x}
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
@@ -5079,10 +5079,10 @@ Types:
         - Name: x
           Offset: 1
           Expression:
-            Type: 38 VoidPointerType unsafe.Pointer
+            Type: 19 VoidPointerType unsafe.Pointer
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 79, index: 0, name: x}
+                  Variable: {subprogram: 73, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
@@ -5094,10 +5094,10 @@ Types:
         - Name: a
           Offset: 1
           Expression:
-            Type: 29 ArrayType [100]uint
+            Type: 50 ArrayType [100]uint
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 24, index: 0, name: a}
+                  Variable: {subprogram: 18, index: 0, name: a}
                   Offset: 0
                   ByteSize: 800
     - __kind: EventRootType
@@ -5109,182 +5109,182 @@ Types:
         - Name: xs
           Offset: 1
           Expression:
-            Type: 159 GoSliceHeaderType []uint
+            Type: 173 GoSliceHeaderType []uint
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 93, index: 0, name: xs}
+                  Variable: {subprogram: 87, index: 0, name: xs}
                   Offset: 0
                   ByteSize: 24
     - __kind: ArrayType
-      ID: 29
+      ID: 50
       Name: '[100]uint'
       ByteSize: 800
       GoKind: 17
       Count: 100
       HasCount: true
-      Element: 20 BaseType uint
+      Element: 12 BaseType uint
     - __kind: ArrayType
-      ID: 28
+      ID: 49
       Name: '[2][2][2]int'
       ByteSize: 64
       GoKind: 17
       Count: 2
       HasCount: true
-      Element: 27 ArrayType [2][2]int
+      Element: 48 ArrayType [2][2]int
     - __kind: ArrayType
-      ID: 27
+      ID: 48
       Name: '[2][2]int'
       ByteSize: 32
       GoKind: 17
       Count: 2
       HasCount: true
-      Element: 12 ArrayType [2]int
+      Element: 40 ArrayType [2]int
     - __kind: ArrayType
-      ID: 10
+      ID: 39
       Name: '[2]bool'
       ByteSize: 2
       GoKind: 17
       Count: 2
       HasCount: true
-      Element: 11 BaseType bool
+      Element: 4 BaseType bool
     - __kind: ArrayType
-      ID: 12
+      ID: 40
       Name: '[2]int'
       ByteSize: 16
       GoRuntimeType: 617920
       GoKind: 17
       Count: 2
       HasCount: true
-      Element: 1 BaseType int
+      Element: 9 BaseType int
     - __kind: ArrayType
-      ID: 15
+      ID: 42
       Name: '[2]int16'
       ByteSize: 4
       GoKind: 17
       Count: 2
       HasCount: true
-      Element: 16 BaseType int16
+      Element: 23 BaseType int16
     - __kind: ArrayType
-      ID: 5
+      ID: 37
       Name: '[2]int32'
       ByteSize: 8
       GoRuntimeType: 619072
       GoKind: 17
       Count: 2
       HasCount: true
-      Element: 6 BaseType int32
+      Element: 13 BaseType int32
     - __kind: ArrayType
-      ID: 17
+      ID: 43
       Name: '[2]int64'
       ByteSize: 16
       GoKind: 17
       Count: 2
       HasCount: true
-      Element: 18 BaseType int64
+      Element: 14 BaseType int64
     - __kind: ArrayType
-      ID: 13
+      ID: 41
       Name: '[2]int8'
       ByteSize: 2
       GoKind: 17
       Count: 2
       HasCount: true
-      Element: 14 BaseType int8
+      Element: 15 BaseType int8
     - __kind: ArrayType
-      ID: 102
+      ID: 118
       Name: '[2]map[string]int'
       ByteSize: 16
       GoKind: 17
       Count: 2
       HasCount: true
-      Element: 82 GoMapType map[string]int
+      Element: 98 GoMapType map[string]int
     - __kind: ArrayType
-      ID: 7
+      ID: 38
       Name: '[2]string'
       ByteSize: 32
       GoRuntimeType: 619168
       GoKind: 17
       Count: 2
       HasCount: true
-      Element: 8 GoStringHeaderType string
+      Element: 11 GoStringHeaderType string
     - __kind: ArrayType
-      ID: 19
+      ID: 44
       Name: '[2]uint'
       ByteSize: 16
       GoKind: 17
       Count: 2
       HasCount: true
-      Element: 20 BaseType uint
+      Element: 12 BaseType uint
     - __kind: ArrayType
-      ID: 21
+      ID: 45
       Name: '[2]uint16'
       ByteSize: 4
       GoKind: 17
       Count: 2
       HasCount: true
-      Element: 22 BaseType uint16
+      Element: 7 BaseType uint16
     - __kind: ArrayType
-      ID: 23
+      ID: 46
       Name: '[2]uint32'
       ByteSize: 8
       GoKind: 17
       Count: 2
       HasCount: true
-      Element: 24 BaseType uint32
+      Element: 2 BaseType uint32
     - __kind: ArrayType
-      ID: 25
+      ID: 47
       Name: '[2]uint64'
       ByteSize: 16
       GoRuntimeType: 619264
       GoKind: 17
       Count: 2
       HasCount: true
-      Element: 26 BaseType uint64
+      Element: 10 BaseType uint64
     - __kind: ArrayType
-      ID: 3
+      ID: 36
       Name: '[2]uint8'
       ByteSize: 2
       GoRuntimeType: 618976
       GoKind: 17
       Count: 2
       HasCount: true
-      Element: 4 BaseType uint8
+      Element: 3 BaseType uint8
     - __kind: ArrayType
-      ID: 139
+      ID: 155
       Name: '[4]int'
       ByteSize: 32
       GoRuntimeType: 617536
       GoKind: 17
       Count: 4
       HasCount: true
-      Element: 1 BaseType int
+      Element: 9 BaseType int
     - __kind: ArrayType
-      ID: 100
+      ID: 116
       Name: '[4]string'
       ByteSize: 64
       GoRuntimeType: 617824
       GoKind: 17
       Count: 4
       HasCount: true
-      Element: 8 GoStringHeaderType string
+      Element: 11 GoStringHeaderType string
     - __kind: ArrayType
-      ID: 2
+      ID: 72
       Name: '[5]int'
       ByteSize: 40
       GoKind: 17
       Count: 5
       HasCount: true
-      Element: 1 BaseType int
+      Element: 9 BaseType int
     - __kind: ArrayType
-      ID: 63
+      ID: 80
       Name: '[8]uint8'
       ByteSize: 8
       GoRuntimeType: 615616
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 4 BaseType uint8
+      Element: 3 BaseType uint8
     - __kind: GoSliceHeaderType
-      ID: 70
+      ID: 86
       Name: '[]*runtime.bmap'
       ByteSize: 24
       GoRuntimeType: 451744
@@ -5292,21 +5292,21 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 71 PointerType **runtime.bmap
+          Type: 87 PointerType **runtime.bmap
         - Name: len
           Offset: 8
-          Type: 1 BaseType int
+          Type: 9 BaseType int
         - Name: cap
           Offset: 16
-          Type: 1 BaseType int
+          Type: 9 BaseType int
       Data: 192 GoSliceDataType []*runtime.bmap.array
     - __kind: GoSliceDataType
       ID: 192
       Name: '[]*runtime.bmap.array'
       ByteSize: 2048
-      Element: 72 PointerType *runtime.bmap
+      Element: 88 PointerType *runtime.bmap
     - __kind: GoSliceHeaderType
-      ID: 34
+      ID: 53
       Name: '[]*string'
       ByteSize: 24
       GoRuntimeType: 443360
@@ -5314,42 +5314,42 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 35 PointerType **string
+          Type: 54 PointerType **string
         - Name: len
           Offset: 8
-          Type: 1 BaseType int
+          Type: 9 BaseType int
         - Name: cap
           Offset: 16
-          Type: 1 BaseType int
+          Type: 9 BaseType int
       Data: 189 GoSliceDataType []*string.array
     - __kind: GoSliceDataType
       ID: 189
       Name: '[]*string.array'
       ByteSize: 2048
-      Element: 36 PointerType *string
+      Element: 22 PointerType *string
     - __kind: GoSliceHeaderType
-      ID: 160
+      ID: 174
       Name: '[][]uint'
       ByteSize: 24
       GoKind: 23
       RawFields:
         - Name: array
           Offset: 0
-          Type: 161 PointerType *[]uint
+          Type: 175 PointerType *[]uint
         - Name: len
           Offset: 8
-          Type: 1 BaseType int
+          Type: 9 BaseType int
         - Name: cap
           Offset: 16
-          Type: 1 BaseType int
+          Type: 9 BaseType int
       Data: 213 GoSliceDataType [][]uint.array
     - __kind: GoSliceDataType
       ID: 213
       Name: '[][]uint.array'
       ByteSize: 2048
-      Element: 159 GoSliceHeaderType []uint
+      Element: 173 GoSliceHeaderType []uint
     - __kind: GoSliceHeaderType
-      ID: 165
+      ID: 179
       Name: '[]bool'
       ByteSize: 24
       GoRuntimeType: 449888
@@ -5357,123 +5357,123 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 155 PointerType *bool
+          Type: 5 PointerType *bool
         - Name: len
           Offset: 8
-          Type: 1 BaseType int
+          Type: 9 BaseType int
         - Name: cap
           Offset: 16
-          Type: 1 BaseType int
+          Type: 9 BaseType int
       Data: 217 GoSliceDataType []bool.array
     - __kind: GoSliceDataType
       ID: 217
       Name: '[]bool.array'
       ByteSize: 2048
-      Element: 11 BaseType bool
+      Element: 4 BaseType bool
     - __kind: GoSliceDataType
       ID: 208
       Name: '[]bucket<[4]int,[4]int>.array'
       ByteSize: 2048
-      Element: 150 GoHMapBucketType bucket<[4]int,[4]int>
+      Element: 166 GoHMapBucketType bucket<[4]int,[4]int>
     - __kind: GoSliceDataType
       ID: 207
       Name: '[]bucket<[4]int,uint8>.array'
       ByteSize: 2048
-      Element: 144 GoHMapBucketType bucket<[4]int,uint8>
+      Element: 160 GoHMapBucketType bucket<[4]int,uint8>
     - __kind: GoSliceDataType
       ID: 199
       Name: '[]bucket<[4]string,[2]int>.array'
       ByteSize: 2048
-      Element: 98 GoHMapBucketType bucket<[4]string,[2]int>
+      Element: 114 GoHMapBucketType bucket<[4]string,[2]int>
     - __kind: GoSliceDataType
       ID: 203
       Name: '[]bucket<bool,main.node>.array'
       ByteSize: 2048
-      Element: 116 GoHMapBucketType bucket<bool,main.node>
+      Element: 132 GoHMapBucketType bucket<bool,main.node>
     - __kind: GoSliceDataType
       ID: 191
       Name: '[]bucket<int,int>.array'
       ByteSize: 2048
-      Element: 62 GoHMapBucketType bucket<int,int>
+      Element: 79 GoHMapBucketType bucket<int,int>
     - __kind: GoSliceDataType
       ID: 204
       Name: '[]bucket<int,uint8>.array'
       ByteSize: 2048
-      Element: 125 GoHMapBucketType bucket<int,uint8>
+      Element: 141 GoHMapBucketType bucket<int,uint8>
     - __kind: GoSliceDataType
       ID: 200
       Name: '[]bucket<string,[]main.structWithMap>.array'
       ByteSize: 2048
-      Element: 108 GoHMapBucketType bucket<string,[]main.structWithMap>
+      Element: 124 GoHMapBucketType bucket<string,[]main.structWithMap>
     - __kind: GoSliceDataType
       ID: 196
       Name: '[]bucket<string,[]string>.array'
       ByteSize: 2048
-      Element: 91 GoHMapBucketType bucket<string,[]string>
+      Element: 107 GoHMapBucketType bucket<string,[]string>
     - __kind: GoSliceDataType
       ID: 195
       Name: '[]bucket<string,int>.array'
       ByteSize: 2048
-      Element: 86 GoHMapBucketType bucket<string,int>
+      Element: 102 GoHMapBucketType bucket<string,int>
     - __kind: GoSliceDataType
       ID: 194
       Name: '[]bucket<string,main.nestedStruct>.array'
       ByteSize: 2048
-      Element: 78 GoHMapBucketType bucket<string,main.nestedStruct>
+      Element: 94 GoHMapBucketType bucket<string,main.nestedStruct>
     - __kind: GoSliceDataType
       ID: 206
       Name: '[]bucket<uint8,[4]int>.array'
       ByteSize: 2048
-      Element: 137 GoHMapBucketType bucket<uint8,[4]int>
+      Element: 153 GoHMapBucketType bucket<uint8,[4]int>
     - __kind: GoSliceDataType
       ID: 205
       Name: '[]bucket<uint8,uint8>.array'
       ByteSize: 2048
-      Element: 131 GoHMapBucketType bucket<uint8,uint8>
+      Element: 147 GoHMapBucketType bucket<uint8,uint8>
     - __kind: ArrayType
-      ID: 145
+      ID: 161
       Name: '[]key<[4]int>'
       ByteSize: 256
       Count: 8
       HasCount: true
-      Element: 139 ArrayType [4]int
+      Element: 155 ArrayType [4]int
     - __kind: ArrayType
-      ID: 99
+      ID: 115
       Name: '[]key<[4]string>'
       ByteSize: 512
       Count: 8
       HasCount: true
-      Element: 100 ArrayType [4]string
+      Element: 116 ArrayType [4]string
     - __kind: ArrayType
-      ID: 117
+      ID: 133
       Name: '[]key<bool>'
       ByteSize: 8
       Count: 8
       HasCount: true
-      Element: 11 BaseType bool
+      Element: 4 BaseType bool
     - __kind: ArrayType
-      ID: 64
+      ID: 81
       Name: '[]key<int>'
       ByteSize: 64
       Count: 8
       HasCount: true
-      Element: 1 BaseType int
+      Element: 9 BaseType int
     - __kind: ArrayType
-      ID: 79
+      ID: 95
       Name: '[]key<string>'
       ByteSize: 128
       Count: 8
       HasCount: true
-      Element: 8 GoStringHeaderType string
+      Element: 11 GoStringHeaderType string
     - __kind: ArrayType
-      ID: 132
+      ID: 148
       Name: '[]key<uint8>'
       ByteSize: 8
       Count: 8
       HasCount: true
-      Element: 4 BaseType uint8
+      Element: 3 BaseType uint8
     - __kind: GoSliceHeaderType
-      ID: 110
+      ID: 126
       Name: '[]main.structWithMap'
       ByteSize: 24
       GoRuntimeType: 442848
@@ -5481,42 +5481,42 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 111 PointerType *main.structWithMap
+          Type: 127 PointerType *main.structWithMap
         - Name: len
           Offset: 8
-          Type: 1 BaseType int
+          Type: 9 BaseType int
         - Name: cap
           Offset: 16
-          Type: 1 BaseType int
+          Type: 9 BaseType int
       Data: 201 GoSliceDataType []main.structWithMap.array
     - __kind: GoSliceDataType
       ID: 201
       Name: '[]main.structWithMap.array'
       ByteSize: 2048
-      Element: 57 StructureType main.structWithMap
+      Element: 74 StructureType main.structWithMap
     - __kind: GoSliceHeaderType
-      ID: 162
+      ID: 176
       Name: '[]main.structWithNoStrings'
       ByteSize: 24
       GoKind: 23
       RawFields:
         - Name: array
           Offset: 0
-          Type: 163 PointerType *main.structWithNoStrings
+          Type: 177 PointerType *main.structWithNoStrings
         - Name: len
           Offset: 8
-          Type: 1 BaseType int
+          Type: 9 BaseType int
         - Name: cap
           Offset: 16
-          Type: 1 BaseType int
+          Type: 9 BaseType int
       Data: 215 GoSliceDataType []main.structWithNoStrings.array
     - __kind: GoSliceDataType
       ID: 215
       Name: '[]main.structWithNoStrings.array'
       ByteSize: 2048
-      Element: 164 StructureType main.structWithNoStrings
+      Element: 178 StructureType main.structWithNoStrings
     - __kind: GoSliceHeaderType
-      ID: 93
+      ID: 109
       Name: '[]string'
       ByteSize: 24
       GoRuntimeType: 450016
@@ -5524,21 +5524,21 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 36 PointerType *string
+          Type: 22 PointerType *string
         - Name: len
           Offset: 8
-          Type: 1 BaseType int
+          Type: 9 BaseType int
         - Name: cap
           Offset: 16
-          Type: 1 BaseType int
+          Type: 9 BaseType int
       Data: 197 GoSliceDataType []string.array
     - __kind: GoSliceDataType
       ID: 197
       Name: '[]string.array'
       ByteSize: 2048
-      Element: 8 GoStringHeaderType string
+      Element: 11 GoStringHeaderType string
     - __kind: GoSliceHeaderType
-      ID: 159
+      ID: 173
       Name: '[]uint'
       ByteSize: 24
       GoRuntimeType: 449504
@@ -5546,21 +5546,21 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 154 PointerType *uint
+          Type: 34 PointerType *uint
         - Name: len
           Offset: 8
-          Type: 1 BaseType int
+          Type: 9 BaseType int
         - Name: cap
           Offset: 16
-          Type: 1 BaseType int
+          Type: 9 BaseType int
       Data: 211 GoSliceDataType []uint.array
     - __kind: GoSliceDataType
       ID: 211
       Name: '[]uint.array'
       ByteSize: 2048
-      Element: 20 BaseType uint
+      Element: 12 BaseType uint
     - __kind: GoSliceHeaderType
-      ID: 166
+      ID: 180
       Name: '[]uint16'
       ByteSize: 24
       GoRuntimeType: 448864
@@ -5568,333 +5568,333 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 167 PointerType *uint16
+          Type: 30 PointerType *uint16
         - Name: len
           Offset: 8
-          Type: 1 BaseType int
+          Type: 9 BaseType int
         - Name: cap
           Offset: 16
-          Type: 1 BaseType int
+          Type: 9 BaseType int
       Data: 219 GoSliceDataType []uint16.array
     - __kind: GoSliceDataType
       ID: 219
       Name: '[]uint16.array'
       ByteSize: 2048
-      Element: 22 BaseType uint16
+      Element: 7 BaseType uint16
     - __kind: ArrayType
-      ID: 101
+      ID: 117
       Name: '[]val<[2]int>'
       ByteSize: 128
       Count: 8
       HasCount: true
-      Element: 12 ArrayType [2]int
+      Element: 40 ArrayType [2]int
     - __kind: ArrayType
-      ID: 138
+      ID: 154
       Name: '[]val<[4]int>'
       ByteSize: 256
       Count: 8
       HasCount: true
-      Element: 139 ArrayType [4]int
+      Element: 155 ArrayType [4]int
     - __kind: ArrayType
-      ID: 109
+      ID: 125
       Name: '[]val<[]main.structWithMap>'
       ByteSize: 192
       Count: 8
       HasCount: true
-      Element: 110 GoSliceHeaderType []main.structWithMap
+      Element: 126 GoSliceHeaderType []main.structWithMap
     - __kind: ArrayType
-      ID: 92
+      ID: 108
       Name: '[]val<[]string>'
       ByteSize: 192
       Count: 8
       HasCount: true
-      Element: 93 GoSliceHeaderType []string
+      Element: 109 GoSliceHeaderType []string
     - __kind: ArrayType
-      ID: 65
+      ID: 82
       Name: '[]val<int>'
       ByteSize: 64
       Count: 8
       HasCount: true
-      Element: 1 BaseType int
+      Element: 9 BaseType int
     - __kind: ArrayType
-      ID: 80
+      ID: 96
       Name: '[]val<main.nestedStruct>'
       ByteSize: 192
       Count: 8
       HasCount: true
-      Element: 81 StructureType main.nestedStruct
+      Element: 97 StructureType main.nestedStruct
     - __kind: ArrayType
-      ID: 118
+      ID: 134
       Name: '[]val<main.node>'
       ByteSize: 128
       Count: 8
       HasCount: true
-      Element: 119 StructureType main.node
+      Element: 135 StructureType main.node
     - __kind: ArrayType
-      ID: 126
+      ID: 142
       Name: '[]val<uint8>'
       ByteSize: 8
       Count: 8
       HasCount: true
-      Element: 4 BaseType uint8
+      Element: 3 BaseType uint8
     - __kind: BaseType
-      ID: 11
+      ID: 4
       Name: bool
       ByteSize: 1
       GoRuntimeType: 528064
       GoKind: 1
     - __kind: GoHMapBucketType
-      ID: 150
+      ID: 166
       Name: bucket<[4]int,[4]int>
       ByteSize: 528
       RawFields:
         - Name: tophash
           Offset: 0
-          Type: 63 ArrayType [8]uint8
+          Type: 80 ArrayType [8]uint8
         - Name: keys
           Offset: 8
-          Type: 145 ArrayType []key<[4]int>
+          Type: 161 ArrayType []key<[4]int>
         - Name: values
           Offset: 264
-          Type: 138 ArrayType []val<[4]int>
+          Type: 154 ArrayType []val<[4]int>
         - Name: overflow
           Offset: 520
-          Type: 149 PointerType *bucket<[4]int,[4]int>
-      KeyType: 139 ArrayType [4]int
-      ValueType: 139 ArrayType [4]int
+          Type: 165 PointerType *bucket<[4]int,[4]int>
+      KeyType: 155 ArrayType [4]int
+      ValueType: 155 ArrayType [4]int
     - __kind: GoHMapBucketType
-      ID: 144
+      ID: 160
       Name: bucket<[4]int,uint8>
       ByteSize: 280
       RawFields:
         - Name: tophash
           Offset: 0
-          Type: 63 ArrayType [8]uint8
+          Type: 80 ArrayType [8]uint8
         - Name: keys
           Offset: 8
-          Type: 145 ArrayType []key<[4]int>
+          Type: 161 ArrayType []key<[4]int>
         - Name: values
           Offset: 264
-          Type: 126 ArrayType []val<uint8>
+          Type: 142 ArrayType []val<uint8>
         - Name: overflow
           Offset: 272
-          Type: 143 PointerType *bucket<[4]int,uint8>
-      KeyType: 139 ArrayType [4]int
-      ValueType: 4 BaseType uint8
+          Type: 159 PointerType *bucket<[4]int,uint8>
+      KeyType: 155 ArrayType [4]int
+      ValueType: 3 BaseType uint8
     - __kind: GoHMapBucketType
-      ID: 98
+      ID: 114
       Name: bucket<[4]string,[2]int>
       ByteSize: 656
       RawFields:
         - Name: tophash
           Offset: 0
-          Type: 63 ArrayType [8]uint8
+          Type: 80 ArrayType [8]uint8
         - Name: keys
           Offset: 8
-          Type: 99 ArrayType []key<[4]string>
+          Type: 115 ArrayType []key<[4]string>
         - Name: values
           Offset: 520
-          Type: 101 ArrayType []val<[2]int>
+          Type: 117 ArrayType []val<[2]int>
         - Name: overflow
           Offset: 648
-          Type: 97 PointerType *bucket<[4]string,[2]int>
-      KeyType: 100 ArrayType [4]string
-      ValueType: 12 ArrayType [2]int
+          Type: 113 PointerType *bucket<[4]string,[2]int>
+      KeyType: 116 ArrayType [4]string
+      ValueType: 40 ArrayType [2]int
     - __kind: GoHMapBucketType
-      ID: 116
+      ID: 132
       Name: bucket<bool,main.node>
       ByteSize: 152
       RawFields:
         - Name: tophash
           Offset: 0
-          Type: 63 ArrayType [8]uint8
+          Type: 80 ArrayType [8]uint8
         - Name: keys
           Offset: 8
-          Type: 117 ArrayType []key<bool>
+          Type: 133 ArrayType []key<bool>
         - Name: values
           Offset: 16
-          Type: 118 ArrayType []val<main.node>
+          Type: 134 ArrayType []val<main.node>
         - Name: overflow
           Offset: 144
-          Type: 115 PointerType *bucket<bool,main.node>
-      KeyType: 11 BaseType bool
-      ValueType: 119 StructureType main.node
+          Type: 131 PointerType *bucket<bool,main.node>
+      KeyType: 4 BaseType bool
+      ValueType: 135 StructureType main.node
     - __kind: GoHMapBucketType
-      ID: 62
+      ID: 79
       Name: bucket<int,int>
       ByteSize: 144
       RawFields:
         - Name: tophash
           Offset: 0
-          Type: 63 ArrayType [8]uint8
+          Type: 80 ArrayType [8]uint8
         - Name: keys
           Offset: 8
-          Type: 64 ArrayType []key<int>
+          Type: 81 ArrayType []key<int>
         - Name: values
           Offset: 72
-          Type: 65 ArrayType []val<int>
+          Type: 82 ArrayType []val<int>
         - Name: overflow
           Offset: 136
-          Type: 61 PointerType *bucket<int,int>
-      KeyType: 1 BaseType int
-      ValueType: 1 BaseType int
+          Type: 78 PointerType *bucket<int,int>
+      KeyType: 9 BaseType int
+      ValueType: 9 BaseType int
     - __kind: GoHMapBucketType
-      ID: 125
+      ID: 141
       Name: bucket<int,uint8>
       ByteSize: 88
       RawFields:
         - Name: tophash
           Offset: 0
-          Type: 63 ArrayType [8]uint8
+          Type: 80 ArrayType [8]uint8
         - Name: keys
           Offset: 8
-          Type: 64 ArrayType []key<int>
+          Type: 81 ArrayType []key<int>
         - Name: values
           Offset: 72
-          Type: 126 ArrayType []val<uint8>
+          Type: 142 ArrayType []val<uint8>
         - Name: overflow
           Offset: 80
-          Type: 124 PointerType *bucket<int,uint8>
-      KeyType: 1 BaseType int
-      ValueType: 4 BaseType uint8
+          Type: 140 PointerType *bucket<int,uint8>
+      KeyType: 9 BaseType int
+      ValueType: 3 BaseType uint8
     - __kind: GoHMapBucketType
-      ID: 108
+      ID: 124
       Name: bucket<string,[]main.structWithMap>
       ByteSize: 336
       RawFields:
         - Name: tophash
           Offset: 0
-          Type: 63 ArrayType [8]uint8
+          Type: 80 ArrayType [8]uint8
         - Name: keys
           Offset: 8
-          Type: 79 ArrayType []key<string>
+          Type: 95 ArrayType []key<string>
         - Name: values
           Offset: 136
-          Type: 109 ArrayType []val<[]main.structWithMap>
+          Type: 125 ArrayType []val<[]main.structWithMap>
         - Name: overflow
           Offset: 328
-          Type: 107 PointerType *bucket<string,[]main.structWithMap>
-      KeyType: 8 GoStringHeaderType string
-      ValueType: 110 GoSliceHeaderType []main.structWithMap
+          Type: 123 PointerType *bucket<string,[]main.structWithMap>
+      KeyType: 11 GoStringHeaderType string
+      ValueType: 126 GoSliceHeaderType []main.structWithMap
     - __kind: GoHMapBucketType
-      ID: 91
+      ID: 107
       Name: bucket<string,[]string>
       ByteSize: 336
       RawFields:
         - Name: tophash
           Offset: 0
-          Type: 63 ArrayType [8]uint8
+          Type: 80 ArrayType [8]uint8
         - Name: keys
           Offset: 8
-          Type: 79 ArrayType []key<string>
+          Type: 95 ArrayType []key<string>
         - Name: values
           Offset: 136
-          Type: 92 ArrayType []val<[]string>
+          Type: 108 ArrayType []val<[]string>
         - Name: overflow
           Offset: 328
-          Type: 90 PointerType *bucket<string,[]string>
-      KeyType: 8 GoStringHeaderType string
-      ValueType: 93 GoSliceHeaderType []string
+          Type: 106 PointerType *bucket<string,[]string>
+      KeyType: 11 GoStringHeaderType string
+      ValueType: 109 GoSliceHeaderType []string
     - __kind: GoHMapBucketType
-      ID: 86
+      ID: 102
       Name: bucket<string,int>
       ByteSize: 208
       RawFields:
         - Name: tophash
           Offset: 0
-          Type: 63 ArrayType [8]uint8
+          Type: 80 ArrayType [8]uint8
         - Name: keys
           Offset: 8
-          Type: 79 ArrayType []key<string>
+          Type: 95 ArrayType []key<string>
         - Name: values
           Offset: 136
-          Type: 65 ArrayType []val<int>
+          Type: 82 ArrayType []val<int>
         - Name: overflow
           Offset: 200
-          Type: 85 PointerType *bucket<string,int>
-      KeyType: 8 GoStringHeaderType string
-      ValueType: 1 BaseType int
+          Type: 101 PointerType *bucket<string,int>
+      KeyType: 11 GoStringHeaderType string
+      ValueType: 9 BaseType int
     - __kind: GoHMapBucketType
-      ID: 78
+      ID: 94
       Name: bucket<string,main.nestedStruct>
       ByteSize: 336
       RawFields:
         - Name: tophash
           Offset: 0
-          Type: 63 ArrayType [8]uint8
+          Type: 80 ArrayType [8]uint8
         - Name: keys
           Offset: 8
-          Type: 79 ArrayType []key<string>
+          Type: 95 ArrayType []key<string>
         - Name: values
           Offset: 136
-          Type: 80 ArrayType []val<main.nestedStruct>
+          Type: 96 ArrayType []val<main.nestedStruct>
         - Name: overflow
           Offset: 328
-          Type: 77 PointerType *bucket<string,main.nestedStruct>
-      KeyType: 8 GoStringHeaderType string
-      ValueType: 81 StructureType main.nestedStruct
+          Type: 93 PointerType *bucket<string,main.nestedStruct>
+      KeyType: 11 GoStringHeaderType string
+      ValueType: 97 StructureType main.nestedStruct
     - __kind: GoHMapBucketType
-      ID: 137
+      ID: 153
       Name: bucket<uint8,[4]int>
       ByteSize: 280
       RawFields:
         - Name: tophash
           Offset: 0
-          Type: 63 ArrayType [8]uint8
+          Type: 80 ArrayType [8]uint8
         - Name: keys
           Offset: 8
-          Type: 132 ArrayType []key<uint8>
+          Type: 148 ArrayType []key<uint8>
         - Name: values
           Offset: 16
-          Type: 138 ArrayType []val<[4]int>
+          Type: 154 ArrayType []val<[4]int>
         - Name: overflow
           Offset: 272
-          Type: 136 PointerType *bucket<uint8,[4]int>
-      KeyType: 4 BaseType uint8
-      ValueType: 139 ArrayType [4]int
+          Type: 152 PointerType *bucket<uint8,[4]int>
+      KeyType: 3 BaseType uint8
+      ValueType: 155 ArrayType [4]int
     - __kind: GoHMapBucketType
-      ID: 131
+      ID: 147
       Name: bucket<uint8,uint8>
       ByteSize: 32
       RawFields:
         - Name: tophash
           Offset: 0
-          Type: 63 ArrayType [8]uint8
+          Type: 80 ArrayType [8]uint8
         - Name: keys
           Offset: 8
-          Type: 132 ArrayType []key<uint8>
+          Type: 148 ArrayType []key<uint8>
         - Name: values
           Offset: 16
-          Type: 126 ArrayType []val<uint8>
+          Type: 142 ArrayType []val<uint8>
         - Name: overflow
           Offset: 24
-          Type: 130 PointerType *bucket<uint8,uint8>
-      KeyType: 4 BaseType uint8
-      ValueType: 4 BaseType uint8
+          Type: 146 PointerType *bucket<uint8,uint8>
+      KeyType: 3 BaseType uint8
+      ValueType: 3 BaseType uint8
     - __kind: GoChannelType
-      ID: 151
+      ID: 167
       Name: chan bool
       GoRuntimeType: 539328
       GoKind: 18
     - __kind: GoChannelType
-      ID: 40
+      ID: 57
       Name: chan struct {}
       GoRuntimeType: 538240
       GoKind: 18
     - __kind: BaseType
-      ID: 178
+      ID: 25
       Name: complex128
       ByteSize: 16
       GoRuntimeType: 527872
       GoKind: 16
     - __kind: BaseType
-      ID: 177
+      ID: 24
       Name: complex64
       ByteSize: 8
       GoRuntimeType: 527808
       GoKind: 15
     - __kind: GoInterfaceType
-      ID: 56
+      ID: 18
       Name: error
       ByteSize: 16
       GoRuntimeType: 978048
@@ -5902,468 +5902,468 @@ Types:
       RawFields:
         - Name: tab
           Offset: 0
-          Type: 38 VoidPointerType unsafe.Pointer
+          Type: 19 VoidPointerType unsafe.Pointer
         - Name: data
           Offset: 8
-          Type: 38 VoidPointerType unsafe.Pointer
+          Type: 19 VoidPointerType unsafe.Pointer
     - __kind: BaseType
-      ID: 30
+      ID: 16
       Name: float32
       ByteSize: 4
       GoRuntimeType: 527936
       GoKind: 13
     - __kind: BaseType
-      ID: 31
+      ID: 17
       Name: float64
       ByteSize: 8
       GoRuntimeType: 528000
       GoKind: 14
     - __kind: GoSubroutineType
-      ID: 43
+      ID: 60
       Name: func()
       ByteSize: 8
       GoRuntimeType: 441952
       GoKind: 19
     - __kind: GoHMapHeaderType
-      ID: 148
+      ID: 164
       Name: hash<[4]int,[4]int>
       ByteSize: 48
       RawFields:
         - Name: count
           Offset: 0
-          Type: 1 BaseType int
+          Type: 9 BaseType int
         - Name: flags
           Offset: 8
-          Type: 4 BaseType uint8
+          Type: 3 BaseType uint8
         - Name: B
           Offset: 9
-          Type: 4 BaseType uint8
+          Type: 3 BaseType uint8
         - Name: noverflow
           Offset: 10
-          Type: 22 BaseType uint16
+          Type: 7 BaseType uint16
         - Name: hash0
           Offset: 12
-          Type: 24 BaseType uint32
+          Type: 2 BaseType uint32
         - Name: buckets
           Offset: 16
-          Type: 149 PointerType *bucket<[4]int,[4]int>
+          Type: 165 PointerType *bucket<[4]int,[4]int>
         - Name: oldbuckets
           Offset: 24
-          Type: 149 PointerType *bucket<[4]int,[4]int>
+          Type: 165 PointerType *bucket<[4]int,[4]int>
         - Name: nevacuate
           Offset: 32
-          Type: 66 BaseType uintptr
+          Type: 1 BaseType uintptr
         - Name: extra
           Offset: 40
-          Type: 67 PointerType *runtime.mapextra
-      BucketType: 150 GoHMapBucketType bucket<[4]int,[4]int>
+          Type: 83 PointerType *runtime.mapextra
+      BucketType: 166 GoHMapBucketType bucket<[4]int,[4]int>
       BucketsType: 208 GoSliceDataType []bucket<[4]int,[4]int>.array
     - __kind: GoHMapHeaderType
-      ID: 142
+      ID: 158
       Name: hash<[4]int,uint8>
       ByteSize: 48
       RawFields:
         - Name: count
           Offset: 0
-          Type: 1 BaseType int
+          Type: 9 BaseType int
         - Name: flags
           Offset: 8
-          Type: 4 BaseType uint8
+          Type: 3 BaseType uint8
         - Name: B
           Offset: 9
-          Type: 4 BaseType uint8
+          Type: 3 BaseType uint8
         - Name: noverflow
           Offset: 10
-          Type: 22 BaseType uint16
+          Type: 7 BaseType uint16
         - Name: hash0
           Offset: 12
-          Type: 24 BaseType uint32
+          Type: 2 BaseType uint32
         - Name: buckets
           Offset: 16
-          Type: 143 PointerType *bucket<[4]int,uint8>
+          Type: 159 PointerType *bucket<[4]int,uint8>
         - Name: oldbuckets
           Offset: 24
-          Type: 143 PointerType *bucket<[4]int,uint8>
+          Type: 159 PointerType *bucket<[4]int,uint8>
         - Name: nevacuate
           Offset: 32
-          Type: 66 BaseType uintptr
+          Type: 1 BaseType uintptr
         - Name: extra
           Offset: 40
-          Type: 67 PointerType *runtime.mapextra
-      BucketType: 144 GoHMapBucketType bucket<[4]int,uint8>
+          Type: 83 PointerType *runtime.mapextra
+      BucketType: 160 GoHMapBucketType bucket<[4]int,uint8>
       BucketsType: 207 GoSliceDataType []bucket<[4]int,uint8>.array
     - __kind: GoHMapHeaderType
-      ID: 96
+      ID: 112
       Name: hash<[4]string,[2]int>
       ByteSize: 48
       RawFields:
         - Name: count
           Offset: 0
-          Type: 1 BaseType int
+          Type: 9 BaseType int
         - Name: flags
           Offset: 8
-          Type: 4 BaseType uint8
+          Type: 3 BaseType uint8
         - Name: B
           Offset: 9
-          Type: 4 BaseType uint8
+          Type: 3 BaseType uint8
         - Name: noverflow
           Offset: 10
-          Type: 22 BaseType uint16
+          Type: 7 BaseType uint16
         - Name: hash0
           Offset: 12
-          Type: 24 BaseType uint32
+          Type: 2 BaseType uint32
         - Name: buckets
           Offset: 16
-          Type: 97 PointerType *bucket<[4]string,[2]int>
+          Type: 113 PointerType *bucket<[4]string,[2]int>
         - Name: oldbuckets
           Offset: 24
-          Type: 97 PointerType *bucket<[4]string,[2]int>
+          Type: 113 PointerType *bucket<[4]string,[2]int>
         - Name: nevacuate
           Offset: 32
-          Type: 66 BaseType uintptr
+          Type: 1 BaseType uintptr
         - Name: extra
           Offset: 40
-          Type: 67 PointerType *runtime.mapextra
-      BucketType: 98 GoHMapBucketType bucket<[4]string,[2]int>
+          Type: 83 PointerType *runtime.mapextra
+      BucketType: 114 GoHMapBucketType bucket<[4]string,[2]int>
       BucketsType: 199 GoSliceDataType []bucket<[4]string,[2]int>.array
     - __kind: GoHMapHeaderType
-      ID: 114
+      ID: 130
       Name: hash<bool,main.node>
       ByteSize: 48
       RawFields:
         - Name: count
           Offset: 0
-          Type: 1 BaseType int
+          Type: 9 BaseType int
         - Name: flags
           Offset: 8
-          Type: 4 BaseType uint8
+          Type: 3 BaseType uint8
         - Name: B
           Offset: 9
-          Type: 4 BaseType uint8
+          Type: 3 BaseType uint8
         - Name: noverflow
           Offset: 10
-          Type: 22 BaseType uint16
+          Type: 7 BaseType uint16
         - Name: hash0
           Offset: 12
-          Type: 24 BaseType uint32
+          Type: 2 BaseType uint32
         - Name: buckets
           Offset: 16
-          Type: 115 PointerType *bucket<bool,main.node>
+          Type: 131 PointerType *bucket<bool,main.node>
         - Name: oldbuckets
           Offset: 24
-          Type: 115 PointerType *bucket<bool,main.node>
+          Type: 131 PointerType *bucket<bool,main.node>
         - Name: nevacuate
           Offset: 32
-          Type: 66 BaseType uintptr
+          Type: 1 BaseType uintptr
         - Name: extra
           Offset: 40
-          Type: 67 PointerType *runtime.mapextra
-      BucketType: 116 GoHMapBucketType bucket<bool,main.node>
+          Type: 83 PointerType *runtime.mapextra
+      BucketType: 132 GoHMapBucketType bucket<bool,main.node>
       BucketsType: 203 GoSliceDataType []bucket<bool,main.node>.array
     - __kind: GoHMapHeaderType
-      ID: 60
+      ID: 77
       Name: hash<int,int>
       ByteSize: 48
       RawFields:
         - Name: count
           Offset: 0
-          Type: 1 BaseType int
+          Type: 9 BaseType int
         - Name: flags
           Offset: 8
-          Type: 4 BaseType uint8
+          Type: 3 BaseType uint8
         - Name: B
           Offset: 9
-          Type: 4 BaseType uint8
+          Type: 3 BaseType uint8
         - Name: noverflow
           Offset: 10
-          Type: 22 BaseType uint16
+          Type: 7 BaseType uint16
         - Name: hash0
           Offset: 12
-          Type: 24 BaseType uint32
+          Type: 2 BaseType uint32
         - Name: buckets
           Offset: 16
-          Type: 61 PointerType *bucket<int,int>
+          Type: 78 PointerType *bucket<int,int>
         - Name: oldbuckets
           Offset: 24
-          Type: 61 PointerType *bucket<int,int>
+          Type: 78 PointerType *bucket<int,int>
         - Name: nevacuate
           Offset: 32
-          Type: 66 BaseType uintptr
+          Type: 1 BaseType uintptr
         - Name: extra
           Offset: 40
-          Type: 67 PointerType *runtime.mapextra
-      BucketType: 62 GoHMapBucketType bucket<int,int>
+          Type: 83 PointerType *runtime.mapextra
+      BucketType: 79 GoHMapBucketType bucket<int,int>
       BucketsType: 191 GoSliceDataType []bucket<int,int>.array
     - __kind: GoHMapHeaderType
-      ID: 123
+      ID: 139
       Name: hash<int,uint8>
       ByteSize: 48
       RawFields:
         - Name: count
           Offset: 0
-          Type: 1 BaseType int
+          Type: 9 BaseType int
         - Name: flags
           Offset: 8
-          Type: 4 BaseType uint8
+          Type: 3 BaseType uint8
         - Name: B
           Offset: 9
-          Type: 4 BaseType uint8
+          Type: 3 BaseType uint8
         - Name: noverflow
           Offset: 10
-          Type: 22 BaseType uint16
+          Type: 7 BaseType uint16
         - Name: hash0
           Offset: 12
-          Type: 24 BaseType uint32
+          Type: 2 BaseType uint32
         - Name: buckets
           Offset: 16
-          Type: 124 PointerType *bucket<int,uint8>
+          Type: 140 PointerType *bucket<int,uint8>
         - Name: oldbuckets
           Offset: 24
-          Type: 124 PointerType *bucket<int,uint8>
+          Type: 140 PointerType *bucket<int,uint8>
         - Name: nevacuate
           Offset: 32
-          Type: 66 BaseType uintptr
+          Type: 1 BaseType uintptr
         - Name: extra
           Offset: 40
-          Type: 67 PointerType *runtime.mapextra
-      BucketType: 125 GoHMapBucketType bucket<int,uint8>
+          Type: 83 PointerType *runtime.mapextra
+      BucketType: 141 GoHMapBucketType bucket<int,uint8>
       BucketsType: 204 GoSliceDataType []bucket<int,uint8>.array
     - __kind: GoHMapHeaderType
-      ID: 106
+      ID: 122
       Name: hash<string,[]main.structWithMap>
       ByteSize: 48
       RawFields:
         - Name: count
           Offset: 0
-          Type: 1 BaseType int
+          Type: 9 BaseType int
         - Name: flags
           Offset: 8
-          Type: 4 BaseType uint8
+          Type: 3 BaseType uint8
         - Name: B
           Offset: 9
-          Type: 4 BaseType uint8
+          Type: 3 BaseType uint8
         - Name: noverflow
           Offset: 10
-          Type: 22 BaseType uint16
+          Type: 7 BaseType uint16
         - Name: hash0
           Offset: 12
-          Type: 24 BaseType uint32
+          Type: 2 BaseType uint32
         - Name: buckets
           Offset: 16
-          Type: 107 PointerType *bucket<string,[]main.structWithMap>
+          Type: 123 PointerType *bucket<string,[]main.structWithMap>
         - Name: oldbuckets
           Offset: 24
-          Type: 107 PointerType *bucket<string,[]main.structWithMap>
+          Type: 123 PointerType *bucket<string,[]main.structWithMap>
         - Name: nevacuate
           Offset: 32
-          Type: 66 BaseType uintptr
+          Type: 1 BaseType uintptr
         - Name: extra
           Offset: 40
-          Type: 67 PointerType *runtime.mapextra
-      BucketType: 108 GoHMapBucketType bucket<string,[]main.structWithMap>
+          Type: 83 PointerType *runtime.mapextra
+      BucketType: 124 GoHMapBucketType bucket<string,[]main.structWithMap>
       BucketsType: 200 GoSliceDataType []bucket<string,[]main.structWithMap>.array
     - __kind: GoHMapHeaderType
-      ID: 89
+      ID: 105
       Name: hash<string,[]string>
       ByteSize: 48
       RawFields:
         - Name: count
           Offset: 0
-          Type: 1 BaseType int
+          Type: 9 BaseType int
         - Name: flags
           Offset: 8
-          Type: 4 BaseType uint8
+          Type: 3 BaseType uint8
         - Name: B
           Offset: 9
-          Type: 4 BaseType uint8
+          Type: 3 BaseType uint8
         - Name: noverflow
           Offset: 10
-          Type: 22 BaseType uint16
+          Type: 7 BaseType uint16
         - Name: hash0
           Offset: 12
-          Type: 24 BaseType uint32
+          Type: 2 BaseType uint32
         - Name: buckets
           Offset: 16
-          Type: 90 PointerType *bucket<string,[]string>
+          Type: 106 PointerType *bucket<string,[]string>
         - Name: oldbuckets
           Offset: 24
-          Type: 90 PointerType *bucket<string,[]string>
+          Type: 106 PointerType *bucket<string,[]string>
         - Name: nevacuate
           Offset: 32
-          Type: 66 BaseType uintptr
+          Type: 1 BaseType uintptr
         - Name: extra
           Offset: 40
-          Type: 67 PointerType *runtime.mapextra
-      BucketType: 91 GoHMapBucketType bucket<string,[]string>
+          Type: 83 PointerType *runtime.mapextra
+      BucketType: 107 GoHMapBucketType bucket<string,[]string>
       BucketsType: 196 GoSliceDataType []bucket<string,[]string>.array
     - __kind: GoHMapHeaderType
-      ID: 84
+      ID: 100
       Name: hash<string,int>
       ByteSize: 48
       RawFields:
         - Name: count
           Offset: 0
-          Type: 1 BaseType int
+          Type: 9 BaseType int
         - Name: flags
           Offset: 8
-          Type: 4 BaseType uint8
+          Type: 3 BaseType uint8
         - Name: B
           Offset: 9
-          Type: 4 BaseType uint8
+          Type: 3 BaseType uint8
         - Name: noverflow
           Offset: 10
-          Type: 22 BaseType uint16
+          Type: 7 BaseType uint16
         - Name: hash0
           Offset: 12
-          Type: 24 BaseType uint32
+          Type: 2 BaseType uint32
         - Name: buckets
           Offset: 16
-          Type: 85 PointerType *bucket<string,int>
+          Type: 101 PointerType *bucket<string,int>
         - Name: oldbuckets
           Offset: 24
-          Type: 85 PointerType *bucket<string,int>
+          Type: 101 PointerType *bucket<string,int>
         - Name: nevacuate
           Offset: 32
-          Type: 66 BaseType uintptr
+          Type: 1 BaseType uintptr
         - Name: extra
           Offset: 40
-          Type: 67 PointerType *runtime.mapextra
-      BucketType: 86 GoHMapBucketType bucket<string,int>
+          Type: 83 PointerType *runtime.mapextra
+      BucketType: 102 GoHMapBucketType bucket<string,int>
       BucketsType: 195 GoSliceDataType []bucket<string,int>.array
     - __kind: GoHMapHeaderType
-      ID: 76
+      ID: 92
       Name: hash<string,main.nestedStruct>
       ByteSize: 48
       RawFields:
         - Name: count
           Offset: 0
-          Type: 1 BaseType int
+          Type: 9 BaseType int
         - Name: flags
           Offset: 8
-          Type: 4 BaseType uint8
+          Type: 3 BaseType uint8
         - Name: B
           Offset: 9
-          Type: 4 BaseType uint8
+          Type: 3 BaseType uint8
         - Name: noverflow
           Offset: 10
-          Type: 22 BaseType uint16
+          Type: 7 BaseType uint16
         - Name: hash0
           Offset: 12
-          Type: 24 BaseType uint32
+          Type: 2 BaseType uint32
         - Name: buckets
           Offset: 16
-          Type: 77 PointerType *bucket<string,main.nestedStruct>
+          Type: 93 PointerType *bucket<string,main.nestedStruct>
         - Name: oldbuckets
           Offset: 24
-          Type: 77 PointerType *bucket<string,main.nestedStruct>
+          Type: 93 PointerType *bucket<string,main.nestedStruct>
         - Name: nevacuate
           Offset: 32
-          Type: 66 BaseType uintptr
+          Type: 1 BaseType uintptr
         - Name: extra
           Offset: 40
-          Type: 67 PointerType *runtime.mapextra
-      BucketType: 78 GoHMapBucketType bucket<string,main.nestedStruct>
+          Type: 83 PointerType *runtime.mapextra
+      BucketType: 94 GoHMapBucketType bucket<string,main.nestedStruct>
       BucketsType: 194 GoSliceDataType []bucket<string,main.nestedStruct>.array
     - __kind: GoHMapHeaderType
-      ID: 135
+      ID: 151
       Name: hash<uint8,[4]int>
       ByteSize: 48
       RawFields:
         - Name: count
           Offset: 0
-          Type: 1 BaseType int
+          Type: 9 BaseType int
         - Name: flags
           Offset: 8
-          Type: 4 BaseType uint8
+          Type: 3 BaseType uint8
         - Name: B
           Offset: 9
-          Type: 4 BaseType uint8
+          Type: 3 BaseType uint8
         - Name: noverflow
           Offset: 10
-          Type: 22 BaseType uint16
+          Type: 7 BaseType uint16
         - Name: hash0
           Offset: 12
-          Type: 24 BaseType uint32
+          Type: 2 BaseType uint32
         - Name: buckets
           Offset: 16
-          Type: 136 PointerType *bucket<uint8,[4]int>
+          Type: 152 PointerType *bucket<uint8,[4]int>
         - Name: oldbuckets
           Offset: 24
-          Type: 136 PointerType *bucket<uint8,[4]int>
+          Type: 152 PointerType *bucket<uint8,[4]int>
         - Name: nevacuate
           Offset: 32
-          Type: 66 BaseType uintptr
+          Type: 1 BaseType uintptr
         - Name: extra
           Offset: 40
-          Type: 67 PointerType *runtime.mapextra
-      BucketType: 137 GoHMapBucketType bucket<uint8,[4]int>
+          Type: 83 PointerType *runtime.mapextra
+      BucketType: 153 GoHMapBucketType bucket<uint8,[4]int>
       BucketsType: 206 GoSliceDataType []bucket<uint8,[4]int>.array
     - __kind: GoHMapHeaderType
-      ID: 129
+      ID: 145
       Name: hash<uint8,uint8>
       ByteSize: 48
       RawFields:
         - Name: count
           Offset: 0
-          Type: 1 BaseType int
+          Type: 9 BaseType int
         - Name: flags
           Offset: 8
-          Type: 4 BaseType uint8
+          Type: 3 BaseType uint8
         - Name: B
           Offset: 9
-          Type: 4 BaseType uint8
+          Type: 3 BaseType uint8
         - Name: noverflow
           Offset: 10
-          Type: 22 BaseType uint16
+          Type: 7 BaseType uint16
         - Name: hash0
           Offset: 12
-          Type: 24 BaseType uint32
+          Type: 2 BaseType uint32
         - Name: buckets
           Offset: 16
-          Type: 130 PointerType *bucket<uint8,uint8>
+          Type: 146 PointerType *bucket<uint8,uint8>
         - Name: oldbuckets
           Offset: 24
-          Type: 130 PointerType *bucket<uint8,uint8>
+          Type: 146 PointerType *bucket<uint8,uint8>
         - Name: nevacuate
           Offset: 32
-          Type: 66 BaseType uintptr
+          Type: 1 BaseType uintptr
         - Name: extra
           Offset: 40
-          Type: 67 PointerType *runtime.mapextra
-      BucketType: 131 GoHMapBucketType bucket<uint8,uint8>
+          Type: 83 PointerType *runtime.mapextra
+      BucketType: 147 GoHMapBucketType bucket<uint8,uint8>
       BucketsType: 205 GoSliceDataType []bucket<uint8,uint8>.array
     - __kind: BaseType
-      ID: 1
+      ID: 9
       Name: int
       ByteSize: 8
       GoRuntimeType: 527616
       GoKind: 2
     - __kind: BaseType
-      ID: 16
+      ID: 23
       Name: int16
       ByteSize: 2
       GoRuntimeType: 527232
       GoKind: 4
     - __kind: BaseType
-      ID: 6
+      ID: 13
       Name: int32
       ByteSize: 4
       GoRuntimeType: 527360
       GoKind: 5
     - __kind: BaseType
-      ID: 18
+      ID: 14
       Name: int64
       ByteSize: 8
       GoRuntimeType: 527488
       GoKind: 6
     - __kind: BaseType
-      ID: 14
+      ID: 15
       Name: int8
       ByteSize: 1
       GoRuntimeType: 527104
       GoKind: 3
     - __kind: GoEmptyInterfaceType
-      ID: 41
+      ID: 58
       Name: interface {}
       ByteSize: 16
       GoRuntimeType: 772480
@@ -6371,12 +6371,12 @@ Types:
       RawFields:
         - Name: _type
           Offset: 0
-          Type: 38 VoidPointerType unsafe.Pointer
+          Type: 19 VoidPointerType unsafe.Pointer
         - Name: data
           Offset: 8
-          Type: 38 VoidPointerType unsafe.Pointer
+          Type: 19 VoidPointerType unsafe.Pointer
     - __kind: GoInterfaceType
-      ID: 37
+      ID: 55
       Name: io.Writer
       ByteSize: 16
       GoRuntimeType: 973952
@@ -6384,30 +6384,30 @@ Types:
       RawFields:
         - Name: tab
           Offset: 0
-          Type: 38 VoidPointerType unsafe.Pointer
+          Type: 19 VoidPointerType unsafe.Pointer
         - Name: data
           Offset: 8
-          Type: 38 VoidPointerType unsafe.Pointer
+          Type: 19 VoidPointerType unsafe.Pointer
     - __kind: StructureType
-      ID: 172
+      ID: 185
       Name: main.aStruct
       ByteSize: 56
       GoKind: 25
       RawFields:
         - Name: aBool
           Offset: 0
-          Type: 11 BaseType bool
+          Type: 4 BaseType bool
         - Name: aString
           Offset: 8
-          Type: 8 GoStringHeaderType string
+          Type: 11 GoStringHeaderType string
         - Name: aNumber
           Offset: 24
-          Type: 1 BaseType int
+          Type: 9 BaseType int
         - Name: nested
           Offset: 32
-          Type: 81 StructureType main.nestedStruct
+          Type: 97 StructureType main.nestedStruct
     - __kind: GoInterfaceType
-      ID: 55
+      ID: 73
       Name: main.behavior
       ByteSize: 16
       GoRuntimeType: 973568
@@ -6415,32 +6415,32 @@ Types:
       RawFields:
         - Name: tab
           Offset: 0
-          Type: 38 VoidPointerType unsafe.Pointer
+          Type: 19 VoidPointerType unsafe.Pointer
         - Name: data
           Offset: 8
-          Type: 38 VoidPointerType unsafe.Pointer
+          Type: 19 VoidPointerType unsafe.Pointer
     - __kind: StructureType
-      ID: 33
+      ID: 52
       Name: main.bigStruct
       ByteSize: 48
       GoKind: 25
       RawFields:
         - Name: x
           Offset: 0
-          Type: 34 GoSliceHeaderType []*string
+          Type: 53 GoSliceHeaderType []*string
         - Name: z
           Offset: 24
-          Type: 1 BaseType int
+          Type: 9 BaseType int
         - Name: writer
           Offset: 32
-          Type: 37 GoInterfaceType io.Writer
+          Type: 55 GoInterfaceType io.Writer
     - __kind: StructureType
-      ID: 173
+      ID: 186
       Name: main.emptyStruct
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 45
+      ID: 62
       Name: main.esotericHeap
       ByteSize: 112
       GoRuntimeType: 1.69296e+06
@@ -6448,21 +6448,21 @@ Types:
       RawFields:
         - Name: esotericStack
           Offset: 0
-          Type: 39 StructureType main.esotericStack
+          Type: 56 StructureType main.esotericStack
         - Name: mu
           Offset: 64
-          Type: 46 StructureType sync.Mutex
+          Type: 63 StructureType sync.Mutex
         - Name: once
           Offset: 72
-          Type: 47 StructureType sync.Once
+          Type: 64 StructureType sync.Once
         - Name: wg
           Offset: 88
-          Type: 50 StructureType sync.WaitGroup
+          Type: 67 StructureType sync.WaitGroup
         - Name: a
           Offset: 104
-          Type: 54 StructureType sync/atomic.Int32
+          Type: 71 StructureType sync/atomic.Int32
     - __kind: StructureType
-      ID: 39
+      ID: 56
       Name: main.esotericStack
       ByteSize: 64
       GoRuntimeType: 1.819424e+06
@@ -6470,27 +6470,27 @@ Types:
       RawFields:
         - Name: _
           Offset: 0
-          Type: 6 BaseType int32
+          Type: 13 BaseType int32
         - Name: _valid
           Offset: 4
-          Type: 6 BaseType int32
+          Type: 13 BaseType int32
         - Name: c
           Offset: 8
-          Type: 40 GoChannelType chan struct {}
+          Type: 57 GoChannelType chan struct {}
         - Name: val
           Offset: 16
-          Type: 41 GoEmptyInterfaceType interface {}
+          Type: 58 GoEmptyInterfaceType interface {}
         - Name: _
           Offset: 32
-          Type: 26 BaseType uint64
+          Type: 10 BaseType uint64
         - Name: work
           Offset: 40
-          Type: 42 GoInterfaceType main.something
+          Type: 59 GoInterfaceType main.something
         - Name: foo
           Offset: 56
-          Type: 43 GoSubroutineType func()
+          Type: 60 GoSubroutineType func()
     - __kind: StructureType
-      ID: 81
+      ID: 97
       Name: main.nestedStruct
       ByteSize: 24
       GoRuntimeType: 1.270208e+06
@@ -6498,12 +6498,12 @@ Types:
       RawFields:
         - Name: anotherInt
           Offset: 0
-          Type: 1 BaseType int
+          Type: 9 BaseType int
         - Name: anotherString
           Offset: 8
-          Type: 8 GoStringHeaderType string
+          Type: 11 GoStringHeaderType string
     - __kind: StructureType
-      ID: 119
+      ID: 135
       Name: main.node
       ByteSize: 16
       GoRuntimeType: 1.270048e+06
@@ -6511,21 +6511,21 @@ Types:
       RawFields:
         - Name: val
           Offset: 0
-          Type: 1 BaseType int
+          Type: 9 BaseType int
         - Name: b
           Offset: 8
-          Type: 120 PointerType *main.node
+          Type: 136 PointerType *main.node
     - __kind: StructureType
-      ID: 171
+      ID: 184
       Name: main.oneStringStruct
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: a
           Offset: 0
-          Type: 8 GoStringHeaderType string
+          Type: 11 GoStringHeaderType string
     - __kind: GoInterfaceType
-      ID: 42
+      ID: 59
       Name: main.something
       ByteSize: 16
       GoRuntimeType: 973696
@@ -6533,12 +6533,12 @@ Types:
       RawFields:
         - Name: tab
           Offset: 0
-          Type: 38 VoidPointerType unsafe.Pointer
+          Type: 19 VoidPointerType unsafe.Pointer
         - Name: data
           Offset: 8
-          Type: 38 VoidPointerType unsafe.Pointer
+          Type: 19 VoidPointerType unsafe.Pointer
     - __kind: StructureType
-      ID: 57
+      ID: 74
       Name: main.structWithMap
       ByteSize: 8
       GoRuntimeType: 1.09264e+06
@@ -6546,158 +6546,158 @@ Types:
       RawFields:
         - Name: m
           Offset: 0
-          Type: 58 GoMapType map[int]int
+          Type: 75 GoMapType map[int]int
     - __kind: StructureType
-      ID: 164
+      ID: 178
       Name: main.structWithNoStrings
       ByteSize: 2
       GoKind: 25
       RawFields:
         - Name: aUint8
           Offset: 0
-          Type: 4 BaseType uint8
+          Type: 3 BaseType uint8
         - Name: aBool
           Offset: 1
-          Type: 11 BaseType bool
+          Type: 4 BaseType bool
     - __kind: StructureType
-      ID: 153
+      ID: 169
       Name: main.structWithTwoValues
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: a
           Offset: 0
-          Type: 20 BaseType uint
+          Type: 12 BaseType uint
         - Name: b
           Offset: 8
-          Type: 11 BaseType bool
+          Type: 4 BaseType bool
     - __kind: GoSliceHeaderType
-      ID: 157
+      ID: 171
       Name: main.t
       ByteSize: 24
       GoKind: 23
       RawFields:
         - Name: array
           Offset: 0
-          Type: 158 PointerType **main.t
+          Type: 172 PointerType **main.t
         - Name: len
           Offset: 8
-          Type: 1 BaseType int
+          Type: 9 BaseType int
         - Name: cap
           Offset: 16
-          Type: 1 BaseType int
+          Type: 9 BaseType int
       Data: 209 GoSliceDataType main.t.array
     - __kind: GoSliceDataType
       ID: 209
       Name: main.t.array
       ByteSize: 2048
-      Element: 156 PointerType *main.t
+      Element: 170 PointerType *main.t
     - __kind: StructureType
-      ID: 168
+      ID: 181
       Name: main.threeStringStruct
       ByteSize: 48
       GoKind: 25
       RawFields:
         - Name: a
           Offset: 0
-          Type: 8 GoStringHeaderType string
+          Type: 11 GoStringHeaderType string
         - Name: b
           Offset: 16
-          Type: 8 GoStringHeaderType string
+          Type: 11 GoStringHeaderType string
         - Name: c
           Offset: 32
-          Type: 8 GoStringHeaderType string
+          Type: 11 GoStringHeaderType string
     - __kind: BaseType
-      ID: 32
+      ID: 51
       Name: main.typeAlias
       ByteSize: 2
       GoKind: 9
     - __kind: GoMapType
-      ID: 146
+      ID: 162
       Name: map[[4]int][4]int
       ByteSize: 8
       GoRuntimeType: 873952
       GoKind: 21
-      HeaderType: 148 GoHMapHeaderType hash<[4]int,[4]int>
+      HeaderType: 164 GoHMapHeaderType hash<[4]int,[4]int>
     - __kind: GoMapType
-      ID: 140
+      ID: 156
       Name: map[[4]int]uint8
       ByteSize: 8
       GoRuntimeType: 874048
       GoKind: 21
-      HeaderType: 142 GoHMapHeaderType hash<[4]int,uint8>
+      HeaderType: 158 GoHMapHeaderType hash<[4]int,uint8>
     - __kind: GoMapType
-      ID: 94
+      ID: 110
       Name: map[[4]string][2]int
       ByteSize: 8
       GoRuntimeType: 874144
       GoKind: 21
-      HeaderType: 96 GoHMapHeaderType hash<[4]string,[2]int>
+      HeaderType: 112 GoHMapHeaderType hash<[4]string,[2]int>
     - __kind: GoMapType
-      ID: 112
+      ID: 128
       Name: map[bool]main.node
       ByteSize: 8
       GoRuntimeType: 874240
       GoKind: 21
-      HeaderType: 114 GoHMapHeaderType hash<bool,main.node>
+      HeaderType: 130 GoHMapHeaderType hash<bool,main.node>
     - __kind: GoMapType
-      ID: 58
+      ID: 75
       Name: map[int]int
       ByteSize: 8
       GoRuntimeType: 872992
       GoKind: 21
-      HeaderType: 60 GoHMapHeaderType hash<int,int>
+      HeaderType: 77 GoHMapHeaderType hash<int,int>
     - __kind: GoMapType
-      ID: 121
+      ID: 137
       Name: map[int]uint8
       ByteSize: 8
       GoRuntimeType: 874336
       GoKind: 21
-      HeaderType: 123 GoHMapHeaderType hash<int,uint8>
+      HeaderType: 139 GoHMapHeaderType hash<int,uint8>
     - __kind: GoMapType
-      ID: 104
+      ID: 120
       Name: map[string][]main.structWithMap
       ByteSize: 8
       GoRuntimeType: 874432
       GoKind: 21
-      HeaderType: 106 GoHMapHeaderType hash<string,[]main.structWithMap>
+      HeaderType: 122 GoHMapHeaderType hash<string,[]main.structWithMap>
     - __kind: GoMapType
-      ID: 87
+      ID: 103
       Name: map[string][]string
       ByteSize: 8
       GoRuntimeType: 874528
       GoKind: 21
-      HeaderType: 89 GoHMapHeaderType hash<string,[]string>
+      HeaderType: 105 GoHMapHeaderType hash<string,[]string>
     - __kind: GoMapType
-      ID: 82
+      ID: 98
       Name: map[string]int
       ByteSize: 8
       GoRuntimeType: 874624
       GoKind: 21
-      HeaderType: 84 GoHMapHeaderType hash<string,int>
+      HeaderType: 100 GoHMapHeaderType hash<string,int>
     - __kind: GoMapType
-      ID: 74
+      ID: 90
       Name: map[string]main.nestedStruct
       ByteSize: 8
       GoRuntimeType: 874720
       GoKind: 21
-      HeaderType: 76 GoHMapHeaderType hash<string,main.nestedStruct>
+      HeaderType: 92 GoHMapHeaderType hash<string,main.nestedStruct>
     - __kind: GoMapType
-      ID: 133
+      ID: 149
       Name: map[uint8][4]int
       ByteSize: 8
       GoRuntimeType: 874816
       GoKind: 21
-      HeaderType: 135 GoHMapHeaderType hash<uint8,[4]int>
+      HeaderType: 151 GoHMapHeaderType hash<uint8,[4]int>
     - __kind: GoMapType
-      ID: 127
+      ID: 143
       Name: map[uint8]uint8
       ByteSize: 8
       GoRuntimeType: 874912
       GoKind: 21
-      HeaderType: 129 GoHMapHeaderType hash<uint8,uint8>
+      HeaderType: 145 GoHMapHeaderType hash<uint8,uint8>
     - __kind: StructureType
-      ID: 73
+      ID: 89
       Name: runtime.bmap
       ByteSize: 8
       GoRuntimeType: 1.10096e+06
@@ -6705,9 +6705,9 @@ Types:
       RawFields:
         - Name: tophash
           Offset: 0
-          Type: 63 ArrayType [8]uint8
+          Type: 80 ArrayType [8]uint8
     - __kind: StructureType
-      ID: 68
+      ID: 84
       Name: runtime.mapextra
       ByteSize: 24
       GoRuntimeType: 1.417408e+06
@@ -6715,15 +6715,15 @@ Types:
       RawFields:
         - Name: overflow
           Offset: 0
-          Type: 69 PointerType *[]*runtime.bmap
+          Type: 85 PointerType *[]*runtime.bmap
         - Name: oldoverflow
           Offset: 8
-          Type: 69 PointerType *[]*runtime.bmap
+          Type: 85 PointerType *[]*runtime.bmap
         - Name: nextOverflow
           Offset: 16
-          Type: 72 PointerType *runtime.bmap
+          Type: 88 PointerType *runtime.bmap
     - __kind: GoStringHeaderType
-      ID: 8
+      ID: 11
       Name: string
       ByteSize: 16
       GoRuntimeType: 527040
@@ -6734,14 +6734,14 @@ Types:
           Type: 188 PointerType *string.str
         - Name: len
           Offset: 8
-          Type: 1 BaseType int
+          Type: 9 BaseType int
       Data: 187 GoStringDataType string.str
     - __kind: GoStringDataType
       ID: 187
       Name: string.str
       ByteSize: 2048
     - __kind: StructureType
-      ID: 46
+      ID: 63
       Name: sync.Mutex
       ByteSize: 8
       GoRuntimeType: 1.271488e+06
@@ -6749,12 +6749,12 @@ Types:
       RawFields:
         - Name: state
           Offset: 0
-          Type: 6 BaseType int32
+          Type: 13 BaseType int32
         - Name: sema
           Offset: 4
-          Type: 24 BaseType uint32
+          Type: 2 BaseType uint32
     - __kind: StructureType
-      ID: 47
+      ID: 64
       Name: sync.Once
       ByteSize: 12
       GoRuntimeType: 1.272608e+06
@@ -6762,12 +6762,12 @@ Types:
       RawFields:
         - Name: done
           Offset: 0
-          Type: 48 StructureType sync/atomic.Uint32
+          Type: 65 StructureType sync/atomic.Uint32
         - Name: m
           Offset: 4
-          Type: 46 StructureType sync.Mutex
+          Type: 63 StructureType sync.Mutex
     - __kind: StructureType
-      ID: 50
+      ID: 67
       Name: sync.WaitGroup
       ByteSize: 16
       GoRuntimeType: 1.411456e+06
@@ -6775,21 +6775,21 @@ Types:
       RawFields:
         - Name: noCopy
           Offset: 0
-          Type: 51 StructureType sync.noCopy
+          Type: 68 StructureType sync.noCopy
         - Name: state
           Offset: 0
-          Type: 52 StructureType sync/atomic.Uint64
+          Type: 69 StructureType sync/atomic.Uint64
         - Name: sema
           Offset: 8
-          Type: 24 BaseType uint32
+          Type: 2 BaseType uint32
     - __kind: StructureType
-      ID: 51
+      ID: 68
       Name: sync.noCopy
       GoRuntimeType: 940704
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 54
+      ID: 71
       Name: sync/atomic.Int32
       ByteSize: 4
       GoRuntimeType: 1.272928e+06
@@ -6797,12 +6797,12 @@ Types:
       RawFields:
         - Name: _
           Offset: 0
-          Type: 49 StructureType sync/atomic.noCopy
+          Type: 66 StructureType sync/atomic.noCopy
         - Name: v
           Offset: 0
-          Type: 6 BaseType int32
+          Type: 13 BaseType int32
     - __kind: StructureType
-      ID: 48
+      ID: 65
       Name: sync/atomic.Uint32
       ByteSize: 4
       GoRuntimeType: 1.273088e+06
@@ -6810,12 +6810,12 @@ Types:
       RawFields:
         - Name: _
           Offset: 0
-          Type: 49 StructureType sync/atomic.noCopy
+          Type: 66 StructureType sync/atomic.noCopy
         - Name: v
           Offset: 0
-          Type: 24 BaseType uint32
+          Type: 2 BaseType uint32
     - __kind: StructureType
-      ID: 52
+      ID: 69
       Name: sync/atomic.Uint64
       ByteSize: 8
       GoRuntimeType: 1.41184e+06
@@ -6823,63 +6823,63 @@ Types:
       RawFields:
         - Name: _
           Offset: 0
-          Type: 49 StructureType sync/atomic.noCopy
+          Type: 66 StructureType sync/atomic.noCopy
         - Name: _
           Offset: 0
-          Type: 53 StructureType sync/atomic.align64
+          Type: 70 StructureType sync/atomic.align64
         - Name: v
           Offset: 0
-          Type: 26 BaseType uint64
+          Type: 10 BaseType uint64
     - __kind: StructureType
-      ID: 53
+      ID: 70
       Name: sync/atomic.align64
       GoRuntimeType: 940896
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 49
+      ID: 66
       Name: sync/atomic.noCopy
       GoRuntimeType: 940800
       GoKind: 25
       RawFields: []
     - __kind: BaseType
-      ID: 20
+      ID: 12
       Name: uint
       ByteSize: 8
       GoRuntimeType: 527680
       GoKind: 7
     - __kind: BaseType
-      ID: 22
+      ID: 7
       Name: uint16
       ByteSize: 2
       GoRuntimeType: 527296
       GoKind: 9
     - __kind: BaseType
-      ID: 24
+      ID: 2
       Name: uint32
       ByteSize: 4
       GoRuntimeType: 527424
       GoKind: 10
     - __kind: BaseType
-      ID: 26
+      ID: 10
       Name: uint64
       ByteSize: 8
       GoRuntimeType: 527552
       GoKind: 11
     - __kind: BaseType
-      ID: 4
+      ID: 3
       Name: uint8
       ByteSize: 1
       GoRuntimeType: 527168
       GoKind: 8
     - __kind: BaseType
-      ID: 66
+      ID: 1
       Name: uintptr
       ByteSize: 8
       GoRuntimeType: 527744
       GoKind: 12
     - __kind: VoidPointerType
-      ID: 38
+      ID: 19
       Name: unsafe.Pointer
       ByteSize: 8
       GoRuntimeType: 528128

--- a/pkg/dyninst/irgen/testdata/snapshot/sample.arch=arm64,toolchain=go1.23.11.yaml
+++ b/pkg/dyninst/irgen/testdata/snapshot/sample.arch=arm64,toolchain=go1.23.11.yaml
@@ -8,11 +8,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 88}
+      subprogram: {subprogram: 96}
       events:
-        - ID: 88
-          Type: 301 EventRootType Probe[main.stackC]
-          InjectionPoints: [{PC: "0x88f5fc", Frameless: true}]
+        - ID: 96
+          Type: 404 EventRootType Probe[main.stackC]
+          InjectionPoints: [{PC: "0x89000c", Frameless: true}]
           Condition: null
     - id: testAny
       version: 0
@@ -22,11 +22,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 45}
+      subprogram: {subprogram: 53}
       events:
-        - ID: 45
-          Type: 258 EventRootType Probe[main.testAny]
-          InjectionPoints: [{PC: "0x88d16c", Frameless: true}]
+        - ID: 53
+          Type: 361 EventRootType Probe[main.testAny]
+          InjectionPoints: [{PC: "0x88db7c", Frameless: true}]
           Condition: null
     - id: testArrayOfArrays
       version: 0
@@ -39,8 +39,8 @@ Probes:
       subprogram: {subprogram: 15}
       events:
         - ID: 15
-          Type: 228 EventRootType Probe[main.testArrayOfArrays]
-          InjectionPoints: [{PC: "0x88bee0", Frameless: true}]
+          Type: 323 EventRootType Probe[main.testArrayOfArrays]
+          InjectionPoints: [{PC: "0x88c310", Frameless: true}]
           Condition: null
     - id: testArrayOfArraysOfArrays
       version: 0
@@ -53,8 +53,8 @@ Probes:
       subprogram: {subprogram: 17}
       events:
         - ID: 17
-          Type: 230 EventRootType Probe[main.testArrayOfArraysOfArrays]
-          InjectionPoints: [{PC: "0x88bf00", Frameless: true}]
+          Type: 325 EventRootType Probe[main.testArrayOfArraysOfArrays]
+          InjectionPoints: [{PC: "0x88c330", Frameless: true}]
           Condition: null
     - id: testArrayOfMaps
       version: 0
@@ -64,11 +64,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 53}
+      subprogram: {subprogram: 61}
       events:
-        - ID: 53
-          Type: 266 EventRootType Probe[main.testArrayOfMaps]
-          InjectionPoints: [{PC: "0x88d650", Frameless: true}]
+        - ID: 61
+          Type: 369 EventRootType Probe[main.testArrayOfMaps]
+          InjectionPoints: [{PC: "0x88e060", Frameless: true}]
           Condition: null
     - id: testArrayOfStrings
       version: 0
@@ -81,8 +81,8 @@ Probes:
       subprogram: {subprogram: 16}
       events:
         - ID: 16
-          Type: 229 EventRootType Probe[main.testArrayOfStrings]
-          InjectionPoints: [{PC: "0x88bef0", Frameless: true}]
+          Type: 324 EventRootType Probe[main.testArrayOfStrings]
+          InjectionPoints: [{PC: "0x88c320", Frameless: true}]
           Condition: null
     - id: testBigStruct
       version: 0
@@ -95,8 +95,8 @@ Probes:
       subprogram: {subprogram: 35}
       events:
         - ID: 35
-          Type: 248 EventRootType Probe[main.testBigStruct]
-          InjectionPoints: [{PC: "0x88c460", Frameless: true}]
+          Type: 343 EventRootType Probe[main.testBigStruct]
+          InjectionPoints: [{PC: "0x88c890", Frameless: true}]
           Condition: null
     - id: testBoolArray
       version: 0
@@ -109,8 +109,8 @@ Probes:
       subprogram: {subprogram: 4}
       events:
         - ID: 4
-          Type: 217 EventRootType Probe[main.testBoolArray]
-          InjectionPoints: [{PC: "0x88be30", Frameless: true}]
+          Type: 312 EventRootType Probe[main.testBoolArray]
+          InjectionPoints: [{PC: "0x88c260", Frameless: true}]
           Condition: null
     - id: testByteArray
       version: 0
@@ -123,8 +123,8 @@ Probes:
       subprogram: {subprogram: 1}
       events:
         - ID: 1
-          Type: 214 EventRootType Probe[main.testByteArray]
-          InjectionPoints: [{PC: "0x88be00", Frameless: true}]
+          Type: 309 EventRootType Probe[main.testByteArray]
+          InjectionPoints: [{PC: "0x88c230", Frameless: true}]
           Condition: null
     - id: testChannel
       version: 0
@@ -134,11 +134,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 69}
+      subprogram: {subprogram: 77}
       events:
-        - ID: 69
-          Type: 282 EventRootType Probe[main.testChannel]
-          InjectionPoints: [{PC: "0x88ec00", Frameless: true}]
+        - ID: 77
+          Type: 385 EventRootType Probe[main.testChannel]
+          InjectionPoints: [{PC: "0x88f610", Frameless: true}]
           Condition: null
     - id: testCombinedByte
       version: 0
@@ -148,11 +148,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 67}
+      subprogram: {subprogram: 75}
       events:
-        - ID: 67
-          Type: 280 EventRootType Probe[main.testCombinedByte]
-          InjectionPoints: [{PC: "0x88e980", Frameless: true}]
+        - ID: 75
+          Type: 383 EventRootType Probe[main.testCombinedByte]
+          InjectionPoints: [{PC: "0x88f390", Frameless: true}]
           Condition: null
     - id: testCycle
       version: 0
@@ -162,11 +162,113 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 77}
+      subprogram: {subprogram: 85}
       events:
-        - ID: 77
-          Type: 290 EventRootType Probe[main.testCycle]
-          InjectionPoints: [{PC: "0x88eea0", Frameless: true}]
+        - ID: 85
+          Type: 393 EventRootType Probe[main.testCycle]
+          InjectionPoints: [{PC: "0x88f8b0", Frameless: true}]
+          Condition: null
+    - id: testDeepMap1
+      version: 0
+      type: LOG_PROBE
+      where: {methodName: main.testDeepMap1}
+      capture:
+        maxReferenceDepth: 1
+        maxFieldCount: 0
+        maxCollectionSize: 0
+      template: ""
+      segments: []
+      captureSnapshot: true
+      subprogram: {subprogram: 40}
+      events:
+        - ID: 40
+          Type: 348 EventRootType Probe[main.testDeepMap1]
+          InjectionPoints: [{PC: "0x88cc70", Frameless: true}]
+          Condition: null
+    - id: testDeepMap7
+      version: 0
+      type: LOG_PROBE
+      where: {methodName: main.testDeepMap7}
+      capture:
+        maxReferenceDepth: 5
+        maxFieldCount: 0
+        maxCollectionSize: 0
+      template: ""
+      segments: []
+      captureSnapshot: true
+      subprogram: {subprogram: 41}
+      events:
+        - ID: 41
+          Type: 349 EventRootType Probe[main.testDeepMap7]
+          InjectionPoints: [{PC: "0x88cc80", Frameless: true}]
+          Condition: null
+    - id: testDeepPtr1
+      version: 0
+      type: LOG_PROBE
+      where: {methodName: main.testDeepPtr1}
+      capture:
+        maxReferenceDepth: 1
+        maxFieldCount: 0
+        maxCollectionSize: 0
+      template: ""
+      segments: []
+      captureSnapshot: true
+      subprogram: {subprogram: 36}
+      events:
+        - ID: 36
+          Type: 344 EventRootType Probe[main.testDeepPtr1]
+          InjectionPoints: [{PC: "0x88c960", Frameless: true}]
+          Condition: null
+    - id: testDeepPtr7
+      version: 0
+      type: LOG_PROBE
+      where: {methodName: main.testDeepPtr7}
+      capture:
+        maxReferenceDepth: 5
+        maxFieldCount: 0
+        maxCollectionSize: 0
+      template: ""
+      segments: []
+      captureSnapshot: true
+      subprogram: {subprogram: 37}
+      events:
+        - ID: 37
+          Type: 345 EventRootType Probe[main.testDeepPtr7]
+          InjectionPoints: [{PC: "0x88c970", Frameless: true}]
+          Condition: null
+    - id: testDeepSlice1
+      version: 0
+      type: LOG_PROBE
+      where: {methodName: main.testDeepSlice1}
+      capture:
+        maxReferenceDepth: 1
+        maxFieldCount: 0
+        maxCollectionSize: 0
+      template: ""
+      segments: []
+      captureSnapshot: true
+      subprogram: {subprogram: 38}
+      events:
+        - ID: 38
+          Type: 346 EventRootType Probe[main.testDeepSlice1]
+          InjectionPoints: [{PC: "0x88cb10", Frameless: true}]
+          Condition: null
+    - id: testDeepSlice7
+      version: 0
+      type: LOG_PROBE
+      where: {methodName: main.testDeepSlice7}
+      capture:
+        maxReferenceDepth: 5
+        maxFieldCount: 0
+        maxCollectionSize: 0
+      template: ""
+      segments: []
+      captureSnapshot: true
+      subprogram: {subprogram: 39}
+      events:
+        - ID: 39
+          Type: 347 EventRootType Probe[main.testDeepSlice7]
+          InjectionPoints: [{PC: "0x88cb20", Frameless: true}]
           Condition: null
     - id: testEmptySlice
       version: 0
@@ -176,11 +278,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 79}
+      subprogram: {subprogram: 87}
       events:
-        - ID: 79
-          Type: 292 EventRootType Probe[main.testEmptySlice]
-          InjectionPoints: [{PC: "0x88f2a0", Frameless: true}]
+        - ID: 87
+          Type: 395 EventRootType Probe[main.testEmptySlice]
+          InjectionPoints: [{PC: "0x88fcb0", Frameless: true}]
           Condition: null
     - id: testEmptySliceOfStructs
       version: 0
@@ -190,11 +292,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 82}
+      subprogram: {subprogram: 90}
       events:
-        - ID: 82
-          Type: 295 EventRootType Probe[main.testEmptySliceOfStructs]
-          InjectionPoints: [{PC: "0x88f2d0", Frameless: true}]
+        - ID: 90
+          Type: 398 EventRootType Probe[main.testEmptySliceOfStructs]
+          InjectionPoints: [{PC: "0x88fce0", Frameless: true}]
           Condition: null
     - id: testEmptyString
       version: 0
@@ -204,11 +306,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 96}
+      subprogram: {subprogram: 104}
       events:
-        - ID: 96
-          Type: 309 EventRootType Probe[main.testEmptyString]
-          InjectionPoints: [{PC: "0x88f6e0", Frameless: true}]
+        - ID: 104
+          Type: 412 EventRootType Probe[main.testEmptyString]
+          InjectionPoints: [{PC: "0x8900f0", Frameless: true}]
           Condition: null
     - id: testEmptyStruct
       version: 0
@@ -218,11 +320,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 98}
+      subprogram: {subprogram: 106}
       events:
-        - ID: 98
-          Type: 311 EventRootType Probe[main.testEmptyStruct]
-          InjectionPoints: [{PC: "0x88f9f0", Frameless: true}]
+        - ID: 106
+          Type: 414 EventRootType Probe[main.testEmptyStruct]
+          InjectionPoints: [{PC: "0x890400", Frameless: true}]
           Condition: null
     - id: testError
       version: 0
@@ -232,11 +334,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 46}
+      subprogram: {subprogram: 54}
       events:
-        - ID: 46
-          Type: 259 EventRootType Probe[main.testError]
-          InjectionPoints: [{PC: "0x88d1d0", Frameless: true}]
+        - ID: 54
+          Type: 362 EventRootType Probe[main.testError]
+          InjectionPoints: [{PC: "0x88dbe0", Frameless: true}]
           Condition: null
     - id: testEsotericHeap
       version: 0
@@ -246,11 +348,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 37}
+      subprogram: {subprogram: 45}
       events:
-        - ID: 37
-          Type: 250 EventRootType Probe[main.testEsotericHeap]
-          InjectionPoints: [{PC: "0x88c71c", Frameless: true}]
+        - ID: 45
+          Type: 353 EventRootType Probe[main.testEsotericHeap]
+          InjectionPoints: [{PC: "0x88d12c", Frameless: true}]
           Condition: null
     - id: testEsotericStack
       version: 0
@@ -260,11 +362,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 36}
+      subprogram: {subprogram: 44}
       events:
-        - ID: 36
-          Type: 249 EventRootType Probe[main.testEsotericStack]
-          InjectionPoints: [{PC: "0x88c62c", Frameless: true}]
+        - ID: 44
+          Type: 352 EventRootType Probe[main.testEsotericStack]
+          InjectionPoints: [{PC: "0x88d03c", Frameless: true}]
           Condition: null
     - id: testFrameless
       version: 0
@@ -274,11 +376,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 42}
+      subprogram: {subprogram: 50}
       events:
-        - ID: 42
-          Type: 255 EventRootType Probe[main.testFrameless]
-          InjectionPoints: [{PC: "0x88ce50", Frameless: true}]
+        - ID: 50
+          Type: 358 EventRootType Probe[main.testFrameless]
+          InjectionPoints: [{PC: "0x88d860", Frameless: true}]
           Condition: null
     - id: testFramelessArray
       version: 0
@@ -288,11 +390,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 43}
+      subprogram: {subprogram: 51}
       events:
-        - ID: 43
-          Type: 256 EventRootType Probe[main.testFramelessArray]
-          InjectionPoints: [{PC: "0x88ce60", Frameless: true}]
+        - ID: 51
+          Type: 359 EventRootType Probe[main.testFramelessArray]
+          InjectionPoints: [{PC: "0x88d870", Frameless: true}]
           Condition: null
     - id: testInlinedBA
       version: 0
@@ -302,11 +404,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 38}
+      subprogram: {subprogram: 46}
       events:
-        - ID: 38
-          Type: 251 EventRootType Probe[main.testInlinedBA]
-          InjectionPoints: [{PC: "0x88cb5c", Frameless: true}]
+        - ID: 46
+          Type: 354 EventRootType Probe[main.testInlinedBA]
+          InjectionPoints: [{PC: "0x88d56c", Frameless: true}]
           Condition: null
     - id: testInlinedBB
       version: 0
@@ -316,11 +418,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 39}
+      subprogram: {subprogram: 47}
       events:
-        - ID: 39
-          Type: 252 EventRootType Probe[main.testInlinedBB]
-          InjectionPoints: [{PC: "0x88cbec", Frameless: true}]
+        - ID: 47
+          Type: 355 EventRootType Probe[main.testInlinedBB]
+          InjectionPoints: [{PC: "0x88d5fc", Frameless: true}]
           Condition: null
     - id: testInlinedBBA
       version: 0
@@ -330,11 +432,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 40}
+      subprogram: {subprogram: 48}
       events:
-        - ID: 40
-          Type: 253 EventRootType Probe[main.testInlinedBBA]
-          InjectionPoints: [{PC: "0x88ccbc", Frameless: true}]
+        - ID: 48
+          Type: 356 EventRootType Probe[main.testInlinedBBA]
+          InjectionPoints: [{PC: "0x88d6cc", Frameless: true}]
           Condition: null
     - id: testInlinedBBB
       version: 0
@@ -344,11 +446,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 100}
+      subprogram: {subprogram: 108}
       events:
-        - ID: 100
-          Type: 313 EventRootType Probe[main.testInlinedBBB]
-          InjectionPoints: [{PC: "0x88cc48", Frameless: false}]
+        - ID: 108
+          Type: 416 EventRootType Probe[main.testInlinedBBB]
+          InjectionPoints: [{PC: "0x88d658", Frameless: false}]
           Condition: null
     - id: testInlinedBC
       version: 0
@@ -358,11 +460,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 41}
+      subprogram: {subprogram: 49}
       events:
-        - ID: 41
-          Type: 254 EventRootType Probe[main.testInlinedBC]
-          InjectionPoints: [{PC: "0x88cd3c", Frameless: true}]
+        - ID: 49
+          Type: 357 EventRootType Probe[main.testInlinedBC]
+          InjectionPoints: [{PC: "0x88d74c", Frameless: true}]
           Condition: null
     - id: testInlinedBCA
       version: 0
@@ -372,11 +474,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 101}
+      subprogram: {subprogram: 109}
       events:
-        - ID: 101
-          Type: 314 EventRootType Probe[main.testInlinedBCA]
-          InjectionPoints: [{PC: "0x88cd4c", Frameless: false}]
+        - ID: 109
+          Type: 417 EventRootType Probe[main.testInlinedBCA]
+          InjectionPoints: [{PC: "0x88d75c", Frameless: false}]
           Condition: null
     - id: testInlinedBCB
       version: 0
@@ -386,11 +488,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 102}
+      subprogram: {subprogram: 110}
       events:
-        - ID: 102
-          Type: 315 EventRootType Probe[main.testInlinedBCB]
-          InjectionPoints: [{PC: "0x88ce00", Frameless: false}]
+        - ID: 110
+          Type: 418 EventRootType Probe[main.testInlinedBCB]
+          InjectionPoints: [{PC: "0x88d810", Frameless: false}]
           Condition: null
     - id: testInlinedPrint
       version: 0
@@ -401,20 +503,20 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 99}
+      subprogram: {subprogram: 107}
       events:
-        - ID: 99
-          Type: 312 EventRootType Probe[main.testInlinedPrint]
+        - ID: 107
+          Type: 415 EventRootType Probe[main.testInlinedPrint]
           InjectionPoints:
-            - PC: "0x88c9bc"
+            - PC: "0x88d3cc"
               Frameless: true
-            - PC: "0x88ca3c"
+            - PC: "0x88d44c"
               Frameless: false
-            - PC: "0x88cb88"
+            - PC: "0x88d598"
               Frameless: false
-            - PC: "0x88cc04"
+            - PC: "0x88d614"
               Frameless: false
-            - PC: "0x88cccc"
+            - PC: "0x88d6dc"
               Frameless: false
           Condition: null
     - id: testInlinedSq
@@ -425,11 +527,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 103}
+      subprogram: {subprogram: 111}
       events:
-        - ID: 103
-          Type: 316 EventRootType Probe[main.testInlinedSq]
-          InjectionPoints: [{PC: "0x88ce54", Frameless: true}]
+        - ID: 111
+          Type: 419 EventRootType Probe[main.testInlinedSq]
+          InjectionPoints: [{PC: "0x88d864", Frameless: true}]
           Condition: null
     - id: testInlinedSumArray
       version: 0
@@ -440,14 +542,14 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 104}
+      subprogram: {subprogram: 112}
       events:
-        - ID: 104
-          Type: 317 EventRootType Probe[main.testInlinedSumArray]
+        - ID: 112
+          Type: 420 EventRootType Probe[main.testInlinedSumArray]
           InjectionPoints:
-            - PC: "0x88ce84"
+            - PC: "0x88d894"
               Frameless: false
-            - PC: "0x88cf1c"
+            - PC: "0x88d92c"
               Frameless: false
           Condition: null
     - id: testInt16Array
@@ -461,8 +563,8 @@ Probes:
       subprogram: {subprogram: 7}
       events:
         - ID: 7
-          Type: 220 EventRootType Probe[main.testInt16Array]
-          InjectionPoints: [{PC: "0x88be60", Frameless: true}]
+          Type: 315 EventRootType Probe[main.testInt16Array]
+          InjectionPoints: [{PC: "0x88c290", Frameless: true}]
           Condition: null
     - id: testInt32Array
       version: 0
@@ -475,8 +577,8 @@ Probes:
       subprogram: {subprogram: 8}
       events:
         - ID: 8
-          Type: 221 EventRootType Probe[main.testInt32Array]
-          InjectionPoints: [{PC: "0x88be70", Frameless: true}]
+          Type: 316 EventRootType Probe[main.testInt32Array]
+          InjectionPoints: [{PC: "0x88c2a0", Frameless: true}]
           Condition: null
     - id: testInt64Array
       version: 0
@@ -489,8 +591,8 @@ Probes:
       subprogram: {subprogram: 9}
       events:
         - ID: 9
-          Type: 222 EventRootType Probe[main.testInt64Array]
-          InjectionPoints: [{PC: "0x88be80", Frameless: true}]
+          Type: 317 EventRootType Probe[main.testInt64Array]
+          InjectionPoints: [{PC: "0x88c2b0", Frameless: true}]
           Condition: null
     - id: testInt8Array
       version: 0
@@ -503,8 +605,8 @@ Probes:
       subprogram: {subprogram: 6}
       events:
         - ID: 6
-          Type: 219 EventRootType Probe[main.testInt8Array]
-          InjectionPoints: [{PC: "0x88be50", Frameless: true}]
+          Type: 314 EventRootType Probe[main.testInt8Array]
+          InjectionPoints: [{PC: "0x88c280", Frameless: true}]
           Condition: null
     - id: testIntArray
       version: 0
@@ -517,8 +619,8 @@ Probes:
       subprogram: {subprogram: 5}
       events:
         - ID: 5
-          Type: 218 EventRootType Probe[main.testIntArray]
-          InjectionPoints: [{PC: "0x88be40", Frameless: true}]
+          Type: 313 EventRootType Probe[main.testIntArray]
+          InjectionPoints: [{PC: "0x88c270", Frameless: true}]
           Condition: null
     - id: testInterface
       version: 0
@@ -528,11 +630,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 44}
+      subprogram: {subprogram: 52}
       events:
-        - ID: 44
-          Type: 257 EventRootType Probe[main.testInterface]
-          InjectionPoints: [{PC: "0x88d10c", Frameless: true}]
+        - ID: 52
+          Type: 360 EventRootType Probe[main.testInterface]
+          InjectionPoints: [{PC: "0x88db1c", Frameless: true}]
           Condition: null
     - id: testLinkedList
       version: 0
@@ -542,11 +644,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 71}
+      subprogram: {subprogram: 79}
       events:
-        - ID: 71
-          Type: 284 EventRootType Probe[main.testLinkedList]
-          InjectionPoints: [{PC: "0x88edb0", Frameless: true}]
+        - ID: 79
+          Type: 387 EventRootType Probe[main.testLinkedList]
+          InjectionPoints: [{PC: "0x88f7c0", Frameless: true}]
           Condition: null
     - id: testMapArrayToArray
       version: 0
@@ -556,11 +658,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 51}
+      subprogram: {subprogram: 59}
       events:
-        - ID: 51
-          Type: 264 EventRootType Probe[main.testMapArrayToArray]
-          InjectionPoints: [{PC: "0x88d630", Frameless: true}]
+        - ID: 59
+          Type: 367 EventRootType Probe[main.testMapArrayToArray]
+          InjectionPoints: [{PC: "0x88e040", Frameless: true}]
           Condition: null
     - id: testMapEmbeddedMaps
       version: 0
@@ -570,11 +672,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 57}
+      subprogram: {subprogram: 65}
       events:
-        - ID: 57
-          Type: 270 EventRootType Probe[main.testMapEmbeddedMaps]
-          InjectionPoints: [{PC: "0x88d690", Frameless: true}]
+        - ID: 65
+          Type: 373 EventRootType Probe[main.testMapEmbeddedMaps]
+          InjectionPoints: [{PC: "0x88e0a0", Frameless: true}]
           Condition: null
     - id: testMapIntToInt
       version: 0
@@ -584,11 +686,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 55}
+      subprogram: {subprogram: 63}
       events:
-        - ID: 55
-          Type: 268 EventRootType Probe[main.testMapIntToInt]
-          InjectionPoints: [{PC: "0x88d670", Frameless: true}]
+        - ID: 63
+          Type: 371 EventRootType Probe[main.testMapIntToInt]
+          InjectionPoints: [{PC: "0x88e080", Frameless: true}]
           Condition: null
     - id: testMapLargeKeyLargeValue
       version: 0
@@ -598,11 +700,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 66}
+      subprogram: {subprogram: 74}
       events:
-        - ID: 66
-          Type: 279 EventRootType Probe[main.testMapLargeKeyLargeValue]
-          InjectionPoints: [{PC: "0x88d720", Frameless: true}]
+        - ID: 74
+          Type: 382 EventRootType Probe[main.testMapLargeKeyLargeValue]
+          InjectionPoints: [{PC: "0x88e130", Frameless: true}]
           Condition: null
     - id: testMapLargeKeySmallValue
       version: 0
@@ -612,11 +714,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 65}
+      subprogram: {subprogram: 73}
       events:
-        - ID: 65
-          Type: 278 EventRootType Probe[main.testMapLargeKeySmallValue]
-          InjectionPoints: [{PC: "0x88d710", Frameless: true}]
+        - ID: 73
+          Type: 381 EventRootType Probe[main.testMapLargeKeySmallValue]
+          InjectionPoints: [{PC: "0x88e120", Frameless: true}]
           Condition: null
     - id: testMapMassive
       version: 0
@@ -626,11 +728,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 56}
+      subprogram: {subprogram: 64}
       events:
-        - ID: 56
-          Type: 269 EventRootType Probe[main.testMapMassive]
-          InjectionPoints: [{PC: "0x88d680", Frameless: true}]
+        - ID: 64
+          Type: 372 EventRootType Probe[main.testMapMassive]
+          InjectionPoints: [{PC: "0x88e090", Frameless: true}]
           Condition: null
     - id: testMapSmallKeyLargeValue
       version: 0
@@ -640,11 +742,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 64}
+      subprogram: {subprogram: 72}
       events:
-        - ID: 64
-          Type: 277 EventRootType Probe[main.testMapSmallKeyLargeValue]
-          InjectionPoints: [{PC: "0x88d700", Frameless: true}]
+        - ID: 72
+          Type: 380 EventRootType Probe[main.testMapSmallKeyLargeValue]
+          InjectionPoints: [{PC: "0x88e110", Frameless: true}]
           Condition: null
     - id: testMapSmallKeySmallValue
       version: 0
@@ -654,11 +756,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 63}
+      subprogram: {subprogram: 71}
       events:
-        - ID: 63
-          Type: 276 EventRootType Probe[main.testMapSmallKeySmallValue]
-          InjectionPoints: [{PC: "0x88d6f0", Frameless: true}]
+        - ID: 71
+          Type: 379 EventRootType Probe[main.testMapSmallKeySmallValue]
+          InjectionPoints: [{PC: "0x88e100", Frameless: true}]
           Condition: null
     - id: testMapStringToInt
       version: 0
@@ -668,11 +770,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 49}
+      subprogram: {subprogram: 57}
       events:
-        - ID: 49
-          Type: 262 EventRootType Probe[main.testMapStringToInt]
-          InjectionPoints: [{PC: "0x88d610", Frameless: true}]
+        - ID: 57
+          Type: 365 EventRootType Probe[main.testMapStringToInt]
+          InjectionPoints: [{PC: "0x88e020", Frameless: true}]
           Condition: null
     - id: testMapStringToSlice
       version: 0
@@ -682,11 +784,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 50}
+      subprogram: {subprogram: 58}
       events:
-        - ID: 50
-          Type: 263 EventRootType Probe[main.testMapStringToSlice]
-          InjectionPoints: [{PC: "0x88d620", Frameless: true}]
+        - ID: 58
+          Type: 366 EventRootType Probe[main.testMapStringToSlice]
+          InjectionPoints: [{PC: "0x88e030", Frameless: true}]
           Condition: null
     - id: testMapStringToStruct
       version: 0
@@ -696,11 +798,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 48}
+      subprogram: {subprogram: 56}
       events:
-        - ID: 48
-          Type: 261 EventRootType Probe[main.testMapStringToStruct]
-          InjectionPoints: [{PC: "0x88d600", Frameless: true}]
+        - ID: 56
+          Type: 364 EventRootType Probe[main.testMapStringToStruct]
+          InjectionPoints: [{PC: "0x88e010", Frameless: true}]
           Condition: null
     - id: testMapWithLinkedList
       version: 0
@@ -710,11 +812,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 58}
+      subprogram: {subprogram: 66}
       events:
-        - ID: 58
-          Type: 271 EventRootType Probe[main.testMapWithLinkedList]
-          InjectionPoints: [{PC: "0x88d6a0", Frameless: true}]
+        - ID: 66
+          Type: 374 EventRootType Probe[main.testMapWithLinkedList]
+          InjectionPoints: [{PC: "0x88e0b0", Frameless: true}]
           Condition: null
     - id: testMapWithSmallKeyAndValue
       version: 0
@@ -724,11 +826,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 61}
+      subprogram: {subprogram: 69}
       events:
-        - ID: 61
-          Type: 274 EventRootType Probe[main.testMapWithSmallKeyAndValue]
-          InjectionPoints: [{PC: "0x88d6d0", Frameless: true}]
+        - ID: 69
+          Type: 377 EventRootType Probe[main.testMapWithSmallKeyAndValue]
+          InjectionPoints: [{PC: "0x88e0e0", Frameless: true}]
           Condition: null
     - id: testMapWithSmallKeyAndValueMassive
       version: 0
@@ -738,11 +840,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 62}
+      subprogram: {subprogram: 70}
       events:
-        - ID: 62
-          Type: 275 EventRootType Probe[main.testMapWithSmallKeyAndValueMassive]
-          InjectionPoints: [{PC: "0x88d6e0", Frameless: true}]
+        - ID: 70
+          Type: 378 EventRootType Probe[main.testMapWithSmallKeyAndValueMassive]
+          InjectionPoints: [{PC: "0x88e0f0", Frameless: true}]
           Condition: null
     - id: testMapWithSmallValue
       version: 0
@@ -752,11 +854,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 59}
+      subprogram: {subprogram: 67}
       events:
-        - ID: 59
-          Type: 272 EventRootType Probe[main.testMapWithSmallValue]
-          InjectionPoints: [{PC: "0x88d6b0", Frameless: true}]
+        - ID: 67
+          Type: 375 EventRootType Probe[main.testMapWithSmallValue]
+          InjectionPoints: [{PC: "0x88e0c0", Frameless: true}]
           Condition: null
     - id: testMapWithSmallValueMassive
       version: 0
@@ -766,11 +868,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 60}
+      subprogram: {subprogram: 68}
       events:
-        - ID: 60
-          Type: 273 EventRootType Probe[main.testMapWithSmallValueMassive]
-          InjectionPoints: [{PC: "0x88d6c0", Frameless: true}]
+        - ID: 68
+          Type: 376 EventRootType Probe[main.testMapWithSmallValueMassive]
+          InjectionPoints: [{PC: "0x88e0d0", Frameless: true}]
           Condition: null
     - id: testMassiveString
       version: 0
@@ -780,11 +882,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 94}
+      subprogram: {subprogram: 102}
       events:
-        - ID: 94
-          Type: 307 EventRootType Probe[main.testMassiveString]
-          InjectionPoints: [{PC: "0x88f6c0", Frameless: true}]
+        - ID: 102
+          Type: 410 EventRootType Probe[main.testMassiveString]
+          InjectionPoints: [{PC: "0x8900d0", Frameless: true}]
           Condition: null
     - id: testMultipleSimpleParams
       version: 0
@@ -794,11 +896,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 68}
+      subprogram: {subprogram: 76}
       events:
-        - ID: 68
-          Type: 281 EventRootType Probe[main.testMultipleSimpleParams]
-          InjectionPoints: [{PC: "0x88ea60", Frameless: true}]
+        - ID: 76
+          Type: 384 EventRootType Probe[main.testMultipleSimpleParams]
+          InjectionPoints: [{PC: "0x88f470", Frameless: true}]
           Condition: null
     - id: testNilPointer
       version: 0
@@ -808,11 +910,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 76}
+      subprogram: {subprogram: 84}
       events:
-        - ID: 76
-          Type: 289 EventRootType Probe[main.testNilPointer]
-          InjectionPoints: [{PC: "0x88ee80", Frameless: true}]
+        - ID: 84
+          Type: 392 EventRootType Probe[main.testNilPointer]
+          InjectionPoints: [{PC: "0x88f890", Frameless: true}]
           Condition: null
     - id: testNilSlice
       version: 0
@@ -822,11 +924,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 86}
+      subprogram: {subprogram: 94}
       events:
-        - ID: 86
-          Type: 299 EventRootType Probe[main.testNilSlice]
-          InjectionPoints: [{PC: "0x88f310", Frameless: true}]
+        - ID: 94
+          Type: 402 EventRootType Probe[main.testNilSlice]
+          InjectionPoints: [{PC: "0x88fd20", Frameless: true}]
           Condition: null
     - id: testNilSliceOfStructs
       version: 0
@@ -836,11 +938,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 83}
+      subprogram: {subprogram: 91}
       events:
-        - ID: 83
-          Type: 296 EventRootType Probe[main.testNilSliceOfStructs]
-          InjectionPoints: [{PC: "0x88f2e0", Frameless: true}]
+        - ID: 91
+          Type: 399 EventRootType Probe[main.testNilSliceOfStructs]
+          InjectionPoints: [{PC: "0x88fcf0", Frameless: true}]
           Condition: null
     - id: testNilSliceWithOtherParams
       version: 0
@@ -850,11 +952,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 85}
+      subprogram: {subprogram: 93}
       events:
-        - ID: 85
-          Type: 298 EventRootType Probe[main.testNilSliceWithOtherParams]
-          InjectionPoints: [{PC: "0x88f300", Frameless: true}]
+        - ID: 93
+          Type: 401 EventRootType Probe[main.testNilSliceWithOtherParams]
+          InjectionPoints: [{PC: "0x88fd10", Frameless: true}]
           Condition: null
     - id: testOneStringInStructPointer
       version: 0
@@ -864,11 +966,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 93}
+      subprogram: {subprogram: 101}
       events:
-        - ID: 93
-          Type: 306 EventRootType Probe[main.testOneStringInStructPointer]
-          InjectionPoints: [{PC: "0x88f6b0", Frameless: true}]
+        - ID: 101
+          Type: 409 EventRootType Probe[main.testOneStringInStructPointer]
+          InjectionPoints: [{PC: "0x8900c0", Frameless: true}]
           Condition: null
     - id: testPointerLoop
       version: 0
@@ -878,11 +980,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 72}
+      subprogram: {subprogram: 80}
       events:
-        - ID: 72
-          Type: 285 EventRootType Probe[main.testPointerLoop]
-          InjectionPoints: [{PC: "0x88edc0", Frameless: true}]
+        - ID: 80
+          Type: 388 EventRootType Probe[main.testPointerLoop]
+          InjectionPoints: [{PC: "0x88f7d0", Frameless: true}]
           Condition: null
     - id: testPointerToMap
       version: 0
@@ -892,11 +994,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 54}
+      subprogram: {subprogram: 62}
       events:
-        - ID: 54
-          Type: 267 EventRootType Probe[main.testPointerToMap]
-          InjectionPoints: [{PC: "0x88d660", Frameless: true}]
+        - ID: 62
+          Type: 370 EventRootType Probe[main.testPointerToMap]
+          InjectionPoints: [{PC: "0x88e070", Frameless: true}]
           Condition: null
     - id: testPointerToSimpleStruct
       version: 0
@@ -906,11 +1008,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 70}
+      subprogram: {subprogram: 78}
       events:
-        - ID: 70
-          Type: 283 EventRootType Probe[main.testPointerToSimpleStruct]
-          InjectionPoints: [{PC: "0x88eda0", Frameless: true}]
+        - ID: 78
+          Type: 386 EventRootType Probe[main.testPointerToSimpleStruct]
+          InjectionPoints: [{PC: "0x88f7b0", Frameless: true}]
           Condition: null
     - id: testRuneArray
       version: 0
@@ -923,8 +1025,8 @@ Probes:
       subprogram: {subprogram: 2}
       events:
         - ID: 2
-          Type: 215 EventRootType Probe[main.testRuneArray]
-          InjectionPoints: [{PC: "0x88be10", Frameless: true}]
+          Type: 310 EventRootType Probe[main.testRuneArray]
+          InjectionPoints: [{PC: "0x88c240", Frameless: true}]
           Condition: null
     - id: testSingleBool
       version: 0
@@ -937,8 +1039,8 @@ Probes:
       subprogram: {subprogram: 21}
       events:
         - ID: 21
-          Type: 234 EventRootType Probe[main.testSingleBool]
-          InjectionPoints: [{PC: "0x88c280", Frameless: true}]
+          Type: 329 EventRootType Probe[main.testSingleBool]
+          InjectionPoints: [{PC: "0x88c6b0", Frameless: true}]
           Condition: null
     - id: testSingleByte
       version: 0
@@ -951,8 +1053,8 @@ Probes:
       subprogram: {subprogram: 19}
       events:
         - ID: 19
-          Type: 232 EventRootType Probe[main.testSingleByte]
-          InjectionPoints: [{PC: "0x88c260", Frameless: true}]
+          Type: 327 EventRootType Probe[main.testSingleByte]
+          InjectionPoints: [{PC: "0x88c690", Frameless: true}]
           Condition: null
     - id: testSingleFloat32
       version: 0
@@ -965,8 +1067,8 @@ Probes:
       subprogram: {subprogram: 32}
       events:
         - ID: 32
-          Type: 245 EventRootType Probe[main.testSingleFloat32]
-          InjectionPoints: [{PC: "0x88c330", Frameless: true}]
+          Type: 340 EventRootType Probe[main.testSingleFloat32]
+          InjectionPoints: [{PC: "0x88c760", Frameless: true}]
           Condition: null
     - id: testSingleFloat64
       version: 0
@@ -979,8 +1081,8 @@ Probes:
       subprogram: {subprogram: 33}
       events:
         - ID: 33
-          Type: 246 EventRootType Probe[main.testSingleFloat64]
-          InjectionPoints: [{PC: "0x88c340", Frameless: true}]
+          Type: 341 EventRootType Probe[main.testSingleFloat64]
+          InjectionPoints: [{PC: "0x88c770", Frameless: true}]
           Condition: null
     - id: testSingleInt
       version: 0
@@ -993,8 +1095,8 @@ Probes:
       subprogram: {subprogram: 22}
       events:
         - ID: 22
-          Type: 235 EventRootType Probe[main.testSingleInt]
-          InjectionPoints: [{PC: "0x88c290", Frameless: true}]
+          Type: 330 EventRootType Probe[main.testSingleInt]
+          InjectionPoints: [{PC: "0x88c6c0", Frameless: true}]
           Condition: null
     - id: testSingleInt16
       version: 0
@@ -1007,8 +1109,8 @@ Probes:
       subprogram: {subprogram: 24}
       events:
         - ID: 24
-          Type: 237 EventRootType Probe[main.testSingleInt16]
-          InjectionPoints: [{PC: "0x88c2b0", Frameless: true}]
+          Type: 332 EventRootType Probe[main.testSingleInt16]
+          InjectionPoints: [{PC: "0x88c6e0", Frameless: true}]
           Condition: null
     - id: testSingleInt32
       version: 0
@@ -1021,8 +1123,8 @@ Probes:
       subprogram: {subprogram: 25}
       events:
         - ID: 25
-          Type: 238 EventRootType Probe[main.testSingleInt32]
-          InjectionPoints: [{PC: "0x88c2c0", Frameless: true}]
+          Type: 333 EventRootType Probe[main.testSingleInt32]
+          InjectionPoints: [{PC: "0x88c6f0", Frameless: true}]
           Condition: null
     - id: testSingleInt64
       version: 0
@@ -1035,8 +1137,8 @@ Probes:
       subprogram: {subprogram: 26}
       events:
         - ID: 26
-          Type: 239 EventRootType Probe[main.testSingleInt64]
-          InjectionPoints: [{PC: "0x88c2d0", Frameless: true}]
+          Type: 334 EventRootType Probe[main.testSingleInt64]
+          InjectionPoints: [{PC: "0x88c700", Frameless: true}]
           Condition: null
     - id: testSingleInt8
       version: 0
@@ -1049,8 +1151,8 @@ Probes:
       subprogram: {subprogram: 23}
       events:
         - ID: 23
-          Type: 236 EventRootType Probe[main.testSingleInt8]
-          InjectionPoints: [{PC: "0x88c2a0", Frameless: true}]
+          Type: 331 EventRootType Probe[main.testSingleInt8]
+          InjectionPoints: [{PC: "0x88c6d0", Frameless: true}]
           Condition: null
     - id: testSingleRune
       version: 0
@@ -1063,8 +1165,8 @@ Probes:
       subprogram: {subprogram: 20}
       events:
         - ID: 20
-          Type: 233 EventRootType Probe[main.testSingleRune]
-          InjectionPoints: [{PC: "0x88c270", Frameless: true}]
+          Type: 328 EventRootType Probe[main.testSingleRune]
+          InjectionPoints: [{PC: "0x88c6a0", Frameless: true}]
           Condition: null
     - id: testSingleString
       version: 0
@@ -1074,11 +1176,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 89}
+      subprogram: {subprogram: 97}
       events:
-        - ID: 89
-          Type: 302 EventRootType Probe[main.testSingleString]
-          InjectionPoints: [{PC: "0x88f660", Frameless: true}]
+        - ID: 97
+          Type: 405 EventRootType Probe[main.testSingleString]
+          InjectionPoints: [{PC: "0x890070", Frameless: true}]
           Condition: null
     - id: testSingleUint
       version: 0
@@ -1091,8 +1193,8 @@ Probes:
       subprogram: {subprogram: 27}
       events:
         - ID: 27
-          Type: 240 EventRootType Probe[main.testSingleUint]
-          InjectionPoints: [{PC: "0x88c2e0", Frameless: true}]
+          Type: 335 EventRootType Probe[main.testSingleUint]
+          InjectionPoints: [{PC: "0x88c710", Frameless: true}]
           Condition: null
     - id: testSingleUint16
       version: 0
@@ -1105,8 +1207,8 @@ Probes:
       subprogram: {subprogram: 29}
       events:
         - ID: 29
-          Type: 242 EventRootType Probe[main.testSingleUint16]
-          InjectionPoints: [{PC: "0x88c300", Frameless: true}]
+          Type: 337 EventRootType Probe[main.testSingleUint16]
+          InjectionPoints: [{PC: "0x88c730", Frameless: true}]
           Condition: null
     - id: testSingleUint32
       version: 0
@@ -1119,8 +1221,8 @@ Probes:
       subprogram: {subprogram: 30}
       events:
         - ID: 30
-          Type: 243 EventRootType Probe[main.testSingleUint32]
-          InjectionPoints: [{PC: "0x88c310", Frameless: true}]
+          Type: 338 EventRootType Probe[main.testSingleUint32]
+          InjectionPoints: [{PC: "0x88c740", Frameless: true}]
           Condition: null
     - id: testSingleUint64
       version: 0
@@ -1133,8 +1235,8 @@ Probes:
       subprogram: {subprogram: 31}
       events:
         - ID: 31
-          Type: 244 EventRootType Probe[main.testSingleUint64]
-          InjectionPoints: [{PC: "0x88c320", Frameless: true}]
+          Type: 339 EventRootType Probe[main.testSingleUint64]
+          InjectionPoints: [{PC: "0x88c750", Frameless: true}]
           Condition: null
     - id: testSingleUint8
       version: 0
@@ -1147,8 +1249,8 @@ Probes:
       subprogram: {subprogram: 28}
       events:
         - ID: 28
-          Type: 241 EventRootType Probe[main.testSingleUint8]
-          InjectionPoints: [{PC: "0x88c2f0", Frameless: true}]
+          Type: 336 EventRootType Probe[main.testSingleUint8]
+          InjectionPoints: [{PC: "0x88c720", Frameless: true}]
           Condition: null
     - id: testSliceOfSlices
       version: 0
@@ -1158,11 +1260,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 80}
+      subprogram: {subprogram: 88}
       events:
-        - ID: 80
-          Type: 293 EventRootType Probe[main.testSliceOfSlices]
-          InjectionPoints: [{PC: "0x88f2b0", Frameless: true}]
+        - ID: 88
+          Type: 396 EventRootType Probe[main.testSliceOfSlices]
+          InjectionPoints: [{PC: "0x88fcc0", Frameless: true}]
           Condition: null
     - id: testSmallMap
       version: 0
@@ -1172,11 +1274,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 52}
+      subprogram: {subprogram: 60}
       events:
-        - ID: 52
-          Type: 265 EventRootType Probe[main.testSmallMap]
-          InjectionPoints: [{PC: "0x88d640", Frameless: true}]
+        - ID: 60
+          Type: 368 EventRootType Probe[main.testSmallMap]
+          InjectionPoints: [{PC: "0x88e050", Frameless: true}]
           Condition: null
     - id: testStringArray
       version: 0
@@ -1189,8 +1291,8 @@ Probes:
       subprogram: {subprogram: 3}
       events:
         - ID: 3
-          Type: 216 EventRootType Probe[main.testStringArray]
-          InjectionPoints: [{PC: "0x88be20", Frameless: true}]
+          Type: 311 EventRootType Probe[main.testStringArray]
+          InjectionPoints: [{PC: "0x88c250", Frameless: true}]
           Condition: null
     - id: testStringPointer
       version: 0
@@ -1200,11 +1302,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 75}
+      subprogram: {subprogram: 83}
       events:
-        - ID: 75
-          Type: 288 EventRootType Probe[main.testStringPointer]
-          InjectionPoints: [{PC: "0x88ee60", Frameless: true}]
+        - ID: 83
+          Type: 391 EventRootType Probe[main.testStringPointer]
+          InjectionPoints: [{PC: "0x88f870", Frameless: true}]
           Condition: null
     - id: testStringSlice
       version: 0
@@ -1214,11 +1316,45 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 84}
+      subprogram: {subprogram: 92}
       events:
-        - ID: 84
-          Type: 297 EventRootType Probe[main.testStringSlice]
-          InjectionPoints: [{PC: "0x88f2f0", Frameless: true}]
+        - ID: 92
+          Type: 400 EventRootType Probe[main.testStringSlice]
+          InjectionPoints: [{PC: "0x88fd00", Frameless: true}]
+          Condition: null
+    - id: testStringType1
+      version: 0
+      type: LOG_PROBE
+      where: {methodName: main.testStringType1}
+      capture:
+        maxReferenceDepth: 1
+        maxFieldCount: 0
+        maxCollectionSize: 0
+      template: ""
+      segments: []
+      captureSnapshot: true
+      subprogram: {subprogram: 42}
+      events:
+        - ID: 42
+          Type: 350 EventRootType Probe[main.testStringType1]
+          InjectionPoints: [{PC: "0x88cc90", Frameless: true}]
+          Condition: null
+    - id: testStringType2
+      version: 0
+      type: LOG_PROBE
+      where: {methodName: main.testStringType2}
+      capture:
+        maxReferenceDepth: 1
+        maxFieldCount: 0
+        maxCollectionSize: 0
+      template: ""
+      segments: []
+      captureSnapshot: true
+      subprogram: {subprogram: 43}
+      events:
+        - ID: 43
+          Type: 351 EventRootType Probe[main.testStringType2]
+          InjectionPoints: [{PC: "0x88cca0", Frameless: true}]
           Condition: null
     - id: testStruct
       version: 0
@@ -1228,11 +1364,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 97}
+      subprogram: {subprogram: 105}
       events:
-        - ID: 97
-          Type: 310 EventRootType Probe[main.testStruct]
-          InjectionPoints: [{PC: "0x88f8f0", Frameless: true}]
+        - ID: 105
+          Type: 413 EventRootType Probe[main.testStruct]
+          InjectionPoints: [{PC: "0x890300", Frameless: true}]
           Condition: null
     - id: testStructSlice
       version: 0
@@ -1242,11 +1378,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 81}
+      subprogram: {subprogram: 89}
       events:
-        - ID: 81
-          Type: 294 EventRootType Probe[main.testStructSlice]
-          InjectionPoints: [{PC: "0x88f2c0", Frameless: true}]
+        - ID: 89
+          Type: 397 EventRootType Probe[main.testStructSlice]
+          InjectionPoints: [{PC: "0x88fcd0", Frameless: true}]
           Condition: null
     - id: testStructWithMap
       version: 0
@@ -1256,11 +1392,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 47}
+      subprogram: {subprogram: 55}
       events:
-        - ID: 47
-          Type: 260 EventRootType Probe[main.testStructWithMap]
-          InjectionPoints: [{PC: "0x88d5f0", Frameless: true}]
+        - ID: 55
+          Type: 363 EventRootType Probe[main.testStructWithMap]
+          InjectionPoints: [{PC: "0x88e000", Frameless: true}]
           Condition: null
     - id: testThreeStrings
       version: 0
@@ -1270,11 +1406,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 90}
+      subprogram: {subprogram: 98}
       events:
-        - ID: 90
-          Type: 303 EventRootType Probe[main.testThreeStrings]
-          InjectionPoints: [{PC: "0x88f670", Frameless: true}]
+        - ID: 98
+          Type: 406 EventRootType Probe[main.testThreeStrings]
+          InjectionPoints: [{PC: "0x890080", Frameless: true}]
           Condition: null
     - id: testThreeStringsInStruct
       version: 0
@@ -1284,11 +1420,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 91}
+      subprogram: {subprogram: 99}
       events:
-        - ID: 91
-          Type: 304 EventRootType Probe[main.testThreeStringsInStruct]
-          InjectionPoints: [{PC: "0x88f680", Frameless: true}]
+        - ID: 99
+          Type: 407 EventRootType Probe[main.testThreeStringsInStruct]
+          InjectionPoints: [{PC: "0x890090", Frameless: true}]
           Condition: null
     - id: testThreeStringsInStructPointer
       version: 0
@@ -1298,11 +1434,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 92}
+      subprogram: {subprogram: 100}
       events:
-        - ID: 92
-          Type: 305 EventRootType Probe[main.testThreeStringsInStructPointer]
-          InjectionPoints: [{PC: "0x88f6a0", Frameless: true}]
+        - ID: 100
+          Type: 408 EventRootType Probe[main.testThreeStringsInStructPointer]
+          InjectionPoints: [{PC: "0x8900b0", Frameless: true}]
           Condition: null
     - id: testTypeAlias
       version: 0
@@ -1315,8 +1451,8 @@ Probes:
       subprogram: {subprogram: 34}
       events:
         - ID: 34
-          Type: 247 EventRootType Probe[main.testTypeAlias]
-          InjectionPoints: [{PC: "0x88c350", Frameless: true}]
+          Type: 342 EventRootType Probe[main.testTypeAlias]
+          InjectionPoints: [{PC: "0x88c780", Frameless: true}]
           Condition: null
     - id: testUint16Array
       version: 0
@@ -1329,8 +1465,8 @@ Probes:
       subprogram: {subprogram: 12}
       events:
         - ID: 12
-          Type: 225 EventRootType Probe[main.testUint16Array]
-          InjectionPoints: [{PC: "0x88beb0", Frameless: true}]
+          Type: 320 EventRootType Probe[main.testUint16Array]
+          InjectionPoints: [{PC: "0x88c2e0", Frameless: true}]
           Condition: null
     - id: testUint32Array
       version: 0
@@ -1343,8 +1479,8 @@ Probes:
       subprogram: {subprogram: 13}
       events:
         - ID: 13
-          Type: 226 EventRootType Probe[main.testUint32Array]
-          InjectionPoints: [{PC: "0x88bec0", Frameless: true}]
+          Type: 321 EventRootType Probe[main.testUint32Array]
+          InjectionPoints: [{PC: "0x88c2f0", Frameless: true}]
           Condition: null
     - id: testUint64Array
       version: 0
@@ -1357,8 +1493,8 @@ Probes:
       subprogram: {subprogram: 14}
       events:
         - ID: 14
-          Type: 227 EventRootType Probe[main.testUint64Array]
-          InjectionPoints: [{PC: "0x88bed0", Frameless: true}]
+          Type: 322 EventRootType Probe[main.testUint64Array]
+          InjectionPoints: [{PC: "0x88c300", Frameless: true}]
           Condition: null
     - id: testUint8Array
       version: 0
@@ -1371,8 +1507,8 @@ Probes:
       subprogram: {subprogram: 11}
       events:
         - ID: 11
-          Type: 224 EventRootType Probe[main.testUint8Array]
-          InjectionPoints: [{PC: "0x88bea0", Frameless: true}]
+          Type: 319 EventRootType Probe[main.testUint8Array]
+          InjectionPoints: [{PC: "0x88c2d0", Frameless: true}]
           Condition: null
     - id: testUintArray
       version: 0
@@ -1385,8 +1521,8 @@ Probes:
       subprogram: {subprogram: 10}
       events:
         - ID: 10
-          Type: 223 EventRootType Probe[main.testUintArray]
-          InjectionPoints: [{PC: "0x88be90", Frameless: true}]
+          Type: 318 EventRootType Probe[main.testUintArray]
+          InjectionPoints: [{PC: "0x88c2c0", Frameless: true}]
           Condition: null
     - id: testUintPointer
       version: 0
@@ -1396,11 +1532,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 74}
+      subprogram: {subprogram: 82}
       events:
-        - ID: 74
-          Type: 287 EventRootType Probe[main.testUintPointer]
-          InjectionPoints: [{PC: "0x88edf0", Frameless: true}]
+        - ID: 82
+          Type: 390 EventRootType Probe[main.testUintPointer]
+          InjectionPoints: [{PC: "0x88f800", Frameless: true}]
           Condition: null
     - id: testUintSlice
       version: 0
@@ -1410,11 +1546,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 78}
+      subprogram: {subprogram: 86}
       events:
-        - ID: 78
-          Type: 291 EventRootType Probe[main.testUintSlice]
-          InjectionPoints: [{PC: "0x88f290", Frameless: true}]
+        - ID: 86
+          Type: 394 EventRootType Probe[main.testUintSlice]
+          InjectionPoints: [{PC: "0x88fca0", Frameless: true}]
           Condition: null
     - id: testUnitializedString
       version: 0
@@ -1424,11 +1560,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 95}
+      subprogram: {subprogram: 103}
       events:
-        - ID: 95
-          Type: 308 EventRootType Probe[main.testUnitializedString]
-          InjectionPoints: [{PC: "0x88f6d0", Frameless: true}]
+        - ID: 103
+          Type: 411 EventRootType Probe[main.testUnitializedString]
+          InjectionPoints: [{PC: "0x8900e0", Frameless: true}]
           Condition: null
     - id: testUnsafePointer
       version: 0
@@ -1438,11 +1574,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 73}
+      subprogram: {subprogram: 81}
       events:
-        - ID: 73
-          Type: 286 EventRootType Probe[main.testUnsafePointer]
-          InjectionPoints: [{PC: "0x88edd0", Frameless: true}]
+        - ID: 81
+          Type: 389 EventRootType Probe[main.testUnsafePointer]
+          InjectionPoints: [{PC: "0x88f7e0", Frameless: true}]
           Condition: null
     - id: testVeryLargeArray
       version: 0
@@ -1455,8 +1591,8 @@ Probes:
       subprogram: {subprogram: 18}
       events:
         - ID: 18
-          Type: 231 EventRootType Probe[main.testVeryLargeArray]
-          InjectionPoints: [{PC: "0x88bf30", Frameless: true}]
+          Type: 326 EventRootType Probe[main.testVeryLargeArray]
+          InjectionPoints: [{PC: "0x88c360", Frameless: true}]
           Condition: null
     - id: testVeryLargeSlice
       version: 0
@@ -1466,430 +1602,430 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 87}
+      subprogram: {subprogram: 95}
       events:
-        - ID: 87
-          Type: 300 EventRootType Probe[main.testVeryLargeSlice]
-          InjectionPoints: [{PC: "0x88f320", Frameless: true}]
+        - ID: 95
+          Type: 403 EventRootType Probe[main.testVeryLargeSlice]
+          InjectionPoints: [{PC: "0x88fd30", Frameless: true}]
           Condition: null
 Subprograms:
     - ID: 1
       Name: main.testByteArray
-      OutOfLinePCRanges: [0x88be00..0x88be10]
+      OutOfLinePCRanges: [0x88c230..0x88c240]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 36 ArrayType [2]uint8
           Locations:
-            - Range: 0x88be00..0x88be10
+            - Range: 0x88c230..0x88c240
               Pieces: [{Size: 2, Op: {CfaOffset: 8}}]
           IsParameter: true
           IsReturn: false
     - ID: 2
       Name: main.testRuneArray
-      OutOfLinePCRanges: [0x88be10..0x88be20]
+      OutOfLinePCRanges: [0x88c240..0x88c250]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 37 ArrayType [2]int32
           Locations:
-            - Range: 0x88be10..0x88be20
+            - Range: 0x88c240..0x88c250
               Pieces: [{Size: 8, Op: {CfaOffset: 8}}]
           IsParameter: true
           IsReturn: false
     - ID: 3
       Name: main.testStringArray
-      OutOfLinePCRanges: [0x88be20..0x88be30]
+      OutOfLinePCRanges: [0x88c250..0x88c260]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 38 ArrayType [2]string
           Locations:
-            - Range: 0x88be20..0x88be30
+            - Range: 0x88c250..0x88c260
               Pieces: [{Size: 32, Op: {CfaOffset: 8}}]
           IsParameter: true
           IsReturn: false
     - ID: 4
       Name: main.testBoolArray
-      OutOfLinePCRanges: [0x88be30..0x88be40]
+      OutOfLinePCRanges: [0x88c260..0x88c270]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 39 ArrayType [2]bool
           Locations:
-            - Range: 0x88be30..0x88be40
+            - Range: 0x88c260..0x88c270
               Pieces: [{Size: 2, Op: {CfaOffset: 8}}]
           IsParameter: true
           IsReturn: false
     - ID: 5
       Name: main.testIntArray
-      OutOfLinePCRanges: [0x88be40..0x88be50]
+      OutOfLinePCRanges: [0x88c270..0x88c280]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 40 ArrayType [2]int
           Locations:
-            - Range: 0x88be40..0x88be50
+            - Range: 0x88c270..0x88c280
               Pieces: [{Size: 16, Op: {CfaOffset: 8}}]
           IsParameter: true
           IsReturn: false
     - ID: 6
       Name: main.testInt8Array
-      OutOfLinePCRanges: [0x88be50..0x88be60]
+      OutOfLinePCRanges: [0x88c280..0x88c290]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 41 ArrayType [2]int8
           Locations:
-            - Range: 0x88be50..0x88be60
+            - Range: 0x88c280..0x88c290
               Pieces: [{Size: 2, Op: {CfaOffset: 8}}]
           IsParameter: true
           IsReturn: false
     - ID: 7
       Name: main.testInt16Array
-      OutOfLinePCRanges: [0x88be60..0x88be70]
+      OutOfLinePCRanges: [0x88c290..0x88c2a0]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 42 ArrayType [2]int16
           Locations:
-            - Range: 0x88be60..0x88be70
+            - Range: 0x88c290..0x88c2a0
               Pieces: [{Size: 4, Op: {CfaOffset: 8}}]
           IsParameter: true
           IsReturn: false
     - ID: 8
       Name: main.testInt32Array
-      OutOfLinePCRanges: [0x88be70..0x88be80]
+      OutOfLinePCRanges: [0x88c2a0..0x88c2b0]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 37 ArrayType [2]int32
           Locations:
-            - Range: 0x88be70..0x88be80
+            - Range: 0x88c2a0..0x88c2b0
               Pieces: [{Size: 8, Op: {CfaOffset: 8}}]
           IsParameter: true
           IsReturn: false
     - ID: 9
       Name: main.testInt64Array
-      OutOfLinePCRanges: [0x88be80..0x88be90]
+      OutOfLinePCRanges: [0x88c2b0..0x88c2c0]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 43 ArrayType [2]int64
           Locations:
-            - Range: 0x88be80..0x88be90
+            - Range: 0x88c2b0..0x88c2c0
               Pieces: [{Size: 16, Op: {CfaOffset: 8}}]
           IsParameter: true
           IsReturn: false
     - ID: 10
       Name: main.testUintArray
-      OutOfLinePCRanges: [0x88be90..0x88bea0]
+      OutOfLinePCRanges: [0x88c2c0..0x88c2d0]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 44 ArrayType [2]uint
           Locations:
-            - Range: 0x88be90..0x88bea0
+            - Range: 0x88c2c0..0x88c2d0
               Pieces: [{Size: 16, Op: {CfaOffset: 8}}]
           IsParameter: true
           IsReturn: false
     - ID: 11
       Name: main.testUint8Array
-      OutOfLinePCRanges: [0x88bea0..0x88beb0]
+      OutOfLinePCRanges: [0x88c2d0..0x88c2e0]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 36 ArrayType [2]uint8
           Locations:
-            - Range: 0x88bea0..0x88beb0
+            - Range: 0x88c2d0..0x88c2e0
               Pieces: [{Size: 2, Op: {CfaOffset: 8}}]
           IsParameter: true
           IsReturn: false
     - ID: 12
       Name: main.testUint16Array
-      OutOfLinePCRanges: [0x88beb0..0x88bec0]
+      OutOfLinePCRanges: [0x88c2e0..0x88c2f0]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 45 ArrayType [2]uint16
           Locations:
-            - Range: 0x88beb0..0x88bec0
+            - Range: 0x88c2e0..0x88c2f0
               Pieces: [{Size: 4, Op: {CfaOffset: 8}}]
           IsParameter: true
           IsReturn: false
     - ID: 13
       Name: main.testUint32Array
-      OutOfLinePCRanges: [0x88bec0..0x88bed0]
+      OutOfLinePCRanges: [0x88c2f0..0x88c300]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 46 ArrayType [2]uint32
           Locations:
-            - Range: 0x88bec0..0x88bed0
+            - Range: 0x88c2f0..0x88c300
               Pieces: [{Size: 8, Op: {CfaOffset: 8}}]
           IsParameter: true
           IsReturn: false
     - ID: 14
       Name: main.testUint64Array
-      OutOfLinePCRanges: [0x88bed0..0x88bee0]
+      OutOfLinePCRanges: [0x88c300..0x88c310]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 47 ArrayType [2]uint64
           Locations:
-            - Range: 0x88bed0..0x88bee0
+            - Range: 0x88c300..0x88c310
               Pieces: [{Size: 16, Op: {CfaOffset: 8}}]
           IsParameter: true
           IsReturn: false
     - ID: 15
       Name: main.testArrayOfArrays
-      OutOfLinePCRanges: [0x88bee0..0x88bef0]
+      OutOfLinePCRanges: [0x88c310..0x88c320]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 48 ArrayType [2][2]int
           Locations:
-            - Range: 0x88bee0..0x88bef0
+            - Range: 0x88c310..0x88c320
               Pieces: [{Size: 32, Op: {CfaOffset: 8}}]
           IsParameter: true
           IsReturn: false
     - ID: 16
       Name: main.testArrayOfStrings
-      OutOfLinePCRanges: [0x88bef0..0x88bf00]
+      OutOfLinePCRanges: [0x88c320..0x88c330]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 38 ArrayType [2]string
           Locations:
-            - Range: 0x88bef0..0x88bf00
+            - Range: 0x88c320..0x88c330
               Pieces: [{Size: 32, Op: {CfaOffset: 8}}]
           IsParameter: true
           IsReturn: false
     - ID: 17
       Name: main.testArrayOfArraysOfArrays
-      OutOfLinePCRanges: [0x88bf00..0x88bf10]
+      OutOfLinePCRanges: [0x88c330..0x88c340]
       InlinePCRanges: []
       Variables:
         - Name: b
           Type: 49 ArrayType [2][2][2]int
           Locations:
-            - Range: 0x88bf00..0x88bf10
+            - Range: 0x88c330..0x88c340
               Pieces: [{Size: 64, Op: {CfaOffset: 8}}]
           IsParameter: true
           IsReturn: false
     - ID: 18
       Name: main.testVeryLargeArray
-      OutOfLinePCRanges: [0x88bf30..0x88bf40]
+      OutOfLinePCRanges: [0x88c360..0x88c370]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 50 ArrayType [100]uint
           Locations:
-            - Range: 0x88bf30..0x88bf40
+            - Range: 0x88c360..0x88c370
               Pieces: [{Size: 800, Op: {CfaOffset: 8}}]
           IsParameter: true
           IsReturn: false
     - ID: 19
       Name: main.testSingleByte
-      OutOfLinePCRanges: [0x88c260..0x88c270]
+      OutOfLinePCRanges: [0x88c690..0x88c6a0]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 3 BaseType uint8
           Locations:
-            - Range: 0x88c260..0x88c270
+            - Range: 0x88c690..0x88c6a0
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
     - ID: 20
       Name: main.testSingleRune
-      OutOfLinePCRanges: [0x88c270..0x88c280]
+      OutOfLinePCRanges: [0x88c6a0..0x88c6b0]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 13 BaseType int32
           Locations:
-            - Range: 0x88c270..0x88c280
+            - Range: 0x88c6a0..0x88c6b0
               Pieces: [{Size: 4, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
     - ID: 21
       Name: main.testSingleBool
-      OutOfLinePCRanges: [0x88c280..0x88c290]
+      OutOfLinePCRanges: [0x88c6b0..0x88c6c0]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 4 BaseType bool
           Locations:
-            - Range: 0x88c280..0x88c290
+            - Range: 0x88c6b0..0x88c6c0
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
     - ID: 22
       Name: main.testSingleInt
-      OutOfLinePCRanges: [0x88c290..0x88c2a0]
+      OutOfLinePCRanges: [0x88c6c0..0x88c6d0]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 9 BaseType int
           Locations:
-            - Range: 0x88c290..0x88c2a0
+            - Range: 0x88c6c0..0x88c6d0
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
     - ID: 23
       Name: main.testSingleInt8
-      OutOfLinePCRanges: [0x88c2a0..0x88c2b0]
+      OutOfLinePCRanges: [0x88c6d0..0x88c6e0]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 15 BaseType int8
           Locations:
-            - Range: 0x88c2a0..0x88c2b0
+            - Range: 0x88c6d0..0x88c6e0
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
     - ID: 24
       Name: main.testSingleInt16
-      OutOfLinePCRanges: [0x88c2b0..0x88c2c0]
+      OutOfLinePCRanges: [0x88c6e0..0x88c6f0]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 23 BaseType int16
           Locations:
-            - Range: 0x88c2b0..0x88c2c0
+            - Range: 0x88c6e0..0x88c6f0
               Pieces: [{Size: 2, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
     - ID: 25
       Name: main.testSingleInt32
-      OutOfLinePCRanges: [0x88c2c0..0x88c2d0]
+      OutOfLinePCRanges: [0x88c6f0..0x88c700]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 13 BaseType int32
           Locations:
-            - Range: 0x88c2c0..0x88c2d0
+            - Range: 0x88c6f0..0x88c700
               Pieces: [{Size: 4, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
     - ID: 26
       Name: main.testSingleInt64
-      OutOfLinePCRanges: [0x88c2d0..0x88c2e0]
+      OutOfLinePCRanges: [0x88c700..0x88c710]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 14 BaseType int64
           Locations:
-            - Range: 0x88c2d0..0x88c2e0
+            - Range: 0x88c700..0x88c710
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
     - ID: 27
       Name: main.testSingleUint
-      OutOfLinePCRanges: [0x88c2e0..0x88c2f0]
+      OutOfLinePCRanges: [0x88c710..0x88c720]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 12 BaseType uint
           Locations:
-            - Range: 0x88c2e0..0x88c2f0
+            - Range: 0x88c710..0x88c720
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
     - ID: 28
       Name: main.testSingleUint8
-      OutOfLinePCRanges: [0x88c2f0..0x88c300]
+      OutOfLinePCRanges: [0x88c720..0x88c730]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 3 BaseType uint8
           Locations:
-            - Range: 0x88c2f0..0x88c300
+            - Range: 0x88c720..0x88c730
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
     - ID: 29
       Name: main.testSingleUint16
-      OutOfLinePCRanges: [0x88c300..0x88c310]
+      OutOfLinePCRanges: [0x88c730..0x88c740]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 7 BaseType uint16
           Locations:
-            - Range: 0x88c300..0x88c310
+            - Range: 0x88c730..0x88c740
               Pieces: [{Size: 2, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
     - ID: 30
       Name: main.testSingleUint32
-      OutOfLinePCRanges: [0x88c310..0x88c320]
+      OutOfLinePCRanges: [0x88c740..0x88c750]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 2 BaseType uint32
           Locations:
-            - Range: 0x88c310..0x88c320
+            - Range: 0x88c740..0x88c750
               Pieces: [{Size: 4, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
     - ID: 31
       Name: main.testSingleUint64
-      OutOfLinePCRanges: [0x88c320..0x88c330]
+      OutOfLinePCRanges: [0x88c750..0x88c760]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 10 BaseType uint64
           Locations:
-            - Range: 0x88c320..0x88c330
+            - Range: 0x88c750..0x88c760
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
     - ID: 32
       Name: main.testSingleFloat32
-      OutOfLinePCRanges: [0x88c330..0x88c340]
+      OutOfLinePCRanges: [0x88c760..0x88c770]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 16 BaseType float32
           Locations:
-            - Range: 0x88c330..0x88c340
+            - Range: 0x88c760..0x88c770
               Pieces: [{Size: 4, Op: {RegNo: 64, Shift: 0}}]
           IsParameter: true
           IsReturn: false
     - ID: 33
       Name: main.testSingleFloat64
-      OutOfLinePCRanges: [0x88c340..0x88c350]
+      OutOfLinePCRanges: [0x88c770..0x88c780]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 17 BaseType float64
           Locations:
-            - Range: 0x88c340..0x88c350
+            - Range: 0x88c770..0x88c780
               Pieces: [{Size: 8, Op: {RegNo: 64, Shift: 0}}]
           IsParameter: true
           IsReturn: false
     - ID: 34
       Name: main.testTypeAlias
-      OutOfLinePCRanges: [0x88c350..0x88c360]
+      OutOfLinePCRanges: [0x88c780..0x88c790]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 51 BaseType main.typeAlias
           Locations:
-            - Range: 0x88c350..0x88c360
+            - Range: 0x88c780..0x88c790
               Pieces: [{Size: 2, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
     - ID: 35
       Name: main.testBigStruct
-      OutOfLinePCRanges: [0x88c460..0x88c480]
+      OutOfLinePCRanges: [0x88c890..0x88c8b0]
       InlinePCRanges: []
       Variables:
         - Name: b
           Type: 52 StructureType main.bigStruct
           Locations:
-            - Range: 0x88c460..0x88c480
+            - Range: 0x88c890..0x88c8b0
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -1906,14 +2042,116 @@ Subprograms:
           IsParameter: true
           IsReturn: false
     - ID: 36
+      Name: main.testDeepPtr1
+      OutOfLinePCRanges: [0x88c960..0x88c970]
+      InlinePCRanges: []
+      Variables:
+        - Name: a
+          Type: 56 StructureType main.deepPtr1
+          Locations:
+            - Range: 0x88c960..0x88c970
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+          IsParameter: true
+          IsReturn: false
+    - ID: 37
+      Name: main.testDeepPtr7
+      OutOfLinePCRanges: [0x88c970..0x88c980]
+      InlinePCRanges: []
+      Variables:
+        - Name: a
+          Type: 59 PointerType *main.deepPtr7
+          Locations:
+            - Range: 0x88c970..0x88c980
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+          IsParameter: true
+          IsReturn: false
+    - ID: 38
+      Name: main.testDeepSlice1
+      OutOfLinePCRanges: [0x88cb10..0x88cb20]
+      InlinePCRanges: []
+      Variables:
+        - Name: a
+          Type: 61 StructureType main.deepSlice1
+          Locations:
+            - Range: 0x88cb10..0x88cb20
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 0, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 1, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 2, Shift: 0}
+          IsParameter: true
+          IsReturn: false
+    - ID: 39
+      Name: main.testDeepSlice7
+      OutOfLinePCRanges: [0x88cb20..0x88cb30]
+      InlinePCRanges: []
+      Variables:
+        - Name: a
+          Type: 65 PointerType *main.deepSlice7
+          Locations:
+            - Range: 0x88cb20..0x88cb30
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+          IsParameter: true
+          IsReturn: false
+    - ID: 40
+      Name: main.testDeepMap1
+      OutOfLinePCRanges: [0x88cc70..0x88cc80]
+      InlinePCRanges: []
+      Variables:
+        - Name: a
+          Type: 67 StructureType main.deepMap1
+          Locations:
+            - Range: 0x88cc70..0x88cc80
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+          IsParameter: true
+          IsReturn: false
+    - ID: 41
+      Name: main.testDeepMap7
+      OutOfLinePCRanges: [0x88cc80..0x88cc90]
+      InlinePCRanges: []
+      Variables:
+        - Name: a
+          Type: 75 PointerType *main.deepMap7
+          Locations:
+            - Range: 0x88cc80..0x88cc90
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+          IsParameter: true
+          IsReturn: false
+    - ID: 42
+      Name: main.testStringType1
+      OutOfLinePCRanges: [0x88cc90..0x88cca0]
+      InlinePCRanges: []
+      Variables:
+        - Name: a
+          Type: 77 PointerType *main.stringType1
+          Locations:
+            - Range: 0x88cc90..0x88cca0
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+          IsParameter: true
+          IsReturn: false
+    - ID: 43
+      Name: main.testStringType2
+      OutOfLinePCRanges: [0x88cca0..0x88ccb0]
+      InlinePCRanges: []
+      Variables:
+        - Name: a
+          Type: 79 PointerType **main.stringType2
+          Locations:
+            - Range: 0x88cca0..0x88ccb0
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+          IsParameter: true
+          IsReturn: false
+    - ID: 44
       Name: main.testEsotericStack
-      OutOfLinePCRanges: [0x88c620..0x88c710]
+      OutOfLinePCRanges: [0x88d030..0x88d120]
       InlinePCRanges: []
       Variables:
         - Name: e
-          Type: 56 StructureType main.esotericStack
+          Type: 81 StructureType main.esotericStack
           Locations:
-            - Range: 0x88c620..0x88c668
+            - Range: 0x88d030..0x88d078
               Pieces:
                 - Size: 4
                   Op: {RegNo: 0, Shift: 0}
@@ -1933,7 +2171,7 @@ Subprograms:
                   Op: {RegNo: 7, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 8, Shift: 0}
-            - Range: 0x88c668..0x88c66c
+            - Range: 0x88d078..0x88d07c
               Pieces:
                 - Size: 4
                   Op: null
@@ -1953,7 +2191,7 @@ Subprograms:
                   Op: {RegNo: 7, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 8, Shift: 0}
-            - Range: 0x88c66c..0x88c670
+            - Range: 0x88d07c..0x88d080
               Pieces:
                 - Size: 4
                   Op: null
@@ -1975,146 +2213,146 @@ Subprograms:
                   Op: {RegNo: 8, Shift: 0}
           IsParameter: true
           IsReturn: false
-    - ID: 37
+    - ID: 45
       Name: main.testEsotericHeap
-      OutOfLinePCRanges: [0x88c710..0x88c790]
+      OutOfLinePCRanges: [0x88d120..0x88d1a0]
       InlinePCRanges: []
       Variables:
         - Name: e
-          Type: 61 PointerType *main.esotericHeap
+          Type: 86 PointerType *main.esotericHeap
           Locations:
-            - Range: 0x88c710..0x88c748
+            - Range: 0x88d120..0x88d158
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 38
+    - ID: 46
       Name: main.testInlinedBA
-      OutOfLinePCRanges: [0x88cb50..0x88cbe0]
+      OutOfLinePCRanges: [0x88d560..0x88d5f0]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 9 BaseType int
           Locations:
-            - Range: 0x88cb50..0x88cb88
+            - Range: 0x88d560..0x88d598
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 39
+    - ID: 47
       Name: main.testInlinedBB
-      OutOfLinePCRanges: [0x88cbe0..0x88ccb0]
+      OutOfLinePCRanges: [0x88d5f0..0x88d6c0]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 9 BaseType int
           Locations:
-            - Range: 0x88cbe0..0x88cbfc
+            - Range: 0x88d5f0..0x88d60c
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
         - Name: y
           Type: 9 BaseType int
           Locations:
-            - Range: 0x88cbe0..0x88cc0c
+            - Range: 0x88d5f0..0x88d61c
               Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
           IsParameter: true
           IsReturn: false
         - Name: z
           Type: 9 BaseType int
           Locations:
-            - Range: 0x88cbfc..0x88cc0c
+            - Range: 0x88d60c..0x88d61c
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x88cc0c..0x88ccb0
+            - Range: 0x88d61c..0x88d6c0
               Pieces: [{Size: 8, Op: {CfaOffset: -48}}]
           IsParameter: false
           IsReturn: false
-    - ID: 40
+    - ID: 48
       Name: main.testInlinedBBA
-      OutOfLinePCRanges: [0x88ccb0..0x88cd30]
+      OutOfLinePCRanges: [0x88d6c0..0x88d740]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 9 BaseType int
           Locations:
-            - Range: 0x88ccb0..0x88ccd4
+            - Range: 0x88d6c0..0x88d6e4
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 41
+    - ID: 49
       Name: main.testInlinedBC
-      OutOfLinePCRanges: [0x88cd30..0x88ce50]
+      OutOfLinePCRanges: [0x88d740..0x88d860]
       InlinePCRanges: []
       Variables:
         - Name: s
           Type: 9 BaseType int
           Locations:
-            - Range: 0x88cd98..0x88cda0
+            - Range: 0x88d7a8..0x88d7b0
               Pieces: [{Size: 8, Op: {CfaOffset: -72}}]
-            - Range: 0x88cda0..0x88cdb8
+            - Range: 0x88d7b0..0x88d7c8
               Pieces: [{Size: 8, Op: {CfaOffset: -72}}]
-            - Range: 0x88cdb8..0x88cdcc
+            - Range: 0x88d7c8..0x88d7dc
               Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
           IsParameter: false
           IsReturn: false
         - Name: i
           Type: 9 BaseType int
           Locations:
-            - Range: 0x88cd94..0x88cd9c
+            - Range: 0x88d7a4..0x88d7ac
               Pieces: [{Size: 8, Op: {CfaOffset: -64}}]
-            - Range: 0x88cd9c..0x88cdb8
+            - Range: 0x88d7ac..0x88d7c8
               Pieces: [{Size: 8, Op: {CfaOffset: -64}}]
-            - Range: 0x88cdb8..0x88cdc8
+            - Range: 0x88d7c8..0x88d7d8
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: false
           IsReturn: false
-    - ID: 42
+    - ID: 50
       Name: main.testFrameless
-      OutOfLinePCRanges: [0x88ce50..0x88ce60]
+      OutOfLinePCRanges: [0x88d860..0x88d870]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 9 BaseType int
           Locations:
-            - Range: 0x88ce50..0x88ce58
+            - Range: 0x88d860..0x88d868
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
         - Name: ~r0
           Type: 9 BaseType int
-          Locations: [{Range: 0x88ce50..0x88ce60, Pieces: []}]
+          Locations: [{Range: 0x88d860..0x88d870, Pieces: []}]
           IsParameter: true
           IsReturn: true
-    - ID: 43
+    - ID: 51
       Name: main.testFramelessArray
-      OutOfLinePCRanges: [0x88ce60..0x88cec0]
+      OutOfLinePCRanges: [0x88d870..0x88d8d0]
       InlinePCRanges: []
       Variables:
         - Name: a
-          Type: 63 ArrayType [5]int
+          Type: 88 ArrayType [5]int
           Locations:
-            - Range: 0x88ce60..0x88cec0
+            - Range: 0x88d870..0x88d8d0
               Pieces: [{Size: 40, Op: {CfaOffset: 8}}]
           IsParameter: true
           IsReturn: false
         - Name: ~r0
           Type: 9 BaseType int
-          Locations: [{Range: 0x88ce60..0x88cec0, Pieces: []}]
+          Locations: [{Range: 0x88d870..0x88d8d0, Pieces: []}]
           IsParameter: true
           IsReturn: true
-    - ID: 44
+    - ID: 52
       Name: main.testInterface
-      OutOfLinePCRanges: [0x88d100..0x88d160]
+      OutOfLinePCRanges: [0x88db10..0x88db70]
       InlinePCRanges: []
       Variables:
         - Name: b
-          Type: 64 GoInterfaceType main.behavior
+          Type: 89 GoInterfaceType main.behavior
           Locations:
-            - Range: 0x88d100..0x88d128
+            - Range: 0x88db10..0x88db38
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0x88d128..0x88d12c
+            - Range: 0x88db38..0x88db3c
               Pieces:
                 - Size: 8
                   Op: null
@@ -2124,24 +2362,24 @@ Subprograms:
           IsReturn: false
         - Name: ~r0
           Type: 11 GoStringHeaderType string
-          Locations: [{Range: 0x88d100..0x88d160, Pieces: []}]
+          Locations: [{Range: 0x88db10..0x88db70, Pieces: []}]
           IsParameter: true
           IsReturn: true
-    - ID: 45
+    - ID: 53
       Name: main.testAny
-      OutOfLinePCRanges: [0x88d160..0x88d1d0]
+      OutOfLinePCRanges: [0x88db70..0x88dbe0]
       InlinePCRanges: []
       Variables:
         - Name: a
-          Type: 58 GoEmptyInterfaceType interface {}
+          Type: 83 GoEmptyInterfaceType interface {}
           Locations:
-            - Range: 0x88d160..0x88d190
+            - Range: 0x88db70..0x88dba0
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0x88d190..0x88d194
+            - Range: 0x88dba0..0x88dba4
               Pieces:
                 - Size: 8
                   Op: null
@@ -2151,18 +2389,18 @@ Subprograms:
           IsReturn: false
         - Name: ~r0
           Type: 11 GoStringHeaderType string
-          Locations: [{Range: 0x88d160..0x88d1d0, Pieces: []}]
+          Locations: [{Range: 0x88db70..0x88dbe0, Pieces: []}]
           IsParameter: true
           IsReturn: true
-    - ID: 46
+    - ID: 54
       Name: main.testError
-      OutOfLinePCRanges: [0x88d1d0..0x88d1e0]
+      OutOfLinePCRanges: [0x88dbe0..0x88dbf0]
       InlinePCRanges: []
       Variables:
         - Name: e
           Type: 18 GoInterfaceType error
           Locations:
-            - Range: 0x88d1d0..0x88d1e0
+            - Range: 0x88dbe0..0x88dbf0
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -2170,309 +2408,309 @@ Subprograms:
                   Op: {RegNo: 1, Shift: 0}
           IsParameter: true
           IsReturn: false
-    - ID: 47
+    - ID: 55
       Name: main.testStructWithMap
-      OutOfLinePCRanges: [0x88d5f0..0x88d600]
+      OutOfLinePCRanges: [0x88e000..0x88e010]
       InlinePCRanges: []
       Variables:
         - Name: s
-          Type: 65 StructureType main.structWithMap
+          Type: 90 StructureType main.structWithMap
           Locations:
-            - Range: 0x88d5f0..0x88d600
-              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-          IsParameter: true
-          IsReturn: false
-    - ID: 48
-      Name: main.testMapStringToStruct
-      OutOfLinePCRanges: [0x88d600..0x88d610]
-      InlinePCRanges: []
-      Variables:
-        - Name: m
-          Type: 73 GoMapType map[string]main.nestedStruct
-          Locations:
-            - Range: 0x88d600..0x88d610
-              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-          IsParameter: true
-          IsReturn: false
-    - ID: 49
-      Name: main.testMapStringToInt
-      OutOfLinePCRanges: [0x88d610..0x88d620]
-      InlinePCRanges: []
-      Variables:
-        - Name: m
-          Type: 78 GoMapType map[string]int
-          Locations:
-            - Range: 0x88d610..0x88d620
-              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-          IsParameter: true
-          IsReturn: false
-    - ID: 50
-      Name: main.testMapStringToSlice
-      OutOfLinePCRanges: [0x88d620..0x88d630]
-      InlinePCRanges: []
-      Variables:
-        - Name: m
-          Type: 83 GoMapType map[string][]string
-          Locations:
-            - Range: 0x88d620..0x88d630
-              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-          IsParameter: true
-          IsReturn: false
-    - ID: 51
-      Name: main.testMapArrayToArray
-      OutOfLinePCRanges: [0x88d630..0x88d640]
-      InlinePCRanges: []
-      Variables:
-        - Name: m
-          Type: 88 GoMapType map[[4]string][2]int
-          Locations:
-            - Range: 0x88d630..0x88d640
-              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-          IsParameter: true
-          IsReturn: false
-    - ID: 52
-      Name: main.testSmallMap
-      OutOfLinePCRanges: [0x88d640..0x88d650]
-      InlinePCRanges: []
-      Variables:
-        - Name: m
-          Type: 78 GoMapType map[string]int
-          Locations:
-            - Range: 0x88d640..0x88d650
-              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-          IsParameter: true
-          IsReturn: false
-    - ID: 53
-      Name: main.testArrayOfMaps
-      OutOfLinePCRanges: [0x88d650..0x88d660]
-      InlinePCRanges: []
-      Variables:
-        - Name: m
-          Type: 93 ArrayType [2]map[string]int
-          Locations:
-            - Range: 0x88d650..0x88d660
-              Pieces: [{Size: 16, Op: {CfaOffset: 8}}]
-          IsParameter: true
-          IsReturn: false
-    - ID: 54
-      Name: main.testPointerToMap
-      OutOfLinePCRanges: [0x88d660..0x88d670]
-      InlinePCRanges: []
-      Variables:
-        - Name: m
-          Type: 94 PointerType *map[string]int
-          Locations:
-            - Range: 0x88d660..0x88d670
-              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-          IsParameter: true
-          IsReturn: false
-    - ID: 55
-      Name: main.testMapIntToInt
-      OutOfLinePCRanges: [0x88d670..0x88d680]
-      InlinePCRanges: []
-      Variables:
-        - Name: m
-          Type: 66 GoMapType map[int]int
-          Locations:
-            - Range: 0x88d670..0x88d680
+            - Range: 0x88e000..0x88e010
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
     - ID: 56
-      Name: main.testMapMassive
-      OutOfLinePCRanges: [0x88d680..0x88d690]
+      Name: main.testMapStringToStruct
+      OutOfLinePCRanges: [0x88e010..0x88e020]
       InlinePCRanges: []
       Variables:
-        - Name: redactMyEntries
-          Type: 95 GoMapType map[string][]main.structWithMap
+        - Name: m
+          Type: 96 GoMapType map[string]main.nestedStruct
           Locations:
-            - Range: 0x88d680..0x88d690
+            - Range: 0x88e010..0x88e020
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
     - ID: 57
-      Name: main.testMapEmbeddedMaps
-      OutOfLinePCRanges: [0x88d690..0x88d6a0]
+      Name: main.testMapStringToInt
+      OutOfLinePCRanges: [0x88e020..0x88e030]
       InlinePCRanges: []
       Variables:
         - Name: m
-          Type: 95 GoMapType map[string][]main.structWithMap
+          Type: 101 GoMapType map[string]int
           Locations:
-            - Range: 0x88d690..0x88d6a0
+            - Range: 0x88e020..0x88e030
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
     - ID: 58
-      Name: main.testMapWithLinkedList
-      OutOfLinePCRanges: [0x88d6a0..0x88d6b0]
+      Name: main.testMapStringToSlice
+      OutOfLinePCRanges: [0x88e030..0x88e040]
       InlinePCRanges: []
       Variables:
         - Name: m
-          Type: 100 GoMapType map[bool]main.node
+          Type: 106 GoMapType map[string][]string
           Locations:
-            - Range: 0x88d6a0..0x88d6b0
+            - Range: 0x88e030..0x88e040
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
     - ID: 59
-      Name: main.testMapWithSmallValue
-      OutOfLinePCRanges: [0x88d6b0..0x88d6c0]
+      Name: main.testMapArrayToArray
+      OutOfLinePCRanges: [0x88e040..0x88e050]
       InlinePCRanges: []
       Variables:
         - Name: m
-          Type: 105 GoMapType map[int]uint8
+          Type: 111 GoMapType map[[4]string][2]int
           Locations:
-            - Range: 0x88d6b0..0x88d6c0
+            - Range: 0x88e040..0x88e050
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
     - ID: 60
-      Name: main.testMapWithSmallValueMassive
-      OutOfLinePCRanges: [0x88d6c0..0x88d6d0]
+      Name: main.testSmallMap
+      OutOfLinePCRanges: [0x88e050..0x88e060]
       InlinePCRanges: []
       Variables:
-        - Name: redactMyEntries
-          Type: 105 GoMapType map[int]uint8
+        - Name: m
+          Type: 101 GoMapType map[string]int
           Locations:
-            - Range: 0x88d6c0..0x88d6d0
+            - Range: 0x88e050..0x88e060
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
     - ID: 61
-      Name: main.testMapWithSmallKeyAndValue
-      OutOfLinePCRanges: [0x88d6d0..0x88d6e0]
+      Name: main.testArrayOfMaps
+      OutOfLinePCRanges: [0x88e060..0x88e070]
       InlinePCRanges: []
       Variables:
         - Name: m
-          Type: 110 GoMapType map[uint8]uint8
+          Type: 116 ArrayType [2]map[string]int
           Locations:
-            - Range: 0x88d6d0..0x88d6e0
-              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+            - Range: 0x88e060..0x88e070
+              Pieces: [{Size: 16, Op: {CfaOffset: 8}}]
           IsParameter: true
           IsReturn: false
     - ID: 62
-      Name: main.testMapWithSmallKeyAndValueMassive
-      OutOfLinePCRanges: [0x88d6e0..0x88d6f0]
+      Name: main.testPointerToMap
+      OutOfLinePCRanges: [0x88e070..0x88e080]
       InlinePCRanges: []
       Variables:
         - Name: m
-          Type: 110 GoMapType map[uint8]uint8
+          Type: 117 PointerType *map[string]int
           Locations:
-            - Range: 0x88d6e0..0x88d6f0
+            - Range: 0x88e070..0x88e080
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
     - ID: 63
-      Name: main.testMapSmallKeySmallValue
-      OutOfLinePCRanges: [0x88d6f0..0x88d700]
+      Name: main.testMapIntToInt
+      OutOfLinePCRanges: [0x88e080..0x88e090]
       InlinePCRanges: []
       Variables:
         - Name: m
-          Type: 110 GoMapType map[uint8]uint8
+          Type: 91 GoMapType map[int]int
           Locations:
-            - Range: 0x88d6f0..0x88d700
+            - Range: 0x88e080..0x88e090
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
     - ID: 64
-      Name: main.testMapSmallKeyLargeValue
-      OutOfLinePCRanges: [0x88d700..0x88d710]
+      Name: main.testMapMassive
+      OutOfLinePCRanges: [0x88e090..0x88e0a0]
       InlinePCRanges: []
       Variables:
-        - Name: m
-          Type: 115 GoMapType map[uint8][4]int
+        - Name: redactMyEntries
+          Type: 118 GoMapType map[string][]main.structWithMap
           Locations:
-            - Range: 0x88d700..0x88d710
+            - Range: 0x88e090..0x88e0a0
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
     - ID: 65
-      Name: main.testMapLargeKeySmallValue
-      OutOfLinePCRanges: [0x88d710..0x88d720]
+      Name: main.testMapEmbeddedMaps
+      OutOfLinePCRanges: [0x88e0a0..0x88e0b0]
       InlinePCRanges: []
       Variables:
         - Name: m
-          Type: 120 GoMapType map[[4]int]uint8
+          Type: 118 GoMapType map[string][]main.structWithMap
           Locations:
-            - Range: 0x88d710..0x88d720
+            - Range: 0x88e0a0..0x88e0b0
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
     - ID: 66
-      Name: main.testMapLargeKeyLargeValue
-      OutOfLinePCRanges: [0x88d720..0x88d730]
+      Name: main.testMapWithLinkedList
+      OutOfLinePCRanges: [0x88e0b0..0x88e0c0]
       InlinePCRanges: []
       Variables:
         - Name: m
-          Type: 125 GoMapType map[[4]int][4]int
+          Type: 123 GoMapType map[bool]main.node
           Locations:
-            - Range: 0x88d720..0x88d730
+            - Range: 0x88e0b0..0x88e0c0
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
     - ID: 67
+      Name: main.testMapWithSmallValue
+      OutOfLinePCRanges: [0x88e0c0..0x88e0d0]
+      InlinePCRanges: []
+      Variables:
+        - Name: m
+          Type: 128 GoMapType map[int]uint8
+          Locations:
+            - Range: 0x88e0c0..0x88e0d0
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+          IsParameter: true
+          IsReturn: false
+    - ID: 68
+      Name: main.testMapWithSmallValueMassive
+      OutOfLinePCRanges: [0x88e0d0..0x88e0e0]
+      InlinePCRanges: []
+      Variables:
+        - Name: redactMyEntries
+          Type: 128 GoMapType map[int]uint8
+          Locations:
+            - Range: 0x88e0d0..0x88e0e0
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+          IsParameter: true
+          IsReturn: false
+    - ID: 69
+      Name: main.testMapWithSmallKeyAndValue
+      OutOfLinePCRanges: [0x88e0e0..0x88e0f0]
+      InlinePCRanges: []
+      Variables:
+        - Name: m
+          Type: 133 GoMapType map[uint8]uint8
+          Locations:
+            - Range: 0x88e0e0..0x88e0f0
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+          IsParameter: true
+          IsReturn: false
+    - ID: 70
+      Name: main.testMapWithSmallKeyAndValueMassive
+      OutOfLinePCRanges: [0x88e0f0..0x88e100]
+      InlinePCRanges: []
+      Variables:
+        - Name: m
+          Type: 133 GoMapType map[uint8]uint8
+          Locations:
+            - Range: 0x88e0f0..0x88e100
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+          IsParameter: true
+          IsReturn: false
+    - ID: 71
+      Name: main.testMapSmallKeySmallValue
+      OutOfLinePCRanges: [0x88e100..0x88e110]
+      InlinePCRanges: []
+      Variables:
+        - Name: m
+          Type: 133 GoMapType map[uint8]uint8
+          Locations:
+            - Range: 0x88e100..0x88e110
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+          IsParameter: true
+          IsReturn: false
+    - ID: 72
+      Name: main.testMapSmallKeyLargeValue
+      OutOfLinePCRanges: [0x88e110..0x88e120]
+      InlinePCRanges: []
+      Variables:
+        - Name: m
+          Type: 138 GoMapType map[uint8][4]int
+          Locations:
+            - Range: 0x88e110..0x88e120
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+          IsParameter: true
+          IsReturn: false
+    - ID: 73
+      Name: main.testMapLargeKeySmallValue
+      OutOfLinePCRanges: [0x88e120..0x88e130]
+      InlinePCRanges: []
+      Variables:
+        - Name: m
+          Type: 143 GoMapType map[[4]int]uint8
+          Locations:
+            - Range: 0x88e120..0x88e130
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+          IsParameter: true
+          IsReturn: false
+    - ID: 74
+      Name: main.testMapLargeKeyLargeValue
+      OutOfLinePCRanges: [0x88e130..0x88e140]
+      InlinePCRanges: []
+      Variables:
+        - Name: m
+          Type: 148 GoMapType map[[4]int][4]int
+          Locations:
+            - Range: 0x88e130..0x88e140
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+          IsParameter: true
+          IsReturn: false
+    - ID: 75
       Name: main.testCombinedByte
-      OutOfLinePCRanges: [0x88e980..0x88e990]
+      OutOfLinePCRanges: [0x88f390..0x88f3a0]
       InlinePCRanges: []
       Variables:
         - Name: w
           Type: 3 BaseType uint8
           Locations:
-            - Range: 0x88e980..0x88e990
+            - Range: 0x88f390..0x88f3a0
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
         - Name: x
           Type: 3 BaseType uint8
           Locations:
-            - Range: 0x88e980..0x88e990
+            - Range: 0x88f390..0x88f3a0
               Pieces: [{Size: 1, Op: {RegNo: 1, Shift: 0}}]
           IsParameter: true
           IsReturn: false
         - Name: y
           Type: 16 BaseType float32
           Locations:
-            - Range: 0x88e980..0x88e990
+            - Range: 0x88f390..0x88f3a0
               Pieces: [{Size: 4, Op: {RegNo: 64, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 68
+    - ID: 76
       Name: main.testMultipleSimpleParams
-      OutOfLinePCRanges: [0x88ea60..0x88ea70]
+      OutOfLinePCRanges: [0x88f470..0x88f480]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 4 BaseType bool
           Locations:
-            - Range: 0x88ea60..0x88ea70
+            - Range: 0x88f470..0x88f480
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
         - Name: b
           Type: 3 BaseType uint8
           Locations:
-            - Range: 0x88ea60..0x88ea70
+            - Range: 0x88f470..0x88f480
               Pieces: [{Size: 1, Op: {RegNo: 1, Shift: 0}}]
           IsParameter: true
           IsReturn: false
         - Name: c
           Type: 13 BaseType int32
           Locations:
-            - Range: 0x88ea60..0x88ea70
+            - Range: 0x88f470..0x88f480
               Pieces: [{Size: 4, Op: {RegNo: 2, Shift: 0}}]
           IsParameter: true
           IsReturn: false
         - Name: d
           Type: 12 BaseType uint
           Locations:
-            - Range: 0x88ea60..0x88ea70
+            - Range: 0x88f470..0x88f480
               Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
           IsParameter: true
           IsReturn: false
         - Name: e
           Type: 11 GoStringHeaderType string
           Locations:
-            - Range: 0x88ea60..0x88ea70
+            - Range: 0x88f470..0x88f480
               Pieces:
                 - Size: 8
                   Op: {RegNo: 4, Shift: 0}
@@ -2480,39 +2718,39 @@ Subprograms:
                   Op: {RegNo: 5, Shift: 0}
           IsParameter: true
           IsReturn: false
-    - ID: 69
+    - ID: 77
       Name: main.testChannel
-      OutOfLinePCRanges: [0x88ec00..0x88ec10]
+      OutOfLinePCRanges: [0x88f610..0x88f620]
       InlinePCRanges: []
       Variables:
         - Name: c
-          Type: 130 GoChannelType chan bool
+          Type: 153 GoChannelType chan bool
           Locations:
-            - Range: 0x88ec00..0x88ec10
+            - Range: 0x88f610..0x88f620
               Pieces: [{Size: 0, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 70
+    - ID: 78
       Name: main.testPointerToSimpleStruct
-      OutOfLinePCRanges: [0x88eda0..0x88edb0]
+      OutOfLinePCRanges: [0x88f7b0..0x88f7c0]
       InlinePCRanges: []
       Variables:
         - Name: a
-          Type: 131 PointerType *main.structWithTwoValues
+          Type: 154 PointerType *main.structWithTwoValues
           Locations:
-            - Range: 0x88eda0..0x88edb0
+            - Range: 0x88f7b0..0x88f7c0
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 71
+    - ID: 79
       Name: main.testLinkedList
-      OutOfLinePCRanges: [0x88edb0..0x88edc0]
+      OutOfLinePCRanges: [0x88f7c0..0x88f7d0]
       InlinePCRanges: []
       Variables:
         - Name: a
-          Type: 133 StructureType main.node
+          Type: 156 StructureType main.node
           Locations:
-            - Range: 0x88edb0..0x88edc0
+            - Range: 0x88f7c0..0x88f7d0
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -2520,273 +2758,94 @@ Subprograms:
                   Op: {RegNo: 1, Shift: 0}
           IsParameter: true
           IsReturn: false
-    - ID: 72
+    - ID: 80
       Name: main.testPointerLoop
-      OutOfLinePCRanges: [0x88edc0..0x88edd0]
+      OutOfLinePCRanges: [0x88f7d0..0x88f7e0]
       InlinePCRanges: []
       Variables:
         - Name: a
-          Type: 134 PointerType *main.node
+          Type: 157 PointerType *main.node
           Locations:
-            - Range: 0x88edc0..0x88edd0
+            - Range: 0x88f7d0..0x88f7e0
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 73
+    - ID: 81
       Name: main.testUnsafePointer
-      OutOfLinePCRanges: [0x88edd0..0x88ede0]
+      OutOfLinePCRanges: [0x88f7e0..0x88f7f0]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 19 VoidPointerType unsafe.Pointer
           Locations:
-            - Range: 0x88edd0..0x88ede0
+            - Range: 0x88f7e0..0x88f7f0
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 74
+    - ID: 82
       Name: main.testUintPointer
-      OutOfLinePCRanges: [0x88edf0..0x88ee00]
+      OutOfLinePCRanges: [0x88f800..0x88f810]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 34 PointerType *uint
           Locations:
-            - Range: 0x88edf0..0x88ee00
+            - Range: 0x88f800..0x88f810
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 75
+    - ID: 83
       Name: main.testStringPointer
-      OutOfLinePCRanges: [0x88ee60..0x88ee70]
+      OutOfLinePCRanges: [0x88f870..0x88f880]
       InlinePCRanges: []
       Variables:
         - Name: z
           Type: 22 PointerType *string
           Locations:
-            - Range: 0x88ee60..0x88ee70
+            - Range: 0x88f870..0x88f880
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 76
+    - ID: 84
       Name: main.testNilPointer
-      OutOfLinePCRanges: [0x88ee80..0x88ee90]
+      OutOfLinePCRanges: [0x88f890..0x88f8a0]
       InlinePCRanges: []
       Variables:
         - Name: z
           Type: 5 PointerType *bool
           Locations:
-            - Range: 0x88ee80..0x88ee90
+            - Range: 0x88f890..0x88f8a0
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
         - Name: a
           Type: 12 BaseType uint
           Locations:
-            - Range: 0x88ee80..0x88ee90
+            - Range: 0x88f890..0x88f8a0
               Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 77
+    - ID: 85
       Name: main.testCycle
-      OutOfLinePCRanges: [0x88eea0..0x88eeb0]
+      OutOfLinePCRanges: [0x88f8b0..0x88f8c0]
       InlinePCRanges: []
       Variables:
         - Name: t
-          Type: 135 PointerType *main.t
+          Type: 158 PointerType *main.t
           Locations:
-            - Range: 0x88eea0..0x88eeb0
+            - Range: 0x88f8b0..0x88f8c0
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 78
-      Name: main.testUintSlice
-      OutOfLinePCRanges: [0x88f290..0x88f2a0]
-      InlinePCRanges: []
-      Variables:
-        - Name: u
-          Type: 137 GoSliceHeaderType []uint
-          Locations:
-            - Range: 0x88f290..0x88f2a0
-              Pieces:
-                - Size: 8
-                  Op: {RegNo: 0, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 1, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 2, Shift: 0}
-          IsParameter: true
-          IsReturn: false
-    - ID: 79
-      Name: main.testEmptySlice
-      OutOfLinePCRanges: [0x88f2a0..0x88f2b0]
-      InlinePCRanges: []
-      Variables:
-        - Name: u
-          Type: 137 GoSliceHeaderType []uint
-          Locations:
-            - Range: 0x88f2a0..0x88f2b0
-              Pieces:
-                - Size: 8
-                  Op: {RegNo: 0, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 1, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 2, Shift: 0}
-          IsParameter: true
-          IsReturn: false
-    - ID: 80
-      Name: main.testSliceOfSlices
-      OutOfLinePCRanges: [0x88f2b0..0x88f2c0]
-      InlinePCRanges: []
-      Variables:
-        - Name: u
-          Type: 138 GoSliceHeaderType [][]uint
-          Locations:
-            - Range: 0x88f2b0..0x88f2c0
-              Pieces:
-                - Size: 8
-                  Op: {RegNo: 0, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 1, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 2, Shift: 0}
-          IsParameter: true
-          IsReturn: false
-    - ID: 81
-      Name: main.testStructSlice
-      OutOfLinePCRanges: [0x88f2c0..0x88f2d0]
-      InlinePCRanges: []
-      Variables:
-        - Name: xs
-          Type: 140 GoSliceHeaderType []main.structWithNoStrings
-          Locations:
-            - Range: 0x88f2c0..0x88f2d0
-              Pieces:
-                - Size: 8
-                  Op: {RegNo: 0, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 1, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 2, Shift: 0}
-          IsParameter: true
-          IsReturn: false
-        - Name: a
-          Type: 9 BaseType int
-          Locations:
-            - Range: 0x88f2c0..0x88f2d0
-              Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
-          IsParameter: true
-          IsReturn: false
-    - ID: 82
-      Name: main.testEmptySliceOfStructs
-      OutOfLinePCRanges: [0x88f2d0..0x88f2e0]
-      InlinePCRanges: []
-      Variables:
-        - Name: xs
-          Type: 140 GoSliceHeaderType []main.structWithNoStrings
-          Locations:
-            - Range: 0x88f2d0..0x88f2e0
-              Pieces:
-                - Size: 8
-                  Op: {RegNo: 0, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 1, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 2, Shift: 0}
-          IsParameter: true
-          IsReturn: false
-        - Name: a
-          Type: 9 BaseType int
-          Locations:
-            - Range: 0x88f2d0..0x88f2e0
-              Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
-          IsParameter: true
-          IsReturn: false
-    - ID: 83
-      Name: main.testNilSliceOfStructs
-      OutOfLinePCRanges: [0x88f2e0..0x88f2f0]
-      InlinePCRanges: []
-      Variables:
-        - Name: xs
-          Type: 140 GoSliceHeaderType []main.structWithNoStrings
-          Locations:
-            - Range: 0x88f2e0..0x88f2f0
-              Pieces:
-                - Size: 8
-                  Op: {RegNo: 0, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 1, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 2, Shift: 0}
-          IsParameter: true
-          IsReturn: false
-        - Name: a
-          Type: 9 BaseType int
-          Locations:
-            - Range: 0x88f2e0..0x88f2f0
-              Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
-          IsParameter: true
-          IsReturn: false
-    - ID: 84
-      Name: main.testStringSlice
-      OutOfLinePCRanges: [0x88f2f0..0x88f300]
-      InlinePCRanges: []
-      Variables:
-        - Name: s
-          Type: 143 GoSliceHeaderType []string
-          Locations:
-            - Range: 0x88f2f0..0x88f300
-              Pieces:
-                - Size: 8
-                  Op: {RegNo: 0, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 1, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 2, Shift: 0}
-          IsParameter: true
-          IsReturn: false
-    - ID: 85
-      Name: main.testNilSliceWithOtherParams
-      OutOfLinePCRanges: [0x88f300..0x88f310]
-      InlinePCRanges: []
-      Variables:
-        - Name: a
-          Type: 15 BaseType int8
-          Locations:
-            - Range: 0x88f300..0x88f310
-              Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
-          IsParameter: true
-          IsReturn: false
-        - Name: s
-          Type: 144 GoSliceHeaderType []bool
-          Locations:
-            - Range: 0x88f300..0x88f310
-              Pieces:
-                - Size: 8
-                  Op: {RegNo: 1, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 2, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 3, Shift: 0}
-          IsParameter: true
-          IsReturn: false
-        - Name: x
-          Type: 12 BaseType uint
-          Locations:
-            - Range: 0x88f300..0x88f310
-              Pieces: [{Size: 8, Op: {RegNo: 4, Shift: 0}}]
-          IsParameter: true
-          IsReturn: false
     - ID: 86
-      Name: main.testNilSlice
-      OutOfLinePCRanges: [0x88f310..0x88f320]
+      Name: main.testUintSlice
+      OutOfLinePCRanges: [0x88fca0..0x88fcb0]
       InlinePCRanges: []
       Variables:
-        - Name: xs
-          Type: 145 GoSliceHeaderType []uint16
+        - Name: u
+          Type: 160 GoSliceHeaderType []uint
           Locations:
-            - Range: 0x88f310..0x88f320
+            - Range: 0x88fca0..0x88fcb0
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -2797,14 +2856,14 @@ Subprograms:
           IsParameter: true
           IsReturn: false
     - ID: 87
-      Name: main.testVeryLargeSlice
-      OutOfLinePCRanges: [0x88f320..0x88f330]
+      Name: main.testEmptySlice
+      OutOfLinePCRanges: [0x88fcb0..0x88fcc0]
       InlinePCRanges: []
       Variables:
-        - Name: xs
-          Type: 137 GoSliceHeaderType []uint
+        - Name: u
+          Type: 160 GoSliceHeaderType []uint
           Locations:
-            - Range: 0x88f320..0x88f330
+            - Range: 0x88fcb0..0x88fcc0
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -2815,24 +2874,203 @@ Subprograms:
           IsParameter: true
           IsReturn: false
     - ID: 88
+      Name: main.testSliceOfSlices
+      OutOfLinePCRanges: [0x88fcc0..0x88fcd0]
+      InlinePCRanges: []
+      Variables:
+        - Name: u
+          Type: 161 GoSliceHeaderType [][]uint
+          Locations:
+            - Range: 0x88fcc0..0x88fcd0
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 0, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 1, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 2, Shift: 0}
+          IsParameter: true
+          IsReturn: false
+    - ID: 89
+      Name: main.testStructSlice
+      OutOfLinePCRanges: [0x88fcd0..0x88fce0]
+      InlinePCRanges: []
+      Variables:
+        - Name: xs
+          Type: 163 GoSliceHeaderType []main.structWithNoStrings
+          Locations:
+            - Range: 0x88fcd0..0x88fce0
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 0, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 1, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 2, Shift: 0}
+          IsParameter: true
+          IsReturn: false
+        - Name: a
+          Type: 9 BaseType int
+          Locations:
+            - Range: 0x88fcd0..0x88fce0
+              Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
+          IsParameter: true
+          IsReturn: false
+    - ID: 90
+      Name: main.testEmptySliceOfStructs
+      OutOfLinePCRanges: [0x88fce0..0x88fcf0]
+      InlinePCRanges: []
+      Variables:
+        - Name: xs
+          Type: 163 GoSliceHeaderType []main.structWithNoStrings
+          Locations:
+            - Range: 0x88fce0..0x88fcf0
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 0, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 1, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 2, Shift: 0}
+          IsParameter: true
+          IsReturn: false
+        - Name: a
+          Type: 9 BaseType int
+          Locations:
+            - Range: 0x88fce0..0x88fcf0
+              Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
+          IsParameter: true
+          IsReturn: false
+    - ID: 91
+      Name: main.testNilSliceOfStructs
+      OutOfLinePCRanges: [0x88fcf0..0x88fd00]
+      InlinePCRanges: []
+      Variables:
+        - Name: xs
+          Type: 163 GoSliceHeaderType []main.structWithNoStrings
+          Locations:
+            - Range: 0x88fcf0..0x88fd00
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 0, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 1, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 2, Shift: 0}
+          IsParameter: true
+          IsReturn: false
+        - Name: a
+          Type: 9 BaseType int
+          Locations:
+            - Range: 0x88fcf0..0x88fd00
+              Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
+          IsParameter: true
+          IsReturn: false
+    - ID: 92
+      Name: main.testStringSlice
+      OutOfLinePCRanges: [0x88fd00..0x88fd10]
+      InlinePCRanges: []
+      Variables:
+        - Name: s
+          Type: 166 GoSliceHeaderType []string
+          Locations:
+            - Range: 0x88fd00..0x88fd10
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 0, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 1, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 2, Shift: 0}
+          IsParameter: true
+          IsReturn: false
+    - ID: 93
+      Name: main.testNilSliceWithOtherParams
+      OutOfLinePCRanges: [0x88fd10..0x88fd20]
+      InlinePCRanges: []
+      Variables:
+        - Name: a
+          Type: 15 BaseType int8
+          Locations:
+            - Range: 0x88fd10..0x88fd20
+              Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
+          IsParameter: true
+          IsReturn: false
+        - Name: s
+          Type: 167 GoSliceHeaderType []bool
+          Locations:
+            - Range: 0x88fd10..0x88fd20
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 1, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 2, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 3, Shift: 0}
+          IsParameter: true
+          IsReturn: false
+        - Name: x
+          Type: 12 BaseType uint
+          Locations:
+            - Range: 0x88fd10..0x88fd20
+              Pieces: [{Size: 8, Op: {RegNo: 4, Shift: 0}}]
+          IsParameter: true
+          IsReturn: false
+    - ID: 94
+      Name: main.testNilSlice
+      OutOfLinePCRanges: [0x88fd20..0x88fd30]
+      InlinePCRanges: []
+      Variables:
+        - Name: xs
+          Type: 168 GoSliceHeaderType []uint16
+          Locations:
+            - Range: 0x88fd20..0x88fd30
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 0, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 1, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 2, Shift: 0}
+          IsParameter: true
+          IsReturn: false
+    - ID: 95
+      Name: main.testVeryLargeSlice
+      OutOfLinePCRanges: [0x88fd30..0x88fd40]
+      InlinePCRanges: []
+      Variables:
+        - Name: xs
+          Type: 160 GoSliceHeaderType []uint
+          Locations:
+            - Range: 0x88fd30..0x88fd40
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 0, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 1, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 2, Shift: 0}
+          IsParameter: true
+          IsReturn: false
+    - ID: 96
       Name: main.stackC
-      OutOfLinePCRanges: [0x88f5f0..0x88f660]
+      OutOfLinePCRanges: [0x890000..0x890070]
       InlinePCRanges: []
       Variables:
         - Name: ~r0
           Type: 11 GoStringHeaderType string
-          Locations: [{Range: 0x88f5f0..0x88f660, Pieces: []}]
+          Locations: [{Range: 0x890000..0x890070, Pieces: []}]
           IsParameter: true
           IsReturn: true
-    - ID: 89
+    - ID: 97
       Name: main.testSingleString
-      OutOfLinePCRanges: [0x88f660..0x88f670]
+      OutOfLinePCRanges: [0x890070..0x890080]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 11 GoStringHeaderType string
           Locations:
-            - Range: 0x88f660..0x88f670
+            - Range: 0x890070..0x890080
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -2840,15 +3078,15 @@ Subprograms:
                   Op: {RegNo: 1, Shift: 0}
           IsParameter: true
           IsReturn: false
-    - ID: 90
+    - ID: 98
       Name: main.testThreeStrings
-      OutOfLinePCRanges: [0x88f670..0x88f680]
+      OutOfLinePCRanges: [0x890080..0x890090]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 11 GoStringHeaderType string
           Locations:
-            - Range: 0x88f670..0x88f680
+            - Range: 0x890080..0x890090
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -2859,7 +3097,7 @@ Subprograms:
         - Name: y
           Type: 11 GoStringHeaderType string
           Locations:
-            - Range: 0x88f670..0x88f680
+            - Range: 0x890080..0x890090
               Pieces:
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
@@ -2870,7 +3108,7 @@ Subprograms:
         - Name: z
           Type: 11 GoStringHeaderType string
           Locations:
-            - Range: 0x88f670..0x88f680
+            - Range: 0x890080..0x890090
               Pieces:
                 - Size: 8
                   Op: {RegNo: 4, Shift: 0}
@@ -2878,15 +3116,15 @@ Subprograms:
                   Op: {RegNo: 5, Shift: 0}
           IsParameter: true
           IsReturn: false
-    - ID: 91
+    - ID: 99
       Name: main.testThreeStringsInStruct
-      OutOfLinePCRanges: [0x88f680..0x88f6a0]
+      OutOfLinePCRanges: [0x890090..0x8900b0]
       InlinePCRanges: []
       Variables:
         - Name: a
-          Type: 146 StructureType main.threeStringStruct
+          Type: 169 StructureType main.threeStringStruct
           Locations:
-            - Range: 0x88f680..0x88f6a0
+            - Range: 0x890090..0x8900b0
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -2902,39 +3140,39 @@ Subprograms:
                   Op: {RegNo: 5, Shift: 0}
           IsParameter: true
           IsReturn: false
-    - ID: 92
+    - ID: 100
       Name: main.testThreeStringsInStructPointer
-      OutOfLinePCRanges: [0x88f6a0..0x88f6b0]
+      OutOfLinePCRanges: [0x8900b0..0x8900c0]
       InlinePCRanges: []
       Variables:
         - Name: a
-          Type: 147 PointerType *main.threeStringStruct
+          Type: 170 PointerType *main.threeStringStruct
           Locations:
-            - Range: 0x88f6a0..0x88f6b0
+            - Range: 0x8900b0..0x8900c0
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 93
+    - ID: 101
       Name: main.testOneStringInStructPointer
-      OutOfLinePCRanges: [0x88f6b0..0x88f6c0]
+      OutOfLinePCRanges: [0x8900c0..0x8900d0]
       InlinePCRanges: []
       Variables:
         - Name: a
-          Type: 148 PointerType *main.oneStringStruct
+          Type: 171 PointerType *main.oneStringStruct
           Locations:
-            - Range: 0x88f6b0..0x88f6c0
+            - Range: 0x8900c0..0x8900d0
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 94
+    - ID: 102
       Name: main.testMassiveString
-      OutOfLinePCRanges: [0x88f6c0..0x88f6d0]
+      OutOfLinePCRanges: [0x8900d0..0x8900e0]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 11 GoStringHeaderType string
           Locations:
-            - Range: 0x88f6c0..0x88f6d0
+            - Range: 0x8900d0..0x8900e0
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -2942,15 +3180,15 @@ Subprograms:
                   Op: {RegNo: 1, Shift: 0}
           IsParameter: true
           IsReturn: false
-    - ID: 95
+    - ID: 103
       Name: main.testUnitializedString
-      OutOfLinePCRanges: [0x88f6d0..0x88f6e0]
+      OutOfLinePCRanges: [0x8900e0..0x8900f0]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 11 GoStringHeaderType string
           Locations:
-            - Range: 0x88f6d0..0x88f6e0
+            - Range: 0x8900e0..0x8900f0
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -2958,15 +3196,15 @@ Subprograms:
                   Op: {RegNo: 1, Shift: 0}
           IsParameter: true
           IsReturn: false
-    - ID: 96
+    - ID: 104
       Name: main.testEmptyString
-      OutOfLinePCRanges: [0x88f6e0..0x88f6f0]
+      OutOfLinePCRanges: [0x8900f0..0x890100]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 11 GoStringHeaderType string
           Locations:
-            - Range: 0x88f6e0..0x88f6f0
+            - Range: 0x8900f0..0x890100
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -2974,15 +3212,15 @@ Subprograms:
                   Op: {RegNo: 1, Shift: 0}
           IsParameter: true
           IsReturn: false
-    - ID: 97
+    - ID: 105
       Name: main.testStruct
-      OutOfLinePCRanges: [0x88f8f0..0x88f910]
+      OutOfLinePCRanges: [0x890300..0x890320]
       InlinePCRanges: []
       Variables:
         - Name: x
-          Type: 150 StructureType main.aStruct
+          Type: 173 StructureType main.aStruct
           Locations:
-            - Range: 0x88f8f0..0x88f910
+            - Range: 0x890300..0x890320
               Pieces:
                 - Size: 1
                   Op: {RegNo: 0, Shift: 0}
@@ -3000,467 +3238,697 @@ Subprograms:
                   Op: {RegNo: 6, Shift: 0}
           IsParameter: true
           IsReturn: false
-    - ID: 98
+    - ID: 106
       Name: main.testEmptyStruct
-      OutOfLinePCRanges: [0x88f9f0..0x88fa00]
+      OutOfLinePCRanges: [0x890400..0x890410]
       InlinePCRanges: []
       Variables:
         - Name: e
-          Type: 152 StructureType main.emptyStruct
-          Locations: [{Range: 0x88f9f0..0x88fa00, Pieces: []}]
+          Type: 175 StructureType main.emptyStruct
+          Locations: [{Range: 0x890400..0x890410, Pieces: []}]
           IsParameter: true
           IsReturn: false
-    - ID: 99
+    - ID: 107
       Name: main.testInlinedPrint
-      OutOfLinePCRanges: [0x88c9b0..0x88ca20]
+      OutOfLinePCRanges: [0x88d3c0..0x88d430]
       InlinePCRanges:
-        - Ranges: [0x88ca3c..0x88ca74]
-          RootRanges: [0x88ca20..0x88caa0]
-        - Ranges: [0x88cb88..0x88cbc0]
-          RootRanges: [0x88cb50..0x88cbe0]
-        - Ranges: [0x88cc04..0x88cc3c]
-          RootRanges: [0x88cbe0..0x88ccb0]
-        - Ranges: [0x88cccc..0x88cd04]
-          RootRanges: [0x88ccb0..0x88cd30]
+        - Ranges: [0x88d44c..0x88d484]
+          RootRanges: [0x88d430..0x88d4b0]
+        - Ranges: [0x88d598..0x88d5d0]
+          RootRanges: [0x88d560..0x88d5f0]
+        - Ranges: [0x88d614..0x88d64c]
+          RootRanges: [0x88d5f0..0x88d6c0]
+        - Ranges: [0x88d6dc..0x88d714]
+          RootRanges: [0x88d6c0..0x88d740]
       Variables:
         - Name: x
           Type: 9 BaseType int
           Locations:
-            - Range: 0x88c9b0..0x88c9d0
+            - Range: 0x88d3c0..0x88d3e0
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x88ca3c..0x88ca44
+            - Range: 0x88d44c..0x88d454
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x88cb88..0x88cb90
+            - Range: 0x88d598..0x88d5a0
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x88cbfc..0x88cc0c
+            - Range: 0x88d60c..0x88d61c
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x88cc0c..0x88ccb0
+            - Range: 0x88d61c..0x88d6c0
               Pieces: [{Size: 8, Op: {CfaOffset: -48}}]
-            - Range: 0x88ccb0..0x88ccd4
+            - Range: 0x88d6c0..0x88d6e4
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 100
+    - ID: 108
       Name: main.testInlinedBBB
       OutOfLinePCRanges: []
       InlinePCRanges:
-        - Ranges: [0x88cc48..0x88cc80]
-          RootRanges: [0x88cbe0..0x88ccb0]
+        - Ranges: [0x88d658..0x88d690]
+          RootRanges: [0x88d5f0..0x88d6c0]
       Variables: []
-    - ID: 101
+    - ID: 109
       Name: main.testInlinedBCA
       OutOfLinePCRanges: []
       InlinePCRanges:
-        - Ranges: [0x88cd4c..0x88cd90]
-          RootRanges: [0x88cd30..0x88ce50]
+        - Ranges: [0x88d75c..0x88d7a0]
+          RootRanges: [0x88d740..0x88d860]
       Variables: []
-    - ID: 102
+    - ID: 110
       Name: main.testInlinedBCB
       OutOfLinePCRanges: []
       InlinePCRanges:
-        - Ranges: [0x88ce00..0x88ce38]
-          RootRanges: [0x88cd30..0x88ce50]
+        - Ranges: [0x88d810..0x88d848]
+          RootRanges: [0x88d740..0x88d860]
       Variables: []
-    - ID: 103
+    - ID: 111
       Name: main.testInlinedSq
       OutOfLinePCRanges: []
       InlinePCRanges:
-        - Ranges: [0x88ce54..0x88ce58]
-          RootRanges: [0x88ce50..0x88ce60]
+        - Ranges: [0x88d864..0x88d868]
+          RootRanges: [0x88d860..0x88d870]
       Variables:
         - Name: x
           Type: 9 BaseType int
           Locations:
-            - Range: 0x88ce50..0x88ce58
+            - Range: 0x88d860..0x88d868
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 104
+    - ID: 112
       Name: main.testInlinedSumArray
       OutOfLinePCRanges: []
       InlinePCRanges:
-        - Ranges: [0x88ce84..0x88cea8]
-          RootRanges: [0x88ce60..0x88cec0]
-        - Ranges: [0x88cf1c..0x88cf44]
-          RootRanges: [0x88cec0..0x88d010]
+        - Ranges: [0x88d894..0x88d8b8]
+          RootRanges: [0x88d870..0x88d8d0]
+        - Ranges: [0x88d92c..0x88d954]
+          RootRanges: [0x88d8d0..0x88da20]
       Variables:
         - Name: a
-          Type: 63 ArrayType [5]int
+          Type: 88 ArrayType [5]int
           Locations:
-            - Range: 0x88ce70..0x88cec0
+            - Range: 0x88d880..0x88d8d0
               Pieces: [{Size: 40, Op: {CfaOffset: -48}}]
-            - Range: 0x88cf08..0x88d010
+            - Range: 0x88d918..0x88da20
               Pieces: [{Size: 40, Op: {CfaOffset: -120}}]
           IsParameter: true
           IsReturn: false
 Types:
     - __kind: PointerType
-      ID: 209
+      ID: 63
+      Name: '**main.deepSlice2'
+      ByteSize: 8
+      Pointee: 64 PointerType *main.deepSlice2
+    - __kind: PointerType
+      ID: 236
+      Name: '**main.deepSlice3'
+      ByteSize: 8
+      Pointee: 237 PointerType *main.deepSlice3
+    - __kind: PointerType
+      ID: 255
+      Name: '**main.deepSlice8'
+      ByteSize: 8
+      Pointee: 256 PointerType *main.deepSlice8
+    - __kind: PointerType
+      ID: 261
+      Name: '**main.deepSlice9'
+      ByteSize: 8
+      Pointee: 262 PointerType *main.deepSlice9
+    - __kind: PointerType
+      ID: 79
+      Name: '**main.stringType2'
+      ByteSize: 8
+      GoKind: 22
+      Pointee: 80 PointerType *main.stringType2
+    - __kind: PointerType
+      ID: 304
       Name: '**main.t'
       ByteSize: 8
-      Pointee: 135 PointerType *main.t
+      Pointee: 158 PointerType *main.t
     - __kind: PointerType
       ID: 54
       Name: '**string'
       ByteSize: 8
-      GoRuntimeType: 486144
+      GoRuntimeType: 490336
       GoKind: 22
       Pointee: 22 PointerType *string
     - __kind: PointerType
-      ID: 156
+      ID: 182
+      Name: '*[]*main.deepSlice2.array'
+      ByteSize: 8
+      Pointee: 181 GoSliceDataType []*main.deepSlice2.array
+    - __kind: PointerType
+      ID: 240
+      Name: '*[]*main.deepSlice3.array'
+      ByteSize: 8
+      Pointee: 239 GoSliceDataType []*main.deepSlice3.array
+    - __kind: PointerType
+      ID: 259
+      Name: '*[]*main.deepSlice8.array'
+      ByteSize: 8
+      Pointee: 258 GoSliceDataType []*main.deepSlice8.array
+    - __kind: PointerType
+      ID: 265
+      Name: '*[]*main.deepSlice9.array'
+      ByteSize: 8
+      Pointee: 264 GoSliceDataType []*main.deepSlice9.array
+    - __kind: PointerType
+      ID: 179
       Name: '*[]*string.array'
       ByteSize: 8
-      Pointee: 155 GoSliceDataType []*string.array
+      Pointee: 178 GoSliceDataType []*string.array
     - __kind: PointerType
-      ID: 191
+      ID: 221
       Name: '*[][]uint.array'
       ByteSize: 8
-      Pointee: 190 GoSliceDataType [][]uint.array
+      Pointee: 220 GoSliceDataType [][]uint.array
     - __kind: PointerType
-      ID: 197
+      ID: 227
       Name: '*[]bool.array'
       ByteSize: 8
-      Pointee: 196 GoSliceDataType []bool.array
+      Pointee: 226 GoSliceDataType []bool.array
     - __kind: PointerType
-      ID: 213
+      ID: 269
+      Name: '*[]interface {}.array'
+      ByteSize: 8
+      Pointee: 268 GoSliceDataType []interface {}.array
+    - __kind: PointerType
+      ID: 308
       Name: '*[]main.structWithMap.array'
       ByteSize: 8
-      Pointee: 212 GoSliceDataType []main.structWithMap.array
+      Pointee: 307 GoSliceDataType []main.structWithMap.array
     - __kind: PointerType
-      ID: 193
+      ID: 223
       Name: '*[]main.structWithNoStrings.array'
       ByteSize: 8
-      Pointee: 192 GoSliceDataType []main.structWithNoStrings.array
+      Pointee: 222 GoSliceDataType []main.structWithNoStrings.array
     - __kind: PointerType
-      ID: 195
+      ID: 225
       Name: '*[]string.array'
       ByteSize: 8
-      Pointee: 194 GoSliceDataType []string.array
+      Pointee: 224 GoSliceDataType []string.array
     - __kind: PointerType
-      ID: 139
+      ID: 162
       Name: '*[]uint'
       ByteSize: 8
-      Pointee: 137 GoSliceHeaderType []uint
+      Pointee: 160 GoSliceHeaderType []uint
     - __kind: PointerType
-      ID: 189
+      ID: 219
       Name: '*[]uint.array'
       ByteSize: 8
-      Pointee: 188 GoSliceDataType []uint.array
+      Pointee: 218 GoSliceDataType []uint.array
     - __kind: PointerType
-      ID: 199
+      ID: 229
       Name: '*[]uint16.array'
       ByteSize: 8
-      Pointee: 198 GoSliceDataType []uint16.array
+      Pointee: 228 GoSliceDataType []uint16.array
     - __kind: PointerType
       ID: 5
       Name: '*bool'
       ByteSize: 8
-      GoRuntimeType: 360288
+      GoRuntimeType: 363456
       GoKind: 22
       Pointee: 4 BaseType bool
     - __kind: PointerType
-      ID: 128
+      ID: 151
       Name: '*bucket<[4]int,[4]int>'
       ByteSize: 8
-      Pointee: 129 GoHMapBucketType bucket<[4]int,[4]int>
+      Pointee: 152 GoHMapBucketType bucket<[4]int,[4]int>
     - __kind: PointerType
-      ID: 123
+      ID: 146
       Name: '*bucket<[4]int,uint8>'
       ByteSize: 8
-      Pointee: 124 GoHMapBucketType bucket<[4]int,uint8>
+      Pointee: 147 GoHMapBucketType bucket<[4]int,uint8>
     - __kind: PointerType
-      ID: 91
+      ID: 114
       Name: '*bucket<[4]string,[2]int>'
       ByteSize: 8
-      Pointee: 92 GoHMapBucketType bucket<[4]string,[2]int>
+      Pointee: 115 GoHMapBucketType bucket<[4]string,[2]int>
     - __kind: PointerType
-      ID: 103
+      ID: 126
       Name: '*bucket<bool,main.node>'
       ByteSize: 8
-      Pointee: 104 GoHMapBucketType bucket<bool,main.node>
+      Pointee: 127 GoHMapBucketType bucket<bool,main.node>
     - __kind: PointerType
-      ID: 69
+      ID: 71
+      Name: '*bucket<int,*main.deepMap2>'
+      ByteSize: 8
+      Pointee: 72 GoHMapBucketType bucket<int,*main.deepMap2>
+    - __kind: PointerType
+      ID: 244
+      Name: '*bucket<int,*main.deepMap3>'
+      ByteSize: 8
+      Pointee: 245 GoHMapBucketType bucket<int,*main.deepMap3>
+    - __kind: PointerType
+      ID: 273
+      Name: '*bucket<int,*main.deepMap8>'
+      ByteSize: 8
+      Pointee: 274 GoHMapBucketType bucket<int,*main.deepMap8>
+    - __kind: PointerType
+      ID: 282
+      Name: '*bucket<int,*main.deepMap9>'
+      ByteSize: 8
+      Pointee: 283 GoHMapBucketType bucket<int,*main.deepMap9>
+    - __kind: PointerType
+      ID: 94
       Name: '*bucket<int,int>'
       ByteSize: 8
-      Pointee: 70 GoHMapBucketType bucket<int,int>
+      Pointee: 95 GoHMapBucketType bucket<int,int>
     - __kind: PointerType
-      ID: 108
+      ID: 291
+      Name: '*bucket<int,interface {}>'
+      ByteSize: 8
+      Pointee: 292 GoHMapBucketType bucket<int,interface {}>
+    - __kind: PointerType
+      ID: 131
       Name: '*bucket<int,uint8>'
       ByteSize: 8
-      Pointee: 109 GoHMapBucketType bucket<int,uint8>
+      Pointee: 132 GoHMapBucketType bucket<int,uint8>
     - __kind: PointerType
-      ID: 98
+      ID: 121
       Name: '*bucket<string,[]main.structWithMap>'
       ByteSize: 8
-      Pointee: 99 GoHMapBucketType bucket<string,[]main.structWithMap>
+      Pointee: 122 GoHMapBucketType bucket<string,[]main.structWithMap>
     - __kind: PointerType
-      ID: 86
+      ID: 109
       Name: '*bucket<string,[]string>'
       ByteSize: 8
-      Pointee: 87 GoHMapBucketType bucket<string,[]string>
+      Pointee: 110 GoHMapBucketType bucket<string,[]string>
     - __kind: PointerType
-      ID: 81
+      ID: 104
       Name: '*bucket<string,int>'
       ByteSize: 8
-      Pointee: 82 GoHMapBucketType bucket<string,int>
+      Pointee: 105 GoHMapBucketType bucket<string,int>
     - __kind: PointerType
-      ID: 76
+      ID: 99
       Name: '*bucket<string,main.nestedStruct>'
       ByteSize: 8
-      Pointee: 77 GoHMapBucketType bucket<string,main.nestedStruct>
+      Pointee: 100 GoHMapBucketType bucket<string,main.nestedStruct>
     - __kind: PointerType
-      ID: 118
+      ID: 141
       Name: '*bucket<uint8,[4]int>'
       ByteSize: 8
-      Pointee: 119 GoHMapBucketType bucket<uint8,[4]int>
+      Pointee: 142 GoHMapBucketType bucket<uint8,[4]int>
     - __kind: PointerType
-      ID: 113
+      ID: 136
       Name: '*bucket<uint8,uint8>'
       ByteSize: 8
-      Pointee: 114 GoHMapBucketType bucket<uint8,uint8>
+      Pointee: 137 GoHMapBucketType bucket<uint8,uint8>
     - __kind: PointerType
       ID: 33
       Name: '*error'
       ByteSize: 8
-      GoRuntimeType: 359200
+      GoRuntimeType: 362368
       GoKind: 22
       Pointee: 18 GoInterfaceType error
     - __kind: PointerType
       ID: 35
       Name: '*float32'
       ByteSize: 8
-      GoRuntimeType: 360160
+      GoRuntimeType: 363328
       GoKind: 22
       Pointee: 16 BaseType float32
     - __kind: PointerType
       ID: 26
       Name: '*float64'
       ByteSize: 8
-      GoRuntimeType: 360224
+      GoRuntimeType: 363392
       GoKind: 22
       Pointee: 17 BaseType float64
     - __kind: PointerType
-      ID: 126
+      ID: 149
       Name: '*hash<[4]int,[4]int>'
       ByteSize: 8
-      Pointee: 127 GoHMapHeaderType hash<[4]int,[4]int>
+      Pointee: 150 GoHMapHeaderType hash<[4]int,[4]int>
     - __kind: PointerType
-      ID: 121
+      ID: 144
       Name: '*hash<[4]int,uint8>'
       ByteSize: 8
-      Pointee: 122 GoHMapHeaderType hash<[4]int,uint8>
+      Pointee: 145 GoHMapHeaderType hash<[4]int,uint8>
     - __kind: PointerType
-      ID: 89
+      ID: 112
       Name: '*hash<[4]string,[2]int>'
       ByteSize: 8
-      Pointee: 90 GoHMapHeaderType hash<[4]string,[2]int>
+      Pointee: 113 GoHMapHeaderType hash<[4]string,[2]int>
     - __kind: PointerType
-      ID: 101
+      ID: 124
       Name: '*hash<bool,main.node>'
       ByteSize: 8
-      Pointee: 102 GoHMapHeaderType hash<bool,main.node>
+      Pointee: 125 GoHMapHeaderType hash<bool,main.node>
     - __kind: PointerType
-      ID: 67
+      ID: 69
+      Name: '*hash<int,*main.deepMap2>'
+      ByteSize: 8
+      Pointee: 70 GoHMapHeaderType hash<int,*main.deepMap2>
+    - __kind: PointerType
+      ID: 242
+      Name: '*hash<int,*main.deepMap3>'
+      ByteSize: 8
+      Pointee: 243 GoHMapHeaderType hash<int,*main.deepMap3>
+    - __kind: PointerType
+      ID: 271
+      Name: '*hash<int,*main.deepMap8>'
+      ByteSize: 8
+      Pointee: 272 GoHMapHeaderType hash<int,*main.deepMap8>
+    - __kind: PointerType
+      ID: 280
+      Name: '*hash<int,*main.deepMap9>'
+      ByteSize: 8
+      Pointee: 281 GoHMapHeaderType hash<int,*main.deepMap9>
+    - __kind: PointerType
+      ID: 92
       Name: '*hash<int,int>'
       ByteSize: 8
-      Pointee: 68 GoHMapHeaderType hash<int,int>
+      Pointee: 93 GoHMapHeaderType hash<int,int>
     - __kind: PointerType
-      ID: 106
+      ID: 289
+      Name: '*hash<int,interface {}>'
+      ByteSize: 8
+      Pointee: 290 GoHMapHeaderType hash<int,interface {}>
+    - __kind: PointerType
+      ID: 129
       Name: '*hash<int,uint8>'
       ByteSize: 8
-      Pointee: 107 GoHMapHeaderType hash<int,uint8>
+      Pointee: 130 GoHMapHeaderType hash<int,uint8>
     - __kind: PointerType
-      ID: 96
+      ID: 119
       Name: '*hash<string,[]main.structWithMap>'
       ByteSize: 8
-      Pointee: 97 GoHMapHeaderType hash<string,[]main.structWithMap>
+      Pointee: 120 GoHMapHeaderType hash<string,[]main.structWithMap>
     - __kind: PointerType
-      ID: 84
+      ID: 107
       Name: '*hash<string,[]string>'
       ByteSize: 8
-      Pointee: 85 GoHMapHeaderType hash<string,[]string>
+      Pointee: 108 GoHMapHeaderType hash<string,[]string>
     - __kind: PointerType
-      ID: 79
+      ID: 102
       Name: '*hash<string,int>'
       ByteSize: 8
-      Pointee: 80 GoHMapHeaderType hash<string,int>
+      Pointee: 103 GoHMapHeaderType hash<string,int>
     - __kind: PointerType
-      ID: 74
+      ID: 97
       Name: '*hash<string,main.nestedStruct>'
       ByteSize: 8
-      Pointee: 75 GoHMapHeaderType hash<string,main.nestedStruct>
+      Pointee: 98 GoHMapHeaderType hash<string,main.nestedStruct>
     - __kind: PointerType
-      ID: 116
+      ID: 139
       Name: '*hash<uint8,[4]int>'
       ByteSize: 8
-      Pointee: 117 GoHMapHeaderType hash<uint8,[4]int>
+      Pointee: 140 GoHMapHeaderType hash<uint8,[4]int>
     - __kind: PointerType
-      ID: 111
+      ID: 134
       Name: '*hash<uint8,uint8>'
       ByteSize: 8
-      Pointee: 112 GoHMapHeaderType hash<uint8,uint8>
+      Pointee: 135 GoHMapHeaderType hash<uint8,uint8>
     - __kind: PointerType
       ID: 28
       Name: '*int'
       ByteSize: 8
-      GoRuntimeType: 359840
+      GoRuntimeType: 363008
       GoKind: 22
       Pointee: 9 BaseType int
     - __kind: PointerType
       ID: 31
       Name: '*int16'
       ByteSize: 8
-      GoRuntimeType: 359456
+      GoRuntimeType: 362624
       GoKind: 22
       Pointee: 23 BaseType int16
     - __kind: PointerType
       ID: 20
       Name: '*int32'
       ByteSize: 8
-      GoRuntimeType: 359584
+      GoRuntimeType: 362752
       GoKind: 22
       Pointee: 13 BaseType int32
     - __kind: PointerType
       ID: 27
       Name: '*int64'
       ByteSize: 8
-      GoRuntimeType: 359712
+      GoRuntimeType: 362880
       GoKind: 22
       Pointee: 14 BaseType int64
     - __kind: PointerType
       ID: 32
       Name: '*int8'
       ByteSize: 8
-      GoRuntimeType: 359328
+      GoRuntimeType: 362496
       GoKind: 22
       Pointee: 15 BaseType int8
     - __kind: PointerType
-      ID: 61
+      ID: 267
+      Name: '*interface {}'
+      ByteSize: 8
+      GoRuntimeType: 363584
+      GoKind: 22
+      Pointee: 83 GoEmptyInterfaceType interface {}
+    - __kind: PointerType
+      ID: 186
+      Name: '*main.deepMap2'
+      ByteSize: 8
+      GoRuntimeType: 356096
+      GoKind: 22
+      Pointee: 187 StructureType main.deepMap2
+    - __kind: PointerType
+      ID: 247
+      Name: '*main.deepMap3'
+      ByteSize: 8
+      GoRuntimeType: 356032
+      GoKind: 22
+      Pointee: 248 UnresolvedPointeeType main.deepMap3
+    - __kind: PointerType
+      ID: 75
+      Name: '*main.deepMap7'
+      ByteSize: 8
+      GoRuntimeType: 355776
+      GoKind: 22
+      Pointee: 76 StructureType main.deepMap7
+    - __kind: PointerType
+      ID: 276
+      Name: '*main.deepMap8'
+      ByteSize: 8
+      GoRuntimeType: 355712
+      GoKind: 22
+      Pointee: 277 StructureType main.deepMap8
+    - __kind: PointerType
+      ID: 285
+      Name: '*main.deepMap9'
+      ByteSize: 8
+      GoRuntimeType: 355648
+      GoKind: 22
+      Pointee: 286 StructureType main.deepMap9
+    - __kind: PointerType
+      ID: 57
+      Name: '*main.deepPtr2'
+      ByteSize: 8
+      GoRuntimeType: 356672
+      GoKind: 22
+      Pointee: 58 StructureType main.deepPtr2
+    - __kind: PointerType
+      ID: 230
+      Name: '*main.deepPtr3'
+      ByteSize: 8
+      GoRuntimeType: 356608
+      GoKind: 22
+      Pointee: 231 UnresolvedPointeeType main.deepPtr3
+    - __kind: PointerType
+      ID: 59
+      Name: '*main.deepPtr7'
+      ByteSize: 8
+      GoRuntimeType: 356352
+      GoKind: 22
+      Pointee: 60 StructureType main.deepPtr7
+    - __kind: PointerType
+      ID: 250
+      Name: '*main.deepPtr8'
+      ByteSize: 8
+      GoRuntimeType: 356288
+      GoKind: 22
+      Pointee: 251 StructureType main.deepPtr8
+    - __kind: PointerType
+      ID: 252
+      Name: '*main.deepPtr9'
+      ByteSize: 8
+      GoRuntimeType: 356224
+      GoKind: 22
+      Pointee: 253 StructureType main.deepPtr9
+    - __kind: PointerType
+      ID: 64
+      Name: '*main.deepSlice2'
+      ByteSize: 8
+      GoRuntimeType: 357248
+      GoKind: 22
+      Pointee: 180 StructureType main.deepSlice2
+    - __kind: PointerType
+      ID: 237
+      Name: '*main.deepSlice3'
+      ByteSize: 8
+      GoRuntimeType: 357184
+      GoKind: 22
+      Pointee: 238 UnresolvedPointeeType main.deepSlice3
+    - __kind: PointerType
+      ID: 65
+      Name: '*main.deepSlice7'
+      ByteSize: 8
+      GoRuntimeType: 356928
+      GoKind: 22
+      Pointee: 66 StructureType main.deepSlice7
+    - __kind: PointerType
+      ID: 256
+      Name: '*main.deepSlice8'
+      ByteSize: 8
+      GoRuntimeType: 356864
+      GoKind: 22
+      Pointee: 257 StructureType main.deepSlice8
+    - __kind: PointerType
+      ID: 262
+      Name: '*main.deepSlice9'
+      ByteSize: 8
+      GoRuntimeType: 356800
+      GoKind: 22
+      Pointee: 263 StructureType main.deepSlice9
+    - __kind: PointerType
+      ID: 86
       Name: '*main.esotericHeap'
       ByteSize: 8
-      GoRuntimeType: 354208
+      GoRuntimeType: 357376
       GoKind: 22
-      Pointee: 62 StructureType main.esotericHeap
+      Pointee: 87 StructureType main.esotericHeap
     - __kind: PointerType
-      ID: 134
+      ID: 157
       Name: '*main.node'
       ByteSize: 8
-      GoRuntimeType: 354272
+      GoRuntimeType: 357440
       GoKind: 22
-      Pointee: 133 StructureType main.node
+      Pointee: 156 StructureType main.node
     - __kind: PointerType
-      ID: 148
+      ID: 171
       Name: '*main.oneStringStruct'
       ByteSize: 8
       GoKind: 22
-      Pointee: 149 StructureType main.oneStringStruct
+      Pointee: 172 StructureType main.oneStringStruct
     - __kind: PointerType
-      ID: 173
+      ID: 77
+      Name: '*main.stringType1'
+      ByteSize: 8
+      GoKind: 22
+      Pointee: 78 GoStringHeaderType main.stringType1
+    - __kind: PointerType
+      ID: 233
+      Name: '*main.stringType1.str'
+      ByteSize: 8
+      Pointee: 232 GoStringDataType main.stringType1.str
+    - __kind: PointerType
+      ID: 80
+      Name: '*main.stringType2'
+      ByteSize: 8
+      GoKind: 22
+      Pointee: 234 UnresolvedPointeeType main.stringType2
+    - __kind: PointerType
+      ID: 203
       Name: '*main.structWithMap'
       ByteSize: 8
-      GoRuntimeType: 354144
+      GoRuntimeType: 355584
       GoKind: 22
-      Pointee: 65 StructureType main.structWithMap
+      Pointee: 90 StructureType main.structWithMap
     - __kind: PointerType
-      ID: 141
+      ID: 164
       Name: '*main.structWithNoStrings'
       ByteSize: 8
-      Pointee: 142 StructureType main.structWithNoStrings
+      Pointee: 165 StructureType main.structWithNoStrings
     - __kind: PointerType
-      ID: 131
+      ID: 154
       Name: '*main.structWithTwoValues'
       ByteSize: 8
       GoKind: 22
-      Pointee: 132 StructureType main.structWithTwoValues
+      Pointee: 155 StructureType main.structWithTwoValues
     - __kind: PointerType
-      ID: 135
+      ID: 158
       Name: '*main.t'
       ByteSize: 8
       GoKind: 22
-      Pointee: 136 GoSliceHeaderType main.t
+      Pointee: 159 GoSliceHeaderType main.t
     - __kind: PointerType
-      ID: 211
+      ID: 306
       Name: '*main.t.array'
       ByteSize: 8
-      Pointee: 210 GoSliceDataType main.t.array
+      Pointee: 305 GoSliceDataType main.t.array
     - __kind: PointerType
-      ID: 147
+      ID: 170
       Name: '*main.threeStringStruct'
       ByteSize: 8
       GoKind: 22
-      Pointee: 146 StructureType main.threeStringStruct
+      Pointee: 169 StructureType main.threeStringStruct
     - __kind: PointerType
-      ID: 94
+      ID: 117
       Name: '*map[string]int'
       ByteSize: 8
       GoKind: 22
-      Pointee: 78 GoMapType map[string]int
+      Pointee: 101 GoMapType map[string]int
     - __kind: PointerType
-      ID: 71
+      ID: 73
       Name: '*runtime.mapextra'
       ByteSize: 8
-      GoRuntimeType: 363168
+      GoRuntimeType: 366336
       GoKind: 22
-      Pointee: 72 UnresolvedPointeeType runtime.mapextra
+      Pointee: 74 UnresolvedPointeeType runtime.mapextra
     - __kind: PointerType
       ID: 22
       Name: '*string'
       ByteSize: 8
-      GoRuntimeType: 359264
+      GoRuntimeType: 362432
       GoKind: 22
       Pointee: 11 GoStringHeaderType string
     - __kind: PointerType
-      ID: 154
+      ID: 177
       Name: '*string.str'
       ByteSize: 8
-      Pointee: 153 GoStringDataType string.str
+      Pointee: 176 GoStringDataType string.str
     - __kind: PointerType
       ID: 34
       Name: '*uint'
       ByteSize: 8
-      GoRuntimeType: 359904
+      GoRuntimeType: 363072
       GoKind: 22
       Pointee: 12 BaseType uint
     - __kind: PointerType
       ID: 30
       Name: '*uint16'
       ByteSize: 8
-      GoRuntimeType: 359520
+      GoRuntimeType: 362688
       GoKind: 22
       Pointee: 7 BaseType uint16
     - __kind: PointerType
       ID: 21
       Name: '*uint32'
       ByteSize: 8
-      GoRuntimeType: 359648
+      GoRuntimeType: 362816
       GoKind: 22
       Pointee: 2 BaseType uint32
     - __kind: PointerType
       ID: 29
       Name: '*uint64'
       ByteSize: 8
-      GoRuntimeType: 359776
+      GoRuntimeType: 362944
       GoKind: 22
       Pointee: 10 BaseType uint64
     - __kind: PointerType
       ID: 6
       Name: '*uint8'
       ByteSize: 8
-      GoRuntimeType: 359392
+      GoRuntimeType: 362560
       GoKind: 22
       Pointee: 3 BaseType uint8
     - __kind: PointerType
       ID: 8
       Name: '*uintptr'
       ByteSize: 8
-      GoRuntimeType: 359968
+      GoRuntimeType: 363136
       GoKind: 22
       Pointee: 1 BaseType uintptr
     - __kind: EventRootType
-      ID: 301
+      ID: 404
       Name: Probe[main.stackC]
     - __kind: EventRootType
-      ID: 258
+      ID: 361
       Name: Probe[main.testAny]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -3468,14 +3936,14 @@ Types:
         - Name: a
           Offset: 1
           Expression:
-            Type: 58 GoEmptyInterfaceType interface {}
+            Type: 83 GoEmptyInterfaceType interface {}
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 45, index: 0, name: a}
+                  Variable: {subprogram: 53, index: 0, name: a}
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 230
+      ID: 325
       Name: Probe[main.testArrayOfArraysOfArrays]
       ByteSize: 65
       PresenceBitsetSize: 1
@@ -3490,7 +3958,7 @@ Types:
                   Offset: 0
                   ByteSize: 64
     - __kind: EventRootType
-      ID: 228
+      ID: 323
       Name: Probe[main.testArrayOfArrays]
       ByteSize: 33
       PresenceBitsetSize: 1
@@ -3505,7 +3973,7 @@ Types:
                   Offset: 0
                   ByteSize: 32
     - __kind: EventRootType
-      ID: 266
+      ID: 369
       Name: Probe[main.testArrayOfMaps]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -3513,14 +3981,14 @@ Types:
         - Name: m
           Offset: 1
           Expression:
-            Type: 93 ArrayType [2]map[string]int
+            Type: 116 ArrayType [2]map[string]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 53, index: 0, name: m}
+                  Variable: {subprogram: 61, index: 0, name: m}
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 229
+      ID: 324
       Name: Probe[main.testArrayOfStrings]
       ByteSize: 33
       PresenceBitsetSize: 1
@@ -3535,7 +4003,7 @@ Types:
                   Offset: 0
                   ByteSize: 32
     - __kind: EventRootType
-      ID: 248
+      ID: 343
       Name: Probe[main.testBigStruct]
       ByteSize: 49
       PresenceBitsetSize: 1
@@ -3550,7 +4018,7 @@ Types:
                   Offset: 0
                   ByteSize: 48
     - __kind: EventRootType
-      ID: 217
+      ID: 312
       Name: Probe[main.testBoolArray]
       ByteSize: 3
       PresenceBitsetSize: 1
@@ -3565,7 +4033,7 @@ Types:
                   Offset: 0
                   ByteSize: 2
     - __kind: EventRootType
-      ID: 214
+      ID: 309
       Name: Probe[main.testByteArray]
       ByteSize: 3
       PresenceBitsetSize: 1
@@ -3580,7 +4048,7 @@ Types:
                   Offset: 0
                   ByteSize: 2
     - __kind: EventRootType
-      ID: 282
+      ID: 385
       Name: Probe[main.testChannel]
       ByteSize: 1
       PresenceBitsetSize: 1
@@ -3588,14 +4056,14 @@ Types:
         - Name: c
           Offset: 1
           Expression:
-            Type: 130 GoChannelType chan bool
+            Type: 153 GoChannelType chan bool
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 69, index: 0, name: c}
+                  Variable: {subprogram: 77, index: 0, name: c}
                   Offset: 0
                   ByteSize: 0
     - __kind: EventRootType
-      ID: 280
+      ID: 383
       Name: Probe[main.testCombinedByte]
       ByteSize: 7
       PresenceBitsetSize: 1
@@ -3606,7 +4074,7 @@ Types:
             Type: 3 BaseType uint8
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 67, index: 0, name: w}
+                  Variable: {subprogram: 75, index: 0, name: w}
                   Offset: 0
                   ByteSize: 1
         - Name: x
@@ -3615,7 +4083,7 @@ Types:
             Type: 3 BaseType uint8
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 67, index: 1, name: x}
+                  Variable: {subprogram: 75, index: 1, name: x}
                   Offset: 0
                   ByteSize: 1
         - Name: y
@@ -3624,11 +4092,11 @@ Types:
             Type: 16 BaseType float32
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 67, index: 2, name: y}
+                  Variable: {subprogram: 75, index: 2, name: y}
                   Offset: 0
                   ByteSize: 4
     - __kind: EventRootType
-      ID: 290
+      ID: 393
       Name: Probe[main.testCycle]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -3636,14 +4104,104 @@ Types:
         - Name: t
           Offset: 1
           Expression:
-            Type: 135 PointerType *main.t
+            Type: 158 PointerType *main.t
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 77, index: 0, name: t}
+                  Variable: {subprogram: 85, index: 0, name: t}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 295
+      ID: 348
+      Name: Probe[main.testDeepMap1]
+      ByteSize: 9
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: a
+          Offset: 1
+          Expression:
+            Type: 67 StructureType main.deepMap1
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 40, index: 0, name: a}
+                  Offset: 0
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 349
+      Name: Probe[main.testDeepMap7]
+      ByteSize: 9
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: a
+          Offset: 1
+          Expression:
+            Type: 75 PointerType *main.deepMap7
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 41, index: 0, name: a}
+                  Offset: 0
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 344
+      Name: Probe[main.testDeepPtr1]
+      ByteSize: 9
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: a
+          Offset: 1
+          Expression:
+            Type: 56 StructureType main.deepPtr1
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 36, index: 0, name: a}
+                  Offset: 0
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 345
+      Name: Probe[main.testDeepPtr7]
+      ByteSize: 9
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: a
+          Offset: 1
+          Expression:
+            Type: 59 PointerType *main.deepPtr7
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 37, index: 0, name: a}
+                  Offset: 0
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 346
+      Name: Probe[main.testDeepSlice1]
+      ByteSize: 25
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: a
+          Offset: 1
+          Expression:
+            Type: 61 StructureType main.deepSlice1
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 38, index: 0, name: a}
+                  Offset: 0
+                  ByteSize: 24
+    - __kind: EventRootType
+      ID: 347
+      Name: Probe[main.testDeepSlice7]
+      ByteSize: 9
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: a
+          Offset: 1
+          Expression:
+            Type: 65 PointerType *main.deepSlice7
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 39, index: 0, name: a}
+                  Offset: 0
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 398
       Name: Probe[main.testEmptySliceOfStructs]
       ByteSize: 33
       PresenceBitsetSize: 1
@@ -3651,10 +4209,10 @@ Types:
         - Name: xs
           Offset: 1
           Expression:
-            Type: 140 GoSliceHeaderType []main.structWithNoStrings
+            Type: 163 GoSliceHeaderType []main.structWithNoStrings
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 82, index: 0, name: xs}
+                  Variable: {subprogram: 90, index: 0, name: xs}
                   Offset: 0
                   ByteSize: 24
         - Name: a
@@ -3663,11 +4221,11 @@ Types:
             Type: 9 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 82, index: 1, name: a}
+                  Variable: {subprogram: 90, index: 1, name: a}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 292
+      ID: 395
       Name: Probe[main.testEmptySlice]
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -3675,14 +4233,14 @@ Types:
         - Name: u
           Offset: 1
           Expression:
-            Type: 137 GoSliceHeaderType []uint
+            Type: 160 GoSliceHeaderType []uint
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 79, index: 0, name: u}
+                  Variable: {subprogram: 87, index: 0, name: u}
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 309
+      ID: 412
       Name: Probe[main.testEmptyString]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -3693,11 +4251,11 @@ Types:
             Type: 11 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 96, index: 0, name: x}
+                  Variable: {subprogram: 104, index: 0, name: x}
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 311
+      ID: 414
       Name: Probe[main.testEmptyStruct]
       ByteSize: 1
       PresenceBitsetSize: 1
@@ -3705,14 +4263,14 @@ Types:
         - Name: e
           Offset: 1
           Expression:
-            Type: 152 StructureType main.emptyStruct
+            Type: 175 StructureType main.emptyStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 98, index: 0, name: e}
+                  Variable: {subprogram: 106, index: 0, name: e}
                   Offset: 0
                   ByteSize: 0
     - __kind: EventRootType
-      ID: 259
+      ID: 362
       Name: Probe[main.testError]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -3723,11 +4281,11 @@ Types:
             Type: 18 GoInterfaceType error
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 46, index: 0, name: e}
+                  Variable: {subprogram: 54, index: 0, name: e}
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 250
+      ID: 353
       Name: Probe[main.testEsotericHeap]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -3735,14 +4293,14 @@ Types:
         - Name: e
           Offset: 1
           Expression:
-            Type: 61 PointerType *main.esotericHeap
+            Type: 86 PointerType *main.esotericHeap
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 37, index: 0, name: e}
+                  Variable: {subprogram: 45, index: 0, name: e}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 249
+      ID: 352
       Name: Probe[main.testEsotericStack]
       ByteSize: 65
       PresenceBitsetSize: 1
@@ -3750,14 +4308,14 @@ Types:
         - Name: e
           Offset: 1
           Expression:
-            Type: 56 StructureType main.esotericStack
+            Type: 81 StructureType main.esotericStack
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 36, index: 0, name: e}
+                  Variable: {subprogram: 44, index: 0, name: e}
                   Offset: 0
                   ByteSize: 64
     - __kind: EventRootType
-      ID: 256
+      ID: 359
       Name: Probe[main.testFramelessArray]
       ByteSize: 41
       PresenceBitsetSize: 1
@@ -3765,14 +4323,14 @@ Types:
         - Name: a
           Offset: 1
           Expression:
-            Type: 63 ArrayType [5]int
+            Type: 88 ArrayType [5]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 43, index: 0, name: a}
+                  Variable: {subprogram: 51, index: 0, name: a}
                   Offset: 0
                   ByteSize: 40
     - __kind: EventRootType
-      ID: 255
+      ID: 358
       Name: Probe[main.testFrameless]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -3783,11 +4341,11 @@ Types:
             Type: 9 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 42, index: 0, name: x}
+                  Variable: {subprogram: 50, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 251
+      ID: 354
       Name: Probe[main.testInlinedBA]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -3798,11 +4356,11 @@ Types:
             Type: 9 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 38, index: 0, name: x}
+                  Variable: {subprogram: 46, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 253
+      ID: 356
       Name: Probe[main.testInlinedBBA]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -3813,14 +4371,14 @@ Types:
             Type: 9 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 40, index: 0, name: x}
+                  Variable: {subprogram: 48, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 313
+      ID: 416
       Name: Probe[main.testInlinedBBB]
     - __kind: EventRootType
-      ID: 252
+      ID: 355
       Name: Probe[main.testInlinedBB]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -3831,7 +4389,7 @@ Types:
             Type: 9 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 39, index: 0, name: x}
+                  Variable: {subprogram: 47, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
         - Name: y
@@ -3840,20 +4398,20 @@ Types:
             Type: 9 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 39, index: 1, name: y}
+                  Variable: {subprogram: 47, index: 1, name: y}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 314
+      ID: 417
       Name: Probe[main.testInlinedBCA]
     - __kind: EventRootType
-      ID: 315
+      ID: 418
       Name: Probe[main.testInlinedBCB]
     - __kind: EventRootType
-      ID: 254
+      ID: 357
       Name: Probe[main.testInlinedBC]
     - __kind: EventRootType
-      ID: 312
+      ID: 415
       Name: Probe[main.testInlinedPrint]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -3864,11 +4422,11 @@ Types:
             Type: 9 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 99, index: 0, name: x}
+                  Variable: {subprogram: 107, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 316
+      ID: 419
       Name: Probe[main.testInlinedSq]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -3879,11 +4437,11 @@ Types:
             Type: 9 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 103, index: 0, name: x}
+                  Variable: {subprogram: 111, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 317
+      ID: 420
       Name: Probe[main.testInlinedSumArray]
       ByteSize: 41
       PresenceBitsetSize: 1
@@ -3891,14 +4449,14 @@ Types:
         - Name: a
           Offset: 1
           Expression:
-            Type: 63 ArrayType [5]int
+            Type: 88 ArrayType [5]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 104, index: 0, name: a}
+                  Variable: {subprogram: 112, index: 0, name: a}
                   Offset: 0
                   ByteSize: 40
     - __kind: EventRootType
-      ID: 220
+      ID: 315
       Name: Probe[main.testInt16Array]
       ByteSize: 5
       PresenceBitsetSize: 1
@@ -3913,7 +4471,7 @@ Types:
                   Offset: 0
                   ByteSize: 4
     - __kind: EventRootType
-      ID: 221
+      ID: 316
       Name: Probe[main.testInt32Array]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -3928,7 +4486,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 222
+      ID: 317
       Name: Probe[main.testInt64Array]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -3943,7 +4501,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 219
+      ID: 314
       Name: Probe[main.testInt8Array]
       ByteSize: 3
       PresenceBitsetSize: 1
@@ -3958,7 +4516,7 @@ Types:
                   Offset: 0
                   ByteSize: 2
     - __kind: EventRootType
-      ID: 218
+      ID: 313
       Name: Probe[main.testIntArray]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -3973,7 +4531,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 257
+      ID: 360
       Name: Probe[main.testInterface]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -3981,14 +4539,14 @@ Types:
         - Name: b
           Offset: 1
           Expression:
-            Type: 64 GoInterfaceType main.behavior
+            Type: 89 GoInterfaceType main.behavior
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 44, index: 0, name: b}
+                  Variable: {subprogram: 52, index: 0, name: b}
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 284
+      ID: 387
       Name: Probe[main.testLinkedList]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -3996,14 +4554,14 @@ Types:
         - Name: a
           Offset: 1
           Expression:
-            Type: 133 StructureType main.node
+            Type: 156 StructureType main.node
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 71, index: 0, name: a}
+                  Variable: {subprogram: 79, index: 0, name: a}
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 264
+      ID: 367
       Name: Probe[main.testMapArrayToArray]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -4011,14 +4569,14 @@ Types:
         - Name: m
           Offset: 1
           Expression:
-            Type: 88 GoMapType map[[4]string][2]int
+            Type: 111 GoMapType map[[4]string][2]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 51, index: 0, name: m}
+                  Variable: {subprogram: 59, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 270
+      ID: 373
       Name: Probe[main.testMapEmbeddedMaps]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -4026,14 +4584,14 @@ Types:
         - Name: m
           Offset: 1
           Expression:
-            Type: 95 GoMapType map[string][]main.structWithMap
+            Type: 118 GoMapType map[string][]main.structWithMap
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 57, index: 0, name: m}
+                  Variable: {subprogram: 65, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 268
+      ID: 371
       Name: Probe[main.testMapIntToInt]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -4041,14 +4599,14 @@ Types:
         - Name: m
           Offset: 1
           Expression:
-            Type: 66 GoMapType map[int]int
+            Type: 91 GoMapType map[int]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 55, index: 0, name: m}
+                  Variable: {subprogram: 63, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 279
+      ID: 382
       Name: Probe[main.testMapLargeKeyLargeValue]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -4056,14 +4614,14 @@ Types:
         - Name: m
           Offset: 1
           Expression:
-            Type: 125 GoMapType map[[4]int][4]int
+            Type: 148 GoMapType map[[4]int][4]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 66, index: 0, name: m}
+                  Variable: {subprogram: 74, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 278
+      ID: 381
       Name: Probe[main.testMapLargeKeySmallValue]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -4071,14 +4629,14 @@ Types:
         - Name: m
           Offset: 1
           Expression:
-            Type: 120 GoMapType map[[4]int]uint8
+            Type: 143 GoMapType map[[4]int]uint8
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 65, index: 0, name: m}
+                  Variable: {subprogram: 73, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 269
+      ID: 372
       Name: Probe[main.testMapMassive]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -4086,14 +4644,14 @@ Types:
         - Name: redactMyEntries
           Offset: 1
           Expression:
-            Type: 95 GoMapType map[string][]main.structWithMap
+            Type: 118 GoMapType map[string][]main.structWithMap
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 56, index: 0, name: redactMyEntries}
+                  Variable: {subprogram: 64, index: 0, name: redactMyEntries}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 277
+      ID: 380
       Name: Probe[main.testMapSmallKeyLargeValue]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -4101,14 +4659,14 @@ Types:
         - Name: m
           Offset: 1
           Expression:
-            Type: 115 GoMapType map[uint8][4]int
+            Type: 138 GoMapType map[uint8][4]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 64, index: 0, name: m}
+                  Variable: {subprogram: 72, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 276
+      ID: 379
       Name: Probe[main.testMapSmallKeySmallValue]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -4116,14 +4674,14 @@ Types:
         - Name: m
           Offset: 1
           Expression:
-            Type: 110 GoMapType map[uint8]uint8
+            Type: 133 GoMapType map[uint8]uint8
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 63, index: 0, name: m}
+                  Variable: {subprogram: 71, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 262
+      ID: 365
       Name: Probe[main.testMapStringToInt]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -4131,14 +4689,14 @@ Types:
         - Name: m
           Offset: 1
           Expression:
-            Type: 78 GoMapType map[string]int
+            Type: 101 GoMapType map[string]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 49, index: 0, name: m}
+                  Variable: {subprogram: 57, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 263
+      ID: 366
       Name: Probe[main.testMapStringToSlice]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -4146,14 +4704,14 @@ Types:
         - Name: m
           Offset: 1
           Expression:
-            Type: 83 GoMapType map[string][]string
+            Type: 106 GoMapType map[string][]string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 50, index: 0, name: m}
+                  Variable: {subprogram: 58, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 261
+      ID: 364
       Name: Probe[main.testMapStringToStruct]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -4161,14 +4719,14 @@ Types:
         - Name: m
           Offset: 1
           Expression:
-            Type: 73 GoMapType map[string]main.nestedStruct
+            Type: 96 GoMapType map[string]main.nestedStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 48, index: 0, name: m}
+                  Variable: {subprogram: 56, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 271
+      ID: 374
       Name: Probe[main.testMapWithLinkedList]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -4176,14 +4734,14 @@ Types:
         - Name: m
           Offset: 1
           Expression:
-            Type: 100 GoMapType map[bool]main.node
+            Type: 123 GoMapType map[bool]main.node
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 58, index: 0, name: m}
+                  Variable: {subprogram: 66, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 275
+      ID: 378
       Name: Probe[main.testMapWithSmallKeyAndValueMassive]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -4191,14 +4749,14 @@ Types:
         - Name: m
           Offset: 1
           Expression:
-            Type: 110 GoMapType map[uint8]uint8
+            Type: 133 GoMapType map[uint8]uint8
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 62, index: 0, name: m}
+                  Variable: {subprogram: 70, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 274
+      ID: 377
       Name: Probe[main.testMapWithSmallKeyAndValue]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -4206,14 +4764,14 @@ Types:
         - Name: m
           Offset: 1
           Expression:
-            Type: 110 GoMapType map[uint8]uint8
+            Type: 133 GoMapType map[uint8]uint8
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 61, index: 0, name: m}
+                  Variable: {subprogram: 69, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 273
+      ID: 376
       Name: Probe[main.testMapWithSmallValueMassive]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -4221,14 +4779,14 @@ Types:
         - Name: redactMyEntries
           Offset: 1
           Expression:
-            Type: 105 GoMapType map[int]uint8
+            Type: 128 GoMapType map[int]uint8
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 60, index: 0, name: redactMyEntries}
+                  Variable: {subprogram: 68, index: 0, name: redactMyEntries}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 272
+      ID: 375
       Name: Probe[main.testMapWithSmallValue]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -4236,14 +4794,14 @@ Types:
         - Name: m
           Offset: 1
           Expression:
-            Type: 105 GoMapType map[int]uint8
+            Type: 128 GoMapType map[int]uint8
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 59, index: 0, name: m}
+                  Variable: {subprogram: 67, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 307
+      ID: 410
       Name: Probe[main.testMassiveString]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -4254,11 +4812,11 @@ Types:
             Type: 11 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 94, index: 0, name: x}
+                  Variable: {subprogram: 102, index: 0, name: x}
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 281
+      ID: 384
       Name: Probe[main.testMultipleSimpleParams]
       ByteSize: 31
       PresenceBitsetSize: 1
@@ -4269,7 +4827,7 @@ Types:
             Type: 4 BaseType bool
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 68, index: 0, name: a}
+                  Variable: {subprogram: 76, index: 0, name: a}
                   Offset: 0
                   ByteSize: 1
         - Name: b
@@ -4278,7 +4836,7 @@ Types:
             Type: 3 BaseType uint8
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 68, index: 1, name: b}
+                  Variable: {subprogram: 76, index: 1, name: b}
                   Offset: 0
                   ByteSize: 1
         - Name: c
@@ -4287,7 +4845,7 @@ Types:
             Type: 13 BaseType int32
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 68, index: 2, name: c}
+                  Variable: {subprogram: 76, index: 2, name: c}
                   Offset: 0
                   ByteSize: 4
         - Name: d
@@ -4296,7 +4854,7 @@ Types:
             Type: 12 BaseType uint
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 68, index: 3, name: d}
+                  Variable: {subprogram: 76, index: 3, name: d}
                   Offset: 0
                   ByteSize: 8
         - Name: e
@@ -4305,11 +4863,11 @@ Types:
             Type: 11 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 68, index: 4, name: e}
+                  Variable: {subprogram: 76, index: 4, name: e}
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 289
+      ID: 392
       Name: Probe[main.testNilPointer]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -4320,7 +4878,7 @@ Types:
             Type: 5 PointerType *bool
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 76, index: 0, name: z}
+                  Variable: {subprogram: 84, index: 0, name: z}
                   Offset: 0
                   ByteSize: 8
         - Name: a
@@ -4329,11 +4887,11 @@ Types:
             Type: 12 BaseType uint
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 76, index: 1, name: a}
+                  Variable: {subprogram: 84, index: 1, name: a}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 296
+      ID: 399
       Name: Probe[main.testNilSliceOfStructs]
       ByteSize: 33
       PresenceBitsetSize: 1
@@ -4341,10 +4899,10 @@ Types:
         - Name: xs
           Offset: 1
           Expression:
-            Type: 140 GoSliceHeaderType []main.structWithNoStrings
+            Type: 163 GoSliceHeaderType []main.structWithNoStrings
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 83, index: 0, name: xs}
+                  Variable: {subprogram: 91, index: 0, name: xs}
                   Offset: 0
                   ByteSize: 24
         - Name: a
@@ -4353,11 +4911,11 @@ Types:
             Type: 9 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 83, index: 1, name: a}
+                  Variable: {subprogram: 91, index: 1, name: a}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 298
+      ID: 401
       Name: Probe[main.testNilSliceWithOtherParams]
       ByteSize: 34
       PresenceBitsetSize: 1
@@ -4368,16 +4926,16 @@ Types:
             Type: 15 BaseType int8
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 85, index: 0, name: a}
+                  Variable: {subprogram: 93, index: 0, name: a}
                   Offset: 0
                   ByteSize: 1
         - Name: s
           Offset: 2
           Expression:
-            Type: 144 GoSliceHeaderType []bool
+            Type: 167 GoSliceHeaderType []bool
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 85, index: 1, name: s}
+                  Variable: {subprogram: 93, index: 1, name: s}
                   Offset: 0
                   ByteSize: 24
         - Name: x
@@ -4386,11 +4944,11 @@ Types:
             Type: 12 BaseType uint
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 85, index: 2, name: x}
+                  Variable: {subprogram: 93, index: 2, name: x}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 299
+      ID: 402
       Name: Probe[main.testNilSlice]
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -4398,14 +4956,14 @@ Types:
         - Name: xs
           Offset: 1
           Expression:
-            Type: 145 GoSliceHeaderType []uint16
+            Type: 168 GoSliceHeaderType []uint16
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 86, index: 0, name: xs}
+                  Variable: {subprogram: 94, index: 0, name: xs}
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 306
+      ID: 409
       Name: Probe[main.testOneStringInStructPointer]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -4413,14 +4971,14 @@ Types:
         - Name: a
           Offset: 1
           Expression:
-            Type: 148 PointerType *main.oneStringStruct
+            Type: 171 PointerType *main.oneStringStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 93, index: 0, name: a}
+                  Variable: {subprogram: 101, index: 0, name: a}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 285
+      ID: 388
       Name: Probe[main.testPointerLoop]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -4428,14 +4986,14 @@ Types:
         - Name: a
           Offset: 1
           Expression:
-            Type: 134 PointerType *main.node
+            Type: 157 PointerType *main.node
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 72, index: 0, name: a}
+                  Variable: {subprogram: 80, index: 0, name: a}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 267
+      ID: 370
       Name: Probe[main.testPointerToMap]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -4443,14 +5001,14 @@ Types:
         - Name: m
           Offset: 1
           Expression:
-            Type: 94 PointerType *map[string]int
+            Type: 117 PointerType *map[string]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 54, index: 0, name: m}
+                  Variable: {subprogram: 62, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 283
+      ID: 386
       Name: Probe[main.testPointerToSimpleStruct]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -4458,14 +5016,14 @@ Types:
         - Name: a
           Offset: 1
           Expression:
-            Type: 131 PointerType *main.structWithTwoValues
+            Type: 154 PointerType *main.structWithTwoValues
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 70, index: 0, name: a}
+                  Variable: {subprogram: 78, index: 0, name: a}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 215
+      ID: 310
       Name: Probe[main.testRuneArray]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -4480,7 +5038,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 234
+      ID: 329
       Name: Probe[main.testSingleBool]
       ByteSize: 2
       PresenceBitsetSize: 1
@@ -4495,7 +5053,7 @@ Types:
                   Offset: 0
                   ByteSize: 1
     - __kind: EventRootType
-      ID: 232
+      ID: 327
       Name: Probe[main.testSingleByte]
       ByteSize: 2
       PresenceBitsetSize: 1
@@ -4510,7 +5068,7 @@ Types:
                   Offset: 0
                   ByteSize: 1
     - __kind: EventRootType
-      ID: 245
+      ID: 340
       Name: Probe[main.testSingleFloat32]
       ByteSize: 5
       PresenceBitsetSize: 1
@@ -4525,7 +5083,7 @@ Types:
                   Offset: 0
                   ByteSize: 4
     - __kind: EventRootType
-      ID: 246
+      ID: 341
       Name: Probe[main.testSingleFloat64]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -4540,7 +5098,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 237
+      ID: 332
       Name: Probe[main.testSingleInt16]
       ByteSize: 3
       PresenceBitsetSize: 1
@@ -4555,7 +5113,7 @@ Types:
                   Offset: 0
                   ByteSize: 2
     - __kind: EventRootType
-      ID: 238
+      ID: 333
       Name: Probe[main.testSingleInt32]
       ByteSize: 5
       PresenceBitsetSize: 1
@@ -4570,7 +5128,7 @@ Types:
                   Offset: 0
                   ByteSize: 4
     - __kind: EventRootType
-      ID: 239
+      ID: 334
       Name: Probe[main.testSingleInt64]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -4585,7 +5143,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 236
+      ID: 331
       Name: Probe[main.testSingleInt8]
       ByteSize: 2
       PresenceBitsetSize: 1
@@ -4600,7 +5158,7 @@ Types:
                   Offset: 0
                   ByteSize: 1
     - __kind: EventRootType
-      ID: 235
+      ID: 330
       Name: Probe[main.testSingleInt]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -4615,7 +5173,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 233
+      ID: 328
       Name: Probe[main.testSingleRune]
       ByteSize: 5
       PresenceBitsetSize: 1
@@ -4630,7 +5188,7 @@ Types:
                   Offset: 0
                   ByteSize: 4
     - __kind: EventRootType
-      ID: 302
+      ID: 405
       Name: Probe[main.testSingleString]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -4641,11 +5199,11 @@ Types:
             Type: 11 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 89, index: 0, name: x}
+                  Variable: {subprogram: 97, index: 0, name: x}
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 242
+      ID: 337
       Name: Probe[main.testSingleUint16]
       ByteSize: 3
       PresenceBitsetSize: 1
@@ -4660,7 +5218,7 @@ Types:
                   Offset: 0
                   ByteSize: 2
     - __kind: EventRootType
-      ID: 243
+      ID: 338
       Name: Probe[main.testSingleUint32]
       ByteSize: 5
       PresenceBitsetSize: 1
@@ -4675,7 +5233,7 @@ Types:
                   Offset: 0
                   ByteSize: 4
     - __kind: EventRootType
-      ID: 244
+      ID: 339
       Name: Probe[main.testSingleUint64]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -4690,7 +5248,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 241
+      ID: 336
       Name: Probe[main.testSingleUint8]
       ByteSize: 2
       PresenceBitsetSize: 1
@@ -4705,7 +5263,7 @@ Types:
                   Offset: 0
                   ByteSize: 1
     - __kind: EventRootType
-      ID: 240
+      ID: 335
       Name: Probe[main.testSingleUint]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -4720,7 +5278,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 293
+      ID: 396
       Name: Probe[main.testSliceOfSlices]
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -4728,14 +5286,14 @@ Types:
         - Name: u
           Offset: 1
           Expression:
-            Type: 138 GoSliceHeaderType [][]uint
+            Type: 161 GoSliceHeaderType [][]uint
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 80, index: 0, name: u}
+                  Variable: {subprogram: 88, index: 0, name: u}
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 265
+      ID: 368
       Name: Probe[main.testSmallMap]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -4743,14 +5301,14 @@ Types:
         - Name: m
           Offset: 1
           Expression:
-            Type: 78 GoMapType map[string]int
+            Type: 101 GoMapType map[string]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 52, index: 0, name: m}
+                  Variable: {subprogram: 60, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 216
+      ID: 311
       Name: Probe[main.testStringArray]
       ByteSize: 33
       PresenceBitsetSize: 1
@@ -4765,7 +5323,7 @@ Types:
                   Offset: 0
                   ByteSize: 32
     - __kind: EventRootType
-      ID: 288
+      ID: 391
       Name: Probe[main.testStringPointer]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -4776,11 +5334,11 @@ Types:
             Type: 22 PointerType *string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 75, index: 0, name: z}
+                  Variable: {subprogram: 83, index: 0, name: z}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 297
+      ID: 400
       Name: Probe[main.testStringSlice]
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -4788,14 +5346,44 @@ Types:
         - Name: s
           Offset: 1
           Expression:
-            Type: 143 GoSliceHeaderType []string
+            Type: 166 GoSliceHeaderType []string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 84, index: 0, name: s}
+                  Variable: {subprogram: 92, index: 0, name: s}
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 294
+      ID: 350
+      Name: Probe[main.testStringType1]
+      ByteSize: 9
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: a
+          Offset: 1
+          Expression:
+            Type: 77 PointerType *main.stringType1
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 42, index: 0, name: a}
+                  Offset: 0
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 351
+      Name: Probe[main.testStringType2]
+      ByteSize: 9
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: a
+          Offset: 1
+          Expression:
+            Type: 79 PointerType **main.stringType2
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 43, index: 0, name: a}
+                  Offset: 0
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 397
       Name: Probe[main.testStructSlice]
       ByteSize: 33
       PresenceBitsetSize: 1
@@ -4803,10 +5391,10 @@ Types:
         - Name: xs
           Offset: 1
           Expression:
-            Type: 140 GoSliceHeaderType []main.structWithNoStrings
+            Type: 163 GoSliceHeaderType []main.structWithNoStrings
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 81, index: 0, name: xs}
+                  Variable: {subprogram: 89, index: 0, name: xs}
                   Offset: 0
                   ByteSize: 24
         - Name: a
@@ -4815,11 +5403,11 @@ Types:
             Type: 9 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 81, index: 1, name: a}
+                  Variable: {subprogram: 89, index: 1, name: a}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 260
+      ID: 363
       Name: Probe[main.testStructWithMap]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -4827,14 +5415,14 @@ Types:
         - Name: s
           Offset: 1
           Expression:
-            Type: 65 StructureType main.structWithMap
+            Type: 90 StructureType main.structWithMap
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 47, index: 0, name: s}
+                  Variable: {subprogram: 55, index: 0, name: s}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 310
+      ID: 413
       Name: Probe[main.testStruct]
       ByteSize: 57
       PresenceBitsetSize: 1
@@ -4842,14 +5430,14 @@ Types:
         - Name: x
           Offset: 1
           Expression:
-            Type: 150 StructureType main.aStruct
+            Type: 173 StructureType main.aStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 97, index: 0, name: x}
+                  Variable: {subprogram: 105, index: 0, name: x}
                   Offset: 0
                   ByteSize: 56
     - __kind: EventRootType
-      ID: 305
+      ID: 408
       Name: Probe[main.testThreeStringsInStructPointer]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -4857,14 +5445,14 @@ Types:
         - Name: a
           Offset: 1
           Expression:
-            Type: 147 PointerType *main.threeStringStruct
+            Type: 170 PointerType *main.threeStringStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 92, index: 0, name: a}
+                  Variable: {subprogram: 100, index: 0, name: a}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 304
+      ID: 407
       Name: Probe[main.testThreeStringsInStruct]
       ByteSize: 49
       PresenceBitsetSize: 1
@@ -4872,14 +5460,14 @@ Types:
         - Name: a
           Offset: 1
           Expression:
-            Type: 146 StructureType main.threeStringStruct
+            Type: 169 StructureType main.threeStringStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 91, index: 0, name: a}
+                  Variable: {subprogram: 99, index: 0, name: a}
                   Offset: 0
                   ByteSize: 48
     - __kind: EventRootType
-      ID: 303
+      ID: 406
       Name: Probe[main.testThreeStrings]
       ByteSize: 49
       PresenceBitsetSize: 1
@@ -4890,7 +5478,7 @@ Types:
             Type: 11 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 90, index: 0, name: x}
+                  Variable: {subprogram: 98, index: 0, name: x}
                   Offset: 0
                   ByteSize: 16
         - Name: y
@@ -4899,7 +5487,7 @@ Types:
             Type: 11 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 90, index: 1, name: y}
+                  Variable: {subprogram: 98, index: 1, name: y}
                   Offset: 0
                   ByteSize: 16
         - Name: z
@@ -4908,11 +5496,11 @@ Types:
             Type: 11 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 90, index: 2, name: z}
+                  Variable: {subprogram: 98, index: 2, name: z}
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 247
+      ID: 342
       Name: Probe[main.testTypeAlias]
       ByteSize: 3
       PresenceBitsetSize: 1
@@ -4927,7 +5515,7 @@ Types:
                   Offset: 0
                   ByteSize: 2
     - __kind: EventRootType
-      ID: 225
+      ID: 320
       Name: Probe[main.testUint16Array]
       ByteSize: 5
       PresenceBitsetSize: 1
@@ -4942,7 +5530,7 @@ Types:
                   Offset: 0
                   ByteSize: 4
     - __kind: EventRootType
-      ID: 226
+      ID: 321
       Name: Probe[main.testUint32Array]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -4957,7 +5545,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 227
+      ID: 322
       Name: Probe[main.testUint64Array]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -4972,7 +5560,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 224
+      ID: 319
       Name: Probe[main.testUint8Array]
       ByteSize: 3
       PresenceBitsetSize: 1
@@ -4987,7 +5575,7 @@ Types:
                   Offset: 0
                   ByteSize: 2
     - __kind: EventRootType
-      ID: 223
+      ID: 318
       Name: Probe[main.testUintArray]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -5002,7 +5590,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 287
+      ID: 390
       Name: Probe[main.testUintPointer]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -5013,11 +5601,11 @@ Types:
             Type: 34 PointerType *uint
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 74, index: 0, name: x}
+                  Variable: {subprogram: 82, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 291
+      ID: 394
       Name: Probe[main.testUintSlice]
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -5025,14 +5613,14 @@ Types:
         - Name: u
           Offset: 1
           Expression:
-            Type: 137 GoSliceHeaderType []uint
+            Type: 160 GoSliceHeaderType []uint
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 78, index: 0, name: u}
+                  Variable: {subprogram: 86, index: 0, name: u}
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 308
+      ID: 411
       Name: Probe[main.testUnitializedString]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -5043,11 +5631,11 @@ Types:
             Type: 11 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 95, index: 0, name: x}
+                  Variable: {subprogram: 103, index: 0, name: x}
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 286
+      ID: 389
       Name: Probe[main.testUnsafePointer]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -5058,11 +5646,11 @@ Types:
             Type: 19 VoidPointerType unsafe.Pointer
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 73, index: 0, name: x}
+                  Variable: {subprogram: 81, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 231
+      ID: 326
       Name: Probe[main.testVeryLargeArray]
       ByteSize: 801
       PresenceBitsetSize: 1
@@ -5077,7 +5665,7 @@ Types:
                   Offset: 0
                   ByteSize: 800
     - __kind: EventRootType
-      ID: 300
+      ID: 403
       Name: Probe[main.testVeryLargeSlice]
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -5085,10 +5673,10 @@ Types:
         - Name: xs
           Offset: 1
           Expression:
-            Type: 137 GoSliceHeaderType []uint
+            Type: 160 GoSliceHeaderType []uint
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 87, index: 0, name: xs}
+                  Variable: {subprogram: 95, index: 0, name: xs}
                   Offset: 0
                   ByteSize: 24
     - __kind: ArrayType
@@ -5127,7 +5715,7 @@ Types:
       ID: 40
       Name: '[2]int'
       ByteSize: 16
-      GoRuntimeType: 617920
+      GoRuntimeType: 622880
       GoKind: 17
       Count: 2
       HasCount: true
@@ -5144,7 +5732,7 @@ Types:
       ID: 37
       Name: '[2]int32'
       ByteSize: 8
-      GoRuntimeType: 619072
+      GoRuntimeType: 624032
       GoKind: 17
       Count: 2
       HasCount: true
@@ -5166,18 +5754,18 @@ Types:
       HasCount: true
       Element: 15 BaseType int8
     - __kind: ArrayType
-      ID: 93
+      ID: 116
       Name: '[2]map[string]int'
       ByteSize: 16
       GoKind: 17
       Count: 2
       HasCount: true
-      Element: 78 GoMapType map[string]int
+      Element: 101 GoMapType map[string]int
     - __kind: ArrayType
       ID: 38
       Name: '[2]string'
       ByteSize: 32
-      GoRuntimeType: 619168
+      GoRuntimeType: 624128
       GoKind: 17
       Count: 2
       HasCount: true
@@ -5210,7 +5798,7 @@ Types:
       ID: 47
       Name: '[2]uint64'
       ByteSize: 16
-      GoRuntimeType: 619264
+      GoRuntimeType: 624224
       GoKind: 17
       Count: 2
       HasCount: true
@@ -5219,31 +5807,31 @@ Types:
       ID: 36
       Name: '[2]uint8'
       ByteSize: 2
-      GoRuntimeType: 618976
+      GoRuntimeType: 623936
       GoKind: 17
       Count: 2
       HasCount: true
       Element: 3 BaseType uint8
     - __kind: ArrayType
-      ID: 183
+      ID: 213
       Name: '[4]int'
       ByteSize: 32
-      GoRuntimeType: 617536
+      GoRuntimeType: 622496
       GoKind: 17
       Count: 4
       HasCount: true
       Element: 9 BaseType int
     - __kind: ArrayType
-      ID: 168
+      ID: 198
       Name: '[4]string'
       ByteSize: 64
-      GoRuntimeType: 617824
+      GoRuntimeType: 622784
       GoKind: 17
       Count: 4
       HasCount: true
       Element: 11 GoStringHeaderType string
     - __kind: ArrayType
-      ID: 63
+      ID: 88
       Name: '[5]int'
       ByteSize: 40
       GoKind: 17
@@ -5251,19 +5839,107 @@ Types:
       HasCount: true
       Element: 9 BaseType int
     - __kind: ArrayType
-      ID: 157
+      ID: 183
       Name: '[8]uint8'
       ByteSize: 8
-      GoRuntimeType: 615616
+      GoRuntimeType: 619808
       GoKind: 17
       Count: 8
       HasCount: true
       Element: 3 BaseType uint8
     - __kind: GoSliceHeaderType
+      ID: 62
+      Name: '[]*main.deepSlice2'
+      ByteSize: 24
+      GoRuntimeType: 446784
+      GoKind: 23
+      RawFields:
+        - Name: array
+          Offset: 0
+          Type: 63 PointerType **main.deepSlice2
+        - Name: len
+          Offset: 8
+          Type: 9 BaseType int
+        - Name: cap
+          Offset: 16
+          Type: 9 BaseType int
+      Data: 181 GoSliceDataType []*main.deepSlice2.array
+    - __kind: GoSliceDataType
+      ID: 181
+      Name: '[]*main.deepSlice2.array'
+      ByteSize: 2048
+      Element: 64 PointerType *main.deepSlice2
+    - __kind: GoSliceHeaderType
+      ID: 235
+      Name: '[]*main.deepSlice3'
+      ByteSize: 24
+      GoRuntimeType: 446720
+      GoKind: 23
+      RawFields:
+        - Name: array
+          Offset: 0
+          Type: 236 PointerType **main.deepSlice3
+        - Name: len
+          Offset: 8
+          Type: 9 BaseType int
+        - Name: cap
+          Offset: 16
+          Type: 9 BaseType int
+      Data: 239 GoSliceDataType []*main.deepSlice3.array
+    - __kind: GoSliceDataType
+      ID: 239
+      Name: '[]*main.deepSlice3.array'
+      ByteSize: 2048
+      Element: 237 PointerType *main.deepSlice3
+    - __kind: GoSliceHeaderType
+      ID: 254
+      Name: '[]*main.deepSlice8'
+      ByteSize: 24
+      GoRuntimeType: 446400
+      GoKind: 23
+      RawFields:
+        - Name: array
+          Offset: 0
+          Type: 255 PointerType **main.deepSlice8
+        - Name: len
+          Offset: 8
+          Type: 9 BaseType int
+        - Name: cap
+          Offset: 16
+          Type: 9 BaseType int
+      Data: 258 GoSliceDataType []*main.deepSlice8.array
+    - __kind: GoSliceDataType
+      ID: 258
+      Name: '[]*main.deepSlice8.array'
+      ByteSize: 2048
+      Element: 256 PointerType *main.deepSlice8
+    - __kind: GoSliceHeaderType
+      ID: 260
+      Name: '[]*main.deepSlice9'
+      ByteSize: 24
+      GoRuntimeType: 446336
+      GoKind: 23
+      RawFields:
+        - Name: array
+          Offset: 0
+          Type: 261 PointerType **main.deepSlice9
+        - Name: len
+          Offset: 8
+          Type: 9 BaseType int
+        - Name: cap
+          Offset: 16
+          Type: 9 BaseType int
+      Data: 264 GoSliceDataType []*main.deepSlice9.array
+    - __kind: GoSliceDataType
+      ID: 264
+      Name: '[]*main.deepSlice9.array'
+      ByteSize: 2048
+      Element: 262 PointerType *main.deepSlice9
+    - __kind: GoSliceHeaderType
       ID: 53
       Name: '[]*string'
       ByteSize: 24
-      GoRuntimeType: 443360
+      GoRuntimeType: 447552
       GoKind: 23
       RawFields:
         - Name: array
@@ -5275,38 +5951,38 @@ Types:
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 155 GoSliceDataType []*string.array
+      Data: 178 GoSliceDataType []*string.array
     - __kind: GoSliceDataType
-      ID: 155
+      ID: 178
       Name: '[]*string.array'
       ByteSize: 2048
       Element: 22 PointerType *string
     - __kind: GoSliceHeaderType
-      ID: 138
+      ID: 161
       Name: '[][]uint'
       ByteSize: 24
       GoKind: 23
       RawFields:
         - Name: array
           Offset: 0
-          Type: 139 PointerType *[]uint
+          Type: 162 PointerType *[]uint
         - Name: len
           Offset: 8
           Type: 9 BaseType int
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 190 GoSliceDataType [][]uint.array
+      Data: 220 GoSliceDataType [][]uint.array
     - __kind: GoSliceDataType
-      ID: 190
+      ID: 220
       Name: '[][]uint.array'
       ByteSize: 2048
-      Element: 137 GoSliceHeaderType []uint
+      Element: 160 GoSliceHeaderType []uint
     - __kind: GoSliceHeaderType
-      ID: 144
+      ID: 167
       Name: '[]bool'
       ByteSize: 24
-      GoRuntimeType: 449888
+      GoRuntimeType: 454080
       GoKind: 23
       RawFields:
         - Name: array
@@ -5318,162 +5994,209 @@ Types:
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 196 GoSliceDataType []bool.array
+      Data: 226 GoSliceDataType []bool.array
     - __kind: GoSliceDataType
-      ID: 196
+      ID: 226
       Name: '[]bool.array'
       ByteSize: 2048
       Element: 4 BaseType bool
     - __kind: GoSliceDataType
-      ID: 187
+      ID: 217
       Name: '[]bucket<[4]int,[4]int>.array'
       ByteSize: 2048
-      Element: 129 GoHMapBucketType bucket<[4]int,[4]int>
+      Element: 152 GoHMapBucketType bucket<[4]int,[4]int>
     - __kind: GoSliceDataType
-      ID: 186
+      ID: 216
       Name: '[]bucket<[4]int,uint8>.array'
       ByteSize: 2048
-      Element: 124 GoHMapBucketType bucket<[4]int,uint8>
+      Element: 147 GoHMapBucketType bucket<[4]int,uint8>
     - __kind: GoSliceDataType
-      ID: 170
+      ID: 200
       Name: '[]bucket<[4]string,[2]int>.array'
       ByteSize: 2048
-      Element: 92 GoHMapBucketType bucket<[4]string,[2]int>
+      Element: 115 GoHMapBucketType bucket<[4]string,[2]int>
     - __kind: GoSliceDataType
-      ID: 177
+      ID: 207
       Name: '[]bucket<bool,main.node>.array'
       ByteSize: 2048
-      Element: 104 GoHMapBucketType bucket<bool,main.node>
+      Element: 127 GoHMapBucketType bucket<bool,main.node>
     - __kind: GoSliceDataType
-      ID: 160
+      ID: 188
+      Name: '[]bucket<int,*main.deepMap2>.array'
+      ByteSize: 2048
+      Element: 72 GoHMapBucketType bucket<int,*main.deepMap2>
+    - __kind: GoSliceDataType
+      ID: 249
+      Name: '[]bucket<int,*main.deepMap3>.array'
+      ByteSize: 2048
+      Element: 245 GoHMapBucketType bucket<int,*main.deepMap3>
+    - __kind: GoSliceDataType
+      ID: 278
+      Name: '[]bucket<int,*main.deepMap8>.array'
+      ByteSize: 2048
+      Element: 274 GoHMapBucketType bucket<int,*main.deepMap8>
+    - __kind: GoSliceDataType
+      ID: 287
+      Name: '[]bucket<int,*main.deepMap9>.array'
+      ByteSize: 2048
+      Element: 283 GoHMapBucketType bucket<int,*main.deepMap9>
+    - __kind: GoSliceDataType
+      ID: 190
       Name: '[]bucket<int,int>.array'
       ByteSize: 2048
-      Element: 70 GoHMapBucketType bucket<int,int>
+      Element: 95 GoHMapBucketType bucket<int,int>
     - __kind: GoSliceDataType
-      ID: 179
+      ID: 294
+      Name: '[]bucket<int,interface {}>.array'
+      ByteSize: 2048
+      Element: 292 GoHMapBucketType bucket<int,interface {}>
+    - __kind: GoSliceDataType
+      ID: 209
       Name: '[]bucket<int,uint8>.array'
       ByteSize: 2048
-      Element: 109 GoHMapBucketType bucket<int,uint8>
+      Element: 132 GoHMapBucketType bucket<int,uint8>
     - __kind: GoSliceDataType
-      ID: 174
+      ID: 204
       Name: '[]bucket<string,[]main.structWithMap>.array'
       ByteSize: 2048
-      Element: 99 GoHMapBucketType bucket<string,[]main.structWithMap>
+      Element: 122 GoHMapBucketType bucket<string,[]main.structWithMap>
     - __kind: GoSliceDataType
-      ID: 166
+      ID: 196
       Name: '[]bucket<string,[]string>.array'
       ByteSize: 2048
-      Element: 87 GoHMapBucketType bucket<string,[]string>
+      Element: 110 GoHMapBucketType bucket<string,[]string>
     - __kind: GoSliceDataType
-      ID: 164
+      ID: 194
       Name: '[]bucket<string,int>.array'
       ByteSize: 2048
-      Element: 82 GoHMapBucketType bucket<string,int>
+      Element: 105 GoHMapBucketType bucket<string,int>
     - __kind: GoSliceDataType
-      ID: 163
+      ID: 193
       Name: '[]bucket<string,main.nestedStruct>.array'
       ByteSize: 2048
-      Element: 77 GoHMapBucketType bucket<string,main.nestedStruct>
+      Element: 100 GoHMapBucketType bucket<string,main.nestedStruct>
     - __kind: GoSliceDataType
-      ID: 184
+      ID: 214
       Name: '[]bucket<uint8,[4]int>.array'
       ByteSize: 2048
-      Element: 119 GoHMapBucketType bucket<uint8,[4]int>
+      Element: 142 GoHMapBucketType bucket<uint8,[4]int>
     - __kind: GoSliceDataType
-      ID: 181
+      ID: 211
       Name: '[]bucket<uint8,uint8>.array'
       ByteSize: 2048
-      Element: 114 GoHMapBucketType bucket<uint8,uint8>
+      Element: 137 GoHMapBucketType bucket<uint8,uint8>
+    - __kind: GoSliceHeaderType
+      ID: 266
+      Name: '[]interface {}'
+      ByteSize: 24
+      GoRuntimeType: 454400
+      GoKind: 23
+      RawFields:
+        - Name: array
+          Offset: 0
+          Type: 267 PointerType *interface {}
+        - Name: len
+          Offset: 8
+          Type: 9 BaseType int
+        - Name: cap
+          Offset: 16
+          Type: 9 BaseType int
+      Data: 268 GoSliceDataType []interface {}.array
+    - __kind: GoSliceDataType
+      ID: 268
+      Name: '[]interface {}.array'
+      ByteSize: 2048
+      Element: 83 GoEmptyInterfaceType interface {}
     - __kind: ArrayType
-      ID: 185
+      ID: 215
       Name: '[]key<[4]int>'
       ByteSize: 256
       Count: 8
       HasCount: true
-      Element: 183 ArrayType [4]int
+      Element: 213 ArrayType [4]int
     - __kind: ArrayType
-      ID: 167
+      ID: 197
       Name: '[]key<[4]string>'
       ByteSize: 512
       Count: 8
       HasCount: true
-      Element: 168 ArrayType [4]string
+      Element: 198 ArrayType [4]string
     - __kind: ArrayType
-      ID: 175
+      ID: 205
       Name: '[]key<bool>'
       ByteSize: 8
       Count: 8
       HasCount: true
       Element: 4 BaseType bool
     - __kind: ArrayType
-      ID: 158
+      ID: 184
       Name: '[]key<int>'
       ByteSize: 64
       Count: 8
       HasCount: true
       Element: 9 BaseType int
     - __kind: ArrayType
-      ID: 161
+      ID: 191
       Name: '[]key<string>'
       ByteSize: 128
       Count: 8
       HasCount: true
       Element: 11 GoStringHeaderType string
     - __kind: ArrayType
-      ID: 180
+      ID: 210
       Name: '[]key<uint8>'
       ByteSize: 8
       Count: 8
       HasCount: true
       Element: 3 BaseType uint8
     - __kind: GoSliceHeaderType
-      ID: 172
+      ID: 202
       Name: '[]main.structWithMap'
       ByteSize: 24
-      GoRuntimeType: 442848
+      GoRuntimeType: 447040
       GoKind: 23
       RawFields:
         - Name: array
           Offset: 0
-          Type: 173 PointerType *main.structWithMap
+          Type: 203 PointerType *main.structWithMap
         - Name: len
           Offset: 8
           Type: 9 BaseType int
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 212 GoSliceDataType []main.structWithMap.array
+      Data: 307 GoSliceDataType []main.structWithMap.array
     - __kind: GoSliceDataType
-      ID: 212
+      ID: 307
       Name: '[]main.structWithMap.array'
       ByteSize: 2048
-      Element: 65 StructureType main.structWithMap
+      Element: 90 StructureType main.structWithMap
     - __kind: GoSliceHeaderType
-      ID: 140
+      ID: 163
       Name: '[]main.structWithNoStrings'
       ByteSize: 24
       GoKind: 23
       RawFields:
         - Name: array
           Offset: 0
-          Type: 141 PointerType *main.structWithNoStrings
+          Type: 164 PointerType *main.structWithNoStrings
         - Name: len
           Offset: 8
           Type: 9 BaseType int
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 192 GoSliceDataType []main.structWithNoStrings.array
+      Data: 222 GoSliceDataType []main.structWithNoStrings.array
     - __kind: GoSliceDataType
-      ID: 192
+      ID: 222
       Name: '[]main.structWithNoStrings.array'
       ByteSize: 2048
-      Element: 142 StructureType main.structWithNoStrings
+      Element: 165 StructureType main.structWithNoStrings
     - __kind: GoSliceHeaderType
-      ID: 143
+      ID: 166
       Name: '[]string'
       ByteSize: 24
-      GoRuntimeType: 450016
+      GoRuntimeType: 454208
       GoKind: 23
       RawFields:
         - Name: array
@@ -5485,17 +6208,17 @@ Types:
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 194 GoSliceDataType []string.array
+      Data: 224 GoSliceDataType []string.array
     - __kind: GoSliceDataType
-      ID: 194
+      ID: 224
       Name: '[]string.array'
       ByteSize: 2048
       Element: 11 GoStringHeaderType string
     - __kind: GoSliceHeaderType
-      ID: 137
+      ID: 160
       Name: '[]uint'
       ByteSize: 24
-      GoRuntimeType: 449504
+      GoRuntimeType: 453696
       GoKind: 23
       RawFields:
         - Name: array
@@ -5507,17 +6230,17 @@ Types:
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 188 GoSliceDataType []uint.array
+      Data: 218 GoSliceDataType []uint.array
     - __kind: GoSliceDataType
-      ID: 188
+      ID: 218
       Name: '[]uint.array'
       ByteSize: 2048
       Element: 12 BaseType uint
     - __kind: GoSliceHeaderType
-      ID: 145
+      ID: 168
       Name: '[]uint16'
       ByteSize: 24
-      GoRuntimeType: 448864
+      GoRuntimeType: 453056
       GoKind: 23
       RawFields:
         - Name: array
@@ -5529,63 +6252,98 @@ Types:
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 198 GoSliceDataType []uint16.array
+      Data: 228 GoSliceDataType []uint16.array
     - __kind: GoSliceDataType
-      ID: 198
+      ID: 228
       Name: '[]uint16.array'
       ByteSize: 2048
       Element: 7 BaseType uint16
     - __kind: ArrayType
-      ID: 169
+      ID: 185
+      Name: '[]val<*main.deepMap2>'
+      ByteSize: 64
+      Count: 8
+      HasCount: true
+      Element: 186 PointerType *main.deepMap2
+    - __kind: ArrayType
+      ID: 246
+      Name: '[]val<*main.deepMap3>'
+      ByteSize: 64
+      Count: 8
+      HasCount: true
+      Element: 247 PointerType *main.deepMap3
+    - __kind: ArrayType
+      ID: 275
+      Name: '[]val<*main.deepMap8>'
+      ByteSize: 64
+      Count: 8
+      HasCount: true
+      Element: 276 PointerType *main.deepMap8
+    - __kind: ArrayType
+      ID: 284
+      Name: '[]val<*main.deepMap9>'
+      ByteSize: 64
+      Count: 8
+      HasCount: true
+      Element: 285 PointerType *main.deepMap9
+    - __kind: ArrayType
+      ID: 199
       Name: '[]val<[2]int>'
       ByteSize: 128
       Count: 8
       HasCount: true
       Element: 40 ArrayType [2]int
     - __kind: ArrayType
-      ID: 182
+      ID: 212
       Name: '[]val<[4]int>'
       ByteSize: 256
       Count: 8
       HasCount: true
-      Element: 183 ArrayType [4]int
+      Element: 213 ArrayType [4]int
     - __kind: ArrayType
-      ID: 171
+      ID: 201
       Name: '[]val<[]main.structWithMap>'
       ByteSize: 192
       Count: 8
       HasCount: true
-      Element: 172 GoSliceHeaderType []main.structWithMap
+      Element: 202 GoSliceHeaderType []main.structWithMap
     - __kind: ArrayType
-      ID: 165
+      ID: 195
       Name: '[]val<[]string>'
       ByteSize: 192
       Count: 8
       HasCount: true
-      Element: 143 GoSliceHeaderType []string
+      Element: 166 GoSliceHeaderType []string
     - __kind: ArrayType
-      ID: 159
+      ID: 189
       Name: '[]val<int>'
       ByteSize: 64
       Count: 8
       HasCount: true
       Element: 9 BaseType int
     - __kind: ArrayType
-      ID: 162
+      ID: 293
+      Name: '[]val<interface {}>'
+      ByteSize: 128
+      Count: 8
+      HasCount: true
+      Element: 83 GoEmptyInterfaceType interface {}
+    - __kind: ArrayType
+      ID: 192
       Name: '[]val<main.nestedStruct>'
       ByteSize: 192
       Count: 8
       HasCount: true
-      Element: 151 StructureType main.nestedStruct
+      Element: 174 StructureType main.nestedStruct
     - __kind: ArrayType
-      ID: 176
+      ID: 206
       Name: '[]val<main.node>'
       ByteSize: 128
       Count: 8
       HasCount: true
-      Element: 133 StructureType main.node
+      Element: 156 StructureType main.node
     - __kind: ArrayType
-      ID: 178
+      ID: 208
       Name: '[]val<uint8>'
       ByteSize: 8
       Count: 8
@@ -5595,263 +6353,358 @@ Types:
       ID: 4
       Name: bool
       ByteSize: 1
-      GoRuntimeType: 528064
+      GoRuntimeType: 532256
       GoKind: 1
     - __kind: GoHMapBucketType
-      ID: 129
+      ID: 152
       Name: bucket<[4]int,[4]int>
       ByteSize: 528
       RawFields:
         - Name: tophash
           Offset: 0
-          Type: 157 ArrayType [8]uint8
+          Type: 183 ArrayType [8]uint8
         - Name: keys
           Offset: 8
-          Type: 185 ArrayType []key<[4]int>
+          Type: 215 ArrayType []key<[4]int>
         - Name: values
           Offset: 264
-          Type: 182 ArrayType []val<[4]int>
+          Type: 212 ArrayType []val<[4]int>
         - Name: overflow
           Offset: 520
-          Type: 128 PointerType *bucket<[4]int,[4]int>
-      KeyType: 183 ArrayType [4]int
-      ValueType: 183 ArrayType [4]int
+          Type: 151 PointerType *bucket<[4]int,[4]int>
+      KeyType: 213 ArrayType [4]int
+      ValueType: 213 ArrayType [4]int
     - __kind: GoHMapBucketType
-      ID: 124
+      ID: 147
       Name: bucket<[4]int,uint8>
       ByteSize: 280
       RawFields:
         - Name: tophash
           Offset: 0
-          Type: 157 ArrayType [8]uint8
+          Type: 183 ArrayType [8]uint8
         - Name: keys
           Offset: 8
-          Type: 185 ArrayType []key<[4]int>
+          Type: 215 ArrayType []key<[4]int>
         - Name: values
           Offset: 264
-          Type: 178 ArrayType []val<uint8>
+          Type: 208 ArrayType []val<uint8>
         - Name: overflow
           Offset: 272
-          Type: 123 PointerType *bucket<[4]int,uint8>
-      KeyType: 183 ArrayType [4]int
+          Type: 146 PointerType *bucket<[4]int,uint8>
+      KeyType: 213 ArrayType [4]int
       ValueType: 3 BaseType uint8
     - __kind: GoHMapBucketType
-      ID: 92
+      ID: 115
       Name: bucket<[4]string,[2]int>
       ByteSize: 656
       RawFields:
         - Name: tophash
           Offset: 0
-          Type: 157 ArrayType [8]uint8
+          Type: 183 ArrayType [8]uint8
         - Name: keys
           Offset: 8
-          Type: 167 ArrayType []key<[4]string>
+          Type: 197 ArrayType []key<[4]string>
         - Name: values
           Offset: 520
-          Type: 169 ArrayType []val<[2]int>
+          Type: 199 ArrayType []val<[2]int>
         - Name: overflow
           Offset: 648
-          Type: 91 PointerType *bucket<[4]string,[2]int>
-      KeyType: 168 ArrayType [4]string
+          Type: 114 PointerType *bucket<[4]string,[2]int>
+      KeyType: 198 ArrayType [4]string
       ValueType: 40 ArrayType [2]int
     - __kind: GoHMapBucketType
-      ID: 104
+      ID: 127
       Name: bucket<bool,main.node>
       ByteSize: 152
       RawFields:
         - Name: tophash
           Offset: 0
-          Type: 157 ArrayType [8]uint8
+          Type: 183 ArrayType [8]uint8
         - Name: keys
           Offset: 8
-          Type: 175 ArrayType []key<bool>
+          Type: 205 ArrayType []key<bool>
         - Name: values
           Offset: 16
-          Type: 176 ArrayType []val<main.node>
+          Type: 206 ArrayType []val<main.node>
         - Name: overflow
           Offset: 144
-          Type: 103 PointerType *bucket<bool,main.node>
+          Type: 126 PointerType *bucket<bool,main.node>
       KeyType: 4 BaseType bool
-      ValueType: 133 StructureType main.node
+      ValueType: 156 StructureType main.node
     - __kind: GoHMapBucketType
-      ID: 70
+      ID: 72
+      Name: bucket<int,*main.deepMap2>
+      ByteSize: 144
+      RawFields:
+        - Name: tophash
+          Offset: 0
+          Type: 183 ArrayType [8]uint8
+        - Name: keys
+          Offset: 8
+          Type: 184 ArrayType []key<int>
+        - Name: values
+          Offset: 72
+          Type: 185 ArrayType []val<*main.deepMap2>
+        - Name: overflow
+          Offset: 136
+          Type: 71 PointerType *bucket<int,*main.deepMap2>
+      KeyType: 9 BaseType int
+      ValueType: 186 PointerType *main.deepMap2
+    - __kind: GoHMapBucketType
+      ID: 245
+      Name: bucket<int,*main.deepMap3>
+      ByteSize: 144
+      RawFields:
+        - Name: tophash
+          Offset: 0
+          Type: 183 ArrayType [8]uint8
+        - Name: keys
+          Offset: 8
+          Type: 184 ArrayType []key<int>
+        - Name: values
+          Offset: 72
+          Type: 246 ArrayType []val<*main.deepMap3>
+        - Name: overflow
+          Offset: 136
+          Type: 244 PointerType *bucket<int,*main.deepMap3>
+      KeyType: 9 BaseType int
+      ValueType: 247 PointerType *main.deepMap3
+    - __kind: GoHMapBucketType
+      ID: 274
+      Name: bucket<int,*main.deepMap8>
+      ByteSize: 144
+      RawFields:
+        - Name: tophash
+          Offset: 0
+          Type: 183 ArrayType [8]uint8
+        - Name: keys
+          Offset: 8
+          Type: 184 ArrayType []key<int>
+        - Name: values
+          Offset: 72
+          Type: 275 ArrayType []val<*main.deepMap8>
+        - Name: overflow
+          Offset: 136
+          Type: 273 PointerType *bucket<int,*main.deepMap8>
+      KeyType: 9 BaseType int
+      ValueType: 276 PointerType *main.deepMap8
+    - __kind: GoHMapBucketType
+      ID: 283
+      Name: bucket<int,*main.deepMap9>
+      ByteSize: 144
+      RawFields:
+        - Name: tophash
+          Offset: 0
+          Type: 183 ArrayType [8]uint8
+        - Name: keys
+          Offset: 8
+          Type: 184 ArrayType []key<int>
+        - Name: values
+          Offset: 72
+          Type: 284 ArrayType []val<*main.deepMap9>
+        - Name: overflow
+          Offset: 136
+          Type: 282 PointerType *bucket<int,*main.deepMap9>
+      KeyType: 9 BaseType int
+      ValueType: 285 PointerType *main.deepMap9
+    - __kind: GoHMapBucketType
+      ID: 95
       Name: bucket<int,int>
       ByteSize: 144
       RawFields:
         - Name: tophash
           Offset: 0
-          Type: 157 ArrayType [8]uint8
+          Type: 183 ArrayType [8]uint8
         - Name: keys
           Offset: 8
-          Type: 158 ArrayType []key<int>
+          Type: 184 ArrayType []key<int>
         - Name: values
           Offset: 72
-          Type: 159 ArrayType []val<int>
+          Type: 189 ArrayType []val<int>
         - Name: overflow
           Offset: 136
-          Type: 69 PointerType *bucket<int,int>
+          Type: 94 PointerType *bucket<int,int>
       KeyType: 9 BaseType int
       ValueType: 9 BaseType int
     - __kind: GoHMapBucketType
-      ID: 109
+      ID: 292
+      Name: bucket<int,interface {}>
+      ByteSize: 208
+      RawFields:
+        - Name: tophash
+          Offset: 0
+          Type: 183 ArrayType [8]uint8
+        - Name: keys
+          Offset: 8
+          Type: 184 ArrayType []key<int>
+        - Name: values
+          Offset: 72
+          Type: 293 ArrayType []val<interface {}>
+        - Name: overflow
+          Offset: 200
+          Type: 291 PointerType *bucket<int,interface {}>
+      KeyType: 9 BaseType int
+      ValueType: 83 GoEmptyInterfaceType interface {}
+    - __kind: GoHMapBucketType
+      ID: 132
       Name: bucket<int,uint8>
       ByteSize: 88
       RawFields:
         - Name: tophash
           Offset: 0
-          Type: 157 ArrayType [8]uint8
+          Type: 183 ArrayType [8]uint8
         - Name: keys
           Offset: 8
-          Type: 158 ArrayType []key<int>
+          Type: 184 ArrayType []key<int>
         - Name: values
           Offset: 72
-          Type: 178 ArrayType []val<uint8>
+          Type: 208 ArrayType []val<uint8>
         - Name: overflow
           Offset: 80
-          Type: 108 PointerType *bucket<int,uint8>
+          Type: 131 PointerType *bucket<int,uint8>
       KeyType: 9 BaseType int
       ValueType: 3 BaseType uint8
     - __kind: GoHMapBucketType
-      ID: 99
+      ID: 122
       Name: bucket<string,[]main.structWithMap>
       ByteSize: 336
       RawFields:
         - Name: tophash
           Offset: 0
-          Type: 157 ArrayType [8]uint8
+          Type: 183 ArrayType [8]uint8
         - Name: keys
           Offset: 8
-          Type: 161 ArrayType []key<string>
+          Type: 191 ArrayType []key<string>
         - Name: values
           Offset: 136
-          Type: 171 ArrayType []val<[]main.structWithMap>
+          Type: 201 ArrayType []val<[]main.structWithMap>
         - Name: overflow
           Offset: 328
-          Type: 98 PointerType *bucket<string,[]main.structWithMap>
+          Type: 121 PointerType *bucket<string,[]main.structWithMap>
       KeyType: 11 GoStringHeaderType string
-      ValueType: 172 GoSliceHeaderType []main.structWithMap
+      ValueType: 202 GoSliceHeaderType []main.structWithMap
     - __kind: GoHMapBucketType
-      ID: 87
+      ID: 110
       Name: bucket<string,[]string>
       ByteSize: 336
       RawFields:
         - Name: tophash
           Offset: 0
-          Type: 157 ArrayType [8]uint8
+          Type: 183 ArrayType [8]uint8
         - Name: keys
           Offset: 8
-          Type: 161 ArrayType []key<string>
+          Type: 191 ArrayType []key<string>
         - Name: values
           Offset: 136
-          Type: 165 ArrayType []val<[]string>
+          Type: 195 ArrayType []val<[]string>
         - Name: overflow
           Offset: 328
-          Type: 86 PointerType *bucket<string,[]string>
+          Type: 109 PointerType *bucket<string,[]string>
       KeyType: 11 GoStringHeaderType string
-      ValueType: 143 GoSliceHeaderType []string
+      ValueType: 166 GoSliceHeaderType []string
     - __kind: GoHMapBucketType
-      ID: 82
+      ID: 105
       Name: bucket<string,int>
       ByteSize: 208
       RawFields:
         - Name: tophash
           Offset: 0
-          Type: 157 ArrayType [8]uint8
+          Type: 183 ArrayType [8]uint8
         - Name: keys
           Offset: 8
-          Type: 161 ArrayType []key<string>
+          Type: 191 ArrayType []key<string>
         - Name: values
           Offset: 136
-          Type: 159 ArrayType []val<int>
+          Type: 189 ArrayType []val<int>
         - Name: overflow
           Offset: 200
-          Type: 81 PointerType *bucket<string,int>
+          Type: 104 PointerType *bucket<string,int>
       KeyType: 11 GoStringHeaderType string
       ValueType: 9 BaseType int
     - __kind: GoHMapBucketType
-      ID: 77
+      ID: 100
       Name: bucket<string,main.nestedStruct>
       ByteSize: 336
       RawFields:
         - Name: tophash
           Offset: 0
-          Type: 157 ArrayType [8]uint8
+          Type: 183 ArrayType [8]uint8
         - Name: keys
           Offset: 8
-          Type: 161 ArrayType []key<string>
+          Type: 191 ArrayType []key<string>
         - Name: values
           Offset: 136
-          Type: 162 ArrayType []val<main.nestedStruct>
+          Type: 192 ArrayType []val<main.nestedStruct>
         - Name: overflow
           Offset: 328
-          Type: 76 PointerType *bucket<string,main.nestedStruct>
+          Type: 99 PointerType *bucket<string,main.nestedStruct>
       KeyType: 11 GoStringHeaderType string
-      ValueType: 151 StructureType main.nestedStruct
+      ValueType: 174 StructureType main.nestedStruct
     - __kind: GoHMapBucketType
-      ID: 119
+      ID: 142
       Name: bucket<uint8,[4]int>
       ByteSize: 280
       RawFields:
         - Name: tophash
           Offset: 0
-          Type: 157 ArrayType [8]uint8
+          Type: 183 ArrayType [8]uint8
         - Name: keys
           Offset: 8
-          Type: 180 ArrayType []key<uint8>
+          Type: 210 ArrayType []key<uint8>
         - Name: values
           Offset: 16
-          Type: 182 ArrayType []val<[4]int>
+          Type: 212 ArrayType []val<[4]int>
         - Name: overflow
           Offset: 272
-          Type: 118 PointerType *bucket<uint8,[4]int>
+          Type: 141 PointerType *bucket<uint8,[4]int>
       KeyType: 3 BaseType uint8
-      ValueType: 183 ArrayType [4]int
+      ValueType: 213 ArrayType [4]int
     - __kind: GoHMapBucketType
-      ID: 114
+      ID: 137
       Name: bucket<uint8,uint8>
       ByteSize: 32
       RawFields:
         - Name: tophash
           Offset: 0
-          Type: 157 ArrayType [8]uint8
+          Type: 183 ArrayType [8]uint8
         - Name: keys
           Offset: 8
-          Type: 180 ArrayType []key<uint8>
+          Type: 210 ArrayType []key<uint8>
         - Name: values
           Offset: 16
-          Type: 178 ArrayType []val<uint8>
+          Type: 208 ArrayType []val<uint8>
         - Name: overflow
           Offset: 24
-          Type: 113 PointerType *bucket<uint8,uint8>
+          Type: 136 PointerType *bucket<uint8,uint8>
       KeyType: 3 BaseType uint8
       ValueType: 3 BaseType uint8
     - __kind: GoChannelType
-      ID: 130
+      ID: 153
       Name: chan bool
-      GoRuntimeType: 539328
+      GoRuntimeType: 543520
       GoKind: 18
     - __kind: GoChannelType
-      ID: 57
+      ID: 82
       Name: chan struct {}
-      GoRuntimeType: 538240
+      GoRuntimeType: 542432
       GoKind: 18
     - __kind: BaseType
       ID: 25
       Name: complex128
       ByteSize: 16
-      GoRuntimeType: 527872
+      GoRuntimeType: 532064
       GoKind: 16
     - __kind: BaseType
       ID: 24
       Name: complex64
       ByteSize: 8
-      GoRuntimeType: 527808
+      GoRuntimeType: 532000
       GoKind: 15
     - __kind: GoInterfaceType
       ID: 18
       Name: error
       ByteSize: 16
-      GoRuntimeType: 978048
+      GoRuntimeType: 983872
       GoKind: 20
       RawFields:
         - Name: tab
@@ -5864,22 +6717,22 @@ Types:
       ID: 16
       Name: float32
       ByteSize: 4
-      GoRuntimeType: 527936
+      GoRuntimeType: 532128
       GoKind: 13
     - __kind: BaseType
       ID: 17
       Name: float64
       ByteSize: 8
-      GoRuntimeType: 528000
+      GoRuntimeType: 532192
       GoKind: 14
     - __kind: GoSubroutineType
-      ID: 60
+      ID: 85
       Name: func()
       ByteSize: 8
-      GoRuntimeType: 441952
+      GoRuntimeType: 445120
       GoKind: 19
     - __kind: GoHMapHeaderType
-      ID: 127
+      ID: 150
       Name: hash<[4]int,[4]int>
       ByteSize: 48
       RawFields:
@@ -5900,20 +6753,20 @@ Types:
           Type: 2 BaseType uint32
         - Name: buckets
           Offset: 16
-          Type: 128 PointerType *bucket<[4]int,[4]int>
+          Type: 151 PointerType *bucket<[4]int,[4]int>
         - Name: oldbuckets
           Offset: 24
-          Type: 128 PointerType *bucket<[4]int,[4]int>
+          Type: 151 PointerType *bucket<[4]int,[4]int>
         - Name: nevacuate
           Offset: 32
           Type: 1 BaseType uintptr
         - Name: extra
           Offset: 40
-          Type: 71 PointerType *runtime.mapextra
-      BucketType: 129 GoHMapBucketType bucket<[4]int,[4]int>
-      BucketsType: 187 GoSliceDataType []bucket<[4]int,[4]int>.array
+          Type: 73 PointerType *runtime.mapextra
+      BucketType: 152 GoHMapBucketType bucket<[4]int,[4]int>
+      BucketsType: 217 GoSliceDataType []bucket<[4]int,[4]int>.array
     - __kind: GoHMapHeaderType
-      ID: 122
+      ID: 145
       Name: hash<[4]int,uint8>
       ByteSize: 48
       RawFields:
@@ -5934,20 +6787,20 @@ Types:
           Type: 2 BaseType uint32
         - Name: buckets
           Offset: 16
-          Type: 123 PointerType *bucket<[4]int,uint8>
+          Type: 146 PointerType *bucket<[4]int,uint8>
         - Name: oldbuckets
           Offset: 24
-          Type: 123 PointerType *bucket<[4]int,uint8>
+          Type: 146 PointerType *bucket<[4]int,uint8>
         - Name: nevacuate
           Offset: 32
           Type: 1 BaseType uintptr
         - Name: extra
           Offset: 40
-          Type: 71 PointerType *runtime.mapextra
-      BucketType: 124 GoHMapBucketType bucket<[4]int,uint8>
-      BucketsType: 186 GoSliceDataType []bucket<[4]int,uint8>.array
+          Type: 73 PointerType *runtime.mapextra
+      BucketType: 147 GoHMapBucketType bucket<[4]int,uint8>
+      BucketsType: 216 GoSliceDataType []bucket<[4]int,uint8>.array
     - __kind: GoHMapHeaderType
-      ID: 90
+      ID: 113
       Name: hash<[4]string,[2]int>
       ByteSize: 48
       RawFields:
@@ -5968,20 +6821,20 @@ Types:
           Type: 2 BaseType uint32
         - Name: buckets
           Offset: 16
-          Type: 91 PointerType *bucket<[4]string,[2]int>
+          Type: 114 PointerType *bucket<[4]string,[2]int>
         - Name: oldbuckets
           Offset: 24
-          Type: 91 PointerType *bucket<[4]string,[2]int>
+          Type: 114 PointerType *bucket<[4]string,[2]int>
         - Name: nevacuate
           Offset: 32
           Type: 1 BaseType uintptr
         - Name: extra
           Offset: 40
-          Type: 71 PointerType *runtime.mapextra
-      BucketType: 92 GoHMapBucketType bucket<[4]string,[2]int>
-      BucketsType: 170 GoSliceDataType []bucket<[4]string,[2]int>.array
+          Type: 73 PointerType *runtime.mapextra
+      BucketType: 115 GoHMapBucketType bucket<[4]string,[2]int>
+      BucketsType: 200 GoSliceDataType []bucket<[4]string,[2]int>.array
     - __kind: GoHMapHeaderType
-      ID: 102
+      ID: 125
       Name: hash<bool,main.node>
       ByteSize: 48
       RawFields:
@@ -6002,20 +6855,156 @@ Types:
           Type: 2 BaseType uint32
         - Name: buckets
           Offset: 16
-          Type: 103 PointerType *bucket<bool,main.node>
+          Type: 126 PointerType *bucket<bool,main.node>
         - Name: oldbuckets
           Offset: 24
-          Type: 103 PointerType *bucket<bool,main.node>
+          Type: 126 PointerType *bucket<bool,main.node>
         - Name: nevacuate
           Offset: 32
           Type: 1 BaseType uintptr
         - Name: extra
           Offset: 40
-          Type: 71 PointerType *runtime.mapextra
-      BucketType: 104 GoHMapBucketType bucket<bool,main.node>
-      BucketsType: 177 GoSliceDataType []bucket<bool,main.node>.array
+          Type: 73 PointerType *runtime.mapextra
+      BucketType: 127 GoHMapBucketType bucket<bool,main.node>
+      BucketsType: 207 GoSliceDataType []bucket<bool,main.node>.array
     - __kind: GoHMapHeaderType
-      ID: 68
+      ID: 70
+      Name: hash<int,*main.deepMap2>
+      ByteSize: 48
+      RawFields:
+        - Name: count
+          Offset: 0
+          Type: 9 BaseType int
+        - Name: flags
+          Offset: 8
+          Type: 3 BaseType uint8
+        - Name: B
+          Offset: 9
+          Type: 3 BaseType uint8
+        - Name: noverflow
+          Offset: 10
+          Type: 7 BaseType uint16
+        - Name: hash0
+          Offset: 12
+          Type: 2 BaseType uint32
+        - Name: buckets
+          Offset: 16
+          Type: 71 PointerType *bucket<int,*main.deepMap2>
+        - Name: oldbuckets
+          Offset: 24
+          Type: 71 PointerType *bucket<int,*main.deepMap2>
+        - Name: nevacuate
+          Offset: 32
+          Type: 1 BaseType uintptr
+        - Name: extra
+          Offset: 40
+          Type: 73 PointerType *runtime.mapextra
+      BucketType: 72 GoHMapBucketType bucket<int,*main.deepMap2>
+      BucketsType: 188 GoSliceDataType []bucket<int,*main.deepMap2>.array
+    - __kind: GoHMapHeaderType
+      ID: 243
+      Name: hash<int,*main.deepMap3>
+      ByteSize: 48
+      RawFields:
+        - Name: count
+          Offset: 0
+          Type: 9 BaseType int
+        - Name: flags
+          Offset: 8
+          Type: 3 BaseType uint8
+        - Name: B
+          Offset: 9
+          Type: 3 BaseType uint8
+        - Name: noverflow
+          Offset: 10
+          Type: 7 BaseType uint16
+        - Name: hash0
+          Offset: 12
+          Type: 2 BaseType uint32
+        - Name: buckets
+          Offset: 16
+          Type: 244 PointerType *bucket<int,*main.deepMap3>
+        - Name: oldbuckets
+          Offset: 24
+          Type: 244 PointerType *bucket<int,*main.deepMap3>
+        - Name: nevacuate
+          Offset: 32
+          Type: 1 BaseType uintptr
+        - Name: extra
+          Offset: 40
+          Type: 73 PointerType *runtime.mapextra
+      BucketType: 245 GoHMapBucketType bucket<int,*main.deepMap3>
+      BucketsType: 249 GoSliceDataType []bucket<int,*main.deepMap3>.array
+    - __kind: GoHMapHeaderType
+      ID: 272
+      Name: hash<int,*main.deepMap8>
+      ByteSize: 48
+      RawFields:
+        - Name: count
+          Offset: 0
+          Type: 9 BaseType int
+        - Name: flags
+          Offset: 8
+          Type: 3 BaseType uint8
+        - Name: B
+          Offset: 9
+          Type: 3 BaseType uint8
+        - Name: noverflow
+          Offset: 10
+          Type: 7 BaseType uint16
+        - Name: hash0
+          Offset: 12
+          Type: 2 BaseType uint32
+        - Name: buckets
+          Offset: 16
+          Type: 273 PointerType *bucket<int,*main.deepMap8>
+        - Name: oldbuckets
+          Offset: 24
+          Type: 273 PointerType *bucket<int,*main.deepMap8>
+        - Name: nevacuate
+          Offset: 32
+          Type: 1 BaseType uintptr
+        - Name: extra
+          Offset: 40
+          Type: 73 PointerType *runtime.mapextra
+      BucketType: 274 GoHMapBucketType bucket<int,*main.deepMap8>
+      BucketsType: 278 GoSliceDataType []bucket<int,*main.deepMap8>.array
+    - __kind: GoHMapHeaderType
+      ID: 281
+      Name: hash<int,*main.deepMap9>
+      ByteSize: 48
+      RawFields:
+        - Name: count
+          Offset: 0
+          Type: 9 BaseType int
+        - Name: flags
+          Offset: 8
+          Type: 3 BaseType uint8
+        - Name: B
+          Offset: 9
+          Type: 3 BaseType uint8
+        - Name: noverflow
+          Offset: 10
+          Type: 7 BaseType uint16
+        - Name: hash0
+          Offset: 12
+          Type: 2 BaseType uint32
+        - Name: buckets
+          Offset: 16
+          Type: 282 PointerType *bucket<int,*main.deepMap9>
+        - Name: oldbuckets
+          Offset: 24
+          Type: 282 PointerType *bucket<int,*main.deepMap9>
+        - Name: nevacuate
+          Offset: 32
+          Type: 1 BaseType uintptr
+        - Name: extra
+          Offset: 40
+          Type: 73 PointerType *runtime.mapextra
+      BucketType: 283 GoHMapBucketType bucket<int,*main.deepMap9>
+      BucketsType: 287 GoSliceDataType []bucket<int,*main.deepMap9>.array
+    - __kind: GoHMapHeaderType
+      ID: 93
       Name: hash<int,int>
       ByteSize: 48
       RawFields:
@@ -6036,20 +7025,54 @@ Types:
           Type: 2 BaseType uint32
         - Name: buckets
           Offset: 16
-          Type: 69 PointerType *bucket<int,int>
+          Type: 94 PointerType *bucket<int,int>
         - Name: oldbuckets
           Offset: 24
-          Type: 69 PointerType *bucket<int,int>
+          Type: 94 PointerType *bucket<int,int>
         - Name: nevacuate
           Offset: 32
           Type: 1 BaseType uintptr
         - Name: extra
           Offset: 40
-          Type: 71 PointerType *runtime.mapextra
-      BucketType: 70 GoHMapBucketType bucket<int,int>
-      BucketsType: 160 GoSliceDataType []bucket<int,int>.array
+          Type: 73 PointerType *runtime.mapextra
+      BucketType: 95 GoHMapBucketType bucket<int,int>
+      BucketsType: 190 GoSliceDataType []bucket<int,int>.array
     - __kind: GoHMapHeaderType
-      ID: 107
+      ID: 290
+      Name: hash<int,interface {}>
+      ByteSize: 48
+      RawFields:
+        - Name: count
+          Offset: 0
+          Type: 9 BaseType int
+        - Name: flags
+          Offset: 8
+          Type: 3 BaseType uint8
+        - Name: B
+          Offset: 9
+          Type: 3 BaseType uint8
+        - Name: noverflow
+          Offset: 10
+          Type: 7 BaseType uint16
+        - Name: hash0
+          Offset: 12
+          Type: 2 BaseType uint32
+        - Name: buckets
+          Offset: 16
+          Type: 291 PointerType *bucket<int,interface {}>
+        - Name: oldbuckets
+          Offset: 24
+          Type: 291 PointerType *bucket<int,interface {}>
+        - Name: nevacuate
+          Offset: 32
+          Type: 1 BaseType uintptr
+        - Name: extra
+          Offset: 40
+          Type: 73 PointerType *runtime.mapextra
+      BucketType: 292 GoHMapBucketType bucket<int,interface {}>
+      BucketsType: 294 GoSliceDataType []bucket<int,interface {}>.array
+    - __kind: GoHMapHeaderType
+      ID: 130
       Name: hash<int,uint8>
       ByteSize: 48
       RawFields:
@@ -6070,20 +7093,20 @@ Types:
           Type: 2 BaseType uint32
         - Name: buckets
           Offset: 16
-          Type: 108 PointerType *bucket<int,uint8>
+          Type: 131 PointerType *bucket<int,uint8>
         - Name: oldbuckets
           Offset: 24
-          Type: 108 PointerType *bucket<int,uint8>
+          Type: 131 PointerType *bucket<int,uint8>
         - Name: nevacuate
           Offset: 32
           Type: 1 BaseType uintptr
         - Name: extra
           Offset: 40
-          Type: 71 PointerType *runtime.mapextra
-      BucketType: 109 GoHMapBucketType bucket<int,uint8>
-      BucketsType: 179 GoSliceDataType []bucket<int,uint8>.array
+          Type: 73 PointerType *runtime.mapextra
+      BucketType: 132 GoHMapBucketType bucket<int,uint8>
+      BucketsType: 209 GoSliceDataType []bucket<int,uint8>.array
     - __kind: GoHMapHeaderType
-      ID: 97
+      ID: 120
       Name: hash<string,[]main.structWithMap>
       ByteSize: 48
       RawFields:
@@ -6104,20 +7127,20 @@ Types:
           Type: 2 BaseType uint32
         - Name: buckets
           Offset: 16
-          Type: 98 PointerType *bucket<string,[]main.structWithMap>
+          Type: 121 PointerType *bucket<string,[]main.structWithMap>
         - Name: oldbuckets
           Offset: 24
-          Type: 98 PointerType *bucket<string,[]main.structWithMap>
+          Type: 121 PointerType *bucket<string,[]main.structWithMap>
         - Name: nevacuate
           Offset: 32
           Type: 1 BaseType uintptr
         - Name: extra
           Offset: 40
-          Type: 71 PointerType *runtime.mapextra
-      BucketType: 99 GoHMapBucketType bucket<string,[]main.structWithMap>
-      BucketsType: 174 GoSliceDataType []bucket<string,[]main.structWithMap>.array
+          Type: 73 PointerType *runtime.mapextra
+      BucketType: 122 GoHMapBucketType bucket<string,[]main.structWithMap>
+      BucketsType: 204 GoSliceDataType []bucket<string,[]main.structWithMap>.array
     - __kind: GoHMapHeaderType
-      ID: 85
+      ID: 108
       Name: hash<string,[]string>
       ByteSize: 48
       RawFields:
@@ -6138,20 +7161,20 @@ Types:
           Type: 2 BaseType uint32
         - Name: buckets
           Offset: 16
-          Type: 86 PointerType *bucket<string,[]string>
+          Type: 109 PointerType *bucket<string,[]string>
         - Name: oldbuckets
           Offset: 24
-          Type: 86 PointerType *bucket<string,[]string>
+          Type: 109 PointerType *bucket<string,[]string>
         - Name: nevacuate
           Offset: 32
           Type: 1 BaseType uintptr
         - Name: extra
           Offset: 40
-          Type: 71 PointerType *runtime.mapextra
-      BucketType: 87 GoHMapBucketType bucket<string,[]string>
-      BucketsType: 166 GoSliceDataType []bucket<string,[]string>.array
+          Type: 73 PointerType *runtime.mapextra
+      BucketType: 110 GoHMapBucketType bucket<string,[]string>
+      BucketsType: 196 GoSliceDataType []bucket<string,[]string>.array
     - __kind: GoHMapHeaderType
-      ID: 80
+      ID: 103
       Name: hash<string,int>
       ByteSize: 48
       RawFields:
@@ -6172,20 +7195,20 @@ Types:
           Type: 2 BaseType uint32
         - Name: buckets
           Offset: 16
-          Type: 81 PointerType *bucket<string,int>
+          Type: 104 PointerType *bucket<string,int>
         - Name: oldbuckets
           Offset: 24
-          Type: 81 PointerType *bucket<string,int>
+          Type: 104 PointerType *bucket<string,int>
         - Name: nevacuate
           Offset: 32
           Type: 1 BaseType uintptr
         - Name: extra
           Offset: 40
-          Type: 71 PointerType *runtime.mapextra
-      BucketType: 82 GoHMapBucketType bucket<string,int>
-      BucketsType: 164 GoSliceDataType []bucket<string,int>.array
+          Type: 73 PointerType *runtime.mapextra
+      BucketType: 105 GoHMapBucketType bucket<string,int>
+      BucketsType: 194 GoSliceDataType []bucket<string,int>.array
     - __kind: GoHMapHeaderType
-      ID: 75
+      ID: 98
       Name: hash<string,main.nestedStruct>
       ByteSize: 48
       RawFields:
@@ -6206,20 +7229,20 @@ Types:
           Type: 2 BaseType uint32
         - Name: buckets
           Offset: 16
-          Type: 76 PointerType *bucket<string,main.nestedStruct>
+          Type: 99 PointerType *bucket<string,main.nestedStruct>
         - Name: oldbuckets
           Offset: 24
-          Type: 76 PointerType *bucket<string,main.nestedStruct>
+          Type: 99 PointerType *bucket<string,main.nestedStruct>
         - Name: nevacuate
           Offset: 32
           Type: 1 BaseType uintptr
         - Name: extra
           Offset: 40
-          Type: 71 PointerType *runtime.mapextra
-      BucketType: 77 GoHMapBucketType bucket<string,main.nestedStruct>
-      BucketsType: 163 GoSliceDataType []bucket<string,main.nestedStruct>.array
+          Type: 73 PointerType *runtime.mapextra
+      BucketType: 100 GoHMapBucketType bucket<string,main.nestedStruct>
+      BucketsType: 193 GoSliceDataType []bucket<string,main.nestedStruct>.array
     - __kind: GoHMapHeaderType
-      ID: 117
+      ID: 140
       Name: hash<uint8,[4]int>
       ByteSize: 48
       RawFields:
@@ -6240,20 +7263,20 @@ Types:
           Type: 2 BaseType uint32
         - Name: buckets
           Offset: 16
-          Type: 118 PointerType *bucket<uint8,[4]int>
+          Type: 141 PointerType *bucket<uint8,[4]int>
         - Name: oldbuckets
           Offset: 24
-          Type: 118 PointerType *bucket<uint8,[4]int>
+          Type: 141 PointerType *bucket<uint8,[4]int>
         - Name: nevacuate
           Offset: 32
           Type: 1 BaseType uintptr
         - Name: extra
           Offset: 40
-          Type: 71 PointerType *runtime.mapextra
-      BucketType: 119 GoHMapBucketType bucket<uint8,[4]int>
-      BucketsType: 184 GoSliceDataType []bucket<uint8,[4]int>.array
+          Type: 73 PointerType *runtime.mapextra
+      BucketType: 142 GoHMapBucketType bucket<uint8,[4]int>
+      BucketsType: 214 GoSliceDataType []bucket<uint8,[4]int>.array
     - __kind: GoHMapHeaderType
-      ID: 112
+      ID: 135
       Name: hash<uint8,uint8>
       ByteSize: 48
       RawFields:
@@ -6274,53 +7297,53 @@ Types:
           Type: 2 BaseType uint32
         - Name: buckets
           Offset: 16
-          Type: 113 PointerType *bucket<uint8,uint8>
+          Type: 136 PointerType *bucket<uint8,uint8>
         - Name: oldbuckets
           Offset: 24
-          Type: 113 PointerType *bucket<uint8,uint8>
+          Type: 136 PointerType *bucket<uint8,uint8>
         - Name: nevacuate
           Offset: 32
           Type: 1 BaseType uintptr
         - Name: extra
           Offset: 40
-          Type: 71 PointerType *runtime.mapextra
-      BucketType: 114 GoHMapBucketType bucket<uint8,uint8>
-      BucketsType: 181 GoSliceDataType []bucket<uint8,uint8>.array
+          Type: 73 PointerType *runtime.mapextra
+      BucketType: 137 GoHMapBucketType bucket<uint8,uint8>
+      BucketsType: 211 GoSliceDataType []bucket<uint8,uint8>.array
     - __kind: BaseType
       ID: 9
       Name: int
       ByteSize: 8
-      GoRuntimeType: 527616
+      GoRuntimeType: 531808
       GoKind: 2
     - __kind: BaseType
       ID: 23
       Name: int16
       ByteSize: 2
-      GoRuntimeType: 527232
+      GoRuntimeType: 531424
       GoKind: 4
     - __kind: BaseType
       ID: 13
       Name: int32
       ByteSize: 4
-      GoRuntimeType: 527360
+      GoRuntimeType: 531552
       GoKind: 5
     - __kind: BaseType
       ID: 14
       Name: int64
       ByteSize: 8
-      GoRuntimeType: 527488
+      GoRuntimeType: 531680
       GoKind: 6
     - __kind: BaseType
       ID: 15
       Name: int8
       ByteSize: 1
-      GoRuntimeType: 527104
+      GoRuntimeType: 531296
       GoKind: 3
     - __kind: GoEmptyInterfaceType
-      ID: 58
+      ID: 83
       Name: interface {}
       ByteSize: 16
-      GoRuntimeType: 772480
+      GoRuntimeType: 777440
       GoKind: 20
       RawFields:
         - Name: _type
@@ -6333,7 +7356,7 @@ Types:
       ID: 55
       Name: io.Writer
       ByteSize: 16
-      GoRuntimeType: 973952
+      GoRuntimeType: 979776
       GoKind: 20
       RawFields:
         - Name: tab
@@ -6343,7 +7366,7 @@ Types:
           Offset: 8
           Type: 19 VoidPointerType unsafe.Pointer
     - __kind: StructureType
-      ID: 150
+      ID: 173
       Name: main.aStruct
       ByteSize: 56
       GoKind: 25
@@ -6359,12 +7382,12 @@ Types:
           Type: 9 BaseType int
         - Name: nested
           Offset: 32
-          Type: 151 StructureType main.nestedStruct
+          Type: 174 StructureType main.nestedStruct
     - __kind: GoInterfaceType
-      ID: 64
+      ID: 89
       Name: main.behavior
       ByteSize: 16
-      GoRuntimeType: 973568
+      GoRuntimeType: 979392
       GoKind: 20
       RawFields:
         - Name: tab
@@ -6389,37 +7412,199 @@ Types:
           Offset: 32
           Type: 55 GoInterfaceType io.Writer
     - __kind: StructureType
-      ID: 152
+      ID: 67
+      Name: main.deepMap1
+      ByteSize: 8
+      GoRuntimeType: 1.099616e+06
+      GoKind: 25
+      RawFields:
+        - Name: a
+          Offset: 0
+          Type: 68 GoMapType map[int]*main.deepMap2
+    - __kind: StructureType
+      ID: 187
+      Name: main.deepMap2
+      ByteSize: 8
+      GoRuntimeType: 1.099488e+06
+      GoKind: 25
+      RawFields:
+        - Name: a
+          Offset: 0
+          Type: 241 GoMapType map[int]*main.deepMap3
+    - __kind: UnresolvedPointeeType
+      ID: 248
+      Name: main.deepMap3
+      ByteSize: 8
+    - __kind: StructureType
+      ID: 76
+      Name: main.deepMap7
+      ByteSize: 8
+      GoRuntimeType: 1.098848e+06
+      GoKind: 25
+      RawFields:
+        - Name: a
+          Offset: 0
+          Type: 270 GoMapType map[int]*main.deepMap8
+    - __kind: StructureType
+      ID: 277
+      Name: main.deepMap8
+      ByteSize: 8
+      GoRuntimeType: 1.09872e+06
+      GoKind: 25
+      RawFields:
+        - Name: a
+          Offset: 0
+          Type: 279 GoMapType map[int]*main.deepMap9
+    - __kind: StructureType
+      ID: 286
+      Name: main.deepMap9
+      ByteSize: 8
+      GoRuntimeType: 1.098592e+06
+      GoKind: 25
+      RawFields:
+        - Name: a
+          Offset: 0
+          Type: 288 GoMapType map[int]interface {}
+    - __kind: StructureType
+      ID: 56
+      Name: main.deepPtr1
+      ByteSize: 8
+      GoRuntimeType: 1.100768e+06
+      GoKind: 25
+      RawFields:
+        - Name: a
+          Offset: 0
+          Type: 57 PointerType *main.deepPtr2
+    - __kind: StructureType
+      ID: 58
+      Name: main.deepPtr2
+      ByteSize: 8
+      GoRuntimeType: 1.10064e+06
+      GoKind: 25
+      RawFields:
+        - Name: a
+          Offset: 0
+          Type: 230 PointerType *main.deepPtr3
+    - __kind: UnresolvedPointeeType
+      ID: 231
+      Name: main.deepPtr3
+      ByteSize: 8
+    - __kind: StructureType
+      ID: 60
+      Name: main.deepPtr7
+      ByteSize: 8
+      GoRuntimeType: 1.1e+06
+      GoKind: 25
+      RawFields:
+        - Name: a
+          Offset: 0
+          Type: 250 PointerType *main.deepPtr8
+    - __kind: StructureType
+      ID: 251
+      Name: main.deepPtr8
+      ByteSize: 8
+      GoRuntimeType: 1.099872e+06
+      GoKind: 25
+      RawFields:
+        - Name: a
+          Offset: 0
+          Type: 252 PointerType *main.deepPtr9
+    - __kind: StructureType
+      ID: 253
+      Name: main.deepPtr9
+      ByteSize: 16
+      GoRuntimeType: 1.099744e+06
+      GoKind: 25
+      RawFields:
+        - Name: a
+          Offset: 0
+          Type: 83 GoEmptyInterfaceType interface {}
+    - __kind: StructureType
+      ID: 61
+      Name: main.deepSlice1
+      ByteSize: 24
+      GoRuntimeType: 1.10192e+06
+      GoKind: 25
+      RawFields:
+        - Name: a
+          Offset: 0
+          Type: 62 GoSliceHeaderType []*main.deepSlice2
+    - __kind: StructureType
+      ID: 180
+      Name: main.deepSlice2
+      ByteSize: 24
+      GoRuntimeType: 1.101792e+06
+      GoKind: 25
+      RawFields:
+        - Name: a
+          Offset: 0
+          Type: 235 GoSliceHeaderType []*main.deepSlice3
+    - __kind: UnresolvedPointeeType
+      ID: 238
+      Name: main.deepSlice3
+      ByteSize: 8
+    - __kind: StructureType
+      ID: 66
+      Name: main.deepSlice7
+      ByteSize: 24
+      GoRuntimeType: 1.101152e+06
+      GoKind: 25
+      RawFields:
+        - Name: a
+          Offset: 0
+          Type: 254 GoSliceHeaderType []*main.deepSlice8
+    - __kind: StructureType
+      ID: 257
+      Name: main.deepSlice8
+      ByteSize: 24
+      GoRuntimeType: 1.101024e+06
+      GoKind: 25
+      RawFields:
+        - Name: a
+          Offset: 0
+          Type: 260 GoSliceHeaderType []*main.deepSlice9
+    - __kind: StructureType
+      ID: 263
+      Name: main.deepSlice9
+      ByteSize: 24
+      GoRuntimeType: 1.100896e+06
+      GoKind: 25
+      RawFields:
+        - Name: a
+          Offset: 0
+          Type: 266 GoSliceHeaderType []interface {}
+    - __kind: StructureType
+      ID: 175
       Name: main.emptyStruct
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 62
+      ID: 87
       Name: main.esotericHeap
       ByteSize: 112
-      GoRuntimeType: 1.69296e+06
+      GoRuntimeType: 1.703968e+06
       GoKind: 25
       RawFields:
         - Name: esotericStack
           Offset: 0
-          Type: 56 StructureType main.esotericStack
+          Type: 81 StructureType main.esotericStack
         - Name: mu
           Offset: 64
-          Type: 200 StructureType sync.Mutex
+          Type: 295 StructureType sync.Mutex
         - Name: once
           Offset: 72
-          Type: 201 StructureType sync.Once
+          Type: 296 StructureType sync.Once
         - Name: wg
           Offset: 88
-          Type: 204 StructureType sync.WaitGroup
+          Type: 299 StructureType sync.WaitGroup
         - Name: a
           Offset: 104
-          Type: 208 StructureType sync/atomic.Int32
+          Type: 303 StructureType sync/atomic.Int32
     - __kind: StructureType
-      ID: 56
+      ID: 81
       Name: main.esotericStack
       ByteSize: 64
-      GoRuntimeType: 1.819424e+06
+      GoRuntimeType: 1.830432e+06
       GoKind: 25
       RawFields:
         - Name: _
@@ -6430,24 +7615,24 @@ Types:
           Type: 13 BaseType int32
         - Name: c
           Offset: 8
-          Type: 57 GoChannelType chan struct {}
+          Type: 82 GoChannelType chan struct {}
         - Name: val
           Offset: 16
-          Type: 58 GoEmptyInterfaceType interface {}
+          Type: 83 GoEmptyInterfaceType interface {}
         - Name: _
           Offset: 32
           Type: 10 BaseType uint64
         - Name: work
           Offset: 40
-          Type: 59 GoInterfaceType main.something
+          Type: 84 GoInterfaceType main.something
         - Name: foo
           Offset: 56
-          Type: 60 GoSubroutineType func()
+          Type: 85 GoSubroutineType func()
     - __kind: StructureType
-      ID: 151
+      ID: 174
       Name: main.nestedStruct
       ByteSize: 24
-      GoRuntimeType: 1.270208e+06
+      GoRuntimeType: 1.279488e+06
       GoKind: 25
       RawFields:
         - Name: anotherInt
@@ -6457,10 +7642,10 @@ Types:
           Offset: 8
           Type: 11 GoStringHeaderType string
     - __kind: StructureType
-      ID: 133
+      ID: 156
       Name: main.node
       ByteSize: 16
-      GoRuntimeType: 1.270048e+06
+      GoRuntimeType: 1.279328e+06
       GoKind: 25
       RawFields:
         - Name: val
@@ -6468,9 +7653,9 @@ Types:
           Type: 9 BaseType int
         - Name: b
           Offset: 8
-          Type: 134 PointerType *main.node
+          Type: 157 PointerType *main.node
     - __kind: StructureType
-      ID: 149
+      ID: 172
       Name: main.oneStringStruct
       ByteSize: 16
       GoKind: 25
@@ -6479,10 +7664,10 @@ Types:
           Offset: 0
           Type: 11 GoStringHeaderType string
     - __kind: GoInterfaceType
-      ID: 59
+      ID: 84
       Name: main.something
       ByteSize: 16
-      GoRuntimeType: 973696
+      GoRuntimeType: 979520
       GoKind: 20
       RawFields:
         - Name: tab
@@ -6491,18 +7676,39 @@ Types:
         - Name: data
           Offset: 8
           Type: 19 VoidPointerType unsafe.Pointer
+    - __kind: GoStringHeaderType
+      ID: 78
+      Name: main.stringType1
+      ByteSize: 16
+      GoKind: 24
+      RawFields:
+        - Name: str
+          Offset: 0
+          Type: 233 PointerType *main.stringType1.str
+        - Name: len
+          Offset: 8
+          Type: 9 BaseType int
+      Data: 232 GoStringDataType main.stringType1.str
+    - __kind: GoStringDataType
+      ID: 232
+      Name: main.stringType1.str
+      ByteSize: 2048
+    - __kind: UnresolvedPointeeType
+      ID: 234
+      Name: main.stringType2
+      ByteSize: 8
     - __kind: StructureType
-      ID: 65
+      ID: 90
       Name: main.structWithMap
       ByteSize: 8
-      GoRuntimeType: 1.09264e+06
+      GoRuntimeType: 1.098464e+06
       GoKind: 25
       RawFields:
         - Name: m
           Offset: 0
-          Type: 66 GoMapType map[int]int
+          Type: 91 GoMapType map[int]int
     - __kind: StructureType
-      ID: 142
+      ID: 165
       Name: main.structWithNoStrings
       ByteSize: 2
       GoKind: 25
@@ -6514,7 +7720,7 @@ Types:
           Offset: 1
           Type: 4 BaseType bool
     - __kind: StructureType
-      ID: 132
+      ID: 155
       Name: main.structWithTwoValues
       ByteSize: 16
       GoKind: 25
@@ -6526,28 +7732,28 @@ Types:
           Offset: 8
           Type: 4 BaseType bool
     - __kind: GoSliceHeaderType
-      ID: 136
+      ID: 159
       Name: main.t
       ByteSize: 24
       GoKind: 23
       RawFields:
         - Name: array
           Offset: 0
-          Type: 209 PointerType **main.t
+          Type: 304 PointerType **main.t
         - Name: len
           Offset: 8
           Type: 9 BaseType int
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 210 GoSliceDataType main.t.array
+      Data: 305 GoSliceDataType main.t.array
     - __kind: GoSliceDataType
-      ID: 210
+      ID: 305
       Name: main.t.array
       ByteSize: 2048
-      Element: 135 PointerType *main.t
+      Element: 158 PointerType *main.t
     - __kind: StructureType
-      ID: 146
+      ID: 169
       Name: main.threeStringStruct
       ByteSize: 48
       GoKind: 25
@@ -6567,116 +7773,151 @@ Types:
       ByteSize: 2
       GoKind: 9
     - __kind: GoMapType
-      ID: 125
+      ID: 148
       Name: map[[4]int][4]int
       ByteSize: 8
-      GoRuntimeType: 873952
+      GoRuntimeType: 879776
       GoKind: 21
-      HeaderType: 127 GoHMapHeaderType hash<[4]int,[4]int>
+      HeaderType: 150 GoHMapHeaderType hash<[4]int,[4]int>
     - __kind: GoMapType
-      ID: 120
+      ID: 143
       Name: map[[4]int]uint8
       ByteSize: 8
-      GoRuntimeType: 874048
+      GoRuntimeType: 879872
       GoKind: 21
-      HeaderType: 122 GoHMapHeaderType hash<[4]int,uint8>
+      HeaderType: 145 GoHMapHeaderType hash<[4]int,uint8>
     - __kind: GoMapType
-      ID: 88
+      ID: 111
       Name: map[[4]string][2]int
       ByteSize: 8
-      GoRuntimeType: 874144
+      GoRuntimeType: 879968
       GoKind: 21
-      HeaderType: 90 GoHMapHeaderType hash<[4]string,[2]int>
+      HeaderType: 113 GoHMapHeaderType hash<[4]string,[2]int>
     - __kind: GoMapType
-      ID: 100
+      ID: 123
       Name: map[bool]main.node
       ByteSize: 8
-      GoRuntimeType: 874240
+      GoRuntimeType: 880064
       GoKind: 21
-      HeaderType: 102 GoHMapHeaderType hash<bool,main.node>
+      HeaderType: 125 GoHMapHeaderType hash<bool,main.node>
     - __kind: GoMapType
-      ID: 66
+      ID: 68
+      Name: map[int]*main.deepMap2
+      ByteSize: 8
+      GoRuntimeType: 879680
+      GoKind: 21
+      HeaderType: 70 GoHMapHeaderType hash<int,*main.deepMap2>
+    - __kind: GoMapType
+      ID: 241
+      Name: map[int]*main.deepMap3
+      ByteSize: 8
+      GoRuntimeType: 879584
+      GoKind: 21
+      HeaderType: 243 GoHMapHeaderType hash<int,*main.deepMap3>
+    - __kind: GoMapType
+      ID: 270
+      Name: map[int]*main.deepMap8
+      ByteSize: 8
+      GoRuntimeType: 879104
+      GoKind: 21
+      HeaderType: 272 GoHMapHeaderType hash<int,*main.deepMap8>
+    - __kind: GoMapType
+      ID: 279
+      Name: map[int]*main.deepMap9
+      ByteSize: 8
+      GoRuntimeType: 879008
+      GoKind: 21
+      HeaderType: 281 GoHMapHeaderType hash<int,*main.deepMap9>
+    - __kind: GoMapType
+      ID: 91
       Name: map[int]int
       ByteSize: 8
-      GoRuntimeType: 872992
+      GoRuntimeType: 877952
       GoKind: 21
-      HeaderType: 68 GoHMapHeaderType hash<int,int>
+      HeaderType: 93 GoHMapHeaderType hash<int,int>
     - __kind: GoMapType
-      ID: 105
+      ID: 288
+      Name: map[int]interface {}
+      ByteSize: 8
+      GoRuntimeType: 878912
+      GoKind: 21
+      HeaderType: 290 GoHMapHeaderType hash<int,interface {}>
+    - __kind: GoMapType
+      ID: 128
       Name: map[int]uint8
       ByteSize: 8
-      GoRuntimeType: 874336
+      GoRuntimeType: 880160
       GoKind: 21
-      HeaderType: 107 GoHMapHeaderType hash<int,uint8>
+      HeaderType: 130 GoHMapHeaderType hash<int,uint8>
     - __kind: GoMapType
-      ID: 95
+      ID: 118
       Name: map[string][]main.structWithMap
       ByteSize: 8
-      GoRuntimeType: 874432
+      GoRuntimeType: 880256
       GoKind: 21
-      HeaderType: 97 GoHMapHeaderType hash<string,[]main.structWithMap>
+      HeaderType: 120 GoHMapHeaderType hash<string,[]main.structWithMap>
     - __kind: GoMapType
-      ID: 83
+      ID: 106
       Name: map[string][]string
       ByteSize: 8
-      GoRuntimeType: 874528
+      GoRuntimeType: 880352
       GoKind: 21
-      HeaderType: 85 GoHMapHeaderType hash<string,[]string>
+      HeaderType: 108 GoHMapHeaderType hash<string,[]string>
     - __kind: GoMapType
-      ID: 78
+      ID: 101
       Name: map[string]int
       ByteSize: 8
-      GoRuntimeType: 874624
+      GoRuntimeType: 880448
       GoKind: 21
-      HeaderType: 80 GoHMapHeaderType hash<string,int>
+      HeaderType: 103 GoHMapHeaderType hash<string,int>
     - __kind: GoMapType
-      ID: 73
+      ID: 96
       Name: map[string]main.nestedStruct
       ByteSize: 8
-      GoRuntimeType: 874720
+      GoRuntimeType: 880544
       GoKind: 21
-      HeaderType: 75 GoHMapHeaderType hash<string,main.nestedStruct>
+      HeaderType: 98 GoHMapHeaderType hash<string,main.nestedStruct>
     - __kind: GoMapType
-      ID: 115
+      ID: 138
       Name: map[uint8][4]int
       ByteSize: 8
-      GoRuntimeType: 874816
+      GoRuntimeType: 880640
       GoKind: 21
-      HeaderType: 117 GoHMapHeaderType hash<uint8,[4]int>
+      HeaderType: 140 GoHMapHeaderType hash<uint8,[4]int>
     - __kind: GoMapType
-      ID: 110
+      ID: 133
       Name: map[uint8]uint8
       ByteSize: 8
-      GoRuntimeType: 874912
+      GoRuntimeType: 880736
       GoKind: 21
-      HeaderType: 112 GoHMapHeaderType hash<uint8,uint8>
+      HeaderType: 135 GoHMapHeaderType hash<uint8,uint8>
     - __kind: UnresolvedPointeeType
-      ID: 72
+      ID: 74
       Name: runtime.mapextra
       ByteSize: 8
     - __kind: GoStringHeaderType
       ID: 11
       Name: string
       ByteSize: 16
-      GoRuntimeType: 527040
+      GoRuntimeType: 531232
       GoKind: 24
       RawFields:
         - Name: str
           Offset: 0
-          Type: 154 PointerType *string.str
+          Type: 177 PointerType *string.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 153 GoStringDataType string.str
+      Data: 176 GoStringDataType string.str
     - __kind: GoStringDataType
-      ID: 153
+      ID: 176
       Name: string.str
       ByteSize: 2048
     - __kind: StructureType
-      ID: 200
+      ID: 295
       Name: sync.Mutex
       ByteSize: 8
-      GoRuntimeType: 1.271488e+06
+      GoRuntimeType: 1.280768e+06
       GoKind: 25
       RawFields:
         - Name: state
@@ -6686,136 +7927,136 @@ Types:
           Offset: 4
           Type: 2 BaseType uint32
     - __kind: StructureType
-      ID: 201
+      ID: 296
       Name: sync.Once
       ByteSize: 12
-      GoRuntimeType: 1.272608e+06
+      GoRuntimeType: 1.281888e+06
       GoKind: 25
       RawFields:
         - Name: done
           Offset: 0
-          Type: 202 StructureType sync/atomic.Uint32
+          Type: 297 StructureType sync/atomic.Uint32
         - Name: m
           Offset: 4
-          Type: 200 StructureType sync.Mutex
+          Type: 295 StructureType sync.Mutex
     - __kind: StructureType
-      ID: 204
+      ID: 299
       Name: sync.WaitGroup
       ByteSize: 16
-      GoRuntimeType: 1.411456e+06
+      GoRuntimeType: 1.420736e+06
       GoKind: 25
       RawFields:
         - Name: noCopy
           Offset: 0
-          Type: 205 StructureType sync.noCopy
+          Type: 300 StructureType sync.noCopy
         - Name: state
           Offset: 0
-          Type: 206 StructureType sync/atomic.Uint64
+          Type: 301 StructureType sync/atomic.Uint64
         - Name: sema
           Offset: 8
           Type: 2 BaseType uint32
     - __kind: StructureType
-      ID: 205
+      ID: 300
       Name: sync.noCopy
-      GoRuntimeType: 940704
+      GoRuntimeType: 946528
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 208
+      ID: 303
       Name: sync/atomic.Int32
       ByteSize: 4
-      GoRuntimeType: 1.272928e+06
+      GoRuntimeType: 1.282208e+06
       GoKind: 25
       RawFields:
         - Name: _
           Offset: 0
-          Type: 203 StructureType sync/atomic.noCopy
+          Type: 298 StructureType sync/atomic.noCopy
         - Name: v
           Offset: 0
           Type: 13 BaseType int32
     - __kind: StructureType
-      ID: 202
+      ID: 297
       Name: sync/atomic.Uint32
       ByteSize: 4
-      GoRuntimeType: 1.273088e+06
+      GoRuntimeType: 1.282368e+06
       GoKind: 25
       RawFields:
         - Name: _
           Offset: 0
-          Type: 203 StructureType sync/atomic.noCopy
+          Type: 298 StructureType sync/atomic.noCopy
         - Name: v
           Offset: 0
           Type: 2 BaseType uint32
     - __kind: StructureType
-      ID: 206
+      ID: 301
       Name: sync/atomic.Uint64
       ByteSize: 8
-      GoRuntimeType: 1.41184e+06
+      GoRuntimeType: 1.42112e+06
       GoKind: 25
       RawFields:
         - Name: _
           Offset: 0
-          Type: 203 StructureType sync/atomic.noCopy
+          Type: 298 StructureType sync/atomic.noCopy
         - Name: _
           Offset: 0
-          Type: 207 StructureType sync/atomic.align64
+          Type: 302 StructureType sync/atomic.align64
         - Name: v
           Offset: 0
           Type: 10 BaseType uint64
     - __kind: StructureType
-      ID: 207
+      ID: 302
       Name: sync/atomic.align64
-      GoRuntimeType: 940896
+      GoRuntimeType: 946720
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 203
+      ID: 298
       Name: sync/atomic.noCopy
-      GoRuntimeType: 940800
+      GoRuntimeType: 946624
       GoKind: 25
       RawFields: []
     - __kind: BaseType
       ID: 12
       Name: uint
       ByteSize: 8
-      GoRuntimeType: 527680
+      GoRuntimeType: 531872
       GoKind: 7
     - __kind: BaseType
       ID: 7
       Name: uint16
       ByteSize: 2
-      GoRuntimeType: 527296
+      GoRuntimeType: 531488
       GoKind: 9
     - __kind: BaseType
       ID: 2
       Name: uint32
       ByteSize: 4
-      GoRuntimeType: 527424
+      GoRuntimeType: 531616
       GoKind: 10
     - __kind: BaseType
       ID: 10
       Name: uint64
       ByteSize: 8
-      GoRuntimeType: 527552
+      GoRuntimeType: 531744
       GoKind: 11
     - __kind: BaseType
       ID: 3
       Name: uint8
       ByteSize: 1
-      GoRuntimeType: 527168
+      GoRuntimeType: 531360
       GoKind: 8
     - __kind: BaseType
       ID: 1
       Name: uintptr
       ByteSize: 8
-      GoRuntimeType: 527744
+      GoRuntimeType: 531936
       GoKind: 12
     - __kind: VoidPointerType
       ID: 19
       Name: unsafe.Pointer
       ByteSize: 8
-      GoRuntimeType: 528128
+      GoRuntimeType: 532320
       GoKind: 26
-MaxTypeID: 317
+MaxTypeID: 420
 Issues: []
-GoModuledataInfo: {FirstModuledataAddr: "0x12cd8a0", TypesOffset: 296}
+GoModuledataInfo: {FirstModuledataAddr: "0x12cd8e0", TypesOffset: 296}

--- a/pkg/dyninst/irgen/testdata/snapshot/sample.arch=arm64,toolchain=go1.24.3.yaml
+++ b/pkg/dyninst/irgen/testdata/snapshot/sample.arch=arm64,toolchain=go1.24.3.yaml
@@ -8,7 +8,7 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 94}
+      subprogram: {subprogram: 88}
       events:
         - ID: 88
           Type: 369 EventRootType Probe[main.stackC]
@@ -22,7 +22,7 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 51}
+      subprogram: {subprogram: 45}
       events:
         - ID: 45
           Type: 326 EventRootType Probe[main.testAny]
@@ -36,7 +36,7 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 21}
+      subprogram: {subprogram: 15}
       events:
         - ID: 15
           Type: 296 EventRootType Probe[main.testArrayOfArrays]
@@ -50,7 +50,7 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 23}
+      subprogram: {subprogram: 17}
       events:
         - ID: 17
           Type: 298 EventRootType Probe[main.testArrayOfArraysOfArrays]
@@ -64,7 +64,7 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 59}
+      subprogram: {subprogram: 53}
       events:
         - ID: 53
           Type: 334 EventRootType Probe[main.testArrayOfMaps]
@@ -78,7 +78,7 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 22}
+      subprogram: {subprogram: 16}
       events:
         - ID: 16
           Type: 297 EventRootType Probe[main.testArrayOfStrings]
@@ -92,7 +92,7 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 41}
+      subprogram: {subprogram: 35}
       events:
         - ID: 35
           Type: 316 EventRootType Probe[main.testBigStruct]
@@ -106,7 +106,7 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 10}
+      subprogram: {subprogram: 4}
       events:
         - ID: 4
           Type: 285 EventRootType Probe[main.testBoolArray]
@@ -120,7 +120,7 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 7}
+      subprogram: {subprogram: 1}
       events:
         - ID: 1
           Type: 282 EventRootType Probe[main.testByteArray]
@@ -134,7 +134,7 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 75}
+      subprogram: {subprogram: 69}
       events:
         - ID: 69
           Type: 350 EventRootType Probe[main.testChannel]
@@ -148,7 +148,7 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 73}
+      subprogram: {subprogram: 67}
       events:
         - ID: 67
           Type: 348 EventRootType Probe[main.testCombinedByte]
@@ -162,7 +162,7 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 83}
+      subprogram: {subprogram: 77}
       events:
         - ID: 77
           Type: 358 EventRootType Probe[main.testCycle]
@@ -176,7 +176,7 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 85}
+      subprogram: {subprogram: 79}
       events:
         - ID: 79
           Type: 360 EventRootType Probe[main.testEmptySlice]
@@ -190,7 +190,7 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 88}
+      subprogram: {subprogram: 82}
       events:
         - ID: 82
           Type: 363 EventRootType Probe[main.testEmptySliceOfStructs]
@@ -204,7 +204,7 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 102}
+      subprogram: {subprogram: 96}
       events:
         - ID: 96
           Type: 377 EventRootType Probe[main.testEmptyString]
@@ -218,7 +218,7 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 104}
+      subprogram: {subprogram: 98}
       events:
         - ID: 98
           Type: 379 EventRootType Probe[main.testEmptyStruct]
@@ -232,7 +232,7 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 52}
+      subprogram: {subprogram: 46}
       events:
         - ID: 46
           Type: 327 EventRootType Probe[main.testError]
@@ -246,7 +246,7 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 43}
+      subprogram: {subprogram: 37}
       events:
         - ID: 37
           Type: 318 EventRootType Probe[main.testEsotericHeap]
@@ -260,7 +260,7 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 42}
+      subprogram: {subprogram: 36}
       events:
         - ID: 36
           Type: 317 EventRootType Probe[main.testEsotericStack]
@@ -274,7 +274,7 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 48}
+      subprogram: {subprogram: 42}
       events:
         - ID: 42
           Type: 323 EventRootType Probe[main.testFrameless]
@@ -288,7 +288,7 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 49}
+      subprogram: {subprogram: 43}
       events:
         - ID: 43
           Type: 324 EventRootType Probe[main.testFramelessArray]
@@ -302,7 +302,7 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 44}
+      subprogram: {subprogram: 38}
       events:
         - ID: 38
           Type: 319 EventRootType Probe[main.testInlinedBA]
@@ -316,7 +316,7 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 45}
+      subprogram: {subprogram: 39}
       events:
         - ID: 39
           Type: 320 EventRootType Probe[main.testInlinedBB]
@@ -330,7 +330,7 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 46}
+      subprogram: {subprogram: 40}
       events:
         - ID: 40
           Type: 321 EventRootType Probe[main.testInlinedBBA]
@@ -344,7 +344,7 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 2}
+      subprogram: {subprogram: 100}
       events:
         - ID: 100
           Type: 381 EventRootType Probe[main.testInlinedBBB]
@@ -358,7 +358,7 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 47}
+      subprogram: {subprogram: 41}
       events:
         - ID: 41
           Type: 322 EventRootType Probe[main.testInlinedBC]
@@ -372,7 +372,7 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 3}
+      subprogram: {subprogram: 101}
       events:
         - ID: 101
           Type: 382 EventRootType Probe[main.testInlinedBCA]
@@ -386,7 +386,7 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 4}
+      subprogram: {subprogram: 102}
       events:
         - ID: 102
           Type: 383 EventRootType Probe[main.testInlinedBCB]
@@ -401,7 +401,7 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 1}
+      subprogram: {subprogram: 99}
       events:
         - ID: 99
           Type: 380 EventRootType Probe[main.testInlinedPrint]
@@ -425,7 +425,7 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 5}
+      subprogram: {subprogram: 103}
       events:
         - ID: 103
           Type: 384 EventRootType Probe[main.testInlinedSq]
@@ -440,7 +440,7 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 6}
+      subprogram: {subprogram: 104}
       events:
         - ID: 104
           Type: 385 EventRootType Probe[main.testInlinedSumArray]
@@ -458,7 +458,7 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 13}
+      subprogram: {subprogram: 7}
       events:
         - ID: 7
           Type: 288 EventRootType Probe[main.testInt16Array]
@@ -472,7 +472,7 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 14}
+      subprogram: {subprogram: 8}
       events:
         - ID: 8
           Type: 289 EventRootType Probe[main.testInt32Array]
@@ -486,7 +486,7 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 15}
+      subprogram: {subprogram: 9}
       events:
         - ID: 9
           Type: 290 EventRootType Probe[main.testInt64Array]
@@ -500,7 +500,7 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 12}
+      subprogram: {subprogram: 6}
       events:
         - ID: 6
           Type: 287 EventRootType Probe[main.testInt8Array]
@@ -514,7 +514,7 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 11}
+      subprogram: {subprogram: 5}
       events:
         - ID: 5
           Type: 286 EventRootType Probe[main.testIntArray]
@@ -528,7 +528,7 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 50}
+      subprogram: {subprogram: 44}
       events:
         - ID: 44
           Type: 325 EventRootType Probe[main.testInterface]
@@ -542,7 +542,7 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 77}
+      subprogram: {subprogram: 71}
       events:
         - ID: 71
           Type: 352 EventRootType Probe[main.testLinkedList]
@@ -556,7 +556,7 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 57}
+      subprogram: {subprogram: 51}
       events:
         - ID: 51
           Type: 332 EventRootType Probe[main.testMapArrayToArray]
@@ -570,7 +570,7 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 63}
+      subprogram: {subprogram: 57}
       events:
         - ID: 57
           Type: 338 EventRootType Probe[main.testMapEmbeddedMaps]
@@ -584,7 +584,7 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 61}
+      subprogram: {subprogram: 55}
       events:
         - ID: 55
           Type: 336 EventRootType Probe[main.testMapIntToInt]
@@ -598,7 +598,7 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 72}
+      subprogram: {subprogram: 66}
       events:
         - ID: 66
           Type: 347 EventRootType Probe[main.testMapLargeKeyLargeValue]
@@ -612,7 +612,7 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 71}
+      subprogram: {subprogram: 65}
       events:
         - ID: 65
           Type: 346 EventRootType Probe[main.testMapLargeKeySmallValue]
@@ -626,7 +626,7 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 62}
+      subprogram: {subprogram: 56}
       events:
         - ID: 56
           Type: 337 EventRootType Probe[main.testMapMassive]
@@ -640,7 +640,7 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 70}
+      subprogram: {subprogram: 64}
       events:
         - ID: 64
           Type: 345 EventRootType Probe[main.testMapSmallKeyLargeValue]
@@ -654,7 +654,7 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 69}
+      subprogram: {subprogram: 63}
       events:
         - ID: 63
           Type: 344 EventRootType Probe[main.testMapSmallKeySmallValue]
@@ -668,7 +668,7 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 55}
+      subprogram: {subprogram: 49}
       events:
         - ID: 49
           Type: 330 EventRootType Probe[main.testMapStringToInt]
@@ -682,7 +682,7 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 56}
+      subprogram: {subprogram: 50}
       events:
         - ID: 50
           Type: 331 EventRootType Probe[main.testMapStringToSlice]
@@ -696,7 +696,7 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 54}
+      subprogram: {subprogram: 48}
       events:
         - ID: 48
           Type: 329 EventRootType Probe[main.testMapStringToStruct]
@@ -710,7 +710,7 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 64}
+      subprogram: {subprogram: 58}
       events:
         - ID: 58
           Type: 339 EventRootType Probe[main.testMapWithLinkedList]
@@ -724,7 +724,7 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 67}
+      subprogram: {subprogram: 61}
       events:
         - ID: 61
           Type: 342 EventRootType Probe[main.testMapWithSmallKeyAndValue]
@@ -738,7 +738,7 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 68}
+      subprogram: {subprogram: 62}
       events:
         - ID: 62
           Type: 343 EventRootType Probe[main.testMapWithSmallKeyAndValueMassive]
@@ -752,7 +752,7 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 65}
+      subprogram: {subprogram: 59}
       events:
         - ID: 59
           Type: 340 EventRootType Probe[main.testMapWithSmallValue]
@@ -766,7 +766,7 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 66}
+      subprogram: {subprogram: 60}
       events:
         - ID: 60
           Type: 341 EventRootType Probe[main.testMapWithSmallValueMassive]
@@ -780,7 +780,7 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 100}
+      subprogram: {subprogram: 94}
       events:
         - ID: 94
           Type: 375 EventRootType Probe[main.testMassiveString]
@@ -794,7 +794,7 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 74}
+      subprogram: {subprogram: 68}
       events:
         - ID: 68
           Type: 349 EventRootType Probe[main.testMultipleSimpleParams]
@@ -808,7 +808,7 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 82}
+      subprogram: {subprogram: 76}
       events:
         - ID: 76
           Type: 357 EventRootType Probe[main.testNilPointer]
@@ -822,7 +822,7 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 92}
+      subprogram: {subprogram: 86}
       events:
         - ID: 86
           Type: 367 EventRootType Probe[main.testNilSlice]
@@ -836,7 +836,7 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 89}
+      subprogram: {subprogram: 83}
       events:
         - ID: 83
           Type: 364 EventRootType Probe[main.testNilSliceOfStructs]
@@ -850,7 +850,7 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 91}
+      subprogram: {subprogram: 85}
       events:
         - ID: 85
           Type: 366 EventRootType Probe[main.testNilSliceWithOtherParams]
@@ -864,7 +864,7 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 99}
+      subprogram: {subprogram: 93}
       events:
         - ID: 93
           Type: 374 EventRootType Probe[main.testOneStringInStructPointer]
@@ -878,7 +878,7 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 78}
+      subprogram: {subprogram: 72}
       events:
         - ID: 72
           Type: 353 EventRootType Probe[main.testPointerLoop]
@@ -892,7 +892,7 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 60}
+      subprogram: {subprogram: 54}
       events:
         - ID: 54
           Type: 335 EventRootType Probe[main.testPointerToMap]
@@ -906,7 +906,7 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 76}
+      subprogram: {subprogram: 70}
       events:
         - ID: 70
           Type: 351 EventRootType Probe[main.testPointerToSimpleStruct]
@@ -920,7 +920,7 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 8}
+      subprogram: {subprogram: 2}
       events:
         - ID: 2
           Type: 283 EventRootType Probe[main.testRuneArray]
@@ -934,7 +934,7 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 27}
+      subprogram: {subprogram: 21}
       events:
         - ID: 21
           Type: 302 EventRootType Probe[main.testSingleBool]
@@ -948,7 +948,7 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 25}
+      subprogram: {subprogram: 19}
       events:
         - ID: 19
           Type: 300 EventRootType Probe[main.testSingleByte]
@@ -962,7 +962,7 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 38}
+      subprogram: {subprogram: 32}
       events:
         - ID: 32
           Type: 313 EventRootType Probe[main.testSingleFloat32]
@@ -976,7 +976,7 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 39}
+      subprogram: {subprogram: 33}
       events:
         - ID: 33
           Type: 314 EventRootType Probe[main.testSingleFloat64]
@@ -990,7 +990,7 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 28}
+      subprogram: {subprogram: 22}
       events:
         - ID: 22
           Type: 303 EventRootType Probe[main.testSingleInt]
@@ -1004,7 +1004,7 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 30}
+      subprogram: {subprogram: 24}
       events:
         - ID: 24
           Type: 305 EventRootType Probe[main.testSingleInt16]
@@ -1018,7 +1018,7 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 31}
+      subprogram: {subprogram: 25}
       events:
         - ID: 25
           Type: 306 EventRootType Probe[main.testSingleInt32]
@@ -1032,7 +1032,7 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 32}
+      subprogram: {subprogram: 26}
       events:
         - ID: 26
           Type: 307 EventRootType Probe[main.testSingleInt64]
@@ -1046,7 +1046,7 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 29}
+      subprogram: {subprogram: 23}
       events:
         - ID: 23
           Type: 304 EventRootType Probe[main.testSingleInt8]
@@ -1060,7 +1060,7 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 26}
+      subprogram: {subprogram: 20}
       events:
         - ID: 20
           Type: 301 EventRootType Probe[main.testSingleRune]
@@ -1074,7 +1074,7 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 95}
+      subprogram: {subprogram: 89}
       events:
         - ID: 89
           Type: 370 EventRootType Probe[main.testSingleString]
@@ -1088,7 +1088,7 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 33}
+      subprogram: {subprogram: 27}
       events:
         - ID: 27
           Type: 308 EventRootType Probe[main.testSingleUint]
@@ -1102,7 +1102,7 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 35}
+      subprogram: {subprogram: 29}
       events:
         - ID: 29
           Type: 310 EventRootType Probe[main.testSingleUint16]
@@ -1116,7 +1116,7 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 36}
+      subprogram: {subprogram: 30}
       events:
         - ID: 30
           Type: 311 EventRootType Probe[main.testSingleUint32]
@@ -1130,7 +1130,7 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 37}
+      subprogram: {subprogram: 31}
       events:
         - ID: 31
           Type: 312 EventRootType Probe[main.testSingleUint64]
@@ -1144,7 +1144,7 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 34}
+      subprogram: {subprogram: 28}
       events:
         - ID: 28
           Type: 309 EventRootType Probe[main.testSingleUint8]
@@ -1158,7 +1158,7 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 86}
+      subprogram: {subprogram: 80}
       events:
         - ID: 80
           Type: 361 EventRootType Probe[main.testSliceOfSlices]
@@ -1172,7 +1172,7 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 58}
+      subprogram: {subprogram: 52}
       events:
         - ID: 52
           Type: 333 EventRootType Probe[main.testSmallMap]
@@ -1186,7 +1186,7 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 9}
+      subprogram: {subprogram: 3}
       events:
         - ID: 3
           Type: 284 EventRootType Probe[main.testStringArray]
@@ -1200,7 +1200,7 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 81}
+      subprogram: {subprogram: 75}
       events:
         - ID: 75
           Type: 356 EventRootType Probe[main.testStringPointer]
@@ -1214,7 +1214,7 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 90}
+      subprogram: {subprogram: 84}
       events:
         - ID: 84
           Type: 365 EventRootType Probe[main.testStringSlice]
@@ -1228,7 +1228,7 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 103}
+      subprogram: {subprogram: 97}
       events:
         - ID: 97
           Type: 378 EventRootType Probe[main.testStruct]
@@ -1242,7 +1242,7 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 87}
+      subprogram: {subprogram: 81}
       events:
         - ID: 81
           Type: 362 EventRootType Probe[main.testStructSlice]
@@ -1256,7 +1256,7 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 53}
+      subprogram: {subprogram: 47}
       events:
         - ID: 47
           Type: 328 EventRootType Probe[main.testStructWithMap]
@@ -1270,7 +1270,7 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 96}
+      subprogram: {subprogram: 90}
       events:
         - ID: 90
           Type: 371 EventRootType Probe[main.testThreeStrings]
@@ -1284,7 +1284,7 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 97}
+      subprogram: {subprogram: 91}
       events:
         - ID: 91
           Type: 372 EventRootType Probe[main.testThreeStringsInStruct]
@@ -1298,7 +1298,7 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 98}
+      subprogram: {subprogram: 92}
       events:
         - ID: 92
           Type: 373 EventRootType Probe[main.testThreeStringsInStructPointer]
@@ -1312,7 +1312,7 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 40}
+      subprogram: {subprogram: 34}
       events:
         - ID: 34
           Type: 315 EventRootType Probe[main.testTypeAlias]
@@ -1326,7 +1326,7 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 18}
+      subprogram: {subprogram: 12}
       events:
         - ID: 12
           Type: 293 EventRootType Probe[main.testUint16Array]
@@ -1340,7 +1340,7 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 19}
+      subprogram: {subprogram: 13}
       events:
         - ID: 13
           Type: 294 EventRootType Probe[main.testUint32Array]
@@ -1354,7 +1354,7 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 20}
+      subprogram: {subprogram: 14}
       events:
         - ID: 14
           Type: 295 EventRootType Probe[main.testUint64Array]
@@ -1368,7 +1368,7 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 17}
+      subprogram: {subprogram: 11}
       events:
         - ID: 11
           Type: 292 EventRootType Probe[main.testUint8Array]
@@ -1382,7 +1382,7 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 16}
+      subprogram: {subprogram: 10}
       events:
         - ID: 10
           Type: 291 EventRootType Probe[main.testUintArray]
@@ -1396,7 +1396,7 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 80}
+      subprogram: {subprogram: 74}
       events:
         - ID: 74
           Type: 355 EventRootType Probe[main.testUintPointer]
@@ -1410,7 +1410,7 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 84}
+      subprogram: {subprogram: 78}
       events:
         - ID: 78
           Type: 359 EventRootType Probe[main.testUintSlice]
@@ -1424,7 +1424,7 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 101}
+      subprogram: {subprogram: 95}
       events:
         - ID: 95
           Type: 376 EventRootType Probe[main.testUnitializedString]
@@ -1438,7 +1438,7 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 79}
+      subprogram: {subprogram: 73}
       events:
         - ID: 73
           Type: 354 EventRootType Probe[main.testUnsafePointer]
@@ -1452,7 +1452,7 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 24}
+      subprogram: {subprogram: 18}
       events:
         - ID: 18
           Type: 299 EventRootType Probe[main.testVeryLargeArray]
@@ -1466,428 +1466,428 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 93}
+      subprogram: {subprogram: 87}
       events:
         - ID: 87
           Type: 368 EventRootType Probe[main.testVeryLargeSlice]
           InjectionPoints: [{PC: "0x84ca90", Frameless: true}]
           Condition: null
 Subprograms:
-    - ID: 7
+    - ID: 1
       Name: main.testByteArray
       OutOfLinePCRanges: [0x849540..0x849550]
       InlinePCRanges: []
       Variables:
         - Name: x
-          Type: 3 ArrayType [2]uint8
+          Type: 36 ArrayType [2]uint8
           Locations:
             - Range: 0x849540..0x849550
               Pieces: [{Size: 2, Op: {CfaOffset: 8}}]
           IsParameter: true
           IsReturn: false
-    - ID: 8
+    - ID: 2
       Name: main.testRuneArray
       OutOfLinePCRanges: [0x849550..0x849560]
       InlinePCRanges: []
       Variables:
         - Name: x
-          Type: 5 ArrayType [2]int32
+          Type: 37 ArrayType [2]int32
           Locations:
             - Range: 0x849550..0x849560
               Pieces: [{Size: 8, Op: {CfaOffset: 8}}]
           IsParameter: true
           IsReturn: false
-    - ID: 9
+    - ID: 3
       Name: main.testStringArray
       OutOfLinePCRanges: [0x849560..0x849570]
       InlinePCRanges: []
       Variables:
         - Name: x
-          Type: 7 ArrayType [2]string
+          Type: 38 ArrayType [2]string
           Locations:
             - Range: 0x849560..0x849570
               Pieces: [{Size: 32, Op: {CfaOffset: 8}}]
           IsParameter: true
           IsReturn: false
-    - ID: 10
+    - ID: 4
       Name: main.testBoolArray
       OutOfLinePCRanges: [0x849570..0x849580]
       InlinePCRanges: []
       Variables:
         - Name: x
-          Type: 10 ArrayType [2]bool
+          Type: 39 ArrayType [2]bool
           Locations:
             - Range: 0x849570..0x849580
               Pieces: [{Size: 2, Op: {CfaOffset: 8}}]
           IsParameter: true
           IsReturn: false
-    - ID: 11
+    - ID: 5
       Name: main.testIntArray
       OutOfLinePCRanges: [0x849580..0x849590]
       InlinePCRanges: []
       Variables:
         - Name: x
-          Type: 12 ArrayType [2]int
+          Type: 40 ArrayType [2]int
           Locations:
             - Range: 0x849580..0x849590
               Pieces: [{Size: 16, Op: {CfaOffset: 8}}]
           IsParameter: true
           IsReturn: false
-    - ID: 12
+    - ID: 6
       Name: main.testInt8Array
       OutOfLinePCRanges: [0x849590..0x8495a0]
       InlinePCRanges: []
       Variables:
         - Name: x
-          Type: 13 ArrayType [2]int8
+          Type: 41 ArrayType [2]int8
           Locations:
             - Range: 0x849590..0x8495a0
               Pieces: [{Size: 2, Op: {CfaOffset: 8}}]
           IsParameter: true
           IsReturn: false
-    - ID: 13
+    - ID: 7
       Name: main.testInt16Array
       OutOfLinePCRanges: [0x8495a0..0x8495b0]
       InlinePCRanges: []
       Variables:
         - Name: x
-          Type: 15 ArrayType [2]int16
+          Type: 42 ArrayType [2]int16
           Locations:
             - Range: 0x8495a0..0x8495b0
               Pieces: [{Size: 4, Op: {CfaOffset: 8}}]
           IsParameter: true
           IsReturn: false
-    - ID: 14
+    - ID: 8
       Name: main.testInt32Array
       OutOfLinePCRanges: [0x8495b0..0x8495c0]
       InlinePCRanges: []
       Variables:
         - Name: x
-          Type: 5 ArrayType [2]int32
+          Type: 37 ArrayType [2]int32
           Locations:
             - Range: 0x8495b0..0x8495c0
               Pieces: [{Size: 8, Op: {CfaOffset: 8}}]
           IsParameter: true
           IsReturn: false
-    - ID: 15
+    - ID: 9
       Name: main.testInt64Array
       OutOfLinePCRanges: [0x8495c0..0x8495d0]
       InlinePCRanges: []
       Variables:
         - Name: x
-          Type: 17 ArrayType [2]int64
+          Type: 43 ArrayType [2]int64
           Locations:
             - Range: 0x8495c0..0x8495d0
               Pieces: [{Size: 16, Op: {CfaOffset: 8}}]
           IsParameter: true
           IsReturn: false
-    - ID: 16
+    - ID: 10
       Name: main.testUintArray
       OutOfLinePCRanges: [0x8495d0..0x8495e0]
       InlinePCRanges: []
       Variables:
         - Name: x
-          Type: 19 ArrayType [2]uint
+          Type: 44 ArrayType [2]uint
           Locations:
             - Range: 0x8495d0..0x8495e0
               Pieces: [{Size: 16, Op: {CfaOffset: 8}}]
           IsParameter: true
           IsReturn: false
-    - ID: 17
+    - ID: 11
       Name: main.testUint8Array
       OutOfLinePCRanges: [0x8495e0..0x8495f0]
       InlinePCRanges: []
       Variables:
         - Name: x
-          Type: 3 ArrayType [2]uint8
+          Type: 36 ArrayType [2]uint8
           Locations:
             - Range: 0x8495e0..0x8495f0
               Pieces: [{Size: 2, Op: {CfaOffset: 8}}]
           IsParameter: true
           IsReturn: false
-    - ID: 18
+    - ID: 12
       Name: main.testUint16Array
       OutOfLinePCRanges: [0x8495f0..0x849600]
       InlinePCRanges: []
       Variables:
         - Name: x
-          Type: 21 ArrayType [2]uint16
+          Type: 45 ArrayType [2]uint16
           Locations:
             - Range: 0x8495f0..0x849600
               Pieces: [{Size: 4, Op: {CfaOffset: 8}}]
           IsParameter: true
           IsReturn: false
-    - ID: 19
+    - ID: 13
       Name: main.testUint32Array
       OutOfLinePCRanges: [0x849600..0x849610]
       InlinePCRanges: []
       Variables:
         - Name: x
-          Type: 23 ArrayType [2]uint32
+          Type: 46 ArrayType [2]uint32
           Locations:
             - Range: 0x849600..0x849610
               Pieces: [{Size: 8, Op: {CfaOffset: 8}}]
           IsParameter: true
           IsReturn: false
-    - ID: 20
+    - ID: 14
       Name: main.testUint64Array
       OutOfLinePCRanges: [0x849610..0x849620]
       InlinePCRanges: []
       Variables:
         - Name: x
-          Type: 25 ArrayType [2]uint64
+          Type: 47 ArrayType [2]uint64
           Locations:
             - Range: 0x849610..0x849620
               Pieces: [{Size: 16, Op: {CfaOffset: 8}}]
           IsParameter: true
           IsReturn: false
-    - ID: 21
+    - ID: 15
       Name: main.testArrayOfArrays
       OutOfLinePCRanges: [0x849620..0x849630]
       InlinePCRanges: []
       Variables:
         - Name: a
-          Type: 27 ArrayType [2][2]int
+          Type: 48 ArrayType [2][2]int
           Locations:
             - Range: 0x849620..0x849630
               Pieces: [{Size: 32, Op: {CfaOffset: 8}}]
           IsParameter: true
           IsReturn: false
-    - ID: 22
+    - ID: 16
       Name: main.testArrayOfStrings
       OutOfLinePCRanges: [0x849630..0x849640]
       InlinePCRanges: []
       Variables:
         - Name: a
-          Type: 7 ArrayType [2]string
+          Type: 38 ArrayType [2]string
           Locations:
             - Range: 0x849630..0x849640
               Pieces: [{Size: 32, Op: {CfaOffset: 8}}]
           IsParameter: true
           IsReturn: false
-    - ID: 23
+    - ID: 17
       Name: main.testArrayOfArraysOfArrays
       OutOfLinePCRanges: [0x849640..0x849650]
       InlinePCRanges: []
       Variables:
         - Name: b
-          Type: 28 ArrayType [2][2][2]int
+          Type: 49 ArrayType [2][2][2]int
           Locations:
             - Range: 0x849640..0x849650
               Pieces: [{Size: 64, Op: {CfaOffset: 8}}]
           IsParameter: true
           IsReturn: false
-    - ID: 24
+    - ID: 18
       Name: main.testVeryLargeArray
       OutOfLinePCRanges: [0x849670..0x849680]
       InlinePCRanges: []
       Variables:
         - Name: a
-          Type: 29 ArrayType [100]uint
+          Type: 50 ArrayType [100]uint
           Locations:
             - Range: 0x849670..0x849680
               Pieces: [{Size: 800, Op: {CfaOffset: 8}}]
           IsParameter: true
           IsReturn: false
-    - ID: 25
+    - ID: 19
       Name: main.testSingleByte
       OutOfLinePCRanges: [0x8499a0..0x8499b0]
       InlinePCRanges: []
       Variables:
         - Name: x
-          Type: 4 BaseType uint8
+          Type: 3 BaseType uint8
           Locations:
             - Range: 0x8499a0..0x8499b0
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 26
+    - ID: 20
       Name: main.testSingleRune
       OutOfLinePCRanges: [0x8499b0..0x8499c0]
       InlinePCRanges: []
       Variables:
         - Name: x
-          Type: 6 BaseType int32
+          Type: 12 BaseType int32
           Locations:
             - Range: 0x8499b0..0x8499c0
               Pieces: [{Size: 4, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 27
+    - ID: 21
       Name: main.testSingleBool
       OutOfLinePCRanges: [0x8499c0..0x8499d0]
       InlinePCRanges: []
       Variables:
         - Name: x
-          Type: 11 BaseType bool
+          Type: 4 BaseType bool
           Locations:
             - Range: 0x8499c0..0x8499d0
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 28
+    - ID: 22
       Name: main.testSingleInt
       OutOfLinePCRanges: [0x8499d0..0x8499e0]
       InlinePCRanges: []
       Variables:
         - Name: x
-          Type: 1 BaseType int
+          Type: 7 BaseType int
           Locations:
             - Range: 0x8499d0..0x8499e0
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 29
+    - ID: 23
       Name: main.testSingleInt8
       OutOfLinePCRanges: [0x8499e0..0x8499f0]
       InlinePCRanges: []
       Variables:
         - Name: x
-          Type: 14 BaseType int8
+          Type: 16 BaseType int8
           Locations:
             - Range: 0x8499e0..0x8499f0
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 30
+    - ID: 24
       Name: main.testSingleInt16
       OutOfLinePCRanges: [0x8499f0..0x849a00]
       InlinePCRanges: []
       Variables:
         - Name: x
-          Type: 16 BaseType int16
+          Type: 23 BaseType int16
           Locations:
             - Range: 0x8499f0..0x849a00
               Pieces: [{Size: 2, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 31
+    - ID: 25
       Name: main.testSingleInt32
       OutOfLinePCRanges: [0x849a00..0x849a10]
       InlinePCRanges: []
       Variables:
         - Name: x
-          Type: 6 BaseType int32
+          Type: 12 BaseType int32
           Locations:
             - Range: 0x849a00..0x849a10
               Pieces: [{Size: 4, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 32
+    - ID: 26
       Name: main.testSingleInt64
       OutOfLinePCRanges: [0x849a10..0x849a20]
       InlinePCRanges: []
       Variables:
         - Name: x
-          Type: 18 BaseType int64
+          Type: 13 BaseType int64
           Locations:
             - Range: 0x849a10..0x849a20
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 33
+    - ID: 27
       Name: main.testSingleUint
       OutOfLinePCRanges: [0x849a20..0x849a30]
       InlinePCRanges: []
       Variables:
         - Name: x
-          Type: 20 BaseType uint
+          Type: 10 BaseType uint
           Locations:
             - Range: 0x849a20..0x849a30
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 34
+    - ID: 28
       Name: main.testSingleUint8
       OutOfLinePCRanges: [0x849a30..0x849a40]
       InlinePCRanges: []
       Variables:
         - Name: x
-          Type: 4 BaseType uint8
+          Type: 3 BaseType uint8
           Locations:
             - Range: 0x849a30..0x849a40
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 35
+    - ID: 29
       Name: main.testSingleUint16
       OutOfLinePCRanges: [0x849a40..0x849a50]
       InlinePCRanges: []
       Variables:
         - Name: x
-          Type: 22 BaseType uint16
+          Type: 6 BaseType uint16
           Locations:
             - Range: 0x849a40..0x849a50
               Pieces: [{Size: 2, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 36
+    - ID: 30
       Name: main.testSingleUint32
       OutOfLinePCRanges: [0x849a50..0x849a60]
       InlinePCRanges: []
       Variables:
         - Name: x
-          Type: 24 BaseType uint32
+          Type: 2 BaseType uint32
           Locations:
             - Range: 0x849a50..0x849a60
               Pieces: [{Size: 4, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 37
+    - ID: 31
       Name: main.testSingleUint64
       OutOfLinePCRanges: [0x849a60..0x849a70]
       InlinePCRanges: []
       Variables:
         - Name: x
-          Type: 26 BaseType uint64
+          Type: 8 BaseType uint64
           Locations:
             - Range: 0x849a60..0x849a70
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 38
+    - ID: 32
       Name: main.testSingleFloat32
       OutOfLinePCRanges: [0x849a70..0x849a80]
       InlinePCRanges: []
       Variables:
         - Name: x
-          Type: 30 BaseType float32
+          Type: 17 BaseType float32
           Locations:
             - Range: 0x849a70..0x849a80
               Pieces: [{Size: 4, Op: {RegNo: 64, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 39
+    - ID: 33
       Name: main.testSingleFloat64
       OutOfLinePCRanges: [0x849a80..0x849a90]
       InlinePCRanges: []
       Variables:
         - Name: x
-          Type: 31 BaseType float64
+          Type: 18 BaseType float64
           Locations:
             - Range: 0x849a80..0x849a90
               Pieces: [{Size: 8, Op: {RegNo: 64, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 40
+    - ID: 34
       Name: main.testTypeAlias
       OutOfLinePCRanges: [0x849a90..0x849aa0]
       InlinePCRanges: []
       Variables:
         - Name: x
-          Type: 32 BaseType main.typeAlias
+          Type: 51 BaseType main.typeAlias
           Locations:
             - Range: 0x849a90..0x849aa0
               Pieces: [{Size: 2, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 41
+    - ID: 35
       Name: main.testBigStruct
       OutOfLinePCRanges: [0x849ba0..0x849bc0]
       InlinePCRanges: []
       Variables:
         - Name: b
-          Type: 33 StructureType main.bigStruct
+          Type: 52 StructureType main.bigStruct
           Locations:
             - Range: 0x849ba0..0x849bc0
               Pieces:
@@ -1905,13 +1905,13 @@ Subprograms:
                   Op: {RegNo: 5, Shift: 0}
           IsParameter: true
           IsReturn: false
-    - ID: 42
+    - ID: 36
       Name: main.testEsotericStack
       OutOfLinePCRanges: [0x849d60..0x849e30]
       InlinePCRanges: []
       Variables:
         - Name: e
-          Type: 39 StructureType main.esotericStack
+          Type: 56 StructureType main.esotericStack
           Locations:
             - Range: 0x849d60..0x849da8
               Pieces:
@@ -1975,51 +1975,51 @@ Subprograms:
                   Op: {RegNo: 8, Shift: 0}
           IsParameter: true
           IsReturn: false
-    - ID: 43
+    - ID: 37
       Name: main.testEsotericHeap
       OutOfLinePCRanges: [0x849e30..0x849eb0]
       InlinePCRanges: []
       Variables:
         - Name: e
-          Type: 44 PointerType *main.esotericHeap
+          Type: 61 PointerType *main.esotericHeap
           Locations:
             - Range: 0x849e30..0x849e68
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 44
+    - ID: 38
       Name: main.testInlinedBA
       OutOfLinePCRanges: [0x84a270..0x84a300]
       InlinePCRanges: []
       Variables:
         - Name: x
-          Type: 1 BaseType int
+          Type: 7 BaseType int
           Locations:
             - Range: 0x84a270..0x84a2a8
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 45
+    - ID: 39
       Name: main.testInlinedBB
       OutOfLinePCRanges: [0x84a300..0x84a3c0]
       InlinePCRanges: []
       Variables:
         - Name: x
-          Type: 1 BaseType int
+          Type: 7 BaseType int
           Locations:
             - Range: 0x84a300..0x84a31c
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
         - Name: y
-          Type: 1 BaseType int
+          Type: 7 BaseType int
           Locations:
             - Range: 0x84a300..0x84a32c
               Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
           IsParameter: true
           IsReturn: false
         - Name: z
-          Type: 1 BaseType int
+          Type: 7 BaseType int
           Locations:
             - Range: 0x84a31c..0x84a32c
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
@@ -2027,25 +2027,25 @@ Subprograms:
               Pieces: [{Size: 8, Op: {CfaOffset: -48}}]
           IsParameter: false
           IsReturn: false
-    - ID: 46
+    - ID: 40
       Name: main.testInlinedBBA
       OutOfLinePCRanges: [0x84a3c0..0x84a440]
       InlinePCRanges: []
       Variables:
         - Name: x
-          Type: 1 BaseType int
+          Type: 7 BaseType int
           Locations:
             - Range: 0x84a3c0..0x84a3e4
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 47
+    - ID: 41
       Name: main.testInlinedBC
       OutOfLinePCRanges: [0x84a440..0x84a560]
       InlinePCRanges: []
       Variables:
         - Name: s
-          Type: 1 BaseType int
+          Type: 7 BaseType int
           Locations:
             - Range: 0x84a4a8..0x84a4b0
               Pieces: [{Size: 8, Op: {CfaOffset: -72}}]
@@ -2056,7 +2056,7 @@ Subprograms:
           IsParameter: false
           IsReturn: false
         - Name: i
-          Type: 1 BaseType int
+          Type: 7 BaseType int
           Locations:
             - Range: 0x84a4a4..0x84a4ac
               Pieces: [{Size: 8, Op: {CfaOffset: -64}}]
@@ -2066,47 +2066,47 @@ Subprograms:
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: false
           IsReturn: false
-    - ID: 48
+    - ID: 42
       Name: main.testFrameless
       OutOfLinePCRanges: [0x84a560..0x84a570]
       InlinePCRanges: []
       Variables:
         - Name: x
-          Type: 1 BaseType int
+          Type: 7 BaseType int
           Locations:
             - Range: 0x84a560..0x84a568
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
         - Name: ~r0
-          Type: 1 BaseType int
+          Type: 7 BaseType int
           Locations: [{Range: 0x84a560..0x84a570, Pieces: []}]
           IsParameter: true
           IsReturn: true
-    - ID: 49
+    - ID: 43
       Name: main.testFramelessArray
       OutOfLinePCRanges: [0x84a570..0x84a5d0]
       InlinePCRanges: []
       Variables:
         - Name: a
-          Type: 2 ArrayType [5]int
+          Type: 73 ArrayType [5]int
           Locations:
             - Range: 0x84a570..0x84a5d0
               Pieces: [{Size: 40, Op: {CfaOffset: 8}}]
           IsParameter: true
           IsReturn: false
         - Name: ~r0
-          Type: 1 BaseType int
+          Type: 7 BaseType int
           Locations: [{Range: 0x84a570..0x84a5d0, Pieces: []}]
           IsParameter: true
           IsReturn: true
-    - ID: 50
+    - ID: 44
       Name: main.testInterface
       OutOfLinePCRanges: [0x84a800..0x84a850]
       InlinePCRanges: []
       Variables:
         - Name: b
-          Type: 56 GoInterfaceType main.behavior
+          Type: 74 GoInterfaceType main.behavior
           Locations:
             - Range: 0x84a800..0x84a828
               Pieces:
@@ -2123,17 +2123,17 @@ Subprograms:
           IsParameter: true
           IsReturn: false
         - Name: ~r0
-          Type: 8 GoStringHeaderType string
+          Type: 9 GoStringHeaderType string
           Locations: [{Range: 0x84a800..0x84a850, Pieces: []}]
           IsParameter: true
           IsReturn: true
-    - ID: 51
+    - ID: 45
       Name: main.testAny
       OutOfLinePCRanges: [0x84a850..0x84a8c0]
       InlinePCRanges: []
       Variables:
         - Name: a
-          Type: 41 GoEmptyInterfaceType interface {}
+          Type: 58 GoEmptyInterfaceType interface {}
           Locations:
             - Range: 0x84a850..0x84a880
               Pieces:
@@ -2150,17 +2150,17 @@ Subprograms:
           IsParameter: true
           IsReturn: false
         - Name: ~r0
-          Type: 8 GoStringHeaderType string
+          Type: 9 GoStringHeaderType string
           Locations: [{Range: 0x84a850..0x84a8c0, Pieces: []}]
           IsParameter: true
           IsReturn: true
-    - ID: 52
+    - ID: 46
       Name: main.testError
       OutOfLinePCRanges: [0x84a8c0..0x84a8d0]
       InlinePCRanges: []
       Variables:
         - Name: e
-          Type: 57 GoInterfaceType error
+          Type: 14 GoInterfaceType error
           Locations:
             - Range: 0x84a8c0..0x84a8d0
               Pieces:
@@ -2170,307 +2170,307 @@ Subprograms:
                   Op: {RegNo: 1, Shift: 0}
           IsParameter: true
           IsReturn: false
-    - ID: 53
+    - ID: 47
       Name: main.testStructWithMap
       OutOfLinePCRanges: [0x84ace0..0x84acf0]
       InlinePCRanges: []
       Variables:
         - Name: s
-          Type: 58 StructureType main.structWithMap
+          Type: 75 StructureType main.structWithMap
           Locations:
             - Range: 0x84ace0..0x84acf0
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 54
+    - ID: 48
       Name: main.testMapStringToStruct
       OutOfLinePCRanges: [0x84acf0..0x84ad00]
       InlinePCRanges: []
       Variables:
         - Name: m
-          Type: 71 GoMapType map[string]main.nestedStruct
+          Type: 87 GoMapType map[string]main.nestedStruct
           Locations:
             - Range: 0x84acf0..0x84ad00
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 55
+    - ID: 49
       Name: main.testMapStringToInt
       OutOfLinePCRanges: [0x84ad00..0x84ad10]
       InlinePCRanges: []
       Variables:
         - Name: m
-          Type: 83 GoMapType map[string]int
+          Type: 99 GoMapType map[string]int
           Locations:
             - Range: 0x84ad00..0x84ad10
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 56
+    - ID: 50
       Name: main.testMapStringToSlice
       OutOfLinePCRanges: [0x84ad10..0x84ad20]
       InlinePCRanges: []
       Variables:
         - Name: m
-          Type: 94 GoMapType map[string][]string
+          Type: 110 GoMapType map[string][]string
           Locations:
             - Range: 0x84ad10..0x84ad20
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 57
+    - ID: 51
       Name: main.testMapArrayToArray
       OutOfLinePCRanges: [0x84ad20..0x84ad30]
       InlinePCRanges: []
       Variables:
         - Name: m
-          Type: 106 GoMapType map[[4]string][2]int
+          Type: 122 GoMapType map[[4]string][2]int
           Locations:
             - Range: 0x84ad20..0x84ad30
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 58
+    - ID: 52
       Name: main.testSmallMap
       OutOfLinePCRanges: [0x84ad30..0x84ad40]
       InlinePCRanges: []
       Variables:
         - Name: m
-          Type: 83 GoMapType map[string]int
+          Type: 99 GoMapType map[string]int
           Locations:
             - Range: 0x84ad30..0x84ad40
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 59
+    - ID: 53
       Name: main.testArrayOfMaps
       OutOfLinePCRanges: [0x84ad40..0x84ad50]
       InlinePCRanges: []
       Variables:
         - Name: m
-          Type: 118 ArrayType [2]map[string]int
+          Type: 134 ArrayType [2]map[string]int
           Locations:
             - Range: 0x84ad40..0x84ad50
               Pieces: [{Size: 16, Op: {CfaOffset: 8}}]
           IsParameter: true
           IsReturn: false
-    - ID: 60
+    - ID: 54
       Name: main.testPointerToMap
       OutOfLinePCRanges: [0x84ad50..0x84ad60]
       InlinePCRanges: []
       Variables:
         - Name: m
-          Type: 119 PointerType *map[string]int
+          Type: 135 PointerType *map[string]int
           Locations:
             - Range: 0x84ad50..0x84ad60
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 61
+    - ID: 55
       Name: main.testMapIntToInt
       OutOfLinePCRanges: [0x84ad60..0x84ad70]
       InlinePCRanges: []
       Variables:
         - Name: m
-          Type: 59 GoMapType map[int]int
+          Type: 76 GoMapType map[int]int
           Locations:
             - Range: 0x84ad60..0x84ad70
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 62
+    - ID: 56
       Name: main.testMapMassive
       OutOfLinePCRanges: [0x84ad70..0x84ad80]
       InlinePCRanges: []
       Variables:
         - Name: redactMyEntries
-          Type: 120 GoMapType map[string][]main.structWithMap
+          Type: 136 GoMapType map[string][]main.structWithMap
           Locations:
             - Range: 0x84ad70..0x84ad80
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 63
+    - ID: 57
       Name: main.testMapEmbeddedMaps
       OutOfLinePCRanges: [0x84ad80..0x84ad90]
       InlinePCRanges: []
       Variables:
         - Name: m
-          Type: 120 GoMapType map[string][]main.structWithMap
+          Type: 136 GoMapType map[string][]main.structWithMap
           Locations:
             - Range: 0x84ad80..0x84ad90
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 64
+    - ID: 58
       Name: main.testMapWithLinkedList
       OutOfLinePCRanges: [0x84ad90..0x84ada0]
       InlinePCRanges: []
       Variables:
         - Name: m
-          Type: 133 GoMapType map[bool]main.node
+          Type: 149 GoMapType map[bool]main.node
           Locations:
             - Range: 0x84ad90..0x84ada0
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 65
+    - ID: 59
       Name: main.testMapWithSmallValue
       OutOfLinePCRanges: [0x84ada0..0x84adb0]
       InlinePCRanges: []
       Variables:
         - Name: m
-          Type: 146 GoMapType map[int]uint8
+          Type: 162 GoMapType map[int]uint8
           Locations:
             - Range: 0x84ada0..0x84adb0
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 66
+    - ID: 60
       Name: main.testMapWithSmallValueMassive
       OutOfLinePCRanges: [0x84adb0..0x84adc0]
       InlinePCRanges: []
       Variables:
         - Name: redactMyEntries
-          Type: 146 GoMapType map[int]uint8
+          Type: 162 GoMapType map[int]uint8
           Locations:
             - Range: 0x84adb0..0x84adc0
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 67
+    - ID: 61
       Name: main.testMapWithSmallKeyAndValue
       OutOfLinePCRanges: [0x84adc0..0x84add0]
       InlinePCRanges: []
       Variables:
         - Name: m
-          Type: 157 GoMapType map[uint8]uint8
+          Type: 173 GoMapType map[uint8]uint8
           Locations:
             - Range: 0x84adc0..0x84add0
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 68
+    - ID: 62
       Name: main.testMapWithSmallKeyAndValueMassive
       OutOfLinePCRanges: [0x84add0..0x84ade0]
       InlinePCRanges: []
       Variables:
         - Name: m
-          Type: 157 GoMapType map[uint8]uint8
+          Type: 173 GoMapType map[uint8]uint8
           Locations:
             - Range: 0x84add0..0x84ade0
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 69
+    - ID: 63
       Name: main.testMapSmallKeySmallValue
       OutOfLinePCRanges: [0x84ade0..0x84adf0]
       InlinePCRanges: []
       Variables:
         - Name: m
-          Type: 157 GoMapType map[uint8]uint8
+          Type: 173 GoMapType map[uint8]uint8
           Locations:
             - Range: 0x84ade0..0x84adf0
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 70
+    - ID: 64
       Name: main.testMapSmallKeyLargeValue
       OutOfLinePCRanges: [0x84adf0..0x84ae00]
       InlinePCRanges: []
       Variables:
         - Name: m
-          Type: 168 GoMapType map[uint8][4]int
+          Type: 184 GoMapType map[uint8][4]int
           Locations:
             - Range: 0x84adf0..0x84ae00
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 71
+    - ID: 65
       Name: main.testMapLargeKeySmallValue
       OutOfLinePCRanges: [0x84ae00..0x84ae10]
       InlinePCRanges: []
       Variables:
         - Name: m
-          Type: 180 GoMapType map[[4]int]uint8
+          Type: 196 GoMapType map[[4]int]uint8
           Locations:
             - Range: 0x84ae00..0x84ae10
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 72
+    - ID: 66
       Name: main.testMapLargeKeyLargeValue
       OutOfLinePCRanges: [0x84ae10..0x84ae20]
       InlinePCRanges: []
       Variables:
         - Name: m
-          Type: 191 GoMapType map[[4]int][4]int
+          Type: 207 GoMapType map[[4]int][4]int
           Locations:
             - Range: 0x84ae10..0x84ae20
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 73
+    - ID: 67
       Name: main.testCombinedByte
       OutOfLinePCRanges: [0x84c110..0x84c120]
       InlinePCRanges: []
       Variables:
         - Name: w
-          Type: 4 BaseType uint8
+          Type: 3 BaseType uint8
           Locations:
             - Range: 0x84c110..0x84c120
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
         - Name: x
-          Type: 4 BaseType uint8
+          Type: 3 BaseType uint8
           Locations:
             - Range: 0x84c110..0x84c120
               Pieces: [{Size: 1, Op: {RegNo: 1, Shift: 0}}]
           IsParameter: true
           IsReturn: false
         - Name: y
-          Type: 30 BaseType float32
+          Type: 17 BaseType float32
           Locations:
             - Range: 0x84c110..0x84c120
               Pieces: [{Size: 4, Op: {RegNo: 64, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 74
+    - ID: 68
       Name: main.testMultipleSimpleParams
       OutOfLinePCRanges: [0x84c1f0..0x84c200]
       InlinePCRanges: []
       Variables:
         - Name: a
-          Type: 11 BaseType bool
+          Type: 4 BaseType bool
           Locations:
             - Range: 0x84c1f0..0x84c200
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
         - Name: b
-          Type: 4 BaseType uint8
+          Type: 3 BaseType uint8
           Locations:
             - Range: 0x84c1f0..0x84c200
               Pieces: [{Size: 1, Op: {RegNo: 1, Shift: 0}}]
           IsParameter: true
           IsReturn: false
         - Name: c
-          Type: 6 BaseType int32
+          Type: 12 BaseType int32
           Locations:
             - Range: 0x84c1f0..0x84c200
               Pieces: [{Size: 4, Op: {RegNo: 2, Shift: 0}}]
           IsParameter: true
           IsReturn: false
         - Name: d
-          Type: 20 BaseType uint
+          Type: 10 BaseType uint
           Locations:
             - Range: 0x84c1f0..0x84c200
               Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
           IsParameter: true
           IsReturn: false
         - Name: e
-          Type: 8 GoStringHeaderType string
+          Type: 9 GoStringHeaderType string
           Locations:
             - Range: 0x84c1f0..0x84c200
               Pieces:
@@ -2480,37 +2480,37 @@ Subprograms:
                   Op: {RegNo: 5, Shift: 0}
           IsParameter: true
           IsReturn: false
-    - ID: 75
+    - ID: 69
       Name: main.testChannel
       OutOfLinePCRanges: [0x84c390..0x84c3a0]
       InlinePCRanges: []
       Variables:
         - Name: c
-          Type: 202 GoChannelType chan bool
+          Type: 218 GoChannelType chan bool
           Locations:
             - Range: 0x84c390..0x84c3a0
               Pieces: [{Size: 0, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 76
+    - ID: 70
       Name: main.testPointerToSimpleStruct
       OutOfLinePCRanges: [0x84c530..0x84c540]
       InlinePCRanges: []
       Variables:
         - Name: a
-          Type: 203 PointerType *main.structWithTwoValues
+          Type: 219 PointerType *main.structWithTwoValues
           Locations:
             - Range: 0x84c530..0x84c540
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 77
+    - ID: 71
       Name: main.testLinkedList
       OutOfLinePCRanges: [0x84c540..0x84c550]
       InlinePCRanges: []
       Variables:
         - Name: a
-          Type: 144 StructureType main.node
+          Type: 160 StructureType main.node
           Locations:
             - Range: 0x84c540..0x84c550
               Pieces:
@@ -2520,92 +2520,92 @@ Subprograms:
                   Op: {RegNo: 1, Shift: 0}
           IsParameter: true
           IsReturn: false
-    - ID: 78
+    - ID: 72
       Name: main.testPointerLoop
       OutOfLinePCRanges: [0x84c550..0x84c560]
       InlinePCRanges: []
       Variables:
         - Name: a
-          Type: 145 PointerType *main.node
+          Type: 161 PointerType *main.node
           Locations:
             - Range: 0x84c550..0x84c560
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 79
+    - ID: 73
       Name: main.testUnsafePointer
       OutOfLinePCRanges: [0x84c560..0x84c570]
       InlinePCRanges: []
       Variables:
         - Name: x
-          Type: 38 VoidPointerType unsafe.Pointer
+          Type: 15 VoidPointerType unsafe.Pointer
           Locations:
             - Range: 0x84c560..0x84c570
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 80
+    - ID: 74
       Name: main.testUintPointer
       OutOfLinePCRanges: [0x84c580..0x84c590]
       InlinePCRanges: []
       Variables:
         - Name: x
-          Type: 205 PointerType *uint
+          Type: 34 PointerType *uint
           Locations:
             - Range: 0x84c580..0x84c590
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 81
+    - ID: 75
       Name: main.testStringPointer
       OutOfLinePCRanges: [0x84c5f0..0x84c600]
       InlinePCRanges: []
       Variables:
         - Name: z
-          Type: 36 PointerType *string
+          Type: 22 PointerType *string
           Locations:
             - Range: 0x84c5f0..0x84c600
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 82
+    - ID: 76
       Name: main.testNilPointer
       OutOfLinePCRanges: [0x84c610..0x84c620]
       InlinePCRanges: []
       Variables:
         - Name: z
-          Type: 206 PointerType *bool
+          Type: 11 PointerType *bool
           Locations:
             - Range: 0x84c610..0x84c620
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
         - Name: a
-          Type: 20 BaseType uint
+          Type: 10 BaseType uint
           Locations:
             - Range: 0x84c610..0x84c620
               Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 83
+    - ID: 77
       Name: main.testCycle
       OutOfLinePCRanges: [0x84c630..0x84c640]
       InlinePCRanges: []
       Variables:
         - Name: t
-          Type: 207 PointerType *main.t
+          Type: 221 PointerType *main.t
           Locations:
             - Range: 0x84c630..0x84c640
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 84
+    - ID: 78
       Name: main.testUintSlice
       OutOfLinePCRanges: [0x84ca00..0x84ca10]
       InlinePCRanges: []
       Variables:
         - Name: u
-          Type: 210 GoSliceHeaderType []uint
+          Type: 224 GoSliceHeaderType []uint
           Locations:
             - Range: 0x84ca00..0x84ca10
               Pieces:
@@ -2617,13 +2617,13 @@ Subprograms:
                   Op: {RegNo: 2, Shift: 0}
           IsParameter: true
           IsReturn: false
-    - ID: 85
+    - ID: 79
       Name: main.testEmptySlice
       OutOfLinePCRanges: [0x84ca10..0x84ca20]
       InlinePCRanges: []
       Variables:
         - Name: u
-          Type: 210 GoSliceHeaderType []uint
+          Type: 224 GoSliceHeaderType []uint
           Locations:
             - Range: 0x84ca10..0x84ca20
               Pieces:
@@ -2635,13 +2635,13 @@ Subprograms:
                   Op: {RegNo: 2, Shift: 0}
           IsParameter: true
           IsReturn: false
-    - ID: 86
+    - ID: 80
       Name: main.testSliceOfSlices
       OutOfLinePCRanges: [0x84ca20..0x84ca30]
       InlinePCRanges: []
       Variables:
         - Name: u
-          Type: 211 GoSliceHeaderType [][]uint
+          Type: 225 GoSliceHeaderType [][]uint
           Locations:
             - Range: 0x84ca20..0x84ca30
               Pieces:
@@ -2653,13 +2653,13 @@ Subprograms:
                   Op: {RegNo: 2, Shift: 0}
           IsParameter: true
           IsReturn: false
-    - ID: 87
+    - ID: 81
       Name: main.testStructSlice
       OutOfLinePCRanges: [0x84ca30..0x84ca40]
       InlinePCRanges: []
       Variables:
         - Name: xs
-          Type: 213 GoSliceHeaderType []main.structWithNoStrings
+          Type: 227 GoSliceHeaderType []main.structWithNoStrings
           Locations:
             - Range: 0x84ca30..0x84ca40
               Pieces:
@@ -2672,19 +2672,19 @@ Subprograms:
           IsParameter: true
           IsReturn: false
         - Name: a
-          Type: 1 BaseType int
+          Type: 7 BaseType int
           Locations:
             - Range: 0x84ca30..0x84ca40
               Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 88
+    - ID: 82
       Name: main.testEmptySliceOfStructs
       OutOfLinePCRanges: [0x84ca40..0x84ca50]
       InlinePCRanges: []
       Variables:
         - Name: xs
-          Type: 213 GoSliceHeaderType []main.structWithNoStrings
+          Type: 227 GoSliceHeaderType []main.structWithNoStrings
           Locations:
             - Range: 0x84ca40..0x84ca50
               Pieces:
@@ -2697,19 +2697,19 @@ Subprograms:
           IsParameter: true
           IsReturn: false
         - Name: a
-          Type: 1 BaseType int
+          Type: 7 BaseType int
           Locations:
             - Range: 0x84ca40..0x84ca50
               Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 89
+    - ID: 83
       Name: main.testNilSliceOfStructs
       OutOfLinePCRanges: [0x84ca50..0x84ca60]
       InlinePCRanges: []
       Variables:
         - Name: xs
-          Type: 213 GoSliceHeaderType []main.structWithNoStrings
+          Type: 227 GoSliceHeaderType []main.structWithNoStrings
           Locations:
             - Range: 0x84ca50..0x84ca60
               Pieces:
@@ -2722,19 +2722,19 @@ Subprograms:
           IsParameter: true
           IsReturn: false
         - Name: a
-          Type: 1 BaseType int
+          Type: 7 BaseType int
           Locations:
             - Range: 0x84ca50..0x84ca60
               Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 90
+    - ID: 84
       Name: main.testStringSlice
       OutOfLinePCRanges: [0x84ca60..0x84ca70]
       InlinePCRanges: []
       Variables:
         - Name: s
-          Type: 105 GoSliceHeaderType []string
+          Type: 121 GoSliceHeaderType []string
           Locations:
             - Range: 0x84ca60..0x84ca70
               Pieces:
@@ -2746,20 +2746,20 @@ Subprograms:
                   Op: {RegNo: 2, Shift: 0}
           IsParameter: true
           IsReturn: false
-    - ID: 91
+    - ID: 85
       Name: main.testNilSliceWithOtherParams
       OutOfLinePCRanges: [0x84ca70..0x84ca80]
       InlinePCRanges: []
       Variables:
         - Name: a
-          Type: 14 BaseType int8
+          Type: 16 BaseType int8
           Locations:
             - Range: 0x84ca70..0x84ca80
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
         - Name: s
-          Type: 216 GoSliceHeaderType []bool
+          Type: 230 GoSliceHeaderType []bool
           Locations:
             - Range: 0x84ca70..0x84ca80
               Pieces:
@@ -2772,19 +2772,19 @@ Subprograms:
           IsParameter: true
           IsReturn: false
         - Name: x
-          Type: 20 BaseType uint
+          Type: 10 BaseType uint
           Locations:
             - Range: 0x84ca70..0x84ca80
               Pieces: [{Size: 8, Op: {RegNo: 4, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 92
+    - ID: 86
       Name: main.testNilSlice
       OutOfLinePCRanges: [0x84ca80..0x84ca90]
       InlinePCRanges: []
       Variables:
         - Name: xs
-          Type: 217 GoSliceHeaderType []uint16
+          Type: 231 GoSliceHeaderType []uint16
           Locations:
             - Range: 0x84ca80..0x84ca90
               Pieces:
@@ -2796,13 +2796,13 @@ Subprograms:
                   Op: {RegNo: 2, Shift: 0}
           IsParameter: true
           IsReturn: false
-    - ID: 93
+    - ID: 87
       Name: main.testVeryLargeSlice
       OutOfLinePCRanges: [0x84ca90..0x84caa0]
       InlinePCRanges: []
       Variables:
         - Name: xs
-          Type: 210 GoSliceHeaderType []uint
+          Type: 224 GoSliceHeaderType []uint
           Locations:
             - Range: 0x84ca90..0x84caa0
               Pieces:
@@ -2814,23 +2814,23 @@ Subprograms:
                   Op: {RegNo: 2, Shift: 0}
           IsParameter: true
           IsReturn: false
-    - ID: 94
+    - ID: 88
       Name: main.stackC
       OutOfLinePCRanges: [0x84cd60..0x84cdd0]
       InlinePCRanges: []
       Variables:
         - Name: ~r0
-          Type: 8 GoStringHeaderType string
+          Type: 9 GoStringHeaderType string
           Locations: [{Range: 0x84cd60..0x84cdd0, Pieces: []}]
           IsParameter: true
           IsReturn: true
-    - ID: 95
+    - ID: 89
       Name: main.testSingleString
       OutOfLinePCRanges: [0x84cdd0..0x84cde0]
       InlinePCRanges: []
       Variables:
         - Name: x
-          Type: 8 GoStringHeaderType string
+          Type: 9 GoStringHeaderType string
           Locations:
             - Range: 0x84cdd0..0x84cde0
               Pieces:
@@ -2840,13 +2840,13 @@ Subprograms:
                   Op: {RegNo: 1, Shift: 0}
           IsParameter: true
           IsReturn: false
-    - ID: 96
+    - ID: 90
       Name: main.testThreeStrings
       OutOfLinePCRanges: [0x84cde0..0x84cdf0]
       InlinePCRanges: []
       Variables:
         - Name: x
-          Type: 8 GoStringHeaderType string
+          Type: 9 GoStringHeaderType string
           Locations:
             - Range: 0x84cde0..0x84cdf0
               Pieces:
@@ -2857,7 +2857,7 @@ Subprograms:
           IsParameter: true
           IsReturn: false
         - Name: y
-          Type: 8 GoStringHeaderType string
+          Type: 9 GoStringHeaderType string
           Locations:
             - Range: 0x84cde0..0x84cdf0
               Pieces:
@@ -2868,7 +2868,7 @@ Subprograms:
           IsParameter: true
           IsReturn: false
         - Name: z
-          Type: 8 GoStringHeaderType string
+          Type: 9 GoStringHeaderType string
           Locations:
             - Range: 0x84cde0..0x84cdf0
               Pieces:
@@ -2878,13 +2878,13 @@ Subprograms:
                   Op: {RegNo: 5, Shift: 0}
           IsParameter: true
           IsReturn: false
-    - ID: 97
+    - ID: 91
       Name: main.testThreeStringsInStruct
       OutOfLinePCRanges: [0x84cdf0..0x84ce10]
       InlinePCRanges: []
       Variables:
         - Name: a
-          Type: 219 StructureType main.threeStringStruct
+          Type: 232 StructureType main.threeStringStruct
           Locations:
             - Range: 0x84cdf0..0x84ce10
               Pieces:
@@ -2902,37 +2902,37 @@ Subprograms:
                   Op: {RegNo: 5, Shift: 0}
           IsParameter: true
           IsReturn: false
-    - ID: 98
+    - ID: 92
       Name: main.testThreeStringsInStructPointer
       OutOfLinePCRanges: [0x84ce10..0x84ce20]
       InlinePCRanges: []
       Variables:
         - Name: a
-          Type: 220 PointerType *main.threeStringStruct
+          Type: 233 PointerType *main.threeStringStruct
           Locations:
             - Range: 0x84ce10..0x84ce20
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 99
+    - ID: 93
       Name: main.testOneStringInStructPointer
       OutOfLinePCRanges: [0x84ce20..0x84ce30]
       InlinePCRanges: []
       Variables:
         - Name: a
-          Type: 221 PointerType *main.oneStringStruct
+          Type: 234 PointerType *main.oneStringStruct
           Locations:
             - Range: 0x84ce20..0x84ce30
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 100
+    - ID: 94
       Name: main.testMassiveString
       OutOfLinePCRanges: [0x84ce30..0x84ce40]
       InlinePCRanges: []
       Variables:
         - Name: x
-          Type: 8 GoStringHeaderType string
+          Type: 9 GoStringHeaderType string
           Locations:
             - Range: 0x84ce30..0x84ce40
               Pieces:
@@ -2942,13 +2942,13 @@ Subprograms:
                   Op: {RegNo: 1, Shift: 0}
           IsParameter: true
           IsReturn: false
-    - ID: 101
+    - ID: 95
       Name: main.testUnitializedString
       OutOfLinePCRanges: [0x84ce40..0x84ce50]
       InlinePCRanges: []
       Variables:
         - Name: x
-          Type: 8 GoStringHeaderType string
+          Type: 9 GoStringHeaderType string
           Locations:
             - Range: 0x84ce40..0x84ce50
               Pieces:
@@ -2958,13 +2958,13 @@ Subprograms:
                   Op: {RegNo: 1, Shift: 0}
           IsParameter: true
           IsReturn: false
-    - ID: 102
+    - ID: 96
       Name: main.testEmptyString
       OutOfLinePCRanges: [0x84ce50..0x84ce60]
       InlinePCRanges: []
       Variables:
         - Name: x
-          Type: 8 GoStringHeaderType string
+          Type: 9 GoStringHeaderType string
           Locations:
             - Range: 0x84ce50..0x84ce60
               Pieces:
@@ -2974,13 +2974,13 @@ Subprograms:
                   Op: {RegNo: 1, Shift: 0}
           IsParameter: true
           IsReturn: false
-    - ID: 103
+    - ID: 97
       Name: main.testStruct
       OutOfLinePCRanges: [0x84d060..0x84d080]
       InlinePCRanges: []
       Variables:
         - Name: x
-          Type: 223 StructureType main.aStruct
+          Type: 236 StructureType main.aStruct
           Locations:
             - Range: 0x84d060..0x84d080
               Pieces:
@@ -3000,17 +3000,17 @@ Subprograms:
                   Op: {RegNo: 6, Shift: 0}
           IsParameter: true
           IsReturn: false
-    - ID: 104
+    - ID: 98
       Name: main.testEmptyStruct
       OutOfLinePCRanges: [0x84d160..0x84d170]
       InlinePCRanges: []
       Variables:
         - Name: e
-          Type: 224 StructureType main.emptyStruct
+          Type: 237 StructureType main.emptyStruct
           Locations: [{Range: 0x84d160..0x84d170, Pieces: []}]
           IsParameter: true
           IsReturn: false
-    - ID: 1
+    - ID: 99
       Name: main.testInlinedPrint
       OutOfLinePCRanges: [0x84a0d0..0x84a140]
       InlinePCRanges:
@@ -3024,7 +3024,7 @@ Subprograms:
           RootRanges: [0x84a3c0..0x84a440]
       Variables:
         - Name: x
-          Type: 1 BaseType int
+          Type: 7 BaseType int
           Locations:
             - Range: 0x84a0d0..0x84a0f0
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
@@ -3040,28 +3040,28 @@ Subprograms:
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 2
+    - ID: 100
       Name: main.testInlinedBBB
       OutOfLinePCRanges: []
       InlinePCRanges:
         - Ranges: [0x84a368..0x84a3a0]
           RootRanges: [0x84a300..0x84a3c0]
       Variables: []
-    - ID: 3
+    - ID: 101
       Name: main.testInlinedBCA
       OutOfLinePCRanges: []
       InlinePCRanges:
         - Ranges: [0x84a45c..0x84a4a0]
           RootRanges: [0x84a440..0x84a560]
       Variables: []
-    - ID: 4
+    - ID: 102
       Name: main.testInlinedBCB
       OutOfLinePCRanges: []
       InlinePCRanges:
         - Ranges: [0x84a510..0x84a548]
           RootRanges: [0x84a440..0x84a560]
       Variables: []
-    - ID: 5
+    - ID: 103
       Name: main.testInlinedSq
       OutOfLinePCRanges: []
       InlinePCRanges:
@@ -3069,13 +3069,13 @@ Subprograms:
           RootRanges: [0x84a560..0x84a570]
       Variables:
         - Name: x
-          Type: 1 BaseType int
+          Type: 7 BaseType int
           Locations:
             - Range: 0x84a560..0x84a568
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 6
+    - ID: 104
       Name: main.testInlinedSumArray
       OutOfLinePCRanges: []
       InlinePCRanges:
@@ -3085,7 +3085,7 @@ Subprograms:
           RootRanges: [0x84a5d0..0x84a720]
       Variables:
         - Name: a
-          Type: 2 ArrayType [5]int
+          Type: 73 ArrayType [5]int
           Locations:
             - Range: 0x84a580..0x84a5d0
               Pieces: [{Size: 40, Op: {CfaOffset: -48}}]
@@ -3095,77 +3095,77 @@ Subprograms:
           IsReturn: false
 Types:
     - __kind: PointerType
-      ID: 209
+      ID: 223
       Name: '**main.t'
       ByteSize: 8
-      Pointee: 207 PointerType *main.t
+      Pointee: 221 PointerType *main.t
     - __kind: PointerType
-      ID: 35
+      ID: 54
       Name: '**string'
       ByteSize: 8
       GoRuntimeType: 520928
       GoKind: 22
-      Pointee: 36 PointerType *string
+      Pointee: 22 PointerType *string
     - __kind: PointerType
-      ID: 194
+      ID: 210
       Name: '**table<[4]int,[4]int>'
       ByteSize: 8
-      Pointee: 195 PointerType *table<[4]int,[4]int>
+      Pointee: 211 PointerType *table<[4]int,[4]int>
     - __kind: PointerType
-      ID: 183
+      ID: 199
       Name: '**table<[4]int,uint8>'
       ByteSize: 8
-      Pointee: 184 PointerType *table<[4]int,uint8>
+      Pointee: 200 PointerType *table<[4]int,uint8>
     - __kind: PointerType
-      ID: 109
+      ID: 125
       Name: '**table<[4]string,[2]int>'
       ByteSize: 8
-      Pointee: 110 PointerType *table<[4]string,[2]int>
+      Pointee: 126 PointerType *table<[4]string,[2]int>
     - __kind: PointerType
-      ID: 136
+      ID: 152
       Name: '**table<bool,main.node>'
       ByteSize: 8
-      Pointee: 137 PointerType *table<bool,main.node>
+      Pointee: 153 PointerType *table<bool,main.node>
     - __kind: PointerType
-      ID: 63
+      ID: 79
       Name: '**table<int,int>'
       ByteSize: 8
-      Pointee: 64 PointerType *table<int,int>
+      Pointee: 80 PointerType *table<int,int>
     - __kind: PointerType
-      ID: 149
+      ID: 165
       Name: '**table<int,uint8>'
       ByteSize: 8
-      Pointee: 150 PointerType *table<int,uint8>
+      Pointee: 166 PointerType *table<int,uint8>
     - __kind: PointerType
-      ID: 123
+      ID: 139
       Name: '**table<string,[]main.structWithMap>'
       ByteSize: 8
-      Pointee: 124 PointerType *table<string,[]main.structWithMap>
+      Pointee: 140 PointerType *table<string,[]main.structWithMap>
     - __kind: PointerType
-      ID: 97
+      ID: 113
       Name: '**table<string,[]string>'
       ByteSize: 8
-      Pointee: 98 PointerType *table<string,[]string>
+      Pointee: 114 PointerType *table<string,[]string>
     - __kind: PointerType
-      ID: 86
+      ID: 102
       Name: '**table<string,int>'
       ByteSize: 8
-      Pointee: 87 PointerType *table<string,int>
+      Pointee: 103 PointerType *table<string,int>
     - __kind: PointerType
-      ID: 74
+      ID: 90
       Name: '**table<string,main.nestedStruct>'
       ByteSize: 8
-      Pointee: 75 PointerType *table<string,main.nestedStruct>
+      Pointee: 91 PointerType *table<string,main.nestedStruct>
     - __kind: PointerType
-      ID: 171
+      ID: 187
       Name: '**table<uint8,[4]int>'
       ByteSize: 8
-      Pointee: 172 PointerType *table<uint8,[4]int>
+      Pointee: 188 PointerType *table<uint8,[4]int>
     - __kind: PointerType
-      ID: 160
+      ID: 176
       Name: '**table<uint8,uint8>'
       ByteSize: 8
-      Pointee: 161 PointerType *table<uint8,uint8>
+      Pointee: 177 PointerType *table<uint8,uint8>
     - __kind: PointerType
       ID: 241
       Name: '*[]*string.array'
@@ -3197,10 +3197,10 @@ Types:
       ByteSize: 8
       Pointee: 250 GoSliceDataType []string.array
     - __kind: PointerType
-      ID: 212
+      ID: 226
       Name: '*[]uint'
       ByteSize: 8
-      Pointee: 210 GoSliceHeaderType []uint
+      Pointee: 224 GoSliceHeaderType []uint
     - __kind: PointerType
       ID: 273
       Name: '*[]uint.array'
@@ -3212,363 +3212,363 @@ Types:
       ByteSize: 8
       Pointee: 280 GoSliceDataType []uint16.array
     - __kind: PointerType
-      ID: 206
+      ID: 11
       Name: '*bool'
       ByteSize: 8
       GoRuntimeType: 386176
       GoKind: 22
-      Pointee: 11 BaseType bool
+      Pointee: 4 BaseType bool
     - __kind: PointerType
-      ID: 236
+      ID: 33
       Name: '*error'
       ByteSize: 8
       GoRuntimeType: 385088
       GoKind: 22
-      Pointee: 57 GoInterfaceType error
+      Pointee: 14 GoInterfaceType error
     - __kind: PointerType
-      ID: 237
+      ID: 35
       Name: '*float32'
       ByteSize: 8
       GoRuntimeType: 386048
       GoKind: 22
-      Pointee: 30 BaseType float32
+      Pointee: 17 BaseType float32
     - __kind: PointerType
-      ID: 230
+      ID: 26
       Name: '*float64'
       ByteSize: 8
       GoRuntimeType: 386112
       GoKind: 22
-      Pointee: 31 BaseType float64
+      Pointee: 18 BaseType float64
     - __kind: PointerType
-      ID: 232
+      ID: 28
       Name: '*int'
       ByteSize: 8
       GoRuntimeType: 385728
       GoKind: 22
-      Pointee: 1 BaseType int
+      Pointee: 7 BaseType int
     - __kind: PointerType
-      ID: 234
+      ID: 31
       Name: '*int16'
       ByteSize: 8
       GoRuntimeType: 385344
       GoKind: 22
-      Pointee: 16 BaseType int16
+      Pointee: 23 BaseType int16
     - __kind: PointerType
-      ID: 226
+      ID: 20
       Name: '*int32'
       ByteSize: 8
       GoRuntimeType: 385472
       GoKind: 22
-      Pointee: 6 BaseType int32
+      Pointee: 12 BaseType int32
     - __kind: PointerType
-      ID: 231
+      ID: 27
       Name: '*int64'
       ByteSize: 8
       GoRuntimeType: 385600
       GoKind: 22
-      Pointee: 18 BaseType int64
+      Pointee: 13 BaseType int64
     - __kind: PointerType
-      ID: 235
+      ID: 32
       Name: '*int8'
       ByteSize: 8
       GoRuntimeType: 385216
       GoKind: 22
-      Pointee: 14 BaseType int8
+      Pointee: 16 BaseType int8
     - __kind: PointerType
-      ID: 44
+      ID: 61
       Name: '*main.esotericHeap'
       ByteSize: 8
       GoRuntimeType: 380160
       GoKind: 22
-      Pointee: 45 StructureType main.esotericHeap
+      Pointee: 62 StructureType main.esotericHeap
     - __kind: PointerType
-      ID: 145
+      ID: 161
       Name: '*main.node'
       ByteSize: 8
       GoRuntimeType: 380224
       GoKind: 22
-      Pointee: 144 StructureType main.node
+      Pointee: 160 StructureType main.node
     - __kind: PointerType
-      ID: 221
+      ID: 234
       Name: '*main.oneStringStruct'
       ByteSize: 8
       GoKind: 22
-      Pointee: 222 StructureType main.oneStringStruct
+      Pointee: 235 StructureType main.oneStringStruct
     - __kind: PointerType
-      ID: 132
+      ID: 148
       Name: '*main.structWithMap'
       ByteSize: 8
       GoRuntimeType: 380096
       GoKind: 22
-      Pointee: 58 StructureType main.structWithMap
+      Pointee: 75 StructureType main.structWithMap
     - __kind: PointerType
-      ID: 214
+      ID: 228
       Name: '*main.structWithNoStrings'
       ByteSize: 8
-      Pointee: 215 StructureType main.structWithNoStrings
+      Pointee: 229 StructureType main.structWithNoStrings
     - __kind: PointerType
-      ID: 203
+      ID: 219
       Name: '*main.structWithTwoValues'
       ByteSize: 8
       GoKind: 22
-      Pointee: 204 StructureType main.structWithTwoValues
+      Pointee: 220 StructureType main.structWithTwoValues
     - __kind: PointerType
-      ID: 207
+      ID: 221
       Name: '*main.t'
       ByteSize: 8
       GoKind: 22
-      Pointee: 208 GoSliceHeaderType main.t
+      Pointee: 222 GoSliceHeaderType main.t
     - __kind: PointerType
       ID: 271
       Name: '*main.t.array'
       ByteSize: 8
       Pointee: 270 GoSliceDataType main.t.array
     - __kind: PointerType
-      ID: 220
+      ID: 233
       Name: '*main.threeStringStruct'
       ByteSize: 8
       GoKind: 22
-      Pointee: 219 StructureType main.threeStringStruct
+      Pointee: 232 StructureType main.threeStringStruct
     - __kind: PointerType
-      ID: 192
+      ID: 208
       Name: '*map<[4]int,[4]int>'
       ByteSize: 8
-      Pointee: 193 GoSwissMapHeaderType map<[4]int,[4]int>
+      Pointee: 209 GoSwissMapHeaderType map<[4]int,[4]int>
     - __kind: PointerType
-      ID: 181
+      ID: 197
       Name: '*map<[4]int,uint8>'
       ByteSize: 8
-      Pointee: 182 GoSwissMapHeaderType map<[4]int,uint8>
+      Pointee: 198 GoSwissMapHeaderType map<[4]int,uint8>
     - __kind: PointerType
-      ID: 107
+      ID: 123
       Name: '*map<[4]string,[2]int>'
       ByteSize: 8
-      Pointee: 108 GoSwissMapHeaderType map<[4]string,[2]int>
+      Pointee: 124 GoSwissMapHeaderType map<[4]string,[2]int>
     - __kind: PointerType
-      ID: 134
+      ID: 150
       Name: '*map<bool,main.node>'
       ByteSize: 8
-      Pointee: 135 GoSwissMapHeaderType map<bool,main.node>
+      Pointee: 151 GoSwissMapHeaderType map<bool,main.node>
     - __kind: PointerType
-      ID: 60
+      ID: 77
       Name: '*map<int,int>'
       ByteSize: 8
-      Pointee: 61 GoSwissMapHeaderType map<int,int>
+      Pointee: 78 GoSwissMapHeaderType map<int,int>
     - __kind: PointerType
-      ID: 147
+      ID: 163
       Name: '*map<int,uint8>'
       ByteSize: 8
-      Pointee: 148 GoSwissMapHeaderType map<int,uint8>
+      Pointee: 164 GoSwissMapHeaderType map<int,uint8>
     - __kind: PointerType
-      ID: 121
+      ID: 137
       Name: '*map<string,[]main.structWithMap>'
       ByteSize: 8
-      Pointee: 122 GoSwissMapHeaderType map<string,[]main.structWithMap>
+      Pointee: 138 GoSwissMapHeaderType map<string,[]main.structWithMap>
     - __kind: PointerType
-      ID: 95
+      ID: 111
       Name: '*map<string,[]string>'
       ByteSize: 8
-      Pointee: 96 GoSwissMapHeaderType map<string,[]string>
+      Pointee: 112 GoSwissMapHeaderType map<string,[]string>
     - __kind: PointerType
-      ID: 84
+      ID: 100
       Name: '*map<string,int>'
       ByteSize: 8
-      Pointee: 85 GoSwissMapHeaderType map<string,int>
+      Pointee: 101 GoSwissMapHeaderType map<string,int>
     - __kind: PointerType
-      ID: 72
+      ID: 88
       Name: '*map<string,main.nestedStruct>'
       ByteSize: 8
-      Pointee: 73 GoSwissMapHeaderType map<string,main.nestedStruct>
+      Pointee: 89 GoSwissMapHeaderType map<string,main.nestedStruct>
     - __kind: PointerType
-      ID: 169
+      ID: 185
       Name: '*map<uint8,[4]int>'
       ByteSize: 8
-      Pointee: 170 GoSwissMapHeaderType map<uint8,[4]int>
+      Pointee: 186 GoSwissMapHeaderType map<uint8,[4]int>
     - __kind: PointerType
-      ID: 158
+      ID: 174
       Name: '*map<uint8,uint8>'
       ByteSize: 8
-      Pointee: 159 GoSwissMapHeaderType map<uint8,uint8>
+      Pointee: 175 GoSwissMapHeaderType map<uint8,uint8>
     - __kind: PointerType
-      ID: 119
+      ID: 135
       Name: '*map[string]int'
       ByteSize: 8
       GoKind: 22
-      Pointee: 83 GoMapType map[string]int
+      Pointee: 99 GoMapType map[string]int
     - __kind: PointerType
-      ID: 198
+      ID: 214
       Name: '*noalg.map.group[[4]int][4]int'
       ByteSize: 8
-      Pointee: 199 StructureType noalg.map.group[[4]int][4]int
+      Pointee: 215 StructureType noalg.map.group[[4]int][4]int
     - __kind: PointerType
-      ID: 187
+      ID: 203
       Name: '*noalg.map.group[[4]int]uint8'
       ByteSize: 8
-      Pointee: 188 StructureType noalg.map.group[[4]int]uint8
+      Pointee: 204 StructureType noalg.map.group[[4]int]uint8
     - __kind: PointerType
-      ID: 113
+      ID: 129
       Name: '*noalg.map.group[[4]string][2]int'
       ByteSize: 8
-      Pointee: 114 StructureType noalg.map.group[[4]string][2]int
+      Pointee: 130 StructureType noalg.map.group[[4]string][2]int
     - __kind: PointerType
-      ID: 140
+      ID: 156
       Name: '*noalg.map.group[bool]main.node'
       ByteSize: 8
-      Pointee: 141 StructureType noalg.map.group[bool]main.node
+      Pointee: 157 StructureType noalg.map.group[bool]main.node
     - __kind: PointerType
-      ID: 67
+      ID: 83
       Name: '*noalg.map.group[int]int'
       ByteSize: 8
-      Pointee: 68 StructureType noalg.map.group[int]int
+      Pointee: 84 StructureType noalg.map.group[int]int
     - __kind: PointerType
-      ID: 153
+      ID: 169
       Name: '*noalg.map.group[int]uint8'
       ByteSize: 8
-      Pointee: 154 StructureType noalg.map.group[int]uint8
+      Pointee: 170 StructureType noalg.map.group[int]uint8
     - __kind: PointerType
-      ID: 127
+      ID: 143
       Name: '*noalg.map.group[string][]main.structWithMap'
       ByteSize: 8
-      Pointee: 128 StructureType noalg.map.group[string][]main.structWithMap
+      Pointee: 144 StructureType noalg.map.group[string][]main.structWithMap
     - __kind: PointerType
-      ID: 101
+      ID: 117
       Name: '*noalg.map.group[string][]string'
       ByteSize: 8
-      Pointee: 102 StructureType noalg.map.group[string][]string
+      Pointee: 118 StructureType noalg.map.group[string][]string
     - __kind: PointerType
-      ID: 90
+      ID: 106
       Name: '*noalg.map.group[string]int'
       ByteSize: 8
-      Pointee: 91 StructureType noalg.map.group[string]int
+      Pointee: 107 StructureType noalg.map.group[string]int
     - __kind: PointerType
-      ID: 78
+      ID: 94
       Name: '*noalg.map.group[string]main.nestedStruct'
       ByteSize: 8
-      Pointee: 79 StructureType noalg.map.group[string]main.nestedStruct
+      Pointee: 95 StructureType noalg.map.group[string]main.nestedStruct
     - __kind: PointerType
-      ID: 175
+      ID: 191
       Name: '*noalg.map.group[uint8][4]int'
       ByteSize: 8
-      Pointee: 176 StructureType noalg.map.group[uint8][4]int
+      Pointee: 192 StructureType noalg.map.group[uint8][4]int
     - __kind: PointerType
-      ID: 164
+      ID: 180
       Name: '*noalg.map.group[uint8]uint8'
       ByteSize: 8
-      Pointee: 165 StructureType noalg.map.group[uint8]uint8
+      Pointee: 181 StructureType noalg.map.group[uint8]uint8
     - __kind: PointerType
-      ID: 36
+      ID: 22
       Name: '*string'
       ByteSize: 8
       GoRuntimeType: 385152
       GoKind: 22
-      Pointee: 8 GoStringHeaderType string
+      Pointee: 9 GoStringHeaderType string
     - __kind: PointerType
       ID: 239
       Name: '*string.str'
       ByteSize: 8
       Pointee: 238 GoStringDataType string.str
     - __kind: PointerType
-      ID: 195
+      ID: 211
       Name: '*table<[4]int,[4]int>'
       ByteSize: 8
-      Pointee: 196 StructureType table<[4]int,[4]int>
+      Pointee: 212 StructureType table<[4]int,[4]int>
     - __kind: PointerType
-      ID: 184
+      ID: 200
       Name: '*table<[4]int,uint8>'
       ByteSize: 8
-      Pointee: 185 StructureType table<[4]int,uint8>
+      Pointee: 201 StructureType table<[4]int,uint8>
     - __kind: PointerType
-      ID: 110
+      ID: 126
       Name: '*table<[4]string,[2]int>'
       ByteSize: 8
-      Pointee: 111 StructureType table<[4]string,[2]int>
+      Pointee: 127 StructureType table<[4]string,[2]int>
     - __kind: PointerType
-      ID: 137
+      ID: 153
       Name: '*table<bool,main.node>'
       ByteSize: 8
-      Pointee: 138 StructureType table<bool,main.node>
+      Pointee: 154 StructureType table<bool,main.node>
     - __kind: PointerType
-      ID: 64
+      ID: 80
       Name: '*table<int,int>'
       ByteSize: 8
-      Pointee: 65 StructureType table<int,int>
+      Pointee: 81 StructureType table<int,int>
     - __kind: PointerType
-      ID: 150
+      ID: 166
       Name: '*table<int,uint8>'
       ByteSize: 8
-      Pointee: 151 StructureType table<int,uint8>
+      Pointee: 167 StructureType table<int,uint8>
     - __kind: PointerType
-      ID: 124
+      ID: 140
       Name: '*table<string,[]main.structWithMap>'
       ByteSize: 8
-      Pointee: 125 StructureType table<string,[]main.structWithMap>
+      Pointee: 141 StructureType table<string,[]main.structWithMap>
     - __kind: PointerType
-      ID: 98
+      ID: 114
       Name: '*table<string,[]string>'
       ByteSize: 8
-      Pointee: 99 StructureType table<string,[]string>
+      Pointee: 115 StructureType table<string,[]string>
     - __kind: PointerType
-      ID: 87
+      ID: 103
       Name: '*table<string,int>'
       ByteSize: 8
-      Pointee: 88 StructureType table<string,int>
+      Pointee: 104 StructureType table<string,int>
     - __kind: PointerType
-      ID: 75
+      ID: 91
       Name: '*table<string,main.nestedStruct>'
       ByteSize: 8
-      Pointee: 76 StructureType table<string,main.nestedStruct>
+      Pointee: 92 StructureType table<string,main.nestedStruct>
     - __kind: PointerType
-      ID: 172
+      ID: 188
       Name: '*table<uint8,[4]int>'
       ByteSize: 8
-      Pointee: 173 StructureType table<uint8,[4]int>
+      Pointee: 189 StructureType table<uint8,[4]int>
     - __kind: PointerType
-      ID: 161
+      ID: 177
       Name: '*table<uint8,uint8>'
       ByteSize: 8
-      Pointee: 162 StructureType table<uint8,uint8>
+      Pointee: 178 StructureType table<uint8,uint8>
     - __kind: PointerType
-      ID: 205
+      ID: 34
       Name: '*uint'
       ByteSize: 8
       GoRuntimeType: 385792
       GoKind: 22
-      Pointee: 20 BaseType uint
+      Pointee: 10 BaseType uint
     - __kind: PointerType
-      ID: 218
+      ID: 30
       Name: '*uint16'
       ByteSize: 8
       GoRuntimeType: 385408
       GoKind: 22
-      Pointee: 22 BaseType uint16
+      Pointee: 6 BaseType uint16
     - __kind: PointerType
-      ID: 227
+      ID: 21
       Name: '*uint32'
       ByteSize: 8
       GoRuntimeType: 385536
       GoKind: 22
-      Pointee: 24 BaseType uint32
+      Pointee: 2 BaseType uint32
     - __kind: PointerType
-      ID: 233
+      ID: 29
       Name: '*uint64'
       ByteSize: 8
       GoRuntimeType: 385664
       GoKind: 22
-      Pointee: 26 BaseType uint64
+      Pointee: 8 BaseType uint64
     - __kind: PointerType
-      ID: 9
+      ID: 5
       Name: '*uint8'
       ByteSize: 8
       GoRuntimeType: 385280
       GoKind: 22
-      Pointee: 4 BaseType uint8
+      Pointee: 3 BaseType uint8
     - __kind: PointerType
-      ID: 225
+      ID: 19
       Name: '*uintptr'
       ByteSize: 8
       GoRuntimeType: 385856
       GoKind: 22
-      Pointee: 62 BaseType uintptr
+      Pointee: 1 BaseType uintptr
     - __kind: EventRootType
       ID: 369
       Name: Probe[main.stackC]
@@ -3581,10 +3581,10 @@ Types:
         - Name: a
           Offset: 1
           Expression:
-            Type: 41 GoEmptyInterfaceType interface {}
+            Type: 58 GoEmptyInterfaceType interface {}
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 51, index: 0, name: a}
+                  Variable: {subprogram: 45, index: 0, name: a}
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
@@ -3596,10 +3596,10 @@ Types:
         - Name: b
           Offset: 1
           Expression:
-            Type: 28 ArrayType [2][2][2]int
+            Type: 49 ArrayType [2][2][2]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 23, index: 0, name: b}
+                  Variable: {subprogram: 17, index: 0, name: b}
                   Offset: 0
                   ByteSize: 64
     - __kind: EventRootType
@@ -3611,10 +3611,10 @@ Types:
         - Name: a
           Offset: 1
           Expression:
-            Type: 27 ArrayType [2][2]int
+            Type: 48 ArrayType [2][2]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 21, index: 0, name: a}
+                  Variable: {subprogram: 15, index: 0, name: a}
                   Offset: 0
                   ByteSize: 32
     - __kind: EventRootType
@@ -3626,10 +3626,10 @@ Types:
         - Name: m
           Offset: 1
           Expression:
-            Type: 118 ArrayType [2]map[string]int
+            Type: 134 ArrayType [2]map[string]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 59, index: 0, name: m}
+                  Variable: {subprogram: 53, index: 0, name: m}
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
@@ -3641,10 +3641,10 @@ Types:
         - Name: a
           Offset: 1
           Expression:
-            Type: 7 ArrayType [2]string
+            Type: 38 ArrayType [2]string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 22, index: 0, name: a}
+                  Variable: {subprogram: 16, index: 0, name: a}
                   Offset: 0
                   ByteSize: 32
     - __kind: EventRootType
@@ -3656,10 +3656,10 @@ Types:
         - Name: b
           Offset: 1
           Expression:
-            Type: 33 StructureType main.bigStruct
+            Type: 52 StructureType main.bigStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 41, index: 0, name: b}
+                  Variable: {subprogram: 35, index: 0, name: b}
                   Offset: 0
                   ByteSize: 48
     - __kind: EventRootType
@@ -3671,10 +3671,10 @@ Types:
         - Name: x
           Offset: 1
           Expression:
-            Type: 10 ArrayType [2]bool
+            Type: 39 ArrayType [2]bool
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 10, index: 0, name: x}
+                  Variable: {subprogram: 4, index: 0, name: x}
                   Offset: 0
                   ByteSize: 2
     - __kind: EventRootType
@@ -3686,10 +3686,10 @@ Types:
         - Name: x
           Offset: 1
           Expression:
-            Type: 3 ArrayType [2]uint8
+            Type: 36 ArrayType [2]uint8
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 7, index: 0, name: x}
+                  Variable: {subprogram: 1, index: 0, name: x}
                   Offset: 0
                   ByteSize: 2
     - __kind: EventRootType
@@ -3701,10 +3701,10 @@ Types:
         - Name: c
           Offset: 1
           Expression:
-            Type: 202 GoChannelType chan bool
+            Type: 218 GoChannelType chan bool
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 75, index: 0, name: c}
+                  Variable: {subprogram: 69, index: 0, name: c}
                   Offset: 0
                   ByteSize: 0
     - __kind: EventRootType
@@ -3716,28 +3716,28 @@ Types:
         - Name: w
           Offset: 1
           Expression:
-            Type: 4 BaseType uint8
+            Type: 3 BaseType uint8
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 73, index: 0, name: w}
+                  Variable: {subprogram: 67, index: 0, name: w}
                   Offset: 0
                   ByteSize: 1
         - Name: x
           Offset: 2
           Expression:
-            Type: 4 BaseType uint8
+            Type: 3 BaseType uint8
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 73, index: 1, name: x}
+                  Variable: {subprogram: 67, index: 1, name: x}
                   Offset: 0
                   ByteSize: 1
         - Name: y
           Offset: 3
           Expression:
-            Type: 30 BaseType float32
+            Type: 17 BaseType float32
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 73, index: 2, name: y}
+                  Variable: {subprogram: 67, index: 2, name: y}
                   Offset: 0
                   ByteSize: 4
     - __kind: EventRootType
@@ -3749,10 +3749,10 @@ Types:
         - Name: t
           Offset: 1
           Expression:
-            Type: 207 PointerType *main.t
+            Type: 221 PointerType *main.t
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 83, index: 0, name: t}
+                  Variable: {subprogram: 77, index: 0, name: t}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
@@ -3764,19 +3764,19 @@ Types:
         - Name: xs
           Offset: 1
           Expression:
-            Type: 213 GoSliceHeaderType []main.structWithNoStrings
+            Type: 227 GoSliceHeaderType []main.structWithNoStrings
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 88, index: 0, name: xs}
+                  Variable: {subprogram: 82, index: 0, name: xs}
                   Offset: 0
                   ByteSize: 24
         - Name: a
           Offset: 25
           Expression:
-            Type: 1 BaseType int
+            Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 88, index: 1, name: a}
+                  Variable: {subprogram: 82, index: 1, name: a}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
@@ -3788,10 +3788,10 @@ Types:
         - Name: u
           Offset: 1
           Expression:
-            Type: 210 GoSliceHeaderType []uint
+            Type: 224 GoSliceHeaderType []uint
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 85, index: 0, name: u}
+                  Variable: {subprogram: 79, index: 0, name: u}
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
@@ -3803,10 +3803,10 @@ Types:
         - Name: x
           Offset: 1
           Expression:
-            Type: 8 GoStringHeaderType string
+            Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 102, index: 0, name: x}
+                  Variable: {subprogram: 96, index: 0, name: x}
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
@@ -3818,10 +3818,10 @@ Types:
         - Name: e
           Offset: 1
           Expression:
-            Type: 224 StructureType main.emptyStruct
+            Type: 237 StructureType main.emptyStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 104, index: 0, name: e}
+                  Variable: {subprogram: 98, index: 0, name: e}
                   Offset: 0
                   ByteSize: 0
     - __kind: EventRootType
@@ -3833,10 +3833,10 @@ Types:
         - Name: e
           Offset: 1
           Expression:
-            Type: 57 GoInterfaceType error
+            Type: 14 GoInterfaceType error
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 52, index: 0, name: e}
+                  Variable: {subprogram: 46, index: 0, name: e}
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
@@ -3848,10 +3848,10 @@ Types:
         - Name: e
           Offset: 1
           Expression:
-            Type: 44 PointerType *main.esotericHeap
+            Type: 61 PointerType *main.esotericHeap
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 43, index: 0, name: e}
+                  Variable: {subprogram: 37, index: 0, name: e}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
@@ -3863,10 +3863,10 @@ Types:
         - Name: e
           Offset: 1
           Expression:
-            Type: 39 StructureType main.esotericStack
+            Type: 56 StructureType main.esotericStack
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 42, index: 0, name: e}
+                  Variable: {subprogram: 36, index: 0, name: e}
                   Offset: 0
                   ByteSize: 64
     - __kind: EventRootType
@@ -3878,10 +3878,10 @@ Types:
         - Name: a
           Offset: 1
           Expression:
-            Type: 2 ArrayType [5]int
+            Type: 73 ArrayType [5]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 49, index: 0, name: a}
+                  Variable: {subprogram: 43, index: 0, name: a}
                   Offset: 0
                   ByteSize: 40
     - __kind: EventRootType
@@ -3893,10 +3893,10 @@ Types:
         - Name: x
           Offset: 1
           Expression:
-            Type: 1 BaseType int
+            Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 48, index: 0, name: x}
+                  Variable: {subprogram: 42, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
@@ -3908,10 +3908,10 @@ Types:
         - Name: x
           Offset: 1
           Expression:
-            Type: 1 BaseType int
+            Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 44, index: 0, name: x}
+                  Variable: {subprogram: 38, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
@@ -3923,10 +3923,10 @@ Types:
         - Name: x
           Offset: 1
           Expression:
-            Type: 1 BaseType int
+            Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 46, index: 0, name: x}
+                  Variable: {subprogram: 40, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
@@ -3941,19 +3941,19 @@ Types:
         - Name: x
           Offset: 1
           Expression:
-            Type: 1 BaseType int
+            Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 45, index: 0, name: x}
+                  Variable: {subprogram: 39, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
         - Name: y
           Offset: 9
           Expression:
-            Type: 1 BaseType int
+            Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 45, index: 1, name: y}
+                  Variable: {subprogram: 39, index: 1, name: y}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
@@ -3974,10 +3974,10 @@ Types:
         - Name: x
           Offset: 1
           Expression:
-            Type: 1 BaseType int
+            Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 1, index: 0, name: x}
+                  Variable: {subprogram: 99, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
@@ -3989,10 +3989,10 @@ Types:
         - Name: x
           Offset: 1
           Expression:
-            Type: 1 BaseType int
+            Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 5, index: 0, name: x}
+                  Variable: {subprogram: 103, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
@@ -4004,10 +4004,10 @@ Types:
         - Name: a
           Offset: 1
           Expression:
-            Type: 2 ArrayType [5]int
+            Type: 73 ArrayType [5]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 6, index: 0, name: a}
+                  Variable: {subprogram: 104, index: 0, name: a}
                   Offset: 0
                   ByteSize: 40
     - __kind: EventRootType
@@ -4019,10 +4019,10 @@ Types:
         - Name: x
           Offset: 1
           Expression:
-            Type: 15 ArrayType [2]int16
+            Type: 42 ArrayType [2]int16
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 13, index: 0, name: x}
+                  Variable: {subprogram: 7, index: 0, name: x}
                   Offset: 0
                   ByteSize: 4
     - __kind: EventRootType
@@ -4034,10 +4034,10 @@ Types:
         - Name: x
           Offset: 1
           Expression:
-            Type: 5 ArrayType [2]int32
+            Type: 37 ArrayType [2]int32
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 14, index: 0, name: x}
+                  Variable: {subprogram: 8, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
@@ -4049,10 +4049,10 @@ Types:
         - Name: x
           Offset: 1
           Expression:
-            Type: 17 ArrayType [2]int64
+            Type: 43 ArrayType [2]int64
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 15, index: 0, name: x}
+                  Variable: {subprogram: 9, index: 0, name: x}
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
@@ -4064,10 +4064,10 @@ Types:
         - Name: x
           Offset: 1
           Expression:
-            Type: 13 ArrayType [2]int8
+            Type: 41 ArrayType [2]int8
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 12, index: 0, name: x}
+                  Variable: {subprogram: 6, index: 0, name: x}
                   Offset: 0
                   ByteSize: 2
     - __kind: EventRootType
@@ -4079,10 +4079,10 @@ Types:
         - Name: x
           Offset: 1
           Expression:
-            Type: 12 ArrayType [2]int
+            Type: 40 ArrayType [2]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 11, index: 0, name: x}
+                  Variable: {subprogram: 5, index: 0, name: x}
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
@@ -4094,10 +4094,10 @@ Types:
         - Name: b
           Offset: 1
           Expression:
-            Type: 56 GoInterfaceType main.behavior
+            Type: 74 GoInterfaceType main.behavior
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 50, index: 0, name: b}
+                  Variable: {subprogram: 44, index: 0, name: b}
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
@@ -4109,10 +4109,10 @@ Types:
         - Name: a
           Offset: 1
           Expression:
-            Type: 144 StructureType main.node
+            Type: 160 StructureType main.node
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 77, index: 0, name: a}
+                  Variable: {subprogram: 71, index: 0, name: a}
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
@@ -4124,10 +4124,10 @@ Types:
         - Name: m
           Offset: 1
           Expression:
-            Type: 106 GoMapType map[[4]string][2]int
+            Type: 122 GoMapType map[[4]string][2]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 57, index: 0, name: m}
+                  Variable: {subprogram: 51, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
@@ -4139,10 +4139,10 @@ Types:
         - Name: m
           Offset: 1
           Expression:
-            Type: 120 GoMapType map[string][]main.structWithMap
+            Type: 136 GoMapType map[string][]main.structWithMap
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 63, index: 0, name: m}
+                  Variable: {subprogram: 57, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
@@ -4154,10 +4154,10 @@ Types:
         - Name: m
           Offset: 1
           Expression:
-            Type: 59 GoMapType map[int]int
+            Type: 76 GoMapType map[int]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 61, index: 0, name: m}
+                  Variable: {subprogram: 55, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
@@ -4169,10 +4169,10 @@ Types:
         - Name: m
           Offset: 1
           Expression:
-            Type: 191 GoMapType map[[4]int][4]int
+            Type: 207 GoMapType map[[4]int][4]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 72, index: 0, name: m}
+                  Variable: {subprogram: 66, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
@@ -4184,10 +4184,10 @@ Types:
         - Name: m
           Offset: 1
           Expression:
-            Type: 180 GoMapType map[[4]int]uint8
+            Type: 196 GoMapType map[[4]int]uint8
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 71, index: 0, name: m}
+                  Variable: {subprogram: 65, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
@@ -4199,10 +4199,10 @@ Types:
         - Name: redactMyEntries
           Offset: 1
           Expression:
-            Type: 120 GoMapType map[string][]main.structWithMap
+            Type: 136 GoMapType map[string][]main.structWithMap
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 62, index: 0, name: redactMyEntries}
+                  Variable: {subprogram: 56, index: 0, name: redactMyEntries}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
@@ -4214,10 +4214,10 @@ Types:
         - Name: m
           Offset: 1
           Expression:
-            Type: 168 GoMapType map[uint8][4]int
+            Type: 184 GoMapType map[uint8][4]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 70, index: 0, name: m}
+                  Variable: {subprogram: 64, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
@@ -4229,10 +4229,10 @@ Types:
         - Name: m
           Offset: 1
           Expression:
-            Type: 157 GoMapType map[uint8]uint8
+            Type: 173 GoMapType map[uint8]uint8
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 69, index: 0, name: m}
+                  Variable: {subprogram: 63, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
@@ -4244,10 +4244,10 @@ Types:
         - Name: m
           Offset: 1
           Expression:
-            Type: 83 GoMapType map[string]int
+            Type: 99 GoMapType map[string]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 55, index: 0, name: m}
+                  Variable: {subprogram: 49, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
@@ -4259,10 +4259,10 @@ Types:
         - Name: m
           Offset: 1
           Expression:
-            Type: 94 GoMapType map[string][]string
+            Type: 110 GoMapType map[string][]string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 56, index: 0, name: m}
+                  Variable: {subprogram: 50, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
@@ -4274,10 +4274,10 @@ Types:
         - Name: m
           Offset: 1
           Expression:
-            Type: 71 GoMapType map[string]main.nestedStruct
+            Type: 87 GoMapType map[string]main.nestedStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 54, index: 0, name: m}
+                  Variable: {subprogram: 48, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
@@ -4289,10 +4289,10 @@ Types:
         - Name: m
           Offset: 1
           Expression:
-            Type: 133 GoMapType map[bool]main.node
+            Type: 149 GoMapType map[bool]main.node
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 64, index: 0, name: m}
+                  Variable: {subprogram: 58, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
@@ -4304,10 +4304,10 @@ Types:
         - Name: m
           Offset: 1
           Expression:
-            Type: 157 GoMapType map[uint8]uint8
+            Type: 173 GoMapType map[uint8]uint8
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 68, index: 0, name: m}
+                  Variable: {subprogram: 62, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
@@ -4319,10 +4319,10 @@ Types:
         - Name: m
           Offset: 1
           Expression:
-            Type: 157 GoMapType map[uint8]uint8
+            Type: 173 GoMapType map[uint8]uint8
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 67, index: 0, name: m}
+                  Variable: {subprogram: 61, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
@@ -4334,10 +4334,10 @@ Types:
         - Name: redactMyEntries
           Offset: 1
           Expression:
-            Type: 146 GoMapType map[int]uint8
+            Type: 162 GoMapType map[int]uint8
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 66, index: 0, name: redactMyEntries}
+                  Variable: {subprogram: 60, index: 0, name: redactMyEntries}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
@@ -4349,10 +4349,10 @@ Types:
         - Name: m
           Offset: 1
           Expression:
-            Type: 146 GoMapType map[int]uint8
+            Type: 162 GoMapType map[int]uint8
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 65, index: 0, name: m}
+                  Variable: {subprogram: 59, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
@@ -4364,10 +4364,10 @@ Types:
         - Name: x
           Offset: 1
           Expression:
-            Type: 8 GoStringHeaderType string
+            Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 100, index: 0, name: x}
+                  Variable: {subprogram: 94, index: 0, name: x}
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
@@ -4379,46 +4379,46 @@ Types:
         - Name: a
           Offset: 1
           Expression:
-            Type: 11 BaseType bool
+            Type: 4 BaseType bool
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 74, index: 0, name: a}
+                  Variable: {subprogram: 68, index: 0, name: a}
                   Offset: 0
                   ByteSize: 1
         - Name: b
           Offset: 2
           Expression:
-            Type: 4 BaseType uint8
+            Type: 3 BaseType uint8
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 74, index: 1, name: b}
+                  Variable: {subprogram: 68, index: 1, name: b}
                   Offset: 0
                   ByteSize: 1
         - Name: c
           Offset: 3
           Expression:
-            Type: 6 BaseType int32
+            Type: 12 BaseType int32
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 74, index: 2, name: c}
+                  Variable: {subprogram: 68, index: 2, name: c}
                   Offset: 0
                   ByteSize: 4
         - Name: d
           Offset: 7
           Expression:
-            Type: 20 BaseType uint
+            Type: 10 BaseType uint
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 74, index: 3, name: d}
+                  Variable: {subprogram: 68, index: 3, name: d}
                   Offset: 0
                   ByteSize: 8
         - Name: e
           Offset: 15
           Expression:
-            Type: 8 GoStringHeaderType string
+            Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 74, index: 4, name: e}
+                  Variable: {subprogram: 68, index: 4, name: e}
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
@@ -4430,19 +4430,19 @@ Types:
         - Name: z
           Offset: 1
           Expression:
-            Type: 206 PointerType *bool
+            Type: 11 PointerType *bool
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 82, index: 0, name: z}
+                  Variable: {subprogram: 76, index: 0, name: z}
                   Offset: 0
                   ByteSize: 8
         - Name: a
           Offset: 9
           Expression:
-            Type: 20 BaseType uint
+            Type: 10 BaseType uint
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 82, index: 1, name: a}
+                  Variable: {subprogram: 76, index: 1, name: a}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
@@ -4454,19 +4454,19 @@ Types:
         - Name: xs
           Offset: 1
           Expression:
-            Type: 213 GoSliceHeaderType []main.structWithNoStrings
+            Type: 227 GoSliceHeaderType []main.structWithNoStrings
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 89, index: 0, name: xs}
+                  Variable: {subprogram: 83, index: 0, name: xs}
                   Offset: 0
                   ByteSize: 24
         - Name: a
           Offset: 25
           Expression:
-            Type: 1 BaseType int
+            Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 89, index: 1, name: a}
+                  Variable: {subprogram: 83, index: 1, name: a}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
@@ -4478,28 +4478,28 @@ Types:
         - Name: a
           Offset: 1
           Expression:
-            Type: 14 BaseType int8
+            Type: 16 BaseType int8
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 91, index: 0, name: a}
+                  Variable: {subprogram: 85, index: 0, name: a}
                   Offset: 0
                   ByteSize: 1
         - Name: s
           Offset: 2
           Expression:
-            Type: 216 GoSliceHeaderType []bool
+            Type: 230 GoSliceHeaderType []bool
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 91, index: 1, name: s}
+                  Variable: {subprogram: 85, index: 1, name: s}
                   Offset: 0
                   ByteSize: 24
         - Name: x
           Offset: 26
           Expression:
-            Type: 20 BaseType uint
+            Type: 10 BaseType uint
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 91, index: 2, name: x}
+                  Variable: {subprogram: 85, index: 2, name: x}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
@@ -4511,10 +4511,10 @@ Types:
         - Name: xs
           Offset: 1
           Expression:
-            Type: 217 GoSliceHeaderType []uint16
+            Type: 231 GoSliceHeaderType []uint16
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 92, index: 0, name: xs}
+                  Variable: {subprogram: 86, index: 0, name: xs}
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
@@ -4526,10 +4526,10 @@ Types:
         - Name: a
           Offset: 1
           Expression:
-            Type: 221 PointerType *main.oneStringStruct
+            Type: 234 PointerType *main.oneStringStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 99, index: 0, name: a}
+                  Variable: {subprogram: 93, index: 0, name: a}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
@@ -4541,10 +4541,10 @@ Types:
         - Name: a
           Offset: 1
           Expression:
-            Type: 145 PointerType *main.node
+            Type: 161 PointerType *main.node
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 78, index: 0, name: a}
+                  Variable: {subprogram: 72, index: 0, name: a}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
@@ -4556,10 +4556,10 @@ Types:
         - Name: m
           Offset: 1
           Expression:
-            Type: 119 PointerType *map[string]int
+            Type: 135 PointerType *map[string]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 60, index: 0, name: m}
+                  Variable: {subprogram: 54, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
@@ -4571,10 +4571,10 @@ Types:
         - Name: a
           Offset: 1
           Expression:
-            Type: 203 PointerType *main.structWithTwoValues
+            Type: 219 PointerType *main.structWithTwoValues
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 76, index: 0, name: a}
+                  Variable: {subprogram: 70, index: 0, name: a}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
@@ -4586,10 +4586,10 @@ Types:
         - Name: x
           Offset: 1
           Expression:
-            Type: 5 ArrayType [2]int32
+            Type: 37 ArrayType [2]int32
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 8, index: 0, name: x}
+                  Variable: {subprogram: 2, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
@@ -4601,10 +4601,10 @@ Types:
         - Name: x
           Offset: 1
           Expression:
-            Type: 11 BaseType bool
+            Type: 4 BaseType bool
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 27, index: 0, name: x}
+                  Variable: {subprogram: 21, index: 0, name: x}
                   Offset: 0
                   ByteSize: 1
     - __kind: EventRootType
@@ -4616,10 +4616,10 @@ Types:
         - Name: x
           Offset: 1
           Expression:
-            Type: 4 BaseType uint8
+            Type: 3 BaseType uint8
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 25, index: 0, name: x}
+                  Variable: {subprogram: 19, index: 0, name: x}
                   Offset: 0
                   ByteSize: 1
     - __kind: EventRootType
@@ -4631,10 +4631,10 @@ Types:
         - Name: x
           Offset: 1
           Expression:
-            Type: 30 BaseType float32
+            Type: 17 BaseType float32
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 38, index: 0, name: x}
+                  Variable: {subprogram: 32, index: 0, name: x}
                   Offset: 0
                   ByteSize: 4
     - __kind: EventRootType
@@ -4646,10 +4646,10 @@ Types:
         - Name: x
           Offset: 1
           Expression:
-            Type: 31 BaseType float64
+            Type: 18 BaseType float64
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 39, index: 0, name: x}
+                  Variable: {subprogram: 33, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
@@ -4661,10 +4661,10 @@ Types:
         - Name: x
           Offset: 1
           Expression:
-            Type: 16 BaseType int16
+            Type: 23 BaseType int16
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 30, index: 0, name: x}
+                  Variable: {subprogram: 24, index: 0, name: x}
                   Offset: 0
                   ByteSize: 2
     - __kind: EventRootType
@@ -4676,10 +4676,10 @@ Types:
         - Name: x
           Offset: 1
           Expression:
-            Type: 6 BaseType int32
+            Type: 12 BaseType int32
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 31, index: 0, name: x}
+                  Variable: {subprogram: 25, index: 0, name: x}
                   Offset: 0
                   ByteSize: 4
     - __kind: EventRootType
@@ -4691,10 +4691,10 @@ Types:
         - Name: x
           Offset: 1
           Expression:
-            Type: 18 BaseType int64
+            Type: 13 BaseType int64
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 32, index: 0, name: x}
+                  Variable: {subprogram: 26, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
@@ -4706,10 +4706,10 @@ Types:
         - Name: x
           Offset: 1
           Expression:
-            Type: 14 BaseType int8
+            Type: 16 BaseType int8
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 29, index: 0, name: x}
+                  Variable: {subprogram: 23, index: 0, name: x}
                   Offset: 0
                   ByteSize: 1
     - __kind: EventRootType
@@ -4721,10 +4721,10 @@ Types:
         - Name: x
           Offset: 1
           Expression:
-            Type: 1 BaseType int
+            Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 28, index: 0, name: x}
+                  Variable: {subprogram: 22, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
@@ -4736,10 +4736,10 @@ Types:
         - Name: x
           Offset: 1
           Expression:
-            Type: 6 BaseType int32
+            Type: 12 BaseType int32
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 26, index: 0, name: x}
+                  Variable: {subprogram: 20, index: 0, name: x}
                   Offset: 0
                   ByteSize: 4
     - __kind: EventRootType
@@ -4751,10 +4751,10 @@ Types:
         - Name: x
           Offset: 1
           Expression:
-            Type: 8 GoStringHeaderType string
+            Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 95, index: 0, name: x}
+                  Variable: {subprogram: 89, index: 0, name: x}
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
@@ -4766,10 +4766,10 @@ Types:
         - Name: x
           Offset: 1
           Expression:
-            Type: 22 BaseType uint16
+            Type: 6 BaseType uint16
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 35, index: 0, name: x}
+                  Variable: {subprogram: 29, index: 0, name: x}
                   Offset: 0
                   ByteSize: 2
     - __kind: EventRootType
@@ -4781,10 +4781,10 @@ Types:
         - Name: x
           Offset: 1
           Expression:
-            Type: 24 BaseType uint32
+            Type: 2 BaseType uint32
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 36, index: 0, name: x}
+                  Variable: {subprogram: 30, index: 0, name: x}
                   Offset: 0
                   ByteSize: 4
     - __kind: EventRootType
@@ -4796,10 +4796,10 @@ Types:
         - Name: x
           Offset: 1
           Expression:
-            Type: 26 BaseType uint64
+            Type: 8 BaseType uint64
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 37, index: 0, name: x}
+                  Variable: {subprogram: 31, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
@@ -4811,10 +4811,10 @@ Types:
         - Name: x
           Offset: 1
           Expression:
-            Type: 4 BaseType uint8
+            Type: 3 BaseType uint8
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 34, index: 0, name: x}
+                  Variable: {subprogram: 28, index: 0, name: x}
                   Offset: 0
                   ByteSize: 1
     - __kind: EventRootType
@@ -4826,10 +4826,10 @@ Types:
         - Name: x
           Offset: 1
           Expression:
-            Type: 20 BaseType uint
+            Type: 10 BaseType uint
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 33, index: 0, name: x}
+                  Variable: {subprogram: 27, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
@@ -4841,10 +4841,10 @@ Types:
         - Name: u
           Offset: 1
           Expression:
-            Type: 211 GoSliceHeaderType [][]uint
+            Type: 225 GoSliceHeaderType [][]uint
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 86, index: 0, name: u}
+                  Variable: {subprogram: 80, index: 0, name: u}
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
@@ -4856,10 +4856,10 @@ Types:
         - Name: m
           Offset: 1
           Expression:
-            Type: 83 GoMapType map[string]int
+            Type: 99 GoMapType map[string]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 58, index: 0, name: m}
+                  Variable: {subprogram: 52, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
@@ -4871,10 +4871,10 @@ Types:
         - Name: x
           Offset: 1
           Expression:
-            Type: 7 ArrayType [2]string
+            Type: 38 ArrayType [2]string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 9, index: 0, name: x}
+                  Variable: {subprogram: 3, index: 0, name: x}
                   Offset: 0
                   ByteSize: 32
     - __kind: EventRootType
@@ -4886,10 +4886,10 @@ Types:
         - Name: z
           Offset: 1
           Expression:
-            Type: 36 PointerType *string
+            Type: 22 PointerType *string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 81, index: 0, name: z}
+                  Variable: {subprogram: 75, index: 0, name: z}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
@@ -4901,10 +4901,10 @@ Types:
         - Name: s
           Offset: 1
           Expression:
-            Type: 105 GoSliceHeaderType []string
+            Type: 121 GoSliceHeaderType []string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 90, index: 0, name: s}
+                  Variable: {subprogram: 84, index: 0, name: s}
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
@@ -4916,19 +4916,19 @@ Types:
         - Name: xs
           Offset: 1
           Expression:
-            Type: 213 GoSliceHeaderType []main.structWithNoStrings
+            Type: 227 GoSliceHeaderType []main.structWithNoStrings
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 87, index: 0, name: xs}
+                  Variable: {subprogram: 81, index: 0, name: xs}
                   Offset: 0
                   ByteSize: 24
         - Name: a
           Offset: 25
           Expression:
-            Type: 1 BaseType int
+            Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 87, index: 1, name: a}
+                  Variable: {subprogram: 81, index: 1, name: a}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
@@ -4940,10 +4940,10 @@ Types:
         - Name: s
           Offset: 1
           Expression:
-            Type: 58 StructureType main.structWithMap
+            Type: 75 StructureType main.structWithMap
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 53, index: 0, name: s}
+                  Variable: {subprogram: 47, index: 0, name: s}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
@@ -4955,10 +4955,10 @@ Types:
         - Name: x
           Offset: 1
           Expression:
-            Type: 223 StructureType main.aStruct
+            Type: 236 StructureType main.aStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 103, index: 0, name: x}
+                  Variable: {subprogram: 97, index: 0, name: x}
                   Offset: 0
                   ByteSize: 56
     - __kind: EventRootType
@@ -4970,10 +4970,10 @@ Types:
         - Name: a
           Offset: 1
           Expression:
-            Type: 220 PointerType *main.threeStringStruct
+            Type: 233 PointerType *main.threeStringStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 98, index: 0, name: a}
+                  Variable: {subprogram: 92, index: 0, name: a}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
@@ -4985,10 +4985,10 @@ Types:
         - Name: a
           Offset: 1
           Expression:
-            Type: 219 StructureType main.threeStringStruct
+            Type: 232 StructureType main.threeStringStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 97, index: 0, name: a}
+                  Variable: {subprogram: 91, index: 0, name: a}
                   Offset: 0
                   ByteSize: 48
     - __kind: EventRootType
@@ -5000,28 +5000,28 @@ Types:
         - Name: x
           Offset: 1
           Expression:
-            Type: 8 GoStringHeaderType string
+            Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 96, index: 0, name: x}
+                  Variable: {subprogram: 90, index: 0, name: x}
                   Offset: 0
                   ByteSize: 16
         - Name: y
           Offset: 17
           Expression:
-            Type: 8 GoStringHeaderType string
+            Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 96, index: 1, name: y}
+                  Variable: {subprogram: 90, index: 1, name: y}
                   Offset: 0
                   ByteSize: 16
         - Name: z
           Offset: 33
           Expression:
-            Type: 8 GoStringHeaderType string
+            Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 96, index: 2, name: z}
+                  Variable: {subprogram: 90, index: 2, name: z}
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
@@ -5033,10 +5033,10 @@ Types:
         - Name: x
           Offset: 1
           Expression:
-            Type: 32 BaseType main.typeAlias
+            Type: 51 BaseType main.typeAlias
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 40, index: 0, name: x}
+                  Variable: {subprogram: 34, index: 0, name: x}
                   Offset: 0
                   ByteSize: 2
     - __kind: EventRootType
@@ -5048,10 +5048,10 @@ Types:
         - Name: x
           Offset: 1
           Expression:
-            Type: 21 ArrayType [2]uint16
+            Type: 45 ArrayType [2]uint16
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 18, index: 0, name: x}
+                  Variable: {subprogram: 12, index: 0, name: x}
                   Offset: 0
                   ByteSize: 4
     - __kind: EventRootType
@@ -5063,10 +5063,10 @@ Types:
         - Name: x
           Offset: 1
           Expression:
-            Type: 23 ArrayType [2]uint32
+            Type: 46 ArrayType [2]uint32
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 19, index: 0, name: x}
+                  Variable: {subprogram: 13, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
@@ -5078,10 +5078,10 @@ Types:
         - Name: x
           Offset: 1
           Expression:
-            Type: 25 ArrayType [2]uint64
+            Type: 47 ArrayType [2]uint64
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 20, index: 0, name: x}
+                  Variable: {subprogram: 14, index: 0, name: x}
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
@@ -5093,10 +5093,10 @@ Types:
         - Name: x
           Offset: 1
           Expression:
-            Type: 3 ArrayType [2]uint8
+            Type: 36 ArrayType [2]uint8
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 17, index: 0, name: x}
+                  Variable: {subprogram: 11, index: 0, name: x}
                   Offset: 0
                   ByteSize: 2
     - __kind: EventRootType
@@ -5108,10 +5108,10 @@ Types:
         - Name: x
           Offset: 1
           Expression:
-            Type: 19 ArrayType [2]uint
+            Type: 44 ArrayType [2]uint
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 16, index: 0, name: x}
+                  Variable: {subprogram: 10, index: 0, name: x}
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
@@ -5123,10 +5123,10 @@ Types:
         - Name: x
           Offset: 1
           Expression:
-            Type: 205 PointerType *uint
+            Type: 34 PointerType *uint
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 80, index: 0, name: x}
+                  Variable: {subprogram: 74, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
@@ -5138,10 +5138,10 @@ Types:
         - Name: u
           Offset: 1
           Expression:
-            Type: 210 GoSliceHeaderType []uint
+            Type: 224 GoSliceHeaderType []uint
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 84, index: 0, name: u}
+                  Variable: {subprogram: 78, index: 0, name: u}
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
@@ -5153,10 +5153,10 @@ Types:
         - Name: x
           Offset: 1
           Expression:
-            Type: 8 GoStringHeaderType string
+            Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 101, index: 0, name: x}
+                  Variable: {subprogram: 95, index: 0, name: x}
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
@@ -5168,10 +5168,10 @@ Types:
         - Name: x
           Offset: 1
           Expression:
-            Type: 38 VoidPointerType unsafe.Pointer
+            Type: 15 VoidPointerType unsafe.Pointer
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 79, index: 0, name: x}
+                  Variable: {subprogram: 73, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
@@ -5183,10 +5183,10 @@ Types:
         - Name: a
           Offset: 1
           Expression:
-            Type: 29 ArrayType [100]uint
+            Type: 50 ArrayType [100]uint
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 24, index: 0, name: a}
+                  Variable: {subprogram: 18, index: 0, name: a}
                   Offset: 0
                   ByteSize: 800
     - __kind: EventRootType
@@ -5198,173 +5198,173 @@ Types:
         - Name: xs
           Offset: 1
           Expression:
-            Type: 210 GoSliceHeaderType []uint
+            Type: 224 GoSliceHeaderType []uint
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 93, index: 0, name: xs}
+                  Variable: {subprogram: 87, index: 0, name: xs}
                   Offset: 0
                   ByteSize: 24
     - __kind: ArrayType
-      ID: 29
+      ID: 50
       Name: '[100]uint'
       ByteSize: 800
       GoKind: 17
       Count: 100
       HasCount: true
-      Element: 20 BaseType uint
+      Element: 10 BaseType uint
     - __kind: ArrayType
-      ID: 28
+      ID: 49
       Name: '[2][2][2]int'
       ByteSize: 64
       GoKind: 17
       Count: 2
       HasCount: true
-      Element: 27 ArrayType [2][2]int
+      Element: 48 ArrayType [2][2]int
     - __kind: ArrayType
-      ID: 27
+      ID: 48
       Name: '[2][2]int'
       ByteSize: 32
       GoKind: 17
       Count: 2
       HasCount: true
-      Element: 12 ArrayType [2]int
+      Element: 40 ArrayType [2]int
     - __kind: ArrayType
-      ID: 10
+      ID: 39
       Name: '[2]bool'
       ByteSize: 2
       GoKind: 17
       Count: 2
       HasCount: true
-      Element: 11 BaseType bool
+      Element: 4 BaseType bool
     - __kind: ArrayType
-      ID: 12
+      ID: 40
       Name: '[2]int'
       ByteSize: 16
       GoRuntimeType: 673088
       GoKind: 17
       Count: 2
       HasCount: true
-      Element: 1 BaseType int
+      Element: 7 BaseType int
     - __kind: ArrayType
-      ID: 15
+      ID: 42
       Name: '[2]int16'
       ByteSize: 4
       GoKind: 17
       Count: 2
       HasCount: true
-      Element: 16 BaseType int16
+      Element: 23 BaseType int16
     - __kind: ArrayType
-      ID: 5
+      ID: 37
       Name: '[2]int32'
       ByteSize: 8
       GoRuntimeType: 674432
       GoKind: 17
       Count: 2
       HasCount: true
-      Element: 6 BaseType int32
+      Element: 12 BaseType int32
     - __kind: ArrayType
-      ID: 17
+      ID: 43
       Name: '[2]int64'
       ByteSize: 16
       GoKind: 17
       Count: 2
       HasCount: true
-      Element: 18 BaseType int64
+      Element: 13 BaseType int64
     - __kind: ArrayType
-      ID: 13
+      ID: 41
       Name: '[2]int8'
       ByteSize: 2
       GoKind: 17
       Count: 2
       HasCount: true
-      Element: 14 BaseType int8
+      Element: 16 BaseType int8
     - __kind: ArrayType
-      ID: 118
+      ID: 134
       Name: '[2]map[string]int'
       ByteSize: 16
       GoKind: 17
       Count: 2
       HasCount: true
-      Element: 83 GoMapType map[string]int
+      Element: 99 GoMapType map[string]int
     - __kind: ArrayType
-      ID: 7
+      ID: 38
       Name: '[2]string'
       ByteSize: 32
       GoRuntimeType: 674528
       GoKind: 17
       Count: 2
       HasCount: true
-      Element: 8 GoStringHeaderType string
+      Element: 9 GoStringHeaderType string
     - __kind: ArrayType
-      ID: 19
+      ID: 44
       Name: '[2]uint'
       ByteSize: 16
       GoKind: 17
       Count: 2
       HasCount: true
-      Element: 20 BaseType uint
+      Element: 10 BaseType uint
     - __kind: ArrayType
-      ID: 21
+      ID: 45
       Name: '[2]uint16'
       ByteSize: 4
       GoKind: 17
       Count: 2
       HasCount: true
-      Element: 22 BaseType uint16
+      Element: 6 BaseType uint16
     - __kind: ArrayType
-      ID: 23
+      ID: 46
       Name: '[2]uint32'
       ByteSize: 8
       GoKind: 17
       Count: 2
       HasCount: true
-      Element: 24 BaseType uint32
+      Element: 2 BaseType uint32
     - __kind: ArrayType
-      ID: 25
+      ID: 47
       Name: '[2]uint64'
       ByteSize: 16
       GoRuntimeType: 674624
       GoKind: 17
       Count: 2
       HasCount: true
-      Element: 26 BaseType uint64
+      Element: 8 BaseType uint64
     - __kind: ArrayType
-      ID: 3
+      ID: 36
       Name: '[2]uint8'
       ByteSize: 2
       GoRuntimeType: 674336
       GoKind: 17
       Count: 2
       HasCount: true
-      Element: 4 BaseType uint8
+      Element: 3 BaseType uint8
     - __kind: ArrayType
-      ID: 179
+      ID: 195
       Name: '[4]int'
       ByteSize: 32
       GoRuntimeType: 672704
       GoKind: 17
       Count: 4
       HasCount: true
-      Element: 1 BaseType int
+      Element: 7 BaseType int
     - __kind: ArrayType
-      ID: 117
+      ID: 133
       Name: '[4]string'
       ByteSize: 64
       GoRuntimeType: 672992
       GoKind: 17
       Count: 4
       HasCount: true
-      Element: 8 GoStringHeaderType string
+      Element: 9 GoStringHeaderType string
     - __kind: ArrayType
-      ID: 2
+      ID: 73
       Name: '[5]int'
       ByteSize: 40
       GoKind: 17
       Count: 5
       HasCount: true
-      Element: 1 BaseType int
+      Element: 7 BaseType int
     - __kind: GoSliceHeaderType
-      ID: 34
+      ID: 53
       Name: '[]*string'
       ByteSize: 24
       GoRuntimeType: 470528
@@ -5372,102 +5372,102 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 35 PointerType **string
+          Type: 54 PointerType **string
         - Name: len
           Offset: 8
-          Type: 1 BaseType int
+          Type: 7 BaseType int
         - Name: cap
           Offset: 16
-          Type: 1 BaseType int
+          Type: 7 BaseType int
       Data: 240 GoSliceDataType []*string.array
     - __kind: GoSliceDataType
       ID: 240
       Name: '[]*string.array'
       ByteSize: 2048
-      Element: 36 PointerType *string
+      Element: 22 PointerType *string
     - __kind: GoSliceDataType
       ID: 268
       Name: '[]*table<[4]int,[4]int>.array'
       ByteSize: 8192
-      Element: 195 PointerType *table<[4]int,[4]int>
+      Element: 211 PointerType *table<[4]int,[4]int>
     - __kind: GoSliceDataType
       ID: 266
       Name: '[]*table<[4]int,uint8>.array'
       ByteSize: 8192
-      Element: 184 PointerType *table<[4]int,uint8>
+      Element: 200 PointerType *table<[4]int,uint8>
     - __kind: GoSliceDataType
       ID: 252
       Name: '[]*table<[4]string,[2]int>.array'
       ByteSize: 8192
-      Element: 110 PointerType *table<[4]string,[2]int>
+      Element: 126 PointerType *table<[4]string,[2]int>
     - __kind: GoSliceDataType
       ID: 258
       Name: '[]*table<bool,main.node>.array'
       ByteSize: 8192
-      Element: 137 PointerType *table<bool,main.node>
+      Element: 153 PointerType *table<bool,main.node>
     - __kind: GoSliceDataType
       ID: 242
       Name: '[]*table<int,int>.array'
       ByteSize: 8192
-      Element: 64 PointerType *table<int,int>
+      Element: 80 PointerType *table<int,int>
     - __kind: GoSliceDataType
       ID: 260
       Name: '[]*table<int,uint8>.array'
       ByteSize: 8192
-      Element: 150 PointerType *table<int,uint8>
+      Element: 166 PointerType *table<int,uint8>
     - __kind: GoSliceDataType
       ID: 254
       Name: '[]*table<string,[]main.structWithMap>.array'
       ByteSize: 8192
-      Element: 124 PointerType *table<string,[]main.structWithMap>
+      Element: 140 PointerType *table<string,[]main.structWithMap>
     - __kind: GoSliceDataType
       ID: 248
       Name: '[]*table<string,[]string>.array'
       ByteSize: 8192
-      Element: 98 PointerType *table<string,[]string>
+      Element: 114 PointerType *table<string,[]string>
     - __kind: GoSliceDataType
       ID: 246
       Name: '[]*table<string,int>.array'
       ByteSize: 8192
-      Element: 87 PointerType *table<string,int>
+      Element: 103 PointerType *table<string,int>
     - __kind: GoSliceDataType
       ID: 244
       Name: '[]*table<string,main.nestedStruct>.array'
       ByteSize: 8192
-      Element: 75 PointerType *table<string,main.nestedStruct>
+      Element: 91 PointerType *table<string,main.nestedStruct>
     - __kind: GoSliceDataType
       ID: 264
       Name: '[]*table<uint8,[4]int>.array'
       ByteSize: 8192
-      Element: 172 PointerType *table<uint8,[4]int>
+      Element: 188 PointerType *table<uint8,[4]int>
     - __kind: GoSliceDataType
       ID: 262
       Name: '[]*table<uint8,uint8>.array'
       ByteSize: 8192
-      Element: 161 PointerType *table<uint8,uint8>
+      Element: 177 PointerType *table<uint8,uint8>
     - __kind: GoSliceHeaderType
-      ID: 211
+      ID: 225
       Name: '[][]uint'
       ByteSize: 24
       GoKind: 23
       RawFields:
         - Name: array
           Offset: 0
-          Type: 212 PointerType *[]uint
+          Type: 226 PointerType *[]uint
         - Name: len
           Offset: 8
-          Type: 1 BaseType int
+          Type: 7 BaseType int
         - Name: cap
           Offset: 16
-          Type: 1 BaseType int
+          Type: 7 BaseType int
       Data: 274 GoSliceDataType [][]uint.array
     - __kind: GoSliceDataType
       ID: 274
       Name: '[][]uint.array'
       ByteSize: 2048
-      Element: 210 GoSliceHeaderType []uint
+      Element: 224 GoSliceHeaderType []uint
     - __kind: GoSliceHeaderType
-      ID: 216
+      ID: 230
       Name: '[]bool'
       ByteSize: 24
       GoRuntimeType: 478400
@@ -5475,21 +5475,21 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 206 PointerType *bool
+          Type: 11 PointerType *bool
         - Name: len
           Offset: 8
-          Type: 1 BaseType int
+          Type: 7 BaseType int
         - Name: cap
           Offset: 16
-          Type: 1 BaseType int
+          Type: 7 BaseType int
       Data: 278 GoSliceDataType []bool.array
     - __kind: GoSliceDataType
       ID: 278
       Name: '[]bool.array'
       ByteSize: 2048
-      Element: 11 BaseType bool
+      Element: 4 BaseType bool
     - __kind: GoSliceHeaderType
-      ID: 131
+      ID: 147
       Name: '[]main.structWithMap'
       ByteSize: 24
       GoRuntimeType: 469760
@@ -5497,102 +5497,102 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 132 PointerType *main.structWithMap
+          Type: 148 PointerType *main.structWithMap
         - Name: len
           Offset: 8
-          Type: 1 BaseType int
+          Type: 7 BaseType int
         - Name: cap
           Offset: 16
-          Type: 1 BaseType int
+          Type: 7 BaseType int
       Data: 256 GoSliceDataType []main.structWithMap.array
     - __kind: GoSliceDataType
       ID: 256
       Name: '[]main.structWithMap.array'
       ByteSize: 2048
-      Element: 58 StructureType main.structWithMap
+      Element: 75 StructureType main.structWithMap
     - __kind: GoSliceHeaderType
-      ID: 213
+      ID: 227
       Name: '[]main.structWithNoStrings'
       ByteSize: 24
       GoKind: 23
       RawFields:
         - Name: array
           Offset: 0
-          Type: 214 PointerType *main.structWithNoStrings
+          Type: 228 PointerType *main.structWithNoStrings
         - Name: len
           Offset: 8
-          Type: 1 BaseType int
+          Type: 7 BaseType int
         - Name: cap
           Offset: 16
-          Type: 1 BaseType int
+          Type: 7 BaseType int
       Data: 276 GoSliceDataType []main.structWithNoStrings.array
     - __kind: GoSliceDataType
       ID: 276
       Name: '[]main.structWithNoStrings.array'
       ByteSize: 2048
-      Element: 215 StructureType main.structWithNoStrings
+      Element: 229 StructureType main.structWithNoStrings
     - __kind: GoSliceDataType
       ID: 269
       Name: '[]noalg.map.group[[4]int][4]int.array'
       ByteSize: 2048
-      Element: 199 StructureType noalg.map.group[[4]int][4]int
+      Element: 215 StructureType noalg.map.group[[4]int][4]int
     - __kind: GoSliceDataType
       ID: 267
       Name: '[]noalg.map.group[[4]int]uint8.array'
       ByteSize: 2048
-      Element: 188 StructureType noalg.map.group[[4]int]uint8
+      Element: 204 StructureType noalg.map.group[[4]int]uint8
     - __kind: GoSliceDataType
       ID: 253
       Name: '[]noalg.map.group[[4]string][2]int.array'
       ByteSize: 2048
-      Element: 114 StructureType noalg.map.group[[4]string][2]int
+      Element: 130 StructureType noalg.map.group[[4]string][2]int
     - __kind: GoSliceDataType
       ID: 259
       Name: '[]noalg.map.group[bool]main.node.array'
       ByteSize: 2048
-      Element: 141 StructureType noalg.map.group[bool]main.node
+      Element: 157 StructureType noalg.map.group[bool]main.node
     - __kind: GoSliceDataType
       ID: 243
       Name: '[]noalg.map.group[int]int.array'
       ByteSize: 2048
-      Element: 68 StructureType noalg.map.group[int]int
+      Element: 84 StructureType noalg.map.group[int]int
     - __kind: GoSliceDataType
       ID: 261
       Name: '[]noalg.map.group[int]uint8.array'
       ByteSize: 2048
-      Element: 154 StructureType noalg.map.group[int]uint8
+      Element: 170 StructureType noalg.map.group[int]uint8
     - __kind: GoSliceDataType
       ID: 255
       Name: '[]noalg.map.group[string][]main.structWithMap.array'
       ByteSize: 2048
-      Element: 128 StructureType noalg.map.group[string][]main.structWithMap
+      Element: 144 StructureType noalg.map.group[string][]main.structWithMap
     - __kind: GoSliceDataType
       ID: 249
       Name: '[]noalg.map.group[string][]string.array'
       ByteSize: 2048
-      Element: 102 StructureType noalg.map.group[string][]string
+      Element: 118 StructureType noalg.map.group[string][]string
     - __kind: GoSliceDataType
       ID: 247
       Name: '[]noalg.map.group[string]int.array'
       ByteSize: 2048
-      Element: 91 StructureType noalg.map.group[string]int
+      Element: 107 StructureType noalg.map.group[string]int
     - __kind: GoSliceDataType
       ID: 245
       Name: '[]noalg.map.group[string]main.nestedStruct.array'
       ByteSize: 2048
-      Element: 79 StructureType noalg.map.group[string]main.nestedStruct
+      Element: 95 StructureType noalg.map.group[string]main.nestedStruct
     - __kind: GoSliceDataType
       ID: 265
       Name: '[]noalg.map.group[uint8][4]int.array'
       ByteSize: 2048
-      Element: 176 StructureType noalg.map.group[uint8][4]int
+      Element: 192 StructureType noalg.map.group[uint8][4]int
     - __kind: GoSliceDataType
       ID: 263
       Name: '[]noalg.map.group[uint8]uint8.array'
       ByteSize: 2048
-      Element: 165 StructureType noalg.map.group[uint8]uint8
+      Element: 181 StructureType noalg.map.group[uint8]uint8
     - __kind: GoSliceHeaderType
-      ID: 105
+      ID: 121
       Name: '[]string'
       ByteSize: 24
       GoRuntimeType: 478528
@@ -5600,21 +5600,21 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 36 PointerType *string
+          Type: 22 PointerType *string
         - Name: len
           Offset: 8
-          Type: 1 BaseType int
+          Type: 7 BaseType int
         - Name: cap
           Offset: 16
-          Type: 1 BaseType int
+          Type: 7 BaseType int
       Data: 250 GoSliceDataType []string.array
     - __kind: GoSliceDataType
       ID: 250
       Name: '[]string.array'
       ByteSize: 2048
-      Element: 8 GoStringHeaderType string
+      Element: 9 GoStringHeaderType string
     - __kind: GoSliceHeaderType
-      ID: 210
+      ID: 224
       Name: '[]uint'
       ByteSize: 24
       GoRuntimeType: 478016
@@ -5622,21 +5622,21 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 205 PointerType *uint
+          Type: 34 PointerType *uint
         - Name: len
           Offset: 8
-          Type: 1 BaseType int
+          Type: 7 BaseType int
         - Name: cap
           Offset: 16
-          Type: 1 BaseType int
+          Type: 7 BaseType int
       Data: 272 GoSliceDataType []uint.array
     - __kind: GoSliceDataType
       ID: 272
       Name: '[]uint.array'
       ByteSize: 2048
-      Element: 20 BaseType uint
+      Element: 10 BaseType uint
     - __kind: GoSliceHeaderType
-      ID: 217
+      ID: 231
       Name: '[]uint16'
       ByteSize: 24
       GoRuntimeType: 477376
@@ -5644,49 +5644,49 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 218 PointerType *uint16
+          Type: 30 PointerType *uint16
         - Name: len
           Offset: 8
-          Type: 1 BaseType int
+          Type: 7 BaseType int
         - Name: cap
           Offset: 16
-          Type: 1 BaseType int
+          Type: 7 BaseType int
       Data: 280 GoSliceDataType []uint16.array
     - __kind: GoSliceDataType
       ID: 280
       Name: '[]uint16.array'
       ByteSize: 2048
-      Element: 22 BaseType uint16
+      Element: 6 BaseType uint16
     - __kind: BaseType
-      ID: 11
+      ID: 4
       Name: bool
       ByteSize: 1
       GoRuntimeType: 575840
       GoKind: 1
     - __kind: GoChannelType
-      ID: 202
+      ID: 218
       Name: chan bool
       GoRuntimeType: 587168
       GoKind: 18
     - __kind: GoChannelType
-      ID: 40
+      ID: 57
       Name: chan struct {}
       GoRuntimeType: 586080
       GoKind: 18
     - __kind: BaseType
-      ID: 229
+      ID: 25
       Name: complex128
       ByteSize: 16
       GoRuntimeType: 575648
       GoKind: 16
     - __kind: BaseType
-      ID: 228
+      ID: 24
       Name: complex64
       ByteSize: 8
       GoRuntimeType: 575584
       GoKind: 15
     - __kind: GoInterfaceType
-      ID: 57
+      ID: 14
       Name: error
       ByteSize: 16
       GoRuntimeType: 1.015744e+06
@@ -5694,228 +5694,228 @@ Types:
       RawFields:
         - Name: tab
           Offset: 0
-          Type: 38 VoidPointerType unsafe.Pointer
+          Type: 15 VoidPointerType unsafe.Pointer
         - Name: data
           Offset: 8
-          Type: 38 VoidPointerType unsafe.Pointer
+          Type: 15 VoidPointerType unsafe.Pointer
     - __kind: BaseType
-      ID: 30
+      ID: 17
       Name: float32
       ByteSize: 4
       GoRuntimeType: 575712
       GoKind: 13
     - __kind: BaseType
-      ID: 31
+      ID: 18
       Name: float64
       ByteSize: 8
       GoRuntimeType: 575776
       GoKind: 14
     - __kind: GoSubroutineType
-      ID: 43
+      ID: 60
       Name: func()
       ByteSize: 8
       GoRuntimeType: 468800
       GoKind: 19
     - __kind: GoSwissMapGroupsType
-      ID: 197
+      ID: 213
       Name: groupReference<[4]int,[4]int>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 198 PointerType *noalg.map.group[[4]int][4]int
+          Type: 214 PointerType *noalg.map.group[[4]int][4]int
         - Name: lengthMask
           Offset: 8
-          Type: 26 BaseType uint64
-      GroupType: 199 StructureType noalg.map.group[[4]int][4]int
+          Type: 8 BaseType uint64
+      GroupType: 215 StructureType noalg.map.group[[4]int][4]int
       GroupSliceType: 269 GoSliceDataType []noalg.map.group[[4]int][4]int.array
     - __kind: GoSwissMapGroupsType
-      ID: 186
+      ID: 202
       Name: groupReference<[4]int,uint8>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 187 PointerType *noalg.map.group[[4]int]uint8
+          Type: 203 PointerType *noalg.map.group[[4]int]uint8
         - Name: lengthMask
           Offset: 8
-          Type: 26 BaseType uint64
-      GroupType: 188 StructureType noalg.map.group[[4]int]uint8
+          Type: 8 BaseType uint64
+      GroupType: 204 StructureType noalg.map.group[[4]int]uint8
       GroupSliceType: 267 GoSliceDataType []noalg.map.group[[4]int]uint8.array
     - __kind: GoSwissMapGroupsType
-      ID: 112
+      ID: 128
       Name: groupReference<[4]string,[2]int>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 113 PointerType *noalg.map.group[[4]string][2]int
+          Type: 129 PointerType *noalg.map.group[[4]string][2]int
         - Name: lengthMask
           Offset: 8
-          Type: 26 BaseType uint64
-      GroupType: 114 StructureType noalg.map.group[[4]string][2]int
+          Type: 8 BaseType uint64
+      GroupType: 130 StructureType noalg.map.group[[4]string][2]int
       GroupSliceType: 253 GoSliceDataType []noalg.map.group[[4]string][2]int.array
     - __kind: GoSwissMapGroupsType
-      ID: 139
+      ID: 155
       Name: groupReference<bool,main.node>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 140 PointerType *noalg.map.group[bool]main.node
+          Type: 156 PointerType *noalg.map.group[bool]main.node
         - Name: lengthMask
           Offset: 8
-          Type: 26 BaseType uint64
-      GroupType: 141 StructureType noalg.map.group[bool]main.node
+          Type: 8 BaseType uint64
+      GroupType: 157 StructureType noalg.map.group[bool]main.node
       GroupSliceType: 259 GoSliceDataType []noalg.map.group[bool]main.node.array
     - __kind: GoSwissMapGroupsType
-      ID: 66
+      ID: 82
       Name: groupReference<int,int>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 67 PointerType *noalg.map.group[int]int
+          Type: 83 PointerType *noalg.map.group[int]int
         - Name: lengthMask
           Offset: 8
-          Type: 26 BaseType uint64
-      GroupType: 68 StructureType noalg.map.group[int]int
+          Type: 8 BaseType uint64
+      GroupType: 84 StructureType noalg.map.group[int]int
       GroupSliceType: 243 GoSliceDataType []noalg.map.group[int]int.array
     - __kind: GoSwissMapGroupsType
-      ID: 152
+      ID: 168
       Name: groupReference<int,uint8>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 153 PointerType *noalg.map.group[int]uint8
+          Type: 169 PointerType *noalg.map.group[int]uint8
         - Name: lengthMask
           Offset: 8
-          Type: 26 BaseType uint64
-      GroupType: 154 StructureType noalg.map.group[int]uint8
+          Type: 8 BaseType uint64
+      GroupType: 170 StructureType noalg.map.group[int]uint8
       GroupSliceType: 261 GoSliceDataType []noalg.map.group[int]uint8.array
     - __kind: GoSwissMapGroupsType
-      ID: 126
+      ID: 142
       Name: groupReference<string,[]main.structWithMap>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 127 PointerType *noalg.map.group[string][]main.structWithMap
+          Type: 143 PointerType *noalg.map.group[string][]main.structWithMap
         - Name: lengthMask
           Offset: 8
-          Type: 26 BaseType uint64
-      GroupType: 128 StructureType noalg.map.group[string][]main.structWithMap
+          Type: 8 BaseType uint64
+      GroupType: 144 StructureType noalg.map.group[string][]main.structWithMap
       GroupSliceType: 255 GoSliceDataType []noalg.map.group[string][]main.structWithMap.array
     - __kind: GoSwissMapGroupsType
-      ID: 100
+      ID: 116
       Name: groupReference<string,[]string>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 101 PointerType *noalg.map.group[string][]string
+          Type: 117 PointerType *noalg.map.group[string][]string
         - Name: lengthMask
           Offset: 8
-          Type: 26 BaseType uint64
-      GroupType: 102 StructureType noalg.map.group[string][]string
+          Type: 8 BaseType uint64
+      GroupType: 118 StructureType noalg.map.group[string][]string
       GroupSliceType: 249 GoSliceDataType []noalg.map.group[string][]string.array
     - __kind: GoSwissMapGroupsType
-      ID: 89
+      ID: 105
       Name: groupReference<string,int>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 90 PointerType *noalg.map.group[string]int
+          Type: 106 PointerType *noalg.map.group[string]int
         - Name: lengthMask
           Offset: 8
-          Type: 26 BaseType uint64
-      GroupType: 91 StructureType noalg.map.group[string]int
+          Type: 8 BaseType uint64
+      GroupType: 107 StructureType noalg.map.group[string]int
       GroupSliceType: 247 GoSliceDataType []noalg.map.group[string]int.array
     - __kind: GoSwissMapGroupsType
-      ID: 77
+      ID: 93
       Name: groupReference<string,main.nestedStruct>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 78 PointerType *noalg.map.group[string]main.nestedStruct
+          Type: 94 PointerType *noalg.map.group[string]main.nestedStruct
         - Name: lengthMask
           Offset: 8
-          Type: 26 BaseType uint64
-      GroupType: 79 StructureType noalg.map.group[string]main.nestedStruct
+          Type: 8 BaseType uint64
+      GroupType: 95 StructureType noalg.map.group[string]main.nestedStruct
       GroupSliceType: 245 GoSliceDataType []noalg.map.group[string]main.nestedStruct.array
     - __kind: GoSwissMapGroupsType
-      ID: 174
+      ID: 190
       Name: groupReference<uint8,[4]int>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 175 PointerType *noalg.map.group[uint8][4]int
+          Type: 191 PointerType *noalg.map.group[uint8][4]int
         - Name: lengthMask
           Offset: 8
-          Type: 26 BaseType uint64
-      GroupType: 176 StructureType noalg.map.group[uint8][4]int
+          Type: 8 BaseType uint64
+      GroupType: 192 StructureType noalg.map.group[uint8][4]int
       GroupSliceType: 265 GoSliceDataType []noalg.map.group[uint8][4]int.array
     - __kind: GoSwissMapGroupsType
-      ID: 163
+      ID: 179
       Name: groupReference<uint8,uint8>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 164 PointerType *noalg.map.group[uint8]uint8
+          Type: 180 PointerType *noalg.map.group[uint8]uint8
         - Name: lengthMask
           Offset: 8
-          Type: 26 BaseType uint64
-      GroupType: 165 StructureType noalg.map.group[uint8]uint8
+          Type: 8 BaseType uint64
+      GroupType: 181 StructureType noalg.map.group[uint8]uint8
       GroupSliceType: 263 GoSliceDataType []noalg.map.group[uint8]uint8.array
     - __kind: BaseType
-      ID: 1
+      ID: 7
       Name: int
       ByteSize: 8
       GoRuntimeType: 575392
       GoKind: 2
     - __kind: BaseType
-      ID: 16
+      ID: 23
       Name: int16
       ByteSize: 2
       GoRuntimeType: 575008
       GoKind: 4
     - __kind: BaseType
-      ID: 6
+      ID: 12
       Name: int32
       ByteSize: 4
       GoRuntimeType: 575136
       GoKind: 5
     - __kind: BaseType
-      ID: 18
+      ID: 13
       Name: int64
       ByteSize: 8
       GoRuntimeType: 575264
       GoKind: 6
     - __kind: BaseType
-      ID: 14
+      ID: 16
       Name: int8
       ByteSize: 1
       GoRuntimeType: 574880
       GoKind: 3
     - __kind: GoEmptyInterfaceType
-      ID: 41
+      ID: 58
       Name: interface {}
       ByteSize: 16
       GoRuntimeType: 837760
@@ -5923,12 +5923,12 @@ Types:
       RawFields:
         - Name: _type
           Offset: 0
-          Type: 38 VoidPointerType unsafe.Pointer
+          Type: 15 VoidPointerType unsafe.Pointer
         - Name: data
           Offset: 8
-          Type: 38 VoidPointerType unsafe.Pointer
+          Type: 15 VoidPointerType unsafe.Pointer
     - __kind: StructureType
-      ID: 48
+      ID: 65
       Name: internal/sync.Mutex
       ByteSize: 8
       GoRuntimeType: 1.453952e+06
@@ -5936,12 +5936,12 @@ Types:
       RawFields:
         - Name: state
           Offset: 0
-          Type: 6 BaseType int32
+          Type: 12 BaseType int32
         - Name: sema
           Offset: 4
-          Type: 24 BaseType uint32
+          Type: 2 BaseType uint32
     - __kind: GoInterfaceType
-      ID: 37
+      ID: 55
       Name: io.Writer
       ByteSize: 16
       GoRuntimeType: 1.011776e+06
@@ -5949,30 +5949,30 @@ Types:
       RawFields:
         - Name: tab
           Offset: 0
-          Type: 38 VoidPointerType unsafe.Pointer
+          Type: 15 VoidPointerType unsafe.Pointer
         - Name: data
           Offset: 8
-          Type: 38 VoidPointerType unsafe.Pointer
+          Type: 15 VoidPointerType unsafe.Pointer
     - __kind: StructureType
-      ID: 223
+      ID: 236
       Name: main.aStruct
       ByteSize: 56
       GoKind: 25
       RawFields:
         - Name: aBool
           Offset: 0
-          Type: 11 BaseType bool
+          Type: 4 BaseType bool
         - Name: aString
           Offset: 8
-          Type: 8 GoStringHeaderType string
+          Type: 9 GoStringHeaderType string
         - Name: aNumber
           Offset: 24
-          Type: 1 BaseType int
+          Type: 7 BaseType int
         - Name: nested
           Offset: 32
-          Type: 82 StructureType main.nestedStruct
+          Type: 98 StructureType main.nestedStruct
     - __kind: GoInterfaceType
-      ID: 56
+      ID: 74
       Name: main.behavior
       ByteSize: 16
       GoRuntimeType: 1.011392e+06
@@ -5980,32 +5980,32 @@ Types:
       RawFields:
         - Name: tab
           Offset: 0
-          Type: 38 VoidPointerType unsafe.Pointer
+          Type: 15 VoidPointerType unsafe.Pointer
         - Name: data
           Offset: 8
-          Type: 38 VoidPointerType unsafe.Pointer
+          Type: 15 VoidPointerType unsafe.Pointer
     - __kind: StructureType
-      ID: 33
+      ID: 52
       Name: main.bigStruct
       ByteSize: 48
       GoKind: 25
       RawFields:
         - Name: x
           Offset: 0
-          Type: 34 GoSliceHeaderType []*string
+          Type: 53 GoSliceHeaderType []*string
         - Name: z
           Offset: 24
-          Type: 1 BaseType int
+          Type: 7 BaseType int
         - Name: writer
           Offset: 32
-          Type: 37 GoInterfaceType io.Writer
+          Type: 55 GoInterfaceType io.Writer
     - __kind: StructureType
-      ID: 224
+      ID: 237
       Name: main.emptyStruct
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 45
+      ID: 62
       Name: main.esotericHeap
       ByteSize: 112
       GoRuntimeType: 1.811168e+06
@@ -6013,21 +6013,21 @@ Types:
       RawFields:
         - Name: esotericStack
           Offset: 0
-          Type: 39 StructureType main.esotericStack
+          Type: 56 StructureType main.esotericStack
         - Name: mu
           Offset: 64
-          Type: 46 StructureType sync.Mutex
+          Type: 63 StructureType sync.Mutex
         - Name: once
           Offset: 72
-          Type: 49 StructureType sync.Once
+          Type: 66 StructureType sync.Once
         - Name: wg
           Offset: 88
-          Type: 52 StructureType sync.WaitGroup
+          Type: 69 StructureType sync.WaitGroup
         - Name: a
           Offset: 104
-          Type: 55 StructureType sync/atomic.Int32
+          Type: 72 StructureType sync/atomic.Int32
     - __kind: StructureType
-      ID: 39
+      ID: 56
       Name: main.esotericStack
       ByteSize: 64
       GoRuntimeType: 1.944768e+06
@@ -6035,27 +6035,27 @@ Types:
       RawFields:
         - Name: _
           Offset: 0
-          Type: 6 BaseType int32
+          Type: 12 BaseType int32
         - Name: _valid
           Offset: 4
-          Type: 6 BaseType int32
+          Type: 12 BaseType int32
         - Name: c
           Offset: 8
-          Type: 40 GoChannelType chan struct {}
+          Type: 57 GoChannelType chan struct {}
         - Name: val
           Offset: 16
-          Type: 41 GoEmptyInterfaceType interface {}
+          Type: 58 GoEmptyInterfaceType interface {}
         - Name: _
           Offset: 32
-          Type: 26 BaseType uint64
+          Type: 8 BaseType uint64
         - Name: work
           Offset: 40
-          Type: 42 GoInterfaceType main.something
+          Type: 59 GoInterfaceType main.something
         - Name: foo
           Offset: 56
-          Type: 43 GoSubroutineType func()
+          Type: 60 GoSubroutineType func()
     - __kind: StructureType
-      ID: 82
+      ID: 98
       Name: main.nestedStruct
       ByteSize: 24
       GoRuntimeType: 1.443392e+06
@@ -6063,12 +6063,12 @@ Types:
       RawFields:
         - Name: anotherInt
           Offset: 0
-          Type: 1 BaseType int
+          Type: 7 BaseType int
         - Name: anotherString
           Offset: 8
-          Type: 8 GoStringHeaderType string
+          Type: 9 GoStringHeaderType string
     - __kind: StructureType
-      ID: 144
+      ID: 160
       Name: main.node
       ByteSize: 16
       GoRuntimeType: 1.443232e+06
@@ -6076,21 +6076,21 @@ Types:
       RawFields:
         - Name: val
           Offset: 0
-          Type: 1 BaseType int
+          Type: 7 BaseType int
         - Name: b
           Offset: 8
-          Type: 145 PointerType *main.node
+          Type: 161 PointerType *main.node
     - __kind: StructureType
-      ID: 222
+      ID: 235
       Name: main.oneStringStruct
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: a
           Offset: 0
-          Type: 8 GoStringHeaderType string
+          Type: 9 GoStringHeaderType string
     - __kind: GoInterfaceType
-      ID: 42
+      ID: 59
       Name: main.something
       ByteSize: 16
       GoRuntimeType: 1.01152e+06
@@ -6098,12 +6098,12 @@ Types:
       RawFields:
         - Name: tab
           Offset: 0
-          Type: 38 VoidPointerType unsafe.Pointer
+          Type: 15 VoidPointerType unsafe.Pointer
         - Name: data
           Offset: 8
-          Type: 38 VoidPointerType unsafe.Pointer
+          Type: 15 VoidPointerType unsafe.Pointer
     - __kind: StructureType
-      ID: 58
+      ID: 75
       Name: main.structWithMap
       ByteSize: 8
       GoRuntimeType: 1.172832e+06
@@ -6111,650 +6111,650 @@ Types:
       RawFields:
         - Name: m
           Offset: 0
-          Type: 59 GoMapType map[int]int
+          Type: 76 GoMapType map[int]int
     - __kind: StructureType
-      ID: 215
+      ID: 229
       Name: main.structWithNoStrings
       ByteSize: 2
       GoKind: 25
       RawFields:
         - Name: aUint8
           Offset: 0
-          Type: 4 BaseType uint8
+          Type: 3 BaseType uint8
         - Name: aBool
           Offset: 1
-          Type: 11 BaseType bool
+          Type: 4 BaseType bool
     - __kind: StructureType
-      ID: 204
+      ID: 220
       Name: main.structWithTwoValues
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: a
           Offset: 0
-          Type: 20 BaseType uint
+          Type: 10 BaseType uint
         - Name: b
           Offset: 8
-          Type: 11 BaseType bool
+          Type: 4 BaseType bool
     - __kind: GoSliceHeaderType
-      ID: 208
+      ID: 222
       Name: main.t
       ByteSize: 24
       GoKind: 23
       RawFields:
         - Name: array
           Offset: 0
-          Type: 209 PointerType **main.t
+          Type: 223 PointerType **main.t
         - Name: len
           Offset: 8
-          Type: 1 BaseType int
+          Type: 7 BaseType int
         - Name: cap
           Offset: 16
-          Type: 1 BaseType int
+          Type: 7 BaseType int
       Data: 270 GoSliceDataType main.t.array
     - __kind: GoSliceDataType
       ID: 270
       Name: main.t.array
       ByteSize: 2048
-      Element: 207 PointerType *main.t
+      Element: 221 PointerType *main.t
     - __kind: StructureType
-      ID: 219
+      ID: 232
       Name: main.threeStringStruct
       ByteSize: 48
       GoKind: 25
       RawFields:
         - Name: a
           Offset: 0
-          Type: 8 GoStringHeaderType string
+          Type: 9 GoStringHeaderType string
         - Name: b
           Offset: 16
-          Type: 8 GoStringHeaderType string
+          Type: 9 GoStringHeaderType string
         - Name: c
           Offset: 32
-          Type: 8 GoStringHeaderType string
+          Type: 9 GoStringHeaderType string
     - __kind: BaseType
-      ID: 32
+      ID: 51
       Name: main.typeAlias
       ByteSize: 2
       GoKind: 9
     - __kind: GoSwissMapHeaderType
-      ID: 193
+      ID: 209
       Name: map<[4]int,[4]int>
       ByteSize: 48
       GoKind: 25
       RawFields:
         - Name: used
           Offset: 0
-          Type: 26 BaseType uint64
+          Type: 8 BaseType uint64
         - Name: seed
           Offset: 8
-          Type: 62 BaseType uintptr
+          Type: 1 BaseType uintptr
         - Name: dirPtr
           Offset: 16
-          Type: 194 PointerType **table<[4]int,[4]int>
+          Type: 210 PointerType **table<[4]int,[4]int>
         - Name: dirLen
           Offset: 24
-          Type: 1 BaseType int
+          Type: 7 BaseType int
         - Name: globalDepth
           Offset: 32
-          Type: 4 BaseType uint8
+          Type: 3 BaseType uint8
         - Name: globalShift
           Offset: 33
-          Type: 4 BaseType uint8
+          Type: 3 BaseType uint8
         - Name: writing
           Offset: 34
-          Type: 4 BaseType uint8
+          Type: 3 BaseType uint8
         - Name: clearSeq
           Offset: 40
-          Type: 26 BaseType uint64
+          Type: 8 BaseType uint64
       TablePtrSliceType: 268 GoSliceDataType []*table<[4]int,[4]int>.array
-      GroupType: 199 StructureType noalg.map.group[[4]int][4]int
+      GroupType: 215 StructureType noalg.map.group[[4]int][4]int
     - __kind: GoSwissMapHeaderType
-      ID: 182
+      ID: 198
       Name: map<[4]int,uint8>
       ByteSize: 48
       GoKind: 25
       RawFields:
         - Name: used
           Offset: 0
-          Type: 26 BaseType uint64
+          Type: 8 BaseType uint64
         - Name: seed
           Offset: 8
-          Type: 62 BaseType uintptr
+          Type: 1 BaseType uintptr
         - Name: dirPtr
           Offset: 16
-          Type: 183 PointerType **table<[4]int,uint8>
+          Type: 199 PointerType **table<[4]int,uint8>
         - Name: dirLen
           Offset: 24
-          Type: 1 BaseType int
+          Type: 7 BaseType int
         - Name: globalDepth
           Offset: 32
-          Type: 4 BaseType uint8
+          Type: 3 BaseType uint8
         - Name: globalShift
           Offset: 33
-          Type: 4 BaseType uint8
+          Type: 3 BaseType uint8
         - Name: writing
           Offset: 34
-          Type: 4 BaseType uint8
+          Type: 3 BaseType uint8
         - Name: clearSeq
           Offset: 40
-          Type: 26 BaseType uint64
+          Type: 8 BaseType uint64
       TablePtrSliceType: 266 GoSliceDataType []*table<[4]int,uint8>.array
-      GroupType: 188 StructureType noalg.map.group[[4]int]uint8
+      GroupType: 204 StructureType noalg.map.group[[4]int]uint8
     - __kind: GoSwissMapHeaderType
-      ID: 108
+      ID: 124
       Name: map<[4]string,[2]int>
       ByteSize: 48
       GoKind: 25
       RawFields:
         - Name: used
           Offset: 0
-          Type: 26 BaseType uint64
+          Type: 8 BaseType uint64
         - Name: seed
           Offset: 8
-          Type: 62 BaseType uintptr
+          Type: 1 BaseType uintptr
         - Name: dirPtr
           Offset: 16
-          Type: 109 PointerType **table<[4]string,[2]int>
+          Type: 125 PointerType **table<[4]string,[2]int>
         - Name: dirLen
           Offset: 24
-          Type: 1 BaseType int
+          Type: 7 BaseType int
         - Name: globalDepth
           Offset: 32
-          Type: 4 BaseType uint8
+          Type: 3 BaseType uint8
         - Name: globalShift
           Offset: 33
-          Type: 4 BaseType uint8
+          Type: 3 BaseType uint8
         - Name: writing
           Offset: 34
-          Type: 4 BaseType uint8
+          Type: 3 BaseType uint8
         - Name: clearSeq
           Offset: 40
-          Type: 26 BaseType uint64
+          Type: 8 BaseType uint64
       TablePtrSliceType: 252 GoSliceDataType []*table<[4]string,[2]int>.array
-      GroupType: 114 StructureType noalg.map.group[[4]string][2]int
+      GroupType: 130 StructureType noalg.map.group[[4]string][2]int
     - __kind: GoSwissMapHeaderType
-      ID: 135
+      ID: 151
       Name: map<bool,main.node>
       ByteSize: 48
       GoKind: 25
       RawFields:
         - Name: used
           Offset: 0
-          Type: 26 BaseType uint64
+          Type: 8 BaseType uint64
         - Name: seed
           Offset: 8
-          Type: 62 BaseType uintptr
+          Type: 1 BaseType uintptr
         - Name: dirPtr
           Offset: 16
-          Type: 136 PointerType **table<bool,main.node>
+          Type: 152 PointerType **table<bool,main.node>
         - Name: dirLen
           Offset: 24
-          Type: 1 BaseType int
+          Type: 7 BaseType int
         - Name: globalDepth
           Offset: 32
-          Type: 4 BaseType uint8
+          Type: 3 BaseType uint8
         - Name: globalShift
           Offset: 33
-          Type: 4 BaseType uint8
+          Type: 3 BaseType uint8
         - Name: writing
           Offset: 34
-          Type: 4 BaseType uint8
+          Type: 3 BaseType uint8
         - Name: clearSeq
           Offset: 40
-          Type: 26 BaseType uint64
+          Type: 8 BaseType uint64
       TablePtrSliceType: 258 GoSliceDataType []*table<bool,main.node>.array
-      GroupType: 141 StructureType noalg.map.group[bool]main.node
+      GroupType: 157 StructureType noalg.map.group[bool]main.node
     - __kind: GoSwissMapHeaderType
-      ID: 61
+      ID: 78
       Name: map<int,int>
       ByteSize: 48
       GoKind: 25
       RawFields:
         - Name: used
           Offset: 0
-          Type: 26 BaseType uint64
+          Type: 8 BaseType uint64
         - Name: seed
           Offset: 8
-          Type: 62 BaseType uintptr
+          Type: 1 BaseType uintptr
         - Name: dirPtr
           Offset: 16
-          Type: 63 PointerType **table<int,int>
+          Type: 79 PointerType **table<int,int>
         - Name: dirLen
           Offset: 24
-          Type: 1 BaseType int
+          Type: 7 BaseType int
         - Name: globalDepth
           Offset: 32
-          Type: 4 BaseType uint8
+          Type: 3 BaseType uint8
         - Name: globalShift
           Offset: 33
-          Type: 4 BaseType uint8
+          Type: 3 BaseType uint8
         - Name: writing
           Offset: 34
-          Type: 4 BaseType uint8
+          Type: 3 BaseType uint8
         - Name: clearSeq
           Offset: 40
-          Type: 26 BaseType uint64
+          Type: 8 BaseType uint64
       TablePtrSliceType: 242 GoSliceDataType []*table<int,int>.array
-      GroupType: 68 StructureType noalg.map.group[int]int
+      GroupType: 84 StructureType noalg.map.group[int]int
     - __kind: GoSwissMapHeaderType
-      ID: 148
+      ID: 164
       Name: map<int,uint8>
       ByteSize: 48
       GoKind: 25
       RawFields:
         - Name: used
           Offset: 0
-          Type: 26 BaseType uint64
+          Type: 8 BaseType uint64
         - Name: seed
           Offset: 8
-          Type: 62 BaseType uintptr
+          Type: 1 BaseType uintptr
         - Name: dirPtr
           Offset: 16
-          Type: 149 PointerType **table<int,uint8>
+          Type: 165 PointerType **table<int,uint8>
         - Name: dirLen
           Offset: 24
-          Type: 1 BaseType int
+          Type: 7 BaseType int
         - Name: globalDepth
           Offset: 32
-          Type: 4 BaseType uint8
+          Type: 3 BaseType uint8
         - Name: globalShift
           Offset: 33
-          Type: 4 BaseType uint8
+          Type: 3 BaseType uint8
         - Name: writing
           Offset: 34
-          Type: 4 BaseType uint8
+          Type: 3 BaseType uint8
         - Name: clearSeq
           Offset: 40
-          Type: 26 BaseType uint64
+          Type: 8 BaseType uint64
       TablePtrSliceType: 260 GoSliceDataType []*table<int,uint8>.array
-      GroupType: 154 StructureType noalg.map.group[int]uint8
+      GroupType: 170 StructureType noalg.map.group[int]uint8
     - __kind: GoSwissMapHeaderType
-      ID: 122
+      ID: 138
       Name: map<string,[]main.structWithMap>
       ByteSize: 48
       GoKind: 25
       RawFields:
         - Name: used
           Offset: 0
-          Type: 26 BaseType uint64
+          Type: 8 BaseType uint64
         - Name: seed
           Offset: 8
-          Type: 62 BaseType uintptr
+          Type: 1 BaseType uintptr
         - Name: dirPtr
           Offset: 16
-          Type: 123 PointerType **table<string,[]main.structWithMap>
+          Type: 139 PointerType **table<string,[]main.structWithMap>
         - Name: dirLen
           Offset: 24
-          Type: 1 BaseType int
+          Type: 7 BaseType int
         - Name: globalDepth
           Offset: 32
-          Type: 4 BaseType uint8
+          Type: 3 BaseType uint8
         - Name: globalShift
           Offset: 33
-          Type: 4 BaseType uint8
+          Type: 3 BaseType uint8
         - Name: writing
           Offset: 34
-          Type: 4 BaseType uint8
+          Type: 3 BaseType uint8
         - Name: clearSeq
           Offset: 40
-          Type: 26 BaseType uint64
+          Type: 8 BaseType uint64
       TablePtrSliceType: 254 GoSliceDataType []*table<string,[]main.structWithMap>.array
-      GroupType: 128 StructureType noalg.map.group[string][]main.structWithMap
+      GroupType: 144 StructureType noalg.map.group[string][]main.structWithMap
     - __kind: GoSwissMapHeaderType
-      ID: 96
+      ID: 112
       Name: map<string,[]string>
       ByteSize: 48
       GoKind: 25
       RawFields:
         - Name: used
           Offset: 0
-          Type: 26 BaseType uint64
+          Type: 8 BaseType uint64
         - Name: seed
           Offset: 8
-          Type: 62 BaseType uintptr
+          Type: 1 BaseType uintptr
         - Name: dirPtr
           Offset: 16
-          Type: 97 PointerType **table<string,[]string>
+          Type: 113 PointerType **table<string,[]string>
         - Name: dirLen
           Offset: 24
-          Type: 1 BaseType int
+          Type: 7 BaseType int
         - Name: globalDepth
           Offset: 32
-          Type: 4 BaseType uint8
+          Type: 3 BaseType uint8
         - Name: globalShift
           Offset: 33
-          Type: 4 BaseType uint8
+          Type: 3 BaseType uint8
         - Name: writing
           Offset: 34
-          Type: 4 BaseType uint8
+          Type: 3 BaseType uint8
         - Name: clearSeq
           Offset: 40
-          Type: 26 BaseType uint64
+          Type: 8 BaseType uint64
       TablePtrSliceType: 248 GoSliceDataType []*table<string,[]string>.array
-      GroupType: 102 StructureType noalg.map.group[string][]string
+      GroupType: 118 StructureType noalg.map.group[string][]string
     - __kind: GoSwissMapHeaderType
-      ID: 85
+      ID: 101
       Name: map<string,int>
       ByteSize: 48
       GoKind: 25
       RawFields:
         - Name: used
           Offset: 0
-          Type: 26 BaseType uint64
+          Type: 8 BaseType uint64
         - Name: seed
           Offset: 8
-          Type: 62 BaseType uintptr
+          Type: 1 BaseType uintptr
         - Name: dirPtr
           Offset: 16
-          Type: 86 PointerType **table<string,int>
+          Type: 102 PointerType **table<string,int>
         - Name: dirLen
           Offset: 24
-          Type: 1 BaseType int
+          Type: 7 BaseType int
         - Name: globalDepth
           Offset: 32
-          Type: 4 BaseType uint8
+          Type: 3 BaseType uint8
         - Name: globalShift
           Offset: 33
-          Type: 4 BaseType uint8
+          Type: 3 BaseType uint8
         - Name: writing
           Offset: 34
-          Type: 4 BaseType uint8
+          Type: 3 BaseType uint8
         - Name: clearSeq
           Offset: 40
-          Type: 26 BaseType uint64
+          Type: 8 BaseType uint64
       TablePtrSliceType: 246 GoSliceDataType []*table<string,int>.array
-      GroupType: 91 StructureType noalg.map.group[string]int
+      GroupType: 107 StructureType noalg.map.group[string]int
     - __kind: GoSwissMapHeaderType
-      ID: 73
+      ID: 89
       Name: map<string,main.nestedStruct>
       ByteSize: 48
       GoKind: 25
       RawFields:
         - Name: used
           Offset: 0
-          Type: 26 BaseType uint64
+          Type: 8 BaseType uint64
         - Name: seed
           Offset: 8
-          Type: 62 BaseType uintptr
+          Type: 1 BaseType uintptr
         - Name: dirPtr
           Offset: 16
-          Type: 74 PointerType **table<string,main.nestedStruct>
+          Type: 90 PointerType **table<string,main.nestedStruct>
         - Name: dirLen
           Offset: 24
-          Type: 1 BaseType int
+          Type: 7 BaseType int
         - Name: globalDepth
           Offset: 32
-          Type: 4 BaseType uint8
+          Type: 3 BaseType uint8
         - Name: globalShift
           Offset: 33
-          Type: 4 BaseType uint8
+          Type: 3 BaseType uint8
         - Name: writing
           Offset: 34
-          Type: 4 BaseType uint8
+          Type: 3 BaseType uint8
         - Name: clearSeq
           Offset: 40
-          Type: 26 BaseType uint64
+          Type: 8 BaseType uint64
       TablePtrSliceType: 244 GoSliceDataType []*table<string,main.nestedStruct>.array
-      GroupType: 79 StructureType noalg.map.group[string]main.nestedStruct
+      GroupType: 95 StructureType noalg.map.group[string]main.nestedStruct
     - __kind: GoSwissMapHeaderType
-      ID: 170
+      ID: 186
       Name: map<uint8,[4]int>
       ByteSize: 48
       GoKind: 25
       RawFields:
         - Name: used
           Offset: 0
-          Type: 26 BaseType uint64
+          Type: 8 BaseType uint64
         - Name: seed
           Offset: 8
-          Type: 62 BaseType uintptr
+          Type: 1 BaseType uintptr
         - Name: dirPtr
           Offset: 16
-          Type: 171 PointerType **table<uint8,[4]int>
+          Type: 187 PointerType **table<uint8,[4]int>
         - Name: dirLen
           Offset: 24
-          Type: 1 BaseType int
+          Type: 7 BaseType int
         - Name: globalDepth
           Offset: 32
-          Type: 4 BaseType uint8
+          Type: 3 BaseType uint8
         - Name: globalShift
           Offset: 33
-          Type: 4 BaseType uint8
+          Type: 3 BaseType uint8
         - Name: writing
           Offset: 34
-          Type: 4 BaseType uint8
+          Type: 3 BaseType uint8
         - Name: clearSeq
           Offset: 40
-          Type: 26 BaseType uint64
+          Type: 8 BaseType uint64
       TablePtrSliceType: 264 GoSliceDataType []*table<uint8,[4]int>.array
-      GroupType: 176 StructureType noalg.map.group[uint8][4]int
+      GroupType: 192 StructureType noalg.map.group[uint8][4]int
     - __kind: GoSwissMapHeaderType
-      ID: 159
+      ID: 175
       Name: map<uint8,uint8>
       ByteSize: 48
       GoKind: 25
       RawFields:
         - Name: used
           Offset: 0
-          Type: 26 BaseType uint64
+          Type: 8 BaseType uint64
         - Name: seed
           Offset: 8
-          Type: 62 BaseType uintptr
+          Type: 1 BaseType uintptr
         - Name: dirPtr
           Offset: 16
-          Type: 160 PointerType **table<uint8,uint8>
+          Type: 176 PointerType **table<uint8,uint8>
         - Name: dirLen
           Offset: 24
-          Type: 1 BaseType int
+          Type: 7 BaseType int
         - Name: globalDepth
           Offset: 32
-          Type: 4 BaseType uint8
+          Type: 3 BaseType uint8
         - Name: globalShift
           Offset: 33
-          Type: 4 BaseType uint8
+          Type: 3 BaseType uint8
         - Name: writing
           Offset: 34
-          Type: 4 BaseType uint8
+          Type: 3 BaseType uint8
         - Name: clearSeq
           Offset: 40
-          Type: 26 BaseType uint64
+          Type: 8 BaseType uint64
       TablePtrSliceType: 262 GoSliceDataType []*table<uint8,uint8>.array
-      GroupType: 165 StructureType noalg.map.group[uint8]uint8
+      GroupType: 181 StructureType noalg.map.group[uint8]uint8
     - __kind: GoMapType
-      ID: 191
+      ID: 207
       Name: map[[4]int][4]int
       ByteSize: 8
       GoRuntimeType: 1.116896e+06
       GoKind: 21
-      HeaderType: 193 GoSwissMapHeaderType map<[4]int,[4]int>
+      HeaderType: 209 GoSwissMapHeaderType map<[4]int,[4]int>
     - __kind: GoMapType
-      ID: 180
+      ID: 196
       Name: map[[4]int]uint8
       ByteSize: 8
       GoRuntimeType: 1.117024e+06
       GoKind: 21
-      HeaderType: 182 GoSwissMapHeaderType map<[4]int,uint8>
+      HeaderType: 198 GoSwissMapHeaderType map<[4]int,uint8>
     - __kind: GoMapType
-      ID: 106
+      ID: 122
       Name: map[[4]string][2]int
       ByteSize: 8
       GoRuntimeType: 1.117152e+06
       GoKind: 21
-      HeaderType: 108 GoSwissMapHeaderType map<[4]string,[2]int>
+      HeaderType: 124 GoSwissMapHeaderType map<[4]string,[2]int>
     - __kind: GoMapType
-      ID: 133
+      ID: 149
       Name: map[bool]main.node
       ByteSize: 8
       GoRuntimeType: 1.11728e+06
       GoKind: 21
-      HeaderType: 135 GoSwissMapHeaderType map<bool,main.node>
+      HeaderType: 151 GoSwissMapHeaderType map<bool,main.node>
     - __kind: GoMapType
-      ID: 59
+      ID: 76
       Name: map[int]int
       ByteSize: 8
       GoRuntimeType: 1.116512e+06
       GoKind: 21
-      HeaderType: 61 GoSwissMapHeaderType map<int,int>
+      HeaderType: 78 GoSwissMapHeaderType map<int,int>
     - __kind: GoMapType
-      ID: 146
+      ID: 162
       Name: map[int]uint8
       ByteSize: 8
       GoRuntimeType: 1.117408e+06
       GoKind: 21
-      HeaderType: 148 GoSwissMapHeaderType map<int,uint8>
+      HeaderType: 164 GoSwissMapHeaderType map<int,uint8>
     - __kind: GoMapType
-      ID: 120
+      ID: 136
       Name: map[string][]main.structWithMap
       ByteSize: 8
       GoRuntimeType: 1.117536e+06
       GoKind: 21
-      HeaderType: 122 GoSwissMapHeaderType map<string,[]main.structWithMap>
+      HeaderType: 138 GoSwissMapHeaderType map<string,[]main.structWithMap>
     - __kind: GoMapType
-      ID: 94
+      ID: 110
       Name: map[string][]string
       ByteSize: 8
       GoRuntimeType: 1.117664e+06
       GoKind: 21
-      HeaderType: 96 GoSwissMapHeaderType map<string,[]string>
+      HeaderType: 112 GoSwissMapHeaderType map<string,[]string>
     - __kind: GoMapType
-      ID: 83
+      ID: 99
       Name: map[string]int
       ByteSize: 8
       GoRuntimeType: 1.117792e+06
       GoKind: 21
-      HeaderType: 85 GoSwissMapHeaderType map<string,int>
+      HeaderType: 101 GoSwissMapHeaderType map<string,int>
     - __kind: GoMapType
-      ID: 71
+      ID: 87
       Name: map[string]main.nestedStruct
       ByteSize: 8
       GoRuntimeType: 1.11792e+06
       GoKind: 21
-      HeaderType: 73 GoSwissMapHeaderType map<string,main.nestedStruct>
+      HeaderType: 89 GoSwissMapHeaderType map<string,main.nestedStruct>
     - __kind: GoMapType
-      ID: 168
+      ID: 184
       Name: map[uint8][4]int
       ByteSize: 8
       GoRuntimeType: 1.118048e+06
       GoKind: 21
-      HeaderType: 170 GoSwissMapHeaderType map<uint8,[4]int>
+      HeaderType: 186 GoSwissMapHeaderType map<uint8,[4]int>
     - __kind: GoMapType
-      ID: 157
+      ID: 173
       Name: map[uint8]uint8
       ByteSize: 8
       GoRuntimeType: 1.118176e+06
       GoKind: 21
-      HeaderType: 159 GoSwissMapHeaderType map<uint8,uint8>
+      HeaderType: 175 GoSwissMapHeaderType map<uint8,uint8>
     - __kind: ArrayType
-      ID: 200
+      ID: 216
       Name: noalg.[8]struct { key [4]int; elem [4]int }
       ByteSize: 512
       GoRuntimeType: 672800
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 201 StructureType noalg.struct { key [4]int; elem [4]int }
+      Element: 217 StructureType noalg.struct { key [4]int; elem [4]int }
     - __kind: ArrayType
-      ID: 189
+      ID: 205
       Name: noalg.[8]struct { key [4]int; elem uint8 }
       ByteSize: 320
       GoRuntimeType: 672896
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 190 StructureType noalg.struct { key [4]int; elem uint8 }
+      Element: 206 StructureType noalg.struct { key [4]int; elem uint8 }
     - __kind: ArrayType
-      ID: 115
+      ID: 131
       Name: noalg.[8]struct { key [4]string; elem [2]int }
       ByteSize: 640
       GoRuntimeType: 673184
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 116 StructureType noalg.struct { key [4]string; elem [2]int }
+      Element: 132 StructureType noalg.struct { key [4]string; elem [2]int }
     - __kind: ArrayType
-      ID: 142
+      ID: 158
       Name: noalg.[8]struct { key bool; elem main.node }
       ByteSize: 192
       GoRuntimeType: 673280
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 143 StructureType noalg.struct { key bool; elem main.node }
+      Element: 159 StructureType noalg.struct { key bool; elem main.node }
     - __kind: ArrayType
-      ID: 69
+      ID: 85
       Name: noalg.[8]struct { key int; elem int }
       ByteSize: 128
       GoRuntimeType: 671072
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 70 StructureType noalg.struct { key int; elem int }
+      Element: 86 StructureType noalg.struct { key int; elem int }
     - __kind: ArrayType
-      ID: 155
+      ID: 171
       Name: noalg.[8]struct { key int; elem uint8 }
       ByteSize: 128
       GoRuntimeType: 673376
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 156 StructureType noalg.struct { key int; elem uint8 }
+      Element: 172 StructureType noalg.struct { key int; elem uint8 }
     - __kind: ArrayType
-      ID: 129
+      ID: 145
       Name: noalg.[8]struct { key string; elem []main.structWithMap }
       ByteSize: 320
       GoRuntimeType: 673472
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 130 StructureType noalg.struct { key string; elem []main.structWithMap }
+      Element: 146 StructureType noalg.struct { key string; elem []main.structWithMap }
     - __kind: ArrayType
-      ID: 103
+      ID: 119
       Name: noalg.[8]struct { key string; elem []string }
       ByteSize: 320
       GoRuntimeType: 673568
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 104 StructureType noalg.struct { key string; elem []string }
+      Element: 120 StructureType noalg.struct { key string; elem []string }
     - __kind: ArrayType
-      ID: 92
+      ID: 108
       Name: noalg.[8]struct { key string; elem int }
       ByteSize: 192
       GoRuntimeType: 673664
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 93 StructureType noalg.struct { key string; elem int }
+      Element: 109 StructureType noalg.struct { key string; elem int }
     - __kind: ArrayType
-      ID: 80
+      ID: 96
       Name: noalg.[8]struct { key string; elem main.nestedStruct }
       ByteSize: 320
       GoRuntimeType: 673760
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 81 StructureType noalg.struct { key string; elem main.nestedStruct }
+      Element: 97 StructureType noalg.struct { key string; elem main.nestedStruct }
     - __kind: ArrayType
-      ID: 177
+      ID: 193
       Name: noalg.[8]struct { key uint8; elem [4]int }
       ByteSize: 320
       GoRuntimeType: 673856
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 178 StructureType noalg.struct { key uint8; elem [4]int }
+      Element: 194 StructureType noalg.struct { key uint8; elem [4]int }
     - __kind: ArrayType
-      ID: 166
+      ID: 182
       Name: noalg.[8]struct { key uint8; elem uint8 }
       ByteSize: 16
       GoRuntimeType: 673952
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 167 StructureType noalg.struct { key uint8; elem uint8 }
+      Element: 183 StructureType noalg.struct { key uint8; elem uint8 }
     - __kind: StructureType
-      ID: 199
+      ID: 215
       Name: noalg.map.group[[4]int][4]int
       ByteSize: 520
       GoRuntimeType: 1.276576e+06
@@ -6762,12 +6762,12 @@ Types:
       RawFields:
         - Name: ctrl
           Offset: 0
-          Type: 26 BaseType uint64
+          Type: 8 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 200 ArrayType noalg.[8]struct { key [4]int; elem [4]int }
+          Type: 216 ArrayType noalg.[8]struct { key [4]int; elem [4]int }
     - __kind: StructureType
-      ID: 188
+      ID: 204
       Name: noalg.map.group[[4]int]uint8
       ByteSize: 328
       GoRuntimeType: 1.276832e+06
@@ -6775,12 +6775,12 @@ Types:
       RawFields:
         - Name: ctrl
           Offset: 0
-          Type: 26 BaseType uint64
+          Type: 8 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 189 ArrayType noalg.[8]struct { key [4]int; elem uint8 }
+          Type: 205 ArrayType noalg.[8]struct { key [4]int; elem uint8 }
     - __kind: StructureType
-      ID: 114
+      ID: 130
       Name: noalg.map.group[[4]string][2]int
       ByteSize: 648
       GoRuntimeType: 1.277088e+06
@@ -6788,12 +6788,12 @@ Types:
       RawFields:
         - Name: ctrl
           Offset: 0
-          Type: 26 BaseType uint64
+          Type: 8 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 115 ArrayType noalg.[8]struct { key [4]string; elem [2]int }
+          Type: 131 ArrayType noalg.[8]struct { key [4]string; elem [2]int }
     - __kind: StructureType
-      ID: 141
+      ID: 157
       Name: noalg.map.group[bool]main.node
       ByteSize: 200
       GoRuntimeType: 1.277344e+06
@@ -6801,12 +6801,12 @@ Types:
       RawFields:
         - Name: ctrl
           Offset: 0
-          Type: 26 BaseType uint64
+          Type: 8 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 142 ArrayType noalg.[8]struct { key bool; elem main.node }
+          Type: 158 ArrayType noalg.[8]struct { key bool; elem main.node }
     - __kind: StructureType
-      ID: 68
+      ID: 84
       Name: noalg.map.group[int]int
       ByteSize: 136
       GoRuntimeType: 1.275808e+06
@@ -6814,12 +6814,12 @@ Types:
       RawFields:
         - Name: ctrl
           Offset: 0
-          Type: 26 BaseType uint64
+          Type: 8 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 69 ArrayType noalg.[8]struct { key int; elem int }
+          Type: 85 ArrayType noalg.[8]struct { key int; elem int }
     - __kind: StructureType
-      ID: 154
+      ID: 170
       Name: noalg.map.group[int]uint8
       ByteSize: 136
       GoRuntimeType: 1.2776e+06
@@ -6827,12 +6827,12 @@ Types:
       RawFields:
         - Name: ctrl
           Offset: 0
-          Type: 26 BaseType uint64
+          Type: 8 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 155 ArrayType noalg.[8]struct { key int; elem uint8 }
+          Type: 171 ArrayType noalg.[8]struct { key int; elem uint8 }
     - __kind: StructureType
-      ID: 128
+      ID: 144
       Name: noalg.map.group[string][]main.structWithMap
       ByteSize: 328
       GoRuntimeType: 1.277856e+06
@@ -6840,12 +6840,12 @@ Types:
       RawFields:
         - Name: ctrl
           Offset: 0
-          Type: 26 BaseType uint64
+          Type: 8 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 129 ArrayType noalg.[8]struct { key string; elem []main.structWithMap }
+          Type: 145 ArrayType noalg.[8]struct { key string; elem []main.structWithMap }
     - __kind: StructureType
-      ID: 102
+      ID: 118
       Name: noalg.map.group[string][]string
       ByteSize: 328
       GoRuntimeType: 1.278112e+06
@@ -6853,12 +6853,12 @@ Types:
       RawFields:
         - Name: ctrl
           Offset: 0
-          Type: 26 BaseType uint64
+          Type: 8 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 103 ArrayType noalg.[8]struct { key string; elem []string }
+          Type: 119 ArrayType noalg.[8]struct { key string; elem []string }
     - __kind: StructureType
-      ID: 91
+      ID: 107
       Name: noalg.map.group[string]int
       ByteSize: 200
       GoRuntimeType: 1.278368e+06
@@ -6866,12 +6866,12 @@ Types:
       RawFields:
         - Name: ctrl
           Offset: 0
-          Type: 26 BaseType uint64
+          Type: 8 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 92 ArrayType noalg.[8]struct { key string; elem int }
+          Type: 108 ArrayType noalg.[8]struct { key string; elem int }
     - __kind: StructureType
-      ID: 79
+      ID: 95
       Name: noalg.map.group[string]main.nestedStruct
       ByteSize: 328
       GoRuntimeType: 1.278624e+06
@@ -6879,12 +6879,12 @@ Types:
       RawFields:
         - Name: ctrl
           Offset: 0
-          Type: 26 BaseType uint64
+          Type: 8 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 80 ArrayType noalg.[8]struct { key string; elem main.nestedStruct }
+          Type: 96 ArrayType noalg.[8]struct { key string; elem main.nestedStruct }
     - __kind: StructureType
-      ID: 176
+      ID: 192
       Name: noalg.map.group[uint8][4]int
       ByteSize: 328
       GoRuntimeType: 1.27888e+06
@@ -6892,12 +6892,12 @@ Types:
       RawFields:
         - Name: ctrl
           Offset: 0
-          Type: 26 BaseType uint64
+          Type: 8 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 177 ArrayType noalg.[8]struct { key uint8; elem [4]int }
+          Type: 193 ArrayType noalg.[8]struct { key uint8; elem [4]int }
     - __kind: StructureType
-      ID: 165
+      ID: 181
       Name: noalg.map.group[uint8]uint8
       ByteSize: 24
       GoRuntimeType: 1.279136e+06
@@ -6905,12 +6905,12 @@ Types:
       RawFields:
         - Name: ctrl
           Offset: 0
-          Type: 26 BaseType uint64
+          Type: 8 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 166 ArrayType noalg.[8]struct { key uint8; elem uint8 }
+          Type: 182 ArrayType noalg.[8]struct { key uint8; elem uint8 }
     - __kind: StructureType
-      ID: 201
+      ID: 217
       Name: noalg.struct { key [4]int; elem [4]int }
       ByteSize: 64
       GoRuntimeType: 1.276448e+06
@@ -6918,12 +6918,12 @@ Types:
       RawFields:
         - Name: key
           Offset: 0
-          Type: 179 ArrayType [4]int
+          Type: 195 ArrayType [4]int
         - Name: elem
           Offset: 32
-          Type: 179 ArrayType [4]int
+          Type: 195 ArrayType [4]int
     - __kind: StructureType
-      ID: 190
+      ID: 206
       Name: noalg.struct { key [4]int; elem uint8 }
       ByteSize: 40
       GoRuntimeType: 1.276704e+06
@@ -6931,12 +6931,12 @@ Types:
       RawFields:
         - Name: key
           Offset: 0
-          Type: 179 ArrayType [4]int
+          Type: 195 ArrayType [4]int
         - Name: elem
           Offset: 32
-          Type: 4 BaseType uint8
+          Type: 3 BaseType uint8
     - __kind: StructureType
-      ID: 116
+      ID: 132
       Name: noalg.struct { key [4]string; elem [2]int }
       ByteSize: 80
       GoRuntimeType: 1.27696e+06
@@ -6944,12 +6944,12 @@ Types:
       RawFields:
         - Name: key
           Offset: 0
-          Type: 117 ArrayType [4]string
+          Type: 133 ArrayType [4]string
         - Name: elem
           Offset: 64
-          Type: 12 ArrayType [2]int
+          Type: 40 ArrayType [2]int
     - __kind: StructureType
-      ID: 143
+      ID: 159
       Name: noalg.struct { key bool; elem main.node }
       ByteSize: 24
       GoRuntimeType: 1.277216e+06
@@ -6957,12 +6957,12 @@ Types:
       RawFields:
         - Name: key
           Offset: 0
-          Type: 11 BaseType bool
+          Type: 4 BaseType bool
         - Name: elem
           Offset: 8
-          Type: 144 StructureType main.node
+          Type: 160 StructureType main.node
     - __kind: StructureType
-      ID: 70
+      ID: 86
       Name: noalg.struct { key int; elem int }
       ByteSize: 16
       GoRuntimeType: 1.27568e+06
@@ -6970,12 +6970,12 @@ Types:
       RawFields:
         - Name: key
           Offset: 0
-          Type: 1 BaseType int
+          Type: 7 BaseType int
         - Name: elem
           Offset: 8
-          Type: 1 BaseType int
+          Type: 7 BaseType int
     - __kind: StructureType
-      ID: 156
+      ID: 172
       Name: noalg.struct { key int; elem uint8 }
       ByteSize: 16
       GoRuntimeType: 1.277472e+06
@@ -6983,12 +6983,12 @@ Types:
       RawFields:
         - Name: key
           Offset: 0
-          Type: 1 BaseType int
+          Type: 7 BaseType int
         - Name: elem
           Offset: 8
-          Type: 4 BaseType uint8
+          Type: 3 BaseType uint8
     - __kind: StructureType
-      ID: 130
+      ID: 146
       Name: noalg.struct { key string; elem []main.structWithMap }
       ByteSize: 40
       GoRuntimeType: 1.277728e+06
@@ -6996,12 +6996,12 @@ Types:
       RawFields:
         - Name: key
           Offset: 0
-          Type: 8 GoStringHeaderType string
+          Type: 9 GoStringHeaderType string
         - Name: elem
           Offset: 16
-          Type: 131 GoSliceHeaderType []main.structWithMap
+          Type: 147 GoSliceHeaderType []main.structWithMap
     - __kind: StructureType
-      ID: 104
+      ID: 120
       Name: noalg.struct { key string; elem []string }
       ByteSize: 40
       GoRuntimeType: 1.277984e+06
@@ -7009,12 +7009,12 @@ Types:
       RawFields:
         - Name: key
           Offset: 0
-          Type: 8 GoStringHeaderType string
+          Type: 9 GoStringHeaderType string
         - Name: elem
           Offset: 16
-          Type: 105 GoSliceHeaderType []string
+          Type: 121 GoSliceHeaderType []string
     - __kind: StructureType
-      ID: 93
+      ID: 109
       Name: noalg.struct { key string; elem int }
       ByteSize: 24
       GoRuntimeType: 1.27824e+06
@@ -7022,12 +7022,12 @@ Types:
       RawFields:
         - Name: key
           Offset: 0
-          Type: 8 GoStringHeaderType string
+          Type: 9 GoStringHeaderType string
         - Name: elem
           Offset: 16
-          Type: 1 BaseType int
+          Type: 7 BaseType int
     - __kind: StructureType
-      ID: 81
+      ID: 97
       Name: noalg.struct { key string; elem main.nestedStruct }
       ByteSize: 40
       GoRuntimeType: 1.278496e+06
@@ -7035,12 +7035,12 @@ Types:
       RawFields:
         - Name: key
           Offset: 0
-          Type: 8 GoStringHeaderType string
+          Type: 9 GoStringHeaderType string
         - Name: elem
           Offset: 16
-          Type: 82 StructureType main.nestedStruct
+          Type: 98 StructureType main.nestedStruct
     - __kind: StructureType
-      ID: 178
+      ID: 194
       Name: noalg.struct { key uint8; elem [4]int }
       ByteSize: 40
       GoRuntimeType: 1.278752e+06
@@ -7048,12 +7048,12 @@ Types:
       RawFields:
         - Name: key
           Offset: 0
-          Type: 4 BaseType uint8
+          Type: 3 BaseType uint8
         - Name: elem
           Offset: 8
-          Type: 179 ArrayType [4]int
+          Type: 195 ArrayType [4]int
     - __kind: StructureType
-      ID: 167
+      ID: 183
       Name: noalg.struct { key uint8; elem uint8 }
       ByteSize: 2
       GoRuntimeType: 1.279008e+06
@@ -7061,12 +7061,12 @@ Types:
       RawFields:
         - Name: key
           Offset: 0
-          Type: 4 BaseType uint8
+          Type: 3 BaseType uint8
         - Name: elem
           Offset: 1
-          Type: 4 BaseType uint8
+          Type: 3 BaseType uint8
     - __kind: GoStringHeaderType
-      ID: 8
+      ID: 9
       Name: string
       ByteSize: 16
       GoRuntimeType: 574816
@@ -7077,14 +7077,14 @@ Types:
           Type: 239 PointerType *string.str
         - Name: len
           Offset: 8
-          Type: 1 BaseType int
+          Type: 7 BaseType int
       Data: 238 GoStringDataType string.str
     - __kind: GoStringDataType
       ID: 238
       Name: string.str
       ByteSize: 2048
     - __kind: StructureType
-      ID: 46
+      ID: 63
       Name: sync.Mutex
       ByteSize: 8
       GoRuntimeType: 1.444672e+06
@@ -7092,12 +7092,12 @@ Types:
       RawFields:
         - Name: _
           Offset: 0
-          Type: 47 StructureType sync.noCopy
+          Type: 64 StructureType sync.noCopy
         - Name: mu
           Offset: 0
-          Type: 48 StructureType internal/sync.Mutex
+          Type: 65 StructureType internal/sync.Mutex
     - __kind: StructureType
-      ID: 49
+      ID: 66
       Name: sync.Once
       ByteSize: 12
       GoRuntimeType: 1.593184e+06
@@ -7105,15 +7105,15 @@ Types:
       RawFields:
         - Name: _
           Offset: 0
-          Type: 47 StructureType sync.noCopy
+          Type: 64 StructureType sync.noCopy
         - Name: done
           Offset: 0
-          Type: 50 StructureType sync/atomic.Uint32
+          Type: 67 StructureType sync/atomic.Uint32
         - Name: m
           Offset: 4
-          Type: 46 StructureType sync.Mutex
+          Type: 63 StructureType sync.Mutex
     - __kind: StructureType
-      ID: 52
+      ID: 69
       Name: sync.WaitGroup
       ByteSize: 16
       GoRuntimeType: 1.593376e+06
@@ -7121,21 +7121,21 @@ Types:
       RawFields:
         - Name: noCopy
           Offset: 0
-          Type: 47 StructureType sync.noCopy
+          Type: 64 StructureType sync.noCopy
         - Name: state
           Offset: 0
-          Type: 53 StructureType sync/atomic.Uint64
+          Type: 70 StructureType sync/atomic.Uint64
         - Name: sema
           Offset: 8
-          Type: 24 BaseType uint32
+          Type: 2 BaseType uint32
     - __kind: StructureType
-      ID: 47
+      ID: 64
       Name: sync.noCopy
       GoRuntimeType: 977056
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 55
+      ID: 72
       Name: sync/atomic.Int32
       ByteSize: 4
       GoRuntimeType: 1.445952e+06
@@ -7143,12 +7143,12 @@ Types:
       RawFields:
         - Name: _
           Offset: 0
-          Type: 51 StructureType sync/atomic.noCopy
+          Type: 68 StructureType sync/atomic.noCopy
         - Name: v
           Offset: 0
-          Type: 6 BaseType int32
+          Type: 12 BaseType int32
     - __kind: StructureType
-      ID: 50
+      ID: 67
       Name: sync/atomic.Uint32
       ByteSize: 4
       GoRuntimeType: 1.446112e+06
@@ -7156,12 +7156,12 @@ Types:
       RawFields:
         - Name: _
           Offset: 0
-          Type: 51 StructureType sync/atomic.noCopy
+          Type: 68 StructureType sync/atomic.noCopy
         - Name: v
           Offset: 0
-          Type: 24 BaseType uint32
+          Type: 2 BaseType uint32
     - __kind: StructureType
-      ID: 53
+      ID: 70
       Name: sync/atomic.Uint64
       ByteSize: 8
       GoRuntimeType: 1.59376e+06
@@ -7169,351 +7169,351 @@ Types:
       RawFields:
         - Name: _
           Offset: 0
-          Type: 51 StructureType sync/atomic.noCopy
+          Type: 68 StructureType sync/atomic.noCopy
         - Name: _
           Offset: 0
-          Type: 54 StructureType sync/atomic.align64
+          Type: 71 StructureType sync/atomic.align64
         - Name: v
           Offset: 0
-          Type: 26 BaseType uint64
+          Type: 8 BaseType uint64
     - __kind: StructureType
-      ID: 54
+      ID: 71
       Name: sync/atomic.align64
       GoRuntimeType: 977248
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 51
+      ID: 68
       Name: sync/atomic.noCopy
       GoRuntimeType: 977152
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 196
+      ID: 212
       Name: table<[4]int,[4]int>
       ByteSize: 32
       GoKind: 25
       RawFields:
         - Name: used
           Offset: 0
-          Type: 22 BaseType uint16
+          Type: 6 BaseType uint16
         - Name: capacity
           Offset: 2
-          Type: 22 BaseType uint16
+          Type: 6 BaseType uint16
         - Name: growthLeft
           Offset: 4
-          Type: 22 BaseType uint16
+          Type: 6 BaseType uint16
         - Name: localDepth
           Offset: 6
-          Type: 4 BaseType uint8
+          Type: 3 BaseType uint8
         - Name: index
           Offset: 8
-          Type: 1 BaseType int
+          Type: 7 BaseType int
         - Name: groups
           Offset: 16
-          Type: 197 GoSwissMapGroupsType groupReference<[4]int,[4]int>
+          Type: 213 GoSwissMapGroupsType groupReference<[4]int,[4]int>
     - __kind: StructureType
-      ID: 185
+      ID: 201
       Name: table<[4]int,uint8>
       ByteSize: 32
       GoKind: 25
       RawFields:
         - Name: used
           Offset: 0
-          Type: 22 BaseType uint16
+          Type: 6 BaseType uint16
         - Name: capacity
           Offset: 2
-          Type: 22 BaseType uint16
+          Type: 6 BaseType uint16
         - Name: growthLeft
           Offset: 4
-          Type: 22 BaseType uint16
+          Type: 6 BaseType uint16
         - Name: localDepth
           Offset: 6
-          Type: 4 BaseType uint8
+          Type: 3 BaseType uint8
         - Name: index
           Offset: 8
-          Type: 1 BaseType int
+          Type: 7 BaseType int
         - Name: groups
           Offset: 16
-          Type: 186 GoSwissMapGroupsType groupReference<[4]int,uint8>
+          Type: 202 GoSwissMapGroupsType groupReference<[4]int,uint8>
     - __kind: StructureType
-      ID: 111
+      ID: 127
       Name: table<[4]string,[2]int>
       ByteSize: 32
       GoKind: 25
       RawFields:
         - Name: used
           Offset: 0
-          Type: 22 BaseType uint16
+          Type: 6 BaseType uint16
         - Name: capacity
           Offset: 2
-          Type: 22 BaseType uint16
+          Type: 6 BaseType uint16
         - Name: growthLeft
           Offset: 4
-          Type: 22 BaseType uint16
+          Type: 6 BaseType uint16
         - Name: localDepth
           Offset: 6
-          Type: 4 BaseType uint8
+          Type: 3 BaseType uint8
         - Name: index
           Offset: 8
-          Type: 1 BaseType int
+          Type: 7 BaseType int
         - Name: groups
           Offset: 16
-          Type: 112 GoSwissMapGroupsType groupReference<[4]string,[2]int>
+          Type: 128 GoSwissMapGroupsType groupReference<[4]string,[2]int>
     - __kind: StructureType
-      ID: 138
+      ID: 154
       Name: table<bool,main.node>
       ByteSize: 32
       GoKind: 25
       RawFields:
         - Name: used
           Offset: 0
-          Type: 22 BaseType uint16
+          Type: 6 BaseType uint16
         - Name: capacity
           Offset: 2
-          Type: 22 BaseType uint16
+          Type: 6 BaseType uint16
         - Name: growthLeft
           Offset: 4
-          Type: 22 BaseType uint16
+          Type: 6 BaseType uint16
         - Name: localDepth
           Offset: 6
-          Type: 4 BaseType uint8
+          Type: 3 BaseType uint8
         - Name: index
           Offset: 8
-          Type: 1 BaseType int
+          Type: 7 BaseType int
         - Name: groups
           Offset: 16
-          Type: 139 GoSwissMapGroupsType groupReference<bool,main.node>
+          Type: 155 GoSwissMapGroupsType groupReference<bool,main.node>
     - __kind: StructureType
-      ID: 65
+      ID: 81
       Name: table<int,int>
       ByteSize: 32
       GoKind: 25
       RawFields:
         - Name: used
           Offset: 0
-          Type: 22 BaseType uint16
+          Type: 6 BaseType uint16
         - Name: capacity
           Offset: 2
-          Type: 22 BaseType uint16
+          Type: 6 BaseType uint16
         - Name: growthLeft
           Offset: 4
-          Type: 22 BaseType uint16
+          Type: 6 BaseType uint16
         - Name: localDepth
           Offset: 6
-          Type: 4 BaseType uint8
+          Type: 3 BaseType uint8
         - Name: index
           Offset: 8
-          Type: 1 BaseType int
+          Type: 7 BaseType int
         - Name: groups
           Offset: 16
-          Type: 66 GoSwissMapGroupsType groupReference<int,int>
+          Type: 82 GoSwissMapGroupsType groupReference<int,int>
     - __kind: StructureType
-      ID: 151
+      ID: 167
       Name: table<int,uint8>
       ByteSize: 32
       GoKind: 25
       RawFields:
         - Name: used
           Offset: 0
-          Type: 22 BaseType uint16
+          Type: 6 BaseType uint16
         - Name: capacity
           Offset: 2
-          Type: 22 BaseType uint16
+          Type: 6 BaseType uint16
         - Name: growthLeft
           Offset: 4
-          Type: 22 BaseType uint16
+          Type: 6 BaseType uint16
         - Name: localDepth
           Offset: 6
-          Type: 4 BaseType uint8
+          Type: 3 BaseType uint8
         - Name: index
           Offset: 8
-          Type: 1 BaseType int
+          Type: 7 BaseType int
         - Name: groups
           Offset: 16
-          Type: 152 GoSwissMapGroupsType groupReference<int,uint8>
+          Type: 168 GoSwissMapGroupsType groupReference<int,uint8>
     - __kind: StructureType
-      ID: 125
+      ID: 141
       Name: table<string,[]main.structWithMap>
       ByteSize: 32
       GoKind: 25
       RawFields:
         - Name: used
           Offset: 0
-          Type: 22 BaseType uint16
+          Type: 6 BaseType uint16
         - Name: capacity
           Offset: 2
-          Type: 22 BaseType uint16
+          Type: 6 BaseType uint16
         - Name: growthLeft
           Offset: 4
-          Type: 22 BaseType uint16
+          Type: 6 BaseType uint16
         - Name: localDepth
           Offset: 6
-          Type: 4 BaseType uint8
+          Type: 3 BaseType uint8
         - Name: index
           Offset: 8
-          Type: 1 BaseType int
+          Type: 7 BaseType int
         - Name: groups
           Offset: 16
-          Type: 126 GoSwissMapGroupsType groupReference<string,[]main.structWithMap>
+          Type: 142 GoSwissMapGroupsType groupReference<string,[]main.structWithMap>
     - __kind: StructureType
-      ID: 99
+      ID: 115
       Name: table<string,[]string>
       ByteSize: 32
       GoKind: 25
       RawFields:
         - Name: used
           Offset: 0
-          Type: 22 BaseType uint16
+          Type: 6 BaseType uint16
         - Name: capacity
           Offset: 2
-          Type: 22 BaseType uint16
+          Type: 6 BaseType uint16
         - Name: growthLeft
           Offset: 4
-          Type: 22 BaseType uint16
+          Type: 6 BaseType uint16
         - Name: localDepth
           Offset: 6
-          Type: 4 BaseType uint8
+          Type: 3 BaseType uint8
         - Name: index
           Offset: 8
-          Type: 1 BaseType int
+          Type: 7 BaseType int
         - Name: groups
           Offset: 16
-          Type: 100 GoSwissMapGroupsType groupReference<string,[]string>
+          Type: 116 GoSwissMapGroupsType groupReference<string,[]string>
     - __kind: StructureType
-      ID: 88
+      ID: 104
       Name: table<string,int>
       ByteSize: 32
       GoKind: 25
       RawFields:
         - Name: used
           Offset: 0
-          Type: 22 BaseType uint16
+          Type: 6 BaseType uint16
         - Name: capacity
           Offset: 2
-          Type: 22 BaseType uint16
+          Type: 6 BaseType uint16
         - Name: growthLeft
           Offset: 4
-          Type: 22 BaseType uint16
+          Type: 6 BaseType uint16
         - Name: localDepth
           Offset: 6
-          Type: 4 BaseType uint8
+          Type: 3 BaseType uint8
         - Name: index
           Offset: 8
-          Type: 1 BaseType int
+          Type: 7 BaseType int
         - Name: groups
           Offset: 16
-          Type: 89 GoSwissMapGroupsType groupReference<string,int>
+          Type: 105 GoSwissMapGroupsType groupReference<string,int>
     - __kind: StructureType
-      ID: 76
+      ID: 92
       Name: table<string,main.nestedStruct>
       ByteSize: 32
       GoKind: 25
       RawFields:
         - Name: used
           Offset: 0
-          Type: 22 BaseType uint16
+          Type: 6 BaseType uint16
         - Name: capacity
           Offset: 2
-          Type: 22 BaseType uint16
+          Type: 6 BaseType uint16
         - Name: growthLeft
           Offset: 4
-          Type: 22 BaseType uint16
+          Type: 6 BaseType uint16
         - Name: localDepth
           Offset: 6
-          Type: 4 BaseType uint8
+          Type: 3 BaseType uint8
         - Name: index
           Offset: 8
-          Type: 1 BaseType int
+          Type: 7 BaseType int
         - Name: groups
           Offset: 16
-          Type: 77 GoSwissMapGroupsType groupReference<string,main.nestedStruct>
+          Type: 93 GoSwissMapGroupsType groupReference<string,main.nestedStruct>
     - __kind: StructureType
-      ID: 173
+      ID: 189
       Name: table<uint8,[4]int>
       ByteSize: 32
       GoKind: 25
       RawFields:
         - Name: used
           Offset: 0
-          Type: 22 BaseType uint16
+          Type: 6 BaseType uint16
         - Name: capacity
           Offset: 2
-          Type: 22 BaseType uint16
+          Type: 6 BaseType uint16
         - Name: growthLeft
           Offset: 4
-          Type: 22 BaseType uint16
+          Type: 6 BaseType uint16
         - Name: localDepth
           Offset: 6
-          Type: 4 BaseType uint8
+          Type: 3 BaseType uint8
         - Name: index
           Offset: 8
-          Type: 1 BaseType int
+          Type: 7 BaseType int
         - Name: groups
           Offset: 16
-          Type: 174 GoSwissMapGroupsType groupReference<uint8,[4]int>
+          Type: 190 GoSwissMapGroupsType groupReference<uint8,[4]int>
     - __kind: StructureType
-      ID: 162
+      ID: 178
       Name: table<uint8,uint8>
       ByteSize: 32
       GoKind: 25
       RawFields:
         - Name: used
           Offset: 0
-          Type: 22 BaseType uint16
+          Type: 6 BaseType uint16
         - Name: capacity
           Offset: 2
-          Type: 22 BaseType uint16
+          Type: 6 BaseType uint16
         - Name: growthLeft
           Offset: 4
-          Type: 22 BaseType uint16
+          Type: 6 BaseType uint16
         - Name: localDepth
           Offset: 6
-          Type: 4 BaseType uint8
+          Type: 3 BaseType uint8
         - Name: index
           Offset: 8
-          Type: 1 BaseType int
+          Type: 7 BaseType int
         - Name: groups
           Offset: 16
-          Type: 163 GoSwissMapGroupsType groupReference<uint8,uint8>
+          Type: 179 GoSwissMapGroupsType groupReference<uint8,uint8>
     - __kind: BaseType
-      ID: 20
+      ID: 10
       Name: uint
       ByteSize: 8
       GoRuntimeType: 575456
       GoKind: 7
     - __kind: BaseType
-      ID: 22
+      ID: 6
       Name: uint16
       ByteSize: 2
       GoRuntimeType: 575072
       GoKind: 9
     - __kind: BaseType
-      ID: 24
+      ID: 2
       Name: uint32
       ByteSize: 4
       GoRuntimeType: 575200
       GoKind: 10
     - __kind: BaseType
-      ID: 26
+      ID: 8
       Name: uint64
       ByteSize: 8
       GoRuntimeType: 575328
       GoKind: 11
     - __kind: BaseType
-      ID: 4
+      ID: 3
       Name: uint8
       ByteSize: 1
       GoRuntimeType: 574944
       GoKind: 8
     - __kind: BaseType
-      ID: 62
+      ID: 1
       Name: uintptr
       ByteSize: 8
       GoRuntimeType: 575520
       GoKind: 12
     - __kind: VoidPointerType
-      ID: 38
+      ID: 15
       Name: unsafe.Pointer
       ByteSize: 8
       GoRuntimeType: 575904

--- a/pkg/dyninst/irgen/testdata/snapshot/sample.arch=arm64,toolchain=go1.24.3.yaml
+++ b/pkg/dyninst/irgen/testdata/snapshot/sample.arch=arm64,toolchain=go1.24.3.yaml
@@ -8,11 +8,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 88}
+      subprogram: {subprogram: 96}
       events:
-        - ID: 88
-          Type: 369 EventRootType Probe[main.stackC]
-          InjectionPoints: [{PC: "0x84cd6c", Frameless: true}]
+        - ID: 96
+          Type: 502 EventRootType Probe[main.stackC]
+          InjectionPoints: [{PC: "0x84d77c", Frameless: true}]
           Condition: null
     - id: testAny
       version: 0
@@ -22,11 +22,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 45}
+      subprogram: {subprogram: 53}
       events:
-        - ID: 45
-          Type: 326 EventRootType Probe[main.testAny]
-          InjectionPoints: [{PC: "0x84a85c", Frameless: true}]
+        - ID: 53
+          Type: 459 EventRootType Probe[main.testAny]
+          InjectionPoints: [{PC: "0x84b26c", Frameless: true}]
           Condition: null
     - id: testArrayOfArrays
       version: 0
@@ -39,8 +39,8 @@ Probes:
       subprogram: {subprogram: 15}
       events:
         - ID: 15
-          Type: 296 EventRootType Probe[main.testArrayOfArrays]
-          InjectionPoints: [{PC: "0x849620", Frameless: true}]
+          Type: 421 EventRootType Probe[main.testArrayOfArrays]
+          InjectionPoints: [{PC: "0x849a50", Frameless: true}]
           Condition: null
     - id: testArrayOfArraysOfArrays
       version: 0
@@ -53,8 +53,8 @@ Probes:
       subprogram: {subprogram: 17}
       events:
         - ID: 17
-          Type: 298 EventRootType Probe[main.testArrayOfArraysOfArrays]
-          InjectionPoints: [{PC: "0x849640", Frameless: true}]
+          Type: 423 EventRootType Probe[main.testArrayOfArraysOfArrays]
+          InjectionPoints: [{PC: "0x849a70", Frameless: true}]
           Condition: null
     - id: testArrayOfMaps
       version: 0
@@ -64,11 +64,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 53}
+      subprogram: {subprogram: 61}
       events:
-        - ID: 53
-          Type: 334 EventRootType Probe[main.testArrayOfMaps]
-          InjectionPoints: [{PC: "0x84ad40", Frameless: true}]
+        - ID: 61
+          Type: 467 EventRootType Probe[main.testArrayOfMaps]
+          InjectionPoints: [{PC: "0x84b750", Frameless: true}]
           Condition: null
     - id: testArrayOfStrings
       version: 0
@@ -81,8 +81,8 @@ Probes:
       subprogram: {subprogram: 16}
       events:
         - ID: 16
-          Type: 297 EventRootType Probe[main.testArrayOfStrings]
-          InjectionPoints: [{PC: "0x849630", Frameless: true}]
+          Type: 422 EventRootType Probe[main.testArrayOfStrings]
+          InjectionPoints: [{PC: "0x849a60", Frameless: true}]
           Condition: null
     - id: testBigStruct
       version: 0
@@ -95,8 +95,8 @@ Probes:
       subprogram: {subprogram: 35}
       events:
         - ID: 35
-          Type: 316 EventRootType Probe[main.testBigStruct]
-          InjectionPoints: [{PC: "0x849ba0", Frameless: true}]
+          Type: 441 EventRootType Probe[main.testBigStruct]
+          InjectionPoints: [{PC: "0x849fd0", Frameless: true}]
           Condition: null
     - id: testBoolArray
       version: 0
@@ -109,8 +109,8 @@ Probes:
       subprogram: {subprogram: 4}
       events:
         - ID: 4
-          Type: 285 EventRootType Probe[main.testBoolArray]
-          InjectionPoints: [{PC: "0x849570", Frameless: true}]
+          Type: 410 EventRootType Probe[main.testBoolArray]
+          InjectionPoints: [{PC: "0x8499a0", Frameless: true}]
           Condition: null
     - id: testByteArray
       version: 0
@@ -123,8 +123,8 @@ Probes:
       subprogram: {subprogram: 1}
       events:
         - ID: 1
-          Type: 282 EventRootType Probe[main.testByteArray]
-          InjectionPoints: [{PC: "0x849540", Frameless: true}]
+          Type: 407 EventRootType Probe[main.testByteArray]
+          InjectionPoints: [{PC: "0x849970", Frameless: true}]
           Condition: null
     - id: testChannel
       version: 0
@@ -134,11 +134,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 69}
+      subprogram: {subprogram: 77}
       events:
-        - ID: 69
-          Type: 350 EventRootType Probe[main.testChannel]
-          InjectionPoints: [{PC: "0x84c390", Frameless: true}]
+        - ID: 77
+          Type: 483 EventRootType Probe[main.testChannel]
+          InjectionPoints: [{PC: "0x84cda0", Frameless: true}]
           Condition: null
     - id: testCombinedByte
       version: 0
@@ -148,11 +148,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 67}
+      subprogram: {subprogram: 75}
       events:
-        - ID: 67
-          Type: 348 EventRootType Probe[main.testCombinedByte]
-          InjectionPoints: [{PC: "0x84c110", Frameless: true}]
+        - ID: 75
+          Type: 481 EventRootType Probe[main.testCombinedByte]
+          InjectionPoints: [{PC: "0x84cb20", Frameless: true}]
           Condition: null
     - id: testCycle
       version: 0
@@ -162,11 +162,113 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 77}
+      subprogram: {subprogram: 85}
       events:
-        - ID: 77
-          Type: 358 EventRootType Probe[main.testCycle]
-          InjectionPoints: [{PC: "0x84c630", Frameless: true}]
+        - ID: 85
+          Type: 491 EventRootType Probe[main.testCycle]
+          InjectionPoints: [{PC: "0x84d040", Frameless: true}]
+          Condition: null
+    - id: testDeepMap1
+      version: 0
+      type: LOG_PROBE
+      where: {methodName: main.testDeepMap1}
+      capture:
+        maxReferenceDepth: 1
+        maxFieldCount: 0
+        maxCollectionSize: 0
+      template: ""
+      segments: []
+      captureSnapshot: true
+      subprogram: {subprogram: 40}
+      events:
+        - ID: 40
+          Type: 446 EventRootType Probe[main.testDeepMap1]
+          InjectionPoints: [{PC: "0x84a3b0", Frameless: true}]
+          Condition: null
+    - id: testDeepMap7
+      version: 0
+      type: LOG_PROBE
+      where: {methodName: main.testDeepMap7}
+      capture:
+        maxReferenceDepth: 5
+        maxFieldCount: 0
+        maxCollectionSize: 0
+      template: ""
+      segments: []
+      captureSnapshot: true
+      subprogram: {subprogram: 41}
+      events:
+        - ID: 41
+          Type: 447 EventRootType Probe[main.testDeepMap7]
+          InjectionPoints: [{PC: "0x84a3c0", Frameless: true}]
+          Condition: null
+    - id: testDeepPtr1
+      version: 0
+      type: LOG_PROBE
+      where: {methodName: main.testDeepPtr1}
+      capture:
+        maxReferenceDepth: 1
+        maxFieldCount: 0
+        maxCollectionSize: 0
+      template: ""
+      segments: []
+      captureSnapshot: true
+      subprogram: {subprogram: 36}
+      events:
+        - ID: 36
+          Type: 442 EventRootType Probe[main.testDeepPtr1]
+          InjectionPoints: [{PC: "0x84a0a0", Frameless: true}]
+          Condition: null
+    - id: testDeepPtr7
+      version: 0
+      type: LOG_PROBE
+      where: {methodName: main.testDeepPtr7}
+      capture:
+        maxReferenceDepth: 5
+        maxFieldCount: 0
+        maxCollectionSize: 0
+      template: ""
+      segments: []
+      captureSnapshot: true
+      subprogram: {subprogram: 37}
+      events:
+        - ID: 37
+          Type: 443 EventRootType Probe[main.testDeepPtr7]
+          InjectionPoints: [{PC: "0x84a0b0", Frameless: true}]
+          Condition: null
+    - id: testDeepSlice1
+      version: 0
+      type: LOG_PROBE
+      where: {methodName: main.testDeepSlice1}
+      capture:
+        maxReferenceDepth: 1
+        maxFieldCount: 0
+        maxCollectionSize: 0
+      template: ""
+      segments: []
+      captureSnapshot: true
+      subprogram: {subprogram: 38}
+      events:
+        - ID: 38
+          Type: 444 EventRootType Probe[main.testDeepSlice1]
+          InjectionPoints: [{PC: "0x84a250", Frameless: true}]
+          Condition: null
+    - id: testDeepSlice7
+      version: 0
+      type: LOG_PROBE
+      where: {methodName: main.testDeepSlice7}
+      capture:
+        maxReferenceDepth: 5
+        maxFieldCount: 0
+        maxCollectionSize: 0
+      template: ""
+      segments: []
+      captureSnapshot: true
+      subprogram: {subprogram: 39}
+      events:
+        - ID: 39
+          Type: 445 EventRootType Probe[main.testDeepSlice7]
+          InjectionPoints: [{PC: "0x84a260", Frameless: true}]
           Condition: null
     - id: testEmptySlice
       version: 0
@@ -176,11 +278,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 79}
+      subprogram: {subprogram: 87}
       events:
-        - ID: 79
-          Type: 360 EventRootType Probe[main.testEmptySlice]
-          InjectionPoints: [{PC: "0x84ca10", Frameless: true}]
+        - ID: 87
+          Type: 493 EventRootType Probe[main.testEmptySlice]
+          InjectionPoints: [{PC: "0x84d420", Frameless: true}]
           Condition: null
     - id: testEmptySliceOfStructs
       version: 0
@@ -190,11 +292,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 82}
+      subprogram: {subprogram: 90}
       events:
-        - ID: 82
-          Type: 363 EventRootType Probe[main.testEmptySliceOfStructs]
-          InjectionPoints: [{PC: "0x84ca40", Frameless: true}]
+        - ID: 90
+          Type: 496 EventRootType Probe[main.testEmptySliceOfStructs]
+          InjectionPoints: [{PC: "0x84d450", Frameless: true}]
           Condition: null
     - id: testEmptyString
       version: 0
@@ -204,11 +306,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 96}
+      subprogram: {subprogram: 104}
       events:
-        - ID: 96
-          Type: 377 EventRootType Probe[main.testEmptyString]
-          InjectionPoints: [{PC: "0x84ce50", Frameless: true}]
+        - ID: 104
+          Type: 510 EventRootType Probe[main.testEmptyString]
+          InjectionPoints: [{PC: "0x84d860", Frameless: true}]
           Condition: null
     - id: testEmptyStruct
       version: 0
@@ -218,11 +320,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 98}
+      subprogram: {subprogram: 106}
       events:
-        - ID: 98
-          Type: 379 EventRootType Probe[main.testEmptyStruct]
-          InjectionPoints: [{PC: "0x84d160", Frameless: true}]
+        - ID: 106
+          Type: 512 EventRootType Probe[main.testEmptyStruct]
+          InjectionPoints: [{PC: "0x84db70", Frameless: true}]
           Condition: null
     - id: testError
       version: 0
@@ -232,11 +334,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 46}
+      subprogram: {subprogram: 54}
       events:
-        - ID: 46
-          Type: 327 EventRootType Probe[main.testError]
-          InjectionPoints: [{PC: "0x84a8c0", Frameless: true}]
+        - ID: 54
+          Type: 460 EventRootType Probe[main.testError]
+          InjectionPoints: [{PC: "0x84b2d0", Frameless: true}]
           Condition: null
     - id: testEsotericHeap
       version: 0
@@ -246,11 +348,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 37}
+      subprogram: {subprogram: 45}
       events:
-        - ID: 37
-          Type: 318 EventRootType Probe[main.testEsotericHeap]
-          InjectionPoints: [{PC: "0x849e3c", Frameless: true}]
+        - ID: 45
+          Type: 451 EventRootType Probe[main.testEsotericHeap]
+          InjectionPoints: [{PC: "0x84a84c", Frameless: true}]
           Condition: null
     - id: testEsotericStack
       version: 0
@@ -260,11 +362,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 36}
+      subprogram: {subprogram: 44}
       events:
-        - ID: 36
-          Type: 317 EventRootType Probe[main.testEsotericStack]
-          InjectionPoints: [{PC: "0x849d6c", Frameless: true}]
+        - ID: 44
+          Type: 450 EventRootType Probe[main.testEsotericStack]
+          InjectionPoints: [{PC: "0x84a77c", Frameless: true}]
           Condition: null
     - id: testFrameless
       version: 0
@@ -274,11 +376,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 42}
+      subprogram: {subprogram: 50}
       events:
-        - ID: 42
-          Type: 323 EventRootType Probe[main.testFrameless]
-          InjectionPoints: [{PC: "0x84a560", Frameless: true}]
+        - ID: 50
+          Type: 456 EventRootType Probe[main.testFrameless]
+          InjectionPoints: [{PC: "0x84af70", Frameless: true}]
           Condition: null
     - id: testFramelessArray
       version: 0
@@ -288,11 +390,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 43}
+      subprogram: {subprogram: 51}
       events:
-        - ID: 43
-          Type: 324 EventRootType Probe[main.testFramelessArray]
-          InjectionPoints: [{PC: "0x84a570", Frameless: true}]
+        - ID: 51
+          Type: 457 EventRootType Probe[main.testFramelessArray]
+          InjectionPoints: [{PC: "0x84af80", Frameless: true}]
           Condition: null
     - id: testInlinedBA
       version: 0
@@ -302,11 +404,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 38}
+      subprogram: {subprogram: 46}
       events:
-        - ID: 38
-          Type: 319 EventRootType Probe[main.testInlinedBA]
-          InjectionPoints: [{PC: "0x84a27c", Frameless: true}]
+        - ID: 46
+          Type: 452 EventRootType Probe[main.testInlinedBA]
+          InjectionPoints: [{PC: "0x84ac8c", Frameless: true}]
           Condition: null
     - id: testInlinedBB
       version: 0
@@ -316,11 +418,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 39}
+      subprogram: {subprogram: 47}
       events:
-        - ID: 39
-          Type: 320 EventRootType Probe[main.testInlinedBB]
-          InjectionPoints: [{PC: "0x84a30c", Frameless: true}]
+        - ID: 47
+          Type: 453 EventRootType Probe[main.testInlinedBB]
+          InjectionPoints: [{PC: "0x84ad1c", Frameless: true}]
           Condition: null
     - id: testInlinedBBA
       version: 0
@@ -330,11 +432,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 40}
+      subprogram: {subprogram: 48}
       events:
-        - ID: 40
-          Type: 321 EventRootType Probe[main.testInlinedBBA]
-          InjectionPoints: [{PC: "0x84a3cc", Frameless: true}]
+        - ID: 48
+          Type: 454 EventRootType Probe[main.testInlinedBBA]
+          InjectionPoints: [{PC: "0x84addc", Frameless: true}]
           Condition: null
     - id: testInlinedBBB
       version: 0
@@ -344,11 +446,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 100}
+      subprogram: {subprogram: 108}
       events:
-        - ID: 100
-          Type: 381 EventRootType Probe[main.testInlinedBBB]
-          InjectionPoints: [{PC: "0x84a368", Frameless: false}]
+        - ID: 108
+          Type: 514 EventRootType Probe[main.testInlinedBBB]
+          InjectionPoints: [{PC: "0x84ad78", Frameless: false}]
           Condition: null
     - id: testInlinedBC
       version: 0
@@ -358,11 +460,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 41}
+      subprogram: {subprogram: 49}
       events:
-        - ID: 41
-          Type: 322 EventRootType Probe[main.testInlinedBC]
-          InjectionPoints: [{PC: "0x84a44c", Frameless: true}]
+        - ID: 49
+          Type: 455 EventRootType Probe[main.testInlinedBC]
+          InjectionPoints: [{PC: "0x84ae5c", Frameless: true}]
           Condition: null
     - id: testInlinedBCA
       version: 0
@@ -372,11 +474,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 101}
+      subprogram: {subprogram: 109}
       events:
-        - ID: 101
-          Type: 382 EventRootType Probe[main.testInlinedBCA]
-          InjectionPoints: [{PC: "0x84a45c", Frameless: false}]
+        - ID: 109
+          Type: 515 EventRootType Probe[main.testInlinedBCA]
+          InjectionPoints: [{PC: "0x84ae6c", Frameless: false}]
           Condition: null
     - id: testInlinedBCB
       version: 0
@@ -386,11 +488,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 102}
+      subprogram: {subprogram: 110}
       events:
-        - ID: 102
-          Type: 383 EventRootType Probe[main.testInlinedBCB]
-          InjectionPoints: [{PC: "0x84a510", Frameless: false}]
+        - ID: 110
+          Type: 516 EventRootType Probe[main.testInlinedBCB]
+          InjectionPoints: [{PC: "0x84af20", Frameless: false}]
           Condition: null
     - id: testInlinedPrint
       version: 0
@@ -401,20 +503,20 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 99}
+      subprogram: {subprogram: 107}
       events:
-        - ID: 99
-          Type: 380 EventRootType Probe[main.testInlinedPrint]
+        - ID: 107
+          Type: 513 EventRootType Probe[main.testInlinedPrint]
           InjectionPoints:
-            - PC: "0x84a0dc"
+            - PC: "0x84aaec"
               Frameless: true
-            - PC: "0x84a15c"
+            - PC: "0x84ab6c"
               Frameless: false
-            - PC: "0x84a2a8"
+            - PC: "0x84acb8"
               Frameless: false
-            - PC: "0x84a324"
+            - PC: "0x84ad34"
               Frameless: false
-            - PC: "0x84a3dc"
+            - PC: "0x84adec"
               Frameless: false
           Condition: null
     - id: testInlinedSq
@@ -425,11 +527,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 103}
+      subprogram: {subprogram: 111}
       events:
-        - ID: 103
-          Type: 384 EventRootType Probe[main.testInlinedSq]
-          InjectionPoints: [{PC: "0x84a564", Frameless: true}]
+        - ID: 111
+          Type: 517 EventRootType Probe[main.testInlinedSq]
+          InjectionPoints: [{PC: "0x84af74", Frameless: true}]
           Condition: null
     - id: testInlinedSumArray
       version: 0
@@ -440,14 +542,14 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 104}
+      subprogram: {subprogram: 112}
       events:
-        - ID: 104
-          Type: 385 EventRootType Probe[main.testInlinedSumArray]
+        - ID: 112
+          Type: 518 EventRootType Probe[main.testInlinedSumArray]
           InjectionPoints:
-            - PC: "0x84a594"
+            - PC: "0x84afa4"
               Frameless: false
-            - PC: "0x84a62c"
+            - PC: "0x84b03c"
               Frameless: false
           Condition: null
     - id: testInt16Array
@@ -461,8 +563,8 @@ Probes:
       subprogram: {subprogram: 7}
       events:
         - ID: 7
-          Type: 288 EventRootType Probe[main.testInt16Array]
-          InjectionPoints: [{PC: "0x8495a0", Frameless: true}]
+          Type: 413 EventRootType Probe[main.testInt16Array]
+          InjectionPoints: [{PC: "0x8499d0", Frameless: true}]
           Condition: null
     - id: testInt32Array
       version: 0
@@ -475,8 +577,8 @@ Probes:
       subprogram: {subprogram: 8}
       events:
         - ID: 8
-          Type: 289 EventRootType Probe[main.testInt32Array]
-          InjectionPoints: [{PC: "0x8495b0", Frameless: true}]
+          Type: 414 EventRootType Probe[main.testInt32Array]
+          InjectionPoints: [{PC: "0x8499e0", Frameless: true}]
           Condition: null
     - id: testInt64Array
       version: 0
@@ -489,8 +591,8 @@ Probes:
       subprogram: {subprogram: 9}
       events:
         - ID: 9
-          Type: 290 EventRootType Probe[main.testInt64Array]
-          InjectionPoints: [{PC: "0x8495c0", Frameless: true}]
+          Type: 415 EventRootType Probe[main.testInt64Array]
+          InjectionPoints: [{PC: "0x8499f0", Frameless: true}]
           Condition: null
     - id: testInt8Array
       version: 0
@@ -503,8 +605,8 @@ Probes:
       subprogram: {subprogram: 6}
       events:
         - ID: 6
-          Type: 287 EventRootType Probe[main.testInt8Array]
-          InjectionPoints: [{PC: "0x849590", Frameless: true}]
+          Type: 412 EventRootType Probe[main.testInt8Array]
+          InjectionPoints: [{PC: "0x8499c0", Frameless: true}]
           Condition: null
     - id: testIntArray
       version: 0
@@ -517,8 +619,8 @@ Probes:
       subprogram: {subprogram: 5}
       events:
         - ID: 5
-          Type: 286 EventRootType Probe[main.testIntArray]
-          InjectionPoints: [{PC: "0x849580", Frameless: true}]
+          Type: 411 EventRootType Probe[main.testIntArray]
+          InjectionPoints: [{PC: "0x8499b0", Frameless: true}]
           Condition: null
     - id: testInterface
       version: 0
@@ -528,11 +630,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 44}
+      subprogram: {subprogram: 52}
       events:
-        - ID: 44
-          Type: 325 EventRootType Probe[main.testInterface]
-          InjectionPoints: [{PC: "0x84a80c", Frameless: true}]
+        - ID: 52
+          Type: 458 EventRootType Probe[main.testInterface]
+          InjectionPoints: [{PC: "0x84b21c", Frameless: true}]
           Condition: null
     - id: testLinkedList
       version: 0
@@ -542,11 +644,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 71}
+      subprogram: {subprogram: 79}
       events:
-        - ID: 71
-          Type: 352 EventRootType Probe[main.testLinkedList]
-          InjectionPoints: [{PC: "0x84c540", Frameless: true}]
+        - ID: 79
+          Type: 485 EventRootType Probe[main.testLinkedList]
+          InjectionPoints: [{PC: "0x84cf50", Frameless: true}]
           Condition: null
     - id: testMapArrayToArray
       version: 0
@@ -556,11 +658,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 51}
+      subprogram: {subprogram: 59}
       events:
-        - ID: 51
-          Type: 332 EventRootType Probe[main.testMapArrayToArray]
-          InjectionPoints: [{PC: "0x84ad20", Frameless: true}]
+        - ID: 59
+          Type: 465 EventRootType Probe[main.testMapArrayToArray]
+          InjectionPoints: [{PC: "0x84b730", Frameless: true}]
           Condition: null
     - id: testMapEmbeddedMaps
       version: 0
@@ -570,11 +672,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 57}
+      subprogram: {subprogram: 65}
       events:
-        - ID: 57
-          Type: 338 EventRootType Probe[main.testMapEmbeddedMaps]
-          InjectionPoints: [{PC: "0x84ad80", Frameless: true}]
+        - ID: 65
+          Type: 471 EventRootType Probe[main.testMapEmbeddedMaps]
+          InjectionPoints: [{PC: "0x84b790", Frameless: true}]
           Condition: null
     - id: testMapIntToInt
       version: 0
@@ -584,11 +686,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 55}
+      subprogram: {subprogram: 63}
       events:
-        - ID: 55
-          Type: 336 EventRootType Probe[main.testMapIntToInt]
-          InjectionPoints: [{PC: "0x84ad60", Frameless: true}]
+        - ID: 63
+          Type: 469 EventRootType Probe[main.testMapIntToInt]
+          InjectionPoints: [{PC: "0x84b770", Frameless: true}]
           Condition: null
     - id: testMapLargeKeyLargeValue
       version: 0
@@ -598,11 +700,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 66}
+      subprogram: {subprogram: 74}
       events:
-        - ID: 66
-          Type: 347 EventRootType Probe[main.testMapLargeKeyLargeValue]
-          InjectionPoints: [{PC: "0x84ae10", Frameless: true}]
+        - ID: 74
+          Type: 480 EventRootType Probe[main.testMapLargeKeyLargeValue]
+          InjectionPoints: [{PC: "0x84b820", Frameless: true}]
           Condition: null
     - id: testMapLargeKeySmallValue
       version: 0
@@ -612,11 +714,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 65}
+      subprogram: {subprogram: 73}
       events:
-        - ID: 65
-          Type: 346 EventRootType Probe[main.testMapLargeKeySmallValue]
-          InjectionPoints: [{PC: "0x84ae00", Frameless: true}]
+        - ID: 73
+          Type: 479 EventRootType Probe[main.testMapLargeKeySmallValue]
+          InjectionPoints: [{PC: "0x84b810", Frameless: true}]
           Condition: null
     - id: testMapMassive
       version: 0
@@ -626,11 +728,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 56}
+      subprogram: {subprogram: 64}
       events:
-        - ID: 56
-          Type: 337 EventRootType Probe[main.testMapMassive]
-          InjectionPoints: [{PC: "0x84ad70", Frameless: true}]
+        - ID: 64
+          Type: 470 EventRootType Probe[main.testMapMassive]
+          InjectionPoints: [{PC: "0x84b780", Frameless: true}]
           Condition: null
     - id: testMapSmallKeyLargeValue
       version: 0
@@ -640,11 +742,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 64}
+      subprogram: {subprogram: 72}
       events:
-        - ID: 64
-          Type: 345 EventRootType Probe[main.testMapSmallKeyLargeValue]
-          InjectionPoints: [{PC: "0x84adf0", Frameless: true}]
+        - ID: 72
+          Type: 478 EventRootType Probe[main.testMapSmallKeyLargeValue]
+          InjectionPoints: [{PC: "0x84b800", Frameless: true}]
           Condition: null
     - id: testMapSmallKeySmallValue
       version: 0
@@ -654,11 +756,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 63}
+      subprogram: {subprogram: 71}
       events:
-        - ID: 63
-          Type: 344 EventRootType Probe[main.testMapSmallKeySmallValue]
-          InjectionPoints: [{PC: "0x84ade0", Frameless: true}]
+        - ID: 71
+          Type: 477 EventRootType Probe[main.testMapSmallKeySmallValue]
+          InjectionPoints: [{PC: "0x84b7f0", Frameless: true}]
           Condition: null
     - id: testMapStringToInt
       version: 0
@@ -668,11 +770,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 49}
+      subprogram: {subprogram: 57}
       events:
-        - ID: 49
-          Type: 330 EventRootType Probe[main.testMapStringToInt]
-          InjectionPoints: [{PC: "0x84ad00", Frameless: true}]
+        - ID: 57
+          Type: 463 EventRootType Probe[main.testMapStringToInt]
+          InjectionPoints: [{PC: "0x84b710", Frameless: true}]
           Condition: null
     - id: testMapStringToSlice
       version: 0
@@ -682,11 +784,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 50}
+      subprogram: {subprogram: 58}
       events:
-        - ID: 50
-          Type: 331 EventRootType Probe[main.testMapStringToSlice]
-          InjectionPoints: [{PC: "0x84ad10", Frameless: true}]
+        - ID: 58
+          Type: 464 EventRootType Probe[main.testMapStringToSlice]
+          InjectionPoints: [{PC: "0x84b720", Frameless: true}]
           Condition: null
     - id: testMapStringToStruct
       version: 0
@@ -696,11 +798,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 48}
+      subprogram: {subprogram: 56}
       events:
-        - ID: 48
-          Type: 329 EventRootType Probe[main.testMapStringToStruct]
-          InjectionPoints: [{PC: "0x84acf0", Frameless: true}]
+        - ID: 56
+          Type: 462 EventRootType Probe[main.testMapStringToStruct]
+          InjectionPoints: [{PC: "0x84b700", Frameless: true}]
           Condition: null
     - id: testMapWithLinkedList
       version: 0
@@ -710,11 +812,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 58}
+      subprogram: {subprogram: 66}
       events:
-        - ID: 58
-          Type: 339 EventRootType Probe[main.testMapWithLinkedList]
-          InjectionPoints: [{PC: "0x84ad90", Frameless: true}]
+        - ID: 66
+          Type: 472 EventRootType Probe[main.testMapWithLinkedList]
+          InjectionPoints: [{PC: "0x84b7a0", Frameless: true}]
           Condition: null
     - id: testMapWithSmallKeyAndValue
       version: 0
@@ -724,11 +826,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 61}
+      subprogram: {subprogram: 69}
       events:
-        - ID: 61
-          Type: 342 EventRootType Probe[main.testMapWithSmallKeyAndValue]
-          InjectionPoints: [{PC: "0x84adc0", Frameless: true}]
+        - ID: 69
+          Type: 475 EventRootType Probe[main.testMapWithSmallKeyAndValue]
+          InjectionPoints: [{PC: "0x84b7d0", Frameless: true}]
           Condition: null
     - id: testMapWithSmallKeyAndValueMassive
       version: 0
@@ -738,11 +840,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 62}
+      subprogram: {subprogram: 70}
       events:
-        - ID: 62
-          Type: 343 EventRootType Probe[main.testMapWithSmallKeyAndValueMassive]
-          InjectionPoints: [{PC: "0x84add0", Frameless: true}]
+        - ID: 70
+          Type: 476 EventRootType Probe[main.testMapWithSmallKeyAndValueMassive]
+          InjectionPoints: [{PC: "0x84b7e0", Frameless: true}]
           Condition: null
     - id: testMapWithSmallValue
       version: 0
@@ -752,11 +854,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 59}
+      subprogram: {subprogram: 67}
       events:
-        - ID: 59
-          Type: 340 EventRootType Probe[main.testMapWithSmallValue]
-          InjectionPoints: [{PC: "0x84ada0", Frameless: true}]
+        - ID: 67
+          Type: 473 EventRootType Probe[main.testMapWithSmallValue]
+          InjectionPoints: [{PC: "0x84b7b0", Frameless: true}]
           Condition: null
     - id: testMapWithSmallValueMassive
       version: 0
@@ -766,11 +868,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 60}
+      subprogram: {subprogram: 68}
       events:
-        - ID: 60
-          Type: 341 EventRootType Probe[main.testMapWithSmallValueMassive]
-          InjectionPoints: [{PC: "0x84adb0", Frameless: true}]
+        - ID: 68
+          Type: 474 EventRootType Probe[main.testMapWithSmallValueMassive]
+          InjectionPoints: [{PC: "0x84b7c0", Frameless: true}]
           Condition: null
     - id: testMassiveString
       version: 0
@@ -780,11 +882,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 94}
+      subprogram: {subprogram: 102}
       events:
-        - ID: 94
-          Type: 375 EventRootType Probe[main.testMassiveString]
-          InjectionPoints: [{PC: "0x84ce30", Frameless: true}]
+        - ID: 102
+          Type: 508 EventRootType Probe[main.testMassiveString]
+          InjectionPoints: [{PC: "0x84d840", Frameless: true}]
           Condition: null
     - id: testMultipleSimpleParams
       version: 0
@@ -794,11 +896,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 68}
+      subprogram: {subprogram: 76}
       events:
-        - ID: 68
-          Type: 349 EventRootType Probe[main.testMultipleSimpleParams]
-          InjectionPoints: [{PC: "0x84c1f0", Frameless: true}]
+        - ID: 76
+          Type: 482 EventRootType Probe[main.testMultipleSimpleParams]
+          InjectionPoints: [{PC: "0x84cc00", Frameless: true}]
           Condition: null
     - id: testNilPointer
       version: 0
@@ -808,11 +910,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 76}
+      subprogram: {subprogram: 84}
       events:
-        - ID: 76
-          Type: 357 EventRootType Probe[main.testNilPointer]
-          InjectionPoints: [{PC: "0x84c610", Frameless: true}]
+        - ID: 84
+          Type: 490 EventRootType Probe[main.testNilPointer]
+          InjectionPoints: [{PC: "0x84d020", Frameless: true}]
           Condition: null
     - id: testNilSlice
       version: 0
@@ -822,11 +924,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 86}
+      subprogram: {subprogram: 94}
       events:
-        - ID: 86
-          Type: 367 EventRootType Probe[main.testNilSlice]
-          InjectionPoints: [{PC: "0x84ca80", Frameless: true}]
+        - ID: 94
+          Type: 500 EventRootType Probe[main.testNilSlice]
+          InjectionPoints: [{PC: "0x84d490", Frameless: true}]
           Condition: null
     - id: testNilSliceOfStructs
       version: 0
@@ -836,11 +938,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 83}
+      subprogram: {subprogram: 91}
       events:
-        - ID: 83
-          Type: 364 EventRootType Probe[main.testNilSliceOfStructs]
-          InjectionPoints: [{PC: "0x84ca50", Frameless: true}]
+        - ID: 91
+          Type: 497 EventRootType Probe[main.testNilSliceOfStructs]
+          InjectionPoints: [{PC: "0x84d460", Frameless: true}]
           Condition: null
     - id: testNilSliceWithOtherParams
       version: 0
@@ -850,11 +952,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 85}
+      subprogram: {subprogram: 93}
       events:
-        - ID: 85
-          Type: 366 EventRootType Probe[main.testNilSliceWithOtherParams]
-          InjectionPoints: [{PC: "0x84ca70", Frameless: true}]
+        - ID: 93
+          Type: 499 EventRootType Probe[main.testNilSliceWithOtherParams]
+          InjectionPoints: [{PC: "0x84d480", Frameless: true}]
           Condition: null
     - id: testOneStringInStructPointer
       version: 0
@@ -864,11 +966,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 93}
+      subprogram: {subprogram: 101}
       events:
-        - ID: 93
-          Type: 374 EventRootType Probe[main.testOneStringInStructPointer]
-          InjectionPoints: [{PC: "0x84ce20", Frameless: true}]
+        - ID: 101
+          Type: 507 EventRootType Probe[main.testOneStringInStructPointer]
+          InjectionPoints: [{PC: "0x84d830", Frameless: true}]
           Condition: null
     - id: testPointerLoop
       version: 0
@@ -878,11 +980,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 72}
+      subprogram: {subprogram: 80}
       events:
-        - ID: 72
-          Type: 353 EventRootType Probe[main.testPointerLoop]
-          InjectionPoints: [{PC: "0x84c550", Frameless: true}]
+        - ID: 80
+          Type: 486 EventRootType Probe[main.testPointerLoop]
+          InjectionPoints: [{PC: "0x84cf60", Frameless: true}]
           Condition: null
     - id: testPointerToMap
       version: 0
@@ -892,11 +994,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 54}
+      subprogram: {subprogram: 62}
       events:
-        - ID: 54
-          Type: 335 EventRootType Probe[main.testPointerToMap]
-          InjectionPoints: [{PC: "0x84ad50", Frameless: true}]
+        - ID: 62
+          Type: 468 EventRootType Probe[main.testPointerToMap]
+          InjectionPoints: [{PC: "0x84b760", Frameless: true}]
           Condition: null
     - id: testPointerToSimpleStruct
       version: 0
@@ -906,11 +1008,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 70}
+      subprogram: {subprogram: 78}
       events:
-        - ID: 70
-          Type: 351 EventRootType Probe[main.testPointerToSimpleStruct]
-          InjectionPoints: [{PC: "0x84c530", Frameless: true}]
+        - ID: 78
+          Type: 484 EventRootType Probe[main.testPointerToSimpleStruct]
+          InjectionPoints: [{PC: "0x84cf40", Frameless: true}]
           Condition: null
     - id: testRuneArray
       version: 0
@@ -923,8 +1025,8 @@ Probes:
       subprogram: {subprogram: 2}
       events:
         - ID: 2
-          Type: 283 EventRootType Probe[main.testRuneArray]
-          InjectionPoints: [{PC: "0x849550", Frameless: true}]
+          Type: 408 EventRootType Probe[main.testRuneArray]
+          InjectionPoints: [{PC: "0x849980", Frameless: true}]
           Condition: null
     - id: testSingleBool
       version: 0
@@ -937,8 +1039,8 @@ Probes:
       subprogram: {subprogram: 21}
       events:
         - ID: 21
-          Type: 302 EventRootType Probe[main.testSingleBool]
-          InjectionPoints: [{PC: "0x8499c0", Frameless: true}]
+          Type: 427 EventRootType Probe[main.testSingleBool]
+          InjectionPoints: [{PC: "0x849df0", Frameless: true}]
           Condition: null
     - id: testSingleByte
       version: 0
@@ -951,8 +1053,8 @@ Probes:
       subprogram: {subprogram: 19}
       events:
         - ID: 19
-          Type: 300 EventRootType Probe[main.testSingleByte]
-          InjectionPoints: [{PC: "0x8499a0", Frameless: true}]
+          Type: 425 EventRootType Probe[main.testSingleByte]
+          InjectionPoints: [{PC: "0x849dd0", Frameless: true}]
           Condition: null
     - id: testSingleFloat32
       version: 0
@@ -965,8 +1067,8 @@ Probes:
       subprogram: {subprogram: 32}
       events:
         - ID: 32
-          Type: 313 EventRootType Probe[main.testSingleFloat32]
-          InjectionPoints: [{PC: "0x849a70", Frameless: true}]
+          Type: 438 EventRootType Probe[main.testSingleFloat32]
+          InjectionPoints: [{PC: "0x849ea0", Frameless: true}]
           Condition: null
     - id: testSingleFloat64
       version: 0
@@ -979,8 +1081,8 @@ Probes:
       subprogram: {subprogram: 33}
       events:
         - ID: 33
-          Type: 314 EventRootType Probe[main.testSingleFloat64]
-          InjectionPoints: [{PC: "0x849a80", Frameless: true}]
+          Type: 439 EventRootType Probe[main.testSingleFloat64]
+          InjectionPoints: [{PC: "0x849eb0", Frameless: true}]
           Condition: null
     - id: testSingleInt
       version: 0
@@ -993,8 +1095,8 @@ Probes:
       subprogram: {subprogram: 22}
       events:
         - ID: 22
-          Type: 303 EventRootType Probe[main.testSingleInt]
-          InjectionPoints: [{PC: "0x8499d0", Frameless: true}]
+          Type: 428 EventRootType Probe[main.testSingleInt]
+          InjectionPoints: [{PC: "0x849e00", Frameless: true}]
           Condition: null
     - id: testSingleInt16
       version: 0
@@ -1007,8 +1109,8 @@ Probes:
       subprogram: {subprogram: 24}
       events:
         - ID: 24
-          Type: 305 EventRootType Probe[main.testSingleInt16]
-          InjectionPoints: [{PC: "0x8499f0", Frameless: true}]
+          Type: 430 EventRootType Probe[main.testSingleInt16]
+          InjectionPoints: [{PC: "0x849e20", Frameless: true}]
           Condition: null
     - id: testSingleInt32
       version: 0
@@ -1021,8 +1123,8 @@ Probes:
       subprogram: {subprogram: 25}
       events:
         - ID: 25
-          Type: 306 EventRootType Probe[main.testSingleInt32]
-          InjectionPoints: [{PC: "0x849a00", Frameless: true}]
+          Type: 431 EventRootType Probe[main.testSingleInt32]
+          InjectionPoints: [{PC: "0x849e30", Frameless: true}]
           Condition: null
     - id: testSingleInt64
       version: 0
@@ -1035,8 +1137,8 @@ Probes:
       subprogram: {subprogram: 26}
       events:
         - ID: 26
-          Type: 307 EventRootType Probe[main.testSingleInt64]
-          InjectionPoints: [{PC: "0x849a10", Frameless: true}]
+          Type: 432 EventRootType Probe[main.testSingleInt64]
+          InjectionPoints: [{PC: "0x849e40", Frameless: true}]
           Condition: null
     - id: testSingleInt8
       version: 0
@@ -1049,8 +1151,8 @@ Probes:
       subprogram: {subprogram: 23}
       events:
         - ID: 23
-          Type: 304 EventRootType Probe[main.testSingleInt8]
-          InjectionPoints: [{PC: "0x8499e0", Frameless: true}]
+          Type: 429 EventRootType Probe[main.testSingleInt8]
+          InjectionPoints: [{PC: "0x849e10", Frameless: true}]
           Condition: null
     - id: testSingleRune
       version: 0
@@ -1063,8 +1165,8 @@ Probes:
       subprogram: {subprogram: 20}
       events:
         - ID: 20
-          Type: 301 EventRootType Probe[main.testSingleRune]
-          InjectionPoints: [{PC: "0x8499b0", Frameless: true}]
+          Type: 426 EventRootType Probe[main.testSingleRune]
+          InjectionPoints: [{PC: "0x849de0", Frameless: true}]
           Condition: null
     - id: testSingleString
       version: 0
@@ -1074,11 +1176,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 89}
+      subprogram: {subprogram: 97}
       events:
-        - ID: 89
-          Type: 370 EventRootType Probe[main.testSingleString]
-          InjectionPoints: [{PC: "0x84cdd0", Frameless: true}]
+        - ID: 97
+          Type: 503 EventRootType Probe[main.testSingleString]
+          InjectionPoints: [{PC: "0x84d7e0", Frameless: true}]
           Condition: null
     - id: testSingleUint
       version: 0
@@ -1091,8 +1193,8 @@ Probes:
       subprogram: {subprogram: 27}
       events:
         - ID: 27
-          Type: 308 EventRootType Probe[main.testSingleUint]
-          InjectionPoints: [{PC: "0x849a20", Frameless: true}]
+          Type: 433 EventRootType Probe[main.testSingleUint]
+          InjectionPoints: [{PC: "0x849e50", Frameless: true}]
           Condition: null
     - id: testSingleUint16
       version: 0
@@ -1105,8 +1207,8 @@ Probes:
       subprogram: {subprogram: 29}
       events:
         - ID: 29
-          Type: 310 EventRootType Probe[main.testSingleUint16]
-          InjectionPoints: [{PC: "0x849a40", Frameless: true}]
+          Type: 435 EventRootType Probe[main.testSingleUint16]
+          InjectionPoints: [{PC: "0x849e70", Frameless: true}]
           Condition: null
     - id: testSingleUint32
       version: 0
@@ -1119,8 +1221,8 @@ Probes:
       subprogram: {subprogram: 30}
       events:
         - ID: 30
-          Type: 311 EventRootType Probe[main.testSingleUint32]
-          InjectionPoints: [{PC: "0x849a50", Frameless: true}]
+          Type: 436 EventRootType Probe[main.testSingleUint32]
+          InjectionPoints: [{PC: "0x849e80", Frameless: true}]
           Condition: null
     - id: testSingleUint64
       version: 0
@@ -1133,8 +1235,8 @@ Probes:
       subprogram: {subprogram: 31}
       events:
         - ID: 31
-          Type: 312 EventRootType Probe[main.testSingleUint64]
-          InjectionPoints: [{PC: "0x849a60", Frameless: true}]
+          Type: 437 EventRootType Probe[main.testSingleUint64]
+          InjectionPoints: [{PC: "0x849e90", Frameless: true}]
           Condition: null
     - id: testSingleUint8
       version: 0
@@ -1147,8 +1249,8 @@ Probes:
       subprogram: {subprogram: 28}
       events:
         - ID: 28
-          Type: 309 EventRootType Probe[main.testSingleUint8]
-          InjectionPoints: [{PC: "0x849a30", Frameless: true}]
+          Type: 434 EventRootType Probe[main.testSingleUint8]
+          InjectionPoints: [{PC: "0x849e60", Frameless: true}]
           Condition: null
     - id: testSliceOfSlices
       version: 0
@@ -1158,11 +1260,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 80}
+      subprogram: {subprogram: 88}
       events:
-        - ID: 80
-          Type: 361 EventRootType Probe[main.testSliceOfSlices]
-          InjectionPoints: [{PC: "0x84ca20", Frameless: true}]
+        - ID: 88
+          Type: 494 EventRootType Probe[main.testSliceOfSlices]
+          InjectionPoints: [{PC: "0x84d430", Frameless: true}]
           Condition: null
     - id: testSmallMap
       version: 0
@@ -1172,11 +1274,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 52}
+      subprogram: {subprogram: 60}
       events:
-        - ID: 52
-          Type: 333 EventRootType Probe[main.testSmallMap]
-          InjectionPoints: [{PC: "0x84ad30", Frameless: true}]
+        - ID: 60
+          Type: 466 EventRootType Probe[main.testSmallMap]
+          InjectionPoints: [{PC: "0x84b740", Frameless: true}]
           Condition: null
     - id: testStringArray
       version: 0
@@ -1189,8 +1291,8 @@ Probes:
       subprogram: {subprogram: 3}
       events:
         - ID: 3
-          Type: 284 EventRootType Probe[main.testStringArray]
-          InjectionPoints: [{PC: "0x849560", Frameless: true}]
+          Type: 409 EventRootType Probe[main.testStringArray]
+          InjectionPoints: [{PC: "0x849990", Frameless: true}]
           Condition: null
     - id: testStringPointer
       version: 0
@@ -1200,11 +1302,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 75}
+      subprogram: {subprogram: 83}
       events:
-        - ID: 75
-          Type: 356 EventRootType Probe[main.testStringPointer]
-          InjectionPoints: [{PC: "0x84c5f0", Frameless: true}]
+        - ID: 83
+          Type: 489 EventRootType Probe[main.testStringPointer]
+          InjectionPoints: [{PC: "0x84d000", Frameless: true}]
           Condition: null
     - id: testStringSlice
       version: 0
@@ -1214,11 +1316,45 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 84}
+      subprogram: {subprogram: 92}
       events:
-        - ID: 84
-          Type: 365 EventRootType Probe[main.testStringSlice]
-          InjectionPoints: [{PC: "0x84ca60", Frameless: true}]
+        - ID: 92
+          Type: 498 EventRootType Probe[main.testStringSlice]
+          InjectionPoints: [{PC: "0x84d470", Frameless: true}]
+          Condition: null
+    - id: testStringType1
+      version: 0
+      type: LOG_PROBE
+      where: {methodName: main.testStringType1}
+      capture:
+        maxReferenceDepth: 1
+        maxFieldCount: 0
+        maxCollectionSize: 0
+      template: ""
+      segments: []
+      captureSnapshot: true
+      subprogram: {subprogram: 42}
+      events:
+        - ID: 42
+          Type: 448 EventRootType Probe[main.testStringType1]
+          InjectionPoints: [{PC: "0x84a3d0", Frameless: true}]
+          Condition: null
+    - id: testStringType2
+      version: 0
+      type: LOG_PROBE
+      where: {methodName: main.testStringType2}
+      capture:
+        maxReferenceDepth: 1
+        maxFieldCount: 0
+        maxCollectionSize: 0
+      template: ""
+      segments: []
+      captureSnapshot: true
+      subprogram: {subprogram: 43}
+      events:
+        - ID: 43
+          Type: 449 EventRootType Probe[main.testStringType2]
+          InjectionPoints: [{PC: "0x84a3e0", Frameless: true}]
           Condition: null
     - id: testStruct
       version: 0
@@ -1228,11 +1364,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 97}
+      subprogram: {subprogram: 105}
       events:
-        - ID: 97
-          Type: 378 EventRootType Probe[main.testStruct]
-          InjectionPoints: [{PC: "0x84d060", Frameless: true}]
+        - ID: 105
+          Type: 511 EventRootType Probe[main.testStruct]
+          InjectionPoints: [{PC: "0x84da70", Frameless: true}]
           Condition: null
     - id: testStructSlice
       version: 0
@@ -1242,11 +1378,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 81}
+      subprogram: {subprogram: 89}
       events:
-        - ID: 81
-          Type: 362 EventRootType Probe[main.testStructSlice]
-          InjectionPoints: [{PC: "0x84ca30", Frameless: true}]
+        - ID: 89
+          Type: 495 EventRootType Probe[main.testStructSlice]
+          InjectionPoints: [{PC: "0x84d440", Frameless: true}]
           Condition: null
     - id: testStructWithMap
       version: 0
@@ -1256,11 +1392,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 47}
+      subprogram: {subprogram: 55}
       events:
-        - ID: 47
-          Type: 328 EventRootType Probe[main.testStructWithMap]
-          InjectionPoints: [{PC: "0x84ace0", Frameless: true}]
+        - ID: 55
+          Type: 461 EventRootType Probe[main.testStructWithMap]
+          InjectionPoints: [{PC: "0x84b6f0", Frameless: true}]
           Condition: null
     - id: testThreeStrings
       version: 0
@@ -1270,11 +1406,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 90}
+      subprogram: {subprogram: 98}
       events:
-        - ID: 90
-          Type: 371 EventRootType Probe[main.testThreeStrings]
-          InjectionPoints: [{PC: "0x84cde0", Frameless: true}]
+        - ID: 98
+          Type: 504 EventRootType Probe[main.testThreeStrings]
+          InjectionPoints: [{PC: "0x84d7f0", Frameless: true}]
           Condition: null
     - id: testThreeStringsInStruct
       version: 0
@@ -1284,11 +1420,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 91}
+      subprogram: {subprogram: 99}
       events:
-        - ID: 91
-          Type: 372 EventRootType Probe[main.testThreeStringsInStruct]
-          InjectionPoints: [{PC: "0x84cdf0", Frameless: true}]
+        - ID: 99
+          Type: 505 EventRootType Probe[main.testThreeStringsInStruct]
+          InjectionPoints: [{PC: "0x84d800", Frameless: true}]
           Condition: null
     - id: testThreeStringsInStructPointer
       version: 0
@@ -1298,11 +1434,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 92}
+      subprogram: {subprogram: 100}
       events:
-        - ID: 92
-          Type: 373 EventRootType Probe[main.testThreeStringsInStructPointer]
-          InjectionPoints: [{PC: "0x84ce10", Frameless: true}]
+        - ID: 100
+          Type: 506 EventRootType Probe[main.testThreeStringsInStructPointer]
+          InjectionPoints: [{PC: "0x84d820", Frameless: true}]
           Condition: null
     - id: testTypeAlias
       version: 0
@@ -1315,8 +1451,8 @@ Probes:
       subprogram: {subprogram: 34}
       events:
         - ID: 34
-          Type: 315 EventRootType Probe[main.testTypeAlias]
-          InjectionPoints: [{PC: "0x849a90", Frameless: true}]
+          Type: 440 EventRootType Probe[main.testTypeAlias]
+          InjectionPoints: [{PC: "0x849ec0", Frameless: true}]
           Condition: null
     - id: testUint16Array
       version: 0
@@ -1329,8 +1465,8 @@ Probes:
       subprogram: {subprogram: 12}
       events:
         - ID: 12
-          Type: 293 EventRootType Probe[main.testUint16Array]
-          InjectionPoints: [{PC: "0x8495f0", Frameless: true}]
+          Type: 418 EventRootType Probe[main.testUint16Array]
+          InjectionPoints: [{PC: "0x849a20", Frameless: true}]
           Condition: null
     - id: testUint32Array
       version: 0
@@ -1343,8 +1479,8 @@ Probes:
       subprogram: {subprogram: 13}
       events:
         - ID: 13
-          Type: 294 EventRootType Probe[main.testUint32Array]
-          InjectionPoints: [{PC: "0x849600", Frameless: true}]
+          Type: 419 EventRootType Probe[main.testUint32Array]
+          InjectionPoints: [{PC: "0x849a30", Frameless: true}]
           Condition: null
     - id: testUint64Array
       version: 0
@@ -1357,8 +1493,8 @@ Probes:
       subprogram: {subprogram: 14}
       events:
         - ID: 14
-          Type: 295 EventRootType Probe[main.testUint64Array]
-          InjectionPoints: [{PC: "0x849610", Frameless: true}]
+          Type: 420 EventRootType Probe[main.testUint64Array]
+          InjectionPoints: [{PC: "0x849a40", Frameless: true}]
           Condition: null
     - id: testUint8Array
       version: 0
@@ -1371,8 +1507,8 @@ Probes:
       subprogram: {subprogram: 11}
       events:
         - ID: 11
-          Type: 292 EventRootType Probe[main.testUint8Array]
-          InjectionPoints: [{PC: "0x8495e0", Frameless: true}]
+          Type: 417 EventRootType Probe[main.testUint8Array]
+          InjectionPoints: [{PC: "0x849a10", Frameless: true}]
           Condition: null
     - id: testUintArray
       version: 0
@@ -1385,8 +1521,8 @@ Probes:
       subprogram: {subprogram: 10}
       events:
         - ID: 10
-          Type: 291 EventRootType Probe[main.testUintArray]
-          InjectionPoints: [{PC: "0x8495d0", Frameless: true}]
+          Type: 416 EventRootType Probe[main.testUintArray]
+          InjectionPoints: [{PC: "0x849a00", Frameless: true}]
           Condition: null
     - id: testUintPointer
       version: 0
@@ -1396,11 +1532,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 74}
+      subprogram: {subprogram: 82}
       events:
-        - ID: 74
-          Type: 355 EventRootType Probe[main.testUintPointer]
-          InjectionPoints: [{PC: "0x84c580", Frameless: true}]
+        - ID: 82
+          Type: 488 EventRootType Probe[main.testUintPointer]
+          InjectionPoints: [{PC: "0x84cf90", Frameless: true}]
           Condition: null
     - id: testUintSlice
       version: 0
@@ -1410,11 +1546,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 78}
+      subprogram: {subprogram: 86}
       events:
-        - ID: 78
-          Type: 359 EventRootType Probe[main.testUintSlice]
-          InjectionPoints: [{PC: "0x84ca00", Frameless: true}]
+        - ID: 86
+          Type: 492 EventRootType Probe[main.testUintSlice]
+          InjectionPoints: [{PC: "0x84d410", Frameless: true}]
           Condition: null
     - id: testUnitializedString
       version: 0
@@ -1424,11 +1560,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 95}
+      subprogram: {subprogram: 103}
       events:
-        - ID: 95
-          Type: 376 EventRootType Probe[main.testUnitializedString]
-          InjectionPoints: [{PC: "0x84ce40", Frameless: true}]
+        - ID: 103
+          Type: 509 EventRootType Probe[main.testUnitializedString]
+          InjectionPoints: [{PC: "0x84d850", Frameless: true}]
           Condition: null
     - id: testUnsafePointer
       version: 0
@@ -1438,11 +1574,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 73}
+      subprogram: {subprogram: 81}
       events:
-        - ID: 73
-          Type: 354 EventRootType Probe[main.testUnsafePointer]
-          InjectionPoints: [{PC: "0x84c560", Frameless: true}]
+        - ID: 81
+          Type: 487 EventRootType Probe[main.testUnsafePointer]
+          InjectionPoints: [{PC: "0x84cf70", Frameless: true}]
           Condition: null
     - id: testVeryLargeArray
       version: 0
@@ -1455,8 +1591,8 @@ Probes:
       subprogram: {subprogram: 18}
       events:
         - ID: 18
-          Type: 299 EventRootType Probe[main.testVeryLargeArray]
-          InjectionPoints: [{PC: "0x849670", Frameless: true}]
+          Type: 424 EventRootType Probe[main.testVeryLargeArray]
+          InjectionPoints: [{PC: "0x849aa0", Frameless: true}]
           Condition: null
     - id: testVeryLargeSlice
       version: 0
@@ -1466,430 +1602,430 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 87}
+      subprogram: {subprogram: 95}
       events:
-        - ID: 87
-          Type: 368 EventRootType Probe[main.testVeryLargeSlice]
-          InjectionPoints: [{PC: "0x84ca90", Frameless: true}]
+        - ID: 95
+          Type: 501 EventRootType Probe[main.testVeryLargeSlice]
+          InjectionPoints: [{PC: "0x84d4a0", Frameless: true}]
           Condition: null
 Subprograms:
     - ID: 1
       Name: main.testByteArray
-      OutOfLinePCRanges: [0x849540..0x849550]
+      OutOfLinePCRanges: [0x849970..0x849980]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 36 ArrayType [2]uint8
           Locations:
-            - Range: 0x849540..0x849550
+            - Range: 0x849970..0x849980
               Pieces: [{Size: 2, Op: {CfaOffset: 8}}]
           IsParameter: true
           IsReturn: false
     - ID: 2
       Name: main.testRuneArray
-      OutOfLinePCRanges: [0x849550..0x849560]
+      OutOfLinePCRanges: [0x849980..0x849990]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 37 ArrayType [2]int32
           Locations:
-            - Range: 0x849550..0x849560
+            - Range: 0x849980..0x849990
               Pieces: [{Size: 8, Op: {CfaOffset: 8}}]
           IsParameter: true
           IsReturn: false
     - ID: 3
       Name: main.testStringArray
-      OutOfLinePCRanges: [0x849560..0x849570]
+      OutOfLinePCRanges: [0x849990..0x8499a0]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 38 ArrayType [2]string
           Locations:
-            - Range: 0x849560..0x849570
+            - Range: 0x849990..0x8499a0
               Pieces: [{Size: 32, Op: {CfaOffset: 8}}]
           IsParameter: true
           IsReturn: false
     - ID: 4
       Name: main.testBoolArray
-      OutOfLinePCRanges: [0x849570..0x849580]
+      OutOfLinePCRanges: [0x8499a0..0x8499b0]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 39 ArrayType [2]bool
           Locations:
-            - Range: 0x849570..0x849580
+            - Range: 0x8499a0..0x8499b0
               Pieces: [{Size: 2, Op: {CfaOffset: 8}}]
           IsParameter: true
           IsReturn: false
     - ID: 5
       Name: main.testIntArray
-      OutOfLinePCRanges: [0x849580..0x849590]
+      OutOfLinePCRanges: [0x8499b0..0x8499c0]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 40 ArrayType [2]int
           Locations:
-            - Range: 0x849580..0x849590
+            - Range: 0x8499b0..0x8499c0
               Pieces: [{Size: 16, Op: {CfaOffset: 8}}]
           IsParameter: true
           IsReturn: false
     - ID: 6
       Name: main.testInt8Array
-      OutOfLinePCRanges: [0x849590..0x8495a0]
+      OutOfLinePCRanges: [0x8499c0..0x8499d0]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 41 ArrayType [2]int8
           Locations:
-            - Range: 0x849590..0x8495a0
+            - Range: 0x8499c0..0x8499d0
               Pieces: [{Size: 2, Op: {CfaOffset: 8}}]
           IsParameter: true
           IsReturn: false
     - ID: 7
       Name: main.testInt16Array
-      OutOfLinePCRanges: [0x8495a0..0x8495b0]
+      OutOfLinePCRanges: [0x8499d0..0x8499e0]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 42 ArrayType [2]int16
           Locations:
-            - Range: 0x8495a0..0x8495b0
+            - Range: 0x8499d0..0x8499e0
               Pieces: [{Size: 4, Op: {CfaOffset: 8}}]
           IsParameter: true
           IsReturn: false
     - ID: 8
       Name: main.testInt32Array
-      OutOfLinePCRanges: [0x8495b0..0x8495c0]
+      OutOfLinePCRanges: [0x8499e0..0x8499f0]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 37 ArrayType [2]int32
           Locations:
-            - Range: 0x8495b0..0x8495c0
+            - Range: 0x8499e0..0x8499f0
               Pieces: [{Size: 8, Op: {CfaOffset: 8}}]
           IsParameter: true
           IsReturn: false
     - ID: 9
       Name: main.testInt64Array
-      OutOfLinePCRanges: [0x8495c0..0x8495d0]
+      OutOfLinePCRanges: [0x8499f0..0x849a00]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 43 ArrayType [2]int64
           Locations:
-            - Range: 0x8495c0..0x8495d0
+            - Range: 0x8499f0..0x849a00
               Pieces: [{Size: 16, Op: {CfaOffset: 8}}]
           IsParameter: true
           IsReturn: false
     - ID: 10
       Name: main.testUintArray
-      OutOfLinePCRanges: [0x8495d0..0x8495e0]
+      OutOfLinePCRanges: [0x849a00..0x849a10]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 44 ArrayType [2]uint
           Locations:
-            - Range: 0x8495d0..0x8495e0
+            - Range: 0x849a00..0x849a10
               Pieces: [{Size: 16, Op: {CfaOffset: 8}}]
           IsParameter: true
           IsReturn: false
     - ID: 11
       Name: main.testUint8Array
-      OutOfLinePCRanges: [0x8495e0..0x8495f0]
+      OutOfLinePCRanges: [0x849a10..0x849a20]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 36 ArrayType [2]uint8
           Locations:
-            - Range: 0x8495e0..0x8495f0
+            - Range: 0x849a10..0x849a20
               Pieces: [{Size: 2, Op: {CfaOffset: 8}}]
           IsParameter: true
           IsReturn: false
     - ID: 12
       Name: main.testUint16Array
-      OutOfLinePCRanges: [0x8495f0..0x849600]
+      OutOfLinePCRanges: [0x849a20..0x849a30]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 45 ArrayType [2]uint16
           Locations:
-            - Range: 0x8495f0..0x849600
+            - Range: 0x849a20..0x849a30
               Pieces: [{Size: 4, Op: {CfaOffset: 8}}]
           IsParameter: true
           IsReturn: false
     - ID: 13
       Name: main.testUint32Array
-      OutOfLinePCRanges: [0x849600..0x849610]
+      OutOfLinePCRanges: [0x849a30..0x849a40]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 46 ArrayType [2]uint32
           Locations:
-            - Range: 0x849600..0x849610
+            - Range: 0x849a30..0x849a40
               Pieces: [{Size: 8, Op: {CfaOffset: 8}}]
           IsParameter: true
           IsReturn: false
     - ID: 14
       Name: main.testUint64Array
-      OutOfLinePCRanges: [0x849610..0x849620]
+      OutOfLinePCRanges: [0x849a40..0x849a50]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 47 ArrayType [2]uint64
           Locations:
-            - Range: 0x849610..0x849620
+            - Range: 0x849a40..0x849a50
               Pieces: [{Size: 16, Op: {CfaOffset: 8}}]
           IsParameter: true
           IsReturn: false
     - ID: 15
       Name: main.testArrayOfArrays
-      OutOfLinePCRanges: [0x849620..0x849630]
+      OutOfLinePCRanges: [0x849a50..0x849a60]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 48 ArrayType [2][2]int
           Locations:
-            - Range: 0x849620..0x849630
+            - Range: 0x849a50..0x849a60
               Pieces: [{Size: 32, Op: {CfaOffset: 8}}]
           IsParameter: true
           IsReturn: false
     - ID: 16
       Name: main.testArrayOfStrings
-      OutOfLinePCRanges: [0x849630..0x849640]
+      OutOfLinePCRanges: [0x849a60..0x849a70]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 38 ArrayType [2]string
           Locations:
-            - Range: 0x849630..0x849640
+            - Range: 0x849a60..0x849a70
               Pieces: [{Size: 32, Op: {CfaOffset: 8}}]
           IsParameter: true
           IsReturn: false
     - ID: 17
       Name: main.testArrayOfArraysOfArrays
-      OutOfLinePCRanges: [0x849640..0x849650]
+      OutOfLinePCRanges: [0x849a70..0x849a80]
       InlinePCRanges: []
       Variables:
         - Name: b
           Type: 49 ArrayType [2][2][2]int
           Locations:
-            - Range: 0x849640..0x849650
+            - Range: 0x849a70..0x849a80
               Pieces: [{Size: 64, Op: {CfaOffset: 8}}]
           IsParameter: true
           IsReturn: false
     - ID: 18
       Name: main.testVeryLargeArray
-      OutOfLinePCRanges: [0x849670..0x849680]
+      OutOfLinePCRanges: [0x849aa0..0x849ab0]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 50 ArrayType [100]uint
           Locations:
-            - Range: 0x849670..0x849680
+            - Range: 0x849aa0..0x849ab0
               Pieces: [{Size: 800, Op: {CfaOffset: 8}}]
           IsParameter: true
           IsReturn: false
     - ID: 19
       Name: main.testSingleByte
-      OutOfLinePCRanges: [0x8499a0..0x8499b0]
+      OutOfLinePCRanges: [0x849dd0..0x849de0]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 3 BaseType uint8
           Locations:
-            - Range: 0x8499a0..0x8499b0
+            - Range: 0x849dd0..0x849de0
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
     - ID: 20
       Name: main.testSingleRune
-      OutOfLinePCRanges: [0x8499b0..0x8499c0]
+      OutOfLinePCRanges: [0x849de0..0x849df0]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 12 BaseType int32
           Locations:
-            - Range: 0x8499b0..0x8499c0
+            - Range: 0x849de0..0x849df0
               Pieces: [{Size: 4, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
     - ID: 21
       Name: main.testSingleBool
-      OutOfLinePCRanges: [0x8499c0..0x8499d0]
+      OutOfLinePCRanges: [0x849df0..0x849e00]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 4 BaseType bool
           Locations:
-            - Range: 0x8499c0..0x8499d0
+            - Range: 0x849df0..0x849e00
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
     - ID: 22
       Name: main.testSingleInt
-      OutOfLinePCRanges: [0x8499d0..0x8499e0]
+      OutOfLinePCRanges: [0x849e00..0x849e10]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 7 BaseType int
           Locations:
-            - Range: 0x8499d0..0x8499e0
+            - Range: 0x849e00..0x849e10
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
     - ID: 23
       Name: main.testSingleInt8
-      OutOfLinePCRanges: [0x8499e0..0x8499f0]
+      OutOfLinePCRanges: [0x849e10..0x849e20]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 16 BaseType int8
           Locations:
-            - Range: 0x8499e0..0x8499f0
+            - Range: 0x849e10..0x849e20
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
     - ID: 24
       Name: main.testSingleInt16
-      OutOfLinePCRanges: [0x8499f0..0x849a00]
+      OutOfLinePCRanges: [0x849e20..0x849e30]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 23 BaseType int16
           Locations:
-            - Range: 0x8499f0..0x849a00
+            - Range: 0x849e20..0x849e30
               Pieces: [{Size: 2, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
     - ID: 25
       Name: main.testSingleInt32
-      OutOfLinePCRanges: [0x849a00..0x849a10]
+      OutOfLinePCRanges: [0x849e30..0x849e40]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 12 BaseType int32
           Locations:
-            - Range: 0x849a00..0x849a10
+            - Range: 0x849e30..0x849e40
               Pieces: [{Size: 4, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
     - ID: 26
       Name: main.testSingleInt64
-      OutOfLinePCRanges: [0x849a10..0x849a20]
+      OutOfLinePCRanges: [0x849e40..0x849e50]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 13 BaseType int64
           Locations:
-            - Range: 0x849a10..0x849a20
+            - Range: 0x849e40..0x849e50
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
     - ID: 27
       Name: main.testSingleUint
-      OutOfLinePCRanges: [0x849a20..0x849a30]
+      OutOfLinePCRanges: [0x849e50..0x849e60]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 10 BaseType uint
           Locations:
-            - Range: 0x849a20..0x849a30
+            - Range: 0x849e50..0x849e60
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
     - ID: 28
       Name: main.testSingleUint8
-      OutOfLinePCRanges: [0x849a30..0x849a40]
+      OutOfLinePCRanges: [0x849e60..0x849e70]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 3 BaseType uint8
           Locations:
-            - Range: 0x849a30..0x849a40
+            - Range: 0x849e60..0x849e70
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
     - ID: 29
       Name: main.testSingleUint16
-      OutOfLinePCRanges: [0x849a40..0x849a50]
+      OutOfLinePCRanges: [0x849e70..0x849e80]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 6 BaseType uint16
           Locations:
-            - Range: 0x849a40..0x849a50
+            - Range: 0x849e70..0x849e80
               Pieces: [{Size: 2, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
     - ID: 30
       Name: main.testSingleUint32
-      OutOfLinePCRanges: [0x849a50..0x849a60]
+      OutOfLinePCRanges: [0x849e80..0x849e90]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 2 BaseType uint32
           Locations:
-            - Range: 0x849a50..0x849a60
+            - Range: 0x849e80..0x849e90
               Pieces: [{Size: 4, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
     - ID: 31
       Name: main.testSingleUint64
-      OutOfLinePCRanges: [0x849a60..0x849a70]
+      OutOfLinePCRanges: [0x849e90..0x849ea0]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 8 BaseType uint64
           Locations:
-            - Range: 0x849a60..0x849a70
+            - Range: 0x849e90..0x849ea0
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
     - ID: 32
       Name: main.testSingleFloat32
-      OutOfLinePCRanges: [0x849a70..0x849a80]
+      OutOfLinePCRanges: [0x849ea0..0x849eb0]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 17 BaseType float32
           Locations:
-            - Range: 0x849a70..0x849a80
+            - Range: 0x849ea0..0x849eb0
               Pieces: [{Size: 4, Op: {RegNo: 64, Shift: 0}}]
           IsParameter: true
           IsReturn: false
     - ID: 33
       Name: main.testSingleFloat64
-      OutOfLinePCRanges: [0x849a80..0x849a90]
+      OutOfLinePCRanges: [0x849eb0..0x849ec0]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 18 BaseType float64
           Locations:
-            - Range: 0x849a80..0x849a90
+            - Range: 0x849eb0..0x849ec0
               Pieces: [{Size: 8, Op: {RegNo: 64, Shift: 0}}]
           IsParameter: true
           IsReturn: false
     - ID: 34
       Name: main.testTypeAlias
-      OutOfLinePCRanges: [0x849a90..0x849aa0]
+      OutOfLinePCRanges: [0x849ec0..0x849ed0]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 51 BaseType main.typeAlias
           Locations:
-            - Range: 0x849a90..0x849aa0
+            - Range: 0x849ec0..0x849ed0
               Pieces: [{Size: 2, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
     - ID: 35
       Name: main.testBigStruct
-      OutOfLinePCRanges: [0x849ba0..0x849bc0]
+      OutOfLinePCRanges: [0x849fd0..0x849ff0]
       InlinePCRanges: []
       Variables:
         - Name: b
           Type: 52 StructureType main.bigStruct
           Locations:
-            - Range: 0x849ba0..0x849bc0
+            - Range: 0x849fd0..0x849ff0
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -1906,14 +2042,116 @@ Subprograms:
           IsParameter: true
           IsReturn: false
     - ID: 36
+      Name: main.testDeepPtr1
+      OutOfLinePCRanges: [0x84a0a0..0x84a0b0]
+      InlinePCRanges: []
+      Variables:
+        - Name: a
+          Type: 56 StructureType main.deepPtr1
+          Locations:
+            - Range: 0x84a0a0..0x84a0b0
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+          IsParameter: true
+          IsReturn: false
+    - ID: 37
+      Name: main.testDeepPtr7
+      OutOfLinePCRanges: [0x84a0b0..0x84a0c0]
+      InlinePCRanges: []
+      Variables:
+        - Name: a
+          Type: 59 PointerType *main.deepPtr7
+          Locations:
+            - Range: 0x84a0b0..0x84a0c0
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+          IsParameter: true
+          IsReturn: false
+    - ID: 38
+      Name: main.testDeepSlice1
+      OutOfLinePCRanges: [0x84a250..0x84a260]
+      InlinePCRanges: []
+      Variables:
+        - Name: a
+          Type: 61 StructureType main.deepSlice1
+          Locations:
+            - Range: 0x84a250..0x84a260
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 0, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 1, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 2, Shift: 0}
+          IsParameter: true
+          IsReturn: false
+    - ID: 39
+      Name: main.testDeepSlice7
+      OutOfLinePCRanges: [0x84a260..0x84a270]
+      InlinePCRanges: []
+      Variables:
+        - Name: a
+          Type: 65 PointerType *main.deepSlice7
+          Locations:
+            - Range: 0x84a260..0x84a270
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+          IsParameter: true
+          IsReturn: false
+    - ID: 40
+      Name: main.testDeepMap1
+      OutOfLinePCRanges: [0x84a3b0..0x84a3c0]
+      InlinePCRanges: []
+      Variables:
+        - Name: a
+          Type: 67 StructureType main.deepMap1
+          Locations:
+            - Range: 0x84a3b0..0x84a3c0
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+          IsParameter: true
+          IsReturn: false
+    - ID: 41
+      Name: main.testDeepMap7
+      OutOfLinePCRanges: [0x84a3c0..0x84a3d0]
+      InlinePCRanges: []
+      Variables:
+        - Name: a
+          Type: 73 PointerType *main.deepMap7
+          Locations:
+            - Range: 0x84a3c0..0x84a3d0
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+          IsParameter: true
+          IsReturn: false
+    - ID: 42
+      Name: main.testStringType1
+      OutOfLinePCRanges: [0x84a3d0..0x84a3e0]
+      InlinePCRanges: []
+      Variables:
+        - Name: a
+          Type: 75 PointerType *main.stringType1
+          Locations:
+            - Range: 0x84a3d0..0x84a3e0
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+          IsParameter: true
+          IsReturn: false
+    - ID: 43
+      Name: main.testStringType2
+      OutOfLinePCRanges: [0x84a3e0..0x84a3f0]
+      InlinePCRanges: []
+      Variables:
+        - Name: a
+          Type: 77 PointerType **main.stringType2
+          Locations:
+            - Range: 0x84a3e0..0x84a3f0
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+          IsParameter: true
+          IsReturn: false
+    - ID: 44
       Name: main.testEsotericStack
-      OutOfLinePCRanges: [0x849d60..0x849e30]
+      OutOfLinePCRanges: [0x84a770..0x84a840]
       InlinePCRanges: []
       Variables:
         - Name: e
-          Type: 56 StructureType main.esotericStack
+          Type: 79 StructureType main.esotericStack
           Locations:
-            - Range: 0x849d60..0x849da8
+            - Range: 0x84a770..0x84a7b8
               Pieces:
                 - Size: 4
                   Op: {RegNo: 0, Shift: 0}
@@ -1933,7 +2171,7 @@ Subprograms:
                   Op: {RegNo: 7, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 8, Shift: 0}
-            - Range: 0x849da8..0x849dac
+            - Range: 0x84a7b8..0x84a7bc
               Pieces:
                 - Size: 4
                   Op: null
@@ -1953,7 +2191,7 @@ Subprograms:
                   Op: {RegNo: 7, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 8, Shift: 0}
-            - Range: 0x849dac..0x849db0
+            - Range: 0x84a7bc..0x84a7c0
               Pieces:
                 - Size: 4
                   Op: null
@@ -1975,146 +2213,146 @@ Subprograms:
                   Op: {RegNo: 8, Shift: 0}
           IsParameter: true
           IsReturn: false
-    - ID: 37
+    - ID: 45
       Name: main.testEsotericHeap
-      OutOfLinePCRanges: [0x849e30..0x849eb0]
+      OutOfLinePCRanges: [0x84a840..0x84a8c0]
       InlinePCRanges: []
       Variables:
         - Name: e
-          Type: 61 PointerType *main.esotericHeap
+          Type: 84 PointerType *main.esotericHeap
           Locations:
-            - Range: 0x849e30..0x849e68
+            - Range: 0x84a840..0x84a878
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 38
+    - ID: 46
       Name: main.testInlinedBA
-      OutOfLinePCRanges: [0x84a270..0x84a300]
+      OutOfLinePCRanges: [0x84ac80..0x84ad10]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 7 BaseType int
           Locations:
-            - Range: 0x84a270..0x84a2a8
+            - Range: 0x84ac80..0x84acb8
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 39
+    - ID: 47
       Name: main.testInlinedBB
-      OutOfLinePCRanges: [0x84a300..0x84a3c0]
+      OutOfLinePCRanges: [0x84ad10..0x84add0]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 7 BaseType int
           Locations:
-            - Range: 0x84a300..0x84a31c
+            - Range: 0x84ad10..0x84ad2c
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
         - Name: y
           Type: 7 BaseType int
           Locations:
-            - Range: 0x84a300..0x84a32c
+            - Range: 0x84ad10..0x84ad3c
               Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
           IsParameter: true
           IsReturn: false
         - Name: z
           Type: 7 BaseType int
           Locations:
-            - Range: 0x84a31c..0x84a32c
+            - Range: 0x84ad2c..0x84ad3c
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x84a32c..0x84a3c0
+            - Range: 0x84ad3c..0x84add0
               Pieces: [{Size: 8, Op: {CfaOffset: -48}}]
           IsParameter: false
           IsReturn: false
-    - ID: 40
+    - ID: 48
       Name: main.testInlinedBBA
-      OutOfLinePCRanges: [0x84a3c0..0x84a440]
+      OutOfLinePCRanges: [0x84add0..0x84ae50]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 7 BaseType int
           Locations:
-            - Range: 0x84a3c0..0x84a3e4
+            - Range: 0x84add0..0x84adf4
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 41
+    - ID: 49
       Name: main.testInlinedBC
-      OutOfLinePCRanges: [0x84a440..0x84a560]
+      OutOfLinePCRanges: [0x84ae50..0x84af70]
       InlinePCRanges: []
       Variables:
         - Name: s
           Type: 7 BaseType int
           Locations:
-            - Range: 0x84a4a8..0x84a4b0
+            - Range: 0x84aeb8..0x84aec0
               Pieces: [{Size: 8, Op: {CfaOffset: -72}}]
-            - Range: 0x84a4b0..0x84a4c8
+            - Range: 0x84aec0..0x84aed8
               Pieces: [{Size: 8, Op: {CfaOffset: -72}}]
-            - Range: 0x84a4c8..0x84a4dc
+            - Range: 0x84aed8..0x84aeec
               Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
           IsParameter: false
           IsReturn: false
         - Name: i
           Type: 7 BaseType int
           Locations:
-            - Range: 0x84a4a4..0x84a4ac
+            - Range: 0x84aeb4..0x84aebc
               Pieces: [{Size: 8, Op: {CfaOffset: -64}}]
-            - Range: 0x84a4ac..0x84a4c8
+            - Range: 0x84aebc..0x84aed8
               Pieces: [{Size: 8, Op: {CfaOffset: -64}}]
-            - Range: 0x84a4c8..0x84a4d8
+            - Range: 0x84aed8..0x84aee8
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: false
           IsReturn: false
-    - ID: 42
+    - ID: 50
       Name: main.testFrameless
-      OutOfLinePCRanges: [0x84a560..0x84a570]
+      OutOfLinePCRanges: [0x84af70..0x84af80]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 7 BaseType int
           Locations:
-            - Range: 0x84a560..0x84a568
+            - Range: 0x84af70..0x84af78
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
         - Name: ~r0
           Type: 7 BaseType int
-          Locations: [{Range: 0x84a560..0x84a570, Pieces: []}]
+          Locations: [{Range: 0x84af70..0x84af80, Pieces: []}]
           IsParameter: true
           IsReturn: true
-    - ID: 43
+    - ID: 51
       Name: main.testFramelessArray
-      OutOfLinePCRanges: [0x84a570..0x84a5d0]
+      OutOfLinePCRanges: [0x84af80..0x84afe0]
       InlinePCRanges: []
       Variables:
         - Name: a
-          Type: 63 ArrayType [5]int
+          Type: 86 ArrayType [5]int
           Locations:
-            - Range: 0x84a570..0x84a5d0
+            - Range: 0x84af80..0x84afe0
               Pieces: [{Size: 40, Op: {CfaOffset: 8}}]
           IsParameter: true
           IsReturn: false
         - Name: ~r0
           Type: 7 BaseType int
-          Locations: [{Range: 0x84a570..0x84a5d0, Pieces: []}]
+          Locations: [{Range: 0x84af80..0x84afe0, Pieces: []}]
           IsParameter: true
           IsReturn: true
-    - ID: 44
+    - ID: 52
       Name: main.testInterface
-      OutOfLinePCRanges: [0x84a800..0x84a850]
+      OutOfLinePCRanges: [0x84b210..0x84b260]
       InlinePCRanges: []
       Variables:
         - Name: b
-          Type: 64 GoInterfaceType main.behavior
+          Type: 87 GoInterfaceType main.behavior
           Locations:
-            - Range: 0x84a800..0x84a828
+            - Range: 0x84b210..0x84b238
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0x84a828..0x84a82c
+            - Range: 0x84b238..0x84b23c
               Pieces:
                 - Size: 8
                   Op: null
@@ -2124,24 +2362,24 @@ Subprograms:
           IsReturn: false
         - Name: ~r0
           Type: 9 GoStringHeaderType string
-          Locations: [{Range: 0x84a800..0x84a850, Pieces: []}]
+          Locations: [{Range: 0x84b210..0x84b260, Pieces: []}]
           IsParameter: true
           IsReturn: true
-    - ID: 45
+    - ID: 53
       Name: main.testAny
-      OutOfLinePCRanges: [0x84a850..0x84a8c0]
+      OutOfLinePCRanges: [0x84b260..0x84b2d0]
       InlinePCRanges: []
       Variables:
         - Name: a
-          Type: 58 GoEmptyInterfaceType interface {}
+          Type: 81 GoEmptyInterfaceType interface {}
           Locations:
-            - Range: 0x84a850..0x84a880
+            - Range: 0x84b260..0x84b290
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0x84a880..0x84a884
+            - Range: 0x84b290..0x84b294
               Pieces:
                 - Size: 8
                   Op: null
@@ -2151,18 +2389,18 @@ Subprograms:
           IsReturn: false
         - Name: ~r0
           Type: 9 GoStringHeaderType string
-          Locations: [{Range: 0x84a850..0x84a8c0, Pieces: []}]
+          Locations: [{Range: 0x84b260..0x84b2d0, Pieces: []}]
           IsParameter: true
           IsReturn: true
-    - ID: 46
+    - ID: 54
       Name: main.testError
-      OutOfLinePCRanges: [0x84a8c0..0x84a8d0]
+      OutOfLinePCRanges: [0x84b2d0..0x84b2e0]
       InlinePCRanges: []
       Variables:
         - Name: e
           Type: 14 GoInterfaceType error
           Locations:
-            - Range: 0x84a8c0..0x84a8d0
+            - Range: 0x84b2d0..0x84b2e0
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -2170,309 +2408,309 @@ Subprograms:
                   Op: {RegNo: 1, Shift: 0}
           IsParameter: true
           IsReturn: false
-    - ID: 47
+    - ID: 55
       Name: main.testStructWithMap
-      OutOfLinePCRanges: [0x84ace0..0x84acf0]
+      OutOfLinePCRanges: [0x84b6f0..0x84b700]
       InlinePCRanges: []
       Variables:
         - Name: s
-          Type: 65 StructureType main.structWithMap
+          Type: 88 StructureType main.structWithMap
           Locations:
-            - Range: 0x84ace0..0x84acf0
-              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-          IsParameter: true
-          IsReturn: false
-    - ID: 48
-      Name: main.testMapStringToStruct
-      OutOfLinePCRanges: [0x84acf0..0x84ad00]
-      InlinePCRanges: []
-      Variables:
-        - Name: m
-          Type: 71 GoMapType map[string]main.nestedStruct
-          Locations:
-            - Range: 0x84acf0..0x84ad00
-              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-          IsParameter: true
-          IsReturn: false
-    - ID: 49
-      Name: main.testMapStringToInt
-      OutOfLinePCRanges: [0x84ad00..0x84ad10]
-      InlinePCRanges: []
-      Variables:
-        - Name: m
-          Type: 76 GoMapType map[string]int
-          Locations:
-            - Range: 0x84ad00..0x84ad10
-              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-          IsParameter: true
-          IsReturn: false
-    - ID: 50
-      Name: main.testMapStringToSlice
-      OutOfLinePCRanges: [0x84ad10..0x84ad20]
-      InlinePCRanges: []
-      Variables:
-        - Name: m
-          Type: 81 GoMapType map[string][]string
-          Locations:
-            - Range: 0x84ad10..0x84ad20
-              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-          IsParameter: true
-          IsReturn: false
-    - ID: 51
-      Name: main.testMapArrayToArray
-      OutOfLinePCRanges: [0x84ad20..0x84ad30]
-      InlinePCRanges: []
-      Variables:
-        - Name: m
-          Type: 86 GoMapType map[[4]string][2]int
-          Locations:
-            - Range: 0x84ad20..0x84ad30
-              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-          IsParameter: true
-          IsReturn: false
-    - ID: 52
-      Name: main.testSmallMap
-      OutOfLinePCRanges: [0x84ad30..0x84ad40]
-      InlinePCRanges: []
-      Variables:
-        - Name: m
-          Type: 76 GoMapType map[string]int
-          Locations:
-            - Range: 0x84ad30..0x84ad40
-              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-          IsParameter: true
-          IsReturn: false
-    - ID: 53
-      Name: main.testArrayOfMaps
-      OutOfLinePCRanges: [0x84ad40..0x84ad50]
-      InlinePCRanges: []
-      Variables:
-        - Name: m
-          Type: 91 ArrayType [2]map[string]int
-          Locations:
-            - Range: 0x84ad40..0x84ad50
-              Pieces: [{Size: 16, Op: {CfaOffset: 8}}]
-          IsParameter: true
-          IsReturn: false
-    - ID: 54
-      Name: main.testPointerToMap
-      OutOfLinePCRanges: [0x84ad50..0x84ad60]
-      InlinePCRanges: []
-      Variables:
-        - Name: m
-          Type: 92 PointerType *map[string]int
-          Locations:
-            - Range: 0x84ad50..0x84ad60
-              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-          IsParameter: true
-          IsReturn: false
-    - ID: 55
-      Name: main.testMapIntToInt
-      OutOfLinePCRanges: [0x84ad60..0x84ad70]
-      InlinePCRanges: []
-      Variables:
-        - Name: m
-          Type: 66 GoMapType map[int]int
-          Locations:
-            - Range: 0x84ad60..0x84ad70
+            - Range: 0x84b6f0..0x84b700
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
     - ID: 56
-      Name: main.testMapMassive
-      OutOfLinePCRanges: [0x84ad70..0x84ad80]
+      Name: main.testMapStringToStruct
+      OutOfLinePCRanges: [0x84b700..0x84b710]
       InlinePCRanges: []
       Variables:
-        - Name: redactMyEntries
-          Type: 93 GoMapType map[string][]main.structWithMap
+        - Name: m
+          Type: 94 GoMapType map[string]main.nestedStruct
           Locations:
-            - Range: 0x84ad70..0x84ad80
+            - Range: 0x84b700..0x84b710
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
     - ID: 57
-      Name: main.testMapEmbeddedMaps
-      OutOfLinePCRanges: [0x84ad80..0x84ad90]
+      Name: main.testMapStringToInt
+      OutOfLinePCRanges: [0x84b710..0x84b720]
       InlinePCRanges: []
       Variables:
         - Name: m
-          Type: 93 GoMapType map[string][]main.structWithMap
+          Type: 99 GoMapType map[string]int
           Locations:
-            - Range: 0x84ad80..0x84ad90
+            - Range: 0x84b710..0x84b720
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
     - ID: 58
-      Name: main.testMapWithLinkedList
-      OutOfLinePCRanges: [0x84ad90..0x84ada0]
+      Name: main.testMapStringToSlice
+      OutOfLinePCRanges: [0x84b720..0x84b730]
       InlinePCRanges: []
       Variables:
         - Name: m
-          Type: 98 GoMapType map[bool]main.node
+          Type: 104 GoMapType map[string][]string
           Locations:
-            - Range: 0x84ad90..0x84ada0
+            - Range: 0x84b720..0x84b730
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
     - ID: 59
-      Name: main.testMapWithSmallValue
-      OutOfLinePCRanges: [0x84ada0..0x84adb0]
+      Name: main.testMapArrayToArray
+      OutOfLinePCRanges: [0x84b730..0x84b740]
       InlinePCRanges: []
       Variables:
         - Name: m
-          Type: 103 GoMapType map[int]uint8
+          Type: 109 GoMapType map[[4]string][2]int
           Locations:
-            - Range: 0x84ada0..0x84adb0
+            - Range: 0x84b730..0x84b740
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
     - ID: 60
-      Name: main.testMapWithSmallValueMassive
-      OutOfLinePCRanges: [0x84adb0..0x84adc0]
+      Name: main.testSmallMap
+      OutOfLinePCRanges: [0x84b740..0x84b750]
       InlinePCRanges: []
       Variables:
-        - Name: redactMyEntries
-          Type: 103 GoMapType map[int]uint8
+        - Name: m
+          Type: 99 GoMapType map[string]int
           Locations:
-            - Range: 0x84adb0..0x84adc0
+            - Range: 0x84b740..0x84b750
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
     - ID: 61
-      Name: main.testMapWithSmallKeyAndValue
-      OutOfLinePCRanges: [0x84adc0..0x84add0]
+      Name: main.testArrayOfMaps
+      OutOfLinePCRanges: [0x84b750..0x84b760]
       InlinePCRanges: []
       Variables:
         - Name: m
-          Type: 108 GoMapType map[uint8]uint8
+          Type: 114 ArrayType [2]map[string]int
           Locations:
-            - Range: 0x84adc0..0x84add0
-              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+            - Range: 0x84b750..0x84b760
+              Pieces: [{Size: 16, Op: {CfaOffset: 8}}]
           IsParameter: true
           IsReturn: false
     - ID: 62
-      Name: main.testMapWithSmallKeyAndValueMassive
-      OutOfLinePCRanges: [0x84add0..0x84ade0]
+      Name: main.testPointerToMap
+      OutOfLinePCRanges: [0x84b760..0x84b770]
       InlinePCRanges: []
       Variables:
         - Name: m
-          Type: 108 GoMapType map[uint8]uint8
+          Type: 115 PointerType *map[string]int
           Locations:
-            - Range: 0x84add0..0x84ade0
+            - Range: 0x84b760..0x84b770
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
     - ID: 63
-      Name: main.testMapSmallKeySmallValue
-      OutOfLinePCRanges: [0x84ade0..0x84adf0]
+      Name: main.testMapIntToInt
+      OutOfLinePCRanges: [0x84b770..0x84b780]
       InlinePCRanges: []
       Variables:
         - Name: m
-          Type: 108 GoMapType map[uint8]uint8
+          Type: 89 GoMapType map[int]int
           Locations:
-            - Range: 0x84ade0..0x84adf0
+            - Range: 0x84b770..0x84b780
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
     - ID: 64
-      Name: main.testMapSmallKeyLargeValue
-      OutOfLinePCRanges: [0x84adf0..0x84ae00]
+      Name: main.testMapMassive
+      OutOfLinePCRanges: [0x84b780..0x84b790]
       InlinePCRanges: []
       Variables:
-        - Name: m
-          Type: 113 GoMapType map[uint8][4]int
+        - Name: redactMyEntries
+          Type: 116 GoMapType map[string][]main.structWithMap
           Locations:
-            - Range: 0x84adf0..0x84ae00
+            - Range: 0x84b780..0x84b790
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
     - ID: 65
-      Name: main.testMapLargeKeySmallValue
-      OutOfLinePCRanges: [0x84ae00..0x84ae10]
+      Name: main.testMapEmbeddedMaps
+      OutOfLinePCRanges: [0x84b790..0x84b7a0]
       InlinePCRanges: []
       Variables:
         - Name: m
-          Type: 118 GoMapType map[[4]int]uint8
+          Type: 116 GoMapType map[string][]main.structWithMap
           Locations:
-            - Range: 0x84ae00..0x84ae10
+            - Range: 0x84b790..0x84b7a0
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
     - ID: 66
-      Name: main.testMapLargeKeyLargeValue
-      OutOfLinePCRanges: [0x84ae10..0x84ae20]
+      Name: main.testMapWithLinkedList
+      OutOfLinePCRanges: [0x84b7a0..0x84b7b0]
       InlinePCRanges: []
       Variables:
         - Name: m
-          Type: 123 GoMapType map[[4]int][4]int
+          Type: 121 GoMapType map[bool]main.node
           Locations:
-            - Range: 0x84ae10..0x84ae20
+            - Range: 0x84b7a0..0x84b7b0
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
     - ID: 67
+      Name: main.testMapWithSmallValue
+      OutOfLinePCRanges: [0x84b7b0..0x84b7c0]
+      InlinePCRanges: []
+      Variables:
+        - Name: m
+          Type: 126 GoMapType map[int]uint8
+          Locations:
+            - Range: 0x84b7b0..0x84b7c0
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+          IsParameter: true
+          IsReturn: false
+    - ID: 68
+      Name: main.testMapWithSmallValueMassive
+      OutOfLinePCRanges: [0x84b7c0..0x84b7d0]
+      InlinePCRanges: []
+      Variables:
+        - Name: redactMyEntries
+          Type: 126 GoMapType map[int]uint8
+          Locations:
+            - Range: 0x84b7c0..0x84b7d0
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+          IsParameter: true
+          IsReturn: false
+    - ID: 69
+      Name: main.testMapWithSmallKeyAndValue
+      OutOfLinePCRanges: [0x84b7d0..0x84b7e0]
+      InlinePCRanges: []
+      Variables:
+        - Name: m
+          Type: 131 GoMapType map[uint8]uint8
+          Locations:
+            - Range: 0x84b7d0..0x84b7e0
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+          IsParameter: true
+          IsReturn: false
+    - ID: 70
+      Name: main.testMapWithSmallKeyAndValueMassive
+      OutOfLinePCRanges: [0x84b7e0..0x84b7f0]
+      InlinePCRanges: []
+      Variables:
+        - Name: m
+          Type: 131 GoMapType map[uint8]uint8
+          Locations:
+            - Range: 0x84b7e0..0x84b7f0
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+          IsParameter: true
+          IsReturn: false
+    - ID: 71
+      Name: main.testMapSmallKeySmallValue
+      OutOfLinePCRanges: [0x84b7f0..0x84b800]
+      InlinePCRanges: []
+      Variables:
+        - Name: m
+          Type: 131 GoMapType map[uint8]uint8
+          Locations:
+            - Range: 0x84b7f0..0x84b800
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+          IsParameter: true
+          IsReturn: false
+    - ID: 72
+      Name: main.testMapSmallKeyLargeValue
+      OutOfLinePCRanges: [0x84b800..0x84b810]
+      InlinePCRanges: []
+      Variables:
+        - Name: m
+          Type: 136 GoMapType map[uint8][4]int
+          Locations:
+            - Range: 0x84b800..0x84b810
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+          IsParameter: true
+          IsReturn: false
+    - ID: 73
+      Name: main.testMapLargeKeySmallValue
+      OutOfLinePCRanges: [0x84b810..0x84b820]
+      InlinePCRanges: []
+      Variables:
+        - Name: m
+          Type: 141 GoMapType map[[4]int]uint8
+          Locations:
+            - Range: 0x84b810..0x84b820
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+          IsParameter: true
+          IsReturn: false
+    - ID: 74
+      Name: main.testMapLargeKeyLargeValue
+      OutOfLinePCRanges: [0x84b820..0x84b830]
+      InlinePCRanges: []
+      Variables:
+        - Name: m
+          Type: 146 GoMapType map[[4]int][4]int
+          Locations:
+            - Range: 0x84b820..0x84b830
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+          IsParameter: true
+          IsReturn: false
+    - ID: 75
       Name: main.testCombinedByte
-      OutOfLinePCRanges: [0x84c110..0x84c120]
+      OutOfLinePCRanges: [0x84cb20..0x84cb30]
       InlinePCRanges: []
       Variables:
         - Name: w
           Type: 3 BaseType uint8
           Locations:
-            - Range: 0x84c110..0x84c120
+            - Range: 0x84cb20..0x84cb30
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
         - Name: x
           Type: 3 BaseType uint8
           Locations:
-            - Range: 0x84c110..0x84c120
+            - Range: 0x84cb20..0x84cb30
               Pieces: [{Size: 1, Op: {RegNo: 1, Shift: 0}}]
           IsParameter: true
           IsReturn: false
         - Name: y
           Type: 17 BaseType float32
           Locations:
-            - Range: 0x84c110..0x84c120
+            - Range: 0x84cb20..0x84cb30
               Pieces: [{Size: 4, Op: {RegNo: 64, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 68
+    - ID: 76
       Name: main.testMultipleSimpleParams
-      OutOfLinePCRanges: [0x84c1f0..0x84c200]
+      OutOfLinePCRanges: [0x84cc00..0x84cc10]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 4 BaseType bool
           Locations:
-            - Range: 0x84c1f0..0x84c200
+            - Range: 0x84cc00..0x84cc10
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
         - Name: b
           Type: 3 BaseType uint8
           Locations:
-            - Range: 0x84c1f0..0x84c200
+            - Range: 0x84cc00..0x84cc10
               Pieces: [{Size: 1, Op: {RegNo: 1, Shift: 0}}]
           IsParameter: true
           IsReturn: false
         - Name: c
           Type: 12 BaseType int32
           Locations:
-            - Range: 0x84c1f0..0x84c200
+            - Range: 0x84cc00..0x84cc10
               Pieces: [{Size: 4, Op: {RegNo: 2, Shift: 0}}]
           IsParameter: true
           IsReturn: false
         - Name: d
           Type: 10 BaseType uint
           Locations:
-            - Range: 0x84c1f0..0x84c200
+            - Range: 0x84cc00..0x84cc10
               Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
           IsParameter: true
           IsReturn: false
         - Name: e
           Type: 9 GoStringHeaderType string
           Locations:
-            - Range: 0x84c1f0..0x84c200
+            - Range: 0x84cc00..0x84cc10
               Pieces:
                 - Size: 8
                   Op: {RegNo: 4, Shift: 0}
@@ -2480,39 +2718,39 @@ Subprograms:
                   Op: {RegNo: 5, Shift: 0}
           IsParameter: true
           IsReturn: false
-    - ID: 69
+    - ID: 77
       Name: main.testChannel
-      OutOfLinePCRanges: [0x84c390..0x84c3a0]
+      OutOfLinePCRanges: [0x84cda0..0x84cdb0]
       InlinePCRanges: []
       Variables:
         - Name: c
-          Type: 128 GoChannelType chan bool
+          Type: 151 GoChannelType chan bool
           Locations:
-            - Range: 0x84c390..0x84c3a0
+            - Range: 0x84cda0..0x84cdb0
               Pieces: [{Size: 0, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 70
+    - ID: 78
       Name: main.testPointerToSimpleStruct
-      OutOfLinePCRanges: [0x84c530..0x84c540]
+      OutOfLinePCRanges: [0x84cf40..0x84cf50]
       InlinePCRanges: []
       Variables:
         - Name: a
-          Type: 129 PointerType *main.structWithTwoValues
+          Type: 152 PointerType *main.structWithTwoValues
           Locations:
-            - Range: 0x84c530..0x84c540
+            - Range: 0x84cf40..0x84cf50
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 71
+    - ID: 79
       Name: main.testLinkedList
-      OutOfLinePCRanges: [0x84c540..0x84c550]
+      OutOfLinePCRanges: [0x84cf50..0x84cf60]
       InlinePCRanges: []
       Variables:
         - Name: a
-          Type: 131 StructureType main.node
+          Type: 154 StructureType main.node
           Locations:
-            - Range: 0x84c540..0x84c550
+            - Range: 0x84cf50..0x84cf60
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -2520,273 +2758,94 @@ Subprograms:
                   Op: {RegNo: 1, Shift: 0}
           IsParameter: true
           IsReturn: false
-    - ID: 72
+    - ID: 80
       Name: main.testPointerLoop
-      OutOfLinePCRanges: [0x84c550..0x84c560]
+      OutOfLinePCRanges: [0x84cf60..0x84cf70]
       InlinePCRanges: []
       Variables:
         - Name: a
-          Type: 132 PointerType *main.node
+          Type: 155 PointerType *main.node
           Locations:
-            - Range: 0x84c550..0x84c560
+            - Range: 0x84cf60..0x84cf70
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 73
+    - ID: 81
       Name: main.testUnsafePointer
-      OutOfLinePCRanges: [0x84c560..0x84c570]
+      OutOfLinePCRanges: [0x84cf70..0x84cf80]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 15 VoidPointerType unsafe.Pointer
           Locations:
-            - Range: 0x84c560..0x84c570
+            - Range: 0x84cf70..0x84cf80
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 74
+    - ID: 82
       Name: main.testUintPointer
-      OutOfLinePCRanges: [0x84c580..0x84c590]
+      OutOfLinePCRanges: [0x84cf90..0x84cfa0]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 34 PointerType *uint
           Locations:
-            - Range: 0x84c580..0x84c590
+            - Range: 0x84cf90..0x84cfa0
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 75
+    - ID: 83
       Name: main.testStringPointer
-      OutOfLinePCRanges: [0x84c5f0..0x84c600]
+      OutOfLinePCRanges: [0x84d000..0x84d010]
       InlinePCRanges: []
       Variables:
         - Name: z
           Type: 22 PointerType *string
           Locations:
-            - Range: 0x84c5f0..0x84c600
+            - Range: 0x84d000..0x84d010
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 76
+    - ID: 84
       Name: main.testNilPointer
-      OutOfLinePCRanges: [0x84c610..0x84c620]
+      OutOfLinePCRanges: [0x84d020..0x84d030]
       InlinePCRanges: []
       Variables:
         - Name: z
           Type: 11 PointerType *bool
           Locations:
-            - Range: 0x84c610..0x84c620
+            - Range: 0x84d020..0x84d030
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
         - Name: a
           Type: 10 BaseType uint
           Locations:
-            - Range: 0x84c610..0x84c620
+            - Range: 0x84d020..0x84d030
               Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 77
+    - ID: 85
       Name: main.testCycle
-      OutOfLinePCRanges: [0x84c630..0x84c640]
+      OutOfLinePCRanges: [0x84d040..0x84d050]
       InlinePCRanges: []
       Variables:
         - Name: t
-          Type: 133 PointerType *main.t
+          Type: 156 PointerType *main.t
           Locations:
-            - Range: 0x84c630..0x84c640
+            - Range: 0x84d040..0x84d050
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 78
-      Name: main.testUintSlice
-      OutOfLinePCRanges: [0x84ca00..0x84ca10]
-      InlinePCRanges: []
-      Variables:
-        - Name: u
-          Type: 135 GoSliceHeaderType []uint
-          Locations:
-            - Range: 0x84ca00..0x84ca10
-              Pieces:
-                - Size: 8
-                  Op: {RegNo: 0, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 1, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 2, Shift: 0}
-          IsParameter: true
-          IsReturn: false
-    - ID: 79
-      Name: main.testEmptySlice
-      OutOfLinePCRanges: [0x84ca10..0x84ca20]
-      InlinePCRanges: []
-      Variables:
-        - Name: u
-          Type: 135 GoSliceHeaderType []uint
-          Locations:
-            - Range: 0x84ca10..0x84ca20
-              Pieces:
-                - Size: 8
-                  Op: {RegNo: 0, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 1, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 2, Shift: 0}
-          IsParameter: true
-          IsReturn: false
-    - ID: 80
-      Name: main.testSliceOfSlices
-      OutOfLinePCRanges: [0x84ca20..0x84ca30]
-      InlinePCRanges: []
-      Variables:
-        - Name: u
-          Type: 136 GoSliceHeaderType [][]uint
-          Locations:
-            - Range: 0x84ca20..0x84ca30
-              Pieces:
-                - Size: 8
-                  Op: {RegNo: 0, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 1, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 2, Shift: 0}
-          IsParameter: true
-          IsReturn: false
-    - ID: 81
-      Name: main.testStructSlice
-      OutOfLinePCRanges: [0x84ca30..0x84ca40]
-      InlinePCRanges: []
-      Variables:
-        - Name: xs
-          Type: 138 GoSliceHeaderType []main.structWithNoStrings
-          Locations:
-            - Range: 0x84ca30..0x84ca40
-              Pieces:
-                - Size: 8
-                  Op: {RegNo: 0, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 1, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 2, Shift: 0}
-          IsParameter: true
-          IsReturn: false
-        - Name: a
-          Type: 7 BaseType int
-          Locations:
-            - Range: 0x84ca30..0x84ca40
-              Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
-          IsParameter: true
-          IsReturn: false
-    - ID: 82
-      Name: main.testEmptySliceOfStructs
-      OutOfLinePCRanges: [0x84ca40..0x84ca50]
-      InlinePCRanges: []
-      Variables:
-        - Name: xs
-          Type: 138 GoSliceHeaderType []main.structWithNoStrings
-          Locations:
-            - Range: 0x84ca40..0x84ca50
-              Pieces:
-                - Size: 8
-                  Op: {RegNo: 0, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 1, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 2, Shift: 0}
-          IsParameter: true
-          IsReturn: false
-        - Name: a
-          Type: 7 BaseType int
-          Locations:
-            - Range: 0x84ca40..0x84ca50
-              Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
-          IsParameter: true
-          IsReturn: false
-    - ID: 83
-      Name: main.testNilSliceOfStructs
-      OutOfLinePCRanges: [0x84ca50..0x84ca60]
-      InlinePCRanges: []
-      Variables:
-        - Name: xs
-          Type: 138 GoSliceHeaderType []main.structWithNoStrings
-          Locations:
-            - Range: 0x84ca50..0x84ca60
-              Pieces:
-                - Size: 8
-                  Op: {RegNo: 0, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 1, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 2, Shift: 0}
-          IsParameter: true
-          IsReturn: false
-        - Name: a
-          Type: 7 BaseType int
-          Locations:
-            - Range: 0x84ca50..0x84ca60
-              Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
-          IsParameter: true
-          IsReturn: false
-    - ID: 84
-      Name: main.testStringSlice
-      OutOfLinePCRanges: [0x84ca60..0x84ca70]
-      InlinePCRanges: []
-      Variables:
-        - Name: s
-          Type: 141 GoSliceHeaderType []string
-          Locations:
-            - Range: 0x84ca60..0x84ca70
-              Pieces:
-                - Size: 8
-                  Op: {RegNo: 0, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 1, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 2, Shift: 0}
-          IsParameter: true
-          IsReturn: false
-    - ID: 85
-      Name: main.testNilSliceWithOtherParams
-      OutOfLinePCRanges: [0x84ca70..0x84ca80]
-      InlinePCRanges: []
-      Variables:
-        - Name: a
-          Type: 16 BaseType int8
-          Locations:
-            - Range: 0x84ca70..0x84ca80
-              Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
-          IsParameter: true
-          IsReturn: false
-        - Name: s
-          Type: 142 GoSliceHeaderType []bool
-          Locations:
-            - Range: 0x84ca70..0x84ca80
-              Pieces:
-                - Size: 8
-                  Op: {RegNo: 1, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 2, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 3, Shift: 0}
-          IsParameter: true
-          IsReturn: false
-        - Name: x
-          Type: 10 BaseType uint
-          Locations:
-            - Range: 0x84ca70..0x84ca80
-              Pieces: [{Size: 8, Op: {RegNo: 4, Shift: 0}}]
-          IsParameter: true
-          IsReturn: false
     - ID: 86
-      Name: main.testNilSlice
-      OutOfLinePCRanges: [0x84ca80..0x84ca90]
+      Name: main.testUintSlice
+      OutOfLinePCRanges: [0x84d410..0x84d420]
       InlinePCRanges: []
       Variables:
-        - Name: xs
-          Type: 143 GoSliceHeaderType []uint16
+        - Name: u
+          Type: 158 GoSliceHeaderType []uint
           Locations:
-            - Range: 0x84ca80..0x84ca90
+            - Range: 0x84d410..0x84d420
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -2797,14 +2856,14 @@ Subprograms:
           IsParameter: true
           IsReturn: false
     - ID: 87
-      Name: main.testVeryLargeSlice
-      OutOfLinePCRanges: [0x84ca90..0x84caa0]
+      Name: main.testEmptySlice
+      OutOfLinePCRanges: [0x84d420..0x84d430]
       InlinePCRanges: []
       Variables:
-        - Name: xs
-          Type: 135 GoSliceHeaderType []uint
+        - Name: u
+          Type: 158 GoSliceHeaderType []uint
           Locations:
-            - Range: 0x84ca90..0x84caa0
+            - Range: 0x84d420..0x84d430
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -2815,24 +2874,203 @@ Subprograms:
           IsParameter: true
           IsReturn: false
     - ID: 88
+      Name: main.testSliceOfSlices
+      OutOfLinePCRanges: [0x84d430..0x84d440]
+      InlinePCRanges: []
+      Variables:
+        - Name: u
+          Type: 159 GoSliceHeaderType [][]uint
+          Locations:
+            - Range: 0x84d430..0x84d440
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 0, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 1, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 2, Shift: 0}
+          IsParameter: true
+          IsReturn: false
+    - ID: 89
+      Name: main.testStructSlice
+      OutOfLinePCRanges: [0x84d440..0x84d450]
+      InlinePCRanges: []
+      Variables:
+        - Name: xs
+          Type: 161 GoSliceHeaderType []main.structWithNoStrings
+          Locations:
+            - Range: 0x84d440..0x84d450
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 0, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 1, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 2, Shift: 0}
+          IsParameter: true
+          IsReturn: false
+        - Name: a
+          Type: 7 BaseType int
+          Locations:
+            - Range: 0x84d440..0x84d450
+              Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
+          IsParameter: true
+          IsReturn: false
+    - ID: 90
+      Name: main.testEmptySliceOfStructs
+      OutOfLinePCRanges: [0x84d450..0x84d460]
+      InlinePCRanges: []
+      Variables:
+        - Name: xs
+          Type: 161 GoSliceHeaderType []main.structWithNoStrings
+          Locations:
+            - Range: 0x84d450..0x84d460
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 0, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 1, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 2, Shift: 0}
+          IsParameter: true
+          IsReturn: false
+        - Name: a
+          Type: 7 BaseType int
+          Locations:
+            - Range: 0x84d450..0x84d460
+              Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
+          IsParameter: true
+          IsReturn: false
+    - ID: 91
+      Name: main.testNilSliceOfStructs
+      OutOfLinePCRanges: [0x84d460..0x84d470]
+      InlinePCRanges: []
+      Variables:
+        - Name: xs
+          Type: 161 GoSliceHeaderType []main.structWithNoStrings
+          Locations:
+            - Range: 0x84d460..0x84d470
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 0, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 1, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 2, Shift: 0}
+          IsParameter: true
+          IsReturn: false
+        - Name: a
+          Type: 7 BaseType int
+          Locations:
+            - Range: 0x84d460..0x84d470
+              Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
+          IsParameter: true
+          IsReturn: false
+    - ID: 92
+      Name: main.testStringSlice
+      OutOfLinePCRanges: [0x84d470..0x84d480]
+      InlinePCRanges: []
+      Variables:
+        - Name: s
+          Type: 164 GoSliceHeaderType []string
+          Locations:
+            - Range: 0x84d470..0x84d480
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 0, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 1, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 2, Shift: 0}
+          IsParameter: true
+          IsReturn: false
+    - ID: 93
+      Name: main.testNilSliceWithOtherParams
+      OutOfLinePCRanges: [0x84d480..0x84d490]
+      InlinePCRanges: []
+      Variables:
+        - Name: a
+          Type: 16 BaseType int8
+          Locations:
+            - Range: 0x84d480..0x84d490
+              Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
+          IsParameter: true
+          IsReturn: false
+        - Name: s
+          Type: 165 GoSliceHeaderType []bool
+          Locations:
+            - Range: 0x84d480..0x84d490
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 1, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 2, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 3, Shift: 0}
+          IsParameter: true
+          IsReturn: false
+        - Name: x
+          Type: 10 BaseType uint
+          Locations:
+            - Range: 0x84d480..0x84d490
+              Pieces: [{Size: 8, Op: {RegNo: 4, Shift: 0}}]
+          IsParameter: true
+          IsReturn: false
+    - ID: 94
+      Name: main.testNilSlice
+      OutOfLinePCRanges: [0x84d490..0x84d4a0]
+      InlinePCRanges: []
+      Variables:
+        - Name: xs
+          Type: 166 GoSliceHeaderType []uint16
+          Locations:
+            - Range: 0x84d490..0x84d4a0
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 0, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 1, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 2, Shift: 0}
+          IsParameter: true
+          IsReturn: false
+    - ID: 95
+      Name: main.testVeryLargeSlice
+      OutOfLinePCRanges: [0x84d4a0..0x84d4b0]
+      InlinePCRanges: []
+      Variables:
+        - Name: xs
+          Type: 158 GoSliceHeaderType []uint
+          Locations:
+            - Range: 0x84d4a0..0x84d4b0
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 0, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 1, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 2, Shift: 0}
+          IsParameter: true
+          IsReturn: false
+    - ID: 96
       Name: main.stackC
-      OutOfLinePCRanges: [0x84cd60..0x84cdd0]
+      OutOfLinePCRanges: [0x84d770..0x84d7e0]
       InlinePCRanges: []
       Variables:
         - Name: ~r0
           Type: 9 GoStringHeaderType string
-          Locations: [{Range: 0x84cd60..0x84cdd0, Pieces: []}]
+          Locations: [{Range: 0x84d770..0x84d7e0, Pieces: []}]
           IsParameter: true
           IsReturn: true
-    - ID: 89
+    - ID: 97
       Name: main.testSingleString
-      OutOfLinePCRanges: [0x84cdd0..0x84cde0]
+      OutOfLinePCRanges: [0x84d7e0..0x84d7f0]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 9 GoStringHeaderType string
           Locations:
-            - Range: 0x84cdd0..0x84cde0
+            - Range: 0x84d7e0..0x84d7f0
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -2840,15 +3078,15 @@ Subprograms:
                   Op: {RegNo: 1, Shift: 0}
           IsParameter: true
           IsReturn: false
-    - ID: 90
+    - ID: 98
       Name: main.testThreeStrings
-      OutOfLinePCRanges: [0x84cde0..0x84cdf0]
+      OutOfLinePCRanges: [0x84d7f0..0x84d800]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 9 GoStringHeaderType string
           Locations:
-            - Range: 0x84cde0..0x84cdf0
+            - Range: 0x84d7f0..0x84d800
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -2859,7 +3097,7 @@ Subprograms:
         - Name: y
           Type: 9 GoStringHeaderType string
           Locations:
-            - Range: 0x84cde0..0x84cdf0
+            - Range: 0x84d7f0..0x84d800
               Pieces:
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
@@ -2870,7 +3108,7 @@ Subprograms:
         - Name: z
           Type: 9 GoStringHeaderType string
           Locations:
-            - Range: 0x84cde0..0x84cdf0
+            - Range: 0x84d7f0..0x84d800
               Pieces:
                 - Size: 8
                   Op: {RegNo: 4, Shift: 0}
@@ -2878,15 +3116,15 @@ Subprograms:
                   Op: {RegNo: 5, Shift: 0}
           IsParameter: true
           IsReturn: false
-    - ID: 91
+    - ID: 99
       Name: main.testThreeStringsInStruct
-      OutOfLinePCRanges: [0x84cdf0..0x84ce10]
+      OutOfLinePCRanges: [0x84d800..0x84d820]
       InlinePCRanges: []
       Variables:
         - Name: a
-          Type: 144 StructureType main.threeStringStruct
+          Type: 167 StructureType main.threeStringStruct
           Locations:
-            - Range: 0x84cdf0..0x84ce10
+            - Range: 0x84d800..0x84d820
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -2902,39 +3140,39 @@ Subprograms:
                   Op: {RegNo: 5, Shift: 0}
           IsParameter: true
           IsReturn: false
-    - ID: 92
+    - ID: 100
       Name: main.testThreeStringsInStructPointer
-      OutOfLinePCRanges: [0x84ce10..0x84ce20]
+      OutOfLinePCRanges: [0x84d820..0x84d830]
       InlinePCRanges: []
       Variables:
         - Name: a
-          Type: 145 PointerType *main.threeStringStruct
+          Type: 168 PointerType *main.threeStringStruct
           Locations:
-            - Range: 0x84ce10..0x84ce20
+            - Range: 0x84d820..0x84d830
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 93
+    - ID: 101
       Name: main.testOneStringInStructPointer
-      OutOfLinePCRanges: [0x84ce20..0x84ce30]
+      OutOfLinePCRanges: [0x84d830..0x84d840]
       InlinePCRanges: []
       Variables:
         - Name: a
-          Type: 146 PointerType *main.oneStringStruct
+          Type: 169 PointerType *main.oneStringStruct
           Locations:
-            - Range: 0x84ce20..0x84ce30
+            - Range: 0x84d830..0x84d840
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 94
+    - ID: 102
       Name: main.testMassiveString
-      OutOfLinePCRanges: [0x84ce30..0x84ce40]
+      OutOfLinePCRanges: [0x84d840..0x84d850]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 9 GoStringHeaderType string
           Locations:
-            - Range: 0x84ce30..0x84ce40
+            - Range: 0x84d840..0x84d850
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -2942,15 +3180,15 @@ Subprograms:
                   Op: {RegNo: 1, Shift: 0}
           IsParameter: true
           IsReturn: false
-    - ID: 95
+    - ID: 103
       Name: main.testUnitializedString
-      OutOfLinePCRanges: [0x84ce40..0x84ce50]
+      OutOfLinePCRanges: [0x84d850..0x84d860]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 9 GoStringHeaderType string
           Locations:
-            - Range: 0x84ce40..0x84ce50
+            - Range: 0x84d850..0x84d860
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -2958,15 +3196,15 @@ Subprograms:
                   Op: {RegNo: 1, Shift: 0}
           IsParameter: true
           IsReturn: false
-    - ID: 96
+    - ID: 104
       Name: main.testEmptyString
-      OutOfLinePCRanges: [0x84ce50..0x84ce60]
+      OutOfLinePCRanges: [0x84d860..0x84d870]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 9 GoStringHeaderType string
           Locations:
-            - Range: 0x84ce50..0x84ce60
+            - Range: 0x84d860..0x84d870
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -2974,15 +3212,15 @@ Subprograms:
                   Op: {RegNo: 1, Shift: 0}
           IsParameter: true
           IsReturn: false
-    - ID: 97
+    - ID: 105
       Name: main.testStruct
-      OutOfLinePCRanges: [0x84d060..0x84d080]
+      OutOfLinePCRanges: [0x84da70..0x84da90]
       InlinePCRanges: []
       Variables:
         - Name: x
-          Type: 148 StructureType main.aStruct
+          Type: 171 StructureType main.aStruct
           Locations:
-            - Range: 0x84d060..0x84d080
+            - Range: 0x84da70..0x84da90
               Pieces:
                 - Size: 1
                   Op: {RegNo: 0, Shift: 0}
@@ -3000,580 +3238,860 @@ Subprograms:
                   Op: {RegNo: 6, Shift: 0}
           IsParameter: true
           IsReturn: false
-    - ID: 98
+    - ID: 106
       Name: main.testEmptyStruct
-      OutOfLinePCRanges: [0x84d160..0x84d170]
+      OutOfLinePCRanges: [0x84db70..0x84db80]
       InlinePCRanges: []
       Variables:
         - Name: e
-          Type: 150 StructureType main.emptyStruct
-          Locations: [{Range: 0x84d160..0x84d170, Pieces: []}]
+          Type: 173 StructureType main.emptyStruct
+          Locations: [{Range: 0x84db70..0x84db80, Pieces: []}]
           IsParameter: true
           IsReturn: false
-    - ID: 99
+    - ID: 107
       Name: main.testInlinedPrint
-      OutOfLinePCRanges: [0x84a0d0..0x84a140]
+      OutOfLinePCRanges: [0x84aae0..0x84ab50]
       InlinePCRanges:
-        - Ranges: [0x84a15c..0x84a194]
-          RootRanges: [0x84a140..0x84a1c0]
-        - Ranges: [0x84a2a8..0x84a2e0]
-          RootRanges: [0x84a270..0x84a300]
-        - Ranges: [0x84a324..0x84a35c]
-          RootRanges: [0x84a300..0x84a3c0]
-        - Ranges: [0x84a3dc..0x84a414]
-          RootRanges: [0x84a3c0..0x84a440]
+        - Ranges: [0x84ab6c..0x84aba4]
+          RootRanges: [0x84ab50..0x84abd0]
+        - Ranges: [0x84acb8..0x84acf0]
+          RootRanges: [0x84ac80..0x84ad10]
+        - Ranges: [0x84ad34..0x84ad6c]
+          RootRanges: [0x84ad10..0x84add0]
+        - Ranges: [0x84adec..0x84ae24]
+          RootRanges: [0x84add0..0x84ae50]
       Variables:
         - Name: x
           Type: 7 BaseType int
           Locations:
-            - Range: 0x84a0d0..0x84a0f0
+            - Range: 0x84aae0..0x84ab00
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x84a15c..0x84a164
+            - Range: 0x84ab6c..0x84ab74
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x84a2a8..0x84a2b0
+            - Range: 0x84acb8..0x84acc0
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x84a31c..0x84a32c
+            - Range: 0x84ad2c..0x84ad3c
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x84a32c..0x84a3c0
+            - Range: 0x84ad3c..0x84add0
               Pieces: [{Size: 8, Op: {CfaOffset: -48}}]
-            - Range: 0x84a3c0..0x84a3e4
+            - Range: 0x84add0..0x84adf4
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 100
+    - ID: 108
       Name: main.testInlinedBBB
       OutOfLinePCRanges: []
       InlinePCRanges:
-        - Ranges: [0x84a368..0x84a3a0]
-          RootRanges: [0x84a300..0x84a3c0]
+        - Ranges: [0x84ad78..0x84adb0]
+          RootRanges: [0x84ad10..0x84add0]
       Variables: []
-    - ID: 101
+    - ID: 109
       Name: main.testInlinedBCA
       OutOfLinePCRanges: []
       InlinePCRanges:
-        - Ranges: [0x84a45c..0x84a4a0]
-          RootRanges: [0x84a440..0x84a560]
+        - Ranges: [0x84ae6c..0x84aeb0]
+          RootRanges: [0x84ae50..0x84af70]
       Variables: []
-    - ID: 102
+    - ID: 110
       Name: main.testInlinedBCB
       OutOfLinePCRanges: []
       InlinePCRanges:
-        - Ranges: [0x84a510..0x84a548]
-          RootRanges: [0x84a440..0x84a560]
+        - Ranges: [0x84af20..0x84af58]
+          RootRanges: [0x84ae50..0x84af70]
       Variables: []
-    - ID: 103
+    - ID: 111
       Name: main.testInlinedSq
       OutOfLinePCRanges: []
       InlinePCRanges:
-        - Ranges: [0x84a564..0x84a568]
-          RootRanges: [0x84a560..0x84a570]
+        - Ranges: [0x84af74..0x84af78]
+          RootRanges: [0x84af70..0x84af80]
       Variables:
         - Name: x
           Type: 7 BaseType int
           Locations:
-            - Range: 0x84a560..0x84a568
+            - Range: 0x84af70..0x84af78
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 104
+    - ID: 112
       Name: main.testInlinedSumArray
       OutOfLinePCRanges: []
       InlinePCRanges:
-        - Ranges: [0x84a594..0x84a5b8]
-          RootRanges: [0x84a570..0x84a5d0]
-        - Ranges: [0x84a62c..0x84a654]
-          RootRanges: [0x84a5d0..0x84a720]
+        - Ranges: [0x84afa4..0x84afc8]
+          RootRanges: [0x84af80..0x84afe0]
+        - Ranges: [0x84b03c..0x84b064]
+          RootRanges: [0x84afe0..0x84b130]
       Variables:
         - Name: a
-          Type: 63 ArrayType [5]int
+          Type: 86 ArrayType [5]int
           Locations:
-            - Range: 0x84a580..0x84a5d0
+            - Range: 0x84af90..0x84afe0
               Pieces: [{Size: 40, Op: {CfaOffset: -48}}]
-            - Range: 0x84a618..0x84a720
+            - Range: 0x84b028..0x84b130
               Pieces: [{Size: 40, Op: {CfaOffset: -120}}]
           IsParameter: true
           IsReturn: false
 Types:
     - __kind: PointerType
-      ID: 277
+      ID: 63
+      Name: '**main.deepSlice2'
+      ByteSize: 8
+      Pointee: 64 PointerType *main.deepSlice2
+    - __kind: PointerType
+      ID: 309
+      Name: '**main.deepSlice3'
+      ByteSize: 8
+      Pointee: 310 PointerType *main.deepSlice3
+    - __kind: PointerType
+      ID: 334
+      Name: '**main.deepSlice8'
+      ByteSize: 8
+      Pointee: 335 PointerType *main.deepSlice8
+    - __kind: PointerType
+      ID: 340
+      Name: '**main.deepSlice9'
+      ByteSize: 8
+      Pointee: 341 PointerType *main.deepSlice9
+    - __kind: PointerType
+      ID: 77
+      Name: '**main.stringType2'
+      ByteSize: 8
+      GoKind: 22
+      Pointee: 78 PointerType *main.stringType2
+    - __kind: PointerType
+      ID: 402
       Name: '**main.t'
       ByteSize: 8
-      Pointee: 133 PointerType *main.t
+      Pointee: 156 PointerType *main.t
     - __kind: PointerType
       ID: 54
       Name: '**string'
       ByteSize: 8
-      GoRuntimeType: 520928
+      GoRuntimeType: 526016
       GoKind: 22
       Pointee: 22 PointerType *string
     - __kind: PointerType
-      ID: 126
+      ID: 149
       Name: '**table<[4]int,[4]int>'
       ByteSize: 8
-      Pointee: 127 PointerType *table<[4]int,[4]int>
+      Pointee: 150 PointerType *table<[4]int,[4]int>
     - __kind: PointerType
-      ID: 121
+      ID: 144
       Name: '**table<[4]int,uint8>'
       ByteSize: 8
-      Pointee: 122 PointerType *table<[4]int,uint8>
+      Pointee: 145 PointerType *table<[4]int,uint8>
     - __kind: PointerType
-      ID: 89
+      ID: 112
       Name: '**table<[4]string,[2]int>'
       ByteSize: 8
-      Pointee: 90 PointerType *table<[4]string,[2]int>
+      Pointee: 113 PointerType *table<[4]string,[2]int>
     - __kind: PointerType
-      ID: 101
+      ID: 124
       Name: '**table<bool,main.node>'
       ByteSize: 8
-      Pointee: 102 PointerType *table<bool,main.node>
+      Pointee: 125 PointerType *table<bool,main.node>
     - __kind: PointerType
-      ID: 69
+      ID: 71
+      Name: '**table<int,*main.deepMap2>'
+      ByteSize: 8
+      Pointee: 72 PointerType *table<int,*main.deepMap2>
+    - __kind: PointerType
+      ID: 317
+      Name: '**table<int,*main.deepMap3>'
+      ByteSize: 8
+      Pointee: 318 PointerType *table<int,*main.deepMap3>
+    - __kind: PointerType
+      ID: 352
+      Name: '**table<int,*main.deepMap8>'
+      ByteSize: 8
+      Pointee: 353 PointerType *table<int,*main.deepMap8>
+    - __kind: PointerType
+      ID: 367
+      Name: '**table<int,*main.deepMap9>'
+      ByteSize: 8
+      Pointee: 368 PointerType *table<int,*main.deepMap9>
+    - __kind: PointerType
+      ID: 92
       Name: '**table<int,int>'
       ByteSize: 8
-      Pointee: 70 PointerType *table<int,int>
+      Pointee: 93 PointerType *table<int,int>
     - __kind: PointerType
-      ID: 106
+      ID: 382
+      Name: '**table<int,interface {}>'
+      ByteSize: 8
+      Pointee: 383 PointerType *table<int,interface {}>
+    - __kind: PointerType
+      ID: 129
       Name: '**table<int,uint8>'
       ByteSize: 8
-      Pointee: 107 PointerType *table<int,uint8>
+      Pointee: 130 PointerType *table<int,uint8>
     - __kind: PointerType
-      ID: 96
+      ID: 119
       Name: '**table<string,[]main.structWithMap>'
       ByteSize: 8
-      Pointee: 97 PointerType *table<string,[]main.structWithMap>
+      Pointee: 120 PointerType *table<string,[]main.structWithMap>
     - __kind: PointerType
-      ID: 84
+      ID: 107
       Name: '**table<string,[]string>'
       ByteSize: 8
-      Pointee: 85 PointerType *table<string,[]string>
+      Pointee: 108 PointerType *table<string,[]string>
     - __kind: PointerType
-      ID: 79
+      ID: 102
       Name: '**table<string,int>'
       ByteSize: 8
-      Pointee: 80 PointerType *table<string,int>
+      Pointee: 103 PointerType *table<string,int>
     - __kind: PointerType
-      ID: 74
+      ID: 97
       Name: '**table<string,main.nestedStruct>'
       ByteSize: 8
-      Pointee: 75 PointerType *table<string,main.nestedStruct>
+      Pointee: 98 PointerType *table<string,main.nestedStruct>
     - __kind: PointerType
-      ID: 116
+      ID: 139
       Name: '**table<uint8,[4]int>'
       ByteSize: 8
-      Pointee: 117 PointerType *table<uint8,[4]int>
+      Pointee: 140 PointerType *table<uint8,[4]int>
     - __kind: PointerType
-      ID: 111
+      ID: 134
       Name: '**table<uint8,uint8>'
       ByteSize: 8
-      Pointee: 112 PointerType *table<uint8,uint8>
+      Pointee: 135 PointerType *table<uint8,uint8>
     - __kind: PointerType
-      ID: 154
+      ID: 180
+      Name: '*[]*main.deepSlice2.array'
+      ByteSize: 8
+      Pointee: 179 GoSliceDataType []*main.deepSlice2.array
+    - __kind: PointerType
+      ID: 313
+      Name: '*[]*main.deepSlice3.array'
+      ByteSize: 8
+      Pointee: 312 GoSliceDataType []*main.deepSlice3.array
+    - __kind: PointerType
+      ID: 338
+      Name: '*[]*main.deepSlice8.array'
+      ByteSize: 8
+      Pointee: 337 GoSliceDataType []*main.deepSlice8.array
+    - __kind: PointerType
+      ID: 344
+      Name: '*[]*main.deepSlice9.array'
+      ByteSize: 8
+      Pointee: 343 GoSliceDataType []*main.deepSlice9.array
+    - __kind: PointerType
+      ID: 177
       Name: '*[]*string.array'
       ByteSize: 8
-      Pointee: 153 GoSliceDataType []*string.array
+      Pointee: 176 GoSliceDataType []*string.array
     - __kind: PointerType
-      ID: 258
+      ID: 294
       Name: '*[][]uint.array'
       ByteSize: 8
-      Pointee: 257 GoSliceDataType [][]uint.array
+      Pointee: 293 GoSliceDataType [][]uint.array
     - __kind: PointerType
-      ID: 264
+      ID: 300
       Name: '*[]bool.array'
       ByteSize: 8
-      Pointee: 263 GoSliceDataType []bool.array
+      Pointee: 299 GoSliceDataType []bool.array
     - __kind: PointerType
-      ID: 281
+      ID: 348
+      Name: '*[]interface {}.array'
+      ByteSize: 8
+      Pointee: 347 GoSliceDataType []interface {}.array
+    - __kind: PointerType
+      ID: 406
       Name: '*[]main.structWithMap.array'
       ByteSize: 8
-      Pointee: 280 GoSliceDataType []main.structWithMap.array
+      Pointee: 405 GoSliceDataType []main.structWithMap.array
     - __kind: PointerType
-      ID: 260
+      ID: 296
       Name: '*[]main.structWithNoStrings.array'
       ByteSize: 8
-      Pointee: 259 GoSliceDataType []main.structWithNoStrings.array
+      Pointee: 295 GoSliceDataType []main.structWithNoStrings.array
     - __kind: PointerType
-      ID: 262
+      ID: 298
       Name: '*[]string.array'
       ByteSize: 8
-      Pointee: 261 GoSliceDataType []string.array
+      Pointee: 297 GoSliceDataType []string.array
     - __kind: PointerType
-      ID: 137
+      ID: 160
       Name: '*[]uint'
       ByteSize: 8
-      Pointee: 135 GoSliceHeaderType []uint
+      Pointee: 158 GoSliceHeaderType []uint
     - __kind: PointerType
-      ID: 256
+      ID: 292
       Name: '*[]uint.array'
       ByteSize: 8
-      Pointee: 255 GoSliceDataType []uint.array
+      Pointee: 291 GoSliceDataType []uint.array
     - __kind: PointerType
-      ID: 266
+      ID: 302
       Name: '*[]uint16.array'
       ByteSize: 8
-      Pointee: 265 GoSliceDataType []uint16.array
+      Pointee: 301 GoSliceDataType []uint16.array
     - __kind: PointerType
       ID: 11
       Name: '*bool'
       ByteSize: 8
-      GoRuntimeType: 386176
+      GoRuntimeType: 390176
       GoKind: 22
       Pointee: 4 BaseType bool
     - __kind: PointerType
       ID: 33
       Name: '*error'
       ByteSize: 8
-      GoRuntimeType: 385088
+      GoRuntimeType: 389088
       GoKind: 22
       Pointee: 14 GoInterfaceType error
     - __kind: PointerType
       ID: 35
       Name: '*float32'
       ByteSize: 8
-      GoRuntimeType: 386048
+      GoRuntimeType: 390048
       GoKind: 22
       Pointee: 17 BaseType float32
     - __kind: PointerType
       ID: 26
       Name: '*float64'
       ByteSize: 8
-      GoRuntimeType: 386112
+      GoRuntimeType: 390112
       GoKind: 22
       Pointee: 18 BaseType float64
     - __kind: PointerType
       ID: 28
       Name: '*int'
       ByteSize: 8
-      GoRuntimeType: 385728
+      GoRuntimeType: 389728
       GoKind: 22
       Pointee: 7 BaseType int
     - __kind: PointerType
       ID: 31
       Name: '*int16'
       ByteSize: 8
-      GoRuntimeType: 385344
+      GoRuntimeType: 389344
       GoKind: 22
       Pointee: 23 BaseType int16
     - __kind: PointerType
       ID: 20
       Name: '*int32'
       ByteSize: 8
-      GoRuntimeType: 385472
+      GoRuntimeType: 389472
       GoKind: 22
       Pointee: 12 BaseType int32
     - __kind: PointerType
       ID: 27
       Name: '*int64'
       ByteSize: 8
-      GoRuntimeType: 385600
+      GoRuntimeType: 389600
       GoKind: 22
       Pointee: 13 BaseType int64
     - __kind: PointerType
       ID: 32
       Name: '*int8'
       ByteSize: 8
-      GoRuntimeType: 385216
+      GoRuntimeType: 389216
       GoKind: 22
       Pointee: 16 BaseType int8
     - __kind: PointerType
-      ID: 61
+      ID: 346
+      Name: '*interface {}'
+      ByteSize: 8
+      GoRuntimeType: 390304
+      GoKind: 22
+      Pointee: 81 GoEmptyInterfaceType interface {}
+    - __kind: PointerType
+      ID: 187
+      Name: '*main.deepMap2'
+      ByteSize: 8
+      GoRuntimeType: 382880
+      GoKind: 22
+      Pointee: 188 StructureType main.deepMap2
+    - __kind: PointerType
+      ID: 325
+      Name: '*main.deepMap3'
+      ByteSize: 8
+      GoRuntimeType: 382816
+      GoKind: 22
+      Pointee: 326 UnresolvedPointeeType main.deepMap3
+    - __kind: PointerType
+      ID: 73
+      Name: '*main.deepMap7'
+      ByteSize: 8
+      GoRuntimeType: 382560
+      GoKind: 22
+      Pointee: 74 StructureType main.deepMap7
+    - __kind: PointerType
+      ID: 360
+      Name: '*main.deepMap8'
+      ByteSize: 8
+      GoRuntimeType: 382496
+      GoKind: 22
+      Pointee: 361 StructureType main.deepMap8
+    - __kind: PointerType
+      ID: 375
+      Name: '*main.deepMap9'
+      ByteSize: 8
+      GoRuntimeType: 382432
+      GoKind: 22
+      Pointee: 376 StructureType main.deepMap9
+    - __kind: PointerType
+      ID: 57
+      Name: '*main.deepPtr2'
+      ByteSize: 8
+      GoRuntimeType: 383456
+      GoKind: 22
+      Pointee: 58 StructureType main.deepPtr2
+    - __kind: PointerType
+      ID: 303
+      Name: '*main.deepPtr3'
+      ByteSize: 8
+      GoRuntimeType: 383392
+      GoKind: 22
+      Pointee: 304 UnresolvedPointeeType main.deepPtr3
+    - __kind: PointerType
+      ID: 59
+      Name: '*main.deepPtr7'
+      ByteSize: 8
+      GoRuntimeType: 383136
+      GoKind: 22
+      Pointee: 60 StructureType main.deepPtr7
+    - __kind: PointerType
+      ID: 329
+      Name: '*main.deepPtr8'
+      ByteSize: 8
+      GoRuntimeType: 383072
+      GoKind: 22
+      Pointee: 330 StructureType main.deepPtr8
+    - __kind: PointerType
+      ID: 331
+      Name: '*main.deepPtr9'
+      ByteSize: 8
+      GoRuntimeType: 383008
+      GoKind: 22
+      Pointee: 332 StructureType main.deepPtr9
+    - __kind: PointerType
+      ID: 64
+      Name: '*main.deepSlice2'
+      ByteSize: 8
+      GoRuntimeType: 384032
+      GoKind: 22
+      Pointee: 178 StructureType main.deepSlice2
+    - __kind: PointerType
+      ID: 310
+      Name: '*main.deepSlice3'
+      ByteSize: 8
+      GoRuntimeType: 383968
+      GoKind: 22
+      Pointee: 311 UnresolvedPointeeType main.deepSlice3
+    - __kind: PointerType
+      ID: 65
+      Name: '*main.deepSlice7'
+      ByteSize: 8
+      GoRuntimeType: 383712
+      GoKind: 22
+      Pointee: 66 StructureType main.deepSlice7
+    - __kind: PointerType
+      ID: 335
+      Name: '*main.deepSlice8'
+      ByteSize: 8
+      GoRuntimeType: 383648
+      GoKind: 22
+      Pointee: 336 StructureType main.deepSlice8
+    - __kind: PointerType
+      ID: 341
+      Name: '*main.deepSlice9'
+      ByteSize: 8
+      GoRuntimeType: 383584
+      GoKind: 22
+      Pointee: 342 StructureType main.deepSlice9
+    - __kind: PointerType
+      ID: 84
       Name: '*main.esotericHeap'
       ByteSize: 8
-      GoRuntimeType: 380160
+      GoRuntimeType: 384160
       GoKind: 22
-      Pointee: 62 StructureType main.esotericHeap
+      Pointee: 85 StructureType main.esotericHeap
     - __kind: PointerType
-      ID: 132
+      ID: 155
       Name: '*main.node'
       ByteSize: 8
-      GoRuntimeType: 380224
+      GoRuntimeType: 384224
       GoKind: 22
-      Pointee: 131 StructureType main.node
+      Pointee: 154 StructureType main.node
     - __kind: PointerType
-      ID: 146
+      ID: 169
       Name: '*main.oneStringStruct'
       ByteSize: 8
       GoKind: 22
-      Pointee: 147 StructureType main.oneStringStruct
+      Pointee: 170 StructureType main.oneStringStruct
     - __kind: PointerType
-      ID: 203
+      ID: 75
+      Name: '*main.stringType1'
+      ByteSize: 8
+      GoKind: 22
+      Pointee: 76 GoStringHeaderType main.stringType1
+    - __kind: PointerType
+      ID: 306
+      Name: '*main.stringType1.str'
+      ByteSize: 8
+      Pointee: 305 GoStringDataType main.stringType1.str
+    - __kind: PointerType
+      ID: 78
+      Name: '*main.stringType2'
+      ByteSize: 8
+      GoKind: 22
+      Pointee: 307 UnresolvedPointeeType main.stringType2
+    - __kind: PointerType
+      ID: 239
       Name: '*main.structWithMap'
       ByteSize: 8
-      GoRuntimeType: 380096
+      GoRuntimeType: 382368
       GoKind: 22
-      Pointee: 65 StructureType main.structWithMap
+      Pointee: 88 StructureType main.structWithMap
     - __kind: PointerType
-      ID: 139
+      ID: 162
       Name: '*main.structWithNoStrings'
       ByteSize: 8
-      Pointee: 140 StructureType main.structWithNoStrings
+      Pointee: 163 StructureType main.structWithNoStrings
     - __kind: PointerType
-      ID: 129
+      ID: 152
       Name: '*main.structWithTwoValues'
       ByteSize: 8
       GoKind: 22
-      Pointee: 130 StructureType main.structWithTwoValues
+      Pointee: 153 StructureType main.structWithTwoValues
     - __kind: PointerType
-      ID: 133
+      ID: 156
       Name: '*main.t'
       ByteSize: 8
       GoKind: 22
-      Pointee: 134 GoSliceHeaderType main.t
+      Pointee: 157 GoSliceHeaderType main.t
     - __kind: PointerType
-      ID: 279
+      ID: 404
       Name: '*main.t.array'
       ByteSize: 8
-      Pointee: 278 GoSliceDataType main.t.array
+      Pointee: 403 GoSliceDataType main.t.array
     - __kind: PointerType
-      ID: 145
+      ID: 168
       Name: '*main.threeStringStruct'
       ByteSize: 8
       GoKind: 22
-      Pointee: 144 StructureType main.threeStringStruct
+      Pointee: 167 StructureType main.threeStringStruct
     - __kind: PointerType
-      ID: 124
+      ID: 147
       Name: '*map<[4]int,[4]int>'
       ByteSize: 8
-      Pointee: 125 GoSwissMapHeaderType map<[4]int,[4]int>
+      Pointee: 148 GoSwissMapHeaderType map<[4]int,[4]int>
     - __kind: PointerType
-      ID: 119
+      ID: 142
       Name: '*map<[4]int,uint8>'
       ByteSize: 8
-      Pointee: 120 GoSwissMapHeaderType map<[4]int,uint8>
+      Pointee: 143 GoSwissMapHeaderType map<[4]int,uint8>
     - __kind: PointerType
-      ID: 87
+      ID: 110
       Name: '*map<[4]string,[2]int>'
       ByteSize: 8
-      Pointee: 88 GoSwissMapHeaderType map<[4]string,[2]int>
+      Pointee: 111 GoSwissMapHeaderType map<[4]string,[2]int>
     - __kind: PointerType
-      ID: 99
+      ID: 122
       Name: '*map<bool,main.node>'
       ByteSize: 8
-      Pointee: 100 GoSwissMapHeaderType map<bool,main.node>
+      Pointee: 123 GoSwissMapHeaderType map<bool,main.node>
     - __kind: PointerType
-      ID: 67
+      ID: 69
+      Name: '*map<int,*main.deepMap2>'
+      ByteSize: 8
+      Pointee: 70 GoSwissMapHeaderType map<int,*main.deepMap2>
+    - __kind: PointerType
+      ID: 315
+      Name: '*map<int,*main.deepMap3>'
+      ByteSize: 8
+      Pointee: 316 GoSwissMapHeaderType map<int,*main.deepMap3>
+    - __kind: PointerType
+      ID: 350
+      Name: '*map<int,*main.deepMap8>'
+      ByteSize: 8
+      Pointee: 351 GoSwissMapHeaderType map<int,*main.deepMap8>
+    - __kind: PointerType
+      ID: 365
+      Name: '*map<int,*main.deepMap9>'
+      ByteSize: 8
+      Pointee: 366 GoSwissMapHeaderType map<int,*main.deepMap9>
+    - __kind: PointerType
+      ID: 90
       Name: '*map<int,int>'
       ByteSize: 8
-      Pointee: 68 GoSwissMapHeaderType map<int,int>
+      Pointee: 91 GoSwissMapHeaderType map<int,int>
     - __kind: PointerType
-      ID: 104
+      ID: 380
+      Name: '*map<int,interface {}>'
+      ByteSize: 8
+      Pointee: 381 GoSwissMapHeaderType map<int,interface {}>
+    - __kind: PointerType
+      ID: 127
       Name: '*map<int,uint8>'
       ByteSize: 8
-      Pointee: 105 GoSwissMapHeaderType map<int,uint8>
+      Pointee: 128 GoSwissMapHeaderType map<int,uint8>
     - __kind: PointerType
-      ID: 94
+      ID: 117
       Name: '*map<string,[]main.structWithMap>'
       ByteSize: 8
-      Pointee: 95 GoSwissMapHeaderType map<string,[]main.structWithMap>
+      Pointee: 118 GoSwissMapHeaderType map<string,[]main.structWithMap>
     - __kind: PointerType
-      ID: 82
+      ID: 105
       Name: '*map<string,[]string>'
       ByteSize: 8
-      Pointee: 83 GoSwissMapHeaderType map<string,[]string>
+      Pointee: 106 GoSwissMapHeaderType map<string,[]string>
     - __kind: PointerType
-      ID: 77
+      ID: 100
       Name: '*map<string,int>'
       ByteSize: 8
-      Pointee: 78 GoSwissMapHeaderType map<string,int>
+      Pointee: 101 GoSwissMapHeaderType map<string,int>
     - __kind: PointerType
-      ID: 72
+      ID: 95
       Name: '*map<string,main.nestedStruct>'
       ByteSize: 8
-      Pointee: 73 GoSwissMapHeaderType map<string,main.nestedStruct>
+      Pointee: 96 GoSwissMapHeaderType map<string,main.nestedStruct>
     - __kind: PointerType
-      ID: 114
+      ID: 137
       Name: '*map<uint8,[4]int>'
       ByteSize: 8
-      Pointee: 115 GoSwissMapHeaderType map<uint8,[4]int>
+      Pointee: 138 GoSwissMapHeaderType map<uint8,[4]int>
     - __kind: PointerType
-      ID: 109
+      ID: 132
       Name: '*map<uint8,uint8>'
       ByteSize: 8
-      Pointee: 110 GoSwissMapHeaderType map<uint8,uint8>
+      Pointee: 133 GoSwissMapHeaderType map<uint8,uint8>
     - __kind: PointerType
-      ID: 92
+      ID: 115
       Name: '*map[string]int'
       ByteSize: 8
       GoKind: 22
-      Pointee: 76 GoMapType map[string]int
+      Pointee: 99 GoMapType map[string]int
     - __kind: PointerType
-      ID: 249
+      ID: 285
       Name: '*noalg.map.group[[4]int][4]int'
       ByteSize: 8
-      Pointee: 250 StructureType noalg.map.group[[4]int][4]int
+      Pointee: 286 StructureType noalg.map.group[[4]int][4]int
     - __kind: PointerType
-      ID: 241
+      ID: 277
       Name: '*noalg.map.group[[4]int]uint8'
       ByteSize: 8
-      Pointee: 242 StructureType noalg.map.group[[4]int]uint8
+      Pointee: 278 StructureType noalg.map.group[[4]int]uint8
     - __kind: PointerType
-      ID: 189
+      ID: 225
       Name: '*noalg.map.group[[4]string][2]int'
       ByteSize: 8
-      Pointee: 190 StructureType noalg.map.group[[4]string][2]int
+      Pointee: 226 StructureType noalg.map.group[[4]string][2]int
     - __kind: PointerType
-      ID: 208
+      ID: 244
       Name: '*noalg.map.group[bool]main.node'
       ByteSize: 8
-      Pointee: 209 StructureType noalg.map.group[bool]main.node
+      Pointee: 245 StructureType noalg.map.group[bool]main.node
     - __kind: PointerType
-      ID: 157
+      ID: 183
+      Name: '*noalg.map.group[int]*main.deepMap2'
+      ByteSize: 8
+      Pointee: 184 StructureType noalg.map.group[int]*main.deepMap2
+    - __kind: PointerType
+      ID: 321
+      Name: '*noalg.map.group[int]*main.deepMap3'
+      ByteSize: 8
+      Pointee: 322 StructureType noalg.map.group[int]*main.deepMap3
+    - __kind: PointerType
+      ID: 356
+      Name: '*noalg.map.group[int]*main.deepMap8'
+      ByteSize: 8
+      Pointee: 357 StructureType noalg.map.group[int]*main.deepMap8
+    - __kind: PointerType
+      ID: 371
+      Name: '*noalg.map.group[int]*main.deepMap9'
+      ByteSize: 8
+      Pointee: 372 StructureType noalg.map.group[int]*main.deepMap9
+    - __kind: PointerType
+      ID: 193
       Name: '*noalg.map.group[int]int'
       ByteSize: 8
-      Pointee: 158 StructureType noalg.map.group[int]int
+      Pointee: 194 StructureType noalg.map.group[int]int
     - __kind: PointerType
-      ID: 216
+      ID: 386
+      Name: '*noalg.map.group[int]interface {}'
+      ByteSize: 8
+      Pointee: 387 StructureType noalg.map.group[int]interface {}
+    - __kind: PointerType
+      ID: 252
       Name: '*noalg.map.group[int]uint8'
       ByteSize: 8
-      Pointee: 217 StructureType noalg.map.group[int]uint8
+      Pointee: 253 StructureType noalg.map.group[int]uint8
     - __kind: PointerType
-      ID: 198
+      ID: 234
       Name: '*noalg.map.group[string][]main.structWithMap'
       ByteSize: 8
-      Pointee: 199 StructureType noalg.map.group[string][]main.structWithMap
+      Pointee: 235 StructureType noalg.map.group[string][]main.structWithMap
     - __kind: PointerType
-      ID: 181
+      ID: 217
       Name: '*noalg.map.group[string][]string'
       ByteSize: 8
-      Pointee: 182 StructureType noalg.map.group[string][]string
+      Pointee: 218 StructureType noalg.map.group[string][]string
     - __kind: PointerType
-      ID: 173
+      ID: 209
       Name: '*noalg.map.group[string]int'
       ByteSize: 8
-      Pointee: 174 StructureType noalg.map.group[string]int
+      Pointee: 210 StructureType noalg.map.group[string]int
     - __kind: PointerType
-      ID: 165
+      ID: 201
       Name: '*noalg.map.group[string]main.nestedStruct'
       ByteSize: 8
-      Pointee: 166 StructureType noalg.map.group[string]main.nestedStruct
+      Pointee: 202 StructureType noalg.map.group[string]main.nestedStruct
     - __kind: PointerType
-      ID: 232
+      ID: 268
       Name: '*noalg.map.group[uint8][4]int'
       ByteSize: 8
-      Pointee: 233 StructureType noalg.map.group[uint8][4]int
+      Pointee: 269 StructureType noalg.map.group[uint8][4]int
     - __kind: PointerType
-      ID: 224
+      ID: 260
       Name: '*noalg.map.group[uint8]uint8'
       ByteSize: 8
-      Pointee: 225 StructureType noalg.map.group[uint8]uint8
+      Pointee: 261 StructureType noalg.map.group[uint8]uint8
     - __kind: PointerType
       ID: 22
       Name: '*string'
       ByteSize: 8
-      GoRuntimeType: 385152
+      GoRuntimeType: 389152
       GoKind: 22
       Pointee: 9 GoStringHeaderType string
     - __kind: PointerType
-      ID: 152
+      ID: 175
       Name: '*string.str'
       ByteSize: 8
-      Pointee: 151 GoStringDataType string.str
+      Pointee: 174 GoStringDataType string.str
     - __kind: PointerType
-      ID: 127
+      ID: 150
       Name: '*table<[4]int,[4]int>'
       ByteSize: 8
-      Pointee: 247 StructureType table<[4]int,[4]int>
+      Pointee: 283 StructureType table<[4]int,[4]int>
     - __kind: PointerType
-      ID: 122
+      ID: 145
       Name: '*table<[4]int,uint8>'
       ByteSize: 8
-      Pointee: 239 StructureType table<[4]int,uint8>
+      Pointee: 275 StructureType table<[4]int,uint8>
     - __kind: PointerType
-      ID: 90
+      ID: 113
       Name: '*table<[4]string,[2]int>'
       ByteSize: 8
-      Pointee: 187 StructureType table<[4]string,[2]int>
+      Pointee: 223 StructureType table<[4]string,[2]int>
     - __kind: PointerType
-      ID: 102
+      ID: 125
       Name: '*table<bool,main.node>'
       ByteSize: 8
-      Pointee: 206 StructureType table<bool,main.node>
+      Pointee: 242 StructureType table<bool,main.node>
     - __kind: PointerType
-      ID: 70
+      ID: 72
+      Name: '*table<int,*main.deepMap2>'
+      ByteSize: 8
+      Pointee: 181 StructureType table<int,*main.deepMap2>
+    - __kind: PointerType
+      ID: 318
+      Name: '*table<int,*main.deepMap3>'
+      ByteSize: 8
+      Pointee: 319 StructureType table<int,*main.deepMap3>
+    - __kind: PointerType
+      ID: 353
+      Name: '*table<int,*main.deepMap8>'
+      ByteSize: 8
+      Pointee: 354 StructureType table<int,*main.deepMap8>
+    - __kind: PointerType
+      ID: 368
+      Name: '*table<int,*main.deepMap9>'
+      ByteSize: 8
+      Pointee: 369 StructureType table<int,*main.deepMap9>
+    - __kind: PointerType
+      ID: 93
       Name: '*table<int,int>'
       ByteSize: 8
-      Pointee: 155 StructureType table<int,int>
+      Pointee: 191 StructureType table<int,int>
     - __kind: PointerType
-      ID: 107
+      ID: 383
+      Name: '*table<int,interface {}>'
+      ByteSize: 8
+      Pointee: 384 StructureType table<int,interface {}>
+    - __kind: PointerType
+      ID: 130
       Name: '*table<int,uint8>'
       ByteSize: 8
-      Pointee: 214 StructureType table<int,uint8>
+      Pointee: 250 StructureType table<int,uint8>
     - __kind: PointerType
-      ID: 97
+      ID: 120
       Name: '*table<string,[]main.structWithMap>'
       ByteSize: 8
-      Pointee: 196 StructureType table<string,[]main.structWithMap>
+      Pointee: 232 StructureType table<string,[]main.structWithMap>
     - __kind: PointerType
-      ID: 85
+      ID: 108
       Name: '*table<string,[]string>'
       ByteSize: 8
-      Pointee: 179 StructureType table<string,[]string>
+      Pointee: 215 StructureType table<string,[]string>
     - __kind: PointerType
-      ID: 80
+      ID: 103
       Name: '*table<string,int>'
       ByteSize: 8
-      Pointee: 171 StructureType table<string,int>
+      Pointee: 207 StructureType table<string,int>
     - __kind: PointerType
-      ID: 75
+      ID: 98
       Name: '*table<string,main.nestedStruct>'
       ByteSize: 8
-      Pointee: 163 StructureType table<string,main.nestedStruct>
+      Pointee: 199 StructureType table<string,main.nestedStruct>
     - __kind: PointerType
-      ID: 117
+      ID: 140
       Name: '*table<uint8,[4]int>'
       ByteSize: 8
-      Pointee: 230 StructureType table<uint8,[4]int>
+      Pointee: 266 StructureType table<uint8,[4]int>
     - __kind: PointerType
-      ID: 112
+      ID: 135
       Name: '*table<uint8,uint8>'
       ByteSize: 8
-      Pointee: 222 StructureType table<uint8,uint8>
+      Pointee: 258 StructureType table<uint8,uint8>
     - __kind: PointerType
       ID: 34
       Name: '*uint'
       ByteSize: 8
-      GoRuntimeType: 385792
+      GoRuntimeType: 389792
       GoKind: 22
       Pointee: 10 BaseType uint
     - __kind: PointerType
       ID: 30
       Name: '*uint16'
       ByteSize: 8
-      GoRuntimeType: 385408
+      GoRuntimeType: 389408
       GoKind: 22
       Pointee: 6 BaseType uint16
     - __kind: PointerType
       ID: 21
       Name: '*uint32'
       ByteSize: 8
-      GoRuntimeType: 385536
+      GoRuntimeType: 389536
       GoKind: 22
       Pointee: 2 BaseType uint32
     - __kind: PointerType
       ID: 29
       Name: '*uint64'
       ByteSize: 8
-      GoRuntimeType: 385664
+      GoRuntimeType: 389664
       GoKind: 22
       Pointee: 8 BaseType uint64
     - __kind: PointerType
       ID: 5
       Name: '*uint8'
       ByteSize: 8
-      GoRuntimeType: 385280
+      GoRuntimeType: 389280
       GoKind: 22
       Pointee: 3 BaseType uint8
     - __kind: PointerType
       ID: 19
       Name: '*uintptr'
       ByteSize: 8
-      GoRuntimeType: 385856
+      GoRuntimeType: 389856
       GoKind: 22
       Pointee: 1 BaseType uintptr
     - __kind: EventRootType
-      ID: 369
+      ID: 502
       Name: Probe[main.stackC]
     - __kind: EventRootType
-      ID: 326
+      ID: 459
       Name: Probe[main.testAny]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -3581,14 +4099,14 @@ Types:
         - Name: a
           Offset: 1
           Expression:
-            Type: 58 GoEmptyInterfaceType interface {}
+            Type: 81 GoEmptyInterfaceType interface {}
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 45, index: 0, name: a}
+                  Variable: {subprogram: 53, index: 0, name: a}
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 298
+      ID: 423
       Name: Probe[main.testArrayOfArraysOfArrays]
       ByteSize: 65
       PresenceBitsetSize: 1
@@ -3603,7 +4121,7 @@ Types:
                   Offset: 0
                   ByteSize: 64
     - __kind: EventRootType
-      ID: 296
+      ID: 421
       Name: Probe[main.testArrayOfArrays]
       ByteSize: 33
       PresenceBitsetSize: 1
@@ -3618,7 +4136,7 @@ Types:
                   Offset: 0
                   ByteSize: 32
     - __kind: EventRootType
-      ID: 334
+      ID: 467
       Name: Probe[main.testArrayOfMaps]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -3626,14 +4144,14 @@ Types:
         - Name: m
           Offset: 1
           Expression:
-            Type: 91 ArrayType [2]map[string]int
+            Type: 114 ArrayType [2]map[string]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 53, index: 0, name: m}
+                  Variable: {subprogram: 61, index: 0, name: m}
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 297
+      ID: 422
       Name: Probe[main.testArrayOfStrings]
       ByteSize: 33
       PresenceBitsetSize: 1
@@ -3648,7 +4166,7 @@ Types:
                   Offset: 0
                   ByteSize: 32
     - __kind: EventRootType
-      ID: 316
+      ID: 441
       Name: Probe[main.testBigStruct]
       ByteSize: 49
       PresenceBitsetSize: 1
@@ -3663,7 +4181,7 @@ Types:
                   Offset: 0
                   ByteSize: 48
     - __kind: EventRootType
-      ID: 285
+      ID: 410
       Name: Probe[main.testBoolArray]
       ByteSize: 3
       PresenceBitsetSize: 1
@@ -3678,7 +4196,7 @@ Types:
                   Offset: 0
                   ByteSize: 2
     - __kind: EventRootType
-      ID: 282
+      ID: 407
       Name: Probe[main.testByteArray]
       ByteSize: 3
       PresenceBitsetSize: 1
@@ -3693,7 +4211,7 @@ Types:
                   Offset: 0
                   ByteSize: 2
     - __kind: EventRootType
-      ID: 350
+      ID: 483
       Name: Probe[main.testChannel]
       ByteSize: 1
       PresenceBitsetSize: 1
@@ -3701,14 +4219,14 @@ Types:
         - Name: c
           Offset: 1
           Expression:
-            Type: 128 GoChannelType chan bool
+            Type: 151 GoChannelType chan bool
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 69, index: 0, name: c}
+                  Variable: {subprogram: 77, index: 0, name: c}
                   Offset: 0
                   ByteSize: 0
     - __kind: EventRootType
-      ID: 348
+      ID: 481
       Name: Probe[main.testCombinedByte]
       ByteSize: 7
       PresenceBitsetSize: 1
@@ -3719,7 +4237,7 @@ Types:
             Type: 3 BaseType uint8
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 67, index: 0, name: w}
+                  Variable: {subprogram: 75, index: 0, name: w}
                   Offset: 0
                   ByteSize: 1
         - Name: x
@@ -3728,7 +4246,7 @@ Types:
             Type: 3 BaseType uint8
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 67, index: 1, name: x}
+                  Variable: {subprogram: 75, index: 1, name: x}
                   Offset: 0
                   ByteSize: 1
         - Name: y
@@ -3737,11 +4255,11 @@ Types:
             Type: 17 BaseType float32
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 67, index: 2, name: y}
+                  Variable: {subprogram: 75, index: 2, name: y}
                   Offset: 0
                   ByteSize: 4
     - __kind: EventRootType
-      ID: 358
+      ID: 491
       Name: Probe[main.testCycle]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -3749,14 +4267,104 @@ Types:
         - Name: t
           Offset: 1
           Expression:
-            Type: 133 PointerType *main.t
+            Type: 156 PointerType *main.t
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 77, index: 0, name: t}
+                  Variable: {subprogram: 85, index: 0, name: t}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 363
+      ID: 446
+      Name: Probe[main.testDeepMap1]
+      ByteSize: 9
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: a
+          Offset: 1
+          Expression:
+            Type: 67 StructureType main.deepMap1
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 40, index: 0, name: a}
+                  Offset: 0
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 447
+      Name: Probe[main.testDeepMap7]
+      ByteSize: 9
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: a
+          Offset: 1
+          Expression:
+            Type: 73 PointerType *main.deepMap7
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 41, index: 0, name: a}
+                  Offset: 0
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 442
+      Name: Probe[main.testDeepPtr1]
+      ByteSize: 9
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: a
+          Offset: 1
+          Expression:
+            Type: 56 StructureType main.deepPtr1
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 36, index: 0, name: a}
+                  Offset: 0
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 443
+      Name: Probe[main.testDeepPtr7]
+      ByteSize: 9
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: a
+          Offset: 1
+          Expression:
+            Type: 59 PointerType *main.deepPtr7
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 37, index: 0, name: a}
+                  Offset: 0
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 444
+      Name: Probe[main.testDeepSlice1]
+      ByteSize: 25
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: a
+          Offset: 1
+          Expression:
+            Type: 61 StructureType main.deepSlice1
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 38, index: 0, name: a}
+                  Offset: 0
+                  ByteSize: 24
+    - __kind: EventRootType
+      ID: 445
+      Name: Probe[main.testDeepSlice7]
+      ByteSize: 9
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: a
+          Offset: 1
+          Expression:
+            Type: 65 PointerType *main.deepSlice7
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 39, index: 0, name: a}
+                  Offset: 0
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 496
       Name: Probe[main.testEmptySliceOfStructs]
       ByteSize: 33
       PresenceBitsetSize: 1
@@ -3764,10 +4372,10 @@ Types:
         - Name: xs
           Offset: 1
           Expression:
-            Type: 138 GoSliceHeaderType []main.structWithNoStrings
+            Type: 161 GoSliceHeaderType []main.structWithNoStrings
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 82, index: 0, name: xs}
+                  Variable: {subprogram: 90, index: 0, name: xs}
                   Offset: 0
                   ByteSize: 24
         - Name: a
@@ -3776,11 +4384,11 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 82, index: 1, name: a}
+                  Variable: {subprogram: 90, index: 1, name: a}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 360
+      ID: 493
       Name: Probe[main.testEmptySlice]
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -3788,14 +4396,14 @@ Types:
         - Name: u
           Offset: 1
           Expression:
-            Type: 135 GoSliceHeaderType []uint
+            Type: 158 GoSliceHeaderType []uint
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 79, index: 0, name: u}
+                  Variable: {subprogram: 87, index: 0, name: u}
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 377
+      ID: 510
       Name: Probe[main.testEmptyString]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -3806,11 +4414,11 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 96, index: 0, name: x}
+                  Variable: {subprogram: 104, index: 0, name: x}
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 379
+      ID: 512
       Name: Probe[main.testEmptyStruct]
       ByteSize: 1
       PresenceBitsetSize: 1
@@ -3818,14 +4426,14 @@ Types:
         - Name: e
           Offset: 1
           Expression:
-            Type: 150 StructureType main.emptyStruct
+            Type: 173 StructureType main.emptyStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 98, index: 0, name: e}
+                  Variable: {subprogram: 106, index: 0, name: e}
                   Offset: 0
                   ByteSize: 0
     - __kind: EventRootType
-      ID: 327
+      ID: 460
       Name: Probe[main.testError]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -3836,11 +4444,11 @@ Types:
             Type: 14 GoInterfaceType error
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 46, index: 0, name: e}
+                  Variable: {subprogram: 54, index: 0, name: e}
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 318
+      ID: 451
       Name: Probe[main.testEsotericHeap]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -3848,14 +4456,14 @@ Types:
         - Name: e
           Offset: 1
           Expression:
-            Type: 61 PointerType *main.esotericHeap
+            Type: 84 PointerType *main.esotericHeap
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 37, index: 0, name: e}
+                  Variable: {subprogram: 45, index: 0, name: e}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 317
+      ID: 450
       Name: Probe[main.testEsotericStack]
       ByteSize: 65
       PresenceBitsetSize: 1
@@ -3863,14 +4471,14 @@ Types:
         - Name: e
           Offset: 1
           Expression:
-            Type: 56 StructureType main.esotericStack
+            Type: 79 StructureType main.esotericStack
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 36, index: 0, name: e}
+                  Variable: {subprogram: 44, index: 0, name: e}
                   Offset: 0
                   ByteSize: 64
     - __kind: EventRootType
-      ID: 324
+      ID: 457
       Name: Probe[main.testFramelessArray]
       ByteSize: 41
       PresenceBitsetSize: 1
@@ -3878,14 +4486,14 @@ Types:
         - Name: a
           Offset: 1
           Expression:
-            Type: 63 ArrayType [5]int
+            Type: 86 ArrayType [5]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 43, index: 0, name: a}
+                  Variable: {subprogram: 51, index: 0, name: a}
                   Offset: 0
                   ByteSize: 40
     - __kind: EventRootType
-      ID: 323
+      ID: 456
       Name: Probe[main.testFrameless]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -3896,11 +4504,11 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 42, index: 0, name: x}
+                  Variable: {subprogram: 50, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 319
+      ID: 452
       Name: Probe[main.testInlinedBA]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -3911,11 +4519,11 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 38, index: 0, name: x}
+                  Variable: {subprogram: 46, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 321
+      ID: 454
       Name: Probe[main.testInlinedBBA]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -3926,14 +4534,14 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 40, index: 0, name: x}
+                  Variable: {subprogram: 48, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 381
+      ID: 514
       Name: Probe[main.testInlinedBBB]
     - __kind: EventRootType
-      ID: 320
+      ID: 453
       Name: Probe[main.testInlinedBB]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -3944,7 +4552,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 39, index: 0, name: x}
+                  Variable: {subprogram: 47, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
         - Name: y
@@ -3953,20 +4561,20 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 39, index: 1, name: y}
+                  Variable: {subprogram: 47, index: 1, name: y}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 382
+      ID: 515
       Name: Probe[main.testInlinedBCA]
     - __kind: EventRootType
-      ID: 383
+      ID: 516
       Name: Probe[main.testInlinedBCB]
     - __kind: EventRootType
-      ID: 322
+      ID: 455
       Name: Probe[main.testInlinedBC]
     - __kind: EventRootType
-      ID: 380
+      ID: 513
       Name: Probe[main.testInlinedPrint]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -3977,11 +4585,11 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 99, index: 0, name: x}
+                  Variable: {subprogram: 107, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 384
+      ID: 517
       Name: Probe[main.testInlinedSq]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -3992,11 +4600,11 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 103, index: 0, name: x}
+                  Variable: {subprogram: 111, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 385
+      ID: 518
       Name: Probe[main.testInlinedSumArray]
       ByteSize: 41
       PresenceBitsetSize: 1
@@ -4004,14 +4612,14 @@ Types:
         - Name: a
           Offset: 1
           Expression:
-            Type: 63 ArrayType [5]int
+            Type: 86 ArrayType [5]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 104, index: 0, name: a}
+                  Variable: {subprogram: 112, index: 0, name: a}
                   Offset: 0
                   ByteSize: 40
     - __kind: EventRootType
-      ID: 288
+      ID: 413
       Name: Probe[main.testInt16Array]
       ByteSize: 5
       PresenceBitsetSize: 1
@@ -4026,7 +4634,7 @@ Types:
                   Offset: 0
                   ByteSize: 4
     - __kind: EventRootType
-      ID: 289
+      ID: 414
       Name: Probe[main.testInt32Array]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -4041,7 +4649,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 290
+      ID: 415
       Name: Probe[main.testInt64Array]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -4056,7 +4664,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 287
+      ID: 412
       Name: Probe[main.testInt8Array]
       ByteSize: 3
       PresenceBitsetSize: 1
@@ -4071,7 +4679,7 @@ Types:
                   Offset: 0
                   ByteSize: 2
     - __kind: EventRootType
-      ID: 286
+      ID: 411
       Name: Probe[main.testIntArray]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -4086,7 +4694,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 325
+      ID: 458
       Name: Probe[main.testInterface]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -4094,14 +4702,14 @@ Types:
         - Name: b
           Offset: 1
           Expression:
-            Type: 64 GoInterfaceType main.behavior
+            Type: 87 GoInterfaceType main.behavior
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 44, index: 0, name: b}
+                  Variable: {subprogram: 52, index: 0, name: b}
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 352
+      ID: 485
       Name: Probe[main.testLinkedList]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -4109,14 +4717,14 @@ Types:
         - Name: a
           Offset: 1
           Expression:
-            Type: 131 StructureType main.node
+            Type: 154 StructureType main.node
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 71, index: 0, name: a}
+                  Variable: {subprogram: 79, index: 0, name: a}
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 332
+      ID: 465
       Name: Probe[main.testMapArrayToArray]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -4124,14 +4732,14 @@ Types:
         - Name: m
           Offset: 1
           Expression:
-            Type: 86 GoMapType map[[4]string][2]int
+            Type: 109 GoMapType map[[4]string][2]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 51, index: 0, name: m}
+                  Variable: {subprogram: 59, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 338
+      ID: 471
       Name: Probe[main.testMapEmbeddedMaps]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -4139,14 +4747,14 @@ Types:
         - Name: m
           Offset: 1
           Expression:
-            Type: 93 GoMapType map[string][]main.structWithMap
+            Type: 116 GoMapType map[string][]main.structWithMap
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 57, index: 0, name: m}
+                  Variable: {subprogram: 65, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 336
+      ID: 469
       Name: Probe[main.testMapIntToInt]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -4154,14 +4762,14 @@ Types:
         - Name: m
           Offset: 1
           Expression:
-            Type: 66 GoMapType map[int]int
+            Type: 89 GoMapType map[int]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 55, index: 0, name: m}
+                  Variable: {subprogram: 63, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 347
+      ID: 480
       Name: Probe[main.testMapLargeKeyLargeValue]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -4169,14 +4777,14 @@ Types:
         - Name: m
           Offset: 1
           Expression:
-            Type: 123 GoMapType map[[4]int][4]int
+            Type: 146 GoMapType map[[4]int][4]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 66, index: 0, name: m}
+                  Variable: {subprogram: 74, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 346
+      ID: 479
       Name: Probe[main.testMapLargeKeySmallValue]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -4184,14 +4792,14 @@ Types:
         - Name: m
           Offset: 1
           Expression:
-            Type: 118 GoMapType map[[4]int]uint8
+            Type: 141 GoMapType map[[4]int]uint8
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 65, index: 0, name: m}
+                  Variable: {subprogram: 73, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 337
+      ID: 470
       Name: Probe[main.testMapMassive]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -4199,14 +4807,14 @@ Types:
         - Name: redactMyEntries
           Offset: 1
           Expression:
-            Type: 93 GoMapType map[string][]main.structWithMap
+            Type: 116 GoMapType map[string][]main.structWithMap
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 56, index: 0, name: redactMyEntries}
+                  Variable: {subprogram: 64, index: 0, name: redactMyEntries}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 345
+      ID: 478
       Name: Probe[main.testMapSmallKeyLargeValue]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -4214,14 +4822,14 @@ Types:
         - Name: m
           Offset: 1
           Expression:
-            Type: 113 GoMapType map[uint8][4]int
+            Type: 136 GoMapType map[uint8][4]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 64, index: 0, name: m}
+                  Variable: {subprogram: 72, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 344
+      ID: 477
       Name: Probe[main.testMapSmallKeySmallValue]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -4229,14 +4837,14 @@ Types:
         - Name: m
           Offset: 1
           Expression:
-            Type: 108 GoMapType map[uint8]uint8
+            Type: 131 GoMapType map[uint8]uint8
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 63, index: 0, name: m}
+                  Variable: {subprogram: 71, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 330
+      ID: 463
       Name: Probe[main.testMapStringToInt]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -4244,14 +4852,14 @@ Types:
         - Name: m
           Offset: 1
           Expression:
-            Type: 76 GoMapType map[string]int
+            Type: 99 GoMapType map[string]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 49, index: 0, name: m}
+                  Variable: {subprogram: 57, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 331
+      ID: 464
       Name: Probe[main.testMapStringToSlice]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -4259,14 +4867,14 @@ Types:
         - Name: m
           Offset: 1
           Expression:
-            Type: 81 GoMapType map[string][]string
+            Type: 104 GoMapType map[string][]string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 50, index: 0, name: m}
+                  Variable: {subprogram: 58, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 329
+      ID: 462
       Name: Probe[main.testMapStringToStruct]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -4274,14 +4882,14 @@ Types:
         - Name: m
           Offset: 1
           Expression:
-            Type: 71 GoMapType map[string]main.nestedStruct
+            Type: 94 GoMapType map[string]main.nestedStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 48, index: 0, name: m}
+                  Variable: {subprogram: 56, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 339
+      ID: 472
       Name: Probe[main.testMapWithLinkedList]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -4289,14 +4897,14 @@ Types:
         - Name: m
           Offset: 1
           Expression:
-            Type: 98 GoMapType map[bool]main.node
+            Type: 121 GoMapType map[bool]main.node
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 58, index: 0, name: m}
+                  Variable: {subprogram: 66, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 343
+      ID: 476
       Name: Probe[main.testMapWithSmallKeyAndValueMassive]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -4304,14 +4912,14 @@ Types:
         - Name: m
           Offset: 1
           Expression:
-            Type: 108 GoMapType map[uint8]uint8
+            Type: 131 GoMapType map[uint8]uint8
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 62, index: 0, name: m}
+                  Variable: {subprogram: 70, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 342
+      ID: 475
       Name: Probe[main.testMapWithSmallKeyAndValue]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -4319,14 +4927,14 @@ Types:
         - Name: m
           Offset: 1
           Expression:
-            Type: 108 GoMapType map[uint8]uint8
+            Type: 131 GoMapType map[uint8]uint8
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 61, index: 0, name: m}
+                  Variable: {subprogram: 69, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 341
+      ID: 474
       Name: Probe[main.testMapWithSmallValueMassive]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -4334,14 +4942,14 @@ Types:
         - Name: redactMyEntries
           Offset: 1
           Expression:
-            Type: 103 GoMapType map[int]uint8
+            Type: 126 GoMapType map[int]uint8
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 60, index: 0, name: redactMyEntries}
+                  Variable: {subprogram: 68, index: 0, name: redactMyEntries}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 340
+      ID: 473
       Name: Probe[main.testMapWithSmallValue]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -4349,14 +4957,14 @@ Types:
         - Name: m
           Offset: 1
           Expression:
-            Type: 103 GoMapType map[int]uint8
+            Type: 126 GoMapType map[int]uint8
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 59, index: 0, name: m}
+                  Variable: {subprogram: 67, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 375
+      ID: 508
       Name: Probe[main.testMassiveString]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -4367,11 +4975,11 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 94, index: 0, name: x}
+                  Variable: {subprogram: 102, index: 0, name: x}
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 349
+      ID: 482
       Name: Probe[main.testMultipleSimpleParams]
       ByteSize: 31
       PresenceBitsetSize: 1
@@ -4382,7 +4990,7 @@ Types:
             Type: 4 BaseType bool
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 68, index: 0, name: a}
+                  Variable: {subprogram: 76, index: 0, name: a}
                   Offset: 0
                   ByteSize: 1
         - Name: b
@@ -4391,7 +4999,7 @@ Types:
             Type: 3 BaseType uint8
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 68, index: 1, name: b}
+                  Variable: {subprogram: 76, index: 1, name: b}
                   Offset: 0
                   ByteSize: 1
         - Name: c
@@ -4400,7 +5008,7 @@ Types:
             Type: 12 BaseType int32
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 68, index: 2, name: c}
+                  Variable: {subprogram: 76, index: 2, name: c}
                   Offset: 0
                   ByteSize: 4
         - Name: d
@@ -4409,7 +5017,7 @@ Types:
             Type: 10 BaseType uint
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 68, index: 3, name: d}
+                  Variable: {subprogram: 76, index: 3, name: d}
                   Offset: 0
                   ByteSize: 8
         - Name: e
@@ -4418,11 +5026,11 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 68, index: 4, name: e}
+                  Variable: {subprogram: 76, index: 4, name: e}
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 357
+      ID: 490
       Name: Probe[main.testNilPointer]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -4433,7 +5041,7 @@ Types:
             Type: 11 PointerType *bool
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 76, index: 0, name: z}
+                  Variable: {subprogram: 84, index: 0, name: z}
                   Offset: 0
                   ByteSize: 8
         - Name: a
@@ -4442,11 +5050,11 @@ Types:
             Type: 10 BaseType uint
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 76, index: 1, name: a}
+                  Variable: {subprogram: 84, index: 1, name: a}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 364
+      ID: 497
       Name: Probe[main.testNilSliceOfStructs]
       ByteSize: 33
       PresenceBitsetSize: 1
@@ -4454,10 +5062,10 @@ Types:
         - Name: xs
           Offset: 1
           Expression:
-            Type: 138 GoSliceHeaderType []main.structWithNoStrings
+            Type: 161 GoSliceHeaderType []main.structWithNoStrings
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 83, index: 0, name: xs}
+                  Variable: {subprogram: 91, index: 0, name: xs}
                   Offset: 0
                   ByteSize: 24
         - Name: a
@@ -4466,11 +5074,11 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 83, index: 1, name: a}
+                  Variable: {subprogram: 91, index: 1, name: a}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 366
+      ID: 499
       Name: Probe[main.testNilSliceWithOtherParams]
       ByteSize: 34
       PresenceBitsetSize: 1
@@ -4481,16 +5089,16 @@ Types:
             Type: 16 BaseType int8
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 85, index: 0, name: a}
+                  Variable: {subprogram: 93, index: 0, name: a}
                   Offset: 0
                   ByteSize: 1
         - Name: s
           Offset: 2
           Expression:
-            Type: 142 GoSliceHeaderType []bool
+            Type: 165 GoSliceHeaderType []bool
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 85, index: 1, name: s}
+                  Variable: {subprogram: 93, index: 1, name: s}
                   Offset: 0
                   ByteSize: 24
         - Name: x
@@ -4499,11 +5107,11 @@ Types:
             Type: 10 BaseType uint
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 85, index: 2, name: x}
+                  Variable: {subprogram: 93, index: 2, name: x}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 367
+      ID: 500
       Name: Probe[main.testNilSlice]
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -4511,14 +5119,14 @@ Types:
         - Name: xs
           Offset: 1
           Expression:
-            Type: 143 GoSliceHeaderType []uint16
+            Type: 166 GoSliceHeaderType []uint16
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 86, index: 0, name: xs}
+                  Variable: {subprogram: 94, index: 0, name: xs}
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 374
+      ID: 507
       Name: Probe[main.testOneStringInStructPointer]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -4526,14 +5134,14 @@ Types:
         - Name: a
           Offset: 1
           Expression:
-            Type: 146 PointerType *main.oneStringStruct
+            Type: 169 PointerType *main.oneStringStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 93, index: 0, name: a}
+                  Variable: {subprogram: 101, index: 0, name: a}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 353
+      ID: 486
       Name: Probe[main.testPointerLoop]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -4541,14 +5149,14 @@ Types:
         - Name: a
           Offset: 1
           Expression:
-            Type: 132 PointerType *main.node
+            Type: 155 PointerType *main.node
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 72, index: 0, name: a}
+                  Variable: {subprogram: 80, index: 0, name: a}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 335
+      ID: 468
       Name: Probe[main.testPointerToMap]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -4556,14 +5164,14 @@ Types:
         - Name: m
           Offset: 1
           Expression:
-            Type: 92 PointerType *map[string]int
+            Type: 115 PointerType *map[string]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 54, index: 0, name: m}
+                  Variable: {subprogram: 62, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 351
+      ID: 484
       Name: Probe[main.testPointerToSimpleStruct]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -4571,14 +5179,14 @@ Types:
         - Name: a
           Offset: 1
           Expression:
-            Type: 129 PointerType *main.structWithTwoValues
+            Type: 152 PointerType *main.structWithTwoValues
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 70, index: 0, name: a}
+                  Variable: {subprogram: 78, index: 0, name: a}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 283
+      ID: 408
       Name: Probe[main.testRuneArray]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -4593,7 +5201,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 302
+      ID: 427
       Name: Probe[main.testSingleBool]
       ByteSize: 2
       PresenceBitsetSize: 1
@@ -4608,7 +5216,7 @@ Types:
                   Offset: 0
                   ByteSize: 1
     - __kind: EventRootType
-      ID: 300
+      ID: 425
       Name: Probe[main.testSingleByte]
       ByteSize: 2
       PresenceBitsetSize: 1
@@ -4623,7 +5231,7 @@ Types:
                   Offset: 0
                   ByteSize: 1
     - __kind: EventRootType
-      ID: 313
+      ID: 438
       Name: Probe[main.testSingleFloat32]
       ByteSize: 5
       PresenceBitsetSize: 1
@@ -4638,7 +5246,7 @@ Types:
                   Offset: 0
                   ByteSize: 4
     - __kind: EventRootType
-      ID: 314
+      ID: 439
       Name: Probe[main.testSingleFloat64]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -4653,7 +5261,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 305
+      ID: 430
       Name: Probe[main.testSingleInt16]
       ByteSize: 3
       PresenceBitsetSize: 1
@@ -4668,7 +5276,7 @@ Types:
                   Offset: 0
                   ByteSize: 2
     - __kind: EventRootType
-      ID: 306
+      ID: 431
       Name: Probe[main.testSingleInt32]
       ByteSize: 5
       PresenceBitsetSize: 1
@@ -4683,7 +5291,7 @@ Types:
                   Offset: 0
                   ByteSize: 4
     - __kind: EventRootType
-      ID: 307
+      ID: 432
       Name: Probe[main.testSingleInt64]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -4698,7 +5306,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 304
+      ID: 429
       Name: Probe[main.testSingleInt8]
       ByteSize: 2
       PresenceBitsetSize: 1
@@ -4713,7 +5321,7 @@ Types:
                   Offset: 0
                   ByteSize: 1
     - __kind: EventRootType
-      ID: 303
+      ID: 428
       Name: Probe[main.testSingleInt]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -4728,7 +5336,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 301
+      ID: 426
       Name: Probe[main.testSingleRune]
       ByteSize: 5
       PresenceBitsetSize: 1
@@ -4743,7 +5351,7 @@ Types:
                   Offset: 0
                   ByteSize: 4
     - __kind: EventRootType
-      ID: 370
+      ID: 503
       Name: Probe[main.testSingleString]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -4754,11 +5362,11 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 89, index: 0, name: x}
+                  Variable: {subprogram: 97, index: 0, name: x}
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 310
+      ID: 435
       Name: Probe[main.testSingleUint16]
       ByteSize: 3
       PresenceBitsetSize: 1
@@ -4773,7 +5381,7 @@ Types:
                   Offset: 0
                   ByteSize: 2
     - __kind: EventRootType
-      ID: 311
+      ID: 436
       Name: Probe[main.testSingleUint32]
       ByteSize: 5
       PresenceBitsetSize: 1
@@ -4788,7 +5396,7 @@ Types:
                   Offset: 0
                   ByteSize: 4
     - __kind: EventRootType
-      ID: 312
+      ID: 437
       Name: Probe[main.testSingleUint64]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -4803,7 +5411,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 309
+      ID: 434
       Name: Probe[main.testSingleUint8]
       ByteSize: 2
       PresenceBitsetSize: 1
@@ -4818,7 +5426,7 @@ Types:
                   Offset: 0
                   ByteSize: 1
     - __kind: EventRootType
-      ID: 308
+      ID: 433
       Name: Probe[main.testSingleUint]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -4833,7 +5441,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 361
+      ID: 494
       Name: Probe[main.testSliceOfSlices]
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -4841,14 +5449,14 @@ Types:
         - Name: u
           Offset: 1
           Expression:
-            Type: 136 GoSliceHeaderType [][]uint
+            Type: 159 GoSliceHeaderType [][]uint
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 80, index: 0, name: u}
+                  Variable: {subprogram: 88, index: 0, name: u}
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 333
+      ID: 466
       Name: Probe[main.testSmallMap]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -4856,14 +5464,14 @@ Types:
         - Name: m
           Offset: 1
           Expression:
-            Type: 76 GoMapType map[string]int
+            Type: 99 GoMapType map[string]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 52, index: 0, name: m}
+                  Variable: {subprogram: 60, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 284
+      ID: 409
       Name: Probe[main.testStringArray]
       ByteSize: 33
       PresenceBitsetSize: 1
@@ -4878,7 +5486,7 @@ Types:
                   Offset: 0
                   ByteSize: 32
     - __kind: EventRootType
-      ID: 356
+      ID: 489
       Name: Probe[main.testStringPointer]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -4889,11 +5497,11 @@ Types:
             Type: 22 PointerType *string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 75, index: 0, name: z}
+                  Variable: {subprogram: 83, index: 0, name: z}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 365
+      ID: 498
       Name: Probe[main.testStringSlice]
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -4901,14 +5509,44 @@ Types:
         - Name: s
           Offset: 1
           Expression:
-            Type: 141 GoSliceHeaderType []string
+            Type: 164 GoSliceHeaderType []string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 84, index: 0, name: s}
+                  Variable: {subprogram: 92, index: 0, name: s}
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 362
+      ID: 448
+      Name: Probe[main.testStringType1]
+      ByteSize: 9
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: a
+          Offset: 1
+          Expression:
+            Type: 75 PointerType *main.stringType1
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 42, index: 0, name: a}
+                  Offset: 0
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 449
+      Name: Probe[main.testStringType2]
+      ByteSize: 9
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: a
+          Offset: 1
+          Expression:
+            Type: 77 PointerType **main.stringType2
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 43, index: 0, name: a}
+                  Offset: 0
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 495
       Name: Probe[main.testStructSlice]
       ByteSize: 33
       PresenceBitsetSize: 1
@@ -4916,10 +5554,10 @@ Types:
         - Name: xs
           Offset: 1
           Expression:
-            Type: 138 GoSliceHeaderType []main.structWithNoStrings
+            Type: 161 GoSliceHeaderType []main.structWithNoStrings
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 81, index: 0, name: xs}
+                  Variable: {subprogram: 89, index: 0, name: xs}
                   Offset: 0
                   ByteSize: 24
         - Name: a
@@ -4928,11 +5566,11 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 81, index: 1, name: a}
+                  Variable: {subprogram: 89, index: 1, name: a}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 328
+      ID: 461
       Name: Probe[main.testStructWithMap]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -4940,14 +5578,14 @@ Types:
         - Name: s
           Offset: 1
           Expression:
-            Type: 65 StructureType main.structWithMap
+            Type: 88 StructureType main.structWithMap
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 47, index: 0, name: s}
+                  Variable: {subprogram: 55, index: 0, name: s}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 378
+      ID: 511
       Name: Probe[main.testStruct]
       ByteSize: 57
       PresenceBitsetSize: 1
@@ -4955,14 +5593,14 @@ Types:
         - Name: x
           Offset: 1
           Expression:
-            Type: 148 StructureType main.aStruct
+            Type: 171 StructureType main.aStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 97, index: 0, name: x}
+                  Variable: {subprogram: 105, index: 0, name: x}
                   Offset: 0
                   ByteSize: 56
     - __kind: EventRootType
-      ID: 373
+      ID: 506
       Name: Probe[main.testThreeStringsInStructPointer]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -4970,14 +5608,14 @@ Types:
         - Name: a
           Offset: 1
           Expression:
-            Type: 145 PointerType *main.threeStringStruct
+            Type: 168 PointerType *main.threeStringStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 92, index: 0, name: a}
+                  Variable: {subprogram: 100, index: 0, name: a}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 372
+      ID: 505
       Name: Probe[main.testThreeStringsInStruct]
       ByteSize: 49
       PresenceBitsetSize: 1
@@ -4985,14 +5623,14 @@ Types:
         - Name: a
           Offset: 1
           Expression:
-            Type: 144 StructureType main.threeStringStruct
+            Type: 167 StructureType main.threeStringStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 91, index: 0, name: a}
+                  Variable: {subprogram: 99, index: 0, name: a}
                   Offset: 0
                   ByteSize: 48
     - __kind: EventRootType
-      ID: 371
+      ID: 504
       Name: Probe[main.testThreeStrings]
       ByteSize: 49
       PresenceBitsetSize: 1
@@ -5003,7 +5641,7 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 90, index: 0, name: x}
+                  Variable: {subprogram: 98, index: 0, name: x}
                   Offset: 0
                   ByteSize: 16
         - Name: y
@@ -5012,7 +5650,7 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 90, index: 1, name: y}
+                  Variable: {subprogram: 98, index: 1, name: y}
                   Offset: 0
                   ByteSize: 16
         - Name: z
@@ -5021,11 +5659,11 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 90, index: 2, name: z}
+                  Variable: {subprogram: 98, index: 2, name: z}
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 315
+      ID: 440
       Name: Probe[main.testTypeAlias]
       ByteSize: 3
       PresenceBitsetSize: 1
@@ -5040,7 +5678,7 @@ Types:
                   Offset: 0
                   ByteSize: 2
     - __kind: EventRootType
-      ID: 293
+      ID: 418
       Name: Probe[main.testUint16Array]
       ByteSize: 5
       PresenceBitsetSize: 1
@@ -5055,7 +5693,7 @@ Types:
                   Offset: 0
                   ByteSize: 4
     - __kind: EventRootType
-      ID: 294
+      ID: 419
       Name: Probe[main.testUint32Array]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -5070,7 +5708,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 295
+      ID: 420
       Name: Probe[main.testUint64Array]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -5085,7 +5723,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 292
+      ID: 417
       Name: Probe[main.testUint8Array]
       ByteSize: 3
       PresenceBitsetSize: 1
@@ -5100,7 +5738,7 @@ Types:
                   Offset: 0
                   ByteSize: 2
     - __kind: EventRootType
-      ID: 291
+      ID: 416
       Name: Probe[main.testUintArray]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -5115,7 +5753,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 355
+      ID: 488
       Name: Probe[main.testUintPointer]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -5126,11 +5764,11 @@ Types:
             Type: 34 PointerType *uint
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 74, index: 0, name: x}
+                  Variable: {subprogram: 82, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 359
+      ID: 492
       Name: Probe[main.testUintSlice]
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -5138,14 +5776,14 @@ Types:
         - Name: u
           Offset: 1
           Expression:
-            Type: 135 GoSliceHeaderType []uint
+            Type: 158 GoSliceHeaderType []uint
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 78, index: 0, name: u}
+                  Variable: {subprogram: 86, index: 0, name: u}
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 376
+      ID: 509
       Name: Probe[main.testUnitializedString]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -5156,11 +5794,11 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 95, index: 0, name: x}
+                  Variable: {subprogram: 103, index: 0, name: x}
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 354
+      ID: 487
       Name: Probe[main.testUnsafePointer]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -5171,11 +5809,11 @@ Types:
             Type: 15 VoidPointerType unsafe.Pointer
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 73, index: 0, name: x}
+                  Variable: {subprogram: 81, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 299
+      ID: 424
       Name: Probe[main.testVeryLargeArray]
       ByteSize: 801
       PresenceBitsetSize: 1
@@ -5190,7 +5828,7 @@ Types:
                   Offset: 0
                   ByteSize: 800
     - __kind: EventRootType
-      ID: 368
+      ID: 501
       Name: Probe[main.testVeryLargeSlice]
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -5198,10 +5836,10 @@ Types:
         - Name: xs
           Offset: 1
           Expression:
-            Type: 135 GoSliceHeaderType []uint
+            Type: 158 GoSliceHeaderType []uint
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 87, index: 0, name: xs}
+                  Variable: {subprogram: 95, index: 0, name: xs}
                   Offset: 0
                   ByteSize: 24
     - __kind: ArrayType
@@ -5240,7 +5878,7 @@ Types:
       ID: 40
       Name: '[2]int'
       ByteSize: 16
-      GoRuntimeType: 673088
+      GoRuntimeType: 679040
       GoKind: 17
       Count: 2
       HasCount: true
@@ -5257,7 +5895,7 @@ Types:
       ID: 37
       Name: '[2]int32'
       ByteSize: 8
-      GoRuntimeType: 674432
+      GoRuntimeType: 680384
       GoKind: 17
       Count: 2
       HasCount: true
@@ -5279,18 +5917,18 @@ Types:
       HasCount: true
       Element: 16 BaseType int8
     - __kind: ArrayType
-      ID: 91
+      ID: 114
       Name: '[2]map[string]int'
       ByteSize: 16
       GoKind: 17
       Count: 2
       HasCount: true
-      Element: 76 GoMapType map[string]int
+      Element: 99 GoMapType map[string]int
     - __kind: ArrayType
       ID: 38
       Name: '[2]string'
       ByteSize: 32
-      GoRuntimeType: 674528
+      GoRuntimeType: 680480
       GoKind: 17
       Count: 2
       HasCount: true
@@ -5323,7 +5961,7 @@ Types:
       ID: 47
       Name: '[2]uint64'
       ByteSize: 16
-      GoRuntimeType: 674624
+      GoRuntimeType: 680576
       GoKind: 17
       Count: 2
       HasCount: true
@@ -5332,31 +5970,31 @@ Types:
       ID: 36
       Name: '[2]uint8'
       ByteSize: 2
-      GoRuntimeType: 674336
+      GoRuntimeType: 680288
       GoKind: 17
       Count: 2
       HasCount: true
       Element: 3 BaseType uint8
     - __kind: ArrayType
-      ID: 236
+      ID: 272
       Name: '[4]int'
       ByteSize: 32
-      GoRuntimeType: 672704
+      GoRuntimeType: 678656
       GoKind: 17
       Count: 4
       HasCount: true
       Element: 7 BaseType int
     - __kind: ArrayType
-      ID: 193
+      ID: 229
       Name: '[4]string'
       ByteSize: 64
-      GoRuntimeType: 672992
+      GoRuntimeType: 678944
       GoKind: 17
       Count: 4
       HasCount: true
       Element: 9 GoStringHeaderType string
     - __kind: ArrayType
-      ID: 63
+      ID: 86
       Name: '[5]int'
       ByteSize: 40
       GoKind: 17
@@ -5364,10 +6002,98 @@ Types:
       HasCount: true
       Element: 7 BaseType int
     - __kind: GoSliceHeaderType
+      ID: 62
+      Name: '[]*main.deepSlice2'
+      ByteSize: 24
+      GoRuntimeType: 474592
+      GoKind: 23
+      RawFields:
+        - Name: array
+          Offset: 0
+          Type: 63 PointerType **main.deepSlice2
+        - Name: len
+          Offset: 8
+          Type: 7 BaseType int
+        - Name: cap
+          Offset: 16
+          Type: 7 BaseType int
+      Data: 179 GoSliceDataType []*main.deepSlice2.array
+    - __kind: GoSliceDataType
+      ID: 179
+      Name: '[]*main.deepSlice2.array'
+      ByteSize: 2048
+      Element: 64 PointerType *main.deepSlice2
+    - __kind: GoSliceHeaderType
+      ID: 308
+      Name: '[]*main.deepSlice3'
+      ByteSize: 24
+      GoRuntimeType: 474528
+      GoKind: 23
+      RawFields:
+        - Name: array
+          Offset: 0
+          Type: 309 PointerType **main.deepSlice3
+        - Name: len
+          Offset: 8
+          Type: 7 BaseType int
+        - Name: cap
+          Offset: 16
+          Type: 7 BaseType int
+      Data: 312 GoSliceDataType []*main.deepSlice3.array
+    - __kind: GoSliceDataType
+      ID: 312
+      Name: '[]*main.deepSlice3.array'
+      ByteSize: 2048
+      Element: 310 PointerType *main.deepSlice3
+    - __kind: GoSliceHeaderType
+      ID: 333
+      Name: '[]*main.deepSlice8'
+      ByteSize: 24
+      GoRuntimeType: 474208
+      GoKind: 23
+      RawFields:
+        - Name: array
+          Offset: 0
+          Type: 334 PointerType **main.deepSlice8
+        - Name: len
+          Offset: 8
+          Type: 7 BaseType int
+        - Name: cap
+          Offset: 16
+          Type: 7 BaseType int
+      Data: 337 GoSliceDataType []*main.deepSlice8.array
+    - __kind: GoSliceDataType
+      ID: 337
+      Name: '[]*main.deepSlice8.array'
+      ByteSize: 2048
+      Element: 335 PointerType *main.deepSlice8
+    - __kind: GoSliceHeaderType
+      ID: 339
+      Name: '[]*main.deepSlice9'
+      ByteSize: 24
+      GoRuntimeType: 474144
+      GoKind: 23
+      RawFields:
+        - Name: array
+          Offset: 0
+          Type: 340 PointerType **main.deepSlice9
+        - Name: len
+          Offset: 8
+          Type: 7 BaseType int
+        - Name: cap
+          Offset: 16
+          Type: 7 BaseType int
+      Data: 343 GoSliceDataType []*main.deepSlice9.array
+    - __kind: GoSliceDataType
+      ID: 343
+      Name: '[]*main.deepSlice9.array'
+      ByteSize: 2048
+      Element: 341 PointerType *main.deepSlice9
+    - __kind: GoSliceHeaderType
       ID: 53
       Name: '[]*string'
       ByteSize: 24
-      GoRuntimeType: 470528
+      GoRuntimeType: 475616
       GoKind: 23
       RawFields:
         - Name: array
@@ -5379,98 +6105,123 @@ Types:
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 153 GoSliceDataType []*string.array
+      Data: 176 GoSliceDataType []*string.array
     - __kind: GoSliceDataType
-      ID: 153
+      ID: 176
       Name: '[]*string.array'
       ByteSize: 2048
       Element: 22 PointerType *string
     - __kind: GoSliceDataType
-      ID: 253
+      ID: 289
       Name: '[]*table<[4]int,[4]int>.array'
       ByteSize: 8192
-      Element: 127 PointerType *table<[4]int,[4]int>
+      Element: 150 PointerType *table<[4]int,[4]int>
     - __kind: GoSliceDataType
-      ID: 245
+      ID: 281
       Name: '[]*table<[4]int,uint8>.array'
       ByteSize: 8192
-      Element: 122 PointerType *table<[4]int,uint8>
+      Element: 145 PointerType *table<[4]int,uint8>
     - __kind: GoSliceDataType
-      ID: 194
+      ID: 230
       Name: '[]*table<[4]string,[2]int>.array'
       ByteSize: 8192
-      Element: 90 PointerType *table<[4]string,[2]int>
+      Element: 113 PointerType *table<[4]string,[2]int>
     - __kind: GoSliceDataType
-      ID: 212
+      ID: 248
       Name: '[]*table<bool,main.node>.array'
       ByteSize: 8192
-      Element: 102 PointerType *table<bool,main.node>
+      Element: 125 PointerType *table<bool,main.node>
     - __kind: GoSliceDataType
-      ID: 161
+      ID: 189
+      Name: '[]*table<int,*main.deepMap2>.array'
+      ByteSize: 8192
+      Element: 72 PointerType *table<int,*main.deepMap2>
+    - __kind: GoSliceDataType
+      ID: 327
+      Name: '[]*table<int,*main.deepMap3>.array'
+      ByteSize: 8192
+      Element: 318 PointerType *table<int,*main.deepMap3>
+    - __kind: GoSliceDataType
+      ID: 362
+      Name: '[]*table<int,*main.deepMap8>.array'
+      ByteSize: 8192
+      Element: 353 PointerType *table<int,*main.deepMap8>
+    - __kind: GoSliceDataType
+      ID: 377
+      Name: '[]*table<int,*main.deepMap9>.array'
+      ByteSize: 8192
+      Element: 368 PointerType *table<int,*main.deepMap9>
+    - __kind: GoSliceDataType
+      ID: 197
       Name: '[]*table<int,int>.array'
       ByteSize: 8192
-      Element: 70 PointerType *table<int,int>
+      Element: 93 PointerType *table<int,int>
     - __kind: GoSliceDataType
-      ID: 220
+      ID: 390
+      Name: '[]*table<int,interface {}>.array'
+      ByteSize: 8192
+      Element: 383 PointerType *table<int,interface {}>
+    - __kind: GoSliceDataType
+      ID: 256
       Name: '[]*table<int,uint8>.array'
       ByteSize: 8192
-      Element: 107 PointerType *table<int,uint8>
+      Element: 130 PointerType *table<int,uint8>
     - __kind: GoSliceDataType
-      ID: 204
+      ID: 240
       Name: '[]*table<string,[]main.structWithMap>.array'
       ByteSize: 8192
-      Element: 97 PointerType *table<string,[]main.structWithMap>
+      Element: 120 PointerType *table<string,[]main.structWithMap>
     - __kind: GoSliceDataType
-      ID: 185
+      ID: 221
       Name: '[]*table<string,[]string>.array'
       ByteSize: 8192
-      Element: 85 PointerType *table<string,[]string>
+      Element: 108 PointerType *table<string,[]string>
     - __kind: GoSliceDataType
-      ID: 177
+      ID: 213
       Name: '[]*table<string,int>.array'
       ByteSize: 8192
-      Element: 80 PointerType *table<string,int>
+      Element: 103 PointerType *table<string,int>
     - __kind: GoSliceDataType
-      ID: 169
+      ID: 205
       Name: '[]*table<string,main.nestedStruct>.array'
       ByteSize: 8192
-      Element: 75 PointerType *table<string,main.nestedStruct>
+      Element: 98 PointerType *table<string,main.nestedStruct>
     - __kind: GoSliceDataType
-      ID: 237
+      ID: 273
       Name: '[]*table<uint8,[4]int>.array'
       ByteSize: 8192
-      Element: 117 PointerType *table<uint8,[4]int>
+      Element: 140 PointerType *table<uint8,[4]int>
     - __kind: GoSliceDataType
-      ID: 228
+      ID: 264
       Name: '[]*table<uint8,uint8>.array'
       ByteSize: 8192
-      Element: 112 PointerType *table<uint8,uint8>
+      Element: 135 PointerType *table<uint8,uint8>
     - __kind: GoSliceHeaderType
-      ID: 136
+      ID: 159
       Name: '[][]uint'
       ByteSize: 24
       GoKind: 23
       RawFields:
         - Name: array
           Offset: 0
-          Type: 137 PointerType *[]uint
+          Type: 160 PointerType *[]uint
         - Name: len
           Offset: 8
           Type: 7 BaseType int
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 257 GoSliceDataType [][]uint.array
+      Data: 293 GoSliceDataType [][]uint.array
     - __kind: GoSliceDataType
-      ID: 257
+      ID: 293
       Name: '[][]uint.array'
       ByteSize: 2048
-      Element: 135 GoSliceHeaderType []uint
+      Element: 158 GoSliceHeaderType []uint
     - __kind: GoSliceHeaderType
-      ID: 142
+      ID: 165
       Name: '[]bool'
       ByteSize: 24
-      GoRuntimeType: 478400
+      GoRuntimeType: 483488
       GoKind: 23
       RawFields:
         - Name: array
@@ -5482,120 +6233,167 @@ Types:
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 263 GoSliceDataType []bool.array
+      Data: 299 GoSliceDataType []bool.array
     - __kind: GoSliceDataType
-      ID: 263
+      ID: 299
       Name: '[]bool.array'
       ByteSize: 2048
       Element: 4 BaseType bool
     - __kind: GoSliceHeaderType
-      ID: 202
-      Name: '[]main.structWithMap'
+      ID: 345
+      Name: '[]interface {}'
       ByteSize: 24
-      GoRuntimeType: 469760
+      GoRuntimeType: 483808
       GoKind: 23
       RawFields:
         - Name: array
           Offset: 0
-          Type: 203 PointerType *main.structWithMap
+          Type: 346 PointerType *interface {}
         - Name: len
           Offset: 8
           Type: 7 BaseType int
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 280 GoSliceDataType []main.structWithMap.array
+      Data: 347 GoSliceDataType []interface {}.array
     - __kind: GoSliceDataType
-      ID: 280
+      ID: 347
+      Name: '[]interface {}.array'
+      ByteSize: 2048
+      Element: 81 GoEmptyInterfaceType interface {}
+    - __kind: GoSliceHeaderType
+      ID: 238
+      Name: '[]main.structWithMap'
+      ByteSize: 24
+      GoRuntimeType: 474848
+      GoKind: 23
+      RawFields:
+        - Name: array
+          Offset: 0
+          Type: 239 PointerType *main.structWithMap
+        - Name: len
+          Offset: 8
+          Type: 7 BaseType int
+        - Name: cap
+          Offset: 16
+          Type: 7 BaseType int
+      Data: 405 GoSliceDataType []main.structWithMap.array
+    - __kind: GoSliceDataType
+      ID: 405
       Name: '[]main.structWithMap.array'
       ByteSize: 2048
-      Element: 65 StructureType main.structWithMap
+      Element: 88 StructureType main.structWithMap
     - __kind: GoSliceHeaderType
-      ID: 138
+      ID: 161
       Name: '[]main.structWithNoStrings'
       ByteSize: 24
       GoKind: 23
       RawFields:
         - Name: array
           Offset: 0
-          Type: 139 PointerType *main.structWithNoStrings
+          Type: 162 PointerType *main.structWithNoStrings
         - Name: len
           Offset: 8
           Type: 7 BaseType int
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 259 GoSliceDataType []main.structWithNoStrings.array
+      Data: 295 GoSliceDataType []main.structWithNoStrings.array
     - __kind: GoSliceDataType
-      ID: 259
+      ID: 295
       Name: '[]main.structWithNoStrings.array'
       ByteSize: 2048
-      Element: 140 StructureType main.structWithNoStrings
+      Element: 163 StructureType main.structWithNoStrings
     - __kind: GoSliceDataType
-      ID: 254
+      ID: 290
       Name: '[]noalg.map.group[[4]int][4]int.array'
       ByteSize: 2048
-      Element: 250 StructureType noalg.map.group[[4]int][4]int
+      Element: 286 StructureType noalg.map.group[[4]int][4]int
     - __kind: GoSliceDataType
-      ID: 246
+      ID: 282
       Name: '[]noalg.map.group[[4]int]uint8.array'
       ByteSize: 2048
-      Element: 242 StructureType noalg.map.group[[4]int]uint8
+      Element: 278 StructureType noalg.map.group[[4]int]uint8
     - __kind: GoSliceDataType
-      ID: 195
+      ID: 231
       Name: '[]noalg.map.group[[4]string][2]int.array'
       ByteSize: 2048
-      Element: 190 StructureType noalg.map.group[[4]string][2]int
+      Element: 226 StructureType noalg.map.group[[4]string][2]int
     - __kind: GoSliceDataType
-      ID: 213
+      ID: 249
       Name: '[]noalg.map.group[bool]main.node.array'
       ByteSize: 2048
-      Element: 209 StructureType noalg.map.group[bool]main.node
+      Element: 245 StructureType noalg.map.group[bool]main.node
     - __kind: GoSliceDataType
-      ID: 162
+      ID: 190
+      Name: '[]noalg.map.group[int]*main.deepMap2.array'
+      ByteSize: 2048
+      Element: 184 StructureType noalg.map.group[int]*main.deepMap2
+    - __kind: GoSliceDataType
+      ID: 328
+      Name: '[]noalg.map.group[int]*main.deepMap3.array'
+      ByteSize: 2048
+      Element: 322 StructureType noalg.map.group[int]*main.deepMap3
+    - __kind: GoSliceDataType
+      ID: 363
+      Name: '[]noalg.map.group[int]*main.deepMap8.array'
+      ByteSize: 2048
+      Element: 357 StructureType noalg.map.group[int]*main.deepMap8
+    - __kind: GoSliceDataType
+      ID: 378
+      Name: '[]noalg.map.group[int]*main.deepMap9.array'
+      ByteSize: 2048
+      Element: 372 StructureType noalg.map.group[int]*main.deepMap9
+    - __kind: GoSliceDataType
+      ID: 198
       Name: '[]noalg.map.group[int]int.array'
       ByteSize: 2048
-      Element: 158 StructureType noalg.map.group[int]int
+      Element: 194 StructureType noalg.map.group[int]int
     - __kind: GoSliceDataType
-      ID: 221
+      ID: 391
+      Name: '[]noalg.map.group[int]interface {}.array'
+      ByteSize: 2048
+      Element: 387 StructureType noalg.map.group[int]interface {}
+    - __kind: GoSliceDataType
+      ID: 257
       Name: '[]noalg.map.group[int]uint8.array'
       ByteSize: 2048
-      Element: 217 StructureType noalg.map.group[int]uint8
+      Element: 253 StructureType noalg.map.group[int]uint8
     - __kind: GoSliceDataType
-      ID: 205
+      ID: 241
       Name: '[]noalg.map.group[string][]main.structWithMap.array'
       ByteSize: 2048
-      Element: 199 StructureType noalg.map.group[string][]main.structWithMap
+      Element: 235 StructureType noalg.map.group[string][]main.structWithMap
     - __kind: GoSliceDataType
-      ID: 186
+      ID: 222
       Name: '[]noalg.map.group[string][]string.array'
       ByteSize: 2048
-      Element: 182 StructureType noalg.map.group[string][]string
+      Element: 218 StructureType noalg.map.group[string][]string
     - __kind: GoSliceDataType
-      ID: 178
+      ID: 214
       Name: '[]noalg.map.group[string]int.array'
       ByteSize: 2048
-      Element: 174 StructureType noalg.map.group[string]int
+      Element: 210 StructureType noalg.map.group[string]int
     - __kind: GoSliceDataType
-      ID: 170
+      ID: 206
       Name: '[]noalg.map.group[string]main.nestedStruct.array'
       ByteSize: 2048
-      Element: 166 StructureType noalg.map.group[string]main.nestedStruct
+      Element: 202 StructureType noalg.map.group[string]main.nestedStruct
     - __kind: GoSliceDataType
-      ID: 238
+      ID: 274
       Name: '[]noalg.map.group[uint8][4]int.array'
       ByteSize: 2048
-      Element: 233 StructureType noalg.map.group[uint8][4]int
+      Element: 269 StructureType noalg.map.group[uint8][4]int
     - __kind: GoSliceDataType
-      ID: 229
+      ID: 265
       Name: '[]noalg.map.group[uint8]uint8.array'
       ByteSize: 2048
-      Element: 225 StructureType noalg.map.group[uint8]uint8
+      Element: 261 StructureType noalg.map.group[uint8]uint8
     - __kind: GoSliceHeaderType
-      ID: 141
+      ID: 164
       Name: '[]string'
       ByteSize: 24
-      GoRuntimeType: 478528
+      GoRuntimeType: 483616
       GoKind: 23
       RawFields:
         - Name: array
@@ -5607,17 +6405,17 @@ Types:
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 261 GoSliceDataType []string.array
+      Data: 297 GoSliceDataType []string.array
     - __kind: GoSliceDataType
-      ID: 261
+      ID: 297
       Name: '[]string.array'
       ByteSize: 2048
       Element: 9 GoStringHeaderType string
     - __kind: GoSliceHeaderType
-      ID: 135
+      ID: 158
       Name: '[]uint'
       ByteSize: 24
-      GoRuntimeType: 478016
+      GoRuntimeType: 483104
       GoKind: 23
       RawFields:
         - Name: array
@@ -5629,17 +6427,17 @@ Types:
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 255 GoSliceDataType []uint.array
+      Data: 291 GoSliceDataType []uint.array
     - __kind: GoSliceDataType
-      ID: 255
+      ID: 291
       Name: '[]uint.array'
       ByteSize: 2048
       Element: 10 BaseType uint
     - __kind: GoSliceHeaderType
-      ID: 143
+      ID: 166
       Name: '[]uint16'
       ByteSize: 24
-      GoRuntimeType: 477376
+      GoRuntimeType: 482464
       GoKind: 23
       RawFields:
         - Name: array
@@ -5651,9 +6449,9 @@ Types:
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 265 GoSliceDataType []uint16.array
+      Data: 301 GoSliceDataType []uint16.array
     - __kind: GoSliceDataType
-      ID: 265
+      ID: 301
       Name: '[]uint16.array'
       ByteSize: 2048
       Element: 6 BaseType uint16
@@ -5661,35 +6459,35 @@ Types:
       ID: 4
       Name: bool
       ByteSize: 1
-      GoRuntimeType: 575840
+      GoRuntimeType: 580928
       GoKind: 1
     - __kind: GoChannelType
-      ID: 128
+      ID: 151
       Name: chan bool
-      GoRuntimeType: 587168
+      GoRuntimeType: 592256
       GoKind: 18
     - __kind: GoChannelType
-      ID: 57
+      ID: 80
       Name: chan struct {}
-      GoRuntimeType: 586080
+      GoRuntimeType: 591168
       GoKind: 18
     - __kind: BaseType
       ID: 25
       Name: complex128
       ByteSize: 16
-      GoRuntimeType: 575648
+      GoRuntimeType: 580736
       GoKind: 16
     - __kind: BaseType
       ID: 24
       Name: complex64
       ByteSize: 8
-      GoRuntimeType: 575584
+      GoRuntimeType: 580672
       GoKind: 15
     - __kind: GoInterfaceType
       ID: 14
       Name: error
       ByteSize: 16
-      GoRuntimeType: 1.015744e+06
+      GoRuntimeType: 1.021696e+06
       GoKind: 20
       RawFields:
         - Name: tab
@@ -5702,223 +6500,293 @@ Types:
       ID: 17
       Name: float32
       ByteSize: 4
-      GoRuntimeType: 575712
+      GoRuntimeType: 580800
       GoKind: 13
     - __kind: BaseType
       ID: 18
       Name: float64
       ByteSize: 8
-      GoRuntimeType: 575776
+      GoRuntimeType: 580864
       GoKind: 14
     - __kind: GoSubroutineType
-      ID: 60
+      ID: 83
       Name: func()
       ByteSize: 8
-      GoRuntimeType: 468800
+      GoRuntimeType: 472800
       GoKind: 19
     - __kind: GoSwissMapGroupsType
-      ID: 248
+      ID: 284
       Name: groupReference<[4]int,[4]int>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 249 PointerType *noalg.map.group[[4]int][4]int
+          Type: 285 PointerType *noalg.map.group[[4]int][4]int
         - Name: lengthMask
           Offset: 8
           Type: 8 BaseType uint64
-      GroupType: 250 StructureType noalg.map.group[[4]int][4]int
-      GroupSliceType: 254 GoSliceDataType []noalg.map.group[[4]int][4]int.array
+      GroupType: 286 StructureType noalg.map.group[[4]int][4]int
+      GroupSliceType: 290 GoSliceDataType []noalg.map.group[[4]int][4]int.array
     - __kind: GoSwissMapGroupsType
-      ID: 240
+      ID: 276
       Name: groupReference<[4]int,uint8>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 241 PointerType *noalg.map.group[[4]int]uint8
+          Type: 277 PointerType *noalg.map.group[[4]int]uint8
         - Name: lengthMask
           Offset: 8
           Type: 8 BaseType uint64
-      GroupType: 242 StructureType noalg.map.group[[4]int]uint8
-      GroupSliceType: 246 GoSliceDataType []noalg.map.group[[4]int]uint8.array
+      GroupType: 278 StructureType noalg.map.group[[4]int]uint8
+      GroupSliceType: 282 GoSliceDataType []noalg.map.group[[4]int]uint8.array
     - __kind: GoSwissMapGroupsType
-      ID: 188
+      ID: 224
       Name: groupReference<[4]string,[2]int>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 189 PointerType *noalg.map.group[[4]string][2]int
+          Type: 225 PointerType *noalg.map.group[[4]string][2]int
         - Name: lengthMask
           Offset: 8
           Type: 8 BaseType uint64
-      GroupType: 190 StructureType noalg.map.group[[4]string][2]int
-      GroupSliceType: 195 GoSliceDataType []noalg.map.group[[4]string][2]int.array
+      GroupType: 226 StructureType noalg.map.group[[4]string][2]int
+      GroupSliceType: 231 GoSliceDataType []noalg.map.group[[4]string][2]int.array
     - __kind: GoSwissMapGroupsType
-      ID: 207
+      ID: 243
       Name: groupReference<bool,main.node>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 208 PointerType *noalg.map.group[bool]main.node
+          Type: 244 PointerType *noalg.map.group[bool]main.node
         - Name: lengthMask
           Offset: 8
           Type: 8 BaseType uint64
-      GroupType: 209 StructureType noalg.map.group[bool]main.node
-      GroupSliceType: 213 GoSliceDataType []noalg.map.group[bool]main.node.array
+      GroupType: 245 StructureType noalg.map.group[bool]main.node
+      GroupSliceType: 249 GoSliceDataType []noalg.map.group[bool]main.node.array
     - __kind: GoSwissMapGroupsType
-      ID: 156
+      ID: 182
+      Name: groupReference<int,*main.deepMap2>
+      ByteSize: 16
+      GoKind: 25
+      RawFields:
+        - Name: data
+          Offset: 0
+          Type: 183 PointerType *noalg.map.group[int]*main.deepMap2
+        - Name: lengthMask
+          Offset: 8
+          Type: 8 BaseType uint64
+      GroupType: 184 StructureType noalg.map.group[int]*main.deepMap2
+      GroupSliceType: 190 GoSliceDataType []noalg.map.group[int]*main.deepMap2.array
+    - __kind: GoSwissMapGroupsType
+      ID: 320
+      Name: groupReference<int,*main.deepMap3>
+      ByteSize: 16
+      GoKind: 25
+      RawFields:
+        - Name: data
+          Offset: 0
+          Type: 321 PointerType *noalg.map.group[int]*main.deepMap3
+        - Name: lengthMask
+          Offset: 8
+          Type: 8 BaseType uint64
+      GroupType: 322 StructureType noalg.map.group[int]*main.deepMap3
+      GroupSliceType: 328 GoSliceDataType []noalg.map.group[int]*main.deepMap3.array
+    - __kind: GoSwissMapGroupsType
+      ID: 355
+      Name: groupReference<int,*main.deepMap8>
+      ByteSize: 16
+      GoKind: 25
+      RawFields:
+        - Name: data
+          Offset: 0
+          Type: 356 PointerType *noalg.map.group[int]*main.deepMap8
+        - Name: lengthMask
+          Offset: 8
+          Type: 8 BaseType uint64
+      GroupType: 357 StructureType noalg.map.group[int]*main.deepMap8
+      GroupSliceType: 363 GoSliceDataType []noalg.map.group[int]*main.deepMap8.array
+    - __kind: GoSwissMapGroupsType
+      ID: 370
+      Name: groupReference<int,*main.deepMap9>
+      ByteSize: 16
+      GoKind: 25
+      RawFields:
+        - Name: data
+          Offset: 0
+          Type: 371 PointerType *noalg.map.group[int]*main.deepMap9
+        - Name: lengthMask
+          Offset: 8
+          Type: 8 BaseType uint64
+      GroupType: 372 StructureType noalg.map.group[int]*main.deepMap9
+      GroupSliceType: 378 GoSliceDataType []noalg.map.group[int]*main.deepMap9.array
+    - __kind: GoSwissMapGroupsType
+      ID: 192
       Name: groupReference<int,int>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 157 PointerType *noalg.map.group[int]int
+          Type: 193 PointerType *noalg.map.group[int]int
         - Name: lengthMask
           Offset: 8
           Type: 8 BaseType uint64
-      GroupType: 158 StructureType noalg.map.group[int]int
-      GroupSliceType: 162 GoSliceDataType []noalg.map.group[int]int.array
+      GroupType: 194 StructureType noalg.map.group[int]int
+      GroupSliceType: 198 GoSliceDataType []noalg.map.group[int]int.array
     - __kind: GoSwissMapGroupsType
-      ID: 215
+      ID: 385
+      Name: groupReference<int,interface {}>
+      ByteSize: 16
+      GoKind: 25
+      RawFields:
+        - Name: data
+          Offset: 0
+          Type: 386 PointerType *noalg.map.group[int]interface {}
+        - Name: lengthMask
+          Offset: 8
+          Type: 8 BaseType uint64
+      GroupType: 387 StructureType noalg.map.group[int]interface {}
+      GroupSliceType: 391 GoSliceDataType []noalg.map.group[int]interface {}.array
+    - __kind: GoSwissMapGroupsType
+      ID: 251
       Name: groupReference<int,uint8>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 216 PointerType *noalg.map.group[int]uint8
+          Type: 252 PointerType *noalg.map.group[int]uint8
         - Name: lengthMask
           Offset: 8
           Type: 8 BaseType uint64
-      GroupType: 217 StructureType noalg.map.group[int]uint8
-      GroupSliceType: 221 GoSliceDataType []noalg.map.group[int]uint8.array
+      GroupType: 253 StructureType noalg.map.group[int]uint8
+      GroupSliceType: 257 GoSliceDataType []noalg.map.group[int]uint8.array
     - __kind: GoSwissMapGroupsType
-      ID: 197
+      ID: 233
       Name: groupReference<string,[]main.structWithMap>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 198 PointerType *noalg.map.group[string][]main.structWithMap
+          Type: 234 PointerType *noalg.map.group[string][]main.structWithMap
         - Name: lengthMask
           Offset: 8
           Type: 8 BaseType uint64
-      GroupType: 199 StructureType noalg.map.group[string][]main.structWithMap
-      GroupSliceType: 205 GoSliceDataType []noalg.map.group[string][]main.structWithMap.array
+      GroupType: 235 StructureType noalg.map.group[string][]main.structWithMap
+      GroupSliceType: 241 GoSliceDataType []noalg.map.group[string][]main.structWithMap.array
     - __kind: GoSwissMapGroupsType
-      ID: 180
+      ID: 216
       Name: groupReference<string,[]string>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 181 PointerType *noalg.map.group[string][]string
+          Type: 217 PointerType *noalg.map.group[string][]string
         - Name: lengthMask
           Offset: 8
           Type: 8 BaseType uint64
-      GroupType: 182 StructureType noalg.map.group[string][]string
-      GroupSliceType: 186 GoSliceDataType []noalg.map.group[string][]string.array
+      GroupType: 218 StructureType noalg.map.group[string][]string
+      GroupSliceType: 222 GoSliceDataType []noalg.map.group[string][]string.array
     - __kind: GoSwissMapGroupsType
-      ID: 172
+      ID: 208
       Name: groupReference<string,int>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 173 PointerType *noalg.map.group[string]int
+          Type: 209 PointerType *noalg.map.group[string]int
         - Name: lengthMask
           Offset: 8
           Type: 8 BaseType uint64
-      GroupType: 174 StructureType noalg.map.group[string]int
-      GroupSliceType: 178 GoSliceDataType []noalg.map.group[string]int.array
+      GroupType: 210 StructureType noalg.map.group[string]int
+      GroupSliceType: 214 GoSliceDataType []noalg.map.group[string]int.array
     - __kind: GoSwissMapGroupsType
-      ID: 164
+      ID: 200
       Name: groupReference<string,main.nestedStruct>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 165 PointerType *noalg.map.group[string]main.nestedStruct
+          Type: 201 PointerType *noalg.map.group[string]main.nestedStruct
         - Name: lengthMask
           Offset: 8
           Type: 8 BaseType uint64
-      GroupType: 166 StructureType noalg.map.group[string]main.nestedStruct
-      GroupSliceType: 170 GoSliceDataType []noalg.map.group[string]main.nestedStruct.array
+      GroupType: 202 StructureType noalg.map.group[string]main.nestedStruct
+      GroupSliceType: 206 GoSliceDataType []noalg.map.group[string]main.nestedStruct.array
     - __kind: GoSwissMapGroupsType
-      ID: 231
+      ID: 267
       Name: groupReference<uint8,[4]int>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 232 PointerType *noalg.map.group[uint8][4]int
+          Type: 268 PointerType *noalg.map.group[uint8][4]int
         - Name: lengthMask
           Offset: 8
           Type: 8 BaseType uint64
-      GroupType: 233 StructureType noalg.map.group[uint8][4]int
-      GroupSliceType: 238 GoSliceDataType []noalg.map.group[uint8][4]int.array
+      GroupType: 269 StructureType noalg.map.group[uint8][4]int
+      GroupSliceType: 274 GoSliceDataType []noalg.map.group[uint8][4]int.array
     - __kind: GoSwissMapGroupsType
-      ID: 223
+      ID: 259
       Name: groupReference<uint8,uint8>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 224 PointerType *noalg.map.group[uint8]uint8
+          Type: 260 PointerType *noalg.map.group[uint8]uint8
         - Name: lengthMask
           Offset: 8
           Type: 8 BaseType uint64
-      GroupType: 225 StructureType noalg.map.group[uint8]uint8
-      GroupSliceType: 229 GoSliceDataType []noalg.map.group[uint8]uint8.array
+      GroupType: 261 StructureType noalg.map.group[uint8]uint8
+      GroupSliceType: 265 GoSliceDataType []noalg.map.group[uint8]uint8.array
     - __kind: BaseType
       ID: 7
       Name: int
       ByteSize: 8
-      GoRuntimeType: 575392
+      GoRuntimeType: 580480
       GoKind: 2
     - __kind: BaseType
       ID: 23
       Name: int16
       ByteSize: 2
-      GoRuntimeType: 575008
+      GoRuntimeType: 580096
       GoKind: 4
     - __kind: BaseType
       ID: 12
       Name: int32
       ByteSize: 4
-      GoRuntimeType: 575136
+      GoRuntimeType: 580224
       GoKind: 5
     - __kind: BaseType
       ID: 13
       Name: int64
       ByteSize: 8
-      GoRuntimeType: 575264
+      GoRuntimeType: 580352
       GoKind: 6
     - __kind: BaseType
       ID: 16
       Name: int8
       ByteSize: 1
-      GoRuntimeType: 574880
+      GoRuntimeType: 579968
       GoKind: 3
     - __kind: GoEmptyInterfaceType
-      ID: 58
+      ID: 81
       Name: interface {}
       ByteSize: 16
-      GoRuntimeType: 837760
+      GoRuntimeType: 843712
       GoKind: 20
       RawFields:
         - Name: _type
@@ -5928,10 +6796,10 @@ Types:
           Offset: 8
           Type: 15 VoidPointerType unsafe.Pointer
     - __kind: StructureType
-      ID: 269
+      ID: 394
       Name: internal/sync.Mutex
       ByteSize: 8
-      GoRuntimeType: 1.453952e+06
+      GoRuntimeType: 1.466816e+06
       GoKind: 25
       RawFields:
         - Name: state
@@ -5944,7 +6812,7 @@ Types:
       ID: 55
       Name: io.Writer
       ByteSize: 16
-      GoRuntimeType: 1.011776e+06
+      GoRuntimeType: 1.017728e+06
       GoKind: 20
       RawFields:
         - Name: tab
@@ -5954,7 +6822,7 @@ Types:
           Offset: 8
           Type: 15 VoidPointerType unsafe.Pointer
     - __kind: StructureType
-      ID: 148
+      ID: 171
       Name: main.aStruct
       ByteSize: 56
       GoKind: 25
@@ -5970,12 +6838,12 @@ Types:
           Type: 7 BaseType int
         - Name: nested
           Offset: 32
-          Type: 149 StructureType main.nestedStruct
+          Type: 172 StructureType main.nestedStruct
     - __kind: GoInterfaceType
-      ID: 64
+      ID: 87
       Name: main.behavior
       ByteSize: 16
-      GoRuntimeType: 1.011392e+06
+      GoRuntimeType: 1.017344e+06
       GoKind: 20
       RawFields:
         - Name: tab
@@ -6000,37 +6868,199 @@ Types:
           Offset: 32
           Type: 55 GoInterfaceType io.Writer
     - __kind: StructureType
-      ID: 150
+      ID: 67
+      Name: main.deepMap1
+      ByteSize: 8
+      GoRuntimeType: 1.181088e+06
+      GoKind: 25
+      RawFields:
+        - Name: a
+          Offset: 0
+          Type: 68 GoMapType map[int]*main.deepMap2
+    - __kind: StructureType
+      ID: 188
+      Name: main.deepMap2
+      ByteSize: 8
+      GoRuntimeType: 1.18096e+06
+      GoKind: 25
+      RawFields:
+        - Name: a
+          Offset: 0
+          Type: 314 GoMapType map[int]*main.deepMap3
+    - __kind: UnresolvedPointeeType
+      ID: 326
+      Name: main.deepMap3
+      ByteSize: 8
+    - __kind: StructureType
+      ID: 74
+      Name: main.deepMap7
+      ByteSize: 8
+      GoRuntimeType: 1.18032e+06
+      GoKind: 25
+      RawFields:
+        - Name: a
+          Offset: 0
+          Type: 349 GoMapType map[int]*main.deepMap8
+    - __kind: StructureType
+      ID: 361
+      Name: main.deepMap8
+      ByteSize: 8
+      GoRuntimeType: 1.180192e+06
+      GoKind: 25
+      RawFields:
+        - Name: a
+          Offset: 0
+          Type: 364 GoMapType map[int]*main.deepMap9
+    - __kind: StructureType
+      ID: 376
+      Name: main.deepMap9
+      ByteSize: 8
+      GoRuntimeType: 1.180064e+06
+      GoKind: 25
+      RawFields:
+        - Name: a
+          Offset: 0
+          Type: 379 GoMapType map[int]interface {}
+    - __kind: StructureType
+      ID: 56
+      Name: main.deepPtr1
+      ByteSize: 8
+      GoRuntimeType: 1.18224e+06
+      GoKind: 25
+      RawFields:
+        - Name: a
+          Offset: 0
+          Type: 57 PointerType *main.deepPtr2
+    - __kind: StructureType
+      ID: 58
+      Name: main.deepPtr2
+      ByteSize: 8
+      GoRuntimeType: 1.182112e+06
+      GoKind: 25
+      RawFields:
+        - Name: a
+          Offset: 0
+          Type: 303 PointerType *main.deepPtr3
+    - __kind: UnresolvedPointeeType
+      ID: 304
+      Name: main.deepPtr3
+      ByteSize: 8
+    - __kind: StructureType
+      ID: 60
+      Name: main.deepPtr7
+      ByteSize: 8
+      GoRuntimeType: 1.181472e+06
+      GoKind: 25
+      RawFields:
+        - Name: a
+          Offset: 0
+          Type: 329 PointerType *main.deepPtr8
+    - __kind: StructureType
+      ID: 330
+      Name: main.deepPtr8
+      ByteSize: 8
+      GoRuntimeType: 1.181344e+06
+      GoKind: 25
+      RawFields:
+        - Name: a
+          Offset: 0
+          Type: 331 PointerType *main.deepPtr9
+    - __kind: StructureType
+      ID: 332
+      Name: main.deepPtr9
+      ByteSize: 16
+      GoRuntimeType: 1.181216e+06
+      GoKind: 25
+      RawFields:
+        - Name: a
+          Offset: 0
+          Type: 81 GoEmptyInterfaceType interface {}
+    - __kind: StructureType
+      ID: 61
+      Name: main.deepSlice1
+      ByteSize: 24
+      GoRuntimeType: 1.183392e+06
+      GoKind: 25
+      RawFields:
+        - Name: a
+          Offset: 0
+          Type: 62 GoSliceHeaderType []*main.deepSlice2
+    - __kind: StructureType
+      ID: 178
+      Name: main.deepSlice2
+      ByteSize: 24
+      GoRuntimeType: 1.183264e+06
+      GoKind: 25
+      RawFields:
+        - Name: a
+          Offset: 0
+          Type: 308 GoSliceHeaderType []*main.deepSlice3
+    - __kind: UnresolvedPointeeType
+      ID: 311
+      Name: main.deepSlice3
+      ByteSize: 8
+    - __kind: StructureType
+      ID: 66
+      Name: main.deepSlice7
+      ByteSize: 24
+      GoRuntimeType: 1.182624e+06
+      GoKind: 25
+      RawFields:
+        - Name: a
+          Offset: 0
+          Type: 333 GoSliceHeaderType []*main.deepSlice8
+    - __kind: StructureType
+      ID: 336
+      Name: main.deepSlice8
+      ByteSize: 24
+      GoRuntimeType: 1.182496e+06
+      GoKind: 25
+      RawFields:
+        - Name: a
+          Offset: 0
+          Type: 339 GoSliceHeaderType []*main.deepSlice9
+    - __kind: StructureType
+      ID: 342
+      Name: main.deepSlice9
+      ByteSize: 24
+      GoRuntimeType: 1.182368e+06
+      GoKind: 25
+      RawFields:
+        - Name: a
+          Offset: 0
+          Type: 345 GoSliceHeaderType []interface {}
+    - __kind: StructureType
+      ID: 173
       Name: main.emptyStruct
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 62
+      ID: 85
       Name: main.esotericHeap
       ByteSize: 112
-      GoRuntimeType: 1.811168e+06
+      GoRuntimeType: 1.824032e+06
       GoKind: 25
       RawFields:
         - Name: esotericStack
           Offset: 0
-          Type: 56 StructureType main.esotericStack
+          Type: 79 StructureType main.esotericStack
         - Name: mu
           Offset: 64
-          Type: 267 StructureType sync.Mutex
+          Type: 392 StructureType sync.Mutex
         - Name: once
           Offset: 72
-          Type: 270 StructureType sync.Once
+          Type: 395 StructureType sync.Once
         - Name: wg
           Offset: 88
-          Type: 273 StructureType sync.WaitGroup
+          Type: 398 StructureType sync.WaitGroup
         - Name: a
           Offset: 104
-          Type: 276 StructureType sync/atomic.Int32
+          Type: 401 StructureType sync/atomic.Int32
     - __kind: StructureType
-      ID: 56
+      ID: 79
       Name: main.esotericStack
       ByteSize: 64
-      GoRuntimeType: 1.944768e+06
+      GoRuntimeType: 1.957632e+06
       GoKind: 25
       RawFields:
         - Name: _
@@ -6041,24 +7071,24 @@ Types:
           Type: 12 BaseType int32
         - Name: c
           Offset: 8
-          Type: 57 GoChannelType chan struct {}
+          Type: 80 GoChannelType chan struct {}
         - Name: val
           Offset: 16
-          Type: 58 GoEmptyInterfaceType interface {}
+          Type: 81 GoEmptyInterfaceType interface {}
         - Name: _
           Offset: 32
           Type: 8 BaseType uint64
         - Name: work
           Offset: 40
-          Type: 59 GoInterfaceType main.something
+          Type: 82 GoInterfaceType main.something
         - Name: foo
           Offset: 56
-          Type: 60 GoSubroutineType func()
+          Type: 83 GoSubroutineType func()
     - __kind: StructureType
-      ID: 149
+      ID: 172
       Name: main.nestedStruct
       ByteSize: 24
-      GoRuntimeType: 1.443392e+06
+      GoRuntimeType: 1.456256e+06
       GoKind: 25
       RawFields:
         - Name: anotherInt
@@ -6068,10 +7098,10 @@ Types:
           Offset: 8
           Type: 9 GoStringHeaderType string
     - __kind: StructureType
-      ID: 131
+      ID: 154
       Name: main.node
       ByteSize: 16
-      GoRuntimeType: 1.443232e+06
+      GoRuntimeType: 1.456096e+06
       GoKind: 25
       RawFields:
         - Name: val
@@ -6079,9 +7109,9 @@ Types:
           Type: 7 BaseType int
         - Name: b
           Offset: 8
-          Type: 132 PointerType *main.node
+          Type: 155 PointerType *main.node
     - __kind: StructureType
-      ID: 147
+      ID: 170
       Name: main.oneStringStruct
       ByteSize: 16
       GoKind: 25
@@ -6090,10 +7120,10 @@ Types:
           Offset: 0
           Type: 9 GoStringHeaderType string
     - __kind: GoInterfaceType
-      ID: 59
+      ID: 82
       Name: main.something
       ByteSize: 16
-      GoRuntimeType: 1.01152e+06
+      GoRuntimeType: 1.017472e+06
       GoKind: 20
       RawFields:
         - Name: tab
@@ -6102,18 +7132,39 @@ Types:
         - Name: data
           Offset: 8
           Type: 15 VoidPointerType unsafe.Pointer
+    - __kind: GoStringHeaderType
+      ID: 76
+      Name: main.stringType1
+      ByteSize: 16
+      GoKind: 24
+      RawFields:
+        - Name: str
+          Offset: 0
+          Type: 306 PointerType *main.stringType1.str
+        - Name: len
+          Offset: 8
+          Type: 7 BaseType int
+      Data: 305 GoStringDataType main.stringType1.str
+    - __kind: GoStringDataType
+      ID: 305
+      Name: main.stringType1.str
+      ByteSize: 2048
+    - __kind: UnresolvedPointeeType
+      ID: 307
+      Name: main.stringType2
+      ByteSize: 8
     - __kind: StructureType
-      ID: 65
+      ID: 88
       Name: main.structWithMap
       ByteSize: 8
-      GoRuntimeType: 1.172832e+06
+      GoRuntimeType: 1.179936e+06
       GoKind: 25
       RawFields:
         - Name: m
           Offset: 0
-          Type: 66 GoMapType map[int]int
+          Type: 89 GoMapType map[int]int
     - __kind: StructureType
-      ID: 140
+      ID: 163
       Name: main.structWithNoStrings
       ByteSize: 2
       GoKind: 25
@@ -6125,7 +7176,7 @@ Types:
           Offset: 1
           Type: 4 BaseType bool
     - __kind: StructureType
-      ID: 130
+      ID: 153
       Name: main.structWithTwoValues
       ByteSize: 16
       GoKind: 25
@@ -6137,28 +7188,28 @@ Types:
           Offset: 8
           Type: 4 BaseType bool
     - __kind: GoSliceHeaderType
-      ID: 134
+      ID: 157
       Name: main.t
       ByteSize: 24
       GoKind: 23
       RawFields:
         - Name: array
           Offset: 0
-          Type: 277 PointerType **main.t
+          Type: 402 PointerType **main.t
         - Name: len
           Offset: 8
           Type: 7 BaseType int
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 278 GoSliceDataType main.t.array
+      Data: 403 GoSliceDataType main.t.array
     - __kind: GoSliceDataType
-      ID: 278
+      ID: 403
       Name: main.t.array
       ByteSize: 2048
-      Element: 133 PointerType *main.t
+      Element: 156 PointerType *main.t
     - __kind: StructureType
-      ID: 144
+      ID: 167
       Name: main.threeStringStruct
       ByteSize: 48
       GoKind: 25
@@ -6178,7 +7229,7 @@ Types:
       ByteSize: 2
       GoKind: 9
     - __kind: GoSwissMapHeaderType
-      ID: 125
+      ID: 148
       Name: map<[4]int,[4]int>
       ByteSize: 48
       GoKind: 25
@@ -6191,7 +7242,7 @@ Types:
           Type: 1 BaseType uintptr
         - Name: dirPtr
           Offset: 16
-          Type: 126 PointerType **table<[4]int,[4]int>
+          Type: 149 PointerType **table<[4]int,[4]int>
         - Name: dirLen
           Offset: 24
           Type: 7 BaseType int
@@ -6207,10 +7258,10 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 8 BaseType uint64
-      TablePtrSliceType: 253 GoSliceDataType []*table<[4]int,[4]int>.array
-      GroupType: 250 StructureType noalg.map.group[[4]int][4]int
+      TablePtrSliceType: 289 GoSliceDataType []*table<[4]int,[4]int>.array
+      GroupType: 286 StructureType noalg.map.group[[4]int][4]int
     - __kind: GoSwissMapHeaderType
-      ID: 120
+      ID: 143
       Name: map<[4]int,uint8>
       ByteSize: 48
       GoKind: 25
@@ -6223,7 +7274,7 @@ Types:
           Type: 1 BaseType uintptr
         - Name: dirPtr
           Offset: 16
-          Type: 121 PointerType **table<[4]int,uint8>
+          Type: 144 PointerType **table<[4]int,uint8>
         - Name: dirLen
           Offset: 24
           Type: 7 BaseType int
@@ -6239,10 +7290,10 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 8 BaseType uint64
-      TablePtrSliceType: 245 GoSliceDataType []*table<[4]int,uint8>.array
-      GroupType: 242 StructureType noalg.map.group[[4]int]uint8
+      TablePtrSliceType: 281 GoSliceDataType []*table<[4]int,uint8>.array
+      GroupType: 278 StructureType noalg.map.group[[4]int]uint8
     - __kind: GoSwissMapHeaderType
-      ID: 88
+      ID: 111
       Name: map<[4]string,[2]int>
       ByteSize: 48
       GoKind: 25
@@ -6255,7 +7306,7 @@ Types:
           Type: 1 BaseType uintptr
         - Name: dirPtr
           Offset: 16
-          Type: 89 PointerType **table<[4]string,[2]int>
+          Type: 112 PointerType **table<[4]string,[2]int>
         - Name: dirLen
           Offset: 24
           Type: 7 BaseType int
@@ -6271,10 +7322,10 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 8 BaseType uint64
-      TablePtrSliceType: 194 GoSliceDataType []*table<[4]string,[2]int>.array
-      GroupType: 190 StructureType noalg.map.group[[4]string][2]int
+      TablePtrSliceType: 230 GoSliceDataType []*table<[4]string,[2]int>.array
+      GroupType: 226 StructureType noalg.map.group[[4]string][2]int
     - __kind: GoSwissMapHeaderType
-      ID: 100
+      ID: 123
       Name: map<bool,main.node>
       ByteSize: 48
       GoKind: 25
@@ -6287,7 +7338,7 @@ Types:
           Type: 1 BaseType uintptr
         - Name: dirPtr
           Offset: 16
-          Type: 101 PointerType **table<bool,main.node>
+          Type: 124 PointerType **table<bool,main.node>
         - Name: dirLen
           Offset: 24
           Type: 7 BaseType int
@@ -6303,10 +7354,138 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 8 BaseType uint64
-      TablePtrSliceType: 212 GoSliceDataType []*table<bool,main.node>.array
-      GroupType: 209 StructureType noalg.map.group[bool]main.node
+      TablePtrSliceType: 248 GoSliceDataType []*table<bool,main.node>.array
+      GroupType: 245 StructureType noalg.map.group[bool]main.node
     - __kind: GoSwissMapHeaderType
-      ID: 68
+      ID: 70
+      Name: map<int,*main.deepMap2>
+      ByteSize: 48
+      GoKind: 25
+      RawFields:
+        - Name: used
+          Offset: 0
+          Type: 8 BaseType uint64
+        - Name: seed
+          Offset: 8
+          Type: 1 BaseType uintptr
+        - Name: dirPtr
+          Offset: 16
+          Type: 71 PointerType **table<int,*main.deepMap2>
+        - Name: dirLen
+          Offset: 24
+          Type: 7 BaseType int
+        - Name: globalDepth
+          Offset: 32
+          Type: 3 BaseType uint8
+        - Name: globalShift
+          Offset: 33
+          Type: 3 BaseType uint8
+        - Name: writing
+          Offset: 34
+          Type: 3 BaseType uint8
+        - Name: clearSeq
+          Offset: 40
+          Type: 8 BaseType uint64
+      TablePtrSliceType: 189 GoSliceDataType []*table<int,*main.deepMap2>.array
+      GroupType: 184 StructureType noalg.map.group[int]*main.deepMap2
+    - __kind: GoSwissMapHeaderType
+      ID: 316
+      Name: map<int,*main.deepMap3>
+      ByteSize: 48
+      GoKind: 25
+      RawFields:
+        - Name: used
+          Offset: 0
+          Type: 8 BaseType uint64
+        - Name: seed
+          Offset: 8
+          Type: 1 BaseType uintptr
+        - Name: dirPtr
+          Offset: 16
+          Type: 317 PointerType **table<int,*main.deepMap3>
+        - Name: dirLen
+          Offset: 24
+          Type: 7 BaseType int
+        - Name: globalDepth
+          Offset: 32
+          Type: 3 BaseType uint8
+        - Name: globalShift
+          Offset: 33
+          Type: 3 BaseType uint8
+        - Name: writing
+          Offset: 34
+          Type: 3 BaseType uint8
+        - Name: clearSeq
+          Offset: 40
+          Type: 8 BaseType uint64
+      TablePtrSliceType: 327 GoSliceDataType []*table<int,*main.deepMap3>.array
+      GroupType: 322 StructureType noalg.map.group[int]*main.deepMap3
+    - __kind: GoSwissMapHeaderType
+      ID: 351
+      Name: map<int,*main.deepMap8>
+      ByteSize: 48
+      GoKind: 25
+      RawFields:
+        - Name: used
+          Offset: 0
+          Type: 8 BaseType uint64
+        - Name: seed
+          Offset: 8
+          Type: 1 BaseType uintptr
+        - Name: dirPtr
+          Offset: 16
+          Type: 352 PointerType **table<int,*main.deepMap8>
+        - Name: dirLen
+          Offset: 24
+          Type: 7 BaseType int
+        - Name: globalDepth
+          Offset: 32
+          Type: 3 BaseType uint8
+        - Name: globalShift
+          Offset: 33
+          Type: 3 BaseType uint8
+        - Name: writing
+          Offset: 34
+          Type: 3 BaseType uint8
+        - Name: clearSeq
+          Offset: 40
+          Type: 8 BaseType uint64
+      TablePtrSliceType: 362 GoSliceDataType []*table<int,*main.deepMap8>.array
+      GroupType: 357 StructureType noalg.map.group[int]*main.deepMap8
+    - __kind: GoSwissMapHeaderType
+      ID: 366
+      Name: map<int,*main.deepMap9>
+      ByteSize: 48
+      GoKind: 25
+      RawFields:
+        - Name: used
+          Offset: 0
+          Type: 8 BaseType uint64
+        - Name: seed
+          Offset: 8
+          Type: 1 BaseType uintptr
+        - Name: dirPtr
+          Offset: 16
+          Type: 367 PointerType **table<int,*main.deepMap9>
+        - Name: dirLen
+          Offset: 24
+          Type: 7 BaseType int
+        - Name: globalDepth
+          Offset: 32
+          Type: 3 BaseType uint8
+        - Name: globalShift
+          Offset: 33
+          Type: 3 BaseType uint8
+        - Name: writing
+          Offset: 34
+          Type: 3 BaseType uint8
+        - Name: clearSeq
+          Offset: 40
+          Type: 8 BaseType uint64
+      TablePtrSliceType: 377 GoSliceDataType []*table<int,*main.deepMap9>.array
+      GroupType: 372 StructureType noalg.map.group[int]*main.deepMap9
+    - __kind: GoSwissMapHeaderType
+      ID: 91
       Name: map<int,int>
       ByteSize: 48
       GoKind: 25
@@ -6319,7 +7498,7 @@ Types:
           Type: 1 BaseType uintptr
         - Name: dirPtr
           Offset: 16
-          Type: 69 PointerType **table<int,int>
+          Type: 92 PointerType **table<int,int>
         - Name: dirLen
           Offset: 24
           Type: 7 BaseType int
@@ -6335,10 +7514,42 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 8 BaseType uint64
-      TablePtrSliceType: 161 GoSliceDataType []*table<int,int>.array
-      GroupType: 158 StructureType noalg.map.group[int]int
+      TablePtrSliceType: 197 GoSliceDataType []*table<int,int>.array
+      GroupType: 194 StructureType noalg.map.group[int]int
     - __kind: GoSwissMapHeaderType
-      ID: 105
+      ID: 381
+      Name: map<int,interface {}>
+      ByteSize: 48
+      GoKind: 25
+      RawFields:
+        - Name: used
+          Offset: 0
+          Type: 8 BaseType uint64
+        - Name: seed
+          Offset: 8
+          Type: 1 BaseType uintptr
+        - Name: dirPtr
+          Offset: 16
+          Type: 382 PointerType **table<int,interface {}>
+        - Name: dirLen
+          Offset: 24
+          Type: 7 BaseType int
+        - Name: globalDepth
+          Offset: 32
+          Type: 3 BaseType uint8
+        - Name: globalShift
+          Offset: 33
+          Type: 3 BaseType uint8
+        - Name: writing
+          Offset: 34
+          Type: 3 BaseType uint8
+        - Name: clearSeq
+          Offset: 40
+          Type: 8 BaseType uint64
+      TablePtrSliceType: 390 GoSliceDataType []*table<int,interface {}>.array
+      GroupType: 387 StructureType noalg.map.group[int]interface {}
+    - __kind: GoSwissMapHeaderType
+      ID: 128
       Name: map<int,uint8>
       ByteSize: 48
       GoKind: 25
@@ -6351,7 +7562,7 @@ Types:
           Type: 1 BaseType uintptr
         - Name: dirPtr
           Offset: 16
-          Type: 106 PointerType **table<int,uint8>
+          Type: 129 PointerType **table<int,uint8>
         - Name: dirLen
           Offset: 24
           Type: 7 BaseType int
@@ -6367,10 +7578,10 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 8 BaseType uint64
-      TablePtrSliceType: 220 GoSliceDataType []*table<int,uint8>.array
-      GroupType: 217 StructureType noalg.map.group[int]uint8
+      TablePtrSliceType: 256 GoSliceDataType []*table<int,uint8>.array
+      GroupType: 253 StructureType noalg.map.group[int]uint8
     - __kind: GoSwissMapHeaderType
-      ID: 95
+      ID: 118
       Name: map<string,[]main.structWithMap>
       ByteSize: 48
       GoKind: 25
@@ -6383,7 +7594,7 @@ Types:
           Type: 1 BaseType uintptr
         - Name: dirPtr
           Offset: 16
-          Type: 96 PointerType **table<string,[]main.structWithMap>
+          Type: 119 PointerType **table<string,[]main.structWithMap>
         - Name: dirLen
           Offset: 24
           Type: 7 BaseType int
@@ -6399,10 +7610,10 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 8 BaseType uint64
-      TablePtrSliceType: 204 GoSliceDataType []*table<string,[]main.structWithMap>.array
-      GroupType: 199 StructureType noalg.map.group[string][]main.structWithMap
+      TablePtrSliceType: 240 GoSliceDataType []*table<string,[]main.structWithMap>.array
+      GroupType: 235 StructureType noalg.map.group[string][]main.structWithMap
     - __kind: GoSwissMapHeaderType
-      ID: 83
+      ID: 106
       Name: map<string,[]string>
       ByteSize: 48
       GoKind: 25
@@ -6415,7 +7626,7 @@ Types:
           Type: 1 BaseType uintptr
         - Name: dirPtr
           Offset: 16
-          Type: 84 PointerType **table<string,[]string>
+          Type: 107 PointerType **table<string,[]string>
         - Name: dirLen
           Offset: 24
           Type: 7 BaseType int
@@ -6431,10 +7642,10 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 8 BaseType uint64
-      TablePtrSliceType: 185 GoSliceDataType []*table<string,[]string>.array
-      GroupType: 182 StructureType noalg.map.group[string][]string
+      TablePtrSliceType: 221 GoSliceDataType []*table<string,[]string>.array
+      GroupType: 218 StructureType noalg.map.group[string][]string
     - __kind: GoSwissMapHeaderType
-      ID: 78
+      ID: 101
       Name: map<string,int>
       ByteSize: 48
       GoKind: 25
@@ -6447,7 +7658,7 @@ Types:
           Type: 1 BaseType uintptr
         - Name: dirPtr
           Offset: 16
-          Type: 79 PointerType **table<string,int>
+          Type: 102 PointerType **table<string,int>
         - Name: dirLen
           Offset: 24
           Type: 7 BaseType int
@@ -6463,10 +7674,10 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 8 BaseType uint64
-      TablePtrSliceType: 177 GoSliceDataType []*table<string,int>.array
-      GroupType: 174 StructureType noalg.map.group[string]int
+      TablePtrSliceType: 213 GoSliceDataType []*table<string,int>.array
+      GroupType: 210 StructureType noalg.map.group[string]int
     - __kind: GoSwissMapHeaderType
-      ID: 73
+      ID: 96
       Name: map<string,main.nestedStruct>
       ByteSize: 48
       GoKind: 25
@@ -6479,7 +7690,7 @@ Types:
           Type: 1 BaseType uintptr
         - Name: dirPtr
           Offset: 16
-          Type: 74 PointerType **table<string,main.nestedStruct>
+          Type: 97 PointerType **table<string,main.nestedStruct>
         - Name: dirLen
           Offset: 24
           Type: 7 BaseType int
@@ -6495,10 +7706,10 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 8 BaseType uint64
-      TablePtrSliceType: 169 GoSliceDataType []*table<string,main.nestedStruct>.array
-      GroupType: 166 StructureType noalg.map.group[string]main.nestedStruct
+      TablePtrSliceType: 205 GoSliceDataType []*table<string,main.nestedStruct>.array
+      GroupType: 202 StructureType noalg.map.group[string]main.nestedStruct
     - __kind: GoSwissMapHeaderType
-      ID: 115
+      ID: 138
       Name: map<uint8,[4]int>
       ByteSize: 48
       GoKind: 25
@@ -6511,7 +7722,7 @@ Types:
           Type: 1 BaseType uintptr
         - Name: dirPtr
           Offset: 16
-          Type: 116 PointerType **table<uint8,[4]int>
+          Type: 139 PointerType **table<uint8,[4]int>
         - Name: dirLen
           Offset: 24
           Type: 7 BaseType int
@@ -6527,10 +7738,10 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 8 BaseType uint64
-      TablePtrSliceType: 237 GoSliceDataType []*table<uint8,[4]int>.array
-      GroupType: 233 StructureType noalg.map.group[uint8][4]int
+      TablePtrSliceType: 273 GoSliceDataType []*table<uint8,[4]int>.array
+      GroupType: 269 StructureType noalg.map.group[uint8][4]int
     - __kind: GoSwissMapHeaderType
-      ID: 110
+      ID: 133
       Name: map<uint8,uint8>
       ByteSize: 48
       GoKind: 25
@@ -6543,7 +7754,7 @@ Types:
           Type: 1 BaseType uintptr
         - Name: dirPtr
           Offset: 16
-          Type: 111 PointerType **table<uint8,uint8>
+          Type: 134 PointerType **table<uint8,uint8>
         - Name: dirLen
           Offset: 24
           Type: 7 BaseType int
@@ -6559,205 +7770,285 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 8 BaseType uint64
-      TablePtrSliceType: 228 GoSliceDataType []*table<uint8,uint8>.array
-      GroupType: 225 StructureType noalg.map.group[uint8]uint8
+      TablePtrSliceType: 264 GoSliceDataType []*table<uint8,uint8>.array
+      GroupType: 261 StructureType noalg.map.group[uint8]uint8
     - __kind: GoMapType
-      ID: 123
+      ID: 146
       Name: map[[4]int][4]int
       ByteSize: 8
-      GoRuntimeType: 1.116896e+06
+      GoRuntimeType: 1.124e+06
       GoKind: 21
-      HeaderType: 125 GoSwissMapHeaderType map<[4]int,[4]int>
+      HeaderType: 148 GoSwissMapHeaderType map<[4]int,[4]int>
     - __kind: GoMapType
-      ID: 118
+      ID: 141
       Name: map[[4]int]uint8
       ByteSize: 8
-      GoRuntimeType: 1.117024e+06
+      GoRuntimeType: 1.124128e+06
       GoKind: 21
-      HeaderType: 120 GoSwissMapHeaderType map<[4]int,uint8>
+      HeaderType: 143 GoSwissMapHeaderType map<[4]int,uint8>
     - __kind: GoMapType
-      ID: 86
+      ID: 109
       Name: map[[4]string][2]int
       ByteSize: 8
-      GoRuntimeType: 1.117152e+06
+      GoRuntimeType: 1.124256e+06
       GoKind: 21
-      HeaderType: 88 GoSwissMapHeaderType map<[4]string,[2]int>
+      HeaderType: 111 GoSwissMapHeaderType map<[4]string,[2]int>
     - __kind: GoMapType
-      ID: 98
+      ID: 121
       Name: map[bool]main.node
       ByteSize: 8
-      GoRuntimeType: 1.11728e+06
+      GoRuntimeType: 1.124384e+06
       GoKind: 21
-      HeaderType: 100 GoSwissMapHeaderType map<bool,main.node>
+      HeaderType: 123 GoSwissMapHeaderType map<bool,main.node>
     - __kind: GoMapType
-      ID: 66
+      ID: 68
+      Name: map[int]*main.deepMap2
+      ByteSize: 8
+      GoRuntimeType: 1.123872e+06
+      GoKind: 21
+      HeaderType: 70 GoSwissMapHeaderType map<int,*main.deepMap2>
+    - __kind: GoMapType
+      ID: 314
+      Name: map[int]*main.deepMap3
+      ByteSize: 8
+      GoRuntimeType: 1.123744e+06
+      GoKind: 21
+      HeaderType: 316 GoSwissMapHeaderType map<int,*main.deepMap3>
+    - __kind: GoMapType
+      ID: 349
+      Name: map[int]*main.deepMap8
+      ByteSize: 8
+      GoRuntimeType: 1.123104e+06
+      GoKind: 21
+      HeaderType: 351 GoSwissMapHeaderType map<int,*main.deepMap8>
+    - __kind: GoMapType
+      ID: 364
+      Name: map[int]*main.deepMap9
+      ByteSize: 8
+      GoRuntimeType: 1.122976e+06
+      GoKind: 21
+      HeaderType: 366 GoSwissMapHeaderType map<int,*main.deepMap9>
+    - __kind: GoMapType
+      ID: 89
       Name: map[int]int
       ByteSize: 8
-      GoRuntimeType: 1.116512e+06
+      GoRuntimeType: 1.122464e+06
       GoKind: 21
-      HeaderType: 68 GoSwissMapHeaderType map<int,int>
+      HeaderType: 91 GoSwissMapHeaderType map<int,int>
     - __kind: GoMapType
-      ID: 103
+      ID: 379
+      Name: map[int]interface {}
+      ByteSize: 8
+      GoRuntimeType: 1.122848e+06
+      GoKind: 21
+      HeaderType: 381 GoSwissMapHeaderType map<int,interface {}>
+    - __kind: GoMapType
+      ID: 126
       Name: map[int]uint8
       ByteSize: 8
-      GoRuntimeType: 1.117408e+06
+      GoRuntimeType: 1.124512e+06
       GoKind: 21
-      HeaderType: 105 GoSwissMapHeaderType map<int,uint8>
+      HeaderType: 128 GoSwissMapHeaderType map<int,uint8>
     - __kind: GoMapType
-      ID: 93
+      ID: 116
       Name: map[string][]main.structWithMap
       ByteSize: 8
-      GoRuntimeType: 1.117536e+06
+      GoRuntimeType: 1.12464e+06
       GoKind: 21
-      HeaderType: 95 GoSwissMapHeaderType map<string,[]main.structWithMap>
+      HeaderType: 118 GoSwissMapHeaderType map<string,[]main.structWithMap>
     - __kind: GoMapType
-      ID: 81
+      ID: 104
       Name: map[string][]string
       ByteSize: 8
-      GoRuntimeType: 1.117664e+06
+      GoRuntimeType: 1.124768e+06
       GoKind: 21
-      HeaderType: 83 GoSwissMapHeaderType map<string,[]string>
+      HeaderType: 106 GoSwissMapHeaderType map<string,[]string>
     - __kind: GoMapType
-      ID: 76
+      ID: 99
       Name: map[string]int
       ByteSize: 8
-      GoRuntimeType: 1.117792e+06
+      GoRuntimeType: 1.124896e+06
       GoKind: 21
-      HeaderType: 78 GoSwissMapHeaderType map<string,int>
+      HeaderType: 101 GoSwissMapHeaderType map<string,int>
     - __kind: GoMapType
-      ID: 71
+      ID: 94
       Name: map[string]main.nestedStruct
       ByteSize: 8
-      GoRuntimeType: 1.11792e+06
+      GoRuntimeType: 1.125024e+06
       GoKind: 21
-      HeaderType: 73 GoSwissMapHeaderType map<string,main.nestedStruct>
+      HeaderType: 96 GoSwissMapHeaderType map<string,main.nestedStruct>
     - __kind: GoMapType
-      ID: 113
+      ID: 136
       Name: map[uint8][4]int
       ByteSize: 8
-      GoRuntimeType: 1.118048e+06
+      GoRuntimeType: 1.125152e+06
       GoKind: 21
-      HeaderType: 115 GoSwissMapHeaderType map<uint8,[4]int>
+      HeaderType: 138 GoSwissMapHeaderType map<uint8,[4]int>
     - __kind: GoMapType
-      ID: 108
+      ID: 131
       Name: map[uint8]uint8
       ByteSize: 8
-      GoRuntimeType: 1.118176e+06
+      GoRuntimeType: 1.12528e+06
       GoKind: 21
-      HeaderType: 110 GoSwissMapHeaderType map<uint8,uint8>
+      HeaderType: 133 GoSwissMapHeaderType map<uint8,uint8>
     - __kind: ArrayType
-      ID: 251
+      ID: 287
       Name: noalg.[8]struct { key [4]int; elem [4]int }
       ByteSize: 512
-      GoRuntimeType: 672800
+      GoRuntimeType: 678752
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 252 StructureType noalg.struct { key [4]int; elem [4]int }
+      Element: 288 StructureType noalg.struct { key [4]int; elem [4]int }
     - __kind: ArrayType
-      ID: 243
+      ID: 279
       Name: noalg.[8]struct { key [4]int; elem uint8 }
       ByteSize: 320
-      GoRuntimeType: 672896
+      GoRuntimeType: 678848
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 244 StructureType noalg.struct { key [4]int; elem uint8 }
+      Element: 280 StructureType noalg.struct { key [4]int; elem uint8 }
     - __kind: ArrayType
-      ID: 191
+      ID: 227
       Name: noalg.[8]struct { key [4]string; elem [2]int }
       ByteSize: 640
-      GoRuntimeType: 673184
+      GoRuntimeType: 679136
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 192 StructureType noalg.struct { key [4]string; elem [2]int }
+      Element: 228 StructureType noalg.struct { key [4]string; elem [2]int }
     - __kind: ArrayType
-      ID: 210
+      ID: 246
       Name: noalg.[8]struct { key bool; elem main.node }
       ByteSize: 192
-      GoRuntimeType: 673280
+      GoRuntimeType: 679232
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 211 StructureType noalg.struct { key bool; elem main.node }
+      Element: 247 StructureType noalg.struct { key bool; elem main.node }
     - __kind: ArrayType
-      ID: 159
+      ID: 185
+      Name: noalg.[8]struct { key int; elem *main.deepMap2 }
+      ByteSize: 128
+      GoRuntimeType: 678080
+      GoKind: 17
+      Count: 8
+      HasCount: true
+      Element: 186 StructureType noalg.struct { key int; elem *main.deepMap2 }
+    - __kind: ArrayType
+      ID: 323
+      Name: noalg.[8]struct { key int; elem *main.deepMap3 }
+      ByteSize: 128
+      GoRuntimeType: 677984
+      GoKind: 17
+      Count: 8
+      HasCount: true
+      Element: 324 StructureType noalg.struct { key int; elem *main.deepMap3 }
+    - __kind: ArrayType
+      ID: 358
+      Name: noalg.[8]struct { key int; elem *main.deepMap8 }
+      ByteSize: 128
+      GoRuntimeType: 677504
+      GoKind: 17
+      Count: 8
+      HasCount: true
+      Element: 359 StructureType noalg.struct { key int; elem *main.deepMap8 }
+    - __kind: ArrayType
+      ID: 373
+      Name: noalg.[8]struct { key int; elem *main.deepMap9 }
+      ByteSize: 128
+      GoRuntimeType: 677408
+      GoKind: 17
+      Count: 8
+      HasCount: true
+      Element: 374 StructureType noalg.struct { key int; elem *main.deepMap9 }
+    - __kind: ArrayType
+      ID: 195
       Name: noalg.[8]struct { key int; elem int }
       ByteSize: 128
-      GoRuntimeType: 671072
+      GoRuntimeType: 676160
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 160 StructureType noalg.struct { key int; elem int }
+      Element: 196 StructureType noalg.struct { key int; elem int }
     - __kind: ArrayType
-      ID: 218
+      ID: 388
+      Name: noalg.[8]struct { key int; elem interface {} }
+      ByteSize: 192
+      GoRuntimeType: 677312
+      GoKind: 17
+      Count: 8
+      HasCount: true
+      Element: 389 StructureType noalg.struct { key int; elem interface {} }
+    - __kind: ArrayType
+      ID: 254
       Name: noalg.[8]struct { key int; elem uint8 }
       ByteSize: 128
-      GoRuntimeType: 673376
+      GoRuntimeType: 679328
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 219 StructureType noalg.struct { key int; elem uint8 }
+      Element: 255 StructureType noalg.struct { key int; elem uint8 }
     - __kind: ArrayType
-      ID: 200
+      ID: 236
       Name: noalg.[8]struct { key string; elem []main.structWithMap }
       ByteSize: 320
-      GoRuntimeType: 673472
+      GoRuntimeType: 679424
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 201 StructureType noalg.struct { key string; elem []main.structWithMap }
+      Element: 237 StructureType noalg.struct { key string; elem []main.structWithMap }
     - __kind: ArrayType
-      ID: 183
+      ID: 219
       Name: noalg.[8]struct { key string; elem []string }
       ByteSize: 320
-      GoRuntimeType: 673568
+      GoRuntimeType: 679520
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 184 StructureType noalg.struct { key string; elem []string }
+      Element: 220 StructureType noalg.struct { key string; elem []string }
     - __kind: ArrayType
-      ID: 175
+      ID: 211
       Name: noalg.[8]struct { key string; elem int }
       ByteSize: 192
-      GoRuntimeType: 673664
+      GoRuntimeType: 679616
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 176 StructureType noalg.struct { key string; elem int }
+      Element: 212 StructureType noalg.struct { key string; elem int }
     - __kind: ArrayType
-      ID: 167
+      ID: 203
       Name: noalg.[8]struct { key string; elem main.nestedStruct }
       ByteSize: 320
-      GoRuntimeType: 673760
+      GoRuntimeType: 679712
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 168 StructureType noalg.struct { key string; elem main.nestedStruct }
+      Element: 204 StructureType noalg.struct { key string; elem main.nestedStruct }
     - __kind: ArrayType
-      ID: 234
+      ID: 270
       Name: noalg.[8]struct { key uint8; elem [4]int }
       ByteSize: 320
-      GoRuntimeType: 673856
+      GoRuntimeType: 679808
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 235 StructureType noalg.struct { key uint8; elem [4]int }
+      Element: 271 StructureType noalg.struct { key uint8; elem [4]int }
     - __kind: ArrayType
-      ID: 226
+      ID: 262
       Name: noalg.[8]struct { key uint8; elem uint8 }
       ByteSize: 16
-      GoRuntimeType: 673952
+      GoRuntimeType: 679904
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 227 StructureType noalg.struct { key uint8; elem uint8 }
+      Element: 263 StructureType noalg.struct { key uint8; elem uint8 }
     - __kind: StructureType
-      ID: 250
+      ID: 286
       Name: noalg.map.group[[4]int][4]int
       ByteSize: 520
-      GoRuntimeType: 1.276576e+06
+      GoRuntimeType: 1.28944e+06
       GoKind: 25
       RawFields:
         - Name: ctrl
@@ -6765,12 +8056,12 @@ Types:
           Type: 8 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 251 ArrayType noalg.[8]struct { key [4]int; elem [4]int }
+          Type: 287 ArrayType noalg.[8]struct { key [4]int; elem [4]int }
     - __kind: StructureType
-      ID: 242
+      ID: 278
       Name: noalg.map.group[[4]int]uint8
       ByteSize: 328
-      GoRuntimeType: 1.276832e+06
+      GoRuntimeType: 1.289696e+06
       GoKind: 25
       RawFields:
         - Name: ctrl
@@ -6778,12 +8069,12 @@ Types:
           Type: 8 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 243 ArrayType noalg.[8]struct { key [4]int; elem uint8 }
+          Type: 279 ArrayType noalg.[8]struct { key [4]int; elem uint8 }
     - __kind: StructureType
-      ID: 190
+      ID: 226
       Name: noalg.map.group[[4]string][2]int
       ByteSize: 648
-      GoRuntimeType: 1.277088e+06
+      GoRuntimeType: 1.289952e+06
       GoKind: 25
       RawFields:
         - Name: ctrl
@@ -6791,12 +8082,12 @@ Types:
           Type: 8 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 191 ArrayType noalg.[8]struct { key [4]string; elem [2]int }
+          Type: 227 ArrayType noalg.[8]struct { key [4]string; elem [2]int }
     - __kind: StructureType
-      ID: 209
+      ID: 245
       Name: noalg.map.group[bool]main.node
       ByteSize: 200
-      GoRuntimeType: 1.277344e+06
+      GoRuntimeType: 1.290208e+06
       GoKind: 25
       RawFields:
         - Name: ctrl
@@ -6804,12 +8095,64 @@ Types:
           Type: 8 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 210 ArrayType noalg.[8]struct { key bool; elem main.node }
+          Type: 246 ArrayType noalg.[8]struct { key bool; elem main.node }
     - __kind: StructureType
-      ID: 158
+      ID: 184
+      Name: noalg.map.group[int]*main.deepMap2
+      ByteSize: 136
+      GoRuntimeType: 1.289184e+06
+      GoKind: 25
+      RawFields:
+        - Name: ctrl
+          Offset: 0
+          Type: 8 BaseType uint64
+        - Name: slots
+          Offset: 8
+          Type: 185 ArrayType noalg.[8]struct { key int; elem *main.deepMap2 }
+    - __kind: StructureType
+      ID: 322
+      Name: noalg.map.group[int]*main.deepMap3
+      ByteSize: 136
+      GoRuntimeType: 1.288928e+06
+      GoKind: 25
+      RawFields:
+        - Name: ctrl
+          Offset: 0
+          Type: 8 BaseType uint64
+        - Name: slots
+          Offset: 8
+          Type: 323 ArrayType noalg.[8]struct { key int; elem *main.deepMap3 }
+    - __kind: StructureType
+      ID: 357
+      Name: noalg.map.group[int]*main.deepMap8
+      ByteSize: 136
+      GoRuntimeType: 1.287648e+06
+      GoKind: 25
+      RawFields:
+        - Name: ctrl
+          Offset: 0
+          Type: 8 BaseType uint64
+        - Name: slots
+          Offset: 8
+          Type: 358 ArrayType noalg.[8]struct { key int; elem *main.deepMap8 }
+    - __kind: StructureType
+      ID: 372
+      Name: noalg.map.group[int]*main.deepMap9
+      ByteSize: 136
+      GoRuntimeType: 1.287392e+06
+      GoKind: 25
+      RawFields:
+        - Name: ctrl
+          Offset: 0
+          Type: 8 BaseType uint64
+        - Name: slots
+          Offset: 8
+          Type: 373 ArrayType noalg.[8]struct { key int; elem *main.deepMap9 }
+    - __kind: StructureType
+      ID: 194
       Name: noalg.map.group[int]int
       ByteSize: 136
-      GoRuntimeType: 1.275808e+06
+      GoRuntimeType: 1.286368e+06
       GoKind: 25
       RawFields:
         - Name: ctrl
@@ -6817,12 +8160,25 @@ Types:
           Type: 8 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 159 ArrayType noalg.[8]struct { key int; elem int }
+          Type: 195 ArrayType noalg.[8]struct { key int; elem int }
     - __kind: StructureType
-      ID: 217
+      ID: 387
+      Name: noalg.map.group[int]interface {}
+      ByteSize: 200
+      GoRuntimeType: 1.287136e+06
+      GoKind: 25
+      RawFields:
+        - Name: ctrl
+          Offset: 0
+          Type: 8 BaseType uint64
+        - Name: slots
+          Offset: 8
+          Type: 388 ArrayType noalg.[8]struct { key int; elem interface {} }
+    - __kind: StructureType
+      ID: 253
       Name: noalg.map.group[int]uint8
       ByteSize: 136
-      GoRuntimeType: 1.2776e+06
+      GoRuntimeType: 1.290464e+06
       GoKind: 25
       RawFields:
         - Name: ctrl
@@ -6830,12 +8186,12 @@ Types:
           Type: 8 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 218 ArrayType noalg.[8]struct { key int; elem uint8 }
+          Type: 254 ArrayType noalg.[8]struct { key int; elem uint8 }
     - __kind: StructureType
-      ID: 199
+      ID: 235
       Name: noalg.map.group[string][]main.structWithMap
       ByteSize: 328
-      GoRuntimeType: 1.277856e+06
+      GoRuntimeType: 1.29072e+06
       GoKind: 25
       RawFields:
         - Name: ctrl
@@ -6843,12 +8199,12 @@ Types:
           Type: 8 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 200 ArrayType noalg.[8]struct { key string; elem []main.structWithMap }
+          Type: 236 ArrayType noalg.[8]struct { key string; elem []main.structWithMap }
     - __kind: StructureType
-      ID: 182
+      ID: 218
       Name: noalg.map.group[string][]string
       ByteSize: 328
-      GoRuntimeType: 1.278112e+06
+      GoRuntimeType: 1.290976e+06
       GoKind: 25
       RawFields:
         - Name: ctrl
@@ -6856,12 +8212,12 @@ Types:
           Type: 8 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 183 ArrayType noalg.[8]struct { key string; elem []string }
+          Type: 219 ArrayType noalg.[8]struct { key string; elem []string }
     - __kind: StructureType
-      ID: 174
+      ID: 210
       Name: noalg.map.group[string]int
       ByteSize: 200
-      GoRuntimeType: 1.278368e+06
+      GoRuntimeType: 1.291232e+06
       GoKind: 25
       RawFields:
         - Name: ctrl
@@ -6869,12 +8225,12 @@ Types:
           Type: 8 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 175 ArrayType noalg.[8]struct { key string; elem int }
+          Type: 211 ArrayType noalg.[8]struct { key string; elem int }
     - __kind: StructureType
-      ID: 166
+      ID: 202
       Name: noalg.map.group[string]main.nestedStruct
       ByteSize: 328
-      GoRuntimeType: 1.278624e+06
+      GoRuntimeType: 1.291488e+06
       GoKind: 25
       RawFields:
         - Name: ctrl
@@ -6882,12 +8238,12 @@ Types:
           Type: 8 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 167 ArrayType noalg.[8]struct { key string; elem main.nestedStruct }
+          Type: 203 ArrayType noalg.[8]struct { key string; elem main.nestedStruct }
     - __kind: StructureType
-      ID: 233
+      ID: 269
       Name: noalg.map.group[uint8][4]int
       ByteSize: 328
-      GoRuntimeType: 1.27888e+06
+      GoRuntimeType: 1.291744e+06
       GoKind: 25
       RawFields:
         - Name: ctrl
@@ -6895,12 +8251,12 @@ Types:
           Type: 8 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 234 ArrayType noalg.[8]struct { key uint8; elem [4]int }
+          Type: 270 ArrayType noalg.[8]struct { key uint8; elem [4]int }
     - __kind: StructureType
-      ID: 225
+      ID: 261
       Name: noalg.map.group[uint8]uint8
       ByteSize: 24
-      GoRuntimeType: 1.279136e+06
+      GoRuntimeType: 1.292e+06
       GoKind: 25
       RawFields:
         - Name: ctrl
@@ -6908,51 +8264,51 @@ Types:
           Type: 8 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 226 ArrayType noalg.[8]struct { key uint8; elem uint8 }
+          Type: 262 ArrayType noalg.[8]struct { key uint8; elem uint8 }
     - __kind: StructureType
-      ID: 252
+      ID: 288
       Name: noalg.struct { key [4]int; elem [4]int }
       ByteSize: 64
-      GoRuntimeType: 1.276448e+06
+      GoRuntimeType: 1.289312e+06
       GoKind: 25
       RawFields:
         - Name: key
           Offset: 0
-          Type: 236 ArrayType [4]int
+          Type: 272 ArrayType [4]int
         - Name: elem
           Offset: 32
-          Type: 236 ArrayType [4]int
+          Type: 272 ArrayType [4]int
     - __kind: StructureType
-      ID: 244
+      ID: 280
       Name: noalg.struct { key [4]int; elem uint8 }
       ByteSize: 40
-      GoRuntimeType: 1.276704e+06
+      GoRuntimeType: 1.289568e+06
       GoKind: 25
       RawFields:
         - Name: key
           Offset: 0
-          Type: 236 ArrayType [4]int
+          Type: 272 ArrayType [4]int
         - Name: elem
           Offset: 32
           Type: 3 BaseType uint8
     - __kind: StructureType
-      ID: 192
+      ID: 228
       Name: noalg.struct { key [4]string; elem [2]int }
       ByteSize: 80
-      GoRuntimeType: 1.27696e+06
+      GoRuntimeType: 1.289824e+06
       GoKind: 25
       RawFields:
         - Name: key
           Offset: 0
-          Type: 193 ArrayType [4]string
+          Type: 229 ArrayType [4]string
         - Name: elem
           Offset: 64
           Type: 40 ArrayType [2]int
     - __kind: StructureType
-      ID: 211
+      ID: 247
       Name: noalg.struct { key bool; elem main.node }
       ByteSize: 24
-      GoRuntimeType: 1.277216e+06
+      GoRuntimeType: 1.29008e+06
       GoKind: 25
       RawFields:
         - Name: key
@@ -6960,12 +8316,64 @@ Types:
           Type: 4 BaseType bool
         - Name: elem
           Offset: 8
-          Type: 131 StructureType main.node
+          Type: 154 StructureType main.node
     - __kind: StructureType
-      ID: 160
+      ID: 186
+      Name: noalg.struct { key int; elem *main.deepMap2 }
+      ByteSize: 16
+      GoRuntimeType: 1.289056e+06
+      GoKind: 25
+      RawFields:
+        - Name: key
+          Offset: 0
+          Type: 7 BaseType int
+        - Name: elem
+          Offset: 8
+          Type: 187 PointerType *main.deepMap2
+    - __kind: StructureType
+      ID: 324
+      Name: noalg.struct { key int; elem *main.deepMap3 }
+      ByteSize: 16
+      GoRuntimeType: 1.2888e+06
+      GoKind: 25
+      RawFields:
+        - Name: key
+          Offset: 0
+          Type: 7 BaseType int
+        - Name: elem
+          Offset: 8
+          Type: 325 PointerType *main.deepMap3
+    - __kind: StructureType
+      ID: 359
+      Name: noalg.struct { key int; elem *main.deepMap8 }
+      ByteSize: 16
+      GoRuntimeType: 1.28752e+06
+      GoKind: 25
+      RawFields:
+        - Name: key
+          Offset: 0
+          Type: 7 BaseType int
+        - Name: elem
+          Offset: 8
+          Type: 360 PointerType *main.deepMap8
+    - __kind: StructureType
+      ID: 374
+      Name: noalg.struct { key int; elem *main.deepMap9 }
+      ByteSize: 16
+      GoRuntimeType: 1.287264e+06
+      GoKind: 25
+      RawFields:
+        - Name: key
+          Offset: 0
+          Type: 7 BaseType int
+        - Name: elem
+          Offset: 8
+          Type: 375 PointerType *main.deepMap9
+    - __kind: StructureType
+      ID: 196
       Name: noalg.struct { key int; elem int }
       ByteSize: 16
-      GoRuntimeType: 1.27568e+06
+      GoRuntimeType: 1.28624e+06
       GoKind: 25
       RawFields:
         - Name: key
@@ -6975,10 +8383,23 @@ Types:
           Offset: 8
           Type: 7 BaseType int
     - __kind: StructureType
-      ID: 219
+      ID: 389
+      Name: noalg.struct { key int; elem interface {} }
+      ByteSize: 24
+      GoRuntimeType: 1.287008e+06
+      GoKind: 25
+      RawFields:
+        - Name: key
+          Offset: 0
+          Type: 7 BaseType int
+        - Name: elem
+          Offset: 8
+          Type: 81 GoEmptyInterfaceType interface {}
+    - __kind: StructureType
+      ID: 255
       Name: noalg.struct { key int; elem uint8 }
       ByteSize: 16
-      GoRuntimeType: 1.277472e+06
+      GoRuntimeType: 1.290336e+06
       GoKind: 25
       RawFields:
         - Name: key
@@ -6988,10 +8409,10 @@ Types:
           Offset: 8
           Type: 3 BaseType uint8
     - __kind: StructureType
-      ID: 201
+      ID: 237
       Name: noalg.struct { key string; elem []main.structWithMap }
       ByteSize: 40
-      GoRuntimeType: 1.277728e+06
+      GoRuntimeType: 1.290592e+06
       GoKind: 25
       RawFields:
         - Name: key
@@ -6999,12 +8420,12 @@ Types:
           Type: 9 GoStringHeaderType string
         - Name: elem
           Offset: 16
-          Type: 202 GoSliceHeaderType []main.structWithMap
+          Type: 238 GoSliceHeaderType []main.structWithMap
     - __kind: StructureType
-      ID: 184
+      ID: 220
       Name: noalg.struct { key string; elem []string }
       ByteSize: 40
-      GoRuntimeType: 1.277984e+06
+      GoRuntimeType: 1.290848e+06
       GoKind: 25
       RawFields:
         - Name: key
@@ -7012,12 +8433,12 @@ Types:
           Type: 9 GoStringHeaderType string
         - Name: elem
           Offset: 16
-          Type: 141 GoSliceHeaderType []string
+          Type: 164 GoSliceHeaderType []string
     - __kind: StructureType
-      ID: 176
+      ID: 212
       Name: noalg.struct { key string; elem int }
       ByteSize: 24
-      GoRuntimeType: 1.27824e+06
+      GoRuntimeType: 1.291104e+06
       GoKind: 25
       RawFields:
         - Name: key
@@ -7027,10 +8448,10 @@ Types:
           Offset: 16
           Type: 7 BaseType int
     - __kind: StructureType
-      ID: 168
+      ID: 204
       Name: noalg.struct { key string; elem main.nestedStruct }
       ByteSize: 40
-      GoRuntimeType: 1.278496e+06
+      GoRuntimeType: 1.29136e+06
       GoKind: 25
       RawFields:
         - Name: key
@@ -7038,12 +8459,12 @@ Types:
           Type: 9 GoStringHeaderType string
         - Name: elem
           Offset: 16
-          Type: 149 StructureType main.nestedStruct
+          Type: 172 StructureType main.nestedStruct
     - __kind: StructureType
-      ID: 235
+      ID: 271
       Name: noalg.struct { key uint8; elem [4]int }
       ByteSize: 40
-      GoRuntimeType: 1.278752e+06
+      GoRuntimeType: 1.291616e+06
       GoKind: 25
       RawFields:
         - Name: key
@@ -7051,12 +8472,12 @@ Types:
           Type: 3 BaseType uint8
         - Name: elem
           Offset: 8
-          Type: 236 ArrayType [4]int
+          Type: 272 ArrayType [4]int
     - __kind: StructureType
-      ID: 227
+      ID: 263
       Name: noalg.struct { key uint8; elem uint8 }
       ByteSize: 2
-      GoRuntimeType: 1.279008e+06
+      GoRuntimeType: 1.291872e+06
       GoKind: 25
       RawFields:
         - Name: key
@@ -7069,127 +8490,127 @@ Types:
       ID: 9
       Name: string
       ByteSize: 16
-      GoRuntimeType: 574816
+      GoRuntimeType: 579904
       GoKind: 24
       RawFields:
         - Name: str
           Offset: 0
-          Type: 152 PointerType *string.str
+          Type: 175 PointerType *string.str
         - Name: len
           Offset: 8
           Type: 7 BaseType int
-      Data: 151 GoStringDataType string.str
+      Data: 174 GoStringDataType string.str
     - __kind: GoStringDataType
-      ID: 151
+      ID: 174
       Name: string.str
       ByteSize: 2048
     - __kind: StructureType
-      ID: 267
+      ID: 392
       Name: sync.Mutex
       ByteSize: 8
-      GoRuntimeType: 1.444672e+06
+      GoRuntimeType: 1.457536e+06
       GoKind: 25
       RawFields:
         - Name: _
           Offset: 0
-          Type: 268 StructureType sync.noCopy
+          Type: 393 StructureType sync.noCopy
         - Name: mu
           Offset: 0
-          Type: 269 StructureType internal/sync.Mutex
+          Type: 394 StructureType internal/sync.Mutex
     - __kind: StructureType
-      ID: 270
+      ID: 395
       Name: sync.Once
       ByteSize: 12
-      GoRuntimeType: 1.593184e+06
+      GoRuntimeType: 1.606048e+06
       GoKind: 25
       RawFields:
         - Name: _
           Offset: 0
-          Type: 268 StructureType sync.noCopy
+          Type: 393 StructureType sync.noCopy
         - Name: done
           Offset: 0
-          Type: 271 StructureType sync/atomic.Uint32
+          Type: 396 StructureType sync/atomic.Uint32
         - Name: m
           Offset: 4
-          Type: 267 StructureType sync.Mutex
+          Type: 392 StructureType sync.Mutex
     - __kind: StructureType
-      ID: 273
+      ID: 398
       Name: sync.WaitGroup
       ByteSize: 16
-      GoRuntimeType: 1.593376e+06
+      GoRuntimeType: 1.60624e+06
       GoKind: 25
       RawFields:
         - Name: noCopy
           Offset: 0
-          Type: 268 StructureType sync.noCopy
+          Type: 393 StructureType sync.noCopy
         - Name: state
           Offset: 0
-          Type: 274 StructureType sync/atomic.Uint64
+          Type: 399 StructureType sync/atomic.Uint64
         - Name: sema
           Offset: 8
           Type: 2 BaseType uint32
     - __kind: StructureType
-      ID: 268
+      ID: 393
       Name: sync.noCopy
-      GoRuntimeType: 977056
+      GoRuntimeType: 983008
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 276
+      ID: 401
       Name: sync/atomic.Int32
       ByteSize: 4
-      GoRuntimeType: 1.445952e+06
+      GoRuntimeType: 1.458816e+06
       GoKind: 25
       RawFields:
         - Name: _
           Offset: 0
-          Type: 272 StructureType sync/atomic.noCopy
+          Type: 397 StructureType sync/atomic.noCopy
         - Name: v
           Offset: 0
           Type: 12 BaseType int32
     - __kind: StructureType
-      ID: 271
+      ID: 396
       Name: sync/atomic.Uint32
       ByteSize: 4
-      GoRuntimeType: 1.446112e+06
+      GoRuntimeType: 1.458976e+06
       GoKind: 25
       RawFields:
         - Name: _
           Offset: 0
-          Type: 272 StructureType sync/atomic.noCopy
+          Type: 397 StructureType sync/atomic.noCopy
         - Name: v
           Offset: 0
           Type: 2 BaseType uint32
     - __kind: StructureType
-      ID: 274
+      ID: 399
       Name: sync/atomic.Uint64
       ByteSize: 8
-      GoRuntimeType: 1.59376e+06
+      GoRuntimeType: 1.606624e+06
       GoKind: 25
       RawFields:
         - Name: _
           Offset: 0
-          Type: 272 StructureType sync/atomic.noCopy
+          Type: 397 StructureType sync/atomic.noCopy
         - Name: _
           Offset: 0
-          Type: 275 StructureType sync/atomic.align64
+          Type: 400 StructureType sync/atomic.align64
         - Name: v
           Offset: 0
           Type: 8 BaseType uint64
     - __kind: StructureType
-      ID: 275
+      ID: 400
       Name: sync/atomic.align64
-      GoRuntimeType: 977248
+      GoRuntimeType: 983200
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 272
+      ID: 397
       Name: sync/atomic.noCopy
-      GoRuntimeType: 977152
+      GoRuntimeType: 983104
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 247
+      ID: 283
       Name: table<[4]int,[4]int>
       ByteSize: 32
       GoKind: 25
@@ -7211,9 +8632,9 @@ Types:
           Type: 7 BaseType int
         - Name: groups
           Offset: 16
-          Type: 248 GoSwissMapGroupsType groupReference<[4]int,[4]int>
+          Type: 284 GoSwissMapGroupsType groupReference<[4]int,[4]int>
     - __kind: StructureType
-      ID: 239
+      ID: 275
       Name: table<[4]int,uint8>
       ByteSize: 32
       GoKind: 25
@@ -7235,9 +8656,9 @@ Types:
           Type: 7 BaseType int
         - Name: groups
           Offset: 16
-          Type: 240 GoSwissMapGroupsType groupReference<[4]int,uint8>
+          Type: 276 GoSwissMapGroupsType groupReference<[4]int,uint8>
     - __kind: StructureType
-      ID: 187
+      ID: 223
       Name: table<[4]string,[2]int>
       ByteSize: 32
       GoKind: 25
@@ -7259,9 +8680,9 @@ Types:
           Type: 7 BaseType int
         - Name: groups
           Offset: 16
-          Type: 188 GoSwissMapGroupsType groupReference<[4]string,[2]int>
+          Type: 224 GoSwissMapGroupsType groupReference<[4]string,[2]int>
     - __kind: StructureType
-      ID: 206
+      ID: 242
       Name: table<bool,main.node>
       ByteSize: 32
       GoKind: 25
@@ -7283,9 +8704,105 @@ Types:
           Type: 7 BaseType int
         - Name: groups
           Offset: 16
-          Type: 207 GoSwissMapGroupsType groupReference<bool,main.node>
+          Type: 243 GoSwissMapGroupsType groupReference<bool,main.node>
     - __kind: StructureType
-      ID: 155
+      ID: 181
+      Name: table<int,*main.deepMap2>
+      ByteSize: 32
+      GoKind: 25
+      RawFields:
+        - Name: used
+          Offset: 0
+          Type: 6 BaseType uint16
+        - Name: capacity
+          Offset: 2
+          Type: 6 BaseType uint16
+        - Name: growthLeft
+          Offset: 4
+          Type: 6 BaseType uint16
+        - Name: localDepth
+          Offset: 6
+          Type: 3 BaseType uint8
+        - Name: index
+          Offset: 8
+          Type: 7 BaseType int
+        - Name: groups
+          Offset: 16
+          Type: 182 GoSwissMapGroupsType groupReference<int,*main.deepMap2>
+    - __kind: StructureType
+      ID: 319
+      Name: table<int,*main.deepMap3>
+      ByteSize: 32
+      GoKind: 25
+      RawFields:
+        - Name: used
+          Offset: 0
+          Type: 6 BaseType uint16
+        - Name: capacity
+          Offset: 2
+          Type: 6 BaseType uint16
+        - Name: growthLeft
+          Offset: 4
+          Type: 6 BaseType uint16
+        - Name: localDepth
+          Offset: 6
+          Type: 3 BaseType uint8
+        - Name: index
+          Offset: 8
+          Type: 7 BaseType int
+        - Name: groups
+          Offset: 16
+          Type: 320 GoSwissMapGroupsType groupReference<int,*main.deepMap3>
+    - __kind: StructureType
+      ID: 354
+      Name: table<int,*main.deepMap8>
+      ByteSize: 32
+      GoKind: 25
+      RawFields:
+        - Name: used
+          Offset: 0
+          Type: 6 BaseType uint16
+        - Name: capacity
+          Offset: 2
+          Type: 6 BaseType uint16
+        - Name: growthLeft
+          Offset: 4
+          Type: 6 BaseType uint16
+        - Name: localDepth
+          Offset: 6
+          Type: 3 BaseType uint8
+        - Name: index
+          Offset: 8
+          Type: 7 BaseType int
+        - Name: groups
+          Offset: 16
+          Type: 355 GoSwissMapGroupsType groupReference<int,*main.deepMap8>
+    - __kind: StructureType
+      ID: 369
+      Name: table<int,*main.deepMap9>
+      ByteSize: 32
+      GoKind: 25
+      RawFields:
+        - Name: used
+          Offset: 0
+          Type: 6 BaseType uint16
+        - Name: capacity
+          Offset: 2
+          Type: 6 BaseType uint16
+        - Name: growthLeft
+          Offset: 4
+          Type: 6 BaseType uint16
+        - Name: localDepth
+          Offset: 6
+          Type: 3 BaseType uint8
+        - Name: index
+          Offset: 8
+          Type: 7 BaseType int
+        - Name: groups
+          Offset: 16
+          Type: 370 GoSwissMapGroupsType groupReference<int,*main.deepMap9>
+    - __kind: StructureType
+      ID: 191
       Name: table<int,int>
       ByteSize: 32
       GoKind: 25
@@ -7307,9 +8824,33 @@ Types:
           Type: 7 BaseType int
         - Name: groups
           Offset: 16
-          Type: 156 GoSwissMapGroupsType groupReference<int,int>
+          Type: 192 GoSwissMapGroupsType groupReference<int,int>
     - __kind: StructureType
-      ID: 214
+      ID: 384
+      Name: table<int,interface {}>
+      ByteSize: 32
+      GoKind: 25
+      RawFields:
+        - Name: used
+          Offset: 0
+          Type: 6 BaseType uint16
+        - Name: capacity
+          Offset: 2
+          Type: 6 BaseType uint16
+        - Name: growthLeft
+          Offset: 4
+          Type: 6 BaseType uint16
+        - Name: localDepth
+          Offset: 6
+          Type: 3 BaseType uint8
+        - Name: index
+          Offset: 8
+          Type: 7 BaseType int
+        - Name: groups
+          Offset: 16
+          Type: 385 GoSwissMapGroupsType groupReference<int,interface {}>
+    - __kind: StructureType
+      ID: 250
       Name: table<int,uint8>
       ByteSize: 32
       GoKind: 25
@@ -7331,9 +8872,9 @@ Types:
           Type: 7 BaseType int
         - Name: groups
           Offset: 16
-          Type: 215 GoSwissMapGroupsType groupReference<int,uint8>
+          Type: 251 GoSwissMapGroupsType groupReference<int,uint8>
     - __kind: StructureType
-      ID: 196
+      ID: 232
       Name: table<string,[]main.structWithMap>
       ByteSize: 32
       GoKind: 25
@@ -7355,9 +8896,9 @@ Types:
           Type: 7 BaseType int
         - Name: groups
           Offset: 16
-          Type: 197 GoSwissMapGroupsType groupReference<string,[]main.structWithMap>
+          Type: 233 GoSwissMapGroupsType groupReference<string,[]main.structWithMap>
     - __kind: StructureType
-      ID: 179
+      ID: 215
       Name: table<string,[]string>
       ByteSize: 32
       GoKind: 25
@@ -7379,9 +8920,9 @@ Types:
           Type: 7 BaseType int
         - Name: groups
           Offset: 16
-          Type: 180 GoSwissMapGroupsType groupReference<string,[]string>
+          Type: 216 GoSwissMapGroupsType groupReference<string,[]string>
     - __kind: StructureType
-      ID: 171
+      ID: 207
       Name: table<string,int>
       ByteSize: 32
       GoKind: 25
@@ -7403,9 +8944,9 @@ Types:
           Type: 7 BaseType int
         - Name: groups
           Offset: 16
-          Type: 172 GoSwissMapGroupsType groupReference<string,int>
+          Type: 208 GoSwissMapGroupsType groupReference<string,int>
     - __kind: StructureType
-      ID: 163
+      ID: 199
       Name: table<string,main.nestedStruct>
       ByteSize: 32
       GoKind: 25
@@ -7427,9 +8968,9 @@ Types:
           Type: 7 BaseType int
         - Name: groups
           Offset: 16
-          Type: 164 GoSwissMapGroupsType groupReference<string,main.nestedStruct>
+          Type: 200 GoSwissMapGroupsType groupReference<string,main.nestedStruct>
     - __kind: StructureType
-      ID: 230
+      ID: 266
       Name: table<uint8,[4]int>
       ByteSize: 32
       GoKind: 25
@@ -7451,9 +8992,9 @@ Types:
           Type: 7 BaseType int
         - Name: groups
           Offset: 16
-          Type: 231 GoSwissMapGroupsType groupReference<uint8,[4]int>
+          Type: 267 GoSwissMapGroupsType groupReference<uint8,[4]int>
     - __kind: StructureType
-      ID: 222
+      ID: 258
       Name: table<uint8,uint8>
       ByteSize: 32
       GoKind: 25
@@ -7475,49 +9016,49 @@ Types:
           Type: 7 BaseType int
         - Name: groups
           Offset: 16
-          Type: 223 GoSwissMapGroupsType groupReference<uint8,uint8>
+          Type: 259 GoSwissMapGroupsType groupReference<uint8,uint8>
     - __kind: BaseType
       ID: 10
       Name: uint
       ByteSize: 8
-      GoRuntimeType: 575456
+      GoRuntimeType: 580544
       GoKind: 7
     - __kind: BaseType
       ID: 6
       Name: uint16
       ByteSize: 2
-      GoRuntimeType: 575072
+      GoRuntimeType: 580160
       GoKind: 9
     - __kind: BaseType
       ID: 2
       Name: uint32
       ByteSize: 4
-      GoRuntimeType: 575200
+      GoRuntimeType: 580288
       GoKind: 10
     - __kind: BaseType
       ID: 8
       Name: uint64
       ByteSize: 8
-      GoRuntimeType: 575328
+      GoRuntimeType: 580416
       GoKind: 11
     - __kind: BaseType
       ID: 3
       Name: uint8
       ByteSize: 1
-      GoRuntimeType: 574944
+      GoRuntimeType: 580032
       GoKind: 8
     - __kind: BaseType
       ID: 1
       Name: uintptr
       ByteSize: 8
-      GoRuntimeType: 575520
+      GoRuntimeType: 580608
       GoKind: 12
     - __kind: VoidPointerType
       ID: 15
       Name: unsafe.Pointer
       ByteSize: 8
-      GoRuntimeType: 575904
+      GoRuntimeType: 580992
       GoKind: 26
-MaxTypeID: 385
+MaxTypeID: 518
 Issues: []
-GoModuledataInfo: {FirstModuledataAddr: "0x131d320", TypesOffset: 296}
+GoModuledataInfo: {FirstModuledataAddr: "0x131d360", TypesOffset: 296}

--- a/pkg/dyninst/irgen/testdata/snapshot/sample.arch=arm64,toolchain=go1.24.3.yaml
+++ b/pkg/dyninst/irgen/testdata/snapshot/sample.arch=arm64,toolchain=go1.24.3.yaml
@@ -3094,275 +3094,11 @@ Subprograms:
           IsParameter: true
           IsReturn: false
 Types:
-    - __kind: BaseType
-      ID: 1
-      Name: int
-      ByteSize: 8
-      GoRuntimeType: 575392
-      GoKind: 2
-    - __kind: ArrayType
-      ID: 2
-      Name: '[5]int'
-      ByteSize: 40
-      GoKind: 17
-      Count: 5
-      HasCount: true
-      Element: 1 BaseType int
-    - __kind: ArrayType
-      ID: 3
-      Name: '[2]uint8'
-      ByteSize: 2
-      GoRuntimeType: 674336
-      GoKind: 17
-      Count: 2
-      HasCount: true
-      Element: 4 BaseType uint8
-    - __kind: BaseType
-      ID: 4
-      Name: uint8
-      ByteSize: 1
-      GoRuntimeType: 574944
-      GoKind: 8
-    - __kind: ArrayType
-      ID: 5
-      Name: '[2]int32'
-      ByteSize: 8
-      GoRuntimeType: 674432
-      GoKind: 17
-      Count: 2
-      HasCount: true
-      Element: 6 BaseType int32
-    - __kind: BaseType
-      ID: 6
-      Name: int32
-      ByteSize: 4
-      GoRuntimeType: 575136
-      GoKind: 5
-    - __kind: ArrayType
-      ID: 7
-      Name: '[2]string'
-      ByteSize: 32
-      GoRuntimeType: 674528
-      GoKind: 17
-      Count: 2
-      HasCount: true
-      Element: 8 GoStringHeaderType string
-    - __kind: GoStringHeaderType
-      ID: 8
-      Name: string
-      ByteSize: 16
-      GoRuntimeType: 574816
-      GoKind: 24
-      RawFields:
-        - Name: str
-          Offset: 0
-          Type: 239 PointerType *string.str
-        - Name: len
-          Offset: 8
-          Type: 1 BaseType int
-      Data: 238 GoStringDataType string.str
     - __kind: PointerType
-      ID: 9
-      Name: '*uint8'
+      ID: 209
+      Name: '**main.t'
       ByteSize: 8
-      GoRuntimeType: 385280
-      GoKind: 22
-      Pointee: 4 BaseType uint8
-    - __kind: ArrayType
-      ID: 10
-      Name: '[2]bool'
-      ByteSize: 2
-      GoKind: 17
-      Count: 2
-      HasCount: true
-      Element: 11 BaseType bool
-    - __kind: BaseType
-      ID: 11
-      Name: bool
-      ByteSize: 1
-      GoRuntimeType: 575840
-      GoKind: 1
-    - __kind: ArrayType
-      ID: 12
-      Name: '[2]int'
-      ByteSize: 16
-      GoRuntimeType: 673088
-      GoKind: 17
-      Count: 2
-      HasCount: true
-      Element: 1 BaseType int
-    - __kind: ArrayType
-      ID: 13
-      Name: '[2]int8'
-      ByteSize: 2
-      GoKind: 17
-      Count: 2
-      HasCount: true
-      Element: 14 BaseType int8
-    - __kind: BaseType
-      ID: 14
-      Name: int8
-      ByteSize: 1
-      GoRuntimeType: 574880
-      GoKind: 3
-    - __kind: ArrayType
-      ID: 15
-      Name: '[2]int16'
-      ByteSize: 4
-      GoKind: 17
-      Count: 2
-      HasCount: true
-      Element: 16 BaseType int16
-    - __kind: BaseType
-      ID: 16
-      Name: int16
-      ByteSize: 2
-      GoRuntimeType: 575008
-      GoKind: 4
-    - __kind: ArrayType
-      ID: 17
-      Name: '[2]int64'
-      ByteSize: 16
-      GoKind: 17
-      Count: 2
-      HasCount: true
-      Element: 18 BaseType int64
-    - __kind: BaseType
-      ID: 18
-      Name: int64
-      ByteSize: 8
-      GoRuntimeType: 575264
-      GoKind: 6
-    - __kind: ArrayType
-      ID: 19
-      Name: '[2]uint'
-      ByteSize: 16
-      GoKind: 17
-      Count: 2
-      HasCount: true
-      Element: 20 BaseType uint
-    - __kind: BaseType
-      ID: 20
-      Name: uint
-      ByteSize: 8
-      GoRuntimeType: 575456
-      GoKind: 7
-    - __kind: ArrayType
-      ID: 21
-      Name: '[2]uint16'
-      ByteSize: 4
-      GoKind: 17
-      Count: 2
-      HasCount: true
-      Element: 22 BaseType uint16
-    - __kind: BaseType
-      ID: 22
-      Name: uint16
-      ByteSize: 2
-      GoRuntimeType: 575072
-      GoKind: 9
-    - __kind: ArrayType
-      ID: 23
-      Name: '[2]uint32'
-      ByteSize: 8
-      GoKind: 17
-      Count: 2
-      HasCount: true
-      Element: 24 BaseType uint32
-    - __kind: BaseType
-      ID: 24
-      Name: uint32
-      ByteSize: 4
-      GoRuntimeType: 575200
-      GoKind: 10
-    - __kind: ArrayType
-      ID: 25
-      Name: '[2]uint64'
-      ByteSize: 16
-      GoRuntimeType: 674624
-      GoKind: 17
-      Count: 2
-      HasCount: true
-      Element: 26 BaseType uint64
-    - __kind: BaseType
-      ID: 26
-      Name: uint64
-      ByteSize: 8
-      GoRuntimeType: 575328
-      GoKind: 11
-    - __kind: ArrayType
-      ID: 27
-      Name: '[2][2]int'
-      ByteSize: 32
-      GoKind: 17
-      Count: 2
-      HasCount: true
-      Element: 12 ArrayType [2]int
-    - __kind: ArrayType
-      ID: 28
-      Name: '[2][2][2]int'
-      ByteSize: 64
-      GoKind: 17
-      Count: 2
-      HasCount: true
-      Element: 27 ArrayType [2][2]int
-    - __kind: ArrayType
-      ID: 29
-      Name: '[100]uint'
-      ByteSize: 800
-      GoKind: 17
-      Count: 100
-      HasCount: true
-      Element: 20 BaseType uint
-    - __kind: BaseType
-      ID: 30
-      Name: float32
-      ByteSize: 4
-      GoRuntimeType: 575712
-      GoKind: 13
-    - __kind: BaseType
-      ID: 31
-      Name: float64
-      ByteSize: 8
-      GoRuntimeType: 575776
-      GoKind: 14
-    - __kind: BaseType
-      ID: 32
-      Name: main.typeAlias
-      ByteSize: 2
-      GoKind: 9
-    - __kind: StructureType
-      ID: 33
-      Name: main.bigStruct
-      ByteSize: 48
-      GoKind: 25
-      RawFields:
-        - Name: x
-          Offset: 0
-          Type: 34 GoSliceHeaderType []*string
-        - Name: z
-          Offset: 24
-          Type: 1 BaseType int
-        - Name: writer
-          Offset: 32
-          Type: 37 GoInterfaceType io.Writer
-    - __kind: GoSliceHeaderType
-      ID: 34
-      Name: '[]*string'
-      ByteSize: 24
-      GoRuntimeType: 470528
-      GoKind: 23
-      RawFields:
-        - Name: array
-          Offset: 0
-          Type: 35 PointerType **string
-        - Name: len
-          Offset: 8
-          Type: 1 BaseType int
-        - Name: cap
-          Offset: 16
-          Type: 1 BaseType int
-      Data: 240 GoSliceDataType []*string.array
+      Pointee: 207 PointerType *main.t
     - __kind: PointerType
       ID: 35
       Name: '**string'
@@ -3371,2005 +3107,110 @@ Types:
       GoKind: 22
       Pointee: 36 PointerType *string
     - __kind: PointerType
-      ID: 36
-      Name: '*string'
+      ID: 194
+      Name: '**table<[4]int,[4]int>'
       ByteSize: 8
-      GoRuntimeType: 385152
-      GoKind: 22
-      Pointee: 8 GoStringHeaderType string
-    - __kind: GoInterfaceType
-      ID: 37
-      Name: io.Writer
-      ByteSize: 16
-      GoRuntimeType: 1.011776e+06
-      GoKind: 20
-      RawFields:
-        - Name: tab
-          Offset: 0
-          Type: 38 VoidPointerType unsafe.Pointer
-        - Name: data
-          Offset: 8
-          Type: 38 VoidPointerType unsafe.Pointer
-    - __kind: VoidPointerType
-      ID: 38
-      Name: unsafe.Pointer
-      ByteSize: 8
-      GoRuntimeType: 575904
-      GoKind: 26
-    - __kind: StructureType
-      ID: 39
-      Name: main.esotericStack
-      ByteSize: 64
-      GoRuntimeType: 1.944768e+06
-      GoKind: 25
-      RawFields:
-        - Name: _
-          Offset: 0
-          Type: 6 BaseType int32
-        - Name: _valid
-          Offset: 4
-          Type: 6 BaseType int32
-        - Name: c
-          Offset: 8
-          Type: 40 GoChannelType chan struct {}
-        - Name: val
-          Offset: 16
-          Type: 41 GoEmptyInterfaceType interface {}
-        - Name: _
-          Offset: 32
-          Type: 26 BaseType uint64
-        - Name: work
-          Offset: 40
-          Type: 42 GoInterfaceType main.something
-        - Name: foo
-          Offset: 56
-          Type: 43 GoSubroutineType func()
-    - __kind: GoChannelType
-      ID: 40
-      Name: chan struct {}
-      GoRuntimeType: 586080
-      GoKind: 18
-    - __kind: GoEmptyInterfaceType
-      ID: 41
-      Name: interface {}
-      ByteSize: 16
-      GoRuntimeType: 837760
-      GoKind: 20
-      RawFields:
-        - Name: _type
-          Offset: 0
-          Type: 38 VoidPointerType unsafe.Pointer
-        - Name: data
-          Offset: 8
-          Type: 38 VoidPointerType unsafe.Pointer
-    - __kind: GoInterfaceType
-      ID: 42
-      Name: main.something
-      ByteSize: 16
-      GoRuntimeType: 1.01152e+06
-      GoKind: 20
-      RawFields:
-        - Name: tab
-          Offset: 0
-          Type: 38 VoidPointerType unsafe.Pointer
-        - Name: data
-          Offset: 8
-          Type: 38 VoidPointerType unsafe.Pointer
-    - __kind: GoSubroutineType
-      ID: 43
-      Name: func()
-      ByteSize: 8
-      GoRuntimeType: 468800
-      GoKind: 19
-    - __kind: PointerType
-      ID: 44
-      Name: '*main.esotericHeap'
-      ByteSize: 8
-      GoRuntimeType: 380160
-      GoKind: 22
-      Pointee: 45 StructureType main.esotericHeap
-    - __kind: StructureType
-      ID: 45
-      Name: main.esotericHeap
-      ByteSize: 112
-      GoRuntimeType: 1.811168e+06
-      GoKind: 25
-      RawFields:
-        - Name: esotericStack
-          Offset: 0
-          Type: 39 StructureType main.esotericStack
-        - Name: mu
-          Offset: 64
-          Type: 46 StructureType sync.Mutex
-        - Name: once
-          Offset: 72
-          Type: 49 StructureType sync.Once
-        - Name: wg
-          Offset: 88
-          Type: 52 StructureType sync.WaitGroup
-        - Name: a
-          Offset: 104
-          Type: 55 StructureType sync/atomic.Int32
-    - __kind: StructureType
-      ID: 46
-      Name: sync.Mutex
-      ByteSize: 8
-      GoRuntimeType: 1.444672e+06
-      GoKind: 25
-      RawFields:
-        - Name: _
-          Offset: 0
-          Type: 47 StructureType sync.noCopy
-        - Name: mu
-          Offset: 0
-          Type: 48 StructureType internal/sync.Mutex
-    - __kind: StructureType
-      ID: 47
-      Name: sync.noCopy
-      GoRuntimeType: 977056
-      GoKind: 25
-      RawFields: []
-    - __kind: StructureType
-      ID: 48
-      Name: internal/sync.Mutex
-      ByteSize: 8
-      GoRuntimeType: 1.453952e+06
-      GoKind: 25
-      RawFields:
-        - Name: state
-          Offset: 0
-          Type: 6 BaseType int32
-        - Name: sema
-          Offset: 4
-          Type: 24 BaseType uint32
-    - __kind: StructureType
-      ID: 49
-      Name: sync.Once
-      ByteSize: 12
-      GoRuntimeType: 1.593184e+06
-      GoKind: 25
-      RawFields:
-        - Name: _
-          Offset: 0
-          Type: 47 StructureType sync.noCopy
-        - Name: done
-          Offset: 0
-          Type: 50 StructureType sync/atomic.Uint32
-        - Name: m
-          Offset: 4
-          Type: 46 StructureType sync.Mutex
-    - __kind: StructureType
-      ID: 50
-      Name: sync/atomic.Uint32
-      ByteSize: 4
-      GoRuntimeType: 1.446112e+06
-      GoKind: 25
-      RawFields:
-        - Name: _
-          Offset: 0
-          Type: 51 StructureType sync/atomic.noCopy
-        - Name: v
-          Offset: 0
-          Type: 24 BaseType uint32
-    - __kind: StructureType
-      ID: 51
-      Name: sync/atomic.noCopy
-      GoRuntimeType: 977152
-      GoKind: 25
-      RawFields: []
-    - __kind: StructureType
-      ID: 52
-      Name: sync.WaitGroup
-      ByteSize: 16
-      GoRuntimeType: 1.593376e+06
-      GoKind: 25
-      RawFields:
-        - Name: noCopy
-          Offset: 0
-          Type: 47 StructureType sync.noCopy
-        - Name: state
-          Offset: 0
-          Type: 53 StructureType sync/atomic.Uint64
-        - Name: sema
-          Offset: 8
-          Type: 24 BaseType uint32
-    - __kind: StructureType
-      ID: 53
-      Name: sync/atomic.Uint64
-      ByteSize: 8
-      GoRuntimeType: 1.59376e+06
-      GoKind: 25
-      RawFields:
-        - Name: _
-          Offset: 0
-          Type: 51 StructureType sync/atomic.noCopy
-        - Name: _
-          Offset: 0
-          Type: 54 StructureType sync/atomic.align64
-        - Name: v
-          Offset: 0
-          Type: 26 BaseType uint64
-    - __kind: StructureType
-      ID: 54
-      Name: sync/atomic.align64
-      GoRuntimeType: 977248
-      GoKind: 25
-      RawFields: []
-    - __kind: StructureType
-      ID: 55
-      Name: sync/atomic.Int32
-      ByteSize: 4
-      GoRuntimeType: 1.445952e+06
-      GoKind: 25
-      RawFields:
-        - Name: _
-          Offset: 0
-          Type: 51 StructureType sync/atomic.noCopy
-        - Name: v
-          Offset: 0
-          Type: 6 BaseType int32
-    - __kind: GoInterfaceType
-      ID: 56
-      Name: main.behavior
-      ByteSize: 16
-      GoRuntimeType: 1.011392e+06
-      GoKind: 20
-      RawFields:
-        - Name: tab
-          Offset: 0
-          Type: 38 VoidPointerType unsafe.Pointer
-        - Name: data
-          Offset: 8
-          Type: 38 VoidPointerType unsafe.Pointer
-    - __kind: GoInterfaceType
-      ID: 57
-      Name: error
-      ByteSize: 16
-      GoRuntimeType: 1.015744e+06
-      GoKind: 20
-      RawFields:
-        - Name: tab
-          Offset: 0
-          Type: 38 VoidPointerType unsafe.Pointer
-        - Name: data
-          Offset: 8
-          Type: 38 VoidPointerType unsafe.Pointer
-    - __kind: StructureType
-      ID: 58
-      Name: main.structWithMap
-      ByteSize: 8
-      GoRuntimeType: 1.172832e+06
-      GoKind: 25
-      RawFields:
-        - Name: m
-          Offset: 0
-          Type: 59 GoMapType map[int]int
-    - __kind: GoMapType
-      ID: 59
-      Name: map[int]int
-      ByteSize: 8
-      GoRuntimeType: 1.116512e+06
-      GoKind: 21
-      HeaderType: 61 GoSwissMapHeaderType map<int,int>
-    - __kind: PointerType
-      ID: 60
-      Name: '*map<int,int>'
-      ByteSize: 8
-      Pointee: 61 GoSwissMapHeaderType map<int,int>
-    - __kind: GoSwissMapHeaderType
-      ID: 61
-      Name: map<int,int>
-      ByteSize: 48
-      GoKind: 25
-      RawFields:
-        - Name: used
-          Offset: 0
-          Type: 26 BaseType uint64
-        - Name: seed
-          Offset: 8
-          Type: 62 BaseType uintptr
-        - Name: dirPtr
-          Offset: 16
-          Type: 63 PointerType **table<int,int>
-        - Name: dirLen
-          Offset: 24
-          Type: 1 BaseType int
-        - Name: globalDepth
-          Offset: 32
-          Type: 4 BaseType uint8
-        - Name: globalShift
-          Offset: 33
-          Type: 4 BaseType uint8
-        - Name: writing
-          Offset: 34
-          Type: 4 BaseType uint8
-        - Name: clearSeq
-          Offset: 40
-          Type: 26 BaseType uint64
-      TablePtrSliceType: 242 GoSliceDataType []*table<int,int>.array
-      GroupType: 68 StructureType noalg.map.group[int]int
-    - __kind: BaseType
-      ID: 62
-      Name: uintptr
-      ByteSize: 8
-      GoRuntimeType: 575520
-      GoKind: 12
-    - __kind: PointerType
-      ID: 63
-      Name: '**table<int,int>'
-      ByteSize: 8
-      Pointee: 64 PointerType *table<int,int>
-    - __kind: PointerType
-      ID: 64
-      Name: '*table<int,int>'
-      ByteSize: 8
-      Pointee: 65 StructureType table<int,int>
-    - __kind: StructureType
-      ID: 65
-      Name: table<int,int>
-      ByteSize: 32
-      GoKind: 25
-      RawFields:
-        - Name: used
-          Offset: 0
-          Type: 22 BaseType uint16
-        - Name: capacity
-          Offset: 2
-          Type: 22 BaseType uint16
-        - Name: growthLeft
-          Offset: 4
-          Type: 22 BaseType uint16
-        - Name: localDepth
-          Offset: 6
-          Type: 4 BaseType uint8
-        - Name: index
-          Offset: 8
-          Type: 1 BaseType int
-        - Name: groups
-          Offset: 16
-          Type: 66 GoSwissMapGroupsType groupReference<int,int>
-    - __kind: GoSwissMapGroupsType
-      ID: 66
-      Name: groupReference<int,int>
-      ByteSize: 16
-      GoKind: 25
-      RawFields:
-        - Name: data
-          Offset: 0
-          Type: 67 PointerType *noalg.map.group[int]int
-        - Name: lengthMask
-          Offset: 8
-          Type: 26 BaseType uint64
-      GroupType: 68 StructureType noalg.map.group[int]int
-      GroupSliceType: 243 GoSliceDataType []noalg.map.group[int]int.array
-    - __kind: PointerType
-      ID: 67
-      Name: '*noalg.map.group[int]int'
-      ByteSize: 8
-      Pointee: 68 StructureType noalg.map.group[int]int
-    - __kind: StructureType
-      ID: 68
-      Name: noalg.map.group[int]int
-      ByteSize: 136
-      GoRuntimeType: 1.275808e+06
-      GoKind: 25
-      RawFields:
-        - Name: ctrl
-          Offset: 0
-          Type: 26 BaseType uint64
-        - Name: slots
-          Offset: 8
-          Type: 69 ArrayType noalg.[8]struct { key int; elem int }
-    - __kind: ArrayType
-      ID: 69
-      Name: noalg.[8]struct { key int; elem int }
-      ByteSize: 128
-      GoRuntimeType: 671072
-      GoKind: 17
-      Count: 8
-      HasCount: true
-      Element: 70 StructureType noalg.struct { key int; elem int }
-    - __kind: StructureType
-      ID: 70
-      Name: noalg.struct { key int; elem int }
-      ByteSize: 16
-      GoRuntimeType: 1.27568e+06
-      GoKind: 25
-      RawFields:
-        - Name: key
-          Offset: 0
-          Type: 1 BaseType int
-        - Name: elem
-          Offset: 8
-          Type: 1 BaseType int
-    - __kind: GoMapType
-      ID: 71
-      Name: map[string]main.nestedStruct
-      ByteSize: 8
-      GoRuntimeType: 1.11792e+06
-      GoKind: 21
-      HeaderType: 73 GoSwissMapHeaderType map<string,main.nestedStruct>
-    - __kind: PointerType
-      ID: 72
-      Name: '*map<string,main.nestedStruct>'
-      ByteSize: 8
-      Pointee: 73 GoSwissMapHeaderType map<string,main.nestedStruct>
-    - __kind: GoSwissMapHeaderType
-      ID: 73
-      Name: map<string,main.nestedStruct>
-      ByteSize: 48
-      GoKind: 25
-      RawFields:
-        - Name: used
-          Offset: 0
-          Type: 26 BaseType uint64
-        - Name: seed
-          Offset: 8
-          Type: 62 BaseType uintptr
-        - Name: dirPtr
-          Offset: 16
-          Type: 74 PointerType **table<string,main.nestedStruct>
-        - Name: dirLen
-          Offset: 24
-          Type: 1 BaseType int
-        - Name: globalDepth
-          Offset: 32
-          Type: 4 BaseType uint8
-        - Name: globalShift
-          Offset: 33
-          Type: 4 BaseType uint8
-        - Name: writing
-          Offset: 34
-          Type: 4 BaseType uint8
-        - Name: clearSeq
-          Offset: 40
-          Type: 26 BaseType uint64
-      TablePtrSliceType: 244 GoSliceDataType []*table<string,main.nestedStruct>.array
-      GroupType: 79 StructureType noalg.map.group[string]main.nestedStruct
-    - __kind: PointerType
-      ID: 74
-      Name: '**table<string,main.nestedStruct>'
-      ByteSize: 8
-      Pointee: 75 PointerType *table<string,main.nestedStruct>
-    - __kind: PointerType
-      ID: 75
-      Name: '*table<string,main.nestedStruct>'
-      ByteSize: 8
-      Pointee: 76 StructureType table<string,main.nestedStruct>
-    - __kind: StructureType
-      ID: 76
-      Name: table<string,main.nestedStruct>
-      ByteSize: 32
-      GoKind: 25
-      RawFields:
-        - Name: used
-          Offset: 0
-          Type: 22 BaseType uint16
-        - Name: capacity
-          Offset: 2
-          Type: 22 BaseType uint16
-        - Name: growthLeft
-          Offset: 4
-          Type: 22 BaseType uint16
-        - Name: localDepth
-          Offset: 6
-          Type: 4 BaseType uint8
-        - Name: index
-          Offset: 8
-          Type: 1 BaseType int
-        - Name: groups
-          Offset: 16
-          Type: 77 GoSwissMapGroupsType groupReference<string,main.nestedStruct>
-    - __kind: GoSwissMapGroupsType
-      ID: 77
-      Name: groupReference<string,main.nestedStruct>
-      ByteSize: 16
-      GoKind: 25
-      RawFields:
-        - Name: data
-          Offset: 0
-          Type: 78 PointerType *noalg.map.group[string]main.nestedStruct
-        - Name: lengthMask
-          Offset: 8
-          Type: 26 BaseType uint64
-      GroupType: 79 StructureType noalg.map.group[string]main.nestedStruct
-      GroupSliceType: 245 GoSliceDataType []noalg.map.group[string]main.nestedStruct.array
-    - __kind: PointerType
-      ID: 78
-      Name: '*noalg.map.group[string]main.nestedStruct'
-      ByteSize: 8
-      Pointee: 79 StructureType noalg.map.group[string]main.nestedStruct
-    - __kind: StructureType
-      ID: 79
-      Name: noalg.map.group[string]main.nestedStruct
-      ByteSize: 328
-      GoRuntimeType: 1.278624e+06
-      GoKind: 25
-      RawFields:
-        - Name: ctrl
-          Offset: 0
-          Type: 26 BaseType uint64
-        - Name: slots
-          Offset: 8
-          Type: 80 ArrayType noalg.[8]struct { key string; elem main.nestedStruct }
-    - __kind: ArrayType
-      ID: 80
-      Name: noalg.[8]struct { key string; elem main.nestedStruct }
-      ByteSize: 320
-      GoRuntimeType: 673760
-      GoKind: 17
-      Count: 8
-      HasCount: true
-      Element: 81 StructureType noalg.struct { key string; elem main.nestedStruct }
-    - __kind: StructureType
-      ID: 81
-      Name: noalg.struct { key string; elem main.nestedStruct }
-      ByteSize: 40
-      GoRuntimeType: 1.278496e+06
-      GoKind: 25
-      RawFields:
-        - Name: key
-          Offset: 0
-          Type: 8 GoStringHeaderType string
-        - Name: elem
-          Offset: 16
-          Type: 82 StructureType main.nestedStruct
-    - __kind: StructureType
-      ID: 82
-      Name: main.nestedStruct
-      ByteSize: 24
-      GoRuntimeType: 1.443392e+06
-      GoKind: 25
-      RawFields:
-        - Name: anotherInt
-          Offset: 0
-          Type: 1 BaseType int
-        - Name: anotherString
-          Offset: 8
-          Type: 8 GoStringHeaderType string
-    - __kind: GoMapType
-      ID: 83
-      Name: map[string]int
-      ByteSize: 8
-      GoRuntimeType: 1.117792e+06
-      GoKind: 21
-      HeaderType: 85 GoSwissMapHeaderType map<string,int>
-    - __kind: PointerType
-      ID: 84
-      Name: '*map<string,int>'
-      ByteSize: 8
-      Pointee: 85 GoSwissMapHeaderType map<string,int>
-    - __kind: GoSwissMapHeaderType
-      ID: 85
-      Name: map<string,int>
-      ByteSize: 48
-      GoKind: 25
-      RawFields:
-        - Name: used
-          Offset: 0
-          Type: 26 BaseType uint64
-        - Name: seed
-          Offset: 8
-          Type: 62 BaseType uintptr
-        - Name: dirPtr
-          Offset: 16
-          Type: 86 PointerType **table<string,int>
-        - Name: dirLen
-          Offset: 24
-          Type: 1 BaseType int
-        - Name: globalDepth
-          Offset: 32
-          Type: 4 BaseType uint8
-        - Name: globalShift
-          Offset: 33
-          Type: 4 BaseType uint8
-        - Name: writing
-          Offset: 34
-          Type: 4 BaseType uint8
-        - Name: clearSeq
-          Offset: 40
-          Type: 26 BaseType uint64
-      TablePtrSliceType: 246 GoSliceDataType []*table<string,int>.array
-      GroupType: 91 StructureType noalg.map.group[string]int
-    - __kind: PointerType
-      ID: 86
-      Name: '**table<string,int>'
-      ByteSize: 8
-      Pointee: 87 PointerType *table<string,int>
-    - __kind: PointerType
-      ID: 87
-      Name: '*table<string,int>'
-      ByteSize: 8
-      Pointee: 88 StructureType table<string,int>
-    - __kind: StructureType
-      ID: 88
-      Name: table<string,int>
-      ByteSize: 32
-      GoKind: 25
-      RawFields:
-        - Name: used
-          Offset: 0
-          Type: 22 BaseType uint16
-        - Name: capacity
-          Offset: 2
-          Type: 22 BaseType uint16
-        - Name: growthLeft
-          Offset: 4
-          Type: 22 BaseType uint16
-        - Name: localDepth
-          Offset: 6
-          Type: 4 BaseType uint8
-        - Name: index
-          Offset: 8
-          Type: 1 BaseType int
-        - Name: groups
-          Offset: 16
-          Type: 89 GoSwissMapGroupsType groupReference<string,int>
-    - __kind: GoSwissMapGroupsType
-      ID: 89
-      Name: groupReference<string,int>
-      ByteSize: 16
-      GoKind: 25
-      RawFields:
-        - Name: data
-          Offset: 0
-          Type: 90 PointerType *noalg.map.group[string]int
-        - Name: lengthMask
-          Offset: 8
-          Type: 26 BaseType uint64
-      GroupType: 91 StructureType noalg.map.group[string]int
-      GroupSliceType: 247 GoSliceDataType []noalg.map.group[string]int.array
-    - __kind: PointerType
-      ID: 90
-      Name: '*noalg.map.group[string]int'
-      ByteSize: 8
-      Pointee: 91 StructureType noalg.map.group[string]int
-    - __kind: StructureType
-      ID: 91
-      Name: noalg.map.group[string]int
-      ByteSize: 200
-      GoRuntimeType: 1.278368e+06
-      GoKind: 25
-      RawFields:
-        - Name: ctrl
-          Offset: 0
-          Type: 26 BaseType uint64
-        - Name: slots
-          Offset: 8
-          Type: 92 ArrayType noalg.[8]struct { key string; elem int }
-    - __kind: ArrayType
-      ID: 92
-      Name: noalg.[8]struct { key string; elem int }
-      ByteSize: 192
-      GoRuntimeType: 673664
-      GoKind: 17
-      Count: 8
-      HasCount: true
-      Element: 93 StructureType noalg.struct { key string; elem int }
-    - __kind: StructureType
-      ID: 93
-      Name: noalg.struct { key string; elem int }
-      ByteSize: 24
-      GoRuntimeType: 1.27824e+06
-      GoKind: 25
-      RawFields:
-        - Name: key
-          Offset: 0
-          Type: 8 GoStringHeaderType string
-        - Name: elem
-          Offset: 16
-          Type: 1 BaseType int
-    - __kind: GoMapType
-      ID: 94
-      Name: map[string][]string
-      ByteSize: 8
-      GoRuntimeType: 1.117664e+06
-      GoKind: 21
-      HeaderType: 96 GoSwissMapHeaderType map<string,[]string>
-    - __kind: PointerType
-      ID: 95
-      Name: '*map<string,[]string>'
-      ByteSize: 8
-      Pointee: 96 GoSwissMapHeaderType map<string,[]string>
-    - __kind: GoSwissMapHeaderType
-      ID: 96
-      Name: map<string,[]string>
-      ByteSize: 48
-      GoKind: 25
-      RawFields:
-        - Name: used
-          Offset: 0
-          Type: 26 BaseType uint64
-        - Name: seed
-          Offset: 8
-          Type: 62 BaseType uintptr
-        - Name: dirPtr
-          Offset: 16
-          Type: 97 PointerType **table<string,[]string>
-        - Name: dirLen
-          Offset: 24
-          Type: 1 BaseType int
-        - Name: globalDepth
-          Offset: 32
-          Type: 4 BaseType uint8
-        - Name: globalShift
-          Offset: 33
-          Type: 4 BaseType uint8
-        - Name: writing
-          Offset: 34
-          Type: 4 BaseType uint8
-        - Name: clearSeq
-          Offset: 40
-          Type: 26 BaseType uint64
-      TablePtrSliceType: 248 GoSliceDataType []*table<string,[]string>.array
-      GroupType: 102 StructureType noalg.map.group[string][]string
-    - __kind: PointerType
-      ID: 97
-      Name: '**table<string,[]string>'
-      ByteSize: 8
-      Pointee: 98 PointerType *table<string,[]string>
-    - __kind: PointerType
-      ID: 98
-      Name: '*table<string,[]string>'
-      ByteSize: 8
-      Pointee: 99 StructureType table<string,[]string>
-    - __kind: StructureType
-      ID: 99
-      Name: table<string,[]string>
-      ByteSize: 32
-      GoKind: 25
-      RawFields:
-        - Name: used
-          Offset: 0
-          Type: 22 BaseType uint16
-        - Name: capacity
-          Offset: 2
-          Type: 22 BaseType uint16
-        - Name: growthLeft
-          Offset: 4
-          Type: 22 BaseType uint16
-        - Name: localDepth
-          Offset: 6
-          Type: 4 BaseType uint8
-        - Name: index
-          Offset: 8
-          Type: 1 BaseType int
-        - Name: groups
-          Offset: 16
-          Type: 100 GoSwissMapGroupsType groupReference<string,[]string>
-    - __kind: GoSwissMapGroupsType
-      ID: 100
-      Name: groupReference<string,[]string>
-      ByteSize: 16
-      GoKind: 25
-      RawFields:
-        - Name: data
-          Offset: 0
-          Type: 101 PointerType *noalg.map.group[string][]string
-        - Name: lengthMask
-          Offset: 8
-          Type: 26 BaseType uint64
-      GroupType: 102 StructureType noalg.map.group[string][]string
-      GroupSliceType: 249 GoSliceDataType []noalg.map.group[string][]string.array
-    - __kind: PointerType
-      ID: 101
-      Name: '*noalg.map.group[string][]string'
-      ByteSize: 8
-      Pointee: 102 StructureType noalg.map.group[string][]string
-    - __kind: StructureType
-      ID: 102
-      Name: noalg.map.group[string][]string
-      ByteSize: 328
-      GoRuntimeType: 1.278112e+06
-      GoKind: 25
-      RawFields:
-        - Name: ctrl
-          Offset: 0
-          Type: 26 BaseType uint64
-        - Name: slots
-          Offset: 8
-          Type: 103 ArrayType noalg.[8]struct { key string; elem []string }
-    - __kind: ArrayType
-      ID: 103
-      Name: noalg.[8]struct { key string; elem []string }
-      ByteSize: 320
-      GoRuntimeType: 673568
-      GoKind: 17
-      Count: 8
-      HasCount: true
-      Element: 104 StructureType noalg.struct { key string; elem []string }
-    - __kind: StructureType
-      ID: 104
-      Name: noalg.struct { key string; elem []string }
-      ByteSize: 40
-      GoRuntimeType: 1.277984e+06
-      GoKind: 25
-      RawFields:
-        - Name: key
-          Offset: 0
-          Type: 8 GoStringHeaderType string
-        - Name: elem
-          Offset: 16
-          Type: 105 GoSliceHeaderType []string
-    - __kind: GoSliceHeaderType
-      ID: 105
-      Name: '[]string'
-      ByteSize: 24
-      GoRuntimeType: 478528
-      GoKind: 23
-      RawFields:
-        - Name: array
-          Offset: 0
-          Type: 36 PointerType *string
-        - Name: len
-          Offset: 8
-          Type: 1 BaseType int
-        - Name: cap
-          Offset: 16
-          Type: 1 BaseType int
-      Data: 250 GoSliceDataType []string.array
-    - __kind: GoMapType
-      ID: 106
-      Name: map[[4]string][2]int
-      ByteSize: 8
-      GoRuntimeType: 1.117152e+06
-      GoKind: 21
-      HeaderType: 108 GoSwissMapHeaderType map<[4]string,[2]int>
-    - __kind: PointerType
-      ID: 107
-      Name: '*map<[4]string,[2]int>'
-      ByteSize: 8
-      Pointee: 108 GoSwissMapHeaderType map<[4]string,[2]int>
-    - __kind: GoSwissMapHeaderType
-      ID: 108
-      Name: map<[4]string,[2]int>
-      ByteSize: 48
-      GoKind: 25
-      RawFields:
-        - Name: used
-          Offset: 0
-          Type: 26 BaseType uint64
-        - Name: seed
-          Offset: 8
-          Type: 62 BaseType uintptr
-        - Name: dirPtr
-          Offset: 16
-          Type: 109 PointerType **table<[4]string,[2]int>
-        - Name: dirLen
-          Offset: 24
-          Type: 1 BaseType int
-        - Name: globalDepth
-          Offset: 32
-          Type: 4 BaseType uint8
-        - Name: globalShift
-          Offset: 33
-          Type: 4 BaseType uint8
-        - Name: writing
-          Offset: 34
-          Type: 4 BaseType uint8
-        - Name: clearSeq
-          Offset: 40
-          Type: 26 BaseType uint64
-      TablePtrSliceType: 252 GoSliceDataType []*table<[4]string,[2]int>.array
-      GroupType: 114 StructureType noalg.map.group[[4]string][2]int
-    - __kind: PointerType
-      ID: 109
-      Name: '**table<[4]string,[2]int>'
-      ByteSize: 8
-      Pointee: 110 PointerType *table<[4]string,[2]int>
-    - __kind: PointerType
-      ID: 110
-      Name: '*table<[4]string,[2]int>'
-      ByteSize: 8
-      Pointee: 111 StructureType table<[4]string,[2]int>
-    - __kind: StructureType
-      ID: 111
-      Name: table<[4]string,[2]int>
-      ByteSize: 32
-      GoKind: 25
-      RawFields:
-        - Name: used
-          Offset: 0
-          Type: 22 BaseType uint16
-        - Name: capacity
-          Offset: 2
-          Type: 22 BaseType uint16
-        - Name: growthLeft
-          Offset: 4
-          Type: 22 BaseType uint16
-        - Name: localDepth
-          Offset: 6
-          Type: 4 BaseType uint8
-        - Name: index
-          Offset: 8
-          Type: 1 BaseType int
-        - Name: groups
-          Offset: 16
-          Type: 112 GoSwissMapGroupsType groupReference<[4]string,[2]int>
-    - __kind: GoSwissMapGroupsType
-      ID: 112
-      Name: groupReference<[4]string,[2]int>
-      ByteSize: 16
-      GoKind: 25
-      RawFields:
-        - Name: data
-          Offset: 0
-          Type: 113 PointerType *noalg.map.group[[4]string][2]int
-        - Name: lengthMask
-          Offset: 8
-          Type: 26 BaseType uint64
-      GroupType: 114 StructureType noalg.map.group[[4]string][2]int
-      GroupSliceType: 253 GoSliceDataType []noalg.map.group[[4]string][2]int.array
-    - __kind: PointerType
-      ID: 113
-      Name: '*noalg.map.group[[4]string][2]int'
-      ByteSize: 8
-      Pointee: 114 StructureType noalg.map.group[[4]string][2]int
-    - __kind: StructureType
-      ID: 114
-      Name: noalg.map.group[[4]string][2]int
-      ByteSize: 648
-      GoRuntimeType: 1.277088e+06
-      GoKind: 25
-      RawFields:
-        - Name: ctrl
-          Offset: 0
-          Type: 26 BaseType uint64
-        - Name: slots
-          Offset: 8
-          Type: 115 ArrayType noalg.[8]struct { key [4]string; elem [2]int }
-    - __kind: ArrayType
-      ID: 115
-      Name: noalg.[8]struct { key [4]string; elem [2]int }
-      ByteSize: 640
-      GoRuntimeType: 673184
-      GoKind: 17
-      Count: 8
-      HasCount: true
-      Element: 116 StructureType noalg.struct { key [4]string; elem [2]int }
-    - __kind: StructureType
-      ID: 116
-      Name: noalg.struct { key [4]string; elem [2]int }
-      ByteSize: 80
-      GoRuntimeType: 1.27696e+06
-      GoKind: 25
-      RawFields:
-        - Name: key
-          Offset: 0
-          Type: 117 ArrayType [4]string
-        - Name: elem
-          Offset: 64
-          Type: 12 ArrayType [2]int
-    - __kind: ArrayType
-      ID: 117
-      Name: '[4]string'
-      ByteSize: 64
-      GoRuntimeType: 672992
-      GoKind: 17
-      Count: 4
-      HasCount: true
-      Element: 8 GoStringHeaderType string
-    - __kind: ArrayType
-      ID: 118
-      Name: '[2]map[string]int'
-      ByteSize: 16
-      GoKind: 17
-      Count: 2
-      HasCount: true
-      Element: 83 GoMapType map[string]int
-    - __kind: PointerType
-      ID: 119
-      Name: '*map[string]int'
-      ByteSize: 8
-      GoKind: 22
-      Pointee: 83 GoMapType map[string]int
-    - __kind: GoMapType
-      ID: 120
-      Name: map[string][]main.structWithMap
-      ByteSize: 8
-      GoRuntimeType: 1.117536e+06
-      GoKind: 21
-      HeaderType: 122 GoSwissMapHeaderType map<string,[]main.structWithMap>
-    - __kind: PointerType
-      ID: 121
-      Name: '*map<string,[]main.structWithMap>'
-      ByteSize: 8
-      Pointee: 122 GoSwissMapHeaderType map<string,[]main.structWithMap>
-    - __kind: GoSwissMapHeaderType
-      ID: 122
-      Name: map<string,[]main.structWithMap>
-      ByteSize: 48
-      GoKind: 25
-      RawFields:
-        - Name: used
-          Offset: 0
-          Type: 26 BaseType uint64
-        - Name: seed
-          Offset: 8
-          Type: 62 BaseType uintptr
-        - Name: dirPtr
-          Offset: 16
-          Type: 123 PointerType **table<string,[]main.structWithMap>
-        - Name: dirLen
-          Offset: 24
-          Type: 1 BaseType int
-        - Name: globalDepth
-          Offset: 32
-          Type: 4 BaseType uint8
-        - Name: globalShift
-          Offset: 33
-          Type: 4 BaseType uint8
-        - Name: writing
-          Offset: 34
-          Type: 4 BaseType uint8
-        - Name: clearSeq
-          Offset: 40
-          Type: 26 BaseType uint64
-      TablePtrSliceType: 254 GoSliceDataType []*table<string,[]main.structWithMap>.array
-      GroupType: 128 StructureType noalg.map.group[string][]main.structWithMap
-    - __kind: PointerType
-      ID: 123
-      Name: '**table<string,[]main.structWithMap>'
-      ByteSize: 8
-      Pointee: 124 PointerType *table<string,[]main.structWithMap>
-    - __kind: PointerType
-      ID: 124
-      Name: '*table<string,[]main.structWithMap>'
-      ByteSize: 8
-      Pointee: 125 StructureType table<string,[]main.structWithMap>
-    - __kind: StructureType
-      ID: 125
-      Name: table<string,[]main.structWithMap>
-      ByteSize: 32
-      GoKind: 25
-      RawFields:
-        - Name: used
-          Offset: 0
-          Type: 22 BaseType uint16
-        - Name: capacity
-          Offset: 2
-          Type: 22 BaseType uint16
-        - Name: growthLeft
-          Offset: 4
-          Type: 22 BaseType uint16
-        - Name: localDepth
-          Offset: 6
-          Type: 4 BaseType uint8
-        - Name: index
-          Offset: 8
-          Type: 1 BaseType int
-        - Name: groups
-          Offset: 16
-          Type: 126 GoSwissMapGroupsType groupReference<string,[]main.structWithMap>
-    - __kind: GoSwissMapGroupsType
-      ID: 126
-      Name: groupReference<string,[]main.structWithMap>
-      ByteSize: 16
-      GoKind: 25
-      RawFields:
-        - Name: data
-          Offset: 0
-          Type: 127 PointerType *noalg.map.group[string][]main.structWithMap
-        - Name: lengthMask
-          Offset: 8
-          Type: 26 BaseType uint64
-      GroupType: 128 StructureType noalg.map.group[string][]main.structWithMap
-      GroupSliceType: 255 GoSliceDataType []noalg.map.group[string][]main.structWithMap.array
-    - __kind: PointerType
-      ID: 127
-      Name: '*noalg.map.group[string][]main.structWithMap'
-      ByteSize: 8
-      Pointee: 128 StructureType noalg.map.group[string][]main.structWithMap
-    - __kind: StructureType
-      ID: 128
-      Name: noalg.map.group[string][]main.structWithMap
-      ByteSize: 328
-      GoRuntimeType: 1.277856e+06
-      GoKind: 25
-      RawFields:
-        - Name: ctrl
-          Offset: 0
-          Type: 26 BaseType uint64
-        - Name: slots
-          Offset: 8
-          Type: 129 ArrayType noalg.[8]struct { key string; elem []main.structWithMap }
-    - __kind: ArrayType
-      ID: 129
-      Name: noalg.[8]struct { key string; elem []main.structWithMap }
-      ByteSize: 320
-      GoRuntimeType: 673472
-      GoKind: 17
-      Count: 8
-      HasCount: true
-      Element: 130 StructureType noalg.struct { key string; elem []main.structWithMap }
-    - __kind: StructureType
-      ID: 130
-      Name: noalg.struct { key string; elem []main.structWithMap }
-      ByteSize: 40
-      GoRuntimeType: 1.277728e+06
-      GoKind: 25
-      RawFields:
-        - Name: key
-          Offset: 0
-          Type: 8 GoStringHeaderType string
-        - Name: elem
-          Offset: 16
-          Type: 131 GoSliceHeaderType []main.structWithMap
-    - __kind: GoSliceHeaderType
-      ID: 131
-      Name: '[]main.structWithMap'
-      ByteSize: 24
-      GoRuntimeType: 469760
-      GoKind: 23
-      RawFields:
-        - Name: array
-          Offset: 0
-          Type: 132 PointerType *main.structWithMap
-        - Name: len
-          Offset: 8
-          Type: 1 BaseType int
-        - Name: cap
-          Offset: 16
-          Type: 1 BaseType int
-      Data: 256 GoSliceDataType []main.structWithMap.array
-    - __kind: PointerType
-      ID: 132
-      Name: '*main.structWithMap'
-      ByteSize: 8
-      GoRuntimeType: 380096
-      GoKind: 22
-      Pointee: 58 StructureType main.structWithMap
-    - __kind: GoMapType
-      ID: 133
-      Name: map[bool]main.node
-      ByteSize: 8
-      GoRuntimeType: 1.11728e+06
-      GoKind: 21
-      HeaderType: 135 GoSwissMapHeaderType map<bool,main.node>
-    - __kind: PointerType
-      ID: 134
-      Name: '*map<bool,main.node>'
-      ByteSize: 8
-      Pointee: 135 GoSwissMapHeaderType map<bool,main.node>
-    - __kind: GoSwissMapHeaderType
-      ID: 135
-      Name: map<bool,main.node>
-      ByteSize: 48
-      GoKind: 25
-      RawFields:
-        - Name: used
-          Offset: 0
-          Type: 26 BaseType uint64
-        - Name: seed
-          Offset: 8
-          Type: 62 BaseType uintptr
-        - Name: dirPtr
-          Offset: 16
-          Type: 136 PointerType **table<bool,main.node>
-        - Name: dirLen
-          Offset: 24
-          Type: 1 BaseType int
-        - Name: globalDepth
-          Offset: 32
-          Type: 4 BaseType uint8
-        - Name: globalShift
-          Offset: 33
-          Type: 4 BaseType uint8
-        - Name: writing
-          Offset: 34
-          Type: 4 BaseType uint8
-        - Name: clearSeq
-          Offset: 40
-          Type: 26 BaseType uint64
-      TablePtrSliceType: 258 GoSliceDataType []*table<bool,main.node>.array
-      GroupType: 141 StructureType noalg.map.group[bool]main.node
-    - __kind: PointerType
-      ID: 136
-      Name: '**table<bool,main.node>'
-      ByteSize: 8
-      Pointee: 137 PointerType *table<bool,main.node>
-    - __kind: PointerType
-      ID: 137
-      Name: '*table<bool,main.node>'
-      ByteSize: 8
-      Pointee: 138 StructureType table<bool,main.node>
-    - __kind: StructureType
-      ID: 138
-      Name: table<bool,main.node>
-      ByteSize: 32
-      GoKind: 25
-      RawFields:
-        - Name: used
-          Offset: 0
-          Type: 22 BaseType uint16
-        - Name: capacity
-          Offset: 2
-          Type: 22 BaseType uint16
-        - Name: growthLeft
-          Offset: 4
-          Type: 22 BaseType uint16
-        - Name: localDepth
-          Offset: 6
-          Type: 4 BaseType uint8
-        - Name: index
-          Offset: 8
-          Type: 1 BaseType int
-        - Name: groups
-          Offset: 16
-          Type: 139 GoSwissMapGroupsType groupReference<bool,main.node>
-    - __kind: GoSwissMapGroupsType
-      ID: 139
-      Name: groupReference<bool,main.node>
-      ByteSize: 16
-      GoKind: 25
-      RawFields:
-        - Name: data
-          Offset: 0
-          Type: 140 PointerType *noalg.map.group[bool]main.node
-        - Name: lengthMask
-          Offset: 8
-          Type: 26 BaseType uint64
-      GroupType: 141 StructureType noalg.map.group[bool]main.node
-      GroupSliceType: 259 GoSliceDataType []noalg.map.group[bool]main.node.array
-    - __kind: PointerType
-      ID: 140
-      Name: '*noalg.map.group[bool]main.node'
-      ByteSize: 8
-      Pointee: 141 StructureType noalg.map.group[bool]main.node
-    - __kind: StructureType
-      ID: 141
-      Name: noalg.map.group[bool]main.node
-      ByteSize: 200
-      GoRuntimeType: 1.277344e+06
-      GoKind: 25
-      RawFields:
-        - Name: ctrl
-          Offset: 0
-          Type: 26 BaseType uint64
-        - Name: slots
-          Offset: 8
-          Type: 142 ArrayType noalg.[8]struct { key bool; elem main.node }
-    - __kind: ArrayType
-      ID: 142
-      Name: noalg.[8]struct { key bool; elem main.node }
-      ByteSize: 192
-      GoRuntimeType: 673280
-      GoKind: 17
-      Count: 8
-      HasCount: true
-      Element: 143 StructureType noalg.struct { key bool; elem main.node }
-    - __kind: StructureType
-      ID: 143
-      Name: noalg.struct { key bool; elem main.node }
-      ByteSize: 24
-      GoRuntimeType: 1.277216e+06
-      GoKind: 25
-      RawFields:
-        - Name: key
-          Offset: 0
-          Type: 11 BaseType bool
-        - Name: elem
-          Offset: 8
-          Type: 144 StructureType main.node
-    - __kind: StructureType
-      ID: 144
-      Name: main.node
-      ByteSize: 16
-      GoRuntimeType: 1.443232e+06
-      GoKind: 25
-      RawFields:
-        - Name: val
-          Offset: 0
-          Type: 1 BaseType int
-        - Name: b
-          Offset: 8
-          Type: 145 PointerType *main.node
-    - __kind: PointerType
-      ID: 145
-      Name: '*main.node'
-      ByteSize: 8
-      GoRuntimeType: 380224
-      GoKind: 22
-      Pointee: 144 StructureType main.node
-    - __kind: GoMapType
-      ID: 146
-      Name: map[int]uint8
-      ByteSize: 8
-      GoRuntimeType: 1.117408e+06
-      GoKind: 21
-      HeaderType: 148 GoSwissMapHeaderType map<int,uint8>
-    - __kind: PointerType
-      ID: 147
-      Name: '*map<int,uint8>'
-      ByteSize: 8
-      Pointee: 148 GoSwissMapHeaderType map<int,uint8>
-    - __kind: GoSwissMapHeaderType
-      ID: 148
-      Name: map<int,uint8>
-      ByteSize: 48
-      GoKind: 25
-      RawFields:
-        - Name: used
-          Offset: 0
-          Type: 26 BaseType uint64
-        - Name: seed
-          Offset: 8
-          Type: 62 BaseType uintptr
-        - Name: dirPtr
-          Offset: 16
-          Type: 149 PointerType **table<int,uint8>
-        - Name: dirLen
-          Offset: 24
-          Type: 1 BaseType int
-        - Name: globalDepth
-          Offset: 32
-          Type: 4 BaseType uint8
-        - Name: globalShift
-          Offset: 33
-          Type: 4 BaseType uint8
-        - Name: writing
-          Offset: 34
-          Type: 4 BaseType uint8
-        - Name: clearSeq
-          Offset: 40
-          Type: 26 BaseType uint64
-      TablePtrSliceType: 260 GoSliceDataType []*table<int,uint8>.array
-      GroupType: 154 StructureType noalg.map.group[int]uint8
-    - __kind: PointerType
-      ID: 149
-      Name: '**table<int,uint8>'
-      ByteSize: 8
-      Pointee: 150 PointerType *table<int,uint8>
-    - __kind: PointerType
-      ID: 150
-      Name: '*table<int,uint8>'
-      ByteSize: 8
-      Pointee: 151 StructureType table<int,uint8>
-    - __kind: StructureType
-      ID: 151
-      Name: table<int,uint8>
-      ByteSize: 32
-      GoKind: 25
-      RawFields:
-        - Name: used
-          Offset: 0
-          Type: 22 BaseType uint16
-        - Name: capacity
-          Offset: 2
-          Type: 22 BaseType uint16
-        - Name: growthLeft
-          Offset: 4
-          Type: 22 BaseType uint16
-        - Name: localDepth
-          Offset: 6
-          Type: 4 BaseType uint8
-        - Name: index
-          Offset: 8
-          Type: 1 BaseType int
-        - Name: groups
-          Offset: 16
-          Type: 152 GoSwissMapGroupsType groupReference<int,uint8>
-    - __kind: GoSwissMapGroupsType
-      ID: 152
-      Name: groupReference<int,uint8>
-      ByteSize: 16
-      GoKind: 25
-      RawFields:
-        - Name: data
-          Offset: 0
-          Type: 153 PointerType *noalg.map.group[int]uint8
-        - Name: lengthMask
-          Offset: 8
-          Type: 26 BaseType uint64
-      GroupType: 154 StructureType noalg.map.group[int]uint8
-      GroupSliceType: 261 GoSliceDataType []noalg.map.group[int]uint8.array
-    - __kind: PointerType
-      ID: 153
-      Name: '*noalg.map.group[int]uint8'
-      ByteSize: 8
-      Pointee: 154 StructureType noalg.map.group[int]uint8
-    - __kind: StructureType
-      ID: 154
-      Name: noalg.map.group[int]uint8
-      ByteSize: 136
-      GoRuntimeType: 1.2776e+06
-      GoKind: 25
-      RawFields:
-        - Name: ctrl
-          Offset: 0
-          Type: 26 BaseType uint64
-        - Name: slots
-          Offset: 8
-          Type: 155 ArrayType noalg.[8]struct { key int; elem uint8 }
-    - __kind: ArrayType
-      ID: 155
-      Name: noalg.[8]struct { key int; elem uint8 }
-      ByteSize: 128
-      GoRuntimeType: 673376
-      GoKind: 17
-      Count: 8
-      HasCount: true
-      Element: 156 StructureType noalg.struct { key int; elem uint8 }
-    - __kind: StructureType
-      ID: 156
-      Name: noalg.struct { key int; elem uint8 }
-      ByteSize: 16
-      GoRuntimeType: 1.277472e+06
-      GoKind: 25
-      RawFields:
-        - Name: key
-          Offset: 0
-          Type: 1 BaseType int
-        - Name: elem
-          Offset: 8
-          Type: 4 BaseType uint8
-    - __kind: GoMapType
-      ID: 157
-      Name: map[uint8]uint8
-      ByteSize: 8
-      GoRuntimeType: 1.118176e+06
-      GoKind: 21
-      HeaderType: 159 GoSwissMapHeaderType map<uint8,uint8>
-    - __kind: PointerType
-      ID: 158
-      Name: '*map<uint8,uint8>'
-      ByteSize: 8
-      Pointee: 159 GoSwissMapHeaderType map<uint8,uint8>
-    - __kind: GoSwissMapHeaderType
-      ID: 159
-      Name: map<uint8,uint8>
-      ByteSize: 48
-      GoKind: 25
-      RawFields:
-        - Name: used
-          Offset: 0
-          Type: 26 BaseType uint64
-        - Name: seed
-          Offset: 8
-          Type: 62 BaseType uintptr
-        - Name: dirPtr
-          Offset: 16
-          Type: 160 PointerType **table<uint8,uint8>
-        - Name: dirLen
-          Offset: 24
-          Type: 1 BaseType int
-        - Name: globalDepth
-          Offset: 32
-          Type: 4 BaseType uint8
-        - Name: globalShift
-          Offset: 33
-          Type: 4 BaseType uint8
-        - Name: writing
-          Offset: 34
-          Type: 4 BaseType uint8
-        - Name: clearSeq
-          Offset: 40
-          Type: 26 BaseType uint64
-      TablePtrSliceType: 262 GoSliceDataType []*table<uint8,uint8>.array
-      GroupType: 165 StructureType noalg.map.group[uint8]uint8
-    - __kind: PointerType
-      ID: 160
-      Name: '**table<uint8,uint8>'
-      ByteSize: 8
-      Pointee: 161 PointerType *table<uint8,uint8>
-    - __kind: PointerType
-      ID: 161
-      Name: '*table<uint8,uint8>'
-      ByteSize: 8
-      Pointee: 162 StructureType table<uint8,uint8>
-    - __kind: StructureType
-      ID: 162
-      Name: table<uint8,uint8>
-      ByteSize: 32
-      GoKind: 25
-      RawFields:
-        - Name: used
-          Offset: 0
-          Type: 22 BaseType uint16
-        - Name: capacity
-          Offset: 2
-          Type: 22 BaseType uint16
-        - Name: growthLeft
-          Offset: 4
-          Type: 22 BaseType uint16
-        - Name: localDepth
-          Offset: 6
-          Type: 4 BaseType uint8
-        - Name: index
-          Offset: 8
-          Type: 1 BaseType int
-        - Name: groups
-          Offset: 16
-          Type: 163 GoSwissMapGroupsType groupReference<uint8,uint8>
-    - __kind: GoSwissMapGroupsType
-      ID: 163
-      Name: groupReference<uint8,uint8>
-      ByteSize: 16
-      GoKind: 25
-      RawFields:
-        - Name: data
-          Offset: 0
-          Type: 164 PointerType *noalg.map.group[uint8]uint8
-        - Name: lengthMask
-          Offset: 8
-          Type: 26 BaseType uint64
-      GroupType: 165 StructureType noalg.map.group[uint8]uint8
-      GroupSliceType: 263 GoSliceDataType []noalg.map.group[uint8]uint8.array
-    - __kind: PointerType
-      ID: 164
-      Name: '*noalg.map.group[uint8]uint8'
-      ByteSize: 8
-      Pointee: 165 StructureType noalg.map.group[uint8]uint8
-    - __kind: StructureType
-      ID: 165
-      Name: noalg.map.group[uint8]uint8
-      ByteSize: 24
-      GoRuntimeType: 1.279136e+06
-      GoKind: 25
-      RawFields:
-        - Name: ctrl
-          Offset: 0
-          Type: 26 BaseType uint64
-        - Name: slots
-          Offset: 8
-          Type: 166 ArrayType noalg.[8]struct { key uint8; elem uint8 }
-    - __kind: ArrayType
-      ID: 166
-      Name: noalg.[8]struct { key uint8; elem uint8 }
-      ByteSize: 16
-      GoRuntimeType: 673952
-      GoKind: 17
-      Count: 8
-      HasCount: true
-      Element: 167 StructureType noalg.struct { key uint8; elem uint8 }
-    - __kind: StructureType
-      ID: 167
-      Name: noalg.struct { key uint8; elem uint8 }
-      ByteSize: 2
-      GoRuntimeType: 1.279008e+06
-      GoKind: 25
-      RawFields:
-        - Name: key
-          Offset: 0
-          Type: 4 BaseType uint8
-        - Name: elem
-          Offset: 1
-          Type: 4 BaseType uint8
-    - __kind: GoMapType
-      ID: 168
-      Name: map[uint8][4]int
-      ByteSize: 8
-      GoRuntimeType: 1.118048e+06
-      GoKind: 21
-      HeaderType: 170 GoSwissMapHeaderType map<uint8,[4]int>
-    - __kind: PointerType
-      ID: 169
-      Name: '*map<uint8,[4]int>'
-      ByteSize: 8
-      Pointee: 170 GoSwissMapHeaderType map<uint8,[4]int>
-    - __kind: GoSwissMapHeaderType
-      ID: 170
-      Name: map<uint8,[4]int>
-      ByteSize: 48
-      GoKind: 25
-      RawFields:
-        - Name: used
-          Offset: 0
-          Type: 26 BaseType uint64
-        - Name: seed
-          Offset: 8
-          Type: 62 BaseType uintptr
-        - Name: dirPtr
-          Offset: 16
-          Type: 171 PointerType **table<uint8,[4]int>
-        - Name: dirLen
-          Offset: 24
-          Type: 1 BaseType int
-        - Name: globalDepth
-          Offset: 32
-          Type: 4 BaseType uint8
-        - Name: globalShift
-          Offset: 33
-          Type: 4 BaseType uint8
-        - Name: writing
-          Offset: 34
-          Type: 4 BaseType uint8
-        - Name: clearSeq
-          Offset: 40
-          Type: 26 BaseType uint64
-      TablePtrSliceType: 264 GoSliceDataType []*table<uint8,[4]int>.array
-      GroupType: 176 StructureType noalg.map.group[uint8][4]int
-    - __kind: PointerType
-      ID: 171
-      Name: '**table<uint8,[4]int>'
-      ByteSize: 8
-      Pointee: 172 PointerType *table<uint8,[4]int>
-    - __kind: PointerType
-      ID: 172
-      Name: '*table<uint8,[4]int>'
-      ByteSize: 8
-      Pointee: 173 StructureType table<uint8,[4]int>
-    - __kind: StructureType
-      ID: 173
-      Name: table<uint8,[4]int>
-      ByteSize: 32
-      GoKind: 25
-      RawFields:
-        - Name: used
-          Offset: 0
-          Type: 22 BaseType uint16
-        - Name: capacity
-          Offset: 2
-          Type: 22 BaseType uint16
-        - Name: growthLeft
-          Offset: 4
-          Type: 22 BaseType uint16
-        - Name: localDepth
-          Offset: 6
-          Type: 4 BaseType uint8
-        - Name: index
-          Offset: 8
-          Type: 1 BaseType int
-        - Name: groups
-          Offset: 16
-          Type: 174 GoSwissMapGroupsType groupReference<uint8,[4]int>
-    - __kind: GoSwissMapGroupsType
-      ID: 174
-      Name: groupReference<uint8,[4]int>
-      ByteSize: 16
-      GoKind: 25
-      RawFields:
-        - Name: data
-          Offset: 0
-          Type: 175 PointerType *noalg.map.group[uint8][4]int
-        - Name: lengthMask
-          Offset: 8
-          Type: 26 BaseType uint64
-      GroupType: 176 StructureType noalg.map.group[uint8][4]int
-      GroupSliceType: 265 GoSliceDataType []noalg.map.group[uint8][4]int.array
-    - __kind: PointerType
-      ID: 175
-      Name: '*noalg.map.group[uint8][4]int'
-      ByteSize: 8
-      Pointee: 176 StructureType noalg.map.group[uint8][4]int
-    - __kind: StructureType
-      ID: 176
-      Name: noalg.map.group[uint8][4]int
-      ByteSize: 328
-      GoRuntimeType: 1.27888e+06
-      GoKind: 25
-      RawFields:
-        - Name: ctrl
-          Offset: 0
-          Type: 26 BaseType uint64
-        - Name: slots
-          Offset: 8
-          Type: 177 ArrayType noalg.[8]struct { key uint8; elem [4]int }
-    - __kind: ArrayType
-      ID: 177
-      Name: noalg.[8]struct { key uint8; elem [4]int }
-      ByteSize: 320
-      GoRuntimeType: 673856
-      GoKind: 17
-      Count: 8
-      HasCount: true
-      Element: 178 StructureType noalg.struct { key uint8; elem [4]int }
-    - __kind: StructureType
-      ID: 178
-      Name: noalg.struct { key uint8; elem [4]int }
-      ByteSize: 40
-      GoRuntimeType: 1.278752e+06
-      GoKind: 25
-      RawFields:
-        - Name: key
-          Offset: 0
-          Type: 4 BaseType uint8
-        - Name: elem
-          Offset: 8
-          Type: 179 ArrayType [4]int
-    - __kind: ArrayType
-      ID: 179
-      Name: '[4]int'
-      ByteSize: 32
-      GoRuntimeType: 672704
-      GoKind: 17
-      Count: 4
-      HasCount: true
-      Element: 1 BaseType int
-    - __kind: GoMapType
-      ID: 180
-      Name: map[[4]int]uint8
-      ByteSize: 8
-      GoRuntimeType: 1.117024e+06
-      GoKind: 21
-      HeaderType: 182 GoSwissMapHeaderType map<[4]int,uint8>
-    - __kind: PointerType
-      ID: 181
-      Name: '*map<[4]int,uint8>'
-      ByteSize: 8
-      Pointee: 182 GoSwissMapHeaderType map<[4]int,uint8>
-    - __kind: GoSwissMapHeaderType
-      ID: 182
-      Name: map<[4]int,uint8>
-      ByteSize: 48
-      GoKind: 25
-      RawFields:
-        - Name: used
-          Offset: 0
-          Type: 26 BaseType uint64
-        - Name: seed
-          Offset: 8
-          Type: 62 BaseType uintptr
-        - Name: dirPtr
-          Offset: 16
-          Type: 183 PointerType **table<[4]int,uint8>
-        - Name: dirLen
-          Offset: 24
-          Type: 1 BaseType int
-        - Name: globalDepth
-          Offset: 32
-          Type: 4 BaseType uint8
-        - Name: globalShift
-          Offset: 33
-          Type: 4 BaseType uint8
-        - Name: writing
-          Offset: 34
-          Type: 4 BaseType uint8
-        - Name: clearSeq
-          Offset: 40
-          Type: 26 BaseType uint64
-      TablePtrSliceType: 266 GoSliceDataType []*table<[4]int,uint8>.array
-      GroupType: 188 StructureType noalg.map.group[[4]int]uint8
+      Pointee: 195 PointerType *table<[4]int,[4]int>
     - __kind: PointerType
       ID: 183
       Name: '**table<[4]int,uint8>'
       ByteSize: 8
       Pointee: 184 PointerType *table<[4]int,uint8>
     - __kind: PointerType
-      ID: 184
-      Name: '*table<[4]int,uint8>'
+      ID: 109
+      Name: '**table<[4]string,[2]int>'
       ByteSize: 8
-      Pointee: 185 StructureType table<[4]int,uint8>
-    - __kind: StructureType
-      ID: 185
-      Name: table<[4]int,uint8>
-      ByteSize: 32
-      GoKind: 25
-      RawFields:
-        - Name: used
-          Offset: 0
-          Type: 22 BaseType uint16
-        - Name: capacity
-          Offset: 2
-          Type: 22 BaseType uint16
-        - Name: growthLeft
-          Offset: 4
-          Type: 22 BaseType uint16
-        - Name: localDepth
-          Offset: 6
-          Type: 4 BaseType uint8
-        - Name: index
-          Offset: 8
-          Type: 1 BaseType int
-        - Name: groups
-          Offset: 16
-          Type: 186 GoSwissMapGroupsType groupReference<[4]int,uint8>
-    - __kind: GoSwissMapGroupsType
-      ID: 186
-      Name: groupReference<[4]int,uint8>
-      ByteSize: 16
-      GoKind: 25
-      RawFields:
-        - Name: data
-          Offset: 0
-          Type: 187 PointerType *noalg.map.group[[4]int]uint8
-        - Name: lengthMask
-          Offset: 8
-          Type: 26 BaseType uint64
-      GroupType: 188 StructureType noalg.map.group[[4]int]uint8
-      GroupSliceType: 267 GoSliceDataType []noalg.map.group[[4]int]uint8.array
+      Pointee: 110 PointerType *table<[4]string,[2]int>
     - __kind: PointerType
-      ID: 187
-      Name: '*noalg.map.group[[4]int]uint8'
+      ID: 136
+      Name: '**table<bool,main.node>'
       ByteSize: 8
-      Pointee: 188 StructureType noalg.map.group[[4]int]uint8
-    - __kind: StructureType
-      ID: 188
-      Name: noalg.map.group[[4]int]uint8
-      ByteSize: 328
-      GoRuntimeType: 1.276832e+06
-      GoKind: 25
-      RawFields:
-        - Name: ctrl
-          Offset: 0
-          Type: 26 BaseType uint64
-        - Name: slots
-          Offset: 8
-          Type: 189 ArrayType noalg.[8]struct { key [4]int; elem uint8 }
-    - __kind: ArrayType
-      ID: 189
-      Name: noalg.[8]struct { key [4]int; elem uint8 }
-      ByteSize: 320
-      GoRuntimeType: 672896
-      GoKind: 17
-      Count: 8
-      HasCount: true
-      Element: 190 StructureType noalg.struct { key [4]int; elem uint8 }
-    - __kind: StructureType
-      ID: 190
-      Name: noalg.struct { key [4]int; elem uint8 }
-      ByteSize: 40
-      GoRuntimeType: 1.276704e+06
-      GoKind: 25
-      RawFields:
-        - Name: key
-          Offset: 0
-          Type: 179 ArrayType [4]int
-        - Name: elem
-          Offset: 32
-          Type: 4 BaseType uint8
-    - __kind: GoMapType
-      ID: 191
-      Name: map[[4]int][4]int
-      ByteSize: 8
-      GoRuntimeType: 1.116896e+06
-      GoKind: 21
-      HeaderType: 193 GoSwissMapHeaderType map<[4]int,[4]int>
+      Pointee: 137 PointerType *table<bool,main.node>
     - __kind: PointerType
-      ID: 192
-      Name: '*map<[4]int,[4]int>'
+      ID: 63
+      Name: '**table<int,int>'
       ByteSize: 8
-      Pointee: 193 GoSwissMapHeaderType map<[4]int,[4]int>
-    - __kind: GoSwissMapHeaderType
-      ID: 193
-      Name: map<[4]int,[4]int>
-      ByteSize: 48
-      GoKind: 25
-      RawFields:
-        - Name: used
-          Offset: 0
-          Type: 26 BaseType uint64
-        - Name: seed
-          Offset: 8
-          Type: 62 BaseType uintptr
-        - Name: dirPtr
-          Offset: 16
-          Type: 194 PointerType **table<[4]int,[4]int>
-        - Name: dirLen
-          Offset: 24
-          Type: 1 BaseType int
-        - Name: globalDepth
-          Offset: 32
-          Type: 4 BaseType uint8
-        - Name: globalShift
-          Offset: 33
-          Type: 4 BaseType uint8
-        - Name: writing
-          Offset: 34
-          Type: 4 BaseType uint8
-        - Name: clearSeq
-          Offset: 40
-          Type: 26 BaseType uint64
-      TablePtrSliceType: 268 GoSliceDataType []*table<[4]int,[4]int>.array
-      GroupType: 199 StructureType noalg.map.group[[4]int][4]int
+      Pointee: 64 PointerType *table<int,int>
     - __kind: PointerType
-      ID: 194
-      Name: '**table<[4]int,[4]int>'
+      ID: 149
+      Name: '**table<int,uint8>'
       ByteSize: 8
-      Pointee: 195 PointerType *table<[4]int,[4]int>
+      Pointee: 150 PointerType *table<int,uint8>
     - __kind: PointerType
-      ID: 195
-      Name: '*table<[4]int,[4]int>'
+      ID: 123
+      Name: '**table<string,[]main.structWithMap>'
       ByteSize: 8
-      Pointee: 196 StructureType table<[4]int,[4]int>
-    - __kind: StructureType
-      ID: 196
-      Name: table<[4]int,[4]int>
-      ByteSize: 32
-      GoKind: 25
-      RawFields:
-        - Name: used
-          Offset: 0
-          Type: 22 BaseType uint16
-        - Name: capacity
-          Offset: 2
-          Type: 22 BaseType uint16
-        - Name: growthLeft
-          Offset: 4
-          Type: 22 BaseType uint16
-        - Name: localDepth
-          Offset: 6
-          Type: 4 BaseType uint8
-        - Name: index
-          Offset: 8
-          Type: 1 BaseType int
-        - Name: groups
-          Offset: 16
-          Type: 197 GoSwissMapGroupsType groupReference<[4]int,[4]int>
-    - __kind: GoSwissMapGroupsType
-      ID: 197
-      Name: groupReference<[4]int,[4]int>
-      ByteSize: 16
-      GoKind: 25
-      RawFields:
-        - Name: data
-          Offset: 0
-          Type: 198 PointerType *noalg.map.group[[4]int][4]int
-        - Name: lengthMask
-          Offset: 8
-          Type: 26 BaseType uint64
-      GroupType: 199 StructureType noalg.map.group[[4]int][4]int
-      GroupSliceType: 269 GoSliceDataType []noalg.map.group[[4]int][4]int.array
+      Pointee: 124 PointerType *table<string,[]main.structWithMap>
     - __kind: PointerType
-      ID: 198
-      Name: '*noalg.map.group[[4]int][4]int'
+      ID: 97
+      Name: '**table<string,[]string>'
       ByteSize: 8
-      Pointee: 199 StructureType noalg.map.group[[4]int][4]int
-    - __kind: StructureType
-      ID: 199
-      Name: noalg.map.group[[4]int][4]int
-      ByteSize: 520
-      GoRuntimeType: 1.276576e+06
-      GoKind: 25
-      RawFields:
-        - Name: ctrl
-          Offset: 0
-          Type: 26 BaseType uint64
-        - Name: slots
-          Offset: 8
-          Type: 200 ArrayType noalg.[8]struct { key [4]int; elem [4]int }
-    - __kind: ArrayType
-      ID: 200
-      Name: noalg.[8]struct { key [4]int; elem [4]int }
-      ByteSize: 512
-      GoRuntimeType: 672800
-      GoKind: 17
-      Count: 8
-      HasCount: true
-      Element: 201 StructureType noalg.struct { key [4]int; elem [4]int }
-    - __kind: StructureType
-      ID: 201
-      Name: noalg.struct { key [4]int; elem [4]int }
-      ByteSize: 64
-      GoRuntimeType: 1.276448e+06
-      GoKind: 25
-      RawFields:
-        - Name: key
-          Offset: 0
-          Type: 179 ArrayType [4]int
-        - Name: elem
-          Offset: 32
-          Type: 179 ArrayType [4]int
-    - __kind: GoChannelType
-      ID: 202
-      Name: chan bool
-      GoRuntimeType: 587168
-      GoKind: 18
+      Pointee: 98 PointerType *table<string,[]string>
     - __kind: PointerType
-      ID: 203
-      Name: '*main.structWithTwoValues'
+      ID: 86
+      Name: '**table<string,int>'
       ByteSize: 8
-      GoKind: 22
-      Pointee: 204 StructureType main.structWithTwoValues
-    - __kind: StructureType
-      ID: 204
-      Name: main.structWithTwoValues
-      ByteSize: 16
-      GoKind: 25
-      RawFields:
-        - Name: a
-          Offset: 0
-          Type: 20 BaseType uint
-        - Name: b
-          Offset: 8
-          Type: 11 BaseType bool
+      Pointee: 87 PointerType *table<string,int>
     - __kind: PointerType
-      ID: 205
-      Name: '*uint'
+      ID: 74
+      Name: '**table<string,main.nestedStruct>'
       ByteSize: 8
-      GoRuntimeType: 385792
-      GoKind: 22
-      Pointee: 20 BaseType uint
+      Pointee: 75 PointerType *table<string,main.nestedStruct>
+    - __kind: PointerType
+      ID: 171
+      Name: '**table<uint8,[4]int>'
+      ByteSize: 8
+      Pointee: 172 PointerType *table<uint8,[4]int>
+    - __kind: PointerType
+      ID: 160
+      Name: '**table<uint8,uint8>'
+      ByteSize: 8
+      Pointee: 161 PointerType *table<uint8,uint8>
+    - __kind: PointerType
+      ID: 241
+      Name: '*[]*string.array'
+      ByteSize: 8
+      Pointee: 240 GoSliceDataType []*string.array
+    - __kind: PointerType
+      ID: 275
+      Name: '*[][]uint.array'
+      ByteSize: 8
+      Pointee: 274 GoSliceDataType [][]uint.array
+    - __kind: PointerType
+      ID: 279
+      Name: '*[]bool.array'
+      ByteSize: 8
+      Pointee: 278 GoSliceDataType []bool.array
+    - __kind: PointerType
+      ID: 257
+      Name: '*[]main.structWithMap.array'
+      ByteSize: 8
+      Pointee: 256 GoSliceDataType []main.structWithMap.array
+    - __kind: PointerType
+      ID: 277
+      Name: '*[]main.structWithNoStrings.array'
+      ByteSize: 8
+      Pointee: 276 GoSliceDataType []main.structWithNoStrings.array
+    - __kind: PointerType
+      ID: 251
+      Name: '*[]string.array'
+      ByteSize: 8
+      Pointee: 250 GoSliceDataType []string.array
+    - __kind: PointerType
+      ID: 212
+      Name: '*[]uint'
+      ByteSize: 8
+      Pointee: 210 GoSliceHeaderType []uint
+    - __kind: PointerType
+      ID: 273
+      Name: '*[]uint.array'
+      ByteSize: 8
+      Pointee: 272 GoSliceDataType []uint.array
+    - __kind: PointerType
+      ID: 281
+      Name: '*[]uint16.array'
+      ByteSize: 8
+      Pointee: 280 GoSliceDataType []uint16.array
     - __kind: PointerType
       ID: 206
       Name: '*bool'
@@ -5377,279 +3218,6 @@ Types:
       GoRuntimeType: 386176
       GoKind: 22
       Pointee: 11 BaseType bool
-    - __kind: PointerType
-      ID: 207
-      Name: '*main.t'
-      ByteSize: 8
-      GoKind: 22
-      Pointee: 208 GoSliceHeaderType main.t
-    - __kind: GoSliceHeaderType
-      ID: 208
-      Name: main.t
-      ByteSize: 24
-      GoKind: 23
-      RawFields:
-        - Name: array
-          Offset: 0
-          Type: 209 PointerType **main.t
-        - Name: len
-          Offset: 8
-          Type: 1 BaseType int
-        - Name: cap
-          Offset: 16
-          Type: 1 BaseType int
-      Data: 270 GoSliceDataType main.t.array
-    - __kind: PointerType
-      ID: 209
-      Name: '**main.t'
-      ByteSize: 8
-      Pointee: 207 PointerType *main.t
-    - __kind: GoSliceHeaderType
-      ID: 210
-      Name: '[]uint'
-      ByteSize: 24
-      GoRuntimeType: 478016
-      GoKind: 23
-      RawFields:
-        - Name: array
-          Offset: 0
-          Type: 205 PointerType *uint
-        - Name: len
-          Offset: 8
-          Type: 1 BaseType int
-        - Name: cap
-          Offset: 16
-          Type: 1 BaseType int
-      Data: 272 GoSliceDataType []uint.array
-    - __kind: GoSliceHeaderType
-      ID: 211
-      Name: '[][]uint'
-      ByteSize: 24
-      GoKind: 23
-      RawFields:
-        - Name: array
-          Offset: 0
-          Type: 212 PointerType *[]uint
-        - Name: len
-          Offset: 8
-          Type: 1 BaseType int
-        - Name: cap
-          Offset: 16
-          Type: 1 BaseType int
-      Data: 274 GoSliceDataType [][]uint.array
-    - __kind: PointerType
-      ID: 212
-      Name: '*[]uint'
-      ByteSize: 8
-      Pointee: 210 GoSliceHeaderType []uint
-    - __kind: GoSliceHeaderType
-      ID: 213
-      Name: '[]main.structWithNoStrings'
-      ByteSize: 24
-      GoKind: 23
-      RawFields:
-        - Name: array
-          Offset: 0
-          Type: 214 PointerType *main.structWithNoStrings
-        - Name: len
-          Offset: 8
-          Type: 1 BaseType int
-        - Name: cap
-          Offset: 16
-          Type: 1 BaseType int
-      Data: 276 GoSliceDataType []main.structWithNoStrings.array
-    - __kind: PointerType
-      ID: 214
-      Name: '*main.structWithNoStrings'
-      ByteSize: 8
-      Pointee: 215 StructureType main.structWithNoStrings
-    - __kind: StructureType
-      ID: 215
-      Name: main.structWithNoStrings
-      ByteSize: 2
-      GoKind: 25
-      RawFields:
-        - Name: aUint8
-          Offset: 0
-          Type: 4 BaseType uint8
-        - Name: aBool
-          Offset: 1
-          Type: 11 BaseType bool
-    - __kind: GoSliceHeaderType
-      ID: 216
-      Name: '[]bool'
-      ByteSize: 24
-      GoRuntimeType: 478400
-      GoKind: 23
-      RawFields:
-        - Name: array
-          Offset: 0
-          Type: 206 PointerType *bool
-        - Name: len
-          Offset: 8
-          Type: 1 BaseType int
-        - Name: cap
-          Offset: 16
-          Type: 1 BaseType int
-      Data: 278 GoSliceDataType []bool.array
-    - __kind: GoSliceHeaderType
-      ID: 217
-      Name: '[]uint16'
-      ByteSize: 24
-      GoRuntimeType: 477376
-      GoKind: 23
-      RawFields:
-        - Name: array
-          Offset: 0
-          Type: 218 PointerType *uint16
-        - Name: len
-          Offset: 8
-          Type: 1 BaseType int
-        - Name: cap
-          Offset: 16
-          Type: 1 BaseType int
-      Data: 280 GoSliceDataType []uint16.array
-    - __kind: PointerType
-      ID: 218
-      Name: '*uint16'
-      ByteSize: 8
-      GoRuntimeType: 385408
-      GoKind: 22
-      Pointee: 22 BaseType uint16
-    - __kind: StructureType
-      ID: 219
-      Name: main.threeStringStruct
-      ByteSize: 48
-      GoKind: 25
-      RawFields:
-        - Name: a
-          Offset: 0
-          Type: 8 GoStringHeaderType string
-        - Name: b
-          Offset: 16
-          Type: 8 GoStringHeaderType string
-        - Name: c
-          Offset: 32
-          Type: 8 GoStringHeaderType string
-    - __kind: PointerType
-      ID: 220
-      Name: '*main.threeStringStruct'
-      ByteSize: 8
-      GoKind: 22
-      Pointee: 219 StructureType main.threeStringStruct
-    - __kind: PointerType
-      ID: 221
-      Name: '*main.oneStringStruct'
-      ByteSize: 8
-      GoKind: 22
-      Pointee: 222 StructureType main.oneStringStruct
-    - __kind: StructureType
-      ID: 222
-      Name: main.oneStringStruct
-      ByteSize: 16
-      GoKind: 25
-      RawFields:
-        - Name: a
-          Offset: 0
-          Type: 8 GoStringHeaderType string
-    - __kind: StructureType
-      ID: 223
-      Name: main.aStruct
-      ByteSize: 56
-      GoKind: 25
-      RawFields:
-        - Name: aBool
-          Offset: 0
-          Type: 11 BaseType bool
-        - Name: aString
-          Offset: 8
-          Type: 8 GoStringHeaderType string
-        - Name: aNumber
-          Offset: 24
-          Type: 1 BaseType int
-        - Name: nested
-          Offset: 32
-          Type: 82 StructureType main.nestedStruct
-    - __kind: StructureType
-      ID: 224
-      Name: main.emptyStruct
-      GoKind: 25
-      RawFields: []
-    - __kind: PointerType
-      ID: 225
-      Name: '*uintptr'
-      ByteSize: 8
-      GoRuntimeType: 385856
-      GoKind: 22
-      Pointee: 62 BaseType uintptr
-    - __kind: PointerType
-      ID: 226
-      Name: '*int32'
-      ByteSize: 8
-      GoRuntimeType: 385472
-      GoKind: 22
-      Pointee: 6 BaseType int32
-    - __kind: PointerType
-      ID: 227
-      Name: '*uint32'
-      ByteSize: 8
-      GoRuntimeType: 385536
-      GoKind: 22
-      Pointee: 24 BaseType uint32
-    - __kind: BaseType
-      ID: 228
-      Name: complex64
-      ByteSize: 8
-      GoRuntimeType: 575584
-      GoKind: 15
-    - __kind: BaseType
-      ID: 229
-      Name: complex128
-      ByteSize: 16
-      GoRuntimeType: 575648
-      GoKind: 16
-    - __kind: PointerType
-      ID: 230
-      Name: '*float64'
-      ByteSize: 8
-      GoRuntimeType: 386112
-      GoKind: 22
-      Pointee: 31 BaseType float64
-    - __kind: PointerType
-      ID: 231
-      Name: '*int64'
-      ByteSize: 8
-      GoRuntimeType: 385600
-      GoKind: 22
-      Pointee: 18 BaseType int64
-    - __kind: PointerType
-      ID: 232
-      Name: '*int'
-      ByteSize: 8
-      GoRuntimeType: 385728
-      GoKind: 22
-      Pointee: 1 BaseType int
-    - __kind: PointerType
-      ID: 233
-      Name: '*uint64'
-      ByteSize: 8
-      GoRuntimeType: 385664
-      GoKind: 22
-      Pointee: 26 BaseType uint64
-    - __kind: PointerType
-      ID: 234
-      Name: '*int16'
-      ByteSize: 8
-      GoRuntimeType: 385344
-      GoKind: 22
-      Pointee: 16 BaseType int16
-    - __kind: PointerType
-      ID: 235
-      Name: '*int8'
-      ByteSize: 8
-      GoRuntimeType: 385216
-      GoKind: 22
-      Pointee: 14 BaseType int8
     - __kind: PointerType
       ID: 236
       Name: '*error'
@@ -5664,270 +3232,436 @@ Types:
       GoRuntimeType: 386048
       GoKind: 22
       Pointee: 30 BaseType float32
-    - __kind: GoStringDataType
-      ID: 238
-      Name: string.str
-      ByteSize: 2048
     - __kind: PointerType
-      ID: 239
-      Name: '*string.str'
+      ID: 230
+      Name: '*float64'
       ByteSize: 8
-      Pointee: 238 GoStringDataType string.str
-    - __kind: GoSliceDataType
-      ID: 240
-      Name: '[]*string.array'
-      ByteSize: 2048
-      Element: 36 PointerType *string
+      GoRuntimeType: 386112
+      GoKind: 22
+      Pointee: 31 BaseType float64
     - __kind: PointerType
-      ID: 241
-      Name: '*[]*string.array'
+      ID: 232
+      Name: '*int'
       ByteSize: 8
-      Pointee: 240 GoSliceDataType []*string.array
-    - __kind: GoSliceDataType
-      ID: 242
-      Name: '[]*table<int,int>.array'
-      ByteSize: 8192
-      Element: 64 PointerType *table<int,int>
-    - __kind: GoSliceDataType
-      ID: 243
-      Name: '[]noalg.map.group[int]int.array'
-      ByteSize: 2048
-      Element: 68 StructureType noalg.map.group[int]int
-    - __kind: GoSliceDataType
-      ID: 244
-      Name: '[]*table<string,main.nestedStruct>.array'
-      ByteSize: 8192
-      Element: 75 PointerType *table<string,main.nestedStruct>
-    - __kind: GoSliceDataType
-      ID: 245
-      Name: '[]noalg.map.group[string]main.nestedStruct.array'
-      ByteSize: 2048
-      Element: 79 StructureType noalg.map.group[string]main.nestedStruct
-    - __kind: GoSliceDataType
-      ID: 246
-      Name: '[]*table<string,int>.array'
-      ByteSize: 8192
-      Element: 87 PointerType *table<string,int>
-    - __kind: GoSliceDataType
-      ID: 247
-      Name: '[]noalg.map.group[string]int.array'
-      ByteSize: 2048
-      Element: 91 StructureType noalg.map.group[string]int
-    - __kind: GoSliceDataType
-      ID: 248
-      Name: '[]*table<string,[]string>.array'
-      ByteSize: 8192
-      Element: 98 PointerType *table<string,[]string>
-    - __kind: GoSliceDataType
-      ID: 249
-      Name: '[]noalg.map.group[string][]string.array'
-      ByteSize: 2048
-      Element: 102 StructureType noalg.map.group[string][]string
-    - __kind: GoSliceDataType
-      ID: 250
-      Name: '[]string.array'
-      ByteSize: 2048
-      Element: 8 GoStringHeaderType string
+      GoRuntimeType: 385728
+      GoKind: 22
+      Pointee: 1 BaseType int
     - __kind: PointerType
-      ID: 251
-      Name: '*[]string.array'
+      ID: 234
+      Name: '*int16'
       ByteSize: 8
-      Pointee: 250 GoSliceDataType []string.array
-    - __kind: GoSliceDataType
-      ID: 252
-      Name: '[]*table<[4]string,[2]int>.array'
-      ByteSize: 8192
-      Element: 110 PointerType *table<[4]string,[2]int>
-    - __kind: GoSliceDataType
-      ID: 253
-      Name: '[]noalg.map.group[[4]string][2]int.array'
-      ByteSize: 2048
-      Element: 114 StructureType noalg.map.group[[4]string][2]int
-    - __kind: GoSliceDataType
-      ID: 254
-      Name: '[]*table<string,[]main.structWithMap>.array'
-      ByteSize: 8192
-      Element: 124 PointerType *table<string,[]main.structWithMap>
-    - __kind: GoSliceDataType
-      ID: 255
-      Name: '[]noalg.map.group[string][]main.structWithMap.array'
-      ByteSize: 2048
-      Element: 128 StructureType noalg.map.group[string][]main.structWithMap
-    - __kind: GoSliceDataType
-      ID: 256
-      Name: '[]main.structWithMap.array'
-      ByteSize: 2048
-      Element: 58 StructureType main.structWithMap
+      GoRuntimeType: 385344
+      GoKind: 22
+      Pointee: 16 BaseType int16
     - __kind: PointerType
-      ID: 257
-      Name: '*[]main.structWithMap.array'
+      ID: 226
+      Name: '*int32'
       ByteSize: 8
-      Pointee: 256 GoSliceDataType []main.structWithMap.array
-    - __kind: GoSliceDataType
-      ID: 258
-      Name: '[]*table<bool,main.node>.array'
-      ByteSize: 8192
-      Element: 137 PointerType *table<bool,main.node>
-    - __kind: GoSliceDataType
-      ID: 259
-      Name: '[]noalg.map.group[bool]main.node.array'
-      ByteSize: 2048
-      Element: 141 StructureType noalg.map.group[bool]main.node
-    - __kind: GoSliceDataType
-      ID: 260
-      Name: '[]*table<int,uint8>.array'
-      ByteSize: 8192
-      Element: 150 PointerType *table<int,uint8>
-    - __kind: GoSliceDataType
-      ID: 261
-      Name: '[]noalg.map.group[int]uint8.array'
-      ByteSize: 2048
-      Element: 154 StructureType noalg.map.group[int]uint8
-    - __kind: GoSliceDataType
-      ID: 262
-      Name: '[]*table<uint8,uint8>.array'
-      ByteSize: 8192
-      Element: 161 PointerType *table<uint8,uint8>
-    - __kind: GoSliceDataType
-      ID: 263
-      Name: '[]noalg.map.group[uint8]uint8.array'
-      ByteSize: 2048
-      Element: 165 StructureType noalg.map.group[uint8]uint8
-    - __kind: GoSliceDataType
-      ID: 264
-      Name: '[]*table<uint8,[4]int>.array'
-      ByteSize: 8192
-      Element: 172 PointerType *table<uint8,[4]int>
-    - __kind: GoSliceDataType
-      ID: 265
-      Name: '[]noalg.map.group[uint8][4]int.array'
-      ByteSize: 2048
-      Element: 176 StructureType noalg.map.group[uint8][4]int
-    - __kind: GoSliceDataType
-      ID: 266
-      Name: '[]*table<[4]int,uint8>.array'
-      ByteSize: 8192
-      Element: 184 PointerType *table<[4]int,uint8>
-    - __kind: GoSliceDataType
-      ID: 267
-      Name: '[]noalg.map.group[[4]int]uint8.array'
-      ByteSize: 2048
-      Element: 188 StructureType noalg.map.group[[4]int]uint8
-    - __kind: GoSliceDataType
-      ID: 268
-      Name: '[]*table<[4]int,[4]int>.array'
-      ByteSize: 8192
-      Element: 195 PointerType *table<[4]int,[4]int>
-    - __kind: GoSliceDataType
-      ID: 269
-      Name: '[]noalg.map.group[[4]int][4]int.array'
-      ByteSize: 2048
-      Element: 199 StructureType noalg.map.group[[4]int][4]int
-    - __kind: GoSliceDataType
-      ID: 270
-      Name: main.t.array
-      ByteSize: 2048
-      Element: 207 PointerType *main.t
+      GoRuntimeType: 385472
+      GoKind: 22
+      Pointee: 6 BaseType int32
+    - __kind: PointerType
+      ID: 231
+      Name: '*int64'
+      ByteSize: 8
+      GoRuntimeType: 385600
+      GoKind: 22
+      Pointee: 18 BaseType int64
+    - __kind: PointerType
+      ID: 235
+      Name: '*int8'
+      ByteSize: 8
+      GoRuntimeType: 385216
+      GoKind: 22
+      Pointee: 14 BaseType int8
+    - __kind: PointerType
+      ID: 44
+      Name: '*main.esotericHeap'
+      ByteSize: 8
+      GoRuntimeType: 380160
+      GoKind: 22
+      Pointee: 45 StructureType main.esotericHeap
+    - __kind: PointerType
+      ID: 145
+      Name: '*main.node'
+      ByteSize: 8
+      GoRuntimeType: 380224
+      GoKind: 22
+      Pointee: 144 StructureType main.node
+    - __kind: PointerType
+      ID: 221
+      Name: '*main.oneStringStruct'
+      ByteSize: 8
+      GoKind: 22
+      Pointee: 222 StructureType main.oneStringStruct
+    - __kind: PointerType
+      ID: 132
+      Name: '*main.structWithMap'
+      ByteSize: 8
+      GoRuntimeType: 380096
+      GoKind: 22
+      Pointee: 58 StructureType main.structWithMap
+    - __kind: PointerType
+      ID: 214
+      Name: '*main.structWithNoStrings'
+      ByteSize: 8
+      Pointee: 215 StructureType main.structWithNoStrings
+    - __kind: PointerType
+      ID: 203
+      Name: '*main.structWithTwoValues'
+      ByteSize: 8
+      GoKind: 22
+      Pointee: 204 StructureType main.structWithTwoValues
+    - __kind: PointerType
+      ID: 207
+      Name: '*main.t'
+      ByteSize: 8
+      GoKind: 22
+      Pointee: 208 GoSliceHeaderType main.t
     - __kind: PointerType
       ID: 271
       Name: '*main.t.array'
       ByteSize: 8
       Pointee: 270 GoSliceDataType main.t.array
-    - __kind: GoSliceDataType
-      ID: 272
-      Name: '[]uint.array'
-      ByteSize: 2048
-      Element: 20 BaseType uint
     - __kind: PointerType
-      ID: 273
-      Name: '*[]uint.array'
+      ID: 220
+      Name: '*main.threeStringStruct'
       ByteSize: 8
-      Pointee: 272 GoSliceDataType []uint.array
-    - __kind: GoSliceDataType
-      ID: 274
-      Name: '[][]uint.array'
-      ByteSize: 2048
-      Element: 210 GoSliceHeaderType []uint
+      GoKind: 22
+      Pointee: 219 StructureType main.threeStringStruct
     - __kind: PointerType
-      ID: 275
-      Name: '*[][]uint.array'
+      ID: 192
+      Name: '*map<[4]int,[4]int>'
       ByteSize: 8
-      Pointee: 274 GoSliceDataType [][]uint.array
-    - __kind: GoSliceDataType
-      ID: 276
-      Name: '[]main.structWithNoStrings.array'
-      ByteSize: 2048
-      Element: 215 StructureType main.structWithNoStrings
+      Pointee: 193 GoSwissMapHeaderType map<[4]int,[4]int>
     - __kind: PointerType
-      ID: 277
-      Name: '*[]main.structWithNoStrings.array'
+      ID: 181
+      Name: '*map<[4]int,uint8>'
       ByteSize: 8
-      Pointee: 276 GoSliceDataType []main.structWithNoStrings.array
-    - __kind: GoSliceDataType
-      ID: 278
-      Name: '[]bool.array'
-      ByteSize: 2048
-      Element: 11 BaseType bool
+      Pointee: 182 GoSwissMapHeaderType map<[4]int,uint8>
     - __kind: PointerType
-      ID: 279
-      Name: '*[]bool.array'
+      ID: 107
+      Name: '*map<[4]string,[2]int>'
       ByteSize: 8
-      Pointee: 278 GoSliceDataType []bool.array
-    - __kind: GoSliceDataType
-      ID: 280
-      Name: '[]uint16.array'
-      ByteSize: 2048
-      Element: 22 BaseType uint16
+      Pointee: 108 GoSwissMapHeaderType map<[4]string,[2]int>
     - __kind: PointerType
-      ID: 281
-      Name: '*[]uint16.array'
+      ID: 134
+      Name: '*map<bool,main.node>'
       ByteSize: 8
-      Pointee: 280 GoSliceDataType []uint16.array
+      Pointee: 135 GoSwissMapHeaderType map<bool,main.node>
+    - __kind: PointerType
+      ID: 60
+      Name: '*map<int,int>'
+      ByteSize: 8
+      Pointee: 61 GoSwissMapHeaderType map<int,int>
+    - __kind: PointerType
+      ID: 147
+      Name: '*map<int,uint8>'
+      ByteSize: 8
+      Pointee: 148 GoSwissMapHeaderType map<int,uint8>
+    - __kind: PointerType
+      ID: 121
+      Name: '*map<string,[]main.structWithMap>'
+      ByteSize: 8
+      Pointee: 122 GoSwissMapHeaderType map<string,[]main.structWithMap>
+    - __kind: PointerType
+      ID: 95
+      Name: '*map<string,[]string>'
+      ByteSize: 8
+      Pointee: 96 GoSwissMapHeaderType map<string,[]string>
+    - __kind: PointerType
+      ID: 84
+      Name: '*map<string,int>'
+      ByteSize: 8
+      Pointee: 85 GoSwissMapHeaderType map<string,int>
+    - __kind: PointerType
+      ID: 72
+      Name: '*map<string,main.nestedStruct>'
+      ByteSize: 8
+      Pointee: 73 GoSwissMapHeaderType map<string,main.nestedStruct>
+    - __kind: PointerType
+      ID: 169
+      Name: '*map<uint8,[4]int>'
+      ByteSize: 8
+      Pointee: 170 GoSwissMapHeaderType map<uint8,[4]int>
+    - __kind: PointerType
+      ID: 158
+      Name: '*map<uint8,uint8>'
+      ByteSize: 8
+      Pointee: 159 GoSwissMapHeaderType map<uint8,uint8>
+    - __kind: PointerType
+      ID: 119
+      Name: '*map[string]int'
+      ByteSize: 8
+      GoKind: 22
+      Pointee: 83 GoMapType map[string]int
+    - __kind: PointerType
+      ID: 198
+      Name: '*noalg.map.group[[4]int][4]int'
+      ByteSize: 8
+      Pointee: 199 StructureType noalg.map.group[[4]int][4]int
+    - __kind: PointerType
+      ID: 187
+      Name: '*noalg.map.group[[4]int]uint8'
+      ByteSize: 8
+      Pointee: 188 StructureType noalg.map.group[[4]int]uint8
+    - __kind: PointerType
+      ID: 113
+      Name: '*noalg.map.group[[4]string][2]int'
+      ByteSize: 8
+      Pointee: 114 StructureType noalg.map.group[[4]string][2]int
+    - __kind: PointerType
+      ID: 140
+      Name: '*noalg.map.group[bool]main.node'
+      ByteSize: 8
+      Pointee: 141 StructureType noalg.map.group[bool]main.node
+    - __kind: PointerType
+      ID: 67
+      Name: '*noalg.map.group[int]int'
+      ByteSize: 8
+      Pointee: 68 StructureType noalg.map.group[int]int
+    - __kind: PointerType
+      ID: 153
+      Name: '*noalg.map.group[int]uint8'
+      ByteSize: 8
+      Pointee: 154 StructureType noalg.map.group[int]uint8
+    - __kind: PointerType
+      ID: 127
+      Name: '*noalg.map.group[string][]main.structWithMap'
+      ByteSize: 8
+      Pointee: 128 StructureType noalg.map.group[string][]main.structWithMap
+    - __kind: PointerType
+      ID: 101
+      Name: '*noalg.map.group[string][]string'
+      ByteSize: 8
+      Pointee: 102 StructureType noalg.map.group[string][]string
+    - __kind: PointerType
+      ID: 90
+      Name: '*noalg.map.group[string]int'
+      ByteSize: 8
+      Pointee: 91 StructureType noalg.map.group[string]int
+    - __kind: PointerType
+      ID: 78
+      Name: '*noalg.map.group[string]main.nestedStruct'
+      ByteSize: 8
+      Pointee: 79 StructureType noalg.map.group[string]main.nestedStruct
+    - __kind: PointerType
+      ID: 175
+      Name: '*noalg.map.group[uint8][4]int'
+      ByteSize: 8
+      Pointee: 176 StructureType noalg.map.group[uint8][4]int
+    - __kind: PointerType
+      ID: 164
+      Name: '*noalg.map.group[uint8]uint8'
+      ByteSize: 8
+      Pointee: 165 StructureType noalg.map.group[uint8]uint8
+    - __kind: PointerType
+      ID: 36
+      Name: '*string'
+      ByteSize: 8
+      GoRuntimeType: 385152
+      GoKind: 22
+      Pointee: 8 GoStringHeaderType string
+    - __kind: PointerType
+      ID: 239
+      Name: '*string.str'
+      ByteSize: 8
+      Pointee: 238 GoStringDataType string.str
+    - __kind: PointerType
+      ID: 195
+      Name: '*table<[4]int,[4]int>'
+      ByteSize: 8
+      Pointee: 196 StructureType table<[4]int,[4]int>
+    - __kind: PointerType
+      ID: 184
+      Name: '*table<[4]int,uint8>'
+      ByteSize: 8
+      Pointee: 185 StructureType table<[4]int,uint8>
+    - __kind: PointerType
+      ID: 110
+      Name: '*table<[4]string,[2]int>'
+      ByteSize: 8
+      Pointee: 111 StructureType table<[4]string,[2]int>
+    - __kind: PointerType
+      ID: 137
+      Name: '*table<bool,main.node>'
+      ByteSize: 8
+      Pointee: 138 StructureType table<bool,main.node>
+    - __kind: PointerType
+      ID: 64
+      Name: '*table<int,int>'
+      ByteSize: 8
+      Pointee: 65 StructureType table<int,int>
+    - __kind: PointerType
+      ID: 150
+      Name: '*table<int,uint8>'
+      ByteSize: 8
+      Pointee: 151 StructureType table<int,uint8>
+    - __kind: PointerType
+      ID: 124
+      Name: '*table<string,[]main.structWithMap>'
+      ByteSize: 8
+      Pointee: 125 StructureType table<string,[]main.structWithMap>
+    - __kind: PointerType
+      ID: 98
+      Name: '*table<string,[]string>'
+      ByteSize: 8
+      Pointee: 99 StructureType table<string,[]string>
+    - __kind: PointerType
+      ID: 87
+      Name: '*table<string,int>'
+      ByteSize: 8
+      Pointee: 88 StructureType table<string,int>
+    - __kind: PointerType
+      ID: 75
+      Name: '*table<string,main.nestedStruct>'
+      ByteSize: 8
+      Pointee: 76 StructureType table<string,main.nestedStruct>
+    - __kind: PointerType
+      ID: 172
+      Name: '*table<uint8,[4]int>'
+      ByteSize: 8
+      Pointee: 173 StructureType table<uint8,[4]int>
+    - __kind: PointerType
+      ID: 161
+      Name: '*table<uint8,uint8>'
+      ByteSize: 8
+      Pointee: 162 StructureType table<uint8,uint8>
+    - __kind: PointerType
+      ID: 205
+      Name: '*uint'
+      ByteSize: 8
+      GoRuntimeType: 385792
+      GoKind: 22
+      Pointee: 20 BaseType uint
+    - __kind: PointerType
+      ID: 218
+      Name: '*uint16'
+      ByteSize: 8
+      GoRuntimeType: 385408
+      GoKind: 22
+      Pointee: 22 BaseType uint16
+    - __kind: PointerType
+      ID: 227
+      Name: '*uint32'
+      ByteSize: 8
+      GoRuntimeType: 385536
+      GoKind: 22
+      Pointee: 24 BaseType uint32
+    - __kind: PointerType
+      ID: 233
+      Name: '*uint64'
+      ByteSize: 8
+      GoRuntimeType: 385664
+      GoKind: 22
+      Pointee: 26 BaseType uint64
+    - __kind: PointerType
+      ID: 9
+      Name: '*uint8'
+      ByteSize: 8
+      GoRuntimeType: 385280
+      GoKind: 22
+      Pointee: 4 BaseType uint8
+    - __kind: PointerType
+      ID: 225
+      Name: '*uintptr'
+      ByteSize: 8
+      GoRuntimeType: 385856
+      GoKind: 22
+      Pointee: 62 BaseType uintptr
     - __kind: EventRootType
-      ID: 282
-      Name: Probe[main.testByteArray]
-      ByteSize: 3
+      ID: 369
+      Name: Probe[main.stackC]
+    - __kind: EventRootType
+      ID: 326
+      Name: Probe[main.testAny]
+      ByteSize: 17
       PresenceBitsetSize: 1
       Expressions:
-        - Name: x
+        - Name: a
           Offset: 1
           Expression:
-            Type: 3 ArrayType [2]uint8
+            Type: 41 GoEmptyInterfaceType interface {}
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 7, index: 0, name: x}
+                  Variable: {subprogram: 51, index: 0, name: a}
                   Offset: 0
-                  ByteSize: 2
+                  ByteSize: 16
     - __kind: EventRootType
-      ID: 283
-      Name: Probe[main.testRuneArray]
-      ByteSize: 9
+      ID: 298
+      Name: Probe[main.testArrayOfArraysOfArrays]
+      ByteSize: 65
       PresenceBitsetSize: 1
       Expressions:
-        - Name: x
+        - Name: b
           Offset: 1
           Expression:
-            Type: 5 ArrayType [2]int32
+            Type: 28 ArrayType [2][2][2]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 8, index: 0, name: x}
+                  Variable: {subprogram: 23, index: 0, name: b}
                   Offset: 0
-                  ByteSize: 8
+                  ByteSize: 64
     - __kind: EventRootType
-      ID: 284
-      Name: Probe[main.testStringArray]
+      ID: 296
+      Name: Probe[main.testArrayOfArrays]
       ByteSize: 33
       PresenceBitsetSize: 1
       Expressions:
-        - Name: x
+        - Name: a
+          Offset: 1
+          Expression:
+            Type: 27 ArrayType [2][2]int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 21, index: 0, name: a}
+                  Offset: 0
+                  ByteSize: 32
+    - __kind: EventRootType
+      ID: 334
+      Name: Probe[main.testArrayOfMaps]
+      ByteSize: 17
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: m
+          Offset: 1
+          Expression:
+            Type: 118 ArrayType [2]map[string]int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 59, index: 0, name: m}
+                  Offset: 0
+                  ByteSize: 16
+    - __kind: EventRootType
+      ID: 297
+      Name: Probe[main.testArrayOfStrings]
+      ByteSize: 33
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: a
           Offset: 1
           Expression:
             Type: 7 ArrayType [2]string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 9, index: 0, name: x}
+                  Variable: {subprogram: 22, index: 0, name: a}
                   Offset: 0
                   ByteSize: 32
+    - __kind: EventRootType
+      ID: 316
+      Name: Probe[main.testBigStruct]
+      ByteSize: 49
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: b
+          Offset: 1
+          Expression:
+            Type: 33 StructureType main.bigStruct
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 41, index: 0, name: b}
+                  Offset: 0
+                  ByteSize: 48
     - __kind: EventRootType
       ID: 285
       Name: Probe[main.testBoolArray]
@@ -5944,35 +3678,338 @@ Types:
                   Offset: 0
                   ByteSize: 2
     - __kind: EventRootType
-      ID: 286
-      Name: Probe[main.testIntArray]
-      ByteSize: 17
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: x
-          Offset: 1
-          Expression:
-            Type: 12 ArrayType [2]int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 11, index: 0, name: x}
-                  Offset: 0
-                  ByteSize: 16
-    - __kind: EventRootType
-      ID: 287
-      Name: Probe[main.testInt8Array]
+      ID: 282
+      Name: Probe[main.testByteArray]
       ByteSize: 3
       PresenceBitsetSize: 1
       Expressions:
         - Name: x
           Offset: 1
           Expression:
-            Type: 13 ArrayType [2]int8
+            Type: 3 ArrayType [2]uint8
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 12, index: 0, name: x}
+                  Variable: {subprogram: 7, index: 0, name: x}
                   Offset: 0
                   ByteSize: 2
+    - __kind: EventRootType
+      ID: 350
+      Name: Probe[main.testChannel]
+      ByteSize: 1
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: c
+          Offset: 1
+          Expression:
+            Type: 202 GoChannelType chan bool
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 75, index: 0, name: c}
+                  Offset: 0
+                  ByteSize: 0
+    - __kind: EventRootType
+      ID: 348
+      Name: Probe[main.testCombinedByte]
+      ByteSize: 7
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: w
+          Offset: 1
+          Expression:
+            Type: 4 BaseType uint8
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 73, index: 0, name: w}
+                  Offset: 0
+                  ByteSize: 1
+        - Name: x
+          Offset: 2
+          Expression:
+            Type: 4 BaseType uint8
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 73, index: 1, name: x}
+                  Offset: 0
+                  ByteSize: 1
+        - Name: y
+          Offset: 3
+          Expression:
+            Type: 30 BaseType float32
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 73, index: 2, name: y}
+                  Offset: 0
+                  ByteSize: 4
+    - __kind: EventRootType
+      ID: 358
+      Name: Probe[main.testCycle]
+      ByteSize: 9
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: t
+          Offset: 1
+          Expression:
+            Type: 207 PointerType *main.t
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 83, index: 0, name: t}
+                  Offset: 0
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 363
+      Name: Probe[main.testEmptySliceOfStructs]
+      ByteSize: 33
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: xs
+          Offset: 1
+          Expression:
+            Type: 213 GoSliceHeaderType []main.structWithNoStrings
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 88, index: 0, name: xs}
+                  Offset: 0
+                  ByteSize: 24
+        - Name: a
+          Offset: 25
+          Expression:
+            Type: 1 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 88, index: 1, name: a}
+                  Offset: 0
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 360
+      Name: Probe[main.testEmptySlice]
+      ByteSize: 25
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: u
+          Offset: 1
+          Expression:
+            Type: 210 GoSliceHeaderType []uint
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 85, index: 0, name: u}
+                  Offset: 0
+                  ByteSize: 24
+    - __kind: EventRootType
+      ID: 377
+      Name: Probe[main.testEmptyString]
+      ByteSize: 17
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: x
+          Offset: 1
+          Expression:
+            Type: 8 GoStringHeaderType string
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 102, index: 0, name: x}
+                  Offset: 0
+                  ByteSize: 16
+    - __kind: EventRootType
+      ID: 379
+      Name: Probe[main.testEmptyStruct]
+      ByteSize: 1
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: e
+          Offset: 1
+          Expression:
+            Type: 224 StructureType main.emptyStruct
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 104, index: 0, name: e}
+                  Offset: 0
+                  ByteSize: 0
+    - __kind: EventRootType
+      ID: 327
+      Name: Probe[main.testError]
+      ByteSize: 17
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: e
+          Offset: 1
+          Expression:
+            Type: 57 GoInterfaceType error
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 52, index: 0, name: e}
+                  Offset: 0
+                  ByteSize: 16
+    - __kind: EventRootType
+      ID: 318
+      Name: Probe[main.testEsotericHeap]
+      ByteSize: 9
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: e
+          Offset: 1
+          Expression:
+            Type: 44 PointerType *main.esotericHeap
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 43, index: 0, name: e}
+                  Offset: 0
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 317
+      Name: Probe[main.testEsotericStack]
+      ByteSize: 65
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: e
+          Offset: 1
+          Expression:
+            Type: 39 StructureType main.esotericStack
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 42, index: 0, name: e}
+                  Offset: 0
+                  ByteSize: 64
+    - __kind: EventRootType
+      ID: 324
+      Name: Probe[main.testFramelessArray]
+      ByteSize: 41
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: a
+          Offset: 1
+          Expression:
+            Type: 2 ArrayType [5]int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 49, index: 0, name: a}
+                  Offset: 0
+                  ByteSize: 40
+    - __kind: EventRootType
+      ID: 323
+      Name: Probe[main.testFrameless]
+      ByteSize: 9
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: x
+          Offset: 1
+          Expression:
+            Type: 1 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 48, index: 0, name: x}
+                  Offset: 0
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 319
+      Name: Probe[main.testInlinedBA]
+      ByteSize: 9
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: x
+          Offset: 1
+          Expression:
+            Type: 1 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 44, index: 0, name: x}
+                  Offset: 0
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 321
+      Name: Probe[main.testInlinedBBA]
+      ByteSize: 9
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: x
+          Offset: 1
+          Expression:
+            Type: 1 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 46, index: 0, name: x}
+                  Offset: 0
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 381
+      Name: Probe[main.testInlinedBBB]
+    - __kind: EventRootType
+      ID: 320
+      Name: Probe[main.testInlinedBB]
+      ByteSize: 17
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: x
+          Offset: 1
+          Expression:
+            Type: 1 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 45, index: 0, name: x}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: y
+          Offset: 9
+          Expression:
+            Type: 1 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 45, index: 1, name: y}
+                  Offset: 0
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 382
+      Name: Probe[main.testInlinedBCA]
+    - __kind: EventRootType
+      ID: 383
+      Name: Probe[main.testInlinedBCB]
+    - __kind: EventRootType
+      ID: 322
+      Name: Probe[main.testInlinedBC]
+    - __kind: EventRootType
+      ID: 380
+      Name: Probe[main.testInlinedPrint]
+      ByteSize: 9
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: x
+          Offset: 1
+          Expression:
+            Type: 1 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 1, index: 0, name: x}
+                  Offset: 0
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 384
+      Name: Probe[main.testInlinedSq]
+      ByteSize: 9
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: x
+          Offset: 1
+          Expression:
+            Type: 1 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 5, index: 0, name: x}
+                  Offset: 0
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 385
+      Name: Probe[main.testInlinedSumArray]
+      ByteSize: 41
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: a
+          Offset: 1
+          Expression:
+            Type: 2 ArrayType [5]int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 6, index: 0, name: a}
+                  Offset: 0
+                  ByteSize: 40
     - __kind: EventRootType
       ID: 288
       Name: Probe[main.testInt16Array]
@@ -6019,512 +4056,35 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 291
-      Name: Probe[main.testUintArray]
+      ID: 287
+      Name: Probe[main.testInt8Array]
+      ByteSize: 3
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: x
+          Offset: 1
+          Expression:
+            Type: 13 ArrayType [2]int8
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 12, index: 0, name: x}
+                  Offset: 0
+                  ByteSize: 2
+    - __kind: EventRootType
+      ID: 286
+      Name: Probe[main.testIntArray]
       ByteSize: 17
       PresenceBitsetSize: 1
       Expressions:
         - Name: x
           Offset: 1
           Expression:
-            Type: 19 ArrayType [2]uint
+            Type: 12 ArrayType [2]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 16, index: 0, name: x}
+                  Variable: {subprogram: 11, index: 0, name: x}
                   Offset: 0
                   ByteSize: 16
-    - __kind: EventRootType
-      ID: 292
-      Name: Probe[main.testUint8Array]
-      ByteSize: 3
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: x
-          Offset: 1
-          Expression:
-            Type: 3 ArrayType [2]uint8
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 17, index: 0, name: x}
-                  Offset: 0
-                  ByteSize: 2
-    - __kind: EventRootType
-      ID: 293
-      Name: Probe[main.testUint16Array]
-      ByteSize: 5
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: x
-          Offset: 1
-          Expression:
-            Type: 21 ArrayType [2]uint16
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 18, index: 0, name: x}
-                  Offset: 0
-                  ByteSize: 4
-    - __kind: EventRootType
-      ID: 294
-      Name: Probe[main.testUint32Array]
-      ByteSize: 9
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: x
-          Offset: 1
-          Expression:
-            Type: 23 ArrayType [2]uint32
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 19, index: 0, name: x}
-                  Offset: 0
-                  ByteSize: 8
-    - __kind: EventRootType
-      ID: 295
-      Name: Probe[main.testUint64Array]
-      ByteSize: 17
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: x
-          Offset: 1
-          Expression:
-            Type: 25 ArrayType [2]uint64
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 20, index: 0, name: x}
-                  Offset: 0
-                  ByteSize: 16
-    - __kind: EventRootType
-      ID: 296
-      Name: Probe[main.testArrayOfArrays]
-      ByteSize: 33
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: a
-          Offset: 1
-          Expression:
-            Type: 27 ArrayType [2][2]int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 21, index: 0, name: a}
-                  Offset: 0
-                  ByteSize: 32
-    - __kind: EventRootType
-      ID: 297
-      Name: Probe[main.testArrayOfStrings]
-      ByteSize: 33
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: a
-          Offset: 1
-          Expression:
-            Type: 7 ArrayType [2]string
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 22, index: 0, name: a}
-                  Offset: 0
-                  ByteSize: 32
-    - __kind: EventRootType
-      ID: 298
-      Name: Probe[main.testArrayOfArraysOfArrays]
-      ByteSize: 65
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: b
-          Offset: 1
-          Expression:
-            Type: 28 ArrayType [2][2][2]int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 23, index: 0, name: b}
-                  Offset: 0
-                  ByteSize: 64
-    - __kind: EventRootType
-      ID: 299
-      Name: Probe[main.testVeryLargeArray]
-      ByteSize: 801
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: a
-          Offset: 1
-          Expression:
-            Type: 29 ArrayType [100]uint
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 24, index: 0, name: a}
-                  Offset: 0
-                  ByteSize: 800
-    - __kind: EventRootType
-      ID: 300
-      Name: Probe[main.testSingleByte]
-      ByteSize: 2
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: x
-          Offset: 1
-          Expression:
-            Type: 4 BaseType uint8
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 25, index: 0, name: x}
-                  Offset: 0
-                  ByteSize: 1
-    - __kind: EventRootType
-      ID: 301
-      Name: Probe[main.testSingleRune]
-      ByteSize: 5
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: x
-          Offset: 1
-          Expression:
-            Type: 6 BaseType int32
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 26, index: 0, name: x}
-                  Offset: 0
-                  ByteSize: 4
-    - __kind: EventRootType
-      ID: 302
-      Name: Probe[main.testSingleBool]
-      ByteSize: 2
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: x
-          Offset: 1
-          Expression:
-            Type: 11 BaseType bool
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 27, index: 0, name: x}
-                  Offset: 0
-                  ByteSize: 1
-    - __kind: EventRootType
-      ID: 303
-      Name: Probe[main.testSingleInt]
-      ByteSize: 9
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: x
-          Offset: 1
-          Expression:
-            Type: 1 BaseType int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 28, index: 0, name: x}
-                  Offset: 0
-                  ByteSize: 8
-    - __kind: EventRootType
-      ID: 304
-      Name: Probe[main.testSingleInt8]
-      ByteSize: 2
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: x
-          Offset: 1
-          Expression:
-            Type: 14 BaseType int8
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 29, index: 0, name: x}
-                  Offset: 0
-                  ByteSize: 1
-    - __kind: EventRootType
-      ID: 305
-      Name: Probe[main.testSingleInt16]
-      ByteSize: 3
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: x
-          Offset: 1
-          Expression:
-            Type: 16 BaseType int16
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 30, index: 0, name: x}
-                  Offset: 0
-                  ByteSize: 2
-    - __kind: EventRootType
-      ID: 306
-      Name: Probe[main.testSingleInt32]
-      ByteSize: 5
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: x
-          Offset: 1
-          Expression:
-            Type: 6 BaseType int32
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 31, index: 0, name: x}
-                  Offset: 0
-                  ByteSize: 4
-    - __kind: EventRootType
-      ID: 307
-      Name: Probe[main.testSingleInt64]
-      ByteSize: 9
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: x
-          Offset: 1
-          Expression:
-            Type: 18 BaseType int64
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 32, index: 0, name: x}
-                  Offset: 0
-                  ByteSize: 8
-    - __kind: EventRootType
-      ID: 308
-      Name: Probe[main.testSingleUint]
-      ByteSize: 9
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: x
-          Offset: 1
-          Expression:
-            Type: 20 BaseType uint
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 33, index: 0, name: x}
-                  Offset: 0
-                  ByteSize: 8
-    - __kind: EventRootType
-      ID: 309
-      Name: Probe[main.testSingleUint8]
-      ByteSize: 2
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: x
-          Offset: 1
-          Expression:
-            Type: 4 BaseType uint8
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 34, index: 0, name: x}
-                  Offset: 0
-                  ByteSize: 1
-    - __kind: EventRootType
-      ID: 310
-      Name: Probe[main.testSingleUint16]
-      ByteSize: 3
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: x
-          Offset: 1
-          Expression:
-            Type: 22 BaseType uint16
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 35, index: 0, name: x}
-                  Offset: 0
-                  ByteSize: 2
-    - __kind: EventRootType
-      ID: 311
-      Name: Probe[main.testSingleUint32]
-      ByteSize: 5
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: x
-          Offset: 1
-          Expression:
-            Type: 24 BaseType uint32
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 36, index: 0, name: x}
-                  Offset: 0
-                  ByteSize: 4
-    - __kind: EventRootType
-      ID: 312
-      Name: Probe[main.testSingleUint64]
-      ByteSize: 9
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: x
-          Offset: 1
-          Expression:
-            Type: 26 BaseType uint64
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 37, index: 0, name: x}
-                  Offset: 0
-                  ByteSize: 8
-    - __kind: EventRootType
-      ID: 313
-      Name: Probe[main.testSingleFloat32]
-      ByteSize: 5
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: x
-          Offset: 1
-          Expression:
-            Type: 30 BaseType float32
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 38, index: 0, name: x}
-                  Offset: 0
-                  ByteSize: 4
-    - __kind: EventRootType
-      ID: 314
-      Name: Probe[main.testSingleFloat64]
-      ByteSize: 9
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: x
-          Offset: 1
-          Expression:
-            Type: 31 BaseType float64
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 39, index: 0, name: x}
-                  Offset: 0
-                  ByteSize: 8
-    - __kind: EventRootType
-      ID: 315
-      Name: Probe[main.testTypeAlias]
-      ByteSize: 3
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: x
-          Offset: 1
-          Expression:
-            Type: 32 BaseType main.typeAlias
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 40, index: 0, name: x}
-                  Offset: 0
-                  ByteSize: 2
-    - __kind: EventRootType
-      ID: 316
-      Name: Probe[main.testBigStruct]
-      ByteSize: 49
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: b
-          Offset: 1
-          Expression:
-            Type: 33 StructureType main.bigStruct
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 41, index: 0, name: b}
-                  Offset: 0
-                  ByteSize: 48
-    - __kind: EventRootType
-      ID: 317
-      Name: Probe[main.testEsotericStack]
-      ByteSize: 65
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: e
-          Offset: 1
-          Expression:
-            Type: 39 StructureType main.esotericStack
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 42, index: 0, name: e}
-                  Offset: 0
-                  ByteSize: 64
-    - __kind: EventRootType
-      ID: 318
-      Name: Probe[main.testEsotericHeap]
-      ByteSize: 9
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: e
-          Offset: 1
-          Expression:
-            Type: 44 PointerType *main.esotericHeap
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 43, index: 0, name: e}
-                  Offset: 0
-                  ByteSize: 8
-    - __kind: EventRootType
-      ID: 319
-      Name: Probe[main.testInlinedBA]
-      ByteSize: 9
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: x
-          Offset: 1
-          Expression:
-            Type: 1 BaseType int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 44, index: 0, name: x}
-                  Offset: 0
-                  ByteSize: 8
-    - __kind: EventRootType
-      ID: 320
-      Name: Probe[main.testInlinedBB]
-      ByteSize: 17
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: x
-          Offset: 1
-          Expression:
-            Type: 1 BaseType int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 45, index: 0, name: x}
-                  Offset: 0
-                  ByteSize: 8
-        - Name: y
-          Offset: 9
-          Expression:
-            Type: 1 BaseType int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 45, index: 1, name: y}
-                  Offset: 0
-                  ByteSize: 8
-    - __kind: EventRootType
-      ID: 321
-      Name: Probe[main.testInlinedBBA]
-      ByteSize: 9
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: x
-          Offset: 1
-          Expression:
-            Type: 1 BaseType int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 46, index: 0, name: x}
-                  Offset: 0
-                  ByteSize: 8
-    - __kind: EventRootType
-      ID: 322
-      Name: Probe[main.testInlinedBC]
-    - __kind: EventRootType
-      ID: 323
-      Name: Probe[main.testFrameless]
-      ByteSize: 9
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: x
-          Offset: 1
-          Expression:
-            Type: 1 BaseType int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 48, index: 0, name: x}
-                  Offset: 0
-                  ByteSize: 8
-    - __kind: EventRootType
-      ID: 324
-      Name: Probe[main.testFramelessArray]
-      ByteSize: 41
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: a
-          Offset: 1
-          Expression:
-            Type: 2 ArrayType [5]int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 49, index: 0, name: a}
-                  Offset: 0
-                  ByteSize: 40
     - __kind: EventRootType
       ID: 325
       Name: Probe[main.testInterface]
@@ -6541,63 +4101,138 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 326
-      Name: Probe[main.testAny]
+      ID: 352
+      Name: Probe[main.testLinkedList]
       ByteSize: 17
       PresenceBitsetSize: 1
       Expressions:
         - Name: a
           Offset: 1
           Expression:
-            Type: 41 GoEmptyInterfaceType interface {}
+            Type: 144 StructureType main.node
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 51, index: 0, name: a}
+                  Variable: {subprogram: 77, index: 0, name: a}
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 327
-      Name: Probe[main.testError]
-      ByteSize: 17
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: e
-          Offset: 1
-          Expression:
-            Type: 57 GoInterfaceType error
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 52, index: 0, name: e}
-                  Offset: 0
-                  ByteSize: 16
-    - __kind: EventRootType
-      ID: 328
-      Name: Probe[main.testStructWithMap]
-      ByteSize: 9
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: s
-          Offset: 1
-          Expression:
-            Type: 58 StructureType main.structWithMap
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 53, index: 0, name: s}
-                  Offset: 0
-                  ByteSize: 8
-    - __kind: EventRootType
-      ID: 329
-      Name: Probe[main.testMapStringToStruct]
+      ID: 332
+      Name: Probe[main.testMapArrayToArray]
       ByteSize: 9
       PresenceBitsetSize: 1
       Expressions:
         - Name: m
           Offset: 1
           Expression:
-            Type: 71 GoMapType map[string]main.nestedStruct
+            Type: 106 GoMapType map[[4]string][2]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 54, index: 0, name: m}
+                  Variable: {subprogram: 57, index: 0, name: m}
+                  Offset: 0
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 338
+      Name: Probe[main.testMapEmbeddedMaps]
+      ByteSize: 9
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: m
+          Offset: 1
+          Expression:
+            Type: 120 GoMapType map[string][]main.structWithMap
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 63, index: 0, name: m}
+                  Offset: 0
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 336
+      Name: Probe[main.testMapIntToInt]
+      ByteSize: 9
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: m
+          Offset: 1
+          Expression:
+            Type: 59 GoMapType map[int]int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 61, index: 0, name: m}
+                  Offset: 0
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 347
+      Name: Probe[main.testMapLargeKeyLargeValue]
+      ByteSize: 9
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: m
+          Offset: 1
+          Expression:
+            Type: 191 GoMapType map[[4]int][4]int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 72, index: 0, name: m}
+                  Offset: 0
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 346
+      Name: Probe[main.testMapLargeKeySmallValue]
+      ByteSize: 9
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: m
+          Offset: 1
+          Expression:
+            Type: 180 GoMapType map[[4]int]uint8
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 71, index: 0, name: m}
+                  Offset: 0
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 337
+      Name: Probe[main.testMapMassive]
+      ByteSize: 9
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: redactMyEntries
+          Offset: 1
+          Expression:
+            Type: 120 GoMapType map[string][]main.structWithMap
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 62, index: 0, name: redactMyEntries}
+                  Offset: 0
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 345
+      Name: Probe[main.testMapSmallKeyLargeValue]
+      ByteSize: 9
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: m
+          Offset: 1
+          Expression:
+            Type: 168 GoMapType map[uint8][4]int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 70, index: 0, name: m}
+                  Offset: 0
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 344
+      Name: Probe[main.testMapSmallKeySmallValue]
+      ByteSize: 9
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: m
+          Offset: 1
+          Expression:
+            Type: 157 GoMapType map[uint8]uint8
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 69, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
@@ -6631,108 +4266,18 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 332
-      Name: Probe[main.testMapArrayToArray]
+      ID: 329
+      Name: Probe[main.testMapStringToStruct]
       ByteSize: 9
       PresenceBitsetSize: 1
       Expressions:
         - Name: m
           Offset: 1
           Expression:
-            Type: 106 GoMapType map[[4]string][2]int
+            Type: 71 GoMapType map[string]main.nestedStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 57, index: 0, name: m}
-                  Offset: 0
-                  ByteSize: 8
-    - __kind: EventRootType
-      ID: 333
-      Name: Probe[main.testSmallMap]
-      ByteSize: 9
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: m
-          Offset: 1
-          Expression:
-            Type: 83 GoMapType map[string]int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 58, index: 0, name: m}
-                  Offset: 0
-                  ByteSize: 8
-    - __kind: EventRootType
-      ID: 334
-      Name: Probe[main.testArrayOfMaps]
-      ByteSize: 17
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: m
-          Offset: 1
-          Expression:
-            Type: 118 ArrayType [2]map[string]int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 59, index: 0, name: m}
-                  Offset: 0
-                  ByteSize: 16
-    - __kind: EventRootType
-      ID: 335
-      Name: Probe[main.testPointerToMap]
-      ByteSize: 9
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: m
-          Offset: 1
-          Expression:
-            Type: 119 PointerType *map[string]int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 60, index: 0, name: m}
-                  Offset: 0
-                  ByteSize: 8
-    - __kind: EventRootType
-      ID: 336
-      Name: Probe[main.testMapIntToInt]
-      ByteSize: 9
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: m
-          Offset: 1
-          Expression:
-            Type: 59 GoMapType map[int]int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 61, index: 0, name: m}
-                  Offset: 0
-                  ByteSize: 8
-    - __kind: EventRootType
-      ID: 337
-      Name: Probe[main.testMapMassive]
-      ByteSize: 9
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: redactMyEntries
-          Offset: 1
-          Expression:
-            Type: 120 GoMapType map[string][]main.structWithMap
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 62, index: 0, name: redactMyEntries}
-                  Offset: 0
-                  ByteSize: 8
-    - __kind: EventRootType
-      ID: 338
-      Name: Probe[main.testMapEmbeddedMaps]
-      ByteSize: 9
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: m
-          Offset: 1
-          Expression:
-            Type: 120 GoMapType map[string][]main.structWithMap
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 63, index: 0, name: m}
+                  Variable: {subprogram: 54, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
@@ -6751,33 +4296,18 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 340
-      Name: Probe[main.testMapWithSmallValue]
+      ID: 343
+      Name: Probe[main.testMapWithSmallKeyAndValueMassive]
       ByteSize: 9
       PresenceBitsetSize: 1
       Expressions:
         - Name: m
           Offset: 1
           Expression:
-            Type: 146 GoMapType map[int]uint8
+            Type: 157 GoMapType map[uint8]uint8
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 65, index: 0, name: m}
-                  Offset: 0
-                  ByteSize: 8
-    - __kind: EventRootType
-      ID: 341
-      Name: Probe[main.testMapWithSmallValueMassive]
-      ByteSize: 9
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: redactMyEntries
-          Offset: 1
-          Expression:
-            Type: 146 GoMapType map[int]uint8
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 66, index: 0, name: redactMyEntries}
+                  Variable: {subprogram: 68, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
@@ -6796,113 +4326,50 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 343
-      Name: Probe[main.testMapWithSmallKeyAndValueMassive]
+      ID: 341
+      Name: Probe[main.testMapWithSmallValueMassive]
+      ByteSize: 9
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: redactMyEntries
+          Offset: 1
+          Expression:
+            Type: 146 GoMapType map[int]uint8
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 66, index: 0, name: redactMyEntries}
+                  Offset: 0
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 340
+      Name: Probe[main.testMapWithSmallValue]
       ByteSize: 9
       PresenceBitsetSize: 1
       Expressions:
         - Name: m
           Offset: 1
           Expression:
-            Type: 157 GoMapType map[uint8]uint8
+            Type: 146 GoMapType map[int]uint8
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 68, index: 0, name: m}
+                  Variable: {subprogram: 65, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 344
-      Name: Probe[main.testMapSmallKeySmallValue]
-      ByteSize: 9
+      ID: 375
+      Name: Probe[main.testMassiveString]
+      ByteSize: 17
       PresenceBitsetSize: 1
       Expressions:
-        - Name: m
-          Offset: 1
-          Expression:
-            Type: 157 GoMapType map[uint8]uint8
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 69, index: 0, name: m}
-                  Offset: 0
-                  ByteSize: 8
-    - __kind: EventRootType
-      ID: 345
-      Name: Probe[main.testMapSmallKeyLargeValue]
-      ByteSize: 9
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: m
-          Offset: 1
-          Expression:
-            Type: 168 GoMapType map[uint8][4]int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 70, index: 0, name: m}
-                  Offset: 0
-                  ByteSize: 8
-    - __kind: EventRootType
-      ID: 346
-      Name: Probe[main.testMapLargeKeySmallValue]
-      ByteSize: 9
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: m
-          Offset: 1
-          Expression:
-            Type: 180 GoMapType map[[4]int]uint8
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 71, index: 0, name: m}
-                  Offset: 0
-                  ByteSize: 8
-    - __kind: EventRootType
-      ID: 347
-      Name: Probe[main.testMapLargeKeyLargeValue]
-      ByteSize: 9
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: m
-          Offset: 1
-          Expression:
-            Type: 191 GoMapType map[[4]int][4]int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 72, index: 0, name: m}
-                  Offset: 0
-                  ByteSize: 8
-    - __kind: EventRootType
-      ID: 348
-      Name: Probe[main.testCombinedByte]
-      ByteSize: 7
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: w
-          Offset: 1
-          Expression:
-            Type: 4 BaseType uint8
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 73, index: 0, name: w}
-                  Offset: 0
-                  ByteSize: 1
         - Name: x
-          Offset: 2
+          Offset: 1
           Expression:
-            Type: 4 BaseType uint8
+            Type: 8 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 73, index: 1, name: x}
+                  Variable: {subprogram: 100, index: 0, name: x}
                   Offset: 0
-                  ByteSize: 1
-        - Name: y
-          Offset: 3
-          Expression:
-            Type: 30 BaseType float32
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 73, index: 2, name: y}
-                  Offset: 0
-                  ByteSize: 4
+                  ByteSize: 16
     - __kind: EventRootType
       ID: 349
       Name: Probe[main.testMultipleSimpleParams]
@@ -6955,111 +4422,6 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 350
-      Name: Probe[main.testChannel]
-      ByteSize: 1
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: c
-          Offset: 1
-          Expression:
-            Type: 202 GoChannelType chan bool
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 75, index: 0, name: c}
-                  Offset: 0
-                  ByteSize: 0
-    - __kind: EventRootType
-      ID: 351
-      Name: Probe[main.testPointerToSimpleStruct]
-      ByteSize: 9
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: a
-          Offset: 1
-          Expression:
-            Type: 203 PointerType *main.structWithTwoValues
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 76, index: 0, name: a}
-                  Offset: 0
-                  ByteSize: 8
-    - __kind: EventRootType
-      ID: 352
-      Name: Probe[main.testLinkedList]
-      ByteSize: 17
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: a
-          Offset: 1
-          Expression:
-            Type: 144 StructureType main.node
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 77, index: 0, name: a}
-                  Offset: 0
-                  ByteSize: 16
-    - __kind: EventRootType
-      ID: 353
-      Name: Probe[main.testPointerLoop]
-      ByteSize: 9
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: a
-          Offset: 1
-          Expression:
-            Type: 145 PointerType *main.node
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 78, index: 0, name: a}
-                  Offset: 0
-                  ByteSize: 8
-    - __kind: EventRootType
-      ID: 354
-      Name: Probe[main.testUnsafePointer]
-      ByteSize: 9
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: x
-          Offset: 1
-          Expression:
-            Type: 38 VoidPointerType unsafe.Pointer
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 79, index: 0, name: x}
-                  Offset: 0
-                  ByteSize: 8
-    - __kind: EventRootType
-      ID: 355
-      Name: Probe[main.testUintPointer]
-      ByteSize: 9
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: x
-          Offset: 1
-          Expression:
-            Type: 205 PointerType *uint
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 80, index: 0, name: x}
-                  Offset: 0
-                  ByteSize: 8
-    - __kind: EventRootType
-      ID: 356
-      Name: Probe[main.testStringPointer]
-      ByteSize: 9
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: z
-          Offset: 1
-          Expression:
-            Type: 36 PointerType *string
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 81, index: 0, name: z}
-                  Offset: 0
-                  ByteSize: 8
-    - __kind: EventRootType
       ID: 357
       Name: Probe[main.testNilPointer]
       ByteSize: 17
@@ -7081,114 +4443,6 @@ Types:
             Operations:
                 - __kind: LocationOp
                   Variable: {subprogram: 82, index: 1, name: a}
-                  Offset: 0
-                  ByteSize: 8
-    - __kind: EventRootType
-      ID: 358
-      Name: Probe[main.testCycle]
-      ByteSize: 9
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: t
-          Offset: 1
-          Expression:
-            Type: 207 PointerType *main.t
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 83, index: 0, name: t}
-                  Offset: 0
-                  ByteSize: 8
-    - __kind: EventRootType
-      ID: 359
-      Name: Probe[main.testUintSlice]
-      ByteSize: 25
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: u
-          Offset: 1
-          Expression:
-            Type: 210 GoSliceHeaderType []uint
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 84, index: 0, name: u}
-                  Offset: 0
-                  ByteSize: 24
-    - __kind: EventRootType
-      ID: 360
-      Name: Probe[main.testEmptySlice]
-      ByteSize: 25
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: u
-          Offset: 1
-          Expression:
-            Type: 210 GoSliceHeaderType []uint
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 85, index: 0, name: u}
-                  Offset: 0
-                  ByteSize: 24
-    - __kind: EventRootType
-      ID: 361
-      Name: Probe[main.testSliceOfSlices]
-      ByteSize: 25
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: u
-          Offset: 1
-          Expression:
-            Type: 211 GoSliceHeaderType [][]uint
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 86, index: 0, name: u}
-                  Offset: 0
-                  ByteSize: 24
-    - __kind: EventRootType
-      ID: 362
-      Name: Probe[main.testStructSlice]
-      ByteSize: 33
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: xs
-          Offset: 1
-          Expression:
-            Type: 213 GoSliceHeaderType []main.structWithNoStrings
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 87, index: 0, name: xs}
-                  Offset: 0
-                  ByteSize: 24
-        - Name: a
-          Offset: 25
-          Expression:
-            Type: 1 BaseType int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 87, index: 1, name: a}
-                  Offset: 0
-                  ByteSize: 8
-    - __kind: EventRootType
-      ID: 363
-      Name: Probe[main.testEmptySliceOfStructs]
-      ByteSize: 33
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: xs
-          Offset: 1
-          Expression:
-            Type: 213 GoSliceHeaderType []main.structWithNoStrings
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 88, index: 0, name: xs}
-                  Offset: 0
-                  ByteSize: 24
-        - Name: a
-          Offset: 25
-          Expression:
-            Type: 1 BaseType int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 88, index: 1, name: a}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
@@ -7215,21 +4469,6 @@ Types:
                   Variable: {subprogram: 89, index: 1, name: a}
                   Offset: 0
                   ByteSize: 8
-    - __kind: EventRootType
-      ID: 365
-      Name: Probe[main.testStringSlice]
-      ByteSize: 25
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: s
-          Offset: 1
-          Expression:
-            Type: 105 GoSliceHeaderType []string
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 90, index: 0, name: s}
-                  Offset: 0
-                  ByteSize: 24
     - __kind: EventRootType
       ID: 366
       Name: Probe[main.testNilSliceWithOtherParams]
@@ -7279,23 +4518,230 @@ Types:
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 368
-      Name: Probe[main.testVeryLargeSlice]
-      ByteSize: 25
+      ID: 374
+      Name: Probe[main.testOneStringInStructPointer]
+      ByteSize: 9
       PresenceBitsetSize: 1
       Expressions:
-        - Name: xs
+        - Name: a
           Offset: 1
           Expression:
-            Type: 210 GoSliceHeaderType []uint
+            Type: 221 PointerType *main.oneStringStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 93, index: 0, name: xs}
+                  Variable: {subprogram: 99, index: 0, name: a}
                   Offset: 0
-                  ByteSize: 24
+                  ByteSize: 8
     - __kind: EventRootType
-      ID: 369
-      Name: Probe[main.stackC]
+      ID: 353
+      Name: Probe[main.testPointerLoop]
+      ByteSize: 9
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: a
+          Offset: 1
+          Expression:
+            Type: 145 PointerType *main.node
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 78, index: 0, name: a}
+                  Offset: 0
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 335
+      Name: Probe[main.testPointerToMap]
+      ByteSize: 9
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: m
+          Offset: 1
+          Expression:
+            Type: 119 PointerType *map[string]int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 60, index: 0, name: m}
+                  Offset: 0
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 351
+      Name: Probe[main.testPointerToSimpleStruct]
+      ByteSize: 9
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: a
+          Offset: 1
+          Expression:
+            Type: 203 PointerType *main.structWithTwoValues
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 76, index: 0, name: a}
+                  Offset: 0
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 283
+      Name: Probe[main.testRuneArray]
+      ByteSize: 9
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: x
+          Offset: 1
+          Expression:
+            Type: 5 ArrayType [2]int32
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 8, index: 0, name: x}
+                  Offset: 0
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 302
+      Name: Probe[main.testSingleBool]
+      ByteSize: 2
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: x
+          Offset: 1
+          Expression:
+            Type: 11 BaseType bool
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 27, index: 0, name: x}
+                  Offset: 0
+                  ByteSize: 1
+    - __kind: EventRootType
+      ID: 300
+      Name: Probe[main.testSingleByte]
+      ByteSize: 2
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: x
+          Offset: 1
+          Expression:
+            Type: 4 BaseType uint8
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 25, index: 0, name: x}
+                  Offset: 0
+                  ByteSize: 1
+    - __kind: EventRootType
+      ID: 313
+      Name: Probe[main.testSingleFloat32]
+      ByteSize: 5
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: x
+          Offset: 1
+          Expression:
+            Type: 30 BaseType float32
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 38, index: 0, name: x}
+                  Offset: 0
+                  ByteSize: 4
+    - __kind: EventRootType
+      ID: 314
+      Name: Probe[main.testSingleFloat64]
+      ByteSize: 9
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: x
+          Offset: 1
+          Expression:
+            Type: 31 BaseType float64
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 39, index: 0, name: x}
+                  Offset: 0
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 305
+      Name: Probe[main.testSingleInt16]
+      ByteSize: 3
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: x
+          Offset: 1
+          Expression:
+            Type: 16 BaseType int16
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 30, index: 0, name: x}
+                  Offset: 0
+                  ByteSize: 2
+    - __kind: EventRootType
+      ID: 306
+      Name: Probe[main.testSingleInt32]
+      ByteSize: 5
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: x
+          Offset: 1
+          Expression:
+            Type: 6 BaseType int32
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 31, index: 0, name: x}
+                  Offset: 0
+                  ByteSize: 4
+    - __kind: EventRootType
+      ID: 307
+      Name: Probe[main.testSingleInt64]
+      ByteSize: 9
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: x
+          Offset: 1
+          Expression:
+            Type: 18 BaseType int64
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 32, index: 0, name: x}
+                  Offset: 0
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 304
+      Name: Probe[main.testSingleInt8]
+      ByteSize: 2
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: x
+          Offset: 1
+          Expression:
+            Type: 14 BaseType int8
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 29, index: 0, name: x}
+                  Offset: 0
+                  ByteSize: 1
+    - __kind: EventRootType
+      ID: 303
+      Name: Probe[main.testSingleInt]
+      ByteSize: 9
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: x
+          Offset: 1
+          Expression:
+            Type: 1 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 28, index: 0, name: x}
+                  Offset: 0
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 301
+      Name: Probe[main.testSingleRune]
+      ByteSize: 5
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: x
+          Offset: 1
+          Expression:
+            Type: 6 BaseType int32
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 26, index: 0, name: x}
+                  Offset: 0
+                  ByteSize: 4
     - __kind: EventRootType
       ID: 370
       Name: Probe[main.testSingleString]
@@ -7311,6 +4757,240 @@ Types:
                   Variable: {subprogram: 95, index: 0, name: x}
                   Offset: 0
                   ByteSize: 16
+    - __kind: EventRootType
+      ID: 310
+      Name: Probe[main.testSingleUint16]
+      ByteSize: 3
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: x
+          Offset: 1
+          Expression:
+            Type: 22 BaseType uint16
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 35, index: 0, name: x}
+                  Offset: 0
+                  ByteSize: 2
+    - __kind: EventRootType
+      ID: 311
+      Name: Probe[main.testSingleUint32]
+      ByteSize: 5
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: x
+          Offset: 1
+          Expression:
+            Type: 24 BaseType uint32
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 36, index: 0, name: x}
+                  Offset: 0
+                  ByteSize: 4
+    - __kind: EventRootType
+      ID: 312
+      Name: Probe[main.testSingleUint64]
+      ByteSize: 9
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: x
+          Offset: 1
+          Expression:
+            Type: 26 BaseType uint64
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 37, index: 0, name: x}
+                  Offset: 0
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 309
+      Name: Probe[main.testSingleUint8]
+      ByteSize: 2
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: x
+          Offset: 1
+          Expression:
+            Type: 4 BaseType uint8
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 34, index: 0, name: x}
+                  Offset: 0
+                  ByteSize: 1
+    - __kind: EventRootType
+      ID: 308
+      Name: Probe[main.testSingleUint]
+      ByteSize: 9
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: x
+          Offset: 1
+          Expression:
+            Type: 20 BaseType uint
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 33, index: 0, name: x}
+                  Offset: 0
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 361
+      Name: Probe[main.testSliceOfSlices]
+      ByteSize: 25
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: u
+          Offset: 1
+          Expression:
+            Type: 211 GoSliceHeaderType [][]uint
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 86, index: 0, name: u}
+                  Offset: 0
+                  ByteSize: 24
+    - __kind: EventRootType
+      ID: 333
+      Name: Probe[main.testSmallMap]
+      ByteSize: 9
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: m
+          Offset: 1
+          Expression:
+            Type: 83 GoMapType map[string]int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 58, index: 0, name: m}
+                  Offset: 0
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 284
+      Name: Probe[main.testStringArray]
+      ByteSize: 33
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: x
+          Offset: 1
+          Expression:
+            Type: 7 ArrayType [2]string
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 9, index: 0, name: x}
+                  Offset: 0
+                  ByteSize: 32
+    - __kind: EventRootType
+      ID: 356
+      Name: Probe[main.testStringPointer]
+      ByteSize: 9
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: z
+          Offset: 1
+          Expression:
+            Type: 36 PointerType *string
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 81, index: 0, name: z}
+                  Offset: 0
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 365
+      Name: Probe[main.testStringSlice]
+      ByteSize: 25
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: s
+          Offset: 1
+          Expression:
+            Type: 105 GoSliceHeaderType []string
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 90, index: 0, name: s}
+                  Offset: 0
+                  ByteSize: 24
+    - __kind: EventRootType
+      ID: 362
+      Name: Probe[main.testStructSlice]
+      ByteSize: 33
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: xs
+          Offset: 1
+          Expression:
+            Type: 213 GoSliceHeaderType []main.structWithNoStrings
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 87, index: 0, name: xs}
+                  Offset: 0
+                  ByteSize: 24
+        - Name: a
+          Offset: 25
+          Expression:
+            Type: 1 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 87, index: 1, name: a}
+                  Offset: 0
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 328
+      Name: Probe[main.testStructWithMap]
+      ByteSize: 9
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: s
+          Offset: 1
+          Expression:
+            Type: 58 StructureType main.structWithMap
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 53, index: 0, name: s}
+                  Offset: 0
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 378
+      Name: Probe[main.testStruct]
+      ByteSize: 57
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: x
+          Offset: 1
+          Expression:
+            Type: 223 StructureType main.aStruct
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 103, index: 0, name: x}
+                  Offset: 0
+                  ByteSize: 56
+    - __kind: EventRootType
+      ID: 373
+      Name: Probe[main.testThreeStringsInStructPointer]
+      ByteSize: 9
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: a
+          Offset: 1
+          Expression:
+            Type: 220 PointerType *main.threeStringStruct
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 98, index: 0, name: a}
+                  Offset: 0
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 372
+      Name: Probe[main.testThreeStringsInStruct]
+      ByteSize: 49
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: a
+          Offset: 1
+          Expression:
+            Type: 219 StructureType main.threeStringStruct
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 97, index: 0, name: a}
+                  Offset: 0
+                  ByteSize: 48
     - __kind: EventRootType
       ID: 371
       Name: Probe[main.testThreeStrings]
@@ -7345,65 +5025,125 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 372
-      Name: Probe[main.testThreeStringsInStruct]
-      ByteSize: 49
+      ID: 315
+      Name: Probe[main.testTypeAlias]
+      ByteSize: 3
       PresenceBitsetSize: 1
       Expressions:
-        - Name: a
+        - Name: x
           Offset: 1
           Expression:
-            Type: 219 StructureType main.threeStringStruct
+            Type: 32 BaseType main.typeAlias
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 97, index: 0, name: a}
+                  Variable: {subprogram: 40, index: 0, name: x}
                   Offset: 0
-                  ByteSize: 48
+                  ByteSize: 2
     - __kind: EventRootType
-      ID: 373
-      Name: Probe[main.testThreeStringsInStructPointer]
+      ID: 293
+      Name: Probe[main.testUint16Array]
+      ByteSize: 5
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: x
+          Offset: 1
+          Expression:
+            Type: 21 ArrayType [2]uint16
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 18, index: 0, name: x}
+                  Offset: 0
+                  ByteSize: 4
+    - __kind: EventRootType
+      ID: 294
+      Name: Probe[main.testUint32Array]
       ByteSize: 9
       PresenceBitsetSize: 1
       Expressions:
-        - Name: a
+        - Name: x
           Offset: 1
           Expression:
-            Type: 220 PointerType *main.threeStringStruct
+            Type: 23 ArrayType [2]uint32
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 98, index: 0, name: a}
+                  Variable: {subprogram: 19, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 374
-      Name: Probe[main.testOneStringInStructPointer]
-      ByteSize: 9
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: a
-          Offset: 1
-          Expression:
-            Type: 221 PointerType *main.oneStringStruct
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 99, index: 0, name: a}
-                  Offset: 0
-                  ByteSize: 8
-    - __kind: EventRootType
-      ID: 375
-      Name: Probe[main.testMassiveString]
+      ID: 295
+      Name: Probe[main.testUint64Array]
       ByteSize: 17
       PresenceBitsetSize: 1
       Expressions:
         - Name: x
           Offset: 1
           Expression:
-            Type: 8 GoStringHeaderType string
+            Type: 25 ArrayType [2]uint64
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 100, index: 0, name: x}
+                  Variable: {subprogram: 20, index: 0, name: x}
                   Offset: 0
                   ByteSize: 16
+    - __kind: EventRootType
+      ID: 292
+      Name: Probe[main.testUint8Array]
+      ByteSize: 3
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: x
+          Offset: 1
+          Expression:
+            Type: 3 ArrayType [2]uint8
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 17, index: 0, name: x}
+                  Offset: 0
+                  ByteSize: 2
+    - __kind: EventRootType
+      ID: 291
+      Name: Probe[main.testUintArray]
+      ByteSize: 17
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: x
+          Offset: 1
+          Expression:
+            Type: 19 ArrayType [2]uint
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 16, index: 0, name: x}
+                  Offset: 0
+                  ByteSize: 16
+    - __kind: EventRootType
+      ID: 355
+      Name: Probe[main.testUintPointer]
+      ByteSize: 9
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: x
+          Offset: 1
+          Expression:
+            Type: 205 PointerType *uint
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 80, index: 0, name: x}
+                  Offset: 0
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 359
+      Name: Probe[main.testUintSlice]
+      ByteSize: 25
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: u
+          Offset: 1
+          Expression:
+            Type: 210 GoSliceHeaderType []uint
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 84, index: 0, name: u}
+                  Offset: 0
+                  ByteSize: 24
     - __kind: EventRootType
       ID: 376
       Name: Probe[main.testUnitializedString]
@@ -7420,104 +5160,2364 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 377
-      Name: Probe[main.testEmptyString]
-      ByteSize: 17
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: x
-          Offset: 1
-          Expression:
-            Type: 8 GoStringHeaderType string
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 102, index: 0, name: x}
-                  Offset: 0
-                  ByteSize: 16
-    - __kind: EventRootType
-      ID: 378
-      Name: Probe[main.testStruct]
-      ByteSize: 57
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: x
-          Offset: 1
-          Expression:
-            Type: 223 StructureType main.aStruct
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 103, index: 0, name: x}
-                  Offset: 0
-                  ByteSize: 56
-    - __kind: EventRootType
-      ID: 379
-      Name: Probe[main.testEmptyStruct]
-      ByteSize: 1
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: e
-          Offset: 1
-          Expression:
-            Type: 224 StructureType main.emptyStruct
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 104, index: 0, name: e}
-                  Offset: 0
-                  ByteSize: 0
-    - __kind: EventRootType
-      ID: 380
-      Name: Probe[main.testInlinedPrint]
+      ID: 354
+      Name: Probe[main.testUnsafePointer]
       ByteSize: 9
       PresenceBitsetSize: 1
       Expressions:
         - Name: x
           Offset: 1
           Expression:
-            Type: 1 BaseType int
+            Type: 38 VoidPointerType unsafe.Pointer
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 1, index: 0, name: x}
+                  Variable: {subprogram: 79, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 381
-      Name: Probe[main.testInlinedBBB]
-    - __kind: EventRootType
-      ID: 382
-      Name: Probe[main.testInlinedBCA]
-    - __kind: EventRootType
-      ID: 383
-      Name: Probe[main.testInlinedBCB]
-    - __kind: EventRootType
-      ID: 384
-      Name: Probe[main.testInlinedSq]
-      ByteSize: 9
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: x
-          Offset: 1
-          Expression:
-            Type: 1 BaseType int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 5, index: 0, name: x}
-                  Offset: 0
-                  ByteSize: 8
-    - __kind: EventRootType
-      ID: 385
-      Name: Probe[main.testInlinedSumArray]
-      ByteSize: 41
+      ID: 299
+      Name: Probe[main.testVeryLargeArray]
+      ByteSize: 801
       PresenceBitsetSize: 1
       Expressions:
         - Name: a
           Offset: 1
           Expression:
-            Type: 2 ArrayType [5]int
+            Type: 29 ArrayType [100]uint
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 6, index: 0, name: a}
+                  Variable: {subprogram: 24, index: 0, name: a}
                   Offset: 0
-                  ByteSize: 40
+                  ByteSize: 800
+    - __kind: EventRootType
+      ID: 368
+      Name: Probe[main.testVeryLargeSlice]
+      ByteSize: 25
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: xs
+          Offset: 1
+          Expression:
+            Type: 210 GoSliceHeaderType []uint
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 93, index: 0, name: xs}
+                  Offset: 0
+                  ByteSize: 24
+    - __kind: ArrayType
+      ID: 29
+      Name: '[100]uint'
+      ByteSize: 800
+      GoKind: 17
+      Count: 100
+      HasCount: true
+      Element: 20 BaseType uint
+    - __kind: ArrayType
+      ID: 28
+      Name: '[2][2][2]int'
+      ByteSize: 64
+      GoKind: 17
+      Count: 2
+      HasCount: true
+      Element: 27 ArrayType [2][2]int
+    - __kind: ArrayType
+      ID: 27
+      Name: '[2][2]int'
+      ByteSize: 32
+      GoKind: 17
+      Count: 2
+      HasCount: true
+      Element: 12 ArrayType [2]int
+    - __kind: ArrayType
+      ID: 10
+      Name: '[2]bool'
+      ByteSize: 2
+      GoKind: 17
+      Count: 2
+      HasCount: true
+      Element: 11 BaseType bool
+    - __kind: ArrayType
+      ID: 12
+      Name: '[2]int'
+      ByteSize: 16
+      GoRuntimeType: 673088
+      GoKind: 17
+      Count: 2
+      HasCount: true
+      Element: 1 BaseType int
+    - __kind: ArrayType
+      ID: 15
+      Name: '[2]int16'
+      ByteSize: 4
+      GoKind: 17
+      Count: 2
+      HasCount: true
+      Element: 16 BaseType int16
+    - __kind: ArrayType
+      ID: 5
+      Name: '[2]int32'
+      ByteSize: 8
+      GoRuntimeType: 674432
+      GoKind: 17
+      Count: 2
+      HasCount: true
+      Element: 6 BaseType int32
+    - __kind: ArrayType
+      ID: 17
+      Name: '[2]int64'
+      ByteSize: 16
+      GoKind: 17
+      Count: 2
+      HasCount: true
+      Element: 18 BaseType int64
+    - __kind: ArrayType
+      ID: 13
+      Name: '[2]int8'
+      ByteSize: 2
+      GoKind: 17
+      Count: 2
+      HasCount: true
+      Element: 14 BaseType int8
+    - __kind: ArrayType
+      ID: 118
+      Name: '[2]map[string]int'
+      ByteSize: 16
+      GoKind: 17
+      Count: 2
+      HasCount: true
+      Element: 83 GoMapType map[string]int
+    - __kind: ArrayType
+      ID: 7
+      Name: '[2]string'
+      ByteSize: 32
+      GoRuntimeType: 674528
+      GoKind: 17
+      Count: 2
+      HasCount: true
+      Element: 8 GoStringHeaderType string
+    - __kind: ArrayType
+      ID: 19
+      Name: '[2]uint'
+      ByteSize: 16
+      GoKind: 17
+      Count: 2
+      HasCount: true
+      Element: 20 BaseType uint
+    - __kind: ArrayType
+      ID: 21
+      Name: '[2]uint16'
+      ByteSize: 4
+      GoKind: 17
+      Count: 2
+      HasCount: true
+      Element: 22 BaseType uint16
+    - __kind: ArrayType
+      ID: 23
+      Name: '[2]uint32'
+      ByteSize: 8
+      GoKind: 17
+      Count: 2
+      HasCount: true
+      Element: 24 BaseType uint32
+    - __kind: ArrayType
+      ID: 25
+      Name: '[2]uint64'
+      ByteSize: 16
+      GoRuntimeType: 674624
+      GoKind: 17
+      Count: 2
+      HasCount: true
+      Element: 26 BaseType uint64
+    - __kind: ArrayType
+      ID: 3
+      Name: '[2]uint8'
+      ByteSize: 2
+      GoRuntimeType: 674336
+      GoKind: 17
+      Count: 2
+      HasCount: true
+      Element: 4 BaseType uint8
+    - __kind: ArrayType
+      ID: 179
+      Name: '[4]int'
+      ByteSize: 32
+      GoRuntimeType: 672704
+      GoKind: 17
+      Count: 4
+      HasCount: true
+      Element: 1 BaseType int
+    - __kind: ArrayType
+      ID: 117
+      Name: '[4]string'
+      ByteSize: 64
+      GoRuntimeType: 672992
+      GoKind: 17
+      Count: 4
+      HasCount: true
+      Element: 8 GoStringHeaderType string
+    - __kind: ArrayType
+      ID: 2
+      Name: '[5]int'
+      ByteSize: 40
+      GoKind: 17
+      Count: 5
+      HasCount: true
+      Element: 1 BaseType int
+    - __kind: GoSliceHeaderType
+      ID: 34
+      Name: '[]*string'
+      ByteSize: 24
+      GoRuntimeType: 470528
+      GoKind: 23
+      RawFields:
+        - Name: array
+          Offset: 0
+          Type: 35 PointerType **string
+        - Name: len
+          Offset: 8
+          Type: 1 BaseType int
+        - Name: cap
+          Offset: 16
+          Type: 1 BaseType int
+      Data: 240 GoSliceDataType []*string.array
+    - __kind: GoSliceDataType
+      ID: 240
+      Name: '[]*string.array'
+      ByteSize: 2048
+      Element: 36 PointerType *string
+    - __kind: GoSliceDataType
+      ID: 268
+      Name: '[]*table<[4]int,[4]int>.array'
+      ByteSize: 8192
+      Element: 195 PointerType *table<[4]int,[4]int>
+    - __kind: GoSliceDataType
+      ID: 266
+      Name: '[]*table<[4]int,uint8>.array'
+      ByteSize: 8192
+      Element: 184 PointerType *table<[4]int,uint8>
+    - __kind: GoSliceDataType
+      ID: 252
+      Name: '[]*table<[4]string,[2]int>.array'
+      ByteSize: 8192
+      Element: 110 PointerType *table<[4]string,[2]int>
+    - __kind: GoSliceDataType
+      ID: 258
+      Name: '[]*table<bool,main.node>.array'
+      ByteSize: 8192
+      Element: 137 PointerType *table<bool,main.node>
+    - __kind: GoSliceDataType
+      ID: 242
+      Name: '[]*table<int,int>.array'
+      ByteSize: 8192
+      Element: 64 PointerType *table<int,int>
+    - __kind: GoSliceDataType
+      ID: 260
+      Name: '[]*table<int,uint8>.array'
+      ByteSize: 8192
+      Element: 150 PointerType *table<int,uint8>
+    - __kind: GoSliceDataType
+      ID: 254
+      Name: '[]*table<string,[]main.structWithMap>.array'
+      ByteSize: 8192
+      Element: 124 PointerType *table<string,[]main.structWithMap>
+    - __kind: GoSliceDataType
+      ID: 248
+      Name: '[]*table<string,[]string>.array'
+      ByteSize: 8192
+      Element: 98 PointerType *table<string,[]string>
+    - __kind: GoSliceDataType
+      ID: 246
+      Name: '[]*table<string,int>.array'
+      ByteSize: 8192
+      Element: 87 PointerType *table<string,int>
+    - __kind: GoSliceDataType
+      ID: 244
+      Name: '[]*table<string,main.nestedStruct>.array'
+      ByteSize: 8192
+      Element: 75 PointerType *table<string,main.nestedStruct>
+    - __kind: GoSliceDataType
+      ID: 264
+      Name: '[]*table<uint8,[4]int>.array'
+      ByteSize: 8192
+      Element: 172 PointerType *table<uint8,[4]int>
+    - __kind: GoSliceDataType
+      ID: 262
+      Name: '[]*table<uint8,uint8>.array'
+      ByteSize: 8192
+      Element: 161 PointerType *table<uint8,uint8>
+    - __kind: GoSliceHeaderType
+      ID: 211
+      Name: '[][]uint'
+      ByteSize: 24
+      GoKind: 23
+      RawFields:
+        - Name: array
+          Offset: 0
+          Type: 212 PointerType *[]uint
+        - Name: len
+          Offset: 8
+          Type: 1 BaseType int
+        - Name: cap
+          Offset: 16
+          Type: 1 BaseType int
+      Data: 274 GoSliceDataType [][]uint.array
+    - __kind: GoSliceDataType
+      ID: 274
+      Name: '[][]uint.array'
+      ByteSize: 2048
+      Element: 210 GoSliceHeaderType []uint
+    - __kind: GoSliceHeaderType
+      ID: 216
+      Name: '[]bool'
+      ByteSize: 24
+      GoRuntimeType: 478400
+      GoKind: 23
+      RawFields:
+        - Name: array
+          Offset: 0
+          Type: 206 PointerType *bool
+        - Name: len
+          Offset: 8
+          Type: 1 BaseType int
+        - Name: cap
+          Offset: 16
+          Type: 1 BaseType int
+      Data: 278 GoSliceDataType []bool.array
+    - __kind: GoSliceDataType
+      ID: 278
+      Name: '[]bool.array'
+      ByteSize: 2048
+      Element: 11 BaseType bool
+    - __kind: GoSliceHeaderType
+      ID: 131
+      Name: '[]main.structWithMap'
+      ByteSize: 24
+      GoRuntimeType: 469760
+      GoKind: 23
+      RawFields:
+        - Name: array
+          Offset: 0
+          Type: 132 PointerType *main.structWithMap
+        - Name: len
+          Offset: 8
+          Type: 1 BaseType int
+        - Name: cap
+          Offset: 16
+          Type: 1 BaseType int
+      Data: 256 GoSliceDataType []main.structWithMap.array
+    - __kind: GoSliceDataType
+      ID: 256
+      Name: '[]main.structWithMap.array'
+      ByteSize: 2048
+      Element: 58 StructureType main.structWithMap
+    - __kind: GoSliceHeaderType
+      ID: 213
+      Name: '[]main.structWithNoStrings'
+      ByteSize: 24
+      GoKind: 23
+      RawFields:
+        - Name: array
+          Offset: 0
+          Type: 214 PointerType *main.structWithNoStrings
+        - Name: len
+          Offset: 8
+          Type: 1 BaseType int
+        - Name: cap
+          Offset: 16
+          Type: 1 BaseType int
+      Data: 276 GoSliceDataType []main.structWithNoStrings.array
+    - __kind: GoSliceDataType
+      ID: 276
+      Name: '[]main.structWithNoStrings.array'
+      ByteSize: 2048
+      Element: 215 StructureType main.structWithNoStrings
+    - __kind: GoSliceDataType
+      ID: 269
+      Name: '[]noalg.map.group[[4]int][4]int.array'
+      ByteSize: 2048
+      Element: 199 StructureType noalg.map.group[[4]int][4]int
+    - __kind: GoSliceDataType
+      ID: 267
+      Name: '[]noalg.map.group[[4]int]uint8.array'
+      ByteSize: 2048
+      Element: 188 StructureType noalg.map.group[[4]int]uint8
+    - __kind: GoSliceDataType
+      ID: 253
+      Name: '[]noalg.map.group[[4]string][2]int.array'
+      ByteSize: 2048
+      Element: 114 StructureType noalg.map.group[[4]string][2]int
+    - __kind: GoSliceDataType
+      ID: 259
+      Name: '[]noalg.map.group[bool]main.node.array'
+      ByteSize: 2048
+      Element: 141 StructureType noalg.map.group[bool]main.node
+    - __kind: GoSliceDataType
+      ID: 243
+      Name: '[]noalg.map.group[int]int.array'
+      ByteSize: 2048
+      Element: 68 StructureType noalg.map.group[int]int
+    - __kind: GoSliceDataType
+      ID: 261
+      Name: '[]noalg.map.group[int]uint8.array'
+      ByteSize: 2048
+      Element: 154 StructureType noalg.map.group[int]uint8
+    - __kind: GoSliceDataType
+      ID: 255
+      Name: '[]noalg.map.group[string][]main.structWithMap.array'
+      ByteSize: 2048
+      Element: 128 StructureType noalg.map.group[string][]main.structWithMap
+    - __kind: GoSliceDataType
+      ID: 249
+      Name: '[]noalg.map.group[string][]string.array'
+      ByteSize: 2048
+      Element: 102 StructureType noalg.map.group[string][]string
+    - __kind: GoSliceDataType
+      ID: 247
+      Name: '[]noalg.map.group[string]int.array'
+      ByteSize: 2048
+      Element: 91 StructureType noalg.map.group[string]int
+    - __kind: GoSliceDataType
+      ID: 245
+      Name: '[]noalg.map.group[string]main.nestedStruct.array'
+      ByteSize: 2048
+      Element: 79 StructureType noalg.map.group[string]main.nestedStruct
+    - __kind: GoSliceDataType
+      ID: 265
+      Name: '[]noalg.map.group[uint8][4]int.array'
+      ByteSize: 2048
+      Element: 176 StructureType noalg.map.group[uint8][4]int
+    - __kind: GoSliceDataType
+      ID: 263
+      Name: '[]noalg.map.group[uint8]uint8.array'
+      ByteSize: 2048
+      Element: 165 StructureType noalg.map.group[uint8]uint8
+    - __kind: GoSliceHeaderType
+      ID: 105
+      Name: '[]string'
+      ByteSize: 24
+      GoRuntimeType: 478528
+      GoKind: 23
+      RawFields:
+        - Name: array
+          Offset: 0
+          Type: 36 PointerType *string
+        - Name: len
+          Offset: 8
+          Type: 1 BaseType int
+        - Name: cap
+          Offset: 16
+          Type: 1 BaseType int
+      Data: 250 GoSliceDataType []string.array
+    - __kind: GoSliceDataType
+      ID: 250
+      Name: '[]string.array'
+      ByteSize: 2048
+      Element: 8 GoStringHeaderType string
+    - __kind: GoSliceHeaderType
+      ID: 210
+      Name: '[]uint'
+      ByteSize: 24
+      GoRuntimeType: 478016
+      GoKind: 23
+      RawFields:
+        - Name: array
+          Offset: 0
+          Type: 205 PointerType *uint
+        - Name: len
+          Offset: 8
+          Type: 1 BaseType int
+        - Name: cap
+          Offset: 16
+          Type: 1 BaseType int
+      Data: 272 GoSliceDataType []uint.array
+    - __kind: GoSliceDataType
+      ID: 272
+      Name: '[]uint.array'
+      ByteSize: 2048
+      Element: 20 BaseType uint
+    - __kind: GoSliceHeaderType
+      ID: 217
+      Name: '[]uint16'
+      ByteSize: 24
+      GoRuntimeType: 477376
+      GoKind: 23
+      RawFields:
+        - Name: array
+          Offset: 0
+          Type: 218 PointerType *uint16
+        - Name: len
+          Offset: 8
+          Type: 1 BaseType int
+        - Name: cap
+          Offset: 16
+          Type: 1 BaseType int
+      Data: 280 GoSliceDataType []uint16.array
+    - __kind: GoSliceDataType
+      ID: 280
+      Name: '[]uint16.array'
+      ByteSize: 2048
+      Element: 22 BaseType uint16
+    - __kind: BaseType
+      ID: 11
+      Name: bool
+      ByteSize: 1
+      GoRuntimeType: 575840
+      GoKind: 1
+    - __kind: GoChannelType
+      ID: 202
+      Name: chan bool
+      GoRuntimeType: 587168
+      GoKind: 18
+    - __kind: GoChannelType
+      ID: 40
+      Name: chan struct {}
+      GoRuntimeType: 586080
+      GoKind: 18
+    - __kind: BaseType
+      ID: 229
+      Name: complex128
+      ByteSize: 16
+      GoRuntimeType: 575648
+      GoKind: 16
+    - __kind: BaseType
+      ID: 228
+      Name: complex64
+      ByteSize: 8
+      GoRuntimeType: 575584
+      GoKind: 15
+    - __kind: GoInterfaceType
+      ID: 57
+      Name: error
+      ByteSize: 16
+      GoRuntimeType: 1.015744e+06
+      GoKind: 20
+      RawFields:
+        - Name: tab
+          Offset: 0
+          Type: 38 VoidPointerType unsafe.Pointer
+        - Name: data
+          Offset: 8
+          Type: 38 VoidPointerType unsafe.Pointer
+    - __kind: BaseType
+      ID: 30
+      Name: float32
+      ByteSize: 4
+      GoRuntimeType: 575712
+      GoKind: 13
+    - __kind: BaseType
+      ID: 31
+      Name: float64
+      ByteSize: 8
+      GoRuntimeType: 575776
+      GoKind: 14
+    - __kind: GoSubroutineType
+      ID: 43
+      Name: func()
+      ByteSize: 8
+      GoRuntimeType: 468800
+      GoKind: 19
+    - __kind: GoSwissMapGroupsType
+      ID: 197
+      Name: groupReference<[4]int,[4]int>
+      ByteSize: 16
+      GoKind: 25
+      RawFields:
+        - Name: data
+          Offset: 0
+          Type: 198 PointerType *noalg.map.group[[4]int][4]int
+        - Name: lengthMask
+          Offset: 8
+          Type: 26 BaseType uint64
+      GroupType: 199 StructureType noalg.map.group[[4]int][4]int
+      GroupSliceType: 269 GoSliceDataType []noalg.map.group[[4]int][4]int.array
+    - __kind: GoSwissMapGroupsType
+      ID: 186
+      Name: groupReference<[4]int,uint8>
+      ByteSize: 16
+      GoKind: 25
+      RawFields:
+        - Name: data
+          Offset: 0
+          Type: 187 PointerType *noalg.map.group[[4]int]uint8
+        - Name: lengthMask
+          Offset: 8
+          Type: 26 BaseType uint64
+      GroupType: 188 StructureType noalg.map.group[[4]int]uint8
+      GroupSliceType: 267 GoSliceDataType []noalg.map.group[[4]int]uint8.array
+    - __kind: GoSwissMapGroupsType
+      ID: 112
+      Name: groupReference<[4]string,[2]int>
+      ByteSize: 16
+      GoKind: 25
+      RawFields:
+        - Name: data
+          Offset: 0
+          Type: 113 PointerType *noalg.map.group[[4]string][2]int
+        - Name: lengthMask
+          Offset: 8
+          Type: 26 BaseType uint64
+      GroupType: 114 StructureType noalg.map.group[[4]string][2]int
+      GroupSliceType: 253 GoSliceDataType []noalg.map.group[[4]string][2]int.array
+    - __kind: GoSwissMapGroupsType
+      ID: 139
+      Name: groupReference<bool,main.node>
+      ByteSize: 16
+      GoKind: 25
+      RawFields:
+        - Name: data
+          Offset: 0
+          Type: 140 PointerType *noalg.map.group[bool]main.node
+        - Name: lengthMask
+          Offset: 8
+          Type: 26 BaseType uint64
+      GroupType: 141 StructureType noalg.map.group[bool]main.node
+      GroupSliceType: 259 GoSliceDataType []noalg.map.group[bool]main.node.array
+    - __kind: GoSwissMapGroupsType
+      ID: 66
+      Name: groupReference<int,int>
+      ByteSize: 16
+      GoKind: 25
+      RawFields:
+        - Name: data
+          Offset: 0
+          Type: 67 PointerType *noalg.map.group[int]int
+        - Name: lengthMask
+          Offset: 8
+          Type: 26 BaseType uint64
+      GroupType: 68 StructureType noalg.map.group[int]int
+      GroupSliceType: 243 GoSliceDataType []noalg.map.group[int]int.array
+    - __kind: GoSwissMapGroupsType
+      ID: 152
+      Name: groupReference<int,uint8>
+      ByteSize: 16
+      GoKind: 25
+      RawFields:
+        - Name: data
+          Offset: 0
+          Type: 153 PointerType *noalg.map.group[int]uint8
+        - Name: lengthMask
+          Offset: 8
+          Type: 26 BaseType uint64
+      GroupType: 154 StructureType noalg.map.group[int]uint8
+      GroupSliceType: 261 GoSliceDataType []noalg.map.group[int]uint8.array
+    - __kind: GoSwissMapGroupsType
+      ID: 126
+      Name: groupReference<string,[]main.structWithMap>
+      ByteSize: 16
+      GoKind: 25
+      RawFields:
+        - Name: data
+          Offset: 0
+          Type: 127 PointerType *noalg.map.group[string][]main.structWithMap
+        - Name: lengthMask
+          Offset: 8
+          Type: 26 BaseType uint64
+      GroupType: 128 StructureType noalg.map.group[string][]main.structWithMap
+      GroupSliceType: 255 GoSliceDataType []noalg.map.group[string][]main.structWithMap.array
+    - __kind: GoSwissMapGroupsType
+      ID: 100
+      Name: groupReference<string,[]string>
+      ByteSize: 16
+      GoKind: 25
+      RawFields:
+        - Name: data
+          Offset: 0
+          Type: 101 PointerType *noalg.map.group[string][]string
+        - Name: lengthMask
+          Offset: 8
+          Type: 26 BaseType uint64
+      GroupType: 102 StructureType noalg.map.group[string][]string
+      GroupSliceType: 249 GoSliceDataType []noalg.map.group[string][]string.array
+    - __kind: GoSwissMapGroupsType
+      ID: 89
+      Name: groupReference<string,int>
+      ByteSize: 16
+      GoKind: 25
+      RawFields:
+        - Name: data
+          Offset: 0
+          Type: 90 PointerType *noalg.map.group[string]int
+        - Name: lengthMask
+          Offset: 8
+          Type: 26 BaseType uint64
+      GroupType: 91 StructureType noalg.map.group[string]int
+      GroupSliceType: 247 GoSliceDataType []noalg.map.group[string]int.array
+    - __kind: GoSwissMapGroupsType
+      ID: 77
+      Name: groupReference<string,main.nestedStruct>
+      ByteSize: 16
+      GoKind: 25
+      RawFields:
+        - Name: data
+          Offset: 0
+          Type: 78 PointerType *noalg.map.group[string]main.nestedStruct
+        - Name: lengthMask
+          Offset: 8
+          Type: 26 BaseType uint64
+      GroupType: 79 StructureType noalg.map.group[string]main.nestedStruct
+      GroupSliceType: 245 GoSliceDataType []noalg.map.group[string]main.nestedStruct.array
+    - __kind: GoSwissMapGroupsType
+      ID: 174
+      Name: groupReference<uint8,[4]int>
+      ByteSize: 16
+      GoKind: 25
+      RawFields:
+        - Name: data
+          Offset: 0
+          Type: 175 PointerType *noalg.map.group[uint8][4]int
+        - Name: lengthMask
+          Offset: 8
+          Type: 26 BaseType uint64
+      GroupType: 176 StructureType noalg.map.group[uint8][4]int
+      GroupSliceType: 265 GoSliceDataType []noalg.map.group[uint8][4]int.array
+    - __kind: GoSwissMapGroupsType
+      ID: 163
+      Name: groupReference<uint8,uint8>
+      ByteSize: 16
+      GoKind: 25
+      RawFields:
+        - Name: data
+          Offset: 0
+          Type: 164 PointerType *noalg.map.group[uint8]uint8
+        - Name: lengthMask
+          Offset: 8
+          Type: 26 BaseType uint64
+      GroupType: 165 StructureType noalg.map.group[uint8]uint8
+      GroupSliceType: 263 GoSliceDataType []noalg.map.group[uint8]uint8.array
+    - __kind: BaseType
+      ID: 1
+      Name: int
+      ByteSize: 8
+      GoRuntimeType: 575392
+      GoKind: 2
+    - __kind: BaseType
+      ID: 16
+      Name: int16
+      ByteSize: 2
+      GoRuntimeType: 575008
+      GoKind: 4
+    - __kind: BaseType
+      ID: 6
+      Name: int32
+      ByteSize: 4
+      GoRuntimeType: 575136
+      GoKind: 5
+    - __kind: BaseType
+      ID: 18
+      Name: int64
+      ByteSize: 8
+      GoRuntimeType: 575264
+      GoKind: 6
+    - __kind: BaseType
+      ID: 14
+      Name: int8
+      ByteSize: 1
+      GoRuntimeType: 574880
+      GoKind: 3
+    - __kind: GoEmptyInterfaceType
+      ID: 41
+      Name: interface {}
+      ByteSize: 16
+      GoRuntimeType: 837760
+      GoKind: 20
+      RawFields:
+        - Name: _type
+          Offset: 0
+          Type: 38 VoidPointerType unsafe.Pointer
+        - Name: data
+          Offset: 8
+          Type: 38 VoidPointerType unsafe.Pointer
+    - __kind: StructureType
+      ID: 48
+      Name: internal/sync.Mutex
+      ByteSize: 8
+      GoRuntimeType: 1.453952e+06
+      GoKind: 25
+      RawFields:
+        - Name: state
+          Offset: 0
+          Type: 6 BaseType int32
+        - Name: sema
+          Offset: 4
+          Type: 24 BaseType uint32
+    - __kind: GoInterfaceType
+      ID: 37
+      Name: io.Writer
+      ByteSize: 16
+      GoRuntimeType: 1.011776e+06
+      GoKind: 20
+      RawFields:
+        - Name: tab
+          Offset: 0
+          Type: 38 VoidPointerType unsafe.Pointer
+        - Name: data
+          Offset: 8
+          Type: 38 VoidPointerType unsafe.Pointer
+    - __kind: StructureType
+      ID: 223
+      Name: main.aStruct
+      ByteSize: 56
+      GoKind: 25
+      RawFields:
+        - Name: aBool
+          Offset: 0
+          Type: 11 BaseType bool
+        - Name: aString
+          Offset: 8
+          Type: 8 GoStringHeaderType string
+        - Name: aNumber
+          Offset: 24
+          Type: 1 BaseType int
+        - Name: nested
+          Offset: 32
+          Type: 82 StructureType main.nestedStruct
+    - __kind: GoInterfaceType
+      ID: 56
+      Name: main.behavior
+      ByteSize: 16
+      GoRuntimeType: 1.011392e+06
+      GoKind: 20
+      RawFields:
+        - Name: tab
+          Offset: 0
+          Type: 38 VoidPointerType unsafe.Pointer
+        - Name: data
+          Offset: 8
+          Type: 38 VoidPointerType unsafe.Pointer
+    - __kind: StructureType
+      ID: 33
+      Name: main.bigStruct
+      ByteSize: 48
+      GoKind: 25
+      RawFields:
+        - Name: x
+          Offset: 0
+          Type: 34 GoSliceHeaderType []*string
+        - Name: z
+          Offset: 24
+          Type: 1 BaseType int
+        - Name: writer
+          Offset: 32
+          Type: 37 GoInterfaceType io.Writer
+    - __kind: StructureType
+      ID: 224
+      Name: main.emptyStruct
+      GoKind: 25
+      RawFields: []
+    - __kind: StructureType
+      ID: 45
+      Name: main.esotericHeap
+      ByteSize: 112
+      GoRuntimeType: 1.811168e+06
+      GoKind: 25
+      RawFields:
+        - Name: esotericStack
+          Offset: 0
+          Type: 39 StructureType main.esotericStack
+        - Name: mu
+          Offset: 64
+          Type: 46 StructureType sync.Mutex
+        - Name: once
+          Offset: 72
+          Type: 49 StructureType sync.Once
+        - Name: wg
+          Offset: 88
+          Type: 52 StructureType sync.WaitGroup
+        - Name: a
+          Offset: 104
+          Type: 55 StructureType sync/atomic.Int32
+    - __kind: StructureType
+      ID: 39
+      Name: main.esotericStack
+      ByteSize: 64
+      GoRuntimeType: 1.944768e+06
+      GoKind: 25
+      RawFields:
+        - Name: _
+          Offset: 0
+          Type: 6 BaseType int32
+        - Name: _valid
+          Offset: 4
+          Type: 6 BaseType int32
+        - Name: c
+          Offset: 8
+          Type: 40 GoChannelType chan struct {}
+        - Name: val
+          Offset: 16
+          Type: 41 GoEmptyInterfaceType interface {}
+        - Name: _
+          Offset: 32
+          Type: 26 BaseType uint64
+        - Name: work
+          Offset: 40
+          Type: 42 GoInterfaceType main.something
+        - Name: foo
+          Offset: 56
+          Type: 43 GoSubroutineType func()
+    - __kind: StructureType
+      ID: 82
+      Name: main.nestedStruct
+      ByteSize: 24
+      GoRuntimeType: 1.443392e+06
+      GoKind: 25
+      RawFields:
+        - Name: anotherInt
+          Offset: 0
+          Type: 1 BaseType int
+        - Name: anotherString
+          Offset: 8
+          Type: 8 GoStringHeaderType string
+    - __kind: StructureType
+      ID: 144
+      Name: main.node
+      ByteSize: 16
+      GoRuntimeType: 1.443232e+06
+      GoKind: 25
+      RawFields:
+        - Name: val
+          Offset: 0
+          Type: 1 BaseType int
+        - Name: b
+          Offset: 8
+          Type: 145 PointerType *main.node
+    - __kind: StructureType
+      ID: 222
+      Name: main.oneStringStruct
+      ByteSize: 16
+      GoKind: 25
+      RawFields:
+        - Name: a
+          Offset: 0
+          Type: 8 GoStringHeaderType string
+    - __kind: GoInterfaceType
+      ID: 42
+      Name: main.something
+      ByteSize: 16
+      GoRuntimeType: 1.01152e+06
+      GoKind: 20
+      RawFields:
+        - Name: tab
+          Offset: 0
+          Type: 38 VoidPointerType unsafe.Pointer
+        - Name: data
+          Offset: 8
+          Type: 38 VoidPointerType unsafe.Pointer
+    - __kind: StructureType
+      ID: 58
+      Name: main.structWithMap
+      ByteSize: 8
+      GoRuntimeType: 1.172832e+06
+      GoKind: 25
+      RawFields:
+        - Name: m
+          Offset: 0
+          Type: 59 GoMapType map[int]int
+    - __kind: StructureType
+      ID: 215
+      Name: main.structWithNoStrings
+      ByteSize: 2
+      GoKind: 25
+      RawFields:
+        - Name: aUint8
+          Offset: 0
+          Type: 4 BaseType uint8
+        - Name: aBool
+          Offset: 1
+          Type: 11 BaseType bool
+    - __kind: StructureType
+      ID: 204
+      Name: main.structWithTwoValues
+      ByteSize: 16
+      GoKind: 25
+      RawFields:
+        - Name: a
+          Offset: 0
+          Type: 20 BaseType uint
+        - Name: b
+          Offset: 8
+          Type: 11 BaseType bool
+    - __kind: GoSliceHeaderType
+      ID: 208
+      Name: main.t
+      ByteSize: 24
+      GoKind: 23
+      RawFields:
+        - Name: array
+          Offset: 0
+          Type: 209 PointerType **main.t
+        - Name: len
+          Offset: 8
+          Type: 1 BaseType int
+        - Name: cap
+          Offset: 16
+          Type: 1 BaseType int
+      Data: 270 GoSliceDataType main.t.array
+    - __kind: GoSliceDataType
+      ID: 270
+      Name: main.t.array
+      ByteSize: 2048
+      Element: 207 PointerType *main.t
+    - __kind: StructureType
+      ID: 219
+      Name: main.threeStringStruct
+      ByteSize: 48
+      GoKind: 25
+      RawFields:
+        - Name: a
+          Offset: 0
+          Type: 8 GoStringHeaderType string
+        - Name: b
+          Offset: 16
+          Type: 8 GoStringHeaderType string
+        - Name: c
+          Offset: 32
+          Type: 8 GoStringHeaderType string
+    - __kind: BaseType
+      ID: 32
+      Name: main.typeAlias
+      ByteSize: 2
+      GoKind: 9
+    - __kind: GoSwissMapHeaderType
+      ID: 193
+      Name: map<[4]int,[4]int>
+      ByteSize: 48
+      GoKind: 25
+      RawFields:
+        - Name: used
+          Offset: 0
+          Type: 26 BaseType uint64
+        - Name: seed
+          Offset: 8
+          Type: 62 BaseType uintptr
+        - Name: dirPtr
+          Offset: 16
+          Type: 194 PointerType **table<[4]int,[4]int>
+        - Name: dirLen
+          Offset: 24
+          Type: 1 BaseType int
+        - Name: globalDepth
+          Offset: 32
+          Type: 4 BaseType uint8
+        - Name: globalShift
+          Offset: 33
+          Type: 4 BaseType uint8
+        - Name: writing
+          Offset: 34
+          Type: 4 BaseType uint8
+        - Name: clearSeq
+          Offset: 40
+          Type: 26 BaseType uint64
+      TablePtrSliceType: 268 GoSliceDataType []*table<[4]int,[4]int>.array
+      GroupType: 199 StructureType noalg.map.group[[4]int][4]int
+    - __kind: GoSwissMapHeaderType
+      ID: 182
+      Name: map<[4]int,uint8>
+      ByteSize: 48
+      GoKind: 25
+      RawFields:
+        - Name: used
+          Offset: 0
+          Type: 26 BaseType uint64
+        - Name: seed
+          Offset: 8
+          Type: 62 BaseType uintptr
+        - Name: dirPtr
+          Offset: 16
+          Type: 183 PointerType **table<[4]int,uint8>
+        - Name: dirLen
+          Offset: 24
+          Type: 1 BaseType int
+        - Name: globalDepth
+          Offset: 32
+          Type: 4 BaseType uint8
+        - Name: globalShift
+          Offset: 33
+          Type: 4 BaseType uint8
+        - Name: writing
+          Offset: 34
+          Type: 4 BaseType uint8
+        - Name: clearSeq
+          Offset: 40
+          Type: 26 BaseType uint64
+      TablePtrSliceType: 266 GoSliceDataType []*table<[4]int,uint8>.array
+      GroupType: 188 StructureType noalg.map.group[[4]int]uint8
+    - __kind: GoSwissMapHeaderType
+      ID: 108
+      Name: map<[4]string,[2]int>
+      ByteSize: 48
+      GoKind: 25
+      RawFields:
+        - Name: used
+          Offset: 0
+          Type: 26 BaseType uint64
+        - Name: seed
+          Offset: 8
+          Type: 62 BaseType uintptr
+        - Name: dirPtr
+          Offset: 16
+          Type: 109 PointerType **table<[4]string,[2]int>
+        - Name: dirLen
+          Offset: 24
+          Type: 1 BaseType int
+        - Name: globalDepth
+          Offset: 32
+          Type: 4 BaseType uint8
+        - Name: globalShift
+          Offset: 33
+          Type: 4 BaseType uint8
+        - Name: writing
+          Offset: 34
+          Type: 4 BaseType uint8
+        - Name: clearSeq
+          Offset: 40
+          Type: 26 BaseType uint64
+      TablePtrSliceType: 252 GoSliceDataType []*table<[4]string,[2]int>.array
+      GroupType: 114 StructureType noalg.map.group[[4]string][2]int
+    - __kind: GoSwissMapHeaderType
+      ID: 135
+      Name: map<bool,main.node>
+      ByteSize: 48
+      GoKind: 25
+      RawFields:
+        - Name: used
+          Offset: 0
+          Type: 26 BaseType uint64
+        - Name: seed
+          Offset: 8
+          Type: 62 BaseType uintptr
+        - Name: dirPtr
+          Offset: 16
+          Type: 136 PointerType **table<bool,main.node>
+        - Name: dirLen
+          Offset: 24
+          Type: 1 BaseType int
+        - Name: globalDepth
+          Offset: 32
+          Type: 4 BaseType uint8
+        - Name: globalShift
+          Offset: 33
+          Type: 4 BaseType uint8
+        - Name: writing
+          Offset: 34
+          Type: 4 BaseType uint8
+        - Name: clearSeq
+          Offset: 40
+          Type: 26 BaseType uint64
+      TablePtrSliceType: 258 GoSliceDataType []*table<bool,main.node>.array
+      GroupType: 141 StructureType noalg.map.group[bool]main.node
+    - __kind: GoSwissMapHeaderType
+      ID: 61
+      Name: map<int,int>
+      ByteSize: 48
+      GoKind: 25
+      RawFields:
+        - Name: used
+          Offset: 0
+          Type: 26 BaseType uint64
+        - Name: seed
+          Offset: 8
+          Type: 62 BaseType uintptr
+        - Name: dirPtr
+          Offset: 16
+          Type: 63 PointerType **table<int,int>
+        - Name: dirLen
+          Offset: 24
+          Type: 1 BaseType int
+        - Name: globalDepth
+          Offset: 32
+          Type: 4 BaseType uint8
+        - Name: globalShift
+          Offset: 33
+          Type: 4 BaseType uint8
+        - Name: writing
+          Offset: 34
+          Type: 4 BaseType uint8
+        - Name: clearSeq
+          Offset: 40
+          Type: 26 BaseType uint64
+      TablePtrSliceType: 242 GoSliceDataType []*table<int,int>.array
+      GroupType: 68 StructureType noalg.map.group[int]int
+    - __kind: GoSwissMapHeaderType
+      ID: 148
+      Name: map<int,uint8>
+      ByteSize: 48
+      GoKind: 25
+      RawFields:
+        - Name: used
+          Offset: 0
+          Type: 26 BaseType uint64
+        - Name: seed
+          Offset: 8
+          Type: 62 BaseType uintptr
+        - Name: dirPtr
+          Offset: 16
+          Type: 149 PointerType **table<int,uint8>
+        - Name: dirLen
+          Offset: 24
+          Type: 1 BaseType int
+        - Name: globalDepth
+          Offset: 32
+          Type: 4 BaseType uint8
+        - Name: globalShift
+          Offset: 33
+          Type: 4 BaseType uint8
+        - Name: writing
+          Offset: 34
+          Type: 4 BaseType uint8
+        - Name: clearSeq
+          Offset: 40
+          Type: 26 BaseType uint64
+      TablePtrSliceType: 260 GoSliceDataType []*table<int,uint8>.array
+      GroupType: 154 StructureType noalg.map.group[int]uint8
+    - __kind: GoSwissMapHeaderType
+      ID: 122
+      Name: map<string,[]main.structWithMap>
+      ByteSize: 48
+      GoKind: 25
+      RawFields:
+        - Name: used
+          Offset: 0
+          Type: 26 BaseType uint64
+        - Name: seed
+          Offset: 8
+          Type: 62 BaseType uintptr
+        - Name: dirPtr
+          Offset: 16
+          Type: 123 PointerType **table<string,[]main.structWithMap>
+        - Name: dirLen
+          Offset: 24
+          Type: 1 BaseType int
+        - Name: globalDepth
+          Offset: 32
+          Type: 4 BaseType uint8
+        - Name: globalShift
+          Offset: 33
+          Type: 4 BaseType uint8
+        - Name: writing
+          Offset: 34
+          Type: 4 BaseType uint8
+        - Name: clearSeq
+          Offset: 40
+          Type: 26 BaseType uint64
+      TablePtrSliceType: 254 GoSliceDataType []*table<string,[]main.structWithMap>.array
+      GroupType: 128 StructureType noalg.map.group[string][]main.structWithMap
+    - __kind: GoSwissMapHeaderType
+      ID: 96
+      Name: map<string,[]string>
+      ByteSize: 48
+      GoKind: 25
+      RawFields:
+        - Name: used
+          Offset: 0
+          Type: 26 BaseType uint64
+        - Name: seed
+          Offset: 8
+          Type: 62 BaseType uintptr
+        - Name: dirPtr
+          Offset: 16
+          Type: 97 PointerType **table<string,[]string>
+        - Name: dirLen
+          Offset: 24
+          Type: 1 BaseType int
+        - Name: globalDepth
+          Offset: 32
+          Type: 4 BaseType uint8
+        - Name: globalShift
+          Offset: 33
+          Type: 4 BaseType uint8
+        - Name: writing
+          Offset: 34
+          Type: 4 BaseType uint8
+        - Name: clearSeq
+          Offset: 40
+          Type: 26 BaseType uint64
+      TablePtrSliceType: 248 GoSliceDataType []*table<string,[]string>.array
+      GroupType: 102 StructureType noalg.map.group[string][]string
+    - __kind: GoSwissMapHeaderType
+      ID: 85
+      Name: map<string,int>
+      ByteSize: 48
+      GoKind: 25
+      RawFields:
+        - Name: used
+          Offset: 0
+          Type: 26 BaseType uint64
+        - Name: seed
+          Offset: 8
+          Type: 62 BaseType uintptr
+        - Name: dirPtr
+          Offset: 16
+          Type: 86 PointerType **table<string,int>
+        - Name: dirLen
+          Offset: 24
+          Type: 1 BaseType int
+        - Name: globalDepth
+          Offset: 32
+          Type: 4 BaseType uint8
+        - Name: globalShift
+          Offset: 33
+          Type: 4 BaseType uint8
+        - Name: writing
+          Offset: 34
+          Type: 4 BaseType uint8
+        - Name: clearSeq
+          Offset: 40
+          Type: 26 BaseType uint64
+      TablePtrSliceType: 246 GoSliceDataType []*table<string,int>.array
+      GroupType: 91 StructureType noalg.map.group[string]int
+    - __kind: GoSwissMapHeaderType
+      ID: 73
+      Name: map<string,main.nestedStruct>
+      ByteSize: 48
+      GoKind: 25
+      RawFields:
+        - Name: used
+          Offset: 0
+          Type: 26 BaseType uint64
+        - Name: seed
+          Offset: 8
+          Type: 62 BaseType uintptr
+        - Name: dirPtr
+          Offset: 16
+          Type: 74 PointerType **table<string,main.nestedStruct>
+        - Name: dirLen
+          Offset: 24
+          Type: 1 BaseType int
+        - Name: globalDepth
+          Offset: 32
+          Type: 4 BaseType uint8
+        - Name: globalShift
+          Offset: 33
+          Type: 4 BaseType uint8
+        - Name: writing
+          Offset: 34
+          Type: 4 BaseType uint8
+        - Name: clearSeq
+          Offset: 40
+          Type: 26 BaseType uint64
+      TablePtrSliceType: 244 GoSliceDataType []*table<string,main.nestedStruct>.array
+      GroupType: 79 StructureType noalg.map.group[string]main.nestedStruct
+    - __kind: GoSwissMapHeaderType
+      ID: 170
+      Name: map<uint8,[4]int>
+      ByteSize: 48
+      GoKind: 25
+      RawFields:
+        - Name: used
+          Offset: 0
+          Type: 26 BaseType uint64
+        - Name: seed
+          Offset: 8
+          Type: 62 BaseType uintptr
+        - Name: dirPtr
+          Offset: 16
+          Type: 171 PointerType **table<uint8,[4]int>
+        - Name: dirLen
+          Offset: 24
+          Type: 1 BaseType int
+        - Name: globalDepth
+          Offset: 32
+          Type: 4 BaseType uint8
+        - Name: globalShift
+          Offset: 33
+          Type: 4 BaseType uint8
+        - Name: writing
+          Offset: 34
+          Type: 4 BaseType uint8
+        - Name: clearSeq
+          Offset: 40
+          Type: 26 BaseType uint64
+      TablePtrSliceType: 264 GoSliceDataType []*table<uint8,[4]int>.array
+      GroupType: 176 StructureType noalg.map.group[uint8][4]int
+    - __kind: GoSwissMapHeaderType
+      ID: 159
+      Name: map<uint8,uint8>
+      ByteSize: 48
+      GoKind: 25
+      RawFields:
+        - Name: used
+          Offset: 0
+          Type: 26 BaseType uint64
+        - Name: seed
+          Offset: 8
+          Type: 62 BaseType uintptr
+        - Name: dirPtr
+          Offset: 16
+          Type: 160 PointerType **table<uint8,uint8>
+        - Name: dirLen
+          Offset: 24
+          Type: 1 BaseType int
+        - Name: globalDepth
+          Offset: 32
+          Type: 4 BaseType uint8
+        - Name: globalShift
+          Offset: 33
+          Type: 4 BaseType uint8
+        - Name: writing
+          Offset: 34
+          Type: 4 BaseType uint8
+        - Name: clearSeq
+          Offset: 40
+          Type: 26 BaseType uint64
+      TablePtrSliceType: 262 GoSliceDataType []*table<uint8,uint8>.array
+      GroupType: 165 StructureType noalg.map.group[uint8]uint8
+    - __kind: GoMapType
+      ID: 191
+      Name: map[[4]int][4]int
+      ByteSize: 8
+      GoRuntimeType: 1.116896e+06
+      GoKind: 21
+      HeaderType: 193 GoSwissMapHeaderType map<[4]int,[4]int>
+    - __kind: GoMapType
+      ID: 180
+      Name: map[[4]int]uint8
+      ByteSize: 8
+      GoRuntimeType: 1.117024e+06
+      GoKind: 21
+      HeaderType: 182 GoSwissMapHeaderType map<[4]int,uint8>
+    - __kind: GoMapType
+      ID: 106
+      Name: map[[4]string][2]int
+      ByteSize: 8
+      GoRuntimeType: 1.117152e+06
+      GoKind: 21
+      HeaderType: 108 GoSwissMapHeaderType map<[4]string,[2]int>
+    - __kind: GoMapType
+      ID: 133
+      Name: map[bool]main.node
+      ByteSize: 8
+      GoRuntimeType: 1.11728e+06
+      GoKind: 21
+      HeaderType: 135 GoSwissMapHeaderType map<bool,main.node>
+    - __kind: GoMapType
+      ID: 59
+      Name: map[int]int
+      ByteSize: 8
+      GoRuntimeType: 1.116512e+06
+      GoKind: 21
+      HeaderType: 61 GoSwissMapHeaderType map<int,int>
+    - __kind: GoMapType
+      ID: 146
+      Name: map[int]uint8
+      ByteSize: 8
+      GoRuntimeType: 1.117408e+06
+      GoKind: 21
+      HeaderType: 148 GoSwissMapHeaderType map<int,uint8>
+    - __kind: GoMapType
+      ID: 120
+      Name: map[string][]main.structWithMap
+      ByteSize: 8
+      GoRuntimeType: 1.117536e+06
+      GoKind: 21
+      HeaderType: 122 GoSwissMapHeaderType map<string,[]main.structWithMap>
+    - __kind: GoMapType
+      ID: 94
+      Name: map[string][]string
+      ByteSize: 8
+      GoRuntimeType: 1.117664e+06
+      GoKind: 21
+      HeaderType: 96 GoSwissMapHeaderType map<string,[]string>
+    - __kind: GoMapType
+      ID: 83
+      Name: map[string]int
+      ByteSize: 8
+      GoRuntimeType: 1.117792e+06
+      GoKind: 21
+      HeaderType: 85 GoSwissMapHeaderType map<string,int>
+    - __kind: GoMapType
+      ID: 71
+      Name: map[string]main.nestedStruct
+      ByteSize: 8
+      GoRuntimeType: 1.11792e+06
+      GoKind: 21
+      HeaderType: 73 GoSwissMapHeaderType map<string,main.nestedStruct>
+    - __kind: GoMapType
+      ID: 168
+      Name: map[uint8][4]int
+      ByteSize: 8
+      GoRuntimeType: 1.118048e+06
+      GoKind: 21
+      HeaderType: 170 GoSwissMapHeaderType map<uint8,[4]int>
+    - __kind: GoMapType
+      ID: 157
+      Name: map[uint8]uint8
+      ByteSize: 8
+      GoRuntimeType: 1.118176e+06
+      GoKind: 21
+      HeaderType: 159 GoSwissMapHeaderType map<uint8,uint8>
+    - __kind: ArrayType
+      ID: 200
+      Name: noalg.[8]struct { key [4]int; elem [4]int }
+      ByteSize: 512
+      GoRuntimeType: 672800
+      GoKind: 17
+      Count: 8
+      HasCount: true
+      Element: 201 StructureType noalg.struct { key [4]int; elem [4]int }
+    - __kind: ArrayType
+      ID: 189
+      Name: noalg.[8]struct { key [4]int; elem uint8 }
+      ByteSize: 320
+      GoRuntimeType: 672896
+      GoKind: 17
+      Count: 8
+      HasCount: true
+      Element: 190 StructureType noalg.struct { key [4]int; elem uint8 }
+    - __kind: ArrayType
+      ID: 115
+      Name: noalg.[8]struct { key [4]string; elem [2]int }
+      ByteSize: 640
+      GoRuntimeType: 673184
+      GoKind: 17
+      Count: 8
+      HasCount: true
+      Element: 116 StructureType noalg.struct { key [4]string; elem [2]int }
+    - __kind: ArrayType
+      ID: 142
+      Name: noalg.[8]struct { key bool; elem main.node }
+      ByteSize: 192
+      GoRuntimeType: 673280
+      GoKind: 17
+      Count: 8
+      HasCount: true
+      Element: 143 StructureType noalg.struct { key bool; elem main.node }
+    - __kind: ArrayType
+      ID: 69
+      Name: noalg.[8]struct { key int; elem int }
+      ByteSize: 128
+      GoRuntimeType: 671072
+      GoKind: 17
+      Count: 8
+      HasCount: true
+      Element: 70 StructureType noalg.struct { key int; elem int }
+    - __kind: ArrayType
+      ID: 155
+      Name: noalg.[8]struct { key int; elem uint8 }
+      ByteSize: 128
+      GoRuntimeType: 673376
+      GoKind: 17
+      Count: 8
+      HasCount: true
+      Element: 156 StructureType noalg.struct { key int; elem uint8 }
+    - __kind: ArrayType
+      ID: 129
+      Name: noalg.[8]struct { key string; elem []main.structWithMap }
+      ByteSize: 320
+      GoRuntimeType: 673472
+      GoKind: 17
+      Count: 8
+      HasCount: true
+      Element: 130 StructureType noalg.struct { key string; elem []main.structWithMap }
+    - __kind: ArrayType
+      ID: 103
+      Name: noalg.[8]struct { key string; elem []string }
+      ByteSize: 320
+      GoRuntimeType: 673568
+      GoKind: 17
+      Count: 8
+      HasCount: true
+      Element: 104 StructureType noalg.struct { key string; elem []string }
+    - __kind: ArrayType
+      ID: 92
+      Name: noalg.[8]struct { key string; elem int }
+      ByteSize: 192
+      GoRuntimeType: 673664
+      GoKind: 17
+      Count: 8
+      HasCount: true
+      Element: 93 StructureType noalg.struct { key string; elem int }
+    - __kind: ArrayType
+      ID: 80
+      Name: noalg.[8]struct { key string; elem main.nestedStruct }
+      ByteSize: 320
+      GoRuntimeType: 673760
+      GoKind: 17
+      Count: 8
+      HasCount: true
+      Element: 81 StructureType noalg.struct { key string; elem main.nestedStruct }
+    - __kind: ArrayType
+      ID: 177
+      Name: noalg.[8]struct { key uint8; elem [4]int }
+      ByteSize: 320
+      GoRuntimeType: 673856
+      GoKind: 17
+      Count: 8
+      HasCount: true
+      Element: 178 StructureType noalg.struct { key uint8; elem [4]int }
+    - __kind: ArrayType
+      ID: 166
+      Name: noalg.[8]struct { key uint8; elem uint8 }
+      ByteSize: 16
+      GoRuntimeType: 673952
+      GoKind: 17
+      Count: 8
+      HasCount: true
+      Element: 167 StructureType noalg.struct { key uint8; elem uint8 }
+    - __kind: StructureType
+      ID: 199
+      Name: noalg.map.group[[4]int][4]int
+      ByteSize: 520
+      GoRuntimeType: 1.276576e+06
+      GoKind: 25
+      RawFields:
+        - Name: ctrl
+          Offset: 0
+          Type: 26 BaseType uint64
+        - Name: slots
+          Offset: 8
+          Type: 200 ArrayType noalg.[8]struct { key [4]int; elem [4]int }
+    - __kind: StructureType
+      ID: 188
+      Name: noalg.map.group[[4]int]uint8
+      ByteSize: 328
+      GoRuntimeType: 1.276832e+06
+      GoKind: 25
+      RawFields:
+        - Name: ctrl
+          Offset: 0
+          Type: 26 BaseType uint64
+        - Name: slots
+          Offset: 8
+          Type: 189 ArrayType noalg.[8]struct { key [4]int; elem uint8 }
+    - __kind: StructureType
+      ID: 114
+      Name: noalg.map.group[[4]string][2]int
+      ByteSize: 648
+      GoRuntimeType: 1.277088e+06
+      GoKind: 25
+      RawFields:
+        - Name: ctrl
+          Offset: 0
+          Type: 26 BaseType uint64
+        - Name: slots
+          Offset: 8
+          Type: 115 ArrayType noalg.[8]struct { key [4]string; elem [2]int }
+    - __kind: StructureType
+      ID: 141
+      Name: noalg.map.group[bool]main.node
+      ByteSize: 200
+      GoRuntimeType: 1.277344e+06
+      GoKind: 25
+      RawFields:
+        - Name: ctrl
+          Offset: 0
+          Type: 26 BaseType uint64
+        - Name: slots
+          Offset: 8
+          Type: 142 ArrayType noalg.[8]struct { key bool; elem main.node }
+    - __kind: StructureType
+      ID: 68
+      Name: noalg.map.group[int]int
+      ByteSize: 136
+      GoRuntimeType: 1.275808e+06
+      GoKind: 25
+      RawFields:
+        - Name: ctrl
+          Offset: 0
+          Type: 26 BaseType uint64
+        - Name: slots
+          Offset: 8
+          Type: 69 ArrayType noalg.[8]struct { key int; elem int }
+    - __kind: StructureType
+      ID: 154
+      Name: noalg.map.group[int]uint8
+      ByteSize: 136
+      GoRuntimeType: 1.2776e+06
+      GoKind: 25
+      RawFields:
+        - Name: ctrl
+          Offset: 0
+          Type: 26 BaseType uint64
+        - Name: slots
+          Offset: 8
+          Type: 155 ArrayType noalg.[8]struct { key int; elem uint8 }
+    - __kind: StructureType
+      ID: 128
+      Name: noalg.map.group[string][]main.structWithMap
+      ByteSize: 328
+      GoRuntimeType: 1.277856e+06
+      GoKind: 25
+      RawFields:
+        - Name: ctrl
+          Offset: 0
+          Type: 26 BaseType uint64
+        - Name: slots
+          Offset: 8
+          Type: 129 ArrayType noalg.[8]struct { key string; elem []main.structWithMap }
+    - __kind: StructureType
+      ID: 102
+      Name: noalg.map.group[string][]string
+      ByteSize: 328
+      GoRuntimeType: 1.278112e+06
+      GoKind: 25
+      RawFields:
+        - Name: ctrl
+          Offset: 0
+          Type: 26 BaseType uint64
+        - Name: slots
+          Offset: 8
+          Type: 103 ArrayType noalg.[8]struct { key string; elem []string }
+    - __kind: StructureType
+      ID: 91
+      Name: noalg.map.group[string]int
+      ByteSize: 200
+      GoRuntimeType: 1.278368e+06
+      GoKind: 25
+      RawFields:
+        - Name: ctrl
+          Offset: 0
+          Type: 26 BaseType uint64
+        - Name: slots
+          Offset: 8
+          Type: 92 ArrayType noalg.[8]struct { key string; elem int }
+    - __kind: StructureType
+      ID: 79
+      Name: noalg.map.group[string]main.nestedStruct
+      ByteSize: 328
+      GoRuntimeType: 1.278624e+06
+      GoKind: 25
+      RawFields:
+        - Name: ctrl
+          Offset: 0
+          Type: 26 BaseType uint64
+        - Name: slots
+          Offset: 8
+          Type: 80 ArrayType noalg.[8]struct { key string; elem main.nestedStruct }
+    - __kind: StructureType
+      ID: 176
+      Name: noalg.map.group[uint8][4]int
+      ByteSize: 328
+      GoRuntimeType: 1.27888e+06
+      GoKind: 25
+      RawFields:
+        - Name: ctrl
+          Offset: 0
+          Type: 26 BaseType uint64
+        - Name: slots
+          Offset: 8
+          Type: 177 ArrayType noalg.[8]struct { key uint8; elem [4]int }
+    - __kind: StructureType
+      ID: 165
+      Name: noalg.map.group[uint8]uint8
+      ByteSize: 24
+      GoRuntimeType: 1.279136e+06
+      GoKind: 25
+      RawFields:
+        - Name: ctrl
+          Offset: 0
+          Type: 26 BaseType uint64
+        - Name: slots
+          Offset: 8
+          Type: 166 ArrayType noalg.[8]struct { key uint8; elem uint8 }
+    - __kind: StructureType
+      ID: 201
+      Name: noalg.struct { key [4]int; elem [4]int }
+      ByteSize: 64
+      GoRuntimeType: 1.276448e+06
+      GoKind: 25
+      RawFields:
+        - Name: key
+          Offset: 0
+          Type: 179 ArrayType [4]int
+        - Name: elem
+          Offset: 32
+          Type: 179 ArrayType [4]int
+    - __kind: StructureType
+      ID: 190
+      Name: noalg.struct { key [4]int; elem uint8 }
+      ByteSize: 40
+      GoRuntimeType: 1.276704e+06
+      GoKind: 25
+      RawFields:
+        - Name: key
+          Offset: 0
+          Type: 179 ArrayType [4]int
+        - Name: elem
+          Offset: 32
+          Type: 4 BaseType uint8
+    - __kind: StructureType
+      ID: 116
+      Name: noalg.struct { key [4]string; elem [2]int }
+      ByteSize: 80
+      GoRuntimeType: 1.27696e+06
+      GoKind: 25
+      RawFields:
+        - Name: key
+          Offset: 0
+          Type: 117 ArrayType [4]string
+        - Name: elem
+          Offset: 64
+          Type: 12 ArrayType [2]int
+    - __kind: StructureType
+      ID: 143
+      Name: noalg.struct { key bool; elem main.node }
+      ByteSize: 24
+      GoRuntimeType: 1.277216e+06
+      GoKind: 25
+      RawFields:
+        - Name: key
+          Offset: 0
+          Type: 11 BaseType bool
+        - Name: elem
+          Offset: 8
+          Type: 144 StructureType main.node
+    - __kind: StructureType
+      ID: 70
+      Name: noalg.struct { key int; elem int }
+      ByteSize: 16
+      GoRuntimeType: 1.27568e+06
+      GoKind: 25
+      RawFields:
+        - Name: key
+          Offset: 0
+          Type: 1 BaseType int
+        - Name: elem
+          Offset: 8
+          Type: 1 BaseType int
+    - __kind: StructureType
+      ID: 156
+      Name: noalg.struct { key int; elem uint8 }
+      ByteSize: 16
+      GoRuntimeType: 1.277472e+06
+      GoKind: 25
+      RawFields:
+        - Name: key
+          Offset: 0
+          Type: 1 BaseType int
+        - Name: elem
+          Offset: 8
+          Type: 4 BaseType uint8
+    - __kind: StructureType
+      ID: 130
+      Name: noalg.struct { key string; elem []main.structWithMap }
+      ByteSize: 40
+      GoRuntimeType: 1.277728e+06
+      GoKind: 25
+      RawFields:
+        - Name: key
+          Offset: 0
+          Type: 8 GoStringHeaderType string
+        - Name: elem
+          Offset: 16
+          Type: 131 GoSliceHeaderType []main.structWithMap
+    - __kind: StructureType
+      ID: 104
+      Name: noalg.struct { key string; elem []string }
+      ByteSize: 40
+      GoRuntimeType: 1.277984e+06
+      GoKind: 25
+      RawFields:
+        - Name: key
+          Offset: 0
+          Type: 8 GoStringHeaderType string
+        - Name: elem
+          Offset: 16
+          Type: 105 GoSliceHeaderType []string
+    - __kind: StructureType
+      ID: 93
+      Name: noalg.struct { key string; elem int }
+      ByteSize: 24
+      GoRuntimeType: 1.27824e+06
+      GoKind: 25
+      RawFields:
+        - Name: key
+          Offset: 0
+          Type: 8 GoStringHeaderType string
+        - Name: elem
+          Offset: 16
+          Type: 1 BaseType int
+    - __kind: StructureType
+      ID: 81
+      Name: noalg.struct { key string; elem main.nestedStruct }
+      ByteSize: 40
+      GoRuntimeType: 1.278496e+06
+      GoKind: 25
+      RawFields:
+        - Name: key
+          Offset: 0
+          Type: 8 GoStringHeaderType string
+        - Name: elem
+          Offset: 16
+          Type: 82 StructureType main.nestedStruct
+    - __kind: StructureType
+      ID: 178
+      Name: noalg.struct { key uint8; elem [4]int }
+      ByteSize: 40
+      GoRuntimeType: 1.278752e+06
+      GoKind: 25
+      RawFields:
+        - Name: key
+          Offset: 0
+          Type: 4 BaseType uint8
+        - Name: elem
+          Offset: 8
+          Type: 179 ArrayType [4]int
+    - __kind: StructureType
+      ID: 167
+      Name: noalg.struct { key uint8; elem uint8 }
+      ByteSize: 2
+      GoRuntimeType: 1.279008e+06
+      GoKind: 25
+      RawFields:
+        - Name: key
+          Offset: 0
+          Type: 4 BaseType uint8
+        - Name: elem
+          Offset: 1
+          Type: 4 BaseType uint8
+    - __kind: GoStringHeaderType
+      ID: 8
+      Name: string
+      ByteSize: 16
+      GoRuntimeType: 574816
+      GoKind: 24
+      RawFields:
+        - Name: str
+          Offset: 0
+          Type: 239 PointerType *string.str
+        - Name: len
+          Offset: 8
+          Type: 1 BaseType int
+      Data: 238 GoStringDataType string.str
+    - __kind: GoStringDataType
+      ID: 238
+      Name: string.str
+      ByteSize: 2048
+    - __kind: StructureType
+      ID: 46
+      Name: sync.Mutex
+      ByteSize: 8
+      GoRuntimeType: 1.444672e+06
+      GoKind: 25
+      RawFields:
+        - Name: _
+          Offset: 0
+          Type: 47 StructureType sync.noCopy
+        - Name: mu
+          Offset: 0
+          Type: 48 StructureType internal/sync.Mutex
+    - __kind: StructureType
+      ID: 49
+      Name: sync.Once
+      ByteSize: 12
+      GoRuntimeType: 1.593184e+06
+      GoKind: 25
+      RawFields:
+        - Name: _
+          Offset: 0
+          Type: 47 StructureType sync.noCopy
+        - Name: done
+          Offset: 0
+          Type: 50 StructureType sync/atomic.Uint32
+        - Name: m
+          Offset: 4
+          Type: 46 StructureType sync.Mutex
+    - __kind: StructureType
+      ID: 52
+      Name: sync.WaitGroup
+      ByteSize: 16
+      GoRuntimeType: 1.593376e+06
+      GoKind: 25
+      RawFields:
+        - Name: noCopy
+          Offset: 0
+          Type: 47 StructureType sync.noCopy
+        - Name: state
+          Offset: 0
+          Type: 53 StructureType sync/atomic.Uint64
+        - Name: sema
+          Offset: 8
+          Type: 24 BaseType uint32
+    - __kind: StructureType
+      ID: 47
+      Name: sync.noCopy
+      GoRuntimeType: 977056
+      GoKind: 25
+      RawFields: []
+    - __kind: StructureType
+      ID: 55
+      Name: sync/atomic.Int32
+      ByteSize: 4
+      GoRuntimeType: 1.445952e+06
+      GoKind: 25
+      RawFields:
+        - Name: _
+          Offset: 0
+          Type: 51 StructureType sync/atomic.noCopy
+        - Name: v
+          Offset: 0
+          Type: 6 BaseType int32
+    - __kind: StructureType
+      ID: 50
+      Name: sync/atomic.Uint32
+      ByteSize: 4
+      GoRuntimeType: 1.446112e+06
+      GoKind: 25
+      RawFields:
+        - Name: _
+          Offset: 0
+          Type: 51 StructureType sync/atomic.noCopy
+        - Name: v
+          Offset: 0
+          Type: 24 BaseType uint32
+    - __kind: StructureType
+      ID: 53
+      Name: sync/atomic.Uint64
+      ByteSize: 8
+      GoRuntimeType: 1.59376e+06
+      GoKind: 25
+      RawFields:
+        - Name: _
+          Offset: 0
+          Type: 51 StructureType sync/atomic.noCopy
+        - Name: _
+          Offset: 0
+          Type: 54 StructureType sync/atomic.align64
+        - Name: v
+          Offset: 0
+          Type: 26 BaseType uint64
+    - __kind: StructureType
+      ID: 54
+      Name: sync/atomic.align64
+      GoRuntimeType: 977248
+      GoKind: 25
+      RawFields: []
+    - __kind: StructureType
+      ID: 51
+      Name: sync/atomic.noCopy
+      GoRuntimeType: 977152
+      GoKind: 25
+      RawFields: []
+    - __kind: StructureType
+      ID: 196
+      Name: table<[4]int,[4]int>
+      ByteSize: 32
+      GoKind: 25
+      RawFields:
+        - Name: used
+          Offset: 0
+          Type: 22 BaseType uint16
+        - Name: capacity
+          Offset: 2
+          Type: 22 BaseType uint16
+        - Name: growthLeft
+          Offset: 4
+          Type: 22 BaseType uint16
+        - Name: localDepth
+          Offset: 6
+          Type: 4 BaseType uint8
+        - Name: index
+          Offset: 8
+          Type: 1 BaseType int
+        - Name: groups
+          Offset: 16
+          Type: 197 GoSwissMapGroupsType groupReference<[4]int,[4]int>
+    - __kind: StructureType
+      ID: 185
+      Name: table<[4]int,uint8>
+      ByteSize: 32
+      GoKind: 25
+      RawFields:
+        - Name: used
+          Offset: 0
+          Type: 22 BaseType uint16
+        - Name: capacity
+          Offset: 2
+          Type: 22 BaseType uint16
+        - Name: growthLeft
+          Offset: 4
+          Type: 22 BaseType uint16
+        - Name: localDepth
+          Offset: 6
+          Type: 4 BaseType uint8
+        - Name: index
+          Offset: 8
+          Type: 1 BaseType int
+        - Name: groups
+          Offset: 16
+          Type: 186 GoSwissMapGroupsType groupReference<[4]int,uint8>
+    - __kind: StructureType
+      ID: 111
+      Name: table<[4]string,[2]int>
+      ByteSize: 32
+      GoKind: 25
+      RawFields:
+        - Name: used
+          Offset: 0
+          Type: 22 BaseType uint16
+        - Name: capacity
+          Offset: 2
+          Type: 22 BaseType uint16
+        - Name: growthLeft
+          Offset: 4
+          Type: 22 BaseType uint16
+        - Name: localDepth
+          Offset: 6
+          Type: 4 BaseType uint8
+        - Name: index
+          Offset: 8
+          Type: 1 BaseType int
+        - Name: groups
+          Offset: 16
+          Type: 112 GoSwissMapGroupsType groupReference<[4]string,[2]int>
+    - __kind: StructureType
+      ID: 138
+      Name: table<bool,main.node>
+      ByteSize: 32
+      GoKind: 25
+      RawFields:
+        - Name: used
+          Offset: 0
+          Type: 22 BaseType uint16
+        - Name: capacity
+          Offset: 2
+          Type: 22 BaseType uint16
+        - Name: growthLeft
+          Offset: 4
+          Type: 22 BaseType uint16
+        - Name: localDepth
+          Offset: 6
+          Type: 4 BaseType uint8
+        - Name: index
+          Offset: 8
+          Type: 1 BaseType int
+        - Name: groups
+          Offset: 16
+          Type: 139 GoSwissMapGroupsType groupReference<bool,main.node>
+    - __kind: StructureType
+      ID: 65
+      Name: table<int,int>
+      ByteSize: 32
+      GoKind: 25
+      RawFields:
+        - Name: used
+          Offset: 0
+          Type: 22 BaseType uint16
+        - Name: capacity
+          Offset: 2
+          Type: 22 BaseType uint16
+        - Name: growthLeft
+          Offset: 4
+          Type: 22 BaseType uint16
+        - Name: localDepth
+          Offset: 6
+          Type: 4 BaseType uint8
+        - Name: index
+          Offset: 8
+          Type: 1 BaseType int
+        - Name: groups
+          Offset: 16
+          Type: 66 GoSwissMapGroupsType groupReference<int,int>
+    - __kind: StructureType
+      ID: 151
+      Name: table<int,uint8>
+      ByteSize: 32
+      GoKind: 25
+      RawFields:
+        - Name: used
+          Offset: 0
+          Type: 22 BaseType uint16
+        - Name: capacity
+          Offset: 2
+          Type: 22 BaseType uint16
+        - Name: growthLeft
+          Offset: 4
+          Type: 22 BaseType uint16
+        - Name: localDepth
+          Offset: 6
+          Type: 4 BaseType uint8
+        - Name: index
+          Offset: 8
+          Type: 1 BaseType int
+        - Name: groups
+          Offset: 16
+          Type: 152 GoSwissMapGroupsType groupReference<int,uint8>
+    - __kind: StructureType
+      ID: 125
+      Name: table<string,[]main.structWithMap>
+      ByteSize: 32
+      GoKind: 25
+      RawFields:
+        - Name: used
+          Offset: 0
+          Type: 22 BaseType uint16
+        - Name: capacity
+          Offset: 2
+          Type: 22 BaseType uint16
+        - Name: growthLeft
+          Offset: 4
+          Type: 22 BaseType uint16
+        - Name: localDepth
+          Offset: 6
+          Type: 4 BaseType uint8
+        - Name: index
+          Offset: 8
+          Type: 1 BaseType int
+        - Name: groups
+          Offset: 16
+          Type: 126 GoSwissMapGroupsType groupReference<string,[]main.structWithMap>
+    - __kind: StructureType
+      ID: 99
+      Name: table<string,[]string>
+      ByteSize: 32
+      GoKind: 25
+      RawFields:
+        - Name: used
+          Offset: 0
+          Type: 22 BaseType uint16
+        - Name: capacity
+          Offset: 2
+          Type: 22 BaseType uint16
+        - Name: growthLeft
+          Offset: 4
+          Type: 22 BaseType uint16
+        - Name: localDepth
+          Offset: 6
+          Type: 4 BaseType uint8
+        - Name: index
+          Offset: 8
+          Type: 1 BaseType int
+        - Name: groups
+          Offset: 16
+          Type: 100 GoSwissMapGroupsType groupReference<string,[]string>
+    - __kind: StructureType
+      ID: 88
+      Name: table<string,int>
+      ByteSize: 32
+      GoKind: 25
+      RawFields:
+        - Name: used
+          Offset: 0
+          Type: 22 BaseType uint16
+        - Name: capacity
+          Offset: 2
+          Type: 22 BaseType uint16
+        - Name: growthLeft
+          Offset: 4
+          Type: 22 BaseType uint16
+        - Name: localDepth
+          Offset: 6
+          Type: 4 BaseType uint8
+        - Name: index
+          Offset: 8
+          Type: 1 BaseType int
+        - Name: groups
+          Offset: 16
+          Type: 89 GoSwissMapGroupsType groupReference<string,int>
+    - __kind: StructureType
+      ID: 76
+      Name: table<string,main.nestedStruct>
+      ByteSize: 32
+      GoKind: 25
+      RawFields:
+        - Name: used
+          Offset: 0
+          Type: 22 BaseType uint16
+        - Name: capacity
+          Offset: 2
+          Type: 22 BaseType uint16
+        - Name: growthLeft
+          Offset: 4
+          Type: 22 BaseType uint16
+        - Name: localDepth
+          Offset: 6
+          Type: 4 BaseType uint8
+        - Name: index
+          Offset: 8
+          Type: 1 BaseType int
+        - Name: groups
+          Offset: 16
+          Type: 77 GoSwissMapGroupsType groupReference<string,main.nestedStruct>
+    - __kind: StructureType
+      ID: 173
+      Name: table<uint8,[4]int>
+      ByteSize: 32
+      GoKind: 25
+      RawFields:
+        - Name: used
+          Offset: 0
+          Type: 22 BaseType uint16
+        - Name: capacity
+          Offset: 2
+          Type: 22 BaseType uint16
+        - Name: growthLeft
+          Offset: 4
+          Type: 22 BaseType uint16
+        - Name: localDepth
+          Offset: 6
+          Type: 4 BaseType uint8
+        - Name: index
+          Offset: 8
+          Type: 1 BaseType int
+        - Name: groups
+          Offset: 16
+          Type: 174 GoSwissMapGroupsType groupReference<uint8,[4]int>
+    - __kind: StructureType
+      ID: 162
+      Name: table<uint8,uint8>
+      ByteSize: 32
+      GoKind: 25
+      RawFields:
+        - Name: used
+          Offset: 0
+          Type: 22 BaseType uint16
+        - Name: capacity
+          Offset: 2
+          Type: 22 BaseType uint16
+        - Name: growthLeft
+          Offset: 4
+          Type: 22 BaseType uint16
+        - Name: localDepth
+          Offset: 6
+          Type: 4 BaseType uint8
+        - Name: index
+          Offset: 8
+          Type: 1 BaseType int
+        - Name: groups
+          Offset: 16
+          Type: 163 GoSwissMapGroupsType groupReference<uint8,uint8>
+    - __kind: BaseType
+      ID: 20
+      Name: uint
+      ByteSize: 8
+      GoRuntimeType: 575456
+      GoKind: 7
+    - __kind: BaseType
+      ID: 22
+      Name: uint16
+      ByteSize: 2
+      GoRuntimeType: 575072
+      GoKind: 9
+    - __kind: BaseType
+      ID: 24
+      Name: uint32
+      ByteSize: 4
+      GoRuntimeType: 575200
+      GoKind: 10
+    - __kind: BaseType
+      ID: 26
+      Name: uint64
+      ByteSize: 8
+      GoRuntimeType: 575328
+      GoKind: 11
+    - __kind: BaseType
+      ID: 4
+      Name: uint8
+      ByteSize: 1
+      GoRuntimeType: 574944
+      GoKind: 8
+    - __kind: BaseType
+      ID: 62
+      Name: uintptr
+      ByteSize: 8
+      GoRuntimeType: 575520
+      GoKind: 12
+    - __kind: VoidPointerType
+      ID: 38
+      Name: unsafe.Pointer
+      ByteSize: 8
+      GoRuntimeType: 575904
+      GoKind: 26
 MaxTypeID: 385
 Issues: []
 GoModuledataInfo: {FirstModuledataAddr: "0x131d320", TypesOffset: 296}

--- a/pkg/dyninst/irgen/testdata/snapshot/sample.arch=arm64,toolchain=go1.24.3.yaml
+++ b/pkg/dyninst/irgen/testdata/snapshot/sample.arch=arm64,toolchain=go1.24.3.yaml
@@ -2089,7 +2089,7 @@ Subprograms:
       InlinePCRanges: []
       Variables:
         - Name: a
-          Type: 73 ArrayType [5]int
+          Type: 63 ArrayType [5]int
           Locations:
             - Range: 0x84a570..0x84a5d0
               Pieces: [{Size: 40, Op: {CfaOffset: 8}}]
@@ -2106,7 +2106,7 @@ Subprograms:
       InlinePCRanges: []
       Variables:
         - Name: b
-          Type: 74 GoInterfaceType main.behavior
+          Type: 64 GoInterfaceType main.behavior
           Locations:
             - Range: 0x84a800..0x84a828
               Pieces:
@@ -2176,7 +2176,7 @@ Subprograms:
       InlinePCRanges: []
       Variables:
         - Name: s
-          Type: 75 StructureType main.structWithMap
+          Type: 65 StructureType main.structWithMap
           Locations:
             - Range: 0x84ace0..0x84acf0
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
@@ -2188,7 +2188,7 @@ Subprograms:
       InlinePCRanges: []
       Variables:
         - Name: m
-          Type: 87 GoMapType map[string]main.nestedStruct
+          Type: 71 GoMapType map[string]main.nestedStruct
           Locations:
             - Range: 0x84acf0..0x84ad00
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
@@ -2200,7 +2200,7 @@ Subprograms:
       InlinePCRanges: []
       Variables:
         - Name: m
-          Type: 99 GoMapType map[string]int
+          Type: 76 GoMapType map[string]int
           Locations:
             - Range: 0x84ad00..0x84ad10
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
@@ -2212,7 +2212,7 @@ Subprograms:
       InlinePCRanges: []
       Variables:
         - Name: m
-          Type: 110 GoMapType map[string][]string
+          Type: 81 GoMapType map[string][]string
           Locations:
             - Range: 0x84ad10..0x84ad20
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
@@ -2224,7 +2224,7 @@ Subprograms:
       InlinePCRanges: []
       Variables:
         - Name: m
-          Type: 122 GoMapType map[[4]string][2]int
+          Type: 86 GoMapType map[[4]string][2]int
           Locations:
             - Range: 0x84ad20..0x84ad30
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
@@ -2236,7 +2236,7 @@ Subprograms:
       InlinePCRanges: []
       Variables:
         - Name: m
-          Type: 99 GoMapType map[string]int
+          Type: 76 GoMapType map[string]int
           Locations:
             - Range: 0x84ad30..0x84ad40
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
@@ -2248,7 +2248,7 @@ Subprograms:
       InlinePCRanges: []
       Variables:
         - Name: m
-          Type: 134 ArrayType [2]map[string]int
+          Type: 91 ArrayType [2]map[string]int
           Locations:
             - Range: 0x84ad40..0x84ad50
               Pieces: [{Size: 16, Op: {CfaOffset: 8}}]
@@ -2260,7 +2260,7 @@ Subprograms:
       InlinePCRanges: []
       Variables:
         - Name: m
-          Type: 135 PointerType *map[string]int
+          Type: 92 PointerType *map[string]int
           Locations:
             - Range: 0x84ad50..0x84ad60
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
@@ -2272,7 +2272,7 @@ Subprograms:
       InlinePCRanges: []
       Variables:
         - Name: m
-          Type: 76 GoMapType map[int]int
+          Type: 66 GoMapType map[int]int
           Locations:
             - Range: 0x84ad60..0x84ad70
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
@@ -2284,7 +2284,7 @@ Subprograms:
       InlinePCRanges: []
       Variables:
         - Name: redactMyEntries
-          Type: 136 GoMapType map[string][]main.structWithMap
+          Type: 93 GoMapType map[string][]main.structWithMap
           Locations:
             - Range: 0x84ad70..0x84ad80
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
@@ -2296,7 +2296,7 @@ Subprograms:
       InlinePCRanges: []
       Variables:
         - Name: m
-          Type: 136 GoMapType map[string][]main.structWithMap
+          Type: 93 GoMapType map[string][]main.structWithMap
           Locations:
             - Range: 0x84ad80..0x84ad90
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
@@ -2308,7 +2308,7 @@ Subprograms:
       InlinePCRanges: []
       Variables:
         - Name: m
-          Type: 149 GoMapType map[bool]main.node
+          Type: 98 GoMapType map[bool]main.node
           Locations:
             - Range: 0x84ad90..0x84ada0
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
@@ -2320,7 +2320,7 @@ Subprograms:
       InlinePCRanges: []
       Variables:
         - Name: m
-          Type: 162 GoMapType map[int]uint8
+          Type: 103 GoMapType map[int]uint8
           Locations:
             - Range: 0x84ada0..0x84adb0
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
@@ -2332,7 +2332,7 @@ Subprograms:
       InlinePCRanges: []
       Variables:
         - Name: redactMyEntries
-          Type: 162 GoMapType map[int]uint8
+          Type: 103 GoMapType map[int]uint8
           Locations:
             - Range: 0x84adb0..0x84adc0
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
@@ -2344,7 +2344,7 @@ Subprograms:
       InlinePCRanges: []
       Variables:
         - Name: m
-          Type: 173 GoMapType map[uint8]uint8
+          Type: 108 GoMapType map[uint8]uint8
           Locations:
             - Range: 0x84adc0..0x84add0
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
@@ -2356,7 +2356,7 @@ Subprograms:
       InlinePCRanges: []
       Variables:
         - Name: m
-          Type: 173 GoMapType map[uint8]uint8
+          Type: 108 GoMapType map[uint8]uint8
           Locations:
             - Range: 0x84add0..0x84ade0
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
@@ -2368,7 +2368,7 @@ Subprograms:
       InlinePCRanges: []
       Variables:
         - Name: m
-          Type: 173 GoMapType map[uint8]uint8
+          Type: 108 GoMapType map[uint8]uint8
           Locations:
             - Range: 0x84ade0..0x84adf0
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
@@ -2380,7 +2380,7 @@ Subprograms:
       InlinePCRanges: []
       Variables:
         - Name: m
-          Type: 184 GoMapType map[uint8][4]int
+          Type: 113 GoMapType map[uint8][4]int
           Locations:
             - Range: 0x84adf0..0x84ae00
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
@@ -2392,7 +2392,7 @@ Subprograms:
       InlinePCRanges: []
       Variables:
         - Name: m
-          Type: 196 GoMapType map[[4]int]uint8
+          Type: 118 GoMapType map[[4]int]uint8
           Locations:
             - Range: 0x84ae00..0x84ae10
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
@@ -2404,7 +2404,7 @@ Subprograms:
       InlinePCRanges: []
       Variables:
         - Name: m
-          Type: 207 GoMapType map[[4]int][4]int
+          Type: 123 GoMapType map[[4]int][4]int
           Locations:
             - Range: 0x84ae10..0x84ae20
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
@@ -2486,7 +2486,7 @@ Subprograms:
       InlinePCRanges: []
       Variables:
         - Name: c
-          Type: 218 GoChannelType chan bool
+          Type: 128 GoChannelType chan bool
           Locations:
             - Range: 0x84c390..0x84c3a0
               Pieces: [{Size: 0, Op: {RegNo: 0, Shift: 0}}]
@@ -2498,7 +2498,7 @@ Subprograms:
       InlinePCRanges: []
       Variables:
         - Name: a
-          Type: 219 PointerType *main.structWithTwoValues
+          Type: 129 PointerType *main.structWithTwoValues
           Locations:
             - Range: 0x84c530..0x84c540
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
@@ -2510,7 +2510,7 @@ Subprograms:
       InlinePCRanges: []
       Variables:
         - Name: a
-          Type: 160 StructureType main.node
+          Type: 131 StructureType main.node
           Locations:
             - Range: 0x84c540..0x84c550
               Pieces:
@@ -2526,7 +2526,7 @@ Subprograms:
       InlinePCRanges: []
       Variables:
         - Name: a
-          Type: 161 PointerType *main.node
+          Type: 132 PointerType *main.node
           Locations:
             - Range: 0x84c550..0x84c560
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
@@ -2593,7 +2593,7 @@ Subprograms:
       InlinePCRanges: []
       Variables:
         - Name: t
-          Type: 221 PointerType *main.t
+          Type: 133 PointerType *main.t
           Locations:
             - Range: 0x84c630..0x84c640
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
@@ -2605,7 +2605,7 @@ Subprograms:
       InlinePCRanges: []
       Variables:
         - Name: u
-          Type: 224 GoSliceHeaderType []uint
+          Type: 135 GoSliceHeaderType []uint
           Locations:
             - Range: 0x84ca00..0x84ca10
               Pieces:
@@ -2623,7 +2623,7 @@ Subprograms:
       InlinePCRanges: []
       Variables:
         - Name: u
-          Type: 224 GoSliceHeaderType []uint
+          Type: 135 GoSliceHeaderType []uint
           Locations:
             - Range: 0x84ca10..0x84ca20
               Pieces:
@@ -2641,7 +2641,7 @@ Subprograms:
       InlinePCRanges: []
       Variables:
         - Name: u
-          Type: 225 GoSliceHeaderType [][]uint
+          Type: 136 GoSliceHeaderType [][]uint
           Locations:
             - Range: 0x84ca20..0x84ca30
               Pieces:
@@ -2659,7 +2659,7 @@ Subprograms:
       InlinePCRanges: []
       Variables:
         - Name: xs
-          Type: 227 GoSliceHeaderType []main.structWithNoStrings
+          Type: 138 GoSliceHeaderType []main.structWithNoStrings
           Locations:
             - Range: 0x84ca30..0x84ca40
               Pieces:
@@ -2684,7 +2684,7 @@ Subprograms:
       InlinePCRanges: []
       Variables:
         - Name: xs
-          Type: 227 GoSliceHeaderType []main.structWithNoStrings
+          Type: 138 GoSliceHeaderType []main.structWithNoStrings
           Locations:
             - Range: 0x84ca40..0x84ca50
               Pieces:
@@ -2709,7 +2709,7 @@ Subprograms:
       InlinePCRanges: []
       Variables:
         - Name: xs
-          Type: 227 GoSliceHeaderType []main.structWithNoStrings
+          Type: 138 GoSliceHeaderType []main.structWithNoStrings
           Locations:
             - Range: 0x84ca50..0x84ca60
               Pieces:
@@ -2734,7 +2734,7 @@ Subprograms:
       InlinePCRanges: []
       Variables:
         - Name: s
-          Type: 121 GoSliceHeaderType []string
+          Type: 141 GoSliceHeaderType []string
           Locations:
             - Range: 0x84ca60..0x84ca70
               Pieces:
@@ -2759,7 +2759,7 @@ Subprograms:
           IsParameter: true
           IsReturn: false
         - Name: s
-          Type: 230 GoSliceHeaderType []bool
+          Type: 142 GoSliceHeaderType []bool
           Locations:
             - Range: 0x84ca70..0x84ca80
               Pieces:
@@ -2784,7 +2784,7 @@ Subprograms:
       InlinePCRanges: []
       Variables:
         - Name: xs
-          Type: 231 GoSliceHeaderType []uint16
+          Type: 143 GoSliceHeaderType []uint16
           Locations:
             - Range: 0x84ca80..0x84ca90
               Pieces:
@@ -2802,7 +2802,7 @@ Subprograms:
       InlinePCRanges: []
       Variables:
         - Name: xs
-          Type: 224 GoSliceHeaderType []uint
+          Type: 135 GoSliceHeaderType []uint
           Locations:
             - Range: 0x84ca90..0x84caa0
               Pieces:
@@ -2884,7 +2884,7 @@ Subprograms:
       InlinePCRanges: []
       Variables:
         - Name: a
-          Type: 232 StructureType main.threeStringStruct
+          Type: 144 StructureType main.threeStringStruct
           Locations:
             - Range: 0x84cdf0..0x84ce10
               Pieces:
@@ -2908,7 +2908,7 @@ Subprograms:
       InlinePCRanges: []
       Variables:
         - Name: a
-          Type: 233 PointerType *main.threeStringStruct
+          Type: 145 PointerType *main.threeStringStruct
           Locations:
             - Range: 0x84ce10..0x84ce20
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
@@ -2920,7 +2920,7 @@ Subprograms:
       InlinePCRanges: []
       Variables:
         - Name: a
-          Type: 234 PointerType *main.oneStringStruct
+          Type: 146 PointerType *main.oneStringStruct
           Locations:
             - Range: 0x84ce20..0x84ce30
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
@@ -2980,7 +2980,7 @@ Subprograms:
       InlinePCRanges: []
       Variables:
         - Name: x
-          Type: 236 StructureType main.aStruct
+          Type: 148 StructureType main.aStruct
           Locations:
             - Range: 0x84d060..0x84d080
               Pieces:
@@ -3006,7 +3006,7 @@ Subprograms:
       InlinePCRanges: []
       Variables:
         - Name: e
-          Type: 237 StructureType main.emptyStruct
+          Type: 150 StructureType main.emptyStruct
           Locations: [{Range: 0x84d160..0x84d170, Pieces: []}]
           IsParameter: true
           IsReturn: false
@@ -3085,7 +3085,7 @@ Subprograms:
           RootRanges: [0x84a5d0..0x84a720]
       Variables:
         - Name: a
-          Type: 73 ArrayType [5]int
+          Type: 63 ArrayType [5]int
           Locations:
             - Range: 0x84a580..0x84a5d0
               Pieces: [{Size: 40, Op: {CfaOffset: -48}}]
@@ -3095,10 +3095,10 @@ Subprograms:
           IsReturn: false
 Types:
     - __kind: PointerType
-      ID: 223
+      ID: 173
       Name: '**main.t'
       ByteSize: 8
-      Pointee: 221 PointerType *main.t
+      Pointee: 133 PointerType *main.t
     - __kind: PointerType
       ID: 54
       Name: '**string'
@@ -3107,110 +3107,110 @@ Types:
       GoKind: 22
       Pointee: 22 PointerType *string
     - __kind: PointerType
-      ID: 210
+      ID: 126
       Name: '**table<[4]int,[4]int>'
       ByteSize: 8
-      Pointee: 211 PointerType *table<[4]int,[4]int>
+      Pointee: 127 PointerType *table<[4]int,[4]int>
     - __kind: PointerType
-      ID: 199
+      ID: 121
       Name: '**table<[4]int,uint8>'
       ByteSize: 8
-      Pointee: 200 PointerType *table<[4]int,uint8>
+      Pointee: 122 PointerType *table<[4]int,uint8>
     - __kind: PointerType
-      ID: 125
+      ID: 89
       Name: '**table<[4]string,[2]int>'
       ByteSize: 8
-      Pointee: 126 PointerType *table<[4]string,[2]int>
+      Pointee: 90 PointerType *table<[4]string,[2]int>
     - __kind: PointerType
-      ID: 152
+      ID: 101
       Name: '**table<bool,main.node>'
       ByteSize: 8
-      Pointee: 153 PointerType *table<bool,main.node>
+      Pointee: 102 PointerType *table<bool,main.node>
     - __kind: PointerType
-      ID: 79
+      ID: 69
       Name: '**table<int,int>'
       ByteSize: 8
-      Pointee: 80 PointerType *table<int,int>
+      Pointee: 70 PointerType *table<int,int>
     - __kind: PointerType
-      ID: 165
+      ID: 106
       Name: '**table<int,uint8>'
       ByteSize: 8
-      Pointee: 166 PointerType *table<int,uint8>
+      Pointee: 107 PointerType *table<int,uint8>
     - __kind: PointerType
-      ID: 139
+      ID: 96
       Name: '**table<string,[]main.structWithMap>'
       ByteSize: 8
-      Pointee: 140 PointerType *table<string,[]main.structWithMap>
+      Pointee: 97 PointerType *table<string,[]main.structWithMap>
     - __kind: PointerType
-      ID: 113
+      ID: 84
       Name: '**table<string,[]string>'
       ByteSize: 8
-      Pointee: 114 PointerType *table<string,[]string>
+      Pointee: 85 PointerType *table<string,[]string>
     - __kind: PointerType
-      ID: 102
+      ID: 79
       Name: '**table<string,int>'
       ByteSize: 8
-      Pointee: 103 PointerType *table<string,int>
+      Pointee: 80 PointerType *table<string,int>
     - __kind: PointerType
-      ID: 90
+      ID: 74
       Name: '**table<string,main.nestedStruct>'
       ByteSize: 8
-      Pointee: 91 PointerType *table<string,main.nestedStruct>
+      Pointee: 75 PointerType *table<string,main.nestedStruct>
     - __kind: PointerType
-      ID: 187
+      ID: 116
       Name: '**table<uint8,[4]int>'
       ByteSize: 8
-      Pointee: 188 PointerType *table<uint8,[4]int>
+      Pointee: 117 PointerType *table<uint8,[4]int>
     - __kind: PointerType
-      ID: 176
+      ID: 111
       Name: '**table<uint8,uint8>'
       ByteSize: 8
-      Pointee: 177 PointerType *table<uint8,uint8>
+      Pointee: 112 PointerType *table<uint8,uint8>
     - __kind: PointerType
       ID: 241
       Name: '*[]*string.array'
       ByteSize: 8
       Pointee: 240 GoSliceDataType []*string.array
     - __kind: PointerType
-      ID: 275
+      ID: 271
       Name: '*[][]uint.array'
       ByteSize: 8
-      Pointee: 274 GoSliceDataType [][]uint.array
-    - __kind: PointerType
-      ID: 279
-      Name: '*[]bool.array'
-      ByteSize: 8
-      Pointee: 278 GoSliceDataType []bool.array
-    - __kind: PointerType
-      ID: 257
-      Name: '*[]main.structWithMap.array'
-      ByteSize: 8
-      Pointee: 256 GoSliceDataType []main.structWithMap.array
+      Pointee: 270 GoSliceDataType [][]uint.array
     - __kind: PointerType
       ID: 277
-      Name: '*[]main.structWithNoStrings.array'
+      Name: '*[]bool.array'
       ByteSize: 8
-      Pointee: 276 GoSliceDataType []main.structWithNoStrings.array
-    - __kind: PointerType
-      ID: 251
-      Name: '*[]string.array'
-      ByteSize: 8
-      Pointee: 250 GoSliceDataType []string.array
-    - __kind: PointerType
-      ID: 226
-      Name: '*[]uint'
-      ByteSize: 8
-      Pointee: 224 GoSliceHeaderType []uint
-    - __kind: PointerType
-      ID: 273
-      Name: '*[]uint.array'
-      ByteSize: 8
-      Pointee: 272 GoSliceDataType []uint.array
+      Pointee: 276 GoSliceDataType []bool.array
     - __kind: PointerType
       ID: 281
+      Name: '*[]main.structWithMap.array'
+      ByteSize: 8
+      Pointee: 280 GoSliceDataType []main.structWithMap.array
+    - __kind: PointerType
+      ID: 273
+      Name: '*[]main.structWithNoStrings.array'
+      ByteSize: 8
+      Pointee: 272 GoSliceDataType []main.structWithNoStrings.array
+    - __kind: PointerType
+      ID: 275
+      Name: '*[]string.array'
+      ByteSize: 8
+      Pointee: 274 GoSliceDataType []string.array
+    - __kind: PointerType
+      ID: 137
+      Name: '*[]uint'
+      ByteSize: 8
+      Pointee: 135 GoSliceHeaderType []uint
+    - __kind: PointerType
+      ID: 269
+      Name: '*[]uint.array'
+      ByteSize: 8
+      Pointee: 268 GoSliceDataType []uint.array
+    - __kind: PointerType
+      ID: 279
       Name: '*[]uint16.array'
       ByteSize: 8
-      Pointee: 280 GoSliceDataType []uint16.array
+      Pointee: 278 GoSliceDataType []uint16.array
     - __kind: PointerType
       ID: 11
       Name: '*bool'
@@ -3282,179 +3282,179 @@ Types:
       GoKind: 22
       Pointee: 62 StructureType main.esotericHeap
     - __kind: PointerType
-      ID: 161
+      ID: 132
       Name: '*main.node'
       ByteSize: 8
       GoRuntimeType: 380224
       GoKind: 22
-      Pointee: 160 StructureType main.node
+      Pointee: 131 StructureType main.node
     - __kind: PointerType
-      ID: 234
+      ID: 146
       Name: '*main.oneStringStruct'
       ByteSize: 8
       GoKind: 22
-      Pointee: 235 StructureType main.oneStringStruct
+      Pointee: 147 StructureType main.oneStringStruct
     - __kind: PointerType
-      ID: 148
+      ID: 224
       Name: '*main.structWithMap'
       ByteSize: 8
       GoRuntimeType: 380096
       GoKind: 22
-      Pointee: 75 StructureType main.structWithMap
+      Pointee: 65 StructureType main.structWithMap
     - __kind: PointerType
-      ID: 228
+      ID: 139
       Name: '*main.structWithNoStrings'
       ByteSize: 8
-      Pointee: 229 StructureType main.structWithNoStrings
+      Pointee: 140 StructureType main.structWithNoStrings
     - __kind: PointerType
-      ID: 219
+      ID: 129
       Name: '*main.structWithTwoValues'
       ByteSize: 8
       GoKind: 22
-      Pointee: 220 StructureType main.structWithTwoValues
+      Pointee: 130 StructureType main.structWithTwoValues
     - __kind: PointerType
-      ID: 221
+      ID: 133
       Name: '*main.t'
       ByteSize: 8
       GoKind: 22
-      Pointee: 222 GoSliceHeaderType main.t
+      Pointee: 134 GoSliceHeaderType main.t
     - __kind: PointerType
-      ID: 271
+      ID: 267
       Name: '*main.t.array'
       ByteSize: 8
-      Pointee: 270 GoSliceDataType main.t.array
+      Pointee: 266 GoSliceDataType main.t.array
     - __kind: PointerType
-      ID: 233
+      ID: 145
       Name: '*main.threeStringStruct'
       ByteSize: 8
       GoKind: 22
-      Pointee: 232 StructureType main.threeStringStruct
+      Pointee: 144 StructureType main.threeStringStruct
     - __kind: PointerType
-      ID: 208
+      ID: 124
       Name: '*map<[4]int,[4]int>'
       ByteSize: 8
-      Pointee: 209 GoSwissMapHeaderType map<[4]int,[4]int>
+      Pointee: 125 GoSwissMapHeaderType map<[4]int,[4]int>
     - __kind: PointerType
-      ID: 197
+      ID: 119
       Name: '*map<[4]int,uint8>'
       ByteSize: 8
-      Pointee: 198 GoSwissMapHeaderType map<[4]int,uint8>
+      Pointee: 120 GoSwissMapHeaderType map<[4]int,uint8>
     - __kind: PointerType
-      ID: 123
+      ID: 87
       Name: '*map<[4]string,[2]int>'
       ByteSize: 8
-      Pointee: 124 GoSwissMapHeaderType map<[4]string,[2]int>
+      Pointee: 88 GoSwissMapHeaderType map<[4]string,[2]int>
     - __kind: PointerType
-      ID: 150
+      ID: 99
       Name: '*map<bool,main.node>'
       ByteSize: 8
-      Pointee: 151 GoSwissMapHeaderType map<bool,main.node>
+      Pointee: 100 GoSwissMapHeaderType map<bool,main.node>
     - __kind: PointerType
-      ID: 77
+      ID: 67
       Name: '*map<int,int>'
       ByteSize: 8
-      Pointee: 78 GoSwissMapHeaderType map<int,int>
+      Pointee: 68 GoSwissMapHeaderType map<int,int>
     - __kind: PointerType
-      ID: 163
+      ID: 104
       Name: '*map<int,uint8>'
       ByteSize: 8
-      Pointee: 164 GoSwissMapHeaderType map<int,uint8>
+      Pointee: 105 GoSwissMapHeaderType map<int,uint8>
     - __kind: PointerType
-      ID: 137
+      ID: 94
       Name: '*map<string,[]main.structWithMap>'
       ByteSize: 8
-      Pointee: 138 GoSwissMapHeaderType map<string,[]main.structWithMap>
+      Pointee: 95 GoSwissMapHeaderType map<string,[]main.structWithMap>
     - __kind: PointerType
-      ID: 111
+      ID: 82
       Name: '*map<string,[]string>'
       ByteSize: 8
-      Pointee: 112 GoSwissMapHeaderType map<string,[]string>
+      Pointee: 83 GoSwissMapHeaderType map<string,[]string>
     - __kind: PointerType
-      ID: 100
+      ID: 77
       Name: '*map<string,int>'
       ByteSize: 8
-      Pointee: 101 GoSwissMapHeaderType map<string,int>
+      Pointee: 78 GoSwissMapHeaderType map<string,int>
     - __kind: PointerType
-      ID: 88
+      ID: 72
       Name: '*map<string,main.nestedStruct>'
       ByteSize: 8
-      Pointee: 89 GoSwissMapHeaderType map<string,main.nestedStruct>
+      Pointee: 73 GoSwissMapHeaderType map<string,main.nestedStruct>
     - __kind: PointerType
-      ID: 185
+      ID: 114
       Name: '*map<uint8,[4]int>'
       ByteSize: 8
-      Pointee: 186 GoSwissMapHeaderType map<uint8,[4]int>
+      Pointee: 115 GoSwissMapHeaderType map<uint8,[4]int>
     - __kind: PointerType
-      ID: 174
+      ID: 109
       Name: '*map<uint8,uint8>'
       ByteSize: 8
-      Pointee: 175 GoSwissMapHeaderType map<uint8,uint8>
+      Pointee: 110 GoSwissMapHeaderType map<uint8,uint8>
     - __kind: PointerType
-      ID: 135
+      ID: 92
       Name: '*map[string]int'
       ByteSize: 8
       GoKind: 22
-      Pointee: 99 GoMapType map[string]int
+      Pointee: 76 GoMapType map[string]int
     - __kind: PointerType
-      ID: 214
+      ID: 208
       Name: '*noalg.map.group[[4]int][4]int'
       ByteSize: 8
-      Pointee: 215 StructureType noalg.map.group[[4]int][4]int
+      Pointee: 209 StructureType noalg.map.group[[4]int][4]int
     - __kind: PointerType
-      ID: 203
+      ID: 205
       Name: '*noalg.map.group[[4]int]uint8'
       ByteSize: 8
-      Pointee: 204 StructureType noalg.map.group[[4]int]uint8
+      Pointee: 206 StructureType noalg.map.group[[4]int]uint8
     - __kind: PointerType
-      ID: 129
+      ID: 187
       Name: '*noalg.map.group[[4]string][2]int'
       ByteSize: 8
-      Pointee: 130 StructureType noalg.map.group[[4]string][2]int
+      Pointee: 188 StructureType noalg.map.group[[4]string][2]int
     - __kind: PointerType
-      ID: 156
+      ID: 193
       Name: '*noalg.map.group[bool]main.node'
       ByteSize: 8
-      Pointee: 157 StructureType noalg.map.group[bool]main.node
+      Pointee: 194 StructureType noalg.map.group[bool]main.node
     - __kind: PointerType
-      ID: 83
+      ID: 175
       Name: '*noalg.map.group[int]int'
       ByteSize: 8
-      Pointee: 84 StructureType noalg.map.group[int]int
+      Pointee: 176 StructureType noalg.map.group[int]int
     - __kind: PointerType
-      ID: 169
+      ID: 196
       Name: '*noalg.map.group[int]uint8'
       ByteSize: 8
-      Pointee: 170 StructureType noalg.map.group[int]uint8
+      Pointee: 197 StructureType noalg.map.group[int]uint8
     - __kind: PointerType
-      ID: 143
+      ID: 190
       Name: '*noalg.map.group[string][]main.structWithMap'
       ByteSize: 8
-      Pointee: 144 StructureType noalg.map.group[string][]main.structWithMap
+      Pointee: 191 StructureType noalg.map.group[string][]main.structWithMap
     - __kind: PointerType
-      ID: 117
+      ID: 184
       Name: '*noalg.map.group[string][]string'
       ByteSize: 8
-      Pointee: 118 StructureType noalg.map.group[string][]string
+      Pointee: 185 StructureType noalg.map.group[string][]string
     - __kind: PointerType
-      ID: 106
+      ID: 181
       Name: '*noalg.map.group[string]int'
       ByteSize: 8
-      Pointee: 107 StructureType noalg.map.group[string]int
+      Pointee: 182 StructureType noalg.map.group[string]int
     - __kind: PointerType
-      ID: 94
+      ID: 178
       Name: '*noalg.map.group[string]main.nestedStruct'
       ByteSize: 8
-      Pointee: 95 StructureType noalg.map.group[string]main.nestedStruct
+      Pointee: 179 StructureType noalg.map.group[string]main.nestedStruct
     - __kind: PointerType
-      ID: 191
+      ID: 202
       Name: '*noalg.map.group[uint8][4]int'
       ByteSize: 8
-      Pointee: 192 StructureType noalg.map.group[uint8][4]int
+      Pointee: 203 StructureType noalg.map.group[uint8][4]int
     - __kind: PointerType
-      ID: 180
+      ID: 199
       Name: '*noalg.map.group[uint8]uint8'
       ByteSize: 8
-      Pointee: 181 StructureType noalg.map.group[uint8]uint8
+      Pointee: 200 StructureType noalg.map.group[uint8]uint8
     - __kind: PointerType
       ID: 22
       Name: '*string'
@@ -3468,65 +3468,65 @@ Types:
       ByteSize: 8
       Pointee: 238 GoStringDataType string.str
     - __kind: PointerType
-      ID: 211
+      ID: 127
       Name: '*table<[4]int,[4]int>'
       ByteSize: 8
-      Pointee: 212 StructureType table<[4]int,[4]int>
+      Pointee: 172 StructureType table<[4]int,[4]int>
     - __kind: PointerType
-      ID: 200
+      ID: 122
       Name: '*table<[4]int,uint8>'
       ByteSize: 8
-      Pointee: 201 StructureType table<[4]int,uint8>
+      Pointee: 171 StructureType table<[4]int,uint8>
     - __kind: PointerType
-      ID: 126
+      ID: 90
       Name: '*table<[4]string,[2]int>'
       ByteSize: 8
-      Pointee: 127 StructureType table<[4]string,[2]int>
+      Pointee: 165 StructureType table<[4]string,[2]int>
     - __kind: PointerType
-      ID: 153
+      ID: 102
       Name: '*table<bool,main.node>'
       ByteSize: 8
-      Pointee: 154 StructureType table<bool,main.node>
+      Pointee: 167 StructureType table<bool,main.node>
     - __kind: PointerType
-      ID: 80
+      ID: 70
       Name: '*table<int,int>'
       ByteSize: 8
-      Pointee: 81 StructureType table<int,int>
+      Pointee: 161 StructureType table<int,int>
     - __kind: PointerType
-      ID: 166
+      ID: 107
       Name: '*table<int,uint8>'
       ByteSize: 8
-      Pointee: 167 StructureType table<int,uint8>
+      Pointee: 168 StructureType table<int,uint8>
     - __kind: PointerType
-      ID: 140
+      ID: 97
       Name: '*table<string,[]main.structWithMap>'
       ByteSize: 8
-      Pointee: 141 StructureType table<string,[]main.structWithMap>
+      Pointee: 166 StructureType table<string,[]main.structWithMap>
     - __kind: PointerType
-      ID: 114
+      ID: 85
       Name: '*table<string,[]string>'
       ByteSize: 8
-      Pointee: 115 StructureType table<string,[]string>
+      Pointee: 164 StructureType table<string,[]string>
     - __kind: PointerType
-      ID: 103
+      ID: 80
       Name: '*table<string,int>'
       ByteSize: 8
-      Pointee: 104 StructureType table<string,int>
+      Pointee: 163 StructureType table<string,int>
     - __kind: PointerType
-      ID: 91
+      ID: 75
       Name: '*table<string,main.nestedStruct>'
       ByteSize: 8
-      Pointee: 92 StructureType table<string,main.nestedStruct>
+      Pointee: 162 StructureType table<string,main.nestedStruct>
     - __kind: PointerType
-      ID: 188
+      ID: 117
       Name: '*table<uint8,[4]int>'
       ByteSize: 8
-      Pointee: 189 StructureType table<uint8,[4]int>
+      Pointee: 170 StructureType table<uint8,[4]int>
     - __kind: PointerType
-      ID: 177
+      ID: 112
       Name: '*table<uint8,uint8>'
       ByteSize: 8
-      Pointee: 178 StructureType table<uint8,uint8>
+      Pointee: 169 StructureType table<uint8,uint8>
     - __kind: PointerType
       ID: 34
       Name: '*uint'
@@ -3626,7 +3626,7 @@ Types:
         - Name: m
           Offset: 1
           Expression:
-            Type: 134 ArrayType [2]map[string]int
+            Type: 91 ArrayType [2]map[string]int
             Operations:
                 - __kind: LocationOp
                   Variable: {subprogram: 53, index: 0, name: m}
@@ -3701,7 +3701,7 @@ Types:
         - Name: c
           Offset: 1
           Expression:
-            Type: 218 GoChannelType chan bool
+            Type: 128 GoChannelType chan bool
             Operations:
                 - __kind: LocationOp
                   Variable: {subprogram: 69, index: 0, name: c}
@@ -3749,7 +3749,7 @@ Types:
         - Name: t
           Offset: 1
           Expression:
-            Type: 221 PointerType *main.t
+            Type: 133 PointerType *main.t
             Operations:
                 - __kind: LocationOp
                   Variable: {subprogram: 77, index: 0, name: t}
@@ -3764,7 +3764,7 @@ Types:
         - Name: xs
           Offset: 1
           Expression:
-            Type: 227 GoSliceHeaderType []main.structWithNoStrings
+            Type: 138 GoSliceHeaderType []main.structWithNoStrings
             Operations:
                 - __kind: LocationOp
                   Variable: {subprogram: 82, index: 0, name: xs}
@@ -3788,7 +3788,7 @@ Types:
         - Name: u
           Offset: 1
           Expression:
-            Type: 224 GoSliceHeaderType []uint
+            Type: 135 GoSliceHeaderType []uint
             Operations:
                 - __kind: LocationOp
                   Variable: {subprogram: 79, index: 0, name: u}
@@ -3818,7 +3818,7 @@ Types:
         - Name: e
           Offset: 1
           Expression:
-            Type: 237 StructureType main.emptyStruct
+            Type: 150 StructureType main.emptyStruct
             Operations:
                 - __kind: LocationOp
                   Variable: {subprogram: 98, index: 0, name: e}
@@ -3878,7 +3878,7 @@ Types:
         - Name: a
           Offset: 1
           Expression:
-            Type: 73 ArrayType [5]int
+            Type: 63 ArrayType [5]int
             Operations:
                 - __kind: LocationOp
                   Variable: {subprogram: 43, index: 0, name: a}
@@ -4004,7 +4004,7 @@ Types:
         - Name: a
           Offset: 1
           Expression:
-            Type: 73 ArrayType [5]int
+            Type: 63 ArrayType [5]int
             Operations:
                 - __kind: LocationOp
                   Variable: {subprogram: 104, index: 0, name: a}
@@ -4094,7 +4094,7 @@ Types:
         - Name: b
           Offset: 1
           Expression:
-            Type: 74 GoInterfaceType main.behavior
+            Type: 64 GoInterfaceType main.behavior
             Operations:
                 - __kind: LocationOp
                   Variable: {subprogram: 44, index: 0, name: b}
@@ -4109,7 +4109,7 @@ Types:
         - Name: a
           Offset: 1
           Expression:
-            Type: 160 StructureType main.node
+            Type: 131 StructureType main.node
             Operations:
                 - __kind: LocationOp
                   Variable: {subprogram: 71, index: 0, name: a}
@@ -4124,7 +4124,7 @@ Types:
         - Name: m
           Offset: 1
           Expression:
-            Type: 122 GoMapType map[[4]string][2]int
+            Type: 86 GoMapType map[[4]string][2]int
             Operations:
                 - __kind: LocationOp
                   Variable: {subprogram: 51, index: 0, name: m}
@@ -4139,7 +4139,7 @@ Types:
         - Name: m
           Offset: 1
           Expression:
-            Type: 136 GoMapType map[string][]main.structWithMap
+            Type: 93 GoMapType map[string][]main.structWithMap
             Operations:
                 - __kind: LocationOp
                   Variable: {subprogram: 57, index: 0, name: m}
@@ -4154,7 +4154,7 @@ Types:
         - Name: m
           Offset: 1
           Expression:
-            Type: 76 GoMapType map[int]int
+            Type: 66 GoMapType map[int]int
             Operations:
                 - __kind: LocationOp
                   Variable: {subprogram: 55, index: 0, name: m}
@@ -4169,7 +4169,7 @@ Types:
         - Name: m
           Offset: 1
           Expression:
-            Type: 207 GoMapType map[[4]int][4]int
+            Type: 123 GoMapType map[[4]int][4]int
             Operations:
                 - __kind: LocationOp
                   Variable: {subprogram: 66, index: 0, name: m}
@@ -4184,7 +4184,7 @@ Types:
         - Name: m
           Offset: 1
           Expression:
-            Type: 196 GoMapType map[[4]int]uint8
+            Type: 118 GoMapType map[[4]int]uint8
             Operations:
                 - __kind: LocationOp
                   Variable: {subprogram: 65, index: 0, name: m}
@@ -4199,7 +4199,7 @@ Types:
         - Name: redactMyEntries
           Offset: 1
           Expression:
-            Type: 136 GoMapType map[string][]main.structWithMap
+            Type: 93 GoMapType map[string][]main.structWithMap
             Operations:
                 - __kind: LocationOp
                   Variable: {subprogram: 56, index: 0, name: redactMyEntries}
@@ -4214,7 +4214,7 @@ Types:
         - Name: m
           Offset: 1
           Expression:
-            Type: 184 GoMapType map[uint8][4]int
+            Type: 113 GoMapType map[uint8][4]int
             Operations:
                 - __kind: LocationOp
                   Variable: {subprogram: 64, index: 0, name: m}
@@ -4229,7 +4229,7 @@ Types:
         - Name: m
           Offset: 1
           Expression:
-            Type: 173 GoMapType map[uint8]uint8
+            Type: 108 GoMapType map[uint8]uint8
             Operations:
                 - __kind: LocationOp
                   Variable: {subprogram: 63, index: 0, name: m}
@@ -4244,7 +4244,7 @@ Types:
         - Name: m
           Offset: 1
           Expression:
-            Type: 99 GoMapType map[string]int
+            Type: 76 GoMapType map[string]int
             Operations:
                 - __kind: LocationOp
                   Variable: {subprogram: 49, index: 0, name: m}
@@ -4259,7 +4259,7 @@ Types:
         - Name: m
           Offset: 1
           Expression:
-            Type: 110 GoMapType map[string][]string
+            Type: 81 GoMapType map[string][]string
             Operations:
                 - __kind: LocationOp
                   Variable: {subprogram: 50, index: 0, name: m}
@@ -4274,7 +4274,7 @@ Types:
         - Name: m
           Offset: 1
           Expression:
-            Type: 87 GoMapType map[string]main.nestedStruct
+            Type: 71 GoMapType map[string]main.nestedStruct
             Operations:
                 - __kind: LocationOp
                   Variable: {subprogram: 48, index: 0, name: m}
@@ -4289,7 +4289,7 @@ Types:
         - Name: m
           Offset: 1
           Expression:
-            Type: 149 GoMapType map[bool]main.node
+            Type: 98 GoMapType map[bool]main.node
             Operations:
                 - __kind: LocationOp
                   Variable: {subprogram: 58, index: 0, name: m}
@@ -4304,7 +4304,7 @@ Types:
         - Name: m
           Offset: 1
           Expression:
-            Type: 173 GoMapType map[uint8]uint8
+            Type: 108 GoMapType map[uint8]uint8
             Operations:
                 - __kind: LocationOp
                   Variable: {subprogram: 62, index: 0, name: m}
@@ -4319,7 +4319,7 @@ Types:
         - Name: m
           Offset: 1
           Expression:
-            Type: 173 GoMapType map[uint8]uint8
+            Type: 108 GoMapType map[uint8]uint8
             Operations:
                 - __kind: LocationOp
                   Variable: {subprogram: 61, index: 0, name: m}
@@ -4334,7 +4334,7 @@ Types:
         - Name: redactMyEntries
           Offset: 1
           Expression:
-            Type: 162 GoMapType map[int]uint8
+            Type: 103 GoMapType map[int]uint8
             Operations:
                 - __kind: LocationOp
                   Variable: {subprogram: 60, index: 0, name: redactMyEntries}
@@ -4349,7 +4349,7 @@ Types:
         - Name: m
           Offset: 1
           Expression:
-            Type: 162 GoMapType map[int]uint8
+            Type: 103 GoMapType map[int]uint8
             Operations:
                 - __kind: LocationOp
                   Variable: {subprogram: 59, index: 0, name: m}
@@ -4454,7 +4454,7 @@ Types:
         - Name: xs
           Offset: 1
           Expression:
-            Type: 227 GoSliceHeaderType []main.structWithNoStrings
+            Type: 138 GoSliceHeaderType []main.structWithNoStrings
             Operations:
                 - __kind: LocationOp
                   Variable: {subprogram: 83, index: 0, name: xs}
@@ -4487,7 +4487,7 @@ Types:
         - Name: s
           Offset: 2
           Expression:
-            Type: 230 GoSliceHeaderType []bool
+            Type: 142 GoSliceHeaderType []bool
             Operations:
                 - __kind: LocationOp
                   Variable: {subprogram: 85, index: 1, name: s}
@@ -4511,7 +4511,7 @@ Types:
         - Name: xs
           Offset: 1
           Expression:
-            Type: 231 GoSliceHeaderType []uint16
+            Type: 143 GoSliceHeaderType []uint16
             Operations:
                 - __kind: LocationOp
                   Variable: {subprogram: 86, index: 0, name: xs}
@@ -4526,7 +4526,7 @@ Types:
         - Name: a
           Offset: 1
           Expression:
-            Type: 234 PointerType *main.oneStringStruct
+            Type: 146 PointerType *main.oneStringStruct
             Operations:
                 - __kind: LocationOp
                   Variable: {subprogram: 93, index: 0, name: a}
@@ -4541,7 +4541,7 @@ Types:
         - Name: a
           Offset: 1
           Expression:
-            Type: 161 PointerType *main.node
+            Type: 132 PointerType *main.node
             Operations:
                 - __kind: LocationOp
                   Variable: {subprogram: 72, index: 0, name: a}
@@ -4556,7 +4556,7 @@ Types:
         - Name: m
           Offset: 1
           Expression:
-            Type: 135 PointerType *map[string]int
+            Type: 92 PointerType *map[string]int
             Operations:
                 - __kind: LocationOp
                   Variable: {subprogram: 54, index: 0, name: m}
@@ -4571,7 +4571,7 @@ Types:
         - Name: a
           Offset: 1
           Expression:
-            Type: 219 PointerType *main.structWithTwoValues
+            Type: 129 PointerType *main.structWithTwoValues
             Operations:
                 - __kind: LocationOp
                   Variable: {subprogram: 70, index: 0, name: a}
@@ -4841,7 +4841,7 @@ Types:
         - Name: u
           Offset: 1
           Expression:
-            Type: 225 GoSliceHeaderType [][]uint
+            Type: 136 GoSliceHeaderType [][]uint
             Operations:
                 - __kind: LocationOp
                   Variable: {subprogram: 80, index: 0, name: u}
@@ -4856,7 +4856,7 @@ Types:
         - Name: m
           Offset: 1
           Expression:
-            Type: 99 GoMapType map[string]int
+            Type: 76 GoMapType map[string]int
             Operations:
                 - __kind: LocationOp
                   Variable: {subprogram: 52, index: 0, name: m}
@@ -4901,7 +4901,7 @@ Types:
         - Name: s
           Offset: 1
           Expression:
-            Type: 121 GoSliceHeaderType []string
+            Type: 141 GoSliceHeaderType []string
             Operations:
                 - __kind: LocationOp
                   Variable: {subprogram: 84, index: 0, name: s}
@@ -4916,7 +4916,7 @@ Types:
         - Name: xs
           Offset: 1
           Expression:
-            Type: 227 GoSliceHeaderType []main.structWithNoStrings
+            Type: 138 GoSliceHeaderType []main.structWithNoStrings
             Operations:
                 - __kind: LocationOp
                   Variable: {subprogram: 81, index: 0, name: xs}
@@ -4940,7 +4940,7 @@ Types:
         - Name: s
           Offset: 1
           Expression:
-            Type: 75 StructureType main.structWithMap
+            Type: 65 StructureType main.structWithMap
             Operations:
                 - __kind: LocationOp
                   Variable: {subprogram: 47, index: 0, name: s}
@@ -4955,7 +4955,7 @@ Types:
         - Name: x
           Offset: 1
           Expression:
-            Type: 236 StructureType main.aStruct
+            Type: 148 StructureType main.aStruct
             Operations:
                 - __kind: LocationOp
                   Variable: {subprogram: 97, index: 0, name: x}
@@ -4970,7 +4970,7 @@ Types:
         - Name: a
           Offset: 1
           Expression:
-            Type: 233 PointerType *main.threeStringStruct
+            Type: 145 PointerType *main.threeStringStruct
             Operations:
                 - __kind: LocationOp
                   Variable: {subprogram: 92, index: 0, name: a}
@@ -4985,7 +4985,7 @@ Types:
         - Name: a
           Offset: 1
           Expression:
-            Type: 232 StructureType main.threeStringStruct
+            Type: 144 StructureType main.threeStringStruct
             Operations:
                 - __kind: LocationOp
                   Variable: {subprogram: 91, index: 0, name: a}
@@ -5138,7 +5138,7 @@ Types:
         - Name: u
           Offset: 1
           Expression:
-            Type: 224 GoSliceHeaderType []uint
+            Type: 135 GoSliceHeaderType []uint
             Operations:
                 - __kind: LocationOp
                   Variable: {subprogram: 78, index: 0, name: u}
@@ -5198,7 +5198,7 @@ Types:
         - Name: xs
           Offset: 1
           Expression:
-            Type: 224 GoSliceHeaderType []uint
+            Type: 135 GoSliceHeaderType []uint
             Operations:
                 - __kind: LocationOp
                   Variable: {subprogram: 87, index: 0, name: xs}
@@ -5279,13 +5279,13 @@ Types:
       HasCount: true
       Element: 16 BaseType int8
     - __kind: ArrayType
-      ID: 134
+      ID: 91
       Name: '[2]map[string]int'
       ByteSize: 16
       GoKind: 17
       Count: 2
       HasCount: true
-      Element: 99 GoMapType map[string]int
+      Element: 76 GoMapType map[string]int
     - __kind: ArrayType
       ID: 38
       Name: '[2]string'
@@ -5338,7 +5338,7 @@ Types:
       HasCount: true
       Element: 3 BaseType uint8
     - __kind: ArrayType
-      ID: 195
+      ID: 233
       Name: '[4]int'
       ByteSize: 32
       GoRuntimeType: 672704
@@ -5347,7 +5347,7 @@ Types:
       HasCount: true
       Element: 7 BaseType int
     - __kind: ArrayType
-      ID: 133
+      ID: 220
       Name: '[4]string'
       ByteSize: 64
       GoRuntimeType: 672992
@@ -5356,7 +5356,7 @@ Types:
       HasCount: true
       Element: 9 GoStringHeaderType string
     - __kind: ArrayType
-      ID: 73
+      ID: 63
       Name: '[5]int'
       ByteSize: 40
       GoKind: 17
@@ -5386,88 +5386,88 @@ Types:
       ByteSize: 2048
       Element: 22 PointerType *string
     - __kind: GoSliceDataType
-      ID: 268
+      ID: 264
       Name: '[]*table<[4]int,[4]int>.array'
       ByteSize: 8192
-      Element: 211 PointerType *table<[4]int,[4]int>
+      Element: 127 PointerType *table<[4]int,[4]int>
     - __kind: GoSliceDataType
-      ID: 266
+      ID: 262
       Name: '[]*table<[4]int,uint8>.array'
       ByteSize: 8192
-      Element: 200 PointerType *table<[4]int,uint8>
+      Element: 122 PointerType *table<[4]int,uint8>
     - __kind: GoSliceDataType
-      ID: 252
+      ID: 250
       Name: '[]*table<[4]string,[2]int>.array'
       ByteSize: 8192
-      Element: 126 PointerType *table<[4]string,[2]int>
+      Element: 90 PointerType *table<[4]string,[2]int>
     - __kind: GoSliceDataType
-      ID: 258
+      ID: 254
       Name: '[]*table<bool,main.node>.array'
       ByteSize: 8192
-      Element: 153 PointerType *table<bool,main.node>
+      Element: 102 PointerType *table<bool,main.node>
     - __kind: GoSliceDataType
       ID: 242
       Name: '[]*table<int,int>.array'
       ByteSize: 8192
-      Element: 80 PointerType *table<int,int>
+      Element: 70 PointerType *table<int,int>
     - __kind: GoSliceDataType
-      ID: 260
+      ID: 256
       Name: '[]*table<int,uint8>.array'
       ByteSize: 8192
-      Element: 166 PointerType *table<int,uint8>
+      Element: 107 PointerType *table<int,uint8>
     - __kind: GoSliceDataType
-      ID: 254
+      ID: 252
       Name: '[]*table<string,[]main.structWithMap>.array'
       ByteSize: 8192
-      Element: 140 PointerType *table<string,[]main.structWithMap>
+      Element: 97 PointerType *table<string,[]main.structWithMap>
     - __kind: GoSliceDataType
       ID: 248
       Name: '[]*table<string,[]string>.array'
       ByteSize: 8192
-      Element: 114 PointerType *table<string,[]string>
+      Element: 85 PointerType *table<string,[]string>
     - __kind: GoSliceDataType
       ID: 246
       Name: '[]*table<string,int>.array'
       ByteSize: 8192
-      Element: 103 PointerType *table<string,int>
+      Element: 80 PointerType *table<string,int>
     - __kind: GoSliceDataType
       ID: 244
       Name: '[]*table<string,main.nestedStruct>.array'
       ByteSize: 8192
-      Element: 91 PointerType *table<string,main.nestedStruct>
+      Element: 75 PointerType *table<string,main.nestedStruct>
     - __kind: GoSliceDataType
-      ID: 264
+      ID: 260
       Name: '[]*table<uint8,[4]int>.array'
       ByteSize: 8192
-      Element: 188 PointerType *table<uint8,[4]int>
+      Element: 117 PointerType *table<uint8,[4]int>
     - __kind: GoSliceDataType
-      ID: 262
+      ID: 258
       Name: '[]*table<uint8,uint8>.array'
       ByteSize: 8192
-      Element: 177 PointerType *table<uint8,uint8>
+      Element: 112 PointerType *table<uint8,uint8>
     - __kind: GoSliceHeaderType
-      ID: 225
+      ID: 136
       Name: '[][]uint'
       ByteSize: 24
       GoKind: 23
       RawFields:
         - Name: array
           Offset: 0
-          Type: 226 PointerType *[]uint
+          Type: 137 PointerType *[]uint
         - Name: len
           Offset: 8
           Type: 7 BaseType int
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 274 GoSliceDataType [][]uint.array
+      Data: 270 GoSliceDataType [][]uint.array
     - __kind: GoSliceDataType
-      ID: 274
+      ID: 270
       Name: '[][]uint.array'
       ByteSize: 2048
-      Element: 224 GoSliceHeaderType []uint
+      Element: 135 GoSliceHeaderType []uint
     - __kind: GoSliceHeaderType
-      ID: 230
+      ID: 142
       Name: '[]bool'
       ByteSize: 24
       GoRuntimeType: 478400
@@ -5482,14 +5482,14 @@ Types:
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 278 GoSliceDataType []bool.array
+      Data: 276 GoSliceDataType []bool.array
     - __kind: GoSliceDataType
-      ID: 278
+      ID: 276
       Name: '[]bool.array'
       ByteSize: 2048
       Element: 4 BaseType bool
     - __kind: GoSliceHeaderType
-      ID: 147
+      ID: 223
       Name: '[]main.structWithMap'
       ByteSize: 24
       GoRuntimeType: 469760
@@ -5497,102 +5497,102 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 148 PointerType *main.structWithMap
+          Type: 224 PointerType *main.structWithMap
         - Name: len
           Offset: 8
           Type: 7 BaseType int
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 256 GoSliceDataType []main.structWithMap.array
+      Data: 280 GoSliceDataType []main.structWithMap.array
     - __kind: GoSliceDataType
-      ID: 256
+      ID: 280
       Name: '[]main.structWithMap.array'
       ByteSize: 2048
-      Element: 75 StructureType main.structWithMap
+      Element: 65 StructureType main.structWithMap
     - __kind: GoSliceHeaderType
-      ID: 227
+      ID: 138
       Name: '[]main.structWithNoStrings'
       ByteSize: 24
       GoKind: 23
       RawFields:
         - Name: array
           Offset: 0
-          Type: 228 PointerType *main.structWithNoStrings
+          Type: 139 PointerType *main.structWithNoStrings
         - Name: len
           Offset: 8
           Type: 7 BaseType int
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 276 GoSliceDataType []main.structWithNoStrings.array
+      Data: 272 GoSliceDataType []main.structWithNoStrings.array
     - __kind: GoSliceDataType
-      ID: 276
+      ID: 272
       Name: '[]main.structWithNoStrings.array'
       ByteSize: 2048
-      Element: 229 StructureType main.structWithNoStrings
+      Element: 140 StructureType main.structWithNoStrings
     - __kind: GoSliceDataType
-      ID: 269
+      ID: 265
       Name: '[]noalg.map.group[[4]int][4]int.array'
       ByteSize: 2048
-      Element: 215 StructureType noalg.map.group[[4]int][4]int
+      Element: 209 StructureType noalg.map.group[[4]int][4]int
     - __kind: GoSliceDataType
-      ID: 267
+      ID: 263
       Name: '[]noalg.map.group[[4]int]uint8.array'
       ByteSize: 2048
-      Element: 204 StructureType noalg.map.group[[4]int]uint8
+      Element: 206 StructureType noalg.map.group[[4]int]uint8
     - __kind: GoSliceDataType
-      ID: 253
+      ID: 251
       Name: '[]noalg.map.group[[4]string][2]int.array'
       ByteSize: 2048
-      Element: 130 StructureType noalg.map.group[[4]string][2]int
+      Element: 188 StructureType noalg.map.group[[4]string][2]int
     - __kind: GoSliceDataType
-      ID: 259
+      ID: 255
       Name: '[]noalg.map.group[bool]main.node.array'
       ByteSize: 2048
-      Element: 157 StructureType noalg.map.group[bool]main.node
+      Element: 194 StructureType noalg.map.group[bool]main.node
     - __kind: GoSliceDataType
       ID: 243
       Name: '[]noalg.map.group[int]int.array'
       ByteSize: 2048
-      Element: 84 StructureType noalg.map.group[int]int
+      Element: 176 StructureType noalg.map.group[int]int
     - __kind: GoSliceDataType
-      ID: 261
+      ID: 257
       Name: '[]noalg.map.group[int]uint8.array'
       ByteSize: 2048
-      Element: 170 StructureType noalg.map.group[int]uint8
+      Element: 197 StructureType noalg.map.group[int]uint8
     - __kind: GoSliceDataType
-      ID: 255
+      ID: 253
       Name: '[]noalg.map.group[string][]main.structWithMap.array'
       ByteSize: 2048
-      Element: 144 StructureType noalg.map.group[string][]main.structWithMap
+      Element: 191 StructureType noalg.map.group[string][]main.structWithMap
     - __kind: GoSliceDataType
       ID: 249
       Name: '[]noalg.map.group[string][]string.array'
       ByteSize: 2048
-      Element: 118 StructureType noalg.map.group[string][]string
+      Element: 185 StructureType noalg.map.group[string][]string
     - __kind: GoSliceDataType
       ID: 247
       Name: '[]noalg.map.group[string]int.array'
       ByteSize: 2048
-      Element: 107 StructureType noalg.map.group[string]int
+      Element: 182 StructureType noalg.map.group[string]int
     - __kind: GoSliceDataType
       ID: 245
       Name: '[]noalg.map.group[string]main.nestedStruct.array'
       ByteSize: 2048
-      Element: 95 StructureType noalg.map.group[string]main.nestedStruct
+      Element: 179 StructureType noalg.map.group[string]main.nestedStruct
     - __kind: GoSliceDataType
-      ID: 265
+      ID: 261
       Name: '[]noalg.map.group[uint8][4]int.array'
       ByteSize: 2048
-      Element: 192 StructureType noalg.map.group[uint8][4]int
+      Element: 203 StructureType noalg.map.group[uint8][4]int
     - __kind: GoSliceDataType
-      ID: 263
+      ID: 259
       Name: '[]noalg.map.group[uint8]uint8.array'
       ByteSize: 2048
-      Element: 181 StructureType noalg.map.group[uint8]uint8
+      Element: 200 StructureType noalg.map.group[uint8]uint8
     - __kind: GoSliceHeaderType
-      ID: 121
+      ID: 141
       Name: '[]string'
       ByteSize: 24
       GoRuntimeType: 478528
@@ -5607,14 +5607,14 @@ Types:
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 250 GoSliceDataType []string.array
+      Data: 274 GoSliceDataType []string.array
     - __kind: GoSliceDataType
-      ID: 250
+      ID: 274
       Name: '[]string.array'
       ByteSize: 2048
       Element: 9 GoStringHeaderType string
     - __kind: GoSliceHeaderType
-      ID: 224
+      ID: 135
       Name: '[]uint'
       ByteSize: 24
       GoRuntimeType: 478016
@@ -5629,14 +5629,14 @@ Types:
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 272 GoSliceDataType []uint.array
+      Data: 268 GoSliceDataType []uint.array
     - __kind: GoSliceDataType
-      ID: 272
+      ID: 268
       Name: '[]uint.array'
       ByteSize: 2048
       Element: 10 BaseType uint
     - __kind: GoSliceHeaderType
-      ID: 231
+      ID: 143
       Name: '[]uint16'
       ByteSize: 24
       GoRuntimeType: 477376
@@ -5651,9 +5651,9 @@ Types:
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 280 GoSliceDataType []uint16.array
+      Data: 278 GoSliceDataType []uint16.array
     - __kind: GoSliceDataType
-      ID: 280
+      ID: 278
       Name: '[]uint16.array'
       ByteSize: 2048
       Element: 6 BaseType uint16
@@ -5664,7 +5664,7 @@ Types:
       GoRuntimeType: 575840
       GoKind: 1
     - __kind: GoChannelType
-      ID: 218
+      ID: 128
       Name: chan bool
       GoRuntimeType: 587168
       GoKind: 18
@@ -5717,173 +5717,173 @@ Types:
       GoRuntimeType: 468800
       GoKind: 19
     - __kind: GoSwissMapGroupsType
-      ID: 213
+      ID: 207
       Name: groupReference<[4]int,[4]int>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 214 PointerType *noalg.map.group[[4]int][4]int
+          Type: 208 PointerType *noalg.map.group[[4]int][4]int
         - Name: lengthMask
           Offset: 8
           Type: 8 BaseType uint64
-      GroupType: 215 StructureType noalg.map.group[[4]int][4]int
-      GroupSliceType: 269 GoSliceDataType []noalg.map.group[[4]int][4]int.array
+      GroupType: 209 StructureType noalg.map.group[[4]int][4]int
+      GroupSliceType: 265 GoSliceDataType []noalg.map.group[[4]int][4]int.array
     - __kind: GoSwissMapGroupsType
-      ID: 202
+      ID: 204
       Name: groupReference<[4]int,uint8>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 203 PointerType *noalg.map.group[[4]int]uint8
+          Type: 205 PointerType *noalg.map.group[[4]int]uint8
         - Name: lengthMask
           Offset: 8
           Type: 8 BaseType uint64
-      GroupType: 204 StructureType noalg.map.group[[4]int]uint8
-      GroupSliceType: 267 GoSliceDataType []noalg.map.group[[4]int]uint8.array
+      GroupType: 206 StructureType noalg.map.group[[4]int]uint8
+      GroupSliceType: 263 GoSliceDataType []noalg.map.group[[4]int]uint8.array
     - __kind: GoSwissMapGroupsType
-      ID: 128
+      ID: 186
       Name: groupReference<[4]string,[2]int>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 129 PointerType *noalg.map.group[[4]string][2]int
+          Type: 187 PointerType *noalg.map.group[[4]string][2]int
         - Name: lengthMask
           Offset: 8
           Type: 8 BaseType uint64
-      GroupType: 130 StructureType noalg.map.group[[4]string][2]int
-      GroupSliceType: 253 GoSliceDataType []noalg.map.group[[4]string][2]int.array
+      GroupType: 188 StructureType noalg.map.group[[4]string][2]int
+      GroupSliceType: 251 GoSliceDataType []noalg.map.group[[4]string][2]int.array
     - __kind: GoSwissMapGroupsType
-      ID: 155
+      ID: 192
       Name: groupReference<bool,main.node>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 156 PointerType *noalg.map.group[bool]main.node
+          Type: 193 PointerType *noalg.map.group[bool]main.node
         - Name: lengthMask
           Offset: 8
           Type: 8 BaseType uint64
-      GroupType: 157 StructureType noalg.map.group[bool]main.node
-      GroupSliceType: 259 GoSliceDataType []noalg.map.group[bool]main.node.array
+      GroupType: 194 StructureType noalg.map.group[bool]main.node
+      GroupSliceType: 255 GoSliceDataType []noalg.map.group[bool]main.node.array
     - __kind: GoSwissMapGroupsType
-      ID: 82
+      ID: 174
       Name: groupReference<int,int>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 83 PointerType *noalg.map.group[int]int
+          Type: 175 PointerType *noalg.map.group[int]int
         - Name: lengthMask
           Offset: 8
           Type: 8 BaseType uint64
-      GroupType: 84 StructureType noalg.map.group[int]int
+      GroupType: 176 StructureType noalg.map.group[int]int
       GroupSliceType: 243 GoSliceDataType []noalg.map.group[int]int.array
     - __kind: GoSwissMapGroupsType
-      ID: 168
+      ID: 195
       Name: groupReference<int,uint8>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 169 PointerType *noalg.map.group[int]uint8
+          Type: 196 PointerType *noalg.map.group[int]uint8
         - Name: lengthMask
           Offset: 8
           Type: 8 BaseType uint64
-      GroupType: 170 StructureType noalg.map.group[int]uint8
-      GroupSliceType: 261 GoSliceDataType []noalg.map.group[int]uint8.array
+      GroupType: 197 StructureType noalg.map.group[int]uint8
+      GroupSliceType: 257 GoSliceDataType []noalg.map.group[int]uint8.array
     - __kind: GoSwissMapGroupsType
-      ID: 142
+      ID: 189
       Name: groupReference<string,[]main.structWithMap>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 143 PointerType *noalg.map.group[string][]main.structWithMap
+          Type: 190 PointerType *noalg.map.group[string][]main.structWithMap
         - Name: lengthMask
           Offset: 8
           Type: 8 BaseType uint64
-      GroupType: 144 StructureType noalg.map.group[string][]main.structWithMap
-      GroupSliceType: 255 GoSliceDataType []noalg.map.group[string][]main.structWithMap.array
+      GroupType: 191 StructureType noalg.map.group[string][]main.structWithMap
+      GroupSliceType: 253 GoSliceDataType []noalg.map.group[string][]main.structWithMap.array
     - __kind: GoSwissMapGroupsType
-      ID: 116
+      ID: 183
       Name: groupReference<string,[]string>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 117 PointerType *noalg.map.group[string][]string
+          Type: 184 PointerType *noalg.map.group[string][]string
         - Name: lengthMask
           Offset: 8
           Type: 8 BaseType uint64
-      GroupType: 118 StructureType noalg.map.group[string][]string
+      GroupType: 185 StructureType noalg.map.group[string][]string
       GroupSliceType: 249 GoSliceDataType []noalg.map.group[string][]string.array
     - __kind: GoSwissMapGroupsType
-      ID: 105
+      ID: 180
       Name: groupReference<string,int>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 106 PointerType *noalg.map.group[string]int
+          Type: 181 PointerType *noalg.map.group[string]int
         - Name: lengthMask
           Offset: 8
           Type: 8 BaseType uint64
-      GroupType: 107 StructureType noalg.map.group[string]int
+      GroupType: 182 StructureType noalg.map.group[string]int
       GroupSliceType: 247 GoSliceDataType []noalg.map.group[string]int.array
     - __kind: GoSwissMapGroupsType
-      ID: 93
+      ID: 177
       Name: groupReference<string,main.nestedStruct>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 94 PointerType *noalg.map.group[string]main.nestedStruct
+          Type: 178 PointerType *noalg.map.group[string]main.nestedStruct
         - Name: lengthMask
           Offset: 8
           Type: 8 BaseType uint64
-      GroupType: 95 StructureType noalg.map.group[string]main.nestedStruct
+      GroupType: 179 StructureType noalg.map.group[string]main.nestedStruct
       GroupSliceType: 245 GoSliceDataType []noalg.map.group[string]main.nestedStruct.array
     - __kind: GoSwissMapGroupsType
-      ID: 190
+      ID: 201
       Name: groupReference<uint8,[4]int>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 191 PointerType *noalg.map.group[uint8][4]int
+          Type: 202 PointerType *noalg.map.group[uint8][4]int
         - Name: lengthMask
           Offset: 8
           Type: 8 BaseType uint64
-      GroupType: 192 StructureType noalg.map.group[uint8][4]int
-      GroupSliceType: 265 GoSliceDataType []noalg.map.group[uint8][4]int.array
+      GroupType: 203 StructureType noalg.map.group[uint8][4]int
+      GroupSliceType: 261 GoSliceDataType []noalg.map.group[uint8][4]int.array
     - __kind: GoSwissMapGroupsType
-      ID: 179
+      ID: 198
       Name: groupReference<uint8,uint8>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 180 PointerType *noalg.map.group[uint8]uint8
+          Type: 199 PointerType *noalg.map.group[uint8]uint8
         - Name: lengthMask
           Offset: 8
           Type: 8 BaseType uint64
-      GroupType: 181 StructureType noalg.map.group[uint8]uint8
-      GroupSliceType: 263 GoSliceDataType []noalg.map.group[uint8]uint8.array
+      GroupType: 200 StructureType noalg.map.group[uint8]uint8
+      GroupSliceType: 259 GoSliceDataType []noalg.map.group[uint8]uint8.array
     - __kind: BaseType
       ID: 7
       Name: int
@@ -5928,7 +5928,7 @@ Types:
           Offset: 8
           Type: 15 VoidPointerType unsafe.Pointer
     - __kind: StructureType
-      ID: 65
+      ID: 153
       Name: internal/sync.Mutex
       ByteSize: 8
       GoRuntimeType: 1.453952e+06
@@ -5954,7 +5954,7 @@ Types:
           Offset: 8
           Type: 15 VoidPointerType unsafe.Pointer
     - __kind: StructureType
-      ID: 236
+      ID: 148
       Name: main.aStruct
       ByteSize: 56
       GoKind: 25
@@ -5970,9 +5970,9 @@ Types:
           Type: 7 BaseType int
         - Name: nested
           Offset: 32
-          Type: 98 StructureType main.nestedStruct
+          Type: 149 StructureType main.nestedStruct
     - __kind: GoInterfaceType
-      ID: 74
+      ID: 64
       Name: main.behavior
       ByteSize: 16
       GoRuntimeType: 1.011392e+06
@@ -6000,7 +6000,7 @@ Types:
           Offset: 32
           Type: 55 GoInterfaceType io.Writer
     - __kind: StructureType
-      ID: 237
+      ID: 150
       Name: main.emptyStruct
       GoKind: 25
       RawFields: []
@@ -6016,16 +6016,16 @@ Types:
           Type: 56 StructureType main.esotericStack
         - Name: mu
           Offset: 64
-          Type: 63 StructureType sync.Mutex
+          Type: 151 StructureType sync.Mutex
         - Name: once
           Offset: 72
-          Type: 66 StructureType sync.Once
+          Type: 154 StructureType sync.Once
         - Name: wg
           Offset: 88
-          Type: 69 StructureType sync.WaitGroup
+          Type: 157 StructureType sync.WaitGroup
         - Name: a
           Offset: 104
-          Type: 72 StructureType sync/atomic.Int32
+          Type: 160 StructureType sync/atomic.Int32
     - __kind: StructureType
       ID: 56
       Name: main.esotericStack
@@ -6055,7 +6055,7 @@ Types:
           Offset: 56
           Type: 60 GoSubroutineType func()
     - __kind: StructureType
-      ID: 98
+      ID: 149
       Name: main.nestedStruct
       ByteSize: 24
       GoRuntimeType: 1.443392e+06
@@ -6068,7 +6068,7 @@ Types:
           Offset: 8
           Type: 9 GoStringHeaderType string
     - __kind: StructureType
-      ID: 160
+      ID: 131
       Name: main.node
       ByteSize: 16
       GoRuntimeType: 1.443232e+06
@@ -6079,9 +6079,9 @@ Types:
           Type: 7 BaseType int
         - Name: b
           Offset: 8
-          Type: 161 PointerType *main.node
+          Type: 132 PointerType *main.node
     - __kind: StructureType
-      ID: 235
+      ID: 147
       Name: main.oneStringStruct
       ByteSize: 16
       GoKind: 25
@@ -6103,7 +6103,7 @@ Types:
           Offset: 8
           Type: 15 VoidPointerType unsafe.Pointer
     - __kind: StructureType
-      ID: 75
+      ID: 65
       Name: main.structWithMap
       ByteSize: 8
       GoRuntimeType: 1.172832e+06
@@ -6111,9 +6111,9 @@ Types:
       RawFields:
         - Name: m
           Offset: 0
-          Type: 76 GoMapType map[int]int
+          Type: 66 GoMapType map[int]int
     - __kind: StructureType
-      ID: 229
+      ID: 140
       Name: main.structWithNoStrings
       ByteSize: 2
       GoKind: 25
@@ -6125,7 +6125,7 @@ Types:
           Offset: 1
           Type: 4 BaseType bool
     - __kind: StructureType
-      ID: 220
+      ID: 130
       Name: main.structWithTwoValues
       ByteSize: 16
       GoKind: 25
@@ -6137,28 +6137,28 @@ Types:
           Offset: 8
           Type: 4 BaseType bool
     - __kind: GoSliceHeaderType
-      ID: 222
+      ID: 134
       Name: main.t
       ByteSize: 24
       GoKind: 23
       RawFields:
         - Name: array
           Offset: 0
-          Type: 223 PointerType **main.t
+          Type: 173 PointerType **main.t
         - Name: len
           Offset: 8
           Type: 7 BaseType int
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 270 GoSliceDataType main.t.array
+      Data: 266 GoSliceDataType main.t.array
     - __kind: GoSliceDataType
-      ID: 270
+      ID: 266
       Name: main.t.array
       ByteSize: 2048
-      Element: 221 PointerType *main.t
+      Element: 133 PointerType *main.t
     - __kind: StructureType
-      ID: 232
+      ID: 144
       Name: main.threeStringStruct
       ByteSize: 48
       GoKind: 25
@@ -6178,7 +6178,7 @@ Types:
       ByteSize: 2
       GoKind: 9
     - __kind: GoSwissMapHeaderType
-      ID: 209
+      ID: 125
       Name: map<[4]int,[4]int>
       ByteSize: 48
       GoKind: 25
@@ -6191,7 +6191,7 @@ Types:
           Type: 1 BaseType uintptr
         - Name: dirPtr
           Offset: 16
-          Type: 210 PointerType **table<[4]int,[4]int>
+          Type: 126 PointerType **table<[4]int,[4]int>
         - Name: dirLen
           Offset: 24
           Type: 7 BaseType int
@@ -6207,10 +6207,10 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 8 BaseType uint64
-      TablePtrSliceType: 268 GoSliceDataType []*table<[4]int,[4]int>.array
-      GroupType: 215 StructureType noalg.map.group[[4]int][4]int
+      TablePtrSliceType: 264 GoSliceDataType []*table<[4]int,[4]int>.array
+      GroupType: 209 StructureType noalg.map.group[[4]int][4]int
     - __kind: GoSwissMapHeaderType
-      ID: 198
+      ID: 120
       Name: map<[4]int,uint8>
       ByteSize: 48
       GoKind: 25
@@ -6223,7 +6223,7 @@ Types:
           Type: 1 BaseType uintptr
         - Name: dirPtr
           Offset: 16
-          Type: 199 PointerType **table<[4]int,uint8>
+          Type: 121 PointerType **table<[4]int,uint8>
         - Name: dirLen
           Offset: 24
           Type: 7 BaseType int
@@ -6239,10 +6239,10 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 8 BaseType uint64
-      TablePtrSliceType: 266 GoSliceDataType []*table<[4]int,uint8>.array
-      GroupType: 204 StructureType noalg.map.group[[4]int]uint8
+      TablePtrSliceType: 262 GoSliceDataType []*table<[4]int,uint8>.array
+      GroupType: 206 StructureType noalg.map.group[[4]int]uint8
     - __kind: GoSwissMapHeaderType
-      ID: 124
+      ID: 88
       Name: map<[4]string,[2]int>
       ByteSize: 48
       GoKind: 25
@@ -6255,7 +6255,7 @@ Types:
           Type: 1 BaseType uintptr
         - Name: dirPtr
           Offset: 16
-          Type: 125 PointerType **table<[4]string,[2]int>
+          Type: 89 PointerType **table<[4]string,[2]int>
         - Name: dirLen
           Offset: 24
           Type: 7 BaseType int
@@ -6271,10 +6271,10 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 8 BaseType uint64
-      TablePtrSliceType: 252 GoSliceDataType []*table<[4]string,[2]int>.array
-      GroupType: 130 StructureType noalg.map.group[[4]string][2]int
+      TablePtrSliceType: 250 GoSliceDataType []*table<[4]string,[2]int>.array
+      GroupType: 188 StructureType noalg.map.group[[4]string][2]int
     - __kind: GoSwissMapHeaderType
-      ID: 151
+      ID: 100
       Name: map<bool,main.node>
       ByteSize: 48
       GoKind: 25
@@ -6287,7 +6287,7 @@ Types:
           Type: 1 BaseType uintptr
         - Name: dirPtr
           Offset: 16
-          Type: 152 PointerType **table<bool,main.node>
+          Type: 101 PointerType **table<bool,main.node>
         - Name: dirLen
           Offset: 24
           Type: 7 BaseType int
@@ -6303,10 +6303,10 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 8 BaseType uint64
-      TablePtrSliceType: 258 GoSliceDataType []*table<bool,main.node>.array
-      GroupType: 157 StructureType noalg.map.group[bool]main.node
+      TablePtrSliceType: 254 GoSliceDataType []*table<bool,main.node>.array
+      GroupType: 194 StructureType noalg.map.group[bool]main.node
     - __kind: GoSwissMapHeaderType
-      ID: 78
+      ID: 68
       Name: map<int,int>
       ByteSize: 48
       GoKind: 25
@@ -6319,7 +6319,7 @@ Types:
           Type: 1 BaseType uintptr
         - Name: dirPtr
           Offset: 16
-          Type: 79 PointerType **table<int,int>
+          Type: 69 PointerType **table<int,int>
         - Name: dirLen
           Offset: 24
           Type: 7 BaseType int
@@ -6336,9 +6336,9 @@ Types:
           Offset: 40
           Type: 8 BaseType uint64
       TablePtrSliceType: 242 GoSliceDataType []*table<int,int>.array
-      GroupType: 84 StructureType noalg.map.group[int]int
+      GroupType: 176 StructureType noalg.map.group[int]int
     - __kind: GoSwissMapHeaderType
-      ID: 164
+      ID: 105
       Name: map<int,uint8>
       ByteSize: 48
       GoKind: 25
@@ -6351,7 +6351,7 @@ Types:
           Type: 1 BaseType uintptr
         - Name: dirPtr
           Offset: 16
-          Type: 165 PointerType **table<int,uint8>
+          Type: 106 PointerType **table<int,uint8>
         - Name: dirLen
           Offset: 24
           Type: 7 BaseType int
@@ -6367,10 +6367,10 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 8 BaseType uint64
-      TablePtrSliceType: 260 GoSliceDataType []*table<int,uint8>.array
-      GroupType: 170 StructureType noalg.map.group[int]uint8
+      TablePtrSliceType: 256 GoSliceDataType []*table<int,uint8>.array
+      GroupType: 197 StructureType noalg.map.group[int]uint8
     - __kind: GoSwissMapHeaderType
-      ID: 138
+      ID: 95
       Name: map<string,[]main.structWithMap>
       ByteSize: 48
       GoKind: 25
@@ -6383,7 +6383,7 @@ Types:
           Type: 1 BaseType uintptr
         - Name: dirPtr
           Offset: 16
-          Type: 139 PointerType **table<string,[]main.structWithMap>
+          Type: 96 PointerType **table<string,[]main.structWithMap>
         - Name: dirLen
           Offset: 24
           Type: 7 BaseType int
@@ -6399,10 +6399,10 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 8 BaseType uint64
-      TablePtrSliceType: 254 GoSliceDataType []*table<string,[]main.structWithMap>.array
-      GroupType: 144 StructureType noalg.map.group[string][]main.structWithMap
+      TablePtrSliceType: 252 GoSliceDataType []*table<string,[]main.structWithMap>.array
+      GroupType: 191 StructureType noalg.map.group[string][]main.structWithMap
     - __kind: GoSwissMapHeaderType
-      ID: 112
+      ID: 83
       Name: map<string,[]string>
       ByteSize: 48
       GoKind: 25
@@ -6415,7 +6415,7 @@ Types:
           Type: 1 BaseType uintptr
         - Name: dirPtr
           Offset: 16
-          Type: 113 PointerType **table<string,[]string>
+          Type: 84 PointerType **table<string,[]string>
         - Name: dirLen
           Offset: 24
           Type: 7 BaseType int
@@ -6432,9 +6432,9 @@ Types:
           Offset: 40
           Type: 8 BaseType uint64
       TablePtrSliceType: 248 GoSliceDataType []*table<string,[]string>.array
-      GroupType: 118 StructureType noalg.map.group[string][]string
+      GroupType: 185 StructureType noalg.map.group[string][]string
     - __kind: GoSwissMapHeaderType
-      ID: 101
+      ID: 78
       Name: map<string,int>
       ByteSize: 48
       GoKind: 25
@@ -6447,7 +6447,7 @@ Types:
           Type: 1 BaseType uintptr
         - Name: dirPtr
           Offset: 16
-          Type: 102 PointerType **table<string,int>
+          Type: 79 PointerType **table<string,int>
         - Name: dirLen
           Offset: 24
           Type: 7 BaseType int
@@ -6464,9 +6464,9 @@ Types:
           Offset: 40
           Type: 8 BaseType uint64
       TablePtrSliceType: 246 GoSliceDataType []*table<string,int>.array
-      GroupType: 107 StructureType noalg.map.group[string]int
+      GroupType: 182 StructureType noalg.map.group[string]int
     - __kind: GoSwissMapHeaderType
-      ID: 89
+      ID: 73
       Name: map<string,main.nestedStruct>
       ByteSize: 48
       GoKind: 25
@@ -6479,7 +6479,7 @@ Types:
           Type: 1 BaseType uintptr
         - Name: dirPtr
           Offset: 16
-          Type: 90 PointerType **table<string,main.nestedStruct>
+          Type: 74 PointerType **table<string,main.nestedStruct>
         - Name: dirLen
           Offset: 24
           Type: 7 BaseType int
@@ -6496,9 +6496,9 @@ Types:
           Offset: 40
           Type: 8 BaseType uint64
       TablePtrSliceType: 244 GoSliceDataType []*table<string,main.nestedStruct>.array
-      GroupType: 95 StructureType noalg.map.group[string]main.nestedStruct
+      GroupType: 179 StructureType noalg.map.group[string]main.nestedStruct
     - __kind: GoSwissMapHeaderType
-      ID: 186
+      ID: 115
       Name: map<uint8,[4]int>
       ByteSize: 48
       GoKind: 25
@@ -6511,7 +6511,7 @@ Types:
           Type: 1 BaseType uintptr
         - Name: dirPtr
           Offset: 16
-          Type: 187 PointerType **table<uint8,[4]int>
+          Type: 116 PointerType **table<uint8,[4]int>
         - Name: dirLen
           Offset: 24
           Type: 7 BaseType int
@@ -6527,10 +6527,10 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 8 BaseType uint64
-      TablePtrSliceType: 264 GoSliceDataType []*table<uint8,[4]int>.array
-      GroupType: 192 StructureType noalg.map.group[uint8][4]int
+      TablePtrSliceType: 260 GoSliceDataType []*table<uint8,[4]int>.array
+      GroupType: 203 StructureType noalg.map.group[uint8][4]int
     - __kind: GoSwissMapHeaderType
-      ID: 175
+      ID: 110
       Name: map<uint8,uint8>
       ByteSize: 48
       GoKind: 25
@@ -6543,7 +6543,7 @@ Types:
           Type: 1 BaseType uintptr
         - Name: dirPtr
           Offset: 16
-          Type: 176 PointerType **table<uint8,uint8>
+          Type: 111 PointerType **table<uint8,uint8>
         - Name: dirLen
           Offset: 24
           Type: 7 BaseType int
@@ -6559,202 +6559,202 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 8 BaseType uint64
-      TablePtrSliceType: 262 GoSliceDataType []*table<uint8,uint8>.array
-      GroupType: 181 StructureType noalg.map.group[uint8]uint8
+      TablePtrSliceType: 258 GoSliceDataType []*table<uint8,uint8>.array
+      GroupType: 200 StructureType noalg.map.group[uint8]uint8
     - __kind: GoMapType
-      ID: 207
+      ID: 123
       Name: map[[4]int][4]int
       ByteSize: 8
       GoRuntimeType: 1.116896e+06
       GoKind: 21
-      HeaderType: 209 GoSwissMapHeaderType map<[4]int,[4]int>
+      HeaderType: 125 GoSwissMapHeaderType map<[4]int,[4]int>
     - __kind: GoMapType
-      ID: 196
+      ID: 118
       Name: map[[4]int]uint8
       ByteSize: 8
       GoRuntimeType: 1.117024e+06
       GoKind: 21
-      HeaderType: 198 GoSwissMapHeaderType map<[4]int,uint8>
+      HeaderType: 120 GoSwissMapHeaderType map<[4]int,uint8>
     - __kind: GoMapType
-      ID: 122
+      ID: 86
       Name: map[[4]string][2]int
       ByteSize: 8
       GoRuntimeType: 1.117152e+06
       GoKind: 21
-      HeaderType: 124 GoSwissMapHeaderType map<[4]string,[2]int>
+      HeaderType: 88 GoSwissMapHeaderType map<[4]string,[2]int>
     - __kind: GoMapType
-      ID: 149
+      ID: 98
       Name: map[bool]main.node
       ByteSize: 8
       GoRuntimeType: 1.11728e+06
       GoKind: 21
-      HeaderType: 151 GoSwissMapHeaderType map<bool,main.node>
+      HeaderType: 100 GoSwissMapHeaderType map<bool,main.node>
     - __kind: GoMapType
-      ID: 76
+      ID: 66
       Name: map[int]int
       ByteSize: 8
       GoRuntimeType: 1.116512e+06
       GoKind: 21
-      HeaderType: 78 GoSwissMapHeaderType map<int,int>
+      HeaderType: 68 GoSwissMapHeaderType map<int,int>
     - __kind: GoMapType
-      ID: 162
+      ID: 103
       Name: map[int]uint8
       ByteSize: 8
       GoRuntimeType: 1.117408e+06
       GoKind: 21
-      HeaderType: 164 GoSwissMapHeaderType map<int,uint8>
+      HeaderType: 105 GoSwissMapHeaderType map<int,uint8>
     - __kind: GoMapType
-      ID: 136
+      ID: 93
       Name: map[string][]main.structWithMap
       ByteSize: 8
       GoRuntimeType: 1.117536e+06
       GoKind: 21
-      HeaderType: 138 GoSwissMapHeaderType map<string,[]main.structWithMap>
+      HeaderType: 95 GoSwissMapHeaderType map<string,[]main.structWithMap>
     - __kind: GoMapType
-      ID: 110
+      ID: 81
       Name: map[string][]string
       ByteSize: 8
       GoRuntimeType: 1.117664e+06
       GoKind: 21
-      HeaderType: 112 GoSwissMapHeaderType map<string,[]string>
+      HeaderType: 83 GoSwissMapHeaderType map<string,[]string>
     - __kind: GoMapType
-      ID: 99
+      ID: 76
       Name: map[string]int
       ByteSize: 8
       GoRuntimeType: 1.117792e+06
       GoKind: 21
-      HeaderType: 101 GoSwissMapHeaderType map<string,int>
+      HeaderType: 78 GoSwissMapHeaderType map<string,int>
     - __kind: GoMapType
-      ID: 87
+      ID: 71
       Name: map[string]main.nestedStruct
       ByteSize: 8
       GoRuntimeType: 1.11792e+06
       GoKind: 21
-      HeaderType: 89 GoSwissMapHeaderType map<string,main.nestedStruct>
+      HeaderType: 73 GoSwissMapHeaderType map<string,main.nestedStruct>
     - __kind: GoMapType
-      ID: 184
+      ID: 113
       Name: map[uint8][4]int
       ByteSize: 8
       GoRuntimeType: 1.118048e+06
       GoKind: 21
-      HeaderType: 186 GoSwissMapHeaderType map<uint8,[4]int>
+      HeaderType: 115 GoSwissMapHeaderType map<uint8,[4]int>
     - __kind: GoMapType
-      ID: 173
+      ID: 108
       Name: map[uint8]uint8
       ByteSize: 8
       GoRuntimeType: 1.118176e+06
       GoKind: 21
-      HeaderType: 175 GoSwissMapHeaderType map<uint8,uint8>
+      HeaderType: 110 GoSwissMapHeaderType map<uint8,uint8>
     - __kind: ArrayType
-      ID: 216
+      ID: 236
       Name: noalg.[8]struct { key [4]int; elem [4]int }
       ByteSize: 512
       GoRuntimeType: 672800
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 217 StructureType noalg.struct { key [4]int; elem [4]int }
+      Element: 237 StructureType noalg.struct { key [4]int; elem [4]int }
     - __kind: ArrayType
-      ID: 205
+      ID: 234
       Name: noalg.[8]struct { key [4]int; elem uint8 }
       ByteSize: 320
       GoRuntimeType: 672896
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 206 StructureType noalg.struct { key [4]int; elem uint8 }
+      Element: 235 StructureType noalg.struct { key [4]int; elem uint8 }
     - __kind: ArrayType
-      ID: 131
+      ID: 218
       Name: noalg.[8]struct { key [4]string; elem [2]int }
       ByteSize: 640
       GoRuntimeType: 673184
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 132 StructureType noalg.struct { key [4]string; elem [2]int }
+      Element: 219 StructureType noalg.struct { key [4]string; elem [2]int }
     - __kind: ArrayType
-      ID: 158
+      ID: 225
       Name: noalg.[8]struct { key bool; elem main.node }
       ByteSize: 192
       GoRuntimeType: 673280
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 159 StructureType noalg.struct { key bool; elem main.node }
+      Element: 226 StructureType noalg.struct { key bool; elem main.node }
     - __kind: ArrayType
-      ID: 85
+      ID: 210
       Name: noalg.[8]struct { key int; elem int }
       ByteSize: 128
       GoRuntimeType: 671072
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 86 StructureType noalg.struct { key int; elem int }
+      Element: 211 StructureType noalg.struct { key int; elem int }
     - __kind: ArrayType
-      ID: 171
+      ID: 227
       Name: noalg.[8]struct { key int; elem uint8 }
       ByteSize: 128
       GoRuntimeType: 673376
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 172 StructureType noalg.struct { key int; elem uint8 }
+      Element: 228 StructureType noalg.struct { key int; elem uint8 }
     - __kind: ArrayType
-      ID: 145
+      ID: 221
       Name: noalg.[8]struct { key string; elem []main.structWithMap }
       ByteSize: 320
       GoRuntimeType: 673472
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 146 StructureType noalg.struct { key string; elem []main.structWithMap }
+      Element: 222 StructureType noalg.struct { key string; elem []main.structWithMap }
     - __kind: ArrayType
-      ID: 119
+      ID: 216
       Name: noalg.[8]struct { key string; elem []string }
       ByteSize: 320
       GoRuntimeType: 673568
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 120 StructureType noalg.struct { key string; elem []string }
+      Element: 217 StructureType noalg.struct { key string; elem []string }
     - __kind: ArrayType
-      ID: 108
+      ID: 214
       Name: noalg.[8]struct { key string; elem int }
       ByteSize: 192
       GoRuntimeType: 673664
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 109 StructureType noalg.struct { key string; elem int }
+      Element: 215 StructureType noalg.struct { key string; elem int }
     - __kind: ArrayType
-      ID: 96
+      ID: 212
       Name: noalg.[8]struct { key string; elem main.nestedStruct }
       ByteSize: 320
       GoRuntimeType: 673760
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 97 StructureType noalg.struct { key string; elem main.nestedStruct }
+      Element: 213 StructureType noalg.struct { key string; elem main.nestedStruct }
     - __kind: ArrayType
-      ID: 193
+      ID: 231
       Name: noalg.[8]struct { key uint8; elem [4]int }
       ByteSize: 320
       GoRuntimeType: 673856
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 194 StructureType noalg.struct { key uint8; elem [4]int }
+      Element: 232 StructureType noalg.struct { key uint8; elem [4]int }
     - __kind: ArrayType
-      ID: 182
+      ID: 229
       Name: noalg.[8]struct { key uint8; elem uint8 }
       ByteSize: 16
       GoRuntimeType: 673952
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 183 StructureType noalg.struct { key uint8; elem uint8 }
+      Element: 230 StructureType noalg.struct { key uint8; elem uint8 }
     - __kind: StructureType
-      ID: 215
+      ID: 209
       Name: noalg.map.group[[4]int][4]int
       ByteSize: 520
       GoRuntimeType: 1.276576e+06
@@ -6765,9 +6765,9 @@ Types:
           Type: 8 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 216 ArrayType noalg.[8]struct { key [4]int; elem [4]int }
+          Type: 236 ArrayType noalg.[8]struct { key [4]int; elem [4]int }
     - __kind: StructureType
-      ID: 204
+      ID: 206
       Name: noalg.map.group[[4]int]uint8
       ByteSize: 328
       GoRuntimeType: 1.276832e+06
@@ -6778,9 +6778,9 @@ Types:
           Type: 8 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 205 ArrayType noalg.[8]struct { key [4]int; elem uint8 }
+          Type: 234 ArrayType noalg.[8]struct { key [4]int; elem uint8 }
     - __kind: StructureType
-      ID: 130
+      ID: 188
       Name: noalg.map.group[[4]string][2]int
       ByteSize: 648
       GoRuntimeType: 1.277088e+06
@@ -6791,9 +6791,9 @@ Types:
           Type: 8 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 131 ArrayType noalg.[8]struct { key [4]string; elem [2]int }
+          Type: 218 ArrayType noalg.[8]struct { key [4]string; elem [2]int }
     - __kind: StructureType
-      ID: 157
+      ID: 194
       Name: noalg.map.group[bool]main.node
       ByteSize: 200
       GoRuntimeType: 1.277344e+06
@@ -6804,9 +6804,9 @@ Types:
           Type: 8 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 158 ArrayType noalg.[8]struct { key bool; elem main.node }
+          Type: 225 ArrayType noalg.[8]struct { key bool; elem main.node }
     - __kind: StructureType
-      ID: 84
+      ID: 176
       Name: noalg.map.group[int]int
       ByteSize: 136
       GoRuntimeType: 1.275808e+06
@@ -6817,9 +6817,9 @@ Types:
           Type: 8 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 85 ArrayType noalg.[8]struct { key int; elem int }
+          Type: 210 ArrayType noalg.[8]struct { key int; elem int }
     - __kind: StructureType
-      ID: 170
+      ID: 197
       Name: noalg.map.group[int]uint8
       ByteSize: 136
       GoRuntimeType: 1.2776e+06
@@ -6830,9 +6830,9 @@ Types:
           Type: 8 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 171 ArrayType noalg.[8]struct { key int; elem uint8 }
+          Type: 227 ArrayType noalg.[8]struct { key int; elem uint8 }
     - __kind: StructureType
-      ID: 144
+      ID: 191
       Name: noalg.map.group[string][]main.structWithMap
       ByteSize: 328
       GoRuntimeType: 1.277856e+06
@@ -6843,9 +6843,9 @@ Types:
           Type: 8 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 145 ArrayType noalg.[8]struct { key string; elem []main.structWithMap }
+          Type: 221 ArrayType noalg.[8]struct { key string; elem []main.structWithMap }
     - __kind: StructureType
-      ID: 118
+      ID: 185
       Name: noalg.map.group[string][]string
       ByteSize: 328
       GoRuntimeType: 1.278112e+06
@@ -6856,9 +6856,9 @@ Types:
           Type: 8 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 119 ArrayType noalg.[8]struct { key string; elem []string }
+          Type: 216 ArrayType noalg.[8]struct { key string; elem []string }
     - __kind: StructureType
-      ID: 107
+      ID: 182
       Name: noalg.map.group[string]int
       ByteSize: 200
       GoRuntimeType: 1.278368e+06
@@ -6869,9 +6869,9 @@ Types:
           Type: 8 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 108 ArrayType noalg.[8]struct { key string; elem int }
+          Type: 214 ArrayType noalg.[8]struct { key string; elem int }
     - __kind: StructureType
-      ID: 95
+      ID: 179
       Name: noalg.map.group[string]main.nestedStruct
       ByteSize: 328
       GoRuntimeType: 1.278624e+06
@@ -6882,9 +6882,9 @@ Types:
           Type: 8 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 96 ArrayType noalg.[8]struct { key string; elem main.nestedStruct }
+          Type: 212 ArrayType noalg.[8]struct { key string; elem main.nestedStruct }
     - __kind: StructureType
-      ID: 192
+      ID: 203
       Name: noalg.map.group[uint8][4]int
       ByteSize: 328
       GoRuntimeType: 1.27888e+06
@@ -6895,9 +6895,9 @@ Types:
           Type: 8 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 193 ArrayType noalg.[8]struct { key uint8; elem [4]int }
+          Type: 231 ArrayType noalg.[8]struct { key uint8; elem [4]int }
     - __kind: StructureType
-      ID: 181
+      ID: 200
       Name: noalg.map.group[uint8]uint8
       ByteSize: 24
       GoRuntimeType: 1.279136e+06
@@ -6908,9 +6908,9 @@ Types:
           Type: 8 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 182 ArrayType noalg.[8]struct { key uint8; elem uint8 }
+          Type: 229 ArrayType noalg.[8]struct { key uint8; elem uint8 }
     - __kind: StructureType
-      ID: 217
+      ID: 237
       Name: noalg.struct { key [4]int; elem [4]int }
       ByteSize: 64
       GoRuntimeType: 1.276448e+06
@@ -6918,12 +6918,12 @@ Types:
       RawFields:
         - Name: key
           Offset: 0
-          Type: 195 ArrayType [4]int
+          Type: 233 ArrayType [4]int
         - Name: elem
           Offset: 32
-          Type: 195 ArrayType [4]int
+          Type: 233 ArrayType [4]int
     - __kind: StructureType
-      ID: 206
+      ID: 235
       Name: noalg.struct { key [4]int; elem uint8 }
       ByteSize: 40
       GoRuntimeType: 1.276704e+06
@@ -6931,12 +6931,12 @@ Types:
       RawFields:
         - Name: key
           Offset: 0
-          Type: 195 ArrayType [4]int
+          Type: 233 ArrayType [4]int
         - Name: elem
           Offset: 32
           Type: 3 BaseType uint8
     - __kind: StructureType
-      ID: 132
+      ID: 219
       Name: noalg.struct { key [4]string; elem [2]int }
       ByteSize: 80
       GoRuntimeType: 1.27696e+06
@@ -6944,12 +6944,12 @@ Types:
       RawFields:
         - Name: key
           Offset: 0
-          Type: 133 ArrayType [4]string
+          Type: 220 ArrayType [4]string
         - Name: elem
           Offset: 64
           Type: 40 ArrayType [2]int
     - __kind: StructureType
-      ID: 159
+      ID: 226
       Name: noalg.struct { key bool; elem main.node }
       ByteSize: 24
       GoRuntimeType: 1.277216e+06
@@ -6960,9 +6960,9 @@ Types:
           Type: 4 BaseType bool
         - Name: elem
           Offset: 8
-          Type: 160 StructureType main.node
+          Type: 131 StructureType main.node
     - __kind: StructureType
-      ID: 86
+      ID: 211
       Name: noalg.struct { key int; elem int }
       ByteSize: 16
       GoRuntimeType: 1.27568e+06
@@ -6975,7 +6975,7 @@ Types:
           Offset: 8
           Type: 7 BaseType int
     - __kind: StructureType
-      ID: 172
+      ID: 228
       Name: noalg.struct { key int; elem uint8 }
       ByteSize: 16
       GoRuntimeType: 1.277472e+06
@@ -6988,7 +6988,7 @@ Types:
           Offset: 8
           Type: 3 BaseType uint8
     - __kind: StructureType
-      ID: 146
+      ID: 222
       Name: noalg.struct { key string; elem []main.structWithMap }
       ByteSize: 40
       GoRuntimeType: 1.277728e+06
@@ -6999,9 +6999,9 @@ Types:
           Type: 9 GoStringHeaderType string
         - Name: elem
           Offset: 16
-          Type: 147 GoSliceHeaderType []main.structWithMap
+          Type: 223 GoSliceHeaderType []main.structWithMap
     - __kind: StructureType
-      ID: 120
+      ID: 217
       Name: noalg.struct { key string; elem []string }
       ByteSize: 40
       GoRuntimeType: 1.277984e+06
@@ -7012,9 +7012,9 @@ Types:
           Type: 9 GoStringHeaderType string
         - Name: elem
           Offset: 16
-          Type: 121 GoSliceHeaderType []string
+          Type: 141 GoSliceHeaderType []string
     - __kind: StructureType
-      ID: 109
+      ID: 215
       Name: noalg.struct { key string; elem int }
       ByteSize: 24
       GoRuntimeType: 1.27824e+06
@@ -7027,7 +7027,7 @@ Types:
           Offset: 16
           Type: 7 BaseType int
     - __kind: StructureType
-      ID: 97
+      ID: 213
       Name: noalg.struct { key string; elem main.nestedStruct }
       ByteSize: 40
       GoRuntimeType: 1.278496e+06
@@ -7038,9 +7038,9 @@ Types:
           Type: 9 GoStringHeaderType string
         - Name: elem
           Offset: 16
-          Type: 98 StructureType main.nestedStruct
+          Type: 149 StructureType main.nestedStruct
     - __kind: StructureType
-      ID: 194
+      ID: 232
       Name: noalg.struct { key uint8; elem [4]int }
       ByteSize: 40
       GoRuntimeType: 1.278752e+06
@@ -7051,9 +7051,9 @@ Types:
           Type: 3 BaseType uint8
         - Name: elem
           Offset: 8
-          Type: 195 ArrayType [4]int
+          Type: 233 ArrayType [4]int
     - __kind: StructureType
-      ID: 183
+      ID: 230
       Name: noalg.struct { key uint8; elem uint8 }
       ByteSize: 2
       GoRuntimeType: 1.279008e+06
@@ -7084,7 +7084,7 @@ Types:
       Name: string.str
       ByteSize: 2048
     - __kind: StructureType
-      ID: 63
+      ID: 151
       Name: sync.Mutex
       ByteSize: 8
       GoRuntimeType: 1.444672e+06
@@ -7092,12 +7092,12 @@ Types:
       RawFields:
         - Name: _
           Offset: 0
-          Type: 64 StructureType sync.noCopy
+          Type: 152 StructureType sync.noCopy
         - Name: mu
           Offset: 0
-          Type: 65 StructureType internal/sync.Mutex
+          Type: 153 StructureType internal/sync.Mutex
     - __kind: StructureType
-      ID: 66
+      ID: 154
       Name: sync.Once
       ByteSize: 12
       GoRuntimeType: 1.593184e+06
@@ -7105,15 +7105,15 @@ Types:
       RawFields:
         - Name: _
           Offset: 0
-          Type: 64 StructureType sync.noCopy
+          Type: 152 StructureType sync.noCopy
         - Name: done
           Offset: 0
-          Type: 67 StructureType sync/atomic.Uint32
+          Type: 155 StructureType sync/atomic.Uint32
         - Name: m
           Offset: 4
-          Type: 63 StructureType sync.Mutex
+          Type: 151 StructureType sync.Mutex
     - __kind: StructureType
-      ID: 69
+      ID: 157
       Name: sync.WaitGroup
       ByteSize: 16
       GoRuntimeType: 1.593376e+06
@@ -7121,21 +7121,21 @@ Types:
       RawFields:
         - Name: noCopy
           Offset: 0
-          Type: 64 StructureType sync.noCopy
+          Type: 152 StructureType sync.noCopy
         - Name: state
           Offset: 0
-          Type: 70 StructureType sync/atomic.Uint64
+          Type: 158 StructureType sync/atomic.Uint64
         - Name: sema
           Offset: 8
           Type: 2 BaseType uint32
     - __kind: StructureType
-      ID: 64
+      ID: 152
       Name: sync.noCopy
       GoRuntimeType: 977056
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 72
+      ID: 160
       Name: sync/atomic.Int32
       ByteSize: 4
       GoRuntimeType: 1.445952e+06
@@ -7143,12 +7143,12 @@ Types:
       RawFields:
         - Name: _
           Offset: 0
-          Type: 68 StructureType sync/atomic.noCopy
+          Type: 156 StructureType sync/atomic.noCopy
         - Name: v
           Offset: 0
           Type: 12 BaseType int32
     - __kind: StructureType
-      ID: 67
+      ID: 155
       Name: sync/atomic.Uint32
       ByteSize: 4
       GoRuntimeType: 1.446112e+06
@@ -7156,12 +7156,12 @@ Types:
       RawFields:
         - Name: _
           Offset: 0
-          Type: 68 StructureType sync/atomic.noCopy
+          Type: 156 StructureType sync/atomic.noCopy
         - Name: v
           Offset: 0
           Type: 2 BaseType uint32
     - __kind: StructureType
-      ID: 70
+      ID: 158
       Name: sync/atomic.Uint64
       ByteSize: 8
       GoRuntimeType: 1.59376e+06
@@ -7169,27 +7169,27 @@ Types:
       RawFields:
         - Name: _
           Offset: 0
-          Type: 68 StructureType sync/atomic.noCopy
+          Type: 156 StructureType sync/atomic.noCopy
         - Name: _
           Offset: 0
-          Type: 71 StructureType sync/atomic.align64
+          Type: 159 StructureType sync/atomic.align64
         - Name: v
           Offset: 0
           Type: 8 BaseType uint64
     - __kind: StructureType
-      ID: 71
+      ID: 159
       Name: sync/atomic.align64
       GoRuntimeType: 977248
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 68
+      ID: 156
       Name: sync/atomic.noCopy
       GoRuntimeType: 977152
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 212
+      ID: 172
       Name: table<[4]int,[4]int>
       ByteSize: 32
       GoKind: 25
@@ -7211,9 +7211,9 @@ Types:
           Type: 7 BaseType int
         - Name: groups
           Offset: 16
-          Type: 213 GoSwissMapGroupsType groupReference<[4]int,[4]int>
+          Type: 207 GoSwissMapGroupsType groupReference<[4]int,[4]int>
     - __kind: StructureType
-      ID: 201
+      ID: 171
       Name: table<[4]int,uint8>
       ByteSize: 32
       GoKind: 25
@@ -7235,9 +7235,9 @@ Types:
           Type: 7 BaseType int
         - Name: groups
           Offset: 16
-          Type: 202 GoSwissMapGroupsType groupReference<[4]int,uint8>
+          Type: 204 GoSwissMapGroupsType groupReference<[4]int,uint8>
     - __kind: StructureType
-      ID: 127
+      ID: 165
       Name: table<[4]string,[2]int>
       ByteSize: 32
       GoKind: 25
@@ -7259,9 +7259,9 @@ Types:
           Type: 7 BaseType int
         - Name: groups
           Offset: 16
-          Type: 128 GoSwissMapGroupsType groupReference<[4]string,[2]int>
+          Type: 186 GoSwissMapGroupsType groupReference<[4]string,[2]int>
     - __kind: StructureType
-      ID: 154
+      ID: 167
       Name: table<bool,main.node>
       ByteSize: 32
       GoKind: 25
@@ -7283,9 +7283,9 @@ Types:
           Type: 7 BaseType int
         - Name: groups
           Offset: 16
-          Type: 155 GoSwissMapGroupsType groupReference<bool,main.node>
+          Type: 192 GoSwissMapGroupsType groupReference<bool,main.node>
     - __kind: StructureType
-      ID: 81
+      ID: 161
       Name: table<int,int>
       ByteSize: 32
       GoKind: 25
@@ -7307,9 +7307,9 @@ Types:
           Type: 7 BaseType int
         - Name: groups
           Offset: 16
-          Type: 82 GoSwissMapGroupsType groupReference<int,int>
+          Type: 174 GoSwissMapGroupsType groupReference<int,int>
     - __kind: StructureType
-      ID: 167
+      ID: 168
       Name: table<int,uint8>
       ByteSize: 32
       GoKind: 25
@@ -7331,9 +7331,9 @@ Types:
           Type: 7 BaseType int
         - Name: groups
           Offset: 16
-          Type: 168 GoSwissMapGroupsType groupReference<int,uint8>
+          Type: 195 GoSwissMapGroupsType groupReference<int,uint8>
     - __kind: StructureType
-      ID: 141
+      ID: 166
       Name: table<string,[]main.structWithMap>
       ByteSize: 32
       GoKind: 25
@@ -7355,9 +7355,9 @@ Types:
           Type: 7 BaseType int
         - Name: groups
           Offset: 16
-          Type: 142 GoSwissMapGroupsType groupReference<string,[]main.structWithMap>
+          Type: 189 GoSwissMapGroupsType groupReference<string,[]main.structWithMap>
     - __kind: StructureType
-      ID: 115
+      ID: 164
       Name: table<string,[]string>
       ByteSize: 32
       GoKind: 25
@@ -7379,9 +7379,9 @@ Types:
           Type: 7 BaseType int
         - Name: groups
           Offset: 16
-          Type: 116 GoSwissMapGroupsType groupReference<string,[]string>
+          Type: 183 GoSwissMapGroupsType groupReference<string,[]string>
     - __kind: StructureType
-      ID: 104
+      ID: 163
       Name: table<string,int>
       ByteSize: 32
       GoKind: 25
@@ -7403,9 +7403,9 @@ Types:
           Type: 7 BaseType int
         - Name: groups
           Offset: 16
-          Type: 105 GoSwissMapGroupsType groupReference<string,int>
+          Type: 180 GoSwissMapGroupsType groupReference<string,int>
     - __kind: StructureType
-      ID: 92
+      ID: 162
       Name: table<string,main.nestedStruct>
       ByteSize: 32
       GoKind: 25
@@ -7427,9 +7427,9 @@ Types:
           Type: 7 BaseType int
         - Name: groups
           Offset: 16
-          Type: 93 GoSwissMapGroupsType groupReference<string,main.nestedStruct>
+          Type: 177 GoSwissMapGroupsType groupReference<string,main.nestedStruct>
     - __kind: StructureType
-      ID: 189
+      ID: 170
       Name: table<uint8,[4]int>
       ByteSize: 32
       GoKind: 25
@@ -7451,9 +7451,9 @@ Types:
           Type: 7 BaseType int
         - Name: groups
           Offset: 16
-          Type: 190 GoSwissMapGroupsType groupReference<uint8,[4]int>
+          Type: 201 GoSwissMapGroupsType groupReference<uint8,[4]int>
     - __kind: StructureType
-      ID: 178
+      ID: 169
       Name: table<uint8,uint8>
       ByteSize: 32
       GoKind: 25
@@ -7475,7 +7475,7 @@ Types:
           Type: 7 BaseType int
         - Name: groups
           Offset: 16
-          Type: 179 GoSwissMapGroupsType groupReference<uint8,uint8>
+          Type: 198 GoSwissMapGroupsType groupReference<uint8,uint8>
     - __kind: BaseType
       ID: 10
       Name: uint

--- a/pkg/dyninst/irgen/testdata/snapshot/sample.arch=arm64,toolchain=go1.24.3.yaml
+++ b/pkg/dyninst/irgen/testdata/snapshot/sample.arch=arm64,toolchain=go1.24.3.yaml
@@ -3167,10 +3167,10 @@ Types:
       ByteSize: 8
       Pointee: 112 PointerType *table<uint8,uint8>
     - __kind: PointerType
-      ID: 241
+      ID: 177
       Name: '*[]*string.array'
       ByteSize: 8
-      Pointee: 240 GoSliceDataType []*string.array
+      Pointee: 176 GoSliceDataType []*string.array
     - __kind: PointerType
       ID: 271
       Name: '*[][]uint.array'
@@ -3295,7 +3295,7 @@ Types:
       GoKind: 22
       Pointee: 147 StructureType main.oneStringStruct
     - __kind: PointerType
-      ID: 224
+      ID: 220
       Name: '*main.structWithMap'
       ByteSize: 8
       GoRuntimeType: 380096
@@ -3396,65 +3396,65 @@ Types:
       GoKind: 22
       Pointee: 76 GoMapType map[string]int
     - __kind: PointerType
-      ID: 208
+      ID: 260
       Name: '*noalg.map.group[[4]int][4]int'
       ByteSize: 8
-      Pointee: 209 StructureType noalg.map.group[[4]int][4]int
+      Pointee: 261 StructureType noalg.map.group[[4]int][4]int
     - __kind: PointerType
-      ID: 205
+      ID: 253
       Name: '*noalg.map.group[[4]int]uint8'
       ByteSize: 8
-      Pointee: 206 StructureType noalg.map.group[[4]int]uint8
+      Pointee: 254 StructureType noalg.map.group[[4]int]uint8
     - __kind: PointerType
-      ID: 187
+      ID: 207
       Name: '*noalg.map.group[[4]string][2]int'
       ByteSize: 8
-      Pointee: 188 StructureType noalg.map.group[[4]string][2]int
+      Pointee: 208 StructureType noalg.map.group[[4]string][2]int
     - __kind: PointerType
-      ID: 193
+      ID: 224
       Name: '*noalg.map.group[bool]main.node'
       ByteSize: 8
-      Pointee: 194 StructureType noalg.map.group[bool]main.node
+      Pointee: 225 StructureType noalg.map.group[bool]main.node
     - __kind: PointerType
-      ID: 175
+      ID: 179
       Name: '*noalg.map.group[int]int'
       ByteSize: 8
-      Pointee: 176 StructureType noalg.map.group[int]int
+      Pointee: 180 StructureType noalg.map.group[int]int
     - __kind: PointerType
-      ID: 196
+      ID: 231
       Name: '*noalg.map.group[int]uint8'
       ByteSize: 8
-      Pointee: 197 StructureType noalg.map.group[int]uint8
+      Pointee: 232 StructureType noalg.map.group[int]uint8
     - __kind: PointerType
-      ID: 190
+      ID: 215
       Name: '*noalg.map.group[string][]main.structWithMap'
       ByteSize: 8
-      Pointee: 191 StructureType noalg.map.group[string][]main.structWithMap
+      Pointee: 216 StructureType noalg.map.group[string][]main.structWithMap
     - __kind: PointerType
-      ID: 184
+      ID: 200
       Name: '*noalg.map.group[string][]string'
       ByteSize: 8
-      Pointee: 185 StructureType noalg.map.group[string][]string
+      Pointee: 201 StructureType noalg.map.group[string][]string
     - __kind: PointerType
-      ID: 181
+      ID: 193
       Name: '*noalg.map.group[string]int'
       ByteSize: 8
-      Pointee: 182 StructureType noalg.map.group[string]int
+      Pointee: 194 StructureType noalg.map.group[string]int
     - __kind: PointerType
-      ID: 178
+      ID: 186
       Name: '*noalg.map.group[string]main.nestedStruct'
       ByteSize: 8
-      Pointee: 179 StructureType noalg.map.group[string]main.nestedStruct
+      Pointee: 187 StructureType noalg.map.group[string]main.nestedStruct
     - __kind: PointerType
-      ID: 202
+      ID: 245
       Name: '*noalg.map.group[uint8][4]int'
       ByteSize: 8
-      Pointee: 203 StructureType noalg.map.group[uint8][4]int
+      Pointee: 246 StructureType noalg.map.group[uint8][4]int
     - __kind: PointerType
-      ID: 199
+      ID: 238
       Name: '*noalg.map.group[uint8]uint8'
       ByteSize: 8
-      Pointee: 200 StructureType noalg.map.group[uint8]uint8
+      Pointee: 239 StructureType noalg.map.group[uint8]uint8
     - __kind: PointerType
       ID: 22
       Name: '*string'
@@ -3463,10 +3463,10 @@ Types:
       GoKind: 22
       Pointee: 9 GoStringHeaderType string
     - __kind: PointerType
-      ID: 239
+      ID: 175
       Name: '*string.str'
       ByteSize: 8
-      Pointee: 238 GoStringDataType string.str
+      Pointee: 174 GoStringDataType string.str
     - __kind: PointerType
       ID: 127
       Name: '*table<[4]int,[4]int>'
@@ -5338,7 +5338,7 @@ Types:
       HasCount: true
       Element: 3 BaseType uint8
     - __kind: ArrayType
-      ID: 233
+      ID: 249
       Name: '[4]int'
       ByteSize: 32
       GoRuntimeType: 672704
@@ -5347,7 +5347,7 @@ Types:
       HasCount: true
       Element: 7 BaseType int
     - __kind: ArrayType
-      ID: 220
+      ID: 211
       Name: '[4]string'
       ByteSize: 64
       GoRuntimeType: 672992
@@ -5379,9 +5379,9 @@ Types:
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 240 GoSliceDataType []*string.array
+      Data: 176 GoSliceDataType []*string.array
     - __kind: GoSliceDataType
-      ID: 240
+      ID: 176
       Name: '[]*string.array'
       ByteSize: 2048
       Element: 22 PointerType *string
@@ -5391,57 +5391,57 @@ Types:
       ByteSize: 8192
       Element: 127 PointerType *table<[4]int,[4]int>
     - __kind: GoSliceDataType
-      ID: 262
+      ID: 257
       Name: '[]*table<[4]int,uint8>.array'
       ByteSize: 8192
       Element: 122 PointerType *table<[4]int,uint8>
     - __kind: GoSliceDataType
-      ID: 250
+      ID: 212
       Name: '[]*table<[4]string,[2]int>.array'
       ByteSize: 8192
       Element: 90 PointerType *table<[4]string,[2]int>
     - __kind: GoSliceDataType
-      ID: 254
+      ID: 228
       Name: '[]*table<bool,main.node>.array'
       ByteSize: 8192
       Element: 102 PointerType *table<bool,main.node>
     - __kind: GoSliceDataType
-      ID: 242
+      ID: 183
       Name: '[]*table<int,int>.array'
       ByteSize: 8192
       Element: 70 PointerType *table<int,int>
     - __kind: GoSliceDataType
-      ID: 256
+      ID: 235
       Name: '[]*table<int,uint8>.array'
       ByteSize: 8192
       Element: 107 PointerType *table<int,uint8>
     - __kind: GoSliceDataType
-      ID: 252
+      ID: 221
       Name: '[]*table<string,[]main.structWithMap>.array'
       ByteSize: 8192
       Element: 97 PointerType *table<string,[]main.structWithMap>
     - __kind: GoSliceDataType
-      ID: 248
+      ID: 204
       Name: '[]*table<string,[]string>.array'
       ByteSize: 8192
       Element: 85 PointerType *table<string,[]string>
     - __kind: GoSliceDataType
-      ID: 246
+      ID: 197
       Name: '[]*table<string,int>.array'
       ByteSize: 8192
       Element: 80 PointerType *table<string,int>
     - __kind: GoSliceDataType
-      ID: 244
+      ID: 190
       Name: '[]*table<string,main.nestedStruct>.array'
       ByteSize: 8192
       Element: 75 PointerType *table<string,main.nestedStruct>
     - __kind: GoSliceDataType
-      ID: 260
+      ID: 250
       Name: '[]*table<uint8,[4]int>.array'
       ByteSize: 8192
       Element: 117 PointerType *table<uint8,[4]int>
     - __kind: GoSliceDataType
-      ID: 258
+      ID: 242
       Name: '[]*table<uint8,uint8>.array'
       ByteSize: 8192
       Element: 112 PointerType *table<uint8,uint8>
@@ -5489,7 +5489,7 @@ Types:
       ByteSize: 2048
       Element: 4 BaseType bool
     - __kind: GoSliceHeaderType
-      ID: 223
+      ID: 219
       Name: '[]main.structWithMap'
       ByteSize: 24
       GoRuntimeType: 469760
@@ -5497,7 +5497,7 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 224 PointerType *main.structWithMap
+          Type: 220 PointerType *main.structWithMap
         - Name: len
           Offset: 8
           Type: 7 BaseType int
@@ -5535,62 +5535,62 @@ Types:
       ID: 265
       Name: '[]noalg.map.group[[4]int][4]int.array'
       ByteSize: 2048
-      Element: 209 StructureType noalg.map.group[[4]int][4]int
+      Element: 261 StructureType noalg.map.group[[4]int][4]int
     - __kind: GoSliceDataType
-      ID: 263
+      ID: 258
       Name: '[]noalg.map.group[[4]int]uint8.array'
       ByteSize: 2048
-      Element: 206 StructureType noalg.map.group[[4]int]uint8
+      Element: 254 StructureType noalg.map.group[[4]int]uint8
     - __kind: GoSliceDataType
-      ID: 251
+      ID: 213
       Name: '[]noalg.map.group[[4]string][2]int.array'
       ByteSize: 2048
-      Element: 188 StructureType noalg.map.group[[4]string][2]int
+      Element: 208 StructureType noalg.map.group[[4]string][2]int
     - __kind: GoSliceDataType
-      ID: 255
+      ID: 229
       Name: '[]noalg.map.group[bool]main.node.array'
       ByteSize: 2048
-      Element: 194 StructureType noalg.map.group[bool]main.node
+      Element: 225 StructureType noalg.map.group[bool]main.node
     - __kind: GoSliceDataType
-      ID: 243
+      ID: 184
       Name: '[]noalg.map.group[int]int.array'
       ByteSize: 2048
-      Element: 176 StructureType noalg.map.group[int]int
+      Element: 180 StructureType noalg.map.group[int]int
     - __kind: GoSliceDataType
-      ID: 257
+      ID: 236
       Name: '[]noalg.map.group[int]uint8.array'
       ByteSize: 2048
-      Element: 197 StructureType noalg.map.group[int]uint8
+      Element: 232 StructureType noalg.map.group[int]uint8
     - __kind: GoSliceDataType
-      ID: 253
+      ID: 222
       Name: '[]noalg.map.group[string][]main.structWithMap.array'
       ByteSize: 2048
-      Element: 191 StructureType noalg.map.group[string][]main.structWithMap
+      Element: 216 StructureType noalg.map.group[string][]main.structWithMap
     - __kind: GoSliceDataType
-      ID: 249
+      ID: 205
       Name: '[]noalg.map.group[string][]string.array'
       ByteSize: 2048
-      Element: 185 StructureType noalg.map.group[string][]string
+      Element: 201 StructureType noalg.map.group[string][]string
     - __kind: GoSliceDataType
-      ID: 247
+      ID: 198
       Name: '[]noalg.map.group[string]int.array'
       ByteSize: 2048
-      Element: 182 StructureType noalg.map.group[string]int
+      Element: 194 StructureType noalg.map.group[string]int
     - __kind: GoSliceDataType
-      ID: 245
+      ID: 191
       Name: '[]noalg.map.group[string]main.nestedStruct.array'
       ByteSize: 2048
-      Element: 179 StructureType noalg.map.group[string]main.nestedStruct
+      Element: 187 StructureType noalg.map.group[string]main.nestedStruct
     - __kind: GoSliceDataType
-      ID: 261
+      ID: 251
       Name: '[]noalg.map.group[uint8][4]int.array'
       ByteSize: 2048
-      Element: 203 StructureType noalg.map.group[uint8][4]int
+      Element: 246 StructureType noalg.map.group[uint8][4]int
     - __kind: GoSliceDataType
-      ID: 259
+      ID: 243
       Name: '[]noalg.map.group[uint8]uint8.array'
       ByteSize: 2048
-      Element: 200 StructureType noalg.map.group[uint8]uint8
+      Element: 239 StructureType noalg.map.group[uint8]uint8
     - __kind: GoSliceHeaderType
       ID: 141
       Name: '[]string'
@@ -5717,173 +5717,173 @@ Types:
       GoRuntimeType: 468800
       GoKind: 19
     - __kind: GoSwissMapGroupsType
-      ID: 207
+      ID: 259
       Name: groupReference<[4]int,[4]int>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 208 PointerType *noalg.map.group[[4]int][4]int
+          Type: 260 PointerType *noalg.map.group[[4]int][4]int
         - Name: lengthMask
           Offset: 8
           Type: 8 BaseType uint64
-      GroupType: 209 StructureType noalg.map.group[[4]int][4]int
+      GroupType: 261 StructureType noalg.map.group[[4]int][4]int
       GroupSliceType: 265 GoSliceDataType []noalg.map.group[[4]int][4]int.array
     - __kind: GoSwissMapGroupsType
-      ID: 204
+      ID: 252
       Name: groupReference<[4]int,uint8>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 205 PointerType *noalg.map.group[[4]int]uint8
+          Type: 253 PointerType *noalg.map.group[[4]int]uint8
         - Name: lengthMask
           Offset: 8
           Type: 8 BaseType uint64
-      GroupType: 206 StructureType noalg.map.group[[4]int]uint8
-      GroupSliceType: 263 GoSliceDataType []noalg.map.group[[4]int]uint8.array
+      GroupType: 254 StructureType noalg.map.group[[4]int]uint8
+      GroupSliceType: 258 GoSliceDataType []noalg.map.group[[4]int]uint8.array
     - __kind: GoSwissMapGroupsType
-      ID: 186
+      ID: 206
       Name: groupReference<[4]string,[2]int>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 187 PointerType *noalg.map.group[[4]string][2]int
+          Type: 207 PointerType *noalg.map.group[[4]string][2]int
         - Name: lengthMask
           Offset: 8
           Type: 8 BaseType uint64
-      GroupType: 188 StructureType noalg.map.group[[4]string][2]int
-      GroupSliceType: 251 GoSliceDataType []noalg.map.group[[4]string][2]int.array
+      GroupType: 208 StructureType noalg.map.group[[4]string][2]int
+      GroupSliceType: 213 GoSliceDataType []noalg.map.group[[4]string][2]int.array
     - __kind: GoSwissMapGroupsType
-      ID: 192
+      ID: 223
       Name: groupReference<bool,main.node>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 193 PointerType *noalg.map.group[bool]main.node
+          Type: 224 PointerType *noalg.map.group[bool]main.node
         - Name: lengthMask
           Offset: 8
           Type: 8 BaseType uint64
-      GroupType: 194 StructureType noalg.map.group[bool]main.node
-      GroupSliceType: 255 GoSliceDataType []noalg.map.group[bool]main.node.array
+      GroupType: 225 StructureType noalg.map.group[bool]main.node
+      GroupSliceType: 229 GoSliceDataType []noalg.map.group[bool]main.node.array
     - __kind: GoSwissMapGroupsType
-      ID: 174
+      ID: 178
       Name: groupReference<int,int>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 175 PointerType *noalg.map.group[int]int
+          Type: 179 PointerType *noalg.map.group[int]int
         - Name: lengthMask
           Offset: 8
           Type: 8 BaseType uint64
-      GroupType: 176 StructureType noalg.map.group[int]int
-      GroupSliceType: 243 GoSliceDataType []noalg.map.group[int]int.array
+      GroupType: 180 StructureType noalg.map.group[int]int
+      GroupSliceType: 184 GoSliceDataType []noalg.map.group[int]int.array
     - __kind: GoSwissMapGroupsType
-      ID: 195
+      ID: 230
       Name: groupReference<int,uint8>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 196 PointerType *noalg.map.group[int]uint8
+          Type: 231 PointerType *noalg.map.group[int]uint8
         - Name: lengthMask
           Offset: 8
           Type: 8 BaseType uint64
-      GroupType: 197 StructureType noalg.map.group[int]uint8
-      GroupSliceType: 257 GoSliceDataType []noalg.map.group[int]uint8.array
+      GroupType: 232 StructureType noalg.map.group[int]uint8
+      GroupSliceType: 236 GoSliceDataType []noalg.map.group[int]uint8.array
     - __kind: GoSwissMapGroupsType
-      ID: 189
+      ID: 214
       Name: groupReference<string,[]main.structWithMap>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 190 PointerType *noalg.map.group[string][]main.structWithMap
+          Type: 215 PointerType *noalg.map.group[string][]main.structWithMap
         - Name: lengthMask
           Offset: 8
           Type: 8 BaseType uint64
-      GroupType: 191 StructureType noalg.map.group[string][]main.structWithMap
-      GroupSliceType: 253 GoSliceDataType []noalg.map.group[string][]main.structWithMap.array
+      GroupType: 216 StructureType noalg.map.group[string][]main.structWithMap
+      GroupSliceType: 222 GoSliceDataType []noalg.map.group[string][]main.structWithMap.array
     - __kind: GoSwissMapGroupsType
-      ID: 183
+      ID: 199
       Name: groupReference<string,[]string>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 184 PointerType *noalg.map.group[string][]string
+          Type: 200 PointerType *noalg.map.group[string][]string
         - Name: lengthMask
           Offset: 8
           Type: 8 BaseType uint64
-      GroupType: 185 StructureType noalg.map.group[string][]string
-      GroupSliceType: 249 GoSliceDataType []noalg.map.group[string][]string.array
+      GroupType: 201 StructureType noalg.map.group[string][]string
+      GroupSliceType: 205 GoSliceDataType []noalg.map.group[string][]string.array
     - __kind: GoSwissMapGroupsType
-      ID: 180
+      ID: 192
       Name: groupReference<string,int>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 181 PointerType *noalg.map.group[string]int
+          Type: 193 PointerType *noalg.map.group[string]int
         - Name: lengthMask
           Offset: 8
           Type: 8 BaseType uint64
-      GroupType: 182 StructureType noalg.map.group[string]int
-      GroupSliceType: 247 GoSliceDataType []noalg.map.group[string]int.array
+      GroupType: 194 StructureType noalg.map.group[string]int
+      GroupSliceType: 198 GoSliceDataType []noalg.map.group[string]int.array
     - __kind: GoSwissMapGroupsType
-      ID: 177
+      ID: 185
       Name: groupReference<string,main.nestedStruct>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 178 PointerType *noalg.map.group[string]main.nestedStruct
+          Type: 186 PointerType *noalg.map.group[string]main.nestedStruct
         - Name: lengthMask
           Offset: 8
           Type: 8 BaseType uint64
-      GroupType: 179 StructureType noalg.map.group[string]main.nestedStruct
-      GroupSliceType: 245 GoSliceDataType []noalg.map.group[string]main.nestedStruct.array
+      GroupType: 187 StructureType noalg.map.group[string]main.nestedStruct
+      GroupSliceType: 191 GoSliceDataType []noalg.map.group[string]main.nestedStruct.array
     - __kind: GoSwissMapGroupsType
-      ID: 201
+      ID: 244
       Name: groupReference<uint8,[4]int>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 202 PointerType *noalg.map.group[uint8][4]int
+          Type: 245 PointerType *noalg.map.group[uint8][4]int
         - Name: lengthMask
           Offset: 8
           Type: 8 BaseType uint64
-      GroupType: 203 StructureType noalg.map.group[uint8][4]int
-      GroupSliceType: 261 GoSliceDataType []noalg.map.group[uint8][4]int.array
+      GroupType: 246 StructureType noalg.map.group[uint8][4]int
+      GroupSliceType: 251 GoSliceDataType []noalg.map.group[uint8][4]int.array
     - __kind: GoSwissMapGroupsType
-      ID: 198
+      ID: 237
       Name: groupReference<uint8,uint8>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 199 PointerType *noalg.map.group[uint8]uint8
+          Type: 238 PointerType *noalg.map.group[uint8]uint8
         - Name: lengthMask
           Offset: 8
           Type: 8 BaseType uint64
-      GroupType: 200 StructureType noalg.map.group[uint8]uint8
-      GroupSliceType: 259 GoSliceDataType []noalg.map.group[uint8]uint8.array
+      GroupType: 239 StructureType noalg.map.group[uint8]uint8
+      GroupSliceType: 243 GoSliceDataType []noalg.map.group[uint8]uint8.array
     - __kind: BaseType
       ID: 7
       Name: int
@@ -6208,7 +6208,7 @@ Types:
           Offset: 40
           Type: 8 BaseType uint64
       TablePtrSliceType: 264 GoSliceDataType []*table<[4]int,[4]int>.array
-      GroupType: 209 StructureType noalg.map.group[[4]int][4]int
+      GroupType: 261 StructureType noalg.map.group[[4]int][4]int
     - __kind: GoSwissMapHeaderType
       ID: 120
       Name: map<[4]int,uint8>
@@ -6239,8 +6239,8 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 8 BaseType uint64
-      TablePtrSliceType: 262 GoSliceDataType []*table<[4]int,uint8>.array
-      GroupType: 206 StructureType noalg.map.group[[4]int]uint8
+      TablePtrSliceType: 257 GoSliceDataType []*table<[4]int,uint8>.array
+      GroupType: 254 StructureType noalg.map.group[[4]int]uint8
     - __kind: GoSwissMapHeaderType
       ID: 88
       Name: map<[4]string,[2]int>
@@ -6271,8 +6271,8 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 8 BaseType uint64
-      TablePtrSliceType: 250 GoSliceDataType []*table<[4]string,[2]int>.array
-      GroupType: 188 StructureType noalg.map.group[[4]string][2]int
+      TablePtrSliceType: 212 GoSliceDataType []*table<[4]string,[2]int>.array
+      GroupType: 208 StructureType noalg.map.group[[4]string][2]int
     - __kind: GoSwissMapHeaderType
       ID: 100
       Name: map<bool,main.node>
@@ -6303,8 +6303,8 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 8 BaseType uint64
-      TablePtrSliceType: 254 GoSliceDataType []*table<bool,main.node>.array
-      GroupType: 194 StructureType noalg.map.group[bool]main.node
+      TablePtrSliceType: 228 GoSliceDataType []*table<bool,main.node>.array
+      GroupType: 225 StructureType noalg.map.group[bool]main.node
     - __kind: GoSwissMapHeaderType
       ID: 68
       Name: map<int,int>
@@ -6335,8 +6335,8 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 8 BaseType uint64
-      TablePtrSliceType: 242 GoSliceDataType []*table<int,int>.array
-      GroupType: 176 StructureType noalg.map.group[int]int
+      TablePtrSliceType: 183 GoSliceDataType []*table<int,int>.array
+      GroupType: 180 StructureType noalg.map.group[int]int
     - __kind: GoSwissMapHeaderType
       ID: 105
       Name: map<int,uint8>
@@ -6367,8 +6367,8 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 8 BaseType uint64
-      TablePtrSliceType: 256 GoSliceDataType []*table<int,uint8>.array
-      GroupType: 197 StructureType noalg.map.group[int]uint8
+      TablePtrSliceType: 235 GoSliceDataType []*table<int,uint8>.array
+      GroupType: 232 StructureType noalg.map.group[int]uint8
     - __kind: GoSwissMapHeaderType
       ID: 95
       Name: map<string,[]main.structWithMap>
@@ -6399,8 +6399,8 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 8 BaseType uint64
-      TablePtrSliceType: 252 GoSliceDataType []*table<string,[]main.structWithMap>.array
-      GroupType: 191 StructureType noalg.map.group[string][]main.structWithMap
+      TablePtrSliceType: 221 GoSliceDataType []*table<string,[]main.structWithMap>.array
+      GroupType: 216 StructureType noalg.map.group[string][]main.structWithMap
     - __kind: GoSwissMapHeaderType
       ID: 83
       Name: map<string,[]string>
@@ -6431,8 +6431,8 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 8 BaseType uint64
-      TablePtrSliceType: 248 GoSliceDataType []*table<string,[]string>.array
-      GroupType: 185 StructureType noalg.map.group[string][]string
+      TablePtrSliceType: 204 GoSliceDataType []*table<string,[]string>.array
+      GroupType: 201 StructureType noalg.map.group[string][]string
     - __kind: GoSwissMapHeaderType
       ID: 78
       Name: map<string,int>
@@ -6463,8 +6463,8 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 8 BaseType uint64
-      TablePtrSliceType: 246 GoSliceDataType []*table<string,int>.array
-      GroupType: 182 StructureType noalg.map.group[string]int
+      TablePtrSliceType: 197 GoSliceDataType []*table<string,int>.array
+      GroupType: 194 StructureType noalg.map.group[string]int
     - __kind: GoSwissMapHeaderType
       ID: 73
       Name: map<string,main.nestedStruct>
@@ -6495,8 +6495,8 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 8 BaseType uint64
-      TablePtrSliceType: 244 GoSliceDataType []*table<string,main.nestedStruct>.array
-      GroupType: 179 StructureType noalg.map.group[string]main.nestedStruct
+      TablePtrSliceType: 190 GoSliceDataType []*table<string,main.nestedStruct>.array
+      GroupType: 187 StructureType noalg.map.group[string]main.nestedStruct
     - __kind: GoSwissMapHeaderType
       ID: 115
       Name: map<uint8,[4]int>
@@ -6527,8 +6527,8 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 8 BaseType uint64
-      TablePtrSliceType: 260 GoSliceDataType []*table<uint8,[4]int>.array
-      GroupType: 203 StructureType noalg.map.group[uint8][4]int
+      TablePtrSliceType: 250 GoSliceDataType []*table<uint8,[4]int>.array
+      GroupType: 246 StructureType noalg.map.group[uint8][4]int
     - __kind: GoSwissMapHeaderType
       ID: 110
       Name: map<uint8,uint8>
@@ -6559,8 +6559,8 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 8 BaseType uint64
-      TablePtrSliceType: 258 GoSliceDataType []*table<uint8,uint8>.array
-      GroupType: 200 StructureType noalg.map.group[uint8]uint8
+      TablePtrSliceType: 242 GoSliceDataType []*table<uint8,uint8>.array
+      GroupType: 239 StructureType noalg.map.group[uint8]uint8
     - __kind: GoMapType
       ID: 123
       Name: map[[4]int][4]int
@@ -6646,115 +6646,115 @@ Types:
       GoKind: 21
       HeaderType: 110 GoSwissMapHeaderType map<uint8,uint8>
     - __kind: ArrayType
-      ID: 236
+      ID: 262
       Name: noalg.[8]struct { key [4]int; elem [4]int }
       ByteSize: 512
       GoRuntimeType: 672800
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 237 StructureType noalg.struct { key [4]int; elem [4]int }
+      Element: 263 StructureType noalg.struct { key [4]int; elem [4]int }
     - __kind: ArrayType
-      ID: 234
+      ID: 255
       Name: noalg.[8]struct { key [4]int; elem uint8 }
       ByteSize: 320
       GoRuntimeType: 672896
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 235 StructureType noalg.struct { key [4]int; elem uint8 }
+      Element: 256 StructureType noalg.struct { key [4]int; elem uint8 }
     - __kind: ArrayType
-      ID: 218
+      ID: 209
       Name: noalg.[8]struct { key [4]string; elem [2]int }
       ByteSize: 640
       GoRuntimeType: 673184
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 219 StructureType noalg.struct { key [4]string; elem [2]int }
+      Element: 210 StructureType noalg.struct { key [4]string; elem [2]int }
     - __kind: ArrayType
-      ID: 225
+      ID: 226
       Name: noalg.[8]struct { key bool; elem main.node }
       ByteSize: 192
       GoRuntimeType: 673280
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 226 StructureType noalg.struct { key bool; elem main.node }
+      Element: 227 StructureType noalg.struct { key bool; elem main.node }
     - __kind: ArrayType
-      ID: 210
+      ID: 181
       Name: noalg.[8]struct { key int; elem int }
       ByteSize: 128
       GoRuntimeType: 671072
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 211 StructureType noalg.struct { key int; elem int }
+      Element: 182 StructureType noalg.struct { key int; elem int }
     - __kind: ArrayType
-      ID: 227
+      ID: 233
       Name: noalg.[8]struct { key int; elem uint8 }
       ByteSize: 128
       GoRuntimeType: 673376
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 228 StructureType noalg.struct { key int; elem uint8 }
+      Element: 234 StructureType noalg.struct { key int; elem uint8 }
     - __kind: ArrayType
-      ID: 221
+      ID: 217
       Name: noalg.[8]struct { key string; elem []main.structWithMap }
       ByteSize: 320
       GoRuntimeType: 673472
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 222 StructureType noalg.struct { key string; elem []main.structWithMap }
+      Element: 218 StructureType noalg.struct { key string; elem []main.structWithMap }
     - __kind: ArrayType
-      ID: 216
+      ID: 202
       Name: noalg.[8]struct { key string; elem []string }
       ByteSize: 320
       GoRuntimeType: 673568
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 217 StructureType noalg.struct { key string; elem []string }
+      Element: 203 StructureType noalg.struct { key string; elem []string }
     - __kind: ArrayType
-      ID: 214
+      ID: 195
       Name: noalg.[8]struct { key string; elem int }
       ByteSize: 192
       GoRuntimeType: 673664
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 215 StructureType noalg.struct { key string; elem int }
+      Element: 196 StructureType noalg.struct { key string; elem int }
     - __kind: ArrayType
-      ID: 212
+      ID: 188
       Name: noalg.[8]struct { key string; elem main.nestedStruct }
       ByteSize: 320
       GoRuntimeType: 673760
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 213 StructureType noalg.struct { key string; elem main.nestedStruct }
+      Element: 189 StructureType noalg.struct { key string; elem main.nestedStruct }
     - __kind: ArrayType
-      ID: 231
+      ID: 247
       Name: noalg.[8]struct { key uint8; elem [4]int }
       ByteSize: 320
       GoRuntimeType: 673856
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 232 StructureType noalg.struct { key uint8; elem [4]int }
+      Element: 248 StructureType noalg.struct { key uint8; elem [4]int }
     - __kind: ArrayType
-      ID: 229
+      ID: 240
       Name: noalg.[8]struct { key uint8; elem uint8 }
       ByteSize: 16
       GoRuntimeType: 673952
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 230 StructureType noalg.struct { key uint8; elem uint8 }
+      Element: 241 StructureType noalg.struct { key uint8; elem uint8 }
     - __kind: StructureType
-      ID: 209
+      ID: 261
       Name: noalg.map.group[[4]int][4]int
       ByteSize: 520
       GoRuntimeType: 1.276576e+06
@@ -6765,9 +6765,9 @@ Types:
           Type: 8 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 236 ArrayType noalg.[8]struct { key [4]int; elem [4]int }
+          Type: 262 ArrayType noalg.[8]struct { key [4]int; elem [4]int }
     - __kind: StructureType
-      ID: 206
+      ID: 254
       Name: noalg.map.group[[4]int]uint8
       ByteSize: 328
       GoRuntimeType: 1.276832e+06
@@ -6778,9 +6778,9 @@ Types:
           Type: 8 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 234 ArrayType noalg.[8]struct { key [4]int; elem uint8 }
+          Type: 255 ArrayType noalg.[8]struct { key [4]int; elem uint8 }
     - __kind: StructureType
-      ID: 188
+      ID: 208
       Name: noalg.map.group[[4]string][2]int
       ByteSize: 648
       GoRuntimeType: 1.277088e+06
@@ -6791,9 +6791,9 @@ Types:
           Type: 8 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 218 ArrayType noalg.[8]struct { key [4]string; elem [2]int }
+          Type: 209 ArrayType noalg.[8]struct { key [4]string; elem [2]int }
     - __kind: StructureType
-      ID: 194
+      ID: 225
       Name: noalg.map.group[bool]main.node
       ByteSize: 200
       GoRuntimeType: 1.277344e+06
@@ -6804,9 +6804,9 @@ Types:
           Type: 8 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 225 ArrayType noalg.[8]struct { key bool; elem main.node }
+          Type: 226 ArrayType noalg.[8]struct { key bool; elem main.node }
     - __kind: StructureType
-      ID: 176
+      ID: 180
       Name: noalg.map.group[int]int
       ByteSize: 136
       GoRuntimeType: 1.275808e+06
@@ -6817,9 +6817,9 @@ Types:
           Type: 8 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 210 ArrayType noalg.[8]struct { key int; elem int }
+          Type: 181 ArrayType noalg.[8]struct { key int; elem int }
     - __kind: StructureType
-      ID: 197
+      ID: 232
       Name: noalg.map.group[int]uint8
       ByteSize: 136
       GoRuntimeType: 1.2776e+06
@@ -6830,9 +6830,9 @@ Types:
           Type: 8 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 227 ArrayType noalg.[8]struct { key int; elem uint8 }
+          Type: 233 ArrayType noalg.[8]struct { key int; elem uint8 }
     - __kind: StructureType
-      ID: 191
+      ID: 216
       Name: noalg.map.group[string][]main.structWithMap
       ByteSize: 328
       GoRuntimeType: 1.277856e+06
@@ -6843,9 +6843,9 @@ Types:
           Type: 8 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 221 ArrayType noalg.[8]struct { key string; elem []main.structWithMap }
+          Type: 217 ArrayType noalg.[8]struct { key string; elem []main.structWithMap }
     - __kind: StructureType
-      ID: 185
+      ID: 201
       Name: noalg.map.group[string][]string
       ByteSize: 328
       GoRuntimeType: 1.278112e+06
@@ -6856,9 +6856,9 @@ Types:
           Type: 8 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 216 ArrayType noalg.[8]struct { key string; elem []string }
+          Type: 202 ArrayType noalg.[8]struct { key string; elem []string }
     - __kind: StructureType
-      ID: 182
+      ID: 194
       Name: noalg.map.group[string]int
       ByteSize: 200
       GoRuntimeType: 1.278368e+06
@@ -6869,9 +6869,9 @@ Types:
           Type: 8 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 214 ArrayType noalg.[8]struct { key string; elem int }
+          Type: 195 ArrayType noalg.[8]struct { key string; elem int }
     - __kind: StructureType
-      ID: 179
+      ID: 187
       Name: noalg.map.group[string]main.nestedStruct
       ByteSize: 328
       GoRuntimeType: 1.278624e+06
@@ -6882,9 +6882,9 @@ Types:
           Type: 8 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 212 ArrayType noalg.[8]struct { key string; elem main.nestedStruct }
+          Type: 188 ArrayType noalg.[8]struct { key string; elem main.nestedStruct }
     - __kind: StructureType
-      ID: 203
+      ID: 246
       Name: noalg.map.group[uint8][4]int
       ByteSize: 328
       GoRuntimeType: 1.27888e+06
@@ -6895,9 +6895,9 @@ Types:
           Type: 8 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 231 ArrayType noalg.[8]struct { key uint8; elem [4]int }
+          Type: 247 ArrayType noalg.[8]struct { key uint8; elem [4]int }
     - __kind: StructureType
-      ID: 200
+      ID: 239
       Name: noalg.map.group[uint8]uint8
       ByteSize: 24
       GoRuntimeType: 1.279136e+06
@@ -6908,9 +6908,9 @@ Types:
           Type: 8 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 229 ArrayType noalg.[8]struct { key uint8; elem uint8 }
+          Type: 240 ArrayType noalg.[8]struct { key uint8; elem uint8 }
     - __kind: StructureType
-      ID: 237
+      ID: 263
       Name: noalg.struct { key [4]int; elem [4]int }
       ByteSize: 64
       GoRuntimeType: 1.276448e+06
@@ -6918,12 +6918,12 @@ Types:
       RawFields:
         - Name: key
           Offset: 0
-          Type: 233 ArrayType [4]int
+          Type: 249 ArrayType [4]int
         - Name: elem
           Offset: 32
-          Type: 233 ArrayType [4]int
+          Type: 249 ArrayType [4]int
     - __kind: StructureType
-      ID: 235
+      ID: 256
       Name: noalg.struct { key [4]int; elem uint8 }
       ByteSize: 40
       GoRuntimeType: 1.276704e+06
@@ -6931,12 +6931,12 @@ Types:
       RawFields:
         - Name: key
           Offset: 0
-          Type: 233 ArrayType [4]int
+          Type: 249 ArrayType [4]int
         - Name: elem
           Offset: 32
           Type: 3 BaseType uint8
     - __kind: StructureType
-      ID: 219
+      ID: 210
       Name: noalg.struct { key [4]string; elem [2]int }
       ByteSize: 80
       GoRuntimeType: 1.27696e+06
@@ -6944,12 +6944,12 @@ Types:
       RawFields:
         - Name: key
           Offset: 0
-          Type: 220 ArrayType [4]string
+          Type: 211 ArrayType [4]string
         - Name: elem
           Offset: 64
           Type: 40 ArrayType [2]int
     - __kind: StructureType
-      ID: 226
+      ID: 227
       Name: noalg.struct { key bool; elem main.node }
       ByteSize: 24
       GoRuntimeType: 1.277216e+06
@@ -6962,7 +6962,7 @@ Types:
           Offset: 8
           Type: 131 StructureType main.node
     - __kind: StructureType
-      ID: 211
+      ID: 182
       Name: noalg.struct { key int; elem int }
       ByteSize: 16
       GoRuntimeType: 1.27568e+06
@@ -6975,7 +6975,7 @@ Types:
           Offset: 8
           Type: 7 BaseType int
     - __kind: StructureType
-      ID: 228
+      ID: 234
       Name: noalg.struct { key int; elem uint8 }
       ByteSize: 16
       GoRuntimeType: 1.277472e+06
@@ -6988,7 +6988,7 @@ Types:
           Offset: 8
           Type: 3 BaseType uint8
     - __kind: StructureType
-      ID: 222
+      ID: 218
       Name: noalg.struct { key string; elem []main.structWithMap }
       ByteSize: 40
       GoRuntimeType: 1.277728e+06
@@ -6999,9 +6999,9 @@ Types:
           Type: 9 GoStringHeaderType string
         - Name: elem
           Offset: 16
-          Type: 223 GoSliceHeaderType []main.structWithMap
+          Type: 219 GoSliceHeaderType []main.structWithMap
     - __kind: StructureType
-      ID: 217
+      ID: 203
       Name: noalg.struct { key string; elem []string }
       ByteSize: 40
       GoRuntimeType: 1.277984e+06
@@ -7014,7 +7014,7 @@ Types:
           Offset: 16
           Type: 141 GoSliceHeaderType []string
     - __kind: StructureType
-      ID: 215
+      ID: 196
       Name: noalg.struct { key string; elem int }
       ByteSize: 24
       GoRuntimeType: 1.27824e+06
@@ -7027,7 +7027,7 @@ Types:
           Offset: 16
           Type: 7 BaseType int
     - __kind: StructureType
-      ID: 213
+      ID: 189
       Name: noalg.struct { key string; elem main.nestedStruct }
       ByteSize: 40
       GoRuntimeType: 1.278496e+06
@@ -7040,7 +7040,7 @@ Types:
           Offset: 16
           Type: 149 StructureType main.nestedStruct
     - __kind: StructureType
-      ID: 232
+      ID: 248
       Name: noalg.struct { key uint8; elem [4]int }
       ByteSize: 40
       GoRuntimeType: 1.278752e+06
@@ -7051,9 +7051,9 @@ Types:
           Type: 3 BaseType uint8
         - Name: elem
           Offset: 8
-          Type: 233 ArrayType [4]int
+          Type: 249 ArrayType [4]int
     - __kind: StructureType
-      ID: 230
+      ID: 241
       Name: noalg.struct { key uint8; elem uint8 }
       ByteSize: 2
       GoRuntimeType: 1.279008e+06
@@ -7074,13 +7074,13 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 239 PointerType *string.str
+          Type: 175 PointerType *string.str
         - Name: len
           Offset: 8
           Type: 7 BaseType int
-      Data: 238 GoStringDataType string.str
+      Data: 174 GoStringDataType string.str
     - __kind: GoStringDataType
-      ID: 238
+      ID: 174
       Name: string.str
       ByteSize: 2048
     - __kind: StructureType
@@ -7211,7 +7211,7 @@ Types:
           Type: 7 BaseType int
         - Name: groups
           Offset: 16
-          Type: 207 GoSwissMapGroupsType groupReference<[4]int,[4]int>
+          Type: 259 GoSwissMapGroupsType groupReference<[4]int,[4]int>
     - __kind: StructureType
       ID: 171
       Name: table<[4]int,uint8>
@@ -7235,7 +7235,7 @@ Types:
           Type: 7 BaseType int
         - Name: groups
           Offset: 16
-          Type: 204 GoSwissMapGroupsType groupReference<[4]int,uint8>
+          Type: 252 GoSwissMapGroupsType groupReference<[4]int,uint8>
     - __kind: StructureType
       ID: 165
       Name: table<[4]string,[2]int>
@@ -7259,7 +7259,7 @@ Types:
           Type: 7 BaseType int
         - Name: groups
           Offset: 16
-          Type: 186 GoSwissMapGroupsType groupReference<[4]string,[2]int>
+          Type: 206 GoSwissMapGroupsType groupReference<[4]string,[2]int>
     - __kind: StructureType
       ID: 167
       Name: table<bool,main.node>
@@ -7283,7 +7283,7 @@ Types:
           Type: 7 BaseType int
         - Name: groups
           Offset: 16
-          Type: 192 GoSwissMapGroupsType groupReference<bool,main.node>
+          Type: 223 GoSwissMapGroupsType groupReference<bool,main.node>
     - __kind: StructureType
       ID: 161
       Name: table<int,int>
@@ -7307,7 +7307,7 @@ Types:
           Type: 7 BaseType int
         - Name: groups
           Offset: 16
-          Type: 174 GoSwissMapGroupsType groupReference<int,int>
+          Type: 178 GoSwissMapGroupsType groupReference<int,int>
     - __kind: StructureType
       ID: 168
       Name: table<int,uint8>
@@ -7331,7 +7331,7 @@ Types:
           Type: 7 BaseType int
         - Name: groups
           Offset: 16
-          Type: 195 GoSwissMapGroupsType groupReference<int,uint8>
+          Type: 230 GoSwissMapGroupsType groupReference<int,uint8>
     - __kind: StructureType
       ID: 166
       Name: table<string,[]main.structWithMap>
@@ -7355,7 +7355,7 @@ Types:
           Type: 7 BaseType int
         - Name: groups
           Offset: 16
-          Type: 189 GoSwissMapGroupsType groupReference<string,[]main.structWithMap>
+          Type: 214 GoSwissMapGroupsType groupReference<string,[]main.structWithMap>
     - __kind: StructureType
       ID: 164
       Name: table<string,[]string>
@@ -7379,7 +7379,7 @@ Types:
           Type: 7 BaseType int
         - Name: groups
           Offset: 16
-          Type: 183 GoSwissMapGroupsType groupReference<string,[]string>
+          Type: 199 GoSwissMapGroupsType groupReference<string,[]string>
     - __kind: StructureType
       ID: 163
       Name: table<string,int>
@@ -7403,7 +7403,7 @@ Types:
           Type: 7 BaseType int
         - Name: groups
           Offset: 16
-          Type: 180 GoSwissMapGroupsType groupReference<string,int>
+          Type: 192 GoSwissMapGroupsType groupReference<string,int>
     - __kind: StructureType
       ID: 162
       Name: table<string,main.nestedStruct>
@@ -7427,7 +7427,7 @@ Types:
           Type: 7 BaseType int
         - Name: groups
           Offset: 16
-          Type: 177 GoSwissMapGroupsType groupReference<string,main.nestedStruct>
+          Type: 185 GoSwissMapGroupsType groupReference<string,main.nestedStruct>
     - __kind: StructureType
       ID: 170
       Name: table<uint8,[4]int>
@@ -7451,7 +7451,7 @@ Types:
           Type: 7 BaseType int
         - Name: groups
           Offset: 16
-          Type: 201 GoSwissMapGroupsType groupReference<uint8,[4]int>
+          Type: 244 GoSwissMapGroupsType groupReference<uint8,[4]int>
     - __kind: StructureType
       ID: 169
       Name: table<uint8,uint8>
@@ -7475,7 +7475,7 @@ Types:
           Type: 7 BaseType int
         - Name: groups
           Offset: 16
-          Type: 198 GoSwissMapGroupsType groupReference<uint8,uint8>
+          Type: 237 GoSwissMapGroupsType groupReference<uint8,uint8>
     - __kind: BaseType
       ID: 10
       Name: uint

--- a/pkg/dyninst/irgen/testdata/snapshot/sample.arch=arm64,toolchain=go1.24.3.yaml
+++ b/pkg/dyninst/irgen/testdata/snapshot/sample.arch=arm64,toolchain=go1.24.3.yaml
@@ -3095,7 +3095,7 @@ Subprograms:
           IsReturn: false
 Types:
     - __kind: PointerType
-      ID: 173
+      ID: 277
       Name: '**main.t'
       ByteSize: 8
       Pointee: 133 PointerType *main.t
@@ -3167,50 +3167,50 @@ Types:
       ByteSize: 8
       Pointee: 112 PointerType *table<uint8,uint8>
     - __kind: PointerType
-      ID: 177
+      ID: 154
       Name: '*[]*string.array'
       ByteSize: 8
-      Pointee: 176 GoSliceDataType []*string.array
+      Pointee: 153 GoSliceDataType []*string.array
     - __kind: PointerType
-      ID: 271
+      ID: 258
       Name: '*[][]uint.array'
       ByteSize: 8
-      Pointee: 270 GoSliceDataType [][]uint.array
+      Pointee: 257 GoSliceDataType [][]uint.array
     - __kind: PointerType
-      ID: 277
+      ID: 264
       Name: '*[]bool.array'
       ByteSize: 8
-      Pointee: 276 GoSliceDataType []bool.array
+      Pointee: 263 GoSliceDataType []bool.array
     - __kind: PointerType
       ID: 281
       Name: '*[]main.structWithMap.array'
       ByteSize: 8
       Pointee: 280 GoSliceDataType []main.structWithMap.array
     - __kind: PointerType
-      ID: 273
+      ID: 260
       Name: '*[]main.structWithNoStrings.array'
       ByteSize: 8
-      Pointee: 272 GoSliceDataType []main.structWithNoStrings.array
+      Pointee: 259 GoSliceDataType []main.structWithNoStrings.array
     - __kind: PointerType
-      ID: 275
+      ID: 262
       Name: '*[]string.array'
       ByteSize: 8
-      Pointee: 274 GoSliceDataType []string.array
+      Pointee: 261 GoSliceDataType []string.array
     - __kind: PointerType
       ID: 137
       Name: '*[]uint'
       ByteSize: 8
       Pointee: 135 GoSliceHeaderType []uint
     - __kind: PointerType
-      ID: 269
+      ID: 256
       Name: '*[]uint.array'
       ByteSize: 8
-      Pointee: 268 GoSliceDataType []uint.array
+      Pointee: 255 GoSliceDataType []uint.array
     - __kind: PointerType
-      ID: 279
+      ID: 266
       Name: '*[]uint16.array'
       ByteSize: 8
-      Pointee: 278 GoSliceDataType []uint16.array
+      Pointee: 265 GoSliceDataType []uint16.array
     - __kind: PointerType
       ID: 11
       Name: '*bool'
@@ -3295,7 +3295,7 @@ Types:
       GoKind: 22
       Pointee: 147 StructureType main.oneStringStruct
     - __kind: PointerType
-      ID: 220
+      ID: 203
       Name: '*main.structWithMap'
       ByteSize: 8
       GoRuntimeType: 380096
@@ -3319,10 +3319,10 @@ Types:
       GoKind: 22
       Pointee: 134 GoSliceHeaderType main.t
     - __kind: PointerType
-      ID: 267
+      ID: 279
       Name: '*main.t.array'
       ByteSize: 8
-      Pointee: 266 GoSliceDataType main.t.array
+      Pointee: 278 GoSliceDataType main.t.array
     - __kind: PointerType
       ID: 145
       Name: '*main.threeStringStruct'
@@ -3396,65 +3396,65 @@ Types:
       GoKind: 22
       Pointee: 76 GoMapType map[string]int
     - __kind: PointerType
-      ID: 260
+      ID: 249
       Name: '*noalg.map.group[[4]int][4]int'
       ByteSize: 8
-      Pointee: 261 StructureType noalg.map.group[[4]int][4]int
+      Pointee: 250 StructureType noalg.map.group[[4]int][4]int
     - __kind: PointerType
-      ID: 253
+      ID: 241
       Name: '*noalg.map.group[[4]int]uint8'
       ByteSize: 8
-      Pointee: 254 StructureType noalg.map.group[[4]int]uint8
+      Pointee: 242 StructureType noalg.map.group[[4]int]uint8
     - __kind: PointerType
-      ID: 207
+      ID: 189
       Name: '*noalg.map.group[[4]string][2]int'
       ByteSize: 8
-      Pointee: 208 StructureType noalg.map.group[[4]string][2]int
+      Pointee: 190 StructureType noalg.map.group[[4]string][2]int
     - __kind: PointerType
-      ID: 224
+      ID: 208
       Name: '*noalg.map.group[bool]main.node'
       ByteSize: 8
-      Pointee: 225 StructureType noalg.map.group[bool]main.node
+      Pointee: 209 StructureType noalg.map.group[bool]main.node
     - __kind: PointerType
-      ID: 179
+      ID: 157
       Name: '*noalg.map.group[int]int'
       ByteSize: 8
-      Pointee: 180 StructureType noalg.map.group[int]int
+      Pointee: 158 StructureType noalg.map.group[int]int
     - __kind: PointerType
-      ID: 231
+      ID: 216
       Name: '*noalg.map.group[int]uint8'
       ByteSize: 8
-      Pointee: 232 StructureType noalg.map.group[int]uint8
+      Pointee: 217 StructureType noalg.map.group[int]uint8
     - __kind: PointerType
-      ID: 215
+      ID: 198
       Name: '*noalg.map.group[string][]main.structWithMap'
       ByteSize: 8
-      Pointee: 216 StructureType noalg.map.group[string][]main.structWithMap
+      Pointee: 199 StructureType noalg.map.group[string][]main.structWithMap
     - __kind: PointerType
-      ID: 200
+      ID: 181
       Name: '*noalg.map.group[string][]string'
       ByteSize: 8
-      Pointee: 201 StructureType noalg.map.group[string][]string
+      Pointee: 182 StructureType noalg.map.group[string][]string
     - __kind: PointerType
-      ID: 193
+      ID: 173
       Name: '*noalg.map.group[string]int'
       ByteSize: 8
-      Pointee: 194 StructureType noalg.map.group[string]int
+      Pointee: 174 StructureType noalg.map.group[string]int
     - __kind: PointerType
-      ID: 186
+      ID: 165
       Name: '*noalg.map.group[string]main.nestedStruct'
       ByteSize: 8
-      Pointee: 187 StructureType noalg.map.group[string]main.nestedStruct
+      Pointee: 166 StructureType noalg.map.group[string]main.nestedStruct
     - __kind: PointerType
-      ID: 245
+      ID: 232
       Name: '*noalg.map.group[uint8][4]int'
       ByteSize: 8
-      Pointee: 246 StructureType noalg.map.group[uint8][4]int
+      Pointee: 233 StructureType noalg.map.group[uint8][4]int
     - __kind: PointerType
-      ID: 238
+      ID: 224
       Name: '*noalg.map.group[uint8]uint8'
       ByteSize: 8
-      Pointee: 239 StructureType noalg.map.group[uint8]uint8
+      Pointee: 225 StructureType noalg.map.group[uint8]uint8
     - __kind: PointerType
       ID: 22
       Name: '*string'
@@ -3463,70 +3463,70 @@ Types:
       GoKind: 22
       Pointee: 9 GoStringHeaderType string
     - __kind: PointerType
-      ID: 175
+      ID: 152
       Name: '*string.str'
       ByteSize: 8
-      Pointee: 174 GoStringDataType string.str
+      Pointee: 151 GoStringDataType string.str
     - __kind: PointerType
       ID: 127
       Name: '*table<[4]int,[4]int>'
       ByteSize: 8
-      Pointee: 172 StructureType table<[4]int,[4]int>
+      Pointee: 247 StructureType table<[4]int,[4]int>
     - __kind: PointerType
       ID: 122
       Name: '*table<[4]int,uint8>'
       ByteSize: 8
-      Pointee: 171 StructureType table<[4]int,uint8>
+      Pointee: 239 StructureType table<[4]int,uint8>
     - __kind: PointerType
       ID: 90
       Name: '*table<[4]string,[2]int>'
       ByteSize: 8
-      Pointee: 165 StructureType table<[4]string,[2]int>
+      Pointee: 187 StructureType table<[4]string,[2]int>
     - __kind: PointerType
       ID: 102
       Name: '*table<bool,main.node>'
       ByteSize: 8
-      Pointee: 167 StructureType table<bool,main.node>
+      Pointee: 206 StructureType table<bool,main.node>
     - __kind: PointerType
       ID: 70
       Name: '*table<int,int>'
       ByteSize: 8
-      Pointee: 161 StructureType table<int,int>
+      Pointee: 155 StructureType table<int,int>
     - __kind: PointerType
       ID: 107
       Name: '*table<int,uint8>'
       ByteSize: 8
-      Pointee: 168 StructureType table<int,uint8>
+      Pointee: 214 StructureType table<int,uint8>
     - __kind: PointerType
       ID: 97
       Name: '*table<string,[]main.structWithMap>'
       ByteSize: 8
-      Pointee: 166 StructureType table<string,[]main.structWithMap>
+      Pointee: 196 StructureType table<string,[]main.structWithMap>
     - __kind: PointerType
       ID: 85
       Name: '*table<string,[]string>'
       ByteSize: 8
-      Pointee: 164 StructureType table<string,[]string>
+      Pointee: 179 StructureType table<string,[]string>
     - __kind: PointerType
       ID: 80
       Name: '*table<string,int>'
       ByteSize: 8
-      Pointee: 163 StructureType table<string,int>
+      Pointee: 171 StructureType table<string,int>
     - __kind: PointerType
       ID: 75
       Name: '*table<string,main.nestedStruct>'
       ByteSize: 8
-      Pointee: 162 StructureType table<string,main.nestedStruct>
+      Pointee: 163 StructureType table<string,main.nestedStruct>
     - __kind: PointerType
       ID: 117
       Name: '*table<uint8,[4]int>'
       ByteSize: 8
-      Pointee: 170 StructureType table<uint8,[4]int>
+      Pointee: 230 StructureType table<uint8,[4]int>
     - __kind: PointerType
       ID: 112
       Name: '*table<uint8,uint8>'
       ByteSize: 8
-      Pointee: 169 StructureType table<uint8,uint8>
+      Pointee: 222 StructureType table<uint8,uint8>
     - __kind: PointerType
       ID: 34
       Name: '*uint'
@@ -5338,7 +5338,7 @@ Types:
       HasCount: true
       Element: 3 BaseType uint8
     - __kind: ArrayType
-      ID: 249
+      ID: 236
       Name: '[4]int'
       ByteSize: 32
       GoRuntimeType: 672704
@@ -5347,7 +5347,7 @@ Types:
       HasCount: true
       Element: 7 BaseType int
     - __kind: ArrayType
-      ID: 211
+      ID: 193
       Name: '[4]string'
       ByteSize: 64
       GoRuntimeType: 672992
@@ -5379,69 +5379,69 @@ Types:
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 176 GoSliceDataType []*string.array
+      Data: 153 GoSliceDataType []*string.array
     - __kind: GoSliceDataType
-      ID: 176
+      ID: 153
       Name: '[]*string.array'
       ByteSize: 2048
       Element: 22 PointerType *string
     - __kind: GoSliceDataType
-      ID: 264
+      ID: 253
       Name: '[]*table<[4]int,[4]int>.array'
       ByteSize: 8192
       Element: 127 PointerType *table<[4]int,[4]int>
     - __kind: GoSliceDataType
-      ID: 257
+      ID: 245
       Name: '[]*table<[4]int,uint8>.array'
       ByteSize: 8192
       Element: 122 PointerType *table<[4]int,uint8>
     - __kind: GoSliceDataType
-      ID: 212
+      ID: 194
       Name: '[]*table<[4]string,[2]int>.array'
       ByteSize: 8192
       Element: 90 PointerType *table<[4]string,[2]int>
     - __kind: GoSliceDataType
-      ID: 228
+      ID: 212
       Name: '[]*table<bool,main.node>.array'
       ByteSize: 8192
       Element: 102 PointerType *table<bool,main.node>
     - __kind: GoSliceDataType
-      ID: 183
+      ID: 161
       Name: '[]*table<int,int>.array'
       ByteSize: 8192
       Element: 70 PointerType *table<int,int>
     - __kind: GoSliceDataType
-      ID: 235
+      ID: 220
       Name: '[]*table<int,uint8>.array'
       ByteSize: 8192
       Element: 107 PointerType *table<int,uint8>
     - __kind: GoSliceDataType
-      ID: 221
+      ID: 204
       Name: '[]*table<string,[]main.structWithMap>.array'
       ByteSize: 8192
       Element: 97 PointerType *table<string,[]main.structWithMap>
     - __kind: GoSliceDataType
-      ID: 204
+      ID: 185
       Name: '[]*table<string,[]string>.array'
       ByteSize: 8192
       Element: 85 PointerType *table<string,[]string>
     - __kind: GoSliceDataType
-      ID: 197
+      ID: 177
       Name: '[]*table<string,int>.array'
       ByteSize: 8192
       Element: 80 PointerType *table<string,int>
     - __kind: GoSliceDataType
-      ID: 190
+      ID: 169
       Name: '[]*table<string,main.nestedStruct>.array'
       ByteSize: 8192
       Element: 75 PointerType *table<string,main.nestedStruct>
     - __kind: GoSliceDataType
-      ID: 250
+      ID: 237
       Name: '[]*table<uint8,[4]int>.array'
       ByteSize: 8192
       Element: 117 PointerType *table<uint8,[4]int>
     - __kind: GoSliceDataType
-      ID: 242
+      ID: 228
       Name: '[]*table<uint8,uint8>.array'
       ByteSize: 8192
       Element: 112 PointerType *table<uint8,uint8>
@@ -5460,9 +5460,9 @@ Types:
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 270 GoSliceDataType [][]uint.array
+      Data: 257 GoSliceDataType [][]uint.array
     - __kind: GoSliceDataType
-      ID: 270
+      ID: 257
       Name: '[][]uint.array'
       ByteSize: 2048
       Element: 135 GoSliceHeaderType []uint
@@ -5482,14 +5482,14 @@ Types:
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 276 GoSliceDataType []bool.array
+      Data: 263 GoSliceDataType []bool.array
     - __kind: GoSliceDataType
-      ID: 276
+      ID: 263
       Name: '[]bool.array'
       ByteSize: 2048
       Element: 4 BaseType bool
     - __kind: GoSliceHeaderType
-      ID: 219
+      ID: 202
       Name: '[]main.structWithMap'
       ByteSize: 24
       GoRuntimeType: 469760
@@ -5497,7 +5497,7 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 220 PointerType *main.structWithMap
+          Type: 203 PointerType *main.structWithMap
         - Name: len
           Offset: 8
           Type: 7 BaseType int
@@ -5525,72 +5525,72 @@ Types:
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 272 GoSliceDataType []main.structWithNoStrings.array
+      Data: 259 GoSliceDataType []main.structWithNoStrings.array
     - __kind: GoSliceDataType
-      ID: 272
+      ID: 259
       Name: '[]main.structWithNoStrings.array'
       ByteSize: 2048
       Element: 140 StructureType main.structWithNoStrings
     - __kind: GoSliceDataType
-      ID: 265
+      ID: 254
       Name: '[]noalg.map.group[[4]int][4]int.array'
       ByteSize: 2048
-      Element: 261 StructureType noalg.map.group[[4]int][4]int
+      Element: 250 StructureType noalg.map.group[[4]int][4]int
     - __kind: GoSliceDataType
-      ID: 258
+      ID: 246
       Name: '[]noalg.map.group[[4]int]uint8.array'
       ByteSize: 2048
-      Element: 254 StructureType noalg.map.group[[4]int]uint8
+      Element: 242 StructureType noalg.map.group[[4]int]uint8
     - __kind: GoSliceDataType
-      ID: 213
+      ID: 195
       Name: '[]noalg.map.group[[4]string][2]int.array'
       ByteSize: 2048
-      Element: 208 StructureType noalg.map.group[[4]string][2]int
+      Element: 190 StructureType noalg.map.group[[4]string][2]int
     - __kind: GoSliceDataType
-      ID: 229
+      ID: 213
       Name: '[]noalg.map.group[bool]main.node.array'
       ByteSize: 2048
-      Element: 225 StructureType noalg.map.group[bool]main.node
+      Element: 209 StructureType noalg.map.group[bool]main.node
     - __kind: GoSliceDataType
-      ID: 184
+      ID: 162
       Name: '[]noalg.map.group[int]int.array'
       ByteSize: 2048
-      Element: 180 StructureType noalg.map.group[int]int
+      Element: 158 StructureType noalg.map.group[int]int
     - __kind: GoSliceDataType
-      ID: 236
+      ID: 221
       Name: '[]noalg.map.group[int]uint8.array'
       ByteSize: 2048
-      Element: 232 StructureType noalg.map.group[int]uint8
-    - __kind: GoSliceDataType
-      ID: 222
-      Name: '[]noalg.map.group[string][]main.structWithMap.array'
-      ByteSize: 2048
-      Element: 216 StructureType noalg.map.group[string][]main.structWithMap
+      Element: 217 StructureType noalg.map.group[int]uint8
     - __kind: GoSliceDataType
       ID: 205
+      Name: '[]noalg.map.group[string][]main.structWithMap.array'
+      ByteSize: 2048
+      Element: 199 StructureType noalg.map.group[string][]main.structWithMap
+    - __kind: GoSliceDataType
+      ID: 186
       Name: '[]noalg.map.group[string][]string.array'
       ByteSize: 2048
-      Element: 201 StructureType noalg.map.group[string][]string
+      Element: 182 StructureType noalg.map.group[string][]string
     - __kind: GoSliceDataType
-      ID: 198
+      ID: 178
       Name: '[]noalg.map.group[string]int.array'
       ByteSize: 2048
-      Element: 194 StructureType noalg.map.group[string]int
+      Element: 174 StructureType noalg.map.group[string]int
     - __kind: GoSliceDataType
-      ID: 191
+      ID: 170
       Name: '[]noalg.map.group[string]main.nestedStruct.array'
       ByteSize: 2048
-      Element: 187 StructureType noalg.map.group[string]main.nestedStruct
+      Element: 166 StructureType noalg.map.group[string]main.nestedStruct
     - __kind: GoSliceDataType
-      ID: 251
+      ID: 238
       Name: '[]noalg.map.group[uint8][4]int.array'
       ByteSize: 2048
-      Element: 246 StructureType noalg.map.group[uint8][4]int
+      Element: 233 StructureType noalg.map.group[uint8][4]int
     - __kind: GoSliceDataType
-      ID: 243
+      ID: 229
       Name: '[]noalg.map.group[uint8]uint8.array'
       ByteSize: 2048
-      Element: 239 StructureType noalg.map.group[uint8]uint8
+      Element: 225 StructureType noalg.map.group[uint8]uint8
     - __kind: GoSliceHeaderType
       ID: 141
       Name: '[]string'
@@ -5607,9 +5607,9 @@ Types:
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 274 GoSliceDataType []string.array
+      Data: 261 GoSliceDataType []string.array
     - __kind: GoSliceDataType
-      ID: 274
+      ID: 261
       Name: '[]string.array'
       ByteSize: 2048
       Element: 9 GoStringHeaderType string
@@ -5629,9 +5629,9 @@ Types:
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 268 GoSliceDataType []uint.array
+      Data: 255 GoSliceDataType []uint.array
     - __kind: GoSliceDataType
-      ID: 268
+      ID: 255
       Name: '[]uint.array'
       ByteSize: 2048
       Element: 10 BaseType uint
@@ -5651,9 +5651,9 @@ Types:
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 278 GoSliceDataType []uint16.array
+      Data: 265 GoSliceDataType []uint16.array
     - __kind: GoSliceDataType
-      ID: 278
+      ID: 265
       Name: '[]uint16.array'
       ByteSize: 2048
       Element: 6 BaseType uint16
@@ -5717,173 +5717,173 @@ Types:
       GoRuntimeType: 468800
       GoKind: 19
     - __kind: GoSwissMapGroupsType
-      ID: 259
+      ID: 248
       Name: groupReference<[4]int,[4]int>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 260 PointerType *noalg.map.group[[4]int][4]int
+          Type: 249 PointerType *noalg.map.group[[4]int][4]int
         - Name: lengthMask
           Offset: 8
           Type: 8 BaseType uint64
-      GroupType: 261 StructureType noalg.map.group[[4]int][4]int
-      GroupSliceType: 265 GoSliceDataType []noalg.map.group[[4]int][4]int.array
+      GroupType: 250 StructureType noalg.map.group[[4]int][4]int
+      GroupSliceType: 254 GoSliceDataType []noalg.map.group[[4]int][4]int.array
     - __kind: GoSwissMapGroupsType
-      ID: 252
+      ID: 240
       Name: groupReference<[4]int,uint8>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 253 PointerType *noalg.map.group[[4]int]uint8
+          Type: 241 PointerType *noalg.map.group[[4]int]uint8
         - Name: lengthMask
           Offset: 8
           Type: 8 BaseType uint64
-      GroupType: 254 StructureType noalg.map.group[[4]int]uint8
-      GroupSliceType: 258 GoSliceDataType []noalg.map.group[[4]int]uint8.array
+      GroupType: 242 StructureType noalg.map.group[[4]int]uint8
+      GroupSliceType: 246 GoSliceDataType []noalg.map.group[[4]int]uint8.array
     - __kind: GoSwissMapGroupsType
-      ID: 206
+      ID: 188
       Name: groupReference<[4]string,[2]int>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 207 PointerType *noalg.map.group[[4]string][2]int
+          Type: 189 PointerType *noalg.map.group[[4]string][2]int
         - Name: lengthMask
           Offset: 8
           Type: 8 BaseType uint64
-      GroupType: 208 StructureType noalg.map.group[[4]string][2]int
-      GroupSliceType: 213 GoSliceDataType []noalg.map.group[[4]string][2]int.array
+      GroupType: 190 StructureType noalg.map.group[[4]string][2]int
+      GroupSliceType: 195 GoSliceDataType []noalg.map.group[[4]string][2]int.array
     - __kind: GoSwissMapGroupsType
-      ID: 223
+      ID: 207
       Name: groupReference<bool,main.node>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 224 PointerType *noalg.map.group[bool]main.node
+          Type: 208 PointerType *noalg.map.group[bool]main.node
         - Name: lengthMask
           Offset: 8
           Type: 8 BaseType uint64
-      GroupType: 225 StructureType noalg.map.group[bool]main.node
-      GroupSliceType: 229 GoSliceDataType []noalg.map.group[bool]main.node.array
+      GroupType: 209 StructureType noalg.map.group[bool]main.node
+      GroupSliceType: 213 GoSliceDataType []noalg.map.group[bool]main.node.array
     - __kind: GoSwissMapGroupsType
-      ID: 178
+      ID: 156
       Name: groupReference<int,int>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 179 PointerType *noalg.map.group[int]int
+          Type: 157 PointerType *noalg.map.group[int]int
         - Name: lengthMask
           Offset: 8
           Type: 8 BaseType uint64
-      GroupType: 180 StructureType noalg.map.group[int]int
-      GroupSliceType: 184 GoSliceDataType []noalg.map.group[int]int.array
+      GroupType: 158 StructureType noalg.map.group[int]int
+      GroupSliceType: 162 GoSliceDataType []noalg.map.group[int]int.array
     - __kind: GoSwissMapGroupsType
-      ID: 230
+      ID: 215
       Name: groupReference<int,uint8>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 231 PointerType *noalg.map.group[int]uint8
+          Type: 216 PointerType *noalg.map.group[int]uint8
         - Name: lengthMask
           Offset: 8
           Type: 8 BaseType uint64
-      GroupType: 232 StructureType noalg.map.group[int]uint8
-      GroupSliceType: 236 GoSliceDataType []noalg.map.group[int]uint8.array
+      GroupType: 217 StructureType noalg.map.group[int]uint8
+      GroupSliceType: 221 GoSliceDataType []noalg.map.group[int]uint8.array
     - __kind: GoSwissMapGroupsType
-      ID: 214
+      ID: 197
       Name: groupReference<string,[]main.structWithMap>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 215 PointerType *noalg.map.group[string][]main.structWithMap
+          Type: 198 PointerType *noalg.map.group[string][]main.structWithMap
         - Name: lengthMask
           Offset: 8
           Type: 8 BaseType uint64
-      GroupType: 216 StructureType noalg.map.group[string][]main.structWithMap
-      GroupSliceType: 222 GoSliceDataType []noalg.map.group[string][]main.structWithMap.array
+      GroupType: 199 StructureType noalg.map.group[string][]main.structWithMap
+      GroupSliceType: 205 GoSliceDataType []noalg.map.group[string][]main.structWithMap.array
     - __kind: GoSwissMapGroupsType
-      ID: 199
+      ID: 180
       Name: groupReference<string,[]string>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 200 PointerType *noalg.map.group[string][]string
+          Type: 181 PointerType *noalg.map.group[string][]string
         - Name: lengthMask
           Offset: 8
           Type: 8 BaseType uint64
-      GroupType: 201 StructureType noalg.map.group[string][]string
-      GroupSliceType: 205 GoSliceDataType []noalg.map.group[string][]string.array
+      GroupType: 182 StructureType noalg.map.group[string][]string
+      GroupSliceType: 186 GoSliceDataType []noalg.map.group[string][]string.array
     - __kind: GoSwissMapGroupsType
-      ID: 192
+      ID: 172
       Name: groupReference<string,int>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 193 PointerType *noalg.map.group[string]int
+          Type: 173 PointerType *noalg.map.group[string]int
         - Name: lengthMask
           Offset: 8
           Type: 8 BaseType uint64
-      GroupType: 194 StructureType noalg.map.group[string]int
-      GroupSliceType: 198 GoSliceDataType []noalg.map.group[string]int.array
+      GroupType: 174 StructureType noalg.map.group[string]int
+      GroupSliceType: 178 GoSliceDataType []noalg.map.group[string]int.array
     - __kind: GoSwissMapGroupsType
-      ID: 185
+      ID: 164
       Name: groupReference<string,main.nestedStruct>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 186 PointerType *noalg.map.group[string]main.nestedStruct
+          Type: 165 PointerType *noalg.map.group[string]main.nestedStruct
         - Name: lengthMask
           Offset: 8
           Type: 8 BaseType uint64
-      GroupType: 187 StructureType noalg.map.group[string]main.nestedStruct
-      GroupSliceType: 191 GoSliceDataType []noalg.map.group[string]main.nestedStruct.array
+      GroupType: 166 StructureType noalg.map.group[string]main.nestedStruct
+      GroupSliceType: 170 GoSliceDataType []noalg.map.group[string]main.nestedStruct.array
     - __kind: GoSwissMapGroupsType
-      ID: 244
+      ID: 231
       Name: groupReference<uint8,[4]int>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 245 PointerType *noalg.map.group[uint8][4]int
+          Type: 232 PointerType *noalg.map.group[uint8][4]int
         - Name: lengthMask
           Offset: 8
           Type: 8 BaseType uint64
-      GroupType: 246 StructureType noalg.map.group[uint8][4]int
-      GroupSliceType: 251 GoSliceDataType []noalg.map.group[uint8][4]int.array
+      GroupType: 233 StructureType noalg.map.group[uint8][4]int
+      GroupSliceType: 238 GoSliceDataType []noalg.map.group[uint8][4]int.array
     - __kind: GoSwissMapGroupsType
-      ID: 237
+      ID: 223
       Name: groupReference<uint8,uint8>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 238 PointerType *noalg.map.group[uint8]uint8
+          Type: 224 PointerType *noalg.map.group[uint8]uint8
         - Name: lengthMask
           Offset: 8
           Type: 8 BaseType uint64
-      GroupType: 239 StructureType noalg.map.group[uint8]uint8
-      GroupSliceType: 243 GoSliceDataType []noalg.map.group[uint8]uint8.array
+      GroupType: 225 StructureType noalg.map.group[uint8]uint8
+      GroupSliceType: 229 GoSliceDataType []noalg.map.group[uint8]uint8.array
     - __kind: BaseType
       ID: 7
       Name: int
@@ -5928,7 +5928,7 @@ Types:
           Offset: 8
           Type: 15 VoidPointerType unsafe.Pointer
     - __kind: StructureType
-      ID: 153
+      ID: 269
       Name: internal/sync.Mutex
       ByteSize: 8
       GoRuntimeType: 1.453952e+06
@@ -6016,16 +6016,16 @@ Types:
           Type: 56 StructureType main.esotericStack
         - Name: mu
           Offset: 64
-          Type: 151 StructureType sync.Mutex
+          Type: 267 StructureType sync.Mutex
         - Name: once
           Offset: 72
-          Type: 154 StructureType sync.Once
+          Type: 270 StructureType sync.Once
         - Name: wg
           Offset: 88
-          Type: 157 StructureType sync.WaitGroup
+          Type: 273 StructureType sync.WaitGroup
         - Name: a
           Offset: 104
-          Type: 160 StructureType sync/atomic.Int32
+          Type: 276 StructureType sync/atomic.Int32
     - __kind: StructureType
       ID: 56
       Name: main.esotericStack
@@ -6144,16 +6144,16 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 173 PointerType **main.t
+          Type: 277 PointerType **main.t
         - Name: len
           Offset: 8
           Type: 7 BaseType int
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 266 GoSliceDataType main.t.array
+      Data: 278 GoSliceDataType main.t.array
     - __kind: GoSliceDataType
-      ID: 266
+      ID: 278
       Name: main.t.array
       ByteSize: 2048
       Element: 133 PointerType *main.t
@@ -6207,8 +6207,8 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 8 BaseType uint64
-      TablePtrSliceType: 264 GoSliceDataType []*table<[4]int,[4]int>.array
-      GroupType: 261 StructureType noalg.map.group[[4]int][4]int
+      TablePtrSliceType: 253 GoSliceDataType []*table<[4]int,[4]int>.array
+      GroupType: 250 StructureType noalg.map.group[[4]int][4]int
     - __kind: GoSwissMapHeaderType
       ID: 120
       Name: map<[4]int,uint8>
@@ -6239,8 +6239,8 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 8 BaseType uint64
-      TablePtrSliceType: 257 GoSliceDataType []*table<[4]int,uint8>.array
-      GroupType: 254 StructureType noalg.map.group[[4]int]uint8
+      TablePtrSliceType: 245 GoSliceDataType []*table<[4]int,uint8>.array
+      GroupType: 242 StructureType noalg.map.group[[4]int]uint8
     - __kind: GoSwissMapHeaderType
       ID: 88
       Name: map<[4]string,[2]int>
@@ -6271,8 +6271,8 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 8 BaseType uint64
-      TablePtrSliceType: 212 GoSliceDataType []*table<[4]string,[2]int>.array
-      GroupType: 208 StructureType noalg.map.group[[4]string][2]int
+      TablePtrSliceType: 194 GoSliceDataType []*table<[4]string,[2]int>.array
+      GroupType: 190 StructureType noalg.map.group[[4]string][2]int
     - __kind: GoSwissMapHeaderType
       ID: 100
       Name: map<bool,main.node>
@@ -6303,8 +6303,8 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 8 BaseType uint64
-      TablePtrSliceType: 228 GoSliceDataType []*table<bool,main.node>.array
-      GroupType: 225 StructureType noalg.map.group[bool]main.node
+      TablePtrSliceType: 212 GoSliceDataType []*table<bool,main.node>.array
+      GroupType: 209 StructureType noalg.map.group[bool]main.node
     - __kind: GoSwissMapHeaderType
       ID: 68
       Name: map<int,int>
@@ -6335,8 +6335,8 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 8 BaseType uint64
-      TablePtrSliceType: 183 GoSliceDataType []*table<int,int>.array
-      GroupType: 180 StructureType noalg.map.group[int]int
+      TablePtrSliceType: 161 GoSliceDataType []*table<int,int>.array
+      GroupType: 158 StructureType noalg.map.group[int]int
     - __kind: GoSwissMapHeaderType
       ID: 105
       Name: map<int,uint8>
@@ -6367,8 +6367,8 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 8 BaseType uint64
-      TablePtrSliceType: 235 GoSliceDataType []*table<int,uint8>.array
-      GroupType: 232 StructureType noalg.map.group[int]uint8
+      TablePtrSliceType: 220 GoSliceDataType []*table<int,uint8>.array
+      GroupType: 217 StructureType noalg.map.group[int]uint8
     - __kind: GoSwissMapHeaderType
       ID: 95
       Name: map<string,[]main.structWithMap>
@@ -6399,8 +6399,8 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 8 BaseType uint64
-      TablePtrSliceType: 221 GoSliceDataType []*table<string,[]main.structWithMap>.array
-      GroupType: 216 StructureType noalg.map.group[string][]main.structWithMap
+      TablePtrSliceType: 204 GoSliceDataType []*table<string,[]main.structWithMap>.array
+      GroupType: 199 StructureType noalg.map.group[string][]main.structWithMap
     - __kind: GoSwissMapHeaderType
       ID: 83
       Name: map<string,[]string>
@@ -6431,8 +6431,8 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 8 BaseType uint64
-      TablePtrSliceType: 204 GoSliceDataType []*table<string,[]string>.array
-      GroupType: 201 StructureType noalg.map.group[string][]string
+      TablePtrSliceType: 185 GoSliceDataType []*table<string,[]string>.array
+      GroupType: 182 StructureType noalg.map.group[string][]string
     - __kind: GoSwissMapHeaderType
       ID: 78
       Name: map<string,int>
@@ -6463,8 +6463,8 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 8 BaseType uint64
-      TablePtrSliceType: 197 GoSliceDataType []*table<string,int>.array
-      GroupType: 194 StructureType noalg.map.group[string]int
+      TablePtrSliceType: 177 GoSliceDataType []*table<string,int>.array
+      GroupType: 174 StructureType noalg.map.group[string]int
     - __kind: GoSwissMapHeaderType
       ID: 73
       Name: map<string,main.nestedStruct>
@@ -6495,8 +6495,8 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 8 BaseType uint64
-      TablePtrSliceType: 190 GoSliceDataType []*table<string,main.nestedStruct>.array
-      GroupType: 187 StructureType noalg.map.group[string]main.nestedStruct
+      TablePtrSliceType: 169 GoSliceDataType []*table<string,main.nestedStruct>.array
+      GroupType: 166 StructureType noalg.map.group[string]main.nestedStruct
     - __kind: GoSwissMapHeaderType
       ID: 115
       Name: map<uint8,[4]int>
@@ -6527,8 +6527,8 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 8 BaseType uint64
-      TablePtrSliceType: 250 GoSliceDataType []*table<uint8,[4]int>.array
-      GroupType: 246 StructureType noalg.map.group[uint8][4]int
+      TablePtrSliceType: 237 GoSliceDataType []*table<uint8,[4]int>.array
+      GroupType: 233 StructureType noalg.map.group[uint8][4]int
     - __kind: GoSwissMapHeaderType
       ID: 110
       Name: map<uint8,uint8>
@@ -6559,8 +6559,8 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 8 BaseType uint64
-      TablePtrSliceType: 242 GoSliceDataType []*table<uint8,uint8>.array
-      GroupType: 239 StructureType noalg.map.group[uint8]uint8
+      TablePtrSliceType: 228 GoSliceDataType []*table<uint8,uint8>.array
+      GroupType: 225 StructureType noalg.map.group[uint8]uint8
     - __kind: GoMapType
       ID: 123
       Name: map[[4]int][4]int
@@ -6646,115 +6646,115 @@ Types:
       GoKind: 21
       HeaderType: 110 GoSwissMapHeaderType map<uint8,uint8>
     - __kind: ArrayType
-      ID: 262
+      ID: 251
       Name: noalg.[8]struct { key [4]int; elem [4]int }
       ByteSize: 512
       GoRuntimeType: 672800
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 263 StructureType noalg.struct { key [4]int; elem [4]int }
+      Element: 252 StructureType noalg.struct { key [4]int; elem [4]int }
     - __kind: ArrayType
-      ID: 255
+      ID: 243
       Name: noalg.[8]struct { key [4]int; elem uint8 }
       ByteSize: 320
       GoRuntimeType: 672896
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 256 StructureType noalg.struct { key [4]int; elem uint8 }
+      Element: 244 StructureType noalg.struct { key [4]int; elem uint8 }
     - __kind: ArrayType
-      ID: 209
+      ID: 191
       Name: noalg.[8]struct { key [4]string; elem [2]int }
       ByteSize: 640
       GoRuntimeType: 673184
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 210 StructureType noalg.struct { key [4]string; elem [2]int }
+      Element: 192 StructureType noalg.struct { key [4]string; elem [2]int }
     - __kind: ArrayType
-      ID: 226
+      ID: 210
       Name: noalg.[8]struct { key bool; elem main.node }
       ByteSize: 192
       GoRuntimeType: 673280
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 227 StructureType noalg.struct { key bool; elem main.node }
+      Element: 211 StructureType noalg.struct { key bool; elem main.node }
     - __kind: ArrayType
-      ID: 181
+      ID: 159
       Name: noalg.[8]struct { key int; elem int }
       ByteSize: 128
       GoRuntimeType: 671072
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 182 StructureType noalg.struct { key int; elem int }
+      Element: 160 StructureType noalg.struct { key int; elem int }
     - __kind: ArrayType
-      ID: 233
+      ID: 218
       Name: noalg.[8]struct { key int; elem uint8 }
       ByteSize: 128
       GoRuntimeType: 673376
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 234 StructureType noalg.struct { key int; elem uint8 }
+      Element: 219 StructureType noalg.struct { key int; elem uint8 }
     - __kind: ArrayType
-      ID: 217
+      ID: 200
       Name: noalg.[8]struct { key string; elem []main.structWithMap }
       ByteSize: 320
       GoRuntimeType: 673472
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 218 StructureType noalg.struct { key string; elem []main.structWithMap }
+      Element: 201 StructureType noalg.struct { key string; elem []main.structWithMap }
     - __kind: ArrayType
-      ID: 202
+      ID: 183
       Name: noalg.[8]struct { key string; elem []string }
       ByteSize: 320
       GoRuntimeType: 673568
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 203 StructureType noalg.struct { key string; elem []string }
+      Element: 184 StructureType noalg.struct { key string; elem []string }
     - __kind: ArrayType
-      ID: 195
+      ID: 175
       Name: noalg.[8]struct { key string; elem int }
       ByteSize: 192
       GoRuntimeType: 673664
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 196 StructureType noalg.struct { key string; elem int }
+      Element: 176 StructureType noalg.struct { key string; elem int }
     - __kind: ArrayType
-      ID: 188
+      ID: 167
       Name: noalg.[8]struct { key string; elem main.nestedStruct }
       ByteSize: 320
       GoRuntimeType: 673760
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 189 StructureType noalg.struct { key string; elem main.nestedStruct }
+      Element: 168 StructureType noalg.struct { key string; elem main.nestedStruct }
     - __kind: ArrayType
-      ID: 247
+      ID: 234
       Name: noalg.[8]struct { key uint8; elem [4]int }
       ByteSize: 320
       GoRuntimeType: 673856
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 248 StructureType noalg.struct { key uint8; elem [4]int }
+      Element: 235 StructureType noalg.struct { key uint8; elem [4]int }
     - __kind: ArrayType
-      ID: 240
+      ID: 226
       Name: noalg.[8]struct { key uint8; elem uint8 }
       ByteSize: 16
       GoRuntimeType: 673952
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 241 StructureType noalg.struct { key uint8; elem uint8 }
+      Element: 227 StructureType noalg.struct { key uint8; elem uint8 }
     - __kind: StructureType
-      ID: 261
+      ID: 250
       Name: noalg.map.group[[4]int][4]int
       ByteSize: 520
       GoRuntimeType: 1.276576e+06
@@ -6765,9 +6765,9 @@ Types:
           Type: 8 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 262 ArrayType noalg.[8]struct { key [4]int; elem [4]int }
+          Type: 251 ArrayType noalg.[8]struct { key [4]int; elem [4]int }
     - __kind: StructureType
-      ID: 254
+      ID: 242
       Name: noalg.map.group[[4]int]uint8
       ByteSize: 328
       GoRuntimeType: 1.276832e+06
@@ -6778,9 +6778,9 @@ Types:
           Type: 8 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 255 ArrayType noalg.[8]struct { key [4]int; elem uint8 }
+          Type: 243 ArrayType noalg.[8]struct { key [4]int; elem uint8 }
     - __kind: StructureType
-      ID: 208
+      ID: 190
       Name: noalg.map.group[[4]string][2]int
       ByteSize: 648
       GoRuntimeType: 1.277088e+06
@@ -6791,9 +6791,9 @@ Types:
           Type: 8 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 209 ArrayType noalg.[8]struct { key [4]string; elem [2]int }
+          Type: 191 ArrayType noalg.[8]struct { key [4]string; elem [2]int }
     - __kind: StructureType
-      ID: 225
+      ID: 209
       Name: noalg.map.group[bool]main.node
       ByteSize: 200
       GoRuntimeType: 1.277344e+06
@@ -6804,9 +6804,9 @@ Types:
           Type: 8 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 226 ArrayType noalg.[8]struct { key bool; elem main.node }
+          Type: 210 ArrayType noalg.[8]struct { key bool; elem main.node }
     - __kind: StructureType
-      ID: 180
+      ID: 158
       Name: noalg.map.group[int]int
       ByteSize: 136
       GoRuntimeType: 1.275808e+06
@@ -6817,9 +6817,9 @@ Types:
           Type: 8 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 181 ArrayType noalg.[8]struct { key int; elem int }
+          Type: 159 ArrayType noalg.[8]struct { key int; elem int }
     - __kind: StructureType
-      ID: 232
+      ID: 217
       Name: noalg.map.group[int]uint8
       ByteSize: 136
       GoRuntimeType: 1.2776e+06
@@ -6830,9 +6830,9 @@ Types:
           Type: 8 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 233 ArrayType noalg.[8]struct { key int; elem uint8 }
+          Type: 218 ArrayType noalg.[8]struct { key int; elem uint8 }
     - __kind: StructureType
-      ID: 216
+      ID: 199
       Name: noalg.map.group[string][]main.structWithMap
       ByteSize: 328
       GoRuntimeType: 1.277856e+06
@@ -6843,9 +6843,9 @@ Types:
           Type: 8 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 217 ArrayType noalg.[8]struct { key string; elem []main.structWithMap }
+          Type: 200 ArrayType noalg.[8]struct { key string; elem []main.structWithMap }
     - __kind: StructureType
-      ID: 201
+      ID: 182
       Name: noalg.map.group[string][]string
       ByteSize: 328
       GoRuntimeType: 1.278112e+06
@@ -6856,9 +6856,9 @@ Types:
           Type: 8 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 202 ArrayType noalg.[8]struct { key string; elem []string }
+          Type: 183 ArrayType noalg.[8]struct { key string; elem []string }
     - __kind: StructureType
-      ID: 194
+      ID: 174
       Name: noalg.map.group[string]int
       ByteSize: 200
       GoRuntimeType: 1.278368e+06
@@ -6869,9 +6869,9 @@ Types:
           Type: 8 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 195 ArrayType noalg.[8]struct { key string; elem int }
+          Type: 175 ArrayType noalg.[8]struct { key string; elem int }
     - __kind: StructureType
-      ID: 187
+      ID: 166
       Name: noalg.map.group[string]main.nestedStruct
       ByteSize: 328
       GoRuntimeType: 1.278624e+06
@@ -6882,9 +6882,9 @@ Types:
           Type: 8 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 188 ArrayType noalg.[8]struct { key string; elem main.nestedStruct }
+          Type: 167 ArrayType noalg.[8]struct { key string; elem main.nestedStruct }
     - __kind: StructureType
-      ID: 246
+      ID: 233
       Name: noalg.map.group[uint8][4]int
       ByteSize: 328
       GoRuntimeType: 1.27888e+06
@@ -6895,9 +6895,9 @@ Types:
           Type: 8 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 247 ArrayType noalg.[8]struct { key uint8; elem [4]int }
+          Type: 234 ArrayType noalg.[8]struct { key uint8; elem [4]int }
     - __kind: StructureType
-      ID: 239
+      ID: 225
       Name: noalg.map.group[uint8]uint8
       ByteSize: 24
       GoRuntimeType: 1.279136e+06
@@ -6908,9 +6908,9 @@ Types:
           Type: 8 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 240 ArrayType noalg.[8]struct { key uint8; elem uint8 }
+          Type: 226 ArrayType noalg.[8]struct { key uint8; elem uint8 }
     - __kind: StructureType
-      ID: 263
+      ID: 252
       Name: noalg.struct { key [4]int; elem [4]int }
       ByteSize: 64
       GoRuntimeType: 1.276448e+06
@@ -6918,12 +6918,12 @@ Types:
       RawFields:
         - Name: key
           Offset: 0
-          Type: 249 ArrayType [4]int
+          Type: 236 ArrayType [4]int
         - Name: elem
           Offset: 32
-          Type: 249 ArrayType [4]int
+          Type: 236 ArrayType [4]int
     - __kind: StructureType
-      ID: 256
+      ID: 244
       Name: noalg.struct { key [4]int; elem uint8 }
       ByteSize: 40
       GoRuntimeType: 1.276704e+06
@@ -6931,12 +6931,12 @@ Types:
       RawFields:
         - Name: key
           Offset: 0
-          Type: 249 ArrayType [4]int
+          Type: 236 ArrayType [4]int
         - Name: elem
           Offset: 32
           Type: 3 BaseType uint8
     - __kind: StructureType
-      ID: 210
+      ID: 192
       Name: noalg.struct { key [4]string; elem [2]int }
       ByteSize: 80
       GoRuntimeType: 1.27696e+06
@@ -6944,12 +6944,12 @@ Types:
       RawFields:
         - Name: key
           Offset: 0
-          Type: 211 ArrayType [4]string
+          Type: 193 ArrayType [4]string
         - Name: elem
           Offset: 64
           Type: 40 ArrayType [2]int
     - __kind: StructureType
-      ID: 227
+      ID: 211
       Name: noalg.struct { key bool; elem main.node }
       ByteSize: 24
       GoRuntimeType: 1.277216e+06
@@ -6962,7 +6962,7 @@ Types:
           Offset: 8
           Type: 131 StructureType main.node
     - __kind: StructureType
-      ID: 182
+      ID: 160
       Name: noalg.struct { key int; elem int }
       ByteSize: 16
       GoRuntimeType: 1.27568e+06
@@ -6975,7 +6975,7 @@ Types:
           Offset: 8
           Type: 7 BaseType int
     - __kind: StructureType
-      ID: 234
+      ID: 219
       Name: noalg.struct { key int; elem uint8 }
       ByteSize: 16
       GoRuntimeType: 1.277472e+06
@@ -6988,7 +6988,7 @@ Types:
           Offset: 8
           Type: 3 BaseType uint8
     - __kind: StructureType
-      ID: 218
+      ID: 201
       Name: noalg.struct { key string; elem []main.structWithMap }
       ByteSize: 40
       GoRuntimeType: 1.277728e+06
@@ -6999,9 +6999,9 @@ Types:
           Type: 9 GoStringHeaderType string
         - Name: elem
           Offset: 16
-          Type: 219 GoSliceHeaderType []main.structWithMap
+          Type: 202 GoSliceHeaderType []main.structWithMap
     - __kind: StructureType
-      ID: 203
+      ID: 184
       Name: noalg.struct { key string; elem []string }
       ByteSize: 40
       GoRuntimeType: 1.277984e+06
@@ -7014,7 +7014,7 @@ Types:
           Offset: 16
           Type: 141 GoSliceHeaderType []string
     - __kind: StructureType
-      ID: 196
+      ID: 176
       Name: noalg.struct { key string; elem int }
       ByteSize: 24
       GoRuntimeType: 1.27824e+06
@@ -7027,7 +7027,7 @@ Types:
           Offset: 16
           Type: 7 BaseType int
     - __kind: StructureType
-      ID: 189
+      ID: 168
       Name: noalg.struct { key string; elem main.nestedStruct }
       ByteSize: 40
       GoRuntimeType: 1.278496e+06
@@ -7040,7 +7040,7 @@ Types:
           Offset: 16
           Type: 149 StructureType main.nestedStruct
     - __kind: StructureType
-      ID: 248
+      ID: 235
       Name: noalg.struct { key uint8; elem [4]int }
       ByteSize: 40
       GoRuntimeType: 1.278752e+06
@@ -7051,9 +7051,9 @@ Types:
           Type: 3 BaseType uint8
         - Name: elem
           Offset: 8
-          Type: 249 ArrayType [4]int
+          Type: 236 ArrayType [4]int
     - __kind: StructureType
-      ID: 241
+      ID: 227
       Name: noalg.struct { key uint8; elem uint8 }
       ByteSize: 2
       GoRuntimeType: 1.279008e+06
@@ -7074,17 +7074,17 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 175 PointerType *string.str
+          Type: 152 PointerType *string.str
         - Name: len
           Offset: 8
           Type: 7 BaseType int
-      Data: 174 GoStringDataType string.str
+      Data: 151 GoStringDataType string.str
     - __kind: GoStringDataType
-      ID: 174
+      ID: 151
       Name: string.str
       ByteSize: 2048
     - __kind: StructureType
-      ID: 151
+      ID: 267
       Name: sync.Mutex
       ByteSize: 8
       GoRuntimeType: 1.444672e+06
@@ -7092,12 +7092,12 @@ Types:
       RawFields:
         - Name: _
           Offset: 0
-          Type: 152 StructureType sync.noCopy
+          Type: 268 StructureType sync.noCopy
         - Name: mu
           Offset: 0
-          Type: 153 StructureType internal/sync.Mutex
+          Type: 269 StructureType internal/sync.Mutex
     - __kind: StructureType
-      ID: 154
+      ID: 270
       Name: sync.Once
       ByteSize: 12
       GoRuntimeType: 1.593184e+06
@@ -7105,15 +7105,15 @@ Types:
       RawFields:
         - Name: _
           Offset: 0
-          Type: 152 StructureType sync.noCopy
+          Type: 268 StructureType sync.noCopy
         - Name: done
           Offset: 0
-          Type: 155 StructureType sync/atomic.Uint32
+          Type: 271 StructureType sync/atomic.Uint32
         - Name: m
           Offset: 4
-          Type: 151 StructureType sync.Mutex
+          Type: 267 StructureType sync.Mutex
     - __kind: StructureType
-      ID: 157
+      ID: 273
       Name: sync.WaitGroup
       ByteSize: 16
       GoRuntimeType: 1.593376e+06
@@ -7121,21 +7121,21 @@ Types:
       RawFields:
         - Name: noCopy
           Offset: 0
-          Type: 152 StructureType sync.noCopy
+          Type: 268 StructureType sync.noCopy
         - Name: state
           Offset: 0
-          Type: 158 StructureType sync/atomic.Uint64
+          Type: 274 StructureType sync/atomic.Uint64
         - Name: sema
           Offset: 8
           Type: 2 BaseType uint32
     - __kind: StructureType
-      ID: 152
+      ID: 268
       Name: sync.noCopy
       GoRuntimeType: 977056
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 160
+      ID: 276
       Name: sync/atomic.Int32
       ByteSize: 4
       GoRuntimeType: 1.445952e+06
@@ -7143,12 +7143,12 @@ Types:
       RawFields:
         - Name: _
           Offset: 0
-          Type: 156 StructureType sync/atomic.noCopy
+          Type: 272 StructureType sync/atomic.noCopy
         - Name: v
           Offset: 0
           Type: 12 BaseType int32
     - __kind: StructureType
-      ID: 155
+      ID: 271
       Name: sync/atomic.Uint32
       ByteSize: 4
       GoRuntimeType: 1.446112e+06
@@ -7156,12 +7156,12 @@ Types:
       RawFields:
         - Name: _
           Offset: 0
-          Type: 156 StructureType sync/atomic.noCopy
+          Type: 272 StructureType sync/atomic.noCopy
         - Name: v
           Offset: 0
           Type: 2 BaseType uint32
     - __kind: StructureType
-      ID: 158
+      ID: 274
       Name: sync/atomic.Uint64
       ByteSize: 8
       GoRuntimeType: 1.59376e+06
@@ -7169,27 +7169,27 @@ Types:
       RawFields:
         - Name: _
           Offset: 0
-          Type: 156 StructureType sync/atomic.noCopy
+          Type: 272 StructureType sync/atomic.noCopy
         - Name: _
           Offset: 0
-          Type: 159 StructureType sync/atomic.align64
+          Type: 275 StructureType sync/atomic.align64
         - Name: v
           Offset: 0
           Type: 8 BaseType uint64
     - __kind: StructureType
-      ID: 159
+      ID: 275
       Name: sync/atomic.align64
       GoRuntimeType: 977248
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 156
+      ID: 272
       Name: sync/atomic.noCopy
       GoRuntimeType: 977152
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 172
+      ID: 247
       Name: table<[4]int,[4]int>
       ByteSize: 32
       GoKind: 25
@@ -7211,9 +7211,9 @@ Types:
           Type: 7 BaseType int
         - Name: groups
           Offset: 16
-          Type: 259 GoSwissMapGroupsType groupReference<[4]int,[4]int>
+          Type: 248 GoSwissMapGroupsType groupReference<[4]int,[4]int>
     - __kind: StructureType
-      ID: 171
+      ID: 239
       Name: table<[4]int,uint8>
       ByteSize: 32
       GoKind: 25
@@ -7235,9 +7235,9 @@ Types:
           Type: 7 BaseType int
         - Name: groups
           Offset: 16
-          Type: 252 GoSwissMapGroupsType groupReference<[4]int,uint8>
+          Type: 240 GoSwissMapGroupsType groupReference<[4]int,uint8>
     - __kind: StructureType
-      ID: 165
+      ID: 187
       Name: table<[4]string,[2]int>
       ByteSize: 32
       GoKind: 25
@@ -7259,9 +7259,9 @@ Types:
           Type: 7 BaseType int
         - Name: groups
           Offset: 16
-          Type: 206 GoSwissMapGroupsType groupReference<[4]string,[2]int>
+          Type: 188 GoSwissMapGroupsType groupReference<[4]string,[2]int>
     - __kind: StructureType
-      ID: 167
+      ID: 206
       Name: table<bool,main.node>
       ByteSize: 32
       GoKind: 25
@@ -7283,9 +7283,9 @@ Types:
           Type: 7 BaseType int
         - Name: groups
           Offset: 16
-          Type: 223 GoSwissMapGroupsType groupReference<bool,main.node>
+          Type: 207 GoSwissMapGroupsType groupReference<bool,main.node>
     - __kind: StructureType
-      ID: 161
+      ID: 155
       Name: table<int,int>
       ByteSize: 32
       GoKind: 25
@@ -7307,9 +7307,9 @@ Types:
           Type: 7 BaseType int
         - Name: groups
           Offset: 16
-          Type: 178 GoSwissMapGroupsType groupReference<int,int>
+          Type: 156 GoSwissMapGroupsType groupReference<int,int>
     - __kind: StructureType
-      ID: 168
+      ID: 214
       Name: table<int,uint8>
       ByteSize: 32
       GoKind: 25
@@ -7331,9 +7331,9 @@ Types:
           Type: 7 BaseType int
         - Name: groups
           Offset: 16
-          Type: 230 GoSwissMapGroupsType groupReference<int,uint8>
+          Type: 215 GoSwissMapGroupsType groupReference<int,uint8>
     - __kind: StructureType
-      ID: 166
+      ID: 196
       Name: table<string,[]main.structWithMap>
       ByteSize: 32
       GoKind: 25
@@ -7355,9 +7355,9 @@ Types:
           Type: 7 BaseType int
         - Name: groups
           Offset: 16
-          Type: 214 GoSwissMapGroupsType groupReference<string,[]main.structWithMap>
+          Type: 197 GoSwissMapGroupsType groupReference<string,[]main.structWithMap>
     - __kind: StructureType
-      ID: 164
+      ID: 179
       Name: table<string,[]string>
       ByteSize: 32
       GoKind: 25
@@ -7379,9 +7379,9 @@ Types:
           Type: 7 BaseType int
         - Name: groups
           Offset: 16
-          Type: 199 GoSwissMapGroupsType groupReference<string,[]string>
+          Type: 180 GoSwissMapGroupsType groupReference<string,[]string>
     - __kind: StructureType
-      ID: 163
+      ID: 171
       Name: table<string,int>
       ByteSize: 32
       GoKind: 25
@@ -7403,9 +7403,9 @@ Types:
           Type: 7 BaseType int
         - Name: groups
           Offset: 16
-          Type: 192 GoSwissMapGroupsType groupReference<string,int>
+          Type: 172 GoSwissMapGroupsType groupReference<string,int>
     - __kind: StructureType
-      ID: 162
+      ID: 163
       Name: table<string,main.nestedStruct>
       ByteSize: 32
       GoKind: 25
@@ -7427,9 +7427,9 @@ Types:
           Type: 7 BaseType int
         - Name: groups
           Offset: 16
-          Type: 185 GoSwissMapGroupsType groupReference<string,main.nestedStruct>
+          Type: 164 GoSwissMapGroupsType groupReference<string,main.nestedStruct>
     - __kind: StructureType
-      ID: 170
+      ID: 230
       Name: table<uint8,[4]int>
       ByteSize: 32
       GoKind: 25
@@ -7451,9 +7451,9 @@ Types:
           Type: 7 BaseType int
         - Name: groups
           Offset: 16
-          Type: 244 GoSwissMapGroupsType groupReference<uint8,[4]int>
+          Type: 231 GoSwissMapGroupsType groupReference<uint8,[4]int>
     - __kind: StructureType
-      ID: 169
+      ID: 222
       Name: table<uint8,uint8>
       ByteSize: 32
       GoKind: 25
@@ -7475,7 +7475,7 @@ Types:
           Type: 7 BaseType int
         - Name: groups
           Offset: 16
-          Type: 237 GoSwissMapGroupsType groupReference<uint8,uint8>
+          Type: 223 GoSwissMapGroupsType groupReference<uint8,uint8>
     - __kind: BaseType
       ID: 10
       Name: uint

--- a/pkg/dyninst/irgen/testdata/snapshot/sample.arch=arm64,toolchain=go1.25.0.yaml
+++ b/pkg/dyninst/irgen/testdata/snapshot/sample.arch=arm64,toolchain=go1.25.0.yaml
@@ -8,11 +8,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 88}
+      subprogram: {subprogram: 96}
       events:
-        - ID: 88
-          Type: 369 EventRootType Probe[main.stackC]
-          InjectionPoints: [{PC: "0x80947c", Frameless: true}]
+        - ID: 96
+          Type: 502 EventRootType Probe[main.stackC]
+          InjectionPoints: [{PC: "0x809e0c", Frameless: true}]
           Condition: null
     - id: testAny
       version: 0
@@ -22,11 +22,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 45}
+      subprogram: {subprogram: 53}
       events:
-        - ID: 45
-          Type: 326 EventRootType Probe[main.testAny]
-          InjectionPoints: [{PC: "0x8070bc", Frameless: true}]
+        - ID: 53
+          Type: 459 EventRootType Probe[main.testAny]
+          InjectionPoints: [{PC: "0x807a4c", Frameless: true}]
           Condition: null
     - id: testArrayOfArrays
       version: 0
@@ -39,8 +39,8 @@ Probes:
       subprogram: {subprogram: 15}
       events:
         - ID: 15
-          Type: 296 EventRootType Probe[main.testArrayOfArrays]
-          InjectionPoints: [{PC: "0x805f60", Frameless: true}]
+          Type: 421 EventRootType Probe[main.testArrayOfArrays]
+          InjectionPoints: [{PC: "0x806360", Frameless: true}]
           Condition: null
     - id: testArrayOfArraysOfArrays
       version: 0
@@ -53,8 +53,8 @@ Probes:
       subprogram: {subprogram: 17}
       events:
         - ID: 17
-          Type: 298 EventRootType Probe[main.testArrayOfArraysOfArrays]
-          InjectionPoints: [{PC: "0x805f80", Frameless: true}]
+          Type: 423 EventRootType Probe[main.testArrayOfArraysOfArrays]
+          InjectionPoints: [{PC: "0x806380", Frameless: true}]
           Condition: null
     - id: testArrayOfMaps
       version: 0
@@ -64,11 +64,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 53}
+      subprogram: {subprogram: 61}
       events:
-        - ID: 53
-          Type: 334 EventRootType Probe[main.testArrayOfMaps]
-          InjectionPoints: [{PC: "0x807530", Frameless: true}]
+        - ID: 61
+          Type: 467 EventRootType Probe[main.testArrayOfMaps]
+          InjectionPoints: [{PC: "0x807ec0", Frameless: true}]
           Condition: null
     - id: testArrayOfStrings
       version: 0
@@ -81,8 +81,8 @@ Probes:
       subprogram: {subprogram: 16}
       events:
         - ID: 16
-          Type: 297 EventRootType Probe[main.testArrayOfStrings]
-          InjectionPoints: [{PC: "0x805f70", Frameless: true}]
+          Type: 422 EventRootType Probe[main.testArrayOfStrings]
+          InjectionPoints: [{PC: "0x806370", Frameless: true}]
           Condition: null
     - id: testBigStruct
       version: 0
@@ -95,8 +95,8 @@ Probes:
       subprogram: {subprogram: 35}
       events:
         - ID: 35
-          Type: 316 EventRootType Probe[main.testBigStruct]
-          InjectionPoints: [{PC: "0x8064d0", Frameless: true}]
+          Type: 441 EventRootType Probe[main.testBigStruct]
+          InjectionPoints: [{PC: "0x8068d0", Frameless: true}]
           Condition: null
     - id: testBoolArray
       version: 0
@@ -109,8 +109,8 @@ Probes:
       subprogram: {subprogram: 4}
       events:
         - ID: 4
-          Type: 285 EventRootType Probe[main.testBoolArray]
-          InjectionPoints: [{PC: "0x805eb0", Frameless: true}]
+          Type: 410 EventRootType Probe[main.testBoolArray]
+          InjectionPoints: [{PC: "0x8062b0", Frameless: true}]
           Condition: null
     - id: testByteArray
       version: 0
@@ -123,8 +123,8 @@ Probes:
       subprogram: {subprogram: 1}
       events:
         - ID: 1
-          Type: 282 EventRootType Probe[main.testByteArray]
-          InjectionPoints: [{PC: "0x805e80", Frameless: true}]
+          Type: 407 EventRootType Probe[main.testByteArray]
+          InjectionPoints: [{PC: "0x806280", Frameless: true}]
           Condition: null
     - id: testChannel
       version: 0
@@ -134,11 +134,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 69}
+      subprogram: {subprogram: 77}
       events:
-        - ID: 69
-          Type: 350 EventRootType Probe[main.testChannel]
-          InjectionPoints: [{PC: "0x808b20", Frameless: true}]
+        - ID: 77
+          Type: 483 EventRootType Probe[main.testChannel]
+          InjectionPoints: [{PC: "0x8094b0", Frameless: true}]
           Condition: null
     - id: testCombinedByte
       version: 0
@@ -148,11 +148,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 67}
+      subprogram: {subprogram: 75}
       events:
-        - ID: 67
-          Type: 348 EventRootType Probe[main.testCombinedByte]
-          InjectionPoints: [{PC: "0x8088a0", Frameless: true}]
+        - ID: 75
+          Type: 481 EventRootType Probe[main.testCombinedByte]
+          InjectionPoints: [{PC: "0x809230", Frameless: true}]
           Condition: null
     - id: testCycle
       version: 0
@@ -162,11 +162,113 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 77}
+      subprogram: {subprogram: 85}
       events:
-        - ID: 77
-          Type: 358 EventRootType Probe[main.testCycle]
-          InjectionPoints: [{PC: "0x808da0", Frameless: true}]
+        - ID: 85
+          Type: 491 EventRootType Probe[main.testCycle]
+          InjectionPoints: [{PC: "0x809730", Frameless: true}]
+          Condition: null
+    - id: testDeepMap1
+      version: 0
+      type: LOG_PROBE
+      where: {methodName: main.testDeepMap1}
+      capture:
+        maxReferenceDepth: 1
+        maxFieldCount: 0
+        maxCollectionSize: 0
+      template: ""
+      segments: []
+      captureSnapshot: true
+      subprogram: {subprogram: 40}
+      events:
+        - ID: 40
+          Type: 446 EventRootType Probe[main.testDeepMap1]
+          InjectionPoints: [{PC: "0x806c70", Frameless: true}]
+          Condition: null
+    - id: testDeepMap7
+      version: 0
+      type: LOG_PROBE
+      where: {methodName: main.testDeepMap7}
+      capture:
+        maxReferenceDepth: 5
+        maxFieldCount: 0
+        maxCollectionSize: 0
+      template: ""
+      segments: []
+      captureSnapshot: true
+      subprogram: {subprogram: 41}
+      events:
+        - ID: 41
+          Type: 447 EventRootType Probe[main.testDeepMap7]
+          InjectionPoints: [{PC: "0x806c80", Frameless: true}]
+          Condition: null
+    - id: testDeepPtr1
+      version: 0
+      type: LOG_PROBE
+      where: {methodName: main.testDeepPtr1}
+      capture:
+        maxReferenceDepth: 1
+        maxFieldCount: 0
+        maxCollectionSize: 0
+      template: ""
+      segments: []
+      captureSnapshot: true
+      subprogram: {subprogram: 36}
+      events:
+        - ID: 36
+          Type: 442 EventRootType Probe[main.testDeepPtr1]
+          InjectionPoints: [{PC: "0x806990", Frameless: true}]
+          Condition: null
+    - id: testDeepPtr7
+      version: 0
+      type: LOG_PROBE
+      where: {methodName: main.testDeepPtr7}
+      capture:
+        maxReferenceDepth: 5
+        maxFieldCount: 0
+        maxCollectionSize: 0
+      template: ""
+      segments: []
+      captureSnapshot: true
+      subprogram: {subprogram: 37}
+      events:
+        - ID: 37
+          Type: 443 EventRootType Probe[main.testDeepPtr7]
+          InjectionPoints: [{PC: "0x8069a0", Frameless: true}]
+          Condition: null
+    - id: testDeepSlice1
+      version: 0
+      type: LOG_PROBE
+      where: {methodName: main.testDeepSlice1}
+      capture:
+        maxReferenceDepth: 1
+        maxFieldCount: 0
+        maxCollectionSize: 0
+      template: ""
+      segments: []
+      captureSnapshot: true
+      subprogram: {subprogram: 38}
+      events:
+        - ID: 38
+          Type: 444 EventRootType Probe[main.testDeepSlice1]
+          InjectionPoints: [{PC: "0x806b10", Frameless: true}]
+          Condition: null
+    - id: testDeepSlice7
+      version: 0
+      type: LOG_PROBE
+      where: {methodName: main.testDeepSlice7}
+      capture:
+        maxReferenceDepth: 5
+        maxFieldCount: 0
+        maxCollectionSize: 0
+      template: ""
+      segments: []
+      captureSnapshot: true
+      subprogram: {subprogram: 39}
+      events:
+        - ID: 39
+          Type: 445 EventRootType Probe[main.testDeepSlice7]
+          InjectionPoints: [{PC: "0x806b20", Frameless: true}]
           Condition: null
     - id: testEmptySlice
       version: 0
@@ -176,11 +278,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 79}
+      subprogram: {subprogram: 87}
       events:
-        - ID: 79
-          Type: 360 EventRootType Probe[main.testEmptySlice]
-          InjectionPoints: [{PC: "0x809150", Frameless: true}]
+        - ID: 87
+          Type: 493 EventRootType Probe[main.testEmptySlice]
+          InjectionPoints: [{PC: "0x809ae0", Frameless: true}]
           Condition: null
     - id: testEmptySliceOfStructs
       version: 0
@@ -190,11 +292,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 82}
+      subprogram: {subprogram: 90}
       events:
-        - ID: 82
-          Type: 363 EventRootType Probe[main.testEmptySliceOfStructs]
-          InjectionPoints: [{PC: "0x809180", Frameless: true}]
+        - ID: 90
+          Type: 496 EventRootType Probe[main.testEmptySliceOfStructs]
+          InjectionPoints: [{PC: "0x809b10", Frameless: true}]
           Condition: null
     - id: testEmptyString
       version: 0
@@ -204,11 +306,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 96}
+      subprogram: {subprogram: 104}
       events:
-        - ID: 96
-          Type: 377 EventRootType Probe[main.testEmptyString]
-          InjectionPoints: [{PC: "0x809540", Frameless: true}]
+        - ID: 104
+          Type: 510 EventRootType Probe[main.testEmptyString]
+          InjectionPoints: [{PC: "0x809ed0", Frameless: true}]
           Condition: null
     - id: testEmptyStruct
       version: 0
@@ -218,11 +320,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 98}
+      subprogram: {subprogram: 106}
       events:
-        - ID: 98
-          Type: 379 EventRootType Probe[main.testEmptyStruct]
-          InjectionPoints: [{PC: "0x8097e0", Frameless: true}]
+        - ID: 106
+          Type: 512 EventRootType Probe[main.testEmptyStruct]
+          InjectionPoints: [{PC: "0x80a170", Frameless: true}]
           Condition: null
     - id: testError
       version: 0
@@ -232,11 +334,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 46}
+      subprogram: {subprogram: 54}
       events:
-        - ID: 46
-          Type: 327 EventRootType Probe[main.testError]
-          InjectionPoints: [{PC: "0x807110", Frameless: true}]
+        - ID: 54
+          Type: 460 EventRootType Probe[main.testError]
+          InjectionPoints: [{PC: "0x807aa0", Frameless: true}]
           Condition: null
     - id: testEsotericHeap
       version: 0
@@ -246,11 +348,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 37}
+      subprogram: {subprogram: 45}
       events:
-        - ID: 37
-          Type: 318 EventRootType Probe[main.testEsotericHeap]
-          InjectionPoints: [{PC: "0x80671c", Frameless: true}]
+        - ID: 45
+          Type: 451 EventRootType Probe[main.testEsotericHeap]
+          InjectionPoints: [{PC: "0x8070ac", Frameless: true}]
           Condition: null
     - id: testEsotericStack
       version: 0
@@ -260,11 +362,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 36}
+      subprogram: {subprogram: 44}
       events:
-        - ID: 36
-          Type: 317 EventRootType Probe[main.testEsotericStack]
-          InjectionPoints: [{PC: "0x80665c", Frameless: true}]
+        - ID: 44
+          Type: 450 EventRootType Probe[main.testEsotericStack]
+          InjectionPoints: [{PC: "0x806fec", Frameless: true}]
           Condition: null
     - id: testFrameless
       version: 0
@@ -274,11 +376,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 42}
+      subprogram: {subprogram: 50}
       events:
-        - ID: 42
-          Type: 323 EventRootType Probe[main.testFrameless]
-          InjectionPoints: [{PC: "0x806df0", Frameless: true}]
+        - ID: 50
+          Type: 456 EventRootType Probe[main.testFrameless]
+          InjectionPoints: [{PC: "0x807780", Frameless: true}]
           Condition: null
     - id: testFramelessArray
       version: 0
@@ -288,11 +390,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 43}
+      subprogram: {subprogram: 51}
       events:
-        - ID: 43
-          Type: 324 EventRootType Probe[main.testFramelessArray]
-          InjectionPoints: [{PC: "0x806e00", Frameless: true}]
+        - ID: 51
+          Type: 457 EventRootType Probe[main.testFramelessArray]
+          InjectionPoints: [{PC: "0x807790", Frameless: true}]
           Condition: null
     - id: testInlinedBA
       version: 0
@@ -302,11 +404,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 38}
+      subprogram: {subprogram: 46}
       events:
-        - ID: 38
-          Type: 319 EventRootType Probe[main.testInlinedBA]
-          InjectionPoints: [{PC: "0x806b2c", Frameless: true}]
+        - ID: 46
+          Type: 452 EventRootType Probe[main.testInlinedBA]
+          InjectionPoints: [{PC: "0x8074bc", Frameless: true}]
           Condition: null
     - id: testInlinedBB
       version: 0
@@ -316,11 +418,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 39}
+      subprogram: {subprogram: 47}
       events:
-        - ID: 39
-          Type: 320 EventRootType Probe[main.testInlinedBB]
-          InjectionPoints: [{PC: "0x806bbc", Frameless: true}]
+        - ID: 47
+          Type: 453 EventRootType Probe[main.testInlinedBB]
+          InjectionPoints: [{PC: "0x80754c", Frameless: true}]
           Condition: null
     - id: testInlinedBBA
       version: 0
@@ -330,11 +432,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 40}
+      subprogram: {subprogram: 48}
       events:
-        - ID: 40
-          Type: 321 EventRootType Probe[main.testInlinedBBA]
-          InjectionPoints: [{PC: "0x806c7c", Frameless: true}]
+        - ID: 48
+          Type: 454 EventRootType Probe[main.testInlinedBBA]
+          InjectionPoints: [{PC: "0x80760c", Frameless: true}]
           Condition: null
     - id: testInlinedBBB
       version: 0
@@ -344,11 +446,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 100}
+      subprogram: {subprogram: 108}
       events:
-        - ID: 100
-          Type: 381 EventRootType Probe[main.testInlinedBBB]
-          InjectionPoints: [{PC: "0x806c14", Frameless: false}]
+        - ID: 108
+          Type: 514 EventRootType Probe[main.testInlinedBBB]
+          InjectionPoints: [{PC: "0x8075a4", Frameless: false}]
           Condition: null
     - id: testInlinedBC
       version: 0
@@ -358,11 +460,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 41}
+      subprogram: {subprogram: 49}
       events:
-        - ID: 41
-          Type: 322 EventRootType Probe[main.testInlinedBC]
-          InjectionPoints: [{PC: "0x806cec", Frameless: true}]
+        - ID: 49
+          Type: 455 EventRootType Probe[main.testInlinedBC]
+          InjectionPoints: [{PC: "0x80767c", Frameless: true}]
           Condition: null
     - id: testInlinedBCA
       version: 0
@@ -372,11 +474,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 101}
+      subprogram: {subprogram: 109}
       events:
-        - ID: 101
-          Type: 382 EventRootType Probe[main.testInlinedBCA]
-          InjectionPoints: [{PC: "0x806cfc", Frameless: false}]
+        - ID: 109
+          Type: 515 EventRootType Probe[main.testInlinedBCA]
+          InjectionPoints: [{PC: "0x80768c", Frameless: false}]
           Condition: null
     - id: testInlinedBCB
       version: 0
@@ -386,11 +488,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 102}
+      subprogram: {subprogram: 110}
       events:
-        - ID: 102
-          Type: 383 EventRootType Probe[main.testInlinedBCB]
-          InjectionPoints: [{PC: "0x806da0", Frameless: false}]
+        - ID: 110
+          Type: 516 EventRootType Probe[main.testInlinedBCB]
+          InjectionPoints: [{PC: "0x807730", Frameless: false}]
           Condition: null
     - id: testInlinedPrint
       version: 0
@@ -401,20 +503,20 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 99}
+      subprogram: {subprogram: 107}
       events:
-        - ID: 99
-          Type: 380 EventRootType Probe[main.testInlinedPrint]
+        - ID: 107
+          Type: 513 EventRootType Probe[main.testInlinedPrint]
           InjectionPoints:
-            - PC: "0x80699c"
+            - PC: "0x80732c"
               Frameless: true
-            - PC: "0x806a1c"
+            - PC: "0x8073ac"
               Frameless: false
-            - PC: "0x806b58"
+            - PC: "0x8074e8"
               Frameless: false
-            - PC: "0x806bd4"
+            - PC: "0x807564"
               Frameless: false
-            - PC: "0x806c8c"
+            - PC: "0x80761c"
               Frameless: false
           Condition: null
     - id: testInlinedSq
@@ -425,11 +527,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 103}
+      subprogram: {subprogram: 111}
       events:
-        - ID: 103
-          Type: 384 EventRootType Probe[main.testInlinedSq]
-          InjectionPoints: [{PC: "0x806df4", Frameless: true}]
+        - ID: 111
+          Type: 517 EventRootType Probe[main.testInlinedSq]
+          InjectionPoints: [{PC: "0x807784", Frameless: true}]
           Condition: null
     - id: testInlinedSumArray
       version: 0
@@ -440,14 +542,14 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 104}
+      subprogram: {subprogram: 112}
       events:
-        - ID: 104
-          Type: 385 EventRootType Probe[main.testInlinedSumArray]
+        - ID: 112
+          Type: 518 EventRootType Probe[main.testInlinedSumArray]
           InjectionPoints:
-            - PC: "0x806e24"
+            - PC: "0x8077b4"
               Frameless: false
-            - PC: "0x806eac"
+            - PC: "0x80783c"
               Frameless: false
           Condition: null
     - id: testInt16Array
@@ -461,8 +563,8 @@ Probes:
       subprogram: {subprogram: 7}
       events:
         - ID: 7
-          Type: 288 EventRootType Probe[main.testInt16Array]
-          InjectionPoints: [{PC: "0x805ee0", Frameless: true}]
+          Type: 413 EventRootType Probe[main.testInt16Array]
+          InjectionPoints: [{PC: "0x8062e0", Frameless: true}]
           Condition: null
     - id: testInt32Array
       version: 0
@@ -475,8 +577,8 @@ Probes:
       subprogram: {subprogram: 8}
       events:
         - ID: 8
-          Type: 289 EventRootType Probe[main.testInt32Array]
-          InjectionPoints: [{PC: "0x805ef0", Frameless: true}]
+          Type: 414 EventRootType Probe[main.testInt32Array]
+          InjectionPoints: [{PC: "0x8062f0", Frameless: true}]
           Condition: null
     - id: testInt64Array
       version: 0
@@ -489,8 +591,8 @@ Probes:
       subprogram: {subprogram: 9}
       events:
         - ID: 9
-          Type: 290 EventRootType Probe[main.testInt64Array]
-          InjectionPoints: [{PC: "0x805f00", Frameless: true}]
+          Type: 415 EventRootType Probe[main.testInt64Array]
+          InjectionPoints: [{PC: "0x806300", Frameless: true}]
           Condition: null
     - id: testInt8Array
       version: 0
@@ -503,8 +605,8 @@ Probes:
       subprogram: {subprogram: 6}
       events:
         - ID: 6
-          Type: 287 EventRootType Probe[main.testInt8Array]
-          InjectionPoints: [{PC: "0x805ed0", Frameless: true}]
+          Type: 412 EventRootType Probe[main.testInt8Array]
+          InjectionPoints: [{PC: "0x8062d0", Frameless: true}]
           Condition: null
     - id: testIntArray
       version: 0
@@ -517,8 +619,8 @@ Probes:
       subprogram: {subprogram: 5}
       events:
         - ID: 5
-          Type: 286 EventRootType Probe[main.testIntArray]
-          InjectionPoints: [{PC: "0x805ec0", Frameless: true}]
+          Type: 411 EventRootType Probe[main.testIntArray]
+          InjectionPoints: [{PC: "0x8062c0", Frameless: true}]
           Condition: null
     - id: testInterface
       version: 0
@@ -528,11 +630,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 44}
+      subprogram: {subprogram: 52}
       events:
-        - ID: 44
-          Type: 325 EventRootType Probe[main.testInterface]
-          InjectionPoints: [{PC: "0x80706c", Frameless: true}]
+        - ID: 52
+          Type: 458 EventRootType Probe[main.testInterface]
+          InjectionPoints: [{PC: "0x8079fc", Frameless: true}]
           Condition: null
     - id: testLinkedList
       version: 0
@@ -542,11 +644,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 71}
+      subprogram: {subprogram: 79}
       events:
-        - ID: 71
-          Type: 352 EventRootType Probe[main.testLinkedList]
-          InjectionPoints: [{PC: "0x808cb0", Frameless: true}]
+        - ID: 79
+          Type: 485 EventRootType Probe[main.testLinkedList]
+          InjectionPoints: [{PC: "0x809640", Frameless: true}]
           Condition: null
     - id: testMapArrayToArray
       version: 0
@@ -556,11 +658,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 51}
+      subprogram: {subprogram: 59}
       events:
-        - ID: 51
-          Type: 332 EventRootType Probe[main.testMapArrayToArray]
-          InjectionPoints: [{PC: "0x807510", Frameless: true}]
+        - ID: 59
+          Type: 465 EventRootType Probe[main.testMapArrayToArray]
+          InjectionPoints: [{PC: "0x807ea0", Frameless: true}]
           Condition: null
     - id: testMapEmbeddedMaps
       version: 0
@@ -570,11 +672,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 57}
+      subprogram: {subprogram: 65}
       events:
-        - ID: 57
-          Type: 338 EventRootType Probe[main.testMapEmbeddedMaps]
-          InjectionPoints: [{PC: "0x807570", Frameless: true}]
+        - ID: 65
+          Type: 471 EventRootType Probe[main.testMapEmbeddedMaps]
+          InjectionPoints: [{PC: "0x807f00", Frameless: true}]
           Condition: null
     - id: testMapIntToInt
       version: 0
@@ -584,11 +686,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 55}
+      subprogram: {subprogram: 63}
       events:
-        - ID: 55
-          Type: 336 EventRootType Probe[main.testMapIntToInt]
-          InjectionPoints: [{PC: "0x807550", Frameless: true}]
+        - ID: 63
+          Type: 469 EventRootType Probe[main.testMapIntToInt]
+          InjectionPoints: [{PC: "0x807ee0", Frameless: true}]
           Condition: null
     - id: testMapLargeKeyLargeValue
       version: 0
@@ -598,11 +700,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 66}
+      subprogram: {subprogram: 74}
       events:
-        - ID: 66
-          Type: 347 EventRootType Probe[main.testMapLargeKeyLargeValue]
-          InjectionPoints: [{PC: "0x807600", Frameless: true}]
+        - ID: 74
+          Type: 480 EventRootType Probe[main.testMapLargeKeyLargeValue]
+          InjectionPoints: [{PC: "0x807f90", Frameless: true}]
           Condition: null
     - id: testMapLargeKeySmallValue
       version: 0
@@ -612,11 +714,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 65}
+      subprogram: {subprogram: 73}
       events:
-        - ID: 65
-          Type: 346 EventRootType Probe[main.testMapLargeKeySmallValue]
-          InjectionPoints: [{PC: "0x8075f0", Frameless: true}]
+        - ID: 73
+          Type: 479 EventRootType Probe[main.testMapLargeKeySmallValue]
+          InjectionPoints: [{PC: "0x807f80", Frameless: true}]
           Condition: null
     - id: testMapMassive
       version: 0
@@ -626,11 +728,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 56}
+      subprogram: {subprogram: 64}
       events:
-        - ID: 56
-          Type: 337 EventRootType Probe[main.testMapMassive]
-          InjectionPoints: [{PC: "0x807560", Frameless: true}]
+        - ID: 64
+          Type: 470 EventRootType Probe[main.testMapMassive]
+          InjectionPoints: [{PC: "0x807ef0", Frameless: true}]
           Condition: null
     - id: testMapSmallKeyLargeValue
       version: 0
@@ -640,11 +742,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 64}
+      subprogram: {subprogram: 72}
       events:
-        - ID: 64
-          Type: 345 EventRootType Probe[main.testMapSmallKeyLargeValue]
-          InjectionPoints: [{PC: "0x8075e0", Frameless: true}]
+        - ID: 72
+          Type: 478 EventRootType Probe[main.testMapSmallKeyLargeValue]
+          InjectionPoints: [{PC: "0x807f70", Frameless: true}]
           Condition: null
     - id: testMapSmallKeySmallValue
       version: 0
@@ -654,11 +756,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 63}
+      subprogram: {subprogram: 71}
       events:
-        - ID: 63
-          Type: 344 EventRootType Probe[main.testMapSmallKeySmallValue]
-          InjectionPoints: [{PC: "0x8075d0", Frameless: true}]
+        - ID: 71
+          Type: 477 EventRootType Probe[main.testMapSmallKeySmallValue]
+          InjectionPoints: [{PC: "0x807f60", Frameless: true}]
           Condition: null
     - id: testMapStringToInt
       version: 0
@@ -668,11 +770,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 49}
+      subprogram: {subprogram: 57}
       events:
-        - ID: 49
-          Type: 330 EventRootType Probe[main.testMapStringToInt]
-          InjectionPoints: [{PC: "0x8074f0", Frameless: true}]
+        - ID: 57
+          Type: 463 EventRootType Probe[main.testMapStringToInt]
+          InjectionPoints: [{PC: "0x807e80", Frameless: true}]
           Condition: null
     - id: testMapStringToSlice
       version: 0
@@ -682,11 +784,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 50}
+      subprogram: {subprogram: 58}
       events:
-        - ID: 50
-          Type: 331 EventRootType Probe[main.testMapStringToSlice]
-          InjectionPoints: [{PC: "0x807500", Frameless: true}]
+        - ID: 58
+          Type: 464 EventRootType Probe[main.testMapStringToSlice]
+          InjectionPoints: [{PC: "0x807e90", Frameless: true}]
           Condition: null
     - id: testMapStringToStruct
       version: 0
@@ -696,11 +798,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 48}
+      subprogram: {subprogram: 56}
       events:
-        - ID: 48
-          Type: 329 EventRootType Probe[main.testMapStringToStruct]
-          InjectionPoints: [{PC: "0x8074e0", Frameless: true}]
+        - ID: 56
+          Type: 462 EventRootType Probe[main.testMapStringToStruct]
+          InjectionPoints: [{PC: "0x807e70", Frameless: true}]
           Condition: null
     - id: testMapWithLinkedList
       version: 0
@@ -710,11 +812,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 58}
+      subprogram: {subprogram: 66}
       events:
-        - ID: 58
-          Type: 339 EventRootType Probe[main.testMapWithLinkedList]
-          InjectionPoints: [{PC: "0x807580", Frameless: true}]
+        - ID: 66
+          Type: 472 EventRootType Probe[main.testMapWithLinkedList]
+          InjectionPoints: [{PC: "0x807f10", Frameless: true}]
           Condition: null
     - id: testMapWithSmallKeyAndValue
       version: 0
@@ -724,11 +826,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 61}
+      subprogram: {subprogram: 69}
       events:
-        - ID: 61
-          Type: 342 EventRootType Probe[main.testMapWithSmallKeyAndValue]
-          InjectionPoints: [{PC: "0x8075b0", Frameless: true}]
+        - ID: 69
+          Type: 475 EventRootType Probe[main.testMapWithSmallKeyAndValue]
+          InjectionPoints: [{PC: "0x807f40", Frameless: true}]
           Condition: null
     - id: testMapWithSmallKeyAndValueMassive
       version: 0
@@ -738,11 +840,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 62}
+      subprogram: {subprogram: 70}
       events:
-        - ID: 62
-          Type: 343 EventRootType Probe[main.testMapWithSmallKeyAndValueMassive]
-          InjectionPoints: [{PC: "0x8075c0", Frameless: true}]
+        - ID: 70
+          Type: 476 EventRootType Probe[main.testMapWithSmallKeyAndValueMassive]
+          InjectionPoints: [{PC: "0x807f50", Frameless: true}]
           Condition: null
     - id: testMapWithSmallValue
       version: 0
@@ -752,11 +854,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 59}
+      subprogram: {subprogram: 67}
       events:
-        - ID: 59
-          Type: 340 EventRootType Probe[main.testMapWithSmallValue]
-          InjectionPoints: [{PC: "0x807590", Frameless: true}]
+        - ID: 67
+          Type: 473 EventRootType Probe[main.testMapWithSmallValue]
+          InjectionPoints: [{PC: "0x807f20", Frameless: true}]
           Condition: null
     - id: testMapWithSmallValueMassive
       version: 0
@@ -766,11 +868,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 60}
+      subprogram: {subprogram: 68}
       events:
-        - ID: 60
-          Type: 341 EventRootType Probe[main.testMapWithSmallValueMassive]
-          InjectionPoints: [{PC: "0x8075a0", Frameless: true}]
+        - ID: 68
+          Type: 474 EventRootType Probe[main.testMapWithSmallValueMassive]
+          InjectionPoints: [{PC: "0x807f30", Frameless: true}]
           Condition: null
     - id: testMassiveString
       version: 0
@@ -780,11 +882,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 94}
+      subprogram: {subprogram: 102}
       events:
-        - ID: 94
-          Type: 375 EventRootType Probe[main.testMassiveString]
-          InjectionPoints: [{PC: "0x809520", Frameless: true}]
+        - ID: 102
+          Type: 508 EventRootType Probe[main.testMassiveString]
+          InjectionPoints: [{PC: "0x809eb0", Frameless: true}]
           Condition: null
     - id: testMultipleSimpleParams
       version: 0
@@ -794,11 +896,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 68}
+      subprogram: {subprogram: 76}
       events:
-        - ID: 68
-          Type: 349 EventRootType Probe[main.testMultipleSimpleParams]
-          InjectionPoints: [{PC: "0x808980", Frameless: true}]
+        - ID: 76
+          Type: 482 EventRootType Probe[main.testMultipleSimpleParams]
+          InjectionPoints: [{PC: "0x809310", Frameless: true}]
           Condition: null
     - id: testNilPointer
       version: 0
@@ -808,11 +910,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 76}
+      subprogram: {subprogram: 84}
       events:
-        - ID: 76
-          Type: 357 EventRootType Probe[main.testNilPointer]
-          InjectionPoints: [{PC: "0x808d80", Frameless: true}]
+        - ID: 84
+          Type: 490 EventRootType Probe[main.testNilPointer]
+          InjectionPoints: [{PC: "0x809710", Frameless: true}]
           Condition: null
     - id: testNilSlice
       version: 0
@@ -822,11 +924,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 86}
+      subprogram: {subprogram: 94}
       events:
-        - ID: 86
-          Type: 367 EventRootType Probe[main.testNilSlice]
-          InjectionPoints: [{PC: "0x8091c0", Frameless: true}]
+        - ID: 94
+          Type: 500 EventRootType Probe[main.testNilSlice]
+          InjectionPoints: [{PC: "0x809b50", Frameless: true}]
           Condition: null
     - id: testNilSliceOfStructs
       version: 0
@@ -836,11 +938,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 83}
+      subprogram: {subprogram: 91}
       events:
-        - ID: 83
-          Type: 364 EventRootType Probe[main.testNilSliceOfStructs]
-          InjectionPoints: [{PC: "0x809190", Frameless: true}]
+        - ID: 91
+          Type: 497 EventRootType Probe[main.testNilSliceOfStructs]
+          InjectionPoints: [{PC: "0x809b20", Frameless: true}]
           Condition: null
     - id: testNilSliceWithOtherParams
       version: 0
@@ -850,11 +952,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 85}
+      subprogram: {subprogram: 93}
       events:
-        - ID: 85
-          Type: 366 EventRootType Probe[main.testNilSliceWithOtherParams]
-          InjectionPoints: [{PC: "0x8091b0", Frameless: true}]
+        - ID: 93
+          Type: 499 EventRootType Probe[main.testNilSliceWithOtherParams]
+          InjectionPoints: [{PC: "0x809b40", Frameless: true}]
           Condition: null
     - id: testOneStringInStructPointer
       version: 0
@@ -864,11 +966,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 93}
+      subprogram: {subprogram: 101}
       events:
-        - ID: 93
-          Type: 374 EventRootType Probe[main.testOneStringInStructPointer]
-          InjectionPoints: [{PC: "0x809510", Frameless: true}]
+        - ID: 101
+          Type: 507 EventRootType Probe[main.testOneStringInStructPointer]
+          InjectionPoints: [{PC: "0x809ea0", Frameless: true}]
           Condition: null
     - id: testPointerLoop
       version: 0
@@ -878,11 +980,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 72}
+      subprogram: {subprogram: 80}
       events:
-        - ID: 72
-          Type: 353 EventRootType Probe[main.testPointerLoop]
-          InjectionPoints: [{PC: "0x808cc0", Frameless: true}]
+        - ID: 80
+          Type: 486 EventRootType Probe[main.testPointerLoop]
+          InjectionPoints: [{PC: "0x809650", Frameless: true}]
           Condition: null
     - id: testPointerToMap
       version: 0
@@ -892,11 +994,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 54}
+      subprogram: {subprogram: 62}
       events:
-        - ID: 54
-          Type: 335 EventRootType Probe[main.testPointerToMap]
-          InjectionPoints: [{PC: "0x807540", Frameless: true}]
+        - ID: 62
+          Type: 468 EventRootType Probe[main.testPointerToMap]
+          InjectionPoints: [{PC: "0x807ed0", Frameless: true}]
           Condition: null
     - id: testPointerToSimpleStruct
       version: 0
@@ -906,11 +1008,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 70}
+      subprogram: {subprogram: 78}
       events:
-        - ID: 70
-          Type: 351 EventRootType Probe[main.testPointerToSimpleStruct]
-          InjectionPoints: [{PC: "0x808ca0", Frameless: true}]
+        - ID: 78
+          Type: 484 EventRootType Probe[main.testPointerToSimpleStruct]
+          InjectionPoints: [{PC: "0x809630", Frameless: true}]
           Condition: null
     - id: testRuneArray
       version: 0
@@ -923,8 +1025,8 @@ Probes:
       subprogram: {subprogram: 2}
       events:
         - ID: 2
-          Type: 283 EventRootType Probe[main.testRuneArray]
-          InjectionPoints: [{PC: "0x805e90", Frameless: true}]
+          Type: 408 EventRootType Probe[main.testRuneArray]
+          InjectionPoints: [{PC: "0x806290", Frameless: true}]
           Condition: null
     - id: testSingleBool
       version: 0
@@ -937,8 +1039,8 @@ Probes:
       subprogram: {subprogram: 21}
       events:
         - ID: 21
-          Type: 302 EventRootType Probe[main.testSingleBool]
-          InjectionPoints: [{PC: "0x806300", Frameless: true}]
+          Type: 427 EventRootType Probe[main.testSingleBool]
+          InjectionPoints: [{PC: "0x806700", Frameless: true}]
           Condition: null
     - id: testSingleByte
       version: 0
@@ -951,8 +1053,8 @@ Probes:
       subprogram: {subprogram: 19}
       events:
         - ID: 19
-          Type: 300 EventRootType Probe[main.testSingleByte]
-          InjectionPoints: [{PC: "0x8062e0", Frameless: true}]
+          Type: 425 EventRootType Probe[main.testSingleByte]
+          InjectionPoints: [{PC: "0x8066e0", Frameless: true}]
           Condition: null
     - id: testSingleFloat32
       version: 0
@@ -965,8 +1067,8 @@ Probes:
       subprogram: {subprogram: 32}
       events:
         - ID: 32
-          Type: 313 EventRootType Probe[main.testSingleFloat32]
-          InjectionPoints: [{PC: "0x8063b0", Frameless: true}]
+          Type: 438 EventRootType Probe[main.testSingleFloat32]
+          InjectionPoints: [{PC: "0x8067b0", Frameless: true}]
           Condition: null
     - id: testSingleFloat64
       version: 0
@@ -979,8 +1081,8 @@ Probes:
       subprogram: {subprogram: 33}
       events:
         - ID: 33
-          Type: 314 EventRootType Probe[main.testSingleFloat64]
-          InjectionPoints: [{PC: "0x8063c0", Frameless: true}]
+          Type: 439 EventRootType Probe[main.testSingleFloat64]
+          InjectionPoints: [{PC: "0x8067c0", Frameless: true}]
           Condition: null
     - id: testSingleInt
       version: 0
@@ -993,8 +1095,8 @@ Probes:
       subprogram: {subprogram: 22}
       events:
         - ID: 22
-          Type: 303 EventRootType Probe[main.testSingleInt]
-          InjectionPoints: [{PC: "0x806310", Frameless: true}]
+          Type: 428 EventRootType Probe[main.testSingleInt]
+          InjectionPoints: [{PC: "0x806710", Frameless: true}]
           Condition: null
     - id: testSingleInt16
       version: 0
@@ -1007,8 +1109,8 @@ Probes:
       subprogram: {subprogram: 24}
       events:
         - ID: 24
-          Type: 305 EventRootType Probe[main.testSingleInt16]
-          InjectionPoints: [{PC: "0x806330", Frameless: true}]
+          Type: 430 EventRootType Probe[main.testSingleInt16]
+          InjectionPoints: [{PC: "0x806730", Frameless: true}]
           Condition: null
     - id: testSingleInt32
       version: 0
@@ -1021,8 +1123,8 @@ Probes:
       subprogram: {subprogram: 25}
       events:
         - ID: 25
-          Type: 306 EventRootType Probe[main.testSingleInt32]
-          InjectionPoints: [{PC: "0x806340", Frameless: true}]
+          Type: 431 EventRootType Probe[main.testSingleInt32]
+          InjectionPoints: [{PC: "0x806740", Frameless: true}]
           Condition: null
     - id: testSingleInt64
       version: 0
@@ -1035,8 +1137,8 @@ Probes:
       subprogram: {subprogram: 26}
       events:
         - ID: 26
-          Type: 307 EventRootType Probe[main.testSingleInt64]
-          InjectionPoints: [{PC: "0x806350", Frameless: true}]
+          Type: 432 EventRootType Probe[main.testSingleInt64]
+          InjectionPoints: [{PC: "0x806750", Frameless: true}]
           Condition: null
     - id: testSingleInt8
       version: 0
@@ -1049,8 +1151,8 @@ Probes:
       subprogram: {subprogram: 23}
       events:
         - ID: 23
-          Type: 304 EventRootType Probe[main.testSingleInt8]
-          InjectionPoints: [{PC: "0x806320", Frameless: true}]
+          Type: 429 EventRootType Probe[main.testSingleInt8]
+          InjectionPoints: [{PC: "0x806720", Frameless: true}]
           Condition: null
     - id: testSingleRune
       version: 0
@@ -1063,8 +1165,8 @@ Probes:
       subprogram: {subprogram: 20}
       events:
         - ID: 20
-          Type: 301 EventRootType Probe[main.testSingleRune]
-          InjectionPoints: [{PC: "0x8062f0", Frameless: true}]
+          Type: 426 EventRootType Probe[main.testSingleRune]
+          InjectionPoints: [{PC: "0x8066f0", Frameless: true}]
           Condition: null
     - id: testSingleString
       version: 0
@@ -1074,11 +1176,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 89}
+      subprogram: {subprogram: 97}
       events:
-        - ID: 89
-          Type: 370 EventRootType Probe[main.testSingleString]
-          InjectionPoints: [{PC: "0x8094d0", Frameless: true}]
+        - ID: 97
+          Type: 503 EventRootType Probe[main.testSingleString]
+          InjectionPoints: [{PC: "0x809e60", Frameless: true}]
           Condition: null
     - id: testSingleUint
       version: 0
@@ -1091,8 +1193,8 @@ Probes:
       subprogram: {subprogram: 27}
       events:
         - ID: 27
-          Type: 308 EventRootType Probe[main.testSingleUint]
-          InjectionPoints: [{PC: "0x806360", Frameless: true}]
+          Type: 433 EventRootType Probe[main.testSingleUint]
+          InjectionPoints: [{PC: "0x806760", Frameless: true}]
           Condition: null
     - id: testSingleUint16
       version: 0
@@ -1105,8 +1207,8 @@ Probes:
       subprogram: {subprogram: 29}
       events:
         - ID: 29
-          Type: 310 EventRootType Probe[main.testSingleUint16]
-          InjectionPoints: [{PC: "0x806380", Frameless: true}]
+          Type: 435 EventRootType Probe[main.testSingleUint16]
+          InjectionPoints: [{PC: "0x806780", Frameless: true}]
           Condition: null
     - id: testSingleUint32
       version: 0
@@ -1119,8 +1221,8 @@ Probes:
       subprogram: {subprogram: 30}
       events:
         - ID: 30
-          Type: 311 EventRootType Probe[main.testSingleUint32]
-          InjectionPoints: [{PC: "0x806390", Frameless: true}]
+          Type: 436 EventRootType Probe[main.testSingleUint32]
+          InjectionPoints: [{PC: "0x806790", Frameless: true}]
           Condition: null
     - id: testSingleUint64
       version: 0
@@ -1133,8 +1235,8 @@ Probes:
       subprogram: {subprogram: 31}
       events:
         - ID: 31
-          Type: 312 EventRootType Probe[main.testSingleUint64]
-          InjectionPoints: [{PC: "0x8063a0", Frameless: true}]
+          Type: 437 EventRootType Probe[main.testSingleUint64]
+          InjectionPoints: [{PC: "0x8067a0", Frameless: true}]
           Condition: null
     - id: testSingleUint8
       version: 0
@@ -1147,8 +1249,8 @@ Probes:
       subprogram: {subprogram: 28}
       events:
         - ID: 28
-          Type: 309 EventRootType Probe[main.testSingleUint8]
-          InjectionPoints: [{PC: "0x806370", Frameless: true}]
+          Type: 434 EventRootType Probe[main.testSingleUint8]
+          InjectionPoints: [{PC: "0x806770", Frameless: true}]
           Condition: null
     - id: testSliceOfSlices
       version: 0
@@ -1158,11 +1260,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 80}
+      subprogram: {subprogram: 88}
       events:
-        - ID: 80
-          Type: 361 EventRootType Probe[main.testSliceOfSlices]
-          InjectionPoints: [{PC: "0x809160", Frameless: true}]
+        - ID: 88
+          Type: 494 EventRootType Probe[main.testSliceOfSlices]
+          InjectionPoints: [{PC: "0x809af0", Frameless: true}]
           Condition: null
     - id: testSmallMap
       version: 0
@@ -1172,11 +1274,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 52}
+      subprogram: {subprogram: 60}
       events:
-        - ID: 52
-          Type: 333 EventRootType Probe[main.testSmallMap]
-          InjectionPoints: [{PC: "0x807520", Frameless: true}]
+        - ID: 60
+          Type: 466 EventRootType Probe[main.testSmallMap]
+          InjectionPoints: [{PC: "0x807eb0", Frameless: true}]
           Condition: null
     - id: testStringArray
       version: 0
@@ -1189,8 +1291,8 @@ Probes:
       subprogram: {subprogram: 3}
       events:
         - ID: 3
-          Type: 284 EventRootType Probe[main.testStringArray]
-          InjectionPoints: [{PC: "0x805ea0", Frameless: true}]
+          Type: 409 EventRootType Probe[main.testStringArray]
+          InjectionPoints: [{PC: "0x8062a0", Frameless: true}]
           Condition: null
     - id: testStringPointer
       version: 0
@@ -1200,11 +1302,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 75}
+      subprogram: {subprogram: 83}
       events:
-        - ID: 75
-          Type: 356 EventRootType Probe[main.testStringPointer]
-          InjectionPoints: [{PC: "0x808d60", Frameless: true}]
+        - ID: 83
+          Type: 489 EventRootType Probe[main.testStringPointer]
+          InjectionPoints: [{PC: "0x8096f0", Frameless: true}]
           Condition: null
     - id: testStringSlice
       version: 0
@@ -1214,11 +1316,45 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 84}
+      subprogram: {subprogram: 92}
       events:
-        - ID: 84
-          Type: 365 EventRootType Probe[main.testStringSlice]
-          InjectionPoints: [{PC: "0x8091a0", Frameless: true}]
+        - ID: 92
+          Type: 498 EventRootType Probe[main.testStringSlice]
+          InjectionPoints: [{PC: "0x809b30", Frameless: true}]
+          Condition: null
+    - id: testStringType1
+      version: 0
+      type: LOG_PROBE
+      where: {methodName: main.testStringType1}
+      capture:
+        maxReferenceDepth: 1
+        maxFieldCount: 0
+        maxCollectionSize: 0
+      template: ""
+      segments: []
+      captureSnapshot: true
+      subprogram: {subprogram: 42}
+      events:
+        - ID: 42
+          Type: 448 EventRootType Probe[main.testStringType1]
+          InjectionPoints: [{PC: "0x806c90", Frameless: true}]
+          Condition: null
+    - id: testStringType2
+      version: 0
+      type: LOG_PROBE
+      where: {methodName: main.testStringType2}
+      capture:
+        maxReferenceDepth: 1
+        maxFieldCount: 0
+        maxCollectionSize: 0
+      template: ""
+      segments: []
+      captureSnapshot: true
+      subprogram: {subprogram: 43}
+      events:
+        - ID: 43
+          Type: 449 EventRootType Probe[main.testStringType2]
+          InjectionPoints: [{PC: "0x806ca0", Frameless: true}]
           Condition: null
     - id: testStruct
       version: 0
@@ -1228,11 +1364,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 97}
+      subprogram: {subprogram: 105}
       events:
-        - ID: 97
-          Type: 378 EventRootType Probe[main.testStruct]
-          InjectionPoints: [{PC: "0x809710", Frameless: true}]
+        - ID: 105
+          Type: 511 EventRootType Probe[main.testStruct]
+          InjectionPoints: [{PC: "0x80a0a0", Frameless: true}]
           Condition: null
     - id: testStructSlice
       version: 0
@@ -1242,11 +1378,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 81}
+      subprogram: {subprogram: 89}
       events:
-        - ID: 81
-          Type: 362 EventRootType Probe[main.testStructSlice]
-          InjectionPoints: [{PC: "0x809170", Frameless: true}]
+        - ID: 89
+          Type: 495 EventRootType Probe[main.testStructSlice]
+          InjectionPoints: [{PC: "0x809b00", Frameless: true}]
           Condition: null
     - id: testStructWithMap
       version: 0
@@ -1256,11 +1392,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 47}
+      subprogram: {subprogram: 55}
       events:
-        - ID: 47
-          Type: 328 EventRootType Probe[main.testStructWithMap]
-          InjectionPoints: [{PC: "0x8074d0", Frameless: true}]
+        - ID: 55
+          Type: 461 EventRootType Probe[main.testStructWithMap]
+          InjectionPoints: [{PC: "0x807e60", Frameless: true}]
           Condition: null
     - id: testThreeStrings
       version: 0
@@ -1270,11 +1406,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 90}
+      subprogram: {subprogram: 98}
       events:
-        - ID: 90
-          Type: 371 EventRootType Probe[main.testThreeStrings]
-          InjectionPoints: [{PC: "0x8094e0", Frameless: true}]
+        - ID: 98
+          Type: 504 EventRootType Probe[main.testThreeStrings]
+          InjectionPoints: [{PC: "0x809e70", Frameless: true}]
           Condition: null
     - id: testThreeStringsInStruct
       version: 0
@@ -1284,11 +1420,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 91}
+      subprogram: {subprogram: 99}
       events:
-        - ID: 91
-          Type: 372 EventRootType Probe[main.testThreeStringsInStruct]
-          InjectionPoints: [{PC: "0x8094f0", Frameless: true}]
+        - ID: 99
+          Type: 505 EventRootType Probe[main.testThreeStringsInStruct]
+          InjectionPoints: [{PC: "0x809e80", Frameless: true}]
           Condition: null
     - id: testThreeStringsInStructPointer
       version: 0
@@ -1298,11 +1434,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 92}
+      subprogram: {subprogram: 100}
       events:
-        - ID: 92
-          Type: 373 EventRootType Probe[main.testThreeStringsInStructPointer]
-          InjectionPoints: [{PC: "0x809500", Frameless: true}]
+        - ID: 100
+          Type: 506 EventRootType Probe[main.testThreeStringsInStructPointer]
+          InjectionPoints: [{PC: "0x809e90", Frameless: true}]
           Condition: null
     - id: testTypeAlias
       version: 0
@@ -1315,8 +1451,8 @@ Probes:
       subprogram: {subprogram: 34}
       events:
         - ID: 34
-          Type: 315 EventRootType Probe[main.testTypeAlias]
-          InjectionPoints: [{PC: "0x8063d0", Frameless: true}]
+          Type: 440 EventRootType Probe[main.testTypeAlias]
+          InjectionPoints: [{PC: "0x8067d0", Frameless: true}]
           Condition: null
     - id: testUint16Array
       version: 0
@@ -1329,8 +1465,8 @@ Probes:
       subprogram: {subprogram: 12}
       events:
         - ID: 12
-          Type: 293 EventRootType Probe[main.testUint16Array]
-          InjectionPoints: [{PC: "0x805f30", Frameless: true}]
+          Type: 418 EventRootType Probe[main.testUint16Array]
+          InjectionPoints: [{PC: "0x806330", Frameless: true}]
           Condition: null
     - id: testUint32Array
       version: 0
@@ -1343,8 +1479,8 @@ Probes:
       subprogram: {subprogram: 13}
       events:
         - ID: 13
-          Type: 294 EventRootType Probe[main.testUint32Array]
-          InjectionPoints: [{PC: "0x805f40", Frameless: true}]
+          Type: 419 EventRootType Probe[main.testUint32Array]
+          InjectionPoints: [{PC: "0x806340", Frameless: true}]
           Condition: null
     - id: testUint64Array
       version: 0
@@ -1357,8 +1493,8 @@ Probes:
       subprogram: {subprogram: 14}
       events:
         - ID: 14
-          Type: 295 EventRootType Probe[main.testUint64Array]
-          InjectionPoints: [{PC: "0x805f50", Frameless: true}]
+          Type: 420 EventRootType Probe[main.testUint64Array]
+          InjectionPoints: [{PC: "0x806350", Frameless: true}]
           Condition: null
     - id: testUint8Array
       version: 0
@@ -1371,8 +1507,8 @@ Probes:
       subprogram: {subprogram: 11}
       events:
         - ID: 11
-          Type: 292 EventRootType Probe[main.testUint8Array]
-          InjectionPoints: [{PC: "0x805f20", Frameless: true}]
+          Type: 417 EventRootType Probe[main.testUint8Array]
+          InjectionPoints: [{PC: "0x806320", Frameless: true}]
           Condition: null
     - id: testUintArray
       version: 0
@@ -1385,8 +1521,8 @@ Probes:
       subprogram: {subprogram: 10}
       events:
         - ID: 10
-          Type: 291 EventRootType Probe[main.testUintArray]
-          InjectionPoints: [{PC: "0x805f10", Frameless: true}]
+          Type: 416 EventRootType Probe[main.testUintArray]
+          InjectionPoints: [{PC: "0x806310", Frameless: true}]
           Condition: null
     - id: testUintPointer
       version: 0
@@ -1396,11 +1532,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 74}
+      subprogram: {subprogram: 82}
       events:
-        - ID: 74
-          Type: 355 EventRootType Probe[main.testUintPointer]
-          InjectionPoints: [{PC: "0x808cf0", Frameless: true}]
+        - ID: 82
+          Type: 488 EventRootType Probe[main.testUintPointer]
+          InjectionPoints: [{PC: "0x809680", Frameless: true}]
           Condition: null
     - id: testUintSlice
       version: 0
@@ -1410,11 +1546,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 78}
+      subprogram: {subprogram: 86}
       events:
-        - ID: 78
-          Type: 359 EventRootType Probe[main.testUintSlice]
-          InjectionPoints: [{PC: "0x809140", Frameless: true}]
+        - ID: 86
+          Type: 492 EventRootType Probe[main.testUintSlice]
+          InjectionPoints: [{PC: "0x809ad0", Frameless: true}]
           Condition: null
     - id: testUnitializedString
       version: 0
@@ -1424,11 +1560,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 95}
+      subprogram: {subprogram: 103}
       events:
-        - ID: 95
-          Type: 376 EventRootType Probe[main.testUnitializedString]
-          InjectionPoints: [{PC: "0x809530", Frameless: true}]
+        - ID: 103
+          Type: 509 EventRootType Probe[main.testUnitializedString]
+          InjectionPoints: [{PC: "0x809ec0", Frameless: true}]
           Condition: null
     - id: testUnsafePointer
       version: 0
@@ -1438,11 +1574,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 73}
+      subprogram: {subprogram: 81}
       events:
-        - ID: 73
-          Type: 354 EventRootType Probe[main.testUnsafePointer]
-          InjectionPoints: [{PC: "0x808cd0", Frameless: true}]
+        - ID: 81
+          Type: 487 EventRootType Probe[main.testUnsafePointer]
+          InjectionPoints: [{PC: "0x809660", Frameless: true}]
           Condition: null
     - id: testVeryLargeArray
       version: 0
@@ -1455,8 +1591,8 @@ Probes:
       subprogram: {subprogram: 18}
       events:
         - ID: 18
-          Type: 299 EventRootType Probe[main.testVeryLargeArray]
-          InjectionPoints: [{PC: "0x805fb0", Frameless: true}]
+          Type: 424 EventRootType Probe[main.testVeryLargeArray]
+          InjectionPoints: [{PC: "0x8063b0", Frameless: true}]
           Condition: null
     - id: testVeryLargeSlice
       version: 0
@@ -1466,430 +1602,430 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 87}
+      subprogram: {subprogram: 95}
       events:
-        - ID: 87
-          Type: 368 EventRootType Probe[main.testVeryLargeSlice]
-          InjectionPoints: [{PC: "0x8091d0", Frameless: true}]
+        - ID: 95
+          Type: 501 EventRootType Probe[main.testVeryLargeSlice]
+          InjectionPoints: [{PC: "0x809b60", Frameless: true}]
           Condition: null
 Subprograms:
     - ID: 1
       Name: main.testByteArray
-      OutOfLinePCRanges: [0x805e80..0x805e90]
+      OutOfLinePCRanges: [0x806280..0x806290]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 36 ArrayType [2]uint8
           Locations:
-            - Range: 0x805e80..0x805e90
+            - Range: 0x806280..0x806290
               Pieces: [{Size: 2, Op: {CfaOffset: 8}}]
           IsParameter: true
           IsReturn: false
     - ID: 2
       Name: main.testRuneArray
-      OutOfLinePCRanges: [0x805e90..0x805ea0]
+      OutOfLinePCRanges: [0x806290..0x8062a0]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 37 ArrayType [2]int32
           Locations:
-            - Range: 0x805e90..0x805ea0
+            - Range: 0x806290..0x8062a0
               Pieces: [{Size: 8, Op: {CfaOffset: 8}}]
           IsParameter: true
           IsReturn: false
     - ID: 3
       Name: main.testStringArray
-      OutOfLinePCRanges: [0x805ea0..0x805eb0]
+      OutOfLinePCRanges: [0x8062a0..0x8062b0]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 38 ArrayType [2]string
           Locations:
-            - Range: 0x805ea0..0x805eb0
+            - Range: 0x8062a0..0x8062b0
               Pieces: [{Size: 32, Op: {CfaOffset: 8}}]
           IsParameter: true
           IsReturn: false
     - ID: 4
       Name: main.testBoolArray
-      OutOfLinePCRanges: [0x805eb0..0x805ec0]
+      OutOfLinePCRanges: [0x8062b0..0x8062c0]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 39 ArrayType [2]bool
           Locations:
-            - Range: 0x805eb0..0x805ec0
+            - Range: 0x8062b0..0x8062c0
               Pieces: [{Size: 2, Op: {CfaOffset: 8}}]
           IsParameter: true
           IsReturn: false
     - ID: 5
       Name: main.testIntArray
-      OutOfLinePCRanges: [0x805ec0..0x805ed0]
+      OutOfLinePCRanges: [0x8062c0..0x8062d0]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 40 ArrayType [2]int
           Locations:
-            - Range: 0x805ec0..0x805ed0
+            - Range: 0x8062c0..0x8062d0
               Pieces: [{Size: 16, Op: {CfaOffset: 8}}]
           IsParameter: true
           IsReturn: false
     - ID: 6
       Name: main.testInt8Array
-      OutOfLinePCRanges: [0x805ed0..0x805ee0]
+      OutOfLinePCRanges: [0x8062d0..0x8062e0]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 41 ArrayType [2]int8
           Locations:
-            - Range: 0x805ed0..0x805ee0
+            - Range: 0x8062d0..0x8062e0
               Pieces: [{Size: 2, Op: {CfaOffset: 8}}]
           IsParameter: true
           IsReturn: false
     - ID: 7
       Name: main.testInt16Array
-      OutOfLinePCRanges: [0x805ee0..0x805ef0]
+      OutOfLinePCRanges: [0x8062e0..0x8062f0]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 42 ArrayType [2]int16
           Locations:
-            - Range: 0x805ee0..0x805ef0
+            - Range: 0x8062e0..0x8062f0
               Pieces: [{Size: 4, Op: {CfaOffset: 8}}]
           IsParameter: true
           IsReturn: false
     - ID: 8
       Name: main.testInt32Array
-      OutOfLinePCRanges: [0x805ef0..0x805f00]
+      OutOfLinePCRanges: [0x8062f0..0x806300]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 37 ArrayType [2]int32
           Locations:
-            - Range: 0x805ef0..0x805f00
+            - Range: 0x8062f0..0x806300
               Pieces: [{Size: 8, Op: {CfaOffset: 8}}]
           IsParameter: true
           IsReturn: false
     - ID: 9
       Name: main.testInt64Array
-      OutOfLinePCRanges: [0x805f00..0x805f10]
+      OutOfLinePCRanges: [0x806300..0x806310]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 43 ArrayType [2]int64
           Locations:
-            - Range: 0x805f00..0x805f10
+            - Range: 0x806300..0x806310
               Pieces: [{Size: 16, Op: {CfaOffset: 8}}]
           IsParameter: true
           IsReturn: false
     - ID: 10
       Name: main.testUintArray
-      OutOfLinePCRanges: [0x805f10..0x805f20]
+      OutOfLinePCRanges: [0x806310..0x806320]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 44 ArrayType [2]uint
           Locations:
-            - Range: 0x805f10..0x805f20
+            - Range: 0x806310..0x806320
               Pieces: [{Size: 16, Op: {CfaOffset: 8}}]
           IsParameter: true
           IsReturn: false
     - ID: 11
       Name: main.testUint8Array
-      OutOfLinePCRanges: [0x805f20..0x805f30]
+      OutOfLinePCRanges: [0x806320..0x806330]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 36 ArrayType [2]uint8
           Locations:
-            - Range: 0x805f20..0x805f30
+            - Range: 0x806320..0x806330
               Pieces: [{Size: 2, Op: {CfaOffset: 8}}]
           IsParameter: true
           IsReturn: false
     - ID: 12
       Name: main.testUint16Array
-      OutOfLinePCRanges: [0x805f30..0x805f40]
+      OutOfLinePCRanges: [0x806330..0x806340]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 45 ArrayType [2]uint16
           Locations:
-            - Range: 0x805f30..0x805f40
+            - Range: 0x806330..0x806340
               Pieces: [{Size: 4, Op: {CfaOffset: 8}}]
           IsParameter: true
           IsReturn: false
     - ID: 13
       Name: main.testUint32Array
-      OutOfLinePCRanges: [0x805f40..0x805f50]
+      OutOfLinePCRanges: [0x806340..0x806350]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 46 ArrayType [2]uint32
           Locations:
-            - Range: 0x805f40..0x805f50
+            - Range: 0x806340..0x806350
               Pieces: [{Size: 8, Op: {CfaOffset: 8}}]
           IsParameter: true
           IsReturn: false
     - ID: 14
       Name: main.testUint64Array
-      OutOfLinePCRanges: [0x805f50..0x805f60]
+      OutOfLinePCRanges: [0x806350..0x806360]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 47 ArrayType [2]uint64
           Locations:
-            - Range: 0x805f50..0x805f60
+            - Range: 0x806350..0x806360
               Pieces: [{Size: 16, Op: {CfaOffset: 8}}]
           IsParameter: true
           IsReturn: false
     - ID: 15
       Name: main.testArrayOfArrays
-      OutOfLinePCRanges: [0x805f60..0x805f70]
+      OutOfLinePCRanges: [0x806360..0x806370]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 48 ArrayType [2][2]int
           Locations:
-            - Range: 0x805f60..0x805f70
+            - Range: 0x806360..0x806370
               Pieces: [{Size: 32, Op: {CfaOffset: 8}}]
           IsParameter: true
           IsReturn: false
     - ID: 16
       Name: main.testArrayOfStrings
-      OutOfLinePCRanges: [0x805f70..0x805f80]
+      OutOfLinePCRanges: [0x806370..0x806380]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 38 ArrayType [2]string
           Locations:
-            - Range: 0x805f70..0x805f80
+            - Range: 0x806370..0x806380
               Pieces: [{Size: 32, Op: {CfaOffset: 8}}]
           IsParameter: true
           IsReturn: false
     - ID: 17
       Name: main.testArrayOfArraysOfArrays
-      OutOfLinePCRanges: [0x805f80..0x805f90]
+      OutOfLinePCRanges: [0x806380..0x806390]
       InlinePCRanges: []
       Variables:
         - Name: b
           Type: 49 ArrayType [2][2][2]int
           Locations:
-            - Range: 0x805f80..0x805f90
+            - Range: 0x806380..0x806390
               Pieces: [{Size: 64, Op: {CfaOffset: 8}}]
           IsParameter: true
           IsReturn: false
     - ID: 18
       Name: main.testVeryLargeArray
-      OutOfLinePCRanges: [0x805fb0..0x805fc0]
+      OutOfLinePCRanges: [0x8063b0..0x8063c0]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 50 ArrayType [100]uint
           Locations:
-            - Range: 0x805fb0..0x805fc0
+            - Range: 0x8063b0..0x8063c0
               Pieces: [{Size: 800, Op: {CfaOffset: 8}}]
           IsParameter: true
           IsReturn: false
     - ID: 19
       Name: main.testSingleByte
-      OutOfLinePCRanges: [0x8062e0..0x8062f0]
+      OutOfLinePCRanges: [0x8066e0..0x8066f0]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 3 BaseType uint8
           Locations:
-            - Range: 0x8062e0..0x8062f0
+            - Range: 0x8066e0..0x8066f0
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
     - ID: 20
       Name: main.testSingleRune
-      OutOfLinePCRanges: [0x8062f0..0x806300]
+      OutOfLinePCRanges: [0x8066f0..0x806700]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 12 BaseType int32
           Locations:
-            - Range: 0x8062f0..0x806300
+            - Range: 0x8066f0..0x806700
               Pieces: [{Size: 4, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
     - ID: 21
       Name: main.testSingleBool
-      OutOfLinePCRanges: [0x806300..0x806310]
+      OutOfLinePCRanges: [0x806700..0x806710]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 4 BaseType bool
           Locations:
-            - Range: 0x806300..0x806310
+            - Range: 0x806700..0x806710
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
     - ID: 22
       Name: main.testSingleInt
-      OutOfLinePCRanges: [0x806310..0x806320]
+      OutOfLinePCRanges: [0x806710..0x806720]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 7 BaseType int
           Locations:
-            - Range: 0x806310..0x806320
+            - Range: 0x806710..0x806720
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
     - ID: 23
       Name: main.testSingleInt8
-      OutOfLinePCRanges: [0x806320..0x806330]
+      OutOfLinePCRanges: [0x806720..0x806730]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 17 BaseType int8
           Locations:
-            - Range: 0x806320..0x806330
+            - Range: 0x806720..0x806730
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
     - ID: 24
       Name: main.testSingleInt16
-      OutOfLinePCRanges: [0x806330..0x806340]
+      OutOfLinePCRanges: [0x806730..0x806740]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 23 BaseType int16
           Locations:
-            - Range: 0x806330..0x806340
+            - Range: 0x806730..0x806740
               Pieces: [{Size: 2, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
     - ID: 25
       Name: main.testSingleInt32
-      OutOfLinePCRanges: [0x806340..0x806350]
+      OutOfLinePCRanges: [0x806740..0x806750]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 12 BaseType int32
           Locations:
-            - Range: 0x806340..0x806350
+            - Range: 0x806740..0x806750
               Pieces: [{Size: 4, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
     - ID: 26
       Name: main.testSingleInt64
-      OutOfLinePCRanges: [0x806350..0x806360]
+      OutOfLinePCRanges: [0x806750..0x806760]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 13 BaseType int64
           Locations:
-            - Range: 0x806350..0x806360
+            - Range: 0x806750..0x806760
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
     - ID: 27
       Name: main.testSingleUint
-      OutOfLinePCRanges: [0x806360..0x806370]
+      OutOfLinePCRanges: [0x806760..0x806770]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 10 BaseType uint
           Locations:
-            - Range: 0x806360..0x806370
+            - Range: 0x806760..0x806770
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
     - ID: 28
       Name: main.testSingleUint8
-      OutOfLinePCRanges: [0x806370..0x806380]
+      OutOfLinePCRanges: [0x806770..0x806780]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 3 BaseType uint8
           Locations:
-            - Range: 0x806370..0x806380
+            - Range: 0x806770..0x806780
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
     - ID: 29
       Name: main.testSingleUint16
-      OutOfLinePCRanges: [0x806380..0x806390]
+      OutOfLinePCRanges: [0x806780..0x806790]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 6 BaseType uint16
           Locations:
-            - Range: 0x806380..0x806390
+            - Range: 0x806780..0x806790
               Pieces: [{Size: 2, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
     - ID: 30
       Name: main.testSingleUint32
-      OutOfLinePCRanges: [0x806390..0x8063a0]
+      OutOfLinePCRanges: [0x806790..0x8067a0]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 2 BaseType uint32
           Locations:
-            - Range: 0x806390..0x8063a0
+            - Range: 0x806790..0x8067a0
               Pieces: [{Size: 4, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
     - ID: 31
       Name: main.testSingleUint64
-      OutOfLinePCRanges: [0x8063a0..0x8063b0]
+      OutOfLinePCRanges: [0x8067a0..0x8067b0]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 8 BaseType uint64
           Locations:
-            - Range: 0x8063a0..0x8063b0
+            - Range: 0x8067a0..0x8067b0
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
     - ID: 32
       Name: main.testSingleFloat32
-      OutOfLinePCRanges: [0x8063b0..0x8063c0]
+      OutOfLinePCRanges: [0x8067b0..0x8067c0]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 18 BaseType float32
           Locations:
-            - Range: 0x8063b0..0x8063c0
+            - Range: 0x8067b0..0x8067c0
               Pieces: [{Size: 4, Op: {RegNo: 64, Shift: 0}}]
           IsParameter: true
           IsReturn: false
     - ID: 33
       Name: main.testSingleFloat64
-      OutOfLinePCRanges: [0x8063c0..0x8063d0]
+      OutOfLinePCRanges: [0x8067c0..0x8067d0]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 16 BaseType float64
           Locations:
-            - Range: 0x8063c0..0x8063d0
+            - Range: 0x8067c0..0x8067d0
               Pieces: [{Size: 8, Op: {RegNo: 64, Shift: 0}}]
           IsParameter: true
           IsReturn: false
     - ID: 34
       Name: main.testTypeAlias
-      OutOfLinePCRanges: [0x8063d0..0x8063e0]
+      OutOfLinePCRanges: [0x8067d0..0x8067e0]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 51 BaseType main.typeAlias
           Locations:
-            - Range: 0x8063d0..0x8063e0
+            - Range: 0x8067d0..0x8067e0
               Pieces: [{Size: 2, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
     - ID: 35
       Name: main.testBigStruct
-      OutOfLinePCRanges: [0x8064d0..0x8064e0]
+      OutOfLinePCRanges: [0x8068d0..0x8068e0]
       InlinePCRanges: []
       Variables:
         - Name: b
           Type: 52 StructureType main.bigStruct
           Locations:
-            - Range: 0x8064d0..0x8064e0
+            - Range: 0x8068d0..0x8068e0
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -1906,14 +2042,116 @@ Subprograms:
           IsParameter: true
           IsReturn: false
     - ID: 36
+      Name: main.testDeepPtr1
+      OutOfLinePCRanges: [0x806990..0x8069a0]
+      InlinePCRanges: []
+      Variables:
+        - Name: a
+          Type: 56 StructureType main.deepPtr1
+          Locations:
+            - Range: 0x806990..0x8069a0
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+          IsParameter: true
+          IsReturn: false
+    - ID: 37
+      Name: main.testDeepPtr7
+      OutOfLinePCRanges: [0x8069a0..0x8069b0]
+      InlinePCRanges: []
+      Variables:
+        - Name: a
+          Type: 59 PointerType *main.deepPtr7
+          Locations:
+            - Range: 0x8069a0..0x8069b0
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+          IsParameter: true
+          IsReturn: false
+    - ID: 38
+      Name: main.testDeepSlice1
+      OutOfLinePCRanges: [0x806b10..0x806b20]
+      InlinePCRanges: []
+      Variables:
+        - Name: a
+          Type: 61 StructureType main.deepSlice1
+          Locations:
+            - Range: 0x806b10..0x806b20
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 0, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 1, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 2, Shift: 0}
+          IsParameter: true
+          IsReturn: false
+    - ID: 39
+      Name: main.testDeepSlice7
+      OutOfLinePCRanges: [0x806b20..0x806b30]
+      InlinePCRanges: []
+      Variables:
+        - Name: a
+          Type: 65 PointerType *main.deepSlice7
+          Locations:
+            - Range: 0x806b20..0x806b30
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+          IsParameter: true
+          IsReturn: false
+    - ID: 40
+      Name: main.testDeepMap1
+      OutOfLinePCRanges: [0x806c70..0x806c80]
+      InlinePCRanges: []
+      Variables:
+        - Name: a
+          Type: 67 StructureType main.deepMap1
+          Locations:
+            - Range: 0x806c70..0x806c80
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+          IsParameter: true
+          IsReturn: false
+    - ID: 41
+      Name: main.testDeepMap7
+      OutOfLinePCRanges: [0x806c80..0x806c90]
+      InlinePCRanges: []
+      Variables:
+        - Name: a
+          Type: 73 PointerType *main.deepMap7
+          Locations:
+            - Range: 0x806c80..0x806c90
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+          IsParameter: true
+          IsReturn: false
+    - ID: 42
+      Name: main.testStringType1
+      OutOfLinePCRanges: [0x806c90..0x806ca0]
+      InlinePCRanges: []
+      Variables:
+        - Name: a
+          Type: 75 PointerType *main.stringType1
+          Locations:
+            - Range: 0x806c90..0x806ca0
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+          IsParameter: true
+          IsReturn: false
+    - ID: 43
+      Name: main.testStringType2
+      OutOfLinePCRanges: [0x806ca0..0x806cb0]
+      InlinePCRanges: []
+      Variables:
+        - Name: a
+          Type: 77 PointerType **main.stringType2
+          Locations:
+            - Range: 0x806ca0..0x806cb0
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+          IsParameter: true
+          IsReturn: false
+    - ID: 44
       Name: main.testEsotericStack
-      OutOfLinePCRanges: [0x806650..0x806710]
+      OutOfLinePCRanges: [0x806fe0..0x8070a0]
       InlinePCRanges: []
       Variables:
         - Name: e
-          Type: 56 StructureType main.esotericStack
+          Type: 79 StructureType main.esotericStack
           Locations:
-            - Range: 0x806650..0x806688
+            - Range: 0x806fe0..0x807018
               Pieces:
                 - Size: 4
                   Op: {RegNo: 0, Shift: 0}
@@ -1933,7 +2171,7 @@ Subprograms:
                   Op: {RegNo: 7, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 8, Shift: 0}
-            - Range: 0x806688..0x80668c
+            - Range: 0x807018..0x80701c
               Pieces:
                 - Size: 4
                   Op: null
@@ -1953,7 +2191,7 @@ Subprograms:
                   Op: {RegNo: 7, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 8, Shift: 0}
-            - Range: 0x80668c..0x806690
+            - Range: 0x80701c..0x807020
               Pieces:
                 - Size: 4
                   Op: null
@@ -1975,142 +2213,142 @@ Subprograms:
                   Op: {RegNo: 8, Shift: 0}
           IsParameter: true
           IsReturn: false
-    - ID: 37
+    - ID: 45
       Name: main.testEsotericHeap
-      OutOfLinePCRanges: [0x806710..0x806780]
+      OutOfLinePCRanges: [0x8070a0..0x807110]
       InlinePCRanges: []
       Variables:
         - Name: e
-          Type: 61 PointerType *main.esotericHeap
+          Type: 84 PointerType *main.esotericHeap
           Locations:
-            - Range: 0x806710..0x806744
+            - Range: 0x8070a0..0x8070d4
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 38
+    - ID: 46
       Name: main.testInlinedBA
-      OutOfLinePCRanges: [0x806b20..0x806bb0]
+      OutOfLinePCRanges: [0x8074b0..0x807540]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 7 BaseType int
           Locations:
-            - Range: 0x806b20..0x806b58
+            - Range: 0x8074b0..0x8074e8
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 39
+    - ID: 47
       Name: main.testInlinedBB
-      OutOfLinePCRanges: [0x806bb0..0x806c70]
+      OutOfLinePCRanges: [0x807540..0x807600]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 7 BaseType int
           Locations:
-            - Range: 0x806bb0..0x806bcc
+            - Range: 0x807540..0x80755c
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
         - Name: y
           Type: 7 BaseType int
           Locations:
-            - Range: 0x806bb0..0x806bdc
+            - Range: 0x807540..0x80756c
               Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
           IsParameter: true
           IsReturn: false
         - Name: z
           Type: 7 BaseType int
           Locations:
-            - Range: 0x806bcc..0x806bdc
+            - Range: 0x80755c..0x80756c
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x806bdc..0x806c70
+            - Range: 0x80756c..0x807600
               Pieces: [{Size: 8, Op: {CfaOffset: -48}}]
           IsParameter: false
           IsReturn: false
-    - ID: 40
+    - ID: 48
       Name: main.testInlinedBBA
-      OutOfLinePCRanges: [0x806c70..0x806ce0]
+      OutOfLinePCRanges: [0x807600..0x807670]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 7 BaseType int
           Locations:
-            - Range: 0x806c70..0x806c94
+            - Range: 0x807600..0x807624
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 41
+    - ID: 49
       Name: main.testInlinedBC
-      OutOfLinePCRanges: [0x806ce0..0x806df0]
+      OutOfLinePCRanges: [0x807670..0x807780]
       InlinePCRanges: []
       Variables:
         - Name: s
           Type: 7 BaseType int
           Locations:
-            - Range: 0x806cfc..0x806d68
+            - Range: 0x80768c..0x8076f8
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x806d68..0x806d70
+            - Range: 0x8076f8..0x807700
               Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
           IsParameter: false
           IsReturn: false
         - Name: i
           Type: 7 BaseType int
           Locations:
-            - Range: 0x806cfc..0x806d68
+            - Range: 0x80768c..0x8076f8
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x806d68..0x806d6c
+            - Range: 0x8076f8..0x8076fc
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: false
           IsReturn: false
-    - ID: 42
+    - ID: 50
       Name: main.testFrameless
-      OutOfLinePCRanges: [0x806df0..0x806e00]
+      OutOfLinePCRanges: [0x807780..0x807790]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 7 BaseType int
           Locations:
-            - Range: 0x806df0..0x806df8
+            - Range: 0x807780..0x807788
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
         - Name: ~r0
           Type: 7 BaseType int
-          Locations: [{Range: 0x806df0..0x806e00, Pieces: []}]
+          Locations: [{Range: 0x807780..0x807790, Pieces: []}]
           IsParameter: true
           IsReturn: true
-    - ID: 43
+    - ID: 51
       Name: main.testFramelessArray
-      OutOfLinePCRanges: [0x806e00..0x806e50]
+      OutOfLinePCRanges: [0x807790..0x8077e0]
       InlinePCRanges: []
       Variables:
         - Name: a
-          Type: 63 ArrayType [5]int
+          Type: 86 ArrayType [5]int
           Locations:
-            - Range: 0x806e00..0x806e50
+            - Range: 0x807790..0x8077e0
               Pieces: [{Size: 40, Op: {CfaOffset: 8}}]
           IsParameter: true
           IsReturn: false
         - Name: ~r0
           Type: 7 BaseType int
-          Locations: [{Range: 0x806e00..0x806e50, Pieces: []}]
+          Locations: [{Range: 0x807790..0x8077e0, Pieces: []}]
           IsParameter: true
           IsReturn: true
-    - ID: 44
+    - ID: 52
       Name: main.testInterface
-      OutOfLinePCRanges: [0x807060..0x8070b0]
+      OutOfLinePCRanges: [0x8079f0..0x807a40]
       InlinePCRanges: []
       Variables:
         - Name: b
-          Type: 64 GoInterfaceType main.behavior
+          Type: 87 GoInterfaceType main.behavior
           Locations:
-            - Range: 0x807060..0x807088
+            - Range: 0x8079f0..0x807a18
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0x807088..0x80708c
+            - Range: 0x807a18..0x807a1c
               Pieces:
                 - Size: 8
                   Op: null
@@ -2120,24 +2358,24 @@ Subprograms:
           IsReturn: false
         - Name: ~r0
           Type: 9 GoStringHeaderType string
-          Locations: [{Range: 0x807060..0x8070b0, Pieces: []}]
+          Locations: [{Range: 0x8079f0..0x807a40, Pieces: []}]
           IsParameter: true
           IsReturn: true
-    - ID: 45
+    - ID: 53
       Name: main.testAny
-      OutOfLinePCRanges: [0x8070b0..0x807110]
+      OutOfLinePCRanges: [0x807a40..0x807aa0]
       InlinePCRanges: []
       Variables:
         - Name: a
-          Type: 58 GoEmptyInterfaceType interface {}
+          Type: 81 GoEmptyInterfaceType interface {}
           Locations:
-            - Range: 0x8070b0..0x8070dc
+            - Range: 0x807a40..0x807a6c
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0x8070dc..0x8070e0
+            - Range: 0x807a6c..0x807a70
               Pieces:
                 - Size: 8
                   Op: null
@@ -2147,18 +2385,18 @@ Subprograms:
           IsReturn: false
         - Name: ~r0
           Type: 9 GoStringHeaderType string
-          Locations: [{Range: 0x8070b0..0x807110, Pieces: []}]
+          Locations: [{Range: 0x807a40..0x807aa0, Pieces: []}]
           IsParameter: true
           IsReturn: true
-    - ID: 46
+    - ID: 54
       Name: main.testError
-      OutOfLinePCRanges: [0x807110..0x807120]
+      OutOfLinePCRanges: [0x807aa0..0x807ab0]
       InlinePCRanges: []
       Variables:
         - Name: e
           Type: 14 GoInterfaceType error
           Locations:
-            - Range: 0x807110..0x807120
+            - Range: 0x807aa0..0x807ab0
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -2166,309 +2404,309 @@ Subprograms:
                   Op: {RegNo: 1, Shift: 0}
           IsParameter: true
           IsReturn: false
-    - ID: 47
+    - ID: 55
       Name: main.testStructWithMap
-      OutOfLinePCRanges: [0x8074d0..0x8074e0]
+      OutOfLinePCRanges: [0x807e60..0x807e70]
       InlinePCRanges: []
       Variables:
         - Name: s
-          Type: 65 StructureType main.structWithMap
+          Type: 88 StructureType main.structWithMap
           Locations:
-            - Range: 0x8074d0..0x8074e0
-              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-          IsParameter: true
-          IsReturn: false
-    - ID: 48
-      Name: main.testMapStringToStruct
-      OutOfLinePCRanges: [0x8074e0..0x8074f0]
-      InlinePCRanges: []
-      Variables:
-        - Name: m
-          Type: 71 GoMapType map[string]main.nestedStruct
-          Locations:
-            - Range: 0x8074e0..0x8074f0
-              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-          IsParameter: true
-          IsReturn: false
-    - ID: 49
-      Name: main.testMapStringToInt
-      OutOfLinePCRanges: [0x8074f0..0x807500]
-      InlinePCRanges: []
-      Variables:
-        - Name: m
-          Type: 76 GoMapType map[string]int
-          Locations:
-            - Range: 0x8074f0..0x807500
-              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-          IsParameter: true
-          IsReturn: false
-    - ID: 50
-      Name: main.testMapStringToSlice
-      OutOfLinePCRanges: [0x807500..0x807510]
-      InlinePCRanges: []
-      Variables:
-        - Name: m
-          Type: 81 GoMapType map[string][]string
-          Locations:
-            - Range: 0x807500..0x807510
-              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-          IsParameter: true
-          IsReturn: false
-    - ID: 51
-      Name: main.testMapArrayToArray
-      OutOfLinePCRanges: [0x807510..0x807520]
-      InlinePCRanges: []
-      Variables:
-        - Name: m
-          Type: 86 GoMapType map[[4]string][2]int
-          Locations:
-            - Range: 0x807510..0x807520
-              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-          IsParameter: true
-          IsReturn: false
-    - ID: 52
-      Name: main.testSmallMap
-      OutOfLinePCRanges: [0x807520..0x807530]
-      InlinePCRanges: []
-      Variables:
-        - Name: m
-          Type: 76 GoMapType map[string]int
-          Locations:
-            - Range: 0x807520..0x807530
-              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-          IsParameter: true
-          IsReturn: false
-    - ID: 53
-      Name: main.testArrayOfMaps
-      OutOfLinePCRanges: [0x807530..0x807540]
-      InlinePCRanges: []
-      Variables:
-        - Name: m
-          Type: 91 ArrayType [2]map[string]int
-          Locations:
-            - Range: 0x807530..0x807540
-              Pieces: [{Size: 16, Op: {CfaOffset: 8}}]
-          IsParameter: true
-          IsReturn: false
-    - ID: 54
-      Name: main.testPointerToMap
-      OutOfLinePCRanges: [0x807540..0x807550]
-      InlinePCRanges: []
-      Variables:
-        - Name: m
-          Type: 92 PointerType *map[string]int
-          Locations:
-            - Range: 0x807540..0x807550
-              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-          IsParameter: true
-          IsReturn: false
-    - ID: 55
-      Name: main.testMapIntToInt
-      OutOfLinePCRanges: [0x807550..0x807560]
-      InlinePCRanges: []
-      Variables:
-        - Name: m
-          Type: 66 GoMapType map[int]int
-          Locations:
-            - Range: 0x807550..0x807560
+            - Range: 0x807e60..0x807e70
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
     - ID: 56
-      Name: main.testMapMassive
-      OutOfLinePCRanges: [0x807560..0x807570]
+      Name: main.testMapStringToStruct
+      OutOfLinePCRanges: [0x807e70..0x807e80]
       InlinePCRanges: []
       Variables:
-        - Name: redactMyEntries
-          Type: 93 GoMapType map[string][]main.structWithMap
+        - Name: m
+          Type: 94 GoMapType map[string]main.nestedStruct
           Locations:
-            - Range: 0x807560..0x807570
+            - Range: 0x807e70..0x807e80
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
     - ID: 57
-      Name: main.testMapEmbeddedMaps
-      OutOfLinePCRanges: [0x807570..0x807580]
+      Name: main.testMapStringToInt
+      OutOfLinePCRanges: [0x807e80..0x807e90]
       InlinePCRanges: []
       Variables:
         - Name: m
-          Type: 93 GoMapType map[string][]main.structWithMap
+          Type: 99 GoMapType map[string]int
           Locations:
-            - Range: 0x807570..0x807580
+            - Range: 0x807e80..0x807e90
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
     - ID: 58
-      Name: main.testMapWithLinkedList
-      OutOfLinePCRanges: [0x807580..0x807590]
+      Name: main.testMapStringToSlice
+      OutOfLinePCRanges: [0x807e90..0x807ea0]
       InlinePCRanges: []
       Variables:
         - Name: m
-          Type: 98 GoMapType map[bool]main.node
+          Type: 104 GoMapType map[string][]string
           Locations:
-            - Range: 0x807580..0x807590
+            - Range: 0x807e90..0x807ea0
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
     - ID: 59
-      Name: main.testMapWithSmallValue
-      OutOfLinePCRanges: [0x807590..0x8075a0]
+      Name: main.testMapArrayToArray
+      OutOfLinePCRanges: [0x807ea0..0x807eb0]
       InlinePCRanges: []
       Variables:
         - Name: m
-          Type: 103 GoMapType map[int]uint8
+          Type: 109 GoMapType map[[4]string][2]int
           Locations:
-            - Range: 0x807590..0x8075a0
+            - Range: 0x807ea0..0x807eb0
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
     - ID: 60
-      Name: main.testMapWithSmallValueMassive
-      OutOfLinePCRanges: [0x8075a0..0x8075b0]
+      Name: main.testSmallMap
+      OutOfLinePCRanges: [0x807eb0..0x807ec0]
       InlinePCRanges: []
       Variables:
-        - Name: redactMyEntries
-          Type: 103 GoMapType map[int]uint8
+        - Name: m
+          Type: 99 GoMapType map[string]int
           Locations:
-            - Range: 0x8075a0..0x8075b0
+            - Range: 0x807eb0..0x807ec0
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
     - ID: 61
-      Name: main.testMapWithSmallKeyAndValue
-      OutOfLinePCRanges: [0x8075b0..0x8075c0]
+      Name: main.testArrayOfMaps
+      OutOfLinePCRanges: [0x807ec0..0x807ed0]
       InlinePCRanges: []
       Variables:
         - Name: m
-          Type: 108 GoMapType map[uint8]uint8
+          Type: 114 ArrayType [2]map[string]int
           Locations:
-            - Range: 0x8075b0..0x8075c0
-              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+            - Range: 0x807ec0..0x807ed0
+              Pieces: [{Size: 16, Op: {CfaOffset: 8}}]
           IsParameter: true
           IsReturn: false
     - ID: 62
-      Name: main.testMapWithSmallKeyAndValueMassive
-      OutOfLinePCRanges: [0x8075c0..0x8075d0]
+      Name: main.testPointerToMap
+      OutOfLinePCRanges: [0x807ed0..0x807ee0]
       InlinePCRanges: []
       Variables:
         - Name: m
-          Type: 108 GoMapType map[uint8]uint8
+          Type: 115 PointerType *map[string]int
           Locations:
-            - Range: 0x8075c0..0x8075d0
+            - Range: 0x807ed0..0x807ee0
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
     - ID: 63
-      Name: main.testMapSmallKeySmallValue
-      OutOfLinePCRanges: [0x8075d0..0x8075e0]
+      Name: main.testMapIntToInt
+      OutOfLinePCRanges: [0x807ee0..0x807ef0]
       InlinePCRanges: []
       Variables:
         - Name: m
-          Type: 108 GoMapType map[uint8]uint8
+          Type: 89 GoMapType map[int]int
           Locations:
-            - Range: 0x8075d0..0x8075e0
+            - Range: 0x807ee0..0x807ef0
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
     - ID: 64
-      Name: main.testMapSmallKeyLargeValue
-      OutOfLinePCRanges: [0x8075e0..0x8075f0]
+      Name: main.testMapMassive
+      OutOfLinePCRanges: [0x807ef0..0x807f00]
       InlinePCRanges: []
       Variables:
-        - Name: m
-          Type: 113 GoMapType map[uint8][4]int
+        - Name: redactMyEntries
+          Type: 116 GoMapType map[string][]main.structWithMap
           Locations:
-            - Range: 0x8075e0..0x8075f0
+            - Range: 0x807ef0..0x807f00
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
     - ID: 65
-      Name: main.testMapLargeKeySmallValue
-      OutOfLinePCRanges: [0x8075f0..0x807600]
+      Name: main.testMapEmbeddedMaps
+      OutOfLinePCRanges: [0x807f00..0x807f10]
       InlinePCRanges: []
       Variables:
         - Name: m
-          Type: 118 GoMapType map[[4]int]uint8
+          Type: 116 GoMapType map[string][]main.structWithMap
           Locations:
-            - Range: 0x8075f0..0x807600
+            - Range: 0x807f00..0x807f10
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
     - ID: 66
-      Name: main.testMapLargeKeyLargeValue
-      OutOfLinePCRanges: [0x807600..0x807610]
+      Name: main.testMapWithLinkedList
+      OutOfLinePCRanges: [0x807f10..0x807f20]
       InlinePCRanges: []
       Variables:
         - Name: m
-          Type: 123 GoMapType map[[4]int][4]int
+          Type: 121 GoMapType map[bool]main.node
           Locations:
-            - Range: 0x807600..0x807610
+            - Range: 0x807f10..0x807f20
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
     - ID: 67
+      Name: main.testMapWithSmallValue
+      OutOfLinePCRanges: [0x807f20..0x807f30]
+      InlinePCRanges: []
+      Variables:
+        - Name: m
+          Type: 126 GoMapType map[int]uint8
+          Locations:
+            - Range: 0x807f20..0x807f30
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+          IsParameter: true
+          IsReturn: false
+    - ID: 68
+      Name: main.testMapWithSmallValueMassive
+      OutOfLinePCRanges: [0x807f30..0x807f40]
+      InlinePCRanges: []
+      Variables:
+        - Name: redactMyEntries
+          Type: 126 GoMapType map[int]uint8
+          Locations:
+            - Range: 0x807f30..0x807f40
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+          IsParameter: true
+          IsReturn: false
+    - ID: 69
+      Name: main.testMapWithSmallKeyAndValue
+      OutOfLinePCRanges: [0x807f40..0x807f50]
+      InlinePCRanges: []
+      Variables:
+        - Name: m
+          Type: 131 GoMapType map[uint8]uint8
+          Locations:
+            - Range: 0x807f40..0x807f50
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+          IsParameter: true
+          IsReturn: false
+    - ID: 70
+      Name: main.testMapWithSmallKeyAndValueMassive
+      OutOfLinePCRanges: [0x807f50..0x807f60]
+      InlinePCRanges: []
+      Variables:
+        - Name: m
+          Type: 131 GoMapType map[uint8]uint8
+          Locations:
+            - Range: 0x807f50..0x807f60
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+          IsParameter: true
+          IsReturn: false
+    - ID: 71
+      Name: main.testMapSmallKeySmallValue
+      OutOfLinePCRanges: [0x807f60..0x807f70]
+      InlinePCRanges: []
+      Variables:
+        - Name: m
+          Type: 131 GoMapType map[uint8]uint8
+          Locations:
+            - Range: 0x807f60..0x807f70
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+          IsParameter: true
+          IsReturn: false
+    - ID: 72
+      Name: main.testMapSmallKeyLargeValue
+      OutOfLinePCRanges: [0x807f70..0x807f80]
+      InlinePCRanges: []
+      Variables:
+        - Name: m
+          Type: 136 GoMapType map[uint8][4]int
+          Locations:
+            - Range: 0x807f70..0x807f80
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+          IsParameter: true
+          IsReturn: false
+    - ID: 73
+      Name: main.testMapLargeKeySmallValue
+      OutOfLinePCRanges: [0x807f80..0x807f90]
+      InlinePCRanges: []
+      Variables:
+        - Name: m
+          Type: 141 GoMapType map[[4]int]uint8
+          Locations:
+            - Range: 0x807f80..0x807f90
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+          IsParameter: true
+          IsReturn: false
+    - ID: 74
+      Name: main.testMapLargeKeyLargeValue
+      OutOfLinePCRanges: [0x807f90..0x807fa0]
+      InlinePCRanges: []
+      Variables:
+        - Name: m
+          Type: 146 GoMapType map[[4]int][4]int
+          Locations:
+            - Range: 0x807f90..0x807fa0
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+          IsParameter: true
+          IsReturn: false
+    - ID: 75
       Name: main.testCombinedByte
-      OutOfLinePCRanges: [0x8088a0..0x8088b0]
+      OutOfLinePCRanges: [0x809230..0x809240]
       InlinePCRanges: []
       Variables:
         - Name: w
           Type: 3 BaseType uint8
           Locations:
-            - Range: 0x8088a0..0x8088b0
+            - Range: 0x809230..0x809240
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
         - Name: x
           Type: 3 BaseType uint8
           Locations:
-            - Range: 0x8088a0..0x8088b0
+            - Range: 0x809230..0x809240
               Pieces: [{Size: 1, Op: {RegNo: 1, Shift: 0}}]
           IsParameter: true
           IsReturn: false
         - Name: y
           Type: 18 BaseType float32
           Locations:
-            - Range: 0x8088a0..0x8088b0
+            - Range: 0x809230..0x809240
               Pieces: [{Size: 4, Op: {RegNo: 64, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 68
+    - ID: 76
       Name: main.testMultipleSimpleParams
-      OutOfLinePCRanges: [0x808980..0x808990]
+      OutOfLinePCRanges: [0x809310..0x809320]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 4 BaseType bool
           Locations:
-            - Range: 0x808980..0x808990
+            - Range: 0x809310..0x809320
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
         - Name: b
           Type: 3 BaseType uint8
           Locations:
-            - Range: 0x808980..0x808990
+            - Range: 0x809310..0x809320
               Pieces: [{Size: 1, Op: {RegNo: 1, Shift: 0}}]
           IsParameter: true
           IsReturn: false
         - Name: c
           Type: 12 BaseType int32
           Locations:
-            - Range: 0x808980..0x808990
+            - Range: 0x809310..0x809320
               Pieces: [{Size: 4, Op: {RegNo: 2, Shift: 0}}]
           IsParameter: true
           IsReturn: false
         - Name: d
           Type: 10 BaseType uint
           Locations:
-            - Range: 0x808980..0x808990
+            - Range: 0x809310..0x809320
               Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
           IsParameter: true
           IsReturn: false
         - Name: e
           Type: 9 GoStringHeaderType string
           Locations:
-            - Range: 0x808980..0x808990
+            - Range: 0x809310..0x809320
               Pieces:
                 - Size: 8
                   Op: {RegNo: 4, Shift: 0}
@@ -2476,39 +2714,39 @@ Subprograms:
                   Op: {RegNo: 5, Shift: 0}
           IsParameter: true
           IsReturn: false
-    - ID: 69
+    - ID: 77
       Name: main.testChannel
-      OutOfLinePCRanges: [0x808b20..0x808b30]
+      OutOfLinePCRanges: [0x8094b0..0x8094c0]
       InlinePCRanges: []
       Variables:
         - Name: c
-          Type: 128 GoChannelType chan bool
+          Type: 151 GoChannelType chan bool
           Locations:
-            - Range: 0x808b20..0x808b30
+            - Range: 0x8094b0..0x8094c0
               Pieces: [{Size: 0, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 70
+    - ID: 78
       Name: main.testPointerToSimpleStruct
-      OutOfLinePCRanges: [0x808ca0..0x808cb0]
+      OutOfLinePCRanges: [0x809630..0x809640]
       InlinePCRanges: []
       Variables:
         - Name: a
-          Type: 129 PointerType *main.structWithTwoValues
+          Type: 152 PointerType *main.structWithTwoValues
           Locations:
-            - Range: 0x808ca0..0x808cb0
+            - Range: 0x809630..0x809640
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 71
+    - ID: 79
       Name: main.testLinkedList
-      OutOfLinePCRanges: [0x808cb0..0x808cc0]
+      OutOfLinePCRanges: [0x809640..0x809650]
       InlinePCRanges: []
       Variables:
         - Name: a
-          Type: 131 StructureType main.node
+          Type: 154 StructureType main.node
           Locations:
-            - Range: 0x808cb0..0x808cc0
+            - Range: 0x809640..0x809650
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -2516,273 +2754,94 @@ Subprograms:
                   Op: {RegNo: 1, Shift: 0}
           IsParameter: true
           IsReturn: false
-    - ID: 72
+    - ID: 80
       Name: main.testPointerLoop
-      OutOfLinePCRanges: [0x808cc0..0x808cd0]
+      OutOfLinePCRanges: [0x809650..0x809660]
       InlinePCRanges: []
       Variables:
         - Name: a
-          Type: 132 PointerType *main.node
+          Type: 155 PointerType *main.node
           Locations:
-            - Range: 0x808cc0..0x808cd0
+            - Range: 0x809650..0x809660
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 73
+    - ID: 81
       Name: main.testUnsafePointer
-      OutOfLinePCRanges: [0x808cd0..0x808ce0]
+      OutOfLinePCRanges: [0x809660..0x809670]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 15 VoidPointerType unsafe.Pointer
           Locations:
-            - Range: 0x808cd0..0x808ce0
+            - Range: 0x809660..0x809670
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 74
+    - ID: 82
       Name: main.testUintPointer
-      OutOfLinePCRanges: [0x808cf0..0x808d00]
+      OutOfLinePCRanges: [0x809680..0x809690]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 34 PointerType *uint
           Locations:
-            - Range: 0x808cf0..0x808d00
+            - Range: 0x809680..0x809690
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 75
+    - ID: 83
       Name: main.testStringPointer
-      OutOfLinePCRanges: [0x808d60..0x808d70]
+      OutOfLinePCRanges: [0x8096f0..0x809700]
       InlinePCRanges: []
       Variables:
         - Name: z
           Type: 22 PointerType *string
           Locations:
-            - Range: 0x808d60..0x808d70
+            - Range: 0x8096f0..0x809700
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 76
+    - ID: 84
       Name: main.testNilPointer
-      OutOfLinePCRanges: [0x808d80..0x808d90]
+      OutOfLinePCRanges: [0x809710..0x809720]
       InlinePCRanges: []
       Variables:
         - Name: z
           Type: 11 PointerType *bool
           Locations:
-            - Range: 0x808d80..0x808d90
+            - Range: 0x809710..0x809720
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
         - Name: a
           Type: 10 BaseType uint
           Locations:
-            - Range: 0x808d80..0x808d90
+            - Range: 0x809710..0x809720
               Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 77
+    - ID: 85
       Name: main.testCycle
-      OutOfLinePCRanges: [0x808da0..0x808db0]
+      OutOfLinePCRanges: [0x809730..0x809740]
       InlinePCRanges: []
       Variables:
         - Name: t
-          Type: 133 PointerType *main.t
+          Type: 156 PointerType *main.t
           Locations:
-            - Range: 0x808da0..0x808db0
+            - Range: 0x809730..0x809740
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 78
-      Name: main.testUintSlice
-      OutOfLinePCRanges: [0x809140..0x809150]
-      InlinePCRanges: []
-      Variables:
-        - Name: u
-          Type: 135 GoSliceHeaderType []uint
-          Locations:
-            - Range: 0x809140..0x809150
-              Pieces:
-                - Size: 8
-                  Op: {RegNo: 0, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 1, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 2, Shift: 0}
-          IsParameter: true
-          IsReturn: false
-    - ID: 79
-      Name: main.testEmptySlice
-      OutOfLinePCRanges: [0x809150..0x809160]
-      InlinePCRanges: []
-      Variables:
-        - Name: u
-          Type: 135 GoSliceHeaderType []uint
-          Locations:
-            - Range: 0x809150..0x809160
-              Pieces:
-                - Size: 8
-                  Op: {RegNo: 0, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 1, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 2, Shift: 0}
-          IsParameter: true
-          IsReturn: false
-    - ID: 80
-      Name: main.testSliceOfSlices
-      OutOfLinePCRanges: [0x809160..0x809170]
-      InlinePCRanges: []
-      Variables:
-        - Name: u
-          Type: 136 GoSliceHeaderType [][]uint
-          Locations:
-            - Range: 0x809160..0x809170
-              Pieces:
-                - Size: 8
-                  Op: {RegNo: 0, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 1, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 2, Shift: 0}
-          IsParameter: true
-          IsReturn: false
-    - ID: 81
-      Name: main.testStructSlice
-      OutOfLinePCRanges: [0x809170..0x809180]
-      InlinePCRanges: []
-      Variables:
-        - Name: xs
-          Type: 138 GoSliceHeaderType []main.structWithNoStrings
-          Locations:
-            - Range: 0x809170..0x809180
-              Pieces:
-                - Size: 8
-                  Op: {RegNo: 0, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 1, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 2, Shift: 0}
-          IsParameter: true
-          IsReturn: false
-        - Name: a
-          Type: 7 BaseType int
-          Locations:
-            - Range: 0x809170..0x809180
-              Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
-          IsParameter: true
-          IsReturn: false
-    - ID: 82
-      Name: main.testEmptySliceOfStructs
-      OutOfLinePCRanges: [0x809180..0x809190]
-      InlinePCRanges: []
-      Variables:
-        - Name: xs
-          Type: 138 GoSliceHeaderType []main.structWithNoStrings
-          Locations:
-            - Range: 0x809180..0x809190
-              Pieces:
-                - Size: 8
-                  Op: {RegNo: 0, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 1, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 2, Shift: 0}
-          IsParameter: true
-          IsReturn: false
-        - Name: a
-          Type: 7 BaseType int
-          Locations:
-            - Range: 0x809180..0x809190
-              Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
-          IsParameter: true
-          IsReturn: false
-    - ID: 83
-      Name: main.testNilSliceOfStructs
-      OutOfLinePCRanges: [0x809190..0x8091a0]
-      InlinePCRanges: []
-      Variables:
-        - Name: xs
-          Type: 138 GoSliceHeaderType []main.structWithNoStrings
-          Locations:
-            - Range: 0x809190..0x8091a0
-              Pieces:
-                - Size: 8
-                  Op: {RegNo: 0, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 1, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 2, Shift: 0}
-          IsParameter: true
-          IsReturn: false
-        - Name: a
-          Type: 7 BaseType int
-          Locations:
-            - Range: 0x809190..0x8091a0
-              Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
-          IsParameter: true
-          IsReturn: false
-    - ID: 84
-      Name: main.testStringSlice
-      OutOfLinePCRanges: [0x8091a0..0x8091b0]
-      InlinePCRanges: []
-      Variables:
-        - Name: s
-          Type: 141 GoSliceHeaderType []string
-          Locations:
-            - Range: 0x8091a0..0x8091b0
-              Pieces:
-                - Size: 8
-                  Op: {RegNo: 0, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 1, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 2, Shift: 0}
-          IsParameter: true
-          IsReturn: false
-    - ID: 85
-      Name: main.testNilSliceWithOtherParams
-      OutOfLinePCRanges: [0x8091b0..0x8091c0]
-      InlinePCRanges: []
-      Variables:
-        - Name: a
-          Type: 17 BaseType int8
-          Locations:
-            - Range: 0x8091b0..0x8091c0
-              Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
-          IsParameter: true
-          IsReturn: false
-        - Name: s
-          Type: 142 GoSliceHeaderType []bool
-          Locations:
-            - Range: 0x8091b0..0x8091c0
-              Pieces:
-                - Size: 8
-                  Op: {RegNo: 1, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 2, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 3, Shift: 0}
-          IsParameter: true
-          IsReturn: false
-        - Name: x
-          Type: 10 BaseType uint
-          Locations:
-            - Range: 0x8091b0..0x8091c0
-              Pieces: [{Size: 8, Op: {RegNo: 4, Shift: 0}}]
-          IsParameter: true
-          IsReturn: false
     - ID: 86
-      Name: main.testNilSlice
-      OutOfLinePCRanges: [0x8091c0..0x8091d0]
+      Name: main.testUintSlice
+      OutOfLinePCRanges: [0x809ad0..0x809ae0]
       InlinePCRanges: []
       Variables:
-        - Name: xs
-          Type: 143 GoSliceHeaderType []uint16
+        - Name: u
+          Type: 158 GoSliceHeaderType []uint
           Locations:
-            - Range: 0x8091c0..0x8091d0
+            - Range: 0x809ad0..0x809ae0
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -2793,14 +2852,14 @@ Subprograms:
           IsParameter: true
           IsReturn: false
     - ID: 87
-      Name: main.testVeryLargeSlice
-      OutOfLinePCRanges: [0x8091d0..0x8091e0]
+      Name: main.testEmptySlice
+      OutOfLinePCRanges: [0x809ae0..0x809af0]
       InlinePCRanges: []
       Variables:
-        - Name: xs
-          Type: 135 GoSliceHeaderType []uint
+        - Name: u
+          Type: 158 GoSliceHeaderType []uint
           Locations:
-            - Range: 0x8091d0..0x8091e0
+            - Range: 0x809ae0..0x809af0
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -2811,24 +2870,203 @@ Subprograms:
           IsParameter: true
           IsReturn: false
     - ID: 88
+      Name: main.testSliceOfSlices
+      OutOfLinePCRanges: [0x809af0..0x809b00]
+      InlinePCRanges: []
+      Variables:
+        - Name: u
+          Type: 159 GoSliceHeaderType [][]uint
+          Locations:
+            - Range: 0x809af0..0x809b00
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 0, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 1, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 2, Shift: 0}
+          IsParameter: true
+          IsReturn: false
+    - ID: 89
+      Name: main.testStructSlice
+      OutOfLinePCRanges: [0x809b00..0x809b10]
+      InlinePCRanges: []
+      Variables:
+        - Name: xs
+          Type: 161 GoSliceHeaderType []main.structWithNoStrings
+          Locations:
+            - Range: 0x809b00..0x809b10
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 0, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 1, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 2, Shift: 0}
+          IsParameter: true
+          IsReturn: false
+        - Name: a
+          Type: 7 BaseType int
+          Locations:
+            - Range: 0x809b00..0x809b10
+              Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
+          IsParameter: true
+          IsReturn: false
+    - ID: 90
+      Name: main.testEmptySliceOfStructs
+      OutOfLinePCRanges: [0x809b10..0x809b20]
+      InlinePCRanges: []
+      Variables:
+        - Name: xs
+          Type: 161 GoSliceHeaderType []main.structWithNoStrings
+          Locations:
+            - Range: 0x809b10..0x809b20
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 0, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 1, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 2, Shift: 0}
+          IsParameter: true
+          IsReturn: false
+        - Name: a
+          Type: 7 BaseType int
+          Locations:
+            - Range: 0x809b10..0x809b20
+              Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
+          IsParameter: true
+          IsReturn: false
+    - ID: 91
+      Name: main.testNilSliceOfStructs
+      OutOfLinePCRanges: [0x809b20..0x809b30]
+      InlinePCRanges: []
+      Variables:
+        - Name: xs
+          Type: 161 GoSliceHeaderType []main.structWithNoStrings
+          Locations:
+            - Range: 0x809b20..0x809b30
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 0, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 1, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 2, Shift: 0}
+          IsParameter: true
+          IsReturn: false
+        - Name: a
+          Type: 7 BaseType int
+          Locations:
+            - Range: 0x809b20..0x809b30
+              Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
+          IsParameter: true
+          IsReturn: false
+    - ID: 92
+      Name: main.testStringSlice
+      OutOfLinePCRanges: [0x809b30..0x809b40]
+      InlinePCRanges: []
+      Variables:
+        - Name: s
+          Type: 164 GoSliceHeaderType []string
+          Locations:
+            - Range: 0x809b30..0x809b40
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 0, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 1, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 2, Shift: 0}
+          IsParameter: true
+          IsReturn: false
+    - ID: 93
+      Name: main.testNilSliceWithOtherParams
+      OutOfLinePCRanges: [0x809b40..0x809b50]
+      InlinePCRanges: []
+      Variables:
+        - Name: a
+          Type: 17 BaseType int8
+          Locations:
+            - Range: 0x809b40..0x809b50
+              Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
+          IsParameter: true
+          IsReturn: false
+        - Name: s
+          Type: 165 GoSliceHeaderType []bool
+          Locations:
+            - Range: 0x809b40..0x809b50
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 1, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 2, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 3, Shift: 0}
+          IsParameter: true
+          IsReturn: false
+        - Name: x
+          Type: 10 BaseType uint
+          Locations:
+            - Range: 0x809b40..0x809b50
+              Pieces: [{Size: 8, Op: {RegNo: 4, Shift: 0}}]
+          IsParameter: true
+          IsReturn: false
+    - ID: 94
+      Name: main.testNilSlice
+      OutOfLinePCRanges: [0x809b50..0x809b60]
+      InlinePCRanges: []
+      Variables:
+        - Name: xs
+          Type: 166 GoSliceHeaderType []uint16
+          Locations:
+            - Range: 0x809b50..0x809b60
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 0, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 1, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 2, Shift: 0}
+          IsParameter: true
+          IsReturn: false
+    - ID: 95
+      Name: main.testVeryLargeSlice
+      OutOfLinePCRanges: [0x809b60..0x809b70]
+      InlinePCRanges: []
+      Variables:
+        - Name: xs
+          Type: 158 GoSliceHeaderType []uint
+          Locations:
+            - Range: 0x809b60..0x809b70
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 0, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 1, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 2, Shift: 0}
+          IsParameter: true
+          IsReturn: false
+    - ID: 96
       Name: main.stackC
-      OutOfLinePCRanges: [0x809470..0x8094d0]
+      OutOfLinePCRanges: [0x809e00..0x809e60]
       InlinePCRanges: []
       Variables:
         - Name: ~r0
           Type: 9 GoStringHeaderType string
-          Locations: [{Range: 0x809470..0x8094d0, Pieces: []}]
+          Locations: [{Range: 0x809e00..0x809e60, Pieces: []}]
           IsParameter: true
           IsReturn: true
-    - ID: 89
+    - ID: 97
       Name: main.testSingleString
-      OutOfLinePCRanges: [0x8094d0..0x8094e0]
+      OutOfLinePCRanges: [0x809e60..0x809e70]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 9 GoStringHeaderType string
           Locations:
-            - Range: 0x8094d0..0x8094e0
+            - Range: 0x809e60..0x809e70
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -2836,15 +3074,15 @@ Subprograms:
                   Op: {RegNo: 1, Shift: 0}
           IsParameter: true
           IsReturn: false
-    - ID: 90
+    - ID: 98
       Name: main.testThreeStrings
-      OutOfLinePCRanges: [0x8094e0..0x8094f0]
+      OutOfLinePCRanges: [0x809e70..0x809e80]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 9 GoStringHeaderType string
           Locations:
-            - Range: 0x8094e0..0x8094f0
+            - Range: 0x809e70..0x809e80
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -2855,7 +3093,7 @@ Subprograms:
         - Name: y
           Type: 9 GoStringHeaderType string
           Locations:
-            - Range: 0x8094e0..0x8094f0
+            - Range: 0x809e70..0x809e80
               Pieces:
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
@@ -2866,7 +3104,7 @@ Subprograms:
         - Name: z
           Type: 9 GoStringHeaderType string
           Locations:
-            - Range: 0x8094e0..0x8094f0
+            - Range: 0x809e70..0x809e80
               Pieces:
                 - Size: 8
                   Op: {RegNo: 4, Shift: 0}
@@ -2874,15 +3112,15 @@ Subprograms:
                   Op: {RegNo: 5, Shift: 0}
           IsParameter: true
           IsReturn: false
-    - ID: 91
+    - ID: 99
       Name: main.testThreeStringsInStruct
-      OutOfLinePCRanges: [0x8094f0..0x809500]
+      OutOfLinePCRanges: [0x809e80..0x809e90]
       InlinePCRanges: []
       Variables:
         - Name: a
-          Type: 144 StructureType main.threeStringStruct
+          Type: 167 StructureType main.threeStringStruct
           Locations:
-            - Range: 0x8094f0..0x809500
+            - Range: 0x809e80..0x809e90
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -2898,39 +3136,39 @@ Subprograms:
                   Op: {RegNo: 5, Shift: 0}
           IsParameter: true
           IsReturn: false
-    - ID: 92
+    - ID: 100
       Name: main.testThreeStringsInStructPointer
-      OutOfLinePCRanges: [0x809500..0x809510]
+      OutOfLinePCRanges: [0x809e90..0x809ea0]
       InlinePCRanges: []
       Variables:
         - Name: a
-          Type: 145 PointerType *main.threeStringStruct
+          Type: 168 PointerType *main.threeStringStruct
           Locations:
-            - Range: 0x809500..0x809510
+            - Range: 0x809e90..0x809ea0
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 93
+    - ID: 101
       Name: main.testOneStringInStructPointer
-      OutOfLinePCRanges: [0x809510..0x809520]
+      OutOfLinePCRanges: [0x809ea0..0x809eb0]
       InlinePCRanges: []
       Variables:
         - Name: a
-          Type: 146 PointerType *main.oneStringStruct
+          Type: 169 PointerType *main.oneStringStruct
           Locations:
-            - Range: 0x809510..0x809520
+            - Range: 0x809ea0..0x809eb0
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 94
+    - ID: 102
       Name: main.testMassiveString
-      OutOfLinePCRanges: [0x809520..0x809530]
+      OutOfLinePCRanges: [0x809eb0..0x809ec0]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 9 GoStringHeaderType string
           Locations:
-            - Range: 0x809520..0x809530
+            - Range: 0x809eb0..0x809ec0
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -2938,15 +3176,15 @@ Subprograms:
                   Op: {RegNo: 1, Shift: 0}
           IsParameter: true
           IsReturn: false
-    - ID: 95
+    - ID: 103
       Name: main.testUnitializedString
-      OutOfLinePCRanges: [0x809530..0x809540]
+      OutOfLinePCRanges: [0x809ec0..0x809ed0]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 9 GoStringHeaderType string
           Locations:
-            - Range: 0x809530..0x809540
+            - Range: 0x809ec0..0x809ed0
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -2954,15 +3192,15 @@ Subprograms:
                   Op: {RegNo: 1, Shift: 0}
           IsParameter: true
           IsReturn: false
-    - ID: 96
+    - ID: 104
       Name: main.testEmptyString
-      OutOfLinePCRanges: [0x809540..0x809550]
+      OutOfLinePCRanges: [0x809ed0..0x809ee0]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 9 GoStringHeaderType string
           Locations:
-            - Range: 0x809540..0x809550
+            - Range: 0x809ed0..0x809ee0
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -2970,15 +3208,15 @@ Subprograms:
                   Op: {RegNo: 1, Shift: 0}
           IsParameter: true
           IsReturn: false
-    - ID: 97
+    - ID: 105
       Name: main.testStruct
-      OutOfLinePCRanges: [0x809710..0x809730]
+      OutOfLinePCRanges: [0x80a0a0..0x80a0c0]
       InlinePCRanges: []
       Variables:
         - Name: x
-          Type: 148 StructureType main.aStruct
+          Type: 171 StructureType main.aStruct
           Locations:
-            - Range: 0x809710..0x809730
+            - Range: 0x80a0a0..0x80a0c0
               Pieces:
                 - Size: 1
                   Op: {RegNo: 0, Shift: 0}
@@ -2996,580 +3234,860 @@ Subprograms:
                   Op: {RegNo: 6, Shift: 0}
           IsParameter: true
           IsReturn: false
-    - ID: 98
+    - ID: 106
       Name: main.testEmptyStruct
-      OutOfLinePCRanges: [0x8097e0..0x8097f0]
+      OutOfLinePCRanges: [0x80a170..0x80a180]
       InlinePCRanges: []
       Variables:
         - Name: e
-          Type: 150 StructureType main.emptyStruct
-          Locations: [{Range: 0x8097e0..0x8097f0, Pieces: []}]
+          Type: 173 StructureType main.emptyStruct
+          Locations: [{Range: 0x80a170..0x80a180, Pieces: []}]
           IsParameter: true
           IsReturn: false
-    - ID: 99
+    - ID: 107
       Name: main.testInlinedPrint
-      OutOfLinePCRanges: [0x806990..0x806a00]
+      OutOfLinePCRanges: [0x807320..0x807390]
       InlinePCRanges:
-        - Ranges: [0x806a1c..0x806a50]
-          RootRanges: [0x806a00..0x806a70]
-        - Ranges: [0x806b58..0x806b8c]
-          RootRanges: [0x806b20..0x806bb0]
-        - Ranges: [0x806bd4..0x806c08]
-          RootRanges: [0x806bb0..0x806c70]
-        - Ranges: [0x806c8c..0x806cc0]
-          RootRanges: [0x806c70..0x806ce0]
+        - Ranges: [0x8073ac..0x8073e0]
+          RootRanges: [0x807390..0x807400]
+        - Ranges: [0x8074e8..0x80751c]
+          RootRanges: [0x8074b0..0x807540]
+        - Ranges: [0x807564..0x807598]
+          RootRanges: [0x807540..0x807600]
+        - Ranges: [0x80761c..0x807650]
+          RootRanges: [0x807600..0x807670]
       Variables:
         - Name: x
           Type: 7 BaseType int
           Locations:
-            - Range: 0x806990..0x8069b0
+            - Range: 0x807320..0x807340
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x806a1c..0x806a24
+            - Range: 0x8073ac..0x8073b4
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x806b58..0x806b60
+            - Range: 0x8074e8..0x8074f0
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x806bcc..0x806bdc
+            - Range: 0x80755c..0x80756c
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x806bdc..0x806c70
+            - Range: 0x80756c..0x807600
               Pieces: [{Size: 8, Op: {CfaOffset: -48}}]
-            - Range: 0x806c70..0x806c94
+            - Range: 0x807600..0x807624
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 100
+    - ID: 108
       Name: main.testInlinedBBB
       OutOfLinePCRanges: []
       InlinePCRanges:
-        - Ranges: [0x806c14..0x806c48]
-          RootRanges: [0x806bb0..0x806c70]
+        - Ranges: [0x8075a4..0x8075d8]
+          RootRanges: [0x807540..0x807600]
       Variables: []
-    - ID: 101
+    - ID: 109
       Name: main.testInlinedBCA
       OutOfLinePCRanges: []
       InlinePCRanges:
-        - Ranges: [0x806cfc..0x806d30, 0x806d38..0x806d3c]
-          RootRanges: [0x806ce0..0x806df0]
+        - Ranges: [0x80768c..0x8076c0, 0x8076c8..0x8076cc]
+          RootRanges: [0x807670..0x807780]
       Variables: []
-    - ID: 102
+    - ID: 110
       Name: main.testInlinedBCB
       OutOfLinePCRanges: []
       InlinePCRanges:
-        - Ranges: [0x806da0..0x806dd4]
-          RootRanges: [0x806ce0..0x806df0]
+        - Ranges: [0x807730..0x807764]
+          RootRanges: [0x807670..0x807780]
       Variables: []
-    - ID: 103
+    - ID: 111
       Name: main.testInlinedSq
       OutOfLinePCRanges: []
       InlinePCRanges:
-        - Ranges: [0x806df4..0x806df8]
-          RootRanges: [0x806df0..0x806e00]
+        - Ranges: [0x807784..0x807788]
+          RootRanges: [0x807780..0x807790]
       Variables:
         - Name: x
           Type: 7 BaseType int
           Locations:
-            - Range: 0x806df0..0x806df8
+            - Range: 0x807780..0x807788
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 104
+    - ID: 112
       Name: main.testInlinedSumArray
       OutOfLinePCRanges: []
       InlinePCRanges:
-        - Ranges: [0x806e24..0x806e40]
-          RootRanges: [0x806e00..0x806e50]
-        - Ranges: [0x806eac..0x806ecc]
-          RootRanges: [0x806e50..0x806f90]
+        - Ranges: [0x8077b4..0x8077d0]
+          RootRanges: [0x807790..0x8077e0]
+        - Ranges: [0x80783c..0x80785c]
+          RootRanges: [0x8077e0..0x807920]
       Variables:
         - Name: a
-          Type: 63 ArrayType [5]int
+          Type: 86 ArrayType [5]int
           Locations:
-            - Range: 0x806e10..0x806e50
+            - Range: 0x8077a0..0x8077e0
               Pieces: [{Size: 40, Op: {CfaOffset: -48}}]
-            - Range: 0x806e98..0x806f90
+            - Range: 0x807828..0x807920
               Pieces: [{Size: 40, Op: {CfaOffset: -120}}]
           IsParameter: true
           IsReturn: false
 Types:
     - __kind: PointerType
-      ID: 277
+      ID: 63
+      Name: '**main.deepSlice2'
+      ByteSize: 8
+      Pointee: 64 PointerType *main.deepSlice2
+    - __kind: PointerType
+      ID: 309
+      Name: '**main.deepSlice3'
+      ByteSize: 8
+      Pointee: 310 PointerType *main.deepSlice3
+    - __kind: PointerType
+      ID: 334
+      Name: '**main.deepSlice8'
+      ByteSize: 8
+      Pointee: 335 PointerType *main.deepSlice8
+    - __kind: PointerType
+      ID: 340
+      Name: '**main.deepSlice9'
+      ByteSize: 8
+      Pointee: 341 PointerType *main.deepSlice9
+    - __kind: PointerType
+      ID: 77
+      Name: '**main.stringType2'
+      ByteSize: 8
+      GoKind: 22
+      Pointee: 78 PointerType *main.stringType2
+    - __kind: PointerType
+      ID: 402
       Name: '**main.t'
       ByteSize: 8
-      Pointee: 133 PointerType *main.t
+      Pointee: 156 PointerType *main.t
     - __kind: PointerType
       ID: 54
       Name: '**string'
       ByteSize: 8
-      GoRuntimeType: 525280
+      GoRuntimeType: 530400
       GoKind: 22
       Pointee: 22 PointerType *string
     - __kind: PointerType
-      ID: 126
+      ID: 149
       Name: '**table<[4]int,[4]int>'
       ByteSize: 8
-      Pointee: 127 PointerType *table<[4]int,[4]int>
+      Pointee: 150 PointerType *table<[4]int,[4]int>
     - __kind: PointerType
-      ID: 121
+      ID: 144
       Name: '**table<[4]int,uint8>'
       ByteSize: 8
-      Pointee: 122 PointerType *table<[4]int,uint8>
+      Pointee: 145 PointerType *table<[4]int,uint8>
     - __kind: PointerType
-      ID: 89
+      ID: 112
       Name: '**table<[4]string,[2]int>'
       ByteSize: 8
-      Pointee: 90 PointerType *table<[4]string,[2]int>
+      Pointee: 113 PointerType *table<[4]string,[2]int>
     - __kind: PointerType
-      ID: 101
+      ID: 124
       Name: '**table<bool,main.node>'
       ByteSize: 8
-      Pointee: 102 PointerType *table<bool,main.node>
+      Pointee: 125 PointerType *table<bool,main.node>
     - __kind: PointerType
-      ID: 69
+      ID: 71
+      Name: '**table<int,*main.deepMap2>'
+      ByteSize: 8
+      Pointee: 72 PointerType *table<int,*main.deepMap2>
+    - __kind: PointerType
+      ID: 317
+      Name: '**table<int,*main.deepMap3>'
+      ByteSize: 8
+      Pointee: 318 PointerType *table<int,*main.deepMap3>
+    - __kind: PointerType
+      ID: 352
+      Name: '**table<int,*main.deepMap8>'
+      ByteSize: 8
+      Pointee: 353 PointerType *table<int,*main.deepMap8>
+    - __kind: PointerType
+      ID: 367
+      Name: '**table<int,*main.deepMap9>'
+      ByteSize: 8
+      Pointee: 368 PointerType *table<int,*main.deepMap9>
+    - __kind: PointerType
+      ID: 92
       Name: '**table<int,int>'
       ByteSize: 8
-      Pointee: 70 PointerType *table<int,int>
+      Pointee: 93 PointerType *table<int,int>
     - __kind: PointerType
-      ID: 106
+      ID: 382
+      Name: '**table<int,interface {}>'
+      ByteSize: 8
+      Pointee: 383 PointerType *table<int,interface {}>
+    - __kind: PointerType
+      ID: 129
       Name: '**table<int,uint8>'
       ByteSize: 8
-      Pointee: 107 PointerType *table<int,uint8>
+      Pointee: 130 PointerType *table<int,uint8>
     - __kind: PointerType
-      ID: 96
+      ID: 119
       Name: '**table<string,[]main.structWithMap>'
       ByteSize: 8
-      Pointee: 97 PointerType *table<string,[]main.structWithMap>
+      Pointee: 120 PointerType *table<string,[]main.structWithMap>
     - __kind: PointerType
-      ID: 84
+      ID: 107
       Name: '**table<string,[]string>'
       ByteSize: 8
-      Pointee: 85 PointerType *table<string,[]string>
+      Pointee: 108 PointerType *table<string,[]string>
     - __kind: PointerType
-      ID: 79
+      ID: 102
       Name: '**table<string,int>'
       ByteSize: 8
-      Pointee: 80 PointerType *table<string,int>
+      Pointee: 103 PointerType *table<string,int>
     - __kind: PointerType
-      ID: 74
+      ID: 97
       Name: '**table<string,main.nestedStruct>'
       ByteSize: 8
-      Pointee: 75 PointerType *table<string,main.nestedStruct>
+      Pointee: 98 PointerType *table<string,main.nestedStruct>
     - __kind: PointerType
-      ID: 116
+      ID: 139
       Name: '**table<uint8,[4]int>'
       ByteSize: 8
-      Pointee: 117 PointerType *table<uint8,[4]int>
+      Pointee: 140 PointerType *table<uint8,[4]int>
     - __kind: PointerType
-      ID: 111
+      ID: 134
       Name: '**table<uint8,uint8>'
       ByteSize: 8
-      Pointee: 112 PointerType *table<uint8,uint8>
+      Pointee: 135 PointerType *table<uint8,uint8>
     - __kind: PointerType
-      ID: 154
+      ID: 180
+      Name: '*[]*main.deepSlice2.array'
+      ByteSize: 8
+      Pointee: 179 GoSliceDataType []*main.deepSlice2.array
+    - __kind: PointerType
+      ID: 313
+      Name: '*[]*main.deepSlice3.array'
+      ByteSize: 8
+      Pointee: 312 GoSliceDataType []*main.deepSlice3.array
+    - __kind: PointerType
+      ID: 338
+      Name: '*[]*main.deepSlice8.array'
+      ByteSize: 8
+      Pointee: 337 GoSliceDataType []*main.deepSlice8.array
+    - __kind: PointerType
+      ID: 344
+      Name: '*[]*main.deepSlice9.array'
+      ByteSize: 8
+      Pointee: 343 GoSliceDataType []*main.deepSlice9.array
+    - __kind: PointerType
+      ID: 177
       Name: '*[]*string.array'
       ByteSize: 8
-      Pointee: 153 GoSliceDataType []*string.array
+      Pointee: 176 GoSliceDataType []*string.array
     - __kind: PointerType
-      ID: 258
+      ID: 294
       Name: '*[][]uint.array'
       ByteSize: 8
-      Pointee: 257 GoSliceDataType [][]uint.array
+      Pointee: 293 GoSliceDataType [][]uint.array
     - __kind: PointerType
-      ID: 264
+      ID: 300
       Name: '*[]bool.array'
       ByteSize: 8
-      Pointee: 263 GoSliceDataType []bool.array
+      Pointee: 299 GoSliceDataType []bool.array
     - __kind: PointerType
-      ID: 281
+      ID: 348
+      Name: '*[]interface {}.array'
+      ByteSize: 8
+      Pointee: 347 GoSliceDataType []interface {}.array
+    - __kind: PointerType
+      ID: 406
       Name: '*[]main.structWithMap.array'
       ByteSize: 8
-      Pointee: 280 GoSliceDataType []main.structWithMap.array
+      Pointee: 405 GoSliceDataType []main.structWithMap.array
     - __kind: PointerType
-      ID: 260
+      ID: 296
       Name: '*[]main.structWithNoStrings.array'
       ByteSize: 8
-      Pointee: 259 GoSliceDataType []main.structWithNoStrings.array
+      Pointee: 295 GoSliceDataType []main.structWithNoStrings.array
     - __kind: PointerType
-      ID: 262
+      ID: 298
       Name: '*[]string.array'
       ByteSize: 8
-      Pointee: 261 GoSliceDataType []string.array
+      Pointee: 297 GoSliceDataType []string.array
     - __kind: PointerType
-      ID: 137
+      ID: 160
       Name: '*[]uint'
       ByteSize: 8
-      Pointee: 135 GoSliceHeaderType []uint
+      Pointee: 158 GoSliceHeaderType []uint
     - __kind: PointerType
-      ID: 256
+      ID: 292
       Name: '*[]uint.array'
       ByteSize: 8
-      Pointee: 255 GoSliceDataType []uint.array
+      Pointee: 291 GoSliceDataType []uint.array
     - __kind: PointerType
-      ID: 266
+      ID: 302
       Name: '*[]uint16.array'
       ByteSize: 8
-      Pointee: 265 GoSliceDataType []uint16.array
+      Pointee: 301 GoSliceDataType []uint16.array
     - __kind: PointerType
       ID: 11
       Name: '*bool'
       ByteSize: 8
-      GoRuntimeType: 388896
+      GoRuntimeType: 392928
       GoKind: 22
       Pointee: 4 BaseType bool
     - __kind: PointerType
       ID: 33
       Name: '*error'
       ByteSize: 8
-      GoRuntimeType: 387808
+      GoRuntimeType: 391840
       GoKind: 22
       Pointee: 14 GoInterfaceType error
     - __kind: PointerType
       ID: 35
       Name: '*float32'
       ByteSize: 8
-      GoRuntimeType: 388768
+      GoRuntimeType: 392800
       GoKind: 22
       Pointee: 18 BaseType float32
     - __kind: PointerType
       ID: 26
       Name: '*float64'
       ByteSize: 8
-      GoRuntimeType: 388832
+      GoRuntimeType: 392864
       GoKind: 22
       Pointee: 16 BaseType float64
     - __kind: PointerType
       ID: 27
       Name: '*int'
       ByteSize: 8
-      GoRuntimeType: 388448
+      GoRuntimeType: 392480
       GoKind: 22
       Pointee: 7 BaseType int
     - __kind: PointerType
       ID: 31
       Name: '*int16'
       ByteSize: 8
-      GoRuntimeType: 388064
+      GoRuntimeType: 392096
       GoKind: 22
       Pointee: 23 BaseType int16
     - __kind: PointerType
       ID: 20
       Name: '*int32'
       ByteSize: 8
-      GoRuntimeType: 388192
+      GoRuntimeType: 392224
       GoKind: 22
       Pointee: 12 BaseType int32
     - __kind: PointerType
       ID: 29
       Name: '*int64'
       ByteSize: 8
-      GoRuntimeType: 388320
+      GoRuntimeType: 392352
       GoKind: 22
       Pointee: 13 BaseType int64
     - __kind: PointerType
       ID: 32
       Name: '*int8'
       ByteSize: 8
-      GoRuntimeType: 387936
+      GoRuntimeType: 391968
       GoKind: 22
       Pointee: 17 BaseType int8
     - __kind: PointerType
-      ID: 61
+      ID: 346
+      Name: '*interface {}'
+      ByteSize: 8
+      GoRuntimeType: 393056
+      GoKind: 22
+      Pointee: 81 GoEmptyInterfaceType interface {}
+    - __kind: PointerType
+      ID: 187
+      Name: '*main.deepMap2'
+      ByteSize: 8
+      GoRuntimeType: 385696
+      GoKind: 22
+      Pointee: 188 StructureType main.deepMap2
+    - __kind: PointerType
+      ID: 325
+      Name: '*main.deepMap3'
+      ByteSize: 8
+      GoRuntimeType: 385632
+      GoKind: 22
+      Pointee: 326 UnresolvedPointeeType main.deepMap3
+    - __kind: PointerType
+      ID: 73
+      Name: '*main.deepMap7'
+      ByteSize: 8
+      GoRuntimeType: 385376
+      GoKind: 22
+      Pointee: 74 StructureType main.deepMap7
+    - __kind: PointerType
+      ID: 360
+      Name: '*main.deepMap8'
+      ByteSize: 8
+      GoRuntimeType: 385312
+      GoKind: 22
+      Pointee: 361 StructureType main.deepMap8
+    - __kind: PointerType
+      ID: 375
+      Name: '*main.deepMap9'
+      ByteSize: 8
+      GoRuntimeType: 385248
+      GoKind: 22
+      Pointee: 376 StructureType main.deepMap9
+    - __kind: PointerType
+      ID: 57
+      Name: '*main.deepPtr2'
+      ByteSize: 8
+      GoRuntimeType: 386272
+      GoKind: 22
+      Pointee: 58 StructureType main.deepPtr2
+    - __kind: PointerType
+      ID: 303
+      Name: '*main.deepPtr3'
+      ByteSize: 8
+      GoRuntimeType: 386208
+      GoKind: 22
+      Pointee: 304 UnresolvedPointeeType main.deepPtr3
+    - __kind: PointerType
+      ID: 59
+      Name: '*main.deepPtr7'
+      ByteSize: 8
+      GoRuntimeType: 385952
+      GoKind: 22
+      Pointee: 60 StructureType main.deepPtr7
+    - __kind: PointerType
+      ID: 329
+      Name: '*main.deepPtr8'
+      ByteSize: 8
+      GoRuntimeType: 385888
+      GoKind: 22
+      Pointee: 330 StructureType main.deepPtr8
+    - __kind: PointerType
+      ID: 331
+      Name: '*main.deepPtr9'
+      ByteSize: 8
+      GoRuntimeType: 385824
+      GoKind: 22
+      Pointee: 332 StructureType main.deepPtr9
+    - __kind: PointerType
+      ID: 64
+      Name: '*main.deepSlice2'
+      ByteSize: 8
+      GoRuntimeType: 386848
+      GoKind: 22
+      Pointee: 178 StructureType main.deepSlice2
+    - __kind: PointerType
+      ID: 310
+      Name: '*main.deepSlice3'
+      ByteSize: 8
+      GoRuntimeType: 386784
+      GoKind: 22
+      Pointee: 311 UnresolvedPointeeType main.deepSlice3
+    - __kind: PointerType
+      ID: 65
+      Name: '*main.deepSlice7'
+      ByteSize: 8
+      GoRuntimeType: 386528
+      GoKind: 22
+      Pointee: 66 StructureType main.deepSlice7
+    - __kind: PointerType
+      ID: 335
+      Name: '*main.deepSlice8'
+      ByteSize: 8
+      GoRuntimeType: 386464
+      GoKind: 22
+      Pointee: 336 StructureType main.deepSlice8
+    - __kind: PointerType
+      ID: 341
+      Name: '*main.deepSlice9'
+      ByteSize: 8
+      GoRuntimeType: 386400
+      GoKind: 22
+      Pointee: 342 StructureType main.deepSlice9
+    - __kind: PointerType
+      ID: 84
       Name: '*main.esotericHeap'
       ByteSize: 8
-      GoRuntimeType: 382944
+      GoRuntimeType: 386976
       GoKind: 22
-      Pointee: 62 StructureType main.esotericHeap
+      Pointee: 85 StructureType main.esotericHeap
     - __kind: PointerType
-      ID: 132
+      ID: 155
       Name: '*main.node'
       ByteSize: 8
-      GoRuntimeType: 383008
+      GoRuntimeType: 387040
       GoKind: 22
-      Pointee: 131 StructureType main.node
+      Pointee: 154 StructureType main.node
     - __kind: PointerType
-      ID: 146
+      ID: 169
       Name: '*main.oneStringStruct'
       ByteSize: 8
       GoKind: 22
-      Pointee: 147 StructureType main.oneStringStruct
+      Pointee: 170 StructureType main.oneStringStruct
     - __kind: PointerType
-      ID: 203
+      ID: 75
+      Name: '*main.stringType1'
+      ByteSize: 8
+      GoKind: 22
+      Pointee: 76 GoStringHeaderType main.stringType1
+    - __kind: PointerType
+      ID: 306
+      Name: '*main.stringType1.str'
+      ByteSize: 8
+      Pointee: 305 GoStringDataType main.stringType1.str
+    - __kind: PointerType
+      ID: 78
+      Name: '*main.stringType2'
+      ByteSize: 8
+      GoKind: 22
+      Pointee: 307 UnresolvedPointeeType main.stringType2
+    - __kind: PointerType
+      ID: 239
       Name: '*main.structWithMap'
       ByteSize: 8
-      GoRuntimeType: 382880
+      GoRuntimeType: 385184
       GoKind: 22
-      Pointee: 65 StructureType main.structWithMap
+      Pointee: 88 StructureType main.structWithMap
     - __kind: PointerType
-      ID: 139
+      ID: 162
       Name: '*main.structWithNoStrings'
       ByteSize: 8
-      Pointee: 140 StructureType main.structWithNoStrings
+      Pointee: 163 StructureType main.structWithNoStrings
     - __kind: PointerType
-      ID: 129
+      ID: 152
       Name: '*main.structWithTwoValues'
       ByteSize: 8
       GoKind: 22
-      Pointee: 130 StructureType main.structWithTwoValues
+      Pointee: 153 StructureType main.structWithTwoValues
     - __kind: PointerType
-      ID: 133
+      ID: 156
       Name: '*main.t'
       ByteSize: 8
       GoKind: 22
-      Pointee: 134 GoSliceHeaderType main.t
+      Pointee: 157 GoSliceHeaderType main.t
     - __kind: PointerType
-      ID: 279
+      ID: 404
       Name: '*main.t.array'
       ByteSize: 8
-      Pointee: 278 GoSliceDataType main.t.array
+      Pointee: 403 GoSliceDataType main.t.array
     - __kind: PointerType
-      ID: 145
+      ID: 168
       Name: '*main.threeStringStruct'
       ByteSize: 8
       GoKind: 22
-      Pointee: 144 StructureType main.threeStringStruct
+      Pointee: 167 StructureType main.threeStringStruct
     - __kind: PointerType
-      ID: 124
+      ID: 147
       Name: '*map<[4]int,[4]int>'
       ByteSize: 8
-      Pointee: 125 GoSwissMapHeaderType map<[4]int,[4]int>
+      Pointee: 148 GoSwissMapHeaderType map<[4]int,[4]int>
     - __kind: PointerType
-      ID: 119
+      ID: 142
       Name: '*map<[4]int,uint8>'
       ByteSize: 8
-      Pointee: 120 GoSwissMapHeaderType map<[4]int,uint8>
+      Pointee: 143 GoSwissMapHeaderType map<[4]int,uint8>
     - __kind: PointerType
-      ID: 87
+      ID: 110
       Name: '*map<[4]string,[2]int>'
       ByteSize: 8
-      Pointee: 88 GoSwissMapHeaderType map<[4]string,[2]int>
+      Pointee: 111 GoSwissMapHeaderType map<[4]string,[2]int>
     - __kind: PointerType
-      ID: 99
+      ID: 122
       Name: '*map<bool,main.node>'
       ByteSize: 8
-      Pointee: 100 GoSwissMapHeaderType map<bool,main.node>
+      Pointee: 123 GoSwissMapHeaderType map<bool,main.node>
     - __kind: PointerType
-      ID: 67
+      ID: 69
+      Name: '*map<int,*main.deepMap2>'
+      ByteSize: 8
+      Pointee: 70 GoSwissMapHeaderType map<int,*main.deepMap2>
+    - __kind: PointerType
+      ID: 315
+      Name: '*map<int,*main.deepMap3>'
+      ByteSize: 8
+      Pointee: 316 GoSwissMapHeaderType map<int,*main.deepMap3>
+    - __kind: PointerType
+      ID: 350
+      Name: '*map<int,*main.deepMap8>'
+      ByteSize: 8
+      Pointee: 351 GoSwissMapHeaderType map<int,*main.deepMap8>
+    - __kind: PointerType
+      ID: 365
+      Name: '*map<int,*main.deepMap9>'
+      ByteSize: 8
+      Pointee: 366 GoSwissMapHeaderType map<int,*main.deepMap9>
+    - __kind: PointerType
+      ID: 90
       Name: '*map<int,int>'
       ByteSize: 8
-      Pointee: 68 GoSwissMapHeaderType map<int,int>
+      Pointee: 91 GoSwissMapHeaderType map<int,int>
     - __kind: PointerType
-      ID: 104
+      ID: 380
+      Name: '*map<int,interface {}>'
+      ByteSize: 8
+      Pointee: 381 GoSwissMapHeaderType map<int,interface {}>
+    - __kind: PointerType
+      ID: 127
       Name: '*map<int,uint8>'
       ByteSize: 8
-      Pointee: 105 GoSwissMapHeaderType map<int,uint8>
+      Pointee: 128 GoSwissMapHeaderType map<int,uint8>
     - __kind: PointerType
-      ID: 94
+      ID: 117
       Name: '*map<string,[]main.structWithMap>'
       ByteSize: 8
-      Pointee: 95 GoSwissMapHeaderType map<string,[]main.structWithMap>
+      Pointee: 118 GoSwissMapHeaderType map<string,[]main.structWithMap>
     - __kind: PointerType
-      ID: 82
+      ID: 105
       Name: '*map<string,[]string>'
       ByteSize: 8
-      Pointee: 83 GoSwissMapHeaderType map<string,[]string>
+      Pointee: 106 GoSwissMapHeaderType map<string,[]string>
     - __kind: PointerType
-      ID: 77
+      ID: 100
       Name: '*map<string,int>'
       ByteSize: 8
-      Pointee: 78 GoSwissMapHeaderType map<string,int>
+      Pointee: 101 GoSwissMapHeaderType map<string,int>
     - __kind: PointerType
-      ID: 72
+      ID: 95
       Name: '*map<string,main.nestedStruct>'
       ByteSize: 8
-      Pointee: 73 GoSwissMapHeaderType map<string,main.nestedStruct>
+      Pointee: 96 GoSwissMapHeaderType map<string,main.nestedStruct>
     - __kind: PointerType
-      ID: 114
+      ID: 137
       Name: '*map<uint8,[4]int>'
       ByteSize: 8
-      Pointee: 115 GoSwissMapHeaderType map<uint8,[4]int>
+      Pointee: 138 GoSwissMapHeaderType map<uint8,[4]int>
     - __kind: PointerType
-      ID: 109
+      ID: 132
       Name: '*map<uint8,uint8>'
       ByteSize: 8
-      Pointee: 110 GoSwissMapHeaderType map<uint8,uint8>
+      Pointee: 133 GoSwissMapHeaderType map<uint8,uint8>
     - __kind: PointerType
-      ID: 92
+      ID: 115
       Name: '*map[string]int'
       ByteSize: 8
       GoKind: 22
-      Pointee: 76 GoMapType map[string]int
+      Pointee: 99 GoMapType map[string]int
     - __kind: PointerType
-      ID: 249
+      ID: 285
       Name: '*noalg.map.group[[4]int][4]int'
       ByteSize: 8
-      Pointee: 250 StructureType noalg.map.group[[4]int][4]int
+      Pointee: 286 StructureType noalg.map.group[[4]int][4]int
     - __kind: PointerType
-      ID: 241
+      ID: 277
       Name: '*noalg.map.group[[4]int]uint8'
       ByteSize: 8
-      Pointee: 242 StructureType noalg.map.group[[4]int]uint8
+      Pointee: 278 StructureType noalg.map.group[[4]int]uint8
     - __kind: PointerType
-      ID: 189
+      ID: 225
       Name: '*noalg.map.group[[4]string][2]int'
       ByteSize: 8
-      Pointee: 190 StructureType noalg.map.group[[4]string][2]int
+      Pointee: 226 StructureType noalg.map.group[[4]string][2]int
     - __kind: PointerType
-      ID: 208
+      ID: 244
       Name: '*noalg.map.group[bool]main.node'
       ByteSize: 8
-      Pointee: 209 StructureType noalg.map.group[bool]main.node
+      Pointee: 245 StructureType noalg.map.group[bool]main.node
     - __kind: PointerType
-      ID: 157
+      ID: 183
+      Name: '*noalg.map.group[int]*main.deepMap2'
+      ByteSize: 8
+      Pointee: 184 StructureType noalg.map.group[int]*main.deepMap2
+    - __kind: PointerType
+      ID: 321
+      Name: '*noalg.map.group[int]*main.deepMap3'
+      ByteSize: 8
+      Pointee: 322 StructureType noalg.map.group[int]*main.deepMap3
+    - __kind: PointerType
+      ID: 356
+      Name: '*noalg.map.group[int]*main.deepMap8'
+      ByteSize: 8
+      Pointee: 357 StructureType noalg.map.group[int]*main.deepMap8
+    - __kind: PointerType
+      ID: 371
+      Name: '*noalg.map.group[int]*main.deepMap9'
+      ByteSize: 8
+      Pointee: 372 StructureType noalg.map.group[int]*main.deepMap9
+    - __kind: PointerType
+      ID: 193
       Name: '*noalg.map.group[int]int'
       ByteSize: 8
-      Pointee: 158 StructureType noalg.map.group[int]int
+      Pointee: 194 StructureType noalg.map.group[int]int
     - __kind: PointerType
-      ID: 216
+      ID: 386
+      Name: '*noalg.map.group[int]interface {}'
+      ByteSize: 8
+      Pointee: 387 StructureType noalg.map.group[int]interface {}
+    - __kind: PointerType
+      ID: 252
       Name: '*noalg.map.group[int]uint8'
       ByteSize: 8
-      Pointee: 217 StructureType noalg.map.group[int]uint8
+      Pointee: 253 StructureType noalg.map.group[int]uint8
     - __kind: PointerType
-      ID: 198
+      ID: 234
       Name: '*noalg.map.group[string][]main.structWithMap'
       ByteSize: 8
-      Pointee: 199 StructureType noalg.map.group[string][]main.structWithMap
+      Pointee: 235 StructureType noalg.map.group[string][]main.structWithMap
     - __kind: PointerType
-      ID: 181
+      ID: 217
       Name: '*noalg.map.group[string][]string'
       ByteSize: 8
-      Pointee: 182 StructureType noalg.map.group[string][]string
+      Pointee: 218 StructureType noalg.map.group[string][]string
     - __kind: PointerType
-      ID: 173
+      ID: 209
       Name: '*noalg.map.group[string]int'
       ByteSize: 8
-      Pointee: 174 StructureType noalg.map.group[string]int
+      Pointee: 210 StructureType noalg.map.group[string]int
     - __kind: PointerType
-      ID: 165
+      ID: 201
       Name: '*noalg.map.group[string]main.nestedStruct'
       ByteSize: 8
-      Pointee: 166 StructureType noalg.map.group[string]main.nestedStruct
+      Pointee: 202 StructureType noalg.map.group[string]main.nestedStruct
     - __kind: PointerType
-      ID: 232
+      ID: 268
       Name: '*noalg.map.group[uint8][4]int'
       ByteSize: 8
-      Pointee: 233 StructureType noalg.map.group[uint8][4]int
+      Pointee: 269 StructureType noalg.map.group[uint8][4]int
     - __kind: PointerType
-      ID: 224
+      ID: 260
       Name: '*noalg.map.group[uint8]uint8'
       ByteSize: 8
-      Pointee: 225 StructureType noalg.map.group[uint8]uint8
+      Pointee: 261 StructureType noalg.map.group[uint8]uint8
     - __kind: PointerType
       ID: 22
       Name: '*string'
       ByteSize: 8
-      GoRuntimeType: 387872
+      GoRuntimeType: 391904
       GoKind: 22
       Pointee: 9 GoStringHeaderType string
     - __kind: PointerType
-      ID: 152
+      ID: 175
       Name: '*string.str'
       ByteSize: 8
-      Pointee: 151 GoStringDataType string.str
+      Pointee: 174 GoStringDataType string.str
     - __kind: PointerType
-      ID: 127
+      ID: 150
       Name: '*table<[4]int,[4]int>'
       ByteSize: 8
-      Pointee: 247 StructureType table<[4]int,[4]int>
+      Pointee: 283 StructureType table<[4]int,[4]int>
     - __kind: PointerType
-      ID: 122
+      ID: 145
       Name: '*table<[4]int,uint8>'
       ByteSize: 8
-      Pointee: 239 StructureType table<[4]int,uint8>
+      Pointee: 275 StructureType table<[4]int,uint8>
     - __kind: PointerType
-      ID: 90
+      ID: 113
       Name: '*table<[4]string,[2]int>'
       ByteSize: 8
-      Pointee: 187 StructureType table<[4]string,[2]int>
+      Pointee: 223 StructureType table<[4]string,[2]int>
     - __kind: PointerType
-      ID: 102
+      ID: 125
       Name: '*table<bool,main.node>'
       ByteSize: 8
-      Pointee: 206 StructureType table<bool,main.node>
+      Pointee: 242 StructureType table<bool,main.node>
     - __kind: PointerType
-      ID: 70
+      ID: 72
+      Name: '*table<int,*main.deepMap2>'
+      ByteSize: 8
+      Pointee: 181 StructureType table<int,*main.deepMap2>
+    - __kind: PointerType
+      ID: 318
+      Name: '*table<int,*main.deepMap3>'
+      ByteSize: 8
+      Pointee: 319 StructureType table<int,*main.deepMap3>
+    - __kind: PointerType
+      ID: 353
+      Name: '*table<int,*main.deepMap8>'
+      ByteSize: 8
+      Pointee: 354 StructureType table<int,*main.deepMap8>
+    - __kind: PointerType
+      ID: 368
+      Name: '*table<int,*main.deepMap9>'
+      ByteSize: 8
+      Pointee: 369 StructureType table<int,*main.deepMap9>
+    - __kind: PointerType
+      ID: 93
       Name: '*table<int,int>'
       ByteSize: 8
-      Pointee: 155 StructureType table<int,int>
+      Pointee: 191 StructureType table<int,int>
     - __kind: PointerType
-      ID: 107
+      ID: 383
+      Name: '*table<int,interface {}>'
+      ByteSize: 8
+      Pointee: 384 StructureType table<int,interface {}>
+    - __kind: PointerType
+      ID: 130
       Name: '*table<int,uint8>'
       ByteSize: 8
-      Pointee: 214 StructureType table<int,uint8>
+      Pointee: 250 StructureType table<int,uint8>
     - __kind: PointerType
-      ID: 97
+      ID: 120
       Name: '*table<string,[]main.structWithMap>'
       ByteSize: 8
-      Pointee: 196 StructureType table<string,[]main.structWithMap>
+      Pointee: 232 StructureType table<string,[]main.structWithMap>
     - __kind: PointerType
-      ID: 85
+      ID: 108
       Name: '*table<string,[]string>'
       ByteSize: 8
-      Pointee: 179 StructureType table<string,[]string>
+      Pointee: 215 StructureType table<string,[]string>
     - __kind: PointerType
-      ID: 80
+      ID: 103
       Name: '*table<string,int>'
       ByteSize: 8
-      Pointee: 171 StructureType table<string,int>
+      Pointee: 207 StructureType table<string,int>
     - __kind: PointerType
-      ID: 75
+      ID: 98
       Name: '*table<string,main.nestedStruct>'
       ByteSize: 8
-      Pointee: 163 StructureType table<string,main.nestedStruct>
+      Pointee: 199 StructureType table<string,main.nestedStruct>
     - __kind: PointerType
-      ID: 117
+      ID: 140
       Name: '*table<uint8,[4]int>'
       ByteSize: 8
-      Pointee: 230 StructureType table<uint8,[4]int>
+      Pointee: 266 StructureType table<uint8,[4]int>
     - __kind: PointerType
-      ID: 112
+      ID: 135
       Name: '*table<uint8,uint8>'
       ByteSize: 8
-      Pointee: 222 StructureType table<uint8,uint8>
+      Pointee: 258 StructureType table<uint8,uint8>
     - __kind: PointerType
       ID: 34
       Name: '*uint'
       ByteSize: 8
-      GoRuntimeType: 388512
+      GoRuntimeType: 392544
       GoKind: 22
       Pointee: 10 BaseType uint
     - __kind: PointerType
       ID: 30
       Name: '*uint16'
       ByteSize: 8
-      GoRuntimeType: 388128
+      GoRuntimeType: 392160
       GoKind: 22
       Pointee: 6 BaseType uint16
     - __kind: PointerType
       ID: 21
       Name: '*uint32'
       ByteSize: 8
-      GoRuntimeType: 388256
+      GoRuntimeType: 392288
       GoKind: 22
       Pointee: 2 BaseType uint32
     - __kind: PointerType
       ID: 28
       Name: '*uint64'
       ByteSize: 8
-      GoRuntimeType: 388384
+      GoRuntimeType: 392416
       GoKind: 22
       Pointee: 8 BaseType uint64
     - __kind: PointerType
       ID: 5
       Name: '*uint8'
       ByteSize: 8
-      GoRuntimeType: 388000
+      GoRuntimeType: 392032
       GoKind: 22
       Pointee: 3 BaseType uint8
     - __kind: PointerType
       ID: 19
       Name: '*uintptr'
       ByteSize: 8
-      GoRuntimeType: 388576
+      GoRuntimeType: 392608
       GoKind: 22
       Pointee: 1 BaseType uintptr
     - __kind: EventRootType
-      ID: 369
+      ID: 502
       Name: Probe[main.stackC]
     - __kind: EventRootType
-      ID: 326
+      ID: 459
       Name: Probe[main.testAny]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -3577,14 +4095,14 @@ Types:
         - Name: a
           Offset: 1
           Expression:
-            Type: 58 GoEmptyInterfaceType interface {}
+            Type: 81 GoEmptyInterfaceType interface {}
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 45, index: 0, name: a}
+                  Variable: {subprogram: 53, index: 0, name: a}
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 298
+      ID: 423
       Name: Probe[main.testArrayOfArraysOfArrays]
       ByteSize: 65
       PresenceBitsetSize: 1
@@ -3599,7 +4117,7 @@ Types:
                   Offset: 0
                   ByteSize: 64
     - __kind: EventRootType
-      ID: 296
+      ID: 421
       Name: Probe[main.testArrayOfArrays]
       ByteSize: 33
       PresenceBitsetSize: 1
@@ -3614,7 +4132,7 @@ Types:
                   Offset: 0
                   ByteSize: 32
     - __kind: EventRootType
-      ID: 334
+      ID: 467
       Name: Probe[main.testArrayOfMaps]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -3622,14 +4140,14 @@ Types:
         - Name: m
           Offset: 1
           Expression:
-            Type: 91 ArrayType [2]map[string]int
+            Type: 114 ArrayType [2]map[string]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 53, index: 0, name: m}
+                  Variable: {subprogram: 61, index: 0, name: m}
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 297
+      ID: 422
       Name: Probe[main.testArrayOfStrings]
       ByteSize: 33
       PresenceBitsetSize: 1
@@ -3644,7 +4162,7 @@ Types:
                   Offset: 0
                   ByteSize: 32
     - __kind: EventRootType
-      ID: 316
+      ID: 441
       Name: Probe[main.testBigStruct]
       ByteSize: 49
       PresenceBitsetSize: 1
@@ -3659,7 +4177,7 @@ Types:
                   Offset: 0
                   ByteSize: 48
     - __kind: EventRootType
-      ID: 285
+      ID: 410
       Name: Probe[main.testBoolArray]
       ByteSize: 3
       PresenceBitsetSize: 1
@@ -3674,7 +4192,7 @@ Types:
                   Offset: 0
                   ByteSize: 2
     - __kind: EventRootType
-      ID: 282
+      ID: 407
       Name: Probe[main.testByteArray]
       ByteSize: 3
       PresenceBitsetSize: 1
@@ -3689,7 +4207,7 @@ Types:
                   Offset: 0
                   ByteSize: 2
     - __kind: EventRootType
-      ID: 350
+      ID: 483
       Name: Probe[main.testChannel]
       ByteSize: 1
       PresenceBitsetSize: 1
@@ -3697,14 +4215,14 @@ Types:
         - Name: c
           Offset: 1
           Expression:
-            Type: 128 GoChannelType chan bool
+            Type: 151 GoChannelType chan bool
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 69, index: 0, name: c}
+                  Variable: {subprogram: 77, index: 0, name: c}
                   Offset: 0
                   ByteSize: 0
     - __kind: EventRootType
-      ID: 348
+      ID: 481
       Name: Probe[main.testCombinedByte]
       ByteSize: 7
       PresenceBitsetSize: 1
@@ -3715,7 +4233,7 @@ Types:
             Type: 3 BaseType uint8
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 67, index: 0, name: w}
+                  Variable: {subprogram: 75, index: 0, name: w}
                   Offset: 0
                   ByteSize: 1
         - Name: x
@@ -3724,7 +4242,7 @@ Types:
             Type: 3 BaseType uint8
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 67, index: 1, name: x}
+                  Variable: {subprogram: 75, index: 1, name: x}
                   Offset: 0
                   ByteSize: 1
         - Name: y
@@ -3733,11 +4251,11 @@ Types:
             Type: 18 BaseType float32
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 67, index: 2, name: y}
+                  Variable: {subprogram: 75, index: 2, name: y}
                   Offset: 0
                   ByteSize: 4
     - __kind: EventRootType
-      ID: 358
+      ID: 491
       Name: Probe[main.testCycle]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -3745,14 +4263,104 @@ Types:
         - Name: t
           Offset: 1
           Expression:
-            Type: 133 PointerType *main.t
+            Type: 156 PointerType *main.t
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 77, index: 0, name: t}
+                  Variable: {subprogram: 85, index: 0, name: t}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 363
+      ID: 446
+      Name: Probe[main.testDeepMap1]
+      ByteSize: 9
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: a
+          Offset: 1
+          Expression:
+            Type: 67 StructureType main.deepMap1
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 40, index: 0, name: a}
+                  Offset: 0
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 447
+      Name: Probe[main.testDeepMap7]
+      ByteSize: 9
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: a
+          Offset: 1
+          Expression:
+            Type: 73 PointerType *main.deepMap7
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 41, index: 0, name: a}
+                  Offset: 0
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 442
+      Name: Probe[main.testDeepPtr1]
+      ByteSize: 9
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: a
+          Offset: 1
+          Expression:
+            Type: 56 StructureType main.deepPtr1
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 36, index: 0, name: a}
+                  Offset: 0
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 443
+      Name: Probe[main.testDeepPtr7]
+      ByteSize: 9
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: a
+          Offset: 1
+          Expression:
+            Type: 59 PointerType *main.deepPtr7
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 37, index: 0, name: a}
+                  Offset: 0
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 444
+      Name: Probe[main.testDeepSlice1]
+      ByteSize: 25
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: a
+          Offset: 1
+          Expression:
+            Type: 61 StructureType main.deepSlice1
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 38, index: 0, name: a}
+                  Offset: 0
+                  ByteSize: 24
+    - __kind: EventRootType
+      ID: 445
+      Name: Probe[main.testDeepSlice7]
+      ByteSize: 9
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: a
+          Offset: 1
+          Expression:
+            Type: 65 PointerType *main.deepSlice7
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 39, index: 0, name: a}
+                  Offset: 0
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 496
       Name: Probe[main.testEmptySliceOfStructs]
       ByteSize: 33
       PresenceBitsetSize: 1
@@ -3760,10 +4368,10 @@ Types:
         - Name: xs
           Offset: 1
           Expression:
-            Type: 138 GoSliceHeaderType []main.structWithNoStrings
+            Type: 161 GoSliceHeaderType []main.structWithNoStrings
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 82, index: 0, name: xs}
+                  Variable: {subprogram: 90, index: 0, name: xs}
                   Offset: 0
                   ByteSize: 24
         - Name: a
@@ -3772,11 +4380,11 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 82, index: 1, name: a}
+                  Variable: {subprogram: 90, index: 1, name: a}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 360
+      ID: 493
       Name: Probe[main.testEmptySlice]
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -3784,14 +4392,14 @@ Types:
         - Name: u
           Offset: 1
           Expression:
-            Type: 135 GoSliceHeaderType []uint
+            Type: 158 GoSliceHeaderType []uint
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 79, index: 0, name: u}
+                  Variable: {subprogram: 87, index: 0, name: u}
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 377
+      ID: 510
       Name: Probe[main.testEmptyString]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -3802,11 +4410,11 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 96, index: 0, name: x}
+                  Variable: {subprogram: 104, index: 0, name: x}
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 379
+      ID: 512
       Name: Probe[main.testEmptyStruct]
       ByteSize: 1
       PresenceBitsetSize: 1
@@ -3814,14 +4422,14 @@ Types:
         - Name: e
           Offset: 1
           Expression:
-            Type: 150 StructureType main.emptyStruct
+            Type: 173 StructureType main.emptyStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 98, index: 0, name: e}
+                  Variable: {subprogram: 106, index: 0, name: e}
                   Offset: 0
                   ByteSize: 0
     - __kind: EventRootType
-      ID: 327
+      ID: 460
       Name: Probe[main.testError]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -3832,11 +4440,11 @@ Types:
             Type: 14 GoInterfaceType error
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 46, index: 0, name: e}
+                  Variable: {subprogram: 54, index: 0, name: e}
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 318
+      ID: 451
       Name: Probe[main.testEsotericHeap]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -3844,14 +4452,14 @@ Types:
         - Name: e
           Offset: 1
           Expression:
-            Type: 61 PointerType *main.esotericHeap
+            Type: 84 PointerType *main.esotericHeap
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 37, index: 0, name: e}
+                  Variable: {subprogram: 45, index: 0, name: e}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 317
+      ID: 450
       Name: Probe[main.testEsotericStack]
       ByteSize: 65
       PresenceBitsetSize: 1
@@ -3859,14 +4467,14 @@ Types:
         - Name: e
           Offset: 1
           Expression:
-            Type: 56 StructureType main.esotericStack
+            Type: 79 StructureType main.esotericStack
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 36, index: 0, name: e}
+                  Variable: {subprogram: 44, index: 0, name: e}
                   Offset: 0
                   ByteSize: 64
     - __kind: EventRootType
-      ID: 324
+      ID: 457
       Name: Probe[main.testFramelessArray]
       ByteSize: 41
       PresenceBitsetSize: 1
@@ -3874,14 +4482,14 @@ Types:
         - Name: a
           Offset: 1
           Expression:
-            Type: 63 ArrayType [5]int
+            Type: 86 ArrayType [5]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 43, index: 0, name: a}
+                  Variable: {subprogram: 51, index: 0, name: a}
                   Offset: 0
                   ByteSize: 40
     - __kind: EventRootType
-      ID: 323
+      ID: 456
       Name: Probe[main.testFrameless]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -3892,11 +4500,11 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 42, index: 0, name: x}
+                  Variable: {subprogram: 50, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 319
+      ID: 452
       Name: Probe[main.testInlinedBA]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -3907,11 +4515,11 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 38, index: 0, name: x}
+                  Variable: {subprogram: 46, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 321
+      ID: 454
       Name: Probe[main.testInlinedBBA]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -3922,14 +4530,14 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 40, index: 0, name: x}
+                  Variable: {subprogram: 48, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 381
+      ID: 514
       Name: Probe[main.testInlinedBBB]
     - __kind: EventRootType
-      ID: 320
+      ID: 453
       Name: Probe[main.testInlinedBB]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -3940,7 +4548,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 39, index: 0, name: x}
+                  Variable: {subprogram: 47, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
         - Name: y
@@ -3949,20 +4557,20 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 39, index: 1, name: y}
+                  Variable: {subprogram: 47, index: 1, name: y}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 382
+      ID: 515
       Name: Probe[main.testInlinedBCA]
     - __kind: EventRootType
-      ID: 383
+      ID: 516
       Name: Probe[main.testInlinedBCB]
     - __kind: EventRootType
-      ID: 322
+      ID: 455
       Name: Probe[main.testInlinedBC]
     - __kind: EventRootType
-      ID: 380
+      ID: 513
       Name: Probe[main.testInlinedPrint]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -3973,11 +4581,11 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 99, index: 0, name: x}
+                  Variable: {subprogram: 107, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 384
+      ID: 517
       Name: Probe[main.testInlinedSq]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -3988,11 +4596,11 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 103, index: 0, name: x}
+                  Variable: {subprogram: 111, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 385
+      ID: 518
       Name: Probe[main.testInlinedSumArray]
       ByteSize: 41
       PresenceBitsetSize: 1
@@ -4000,14 +4608,14 @@ Types:
         - Name: a
           Offset: 1
           Expression:
-            Type: 63 ArrayType [5]int
+            Type: 86 ArrayType [5]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 104, index: 0, name: a}
+                  Variable: {subprogram: 112, index: 0, name: a}
                   Offset: 0
                   ByteSize: 40
     - __kind: EventRootType
-      ID: 288
+      ID: 413
       Name: Probe[main.testInt16Array]
       ByteSize: 5
       PresenceBitsetSize: 1
@@ -4022,7 +4630,7 @@ Types:
                   Offset: 0
                   ByteSize: 4
     - __kind: EventRootType
-      ID: 289
+      ID: 414
       Name: Probe[main.testInt32Array]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -4037,7 +4645,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 290
+      ID: 415
       Name: Probe[main.testInt64Array]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -4052,7 +4660,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 287
+      ID: 412
       Name: Probe[main.testInt8Array]
       ByteSize: 3
       PresenceBitsetSize: 1
@@ -4067,7 +4675,7 @@ Types:
                   Offset: 0
                   ByteSize: 2
     - __kind: EventRootType
-      ID: 286
+      ID: 411
       Name: Probe[main.testIntArray]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -4082,7 +4690,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 325
+      ID: 458
       Name: Probe[main.testInterface]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -4090,14 +4698,14 @@ Types:
         - Name: b
           Offset: 1
           Expression:
-            Type: 64 GoInterfaceType main.behavior
+            Type: 87 GoInterfaceType main.behavior
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 44, index: 0, name: b}
+                  Variable: {subprogram: 52, index: 0, name: b}
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 352
+      ID: 485
       Name: Probe[main.testLinkedList]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -4105,14 +4713,14 @@ Types:
         - Name: a
           Offset: 1
           Expression:
-            Type: 131 StructureType main.node
+            Type: 154 StructureType main.node
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 71, index: 0, name: a}
+                  Variable: {subprogram: 79, index: 0, name: a}
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 332
+      ID: 465
       Name: Probe[main.testMapArrayToArray]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -4120,14 +4728,14 @@ Types:
         - Name: m
           Offset: 1
           Expression:
-            Type: 86 GoMapType map[[4]string][2]int
+            Type: 109 GoMapType map[[4]string][2]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 51, index: 0, name: m}
+                  Variable: {subprogram: 59, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 338
+      ID: 471
       Name: Probe[main.testMapEmbeddedMaps]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -4135,14 +4743,14 @@ Types:
         - Name: m
           Offset: 1
           Expression:
-            Type: 93 GoMapType map[string][]main.structWithMap
+            Type: 116 GoMapType map[string][]main.structWithMap
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 57, index: 0, name: m}
+                  Variable: {subprogram: 65, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 336
+      ID: 469
       Name: Probe[main.testMapIntToInt]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -4150,14 +4758,14 @@ Types:
         - Name: m
           Offset: 1
           Expression:
-            Type: 66 GoMapType map[int]int
+            Type: 89 GoMapType map[int]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 55, index: 0, name: m}
+                  Variable: {subprogram: 63, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 347
+      ID: 480
       Name: Probe[main.testMapLargeKeyLargeValue]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -4165,14 +4773,14 @@ Types:
         - Name: m
           Offset: 1
           Expression:
-            Type: 123 GoMapType map[[4]int][4]int
+            Type: 146 GoMapType map[[4]int][4]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 66, index: 0, name: m}
+                  Variable: {subprogram: 74, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 346
+      ID: 479
       Name: Probe[main.testMapLargeKeySmallValue]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -4180,14 +4788,14 @@ Types:
         - Name: m
           Offset: 1
           Expression:
-            Type: 118 GoMapType map[[4]int]uint8
+            Type: 141 GoMapType map[[4]int]uint8
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 65, index: 0, name: m}
+                  Variable: {subprogram: 73, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 337
+      ID: 470
       Name: Probe[main.testMapMassive]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -4195,14 +4803,14 @@ Types:
         - Name: redactMyEntries
           Offset: 1
           Expression:
-            Type: 93 GoMapType map[string][]main.structWithMap
+            Type: 116 GoMapType map[string][]main.structWithMap
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 56, index: 0, name: redactMyEntries}
+                  Variable: {subprogram: 64, index: 0, name: redactMyEntries}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 345
+      ID: 478
       Name: Probe[main.testMapSmallKeyLargeValue]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -4210,14 +4818,14 @@ Types:
         - Name: m
           Offset: 1
           Expression:
-            Type: 113 GoMapType map[uint8][4]int
+            Type: 136 GoMapType map[uint8][4]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 64, index: 0, name: m}
+                  Variable: {subprogram: 72, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 344
+      ID: 477
       Name: Probe[main.testMapSmallKeySmallValue]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -4225,14 +4833,14 @@ Types:
         - Name: m
           Offset: 1
           Expression:
-            Type: 108 GoMapType map[uint8]uint8
+            Type: 131 GoMapType map[uint8]uint8
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 63, index: 0, name: m}
+                  Variable: {subprogram: 71, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 330
+      ID: 463
       Name: Probe[main.testMapStringToInt]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -4240,14 +4848,14 @@ Types:
         - Name: m
           Offset: 1
           Expression:
-            Type: 76 GoMapType map[string]int
+            Type: 99 GoMapType map[string]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 49, index: 0, name: m}
+                  Variable: {subprogram: 57, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 331
+      ID: 464
       Name: Probe[main.testMapStringToSlice]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -4255,14 +4863,14 @@ Types:
         - Name: m
           Offset: 1
           Expression:
-            Type: 81 GoMapType map[string][]string
+            Type: 104 GoMapType map[string][]string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 50, index: 0, name: m}
+                  Variable: {subprogram: 58, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 329
+      ID: 462
       Name: Probe[main.testMapStringToStruct]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -4270,14 +4878,14 @@ Types:
         - Name: m
           Offset: 1
           Expression:
-            Type: 71 GoMapType map[string]main.nestedStruct
+            Type: 94 GoMapType map[string]main.nestedStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 48, index: 0, name: m}
+                  Variable: {subprogram: 56, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 339
+      ID: 472
       Name: Probe[main.testMapWithLinkedList]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -4285,14 +4893,14 @@ Types:
         - Name: m
           Offset: 1
           Expression:
-            Type: 98 GoMapType map[bool]main.node
+            Type: 121 GoMapType map[bool]main.node
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 58, index: 0, name: m}
+                  Variable: {subprogram: 66, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 343
+      ID: 476
       Name: Probe[main.testMapWithSmallKeyAndValueMassive]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -4300,14 +4908,14 @@ Types:
         - Name: m
           Offset: 1
           Expression:
-            Type: 108 GoMapType map[uint8]uint8
+            Type: 131 GoMapType map[uint8]uint8
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 62, index: 0, name: m}
+                  Variable: {subprogram: 70, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 342
+      ID: 475
       Name: Probe[main.testMapWithSmallKeyAndValue]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -4315,14 +4923,14 @@ Types:
         - Name: m
           Offset: 1
           Expression:
-            Type: 108 GoMapType map[uint8]uint8
+            Type: 131 GoMapType map[uint8]uint8
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 61, index: 0, name: m}
+                  Variable: {subprogram: 69, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 341
+      ID: 474
       Name: Probe[main.testMapWithSmallValueMassive]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -4330,14 +4938,14 @@ Types:
         - Name: redactMyEntries
           Offset: 1
           Expression:
-            Type: 103 GoMapType map[int]uint8
+            Type: 126 GoMapType map[int]uint8
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 60, index: 0, name: redactMyEntries}
+                  Variable: {subprogram: 68, index: 0, name: redactMyEntries}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 340
+      ID: 473
       Name: Probe[main.testMapWithSmallValue]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -4345,14 +4953,14 @@ Types:
         - Name: m
           Offset: 1
           Expression:
-            Type: 103 GoMapType map[int]uint8
+            Type: 126 GoMapType map[int]uint8
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 59, index: 0, name: m}
+                  Variable: {subprogram: 67, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 375
+      ID: 508
       Name: Probe[main.testMassiveString]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -4363,11 +4971,11 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 94, index: 0, name: x}
+                  Variable: {subprogram: 102, index: 0, name: x}
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 349
+      ID: 482
       Name: Probe[main.testMultipleSimpleParams]
       ByteSize: 31
       PresenceBitsetSize: 1
@@ -4378,7 +4986,7 @@ Types:
             Type: 4 BaseType bool
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 68, index: 0, name: a}
+                  Variable: {subprogram: 76, index: 0, name: a}
                   Offset: 0
                   ByteSize: 1
         - Name: b
@@ -4387,7 +4995,7 @@ Types:
             Type: 3 BaseType uint8
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 68, index: 1, name: b}
+                  Variable: {subprogram: 76, index: 1, name: b}
                   Offset: 0
                   ByteSize: 1
         - Name: c
@@ -4396,7 +5004,7 @@ Types:
             Type: 12 BaseType int32
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 68, index: 2, name: c}
+                  Variable: {subprogram: 76, index: 2, name: c}
                   Offset: 0
                   ByteSize: 4
         - Name: d
@@ -4405,7 +5013,7 @@ Types:
             Type: 10 BaseType uint
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 68, index: 3, name: d}
+                  Variable: {subprogram: 76, index: 3, name: d}
                   Offset: 0
                   ByteSize: 8
         - Name: e
@@ -4414,11 +5022,11 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 68, index: 4, name: e}
+                  Variable: {subprogram: 76, index: 4, name: e}
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 357
+      ID: 490
       Name: Probe[main.testNilPointer]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -4429,7 +5037,7 @@ Types:
             Type: 11 PointerType *bool
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 76, index: 0, name: z}
+                  Variable: {subprogram: 84, index: 0, name: z}
                   Offset: 0
                   ByteSize: 8
         - Name: a
@@ -4438,11 +5046,11 @@ Types:
             Type: 10 BaseType uint
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 76, index: 1, name: a}
+                  Variable: {subprogram: 84, index: 1, name: a}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 364
+      ID: 497
       Name: Probe[main.testNilSliceOfStructs]
       ByteSize: 33
       PresenceBitsetSize: 1
@@ -4450,10 +5058,10 @@ Types:
         - Name: xs
           Offset: 1
           Expression:
-            Type: 138 GoSliceHeaderType []main.structWithNoStrings
+            Type: 161 GoSliceHeaderType []main.structWithNoStrings
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 83, index: 0, name: xs}
+                  Variable: {subprogram: 91, index: 0, name: xs}
                   Offset: 0
                   ByteSize: 24
         - Name: a
@@ -4462,11 +5070,11 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 83, index: 1, name: a}
+                  Variable: {subprogram: 91, index: 1, name: a}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 366
+      ID: 499
       Name: Probe[main.testNilSliceWithOtherParams]
       ByteSize: 34
       PresenceBitsetSize: 1
@@ -4477,16 +5085,16 @@ Types:
             Type: 17 BaseType int8
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 85, index: 0, name: a}
+                  Variable: {subprogram: 93, index: 0, name: a}
                   Offset: 0
                   ByteSize: 1
         - Name: s
           Offset: 2
           Expression:
-            Type: 142 GoSliceHeaderType []bool
+            Type: 165 GoSliceHeaderType []bool
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 85, index: 1, name: s}
+                  Variable: {subprogram: 93, index: 1, name: s}
                   Offset: 0
                   ByteSize: 24
         - Name: x
@@ -4495,11 +5103,11 @@ Types:
             Type: 10 BaseType uint
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 85, index: 2, name: x}
+                  Variable: {subprogram: 93, index: 2, name: x}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 367
+      ID: 500
       Name: Probe[main.testNilSlice]
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -4507,14 +5115,14 @@ Types:
         - Name: xs
           Offset: 1
           Expression:
-            Type: 143 GoSliceHeaderType []uint16
+            Type: 166 GoSliceHeaderType []uint16
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 86, index: 0, name: xs}
+                  Variable: {subprogram: 94, index: 0, name: xs}
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 374
+      ID: 507
       Name: Probe[main.testOneStringInStructPointer]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -4522,14 +5130,14 @@ Types:
         - Name: a
           Offset: 1
           Expression:
-            Type: 146 PointerType *main.oneStringStruct
+            Type: 169 PointerType *main.oneStringStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 93, index: 0, name: a}
+                  Variable: {subprogram: 101, index: 0, name: a}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 353
+      ID: 486
       Name: Probe[main.testPointerLoop]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -4537,14 +5145,14 @@ Types:
         - Name: a
           Offset: 1
           Expression:
-            Type: 132 PointerType *main.node
+            Type: 155 PointerType *main.node
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 72, index: 0, name: a}
+                  Variable: {subprogram: 80, index: 0, name: a}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 335
+      ID: 468
       Name: Probe[main.testPointerToMap]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -4552,14 +5160,14 @@ Types:
         - Name: m
           Offset: 1
           Expression:
-            Type: 92 PointerType *map[string]int
+            Type: 115 PointerType *map[string]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 54, index: 0, name: m}
+                  Variable: {subprogram: 62, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 351
+      ID: 484
       Name: Probe[main.testPointerToSimpleStruct]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -4567,14 +5175,14 @@ Types:
         - Name: a
           Offset: 1
           Expression:
-            Type: 129 PointerType *main.structWithTwoValues
+            Type: 152 PointerType *main.structWithTwoValues
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 70, index: 0, name: a}
+                  Variable: {subprogram: 78, index: 0, name: a}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 283
+      ID: 408
       Name: Probe[main.testRuneArray]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -4589,7 +5197,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 302
+      ID: 427
       Name: Probe[main.testSingleBool]
       ByteSize: 2
       PresenceBitsetSize: 1
@@ -4604,7 +5212,7 @@ Types:
                   Offset: 0
                   ByteSize: 1
     - __kind: EventRootType
-      ID: 300
+      ID: 425
       Name: Probe[main.testSingleByte]
       ByteSize: 2
       PresenceBitsetSize: 1
@@ -4619,7 +5227,7 @@ Types:
                   Offset: 0
                   ByteSize: 1
     - __kind: EventRootType
-      ID: 313
+      ID: 438
       Name: Probe[main.testSingleFloat32]
       ByteSize: 5
       PresenceBitsetSize: 1
@@ -4634,7 +5242,7 @@ Types:
                   Offset: 0
                   ByteSize: 4
     - __kind: EventRootType
-      ID: 314
+      ID: 439
       Name: Probe[main.testSingleFloat64]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -4649,7 +5257,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 305
+      ID: 430
       Name: Probe[main.testSingleInt16]
       ByteSize: 3
       PresenceBitsetSize: 1
@@ -4664,7 +5272,7 @@ Types:
                   Offset: 0
                   ByteSize: 2
     - __kind: EventRootType
-      ID: 306
+      ID: 431
       Name: Probe[main.testSingleInt32]
       ByteSize: 5
       PresenceBitsetSize: 1
@@ -4679,7 +5287,7 @@ Types:
                   Offset: 0
                   ByteSize: 4
     - __kind: EventRootType
-      ID: 307
+      ID: 432
       Name: Probe[main.testSingleInt64]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -4694,7 +5302,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 304
+      ID: 429
       Name: Probe[main.testSingleInt8]
       ByteSize: 2
       PresenceBitsetSize: 1
@@ -4709,7 +5317,7 @@ Types:
                   Offset: 0
                   ByteSize: 1
     - __kind: EventRootType
-      ID: 303
+      ID: 428
       Name: Probe[main.testSingleInt]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -4724,7 +5332,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 301
+      ID: 426
       Name: Probe[main.testSingleRune]
       ByteSize: 5
       PresenceBitsetSize: 1
@@ -4739,7 +5347,7 @@ Types:
                   Offset: 0
                   ByteSize: 4
     - __kind: EventRootType
-      ID: 370
+      ID: 503
       Name: Probe[main.testSingleString]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -4750,11 +5358,11 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 89, index: 0, name: x}
+                  Variable: {subprogram: 97, index: 0, name: x}
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 310
+      ID: 435
       Name: Probe[main.testSingleUint16]
       ByteSize: 3
       PresenceBitsetSize: 1
@@ -4769,7 +5377,7 @@ Types:
                   Offset: 0
                   ByteSize: 2
     - __kind: EventRootType
-      ID: 311
+      ID: 436
       Name: Probe[main.testSingleUint32]
       ByteSize: 5
       PresenceBitsetSize: 1
@@ -4784,7 +5392,7 @@ Types:
                   Offset: 0
                   ByteSize: 4
     - __kind: EventRootType
-      ID: 312
+      ID: 437
       Name: Probe[main.testSingleUint64]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -4799,7 +5407,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 309
+      ID: 434
       Name: Probe[main.testSingleUint8]
       ByteSize: 2
       PresenceBitsetSize: 1
@@ -4814,7 +5422,7 @@ Types:
                   Offset: 0
                   ByteSize: 1
     - __kind: EventRootType
-      ID: 308
+      ID: 433
       Name: Probe[main.testSingleUint]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -4829,7 +5437,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 361
+      ID: 494
       Name: Probe[main.testSliceOfSlices]
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -4837,14 +5445,14 @@ Types:
         - Name: u
           Offset: 1
           Expression:
-            Type: 136 GoSliceHeaderType [][]uint
+            Type: 159 GoSliceHeaderType [][]uint
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 80, index: 0, name: u}
+                  Variable: {subprogram: 88, index: 0, name: u}
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 333
+      ID: 466
       Name: Probe[main.testSmallMap]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -4852,14 +5460,14 @@ Types:
         - Name: m
           Offset: 1
           Expression:
-            Type: 76 GoMapType map[string]int
+            Type: 99 GoMapType map[string]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 52, index: 0, name: m}
+                  Variable: {subprogram: 60, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 284
+      ID: 409
       Name: Probe[main.testStringArray]
       ByteSize: 33
       PresenceBitsetSize: 1
@@ -4874,7 +5482,7 @@ Types:
                   Offset: 0
                   ByteSize: 32
     - __kind: EventRootType
-      ID: 356
+      ID: 489
       Name: Probe[main.testStringPointer]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -4885,11 +5493,11 @@ Types:
             Type: 22 PointerType *string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 75, index: 0, name: z}
+                  Variable: {subprogram: 83, index: 0, name: z}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 365
+      ID: 498
       Name: Probe[main.testStringSlice]
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -4897,14 +5505,44 @@ Types:
         - Name: s
           Offset: 1
           Expression:
-            Type: 141 GoSliceHeaderType []string
+            Type: 164 GoSliceHeaderType []string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 84, index: 0, name: s}
+                  Variable: {subprogram: 92, index: 0, name: s}
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 362
+      ID: 448
+      Name: Probe[main.testStringType1]
+      ByteSize: 9
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: a
+          Offset: 1
+          Expression:
+            Type: 75 PointerType *main.stringType1
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 42, index: 0, name: a}
+                  Offset: 0
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 449
+      Name: Probe[main.testStringType2]
+      ByteSize: 9
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: a
+          Offset: 1
+          Expression:
+            Type: 77 PointerType **main.stringType2
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 43, index: 0, name: a}
+                  Offset: 0
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 495
       Name: Probe[main.testStructSlice]
       ByteSize: 33
       PresenceBitsetSize: 1
@@ -4912,10 +5550,10 @@ Types:
         - Name: xs
           Offset: 1
           Expression:
-            Type: 138 GoSliceHeaderType []main.structWithNoStrings
+            Type: 161 GoSliceHeaderType []main.structWithNoStrings
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 81, index: 0, name: xs}
+                  Variable: {subprogram: 89, index: 0, name: xs}
                   Offset: 0
                   ByteSize: 24
         - Name: a
@@ -4924,11 +5562,11 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 81, index: 1, name: a}
+                  Variable: {subprogram: 89, index: 1, name: a}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 328
+      ID: 461
       Name: Probe[main.testStructWithMap]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -4936,14 +5574,14 @@ Types:
         - Name: s
           Offset: 1
           Expression:
-            Type: 65 StructureType main.structWithMap
+            Type: 88 StructureType main.structWithMap
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 47, index: 0, name: s}
+                  Variable: {subprogram: 55, index: 0, name: s}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 378
+      ID: 511
       Name: Probe[main.testStruct]
       ByteSize: 57
       PresenceBitsetSize: 1
@@ -4951,14 +5589,14 @@ Types:
         - Name: x
           Offset: 1
           Expression:
-            Type: 148 StructureType main.aStruct
+            Type: 171 StructureType main.aStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 97, index: 0, name: x}
+                  Variable: {subprogram: 105, index: 0, name: x}
                   Offset: 0
                   ByteSize: 56
     - __kind: EventRootType
-      ID: 373
+      ID: 506
       Name: Probe[main.testThreeStringsInStructPointer]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -4966,14 +5604,14 @@ Types:
         - Name: a
           Offset: 1
           Expression:
-            Type: 145 PointerType *main.threeStringStruct
+            Type: 168 PointerType *main.threeStringStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 92, index: 0, name: a}
+                  Variable: {subprogram: 100, index: 0, name: a}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 372
+      ID: 505
       Name: Probe[main.testThreeStringsInStruct]
       ByteSize: 49
       PresenceBitsetSize: 1
@@ -4981,14 +5619,14 @@ Types:
         - Name: a
           Offset: 1
           Expression:
-            Type: 144 StructureType main.threeStringStruct
+            Type: 167 StructureType main.threeStringStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 91, index: 0, name: a}
+                  Variable: {subprogram: 99, index: 0, name: a}
                   Offset: 0
                   ByteSize: 48
     - __kind: EventRootType
-      ID: 371
+      ID: 504
       Name: Probe[main.testThreeStrings]
       ByteSize: 49
       PresenceBitsetSize: 1
@@ -4999,7 +5637,7 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 90, index: 0, name: x}
+                  Variable: {subprogram: 98, index: 0, name: x}
                   Offset: 0
                   ByteSize: 16
         - Name: y
@@ -5008,7 +5646,7 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 90, index: 1, name: y}
+                  Variable: {subprogram: 98, index: 1, name: y}
                   Offset: 0
                   ByteSize: 16
         - Name: z
@@ -5017,11 +5655,11 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 90, index: 2, name: z}
+                  Variable: {subprogram: 98, index: 2, name: z}
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 315
+      ID: 440
       Name: Probe[main.testTypeAlias]
       ByteSize: 3
       PresenceBitsetSize: 1
@@ -5036,7 +5674,7 @@ Types:
                   Offset: 0
                   ByteSize: 2
     - __kind: EventRootType
-      ID: 293
+      ID: 418
       Name: Probe[main.testUint16Array]
       ByteSize: 5
       PresenceBitsetSize: 1
@@ -5051,7 +5689,7 @@ Types:
                   Offset: 0
                   ByteSize: 4
     - __kind: EventRootType
-      ID: 294
+      ID: 419
       Name: Probe[main.testUint32Array]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -5066,7 +5704,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 295
+      ID: 420
       Name: Probe[main.testUint64Array]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -5081,7 +5719,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 292
+      ID: 417
       Name: Probe[main.testUint8Array]
       ByteSize: 3
       PresenceBitsetSize: 1
@@ -5096,7 +5734,7 @@ Types:
                   Offset: 0
                   ByteSize: 2
     - __kind: EventRootType
-      ID: 291
+      ID: 416
       Name: Probe[main.testUintArray]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -5111,7 +5749,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 355
+      ID: 488
       Name: Probe[main.testUintPointer]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -5122,11 +5760,11 @@ Types:
             Type: 34 PointerType *uint
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 74, index: 0, name: x}
+                  Variable: {subprogram: 82, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 359
+      ID: 492
       Name: Probe[main.testUintSlice]
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -5134,14 +5772,14 @@ Types:
         - Name: u
           Offset: 1
           Expression:
-            Type: 135 GoSliceHeaderType []uint
+            Type: 158 GoSliceHeaderType []uint
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 78, index: 0, name: u}
+                  Variable: {subprogram: 86, index: 0, name: u}
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 376
+      ID: 509
       Name: Probe[main.testUnitializedString]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -5152,11 +5790,11 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 95, index: 0, name: x}
+                  Variable: {subprogram: 103, index: 0, name: x}
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 354
+      ID: 487
       Name: Probe[main.testUnsafePointer]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -5167,11 +5805,11 @@ Types:
             Type: 15 VoidPointerType unsafe.Pointer
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 73, index: 0, name: x}
+                  Variable: {subprogram: 81, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 299
+      ID: 424
       Name: Probe[main.testVeryLargeArray]
       ByteSize: 801
       PresenceBitsetSize: 1
@@ -5186,7 +5824,7 @@ Types:
                   Offset: 0
                   ByteSize: 800
     - __kind: EventRootType
-      ID: 368
+      ID: 501
       Name: Probe[main.testVeryLargeSlice]
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -5194,10 +5832,10 @@ Types:
         - Name: xs
           Offset: 1
           Expression:
-            Type: 135 GoSliceHeaderType []uint
+            Type: 158 GoSliceHeaderType []uint
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 87, index: 0, name: xs}
+                  Variable: {subprogram: 95, index: 0, name: xs}
                   Offset: 0
                   ByteSize: 24
     - __kind: ArrayType
@@ -5236,7 +5874,7 @@ Types:
       ID: 40
       Name: '[2]int'
       ByteSize: 16
-      GoRuntimeType: 676800
+      GoRuntimeType: 682784
       GoKind: 17
       Count: 2
       HasCount: true
@@ -5253,7 +5891,7 @@ Types:
       ID: 37
       Name: '[2]int32'
       ByteSize: 8
-      GoRuntimeType: 678144
+      GoRuntimeType: 684128
       GoKind: 17
       Count: 2
       HasCount: true
@@ -5275,18 +5913,18 @@ Types:
       HasCount: true
       Element: 17 BaseType int8
     - __kind: ArrayType
-      ID: 91
+      ID: 114
       Name: '[2]map[string]int'
       ByteSize: 16
       GoKind: 17
       Count: 2
       HasCount: true
-      Element: 76 GoMapType map[string]int
+      Element: 99 GoMapType map[string]int
     - __kind: ArrayType
       ID: 38
       Name: '[2]string'
       ByteSize: 32
-      GoRuntimeType: 678240
+      GoRuntimeType: 684224
       GoKind: 17
       Count: 2
       HasCount: true
@@ -5319,7 +5957,7 @@ Types:
       ID: 47
       Name: '[2]uint64'
       ByteSize: 16
-      GoRuntimeType: 678336
+      GoRuntimeType: 684320
       GoKind: 17
       Count: 2
       HasCount: true
@@ -5328,31 +5966,31 @@ Types:
       ID: 36
       Name: '[2]uint8'
       ByteSize: 2
-      GoRuntimeType: 678048
+      GoRuntimeType: 684032
       GoKind: 17
       Count: 2
       HasCount: true
       Element: 3 BaseType uint8
     - __kind: ArrayType
-      ID: 236
+      ID: 272
       Name: '[4]int'
       ByteSize: 32
-      GoRuntimeType: 676416
+      GoRuntimeType: 682400
       GoKind: 17
       Count: 4
       HasCount: true
       Element: 7 BaseType int
     - __kind: ArrayType
-      ID: 193
+      ID: 229
       Name: '[4]string'
       ByteSize: 64
-      GoRuntimeType: 676704
+      GoRuntimeType: 682688
       GoKind: 17
       Count: 4
       HasCount: true
       Element: 9 GoStringHeaderType string
     - __kind: ArrayType
-      ID: 63
+      ID: 86
       Name: '[5]int'
       ByteSize: 40
       GoKind: 17
@@ -5360,10 +5998,98 @@ Types:
       HasCount: true
       Element: 7 BaseType int
     - __kind: GoSliceHeaderType
+      ID: 62
+      Name: '[]*main.deepSlice2'
+      ByteSize: 24
+      GoRuntimeType: 477472
+      GoKind: 23
+      RawFields:
+        - Name: array
+          Offset: 0
+          Type: 63 PointerType **main.deepSlice2
+        - Name: len
+          Offset: 8
+          Type: 7 BaseType int
+        - Name: cap
+          Offset: 16
+          Type: 7 BaseType int
+      Data: 179 GoSliceDataType []*main.deepSlice2.array
+    - __kind: GoSliceDataType
+      ID: 179
+      Name: '[]*main.deepSlice2.array'
+      ByteSize: 2048
+      Element: 64 PointerType *main.deepSlice2
+    - __kind: GoSliceHeaderType
+      ID: 308
+      Name: '[]*main.deepSlice3'
+      ByteSize: 24
+      GoRuntimeType: 477408
+      GoKind: 23
+      RawFields:
+        - Name: array
+          Offset: 0
+          Type: 309 PointerType **main.deepSlice3
+        - Name: len
+          Offset: 8
+          Type: 7 BaseType int
+        - Name: cap
+          Offset: 16
+          Type: 7 BaseType int
+      Data: 312 GoSliceDataType []*main.deepSlice3.array
+    - __kind: GoSliceDataType
+      ID: 312
+      Name: '[]*main.deepSlice3.array'
+      ByteSize: 2048
+      Element: 310 PointerType *main.deepSlice3
+    - __kind: GoSliceHeaderType
+      ID: 333
+      Name: '[]*main.deepSlice8'
+      ByteSize: 24
+      GoRuntimeType: 477088
+      GoKind: 23
+      RawFields:
+        - Name: array
+          Offset: 0
+          Type: 334 PointerType **main.deepSlice8
+        - Name: len
+          Offset: 8
+          Type: 7 BaseType int
+        - Name: cap
+          Offset: 16
+          Type: 7 BaseType int
+      Data: 337 GoSliceDataType []*main.deepSlice8.array
+    - __kind: GoSliceDataType
+      ID: 337
+      Name: '[]*main.deepSlice8.array'
+      ByteSize: 2048
+      Element: 335 PointerType *main.deepSlice8
+    - __kind: GoSliceHeaderType
+      ID: 339
+      Name: '[]*main.deepSlice9'
+      ByteSize: 24
+      GoRuntimeType: 477024
+      GoKind: 23
+      RawFields:
+        - Name: array
+          Offset: 0
+          Type: 340 PointerType **main.deepSlice9
+        - Name: len
+          Offset: 8
+          Type: 7 BaseType int
+        - Name: cap
+          Offset: 16
+          Type: 7 BaseType int
+      Data: 343 GoSliceDataType []*main.deepSlice9.array
+    - __kind: GoSliceDataType
+      ID: 343
+      Name: '[]*main.deepSlice9.array'
+      ByteSize: 2048
+      Element: 341 PointerType *main.deepSlice9
+    - __kind: GoSliceHeaderType
       ID: 53
       Name: '[]*string'
       ByteSize: 24
-      GoRuntimeType: 473376
+      GoRuntimeType: 478496
       GoKind: 23
       RawFields:
         - Name: array
@@ -5375,98 +6101,123 @@ Types:
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 153 GoSliceDataType []*string.array
+      Data: 176 GoSliceDataType []*string.array
     - __kind: GoSliceDataType
-      ID: 153
+      ID: 176
       Name: '[]*string.array'
       ByteSize: 2048
       Element: 22 PointerType *string
     - __kind: GoSliceDataType
-      ID: 253
+      ID: 289
       Name: '[]*table<[4]int,[4]int>.array'
       ByteSize: 8192
-      Element: 127 PointerType *table<[4]int,[4]int>
+      Element: 150 PointerType *table<[4]int,[4]int>
     - __kind: GoSliceDataType
-      ID: 245
+      ID: 281
       Name: '[]*table<[4]int,uint8>.array'
       ByteSize: 8192
-      Element: 122 PointerType *table<[4]int,uint8>
+      Element: 145 PointerType *table<[4]int,uint8>
     - __kind: GoSliceDataType
-      ID: 194
+      ID: 230
       Name: '[]*table<[4]string,[2]int>.array'
       ByteSize: 8192
-      Element: 90 PointerType *table<[4]string,[2]int>
+      Element: 113 PointerType *table<[4]string,[2]int>
     - __kind: GoSliceDataType
-      ID: 212
+      ID: 248
       Name: '[]*table<bool,main.node>.array'
       ByteSize: 8192
-      Element: 102 PointerType *table<bool,main.node>
+      Element: 125 PointerType *table<bool,main.node>
     - __kind: GoSliceDataType
-      ID: 161
+      ID: 189
+      Name: '[]*table<int,*main.deepMap2>.array'
+      ByteSize: 8192
+      Element: 72 PointerType *table<int,*main.deepMap2>
+    - __kind: GoSliceDataType
+      ID: 327
+      Name: '[]*table<int,*main.deepMap3>.array'
+      ByteSize: 8192
+      Element: 318 PointerType *table<int,*main.deepMap3>
+    - __kind: GoSliceDataType
+      ID: 362
+      Name: '[]*table<int,*main.deepMap8>.array'
+      ByteSize: 8192
+      Element: 353 PointerType *table<int,*main.deepMap8>
+    - __kind: GoSliceDataType
+      ID: 377
+      Name: '[]*table<int,*main.deepMap9>.array'
+      ByteSize: 8192
+      Element: 368 PointerType *table<int,*main.deepMap9>
+    - __kind: GoSliceDataType
+      ID: 197
       Name: '[]*table<int,int>.array'
       ByteSize: 8192
-      Element: 70 PointerType *table<int,int>
+      Element: 93 PointerType *table<int,int>
     - __kind: GoSliceDataType
-      ID: 220
+      ID: 390
+      Name: '[]*table<int,interface {}>.array'
+      ByteSize: 8192
+      Element: 383 PointerType *table<int,interface {}>
+    - __kind: GoSliceDataType
+      ID: 256
       Name: '[]*table<int,uint8>.array'
       ByteSize: 8192
-      Element: 107 PointerType *table<int,uint8>
+      Element: 130 PointerType *table<int,uint8>
     - __kind: GoSliceDataType
-      ID: 204
+      ID: 240
       Name: '[]*table<string,[]main.structWithMap>.array'
       ByteSize: 8192
-      Element: 97 PointerType *table<string,[]main.structWithMap>
+      Element: 120 PointerType *table<string,[]main.structWithMap>
     - __kind: GoSliceDataType
-      ID: 185
+      ID: 221
       Name: '[]*table<string,[]string>.array'
       ByteSize: 8192
-      Element: 85 PointerType *table<string,[]string>
+      Element: 108 PointerType *table<string,[]string>
     - __kind: GoSliceDataType
-      ID: 177
+      ID: 213
       Name: '[]*table<string,int>.array'
       ByteSize: 8192
-      Element: 80 PointerType *table<string,int>
+      Element: 103 PointerType *table<string,int>
     - __kind: GoSliceDataType
-      ID: 169
+      ID: 205
       Name: '[]*table<string,main.nestedStruct>.array'
       ByteSize: 8192
-      Element: 75 PointerType *table<string,main.nestedStruct>
+      Element: 98 PointerType *table<string,main.nestedStruct>
     - __kind: GoSliceDataType
-      ID: 237
+      ID: 273
       Name: '[]*table<uint8,[4]int>.array'
       ByteSize: 8192
-      Element: 117 PointerType *table<uint8,[4]int>
+      Element: 140 PointerType *table<uint8,[4]int>
     - __kind: GoSliceDataType
-      ID: 228
+      ID: 264
       Name: '[]*table<uint8,uint8>.array'
       ByteSize: 8192
-      Element: 112 PointerType *table<uint8,uint8>
+      Element: 135 PointerType *table<uint8,uint8>
     - __kind: GoSliceHeaderType
-      ID: 136
+      ID: 159
       Name: '[][]uint'
       ByteSize: 24
       GoKind: 23
       RawFields:
         - Name: array
           Offset: 0
-          Type: 137 PointerType *[]uint
+          Type: 160 PointerType *[]uint
         - Name: len
           Offset: 8
           Type: 7 BaseType int
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 257 GoSliceDataType [][]uint.array
+      Data: 293 GoSliceDataType [][]uint.array
     - __kind: GoSliceDataType
-      ID: 257
+      ID: 293
       Name: '[][]uint.array'
       ByteSize: 2048
-      Element: 135 GoSliceHeaderType []uint
+      Element: 158 GoSliceHeaderType []uint
     - __kind: GoSliceHeaderType
-      ID: 142
+      ID: 165
       Name: '[]bool'
       ByteSize: 24
-      GoRuntimeType: 481696
+      GoRuntimeType: 486816
       GoKind: 23
       RawFields:
         - Name: array
@@ -5478,120 +6229,167 @@ Types:
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 263 GoSliceDataType []bool.array
+      Data: 299 GoSliceDataType []bool.array
     - __kind: GoSliceDataType
-      ID: 263
+      ID: 299
       Name: '[]bool.array'
       ByteSize: 2048
       Element: 4 BaseType bool
     - __kind: GoSliceHeaderType
-      ID: 202
-      Name: '[]main.structWithMap'
+      ID: 345
+      Name: '[]interface {}'
       ByteSize: 24
-      GoRuntimeType: 472608
+      GoRuntimeType: 487136
       GoKind: 23
       RawFields:
         - Name: array
           Offset: 0
-          Type: 203 PointerType *main.structWithMap
+          Type: 346 PointerType *interface {}
         - Name: len
           Offset: 8
           Type: 7 BaseType int
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 280 GoSliceDataType []main.structWithMap.array
+      Data: 347 GoSliceDataType []interface {}.array
     - __kind: GoSliceDataType
-      ID: 280
+      ID: 347
+      Name: '[]interface {}.array'
+      ByteSize: 2048
+      Element: 81 GoEmptyInterfaceType interface {}
+    - __kind: GoSliceHeaderType
+      ID: 238
+      Name: '[]main.structWithMap'
+      ByteSize: 24
+      GoRuntimeType: 477728
+      GoKind: 23
+      RawFields:
+        - Name: array
+          Offset: 0
+          Type: 239 PointerType *main.structWithMap
+        - Name: len
+          Offset: 8
+          Type: 7 BaseType int
+        - Name: cap
+          Offset: 16
+          Type: 7 BaseType int
+      Data: 405 GoSliceDataType []main.structWithMap.array
+    - __kind: GoSliceDataType
+      ID: 405
       Name: '[]main.structWithMap.array'
       ByteSize: 2048
-      Element: 65 StructureType main.structWithMap
+      Element: 88 StructureType main.structWithMap
     - __kind: GoSliceHeaderType
-      ID: 138
+      ID: 161
       Name: '[]main.structWithNoStrings'
       ByteSize: 24
       GoKind: 23
       RawFields:
         - Name: array
           Offset: 0
-          Type: 139 PointerType *main.structWithNoStrings
+          Type: 162 PointerType *main.structWithNoStrings
         - Name: len
           Offset: 8
           Type: 7 BaseType int
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 259 GoSliceDataType []main.structWithNoStrings.array
+      Data: 295 GoSliceDataType []main.structWithNoStrings.array
     - __kind: GoSliceDataType
-      ID: 259
+      ID: 295
       Name: '[]main.structWithNoStrings.array'
       ByteSize: 2048
-      Element: 140 StructureType main.structWithNoStrings
+      Element: 163 StructureType main.structWithNoStrings
     - __kind: GoSliceDataType
-      ID: 254
+      ID: 290
       Name: '[]noalg.map.group[[4]int][4]int.array'
       ByteSize: 2048
-      Element: 250 StructureType noalg.map.group[[4]int][4]int
+      Element: 286 StructureType noalg.map.group[[4]int][4]int
     - __kind: GoSliceDataType
-      ID: 246
+      ID: 282
       Name: '[]noalg.map.group[[4]int]uint8.array'
       ByteSize: 2048
-      Element: 242 StructureType noalg.map.group[[4]int]uint8
+      Element: 278 StructureType noalg.map.group[[4]int]uint8
     - __kind: GoSliceDataType
-      ID: 195
+      ID: 231
       Name: '[]noalg.map.group[[4]string][2]int.array'
       ByteSize: 2048
-      Element: 190 StructureType noalg.map.group[[4]string][2]int
+      Element: 226 StructureType noalg.map.group[[4]string][2]int
     - __kind: GoSliceDataType
-      ID: 213
+      ID: 249
       Name: '[]noalg.map.group[bool]main.node.array'
       ByteSize: 2048
-      Element: 209 StructureType noalg.map.group[bool]main.node
+      Element: 245 StructureType noalg.map.group[bool]main.node
     - __kind: GoSliceDataType
-      ID: 162
+      ID: 190
+      Name: '[]noalg.map.group[int]*main.deepMap2.array'
+      ByteSize: 2048
+      Element: 184 StructureType noalg.map.group[int]*main.deepMap2
+    - __kind: GoSliceDataType
+      ID: 328
+      Name: '[]noalg.map.group[int]*main.deepMap3.array'
+      ByteSize: 2048
+      Element: 322 StructureType noalg.map.group[int]*main.deepMap3
+    - __kind: GoSliceDataType
+      ID: 363
+      Name: '[]noalg.map.group[int]*main.deepMap8.array'
+      ByteSize: 2048
+      Element: 357 StructureType noalg.map.group[int]*main.deepMap8
+    - __kind: GoSliceDataType
+      ID: 378
+      Name: '[]noalg.map.group[int]*main.deepMap9.array'
+      ByteSize: 2048
+      Element: 372 StructureType noalg.map.group[int]*main.deepMap9
+    - __kind: GoSliceDataType
+      ID: 198
       Name: '[]noalg.map.group[int]int.array'
       ByteSize: 2048
-      Element: 158 StructureType noalg.map.group[int]int
+      Element: 194 StructureType noalg.map.group[int]int
     - __kind: GoSliceDataType
-      ID: 221
+      ID: 391
+      Name: '[]noalg.map.group[int]interface {}.array'
+      ByteSize: 2048
+      Element: 387 StructureType noalg.map.group[int]interface {}
+    - __kind: GoSliceDataType
+      ID: 257
       Name: '[]noalg.map.group[int]uint8.array'
       ByteSize: 2048
-      Element: 217 StructureType noalg.map.group[int]uint8
+      Element: 253 StructureType noalg.map.group[int]uint8
     - __kind: GoSliceDataType
-      ID: 205
+      ID: 241
       Name: '[]noalg.map.group[string][]main.structWithMap.array'
       ByteSize: 2048
-      Element: 199 StructureType noalg.map.group[string][]main.structWithMap
+      Element: 235 StructureType noalg.map.group[string][]main.structWithMap
     - __kind: GoSliceDataType
-      ID: 186
+      ID: 222
       Name: '[]noalg.map.group[string][]string.array'
       ByteSize: 2048
-      Element: 182 StructureType noalg.map.group[string][]string
+      Element: 218 StructureType noalg.map.group[string][]string
     - __kind: GoSliceDataType
-      ID: 178
+      ID: 214
       Name: '[]noalg.map.group[string]int.array'
       ByteSize: 2048
-      Element: 174 StructureType noalg.map.group[string]int
+      Element: 210 StructureType noalg.map.group[string]int
     - __kind: GoSliceDataType
-      ID: 170
+      ID: 206
       Name: '[]noalg.map.group[string]main.nestedStruct.array'
       ByteSize: 2048
-      Element: 166 StructureType noalg.map.group[string]main.nestedStruct
+      Element: 202 StructureType noalg.map.group[string]main.nestedStruct
     - __kind: GoSliceDataType
-      ID: 238
+      ID: 274
       Name: '[]noalg.map.group[uint8][4]int.array'
       ByteSize: 2048
-      Element: 233 StructureType noalg.map.group[uint8][4]int
+      Element: 269 StructureType noalg.map.group[uint8][4]int
     - __kind: GoSliceDataType
-      ID: 229
+      ID: 265
       Name: '[]noalg.map.group[uint8]uint8.array'
       ByteSize: 2048
-      Element: 225 StructureType noalg.map.group[uint8]uint8
+      Element: 261 StructureType noalg.map.group[uint8]uint8
     - __kind: GoSliceHeaderType
-      ID: 141
+      ID: 164
       Name: '[]string'
       ByteSize: 24
-      GoRuntimeType: 481824
+      GoRuntimeType: 486944
       GoKind: 23
       RawFields:
         - Name: array
@@ -5603,17 +6401,17 @@ Types:
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 261 GoSliceDataType []string.array
+      Data: 297 GoSliceDataType []string.array
     - __kind: GoSliceDataType
-      ID: 261
+      ID: 297
       Name: '[]string.array'
       ByteSize: 2048
       Element: 9 GoStringHeaderType string
     - __kind: GoSliceHeaderType
-      ID: 135
+      ID: 158
       Name: '[]uint'
       ByteSize: 24
-      GoRuntimeType: 481312
+      GoRuntimeType: 486432
       GoKind: 23
       RawFields:
         - Name: array
@@ -5625,17 +6423,17 @@ Types:
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 255 GoSliceDataType []uint.array
+      Data: 291 GoSliceDataType []uint.array
     - __kind: GoSliceDataType
-      ID: 255
+      ID: 291
       Name: '[]uint.array'
       ByteSize: 2048
       Element: 10 BaseType uint
     - __kind: GoSliceHeaderType
-      ID: 143
+      ID: 166
       Name: '[]uint16'
       ByteSize: 24
-      GoRuntimeType: 480672
+      GoRuntimeType: 485792
       GoKind: 23
       RawFields:
         - Name: array
@@ -5647,9 +6445,9 @@ Types:
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 265 GoSliceDataType []uint16.array
+      Data: 301 GoSliceDataType []uint16.array
     - __kind: GoSliceDataType
-      ID: 265
+      ID: 301
       Name: '[]uint16.array'
       ByteSize: 2048
       Element: 6 BaseType uint16
@@ -5657,35 +6455,35 @@ Types:
       ID: 4
       Name: bool
       ByteSize: 1
-      GoRuntimeType: 579584
+      GoRuntimeType: 584704
       GoKind: 1
     - __kind: GoChannelType
-      ID: 128
+      ID: 151
       Name: chan bool
-      GoRuntimeType: 590912
+      GoRuntimeType: 596032
       GoKind: 18
     - __kind: GoChannelType
-      ID: 57
+      ID: 80
       Name: chan struct {}
-      GoRuntimeType: 589824
+      GoRuntimeType: 594944
       GoKind: 18
     - __kind: BaseType
       ID: 25
       Name: complex128
       ByteSize: 16
-      GoRuntimeType: 579392
+      GoRuntimeType: 584512
       GoKind: 16
     - __kind: BaseType
       ID: 24
       Name: complex64
       ByteSize: 8
-      GoRuntimeType: 579328
+      GoRuntimeType: 584448
       GoKind: 15
     - __kind: GoInterfaceType
       ID: 14
       Name: error
       ByteSize: 16
-      GoRuntimeType: 1.02e+06
+      GoRuntimeType: 1.025984e+06
       GoKind: 20
       RawFields:
         - Name: tab
@@ -5698,223 +6496,293 @@ Types:
       ID: 18
       Name: float32
       ByteSize: 4
-      GoRuntimeType: 579456
+      GoRuntimeType: 584576
       GoKind: 13
     - __kind: BaseType
       ID: 16
       Name: float64
       ByteSize: 8
-      GoRuntimeType: 579520
+      GoRuntimeType: 584640
       GoKind: 14
     - __kind: GoSubroutineType
-      ID: 60
+      ID: 83
       Name: func()
       ByteSize: 8
-      GoRuntimeType: 471584
+      GoRuntimeType: 475616
       GoKind: 19
     - __kind: GoSwissMapGroupsType
-      ID: 248
+      ID: 284
       Name: groupReference<[4]int,[4]int>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 249 PointerType *noalg.map.group[[4]int][4]int
+          Type: 285 PointerType *noalg.map.group[[4]int][4]int
         - Name: lengthMask
           Offset: 8
           Type: 8 BaseType uint64
-      GroupType: 250 StructureType noalg.map.group[[4]int][4]int
-      GroupSliceType: 254 GoSliceDataType []noalg.map.group[[4]int][4]int.array
+      GroupType: 286 StructureType noalg.map.group[[4]int][4]int
+      GroupSliceType: 290 GoSliceDataType []noalg.map.group[[4]int][4]int.array
     - __kind: GoSwissMapGroupsType
-      ID: 240
+      ID: 276
       Name: groupReference<[4]int,uint8>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 241 PointerType *noalg.map.group[[4]int]uint8
+          Type: 277 PointerType *noalg.map.group[[4]int]uint8
         - Name: lengthMask
           Offset: 8
           Type: 8 BaseType uint64
-      GroupType: 242 StructureType noalg.map.group[[4]int]uint8
-      GroupSliceType: 246 GoSliceDataType []noalg.map.group[[4]int]uint8.array
+      GroupType: 278 StructureType noalg.map.group[[4]int]uint8
+      GroupSliceType: 282 GoSliceDataType []noalg.map.group[[4]int]uint8.array
     - __kind: GoSwissMapGroupsType
-      ID: 188
+      ID: 224
       Name: groupReference<[4]string,[2]int>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 189 PointerType *noalg.map.group[[4]string][2]int
+          Type: 225 PointerType *noalg.map.group[[4]string][2]int
         - Name: lengthMask
           Offset: 8
           Type: 8 BaseType uint64
-      GroupType: 190 StructureType noalg.map.group[[4]string][2]int
-      GroupSliceType: 195 GoSliceDataType []noalg.map.group[[4]string][2]int.array
+      GroupType: 226 StructureType noalg.map.group[[4]string][2]int
+      GroupSliceType: 231 GoSliceDataType []noalg.map.group[[4]string][2]int.array
     - __kind: GoSwissMapGroupsType
-      ID: 207
+      ID: 243
       Name: groupReference<bool,main.node>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 208 PointerType *noalg.map.group[bool]main.node
+          Type: 244 PointerType *noalg.map.group[bool]main.node
         - Name: lengthMask
           Offset: 8
           Type: 8 BaseType uint64
-      GroupType: 209 StructureType noalg.map.group[bool]main.node
-      GroupSliceType: 213 GoSliceDataType []noalg.map.group[bool]main.node.array
+      GroupType: 245 StructureType noalg.map.group[bool]main.node
+      GroupSliceType: 249 GoSliceDataType []noalg.map.group[bool]main.node.array
     - __kind: GoSwissMapGroupsType
-      ID: 156
+      ID: 182
+      Name: groupReference<int,*main.deepMap2>
+      ByteSize: 16
+      GoKind: 25
+      RawFields:
+        - Name: data
+          Offset: 0
+          Type: 183 PointerType *noalg.map.group[int]*main.deepMap2
+        - Name: lengthMask
+          Offset: 8
+          Type: 8 BaseType uint64
+      GroupType: 184 StructureType noalg.map.group[int]*main.deepMap2
+      GroupSliceType: 190 GoSliceDataType []noalg.map.group[int]*main.deepMap2.array
+    - __kind: GoSwissMapGroupsType
+      ID: 320
+      Name: groupReference<int,*main.deepMap3>
+      ByteSize: 16
+      GoKind: 25
+      RawFields:
+        - Name: data
+          Offset: 0
+          Type: 321 PointerType *noalg.map.group[int]*main.deepMap3
+        - Name: lengthMask
+          Offset: 8
+          Type: 8 BaseType uint64
+      GroupType: 322 StructureType noalg.map.group[int]*main.deepMap3
+      GroupSliceType: 328 GoSliceDataType []noalg.map.group[int]*main.deepMap3.array
+    - __kind: GoSwissMapGroupsType
+      ID: 355
+      Name: groupReference<int,*main.deepMap8>
+      ByteSize: 16
+      GoKind: 25
+      RawFields:
+        - Name: data
+          Offset: 0
+          Type: 356 PointerType *noalg.map.group[int]*main.deepMap8
+        - Name: lengthMask
+          Offset: 8
+          Type: 8 BaseType uint64
+      GroupType: 357 StructureType noalg.map.group[int]*main.deepMap8
+      GroupSliceType: 363 GoSliceDataType []noalg.map.group[int]*main.deepMap8.array
+    - __kind: GoSwissMapGroupsType
+      ID: 370
+      Name: groupReference<int,*main.deepMap9>
+      ByteSize: 16
+      GoKind: 25
+      RawFields:
+        - Name: data
+          Offset: 0
+          Type: 371 PointerType *noalg.map.group[int]*main.deepMap9
+        - Name: lengthMask
+          Offset: 8
+          Type: 8 BaseType uint64
+      GroupType: 372 StructureType noalg.map.group[int]*main.deepMap9
+      GroupSliceType: 378 GoSliceDataType []noalg.map.group[int]*main.deepMap9.array
+    - __kind: GoSwissMapGroupsType
+      ID: 192
       Name: groupReference<int,int>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 157 PointerType *noalg.map.group[int]int
+          Type: 193 PointerType *noalg.map.group[int]int
         - Name: lengthMask
           Offset: 8
           Type: 8 BaseType uint64
-      GroupType: 158 StructureType noalg.map.group[int]int
-      GroupSliceType: 162 GoSliceDataType []noalg.map.group[int]int.array
+      GroupType: 194 StructureType noalg.map.group[int]int
+      GroupSliceType: 198 GoSliceDataType []noalg.map.group[int]int.array
     - __kind: GoSwissMapGroupsType
-      ID: 215
+      ID: 385
+      Name: groupReference<int,interface {}>
+      ByteSize: 16
+      GoKind: 25
+      RawFields:
+        - Name: data
+          Offset: 0
+          Type: 386 PointerType *noalg.map.group[int]interface {}
+        - Name: lengthMask
+          Offset: 8
+          Type: 8 BaseType uint64
+      GroupType: 387 StructureType noalg.map.group[int]interface {}
+      GroupSliceType: 391 GoSliceDataType []noalg.map.group[int]interface {}.array
+    - __kind: GoSwissMapGroupsType
+      ID: 251
       Name: groupReference<int,uint8>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 216 PointerType *noalg.map.group[int]uint8
+          Type: 252 PointerType *noalg.map.group[int]uint8
         - Name: lengthMask
           Offset: 8
           Type: 8 BaseType uint64
-      GroupType: 217 StructureType noalg.map.group[int]uint8
-      GroupSliceType: 221 GoSliceDataType []noalg.map.group[int]uint8.array
+      GroupType: 253 StructureType noalg.map.group[int]uint8
+      GroupSliceType: 257 GoSliceDataType []noalg.map.group[int]uint8.array
     - __kind: GoSwissMapGroupsType
-      ID: 197
+      ID: 233
       Name: groupReference<string,[]main.structWithMap>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 198 PointerType *noalg.map.group[string][]main.structWithMap
+          Type: 234 PointerType *noalg.map.group[string][]main.structWithMap
         - Name: lengthMask
           Offset: 8
           Type: 8 BaseType uint64
-      GroupType: 199 StructureType noalg.map.group[string][]main.structWithMap
-      GroupSliceType: 205 GoSliceDataType []noalg.map.group[string][]main.structWithMap.array
+      GroupType: 235 StructureType noalg.map.group[string][]main.structWithMap
+      GroupSliceType: 241 GoSliceDataType []noalg.map.group[string][]main.structWithMap.array
     - __kind: GoSwissMapGroupsType
-      ID: 180
+      ID: 216
       Name: groupReference<string,[]string>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 181 PointerType *noalg.map.group[string][]string
+          Type: 217 PointerType *noalg.map.group[string][]string
         - Name: lengthMask
           Offset: 8
           Type: 8 BaseType uint64
-      GroupType: 182 StructureType noalg.map.group[string][]string
-      GroupSliceType: 186 GoSliceDataType []noalg.map.group[string][]string.array
+      GroupType: 218 StructureType noalg.map.group[string][]string
+      GroupSliceType: 222 GoSliceDataType []noalg.map.group[string][]string.array
     - __kind: GoSwissMapGroupsType
-      ID: 172
+      ID: 208
       Name: groupReference<string,int>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 173 PointerType *noalg.map.group[string]int
+          Type: 209 PointerType *noalg.map.group[string]int
         - Name: lengthMask
           Offset: 8
           Type: 8 BaseType uint64
-      GroupType: 174 StructureType noalg.map.group[string]int
-      GroupSliceType: 178 GoSliceDataType []noalg.map.group[string]int.array
+      GroupType: 210 StructureType noalg.map.group[string]int
+      GroupSliceType: 214 GoSliceDataType []noalg.map.group[string]int.array
     - __kind: GoSwissMapGroupsType
-      ID: 164
+      ID: 200
       Name: groupReference<string,main.nestedStruct>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 165 PointerType *noalg.map.group[string]main.nestedStruct
+          Type: 201 PointerType *noalg.map.group[string]main.nestedStruct
         - Name: lengthMask
           Offset: 8
           Type: 8 BaseType uint64
-      GroupType: 166 StructureType noalg.map.group[string]main.nestedStruct
-      GroupSliceType: 170 GoSliceDataType []noalg.map.group[string]main.nestedStruct.array
+      GroupType: 202 StructureType noalg.map.group[string]main.nestedStruct
+      GroupSliceType: 206 GoSliceDataType []noalg.map.group[string]main.nestedStruct.array
     - __kind: GoSwissMapGroupsType
-      ID: 231
+      ID: 267
       Name: groupReference<uint8,[4]int>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 232 PointerType *noalg.map.group[uint8][4]int
+          Type: 268 PointerType *noalg.map.group[uint8][4]int
         - Name: lengthMask
           Offset: 8
           Type: 8 BaseType uint64
-      GroupType: 233 StructureType noalg.map.group[uint8][4]int
-      GroupSliceType: 238 GoSliceDataType []noalg.map.group[uint8][4]int.array
+      GroupType: 269 StructureType noalg.map.group[uint8][4]int
+      GroupSliceType: 274 GoSliceDataType []noalg.map.group[uint8][4]int.array
     - __kind: GoSwissMapGroupsType
-      ID: 223
+      ID: 259
       Name: groupReference<uint8,uint8>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 224 PointerType *noalg.map.group[uint8]uint8
+          Type: 260 PointerType *noalg.map.group[uint8]uint8
         - Name: lengthMask
           Offset: 8
           Type: 8 BaseType uint64
-      GroupType: 225 StructureType noalg.map.group[uint8]uint8
-      GroupSliceType: 229 GoSliceDataType []noalg.map.group[uint8]uint8.array
+      GroupType: 261 StructureType noalg.map.group[uint8]uint8
+      GroupSliceType: 265 GoSliceDataType []noalg.map.group[uint8]uint8.array
     - __kind: BaseType
       ID: 7
       Name: int
       ByteSize: 8
-      GoRuntimeType: 579136
+      GoRuntimeType: 584256
       GoKind: 2
     - __kind: BaseType
       ID: 23
       Name: int16
       ByteSize: 2
-      GoRuntimeType: 578752
+      GoRuntimeType: 583872
       GoKind: 4
     - __kind: BaseType
       ID: 12
       Name: int32
       ByteSize: 4
-      GoRuntimeType: 578880
+      GoRuntimeType: 584000
       GoKind: 5
     - __kind: BaseType
       ID: 13
       Name: int64
       ByteSize: 8
-      GoRuntimeType: 579008
+      GoRuntimeType: 584128
       GoKind: 6
     - __kind: BaseType
       ID: 17
       Name: int8
       ByteSize: 1
-      GoRuntimeType: 578624
+      GoRuntimeType: 583744
       GoKind: 3
     - __kind: GoEmptyInterfaceType
-      ID: 58
+      ID: 81
       Name: interface {}
       ByteSize: 16
-      GoRuntimeType: 841248
+      GoRuntimeType: 847232
       GoKind: 20
       RawFields:
         - Name: _type
@@ -5924,10 +6792,10 @@ Types:
           Offset: 8
           Type: 15 VoidPointerType unsafe.Pointer
     - __kind: StructureType
-      ID: 269
+      ID: 394
       Name: internal/sync.Mutex
       ByteSize: 8
-      GoRuntimeType: 1.459296e+06
+      GoRuntimeType: 1.472192e+06
       GoKind: 25
       RawFields:
         - Name: state
@@ -5940,7 +6808,7 @@ Types:
       ID: 55
       Name: io.Writer
       ByteSize: 16
-      GoRuntimeType: 1.016032e+06
+      GoRuntimeType: 1.022016e+06
       GoKind: 20
       RawFields:
         - Name: tab
@@ -5950,7 +6818,7 @@ Types:
           Offset: 8
           Type: 15 VoidPointerType unsafe.Pointer
     - __kind: StructureType
-      ID: 148
+      ID: 171
       Name: main.aStruct
       ByteSize: 56
       GoKind: 25
@@ -5966,12 +6834,12 @@ Types:
           Type: 7 BaseType int
         - Name: nested
           Offset: 32
-          Type: 149 StructureType main.nestedStruct
+          Type: 172 StructureType main.nestedStruct
     - __kind: GoInterfaceType
-      ID: 64
+      ID: 87
       Name: main.behavior
       ByteSize: 16
-      GoRuntimeType: 1.015648e+06
+      GoRuntimeType: 1.021632e+06
       GoKind: 20
       RawFields:
         - Name: tab
@@ -5996,37 +6864,199 @@ Types:
           Offset: 32
           Type: 55 GoInterfaceType io.Writer
     - __kind: StructureType
-      ID: 150
+      ID: 67
+      Name: main.deepMap1
+      ByteSize: 8
+      GoRuntimeType: 1.185088e+06
+      GoKind: 25
+      RawFields:
+        - Name: a
+          Offset: 0
+          Type: 68 GoMapType map[int]*main.deepMap2
+    - __kind: StructureType
+      ID: 188
+      Name: main.deepMap2
+      ByteSize: 8
+      GoRuntimeType: 1.18496e+06
+      GoKind: 25
+      RawFields:
+        - Name: a
+          Offset: 0
+          Type: 314 GoMapType map[int]*main.deepMap3
+    - __kind: UnresolvedPointeeType
+      ID: 326
+      Name: main.deepMap3
+      ByteSize: 8
+    - __kind: StructureType
+      ID: 74
+      Name: main.deepMap7
+      ByteSize: 8
+      GoRuntimeType: 1.18432e+06
+      GoKind: 25
+      RawFields:
+        - Name: a
+          Offset: 0
+          Type: 349 GoMapType map[int]*main.deepMap8
+    - __kind: StructureType
+      ID: 361
+      Name: main.deepMap8
+      ByteSize: 8
+      GoRuntimeType: 1.184192e+06
+      GoKind: 25
+      RawFields:
+        - Name: a
+          Offset: 0
+          Type: 364 GoMapType map[int]*main.deepMap9
+    - __kind: StructureType
+      ID: 376
+      Name: main.deepMap9
+      ByteSize: 8
+      GoRuntimeType: 1.184064e+06
+      GoKind: 25
+      RawFields:
+        - Name: a
+          Offset: 0
+          Type: 379 GoMapType map[int]interface {}
+    - __kind: StructureType
+      ID: 56
+      Name: main.deepPtr1
+      ByteSize: 8
+      GoRuntimeType: 1.18624e+06
+      GoKind: 25
+      RawFields:
+        - Name: a
+          Offset: 0
+          Type: 57 PointerType *main.deepPtr2
+    - __kind: StructureType
+      ID: 58
+      Name: main.deepPtr2
+      ByteSize: 8
+      GoRuntimeType: 1.186112e+06
+      GoKind: 25
+      RawFields:
+        - Name: a
+          Offset: 0
+          Type: 303 PointerType *main.deepPtr3
+    - __kind: UnresolvedPointeeType
+      ID: 304
+      Name: main.deepPtr3
+      ByteSize: 8
+    - __kind: StructureType
+      ID: 60
+      Name: main.deepPtr7
+      ByteSize: 8
+      GoRuntimeType: 1.185472e+06
+      GoKind: 25
+      RawFields:
+        - Name: a
+          Offset: 0
+          Type: 329 PointerType *main.deepPtr8
+    - __kind: StructureType
+      ID: 330
+      Name: main.deepPtr8
+      ByteSize: 8
+      GoRuntimeType: 1.185344e+06
+      GoKind: 25
+      RawFields:
+        - Name: a
+          Offset: 0
+          Type: 331 PointerType *main.deepPtr9
+    - __kind: StructureType
+      ID: 332
+      Name: main.deepPtr9
+      ByteSize: 16
+      GoRuntimeType: 1.185216e+06
+      GoKind: 25
+      RawFields:
+        - Name: a
+          Offset: 0
+          Type: 81 GoEmptyInterfaceType interface {}
+    - __kind: StructureType
+      ID: 61
+      Name: main.deepSlice1
+      ByteSize: 24
+      GoRuntimeType: 1.187392e+06
+      GoKind: 25
+      RawFields:
+        - Name: a
+          Offset: 0
+          Type: 62 GoSliceHeaderType []*main.deepSlice2
+    - __kind: StructureType
+      ID: 178
+      Name: main.deepSlice2
+      ByteSize: 24
+      GoRuntimeType: 1.187264e+06
+      GoKind: 25
+      RawFields:
+        - Name: a
+          Offset: 0
+          Type: 308 GoSliceHeaderType []*main.deepSlice3
+    - __kind: UnresolvedPointeeType
+      ID: 311
+      Name: main.deepSlice3
+      ByteSize: 8
+    - __kind: StructureType
+      ID: 66
+      Name: main.deepSlice7
+      ByteSize: 24
+      GoRuntimeType: 1.186624e+06
+      GoKind: 25
+      RawFields:
+        - Name: a
+          Offset: 0
+          Type: 333 GoSliceHeaderType []*main.deepSlice8
+    - __kind: StructureType
+      ID: 336
+      Name: main.deepSlice8
+      ByteSize: 24
+      GoRuntimeType: 1.186496e+06
+      GoKind: 25
+      RawFields:
+        - Name: a
+          Offset: 0
+          Type: 339 GoSliceHeaderType []*main.deepSlice9
+    - __kind: StructureType
+      ID: 342
+      Name: main.deepSlice9
+      ByteSize: 24
+      GoRuntimeType: 1.186368e+06
+      GoKind: 25
+      RawFields:
+        - Name: a
+          Offset: 0
+          Type: 345 GoSliceHeaderType []interface {}
+    - __kind: StructureType
+      ID: 173
       Name: main.emptyStruct
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 62
+      ID: 85
       Name: main.esotericHeap
       ByteSize: 112
-      GoRuntimeType: 1.820416e+06
+      GoRuntimeType: 1.833312e+06
       GoKind: 25
       RawFields:
         - Name: esotericStack
           Offset: 0
-          Type: 56 StructureType main.esotericStack
+          Type: 79 StructureType main.esotericStack
         - Name: mu
           Offset: 64
-          Type: 267 StructureType sync.Mutex
+          Type: 392 StructureType sync.Mutex
         - Name: once
           Offset: 72
-          Type: 270 StructureType sync.Once
+          Type: 395 StructureType sync.Once
         - Name: wg
           Offset: 88
-          Type: 273 StructureType sync.WaitGroup
+          Type: 398 StructureType sync.WaitGroup
         - Name: a
           Offset: 104
-          Type: 276 StructureType sync/atomic.Int32
+          Type: 401 StructureType sync/atomic.Int32
     - __kind: StructureType
-      ID: 56
+      ID: 79
       Name: main.esotericStack
       ByteSize: 64
-      GoRuntimeType: 1.953504e+06
+      GoRuntimeType: 1.9664e+06
       GoKind: 25
       RawFields:
         - Name: _
@@ -6037,24 +7067,24 @@ Types:
           Type: 12 BaseType int32
         - Name: c
           Offset: 8
-          Type: 57 GoChannelType chan struct {}
+          Type: 80 GoChannelType chan struct {}
         - Name: val
           Offset: 16
-          Type: 58 GoEmptyInterfaceType interface {}
+          Type: 81 GoEmptyInterfaceType interface {}
         - Name: _
           Offset: 32
           Type: 8 BaseType uint64
         - Name: work
           Offset: 40
-          Type: 59 GoInterfaceType main.something
+          Type: 82 GoInterfaceType main.something
         - Name: foo
           Offset: 56
-          Type: 60 GoSubroutineType func()
+          Type: 83 GoSubroutineType func()
     - __kind: StructureType
-      ID: 149
+      ID: 172
       Name: main.nestedStruct
       ByteSize: 24
-      GoRuntimeType: 1.447936e+06
+      GoRuntimeType: 1.460832e+06
       GoKind: 25
       RawFields:
         - Name: anotherInt
@@ -6064,10 +7094,10 @@ Types:
           Offset: 8
           Type: 9 GoStringHeaderType string
     - __kind: StructureType
-      ID: 131
+      ID: 154
       Name: main.node
       ByteSize: 16
-      GoRuntimeType: 1.447776e+06
+      GoRuntimeType: 1.460672e+06
       GoKind: 25
       RawFields:
         - Name: val
@@ -6075,9 +7105,9 @@ Types:
           Type: 7 BaseType int
         - Name: b
           Offset: 8
-          Type: 132 PointerType *main.node
+          Type: 155 PointerType *main.node
     - __kind: StructureType
-      ID: 147
+      ID: 170
       Name: main.oneStringStruct
       ByteSize: 16
       GoKind: 25
@@ -6086,10 +7116,10 @@ Types:
           Offset: 0
           Type: 9 GoStringHeaderType string
     - __kind: GoInterfaceType
-      ID: 59
+      ID: 82
       Name: main.something
       ByteSize: 16
-      GoRuntimeType: 1.015776e+06
+      GoRuntimeType: 1.02176e+06
       GoKind: 20
       RawFields:
         - Name: tab
@@ -6098,18 +7128,39 @@ Types:
         - Name: data
           Offset: 8
           Type: 15 VoidPointerType unsafe.Pointer
+    - __kind: GoStringHeaderType
+      ID: 76
+      Name: main.stringType1
+      ByteSize: 16
+      GoKind: 24
+      RawFields:
+        - Name: str
+          Offset: 0
+          Type: 306 PointerType *main.stringType1.str
+        - Name: len
+          Offset: 8
+          Type: 7 BaseType int
+      Data: 305 GoStringDataType main.stringType1.str
+    - __kind: GoStringDataType
+      ID: 305
+      Name: main.stringType1.str
+      ByteSize: 2048
+    - __kind: UnresolvedPointeeType
+      ID: 307
+      Name: main.stringType2
+      ByteSize: 8
     - __kind: StructureType
-      ID: 65
+      ID: 88
       Name: main.structWithMap
       ByteSize: 8
-      GoRuntimeType: 1.1768e+06
+      GoRuntimeType: 1.183936e+06
       GoKind: 25
       RawFields:
         - Name: m
           Offset: 0
-          Type: 66 GoMapType map[int]int
+          Type: 89 GoMapType map[int]int
     - __kind: StructureType
-      ID: 140
+      ID: 163
       Name: main.structWithNoStrings
       ByteSize: 2
       GoKind: 25
@@ -6121,7 +7172,7 @@ Types:
           Offset: 1
           Type: 4 BaseType bool
     - __kind: StructureType
-      ID: 130
+      ID: 153
       Name: main.structWithTwoValues
       ByteSize: 16
       GoKind: 25
@@ -6133,28 +7184,28 @@ Types:
           Offset: 8
           Type: 4 BaseType bool
     - __kind: GoSliceHeaderType
-      ID: 134
+      ID: 157
       Name: main.t
       ByteSize: 24
       GoKind: 23
       RawFields:
         - Name: array
           Offset: 0
-          Type: 277 PointerType **main.t
+          Type: 402 PointerType **main.t
         - Name: len
           Offset: 8
           Type: 7 BaseType int
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 278 GoSliceDataType main.t.array
+      Data: 403 GoSliceDataType main.t.array
     - __kind: GoSliceDataType
-      ID: 278
+      ID: 403
       Name: main.t.array
       ByteSize: 2048
-      Element: 133 PointerType *main.t
+      Element: 156 PointerType *main.t
     - __kind: StructureType
-      ID: 144
+      ID: 167
       Name: main.threeStringStruct
       ByteSize: 48
       GoKind: 25
@@ -6174,7 +7225,7 @@ Types:
       ByteSize: 2
       GoKind: 9
     - __kind: GoSwissMapHeaderType
-      ID: 125
+      ID: 148
       Name: map<[4]int,[4]int>
       ByteSize: 48
       GoKind: 25
@@ -6187,7 +7238,7 @@ Types:
           Type: 1 BaseType uintptr
         - Name: dirPtr
           Offset: 16
-          Type: 126 PointerType **table<[4]int,[4]int>
+          Type: 149 PointerType **table<[4]int,[4]int>
         - Name: dirLen
           Offset: 24
           Type: 7 BaseType int
@@ -6206,10 +7257,10 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 8 BaseType uint64
-      TablePtrSliceType: 253 GoSliceDataType []*table<[4]int,[4]int>.array
-      GroupType: 250 StructureType noalg.map.group[[4]int][4]int
+      TablePtrSliceType: 289 GoSliceDataType []*table<[4]int,[4]int>.array
+      GroupType: 286 StructureType noalg.map.group[[4]int][4]int
     - __kind: GoSwissMapHeaderType
-      ID: 120
+      ID: 143
       Name: map<[4]int,uint8>
       ByteSize: 48
       GoKind: 25
@@ -6222,7 +7273,7 @@ Types:
           Type: 1 BaseType uintptr
         - Name: dirPtr
           Offset: 16
-          Type: 121 PointerType **table<[4]int,uint8>
+          Type: 144 PointerType **table<[4]int,uint8>
         - Name: dirLen
           Offset: 24
           Type: 7 BaseType int
@@ -6241,10 +7292,10 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 8 BaseType uint64
-      TablePtrSliceType: 245 GoSliceDataType []*table<[4]int,uint8>.array
-      GroupType: 242 StructureType noalg.map.group[[4]int]uint8
+      TablePtrSliceType: 281 GoSliceDataType []*table<[4]int,uint8>.array
+      GroupType: 278 StructureType noalg.map.group[[4]int]uint8
     - __kind: GoSwissMapHeaderType
-      ID: 88
+      ID: 111
       Name: map<[4]string,[2]int>
       ByteSize: 48
       GoKind: 25
@@ -6257,7 +7308,7 @@ Types:
           Type: 1 BaseType uintptr
         - Name: dirPtr
           Offset: 16
-          Type: 89 PointerType **table<[4]string,[2]int>
+          Type: 112 PointerType **table<[4]string,[2]int>
         - Name: dirLen
           Offset: 24
           Type: 7 BaseType int
@@ -6276,10 +7327,10 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 8 BaseType uint64
-      TablePtrSliceType: 194 GoSliceDataType []*table<[4]string,[2]int>.array
-      GroupType: 190 StructureType noalg.map.group[[4]string][2]int
+      TablePtrSliceType: 230 GoSliceDataType []*table<[4]string,[2]int>.array
+      GroupType: 226 StructureType noalg.map.group[[4]string][2]int
     - __kind: GoSwissMapHeaderType
-      ID: 100
+      ID: 123
       Name: map<bool,main.node>
       ByteSize: 48
       GoKind: 25
@@ -6292,7 +7343,7 @@ Types:
           Type: 1 BaseType uintptr
         - Name: dirPtr
           Offset: 16
-          Type: 101 PointerType **table<bool,main.node>
+          Type: 124 PointerType **table<bool,main.node>
         - Name: dirLen
           Offset: 24
           Type: 7 BaseType int
@@ -6311,10 +7362,150 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 8 BaseType uint64
-      TablePtrSliceType: 212 GoSliceDataType []*table<bool,main.node>.array
-      GroupType: 209 StructureType noalg.map.group[bool]main.node
+      TablePtrSliceType: 248 GoSliceDataType []*table<bool,main.node>.array
+      GroupType: 245 StructureType noalg.map.group[bool]main.node
     - __kind: GoSwissMapHeaderType
-      ID: 68
+      ID: 70
+      Name: map<int,*main.deepMap2>
+      ByteSize: 48
+      GoKind: 25
+      RawFields:
+        - Name: used
+          Offset: 0
+          Type: 8 BaseType uint64
+        - Name: seed
+          Offset: 8
+          Type: 1 BaseType uintptr
+        - Name: dirPtr
+          Offset: 16
+          Type: 71 PointerType **table<int,*main.deepMap2>
+        - Name: dirLen
+          Offset: 24
+          Type: 7 BaseType int
+        - Name: globalDepth
+          Offset: 32
+          Type: 3 BaseType uint8
+        - Name: globalShift
+          Offset: 33
+          Type: 3 BaseType uint8
+        - Name: writing
+          Offset: 34
+          Type: 3 BaseType uint8
+        - Name: tombstonePossible
+          Offset: 35
+          Type: 4 BaseType bool
+        - Name: clearSeq
+          Offset: 40
+          Type: 8 BaseType uint64
+      TablePtrSliceType: 189 GoSliceDataType []*table<int,*main.deepMap2>.array
+      GroupType: 184 StructureType noalg.map.group[int]*main.deepMap2
+    - __kind: GoSwissMapHeaderType
+      ID: 316
+      Name: map<int,*main.deepMap3>
+      ByteSize: 48
+      GoKind: 25
+      RawFields:
+        - Name: used
+          Offset: 0
+          Type: 8 BaseType uint64
+        - Name: seed
+          Offset: 8
+          Type: 1 BaseType uintptr
+        - Name: dirPtr
+          Offset: 16
+          Type: 317 PointerType **table<int,*main.deepMap3>
+        - Name: dirLen
+          Offset: 24
+          Type: 7 BaseType int
+        - Name: globalDepth
+          Offset: 32
+          Type: 3 BaseType uint8
+        - Name: globalShift
+          Offset: 33
+          Type: 3 BaseType uint8
+        - Name: writing
+          Offset: 34
+          Type: 3 BaseType uint8
+        - Name: tombstonePossible
+          Offset: 35
+          Type: 4 BaseType bool
+        - Name: clearSeq
+          Offset: 40
+          Type: 8 BaseType uint64
+      TablePtrSliceType: 327 GoSliceDataType []*table<int,*main.deepMap3>.array
+      GroupType: 322 StructureType noalg.map.group[int]*main.deepMap3
+    - __kind: GoSwissMapHeaderType
+      ID: 351
+      Name: map<int,*main.deepMap8>
+      ByteSize: 48
+      GoKind: 25
+      RawFields:
+        - Name: used
+          Offset: 0
+          Type: 8 BaseType uint64
+        - Name: seed
+          Offset: 8
+          Type: 1 BaseType uintptr
+        - Name: dirPtr
+          Offset: 16
+          Type: 352 PointerType **table<int,*main.deepMap8>
+        - Name: dirLen
+          Offset: 24
+          Type: 7 BaseType int
+        - Name: globalDepth
+          Offset: 32
+          Type: 3 BaseType uint8
+        - Name: globalShift
+          Offset: 33
+          Type: 3 BaseType uint8
+        - Name: writing
+          Offset: 34
+          Type: 3 BaseType uint8
+        - Name: tombstonePossible
+          Offset: 35
+          Type: 4 BaseType bool
+        - Name: clearSeq
+          Offset: 40
+          Type: 8 BaseType uint64
+      TablePtrSliceType: 362 GoSliceDataType []*table<int,*main.deepMap8>.array
+      GroupType: 357 StructureType noalg.map.group[int]*main.deepMap8
+    - __kind: GoSwissMapHeaderType
+      ID: 366
+      Name: map<int,*main.deepMap9>
+      ByteSize: 48
+      GoKind: 25
+      RawFields:
+        - Name: used
+          Offset: 0
+          Type: 8 BaseType uint64
+        - Name: seed
+          Offset: 8
+          Type: 1 BaseType uintptr
+        - Name: dirPtr
+          Offset: 16
+          Type: 367 PointerType **table<int,*main.deepMap9>
+        - Name: dirLen
+          Offset: 24
+          Type: 7 BaseType int
+        - Name: globalDepth
+          Offset: 32
+          Type: 3 BaseType uint8
+        - Name: globalShift
+          Offset: 33
+          Type: 3 BaseType uint8
+        - Name: writing
+          Offset: 34
+          Type: 3 BaseType uint8
+        - Name: tombstonePossible
+          Offset: 35
+          Type: 4 BaseType bool
+        - Name: clearSeq
+          Offset: 40
+          Type: 8 BaseType uint64
+      TablePtrSliceType: 377 GoSliceDataType []*table<int,*main.deepMap9>.array
+      GroupType: 372 StructureType noalg.map.group[int]*main.deepMap9
+    - __kind: GoSwissMapHeaderType
+      ID: 91
       Name: map<int,int>
       ByteSize: 48
       GoKind: 25
@@ -6327,7 +7518,7 @@ Types:
           Type: 1 BaseType uintptr
         - Name: dirPtr
           Offset: 16
-          Type: 69 PointerType **table<int,int>
+          Type: 92 PointerType **table<int,int>
         - Name: dirLen
           Offset: 24
           Type: 7 BaseType int
@@ -6346,10 +7537,45 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 8 BaseType uint64
-      TablePtrSliceType: 161 GoSliceDataType []*table<int,int>.array
-      GroupType: 158 StructureType noalg.map.group[int]int
+      TablePtrSliceType: 197 GoSliceDataType []*table<int,int>.array
+      GroupType: 194 StructureType noalg.map.group[int]int
     - __kind: GoSwissMapHeaderType
-      ID: 105
+      ID: 381
+      Name: map<int,interface {}>
+      ByteSize: 48
+      GoKind: 25
+      RawFields:
+        - Name: used
+          Offset: 0
+          Type: 8 BaseType uint64
+        - Name: seed
+          Offset: 8
+          Type: 1 BaseType uintptr
+        - Name: dirPtr
+          Offset: 16
+          Type: 382 PointerType **table<int,interface {}>
+        - Name: dirLen
+          Offset: 24
+          Type: 7 BaseType int
+        - Name: globalDepth
+          Offset: 32
+          Type: 3 BaseType uint8
+        - Name: globalShift
+          Offset: 33
+          Type: 3 BaseType uint8
+        - Name: writing
+          Offset: 34
+          Type: 3 BaseType uint8
+        - Name: tombstonePossible
+          Offset: 35
+          Type: 4 BaseType bool
+        - Name: clearSeq
+          Offset: 40
+          Type: 8 BaseType uint64
+      TablePtrSliceType: 390 GoSliceDataType []*table<int,interface {}>.array
+      GroupType: 387 StructureType noalg.map.group[int]interface {}
+    - __kind: GoSwissMapHeaderType
+      ID: 128
       Name: map<int,uint8>
       ByteSize: 48
       GoKind: 25
@@ -6362,7 +7588,7 @@ Types:
           Type: 1 BaseType uintptr
         - Name: dirPtr
           Offset: 16
-          Type: 106 PointerType **table<int,uint8>
+          Type: 129 PointerType **table<int,uint8>
         - Name: dirLen
           Offset: 24
           Type: 7 BaseType int
@@ -6381,10 +7607,10 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 8 BaseType uint64
-      TablePtrSliceType: 220 GoSliceDataType []*table<int,uint8>.array
-      GroupType: 217 StructureType noalg.map.group[int]uint8
+      TablePtrSliceType: 256 GoSliceDataType []*table<int,uint8>.array
+      GroupType: 253 StructureType noalg.map.group[int]uint8
     - __kind: GoSwissMapHeaderType
-      ID: 95
+      ID: 118
       Name: map<string,[]main.structWithMap>
       ByteSize: 48
       GoKind: 25
@@ -6397,7 +7623,7 @@ Types:
           Type: 1 BaseType uintptr
         - Name: dirPtr
           Offset: 16
-          Type: 96 PointerType **table<string,[]main.structWithMap>
+          Type: 119 PointerType **table<string,[]main.structWithMap>
         - Name: dirLen
           Offset: 24
           Type: 7 BaseType int
@@ -6416,10 +7642,10 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 8 BaseType uint64
-      TablePtrSliceType: 204 GoSliceDataType []*table<string,[]main.structWithMap>.array
-      GroupType: 199 StructureType noalg.map.group[string][]main.structWithMap
+      TablePtrSliceType: 240 GoSliceDataType []*table<string,[]main.structWithMap>.array
+      GroupType: 235 StructureType noalg.map.group[string][]main.structWithMap
     - __kind: GoSwissMapHeaderType
-      ID: 83
+      ID: 106
       Name: map<string,[]string>
       ByteSize: 48
       GoKind: 25
@@ -6432,7 +7658,7 @@ Types:
           Type: 1 BaseType uintptr
         - Name: dirPtr
           Offset: 16
-          Type: 84 PointerType **table<string,[]string>
+          Type: 107 PointerType **table<string,[]string>
         - Name: dirLen
           Offset: 24
           Type: 7 BaseType int
@@ -6451,10 +7677,10 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 8 BaseType uint64
-      TablePtrSliceType: 185 GoSliceDataType []*table<string,[]string>.array
-      GroupType: 182 StructureType noalg.map.group[string][]string
+      TablePtrSliceType: 221 GoSliceDataType []*table<string,[]string>.array
+      GroupType: 218 StructureType noalg.map.group[string][]string
     - __kind: GoSwissMapHeaderType
-      ID: 78
+      ID: 101
       Name: map<string,int>
       ByteSize: 48
       GoKind: 25
@@ -6467,7 +7693,7 @@ Types:
           Type: 1 BaseType uintptr
         - Name: dirPtr
           Offset: 16
-          Type: 79 PointerType **table<string,int>
+          Type: 102 PointerType **table<string,int>
         - Name: dirLen
           Offset: 24
           Type: 7 BaseType int
@@ -6486,10 +7712,10 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 8 BaseType uint64
-      TablePtrSliceType: 177 GoSliceDataType []*table<string,int>.array
-      GroupType: 174 StructureType noalg.map.group[string]int
+      TablePtrSliceType: 213 GoSliceDataType []*table<string,int>.array
+      GroupType: 210 StructureType noalg.map.group[string]int
     - __kind: GoSwissMapHeaderType
-      ID: 73
+      ID: 96
       Name: map<string,main.nestedStruct>
       ByteSize: 48
       GoKind: 25
@@ -6502,7 +7728,7 @@ Types:
           Type: 1 BaseType uintptr
         - Name: dirPtr
           Offset: 16
-          Type: 74 PointerType **table<string,main.nestedStruct>
+          Type: 97 PointerType **table<string,main.nestedStruct>
         - Name: dirLen
           Offset: 24
           Type: 7 BaseType int
@@ -6521,10 +7747,10 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 8 BaseType uint64
-      TablePtrSliceType: 169 GoSliceDataType []*table<string,main.nestedStruct>.array
-      GroupType: 166 StructureType noalg.map.group[string]main.nestedStruct
+      TablePtrSliceType: 205 GoSliceDataType []*table<string,main.nestedStruct>.array
+      GroupType: 202 StructureType noalg.map.group[string]main.nestedStruct
     - __kind: GoSwissMapHeaderType
-      ID: 115
+      ID: 138
       Name: map<uint8,[4]int>
       ByteSize: 48
       GoKind: 25
@@ -6537,7 +7763,7 @@ Types:
           Type: 1 BaseType uintptr
         - Name: dirPtr
           Offset: 16
-          Type: 116 PointerType **table<uint8,[4]int>
+          Type: 139 PointerType **table<uint8,[4]int>
         - Name: dirLen
           Offset: 24
           Type: 7 BaseType int
@@ -6556,10 +7782,10 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 8 BaseType uint64
-      TablePtrSliceType: 237 GoSliceDataType []*table<uint8,[4]int>.array
-      GroupType: 233 StructureType noalg.map.group[uint8][4]int
+      TablePtrSliceType: 273 GoSliceDataType []*table<uint8,[4]int>.array
+      GroupType: 269 StructureType noalg.map.group[uint8][4]int
     - __kind: GoSwissMapHeaderType
-      ID: 110
+      ID: 133
       Name: map<uint8,uint8>
       ByteSize: 48
       GoKind: 25
@@ -6572,7 +7798,7 @@ Types:
           Type: 1 BaseType uintptr
         - Name: dirPtr
           Offset: 16
-          Type: 111 PointerType **table<uint8,uint8>
+          Type: 134 PointerType **table<uint8,uint8>
         - Name: dirLen
           Offset: 24
           Type: 7 BaseType int
@@ -6591,205 +7817,285 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 8 BaseType uint64
-      TablePtrSliceType: 228 GoSliceDataType []*table<uint8,uint8>.array
-      GroupType: 225 StructureType noalg.map.group[uint8]uint8
+      TablePtrSliceType: 264 GoSliceDataType []*table<uint8,uint8>.array
+      GroupType: 261 StructureType noalg.map.group[uint8]uint8
     - __kind: GoMapType
-      ID: 123
+      ID: 146
       Name: map[[4]int][4]int
       ByteSize: 8
-      GoRuntimeType: 1.121696e+06
+      GoRuntimeType: 1.128832e+06
       GoKind: 21
-      HeaderType: 125 GoSwissMapHeaderType map<[4]int,[4]int>
+      HeaderType: 148 GoSwissMapHeaderType map<[4]int,[4]int>
     - __kind: GoMapType
-      ID: 118
+      ID: 141
       Name: map[[4]int]uint8
       ByteSize: 8
-      GoRuntimeType: 1.121824e+06
+      GoRuntimeType: 1.12896e+06
       GoKind: 21
-      HeaderType: 120 GoSwissMapHeaderType map<[4]int,uint8>
+      HeaderType: 143 GoSwissMapHeaderType map<[4]int,uint8>
     - __kind: GoMapType
-      ID: 86
+      ID: 109
       Name: map[[4]string][2]int
       ByteSize: 8
-      GoRuntimeType: 1.121952e+06
+      GoRuntimeType: 1.129088e+06
       GoKind: 21
-      HeaderType: 88 GoSwissMapHeaderType map<[4]string,[2]int>
+      HeaderType: 111 GoSwissMapHeaderType map<[4]string,[2]int>
     - __kind: GoMapType
-      ID: 98
+      ID: 121
       Name: map[bool]main.node
       ByteSize: 8
-      GoRuntimeType: 1.12208e+06
+      GoRuntimeType: 1.129216e+06
       GoKind: 21
-      HeaderType: 100 GoSwissMapHeaderType map<bool,main.node>
+      HeaderType: 123 GoSwissMapHeaderType map<bool,main.node>
     - __kind: GoMapType
-      ID: 66
+      ID: 68
+      Name: map[int]*main.deepMap2
+      ByteSize: 8
+      GoRuntimeType: 1.128704e+06
+      GoKind: 21
+      HeaderType: 70 GoSwissMapHeaderType map<int,*main.deepMap2>
+    - __kind: GoMapType
+      ID: 314
+      Name: map[int]*main.deepMap3
+      ByteSize: 8
+      GoRuntimeType: 1.128576e+06
+      GoKind: 21
+      HeaderType: 316 GoSwissMapHeaderType map<int,*main.deepMap3>
+    - __kind: GoMapType
+      ID: 349
+      Name: map[int]*main.deepMap8
+      ByteSize: 8
+      GoRuntimeType: 1.127936e+06
+      GoKind: 21
+      HeaderType: 351 GoSwissMapHeaderType map<int,*main.deepMap8>
+    - __kind: GoMapType
+      ID: 364
+      Name: map[int]*main.deepMap9
+      ByteSize: 8
+      GoRuntimeType: 1.127808e+06
+      GoKind: 21
+      HeaderType: 366 GoSwissMapHeaderType map<int,*main.deepMap9>
+    - __kind: GoMapType
+      ID: 89
       Name: map[int]int
       ByteSize: 8
-      GoRuntimeType: 1.121312e+06
+      GoRuntimeType: 1.127296e+06
       GoKind: 21
-      HeaderType: 68 GoSwissMapHeaderType map<int,int>
+      HeaderType: 91 GoSwissMapHeaderType map<int,int>
     - __kind: GoMapType
-      ID: 103
+      ID: 379
+      Name: map[int]interface {}
+      ByteSize: 8
+      GoRuntimeType: 1.12768e+06
+      GoKind: 21
+      HeaderType: 381 GoSwissMapHeaderType map<int,interface {}>
+    - __kind: GoMapType
+      ID: 126
       Name: map[int]uint8
       ByteSize: 8
-      GoRuntimeType: 1.122208e+06
+      GoRuntimeType: 1.129344e+06
       GoKind: 21
-      HeaderType: 105 GoSwissMapHeaderType map<int,uint8>
+      HeaderType: 128 GoSwissMapHeaderType map<int,uint8>
     - __kind: GoMapType
-      ID: 93
+      ID: 116
       Name: map[string][]main.structWithMap
       ByteSize: 8
-      GoRuntimeType: 1.122336e+06
+      GoRuntimeType: 1.129472e+06
       GoKind: 21
-      HeaderType: 95 GoSwissMapHeaderType map<string,[]main.structWithMap>
+      HeaderType: 118 GoSwissMapHeaderType map<string,[]main.structWithMap>
     - __kind: GoMapType
-      ID: 81
+      ID: 104
       Name: map[string][]string
       ByteSize: 8
-      GoRuntimeType: 1.122464e+06
+      GoRuntimeType: 1.1296e+06
       GoKind: 21
-      HeaderType: 83 GoSwissMapHeaderType map<string,[]string>
+      HeaderType: 106 GoSwissMapHeaderType map<string,[]string>
     - __kind: GoMapType
-      ID: 76
+      ID: 99
       Name: map[string]int
       ByteSize: 8
-      GoRuntimeType: 1.122592e+06
+      GoRuntimeType: 1.129728e+06
       GoKind: 21
-      HeaderType: 78 GoSwissMapHeaderType map<string,int>
+      HeaderType: 101 GoSwissMapHeaderType map<string,int>
     - __kind: GoMapType
-      ID: 71
+      ID: 94
       Name: map[string]main.nestedStruct
       ByteSize: 8
-      GoRuntimeType: 1.12272e+06
+      GoRuntimeType: 1.129856e+06
       GoKind: 21
-      HeaderType: 73 GoSwissMapHeaderType map<string,main.nestedStruct>
+      HeaderType: 96 GoSwissMapHeaderType map<string,main.nestedStruct>
     - __kind: GoMapType
-      ID: 113
+      ID: 136
       Name: map[uint8][4]int
       ByteSize: 8
-      GoRuntimeType: 1.122848e+06
+      GoRuntimeType: 1.129984e+06
       GoKind: 21
-      HeaderType: 115 GoSwissMapHeaderType map<uint8,[4]int>
+      HeaderType: 138 GoSwissMapHeaderType map<uint8,[4]int>
     - __kind: GoMapType
-      ID: 108
+      ID: 131
       Name: map[uint8]uint8
       ByteSize: 8
-      GoRuntimeType: 1.122976e+06
+      GoRuntimeType: 1.130112e+06
       GoKind: 21
-      HeaderType: 110 GoSwissMapHeaderType map<uint8,uint8>
+      HeaderType: 133 GoSwissMapHeaderType map<uint8,uint8>
     - __kind: ArrayType
-      ID: 251
+      ID: 287
       Name: noalg.[8]struct { key [4]int; elem [4]int }
       ByteSize: 512
-      GoRuntimeType: 676512
+      GoRuntimeType: 682496
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 252 StructureType noalg.struct { key [4]int; elem [4]int }
+      Element: 288 StructureType noalg.struct { key [4]int; elem [4]int }
     - __kind: ArrayType
-      ID: 243
+      ID: 279
       Name: noalg.[8]struct { key [4]int; elem uint8 }
       ByteSize: 320
-      GoRuntimeType: 676608
+      GoRuntimeType: 682592
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 244 StructureType noalg.struct { key [4]int; elem uint8 }
+      Element: 280 StructureType noalg.struct { key [4]int; elem uint8 }
     - __kind: ArrayType
-      ID: 191
+      ID: 227
       Name: noalg.[8]struct { key [4]string; elem [2]int }
       ByteSize: 640
-      GoRuntimeType: 676896
+      GoRuntimeType: 682880
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 192 StructureType noalg.struct { key [4]string; elem [2]int }
+      Element: 228 StructureType noalg.struct { key [4]string; elem [2]int }
     - __kind: ArrayType
-      ID: 210
+      ID: 246
       Name: noalg.[8]struct { key bool; elem main.node }
       ByteSize: 192
-      GoRuntimeType: 676992
+      GoRuntimeType: 682976
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 211 StructureType noalg.struct { key bool; elem main.node }
+      Element: 247 StructureType noalg.struct { key bool; elem main.node }
     - __kind: ArrayType
-      ID: 159
+      ID: 185
+      Name: noalg.[8]struct { key int; elem *main.deepMap2 }
+      ByteSize: 128
+      GoRuntimeType: 681824
+      GoKind: 17
+      Count: 8
+      HasCount: true
+      Element: 186 StructureType noalg.struct { key int; elem *main.deepMap2 }
+    - __kind: ArrayType
+      ID: 323
+      Name: noalg.[8]struct { key int; elem *main.deepMap3 }
+      ByteSize: 128
+      GoRuntimeType: 681728
+      GoKind: 17
+      Count: 8
+      HasCount: true
+      Element: 324 StructureType noalg.struct { key int; elem *main.deepMap3 }
+    - __kind: ArrayType
+      ID: 358
+      Name: noalg.[8]struct { key int; elem *main.deepMap8 }
+      ByteSize: 128
+      GoRuntimeType: 681248
+      GoKind: 17
+      Count: 8
+      HasCount: true
+      Element: 359 StructureType noalg.struct { key int; elem *main.deepMap8 }
+    - __kind: ArrayType
+      ID: 373
+      Name: noalg.[8]struct { key int; elem *main.deepMap9 }
+      ByteSize: 128
+      GoRuntimeType: 681152
+      GoKind: 17
+      Count: 8
+      HasCount: true
+      Element: 374 StructureType noalg.struct { key int; elem *main.deepMap9 }
+    - __kind: ArrayType
+      ID: 195
       Name: noalg.[8]struct { key int; elem int }
       ByteSize: 128
-      GoRuntimeType: 674784
+      GoRuntimeType: 679904
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 160 StructureType noalg.struct { key int; elem int }
+      Element: 196 StructureType noalg.struct { key int; elem int }
     - __kind: ArrayType
-      ID: 218
+      ID: 388
+      Name: noalg.[8]struct { key int; elem interface {} }
+      ByteSize: 192
+      GoRuntimeType: 681056
+      GoKind: 17
+      Count: 8
+      HasCount: true
+      Element: 389 StructureType noalg.struct { key int; elem interface {} }
+    - __kind: ArrayType
+      ID: 254
       Name: noalg.[8]struct { key int; elem uint8 }
       ByteSize: 128
-      GoRuntimeType: 677088
+      GoRuntimeType: 683072
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 219 StructureType noalg.struct { key int; elem uint8 }
+      Element: 255 StructureType noalg.struct { key int; elem uint8 }
     - __kind: ArrayType
-      ID: 200
+      ID: 236
       Name: noalg.[8]struct { key string; elem []main.structWithMap }
       ByteSize: 320
-      GoRuntimeType: 677184
+      GoRuntimeType: 683168
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 201 StructureType noalg.struct { key string; elem []main.structWithMap }
+      Element: 237 StructureType noalg.struct { key string; elem []main.structWithMap }
     - __kind: ArrayType
-      ID: 183
+      ID: 219
       Name: noalg.[8]struct { key string; elem []string }
       ByteSize: 320
-      GoRuntimeType: 677280
+      GoRuntimeType: 683264
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 184 StructureType noalg.struct { key string; elem []string }
+      Element: 220 StructureType noalg.struct { key string; elem []string }
     - __kind: ArrayType
-      ID: 175
+      ID: 211
       Name: noalg.[8]struct { key string; elem int }
       ByteSize: 192
-      GoRuntimeType: 677376
+      GoRuntimeType: 683360
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 176 StructureType noalg.struct { key string; elem int }
+      Element: 212 StructureType noalg.struct { key string; elem int }
     - __kind: ArrayType
-      ID: 167
+      ID: 203
       Name: noalg.[8]struct { key string; elem main.nestedStruct }
       ByteSize: 320
-      GoRuntimeType: 677472
+      GoRuntimeType: 683456
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 168 StructureType noalg.struct { key string; elem main.nestedStruct }
+      Element: 204 StructureType noalg.struct { key string; elem main.nestedStruct }
     - __kind: ArrayType
-      ID: 234
+      ID: 270
       Name: noalg.[8]struct { key uint8; elem [4]int }
       ByteSize: 320
-      GoRuntimeType: 677568
+      GoRuntimeType: 683552
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 235 StructureType noalg.struct { key uint8; elem [4]int }
+      Element: 271 StructureType noalg.struct { key uint8; elem [4]int }
     - __kind: ArrayType
-      ID: 226
+      ID: 262
       Name: noalg.[8]struct { key uint8; elem uint8 }
       ByteSize: 16
-      GoRuntimeType: 677664
+      GoRuntimeType: 683648
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 227 StructureType noalg.struct { key uint8; elem uint8 }
+      Element: 263 StructureType noalg.struct { key uint8; elem uint8 }
     - __kind: StructureType
-      ID: 250
+      ID: 286
       Name: noalg.map.group[[4]int][4]int
       ByteSize: 520
-      GoRuntimeType: 1.281056e+06
+      GoRuntimeType: 1.293952e+06
       GoKind: 25
       RawFields:
         - Name: ctrl
@@ -6797,12 +8103,12 @@ Types:
           Type: 8 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 251 ArrayType noalg.[8]struct { key [4]int; elem [4]int }
+          Type: 287 ArrayType noalg.[8]struct { key [4]int; elem [4]int }
     - __kind: StructureType
-      ID: 242
+      ID: 278
       Name: noalg.map.group[[4]int]uint8
       ByteSize: 328
-      GoRuntimeType: 1.281312e+06
+      GoRuntimeType: 1.294208e+06
       GoKind: 25
       RawFields:
         - Name: ctrl
@@ -6810,12 +8116,12 @@ Types:
           Type: 8 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 243 ArrayType noalg.[8]struct { key [4]int; elem uint8 }
+          Type: 279 ArrayType noalg.[8]struct { key [4]int; elem uint8 }
     - __kind: StructureType
-      ID: 190
+      ID: 226
       Name: noalg.map.group[[4]string][2]int
       ByteSize: 648
-      GoRuntimeType: 1.281568e+06
+      GoRuntimeType: 1.294464e+06
       GoKind: 25
       RawFields:
         - Name: ctrl
@@ -6823,12 +8129,12 @@ Types:
           Type: 8 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 191 ArrayType noalg.[8]struct { key [4]string; elem [2]int }
+          Type: 227 ArrayType noalg.[8]struct { key [4]string; elem [2]int }
     - __kind: StructureType
-      ID: 209
+      ID: 245
       Name: noalg.map.group[bool]main.node
       ByteSize: 200
-      GoRuntimeType: 1.281824e+06
+      GoRuntimeType: 1.29472e+06
       GoKind: 25
       RawFields:
         - Name: ctrl
@@ -6836,12 +8142,64 @@ Types:
           Type: 8 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 210 ArrayType noalg.[8]struct { key bool; elem main.node }
+          Type: 246 ArrayType noalg.[8]struct { key bool; elem main.node }
     - __kind: StructureType
-      ID: 158
+      ID: 184
+      Name: noalg.map.group[int]*main.deepMap2
+      ByteSize: 136
+      GoRuntimeType: 1.293696e+06
+      GoKind: 25
+      RawFields:
+        - Name: ctrl
+          Offset: 0
+          Type: 8 BaseType uint64
+        - Name: slots
+          Offset: 8
+          Type: 185 ArrayType noalg.[8]struct { key int; elem *main.deepMap2 }
+    - __kind: StructureType
+      ID: 322
+      Name: noalg.map.group[int]*main.deepMap3
+      ByteSize: 136
+      GoRuntimeType: 1.29344e+06
+      GoKind: 25
+      RawFields:
+        - Name: ctrl
+          Offset: 0
+          Type: 8 BaseType uint64
+        - Name: slots
+          Offset: 8
+          Type: 323 ArrayType noalg.[8]struct { key int; elem *main.deepMap3 }
+    - __kind: StructureType
+      ID: 357
+      Name: noalg.map.group[int]*main.deepMap8
+      ByteSize: 136
+      GoRuntimeType: 1.29216e+06
+      GoKind: 25
+      RawFields:
+        - Name: ctrl
+          Offset: 0
+          Type: 8 BaseType uint64
+        - Name: slots
+          Offset: 8
+          Type: 358 ArrayType noalg.[8]struct { key int; elem *main.deepMap8 }
+    - __kind: StructureType
+      ID: 372
+      Name: noalg.map.group[int]*main.deepMap9
+      ByteSize: 136
+      GoRuntimeType: 1.291904e+06
+      GoKind: 25
+      RawFields:
+        - Name: ctrl
+          Offset: 0
+          Type: 8 BaseType uint64
+        - Name: slots
+          Offset: 8
+          Type: 373 ArrayType noalg.[8]struct { key int; elem *main.deepMap9 }
+    - __kind: StructureType
+      ID: 194
       Name: noalg.map.group[int]int
       ByteSize: 136
-      GoRuntimeType: 1.280288e+06
+      GoRuntimeType: 1.29088e+06
       GoKind: 25
       RawFields:
         - Name: ctrl
@@ -6849,12 +8207,25 @@ Types:
           Type: 8 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 159 ArrayType noalg.[8]struct { key int; elem int }
+          Type: 195 ArrayType noalg.[8]struct { key int; elem int }
     - __kind: StructureType
-      ID: 217
+      ID: 387
+      Name: noalg.map.group[int]interface {}
+      ByteSize: 200
+      GoRuntimeType: 1.291648e+06
+      GoKind: 25
+      RawFields:
+        - Name: ctrl
+          Offset: 0
+          Type: 8 BaseType uint64
+        - Name: slots
+          Offset: 8
+          Type: 388 ArrayType noalg.[8]struct { key int; elem interface {} }
+    - __kind: StructureType
+      ID: 253
       Name: noalg.map.group[int]uint8
       ByteSize: 136
-      GoRuntimeType: 1.28208e+06
+      GoRuntimeType: 1.294976e+06
       GoKind: 25
       RawFields:
         - Name: ctrl
@@ -6862,12 +8233,12 @@ Types:
           Type: 8 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 218 ArrayType noalg.[8]struct { key int; elem uint8 }
+          Type: 254 ArrayType noalg.[8]struct { key int; elem uint8 }
     - __kind: StructureType
-      ID: 199
+      ID: 235
       Name: noalg.map.group[string][]main.structWithMap
       ByteSize: 328
-      GoRuntimeType: 1.282336e+06
+      GoRuntimeType: 1.295232e+06
       GoKind: 25
       RawFields:
         - Name: ctrl
@@ -6875,12 +8246,12 @@ Types:
           Type: 8 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 200 ArrayType noalg.[8]struct { key string; elem []main.structWithMap }
+          Type: 236 ArrayType noalg.[8]struct { key string; elem []main.structWithMap }
     - __kind: StructureType
-      ID: 182
+      ID: 218
       Name: noalg.map.group[string][]string
       ByteSize: 328
-      GoRuntimeType: 1.282592e+06
+      GoRuntimeType: 1.295488e+06
       GoKind: 25
       RawFields:
         - Name: ctrl
@@ -6888,12 +8259,12 @@ Types:
           Type: 8 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 183 ArrayType noalg.[8]struct { key string; elem []string }
+          Type: 219 ArrayType noalg.[8]struct { key string; elem []string }
     - __kind: StructureType
-      ID: 174
+      ID: 210
       Name: noalg.map.group[string]int
       ByteSize: 200
-      GoRuntimeType: 1.282848e+06
+      GoRuntimeType: 1.295744e+06
       GoKind: 25
       RawFields:
         - Name: ctrl
@@ -6901,12 +8272,12 @@ Types:
           Type: 8 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 175 ArrayType noalg.[8]struct { key string; elem int }
+          Type: 211 ArrayType noalg.[8]struct { key string; elem int }
     - __kind: StructureType
-      ID: 166
+      ID: 202
       Name: noalg.map.group[string]main.nestedStruct
       ByteSize: 328
-      GoRuntimeType: 1.283104e+06
+      GoRuntimeType: 1.296e+06
       GoKind: 25
       RawFields:
         - Name: ctrl
@@ -6914,12 +8285,12 @@ Types:
           Type: 8 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 167 ArrayType noalg.[8]struct { key string; elem main.nestedStruct }
+          Type: 203 ArrayType noalg.[8]struct { key string; elem main.nestedStruct }
     - __kind: StructureType
-      ID: 233
+      ID: 269
       Name: noalg.map.group[uint8][4]int
       ByteSize: 328
-      GoRuntimeType: 1.28336e+06
+      GoRuntimeType: 1.296256e+06
       GoKind: 25
       RawFields:
         - Name: ctrl
@@ -6927,12 +8298,12 @@ Types:
           Type: 8 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 234 ArrayType noalg.[8]struct { key uint8; elem [4]int }
+          Type: 270 ArrayType noalg.[8]struct { key uint8; elem [4]int }
     - __kind: StructureType
-      ID: 225
+      ID: 261
       Name: noalg.map.group[uint8]uint8
       ByteSize: 24
-      GoRuntimeType: 1.283616e+06
+      GoRuntimeType: 1.296512e+06
       GoKind: 25
       RawFields:
         - Name: ctrl
@@ -6940,51 +8311,51 @@ Types:
           Type: 8 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 226 ArrayType noalg.[8]struct { key uint8; elem uint8 }
+          Type: 262 ArrayType noalg.[8]struct { key uint8; elem uint8 }
     - __kind: StructureType
-      ID: 252
+      ID: 288
       Name: noalg.struct { key [4]int; elem [4]int }
       ByteSize: 64
-      GoRuntimeType: 1.280928e+06
+      GoRuntimeType: 1.293824e+06
       GoKind: 25
       RawFields:
         - Name: key
           Offset: 0
-          Type: 236 ArrayType [4]int
+          Type: 272 ArrayType [4]int
         - Name: elem
           Offset: 32
-          Type: 236 ArrayType [4]int
+          Type: 272 ArrayType [4]int
     - __kind: StructureType
-      ID: 244
+      ID: 280
       Name: noalg.struct { key [4]int; elem uint8 }
       ByteSize: 40
-      GoRuntimeType: 1.281184e+06
+      GoRuntimeType: 1.29408e+06
       GoKind: 25
       RawFields:
         - Name: key
           Offset: 0
-          Type: 236 ArrayType [4]int
+          Type: 272 ArrayType [4]int
         - Name: elem
           Offset: 32
           Type: 3 BaseType uint8
     - __kind: StructureType
-      ID: 192
+      ID: 228
       Name: noalg.struct { key [4]string; elem [2]int }
       ByteSize: 80
-      GoRuntimeType: 1.28144e+06
+      GoRuntimeType: 1.294336e+06
       GoKind: 25
       RawFields:
         - Name: key
           Offset: 0
-          Type: 193 ArrayType [4]string
+          Type: 229 ArrayType [4]string
         - Name: elem
           Offset: 64
           Type: 40 ArrayType [2]int
     - __kind: StructureType
-      ID: 211
+      ID: 247
       Name: noalg.struct { key bool; elem main.node }
       ByteSize: 24
-      GoRuntimeType: 1.281696e+06
+      GoRuntimeType: 1.294592e+06
       GoKind: 25
       RawFields:
         - Name: key
@@ -6992,12 +8363,64 @@ Types:
           Type: 4 BaseType bool
         - Name: elem
           Offset: 8
-          Type: 131 StructureType main.node
+          Type: 154 StructureType main.node
     - __kind: StructureType
-      ID: 160
+      ID: 186
+      Name: noalg.struct { key int; elem *main.deepMap2 }
+      ByteSize: 16
+      GoRuntimeType: 1.293568e+06
+      GoKind: 25
+      RawFields:
+        - Name: key
+          Offset: 0
+          Type: 7 BaseType int
+        - Name: elem
+          Offset: 8
+          Type: 187 PointerType *main.deepMap2
+    - __kind: StructureType
+      ID: 324
+      Name: noalg.struct { key int; elem *main.deepMap3 }
+      ByteSize: 16
+      GoRuntimeType: 1.293312e+06
+      GoKind: 25
+      RawFields:
+        - Name: key
+          Offset: 0
+          Type: 7 BaseType int
+        - Name: elem
+          Offset: 8
+          Type: 325 PointerType *main.deepMap3
+    - __kind: StructureType
+      ID: 359
+      Name: noalg.struct { key int; elem *main.deepMap8 }
+      ByteSize: 16
+      GoRuntimeType: 1.292032e+06
+      GoKind: 25
+      RawFields:
+        - Name: key
+          Offset: 0
+          Type: 7 BaseType int
+        - Name: elem
+          Offset: 8
+          Type: 360 PointerType *main.deepMap8
+    - __kind: StructureType
+      ID: 374
+      Name: noalg.struct { key int; elem *main.deepMap9 }
+      ByteSize: 16
+      GoRuntimeType: 1.291776e+06
+      GoKind: 25
+      RawFields:
+        - Name: key
+          Offset: 0
+          Type: 7 BaseType int
+        - Name: elem
+          Offset: 8
+          Type: 375 PointerType *main.deepMap9
+    - __kind: StructureType
+      ID: 196
       Name: noalg.struct { key int; elem int }
       ByteSize: 16
-      GoRuntimeType: 1.28016e+06
+      GoRuntimeType: 1.290752e+06
       GoKind: 25
       RawFields:
         - Name: key
@@ -7007,10 +8430,23 @@ Types:
           Offset: 8
           Type: 7 BaseType int
     - __kind: StructureType
-      ID: 219
+      ID: 389
+      Name: noalg.struct { key int; elem interface {} }
+      ByteSize: 24
+      GoRuntimeType: 1.29152e+06
+      GoKind: 25
+      RawFields:
+        - Name: key
+          Offset: 0
+          Type: 7 BaseType int
+        - Name: elem
+          Offset: 8
+          Type: 81 GoEmptyInterfaceType interface {}
+    - __kind: StructureType
+      ID: 255
       Name: noalg.struct { key int; elem uint8 }
       ByteSize: 16
-      GoRuntimeType: 1.281952e+06
+      GoRuntimeType: 1.294848e+06
       GoKind: 25
       RawFields:
         - Name: key
@@ -7020,10 +8456,10 @@ Types:
           Offset: 8
           Type: 3 BaseType uint8
     - __kind: StructureType
-      ID: 201
+      ID: 237
       Name: noalg.struct { key string; elem []main.structWithMap }
       ByteSize: 40
-      GoRuntimeType: 1.282208e+06
+      GoRuntimeType: 1.295104e+06
       GoKind: 25
       RawFields:
         - Name: key
@@ -7031,12 +8467,12 @@ Types:
           Type: 9 GoStringHeaderType string
         - Name: elem
           Offset: 16
-          Type: 202 GoSliceHeaderType []main.structWithMap
+          Type: 238 GoSliceHeaderType []main.structWithMap
     - __kind: StructureType
-      ID: 184
+      ID: 220
       Name: noalg.struct { key string; elem []string }
       ByteSize: 40
-      GoRuntimeType: 1.282464e+06
+      GoRuntimeType: 1.29536e+06
       GoKind: 25
       RawFields:
         - Name: key
@@ -7044,12 +8480,12 @@ Types:
           Type: 9 GoStringHeaderType string
         - Name: elem
           Offset: 16
-          Type: 141 GoSliceHeaderType []string
+          Type: 164 GoSliceHeaderType []string
     - __kind: StructureType
-      ID: 176
+      ID: 212
       Name: noalg.struct { key string; elem int }
       ByteSize: 24
-      GoRuntimeType: 1.28272e+06
+      GoRuntimeType: 1.295616e+06
       GoKind: 25
       RawFields:
         - Name: key
@@ -7059,10 +8495,10 @@ Types:
           Offset: 16
           Type: 7 BaseType int
     - __kind: StructureType
-      ID: 168
+      ID: 204
       Name: noalg.struct { key string; elem main.nestedStruct }
       ByteSize: 40
-      GoRuntimeType: 1.282976e+06
+      GoRuntimeType: 1.295872e+06
       GoKind: 25
       RawFields:
         - Name: key
@@ -7070,12 +8506,12 @@ Types:
           Type: 9 GoStringHeaderType string
         - Name: elem
           Offset: 16
-          Type: 149 StructureType main.nestedStruct
+          Type: 172 StructureType main.nestedStruct
     - __kind: StructureType
-      ID: 235
+      ID: 271
       Name: noalg.struct { key uint8; elem [4]int }
       ByteSize: 40
-      GoRuntimeType: 1.283232e+06
+      GoRuntimeType: 1.296128e+06
       GoKind: 25
       RawFields:
         - Name: key
@@ -7083,12 +8519,12 @@ Types:
           Type: 3 BaseType uint8
         - Name: elem
           Offset: 8
-          Type: 236 ArrayType [4]int
+          Type: 272 ArrayType [4]int
     - __kind: StructureType
-      ID: 227
+      ID: 263
       Name: noalg.struct { key uint8; elem uint8 }
       ByteSize: 2
-      GoRuntimeType: 1.283488e+06
+      GoRuntimeType: 1.296384e+06
       GoKind: 25
       RawFields:
         - Name: key
@@ -7101,127 +8537,127 @@ Types:
       ID: 9
       Name: string
       ByteSize: 16
-      GoRuntimeType: 578560
+      GoRuntimeType: 583680
       GoKind: 24
       RawFields:
         - Name: str
           Offset: 0
-          Type: 152 PointerType *string.str
+          Type: 175 PointerType *string.str
         - Name: len
           Offset: 8
           Type: 7 BaseType int
-      Data: 151 GoStringDataType string.str
+      Data: 174 GoStringDataType string.str
     - __kind: GoStringDataType
-      ID: 151
+      ID: 174
       Name: string.str
       ByteSize: 2048
     - __kind: StructureType
-      ID: 267
+      ID: 392
       Name: sync.Mutex
       ByteSize: 8
-      GoRuntimeType: 1.449216e+06
+      GoRuntimeType: 1.462112e+06
       GoKind: 25
       RawFields:
         - Name: _
           Offset: 0
-          Type: 268 StructureType sync.noCopy
+          Type: 393 StructureType sync.noCopy
         - Name: mu
           Offset: 0
-          Type: 269 StructureType internal/sync.Mutex
+          Type: 394 StructureType internal/sync.Mutex
     - __kind: StructureType
-      ID: 270
+      ID: 395
       Name: sync.Once
       ByteSize: 12
-      GoRuntimeType: 1.598272e+06
+      GoRuntimeType: 1.611168e+06
       GoKind: 25
       RawFields:
         - Name: _
           Offset: 0
-          Type: 268 StructureType sync.noCopy
+          Type: 393 StructureType sync.noCopy
         - Name: done
           Offset: 0
-          Type: 271 StructureType sync/atomic.Bool
+          Type: 396 StructureType sync/atomic.Bool
         - Name: m
           Offset: 4
-          Type: 267 StructureType sync.Mutex
+          Type: 392 StructureType sync.Mutex
     - __kind: StructureType
-      ID: 273
+      ID: 398
       Name: sync.WaitGroup
       ByteSize: 16
-      GoRuntimeType: 1.59808e+06
+      GoRuntimeType: 1.610976e+06
       GoKind: 25
       RawFields:
         - Name: noCopy
           Offset: 0
-          Type: 268 StructureType sync.noCopy
+          Type: 393 StructureType sync.noCopy
         - Name: state
           Offset: 0
-          Type: 274 StructureType sync/atomic.Uint64
+          Type: 399 StructureType sync/atomic.Uint64
         - Name: sema
           Offset: 8
           Type: 2 BaseType uint32
     - __kind: StructureType
-      ID: 268
+      ID: 393
       Name: sync.noCopy
-      GoRuntimeType: 981440
+      GoRuntimeType: 987424
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 271
+      ID: 396
       Name: sync/atomic.Bool
       ByteSize: 4
-      GoRuntimeType: 1.450336e+06
+      GoRuntimeType: 1.463232e+06
       GoKind: 25
       RawFields:
         - Name: _
           Offset: 0
-          Type: 272 StructureType sync/atomic.noCopy
+          Type: 397 StructureType sync/atomic.noCopy
         - Name: v
           Offset: 0
           Type: 2 BaseType uint32
     - __kind: StructureType
-      ID: 276
+      ID: 401
       Name: sync/atomic.Int32
       ByteSize: 4
-      GoRuntimeType: 1.450496e+06
+      GoRuntimeType: 1.463392e+06
       GoKind: 25
       RawFields:
         - Name: _
           Offset: 0
-          Type: 272 StructureType sync/atomic.noCopy
+          Type: 397 StructureType sync/atomic.noCopy
         - Name: v
           Offset: 0
           Type: 12 BaseType int32
     - __kind: StructureType
-      ID: 274
+      ID: 399
       Name: sync/atomic.Uint64
       ByteSize: 8
-      GoRuntimeType: 1.598656e+06
+      GoRuntimeType: 1.611552e+06
       GoKind: 25
       RawFields:
         - Name: _
           Offset: 0
-          Type: 272 StructureType sync/atomic.noCopy
+          Type: 397 StructureType sync/atomic.noCopy
         - Name: _
           Offset: 0
-          Type: 275 StructureType sync/atomic.align64
+          Type: 400 StructureType sync/atomic.align64
         - Name: v
           Offset: 0
           Type: 8 BaseType uint64
     - __kind: StructureType
-      ID: 275
+      ID: 400
       Name: sync/atomic.align64
-      GoRuntimeType: 981632
+      GoRuntimeType: 987616
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 272
+      ID: 397
       Name: sync/atomic.noCopy
-      GoRuntimeType: 981536
+      GoRuntimeType: 987520
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 247
+      ID: 283
       Name: table<[4]int,[4]int>
       ByteSize: 32
       GoKind: 25
@@ -7243,9 +8679,9 @@ Types:
           Type: 7 BaseType int
         - Name: groups
           Offset: 16
-          Type: 248 GoSwissMapGroupsType groupReference<[4]int,[4]int>
+          Type: 284 GoSwissMapGroupsType groupReference<[4]int,[4]int>
     - __kind: StructureType
-      ID: 239
+      ID: 275
       Name: table<[4]int,uint8>
       ByteSize: 32
       GoKind: 25
@@ -7267,9 +8703,9 @@ Types:
           Type: 7 BaseType int
         - Name: groups
           Offset: 16
-          Type: 240 GoSwissMapGroupsType groupReference<[4]int,uint8>
+          Type: 276 GoSwissMapGroupsType groupReference<[4]int,uint8>
     - __kind: StructureType
-      ID: 187
+      ID: 223
       Name: table<[4]string,[2]int>
       ByteSize: 32
       GoKind: 25
@@ -7291,9 +8727,9 @@ Types:
           Type: 7 BaseType int
         - Name: groups
           Offset: 16
-          Type: 188 GoSwissMapGroupsType groupReference<[4]string,[2]int>
+          Type: 224 GoSwissMapGroupsType groupReference<[4]string,[2]int>
     - __kind: StructureType
-      ID: 206
+      ID: 242
       Name: table<bool,main.node>
       ByteSize: 32
       GoKind: 25
@@ -7315,9 +8751,105 @@ Types:
           Type: 7 BaseType int
         - Name: groups
           Offset: 16
-          Type: 207 GoSwissMapGroupsType groupReference<bool,main.node>
+          Type: 243 GoSwissMapGroupsType groupReference<bool,main.node>
     - __kind: StructureType
-      ID: 155
+      ID: 181
+      Name: table<int,*main.deepMap2>
+      ByteSize: 32
+      GoKind: 25
+      RawFields:
+        - Name: used
+          Offset: 0
+          Type: 6 BaseType uint16
+        - Name: capacity
+          Offset: 2
+          Type: 6 BaseType uint16
+        - Name: growthLeft
+          Offset: 4
+          Type: 6 BaseType uint16
+        - Name: localDepth
+          Offset: 6
+          Type: 3 BaseType uint8
+        - Name: index
+          Offset: 8
+          Type: 7 BaseType int
+        - Name: groups
+          Offset: 16
+          Type: 182 GoSwissMapGroupsType groupReference<int,*main.deepMap2>
+    - __kind: StructureType
+      ID: 319
+      Name: table<int,*main.deepMap3>
+      ByteSize: 32
+      GoKind: 25
+      RawFields:
+        - Name: used
+          Offset: 0
+          Type: 6 BaseType uint16
+        - Name: capacity
+          Offset: 2
+          Type: 6 BaseType uint16
+        - Name: growthLeft
+          Offset: 4
+          Type: 6 BaseType uint16
+        - Name: localDepth
+          Offset: 6
+          Type: 3 BaseType uint8
+        - Name: index
+          Offset: 8
+          Type: 7 BaseType int
+        - Name: groups
+          Offset: 16
+          Type: 320 GoSwissMapGroupsType groupReference<int,*main.deepMap3>
+    - __kind: StructureType
+      ID: 354
+      Name: table<int,*main.deepMap8>
+      ByteSize: 32
+      GoKind: 25
+      RawFields:
+        - Name: used
+          Offset: 0
+          Type: 6 BaseType uint16
+        - Name: capacity
+          Offset: 2
+          Type: 6 BaseType uint16
+        - Name: growthLeft
+          Offset: 4
+          Type: 6 BaseType uint16
+        - Name: localDepth
+          Offset: 6
+          Type: 3 BaseType uint8
+        - Name: index
+          Offset: 8
+          Type: 7 BaseType int
+        - Name: groups
+          Offset: 16
+          Type: 355 GoSwissMapGroupsType groupReference<int,*main.deepMap8>
+    - __kind: StructureType
+      ID: 369
+      Name: table<int,*main.deepMap9>
+      ByteSize: 32
+      GoKind: 25
+      RawFields:
+        - Name: used
+          Offset: 0
+          Type: 6 BaseType uint16
+        - Name: capacity
+          Offset: 2
+          Type: 6 BaseType uint16
+        - Name: growthLeft
+          Offset: 4
+          Type: 6 BaseType uint16
+        - Name: localDepth
+          Offset: 6
+          Type: 3 BaseType uint8
+        - Name: index
+          Offset: 8
+          Type: 7 BaseType int
+        - Name: groups
+          Offset: 16
+          Type: 370 GoSwissMapGroupsType groupReference<int,*main.deepMap9>
+    - __kind: StructureType
+      ID: 191
       Name: table<int,int>
       ByteSize: 32
       GoKind: 25
@@ -7339,9 +8871,33 @@ Types:
           Type: 7 BaseType int
         - Name: groups
           Offset: 16
-          Type: 156 GoSwissMapGroupsType groupReference<int,int>
+          Type: 192 GoSwissMapGroupsType groupReference<int,int>
     - __kind: StructureType
-      ID: 214
+      ID: 384
+      Name: table<int,interface {}>
+      ByteSize: 32
+      GoKind: 25
+      RawFields:
+        - Name: used
+          Offset: 0
+          Type: 6 BaseType uint16
+        - Name: capacity
+          Offset: 2
+          Type: 6 BaseType uint16
+        - Name: growthLeft
+          Offset: 4
+          Type: 6 BaseType uint16
+        - Name: localDepth
+          Offset: 6
+          Type: 3 BaseType uint8
+        - Name: index
+          Offset: 8
+          Type: 7 BaseType int
+        - Name: groups
+          Offset: 16
+          Type: 385 GoSwissMapGroupsType groupReference<int,interface {}>
+    - __kind: StructureType
+      ID: 250
       Name: table<int,uint8>
       ByteSize: 32
       GoKind: 25
@@ -7363,9 +8919,9 @@ Types:
           Type: 7 BaseType int
         - Name: groups
           Offset: 16
-          Type: 215 GoSwissMapGroupsType groupReference<int,uint8>
+          Type: 251 GoSwissMapGroupsType groupReference<int,uint8>
     - __kind: StructureType
-      ID: 196
+      ID: 232
       Name: table<string,[]main.structWithMap>
       ByteSize: 32
       GoKind: 25
@@ -7387,9 +8943,9 @@ Types:
           Type: 7 BaseType int
         - Name: groups
           Offset: 16
-          Type: 197 GoSwissMapGroupsType groupReference<string,[]main.structWithMap>
+          Type: 233 GoSwissMapGroupsType groupReference<string,[]main.structWithMap>
     - __kind: StructureType
-      ID: 179
+      ID: 215
       Name: table<string,[]string>
       ByteSize: 32
       GoKind: 25
@@ -7411,9 +8967,9 @@ Types:
           Type: 7 BaseType int
         - Name: groups
           Offset: 16
-          Type: 180 GoSwissMapGroupsType groupReference<string,[]string>
+          Type: 216 GoSwissMapGroupsType groupReference<string,[]string>
     - __kind: StructureType
-      ID: 171
+      ID: 207
       Name: table<string,int>
       ByteSize: 32
       GoKind: 25
@@ -7435,9 +8991,9 @@ Types:
           Type: 7 BaseType int
         - Name: groups
           Offset: 16
-          Type: 172 GoSwissMapGroupsType groupReference<string,int>
+          Type: 208 GoSwissMapGroupsType groupReference<string,int>
     - __kind: StructureType
-      ID: 163
+      ID: 199
       Name: table<string,main.nestedStruct>
       ByteSize: 32
       GoKind: 25
@@ -7459,9 +9015,9 @@ Types:
           Type: 7 BaseType int
         - Name: groups
           Offset: 16
-          Type: 164 GoSwissMapGroupsType groupReference<string,main.nestedStruct>
+          Type: 200 GoSwissMapGroupsType groupReference<string,main.nestedStruct>
     - __kind: StructureType
-      ID: 230
+      ID: 266
       Name: table<uint8,[4]int>
       ByteSize: 32
       GoKind: 25
@@ -7483,9 +9039,9 @@ Types:
           Type: 7 BaseType int
         - Name: groups
           Offset: 16
-          Type: 231 GoSwissMapGroupsType groupReference<uint8,[4]int>
+          Type: 267 GoSwissMapGroupsType groupReference<uint8,[4]int>
     - __kind: StructureType
-      ID: 222
+      ID: 258
       Name: table<uint8,uint8>
       ByteSize: 32
       GoKind: 25
@@ -7507,49 +9063,49 @@ Types:
           Type: 7 BaseType int
         - Name: groups
           Offset: 16
-          Type: 223 GoSwissMapGroupsType groupReference<uint8,uint8>
+          Type: 259 GoSwissMapGroupsType groupReference<uint8,uint8>
     - __kind: BaseType
       ID: 10
       Name: uint
       ByteSize: 8
-      GoRuntimeType: 579200
+      GoRuntimeType: 584320
       GoKind: 7
     - __kind: BaseType
       ID: 6
       Name: uint16
       ByteSize: 2
-      GoRuntimeType: 578816
+      GoRuntimeType: 583936
       GoKind: 9
     - __kind: BaseType
       ID: 2
       Name: uint32
       ByteSize: 4
-      GoRuntimeType: 578944
+      GoRuntimeType: 584064
       GoKind: 10
     - __kind: BaseType
       ID: 8
       Name: uint64
       ByteSize: 8
-      GoRuntimeType: 579072
+      GoRuntimeType: 584192
       GoKind: 11
     - __kind: BaseType
       ID: 3
       Name: uint8
       ByteSize: 1
-      GoRuntimeType: 578688
+      GoRuntimeType: 583808
       GoKind: 8
     - __kind: BaseType
       ID: 1
       Name: uintptr
       ByteSize: 8
-      GoRuntimeType: 579264
+      GoRuntimeType: 584384
       GoKind: 12
     - __kind: VoidPointerType
       ID: 15
       Name: unsafe.Pointer
       ByteSize: 8
-      GoRuntimeType: 579648
+      GoRuntimeType: 584768
       GoKind: 26
-MaxTypeID: 385
+MaxTypeID: 518
 Issues: []
-GoModuledataInfo: {FirstModuledataAddr: "0x12ed4c0", TypesOffset: 296}
+GoModuledataInfo: {FirstModuledataAddr: "0x12ed500", TypesOffset: 296}

--- a/pkg/dyninst/irgen/testdata/snapshot/sample.arch=arm64,toolchain=go1.25.0.yaml
+++ b/pkg/dyninst/irgen/testdata/snapshot/sample.arch=arm64,toolchain=go1.25.0.yaml
@@ -3091,7 +3091,7 @@ Subprograms:
           IsReturn: false
 Types:
     - __kind: PointerType
-      ID: 173
+      ID: 277
       Name: '**main.t'
       ByteSize: 8
       Pointee: 133 PointerType *main.t
@@ -3163,50 +3163,50 @@ Types:
       ByteSize: 8
       Pointee: 112 PointerType *table<uint8,uint8>
     - __kind: PointerType
-      ID: 177
+      ID: 154
       Name: '*[]*string.array'
       ByteSize: 8
-      Pointee: 176 GoSliceDataType []*string.array
+      Pointee: 153 GoSliceDataType []*string.array
     - __kind: PointerType
-      ID: 271
+      ID: 258
       Name: '*[][]uint.array'
       ByteSize: 8
-      Pointee: 270 GoSliceDataType [][]uint.array
+      Pointee: 257 GoSliceDataType [][]uint.array
     - __kind: PointerType
-      ID: 277
+      ID: 264
       Name: '*[]bool.array'
       ByteSize: 8
-      Pointee: 276 GoSliceDataType []bool.array
+      Pointee: 263 GoSliceDataType []bool.array
     - __kind: PointerType
       ID: 281
       Name: '*[]main.structWithMap.array'
       ByteSize: 8
       Pointee: 280 GoSliceDataType []main.structWithMap.array
     - __kind: PointerType
-      ID: 273
+      ID: 260
       Name: '*[]main.structWithNoStrings.array'
       ByteSize: 8
-      Pointee: 272 GoSliceDataType []main.structWithNoStrings.array
+      Pointee: 259 GoSliceDataType []main.structWithNoStrings.array
     - __kind: PointerType
-      ID: 275
+      ID: 262
       Name: '*[]string.array'
       ByteSize: 8
-      Pointee: 274 GoSliceDataType []string.array
+      Pointee: 261 GoSliceDataType []string.array
     - __kind: PointerType
       ID: 137
       Name: '*[]uint'
       ByteSize: 8
       Pointee: 135 GoSliceHeaderType []uint
     - __kind: PointerType
-      ID: 269
+      ID: 256
       Name: '*[]uint.array'
       ByteSize: 8
-      Pointee: 268 GoSliceDataType []uint.array
+      Pointee: 255 GoSliceDataType []uint.array
     - __kind: PointerType
-      ID: 279
+      ID: 266
       Name: '*[]uint16.array'
       ByteSize: 8
-      Pointee: 278 GoSliceDataType []uint16.array
+      Pointee: 265 GoSliceDataType []uint16.array
     - __kind: PointerType
       ID: 11
       Name: '*bool'
@@ -3291,7 +3291,7 @@ Types:
       GoKind: 22
       Pointee: 147 StructureType main.oneStringStruct
     - __kind: PointerType
-      ID: 220
+      ID: 203
       Name: '*main.structWithMap'
       ByteSize: 8
       GoRuntimeType: 382880
@@ -3315,10 +3315,10 @@ Types:
       GoKind: 22
       Pointee: 134 GoSliceHeaderType main.t
     - __kind: PointerType
-      ID: 267
+      ID: 279
       Name: '*main.t.array'
       ByteSize: 8
-      Pointee: 266 GoSliceDataType main.t.array
+      Pointee: 278 GoSliceDataType main.t.array
     - __kind: PointerType
       ID: 145
       Name: '*main.threeStringStruct'
@@ -3392,65 +3392,65 @@ Types:
       GoKind: 22
       Pointee: 76 GoMapType map[string]int
     - __kind: PointerType
-      ID: 260
+      ID: 249
       Name: '*noalg.map.group[[4]int][4]int'
       ByteSize: 8
-      Pointee: 261 StructureType noalg.map.group[[4]int][4]int
+      Pointee: 250 StructureType noalg.map.group[[4]int][4]int
     - __kind: PointerType
-      ID: 253
+      ID: 241
       Name: '*noalg.map.group[[4]int]uint8'
       ByteSize: 8
-      Pointee: 254 StructureType noalg.map.group[[4]int]uint8
+      Pointee: 242 StructureType noalg.map.group[[4]int]uint8
     - __kind: PointerType
-      ID: 207
+      ID: 189
       Name: '*noalg.map.group[[4]string][2]int'
       ByteSize: 8
-      Pointee: 208 StructureType noalg.map.group[[4]string][2]int
+      Pointee: 190 StructureType noalg.map.group[[4]string][2]int
     - __kind: PointerType
-      ID: 224
+      ID: 208
       Name: '*noalg.map.group[bool]main.node'
       ByteSize: 8
-      Pointee: 225 StructureType noalg.map.group[bool]main.node
+      Pointee: 209 StructureType noalg.map.group[bool]main.node
     - __kind: PointerType
-      ID: 179
+      ID: 157
       Name: '*noalg.map.group[int]int'
       ByteSize: 8
-      Pointee: 180 StructureType noalg.map.group[int]int
+      Pointee: 158 StructureType noalg.map.group[int]int
     - __kind: PointerType
-      ID: 231
+      ID: 216
       Name: '*noalg.map.group[int]uint8'
       ByteSize: 8
-      Pointee: 232 StructureType noalg.map.group[int]uint8
+      Pointee: 217 StructureType noalg.map.group[int]uint8
     - __kind: PointerType
-      ID: 215
+      ID: 198
       Name: '*noalg.map.group[string][]main.structWithMap'
       ByteSize: 8
-      Pointee: 216 StructureType noalg.map.group[string][]main.structWithMap
+      Pointee: 199 StructureType noalg.map.group[string][]main.structWithMap
     - __kind: PointerType
-      ID: 200
+      ID: 181
       Name: '*noalg.map.group[string][]string'
       ByteSize: 8
-      Pointee: 201 StructureType noalg.map.group[string][]string
+      Pointee: 182 StructureType noalg.map.group[string][]string
     - __kind: PointerType
-      ID: 193
+      ID: 173
       Name: '*noalg.map.group[string]int'
       ByteSize: 8
-      Pointee: 194 StructureType noalg.map.group[string]int
+      Pointee: 174 StructureType noalg.map.group[string]int
     - __kind: PointerType
-      ID: 186
+      ID: 165
       Name: '*noalg.map.group[string]main.nestedStruct'
       ByteSize: 8
-      Pointee: 187 StructureType noalg.map.group[string]main.nestedStruct
+      Pointee: 166 StructureType noalg.map.group[string]main.nestedStruct
     - __kind: PointerType
-      ID: 245
+      ID: 232
       Name: '*noalg.map.group[uint8][4]int'
       ByteSize: 8
-      Pointee: 246 StructureType noalg.map.group[uint8][4]int
+      Pointee: 233 StructureType noalg.map.group[uint8][4]int
     - __kind: PointerType
-      ID: 238
+      ID: 224
       Name: '*noalg.map.group[uint8]uint8'
       ByteSize: 8
-      Pointee: 239 StructureType noalg.map.group[uint8]uint8
+      Pointee: 225 StructureType noalg.map.group[uint8]uint8
     - __kind: PointerType
       ID: 22
       Name: '*string'
@@ -3459,70 +3459,70 @@ Types:
       GoKind: 22
       Pointee: 9 GoStringHeaderType string
     - __kind: PointerType
-      ID: 175
+      ID: 152
       Name: '*string.str'
       ByteSize: 8
-      Pointee: 174 GoStringDataType string.str
+      Pointee: 151 GoStringDataType string.str
     - __kind: PointerType
       ID: 127
       Name: '*table<[4]int,[4]int>'
       ByteSize: 8
-      Pointee: 172 StructureType table<[4]int,[4]int>
+      Pointee: 247 StructureType table<[4]int,[4]int>
     - __kind: PointerType
       ID: 122
       Name: '*table<[4]int,uint8>'
       ByteSize: 8
-      Pointee: 171 StructureType table<[4]int,uint8>
+      Pointee: 239 StructureType table<[4]int,uint8>
     - __kind: PointerType
       ID: 90
       Name: '*table<[4]string,[2]int>'
       ByteSize: 8
-      Pointee: 165 StructureType table<[4]string,[2]int>
+      Pointee: 187 StructureType table<[4]string,[2]int>
     - __kind: PointerType
       ID: 102
       Name: '*table<bool,main.node>'
       ByteSize: 8
-      Pointee: 167 StructureType table<bool,main.node>
+      Pointee: 206 StructureType table<bool,main.node>
     - __kind: PointerType
       ID: 70
       Name: '*table<int,int>'
       ByteSize: 8
-      Pointee: 161 StructureType table<int,int>
+      Pointee: 155 StructureType table<int,int>
     - __kind: PointerType
       ID: 107
       Name: '*table<int,uint8>'
       ByteSize: 8
-      Pointee: 168 StructureType table<int,uint8>
+      Pointee: 214 StructureType table<int,uint8>
     - __kind: PointerType
       ID: 97
       Name: '*table<string,[]main.structWithMap>'
       ByteSize: 8
-      Pointee: 166 StructureType table<string,[]main.structWithMap>
+      Pointee: 196 StructureType table<string,[]main.structWithMap>
     - __kind: PointerType
       ID: 85
       Name: '*table<string,[]string>'
       ByteSize: 8
-      Pointee: 164 StructureType table<string,[]string>
+      Pointee: 179 StructureType table<string,[]string>
     - __kind: PointerType
       ID: 80
       Name: '*table<string,int>'
       ByteSize: 8
-      Pointee: 163 StructureType table<string,int>
+      Pointee: 171 StructureType table<string,int>
     - __kind: PointerType
       ID: 75
       Name: '*table<string,main.nestedStruct>'
       ByteSize: 8
-      Pointee: 162 StructureType table<string,main.nestedStruct>
+      Pointee: 163 StructureType table<string,main.nestedStruct>
     - __kind: PointerType
       ID: 117
       Name: '*table<uint8,[4]int>'
       ByteSize: 8
-      Pointee: 170 StructureType table<uint8,[4]int>
+      Pointee: 230 StructureType table<uint8,[4]int>
     - __kind: PointerType
       ID: 112
       Name: '*table<uint8,uint8>'
       ByteSize: 8
-      Pointee: 169 StructureType table<uint8,uint8>
+      Pointee: 222 StructureType table<uint8,uint8>
     - __kind: PointerType
       ID: 34
       Name: '*uint'
@@ -5334,7 +5334,7 @@ Types:
       HasCount: true
       Element: 3 BaseType uint8
     - __kind: ArrayType
-      ID: 249
+      ID: 236
       Name: '[4]int'
       ByteSize: 32
       GoRuntimeType: 676416
@@ -5343,7 +5343,7 @@ Types:
       HasCount: true
       Element: 7 BaseType int
     - __kind: ArrayType
-      ID: 211
+      ID: 193
       Name: '[4]string'
       ByteSize: 64
       GoRuntimeType: 676704
@@ -5375,69 +5375,69 @@ Types:
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 176 GoSliceDataType []*string.array
+      Data: 153 GoSliceDataType []*string.array
     - __kind: GoSliceDataType
-      ID: 176
+      ID: 153
       Name: '[]*string.array'
       ByteSize: 2048
       Element: 22 PointerType *string
     - __kind: GoSliceDataType
-      ID: 264
+      ID: 253
       Name: '[]*table<[4]int,[4]int>.array'
       ByteSize: 8192
       Element: 127 PointerType *table<[4]int,[4]int>
     - __kind: GoSliceDataType
-      ID: 257
+      ID: 245
       Name: '[]*table<[4]int,uint8>.array'
       ByteSize: 8192
       Element: 122 PointerType *table<[4]int,uint8>
     - __kind: GoSliceDataType
-      ID: 212
+      ID: 194
       Name: '[]*table<[4]string,[2]int>.array'
       ByteSize: 8192
       Element: 90 PointerType *table<[4]string,[2]int>
     - __kind: GoSliceDataType
-      ID: 228
+      ID: 212
       Name: '[]*table<bool,main.node>.array'
       ByteSize: 8192
       Element: 102 PointerType *table<bool,main.node>
     - __kind: GoSliceDataType
-      ID: 183
+      ID: 161
       Name: '[]*table<int,int>.array'
       ByteSize: 8192
       Element: 70 PointerType *table<int,int>
     - __kind: GoSliceDataType
-      ID: 235
+      ID: 220
       Name: '[]*table<int,uint8>.array'
       ByteSize: 8192
       Element: 107 PointerType *table<int,uint8>
     - __kind: GoSliceDataType
-      ID: 221
+      ID: 204
       Name: '[]*table<string,[]main.structWithMap>.array'
       ByteSize: 8192
       Element: 97 PointerType *table<string,[]main.structWithMap>
     - __kind: GoSliceDataType
-      ID: 204
+      ID: 185
       Name: '[]*table<string,[]string>.array'
       ByteSize: 8192
       Element: 85 PointerType *table<string,[]string>
     - __kind: GoSliceDataType
-      ID: 197
+      ID: 177
       Name: '[]*table<string,int>.array'
       ByteSize: 8192
       Element: 80 PointerType *table<string,int>
     - __kind: GoSliceDataType
-      ID: 190
+      ID: 169
       Name: '[]*table<string,main.nestedStruct>.array'
       ByteSize: 8192
       Element: 75 PointerType *table<string,main.nestedStruct>
     - __kind: GoSliceDataType
-      ID: 250
+      ID: 237
       Name: '[]*table<uint8,[4]int>.array'
       ByteSize: 8192
       Element: 117 PointerType *table<uint8,[4]int>
     - __kind: GoSliceDataType
-      ID: 242
+      ID: 228
       Name: '[]*table<uint8,uint8>.array'
       ByteSize: 8192
       Element: 112 PointerType *table<uint8,uint8>
@@ -5456,9 +5456,9 @@ Types:
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 270 GoSliceDataType [][]uint.array
+      Data: 257 GoSliceDataType [][]uint.array
     - __kind: GoSliceDataType
-      ID: 270
+      ID: 257
       Name: '[][]uint.array'
       ByteSize: 2048
       Element: 135 GoSliceHeaderType []uint
@@ -5478,14 +5478,14 @@ Types:
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 276 GoSliceDataType []bool.array
+      Data: 263 GoSliceDataType []bool.array
     - __kind: GoSliceDataType
-      ID: 276
+      ID: 263
       Name: '[]bool.array'
       ByteSize: 2048
       Element: 4 BaseType bool
     - __kind: GoSliceHeaderType
-      ID: 219
+      ID: 202
       Name: '[]main.structWithMap'
       ByteSize: 24
       GoRuntimeType: 472608
@@ -5493,7 +5493,7 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 220 PointerType *main.structWithMap
+          Type: 203 PointerType *main.structWithMap
         - Name: len
           Offset: 8
           Type: 7 BaseType int
@@ -5521,72 +5521,72 @@ Types:
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 272 GoSliceDataType []main.structWithNoStrings.array
+      Data: 259 GoSliceDataType []main.structWithNoStrings.array
     - __kind: GoSliceDataType
-      ID: 272
+      ID: 259
       Name: '[]main.structWithNoStrings.array'
       ByteSize: 2048
       Element: 140 StructureType main.structWithNoStrings
     - __kind: GoSliceDataType
-      ID: 265
+      ID: 254
       Name: '[]noalg.map.group[[4]int][4]int.array'
       ByteSize: 2048
-      Element: 261 StructureType noalg.map.group[[4]int][4]int
+      Element: 250 StructureType noalg.map.group[[4]int][4]int
     - __kind: GoSliceDataType
-      ID: 258
+      ID: 246
       Name: '[]noalg.map.group[[4]int]uint8.array'
       ByteSize: 2048
-      Element: 254 StructureType noalg.map.group[[4]int]uint8
+      Element: 242 StructureType noalg.map.group[[4]int]uint8
     - __kind: GoSliceDataType
-      ID: 213
+      ID: 195
       Name: '[]noalg.map.group[[4]string][2]int.array'
       ByteSize: 2048
-      Element: 208 StructureType noalg.map.group[[4]string][2]int
+      Element: 190 StructureType noalg.map.group[[4]string][2]int
     - __kind: GoSliceDataType
-      ID: 229
+      ID: 213
       Name: '[]noalg.map.group[bool]main.node.array'
       ByteSize: 2048
-      Element: 225 StructureType noalg.map.group[bool]main.node
+      Element: 209 StructureType noalg.map.group[bool]main.node
     - __kind: GoSliceDataType
-      ID: 184
+      ID: 162
       Name: '[]noalg.map.group[int]int.array'
       ByteSize: 2048
-      Element: 180 StructureType noalg.map.group[int]int
+      Element: 158 StructureType noalg.map.group[int]int
     - __kind: GoSliceDataType
-      ID: 236
+      ID: 221
       Name: '[]noalg.map.group[int]uint8.array'
       ByteSize: 2048
-      Element: 232 StructureType noalg.map.group[int]uint8
-    - __kind: GoSliceDataType
-      ID: 222
-      Name: '[]noalg.map.group[string][]main.structWithMap.array'
-      ByteSize: 2048
-      Element: 216 StructureType noalg.map.group[string][]main.structWithMap
+      Element: 217 StructureType noalg.map.group[int]uint8
     - __kind: GoSliceDataType
       ID: 205
+      Name: '[]noalg.map.group[string][]main.structWithMap.array'
+      ByteSize: 2048
+      Element: 199 StructureType noalg.map.group[string][]main.structWithMap
+    - __kind: GoSliceDataType
+      ID: 186
       Name: '[]noalg.map.group[string][]string.array'
       ByteSize: 2048
-      Element: 201 StructureType noalg.map.group[string][]string
+      Element: 182 StructureType noalg.map.group[string][]string
     - __kind: GoSliceDataType
-      ID: 198
+      ID: 178
       Name: '[]noalg.map.group[string]int.array'
       ByteSize: 2048
-      Element: 194 StructureType noalg.map.group[string]int
+      Element: 174 StructureType noalg.map.group[string]int
     - __kind: GoSliceDataType
-      ID: 191
+      ID: 170
       Name: '[]noalg.map.group[string]main.nestedStruct.array'
       ByteSize: 2048
-      Element: 187 StructureType noalg.map.group[string]main.nestedStruct
+      Element: 166 StructureType noalg.map.group[string]main.nestedStruct
     - __kind: GoSliceDataType
-      ID: 251
+      ID: 238
       Name: '[]noalg.map.group[uint8][4]int.array'
       ByteSize: 2048
-      Element: 246 StructureType noalg.map.group[uint8][4]int
+      Element: 233 StructureType noalg.map.group[uint8][4]int
     - __kind: GoSliceDataType
-      ID: 243
+      ID: 229
       Name: '[]noalg.map.group[uint8]uint8.array'
       ByteSize: 2048
-      Element: 239 StructureType noalg.map.group[uint8]uint8
+      Element: 225 StructureType noalg.map.group[uint8]uint8
     - __kind: GoSliceHeaderType
       ID: 141
       Name: '[]string'
@@ -5603,9 +5603,9 @@ Types:
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 274 GoSliceDataType []string.array
+      Data: 261 GoSliceDataType []string.array
     - __kind: GoSliceDataType
-      ID: 274
+      ID: 261
       Name: '[]string.array'
       ByteSize: 2048
       Element: 9 GoStringHeaderType string
@@ -5625,9 +5625,9 @@ Types:
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 268 GoSliceDataType []uint.array
+      Data: 255 GoSliceDataType []uint.array
     - __kind: GoSliceDataType
-      ID: 268
+      ID: 255
       Name: '[]uint.array'
       ByteSize: 2048
       Element: 10 BaseType uint
@@ -5647,9 +5647,9 @@ Types:
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 278 GoSliceDataType []uint16.array
+      Data: 265 GoSliceDataType []uint16.array
     - __kind: GoSliceDataType
-      ID: 278
+      ID: 265
       Name: '[]uint16.array'
       ByteSize: 2048
       Element: 6 BaseType uint16
@@ -5713,173 +5713,173 @@ Types:
       GoRuntimeType: 471584
       GoKind: 19
     - __kind: GoSwissMapGroupsType
-      ID: 259
+      ID: 248
       Name: groupReference<[4]int,[4]int>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 260 PointerType *noalg.map.group[[4]int][4]int
+          Type: 249 PointerType *noalg.map.group[[4]int][4]int
         - Name: lengthMask
           Offset: 8
           Type: 8 BaseType uint64
-      GroupType: 261 StructureType noalg.map.group[[4]int][4]int
-      GroupSliceType: 265 GoSliceDataType []noalg.map.group[[4]int][4]int.array
+      GroupType: 250 StructureType noalg.map.group[[4]int][4]int
+      GroupSliceType: 254 GoSliceDataType []noalg.map.group[[4]int][4]int.array
     - __kind: GoSwissMapGroupsType
-      ID: 252
+      ID: 240
       Name: groupReference<[4]int,uint8>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 253 PointerType *noalg.map.group[[4]int]uint8
+          Type: 241 PointerType *noalg.map.group[[4]int]uint8
         - Name: lengthMask
           Offset: 8
           Type: 8 BaseType uint64
-      GroupType: 254 StructureType noalg.map.group[[4]int]uint8
-      GroupSliceType: 258 GoSliceDataType []noalg.map.group[[4]int]uint8.array
+      GroupType: 242 StructureType noalg.map.group[[4]int]uint8
+      GroupSliceType: 246 GoSliceDataType []noalg.map.group[[4]int]uint8.array
     - __kind: GoSwissMapGroupsType
-      ID: 206
+      ID: 188
       Name: groupReference<[4]string,[2]int>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 207 PointerType *noalg.map.group[[4]string][2]int
+          Type: 189 PointerType *noalg.map.group[[4]string][2]int
         - Name: lengthMask
           Offset: 8
           Type: 8 BaseType uint64
-      GroupType: 208 StructureType noalg.map.group[[4]string][2]int
-      GroupSliceType: 213 GoSliceDataType []noalg.map.group[[4]string][2]int.array
+      GroupType: 190 StructureType noalg.map.group[[4]string][2]int
+      GroupSliceType: 195 GoSliceDataType []noalg.map.group[[4]string][2]int.array
     - __kind: GoSwissMapGroupsType
-      ID: 223
+      ID: 207
       Name: groupReference<bool,main.node>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 224 PointerType *noalg.map.group[bool]main.node
+          Type: 208 PointerType *noalg.map.group[bool]main.node
         - Name: lengthMask
           Offset: 8
           Type: 8 BaseType uint64
-      GroupType: 225 StructureType noalg.map.group[bool]main.node
-      GroupSliceType: 229 GoSliceDataType []noalg.map.group[bool]main.node.array
+      GroupType: 209 StructureType noalg.map.group[bool]main.node
+      GroupSliceType: 213 GoSliceDataType []noalg.map.group[bool]main.node.array
     - __kind: GoSwissMapGroupsType
-      ID: 178
+      ID: 156
       Name: groupReference<int,int>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 179 PointerType *noalg.map.group[int]int
+          Type: 157 PointerType *noalg.map.group[int]int
         - Name: lengthMask
           Offset: 8
           Type: 8 BaseType uint64
-      GroupType: 180 StructureType noalg.map.group[int]int
-      GroupSliceType: 184 GoSliceDataType []noalg.map.group[int]int.array
+      GroupType: 158 StructureType noalg.map.group[int]int
+      GroupSliceType: 162 GoSliceDataType []noalg.map.group[int]int.array
     - __kind: GoSwissMapGroupsType
-      ID: 230
+      ID: 215
       Name: groupReference<int,uint8>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 231 PointerType *noalg.map.group[int]uint8
+          Type: 216 PointerType *noalg.map.group[int]uint8
         - Name: lengthMask
           Offset: 8
           Type: 8 BaseType uint64
-      GroupType: 232 StructureType noalg.map.group[int]uint8
-      GroupSliceType: 236 GoSliceDataType []noalg.map.group[int]uint8.array
+      GroupType: 217 StructureType noalg.map.group[int]uint8
+      GroupSliceType: 221 GoSliceDataType []noalg.map.group[int]uint8.array
     - __kind: GoSwissMapGroupsType
-      ID: 214
+      ID: 197
       Name: groupReference<string,[]main.structWithMap>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 215 PointerType *noalg.map.group[string][]main.structWithMap
+          Type: 198 PointerType *noalg.map.group[string][]main.structWithMap
         - Name: lengthMask
           Offset: 8
           Type: 8 BaseType uint64
-      GroupType: 216 StructureType noalg.map.group[string][]main.structWithMap
-      GroupSliceType: 222 GoSliceDataType []noalg.map.group[string][]main.structWithMap.array
+      GroupType: 199 StructureType noalg.map.group[string][]main.structWithMap
+      GroupSliceType: 205 GoSliceDataType []noalg.map.group[string][]main.structWithMap.array
     - __kind: GoSwissMapGroupsType
-      ID: 199
+      ID: 180
       Name: groupReference<string,[]string>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 200 PointerType *noalg.map.group[string][]string
+          Type: 181 PointerType *noalg.map.group[string][]string
         - Name: lengthMask
           Offset: 8
           Type: 8 BaseType uint64
-      GroupType: 201 StructureType noalg.map.group[string][]string
-      GroupSliceType: 205 GoSliceDataType []noalg.map.group[string][]string.array
+      GroupType: 182 StructureType noalg.map.group[string][]string
+      GroupSliceType: 186 GoSliceDataType []noalg.map.group[string][]string.array
     - __kind: GoSwissMapGroupsType
-      ID: 192
+      ID: 172
       Name: groupReference<string,int>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 193 PointerType *noalg.map.group[string]int
+          Type: 173 PointerType *noalg.map.group[string]int
         - Name: lengthMask
           Offset: 8
           Type: 8 BaseType uint64
-      GroupType: 194 StructureType noalg.map.group[string]int
-      GroupSliceType: 198 GoSliceDataType []noalg.map.group[string]int.array
+      GroupType: 174 StructureType noalg.map.group[string]int
+      GroupSliceType: 178 GoSliceDataType []noalg.map.group[string]int.array
     - __kind: GoSwissMapGroupsType
-      ID: 185
+      ID: 164
       Name: groupReference<string,main.nestedStruct>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 186 PointerType *noalg.map.group[string]main.nestedStruct
+          Type: 165 PointerType *noalg.map.group[string]main.nestedStruct
         - Name: lengthMask
           Offset: 8
           Type: 8 BaseType uint64
-      GroupType: 187 StructureType noalg.map.group[string]main.nestedStruct
-      GroupSliceType: 191 GoSliceDataType []noalg.map.group[string]main.nestedStruct.array
+      GroupType: 166 StructureType noalg.map.group[string]main.nestedStruct
+      GroupSliceType: 170 GoSliceDataType []noalg.map.group[string]main.nestedStruct.array
     - __kind: GoSwissMapGroupsType
-      ID: 244
+      ID: 231
       Name: groupReference<uint8,[4]int>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 245 PointerType *noalg.map.group[uint8][4]int
+          Type: 232 PointerType *noalg.map.group[uint8][4]int
         - Name: lengthMask
           Offset: 8
           Type: 8 BaseType uint64
-      GroupType: 246 StructureType noalg.map.group[uint8][4]int
-      GroupSliceType: 251 GoSliceDataType []noalg.map.group[uint8][4]int.array
+      GroupType: 233 StructureType noalg.map.group[uint8][4]int
+      GroupSliceType: 238 GoSliceDataType []noalg.map.group[uint8][4]int.array
     - __kind: GoSwissMapGroupsType
-      ID: 237
+      ID: 223
       Name: groupReference<uint8,uint8>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 238 PointerType *noalg.map.group[uint8]uint8
+          Type: 224 PointerType *noalg.map.group[uint8]uint8
         - Name: lengthMask
           Offset: 8
           Type: 8 BaseType uint64
-      GroupType: 239 StructureType noalg.map.group[uint8]uint8
-      GroupSliceType: 243 GoSliceDataType []noalg.map.group[uint8]uint8.array
+      GroupType: 225 StructureType noalg.map.group[uint8]uint8
+      GroupSliceType: 229 GoSliceDataType []noalg.map.group[uint8]uint8.array
     - __kind: BaseType
       ID: 7
       Name: int
@@ -5924,7 +5924,7 @@ Types:
           Offset: 8
           Type: 15 VoidPointerType unsafe.Pointer
     - __kind: StructureType
-      ID: 153
+      ID: 269
       Name: internal/sync.Mutex
       ByteSize: 8
       GoRuntimeType: 1.459296e+06
@@ -6012,16 +6012,16 @@ Types:
           Type: 56 StructureType main.esotericStack
         - Name: mu
           Offset: 64
-          Type: 151 StructureType sync.Mutex
+          Type: 267 StructureType sync.Mutex
         - Name: once
           Offset: 72
-          Type: 154 StructureType sync.Once
+          Type: 270 StructureType sync.Once
         - Name: wg
           Offset: 88
-          Type: 157 StructureType sync.WaitGroup
+          Type: 273 StructureType sync.WaitGroup
         - Name: a
           Offset: 104
-          Type: 160 StructureType sync/atomic.Int32
+          Type: 276 StructureType sync/atomic.Int32
     - __kind: StructureType
       ID: 56
       Name: main.esotericStack
@@ -6140,16 +6140,16 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 173 PointerType **main.t
+          Type: 277 PointerType **main.t
         - Name: len
           Offset: 8
           Type: 7 BaseType int
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 266 GoSliceDataType main.t.array
+      Data: 278 GoSliceDataType main.t.array
     - __kind: GoSliceDataType
-      ID: 266
+      ID: 278
       Name: main.t.array
       ByteSize: 2048
       Element: 133 PointerType *main.t
@@ -6206,8 +6206,8 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 8 BaseType uint64
-      TablePtrSliceType: 264 GoSliceDataType []*table<[4]int,[4]int>.array
-      GroupType: 261 StructureType noalg.map.group[[4]int][4]int
+      TablePtrSliceType: 253 GoSliceDataType []*table<[4]int,[4]int>.array
+      GroupType: 250 StructureType noalg.map.group[[4]int][4]int
     - __kind: GoSwissMapHeaderType
       ID: 120
       Name: map<[4]int,uint8>
@@ -6241,8 +6241,8 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 8 BaseType uint64
-      TablePtrSliceType: 257 GoSliceDataType []*table<[4]int,uint8>.array
-      GroupType: 254 StructureType noalg.map.group[[4]int]uint8
+      TablePtrSliceType: 245 GoSliceDataType []*table<[4]int,uint8>.array
+      GroupType: 242 StructureType noalg.map.group[[4]int]uint8
     - __kind: GoSwissMapHeaderType
       ID: 88
       Name: map<[4]string,[2]int>
@@ -6276,8 +6276,8 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 8 BaseType uint64
-      TablePtrSliceType: 212 GoSliceDataType []*table<[4]string,[2]int>.array
-      GroupType: 208 StructureType noalg.map.group[[4]string][2]int
+      TablePtrSliceType: 194 GoSliceDataType []*table<[4]string,[2]int>.array
+      GroupType: 190 StructureType noalg.map.group[[4]string][2]int
     - __kind: GoSwissMapHeaderType
       ID: 100
       Name: map<bool,main.node>
@@ -6311,8 +6311,8 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 8 BaseType uint64
-      TablePtrSliceType: 228 GoSliceDataType []*table<bool,main.node>.array
-      GroupType: 225 StructureType noalg.map.group[bool]main.node
+      TablePtrSliceType: 212 GoSliceDataType []*table<bool,main.node>.array
+      GroupType: 209 StructureType noalg.map.group[bool]main.node
     - __kind: GoSwissMapHeaderType
       ID: 68
       Name: map<int,int>
@@ -6346,8 +6346,8 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 8 BaseType uint64
-      TablePtrSliceType: 183 GoSliceDataType []*table<int,int>.array
-      GroupType: 180 StructureType noalg.map.group[int]int
+      TablePtrSliceType: 161 GoSliceDataType []*table<int,int>.array
+      GroupType: 158 StructureType noalg.map.group[int]int
     - __kind: GoSwissMapHeaderType
       ID: 105
       Name: map<int,uint8>
@@ -6381,8 +6381,8 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 8 BaseType uint64
-      TablePtrSliceType: 235 GoSliceDataType []*table<int,uint8>.array
-      GroupType: 232 StructureType noalg.map.group[int]uint8
+      TablePtrSliceType: 220 GoSliceDataType []*table<int,uint8>.array
+      GroupType: 217 StructureType noalg.map.group[int]uint8
     - __kind: GoSwissMapHeaderType
       ID: 95
       Name: map<string,[]main.structWithMap>
@@ -6416,8 +6416,8 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 8 BaseType uint64
-      TablePtrSliceType: 221 GoSliceDataType []*table<string,[]main.structWithMap>.array
-      GroupType: 216 StructureType noalg.map.group[string][]main.structWithMap
+      TablePtrSliceType: 204 GoSliceDataType []*table<string,[]main.structWithMap>.array
+      GroupType: 199 StructureType noalg.map.group[string][]main.structWithMap
     - __kind: GoSwissMapHeaderType
       ID: 83
       Name: map<string,[]string>
@@ -6451,8 +6451,8 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 8 BaseType uint64
-      TablePtrSliceType: 204 GoSliceDataType []*table<string,[]string>.array
-      GroupType: 201 StructureType noalg.map.group[string][]string
+      TablePtrSliceType: 185 GoSliceDataType []*table<string,[]string>.array
+      GroupType: 182 StructureType noalg.map.group[string][]string
     - __kind: GoSwissMapHeaderType
       ID: 78
       Name: map<string,int>
@@ -6486,8 +6486,8 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 8 BaseType uint64
-      TablePtrSliceType: 197 GoSliceDataType []*table<string,int>.array
-      GroupType: 194 StructureType noalg.map.group[string]int
+      TablePtrSliceType: 177 GoSliceDataType []*table<string,int>.array
+      GroupType: 174 StructureType noalg.map.group[string]int
     - __kind: GoSwissMapHeaderType
       ID: 73
       Name: map<string,main.nestedStruct>
@@ -6521,8 +6521,8 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 8 BaseType uint64
-      TablePtrSliceType: 190 GoSliceDataType []*table<string,main.nestedStruct>.array
-      GroupType: 187 StructureType noalg.map.group[string]main.nestedStruct
+      TablePtrSliceType: 169 GoSliceDataType []*table<string,main.nestedStruct>.array
+      GroupType: 166 StructureType noalg.map.group[string]main.nestedStruct
     - __kind: GoSwissMapHeaderType
       ID: 115
       Name: map<uint8,[4]int>
@@ -6556,8 +6556,8 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 8 BaseType uint64
-      TablePtrSliceType: 250 GoSliceDataType []*table<uint8,[4]int>.array
-      GroupType: 246 StructureType noalg.map.group[uint8][4]int
+      TablePtrSliceType: 237 GoSliceDataType []*table<uint8,[4]int>.array
+      GroupType: 233 StructureType noalg.map.group[uint8][4]int
     - __kind: GoSwissMapHeaderType
       ID: 110
       Name: map<uint8,uint8>
@@ -6591,8 +6591,8 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 8 BaseType uint64
-      TablePtrSliceType: 242 GoSliceDataType []*table<uint8,uint8>.array
-      GroupType: 239 StructureType noalg.map.group[uint8]uint8
+      TablePtrSliceType: 228 GoSliceDataType []*table<uint8,uint8>.array
+      GroupType: 225 StructureType noalg.map.group[uint8]uint8
     - __kind: GoMapType
       ID: 123
       Name: map[[4]int][4]int
@@ -6678,115 +6678,115 @@ Types:
       GoKind: 21
       HeaderType: 110 GoSwissMapHeaderType map<uint8,uint8>
     - __kind: ArrayType
-      ID: 262
+      ID: 251
       Name: noalg.[8]struct { key [4]int; elem [4]int }
       ByteSize: 512
       GoRuntimeType: 676512
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 263 StructureType noalg.struct { key [4]int; elem [4]int }
+      Element: 252 StructureType noalg.struct { key [4]int; elem [4]int }
     - __kind: ArrayType
-      ID: 255
+      ID: 243
       Name: noalg.[8]struct { key [4]int; elem uint8 }
       ByteSize: 320
       GoRuntimeType: 676608
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 256 StructureType noalg.struct { key [4]int; elem uint8 }
+      Element: 244 StructureType noalg.struct { key [4]int; elem uint8 }
     - __kind: ArrayType
-      ID: 209
+      ID: 191
       Name: noalg.[8]struct { key [4]string; elem [2]int }
       ByteSize: 640
       GoRuntimeType: 676896
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 210 StructureType noalg.struct { key [4]string; elem [2]int }
+      Element: 192 StructureType noalg.struct { key [4]string; elem [2]int }
     - __kind: ArrayType
-      ID: 226
+      ID: 210
       Name: noalg.[8]struct { key bool; elem main.node }
       ByteSize: 192
       GoRuntimeType: 676992
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 227 StructureType noalg.struct { key bool; elem main.node }
+      Element: 211 StructureType noalg.struct { key bool; elem main.node }
     - __kind: ArrayType
-      ID: 181
+      ID: 159
       Name: noalg.[8]struct { key int; elem int }
       ByteSize: 128
       GoRuntimeType: 674784
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 182 StructureType noalg.struct { key int; elem int }
+      Element: 160 StructureType noalg.struct { key int; elem int }
     - __kind: ArrayType
-      ID: 233
+      ID: 218
       Name: noalg.[8]struct { key int; elem uint8 }
       ByteSize: 128
       GoRuntimeType: 677088
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 234 StructureType noalg.struct { key int; elem uint8 }
+      Element: 219 StructureType noalg.struct { key int; elem uint8 }
     - __kind: ArrayType
-      ID: 217
+      ID: 200
       Name: noalg.[8]struct { key string; elem []main.structWithMap }
       ByteSize: 320
       GoRuntimeType: 677184
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 218 StructureType noalg.struct { key string; elem []main.structWithMap }
+      Element: 201 StructureType noalg.struct { key string; elem []main.structWithMap }
     - __kind: ArrayType
-      ID: 202
+      ID: 183
       Name: noalg.[8]struct { key string; elem []string }
       ByteSize: 320
       GoRuntimeType: 677280
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 203 StructureType noalg.struct { key string; elem []string }
+      Element: 184 StructureType noalg.struct { key string; elem []string }
     - __kind: ArrayType
-      ID: 195
+      ID: 175
       Name: noalg.[8]struct { key string; elem int }
       ByteSize: 192
       GoRuntimeType: 677376
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 196 StructureType noalg.struct { key string; elem int }
+      Element: 176 StructureType noalg.struct { key string; elem int }
     - __kind: ArrayType
-      ID: 188
+      ID: 167
       Name: noalg.[8]struct { key string; elem main.nestedStruct }
       ByteSize: 320
       GoRuntimeType: 677472
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 189 StructureType noalg.struct { key string; elem main.nestedStruct }
+      Element: 168 StructureType noalg.struct { key string; elem main.nestedStruct }
     - __kind: ArrayType
-      ID: 247
+      ID: 234
       Name: noalg.[8]struct { key uint8; elem [4]int }
       ByteSize: 320
       GoRuntimeType: 677568
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 248 StructureType noalg.struct { key uint8; elem [4]int }
+      Element: 235 StructureType noalg.struct { key uint8; elem [4]int }
     - __kind: ArrayType
-      ID: 240
+      ID: 226
       Name: noalg.[8]struct { key uint8; elem uint8 }
       ByteSize: 16
       GoRuntimeType: 677664
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 241 StructureType noalg.struct { key uint8; elem uint8 }
+      Element: 227 StructureType noalg.struct { key uint8; elem uint8 }
     - __kind: StructureType
-      ID: 261
+      ID: 250
       Name: noalg.map.group[[4]int][4]int
       ByteSize: 520
       GoRuntimeType: 1.281056e+06
@@ -6797,9 +6797,9 @@ Types:
           Type: 8 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 262 ArrayType noalg.[8]struct { key [4]int; elem [4]int }
+          Type: 251 ArrayType noalg.[8]struct { key [4]int; elem [4]int }
     - __kind: StructureType
-      ID: 254
+      ID: 242
       Name: noalg.map.group[[4]int]uint8
       ByteSize: 328
       GoRuntimeType: 1.281312e+06
@@ -6810,9 +6810,9 @@ Types:
           Type: 8 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 255 ArrayType noalg.[8]struct { key [4]int; elem uint8 }
+          Type: 243 ArrayType noalg.[8]struct { key [4]int; elem uint8 }
     - __kind: StructureType
-      ID: 208
+      ID: 190
       Name: noalg.map.group[[4]string][2]int
       ByteSize: 648
       GoRuntimeType: 1.281568e+06
@@ -6823,9 +6823,9 @@ Types:
           Type: 8 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 209 ArrayType noalg.[8]struct { key [4]string; elem [2]int }
+          Type: 191 ArrayType noalg.[8]struct { key [4]string; elem [2]int }
     - __kind: StructureType
-      ID: 225
+      ID: 209
       Name: noalg.map.group[bool]main.node
       ByteSize: 200
       GoRuntimeType: 1.281824e+06
@@ -6836,9 +6836,9 @@ Types:
           Type: 8 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 226 ArrayType noalg.[8]struct { key bool; elem main.node }
+          Type: 210 ArrayType noalg.[8]struct { key bool; elem main.node }
     - __kind: StructureType
-      ID: 180
+      ID: 158
       Name: noalg.map.group[int]int
       ByteSize: 136
       GoRuntimeType: 1.280288e+06
@@ -6849,9 +6849,9 @@ Types:
           Type: 8 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 181 ArrayType noalg.[8]struct { key int; elem int }
+          Type: 159 ArrayType noalg.[8]struct { key int; elem int }
     - __kind: StructureType
-      ID: 232
+      ID: 217
       Name: noalg.map.group[int]uint8
       ByteSize: 136
       GoRuntimeType: 1.28208e+06
@@ -6862,9 +6862,9 @@ Types:
           Type: 8 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 233 ArrayType noalg.[8]struct { key int; elem uint8 }
+          Type: 218 ArrayType noalg.[8]struct { key int; elem uint8 }
     - __kind: StructureType
-      ID: 216
+      ID: 199
       Name: noalg.map.group[string][]main.structWithMap
       ByteSize: 328
       GoRuntimeType: 1.282336e+06
@@ -6875,9 +6875,9 @@ Types:
           Type: 8 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 217 ArrayType noalg.[8]struct { key string; elem []main.structWithMap }
+          Type: 200 ArrayType noalg.[8]struct { key string; elem []main.structWithMap }
     - __kind: StructureType
-      ID: 201
+      ID: 182
       Name: noalg.map.group[string][]string
       ByteSize: 328
       GoRuntimeType: 1.282592e+06
@@ -6888,9 +6888,9 @@ Types:
           Type: 8 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 202 ArrayType noalg.[8]struct { key string; elem []string }
+          Type: 183 ArrayType noalg.[8]struct { key string; elem []string }
     - __kind: StructureType
-      ID: 194
+      ID: 174
       Name: noalg.map.group[string]int
       ByteSize: 200
       GoRuntimeType: 1.282848e+06
@@ -6901,9 +6901,9 @@ Types:
           Type: 8 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 195 ArrayType noalg.[8]struct { key string; elem int }
+          Type: 175 ArrayType noalg.[8]struct { key string; elem int }
     - __kind: StructureType
-      ID: 187
+      ID: 166
       Name: noalg.map.group[string]main.nestedStruct
       ByteSize: 328
       GoRuntimeType: 1.283104e+06
@@ -6914,9 +6914,9 @@ Types:
           Type: 8 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 188 ArrayType noalg.[8]struct { key string; elem main.nestedStruct }
+          Type: 167 ArrayType noalg.[8]struct { key string; elem main.nestedStruct }
     - __kind: StructureType
-      ID: 246
+      ID: 233
       Name: noalg.map.group[uint8][4]int
       ByteSize: 328
       GoRuntimeType: 1.28336e+06
@@ -6927,9 +6927,9 @@ Types:
           Type: 8 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 247 ArrayType noalg.[8]struct { key uint8; elem [4]int }
+          Type: 234 ArrayType noalg.[8]struct { key uint8; elem [4]int }
     - __kind: StructureType
-      ID: 239
+      ID: 225
       Name: noalg.map.group[uint8]uint8
       ByteSize: 24
       GoRuntimeType: 1.283616e+06
@@ -6940,9 +6940,9 @@ Types:
           Type: 8 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 240 ArrayType noalg.[8]struct { key uint8; elem uint8 }
+          Type: 226 ArrayType noalg.[8]struct { key uint8; elem uint8 }
     - __kind: StructureType
-      ID: 263
+      ID: 252
       Name: noalg.struct { key [4]int; elem [4]int }
       ByteSize: 64
       GoRuntimeType: 1.280928e+06
@@ -6950,12 +6950,12 @@ Types:
       RawFields:
         - Name: key
           Offset: 0
-          Type: 249 ArrayType [4]int
+          Type: 236 ArrayType [4]int
         - Name: elem
           Offset: 32
-          Type: 249 ArrayType [4]int
+          Type: 236 ArrayType [4]int
     - __kind: StructureType
-      ID: 256
+      ID: 244
       Name: noalg.struct { key [4]int; elem uint8 }
       ByteSize: 40
       GoRuntimeType: 1.281184e+06
@@ -6963,12 +6963,12 @@ Types:
       RawFields:
         - Name: key
           Offset: 0
-          Type: 249 ArrayType [4]int
+          Type: 236 ArrayType [4]int
         - Name: elem
           Offset: 32
           Type: 3 BaseType uint8
     - __kind: StructureType
-      ID: 210
+      ID: 192
       Name: noalg.struct { key [4]string; elem [2]int }
       ByteSize: 80
       GoRuntimeType: 1.28144e+06
@@ -6976,12 +6976,12 @@ Types:
       RawFields:
         - Name: key
           Offset: 0
-          Type: 211 ArrayType [4]string
+          Type: 193 ArrayType [4]string
         - Name: elem
           Offset: 64
           Type: 40 ArrayType [2]int
     - __kind: StructureType
-      ID: 227
+      ID: 211
       Name: noalg.struct { key bool; elem main.node }
       ByteSize: 24
       GoRuntimeType: 1.281696e+06
@@ -6994,7 +6994,7 @@ Types:
           Offset: 8
           Type: 131 StructureType main.node
     - __kind: StructureType
-      ID: 182
+      ID: 160
       Name: noalg.struct { key int; elem int }
       ByteSize: 16
       GoRuntimeType: 1.28016e+06
@@ -7007,7 +7007,7 @@ Types:
           Offset: 8
           Type: 7 BaseType int
     - __kind: StructureType
-      ID: 234
+      ID: 219
       Name: noalg.struct { key int; elem uint8 }
       ByteSize: 16
       GoRuntimeType: 1.281952e+06
@@ -7020,7 +7020,7 @@ Types:
           Offset: 8
           Type: 3 BaseType uint8
     - __kind: StructureType
-      ID: 218
+      ID: 201
       Name: noalg.struct { key string; elem []main.structWithMap }
       ByteSize: 40
       GoRuntimeType: 1.282208e+06
@@ -7031,9 +7031,9 @@ Types:
           Type: 9 GoStringHeaderType string
         - Name: elem
           Offset: 16
-          Type: 219 GoSliceHeaderType []main.structWithMap
+          Type: 202 GoSliceHeaderType []main.structWithMap
     - __kind: StructureType
-      ID: 203
+      ID: 184
       Name: noalg.struct { key string; elem []string }
       ByteSize: 40
       GoRuntimeType: 1.282464e+06
@@ -7046,7 +7046,7 @@ Types:
           Offset: 16
           Type: 141 GoSliceHeaderType []string
     - __kind: StructureType
-      ID: 196
+      ID: 176
       Name: noalg.struct { key string; elem int }
       ByteSize: 24
       GoRuntimeType: 1.28272e+06
@@ -7059,7 +7059,7 @@ Types:
           Offset: 16
           Type: 7 BaseType int
     - __kind: StructureType
-      ID: 189
+      ID: 168
       Name: noalg.struct { key string; elem main.nestedStruct }
       ByteSize: 40
       GoRuntimeType: 1.282976e+06
@@ -7072,7 +7072,7 @@ Types:
           Offset: 16
           Type: 149 StructureType main.nestedStruct
     - __kind: StructureType
-      ID: 248
+      ID: 235
       Name: noalg.struct { key uint8; elem [4]int }
       ByteSize: 40
       GoRuntimeType: 1.283232e+06
@@ -7083,9 +7083,9 @@ Types:
           Type: 3 BaseType uint8
         - Name: elem
           Offset: 8
-          Type: 249 ArrayType [4]int
+          Type: 236 ArrayType [4]int
     - __kind: StructureType
-      ID: 241
+      ID: 227
       Name: noalg.struct { key uint8; elem uint8 }
       ByteSize: 2
       GoRuntimeType: 1.283488e+06
@@ -7106,17 +7106,17 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 175 PointerType *string.str
+          Type: 152 PointerType *string.str
         - Name: len
           Offset: 8
           Type: 7 BaseType int
-      Data: 174 GoStringDataType string.str
+      Data: 151 GoStringDataType string.str
     - __kind: GoStringDataType
-      ID: 174
+      ID: 151
       Name: string.str
       ByteSize: 2048
     - __kind: StructureType
-      ID: 151
+      ID: 267
       Name: sync.Mutex
       ByteSize: 8
       GoRuntimeType: 1.449216e+06
@@ -7124,12 +7124,12 @@ Types:
       RawFields:
         - Name: _
           Offset: 0
-          Type: 152 StructureType sync.noCopy
+          Type: 268 StructureType sync.noCopy
         - Name: mu
           Offset: 0
-          Type: 153 StructureType internal/sync.Mutex
+          Type: 269 StructureType internal/sync.Mutex
     - __kind: StructureType
-      ID: 154
+      ID: 270
       Name: sync.Once
       ByteSize: 12
       GoRuntimeType: 1.598272e+06
@@ -7137,15 +7137,15 @@ Types:
       RawFields:
         - Name: _
           Offset: 0
-          Type: 152 StructureType sync.noCopy
+          Type: 268 StructureType sync.noCopy
         - Name: done
           Offset: 0
-          Type: 155 StructureType sync/atomic.Bool
+          Type: 271 StructureType sync/atomic.Bool
         - Name: m
           Offset: 4
-          Type: 151 StructureType sync.Mutex
+          Type: 267 StructureType sync.Mutex
     - __kind: StructureType
-      ID: 157
+      ID: 273
       Name: sync.WaitGroup
       ByteSize: 16
       GoRuntimeType: 1.59808e+06
@@ -7153,21 +7153,21 @@ Types:
       RawFields:
         - Name: noCopy
           Offset: 0
-          Type: 152 StructureType sync.noCopy
+          Type: 268 StructureType sync.noCopy
         - Name: state
           Offset: 0
-          Type: 158 StructureType sync/atomic.Uint64
+          Type: 274 StructureType sync/atomic.Uint64
         - Name: sema
           Offset: 8
           Type: 2 BaseType uint32
     - __kind: StructureType
-      ID: 152
+      ID: 268
       Name: sync.noCopy
       GoRuntimeType: 981440
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 155
+      ID: 271
       Name: sync/atomic.Bool
       ByteSize: 4
       GoRuntimeType: 1.450336e+06
@@ -7175,12 +7175,12 @@ Types:
       RawFields:
         - Name: _
           Offset: 0
-          Type: 156 StructureType sync/atomic.noCopy
+          Type: 272 StructureType sync/atomic.noCopy
         - Name: v
           Offset: 0
           Type: 2 BaseType uint32
     - __kind: StructureType
-      ID: 160
+      ID: 276
       Name: sync/atomic.Int32
       ByteSize: 4
       GoRuntimeType: 1.450496e+06
@@ -7188,12 +7188,12 @@ Types:
       RawFields:
         - Name: _
           Offset: 0
-          Type: 156 StructureType sync/atomic.noCopy
+          Type: 272 StructureType sync/atomic.noCopy
         - Name: v
           Offset: 0
           Type: 12 BaseType int32
     - __kind: StructureType
-      ID: 158
+      ID: 274
       Name: sync/atomic.Uint64
       ByteSize: 8
       GoRuntimeType: 1.598656e+06
@@ -7201,27 +7201,27 @@ Types:
       RawFields:
         - Name: _
           Offset: 0
-          Type: 156 StructureType sync/atomic.noCopy
+          Type: 272 StructureType sync/atomic.noCopy
         - Name: _
           Offset: 0
-          Type: 159 StructureType sync/atomic.align64
+          Type: 275 StructureType sync/atomic.align64
         - Name: v
           Offset: 0
           Type: 8 BaseType uint64
     - __kind: StructureType
-      ID: 159
+      ID: 275
       Name: sync/atomic.align64
       GoRuntimeType: 981632
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 156
+      ID: 272
       Name: sync/atomic.noCopy
       GoRuntimeType: 981536
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 172
+      ID: 247
       Name: table<[4]int,[4]int>
       ByteSize: 32
       GoKind: 25
@@ -7243,9 +7243,9 @@ Types:
           Type: 7 BaseType int
         - Name: groups
           Offset: 16
-          Type: 259 GoSwissMapGroupsType groupReference<[4]int,[4]int>
+          Type: 248 GoSwissMapGroupsType groupReference<[4]int,[4]int>
     - __kind: StructureType
-      ID: 171
+      ID: 239
       Name: table<[4]int,uint8>
       ByteSize: 32
       GoKind: 25
@@ -7267,9 +7267,9 @@ Types:
           Type: 7 BaseType int
         - Name: groups
           Offset: 16
-          Type: 252 GoSwissMapGroupsType groupReference<[4]int,uint8>
+          Type: 240 GoSwissMapGroupsType groupReference<[4]int,uint8>
     - __kind: StructureType
-      ID: 165
+      ID: 187
       Name: table<[4]string,[2]int>
       ByteSize: 32
       GoKind: 25
@@ -7291,9 +7291,9 @@ Types:
           Type: 7 BaseType int
         - Name: groups
           Offset: 16
-          Type: 206 GoSwissMapGroupsType groupReference<[4]string,[2]int>
+          Type: 188 GoSwissMapGroupsType groupReference<[4]string,[2]int>
     - __kind: StructureType
-      ID: 167
+      ID: 206
       Name: table<bool,main.node>
       ByteSize: 32
       GoKind: 25
@@ -7315,9 +7315,9 @@ Types:
           Type: 7 BaseType int
         - Name: groups
           Offset: 16
-          Type: 223 GoSwissMapGroupsType groupReference<bool,main.node>
+          Type: 207 GoSwissMapGroupsType groupReference<bool,main.node>
     - __kind: StructureType
-      ID: 161
+      ID: 155
       Name: table<int,int>
       ByteSize: 32
       GoKind: 25
@@ -7339,9 +7339,9 @@ Types:
           Type: 7 BaseType int
         - Name: groups
           Offset: 16
-          Type: 178 GoSwissMapGroupsType groupReference<int,int>
+          Type: 156 GoSwissMapGroupsType groupReference<int,int>
     - __kind: StructureType
-      ID: 168
+      ID: 214
       Name: table<int,uint8>
       ByteSize: 32
       GoKind: 25
@@ -7363,9 +7363,9 @@ Types:
           Type: 7 BaseType int
         - Name: groups
           Offset: 16
-          Type: 230 GoSwissMapGroupsType groupReference<int,uint8>
+          Type: 215 GoSwissMapGroupsType groupReference<int,uint8>
     - __kind: StructureType
-      ID: 166
+      ID: 196
       Name: table<string,[]main.structWithMap>
       ByteSize: 32
       GoKind: 25
@@ -7387,9 +7387,9 @@ Types:
           Type: 7 BaseType int
         - Name: groups
           Offset: 16
-          Type: 214 GoSwissMapGroupsType groupReference<string,[]main.structWithMap>
+          Type: 197 GoSwissMapGroupsType groupReference<string,[]main.structWithMap>
     - __kind: StructureType
-      ID: 164
+      ID: 179
       Name: table<string,[]string>
       ByteSize: 32
       GoKind: 25
@@ -7411,9 +7411,9 @@ Types:
           Type: 7 BaseType int
         - Name: groups
           Offset: 16
-          Type: 199 GoSwissMapGroupsType groupReference<string,[]string>
+          Type: 180 GoSwissMapGroupsType groupReference<string,[]string>
     - __kind: StructureType
-      ID: 163
+      ID: 171
       Name: table<string,int>
       ByteSize: 32
       GoKind: 25
@@ -7435,9 +7435,9 @@ Types:
           Type: 7 BaseType int
         - Name: groups
           Offset: 16
-          Type: 192 GoSwissMapGroupsType groupReference<string,int>
+          Type: 172 GoSwissMapGroupsType groupReference<string,int>
     - __kind: StructureType
-      ID: 162
+      ID: 163
       Name: table<string,main.nestedStruct>
       ByteSize: 32
       GoKind: 25
@@ -7459,9 +7459,9 @@ Types:
           Type: 7 BaseType int
         - Name: groups
           Offset: 16
-          Type: 185 GoSwissMapGroupsType groupReference<string,main.nestedStruct>
+          Type: 164 GoSwissMapGroupsType groupReference<string,main.nestedStruct>
     - __kind: StructureType
-      ID: 170
+      ID: 230
       Name: table<uint8,[4]int>
       ByteSize: 32
       GoKind: 25
@@ -7483,9 +7483,9 @@ Types:
           Type: 7 BaseType int
         - Name: groups
           Offset: 16
-          Type: 244 GoSwissMapGroupsType groupReference<uint8,[4]int>
+          Type: 231 GoSwissMapGroupsType groupReference<uint8,[4]int>
     - __kind: StructureType
-      ID: 169
+      ID: 222
       Name: table<uint8,uint8>
       ByteSize: 32
       GoKind: 25
@@ -7507,7 +7507,7 @@ Types:
           Type: 7 BaseType int
         - Name: groups
           Offset: 16
-          Type: 237 GoSwissMapGroupsType groupReference<uint8,uint8>
+          Type: 223 GoSwissMapGroupsType groupReference<uint8,uint8>
     - __kind: BaseType
       ID: 10
       Name: uint

--- a/pkg/dyninst/irgen/testdata/snapshot/sample.arch=arm64,toolchain=go1.25.0.yaml
+++ b/pkg/dyninst/irgen/testdata/snapshot/sample.arch=arm64,toolchain=go1.25.0.yaml
@@ -8,7 +8,7 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 94}
+      subprogram: {subprogram: 88}
       events:
         - ID: 88
           Type: 369 EventRootType Probe[main.stackC]
@@ -22,7 +22,7 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 51}
+      subprogram: {subprogram: 45}
       events:
         - ID: 45
           Type: 326 EventRootType Probe[main.testAny]
@@ -36,7 +36,7 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 21}
+      subprogram: {subprogram: 15}
       events:
         - ID: 15
           Type: 296 EventRootType Probe[main.testArrayOfArrays]
@@ -50,7 +50,7 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 23}
+      subprogram: {subprogram: 17}
       events:
         - ID: 17
           Type: 298 EventRootType Probe[main.testArrayOfArraysOfArrays]
@@ -64,7 +64,7 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 59}
+      subprogram: {subprogram: 53}
       events:
         - ID: 53
           Type: 334 EventRootType Probe[main.testArrayOfMaps]
@@ -78,7 +78,7 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 22}
+      subprogram: {subprogram: 16}
       events:
         - ID: 16
           Type: 297 EventRootType Probe[main.testArrayOfStrings]
@@ -92,7 +92,7 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 41}
+      subprogram: {subprogram: 35}
       events:
         - ID: 35
           Type: 316 EventRootType Probe[main.testBigStruct]
@@ -106,7 +106,7 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 10}
+      subprogram: {subprogram: 4}
       events:
         - ID: 4
           Type: 285 EventRootType Probe[main.testBoolArray]
@@ -120,7 +120,7 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 7}
+      subprogram: {subprogram: 1}
       events:
         - ID: 1
           Type: 282 EventRootType Probe[main.testByteArray]
@@ -134,7 +134,7 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 75}
+      subprogram: {subprogram: 69}
       events:
         - ID: 69
           Type: 350 EventRootType Probe[main.testChannel]
@@ -148,7 +148,7 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 73}
+      subprogram: {subprogram: 67}
       events:
         - ID: 67
           Type: 348 EventRootType Probe[main.testCombinedByte]
@@ -162,7 +162,7 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 83}
+      subprogram: {subprogram: 77}
       events:
         - ID: 77
           Type: 358 EventRootType Probe[main.testCycle]
@@ -176,7 +176,7 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 85}
+      subprogram: {subprogram: 79}
       events:
         - ID: 79
           Type: 360 EventRootType Probe[main.testEmptySlice]
@@ -190,7 +190,7 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 88}
+      subprogram: {subprogram: 82}
       events:
         - ID: 82
           Type: 363 EventRootType Probe[main.testEmptySliceOfStructs]
@@ -204,7 +204,7 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 102}
+      subprogram: {subprogram: 96}
       events:
         - ID: 96
           Type: 377 EventRootType Probe[main.testEmptyString]
@@ -218,7 +218,7 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 104}
+      subprogram: {subprogram: 98}
       events:
         - ID: 98
           Type: 379 EventRootType Probe[main.testEmptyStruct]
@@ -232,7 +232,7 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 52}
+      subprogram: {subprogram: 46}
       events:
         - ID: 46
           Type: 327 EventRootType Probe[main.testError]
@@ -246,7 +246,7 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 43}
+      subprogram: {subprogram: 37}
       events:
         - ID: 37
           Type: 318 EventRootType Probe[main.testEsotericHeap]
@@ -260,7 +260,7 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 42}
+      subprogram: {subprogram: 36}
       events:
         - ID: 36
           Type: 317 EventRootType Probe[main.testEsotericStack]
@@ -274,7 +274,7 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 48}
+      subprogram: {subprogram: 42}
       events:
         - ID: 42
           Type: 323 EventRootType Probe[main.testFrameless]
@@ -288,7 +288,7 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 49}
+      subprogram: {subprogram: 43}
       events:
         - ID: 43
           Type: 324 EventRootType Probe[main.testFramelessArray]
@@ -302,7 +302,7 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 44}
+      subprogram: {subprogram: 38}
       events:
         - ID: 38
           Type: 319 EventRootType Probe[main.testInlinedBA]
@@ -316,7 +316,7 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 45}
+      subprogram: {subprogram: 39}
       events:
         - ID: 39
           Type: 320 EventRootType Probe[main.testInlinedBB]
@@ -330,7 +330,7 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 46}
+      subprogram: {subprogram: 40}
       events:
         - ID: 40
           Type: 321 EventRootType Probe[main.testInlinedBBA]
@@ -344,7 +344,7 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 2}
+      subprogram: {subprogram: 100}
       events:
         - ID: 100
           Type: 381 EventRootType Probe[main.testInlinedBBB]
@@ -358,7 +358,7 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 47}
+      subprogram: {subprogram: 41}
       events:
         - ID: 41
           Type: 322 EventRootType Probe[main.testInlinedBC]
@@ -372,7 +372,7 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 3}
+      subprogram: {subprogram: 101}
       events:
         - ID: 101
           Type: 382 EventRootType Probe[main.testInlinedBCA]
@@ -386,7 +386,7 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 4}
+      subprogram: {subprogram: 102}
       events:
         - ID: 102
           Type: 383 EventRootType Probe[main.testInlinedBCB]
@@ -401,7 +401,7 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 1}
+      subprogram: {subprogram: 99}
       events:
         - ID: 99
           Type: 380 EventRootType Probe[main.testInlinedPrint]
@@ -425,7 +425,7 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 5}
+      subprogram: {subprogram: 103}
       events:
         - ID: 103
           Type: 384 EventRootType Probe[main.testInlinedSq]
@@ -440,7 +440,7 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 6}
+      subprogram: {subprogram: 104}
       events:
         - ID: 104
           Type: 385 EventRootType Probe[main.testInlinedSumArray]
@@ -458,7 +458,7 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 13}
+      subprogram: {subprogram: 7}
       events:
         - ID: 7
           Type: 288 EventRootType Probe[main.testInt16Array]
@@ -472,7 +472,7 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 14}
+      subprogram: {subprogram: 8}
       events:
         - ID: 8
           Type: 289 EventRootType Probe[main.testInt32Array]
@@ -486,7 +486,7 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 15}
+      subprogram: {subprogram: 9}
       events:
         - ID: 9
           Type: 290 EventRootType Probe[main.testInt64Array]
@@ -500,7 +500,7 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 12}
+      subprogram: {subprogram: 6}
       events:
         - ID: 6
           Type: 287 EventRootType Probe[main.testInt8Array]
@@ -514,7 +514,7 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 11}
+      subprogram: {subprogram: 5}
       events:
         - ID: 5
           Type: 286 EventRootType Probe[main.testIntArray]
@@ -528,7 +528,7 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 50}
+      subprogram: {subprogram: 44}
       events:
         - ID: 44
           Type: 325 EventRootType Probe[main.testInterface]
@@ -542,7 +542,7 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 77}
+      subprogram: {subprogram: 71}
       events:
         - ID: 71
           Type: 352 EventRootType Probe[main.testLinkedList]
@@ -556,7 +556,7 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 57}
+      subprogram: {subprogram: 51}
       events:
         - ID: 51
           Type: 332 EventRootType Probe[main.testMapArrayToArray]
@@ -570,7 +570,7 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 63}
+      subprogram: {subprogram: 57}
       events:
         - ID: 57
           Type: 338 EventRootType Probe[main.testMapEmbeddedMaps]
@@ -584,7 +584,7 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 61}
+      subprogram: {subprogram: 55}
       events:
         - ID: 55
           Type: 336 EventRootType Probe[main.testMapIntToInt]
@@ -598,7 +598,7 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 72}
+      subprogram: {subprogram: 66}
       events:
         - ID: 66
           Type: 347 EventRootType Probe[main.testMapLargeKeyLargeValue]
@@ -612,7 +612,7 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 71}
+      subprogram: {subprogram: 65}
       events:
         - ID: 65
           Type: 346 EventRootType Probe[main.testMapLargeKeySmallValue]
@@ -626,7 +626,7 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 62}
+      subprogram: {subprogram: 56}
       events:
         - ID: 56
           Type: 337 EventRootType Probe[main.testMapMassive]
@@ -640,7 +640,7 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 70}
+      subprogram: {subprogram: 64}
       events:
         - ID: 64
           Type: 345 EventRootType Probe[main.testMapSmallKeyLargeValue]
@@ -654,7 +654,7 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 69}
+      subprogram: {subprogram: 63}
       events:
         - ID: 63
           Type: 344 EventRootType Probe[main.testMapSmallKeySmallValue]
@@ -668,7 +668,7 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 55}
+      subprogram: {subprogram: 49}
       events:
         - ID: 49
           Type: 330 EventRootType Probe[main.testMapStringToInt]
@@ -682,7 +682,7 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 56}
+      subprogram: {subprogram: 50}
       events:
         - ID: 50
           Type: 331 EventRootType Probe[main.testMapStringToSlice]
@@ -696,7 +696,7 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 54}
+      subprogram: {subprogram: 48}
       events:
         - ID: 48
           Type: 329 EventRootType Probe[main.testMapStringToStruct]
@@ -710,7 +710,7 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 64}
+      subprogram: {subprogram: 58}
       events:
         - ID: 58
           Type: 339 EventRootType Probe[main.testMapWithLinkedList]
@@ -724,7 +724,7 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 67}
+      subprogram: {subprogram: 61}
       events:
         - ID: 61
           Type: 342 EventRootType Probe[main.testMapWithSmallKeyAndValue]
@@ -738,7 +738,7 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 68}
+      subprogram: {subprogram: 62}
       events:
         - ID: 62
           Type: 343 EventRootType Probe[main.testMapWithSmallKeyAndValueMassive]
@@ -752,7 +752,7 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 65}
+      subprogram: {subprogram: 59}
       events:
         - ID: 59
           Type: 340 EventRootType Probe[main.testMapWithSmallValue]
@@ -766,7 +766,7 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 66}
+      subprogram: {subprogram: 60}
       events:
         - ID: 60
           Type: 341 EventRootType Probe[main.testMapWithSmallValueMassive]
@@ -780,7 +780,7 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 100}
+      subprogram: {subprogram: 94}
       events:
         - ID: 94
           Type: 375 EventRootType Probe[main.testMassiveString]
@@ -794,7 +794,7 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 74}
+      subprogram: {subprogram: 68}
       events:
         - ID: 68
           Type: 349 EventRootType Probe[main.testMultipleSimpleParams]
@@ -808,7 +808,7 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 82}
+      subprogram: {subprogram: 76}
       events:
         - ID: 76
           Type: 357 EventRootType Probe[main.testNilPointer]
@@ -822,7 +822,7 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 92}
+      subprogram: {subprogram: 86}
       events:
         - ID: 86
           Type: 367 EventRootType Probe[main.testNilSlice]
@@ -836,7 +836,7 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 89}
+      subprogram: {subprogram: 83}
       events:
         - ID: 83
           Type: 364 EventRootType Probe[main.testNilSliceOfStructs]
@@ -850,7 +850,7 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 91}
+      subprogram: {subprogram: 85}
       events:
         - ID: 85
           Type: 366 EventRootType Probe[main.testNilSliceWithOtherParams]
@@ -864,7 +864,7 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 99}
+      subprogram: {subprogram: 93}
       events:
         - ID: 93
           Type: 374 EventRootType Probe[main.testOneStringInStructPointer]
@@ -878,7 +878,7 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 78}
+      subprogram: {subprogram: 72}
       events:
         - ID: 72
           Type: 353 EventRootType Probe[main.testPointerLoop]
@@ -892,7 +892,7 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 60}
+      subprogram: {subprogram: 54}
       events:
         - ID: 54
           Type: 335 EventRootType Probe[main.testPointerToMap]
@@ -906,7 +906,7 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 76}
+      subprogram: {subprogram: 70}
       events:
         - ID: 70
           Type: 351 EventRootType Probe[main.testPointerToSimpleStruct]
@@ -920,7 +920,7 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 8}
+      subprogram: {subprogram: 2}
       events:
         - ID: 2
           Type: 283 EventRootType Probe[main.testRuneArray]
@@ -934,7 +934,7 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 27}
+      subprogram: {subprogram: 21}
       events:
         - ID: 21
           Type: 302 EventRootType Probe[main.testSingleBool]
@@ -948,7 +948,7 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 25}
+      subprogram: {subprogram: 19}
       events:
         - ID: 19
           Type: 300 EventRootType Probe[main.testSingleByte]
@@ -962,7 +962,7 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 38}
+      subprogram: {subprogram: 32}
       events:
         - ID: 32
           Type: 313 EventRootType Probe[main.testSingleFloat32]
@@ -976,7 +976,7 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 39}
+      subprogram: {subprogram: 33}
       events:
         - ID: 33
           Type: 314 EventRootType Probe[main.testSingleFloat64]
@@ -990,7 +990,7 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 28}
+      subprogram: {subprogram: 22}
       events:
         - ID: 22
           Type: 303 EventRootType Probe[main.testSingleInt]
@@ -1004,7 +1004,7 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 30}
+      subprogram: {subprogram: 24}
       events:
         - ID: 24
           Type: 305 EventRootType Probe[main.testSingleInt16]
@@ -1018,7 +1018,7 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 31}
+      subprogram: {subprogram: 25}
       events:
         - ID: 25
           Type: 306 EventRootType Probe[main.testSingleInt32]
@@ -1032,7 +1032,7 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 32}
+      subprogram: {subprogram: 26}
       events:
         - ID: 26
           Type: 307 EventRootType Probe[main.testSingleInt64]
@@ -1046,7 +1046,7 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 29}
+      subprogram: {subprogram: 23}
       events:
         - ID: 23
           Type: 304 EventRootType Probe[main.testSingleInt8]
@@ -1060,7 +1060,7 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 26}
+      subprogram: {subprogram: 20}
       events:
         - ID: 20
           Type: 301 EventRootType Probe[main.testSingleRune]
@@ -1074,7 +1074,7 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 95}
+      subprogram: {subprogram: 89}
       events:
         - ID: 89
           Type: 370 EventRootType Probe[main.testSingleString]
@@ -1088,7 +1088,7 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 33}
+      subprogram: {subprogram: 27}
       events:
         - ID: 27
           Type: 308 EventRootType Probe[main.testSingleUint]
@@ -1102,7 +1102,7 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 35}
+      subprogram: {subprogram: 29}
       events:
         - ID: 29
           Type: 310 EventRootType Probe[main.testSingleUint16]
@@ -1116,7 +1116,7 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 36}
+      subprogram: {subprogram: 30}
       events:
         - ID: 30
           Type: 311 EventRootType Probe[main.testSingleUint32]
@@ -1130,7 +1130,7 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 37}
+      subprogram: {subprogram: 31}
       events:
         - ID: 31
           Type: 312 EventRootType Probe[main.testSingleUint64]
@@ -1144,7 +1144,7 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 34}
+      subprogram: {subprogram: 28}
       events:
         - ID: 28
           Type: 309 EventRootType Probe[main.testSingleUint8]
@@ -1158,7 +1158,7 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 86}
+      subprogram: {subprogram: 80}
       events:
         - ID: 80
           Type: 361 EventRootType Probe[main.testSliceOfSlices]
@@ -1172,7 +1172,7 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 58}
+      subprogram: {subprogram: 52}
       events:
         - ID: 52
           Type: 333 EventRootType Probe[main.testSmallMap]
@@ -1186,7 +1186,7 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 9}
+      subprogram: {subprogram: 3}
       events:
         - ID: 3
           Type: 284 EventRootType Probe[main.testStringArray]
@@ -1200,7 +1200,7 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 81}
+      subprogram: {subprogram: 75}
       events:
         - ID: 75
           Type: 356 EventRootType Probe[main.testStringPointer]
@@ -1214,7 +1214,7 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 90}
+      subprogram: {subprogram: 84}
       events:
         - ID: 84
           Type: 365 EventRootType Probe[main.testStringSlice]
@@ -1228,7 +1228,7 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 103}
+      subprogram: {subprogram: 97}
       events:
         - ID: 97
           Type: 378 EventRootType Probe[main.testStruct]
@@ -1242,7 +1242,7 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 87}
+      subprogram: {subprogram: 81}
       events:
         - ID: 81
           Type: 362 EventRootType Probe[main.testStructSlice]
@@ -1256,7 +1256,7 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 53}
+      subprogram: {subprogram: 47}
       events:
         - ID: 47
           Type: 328 EventRootType Probe[main.testStructWithMap]
@@ -1270,7 +1270,7 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 96}
+      subprogram: {subprogram: 90}
       events:
         - ID: 90
           Type: 371 EventRootType Probe[main.testThreeStrings]
@@ -1284,7 +1284,7 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 97}
+      subprogram: {subprogram: 91}
       events:
         - ID: 91
           Type: 372 EventRootType Probe[main.testThreeStringsInStruct]
@@ -1298,7 +1298,7 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 98}
+      subprogram: {subprogram: 92}
       events:
         - ID: 92
           Type: 373 EventRootType Probe[main.testThreeStringsInStructPointer]
@@ -1312,7 +1312,7 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 40}
+      subprogram: {subprogram: 34}
       events:
         - ID: 34
           Type: 315 EventRootType Probe[main.testTypeAlias]
@@ -1326,7 +1326,7 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 18}
+      subprogram: {subprogram: 12}
       events:
         - ID: 12
           Type: 293 EventRootType Probe[main.testUint16Array]
@@ -1340,7 +1340,7 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 19}
+      subprogram: {subprogram: 13}
       events:
         - ID: 13
           Type: 294 EventRootType Probe[main.testUint32Array]
@@ -1354,7 +1354,7 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 20}
+      subprogram: {subprogram: 14}
       events:
         - ID: 14
           Type: 295 EventRootType Probe[main.testUint64Array]
@@ -1368,7 +1368,7 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 17}
+      subprogram: {subprogram: 11}
       events:
         - ID: 11
           Type: 292 EventRootType Probe[main.testUint8Array]
@@ -1382,7 +1382,7 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 16}
+      subprogram: {subprogram: 10}
       events:
         - ID: 10
           Type: 291 EventRootType Probe[main.testUintArray]
@@ -1396,7 +1396,7 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 80}
+      subprogram: {subprogram: 74}
       events:
         - ID: 74
           Type: 355 EventRootType Probe[main.testUintPointer]
@@ -1410,7 +1410,7 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 84}
+      subprogram: {subprogram: 78}
       events:
         - ID: 78
           Type: 359 EventRootType Probe[main.testUintSlice]
@@ -1424,7 +1424,7 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 101}
+      subprogram: {subprogram: 95}
       events:
         - ID: 95
           Type: 376 EventRootType Probe[main.testUnitializedString]
@@ -1438,7 +1438,7 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 79}
+      subprogram: {subprogram: 73}
       events:
         - ID: 73
           Type: 354 EventRootType Probe[main.testUnsafePointer]
@@ -1452,7 +1452,7 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 24}
+      subprogram: {subprogram: 18}
       events:
         - ID: 18
           Type: 299 EventRootType Probe[main.testVeryLargeArray]
@@ -1466,428 +1466,428 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 93}
+      subprogram: {subprogram: 87}
       events:
         - ID: 87
           Type: 368 EventRootType Probe[main.testVeryLargeSlice]
           InjectionPoints: [{PC: "0x8091d0", Frameless: true}]
           Condition: null
 Subprograms:
-    - ID: 7
+    - ID: 1
       Name: main.testByteArray
       OutOfLinePCRanges: [0x805e80..0x805e90]
       InlinePCRanges: []
       Variables:
         - Name: x
-          Type: 3 ArrayType [2]uint8
+          Type: 36 ArrayType [2]uint8
           Locations:
             - Range: 0x805e80..0x805e90
               Pieces: [{Size: 2, Op: {CfaOffset: 8}}]
           IsParameter: true
           IsReturn: false
-    - ID: 8
+    - ID: 2
       Name: main.testRuneArray
       OutOfLinePCRanges: [0x805e90..0x805ea0]
       InlinePCRanges: []
       Variables:
         - Name: x
-          Type: 5 ArrayType [2]int32
+          Type: 37 ArrayType [2]int32
           Locations:
             - Range: 0x805e90..0x805ea0
               Pieces: [{Size: 8, Op: {CfaOffset: 8}}]
           IsParameter: true
           IsReturn: false
-    - ID: 9
+    - ID: 3
       Name: main.testStringArray
       OutOfLinePCRanges: [0x805ea0..0x805eb0]
       InlinePCRanges: []
       Variables:
         - Name: x
-          Type: 7 ArrayType [2]string
+          Type: 38 ArrayType [2]string
           Locations:
             - Range: 0x805ea0..0x805eb0
               Pieces: [{Size: 32, Op: {CfaOffset: 8}}]
           IsParameter: true
           IsReturn: false
-    - ID: 10
+    - ID: 4
       Name: main.testBoolArray
       OutOfLinePCRanges: [0x805eb0..0x805ec0]
       InlinePCRanges: []
       Variables:
         - Name: x
-          Type: 10 ArrayType [2]bool
+          Type: 39 ArrayType [2]bool
           Locations:
             - Range: 0x805eb0..0x805ec0
               Pieces: [{Size: 2, Op: {CfaOffset: 8}}]
           IsParameter: true
           IsReturn: false
-    - ID: 11
+    - ID: 5
       Name: main.testIntArray
       OutOfLinePCRanges: [0x805ec0..0x805ed0]
       InlinePCRanges: []
       Variables:
         - Name: x
-          Type: 12 ArrayType [2]int
+          Type: 40 ArrayType [2]int
           Locations:
             - Range: 0x805ec0..0x805ed0
               Pieces: [{Size: 16, Op: {CfaOffset: 8}}]
           IsParameter: true
           IsReturn: false
-    - ID: 12
+    - ID: 6
       Name: main.testInt8Array
       OutOfLinePCRanges: [0x805ed0..0x805ee0]
       InlinePCRanges: []
       Variables:
         - Name: x
-          Type: 13 ArrayType [2]int8
+          Type: 41 ArrayType [2]int8
           Locations:
             - Range: 0x805ed0..0x805ee0
               Pieces: [{Size: 2, Op: {CfaOffset: 8}}]
           IsParameter: true
           IsReturn: false
-    - ID: 13
+    - ID: 7
       Name: main.testInt16Array
       OutOfLinePCRanges: [0x805ee0..0x805ef0]
       InlinePCRanges: []
       Variables:
         - Name: x
-          Type: 15 ArrayType [2]int16
+          Type: 42 ArrayType [2]int16
           Locations:
             - Range: 0x805ee0..0x805ef0
               Pieces: [{Size: 4, Op: {CfaOffset: 8}}]
           IsParameter: true
           IsReturn: false
-    - ID: 14
+    - ID: 8
       Name: main.testInt32Array
       OutOfLinePCRanges: [0x805ef0..0x805f00]
       InlinePCRanges: []
       Variables:
         - Name: x
-          Type: 5 ArrayType [2]int32
+          Type: 37 ArrayType [2]int32
           Locations:
             - Range: 0x805ef0..0x805f00
               Pieces: [{Size: 8, Op: {CfaOffset: 8}}]
           IsParameter: true
           IsReturn: false
-    - ID: 15
+    - ID: 9
       Name: main.testInt64Array
       OutOfLinePCRanges: [0x805f00..0x805f10]
       InlinePCRanges: []
       Variables:
         - Name: x
-          Type: 17 ArrayType [2]int64
+          Type: 43 ArrayType [2]int64
           Locations:
             - Range: 0x805f00..0x805f10
               Pieces: [{Size: 16, Op: {CfaOffset: 8}}]
           IsParameter: true
           IsReturn: false
-    - ID: 16
+    - ID: 10
       Name: main.testUintArray
       OutOfLinePCRanges: [0x805f10..0x805f20]
       InlinePCRanges: []
       Variables:
         - Name: x
-          Type: 19 ArrayType [2]uint
+          Type: 44 ArrayType [2]uint
           Locations:
             - Range: 0x805f10..0x805f20
               Pieces: [{Size: 16, Op: {CfaOffset: 8}}]
           IsParameter: true
           IsReturn: false
-    - ID: 17
+    - ID: 11
       Name: main.testUint8Array
       OutOfLinePCRanges: [0x805f20..0x805f30]
       InlinePCRanges: []
       Variables:
         - Name: x
-          Type: 3 ArrayType [2]uint8
+          Type: 36 ArrayType [2]uint8
           Locations:
             - Range: 0x805f20..0x805f30
               Pieces: [{Size: 2, Op: {CfaOffset: 8}}]
           IsParameter: true
           IsReturn: false
-    - ID: 18
+    - ID: 12
       Name: main.testUint16Array
       OutOfLinePCRanges: [0x805f30..0x805f40]
       InlinePCRanges: []
       Variables:
         - Name: x
-          Type: 21 ArrayType [2]uint16
+          Type: 45 ArrayType [2]uint16
           Locations:
             - Range: 0x805f30..0x805f40
               Pieces: [{Size: 4, Op: {CfaOffset: 8}}]
           IsParameter: true
           IsReturn: false
-    - ID: 19
+    - ID: 13
       Name: main.testUint32Array
       OutOfLinePCRanges: [0x805f40..0x805f50]
       InlinePCRanges: []
       Variables:
         - Name: x
-          Type: 23 ArrayType [2]uint32
+          Type: 46 ArrayType [2]uint32
           Locations:
             - Range: 0x805f40..0x805f50
               Pieces: [{Size: 8, Op: {CfaOffset: 8}}]
           IsParameter: true
           IsReturn: false
-    - ID: 20
+    - ID: 14
       Name: main.testUint64Array
       OutOfLinePCRanges: [0x805f50..0x805f60]
       InlinePCRanges: []
       Variables:
         - Name: x
-          Type: 25 ArrayType [2]uint64
+          Type: 47 ArrayType [2]uint64
           Locations:
             - Range: 0x805f50..0x805f60
               Pieces: [{Size: 16, Op: {CfaOffset: 8}}]
           IsParameter: true
           IsReturn: false
-    - ID: 21
+    - ID: 15
       Name: main.testArrayOfArrays
       OutOfLinePCRanges: [0x805f60..0x805f70]
       InlinePCRanges: []
       Variables:
         - Name: a
-          Type: 27 ArrayType [2][2]int
+          Type: 48 ArrayType [2][2]int
           Locations:
             - Range: 0x805f60..0x805f70
               Pieces: [{Size: 32, Op: {CfaOffset: 8}}]
           IsParameter: true
           IsReturn: false
-    - ID: 22
+    - ID: 16
       Name: main.testArrayOfStrings
       OutOfLinePCRanges: [0x805f70..0x805f80]
       InlinePCRanges: []
       Variables:
         - Name: a
-          Type: 7 ArrayType [2]string
+          Type: 38 ArrayType [2]string
           Locations:
             - Range: 0x805f70..0x805f80
               Pieces: [{Size: 32, Op: {CfaOffset: 8}}]
           IsParameter: true
           IsReturn: false
-    - ID: 23
+    - ID: 17
       Name: main.testArrayOfArraysOfArrays
       OutOfLinePCRanges: [0x805f80..0x805f90]
       InlinePCRanges: []
       Variables:
         - Name: b
-          Type: 28 ArrayType [2][2][2]int
+          Type: 49 ArrayType [2][2][2]int
           Locations:
             - Range: 0x805f80..0x805f90
               Pieces: [{Size: 64, Op: {CfaOffset: 8}}]
           IsParameter: true
           IsReturn: false
-    - ID: 24
+    - ID: 18
       Name: main.testVeryLargeArray
       OutOfLinePCRanges: [0x805fb0..0x805fc0]
       InlinePCRanges: []
       Variables:
         - Name: a
-          Type: 29 ArrayType [100]uint
+          Type: 50 ArrayType [100]uint
           Locations:
             - Range: 0x805fb0..0x805fc0
               Pieces: [{Size: 800, Op: {CfaOffset: 8}}]
           IsParameter: true
           IsReturn: false
-    - ID: 25
+    - ID: 19
       Name: main.testSingleByte
       OutOfLinePCRanges: [0x8062e0..0x8062f0]
       InlinePCRanges: []
       Variables:
         - Name: x
-          Type: 4 BaseType uint8
+          Type: 3 BaseType uint8
           Locations:
             - Range: 0x8062e0..0x8062f0
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 26
+    - ID: 20
       Name: main.testSingleRune
       OutOfLinePCRanges: [0x8062f0..0x806300]
       InlinePCRanges: []
       Variables:
         - Name: x
-          Type: 6 BaseType int32
+          Type: 12 BaseType int32
           Locations:
             - Range: 0x8062f0..0x806300
               Pieces: [{Size: 4, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 27
+    - ID: 21
       Name: main.testSingleBool
       OutOfLinePCRanges: [0x806300..0x806310]
       InlinePCRanges: []
       Variables:
         - Name: x
-          Type: 11 BaseType bool
+          Type: 4 BaseType bool
           Locations:
             - Range: 0x806300..0x806310
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 28
+    - ID: 22
       Name: main.testSingleInt
       OutOfLinePCRanges: [0x806310..0x806320]
       InlinePCRanges: []
       Variables:
         - Name: x
-          Type: 1 BaseType int
+          Type: 7 BaseType int
           Locations:
             - Range: 0x806310..0x806320
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 29
+    - ID: 23
       Name: main.testSingleInt8
       OutOfLinePCRanges: [0x806320..0x806330]
       InlinePCRanges: []
       Variables:
         - Name: x
-          Type: 14 BaseType int8
+          Type: 17 BaseType int8
           Locations:
             - Range: 0x806320..0x806330
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 30
+    - ID: 24
       Name: main.testSingleInt16
       OutOfLinePCRanges: [0x806330..0x806340]
       InlinePCRanges: []
       Variables:
         - Name: x
-          Type: 16 BaseType int16
+          Type: 23 BaseType int16
           Locations:
             - Range: 0x806330..0x806340
               Pieces: [{Size: 2, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 31
+    - ID: 25
       Name: main.testSingleInt32
       OutOfLinePCRanges: [0x806340..0x806350]
       InlinePCRanges: []
       Variables:
         - Name: x
-          Type: 6 BaseType int32
+          Type: 12 BaseType int32
           Locations:
             - Range: 0x806340..0x806350
               Pieces: [{Size: 4, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 32
+    - ID: 26
       Name: main.testSingleInt64
       OutOfLinePCRanges: [0x806350..0x806360]
       InlinePCRanges: []
       Variables:
         - Name: x
-          Type: 18 BaseType int64
+          Type: 13 BaseType int64
           Locations:
             - Range: 0x806350..0x806360
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 33
+    - ID: 27
       Name: main.testSingleUint
       OutOfLinePCRanges: [0x806360..0x806370]
       InlinePCRanges: []
       Variables:
         - Name: x
-          Type: 20 BaseType uint
+          Type: 10 BaseType uint
           Locations:
             - Range: 0x806360..0x806370
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 34
+    - ID: 28
       Name: main.testSingleUint8
       OutOfLinePCRanges: [0x806370..0x806380]
       InlinePCRanges: []
       Variables:
         - Name: x
-          Type: 4 BaseType uint8
+          Type: 3 BaseType uint8
           Locations:
             - Range: 0x806370..0x806380
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 35
+    - ID: 29
       Name: main.testSingleUint16
       OutOfLinePCRanges: [0x806380..0x806390]
       InlinePCRanges: []
       Variables:
         - Name: x
-          Type: 22 BaseType uint16
+          Type: 6 BaseType uint16
           Locations:
             - Range: 0x806380..0x806390
               Pieces: [{Size: 2, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 36
+    - ID: 30
       Name: main.testSingleUint32
       OutOfLinePCRanges: [0x806390..0x8063a0]
       InlinePCRanges: []
       Variables:
         - Name: x
-          Type: 24 BaseType uint32
+          Type: 2 BaseType uint32
           Locations:
             - Range: 0x806390..0x8063a0
               Pieces: [{Size: 4, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 37
+    - ID: 31
       Name: main.testSingleUint64
       OutOfLinePCRanges: [0x8063a0..0x8063b0]
       InlinePCRanges: []
       Variables:
         - Name: x
-          Type: 26 BaseType uint64
+          Type: 8 BaseType uint64
           Locations:
             - Range: 0x8063a0..0x8063b0
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 38
+    - ID: 32
       Name: main.testSingleFloat32
       OutOfLinePCRanges: [0x8063b0..0x8063c0]
       InlinePCRanges: []
       Variables:
         - Name: x
-          Type: 30 BaseType float32
+          Type: 18 BaseType float32
           Locations:
             - Range: 0x8063b0..0x8063c0
               Pieces: [{Size: 4, Op: {RegNo: 64, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 39
+    - ID: 33
       Name: main.testSingleFloat64
       OutOfLinePCRanges: [0x8063c0..0x8063d0]
       InlinePCRanges: []
       Variables:
         - Name: x
-          Type: 31 BaseType float64
+          Type: 16 BaseType float64
           Locations:
             - Range: 0x8063c0..0x8063d0
               Pieces: [{Size: 8, Op: {RegNo: 64, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 40
+    - ID: 34
       Name: main.testTypeAlias
       OutOfLinePCRanges: [0x8063d0..0x8063e0]
       InlinePCRanges: []
       Variables:
         - Name: x
-          Type: 32 BaseType main.typeAlias
+          Type: 51 BaseType main.typeAlias
           Locations:
             - Range: 0x8063d0..0x8063e0
               Pieces: [{Size: 2, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 41
+    - ID: 35
       Name: main.testBigStruct
       OutOfLinePCRanges: [0x8064d0..0x8064e0]
       InlinePCRanges: []
       Variables:
         - Name: b
-          Type: 33 StructureType main.bigStruct
+          Type: 52 StructureType main.bigStruct
           Locations:
             - Range: 0x8064d0..0x8064e0
               Pieces:
@@ -1905,13 +1905,13 @@ Subprograms:
                   Op: {RegNo: 5, Shift: 0}
           IsParameter: true
           IsReturn: false
-    - ID: 42
+    - ID: 36
       Name: main.testEsotericStack
       OutOfLinePCRanges: [0x806650..0x806710]
       InlinePCRanges: []
       Variables:
         - Name: e
-          Type: 39 StructureType main.esotericStack
+          Type: 56 StructureType main.esotericStack
           Locations:
             - Range: 0x806650..0x806688
               Pieces:
@@ -1975,51 +1975,51 @@ Subprograms:
                   Op: {RegNo: 8, Shift: 0}
           IsParameter: true
           IsReturn: false
-    - ID: 43
+    - ID: 37
       Name: main.testEsotericHeap
       OutOfLinePCRanges: [0x806710..0x806780]
       InlinePCRanges: []
       Variables:
         - Name: e
-          Type: 44 PointerType *main.esotericHeap
+          Type: 61 PointerType *main.esotericHeap
           Locations:
             - Range: 0x806710..0x806744
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 44
+    - ID: 38
       Name: main.testInlinedBA
       OutOfLinePCRanges: [0x806b20..0x806bb0]
       InlinePCRanges: []
       Variables:
         - Name: x
-          Type: 1 BaseType int
+          Type: 7 BaseType int
           Locations:
             - Range: 0x806b20..0x806b58
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 45
+    - ID: 39
       Name: main.testInlinedBB
       OutOfLinePCRanges: [0x806bb0..0x806c70]
       InlinePCRanges: []
       Variables:
         - Name: x
-          Type: 1 BaseType int
+          Type: 7 BaseType int
           Locations:
             - Range: 0x806bb0..0x806bcc
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
         - Name: y
-          Type: 1 BaseType int
+          Type: 7 BaseType int
           Locations:
             - Range: 0x806bb0..0x806bdc
               Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
           IsParameter: true
           IsReturn: false
         - Name: z
-          Type: 1 BaseType int
+          Type: 7 BaseType int
           Locations:
             - Range: 0x806bcc..0x806bdc
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
@@ -2027,25 +2027,25 @@ Subprograms:
               Pieces: [{Size: 8, Op: {CfaOffset: -48}}]
           IsParameter: false
           IsReturn: false
-    - ID: 46
+    - ID: 40
       Name: main.testInlinedBBA
       OutOfLinePCRanges: [0x806c70..0x806ce0]
       InlinePCRanges: []
       Variables:
         - Name: x
-          Type: 1 BaseType int
+          Type: 7 BaseType int
           Locations:
             - Range: 0x806c70..0x806c94
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 47
+    - ID: 41
       Name: main.testInlinedBC
       OutOfLinePCRanges: [0x806ce0..0x806df0]
       InlinePCRanges: []
       Variables:
         - Name: s
-          Type: 1 BaseType int
+          Type: 7 BaseType int
           Locations:
             - Range: 0x806cfc..0x806d68
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
@@ -2054,7 +2054,7 @@ Subprograms:
           IsParameter: false
           IsReturn: false
         - Name: i
-          Type: 1 BaseType int
+          Type: 7 BaseType int
           Locations:
             - Range: 0x806cfc..0x806d68
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
@@ -2062,47 +2062,47 @@ Subprograms:
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: false
           IsReturn: false
-    - ID: 48
+    - ID: 42
       Name: main.testFrameless
       OutOfLinePCRanges: [0x806df0..0x806e00]
       InlinePCRanges: []
       Variables:
         - Name: x
-          Type: 1 BaseType int
+          Type: 7 BaseType int
           Locations:
             - Range: 0x806df0..0x806df8
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
         - Name: ~r0
-          Type: 1 BaseType int
+          Type: 7 BaseType int
           Locations: [{Range: 0x806df0..0x806e00, Pieces: []}]
           IsParameter: true
           IsReturn: true
-    - ID: 49
+    - ID: 43
       Name: main.testFramelessArray
       OutOfLinePCRanges: [0x806e00..0x806e50]
       InlinePCRanges: []
       Variables:
         - Name: a
-          Type: 2 ArrayType [5]int
+          Type: 73 ArrayType [5]int
           Locations:
             - Range: 0x806e00..0x806e50
               Pieces: [{Size: 40, Op: {CfaOffset: 8}}]
           IsParameter: true
           IsReturn: false
         - Name: ~r0
-          Type: 1 BaseType int
+          Type: 7 BaseType int
           Locations: [{Range: 0x806e00..0x806e50, Pieces: []}]
           IsParameter: true
           IsReturn: true
-    - ID: 50
+    - ID: 44
       Name: main.testInterface
       OutOfLinePCRanges: [0x807060..0x8070b0]
       InlinePCRanges: []
       Variables:
         - Name: b
-          Type: 56 GoInterfaceType main.behavior
+          Type: 74 GoInterfaceType main.behavior
           Locations:
             - Range: 0x807060..0x807088
               Pieces:
@@ -2119,17 +2119,17 @@ Subprograms:
           IsParameter: true
           IsReturn: false
         - Name: ~r0
-          Type: 8 GoStringHeaderType string
+          Type: 9 GoStringHeaderType string
           Locations: [{Range: 0x807060..0x8070b0, Pieces: []}]
           IsParameter: true
           IsReturn: true
-    - ID: 51
+    - ID: 45
       Name: main.testAny
       OutOfLinePCRanges: [0x8070b0..0x807110]
       InlinePCRanges: []
       Variables:
         - Name: a
-          Type: 41 GoEmptyInterfaceType interface {}
+          Type: 58 GoEmptyInterfaceType interface {}
           Locations:
             - Range: 0x8070b0..0x8070dc
               Pieces:
@@ -2146,17 +2146,17 @@ Subprograms:
           IsParameter: true
           IsReturn: false
         - Name: ~r0
-          Type: 8 GoStringHeaderType string
+          Type: 9 GoStringHeaderType string
           Locations: [{Range: 0x8070b0..0x807110, Pieces: []}]
           IsParameter: true
           IsReturn: true
-    - ID: 52
+    - ID: 46
       Name: main.testError
       OutOfLinePCRanges: [0x807110..0x807120]
       InlinePCRanges: []
       Variables:
         - Name: e
-          Type: 57 GoInterfaceType error
+          Type: 14 GoInterfaceType error
           Locations:
             - Range: 0x807110..0x807120
               Pieces:
@@ -2166,307 +2166,307 @@ Subprograms:
                   Op: {RegNo: 1, Shift: 0}
           IsParameter: true
           IsReturn: false
-    - ID: 53
+    - ID: 47
       Name: main.testStructWithMap
       OutOfLinePCRanges: [0x8074d0..0x8074e0]
       InlinePCRanges: []
       Variables:
         - Name: s
-          Type: 58 StructureType main.structWithMap
+          Type: 75 StructureType main.structWithMap
           Locations:
             - Range: 0x8074d0..0x8074e0
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 54
+    - ID: 48
       Name: main.testMapStringToStruct
       OutOfLinePCRanges: [0x8074e0..0x8074f0]
       InlinePCRanges: []
       Variables:
         - Name: m
-          Type: 71 GoMapType map[string]main.nestedStruct
+          Type: 87 GoMapType map[string]main.nestedStruct
           Locations:
             - Range: 0x8074e0..0x8074f0
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 55
+    - ID: 49
       Name: main.testMapStringToInt
       OutOfLinePCRanges: [0x8074f0..0x807500]
       InlinePCRanges: []
       Variables:
         - Name: m
-          Type: 83 GoMapType map[string]int
+          Type: 99 GoMapType map[string]int
           Locations:
             - Range: 0x8074f0..0x807500
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 56
+    - ID: 50
       Name: main.testMapStringToSlice
       OutOfLinePCRanges: [0x807500..0x807510]
       InlinePCRanges: []
       Variables:
         - Name: m
-          Type: 94 GoMapType map[string][]string
+          Type: 110 GoMapType map[string][]string
           Locations:
             - Range: 0x807500..0x807510
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 57
+    - ID: 51
       Name: main.testMapArrayToArray
       OutOfLinePCRanges: [0x807510..0x807520]
       InlinePCRanges: []
       Variables:
         - Name: m
-          Type: 106 GoMapType map[[4]string][2]int
+          Type: 122 GoMapType map[[4]string][2]int
           Locations:
             - Range: 0x807510..0x807520
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 58
+    - ID: 52
       Name: main.testSmallMap
       OutOfLinePCRanges: [0x807520..0x807530]
       InlinePCRanges: []
       Variables:
         - Name: m
-          Type: 83 GoMapType map[string]int
+          Type: 99 GoMapType map[string]int
           Locations:
             - Range: 0x807520..0x807530
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 59
+    - ID: 53
       Name: main.testArrayOfMaps
       OutOfLinePCRanges: [0x807530..0x807540]
       InlinePCRanges: []
       Variables:
         - Name: m
-          Type: 118 ArrayType [2]map[string]int
+          Type: 134 ArrayType [2]map[string]int
           Locations:
             - Range: 0x807530..0x807540
               Pieces: [{Size: 16, Op: {CfaOffset: 8}}]
           IsParameter: true
           IsReturn: false
-    - ID: 60
+    - ID: 54
       Name: main.testPointerToMap
       OutOfLinePCRanges: [0x807540..0x807550]
       InlinePCRanges: []
       Variables:
         - Name: m
-          Type: 119 PointerType *map[string]int
+          Type: 135 PointerType *map[string]int
           Locations:
             - Range: 0x807540..0x807550
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 61
+    - ID: 55
       Name: main.testMapIntToInt
       OutOfLinePCRanges: [0x807550..0x807560]
       InlinePCRanges: []
       Variables:
         - Name: m
-          Type: 59 GoMapType map[int]int
+          Type: 76 GoMapType map[int]int
           Locations:
             - Range: 0x807550..0x807560
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 62
+    - ID: 56
       Name: main.testMapMassive
       OutOfLinePCRanges: [0x807560..0x807570]
       InlinePCRanges: []
       Variables:
         - Name: redactMyEntries
-          Type: 120 GoMapType map[string][]main.structWithMap
+          Type: 136 GoMapType map[string][]main.structWithMap
           Locations:
             - Range: 0x807560..0x807570
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 63
+    - ID: 57
       Name: main.testMapEmbeddedMaps
       OutOfLinePCRanges: [0x807570..0x807580]
       InlinePCRanges: []
       Variables:
         - Name: m
-          Type: 120 GoMapType map[string][]main.structWithMap
+          Type: 136 GoMapType map[string][]main.structWithMap
           Locations:
             - Range: 0x807570..0x807580
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 64
+    - ID: 58
       Name: main.testMapWithLinkedList
       OutOfLinePCRanges: [0x807580..0x807590]
       InlinePCRanges: []
       Variables:
         - Name: m
-          Type: 133 GoMapType map[bool]main.node
+          Type: 149 GoMapType map[bool]main.node
           Locations:
             - Range: 0x807580..0x807590
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 65
+    - ID: 59
       Name: main.testMapWithSmallValue
       OutOfLinePCRanges: [0x807590..0x8075a0]
       InlinePCRanges: []
       Variables:
         - Name: m
-          Type: 146 GoMapType map[int]uint8
+          Type: 162 GoMapType map[int]uint8
           Locations:
             - Range: 0x807590..0x8075a0
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 66
+    - ID: 60
       Name: main.testMapWithSmallValueMassive
       OutOfLinePCRanges: [0x8075a0..0x8075b0]
       InlinePCRanges: []
       Variables:
         - Name: redactMyEntries
-          Type: 146 GoMapType map[int]uint8
+          Type: 162 GoMapType map[int]uint8
           Locations:
             - Range: 0x8075a0..0x8075b0
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 67
+    - ID: 61
       Name: main.testMapWithSmallKeyAndValue
       OutOfLinePCRanges: [0x8075b0..0x8075c0]
       InlinePCRanges: []
       Variables:
         - Name: m
-          Type: 157 GoMapType map[uint8]uint8
+          Type: 173 GoMapType map[uint8]uint8
           Locations:
             - Range: 0x8075b0..0x8075c0
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 68
+    - ID: 62
       Name: main.testMapWithSmallKeyAndValueMassive
       OutOfLinePCRanges: [0x8075c0..0x8075d0]
       InlinePCRanges: []
       Variables:
         - Name: m
-          Type: 157 GoMapType map[uint8]uint8
+          Type: 173 GoMapType map[uint8]uint8
           Locations:
             - Range: 0x8075c0..0x8075d0
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 69
+    - ID: 63
       Name: main.testMapSmallKeySmallValue
       OutOfLinePCRanges: [0x8075d0..0x8075e0]
       InlinePCRanges: []
       Variables:
         - Name: m
-          Type: 157 GoMapType map[uint8]uint8
+          Type: 173 GoMapType map[uint8]uint8
           Locations:
             - Range: 0x8075d0..0x8075e0
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 70
+    - ID: 64
       Name: main.testMapSmallKeyLargeValue
       OutOfLinePCRanges: [0x8075e0..0x8075f0]
       InlinePCRanges: []
       Variables:
         - Name: m
-          Type: 168 GoMapType map[uint8][4]int
+          Type: 184 GoMapType map[uint8][4]int
           Locations:
             - Range: 0x8075e0..0x8075f0
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 71
+    - ID: 65
       Name: main.testMapLargeKeySmallValue
       OutOfLinePCRanges: [0x8075f0..0x807600]
       InlinePCRanges: []
       Variables:
         - Name: m
-          Type: 180 GoMapType map[[4]int]uint8
+          Type: 196 GoMapType map[[4]int]uint8
           Locations:
             - Range: 0x8075f0..0x807600
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 72
+    - ID: 66
       Name: main.testMapLargeKeyLargeValue
       OutOfLinePCRanges: [0x807600..0x807610]
       InlinePCRanges: []
       Variables:
         - Name: m
-          Type: 191 GoMapType map[[4]int][4]int
+          Type: 207 GoMapType map[[4]int][4]int
           Locations:
             - Range: 0x807600..0x807610
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 73
+    - ID: 67
       Name: main.testCombinedByte
       OutOfLinePCRanges: [0x8088a0..0x8088b0]
       InlinePCRanges: []
       Variables:
         - Name: w
-          Type: 4 BaseType uint8
+          Type: 3 BaseType uint8
           Locations:
             - Range: 0x8088a0..0x8088b0
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
         - Name: x
-          Type: 4 BaseType uint8
+          Type: 3 BaseType uint8
           Locations:
             - Range: 0x8088a0..0x8088b0
               Pieces: [{Size: 1, Op: {RegNo: 1, Shift: 0}}]
           IsParameter: true
           IsReturn: false
         - Name: y
-          Type: 30 BaseType float32
+          Type: 18 BaseType float32
           Locations:
             - Range: 0x8088a0..0x8088b0
               Pieces: [{Size: 4, Op: {RegNo: 64, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 74
+    - ID: 68
       Name: main.testMultipleSimpleParams
       OutOfLinePCRanges: [0x808980..0x808990]
       InlinePCRanges: []
       Variables:
         - Name: a
-          Type: 11 BaseType bool
+          Type: 4 BaseType bool
           Locations:
             - Range: 0x808980..0x808990
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
         - Name: b
-          Type: 4 BaseType uint8
+          Type: 3 BaseType uint8
           Locations:
             - Range: 0x808980..0x808990
               Pieces: [{Size: 1, Op: {RegNo: 1, Shift: 0}}]
           IsParameter: true
           IsReturn: false
         - Name: c
-          Type: 6 BaseType int32
+          Type: 12 BaseType int32
           Locations:
             - Range: 0x808980..0x808990
               Pieces: [{Size: 4, Op: {RegNo: 2, Shift: 0}}]
           IsParameter: true
           IsReturn: false
         - Name: d
-          Type: 20 BaseType uint
+          Type: 10 BaseType uint
           Locations:
             - Range: 0x808980..0x808990
               Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
           IsParameter: true
           IsReturn: false
         - Name: e
-          Type: 8 GoStringHeaderType string
+          Type: 9 GoStringHeaderType string
           Locations:
             - Range: 0x808980..0x808990
               Pieces:
@@ -2476,37 +2476,37 @@ Subprograms:
                   Op: {RegNo: 5, Shift: 0}
           IsParameter: true
           IsReturn: false
-    - ID: 75
+    - ID: 69
       Name: main.testChannel
       OutOfLinePCRanges: [0x808b20..0x808b30]
       InlinePCRanges: []
       Variables:
         - Name: c
-          Type: 202 GoChannelType chan bool
+          Type: 218 GoChannelType chan bool
           Locations:
             - Range: 0x808b20..0x808b30
               Pieces: [{Size: 0, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 76
+    - ID: 70
       Name: main.testPointerToSimpleStruct
       OutOfLinePCRanges: [0x808ca0..0x808cb0]
       InlinePCRanges: []
       Variables:
         - Name: a
-          Type: 203 PointerType *main.structWithTwoValues
+          Type: 219 PointerType *main.structWithTwoValues
           Locations:
             - Range: 0x808ca0..0x808cb0
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 77
+    - ID: 71
       Name: main.testLinkedList
       OutOfLinePCRanges: [0x808cb0..0x808cc0]
       InlinePCRanges: []
       Variables:
         - Name: a
-          Type: 144 StructureType main.node
+          Type: 160 StructureType main.node
           Locations:
             - Range: 0x808cb0..0x808cc0
               Pieces:
@@ -2516,92 +2516,92 @@ Subprograms:
                   Op: {RegNo: 1, Shift: 0}
           IsParameter: true
           IsReturn: false
-    - ID: 78
+    - ID: 72
       Name: main.testPointerLoop
       OutOfLinePCRanges: [0x808cc0..0x808cd0]
       InlinePCRanges: []
       Variables:
         - Name: a
-          Type: 145 PointerType *main.node
+          Type: 161 PointerType *main.node
           Locations:
             - Range: 0x808cc0..0x808cd0
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 79
+    - ID: 73
       Name: main.testUnsafePointer
       OutOfLinePCRanges: [0x808cd0..0x808ce0]
       InlinePCRanges: []
       Variables:
         - Name: x
-          Type: 38 VoidPointerType unsafe.Pointer
+          Type: 15 VoidPointerType unsafe.Pointer
           Locations:
             - Range: 0x808cd0..0x808ce0
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 80
+    - ID: 74
       Name: main.testUintPointer
       OutOfLinePCRanges: [0x808cf0..0x808d00]
       InlinePCRanges: []
       Variables:
         - Name: x
-          Type: 205 PointerType *uint
+          Type: 34 PointerType *uint
           Locations:
             - Range: 0x808cf0..0x808d00
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 81
+    - ID: 75
       Name: main.testStringPointer
       OutOfLinePCRanges: [0x808d60..0x808d70]
       InlinePCRanges: []
       Variables:
         - Name: z
-          Type: 36 PointerType *string
+          Type: 22 PointerType *string
           Locations:
             - Range: 0x808d60..0x808d70
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 82
+    - ID: 76
       Name: main.testNilPointer
       OutOfLinePCRanges: [0x808d80..0x808d90]
       InlinePCRanges: []
       Variables:
         - Name: z
-          Type: 206 PointerType *bool
+          Type: 11 PointerType *bool
           Locations:
             - Range: 0x808d80..0x808d90
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
         - Name: a
-          Type: 20 BaseType uint
+          Type: 10 BaseType uint
           Locations:
             - Range: 0x808d80..0x808d90
               Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 83
+    - ID: 77
       Name: main.testCycle
       OutOfLinePCRanges: [0x808da0..0x808db0]
       InlinePCRanges: []
       Variables:
         - Name: t
-          Type: 207 PointerType *main.t
+          Type: 221 PointerType *main.t
           Locations:
             - Range: 0x808da0..0x808db0
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 84
+    - ID: 78
       Name: main.testUintSlice
       OutOfLinePCRanges: [0x809140..0x809150]
       InlinePCRanges: []
       Variables:
         - Name: u
-          Type: 210 GoSliceHeaderType []uint
+          Type: 224 GoSliceHeaderType []uint
           Locations:
             - Range: 0x809140..0x809150
               Pieces:
@@ -2613,13 +2613,13 @@ Subprograms:
                   Op: {RegNo: 2, Shift: 0}
           IsParameter: true
           IsReturn: false
-    - ID: 85
+    - ID: 79
       Name: main.testEmptySlice
       OutOfLinePCRanges: [0x809150..0x809160]
       InlinePCRanges: []
       Variables:
         - Name: u
-          Type: 210 GoSliceHeaderType []uint
+          Type: 224 GoSliceHeaderType []uint
           Locations:
             - Range: 0x809150..0x809160
               Pieces:
@@ -2631,13 +2631,13 @@ Subprograms:
                   Op: {RegNo: 2, Shift: 0}
           IsParameter: true
           IsReturn: false
-    - ID: 86
+    - ID: 80
       Name: main.testSliceOfSlices
       OutOfLinePCRanges: [0x809160..0x809170]
       InlinePCRanges: []
       Variables:
         - Name: u
-          Type: 211 GoSliceHeaderType [][]uint
+          Type: 225 GoSliceHeaderType [][]uint
           Locations:
             - Range: 0x809160..0x809170
               Pieces:
@@ -2649,13 +2649,13 @@ Subprograms:
                   Op: {RegNo: 2, Shift: 0}
           IsParameter: true
           IsReturn: false
-    - ID: 87
+    - ID: 81
       Name: main.testStructSlice
       OutOfLinePCRanges: [0x809170..0x809180]
       InlinePCRanges: []
       Variables:
         - Name: xs
-          Type: 213 GoSliceHeaderType []main.structWithNoStrings
+          Type: 227 GoSliceHeaderType []main.structWithNoStrings
           Locations:
             - Range: 0x809170..0x809180
               Pieces:
@@ -2668,19 +2668,19 @@ Subprograms:
           IsParameter: true
           IsReturn: false
         - Name: a
-          Type: 1 BaseType int
+          Type: 7 BaseType int
           Locations:
             - Range: 0x809170..0x809180
               Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 88
+    - ID: 82
       Name: main.testEmptySliceOfStructs
       OutOfLinePCRanges: [0x809180..0x809190]
       InlinePCRanges: []
       Variables:
         - Name: xs
-          Type: 213 GoSliceHeaderType []main.structWithNoStrings
+          Type: 227 GoSliceHeaderType []main.structWithNoStrings
           Locations:
             - Range: 0x809180..0x809190
               Pieces:
@@ -2693,19 +2693,19 @@ Subprograms:
           IsParameter: true
           IsReturn: false
         - Name: a
-          Type: 1 BaseType int
+          Type: 7 BaseType int
           Locations:
             - Range: 0x809180..0x809190
               Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 89
+    - ID: 83
       Name: main.testNilSliceOfStructs
       OutOfLinePCRanges: [0x809190..0x8091a0]
       InlinePCRanges: []
       Variables:
         - Name: xs
-          Type: 213 GoSliceHeaderType []main.structWithNoStrings
+          Type: 227 GoSliceHeaderType []main.structWithNoStrings
           Locations:
             - Range: 0x809190..0x8091a0
               Pieces:
@@ -2718,19 +2718,19 @@ Subprograms:
           IsParameter: true
           IsReturn: false
         - Name: a
-          Type: 1 BaseType int
+          Type: 7 BaseType int
           Locations:
             - Range: 0x809190..0x8091a0
               Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 90
+    - ID: 84
       Name: main.testStringSlice
       OutOfLinePCRanges: [0x8091a0..0x8091b0]
       InlinePCRanges: []
       Variables:
         - Name: s
-          Type: 105 GoSliceHeaderType []string
+          Type: 121 GoSliceHeaderType []string
           Locations:
             - Range: 0x8091a0..0x8091b0
               Pieces:
@@ -2742,20 +2742,20 @@ Subprograms:
                   Op: {RegNo: 2, Shift: 0}
           IsParameter: true
           IsReturn: false
-    - ID: 91
+    - ID: 85
       Name: main.testNilSliceWithOtherParams
       OutOfLinePCRanges: [0x8091b0..0x8091c0]
       InlinePCRanges: []
       Variables:
         - Name: a
-          Type: 14 BaseType int8
+          Type: 17 BaseType int8
           Locations:
             - Range: 0x8091b0..0x8091c0
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
         - Name: s
-          Type: 216 GoSliceHeaderType []bool
+          Type: 230 GoSliceHeaderType []bool
           Locations:
             - Range: 0x8091b0..0x8091c0
               Pieces:
@@ -2768,19 +2768,19 @@ Subprograms:
           IsParameter: true
           IsReturn: false
         - Name: x
-          Type: 20 BaseType uint
+          Type: 10 BaseType uint
           Locations:
             - Range: 0x8091b0..0x8091c0
               Pieces: [{Size: 8, Op: {RegNo: 4, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 92
+    - ID: 86
       Name: main.testNilSlice
       OutOfLinePCRanges: [0x8091c0..0x8091d0]
       InlinePCRanges: []
       Variables:
         - Name: xs
-          Type: 217 GoSliceHeaderType []uint16
+          Type: 231 GoSliceHeaderType []uint16
           Locations:
             - Range: 0x8091c0..0x8091d0
               Pieces:
@@ -2792,13 +2792,13 @@ Subprograms:
                   Op: {RegNo: 2, Shift: 0}
           IsParameter: true
           IsReturn: false
-    - ID: 93
+    - ID: 87
       Name: main.testVeryLargeSlice
       OutOfLinePCRanges: [0x8091d0..0x8091e0]
       InlinePCRanges: []
       Variables:
         - Name: xs
-          Type: 210 GoSliceHeaderType []uint
+          Type: 224 GoSliceHeaderType []uint
           Locations:
             - Range: 0x8091d0..0x8091e0
               Pieces:
@@ -2810,23 +2810,23 @@ Subprograms:
                   Op: {RegNo: 2, Shift: 0}
           IsParameter: true
           IsReturn: false
-    - ID: 94
+    - ID: 88
       Name: main.stackC
       OutOfLinePCRanges: [0x809470..0x8094d0]
       InlinePCRanges: []
       Variables:
         - Name: ~r0
-          Type: 8 GoStringHeaderType string
+          Type: 9 GoStringHeaderType string
           Locations: [{Range: 0x809470..0x8094d0, Pieces: []}]
           IsParameter: true
           IsReturn: true
-    - ID: 95
+    - ID: 89
       Name: main.testSingleString
       OutOfLinePCRanges: [0x8094d0..0x8094e0]
       InlinePCRanges: []
       Variables:
         - Name: x
-          Type: 8 GoStringHeaderType string
+          Type: 9 GoStringHeaderType string
           Locations:
             - Range: 0x8094d0..0x8094e0
               Pieces:
@@ -2836,13 +2836,13 @@ Subprograms:
                   Op: {RegNo: 1, Shift: 0}
           IsParameter: true
           IsReturn: false
-    - ID: 96
+    - ID: 90
       Name: main.testThreeStrings
       OutOfLinePCRanges: [0x8094e0..0x8094f0]
       InlinePCRanges: []
       Variables:
         - Name: x
-          Type: 8 GoStringHeaderType string
+          Type: 9 GoStringHeaderType string
           Locations:
             - Range: 0x8094e0..0x8094f0
               Pieces:
@@ -2853,7 +2853,7 @@ Subprograms:
           IsParameter: true
           IsReturn: false
         - Name: y
-          Type: 8 GoStringHeaderType string
+          Type: 9 GoStringHeaderType string
           Locations:
             - Range: 0x8094e0..0x8094f0
               Pieces:
@@ -2864,7 +2864,7 @@ Subprograms:
           IsParameter: true
           IsReturn: false
         - Name: z
-          Type: 8 GoStringHeaderType string
+          Type: 9 GoStringHeaderType string
           Locations:
             - Range: 0x8094e0..0x8094f0
               Pieces:
@@ -2874,13 +2874,13 @@ Subprograms:
                   Op: {RegNo: 5, Shift: 0}
           IsParameter: true
           IsReturn: false
-    - ID: 97
+    - ID: 91
       Name: main.testThreeStringsInStruct
       OutOfLinePCRanges: [0x8094f0..0x809500]
       InlinePCRanges: []
       Variables:
         - Name: a
-          Type: 219 StructureType main.threeStringStruct
+          Type: 232 StructureType main.threeStringStruct
           Locations:
             - Range: 0x8094f0..0x809500
               Pieces:
@@ -2898,37 +2898,37 @@ Subprograms:
                   Op: {RegNo: 5, Shift: 0}
           IsParameter: true
           IsReturn: false
-    - ID: 98
+    - ID: 92
       Name: main.testThreeStringsInStructPointer
       OutOfLinePCRanges: [0x809500..0x809510]
       InlinePCRanges: []
       Variables:
         - Name: a
-          Type: 220 PointerType *main.threeStringStruct
+          Type: 233 PointerType *main.threeStringStruct
           Locations:
             - Range: 0x809500..0x809510
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 99
+    - ID: 93
       Name: main.testOneStringInStructPointer
       OutOfLinePCRanges: [0x809510..0x809520]
       InlinePCRanges: []
       Variables:
         - Name: a
-          Type: 221 PointerType *main.oneStringStruct
+          Type: 234 PointerType *main.oneStringStruct
           Locations:
             - Range: 0x809510..0x809520
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 100
+    - ID: 94
       Name: main.testMassiveString
       OutOfLinePCRanges: [0x809520..0x809530]
       InlinePCRanges: []
       Variables:
         - Name: x
-          Type: 8 GoStringHeaderType string
+          Type: 9 GoStringHeaderType string
           Locations:
             - Range: 0x809520..0x809530
               Pieces:
@@ -2938,13 +2938,13 @@ Subprograms:
                   Op: {RegNo: 1, Shift: 0}
           IsParameter: true
           IsReturn: false
-    - ID: 101
+    - ID: 95
       Name: main.testUnitializedString
       OutOfLinePCRanges: [0x809530..0x809540]
       InlinePCRanges: []
       Variables:
         - Name: x
-          Type: 8 GoStringHeaderType string
+          Type: 9 GoStringHeaderType string
           Locations:
             - Range: 0x809530..0x809540
               Pieces:
@@ -2954,13 +2954,13 @@ Subprograms:
                   Op: {RegNo: 1, Shift: 0}
           IsParameter: true
           IsReturn: false
-    - ID: 102
+    - ID: 96
       Name: main.testEmptyString
       OutOfLinePCRanges: [0x809540..0x809550]
       InlinePCRanges: []
       Variables:
         - Name: x
-          Type: 8 GoStringHeaderType string
+          Type: 9 GoStringHeaderType string
           Locations:
             - Range: 0x809540..0x809550
               Pieces:
@@ -2970,13 +2970,13 @@ Subprograms:
                   Op: {RegNo: 1, Shift: 0}
           IsParameter: true
           IsReturn: false
-    - ID: 103
+    - ID: 97
       Name: main.testStruct
       OutOfLinePCRanges: [0x809710..0x809730]
       InlinePCRanges: []
       Variables:
         - Name: x
-          Type: 223 StructureType main.aStruct
+          Type: 236 StructureType main.aStruct
           Locations:
             - Range: 0x809710..0x809730
               Pieces:
@@ -2996,17 +2996,17 @@ Subprograms:
                   Op: {RegNo: 6, Shift: 0}
           IsParameter: true
           IsReturn: false
-    - ID: 104
+    - ID: 98
       Name: main.testEmptyStruct
       OutOfLinePCRanges: [0x8097e0..0x8097f0]
       InlinePCRanges: []
       Variables:
         - Name: e
-          Type: 224 StructureType main.emptyStruct
+          Type: 237 StructureType main.emptyStruct
           Locations: [{Range: 0x8097e0..0x8097f0, Pieces: []}]
           IsParameter: true
           IsReturn: false
-    - ID: 1
+    - ID: 99
       Name: main.testInlinedPrint
       OutOfLinePCRanges: [0x806990..0x806a00]
       InlinePCRanges:
@@ -3020,7 +3020,7 @@ Subprograms:
           RootRanges: [0x806c70..0x806ce0]
       Variables:
         - Name: x
-          Type: 1 BaseType int
+          Type: 7 BaseType int
           Locations:
             - Range: 0x806990..0x8069b0
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
@@ -3036,28 +3036,28 @@ Subprograms:
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 2
+    - ID: 100
       Name: main.testInlinedBBB
       OutOfLinePCRanges: []
       InlinePCRanges:
         - Ranges: [0x806c14..0x806c48]
           RootRanges: [0x806bb0..0x806c70]
       Variables: []
-    - ID: 3
+    - ID: 101
       Name: main.testInlinedBCA
       OutOfLinePCRanges: []
       InlinePCRanges:
         - Ranges: [0x806cfc..0x806d30, 0x806d38..0x806d3c]
           RootRanges: [0x806ce0..0x806df0]
       Variables: []
-    - ID: 4
+    - ID: 102
       Name: main.testInlinedBCB
       OutOfLinePCRanges: []
       InlinePCRanges:
         - Ranges: [0x806da0..0x806dd4]
           RootRanges: [0x806ce0..0x806df0]
       Variables: []
-    - ID: 5
+    - ID: 103
       Name: main.testInlinedSq
       OutOfLinePCRanges: []
       InlinePCRanges:
@@ -3065,13 +3065,13 @@ Subprograms:
           RootRanges: [0x806df0..0x806e00]
       Variables:
         - Name: x
-          Type: 1 BaseType int
+          Type: 7 BaseType int
           Locations:
             - Range: 0x806df0..0x806df8
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 6
+    - ID: 104
       Name: main.testInlinedSumArray
       OutOfLinePCRanges: []
       InlinePCRanges:
@@ -3081,7 +3081,7 @@ Subprograms:
           RootRanges: [0x806e50..0x806f90]
       Variables:
         - Name: a
-          Type: 2 ArrayType [5]int
+          Type: 73 ArrayType [5]int
           Locations:
             - Range: 0x806e10..0x806e50
               Pieces: [{Size: 40, Op: {CfaOffset: -48}}]
@@ -3091,77 +3091,77 @@ Subprograms:
           IsReturn: false
 Types:
     - __kind: PointerType
-      ID: 209
+      ID: 223
       Name: '**main.t'
       ByteSize: 8
-      Pointee: 207 PointerType *main.t
+      Pointee: 221 PointerType *main.t
     - __kind: PointerType
-      ID: 35
+      ID: 54
       Name: '**string'
       ByteSize: 8
       GoRuntimeType: 525280
       GoKind: 22
-      Pointee: 36 PointerType *string
+      Pointee: 22 PointerType *string
     - __kind: PointerType
-      ID: 194
+      ID: 210
       Name: '**table<[4]int,[4]int>'
       ByteSize: 8
-      Pointee: 195 PointerType *table<[4]int,[4]int>
+      Pointee: 211 PointerType *table<[4]int,[4]int>
     - __kind: PointerType
-      ID: 183
+      ID: 199
       Name: '**table<[4]int,uint8>'
       ByteSize: 8
-      Pointee: 184 PointerType *table<[4]int,uint8>
+      Pointee: 200 PointerType *table<[4]int,uint8>
     - __kind: PointerType
-      ID: 109
+      ID: 125
       Name: '**table<[4]string,[2]int>'
       ByteSize: 8
-      Pointee: 110 PointerType *table<[4]string,[2]int>
+      Pointee: 126 PointerType *table<[4]string,[2]int>
     - __kind: PointerType
-      ID: 136
+      ID: 152
       Name: '**table<bool,main.node>'
       ByteSize: 8
-      Pointee: 137 PointerType *table<bool,main.node>
+      Pointee: 153 PointerType *table<bool,main.node>
     - __kind: PointerType
-      ID: 63
+      ID: 79
       Name: '**table<int,int>'
       ByteSize: 8
-      Pointee: 64 PointerType *table<int,int>
+      Pointee: 80 PointerType *table<int,int>
     - __kind: PointerType
-      ID: 149
+      ID: 165
       Name: '**table<int,uint8>'
       ByteSize: 8
-      Pointee: 150 PointerType *table<int,uint8>
+      Pointee: 166 PointerType *table<int,uint8>
     - __kind: PointerType
-      ID: 123
+      ID: 139
       Name: '**table<string,[]main.structWithMap>'
       ByteSize: 8
-      Pointee: 124 PointerType *table<string,[]main.structWithMap>
+      Pointee: 140 PointerType *table<string,[]main.structWithMap>
     - __kind: PointerType
-      ID: 97
+      ID: 113
       Name: '**table<string,[]string>'
       ByteSize: 8
-      Pointee: 98 PointerType *table<string,[]string>
+      Pointee: 114 PointerType *table<string,[]string>
     - __kind: PointerType
-      ID: 86
+      ID: 102
       Name: '**table<string,int>'
       ByteSize: 8
-      Pointee: 87 PointerType *table<string,int>
+      Pointee: 103 PointerType *table<string,int>
     - __kind: PointerType
-      ID: 74
+      ID: 90
       Name: '**table<string,main.nestedStruct>'
       ByteSize: 8
-      Pointee: 75 PointerType *table<string,main.nestedStruct>
+      Pointee: 91 PointerType *table<string,main.nestedStruct>
     - __kind: PointerType
-      ID: 171
+      ID: 187
       Name: '**table<uint8,[4]int>'
       ByteSize: 8
-      Pointee: 172 PointerType *table<uint8,[4]int>
+      Pointee: 188 PointerType *table<uint8,[4]int>
     - __kind: PointerType
-      ID: 160
+      ID: 176
       Name: '**table<uint8,uint8>'
       ByteSize: 8
-      Pointee: 161 PointerType *table<uint8,uint8>
+      Pointee: 177 PointerType *table<uint8,uint8>
     - __kind: PointerType
       ID: 241
       Name: '*[]*string.array'
@@ -3193,10 +3193,10 @@ Types:
       ByteSize: 8
       Pointee: 250 GoSliceDataType []string.array
     - __kind: PointerType
-      ID: 212
+      ID: 226
       Name: '*[]uint'
       ByteSize: 8
-      Pointee: 210 GoSliceHeaderType []uint
+      Pointee: 224 GoSliceHeaderType []uint
     - __kind: PointerType
       ID: 273
       Name: '*[]uint.array'
@@ -3208,363 +3208,363 @@ Types:
       ByteSize: 8
       Pointee: 280 GoSliceDataType []uint16.array
     - __kind: PointerType
-      ID: 206
+      ID: 11
       Name: '*bool'
       ByteSize: 8
       GoRuntimeType: 388896
       GoKind: 22
-      Pointee: 11 BaseType bool
+      Pointee: 4 BaseType bool
     - __kind: PointerType
-      ID: 236
+      ID: 33
       Name: '*error'
       ByteSize: 8
       GoRuntimeType: 387808
       GoKind: 22
-      Pointee: 57 GoInterfaceType error
+      Pointee: 14 GoInterfaceType error
     - __kind: PointerType
-      ID: 237
+      ID: 35
       Name: '*float32'
       ByteSize: 8
       GoRuntimeType: 388768
       GoKind: 22
-      Pointee: 30 BaseType float32
+      Pointee: 18 BaseType float32
     - __kind: PointerType
-      ID: 230
+      ID: 26
       Name: '*float64'
       ByteSize: 8
       GoRuntimeType: 388832
       GoKind: 22
-      Pointee: 31 BaseType float64
+      Pointee: 16 BaseType float64
     - __kind: PointerType
-      ID: 231
+      ID: 27
       Name: '*int'
       ByteSize: 8
       GoRuntimeType: 388448
       GoKind: 22
-      Pointee: 1 BaseType int
+      Pointee: 7 BaseType int
     - __kind: PointerType
-      ID: 234
+      ID: 31
       Name: '*int16'
       ByteSize: 8
       GoRuntimeType: 388064
       GoKind: 22
-      Pointee: 16 BaseType int16
+      Pointee: 23 BaseType int16
     - __kind: PointerType
-      ID: 226
+      ID: 20
       Name: '*int32'
       ByteSize: 8
       GoRuntimeType: 388192
       GoKind: 22
-      Pointee: 6 BaseType int32
+      Pointee: 12 BaseType int32
     - __kind: PointerType
-      ID: 233
+      ID: 29
       Name: '*int64'
       ByteSize: 8
       GoRuntimeType: 388320
       GoKind: 22
-      Pointee: 18 BaseType int64
+      Pointee: 13 BaseType int64
     - __kind: PointerType
-      ID: 235
+      ID: 32
       Name: '*int8'
       ByteSize: 8
       GoRuntimeType: 387936
       GoKind: 22
-      Pointee: 14 BaseType int8
+      Pointee: 17 BaseType int8
     - __kind: PointerType
-      ID: 44
+      ID: 61
       Name: '*main.esotericHeap'
       ByteSize: 8
       GoRuntimeType: 382944
       GoKind: 22
-      Pointee: 45 StructureType main.esotericHeap
+      Pointee: 62 StructureType main.esotericHeap
     - __kind: PointerType
-      ID: 145
+      ID: 161
       Name: '*main.node'
       ByteSize: 8
       GoRuntimeType: 383008
       GoKind: 22
-      Pointee: 144 StructureType main.node
+      Pointee: 160 StructureType main.node
     - __kind: PointerType
-      ID: 221
+      ID: 234
       Name: '*main.oneStringStruct'
       ByteSize: 8
       GoKind: 22
-      Pointee: 222 StructureType main.oneStringStruct
+      Pointee: 235 StructureType main.oneStringStruct
     - __kind: PointerType
-      ID: 132
+      ID: 148
       Name: '*main.structWithMap'
       ByteSize: 8
       GoRuntimeType: 382880
       GoKind: 22
-      Pointee: 58 StructureType main.structWithMap
+      Pointee: 75 StructureType main.structWithMap
     - __kind: PointerType
-      ID: 214
+      ID: 228
       Name: '*main.structWithNoStrings'
       ByteSize: 8
-      Pointee: 215 StructureType main.structWithNoStrings
+      Pointee: 229 StructureType main.structWithNoStrings
     - __kind: PointerType
-      ID: 203
+      ID: 219
       Name: '*main.structWithTwoValues'
       ByteSize: 8
       GoKind: 22
-      Pointee: 204 StructureType main.structWithTwoValues
+      Pointee: 220 StructureType main.structWithTwoValues
     - __kind: PointerType
-      ID: 207
+      ID: 221
       Name: '*main.t'
       ByteSize: 8
       GoKind: 22
-      Pointee: 208 GoSliceHeaderType main.t
+      Pointee: 222 GoSliceHeaderType main.t
     - __kind: PointerType
       ID: 271
       Name: '*main.t.array'
       ByteSize: 8
       Pointee: 270 GoSliceDataType main.t.array
     - __kind: PointerType
-      ID: 220
+      ID: 233
       Name: '*main.threeStringStruct'
       ByteSize: 8
       GoKind: 22
-      Pointee: 219 StructureType main.threeStringStruct
+      Pointee: 232 StructureType main.threeStringStruct
     - __kind: PointerType
-      ID: 192
+      ID: 208
       Name: '*map<[4]int,[4]int>'
       ByteSize: 8
-      Pointee: 193 GoSwissMapHeaderType map<[4]int,[4]int>
+      Pointee: 209 GoSwissMapHeaderType map<[4]int,[4]int>
     - __kind: PointerType
-      ID: 181
+      ID: 197
       Name: '*map<[4]int,uint8>'
       ByteSize: 8
-      Pointee: 182 GoSwissMapHeaderType map<[4]int,uint8>
+      Pointee: 198 GoSwissMapHeaderType map<[4]int,uint8>
     - __kind: PointerType
-      ID: 107
+      ID: 123
       Name: '*map<[4]string,[2]int>'
       ByteSize: 8
-      Pointee: 108 GoSwissMapHeaderType map<[4]string,[2]int>
+      Pointee: 124 GoSwissMapHeaderType map<[4]string,[2]int>
     - __kind: PointerType
-      ID: 134
+      ID: 150
       Name: '*map<bool,main.node>'
       ByteSize: 8
-      Pointee: 135 GoSwissMapHeaderType map<bool,main.node>
+      Pointee: 151 GoSwissMapHeaderType map<bool,main.node>
     - __kind: PointerType
-      ID: 60
+      ID: 77
       Name: '*map<int,int>'
       ByteSize: 8
-      Pointee: 61 GoSwissMapHeaderType map<int,int>
+      Pointee: 78 GoSwissMapHeaderType map<int,int>
     - __kind: PointerType
-      ID: 147
+      ID: 163
       Name: '*map<int,uint8>'
       ByteSize: 8
-      Pointee: 148 GoSwissMapHeaderType map<int,uint8>
+      Pointee: 164 GoSwissMapHeaderType map<int,uint8>
     - __kind: PointerType
-      ID: 121
+      ID: 137
       Name: '*map<string,[]main.structWithMap>'
       ByteSize: 8
-      Pointee: 122 GoSwissMapHeaderType map<string,[]main.structWithMap>
+      Pointee: 138 GoSwissMapHeaderType map<string,[]main.structWithMap>
     - __kind: PointerType
-      ID: 95
+      ID: 111
       Name: '*map<string,[]string>'
       ByteSize: 8
-      Pointee: 96 GoSwissMapHeaderType map<string,[]string>
+      Pointee: 112 GoSwissMapHeaderType map<string,[]string>
     - __kind: PointerType
-      ID: 84
+      ID: 100
       Name: '*map<string,int>'
       ByteSize: 8
-      Pointee: 85 GoSwissMapHeaderType map<string,int>
+      Pointee: 101 GoSwissMapHeaderType map<string,int>
     - __kind: PointerType
-      ID: 72
+      ID: 88
       Name: '*map<string,main.nestedStruct>'
       ByteSize: 8
-      Pointee: 73 GoSwissMapHeaderType map<string,main.nestedStruct>
+      Pointee: 89 GoSwissMapHeaderType map<string,main.nestedStruct>
     - __kind: PointerType
-      ID: 169
+      ID: 185
       Name: '*map<uint8,[4]int>'
       ByteSize: 8
-      Pointee: 170 GoSwissMapHeaderType map<uint8,[4]int>
+      Pointee: 186 GoSwissMapHeaderType map<uint8,[4]int>
     - __kind: PointerType
-      ID: 158
+      ID: 174
       Name: '*map<uint8,uint8>'
       ByteSize: 8
-      Pointee: 159 GoSwissMapHeaderType map<uint8,uint8>
+      Pointee: 175 GoSwissMapHeaderType map<uint8,uint8>
     - __kind: PointerType
-      ID: 119
+      ID: 135
       Name: '*map[string]int'
       ByteSize: 8
       GoKind: 22
-      Pointee: 83 GoMapType map[string]int
+      Pointee: 99 GoMapType map[string]int
     - __kind: PointerType
-      ID: 198
+      ID: 214
       Name: '*noalg.map.group[[4]int][4]int'
       ByteSize: 8
-      Pointee: 199 StructureType noalg.map.group[[4]int][4]int
+      Pointee: 215 StructureType noalg.map.group[[4]int][4]int
     - __kind: PointerType
-      ID: 187
+      ID: 203
       Name: '*noalg.map.group[[4]int]uint8'
       ByteSize: 8
-      Pointee: 188 StructureType noalg.map.group[[4]int]uint8
+      Pointee: 204 StructureType noalg.map.group[[4]int]uint8
     - __kind: PointerType
-      ID: 113
+      ID: 129
       Name: '*noalg.map.group[[4]string][2]int'
       ByteSize: 8
-      Pointee: 114 StructureType noalg.map.group[[4]string][2]int
+      Pointee: 130 StructureType noalg.map.group[[4]string][2]int
     - __kind: PointerType
-      ID: 140
+      ID: 156
       Name: '*noalg.map.group[bool]main.node'
       ByteSize: 8
-      Pointee: 141 StructureType noalg.map.group[bool]main.node
+      Pointee: 157 StructureType noalg.map.group[bool]main.node
     - __kind: PointerType
-      ID: 67
+      ID: 83
       Name: '*noalg.map.group[int]int'
       ByteSize: 8
-      Pointee: 68 StructureType noalg.map.group[int]int
+      Pointee: 84 StructureType noalg.map.group[int]int
     - __kind: PointerType
-      ID: 153
+      ID: 169
       Name: '*noalg.map.group[int]uint8'
       ByteSize: 8
-      Pointee: 154 StructureType noalg.map.group[int]uint8
+      Pointee: 170 StructureType noalg.map.group[int]uint8
     - __kind: PointerType
-      ID: 127
+      ID: 143
       Name: '*noalg.map.group[string][]main.structWithMap'
       ByteSize: 8
-      Pointee: 128 StructureType noalg.map.group[string][]main.structWithMap
+      Pointee: 144 StructureType noalg.map.group[string][]main.structWithMap
     - __kind: PointerType
-      ID: 101
+      ID: 117
       Name: '*noalg.map.group[string][]string'
       ByteSize: 8
-      Pointee: 102 StructureType noalg.map.group[string][]string
+      Pointee: 118 StructureType noalg.map.group[string][]string
     - __kind: PointerType
-      ID: 90
+      ID: 106
       Name: '*noalg.map.group[string]int'
       ByteSize: 8
-      Pointee: 91 StructureType noalg.map.group[string]int
+      Pointee: 107 StructureType noalg.map.group[string]int
     - __kind: PointerType
-      ID: 78
+      ID: 94
       Name: '*noalg.map.group[string]main.nestedStruct'
       ByteSize: 8
-      Pointee: 79 StructureType noalg.map.group[string]main.nestedStruct
+      Pointee: 95 StructureType noalg.map.group[string]main.nestedStruct
     - __kind: PointerType
-      ID: 175
+      ID: 191
       Name: '*noalg.map.group[uint8][4]int'
       ByteSize: 8
-      Pointee: 176 StructureType noalg.map.group[uint8][4]int
+      Pointee: 192 StructureType noalg.map.group[uint8][4]int
     - __kind: PointerType
-      ID: 164
+      ID: 180
       Name: '*noalg.map.group[uint8]uint8'
       ByteSize: 8
-      Pointee: 165 StructureType noalg.map.group[uint8]uint8
+      Pointee: 181 StructureType noalg.map.group[uint8]uint8
     - __kind: PointerType
-      ID: 36
+      ID: 22
       Name: '*string'
       ByteSize: 8
       GoRuntimeType: 387872
       GoKind: 22
-      Pointee: 8 GoStringHeaderType string
+      Pointee: 9 GoStringHeaderType string
     - __kind: PointerType
       ID: 239
       Name: '*string.str'
       ByteSize: 8
       Pointee: 238 GoStringDataType string.str
     - __kind: PointerType
-      ID: 195
+      ID: 211
       Name: '*table<[4]int,[4]int>'
       ByteSize: 8
-      Pointee: 196 StructureType table<[4]int,[4]int>
+      Pointee: 212 StructureType table<[4]int,[4]int>
     - __kind: PointerType
-      ID: 184
+      ID: 200
       Name: '*table<[4]int,uint8>'
       ByteSize: 8
-      Pointee: 185 StructureType table<[4]int,uint8>
+      Pointee: 201 StructureType table<[4]int,uint8>
     - __kind: PointerType
-      ID: 110
+      ID: 126
       Name: '*table<[4]string,[2]int>'
       ByteSize: 8
-      Pointee: 111 StructureType table<[4]string,[2]int>
+      Pointee: 127 StructureType table<[4]string,[2]int>
     - __kind: PointerType
-      ID: 137
+      ID: 153
       Name: '*table<bool,main.node>'
       ByteSize: 8
-      Pointee: 138 StructureType table<bool,main.node>
+      Pointee: 154 StructureType table<bool,main.node>
     - __kind: PointerType
-      ID: 64
+      ID: 80
       Name: '*table<int,int>'
       ByteSize: 8
-      Pointee: 65 StructureType table<int,int>
+      Pointee: 81 StructureType table<int,int>
     - __kind: PointerType
-      ID: 150
+      ID: 166
       Name: '*table<int,uint8>'
       ByteSize: 8
-      Pointee: 151 StructureType table<int,uint8>
+      Pointee: 167 StructureType table<int,uint8>
     - __kind: PointerType
-      ID: 124
+      ID: 140
       Name: '*table<string,[]main.structWithMap>'
       ByteSize: 8
-      Pointee: 125 StructureType table<string,[]main.structWithMap>
+      Pointee: 141 StructureType table<string,[]main.structWithMap>
     - __kind: PointerType
-      ID: 98
+      ID: 114
       Name: '*table<string,[]string>'
       ByteSize: 8
-      Pointee: 99 StructureType table<string,[]string>
+      Pointee: 115 StructureType table<string,[]string>
     - __kind: PointerType
-      ID: 87
+      ID: 103
       Name: '*table<string,int>'
       ByteSize: 8
-      Pointee: 88 StructureType table<string,int>
+      Pointee: 104 StructureType table<string,int>
     - __kind: PointerType
-      ID: 75
+      ID: 91
       Name: '*table<string,main.nestedStruct>'
       ByteSize: 8
-      Pointee: 76 StructureType table<string,main.nestedStruct>
+      Pointee: 92 StructureType table<string,main.nestedStruct>
     - __kind: PointerType
-      ID: 172
+      ID: 188
       Name: '*table<uint8,[4]int>'
       ByteSize: 8
-      Pointee: 173 StructureType table<uint8,[4]int>
+      Pointee: 189 StructureType table<uint8,[4]int>
     - __kind: PointerType
-      ID: 161
+      ID: 177
       Name: '*table<uint8,uint8>'
       ByteSize: 8
-      Pointee: 162 StructureType table<uint8,uint8>
+      Pointee: 178 StructureType table<uint8,uint8>
     - __kind: PointerType
-      ID: 205
+      ID: 34
       Name: '*uint'
       ByteSize: 8
       GoRuntimeType: 388512
       GoKind: 22
-      Pointee: 20 BaseType uint
+      Pointee: 10 BaseType uint
     - __kind: PointerType
-      ID: 218
+      ID: 30
       Name: '*uint16'
       ByteSize: 8
       GoRuntimeType: 388128
       GoKind: 22
-      Pointee: 22 BaseType uint16
+      Pointee: 6 BaseType uint16
     - __kind: PointerType
-      ID: 227
+      ID: 21
       Name: '*uint32'
       ByteSize: 8
       GoRuntimeType: 388256
       GoKind: 22
-      Pointee: 24 BaseType uint32
+      Pointee: 2 BaseType uint32
     - __kind: PointerType
-      ID: 232
+      ID: 28
       Name: '*uint64'
       ByteSize: 8
       GoRuntimeType: 388384
       GoKind: 22
-      Pointee: 26 BaseType uint64
+      Pointee: 8 BaseType uint64
     - __kind: PointerType
-      ID: 9
+      ID: 5
       Name: '*uint8'
       ByteSize: 8
       GoRuntimeType: 388000
       GoKind: 22
-      Pointee: 4 BaseType uint8
+      Pointee: 3 BaseType uint8
     - __kind: PointerType
-      ID: 225
+      ID: 19
       Name: '*uintptr'
       ByteSize: 8
       GoRuntimeType: 388576
       GoKind: 22
-      Pointee: 62 BaseType uintptr
+      Pointee: 1 BaseType uintptr
     - __kind: EventRootType
       ID: 369
       Name: Probe[main.stackC]
@@ -3577,10 +3577,10 @@ Types:
         - Name: a
           Offset: 1
           Expression:
-            Type: 41 GoEmptyInterfaceType interface {}
+            Type: 58 GoEmptyInterfaceType interface {}
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 51, index: 0, name: a}
+                  Variable: {subprogram: 45, index: 0, name: a}
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
@@ -3592,10 +3592,10 @@ Types:
         - Name: b
           Offset: 1
           Expression:
-            Type: 28 ArrayType [2][2][2]int
+            Type: 49 ArrayType [2][2][2]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 23, index: 0, name: b}
+                  Variable: {subprogram: 17, index: 0, name: b}
                   Offset: 0
                   ByteSize: 64
     - __kind: EventRootType
@@ -3607,10 +3607,10 @@ Types:
         - Name: a
           Offset: 1
           Expression:
-            Type: 27 ArrayType [2][2]int
+            Type: 48 ArrayType [2][2]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 21, index: 0, name: a}
+                  Variable: {subprogram: 15, index: 0, name: a}
                   Offset: 0
                   ByteSize: 32
     - __kind: EventRootType
@@ -3622,10 +3622,10 @@ Types:
         - Name: m
           Offset: 1
           Expression:
-            Type: 118 ArrayType [2]map[string]int
+            Type: 134 ArrayType [2]map[string]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 59, index: 0, name: m}
+                  Variable: {subprogram: 53, index: 0, name: m}
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
@@ -3637,10 +3637,10 @@ Types:
         - Name: a
           Offset: 1
           Expression:
-            Type: 7 ArrayType [2]string
+            Type: 38 ArrayType [2]string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 22, index: 0, name: a}
+                  Variable: {subprogram: 16, index: 0, name: a}
                   Offset: 0
                   ByteSize: 32
     - __kind: EventRootType
@@ -3652,10 +3652,10 @@ Types:
         - Name: b
           Offset: 1
           Expression:
-            Type: 33 StructureType main.bigStruct
+            Type: 52 StructureType main.bigStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 41, index: 0, name: b}
+                  Variable: {subprogram: 35, index: 0, name: b}
                   Offset: 0
                   ByteSize: 48
     - __kind: EventRootType
@@ -3667,10 +3667,10 @@ Types:
         - Name: x
           Offset: 1
           Expression:
-            Type: 10 ArrayType [2]bool
+            Type: 39 ArrayType [2]bool
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 10, index: 0, name: x}
+                  Variable: {subprogram: 4, index: 0, name: x}
                   Offset: 0
                   ByteSize: 2
     - __kind: EventRootType
@@ -3682,10 +3682,10 @@ Types:
         - Name: x
           Offset: 1
           Expression:
-            Type: 3 ArrayType [2]uint8
+            Type: 36 ArrayType [2]uint8
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 7, index: 0, name: x}
+                  Variable: {subprogram: 1, index: 0, name: x}
                   Offset: 0
                   ByteSize: 2
     - __kind: EventRootType
@@ -3697,10 +3697,10 @@ Types:
         - Name: c
           Offset: 1
           Expression:
-            Type: 202 GoChannelType chan bool
+            Type: 218 GoChannelType chan bool
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 75, index: 0, name: c}
+                  Variable: {subprogram: 69, index: 0, name: c}
                   Offset: 0
                   ByteSize: 0
     - __kind: EventRootType
@@ -3712,28 +3712,28 @@ Types:
         - Name: w
           Offset: 1
           Expression:
-            Type: 4 BaseType uint8
+            Type: 3 BaseType uint8
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 73, index: 0, name: w}
+                  Variable: {subprogram: 67, index: 0, name: w}
                   Offset: 0
                   ByteSize: 1
         - Name: x
           Offset: 2
           Expression:
-            Type: 4 BaseType uint8
+            Type: 3 BaseType uint8
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 73, index: 1, name: x}
+                  Variable: {subprogram: 67, index: 1, name: x}
                   Offset: 0
                   ByteSize: 1
         - Name: y
           Offset: 3
           Expression:
-            Type: 30 BaseType float32
+            Type: 18 BaseType float32
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 73, index: 2, name: y}
+                  Variable: {subprogram: 67, index: 2, name: y}
                   Offset: 0
                   ByteSize: 4
     - __kind: EventRootType
@@ -3745,10 +3745,10 @@ Types:
         - Name: t
           Offset: 1
           Expression:
-            Type: 207 PointerType *main.t
+            Type: 221 PointerType *main.t
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 83, index: 0, name: t}
+                  Variable: {subprogram: 77, index: 0, name: t}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
@@ -3760,19 +3760,19 @@ Types:
         - Name: xs
           Offset: 1
           Expression:
-            Type: 213 GoSliceHeaderType []main.structWithNoStrings
+            Type: 227 GoSliceHeaderType []main.structWithNoStrings
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 88, index: 0, name: xs}
+                  Variable: {subprogram: 82, index: 0, name: xs}
                   Offset: 0
                   ByteSize: 24
         - Name: a
           Offset: 25
           Expression:
-            Type: 1 BaseType int
+            Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 88, index: 1, name: a}
+                  Variable: {subprogram: 82, index: 1, name: a}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
@@ -3784,10 +3784,10 @@ Types:
         - Name: u
           Offset: 1
           Expression:
-            Type: 210 GoSliceHeaderType []uint
+            Type: 224 GoSliceHeaderType []uint
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 85, index: 0, name: u}
+                  Variable: {subprogram: 79, index: 0, name: u}
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
@@ -3799,10 +3799,10 @@ Types:
         - Name: x
           Offset: 1
           Expression:
-            Type: 8 GoStringHeaderType string
+            Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 102, index: 0, name: x}
+                  Variable: {subprogram: 96, index: 0, name: x}
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
@@ -3814,10 +3814,10 @@ Types:
         - Name: e
           Offset: 1
           Expression:
-            Type: 224 StructureType main.emptyStruct
+            Type: 237 StructureType main.emptyStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 104, index: 0, name: e}
+                  Variable: {subprogram: 98, index: 0, name: e}
                   Offset: 0
                   ByteSize: 0
     - __kind: EventRootType
@@ -3829,10 +3829,10 @@ Types:
         - Name: e
           Offset: 1
           Expression:
-            Type: 57 GoInterfaceType error
+            Type: 14 GoInterfaceType error
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 52, index: 0, name: e}
+                  Variable: {subprogram: 46, index: 0, name: e}
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
@@ -3844,10 +3844,10 @@ Types:
         - Name: e
           Offset: 1
           Expression:
-            Type: 44 PointerType *main.esotericHeap
+            Type: 61 PointerType *main.esotericHeap
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 43, index: 0, name: e}
+                  Variable: {subprogram: 37, index: 0, name: e}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
@@ -3859,10 +3859,10 @@ Types:
         - Name: e
           Offset: 1
           Expression:
-            Type: 39 StructureType main.esotericStack
+            Type: 56 StructureType main.esotericStack
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 42, index: 0, name: e}
+                  Variable: {subprogram: 36, index: 0, name: e}
                   Offset: 0
                   ByteSize: 64
     - __kind: EventRootType
@@ -3874,10 +3874,10 @@ Types:
         - Name: a
           Offset: 1
           Expression:
-            Type: 2 ArrayType [5]int
+            Type: 73 ArrayType [5]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 49, index: 0, name: a}
+                  Variable: {subprogram: 43, index: 0, name: a}
                   Offset: 0
                   ByteSize: 40
     - __kind: EventRootType
@@ -3889,10 +3889,10 @@ Types:
         - Name: x
           Offset: 1
           Expression:
-            Type: 1 BaseType int
+            Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 48, index: 0, name: x}
+                  Variable: {subprogram: 42, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
@@ -3904,10 +3904,10 @@ Types:
         - Name: x
           Offset: 1
           Expression:
-            Type: 1 BaseType int
+            Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 44, index: 0, name: x}
+                  Variable: {subprogram: 38, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
@@ -3919,10 +3919,10 @@ Types:
         - Name: x
           Offset: 1
           Expression:
-            Type: 1 BaseType int
+            Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 46, index: 0, name: x}
+                  Variable: {subprogram: 40, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
@@ -3937,19 +3937,19 @@ Types:
         - Name: x
           Offset: 1
           Expression:
-            Type: 1 BaseType int
+            Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 45, index: 0, name: x}
+                  Variable: {subprogram: 39, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
         - Name: y
           Offset: 9
           Expression:
-            Type: 1 BaseType int
+            Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 45, index: 1, name: y}
+                  Variable: {subprogram: 39, index: 1, name: y}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
@@ -3970,10 +3970,10 @@ Types:
         - Name: x
           Offset: 1
           Expression:
-            Type: 1 BaseType int
+            Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 1, index: 0, name: x}
+                  Variable: {subprogram: 99, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
@@ -3985,10 +3985,10 @@ Types:
         - Name: x
           Offset: 1
           Expression:
-            Type: 1 BaseType int
+            Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 5, index: 0, name: x}
+                  Variable: {subprogram: 103, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
@@ -4000,10 +4000,10 @@ Types:
         - Name: a
           Offset: 1
           Expression:
-            Type: 2 ArrayType [5]int
+            Type: 73 ArrayType [5]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 6, index: 0, name: a}
+                  Variable: {subprogram: 104, index: 0, name: a}
                   Offset: 0
                   ByteSize: 40
     - __kind: EventRootType
@@ -4015,10 +4015,10 @@ Types:
         - Name: x
           Offset: 1
           Expression:
-            Type: 15 ArrayType [2]int16
+            Type: 42 ArrayType [2]int16
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 13, index: 0, name: x}
+                  Variable: {subprogram: 7, index: 0, name: x}
                   Offset: 0
                   ByteSize: 4
     - __kind: EventRootType
@@ -4030,10 +4030,10 @@ Types:
         - Name: x
           Offset: 1
           Expression:
-            Type: 5 ArrayType [2]int32
+            Type: 37 ArrayType [2]int32
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 14, index: 0, name: x}
+                  Variable: {subprogram: 8, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
@@ -4045,10 +4045,10 @@ Types:
         - Name: x
           Offset: 1
           Expression:
-            Type: 17 ArrayType [2]int64
+            Type: 43 ArrayType [2]int64
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 15, index: 0, name: x}
+                  Variable: {subprogram: 9, index: 0, name: x}
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
@@ -4060,10 +4060,10 @@ Types:
         - Name: x
           Offset: 1
           Expression:
-            Type: 13 ArrayType [2]int8
+            Type: 41 ArrayType [2]int8
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 12, index: 0, name: x}
+                  Variable: {subprogram: 6, index: 0, name: x}
                   Offset: 0
                   ByteSize: 2
     - __kind: EventRootType
@@ -4075,10 +4075,10 @@ Types:
         - Name: x
           Offset: 1
           Expression:
-            Type: 12 ArrayType [2]int
+            Type: 40 ArrayType [2]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 11, index: 0, name: x}
+                  Variable: {subprogram: 5, index: 0, name: x}
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
@@ -4090,10 +4090,10 @@ Types:
         - Name: b
           Offset: 1
           Expression:
-            Type: 56 GoInterfaceType main.behavior
+            Type: 74 GoInterfaceType main.behavior
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 50, index: 0, name: b}
+                  Variable: {subprogram: 44, index: 0, name: b}
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
@@ -4105,10 +4105,10 @@ Types:
         - Name: a
           Offset: 1
           Expression:
-            Type: 144 StructureType main.node
+            Type: 160 StructureType main.node
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 77, index: 0, name: a}
+                  Variable: {subprogram: 71, index: 0, name: a}
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
@@ -4120,10 +4120,10 @@ Types:
         - Name: m
           Offset: 1
           Expression:
-            Type: 106 GoMapType map[[4]string][2]int
+            Type: 122 GoMapType map[[4]string][2]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 57, index: 0, name: m}
+                  Variable: {subprogram: 51, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
@@ -4135,10 +4135,10 @@ Types:
         - Name: m
           Offset: 1
           Expression:
-            Type: 120 GoMapType map[string][]main.structWithMap
+            Type: 136 GoMapType map[string][]main.structWithMap
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 63, index: 0, name: m}
+                  Variable: {subprogram: 57, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
@@ -4150,10 +4150,10 @@ Types:
         - Name: m
           Offset: 1
           Expression:
-            Type: 59 GoMapType map[int]int
+            Type: 76 GoMapType map[int]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 61, index: 0, name: m}
+                  Variable: {subprogram: 55, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
@@ -4165,10 +4165,10 @@ Types:
         - Name: m
           Offset: 1
           Expression:
-            Type: 191 GoMapType map[[4]int][4]int
+            Type: 207 GoMapType map[[4]int][4]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 72, index: 0, name: m}
+                  Variable: {subprogram: 66, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
@@ -4180,10 +4180,10 @@ Types:
         - Name: m
           Offset: 1
           Expression:
-            Type: 180 GoMapType map[[4]int]uint8
+            Type: 196 GoMapType map[[4]int]uint8
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 71, index: 0, name: m}
+                  Variable: {subprogram: 65, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
@@ -4195,10 +4195,10 @@ Types:
         - Name: redactMyEntries
           Offset: 1
           Expression:
-            Type: 120 GoMapType map[string][]main.structWithMap
+            Type: 136 GoMapType map[string][]main.structWithMap
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 62, index: 0, name: redactMyEntries}
+                  Variable: {subprogram: 56, index: 0, name: redactMyEntries}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
@@ -4210,10 +4210,10 @@ Types:
         - Name: m
           Offset: 1
           Expression:
-            Type: 168 GoMapType map[uint8][4]int
+            Type: 184 GoMapType map[uint8][4]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 70, index: 0, name: m}
+                  Variable: {subprogram: 64, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
@@ -4225,10 +4225,10 @@ Types:
         - Name: m
           Offset: 1
           Expression:
-            Type: 157 GoMapType map[uint8]uint8
+            Type: 173 GoMapType map[uint8]uint8
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 69, index: 0, name: m}
+                  Variable: {subprogram: 63, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
@@ -4240,10 +4240,10 @@ Types:
         - Name: m
           Offset: 1
           Expression:
-            Type: 83 GoMapType map[string]int
+            Type: 99 GoMapType map[string]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 55, index: 0, name: m}
+                  Variable: {subprogram: 49, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
@@ -4255,10 +4255,10 @@ Types:
         - Name: m
           Offset: 1
           Expression:
-            Type: 94 GoMapType map[string][]string
+            Type: 110 GoMapType map[string][]string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 56, index: 0, name: m}
+                  Variable: {subprogram: 50, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
@@ -4270,10 +4270,10 @@ Types:
         - Name: m
           Offset: 1
           Expression:
-            Type: 71 GoMapType map[string]main.nestedStruct
+            Type: 87 GoMapType map[string]main.nestedStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 54, index: 0, name: m}
+                  Variable: {subprogram: 48, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
@@ -4285,10 +4285,10 @@ Types:
         - Name: m
           Offset: 1
           Expression:
-            Type: 133 GoMapType map[bool]main.node
+            Type: 149 GoMapType map[bool]main.node
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 64, index: 0, name: m}
+                  Variable: {subprogram: 58, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
@@ -4300,10 +4300,10 @@ Types:
         - Name: m
           Offset: 1
           Expression:
-            Type: 157 GoMapType map[uint8]uint8
+            Type: 173 GoMapType map[uint8]uint8
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 68, index: 0, name: m}
+                  Variable: {subprogram: 62, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
@@ -4315,10 +4315,10 @@ Types:
         - Name: m
           Offset: 1
           Expression:
-            Type: 157 GoMapType map[uint8]uint8
+            Type: 173 GoMapType map[uint8]uint8
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 67, index: 0, name: m}
+                  Variable: {subprogram: 61, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
@@ -4330,10 +4330,10 @@ Types:
         - Name: redactMyEntries
           Offset: 1
           Expression:
-            Type: 146 GoMapType map[int]uint8
+            Type: 162 GoMapType map[int]uint8
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 66, index: 0, name: redactMyEntries}
+                  Variable: {subprogram: 60, index: 0, name: redactMyEntries}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
@@ -4345,10 +4345,10 @@ Types:
         - Name: m
           Offset: 1
           Expression:
-            Type: 146 GoMapType map[int]uint8
+            Type: 162 GoMapType map[int]uint8
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 65, index: 0, name: m}
+                  Variable: {subprogram: 59, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
@@ -4360,10 +4360,10 @@ Types:
         - Name: x
           Offset: 1
           Expression:
-            Type: 8 GoStringHeaderType string
+            Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 100, index: 0, name: x}
+                  Variable: {subprogram: 94, index: 0, name: x}
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
@@ -4375,46 +4375,46 @@ Types:
         - Name: a
           Offset: 1
           Expression:
-            Type: 11 BaseType bool
+            Type: 4 BaseType bool
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 74, index: 0, name: a}
+                  Variable: {subprogram: 68, index: 0, name: a}
                   Offset: 0
                   ByteSize: 1
         - Name: b
           Offset: 2
           Expression:
-            Type: 4 BaseType uint8
+            Type: 3 BaseType uint8
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 74, index: 1, name: b}
+                  Variable: {subprogram: 68, index: 1, name: b}
                   Offset: 0
                   ByteSize: 1
         - Name: c
           Offset: 3
           Expression:
-            Type: 6 BaseType int32
+            Type: 12 BaseType int32
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 74, index: 2, name: c}
+                  Variable: {subprogram: 68, index: 2, name: c}
                   Offset: 0
                   ByteSize: 4
         - Name: d
           Offset: 7
           Expression:
-            Type: 20 BaseType uint
+            Type: 10 BaseType uint
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 74, index: 3, name: d}
+                  Variable: {subprogram: 68, index: 3, name: d}
                   Offset: 0
                   ByteSize: 8
         - Name: e
           Offset: 15
           Expression:
-            Type: 8 GoStringHeaderType string
+            Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 74, index: 4, name: e}
+                  Variable: {subprogram: 68, index: 4, name: e}
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
@@ -4426,19 +4426,19 @@ Types:
         - Name: z
           Offset: 1
           Expression:
-            Type: 206 PointerType *bool
+            Type: 11 PointerType *bool
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 82, index: 0, name: z}
+                  Variable: {subprogram: 76, index: 0, name: z}
                   Offset: 0
                   ByteSize: 8
         - Name: a
           Offset: 9
           Expression:
-            Type: 20 BaseType uint
+            Type: 10 BaseType uint
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 82, index: 1, name: a}
+                  Variable: {subprogram: 76, index: 1, name: a}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
@@ -4450,19 +4450,19 @@ Types:
         - Name: xs
           Offset: 1
           Expression:
-            Type: 213 GoSliceHeaderType []main.structWithNoStrings
+            Type: 227 GoSliceHeaderType []main.structWithNoStrings
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 89, index: 0, name: xs}
+                  Variable: {subprogram: 83, index: 0, name: xs}
                   Offset: 0
                   ByteSize: 24
         - Name: a
           Offset: 25
           Expression:
-            Type: 1 BaseType int
+            Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 89, index: 1, name: a}
+                  Variable: {subprogram: 83, index: 1, name: a}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
@@ -4474,28 +4474,28 @@ Types:
         - Name: a
           Offset: 1
           Expression:
-            Type: 14 BaseType int8
+            Type: 17 BaseType int8
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 91, index: 0, name: a}
+                  Variable: {subprogram: 85, index: 0, name: a}
                   Offset: 0
                   ByteSize: 1
         - Name: s
           Offset: 2
           Expression:
-            Type: 216 GoSliceHeaderType []bool
+            Type: 230 GoSliceHeaderType []bool
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 91, index: 1, name: s}
+                  Variable: {subprogram: 85, index: 1, name: s}
                   Offset: 0
                   ByteSize: 24
         - Name: x
           Offset: 26
           Expression:
-            Type: 20 BaseType uint
+            Type: 10 BaseType uint
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 91, index: 2, name: x}
+                  Variable: {subprogram: 85, index: 2, name: x}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
@@ -4507,10 +4507,10 @@ Types:
         - Name: xs
           Offset: 1
           Expression:
-            Type: 217 GoSliceHeaderType []uint16
+            Type: 231 GoSliceHeaderType []uint16
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 92, index: 0, name: xs}
+                  Variable: {subprogram: 86, index: 0, name: xs}
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
@@ -4522,10 +4522,10 @@ Types:
         - Name: a
           Offset: 1
           Expression:
-            Type: 221 PointerType *main.oneStringStruct
+            Type: 234 PointerType *main.oneStringStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 99, index: 0, name: a}
+                  Variable: {subprogram: 93, index: 0, name: a}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
@@ -4537,10 +4537,10 @@ Types:
         - Name: a
           Offset: 1
           Expression:
-            Type: 145 PointerType *main.node
+            Type: 161 PointerType *main.node
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 78, index: 0, name: a}
+                  Variable: {subprogram: 72, index: 0, name: a}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
@@ -4552,10 +4552,10 @@ Types:
         - Name: m
           Offset: 1
           Expression:
-            Type: 119 PointerType *map[string]int
+            Type: 135 PointerType *map[string]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 60, index: 0, name: m}
+                  Variable: {subprogram: 54, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
@@ -4567,10 +4567,10 @@ Types:
         - Name: a
           Offset: 1
           Expression:
-            Type: 203 PointerType *main.structWithTwoValues
+            Type: 219 PointerType *main.structWithTwoValues
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 76, index: 0, name: a}
+                  Variable: {subprogram: 70, index: 0, name: a}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
@@ -4582,10 +4582,10 @@ Types:
         - Name: x
           Offset: 1
           Expression:
-            Type: 5 ArrayType [2]int32
+            Type: 37 ArrayType [2]int32
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 8, index: 0, name: x}
+                  Variable: {subprogram: 2, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
@@ -4597,10 +4597,10 @@ Types:
         - Name: x
           Offset: 1
           Expression:
-            Type: 11 BaseType bool
+            Type: 4 BaseType bool
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 27, index: 0, name: x}
+                  Variable: {subprogram: 21, index: 0, name: x}
                   Offset: 0
                   ByteSize: 1
     - __kind: EventRootType
@@ -4612,10 +4612,10 @@ Types:
         - Name: x
           Offset: 1
           Expression:
-            Type: 4 BaseType uint8
+            Type: 3 BaseType uint8
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 25, index: 0, name: x}
+                  Variable: {subprogram: 19, index: 0, name: x}
                   Offset: 0
                   ByteSize: 1
     - __kind: EventRootType
@@ -4627,10 +4627,10 @@ Types:
         - Name: x
           Offset: 1
           Expression:
-            Type: 30 BaseType float32
+            Type: 18 BaseType float32
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 38, index: 0, name: x}
+                  Variable: {subprogram: 32, index: 0, name: x}
                   Offset: 0
                   ByteSize: 4
     - __kind: EventRootType
@@ -4642,10 +4642,10 @@ Types:
         - Name: x
           Offset: 1
           Expression:
-            Type: 31 BaseType float64
+            Type: 16 BaseType float64
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 39, index: 0, name: x}
+                  Variable: {subprogram: 33, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
@@ -4657,10 +4657,10 @@ Types:
         - Name: x
           Offset: 1
           Expression:
-            Type: 16 BaseType int16
+            Type: 23 BaseType int16
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 30, index: 0, name: x}
+                  Variable: {subprogram: 24, index: 0, name: x}
                   Offset: 0
                   ByteSize: 2
     - __kind: EventRootType
@@ -4672,10 +4672,10 @@ Types:
         - Name: x
           Offset: 1
           Expression:
-            Type: 6 BaseType int32
+            Type: 12 BaseType int32
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 31, index: 0, name: x}
+                  Variable: {subprogram: 25, index: 0, name: x}
                   Offset: 0
                   ByteSize: 4
     - __kind: EventRootType
@@ -4687,10 +4687,10 @@ Types:
         - Name: x
           Offset: 1
           Expression:
-            Type: 18 BaseType int64
+            Type: 13 BaseType int64
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 32, index: 0, name: x}
+                  Variable: {subprogram: 26, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
@@ -4702,10 +4702,10 @@ Types:
         - Name: x
           Offset: 1
           Expression:
-            Type: 14 BaseType int8
+            Type: 17 BaseType int8
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 29, index: 0, name: x}
+                  Variable: {subprogram: 23, index: 0, name: x}
                   Offset: 0
                   ByteSize: 1
     - __kind: EventRootType
@@ -4717,10 +4717,10 @@ Types:
         - Name: x
           Offset: 1
           Expression:
-            Type: 1 BaseType int
+            Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 28, index: 0, name: x}
+                  Variable: {subprogram: 22, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
@@ -4732,10 +4732,10 @@ Types:
         - Name: x
           Offset: 1
           Expression:
-            Type: 6 BaseType int32
+            Type: 12 BaseType int32
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 26, index: 0, name: x}
+                  Variable: {subprogram: 20, index: 0, name: x}
                   Offset: 0
                   ByteSize: 4
     - __kind: EventRootType
@@ -4747,10 +4747,10 @@ Types:
         - Name: x
           Offset: 1
           Expression:
-            Type: 8 GoStringHeaderType string
+            Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 95, index: 0, name: x}
+                  Variable: {subprogram: 89, index: 0, name: x}
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
@@ -4762,10 +4762,10 @@ Types:
         - Name: x
           Offset: 1
           Expression:
-            Type: 22 BaseType uint16
+            Type: 6 BaseType uint16
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 35, index: 0, name: x}
+                  Variable: {subprogram: 29, index: 0, name: x}
                   Offset: 0
                   ByteSize: 2
     - __kind: EventRootType
@@ -4777,10 +4777,10 @@ Types:
         - Name: x
           Offset: 1
           Expression:
-            Type: 24 BaseType uint32
+            Type: 2 BaseType uint32
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 36, index: 0, name: x}
+                  Variable: {subprogram: 30, index: 0, name: x}
                   Offset: 0
                   ByteSize: 4
     - __kind: EventRootType
@@ -4792,10 +4792,10 @@ Types:
         - Name: x
           Offset: 1
           Expression:
-            Type: 26 BaseType uint64
+            Type: 8 BaseType uint64
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 37, index: 0, name: x}
+                  Variable: {subprogram: 31, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
@@ -4807,10 +4807,10 @@ Types:
         - Name: x
           Offset: 1
           Expression:
-            Type: 4 BaseType uint8
+            Type: 3 BaseType uint8
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 34, index: 0, name: x}
+                  Variable: {subprogram: 28, index: 0, name: x}
                   Offset: 0
                   ByteSize: 1
     - __kind: EventRootType
@@ -4822,10 +4822,10 @@ Types:
         - Name: x
           Offset: 1
           Expression:
-            Type: 20 BaseType uint
+            Type: 10 BaseType uint
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 33, index: 0, name: x}
+                  Variable: {subprogram: 27, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
@@ -4837,10 +4837,10 @@ Types:
         - Name: u
           Offset: 1
           Expression:
-            Type: 211 GoSliceHeaderType [][]uint
+            Type: 225 GoSliceHeaderType [][]uint
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 86, index: 0, name: u}
+                  Variable: {subprogram: 80, index: 0, name: u}
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
@@ -4852,10 +4852,10 @@ Types:
         - Name: m
           Offset: 1
           Expression:
-            Type: 83 GoMapType map[string]int
+            Type: 99 GoMapType map[string]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 58, index: 0, name: m}
+                  Variable: {subprogram: 52, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
@@ -4867,10 +4867,10 @@ Types:
         - Name: x
           Offset: 1
           Expression:
-            Type: 7 ArrayType [2]string
+            Type: 38 ArrayType [2]string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 9, index: 0, name: x}
+                  Variable: {subprogram: 3, index: 0, name: x}
                   Offset: 0
                   ByteSize: 32
     - __kind: EventRootType
@@ -4882,10 +4882,10 @@ Types:
         - Name: z
           Offset: 1
           Expression:
-            Type: 36 PointerType *string
+            Type: 22 PointerType *string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 81, index: 0, name: z}
+                  Variable: {subprogram: 75, index: 0, name: z}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
@@ -4897,10 +4897,10 @@ Types:
         - Name: s
           Offset: 1
           Expression:
-            Type: 105 GoSliceHeaderType []string
+            Type: 121 GoSliceHeaderType []string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 90, index: 0, name: s}
+                  Variable: {subprogram: 84, index: 0, name: s}
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
@@ -4912,19 +4912,19 @@ Types:
         - Name: xs
           Offset: 1
           Expression:
-            Type: 213 GoSliceHeaderType []main.structWithNoStrings
+            Type: 227 GoSliceHeaderType []main.structWithNoStrings
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 87, index: 0, name: xs}
+                  Variable: {subprogram: 81, index: 0, name: xs}
                   Offset: 0
                   ByteSize: 24
         - Name: a
           Offset: 25
           Expression:
-            Type: 1 BaseType int
+            Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 87, index: 1, name: a}
+                  Variable: {subprogram: 81, index: 1, name: a}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
@@ -4936,10 +4936,10 @@ Types:
         - Name: s
           Offset: 1
           Expression:
-            Type: 58 StructureType main.structWithMap
+            Type: 75 StructureType main.structWithMap
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 53, index: 0, name: s}
+                  Variable: {subprogram: 47, index: 0, name: s}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
@@ -4951,10 +4951,10 @@ Types:
         - Name: x
           Offset: 1
           Expression:
-            Type: 223 StructureType main.aStruct
+            Type: 236 StructureType main.aStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 103, index: 0, name: x}
+                  Variable: {subprogram: 97, index: 0, name: x}
                   Offset: 0
                   ByteSize: 56
     - __kind: EventRootType
@@ -4966,10 +4966,10 @@ Types:
         - Name: a
           Offset: 1
           Expression:
-            Type: 220 PointerType *main.threeStringStruct
+            Type: 233 PointerType *main.threeStringStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 98, index: 0, name: a}
+                  Variable: {subprogram: 92, index: 0, name: a}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
@@ -4981,10 +4981,10 @@ Types:
         - Name: a
           Offset: 1
           Expression:
-            Type: 219 StructureType main.threeStringStruct
+            Type: 232 StructureType main.threeStringStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 97, index: 0, name: a}
+                  Variable: {subprogram: 91, index: 0, name: a}
                   Offset: 0
                   ByteSize: 48
     - __kind: EventRootType
@@ -4996,28 +4996,28 @@ Types:
         - Name: x
           Offset: 1
           Expression:
-            Type: 8 GoStringHeaderType string
+            Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 96, index: 0, name: x}
+                  Variable: {subprogram: 90, index: 0, name: x}
                   Offset: 0
                   ByteSize: 16
         - Name: y
           Offset: 17
           Expression:
-            Type: 8 GoStringHeaderType string
+            Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 96, index: 1, name: y}
+                  Variable: {subprogram: 90, index: 1, name: y}
                   Offset: 0
                   ByteSize: 16
         - Name: z
           Offset: 33
           Expression:
-            Type: 8 GoStringHeaderType string
+            Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 96, index: 2, name: z}
+                  Variable: {subprogram: 90, index: 2, name: z}
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
@@ -5029,10 +5029,10 @@ Types:
         - Name: x
           Offset: 1
           Expression:
-            Type: 32 BaseType main.typeAlias
+            Type: 51 BaseType main.typeAlias
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 40, index: 0, name: x}
+                  Variable: {subprogram: 34, index: 0, name: x}
                   Offset: 0
                   ByteSize: 2
     - __kind: EventRootType
@@ -5044,10 +5044,10 @@ Types:
         - Name: x
           Offset: 1
           Expression:
-            Type: 21 ArrayType [2]uint16
+            Type: 45 ArrayType [2]uint16
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 18, index: 0, name: x}
+                  Variable: {subprogram: 12, index: 0, name: x}
                   Offset: 0
                   ByteSize: 4
     - __kind: EventRootType
@@ -5059,10 +5059,10 @@ Types:
         - Name: x
           Offset: 1
           Expression:
-            Type: 23 ArrayType [2]uint32
+            Type: 46 ArrayType [2]uint32
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 19, index: 0, name: x}
+                  Variable: {subprogram: 13, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
@@ -5074,10 +5074,10 @@ Types:
         - Name: x
           Offset: 1
           Expression:
-            Type: 25 ArrayType [2]uint64
+            Type: 47 ArrayType [2]uint64
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 20, index: 0, name: x}
+                  Variable: {subprogram: 14, index: 0, name: x}
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
@@ -5089,10 +5089,10 @@ Types:
         - Name: x
           Offset: 1
           Expression:
-            Type: 3 ArrayType [2]uint8
+            Type: 36 ArrayType [2]uint8
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 17, index: 0, name: x}
+                  Variable: {subprogram: 11, index: 0, name: x}
                   Offset: 0
                   ByteSize: 2
     - __kind: EventRootType
@@ -5104,10 +5104,10 @@ Types:
         - Name: x
           Offset: 1
           Expression:
-            Type: 19 ArrayType [2]uint
+            Type: 44 ArrayType [2]uint
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 16, index: 0, name: x}
+                  Variable: {subprogram: 10, index: 0, name: x}
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
@@ -5119,10 +5119,10 @@ Types:
         - Name: x
           Offset: 1
           Expression:
-            Type: 205 PointerType *uint
+            Type: 34 PointerType *uint
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 80, index: 0, name: x}
+                  Variable: {subprogram: 74, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
@@ -5134,10 +5134,10 @@ Types:
         - Name: u
           Offset: 1
           Expression:
-            Type: 210 GoSliceHeaderType []uint
+            Type: 224 GoSliceHeaderType []uint
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 84, index: 0, name: u}
+                  Variable: {subprogram: 78, index: 0, name: u}
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
@@ -5149,10 +5149,10 @@ Types:
         - Name: x
           Offset: 1
           Expression:
-            Type: 8 GoStringHeaderType string
+            Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 101, index: 0, name: x}
+                  Variable: {subprogram: 95, index: 0, name: x}
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
@@ -5164,10 +5164,10 @@ Types:
         - Name: x
           Offset: 1
           Expression:
-            Type: 38 VoidPointerType unsafe.Pointer
+            Type: 15 VoidPointerType unsafe.Pointer
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 79, index: 0, name: x}
+                  Variable: {subprogram: 73, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
@@ -5179,10 +5179,10 @@ Types:
         - Name: a
           Offset: 1
           Expression:
-            Type: 29 ArrayType [100]uint
+            Type: 50 ArrayType [100]uint
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 24, index: 0, name: a}
+                  Variable: {subprogram: 18, index: 0, name: a}
                   Offset: 0
                   ByteSize: 800
     - __kind: EventRootType
@@ -5194,173 +5194,173 @@ Types:
         - Name: xs
           Offset: 1
           Expression:
-            Type: 210 GoSliceHeaderType []uint
+            Type: 224 GoSliceHeaderType []uint
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 93, index: 0, name: xs}
+                  Variable: {subprogram: 87, index: 0, name: xs}
                   Offset: 0
                   ByteSize: 24
     - __kind: ArrayType
-      ID: 29
+      ID: 50
       Name: '[100]uint'
       ByteSize: 800
       GoKind: 17
       Count: 100
       HasCount: true
-      Element: 20 BaseType uint
+      Element: 10 BaseType uint
     - __kind: ArrayType
-      ID: 28
+      ID: 49
       Name: '[2][2][2]int'
       ByteSize: 64
       GoKind: 17
       Count: 2
       HasCount: true
-      Element: 27 ArrayType [2][2]int
+      Element: 48 ArrayType [2][2]int
     - __kind: ArrayType
-      ID: 27
+      ID: 48
       Name: '[2][2]int'
       ByteSize: 32
       GoKind: 17
       Count: 2
       HasCount: true
-      Element: 12 ArrayType [2]int
+      Element: 40 ArrayType [2]int
     - __kind: ArrayType
-      ID: 10
+      ID: 39
       Name: '[2]bool'
       ByteSize: 2
       GoKind: 17
       Count: 2
       HasCount: true
-      Element: 11 BaseType bool
+      Element: 4 BaseType bool
     - __kind: ArrayType
-      ID: 12
+      ID: 40
       Name: '[2]int'
       ByteSize: 16
       GoRuntimeType: 676800
       GoKind: 17
       Count: 2
       HasCount: true
-      Element: 1 BaseType int
+      Element: 7 BaseType int
     - __kind: ArrayType
-      ID: 15
+      ID: 42
       Name: '[2]int16'
       ByteSize: 4
       GoKind: 17
       Count: 2
       HasCount: true
-      Element: 16 BaseType int16
+      Element: 23 BaseType int16
     - __kind: ArrayType
-      ID: 5
+      ID: 37
       Name: '[2]int32'
       ByteSize: 8
       GoRuntimeType: 678144
       GoKind: 17
       Count: 2
       HasCount: true
-      Element: 6 BaseType int32
+      Element: 12 BaseType int32
     - __kind: ArrayType
-      ID: 17
+      ID: 43
       Name: '[2]int64'
       ByteSize: 16
       GoKind: 17
       Count: 2
       HasCount: true
-      Element: 18 BaseType int64
+      Element: 13 BaseType int64
     - __kind: ArrayType
-      ID: 13
+      ID: 41
       Name: '[2]int8'
       ByteSize: 2
       GoKind: 17
       Count: 2
       HasCount: true
-      Element: 14 BaseType int8
+      Element: 17 BaseType int8
     - __kind: ArrayType
-      ID: 118
+      ID: 134
       Name: '[2]map[string]int'
       ByteSize: 16
       GoKind: 17
       Count: 2
       HasCount: true
-      Element: 83 GoMapType map[string]int
+      Element: 99 GoMapType map[string]int
     - __kind: ArrayType
-      ID: 7
+      ID: 38
       Name: '[2]string'
       ByteSize: 32
       GoRuntimeType: 678240
       GoKind: 17
       Count: 2
       HasCount: true
-      Element: 8 GoStringHeaderType string
+      Element: 9 GoStringHeaderType string
     - __kind: ArrayType
-      ID: 19
+      ID: 44
       Name: '[2]uint'
       ByteSize: 16
       GoKind: 17
       Count: 2
       HasCount: true
-      Element: 20 BaseType uint
+      Element: 10 BaseType uint
     - __kind: ArrayType
-      ID: 21
+      ID: 45
       Name: '[2]uint16'
       ByteSize: 4
       GoKind: 17
       Count: 2
       HasCount: true
-      Element: 22 BaseType uint16
+      Element: 6 BaseType uint16
     - __kind: ArrayType
-      ID: 23
+      ID: 46
       Name: '[2]uint32'
       ByteSize: 8
       GoKind: 17
       Count: 2
       HasCount: true
-      Element: 24 BaseType uint32
+      Element: 2 BaseType uint32
     - __kind: ArrayType
-      ID: 25
+      ID: 47
       Name: '[2]uint64'
       ByteSize: 16
       GoRuntimeType: 678336
       GoKind: 17
       Count: 2
       HasCount: true
-      Element: 26 BaseType uint64
+      Element: 8 BaseType uint64
     - __kind: ArrayType
-      ID: 3
+      ID: 36
       Name: '[2]uint8'
       ByteSize: 2
       GoRuntimeType: 678048
       GoKind: 17
       Count: 2
       HasCount: true
-      Element: 4 BaseType uint8
+      Element: 3 BaseType uint8
     - __kind: ArrayType
-      ID: 179
+      ID: 195
       Name: '[4]int'
       ByteSize: 32
       GoRuntimeType: 676416
       GoKind: 17
       Count: 4
       HasCount: true
-      Element: 1 BaseType int
+      Element: 7 BaseType int
     - __kind: ArrayType
-      ID: 117
+      ID: 133
       Name: '[4]string'
       ByteSize: 64
       GoRuntimeType: 676704
       GoKind: 17
       Count: 4
       HasCount: true
-      Element: 8 GoStringHeaderType string
+      Element: 9 GoStringHeaderType string
     - __kind: ArrayType
-      ID: 2
+      ID: 73
       Name: '[5]int'
       ByteSize: 40
       GoKind: 17
       Count: 5
       HasCount: true
-      Element: 1 BaseType int
+      Element: 7 BaseType int
     - __kind: GoSliceHeaderType
-      ID: 34
+      ID: 53
       Name: '[]*string'
       ByteSize: 24
       GoRuntimeType: 473376
@@ -5368,102 +5368,102 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 35 PointerType **string
+          Type: 54 PointerType **string
         - Name: len
           Offset: 8
-          Type: 1 BaseType int
+          Type: 7 BaseType int
         - Name: cap
           Offset: 16
-          Type: 1 BaseType int
+          Type: 7 BaseType int
       Data: 240 GoSliceDataType []*string.array
     - __kind: GoSliceDataType
       ID: 240
       Name: '[]*string.array'
       ByteSize: 2048
-      Element: 36 PointerType *string
+      Element: 22 PointerType *string
     - __kind: GoSliceDataType
       ID: 268
       Name: '[]*table<[4]int,[4]int>.array'
       ByteSize: 8192
-      Element: 195 PointerType *table<[4]int,[4]int>
+      Element: 211 PointerType *table<[4]int,[4]int>
     - __kind: GoSliceDataType
       ID: 266
       Name: '[]*table<[4]int,uint8>.array'
       ByteSize: 8192
-      Element: 184 PointerType *table<[4]int,uint8>
+      Element: 200 PointerType *table<[4]int,uint8>
     - __kind: GoSliceDataType
       ID: 252
       Name: '[]*table<[4]string,[2]int>.array'
       ByteSize: 8192
-      Element: 110 PointerType *table<[4]string,[2]int>
+      Element: 126 PointerType *table<[4]string,[2]int>
     - __kind: GoSliceDataType
       ID: 258
       Name: '[]*table<bool,main.node>.array'
       ByteSize: 8192
-      Element: 137 PointerType *table<bool,main.node>
+      Element: 153 PointerType *table<bool,main.node>
     - __kind: GoSliceDataType
       ID: 242
       Name: '[]*table<int,int>.array'
       ByteSize: 8192
-      Element: 64 PointerType *table<int,int>
+      Element: 80 PointerType *table<int,int>
     - __kind: GoSliceDataType
       ID: 260
       Name: '[]*table<int,uint8>.array'
       ByteSize: 8192
-      Element: 150 PointerType *table<int,uint8>
+      Element: 166 PointerType *table<int,uint8>
     - __kind: GoSliceDataType
       ID: 254
       Name: '[]*table<string,[]main.structWithMap>.array'
       ByteSize: 8192
-      Element: 124 PointerType *table<string,[]main.structWithMap>
+      Element: 140 PointerType *table<string,[]main.structWithMap>
     - __kind: GoSliceDataType
       ID: 248
       Name: '[]*table<string,[]string>.array'
       ByteSize: 8192
-      Element: 98 PointerType *table<string,[]string>
+      Element: 114 PointerType *table<string,[]string>
     - __kind: GoSliceDataType
       ID: 246
       Name: '[]*table<string,int>.array'
       ByteSize: 8192
-      Element: 87 PointerType *table<string,int>
+      Element: 103 PointerType *table<string,int>
     - __kind: GoSliceDataType
       ID: 244
       Name: '[]*table<string,main.nestedStruct>.array'
       ByteSize: 8192
-      Element: 75 PointerType *table<string,main.nestedStruct>
+      Element: 91 PointerType *table<string,main.nestedStruct>
     - __kind: GoSliceDataType
       ID: 264
       Name: '[]*table<uint8,[4]int>.array'
       ByteSize: 8192
-      Element: 172 PointerType *table<uint8,[4]int>
+      Element: 188 PointerType *table<uint8,[4]int>
     - __kind: GoSliceDataType
       ID: 262
       Name: '[]*table<uint8,uint8>.array'
       ByteSize: 8192
-      Element: 161 PointerType *table<uint8,uint8>
+      Element: 177 PointerType *table<uint8,uint8>
     - __kind: GoSliceHeaderType
-      ID: 211
+      ID: 225
       Name: '[][]uint'
       ByteSize: 24
       GoKind: 23
       RawFields:
         - Name: array
           Offset: 0
-          Type: 212 PointerType *[]uint
+          Type: 226 PointerType *[]uint
         - Name: len
           Offset: 8
-          Type: 1 BaseType int
+          Type: 7 BaseType int
         - Name: cap
           Offset: 16
-          Type: 1 BaseType int
+          Type: 7 BaseType int
       Data: 274 GoSliceDataType [][]uint.array
     - __kind: GoSliceDataType
       ID: 274
       Name: '[][]uint.array'
       ByteSize: 2048
-      Element: 210 GoSliceHeaderType []uint
+      Element: 224 GoSliceHeaderType []uint
     - __kind: GoSliceHeaderType
-      ID: 216
+      ID: 230
       Name: '[]bool'
       ByteSize: 24
       GoRuntimeType: 481696
@@ -5471,21 +5471,21 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 206 PointerType *bool
+          Type: 11 PointerType *bool
         - Name: len
           Offset: 8
-          Type: 1 BaseType int
+          Type: 7 BaseType int
         - Name: cap
           Offset: 16
-          Type: 1 BaseType int
+          Type: 7 BaseType int
       Data: 278 GoSliceDataType []bool.array
     - __kind: GoSliceDataType
       ID: 278
       Name: '[]bool.array'
       ByteSize: 2048
-      Element: 11 BaseType bool
+      Element: 4 BaseType bool
     - __kind: GoSliceHeaderType
-      ID: 131
+      ID: 147
       Name: '[]main.structWithMap'
       ByteSize: 24
       GoRuntimeType: 472608
@@ -5493,102 +5493,102 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 132 PointerType *main.structWithMap
+          Type: 148 PointerType *main.structWithMap
         - Name: len
           Offset: 8
-          Type: 1 BaseType int
+          Type: 7 BaseType int
         - Name: cap
           Offset: 16
-          Type: 1 BaseType int
+          Type: 7 BaseType int
       Data: 256 GoSliceDataType []main.structWithMap.array
     - __kind: GoSliceDataType
       ID: 256
       Name: '[]main.structWithMap.array'
       ByteSize: 2048
-      Element: 58 StructureType main.structWithMap
+      Element: 75 StructureType main.structWithMap
     - __kind: GoSliceHeaderType
-      ID: 213
+      ID: 227
       Name: '[]main.structWithNoStrings'
       ByteSize: 24
       GoKind: 23
       RawFields:
         - Name: array
           Offset: 0
-          Type: 214 PointerType *main.structWithNoStrings
+          Type: 228 PointerType *main.structWithNoStrings
         - Name: len
           Offset: 8
-          Type: 1 BaseType int
+          Type: 7 BaseType int
         - Name: cap
           Offset: 16
-          Type: 1 BaseType int
+          Type: 7 BaseType int
       Data: 276 GoSliceDataType []main.structWithNoStrings.array
     - __kind: GoSliceDataType
       ID: 276
       Name: '[]main.structWithNoStrings.array'
       ByteSize: 2048
-      Element: 215 StructureType main.structWithNoStrings
+      Element: 229 StructureType main.structWithNoStrings
     - __kind: GoSliceDataType
       ID: 269
       Name: '[]noalg.map.group[[4]int][4]int.array'
       ByteSize: 2048
-      Element: 199 StructureType noalg.map.group[[4]int][4]int
+      Element: 215 StructureType noalg.map.group[[4]int][4]int
     - __kind: GoSliceDataType
       ID: 267
       Name: '[]noalg.map.group[[4]int]uint8.array'
       ByteSize: 2048
-      Element: 188 StructureType noalg.map.group[[4]int]uint8
+      Element: 204 StructureType noalg.map.group[[4]int]uint8
     - __kind: GoSliceDataType
       ID: 253
       Name: '[]noalg.map.group[[4]string][2]int.array'
       ByteSize: 2048
-      Element: 114 StructureType noalg.map.group[[4]string][2]int
+      Element: 130 StructureType noalg.map.group[[4]string][2]int
     - __kind: GoSliceDataType
       ID: 259
       Name: '[]noalg.map.group[bool]main.node.array'
       ByteSize: 2048
-      Element: 141 StructureType noalg.map.group[bool]main.node
+      Element: 157 StructureType noalg.map.group[bool]main.node
     - __kind: GoSliceDataType
       ID: 243
       Name: '[]noalg.map.group[int]int.array'
       ByteSize: 2048
-      Element: 68 StructureType noalg.map.group[int]int
+      Element: 84 StructureType noalg.map.group[int]int
     - __kind: GoSliceDataType
       ID: 261
       Name: '[]noalg.map.group[int]uint8.array'
       ByteSize: 2048
-      Element: 154 StructureType noalg.map.group[int]uint8
+      Element: 170 StructureType noalg.map.group[int]uint8
     - __kind: GoSliceDataType
       ID: 255
       Name: '[]noalg.map.group[string][]main.structWithMap.array'
       ByteSize: 2048
-      Element: 128 StructureType noalg.map.group[string][]main.structWithMap
+      Element: 144 StructureType noalg.map.group[string][]main.structWithMap
     - __kind: GoSliceDataType
       ID: 249
       Name: '[]noalg.map.group[string][]string.array'
       ByteSize: 2048
-      Element: 102 StructureType noalg.map.group[string][]string
+      Element: 118 StructureType noalg.map.group[string][]string
     - __kind: GoSliceDataType
       ID: 247
       Name: '[]noalg.map.group[string]int.array'
       ByteSize: 2048
-      Element: 91 StructureType noalg.map.group[string]int
+      Element: 107 StructureType noalg.map.group[string]int
     - __kind: GoSliceDataType
       ID: 245
       Name: '[]noalg.map.group[string]main.nestedStruct.array'
       ByteSize: 2048
-      Element: 79 StructureType noalg.map.group[string]main.nestedStruct
+      Element: 95 StructureType noalg.map.group[string]main.nestedStruct
     - __kind: GoSliceDataType
       ID: 265
       Name: '[]noalg.map.group[uint8][4]int.array'
       ByteSize: 2048
-      Element: 176 StructureType noalg.map.group[uint8][4]int
+      Element: 192 StructureType noalg.map.group[uint8][4]int
     - __kind: GoSliceDataType
       ID: 263
       Name: '[]noalg.map.group[uint8]uint8.array'
       ByteSize: 2048
-      Element: 165 StructureType noalg.map.group[uint8]uint8
+      Element: 181 StructureType noalg.map.group[uint8]uint8
     - __kind: GoSliceHeaderType
-      ID: 105
+      ID: 121
       Name: '[]string'
       ByteSize: 24
       GoRuntimeType: 481824
@@ -5596,21 +5596,21 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 36 PointerType *string
+          Type: 22 PointerType *string
         - Name: len
           Offset: 8
-          Type: 1 BaseType int
+          Type: 7 BaseType int
         - Name: cap
           Offset: 16
-          Type: 1 BaseType int
+          Type: 7 BaseType int
       Data: 250 GoSliceDataType []string.array
     - __kind: GoSliceDataType
       ID: 250
       Name: '[]string.array'
       ByteSize: 2048
-      Element: 8 GoStringHeaderType string
+      Element: 9 GoStringHeaderType string
     - __kind: GoSliceHeaderType
-      ID: 210
+      ID: 224
       Name: '[]uint'
       ByteSize: 24
       GoRuntimeType: 481312
@@ -5618,21 +5618,21 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 205 PointerType *uint
+          Type: 34 PointerType *uint
         - Name: len
           Offset: 8
-          Type: 1 BaseType int
+          Type: 7 BaseType int
         - Name: cap
           Offset: 16
-          Type: 1 BaseType int
+          Type: 7 BaseType int
       Data: 272 GoSliceDataType []uint.array
     - __kind: GoSliceDataType
       ID: 272
       Name: '[]uint.array'
       ByteSize: 2048
-      Element: 20 BaseType uint
+      Element: 10 BaseType uint
     - __kind: GoSliceHeaderType
-      ID: 217
+      ID: 231
       Name: '[]uint16'
       ByteSize: 24
       GoRuntimeType: 480672
@@ -5640,49 +5640,49 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 218 PointerType *uint16
+          Type: 30 PointerType *uint16
         - Name: len
           Offset: 8
-          Type: 1 BaseType int
+          Type: 7 BaseType int
         - Name: cap
           Offset: 16
-          Type: 1 BaseType int
+          Type: 7 BaseType int
       Data: 280 GoSliceDataType []uint16.array
     - __kind: GoSliceDataType
       ID: 280
       Name: '[]uint16.array'
       ByteSize: 2048
-      Element: 22 BaseType uint16
+      Element: 6 BaseType uint16
     - __kind: BaseType
-      ID: 11
+      ID: 4
       Name: bool
       ByteSize: 1
       GoRuntimeType: 579584
       GoKind: 1
     - __kind: GoChannelType
-      ID: 202
+      ID: 218
       Name: chan bool
       GoRuntimeType: 590912
       GoKind: 18
     - __kind: GoChannelType
-      ID: 40
+      ID: 57
       Name: chan struct {}
       GoRuntimeType: 589824
       GoKind: 18
     - __kind: BaseType
-      ID: 229
+      ID: 25
       Name: complex128
       ByteSize: 16
       GoRuntimeType: 579392
       GoKind: 16
     - __kind: BaseType
-      ID: 228
+      ID: 24
       Name: complex64
       ByteSize: 8
       GoRuntimeType: 579328
       GoKind: 15
     - __kind: GoInterfaceType
-      ID: 57
+      ID: 14
       Name: error
       ByteSize: 16
       GoRuntimeType: 1.02e+06
@@ -5690,228 +5690,228 @@ Types:
       RawFields:
         - Name: tab
           Offset: 0
-          Type: 38 VoidPointerType unsafe.Pointer
+          Type: 15 VoidPointerType unsafe.Pointer
         - Name: data
           Offset: 8
-          Type: 38 VoidPointerType unsafe.Pointer
+          Type: 15 VoidPointerType unsafe.Pointer
     - __kind: BaseType
-      ID: 30
+      ID: 18
       Name: float32
       ByteSize: 4
       GoRuntimeType: 579456
       GoKind: 13
     - __kind: BaseType
-      ID: 31
+      ID: 16
       Name: float64
       ByteSize: 8
       GoRuntimeType: 579520
       GoKind: 14
     - __kind: GoSubroutineType
-      ID: 43
+      ID: 60
       Name: func()
       ByteSize: 8
       GoRuntimeType: 471584
       GoKind: 19
     - __kind: GoSwissMapGroupsType
-      ID: 197
+      ID: 213
       Name: groupReference<[4]int,[4]int>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 198 PointerType *noalg.map.group[[4]int][4]int
+          Type: 214 PointerType *noalg.map.group[[4]int][4]int
         - Name: lengthMask
           Offset: 8
-          Type: 26 BaseType uint64
-      GroupType: 199 StructureType noalg.map.group[[4]int][4]int
+          Type: 8 BaseType uint64
+      GroupType: 215 StructureType noalg.map.group[[4]int][4]int
       GroupSliceType: 269 GoSliceDataType []noalg.map.group[[4]int][4]int.array
     - __kind: GoSwissMapGroupsType
-      ID: 186
+      ID: 202
       Name: groupReference<[4]int,uint8>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 187 PointerType *noalg.map.group[[4]int]uint8
+          Type: 203 PointerType *noalg.map.group[[4]int]uint8
         - Name: lengthMask
           Offset: 8
-          Type: 26 BaseType uint64
-      GroupType: 188 StructureType noalg.map.group[[4]int]uint8
+          Type: 8 BaseType uint64
+      GroupType: 204 StructureType noalg.map.group[[4]int]uint8
       GroupSliceType: 267 GoSliceDataType []noalg.map.group[[4]int]uint8.array
     - __kind: GoSwissMapGroupsType
-      ID: 112
+      ID: 128
       Name: groupReference<[4]string,[2]int>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 113 PointerType *noalg.map.group[[4]string][2]int
+          Type: 129 PointerType *noalg.map.group[[4]string][2]int
         - Name: lengthMask
           Offset: 8
-          Type: 26 BaseType uint64
-      GroupType: 114 StructureType noalg.map.group[[4]string][2]int
+          Type: 8 BaseType uint64
+      GroupType: 130 StructureType noalg.map.group[[4]string][2]int
       GroupSliceType: 253 GoSliceDataType []noalg.map.group[[4]string][2]int.array
     - __kind: GoSwissMapGroupsType
-      ID: 139
+      ID: 155
       Name: groupReference<bool,main.node>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 140 PointerType *noalg.map.group[bool]main.node
+          Type: 156 PointerType *noalg.map.group[bool]main.node
         - Name: lengthMask
           Offset: 8
-          Type: 26 BaseType uint64
-      GroupType: 141 StructureType noalg.map.group[bool]main.node
+          Type: 8 BaseType uint64
+      GroupType: 157 StructureType noalg.map.group[bool]main.node
       GroupSliceType: 259 GoSliceDataType []noalg.map.group[bool]main.node.array
     - __kind: GoSwissMapGroupsType
-      ID: 66
+      ID: 82
       Name: groupReference<int,int>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 67 PointerType *noalg.map.group[int]int
+          Type: 83 PointerType *noalg.map.group[int]int
         - Name: lengthMask
           Offset: 8
-          Type: 26 BaseType uint64
-      GroupType: 68 StructureType noalg.map.group[int]int
+          Type: 8 BaseType uint64
+      GroupType: 84 StructureType noalg.map.group[int]int
       GroupSliceType: 243 GoSliceDataType []noalg.map.group[int]int.array
     - __kind: GoSwissMapGroupsType
-      ID: 152
+      ID: 168
       Name: groupReference<int,uint8>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 153 PointerType *noalg.map.group[int]uint8
+          Type: 169 PointerType *noalg.map.group[int]uint8
         - Name: lengthMask
           Offset: 8
-          Type: 26 BaseType uint64
-      GroupType: 154 StructureType noalg.map.group[int]uint8
+          Type: 8 BaseType uint64
+      GroupType: 170 StructureType noalg.map.group[int]uint8
       GroupSliceType: 261 GoSliceDataType []noalg.map.group[int]uint8.array
     - __kind: GoSwissMapGroupsType
-      ID: 126
+      ID: 142
       Name: groupReference<string,[]main.structWithMap>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 127 PointerType *noalg.map.group[string][]main.structWithMap
+          Type: 143 PointerType *noalg.map.group[string][]main.structWithMap
         - Name: lengthMask
           Offset: 8
-          Type: 26 BaseType uint64
-      GroupType: 128 StructureType noalg.map.group[string][]main.structWithMap
+          Type: 8 BaseType uint64
+      GroupType: 144 StructureType noalg.map.group[string][]main.structWithMap
       GroupSliceType: 255 GoSliceDataType []noalg.map.group[string][]main.structWithMap.array
     - __kind: GoSwissMapGroupsType
-      ID: 100
+      ID: 116
       Name: groupReference<string,[]string>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 101 PointerType *noalg.map.group[string][]string
+          Type: 117 PointerType *noalg.map.group[string][]string
         - Name: lengthMask
           Offset: 8
-          Type: 26 BaseType uint64
-      GroupType: 102 StructureType noalg.map.group[string][]string
+          Type: 8 BaseType uint64
+      GroupType: 118 StructureType noalg.map.group[string][]string
       GroupSliceType: 249 GoSliceDataType []noalg.map.group[string][]string.array
     - __kind: GoSwissMapGroupsType
-      ID: 89
+      ID: 105
       Name: groupReference<string,int>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 90 PointerType *noalg.map.group[string]int
+          Type: 106 PointerType *noalg.map.group[string]int
         - Name: lengthMask
           Offset: 8
-          Type: 26 BaseType uint64
-      GroupType: 91 StructureType noalg.map.group[string]int
+          Type: 8 BaseType uint64
+      GroupType: 107 StructureType noalg.map.group[string]int
       GroupSliceType: 247 GoSliceDataType []noalg.map.group[string]int.array
     - __kind: GoSwissMapGroupsType
-      ID: 77
+      ID: 93
       Name: groupReference<string,main.nestedStruct>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 78 PointerType *noalg.map.group[string]main.nestedStruct
+          Type: 94 PointerType *noalg.map.group[string]main.nestedStruct
         - Name: lengthMask
           Offset: 8
-          Type: 26 BaseType uint64
-      GroupType: 79 StructureType noalg.map.group[string]main.nestedStruct
+          Type: 8 BaseType uint64
+      GroupType: 95 StructureType noalg.map.group[string]main.nestedStruct
       GroupSliceType: 245 GoSliceDataType []noalg.map.group[string]main.nestedStruct.array
     - __kind: GoSwissMapGroupsType
-      ID: 174
+      ID: 190
       Name: groupReference<uint8,[4]int>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 175 PointerType *noalg.map.group[uint8][4]int
+          Type: 191 PointerType *noalg.map.group[uint8][4]int
         - Name: lengthMask
           Offset: 8
-          Type: 26 BaseType uint64
-      GroupType: 176 StructureType noalg.map.group[uint8][4]int
+          Type: 8 BaseType uint64
+      GroupType: 192 StructureType noalg.map.group[uint8][4]int
       GroupSliceType: 265 GoSliceDataType []noalg.map.group[uint8][4]int.array
     - __kind: GoSwissMapGroupsType
-      ID: 163
+      ID: 179
       Name: groupReference<uint8,uint8>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 164 PointerType *noalg.map.group[uint8]uint8
+          Type: 180 PointerType *noalg.map.group[uint8]uint8
         - Name: lengthMask
           Offset: 8
-          Type: 26 BaseType uint64
-      GroupType: 165 StructureType noalg.map.group[uint8]uint8
+          Type: 8 BaseType uint64
+      GroupType: 181 StructureType noalg.map.group[uint8]uint8
       GroupSliceType: 263 GoSliceDataType []noalg.map.group[uint8]uint8.array
     - __kind: BaseType
-      ID: 1
+      ID: 7
       Name: int
       ByteSize: 8
       GoRuntimeType: 579136
       GoKind: 2
     - __kind: BaseType
-      ID: 16
+      ID: 23
       Name: int16
       ByteSize: 2
       GoRuntimeType: 578752
       GoKind: 4
     - __kind: BaseType
-      ID: 6
+      ID: 12
       Name: int32
       ByteSize: 4
       GoRuntimeType: 578880
       GoKind: 5
     - __kind: BaseType
-      ID: 18
+      ID: 13
       Name: int64
       ByteSize: 8
       GoRuntimeType: 579008
       GoKind: 6
     - __kind: BaseType
-      ID: 14
+      ID: 17
       Name: int8
       ByteSize: 1
       GoRuntimeType: 578624
       GoKind: 3
     - __kind: GoEmptyInterfaceType
-      ID: 41
+      ID: 58
       Name: interface {}
       ByteSize: 16
       GoRuntimeType: 841248
@@ -5919,12 +5919,12 @@ Types:
       RawFields:
         - Name: _type
           Offset: 0
-          Type: 38 VoidPointerType unsafe.Pointer
+          Type: 15 VoidPointerType unsafe.Pointer
         - Name: data
           Offset: 8
-          Type: 38 VoidPointerType unsafe.Pointer
+          Type: 15 VoidPointerType unsafe.Pointer
     - __kind: StructureType
-      ID: 48
+      ID: 65
       Name: internal/sync.Mutex
       ByteSize: 8
       GoRuntimeType: 1.459296e+06
@@ -5932,12 +5932,12 @@ Types:
       RawFields:
         - Name: state
           Offset: 0
-          Type: 6 BaseType int32
+          Type: 12 BaseType int32
         - Name: sema
           Offset: 4
-          Type: 24 BaseType uint32
+          Type: 2 BaseType uint32
     - __kind: GoInterfaceType
-      ID: 37
+      ID: 55
       Name: io.Writer
       ByteSize: 16
       GoRuntimeType: 1.016032e+06
@@ -5945,30 +5945,30 @@ Types:
       RawFields:
         - Name: tab
           Offset: 0
-          Type: 38 VoidPointerType unsafe.Pointer
+          Type: 15 VoidPointerType unsafe.Pointer
         - Name: data
           Offset: 8
-          Type: 38 VoidPointerType unsafe.Pointer
+          Type: 15 VoidPointerType unsafe.Pointer
     - __kind: StructureType
-      ID: 223
+      ID: 236
       Name: main.aStruct
       ByteSize: 56
       GoKind: 25
       RawFields:
         - Name: aBool
           Offset: 0
-          Type: 11 BaseType bool
+          Type: 4 BaseType bool
         - Name: aString
           Offset: 8
-          Type: 8 GoStringHeaderType string
+          Type: 9 GoStringHeaderType string
         - Name: aNumber
           Offset: 24
-          Type: 1 BaseType int
+          Type: 7 BaseType int
         - Name: nested
           Offset: 32
-          Type: 82 StructureType main.nestedStruct
+          Type: 98 StructureType main.nestedStruct
     - __kind: GoInterfaceType
-      ID: 56
+      ID: 74
       Name: main.behavior
       ByteSize: 16
       GoRuntimeType: 1.015648e+06
@@ -5976,32 +5976,32 @@ Types:
       RawFields:
         - Name: tab
           Offset: 0
-          Type: 38 VoidPointerType unsafe.Pointer
+          Type: 15 VoidPointerType unsafe.Pointer
         - Name: data
           Offset: 8
-          Type: 38 VoidPointerType unsafe.Pointer
+          Type: 15 VoidPointerType unsafe.Pointer
     - __kind: StructureType
-      ID: 33
+      ID: 52
       Name: main.bigStruct
       ByteSize: 48
       GoKind: 25
       RawFields:
         - Name: x
           Offset: 0
-          Type: 34 GoSliceHeaderType []*string
+          Type: 53 GoSliceHeaderType []*string
         - Name: z
           Offset: 24
-          Type: 1 BaseType int
+          Type: 7 BaseType int
         - Name: writer
           Offset: 32
-          Type: 37 GoInterfaceType io.Writer
+          Type: 55 GoInterfaceType io.Writer
     - __kind: StructureType
-      ID: 224
+      ID: 237
       Name: main.emptyStruct
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 45
+      ID: 62
       Name: main.esotericHeap
       ByteSize: 112
       GoRuntimeType: 1.820416e+06
@@ -6009,21 +6009,21 @@ Types:
       RawFields:
         - Name: esotericStack
           Offset: 0
-          Type: 39 StructureType main.esotericStack
+          Type: 56 StructureType main.esotericStack
         - Name: mu
           Offset: 64
-          Type: 46 StructureType sync.Mutex
+          Type: 63 StructureType sync.Mutex
         - Name: once
           Offset: 72
-          Type: 49 StructureType sync.Once
+          Type: 66 StructureType sync.Once
         - Name: wg
           Offset: 88
-          Type: 52 StructureType sync.WaitGroup
+          Type: 69 StructureType sync.WaitGroup
         - Name: a
           Offset: 104
-          Type: 55 StructureType sync/atomic.Int32
+          Type: 72 StructureType sync/atomic.Int32
     - __kind: StructureType
-      ID: 39
+      ID: 56
       Name: main.esotericStack
       ByteSize: 64
       GoRuntimeType: 1.953504e+06
@@ -6031,27 +6031,27 @@ Types:
       RawFields:
         - Name: _
           Offset: 0
-          Type: 6 BaseType int32
+          Type: 12 BaseType int32
         - Name: _valid
           Offset: 4
-          Type: 6 BaseType int32
+          Type: 12 BaseType int32
         - Name: c
           Offset: 8
-          Type: 40 GoChannelType chan struct {}
+          Type: 57 GoChannelType chan struct {}
         - Name: val
           Offset: 16
-          Type: 41 GoEmptyInterfaceType interface {}
+          Type: 58 GoEmptyInterfaceType interface {}
         - Name: _
           Offset: 32
-          Type: 26 BaseType uint64
+          Type: 8 BaseType uint64
         - Name: work
           Offset: 40
-          Type: 42 GoInterfaceType main.something
+          Type: 59 GoInterfaceType main.something
         - Name: foo
           Offset: 56
-          Type: 43 GoSubroutineType func()
+          Type: 60 GoSubroutineType func()
     - __kind: StructureType
-      ID: 82
+      ID: 98
       Name: main.nestedStruct
       ByteSize: 24
       GoRuntimeType: 1.447936e+06
@@ -6059,12 +6059,12 @@ Types:
       RawFields:
         - Name: anotherInt
           Offset: 0
-          Type: 1 BaseType int
+          Type: 7 BaseType int
         - Name: anotherString
           Offset: 8
-          Type: 8 GoStringHeaderType string
+          Type: 9 GoStringHeaderType string
     - __kind: StructureType
-      ID: 144
+      ID: 160
       Name: main.node
       ByteSize: 16
       GoRuntimeType: 1.447776e+06
@@ -6072,21 +6072,21 @@ Types:
       RawFields:
         - Name: val
           Offset: 0
-          Type: 1 BaseType int
+          Type: 7 BaseType int
         - Name: b
           Offset: 8
-          Type: 145 PointerType *main.node
+          Type: 161 PointerType *main.node
     - __kind: StructureType
-      ID: 222
+      ID: 235
       Name: main.oneStringStruct
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: a
           Offset: 0
-          Type: 8 GoStringHeaderType string
+          Type: 9 GoStringHeaderType string
     - __kind: GoInterfaceType
-      ID: 42
+      ID: 59
       Name: main.something
       ByteSize: 16
       GoRuntimeType: 1.015776e+06
@@ -6094,12 +6094,12 @@ Types:
       RawFields:
         - Name: tab
           Offset: 0
-          Type: 38 VoidPointerType unsafe.Pointer
+          Type: 15 VoidPointerType unsafe.Pointer
         - Name: data
           Offset: 8
-          Type: 38 VoidPointerType unsafe.Pointer
+          Type: 15 VoidPointerType unsafe.Pointer
     - __kind: StructureType
-      ID: 58
+      ID: 75
       Name: main.structWithMap
       ByteSize: 8
       GoRuntimeType: 1.1768e+06
@@ -6107,686 +6107,686 @@ Types:
       RawFields:
         - Name: m
           Offset: 0
-          Type: 59 GoMapType map[int]int
+          Type: 76 GoMapType map[int]int
     - __kind: StructureType
-      ID: 215
+      ID: 229
       Name: main.structWithNoStrings
       ByteSize: 2
       GoKind: 25
       RawFields:
         - Name: aUint8
           Offset: 0
-          Type: 4 BaseType uint8
+          Type: 3 BaseType uint8
         - Name: aBool
           Offset: 1
-          Type: 11 BaseType bool
+          Type: 4 BaseType bool
     - __kind: StructureType
-      ID: 204
+      ID: 220
       Name: main.structWithTwoValues
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: a
           Offset: 0
-          Type: 20 BaseType uint
+          Type: 10 BaseType uint
         - Name: b
           Offset: 8
-          Type: 11 BaseType bool
+          Type: 4 BaseType bool
     - __kind: GoSliceHeaderType
-      ID: 208
+      ID: 222
       Name: main.t
       ByteSize: 24
       GoKind: 23
       RawFields:
         - Name: array
           Offset: 0
-          Type: 209 PointerType **main.t
+          Type: 223 PointerType **main.t
         - Name: len
           Offset: 8
-          Type: 1 BaseType int
+          Type: 7 BaseType int
         - Name: cap
           Offset: 16
-          Type: 1 BaseType int
+          Type: 7 BaseType int
       Data: 270 GoSliceDataType main.t.array
     - __kind: GoSliceDataType
       ID: 270
       Name: main.t.array
       ByteSize: 2048
-      Element: 207 PointerType *main.t
+      Element: 221 PointerType *main.t
     - __kind: StructureType
-      ID: 219
+      ID: 232
       Name: main.threeStringStruct
       ByteSize: 48
       GoKind: 25
       RawFields:
         - Name: a
           Offset: 0
-          Type: 8 GoStringHeaderType string
+          Type: 9 GoStringHeaderType string
         - Name: b
           Offset: 16
-          Type: 8 GoStringHeaderType string
+          Type: 9 GoStringHeaderType string
         - Name: c
           Offset: 32
-          Type: 8 GoStringHeaderType string
+          Type: 9 GoStringHeaderType string
     - __kind: BaseType
-      ID: 32
+      ID: 51
       Name: main.typeAlias
       ByteSize: 2
       GoKind: 9
     - __kind: GoSwissMapHeaderType
-      ID: 193
+      ID: 209
       Name: map<[4]int,[4]int>
       ByteSize: 48
       GoKind: 25
       RawFields:
         - Name: used
           Offset: 0
-          Type: 26 BaseType uint64
+          Type: 8 BaseType uint64
         - Name: seed
           Offset: 8
-          Type: 62 BaseType uintptr
+          Type: 1 BaseType uintptr
         - Name: dirPtr
           Offset: 16
-          Type: 194 PointerType **table<[4]int,[4]int>
+          Type: 210 PointerType **table<[4]int,[4]int>
         - Name: dirLen
           Offset: 24
-          Type: 1 BaseType int
+          Type: 7 BaseType int
         - Name: globalDepth
           Offset: 32
-          Type: 4 BaseType uint8
+          Type: 3 BaseType uint8
         - Name: globalShift
           Offset: 33
-          Type: 4 BaseType uint8
+          Type: 3 BaseType uint8
         - Name: writing
           Offset: 34
-          Type: 4 BaseType uint8
+          Type: 3 BaseType uint8
         - Name: tombstonePossible
           Offset: 35
-          Type: 11 BaseType bool
+          Type: 4 BaseType bool
         - Name: clearSeq
           Offset: 40
-          Type: 26 BaseType uint64
+          Type: 8 BaseType uint64
       TablePtrSliceType: 268 GoSliceDataType []*table<[4]int,[4]int>.array
-      GroupType: 199 StructureType noalg.map.group[[4]int][4]int
+      GroupType: 215 StructureType noalg.map.group[[4]int][4]int
     - __kind: GoSwissMapHeaderType
-      ID: 182
+      ID: 198
       Name: map<[4]int,uint8>
       ByteSize: 48
       GoKind: 25
       RawFields:
         - Name: used
           Offset: 0
-          Type: 26 BaseType uint64
+          Type: 8 BaseType uint64
         - Name: seed
           Offset: 8
-          Type: 62 BaseType uintptr
+          Type: 1 BaseType uintptr
         - Name: dirPtr
           Offset: 16
-          Type: 183 PointerType **table<[4]int,uint8>
+          Type: 199 PointerType **table<[4]int,uint8>
         - Name: dirLen
           Offset: 24
-          Type: 1 BaseType int
+          Type: 7 BaseType int
         - Name: globalDepth
           Offset: 32
-          Type: 4 BaseType uint8
+          Type: 3 BaseType uint8
         - Name: globalShift
           Offset: 33
-          Type: 4 BaseType uint8
+          Type: 3 BaseType uint8
         - Name: writing
           Offset: 34
-          Type: 4 BaseType uint8
+          Type: 3 BaseType uint8
         - Name: tombstonePossible
           Offset: 35
-          Type: 11 BaseType bool
+          Type: 4 BaseType bool
         - Name: clearSeq
           Offset: 40
-          Type: 26 BaseType uint64
+          Type: 8 BaseType uint64
       TablePtrSliceType: 266 GoSliceDataType []*table<[4]int,uint8>.array
-      GroupType: 188 StructureType noalg.map.group[[4]int]uint8
+      GroupType: 204 StructureType noalg.map.group[[4]int]uint8
     - __kind: GoSwissMapHeaderType
-      ID: 108
+      ID: 124
       Name: map<[4]string,[2]int>
       ByteSize: 48
       GoKind: 25
       RawFields:
         - Name: used
           Offset: 0
-          Type: 26 BaseType uint64
+          Type: 8 BaseType uint64
         - Name: seed
           Offset: 8
-          Type: 62 BaseType uintptr
+          Type: 1 BaseType uintptr
         - Name: dirPtr
           Offset: 16
-          Type: 109 PointerType **table<[4]string,[2]int>
+          Type: 125 PointerType **table<[4]string,[2]int>
         - Name: dirLen
           Offset: 24
-          Type: 1 BaseType int
+          Type: 7 BaseType int
         - Name: globalDepth
           Offset: 32
-          Type: 4 BaseType uint8
+          Type: 3 BaseType uint8
         - Name: globalShift
           Offset: 33
-          Type: 4 BaseType uint8
+          Type: 3 BaseType uint8
         - Name: writing
           Offset: 34
-          Type: 4 BaseType uint8
+          Type: 3 BaseType uint8
         - Name: tombstonePossible
           Offset: 35
-          Type: 11 BaseType bool
+          Type: 4 BaseType bool
         - Name: clearSeq
           Offset: 40
-          Type: 26 BaseType uint64
+          Type: 8 BaseType uint64
       TablePtrSliceType: 252 GoSliceDataType []*table<[4]string,[2]int>.array
-      GroupType: 114 StructureType noalg.map.group[[4]string][2]int
+      GroupType: 130 StructureType noalg.map.group[[4]string][2]int
     - __kind: GoSwissMapHeaderType
-      ID: 135
+      ID: 151
       Name: map<bool,main.node>
       ByteSize: 48
       GoKind: 25
       RawFields:
         - Name: used
           Offset: 0
-          Type: 26 BaseType uint64
+          Type: 8 BaseType uint64
         - Name: seed
           Offset: 8
-          Type: 62 BaseType uintptr
+          Type: 1 BaseType uintptr
         - Name: dirPtr
           Offset: 16
-          Type: 136 PointerType **table<bool,main.node>
+          Type: 152 PointerType **table<bool,main.node>
         - Name: dirLen
           Offset: 24
-          Type: 1 BaseType int
+          Type: 7 BaseType int
         - Name: globalDepth
           Offset: 32
-          Type: 4 BaseType uint8
+          Type: 3 BaseType uint8
         - Name: globalShift
           Offset: 33
-          Type: 4 BaseType uint8
+          Type: 3 BaseType uint8
         - Name: writing
           Offset: 34
-          Type: 4 BaseType uint8
+          Type: 3 BaseType uint8
         - Name: tombstonePossible
           Offset: 35
-          Type: 11 BaseType bool
+          Type: 4 BaseType bool
         - Name: clearSeq
           Offset: 40
-          Type: 26 BaseType uint64
+          Type: 8 BaseType uint64
       TablePtrSliceType: 258 GoSliceDataType []*table<bool,main.node>.array
-      GroupType: 141 StructureType noalg.map.group[bool]main.node
+      GroupType: 157 StructureType noalg.map.group[bool]main.node
     - __kind: GoSwissMapHeaderType
-      ID: 61
+      ID: 78
       Name: map<int,int>
       ByteSize: 48
       GoKind: 25
       RawFields:
         - Name: used
           Offset: 0
-          Type: 26 BaseType uint64
+          Type: 8 BaseType uint64
         - Name: seed
           Offset: 8
-          Type: 62 BaseType uintptr
+          Type: 1 BaseType uintptr
         - Name: dirPtr
           Offset: 16
-          Type: 63 PointerType **table<int,int>
+          Type: 79 PointerType **table<int,int>
         - Name: dirLen
           Offset: 24
-          Type: 1 BaseType int
+          Type: 7 BaseType int
         - Name: globalDepth
           Offset: 32
-          Type: 4 BaseType uint8
+          Type: 3 BaseType uint8
         - Name: globalShift
           Offset: 33
-          Type: 4 BaseType uint8
+          Type: 3 BaseType uint8
         - Name: writing
           Offset: 34
-          Type: 4 BaseType uint8
+          Type: 3 BaseType uint8
         - Name: tombstonePossible
           Offset: 35
-          Type: 11 BaseType bool
+          Type: 4 BaseType bool
         - Name: clearSeq
           Offset: 40
-          Type: 26 BaseType uint64
+          Type: 8 BaseType uint64
       TablePtrSliceType: 242 GoSliceDataType []*table<int,int>.array
-      GroupType: 68 StructureType noalg.map.group[int]int
+      GroupType: 84 StructureType noalg.map.group[int]int
     - __kind: GoSwissMapHeaderType
-      ID: 148
+      ID: 164
       Name: map<int,uint8>
       ByteSize: 48
       GoKind: 25
       RawFields:
         - Name: used
           Offset: 0
-          Type: 26 BaseType uint64
+          Type: 8 BaseType uint64
         - Name: seed
           Offset: 8
-          Type: 62 BaseType uintptr
+          Type: 1 BaseType uintptr
         - Name: dirPtr
           Offset: 16
-          Type: 149 PointerType **table<int,uint8>
+          Type: 165 PointerType **table<int,uint8>
         - Name: dirLen
           Offset: 24
-          Type: 1 BaseType int
+          Type: 7 BaseType int
         - Name: globalDepth
           Offset: 32
-          Type: 4 BaseType uint8
+          Type: 3 BaseType uint8
         - Name: globalShift
           Offset: 33
-          Type: 4 BaseType uint8
+          Type: 3 BaseType uint8
         - Name: writing
           Offset: 34
-          Type: 4 BaseType uint8
+          Type: 3 BaseType uint8
         - Name: tombstonePossible
           Offset: 35
-          Type: 11 BaseType bool
+          Type: 4 BaseType bool
         - Name: clearSeq
           Offset: 40
-          Type: 26 BaseType uint64
+          Type: 8 BaseType uint64
       TablePtrSliceType: 260 GoSliceDataType []*table<int,uint8>.array
-      GroupType: 154 StructureType noalg.map.group[int]uint8
+      GroupType: 170 StructureType noalg.map.group[int]uint8
     - __kind: GoSwissMapHeaderType
-      ID: 122
+      ID: 138
       Name: map<string,[]main.structWithMap>
       ByteSize: 48
       GoKind: 25
       RawFields:
         - Name: used
           Offset: 0
-          Type: 26 BaseType uint64
+          Type: 8 BaseType uint64
         - Name: seed
           Offset: 8
-          Type: 62 BaseType uintptr
+          Type: 1 BaseType uintptr
         - Name: dirPtr
           Offset: 16
-          Type: 123 PointerType **table<string,[]main.structWithMap>
+          Type: 139 PointerType **table<string,[]main.structWithMap>
         - Name: dirLen
           Offset: 24
-          Type: 1 BaseType int
+          Type: 7 BaseType int
         - Name: globalDepth
           Offset: 32
-          Type: 4 BaseType uint8
+          Type: 3 BaseType uint8
         - Name: globalShift
           Offset: 33
-          Type: 4 BaseType uint8
+          Type: 3 BaseType uint8
         - Name: writing
           Offset: 34
-          Type: 4 BaseType uint8
+          Type: 3 BaseType uint8
         - Name: tombstonePossible
           Offset: 35
-          Type: 11 BaseType bool
+          Type: 4 BaseType bool
         - Name: clearSeq
           Offset: 40
-          Type: 26 BaseType uint64
+          Type: 8 BaseType uint64
       TablePtrSliceType: 254 GoSliceDataType []*table<string,[]main.structWithMap>.array
-      GroupType: 128 StructureType noalg.map.group[string][]main.structWithMap
+      GroupType: 144 StructureType noalg.map.group[string][]main.structWithMap
     - __kind: GoSwissMapHeaderType
-      ID: 96
+      ID: 112
       Name: map<string,[]string>
       ByteSize: 48
       GoKind: 25
       RawFields:
         - Name: used
           Offset: 0
-          Type: 26 BaseType uint64
+          Type: 8 BaseType uint64
         - Name: seed
           Offset: 8
-          Type: 62 BaseType uintptr
+          Type: 1 BaseType uintptr
         - Name: dirPtr
           Offset: 16
-          Type: 97 PointerType **table<string,[]string>
+          Type: 113 PointerType **table<string,[]string>
         - Name: dirLen
           Offset: 24
-          Type: 1 BaseType int
+          Type: 7 BaseType int
         - Name: globalDepth
           Offset: 32
-          Type: 4 BaseType uint8
+          Type: 3 BaseType uint8
         - Name: globalShift
           Offset: 33
-          Type: 4 BaseType uint8
+          Type: 3 BaseType uint8
         - Name: writing
           Offset: 34
-          Type: 4 BaseType uint8
+          Type: 3 BaseType uint8
         - Name: tombstonePossible
           Offset: 35
-          Type: 11 BaseType bool
+          Type: 4 BaseType bool
         - Name: clearSeq
           Offset: 40
-          Type: 26 BaseType uint64
+          Type: 8 BaseType uint64
       TablePtrSliceType: 248 GoSliceDataType []*table<string,[]string>.array
-      GroupType: 102 StructureType noalg.map.group[string][]string
+      GroupType: 118 StructureType noalg.map.group[string][]string
     - __kind: GoSwissMapHeaderType
-      ID: 85
+      ID: 101
       Name: map<string,int>
       ByteSize: 48
       GoKind: 25
       RawFields:
         - Name: used
           Offset: 0
-          Type: 26 BaseType uint64
+          Type: 8 BaseType uint64
         - Name: seed
           Offset: 8
-          Type: 62 BaseType uintptr
+          Type: 1 BaseType uintptr
         - Name: dirPtr
           Offset: 16
-          Type: 86 PointerType **table<string,int>
+          Type: 102 PointerType **table<string,int>
         - Name: dirLen
           Offset: 24
-          Type: 1 BaseType int
+          Type: 7 BaseType int
         - Name: globalDepth
           Offset: 32
-          Type: 4 BaseType uint8
+          Type: 3 BaseType uint8
         - Name: globalShift
           Offset: 33
-          Type: 4 BaseType uint8
+          Type: 3 BaseType uint8
         - Name: writing
           Offset: 34
-          Type: 4 BaseType uint8
+          Type: 3 BaseType uint8
         - Name: tombstonePossible
           Offset: 35
-          Type: 11 BaseType bool
+          Type: 4 BaseType bool
         - Name: clearSeq
           Offset: 40
-          Type: 26 BaseType uint64
+          Type: 8 BaseType uint64
       TablePtrSliceType: 246 GoSliceDataType []*table<string,int>.array
-      GroupType: 91 StructureType noalg.map.group[string]int
+      GroupType: 107 StructureType noalg.map.group[string]int
     - __kind: GoSwissMapHeaderType
-      ID: 73
+      ID: 89
       Name: map<string,main.nestedStruct>
       ByteSize: 48
       GoKind: 25
       RawFields:
         - Name: used
           Offset: 0
-          Type: 26 BaseType uint64
+          Type: 8 BaseType uint64
         - Name: seed
           Offset: 8
-          Type: 62 BaseType uintptr
+          Type: 1 BaseType uintptr
         - Name: dirPtr
           Offset: 16
-          Type: 74 PointerType **table<string,main.nestedStruct>
+          Type: 90 PointerType **table<string,main.nestedStruct>
         - Name: dirLen
           Offset: 24
-          Type: 1 BaseType int
+          Type: 7 BaseType int
         - Name: globalDepth
           Offset: 32
-          Type: 4 BaseType uint8
+          Type: 3 BaseType uint8
         - Name: globalShift
           Offset: 33
-          Type: 4 BaseType uint8
+          Type: 3 BaseType uint8
         - Name: writing
           Offset: 34
-          Type: 4 BaseType uint8
+          Type: 3 BaseType uint8
         - Name: tombstonePossible
           Offset: 35
-          Type: 11 BaseType bool
+          Type: 4 BaseType bool
         - Name: clearSeq
           Offset: 40
-          Type: 26 BaseType uint64
+          Type: 8 BaseType uint64
       TablePtrSliceType: 244 GoSliceDataType []*table<string,main.nestedStruct>.array
-      GroupType: 79 StructureType noalg.map.group[string]main.nestedStruct
+      GroupType: 95 StructureType noalg.map.group[string]main.nestedStruct
     - __kind: GoSwissMapHeaderType
-      ID: 170
+      ID: 186
       Name: map<uint8,[4]int>
       ByteSize: 48
       GoKind: 25
       RawFields:
         - Name: used
           Offset: 0
-          Type: 26 BaseType uint64
+          Type: 8 BaseType uint64
         - Name: seed
           Offset: 8
-          Type: 62 BaseType uintptr
+          Type: 1 BaseType uintptr
         - Name: dirPtr
           Offset: 16
-          Type: 171 PointerType **table<uint8,[4]int>
+          Type: 187 PointerType **table<uint8,[4]int>
         - Name: dirLen
           Offset: 24
-          Type: 1 BaseType int
+          Type: 7 BaseType int
         - Name: globalDepth
           Offset: 32
-          Type: 4 BaseType uint8
+          Type: 3 BaseType uint8
         - Name: globalShift
           Offset: 33
-          Type: 4 BaseType uint8
+          Type: 3 BaseType uint8
         - Name: writing
           Offset: 34
-          Type: 4 BaseType uint8
+          Type: 3 BaseType uint8
         - Name: tombstonePossible
           Offset: 35
-          Type: 11 BaseType bool
+          Type: 4 BaseType bool
         - Name: clearSeq
           Offset: 40
-          Type: 26 BaseType uint64
+          Type: 8 BaseType uint64
       TablePtrSliceType: 264 GoSliceDataType []*table<uint8,[4]int>.array
-      GroupType: 176 StructureType noalg.map.group[uint8][4]int
+      GroupType: 192 StructureType noalg.map.group[uint8][4]int
     - __kind: GoSwissMapHeaderType
-      ID: 159
+      ID: 175
       Name: map<uint8,uint8>
       ByteSize: 48
       GoKind: 25
       RawFields:
         - Name: used
           Offset: 0
-          Type: 26 BaseType uint64
+          Type: 8 BaseType uint64
         - Name: seed
           Offset: 8
-          Type: 62 BaseType uintptr
+          Type: 1 BaseType uintptr
         - Name: dirPtr
           Offset: 16
-          Type: 160 PointerType **table<uint8,uint8>
+          Type: 176 PointerType **table<uint8,uint8>
         - Name: dirLen
           Offset: 24
-          Type: 1 BaseType int
+          Type: 7 BaseType int
         - Name: globalDepth
           Offset: 32
-          Type: 4 BaseType uint8
+          Type: 3 BaseType uint8
         - Name: globalShift
           Offset: 33
-          Type: 4 BaseType uint8
+          Type: 3 BaseType uint8
         - Name: writing
           Offset: 34
-          Type: 4 BaseType uint8
+          Type: 3 BaseType uint8
         - Name: tombstonePossible
           Offset: 35
-          Type: 11 BaseType bool
+          Type: 4 BaseType bool
         - Name: clearSeq
           Offset: 40
-          Type: 26 BaseType uint64
+          Type: 8 BaseType uint64
       TablePtrSliceType: 262 GoSliceDataType []*table<uint8,uint8>.array
-      GroupType: 165 StructureType noalg.map.group[uint8]uint8
+      GroupType: 181 StructureType noalg.map.group[uint8]uint8
     - __kind: GoMapType
-      ID: 191
+      ID: 207
       Name: map[[4]int][4]int
       ByteSize: 8
       GoRuntimeType: 1.121696e+06
       GoKind: 21
-      HeaderType: 193 GoSwissMapHeaderType map<[4]int,[4]int>
+      HeaderType: 209 GoSwissMapHeaderType map<[4]int,[4]int>
     - __kind: GoMapType
-      ID: 180
+      ID: 196
       Name: map[[4]int]uint8
       ByteSize: 8
       GoRuntimeType: 1.121824e+06
       GoKind: 21
-      HeaderType: 182 GoSwissMapHeaderType map<[4]int,uint8>
+      HeaderType: 198 GoSwissMapHeaderType map<[4]int,uint8>
     - __kind: GoMapType
-      ID: 106
+      ID: 122
       Name: map[[4]string][2]int
       ByteSize: 8
       GoRuntimeType: 1.121952e+06
       GoKind: 21
-      HeaderType: 108 GoSwissMapHeaderType map<[4]string,[2]int>
+      HeaderType: 124 GoSwissMapHeaderType map<[4]string,[2]int>
     - __kind: GoMapType
-      ID: 133
+      ID: 149
       Name: map[bool]main.node
       ByteSize: 8
       GoRuntimeType: 1.12208e+06
       GoKind: 21
-      HeaderType: 135 GoSwissMapHeaderType map<bool,main.node>
+      HeaderType: 151 GoSwissMapHeaderType map<bool,main.node>
     - __kind: GoMapType
-      ID: 59
+      ID: 76
       Name: map[int]int
       ByteSize: 8
       GoRuntimeType: 1.121312e+06
       GoKind: 21
-      HeaderType: 61 GoSwissMapHeaderType map<int,int>
+      HeaderType: 78 GoSwissMapHeaderType map<int,int>
     - __kind: GoMapType
-      ID: 146
+      ID: 162
       Name: map[int]uint8
       ByteSize: 8
       GoRuntimeType: 1.122208e+06
       GoKind: 21
-      HeaderType: 148 GoSwissMapHeaderType map<int,uint8>
+      HeaderType: 164 GoSwissMapHeaderType map<int,uint8>
     - __kind: GoMapType
-      ID: 120
+      ID: 136
       Name: map[string][]main.structWithMap
       ByteSize: 8
       GoRuntimeType: 1.122336e+06
       GoKind: 21
-      HeaderType: 122 GoSwissMapHeaderType map<string,[]main.structWithMap>
+      HeaderType: 138 GoSwissMapHeaderType map<string,[]main.structWithMap>
     - __kind: GoMapType
-      ID: 94
+      ID: 110
       Name: map[string][]string
       ByteSize: 8
       GoRuntimeType: 1.122464e+06
       GoKind: 21
-      HeaderType: 96 GoSwissMapHeaderType map<string,[]string>
+      HeaderType: 112 GoSwissMapHeaderType map<string,[]string>
     - __kind: GoMapType
-      ID: 83
+      ID: 99
       Name: map[string]int
       ByteSize: 8
       GoRuntimeType: 1.122592e+06
       GoKind: 21
-      HeaderType: 85 GoSwissMapHeaderType map<string,int>
+      HeaderType: 101 GoSwissMapHeaderType map<string,int>
     - __kind: GoMapType
-      ID: 71
+      ID: 87
       Name: map[string]main.nestedStruct
       ByteSize: 8
       GoRuntimeType: 1.12272e+06
       GoKind: 21
-      HeaderType: 73 GoSwissMapHeaderType map<string,main.nestedStruct>
+      HeaderType: 89 GoSwissMapHeaderType map<string,main.nestedStruct>
     - __kind: GoMapType
-      ID: 168
+      ID: 184
       Name: map[uint8][4]int
       ByteSize: 8
       GoRuntimeType: 1.122848e+06
       GoKind: 21
-      HeaderType: 170 GoSwissMapHeaderType map<uint8,[4]int>
+      HeaderType: 186 GoSwissMapHeaderType map<uint8,[4]int>
     - __kind: GoMapType
-      ID: 157
+      ID: 173
       Name: map[uint8]uint8
       ByteSize: 8
       GoRuntimeType: 1.122976e+06
       GoKind: 21
-      HeaderType: 159 GoSwissMapHeaderType map<uint8,uint8>
+      HeaderType: 175 GoSwissMapHeaderType map<uint8,uint8>
     - __kind: ArrayType
-      ID: 200
+      ID: 216
       Name: noalg.[8]struct { key [4]int; elem [4]int }
       ByteSize: 512
       GoRuntimeType: 676512
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 201 StructureType noalg.struct { key [4]int; elem [4]int }
+      Element: 217 StructureType noalg.struct { key [4]int; elem [4]int }
     - __kind: ArrayType
-      ID: 189
+      ID: 205
       Name: noalg.[8]struct { key [4]int; elem uint8 }
       ByteSize: 320
       GoRuntimeType: 676608
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 190 StructureType noalg.struct { key [4]int; elem uint8 }
+      Element: 206 StructureType noalg.struct { key [4]int; elem uint8 }
     - __kind: ArrayType
-      ID: 115
+      ID: 131
       Name: noalg.[8]struct { key [4]string; elem [2]int }
       ByteSize: 640
       GoRuntimeType: 676896
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 116 StructureType noalg.struct { key [4]string; elem [2]int }
+      Element: 132 StructureType noalg.struct { key [4]string; elem [2]int }
     - __kind: ArrayType
-      ID: 142
+      ID: 158
       Name: noalg.[8]struct { key bool; elem main.node }
       ByteSize: 192
       GoRuntimeType: 676992
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 143 StructureType noalg.struct { key bool; elem main.node }
+      Element: 159 StructureType noalg.struct { key bool; elem main.node }
     - __kind: ArrayType
-      ID: 69
+      ID: 85
       Name: noalg.[8]struct { key int; elem int }
       ByteSize: 128
       GoRuntimeType: 674784
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 70 StructureType noalg.struct { key int; elem int }
+      Element: 86 StructureType noalg.struct { key int; elem int }
     - __kind: ArrayType
-      ID: 155
+      ID: 171
       Name: noalg.[8]struct { key int; elem uint8 }
       ByteSize: 128
       GoRuntimeType: 677088
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 156 StructureType noalg.struct { key int; elem uint8 }
+      Element: 172 StructureType noalg.struct { key int; elem uint8 }
     - __kind: ArrayType
-      ID: 129
+      ID: 145
       Name: noalg.[8]struct { key string; elem []main.structWithMap }
       ByteSize: 320
       GoRuntimeType: 677184
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 130 StructureType noalg.struct { key string; elem []main.structWithMap }
+      Element: 146 StructureType noalg.struct { key string; elem []main.structWithMap }
     - __kind: ArrayType
-      ID: 103
+      ID: 119
       Name: noalg.[8]struct { key string; elem []string }
       ByteSize: 320
       GoRuntimeType: 677280
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 104 StructureType noalg.struct { key string; elem []string }
+      Element: 120 StructureType noalg.struct { key string; elem []string }
     - __kind: ArrayType
-      ID: 92
+      ID: 108
       Name: noalg.[8]struct { key string; elem int }
       ByteSize: 192
       GoRuntimeType: 677376
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 93 StructureType noalg.struct { key string; elem int }
+      Element: 109 StructureType noalg.struct { key string; elem int }
     - __kind: ArrayType
-      ID: 80
+      ID: 96
       Name: noalg.[8]struct { key string; elem main.nestedStruct }
       ByteSize: 320
       GoRuntimeType: 677472
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 81 StructureType noalg.struct { key string; elem main.nestedStruct }
+      Element: 97 StructureType noalg.struct { key string; elem main.nestedStruct }
     - __kind: ArrayType
-      ID: 177
+      ID: 193
       Name: noalg.[8]struct { key uint8; elem [4]int }
       ByteSize: 320
       GoRuntimeType: 677568
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 178 StructureType noalg.struct { key uint8; elem [4]int }
+      Element: 194 StructureType noalg.struct { key uint8; elem [4]int }
     - __kind: ArrayType
-      ID: 166
+      ID: 182
       Name: noalg.[8]struct { key uint8; elem uint8 }
       ByteSize: 16
       GoRuntimeType: 677664
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 167 StructureType noalg.struct { key uint8; elem uint8 }
+      Element: 183 StructureType noalg.struct { key uint8; elem uint8 }
     - __kind: StructureType
-      ID: 199
+      ID: 215
       Name: noalg.map.group[[4]int][4]int
       ByteSize: 520
       GoRuntimeType: 1.281056e+06
@@ -6794,12 +6794,12 @@ Types:
       RawFields:
         - Name: ctrl
           Offset: 0
-          Type: 26 BaseType uint64
+          Type: 8 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 200 ArrayType noalg.[8]struct { key [4]int; elem [4]int }
+          Type: 216 ArrayType noalg.[8]struct { key [4]int; elem [4]int }
     - __kind: StructureType
-      ID: 188
+      ID: 204
       Name: noalg.map.group[[4]int]uint8
       ByteSize: 328
       GoRuntimeType: 1.281312e+06
@@ -6807,12 +6807,12 @@ Types:
       RawFields:
         - Name: ctrl
           Offset: 0
-          Type: 26 BaseType uint64
+          Type: 8 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 189 ArrayType noalg.[8]struct { key [4]int; elem uint8 }
+          Type: 205 ArrayType noalg.[8]struct { key [4]int; elem uint8 }
     - __kind: StructureType
-      ID: 114
+      ID: 130
       Name: noalg.map.group[[4]string][2]int
       ByteSize: 648
       GoRuntimeType: 1.281568e+06
@@ -6820,12 +6820,12 @@ Types:
       RawFields:
         - Name: ctrl
           Offset: 0
-          Type: 26 BaseType uint64
+          Type: 8 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 115 ArrayType noalg.[8]struct { key [4]string; elem [2]int }
+          Type: 131 ArrayType noalg.[8]struct { key [4]string; elem [2]int }
     - __kind: StructureType
-      ID: 141
+      ID: 157
       Name: noalg.map.group[bool]main.node
       ByteSize: 200
       GoRuntimeType: 1.281824e+06
@@ -6833,12 +6833,12 @@ Types:
       RawFields:
         - Name: ctrl
           Offset: 0
-          Type: 26 BaseType uint64
+          Type: 8 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 142 ArrayType noalg.[8]struct { key bool; elem main.node }
+          Type: 158 ArrayType noalg.[8]struct { key bool; elem main.node }
     - __kind: StructureType
-      ID: 68
+      ID: 84
       Name: noalg.map.group[int]int
       ByteSize: 136
       GoRuntimeType: 1.280288e+06
@@ -6846,12 +6846,12 @@ Types:
       RawFields:
         - Name: ctrl
           Offset: 0
-          Type: 26 BaseType uint64
+          Type: 8 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 69 ArrayType noalg.[8]struct { key int; elem int }
+          Type: 85 ArrayType noalg.[8]struct { key int; elem int }
     - __kind: StructureType
-      ID: 154
+      ID: 170
       Name: noalg.map.group[int]uint8
       ByteSize: 136
       GoRuntimeType: 1.28208e+06
@@ -6859,12 +6859,12 @@ Types:
       RawFields:
         - Name: ctrl
           Offset: 0
-          Type: 26 BaseType uint64
+          Type: 8 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 155 ArrayType noalg.[8]struct { key int; elem uint8 }
+          Type: 171 ArrayType noalg.[8]struct { key int; elem uint8 }
     - __kind: StructureType
-      ID: 128
+      ID: 144
       Name: noalg.map.group[string][]main.structWithMap
       ByteSize: 328
       GoRuntimeType: 1.282336e+06
@@ -6872,12 +6872,12 @@ Types:
       RawFields:
         - Name: ctrl
           Offset: 0
-          Type: 26 BaseType uint64
+          Type: 8 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 129 ArrayType noalg.[8]struct { key string; elem []main.structWithMap }
+          Type: 145 ArrayType noalg.[8]struct { key string; elem []main.structWithMap }
     - __kind: StructureType
-      ID: 102
+      ID: 118
       Name: noalg.map.group[string][]string
       ByteSize: 328
       GoRuntimeType: 1.282592e+06
@@ -6885,12 +6885,12 @@ Types:
       RawFields:
         - Name: ctrl
           Offset: 0
-          Type: 26 BaseType uint64
+          Type: 8 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 103 ArrayType noalg.[8]struct { key string; elem []string }
+          Type: 119 ArrayType noalg.[8]struct { key string; elem []string }
     - __kind: StructureType
-      ID: 91
+      ID: 107
       Name: noalg.map.group[string]int
       ByteSize: 200
       GoRuntimeType: 1.282848e+06
@@ -6898,12 +6898,12 @@ Types:
       RawFields:
         - Name: ctrl
           Offset: 0
-          Type: 26 BaseType uint64
+          Type: 8 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 92 ArrayType noalg.[8]struct { key string; elem int }
+          Type: 108 ArrayType noalg.[8]struct { key string; elem int }
     - __kind: StructureType
-      ID: 79
+      ID: 95
       Name: noalg.map.group[string]main.nestedStruct
       ByteSize: 328
       GoRuntimeType: 1.283104e+06
@@ -6911,12 +6911,12 @@ Types:
       RawFields:
         - Name: ctrl
           Offset: 0
-          Type: 26 BaseType uint64
+          Type: 8 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 80 ArrayType noalg.[8]struct { key string; elem main.nestedStruct }
+          Type: 96 ArrayType noalg.[8]struct { key string; elem main.nestedStruct }
     - __kind: StructureType
-      ID: 176
+      ID: 192
       Name: noalg.map.group[uint8][4]int
       ByteSize: 328
       GoRuntimeType: 1.28336e+06
@@ -6924,12 +6924,12 @@ Types:
       RawFields:
         - Name: ctrl
           Offset: 0
-          Type: 26 BaseType uint64
+          Type: 8 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 177 ArrayType noalg.[8]struct { key uint8; elem [4]int }
+          Type: 193 ArrayType noalg.[8]struct { key uint8; elem [4]int }
     - __kind: StructureType
-      ID: 165
+      ID: 181
       Name: noalg.map.group[uint8]uint8
       ByteSize: 24
       GoRuntimeType: 1.283616e+06
@@ -6937,12 +6937,12 @@ Types:
       RawFields:
         - Name: ctrl
           Offset: 0
-          Type: 26 BaseType uint64
+          Type: 8 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 166 ArrayType noalg.[8]struct { key uint8; elem uint8 }
+          Type: 182 ArrayType noalg.[8]struct { key uint8; elem uint8 }
     - __kind: StructureType
-      ID: 201
+      ID: 217
       Name: noalg.struct { key [4]int; elem [4]int }
       ByteSize: 64
       GoRuntimeType: 1.280928e+06
@@ -6950,12 +6950,12 @@ Types:
       RawFields:
         - Name: key
           Offset: 0
-          Type: 179 ArrayType [4]int
+          Type: 195 ArrayType [4]int
         - Name: elem
           Offset: 32
-          Type: 179 ArrayType [4]int
+          Type: 195 ArrayType [4]int
     - __kind: StructureType
-      ID: 190
+      ID: 206
       Name: noalg.struct { key [4]int; elem uint8 }
       ByteSize: 40
       GoRuntimeType: 1.281184e+06
@@ -6963,12 +6963,12 @@ Types:
       RawFields:
         - Name: key
           Offset: 0
-          Type: 179 ArrayType [4]int
+          Type: 195 ArrayType [4]int
         - Name: elem
           Offset: 32
-          Type: 4 BaseType uint8
+          Type: 3 BaseType uint8
     - __kind: StructureType
-      ID: 116
+      ID: 132
       Name: noalg.struct { key [4]string; elem [2]int }
       ByteSize: 80
       GoRuntimeType: 1.28144e+06
@@ -6976,12 +6976,12 @@ Types:
       RawFields:
         - Name: key
           Offset: 0
-          Type: 117 ArrayType [4]string
+          Type: 133 ArrayType [4]string
         - Name: elem
           Offset: 64
-          Type: 12 ArrayType [2]int
+          Type: 40 ArrayType [2]int
     - __kind: StructureType
-      ID: 143
+      ID: 159
       Name: noalg.struct { key bool; elem main.node }
       ByteSize: 24
       GoRuntimeType: 1.281696e+06
@@ -6989,12 +6989,12 @@ Types:
       RawFields:
         - Name: key
           Offset: 0
-          Type: 11 BaseType bool
+          Type: 4 BaseType bool
         - Name: elem
           Offset: 8
-          Type: 144 StructureType main.node
+          Type: 160 StructureType main.node
     - __kind: StructureType
-      ID: 70
+      ID: 86
       Name: noalg.struct { key int; elem int }
       ByteSize: 16
       GoRuntimeType: 1.28016e+06
@@ -7002,12 +7002,12 @@ Types:
       RawFields:
         - Name: key
           Offset: 0
-          Type: 1 BaseType int
+          Type: 7 BaseType int
         - Name: elem
           Offset: 8
-          Type: 1 BaseType int
+          Type: 7 BaseType int
     - __kind: StructureType
-      ID: 156
+      ID: 172
       Name: noalg.struct { key int; elem uint8 }
       ByteSize: 16
       GoRuntimeType: 1.281952e+06
@@ -7015,12 +7015,12 @@ Types:
       RawFields:
         - Name: key
           Offset: 0
-          Type: 1 BaseType int
+          Type: 7 BaseType int
         - Name: elem
           Offset: 8
-          Type: 4 BaseType uint8
+          Type: 3 BaseType uint8
     - __kind: StructureType
-      ID: 130
+      ID: 146
       Name: noalg.struct { key string; elem []main.structWithMap }
       ByteSize: 40
       GoRuntimeType: 1.282208e+06
@@ -7028,12 +7028,12 @@ Types:
       RawFields:
         - Name: key
           Offset: 0
-          Type: 8 GoStringHeaderType string
+          Type: 9 GoStringHeaderType string
         - Name: elem
           Offset: 16
-          Type: 131 GoSliceHeaderType []main.structWithMap
+          Type: 147 GoSliceHeaderType []main.structWithMap
     - __kind: StructureType
-      ID: 104
+      ID: 120
       Name: noalg.struct { key string; elem []string }
       ByteSize: 40
       GoRuntimeType: 1.282464e+06
@@ -7041,12 +7041,12 @@ Types:
       RawFields:
         - Name: key
           Offset: 0
-          Type: 8 GoStringHeaderType string
+          Type: 9 GoStringHeaderType string
         - Name: elem
           Offset: 16
-          Type: 105 GoSliceHeaderType []string
+          Type: 121 GoSliceHeaderType []string
     - __kind: StructureType
-      ID: 93
+      ID: 109
       Name: noalg.struct { key string; elem int }
       ByteSize: 24
       GoRuntimeType: 1.28272e+06
@@ -7054,12 +7054,12 @@ Types:
       RawFields:
         - Name: key
           Offset: 0
-          Type: 8 GoStringHeaderType string
+          Type: 9 GoStringHeaderType string
         - Name: elem
           Offset: 16
-          Type: 1 BaseType int
+          Type: 7 BaseType int
     - __kind: StructureType
-      ID: 81
+      ID: 97
       Name: noalg.struct { key string; elem main.nestedStruct }
       ByteSize: 40
       GoRuntimeType: 1.282976e+06
@@ -7067,12 +7067,12 @@ Types:
       RawFields:
         - Name: key
           Offset: 0
-          Type: 8 GoStringHeaderType string
+          Type: 9 GoStringHeaderType string
         - Name: elem
           Offset: 16
-          Type: 82 StructureType main.nestedStruct
+          Type: 98 StructureType main.nestedStruct
     - __kind: StructureType
-      ID: 178
+      ID: 194
       Name: noalg.struct { key uint8; elem [4]int }
       ByteSize: 40
       GoRuntimeType: 1.283232e+06
@@ -7080,12 +7080,12 @@ Types:
       RawFields:
         - Name: key
           Offset: 0
-          Type: 4 BaseType uint8
+          Type: 3 BaseType uint8
         - Name: elem
           Offset: 8
-          Type: 179 ArrayType [4]int
+          Type: 195 ArrayType [4]int
     - __kind: StructureType
-      ID: 167
+      ID: 183
       Name: noalg.struct { key uint8; elem uint8 }
       ByteSize: 2
       GoRuntimeType: 1.283488e+06
@@ -7093,12 +7093,12 @@ Types:
       RawFields:
         - Name: key
           Offset: 0
-          Type: 4 BaseType uint8
+          Type: 3 BaseType uint8
         - Name: elem
           Offset: 1
-          Type: 4 BaseType uint8
+          Type: 3 BaseType uint8
     - __kind: GoStringHeaderType
-      ID: 8
+      ID: 9
       Name: string
       ByteSize: 16
       GoRuntimeType: 578560
@@ -7109,14 +7109,14 @@ Types:
           Type: 239 PointerType *string.str
         - Name: len
           Offset: 8
-          Type: 1 BaseType int
+          Type: 7 BaseType int
       Data: 238 GoStringDataType string.str
     - __kind: GoStringDataType
       ID: 238
       Name: string.str
       ByteSize: 2048
     - __kind: StructureType
-      ID: 46
+      ID: 63
       Name: sync.Mutex
       ByteSize: 8
       GoRuntimeType: 1.449216e+06
@@ -7124,12 +7124,12 @@ Types:
       RawFields:
         - Name: _
           Offset: 0
-          Type: 47 StructureType sync.noCopy
+          Type: 64 StructureType sync.noCopy
         - Name: mu
           Offset: 0
-          Type: 48 StructureType internal/sync.Mutex
+          Type: 65 StructureType internal/sync.Mutex
     - __kind: StructureType
-      ID: 49
+      ID: 66
       Name: sync.Once
       ByteSize: 12
       GoRuntimeType: 1.598272e+06
@@ -7137,15 +7137,15 @@ Types:
       RawFields:
         - Name: _
           Offset: 0
-          Type: 47 StructureType sync.noCopy
+          Type: 64 StructureType sync.noCopy
         - Name: done
           Offset: 0
-          Type: 50 StructureType sync/atomic.Bool
+          Type: 67 StructureType sync/atomic.Bool
         - Name: m
           Offset: 4
-          Type: 46 StructureType sync.Mutex
+          Type: 63 StructureType sync.Mutex
     - __kind: StructureType
-      ID: 52
+      ID: 69
       Name: sync.WaitGroup
       ByteSize: 16
       GoRuntimeType: 1.59808e+06
@@ -7153,21 +7153,21 @@ Types:
       RawFields:
         - Name: noCopy
           Offset: 0
-          Type: 47 StructureType sync.noCopy
+          Type: 64 StructureType sync.noCopy
         - Name: state
           Offset: 0
-          Type: 53 StructureType sync/atomic.Uint64
+          Type: 70 StructureType sync/atomic.Uint64
         - Name: sema
           Offset: 8
-          Type: 24 BaseType uint32
+          Type: 2 BaseType uint32
     - __kind: StructureType
-      ID: 47
+      ID: 64
       Name: sync.noCopy
       GoRuntimeType: 981440
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 50
+      ID: 67
       Name: sync/atomic.Bool
       ByteSize: 4
       GoRuntimeType: 1.450336e+06
@@ -7175,12 +7175,12 @@ Types:
       RawFields:
         - Name: _
           Offset: 0
-          Type: 51 StructureType sync/atomic.noCopy
+          Type: 68 StructureType sync/atomic.noCopy
         - Name: v
           Offset: 0
-          Type: 24 BaseType uint32
+          Type: 2 BaseType uint32
     - __kind: StructureType
-      ID: 55
+      ID: 72
       Name: sync/atomic.Int32
       ByteSize: 4
       GoRuntimeType: 1.450496e+06
@@ -7188,12 +7188,12 @@ Types:
       RawFields:
         - Name: _
           Offset: 0
-          Type: 51 StructureType sync/atomic.noCopy
+          Type: 68 StructureType sync/atomic.noCopy
         - Name: v
           Offset: 0
-          Type: 6 BaseType int32
+          Type: 12 BaseType int32
     - __kind: StructureType
-      ID: 53
+      ID: 70
       Name: sync/atomic.Uint64
       ByteSize: 8
       GoRuntimeType: 1.598656e+06
@@ -7201,351 +7201,351 @@ Types:
       RawFields:
         - Name: _
           Offset: 0
-          Type: 51 StructureType sync/atomic.noCopy
+          Type: 68 StructureType sync/atomic.noCopy
         - Name: _
           Offset: 0
-          Type: 54 StructureType sync/atomic.align64
+          Type: 71 StructureType sync/atomic.align64
         - Name: v
           Offset: 0
-          Type: 26 BaseType uint64
+          Type: 8 BaseType uint64
     - __kind: StructureType
-      ID: 54
+      ID: 71
       Name: sync/atomic.align64
       GoRuntimeType: 981632
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 51
+      ID: 68
       Name: sync/atomic.noCopy
       GoRuntimeType: 981536
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 196
+      ID: 212
       Name: table<[4]int,[4]int>
       ByteSize: 32
       GoKind: 25
       RawFields:
         - Name: used
           Offset: 0
-          Type: 22 BaseType uint16
+          Type: 6 BaseType uint16
         - Name: capacity
           Offset: 2
-          Type: 22 BaseType uint16
+          Type: 6 BaseType uint16
         - Name: growthLeft
           Offset: 4
-          Type: 22 BaseType uint16
+          Type: 6 BaseType uint16
         - Name: localDepth
           Offset: 6
-          Type: 4 BaseType uint8
+          Type: 3 BaseType uint8
         - Name: index
           Offset: 8
-          Type: 1 BaseType int
+          Type: 7 BaseType int
         - Name: groups
           Offset: 16
-          Type: 197 GoSwissMapGroupsType groupReference<[4]int,[4]int>
+          Type: 213 GoSwissMapGroupsType groupReference<[4]int,[4]int>
     - __kind: StructureType
-      ID: 185
+      ID: 201
       Name: table<[4]int,uint8>
       ByteSize: 32
       GoKind: 25
       RawFields:
         - Name: used
           Offset: 0
-          Type: 22 BaseType uint16
+          Type: 6 BaseType uint16
         - Name: capacity
           Offset: 2
-          Type: 22 BaseType uint16
+          Type: 6 BaseType uint16
         - Name: growthLeft
           Offset: 4
-          Type: 22 BaseType uint16
+          Type: 6 BaseType uint16
         - Name: localDepth
           Offset: 6
-          Type: 4 BaseType uint8
+          Type: 3 BaseType uint8
         - Name: index
           Offset: 8
-          Type: 1 BaseType int
+          Type: 7 BaseType int
         - Name: groups
           Offset: 16
-          Type: 186 GoSwissMapGroupsType groupReference<[4]int,uint8>
+          Type: 202 GoSwissMapGroupsType groupReference<[4]int,uint8>
     - __kind: StructureType
-      ID: 111
+      ID: 127
       Name: table<[4]string,[2]int>
       ByteSize: 32
       GoKind: 25
       RawFields:
         - Name: used
           Offset: 0
-          Type: 22 BaseType uint16
+          Type: 6 BaseType uint16
         - Name: capacity
           Offset: 2
-          Type: 22 BaseType uint16
+          Type: 6 BaseType uint16
         - Name: growthLeft
           Offset: 4
-          Type: 22 BaseType uint16
+          Type: 6 BaseType uint16
         - Name: localDepth
           Offset: 6
-          Type: 4 BaseType uint8
+          Type: 3 BaseType uint8
         - Name: index
           Offset: 8
-          Type: 1 BaseType int
+          Type: 7 BaseType int
         - Name: groups
           Offset: 16
-          Type: 112 GoSwissMapGroupsType groupReference<[4]string,[2]int>
+          Type: 128 GoSwissMapGroupsType groupReference<[4]string,[2]int>
     - __kind: StructureType
-      ID: 138
+      ID: 154
       Name: table<bool,main.node>
       ByteSize: 32
       GoKind: 25
       RawFields:
         - Name: used
           Offset: 0
-          Type: 22 BaseType uint16
+          Type: 6 BaseType uint16
         - Name: capacity
           Offset: 2
-          Type: 22 BaseType uint16
+          Type: 6 BaseType uint16
         - Name: growthLeft
           Offset: 4
-          Type: 22 BaseType uint16
+          Type: 6 BaseType uint16
         - Name: localDepth
           Offset: 6
-          Type: 4 BaseType uint8
+          Type: 3 BaseType uint8
         - Name: index
           Offset: 8
-          Type: 1 BaseType int
+          Type: 7 BaseType int
         - Name: groups
           Offset: 16
-          Type: 139 GoSwissMapGroupsType groupReference<bool,main.node>
+          Type: 155 GoSwissMapGroupsType groupReference<bool,main.node>
     - __kind: StructureType
-      ID: 65
+      ID: 81
       Name: table<int,int>
       ByteSize: 32
       GoKind: 25
       RawFields:
         - Name: used
           Offset: 0
-          Type: 22 BaseType uint16
+          Type: 6 BaseType uint16
         - Name: capacity
           Offset: 2
-          Type: 22 BaseType uint16
+          Type: 6 BaseType uint16
         - Name: growthLeft
           Offset: 4
-          Type: 22 BaseType uint16
+          Type: 6 BaseType uint16
         - Name: localDepth
           Offset: 6
-          Type: 4 BaseType uint8
+          Type: 3 BaseType uint8
         - Name: index
           Offset: 8
-          Type: 1 BaseType int
+          Type: 7 BaseType int
         - Name: groups
           Offset: 16
-          Type: 66 GoSwissMapGroupsType groupReference<int,int>
+          Type: 82 GoSwissMapGroupsType groupReference<int,int>
     - __kind: StructureType
-      ID: 151
+      ID: 167
       Name: table<int,uint8>
       ByteSize: 32
       GoKind: 25
       RawFields:
         - Name: used
           Offset: 0
-          Type: 22 BaseType uint16
+          Type: 6 BaseType uint16
         - Name: capacity
           Offset: 2
-          Type: 22 BaseType uint16
+          Type: 6 BaseType uint16
         - Name: growthLeft
           Offset: 4
-          Type: 22 BaseType uint16
+          Type: 6 BaseType uint16
         - Name: localDepth
           Offset: 6
-          Type: 4 BaseType uint8
+          Type: 3 BaseType uint8
         - Name: index
           Offset: 8
-          Type: 1 BaseType int
+          Type: 7 BaseType int
         - Name: groups
           Offset: 16
-          Type: 152 GoSwissMapGroupsType groupReference<int,uint8>
+          Type: 168 GoSwissMapGroupsType groupReference<int,uint8>
     - __kind: StructureType
-      ID: 125
+      ID: 141
       Name: table<string,[]main.structWithMap>
       ByteSize: 32
       GoKind: 25
       RawFields:
         - Name: used
           Offset: 0
-          Type: 22 BaseType uint16
+          Type: 6 BaseType uint16
         - Name: capacity
           Offset: 2
-          Type: 22 BaseType uint16
+          Type: 6 BaseType uint16
         - Name: growthLeft
           Offset: 4
-          Type: 22 BaseType uint16
+          Type: 6 BaseType uint16
         - Name: localDepth
           Offset: 6
-          Type: 4 BaseType uint8
+          Type: 3 BaseType uint8
         - Name: index
           Offset: 8
-          Type: 1 BaseType int
+          Type: 7 BaseType int
         - Name: groups
           Offset: 16
-          Type: 126 GoSwissMapGroupsType groupReference<string,[]main.structWithMap>
+          Type: 142 GoSwissMapGroupsType groupReference<string,[]main.structWithMap>
     - __kind: StructureType
-      ID: 99
+      ID: 115
       Name: table<string,[]string>
       ByteSize: 32
       GoKind: 25
       RawFields:
         - Name: used
           Offset: 0
-          Type: 22 BaseType uint16
+          Type: 6 BaseType uint16
         - Name: capacity
           Offset: 2
-          Type: 22 BaseType uint16
+          Type: 6 BaseType uint16
         - Name: growthLeft
           Offset: 4
-          Type: 22 BaseType uint16
+          Type: 6 BaseType uint16
         - Name: localDepth
           Offset: 6
-          Type: 4 BaseType uint8
+          Type: 3 BaseType uint8
         - Name: index
           Offset: 8
-          Type: 1 BaseType int
+          Type: 7 BaseType int
         - Name: groups
           Offset: 16
-          Type: 100 GoSwissMapGroupsType groupReference<string,[]string>
+          Type: 116 GoSwissMapGroupsType groupReference<string,[]string>
     - __kind: StructureType
-      ID: 88
+      ID: 104
       Name: table<string,int>
       ByteSize: 32
       GoKind: 25
       RawFields:
         - Name: used
           Offset: 0
-          Type: 22 BaseType uint16
+          Type: 6 BaseType uint16
         - Name: capacity
           Offset: 2
-          Type: 22 BaseType uint16
+          Type: 6 BaseType uint16
         - Name: growthLeft
           Offset: 4
-          Type: 22 BaseType uint16
+          Type: 6 BaseType uint16
         - Name: localDepth
           Offset: 6
-          Type: 4 BaseType uint8
+          Type: 3 BaseType uint8
         - Name: index
           Offset: 8
-          Type: 1 BaseType int
+          Type: 7 BaseType int
         - Name: groups
           Offset: 16
-          Type: 89 GoSwissMapGroupsType groupReference<string,int>
+          Type: 105 GoSwissMapGroupsType groupReference<string,int>
     - __kind: StructureType
-      ID: 76
+      ID: 92
       Name: table<string,main.nestedStruct>
       ByteSize: 32
       GoKind: 25
       RawFields:
         - Name: used
           Offset: 0
-          Type: 22 BaseType uint16
+          Type: 6 BaseType uint16
         - Name: capacity
           Offset: 2
-          Type: 22 BaseType uint16
+          Type: 6 BaseType uint16
         - Name: growthLeft
           Offset: 4
-          Type: 22 BaseType uint16
+          Type: 6 BaseType uint16
         - Name: localDepth
           Offset: 6
-          Type: 4 BaseType uint8
+          Type: 3 BaseType uint8
         - Name: index
           Offset: 8
-          Type: 1 BaseType int
+          Type: 7 BaseType int
         - Name: groups
           Offset: 16
-          Type: 77 GoSwissMapGroupsType groupReference<string,main.nestedStruct>
+          Type: 93 GoSwissMapGroupsType groupReference<string,main.nestedStruct>
     - __kind: StructureType
-      ID: 173
+      ID: 189
       Name: table<uint8,[4]int>
       ByteSize: 32
       GoKind: 25
       RawFields:
         - Name: used
           Offset: 0
-          Type: 22 BaseType uint16
+          Type: 6 BaseType uint16
         - Name: capacity
           Offset: 2
-          Type: 22 BaseType uint16
+          Type: 6 BaseType uint16
         - Name: growthLeft
           Offset: 4
-          Type: 22 BaseType uint16
+          Type: 6 BaseType uint16
         - Name: localDepth
           Offset: 6
-          Type: 4 BaseType uint8
+          Type: 3 BaseType uint8
         - Name: index
           Offset: 8
-          Type: 1 BaseType int
+          Type: 7 BaseType int
         - Name: groups
           Offset: 16
-          Type: 174 GoSwissMapGroupsType groupReference<uint8,[4]int>
+          Type: 190 GoSwissMapGroupsType groupReference<uint8,[4]int>
     - __kind: StructureType
-      ID: 162
+      ID: 178
       Name: table<uint8,uint8>
       ByteSize: 32
       GoKind: 25
       RawFields:
         - Name: used
           Offset: 0
-          Type: 22 BaseType uint16
+          Type: 6 BaseType uint16
         - Name: capacity
           Offset: 2
-          Type: 22 BaseType uint16
+          Type: 6 BaseType uint16
         - Name: growthLeft
           Offset: 4
-          Type: 22 BaseType uint16
+          Type: 6 BaseType uint16
         - Name: localDepth
           Offset: 6
-          Type: 4 BaseType uint8
+          Type: 3 BaseType uint8
         - Name: index
           Offset: 8
-          Type: 1 BaseType int
+          Type: 7 BaseType int
         - Name: groups
           Offset: 16
-          Type: 163 GoSwissMapGroupsType groupReference<uint8,uint8>
+          Type: 179 GoSwissMapGroupsType groupReference<uint8,uint8>
     - __kind: BaseType
-      ID: 20
+      ID: 10
       Name: uint
       ByteSize: 8
       GoRuntimeType: 579200
       GoKind: 7
     - __kind: BaseType
-      ID: 22
+      ID: 6
       Name: uint16
       ByteSize: 2
       GoRuntimeType: 578816
       GoKind: 9
     - __kind: BaseType
-      ID: 24
+      ID: 2
       Name: uint32
       ByteSize: 4
       GoRuntimeType: 578944
       GoKind: 10
     - __kind: BaseType
-      ID: 26
+      ID: 8
       Name: uint64
       ByteSize: 8
       GoRuntimeType: 579072
       GoKind: 11
     - __kind: BaseType
-      ID: 4
+      ID: 3
       Name: uint8
       ByteSize: 1
       GoRuntimeType: 578688
       GoKind: 8
     - __kind: BaseType
-      ID: 62
+      ID: 1
       Name: uintptr
       ByteSize: 8
       GoRuntimeType: 579264
       GoKind: 12
     - __kind: VoidPointerType
-      ID: 38
+      ID: 15
       Name: unsafe.Pointer
       ByteSize: 8
       GoRuntimeType: 579648

--- a/pkg/dyninst/irgen/testdata/snapshot/sample.arch=arm64,toolchain=go1.25.0.yaml
+++ b/pkg/dyninst/irgen/testdata/snapshot/sample.arch=arm64,toolchain=go1.25.0.yaml
@@ -3090,275 +3090,11 @@ Subprograms:
           IsParameter: true
           IsReturn: false
 Types:
-    - __kind: BaseType
-      ID: 1
-      Name: int
-      ByteSize: 8
-      GoRuntimeType: 579136
-      GoKind: 2
-    - __kind: ArrayType
-      ID: 2
-      Name: '[5]int'
-      ByteSize: 40
-      GoKind: 17
-      Count: 5
-      HasCount: true
-      Element: 1 BaseType int
-    - __kind: ArrayType
-      ID: 3
-      Name: '[2]uint8'
-      ByteSize: 2
-      GoRuntimeType: 678048
-      GoKind: 17
-      Count: 2
-      HasCount: true
-      Element: 4 BaseType uint8
-    - __kind: BaseType
-      ID: 4
-      Name: uint8
-      ByteSize: 1
-      GoRuntimeType: 578688
-      GoKind: 8
-    - __kind: ArrayType
-      ID: 5
-      Name: '[2]int32'
-      ByteSize: 8
-      GoRuntimeType: 678144
-      GoKind: 17
-      Count: 2
-      HasCount: true
-      Element: 6 BaseType int32
-    - __kind: BaseType
-      ID: 6
-      Name: int32
-      ByteSize: 4
-      GoRuntimeType: 578880
-      GoKind: 5
-    - __kind: ArrayType
-      ID: 7
-      Name: '[2]string'
-      ByteSize: 32
-      GoRuntimeType: 678240
-      GoKind: 17
-      Count: 2
-      HasCount: true
-      Element: 8 GoStringHeaderType string
-    - __kind: GoStringHeaderType
-      ID: 8
-      Name: string
-      ByteSize: 16
-      GoRuntimeType: 578560
-      GoKind: 24
-      RawFields:
-        - Name: str
-          Offset: 0
-          Type: 239 PointerType *string.str
-        - Name: len
-          Offset: 8
-          Type: 1 BaseType int
-      Data: 238 GoStringDataType string.str
     - __kind: PointerType
-      ID: 9
-      Name: '*uint8'
+      ID: 209
+      Name: '**main.t'
       ByteSize: 8
-      GoRuntimeType: 388000
-      GoKind: 22
-      Pointee: 4 BaseType uint8
-    - __kind: ArrayType
-      ID: 10
-      Name: '[2]bool'
-      ByteSize: 2
-      GoKind: 17
-      Count: 2
-      HasCount: true
-      Element: 11 BaseType bool
-    - __kind: BaseType
-      ID: 11
-      Name: bool
-      ByteSize: 1
-      GoRuntimeType: 579584
-      GoKind: 1
-    - __kind: ArrayType
-      ID: 12
-      Name: '[2]int'
-      ByteSize: 16
-      GoRuntimeType: 676800
-      GoKind: 17
-      Count: 2
-      HasCount: true
-      Element: 1 BaseType int
-    - __kind: ArrayType
-      ID: 13
-      Name: '[2]int8'
-      ByteSize: 2
-      GoKind: 17
-      Count: 2
-      HasCount: true
-      Element: 14 BaseType int8
-    - __kind: BaseType
-      ID: 14
-      Name: int8
-      ByteSize: 1
-      GoRuntimeType: 578624
-      GoKind: 3
-    - __kind: ArrayType
-      ID: 15
-      Name: '[2]int16'
-      ByteSize: 4
-      GoKind: 17
-      Count: 2
-      HasCount: true
-      Element: 16 BaseType int16
-    - __kind: BaseType
-      ID: 16
-      Name: int16
-      ByteSize: 2
-      GoRuntimeType: 578752
-      GoKind: 4
-    - __kind: ArrayType
-      ID: 17
-      Name: '[2]int64'
-      ByteSize: 16
-      GoKind: 17
-      Count: 2
-      HasCount: true
-      Element: 18 BaseType int64
-    - __kind: BaseType
-      ID: 18
-      Name: int64
-      ByteSize: 8
-      GoRuntimeType: 579008
-      GoKind: 6
-    - __kind: ArrayType
-      ID: 19
-      Name: '[2]uint'
-      ByteSize: 16
-      GoKind: 17
-      Count: 2
-      HasCount: true
-      Element: 20 BaseType uint
-    - __kind: BaseType
-      ID: 20
-      Name: uint
-      ByteSize: 8
-      GoRuntimeType: 579200
-      GoKind: 7
-    - __kind: ArrayType
-      ID: 21
-      Name: '[2]uint16'
-      ByteSize: 4
-      GoKind: 17
-      Count: 2
-      HasCount: true
-      Element: 22 BaseType uint16
-    - __kind: BaseType
-      ID: 22
-      Name: uint16
-      ByteSize: 2
-      GoRuntimeType: 578816
-      GoKind: 9
-    - __kind: ArrayType
-      ID: 23
-      Name: '[2]uint32'
-      ByteSize: 8
-      GoKind: 17
-      Count: 2
-      HasCount: true
-      Element: 24 BaseType uint32
-    - __kind: BaseType
-      ID: 24
-      Name: uint32
-      ByteSize: 4
-      GoRuntimeType: 578944
-      GoKind: 10
-    - __kind: ArrayType
-      ID: 25
-      Name: '[2]uint64'
-      ByteSize: 16
-      GoRuntimeType: 678336
-      GoKind: 17
-      Count: 2
-      HasCount: true
-      Element: 26 BaseType uint64
-    - __kind: BaseType
-      ID: 26
-      Name: uint64
-      ByteSize: 8
-      GoRuntimeType: 579072
-      GoKind: 11
-    - __kind: ArrayType
-      ID: 27
-      Name: '[2][2]int'
-      ByteSize: 32
-      GoKind: 17
-      Count: 2
-      HasCount: true
-      Element: 12 ArrayType [2]int
-    - __kind: ArrayType
-      ID: 28
-      Name: '[2][2][2]int'
-      ByteSize: 64
-      GoKind: 17
-      Count: 2
-      HasCount: true
-      Element: 27 ArrayType [2][2]int
-    - __kind: ArrayType
-      ID: 29
-      Name: '[100]uint'
-      ByteSize: 800
-      GoKind: 17
-      Count: 100
-      HasCount: true
-      Element: 20 BaseType uint
-    - __kind: BaseType
-      ID: 30
-      Name: float32
-      ByteSize: 4
-      GoRuntimeType: 579456
-      GoKind: 13
-    - __kind: BaseType
-      ID: 31
-      Name: float64
-      ByteSize: 8
-      GoRuntimeType: 579520
-      GoKind: 14
-    - __kind: BaseType
-      ID: 32
-      Name: main.typeAlias
-      ByteSize: 2
-      GoKind: 9
-    - __kind: StructureType
-      ID: 33
-      Name: main.bigStruct
-      ByteSize: 48
-      GoKind: 25
-      RawFields:
-        - Name: x
-          Offset: 0
-          Type: 34 GoSliceHeaderType []*string
-        - Name: z
-          Offset: 24
-          Type: 1 BaseType int
-        - Name: writer
-          Offset: 32
-          Type: 37 GoInterfaceType io.Writer
-    - __kind: GoSliceHeaderType
-      ID: 34
-      Name: '[]*string'
-      ByteSize: 24
-      GoRuntimeType: 473376
-      GoKind: 23
-      RawFields:
-        - Name: array
-          Offset: 0
-          Type: 35 PointerType **string
-        - Name: len
-          Offset: 8
-          Type: 1 BaseType int
-        - Name: cap
-          Offset: 16
-          Type: 1 BaseType int
-      Data: 240 GoSliceDataType []*string.array
+      Pointee: 207 PointerType *main.t
     - __kind: PointerType
       ID: 35
       Name: '**string'
@@ -3367,2041 +3103,110 @@ Types:
       GoKind: 22
       Pointee: 36 PointerType *string
     - __kind: PointerType
-      ID: 36
-      Name: '*string'
+      ID: 194
+      Name: '**table<[4]int,[4]int>'
       ByteSize: 8
-      GoRuntimeType: 387872
-      GoKind: 22
-      Pointee: 8 GoStringHeaderType string
-    - __kind: GoInterfaceType
-      ID: 37
-      Name: io.Writer
-      ByteSize: 16
-      GoRuntimeType: 1.016032e+06
-      GoKind: 20
-      RawFields:
-        - Name: tab
-          Offset: 0
-          Type: 38 VoidPointerType unsafe.Pointer
-        - Name: data
-          Offset: 8
-          Type: 38 VoidPointerType unsafe.Pointer
-    - __kind: VoidPointerType
-      ID: 38
-      Name: unsafe.Pointer
-      ByteSize: 8
-      GoRuntimeType: 579648
-      GoKind: 26
-    - __kind: StructureType
-      ID: 39
-      Name: main.esotericStack
-      ByteSize: 64
-      GoRuntimeType: 1.953504e+06
-      GoKind: 25
-      RawFields:
-        - Name: _
-          Offset: 0
-          Type: 6 BaseType int32
-        - Name: _valid
-          Offset: 4
-          Type: 6 BaseType int32
-        - Name: c
-          Offset: 8
-          Type: 40 GoChannelType chan struct {}
-        - Name: val
-          Offset: 16
-          Type: 41 GoEmptyInterfaceType interface {}
-        - Name: _
-          Offset: 32
-          Type: 26 BaseType uint64
-        - Name: work
-          Offset: 40
-          Type: 42 GoInterfaceType main.something
-        - Name: foo
-          Offset: 56
-          Type: 43 GoSubroutineType func()
-    - __kind: GoChannelType
-      ID: 40
-      Name: chan struct {}
-      GoRuntimeType: 589824
-      GoKind: 18
-    - __kind: GoEmptyInterfaceType
-      ID: 41
-      Name: interface {}
-      ByteSize: 16
-      GoRuntimeType: 841248
-      GoKind: 20
-      RawFields:
-        - Name: _type
-          Offset: 0
-          Type: 38 VoidPointerType unsafe.Pointer
-        - Name: data
-          Offset: 8
-          Type: 38 VoidPointerType unsafe.Pointer
-    - __kind: GoInterfaceType
-      ID: 42
-      Name: main.something
-      ByteSize: 16
-      GoRuntimeType: 1.015776e+06
-      GoKind: 20
-      RawFields:
-        - Name: tab
-          Offset: 0
-          Type: 38 VoidPointerType unsafe.Pointer
-        - Name: data
-          Offset: 8
-          Type: 38 VoidPointerType unsafe.Pointer
-    - __kind: GoSubroutineType
-      ID: 43
-      Name: func()
-      ByteSize: 8
-      GoRuntimeType: 471584
-      GoKind: 19
-    - __kind: PointerType
-      ID: 44
-      Name: '*main.esotericHeap'
-      ByteSize: 8
-      GoRuntimeType: 382944
-      GoKind: 22
-      Pointee: 45 StructureType main.esotericHeap
-    - __kind: StructureType
-      ID: 45
-      Name: main.esotericHeap
-      ByteSize: 112
-      GoRuntimeType: 1.820416e+06
-      GoKind: 25
-      RawFields:
-        - Name: esotericStack
-          Offset: 0
-          Type: 39 StructureType main.esotericStack
-        - Name: mu
-          Offset: 64
-          Type: 46 StructureType sync.Mutex
-        - Name: once
-          Offset: 72
-          Type: 49 StructureType sync.Once
-        - Name: wg
-          Offset: 88
-          Type: 52 StructureType sync.WaitGroup
-        - Name: a
-          Offset: 104
-          Type: 55 StructureType sync/atomic.Int32
-    - __kind: StructureType
-      ID: 46
-      Name: sync.Mutex
-      ByteSize: 8
-      GoRuntimeType: 1.449216e+06
-      GoKind: 25
-      RawFields:
-        - Name: _
-          Offset: 0
-          Type: 47 StructureType sync.noCopy
-        - Name: mu
-          Offset: 0
-          Type: 48 StructureType internal/sync.Mutex
-    - __kind: StructureType
-      ID: 47
-      Name: sync.noCopy
-      GoRuntimeType: 981440
-      GoKind: 25
-      RawFields: []
-    - __kind: StructureType
-      ID: 48
-      Name: internal/sync.Mutex
-      ByteSize: 8
-      GoRuntimeType: 1.459296e+06
-      GoKind: 25
-      RawFields:
-        - Name: state
-          Offset: 0
-          Type: 6 BaseType int32
-        - Name: sema
-          Offset: 4
-          Type: 24 BaseType uint32
-    - __kind: StructureType
-      ID: 49
-      Name: sync.Once
-      ByteSize: 12
-      GoRuntimeType: 1.598272e+06
-      GoKind: 25
-      RawFields:
-        - Name: _
-          Offset: 0
-          Type: 47 StructureType sync.noCopy
-        - Name: done
-          Offset: 0
-          Type: 50 StructureType sync/atomic.Bool
-        - Name: m
-          Offset: 4
-          Type: 46 StructureType sync.Mutex
-    - __kind: StructureType
-      ID: 50
-      Name: sync/atomic.Bool
-      ByteSize: 4
-      GoRuntimeType: 1.450336e+06
-      GoKind: 25
-      RawFields:
-        - Name: _
-          Offset: 0
-          Type: 51 StructureType sync/atomic.noCopy
-        - Name: v
-          Offset: 0
-          Type: 24 BaseType uint32
-    - __kind: StructureType
-      ID: 51
-      Name: sync/atomic.noCopy
-      GoRuntimeType: 981536
-      GoKind: 25
-      RawFields: []
-    - __kind: StructureType
-      ID: 52
-      Name: sync.WaitGroup
-      ByteSize: 16
-      GoRuntimeType: 1.59808e+06
-      GoKind: 25
-      RawFields:
-        - Name: noCopy
-          Offset: 0
-          Type: 47 StructureType sync.noCopy
-        - Name: state
-          Offset: 0
-          Type: 53 StructureType sync/atomic.Uint64
-        - Name: sema
-          Offset: 8
-          Type: 24 BaseType uint32
-    - __kind: StructureType
-      ID: 53
-      Name: sync/atomic.Uint64
-      ByteSize: 8
-      GoRuntimeType: 1.598656e+06
-      GoKind: 25
-      RawFields:
-        - Name: _
-          Offset: 0
-          Type: 51 StructureType sync/atomic.noCopy
-        - Name: _
-          Offset: 0
-          Type: 54 StructureType sync/atomic.align64
-        - Name: v
-          Offset: 0
-          Type: 26 BaseType uint64
-    - __kind: StructureType
-      ID: 54
-      Name: sync/atomic.align64
-      GoRuntimeType: 981632
-      GoKind: 25
-      RawFields: []
-    - __kind: StructureType
-      ID: 55
-      Name: sync/atomic.Int32
-      ByteSize: 4
-      GoRuntimeType: 1.450496e+06
-      GoKind: 25
-      RawFields:
-        - Name: _
-          Offset: 0
-          Type: 51 StructureType sync/atomic.noCopy
-        - Name: v
-          Offset: 0
-          Type: 6 BaseType int32
-    - __kind: GoInterfaceType
-      ID: 56
-      Name: main.behavior
-      ByteSize: 16
-      GoRuntimeType: 1.015648e+06
-      GoKind: 20
-      RawFields:
-        - Name: tab
-          Offset: 0
-          Type: 38 VoidPointerType unsafe.Pointer
-        - Name: data
-          Offset: 8
-          Type: 38 VoidPointerType unsafe.Pointer
-    - __kind: GoInterfaceType
-      ID: 57
-      Name: error
-      ByteSize: 16
-      GoRuntimeType: 1.02e+06
-      GoKind: 20
-      RawFields:
-        - Name: tab
-          Offset: 0
-          Type: 38 VoidPointerType unsafe.Pointer
-        - Name: data
-          Offset: 8
-          Type: 38 VoidPointerType unsafe.Pointer
-    - __kind: StructureType
-      ID: 58
-      Name: main.structWithMap
-      ByteSize: 8
-      GoRuntimeType: 1.1768e+06
-      GoKind: 25
-      RawFields:
-        - Name: m
-          Offset: 0
-          Type: 59 GoMapType map[int]int
-    - __kind: GoMapType
-      ID: 59
-      Name: map[int]int
-      ByteSize: 8
-      GoRuntimeType: 1.121312e+06
-      GoKind: 21
-      HeaderType: 61 GoSwissMapHeaderType map<int,int>
-    - __kind: PointerType
-      ID: 60
-      Name: '*map<int,int>'
-      ByteSize: 8
-      Pointee: 61 GoSwissMapHeaderType map<int,int>
-    - __kind: GoSwissMapHeaderType
-      ID: 61
-      Name: map<int,int>
-      ByteSize: 48
-      GoKind: 25
-      RawFields:
-        - Name: used
-          Offset: 0
-          Type: 26 BaseType uint64
-        - Name: seed
-          Offset: 8
-          Type: 62 BaseType uintptr
-        - Name: dirPtr
-          Offset: 16
-          Type: 63 PointerType **table<int,int>
-        - Name: dirLen
-          Offset: 24
-          Type: 1 BaseType int
-        - Name: globalDepth
-          Offset: 32
-          Type: 4 BaseType uint8
-        - Name: globalShift
-          Offset: 33
-          Type: 4 BaseType uint8
-        - Name: writing
-          Offset: 34
-          Type: 4 BaseType uint8
-        - Name: tombstonePossible
-          Offset: 35
-          Type: 11 BaseType bool
-        - Name: clearSeq
-          Offset: 40
-          Type: 26 BaseType uint64
-      TablePtrSliceType: 242 GoSliceDataType []*table<int,int>.array
-      GroupType: 68 StructureType noalg.map.group[int]int
-    - __kind: BaseType
-      ID: 62
-      Name: uintptr
-      ByteSize: 8
-      GoRuntimeType: 579264
-      GoKind: 12
-    - __kind: PointerType
-      ID: 63
-      Name: '**table<int,int>'
-      ByteSize: 8
-      Pointee: 64 PointerType *table<int,int>
-    - __kind: PointerType
-      ID: 64
-      Name: '*table<int,int>'
-      ByteSize: 8
-      Pointee: 65 StructureType table<int,int>
-    - __kind: StructureType
-      ID: 65
-      Name: table<int,int>
-      ByteSize: 32
-      GoKind: 25
-      RawFields:
-        - Name: used
-          Offset: 0
-          Type: 22 BaseType uint16
-        - Name: capacity
-          Offset: 2
-          Type: 22 BaseType uint16
-        - Name: growthLeft
-          Offset: 4
-          Type: 22 BaseType uint16
-        - Name: localDepth
-          Offset: 6
-          Type: 4 BaseType uint8
-        - Name: index
-          Offset: 8
-          Type: 1 BaseType int
-        - Name: groups
-          Offset: 16
-          Type: 66 GoSwissMapGroupsType groupReference<int,int>
-    - __kind: GoSwissMapGroupsType
-      ID: 66
-      Name: groupReference<int,int>
-      ByteSize: 16
-      GoKind: 25
-      RawFields:
-        - Name: data
-          Offset: 0
-          Type: 67 PointerType *noalg.map.group[int]int
-        - Name: lengthMask
-          Offset: 8
-          Type: 26 BaseType uint64
-      GroupType: 68 StructureType noalg.map.group[int]int
-      GroupSliceType: 243 GoSliceDataType []noalg.map.group[int]int.array
-    - __kind: PointerType
-      ID: 67
-      Name: '*noalg.map.group[int]int'
-      ByteSize: 8
-      Pointee: 68 StructureType noalg.map.group[int]int
-    - __kind: StructureType
-      ID: 68
-      Name: noalg.map.group[int]int
-      ByteSize: 136
-      GoRuntimeType: 1.280288e+06
-      GoKind: 25
-      RawFields:
-        - Name: ctrl
-          Offset: 0
-          Type: 26 BaseType uint64
-        - Name: slots
-          Offset: 8
-          Type: 69 ArrayType noalg.[8]struct { key int; elem int }
-    - __kind: ArrayType
-      ID: 69
-      Name: noalg.[8]struct { key int; elem int }
-      ByteSize: 128
-      GoRuntimeType: 674784
-      GoKind: 17
-      Count: 8
-      HasCount: true
-      Element: 70 StructureType noalg.struct { key int; elem int }
-    - __kind: StructureType
-      ID: 70
-      Name: noalg.struct { key int; elem int }
-      ByteSize: 16
-      GoRuntimeType: 1.28016e+06
-      GoKind: 25
-      RawFields:
-        - Name: key
-          Offset: 0
-          Type: 1 BaseType int
-        - Name: elem
-          Offset: 8
-          Type: 1 BaseType int
-    - __kind: GoMapType
-      ID: 71
-      Name: map[string]main.nestedStruct
-      ByteSize: 8
-      GoRuntimeType: 1.12272e+06
-      GoKind: 21
-      HeaderType: 73 GoSwissMapHeaderType map<string,main.nestedStruct>
-    - __kind: PointerType
-      ID: 72
-      Name: '*map<string,main.nestedStruct>'
-      ByteSize: 8
-      Pointee: 73 GoSwissMapHeaderType map<string,main.nestedStruct>
-    - __kind: GoSwissMapHeaderType
-      ID: 73
-      Name: map<string,main.nestedStruct>
-      ByteSize: 48
-      GoKind: 25
-      RawFields:
-        - Name: used
-          Offset: 0
-          Type: 26 BaseType uint64
-        - Name: seed
-          Offset: 8
-          Type: 62 BaseType uintptr
-        - Name: dirPtr
-          Offset: 16
-          Type: 74 PointerType **table<string,main.nestedStruct>
-        - Name: dirLen
-          Offset: 24
-          Type: 1 BaseType int
-        - Name: globalDepth
-          Offset: 32
-          Type: 4 BaseType uint8
-        - Name: globalShift
-          Offset: 33
-          Type: 4 BaseType uint8
-        - Name: writing
-          Offset: 34
-          Type: 4 BaseType uint8
-        - Name: tombstonePossible
-          Offset: 35
-          Type: 11 BaseType bool
-        - Name: clearSeq
-          Offset: 40
-          Type: 26 BaseType uint64
-      TablePtrSliceType: 244 GoSliceDataType []*table<string,main.nestedStruct>.array
-      GroupType: 79 StructureType noalg.map.group[string]main.nestedStruct
-    - __kind: PointerType
-      ID: 74
-      Name: '**table<string,main.nestedStruct>'
-      ByteSize: 8
-      Pointee: 75 PointerType *table<string,main.nestedStruct>
-    - __kind: PointerType
-      ID: 75
-      Name: '*table<string,main.nestedStruct>'
-      ByteSize: 8
-      Pointee: 76 StructureType table<string,main.nestedStruct>
-    - __kind: StructureType
-      ID: 76
-      Name: table<string,main.nestedStruct>
-      ByteSize: 32
-      GoKind: 25
-      RawFields:
-        - Name: used
-          Offset: 0
-          Type: 22 BaseType uint16
-        - Name: capacity
-          Offset: 2
-          Type: 22 BaseType uint16
-        - Name: growthLeft
-          Offset: 4
-          Type: 22 BaseType uint16
-        - Name: localDepth
-          Offset: 6
-          Type: 4 BaseType uint8
-        - Name: index
-          Offset: 8
-          Type: 1 BaseType int
-        - Name: groups
-          Offset: 16
-          Type: 77 GoSwissMapGroupsType groupReference<string,main.nestedStruct>
-    - __kind: GoSwissMapGroupsType
-      ID: 77
-      Name: groupReference<string,main.nestedStruct>
-      ByteSize: 16
-      GoKind: 25
-      RawFields:
-        - Name: data
-          Offset: 0
-          Type: 78 PointerType *noalg.map.group[string]main.nestedStruct
-        - Name: lengthMask
-          Offset: 8
-          Type: 26 BaseType uint64
-      GroupType: 79 StructureType noalg.map.group[string]main.nestedStruct
-      GroupSliceType: 245 GoSliceDataType []noalg.map.group[string]main.nestedStruct.array
-    - __kind: PointerType
-      ID: 78
-      Name: '*noalg.map.group[string]main.nestedStruct'
-      ByteSize: 8
-      Pointee: 79 StructureType noalg.map.group[string]main.nestedStruct
-    - __kind: StructureType
-      ID: 79
-      Name: noalg.map.group[string]main.nestedStruct
-      ByteSize: 328
-      GoRuntimeType: 1.283104e+06
-      GoKind: 25
-      RawFields:
-        - Name: ctrl
-          Offset: 0
-          Type: 26 BaseType uint64
-        - Name: slots
-          Offset: 8
-          Type: 80 ArrayType noalg.[8]struct { key string; elem main.nestedStruct }
-    - __kind: ArrayType
-      ID: 80
-      Name: noalg.[8]struct { key string; elem main.nestedStruct }
-      ByteSize: 320
-      GoRuntimeType: 677472
-      GoKind: 17
-      Count: 8
-      HasCount: true
-      Element: 81 StructureType noalg.struct { key string; elem main.nestedStruct }
-    - __kind: StructureType
-      ID: 81
-      Name: noalg.struct { key string; elem main.nestedStruct }
-      ByteSize: 40
-      GoRuntimeType: 1.282976e+06
-      GoKind: 25
-      RawFields:
-        - Name: key
-          Offset: 0
-          Type: 8 GoStringHeaderType string
-        - Name: elem
-          Offset: 16
-          Type: 82 StructureType main.nestedStruct
-    - __kind: StructureType
-      ID: 82
-      Name: main.nestedStruct
-      ByteSize: 24
-      GoRuntimeType: 1.447936e+06
-      GoKind: 25
-      RawFields:
-        - Name: anotherInt
-          Offset: 0
-          Type: 1 BaseType int
-        - Name: anotherString
-          Offset: 8
-          Type: 8 GoStringHeaderType string
-    - __kind: GoMapType
-      ID: 83
-      Name: map[string]int
-      ByteSize: 8
-      GoRuntimeType: 1.122592e+06
-      GoKind: 21
-      HeaderType: 85 GoSwissMapHeaderType map<string,int>
-    - __kind: PointerType
-      ID: 84
-      Name: '*map<string,int>'
-      ByteSize: 8
-      Pointee: 85 GoSwissMapHeaderType map<string,int>
-    - __kind: GoSwissMapHeaderType
-      ID: 85
-      Name: map<string,int>
-      ByteSize: 48
-      GoKind: 25
-      RawFields:
-        - Name: used
-          Offset: 0
-          Type: 26 BaseType uint64
-        - Name: seed
-          Offset: 8
-          Type: 62 BaseType uintptr
-        - Name: dirPtr
-          Offset: 16
-          Type: 86 PointerType **table<string,int>
-        - Name: dirLen
-          Offset: 24
-          Type: 1 BaseType int
-        - Name: globalDepth
-          Offset: 32
-          Type: 4 BaseType uint8
-        - Name: globalShift
-          Offset: 33
-          Type: 4 BaseType uint8
-        - Name: writing
-          Offset: 34
-          Type: 4 BaseType uint8
-        - Name: tombstonePossible
-          Offset: 35
-          Type: 11 BaseType bool
-        - Name: clearSeq
-          Offset: 40
-          Type: 26 BaseType uint64
-      TablePtrSliceType: 246 GoSliceDataType []*table<string,int>.array
-      GroupType: 91 StructureType noalg.map.group[string]int
-    - __kind: PointerType
-      ID: 86
-      Name: '**table<string,int>'
-      ByteSize: 8
-      Pointee: 87 PointerType *table<string,int>
-    - __kind: PointerType
-      ID: 87
-      Name: '*table<string,int>'
-      ByteSize: 8
-      Pointee: 88 StructureType table<string,int>
-    - __kind: StructureType
-      ID: 88
-      Name: table<string,int>
-      ByteSize: 32
-      GoKind: 25
-      RawFields:
-        - Name: used
-          Offset: 0
-          Type: 22 BaseType uint16
-        - Name: capacity
-          Offset: 2
-          Type: 22 BaseType uint16
-        - Name: growthLeft
-          Offset: 4
-          Type: 22 BaseType uint16
-        - Name: localDepth
-          Offset: 6
-          Type: 4 BaseType uint8
-        - Name: index
-          Offset: 8
-          Type: 1 BaseType int
-        - Name: groups
-          Offset: 16
-          Type: 89 GoSwissMapGroupsType groupReference<string,int>
-    - __kind: GoSwissMapGroupsType
-      ID: 89
-      Name: groupReference<string,int>
-      ByteSize: 16
-      GoKind: 25
-      RawFields:
-        - Name: data
-          Offset: 0
-          Type: 90 PointerType *noalg.map.group[string]int
-        - Name: lengthMask
-          Offset: 8
-          Type: 26 BaseType uint64
-      GroupType: 91 StructureType noalg.map.group[string]int
-      GroupSliceType: 247 GoSliceDataType []noalg.map.group[string]int.array
-    - __kind: PointerType
-      ID: 90
-      Name: '*noalg.map.group[string]int'
-      ByteSize: 8
-      Pointee: 91 StructureType noalg.map.group[string]int
-    - __kind: StructureType
-      ID: 91
-      Name: noalg.map.group[string]int
-      ByteSize: 200
-      GoRuntimeType: 1.282848e+06
-      GoKind: 25
-      RawFields:
-        - Name: ctrl
-          Offset: 0
-          Type: 26 BaseType uint64
-        - Name: slots
-          Offset: 8
-          Type: 92 ArrayType noalg.[8]struct { key string; elem int }
-    - __kind: ArrayType
-      ID: 92
-      Name: noalg.[8]struct { key string; elem int }
-      ByteSize: 192
-      GoRuntimeType: 677376
-      GoKind: 17
-      Count: 8
-      HasCount: true
-      Element: 93 StructureType noalg.struct { key string; elem int }
-    - __kind: StructureType
-      ID: 93
-      Name: noalg.struct { key string; elem int }
-      ByteSize: 24
-      GoRuntimeType: 1.28272e+06
-      GoKind: 25
-      RawFields:
-        - Name: key
-          Offset: 0
-          Type: 8 GoStringHeaderType string
-        - Name: elem
-          Offset: 16
-          Type: 1 BaseType int
-    - __kind: GoMapType
-      ID: 94
-      Name: map[string][]string
-      ByteSize: 8
-      GoRuntimeType: 1.122464e+06
-      GoKind: 21
-      HeaderType: 96 GoSwissMapHeaderType map<string,[]string>
-    - __kind: PointerType
-      ID: 95
-      Name: '*map<string,[]string>'
-      ByteSize: 8
-      Pointee: 96 GoSwissMapHeaderType map<string,[]string>
-    - __kind: GoSwissMapHeaderType
-      ID: 96
-      Name: map<string,[]string>
-      ByteSize: 48
-      GoKind: 25
-      RawFields:
-        - Name: used
-          Offset: 0
-          Type: 26 BaseType uint64
-        - Name: seed
-          Offset: 8
-          Type: 62 BaseType uintptr
-        - Name: dirPtr
-          Offset: 16
-          Type: 97 PointerType **table<string,[]string>
-        - Name: dirLen
-          Offset: 24
-          Type: 1 BaseType int
-        - Name: globalDepth
-          Offset: 32
-          Type: 4 BaseType uint8
-        - Name: globalShift
-          Offset: 33
-          Type: 4 BaseType uint8
-        - Name: writing
-          Offset: 34
-          Type: 4 BaseType uint8
-        - Name: tombstonePossible
-          Offset: 35
-          Type: 11 BaseType bool
-        - Name: clearSeq
-          Offset: 40
-          Type: 26 BaseType uint64
-      TablePtrSliceType: 248 GoSliceDataType []*table<string,[]string>.array
-      GroupType: 102 StructureType noalg.map.group[string][]string
-    - __kind: PointerType
-      ID: 97
-      Name: '**table<string,[]string>'
-      ByteSize: 8
-      Pointee: 98 PointerType *table<string,[]string>
-    - __kind: PointerType
-      ID: 98
-      Name: '*table<string,[]string>'
-      ByteSize: 8
-      Pointee: 99 StructureType table<string,[]string>
-    - __kind: StructureType
-      ID: 99
-      Name: table<string,[]string>
-      ByteSize: 32
-      GoKind: 25
-      RawFields:
-        - Name: used
-          Offset: 0
-          Type: 22 BaseType uint16
-        - Name: capacity
-          Offset: 2
-          Type: 22 BaseType uint16
-        - Name: growthLeft
-          Offset: 4
-          Type: 22 BaseType uint16
-        - Name: localDepth
-          Offset: 6
-          Type: 4 BaseType uint8
-        - Name: index
-          Offset: 8
-          Type: 1 BaseType int
-        - Name: groups
-          Offset: 16
-          Type: 100 GoSwissMapGroupsType groupReference<string,[]string>
-    - __kind: GoSwissMapGroupsType
-      ID: 100
-      Name: groupReference<string,[]string>
-      ByteSize: 16
-      GoKind: 25
-      RawFields:
-        - Name: data
-          Offset: 0
-          Type: 101 PointerType *noalg.map.group[string][]string
-        - Name: lengthMask
-          Offset: 8
-          Type: 26 BaseType uint64
-      GroupType: 102 StructureType noalg.map.group[string][]string
-      GroupSliceType: 249 GoSliceDataType []noalg.map.group[string][]string.array
-    - __kind: PointerType
-      ID: 101
-      Name: '*noalg.map.group[string][]string'
-      ByteSize: 8
-      Pointee: 102 StructureType noalg.map.group[string][]string
-    - __kind: StructureType
-      ID: 102
-      Name: noalg.map.group[string][]string
-      ByteSize: 328
-      GoRuntimeType: 1.282592e+06
-      GoKind: 25
-      RawFields:
-        - Name: ctrl
-          Offset: 0
-          Type: 26 BaseType uint64
-        - Name: slots
-          Offset: 8
-          Type: 103 ArrayType noalg.[8]struct { key string; elem []string }
-    - __kind: ArrayType
-      ID: 103
-      Name: noalg.[8]struct { key string; elem []string }
-      ByteSize: 320
-      GoRuntimeType: 677280
-      GoKind: 17
-      Count: 8
-      HasCount: true
-      Element: 104 StructureType noalg.struct { key string; elem []string }
-    - __kind: StructureType
-      ID: 104
-      Name: noalg.struct { key string; elem []string }
-      ByteSize: 40
-      GoRuntimeType: 1.282464e+06
-      GoKind: 25
-      RawFields:
-        - Name: key
-          Offset: 0
-          Type: 8 GoStringHeaderType string
-        - Name: elem
-          Offset: 16
-          Type: 105 GoSliceHeaderType []string
-    - __kind: GoSliceHeaderType
-      ID: 105
-      Name: '[]string'
-      ByteSize: 24
-      GoRuntimeType: 481824
-      GoKind: 23
-      RawFields:
-        - Name: array
-          Offset: 0
-          Type: 36 PointerType *string
-        - Name: len
-          Offset: 8
-          Type: 1 BaseType int
-        - Name: cap
-          Offset: 16
-          Type: 1 BaseType int
-      Data: 250 GoSliceDataType []string.array
-    - __kind: GoMapType
-      ID: 106
-      Name: map[[4]string][2]int
-      ByteSize: 8
-      GoRuntimeType: 1.121952e+06
-      GoKind: 21
-      HeaderType: 108 GoSwissMapHeaderType map<[4]string,[2]int>
-    - __kind: PointerType
-      ID: 107
-      Name: '*map<[4]string,[2]int>'
-      ByteSize: 8
-      Pointee: 108 GoSwissMapHeaderType map<[4]string,[2]int>
-    - __kind: GoSwissMapHeaderType
-      ID: 108
-      Name: map<[4]string,[2]int>
-      ByteSize: 48
-      GoKind: 25
-      RawFields:
-        - Name: used
-          Offset: 0
-          Type: 26 BaseType uint64
-        - Name: seed
-          Offset: 8
-          Type: 62 BaseType uintptr
-        - Name: dirPtr
-          Offset: 16
-          Type: 109 PointerType **table<[4]string,[2]int>
-        - Name: dirLen
-          Offset: 24
-          Type: 1 BaseType int
-        - Name: globalDepth
-          Offset: 32
-          Type: 4 BaseType uint8
-        - Name: globalShift
-          Offset: 33
-          Type: 4 BaseType uint8
-        - Name: writing
-          Offset: 34
-          Type: 4 BaseType uint8
-        - Name: tombstonePossible
-          Offset: 35
-          Type: 11 BaseType bool
-        - Name: clearSeq
-          Offset: 40
-          Type: 26 BaseType uint64
-      TablePtrSliceType: 252 GoSliceDataType []*table<[4]string,[2]int>.array
-      GroupType: 114 StructureType noalg.map.group[[4]string][2]int
-    - __kind: PointerType
-      ID: 109
-      Name: '**table<[4]string,[2]int>'
-      ByteSize: 8
-      Pointee: 110 PointerType *table<[4]string,[2]int>
-    - __kind: PointerType
-      ID: 110
-      Name: '*table<[4]string,[2]int>'
-      ByteSize: 8
-      Pointee: 111 StructureType table<[4]string,[2]int>
-    - __kind: StructureType
-      ID: 111
-      Name: table<[4]string,[2]int>
-      ByteSize: 32
-      GoKind: 25
-      RawFields:
-        - Name: used
-          Offset: 0
-          Type: 22 BaseType uint16
-        - Name: capacity
-          Offset: 2
-          Type: 22 BaseType uint16
-        - Name: growthLeft
-          Offset: 4
-          Type: 22 BaseType uint16
-        - Name: localDepth
-          Offset: 6
-          Type: 4 BaseType uint8
-        - Name: index
-          Offset: 8
-          Type: 1 BaseType int
-        - Name: groups
-          Offset: 16
-          Type: 112 GoSwissMapGroupsType groupReference<[4]string,[2]int>
-    - __kind: GoSwissMapGroupsType
-      ID: 112
-      Name: groupReference<[4]string,[2]int>
-      ByteSize: 16
-      GoKind: 25
-      RawFields:
-        - Name: data
-          Offset: 0
-          Type: 113 PointerType *noalg.map.group[[4]string][2]int
-        - Name: lengthMask
-          Offset: 8
-          Type: 26 BaseType uint64
-      GroupType: 114 StructureType noalg.map.group[[4]string][2]int
-      GroupSliceType: 253 GoSliceDataType []noalg.map.group[[4]string][2]int.array
-    - __kind: PointerType
-      ID: 113
-      Name: '*noalg.map.group[[4]string][2]int'
-      ByteSize: 8
-      Pointee: 114 StructureType noalg.map.group[[4]string][2]int
-    - __kind: StructureType
-      ID: 114
-      Name: noalg.map.group[[4]string][2]int
-      ByteSize: 648
-      GoRuntimeType: 1.281568e+06
-      GoKind: 25
-      RawFields:
-        - Name: ctrl
-          Offset: 0
-          Type: 26 BaseType uint64
-        - Name: slots
-          Offset: 8
-          Type: 115 ArrayType noalg.[8]struct { key [4]string; elem [2]int }
-    - __kind: ArrayType
-      ID: 115
-      Name: noalg.[8]struct { key [4]string; elem [2]int }
-      ByteSize: 640
-      GoRuntimeType: 676896
-      GoKind: 17
-      Count: 8
-      HasCount: true
-      Element: 116 StructureType noalg.struct { key [4]string; elem [2]int }
-    - __kind: StructureType
-      ID: 116
-      Name: noalg.struct { key [4]string; elem [2]int }
-      ByteSize: 80
-      GoRuntimeType: 1.28144e+06
-      GoKind: 25
-      RawFields:
-        - Name: key
-          Offset: 0
-          Type: 117 ArrayType [4]string
-        - Name: elem
-          Offset: 64
-          Type: 12 ArrayType [2]int
-    - __kind: ArrayType
-      ID: 117
-      Name: '[4]string'
-      ByteSize: 64
-      GoRuntimeType: 676704
-      GoKind: 17
-      Count: 4
-      HasCount: true
-      Element: 8 GoStringHeaderType string
-    - __kind: ArrayType
-      ID: 118
-      Name: '[2]map[string]int'
-      ByteSize: 16
-      GoKind: 17
-      Count: 2
-      HasCount: true
-      Element: 83 GoMapType map[string]int
-    - __kind: PointerType
-      ID: 119
-      Name: '*map[string]int'
-      ByteSize: 8
-      GoKind: 22
-      Pointee: 83 GoMapType map[string]int
-    - __kind: GoMapType
-      ID: 120
-      Name: map[string][]main.structWithMap
-      ByteSize: 8
-      GoRuntimeType: 1.122336e+06
-      GoKind: 21
-      HeaderType: 122 GoSwissMapHeaderType map<string,[]main.structWithMap>
-    - __kind: PointerType
-      ID: 121
-      Name: '*map<string,[]main.structWithMap>'
-      ByteSize: 8
-      Pointee: 122 GoSwissMapHeaderType map<string,[]main.structWithMap>
-    - __kind: GoSwissMapHeaderType
-      ID: 122
-      Name: map<string,[]main.structWithMap>
-      ByteSize: 48
-      GoKind: 25
-      RawFields:
-        - Name: used
-          Offset: 0
-          Type: 26 BaseType uint64
-        - Name: seed
-          Offset: 8
-          Type: 62 BaseType uintptr
-        - Name: dirPtr
-          Offset: 16
-          Type: 123 PointerType **table<string,[]main.structWithMap>
-        - Name: dirLen
-          Offset: 24
-          Type: 1 BaseType int
-        - Name: globalDepth
-          Offset: 32
-          Type: 4 BaseType uint8
-        - Name: globalShift
-          Offset: 33
-          Type: 4 BaseType uint8
-        - Name: writing
-          Offset: 34
-          Type: 4 BaseType uint8
-        - Name: tombstonePossible
-          Offset: 35
-          Type: 11 BaseType bool
-        - Name: clearSeq
-          Offset: 40
-          Type: 26 BaseType uint64
-      TablePtrSliceType: 254 GoSliceDataType []*table<string,[]main.structWithMap>.array
-      GroupType: 128 StructureType noalg.map.group[string][]main.structWithMap
-    - __kind: PointerType
-      ID: 123
-      Name: '**table<string,[]main.structWithMap>'
-      ByteSize: 8
-      Pointee: 124 PointerType *table<string,[]main.structWithMap>
-    - __kind: PointerType
-      ID: 124
-      Name: '*table<string,[]main.structWithMap>'
-      ByteSize: 8
-      Pointee: 125 StructureType table<string,[]main.structWithMap>
-    - __kind: StructureType
-      ID: 125
-      Name: table<string,[]main.structWithMap>
-      ByteSize: 32
-      GoKind: 25
-      RawFields:
-        - Name: used
-          Offset: 0
-          Type: 22 BaseType uint16
-        - Name: capacity
-          Offset: 2
-          Type: 22 BaseType uint16
-        - Name: growthLeft
-          Offset: 4
-          Type: 22 BaseType uint16
-        - Name: localDepth
-          Offset: 6
-          Type: 4 BaseType uint8
-        - Name: index
-          Offset: 8
-          Type: 1 BaseType int
-        - Name: groups
-          Offset: 16
-          Type: 126 GoSwissMapGroupsType groupReference<string,[]main.structWithMap>
-    - __kind: GoSwissMapGroupsType
-      ID: 126
-      Name: groupReference<string,[]main.structWithMap>
-      ByteSize: 16
-      GoKind: 25
-      RawFields:
-        - Name: data
-          Offset: 0
-          Type: 127 PointerType *noalg.map.group[string][]main.structWithMap
-        - Name: lengthMask
-          Offset: 8
-          Type: 26 BaseType uint64
-      GroupType: 128 StructureType noalg.map.group[string][]main.structWithMap
-      GroupSliceType: 255 GoSliceDataType []noalg.map.group[string][]main.structWithMap.array
-    - __kind: PointerType
-      ID: 127
-      Name: '*noalg.map.group[string][]main.structWithMap'
-      ByteSize: 8
-      Pointee: 128 StructureType noalg.map.group[string][]main.structWithMap
-    - __kind: StructureType
-      ID: 128
-      Name: noalg.map.group[string][]main.structWithMap
-      ByteSize: 328
-      GoRuntimeType: 1.282336e+06
-      GoKind: 25
-      RawFields:
-        - Name: ctrl
-          Offset: 0
-          Type: 26 BaseType uint64
-        - Name: slots
-          Offset: 8
-          Type: 129 ArrayType noalg.[8]struct { key string; elem []main.structWithMap }
-    - __kind: ArrayType
-      ID: 129
-      Name: noalg.[8]struct { key string; elem []main.structWithMap }
-      ByteSize: 320
-      GoRuntimeType: 677184
-      GoKind: 17
-      Count: 8
-      HasCount: true
-      Element: 130 StructureType noalg.struct { key string; elem []main.structWithMap }
-    - __kind: StructureType
-      ID: 130
-      Name: noalg.struct { key string; elem []main.structWithMap }
-      ByteSize: 40
-      GoRuntimeType: 1.282208e+06
-      GoKind: 25
-      RawFields:
-        - Name: key
-          Offset: 0
-          Type: 8 GoStringHeaderType string
-        - Name: elem
-          Offset: 16
-          Type: 131 GoSliceHeaderType []main.structWithMap
-    - __kind: GoSliceHeaderType
-      ID: 131
-      Name: '[]main.structWithMap'
-      ByteSize: 24
-      GoRuntimeType: 472608
-      GoKind: 23
-      RawFields:
-        - Name: array
-          Offset: 0
-          Type: 132 PointerType *main.structWithMap
-        - Name: len
-          Offset: 8
-          Type: 1 BaseType int
-        - Name: cap
-          Offset: 16
-          Type: 1 BaseType int
-      Data: 256 GoSliceDataType []main.structWithMap.array
-    - __kind: PointerType
-      ID: 132
-      Name: '*main.structWithMap'
-      ByteSize: 8
-      GoRuntimeType: 382880
-      GoKind: 22
-      Pointee: 58 StructureType main.structWithMap
-    - __kind: GoMapType
-      ID: 133
-      Name: map[bool]main.node
-      ByteSize: 8
-      GoRuntimeType: 1.12208e+06
-      GoKind: 21
-      HeaderType: 135 GoSwissMapHeaderType map<bool,main.node>
-    - __kind: PointerType
-      ID: 134
-      Name: '*map<bool,main.node>'
-      ByteSize: 8
-      Pointee: 135 GoSwissMapHeaderType map<bool,main.node>
-    - __kind: GoSwissMapHeaderType
-      ID: 135
-      Name: map<bool,main.node>
-      ByteSize: 48
-      GoKind: 25
-      RawFields:
-        - Name: used
-          Offset: 0
-          Type: 26 BaseType uint64
-        - Name: seed
-          Offset: 8
-          Type: 62 BaseType uintptr
-        - Name: dirPtr
-          Offset: 16
-          Type: 136 PointerType **table<bool,main.node>
-        - Name: dirLen
-          Offset: 24
-          Type: 1 BaseType int
-        - Name: globalDepth
-          Offset: 32
-          Type: 4 BaseType uint8
-        - Name: globalShift
-          Offset: 33
-          Type: 4 BaseType uint8
-        - Name: writing
-          Offset: 34
-          Type: 4 BaseType uint8
-        - Name: tombstonePossible
-          Offset: 35
-          Type: 11 BaseType bool
-        - Name: clearSeq
-          Offset: 40
-          Type: 26 BaseType uint64
-      TablePtrSliceType: 258 GoSliceDataType []*table<bool,main.node>.array
-      GroupType: 141 StructureType noalg.map.group[bool]main.node
-    - __kind: PointerType
-      ID: 136
-      Name: '**table<bool,main.node>'
-      ByteSize: 8
-      Pointee: 137 PointerType *table<bool,main.node>
-    - __kind: PointerType
-      ID: 137
-      Name: '*table<bool,main.node>'
-      ByteSize: 8
-      Pointee: 138 StructureType table<bool,main.node>
-    - __kind: StructureType
-      ID: 138
-      Name: table<bool,main.node>
-      ByteSize: 32
-      GoKind: 25
-      RawFields:
-        - Name: used
-          Offset: 0
-          Type: 22 BaseType uint16
-        - Name: capacity
-          Offset: 2
-          Type: 22 BaseType uint16
-        - Name: growthLeft
-          Offset: 4
-          Type: 22 BaseType uint16
-        - Name: localDepth
-          Offset: 6
-          Type: 4 BaseType uint8
-        - Name: index
-          Offset: 8
-          Type: 1 BaseType int
-        - Name: groups
-          Offset: 16
-          Type: 139 GoSwissMapGroupsType groupReference<bool,main.node>
-    - __kind: GoSwissMapGroupsType
-      ID: 139
-      Name: groupReference<bool,main.node>
-      ByteSize: 16
-      GoKind: 25
-      RawFields:
-        - Name: data
-          Offset: 0
-          Type: 140 PointerType *noalg.map.group[bool]main.node
-        - Name: lengthMask
-          Offset: 8
-          Type: 26 BaseType uint64
-      GroupType: 141 StructureType noalg.map.group[bool]main.node
-      GroupSliceType: 259 GoSliceDataType []noalg.map.group[bool]main.node.array
-    - __kind: PointerType
-      ID: 140
-      Name: '*noalg.map.group[bool]main.node'
-      ByteSize: 8
-      Pointee: 141 StructureType noalg.map.group[bool]main.node
-    - __kind: StructureType
-      ID: 141
-      Name: noalg.map.group[bool]main.node
-      ByteSize: 200
-      GoRuntimeType: 1.281824e+06
-      GoKind: 25
-      RawFields:
-        - Name: ctrl
-          Offset: 0
-          Type: 26 BaseType uint64
-        - Name: slots
-          Offset: 8
-          Type: 142 ArrayType noalg.[8]struct { key bool; elem main.node }
-    - __kind: ArrayType
-      ID: 142
-      Name: noalg.[8]struct { key bool; elem main.node }
-      ByteSize: 192
-      GoRuntimeType: 676992
-      GoKind: 17
-      Count: 8
-      HasCount: true
-      Element: 143 StructureType noalg.struct { key bool; elem main.node }
-    - __kind: StructureType
-      ID: 143
-      Name: noalg.struct { key bool; elem main.node }
-      ByteSize: 24
-      GoRuntimeType: 1.281696e+06
-      GoKind: 25
-      RawFields:
-        - Name: key
-          Offset: 0
-          Type: 11 BaseType bool
-        - Name: elem
-          Offset: 8
-          Type: 144 StructureType main.node
-    - __kind: StructureType
-      ID: 144
-      Name: main.node
-      ByteSize: 16
-      GoRuntimeType: 1.447776e+06
-      GoKind: 25
-      RawFields:
-        - Name: val
-          Offset: 0
-          Type: 1 BaseType int
-        - Name: b
-          Offset: 8
-          Type: 145 PointerType *main.node
-    - __kind: PointerType
-      ID: 145
-      Name: '*main.node'
-      ByteSize: 8
-      GoRuntimeType: 383008
-      GoKind: 22
-      Pointee: 144 StructureType main.node
-    - __kind: GoMapType
-      ID: 146
-      Name: map[int]uint8
-      ByteSize: 8
-      GoRuntimeType: 1.122208e+06
-      GoKind: 21
-      HeaderType: 148 GoSwissMapHeaderType map<int,uint8>
-    - __kind: PointerType
-      ID: 147
-      Name: '*map<int,uint8>'
-      ByteSize: 8
-      Pointee: 148 GoSwissMapHeaderType map<int,uint8>
-    - __kind: GoSwissMapHeaderType
-      ID: 148
-      Name: map<int,uint8>
-      ByteSize: 48
-      GoKind: 25
-      RawFields:
-        - Name: used
-          Offset: 0
-          Type: 26 BaseType uint64
-        - Name: seed
-          Offset: 8
-          Type: 62 BaseType uintptr
-        - Name: dirPtr
-          Offset: 16
-          Type: 149 PointerType **table<int,uint8>
-        - Name: dirLen
-          Offset: 24
-          Type: 1 BaseType int
-        - Name: globalDepth
-          Offset: 32
-          Type: 4 BaseType uint8
-        - Name: globalShift
-          Offset: 33
-          Type: 4 BaseType uint8
-        - Name: writing
-          Offset: 34
-          Type: 4 BaseType uint8
-        - Name: tombstonePossible
-          Offset: 35
-          Type: 11 BaseType bool
-        - Name: clearSeq
-          Offset: 40
-          Type: 26 BaseType uint64
-      TablePtrSliceType: 260 GoSliceDataType []*table<int,uint8>.array
-      GroupType: 154 StructureType noalg.map.group[int]uint8
-    - __kind: PointerType
-      ID: 149
-      Name: '**table<int,uint8>'
-      ByteSize: 8
-      Pointee: 150 PointerType *table<int,uint8>
-    - __kind: PointerType
-      ID: 150
-      Name: '*table<int,uint8>'
-      ByteSize: 8
-      Pointee: 151 StructureType table<int,uint8>
-    - __kind: StructureType
-      ID: 151
-      Name: table<int,uint8>
-      ByteSize: 32
-      GoKind: 25
-      RawFields:
-        - Name: used
-          Offset: 0
-          Type: 22 BaseType uint16
-        - Name: capacity
-          Offset: 2
-          Type: 22 BaseType uint16
-        - Name: growthLeft
-          Offset: 4
-          Type: 22 BaseType uint16
-        - Name: localDepth
-          Offset: 6
-          Type: 4 BaseType uint8
-        - Name: index
-          Offset: 8
-          Type: 1 BaseType int
-        - Name: groups
-          Offset: 16
-          Type: 152 GoSwissMapGroupsType groupReference<int,uint8>
-    - __kind: GoSwissMapGroupsType
-      ID: 152
-      Name: groupReference<int,uint8>
-      ByteSize: 16
-      GoKind: 25
-      RawFields:
-        - Name: data
-          Offset: 0
-          Type: 153 PointerType *noalg.map.group[int]uint8
-        - Name: lengthMask
-          Offset: 8
-          Type: 26 BaseType uint64
-      GroupType: 154 StructureType noalg.map.group[int]uint8
-      GroupSliceType: 261 GoSliceDataType []noalg.map.group[int]uint8.array
-    - __kind: PointerType
-      ID: 153
-      Name: '*noalg.map.group[int]uint8'
-      ByteSize: 8
-      Pointee: 154 StructureType noalg.map.group[int]uint8
-    - __kind: StructureType
-      ID: 154
-      Name: noalg.map.group[int]uint8
-      ByteSize: 136
-      GoRuntimeType: 1.28208e+06
-      GoKind: 25
-      RawFields:
-        - Name: ctrl
-          Offset: 0
-          Type: 26 BaseType uint64
-        - Name: slots
-          Offset: 8
-          Type: 155 ArrayType noalg.[8]struct { key int; elem uint8 }
-    - __kind: ArrayType
-      ID: 155
-      Name: noalg.[8]struct { key int; elem uint8 }
-      ByteSize: 128
-      GoRuntimeType: 677088
-      GoKind: 17
-      Count: 8
-      HasCount: true
-      Element: 156 StructureType noalg.struct { key int; elem uint8 }
-    - __kind: StructureType
-      ID: 156
-      Name: noalg.struct { key int; elem uint8 }
-      ByteSize: 16
-      GoRuntimeType: 1.281952e+06
-      GoKind: 25
-      RawFields:
-        - Name: key
-          Offset: 0
-          Type: 1 BaseType int
-        - Name: elem
-          Offset: 8
-          Type: 4 BaseType uint8
-    - __kind: GoMapType
-      ID: 157
-      Name: map[uint8]uint8
-      ByteSize: 8
-      GoRuntimeType: 1.122976e+06
-      GoKind: 21
-      HeaderType: 159 GoSwissMapHeaderType map<uint8,uint8>
-    - __kind: PointerType
-      ID: 158
-      Name: '*map<uint8,uint8>'
-      ByteSize: 8
-      Pointee: 159 GoSwissMapHeaderType map<uint8,uint8>
-    - __kind: GoSwissMapHeaderType
-      ID: 159
-      Name: map<uint8,uint8>
-      ByteSize: 48
-      GoKind: 25
-      RawFields:
-        - Name: used
-          Offset: 0
-          Type: 26 BaseType uint64
-        - Name: seed
-          Offset: 8
-          Type: 62 BaseType uintptr
-        - Name: dirPtr
-          Offset: 16
-          Type: 160 PointerType **table<uint8,uint8>
-        - Name: dirLen
-          Offset: 24
-          Type: 1 BaseType int
-        - Name: globalDepth
-          Offset: 32
-          Type: 4 BaseType uint8
-        - Name: globalShift
-          Offset: 33
-          Type: 4 BaseType uint8
-        - Name: writing
-          Offset: 34
-          Type: 4 BaseType uint8
-        - Name: tombstonePossible
-          Offset: 35
-          Type: 11 BaseType bool
-        - Name: clearSeq
-          Offset: 40
-          Type: 26 BaseType uint64
-      TablePtrSliceType: 262 GoSliceDataType []*table<uint8,uint8>.array
-      GroupType: 165 StructureType noalg.map.group[uint8]uint8
-    - __kind: PointerType
-      ID: 160
-      Name: '**table<uint8,uint8>'
-      ByteSize: 8
-      Pointee: 161 PointerType *table<uint8,uint8>
-    - __kind: PointerType
-      ID: 161
-      Name: '*table<uint8,uint8>'
-      ByteSize: 8
-      Pointee: 162 StructureType table<uint8,uint8>
-    - __kind: StructureType
-      ID: 162
-      Name: table<uint8,uint8>
-      ByteSize: 32
-      GoKind: 25
-      RawFields:
-        - Name: used
-          Offset: 0
-          Type: 22 BaseType uint16
-        - Name: capacity
-          Offset: 2
-          Type: 22 BaseType uint16
-        - Name: growthLeft
-          Offset: 4
-          Type: 22 BaseType uint16
-        - Name: localDepth
-          Offset: 6
-          Type: 4 BaseType uint8
-        - Name: index
-          Offset: 8
-          Type: 1 BaseType int
-        - Name: groups
-          Offset: 16
-          Type: 163 GoSwissMapGroupsType groupReference<uint8,uint8>
-    - __kind: GoSwissMapGroupsType
-      ID: 163
-      Name: groupReference<uint8,uint8>
-      ByteSize: 16
-      GoKind: 25
-      RawFields:
-        - Name: data
-          Offset: 0
-          Type: 164 PointerType *noalg.map.group[uint8]uint8
-        - Name: lengthMask
-          Offset: 8
-          Type: 26 BaseType uint64
-      GroupType: 165 StructureType noalg.map.group[uint8]uint8
-      GroupSliceType: 263 GoSliceDataType []noalg.map.group[uint8]uint8.array
-    - __kind: PointerType
-      ID: 164
-      Name: '*noalg.map.group[uint8]uint8'
-      ByteSize: 8
-      Pointee: 165 StructureType noalg.map.group[uint8]uint8
-    - __kind: StructureType
-      ID: 165
-      Name: noalg.map.group[uint8]uint8
-      ByteSize: 24
-      GoRuntimeType: 1.283616e+06
-      GoKind: 25
-      RawFields:
-        - Name: ctrl
-          Offset: 0
-          Type: 26 BaseType uint64
-        - Name: slots
-          Offset: 8
-          Type: 166 ArrayType noalg.[8]struct { key uint8; elem uint8 }
-    - __kind: ArrayType
-      ID: 166
-      Name: noalg.[8]struct { key uint8; elem uint8 }
-      ByteSize: 16
-      GoRuntimeType: 677664
-      GoKind: 17
-      Count: 8
-      HasCount: true
-      Element: 167 StructureType noalg.struct { key uint8; elem uint8 }
-    - __kind: StructureType
-      ID: 167
-      Name: noalg.struct { key uint8; elem uint8 }
-      ByteSize: 2
-      GoRuntimeType: 1.283488e+06
-      GoKind: 25
-      RawFields:
-        - Name: key
-          Offset: 0
-          Type: 4 BaseType uint8
-        - Name: elem
-          Offset: 1
-          Type: 4 BaseType uint8
-    - __kind: GoMapType
-      ID: 168
-      Name: map[uint8][4]int
-      ByteSize: 8
-      GoRuntimeType: 1.122848e+06
-      GoKind: 21
-      HeaderType: 170 GoSwissMapHeaderType map<uint8,[4]int>
-    - __kind: PointerType
-      ID: 169
-      Name: '*map<uint8,[4]int>'
-      ByteSize: 8
-      Pointee: 170 GoSwissMapHeaderType map<uint8,[4]int>
-    - __kind: GoSwissMapHeaderType
-      ID: 170
-      Name: map<uint8,[4]int>
-      ByteSize: 48
-      GoKind: 25
-      RawFields:
-        - Name: used
-          Offset: 0
-          Type: 26 BaseType uint64
-        - Name: seed
-          Offset: 8
-          Type: 62 BaseType uintptr
-        - Name: dirPtr
-          Offset: 16
-          Type: 171 PointerType **table<uint8,[4]int>
-        - Name: dirLen
-          Offset: 24
-          Type: 1 BaseType int
-        - Name: globalDepth
-          Offset: 32
-          Type: 4 BaseType uint8
-        - Name: globalShift
-          Offset: 33
-          Type: 4 BaseType uint8
-        - Name: writing
-          Offset: 34
-          Type: 4 BaseType uint8
-        - Name: tombstonePossible
-          Offset: 35
-          Type: 11 BaseType bool
-        - Name: clearSeq
-          Offset: 40
-          Type: 26 BaseType uint64
-      TablePtrSliceType: 264 GoSliceDataType []*table<uint8,[4]int>.array
-      GroupType: 176 StructureType noalg.map.group[uint8][4]int
-    - __kind: PointerType
-      ID: 171
-      Name: '**table<uint8,[4]int>'
-      ByteSize: 8
-      Pointee: 172 PointerType *table<uint8,[4]int>
-    - __kind: PointerType
-      ID: 172
-      Name: '*table<uint8,[4]int>'
-      ByteSize: 8
-      Pointee: 173 StructureType table<uint8,[4]int>
-    - __kind: StructureType
-      ID: 173
-      Name: table<uint8,[4]int>
-      ByteSize: 32
-      GoKind: 25
-      RawFields:
-        - Name: used
-          Offset: 0
-          Type: 22 BaseType uint16
-        - Name: capacity
-          Offset: 2
-          Type: 22 BaseType uint16
-        - Name: growthLeft
-          Offset: 4
-          Type: 22 BaseType uint16
-        - Name: localDepth
-          Offset: 6
-          Type: 4 BaseType uint8
-        - Name: index
-          Offset: 8
-          Type: 1 BaseType int
-        - Name: groups
-          Offset: 16
-          Type: 174 GoSwissMapGroupsType groupReference<uint8,[4]int>
-    - __kind: GoSwissMapGroupsType
-      ID: 174
-      Name: groupReference<uint8,[4]int>
-      ByteSize: 16
-      GoKind: 25
-      RawFields:
-        - Name: data
-          Offset: 0
-          Type: 175 PointerType *noalg.map.group[uint8][4]int
-        - Name: lengthMask
-          Offset: 8
-          Type: 26 BaseType uint64
-      GroupType: 176 StructureType noalg.map.group[uint8][4]int
-      GroupSliceType: 265 GoSliceDataType []noalg.map.group[uint8][4]int.array
-    - __kind: PointerType
-      ID: 175
-      Name: '*noalg.map.group[uint8][4]int'
-      ByteSize: 8
-      Pointee: 176 StructureType noalg.map.group[uint8][4]int
-    - __kind: StructureType
-      ID: 176
-      Name: noalg.map.group[uint8][4]int
-      ByteSize: 328
-      GoRuntimeType: 1.28336e+06
-      GoKind: 25
-      RawFields:
-        - Name: ctrl
-          Offset: 0
-          Type: 26 BaseType uint64
-        - Name: slots
-          Offset: 8
-          Type: 177 ArrayType noalg.[8]struct { key uint8; elem [4]int }
-    - __kind: ArrayType
-      ID: 177
-      Name: noalg.[8]struct { key uint8; elem [4]int }
-      ByteSize: 320
-      GoRuntimeType: 677568
-      GoKind: 17
-      Count: 8
-      HasCount: true
-      Element: 178 StructureType noalg.struct { key uint8; elem [4]int }
-    - __kind: StructureType
-      ID: 178
-      Name: noalg.struct { key uint8; elem [4]int }
-      ByteSize: 40
-      GoRuntimeType: 1.283232e+06
-      GoKind: 25
-      RawFields:
-        - Name: key
-          Offset: 0
-          Type: 4 BaseType uint8
-        - Name: elem
-          Offset: 8
-          Type: 179 ArrayType [4]int
-    - __kind: ArrayType
-      ID: 179
-      Name: '[4]int'
-      ByteSize: 32
-      GoRuntimeType: 676416
-      GoKind: 17
-      Count: 4
-      HasCount: true
-      Element: 1 BaseType int
-    - __kind: GoMapType
-      ID: 180
-      Name: map[[4]int]uint8
-      ByteSize: 8
-      GoRuntimeType: 1.121824e+06
-      GoKind: 21
-      HeaderType: 182 GoSwissMapHeaderType map<[4]int,uint8>
-    - __kind: PointerType
-      ID: 181
-      Name: '*map<[4]int,uint8>'
-      ByteSize: 8
-      Pointee: 182 GoSwissMapHeaderType map<[4]int,uint8>
-    - __kind: GoSwissMapHeaderType
-      ID: 182
-      Name: map<[4]int,uint8>
-      ByteSize: 48
-      GoKind: 25
-      RawFields:
-        - Name: used
-          Offset: 0
-          Type: 26 BaseType uint64
-        - Name: seed
-          Offset: 8
-          Type: 62 BaseType uintptr
-        - Name: dirPtr
-          Offset: 16
-          Type: 183 PointerType **table<[4]int,uint8>
-        - Name: dirLen
-          Offset: 24
-          Type: 1 BaseType int
-        - Name: globalDepth
-          Offset: 32
-          Type: 4 BaseType uint8
-        - Name: globalShift
-          Offset: 33
-          Type: 4 BaseType uint8
-        - Name: writing
-          Offset: 34
-          Type: 4 BaseType uint8
-        - Name: tombstonePossible
-          Offset: 35
-          Type: 11 BaseType bool
-        - Name: clearSeq
-          Offset: 40
-          Type: 26 BaseType uint64
-      TablePtrSliceType: 266 GoSliceDataType []*table<[4]int,uint8>.array
-      GroupType: 188 StructureType noalg.map.group[[4]int]uint8
+      Pointee: 195 PointerType *table<[4]int,[4]int>
     - __kind: PointerType
       ID: 183
       Name: '**table<[4]int,uint8>'
       ByteSize: 8
       Pointee: 184 PointerType *table<[4]int,uint8>
     - __kind: PointerType
-      ID: 184
-      Name: '*table<[4]int,uint8>'
+      ID: 109
+      Name: '**table<[4]string,[2]int>'
       ByteSize: 8
-      Pointee: 185 StructureType table<[4]int,uint8>
-    - __kind: StructureType
-      ID: 185
-      Name: table<[4]int,uint8>
-      ByteSize: 32
-      GoKind: 25
-      RawFields:
-        - Name: used
-          Offset: 0
-          Type: 22 BaseType uint16
-        - Name: capacity
-          Offset: 2
-          Type: 22 BaseType uint16
-        - Name: growthLeft
-          Offset: 4
-          Type: 22 BaseType uint16
-        - Name: localDepth
-          Offset: 6
-          Type: 4 BaseType uint8
-        - Name: index
-          Offset: 8
-          Type: 1 BaseType int
-        - Name: groups
-          Offset: 16
-          Type: 186 GoSwissMapGroupsType groupReference<[4]int,uint8>
-    - __kind: GoSwissMapGroupsType
-      ID: 186
-      Name: groupReference<[4]int,uint8>
-      ByteSize: 16
-      GoKind: 25
-      RawFields:
-        - Name: data
-          Offset: 0
-          Type: 187 PointerType *noalg.map.group[[4]int]uint8
-        - Name: lengthMask
-          Offset: 8
-          Type: 26 BaseType uint64
-      GroupType: 188 StructureType noalg.map.group[[4]int]uint8
-      GroupSliceType: 267 GoSliceDataType []noalg.map.group[[4]int]uint8.array
+      Pointee: 110 PointerType *table<[4]string,[2]int>
     - __kind: PointerType
-      ID: 187
-      Name: '*noalg.map.group[[4]int]uint8'
+      ID: 136
+      Name: '**table<bool,main.node>'
       ByteSize: 8
-      Pointee: 188 StructureType noalg.map.group[[4]int]uint8
-    - __kind: StructureType
-      ID: 188
-      Name: noalg.map.group[[4]int]uint8
-      ByteSize: 328
-      GoRuntimeType: 1.281312e+06
-      GoKind: 25
-      RawFields:
-        - Name: ctrl
-          Offset: 0
-          Type: 26 BaseType uint64
-        - Name: slots
-          Offset: 8
-          Type: 189 ArrayType noalg.[8]struct { key [4]int; elem uint8 }
-    - __kind: ArrayType
-      ID: 189
-      Name: noalg.[8]struct { key [4]int; elem uint8 }
-      ByteSize: 320
-      GoRuntimeType: 676608
-      GoKind: 17
-      Count: 8
-      HasCount: true
-      Element: 190 StructureType noalg.struct { key [4]int; elem uint8 }
-    - __kind: StructureType
-      ID: 190
-      Name: noalg.struct { key [4]int; elem uint8 }
-      ByteSize: 40
-      GoRuntimeType: 1.281184e+06
-      GoKind: 25
-      RawFields:
-        - Name: key
-          Offset: 0
-          Type: 179 ArrayType [4]int
-        - Name: elem
-          Offset: 32
-          Type: 4 BaseType uint8
-    - __kind: GoMapType
-      ID: 191
-      Name: map[[4]int][4]int
-      ByteSize: 8
-      GoRuntimeType: 1.121696e+06
-      GoKind: 21
-      HeaderType: 193 GoSwissMapHeaderType map<[4]int,[4]int>
+      Pointee: 137 PointerType *table<bool,main.node>
     - __kind: PointerType
-      ID: 192
-      Name: '*map<[4]int,[4]int>'
+      ID: 63
+      Name: '**table<int,int>'
       ByteSize: 8
-      Pointee: 193 GoSwissMapHeaderType map<[4]int,[4]int>
-    - __kind: GoSwissMapHeaderType
-      ID: 193
-      Name: map<[4]int,[4]int>
-      ByteSize: 48
-      GoKind: 25
-      RawFields:
-        - Name: used
-          Offset: 0
-          Type: 26 BaseType uint64
-        - Name: seed
-          Offset: 8
-          Type: 62 BaseType uintptr
-        - Name: dirPtr
-          Offset: 16
-          Type: 194 PointerType **table<[4]int,[4]int>
-        - Name: dirLen
-          Offset: 24
-          Type: 1 BaseType int
-        - Name: globalDepth
-          Offset: 32
-          Type: 4 BaseType uint8
-        - Name: globalShift
-          Offset: 33
-          Type: 4 BaseType uint8
-        - Name: writing
-          Offset: 34
-          Type: 4 BaseType uint8
-        - Name: tombstonePossible
-          Offset: 35
-          Type: 11 BaseType bool
-        - Name: clearSeq
-          Offset: 40
-          Type: 26 BaseType uint64
-      TablePtrSliceType: 268 GoSliceDataType []*table<[4]int,[4]int>.array
-      GroupType: 199 StructureType noalg.map.group[[4]int][4]int
+      Pointee: 64 PointerType *table<int,int>
     - __kind: PointerType
-      ID: 194
-      Name: '**table<[4]int,[4]int>'
+      ID: 149
+      Name: '**table<int,uint8>'
       ByteSize: 8
-      Pointee: 195 PointerType *table<[4]int,[4]int>
+      Pointee: 150 PointerType *table<int,uint8>
     - __kind: PointerType
-      ID: 195
-      Name: '*table<[4]int,[4]int>'
+      ID: 123
+      Name: '**table<string,[]main.structWithMap>'
       ByteSize: 8
-      Pointee: 196 StructureType table<[4]int,[4]int>
-    - __kind: StructureType
-      ID: 196
-      Name: table<[4]int,[4]int>
-      ByteSize: 32
-      GoKind: 25
-      RawFields:
-        - Name: used
-          Offset: 0
-          Type: 22 BaseType uint16
-        - Name: capacity
-          Offset: 2
-          Type: 22 BaseType uint16
-        - Name: growthLeft
-          Offset: 4
-          Type: 22 BaseType uint16
-        - Name: localDepth
-          Offset: 6
-          Type: 4 BaseType uint8
-        - Name: index
-          Offset: 8
-          Type: 1 BaseType int
-        - Name: groups
-          Offset: 16
-          Type: 197 GoSwissMapGroupsType groupReference<[4]int,[4]int>
-    - __kind: GoSwissMapGroupsType
-      ID: 197
-      Name: groupReference<[4]int,[4]int>
-      ByteSize: 16
-      GoKind: 25
-      RawFields:
-        - Name: data
-          Offset: 0
-          Type: 198 PointerType *noalg.map.group[[4]int][4]int
-        - Name: lengthMask
-          Offset: 8
-          Type: 26 BaseType uint64
-      GroupType: 199 StructureType noalg.map.group[[4]int][4]int
-      GroupSliceType: 269 GoSliceDataType []noalg.map.group[[4]int][4]int.array
+      Pointee: 124 PointerType *table<string,[]main.structWithMap>
     - __kind: PointerType
-      ID: 198
-      Name: '*noalg.map.group[[4]int][4]int'
+      ID: 97
+      Name: '**table<string,[]string>'
       ByteSize: 8
-      Pointee: 199 StructureType noalg.map.group[[4]int][4]int
-    - __kind: StructureType
-      ID: 199
-      Name: noalg.map.group[[4]int][4]int
-      ByteSize: 520
-      GoRuntimeType: 1.281056e+06
-      GoKind: 25
-      RawFields:
-        - Name: ctrl
-          Offset: 0
-          Type: 26 BaseType uint64
-        - Name: slots
-          Offset: 8
-          Type: 200 ArrayType noalg.[8]struct { key [4]int; elem [4]int }
-    - __kind: ArrayType
-      ID: 200
-      Name: noalg.[8]struct { key [4]int; elem [4]int }
-      ByteSize: 512
-      GoRuntimeType: 676512
-      GoKind: 17
-      Count: 8
-      HasCount: true
-      Element: 201 StructureType noalg.struct { key [4]int; elem [4]int }
-    - __kind: StructureType
-      ID: 201
-      Name: noalg.struct { key [4]int; elem [4]int }
-      ByteSize: 64
-      GoRuntimeType: 1.280928e+06
-      GoKind: 25
-      RawFields:
-        - Name: key
-          Offset: 0
-          Type: 179 ArrayType [4]int
-        - Name: elem
-          Offset: 32
-          Type: 179 ArrayType [4]int
-    - __kind: GoChannelType
-      ID: 202
-      Name: chan bool
-      GoRuntimeType: 590912
-      GoKind: 18
+      Pointee: 98 PointerType *table<string,[]string>
     - __kind: PointerType
-      ID: 203
-      Name: '*main.structWithTwoValues'
+      ID: 86
+      Name: '**table<string,int>'
       ByteSize: 8
-      GoKind: 22
-      Pointee: 204 StructureType main.structWithTwoValues
-    - __kind: StructureType
-      ID: 204
-      Name: main.structWithTwoValues
-      ByteSize: 16
-      GoKind: 25
-      RawFields:
-        - Name: a
-          Offset: 0
-          Type: 20 BaseType uint
-        - Name: b
-          Offset: 8
-          Type: 11 BaseType bool
+      Pointee: 87 PointerType *table<string,int>
     - __kind: PointerType
-      ID: 205
-      Name: '*uint'
+      ID: 74
+      Name: '**table<string,main.nestedStruct>'
       ByteSize: 8
-      GoRuntimeType: 388512
-      GoKind: 22
-      Pointee: 20 BaseType uint
+      Pointee: 75 PointerType *table<string,main.nestedStruct>
+    - __kind: PointerType
+      ID: 171
+      Name: '**table<uint8,[4]int>'
+      ByteSize: 8
+      Pointee: 172 PointerType *table<uint8,[4]int>
+    - __kind: PointerType
+      ID: 160
+      Name: '**table<uint8,uint8>'
+      ByteSize: 8
+      Pointee: 161 PointerType *table<uint8,uint8>
+    - __kind: PointerType
+      ID: 241
+      Name: '*[]*string.array'
+      ByteSize: 8
+      Pointee: 240 GoSliceDataType []*string.array
+    - __kind: PointerType
+      ID: 275
+      Name: '*[][]uint.array'
+      ByteSize: 8
+      Pointee: 274 GoSliceDataType [][]uint.array
+    - __kind: PointerType
+      ID: 279
+      Name: '*[]bool.array'
+      ByteSize: 8
+      Pointee: 278 GoSliceDataType []bool.array
+    - __kind: PointerType
+      ID: 257
+      Name: '*[]main.structWithMap.array'
+      ByteSize: 8
+      Pointee: 256 GoSliceDataType []main.structWithMap.array
+    - __kind: PointerType
+      ID: 277
+      Name: '*[]main.structWithNoStrings.array'
+      ByteSize: 8
+      Pointee: 276 GoSliceDataType []main.structWithNoStrings.array
+    - __kind: PointerType
+      ID: 251
+      Name: '*[]string.array'
+      ByteSize: 8
+      Pointee: 250 GoSliceDataType []string.array
+    - __kind: PointerType
+      ID: 212
+      Name: '*[]uint'
+      ByteSize: 8
+      Pointee: 210 GoSliceHeaderType []uint
+    - __kind: PointerType
+      ID: 273
+      Name: '*[]uint.array'
+      ByteSize: 8
+      Pointee: 272 GoSliceDataType []uint.array
+    - __kind: PointerType
+      ID: 281
+      Name: '*[]uint16.array'
+      ByteSize: 8
+      Pointee: 280 GoSliceDataType []uint16.array
     - __kind: PointerType
       ID: 206
       Name: '*bool'
@@ -5410,236 +3215,19 @@ Types:
       GoKind: 22
       Pointee: 11 BaseType bool
     - __kind: PointerType
-      ID: 207
-      Name: '*main.t'
+      ID: 236
+      Name: '*error'
       ByteSize: 8
+      GoRuntimeType: 387808
       GoKind: 22
-      Pointee: 208 GoSliceHeaderType main.t
-    - __kind: GoSliceHeaderType
-      ID: 208
-      Name: main.t
-      ByteSize: 24
-      GoKind: 23
-      RawFields:
-        - Name: array
-          Offset: 0
-          Type: 209 PointerType **main.t
-        - Name: len
-          Offset: 8
-          Type: 1 BaseType int
-        - Name: cap
-          Offset: 16
-          Type: 1 BaseType int
-      Data: 270 GoSliceDataType main.t.array
+      Pointee: 57 GoInterfaceType error
     - __kind: PointerType
-      ID: 209
-      Name: '**main.t'
+      ID: 237
+      Name: '*float32'
       ByteSize: 8
-      Pointee: 207 PointerType *main.t
-    - __kind: GoSliceHeaderType
-      ID: 210
-      Name: '[]uint'
-      ByteSize: 24
-      GoRuntimeType: 481312
-      GoKind: 23
-      RawFields:
-        - Name: array
-          Offset: 0
-          Type: 205 PointerType *uint
-        - Name: len
-          Offset: 8
-          Type: 1 BaseType int
-        - Name: cap
-          Offset: 16
-          Type: 1 BaseType int
-      Data: 272 GoSliceDataType []uint.array
-    - __kind: GoSliceHeaderType
-      ID: 211
-      Name: '[][]uint'
-      ByteSize: 24
-      GoKind: 23
-      RawFields:
-        - Name: array
-          Offset: 0
-          Type: 212 PointerType *[]uint
-        - Name: len
-          Offset: 8
-          Type: 1 BaseType int
-        - Name: cap
-          Offset: 16
-          Type: 1 BaseType int
-      Data: 274 GoSliceDataType [][]uint.array
-    - __kind: PointerType
-      ID: 212
-      Name: '*[]uint'
-      ByteSize: 8
-      Pointee: 210 GoSliceHeaderType []uint
-    - __kind: GoSliceHeaderType
-      ID: 213
-      Name: '[]main.structWithNoStrings'
-      ByteSize: 24
-      GoKind: 23
-      RawFields:
-        - Name: array
-          Offset: 0
-          Type: 214 PointerType *main.structWithNoStrings
-        - Name: len
-          Offset: 8
-          Type: 1 BaseType int
-        - Name: cap
-          Offset: 16
-          Type: 1 BaseType int
-      Data: 276 GoSliceDataType []main.structWithNoStrings.array
-    - __kind: PointerType
-      ID: 214
-      Name: '*main.structWithNoStrings'
-      ByteSize: 8
-      Pointee: 215 StructureType main.structWithNoStrings
-    - __kind: StructureType
-      ID: 215
-      Name: main.structWithNoStrings
-      ByteSize: 2
-      GoKind: 25
-      RawFields:
-        - Name: aUint8
-          Offset: 0
-          Type: 4 BaseType uint8
-        - Name: aBool
-          Offset: 1
-          Type: 11 BaseType bool
-    - __kind: GoSliceHeaderType
-      ID: 216
-      Name: '[]bool'
-      ByteSize: 24
-      GoRuntimeType: 481696
-      GoKind: 23
-      RawFields:
-        - Name: array
-          Offset: 0
-          Type: 206 PointerType *bool
-        - Name: len
-          Offset: 8
-          Type: 1 BaseType int
-        - Name: cap
-          Offset: 16
-          Type: 1 BaseType int
-      Data: 278 GoSliceDataType []bool.array
-    - __kind: GoSliceHeaderType
-      ID: 217
-      Name: '[]uint16'
-      ByteSize: 24
-      GoRuntimeType: 480672
-      GoKind: 23
-      RawFields:
-        - Name: array
-          Offset: 0
-          Type: 218 PointerType *uint16
-        - Name: len
-          Offset: 8
-          Type: 1 BaseType int
-        - Name: cap
-          Offset: 16
-          Type: 1 BaseType int
-      Data: 280 GoSliceDataType []uint16.array
-    - __kind: PointerType
-      ID: 218
-      Name: '*uint16'
-      ByteSize: 8
-      GoRuntimeType: 388128
+      GoRuntimeType: 388768
       GoKind: 22
-      Pointee: 22 BaseType uint16
-    - __kind: StructureType
-      ID: 219
-      Name: main.threeStringStruct
-      ByteSize: 48
-      GoKind: 25
-      RawFields:
-        - Name: a
-          Offset: 0
-          Type: 8 GoStringHeaderType string
-        - Name: b
-          Offset: 16
-          Type: 8 GoStringHeaderType string
-        - Name: c
-          Offset: 32
-          Type: 8 GoStringHeaderType string
-    - __kind: PointerType
-      ID: 220
-      Name: '*main.threeStringStruct'
-      ByteSize: 8
-      GoKind: 22
-      Pointee: 219 StructureType main.threeStringStruct
-    - __kind: PointerType
-      ID: 221
-      Name: '*main.oneStringStruct'
-      ByteSize: 8
-      GoKind: 22
-      Pointee: 222 StructureType main.oneStringStruct
-    - __kind: StructureType
-      ID: 222
-      Name: main.oneStringStruct
-      ByteSize: 16
-      GoKind: 25
-      RawFields:
-        - Name: a
-          Offset: 0
-          Type: 8 GoStringHeaderType string
-    - __kind: StructureType
-      ID: 223
-      Name: main.aStruct
-      ByteSize: 56
-      GoKind: 25
-      RawFields:
-        - Name: aBool
-          Offset: 0
-          Type: 11 BaseType bool
-        - Name: aString
-          Offset: 8
-          Type: 8 GoStringHeaderType string
-        - Name: aNumber
-          Offset: 24
-          Type: 1 BaseType int
-        - Name: nested
-          Offset: 32
-          Type: 82 StructureType main.nestedStruct
-    - __kind: StructureType
-      ID: 224
-      Name: main.emptyStruct
-      GoKind: 25
-      RawFields: []
-    - __kind: PointerType
-      ID: 225
-      Name: '*uintptr'
-      ByteSize: 8
-      GoRuntimeType: 388576
-      GoKind: 22
-      Pointee: 62 BaseType uintptr
-    - __kind: PointerType
-      ID: 226
-      Name: '*int32'
-      ByteSize: 8
-      GoRuntimeType: 388192
-      GoKind: 22
-      Pointee: 6 BaseType int32
-    - __kind: PointerType
-      ID: 227
-      Name: '*uint32'
-      ByteSize: 8
-      GoRuntimeType: 388256
-      GoKind: 22
-      Pointee: 24 BaseType uint32
-    - __kind: BaseType
-      ID: 228
-      Name: complex64
-      ByteSize: 8
-      GoRuntimeType: 579328
-      GoKind: 15
-    - __kind: BaseType
-      ID: 229
-      Name: complex128
-      ByteSize: 16
-      GoRuntimeType: 579392
-      GoKind: 16
+      Pointee: 30 BaseType float32
     - __kind: PointerType
       ID: 230
       Name: '*float64'
@@ -5655,12 +3243,19 @@ Types:
       GoKind: 22
       Pointee: 1 BaseType int
     - __kind: PointerType
-      ID: 232
-      Name: '*uint64'
+      ID: 234
+      Name: '*int16'
       ByteSize: 8
-      GoRuntimeType: 388384
+      GoRuntimeType: 388064
       GoKind: 22
-      Pointee: 26 BaseType uint64
+      Pointee: 16 BaseType int16
+    - __kind: PointerType
+      ID: 226
+      Name: '*int32'
+      ByteSize: 8
+      GoRuntimeType: 388192
+      GoKind: 22
+      Pointee: 6 BaseType int32
     - __kind: PointerType
       ID: 233
       Name: '*int64'
@@ -5669,13 +3264,6 @@ Types:
       GoKind: 22
       Pointee: 18 BaseType int64
     - __kind: PointerType
-      ID: 234
-      Name: '*int16'
-      ByteSize: 8
-      GoRuntimeType: 388064
-      GoKind: 22
-      Pointee: 16 BaseType int16
-    - __kind: PointerType
       ID: 235
       Name: '*int8'
       ByteSize: 8
@@ -5683,283 +3271,393 @@ Types:
       GoKind: 22
       Pointee: 14 BaseType int8
     - __kind: PointerType
-      ID: 236
-      Name: '*error'
+      ID: 44
+      Name: '*main.esotericHeap'
       ByteSize: 8
-      GoRuntimeType: 387808
+      GoRuntimeType: 382944
       GoKind: 22
-      Pointee: 57 GoInterfaceType error
+      Pointee: 45 StructureType main.esotericHeap
     - __kind: PointerType
-      ID: 237
-      Name: '*float32'
+      ID: 145
+      Name: '*main.node'
       ByteSize: 8
-      GoRuntimeType: 388768
+      GoRuntimeType: 383008
       GoKind: 22
-      Pointee: 30 BaseType float32
-    - __kind: GoStringDataType
-      ID: 238
-      Name: string.str
-      ByteSize: 2048
+      Pointee: 144 StructureType main.node
     - __kind: PointerType
-      ID: 239
-      Name: '*string.str'
+      ID: 221
+      Name: '*main.oneStringStruct'
       ByteSize: 8
-      Pointee: 238 GoStringDataType string.str
-    - __kind: GoSliceDataType
-      ID: 240
-      Name: '[]*string.array'
-      ByteSize: 2048
-      Element: 36 PointerType *string
+      GoKind: 22
+      Pointee: 222 StructureType main.oneStringStruct
     - __kind: PointerType
-      ID: 241
-      Name: '*[]*string.array'
+      ID: 132
+      Name: '*main.structWithMap'
       ByteSize: 8
-      Pointee: 240 GoSliceDataType []*string.array
-    - __kind: GoSliceDataType
-      ID: 242
-      Name: '[]*table<int,int>.array'
-      ByteSize: 8192
-      Element: 64 PointerType *table<int,int>
-    - __kind: GoSliceDataType
-      ID: 243
-      Name: '[]noalg.map.group[int]int.array'
-      ByteSize: 2048
-      Element: 68 StructureType noalg.map.group[int]int
-    - __kind: GoSliceDataType
-      ID: 244
-      Name: '[]*table<string,main.nestedStruct>.array'
-      ByteSize: 8192
-      Element: 75 PointerType *table<string,main.nestedStruct>
-    - __kind: GoSliceDataType
-      ID: 245
-      Name: '[]noalg.map.group[string]main.nestedStruct.array'
-      ByteSize: 2048
-      Element: 79 StructureType noalg.map.group[string]main.nestedStruct
-    - __kind: GoSliceDataType
-      ID: 246
-      Name: '[]*table<string,int>.array'
-      ByteSize: 8192
-      Element: 87 PointerType *table<string,int>
-    - __kind: GoSliceDataType
-      ID: 247
-      Name: '[]noalg.map.group[string]int.array'
-      ByteSize: 2048
-      Element: 91 StructureType noalg.map.group[string]int
-    - __kind: GoSliceDataType
-      ID: 248
-      Name: '[]*table<string,[]string>.array'
-      ByteSize: 8192
-      Element: 98 PointerType *table<string,[]string>
-    - __kind: GoSliceDataType
-      ID: 249
-      Name: '[]noalg.map.group[string][]string.array'
-      ByteSize: 2048
-      Element: 102 StructureType noalg.map.group[string][]string
-    - __kind: GoSliceDataType
-      ID: 250
-      Name: '[]string.array'
-      ByteSize: 2048
-      Element: 8 GoStringHeaderType string
+      GoRuntimeType: 382880
+      GoKind: 22
+      Pointee: 58 StructureType main.structWithMap
     - __kind: PointerType
-      ID: 251
-      Name: '*[]string.array'
+      ID: 214
+      Name: '*main.structWithNoStrings'
       ByteSize: 8
-      Pointee: 250 GoSliceDataType []string.array
-    - __kind: GoSliceDataType
-      ID: 252
-      Name: '[]*table<[4]string,[2]int>.array'
-      ByteSize: 8192
-      Element: 110 PointerType *table<[4]string,[2]int>
-    - __kind: GoSliceDataType
-      ID: 253
-      Name: '[]noalg.map.group[[4]string][2]int.array'
-      ByteSize: 2048
-      Element: 114 StructureType noalg.map.group[[4]string][2]int
-    - __kind: GoSliceDataType
-      ID: 254
-      Name: '[]*table<string,[]main.structWithMap>.array'
-      ByteSize: 8192
-      Element: 124 PointerType *table<string,[]main.structWithMap>
-    - __kind: GoSliceDataType
-      ID: 255
-      Name: '[]noalg.map.group[string][]main.structWithMap.array'
-      ByteSize: 2048
-      Element: 128 StructureType noalg.map.group[string][]main.structWithMap
-    - __kind: GoSliceDataType
-      ID: 256
-      Name: '[]main.structWithMap.array'
-      ByteSize: 2048
-      Element: 58 StructureType main.structWithMap
+      Pointee: 215 StructureType main.structWithNoStrings
     - __kind: PointerType
-      ID: 257
-      Name: '*[]main.structWithMap.array'
+      ID: 203
+      Name: '*main.structWithTwoValues'
       ByteSize: 8
-      Pointee: 256 GoSliceDataType []main.structWithMap.array
-    - __kind: GoSliceDataType
-      ID: 258
-      Name: '[]*table<bool,main.node>.array'
-      ByteSize: 8192
-      Element: 137 PointerType *table<bool,main.node>
-    - __kind: GoSliceDataType
-      ID: 259
-      Name: '[]noalg.map.group[bool]main.node.array'
-      ByteSize: 2048
-      Element: 141 StructureType noalg.map.group[bool]main.node
-    - __kind: GoSliceDataType
-      ID: 260
-      Name: '[]*table<int,uint8>.array'
-      ByteSize: 8192
-      Element: 150 PointerType *table<int,uint8>
-    - __kind: GoSliceDataType
-      ID: 261
-      Name: '[]noalg.map.group[int]uint8.array'
-      ByteSize: 2048
-      Element: 154 StructureType noalg.map.group[int]uint8
-    - __kind: GoSliceDataType
-      ID: 262
-      Name: '[]*table<uint8,uint8>.array'
-      ByteSize: 8192
-      Element: 161 PointerType *table<uint8,uint8>
-    - __kind: GoSliceDataType
-      ID: 263
-      Name: '[]noalg.map.group[uint8]uint8.array'
-      ByteSize: 2048
-      Element: 165 StructureType noalg.map.group[uint8]uint8
-    - __kind: GoSliceDataType
-      ID: 264
-      Name: '[]*table<uint8,[4]int>.array'
-      ByteSize: 8192
-      Element: 172 PointerType *table<uint8,[4]int>
-    - __kind: GoSliceDataType
-      ID: 265
-      Name: '[]noalg.map.group[uint8][4]int.array'
-      ByteSize: 2048
-      Element: 176 StructureType noalg.map.group[uint8][4]int
-    - __kind: GoSliceDataType
-      ID: 266
-      Name: '[]*table<[4]int,uint8>.array'
-      ByteSize: 8192
-      Element: 184 PointerType *table<[4]int,uint8>
-    - __kind: GoSliceDataType
-      ID: 267
-      Name: '[]noalg.map.group[[4]int]uint8.array'
-      ByteSize: 2048
-      Element: 188 StructureType noalg.map.group[[4]int]uint8
-    - __kind: GoSliceDataType
-      ID: 268
-      Name: '[]*table<[4]int,[4]int>.array'
-      ByteSize: 8192
-      Element: 195 PointerType *table<[4]int,[4]int>
-    - __kind: GoSliceDataType
-      ID: 269
-      Name: '[]noalg.map.group[[4]int][4]int.array'
-      ByteSize: 2048
-      Element: 199 StructureType noalg.map.group[[4]int][4]int
-    - __kind: GoSliceDataType
-      ID: 270
-      Name: main.t.array
-      ByteSize: 2048
-      Element: 207 PointerType *main.t
+      GoKind: 22
+      Pointee: 204 StructureType main.structWithTwoValues
+    - __kind: PointerType
+      ID: 207
+      Name: '*main.t'
+      ByteSize: 8
+      GoKind: 22
+      Pointee: 208 GoSliceHeaderType main.t
     - __kind: PointerType
       ID: 271
       Name: '*main.t.array'
       ByteSize: 8
       Pointee: 270 GoSliceDataType main.t.array
-    - __kind: GoSliceDataType
-      ID: 272
-      Name: '[]uint.array'
-      ByteSize: 2048
-      Element: 20 BaseType uint
     - __kind: PointerType
-      ID: 273
-      Name: '*[]uint.array'
+      ID: 220
+      Name: '*main.threeStringStruct'
       ByteSize: 8
-      Pointee: 272 GoSliceDataType []uint.array
-    - __kind: GoSliceDataType
-      ID: 274
-      Name: '[][]uint.array'
-      ByteSize: 2048
-      Element: 210 GoSliceHeaderType []uint
+      GoKind: 22
+      Pointee: 219 StructureType main.threeStringStruct
     - __kind: PointerType
-      ID: 275
-      Name: '*[][]uint.array'
+      ID: 192
+      Name: '*map<[4]int,[4]int>'
       ByteSize: 8
-      Pointee: 274 GoSliceDataType [][]uint.array
-    - __kind: GoSliceDataType
-      ID: 276
-      Name: '[]main.structWithNoStrings.array'
-      ByteSize: 2048
-      Element: 215 StructureType main.structWithNoStrings
+      Pointee: 193 GoSwissMapHeaderType map<[4]int,[4]int>
     - __kind: PointerType
-      ID: 277
-      Name: '*[]main.structWithNoStrings.array'
+      ID: 181
+      Name: '*map<[4]int,uint8>'
       ByteSize: 8
-      Pointee: 276 GoSliceDataType []main.structWithNoStrings.array
-    - __kind: GoSliceDataType
-      ID: 278
-      Name: '[]bool.array'
-      ByteSize: 2048
-      Element: 11 BaseType bool
+      Pointee: 182 GoSwissMapHeaderType map<[4]int,uint8>
     - __kind: PointerType
-      ID: 279
-      Name: '*[]bool.array'
+      ID: 107
+      Name: '*map<[4]string,[2]int>'
       ByteSize: 8
-      Pointee: 278 GoSliceDataType []bool.array
-    - __kind: GoSliceDataType
-      ID: 280
-      Name: '[]uint16.array'
-      ByteSize: 2048
-      Element: 22 BaseType uint16
+      Pointee: 108 GoSwissMapHeaderType map<[4]string,[2]int>
     - __kind: PointerType
-      ID: 281
-      Name: '*[]uint16.array'
+      ID: 134
+      Name: '*map<bool,main.node>'
       ByteSize: 8
-      Pointee: 280 GoSliceDataType []uint16.array
+      Pointee: 135 GoSwissMapHeaderType map<bool,main.node>
+    - __kind: PointerType
+      ID: 60
+      Name: '*map<int,int>'
+      ByteSize: 8
+      Pointee: 61 GoSwissMapHeaderType map<int,int>
+    - __kind: PointerType
+      ID: 147
+      Name: '*map<int,uint8>'
+      ByteSize: 8
+      Pointee: 148 GoSwissMapHeaderType map<int,uint8>
+    - __kind: PointerType
+      ID: 121
+      Name: '*map<string,[]main.structWithMap>'
+      ByteSize: 8
+      Pointee: 122 GoSwissMapHeaderType map<string,[]main.structWithMap>
+    - __kind: PointerType
+      ID: 95
+      Name: '*map<string,[]string>'
+      ByteSize: 8
+      Pointee: 96 GoSwissMapHeaderType map<string,[]string>
+    - __kind: PointerType
+      ID: 84
+      Name: '*map<string,int>'
+      ByteSize: 8
+      Pointee: 85 GoSwissMapHeaderType map<string,int>
+    - __kind: PointerType
+      ID: 72
+      Name: '*map<string,main.nestedStruct>'
+      ByteSize: 8
+      Pointee: 73 GoSwissMapHeaderType map<string,main.nestedStruct>
+    - __kind: PointerType
+      ID: 169
+      Name: '*map<uint8,[4]int>'
+      ByteSize: 8
+      Pointee: 170 GoSwissMapHeaderType map<uint8,[4]int>
+    - __kind: PointerType
+      ID: 158
+      Name: '*map<uint8,uint8>'
+      ByteSize: 8
+      Pointee: 159 GoSwissMapHeaderType map<uint8,uint8>
+    - __kind: PointerType
+      ID: 119
+      Name: '*map[string]int'
+      ByteSize: 8
+      GoKind: 22
+      Pointee: 83 GoMapType map[string]int
+    - __kind: PointerType
+      ID: 198
+      Name: '*noalg.map.group[[4]int][4]int'
+      ByteSize: 8
+      Pointee: 199 StructureType noalg.map.group[[4]int][4]int
+    - __kind: PointerType
+      ID: 187
+      Name: '*noalg.map.group[[4]int]uint8'
+      ByteSize: 8
+      Pointee: 188 StructureType noalg.map.group[[4]int]uint8
+    - __kind: PointerType
+      ID: 113
+      Name: '*noalg.map.group[[4]string][2]int'
+      ByteSize: 8
+      Pointee: 114 StructureType noalg.map.group[[4]string][2]int
+    - __kind: PointerType
+      ID: 140
+      Name: '*noalg.map.group[bool]main.node'
+      ByteSize: 8
+      Pointee: 141 StructureType noalg.map.group[bool]main.node
+    - __kind: PointerType
+      ID: 67
+      Name: '*noalg.map.group[int]int'
+      ByteSize: 8
+      Pointee: 68 StructureType noalg.map.group[int]int
+    - __kind: PointerType
+      ID: 153
+      Name: '*noalg.map.group[int]uint8'
+      ByteSize: 8
+      Pointee: 154 StructureType noalg.map.group[int]uint8
+    - __kind: PointerType
+      ID: 127
+      Name: '*noalg.map.group[string][]main.structWithMap'
+      ByteSize: 8
+      Pointee: 128 StructureType noalg.map.group[string][]main.structWithMap
+    - __kind: PointerType
+      ID: 101
+      Name: '*noalg.map.group[string][]string'
+      ByteSize: 8
+      Pointee: 102 StructureType noalg.map.group[string][]string
+    - __kind: PointerType
+      ID: 90
+      Name: '*noalg.map.group[string]int'
+      ByteSize: 8
+      Pointee: 91 StructureType noalg.map.group[string]int
+    - __kind: PointerType
+      ID: 78
+      Name: '*noalg.map.group[string]main.nestedStruct'
+      ByteSize: 8
+      Pointee: 79 StructureType noalg.map.group[string]main.nestedStruct
+    - __kind: PointerType
+      ID: 175
+      Name: '*noalg.map.group[uint8][4]int'
+      ByteSize: 8
+      Pointee: 176 StructureType noalg.map.group[uint8][4]int
+    - __kind: PointerType
+      ID: 164
+      Name: '*noalg.map.group[uint8]uint8'
+      ByteSize: 8
+      Pointee: 165 StructureType noalg.map.group[uint8]uint8
+    - __kind: PointerType
+      ID: 36
+      Name: '*string'
+      ByteSize: 8
+      GoRuntimeType: 387872
+      GoKind: 22
+      Pointee: 8 GoStringHeaderType string
+    - __kind: PointerType
+      ID: 239
+      Name: '*string.str'
+      ByteSize: 8
+      Pointee: 238 GoStringDataType string.str
+    - __kind: PointerType
+      ID: 195
+      Name: '*table<[4]int,[4]int>'
+      ByteSize: 8
+      Pointee: 196 StructureType table<[4]int,[4]int>
+    - __kind: PointerType
+      ID: 184
+      Name: '*table<[4]int,uint8>'
+      ByteSize: 8
+      Pointee: 185 StructureType table<[4]int,uint8>
+    - __kind: PointerType
+      ID: 110
+      Name: '*table<[4]string,[2]int>'
+      ByteSize: 8
+      Pointee: 111 StructureType table<[4]string,[2]int>
+    - __kind: PointerType
+      ID: 137
+      Name: '*table<bool,main.node>'
+      ByteSize: 8
+      Pointee: 138 StructureType table<bool,main.node>
+    - __kind: PointerType
+      ID: 64
+      Name: '*table<int,int>'
+      ByteSize: 8
+      Pointee: 65 StructureType table<int,int>
+    - __kind: PointerType
+      ID: 150
+      Name: '*table<int,uint8>'
+      ByteSize: 8
+      Pointee: 151 StructureType table<int,uint8>
+    - __kind: PointerType
+      ID: 124
+      Name: '*table<string,[]main.structWithMap>'
+      ByteSize: 8
+      Pointee: 125 StructureType table<string,[]main.structWithMap>
+    - __kind: PointerType
+      ID: 98
+      Name: '*table<string,[]string>'
+      ByteSize: 8
+      Pointee: 99 StructureType table<string,[]string>
+    - __kind: PointerType
+      ID: 87
+      Name: '*table<string,int>'
+      ByteSize: 8
+      Pointee: 88 StructureType table<string,int>
+    - __kind: PointerType
+      ID: 75
+      Name: '*table<string,main.nestedStruct>'
+      ByteSize: 8
+      Pointee: 76 StructureType table<string,main.nestedStruct>
+    - __kind: PointerType
+      ID: 172
+      Name: '*table<uint8,[4]int>'
+      ByteSize: 8
+      Pointee: 173 StructureType table<uint8,[4]int>
+    - __kind: PointerType
+      ID: 161
+      Name: '*table<uint8,uint8>'
+      ByteSize: 8
+      Pointee: 162 StructureType table<uint8,uint8>
+    - __kind: PointerType
+      ID: 205
+      Name: '*uint'
+      ByteSize: 8
+      GoRuntimeType: 388512
+      GoKind: 22
+      Pointee: 20 BaseType uint
+    - __kind: PointerType
+      ID: 218
+      Name: '*uint16'
+      ByteSize: 8
+      GoRuntimeType: 388128
+      GoKind: 22
+      Pointee: 22 BaseType uint16
+    - __kind: PointerType
+      ID: 227
+      Name: '*uint32'
+      ByteSize: 8
+      GoRuntimeType: 388256
+      GoKind: 22
+      Pointee: 24 BaseType uint32
+    - __kind: PointerType
+      ID: 232
+      Name: '*uint64'
+      ByteSize: 8
+      GoRuntimeType: 388384
+      GoKind: 22
+      Pointee: 26 BaseType uint64
+    - __kind: PointerType
+      ID: 9
+      Name: '*uint8'
+      ByteSize: 8
+      GoRuntimeType: 388000
+      GoKind: 22
+      Pointee: 4 BaseType uint8
+    - __kind: PointerType
+      ID: 225
+      Name: '*uintptr'
+      ByteSize: 8
+      GoRuntimeType: 388576
+      GoKind: 22
+      Pointee: 62 BaseType uintptr
     - __kind: EventRootType
-      ID: 282
-      Name: Probe[main.testByteArray]
-      ByteSize: 3
+      ID: 369
+      Name: Probe[main.stackC]
+    - __kind: EventRootType
+      ID: 326
+      Name: Probe[main.testAny]
+      ByteSize: 17
       PresenceBitsetSize: 1
       Expressions:
-        - Name: x
+        - Name: a
           Offset: 1
           Expression:
-            Type: 3 ArrayType [2]uint8
+            Type: 41 GoEmptyInterfaceType interface {}
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 7, index: 0, name: x}
+                  Variable: {subprogram: 51, index: 0, name: a}
                   Offset: 0
-                  ByteSize: 2
+                  ByteSize: 16
     - __kind: EventRootType
-      ID: 283
-      Name: Probe[main.testRuneArray]
-      ByteSize: 9
+      ID: 298
+      Name: Probe[main.testArrayOfArraysOfArrays]
+      ByteSize: 65
       PresenceBitsetSize: 1
       Expressions:
-        - Name: x
+        - Name: b
           Offset: 1
           Expression:
-            Type: 5 ArrayType [2]int32
+            Type: 28 ArrayType [2][2][2]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 8, index: 0, name: x}
+                  Variable: {subprogram: 23, index: 0, name: b}
                   Offset: 0
-                  ByteSize: 8
+                  ByteSize: 64
     - __kind: EventRootType
-      ID: 284
-      Name: Probe[main.testStringArray]
+      ID: 296
+      Name: Probe[main.testArrayOfArrays]
       ByteSize: 33
       PresenceBitsetSize: 1
       Expressions:
-        - Name: x
+        - Name: a
+          Offset: 1
+          Expression:
+            Type: 27 ArrayType [2][2]int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 21, index: 0, name: a}
+                  Offset: 0
+                  ByteSize: 32
+    - __kind: EventRootType
+      ID: 334
+      Name: Probe[main.testArrayOfMaps]
+      ByteSize: 17
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: m
+          Offset: 1
+          Expression:
+            Type: 118 ArrayType [2]map[string]int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 59, index: 0, name: m}
+                  Offset: 0
+                  ByteSize: 16
+    - __kind: EventRootType
+      ID: 297
+      Name: Probe[main.testArrayOfStrings]
+      ByteSize: 33
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: a
           Offset: 1
           Expression:
             Type: 7 ArrayType [2]string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 9, index: 0, name: x}
+                  Variable: {subprogram: 22, index: 0, name: a}
                   Offset: 0
                   ByteSize: 32
+    - __kind: EventRootType
+      ID: 316
+      Name: Probe[main.testBigStruct]
+      ByteSize: 49
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: b
+          Offset: 1
+          Expression:
+            Type: 33 StructureType main.bigStruct
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 41, index: 0, name: b}
+                  Offset: 0
+                  ByteSize: 48
     - __kind: EventRootType
       ID: 285
       Name: Probe[main.testBoolArray]
@@ -5976,35 +3674,338 @@ Types:
                   Offset: 0
                   ByteSize: 2
     - __kind: EventRootType
-      ID: 286
-      Name: Probe[main.testIntArray]
-      ByteSize: 17
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: x
-          Offset: 1
-          Expression:
-            Type: 12 ArrayType [2]int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 11, index: 0, name: x}
-                  Offset: 0
-                  ByteSize: 16
-    - __kind: EventRootType
-      ID: 287
-      Name: Probe[main.testInt8Array]
+      ID: 282
+      Name: Probe[main.testByteArray]
       ByteSize: 3
       PresenceBitsetSize: 1
       Expressions:
         - Name: x
           Offset: 1
           Expression:
-            Type: 13 ArrayType [2]int8
+            Type: 3 ArrayType [2]uint8
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 12, index: 0, name: x}
+                  Variable: {subprogram: 7, index: 0, name: x}
                   Offset: 0
                   ByteSize: 2
+    - __kind: EventRootType
+      ID: 350
+      Name: Probe[main.testChannel]
+      ByteSize: 1
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: c
+          Offset: 1
+          Expression:
+            Type: 202 GoChannelType chan bool
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 75, index: 0, name: c}
+                  Offset: 0
+                  ByteSize: 0
+    - __kind: EventRootType
+      ID: 348
+      Name: Probe[main.testCombinedByte]
+      ByteSize: 7
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: w
+          Offset: 1
+          Expression:
+            Type: 4 BaseType uint8
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 73, index: 0, name: w}
+                  Offset: 0
+                  ByteSize: 1
+        - Name: x
+          Offset: 2
+          Expression:
+            Type: 4 BaseType uint8
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 73, index: 1, name: x}
+                  Offset: 0
+                  ByteSize: 1
+        - Name: y
+          Offset: 3
+          Expression:
+            Type: 30 BaseType float32
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 73, index: 2, name: y}
+                  Offset: 0
+                  ByteSize: 4
+    - __kind: EventRootType
+      ID: 358
+      Name: Probe[main.testCycle]
+      ByteSize: 9
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: t
+          Offset: 1
+          Expression:
+            Type: 207 PointerType *main.t
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 83, index: 0, name: t}
+                  Offset: 0
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 363
+      Name: Probe[main.testEmptySliceOfStructs]
+      ByteSize: 33
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: xs
+          Offset: 1
+          Expression:
+            Type: 213 GoSliceHeaderType []main.structWithNoStrings
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 88, index: 0, name: xs}
+                  Offset: 0
+                  ByteSize: 24
+        - Name: a
+          Offset: 25
+          Expression:
+            Type: 1 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 88, index: 1, name: a}
+                  Offset: 0
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 360
+      Name: Probe[main.testEmptySlice]
+      ByteSize: 25
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: u
+          Offset: 1
+          Expression:
+            Type: 210 GoSliceHeaderType []uint
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 85, index: 0, name: u}
+                  Offset: 0
+                  ByteSize: 24
+    - __kind: EventRootType
+      ID: 377
+      Name: Probe[main.testEmptyString]
+      ByteSize: 17
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: x
+          Offset: 1
+          Expression:
+            Type: 8 GoStringHeaderType string
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 102, index: 0, name: x}
+                  Offset: 0
+                  ByteSize: 16
+    - __kind: EventRootType
+      ID: 379
+      Name: Probe[main.testEmptyStruct]
+      ByteSize: 1
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: e
+          Offset: 1
+          Expression:
+            Type: 224 StructureType main.emptyStruct
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 104, index: 0, name: e}
+                  Offset: 0
+                  ByteSize: 0
+    - __kind: EventRootType
+      ID: 327
+      Name: Probe[main.testError]
+      ByteSize: 17
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: e
+          Offset: 1
+          Expression:
+            Type: 57 GoInterfaceType error
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 52, index: 0, name: e}
+                  Offset: 0
+                  ByteSize: 16
+    - __kind: EventRootType
+      ID: 318
+      Name: Probe[main.testEsotericHeap]
+      ByteSize: 9
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: e
+          Offset: 1
+          Expression:
+            Type: 44 PointerType *main.esotericHeap
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 43, index: 0, name: e}
+                  Offset: 0
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 317
+      Name: Probe[main.testEsotericStack]
+      ByteSize: 65
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: e
+          Offset: 1
+          Expression:
+            Type: 39 StructureType main.esotericStack
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 42, index: 0, name: e}
+                  Offset: 0
+                  ByteSize: 64
+    - __kind: EventRootType
+      ID: 324
+      Name: Probe[main.testFramelessArray]
+      ByteSize: 41
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: a
+          Offset: 1
+          Expression:
+            Type: 2 ArrayType [5]int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 49, index: 0, name: a}
+                  Offset: 0
+                  ByteSize: 40
+    - __kind: EventRootType
+      ID: 323
+      Name: Probe[main.testFrameless]
+      ByteSize: 9
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: x
+          Offset: 1
+          Expression:
+            Type: 1 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 48, index: 0, name: x}
+                  Offset: 0
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 319
+      Name: Probe[main.testInlinedBA]
+      ByteSize: 9
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: x
+          Offset: 1
+          Expression:
+            Type: 1 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 44, index: 0, name: x}
+                  Offset: 0
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 321
+      Name: Probe[main.testInlinedBBA]
+      ByteSize: 9
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: x
+          Offset: 1
+          Expression:
+            Type: 1 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 46, index: 0, name: x}
+                  Offset: 0
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 381
+      Name: Probe[main.testInlinedBBB]
+    - __kind: EventRootType
+      ID: 320
+      Name: Probe[main.testInlinedBB]
+      ByteSize: 17
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: x
+          Offset: 1
+          Expression:
+            Type: 1 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 45, index: 0, name: x}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: y
+          Offset: 9
+          Expression:
+            Type: 1 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 45, index: 1, name: y}
+                  Offset: 0
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 382
+      Name: Probe[main.testInlinedBCA]
+    - __kind: EventRootType
+      ID: 383
+      Name: Probe[main.testInlinedBCB]
+    - __kind: EventRootType
+      ID: 322
+      Name: Probe[main.testInlinedBC]
+    - __kind: EventRootType
+      ID: 380
+      Name: Probe[main.testInlinedPrint]
+      ByteSize: 9
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: x
+          Offset: 1
+          Expression:
+            Type: 1 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 1, index: 0, name: x}
+                  Offset: 0
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 384
+      Name: Probe[main.testInlinedSq]
+      ByteSize: 9
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: x
+          Offset: 1
+          Expression:
+            Type: 1 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 5, index: 0, name: x}
+                  Offset: 0
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 385
+      Name: Probe[main.testInlinedSumArray]
+      ByteSize: 41
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: a
+          Offset: 1
+          Expression:
+            Type: 2 ArrayType [5]int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 6, index: 0, name: a}
+                  Offset: 0
+                  ByteSize: 40
     - __kind: EventRootType
       ID: 288
       Name: Probe[main.testInt16Array]
@@ -6051,512 +4052,35 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 291
-      Name: Probe[main.testUintArray]
+      ID: 287
+      Name: Probe[main.testInt8Array]
+      ByteSize: 3
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: x
+          Offset: 1
+          Expression:
+            Type: 13 ArrayType [2]int8
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 12, index: 0, name: x}
+                  Offset: 0
+                  ByteSize: 2
+    - __kind: EventRootType
+      ID: 286
+      Name: Probe[main.testIntArray]
       ByteSize: 17
       PresenceBitsetSize: 1
       Expressions:
         - Name: x
           Offset: 1
           Expression:
-            Type: 19 ArrayType [2]uint
+            Type: 12 ArrayType [2]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 16, index: 0, name: x}
+                  Variable: {subprogram: 11, index: 0, name: x}
                   Offset: 0
                   ByteSize: 16
-    - __kind: EventRootType
-      ID: 292
-      Name: Probe[main.testUint8Array]
-      ByteSize: 3
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: x
-          Offset: 1
-          Expression:
-            Type: 3 ArrayType [2]uint8
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 17, index: 0, name: x}
-                  Offset: 0
-                  ByteSize: 2
-    - __kind: EventRootType
-      ID: 293
-      Name: Probe[main.testUint16Array]
-      ByteSize: 5
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: x
-          Offset: 1
-          Expression:
-            Type: 21 ArrayType [2]uint16
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 18, index: 0, name: x}
-                  Offset: 0
-                  ByteSize: 4
-    - __kind: EventRootType
-      ID: 294
-      Name: Probe[main.testUint32Array]
-      ByteSize: 9
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: x
-          Offset: 1
-          Expression:
-            Type: 23 ArrayType [2]uint32
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 19, index: 0, name: x}
-                  Offset: 0
-                  ByteSize: 8
-    - __kind: EventRootType
-      ID: 295
-      Name: Probe[main.testUint64Array]
-      ByteSize: 17
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: x
-          Offset: 1
-          Expression:
-            Type: 25 ArrayType [2]uint64
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 20, index: 0, name: x}
-                  Offset: 0
-                  ByteSize: 16
-    - __kind: EventRootType
-      ID: 296
-      Name: Probe[main.testArrayOfArrays]
-      ByteSize: 33
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: a
-          Offset: 1
-          Expression:
-            Type: 27 ArrayType [2][2]int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 21, index: 0, name: a}
-                  Offset: 0
-                  ByteSize: 32
-    - __kind: EventRootType
-      ID: 297
-      Name: Probe[main.testArrayOfStrings]
-      ByteSize: 33
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: a
-          Offset: 1
-          Expression:
-            Type: 7 ArrayType [2]string
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 22, index: 0, name: a}
-                  Offset: 0
-                  ByteSize: 32
-    - __kind: EventRootType
-      ID: 298
-      Name: Probe[main.testArrayOfArraysOfArrays]
-      ByteSize: 65
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: b
-          Offset: 1
-          Expression:
-            Type: 28 ArrayType [2][2][2]int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 23, index: 0, name: b}
-                  Offset: 0
-                  ByteSize: 64
-    - __kind: EventRootType
-      ID: 299
-      Name: Probe[main.testVeryLargeArray]
-      ByteSize: 801
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: a
-          Offset: 1
-          Expression:
-            Type: 29 ArrayType [100]uint
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 24, index: 0, name: a}
-                  Offset: 0
-                  ByteSize: 800
-    - __kind: EventRootType
-      ID: 300
-      Name: Probe[main.testSingleByte]
-      ByteSize: 2
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: x
-          Offset: 1
-          Expression:
-            Type: 4 BaseType uint8
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 25, index: 0, name: x}
-                  Offset: 0
-                  ByteSize: 1
-    - __kind: EventRootType
-      ID: 301
-      Name: Probe[main.testSingleRune]
-      ByteSize: 5
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: x
-          Offset: 1
-          Expression:
-            Type: 6 BaseType int32
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 26, index: 0, name: x}
-                  Offset: 0
-                  ByteSize: 4
-    - __kind: EventRootType
-      ID: 302
-      Name: Probe[main.testSingleBool]
-      ByteSize: 2
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: x
-          Offset: 1
-          Expression:
-            Type: 11 BaseType bool
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 27, index: 0, name: x}
-                  Offset: 0
-                  ByteSize: 1
-    - __kind: EventRootType
-      ID: 303
-      Name: Probe[main.testSingleInt]
-      ByteSize: 9
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: x
-          Offset: 1
-          Expression:
-            Type: 1 BaseType int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 28, index: 0, name: x}
-                  Offset: 0
-                  ByteSize: 8
-    - __kind: EventRootType
-      ID: 304
-      Name: Probe[main.testSingleInt8]
-      ByteSize: 2
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: x
-          Offset: 1
-          Expression:
-            Type: 14 BaseType int8
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 29, index: 0, name: x}
-                  Offset: 0
-                  ByteSize: 1
-    - __kind: EventRootType
-      ID: 305
-      Name: Probe[main.testSingleInt16]
-      ByteSize: 3
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: x
-          Offset: 1
-          Expression:
-            Type: 16 BaseType int16
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 30, index: 0, name: x}
-                  Offset: 0
-                  ByteSize: 2
-    - __kind: EventRootType
-      ID: 306
-      Name: Probe[main.testSingleInt32]
-      ByteSize: 5
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: x
-          Offset: 1
-          Expression:
-            Type: 6 BaseType int32
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 31, index: 0, name: x}
-                  Offset: 0
-                  ByteSize: 4
-    - __kind: EventRootType
-      ID: 307
-      Name: Probe[main.testSingleInt64]
-      ByteSize: 9
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: x
-          Offset: 1
-          Expression:
-            Type: 18 BaseType int64
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 32, index: 0, name: x}
-                  Offset: 0
-                  ByteSize: 8
-    - __kind: EventRootType
-      ID: 308
-      Name: Probe[main.testSingleUint]
-      ByteSize: 9
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: x
-          Offset: 1
-          Expression:
-            Type: 20 BaseType uint
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 33, index: 0, name: x}
-                  Offset: 0
-                  ByteSize: 8
-    - __kind: EventRootType
-      ID: 309
-      Name: Probe[main.testSingleUint8]
-      ByteSize: 2
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: x
-          Offset: 1
-          Expression:
-            Type: 4 BaseType uint8
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 34, index: 0, name: x}
-                  Offset: 0
-                  ByteSize: 1
-    - __kind: EventRootType
-      ID: 310
-      Name: Probe[main.testSingleUint16]
-      ByteSize: 3
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: x
-          Offset: 1
-          Expression:
-            Type: 22 BaseType uint16
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 35, index: 0, name: x}
-                  Offset: 0
-                  ByteSize: 2
-    - __kind: EventRootType
-      ID: 311
-      Name: Probe[main.testSingleUint32]
-      ByteSize: 5
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: x
-          Offset: 1
-          Expression:
-            Type: 24 BaseType uint32
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 36, index: 0, name: x}
-                  Offset: 0
-                  ByteSize: 4
-    - __kind: EventRootType
-      ID: 312
-      Name: Probe[main.testSingleUint64]
-      ByteSize: 9
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: x
-          Offset: 1
-          Expression:
-            Type: 26 BaseType uint64
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 37, index: 0, name: x}
-                  Offset: 0
-                  ByteSize: 8
-    - __kind: EventRootType
-      ID: 313
-      Name: Probe[main.testSingleFloat32]
-      ByteSize: 5
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: x
-          Offset: 1
-          Expression:
-            Type: 30 BaseType float32
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 38, index: 0, name: x}
-                  Offset: 0
-                  ByteSize: 4
-    - __kind: EventRootType
-      ID: 314
-      Name: Probe[main.testSingleFloat64]
-      ByteSize: 9
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: x
-          Offset: 1
-          Expression:
-            Type: 31 BaseType float64
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 39, index: 0, name: x}
-                  Offset: 0
-                  ByteSize: 8
-    - __kind: EventRootType
-      ID: 315
-      Name: Probe[main.testTypeAlias]
-      ByteSize: 3
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: x
-          Offset: 1
-          Expression:
-            Type: 32 BaseType main.typeAlias
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 40, index: 0, name: x}
-                  Offset: 0
-                  ByteSize: 2
-    - __kind: EventRootType
-      ID: 316
-      Name: Probe[main.testBigStruct]
-      ByteSize: 49
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: b
-          Offset: 1
-          Expression:
-            Type: 33 StructureType main.bigStruct
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 41, index: 0, name: b}
-                  Offset: 0
-                  ByteSize: 48
-    - __kind: EventRootType
-      ID: 317
-      Name: Probe[main.testEsotericStack]
-      ByteSize: 65
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: e
-          Offset: 1
-          Expression:
-            Type: 39 StructureType main.esotericStack
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 42, index: 0, name: e}
-                  Offset: 0
-                  ByteSize: 64
-    - __kind: EventRootType
-      ID: 318
-      Name: Probe[main.testEsotericHeap]
-      ByteSize: 9
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: e
-          Offset: 1
-          Expression:
-            Type: 44 PointerType *main.esotericHeap
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 43, index: 0, name: e}
-                  Offset: 0
-                  ByteSize: 8
-    - __kind: EventRootType
-      ID: 319
-      Name: Probe[main.testInlinedBA]
-      ByteSize: 9
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: x
-          Offset: 1
-          Expression:
-            Type: 1 BaseType int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 44, index: 0, name: x}
-                  Offset: 0
-                  ByteSize: 8
-    - __kind: EventRootType
-      ID: 320
-      Name: Probe[main.testInlinedBB]
-      ByteSize: 17
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: x
-          Offset: 1
-          Expression:
-            Type: 1 BaseType int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 45, index: 0, name: x}
-                  Offset: 0
-                  ByteSize: 8
-        - Name: y
-          Offset: 9
-          Expression:
-            Type: 1 BaseType int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 45, index: 1, name: y}
-                  Offset: 0
-                  ByteSize: 8
-    - __kind: EventRootType
-      ID: 321
-      Name: Probe[main.testInlinedBBA]
-      ByteSize: 9
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: x
-          Offset: 1
-          Expression:
-            Type: 1 BaseType int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 46, index: 0, name: x}
-                  Offset: 0
-                  ByteSize: 8
-    - __kind: EventRootType
-      ID: 322
-      Name: Probe[main.testInlinedBC]
-    - __kind: EventRootType
-      ID: 323
-      Name: Probe[main.testFrameless]
-      ByteSize: 9
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: x
-          Offset: 1
-          Expression:
-            Type: 1 BaseType int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 48, index: 0, name: x}
-                  Offset: 0
-                  ByteSize: 8
-    - __kind: EventRootType
-      ID: 324
-      Name: Probe[main.testFramelessArray]
-      ByteSize: 41
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: a
-          Offset: 1
-          Expression:
-            Type: 2 ArrayType [5]int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 49, index: 0, name: a}
-                  Offset: 0
-                  ByteSize: 40
     - __kind: EventRootType
       ID: 325
       Name: Probe[main.testInterface]
@@ -6573,63 +4097,138 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 326
-      Name: Probe[main.testAny]
+      ID: 352
+      Name: Probe[main.testLinkedList]
       ByteSize: 17
       PresenceBitsetSize: 1
       Expressions:
         - Name: a
           Offset: 1
           Expression:
-            Type: 41 GoEmptyInterfaceType interface {}
+            Type: 144 StructureType main.node
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 51, index: 0, name: a}
+                  Variable: {subprogram: 77, index: 0, name: a}
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 327
-      Name: Probe[main.testError]
-      ByteSize: 17
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: e
-          Offset: 1
-          Expression:
-            Type: 57 GoInterfaceType error
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 52, index: 0, name: e}
-                  Offset: 0
-                  ByteSize: 16
-    - __kind: EventRootType
-      ID: 328
-      Name: Probe[main.testStructWithMap]
-      ByteSize: 9
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: s
-          Offset: 1
-          Expression:
-            Type: 58 StructureType main.structWithMap
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 53, index: 0, name: s}
-                  Offset: 0
-                  ByteSize: 8
-    - __kind: EventRootType
-      ID: 329
-      Name: Probe[main.testMapStringToStruct]
+      ID: 332
+      Name: Probe[main.testMapArrayToArray]
       ByteSize: 9
       PresenceBitsetSize: 1
       Expressions:
         - Name: m
           Offset: 1
           Expression:
-            Type: 71 GoMapType map[string]main.nestedStruct
+            Type: 106 GoMapType map[[4]string][2]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 54, index: 0, name: m}
+                  Variable: {subprogram: 57, index: 0, name: m}
+                  Offset: 0
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 338
+      Name: Probe[main.testMapEmbeddedMaps]
+      ByteSize: 9
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: m
+          Offset: 1
+          Expression:
+            Type: 120 GoMapType map[string][]main.structWithMap
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 63, index: 0, name: m}
+                  Offset: 0
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 336
+      Name: Probe[main.testMapIntToInt]
+      ByteSize: 9
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: m
+          Offset: 1
+          Expression:
+            Type: 59 GoMapType map[int]int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 61, index: 0, name: m}
+                  Offset: 0
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 347
+      Name: Probe[main.testMapLargeKeyLargeValue]
+      ByteSize: 9
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: m
+          Offset: 1
+          Expression:
+            Type: 191 GoMapType map[[4]int][4]int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 72, index: 0, name: m}
+                  Offset: 0
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 346
+      Name: Probe[main.testMapLargeKeySmallValue]
+      ByteSize: 9
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: m
+          Offset: 1
+          Expression:
+            Type: 180 GoMapType map[[4]int]uint8
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 71, index: 0, name: m}
+                  Offset: 0
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 337
+      Name: Probe[main.testMapMassive]
+      ByteSize: 9
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: redactMyEntries
+          Offset: 1
+          Expression:
+            Type: 120 GoMapType map[string][]main.structWithMap
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 62, index: 0, name: redactMyEntries}
+                  Offset: 0
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 345
+      Name: Probe[main.testMapSmallKeyLargeValue]
+      ByteSize: 9
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: m
+          Offset: 1
+          Expression:
+            Type: 168 GoMapType map[uint8][4]int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 70, index: 0, name: m}
+                  Offset: 0
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 344
+      Name: Probe[main.testMapSmallKeySmallValue]
+      ByteSize: 9
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: m
+          Offset: 1
+          Expression:
+            Type: 157 GoMapType map[uint8]uint8
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 69, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
@@ -6663,108 +4262,18 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 332
-      Name: Probe[main.testMapArrayToArray]
+      ID: 329
+      Name: Probe[main.testMapStringToStruct]
       ByteSize: 9
       PresenceBitsetSize: 1
       Expressions:
         - Name: m
           Offset: 1
           Expression:
-            Type: 106 GoMapType map[[4]string][2]int
+            Type: 71 GoMapType map[string]main.nestedStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 57, index: 0, name: m}
-                  Offset: 0
-                  ByteSize: 8
-    - __kind: EventRootType
-      ID: 333
-      Name: Probe[main.testSmallMap]
-      ByteSize: 9
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: m
-          Offset: 1
-          Expression:
-            Type: 83 GoMapType map[string]int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 58, index: 0, name: m}
-                  Offset: 0
-                  ByteSize: 8
-    - __kind: EventRootType
-      ID: 334
-      Name: Probe[main.testArrayOfMaps]
-      ByteSize: 17
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: m
-          Offset: 1
-          Expression:
-            Type: 118 ArrayType [2]map[string]int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 59, index: 0, name: m}
-                  Offset: 0
-                  ByteSize: 16
-    - __kind: EventRootType
-      ID: 335
-      Name: Probe[main.testPointerToMap]
-      ByteSize: 9
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: m
-          Offset: 1
-          Expression:
-            Type: 119 PointerType *map[string]int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 60, index: 0, name: m}
-                  Offset: 0
-                  ByteSize: 8
-    - __kind: EventRootType
-      ID: 336
-      Name: Probe[main.testMapIntToInt]
-      ByteSize: 9
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: m
-          Offset: 1
-          Expression:
-            Type: 59 GoMapType map[int]int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 61, index: 0, name: m}
-                  Offset: 0
-                  ByteSize: 8
-    - __kind: EventRootType
-      ID: 337
-      Name: Probe[main.testMapMassive]
-      ByteSize: 9
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: redactMyEntries
-          Offset: 1
-          Expression:
-            Type: 120 GoMapType map[string][]main.structWithMap
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 62, index: 0, name: redactMyEntries}
-                  Offset: 0
-                  ByteSize: 8
-    - __kind: EventRootType
-      ID: 338
-      Name: Probe[main.testMapEmbeddedMaps]
-      ByteSize: 9
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: m
-          Offset: 1
-          Expression:
-            Type: 120 GoMapType map[string][]main.structWithMap
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 63, index: 0, name: m}
+                  Variable: {subprogram: 54, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
@@ -6783,33 +4292,18 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 340
-      Name: Probe[main.testMapWithSmallValue]
+      ID: 343
+      Name: Probe[main.testMapWithSmallKeyAndValueMassive]
       ByteSize: 9
       PresenceBitsetSize: 1
       Expressions:
         - Name: m
           Offset: 1
           Expression:
-            Type: 146 GoMapType map[int]uint8
+            Type: 157 GoMapType map[uint8]uint8
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 65, index: 0, name: m}
-                  Offset: 0
-                  ByteSize: 8
-    - __kind: EventRootType
-      ID: 341
-      Name: Probe[main.testMapWithSmallValueMassive]
-      ByteSize: 9
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: redactMyEntries
-          Offset: 1
-          Expression:
-            Type: 146 GoMapType map[int]uint8
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 66, index: 0, name: redactMyEntries}
+                  Variable: {subprogram: 68, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
@@ -6828,113 +4322,50 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 343
-      Name: Probe[main.testMapWithSmallKeyAndValueMassive]
+      ID: 341
+      Name: Probe[main.testMapWithSmallValueMassive]
+      ByteSize: 9
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: redactMyEntries
+          Offset: 1
+          Expression:
+            Type: 146 GoMapType map[int]uint8
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 66, index: 0, name: redactMyEntries}
+                  Offset: 0
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 340
+      Name: Probe[main.testMapWithSmallValue]
       ByteSize: 9
       PresenceBitsetSize: 1
       Expressions:
         - Name: m
           Offset: 1
           Expression:
-            Type: 157 GoMapType map[uint8]uint8
+            Type: 146 GoMapType map[int]uint8
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 68, index: 0, name: m}
+                  Variable: {subprogram: 65, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 344
-      Name: Probe[main.testMapSmallKeySmallValue]
-      ByteSize: 9
+      ID: 375
+      Name: Probe[main.testMassiveString]
+      ByteSize: 17
       PresenceBitsetSize: 1
       Expressions:
-        - Name: m
-          Offset: 1
-          Expression:
-            Type: 157 GoMapType map[uint8]uint8
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 69, index: 0, name: m}
-                  Offset: 0
-                  ByteSize: 8
-    - __kind: EventRootType
-      ID: 345
-      Name: Probe[main.testMapSmallKeyLargeValue]
-      ByteSize: 9
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: m
-          Offset: 1
-          Expression:
-            Type: 168 GoMapType map[uint8][4]int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 70, index: 0, name: m}
-                  Offset: 0
-                  ByteSize: 8
-    - __kind: EventRootType
-      ID: 346
-      Name: Probe[main.testMapLargeKeySmallValue]
-      ByteSize: 9
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: m
-          Offset: 1
-          Expression:
-            Type: 180 GoMapType map[[4]int]uint8
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 71, index: 0, name: m}
-                  Offset: 0
-                  ByteSize: 8
-    - __kind: EventRootType
-      ID: 347
-      Name: Probe[main.testMapLargeKeyLargeValue]
-      ByteSize: 9
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: m
-          Offset: 1
-          Expression:
-            Type: 191 GoMapType map[[4]int][4]int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 72, index: 0, name: m}
-                  Offset: 0
-                  ByteSize: 8
-    - __kind: EventRootType
-      ID: 348
-      Name: Probe[main.testCombinedByte]
-      ByteSize: 7
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: w
-          Offset: 1
-          Expression:
-            Type: 4 BaseType uint8
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 73, index: 0, name: w}
-                  Offset: 0
-                  ByteSize: 1
         - Name: x
-          Offset: 2
+          Offset: 1
           Expression:
-            Type: 4 BaseType uint8
+            Type: 8 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 73, index: 1, name: x}
+                  Variable: {subprogram: 100, index: 0, name: x}
                   Offset: 0
-                  ByteSize: 1
-        - Name: y
-          Offset: 3
-          Expression:
-            Type: 30 BaseType float32
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 73, index: 2, name: y}
-                  Offset: 0
-                  ByteSize: 4
+                  ByteSize: 16
     - __kind: EventRootType
       ID: 349
       Name: Probe[main.testMultipleSimpleParams]
@@ -6987,111 +4418,6 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 350
-      Name: Probe[main.testChannel]
-      ByteSize: 1
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: c
-          Offset: 1
-          Expression:
-            Type: 202 GoChannelType chan bool
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 75, index: 0, name: c}
-                  Offset: 0
-                  ByteSize: 0
-    - __kind: EventRootType
-      ID: 351
-      Name: Probe[main.testPointerToSimpleStruct]
-      ByteSize: 9
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: a
-          Offset: 1
-          Expression:
-            Type: 203 PointerType *main.structWithTwoValues
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 76, index: 0, name: a}
-                  Offset: 0
-                  ByteSize: 8
-    - __kind: EventRootType
-      ID: 352
-      Name: Probe[main.testLinkedList]
-      ByteSize: 17
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: a
-          Offset: 1
-          Expression:
-            Type: 144 StructureType main.node
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 77, index: 0, name: a}
-                  Offset: 0
-                  ByteSize: 16
-    - __kind: EventRootType
-      ID: 353
-      Name: Probe[main.testPointerLoop]
-      ByteSize: 9
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: a
-          Offset: 1
-          Expression:
-            Type: 145 PointerType *main.node
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 78, index: 0, name: a}
-                  Offset: 0
-                  ByteSize: 8
-    - __kind: EventRootType
-      ID: 354
-      Name: Probe[main.testUnsafePointer]
-      ByteSize: 9
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: x
-          Offset: 1
-          Expression:
-            Type: 38 VoidPointerType unsafe.Pointer
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 79, index: 0, name: x}
-                  Offset: 0
-                  ByteSize: 8
-    - __kind: EventRootType
-      ID: 355
-      Name: Probe[main.testUintPointer]
-      ByteSize: 9
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: x
-          Offset: 1
-          Expression:
-            Type: 205 PointerType *uint
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 80, index: 0, name: x}
-                  Offset: 0
-                  ByteSize: 8
-    - __kind: EventRootType
-      ID: 356
-      Name: Probe[main.testStringPointer]
-      ByteSize: 9
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: z
-          Offset: 1
-          Expression:
-            Type: 36 PointerType *string
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 81, index: 0, name: z}
-                  Offset: 0
-                  ByteSize: 8
-    - __kind: EventRootType
       ID: 357
       Name: Probe[main.testNilPointer]
       ByteSize: 17
@@ -7113,114 +4439,6 @@ Types:
             Operations:
                 - __kind: LocationOp
                   Variable: {subprogram: 82, index: 1, name: a}
-                  Offset: 0
-                  ByteSize: 8
-    - __kind: EventRootType
-      ID: 358
-      Name: Probe[main.testCycle]
-      ByteSize: 9
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: t
-          Offset: 1
-          Expression:
-            Type: 207 PointerType *main.t
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 83, index: 0, name: t}
-                  Offset: 0
-                  ByteSize: 8
-    - __kind: EventRootType
-      ID: 359
-      Name: Probe[main.testUintSlice]
-      ByteSize: 25
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: u
-          Offset: 1
-          Expression:
-            Type: 210 GoSliceHeaderType []uint
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 84, index: 0, name: u}
-                  Offset: 0
-                  ByteSize: 24
-    - __kind: EventRootType
-      ID: 360
-      Name: Probe[main.testEmptySlice]
-      ByteSize: 25
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: u
-          Offset: 1
-          Expression:
-            Type: 210 GoSliceHeaderType []uint
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 85, index: 0, name: u}
-                  Offset: 0
-                  ByteSize: 24
-    - __kind: EventRootType
-      ID: 361
-      Name: Probe[main.testSliceOfSlices]
-      ByteSize: 25
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: u
-          Offset: 1
-          Expression:
-            Type: 211 GoSliceHeaderType [][]uint
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 86, index: 0, name: u}
-                  Offset: 0
-                  ByteSize: 24
-    - __kind: EventRootType
-      ID: 362
-      Name: Probe[main.testStructSlice]
-      ByteSize: 33
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: xs
-          Offset: 1
-          Expression:
-            Type: 213 GoSliceHeaderType []main.structWithNoStrings
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 87, index: 0, name: xs}
-                  Offset: 0
-                  ByteSize: 24
-        - Name: a
-          Offset: 25
-          Expression:
-            Type: 1 BaseType int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 87, index: 1, name: a}
-                  Offset: 0
-                  ByteSize: 8
-    - __kind: EventRootType
-      ID: 363
-      Name: Probe[main.testEmptySliceOfStructs]
-      ByteSize: 33
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: xs
-          Offset: 1
-          Expression:
-            Type: 213 GoSliceHeaderType []main.structWithNoStrings
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 88, index: 0, name: xs}
-                  Offset: 0
-                  ByteSize: 24
-        - Name: a
-          Offset: 25
-          Expression:
-            Type: 1 BaseType int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 88, index: 1, name: a}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
@@ -7247,21 +4465,6 @@ Types:
                   Variable: {subprogram: 89, index: 1, name: a}
                   Offset: 0
                   ByteSize: 8
-    - __kind: EventRootType
-      ID: 365
-      Name: Probe[main.testStringSlice]
-      ByteSize: 25
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: s
-          Offset: 1
-          Expression:
-            Type: 105 GoSliceHeaderType []string
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 90, index: 0, name: s}
-                  Offset: 0
-                  ByteSize: 24
     - __kind: EventRootType
       ID: 366
       Name: Probe[main.testNilSliceWithOtherParams]
@@ -7311,23 +4514,230 @@ Types:
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 368
-      Name: Probe[main.testVeryLargeSlice]
-      ByteSize: 25
+      ID: 374
+      Name: Probe[main.testOneStringInStructPointer]
+      ByteSize: 9
       PresenceBitsetSize: 1
       Expressions:
-        - Name: xs
+        - Name: a
           Offset: 1
           Expression:
-            Type: 210 GoSliceHeaderType []uint
+            Type: 221 PointerType *main.oneStringStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 93, index: 0, name: xs}
+                  Variable: {subprogram: 99, index: 0, name: a}
                   Offset: 0
-                  ByteSize: 24
+                  ByteSize: 8
     - __kind: EventRootType
-      ID: 369
-      Name: Probe[main.stackC]
+      ID: 353
+      Name: Probe[main.testPointerLoop]
+      ByteSize: 9
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: a
+          Offset: 1
+          Expression:
+            Type: 145 PointerType *main.node
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 78, index: 0, name: a}
+                  Offset: 0
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 335
+      Name: Probe[main.testPointerToMap]
+      ByteSize: 9
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: m
+          Offset: 1
+          Expression:
+            Type: 119 PointerType *map[string]int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 60, index: 0, name: m}
+                  Offset: 0
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 351
+      Name: Probe[main.testPointerToSimpleStruct]
+      ByteSize: 9
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: a
+          Offset: 1
+          Expression:
+            Type: 203 PointerType *main.structWithTwoValues
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 76, index: 0, name: a}
+                  Offset: 0
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 283
+      Name: Probe[main.testRuneArray]
+      ByteSize: 9
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: x
+          Offset: 1
+          Expression:
+            Type: 5 ArrayType [2]int32
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 8, index: 0, name: x}
+                  Offset: 0
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 302
+      Name: Probe[main.testSingleBool]
+      ByteSize: 2
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: x
+          Offset: 1
+          Expression:
+            Type: 11 BaseType bool
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 27, index: 0, name: x}
+                  Offset: 0
+                  ByteSize: 1
+    - __kind: EventRootType
+      ID: 300
+      Name: Probe[main.testSingleByte]
+      ByteSize: 2
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: x
+          Offset: 1
+          Expression:
+            Type: 4 BaseType uint8
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 25, index: 0, name: x}
+                  Offset: 0
+                  ByteSize: 1
+    - __kind: EventRootType
+      ID: 313
+      Name: Probe[main.testSingleFloat32]
+      ByteSize: 5
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: x
+          Offset: 1
+          Expression:
+            Type: 30 BaseType float32
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 38, index: 0, name: x}
+                  Offset: 0
+                  ByteSize: 4
+    - __kind: EventRootType
+      ID: 314
+      Name: Probe[main.testSingleFloat64]
+      ByteSize: 9
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: x
+          Offset: 1
+          Expression:
+            Type: 31 BaseType float64
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 39, index: 0, name: x}
+                  Offset: 0
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 305
+      Name: Probe[main.testSingleInt16]
+      ByteSize: 3
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: x
+          Offset: 1
+          Expression:
+            Type: 16 BaseType int16
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 30, index: 0, name: x}
+                  Offset: 0
+                  ByteSize: 2
+    - __kind: EventRootType
+      ID: 306
+      Name: Probe[main.testSingleInt32]
+      ByteSize: 5
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: x
+          Offset: 1
+          Expression:
+            Type: 6 BaseType int32
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 31, index: 0, name: x}
+                  Offset: 0
+                  ByteSize: 4
+    - __kind: EventRootType
+      ID: 307
+      Name: Probe[main.testSingleInt64]
+      ByteSize: 9
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: x
+          Offset: 1
+          Expression:
+            Type: 18 BaseType int64
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 32, index: 0, name: x}
+                  Offset: 0
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 304
+      Name: Probe[main.testSingleInt8]
+      ByteSize: 2
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: x
+          Offset: 1
+          Expression:
+            Type: 14 BaseType int8
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 29, index: 0, name: x}
+                  Offset: 0
+                  ByteSize: 1
+    - __kind: EventRootType
+      ID: 303
+      Name: Probe[main.testSingleInt]
+      ByteSize: 9
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: x
+          Offset: 1
+          Expression:
+            Type: 1 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 28, index: 0, name: x}
+                  Offset: 0
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 301
+      Name: Probe[main.testSingleRune]
+      ByteSize: 5
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: x
+          Offset: 1
+          Expression:
+            Type: 6 BaseType int32
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 26, index: 0, name: x}
+                  Offset: 0
+                  ByteSize: 4
     - __kind: EventRootType
       ID: 370
       Name: Probe[main.testSingleString]
@@ -7343,6 +4753,240 @@ Types:
                   Variable: {subprogram: 95, index: 0, name: x}
                   Offset: 0
                   ByteSize: 16
+    - __kind: EventRootType
+      ID: 310
+      Name: Probe[main.testSingleUint16]
+      ByteSize: 3
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: x
+          Offset: 1
+          Expression:
+            Type: 22 BaseType uint16
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 35, index: 0, name: x}
+                  Offset: 0
+                  ByteSize: 2
+    - __kind: EventRootType
+      ID: 311
+      Name: Probe[main.testSingleUint32]
+      ByteSize: 5
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: x
+          Offset: 1
+          Expression:
+            Type: 24 BaseType uint32
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 36, index: 0, name: x}
+                  Offset: 0
+                  ByteSize: 4
+    - __kind: EventRootType
+      ID: 312
+      Name: Probe[main.testSingleUint64]
+      ByteSize: 9
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: x
+          Offset: 1
+          Expression:
+            Type: 26 BaseType uint64
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 37, index: 0, name: x}
+                  Offset: 0
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 309
+      Name: Probe[main.testSingleUint8]
+      ByteSize: 2
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: x
+          Offset: 1
+          Expression:
+            Type: 4 BaseType uint8
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 34, index: 0, name: x}
+                  Offset: 0
+                  ByteSize: 1
+    - __kind: EventRootType
+      ID: 308
+      Name: Probe[main.testSingleUint]
+      ByteSize: 9
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: x
+          Offset: 1
+          Expression:
+            Type: 20 BaseType uint
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 33, index: 0, name: x}
+                  Offset: 0
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 361
+      Name: Probe[main.testSliceOfSlices]
+      ByteSize: 25
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: u
+          Offset: 1
+          Expression:
+            Type: 211 GoSliceHeaderType [][]uint
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 86, index: 0, name: u}
+                  Offset: 0
+                  ByteSize: 24
+    - __kind: EventRootType
+      ID: 333
+      Name: Probe[main.testSmallMap]
+      ByteSize: 9
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: m
+          Offset: 1
+          Expression:
+            Type: 83 GoMapType map[string]int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 58, index: 0, name: m}
+                  Offset: 0
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 284
+      Name: Probe[main.testStringArray]
+      ByteSize: 33
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: x
+          Offset: 1
+          Expression:
+            Type: 7 ArrayType [2]string
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 9, index: 0, name: x}
+                  Offset: 0
+                  ByteSize: 32
+    - __kind: EventRootType
+      ID: 356
+      Name: Probe[main.testStringPointer]
+      ByteSize: 9
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: z
+          Offset: 1
+          Expression:
+            Type: 36 PointerType *string
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 81, index: 0, name: z}
+                  Offset: 0
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 365
+      Name: Probe[main.testStringSlice]
+      ByteSize: 25
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: s
+          Offset: 1
+          Expression:
+            Type: 105 GoSliceHeaderType []string
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 90, index: 0, name: s}
+                  Offset: 0
+                  ByteSize: 24
+    - __kind: EventRootType
+      ID: 362
+      Name: Probe[main.testStructSlice]
+      ByteSize: 33
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: xs
+          Offset: 1
+          Expression:
+            Type: 213 GoSliceHeaderType []main.structWithNoStrings
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 87, index: 0, name: xs}
+                  Offset: 0
+                  ByteSize: 24
+        - Name: a
+          Offset: 25
+          Expression:
+            Type: 1 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 87, index: 1, name: a}
+                  Offset: 0
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 328
+      Name: Probe[main.testStructWithMap]
+      ByteSize: 9
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: s
+          Offset: 1
+          Expression:
+            Type: 58 StructureType main.structWithMap
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 53, index: 0, name: s}
+                  Offset: 0
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 378
+      Name: Probe[main.testStruct]
+      ByteSize: 57
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: x
+          Offset: 1
+          Expression:
+            Type: 223 StructureType main.aStruct
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 103, index: 0, name: x}
+                  Offset: 0
+                  ByteSize: 56
+    - __kind: EventRootType
+      ID: 373
+      Name: Probe[main.testThreeStringsInStructPointer]
+      ByteSize: 9
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: a
+          Offset: 1
+          Expression:
+            Type: 220 PointerType *main.threeStringStruct
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 98, index: 0, name: a}
+                  Offset: 0
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 372
+      Name: Probe[main.testThreeStringsInStruct]
+      ByteSize: 49
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: a
+          Offset: 1
+          Expression:
+            Type: 219 StructureType main.threeStringStruct
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 97, index: 0, name: a}
+                  Offset: 0
+                  ByteSize: 48
     - __kind: EventRootType
       ID: 371
       Name: Probe[main.testThreeStrings]
@@ -7377,65 +5021,125 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 372
-      Name: Probe[main.testThreeStringsInStruct]
-      ByteSize: 49
+      ID: 315
+      Name: Probe[main.testTypeAlias]
+      ByteSize: 3
       PresenceBitsetSize: 1
       Expressions:
-        - Name: a
+        - Name: x
           Offset: 1
           Expression:
-            Type: 219 StructureType main.threeStringStruct
+            Type: 32 BaseType main.typeAlias
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 97, index: 0, name: a}
+                  Variable: {subprogram: 40, index: 0, name: x}
                   Offset: 0
-                  ByteSize: 48
+                  ByteSize: 2
     - __kind: EventRootType
-      ID: 373
-      Name: Probe[main.testThreeStringsInStructPointer]
+      ID: 293
+      Name: Probe[main.testUint16Array]
+      ByteSize: 5
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: x
+          Offset: 1
+          Expression:
+            Type: 21 ArrayType [2]uint16
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 18, index: 0, name: x}
+                  Offset: 0
+                  ByteSize: 4
+    - __kind: EventRootType
+      ID: 294
+      Name: Probe[main.testUint32Array]
       ByteSize: 9
       PresenceBitsetSize: 1
       Expressions:
-        - Name: a
+        - Name: x
           Offset: 1
           Expression:
-            Type: 220 PointerType *main.threeStringStruct
+            Type: 23 ArrayType [2]uint32
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 98, index: 0, name: a}
+                  Variable: {subprogram: 19, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 374
-      Name: Probe[main.testOneStringInStructPointer]
-      ByteSize: 9
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: a
-          Offset: 1
-          Expression:
-            Type: 221 PointerType *main.oneStringStruct
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 99, index: 0, name: a}
-                  Offset: 0
-                  ByteSize: 8
-    - __kind: EventRootType
-      ID: 375
-      Name: Probe[main.testMassiveString]
+      ID: 295
+      Name: Probe[main.testUint64Array]
       ByteSize: 17
       PresenceBitsetSize: 1
       Expressions:
         - Name: x
           Offset: 1
           Expression:
-            Type: 8 GoStringHeaderType string
+            Type: 25 ArrayType [2]uint64
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 100, index: 0, name: x}
+                  Variable: {subprogram: 20, index: 0, name: x}
                   Offset: 0
                   ByteSize: 16
+    - __kind: EventRootType
+      ID: 292
+      Name: Probe[main.testUint8Array]
+      ByteSize: 3
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: x
+          Offset: 1
+          Expression:
+            Type: 3 ArrayType [2]uint8
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 17, index: 0, name: x}
+                  Offset: 0
+                  ByteSize: 2
+    - __kind: EventRootType
+      ID: 291
+      Name: Probe[main.testUintArray]
+      ByteSize: 17
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: x
+          Offset: 1
+          Expression:
+            Type: 19 ArrayType [2]uint
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 16, index: 0, name: x}
+                  Offset: 0
+                  ByteSize: 16
+    - __kind: EventRootType
+      ID: 355
+      Name: Probe[main.testUintPointer]
+      ByteSize: 9
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: x
+          Offset: 1
+          Expression:
+            Type: 205 PointerType *uint
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 80, index: 0, name: x}
+                  Offset: 0
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 359
+      Name: Probe[main.testUintSlice]
+      ByteSize: 25
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: u
+          Offset: 1
+          Expression:
+            Type: 210 GoSliceHeaderType []uint
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 84, index: 0, name: u}
+                  Offset: 0
+                  ByteSize: 24
     - __kind: EventRootType
       ID: 376
       Name: Probe[main.testUnitializedString]
@@ -7452,104 +5156,2400 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 377
-      Name: Probe[main.testEmptyString]
-      ByteSize: 17
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: x
-          Offset: 1
-          Expression:
-            Type: 8 GoStringHeaderType string
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 102, index: 0, name: x}
-                  Offset: 0
-                  ByteSize: 16
-    - __kind: EventRootType
-      ID: 378
-      Name: Probe[main.testStruct]
-      ByteSize: 57
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: x
-          Offset: 1
-          Expression:
-            Type: 223 StructureType main.aStruct
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 103, index: 0, name: x}
-                  Offset: 0
-                  ByteSize: 56
-    - __kind: EventRootType
-      ID: 379
-      Name: Probe[main.testEmptyStruct]
-      ByteSize: 1
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: e
-          Offset: 1
-          Expression:
-            Type: 224 StructureType main.emptyStruct
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 104, index: 0, name: e}
-                  Offset: 0
-                  ByteSize: 0
-    - __kind: EventRootType
-      ID: 380
-      Name: Probe[main.testInlinedPrint]
+      ID: 354
+      Name: Probe[main.testUnsafePointer]
       ByteSize: 9
       PresenceBitsetSize: 1
       Expressions:
         - Name: x
           Offset: 1
           Expression:
-            Type: 1 BaseType int
+            Type: 38 VoidPointerType unsafe.Pointer
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 1, index: 0, name: x}
+                  Variable: {subprogram: 79, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 381
-      Name: Probe[main.testInlinedBBB]
-    - __kind: EventRootType
-      ID: 382
-      Name: Probe[main.testInlinedBCA]
-    - __kind: EventRootType
-      ID: 383
-      Name: Probe[main.testInlinedBCB]
-    - __kind: EventRootType
-      ID: 384
-      Name: Probe[main.testInlinedSq]
-      ByteSize: 9
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: x
-          Offset: 1
-          Expression:
-            Type: 1 BaseType int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 5, index: 0, name: x}
-                  Offset: 0
-                  ByteSize: 8
-    - __kind: EventRootType
-      ID: 385
-      Name: Probe[main.testInlinedSumArray]
-      ByteSize: 41
+      ID: 299
+      Name: Probe[main.testVeryLargeArray]
+      ByteSize: 801
       PresenceBitsetSize: 1
       Expressions:
         - Name: a
           Offset: 1
           Expression:
-            Type: 2 ArrayType [5]int
+            Type: 29 ArrayType [100]uint
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 6, index: 0, name: a}
+                  Variable: {subprogram: 24, index: 0, name: a}
                   Offset: 0
-                  ByteSize: 40
+                  ByteSize: 800
+    - __kind: EventRootType
+      ID: 368
+      Name: Probe[main.testVeryLargeSlice]
+      ByteSize: 25
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: xs
+          Offset: 1
+          Expression:
+            Type: 210 GoSliceHeaderType []uint
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 93, index: 0, name: xs}
+                  Offset: 0
+                  ByteSize: 24
+    - __kind: ArrayType
+      ID: 29
+      Name: '[100]uint'
+      ByteSize: 800
+      GoKind: 17
+      Count: 100
+      HasCount: true
+      Element: 20 BaseType uint
+    - __kind: ArrayType
+      ID: 28
+      Name: '[2][2][2]int'
+      ByteSize: 64
+      GoKind: 17
+      Count: 2
+      HasCount: true
+      Element: 27 ArrayType [2][2]int
+    - __kind: ArrayType
+      ID: 27
+      Name: '[2][2]int'
+      ByteSize: 32
+      GoKind: 17
+      Count: 2
+      HasCount: true
+      Element: 12 ArrayType [2]int
+    - __kind: ArrayType
+      ID: 10
+      Name: '[2]bool'
+      ByteSize: 2
+      GoKind: 17
+      Count: 2
+      HasCount: true
+      Element: 11 BaseType bool
+    - __kind: ArrayType
+      ID: 12
+      Name: '[2]int'
+      ByteSize: 16
+      GoRuntimeType: 676800
+      GoKind: 17
+      Count: 2
+      HasCount: true
+      Element: 1 BaseType int
+    - __kind: ArrayType
+      ID: 15
+      Name: '[2]int16'
+      ByteSize: 4
+      GoKind: 17
+      Count: 2
+      HasCount: true
+      Element: 16 BaseType int16
+    - __kind: ArrayType
+      ID: 5
+      Name: '[2]int32'
+      ByteSize: 8
+      GoRuntimeType: 678144
+      GoKind: 17
+      Count: 2
+      HasCount: true
+      Element: 6 BaseType int32
+    - __kind: ArrayType
+      ID: 17
+      Name: '[2]int64'
+      ByteSize: 16
+      GoKind: 17
+      Count: 2
+      HasCount: true
+      Element: 18 BaseType int64
+    - __kind: ArrayType
+      ID: 13
+      Name: '[2]int8'
+      ByteSize: 2
+      GoKind: 17
+      Count: 2
+      HasCount: true
+      Element: 14 BaseType int8
+    - __kind: ArrayType
+      ID: 118
+      Name: '[2]map[string]int'
+      ByteSize: 16
+      GoKind: 17
+      Count: 2
+      HasCount: true
+      Element: 83 GoMapType map[string]int
+    - __kind: ArrayType
+      ID: 7
+      Name: '[2]string'
+      ByteSize: 32
+      GoRuntimeType: 678240
+      GoKind: 17
+      Count: 2
+      HasCount: true
+      Element: 8 GoStringHeaderType string
+    - __kind: ArrayType
+      ID: 19
+      Name: '[2]uint'
+      ByteSize: 16
+      GoKind: 17
+      Count: 2
+      HasCount: true
+      Element: 20 BaseType uint
+    - __kind: ArrayType
+      ID: 21
+      Name: '[2]uint16'
+      ByteSize: 4
+      GoKind: 17
+      Count: 2
+      HasCount: true
+      Element: 22 BaseType uint16
+    - __kind: ArrayType
+      ID: 23
+      Name: '[2]uint32'
+      ByteSize: 8
+      GoKind: 17
+      Count: 2
+      HasCount: true
+      Element: 24 BaseType uint32
+    - __kind: ArrayType
+      ID: 25
+      Name: '[2]uint64'
+      ByteSize: 16
+      GoRuntimeType: 678336
+      GoKind: 17
+      Count: 2
+      HasCount: true
+      Element: 26 BaseType uint64
+    - __kind: ArrayType
+      ID: 3
+      Name: '[2]uint8'
+      ByteSize: 2
+      GoRuntimeType: 678048
+      GoKind: 17
+      Count: 2
+      HasCount: true
+      Element: 4 BaseType uint8
+    - __kind: ArrayType
+      ID: 179
+      Name: '[4]int'
+      ByteSize: 32
+      GoRuntimeType: 676416
+      GoKind: 17
+      Count: 4
+      HasCount: true
+      Element: 1 BaseType int
+    - __kind: ArrayType
+      ID: 117
+      Name: '[4]string'
+      ByteSize: 64
+      GoRuntimeType: 676704
+      GoKind: 17
+      Count: 4
+      HasCount: true
+      Element: 8 GoStringHeaderType string
+    - __kind: ArrayType
+      ID: 2
+      Name: '[5]int'
+      ByteSize: 40
+      GoKind: 17
+      Count: 5
+      HasCount: true
+      Element: 1 BaseType int
+    - __kind: GoSliceHeaderType
+      ID: 34
+      Name: '[]*string'
+      ByteSize: 24
+      GoRuntimeType: 473376
+      GoKind: 23
+      RawFields:
+        - Name: array
+          Offset: 0
+          Type: 35 PointerType **string
+        - Name: len
+          Offset: 8
+          Type: 1 BaseType int
+        - Name: cap
+          Offset: 16
+          Type: 1 BaseType int
+      Data: 240 GoSliceDataType []*string.array
+    - __kind: GoSliceDataType
+      ID: 240
+      Name: '[]*string.array'
+      ByteSize: 2048
+      Element: 36 PointerType *string
+    - __kind: GoSliceDataType
+      ID: 268
+      Name: '[]*table<[4]int,[4]int>.array'
+      ByteSize: 8192
+      Element: 195 PointerType *table<[4]int,[4]int>
+    - __kind: GoSliceDataType
+      ID: 266
+      Name: '[]*table<[4]int,uint8>.array'
+      ByteSize: 8192
+      Element: 184 PointerType *table<[4]int,uint8>
+    - __kind: GoSliceDataType
+      ID: 252
+      Name: '[]*table<[4]string,[2]int>.array'
+      ByteSize: 8192
+      Element: 110 PointerType *table<[4]string,[2]int>
+    - __kind: GoSliceDataType
+      ID: 258
+      Name: '[]*table<bool,main.node>.array'
+      ByteSize: 8192
+      Element: 137 PointerType *table<bool,main.node>
+    - __kind: GoSliceDataType
+      ID: 242
+      Name: '[]*table<int,int>.array'
+      ByteSize: 8192
+      Element: 64 PointerType *table<int,int>
+    - __kind: GoSliceDataType
+      ID: 260
+      Name: '[]*table<int,uint8>.array'
+      ByteSize: 8192
+      Element: 150 PointerType *table<int,uint8>
+    - __kind: GoSliceDataType
+      ID: 254
+      Name: '[]*table<string,[]main.structWithMap>.array'
+      ByteSize: 8192
+      Element: 124 PointerType *table<string,[]main.structWithMap>
+    - __kind: GoSliceDataType
+      ID: 248
+      Name: '[]*table<string,[]string>.array'
+      ByteSize: 8192
+      Element: 98 PointerType *table<string,[]string>
+    - __kind: GoSliceDataType
+      ID: 246
+      Name: '[]*table<string,int>.array'
+      ByteSize: 8192
+      Element: 87 PointerType *table<string,int>
+    - __kind: GoSliceDataType
+      ID: 244
+      Name: '[]*table<string,main.nestedStruct>.array'
+      ByteSize: 8192
+      Element: 75 PointerType *table<string,main.nestedStruct>
+    - __kind: GoSliceDataType
+      ID: 264
+      Name: '[]*table<uint8,[4]int>.array'
+      ByteSize: 8192
+      Element: 172 PointerType *table<uint8,[4]int>
+    - __kind: GoSliceDataType
+      ID: 262
+      Name: '[]*table<uint8,uint8>.array'
+      ByteSize: 8192
+      Element: 161 PointerType *table<uint8,uint8>
+    - __kind: GoSliceHeaderType
+      ID: 211
+      Name: '[][]uint'
+      ByteSize: 24
+      GoKind: 23
+      RawFields:
+        - Name: array
+          Offset: 0
+          Type: 212 PointerType *[]uint
+        - Name: len
+          Offset: 8
+          Type: 1 BaseType int
+        - Name: cap
+          Offset: 16
+          Type: 1 BaseType int
+      Data: 274 GoSliceDataType [][]uint.array
+    - __kind: GoSliceDataType
+      ID: 274
+      Name: '[][]uint.array'
+      ByteSize: 2048
+      Element: 210 GoSliceHeaderType []uint
+    - __kind: GoSliceHeaderType
+      ID: 216
+      Name: '[]bool'
+      ByteSize: 24
+      GoRuntimeType: 481696
+      GoKind: 23
+      RawFields:
+        - Name: array
+          Offset: 0
+          Type: 206 PointerType *bool
+        - Name: len
+          Offset: 8
+          Type: 1 BaseType int
+        - Name: cap
+          Offset: 16
+          Type: 1 BaseType int
+      Data: 278 GoSliceDataType []bool.array
+    - __kind: GoSliceDataType
+      ID: 278
+      Name: '[]bool.array'
+      ByteSize: 2048
+      Element: 11 BaseType bool
+    - __kind: GoSliceHeaderType
+      ID: 131
+      Name: '[]main.structWithMap'
+      ByteSize: 24
+      GoRuntimeType: 472608
+      GoKind: 23
+      RawFields:
+        - Name: array
+          Offset: 0
+          Type: 132 PointerType *main.structWithMap
+        - Name: len
+          Offset: 8
+          Type: 1 BaseType int
+        - Name: cap
+          Offset: 16
+          Type: 1 BaseType int
+      Data: 256 GoSliceDataType []main.structWithMap.array
+    - __kind: GoSliceDataType
+      ID: 256
+      Name: '[]main.structWithMap.array'
+      ByteSize: 2048
+      Element: 58 StructureType main.structWithMap
+    - __kind: GoSliceHeaderType
+      ID: 213
+      Name: '[]main.structWithNoStrings'
+      ByteSize: 24
+      GoKind: 23
+      RawFields:
+        - Name: array
+          Offset: 0
+          Type: 214 PointerType *main.structWithNoStrings
+        - Name: len
+          Offset: 8
+          Type: 1 BaseType int
+        - Name: cap
+          Offset: 16
+          Type: 1 BaseType int
+      Data: 276 GoSliceDataType []main.structWithNoStrings.array
+    - __kind: GoSliceDataType
+      ID: 276
+      Name: '[]main.structWithNoStrings.array'
+      ByteSize: 2048
+      Element: 215 StructureType main.structWithNoStrings
+    - __kind: GoSliceDataType
+      ID: 269
+      Name: '[]noalg.map.group[[4]int][4]int.array'
+      ByteSize: 2048
+      Element: 199 StructureType noalg.map.group[[4]int][4]int
+    - __kind: GoSliceDataType
+      ID: 267
+      Name: '[]noalg.map.group[[4]int]uint8.array'
+      ByteSize: 2048
+      Element: 188 StructureType noalg.map.group[[4]int]uint8
+    - __kind: GoSliceDataType
+      ID: 253
+      Name: '[]noalg.map.group[[4]string][2]int.array'
+      ByteSize: 2048
+      Element: 114 StructureType noalg.map.group[[4]string][2]int
+    - __kind: GoSliceDataType
+      ID: 259
+      Name: '[]noalg.map.group[bool]main.node.array'
+      ByteSize: 2048
+      Element: 141 StructureType noalg.map.group[bool]main.node
+    - __kind: GoSliceDataType
+      ID: 243
+      Name: '[]noalg.map.group[int]int.array'
+      ByteSize: 2048
+      Element: 68 StructureType noalg.map.group[int]int
+    - __kind: GoSliceDataType
+      ID: 261
+      Name: '[]noalg.map.group[int]uint8.array'
+      ByteSize: 2048
+      Element: 154 StructureType noalg.map.group[int]uint8
+    - __kind: GoSliceDataType
+      ID: 255
+      Name: '[]noalg.map.group[string][]main.structWithMap.array'
+      ByteSize: 2048
+      Element: 128 StructureType noalg.map.group[string][]main.structWithMap
+    - __kind: GoSliceDataType
+      ID: 249
+      Name: '[]noalg.map.group[string][]string.array'
+      ByteSize: 2048
+      Element: 102 StructureType noalg.map.group[string][]string
+    - __kind: GoSliceDataType
+      ID: 247
+      Name: '[]noalg.map.group[string]int.array'
+      ByteSize: 2048
+      Element: 91 StructureType noalg.map.group[string]int
+    - __kind: GoSliceDataType
+      ID: 245
+      Name: '[]noalg.map.group[string]main.nestedStruct.array'
+      ByteSize: 2048
+      Element: 79 StructureType noalg.map.group[string]main.nestedStruct
+    - __kind: GoSliceDataType
+      ID: 265
+      Name: '[]noalg.map.group[uint8][4]int.array'
+      ByteSize: 2048
+      Element: 176 StructureType noalg.map.group[uint8][4]int
+    - __kind: GoSliceDataType
+      ID: 263
+      Name: '[]noalg.map.group[uint8]uint8.array'
+      ByteSize: 2048
+      Element: 165 StructureType noalg.map.group[uint8]uint8
+    - __kind: GoSliceHeaderType
+      ID: 105
+      Name: '[]string'
+      ByteSize: 24
+      GoRuntimeType: 481824
+      GoKind: 23
+      RawFields:
+        - Name: array
+          Offset: 0
+          Type: 36 PointerType *string
+        - Name: len
+          Offset: 8
+          Type: 1 BaseType int
+        - Name: cap
+          Offset: 16
+          Type: 1 BaseType int
+      Data: 250 GoSliceDataType []string.array
+    - __kind: GoSliceDataType
+      ID: 250
+      Name: '[]string.array'
+      ByteSize: 2048
+      Element: 8 GoStringHeaderType string
+    - __kind: GoSliceHeaderType
+      ID: 210
+      Name: '[]uint'
+      ByteSize: 24
+      GoRuntimeType: 481312
+      GoKind: 23
+      RawFields:
+        - Name: array
+          Offset: 0
+          Type: 205 PointerType *uint
+        - Name: len
+          Offset: 8
+          Type: 1 BaseType int
+        - Name: cap
+          Offset: 16
+          Type: 1 BaseType int
+      Data: 272 GoSliceDataType []uint.array
+    - __kind: GoSliceDataType
+      ID: 272
+      Name: '[]uint.array'
+      ByteSize: 2048
+      Element: 20 BaseType uint
+    - __kind: GoSliceHeaderType
+      ID: 217
+      Name: '[]uint16'
+      ByteSize: 24
+      GoRuntimeType: 480672
+      GoKind: 23
+      RawFields:
+        - Name: array
+          Offset: 0
+          Type: 218 PointerType *uint16
+        - Name: len
+          Offset: 8
+          Type: 1 BaseType int
+        - Name: cap
+          Offset: 16
+          Type: 1 BaseType int
+      Data: 280 GoSliceDataType []uint16.array
+    - __kind: GoSliceDataType
+      ID: 280
+      Name: '[]uint16.array'
+      ByteSize: 2048
+      Element: 22 BaseType uint16
+    - __kind: BaseType
+      ID: 11
+      Name: bool
+      ByteSize: 1
+      GoRuntimeType: 579584
+      GoKind: 1
+    - __kind: GoChannelType
+      ID: 202
+      Name: chan bool
+      GoRuntimeType: 590912
+      GoKind: 18
+    - __kind: GoChannelType
+      ID: 40
+      Name: chan struct {}
+      GoRuntimeType: 589824
+      GoKind: 18
+    - __kind: BaseType
+      ID: 229
+      Name: complex128
+      ByteSize: 16
+      GoRuntimeType: 579392
+      GoKind: 16
+    - __kind: BaseType
+      ID: 228
+      Name: complex64
+      ByteSize: 8
+      GoRuntimeType: 579328
+      GoKind: 15
+    - __kind: GoInterfaceType
+      ID: 57
+      Name: error
+      ByteSize: 16
+      GoRuntimeType: 1.02e+06
+      GoKind: 20
+      RawFields:
+        - Name: tab
+          Offset: 0
+          Type: 38 VoidPointerType unsafe.Pointer
+        - Name: data
+          Offset: 8
+          Type: 38 VoidPointerType unsafe.Pointer
+    - __kind: BaseType
+      ID: 30
+      Name: float32
+      ByteSize: 4
+      GoRuntimeType: 579456
+      GoKind: 13
+    - __kind: BaseType
+      ID: 31
+      Name: float64
+      ByteSize: 8
+      GoRuntimeType: 579520
+      GoKind: 14
+    - __kind: GoSubroutineType
+      ID: 43
+      Name: func()
+      ByteSize: 8
+      GoRuntimeType: 471584
+      GoKind: 19
+    - __kind: GoSwissMapGroupsType
+      ID: 197
+      Name: groupReference<[4]int,[4]int>
+      ByteSize: 16
+      GoKind: 25
+      RawFields:
+        - Name: data
+          Offset: 0
+          Type: 198 PointerType *noalg.map.group[[4]int][4]int
+        - Name: lengthMask
+          Offset: 8
+          Type: 26 BaseType uint64
+      GroupType: 199 StructureType noalg.map.group[[4]int][4]int
+      GroupSliceType: 269 GoSliceDataType []noalg.map.group[[4]int][4]int.array
+    - __kind: GoSwissMapGroupsType
+      ID: 186
+      Name: groupReference<[4]int,uint8>
+      ByteSize: 16
+      GoKind: 25
+      RawFields:
+        - Name: data
+          Offset: 0
+          Type: 187 PointerType *noalg.map.group[[4]int]uint8
+        - Name: lengthMask
+          Offset: 8
+          Type: 26 BaseType uint64
+      GroupType: 188 StructureType noalg.map.group[[4]int]uint8
+      GroupSliceType: 267 GoSliceDataType []noalg.map.group[[4]int]uint8.array
+    - __kind: GoSwissMapGroupsType
+      ID: 112
+      Name: groupReference<[4]string,[2]int>
+      ByteSize: 16
+      GoKind: 25
+      RawFields:
+        - Name: data
+          Offset: 0
+          Type: 113 PointerType *noalg.map.group[[4]string][2]int
+        - Name: lengthMask
+          Offset: 8
+          Type: 26 BaseType uint64
+      GroupType: 114 StructureType noalg.map.group[[4]string][2]int
+      GroupSliceType: 253 GoSliceDataType []noalg.map.group[[4]string][2]int.array
+    - __kind: GoSwissMapGroupsType
+      ID: 139
+      Name: groupReference<bool,main.node>
+      ByteSize: 16
+      GoKind: 25
+      RawFields:
+        - Name: data
+          Offset: 0
+          Type: 140 PointerType *noalg.map.group[bool]main.node
+        - Name: lengthMask
+          Offset: 8
+          Type: 26 BaseType uint64
+      GroupType: 141 StructureType noalg.map.group[bool]main.node
+      GroupSliceType: 259 GoSliceDataType []noalg.map.group[bool]main.node.array
+    - __kind: GoSwissMapGroupsType
+      ID: 66
+      Name: groupReference<int,int>
+      ByteSize: 16
+      GoKind: 25
+      RawFields:
+        - Name: data
+          Offset: 0
+          Type: 67 PointerType *noalg.map.group[int]int
+        - Name: lengthMask
+          Offset: 8
+          Type: 26 BaseType uint64
+      GroupType: 68 StructureType noalg.map.group[int]int
+      GroupSliceType: 243 GoSliceDataType []noalg.map.group[int]int.array
+    - __kind: GoSwissMapGroupsType
+      ID: 152
+      Name: groupReference<int,uint8>
+      ByteSize: 16
+      GoKind: 25
+      RawFields:
+        - Name: data
+          Offset: 0
+          Type: 153 PointerType *noalg.map.group[int]uint8
+        - Name: lengthMask
+          Offset: 8
+          Type: 26 BaseType uint64
+      GroupType: 154 StructureType noalg.map.group[int]uint8
+      GroupSliceType: 261 GoSliceDataType []noalg.map.group[int]uint8.array
+    - __kind: GoSwissMapGroupsType
+      ID: 126
+      Name: groupReference<string,[]main.structWithMap>
+      ByteSize: 16
+      GoKind: 25
+      RawFields:
+        - Name: data
+          Offset: 0
+          Type: 127 PointerType *noalg.map.group[string][]main.structWithMap
+        - Name: lengthMask
+          Offset: 8
+          Type: 26 BaseType uint64
+      GroupType: 128 StructureType noalg.map.group[string][]main.structWithMap
+      GroupSliceType: 255 GoSliceDataType []noalg.map.group[string][]main.structWithMap.array
+    - __kind: GoSwissMapGroupsType
+      ID: 100
+      Name: groupReference<string,[]string>
+      ByteSize: 16
+      GoKind: 25
+      RawFields:
+        - Name: data
+          Offset: 0
+          Type: 101 PointerType *noalg.map.group[string][]string
+        - Name: lengthMask
+          Offset: 8
+          Type: 26 BaseType uint64
+      GroupType: 102 StructureType noalg.map.group[string][]string
+      GroupSliceType: 249 GoSliceDataType []noalg.map.group[string][]string.array
+    - __kind: GoSwissMapGroupsType
+      ID: 89
+      Name: groupReference<string,int>
+      ByteSize: 16
+      GoKind: 25
+      RawFields:
+        - Name: data
+          Offset: 0
+          Type: 90 PointerType *noalg.map.group[string]int
+        - Name: lengthMask
+          Offset: 8
+          Type: 26 BaseType uint64
+      GroupType: 91 StructureType noalg.map.group[string]int
+      GroupSliceType: 247 GoSliceDataType []noalg.map.group[string]int.array
+    - __kind: GoSwissMapGroupsType
+      ID: 77
+      Name: groupReference<string,main.nestedStruct>
+      ByteSize: 16
+      GoKind: 25
+      RawFields:
+        - Name: data
+          Offset: 0
+          Type: 78 PointerType *noalg.map.group[string]main.nestedStruct
+        - Name: lengthMask
+          Offset: 8
+          Type: 26 BaseType uint64
+      GroupType: 79 StructureType noalg.map.group[string]main.nestedStruct
+      GroupSliceType: 245 GoSliceDataType []noalg.map.group[string]main.nestedStruct.array
+    - __kind: GoSwissMapGroupsType
+      ID: 174
+      Name: groupReference<uint8,[4]int>
+      ByteSize: 16
+      GoKind: 25
+      RawFields:
+        - Name: data
+          Offset: 0
+          Type: 175 PointerType *noalg.map.group[uint8][4]int
+        - Name: lengthMask
+          Offset: 8
+          Type: 26 BaseType uint64
+      GroupType: 176 StructureType noalg.map.group[uint8][4]int
+      GroupSliceType: 265 GoSliceDataType []noalg.map.group[uint8][4]int.array
+    - __kind: GoSwissMapGroupsType
+      ID: 163
+      Name: groupReference<uint8,uint8>
+      ByteSize: 16
+      GoKind: 25
+      RawFields:
+        - Name: data
+          Offset: 0
+          Type: 164 PointerType *noalg.map.group[uint8]uint8
+        - Name: lengthMask
+          Offset: 8
+          Type: 26 BaseType uint64
+      GroupType: 165 StructureType noalg.map.group[uint8]uint8
+      GroupSliceType: 263 GoSliceDataType []noalg.map.group[uint8]uint8.array
+    - __kind: BaseType
+      ID: 1
+      Name: int
+      ByteSize: 8
+      GoRuntimeType: 579136
+      GoKind: 2
+    - __kind: BaseType
+      ID: 16
+      Name: int16
+      ByteSize: 2
+      GoRuntimeType: 578752
+      GoKind: 4
+    - __kind: BaseType
+      ID: 6
+      Name: int32
+      ByteSize: 4
+      GoRuntimeType: 578880
+      GoKind: 5
+    - __kind: BaseType
+      ID: 18
+      Name: int64
+      ByteSize: 8
+      GoRuntimeType: 579008
+      GoKind: 6
+    - __kind: BaseType
+      ID: 14
+      Name: int8
+      ByteSize: 1
+      GoRuntimeType: 578624
+      GoKind: 3
+    - __kind: GoEmptyInterfaceType
+      ID: 41
+      Name: interface {}
+      ByteSize: 16
+      GoRuntimeType: 841248
+      GoKind: 20
+      RawFields:
+        - Name: _type
+          Offset: 0
+          Type: 38 VoidPointerType unsafe.Pointer
+        - Name: data
+          Offset: 8
+          Type: 38 VoidPointerType unsafe.Pointer
+    - __kind: StructureType
+      ID: 48
+      Name: internal/sync.Mutex
+      ByteSize: 8
+      GoRuntimeType: 1.459296e+06
+      GoKind: 25
+      RawFields:
+        - Name: state
+          Offset: 0
+          Type: 6 BaseType int32
+        - Name: sema
+          Offset: 4
+          Type: 24 BaseType uint32
+    - __kind: GoInterfaceType
+      ID: 37
+      Name: io.Writer
+      ByteSize: 16
+      GoRuntimeType: 1.016032e+06
+      GoKind: 20
+      RawFields:
+        - Name: tab
+          Offset: 0
+          Type: 38 VoidPointerType unsafe.Pointer
+        - Name: data
+          Offset: 8
+          Type: 38 VoidPointerType unsafe.Pointer
+    - __kind: StructureType
+      ID: 223
+      Name: main.aStruct
+      ByteSize: 56
+      GoKind: 25
+      RawFields:
+        - Name: aBool
+          Offset: 0
+          Type: 11 BaseType bool
+        - Name: aString
+          Offset: 8
+          Type: 8 GoStringHeaderType string
+        - Name: aNumber
+          Offset: 24
+          Type: 1 BaseType int
+        - Name: nested
+          Offset: 32
+          Type: 82 StructureType main.nestedStruct
+    - __kind: GoInterfaceType
+      ID: 56
+      Name: main.behavior
+      ByteSize: 16
+      GoRuntimeType: 1.015648e+06
+      GoKind: 20
+      RawFields:
+        - Name: tab
+          Offset: 0
+          Type: 38 VoidPointerType unsafe.Pointer
+        - Name: data
+          Offset: 8
+          Type: 38 VoidPointerType unsafe.Pointer
+    - __kind: StructureType
+      ID: 33
+      Name: main.bigStruct
+      ByteSize: 48
+      GoKind: 25
+      RawFields:
+        - Name: x
+          Offset: 0
+          Type: 34 GoSliceHeaderType []*string
+        - Name: z
+          Offset: 24
+          Type: 1 BaseType int
+        - Name: writer
+          Offset: 32
+          Type: 37 GoInterfaceType io.Writer
+    - __kind: StructureType
+      ID: 224
+      Name: main.emptyStruct
+      GoKind: 25
+      RawFields: []
+    - __kind: StructureType
+      ID: 45
+      Name: main.esotericHeap
+      ByteSize: 112
+      GoRuntimeType: 1.820416e+06
+      GoKind: 25
+      RawFields:
+        - Name: esotericStack
+          Offset: 0
+          Type: 39 StructureType main.esotericStack
+        - Name: mu
+          Offset: 64
+          Type: 46 StructureType sync.Mutex
+        - Name: once
+          Offset: 72
+          Type: 49 StructureType sync.Once
+        - Name: wg
+          Offset: 88
+          Type: 52 StructureType sync.WaitGroup
+        - Name: a
+          Offset: 104
+          Type: 55 StructureType sync/atomic.Int32
+    - __kind: StructureType
+      ID: 39
+      Name: main.esotericStack
+      ByteSize: 64
+      GoRuntimeType: 1.953504e+06
+      GoKind: 25
+      RawFields:
+        - Name: _
+          Offset: 0
+          Type: 6 BaseType int32
+        - Name: _valid
+          Offset: 4
+          Type: 6 BaseType int32
+        - Name: c
+          Offset: 8
+          Type: 40 GoChannelType chan struct {}
+        - Name: val
+          Offset: 16
+          Type: 41 GoEmptyInterfaceType interface {}
+        - Name: _
+          Offset: 32
+          Type: 26 BaseType uint64
+        - Name: work
+          Offset: 40
+          Type: 42 GoInterfaceType main.something
+        - Name: foo
+          Offset: 56
+          Type: 43 GoSubroutineType func()
+    - __kind: StructureType
+      ID: 82
+      Name: main.nestedStruct
+      ByteSize: 24
+      GoRuntimeType: 1.447936e+06
+      GoKind: 25
+      RawFields:
+        - Name: anotherInt
+          Offset: 0
+          Type: 1 BaseType int
+        - Name: anotherString
+          Offset: 8
+          Type: 8 GoStringHeaderType string
+    - __kind: StructureType
+      ID: 144
+      Name: main.node
+      ByteSize: 16
+      GoRuntimeType: 1.447776e+06
+      GoKind: 25
+      RawFields:
+        - Name: val
+          Offset: 0
+          Type: 1 BaseType int
+        - Name: b
+          Offset: 8
+          Type: 145 PointerType *main.node
+    - __kind: StructureType
+      ID: 222
+      Name: main.oneStringStruct
+      ByteSize: 16
+      GoKind: 25
+      RawFields:
+        - Name: a
+          Offset: 0
+          Type: 8 GoStringHeaderType string
+    - __kind: GoInterfaceType
+      ID: 42
+      Name: main.something
+      ByteSize: 16
+      GoRuntimeType: 1.015776e+06
+      GoKind: 20
+      RawFields:
+        - Name: tab
+          Offset: 0
+          Type: 38 VoidPointerType unsafe.Pointer
+        - Name: data
+          Offset: 8
+          Type: 38 VoidPointerType unsafe.Pointer
+    - __kind: StructureType
+      ID: 58
+      Name: main.structWithMap
+      ByteSize: 8
+      GoRuntimeType: 1.1768e+06
+      GoKind: 25
+      RawFields:
+        - Name: m
+          Offset: 0
+          Type: 59 GoMapType map[int]int
+    - __kind: StructureType
+      ID: 215
+      Name: main.structWithNoStrings
+      ByteSize: 2
+      GoKind: 25
+      RawFields:
+        - Name: aUint8
+          Offset: 0
+          Type: 4 BaseType uint8
+        - Name: aBool
+          Offset: 1
+          Type: 11 BaseType bool
+    - __kind: StructureType
+      ID: 204
+      Name: main.structWithTwoValues
+      ByteSize: 16
+      GoKind: 25
+      RawFields:
+        - Name: a
+          Offset: 0
+          Type: 20 BaseType uint
+        - Name: b
+          Offset: 8
+          Type: 11 BaseType bool
+    - __kind: GoSliceHeaderType
+      ID: 208
+      Name: main.t
+      ByteSize: 24
+      GoKind: 23
+      RawFields:
+        - Name: array
+          Offset: 0
+          Type: 209 PointerType **main.t
+        - Name: len
+          Offset: 8
+          Type: 1 BaseType int
+        - Name: cap
+          Offset: 16
+          Type: 1 BaseType int
+      Data: 270 GoSliceDataType main.t.array
+    - __kind: GoSliceDataType
+      ID: 270
+      Name: main.t.array
+      ByteSize: 2048
+      Element: 207 PointerType *main.t
+    - __kind: StructureType
+      ID: 219
+      Name: main.threeStringStruct
+      ByteSize: 48
+      GoKind: 25
+      RawFields:
+        - Name: a
+          Offset: 0
+          Type: 8 GoStringHeaderType string
+        - Name: b
+          Offset: 16
+          Type: 8 GoStringHeaderType string
+        - Name: c
+          Offset: 32
+          Type: 8 GoStringHeaderType string
+    - __kind: BaseType
+      ID: 32
+      Name: main.typeAlias
+      ByteSize: 2
+      GoKind: 9
+    - __kind: GoSwissMapHeaderType
+      ID: 193
+      Name: map<[4]int,[4]int>
+      ByteSize: 48
+      GoKind: 25
+      RawFields:
+        - Name: used
+          Offset: 0
+          Type: 26 BaseType uint64
+        - Name: seed
+          Offset: 8
+          Type: 62 BaseType uintptr
+        - Name: dirPtr
+          Offset: 16
+          Type: 194 PointerType **table<[4]int,[4]int>
+        - Name: dirLen
+          Offset: 24
+          Type: 1 BaseType int
+        - Name: globalDepth
+          Offset: 32
+          Type: 4 BaseType uint8
+        - Name: globalShift
+          Offset: 33
+          Type: 4 BaseType uint8
+        - Name: writing
+          Offset: 34
+          Type: 4 BaseType uint8
+        - Name: tombstonePossible
+          Offset: 35
+          Type: 11 BaseType bool
+        - Name: clearSeq
+          Offset: 40
+          Type: 26 BaseType uint64
+      TablePtrSliceType: 268 GoSliceDataType []*table<[4]int,[4]int>.array
+      GroupType: 199 StructureType noalg.map.group[[4]int][4]int
+    - __kind: GoSwissMapHeaderType
+      ID: 182
+      Name: map<[4]int,uint8>
+      ByteSize: 48
+      GoKind: 25
+      RawFields:
+        - Name: used
+          Offset: 0
+          Type: 26 BaseType uint64
+        - Name: seed
+          Offset: 8
+          Type: 62 BaseType uintptr
+        - Name: dirPtr
+          Offset: 16
+          Type: 183 PointerType **table<[4]int,uint8>
+        - Name: dirLen
+          Offset: 24
+          Type: 1 BaseType int
+        - Name: globalDepth
+          Offset: 32
+          Type: 4 BaseType uint8
+        - Name: globalShift
+          Offset: 33
+          Type: 4 BaseType uint8
+        - Name: writing
+          Offset: 34
+          Type: 4 BaseType uint8
+        - Name: tombstonePossible
+          Offset: 35
+          Type: 11 BaseType bool
+        - Name: clearSeq
+          Offset: 40
+          Type: 26 BaseType uint64
+      TablePtrSliceType: 266 GoSliceDataType []*table<[4]int,uint8>.array
+      GroupType: 188 StructureType noalg.map.group[[4]int]uint8
+    - __kind: GoSwissMapHeaderType
+      ID: 108
+      Name: map<[4]string,[2]int>
+      ByteSize: 48
+      GoKind: 25
+      RawFields:
+        - Name: used
+          Offset: 0
+          Type: 26 BaseType uint64
+        - Name: seed
+          Offset: 8
+          Type: 62 BaseType uintptr
+        - Name: dirPtr
+          Offset: 16
+          Type: 109 PointerType **table<[4]string,[2]int>
+        - Name: dirLen
+          Offset: 24
+          Type: 1 BaseType int
+        - Name: globalDepth
+          Offset: 32
+          Type: 4 BaseType uint8
+        - Name: globalShift
+          Offset: 33
+          Type: 4 BaseType uint8
+        - Name: writing
+          Offset: 34
+          Type: 4 BaseType uint8
+        - Name: tombstonePossible
+          Offset: 35
+          Type: 11 BaseType bool
+        - Name: clearSeq
+          Offset: 40
+          Type: 26 BaseType uint64
+      TablePtrSliceType: 252 GoSliceDataType []*table<[4]string,[2]int>.array
+      GroupType: 114 StructureType noalg.map.group[[4]string][2]int
+    - __kind: GoSwissMapHeaderType
+      ID: 135
+      Name: map<bool,main.node>
+      ByteSize: 48
+      GoKind: 25
+      RawFields:
+        - Name: used
+          Offset: 0
+          Type: 26 BaseType uint64
+        - Name: seed
+          Offset: 8
+          Type: 62 BaseType uintptr
+        - Name: dirPtr
+          Offset: 16
+          Type: 136 PointerType **table<bool,main.node>
+        - Name: dirLen
+          Offset: 24
+          Type: 1 BaseType int
+        - Name: globalDepth
+          Offset: 32
+          Type: 4 BaseType uint8
+        - Name: globalShift
+          Offset: 33
+          Type: 4 BaseType uint8
+        - Name: writing
+          Offset: 34
+          Type: 4 BaseType uint8
+        - Name: tombstonePossible
+          Offset: 35
+          Type: 11 BaseType bool
+        - Name: clearSeq
+          Offset: 40
+          Type: 26 BaseType uint64
+      TablePtrSliceType: 258 GoSliceDataType []*table<bool,main.node>.array
+      GroupType: 141 StructureType noalg.map.group[bool]main.node
+    - __kind: GoSwissMapHeaderType
+      ID: 61
+      Name: map<int,int>
+      ByteSize: 48
+      GoKind: 25
+      RawFields:
+        - Name: used
+          Offset: 0
+          Type: 26 BaseType uint64
+        - Name: seed
+          Offset: 8
+          Type: 62 BaseType uintptr
+        - Name: dirPtr
+          Offset: 16
+          Type: 63 PointerType **table<int,int>
+        - Name: dirLen
+          Offset: 24
+          Type: 1 BaseType int
+        - Name: globalDepth
+          Offset: 32
+          Type: 4 BaseType uint8
+        - Name: globalShift
+          Offset: 33
+          Type: 4 BaseType uint8
+        - Name: writing
+          Offset: 34
+          Type: 4 BaseType uint8
+        - Name: tombstonePossible
+          Offset: 35
+          Type: 11 BaseType bool
+        - Name: clearSeq
+          Offset: 40
+          Type: 26 BaseType uint64
+      TablePtrSliceType: 242 GoSliceDataType []*table<int,int>.array
+      GroupType: 68 StructureType noalg.map.group[int]int
+    - __kind: GoSwissMapHeaderType
+      ID: 148
+      Name: map<int,uint8>
+      ByteSize: 48
+      GoKind: 25
+      RawFields:
+        - Name: used
+          Offset: 0
+          Type: 26 BaseType uint64
+        - Name: seed
+          Offset: 8
+          Type: 62 BaseType uintptr
+        - Name: dirPtr
+          Offset: 16
+          Type: 149 PointerType **table<int,uint8>
+        - Name: dirLen
+          Offset: 24
+          Type: 1 BaseType int
+        - Name: globalDepth
+          Offset: 32
+          Type: 4 BaseType uint8
+        - Name: globalShift
+          Offset: 33
+          Type: 4 BaseType uint8
+        - Name: writing
+          Offset: 34
+          Type: 4 BaseType uint8
+        - Name: tombstonePossible
+          Offset: 35
+          Type: 11 BaseType bool
+        - Name: clearSeq
+          Offset: 40
+          Type: 26 BaseType uint64
+      TablePtrSliceType: 260 GoSliceDataType []*table<int,uint8>.array
+      GroupType: 154 StructureType noalg.map.group[int]uint8
+    - __kind: GoSwissMapHeaderType
+      ID: 122
+      Name: map<string,[]main.structWithMap>
+      ByteSize: 48
+      GoKind: 25
+      RawFields:
+        - Name: used
+          Offset: 0
+          Type: 26 BaseType uint64
+        - Name: seed
+          Offset: 8
+          Type: 62 BaseType uintptr
+        - Name: dirPtr
+          Offset: 16
+          Type: 123 PointerType **table<string,[]main.structWithMap>
+        - Name: dirLen
+          Offset: 24
+          Type: 1 BaseType int
+        - Name: globalDepth
+          Offset: 32
+          Type: 4 BaseType uint8
+        - Name: globalShift
+          Offset: 33
+          Type: 4 BaseType uint8
+        - Name: writing
+          Offset: 34
+          Type: 4 BaseType uint8
+        - Name: tombstonePossible
+          Offset: 35
+          Type: 11 BaseType bool
+        - Name: clearSeq
+          Offset: 40
+          Type: 26 BaseType uint64
+      TablePtrSliceType: 254 GoSliceDataType []*table<string,[]main.structWithMap>.array
+      GroupType: 128 StructureType noalg.map.group[string][]main.structWithMap
+    - __kind: GoSwissMapHeaderType
+      ID: 96
+      Name: map<string,[]string>
+      ByteSize: 48
+      GoKind: 25
+      RawFields:
+        - Name: used
+          Offset: 0
+          Type: 26 BaseType uint64
+        - Name: seed
+          Offset: 8
+          Type: 62 BaseType uintptr
+        - Name: dirPtr
+          Offset: 16
+          Type: 97 PointerType **table<string,[]string>
+        - Name: dirLen
+          Offset: 24
+          Type: 1 BaseType int
+        - Name: globalDepth
+          Offset: 32
+          Type: 4 BaseType uint8
+        - Name: globalShift
+          Offset: 33
+          Type: 4 BaseType uint8
+        - Name: writing
+          Offset: 34
+          Type: 4 BaseType uint8
+        - Name: tombstonePossible
+          Offset: 35
+          Type: 11 BaseType bool
+        - Name: clearSeq
+          Offset: 40
+          Type: 26 BaseType uint64
+      TablePtrSliceType: 248 GoSliceDataType []*table<string,[]string>.array
+      GroupType: 102 StructureType noalg.map.group[string][]string
+    - __kind: GoSwissMapHeaderType
+      ID: 85
+      Name: map<string,int>
+      ByteSize: 48
+      GoKind: 25
+      RawFields:
+        - Name: used
+          Offset: 0
+          Type: 26 BaseType uint64
+        - Name: seed
+          Offset: 8
+          Type: 62 BaseType uintptr
+        - Name: dirPtr
+          Offset: 16
+          Type: 86 PointerType **table<string,int>
+        - Name: dirLen
+          Offset: 24
+          Type: 1 BaseType int
+        - Name: globalDepth
+          Offset: 32
+          Type: 4 BaseType uint8
+        - Name: globalShift
+          Offset: 33
+          Type: 4 BaseType uint8
+        - Name: writing
+          Offset: 34
+          Type: 4 BaseType uint8
+        - Name: tombstonePossible
+          Offset: 35
+          Type: 11 BaseType bool
+        - Name: clearSeq
+          Offset: 40
+          Type: 26 BaseType uint64
+      TablePtrSliceType: 246 GoSliceDataType []*table<string,int>.array
+      GroupType: 91 StructureType noalg.map.group[string]int
+    - __kind: GoSwissMapHeaderType
+      ID: 73
+      Name: map<string,main.nestedStruct>
+      ByteSize: 48
+      GoKind: 25
+      RawFields:
+        - Name: used
+          Offset: 0
+          Type: 26 BaseType uint64
+        - Name: seed
+          Offset: 8
+          Type: 62 BaseType uintptr
+        - Name: dirPtr
+          Offset: 16
+          Type: 74 PointerType **table<string,main.nestedStruct>
+        - Name: dirLen
+          Offset: 24
+          Type: 1 BaseType int
+        - Name: globalDepth
+          Offset: 32
+          Type: 4 BaseType uint8
+        - Name: globalShift
+          Offset: 33
+          Type: 4 BaseType uint8
+        - Name: writing
+          Offset: 34
+          Type: 4 BaseType uint8
+        - Name: tombstonePossible
+          Offset: 35
+          Type: 11 BaseType bool
+        - Name: clearSeq
+          Offset: 40
+          Type: 26 BaseType uint64
+      TablePtrSliceType: 244 GoSliceDataType []*table<string,main.nestedStruct>.array
+      GroupType: 79 StructureType noalg.map.group[string]main.nestedStruct
+    - __kind: GoSwissMapHeaderType
+      ID: 170
+      Name: map<uint8,[4]int>
+      ByteSize: 48
+      GoKind: 25
+      RawFields:
+        - Name: used
+          Offset: 0
+          Type: 26 BaseType uint64
+        - Name: seed
+          Offset: 8
+          Type: 62 BaseType uintptr
+        - Name: dirPtr
+          Offset: 16
+          Type: 171 PointerType **table<uint8,[4]int>
+        - Name: dirLen
+          Offset: 24
+          Type: 1 BaseType int
+        - Name: globalDepth
+          Offset: 32
+          Type: 4 BaseType uint8
+        - Name: globalShift
+          Offset: 33
+          Type: 4 BaseType uint8
+        - Name: writing
+          Offset: 34
+          Type: 4 BaseType uint8
+        - Name: tombstonePossible
+          Offset: 35
+          Type: 11 BaseType bool
+        - Name: clearSeq
+          Offset: 40
+          Type: 26 BaseType uint64
+      TablePtrSliceType: 264 GoSliceDataType []*table<uint8,[4]int>.array
+      GroupType: 176 StructureType noalg.map.group[uint8][4]int
+    - __kind: GoSwissMapHeaderType
+      ID: 159
+      Name: map<uint8,uint8>
+      ByteSize: 48
+      GoKind: 25
+      RawFields:
+        - Name: used
+          Offset: 0
+          Type: 26 BaseType uint64
+        - Name: seed
+          Offset: 8
+          Type: 62 BaseType uintptr
+        - Name: dirPtr
+          Offset: 16
+          Type: 160 PointerType **table<uint8,uint8>
+        - Name: dirLen
+          Offset: 24
+          Type: 1 BaseType int
+        - Name: globalDepth
+          Offset: 32
+          Type: 4 BaseType uint8
+        - Name: globalShift
+          Offset: 33
+          Type: 4 BaseType uint8
+        - Name: writing
+          Offset: 34
+          Type: 4 BaseType uint8
+        - Name: tombstonePossible
+          Offset: 35
+          Type: 11 BaseType bool
+        - Name: clearSeq
+          Offset: 40
+          Type: 26 BaseType uint64
+      TablePtrSliceType: 262 GoSliceDataType []*table<uint8,uint8>.array
+      GroupType: 165 StructureType noalg.map.group[uint8]uint8
+    - __kind: GoMapType
+      ID: 191
+      Name: map[[4]int][4]int
+      ByteSize: 8
+      GoRuntimeType: 1.121696e+06
+      GoKind: 21
+      HeaderType: 193 GoSwissMapHeaderType map<[4]int,[4]int>
+    - __kind: GoMapType
+      ID: 180
+      Name: map[[4]int]uint8
+      ByteSize: 8
+      GoRuntimeType: 1.121824e+06
+      GoKind: 21
+      HeaderType: 182 GoSwissMapHeaderType map<[4]int,uint8>
+    - __kind: GoMapType
+      ID: 106
+      Name: map[[4]string][2]int
+      ByteSize: 8
+      GoRuntimeType: 1.121952e+06
+      GoKind: 21
+      HeaderType: 108 GoSwissMapHeaderType map<[4]string,[2]int>
+    - __kind: GoMapType
+      ID: 133
+      Name: map[bool]main.node
+      ByteSize: 8
+      GoRuntimeType: 1.12208e+06
+      GoKind: 21
+      HeaderType: 135 GoSwissMapHeaderType map<bool,main.node>
+    - __kind: GoMapType
+      ID: 59
+      Name: map[int]int
+      ByteSize: 8
+      GoRuntimeType: 1.121312e+06
+      GoKind: 21
+      HeaderType: 61 GoSwissMapHeaderType map<int,int>
+    - __kind: GoMapType
+      ID: 146
+      Name: map[int]uint8
+      ByteSize: 8
+      GoRuntimeType: 1.122208e+06
+      GoKind: 21
+      HeaderType: 148 GoSwissMapHeaderType map<int,uint8>
+    - __kind: GoMapType
+      ID: 120
+      Name: map[string][]main.structWithMap
+      ByteSize: 8
+      GoRuntimeType: 1.122336e+06
+      GoKind: 21
+      HeaderType: 122 GoSwissMapHeaderType map<string,[]main.structWithMap>
+    - __kind: GoMapType
+      ID: 94
+      Name: map[string][]string
+      ByteSize: 8
+      GoRuntimeType: 1.122464e+06
+      GoKind: 21
+      HeaderType: 96 GoSwissMapHeaderType map<string,[]string>
+    - __kind: GoMapType
+      ID: 83
+      Name: map[string]int
+      ByteSize: 8
+      GoRuntimeType: 1.122592e+06
+      GoKind: 21
+      HeaderType: 85 GoSwissMapHeaderType map<string,int>
+    - __kind: GoMapType
+      ID: 71
+      Name: map[string]main.nestedStruct
+      ByteSize: 8
+      GoRuntimeType: 1.12272e+06
+      GoKind: 21
+      HeaderType: 73 GoSwissMapHeaderType map<string,main.nestedStruct>
+    - __kind: GoMapType
+      ID: 168
+      Name: map[uint8][4]int
+      ByteSize: 8
+      GoRuntimeType: 1.122848e+06
+      GoKind: 21
+      HeaderType: 170 GoSwissMapHeaderType map<uint8,[4]int>
+    - __kind: GoMapType
+      ID: 157
+      Name: map[uint8]uint8
+      ByteSize: 8
+      GoRuntimeType: 1.122976e+06
+      GoKind: 21
+      HeaderType: 159 GoSwissMapHeaderType map<uint8,uint8>
+    - __kind: ArrayType
+      ID: 200
+      Name: noalg.[8]struct { key [4]int; elem [4]int }
+      ByteSize: 512
+      GoRuntimeType: 676512
+      GoKind: 17
+      Count: 8
+      HasCount: true
+      Element: 201 StructureType noalg.struct { key [4]int; elem [4]int }
+    - __kind: ArrayType
+      ID: 189
+      Name: noalg.[8]struct { key [4]int; elem uint8 }
+      ByteSize: 320
+      GoRuntimeType: 676608
+      GoKind: 17
+      Count: 8
+      HasCount: true
+      Element: 190 StructureType noalg.struct { key [4]int; elem uint8 }
+    - __kind: ArrayType
+      ID: 115
+      Name: noalg.[8]struct { key [4]string; elem [2]int }
+      ByteSize: 640
+      GoRuntimeType: 676896
+      GoKind: 17
+      Count: 8
+      HasCount: true
+      Element: 116 StructureType noalg.struct { key [4]string; elem [2]int }
+    - __kind: ArrayType
+      ID: 142
+      Name: noalg.[8]struct { key bool; elem main.node }
+      ByteSize: 192
+      GoRuntimeType: 676992
+      GoKind: 17
+      Count: 8
+      HasCount: true
+      Element: 143 StructureType noalg.struct { key bool; elem main.node }
+    - __kind: ArrayType
+      ID: 69
+      Name: noalg.[8]struct { key int; elem int }
+      ByteSize: 128
+      GoRuntimeType: 674784
+      GoKind: 17
+      Count: 8
+      HasCount: true
+      Element: 70 StructureType noalg.struct { key int; elem int }
+    - __kind: ArrayType
+      ID: 155
+      Name: noalg.[8]struct { key int; elem uint8 }
+      ByteSize: 128
+      GoRuntimeType: 677088
+      GoKind: 17
+      Count: 8
+      HasCount: true
+      Element: 156 StructureType noalg.struct { key int; elem uint8 }
+    - __kind: ArrayType
+      ID: 129
+      Name: noalg.[8]struct { key string; elem []main.structWithMap }
+      ByteSize: 320
+      GoRuntimeType: 677184
+      GoKind: 17
+      Count: 8
+      HasCount: true
+      Element: 130 StructureType noalg.struct { key string; elem []main.structWithMap }
+    - __kind: ArrayType
+      ID: 103
+      Name: noalg.[8]struct { key string; elem []string }
+      ByteSize: 320
+      GoRuntimeType: 677280
+      GoKind: 17
+      Count: 8
+      HasCount: true
+      Element: 104 StructureType noalg.struct { key string; elem []string }
+    - __kind: ArrayType
+      ID: 92
+      Name: noalg.[8]struct { key string; elem int }
+      ByteSize: 192
+      GoRuntimeType: 677376
+      GoKind: 17
+      Count: 8
+      HasCount: true
+      Element: 93 StructureType noalg.struct { key string; elem int }
+    - __kind: ArrayType
+      ID: 80
+      Name: noalg.[8]struct { key string; elem main.nestedStruct }
+      ByteSize: 320
+      GoRuntimeType: 677472
+      GoKind: 17
+      Count: 8
+      HasCount: true
+      Element: 81 StructureType noalg.struct { key string; elem main.nestedStruct }
+    - __kind: ArrayType
+      ID: 177
+      Name: noalg.[8]struct { key uint8; elem [4]int }
+      ByteSize: 320
+      GoRuntimeType: 677568
+      GoKind: 17
+      Count: 8
+      HasCount: true
+      Element: 178 StructureType noalg.struct { key uint8; elem [4]int }
+    - __kind: ArrayType
+      ID: 166
+      Name: noalg.[8]struct { key uint8; elem uint8 }
+      ByteSize: 16
+      GoRuntimeType: 677664
+      GoKind: 17
+      Count: 8
+      HasCount: true
+      Element: 167 StructureType noalg.struct { key uint8; elem uint8 }
+    - __kind: StructureType
+      ID: 199
+      Name: noalg.map.group[[4]int][4]int
+      ByteSize: 520
+      GoRuntimeType: 1.281056e+06
+      GoKind: 25
+      RawFields:
+        - Name: ctrl
+          Offset: 0
+          Type: 26 BaseType uint64
+        - Name: slots
+          Offset: 8
+          Type: 200 ArrayType noalg.[8]struct { key [4]int; elem [4]int }
+    - __kind: StructureType
+      ID: 188
+      Name: noalg.map.group[[4]int]uint8
+      ByteSize: 328
+      GoRuntimeType: 1.281312e+06
+      GoKind: 25
+      RawFields:
+        - Name: ctrl
+          Offset: 0
+          Type: 26 BaseType uint64
+        - Name: slots
+          Offset: 8
+          Type: 189 ArrayType noalg.[8]struct { key [4]int; elem uint8 }
+    - __kind: StructureType
+      ID: 114
+      Name: noalg.map.group[[4]string][2]int
+      ByteSize: 648
+      GoRuntimeType: 1.281568e+06
+      GoKind: 25
+      RawFields:
+        - Name: ctrl
+          Offset: 0
+          Type: 26 BaseType uint64
+        - Name: slots
+          Offset: 8
+          Type: 115 ArrayType noalg.[8]struct { key [4]string; elem [2]int }
+    - __kind: StructureType
+      ID: 141
+      Name: noalg.map.group[bool]main.node
+      ByteSize: 200
+      GoRuntimeType: 1.281824e+06
+      GoKind: 25
+      RawFields:
+        - Name: ctrl
+          Offset: 0
+          Type: 26 BaseType uint64
+        - Name: slots
+          Offset: 8
+          Type: 142 ArrayType noalg.[8]struct { key bool; elem main.node }
+    - __kind: StructureType
+      ID: 68
+      Name: noalg.map.group[int]int
+      ByteSize: 136
+      GoRuntimeType: 1.280288e+06
+      GoKind: 25
+      RawFields:
+        - Name: ctrl
+          Offset: 0
+          Type: 26 BaseType uint64
+        - Name: slots
+          Offset: 8
+          Type: 69 ArrayType noalg.[8]struct { key int; elem int }
+    - __kind: StructureType
+      ID: 154
+      Name: noalg.map.group[int]uint8
+      ByteSize: 136
+      GoRuntimeType: 1.28208e+06
+      GoKind: 25
+      RawFields:
+        - Name: ctrl
+          Offset: 0
+          Type: 26 BaseType uint64
+        - Name: slots
+          Offset: 8
+          Type: 155 ArrayType noalg.[8]struct { key int; elem uint8 }
+    - __kind: StructureType
+      ID: 128
+      Name: noalg.map.group[string][]main.structWithMap
+      ByteSize: 328
+      GoRuntimeType: 1.282336e+06
+      GoKind: 25
+      RawFields:
+        - Name: ctrl
+          Offset: 0
+          Type: 26 BaseType uint64
+        - Name: slots
+          Offset: 8
+          Type: 129 ArrayType noalg.[8]struct { key string; elem []main.structWithMap }
+    - __kind: StructureType
+      ID: 102
+      Name: noalg.map.group[string][]string
+      ByteSize: 328
+      GoRuntimeType: 1.282592e+06
+      GoKind: 25
+      RawFields:
+        - Name: ctrl
+          Offset: 0
+          Type: 26 BaseType uint64
+        - Name: slots
+          Offset: 8
+          Type: 103 ArrayType noalg.[8]struct { key string; elem []string }
+    - __kind: StructureType
+      ID: 91
+      Name: noalg.map.group[string]int
+      ByteSize: 200
+      GoRuntimeType: 1.282848e+06
+      GoKind: 25
+      RawFields:
+        - Name: ctrl
+          Offset: 0
+          Type: 26 BaseType uint64
+        - Name: slots
+          Offset: 8
+          Type: 92 ArrayType noalg.[8]struct { key string; elem int }
+    - __kind: StructureType
+      ID: 79
+      Name: noalg.map.group[string]main.nestedStruct
+      ByteSize: 328
+      GoRuntimeType: 1.283104e+06
+      GoKind: 25
+      RawFields:
+        - Name: ctrl
+          Offset: 0
+          Type: 26 BaseType uint64
+        - Name: slots
+          Offset: 8
+          Type: 80 ArrayType noalg.[8]struct { key string; elem main.nestedStruct }
+    - __kind: StructureType
+      ID: 176
+      Name: noalg.map.group[uint8][4]int
+      ByteSize: 328
+      GoRuntimeType: 1.28336e+06
+      GoKind: 25
+      RawFields:
+        - Name: ctrl
+          Offset: 0
+          Type: 26 BaseType uint64
+        - Name: slots
+          Offset: 8
+          Type: 177 ArrayType noalg.[8]struct { key uint8; elem [4]int }
+    - __kind: StructureType
+      ID: 165
+      Name: noalg.map.group[uint8]uint8
+      ByteSize: 24
+      GoRuntimeType: 1.283616e+06
+      GoKind: 25
+      RawFields:
+        - Name: ctrl
+          Offset: 0
+          Type: 26 BaseType uint64
+        - Name: slots
+          Offset: 8
+          Type: 166 ArrayType noalg.[8]struct { key uint8; elem uint8 }
+    - __kind: StructureType
+      ID: 201
+      Name: noalg.struct { key [4]int; elem [4]int }
+      ByteSize: 64
+      GoRuntimeType: 1.280928e+06
+      GoKind: 25
+      RawFields:
+        - Name: key
+          Offset: 0
+          Type: 179 ArrayType [4]int
+        - Name: elem
+          Offset: 32
+          Type: 179 ArrayType [4]int
+    - __kind: StructureType
+      ID: 190
+      Name: noalg.struct { key [4]int; elem uint8 }
+      ByteSize: 40
+      GoRuntimeType: 1.281184e+06
+      GoKind: 25
+      RawFields:
+        - Name: key
+          Offset: 0
+          Type: 179 ArrayType [4]int
+        - Name: elem
+          Offset: 32
+          Type: 4 BaseType uint8
+    - __kind: StructureType
+      ID: 116
+      Name: noalg.struct { key [4]string; elem [2]int }
+      ByteSize: 80
+      GoRuntimeType: 1.28144e+06
+      GoKind: 25
+      RawFields:
+        - Name: key
+          Offset: 0
+          Type: 117 ArrayType [4]string
+        - Name: elem
+          Offset: 64
+          Type: 12 ArrayType [2]int
+    - __kind: StructureType
+      ID: 143
+      Name: noalg.struct { key bool; elem main.node }
+      ByteSize: 24
+      GoRuntimeType: 1.281696e+06
+      GoKind: 25
+      RawFields:
+        - Name: key
+          Offset: 0
+          Type: 11 BaseType bool
+        - Name: elem
+          Offset: 8
+          Type: 144 StructureType main.node
+    - __kind: StructureType
+      ID: 70
+      Name: noalg.struct { key int; elem int }
+      ByteSize: 16
+      GoRuntimeType: 1.28016e+06
+      GoKind: 25
+      RawFields:
+        - Name: key
+          Offset: 0
+          Type: 1 BaseType int
+        - Name: elem
+          Offset: 8
+          Type: 1 BaseType int
+    - __kind: StructureType
+      ID: 156
+      Name: noalg.struct { key int; elem uint8 }
+      ByteSize: 16
+      GoRuntimeType: 1.281952e+06
+      GoKind: 25
+      RawFields:
+        - Name: key
+          Offset: 0
+          Type: 1 BaseType int
+        - Name: elem
+          Offset: 8
+          Type: 4 BaseType uint8
+    - __kind: StructureType
+      ID: 130
+      Name: noalg.struct { key string; elem []main.structWithMap }
+      ByteSize: 40
+      GoRuntimeType: 1.282208e+06
+      GoKind: 25
+      RawFields:
+        - Name: key
+          Offset: 0
+          Type: 8 GoStringHeaderType string
+        - Name: elem
+          Offset: 16
+          Type: 131 GoSliceHeaderType []main.structWithMap
+    - __kind: StructureType
+      ID: 104
+      Name: noalg.struct { key string; elem []string }
+      ByteSize: 40
+      GoRuntimeType: 1.282464e+06
+      GoKind: 25
+      RawFields:
+        - Name: key
+          Offset: 0
+          Type: 8 GoStringHeaderType string
+        - Name: elem
+          Offset: 16
+          Type: 105 GoSliceHeaderType []string
+    - __kind: StructureType
+      ID: 93
+      Name: noalg.struct { key string; elem int }
+      ByteSize: 24
+      GoRuntimeType: 1.28272e+06
+      GoKind: 25
+      RawFields:
+        - Name: key
+          Offset: 0
+          Type: 8 GoStringHeaderType string
+        - Name: elem
+          Offset: 16
+          Type: 1 BaseType int
+    - __kind: StructureType
+      ID: 81
+      Name: noalg.struct { key string; elem main.nestedStruct }
+      ByteSize: 40
+      GoRuntimeType: 1.282976e+06
+      GoKind: 25
+      RawFields:
+        - Name: key
+          Offset: 0
+          Type: 8 GoStringHeaderType string
+        - Name: elem
+          Offset: 16
+          Type: 82 StructureType main.nestedStruct
+    - __kind: StructureType
+      ID: 178
+      Name: noalg.struct { key uint8; elem [4]int }
+      ByteSize: 40
+      GoRuntimeType: 1.283232e+06
+      GoKind: 25
+      RawFields:
+        - Name: key
+          Offset: 0
+          Type: 4 BaseType uint8
+        - Name: elem
+          Offset: 8
+          Type: 179 ArrayType [4]int
+    - __kind: StructureType
+      ID: 167
+      Name: noalg.struct { key uint8; elem uint8 }
+      ByteSize: 2
+      GoRuntimeType: 1.283488e+06
+      GoKind: 25
+      RawFields:
+        - Name: key
+          Offset: 0
+          Type: 4 BaseType uint8
+        - Name: elem
+          Offset: 1
+          Type: 4 BaseType uint8
+    - __kind: GoStringHeaderType
+      ID: 8
+      Name: string
+      ByteSize: 16
+      GoRuntimeType: 578560
+      GoKind: 24
+      RawFields:
+        - Name: str
+          Offset: 0
+          Type: 239 PointerType *string.str
+        - Name: len
+          Offset: 8
+          Type: 1 BaseType int
+      Data: 238 GoStringDataType string.str
+    - __kind: GoStringDataType
+      ID: 238
+      Name: string.str
+      ByteSize: 2048
+    - __kind: StructureType
+      ID: 46
+      Name: sync.Mutex
+      ByteSize: 8
+      GoRuntimeType: 1.449216e+06
+      GoKind: 25
+      RawFields:
+        - Name: _
+          Offset: 0
+          Type: 47 StructureType sync.noCopy
+        - Name: mu
+          Offset: 0
+          Type: 48 StructureType internal/sync.Mutex
+    - __kind: StructureType
+      ID: 49
+      Name: sync.Once
+      ByteSize: 12
+      GoRuntimeType: 1.598272e+06
+      GoKind: 25
+      RawFields:
+        - Name: _
+          Offset: 0
+          Type: 47 StructureType sync.noCopy
+        - Name: done
+          Offset: 0
+          Type: 50 StructureType sync/atomic.Bool
+        - Name: m
+          Offset: 4
+          Type: 46 StructureType sync.Mutex
+    - __kind: StructureType
+      ID: 52
+      Name: sync.WaitGroup
+      ByteSize: 16
+      GoRuntimeType: 1.59808e+06
+      GoKind: 25
+      RawFields:
+        - Name: noCopy
+          Offset: 0
+          Type: 47 StructureType sync.noCopy
+        - Name: state
+          Offset: 0
+          Type: 53 StructureType sync/atomic.Uint64
+        - Name: sema
+          Offset: 8
+          Type: 24 BaseType uint32
+    - __kind: StructureType
+      ID: 47
+      Name: sync.noCopy
+      GoRuntimeType: 981440
+      GoKind: 25
+      RawFields: []
+    - __kind: StructureType
+      ID: 50
+      Name: sync/atomic.Bool
+      ByteSize: 4
+      GoRuntimeType: 1.450336e+06
+      GoKind: 25
+      RawFields:
+        - Name: _
+          Offset: 0
+          Type: 51 StructureType sync/atomic.noCopy
+        - Name: v
+          Offset: 0
+          Type: 24 BaseType uint32
+    - __kind: StructureType
+      ID: 55
+      Name: sync/atomic.Int32
+      ByteSize: 4
+      GoRuntimeType: 1.450496e+06
+      GoKind: 25
+      RawFields:
+        - Name: _
+          Offset: 0
+          Type: 51 StructureType sync/atomic.noCopy
+        - Name: v
+          Offset: 0
+          Type: 6 BaseType int32
+    - __kind: StructureType
+      ID: 53
+      Name: sync/atomic.Uint64
+      ByteSize: 8
+      GoRuntimeType: 1.598656e+06
+      GoKind: 25
+      RawFields:
+        - Name: _
+          Offset: 0
+          Type: 51 StructureType sync/atomic.noCopy
+        - Name: _
+          Offset: 0
+          Type: 54 StructureType sync/atomic.align64
+        - Name: v
+          Offset: 0
+          Type: 26 BaseType uint64
+    - __kind: StructureType
+      ID: 54
+      Name: sync/atomic.align64
+      GoRuntimeType: 981632
+      GoKind: 25
+      RawFields: []
+    - __kind: StructureType
+      ID: 51
+      Name: sync/atomic.noCopy
+      GoRuntimeType: 981536
+      GoKind: 25
+      RawFields: []
+    - __kind: StructureType
+      ID: 196
+      Name: table<[4]int,[4]int>
+      ByteSize: 32
+      GoKind: 25
+      RawFields:
+        - Name: used
+          Offset: 0
+          Type: 22 BaseType uint16
+        - Name: capacity
+          Offset: 2
+          Type: 22 BaseType uint16
+        - Name: growthLeft
+          Offset: 4
+          Type: 22 BaseType uint16
+        - Name: localDepth
+          Offset: 6
+          Type: 4 BaseType uint8
+        - Name: index
+          Offset: 8
+          Type: 1 BaseType int
+        - Name: groups
+          Offset: 16
+          Type: 197 GoSwissMapGroupsType groupReference<[4]int,[4]int>
+    - __kind: StructureType
+      ID: 185
+      Name: table<[4]int,uint8>
+      ByteSize: 32
+      GoKind: 25
+      RawFields:
+        - Name: used
+          Offset: 0
+          Type: 22 BaseType uint16
+        - Name: capacity
+          Offset: 2
+          Type: 22 BaseType uint16
+        - Name: growthLeft
+          Offset: 4
+          Type: 22 BaseType uint16
+        - Name: localDepth
+          Offset: 6
+          Type: 4 BaseType uint8
+        - Name: index
+          Offset: 8
+          Type: 1 BaseType int
+        - Name: groups
+          Offset: 16
+          Type: 186 GoSwissMapGroupsType groupReference<[4]int,uint8>
+    - __kind: StructureType
+      ID: 111
+      Name: table<[4]string,[2]int>
+      ByteSize: 32
+      GoKind: 25
+      RawFields:
+        - Name: used
+          Offset: 0
+          Type: 22 BaseType uint16
+        - Name: capacity
+          Offset: 2
+          Type: 22 BaseType uint16
+        - Name: growthLeft
+          Offset: 4
+          Type: 22 BaseType uint16
+        - Name: localDepth
+          Offset: 6
+          Type: 4 BaseType uint8
+        - Name: index
+          Offset: 8
+          Type: 1 BaseType int
+        - Name: groups
+          Offset: 16
+          Type: 112 GoSwissMapGroupsType groupReference<[4]string,[2]int>
+    - __kind: StructureType
+      ID: 138
+      Name: table<bool,main.node>
+      ByteSize: 32
+      GoKind: 25
+      RawFields:
+        - Name: used
+          Offset: 0
+          Type: 22 BaseType uint16
+        - Name: capacity
+          Offset: 2
+          Type: 22 BaseType uint16
+        - Name: growthLeft
+          Offset: 4
+          Type: 22 BaseType uint16
+        - Name: localDepth
+          Offset: 6
+          Type: 4 BaseType uint8
+        - Name: index
+          Offset: 8
+          Type: 1 BaseType int
+        - Name: groups
+          Offset: 16
+          Type: 139 GoSwissMapGroupsType groupReference<bool,main.node>
+    - __kind: StructureType
+      ID: 65
+      Name: table<int,int>
+      ByteSize: 32
+      GoKind: 25
+      RawFields:
+        - Name: used
+          Offset: 0
+          Type: 22 BaseType uint16
+        - Name: capacity
+          Offset: 2
+          Type: 22 BaseType uint16
+        - Name: growthLeft
+          Offset: 4
+          Type: 22 BaseType uint16
+        - Name: localDepth
+          Offset: 6
+          Type: 4 BaseType uint8
+        - Name: index
+          Offset: 8
+          Type: 1 BaseType int
+        - Name: groups
+          Offset: 16
+          Type: 66 GoSwissMapGroupsType groupReference<int,int>
+    - __kind: StructureType
+      ID: 151
+      Name: table<int,uint8>
+      ByteSize: 32
+      GoKind: 25
+      RawFields:
+        - Name: used
+          Offset: 0
+          Type: 22 BaseType uint16
+        - Name: capacity
+          Offset: 2
+          Type: 22 BaseType uint16
+        - Name: growthLeft
+          Offset: 4
+          Type: 22 BaseType uint16
+        - Name: localDepth
+          Offset: 6
+          Type: 4 BaseType uint8
+        - Name: index
+          Offset: 8
+          Type: 1 BaseType int
+        - Name: groups
+          Offset: 16
+          Type: 152 GoSwissMapGroupsType groupReference<int,uint8>
+    - __kind: StructureType
+      ID: 125
+      Name: table<string,[]main.structWithMap>
+      ByteSize: 32
+      GoKind: 25
+      RawFields:
+        - Name: used
+          Offset: 0
+          Type: 22 BaseType uint16
+        - Name: capacity
+          Offset: 2
+          Type: 22 BaseType uint16
+        - Name: growthLeft
+          Offset: 4
+          Type: 22 BaseType uint16
+        - Name: localDepth
+          Offset: 6
+          Type: 4 BaseType uint8
+        - Name: index
+          Offset: 8
+          Type: 1 BaseType int
+        - Name: groups
+          Offset: 16
+          Type: 126 GoSwissMapGroupsType groupReference<string,[]main.structWithMap>
+    - __kind: StructureType
+      ID: 99
+      Name: table<string,[]string>
+      ByteSize: 32
+      GoKind: 25
+      RawFields:
+        - Name: used
+          Offset: 0
+          Type: 22 BaseType uint16
+        - Name: capacity
+          Offset: 2
+          Type: 22 BaseType uint16
+        - Name: growthLeft
+          Offset: 4
+          Type: 22 BaseType uint16
+        - Name: localDepth
+          Offset: 6
+          Type: 4 BaseType uint8
+        - Name: index
+          Offset: 8
+          Type: 1 BaseType int
+        - Name: groups
+          Offset: 16
+          Type: 100 GoSwissMapGroupsType groupReference<string,[]string>
+    - __kind: StructureType
+      ID: 88
+      Name: table<string,int>
+      ByteSize: 32
+      GoKind: 25
+      RawFields:
+        - Name: used
+          Offset: 0
+          Type: 22 BaseType uint16
+        - Name: capacity
+          Offset: 2
+          Type: 22 BaseType uint16
+        - Name: growthLeft
+          Offset: 4
+          Type: 22 BaseType uint16
+        - Name: localDepth
+          Offset: 6
+          Type: 4 BaseType uint8
+        - Name: index
+          Offset: 8
+          Type: 1 BaseType int
+        - Name: groups
+          Offset: 16
+          Type: 89 GoSwissMapGroupsType groupReference<string,int>
+    - __kind: StructureType
+      ID: 76
+      Name: table<string,main.nestedStruct>
+      ByteSize: 32
+      GoKind: 25
+      RawFields:
+        - Name: used
+          Offset: 0
+          Type: 22 BaseType uint16
+        - Name: capacity
+          Offset: 2
+          Type: 22 BaseType uint16
+        - Name: growthLeft
+          Offset: 4
+          Type: 22 BaseType uint16
+        - Name: localDepth
+          Offset: 6
+          Type: 4 BaseType uint8
+        - Name: index
+          Offset: 8
+          Type: 1 BaseType int
+        - Name: groups
+          Offset: 16
+          Type: 77 GoSwissMapGroupsType groupReference<string,main.nestedStruct>
+    - __kind: StructureType
+      ID: 173
+      Name: table<uint8,[4]int>
+      ByteSize: 32
+      GoKind: 25
+      RawFields:
+        - Name: used
+          Offset: 0
+          Type: 22 BaseType uint16
+        - Name: capacity
+          Offset: 2
+          Type: 22 BaseType uint16
+        - Name: growthLeft
+          Offset: 4
+          Type: 22 BaseType uint16
+        - Name: localDepth
+          Offset: 6
+          Type: 4 BaseType uint8
+        - Name: index
+          Offset: 8
+          Type: 1 BaseType int
+        - Name: groups
+          Offset: 16
+          Type: 174 GoSwissMapGroupsType groupReference<uint8,[4]int>
+    - __kind: StructureType
+      ID: 162
+      Name: table<uint8,uint8>
+      ByteSize: 32
+      GoKind: 25
+      RawFields:
+        - Name: used
+          Offset: 0
+          Type: 22 BaseType uint16
+        - Name: capacity
+          Offset: 2
+          Type: 22 BaseType uint16
+        - Name: growthLeft
+          Offset: 4
+          Type: 22 BaseType uint16
+        - Name: localDepth
+          Offset: 6
+          Type: 4 BaseType uint8
+        - Name: index
+          Offset: 8
+          Type: 1 BaseType int
+        - Name: groups
+          Offset: 16
+          Type: 163 GoSwissMapGroupsType groupReference<uint8,uint8>
+    - __kind: BaseType
+      ID: 20
+      Name: uint
+      ByteSize: 8
+      GoRuntimeType: 579200
+      GoKind: 7
+    - __kind: BaseType
+      ID: 22
+      Name: uint16
+      ByteSize: 2
+      GoRuntimeType: 578816
+      GoKind: 9
+    - __kind: BaseType
+      ID: 24
+      Name: uint32
+      ByteSize: 4
+      GoRuntimeType: 578944
+      GoKind: 10
+    - __kind: BaseType
+      ID: 26
+      Name: uint64
+      ByteSize: 8
+      GoRuntimeType: 579072
+      GoKind: 11
+    - __kind: BaseType
+      ID: 4
+      Name: uint8
+      ByteSize: 1
+      GoRuntimeType: 578688
+      GoKind: 8
+    - __kind: BaseType
+      ID: 62
+      Name: uintptr
+      ByteSize: 8
+      GoRuntimeType: 579264
+      GoKind: 12
+    - __kind: VoidPointerType
+      ID: 38
+      Name: unsafe.Pointer
+      ByteSize: 8
+      GoRuntimeType: 579648
+      GoKind: 26
 MaxTypeID: 385
 Issues: []
 GoModuledataInfo: {FirstModuledataAddr: "0x12ed4c0", TypesOffset: 296}

--- a/pkg/dyninst/irgen/testdata/snapshot/sample.arch=arm64,toolchain=go1.25.0.yaml
+++ b/pkg/dyninst/irgen/testdata/snapshot/sample.arch=arm64,toolchain=go1.25.0.yaml
@@ -2085,7 +2085,7 @@ Subprograms:
       InlinePCRanges: []
       Variables:
         - Name: a
-          Type: 73 ArrayType [5]int
+          Type: 63 ArrayType [5]int
           Locations:
             - Range: 0x806e00..0x806e50
               Pieces: [{Size: 40, Op: {CfaOffset: 8}}]
@@ -2102,7 +2102,7 @@ Subprograms:
       InlinePCRanges: []
       Variables:
         - Name: b
-          Type: 74 GoInterfaceType main.behavior
+          Type: 64 GoInterfaceType main.behavior
           Locations:
             - Range: 0x807060..0x807088
               Pieces:
@@ -2172,7 +2172,7 @@ Subprograms:
       InlinePCRanges: []
       Variables:
         - Name: s
-          Type: 75 StructureType main.structWithMap
+          Type: 65 StructureType main.structWithMap
           Locations:
             - Range: 0x8074d0..0x8074e0
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
@@ -2184,7 +2184,7 @@ Subprograms:
       InlinePCRanges: []
       Variables:
         - Name: m
-          Type: 87 GoMapType map[string]main.nestedStruct
+          Type: 71 GoMapType map[string]main.nestedStruct
           Locations:
             - Range: 0x8074e0..0x8074f0
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
@@ -2196,7 +2196,7 @@ Subprograms:
       InlinePCRanges: []
       Variables:
         - Name: m
-          Type: 99 GoMapType map[string]int
+          Type: 76 GoMapType map[string]int
           Locations:
             - Range: 0x8074f0..0x807500
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
@@ -2208,7 +2208,7 @@ Subprograms:
       InlinePCRanges: []
       Variables:
         - Name: m
-          Type: 110 GoMapType map[string][]string
+          Type: 81 GoMapType map[string][]string
           Locations:
             - Range: 0x807500..0x807510
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
@@ -2220,7 +2220,7 @@ Subprograms:
       InlinePCRanges: []
       Variables:
         - Name: m
-          Type: 122 GoMapType map[[4]string][2]int
+          Type: 86 GoMapType map[[4]string][2]int
           Locations:
             - Range: 0x807510..0x807520
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
@@ -2232,7 +2232,7 @@ Subprograms:
       InlinePCRanges: []
       Variables:
         - Name: m
-          Type: 99 GoMapType map[string]int
+          Type: 76 GoMapType map[string]int
           Locations:
             - Range: 0x807520..0x807530
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
@@ -2244,7 +2244,7 @@ Subprograms:
       InlinePCRanges: []
       Variables:
         - Name: m
-          Type: 134 ArrayType [2]map[string]int
+          Type: 91 ArrayType [2]map[string]int
           Locations:
             - Range: 0x807530..0x807540
               Pieces: [{Size: 16, Op: {CfaOffset: 8}}]
@@ -2256,7 +2256,7 @@ Subprograms:
       InlinePCRanges: []
       Variables:
         - Name: m
-          Type: 135 PointerType *map[string]int
+          Type: 92 PointerType *map[string]int
           Locations:
             - Range: 0x807540..0x807550
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
@@ -2268,7 +2268,7 @@ Subprograms:
       InlinePCRanges: []
       Variables:
         - Name: m
-          Type: 76 GoMapType map[int]int
+          Type: 66 GoMapType map[int]int
           Locations:
             - Range: 0x807550..0x807560
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
@@ -2280,7 +2280,7 @@ Subprograms:
       InlinePCRanges: []
       Variables:
         - Name: redactMyEntries
-          Type: 136 GoMapType map[string][]main.structWithMap
+          Type: 93 GoMapType map[string][]main.structWithMap
           Locations:
             - Range: 0x807560..0x807570
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
@@ -2292,7 +2292,7 @@ Subprograms:
       InlinePCRanges: []
       Variables:
         - Name: m
-          Type: 136 GoMapType map[string][]main.structWithMap
+          Type: 93 GoMapType map[string][]main.structWithMap
           Locations:
             - Range: 0x807570..0x807580
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
@@ -2304,7 +2304,7 @@ Subprograms:
       InlinePCRanges: []
       Variables:
         - Name: m
-          Type: 149 GoMapType map[bool]main.node
+          Type: 98 GoMapType map[bool]main.node
           Locations:
             - Range: 0x807580..0x807590
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
@@ -2316,7 +2316,7 @@ Subprograms:
       InlinePCRanges: []
       Variables:
         - Name: m
-          Type: 162 GoMapType map[int]uint8
+          Type: 103 GoMapType map[int]uint8
           Locations:
             - Range: 0x807590..0x8075a0
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
@@ -2328,7 +2328,7 @@ Subprograms:
       InlinePCRanges: []
       Variables:
         - Name: redactMyEntries
-          Type: 162 GoMapType map[int]uint8
+          Type: 103 GoMapType map[int]uint8
           Locations:
             - Range: 0x8075a0..0x8075b0
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
@@ -2340,7 +2340,7 @@ Subprograms:
       InlinePCRanges: []
       Variables:
         - Name: m
-          Type: 173 GoMapType map[uint8]uint8
+          Type: 108 GoMapType map[uint8]uint8
           Locations:
             - Range: 0x8075b0..0x8075c0
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
@@ -2352,7 +2352,7 @@ Subprograms:
       InlinePCRanges: []
       Variables:
         - Name: m
-          Type: 173 GoMapType map[uint8]uint8
+          Type: 108 GoMapType map[uint8]uint8
           Locations:
             - Range: 0x8075c0..0x8075d0
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
@@ -2364,7 +2364,7 @@ Subprograms:
       InlinePCRanges: []
       Variables:
         - Name: m
-          Type: 173 GoMapType map[uint8]uint8
+          Type: 108 GoMapType map[uint8]uint8
           Locations:
             - Range: 0x8075d0..0x8075e0
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
@@ -2376,7 +2376,7 @@ Subprograms:
       InlinePCRanges: []
       Variables:
         - Name: m
-          Type: 184 GoMapType map[uint8][4]int
+          Type: 113 GoMapType map[uint8][4]int
           Locations:
             - Range: 0x8075e0..0x8075f0
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
@@ -2388,7 +2388,7 @@ Subprograms:
       InlinePCRanges: []
       Variables:
         - Name: m
-          Type: 196 GoMapType map[[4]int]uint8
+          Type: 118 GoMapType map[[4]int]uint8
           Locations:
             - Range: 0x8075f0..0x807600
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
@@ -2400,7 +2400,7 @@ Subprograms:
       InlinePCRanges: []
       Variables:
         - Name: m
-          Type: 207 GoMapType map[[4]int][4]int
+          Type: 123 GoMapType map[[4]int][4]int
           Locations:
             - Range: 0x807600..0x807610
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
@@ -2482,7 +2482,7 @@ Subprograms:
       InlinePCRanges: []
       Variables:
         - Name: c
-          Type: 218 GoChannelType chan bool
+          Type: 128 GoChannelType chan bool
           Locations:
             - Range: 0x808b20..0x808b30
               Pieces: [{Size: 0, Op: {RegNo: 0, Shift: 0}}]
@@ -2494,7 +2494,7 @@ Subprograms:
       InlinePCRanges: []
       Variables:
         - Name: a
-          Type: 219 PointerType *main.structWithTwoValues
+          Type: 129 PointerType *main.structWithTwoValues
           Locations:
             - Range: 0x808ca0..0x808cb0
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
@@ -2506,7 +2506,7 @@ Subprograms:
       InlinePCRanges: []
       Variables:
         - Name: a
-          Type: 160 StructureType main.node
+          Type: 131 StructureType main.node
           Locations:
             - Range: 0x808cb0..0x808cc0
               Pieces:
@@ -2522,7 +2522,7 @@ Subprograms:
       InlinePCRanges: []
       Variables:
         - Name: a
-          Type: 161 PointerType *main.node
+          Type: 132 PointerType *main.node
           Locations:
             - Range: 0x808cc0..0x808cd0
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
@@ -2589,7 +2589,7 @@ Subprograms:
       InlinePCRanges: []
       Variables:
         - Name: t
-          Type: 221 PointerType *main.t
+          Type: 133 PointerType *main.t
           Locations:
             - Range: 0x808da0..0x808db0
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
@@ -2601,7 +2601,7 @@ Subprograms:
       InlinePCRanges: []
       Variables:
         - Name: u
-          Type: 224 GoSliceHeaderType []uint
+          Type: 135 GoSliceHeaderType []uint
           Locations:
             - Range: 0x809140..0x809150
               Pieces:
@@ -2619,7 +2619,7 @@ Subprograms:
       InlinePCRanges: []
       Variables:
         - Name: u
-          Type: 224 GoSliceHeaderType []uint
+          Type: 135 GoSliceHeaderType []uint
           Locations:
             - Range: 0x809150..0x809160
               Pieces:
@@ -2637,7 +2637,7 @@ Subprograms:
       InlinePCRanges: []
       Variables:
         - Name: u
-          Type: 225 GoSliceHeaderType [][]uint
+          Type: 136 GoSliceHeaderType [][]uint
           Locations:
             - Range: 0x809160..0x809170
               Pieces:
@@ -2655,7 +2655,7 @@ Subprograms:
       InlinePCRanges: []
       Variables:
         - Name: xs
-          Type: 227 GoSliceHeaderType []main.structWithNoStrings
+          Type: 138 GoSliceHeaderType []main.structWithNoStrings
           Locations:
             - Range: 0x809170..0x809180
               Pieces:
@@ -2680,7 +2680,7 @@ Subprograms:
       InlinePCRanges: []
       Variables:
         - Name: xs
-          Type: 227 GoSliceHeaderType []main.structWithNoStrings
+          Type: 138 GoSliceHeaderType []main.structWithNoStrings
           Locations:
             - Range: 0x809180..0x809190
               Pieces:
@@ -2705,7 +2705,7 @@ Subprograms:
       InlinePCRanges: []
       Variables:
         - Name: xs
-          Type: 227 GoSliceHeaderType []main.structWithNoStrings
+          Type: 138 GoSliceHeaderType []main.structWithNoStrings
           Locations:
             - Range: 0x809190..0x8091a0
               Pieces:
@@ -2730,7 +2730,7 @@ Subprograms:
       InlinePCRanges: []
       Variables:
         - Name: s
-          Type: 121 GoSliceHeaderType []string
+          Type: 141 GoSliceHeaderType []string
           Locations:
             - Range: 0x8091a0..0x8091b0
               Pieces:
@@ -2755,7 +2755,7 @@ Subprograms:
           IsParameter: true
           IsReturn: false
         - Name: s
-          Type: 230 GoSliceHeaderType []bool
+          Type: 142 GoSliceHeaderType []bool
           Locations:
             - Range: 0x8091b0..0x8091c0
               Pieces:
@@ -2780,7 +2780,7 @@ Subprograms:
       InlinePCRanges: []
       Variables:
         - Name: xs
-          Type: 231 GoSliceHeaderType []uint16
+          Type: 143 GoSliceHeaderType []uint16
           Locations:
             - Range: 0x8091c0..0x8091d0
               Pieces:
@@ -2798,7 +2798,7 @@ Subprograms:
       InlinePCRanges: []
       Variables:
         - Name: xs
-          Type: 224 GoSliceHeaderType []uint
+          Type: 135 GoSliceHeaderType []uint
           Locations:
             - Range: 0x8091d0..0x8091e0
               Pieces:
@@ -2880,7 +2880,7 @@ Subprograms:
       InlinePCRanges: []
       Variables:
         - Name: a
-          Type: 232 StructureType main.threeStringStruct
+          Type: 144 StructureType main.threeStringStruct
           Locations:
             - Range: 0x8094f0..0x809500
               Pieces:
@@ -2904,7 +2904,7 @@ Subprograms:
       InlinePCRanges: []
       Variables:
         - Name: a
-          Type: 233 PointerType *main.threeStringStruct
+          Type: 145 PointerType *main.threeStringStruct
           Locations:
             - Range: 0x809500..0x809510
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
@@ -2916,7 +2916,7 @@ Subprograms:
       InlinePCRanges: []
       Variables:
         - Name: a
-          Type: 234 PointerType *main.oneStringStruct
+          Type: 146 PointerType *main.oneStringStruct
           Locations:
             - Range: 0x809510..0x809520
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
@@ -2976,7 +2976,7 @@ Subprograms:
       InlinePCRanges: []
       Variables:
         - Name: x
-          Type: 236 StructureType main.aStruct
+          Type: 148 StructureType main.aStruct
           Locations:
             - Range: 0x809710..0x809730
               Pieces:
@@ -3002,7 +3002,7 @@ Subprograms:
       InlinePCRanges: []
       Variables:
         - Name: e
-          Type: 237 StructureType main.emptyStruct
+          Type: 150 StructureType main.emptyStruct
           Locations: [{Range: 0x8097e0..0x8097f0, Pieces: []}]
           IsParameter: true
           IsReturn: false
@@ -3081,7 +3081,7 @@ Subprograms:
           RootRanges: [0x806e50..0x806f90]
       Variables:
         - Name: a
-          Type: 73 ArrayType [5]int
+          Type: 63 ArrayType [5]int
           Locations:
             - Range: 0x806e10..0x806e50
               Pieces: [{Size: 40, Op: {CfaOffset: -48}}]
@@ -3091,10 +3091,10 @@ Subprograms:
           IsReturn: false
 Types:
     - __kind: PointerType
-      ID: 223
+      ID: 173
       Name: '**main.t'
       ByteSize: 8
-      Pointee: 221 PointerType *main.t
+      Pointee: 133 PointerType *main.t
     - __kind: PointerType
       ID: 54
       Name: '**string'
@@ -3103,110 +3103,110 @@ Types:
       GoKind: 22
       Pointee: 22 PointerType *string
     - __kind: PointerType
-      ID: 210
+      ID: 126
       Name: '**table<[4]int,[4]int>'
       ByteSize: 8
-      Pointee: 211 PointerType *table<[4]int,[4]int>
+      Pointee: 127 PointerType *table<[4]int,[4]int>
     - __kind: PointerType
-      ID: 199
+      ID: 121
       Name: '**table<[4]int,uint8>'
       ByteSize: 8
-      Pointee: 200 PointerType *table<[4]int,uint8>
+      Pointee: 122 PointerType *table<[4]int,uint8>
     - __kind: PointerType
-      ID: 125
+      ID: 89
       Name: '**table<[4]string,[2]int>'
       ByteSize: 8
-      Pointee: 126 PointerType *table<[4]string,[2]int>
+      Pointee: 90 PointerType *table<[4]string,[2]int>
     - __kind: PointerType
-      ID: 152
+      ID: 101
       Name: '**table<bool,main.node>'
       ByteSize: 8
-      Pointee: 153 PointerType *table<bool,main.node>
+      Pointee: 102 PointerType *table<bool,main.node>
     - __kind: PointerType
-      ID: 79
+      ID: 69
       Name: '**table<int,int>'
       ByteSize: 8
-      Pointee: 80 PointerType *table<int,int>
+      Pointee: 70 PointerType *table<int,int>
     - __kind: PointerType
-      ID: 165
+      ID: 106
       Name: '**table<int,uint8>'
       ByteSize: 8
-      Pointee: 166 PointerType *table<int,uint8>
+      Pointee: 107 PointerType *table<int,uint8>
     - __kind: PointerType
-      ID: 139
+      ID: 96
       Name: '**table<string,[]main.structWithMap>'
       ByteSize: 8
-      Pointee: 140 PointerType *table<string,[]main.structWithMap>
+      Pointee: 97 PointerType *table<string,[]main.structWithMap>
     - __kind: PointerType
-      ID: 113
+      ID: 84
       Name: '**table<string,[]string>'
       ByteSize: 8
-      Pointee: 114 PointerType *table<string,[]string>
+      Pointee: 85 PointerType *table<string,[]string>
     - __kind: PointerType
-      ID: 102
+      ID: 79
       Name: '**table<string,int>'
       ByteSize: 8
-      Pointee: 103 PointerType *table<string,int>
+      Pointee: 80 PointerType *table<string,int>
     - __kind: PointerType
-      ID: 90
+      ID: 74
       Name: '**table<string,main.nestedStruct>'
       ByteSize: 8
-      Pointee: 91 PointerType *table<string,main.nestedStruct>
+      Pointee: 75 PointerType *table<string,main.nestedStruct>
     - __kind: PointerType
-      ID: 187
+      ID: 116
       Name: '**table<uint8,[4]int>'
       ByteSize: 8
-      Pointee: 188 PointerType *table<uint8,[4]int>
+      Pointee: 117 PointerType *table<uint8,[4]int>
     - __kind: PointerType
-      ID: 176
+      ID: 111
       Name: '**table<uint8,uint8>'
       ByteSize: 8
-      Pointee: 177 PointerType *table<uint8,uint8>
+      Pointee: 112 PointerType *table<uint8,uint8>
     - __kind: PointerType
       ID: 241
       Name: '*[]*string.array'
       ByteSize: 8
       Pointee: 240 GoSliceDataType []*string.array
     - __kind: PointerType
-      ID: 275
+      ID: 271
       Name: '*[][]uint.array'
       ByteSize: 8
-      Pointee: 274 GoSliceDataType [][]uint.array
-    - __kind: PointerType
-      ID: 279
-      Name: '*[]bool.array'
-      ByteSize: 8
-      Pointee: 278 GoSliceDataType []bool.array
-    - __kind: PointerType
-      ID: 257
-      Name: '*[]main.structWithMap.array'
-      ByteSize: 8
-      Pointee: 256 GoSliceDataType []main.structWithMap.array
+      Pointee: 270 GoSliceDataType [][]uint.array
     - __kind: PointerType
       ID: 277
-      Name: '*[]main.structWithNoStrings.array'
+      Name: '*[]bool.array'
       ByteSize: 8
-      Pointee: 276 GoSliceDataType []main.structWithNoStrings.array
-    - __kind: PointerType
-      ID: 251
-      Name: '*[]string.array'
-      ByteSize: 8
-      Pointee: 250 GoSliceDataType []string.array
-    - __kind: PointerType
-      ID: 226
-      Name: '*[]uint'
-      ByteSize: 8
-      Pointee: 224 GoSliceHeaderType []uint
-    - __kind: PointerType
-      ID: 273
-      Name: '*[]uint.array'
-      ByteSize: 8
-      Pointee: 272 GoSliceDataType []uint.array
+      Pointee: 276 GoSliceDataType []bool.array
     - __kind: PointerType
       ID: 281
+      Name: '*[]main.structWithMap.array'
+      ByteSize: 8
+      Pointee: 280 GoSliceDataType []main.structWithMap.array
+    - __kind: PointerType
+      ID: 273
+      Name: '*[]main.structWithNoStrings.array'
+      ByteSize: 8
+      Pointee: 272 GoSliceDataType []main.structWithNoStrings.array
+    - __kind: PointerType
+      ID: 275
+      Name: '*[]string.array'
+      ByteSize: 8
+      Pointee: 274 GoSliceDataType []string.array
+    - __kind: PointerType
+      ID: 137
+      Name: '*[]uint'
+      ByteSize: 8
+      Pointee: 135 GoSliceHeaderType []uint
+    - __kind: PointerType
+      ID: 269
+      Name: '*[]uint.array'
+      ByteSize: 8
+      Pointee: 268 GoSliceDataType []uint.array
+    - __kind: PointerType
+      ID: 279
       Name: '*[]uint16.array'
       ByteSize: 8
-      Pointee: 280 GoSliceDataType []uint16.array
+      Pointee: 278 GoSliceDataType []uint16.array
     - __kind: PointerType
       ID: 11
       Name: '*bool'
@@ -3278,179 +3278,179 @@ Types:
       GoKind: 22
       Pointee: 62 StructureType main.esotericHeap
     - __kind: PointerType
-      ID: 161
+      ID: 132
       Name: '*main.node'
       ByteSize: 8
       GoRuntimeType: 383008
       GoKind: 22
-      Pointee: 160 StructureType main.node
+      Pointee: 131 StructureType main.node
     - __kind: PointerType
-      ID: 234
+      ID: 146
       Name: '*main.oneStringStruct'
       ByteSize: 8
       GoKind: 22
-      Pointee: 235 StructureType main.oneStringStruct
+      Pointee: 147 StructureType main.oneStringStruct
     - __kind: PointerType
-      ID: 148
+      ID: 224
       Name: '*main.structWithMap'
       ByteSize: 8
       GoRuntimeType: 382880
       GoKind: 22
-      Pointee: 75 StructureType main.structWithMap
+      Pointee: 65 StructureType main.structWithMap
     - __kind: PointerType
-      ID: 228
+      ID: 139
       Name: '*main.structWithNoStrings'
       ByteSize: 8
-      Pointee: 229 StructureType main.structWithNoStrings
+      Pointee: 140 StructureType main.structWithNoStrings
     - __kind: PointerType
-      ID: 219
+      ID: 129
       Name: '*main.structWithTwoValues'
       ByteSize: 8
       GoKind: 22
-      Pointee: 220 StructureType main.structWithTwoValues
+      Pointee: 130 StructureType main.structWithTwoValues
     - __kind: PointerType
-      ID: 221
+      ID: 133
       Name: '*main.t'
       ByteSize: 8
       GoKind: 22
-      Pointee: 222 GoSliceHeaderType main.t
+      Pointee: 134 GoSliceHeaderType main.t
     - __kind: PointerType
-      ID: 271
+      ID: 267
       Name: '*main.t.array'
       ByteSize: 8
-      Pointee: 270 GoSliceDataType main.t.array
+      Pointee: 266 GoSliceDataType main.t.array
     - __kind: PointerType
-      ID: 233
+      ID: 145
       Name: '*main.threeStringStruct'
       ByteSize: 8
       GoKind: 22
-      Pointee: 232 StructureType main.threeStringStruct
+      Pointee: 144 StructureType main.threeStringStruct
     - __kind: PointerType
-      ID: 208
+      ID: 124
       Name: '*map<[4]int,[4]int>'
       ByteSize: 8
-      Pointee: 209 GoSwissMapHeaderType map<[4]int,[4]int>
+      Pointee: 125 GoSwissMapHeaderType map<[4]int,[4]int>
     - __kind: PointerType
-      ID: 197
+      ID: 119
       Name: '*map<[4]int,uint8>'
       ByteSize: 8
-      Pointee: 198 GoSwissMapHeaderType map<[4]int,uint8>
+      Pointee: 120 GoSwissMapHeaderType map<[4]int,uint8>
     - __kind: PointerType
-      ID: 123
+      ID: 87
       Name: '*map<[4]string,[2]int>'
       ByteSize: 8
-      Pointee: 124 GoSwissMapHeaderType map<[4]string,[2]int>
+      Pointee: 88 GoSwissMapHeaderType map<[4]string,[2]int>
     - __kind: PointerType
-      ID: 150
+      ID: 99
       Name: '*map<bool,main.node>'
       ByteSize: 8
-      Pointee: 151 GoSwissMapHeaderType map<bool,main.node>
+      Pointee: 100 GoSwissMapHeaderType map<bool,main.node>
     - __kind: PointerType
-      ID: 77
+      ID: 67
       Name: '*map<int,int>'
       ByteSize: 8
-      Pointee: 78 GoSwissMapHeaderType map<int,int>
+      Pointee: 68 GoSwissMapHeaderType map<int,int>
     - __kind: PointerType
-      ID: 163
+      ID: 104
       Name: '*map<int,uint8>'
       ByteSize: 8
-      Pointee: 164 GoSwissMapHeaderType map<int,uint8>
+      Pointee: 105 GoSwissMapHeaderType map<int,uint8>
     - __kind: PointerType
-      ID: 137
+      ID: 94
       Name: '*map<string,[]main.structWithMap>'
       ByteSize: 8
-      Pointee: 138 GoSwissMapHeaderType map<string,[]main.structWithMap>
+      Pointee: 95 GoSwissMapHeaderType map<string,[]main.structWithMap>
     - __kind: PointerType
-      ID: 111
+      ID: 82
       Name: '*map<string,[]string>'
       ByteSize: 8
-      Pointee: 112 GoSwissMapHeaderType map<string,[]string>
+      Pointee: 83 GoSwissMapHeaderType map<string,[]string>
     - __kind: PointerType
-      ID: 100
+      ID: 77
       Name: '*map<string,int>'
       ByteSize: 8
-      Pointee: 101 GoSwissMapHeaderType map<string,int>
+      Pointee: 78 GoSwissMapHeaderType map<string,int>
     - __kind: PointerType
-      ID: 88
+      ID: 72
       Name: '*map<string,main.nestedStruct>'
       ByteSize: 8
-      Pointee: 89 GoSwissMapHeaderType map<string,main.nestedStruct>
+      Pointee: 73 GoSwissMapHeaderType map<string,main.nestedStruct>
     - __kind: PointerType
-      ID: 185
+      ID: 114
       Name: '*map<uint8,[4]int>'
       ByteSize: 8
-      Pointee: 186 GoSwissMapHeaderType map<uint8,[4]int>
+      Pointee: 115 GoSwissMapHeaderType map<uint8,[4]int>
     - __kind: PointerType
-      ID: 174
+      ID: 109
       Name: '*map<uint8,uint8>'
       ByteSize: 8
-      Pointee: 175 GoSwissMapHeaderType map<uint8,uint8>
+      Pointee: 110 GoSwissMapHeaderType map<uint8,uint8>
     - __kind: PointerType
-      ID: 135
+      ID: 92
       Name: '*map[string]int'
       ByteSize: 8
       GoKind: 22
-      Pointee: 99 GoMapType map[string]int
+      Pointee: 76 GoMapType map[string]int
     - __kind: PointerType
-      ID: 214
+      ID: 208
       Name: '*noalg.map.group[[4]int][4]int'
       ByteSize: 8
-      Pointee: 215 StructureType noalg.map.group[[4]int][4]int
+      Pointee: 209 StructureType noalg.map.group[[4]int][4]int
     - __kind: PointerType
-      ID: 203
+      ID: 205
       Name: '*noalg.map.group[[4]int]uint8'
       ByteSize: 8
-      Pointee: 204 StructureType noalg.map.group[[4]int]uint8
+      Pointee: 206 StructureType noalg.map.group[[4]int]uint8
     - __kind: PointerType
-      ID: 129
+      ID: 187
       Name: '*noalg.map.group[[4]string][2]int'
       ByteSize: 8
-      Pointee: 130 StructureType noalg.map.group[[4]string][2]int
+      Pointee: 188 StructureType noalg.map.group[[4]string][2]int
     - __kind: PointerType
-      ID: 156
+      ID: 193
       Name: '*noalg.map.group[bool]main.node'
       ByteSize: 8
-      Pointee: 157 StructureType noalg.map.group[bool]main.node
+      Pointee: 194 StructureType noalg.map.group[bool]main.node
     - __kind: PointerType
-      ID: 83
+      ID: 175
       Name: '*noalg.map.group[int]int'
       ByteSize: 8
-      Pointee: 84 StructureType noalg.map.group[int]int
+      Pointee: 176 StructureType noalg.map.group[int]int
     - __kind: PointerType
-      ID: 169
+      ID: 196
       Name: '*noalg.map.group[int]uint8'
       ByteSize: 8
-      Pointee: 170 StructureType noalg.map.group[int]uint8
+      Pointee: 197 StructureType noalg.map.group[int]uint8
     - __kind: PointerType
-      ID: 143
+      ID: 190
       Name: '*noalg.map.group[string][]main.structWithMap'
       ByteSize: 8
-      Pointee: 144 StructureType noalg.map.group[string][]main.structWithMap
+      Pointee: 191 StructureType noalg.map.group[string][]main.structWithMap
     - __kind: PointerType
-      ID: 117
+      ID: 184
       Name: '*noalg.map.group[string][]string'
       ByteSize: 8
-      Pointee: 118 StructureType noalg.map.group[string][]string
+      Pointee: 185 StructureType noalg.map.group[string][]string
     - __kind: PointerType
-      ID: 106
+      ID: 181
       Name: '*noalg.map.group[string]int'
       ByteSize: 8
-      Pointee: 107 StructureType noalg.map.group[string]int
+      Pointee: 182 StructureType noalg.map.group[string]int
     - __kind: PointerType
-      ID: 94
+      ID: 178
       Name: '*noalg.map.group[string]main.nestedStruct'
       ByteSize: 8
-      Pointee: 95 StructureType noalg.map.group[string]main.nestedStruct
+      Pointee: 179 StructureType noalg.map.group[string]main.nestedStruct
     - __kind: PointerType
-      ID: 191
+      ID: 202
       Name: '*noalg.map.group[uint8][4]int'
       ByteSize: 8
-      Pointee: 192 StructureType noalg.map.group[uint8][4]int
+      Pointee: 203 StructureType noalg.map.group[uint8][4]int
     - __kind: PointerType
-      ID: 180
+      ID: 199
       Name: '*noalg.map.group[uint8]uint8'
       ByteSize: 8
-      Pointee: 181 StructureType noalg.map.group[uint8]uint8
+      Pointee: 200 StructureType noalg.map.group[uint8]uint8
     - __kind: PointerType
       ID: 22
       Name: '*string'
@@ -3464,65 +3464,65 @@ Types:
       ByteSize: 8
       Pointee: 238 GoStringDataType string.str
     - __kind: PointerType
-      ID: 211
+      ID: 127
       Name: '*table<[4]int,[4]int>'
       ByteSize: 8
-      Pointee: 212 StructureType table<[4]int,[4]int>
+      Pointee: 172 StructureType table<[4]int,[4]int>
     - __kind: PointerType
-      ID: 200
+      ID: 122
       Name: '*table<[4]int,uint8>'
       ByteSize: 8
-      Pointee: 201 StructureType table<[4]int,uint8>
+      Pointee: 171 StructureType table<[4]int,uint8>
     - __kind: PointerType
-      ID: 126
+      ID: 90
       Name: '*table<[4]string,[2]int>'
       ByteSize: 8
-      Pointee: 127 StructureType table<[4]string,[2]int>
+      Pointee: 165 StructureType table<[4]string,[2]int>
     - __kind: PointerType
-      ID: 153
+      ID: 102
       Name: '*table<bool,main.node>'
       ByteSize: 8
-      Pointee: 154 StructureType table<bool,main.node>
+      Pointee: 167 StructureType table<bool,main.node>
     - __kind: PointerType
-      ID: 80
+      ID: 70
       Name: '*table<int,int>'
       ByteSize: 8
-      Pointee: 81 StructureType table<int,int>
+      Pointee: 161 StructureType table<int,int>
     - __kind: PointerType
-      ID: 166
+      ID: 107
       Name: '*table<int,uint8>'
       ByteSize: 8
-      Pointee: 167 StructureType table<int,uint8>
+      Pointee: 168 StructureType table<int,uint8>
     - __kind: PointerType
-      ID: 140
+      ID: 97
       Name: '*table<string,[]main.structWithMap>'
       ByteSize: 8
-      Pointee: 141 StructureType table<string,[]main.structWithMap>
+      Pointee: 166 StructureType table<string,[]main.structWithMap>
     - __kind: PointerType
-      ID: 114
+      ID: 85
       Name: '*table<string,[]string>'
       ByteSize: 8
-      Pointee: 115 StructureType table<string,[]string>
+      Pointee: 164 StructureType table<string,[]string>
     - __kind: PointerType
-      ID: 103
+      ID: 80
       Name: '*table<string,int>'
       ByteSize: 8
-      Pointee: 104 StructureType table<string,int>
+      Pointee: 163 StructureType table<string,int>
     - __kind: PointerType
-      ID: 91
+      ID: 75
       Name: '*table<string,main.nestedStruct>'
       ByteSize: 8
-      Pointee: 92 StructureType table<string,main.nestedStruct>
+      Pointee: 162 StructureType table<string,main.nestedStruct>
     - __kind: PointerType
-      ID: 188
+      ID: 117
       Name: '*table<uint8,[4]int>'
       ByteSize: 8
-      Pointee: 189 StructureType table<uint8,[4]int>
+      Pointee: 170 StructureType table<uint8,[4]int>
     - __kind: PointerType
-      ID: 177
+      ID: 112
       Name: '*table<uint8,uint8>'
       ByteSize: 8
-      Pointee: 178 StructureType table<uint8,uint8>
+      Pointee: 169 StructureType table<uint8,uint8>
     - __kind: PointerType
       ID: 34
       Name: '*uint'
@@ -3622,7 +3622,7 @@ Types:
         - Name: m
           Offset: 1
           Expression:
-            Type: 134 ArrayType [2]map[string]int
+            Type: 91 ArrayType [2]map[string]int
             Operations:
                 - __kind: LocationOp
                   Variable: {subprogram: 53, index: 0, name: m}
@@ -3697,7 +3697,7 @@ Types:
         - Name: c
           Offset: 1
           Expression:
-            Type: 218 GoChannelType chan bool
+            Type: 128 GoChannelType chan bool
             Operations:
                 - __kind: LocationOp
                   Variable: {subprogram: 69, index: 0, name: c}
@@ -3745,7 +3745,7 @@ Types:
         - Name: t
           Offset: 1
           Expression:
-            Type: 221 PointerType *main.t
+            Type: 133 PointerType *main.t
             Operations:
                 - __kind: LocationOp
                   Variable: {subprogram: 77, index: 0, name: t}
@@ -3760,7 +3760,7 @@ Types:
         - Name: xs
           Offset: 1
           Expression:
-            Type: 227 GoSliceHeaderType []main.structWithNoStrings
+            Type: 138 GoSliceHeaderType []main.structWithNoStrings
             Operations:
                 - __kind: LocationOp
                   Variable: {subprogram: 82, index: 0, name: xs}
@@ -3784,7 +3784,7 @@ Types:
         - Name: u
           Offset: 1
           Expression:
-            Type: 224 GoSliceHeaderType []uint
+            Type: 135 GoSliceHeaderType []uint
             Operations:
                 - __kind: LocationOp
                   Variable: {subprogram: 79, index: 0, name: u}
@@ -3814,7 +3814,7 @@ Types:
         - Name: e
           Offset: 1
           Expression:
-            Type: 237 StructureType main.emptyStruct
+            Type: 150 StructureType main.emptyStruct
             Operations:
                 - __kind: LocationOp
                   Variable: {subprogram: 98, index: 0, name: e}
@@ -3874,7 +3874,7 @@ Types:
         - Name: a
           Offset: 1
           Expression:
-            Type: 73 ArrayType [5]int
+            Type: 63 ArrayType [5]int
             Operations:
                 - __kind: LocationOp
                   Variable: {subprogram: 43, index: 0, name: a}
@@ -4000,7 +4000,7 @@ Types:
         - Name: a
           Offset: 1
           Expression:
-            Type: 73 ArrayType [5]int
+            Type: 63 ArrayType [5]int
             Operations:
                 - __kind: LocationOp
                   Variable: {subprogram: 104, index: 0, name: a}
@@ -4090,7 +4090,7 @@ Types:
         - Name: b
           Offset: 1
           Expression:
-            Type: 74 GoInterfaceType main.behavior
+            Type: 64 GoInterfaceType main.behavior
             Operations:
                 - __kind: LocationOp
                   Variable: {subprogram: 44, index: 0, name: b}
@@ -4105,7 +4105,7 @@ Types:
         - Name: a
           Offset: 1
           Expression:
-            Type: 160 StructureType main.node
+            Type: 131 StructureType main.node
             Operations:
                 - __kind: LocationOp
                   Variable: {subprogram: 71, index: 0, name: a}
@@ -4120,7 +4120,7 @@ Types:
         - Name: m
           Offset: 1
           Expression:
-            Type: 122 GoMapType map[[4]string][2]int
+            Type: 86 GoMapType map[[4]string][2]int
             Operations:
                 - __kind: LocationOp
                   Variable: {subprogram: 51, index: 0, name: m}
@@ -4135,7 +4135,7 @@ Types:
         - Name: m
           Offset: 1
           Expression:
-            Type: 136 GoMapType map[string][]main.structWithMap
+            Type: 93 GoMapType map[string][]main.structWithMap
             Operations:
                 - __kind: LocationOp
                   Variable: {subprogram: 57, index: 0, name: m}
@@ -4150,7 +4150,7 @@ Types:
         - Name: m
           Offset: 1
           Expression:
-            Type: 76 GoMapType map[int]int
+            Type: 66 GoMapType map[int]int
             Operations:
                 - __kind: LocationOp
                   Variable: {subprogram: 55, index: 0, name: m}
@@ -4165,7 +4165,7 @@ Types:
         - Name: m
           Offset: 1
           Expression:
-            Type: 207 GoMapType map[[4]int][4]int
+            Type: 123 GoMapType map[[4]int][4]int
             Operations:
                 - __kind: LocationOp
                   Variable: {subprogram: 66, index: 0, name: m}
@@ -4180,7 +4180,7 @@ Types:
         - Name: m
           Offset: 1
           Expression:
-            Type: 196 GoMapType map[[4]int]uint8
+            Type: 118 GoMapType map[[4]int]uint8
             Operations:
                 - __kind: LocationOp
                   Variable: {subprogram: 65, index: 0, name: m}
@@ -4195,7 +4195,7 @@ Types:
         - Name: redactMyEntries
           Offset: 1
           Expression:
-            Type: 136 GoMapType map[string][]main.structWithMap
+            Type: 93 GoMapType map[string][]main.structWithMap
             Operations:
                 - __kind: LocationOp
                   Variable: {subprogram: 56, index: 0, name: redactMyEntries}
@@ -4210,7 +4210,7 @@ Types:
         - Name: m
           Offset: 1
           Expression:
-            Type: 184 GoMapType map[uint8][4]int
+            Type: 113 GoMapType map[uint8][4]int
             Operations:
                 - __kind: LocationOp
                   Variable: {subprogram: 64, index: 0, name: m}
@@ -4225,7 +4225,7 @@ Types:
         - Name: m
           Offset: 1
           Expression:
-            Type: 173 GoMapType map[uint8]uint8
+            Type: 108 GoMapType map[uint8]uint8
             Operations:
                 - __kind: LocationOp
                   Variable: {subprogram: 63, index: 0, name: m}
@@ -4240,7 +4240,7 @@ Types:
         - Name: m
           Offset: 1
           Expression:
-            Type: 99 GoMapType map[string]int
+            Type: 76 GoMapType map[string]int
             Operations:
                 - __kind: LocationOp
                   Variable: {subprogram: 49, index: 0, name: m}
@@ -4255,7 +4255,7 @@ Types:
         - Name: m
           Offset: 1
           Expression:
-            Type: 110 GoMapType map[string][]string
+            Type: 81 GoMapType map[string][]string
             Operations:
                 - __kind: LocationOp
                   Variable: {subprogram: 50, index: 0, name: m}
@@ -4270,7 +4270,7 @@ Types:
         - Name: m
           Offset: 1
           Expression:
-            Type: 87 GoMapType map[string]main.nestedStruct
+            Type: 71 GoMapType map[string]main.nestedStruct
             Operations:
                 - __kind: LocationOp
                   Variable: {subprogram: 48, index: 0, name: m}
@@ -4285,7 +4285,7 @@ Types:
         - Name: m
           Offset: 1
           Expression:
-            Type: 149 GoMapType map[bool]main.node
+            Type: 98 GoMapType map[bool]main.node
             Operations:
                 - __kind: LocationOp
                   Variable: {subprogram: 58, index: 0, name: m}
@@ -4300,7 +4300,7 @@ Types:
         - Name: m
           Offset: 1
           Expression:
-            Type: 173 GoMapType map[uint8]uint8
+            Type: 108 GoMapType map[uint8]uint8
             Operations:
                 - __kind: LocationOp
                   Variable: {subprogram: 62, index: 0, name: m}
@@ -4315,7 +4315,7 @@ Types:
         - Name: m
           Offset: 1
           Expression:
-            Type: 173 GoMapType map[uint8]uint8
+            Type: 108 GoMapType map[uint8]uint8
             Operations:
                 - __kind: LocationOp
                   Variable: {subprogram: 61, index: 0, name: m}
@@ -4330,7 +4330,7 @@ Types:
         - Name: redactMyEntries
           Offset: 1
           Expression:
-            Type: 162 GoMapType map[int]uint8
+            Type: 103 GoMapType map[int]uint8
             Operations:
                 - __kind: LocationOp
                   Variable: {subprogram: 60, index: 0, name: redactMyEntries}
@@ -4345,7 +4345,7 @@ Types:
         - Name: m
           Offset: 1
           Expression:
-            Type: 162 GoMapType map[int]uint8
+            Type: 103 GoMapType map[int]uint8
             Operations:
                 - __kind: LocationOp
                   Variable: {subprogram: 59, index: 0, name: m}
@@ -4450,7 +4450,7 @@ Types:
         - Name: xs
           Offset: 1
           Expression:
-            Type: 227 GoSliceHeaderType []main.structWithNoStrings
+            Type: 138 GoSliceHeaderType []main.structWithNoStrings
             Operations:
                 - __kind: LocationOp
                   Variable: {subprogram: 83, index: 0, name: xs}
@@ -4483,7 +4483,7 @@ Types:
         - Name: s
           Offset: 2
           Expression:
-            Type: 230 GoSliceHeaderType []bool
+            Type: 142 GoSliceHeaderType []bool
             Operations:
                 - __kind: LocationOp
                   Variable: {subprogram: 85, index: 1, name: s}
@@ -4507,7 +4507,7 @@ Types:
         - Name: xs
           Offset: 1
           Expression:
-            Type: 231 GoSliceHeaderType []uint16
+            Type: 143 GoSliceHeaderType []uint16
             Operations:
                 - __kind: LocationOp
                   Variable: {subprogram: 86, index: 0, name: xs}
@@ -4522,7 +4522,7 @@ Types:
         - Name: a
           Offset: 1
           Expression:
-            Type: 234 PointerType *main.oneStringStruct
+            Type: 146 PointerType *main.oneStringStruct
             Operations:
                 - __kind: LocationOp
                   Variable: {subprogram: 93, index: 0, name: a}
@@ -4537,7 +4537,7 @@ Types:
         - Name: a
           Offset: 1
           Expression:
-            Type: 161 PointerType *main.node
+            Type: 132 PointerType *main.node
             Operations:
                 - __kind: LocationOp
                   Variable: {subprogram: 72, index: 0, name: a}
@@ -4552,7 +4552,7 @@ Types:
         - Name: m
           Offset: 1
           Expression:
-            Type: 135 PointerType *map[string]int
+            Type: 92 PointerType *map[string]int
             Operations:
                 - __kind: LocationOp
                   Variable: {subprogram: 54, index: 0, name: m}
@@ -4567,7 +4567,7 @@ Types:
         - Name: a
           Offset: 1
           Expression:
-            Type: 219 PointerType *main.structWithTwoValues
+            Type: 129 PointerType *main.structWithTwoValues
             Operations:
                 - __kind: LocationOp
                   Variable: {subprogram: 70, index: 0, name: a}
@@ -4837,7 +4837,7 @@ Types:
         - Name: u
           Offset: 1
           Expression:
-            Type: 225 GoSliceHeaderType [][]uint
+            Type: 136 GoSliceHeaderType [][]uint
             Operations:
                 - __kind: LocationOp
                   Variable: {subprogram: 80, index: 0, name: u}
@@ -4852,7 +4852,7 @@ Types:
         - Name: m
           Offset: 1
           Expression:
-            Type: 99 GoMapType map[string]int
+            Type: 76 GoMapType map[string]int
             Operations:
                 - __kind: LocationOp
                   Variable: {subprogram: 52, index: 0, name: m}
@@ -4897,7 +4897,7 @@ Types:
         - Name: s
           Offset: 1
           Expression:
-            Type: 121 GoSliceHeaderType []string
+            Type: 141 GoSliceHeaderType []string
             Operations:
                 - __kind: LocationOp
                   Variable: {subprogram: 84, index: 0, name: s}
@@ -4912,7 +4912,7 @@ Types:
         - Name: xs
           Offset: 1
           Expression:
-            Type: 227 GoSliceHeaderType []main.structWithNoStrings
+            Type: 138 GoSliceHeaderType []main.structWithNoStrings
             Operations:
                 - __kind: LocationOp
                   Variable: {subprogram: 81, index: 0, name: xs}
@@ -4936,7 +4936,7 @@ Types:
         - Name: s
           Offset: 1
           Expression:
-            Type: 75 StructureType main.structWithMap
+            Type: 65 StructureType main.structWithMap
             Operations:
                 - __kind: LocationOp
                   Variable: {subprogram: 47, index: 0, name: s}
@@ -4951,7 +4951,7 @@ Types:
         - Name: x
           Offset: 1
           Expression:
-            Type: 236 StructureType main.aStruct
+            Type: 148 StructureType main.aStruct
             Operations:
                 - __kind: LocationOp
                   Variable: {subprogram: 97, index: 0, name: x}
@@ -4966,7 +4966,7 @@ Types:
         - Name: a
           Offset: 1
           Expression:
-            Type: 233 PointerType *main.threeStringStruct
+            Type: 145 PointerType *main.threeStringStruct
             Operations:
                 - __kind: LocationOp
                   Variable: {subprogram: 92, index: 0, name: a}
@@ -4981,7 +4981,7 @@ Types:
         - Name: a
           Offset: 1
           Expression:
-            Type: 232 StructureType main.threeStringStruct
+            Type: 144 StructureType main.threeStringStruct
             Operations:
                 - __kind: LocationOp
                   Variable: {subprogram: 91, index: 0, name: a}
@@ -5134,7 +5134,7 @@ Types:
         - Name: u
           Offset: 1
           Expression:
-            Type: 224 GoSliceHeaderType []uint
+            Type: 135 GoSliceHeaderType []uint
             Operations:
                 - __kind: LocationOp
                   Variable: {subprogram: 78, index: 0, name: u}
@@ -5194,7 +5194,7 @@ Types:
         - Name: xs
           Offset: 1
           Expression:
-            Type: 224 GoSliceHeaderType []uint
+            Type: 135 GoSliceHeaderType []uint
             Operations:
                 - __kind: LocationOp
                   Variable: {subprogram: 87, index: 0, name: xs}
@@ -5275,13 +5275,13 @@ Types:
       HasCount: true
       Element: 17 BaseType int8
     - __kind: ArrayType
-      ID: 134
+      ID: 91
       Name: '[2]map[string]int'
       ByteSize: 16
       GoKind: 17
       Count: 2
       HasCount: true
-      Element: 99 GoMapType map[string]int
+      Element: 76 GoMapType map[string]int
     - __kind: ArrayType
       ID: 38
       Name: '[2]string'
@@ -5334,7 +5334,7 @@ Types:
       HasCount: true
       Element: 3 BaseType uint8
     - __kind: ArrayType
-      ID: 195
+      ID: 233
       Name: '[4]int'
       ByteSize: 32
       GoRuntimeType: 676416
@@ -5343,7 +5343,7 @@ Types:
       HasCount: true
       Element: 7 BaseType int
     - __kind: ArrayType
-      ID: 133
+      ID: 220
       Name: '[4]string'
       ByteSize: 64
       GoRuntimeType: 676704
@@ -5352,7 +5352,7 @@ Types:
       HasCount: true
       Element: 9 GoStringHeaderType string
     - __kind: ArrayType
-      ID: 73
+      ID: 63
       Name: '[5]int'
       ByteSize: 40
       GoKind: 17
@@ -5382,88 +5382,88 @@ Types:
       ByteSize: 2048
       Element: 22 PointerType *string
     - __kind: GoSliceDataType
-      ID: 268
+      ID: 264
       Name: '[]*table<[4]int,[4]int>.array'
       ByteSize: 8192
-      Element: 211 PointerType *table<[4]int,[4]int>
+      Element: 127 PointerType *table<[4]int,[4]int>
     - __kind: GoSliceDataType
-      ID: 266
+      ID: 262
       Name: '[]*table<[4]int,uint8>.array'
       ByteSize: 8192
-      Element: 200 PointerType *table<[4]int,uint8>
+      Element: 122 PointerType *table<[4]int,uint8>
     - __kind: GoSliceDataType
-      ID: 252
+      ID: 250
       Name: '[]*table<[4]string,[2]int>.array'
       ByteSize: 8192
-      Element: 126 PointerType *table<[4]string,[2]int>
+      Element: 90 PointerType *table<[4]string,[2]int>
     - __kind: GoSliceDataType
-      ID: 258
+      ID: 254
       Name: '[]*table<bool,main.node>.array'
       ByteSize: 8192
-      Element: 153 PointerType *table<bool,main.node>
+      Element: 102 PointerType *table<bool,main.node>
     - __kind: GoSliceDataType
       ID: 242
       Name: '[]*table<int,int>.array'
       ByteSize: 8192
-      Element: 80 PointerType *table<int,int>
+      Element: 70 PointerType *table<int,int>
     - __kind: GoSliceDataType
-      ID: 260
+      ID: 256
       Name: '[]*table<int,uint8>.array'
       ByteSize: 8192
-      Element: 166 PointerType *table<int,uint8>
+      Element: 107 PointerType *table<int,uint8>
     - __kind: GoSliceDataType
-      ID: 254
+      ID: 252
       Name: '[]*table<string,[]main.structWithMap>.array'
       ByteSize: 8192
-      Element: 140 PointerType *table<string,[]main.structWithMap>
+      Element: 97 PointerType *table<string,[]main.structWithMap>
     - __kind: GoSliceDataType
       ID: 248
       Name: '[]*table<string,[]string>.array'
       ByteSize: 8192
-      Element: 114 PointerType *table<string,[]string>
+      Element: 85 PointerType *table<string,[]string>
     - __kind: GoSliceDataType
       ID: 246
       Name: '[]*table<string,int>.array'
       ByteSize: 8192
-      Element: 103 PointerType *table<string,int>
+      Element: 80 PointerType *table<string,int>
     - __kind: GoSliceDataType
       ID: 244
       Name: '[]*table<string,main.nestedStruct>.array'
       ByteSize: 8192
-      Element: 91 PointerType *table<string,main.nestedStruct>
+      Element: 75 PointerType *table<string,main.nestedStruct>
     - __kind: GoSliceDataType
-      ID: 264
+      ID: 260
       Name: '[]*table<uint8,[4]int>.array'
       ByteSize: 8192
-      Element: 188 PointerType *table<uint8,[4]int>
+      Element: 117 PointerType *table<uint8,[4]int>
     - __kind: GoSliceDataType
-      ID: 262
+      ID: 258
       Name: '[]*table<uint8,uint8>.array'
       ByteSize: 8192
-      Element: 177 PointerType *table<uint8,uint8>
+      Element: 112 PointerType *table<uint8,uint8>
     - __kind: GoSliceHeaderType
-      ID: 225
+      ID: 136
       Name: '[][]uint'
       ByteSize: 24
       GoKind: 23
       RawFields:
         - Name: array
           Offset: 0
-          Type: 226 PointerType *[]uint
+          Type: 137 PointerType *[]uint
         - Name: len
           Offset: 8
           Type: 7 BaseType int
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 274 GoSliceDataType [][]uint.array
+      Data: 270 GoSliceDataType [][]uint.array
     - __kind: GoSliceDataType
-      ID: 274
+      ID: 270
       Name: '[][]uint.array'
       ByteSize: 2048
-      Element: 224 GoSliceHeaderType []uint
+      Element: 135 GoSliceHeaderType []uint
     - __kind: GoSliceHeaderType
-      ID: 230
+      ID: 142
       Name: '[]bool'
       ByteSize: 24
       GoRuntimeType: 481696
@@ -5478,14 +5478,14 @@ Types:
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 278 GoSliceDataType []bool.array
+      Data: 276 GoSliceDataType []bool.array
     - __kind: GoSliceDataType
-      ID: 278
+      ID: 276
       Name: '[]bool.array'
       ByteSize: 2048
       Element: 4 BaseType bool
     - __kind: GoSliceHeaderType
-      ID: 147
+      ID: 223
       Name: '[]main.structWithMap'
       ByteSize: 24
       GoRuntimeType: 472608
@@ -5493,102 +5493,102 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 148 PointerType *main.structWithMap
+          Type: 224 PointerType *main.structWithMap
         - Name: len
           Offset: 8
           Type: 7 BaseType int
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 256 GoSliceDataType []main.structWithMap.array
+      Data: 280 GoSliceDataType []main.structWithMap.array
     - __kind: GoSliceDataType
-      ID: 256
+      ID: 280
       Name: '[]main.structWithMap.array'
       ByteSize: 2048
-      Element: 75 StructureType main.structWithMap
+      Element: 65 StructureType main.structWithMap
     - __kind: GoSliceHeaderType
-      ID: 227
+      ID: 138
       Name: '[]main.structWithNoStrings'
       ByteSize: 24
       GoKind: 23
       RawFields:
         - Name: array
           Offset: 0
-          Type: 228 PointerType *main.structWithNoStrings
+          Type: 139 PointerType *main.structWithNoStrings
         - Name: len
           Offset: 8
           Type: 7 BaseType int
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 276 GoSliceDataType []main.structWithNoStrings.array
+      Data: 272 GoSliceDataType []main.structWithNoStrings.array
     - __kind: GoSliceDataType
-      ID: 276
+      ID: 272
       Name: '[]main.structWithNoStrings.array'
       ByteSize: 2048
-      Element: 229 StructureType main.structWithNoStrings
+      Element: 140 StructureType main.structWithNoStrings
     - __kind: GoSliceDataType
-      ID: 269
+      ID: 265
       Name: '[]noalg.map.group[[4]int][4]int.array'
       ByteSize: 2048
-      Element: 215 StructureType noalg.map.group[[4]int][4]int
+      Element: 209 StructureType noalg.map.group[[4]int][4]int
     - __kind: GoSliceDataType
-      ID: 267
+      ID: 263
       Name: '[]noalg.map.group[[4]int]uint8.array'
       ByteSize: 2048
-      Element: 204 StructureType noalg.map.group[[4]int]uint8
+      Element: 206 StructureType noalg.map.group[[4]int]uint8
     - __kind: GoSliceDataType
-      ID: 253
+      ID: 251
       Name: '[]noalg.map.group[[4]string][2]int.array'
       ByteSize: 2048
-      Element: 130 StructureType noalg.map.group[[4]string][2]int
+      Element: 188 StructureType noalg.map.group[[4]string][2]int
     - __kind: GoSliceDataType
-      ID: 259
+      ID: 255
       Name: '[]noalg.map.group[bool]main.node.array'
       ByteSize: 2048
-      Element: 157 StructureType noalg.map.group[bool]main.node
+      Element: 194 StructureType noalg.map.group[bool]main.node
     - __kind: GoSliceDataType
       ID: 243
       Name: '[]noalg.map.group[int]int.array'
       ByteSize: 2048
-      Element: 84 StructureType noalg.map.group[int]int
+      Element: 176 StructureType noalg.map.group[int]int
     - __kind: GoSliceDataType
-      ID: 261
+      ID: 257
       Name: '[]noalg.map.group[int]uint8.array'
       ByteSize: 2048
-      Element: 170 StructureType noalg.map.group[int]uint8
+      Element: 197 StructureType noalg.map.group[int]uint8
     - __kind: GoSliceDataType
-      ID: 255
+      ID: 253
       Name: '[]noalg.map.group[string][]main.structWithMap.array'
       ByteSize: 2048
-      Element: 144 StructureType noalg.map.group[string][]main.structWithMap
+      Element: 191 StructureType noalg.map.group[string][]main.structWithMap
     - __kind: GoSliceDataType
       ID: 249
       Name: '[]noalg.map.group[string][]string.array'
       ByteSize: 2048
-      Element: 118 StructureType noalg.map.group[string][]string
+      Element: 185 StructureType noalg.map.group[string][]string
     - __kind: GoSliceDataType
       ID: 247
       Name: '[]noalg.map.group[string]int.array'
       ByteSize: 2048
-      Element: 107 StructureType noalg.map.group[string]int
+      Element: 182 StructureType noalg.map.group[string]int
     - __kind: GoSliceDataType
       ID: 245
       Name: '[]noalg.map.group[string]main.nestedStruct.array'
       ByteSize: 2048
-      Element: 95 StructureType noalg.map.group[string]main.nestedStruct
+      Element: 179 StructureType noalg.map.group[string]main.nestedStruct
     - __kind: GoSliceDataType
-      ID: 265
+      ID: 261
       Name: '[]noalg.map.group[uint8][4]int.array'
       ByteSize: 2048
-      Element: 192 StructureType noalg.map.group[uint8][4]int
+      Element: 203 StructureType noalg.map.group[uint8][4]int
     - __kind: GoSliceDataType
-      ID: 263
+      ID: 259
       Name: '[]noalg.map.group[uint8]uint8.array'
       ByteSize: 2048
-      Element: 181 StructureType noalg.map.group[uint8]uint8
+      Element: 200 StructureType noalg.map.group[uint8]uint8
     - __kind: GoSliceHeaderType
-      ID: 121
+      ID: 141
       Name: '[]string'
       ByteSize: 24
       GoRuntimeType: 481824
@@ -5603,14 +5603,14 @@ Types:
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 250 GoSliceDataType []string.array
+      Data: 274 GoSliceDataType []string.array
     - __kind: GoSliceDataType
-      ID: 250
+      ID: 274
       Name: '[]string.array'
       ByteSize: 2048
       Element: 9 GoStringHeaderType string
     - __kind: GoSliceHeaderType
-      ID: 224
+      ID: 135
       Name: '[]uint'
       ByteSize: 24
       GoRuntimeType: 481312
@@ -5625,14 +5625,14 @@ Types:
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 272 GoSliceDataType []uint.array
+      Data: 268 GoSliceDataType []uint.array
     - __kind: GoSliceDataType
-      ID: 272
+      ID: 268
       Name: '[]uint.array'
       ByteSize: 2048
       Element: 10 BaseType uint
     - __kind: GoSliceHeaderType
-      ID: 231
+      ID: 143
       Name: '[]uint16'
       ByteSize: 24
       GoRuntimeType: 480672
@@ -5647,9 +5647,9 @@ Types:
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 280 GoSliceDataType []uint16.array
+      Data: 278 GoSliceDataType []uint16.array
     - __kind: GoSliceDataType
-      ID: 280
+      ID: 278
       Name: '[]uint16.array'
       ByteSize: 2048
       Element: 6 BaseType uint16
@@ -5660,7 +5660,7 @@ Types:
       GoRuntimeType: 579584
       GoKind: 1
     - __kind: GoChannelType
-      ID: 218
+      ID: 128
       Name: chan bool
       GoRuntimeType: 590912
       GoKind: 18
@@ -5713,173 +5713,173 @@ Types:
       GoRuntimeType: 471584
       GoKind: 19
     - __kind: GoSwissMapGroupsType
-      ID: 213
+      ID: 207
       Name: groupReference<[4]int,[4]int>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 214 PointerType *noalg.map.group[[4]int][4]int
+          Type: 208 PointerType *noalg.map.group[[4]int][4]int
         - Name: lengthMask
           Offset: 8
           Type: 8 BaseType uint64
-      GroupType: 215 StructureType noalg.map.group[[4]int][4]int
-      GroupSliceType: 269 GoSliceDataType []noalg.map.group[[4]int][4]int.array
+      GroupType: 209 StructureType noalg.map.group[[4]int][4]int
+      GroupSliceType: 265 GoSliceDataType []noalg.map.group[[4]int][4]int.array
     - __kind: GoSwissMapGroupsType
-      ID: 202
+      ID: 204
       Name: groupReference<[4]int,uint8>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 203 PointerType *noalg.map.group[[4]int]uint8
+          Type: 205 PointerType *noalg.map.group[[4]int]uint8
         - Name: lengthMask
           Offset: 8
           Type: 8 BaseType uint64
-      GroupType: 204 StructureType noalg.map.group[[4]int]uint8
-      GroupSliceType: 267 GoSliceDataType []noalg.map.group[[4]int]uint8.array
+      GroupType: 206 StructureType noalg.map.group[[4]int]uint8
+      GroupSliceType: 263 GoSliceDataType []noalg.map.group[[4]int]uint8.array
     - __kind: GoSwissMapGroupsType
-      ID: 128
+      ID: 186
       Name: groupReference<[4]string,[2]int>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 129 PointerType *noalg.map.group[[4]string][2]int
+          Type: 187 PointerType *noalg.map.group[[4]string][2]int
         - Name: lengthMask
           Offset: 8
           Type: 8 BaseType uint64
-      GroupType: 130 StructureType noalg.map.group[[4]string][2]int
-      GroupSliceType: 253 GoSliceDataType []noalg.map.group[[4]string][2]int.array
+      GroupType: 188 StructureType noalg.map.group[[4]string][2]int
+      GroupSliceType: 251 GoSliceDataType []noalg.map.group[[4]string][2]int.array
     - __kind: GoSwissMapGroupsType
-      ID: 155
+      ID: 192
       Name: groupReference<bool,main.node>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 156 PointerType *noalg.map.group[bool]main.node
+          Type: 193 PointerType *noalg.map.group[bool]main.node
         - Name: lengthMask
           Offset: 8
           Type: 8 BaseType uint64
-      GroupType: 157 StructureType noalg.map.group[bool]main.node
-      GroupSliceType: 259 GoSliceDataType []noalg.map.group[bool]main.node.array
+      GroupType: 194 StructureType noalg.map.group[bool]main.node
+      GroupSliceType: 255 GoSliceDataType []noalg.map.group[bool]main.node.array
     - __kind: GoSwissMapGroupsType
-      ID: 82
+      ID: 174
       Name: groupReference<int,int>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 83 PointerType *noalg.map.group[int]int
+          Type: 175 PointerType *noalg.map.group[int]int
         - Name: lengthMask
           Offset: 8
           Type: 8 BaseType uint64
-      GroupType: 84 StructureType noalg.map.group[int]int
+      GroupType: 176 StructureType noalg.map.group[int]int
       GroupSliceType: 243 GoSliceDataType []noalg.map.group[int]int.array
     - __kind: GoSwissMapGroupsType
-      ID: 168
+      ID: 195
       Name: groupReference<int,uint8>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 169 PointerType *noalg.map.group[int]uint8
+          Type: 196 PointerType *noalg.map.group[int]uint8
         - Name: lengthMask
           Offset: 8
           Type: 8 BaseType uint64
-      GroupType: 170 StructureType noalg.map.group[int]uint8
-      GroupSliceType: 261 GoSliceDataType []noalg.map.group[int]uint8.array
+      GroupType: 197 StructureType noalg.map.group[int]uint8
+      GroupSliceType: 257 GoSliceDataType []noalg.map.group[int]uint8.array
     - __kind: GoSwissMapGroupsType
-      ID: 142
+      ID: 189
       Name: groupReference<string,[]main.structWithMap>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 143 PointerType *noalg.map.group[string][]main.structWithMap
+          Type: 190 PointerType *noalg.map.group[string][]main.structWithMap
         - Name: lengthMask
           Offset: 8
           Type: 8 BaseType uint64
-      GroupType: 144 StructureType noalg.map.group[string][]main.structWithMap
-      GroupSliceType: 255 GoSliceDataType []noalg.map.group[string][]main.structWithMap.array
+      GroupType: 191 StructureType noalg.map.group[string][]main.structWithMap
+      GroupSliceType: 253 GoSliceDataType []noalg.map.group[string][]main.structWithMap.array
     - __kind: GoSwissMapGroupsType
-      ID: 116
+      ID: 183
       Name: groupReference<string,[]string>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 117 PointerType *noalg.map.group[string][]string
+          Type: 184 PointerType *noalg.map.group[string][]string
         - Name: lengthMask
           Offset: 8
           Type: 8 BaseType uint64
-      GroupType: 118 StructureType noalg.map.group[string][]string
+      GroupType: 185 StructureType noalg.map.group[string][]string
       GroupSliceType: 249 GoSliceDataType []noalg.map.group[string][]string.array
     - __kind: GoSwissMapGroupsType
-      ID: 105
+      ID: 180
       Name: groupReference<string,int>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 106 PointerType *noalg.map.group[string]int
+          Type: 181 PointerType *noalg.map.group[string]int
         - Name: lengthMask
           Offset: 8
           Type: 8 BaseType uint64
-      GroupType: 107 StructureType noalg.map.group[string]int
+      GroupType: 182 StructureType noalg.map.group[string]int
       GroupSliceType: 247 GoSliceDataType []noalg.map.group[string]int.array
     - __kind: GoSwissMapGroupsType
-      ID: 93
+      ID: 177
       Name: groupReference<string,main.nestedStruct>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 94 PointerType *noalg.map.group[string]main.nestedStruct
+          Type: 178 PointerType *noalg.map.group[string]main.nestedStruct
         - Name: lengthMask
           Offset: 8
           Type: 8 BaseType uint64
-      GroupType: 95 StructureType noalg.map.group[string]main.nestedStruct
+      GroupType: 179 StructureType noalg.map.group[string]main.nestedStruct
       GroupSliceType: 245 GoSliceDataType []noalg.map.group[string]main.nestedStruct.array
     - __kind: GoSwissMapGroupsType
-      ID: 190
+      ID: 201
       Name: groupReference<uint8,[4]int>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 191 PointerType *noalg.map.group[uint8][4]int
+          Type: 202 PointerType *noalg.map.group[uint8][4]int
         - Name: lengthMask
           Offset: 8
           Type: 8 BaseType uint64
-      GroupType: 192 StructureType noalg.map.group[uint8][4]int
-      GroupSliceType: 265 GoSliceDataType []noalg.map.group[uint8][4]int.array
+      GroupType: 203 StructureType noalg.map.group[uint8][4]int
+      GroupSliceType: 261 GoSliceDataType []noalg.map.group[uint8][4]int.array
     - __kind: GoSwissMapGroupsType
-      ID: 179
+      ID: 198
       Name: groupReference<uint8,uint8>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 180 PointerType *noalg.map.group[uint8]uint8
+          Type: 199 PointerType *noalg.map.group[uint8]uint8
         - Name: lengthMask
           Offset: 8
           Type: 8 BaseType uint64
-      GroupType: 181 StructureType noalg.map.group[uint8]uint8
-      GroupSliceType: 263 GoSliceDataType []noalg.map.group[uint8]uint8.array
+      GroupType: 200 StructureType noalg.map.group[uint8]uint8
+      GroupSliceType: 259 GoSliceDataType []noalg.map.group[uint8]uint8.array
     - __kind: BaseType
       ID: 7
       Name: int
@@ -5924,7 +5924,7 @@ Types:
           Offset: 8
           Type: 15 VoidPointerType unsafe.Pointer
     - __kind: StructureType
-      ID: 65
+      ID: 153
       Name: internal/sync.Mutex
       ByteSize: 8
       GoRuntimeType: 1.459296e+06
@@ -5950,7 +5950,7 @@ Types:
           Offset: 8
           Type: 15 VoidPointerType unsafe.Pointer
     - __kind: StructureType
-      ID: 236
+      ID: 148
       Name: main.aStruct
       ByteSize: 56
       GoKind: 25
@@ -5966,9 +5966,9 @@ Types:
           Type: 7 BaseType int
         - Name: nested
           Offset: 32
-          Type: 98 StructureType main.nestedStruct
+          Type: 149 StructureType main.nestedStruct
     - __kind: GoInterfaceType
-      ID: 74
+      ID: 64
       Name: main.behavior
       ByteSize: 16
       GoRuntimeType: 1.015648e+06
@@ -5996,7 +5996,7 @@ Types:
           Offset: 32
           Type: 55 GoInterfaceType io.Writer
     - __kind: StructureType
-      ID: 237
+      ID: 150
       Name: main.emptyStruct
       GoKind: 25
       RawFields: []
@@ -6012,16 +6012,16 @@ Types:
           Type: 56 StructureType main.esotericStack
         - Name: mu
           Offset: 64
-          Type: 63 StructureType sync.Mutex
+          Type: 151 StructureType sync.Mutex
         - Name: once
           Offset: 72
-          Type: 66 StructureType sync.Once
+          Type: 154 StructureType sync.Once
         - Name: wg
           Offset: 88
-          Type: 69 StructureType sync.WaitGroup
+          Type: 157 StructureType sync.WaitGroup
         - Name: a
           Offset: 104
-          Type: 72 StructureType sync/atomic.Int32
+          Type: 160 StructureType sync/atomic.Int32
     - __kind: StructureType
       ID: 56
       Name: main.esotericStack
@@ -6051,7 +6051,7 @@ Types:
           Offset: 56
           Type: 60 GoSubroutineType func()
     - __kind: StructureType
-      ID: 98
+      ID: 149
       Name: main.nestedStruct
       ByteSize: 24
       GoRuntimeType: 1.447936e+06
@@ -6064,7 +6064,7 @@ Types:
           Offset: 8
           Type: 9 GoStringHeaderType string
     - __kind: StructureType
-      ID: 160
+      ID: 131
       Name: main.node
       ByteSize: 16
       GoRuntimeType: 1.447776e+06
@@ -6075,9 +6075,9 @@ Types:
           Type: 7 BaseType int
         - Name: b
           Offset: 8
-          Type: 161 PointerType *main.node
+          Type: 132 PointerType *main.node
     - __kind: StructureType
-      ID: 235
+      ID: 147
       Name: main.oneStringStruct
       ByteSize: 16
       GoKind: 25
@@ -6099,7 +6099,7 @@ Types:
           Offset: 8
           Type: 15 VoidPointerType unsafe.Pointer
     - __kind: StructureType
-      ID: 75
+      ID: 65
       Name: main.structWithMap
       ByteSize: 8
       GoRuntimeType: 1.1768e+06
@@ -6107,9 +6107,9 @@ Types:
       RawFields:
         - Name: m
           Offset: 0
-          Type: 76 GoMapType map[int]int
+          Type: 66 GoMapType map[int]int
     - __kind: StructureType
-      ID: 229
+      ID: 140
       Name: main.structWithNoStrings
       ByteSize: 2
       GoKind: 25
@@ -6121,7 +6121,7 @@ Types:
           Offset: 1
           Type: 4 BaseType bool
     - __kind: StructureType
-      ID: 220
+      ID: 130
       Name: main.structWithTwoValues
       ByteSize: 16
       GoKind: 25
@@ -6133,28 +6133,28 @@ Types:
           Offset: 8
           Type: 4 BaseType bool
     - __kind: GoSliceHeaderType
-      ID: 222
+      ID: 134
       Name: main.t
       ByteSize: 24
       GoKind: 23
       RawFields:
         - Name: array
           Offset: 0
-          Type: 223 PointerType **main.t
+          Type: 173 PointerType **main.t
         - Name: len
           Offset: 8
           Type: 7 BaseType int
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 270 GoSliceDataType main.t.array
+      Data: 266 GoSliceDataType main.t.array
     - __kind: GoSliceDataType
-      ID: 270
+      ID: 266
       Name: main.t.array
       ByteSize: 2048
-      Element: 221 PointerType *main.t
+      Element: 133 PointerType *main.t
     - __kind: StructureType
-      ID: 232
+      ID: 144
       Name: main.threeStringStruct
       ByteSize: 48
       GoKind: 25
@@ -6174,7 +6174,7 @@ Types:
       ByteSize: 2
       GoKind: 9
     - __kind: GoSwissMapHeaderType
-      ID: 209
+      ID: 125
       Name: map<[4]int,[4]int>
       ByteSize: 48
       GoKind: 25
@@ -6187,7 +6187,7 @@ Types:
           Type: 1 BaseType uintptr
         - Name: dirPtr
           Offset: 16
-          Type: 210 PointerType **table<[4]int,[4]int>
+          Type: 126 PointerType **table<[4]int,[4]int>
         - Name: dirLen
           Offset: 24
           Type: 7 BaseType int
@@ -6206,10 +6206,10 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 8 BaseType uint64
-      TablePtrSliceType: 268 GoSliceDataType []*table<[4]int,[4]int>.array
-      GroupType: 215 StructureType noalg.map.group[[4]int][4]int
+      TablePtrSliceType: 264 GoSliceDataType []*table<[4]int,[4]int>.array
+      GroupType: 209 StructureType noalg.map.group[[4]int][4]int
     - __kind: GoSwissMapHeaderType
-      ID: 198
+      ID: 120
       Name: map<[4]int,uint8>
       ByteSize: 48
       GoKind: 25
@@ -6222,7 +6222,7 @@ Types:
           Type: 1 BaseType uintptr
         - Name: dirPtr
           Offset: 16
-          Type: 199 PointerType **table<[4]int,uint8>
+          Type: 121 PointerType **table<[4]int,uint8>
         - Name: dirLen
           Offset: 24
           Type: 7 BaseType int
@@ -6241,10 +6241,10 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 8 BaseType uint64
-      TablePtrSliceType: 266 GoSliceDataType []*table<[4]int,uint8>.array
-      GroupType: 204 StructureType noalg.map.group[[4]int]uint8
+      TablePtrSliceType: 262 GoSliceDataType []*table<[4]int,uint8>.array
+      GroupType: 206 StructureType noalg.map.group[[4]int]uint8
     - __kind: GoSwissMapHeaderType
-      ID: 124
+      ID: 88
       Name: map<[4]string,[2]int>
       ByteSize: 48
       GoKind: 25
@@ -6257,7 +6257,7 @@ Types:
           Type: 1 BaseType uintptr
         - Name: dirPtr
           Offset: 16
-          Type: 125 PointerType **table<[4]string,[2]int>
+          Type: 89 PointerType **table<[4]string,[2]int>
         - Name: dirLen
           Offset: 24
           Type: 7 BaseType int
@@ -6276,10 +6276,10 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 8 BaseType uint64
-      TablePtrSliceType: 252 GoSliceDataType []*table<[4]string,[2]int>.array
-      GroupType: 130 StructureType noalg.map.group[[4]string][2]int
+      TablePtrSliceType: 250 GoSliceDataType []*table<[4]string,[2]int>.array
+      GroupType: 188 StructureType noalg.map.group[[4]string][2]int
     - __kind: GoSwissMapHeaderType
-      ID: 151
+      ID: 100
       Name: map<bool,main.node>
       ByteSize: 48
       GoKind: 25
@@ -6292,7 +6292,7 @@ Types:
           Type: 1 BaseType uintptr
         - Name: dirPtr
           Offset: 16
-          Type: 152 PointerType **table<bool,main.node>
+          Type: 101 PointerType **table<bool,main.node>
         - Name: dirLen
           Offset: 24
           Type: 7 BaseType int
@@ -6311,10 +6311,10 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 8 BaseType uint64
-      TablePtrSliceType: 258 GoSliceDataType []*table<bool,main.node>.array
-      GroupType: 157 StructureType noalg.map.group[bool]main.node
+      TablePtrSliceType: 254 GoSliceDataType []*table<bool,main.node>.array
+      GroupType: 194 StructureType noalg.map.group[bool]main.node
     - __kind: GoSwissMapHeaderType
-      ID: 78
+      ID: 68
       Name: map<int,int>
       ByteSize: 48
       GoKind: 25
@@ -6327,7 +6327,7 @@ Types:
           Type: 1 BaseType uintptr
         - Name: dirPtr
           Offset: 16
-          Type: 79 PointerType **table<int,int>
+          Type: 69 PointerType **table<int,int>
         - Name: dirLen
           Offset: 24
           Type: 7 BaseType int
@@ -6347,9 +6347,9 @@ Types:
           Offset: 40
           Type: 8 BaseType uint64
       TablePtrSliceType: 242 GoSliceDataType []*table<int,int>.array
-      GroupType: 84 StructureType noalg.map.group[int]int
+      GroupType: 176 StructureType noalg.map.group[int]int
     - __kind: GoSwissMapHeaderType
-      ID: 164
+      ID: 105
       Name: map<int,uint8>
       ByteSize: 48
       GoKind: 25
@@ -6362,7 +6362,7 @@ Types:
           Type: 1 BaseType uintptr
         - Name: dirPtr
           Offset: 16
-          Type: 165 PointerType **table<int,uint8>
+          Type: 106 PointerType **table<int,uint8>
         - Name: dirLen
           Offset: 24
           Type: 7 BaseType int
@@ -6381,10 +6381,10 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 8 BaseType uint64
-      TablePtrSliceType: 260 GoSliceDataType []*table<int,uint8>.array
-      GroupType: 170 StructureType noalg.map.group[int]uint8
+      TablePtrSliceType: 256 GoSliceDataType []*table<int,uint8>.array
+      GroupType: 197 StructureType noalg.map.group[int]uint8
     - __kind: GoSwissMapHeaderType
-      ID: 138
+      ID: 95
       Name: map<string,[]main.structWithMap>
       ByteSize: 48
       GoKind: 25
@@ -6397,7 +6397,7 @@ Types:
           Type: 1 BaseType uintptr
         - Name: dirPtr
           Offset: 16
-          Type: 139 PointerType **table<string,[]main.structWithMap>
+          Type: 96 PointerType **table<string,[]main.structWithMap>
         - Name: dirLen
           Offset: 24
           Type: 7 BaseType int
@@ -6416,10 +6416,10 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 8 BaseType uint64
-      TablePtrSliceType: 254 GoSliceDataType []*table<string,[]main.structWithMap>.array
-      GroupType: 144 StructureType noalg.map.group[string][]main.structWithMap
+      TablePtrSliceType: 252 GoSliceDataType []*table<string,[]main.structWithMap>.array
+      GroupType: 191 StructureType noalg.map.group[string][]main.structWithMap
     - __kind: GoSwissMapHeaderType
-      ID: 112
+      ID: 83
       Name: map<string,[]string>
       ByteSize: 48
       GoKind: 25
@@ -6432,7 +6432,7 @@ Types:
           Type: 1 BaseType uintptr
         - Name: dirPtr
           Offset: 16
-          Type: 113 PointerType **table<string,[]string>
+          Type: 84 PointerType **table<string,[]string>
         - Name: dirLen
           Offset: 24
           Type: 7 BaseType int
@@ -6452,9 +6452,9 @@ Types:
           Offset: 40
           Type: 8 BaseType uint64
       TablePtrSliceType: 248 GoSliceDataType []*table<string,[]string>.array
-      GroupType: 118 StructureType noalg.map.group[string][]string
+      GroupType: 185 StructureType noalg.map.group[string][]string
     - __kind: GoSwissMapHeaderType
-      ID: 101
+      ID: 78
       Name: map<string,int>
       ByteSize: 48
       GoKind: 25
@@ -6467,7 +6467,7 @@ Types:
           Type: 1 BaseType uintptr
         - Name: dirPtr
           Offset: 16
-          Type: 102 PointerType **table<string,int>
+          Type: 79 PointerType **table<string,int>
         - Name: dirLen
           Offset: 24
           Type: 7 BaseType int
@@ -6487,9 +6487,9 @@ Types:
           Offset: 40
           Type: 8 BaseType uint64
       TablePtrSliceType: 246 GoSliceDataType []*table<string,int>.array
-      GroupType: 107 StructureType noalg.map.group[string]int
+      GroupType: 182 StructureType noalg.map.group[string]int
     - __kind: GoSwissMapHeaderType
-      ID: 89
+      ID: 73
       Name: map<string,main.nestedStruct>
       ByteSize: 48
       GoKind: 25
@@ -6502,7 +6502,7 @@ Types:
           Type: 1 BaseType uintptr
         - Name: dirPtr
           Offset: 16
-          Type: 90 PointerType **table<string,main.nestedStruct>
+          Type: 74 PointerType **table<string,main.nestedStruct>
         - Name: dirLen
           Offset: 24
           Type: 7 BaseType int
@@ -6522,9 +6522,9 @@ Types:
           Offset: 40
           Type: 8 BaseType uint64
       TablePtrSliceType: 244 GoSliceDataType []*table<string,main.nestedStruct>.array
-      GroupType: 95 StructureType noalg.map.group[string]main.nestedStruct
+      GroupType: 179 StructureType noalg.map.group[string]main.nestedStruct
     - __kind: GoSwissMapHeaderType
-      ID: 186
+      ID: 115
       Name: map<uint8,[4]int>
       ByteSize: 48
       GoKind: 25
@@ -6537,7 +6537,7 @@ Types:
           Type: 1 BaseType uintptr
         - Name: dirPtr
           Offset: 16
-          Type: 187 PointerType **table<uint8,[4]int>
+          Type: 116 PointerType **table<uint8,[4]int>
         - Name: dirLen
           Offset: 24
           Type: 7 BaseType int
@@ -6556,10 +6556,10 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 8 BaseType uint64
-      TablePtrSliceType: 264 GoSliceDataType []*table<uint8,[4]int>.array
-      GroupType: 192 StructureType noalg.map.group[uint8][4]int
+      TablePtrSliceType: 260 GoSliceDataType []*table<uint8,[4]int>.array
+      GroupType: 203 StructureType noalg.map.group[uint8][4]int
     - __kind: GoSwissMapHeaderType
-      ID: 175
+      ID: 110
       Name: map<uint8,uint8>
       ByteSize: 48
       GoKind: 25
@@ -6572,7 +6572,7 @@ Types:
           Type: 1 BaseType uintptr
         - Name: dirPtr
           Offset: 16
-          Type: 176 PointerType **table<uint8,uint8>
+          Type: 111 PointerType **table<uint8,uint8>
         - Name: dirLen
           Offset: 24
           Type: 7 BaseType int
@@ -6591,202 +6591,202 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 8 BaseType uint64
-      TablePtrSliceType: 262 GoSliceDataType []*table<uint8,uint8>.array
-      GroupType: 181 StructureType noalg.map.group[uint8]uint8
+      TablePtrSliceType: 258 GoSliceDataType []*table<uint8,uint8>.array
+      GroupType: 200 StructureType noalg.map.group[uint8]uint8
     - __kind: GoMapType
-      ID: 207
+      ID: 123
       Name: map[[4]int][4]int
       ByteSize: 8
       GoRuntimeType: 1.121696e+06
       GoKind: 21
-      HeaderType: 209 GoSwissMapHeaderType map<[4]int,[4]int>
+      HeaderType: 125 GoSwissMapHeaderType map<[4]int,[4]int>
     - __kind: GoMapType
-      ID: 196
+      ID: 118
       Name: map[[4]int]uint8
       ByteSize: 8
       GoRuntimeType: 1.121824e+06
       GoKind: 21
-      HeaderType: 198 GoSwissMapHeaderType map<[4]int,uint8>
+      HeaderType: 120 GoSwissMapHeaderType map<[4]int,uint8>
     - __kind: GoMapType
-      ID: 122
+      ID: 86
       Name: map[[4]string][2]int
       ByteSize: 8
       GoRuntimeType: 1.121952e+06
       GoKind: 21
-      HeaderType: 124 GoSwissMapHeaderType map<[4]string,[2]int>
+      HeaderType: 88 GoSwissMapHeaderType map<[4]string,[2]int>
     - __kind: GoMapType
-      ID: 149
+      ID: 98
       Name: map[bool]main.node
       ByteSize: 8
       GoRuntimeType: 1.12208e+06
       GoKind: 21
-      HeaderType: 151 GoSwissMapHeaderType map<bool,main.node>
+      HeaderType: 100 GoSwissMapHeaderType map<bool,main.node>
     - __kind: GoMapType
-      ID: 76
+      ID: 66
       Name: map[int]int
       ByteSize: 8
       GoRuntimeType: 1.121312e+06
       GoKind: 21
-      HeaderType: 78 GoSwissMapHeaderType map<int,int>
+      HeaderType: 68 GoSwissMapHeaderType map<int,int>
     - __kind: GoMapType
-      ID: 162
+      ID: 103
       Name: map[int]uint8
       ByteSize: 8
       GoRuntimeType: 1.122208e+06
       GoKind: 21
-      HeaderType: 164 GoSwissMapHeaderType map<int,uint8>
+      HeaderType: 105 GoSwissMapHeaderType map<int,uint8>
     - __kind: GoMapType
-      ID: 136
+      ID: 93
       Name: map[string][]main.structWithMap
       ByteSize: 8
       GoRuntimeType: 1.122336e+06
       GoKind: 21
-      HeaderType: 138 GoSwissMapHeaderType map<string,[]main.structWithMap>
+      HeaderType: 95 GoSwissMapHeaderType map<string,[]main.structWithMap>
     - __kind: GoMapType
-      ID: 110
+      ID: 81
       Name: map[string][]string
       ByteSize: 8
       GoRuntimeType: 1.122464e+06
       GoKind: 21
-      HeaderType: 112 GoSwissMapHeaderType map<string,[]string>
+      HeaderType: 83 GoSwissMapHeaderType map<string,[]string>
     - __kind: GoMapType
-      ID: 99
+      ID: 76
       Name: map[string]int
       ByteSize: 8
       GoRuntimeType: 1.122592e+06
       GoKind: 21
-      HeaderType: 101 GoSwissMapHeaderType map<string,int>
+      HeaderType: 78 GoSwissMapHeaderType map<string,int>
     - __kind: GoMapType
-      ID: 87
+      ID: 71
       Name: map[string]main.nestedStruct
       ByteSize: 8
       GoRuntimeType: 1.12272e+06
       GoKind: 21
-      HeaderType: 89 GoSwissMapHeaderType map<string,main.nestedStruct>
+      HeaderType: 73 GoSwissMapHeaderType map<string,main.nestedStruct>
     - __kind: GoMapType
-      ID: 184
+      ID: 113
       Name: map[uint8][4]int
       ByteSize: 8
       GoRuntimeType: 1.122848e+06
       GoKind: 21
-      HeaderType: 186 GoSwissMapHeaderType map<uint8,[4]int>
+      HeaderType: 115 GoSwissMapHeaderType map<uint8,[4]int>
     - __kind: GoMapType
-      ID: 173
+      ID: 108
       Name: map[uint8]uint8
       ByteSize: 8
       GoRuntimeType: 1.122976e+06
       GoKind: 21
-      HeaderType: 175 GoSwissMapHeaderType map<uint8,uint8>
+      HeaderType: 110 GoSwissMapHeaderType map<uint8,uint8>
     - __kind: ArrayType
-      ID: 216
+      ID: 236
       Name: noalg.[8]struct { key [4]int; elem [4]int }
       ByteSize: 512
       GoRuntimeType: 676512
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 217 StructureType noalg.struct { key [4]int; elem [4]int }
+      Element: 237 StructureType noalg.struct { key [4]int; elem [4]int }
     - __kind: ArrayType
-      ID: 205
+      ID: 234
       Name: noalg.[8]struct { key [4]int; elem uint8 }
       ByteSize: 320
       GoRuntimeType: 676608
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 206 StructureType noalg.struct { key [4]int; elem uint8 }
+      Element: 235 StructureType noalg.struct { key [4]int; elem uint8 }
     - __kind: ArrayType
-      ID: 131
+      ID: 218
       Name: noalg.[8]struct { key [4]string; elem [2]int }
       ByteSize: 640
       GoRuntimeType: 676896
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 132 StructureType noalg.struct { key [4]string; elem [2]int }
+      Element: 219 StructureType noalg.struct { key [4]string; elem [2]int }
     - __kind: ArrayType
-      ID: 158
+      ID: 225
       Name: noalg.[8]struct { key bool; elem main.node }
       ByteSize: 192
       GoRuntimeType: 676992
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 159 StructureType noalg.struct { key bool; elem main.node }
+      Element: 226 StructureType noalg.struct { key bool; elem main.node }
     - __kind: ArrayType
-      ID: 85
+      ID: 210
       Name: noalg.[8]struct { key int; elem int }
       ByteSize: 128
       GoRuntimeType: 674784
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 86 StructureType noalg.struct { key int; elem int }
+      Element: 211 StructureType noalg.struct { key int; elem int }
     - __kind: ArrayType
-      ID: 171
+      ID: 227
       Name: noalg.[8]struct { key int; elem uint8 }
       ByteSize: 128
       GoRuntimeType: 677088
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 172 StructureType noalg.struct { key int; elem uint8 }
+      Element: 228 StructureType noalg.struct { key int; elem uint8 }
     - __kind: ArrayType
-      ID: 145
+      ID: 221
       Name: noalg.[8]struct { key string; elem []main.structWithMap }
       ByteSize: 320
       GoRuntimeType: 677184
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 146 StructureType noalg.struct { key string; elem []main.structWithMap }
+      Element: 222 StructureType noalg.struct { key string; elem []main.structWithMap }
     - __kind: ArrayType
-      ID: 119
+      ID: 216
       Name: noalg.[8]struct { key string; elem []string }
       ByteSize: 320
       GoRuntimeType: 677280
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 120 StructureType noalg.struct { key string; elem []string }
+      Element: 217 StructureType noalg.struct { key string; elem []string }
     - __kind: ArrayType
-      ID: 108
+      ID: 214
       Name: noalg.[8]struct { key string; elem int }
       ByteSize: 192
       GoRuntimeType: 677376
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 109 StructureType noalg.struct { key string; elem int }
+      Element: 215 StructureType noalg.struct { key string; elem int }
     - __kind: ArrayType
-      ID: 96
+      ID: 212
       Name: noalg.[8]struct { key string; elem main.nestedStruct }
       ByteSize: 320
       GoRuntimeType: 677472
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 97 StructureType noalg.struct { key string; elem main.nestedStruct }
+      Element: 213 StructureType noalg.struct { key string; elem main.nestedStruct }
     - __kind: ArrayType
-      ID: 193
+      ID: 231
       Name: noalg.[8]struct { key uint8; elem [4]int }
       ByteSize: 320
       GoRuntimeType: 677568
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 194 StructureType noalg.struct { key uint8; elem [4]int }
+      Element: 232 StructureType noalg.struct { key uint8; elem [4]int }
     - __kind: ArrayType
-      ID: 182
+      ID: 229
       Name: noalg.[8]struct { key uint8; elem uint8 }
       ByteSize: 16
       GoRuntimeType: 677664
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 183 StructureType noalg.struct { key uint8; elem uint8 }
+      Element: 230 StructureType noalg.struct { key uint8; elem uint8 }
     - __kind: StructureType
-      ID: 215
+      ID: 209
       Name: noalg.map.group[[4]int][4]int
       ByteSize: 520
       GoRuntimeType: 1.281056e+06
@@ -6797,9 +6797,9 @@ Types:
           Type: 8 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 216 ArrayType noalg.[8]struct { key [4]int; elem [4]int }
+          Type: 236 ArrayType noalg.[8]struct { key [4]int; elem [4]int }
     - __kind: StructureType
-      ID: 204
+      ID: 206
       Name: noalg.map.group[[4]int]uint8
       ByteSize: 328
       GoRuntimeType: 1.281312e+06
@@ -6810,9 +6810,9 @@ Types:
           Type: 8 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 205 ArrayType noalg.[8]struct { key [4]int; elem uint8 }
+          Type: 234 ArrayType noalg.[8]struct { key [4]int; elem uint8 }
     - __kind: StructureType
-      ID: 130
+      ID: 188
       Name: noalg.map.group[[4]string][2]int
       ByteSize: 648
       GoRuntimeType: 1.281568e+06
@@ -6823,9 +6823,9 @@ Types:
           Type: 8 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 131 ArrayType noalg.[8]struct { key [4]string; elem [2]int }
+          Type: 218 ArrayType noalg.[8]struct { key [4]string; elem [2]int }
     - __kind: StructureType
-      ID: 157
+      ID: 194
       Name: noalg.map.group[bool]main.node
       ByteSize: 200
       GoRuntimeType: 1.281824e+06
@@ -6836,9 +6836,9 @@ Types:
           Type: 8 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 158 ArrayType noalg.[8]struct { key bool; elem main.node }
+          Type: 225 ArrayType noalg.[8]struct { key bool; elem main.node }
     - __kind: StructureType
-      ID: 84
+      ID: 176
       Name: noalg.map.group[int]int
       ByteSize: 136
       GoRuntimeType: 1.280288e+06
@@ -6849,9 +6849,9 @@ Types:
           Type: 8 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 85 ArrayType noalg.[8]struct { key int; elem int }
+          Type: 210 ArrayType noalg.[8]struct { key int; elem int }
     - __kind: StructureType
-      ID: 170
+      ID: 197
       Name: noalg.map.group[int]uint8
       ByteSize: 136
       GoRuntimeType: 1.28208e+06
@@ -6862,9 +6862,9 @@ Types:
           Type: 8 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 171 ArrayType noalg.[8]struct { key int; elem uint8 }
+          Type: 227 ArrayType noalg.[8]struct { key int; elem uint8 }
     - __kind: StructureType
-      ID: 144
+      ID: 191
       Name: noalg.map.group[string][]main.structWithMap
       ByteSize: 328
       GoRuntimeType: 1.282336e+06
@@ -6875,9 +6875,9 @@ Types:
           Type: 8 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 145 ArrayType noalg.[8]struct { key string; elem []main.structWithMap }
+          Type: 221 ArrayType noalg.[8]struct { key string; elem []main.structWithMap }
     - __kind: StructureType
-      ID: 118
+      ID: 185
       Name: noalg.map.group[string][]string
       ByteSize: 328
       GoRuntimeType: 1.282592e+06
@@ -6888,9 +6888,9 @@ Types:
           Type: 8 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 119 ArrayType noalg.[8]struct { key string; elem []string }
+          Type: 216 ArrayType noalg.[8]struct { key string; elem []string }
     - __kind: StructureType
-      ID: 107
+      ID: 182
       Name: noalg.map.group[string]int
       ByteSize: 200
       GoRuntimeType: 1.282848e+06
@@ -6901,9 +6901,9 @@ Types:
           Type: 8 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 108 ArrayType noalg.[8]struct { key string; elem int }
+          Type: 214 ArrayType noalg.[8]struct { key string; elem int }
     - __kind: StructureType
-      ID: 95
+      ID: 179
       Name: noalg.map.group[string]main.nestedStruct
       ByteSize: 328
       GoRuntimeType: 1.283104e+06
@@ -6914,9 +6914,9 @@ Types:
           Type: 8 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 96 ArrayType noalg.[8]struct { key string; elem main.nestedStruct }
+          Type: 212 ArrayType noalg.[8]struct { key string; elem main.nestedStruct }
     - __kind: StructureType
-      ID: 192
+      ID: 203
       Name: noalg.map.group[uint8][4]int
       ByteSize: 328
       GoRuntimeType: 1.28336e+06
@@ -6927,9 +6927,9 @@ Types:
           Type: 8 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 193 ArrayType noalg.[8]struct { key uint8; elem [4]int }
+          Type: 231 ArrayType noalg.[8]struct { key uint8; elem [4]int }
     - __kind: StructureType
-      ID: 181
+      ID: 200
       Name: noalg.map.group[uint8]uint8
       ByteSize: 24
       GoRuntimeType: 1.283616e+06
@@ -6940,9 +6940,9 @@ Types:
           Type: 8 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 182 ArrayType noalg.[8]struct { key uint8; elem uint8 }
+          Type: 229 ArrayType noalg.[8]struct { key uint8; elem uint8 }
     - __kind: StructureType
-      ID: 217
+      ID: 237
       Name: noalg.struct { key [4]int; elem [4]int }
       ByteSize: 64
       GoRuntimeType: 1.280928e+06
@@ -6950,12 +6950,12 @@ Types:
       RawFields:
         - Name: key
           Offset: 0
-          Type: 195 ArrayType [4]int
+          Type: 233 ArrayType [4]int
         - Name: elem
           Offset: 32
-          Type: 195 ArrayType [4]int
+          Type: 233 ArrayType [4]int
     - __kind: StructureType
-      ID: 206
+      ID: 235
       Name: noalg.struct { key [4]int; elem uint8 }
       ByteSize: 40
       GoRuntimeType: 1.281184e+06
@@ -6963,12 +6963,12 @@ Types:
       RawFields:
         - Name: key
           Offset: 0
-          Type: 195 ArrayType [4]int
+          Type: 233 ArrayType [4]int
         - Name: elem
           Offset: 32
           Type: 3 BaseType uint8
     - __kind: StructureType
-      ID: 132
+      ID: 219
       Name: noalg.struct { key [4]string; elem [2]int }
       ByteSize: 80
       GoRuntimeType: 1.28144e+06
@@ -6976,12 +6976,12 @@ Types:
       RawFields:
         - Name: key
           Offset: 0
-          Type: 133 ArrayType [4]string
+          Type: 220 ArrayType [4]string
         - Name: elem
           Offset: 64
           Type: 40 ArrayType [2]int
     - __kind: StructureType
-      ID: 159
+      ID: 226
       Name: noalg.struct { key bool; elem main.node }
       ByteSize: 24
       GoRuntimeType: 1.281696e+06
@@ -6992,9 +6992,9 @@ Types:
           Type: 4 BaseType bool
         - Name: elem
           Offset: 8
-          Type: 160 StructureType main.node
+          Type: 131 StructureType main.node
     - __kind: StructureType
-      ID: 86
+      ID: 211
       Name: noalg.struct { key int; elem int }
       ByteSize: 16
       GoRuntimeType: 1.28016e+06
@@ -7007,7 +7007,7 @@ Types:
           Offset: 8
           Type: 7 BaseType int
     - __kind: StructureType
-      ID: 172
+      ID: 228
       Name: noalg.struct { key int; elem uint8 }
       ByteSize: 16
       GoRuntimeType: 1.281952e+06
@@ -7020,7 +7020,7 @@ Types:
           Offset: 8
           Type: 3 BaseType uint8
     - __kind: StructureType
-      ID: 146
+      ID: 222
       Name: noalg.struct { key string; elem []main.structWithMap }
       ByteSize: 40
       GoRuntimeType: 1.282208e+06
@@ -7031,9 +7031,9 @@ Types:
           Type: 9 GoStringHeaderType string
         - Name: elem
           Offset: 16
-          Type: 147 GoSliceHeaderType []main.structWithMap
+          Type: 223 GoSliceHeaderType []main.structWithMap
     - __kind: StructureType
-      ID: 120
+      ID: 217
       Name: noalg.struct { key string; elem []string }
       ByteSize: 40
       GoRuntimeType: 1.282464e+06
@@ -7044,9 +7044,9 @@ Types:
           Type: 9 GoStringHeaderType string
         - Name: elem
           Offset: 16
-          Type: 121 GoSliceHeaderType []string
+          Type: 141 GoSliceHeaderType []string
     - __kind: StructureType
-      ID: 109
+      ID: 215
       Name: noalg.struct { key string; elem int }
       ByteSize: 24
       GoRuntimeType: 1.28272e+06
@@ -7059,7 +7059,7 @@ Types:
           Offset: 16
           Type: 7 BaseType int
     - __kind: StructureType
-      ID: 97
+      ID: 213
       Name: noalg.struct { key string; elem main.nestedStruct }
       ByteSize: 40
       GoRuntimeType: 1.282976e+06
@@ -7070,9 +7070,9 @@ Types:
           Type: 9 GoStringHeaderType string
         - Name: elem
           Offset: 16
-          Type: 98 StructureType main.nestedStruct
+          Type: 149 StructureType main.nestedStruct
     - __kind: StructureType
-      ID: 194
+      ID: 232
       Name: noalg.struct { key uint8; elem [4]int }
       ByteSize: 40
       GoRuntimeType: 1.283232e+06
@@ -7083,9 +7083,9 @@ Types:
           Type: 3 BaseType uint8
         - Name: elem
           Offset: 8
-          Type: 195 ArrayType [4]int
+          Type: 233 ArrayType [4]int
     - __kind: StructureType
-      ID: 183
+      ID: 230
       Name: noalg.struct { key uint8; elem uint8 }
       ByteSize: 2
       GoRuntimeType: 1.283488e+06
@@ -7116,7 +7116,7 @@ Types:
       Name: string.str
       ByteSize: 2048
     - __kind: StructureType
-      ID: 63
+      ID: 151
       Name: sync.Mutex
       ByteSize: 8
       GoRuntimeType: 1.449216e+06
@@ -7124,12 +7124,12 @@ Types:
       RawFields:
         - Name: _
           Offset: 0
-          Type: 64 StructureType sync.noCopy
+          Type: 152 StructureType sync.noCopy
         - Name: mu
           Offset: 0
-          Type: 65 StructureType internal/sync.Mutex
+          Type: 153 StructureType internal/sync.Mutex
     - __kind: StructureType
-      ID: 66
+      ID: 154
       Name: sync.Once
       ByteSize: 12
       GoRuntimeType: 1.598272e+06
@@ -7137,15 +7137,15 @@ Types:
       RawFields:
         - Name: _
           Offset: 0
-          Type: 64 StructureType sync.noCopy
+          Type: 152 StructureType sync.noCopy
         - Name: done
           Offset: 0
-          Type: 67 StructureType sync/atomic.Bool
+          Type: 155 StructureType sync/atomic.Bool
         - Name: m
           Offset: 4
-          Type: 63 StructureType sync.Mutex
+          Type: 151 StructureType sync.Mutex
     - __kind: StructureType
-      ID: 69
+      ID: 157
       Name: sync.WaitGroup
       ByteSize: 16
       GoRuntimeType: 1.59808e+06
@@ -7153,21 +7153,21 @@ Types:
       RawFields:
         - Name: noCopy
           Offset: 0
-          Type: 64 StructureType sync.noCopy
+          Type: 152 StructureType sync.noCopy
         - Name: state
           Offset: 0
-          Type: 70 StructureType sync/atomic.Uint64
+          Type: 158 StructureType sync/atomic.Uint64
         - Name: sema
           Offset: 8
           Type: 2 BaseType uint32
     - __kind: StructureType
-      ID: 64
+      ID: 152
       Name: sync.noCopy
       GoRuntimeType: 981440
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 67
+      ID: 155
       Name: sync/atomic.Bool
       ByteSize: 4
       GoRuntimeType: 1.450336e+06
@@ -7175,12 +7175,12 @@ Types:
       RawFields:
         - Name: _
           Offset: 0
-          Type: 68 StructureType sync/atomic.noCopy
+          Type: 156 StructureType sync/atomic.noCopy
         - Name: v
           Offset: 0
           Type: 2 BaseType uint32
     - __kind: StructureType
-      ID: 72
+      ID: 160
       Name: sync/atomic.Int32
       ByteSize: 4
       GoRuntimeType: 1.450496e+06
@@ -7188,12 +7188,12 @@ Types:
       RawFields:
         - Name: _
           Offset: 0
-          Type: 68 StructureType sync/atomic.noCopy
+          Type: 156 StructureType sync/atomic.noCopy
         - Name: v
           Offset: 0
           Type: 12 BaseType int32
     - __kind: StructureType
-      ID: 70
+      ID: 158
       Name: sync/atomic.Uint64
       ByteSize: 8
       GoRuntimeType: 1.598656e+06
@@ -7201,27 +7201,27 @@ Types:
       RawFields:
         - Name: _
           Offset: 0
-          Type: 68 StructureType sync/atomic.noCopy
+          Type: 156 StructureType sync/atomic.noCopy
         - Name: _
           Offset: 0
-          Type: 71 StructureType sync/atomic.align64
+          Type: 159 StructureType sync/atomic.align64
         - Name: v
           Offset: 0
           Type: 8 BaseType uint64
     - __kind: StructureType
-      ID: 71
+      ID: 159
       Name: sync/atomic.align64
       GoRuntimeType: 981632
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 68
+      ID: 156
       Name: sync/atomic.noCopy
       GoRuntimeType: 981536
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 212
+      ID: 172
       Name: table<[4]int,[4]int>
       ByteSize: 32
       GoKind: 25
@@ -7243,9 +7243,9 @@ Types:
           Type: 7 BaseType int
         - Name: groups
           Offset: 16
-          Type: 213 GoSwissMapGroupsType groupReference<[4]int,[4]int>
+          Type: 207 GoSwissMapGroupsType groupReference<[4]int,[4]int>
     - __kind: StructureType
-      ID: 201
+      ID: 171
       Name: table<[4]int,uint8>
       ByteSize: 32
       GoKind: 25
@@ -7267,9 +7267,9 @@ Types:
           Type: 7 BaseType int
         - Name: groups
           Offset: 16
-          Type: 202 GoSwissMapGroupsType groupReference<[4]int,uint8>
+          Type: 204 GoSwissMapGroupsType groupReference<[4]int,uint8>
     - __kind: StructureType
-      ID: 127
+      ID: 165
       Name: table<[4]string,[2]int>
       ByteSize: 32
       GoKind: 25
@@ -7291,9 +7291,9 @@ Types:
           Type: 7 BaseType int
         - Name: groups
           Offset: 16
-          Type: 128 GoSwissMapGroupsType groupReference<[4]string,[2]int>
+          Type: 186 GoSwissMapGroupsType groupReference<[4]string,[2]int>
     - __kind: StructureType
-      ID: 154
+      ID: 167
       Name: table<bool,main.node>
       ByteSize: 32
       GoKind: 25
@@ -7315,9 +7315,9 @@ Types:
           Type: 7 BaseType int
         - Name: groups
           Offset: 16
-          Type: 155 GoSwissMapGroupsType groupReference<bool,main.node>
+          Type: 192 GoSwissMapGroupsType groupReference<bool,main.node>
     - __kind: StructureType
-      ID: 81
+      ID: 161
       Name: table<int,int>
       ByteSize: 32
       GoKind: 25
@@ -7339,9 +7339,9 @@ Types:
           Type: 7 BaseType int
         - Name: groups
           Offset: 16
-          Type: 82 GoSwissMapGroupsType groupReference<int,int>
+          Type: 174 GoSwissMapGroupsType groupReference<int,int>
     - __kind: StructureType
-      ID: 167
+      ID: 168
       Name: table<int,uint8>
       ByteSize: 32
       GoKind: 25
@@ -7363,9 +7363,9 @@ Types:
           Type: 7 BaseType int
         - Name: groups
           Offset: 16
-          Type: 168 GoSwissMapGroupsType groupReference<int,uint8>
+          Type: 195 GoSwissMapGroupsType groupReference<int,uint8>
     - __kind: StructureType
-      ID: 141
+      ID: 166
       Name: table<string,[]main.structWithMap>
       ByteSize: 32
       GoKind: 25
@@ -7387,9 +7387,9 @@ Types:
           Type: 7 BaseType int
         - Name: groups
           Offset: 16
-          Type: 142 GoSwissMapGroupsType groupReference<string,[]main.structWithMap>
+          Type: 189 GoSwissMapGroupsType groupReference<string,[]main.structWithMap>
     - __kind: StructureType
-      ID: 115
+      ID: 164
       Name: table<string,[]string>
       ByteSize: 32
       GoKind: 25
@@ -7411,9 +7411,9 @@ Types:
           Type: 7 BaseType int
         - Name: groups
           Offset: 16
-          Type: 116 GoSwissMapGroupsType groupReference<string,[]string>
+          Type: 183 GoSwissMapGroupsType groupReference<string,[]string>
     - __kind: StructureType
-      ID: 104
+      ID: 163
       Name: table<string,int>
       ByteSize: 32
       GoKind: 25
@@ -7435,9 +7435,9 @@ Types:
           Type: 7 BaseType int
         - Name: groups
           Offset: 16
-          Type: 105 GoSwissMapGroupsType groupReference<string,int>
+          Type: 180 GoSwissMapGroupsType groupReference<string,int>
     - __kind: StructureType
-      ID: 92
+      ID: 162
       Name: table<string,main.nestedStruct>
       ByteSize: 32
       GoKind: 25
@@ -7459,9 +7459,9 @@ Types:
           Type: 7 BaseType int
         - Name: groups
           Offset: 16
-          Type: 93 GoSwissMapGroupsType groupReference<string,main.nestedStruct>
+          Type: 177 GoSwissMapGroupsType groupReference<string,main.nestedStruct>
     - __kind: StructureType
-      ID: 189
+      ID: 170
       Name: table<uint8,[4]int>
       ByteSize: 32
       GoKind: 25
@@ -7483,9 +7483,9 @@ Types:
           Type: 7 BaseType int
         - Name: groups
           Offset: 16
-          Type: 190 GoSwissMapGroupsType groupReference<uint8,[4]int>
+          Type: 201 GoSwissMapGroupsType groupReference<uint8,[4]int>
     - __kind: StructureType
-      ID: 178
+      ID: 169
       Name: table<uint8,uint8>
       ByteSize: 32
       GoKind: 25
@@ -7507,7 +7507,7 @@ Types:
           Type: 7 BaseType int
         - Name: groups
           Offset: 16
-          Type: 179 GoSwissMapGroupsType groupReference<uint8,uint8>
+          Type: 198 GoSwissMapGroupsType groupReference<uint8,uint8>
     - __kind: BaseType
       ID: 10
       Name: uint

--- a/pkg/dyninst/irgen/testdata/snapshot/sample.arch=arm64,toolchain=go1.25.0.yaml
+++ b/pkg/dyninst/irgen/testdata/snapshot/sample.arch=arm64,toolchain=go1.25.0.yaml
@@ -3163,10 +3163,10 @@ Types:
       ByteSize: 8
       Pointee: 112 PointerType *table<uint8,uint8>
     - __kind: PointerType
-      ID: 241
+      ID: 177
       Name: '*[]*string.array'
       ByteSize: 8
-      Pointee: 240 GoSliceDataType []*string.array
+      Pointee: 176 GoSliceDataType []*string.array
     - __kind: PointerType
       ID: 271
       Name: '*[][]uint.array'
@@ -3291,7 +3291,7 @@ Types:
       GoKind: 22
       Pointee: 147 StructureType main.oneStringStruct
     - __kind: PointerType
-      ID: 224
+      ID: 220
       Name: '*main.structWithMap'
       ByteSize: 8
       GoRuntimeType: 382880
@@ -3392,65 +3392,65 @@ Types:
       GoKind: 22
       Pointee: 76 GoMapType map[string]int
     - __kind: PointerType
-      ID: 208
+      ID: 260
       Name: '*noalg.map.group[[4]int][4]int'
       ByteSize: 8
-      Pointee: 209 StructureType noalg.map.group[[4]int][4]int
+      Pointee: 261 StructureType noalg.map.group[[4]int][4]int
     - __kind: PointerType
-      ID: 205
+      ID: 253
       Name: '*noalg.map.group[[4]int]uint8'
       ByteSize: 8
-      Pointee: 206 StructureType noalg.map.group[[4]int]uint8
+      Pointee: 254 StructureType noalg.map.group[[4]int]uint8
     - __kind: PointerType
-      ID: 187
+      ID: 207
       Name: '*noalg.map.group[[4]string][2]int'
       ByteSize: 8
-      Pointee: 188 StructureType noalg.map.group[[4]string][2]int
+      Pointee: 208 StructureType noalg.map.group[[4]string][2]int
     - __kind: PointerType
-      ID: 193
+      ID: 224
       Name: '*noalg.map.group[bool]main.node'
       ByteSize: 8
-      Pointee: 194 StructureType noalg.map.group[bool]main.node
+      Pointee: 225 StructureType noalg.map.group[bool]main.node
     - __kind: PointerType
-      ID: 175
+      ID: 179
       Name: '*noalg.map.group[int]int'
       ByteSize: 8
-      Pointee: 176 StructureType noalg.map.group[int]int
+      Pointee: 180 StructureType noalg.map.group[int]int
     - __kind: PointerType
-      ID: 196
+      ID: 231
       Name: '*noalg.map.group[int]uint8'
       ByteSize: 8
-      Pointee: 197 StructureType noalg.map.group[int]uint8
+      Pointee: 232 StructureType noalg.map.group[int]uint8
     - __kind: PointerType
-      ID: 190
+      ID: 215
       Name: '*noalg.map.group[string][]main.structWithMap'
       ByteSize: 8
-      Pointee: 191 StructureType noalg.map.group[string][]main.structWithMap
+      Pointee: 216 StructureType noalg.map.group[string][]main.structWithMap
     - __kind: PointerType
-      ID: 184
+      ID: 200
       Name: '*noalg.map.group[string][]string'
       ByteSize: 8
-      Pointee: 185 StructureType noalg.map.group[string][]string
+      Pointee: 201 StructureType noalg.map.group[string][]string
     - __kind: PointerType
-      ID: 181
+      ID: 193
       Name: '*noalg.map.group[string]int'
       ByteSize: 8
-      Pointee: 182 StructureType noalg.map.group[string]int
+      Pointee: 194 StructureType noalg.map.group[string]int
     - __kind: PointerType
-      ID: 178
+      ID: 186
       Name: '*noalg.map.group[string]main.nestedStruct'
       ByteSize: 8
-      Pointee: 179 StructureType noalg.map.group[string]main.nestedStruct
+      Pointee: 187 StructureType noalg.map.group[string]main.nestedStruct
     - __kind: PointerType
-      ID: 202
+      ID: 245
       Name: '*noalg.map.group[uint8][4]int'
       ByteSize: 8
-      Pointee: 203 StructureType noalg.map.group[uint8][4]int
+      Pointee: 246 StructureType noalg.map.group[uint8][4]int
     - __kind: PointerType
-      ID: 199
+      ID: 238
       Name: '*noalg.map.group[uint8]uint8'
       ByteSize: 8
-      Pointee: 200 StructureType noalg.map.group[uint8]uint8
+      Pointee: 239 StructureType noalg.map.group[uint8]uint8
     - __kind: PointerType
       ID: 22
       Name: '*string'
@@ -3459,10 +3459,10 @@ Types:
       GoKind: 22
       Pointee: 9 GoStringHeaderType string
     - __kind: PointerType
-      ID: 239
+      ID: 175
       Name: '*string.str'
       ByteSize: 8
-      Pointee: 238 GoStringDataType string.str
+      Pointee: 174 GoStringDataType string.str
     - __kind: PointerType
       ID: 127
       Name: '*table<[4]int,[4]int>'
@@ -5334,7 +5334,7 @@ Types:
       HasCount: true
       Element: 3 BaseType uint8
     - __kind: ArrayType
-      ID: 233
+      ID: 249
       Name: '[4]int'
       ByteSize: 32
       GoRuntimeType: 676416
@@ -5343,7 +5343,7 @@ Types:
       HasCount: true
       Element: 7 BaseType int
     - __kind: ArrayType
-      ID: 220
+      ID: 211
       Name: '[4]string'
       ByteSize: 64
       GoRuntimeType: 676704
@@ -5375,9 +5375,9 @@ Types:
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 240 GoSliceDataType []*string.array
+      Data: 176 GoSliceDataType []*string.array
     - __kind: GoSliceDataType
-      ID: 240
+      ID: 176
       Name: '[]*string.array'
       ByteSize: 2048
       Element: 22 PointerType *string
@@ -5387,57 +5387,57 @@ Types:
       ByteSize: 8192
       Element: 127 PointerType *table<[4]int,[4]int>
     - __kind: GoSliceDataType
-      ID: 262
+      ID: 257
       Name: '[]*table<[4]int,uint8>.array'
       ByteSize: 8192
       Element: 122 PointerType *table<[4]int,uint8>
     - __kind: GoSliceDataType
-      ID: 250
+      ID: 212
       Name: '[]*table<[4]string,[2]int>.array'
       ByteSize: 8192
       Element: 90 PointerType *table<[4]string,[2]int>
     - __kind: GoSliceDataType
-      ID: 254
+      ID: 228
       Name: '[]*table<bool,main.node>.array'
       ByteSize: 8192
       Element: 102 PointerType *table<bool,main.node>
     - __kind: GoSliceDataType
-      ID: 242
+      ID: 183
       Name: '[]*table<int,int>.array'
       ByteSize: 8192
       Element: 70 PointerType *table<int,int>
     - __kind: GoSliceDataType
-      ID: 256
+      ID: 235
       Name: '[]*table<int,uint8>.array'
       ByteSize: 8192
       Element: 107 PointerType *table<int,uint8>
     - __kind: GoSliceDataType
-      ID: 252
+      ID: 221
       Name: '[]*table<string,[]main.structWithMap>.array'
       ByteSize: 8192
       Element: 97 PointerType *table<string,[]main.structWithMap>
     - __kind: GoSliceDataType
-      ID: 248
+      ID: 204
       Name: '[]*table<string,[]string>.array'
       ByteSize: 8192
       Element: 85 PointerType *table<string,[]string>
     - __kind: GoSliceDataType
-      ID: 246
+      ID: 197
       Name: '[]*table<string,int>.array'
       ByteSize: 8192
       Element: 80 PointerType *table<string,int>
     - __kind: GoSliceDataType
-      ID: 244
+      ID: 190
       Name: '[]*table<string,main.nestedStruct>.array'
       ByteSize: 8192
       Element: 75 PointerType *table<string,main.nestedStruct>
     - __kind: GoSliceDataType
-      ID: 260
+      ID: 250
       Name: '[]*table<uint8,[4]int>.array'
       ByteSize: 8192
       Element: 117 PointerType *table<uint8,[4]int>
     - __kind: GoSliceDataType
-      ID: 258
+      ID: 242
       Name: '[]*table<uint8,uint8>.array'
       ByteSize: 8192
       Element: 112 PointerType *table<uint8,uint8>
@@ -5485,7 +5485,7 @@ Types:
       ByteSize: 2048
       Element: 4 BaseType bool
     - __kind: GoSliceHeaderType
-      ID: 223
+      ID: 219
       Name: '[]main.structWithMap'
       ByteSize: 24
       GoRuntimeType: 472608
@@ -5493,7 +5493,7 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 224 PointerType *main.structWithMap
+          Type: 220 PointerType *main.structWithMap
         - Name: len
           Offset: 8
           Type: 7 BaseType int
@@ -5531,62 +5531,62 @@ Types:
       ID: 265
       Name: '[]noalg.map.group[[4]int][4]int.array'
       ByteSize: 2048
-      Element: 209 StructureType noalg.map.group[[4]int][4]int
+      Element: 261 StructureType noalg.map.group[[4]int][4]int
     - __kind: GoSliceDataType
-      ID: 263
+      ID: 258
       Name: '[]noalg.map.group[[4]int]uint8.array'
       ByteSize: 2048
-      Element: 206 StructureType noalg.map.group[[4]int]uint8
+      Element: 254 StructureType noalg.map.group[[4]int]uint8
     - __kind: GoSliceDataType
-      ID: 251
+      ID: 213
       Name: '[]noalg.map.group[[4]string][2]int.array'
       ByteSize: 2048
-      Element: 188 StructureType noalg.map.group[[4]string][2]int
+      Element: 208 StructureType noalg.map.group[[4]string][2]int
     - __kind: GoSliceDataType
-      ID: 255
+      ID: 229
       Name: '[]noalg.map.group[bool]main.node.array'
       ByteSize: 2048
-      Element: 194 StructureType noalg.map.group[bool]main.node
+      Element: 225 StructureType noalg.map.group[bool]main.node
     - __kind: GoSliceDataType
-      ID: 243
+      ID: 184
       Name: '[]noalg.map.group[int]int.array'
       ByteSize: 2048
-      Element: 176 StructureType noalg.map.group[int]int
+      Element: 180 StructureType noalg.map.group[int]int
     - __kind: GoSliceDataType
-      ID: 257
+      ID: 236
       Name: '[]noalg.map.group[int]uint8.array'
       ByteSize: 2048
-      Element: 197 StructureType noalg.map.group[int]uint8
+      Element: 232 StructureType noalg.map.group[int]uint8
     - __kind: GoSliceDataType
-      ID: 253
+      ID: 222
       Name: '[]noalg.map.group[string][]main.structWithMap.array'
       ByteSize: 2048
-      Element: 191 StructureType noalg.map.group[string][]main.structWithMap
+      Element: 216 StructureType noalg.map.group[string][]main.structWithMap
     - __kind: GoSliceDataType
-      ID: 249
+      ID: 205
       Name: '[]noalg.map.group[string][]string.array'
       ByteSize: 2048
-      Element: 185 StructureType noalg.map.group[string][]string
+      Element: 201 StructureType noalg.map.group[string][]string
     - __kind: GoSliceDataType
-      ID: 247
+      ID: 198
       Name: '[]noalg.map.group[string]int.array'
       ByteSize: 2048
-      Element: 182 StructureType noalg.map.group[string]int
+      Element: 194 StructureType noalg.map.group[string]int
     - __kind: GoSliceDataType
-      ID: 245
+      ID: 191
       Name: '[]noalg.map.group[string]main.nestedStruct.array'
       ByteSize: 2048
-      Element: 179 StructureType noalg.map.group[string]main.nestedStruct
+      Element: 187 StructureType noalg.map.group[string]main.nestedStruct
     - __kind: GoSliceDataType
-      ID: 261
+      ID: 251
       Name: '[]noalg.map.group[uint8][4]int.array'
       ByteSize: 2048
-      Element: 203 StructureType noalg.map.group[uint8][4]int
+      Element: 246 StructureType noalg.map.group[uint8][4]int
     - __kind: GoSliceDataType
-      ID: 259
+      ID: 243
       Name: '[]noalg.map.group[uint8]uint8.array'
       ByteSize: 2048
-      Element: 200 StructureType noalg.map.group[uint8]uint8
+      Element: 239 StructureType noalg.map.group[uint8]uint8
     - __kind: GoSliceHeaderType
       ID: 141
       Name: '[]string'
@@ -5713,173 +5713,173 @@ Types:
       GoRuntimeType: 471584
       GoKind: 19
     - __kind: GoSwissMapGroupsType
-      ID: 207
+      ID: 259
       Name: groupReference<[4]int,[4]int>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 208 PointerType *noalg.map.group[[4]int][4]int
+          Type: 260 PointerType *noalg.map.group[[4]int][4]int
         - Name: lengthMask
           Offset: 8
           Type: 8 BaseType uint64
-      GroupType: 209 StructureType noalg.map.group[[4]int][4]int
+      GroupType: 261 StructureType noalg.map.group[[4]int][4]int
       GroupSliceType: 265 GoSliceDataType []noalg.map.group[[4]int][4]int.array
     - __kind: GoSwissMapGroupsType
-      ID: 204
+      ID: 252
       Name: groupReference<[4]int,uint8>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 205 PointerType *noalg.map.group[[4]int]uint8
+          Type: 253 PointerType *noalg.map.group[[4]int]uint8
         - Name: lengthMask
           Offset: 8
           Type: 8 BaseType uint64
-      GroupType: 206 StructureType noalg.map.group[[4]int]uint8
-      GroupSliceType: 263 GoSliceDataType []noalg.map.group[[4]int]uint8.array
+      GroupType: 254 StructureType noalg.map.group[[4]int]uint8
+      GroupSliceType: 258 GoSliceDataType []noalg.map.group[[4]int]uint8.array
     - __kind: GoSwissMapGroupsType
-      ID: 186
+      ID: 206
       Name: groupReference<[4]string,[2]int>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 187 PointerType *noalg.map.group[[4]string][2]int
+          Type: 207 PointerType *noalg.map.group[[4]string][2]int
         - Name: lengthMask
           Offset: 8
           Type: 8 BaseType uint64
-      GroupType: 188 StructureType noalg.map.group[[4]string][2]int
-      GroupSliceType: 251 GoSliceDataType []noalg.map.group[[4]string][2]int.array
+      GroupType: 208 StructureType noalg.map.group[[4]string][2]int
+      GroupSliceType: 213 GoSliceDataType []noalg.map.group[[4]string][2]int.array
     - __kind: GoSwissMapGroupsType
-      ID: 192
+      ID: 223
       Name: groupReference<bool,main.node>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 193 PointerType *noalg.map.group[bool]main.node
+          Type: 224 PointerType *noalg.map.group[bool]main.node
         - Name: lengthMask
           Offset: 8
           Type: 8 BaseType uint64
-      GroupType: 194 StructureType noalg.map.group[bool]main.node
-      GroupSliceType: 255 GoSliceDataType []noalg.map.group[bool]main.node.array
+      GroupType: 225 StructureType noalg.map.group[bool]main.node
+      GroupSliceType: 229 GoSliceDataType []noalg.map.group[bool]main.node.array
     - __kind: GoSwissMapGroupsType
-      ID: 174
+      ID: 178
       Name: groupReference<int,int>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 175 PointerType *noalg.map.group[int]int
+          Type: 179 PointerType *noalg.map.group[int]int
         - Name: lengthMask
           Offset: 8
           Type: 8 BaseType uint64
-      GroupType: 176 StructureType noalg.map.group[int]int
-      GroupSliceType: 243 GoSliceDataType []noalg.map.group[int]int.array
+      GroupType: 180 StructureType noalg.map.group[int]int
+      GroupSliceType: 184 GoSliceDataType []noalg.map.group[int]int.array
     - __kind: GoSwissMapGroupsType
-      ID: 195
+      ID: 230
       Name: groupReference<int,uint8>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 196 PointerType *noalg.map.group[int]uint8
+          Type: 231 PointerType *noalg.map.group[int]uint8
         - Name: lengthMask
           Offset: 8
           Type: 8 BaseType uint64
-      GroupType: 197 StructureType noalg.map.group[int]uint8
-      GroupSliceType: 257 GoSliceDataType []noalg.map.group[int]uint8.array
+      GroupType: 232 StructureType noalg.map.group[int]uint8
+      GroupSliceType: 236 GoSliceDataType []noalg.map.group[int]uint8.array
     - __kind: GoSwissMapGroupsType
-      ID: 189
+      ID: 214
       Name: groupReference<string,[]main.structWithMap>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 190 PointerType *noalg.map.group[string][]main.structWithMap
+          Type: 215 PointerType *noalg.map.group[string][]main.structWithMap
         - Name: lengthMask
           Offset: 8
           Type: 8 BaseType uint64
-      GroupType: 191 StructureType noalg.map.group[string][]main.structWithMap
-      GroupSliceType: 253 GoSliceDataType []noalg.map.group[string][]main.structWithMap.array
+      GroupType: 216 StructureType noalg.map.group[string][]main.structWithMap
+      GroupSliceType: 222 GoSliceDataType []noalg.map.group[string][]main.structWithMap.array
     - __kind: GoSwissMapGroupsType
-      ID: 183
+      ID: 199
       Name: groupReference<string,[]string>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 184 PointerType *noalg.map.group[string][]string
+          Type: 200 PointerType *noalg.map.group[string][]string
         - Name: lengthMask
           Offset: 8
           Type: 8 BaseType uint64
-      GroupType: 185 StructureType noalg.map.group[string][]string
-      GroupSliceType: 249 GoSliceDataType []noalg.map.group[string][]string.array
+      GroupType: 201 StructureType noalg.map.group[string][]string
+      GroupSliceType: 205 GoSliceDataType []noalg.map.group[string][]string.array
     - __kind: GoSwissMapGroupsType
-      ID: 180
+      ID: 192
       Name: groupReference<string,int>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 181 PointerType *noalg.map.group[string]int
+          Type: 193 PointerType *noalg.map.group[string]int
         - Name: lengthMask
           Offset: 8
           Type: 8 BaseType uint64
-      GroupType: 182 StructureType noalg.map.group[string]int
-      GroupSliceType: 247 GoSliceDataType []noalg.map.group[string]int.array
+      GroupType: 194 StructureType noalg.map.group[string]int
+      GroupSliceType: 198 GoSliceDataType []noalg.map.group[string]int.array
     - __kind: GoSwissMapGroupsType
-      ID: 177
+      ID: 185
       Name: groupReference<string,main.nestedStruct>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 178 PointerType *noalg.map.group[string]main.nestedStruct
+          Type: 186 PointerType *noalg.map.group[string]main.nestedStruct
         - Name: lengthMask
           Offset: 8
           Type: 8 BaseType uint64
-      GroupType: 179 StructureType noalg.map.group[string]main.nestedStruct
-      GroupSliceType: 245 GoSliceDataType []noalg.map.group[string]main.nestedStruct.array
+      GroupType: 187 StructureType noalg.map.group[string]main.nestedStruct
+      GroupSliceType: 191 GoSliceDataType []noalg.map.group[string]main.nestedStruct.array
     - __kind: GoSwissMapGroupsType
-      ID: 201
+      ID: 244
       Name: groupReference<uint8,[4]int>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 202 PointerType *noalg.map.group[uint8][4]int
+          Type: 245 PointerType *noalg.map.group[uint8][4]int
         - Name: lengthMask
           Offset: 8
           Type: 8 BaseType uint64
-      GroupType: 203 StructureType noalg.map.group[uint8][4]int
-      GroupSliceType: 261 GoSliceDataType []noalg.map.group[uint8][4]int.array
+      GroupType: 246 StructureType noalg.map.group[uint8][4]int
+      GroupSliceType: 251 GoSliceDataType []noalg.map.group[uint8][4]int.array
     - __kind: GoSwissMapGroupsType
-      ID: 198
+      ID: 237
       Name: groupReference<uint8,uint8>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 199 PointerType *noalg.map.group[uint8]uint8
+          Type: 238 PointerType *noalg.map.group[uint8]uint8
         - Name: lengthMask
           Offset: 8
           Type: 8 BaseType uint64
-      GroupType: 200 StructureType noalg.map.group[uint8]uint8
-      GroupSliceType: 259 GoSliceDataType []noalg.map.group[uint8]uint8.array
+      GroupType: 239 StructureType noalg.map.group[uint8]uint8
+      GroupSliceType: 243 GoSliceDataType []noalg.map.group[uint8]uint8.array
     - __kind: BaseType
       ID: 7
       Name: int
@@ -6207,7 +6207,7 @@ Types:
           Offset: 40
           Type: 8 BaseType uint64
       TablePtrSliceType: 264 GoSliceDataType []*table<[4]int,[4]int>.array
-      GroupType: 209 StructureType noalg.map.group[[4]int][4]int
+      GroupType: 261 StructureType noalg.map.group[[4]int][4]int
     - __kind: GoSwissMapHeaderType
       ID: 120
       Name: map<[4]int,uint8>
@@ -6241,8 +6241,8 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 8 BaseType uint64
-      TablePtrSliceType: 262 GoSliceDataType []*table<[4]int,uint8>.array
-      GroupType: 206 StructureType noalg.map.group[[4]int]uint8
+      TablePtrSliceType: 257 GoSliceDataType []*table<[4]int,uint8>.array
+      GroupType: 254 StructureType noalg.map.group[[4]int]uint8
     - __kind: GoSwissMapHeaderType
       ID: 88
       Name: map<[4]string,[2]int>
@@ -6276,8 +6276,8 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 8 BaseType uint64
-      TablePtrSliceType: 250 GoSliceDataType []*table<[4]string,[2]int>.array
-      GroupType: 188 StructureType noalg.map.group[[4]string][2]int
+      TablePtrSliceType: 212 GoSliceDataType []*table<[4]string,[2]int>.array
+      GroupType: 208 StructureType noalg.map.group[[4]string][2]int
     - __kind: GoSwissMapHeaderType
       ID: 100
       Name: map<bool,main.node>
@@ -6311,8 +6311,8 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 8 BaseType uint64
-      TablePtrSliceType: 254 GoSliceDataType []*table<bool,main.node>.array
-      GroupType: 194 StructureType noalg.map.group[bool]main.node
+      TablePtrSliceType: 228 GoSliceDataType []*table<bool,main.node>.array
+      GroupType: 225 StructureType noalg.map.group[bool]main.node
     - __kind: GoSwissMapHeaderType
       ID: 68
       Name: map<int,int>
@@ -6346,8 +6346,8 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 8 BaseType uint64
-      TablePtrSliceType: 242 GoSliceDataType []*table<int,int>.array
-      GroupType: 176 StructureType noalg.map.group[int]int
+      TablePtrSliceType: 183 GoSliceDataType []*table<int,int>.array
+      GroupType: 180 StructureType noalg.map.group[int]int
     - __kind: GoSwissMapHeaderType
       ID: 105
       Name: map<int,uint8>
@@ -6381,8 +6381,8 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 8 BaseType uint64
-      TablePtrSliceType: 256 GoSliceDataType []*table<int,uint8>.array
-      GroupType: 197 StructureType noalg.map.group[int]uint8
+      TablePtrSliceType: 235 GoSliceDataType []*table<int,uint8>.array
+      GroupType: 232 StructureType noalg.map.group[int]uint8
     - __kind: GoSwissMapHeaderType
       ID: 95
       Name: map<string,[]main.structWithMap>
@@ -6416,8 +6416,8 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 8 BaseType uint64
-      TablePtrSliceType: 252 GoSliceDataType []*table<string,[]main.structWithMap>.array
-      GroupType: 191 StructureType noalg.map.group[string][]main.structWithMap
+      TablePtrSliceType: 221 GoSliceDataType []*table<string,[]main.structWithMap>.array
+      GroupType: 216 StructureType noalg.map.group[string][]main.structWithMap
     - __kind: GoSwissMapHeaderType
       ID: 83
       Name: map<string,[]string>
@@ -6451,8 +6451,8 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 8 BaseType uint64
-      TablePtrSliceType: 248 GoSliceDataType []*table<string,[]string>.array
-      GroupType: 185 StructureType noalg.map.group[string][]string
+      TablePtrSliceType: 204 GoSliceDataType []*table<string,[]string>.array
+      GroupType: 201 StructureType noalg.map.group[string][]string
     - __kind: GoSwissMapHeaderType
       ID: 78
       Name: map<string,int>
@@ -6486,8 +6486,8 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 8 BaseType uint64
-      TablePtrSliceType: 246 GoSliceDataType []*table<string,int>.array
-      GroupType: 182 StructureType noalg.map.group[string]int
+      TablePtrSliceType: 197 GoSliceDataType []*table<string,int>.array
+      GroupType: 194 StructureType noalg.map.group[string]int
     - __kind: GoSwissMapHeaderType
       ID: 73
       Name: map<string,main.nestedStruct>
@@ -6521,8 +6521,8 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 8 BaseType uint64
-      TablePtrSliceType: 244 GoSliceDataType []*table<string,main.nestedStruct>.array
-      GroupType: 179 StructureType noalg.map.group[string]main.nestedStruct
+      TablePtrSliceType: 190 GoSliceDataType []*table<string,main.nestedStruct>.array
+      GroupType: 187 StructureType noalg.map.group[string]main.nestedStruct
     - __kind: GoSwissMapHeaderType
       ID: 115
       Name: map<uint8,[4]int>
@@ -6556,8 +6556,8 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 8 BaseType uint64
-      TablePtrSliceType: 260 GoSliceDataType []*table<uint8,[4]int>.array
-      GroupType: 203 StructureType noalg.map.group[uint8][4]int
+      TablePtrSliceType: 250 GoSliceDataType []*table<uint8,[4]int>.array
+      GroupType: 246 StructureType noalg.map.group[uint8][4]int
     - __kind: GoSwissMapHeaderType
       ID: 110
       Name: map<uint8,uint8>
@@ -6591,8 +6591,8 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 8 BaseType uint64
-      TablePtrSliceType: 258 GoSliceDataType []*table<uint8,uint8>.array
-      GroupType: 200 StructureType noalg.map.group[uint8]uint8
+      TablePtrSliceType: 242 GoSliceDataType []*table<uint8,uint8>.array
+      GroupType: 239 StructureType noalg.map.group[uint8]uint8
     - __kind: GoMapType
       ID: 123
       Name: map[[4]int][4]int
@@ -6678,115 +6678,115 @@ Types:
       GoKind: 21
       HeaderType: 110 GoSwissMapHeaderType map<uint8,uint8>
     - __kind: ArrayType
-      ID: 236
+      ID: 262
       Name: noalg.[8]struct { key [4]int; elem [4]int }
       ByteSize: 512
       GoRuntimeType: 676512
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 237 StructureType noalg.struct { key [4]int; elem [4]int }
+      Element: 263 StructureType noalg.struct { key [4]int; elem [4]int }
     - __kind: ArrayType
-      ID: 234
+      ID: 255
       Name: noalg.[8]struct { key [4]int; elem uint8 }
       ByteSize: 320
       GoRuntimeType: 676608
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 235 StructureType noalg.struct { key [4]int; elem uint8 }
+      Element: 256 StructureType noalg.struct { key [4]int; elem uint8 }
     - __kind: ArrayType
-      ID: 218
+      ID: 209
       Name: noalg.[8]struct { key [4]string; elem [2]int }
       ByteSize: 640
       GoRuntimeType: 676896
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 219 StructureType noalg.struct { key [4]string; elem [2]int }
+      Element: 210 StructureType noalg.struct { key [4]string; elem [2]int }
     - __kind: ArrayType
-      ID: 225
+      ID: 226
       Name: noalg.[8]struct { key bool; elem main.node }
       ByteSize: 192
       GoRuntimeType: 676992
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 226 StructureType noalg.struct { key bool; elem main.node }
+      Element: 227 StructureType noalg.struct { key bool; elem main.node }
     - __kind: ArrayType
-      ID: 210
+      ID: 181
       Name: noalg.[8]struct { key int; elem int }
       ByteSize: 128
       GoRuntimeType: 674784
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 211 StructureType noalg.struct { key int; elem int }
+      Element: 182 StructureType noalg.struct { key int; elem int }
     - __kind: ArrayType
-      ID: 227
+      ID: 233
       Name: noalg.[8]struct { key int; elem uint8 }
       ByteSize: 128
       GoRuntimeType: 677088
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 228 StructureType noalg.struct { key int; elem uint8 }
+      Element: 234 StructureType noalg.struct { key int; elem uint8 }
     - __kind: ArrayType
-      ID: 221
+      ID: 217
       Name: noalg.[8]struct { key string; elem []main.structWithMap }
       ByteSize: 320
       GoRuntimeType: 677184
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 222 StructureType noalg.struct { key string; elem []main.structWithMap }
+      Element: 218 StructureType noalg.struct { key string; elem []main.structWithMap }
     - __kind: ArrayType
-      ID: 216
+      ID: 202
       Name: noalg.[8]struct { key string; elem []string }
       ByteSize: 320
       GoRuntimeType: 677280
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 217 StructureType noalg.struct { key string; elem []string }
+      Element: 203 StructureType noalg.struct { key string; elem []string }
     - __kind: ArrayType
-      ID: 214
+      ID: 195
       Name: noalg.[8]struct { key string; elem int }
       ByteSize: 192
       GoRuntimeType: 677376
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 215 StructureType noalg.struct { key string; elem int }
+      Element: 196 StructureType noalg.struct { key string; elem int }
     - __kind: ArrayType
-      ID: 212
+      ID: 188
       Name: noalg.[8]struct { key string; elem main.nestedStruct }
       ByteSize: 320
       GoRuntimeType: 677472
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 213 StructureType noalg.struct { key string; elem main.nestedStruct }
+      Element: 189 StructureType noalg.struct { key string; elem main.nestedStruct }
     - __kind: ArrayType
-      ID: 231
+      ID: 247
       Name: noalg.[8]struct { key uint8; elem [4]int }
       ByteSize: 320
       GoRuntimeType: 677568
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 232 StructureType noalg.struct { key uint8; elem [4]int }
+      Element: 248 StructureType noalg.struct { key uint8; elem [4]int }
     - __kind: ArrayType
-      ID: 229
+      ID: 240
       Name: noalg.[8]struct { key uint8; elem uint8 }
       ByteSize: 16
       GoRuntimeType: 677664
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 230 StructureType noalg.struct { key uint8; elem uint8 }
+      Element: 241 StructureType noalg.struct { key uint8; elem uint8 }
     - __kind: StructureType
-      ID: 209
+      ID: 261
       Name: noalg.map.group[[4]int][4]int
       ByteSize: 520
       GoRuntimeType: 1.281056e+06
@@ -6797,9 +6797,9 @@ Types:
           Type: 8 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 236 ArrayType noalg.[8]struct { key [4]int; elem [4]int }
+          Type: 262 ArrayType noalg.[8]struct { key [4]int; elem [4]int }
     - __kind: StructureType
-      ID: 206
+      ID: 254
       Name: noalg.map.group[[4]int]uint8
       ByteSize: 328
       GoRuntimeType: 1.281312e+06
@@ -6810,9 +6810,9 @@ Types:
           Type: 8 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 234 ArrayType noalg.[8]struct { key [4]int; elem uint8 }
+          Type: 255 ArrayType noalg.[8]struct { key [4]int; elem uint8 }
     - __kind: StructureType
-      ID: 188
+      ID: 208
       Name: noalg.map.group[[4]string][2]int
       ByteSize: 648
       GoRuntimeType: 1.281568e+06
@@ -6823,9 +6823,9 @@ Types:
           Type: 8 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 218 ArrayType noalg.[8]struct { key [4]string; elem [2]int }
+          Type: 209 ArrayType noalg.[8]struct { key [4]string; elem [2]int }
     - __kind: StructureType
-      ID: 194
+      ID: 225
       Name: noalg.map.group[bool]main.node
       ByteSize: 200
       GoRuntimeType: 1.281824e+06
@@ -6836,9 +6836,9 @@ Types:
           Type: 8 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 225 ArrayType noalg.[8]struct { key bool; elem main.node }
+          Type: 226 ArrayType noalg.[8]struct { key bool; elem main.node }
     - __kind: StructureType
-      ID: 176
+      ID: 180
       Name: noalg.map.group[int]int
       ByteSize: 136
       GoRuntimeType: 1.280288e+06
@@ -6849,9 +6849,9 @@ Types:
           Type: 8 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 210 ArrayType noalg.[8]struct { key int; elem int }
+          Type: 181 ArrayType noalg.[8]struct { key int; elem int }
     - __kind: StructureType
-      ID: 197
+      ID: 232
       Name: noalg.map.group[int]uint8
       ByteSize: 136
       GoRuntimeType: 1.28208e+06
@@ -6862,9 +6862,9 @@ Types:
           Type: 8 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 227 ArrayType noalg.[8]struct { key int; elem uint8 }
+          Type: 233 ArrayType noalg.[8]struct { key int; elem uint8 }
     - __kind: StructureType
-      ID: 191
+      ID: 216
       Name: noalg.map.group[string][]main.structWithMap
       ByteSize: 328
       GoRuntimeType: 1.282336e+06
@@ -6875,9 +6875,9 @@ Types:
           Type: 8 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 221 ArrayType noalg.[8]struct { key string; elem []main.structWithMap }
+          Type: 217 ArrayType noalg.[8]struct { key string; elem []main.structWithMap }
     - __kind: StructureType
-      ID: 185
+      ID: 201
       Name: noalg.map.group[string][]string
       ByteSize: 328
       GoRuntimeType: 1.282592e+06
@@ -6888,9 +6888,9 @@ Types:
           Type: 8 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 216 ArrayType noalg.[8]struct { key string; elem []string }
+          Type: 202 ArrayType noalg.[8]struct { key string; elem []string }
     - __kind: StructureType
-      ID: 182
+      ID: 194
       Name: noalg.map.group[string]int
       ByteSize: 200
       GoRuntimeType: 1.282848e+06
@@ -6901,9 +6901,9 @@ Types:
           Type: 8 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 214 ArrayType noalg.[8]struct { key string; elem int }
+          Type: 195 ArrayType noalg.[8]struct { key string; elem int }
     - __kind: StructureType
-      ID: 179
+      ID: 187
       Name: noalg.map.group[string]main.nestedStruct
       ByteSize: 328
       GoRuntimeType: 1.283104e+06
@@ -6914,9 +6914,9 @@ Types:
           Type: 8 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 212 ArrayType noalg.[8]struct { key string; elem main.nestedStruct }
+          Type: 188 ArrayType noalg.[8]struct { key string; elem main.nestedStruct }
     - __kind: StructureType
-      ID: 203
+      ID: 246
       Name: noalg.map.group[uint8][4]int
       ByteSize: 328
       GoRuntimeType: 1.28336e+06
@@ -6927,9 +6927,9 @@ Types:
           Type: 8 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 231 ArrayType noalg.[8]struct { key uint8; elem [4]int }
+          Type: 247 ArrayType noalg.[8]struct { key uint8; elem [4]int }
     - __kind: StructureType
-      ID: 200
+      ID: 239
       Name: noalg.map.group[uint8]uint8
       ByteSize: 24
       GoRuntimeType: 1.283616e+06
@@ -6940,9 +6940,9 @@ Types:
           Type: 8 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 229 ArrayType noalg.[8]struct { key uint8; elem uint8 }
+          Type: 240 ArrayType noalg.[8]struct { key uint8; elem uint8 }
     - __kind: StructureType
-      ID: 237
+      ID: 263
       Name: noalg.struct { key [4]int; elem [4]int }
       ByteSize: 64
       GoRuntimeType: 1.280928e+06
@@ -6950,12 +6950,12 @@ Types:
       RawFields:
         - Name: key
           Offset: 0
-          Type: 233 ArrayType [4]int
+          Type: 249 ArrayType [4]int
         - Name: elem
           Offset: 32
-          Type: 233 ArrayType [4]int
+          Type: 249 ArrayType [4]int
     - __kind: StructureType
-      ID: 235
+      ID: 256
       Name: noalg.struct { key [4]int; elem uint8 }
       ByteSize: 40
       GoRuntimeType: 1.281184e+06
@@ -6963,12 +6963,12 @@ Types:
       RawFields:
         - Name: key
           Offset: 0
-          Type: 233 ArrayType [4]int
+          Type: 249 ArrayType [4]int
         - Name: elem
           Offset: 32
           Type: 3 BaseType uint8
     - __kind: StructureType
-      ID: 219
+      ID: 210
       Name: noalg.struct { key [4]string; elem [2]int }
       ByteSize: 80
       GoRuntimeType: 1.28144e+06
@@ -6976,12 +6976,12 @@ Types:
       RawFields:
         - Name: key
           Offset: 0
-          Type: 220 ArrayType [4]string
+          Type: 211 ArrayType [4]string
         - Name: elem
           Offset: 64
           Type: 40 ArrayType [2]int
     - __kind: StructureType
-      ID: 226
+      ID: 227
       Name: noalg.struct { key bool; elem main.node }
       ByteSize: 24
       GoRuntimeType: 1.281696e+06
@@ -6994,7 +6994,7 @@ Types:
           Offset: 8
           Type: 131 StructureType main.node
     - __kind: StructureType
-      ID: 211
+      ID: 182
       Name: noalg.struct { key int; elem int }
       ByteSize: 16
       GoRuntimeType: 1.28016e+06
@@ -7007,7 +7007,7 @@ Types:
           Offset: 8
           Type: 7 BaseType int
     - __kind: StructureType
-      ID: 228
+      ID: 234
       Name: noalg.struct { key int; elem uint8 }
       ByteSize: 16
       GoRuntimeType: 1.281952e+06
@@ -7020,7 +7020,7 @@ Types:
           Offset: 8
           Type: 3 BaseType uint8
     - __kind: StructureType
-      ID: 222
+      ID: 218
       Name: noalg.struct { key string; elem []main.structWithMap }
       ByteSize: 40
       GoRuntimeType: 1.282208e+06
@@ -7031,9 +7031,9 @@ Types:
           Type: 9 GoStringHeaderType string
         - Name: elem
           Offset: 16
-          Type: 223 GoSliceHeaderType []main.structWithMap
+          Type: 219 GoSliceHeaderType []main.structWithMap
     - __kind: StructureType
-      ID: 217
+      ID: 203
       Name: noalg.struct { key string; elem []string }
       ByteSize: 40
       GoRuntimeType: 1.282464e+06
@@ -7046,7 +7046,7 @@ Types:
           Offset: 16
           Type: 141 GoSliceHeaderType []string
     - __kind: StructureType
-      ID: 215
+      ID: 196
       Name: noalg.struct { key string; elem int }
       ByteSize: 24
       GoRuntimeType: 1.28272e+06
@@ -7059,7 +7059,7 @@ Types:
           Offset: 16
           Type: 7 BaseType int
     - __kind: StructureType
-      ID: 213
+      ID: 189
       Name: noalg.struct { key string; elem main.nestedStruct }
       ByteSize: 40
       GoRuntimeType: 1.282976e+06
@@ -7072,7 +7072,7 @@ Types:
           Offset: 16
           Type: 149 StructureType main.nestedStruct
     - __kind: StructureType
-      ID: 232
+      ID: 248
       Name: noalg.struct { key uint8; elem [4]int }
       ByteSize: 40
       GoRuntimeType: 1.283232e+06
@@ -7083,9 +7083,9 @@ Types:
           Type: 3 BaseType uint8
         - Name: elem
           Offset: 8
-          Type: 233 ArrayType [4]int
+          Type: 249 ArrayType [4]int
     - __kind: StructureType
-      ID: 230
+      ID: 241
       Name: noalg.struct { key uint8; elem uint8 }
       ByteSize: 2
       GoRuntimeType: 1.283488e+06
@@ -7106,13 +7106,13 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 239 PointerType *string.str
+          Type: 175 PointerType *string.str
         - Name: len
           Offset: 8
           Type: 7 BaseType int
-      Data: 238 GoStringDataType string.str
+      Data: 174 GoStringDataType string.str
     - __kind: GoStringDataType
-      ID: 238
+      ID: 174
       Name: string.str
       ByteSize: 2048
     - __kind: StructureType
@@ -7243,7 +7243,7 @@ Types:
           Type: 7 BaseType int
         - Name: groups
           Offset: 16
-          Type: 207 GoSwissMapGroupsType groupReference<[4]int,[4]int>
+          Type: 259 GoSwissMapGroupsType groupReference<[4]int,[4]int>
     - __kind: StructureType
       ID: 171
       Name: table<[4]int,uint8>
@@ -7267,7 +7267,7 @@ Types:
           Type: 7 BaseType int
         - Name: groups
           Offset: 16
-          Type: 204 GoSwissMapGroupsType groupReference<[4]int,uint8>
+          Type: 252 GoSwissMapGroupsType groupReference<[4]int,uint8>
     - __kind: StructureType
       ID: 165
       Name: table<[4]string,[2]int>
@@ -7291,7 +7291,7 @@ Types:
           Type: 7 BaseType int
         - Name: groups
           Offset: 16
-          Type: 186 GoSwissMapGroupsType groupReference<[4]string,[2]int>
+          Type: 206 GoSwissMapGroupsType groupReference<[4]string,[2]int>
     - __kind: StructureType
       ID: 167
       Name: table<bool,main.node>
@@ -7315,7 +7315,7 @@ Types:
           Type: 7 BaseType int
         - Name: groups
           Offset: 16
-          Type: 192 GoSwissMapGroupsType groupReference<bool,main.node>
+          Type: 223 GoSwissMapGroupsType groupReference<bool,main.node>
     - __kind: StructureType
       ID: 161
       Name: table<int,int>
@@ -7339,7 +7339,7 @@ Types:
           Type: 7 BaseType int
         - Name: groups
           Offset: 16
-          Type: 174 GoSwissMapGroupsType groupReference<int,int>
+          Type: 178 GoSwissMapGroupsType groupReference<int,int>
     - __kind: StructureType
       ID: 168
       Name: table<int,uint8>
@@ -7363,7 +7363,7 @@ Types:
           Type: 7 BaseType int
         - Name: groups
           Offset: 16
-          Type: 195 GoSwissMapGroupsType groupReference<int,uint8>
+          Type: 230 GoSwissMapGroupsType groupReference<int,uint8>
     - __kind: StructureType
       ID: 166
       Name: table<string,[]main.structWithMap>
@@ -7387,7 +7387,7 @@ Types:
           Type: 7 BaseType int
         - Name: groups
           Offset: 16
-          Type: 189 GoSwissMapGroupsType groupReference<string,[]main.structWithMap>
+          Type: 214 GoSwissMapGroupsType groupReference<string,[]main.structWithMap>
     - __kind: StructureType
       ID: 164
       Name: table<string,[]string>
@@ -7411,7 +7411,7 @@ Types:
           Type: 7 BaseType int
         - Name: groups
           Offset: 16
-          Type: 183 GoSwissMapGroupsType groupReference<string,[]string>
+          Type: 199 GoSwissMapGroupsType groupReference<string,[]string>
     - __kind: StructureType
       ID: 163
       Name: table<string,int>
@@ -7435,7 +7435,7 @@ Types:
           Type: 7 BaseType int
         - Name: groups
           Offset: 16
-          Type: 180 GoSwissMapGroupsType groupReference<string,int>
+          Type: 192 GoSwissMapGroupsType groupReference<string,int>
     - __kind: StructureType
       ID: 162
       Name: table<string,main.nestedStruct>
@@ -7459,7 +7459,7 @@ Types:
           Type: 7 BaseType int
         - Name: groups
           Offset: 16
-          Type: 177 GoSwissMapGroupsType groupReference<string,main.nestedStruct>
+          Type: 185 GoSwissMapGroupsType groupReference<string,main.nestedStruct>
     - __kind: StructureType
       ID: 170
       Name: table<uint8,[4]int>
@@ -7483,7 +7483,7 @@ Types:
           Type: 7 BaseType int
         - Name: groups
           Offset: 16
-          Type: 201 GoSwissMapGroupsType groupReference<uint8,[4]int>
+          Type: 244 GoSwissMapGroupsType groupReference<uint8,[4]int>
     - __kind: StructureType
       ID: 169
       Name: table<uint8,uint8>
@@ -7507,7 +7507,7 @@ Types:
           Type: 7 BaseType int
         - Name: groups
           Offset: 16
-          Type: 198 GoSwissMapGroupsType groupReference<uint8,uint8>
+          Type: 237 GoSwissMapGroupsType groupReference<uint8,uint8>
     - __kind: BaseType
       ID: 10
       Name: uint

--- a/pkg/dyninst/irgen/testdata/snapshot/simple.arch=amd64,toolchain=go1.23.11.yaml
+++ b/pkg/dyninst/irgen/testdata/snapshot/simple.arch=amd64,toolchain=go1.23.11.yaml
@@ -341,12 +341,6 @@ Subprograms:
           IsParameter: true
           IsReturn: false
 Types:
-    - __kind: BaseType
-      ID: 1
-      Name: int
-      ByteSize: 8
-      GoRuntimeType: 38016
-      GoKind: 2
     - __kind: PointerType
       ID: 2
       Name: '*****int'
@@ -376,26 +370,162 @@ Types:
       GoKind: 22
       Pointee: 6 PointerType *int
     - __kind: PointerType
+      ID: 30
+      Name: '**runtime.bmap'
+      ByteSize: 8
+      Pointee: 31 PointerType *runtime.bmap
+    - __kind: PointerType
+      ID: 28
+      Name: '*[]*runtime.bmap'
+      ByteSize: 8
+      GoRuntimeType: 35968
+      GoKind: 22
+      Pointee: 29 GoSliceHeaderType []*runtime.bmap
+    - __kind: PointerType
+      ID: 73
+      Name: '*[]*runtime.bmap.array'
+      ByteSize: 8
+      Pointee: 72 GoSliceDataType []*runtime.bmap.array
+    - __kind: PointerType
+      ID: 68
+      Name: '*[]int.array'
+      ByteSize: 8
+      Pointee: 67 GoSliceDataType []int.array
+    - __kind: PointerType
+      ID: 70
+      Name: '*[]string.array'
+      ByteSize: 8
+      Pointee: 69 GoSliceDataType []string.array
+    - __kind: PointerType
+      ID: 43
+      Name: '*bool'
+      ByteSize: 8
+      GoRuntimeType: 26944
+      GoKind: 22
+      Pointee: 42 BaseType bool
+    - __kind: PointerType
+      ID: 20
+      Name: '*bucket<string,int>'
+      ByteSize: 8
+      Pointee: 21 GoHMapBucketType bucket<string,int>
+    - __kind: PointerType
+      ID: 36
+      Name: '*bucket<string,main.bigStruct>'
+      ByteSize: 8
+      Pointee: 37 GoHMapBucketType bucket<string,main.bigStruct>
+    - __kind: PointerType
+      ID: 61
+      Name: '*error'
+      ByteSize: 8
+      GoRuntimeType: 25856
+      GoKind: 22
+      Pointee: 52 GoInterfaceType error
+    - __kind: PointerType
+      ID: 62
+      Name: '*float32'
+      ByteSize: 8
+      GoRuntimeType: 26816
+      GoKind: 22
+      Pointee: 50 BaseType float32
+    - __kind: PointerType
+      ID: 58
+      Name: '*float64'
+      ByteSize: 8
+      GoRuntimeType: 26880
+      GoKind: 22
+      Pointee: 51 BaseType float64
+    - __kind: PointerType
+      ID: 16
+      Name: '*hash<string,int>'
+      ByteSize: 8
+      Pointee: 17 GoHMapHeaderType hash<string,int>
+    - __kind: PointerType
+      ID: 34
+      Name: '*hash<string,main.bigStruct>'
+      ByteSize: 8
+      Pointee: 35 GoHMapHeaderType hash<string,main.bigStruct>
+    - __kind: PointerType
       ID: 6
       Name: '*int'
       ByteSize: 8
       GoRuntimeType: 26496
       GoKind: 22
       Pointee: 1 BaseType int
-    - __kind: GoStringHeaderType
-      ID: 7
-      Name: string
-      ByteSize: 16
-      GoRuntimeType: 37440
-      GoKind: 24
-      RawFields:
-        - Name: str
-          Offset: 0
-          Type: 66 PointerType *string.str
-        - Name: len
-          Offset: 8
-          Type: 1 BaseType int
-      Data: 65 GoStringDataType string.str
+    - __kind: PointerType
+      ID: 54
+      Name: '*int32'
+      ByteSize: 8
+      GoRuntimeType: 26240
+      GoKind: 22
+      Pointee: 46 BaseType int32
+    - __kind: PointerType
+      ID: 59
+      Name: '*int64'
+      ByteSize: 8
+      GoRuntimeType: 26368
+      GoKind: 22
+      Pointee: 47 BaseType int64
+    - __kind: PointerType
+      ID: 39
+      Name: '*main.bigStruct'
+      ByteSize: 8
+      GoRuntimeType: 24256
+      GoKind: 22
+      Pointee: 40 StructureType main.bigStruct
+    - __kind: PointerType
+      ID: 31
+      Name: '*runtime.bmap'
+      ByteSize: 8
+      GoRuntimeType: 66528
+      GoKind: 22
+      Pointee: 32 StructureType runtime.bmap
+    - __kind: PointerType
+      ID: 26
+      Name: '*runtime.mapextra'
+      ByteSize: 8
+      GoRuntimeType: 29760
+      GoKind: 22
+      Pointee: 27 StructureType runtime.mapextra
+    - __kind: PointerType
+      ID: 13
+      Name: '*string'
+      ByteSize: 8
+      GoRuntimeType: 25920
+      GoKind: 22
+      Pointee: 7 GoStringHeaderType string
+    - __kind: PointerType
+      ID: 66
+      Name: '*string.str'
+      ByteSize: 8
+      Pointee: 65 GoStringDataType string.str
+    - __kind: PointerType
+      ID: 63
+      Name: '*uint'
+      ByteSize: 8
+      GoRuntimeType: 26560
+      GoKind: 22
+      Pointee: 49 BaseType uint
+    - __kind: PointerType
+      ID: 64
+      Name: '*uint16'
+      ByteSize: 8
+      GoRuntimeType: 26176
+      GoKind: 22
+      Pointee: 18 BaseType uint16
+    - __kind: PointerType
+      ID: 55
+      Name: '*uint32'
+      ByteSize: 8
+      GoRuntimeType: 26304
+      GoKind: 22
+      Pointee: 19 BaseType uint32
+    - __kind: PointerType
+      ID: 60
+      Name: '*uint64'
+      ByteSize: 8
+      GoRuntimeType: 26432
+      GoKind: 22
+      Pointee: 45 BaseType uint64
     - __kind: PointerType
       ID: 8
       Name: '*uint8'
@@ -403,12 +533,261 @@ Types:
       GoRuntimeType: 26048
       GoKind: 22
       Pointee: 9 BaseType uint8
-    - __kind: BaseType
-      ID: 9
-      Name: uint8
-      ByteSize: 1
-      GoRuntimeType: 37568
-      GoKind: 8
+    - __kind: PointerType
+      ID: 44
+      Name: '*uintptr'
+      ByteSize: 8
+      GoRuntimeType: 26624
+      GoKind: 22
+      Pointee: 25 BaseType uintptr
+    - __kind: EventRootType
+      ID: 85
+      Name: Probe[main.PointerChainArg]
+      ByteSize: 9
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: ptr
+          Offset: 1
+          Expression:
+            Type: 2 PointerType *****int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 2, index: 0, name: ptr}
+                  Offset: 0
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 86
+      Name: Probe[main.PointerSmallChainArg]
+      ByteSize: 9
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: ptr
+          Offset: 1
+          Expression:
+            Type: 5 PointerType **int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 3, index: 0, name: ptr}
+                  Offset: 0
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 83
+      Name: Probe[main.bigMapArg]
+      ByteSize: 9
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: m
+          Offset: 1
+          Expression:
+            Type: 33 GoMapType map[string]main.bigStruct
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 12, index: 0, name: m}
+                  Offset: 0
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 84
+      Name: Probe[main.inlined]
+      ByteSize: 9
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: x
+          Offset: 1
+          Expression:
+            Type: 1 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 1, index: 0, name: x}
+                  Offset: 0
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 75
+      Name: Probe[main.intArg]
+      ByteSize: 9
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: x
+          Offset: 1
+          Expression:
+            Type: 1 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 4, index: 0, name: x}
+                  Offset: 0
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 78
+      Name: Probe[main.intArrayArg]
+      ByteSize: 25
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: s
+          Offset: 1
+          Expression:
+            Type: 11 ArrayType [3]int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 7, index: 0, name: s}
+                  Offset: 0
+                  ByteSize: 24
+    - __kind: EventRootType
+      ID: 77
+      Name: Probe[main.intSliceArg]
+      ByteSize: 25
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: s
+          Offset: 1
+          Expression:
+            Type: 10 GoSliceHeaderType []int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 6, index: 0, name: s}
+                  Offset: 0
+                  ByteSize: 24
+    - __kind: EventRootType
+      ID: 82
+      Name: Probe[main.mapArg]
+      ByteSize: 9
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: m
+          Offset: 1
+          Expression:
+            Type: 15 GoMapType map[string]int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 11, index: 0, name: m}
+                  Offset: 0
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 76
+      Name: Probe[main.stringArg]
+      ByteSize: 17
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: s
+          Offset: 1
+          Expression:
+            Type: 7 GoStringHeaderType string
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 5, index: 0, name: s}
+                  Offset: 0
+                  ByteSize: 16
+    - __kind: EventRootType
+      ID: 81
+      Name: Probe[main.stringArrayArgFrameless]
+      ByteSize: 49
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: s
+          Offset: 1
+          Expression:
+            Type: 14 ArrayType [3]string
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 10, index: 0, name: s}
+                  Offset: 0
+                  ByteSize: 48
+    - __kind: EventRootType
+      ID: 80
+      Name: Probe[main.stringArrayArg]
+      ByteSize: 49
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: s
+          Offset: 1
+          Expression:
+            Type: 14 ArrayType [3]string
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 9, index: 0, name: s}
+                  Offset: 0
+                  ByteSize: 48
+    - __kind: EventRootType
+      ID: 79
+      Name: Probe[main.stringSliceArg]
+      ByteSize: 25
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: s
+          Offset: 1
+          Expression:
+            Type: 12 GoSliceHeaderType []string
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 8, index: 0, name: s}
+                  Offset: 0
+                  ByteSize: 24
+    - __kind: ArrayType
+      ID: 41
+      Name: '[128]uint8'
+      ByteSize: 128
+      GoRuntimeType: 41888
+      GoKind: 17
+      Count: 128
+      HasCount: true
+      Element: 9 BaseType uint8
+    - __kind: ArrayType
+      ID: 11
+      Name: '[3]int'
+      ByteSize: 24
+      GoRuntimeType: 41408
+      GoKind: 17
+      Count: 3
+      HasCount: true
+      Element: 1 BaseType int
+    - __kind: ArrayType
+      ID: 14
+      Name: '[3]string'
+      ByteSize: 48
+      GoRuntimeType: 41504
+      GoKind: 17
+      Count: 3
+      HasCount: true
+      Element: 7 GoStringHeaderType string
+    - __kind: ArrayType
+      ID: 22
+      Name: '[8]uint8'
+      ByteSize: 8
+      GoRuntimeType: 41600
+      GoKind: 17
+      Count: 8
+      HasCount: true
+      Element: 9 BaseType uint8
+    - __kind: GoSliceHeaderType
+      ID: 29
+      Name: '[]*runtime.bmap'
+      ByteSize: 24
+      GoRuntimeType: 35904
+      GoKind: 23
+      RawFields:
+        - Name: array
+          Offset: 0
+          Type: 30 PointerType **runtime.bmap
+        - Name: len
+          Offset: 8
+          Type: 1 BaseType int
+        - Name: cap
+          Offset: 16
+          Type: 1 BaseType int
+      Data: 72 GoSliceDataType []*runtime.bmap.array
+    - __kind: GoSliceDataType
+      ID: 72
+      Name: '[]*runtime.bmap.array'
+      ByteSize: 2048
+      Element: 31 PointerType *runtime.bmap
+    - __kind: GoSliceDataType
+      ID: 71
+      Name: '[]bucket<string,int>.array'
+      ByteSize: 2048
+      Element: 21 GoHMapBucketType bucket<string,int>
+    - __kind: GoSliceDataType
+      ID: 74
+      Name: '[]bucket<string,main.bigStruct>.array'
+      ByteSize: 2048
+      Element: 37 GoHMapBucketType bucket<string,main.bigStruct>
     - __kind: GoSliceHeaderType
       ID: 10
       Name: '[]int'
@@ -426,15 +805,18 @@ Types:
           Offset: 16
           Type: 1 BaseType int
       Data: 67 GoSliceDataType []int.array
-    - __kind: ArrayType
-      ID: 11
-      Name: '[3]int'
-      ByteSize: 24
-      GoRuntimeType: 41408
-      GoKind: 17
-      Count: 3
-      HasCount: true
+    - __kind: GoSliceDataType
+      ID: 67
+      Name: '[]int.array'
+      ByteSize: 2048
       Element: 1 BaseType int
+    - __kind: ArrayType
+      ID: 23
+      Name: '[]key<string>'
+      ByteSize: 128
+      Count: 8
+      HasCount: true
+      Element: 7 GoStringHeaderType string
     - __kind: GoSliceHeaderType
       ID: 12
       Name: '[]string'
@@ -452,34 +834,106 @@ Types:
           Offset: 16
           Type: 1 BaseType int
       Data: 69 GoSliceDataType []string.array
-    - __kind: PointerType
-      ID: 13
-      Name: '*string'
-      ByteSize: 8
-      GoRuntimeType: 25920
-      GoKind: 22
-      Pointee: 7 GoStringHeaderType string
-    - __kind: ArrayType
-      ID: 14
-      Name: '[3]string'
-      ByteSize: 48
-      GoRuntimeType: 41504
-      GoKind: 17
-      Count: 3
-      HasCount: true
+    - __kind: GoSliceDataType
+      ID: 69
+      Name: '[]string.array'
+      ByteSize: 2048
       Element: 7 GoStringHeaderType string
-    - __kind: GoMapType
-      ID: 15
-      Name: map[string]int
+    - __kind: ArrayType
+      ID: 24
+      Name: '[]val<int>'
+      ByteSize: 64
+      Count: 8
+      HasCount: true
+      Element: 1 BaseType int
+    - __kind: ArrayType
+      ID: 38
+      Name: '[]val<main.bigStruct>'
+      ByteSize: 64
+      Count: 8
+      HasCount: true
+      Element: 39 PointerType *main.bigStruct
+    - __kind: BaseType
+      ID: 42
+      Name: bool
+      ByteSize: 1
+      GoRuntimeType: 38464
+      GoKind: 1
+    - __kind: GoHMapBucketType
+      ID: 21
+      Name: bucket<string,int>
+      ByteSize: 208
+      RawFields:
+        - Name: tophash
+          Offset: 0
+          Type: 22 ArrayType [8]uint8
+        - Name: keys
+          Offset: 8
+          Type: 23 ArrayType []key<string>
+        - Name: values
+          Offset: 136
+          Type: 24 ArrayType []val<int>
+        - Name: overflow
+          Offset: 200
+          Type: 20 PointerType *bucket<string,int>
+      KeyType: 7 GoStringHeaderType string
+      ValueType: 1 BaseType int
+    - __kind: GoHMapBucketType
+      ID: 37
+      Name: bucket<string,main.bigStruct>
+      ByteSize: 208
+      RawFields:
+        - Name: tophash
+          Offset: 0
+          Type: 22 ArrayType [8]uint8
+        - Name: keys
+          Offset: 8
+          Type: 23 ArrayType []key<string>
+        - Name: values
+          Offset: 136
+          Type: 38 ArrayType []val<main.bigStruct>
+        - Name: overflow
+          Offset: 200
+          Type: 36 PointerType *bucket<string,main.bigStruct>
+      KeyType: 7 GoStringHeaderType string
+      ValueType: 39 PointerType *main.bigStruct
+    - __kind: BaseType
+      ID: 57
+      Name: complex128
+      ByteSize: 16
+      GoRuntimeType: 38272
+      GoKind: 16
+    - __kind: BaseType
+      ID: 56
+      Name: complex64
       ByteSize: 8
-      GoRuntimeType: 54656
-      GoKind: 21
-      HeaderType: 17 GoHMapHeaderType hash<string,int>
-    - __kind: PointerType
-      ID: 16
-      Name: '*hash<string,int>'
+      GoRuntimeType: 38208
+      GoKind: 15
+    - __kind: GoInterfaceType
+      ID: 52
+      Name: error
+      ByteSize: 16
+      GoRuntimeType: 59008
+      GoKind: 20
+      RawFields:
+        - Name: tab
+          Offset: 0
+          Type: 53 VoidPointerType unsafe.Pointer
+        - Name: data
+          Offset: 8
+          Type: 53 VoidPointerType unsafe.Pointer
+    - __kind: BaseType
+      ID: 50
+      Name: float32
+      ByteSize: 4
+      GoRuntimeType: 38336
+      GoKind: 13
+    - __kind: BaseType
+      ID: 51
+      Name: float64
       ByteSize: 8
-      Pointee: 17 GoHMapHeaderType hash<string,int>
+      GoRuntimeType: 38400
+      GoKind: 14
     - __kind: GoHMapHeaderType
       ID: 17
       Name: hash<string,int>
@@ -514,152 +968,6 @@ Types:
           Type: 26 PointerType *runtime.mapextra
       BucketType: 21 GoHMapBucketType bucket<string,int>
       BucketsType: 71 GoSliceDataType []bucket<string,int>.array
-    - __kind: BaseType
-      ID: 18
-      Name: uint16
-      ByteSize: 2
-      GoRuntimeType: 37696
-      GoKind: 9
-    - __kind: BaseType
-      ID: 19
-      Name: uint32
-      ByteSize: 4
-      GoRuntimeType: 37824
-      GoKind: 10
-    - __kind: PointerType
-      ID: 20
-      Name: '*bucket<string,int>'
-      ByteSize: 8
-      Pointee: 21 GoHMapBucketType bucket<string,int>
-    - __kind: GoHMapBucketType
-      ID: 21
-      Name: bucket<string,int>
-      ByteSize: 208
-      RawFields:
-        - Name: tophash
-          Offset: 0
-          Type: 22 ArrayType [8]uint8
-        - Name: keys
-          Offset: 8
-          Type: 23 ArrayType []key<string>
-        - Name: values
-          Offset: 136
-          Type: 24 ArrayType []val<int>
-        - Name: overflow
-          Offset: 200
-          Type: 20 PointerType *bucket<string,int>
-      KeyType: 7 GoStringHeaderType string
-      ValueType: 1 BaseType int
-    - __kind: ArrayType
-      ID: 22
-      Name: '[8]uint8'
-      ByteSize: 8
-      GoRuntimeType: 41600
-      GoKind: 17
-      Count: 8
-      HasCount: true
-      Element: 9 BaseType uint8
-    - __kind: ArrayType
-      ID: 23
-      Name: '[]key<string>'
-      ByteSize: 128
-      Count: 8
-      HasCount: true
-      Element: 7 GoStringHeaderType string
-    - __kind: ArrayType
-      ID: 24
-      Name: '[]val<int>'
-      ByteSize: 64
-      Count: 8
-      HasCount: true
-      Element: 1 BaseType int
-    - __kind: BaseType
-      ID: 25
-      Name: uintptr
-      ByteSize: 8
-      GoRuntimeType: 38144
-      GoKind: 12
-    - __kind: PointerType
-      ID: 26
-      Name: '*runtime.mapextra'
-      ByteSize: 8
-      GoRuntimeType: 29760
-      GoKind: 22
-      Pointee: 27 StructureType runtime.mapextra
-    - __kind: StructureType
-      ID: 27
-      Name: runtime.mapextra
-      ByteSize: 24
-      GoRuntimeType: 87232
-      GoKind: 25
-      RawFields:
-        - Name: overflow
-          Offset: 0
-          Type: 28 PointerType *[]*runtime.bmap
-        - Name: oldoverflow
-          Offset: 8
-          Type: 28 PointerType *[]*runtime.bmap
-        - Name: nextOverflow
-          Offset: 16
-          Type: 31 PointerType *runtime.bmap
-    - __kind: PointerType
-      ID: 28
-      Name: '*[]*runtime.bmap'
-      ByteSize: 8
-      GoRuntimeType: 35968
-      GoKind: 22
-      Pointee: 29 GoSliceHeaderType []*runtime.bmap
-    - __kind: GoSliceHeaderType
-      ID: 29
-      Name: '[]*runtime.bmap'
-      ByteSize: 24
-      GoRuntimeType: 35904
-      GoKind: 23
-      RawFields:
-        - Name: array
-          Offset: 0
-          Type: 30 PointerType **runtime.bmap
-        - Name: len
-          Offset: 8
-          Type: 1 BaseType int
-        - Name: cap
-          Offset: 16
-          Type: 1 BaseType int
-      Data: 72 GoSliceDataType []*runtime.bmap.array
-    - __kind: PointerType
-      ID: 30
-      Name: '**runtime.bmap'
-      ByteSize: 8
-      Pointee: 31 PointerType *runtime.bmap
-    - __kind: PointerType
-      ID: 31
-      Name: '*runtime.bmap'
-      ByteSize: 8
-      GoRuntimeType: 66528
-      GoKind: 22
-      Pointee: 32 StructureType runtime.bmap
-    - __kind: StructureType
-      ID: 32
-      Name: runtime.bmap
-      ByteSize: 8
-      GoRuntimeType: 66400
-      GoKind: 25
-      RawFields:
-        - Name: tophash
-          Offset: 0
-          Type: 22 ArrayType [8]uint8
-    - __kind: GoMapType
-      ID: 33
-      Name: map[string]main.bigStruct
-      ByteSize: 8
-      GoRuntimeType: 54752
-      GoKind: 21
-      HeaderType: 35 GoHMapHeaderType hash<string,main.bigStruct>
-    - __kind: PointerType
-      ID: 34
-      Name: '*hash<string,main.bigStruct>'
-      ByteSize: 8
-      Pointee: 35 GoHMapHeaderType hash<string,main.bigStruct>
     - __kind: GoHMapHeaderType
       ID: 35
       Name: hash<string,main.bigStruct>
@@ -694,44 +1002,30 @@ Types:
           Type: 26 PointerType *runtime.mapextra
       BucketType: 37 GoHMapBucketType bucket<string,main.bigStruct>
       BucketsType: 74 GoSliceDataType []bucket<string,main.bigStruct>.array
-    - __kind: PointerType
-      ID: 36
-      Name: '*bucket<string,main.bigStruct>'
+    - __kind: BaseType
+      ID: 1
+      Name: int
       ByteSize: 8
-      Pointee: 37 GoHMapBucketType bucket<string,main.bigStruct>
-    - __kind: GoHMapBucketType
-      ID: 37
-      Name: bucket<string,main.bigStruct>
-      ByteSize: 208
-      RawFields:
-        - Name: tophash
-          Offset: 0
-          Type: 22 ArrayType [8]uint8
-        - Name: keys
-          Offset: 8
-          Type: 23 ArrayType []key<string>
-        - Name: values
-          Offset: 136
-          Type: 38 ArrayType []val<main.bigStruct>
-        - Name: overflow
-          Offset: 200
-          Type: 36 PointerType *bucket<string,main.bigStruct>
-      KeyType: 7 GoStringHeaderType string
-      ValueType: 39 PointerType *main.bigStruct
-    - __kind: ArrayType
-      ID: 38
-      Name: '[]val<main.bigStruct>'
-      ByteSize: 64
-      Count: 8
-      HasCount: true
-      Element: 39 PointerType *main.bigStruct
-    - __kind: PointerType
-      ID: 39
-      Name: '*main.bigStruct'
+      GoRuntimeType: 38016
+      GoKind: 2
+    - __kind: BaseType
+      ID: 46
+      Name: int32
+      ByteSize: 4
+      GoRuntimeType: 37760
+      GoKind: 5
+    - __kind: BaseType
+      ID: 47
+      Name: int64
       ByteSize: 8
-      GoRuntimeType: 24256
-      GoKind: 22
-      Pointee: 40 StructureType main.bigStruct
+      GoRuntimeType: 37888
+      GoKind: 6
+    - __kind: BaseType
+      ID: 48
+      Name: int8
+      ByteSize: 1
+      GoRuntimeType: 37504
+      GoKind: 3
     - __kind: StructureType
       ID: 40
       Name: main.bigStruct
@@ -763,59 +1057,64 @@ Types:
         - Name: data
           Offset: 56
           Type: 41 ArrayType [128]uint8
-    - __kind: ArrayType
-      ID: 41
-      Name: '[128]uint8'
-      ByteSize: 128
-      GoRuntimeType: 41888
-      GoKind: 17
-      Count: 128
-      HasCount: true
-      Element: 9 BaseType uint8
-    - __kind: BaseType
-      ID: 42
-      Name: bool
-      ByteSize: 1
-      GoRuntimeType: 38464
-      GoKind: 1
-    - __kind: PointerType
-      ID: 43
-      Name: '*bool'
+    - __kind: GoMapType
+      ID: 15
+      Name: map[string]int
       ByteSize: 8
-      GoRuntimeType: 26944
-      GoKind: 22
-      Pointee: 42 BaseType bool
-    - __kind: PointerType
-      ID: 44
-      Name: '*uintptr'
+      GoRuntimeType: 54656
+      GoKind: 21
+      HeaderType: 17 GoHMapHeaderType hash<string,int>
+    - __kind: GoMapType
+      ID: 33
+      Name: map[string]main.bigStruct
       ByteSize: 8
-      GoRuntimeType: 26624
-      GoKind: 22
-      Pointee: 25 BaseType uintptr
-    - __kind: BaseType
-      ID: 45
-      Name: uint64
+      GoRuntimeType: 54752
+      GoKind: 21
+      HeaderType: 35 GoHMapHeaderType hash<string,main.bigStruct>
+    - __kind: StructureType
+      ID: 32
+      Name: runtime.bmap
       ByteSize: 8
-      GoRuntimeType: 37952
-      GoKind: 11
-    - __kind: BaseType
-      ID: 46
-      Name: int32
-      ByteSize: 4
-      GoRuntimeType: 37760
-      GoKind: 5
-    - __kind: BaseType
-      ID: 47
-      Name: int64
-      ByteSize: 8
-      GoRuntimeType: 37888
-      GoKind: 6
-    - __kind: BaseType
-      ID: 48
-      Name: int8
-      ByteSize: 1
-      GoRuntimeType: 37504
-      GoKind: 3
+      GoRuntimeType: 66400
+      GoKind: 25
+      RawFields:
+        - Name: tophash
+          Offset: 0
+          Type: 22 ArrayType [8]uint8
+    - __kind: StructureType
+      ID: 27
+      Name: runtime.mapextra
+      ByteSize: 24
+      GoRuntimeType: 87232
+      GoKind: 25
+      RawFields:
+        - Name: overflow
+          Offset: 0
+          Type: 28 PointerType *[]*runtime.bmap
+        - Name: oldoverflow
+          Offset: 8
+          Type: 28 PointerType *[]*runtime.bmap
+        - Name: nextOverflow
+          Offset: 16
+          Type: 31 PointerType *runtime.bmap
+    - __kind: GoStringHeaderType
+      ID: 7
+      Name: string
+      ByteSize: 16
+      GoRuntimeType: 37440
+      GoKind: 24
+      RawFields:
+        - Name: str
+          Offset: 0
+          Type: 66 PointerType *string.str
+        - Name: len
+          Offset: 8
+          Type: 1 BaseType int
+      Data: 65 GoStringDataType string.str
+    - __kind: GoStringDataType
+      ID: 65
+      Name: string.str
+      ByteSize: 2048
     - __kind: BaseType
       ID: 49
       Name: uint
@@ -823,340 +1122,41 @@ Types:
       GoRuntimeType: 38080
       GoKind: 7
     - __kind: BaseType
-      ID: 50
-      Name: float32
-      ByteSize: 4
-      GoRuntimeType: 38336
-      GoKind: 13
+      ID: 18
+      Name: uint16
+      ByteSize: 2
+      GoRuntimeType: 37696
+      GoKind: 9
     - __kind: BaseType
-      ID: 51
-      Name: float64
+      ID: 19
+      Name: uint32
+      ByteSize: 4
+      GoRuntimeType: 37824
+      GoKind: 10
+    - __kind: BaseType
+      ID: 45
+      Name: uint64
       ByteSize: 8
-      GoRuntimeType: 38400
-      GoKind: 14
-    - __kind: GoInterfaceType
-      ID: 52
-      Name: error
-      ByteSize: 16
-      GoRuntimeType: 59008
-      GoKind: 20
-      RawFields:
-        - Name: tab
-          Offset: 0
-          Type: 53 VoidPointerType unsafe.Pointer
-        - Name: data
-          Offset: 8
-          Type: 53 VoidPointerType unsafe.Pointer
+      GoRuntimeType: 37952
+      GoKind: 11
+    - __kind: BaseType
+      ID: 9
+      Name: uint8
+      ByteSize: 1
+      GoRuntimeType: 37568
+      GoKind: 8
+    - __kind: BaseType
+      ID: 25
+      Name: uintptr
+      ByteSize: 8
+      GoRuntimeType: 38144
+      GoKind: 12
     - __kind: VoidPointerType
       ID: 53
       Name: unsafe.Pointer
       ByteSize: 8
       GoRuntimeType: 38528
       GoKind: 26
-    - __kind: PointerType
-      ID: 54
-      Name: '*int32'
-      ByteSize: 8
-      GoRuntimeType: 26240
-      GoKind: 22
-      Pointee: 46 BaseType int32
-    - __kind: PointerType
-      ID: 55
-      Name: '*uint32'
-      ByteSize: 8
-      GoRuntimeType: 26304
-      GoKind: 22
-      Pointee: 19 BaseType uint32
-    - __kind: BaseType
-      ID: 56
-      Name: complex64
-      ByteSize: 8
-      GoRuntimeType: 38208
-      GoKind: 15
-    - __kind: BaseType
-      ID: 57
-      Name: complex128
-      ByteSize: 16
-      GoRuntimeType: 38272
-      GoKind: 16
-    - __kind: PointerType
-      ID: 58
-      Name: '*float64'
-      ByteSize: 8
-      GoRuntimeType: 26880
-      GoKind: 22
-      Pointee: 51 BaseType float64
-    - __kind: PointerType
-      ID: 59
-      Name: '*int64'
-      ByteSize: 8
-      GoRuntimeType: 26368
-      GoKind: 22
-      Pointee: 47 BaseType int64
-    - __kind: PointerType
-      ID: 60
-      Name: '*uint64'
-      ByteSize: 8
-      GoRuntimeType: 26432
-      GoKind: 22
-      Pointee: 45 BaseType uint64
-    - __kind: PointerType
-      ID: 61
-      Name: '*error'
-      ByteSize: 8
-      GoRuntimeType: 25856
-      GoKind: 22
-      Pointee: 52 GoInterfaceType error
-    - __kind: PointerType
-      ID: 62
-      Name: '*float32'
-      ByteSize: 8
-      GoRuntimeType: 26816
-      GoKind: 22
-      Pointee: 50 BaseType float32
-    - __kind: PointerType
-      ID: 63
-      Name: '*uint'
-      ByteSize: 8
-      GoRuntimeType: 26560
-      GoKind: 22
-      Pointee: 49 BaseType uint
-    - __kind: PointerType
-      ID: 64
-      Name: '*uint16'
-      ByteSize: 8
-      GoRuntimeType: 26176
-      GoKind: 22
-      Pointee: 18 BaseType uint16
-    - __kind: GoStringDataType
-      ID: 65
-      Name: string.str
-      ByteSize: 2048
-    - __kind: PointerType
-      ID: 66
-      Name: '*string.str'
-      ByteSize: 8
-      Pointee: 65 GoStringDataType string.str
-    - __kind: GoSliceDataType
-      ID: 67
-      Name: '[]int.array'
-      ByteSize: 2048
-      Element: 1 BaseType int
-    - __kind: PointerType
-      ID: 68
-      Name: '*[]int.array'
-      ByteSize: 8
-      Pointee: 67 GoSliceDataType []int.array
-    - __kind: GoSliceDataType
-      ID: 69
-      Name: '[]string.array'
-      ByteSize: 2048
-      Element: 7 GoStringHeaderType string
-    - __kind: PointerType
-      ID: 70
-      Name: '*[]string.array'
-      ByteSize: 8
-      Pointee: 69 GoSliceDataType []string.array
-    - __kind: GoSliceDataType
-      ID: 71
-      Name: '[]bucket<string,int>.array'
-      ByteSize: 2048
-      Element: 21 GoHMapBucketType bucket<string,int>
-    - __kind: GoSliceDataType
-      ID: 72
-      Name: '[]*runtime.bmap.array'
-      ByteSize: 2048
-      Element: 31 PointerType *runtime.bmap
-    - __kind: PointerType
-      ID: 73
-      Name: '*[]*runtime.bmap.array'
-      ByteSize: 8
-      Pointee: 72 GoSliceDataType []*runtime.bmap.array
-    - __kind: GoSliceDataType
-      ID: 74
-      Name: '[]bucket<string,main.bigStruct>.array'
-      ByteSize: 2048
-      Element: 37 GoHMapBucketType bucket<string,main.bigStruct>
-    - __kind: EventRootType
-      ID: 75
-      Name: Probe[main.intArg]
-      ByteSize: 9
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: x
-          Offset: 1
-          Expression:
-            Type: 1 BaseType int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 4, index: 0, name: x}
-                  Offset: 0
-                  ByteSize: 8
-    - __kind: EventRootType
-      ID: 76
-      Name: Probe[main.stringArg]
-      ByteSize: 17
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: s
-          Offset: 1
-          Expression:
-            Type: 7 GoStringHeaderType string
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 5, index: 0, name: s}
-                  Offset: 0
-                  ByteSize: 16
-    - __kind: EventRootType
-      ID: 77
-      Name: Probe[main.intSliceArg]
-      ByteSize: 25
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: s
-          Offset: 1
-          Expression:
-            Type: 10 GoSliceHeaderType []int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 6, index: 0, name: s}
-                  Offset: 0
-                  ByteSize: 24
-    - __kind: EventRootType
-      ID: 78
-      Name: Probe[main.intArrayArg]
-      ByteSize: 25
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: s
-          Offset: 1
-          Expression:
-            Type: 11 ArrayType [3]int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 7, index: 0, name: s}
-                  Offset: 0
-                  ByteSize: 24
-    - __kind: EventRootType
-      ID: 79
-      Name: Probe[main.stringSliceArg]
-      ByteSize: 25
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: s
-          Offset: 1
-          Expression:
-            Type: 12 GoSliceHeaderType []string
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 8, index: 0, name: s}
-                  Offset: 0
-                  ByteSize: 24
-    - __kind: EventRootType
-      ID: 80
-      Name: Probe[main.stringArrayArg]
-      ByteSize: 49
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: s
-          Offset: 1
-          Expression:
-            Type: 14 ArrayType [3]string
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 9, index: 0, name: s}
-                  Offset: 0
-                  ByteSize: 48
-    - __kind: EventRootType
-      ID: 81
-      Name: Probe[main.stringArrayArgFrameless]
-      ByteSize: 49
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: s
-          Offset: 1
-          Expression:
-            Type: 14 ArrayType [3]string
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 10, index: 0, name: s}
-                  Offset: 0
-                  ByteSize: 48
-    - __kind: EventRootType
-      ID: 82
-      Name: Probe[main.mapArg]
-      ByteSize: 9
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: m
-          Offset: 1
-          Expression:
-            Type: 15 GoMapType map[string]int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 11, index: 0, name: m}
-                  Offset: 0
-                  ByteSize: 8
-    - __kind: EventRootType
-      ID: 83
-      Name: Probe[main.bigMapArg]
-      ByteSize: 9
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: m
-          Offset: 1
-          Expression:
-            Type: 33 GoMapType map[string]main.bigStruct
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 12, index: 0, name: m}
-                  Offset: 0
-                  ByteSize: 8
-    - __kind: EventRootType
-      ID: 84
-      Name: Probe[main.inlined]
-      ByteSize: 9
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: x
-          Offset: 1
-          Expression:
-            Type: 1 BaseType int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 1, index: 0, name: x}
-                  Offset: 0
-                  ByteSize: 8
-    - __kind: EventRootType
-      ID: 85
-      Name: Probe[main.PointerChainArg]
-      ByteSize: 9
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: ptr
-          Offset: 1
-          Expression:
-            Type: 2 PointerType *****int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 2, index: 0, name: ptr}
-                  Offset: 0
-                  ByteSize: 8
-    - __kind: EventRootType
-      ID: 86
-      Name: Probe[main.PointerSmallChainArg]
-      ByteSize: 9
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: ptr
-          Offset: 1
-          Expression:
-            Type: 5 PointerType **int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 3, index: 0, name: ptr}
-                  Offset: 0
-                  ByteSize: 8
 MaxTypeID: 86
 Issues: []
 GoModuledataInfo: {FirstModuledataAddr: "0x572240", TypesOffset: 296}

--- a/pkg/dyninst/irgen/testdata/snapshot/simple.arch=amd64,toolchain=go1.23.11.yaml
+++ b/pkg/dyninst/irgen/testdata/snapshot/simple.arch=amd64,toolchain=go1.23.11.yaml
@@ -288,7 +288,7 @@ Subprograms:
       InlinePCRanges: []
       Variables:
         - Name: m
-          Type: 52 GoMapType map[string]main.bigStruct
+          Type: 44 GoMapType map[string]main.bigStruct
           Locations:
             - Range: 0x4a64e0..0x4a6513
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
@@ -320,7 +320,7 @@ Subprograms:
           RootRanges: [0x4a5c40..0x4a609d]
       Variables:
         - Name: ptr
-          Type: 61 PointerType *****int
+          Type: 49 PointerType *****int
           Locations:
             - Range: 0x4a5fdf..0x4a602b
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
@@ -334,7 +334,7 @@ Subprograms:
           RootRanges: [0x4a5c40..0x4a609d]
       Variables:
         - Name: ptr
-          Type: 64 PointerType **int
+          Type: 51 PointerType **int
           Locations:
             - Range: 0x4a6050..0x4a608a
               Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
@@ -342,50 +342,50 @@ Subprograms:
           IsReturn: false
 Types:
     - __kind: PointerType
-      ID: 61
+      ID: 49
       Name: '*****int'
       ByteSize: 8
       GoRuntimeType: 32512
       GoKind: 22
-      Pointee: 62 PointerType ****int
+      Pointee: 50 PointerType ****int
     - __kind: PointerType
-      ID: 62
+      ID: 50
       Name: '****int'
       ByteSize: 8
       GoRuntimeType: 32448
       GoKind: 22
-      Pointee: 63 PointerType ***int
+      Pointee: 62 PointerType ***int
     - __kind: PointerType
-      ID: 63
+      ID: 62
       Name: '***int'
       ByteSize: 8
       GoRuntimeType: 32384
       GoKind: 22
-      Pointee: 64 PointerType **int
+      Pointee: 51 PointerType **int
     - __kind: PointerType
-      ID: 64
+      ID: 51
       Name: '**int'
       ByteSize: 8
       GoRuntimeType: 32320
       GoKind: 22
       Pointee: 27 PointerType *int
     - __kind: PointerType
-      ID: 49
+      ID: 63
       Name: '**runtime.bmap'
       ByteSize: 8
-      Pointee: 50 PointerType *runtime.bmap
+      Pointee: 57 PointerType *runtime.bmap
     - __kind: PointerType
-      ID: 47
+      ID: 55
       Name: '*[]*runtime.bmap'
       ByteSize: 8
       GoRuntimeType: 35968
       GoKind: 22
-      Pointee: 48 GoSliceHeaderType []*runtime.bmap
+      Pointee: 56 GoSliceHeaderType []*runtime.bmap
     - __kind: PointerType
-      ID: 73
+      ID: 74
       Name: '*[]*runtime.bmap.array'
       ByteSize: 8
-      Pointee: 72 GoSliceDataType []*runtime.bmap.array
+      Pointee: 73 GoSliceDataType []*runtime.bmap.array
     - __kind: PointerType
       ID: 68
       Name: '*[]int.array'
@@ -409,10 +409,10 @@ Types:
       ByteSize: 8
       Pointee: 41 GoHMapBucketType bucket<string,int>
     - __kind: PointerType
-      ID: 55
+      ID: 47
       Name: '*bucket<string,main.bigStruct>'
       ByteSize: 8
-      Pointee: 56 GoHMapBucketType bucket<string,main.bigStruct>
+      Pointee: 48 GoHMapBucketType bucket<string,main.bigStruct>
     - __kind: PointerType
       ID: 29
       Name: '*error'
@@ -440,10 +440,10 @@ Types:
       ByteSize: 8
       Pointee: 39 GoHMapHeaderType hash<string,int>
     - __kind: PointerType
-      ID: 53
+      ID: 45
       Name: '*hash<string,main.bigStruct>'
       ByteSize: 8
-      Pointee: 54 GoHMapHeaderType hash<string,main.bigStruct>
+      Pointee: 46 GoHMapHeaderType hash<string,main.bigStruct>
     - __kind: PointerType
       ID: 27
       Name: '*int'
@@ -466,26 +466,26 @@ Types:
       GoKind: 22
       Pointee: 13 BaseType int64
     - __kind: PointerType
-      ID: 58
+      ID: 60
       Name: '*main.bigStruct'
       ByteSize: 8
       GoRuntimeType: 24256
       GoKind: 22
-      Pointee: 59 StructureType main.bigStruct
+      Pointee: 61 StructureType main.bigStruct
     - __kind: PointerType
-      ID: 50
+      ID: 57
       Name: '*runtime.bmap'
       ByteSize: 8
       GoRuntimeType: 66528
       GoKind: 22
-      Pointee: 51 StructureType runtime.bmap
+      Pointee: 58 StructureType runtime.bmap
     - __kind: PointerType
-      ID: 45
+      ID: 42
       Name: '*runtime.mapextra'
       ByteSize: 8
       GoRuntimeType: 29760
       GoKind: 22
-      Pointee: 46 StructureType runtime.mapextra
+      Pointee: 43 StructureType runtime.mapextra
     - __kind: PointerType
       ID: 22
       Name: '*string'
@@ -549,7 +549,7 @@ Types:
         - Name: ptr
           Offset: 1
           Expression:
-            Type: 61 PointerType *****int
+            Type: 49 PointerType *****int
             Operations:
                 - __kind: LocationOp
                   Variable: {subprogram: 11, index: 0, name: ptr}
@@ -564,7 +564,7 @@ Types:
         - Name: ptr
           Offset: 1
           Expression:
-            Type: 64 PointerType **int
+            Type: 51 PointerType **int
             Operations:
                 - __kind: LocationOp
                   Variable: {subprogram: 12, index: 0, name: ptr}
@@ -579,7 +579,7 @@ Types:
         - Name: m
           Offset: 1
           Expression:
-            Type: 52 GoMapType map[string]main.bigStruct
+            Type: 44 GoMapType map[string]main.bigStruct
             Operations:
                 - __kind: LocationOp
                   Variable: {subprogram: 9, index: 0, name: m}
@@ -721,7 +721,7 @@ Types:
                   Offset: 0
                   ByteSize: 24
     - __kind: ArrayType
-      ID: 60
+      ID: 64
       Name: '[128]uint8'
       ByteSize: 128
       GoRuntimeType: 41888
@@ -748,7 +748,7 @@ Types:
       HasCount: true
       Element: 10 GoStringHeaderType string
     - __kind: ArrayType
-      ID: 42
+      ID: 52
       Name: '[8]uint8'
       ByteSize: 8
       GoRuntimeType: 41600
@@ -757,7 +757,7 @@ Types:
       HasCount: true
       Element: 3 BaseType uint8
     - __kind: GoSliceHeaderType
-      ID: 48
+      ID: 56
       Name: '[]*runtime.bmap'
       ByteSize: 24
       GoRuntimeType: 35904
@@ -765,29 +765,29 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 49 PointerType **runtime.bmap
+          Type: 63 PointerType **runtime.bmap
         - Name: len
           Offset: 8
           Type: 9 BaseType int
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 72 GoSliceDataType []*runtime.bmap.array
+      Data: 73 GoSliceDataType []*runtime.bmap.array
     - __kind: GoSliceDataType
-      ID: 72
+      ID: 73
       Name: '[]*runtime.bmap.array'
       ByteSize: 2048
-      Element: 50 PointerType *runtime.bmap
+      Element: 57 PointerType *runtime.bmap
     - __kind: GoSliceDataType
       ID: 71
       Name: '[]bucket<string,int>.array'
       ByteSize: 2048
       Element: 41 GoHMapBucketType bucket<string,int>
     - __kind: GoSliceDataType
-      ID: 74
+      ID: 72
       Name: '[]bucket<string,main.bigStruct>.array'
       ByteSize: 2048
-      Element: 56 GoHMapBucketType bucket<string,main.bigStruct>
+      Element: 48 GoHMapBucketType bucket<string,main.bigStruct>
     - __kind: GoSliceHeaderType
       ID: 33
       Name: '[]int'
@@ -811,7 +811,7 @@ Types:
       ByteSize: 2048
       Element: 9 BaseType int
     - __kind: ArrayType
-      ID: 43
+      ID: 53
       Name: '[]key<string>'
       ByteSize: 128
       Count: 8
@@ -840,19 +840,19 @@ Types:
       ByteSize: 2048
       Element: 10 GoStringHeaderType string
     - __kind: ArrayType
-      ID: 44
+      ID: 54
       Name: '[]val<int>'
       ByteSize: 64
       Count: 8
       HasCount: true
       Element: 9 BaseType int
     - __kind: ArrayType
-      ID: 57
+      ID: 59
       Name: '[]val<main.bigStruct>'
       ByteSize: 64
       Count: 8
       HasCount: true
-      Element: 58 PointerType *main.bigStruct
+      Element: 60 PointerType *main.bigStruct
     - __kind: BaseType
       ID: 4
       Name: bool
@@ -866,37 +866,37 @@ Types:
       RawFields:
         - Name: tophash
           Offset: 0
-          Type: 42 ArrayType [8]uint8
+          Type: 52 ArrayType [8]uint8
         - Name: keys
           Offset: 8
-          Type: 43 ArrayType []key<string>
+          Type: 53 ArrayType []key<string>
         - Name: values
           Offset: 136
-          Type: 44 ArrayType []val<int>
+          Type: 54 ArrayType []val<int>
         - Name: overflow
           Offset: 200
           Type: 40 PointerType *bucket<string,int>
       KeyType: 10 GoStringHeaderType string
       ValueType: 9 BaseType int
     - __kind: GoHMapBucketType
-      ID: 56
+      ID: 48
       Name: bucket<string,main.bigStruct>
       ByteSize: 208
       RawFields:
         - Name: tophash
           Offset: 0
-          Type: 42 ArrayType [8]uint8
+          Type: 52 ArrayType [8]uint8
         - Name: keys
           Offset: 8
-          Type: 43 ArrayType []key<string>
+          Type: 53 ArrayType []key<string>
         - Name: values
           Offset: 136
-          Type: 57 ArrayType []val<main.bigStruct>
+          Type: 59 ArrayType []val<main.bigStruct>
         - Name: overflow
           Offset: 200
-          Type: 55 PointerType *bucket<string,main.bigStruct>
+          Type: 47 PointerType *bucket<string,main.bigStruct>
       KeyType: 10 GoStringHeaderType string
-      ValueType: 58 PointerType *main.bigStruct
+      ValueType: 60 PointerType *main.bigStruct
     - __kind: BaseType
       ID: 24
       Name: complex128
@@ -965,11 +965,11 @@ Types:
           Type: 1 BaseType uintptr
         - Name: extra
           Offset: 40
-          Type: 45 PointerType *runtime.mapextra
+          Type: 42 PointerType *runtime.mapextra
       BucketType: 41 GoHMapBucketType bucket<string,int>
       BucketsType: 71 GoSliceDataType []bucket<string,int>.array
     - __kind: GoHMapHeaderType
-      ID: 54
+      ID: 46
       Name: hash<string,main.bigStruct>
       ByteSize: 48
       RawFields:
@@ -990,18 +990,18 @@ Types:
           Type: 2 BaseType uint32
         - Name: buckets
           Offset: 16
-          Type: 55 PointerType *bucket<string,main.bigStruct>
+          Type: 47 PointerType *bucket<string,main.bigStruct>
         - Name: oldbuckets
           Offset: 24
-          Type: 55 PointerType *bucket<string,main.bigStruct>
+          Type: 47 PointerType *bucket<string,main.bigStruct>
         - Name: nevacuate
           Offset: 32
           Type: 1 BaseType uintptr
         - Name: extra
           Offset: 40
-          Type: 45 PointerType *runtime.mapextra
-      BucketType: 56 GoHMapBucketType bucket<string,main.bigStruct>
-      BucketsType: 74 GoSliceDataType []bucket<string,main.bigStruct>.array
+          Type: 42 PointerType *runtime.mapextra
+      BucketType: 48 GoHMapBucketType bucket<string,main.bigStruct>
+      BucketsType: 72 GoSliceDataType []bucket<string,main.bigStruct>.array
     - __kind: BaseType
       ID: 9
       Name: int
@@ -1027,7 +1027,7 @@ Types:
       GoRuntimeType: 37504
       GoKind: 3
     - __kind: StructureType
-      ID: 59
+      ID: 61
       Name: main.bigStruct
       ByteSize: 184
       GoRuntimeType: 110528
@@ -1056,7 +1056,7 @@ Types:
           Type: 9 BaseType int
         - Name: data
           Offset: 56
-          Type: 60 ArrayType [128]uint8
+          Type: 64 ArrayType [128]uint8
     - __kind: GoMapType
       ID: 37
       Name: map[string]int
@@ -1065,14 +1065,14 @@ Types:
       GoKind: 21
       HeaderType: 39 GoHMapHeaderType hash<string,int>
     - __kind: GoMapType
-      ID: 52
+      ID: 44
       Name: map[string]main.bigStruct
       ByteSize: 8
       GoRuntimeType: 54752
       GoKind: 21
-      HeaderType: 54 GoHMapHeaderType hash<string,main.bigStruct>
+      HeaderType: 46 GoHMapHeaderType hash<string,main.bigStruct>
     - __kind: StructureType
-      ID: 51
+      ID: 58
       Name: runtime.bmap
       ByteSize: 8
       GoRuntimeType: 66400
@@ -1080,9 +1080,9 @@ Types:
       RawFields:
         - Name: tophash
           Offset: 0
-          Type: 42 ArrayType [8]uint8
+          Type: 52 ArrayType [8]uint8
     - __kind: StructureType
-      ID: 46
+      ID: 43
       Name: runtime.mapextra
       ByteSize: 24
       GoRuntimeType: 87232
@@ -1090,13 +1090,13 @@ Types:
       RawFields:
         - Name: overflow
           Offset: 0
-          Type: 47 PointerType *[]*runtime.bmap
+          Type: 55 PointerType *[]*runtime.bmap
         - Name: oldoverflow
           Offset: 8
-          Type: 47 PointerType *[]*runtime.bmap
+          Type: 55 PointerType *[]*runtime.bmap
         - Name: nextOverflow
           Offset: 16
-          Type: 50 PointerType *runtime.bmap
+          Type: 57 PointerType *runtime.bmap
     - __kind: GoStringHeaderType
       ID: 10
       Name: string

--- a/pkg/dyninst/irgen/testdata/snapshot/simple.arch=amd64,toolchain=go1.23.11.yaml
+++ b/pkg/dyninst/irgen/testdata/snapshot/simple.arch=amd64,toolchain=go1.23.11.yaml
@@ -370,7 +370,7 @@ Types:
       GoKind: 22
       Pointee: 27 PointerType *int
     - __kind: PointerType
-      ID: 63
+      ID: 71
       Name: '**runtime.bmap'
       ByteSize: 8
       Pointee: 57 PointerType *runtime.bmap
@@ -387,15 +387,15 @@ Types:
       ByteSize: 8
       Pointee: 73 GoSliceDataType []*runtime.bmap.array
     - __kind: PointerType
-      ID: 68
+      ID: 66
       Name: '*[]int.array'
       ByteSize: 8
-      Pointee: 67 GoSliceDataType []int.array
+      Pointee: 65 GoSliceDataType []int.array
     - __kind: PointerType
-      ID: 70
+      ID: 68
       Name: '*[]string.array'
       ByteSize: 8
-      Pointee: 69 GoSliceDataType []string.array
+      Pointee: 67 GoSliceDataType []string.array
     - __kind: PointerType
       ID: 5
       Name: '*bool'
@@ -494,10 +494,10 @@ Types:
       GoKind: 22
       Pointee: 10 GoStringHeaderType string
     - __kind: PointerType
-      ID: 66
+      ID: 64
       Name: '*string.str'
       ByteSize: 8
-      Pointee: 65 GoStringDataType string.str
+      Pointee: 63 GoStringDataType string.str
     - __kind: PointerType
       ID: 31
       Name: '*uint'
@@ -721,7 +721,7 @@ Types:
                   Offset: 0
                   ByteSize: 24
     - __kind: ArrayType
-      ID: 64
+      ID: 72
       Name: '[128]uint8'
       ByteSize: 128
       GoRuntimeType: 41888
@@ -765,7 +765,7 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 63 PointerType **runtime.bmap
+          Type: 71 PointerType **runtime.bmap
         - Name: len
           Offset: 8
           Type: 9 BaseType int
@@ -779,12 +779,12 @@ Types:
       ByteSize: 2048
       Element: 57 PointerType *runtime.bmap
     - __kind: GoSliceDataType
-      ID: 71
+      ID: 69
       Name: '[]bucket<string,int>.array'
       ByteSize: 2048
       Element: 41 GoHMapBucketType bucket<string,int>
     - __kind: GoSliceDataType
-      ID: 72
+      ID: 70
       Name: '[]bucket<string,main.bigStruct>.array'
       ByteSize: 2048
       Element: 48 GoHMapBucketType bucket<string,main.bigStruct>
@@ -804,9 +804,9 @@ Types:
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 67 GoSliceDataType []int.array
+      Data: 65 GoSliceDataType []int.array
     - __kind: GoSliceDataType
-      ID: 67
+      ID: 65
       Name: '[]int.array'
       ByteSize: 2048
       Element: 9 BaseType int
@@ -833,9 +833,9 @@ Types:
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 69 GoSliceDataType []string.array
+      Data: 67 GoSliceDataType []string.array
     - __kind: GoSliceDataType
-      ID: 69
+      ID: 67
       Name: '[]string.array'
       ByteSize: 2048
       Element: 10 GoStringHeaderType string
@@ -967,7 +967,7 @@ Types:
           Offset: 40
           Type: 42 PointerType *runtime.mapextra
       BucketType: 41 GoHMapBucketType bucket<string,int>
-      BucketsType: 71 GoSliceDataType []bucket<string,int>.array
+      BucketsType: 69 GoSliceDataType []bucket<string,int>.array
     - __kind: GoHMapHeaderType
       ID: 46
       Name: hash<string,main.bigStruct>
@@ -1001,7 +1001,7 @@ Types:
           Offset: 40
           Type: 42 PointerType *runtime.mapextra
       BucketType: 48 GoHMapBucketType bucket<string,main.bigStruct>
-      BucketsType: 72 GoSliceDataType []bucket<string,main.bigStruct>.array
+      BucketsType: 70 GoSliceDataType []bucket<string,main.bigStruct>.array
     - __kind: BaseType
       ID: 9
       Name: int
@@ -1056,7 +1056,7 @@ Types:
           Type: 9 BaseType int
         - Name: data
           Offset: 56
-          Type: 64 ArrayType [128]uint8
+          Type: 72 ArrayType [128]uint8
     - __kind: GoMapType
       ID: 37
       Name: map[string]int
@@ -1106,13 +1106,13 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 66 PointerType *string.str
+          Type: 64 PointerType *string.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 65 GoStringDataType string.str
+      Data: 63 GoStringDataType string.str
     - __kind: GoStringDataType
-      ID: 65
+      ID: 63
       Name: string.str
       ByteSize: 2048
     - __kind: BaseType

--- a/pkg/dyninst/irgen/testdata/snapshot/simple.arch=amd64,toolchain=go1.23.11.yaml
+++ b/pkg/dyninst/irgen/testdata/snapshot/simple.arch=amd64,toolchain=go1.23.11.yaml
@@ -11,7 +11,7 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 2}
+      subprogram: {subprogram: 11}
       events:
         - ID: 11
           Type: 85 EventRootType Probe[main.PointerChainArg]
@@ -28,7 +28,7 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 3}
+      subprogram: {subprogram: 12}
       events:
         - ID: 12
           Type: 86 EventRootType Probe[main.PointerSmallChainArg]
@@ -41,7 +41,7 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 12}
+      subprogram: {subprogram: 9}
       events:
         - ID: 9
           Type: 83 EventRootType Probe[main.bigMapArg]
@@ -55,7 +55,7 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 1}
+      subprogram: {subprogram: 10}
       events:
         - ID: 10
           Type: 84 EventRootType Probe[main.inlined]
@@ -72,7 +72,7 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 4}
+      subprogram: {subprogram: 1}
       events:
         - ID: 1
           Type: 75 EventRootType Probe[main.intArg]
@@ -85,7 +85,7 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 7}
+      subprogram: {subprogram: 4}
       events:
         - ID: 4
           Type: 78 EventRootType Probe[main.intArrayArg]
@@ -98,7 +98,7 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 10}
+      subprogram: {subprogram: 7}
       events:
         - ID: 7
           Type: 81 EventRootType Probe[main.stringArrayArgFrameless]
@@ -111,7 +111,7 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 6}
+      subprogram: {subprogram: 3}
       events:
         - ID: 3
           Type: 77 EventRootType Probe[main.intSliceArg]
@@ -124,7 +124,7 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 11}
+      subprogram: {subprogram: 8}
       events:
         - ID: 8
           Type: 82 EventRootType Probe[main.mapArg]
@@ -137,7 +137,7 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 5}
+      subprogram: {subprogram: 2}
       events:
         - ID: 2
           Type: 76 EventRootType Probe[main.stringArg]
@@ -150,7 +150,7 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 9}
+      subprogram: {subprogram: 6}
       events:
         - ID: 6
           Type: 80 EventRootType Probe[main.stringArrayArg]
@@ -163,32 +163,32 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 8}
+      subprogram: {subprogram: 5}
       events:
         - ID: 5
           Type: 79 EventRootType Probe[main.stringSliceArg]
           InjectionPoints: [{PC: "0x4a62aa", Frameless: false}]
           Condition: null
 Subprograms:
-    - ID: 4
+    - ID: 1
       Name: main.intArg
       OutOfLinePCRanges: [0x4a60a0..0x4a6102]
       InlinePCRanges: []
       Variables:
         - Name: x
-          Type: 1 BaseType int
+          Type: 9 BaseType int
           Locations:
             - Range: 0x4a60a0..0x4a60b9
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 5
+    - ID: 2
       Name: main.stringArg
       OutOfLinePCRanges: [0x4a6120..0x4a6191]
       InlinePCRanges: []
       Variables:
         - Name: s
-          Type: 7 GoStringHeaderType string
+          Type: 10 GoStringHeaderType string
           Locations:
             - Range: 0x4a6120..0x4a613e
               Pieces:
@@ -198,13 +198,13 @@ Subprograms:
                   Op: {RegNo: 3, Shift: 0}
           IsParameter: true
           IsReturn: false
-    - ID: 6
+    - ID: 3
       Name: main.intSliceArg
       OutOfLinePCRanges: [0x4a61a0..0x4a621a]
       InlinePCRanges: []
       Variables:
         - Name: s
-          Type: 10 GoSliceHeaderType []int
+          Type: 33 GoSliceHeaderType []int
           Locations:
             - Range: 0x4a61a0..0x4a61be
               Pieces:
@@ -216,25 +216,25 @@ Subprograms:
                   Op: {RegNo: 2, Shift: 0}
           IsParameter: true
           IsReturn: false
-    - ID: 7
+    - ID: 4
       Name: main.intArrayArg
       OutOfLinePCRanges: [0x4a6220..0x4a6287]
       InlinePCRanges: []
       Variables:
         - Name: s
-          Type: 11 ArrayType [3]int
+          Type: 34 ArrayType [3]int
           Locations:
             - Range: 0x4a6220..0x4a6287
               Pieces: [{Size: 24, Op: {CfaOffset: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 8
+    - ID: 5
       Name: main.stringSliceArg
       OutOfLinePCRanges: [0x4a62a0..0x4a631a]
       InlinePCRanges: []
       Variables:
         - Name: s
-          Type: 12 GoSliceHeaderType []string
+          Type: 35 GoSliceHeaderType []string
           Locations:
             - Range: 0x4a62a0..0x4a62be
               Pieces:
@@ -246,49 +246,49 @@ Subprograms:
                   Op: {RegNo: 2, Shift: 0}
           IsParameter: true
           IsReturn: false
-    - ID: 9
+    - ID: 6
       Name: main.stringArrayArg
       OutOfLinePCRanges: [0x4a6320..0x4a6387]
       InlinePCRanges: []
       Variables:
         - Name: s
-          Type: 14 ArrayType [3]string
+          Type: 36 ArrayType [3]string
           Locations:
             - Range: 0x4a6320..0x4a6387
               Pieces: [{Size: 48, Op: {CfaOffset: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 10
+    - ID: 7
       Name: main.stringArrayArgFrameless
       OutOfLinePCRanges: [0x4a63a0..0x4a63a1]
       InlinePCRanges: []
       Variables:
         - Name: s
-          Type: 14 ArrayType [3]string
+          Type: 36 ArrayType [3]string
           Locations:
             - Range: 0x4a63a0..0x4a63a1
               Pieces: [{Size: 48, Op: {CfaOffset: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 11
+    - ID: 8
       Name: main.mapArg
       OutOfLinePCRanges: [0x4a6480..0x4a64d6]
       InlinePCRanges: []
       Variables:
         - Name: m
-          Type: 15 GoMapType map[string]int
+          Type: 37 GoMapType map[string]int
           Locations:
             - Range: 0x4a6480..0x4a64ad
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 12
+    - ID: 9
       Name: main.bigMapArg
       OutOfLinePCRanges: [0x4a64e0..0x4a659b]
       InlinePCRanges: []
       Variables:
         - Name: m
-          Type: 33 GoMapType map[string]main.bigStruct
+          Type: 52 GoMapType map[string]main.bigStruct
           Locations:
             - Range: 0x4a64e0..0x4a6513
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
@@ -296,7 +296,7 @@ Subprograms:
               Pieces: [{Size: 8, Op: {CfaOffset: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 1
+    - ID: 10
       Name: main.inlined
       OutOfLinePCRanges: [0x4a63c0..0x4a6422]
       InlinePCRanges:
@@ -304,7 +304,7 @@ Subprograms:
           RootRanges: [0x4a5c40..0x4a609d]
       Variables:
         - Name: x
-          Type: 1 BaseType int
+          Type: 9 BaseType int
           Locations:
             - Range: 0x4a5dce..0x4a5e1f
               Pieces: []
@@ -312,7 +312,7 @@ Subprograms:
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 2
+    - ID: 11
       Name: main.PointerChainArg
       OutOfLinePCRanges: []
       InlinePCRanges:
@@ -320,13 +320,13 @@ Subprograms:
           RootRanges: [0x4a5c40..0x4a609d]
       Variables:
         - Name: ptr
-          Type: 2 PointerType *****int
+          Type: 61 PointerType *****int
           Locations:
             - Range: 0x4a5fdf..0x4a602b
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 3
+    - ID: 12
       Name: main.PointerSmallChainArg
       OutOfLinePCRanges: []
       InlinePCRanges:
@@ -334,7 +334,7 @@ Subprograms:
           RootRanges: [0x4a5c40..0x4a609d]
       Variables:
         - Name: ptr
-          Type: 5 PointerType **int
+          Type: 64 PointerType **int
           Locations:
             - Range: 0x4a6050..0x4a608a
               Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
@@ -342,45 +342,45 @@ Subprograms:
           IsReturn: false
 Types:
     - __kind: PointerType
-      ID: 2
+      ID: 61
       Name: '*****int'
       ByteSize: 8
       GoRuntimeType: 32512
       GoKind: 22
-      Pointee: 3 PointerType ****int
+      Pointee: 62 PointerType ****int
     - __kind: PointerType
-      ID: 3
+      ID: 62
       Name: '****int'
       ByteSize: 8
       GoRuntimeType: 32448
       GoKind: 22
-      Pointee: 4 PointerType ***int
+      Pointee: 63 PointerType ***int
     - __kind: PointerType
-      ID: 4
+      ID: 63
       Name: '***int'
       ByteSize: 8
       GoRuntimeType: 32384
       GoKind: 22
-      Pointee: 5 PointerType **int
+      Pointee: 64 PointerType **int
     - __kind: PointerType
-      ID: 5
+      ID: 64
       Name: '**int'
       ByteSize: 8
       GoRuntimeType: 32320
       GoKind: 22
-      Pointee: 6 PointerType *int
+      Pointee: 27 PointerType *int
     - __kind: PointerType
-      ID: 30
+      ID: 49
       Name: '**runtime.bmap'
       ByteSize: 8
-      Pointee: 31 PointerType *runtime.bmap
+      Pointee: 50 PointerType *runtime.bmap
     - __kind: PointerType
-      ID: 28
+      ID: 47
       Name: '*[]*runtime.bmap'
       ByteSize: 8
       GoRuntimeType: 35968
       GoKind: 22
-      Pointee: 29 GoSliceHeaderType []*runtime.bmap
+      Pointee: 48 GoSliceHeaderType []*runtime.bmap
     - __kind: PointerType
       ID: 73
       Name: '*[]*runtime.bmap.array'
@@ -397,149 +397,149 @@ Types:
       ByteSize: 8
       Pointee: 69 GoSliceDataType []string.array
     - __kind: PointerType
-      ID: 43
+      ID: 5
       Name: '*bool'
       ByteSize: 8
       GoRuntimeType: 26944
       GoKind: 22
-      Pointee: 42 BaseType bool
+      Pointee: 4 BaseType bool
     - __kind: PointerType
-      ID: 20
+      ID: 40
       Name: '*bucket<string,int>'
       ByteSize: 8
-      Pointee: 21 GoHMapBucketType bucket<string,int>
+      Pointee: 41 GoHMapBucketType bucket<string,int>
     - __kind: PointerType
-      ID: 36
+      ID: 55
       Name: '*bucket<string,main.bigStruct>'
       ByteSize: 8
-      Pointee: 37 GoHMapBucketType bucket<string,main.bigStruct>
+      Pointee: 56 GoHMapBucketType bucket<string,main.bigStruct>
     - __kind: PointerType
-      ID: 61
+      ID: 29
       Name: '*error'
       ByteSize: 8
       GoRuntimeType: 25856
       GoKind: 22
-      Pointee: 52 GoInterfaceType error
+      Pointee: 18 GoInterfaceType error
     - __kind: PointerType
-      ID: 62
+      ID: 30
       Name: '*float32'
       ByteSize: 8
       GoRuntimeType: 26816
       GoKind: 22
-      Pointee: 50 BaseType float32
+      Pointee: 16 BaseType float32
     - __kind: PointerType
-      ID: 58
+      ID: 25
       Name: '*float64'
       ByteSize: 8
       GoRuntimeType: 26880
       GoKind: 22
-      Pointee: 51 BaseType float64
+      Pointee: 17 BaseType float64
     - __kind: PointerType
-      ID: 16
+      ID: 38
       Name: '*hash<string,int>'
       ByteSize: 8
-      Pointee: 17 GoHMapHeaderType hash<string,int>
+      Pointee: 39 GoHMapHeaderType hash<string,int>
     - __kind: PointerType
-      ID: 34
+      ID: 53
       Name: '*hash<string,main.bigStruct>'
       ByteSize: 8
-      Pointee: 35 GoHMapHeaderType hash<string,main.bigStruct>
+      Pointee: 54 GoHMapHeaderType hash<string,main.bigStruct>
     - __kind: PointerType
-      ID: 6
+      ID: 27
       Name: '*int'
       ByteSize: 8
       GoRuntimeType: 26496
       GoKind: 22
-      Pointee: 1 BaseType int
+      Pointee: 9 BaseType int
     - __kind: PointerType
-      ID: 54
+      ID: 20
       Name: '*int32'
       ByteSize: 8
       GoRuntimeType: 26240
       GoKind: 22
-      Pointee: 46 BaseType int32
+      Pointee: 12 BaseType int32
     - __kind: PointerType
-      ID: 59
+      ID: 26
       Name: '*int64'
       ByteSize: 8
       GoRuntimeType: 26368
       GoKind: 22
-      Pointee: 47 BaseType int64
+      Pointee: 13 BaseType int64
     - __kind: PointerType
-      ID: 39
+      ID: 58
       Name: '*main.bigStruct'
       ByteSize: 8
       GoRuntimeType: 24256
       GoKind: 22
-      Pointee: 40 StructureType main.bigStruct
+      Pointee: 59 StructureType main.bigStruct
     - __kind: PointerType
-      ID: 31
+      ID: 50
       Name: '*runtime.bmap'
       ByteSize: 8
       GoRuntimeType: 66528
       GoKind: 22
-      Pointee: 32 StructureType runtime.bmap
+      Pointee: 51 StructureType runtime.bmap
     - __kind: PointerType
-      ID: 26
+      ID: 45
       Name: '*runtime.mapextra'
       ByteSize: 8
       GoRuntimeType: 29760
       GoKind: 22
-      Pointee: 27 StructureType runtime.mapextra
+      Pointee: 46 StructureType runtime.mapextra
     - __kind: PointerType
-      ID: 13
+      ID: 22
       Name: '*string'
       ByteSize: 8
       GoRuntimeType: 25920
       GoKind: 22
-      Pointee: 7 GoStringHeaderType string
+      Pointee: 10 GoStringHeaderType string
     - __kind: PointerType
       ID: 66
       Name: '*string.str'
       ByteSize: 8
       Pointee: 65 GoStringDataType string.str
     - __kind: PointerType
-      ID: 63
+      ID: 31
       Name: '*uint'
       ByteSize: 8
       GoRuntimeType: 26560
       GoKind: 22
-      Pointee: 49 BaseType uint
+      Pointee: 15 BaseType uint
     - __kind: PointerType
-      ID: 64
+      ID: 32
       Name: '*uint16'
       ByteSize: 8
       GoRuntimeType: 26176
       GoKind: 22
-      Pointee: 18 BaseType uint16
+      Pointee: 7 BaseType uint16
     - __kind: PointerType
-      ID: 55
+      ID: 21
       Name: '*uint32'
       ByteSize: 8
       GoRuntimeType: 26304
       GoKind: 22
-      Pointee: 19 BaseType uint32
+      Pointee: 2 BaseType uint32
     - __kind: PointerType
-      ID: 60
+      ID: 28
       Name: '*uint64'
       ByteSize: 8
       GoRuntimeType: 26432
       GoKind: 22
-      Pointee: 45 BaseType uint64
+      Pointee: 11 BaseType uint64
     - __kind: PointerType
-      ID: 8
+      ID: 6
       Name: '*uint8'
       ByteSize: 8
       GoRuntimeType: 26048
       GoKind: 22
-      Pointee: 9 BaseType uint8
+      Pointee: 3 BaseType uint8
     - __kind: PointerType
-      ID: 44
+      ID: 8
       Name: '*uintptr'
       ByteSize: 8
       GoRuntimeType: 26624
       GoKind: 22
-      Pointee: 25 BaseType uintptr
+      Pointee: 1 BaseType uintptr
     - __kind: EventRootType
       ID: 85
       Name: Probe[main.PointerChainArg]
@@ -549,10 +549,10 @@ Types:
         - Name: ptr
           Offset: 1
           Expression:
-            Type: 2 PointerType *****int
+            Type: 61 PointerType *****int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 2, index: 0, name: ptr}
+                  Variable: {subprogram: 11, index: 0, name: ptr}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
@@ -564,10 +564,10 @@ Types:
         - Name: ptr
           Offset: 1
           Expression:
-            Type: 5 PointerType **int
+            Type: 64 PointerType **int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 3, index: 0, name: ptr}
+                  Variable: {subprogram: 12, index: 0, name: ptr}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
@@ -579,10 +579,10 @@ Types:
         - Name: m
           Offset: 1
           Expression:
-            Type: 33 GoMapType map[string]main.bigStruct
+            Type: 52 GoMapType map[string]main.bigStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 12, index: 0, name: m}
+                  Variable: {subprogram: 9, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
@@ -594,10 +594,10 @@ Types:
         - Name: x
           Offset: 1
           Expression:
-            Type: 1 BaseType int
+            Type: 9 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 1, index: 0, name: x}
+                  Variable: {subprogram: 10, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
@@ -609,10 +609,10 @@ Types:
         - Name: x
           Offset: 1
           Expression:
-            Type: 1 BaseType int
+            Type: 9 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 4, index: 0, name: x}
+                  Variable: {subprogram: 1, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
@@ -624,10 +624,10 @@ Types:
         - Name: s
           Offset: 1
           Expression:
-            Type: 11 ArrayType [3]int
+            Type: 34 ArrayType [3]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 7, index: 0, name: s}
+                  Variable: {subprogram: 4, index: 0, name: s}
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
@@ -639,10 +639,10 @@ Types:
         - Name: s
           Offset: 1
           Expression:
-            Type: 10 GoSliceHeaderType []int
+            Type: 33 GoSliceHeaderType []int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 6, index: 0, name: s}
+                  Variable: {subprogram: 3, index: 0, name: s}
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
@@ -654,10 +654,10 @@ Types:
         - Name: m
           Offset: 1
           Expression:
-            Type: 15 GoMapType map[string]int
+            Type: 37 GoMapType map[string]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 11, index: 0, name: m}
+                  Variable: {subprogram: 8, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
@@ -669,10 +669,10 @@ Types:
         - Name: s
           Offset: 1
           Expression:
-            Type: 7 GoStringHeaderType string
+            Type: 10 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 5, index: 0, name: s}
+                  Variable: {subprogram: 2, index: 0, name: s}
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
@@ -684,10 +684,10 @@ Types:
         - Name: s
           Offset: 1
           Expression:
-            Type: 14 ArrayType [3]string
+            Type: 36 ArrayType [3]string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 10, index: 0, name: s}
+                  Variable: {subprogram: 7, index: 0, name: s}
                   Offset: 0
                   ByteSize: 48
     - __kind: EventRootType
@@ -699,10 +699,10 @@ Types:
         - Name: s
           Offset: 1
           Expression:
-            Type: 14 ArrayType [3]string
+            Type: 36 ArrayType [3]string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 9, index: 0, name: s}
+                  Variable: {subprogram: 6, index: 0, name: s}
                   Offset: 0
                   ByteSize: 48
     - __kind: EventRootType
@@ -714,50 +714,50 @@ Types:
         - Name: s
           Offset: 1
           Expression:
-            Type: 12 GoSliceHeaderType []string
+            Type: 35 GoSliceHeaderType []string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 8, index: 0, name: s}
+                  Variable: {subprogram: 5, index: 0, name: s}
                   Offset: 0
                   ByteSize: 24
     - __kind: ArrayType
-      ID: 41
+      ID: 60
       Name: '[128]uint8'
       ByteSize: 128
       GoRuntimeType: 41888
       GoKind: 17
       Count: 128
       HasCount: true
-      Element: 9 BaseType uint8
+      Element: 3 BaseType uint8
     - __kind: ArrayType
-      ID: 11
+      ID: 34
       Name: '[3]int'
       ByteSize: 24
       GoRuntimeType: 41408
       GoKind: 17
       Count: 3
       HasCount: true
-      Element: 1 BaseType int
+      Element: 9 BaseType int
     - __kind: ArrayType
-      ID: 14
+      ID: 36
       Name: '[3]string'
       ByteSize: 48
       GoRuntimeType: 41504
       GoKind: 17
       Count: 3
       HasCount: true
-      Element: 7 GoStringHeaderType string
+      Element: 10 GoStringHeaderType string
     - __kind: ArrayType
-      ID: 22
+      ID: 42
       Name: '[8]uint8'
       ByteSize: 8
       GoRuntimeType: 41600
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 9 BaseType uint8
+      Element: 3 BaseType uint8
     - __kind: GoSliceHeaderType
-      ID: 29
+      ID: 48
       Name: '[]*runtime.bmap'
       ByteSize: 24
       GoRuntimeType: 35904
@@ -765,31 +765,31 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 30 PointerType **runtime.bmap
+          Type: 49 PointerType **runtime.bmap
         - Name: len
           Offset: 8
-          Type: 1 BaseType int
+          Type: 9 BaseType int
         - Name: cap
           Offset: 16
-          Type: 1 BaseType int
+          Type: 9 BaseType int
       Data: 72 GoSliceDataType []*runtime.bmap.array
     - __kind: GoSliceDataType
       ID: 72
       Name: '[]*runtime.bmap.array'
       ByteSize: 2048
-      Element: 31 PointerType *runtime.bmap
+      Element: 50 PointerType *runtime.bmap
     - __kind: GoSliceDataType
       ID: 71
       Name: '[]bucket<string,int>.array'
       ByteSize: 2048
-      Element: 21 GoHMapBucketType bucket<string,int>
+      Element: 41 GoHMapBucketType bucket<string,int>
     - __kind: GoSliceDataType
       ID: 74
       Name: '[]bucket<string,main.bigStruct>.array'
       ByteSize: 2048
-      Element: 37 GoHMapBucketType bucket<string,main.bigStruct>
+      Element: 56 GoHMapBucketType bucket<string,main.bigStruct>
     - __kind: GoSliceHeaderType
-      ID: 10
+      ID: 33
       Name: '[]int'
       ByteSize: 24
       GoRuntimeType: 33984
@@ -797,28 +797,28 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 6 PointerType *int
+          Type: 27 PointerType *int
         - Name: len
           Offset: 8
-          Type: 1 BaseType int
+          Type: 9 BaseType int
         - Name: cap
           Offset: 16
-          Type: 1 BaseType int
+          Type: 9 BaseType int
       Data: 67 GoSliceDataType []int.array
     - __kind: GoSliceDataType
       ID: 67
       Name: '[]int.array'
       ByteSize: 2048
-      Element: 1 BaseType int
+      Element: 9 BaseType int
     - __kind: ArrayType
-      ID: 23
+      ID: 43
       Name: '[]key<string>'
       ByteSize: 128
       Count: 8
       HasCount: true
-      Element: 7 GoStringHeaderType string
+      Element: 10 GoStringHeaderType string
     - __kind: GoSliceHeaderType
-      ID: 12
+      ID: 35
       Name: '[]string'
       ByteSize: 24
       GoRuntimeType: 34304
@@ -826,91 +826,91 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 13 PointerType *string
+          Type: 22 PointerType *string
         - Name: len
           Offset: 8
-          Type: 1 BaseType int
+          Type: 9 BaseType int
         - Name: cap
           Offset: 16
-          Type: 1 BaseType int
+          Type: 9 BaseType int
       Data: 69 GoSliceDataType []string.array
     - __kind: GoSliceDataType
       ID: 69
       Name: '[]string.array'
       ByteSize: 2048
-      Element: 7 GoStringHeaderType string
+      Element: 10 GoStringHeaderType string
     - __kind: ArrayType
-      ID: 24
+      ID: 44
       Name: '[]val<int>'
       ByteSize: 64
       Count: 8
       HasCount: true
-      Element: 1 BaseType int
+      Element: 9 BaseType int
     - __kind: ArrayType
-      ID: 38
+      ID: 57
       Name: '[]val<main.bigStruct>'
       ByteSize: 64
       Count: 8
       HasCount: true
-      Element: 39 PointerType *main.bigStruct
+      Element: 58 PointerType *main.bigStruct
     - __kind: BaseType
-      ID: 42
+      ID: 4
       Name: bool
       ByteSize: 1
       GoRuntimeType: 38464
       GoKind: 1
     - __kind: GoHMapBucketType
-      ID: 21
+      ID: 41
       Name: bucket<string,int>
       ByteSize: 208
       RawFields:
         - Name: tophash
           Offset: 0
-          Type: 22 ArrayType [8]uint8
+          Type: 42 ArrayType [8]uint8
         - Name: keys
           Offset: 8
-          Type: 23 ArrayType []key<string>
+          Type: 43 ArrayType []key<string>
         - Name: values
           Offset: 136
-          Type: 24 ArrayType []val<int>
+          Type: 44 ArrayType []val<int>
         - Name: overflow
           Offset: 200
-          Type: 20 PointerType *bucket<string,int>
-      KeyType: 7 GoStringHeaderType string
-      ValueType: 1 BaseType int
+          Type: 40 PointerType *bucket<string,int>
+      KeyType: 10 GoStringHeaderType string
+      ValueType: 9 BaseType int
     - __kind: GoHMapBucketType
-      ID: 37
+      ID: 56
       Name: bucket<string,main.bigStruct>
       ByteSize: 208
       RawFields:
         - Name: tophash
           Offset: 0
-          Type: 22 ArrayType [8]uint8
+          Type: 42 ArrayType [8]uint8
         - Name: keys
           Offset: 8
-          Type: 23 ArrayType []key<string>
+          Type: 43 ArrayType []key<string>
         - Name: values
           Offset: 136
-          Type: 38 ArrayType []val<main.bigStruct>
+          Type: 57 ArrayType []val<main.bigStruct>
         - Name: overflow
           Offset: 200
-          Type: 36 PointerType *bucket<string,main.bigStruct>
-      KeyType: 7 GoStringHeaderType string
-      ValueType: 39 PointerType *main.bigStruct
+          Type: 55 PointerType *bucket<string,main.bigStruct>
+      KeyType: 10 GoStringHeaderType string
+      ValueType: 58 PointerType *main.bigStruct
     - __kind: BaseType
-      ID: 57
+      ID: 24
       Name: complex128
       ByteSize: 16
       GoRuntimeType: 38272
       GoKind: 16
     - __kind: BaseType
-      ID: 56
+      ID: 23
       Name: complex64
       ByteSize: 8
       GoRuntimeType: 38208
       GoKind: 15
     - __kind: GoInterfaceType
-      ID: 52
+      ID: 18
       Name: error
       ByteSize: 16
       GoRuntimeType: 59008
@@ -918,116 +918,116 @@ Types:
       RawFields:
         - Name: tab
           Offset: 0
-          Type: 53 VoidPointerType unsafe.Pointer
+          Type: 19 VoidPointerType unsafe.Pointer
         - Name: data
           Offset: 8
-          Type: 53 VoidPointerType unsafe.Pointer
+          Type: 19 VoidPointerType unsafe.Pointer
     - __kind: BaseType
-      ID: 50
+      ID: 16
       Name: float32
       ByteSize: 4
       GoRuntimeType: 38336
       GoKind: 13
     - __kind: BaseType
-      ID: 51
+      ID: 17
       Name: float64
       ByteSize: 8
       GoRuntimeType: 38400
       GoKind: 14
     - __kind: GoHMapHeaderType
-      ID: 17
+      ID: 39
       Name: hash<string,int>
       ByteSize: 48
       RawFields:
         - Name: count
           Offset: 0
-          Type: 1 BaseType int
+          Type: 9 BaseType int
         - Name: flags
           Offset: 8
-          Type: 9 BaseType uint8
+          Type: 3 BaseType uint8
         - Name: B
           Offset: 9
-          Type: 9 BaseType uint8
+          Type: 3 BaseType uint8
         - Name: noverflow
           Offset: 10
-          Type: 18 BaseType uint16
+          Type: 7 BaseType uint16
         - Name: hash0
           Offset: 12
-          Type: 19 BaseType uint32
+          Type: 2 BaseType uint32
         - Name: buckets
           Offset: 16
-          Type: 20 PointerType *bucket<string,int>
+          Type: 40 PointerType *bucket<string,int>
         - Name: oldbuckets
           Offset: 24
-          Type: 20 PointerType *bucket<string,int>
+          Type: 40 PointerType *bucket<string,int>
         - Name: nevacuate
           Offset: 32
-          Type: 25 BaseType uintptr
+          Type: 1 BaseType uintptr
         - Name: extra
           Offset: 40
-          Type: 26 PointerType *runtime.mapextra
-      BucketType: 21 GoHMapBucketType bucket<string,int>
+          Type: 45 PointerType *runtime.mapextra
+      BucketType: 41 GoHMapBucketType bucket<string,int>
       BucketsType: 71 GoSliceDataType []bucket<string,int>.array
     - __kind: GoHMapHeaderType
-      ID: 35
+      ID: 54
       Name: hash<string,main.bigStruct>
       ByteSize: 48
       RawFields:
         - Name: count
           Offset: 0
-          Type: 1 BaseType int
+          Type: 9 BaseType int
         - Name: flags
           Offset: 8
-          Type: 9 BaseType uint8
+          Type: 3 BaseType uint8
         - Name: B
           Offset: 9
-          Type: 9 BaseType uint8
+          Type: 3 BaseType uint8
         - Name: noverflow
           Offset: 10
-          Type: 18 BaseType uint16
+          Type: 7 BaseType uint16
         - Name: hash0
           Offset: 12
-          Type: 19 BaseType uint32
+          Type: 2 BaseType uint32
         - Name: buckets
           Offset: 16
-          Type: 36 PointerType *bucket<string,main.bigStruct>
+          Type: 55 PointerType *bucket<string,main.bigStruct>
         - Name: oldbuckets
           Offset: 24
-          Type: 36 PointerType *bucket<string,main.bigStruct>
+          Type: 55 PointerType *bucket<string,main.bigStruct>
         - Name: nevacuate
           Offset: 32
-          Type: 25 BaseType uintptr
+          Type: 1 BaseType uintptr
         - Name: extra
           Offset: 40
-          Type: 26 PointerType *runtime.mapextra
-      BucketType: 37 GoHMapBucketType bucket<string,main.bigStruct>
+          Type: 45 PointerType *runtime.mapextra
+      BucketType: 56 GoHMapBucketType bucket<string,main.bigStruct>
       BucketsType: 74 GoSliceDataType []bucket<string,main.bigStruct>.array
     - __kind: BaseType
-      ID: 1
+      ID: 9
       Name: int
       ByteSize: 8
       GoRuntimeType: 38016
       GoKind: 2
     - __kind: BaseType
-      ID: 46
+      ID: 12
       Name: int32
       ByteSize: 4
       GoRuntimeType: 37760
       GoKind: 5
     - __kind: BaseType
-      ID: 47
+      ID: 13
       Name: int64
       ByteSize: 8
       GoRuntimeType: 37888
       GoKind: 6
     - __kind: BaseType
-      ID: 48
+      ID: 14
       Name: int8
       ByteSize: 1
       GoRuntimeType: 37504
       GoKind: 3
     - __kind: StructureType
-      ID: 40
+      ID: 59
       Name: main.bigStruct
       ByteSize: 184
       GoRuntimeType: 110528
@@ -1035,44 +1035,44 @@ Types:
       RawFields:
         - Name: Field1
           Offset: 0
-          Type: 1 BaseType int
+          Type: 9 BaseType int
         - Name: Field2
           Offset: 8
-          Type: 1 BaseType int
+          Type: 9 BaseType int
         - Name: Field3
           Offset: 16
-          Type: 1 BaseType int
+          Type: 9 BaseType int
         - Name: Field4
           Offset: 24
-          Type: 1 BaseType int
+          Type: 9 BaseType int
         - Name: Field5
           Offset: 32
-          Type: 1 BaseType int
+          Type: 9 BaseType int
         - Name: Field6
           Offset: 40
-          Type: 1 BaseType int
+          Type: 9 BaseType int
         - Name: Field7
           Offset: 48
-          Type: 1 BaseType int
+          Type: 9 BaseType int
         - Name: data
           Offset: 56
-          Type: 41 ArrayType [128]uint8
+          Type: 60 ArrayType [128]uint8
     - __kind: GoMapType
-      ID: 15
+      ID: 37
       Name: map[string]int
       ByteSize: 8
       GoRuntimeType: 54656
       GoKind: 21
-      HeaderType: 17 GoHMapHeaderType hash<string,int>
+      HeaderType: 39 GoHMapHeaderType hash<string,int>
     - __kind: GoMapType
-      ID: 33
+      ID: 52
       Name: map[string]main.bigStruct
       ByteSize: 8
       GoRuntimeType: 54752
       GoKind: 21
-      HeaderType: 35 GoHMapHeaderType hash<string,main.bigStruct>
+      HeaderType: 54 GoHMapHeaderType hash<string,main.bigStruct>
     - __kind: StructureType
-      ID: 32
+      ID: 51
       Name: runtime.bmap
       ByteSize: 8
       GoRuntimeType: 66400
@@ -1080,9 +1080,9 @@ Types:
       RawFields:
         - Name: tophash
           Offset: 0
-          Type: 22 ArrayType [8]uint8
+          Type: 42 ArrayType [8]uint8
     - __kind: StructureType
-      ID: 27
+      ID: 46
       Name: runtime.mapextra
       ByteSize: 24
       GoRuntimeType: 87232
@@ -1090,15 +1090,15 @@ Types:
       RawFields:
         - Name: overflow
           Offset: 0
-          Type: 28 PointerType *[]*runtime.bmap
+          Type: 47 PointerType *[]*runtime.bmap
         - Name: oldoverflow
           Offset: 8
-          Type: 28 PointerType *[]*runtime.bmap
+          Type: 47 PointerType *[]*runtime.bmap
         - Name: nextOverflow
           Offset: 16
-          Type: 31 PointerType *runtime.bmap
+          Type: 50 PointerType *runtime.bmap
     - __kind: GoStringHeaderType
-      ID: 7
+      ID: 10
       Name: string
       ByteSize: 16
       GoRuntimeType: 37440
@@ -1109,50 +1109,50 @@ Types:
           Type: 66 PointerType *string.str
         - Name: len
           Offset: 8
-          Type: 1 BaseType int
+          Type: 9 BaseType int
       Data: 65 GoStringDataType string.str
     - __kind: GoStringDataType
       ID: 65
       Name: string.str
       ByteSize: 2048
     - __kind: BaseType
-      ID: 49
+      ID: 15
       Name: uint
       ByteSize: 8
       GoRuntimeType: 38080
       GoKind: 7
     - __kind: BaseType
-      ID: 18
+      ID: 7
       Name: uint16
       ByteSize: 2
       GoRuntimeType: 37696
       GoKind: 9
     - __kind: BaseType
-      ID: 19
+      ID: 2
       Name: uint32
       ByteSize: 4
       GoRuntimeType: 37824
       GoKind: 10
     - __kind: BaseType
-      ID: 45
+      ID: 11
       Name: uint64
       ByteSize: 8
       GoRuntimeType: 37952
       GoKind: 11
     - __kind: BaseType
-      ID: 9
+      ID: 3
       Name: uint8
       ByteSize: 1
       GoRuntimeType: 37568
       GoKind: 8
     - __kind: BaseType
-      ID: 25
+      ID: 1
       Name: uintptr
       ByteSize: 8
       GoRuntimeType: 38144
       GoKind: 12
     - __kind: VoidPointerType
-      ID: 53
+      ID: 19
       Name: unsafe.Pointer
       ByteSize: 8
       GoRuntimeType: 38528

--- a/pkg/dyninst/irgen/testdata/snapshot/simple.arch=amd64,toolchain=go1.23.11.yaml
+++ b/pkg/dyninst/irgen/testdata/snapshot/simple.arch=amd64,toolchain=go1.23.11.yaml
@@ -14,7 +14,7 @@ Probes:
       subprogram: {subprogram: 11}
       events:
         - ID: 11
-          Type: 85 EventRootType Probe[main.PointerChainArg]
+          Type: 78 EventRootType Probe[main.PointerChainArg]
           InjectionPoints: [{PC: "0x4a6006", Frameless: false}]
           Condition: null
     - id: PointerSmallChainArg
@@ -31,7 +31,7 @@ Probes:
       subprogram: {subprogram: 12}
       events:
         - ID: 12
-          Type: 86 EventRootType Probe[main.PointerSmallChainArg]
+          Type: 79 EventRootType Probe[main.PointerSmallChainArg]
           InjectionPoints: [{PC: "0x4a6050", Frameless: false}]
           Condition: null
     - id: bigMapArg
@@ -44,7 +44,7 @@ Probes:
       subprogram: {subprogram: 9}
       events:
         - ID: 9
-          Type: 83 EventRootType Probe[main.bigMapArg]
+          Type: 76 EventRootType Probe[main.bigMapArg]
           InjectionPoints: [{PC: "0x4a64f3", Frameless: false}]
           Condition: null
     - id: inlined
@@ -58,7 +58,7 @@ Probes:
       subprogram: {subprogram: 10}
       events:
         - ID: 10
-          Type: 84 EventRootType Probe[main.inlined]
+          Type: 77 EventRootType Probe[main.inlined]
           InjectionPoints:
             - PC: "0x4a63ca"
               Frameless: false
@@ -75,7 +75,7 @@ Probes:
       subprogram: {subprogram: 1}
       events:
         - ID: 1
-          Type: 75 EventRootType Probe[main.intArg]
+          Type: 68 EventRootType Probe[main.intArg]
           InjectionPoints: [{PC: "0x4a60aa", Frameless: false}]
           Condition: null
     - id: intArrayArg
@@ -88,7 +88,7 @@ Probes:
       subprogram: {subprogram: 4}
       events:
         - ID: 4
-          Type: 78 EventRootType Probe[main.intArrayArg]
+          Type: 71 EventRootType Probe[main.intArrayArg]
           InjectionPoints: [{PC: "0x4a622a", Frameless: false}]
           Condition: null
     - id: intArrayArgFrameless
@@ -101,7 +101,7 @@ Probes:
       subprogram: {subprogram: 7}
       events:
         - ID: 7
-          Type: 81 EventRootType Probe[main.stringArrayArgFrameless]
+          Type: 74 EventRootType Probe[main.stringArrayArgFrameless]
           InjectionPoints: [{PC: "0x4a63a0", Frameless: true}]
           Condition: null
     - id: intSliceArg
@@ -114,7 +114,7 @@ Probes:
       subprogram: {subprogram: 3}
       events:
         - ID: 3
-          Type: 77 EventRootType Probe[main.intSliceArg]
+          Type: 70 EventRootType Probe[main.intSliceArg]
           InjectionPoints: [{PC: "0x4a61aa", Frameless: false}]
           Condition: null
     - id: mapArg
@@ -127,7 +127,7 @@ Probes:
       subprogram: {subprogram: 8}
       events:
         - ID: 8
-          Type: 82 EventRootType Probe[main.mapArg]
+          Type: 75 EventRootType Probe[main.mapArg]
           InjectionPoints: [{PC: "0x4a648a", Frameless: false}]
           Condition: null
     - id: stringArg
@@ -140,7 +140,7 @@ Probes:
       subprogram: {subprogram: 2}
       events:
         - ID: 2
-          Type: 76 EventRootType Probe[main.stringArg]
+          Type: 69 EventRootType Probe[main.stringArg]
           InjectionPoints: [{PC: "0x4a612a", Frameless: false}]
           Condition: null
     - id: stringArrayArg
@@ -153,7 +153,7 @@ Probes:
       subprogram: {subprogram: 6}
       events:
         - ID: 6
-          Type: 80 EventRootType Probe[main.stringArrayArg]
+          Type: 73 EventRootType Probe[main.stringArrayArg]
           InjectionPoints: [{PC: "0x4a632a", Frameless: false}]
           Condition: null
     - id: stringSliceArg
@@ -166,7 +166,7 @@ Probes:
       subprogram: {subprogram: 5}
       events:
         - ID: 5
-          Type: 79 EventRootType Probe[main.stringSliceArg]
+          Type: 72 EventRootType Probe[main.stringSliceArg]
           InjectionPoints: [{PC: "0x4a62aa", Frameless: false}]
           Condition: null
 Subprograms:
@@ -354,9 +354,9 @@ Types:
       ByteSize: 8
       GoRuntimeType: 32448
       GoKind: 22
-      Pointee: 62 PointerType ***int
+      Pointee: 66 PointerType ***int
     - __kind: PointerType
-      ID: 62
+      ID: 66
       Name: '***int'
       ByteSize: 8
       GoRuntimeType: 32384
@@ -370,32 +370,15 @@ Types:
       GoKind: 22
       Pointee: 27 PointerType *int
     - __kind: PointerType
-      ID: 71
-      Name: '**runtime.bmap'
-      ByteSize: 8
-      Pointee: 57 PointerType *runtime.bmap
-    - __kind: PointerType
       ID: 55
-      Name: '*[]*runtime.bmap'
-      ByteSize: 8
-      GoRuntimeType: 35968
-      GoKind: 22
-      Pointee: 56 GoSliceHeaderType []*runtime.bmap
-    - __kind: PointerType
-      ID: 74
-      Name: '*[]*runtime.bmap.array'
-      ByteSize: 8
-      Pointee: 73 GoSliceDataType []*runtime.bmap.array
-    - __kind: PointerType
-      ID: 66
       Name: '*[]int.array'
       ByteSize: 8
-      Pointee: 65 GoSliceDataType []int.array
+      Pointee: 54 GoSliceDataType []int.array
     - __kind: PointerType
-      ID: 68
+      ID: 57
       Name: '*[]string.array'
       ByteSize: 8
-      Pointee: 67 GoSliceDataType []string.array
+      Pointee: 56 GoSliceDataType []string.array
     - __kind: PointerType
       ID: 5
       Name: '*bool'
@@ -466,26 +449,19 @@ Types:
       GoKind: 22
       Pointee: 13 BaseType int64
     - __kind: PointerType
-      ID: 60
+      ID: 63
       Name: '*main.bigStruct'
       ByteSize: 8
       GoRuntimeType: 24256
       GoKind: 22
-      Pointee: 61 StructureType main.bigStruct
-    - __kind: PointerType
-      ID: 57
-      Name: '*runtime.bmap'
-      ByteSize: 8
-      GoRuntimeType: 66528
-      GoKind: 22
-      Pointee: 58 StructureType runtime.bmap
+      Pointee: 64 StructureType main.bigStruct
     - __kind: PointerType
       ID: 42
       Name: '*runtime.mapextra'
       ByteSize: 8
       GoRuntimeType: 29760
       GoKind: 22
-      Pointee: 43 StructureType runtime.mapextra
+      Pointee: 43 UnresolvedPointeeType runtime.mapextra
     - __kind: PointerType
       ID: 22
       Name: '*string'
@@ -494,10 +470,10 @@ Types:
       GoKind: 22
       Pointee: 10 GoStringHeaderType string
     - __kind: PointerType
-      ID: 64
+      ID: 53
       Name: '*string.str'
       ByteSize: 8
-      Pointee: 63 GoStringDataType string.str
+      Pointee: 52 GoStringDataType string.str
     - __kind: PointerType
       ID: 31
       Name: '*uint'
@@ -541,7 +517,7 @@ Types:
       GoKind: 22
       Pointee: 1 BaseType uintptr
     - __kind: EventRootType
-      ID: 85
+      ID: 78
       Name: Probe[main.PointerChainArg]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -556,7 +532,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 86
+      ID: 79
       Name: Probe[main.PointerSmallChainArg]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -571,7 +547,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 83
+      ID: 76
       Name: Probe[main.bigMapArg]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -586,7 +562,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 84
+      ID: 77
       Name: Probe[main.inlined]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -601,7 +577,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 75
+      ID: 68
       Name: Probe[main.intArg]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -616,7 +592,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 78
+      ID: 71
       Name: Probe[main.intArrayArg]
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -631,7 +607,7 @@ Types:
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 77
+      ID: 70
       Name: Probe[main.intSliceArg]
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -646,7 +622,7 @@ Types:
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 82
+      ID: 75
       Name: Probe[main.mapArg]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -661,7 +637,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 76
+      ID: 69
       Name: Probe[main.stringArg]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -676,7 +652,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 81
+      ID: 74
       Name: Probe[main.stringArrayArgFrameless]
       ByteSize: 49
       PresenceBitsetSize: 1
@@ -691,7 +667,7 @@ Types:
                   Offset: 0
                   ByteSize: 48
     - __kind: EventRootType
-      ID: 80
+      ID: 73
       Name: Probe[main.stringArrayArg]
       ByteSize: 49
       PresenceBitsetSize: 1
@@ -706,7 +682,7 @@ Types:
                   Offset: 0
                   ByteSize: 48
     - __kind: EventRootType
-      ID: 79
+      ID: 72
       Name: Probe[main.stringSliceArg]
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -721,7 +697,7 @@ Types:
                   Offset: 0
                   ByteSize: 24
     - __kind: ArrayType
-      ID: 72
+      ID: 67
       Name: '[128]uint8'
       ByteSize: 128
       GoRuntimeType: 41888
@@ -748,7 +724,7 @@ Types:
       HasCount: true
       Element: 10 GoStringHeaderType string
     - __kind: ArrayType
-      ID: 52
+      ID: 58
       Name: '[8]uint8'
       ByteSize: 8
       GoRuntimeType: 41600
@@ -756,35 +732,13 @@ Types:
       Count: 8
       HasCount: true
       Element: 3 BaseType uint8
-    - __kind: GoSliceHeaderType
-      ID: 56
-      Name: '[]*runtime.bmap'
-      ByteSize: 24
-      GoRuntimeType: 35904
-      GoKind: 23
-      RawFields:
-        - Name: array
-          Offset: 0
-          Type: 71 PointerType **runtime.bmap
-        - Name: len
-          Offset: 8
-          Type: 9 BaseType int
-        - Name: cap
-          Offset: 16
-          Type: 9 BaseType int
-      Data: 73 GoSliceDataType []*runtime.bmap.array
     - __kind: GoSliceDataType
-      ID: 73
-      Name: '[]*runtime.bmap.array'
-      ByteSize: 2048
-      Element: 57 PointerType *runtime.bmap
-    - __kind: GoSliceDataType
-      ID: 69
+      ID: 61
       Name: '[]bucket<string,int>.array'
       ByteSize: 2048
       Element: 41 GoHMapBucketType bucket<string,int>
     - __kind: GoSliceDataType
-      ID: 70
+      ID: 65
       Name: '[]bucket<string,main.bigStruct>.array'
       ByteSize: 2048
       Element: 48 GoHMapBucketType bucket<string,main.bigStruct>
@@ -804,14 +758,14 @@ Types:
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 65 GoSliceDataType []int.array
+      Data: 54 GoSliceDataType []int.array
     - __kind: GoSliceDataType
-      ID: 65
+      ID: 54
       Name: '[]int.array'
       ByteSize: 2048
       Element: 9 BaseType int
     - __kind: ArrayType
-      ID: 53
+      ID: 59
       Name: '[]key<string>'
       ByteSize: 128
       Count: 8
@@ -833,26 +787,26 @@ Types:
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 67 GoSliceDataType []string.array
+      Data: 56 GoSliceDataType []string.array
     - __kind: GoSliceDataType
-      ID: 67
+      ID: 56
       Name: '[]string.array'
       ByteSize: 2048
       Element: 10 GoStringHeaderType string
     - __kind: ArrayType
-      ID: 54
+      ID: 60
       Name: '[]val<int>'
       ByteSize: 64
       Count: 8
       HasCount: true
       Element: 9 BaseType int
     - __kind: ArrayType
-      ID: 59
+      ID: 62
       Name: '[]val<main.bigStruct>'
       ByteSize: 64
       Count: 8
       HasCount: true
-      Element: 60 PointerType *main.bigStruct
+      Element: 63 PointerType *main.bigStruct
     - __kind: BaseType
       ID: 4
       Name: bool
@@ -866,13 +820,13 @@ Types:
       RawFields:
         - Name: tophash
           Offset: 0
-          Type: 52 ArrayType [8]uint8
+          Type: 58 ArrayType [8]uint8
         - Name: keys
           Offset: 8
-          Type: 53 ArrayType []key<string>
+          Type: 59 ArrayType []key<string>
         - Name: values
           Offset: 136
-          Type: 54 ArrayType []val<int>
+          Type: 60 ArrayType []val<int>
         - Name: overflow
           Offset: 200
           Type: 40 PointerType *bucket<string,int>
@@ -885,18 +839,18 @@ Types:
       RawFields:
         - Name: tophash
           Offset: 0
-          Type: 52 ArrayType [8]uint8
+          Type: 58 ArrayType [8]uint8
         - Name: keys
           Offset: 8
-          Type: 53 ArrayType []key<string>
+          Type: 59 ArrayType []key<string>
         - Name: values
           Offset: 136
-          Type: 59 ArrayType []val<main.bigStruct>
+          Type: 62 ArrayType []val<main.bigStruct>
         - Name: overflow
           Offset: 200
           Type: 47 PointerType *bucket<string,main.bigStruct>
       KeyType: 10 GoStringHeaderType string
-      ValueType: 60 PointerType *main.bigStruct
+      ValueType: 63 PointerType *main.bigStruct
     - __kind: BaseType
       ID: 24
       Name: complex128
@@ -967,7 +921,7 @@ Types:
           Offset: 40
           Type: 42 PointerType *runtime.mapextra
       BucketType: 41 GoHMapBucketType bucket<string,int>
-      BucketsType: 69 GoSliceDataType []bucket<string,int>.array
+      BucketsType: 61 GoSliceDataType []bucket<string,int>.array
     - __kind: GoHMapHeaderType
       ID: 46
       Name: hash<string,main.bigStruct>
@@ -1001,7 +955,7 @@ Types:
           Offset: 40
           Type: 42 PointerType *runtime.mapextra
       BucketType: 48 GoHMapBucketType bucket<string,main.bigStruct>
-      BucketsType: 70 GoSliceDataType []bucket<string,main.bigStruct>.array
+      BucketsType: 65 GoSliceDataType []bucket<string,main.bigStruct>.array
     - __kind: BaseType
       ID: 9
       Name: int
@@ -1027,7 +981,7 @@ Types:
       GoRuntimeType: 37504
       GoKind: 3
     - __kind: StructureType
-      ID: 61
+      ID: 64
       Name: main.bigStruct
       ByteSize: 184
       GoRuntimeType: 110528
@@ -1056,7 +1010,7 @@ Types:
           Type: 9 BaseType int
         - Name: data
           Offset: 56
-          Type: 72 ArrayType [128]uint8
+          Type: 67 ArrayType [128]uint8
     - __kind: GoMapType
       ID: 37
       Name: map[string]int
@@ -1071,32 +1025,10 @@ Types:
       GoRuntimeType: 54752
       GoKind: 21
       HeaderType: 46 GoHMapHeaderType hash<string,main.bigStruct>
-    - __kind: StructureType
-      ID: 58
-      Name: runtime.bmap
-      ByteSize: 8
-      GoRuntimeType: 66400
-      GoKind: 25
-      RawFields:
-        - Name: tophash
-          Offset: 0
-          Type: 52 ArrayType [8]uint8
-    - __kind: StructureType
+    - __kind: UnresolvedPointeeType
       ID: 43
       Name: runtime.mapextra
-      ByteSize: 24
-      GoRuntimeType: 87232
-      GoKind: 25
-      RawFields:
-        - Name: overflow
-          Offset: 0
-          Type: 55 PointerType *[]*runtime.bmap
-        - Name: oldoverflow
-          Offset: 8
-          Type: 55 PointerType *[]*runtime.bmap
-        - Name: nextOverflow
-          Offset: 16
-          Type: 57 PointerType *runtime.bmap
+      ByteSize: 8
     - __kind: GoStringHeaderType
       ID: 10
       Name: string
@@ -1106,13 +1038,13 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 64 PointerType *string.str
+          Type: 53 PointerType *string.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 63 GoStringDataType string.str
+      Data: 52 GoStringDataType string.str
     - __kind: GoStringDataType
-      ID: 63
+      ID: 52
       Name: string.str
       ByteSize: 2048
     - __kind: BaseType
@@ -1157,6 +1089,6 @@ Types:
       ByteSize: 8
       GoRuntimeType: 38528
       GoKind: 26
-MaxTypeID: 86
+MaxTypeID: 79
 Issues: []
 GoModuledataInfo: {FirstModuledataAddr: "0x572240", TypesOffset: 296}

--- a/pkg/dyninst/irgen/testdata/snapshot/simple.arch=amd64,toolchain=go1.24.3.yaml
+++ b/pkg/dyninst/irgen/testdata/snapshot/simple.arch=amd64,toolchain=go1.24.3.yaml
@@ -11,7 +11,7 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 2}
+      subprogram: {subprogram: 11}
       events:
         - ID: 11
           Type: 86 EventRootType Probe[main.PointerChainArg]
@@ -28,7 +28,7 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 3}
+      subprogram: {subprogram: 12}
       events:
         - ID: 12
           Type: 87 EventRootType Probe[main.PointerSmallChainArg]
@@ -41,7 +41,7 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 12}
+      subprogram: {subprogram: 9}
       events:
         - ID: 9
           Type: 84 EventRootType Probe[main.bigMapArg]
@@ -55,7 +55,7 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 1}
+      subprogram: {subprogram: 10}
       events:
         - ID: 10
           Type: 85 EventRootType Probe[main.inlined]
@@ -72,7 +72,7 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 4}
+      subprogram: {subprogram: 1}
       events:
         - ID: 1
           Type: 76 EventRootType Probe[main.intArg]
@@ -85,7 +85,7 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 7}
+      subprogram: {subprogram: 4}
       events:
         - ID: 4
           Type: 79 EventRootType Probe[main.intArrayArg]
@@ -98,7 +98,7 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 10}
+      subprogram: {subprogram: 7}
       events:
         - ID: 7
           Type: 82 EventRootType Probe[main.stringArrayArgFrameless]
@@ -111,7 +111,7 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 6}
+      subprogram: {subprogram: 3}
       events:
         - ID: 3
           Type: 78 EventRootType Probe[main.intSliceArg]
@@ -124,7 +124,7 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 11}
+      subprogram: {subprogram: 8}
       events:
         - ID: 8
           Type: 83 EventRootType Probe[main.mapArg]
@@ -137,7 +137,7 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 5}
+      subprogram: {subprogram: 2}
       events:
         - ID: 2
           Type: 77 EventRootType Probe[main.stringArg]
@@ -150,7 +150,7 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 9}
+      subprogram: {subprogram: 6}
       events:
         - ID: 6
           Type: 81 EventRootType Probe[main.stringArrayArg]
@@ -163,32 +163,32 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 8}
+      subprogram: {subprogram: 5}
       events:
         - ID: 5
           Type: 80 EventRootType Probe[main.stringSliceArg]
           InjectionPoints: [{PC: "0x4a82aa", Frameless: false}]
           Condition: null
 Subprograms:
-    - ID: 4
+    - ID: 1
       Name: main.intArg
       OutOfLinePCRanges: [0x4a80a0..0x4a8102]
       InlinePCRanges: []
       Variables:
         - Name: x
-          Type: 1 BaseType int
+          Type: 7 BaseType int
           Locations:
             - Range: 0x4a80a0..0x4a80b9
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 5
+    - ID: 2
       Name: main.stringArg
       OutOfLinePCRanges: [0x4a8120..0x4a8191]
       InlinePCRanges: []
       Variables:
         - Name: s
-          Type: 7 GoStringHeaderType string
+          Type: 9 GoStringHeaderType string
           Locations:
             - Range: 0x4a8120..0x4a813e
               Pieces:
@@ -198,13 +198,13 @@ Subprograms:
                   Op: {RegNo: 3, Shift: 0}
           IsParameter: true
           IsReturn: false
-    - ID: 6
+    - ID: 3
       Name: main.intSliceArg
       OutOfLinePCRanges: [0x4a81a0..0x4a821a]
       InlinePCRanges: []
       Variables:
         - Name: s
-          Type: 10 GoSliceHeaderType []int
+          Type: 33 GoSliceHeaderType []int
           Locations:
             - Range: 0x4a81a0..0x4a81be
               Pieces:
@@ -216,25 +216,25 @@ Subprograms:
                   Op: {RegNo: 2, Shift: 0}
           IsParameter: true
           IsReturn: false
-    - ID: 7
+    - ID: 4
       Name: main.intArrayArg
       OutOfLinePCRanges: [0x4a8220..0x4a8287]
       InlinePCRanges: []
       Variables:
         - Name: s
-          Type: 11 ArrayType [3]int
+          Type: 34 ArrayType [3]int
           Locations:
             - Range: 0x4a8220..0x4a8287
               Pieces: [{Size: 24, Op: {CfaOffset: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 8
+    - ID: 5
       Name: main.stringSliceArg
       OutOfLinePCRanges: [0x4a82a0..0x4a831a]
       InlinePCRanges: []
       Variables:
         - Name: s
-          Type: 12 GoSliceHeaderType []string
+          Type: 35 GoSliceHeaderType []string
           Locations:
             - Range: 0x4a82a0..0x4a82be
               Pieces:
@@ -246,49 +246,49 @@ Subprograms:
                   Op: {RegNo: 2, Shift: 0}
           IsParameter: true
           IsReturn: false
-    - ID: 9
+    - ID: 6
       Name: main.stringArrayArg
       OutOfLinePCRanges: [0x4a8320..0x4a8387]
       InlinePCRanges: []
       Variables:
         - Name: s
-          Type: 14 ArrayType [3]string
+          Type: 36 ArrayType [3]string
           Locations:
             - Range: 0x4a8320..0x4a8387
               Pieces: [{Size: 48, Op: {CfaOffset: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 10
+    - ID: 7
       Name: main.stringArrayArgFrameless
       OutOfLinePCRanges: [0x4a83a0..0x4a83a1]
       InlinePCRanges: []
       Variables:
         - Name: s
-          Type: 14 ArrayType [3]string
+          Type: 36 ArrayType [3]string
           Locations:
             - Range: 0x4a83a0..0x4a83a1
               Pieces: [{Size: 48, Op: {CfaOffset: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 11
+    - ID: 8
       Name: main.mapArg
       OutOfLinePCRanges: [0x4a8480..0x4a84d6]
       InlinePCRanges: []
       Variables:
         - Name: m
-          Type: 15 GoMapType map[string]int
+          Type: 37 GoMapType map[string]int
           Locations:
             - Range: 0x4a8480..0x4a84ad
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 12
+    - ID: 9
       Name: main.bigMapArg
       OutOfLinePCRanges: [0x4a84e0..0x4a859b]
       InlinePCRanges: []
       Variables:
         - Name: m
-          Type: 29 GoMapType map[string]main.bigStruct
+          Type: 48 GoMapType map[string]main.bigStruct
           Locations:
             - Range: 0x4a84e0..0x4a8513
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
@@ -296,7 +296,7 @@ Subprograms:
               Pieces: [{Size: 8, Op: {CfaOffset: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 1
+    - ID: 10
       Name: main.inlined
       OutOfLinePCRanges: [0x4a83c0..0x4a8422]
       InlinePCRanges:
@@ -304,7 +304,7 @@ Subprograms:
           RootRanges: [0x4a7c40..0x4a809d]
       Variables:
         - Name: x
-          Type: 1 BaseType int
+          Type: 7 BaseType int
           Locations:
             - Range: 0x4a7dce..0x4a7e1f
               Pieces: []
@@ -312,7 +312,7 @@ Subprograms:
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 2
+    - ID: 11
       Name: main.PointerChainArg
       OutOfLinePCRanges: []
       InlinePCRanges:
@@ -320,13 +320,13 @@ Subprograms:
           RootRanges: [0x4a7c40..0x4a809d]
       Variables:
         - Name: ptr
-          Type: 2 PointerType *****int
+          Type: 62 PointerType *****int
           Locations:
             - Range: 0x4a7fdf..0x4a802b
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 3
+    - ID: 12
       Name: main.PointerSmallChainArg
       OutOfLinePCRanges: []
       InlinePCRanges:
@@ -334,7 +334,7 @@ Subprograms:
           RootRanges: [0x4a7c40..0x4a809d]
       Variables:
         - Name: ptr
-          Type: 5 PointerType **int
+          Type: 65 PointerType **int
           Locations:
             - Range: 0x4a8050..0x4a808a
               Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
@@ -342,43 +342,43 @@ Subprograms:
           IsReturn: false
 Types:
     - __kind: PointerType
-      ID: 2
+      ID: 62
       Name: '*****int'
       ByteSize: 8
       GoRuntimeType: 35264
       GoKind: 22
-      Pointee: 3 PointerType ****int
+      Pointee: 63 PointerType ****int
     - __kind: PointerType
-      ID: 3
+      ID: 63
       Name: '****int'
       ByteSize: 8
       GoRuntimeType: 35200
       GoKind: 22
-      Pointee: 4 PointerType ***int
+      Pointee: 64 PointerType ***int
     - __kind: PointerType
-      ID: 4
+      ID: 64
       Name: '***int'
       ByteSize: 8
       GoRuntimeType: 35136
       GoKind: 22
-      Pointee: 5 PointerType **int
+      Pointee: 65 PointerType **int
     - __kind: PointerType
-      ID: 5
+      ID: 65
       Name: '**int'
       ByteSize: 8
       GoRuntimeType: 35072
       GoKind: 22
-      Pointee: 6 PointerType *int
+      Pointee: 27 PointerType *int
     - __kind: PointerType
-      ID: 20
+      ID: 40
       Name: '**table<string,int>'
       ByteSize: 8
-      Pointee: 21 PointerType *table<string,int>
+      Pointee: 41 PointerType *table<string,int>
     - __kind: PointerType
-      ID: 32
+      ID: 51
       Name: '**table<string,main.bigStruct>'
       ByteSize: 8
-      Pointee: 33 PointerType *table<string,main.bigStruct>
+      Pointee: 52 PointerType *table<string,main.bigStruct>
     - __kind: PointerType
       ID: 69
       Name: '*[]int.array'
@@ -390,145 +390,145 @@ Types:
       ByteSize: 8
       Pointee: 70 GoSliceDataType []string.array
     - __kind: PointerType
-      ID: 46
+      ID: 11
       Name: '*bool'
       ByteSize: 8
       GoRuntimeType: 29568
       GoKind: 22
-      Pointee: 44 BaseType bool
+      Pointee: 4 BaseType bool
     - __kind: PointerType
-      ID: 62
+      ID: 29
       Name: '*error'
       ByteSize: 8
       GoRuntimeType: 28480
       GoKind: 22
-      Pointee: 48 GoInterfaceType error
+      Pointee: 13 GoInterfaceType error
     - __kind: PointerType
-      ID: 63
+      ID: 30
       Name: '*float32'
       ByteSize: 8
       GoRuntimeType: 29440
       GoKind: 22
-      Pointee: 52 BaseType float32
+      Pointee: 17 BaseType float32
     - __kind: PointerType
-      ID: 59
+      ID: 25
       Name: '*float64'
       ByteSize: 8
       GoRuntimeType: 29504
       GoKind: 22
-      Pointee: 53 BaseType float64
+      Pointee: 18 BaseType float64
     - __kind: PointerType
-      ID: 6
+      ID: 27
       Name: '*int'
       ByteSize: 8
       GoRuntimeType: 29120
       GoKind: 22
-      Pointee: 1 BaseType int
+      Pointee: 7 BaseType int
     - __kind: PointerType
-      ID: 55
+      ID: 20
       Name: '*int32'
       ByteSize: 8
       GoRuntimeType: 28864
       GoKind: 22
-      Pointee: 45 BaseType int32
+      Pointee: 10 BaseType int32
     - __kind: PointerType
-      ID: 60
+      ID: 26
       Name: '*int64'
       ByteSize: 8
       GoRuntimeType: 28992
       GoKind: 22
-      Pointee: 47 BaseType int64
+      Pointee: 12 BaseType int64
     - __kind: PointerType
-      ID: 40
+      ID: 59
       Name: '*main.bigStruct'
       ByteSize: 8
       GoRuntimeType: 26944
       GoKind: 22
-      Pointee: 41 StructureType main.bigStruct
+      Pointee: 60 StructureType main.bigStruct
     - __kind: PointerType
-      ID: 16
+      ID: 38
       Name: '*map<string,int>'
       ByteSize: 8
-      Pointee: 17 GoSwissMapHeaderType map<string,int>
+      Pointee: 39 GoSwissMapHeaderType map<string,int>
     - __kind: PointerType
-      ID: 30
+      ID: 49
       Name: '*map<string,main.bigStruct>'
       ByteSize: 8
-      Pointee: 31 GoSwissMapHeaderType map<string,main.bigStruct>
+      Pointee: 50 GoSwissMapHeaderType map<string,main.bigStruct>
     - __kind: PointerType
-      ID: 25
+      ID: 44
       Name: '*noalg.map.group[string]int'
       ByteSize: 8
-      Pointee: 26 StructureType noalg.map.group[string]int
+      Pointee: 45 StructureType noalg.map.group[string]int
     - __kind: PointerType
-      ID: 36
+      ID: 55
       Name: '*noalg.map.group[string]main.bigStruct'
       ByteSize: 8
-      Pointee: 37 StructureType noalg.map.group[string]main.bigStruct
+      Pointee: 56 StructureType noalg.map.group[string]main.bigStruct
     - __kind: PointerType
-      ID: 13
+      ID: 22
       Name: '*string'
       ByteSize: 8
       GoRuntimeType: 28544
       GoKind: 22
-      Pointee: 7 GoStringHeaderType string
+      Pointee: 9 GoStringHeaderType string
     - __kind: PointerType
       ID: 67
       Name: '*string.str'
       ByteSize: 8
       Pointee: 66 GoStringDataType string.str
     - __kind: PointerType
-      ID: 21
+      ID: 41
       Name: '*table<string,int>'
       ByteSize: 8
-      Pointee: 22 StructureType table<string,int>
+      Pointee: 42 StructureType table<string,int>
     - __kind: PointerType
-      ID: 33
+      ID: 52
       Name: '*table<string,main.bigStruct>'
       ByteSize: 8
-      Pointee: 34 StructureType table<string,main.bigStruct>
+      Pointee: 53 StructureType table<string,main.bigStruct>
     - __kind: PointerType
-      ID: 64
+      ID: 31
       Name: '*uint'
       ByteSize: 8
       GoRuntimeType: 29184
       GoKind: 22
-      Pointee: 51 BaseType uint
+      Pointee: 16 BaseType uint
     - __kind: PointerType
-      ID: 65
+      ID: 32
       Name: '*uint16'
       ByteSize: 8
       GoRuntimeType: 28800
       GoKind: 22
-      Pointee: 23 BaseType uint16
+      Pointee: 6 BaseType uint16
     - __kind: PointerType
-      ID: 56
+      ID: 21
       Name: '*uint32'
       ByteSize: 8
       GoRuntimeType: 28928
       GoKind: 22
-      Pointee: 43 BaseType uint32
+      Pointee: 2 BaseType uint32
     - __kind: PointerType
-      ID: 61
+      ID: 28
       Name: '*uint64'
       ByteSize: 8
       GoRuntimeType: 29056
       GoKind: 22
-      Pointee: 18 BaseType uint64
+      Pointee: 8 BaseType uint64
     - __kind: PointerType
-      ID: 8
+      ID: 5
       Name: '*uint8'
       ByteSize: 8
       GoRuntimeType: 28672
       GoKind: 22
-      Pointee: 9 BaseType uint8
+      Pointee: 3 BaseType uint8
     - __kind: PointerType
-      ID: 54
+      ID: 19
       Name: '*uintptr'
       ByteSize: 8
       GoRuntimeType: 29248
       GoKind: 22
-      Pointee: 19 BaseType uintptr
+      Pointee: 1 BaseType uintptr
     - __kind: EventRootType
       ID: 86
       Name: Probe[main.PointerChainArg]
@@ -538,10 +538,10 @@ Types:
         - Name: ptr
           Offset: 1
           Expression:
-            Type: 2 PointerType *****int
+            Type: 62 PointerType *****int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 2, index: 0, name: ptr}
+                  Variable: {subprogram: 11, index: 0, name: ptr}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
@@ -553,10 +553,10 @@ Types:
         - Name: ptr
           Offset: 1
           Expression:
-            Type: 5 PointerType **int
+            Type: 65 PointerType **int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 3, index: 0, name: ptr}
+                  Variable: {subprogram: 12, index: 0, name: ptr}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
@@ -568,10 +568,10 @@ Types:
         - Name: m
           Offset: 1
           Expression:
-            Type: 29 GoMapType map[string]main.bigStruct
+            Type: 48 GoMapType map[string]main.bigStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 12, index: 0, name: m}
+                  Variable: {subprogram: 9, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
@@ -583,10 +583,10 @@ Types:
         - Name: x
           Offset: 1
           Expression:
-            Type: 1 BaseType int
+            Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 1, index: 0, name: x}
+                  Variable: {subprogram: 10, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
@@ -598,10 +598,10 @@ Types:
         - Name: x
           Offset: 1
           Expression:
-            Type: 1 BaseType int
+            Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 4, index: 0, name: x}
+                  Variable: {subprogram: 1, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
@@ -613,10 +613,10 @@ Types:
         - Name: s
           Offset: 1
           Expression:
-            Type: 11 ArrayType [3]int
+            Type: 34 ArrayType [3]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 7, index: 0, name: s}
+                  Variable: {subprogram: 4, index: 0, name: s}
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
@@ -628,10 +628,10 @@ Types:
         - Name: s
           Offset: 1
           Expression:
-            Type: 10 GoSliceHeaderType []int
+            Type: 33 GoSliceHeaderType []int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 6, index: 0, name: s}
+                  Variable: {subprogram: 3, index: 0, name: s}
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
@@ -643,10 +643,10 @@ Types:
         - Name: m
           Offset: 1
           Expression:
-            Type: 15 GoMapType map[string]int
+            Type: 37 GoMapType map[string]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 11, index: 0, name: m}
+                  Variable: {subprogram: 8, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
@@ -658,10 +658,10 @@ Types:
         - Name: s
           Offset: 1
           Expression:
-            Type: 7 GoStringHeaderType string
+            Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 5, index: 0, name: s}
+                  Variable: {subprogram: 2, index: 0, name: s}
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
@@ -673,10 +673,10 @@ Types:
         - Name: s
           Offset: 1
           Expression:
-            Type: 14 ArrayType [3]string
+            Type: 36 ArrayType [3]string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 10, index: 0, name: s}
+                  Variable: {subprogram: 7, index: 0, name: s}
                   Offset: 0
                   ByteSize: 48
     - __kind: EventRootType
@@ -688,10 +688,10 @@ Types:
         - Name: s
           Offset: 1
           Expression:
-            Type: 14 ArrayType [3]string
+            Type: 36 ArrayType [3]string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 9, index: 0, name: s}
+                  Variable: {subprogram: 6, index: 0, name: s}
                   Offset: 0
                   ByteSize: 48
     - __kind: EventRootType
@@ -703,51 +703,51 @@ Types:
         - Name: s
           Offset: 1
           Expression:
-            Type: 12 GoSliceHeaderType []string
+            Type: 35 GoSliceHeaderType []string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 8, index: 0, name: s}
+                  Variable: {subprogram: 5, index: 0, name: s}
                   Offset: 0
                   ByteSize: 24
     - __kind: ArrayType
-      ID: 42
+      ID: 61
       Name: '[128]uint8'
       ByteSize: 128
       GoRuntimeType: 46240
       GoKind: 17
       Count: 128
       HasCount: true
-      Element: 9 BaseType uint8
+      Element: 3 BaseType uint8
     - __kind: ArrayType
-      ID: 11
+      ID: 34
       Name: '[3]int'
       ByteSize: 24
       GoRuntimeType: 45952
       GoKind: 17
       Count: 3
       HasCount: true
-      Element: 1 BaseType int
+      Element: 7 BaseType int
     - __kind: ArrayType
-      ID: 14
+      ID: 36
       Name: '[3]string'
       ByteSize: 48
       GoRuntimeType: 46048
       GoKind: 17
       Count: 3
       HasCount: true
-      Element: 7 GoStringHeaderType string
+      Element: 9 GoStringHeaderType string
     - __kind: GoSliceDataType
       ID: 72
       Name: '[]*table<string,int>.array'
       ByteSize: 8192
-      Element: 21 PointerType *table<string,int>
+      Element: 41 PointerType *table<string,int>
     - __kind: GoSliceDataType
       ID: 74
       Name: '[]*table<string,main.bigStruct>.array'
       ByteSize: 8192
-      Element: 33 PointerType *table<string,main.bigStruct>
+      Element: 52 PointerType *table<string,main.bigStruct>
     - __kind: GoSliceHeaderType
-      ID: 10
+      ID: 33
       Name: '[]int'
       ByteSize: 24
       GoRuntimeType: 37696
@@ -755,31 +755,31 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 6 PointerType *int
+          Type: 27 PointerType *int
         - Name: len
           Offset: 8
-          Type: 1 BaseType int
+          Type: 7 BaseType int
         - Name: cap
           Offset: 16
-          Type: 1 BaseType int
+          Type: 7 BaseType int
       Data: 68 GoSliceDataType []int.array
     - __kind: GoSliceDataType
       ID: 68
       Name: '[]int.array'
       ByteSize: 2048
-      Element: 1 BaseType int
+      Element: 7 BaseType int
     - __kind: GoSliceDataType
       ID: 73
       Name: '[]noalg.map.group[string]int.array'
       ByteSize: 2048
-      Element: 26 StructureType noalg.map.group[string]int
+      Element: 45 StructureType noalg.map.group[string]int
     - __kind: GoSliceDataType
       ID: 75
       Name: '[]noalg.map.group[string]main.bigStruct.array'
       ByteSize: 2048
-      Element: 37 StructureType noalg.map.group[string]main.bigStruct
+      Element: 56 StructureType noalg.map.group[string]main.bigStruct
     - __kind: GoSliceHeaderType
-      ID: 12
+      ID: 35
       Name: '[]string'
       ByteSize: 24
       GoRuntimeType: 37952
@@ -787,39 +787,39 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 13 PointerType *string
+          Type: 22 PointerType *string
         - Name: len
           Offset: 8
-          Type: 1 BaseType int
+          Type: 7 BaseType int
         - Name: cap
           Offset: 16
-          Type: 1 BaseType int
+          Type: 7 BaseType int
       Data: 70 GoSliceDataType []string.array
     - __kind: GoSliceDataType
       ID: 70
       Name: '[]string.array'
       ByteSize: 2048
-      Element: 7 GoStringHeaderType string
+      Element: 9 GoStringHeaderType string
     - __kind: BaseType
-      ID: 44
+      ID: 4
       Name: bool
       ByteSize: 1
       GoRuntimeType: 42400
       GoKind: 1
     - __kind: BaseType
-      ID: 58
+      ID: 24
       Name: complex128
       ByteSize: 16
       GoRuntimeType: 42208
       GoKind: 16
     - __kind: BaseType
-      ID: 57
+      ID: 23
       Name: complex64
       ByteSize: 8
       GoRuntimeType: 42144
       GoKind: 15
     - __kind: GoInterfaceType
-      ID: 48
+      ID: 13
       Name: error
       ByteSize: 16
       GoRuntimeType: 63168
@@ -827,76 +827,76 @@ Types:
       RawFields:
         - Name: tab
           Offset: 0
-          Type: 49 VoidPointerType unsafe.Pointer
+          Type: 14 VoidPointerType unsafe.Pointer
         - Name: data
           Offset: 8
-          Type: 49 VoidPointerType unsafe.Pointer
+          Type: 14 VoidPointerType unsafe.Pointer
     - __kind: BaseType
-      ID: 52
+      ID: 17
       Name: float32
       ByteSize: 4
       GoRuntimeType: 42272
       GoKind: 13
     - __kind: BaseType
-      ID: 53
+      ID: 18
       Name: float64
       ByteSize: 8
       GoRuntimeType: 42336
       GoKind: 14
     - __kind: GoSwissMapGroupsType
-      ID: 24
+      ID: 43
       Name: groupReference<string,int>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 25 PointerType *noalg.map.group[string]int
+          Type: 44 PointerType *noalg.map.group[string]int
         - Name: lengthMask
           Offset: 8
-          Type: 18 BaseType uint64
-      GroupType: 26 StructureType noalg.map.group[string]int
+          Type: 8 BaseType uint64
+      GroupType: 45 StructureType noalg.map.group[string]int
       GroupSliceType: 73 GoSliceDataType []noalg.map.group[string]int.array
     - __kind: GoSwissMapGroupsType
-      ID: 35
+      ID: 54
       Name: groupReference<string,main.bigStruct>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 36 PointerType *noalg.map.group[string]main.bigStruct
+          Type: 55 PointerType *noalg.map.group[string]main.bigStruct
         - Name: lengthMask
           Offset: 8
-          Type: 18 BaseType uint64
-      GroupType: 37 StructureType noalg.map.group[string]main.bigStruct
+          Type: 8 BaseType uint64
+      GroupType: 56 StructureType noalg.map.group[string]main.bigStruct
       GroupSliceType: 75 GoSliceDataType []noalg.map.group[string]main.bigStruct.array
     - __kind: BaseType
-      ID: 1
+      ID: 7
       Name: int
       ByteSize: 8
       GoRuntimeType: 41952
       GoKind: 2
     - __kind: BaseType
-      ID: 45
+      ID: 10
       Name: int32
       ByteSize: 4
       GoRuntimeType: 41696
       GoKind: 5
     - __kind: BaseType
-      ID: 47
+      ID: 12
       Name: int64
       ByteSize: 8
       GoRuntimeType: 41824
       GoKind: 6
     - __kind: BaseType
-      ID: 50
+      ID: 15
       Name: int8
       ByteSize: 1
       GoRuntimeType: 41440
       GoKind: 3
     - __kind: StructureType
-      ID: 41
+      ID: 60
       Name: main.bigStruct
       ByteSize: 184
       GoRuntimeType: 119744
@@ -904,126 +904,126 @@ Types:
       RawFields:
         - Name: Field1
           Offset: 0
-          Type: 1 BaseType int
+          Type: 7 BaseType int
         - Name: Field2
           Offset: 8
-          Type: 1 BaseType int
+          Type: 7 BaseType int
         - Name: Field3
           Offset: 16
-          Type: 1 BaseType int
+          Type: 7 BaseType int
         - Name: Field4
           Offset: 24
-          Type: 1 BaseType int
+          Type: 7 BaseType int
         - Name: Field5
           Offset: 32
-          Type: 1 BaseType int
+          Type: 7 BaseType int
         - Name: Field6
           Offset: 40
-          Type: 1 BaseType int
+          Type: 7 BaseType int
         - Name: Field7
           Offset: 48
-          Type: 1 BaseType int
+          Type: 7 BaseType int
         - Name: data
           Offset: 56
-          Type: 42 ArrayType [128]uint8
+          Type: 61 ArrayType [128]uint8
     - __kind: GoSwissMapHeaderType
-      ID: 17
+      ID: 39
       Name: map<string,int>
       ByteSize: 48
       GoKind: 25
       RawFields:
         - Name: used
           Offset: 0
-          Type: 18 BaseType uint64
+          Type: 8 BaseType uint64
         - Name: seed
           Offset: 8
-          Type: 19 BaseType uintptr
+          Type: 1 BaseType uintptr
         - Name: dirPtr
           Offset: 16
-          Type: 20 PointerType **table<string,int>
+          Type: 40 PointerType **table<string,int>
         - Name: dirLen
           Offset: 24
-          Type: 1 BaseType int
+          Type: 7 BaseType int
         - Name: globalDepth
           Offset: 32
-          Type: 9 BaseType uint8
+          Type: 3 BaseType uint8
         - Name: globalShift
           Offset: 33
-          Type: 9 BaseType uint8
+          Type: 3 BaseType uint8
         - Name: writing
           Offset: 34
-          Type: 9 BaseType uint8
+          Type: 3 BaseType uint8
         - Name: clearSeq
           Offset: 40
-          Type: 18 BaseType uint64
+          Type: 8 BaseType uint64
       TablePtrSliceType: 72 GoSliceDataType []*table<string,int>.array
-      GroupType: 26 StructureType noalg.map.group[string]int
+      GroupType: 45 StructureType noalg.map.group[string]int
     - __kind: GoSwissMapHeaderType
-      ID: 31
+      ID: 50
       Name: map<string,main.bigStruct>
       ByteSize: 48
       GoKind: 25
       RawFields:
         - Name: used
           Offset: 0
-          Type: 18 BaseType uint64
+          Type: 8 BaseType uint64
         - Name: seed
           Offset: 8
-          Type: 19 BaseType uintptr
+          Type: 1 BaseType uintptr
         - Name: dirPtr
           Offset: 16
-          Type: 32 PointerType **table<string,main.bigStruct>
+          Type: 51 PointerType **table<string,main.bigStruct>
         - Name: dirLen
           Offset: 24
-          Type: 1 BaseType int
+          Type: 7 BaseType int
         - Name: globalDepth
           Offset: 32
-          Type: 9 BaseType uint8
+          Type: 3 BaseType uint8
         - Name: globalShift
           Offset: 33
-          Type: 9 BaseType uint8
+          Type: 3 BaseType uint8
         - Name: writing
           Offset: 34
-          Type: 9 BaseType uint8
+          Type: 3 BaseType uint8
         - Name: clearSeq
           Offset: 40
-          Type: 18 BaseType uint64
+          Type: 8 BaseType uint64
       TablePtrSliceType: 74 GoSliceDataType []*table<string,main.bigStruct>.array
-      GroupType: 37 StructureType noalg.map.group[string]main.bigStruct
+      GroupType: 56 StructureType noalg.map.group[string]main.bigStruct
     - __kind: GoMapType
-      ID: 15
+      ID: 37
       Name: map[string]int
       ByteSize: 8
       GoRuntimeType: 67264
       GoKind: 21
-      HeaderType: 17 GoSwissMapHeaderType map<string,int>
+      HeaderType: 39 GoSwissMapHeaderType map<string,int>
     - __kind: GoMapType
-      ID: 29
+      ID: 48
       Name: map[string]main.bigStruct
       ByteSize: 8
       GoRuntimeType: 67392
       GoKind: 21
-      HeaderType: 31 GoSwissMapHeaderType map<string,main.bigStruct>
+      HeaderType: 50 GoSwissMapHeaderType map<string,main.bigStruct>
     - __kind: ArrayType
-      ID: 38
+      ID: 57
       Name: noalg.[8]struct { key string; elem *main.bigStruct }
       ByteSize: 192
       GoRuntimeType: 46336
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 39 StructureType noalg.struct { key string; elem *main.bigStruct }
+      Element: 58 StructureType noalg.struct { key string; elem *main.bigStruct }
     - __kind: ArrayType
-      ID: 27
+      ID: 46
       Name: noalg.[8]struct { key string; elem int }
       ByteSize: 192
       GoRuntimeType: 46144
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 28 StructureType noalg.struct { key string; elem int }
+      Element: 47 StructureType noalg.struct { key string; elem int }
     - __kind: StructureType
-      ID: 26
+      ID: 45
       Name: noalg.map.group[string]int
       ByteSize: 200
       GoRuntimeType: 74656
@@ -1031,12 +1031,12 @@ Types:
       RawFields:
         - Name: ctrl
           Offset: 0
-          Type: 18 BaseType uint64
+          Type: 8 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 27 ArrayType noalg.[8]struct { key string; elem int }
+          Type: 46 ArrayType noalg.[8]struct { key string; elem int }
     - __kind: StructureType
-      ID: 37
+      ID: 56
       Name: noalg.map.group[string]main.bigStruct
       ByteSize: 200
       GoRuntimeType: 74912
@@ -1044,12 +1044,12 @@ Types:
       RawFields:
         - Name: ctrl
           Offset: 0
-          Type: 18 BaseType uint64
+          Type: 8 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 38 ArrayType noalg.[8]struct { key string; elem *main.bigStruct }
+          Type: 57 ArrayType noalg.[8]struct { key string; elem *main.bigStruct }
     - __kind: StructureType
-      ID: 39
+      ID: 58
       Name: noalg.struct { key string; elem *main.bigStruct }
       ByteSize: 24
       GoRuntimeType: 74784
@@ -1057,12 +1057,12 @@ Types:
       RawFields:
         - Name: key
           Offset: 0
-          Type: 7 GoStringHeaderType string
+          Type: 9 GoStringHeaderType string
         - Name: elem
           Offset: 16
-          Type: 40 PointerType *main.bigStruct
+          Type: 59 PointerType *main.bigStruct
     - __kind: StructureType
-      ID: 28
+      ID: 47
       Name: noalg.struct { key string; elem int }
       ByteSize: 24
       GoRuntimeType: 74528
@@ -1070,12 +1070,12 @@ Types:
       RawFields:
         - Name: key
           Offset: 0
-          Type: 7 GoStringHeaderType string
+          Type: 9 GoStringHeaderType string
         - Name: elem
           Offset: 16
-          Type: 1 BaseType int
+          Type: 7 BaseType int
     - __kind: GoStringHeaderType
-      ID: 7
+      ID: 9
       Name: string
       ByteSize: 16
       GoRuntimeType: 41376
@@ -1086,98 +1086,98 @@ Types:
           Type: 67 PointerType *string.str
         - Name: len
           Offset: 8
-          Type: 1 BaseType int
+          Type: 7 BaseType int
       Data: 66 GoStringDataType string.str
     - __kind: GoStringDataType
       ID: 66
       Name: string.str
       ByteSize: 2048
     - __kind: StructureType
-      ID: 22
+      ID: 42
       Name: table<string,int>
       ByteSize: 32
       GoKind: 25
       RawFields:
         - Name: used
           Offset: 0
-          Type: 23 BaseType uint16
+          Type: 6 BaseType uint16
         - Name: capacity
           Offset: 2
-          Type: 23 BaseType uint16
+          Type: 6 BaseType uint16
         - Name: growthLeft
           Offset: 4
-          Type: 23 BaseType uint16
+          Type: 6 BaseType uint16
         - Name: localDepth
           Offset: 6
-          Type: 9 BaseType uint8
+          Type: 3 BaseType uint8
         - Name: index
           Offset: 8
-          Type: 1 BaseType int
+          Type: 7 BaseType int
         - Name: groups
           Offset: 16
-          Type: 24 GoSwissMapGroupsType groupReference<string,int>
+          Type: 43 GoSwissMapGroupsType groupReference<string,int>
     - __kind: StructureType
-      ID: 34
+      ID: 53
       Name: table<string,main.bigStruct>
       ByteSize: 32
       GoKind: 25
       RawFields:
         - Name: used
           Offset: 0
-          Type: 23 BaseType uint16
+          Type: 6 BaseType uint16
         - Name: capacity
           Offset: 2
-          Type: 23 BaseType uint16
+          Type: 6 BaseType uint16
         - Name: growthLeft
           Offset: 4
-          Type: 23 BaseType uint16
+          Type: 6 BaseType uint16
         - Name: localDepth
           Offset: 6
-          Type: 9 BaseType uint8
+          Type: 3 BaseType uint8
         - Name: index
           Offset: 8
-          Type: 1 BaseType int
+          Type: 7 BaseType int
         - Name: groups
           Offset: 16
-          Type: 35 GoSwissMapGroupsType groupReference<string,main.bigStruct>
+          Type: 54 GoSwissMapGroupsType groupReference<string,main.bigStruct>
     - __kind: BaseType
-      ID: 51
+      ID: 16
       Name: uint
       ByteSize: 8
       GoRuntimeType: 42016
       GoKind: 7
     - __kind: BaseType
-      ID: 23
+      ID: 6
       Name: uint16
       ByteSize: 2
       GoRuntimeType: 41632
       GoKind: 9
     - __kind: BaseType
-      ID: 43
+      ID: 2
       Name: uint32
       ByteSize: 4
       GoRuntimeType: 41760
       GoKind: 10
     - __kind: BaseType
-      ID: 18
+      ID: 8
       Name: uint64
       ByteSize: 8
       GoRuntimeType: 41888
       GoKind: 11
     - __kind: BaseType
-      ID: 9
+      ID: 3
       Name: uint8
       ByteSize: 1
       GoRuntimeType: 41504
       GoKind: 8
     - __kind: BaseType
-      ID: 19
+      ID: 1
       Name: uintptr
       ByteSize: 8
       GoRuntimeType: 42080
       GoKind: 12
     - __kind: VoidPointerType
-      ID: 49
+      ID: 14
       Name: unsafe.Pointer
       ByteSize: 8
       GoRuntimeType: 42464

--- a/pkg/dyninst/irgen/testdata/snapshot/simple.arch=amd64,toolchain=go1.24.3.yaml
+++ b/pkg/dyninst/irgen/testdata/snapshot/simple.arch=amd64,toolchain=go1.24.3.yaml
@@ -380,15 +380,15 @@ Types:
       ByteSize: 8
       Pointee: 46 PointerType *table<string,main.bigStruct>
     - __kind: PointerType
-      ID: 69
+      ID: 56
       Name: '*[]int.array'
       ByteSize: 8
-      Pointee: 68 GoSliceDataType []int.array
+      Pointee: 55 GoSliceDataType []int.array
     - __kind: PointerType
-      ID: 71
+      ID: 58
       Name: '*[]string.array'
       ByteSize: 8
-      Pointee: 70 GoSliceDataType []string.array
+      Pointee: 57 GoSliceDataType []string.array
     - __kind: PointerType
       ID: 11
       Name: '*bool'
@@ -439,12 +439,12 @@ Types:
       GoKind: 22
       Pointee: 12 BaseType int64
     - __kind: PointerType
-      ID: 63
+      ID: 71
       Name: '*main.bigStruct'
       ByteSize: 8
       GoRuntimeType: 26944
       GoKind: 22
-      Pointee: 64 StructureType main.bigStruct
+      Pointee: 72 StructureType main.bigStruct
     - __kind: PointerType
       ID: 38
       Name: '*map<string,int>'
@@ -456,15 +456,15 @@ Types:
       ByteSize: 8
       Pointee: 44 GoSwissMapHeaderType map<string,main.bigStruct>
     - __kind: PointerType
-      ID: 54
+      ID: 60
       Name: '*noalg.map.group[string]int'
       ByteSize: 8
-      Pointee: 55 StructureType noalg.map.group[string]int
+      Pointee: 61 StructureType noalg.map.group[string]int
     - __kind: PointerType
-      ID: 57
+      ID: 67
       Name: '*noalg.map.group[string]main.bigStruct'
       ByteSize: 8
-      Pointee: 58 StructureType noalg.map.group[string]main.bigStruct
+      Pointee: 68 StructureType noalg.map.group[string]main.bigStruct
     - __kind: PointerType
       ID: 22
       Name: '*string'
@@ -473,10 +473,10 @@ Types:
       GoKind: 22
       Pointee: 9 GoStringHeaderType string
     - __kind: PointerType
-      ID: 67
+      ID: 54
       Name: '*string.str'
       ByteSize: 8
-      Pointee: 66 GoStringDataType string.str
+      Pointee: 53 GoStringDataType string.str
     - __kind: PointerType
       ID: 41
       Name: '*table<string,int>'
@@ -710,7 +710,7 @@ Types:
                   Offset: 0
                   ByteSize: 24
     - __kind: ArrayType
-      ID: 65
+      ID: 75
       Name: '[128]uint8'
       ByteSize: 128
       GoRuntimeType: 46240
@@ -737,12 +737,12 @@ Types:
       HasCount: true
       Element: 9 GoStringHeaderType string
     - __kind: GoSliceDataType
-      ID: 72
+      ID: 64
       Name: '[]*table<string,int>.array'
       ByteSize: 8192
       Element: 41 PointerType *table<string,int>
     - __kind: GoSliceDataType
-      ID: 74
+      ID: 73
       Name: '[]*table<string,main.bigStruct>.array'
       ByteSize: 8192
       Element: 46 PointerType *table<string,main.bigStruct>
@@ -762,22 +762,22 @@ Types:
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 68 GoSliceDataType []int.array
+      Data: 55 GoSliceDataType []int.array
     - __kind: GoSliceDataType
-      ID: 68
+      ID: 55
       Name: '[]int.array'
       ByteSize: 2048
       Element: 7 BaseType int
     - __kind: GoSliceDataType
-      ID: 73
+      ID: 65
       Name: '[]noalg.map.group[string]int.array'
       ByteSize: 2048
-      Element: 55 StructureType noalg.map.group[string]int
+      Element: 61 StructureType noalg.map.group[string]int
     - __kind: GoSliceDataType
-      ID: 75
+      ID: 74
       Name: '[]noalg.map.group[string]main.bigStruct.array'
       ByteSize: 2048
-      Element: 58 StructureType noalg.map.group[string]main.bigStruct
+      Element: 68 StructureType noalg.map.group[string]main.bigStruct
     - __kind: GoSliceHeaderType
       ID: 35
       Name: '[]string'
@@ -794,9 +794,9 @@ Types:
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 70 GoSliceDataType []string.array
+      Data: 57 GoSliceDataType []string.array
     - __kind: GoSliceDataType
-      ID: 70
+      ID: 57
       Name: '[]string.array'
       ByteSize: 2048
       Element: 9 GoStringHeaderType string
@@ -844,33 +844,33 @@ Types:
       GoRuntimeType: 42336
       GoKind: 14
     - __kind: GoSwissMapGroupsType
-      ID: 53
+      ID: 59
       Name: groupReference<string,int>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 54 PointerType *noalg.map.group[string]int
+          Type: 60 PointerType *noalg.map.group[string]int
         - Name: lengthMask
           Offset: 8
           Type: 8 BaseType uint64
-      GroupType: 55 StructureType noalg.map.group[string]int
-      GroupSliceType: 73 GoSliceDataType []noalg.map.group[string]int.array
+      GroupType: 61 StructureType noalg.map.group[string]int
+      GroupSliceType: 65 GoSliceDataType []noalg.map.group[string]int.array
     - __kind: GoSwissMapGroupsType
-      ID: 56
+      ID: 66
       Name: groupReference<string,main.bigStruct>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 57 PointerType *noalg.map.group[string]main.bigStruct
+          Type: 67 PointerType *noalg.map.group[string]main.bigStruct
         - Name: lengthMask
           Offset: 8
           Type: 8 BaseType uint64
-      GroupType: 58 StructureType noalg.map.group[string]main.bigStruct
-      GroupSliceType: 75 GoSliceDataType []noalg.map.group[string]main.bigStruct.array
+      GroupType: 68 StructureType noalg.map.group[string]main.bigStruct
+      GroupSliceType: 74 GoSliceDataType []noalg.map.group[string]main.bigStruct.array
     - __kind: BaseType
       ID: 7
       Name: int
@@ -896,7 +896,7 @@ Types:
       GoRuntimeType: 41440
       GoKind: 3
     - __kind: StructureType
-      ID: 64
+      ID: 72
       Name: main.bigStruct
       ByteSize: 184
       GoRuntimeType: 119744
@@ -925,7 +925,7 @@ Types:
           Type: 7 BaseType int
         - Name: data
           Offset: 56
-          Type: 65 ArrayType [128]uint8
+          Type: 75 ArrayType [128]uint8
     - __kind: GoSwissMapHeaderType
       ID: 39
       Name: map<string,int>
@@ -956,8 +956,8 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 8 BaseType uint64
-      TablePtrSliceType: 72 GoSliceDataType []*table<string,int>.array
-      GroupType: 55 StructureType noalg.map.group[string]int
+      TablePtrSliceType: 64 GoSliceDataType []*table<string,int>.array
+      GroupType: 61 StructureType noalg.map.group[string]int
     - __kind: GoSwissMapHeaderType
       ID: 44
       Name: map<string,main.bigStruct>
@@ -988,8 +988,8 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 8 BaseType uint64
-      TablePtrSliceType: 74 GoSliceDataType []*table<string,main.bigStruct>.array
-      GroupType: 58 StructureType noalg.map.group[string]main.bigStruct
+      TablePtrSliceType: 73 GoSliceDataType []*table<string,main.bigStruct>.array
+      GroupType: 68 StructureType noalg.map.group[string]main.bigStruct
     - __kind: GoMapType
       ID: 37
       Name: map[string]int
@@ -1005,25 +1005,25 @@ Types:
       GoKind: 21
       HeaderType: 44 GoSwissMapHeaderType map<string,main.bigStruct>
     - __kind: ArrayType
-      ID: 61
+      ID: 69
       Name: noalg.[8]struct { key string; elem *main.bigStruct }
       ByteSize: 192
       GoRuntimeType: 46336
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 62 StructureType noalg.struct { key string; elem *main.bigStruct }
+      Element: 70 StructureType noalg.struct { key string; elem *main.bigStruct }
     - __kind: ArrayType
-      ID: 59
+      ID: 62
       Name: noalg.[8]struct { key string; elem int }
       ByteSize: 192
       GoRuntimeType: 46144
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 60 StructureType noalg.struct { key string; elem int }
+      Element: 63 StructureType noalg.struct { key string; elem int }
     - __kind: StructureType
-      ID: 55
+      ID: 61
       Name: noalg.map.group[string]int
       ByteSize: 200
       GoRuntimeType: 74656
@@ -1034,9 +1034,9 @@ Types:
           Type: 8 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 59 ArrayType noalg.[8]struct { key string; elem int }
+          Type: 62 ArrayType noalg.[8]struct { key string; elem int }
     - __kind: StructureType
-      ID: 58
+      ID: 68
       Name: noalg.map.group[string]main.bigStruct
       ByteSize: 200
       GoRuntimeType: 74912
@@ -1047,9 +1047,9 @@ Types:
           Type: 8 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 61 ArrayType noalg.[8]struct { key string; elem *main.bigStruct }
+          Type: 69 ArrayType noalg.[8]struct { key string; elem *main.bigStruct }
     - __kind: StructureType
-      ID: 62
+      ID: 70
       Name: noalg.struct { key string; elem *main.bigStruct }
       ByteSize: 24
       GoRuntimeType: 74784
@@ -1060,9 +1060,9 @@ Types:
           Type: 9 GoStringHeaderType string
         - Name: elem
           Offset: 16
-          Type: 63 PointerType *main.bigStruct
+          Type: 71 PointerType *main.bigStruct
     - __kind: StructureType
-      ID: 60
+      ID: 63
       Name: noalg.struct { key string; elem int }
       ByteSize: 24
       GoRuntimeType: 74528
@@ -1083,13 +1083,13 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 67 PointerType *string.str
+          Type: 54 PointerType *string.str
         - Name: len
           Offset: 8
           Type: 7 BaseType int
-      Data: 66 GoStringDataType string.str
+      Data: 53 GoStringDataType string.str
     - __kind: GoStringDataType
-      ID: 66
+      ID: 53
       Name: string.str
       ByteSize: 2048
     - __kind: StructureType
@@ -1115,7 +1115,7 @@ Types:
           Type: 7 BaseType int
         - Name: groups
           Offset: 16
-          Type: 53 GoSwissMapGroupsType groupReference<string,int>
+          Type: 59 GoSwissMapGroupsType groupReference<string,int>
     - __kind: StructureType
       ID: 51
       Name: table<string,main.bigStruct>
@@ -1139,7 +1139,7 @@ Types:
           Type: 7 BaseType int
         - Name: groups
           Offset: 16
-          Type: 56 GoSwissMapGroupsType groupReference<string,main.bigStruct>
+          Type: 66 GoSwissMapGroupsType groupReference<string,main.bigStruct>
     - __kind: BaseType
       ID: 16
       Name: uint

--- a/pkg/dyninst/irgen/testdata/snapshot/simple.arch=amd64,toolchain=go1.24.3.yaml
+++ b/pkg/dyninst/irgen/testdata/snapshot/simple.arch=amd64,toolchain=go1.24.3.yaml
@@ -354,9 +354,9 @@ Types:
       ByteSize: 8
       GoRuntimeType: 35200
       GoKind: 22
-      Pointee: 52 PointerType ***int
+      Pointee: 74 PointerType ***int
     - __kind: PointerType
-      ID: 52
+      ID: 74
       Name: '***int'
       ByteSize: 8
       GoRuntimeType: 35136
@@ -380,15 +380,15 @@ Types:
       ByteSize: 8
       Pointee: 46 PointerType *table<string,main.bigStruct>
     - __kind: PointerType
-      ID: 56
+      ID: 53
       Name: '*[]int.array'
       ByteSize: 8
-      Pointee: 55 GoSliceDataType []int.array
+      Pointee: 52 GoSliceDataType []int.array
     - __kind: PointerType
-      ID: 58
+      ID: 55
       Name: '*[]string.array'
       ByteSize: 8
-      Pointee: 57 GoSliceDataType []string.array
+      Pointee: 54 GoSliceDataType []string.array
     - __kind: PointerType
       ID: 11
       Name: '*bool'
@@ -439,12 +439,12 @@ Types:
       GoKind: 22
       Pointee: 12 BaseType int64
     - __kind: PointerType
-      ID: 71
+      ID: 70
       Name: '*main.bigStruct'
       ByteSize: 8
       GoRuntimeType: 26944
       GoKind: 22
-      Pointee: 72 StructureType main.bigStruct
+      Pointee: 71 StructureType main.bigStruct
     - __kind: PointerType
       ID: 38
       Name: '*map<string,int>'
@@ -456,15 +456,15 @@ Types:
       ByteSize: 8
       Pointee: 44 GoSwissMapHeaderType map<string,main.bigStruct>
     - __kind: PointerType
-      ID: 60
+      ID: 58
       Name: '*noalg.map.group[string]int'
       ByteSize: 8
-      Pointee: 61 StructureType noalg.map.group[string]int
+      Pointee: 59 StructureType noalg.map.group[string]int
     - __kind: PointerType
-      ID: 67
+      ID: 66
       Name: '*noalg.map.group[string]main.bigStruct'
       ByteSize: 8
-      Pointee: 68 StructureType noalg.map.group[string]main.bigStruct
+      Pointee: 67 StructureType noalg.map.group[string]main.bigStruct
     - __kind: PointerType
       ID: 22
       Name: '*string'
@@ -473,20 +473,20 @@ Types:
       GoKind: 22
       Pointee: 9 GoStringHeaderType string
     - __kind: PointerType
-      ID: 54
+      ID: 51
       Name: '*string.str'
       ByteSize: 8
-      Pointee: 53 GoStringDataType string.str
+      Pointee: 50 GoStringDataType string.str
     - __kind: PointerType
       ID: 41
       Name: '*table<string,int>'
       ByteSize: 8
-      Pointee: 50 StructureType table<string,int>
+      Pointee: 56 StructureType table<string,int>
     - __kind: PointerType
       ID: 46
       Name: '*table<string,main.bigStruct>'
       ByteSize: 8
-      Pointee: 51 StructureType table<string,main.bigStruct>
+      Pointee: 64 StructureType table<string,main.bigStruct>
     - __kind: PointerType
       ID: 31
       Name: '*uint'
@@ -737,12 +737,12 @@ Types:
       HasCount: true
       Element: 9 GoStringHeaderType string
     - __kind: GoSliceDataType
-      ID: 64
+      ID: 62
       Name: '[]*table<string,int>.array'
       ByteSize: 8192
       Element: 41 PointerType *table<string,int>
     - __kind: GoSliceDataType
-      ID: 73
+      ID: 72
       Name: '[]*table<string,main.bigStruct>.array'
       ByteSize: 8192
       Element: 46 PointerType *table<string,main.bigStruct>
@@ -762,22 +762,22 @@ Types:
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 55 GoSliceDataType []int.array
+      Data: 52 GoSliceDataType []int.array
     - __kind: GoSliceDataType
-      ID: 55
+      ID: 52
       Name: '[]int.array'
       ByteSize: 2048
       Element: 7 BaseType int
     - __kind: GoSliceDataType
-      ID: 65
+      ID: 63
       Name: '[]noalg.map.group[string]int.array'
       ByteSize: 2048
-      Element: 61 StructureType noalg.map.group[string]int
+      Element: 59 StructureType noalg.map.group[string]int
     - __kind: GoSliceDataType
-      ID: 74
+      ID: 73
       Name: '[]noalg.map.group[string]main.bigStruct.array'
       ByteSize: 2048
-      Element: 68 StructureType noalg.map.group[string]main.bigStruct
+      Element: 67 StructureType noalg.map.group[string]main.bigStruct
     - __kind: GoSliceHeaderType
       ID: 35
       Name: '[]string'
@@ -794,9 +794,9 @@ Types:
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 57 GoSliceDataType []string.array
+      Data: 54 GoSliceDataType []string.array
     - __kind: GoSliceDataType
-      ID: 57
+      ID: 54
       Name: '[]string.array'
       ByteSize: 2048
       Element: 9 GoStringHeaderType string
@@ -844,33 +844,33 @@ Types:
       GoRuntimeType: 42336
       GoKind: 14
     - __kind: GoSwissMapGroupsType
-      ID: 59
+      ID: 57
       Name: groupReference<string,int>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 60 PointerType *noalg.map.group[string]int
+          Type: 58 PointerType *noalg.map.group[string]int
         - Name: lengthMask
           Offset: 8
           Type: 8 BaseType uint64
-      GroupType: 61 StructureType noalg.map.group[string]int
-      GroupSliceType: 65 GoSliceDataType []noalg.map.group[string]int.array
+      GroupType: 59 StructureType noalg.map.group[string]int
+      GroupSliceType: 63 GoSliceDataType []noalg.map.group[string]int.array
     - __kind: GoSwissMapGroupsType
-      ID: 66
+      ID: 65
       Name: groupReference<string,main.bigStruct>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 67 PointerType *noalg.map.group[string]main.bigStruct
+          Type: 66 PointerType *noalg.map.group[string]main.bigStruct
         - Name: lengthMask
           Offset: 8
           Type: 8 BaseType uint64
-      GroupType: 68 StructureType noalg.map.group[string]main.bigStruct
-      GroupSliceType: 74 GoSliceDataType []noalg.map.group[string]main.bigStruct.array
+      GroupType: 67 StructureType noalg.map.group[string]main.bigStruct
+      GroupSliceType: 73 GoSliceDataType []noalg.map.group[string]main.bigStruct.array
     - __kind: BaseType
       ID: 7
       Name: int
@@ -896,7 +896,7 @@ Types:
       GoRuntimeType: 41440
       GoKind: 3
     - __kind: StructureType
-      ID: 72
+      ID: 71
       Name: main.bigStruct
       ByteSize: 184
       GoRuntimeType: 119744
@@ -956,8 +956,8 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 8 BaseType uint64
-      TablePtrSliceType: 64 GoSliceDataType []*table<string,int>.array
-      GroupType: 61 StructureType noalg.map.group[string]int
+      TablePtrSliceType: 62 GoSliceDataType []*table<string,int>.array
+      GroupType: 59 StructureType noalg.map.group[string]int
     - __kind: GoSwissMapHeaderType
       ID: 44
       Name: map<string,main.bigStruct>
@@ -988,8 +988,8 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 8 BaseType uint64
-      TablePtrSliceType: 73 GoSliceDataType []*table<string,main.bigStruct>.array
-      GroupType: 68 StructureType noalg.map.group[string]main.bigStruct
+      TablePtrSliceType: 72 GoSliceDataType []*table<string,main.bigStruct>.array
+      GroupType: 67 StructureType noalg.map.group[string]main.bigStruct
     - __kind: GoMapType
       ID: 37
       Name: map[string]int
@@ -1005,25 +1005,25 @@ Types:
       GoKind: 21
       HeaderType: 44 GoSwissMapHeaderType map<string,main.bigStruct>
     - __kind: ArrayType
-      ID: 69
+      ID: 68
       Name: noalg.[8]struct { key string; elem *main.bigStruct }
       ByteSize: 192
       GoRuntimeType: 46336
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 70 StructureType noalg.struct { key string; elem *main.bigStruct }
+      Element: 69 StructureType noalg.struct { key string; elem *main.bigStruct }
     - __kind: ArrayType
-      ID: 62
+      ID: 60
       Name: noalg.[8]struct { key string; elem int }
       ByteSize: 192
       GoRuntimeType: 46144
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 63 StructureType noalg.struct { key string; elem int }
+      Element: 61 StructureType noalg.struct { key string; elem int }
     - __kind: StructureType
-      ID: 61
+      ID: 59
       Name: noalg.map.group[string]int
       ByteSize: 200
       GoRuntimeType: 74656
@@ -1034,9 +1034,9 @@ Types:
           Type: 8 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 62 ArrayType noalg.[8]struct { key string; elem int }
+          Type: 60 ArrayType noalg.[8]struct { key string; elem int }
     - __kind: StructureType
-      ID: 68
+      ID: 67
       Name: noalg.map.group[string]main.bigStruct
       ByteSize: 200
       GoRuntimeType: 74912
@@ -1047,9 +1047,9 @@ Types:
           Type: 8 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 69 ArrayType noalg.[8]struct { key string; elem *main.bigStruct }
+          Type: 68 ArrayType noalg.[8]struct { key string; elem *main.bigStruct }
     - __kind: StructureType
-      ID: 70
+      ID: 69
       Name: noalg.struct { key string; elem *main.bigStruct }
       ByteSize: 24
       GoRuntimeType: 74784
@@ -1060,9 +1060,9 @@ Types:
           Type: 9 GoStringHeaderType string
         - Name: elem
           Offset: 16
-          Type: 71 PointerType *main.bigStruct
+          Type: 70 PointerType *main.bigStruct
     - __kind: StructureType
-      ID: 63
+      ID: 61
       Name: noalg.struct { key string; elem int }
       ByteSize: 24
       GoRuntimeType: 74528
@@ -1083,17 +1083,17 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 54 PointerType *string.str
+          Type: 51 PointerType *string.str
         - Name: len
           Offset: 8
           Type: 7 BaseType int
-      Data: 53 GoStringDataType string.str
+      Data: 50 GoStringDataType string.str
     - __kind: GoStringDataType
-      ID: 53
+      ID: 50
       Name: string.str
       ByteSize: 2048
     - __kind: StructureType
-      ID: 50
+      ID: 56
       Name: table<string,int>
       ByteSize: 32
       GoKind: 25
@@ -1115,9 +1115,9 @@ Types:
           Type: 7 BaseType int
         - Name: groups
           Offset: 16
-          Type: 59 GoSwissMapGroupsType groupReference<string,int>
+          Type: 57 GoSwissMapGroupsType groupReference<string,int>
     - __kind: StructureType
-      ID: 51
+      ID: 64
       Name: table<string,main.bigStruct>
       ByteSize: 32
       GoKind: 25
@@ -1139,7 +1139,7 @@ Types:
           Type: 7 BaseType int
         - Name: groups
           Offset: 16
-          Type: 66 GoSwissMapGroupsType groupReference<string,main.bigStruct>
+          Type: 65 GoSwissMapGroupsType groupReference<string,main.bigStruct>
     - __kind: BaseType
       ID: 16
       Name: uint

--- a/pkg/dyninst/irgen/testdata/snapshot/simple.arch=amd64,toolchain=go1.24.3.yaml
+++ b/pkg/dyninst/irgen/testdata/snapshot/simple.arch=amd64,toolchain=go1.24.3.yaml
@@ -341,12 +341,6 @@ Subprograms:
           IsParameter: true
           IsReturn: false
 Types:
-    - __kind: BaseType
-      ID: 1
-      Name: int
-      ByteSize: 8
-      GoRuntimeType: 41952
-      GoKind: 2
     - __kind: PointerType
       ID: 2
       Name: '*****int'
@@ -376,445 +370,25 @@ Types:
       GoKind: 22
       Pointee: 6 PointerType *int
     - __kind: PointerType
-      ID: 6
-      Name: '*int'
-      ByteSize: 8
-      GoRuntimeType: 29120
-      GoKind: 22
-      Pointee: 1 BaseType int
-    - __kind: GoStringHeaderType
-      ID: 7
-      Name: string
-      ByteSize: 16
-      GoRuntimeType: 41376
-      GoKind: 24
-      RawFields:
-        - Name: str
-          Offset: 0
-          Type: 67 PointerType *string.str
-        - Name: len
-          Offset: 8
-          Type: 1 BaseType int
-      Data: 66 GoStringDataType string.str
-    - __kind: PointerType
-      ID: 8
-      Name: '*uint8'
-      ByteSize: 8
-      GoRuntimeType: 28672
-      GoKind: 22
-      Pointee: 9 BaseType uint8
-    - __kind: BaseType
-      ID: 9
-      Name: uint8
-      ByteSize: 1
-      GoRuntimeType: 41504
-      GoKind: 8
-    - __kind: GoSliceHeaderType
-      ID: 10
-      Name: '[]int'
-      ByteSize: 24
-      GoRuntimeType: 37696
-      GoKind: 23
-      RawFields:
-        - Name: array
-          Offset: 0
-          Type: 6 PointerType *int
-        - Name: len
-          Offset: 8
-          Type: 1 BaseType int
-        - Name: cap
-          Offset: 16
-          Type: 1 BaseType int
-      Data: 68 GoSliceDataType []int.array
-    - __kind: ArrayType
-      ID: 11
-      Name: '[3]int'
-      ByteSize: 24
-      GoRuntimeType: 45952
-      GoKind: 17
-      Count: 3
-      HasCount: true
-      Element: 1 BaseType int
-    - __kind: GoSliceHeaderType
-      ID: 12
-      Name: '[]string'
-      ByteSize: 24
-      GoRuntimeType: 37952
-      GoKind: 23
-      RawFields:
-        - Name: array
-          Offset: 0
-          Type: 13 PointerType *string
-        - Name: len
-          Offset: 8
-          Type: 1 BaseType int
-        - Name: cap
-          Offset: 16
-          Type: 1 BaseType int
-      Data: 70 GoSliceDataType []string.array
-    - __kind: PointerType
-      ID: 13
-      Name: '*string'
-      ByteSize: 8
-      GoRuntimeType: 28544
-      GoKind: 22
-      Pointee: 7 GoStringHeaderType string
-    - __kind: ArrayType
-      ID: 14
-      Name: '[3]string'
-      ByteSize: 48
-      GoRuntimeType: 46048
-      GoKind: 17
-      Count: 3
-      HasCount: true
-      Element: 7 GoStringHeaderType string
-    - __kind: GoMapType
-      ID: 15
-      Name: map[string]int
-      ByteSize: 8
-      GoRuntimeType: 67264
-      GoKind: 21
-      HeaderType: 17 GoSwissMapHeaderType map<string,int>
-    - __kind: PointerType
-      ID: 16
-      Name: '*map<string,int>'
-      ByteSize: 8
-      Pointee: 17 GoSwissMapHeaderType map<string,int>
-    - __kind: GoSwissMapHeaderType
-      ID: 17
-      Name: map<string,int>
-      ByteSize: 48
-      GoKind: 25
-      RawFields:
-        - Name: used
-          Offset: 0
-          Type: 18 BaseType uint64
-        - Name: seed
-          Offset: 8
-          Type: 19 BaseType uintptr
-        - Name: dirPtr
-          Offset: 16
-          Type: 20 PointerType **table<string,int>
-        - Name: dirLen
-          Offset: 24
-          Type: 1 BaseType int
-        - Name: globalDepth
-          Offset: 32
-          Type: 9 BaseType uint8
-        - Name: globalShift
-          Offset: 33
-          Type: 9 BaseType uint8
-        - Name: writing
-          Offset: 34
-          Type: 9 BaseType uint8
-        - Name: clearSeq
-          Offset: 40
-          Type: 18 BaseType uint64
-      TablePtrSliceType: 72 GoSliceDataType []*table<string,int>.array
-      GroupType: 26 StructureType noalg.map.group[string]int
-    - __kind: BaseType
-      ID: 18
-      Name: uint64
-      ByteSize: 8
-      GoRuntimeType: 41888
-      GoKind: 11
-    - __kind: BaseType
-      ID: 19
-      Name: uintptr
-      ByteSize: 8
-      GoRuntimeType: 42080
-      GoKind: 12
-    - __kind: PointerType
       ID: 20
       Name: '**table<string,int>'
       ByteSize: 8
       Pointee: 21 PointerType *table<string,int>
-    - __kind: PointerType
-      ID: 21
-      Name: '*table<string,int>'
-      ByteSize: 8
-      Pointee: 22 StructureType table<string,int>
-    - __kind: StructureType
-      ID: 22
-      Name: table<string,int>
-      ByteSize: 32
-      GoKind: 25
-      RawFields:
-        - Name: used
-          Offset: 0
-          Type: 23 BaseType uint16
-        - Name: capacity
-          Offset: 2
-          Type: 23 BaseType uint16
-        - Name: growthLeft
-          Offset: 4
-          Type: 23 BaseType uint16
-        - Name: localDepth
-          Offset: 6
-          Type: 9 BaseType uint8
-        - Name: index
-          Offset: 8
-          Type: 1 BaseType int
-        - Name: groups
-          Offset: 16
-          Type: 24 GoSwissMapGroupsType groupReference<string,int>
-    - __kind: BaseType
-      ID: 23
-      Name: uint16
-      ByteSize: 2
-      GoRuntimeType: 41632
-      GoKind: 9
-    - __kind: GoSwissMapGroupsType
-      ID: 24
-      Name: groupReference<string,int>
-      ByteSize: 16
-      GoKind: 25
-      RawFields:
-        - Name: data
-          Offset: 0
-          Type: 25 PointerType *noalg.map.group[string]int
-        - Name: lengthMask
-          Offset: 8
-          Type: 18 BaseType uint64
-      GroupType: 26 StructureType noalg.map.group[string]int
-      GroupSliceType: 73 GoSliceDataType []noalg.map.group[string]int.array
-    - __kind: PointerType
-      ID: 25
-      Name: '*noalg.map.group[string]int'
-      ByteSize: 8
-      Pointee: 26 StructureType noalg.map.group[string]int
-    - __kind: StructureType
-      ID: 26
-      Name: noalg.map.group[string]int
-      ByteSize: 200
-      GoRuntimeType: 74656
-      GoKind: 25
-      RawFields:
-        - Name: ctrl
-          Offset: 0
-          Type: 18 BaseType uint64
-        - Name: slots
-          Offset: 8
-          Type: 27 ArrayType noalg.[8]struct { key string; elem int }
-    - __kind: ArrayType
-      ID: 27
-      Name: noalg.[8]struct { key string; elem int }
-      ByteSize: 192
-      GoRuntimeType: 46144
-      GoKind: 17
-      Count: 8
-      HasCount: true
-      Element: 28 StructureType noalg.struct { key string; elem int }
-    - __kind: StructureType
-      ID: 28
-      Name: noalg.struct { key string; elem int }
-      ByteSize: 24
-      GoRuntimeType: 74528
-      GoKind: 25
-      RawFields:
-        - Name: key
-          Offset: 0
-          Type: 7 GoStringHeaderType string
-        - Name: elem
-          Offset: 16
-          Type: 1 BaseType int
-    - __kind: GoMapType
-      ID: 29
-      Name: map[string]main.bigStruct
-      ByteSize: 8
-      GoRuntimeType: 67392
-      GoKind: 21
-      HeaderType: 31 GoSwissMapHeaderType map<string,main.bigStruct>
-    - __kind: PointerType
-      ID: 30
-      Name: '*map<string,main.bigStruct>'
-      ByteSize: 8
-      Pointee: 31 GoSwissMapHeaderType map<string,main.bigStruct>
-    - __kind: GoSwissMapHeaderType
-      ID: 31
-      Name: map<string,main.bigStruct>
-      ByteSize: 48
-      GoKind: 25
-      RawFields:
-        - Name: used
-          Offset: 0
-          Type: 18 BaseType uint64
-        - Name: seed
-          Offset: 8
-          Type: 19 BaseType uintptr
-        - Name: dirPtr
-          Offset: 16
-          Type: 32 PointerType **table<string,main.bigStruct>
-        - Name: dirLen
-          Offset: 24
-          Type: 1 BaseType int
-        - Name: globalDepth
-          Offset: 32
-          Type: 9 BaseType uint8
-        - Name: globalShift
-          Offset: 33
-          Type: 9 BaseType uint8
-        - Name: writing
-          Offset: 34
-          Type: 9 BaseType uint8
-        - Name: clearSeq
-          Offset: 40
-          Type: 18 BaseType uint64
-      TablePtrSliceType: 74 GoSliceDataType []*table<string,main.bigStruct>.array
-      GroupType: 37 StructureType noalg.map.group[string]main.bigStruct
     - __kind: PointerType
       ID: 32
       Name: '**table<string,main.bigStruct>'
       ByteSize: 8
       Pointee: 33 PointerType *table<string,main.bigStruct>
     - __kind: PointerType
-      ID: 33
-      Name: '*table<string,main.bigStruct>'
+      ID: 69
+      Name: '*[]int.array'
       ByteSize: 8
-      Pointee: 34 StructureType table<string,main.bigStruct>
-    - __kind: StructureType
-      ID: 34
-      Name: table<string,main.bigStruct>
-      ByteSize: 32
-      GoKind: 25
-      RawFields:
-        - Name: used
-          Offset: 0
-          Type: 23 BaseType uint16
-        - Name: capacity
-          Offset: 2
-          Type: 23 BaseType uint16
-        - Name: growthLeft
-          Offset: 4
-          Type: 23 BaseType uint16
-        - Name: localDepth
-          Offset: 6
-          Type: 9 BaseType uint8
-        - Name: index
-          Offset: 8
-          Type: 1 BaseType int
-        - Name: groups
-          Offset: 16
-          Type: 35 GoSwissMapGroupsType groupReference<string,main.bigStruct>
-    - __kind: GoSwissMapGroupsType
-      ID: 35
-      Name: groupReference<string,main.bigStruct>
-      ByteSize: 16
-      GoKind: 25
-      RawFields:
-        - Name: data
-          Offset: 0
-          Type: 36 PointerType *noalg.map.group[string]main.bigStruct
-        - Name: lengthMask
-          Offset: 8
-          Type: 18 BaseType uint64
-      GroupType: 37 StructureType noalg.map.group[string]main.bigStruct
-      GroupSliceType: 75 GoSliceDataType []noalg.map.group[string]main.bigStruct.array
+      Pointee: 68 GoSliceDataType []int.array
     - __kind: PointerType
-      ID: 36
-      Name: '*noalg.map.group[string]main.bigStruct'
+      ID: 71
+      Name: '*[]string.array'
       ByteSize: 8
-      Pointee: 37 StructureType noalg.map.group[string]main.bigStruct
-    - __kind: StructureType
-      ID: 37
-      Name: noalg.map.group[string]main.bigStruct
-      ByteSize: 200
-      GoRuntimeType: 74912
-      GoKind: 25
-      RawFields:
-        - Name: ctrl
-          Offset: 0
-          Type: 18 BaseType uint64
-        - Name: slots
-          Offset: 8
-          Type: 38 ArrayType noalg.[8]struct { key string; elem *main.bigStruct }
-    - __kind: ArrayType
-      ID: 38
-      Name: noalg.[8]struct { key string; elem *main.bigStruct }
-      ByteSize: 192
-      GoRuntimeType: 46336
-      GoKind: 17
-      Count: 8
-      HasCount: true
-      Element: 39 StructureType noalg.struct { key string; elem *main.bigStruct }
-    - __kind: StructureType
-      ID: 39
-      Name: noalg.struct { key string; elem *main.bigStruct }
-      ByteSize: 24
-      GoRuntimeType: 74784
-      GoKind: 25
-      RawFields:
-        - Name: key
-          Offset: 0
-          Type: 7 GoStringHeaderType string
-        - Name: elem
-          Offset: 16
-          Type: 40 PointerType *main.bigStruct
-    - __kind: PointerType
-      ID: 40
-      Name: '*main.bigStruct'
-      ByteSize: 8
-      GoRuntimeType: 26944
-      GoKind: 22
-      Pointee: 41 StructureType main.bigStruct
-    - __kind: StructureType
-      ID: 41
-      Name: main.bigStruct
-      ByteSize: 184
-      GoRuntimeType: 119744
-      GoKind: 25
-      RawFields:
-        - Name: Field1
-          Offset: 0
-          Type: 1 BaseType int
-        - Name: Field2
-          Offset: 8
-          Type: 1 BaseType int
-        - Name: Field3
-          Offset: 16
-          Type: 1 BaseType int
-        - Name: Field4
-          Offset: 24
-          Type: 1 BaseType int
-        - Name: Field5
-          Offset: 32
-          Type: 1 BaseType int
-        - Name: Field6
-          Offset: 40
-          Type: 1 BaseType int
-        - Name: Field7
-          Offset: 48
-          Type: 1 BaseType int
-        - Name: data
-          Offset: 56
-          Type: 42 ArrayType [128]uint8
-    - __kind: ArrayType
-      ID: 42
-      Name: '[128]uint8'
-      ByteSize: 128
-      GoRuntimeType: 46240
-      GoKind: 17
-      Count: 128
-      HasCount: true
-      Element: 9 BaseType uint8
-    - __kind: BaseType
-      ID: 43
-      Name: uint32
-      ByteSize: 4
-      GoRuntimeType: 41760
-      GoKind: 10
-    - __kind: BaseType
-      ID: 44
-      Name: bool
-      ByteSize: 1
-      GoRuntimeType: 42400
-      GoKind: 1
-    - __kind: BaseType
-      ID: 45
-      Name: int32
-      ByteSize: 4
-      GoRuntimeType: 41696
-      GoKind: 5
+      Pointee: 70 GoSliceDataType []string.array
     - __kind: PointerType
       ID: 46
       Name: '*bool'
@@ -822,109 +396,6 @@ Types:
       GoRuntimeType: 29568
       GoKind: 22
       Pointee: 44 BaseType bool
-    - __kind: BaseType
-      ID: 47
-      Name: int64
-      ByteSize: 8
-      GoRuntimeType: 41824
-      GoKind: 6
-    - __kind: GoInterfaceType
-      ID: 48
-      Name: error
-      ByteSize: 16
-      GoRuntimeType: 63168
-      GoKind: 20
-      RawFields:
-        - Name: tab
-          Offset: 0
-          Type: 49 VoidPointerType unsafe.Pointer
-        - Name: data
-          Offset: 8
-          Type: 49 VoidPointerType unsafe.Pointer
-    - __kind: VoidPointerType
-      ID: 49
-      Name: unsafe.Pointer
-      ByteSize: 8
-      GoRuntimeType: 42464
-      GoKind: 26
-    - __kind: BaseType
-      ID: 50
-      Name: int8
-      ByteSize: 1
-      GoRuntimeType: 41440
-      GoKind: 3
-    - __kind: BaseType
-      ID: 51
-      Name: uint
-      ByteSize: 8
-      GoRuntimeType: 42016
-      GoKind: 7
-    - __kind: BaseType
-      ID: 52
-      Name: float32
-      ByteSize: 4
-      GoRuntimeType: 42272
-      GoKind: 13
-    - __kind: BaseType
-      ID: 53
-      Name: float64
-      ByteSize: 8
-      GoRuntimeType: 42336
-      GoKind: 14
-    - __kind: PointerType
-      ID: 54
-      Name: '*uintptr'
-      ByteSize: 8
-      GoRuntimeType: 29248
-      GoKind: 22
-      Pointee: 19 BaseType uintptr
-    - __kind: PointerType
-      ID: 55
-      Name: '*int32'
-      ByteSize: 8
-      GoRuntimeType: 28864
-      GoKind: 22
-      Pointee: 45 BaseType int32
-    - __kind: PointerType
-      ID: 56
-      Name: '*uint32'
-      ByteSize: 8
-      GoRuntimeType: 28928
-      GoKind: 22
-      Pointee: 43 BaseType uint32
-    - __kind: BaseType
-      ID: 57
-      Name: complex64
-      ByteSize: 8
-      GoRuntimeType: 42144
-      GoKind: 15
-    - __kind: BaseType
-      ID: 58
-      Name: complex128
-      ByteSize: 16
-      GoRuntimeType: 42208
-      GoKind: 16
-    - __kind: PointerType
-      ID: 59
-      Name: '*float64'
-      ByteSize: 8
-      GoRuntimeType: 29504
-      GoKind: 22
-      Pointee: 53 BaseType float64
-    - __kind: PointerType
-      ID: 60
-      Name: '*int64'
-      ByteSize: 8
-      GoRuntimeType: 28992
-      GoKind: 22
-      Pointee: 47 BaseType int64
-    - __kind: PointerType
-      ID: 61
-      Name: '*uint64'
-      ByteSize: 8
-      GoRuntimeType: 29056
-      GoKind: 22
-      Pointee: 18 BaseType uint64
     - __kind: PointerType
       ID: 62
       Name: '*error'
@@ -940,6 +411,83 @@ Types:
       GoKind: 22
       Pointee: 52 BaseType float32
     - __kind: PointerType
+      ID: 59
+      Name: '*float64'
+      ByteSize: 8
+      GoRuntimeType: 29504
+      GoKind: 22
+      Pointee: 53 BaseType float64
+    - __kind: PointerType
+      ID: 6
+      Name: '*int'
+      ByteSize: 8
+      GoRuntimeType: 29120
+      GoKind: 22
+      Pointee: 1 BaseType int
+    - __kind: PointerType
+      ID: 55
+      Name: '*int32'
+      ByteSize: 8
+      GoRuntimeType: 28864
+      GoKind: 22
+      Pointee: 45 BaseType int32
+    - __kind: PointerType
+      ID: 60
+      Name: '*int64'
+      ByteSize: 8
+      GoRuntimeType: 28992
+      GoKind: 22
+      Pointee: 47 BaseType int64
+    - __kind: PointerType
+      ID: 40
+      Name: '*main.bigStruct'
+      ByteSize: 8
+      GoRuntimeType: 26944
+      GoKind: 22
+      Pointee: 41 StructureType main.bigStruct
+    - __kind: PointerType
+      ID: 16
+      Name: '*map<string,int>'
+      ByteSize: 8
+      Pointee: 17 GoSwissMapHeaderType map<string,int>
+    - __kind: PointerType
+      ID: 30
+      Name: '*map<string,main.bigStruct>'
+      ByteSize: 8
+      Pointee: 31 GoSwissMapHeaderType map<string,main.bigStruct>
+    - __kind: PointerType
+      ID: 25
+      Name: '*noalg.map.group[string]int'
+      ByteSize: 8
+      Pointee: 26 StructureType noalg.map.group[string]int
+    - __kind: PointerType
+      ID: 36
+      Name: '*noalg.map.group[string]main.bigStruct'
+      ByteSize: 8
+      Pointee: 37 StructureType noalg.map.group[string]main.bigStruct
+    - __kind: PointerType
+      ID: 13
+      Name: '*string'
+      ByteSize: 8
+      GoRuntimeType: 28544
+      GoKind: 22
+      Pointee: 7 GoStringHeaderType string
+    - __kind: PointerType
+      ID: 67
+      Name: '*string.str'
+      ByteSize: 8
+      Pointee: 66 GoStringDataType string.str
+    - __kind: PointerType
+      ID: 21
+      Name: '*table<string,int>'
+      ByteSize: 8
+      Pointee: 22 StructureType table<string,int>
+    - __kind: PointerType
+      ID: 33
+      Name: '*table<string,main.bigStruct>'
+      ByteSize: 8
+      Pointee: 34 StructureType table<string,main.bigStruct>
+    - __kind: PointerType
       ID: 64
       Name: '*uint'
       ByteSize: 8
@@ -953,173 +501,62 @@ Types:
       GoRuntimeType: 28800
       GoKind: 22
       Pointee: 23 BaseType uint16
-    - __kind: GoStringDataType
-      ID: 66
-      Name: string.str
-      ByteSize: 2048
     - __kind: PointerType
-      ID: 67
-      Name: '*string.str'
+      ID: 56
+      Name: '*uint32'
       ByteSize: 8
-      Pointee: 66 GoStringDataType string.str
-    - __kind: GoSliceDataType
-      ID: 68
-      Name: '[]int.array'
-      ByteSize: 2048
-      Element: 1 BaseType int
+      GoRuntimeType: 28928
+      GoKind: 22
+      Pointee: 43 BaseType uint32
     - __kind: PointerType
-      ID: 69
-      Name: '*[]int.array'
+      ID: 61
+      Name: '*uint64'
       ByteSize: 8
-      Pointee: 68 GoSliceDataType []int.array
-    - __kind: GoSliceDataType
-      ID: 70
-      Name: '[]string.array'
-      ByteSize: 2048
-      Element: 7 GoStringHeaderType string
+      GoRuntimeType: 29056
+      GoKind: 22
+      Pointee: 18 BaseType uint64
     - __kind: PointerType
-      ID: 71
-      Name: '*[]string.array'
+      ID: 8
+      Name: '*uint8'
       ByteSize: 8
-      Pointee: 70 GoSliceDataType []string.array
-    - __kind: GoSliceDataType
-      ID: 72
-      Name: '[]*table<string,int>.array'
-      ByteSize: 8192
-      Element: 21 PointerType *table<string,int>
-    - __kind: GoSliceDataType
-      ID: 73
-      Name: '[]noalg.map.group[string]int.array'
-      ByteSize: 2048
-      Element: 26 StructureType noalg.map.group[string]int
-    - __kind: GoSliceDataType
-      ID: 74
-      Name: '[]*table<string,main.bigStruct>.array'
-      ByteSize: 8192
-      Element: 33 PointerType *table<string,main.bigStruct>
-    - __kind: GoSliceDataType
-      ID: 75
-      Name: '[]noalg.map.group[string]main.bigStruct.array'
-      ByteSize: 2048
-      Element: 37 StructureType noalg.map.group[string]main.bigStruct
+      GoRuntimeType: 28672
+      GoKind: 22
+      Pointee: 9 BaseType uint8
+    - __kind: PointerType
+      ID: 54
+      Name: '*uintptr'
+      ByteSize: 8
+      GoRuntimeType: 29248
+      GoKind: 22
+      Pointee: 19 BaseType uintptr
     - __kind: EventRootType
-      ID: 76
-      Name: Probe[main.intArg]
+      ID: 86
+      Name: Probe[main.PointerChainArg]
       ByteSize: 9
       PresenceBitsetSize: 1
       Expressions:
-        - Name: x
+        - Name: ptr
           Offset: 1
           Expression:
-            Type: 1 BaseType int
+            Type: 2 PointerType *****int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 4, index: 0, name: x}
+                  Variable: {subprogram: 2, index: 0, name: ptr}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 77
-      Name: Probe[main.stringArg]
-      ByteSize: 17
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: s
-          Offset: 1
-          Expression:
-            Type: 7 GoStringHeaderType string
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 5, index: 0, name: s}
-                  Offset: 0
-                  ByteSize: 16
-    - __kind: EventRootType
-      ID: 78
-      Name: Probe[main.intSliceArg]
-      ByteSize: 25
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: s
-          Offset: 1
-          Expression:
-            Type: 10 GoSliceHeaderType []int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 6, index: 0, name: s}
-                  Offset: 0
-                  ByteSize: 24
-    - __kind: EventRootType
-      ID: 79
-      Name: Probe[main.intArrayArg]
-      ByteSize: 25
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: s
-          Offset: 1
-          Expression:
-            Type: 11 ArrayType [3]int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 7, index: 0, name: s}
-                  Offset: 0
-                  ByteSize: 24
-    - __kind: EventRootType
-      ID: 80
-      Name: Probe[main.stringSliceArg]
-      ByteSize: 25
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: s
-          Offset: 1
-          Expression:
-            Type: 12 GoSliceHeaderType []string
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 8, index: 0, name: s}
-                  Offset: 0
-                  ByteSize: 24
-    - __kind: EventRootType
-      ID: 81
-      Name: Probe[main.stringArrayArg]
-      ByteSize: 49
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: s
-          Offset: 1
-          Expression:
-            Type: 14 ArrayType [3]string
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 9, index: 0, name: s}
-                  Offset: 0
-                  ByteSize: 48
-    - __kind: EventRootType
-      ID: 82
-      Name: Probe[main.stringArrayArgFrameless]
-      ByteSize: 49
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: s
-          Offset: 1
-          Expression:
-            Type: 14 ArrayType [3]string
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 10, index: 0, name: s}
-                  Offset: 0
-                  ByteSize: 48
-    - __kind: EventRootType
-      ID: 83
-      Name: Probe[main.mapArg]
+      ID: 87
+      Name: Probe[main.PointerSmallChainArg]
       ByteSize: 9
       PresenceBitsetSize: 1
       Expressions:
-        - Name: m
+        - Name: ptr
           Offset: 1
           Expression:
-            Type: 15 GoMapType map[string]int
+            Type: 5 PointerType **int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 11, index: 0, name: m}
+                  Variable: {subprogram: 3, index: 0, name: ptr}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
@@ -1153,35 +590,598 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 86
-      Name: Probe[main.PointerChainArg]
+      ID: 76
+      Name: Probe[main.intArg]
       ByteSize: 9
       PresenceBitsetSize: 1
       Expressions:
-        - Name: ptr
+        - Name: x
           Offset: 1
           Expression:
-            Type: 2 PointerType *****int
+            Type: 1 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 2, index: 0, name: ptr}
+                  Variable: {subprogram: 4, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 87
-      Name: Probe[main.PointerSmallChainArg]
+      ID: 79
+      Name: Probe[main.intArrayArg]
+      ByteSize: 25
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: s
+          Offset: 1
+          Expression:
+            Type: 11 ArrayType [3]int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 7, index: 0, name: s}
+                  Offset: 0
+                  ByteSize: 24
+    - __kind: EventRootType
+      ID: 78
+      Name: Probe[main.intSliceArg]
+      ByteSize: 25
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: s
+          Offset: 1
+          Expression:
+            Type: 10 GoSliceHeaderType []int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 6, index: 0, name: s}
+                  Offset: 0
+                  ByteSize: 24
+    - __kind: EventRootType
+      ID: 83
+      Name: Probe[main.mapArg]
       ByteSize: 9
       PresenceBitsetSize: 1
       Expressions:
-        - Name: ptr
+        - Name: m
           Offset: 1
           Expression:
-            Type: 5 PointerType **int
+            Type: 15 GoMapType map[string]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 3, index: 0, name: ptr}
+                  Variable: {subprogram: 11, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
+    - __kind: EventRootType
+      ID: 77
+      Name: Probe[main.stringArg]
+      ByteSize: 17
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: s
+          Offset: 1
+          Expression:
+            Type: 7 GoStringHeaderType string
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 5, index: 0, name: s}
+                  Offset: 0
+                  ByteSize: 16
+    - __kind: EventRootType
+      ID: 82
+      Name: Probe[main.stringArrayArgFrameless]
+      ByteSize: 49
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: s
+          Offset: 1
+          Expression:
+            Type: 14 ArrayType [3]string
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 10, index: 0, name: s}
+                  Offset: 0
+                  ByteSize: 48
+    - __kind: EventRootType
+      ID: 81
+      Name: Probe[main.stringArrayArg]
+      ByteSize: 49
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: s
+          Offset: 1
+          Expression:
+            Type: 14 ArrayType [3]string
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 9, index: 0, name: s}
+                  Offset: 0
+                  ByteSize: 48
+    - __kind: EventRootType
+      ID: 80
+      Name: Probe[main.stringSliceArg]
+      ByteSize: 25
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: s
+          Offset: 1
+          Expression:
+            Type: 12 GoSliceHeaderType []string
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 8, index: 0, name: s}
+                  Offset: 0
+                  ByteSize: 24
+    - __kind: ArrayType
+      ID: 42
+      Name: '[128]uint8'
+      ByteSize: 128
+      GoRuntimeType: 46240
+      GoKind: 17
+      Count: 128
+      HasCount: true
+      Element: 9 BaseType uint8
+    - __kind: ArrayType
+      ID: 11
+      Name: '[3]int'
+      ByteSize: 24
+      GoRuntimeType: 45952
+      GoKind: 17
+      Count: 3
+      HasCount: true
+      Element: 1 BaseType int
+    - __kind: ArrayType
+      ID: 14
+      Name: '[3]string'
+      ByteSize: 48
+      GoRuntimeType: 46048
+      GoKind: 17
+      Count: 3
+      HasCount: true
+      Element: 7 GoStringHeaderType string
+    - __kind: GoSliceDataType
+      ID: 72
+      Name: '[]*table<string,int>.array'
+      ByteSize: 8192
+      Element: 21 PointerType *table<string,int>
+    - __kind: GoSliceDataType
+      ID: 74
+      Name: '[]*table<string,main.bigStruct>.array'
+      ByteSize: 8192
+      Element: 33 PointerType *table<string,main.bigStruct>
+    - __kind: GoSliceHeaderType
+      ID: 10
+      Name: '[]int'
+      ByteSize: 24
+      GoRuntimeType: 37696
+      GoKind: 23
+      RawFields:
+        - Name: array
+          Offset: 0
+          Type: 6 PointerType *int
+        - Name: len
+          Offset: 8
+          Type: 1 BaseType int
+        - Name: cap
+          Offset: 16
+          Type: 1 BaseType int
+      Data: 68 GoSliceDataType []int.array
+    - __kind: GoSliceDataType
+      ID: 68
+      Name: '[]int.array'
+      ByteSize: 2048
+      Element: 1 BaseType int
+    - __kind: GoSliceDataType
+      ID: 73
+      Name: '[]noalg.map.group[string]int.array'
+      ByteSize: 2048
+      Element: 26 StructureType noalg.map.group[string]int
+    - __kind: GoSliceDataType
+      ID: 75
+      Name: '[]noalg.map.group[string]main.bigStruct.array'
+      ByteSize: 2048
+      Element: 37 StructureType noalg.map.group[string]main.bigStruct
+    - __kind: GoSliceHeaderType
+      ID: 12
+      Name: '[]string'
+      ByteSize: 24
+      GoRuntimeType: 37952
+      GoKind: 23
+      RawFields:
+        - Name: array
+          Offset: 0
+          Type: 13 PointerType *string
+        - Name: len
+          Offset: 8
+          Type: 1 BaseType int
+        - Name: cap
+          Offset: 16
+          Type: 1 BaseType int
+      Data: 70 GoSliceDataType []string.array
+    - __kind: GoSliceDataType
+      ID: 70
+      Name: '[]string.array'
+      ByteSize: 2048
+      Element: 7 GoStringHeaderType string
+    - __kind: BaseType
+      ID: 44
+      Name: bool
+      ByteSize: 1
+      GoRuntimeType: 42400
+      GoKind: 1
+    - __kind: BaseType
+      ID: 58
+      Name: complex128
+      ByteSize: 16
+      GoRuntimeType: 42208
+      GoKind: 16
+    - __kind: BaseType
+      ID: 57
+      Name: complex64
+      ByteSize: 8
+      GoRuntimeType: 42144
+      GoKind: 15
+    - __kind: GoInterfaceType
+      ID: 48
+      Name: error
+      ByteSize: 16
+      GoRuntimeType: 63168
+      GoKind: 20
+      RawFields:
+        - Name: tab
+          Offset: 0
+          Type: 49 VoidPointerType unsafe.Pointer
+        - Name: data
+          Offset: 8
+          Type: 49 VoidPointerType unsafe.Pointer
+    - __kind: BaseType
+      ID: 52
+      Name: float32
+      ByteSize: 4
+      GoRuntimeType: 42272
+      GoKind: 13
+    - __kind: BaseType
+      ID: 53
+      Name: float64
+      ByteSize: 8
+      GoRuntimeType: 42336
+      GoKind: 14
+    - __kind: GoSwissMapGroupsType
+      ID: 24
+      Name: groupReference<string,int>
+      ByteSize: 16
+      GoKind: 25
+      RawFields:
+        - Name: data
+          Offset: 0
+          Type: 25 PointerType *noalg.map.group[string]int
+        - Name: lengthMask
+          Offset: 8
+          Type: 18 BaseType uint64
+      GroupType: 26 StructureType noalg.map.group[string]int
+      GroupSliceType: 73 GoSliceDataType []noalg.map.group[string]int.array
+    - __kind: GoSwissMapGroupsType
+      ID: 35
+      Name: groupReference<string,main.bigStruct>
+      ByteSize: 16
+      GoKind: 25
+      RawFields:
+        - Name: data
+          Offset: 0
+          Type: 36 PointerType *noalg.map.group[string]main.bigStruct
+        - Name: lengthMask
+          Offset: 8
+          Type: 18 BaseType uint64
+      GroupType: 37 StructureType noalg.map.group[string]main.bigStruct
+      GroupSliceType: 75 GoSliceDataType []noalg.map.group[string]main.bigStruct.array
+    - __kind: BaseType
+      ID: 1
+      Name: int
+      ByteSize: 8
+      GoRuntimeType: 41952
+      GoKind: 2
+    - __kind: BaseType
+      ID: 45
+      Name: int32
+      ByteSize: 4
+      GoRuntimeType: 41696
+      GoKind: 5
+    - __kind: BaseType
+      ID: 47
+      Name: int64
+      ByteSize: 8
+      GoRuntimeType: 41824
+      GoKind: 6
+    - __kind: BaseType
+      ID: 50
+      Name: int8
+      ByteSize: 1
+      GoRuntimeType: 41440
+      GoKind: 3
+    - __kind: StructureType
+      ID: 41
+      Name: main.bigStruct
+      ByteSize: 184
+      GoRuntimeType: 119744
+      GoKind: 25
+      RawFields:
+        - Name: Field1
+          Offset: 0
+          Type: 1 BaseType int
+        - Name: Field2
+          Offset: 8
+          Type: 1 BaseType int
+        - Name: Field3
+          Offset: 16
+          Type: 1 BaseType int
+        - Name: Field4
+          Offset: 24
+          Type: 1 BaseType int
+        - Name: Field5
+          Offset: 32
+          Type: 1 BaseType int
+        - Name: Field6
+          Offset: 40
+          Type: 1 BaseType int
+        - Name: Field7
+          Offset: 48
+          Type: 1 BaseType int
+        - Name: data
+          Offset: 56
+          Type: 42 ArrayType [128]uint8
+    - __kind: GoSwissMapHeaderType
+      ID: 17
+      Name: map<string,int>
+      ByteSize: 48
+      GoKind: 25
+      RawFields:
+        - Name: used
+          Offset: 0
+          Type: 18 BaseType uint64
+        - Name: seed
+          Offset: 8
+          Type: 19 BaseType uintptr
+        - Name: dirPtr
+          Offset: 16
+          Type: 20 PointerType **table<string,int>
+        - Name: dirLen
+          Offset: 24
+          Type: 1 BaseType int
+        - Name: globalDepth
+          Offset: 32
+          Type: 9 BaseType uint8
+        - Name: globalShift
+          Offset: 33
+          Type: 9 BaseType uint8
+        - Name: writing
+          Offset: 34
+          Type: 9 BaseType uint8
+        - Name: clearSeq
+          Offset: 40
+          Type: 18 BaseType uint64
+      TablePtrSliceType: 72 GoSliceDataType []*table<string,int>.array
+      GroupType: 26 StructureType noalg.map.group[string]int
+    - __kind: GoSwissMapHeaderType
+      ID: 31
+      Name: map<string,main.bigStruct>
+      ByteSize: 48
+      GoKind: 25
+      RawFields:
+        - Name: used
+          Offset: 0
+          Type: 18 BaseType uint64
+        - Name: seed
+          Offset: 8
+          Type: 19 BaseType uintptr
+        - Name: dirPtr
+          Offset: 16
+          Type: 32 PointerType **table<string,main.bigStruct>
+        - Name: dirLen
+          Offset: 24
+          Type: 1 BaseType int
+        - Name: globalDepth
+          Offset: 32
+          Type: 9 BaseType uint8
+        - Name: globalShift
+          Offset: 33
+          Type: 9 BaseType uint8
+        - Name: writing
+          Offset: 34
+          Type: 9 BaseType uint8
+        - Name: clearSeq
+          Offset: 40
+          Type: 18 BaseType uint64
+      TablePtrSliceType: 74 GoSliceDataType []*table<string,main.bigStruct>.array
+      GroupType: 37 StructureType noalg.map.group[string]main.bigStruct
+    - __kind: GoMapType
+      ID: 15
+      Name: map[string]int
+      ByteSize: 8
+      GoRuntimeType: 67264
+      GoKind: 21
+      HeaderType: 17 GoSwissMapHeaderType map<string,int>
+    - __kind: GoMapType
+      ID: 29
+      Name: map[string]main.bigStruct
+      ByteSize: 8
+      GoRuntimeType: 67392
+      GoKind: 21
+      HeaderType: 31 GoSwissMapHeaderType map<string,main.bigStruct>
+    - __kind: ArrayType
+      ID: 38
+      Name: noalg.[8]struct { key string; elem *main.bigStruct }
+      ByteSize: 192
+      GoRuntimeType: 46336
+      GoKind: 17
+      Count: 8
+      HasCount: true
+      Element: 39 StructureType noalg.struct { key string; elem *main.bigStruct }
+    - __kind: ArrayType
+      ID: 27
+      Name: noalg.[8]struct { key string; elem int }
+      ByteSize: 192
+      GoRuntimeType: 46144
+      GoKind: 17
+      Count: 8
+      HasCount: true
+      Element: 28 StructureType noalg.struct { key string; elem int }
+    - __kind: StructureType
+      ID: 26
+      Name: noalg.map.group[string]int
+      ByteSize: 200
+      GoRuntimeType: 74656
+      GoKind: 25
+      RawFields:
+        - Name: ctrl
+          Offset: 0
+          Type: 18 BaseType uint64
+        - Name: slots
+          Offset: 8
+          Type: 27 ArrayType noalg.[8]struct { key string; elem int }
+    - __kind: StructureType
+      ID: 37
+      Name: noalg.map.group[string]main.bigStruct
+      ByteSize: 200
+      GoRuntimeType: 74912
+      GoKind: 25
+      RawFields:
+        - Name: ctrl
+          Offset: 0
+          Type: 18 BaseType uint64
+        - Name: slots
+          Offset: 8
+          Type: 38 ArrayType noalg.[8]struct { key string; elem *main.bigStruct }
+    - __kind: StructureType
+      ID: 39
+      Name: noalg.struct { key string; elem *main.bigStruct }
+      ByteSize: 24
+      GoRuntimeType: 74784
+      GoKind: 25
+      RawFields:
+        - Name: key
+          Offset: 0
+          Type: 7 GoStringHeaderType string
+        - Name: elem
+          Offset: 16
+          Type: 40 PointerType *main.bigStruct
+    - __kind: StructureType
+      ID: 28
+      Name: noalg.struct { key string; elem int }
+      ByteSize: 24
+      GoRuntimeType: 74528
+      GoKind: 25
+      RawFields:
+        - Name: key
+          Offset: 0
+          Type: 7 GoStringHeaderType string
+        - Name: elem
+          Offset: 16
+          Type: 1 BaseType int
+    - __kind: GoStringHeaderType
+      ID: 7
+      Name: string
+      ByteSize: 16
+      GoRuntimeType: 41376
+      GoKind: 24
+      RawFields:
+        - Name: str
+          Offset: 0
+          Type: 67 PointerType *string.str
+        - Name: len
+          Offset: 8
+          Type: 1 BaseType int
+      Data: 66 GoStringDataType string.str
+    - __kind: GoStringDataType
+      ID: 66
+      Name: string.str
+      ByteSize: 2048
+    - __kind: StructureType
+      ID: 22
+      Name: table<string,int>
+      ByteSize: 32
+      GoKind: 25
+      RawFields:
+        - Name: used
+          Offset: 0
+          Type: 23 BaseType uint16
+        - Name: capacity
+          Offset: 2
+          Type: 23 BaseType uint16
+        - Name: growthLeft
+          Offset: 4
+          Type: 23 BaseType uint16
+        - Name: localDepth
+          Offset: 6
+          Type: 9 BaseType uint8
+        - Name: index
+          Offset: 8
+          Type: 1 BaseType int
+        - Name: groups
+          Offset: 16
+          Type: 24 GoSwissMapGroupsType groupReference<string,int>
+    - __kind: StructureType
+      ID: 34
+      Name: table<string,main.bigStruct>
+      ByteSize: 32
+      GoKind: 25
+      RawFields:
+        - Name: used
+          Offset: 0
+          Type: 23 BaseType uint16
+        - Name: capacity
+          Offset: 2
+          Type: 23 BaseType uint16
+        - Name: growthLeft
+          Offset: 4
+          Type: 23 BaseType uint16
+        - Name: localDepth
+          Offset: 6
+          Type: 9 BaseType uint8
+        - Name: index
+          Offset: 8
+          Type: 1 BaseType int
+        - Name: groups
+          Offset: 16
+          Type: 35 GoSwissMapGroupsType groupReference<string,main.bigStruct>
+    - __kind: BaseType
+      ID: 51
+      Name: uint
+      ByteSize: 8
+      GoRuntimeType: 42016
+      GoKind: 7
+    - __kind: BaseType
+      ID: 23
+      Name: uint16
+      ByteSize: 2
+      GoRuntimeType: 41632
+      GoKind: 9
+    - __kind: BaseType
+      ID: 43
+      Name: uint32
+      ByteSize: 4
+      GoRuntimeType: 41760
+      GoKind: 10
+    - __kind: BaseType
+      ID: 18
+      Name: uint64
+      ByteSize: 8
+      GoRuntimeType: 41888
+      GoKind: 11
+    - __kind: BaseType
+      ID: 9
+      Name: uint8
+      ByteSize: 1
+      GoRuntimeType: 41504
+      GoKind: 8
+    - __kind: BaseType
+      ID: 19
+      Name: uintptr
+      ByteSize: 8
+      GoRuntimeType: 42080
+      GoKind: 12
+    - __kind: VoidPointerType
+      ID: 49
+      Name: unsafe.Pointer
+      ByteSize: 8
+      GoRuntimeType: 42464
+      GoKind: 26
 MaxTypeID: 87
 Issues: []
 GoModuledataInfo: {FirstModuledataAddr: "0x57e340", TypesOffset: 296}

--- a/pkg/dyninst/irgen/testdata/snapshot/simple.arch=amd64,toolchain=go1.24.3.yaml
+++ b/pkg/dyninst/irgen/testdata/snapshot/simple.arch=amd64,toolchain=go1.24.3.yaml
@@ -288,7 +288,7 @@ Subprograms:
       InlinePCRanges: []
       Variables:
         - Name: m
-          Type: 48 GoMapType map[string]main.bigStruct
+          Type: 42 GoMapType map[string]main.bigStruct
           Locations:
             - Range: 0x4a84e0..0x4a8513
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
@@ -320,7 +320,7 @@ Subprograms:
           RootRanges: [0x4a7c40..0x4a809d]
       Variables:
         - Name: ptr
-          Type: 62 PointerType *****int
+          Type: 47 PointerType *****int
           Locations:
             - Range: 0x4a7fdf..0x4a802b
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
@@ -334,7 +334,7 @@ Subprograms:
           RootRanges: [0x4a7c40..0x4a809d]
       Variables:
         - Name: ptr
-          Type: 65 PointerType **int
+          Type: 49 PointerType **int
           Locations:
             - Range: 0x4a8050..0x4a808a
               Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
@@ -342,28 +342,28 @@ Subprograms:
           IsReturn: false
 Types:
     - __kind: PointerType
-      ID: 62
+      ID: 47
       Name: '*****int'
       ByteSize: 8
       GoRuntimeType: 35264
       GoKind: 22
-      Pointee: 63 PointerType ****int
+      Pointee: 48 PointerType ****int
     - __kind: PointerType
-      ID: 63
+      ID: 48
       Name: '****int'
       ByteSize: 8
       GoRuntimeType: 35200
       GoKind: 22
-      Pointee: 64 PointerType ***int
+      Pointee: 52 PointerType ***int
     - __kind: PointerType
-      ID: 64
+      ID: 52
       Name: '***int'
       ByteSize: 8
       GoRuntimeType: 35136
       GoKind: 22
-      Pointee: 65 PointerType **int
+      Pointee: 49 PointerType **int
     - __kind: PointerType
-      ID: 65
+      ID: 49
       Name: '**int'
       ByteSize: 8
       GoRuntimeType: 35072
@@ -375,10 +375,10 @@ Types:
       ByteSize: 8
       Pointee: 41 PointerType *table<string,int>
     - __kind: PointerType
-      ID: 51
+      ID: 45
       Name: '**table<string,main.bigStruct>'
       ByteSize: 8
-      Pointee: 52 PointerType *table<string,main.bigStruct>
+      Pointee: 46 PointerType *table<string,main.bigStruct>
     - __kind: PointerType
       ID: 69
       Name: '*[]int.array'
@@ -439,32 +439,32 @@ Types:
       GoKind: 22
       Pointee: 12 BaseType int64
     - __kind: PointerType
-      ID: 59
+      ID: 63
       Name: '*main.bigStruct'
       ByteSize: 8
       GoRuntimeType: 26944
       GoKind: 22
-      Pointee: 60 StructureType main.bigStruct
+      Pointee: 64 StructureType main.bigStruct
     - __kind: PointerType
       ID: 38
       Name: '*map<string,int>'
       ByteSize: 8
       Pointee: 39 GoSwissMapHeaderType map<string,int>
     - __kind: PointerType
-      ID: 49
+      ID: 43
       Name: '*map<string,main.bigStruct>'
       ByteSize: 8
-      Pointee: 50 GoSwissMapHeaderType map<string,main.bigStruct>
+      Pointee: 44 GoSwissMapHeaderType map<string,main.bigStruct>
     - __kind: PointerType
-      ID: 44
+      ID: 54
       Name: '*noalg.map.group[string]int'
       ByteSize: 8
-      Pointee: 45 StructureType noalg.map.group[string]int
+      Pointee: 55 StructureType noalg.map.group[string]int
     - __kind: PointerType
-      ID: 55
+      ID: 57
       Name: '*noalg.map.group[string]main.bigStruct'
       ByteSize: 8
-      Pointee: 56 StructureType noalg.map.group[string]main.bigStruct
+      Pointee: 58 StructureType noalg.map.group[string]main.bigStruct
     - __kind: PointerType
       ID: 22
       Name: '*string'
@@ -481,12 +481,12 @@ Types:
       ID: 41
       Name: '*table<string,int>'
       ByteSize: 8
-      Pointee: 42 StructureType table<string,int>
+      Pointee: 50 StructureType table<string,int>
     - __kind: PointerType
-      ID: 52
+      ID: 46
       Name: '*table<string,main.bigStruct>'
       ByteSize: 8
-      Pointee: 53 StructureType table<string,main.bigStruct>
+      Pointee: 51 StructureType table<string,main.bigStruct>
     - __kind: PointerType
       ID: 31
       Name: '*uint'
@@ -538,7 +538,7 @@ Types:
         - Name: ptr
           Offset: 1
           Expression:
-            Type: 62 PointerType *****int
+            Type: 47 PointerType *****int
             Operations:
                 - __kind: LocationOp
                   Variable: {subprogram: 11, index: 0, name: ptr}
@@ -553,7 +553,7 @@ Types:
         - Name: ptr
           Offset: 1
           Expression:
-            Type: 65 PointerType **int
+            Type: 49 PointerType **int
             Operations:
                 - __kind: LocationOp
                   Variable: {subprogram: 12, index: 0, name: ptr}
@@ -568,7 +568,7 @@ Types:
         - Name: m
           Offset: 1
           Expression:
-            Type: 48 GoMapType map[string]main.bigStruct
+            Type: 42 GoMapType map[string]main.bigStruct
             Operations:
                 - __kind: LocationOp
                   Variable: {subprogram: 9, index: 0, name: m}
@@ -710,7 +710,7 @@ Types:
                   Offset: 0
                   ByteSize: 24
     - __kind: ArrayType
-      ID: 61
+      ID: 65
       Name: '[128]uint8'
       ByteSize: 128
       GoRuntimeType: 46240
@@ -745,7 +745,7 @@ Types:
       ID: 74
       Name: '[]*table<string,main.bigStruct>.array'
       ByteSize: 8192
-      Element: 52 PointerType *table<string,main.bigStruct>
+      Element: 46 PointerType *table<string,main.bigStruct>
     - __kind: GoSliceHeaderType
       ID: 33
       Name: '[]int'
@@ -772,12 +772,12 @@ Types:
       ID: 73
       Name: '[]noalg.map.group[string]int.array'
       ByteSize: 2048
-      Element: 45 StructureType noalg.map.group[string]int
+      Element: 55 StructureType noalg.map.group[string]int
     - __kind: GoSliceDataType
       ID: 75
       Name: '[]noalg.map.group[string]main.bigStruct.array'
       ByteSize: 2048
-      Element: 56 StructureType noalg.map.group[string]main.bigStruct
+      Element: 58 StructureType noalg.map.group[string]main.bigStruct
     - __kind: GoSliceHeaderType
       ID: 35
       Name: '[]string'
@@ -844,32 +844,32 @@ Types:
       GoRuntimeType: 42336
       GoKind: 14
     - __kind: GoSwissMapGroupsType
-      ID: 43
+      ID: 53
       Name: groupReference<string,int>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 44 PointerType *noalg.map.group[string]int
+          Type: 54 PointerType *noalg.map.group[string]int
         - Name: lengthMask
           Offset: 8
           Type: 8 BaseType uint64
-      GroupType: 45 StructureType noalg.map.group[string]int
+      GroupType: 55 StructureType noalg.map.group[string]int
       GroupSliceType: 73 GoSliceDataType []noalg.map.group[string]int.array
     - __kind: GoSwissMapGroupsType
-      ID: 54
+      ID: 56
       Name: groupReference<string,main.bigStruct>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 55 PointerType *noalg.map.group[string]main.bigStruct
+          Type: 57 PointerType *noalg.map.group[string]main.bigStruct
         - Name: lengthMask
           Offset: 8
           Type: 8 BaseType uint64
-      GroupType: 56 StructureType noalg.map.group[string]main.bigStruct
+      GroupType: 58 StructureType noalg.map.group[string]main.bigStruct
       GroupSliceType: 75 GoSliceDataType []noalg.map.group[string]main.bigStruct.array
     - __kind: BaseType
       ID: 7
@@ -896,7 +896,7 @@ Types:
       GoRuntimeType: 41440
       GoKind: 3
     - __kind: StructureType
-      ID: 60
+      ID: 64
       Name: main.bigStruct
       ByteSize: 184
       GoRuntimeType: 119744
@@ -925,7 +925,7 @@ Types:
           Type: 7 BaseType int
         - Name: data
           Offset: 56
-          Type: 61 ArrayType [128]uint8
+          Type: 65 ArrayType [128]uint8
     - __kind: GoSwissMapHeaderType
       ID: 39
       Name: map<string,int>
@@ -957,9 +957,9 @@ Types:
           Offset: 40
           Type: 8 BaseType uint64
       TablePtrSliceType: 72 GoSliceDataType []*table<string,int>.array
-      GroupType: 45 StructureType noalg.map.group[string]int
+      GroupType: 55 StructureType noalg.map.group[string]int
     - __kind: GoSwissMapHeaderType
-      ID: 50
+      ID: 44
       Name: map<string,main.bigStruct>
       ByteSize: 48
       GoKind: 25
@@ -972,7 +972,7 @@ Types:
           Type: 1 BaseType uintptr
         - Name: dirPtr
           Offset: 16
-          Type: 51 PointerType **table<string,main.bigStruct>
+          Type: 45 PointerType **table<string,main.bigStruct>
         - Name: dirLen
           Offset: 24
           Type: 7 BaseType int
@@ -989,7 +989,7 @@ Types:
           Offset: 40
           Type: 8 BaseType uint64
       TablePtrSliceType: 74 GoSliceDataType []*table<string,main.bigStruct>.array
-      GroupType: 56 StructureType noalg.map.group[string]main.bigStruct
+      GroupType: 58 StructureType noalg.map.group[string]main.bigStruct
     - __kind: GoMapType
       ID: 37
       Name: map[string]int
@@ -998,32 +998,32 @@ Types:
       GoKind: 21
       HeaderType: 39 GoSwissMapHeaderType map<string,int>
     - __kind: GoMapType
-      ID: 48
+      ID: 42
       Name: map[string]main.bigStruct
       ByteSize: 8
       GoRuntimeType: 67392
       GoKind: 21
-      HeaderType: 50 GoSwissMapHeaderType map<string,main.bigStruct>
+      HeaderType: 44 GoSwissMapHeaderType map<string,main.bigStruct>
     - __kind: ArrayType
-      ID: 57
+      ID: 61
       Name: noalg.[8]struct { key string; elem *main.bigStruct }
       ByteSize: 192
       GoRuntimeType: 46336
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 58 StructureType noalg.struct { key string; elem *main.bigStruct }
+      Element: 62 StructureType noalg.struct { key string; elem *main.bigStruct }
     - __kind: ArrayType
-      ID: 46
+      ID: 59
       Name: noalg.[8]struct { key string; elem int }
       ByteSize: 192
       GoRuntimeType: 46144
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 47 StructureType noalg.struct { key string; elem int }
+      Element: 60 StructureType noalg.struct { key string; elem int }
     - __kind: StructureType
-      ID: 45
+      ID: 55
       Name: noalg.map.group[string]int
       ByteSize: 200
       GoRuntimeType: 74656
@@ -1034,9 +1034,9 @@ Types:
           Type: 8 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 46 ArrayType noalg.[8]struct { key string; elem int }
+          Type: 59 ArrayType noalg.[8]struct { key string; elem int }
     - __kind: StructureType
-      ID: 56
+      ID: 58
       Name: noalg.map.group[string]main.bigStruct
       ByteSize: 200
       GoRuntimeType: 74912
@@ -1047,9 +1047,9 @@ Types:
           Type: 8 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 57 ArrayType noalg.[8]struct { key string; elem *main.bigStruct }
+          Type: 61 ArrayType noalg.[8]struct { key string; elem *main.bigStruct }
     - __kind: StructureType
-      ID: 58
+      ID: 62
       Name: noalg.struct { key string; elem *main.bigStruct }
       ByteSize: 24
       GoRuntimeType: 74784
@@ -1060,9 +1060,9 @@ Types:
           Type: 9 GoStringHeaderType string
         - Name: elem
           Offset: 16
-          Type: 59 PointerType *main.bigStruct
+          Type: 63 PointerType *main.bigStruct
     - __kind: StructureType
-      ID: 47
+      ID: 60
       Name: noalg.struct { key string; elem int }
       ByteSize: 24
       GoRuntimeType: 74528
@@ -1093,7 +1093,7 @@ Types:
       Name: string.str
       ByteSize: 2048
     - __kind: StructureType
-      ID: 42
+      ID: 50
       Name: table<string,int>
       ByteSize: 32
       GoKind: 25
@@ -1115,9 +1115,9 @@ Types:
           Type: 7 BaseType int
         - Name: groups
           Offset: 16
-          Type: 43 GoSwissMapGroupsType groupReference<string,int>
+          Type: 53 GoSwissMapGroupsType groupReference<string,int>
     - __kind: StructureType
-      ID: 53
+      ID: 51
       Name: table<string,main.bigStruct>
       ByteSize: 32
       GoKind: 25
@@ -1139,7 +1139,7 @@ Types:
           Type: 7 BaseType int
         - Name: groups
           Offset: 16
-          Type: 54 GoSwissMapGroupsType groupReference<string,main.bigStruct>
+          Type: 56 GoSwissMapGroupsType groupReference<string,main.bigStruct>
     - __kind: BaseType
       ID: 16
       Name: uint

--- a/pkg/dyninst/irgen/testdata/snapshot/simple.arch=amd64,toolchain=go1.25.0.yaml
+++ b/pkg/dyninst/irgen/testdata/snapshot/simple.arch=amd64,toolchain=go1.25.0.yaml
@@ -288,7 +288,7 @@ Subprograms:
       InlinePCRanges: []
       Variables:
         - Name: m
-          Type: 48 GoMapType map[string]main.bigStruct
+          Type: 42 GoMapType map[string]main.bigStruct
           Locations:
             - Range: 0x4aeae0..0x4aeb13
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
@@ -320,7 +320,7 @@ Subprograms:
           RootRanges: [0x4ae240..0x4ae69d]
       Variables:
         - Name: ptr
-          Type: 62 PointerType *****int
+          Type: 47 PointerType *****int
           Locations:
             - Range: 0x4ae5df..0x4ae62b
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
@@ -334,7 +334,7 @@ Subprograms:
           RootRanges: [0x4ae240..0x4ae69d]
       Variables:
         - Name: ptr
-          Type: 65 PointerType **int
+          Type: 49 PointerType **int
           Locations:
             - Range: 0x4ae650..0x4ae68a
               Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
@@ -342,28 +342,28 @@ Subprograms:
           IsReturn: false
 Types:
     - __kind: PointerType
-      ID: 62
+      ID: 47
       Name: '*****int'
       ByteSize: 8
       GoRuntimeType: 36320
       GoKind: 22
-      Pointee: 63 PointerType ****int
+      Pointee: 48 PointerType ****int
     - __kind: PointerType
-      ID: 63
+      ID: 48
       Name: '****int'
       ByteSize: 8
       GoRuntimeType: 36256
       GoKind: 22
-      Pointee: 64 PointerType ***int
+      Pointee: 52 PointerType ***int
     - __kind: PointerType
-      ID: 64
+      ID: 52
       Name: '***int'
       ByteSize: 8
       GoRuntimeType: 36192
       GoKind: 22
-      Pointee: 65 PointerType **int
+      Pointee: 49 PointerType **int
     - __kind: PointerType
-      ID: 65
+      ID: 49
       Name: '**int'
       ByteSize: 8
       GoRuntimeType: 36128
@@ -375,10 +375,10 @@ Types:
       ByteSize: 8
       Pointee: 41 PointerType *table<string,int>
     - __kind: PointerType
-      ID: 51
+      ID: 45
       Name: '**table<string,main.bigStruct>'
       ByteSize: 8
-      Pointee: 52 PointerType *table<string,main.bigStruct>
+      Pointee: 46 PointerType *table<string,main.bigStruct>
     - __kind: PointerType
       ID: 69
       Name: '*[]int.array'
@@ -439,32 +439,32 @@ Types:
       GoKind: 22
       Pointee: 12 BaseType int64
     - __kind: PointerType
-      ID: 59
+      ID: 63
       Name: '*main.bigStruct'
       ByteSize: 8
       GoRuntimeType: 27808
       GoKind: 22
-      Pointee: 60 StructureType main.bigStruct
+      Pointee: 64 StructureType main.bigStruct
     - __kind: PointerType
       ID: 38
       Name: '*map<string,int>'
       ByteSize: 8
       Pointee: 39 GoSwissMapHeaderType map<string,int>
     - __kind: PointerType
-      ID: 49
+      ID: 43
       Name: '*map<string,main.bigStruct>'
       ByteSize: 8
-      Pointee: 50 GoSwissMapHeaderType map<string,main.bigStruct>
+      Pointee: 44 GoSwissMapHeaderType map<string,main.bigStruct>
     - __kind: PointerType
-      ID: 44
+      ID: 54
       Name: '*noalg.map.group[string]int'
       ByteSize: 8
-      Pointee: 45 StructureType noalg.map.group[string]int
+      Pointee: 55 StructureType noalg.map.group[string]int
     - __kind: PointerType
-      ID: 55
+      ID: 57
       Name: '*noalg.map.group[string]main.bigStruct'
       ByteSize: 8
-      Pointee: 56 StructureType noalg.map.group[string]main.bigStruct
+      Pointee: 58 StructureType noalg.map.group[string]main.bigStruct
     - __kind: PointerType
       ID: 22
       Name: '*string'
@@ -481,12 +481,12 @@ Types:
       ID: 41
       Name: '*table<string,int>'
       ByteSize: 8
-      Pointee: 42 StructureType table<string,int>
+      Pointee: 50 StructureType table<string,int>
     - __kind: PointerType
-      ID: 52
+      ID: 46
       Name: '*table<string,main.bigStruct>'
       ByteSize: 8
-      Pointee: 53 StructureType table<string,main.bigStruct>
+      Pointee: 51 StructureType table<string,main.bigStruct>
     - __kind: PointerType
       ID: 31
       Name: '*uint'
@@ -538,7 +538,7 @@ Types:
         - Name: ptr
           Offset: 1
           Expression:
-            Type: 62 PointerType *****int
+            Type: 47 PointerType *****int
             Operations:
                 - __kind: LocationOp
                   Variable: {subprogram: 11, index: 0, name: ptr}
@@ -553,7 +553,7 @@ Types:
         - Name: ptr
           Offset: 1
           Expression:
-            Type: 65 PointerType **int
+            Type: 49 PointerType **int
             Operations:
                 - __kind: LocationOp
                   Variable: {subprogram: 12, index: 0, name: ptr}
@@ -568,7 +568,7 @@ Types:
         - Name: m
           Offset: 1
           Expression:
-            Type: 48 GoMapType map[string]main.bigStruct
+            Type: 42 GoMapType map[string]main.bigStruct
             Operations:
                 - __kind: LocationOp
                   Variable: {subprogram: 9, index: 0, name: m}
@@ -710,7 +710,7 @@ Types:
                   Offset: 0
                   ByteSize: 24
     - __kind: ArrayType
-      ID: 61
+      ID: 65
       Name: '[128]uint8'
       ByteSize: 128
       GoRuntimeType: 47680
@@ -745,7 +745,7 @@ Types:
       ID: 74
       Name: '[]*table<string,main.bigStruct>.array'
       ByteSize: 8192
-      Element: 52 PointerType *table<string,main.bigStruct>
+      Element: 46 PointerType *table<string,main.bigStruct>
     - __kind: GoSliceHeaderType
       ID: 33
       Name: '[]int'
@@ -772,12 +772,12 @@ Types:
       ID: 73
       Name: '[]noalg.map.group[string]int.array'
       ByteSize: 2048
-      Element: 45 StructureType noalg.map.group[string]int
+      Element: 55 StructureType noalg.map.group[string]int
     - __kind: GoSliceDataType
       ID: 75
       Name: '[]noalg.map.group[string]main.bigStruct.array'
       ByteSize: 2048
-      Element: 56 StructureType noalg.map.group[string]main.bigStruct
+      Element: 58 StructureType noalg.map.group[string]main.bigStruct
     - __kind: GoSliceHeaderType
       ID: 35
       Name: '[]string'
@@ -844,32 +844,32 @@ Types:
       GoRuntimeType: 43712
       GoKind: 14
     - __kind: GoSwissMapGroupsType
-      ID: 43
+      ID: 53
       Name: groupReference<string,int>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 44 PointerType *noalg.map.group[string]int
+          Type: 54 PointerType *noalg.map.group[string]int
         - Name: lengthMask
           Offset: 8
           Type: 8 BaseType uint64
-      GroupType: 45 StructureType noalg.map.group[string]int
+      GroupType: 55 StructureType noalg.map.group[string]int
       GroupSliceType: 73 GoSliceDataType []noalg.map.group[string]int.array
     - __kind: GoSwissMapGroupsType
-      ID: 54
+      ID: 56
       Name: groupReference<string,main.bigStruct>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 55 PointerType *noalg.map.group[string]main.bigStruct
+          Type: 57 PointerType *noalg.map.group[string]main.bigStruct
         - Name: lengthMask
           Offset: 8
           Type: 8 BaseType uint64
-      GroupType: 56 StructureType noalg.map.group[string]main.bigStruct
+      GroupType: 58 StructureType noalg.map.group[string]main.bigStruct
       GroupSliceType: 75 GoSliceDataType []noalg.map.group[string]main.bigStruct.array
     - __kind: BaseType
       ID: 7
@@ -896,7 +896,7 @@ Types:
       GoRuntimeType: 42816
       GoKind: 3
     - __kind: StructureType
-      ID: 60
+      ID: 64
       Name: main.bigStruct
       ByteSize: 184
       GoRuntimeType: 124736
@@ -925,7 +925,7 @@ Types:
           Type: 7 BaseType int
         - Name: data
           Offset: 56
-          Type: 61 ArrayType [128]uint8
+          Type: 65 ArrayType [128]uint8
     - __kind: GoSwissMapHeaderType
       ID: 39
       Name: map<string,int>
@@ -960,9 +960,9 @@ Types:
           Offset: 40
           Type: 8 BaseType uint64
       TablePtrSliceType: 72 GoSliceDataType []*table<string,int>.array
-      GroupType: 45 StructureType noalg.map.group[string]int
+      GroupType: 55 StructureType noalg.map.group[string]int
     - __kind: GoSwissMapHeaderType
-      ID: 50
+      ID: 44
       Name: map<string,main.bigStruct>
       ByteSize: 48
       GoKind: 25
@@ -975,7 +975,7 @@ Types:
           Type: 1 BaseType uintptr
         - Name: dirPtr
           Offset: 16
-          Type: 51 PointerType **table<string,main.bigStruct>
+          Type: 45 PointerType **table<string,main.bigStruct>
         - Name: dirLen
           Offset: 24
           Type: 7 BaseType int
@@ -995,7 +995,7 @@ Types:
           Offset: 40
           Type: 8 BaseType uint64
       TablePtrSliceType: 74 GoSliceDataType []*table<string,main.bigStruct>.array
-      GroupType: 56 StructureType noalg.map.group[string]main.bigStruct
+      GroupType: 58 StructureType noalg.map.group[string]main.bigStruct
     - __kind: GoMapType
       ID: 37
       Name: map[string]int
@@ -1004,32 +1004,32 @@ Types:
       GoKind: 21
       HeaderType: 39 GoSwissMapHeaderType map<string,int>
     - __kind: GoMapType
-      ID: 48
+      ID: 42
       Name: map[string]main.bigStruct
       ByteSize: 8
       GoRuntimeType: 70208
       GoKind: 21
-      HeaderType: 50 GoSwissMapHeaderType map<string,main.bigStruct>
+      HeaderType: 44 GoSwissMapHeaderType map<string,main.bigStruct>
     - __kind: ArrayType
-      ID: 57
+      ID: 61
       Name: noalg.[8]struct { key string; elem *main.bigStruct }
       ByteSize: 192
       GoRuntimeType: 47776
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 58 StructureType noalg.struct { key string; elem *main.bigStruct }
+      Element: 62 StructureType noalg.struct { key string; elem *main.bigStruct }
     - __kind: ArrayType
-      ID: 46
+      ID: 59
       Name: noalg.[8]struct { key string; elem int }
       ByteSize: 192
       GoRuntimeType: 47584
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 47 StructureType noalg.struct { key string; elem int }
+      Element: 60 StructureType noalg.struct { key string; elem int }
     - __kind: StructureType
-      ID: 45
+      ID: 55
       Name: noalg.map.group[string]int
       ByteSize: 200
       GoRuntimeType: 77248
@@ -1040,9 +1040,9 @@ Types:
           Type: 8 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 46 ArrayType noalg.[8]struct { key string; elem int }
+          Type: 59 ArrayType noalg.[8]struct { key string; elem int }
     - __kind: StructureType
-      ID: 56
+      ID: 58
       Name: noalg.map.group[string]main.bigStruct
       ByteSize: 200
       GoRuntimeType: 77504
@@ -1053,9 +1053,9 @@ Types:
           Type: 8 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 57 ArrayType noalg.[8]struct { key string; elem *main.bigStruct }
+          Type: 61 ArrayType noalg.[8]struct { key string; elem *main.bigStruct }
     - __kind: StructureType
-      ID: 58
+      ID: 62
       Name: noalg.struct { key string; elem *main.bigStruct }
       ByteSize: 24
       GoRuntimeType: 77376
@@ -1066,9 +1066,9 @@ Types:
           Type: 9 GoStringHeaderType string
         - Name: elem
           Offset: 16
-          Type: 59 PointerType *main.bigStruct
+          Type: 63 PointerType *main.bigStruct
     - __kind: StructureType
-      ID: 47
+      ID: 60
       Name: noalg.struct { key string; elem int }
       ByteSize: 24
       GoRuntimeType: 77120
@@ -1099,7 +1099,7 @@ Types:
       Name: string.str
       ByteSize: 2048
     - __kind: StructureType
-      ID: 42
+      ID: 50
       Name: table<string,int>
       ByteSize: 32
       GoKind: 25
@@ -1121,9 +1121,9 @@ Types:
           Type: 7 BaseType int
         - Name: groups
           Offset: 16
-          Type: 43 GoSwissMapGroupsType groupReference<string,int>
+          Type: 53 GoSwissMapGroupsType groupReference<string,int>
     - __kind: StructureType
-      ID: 53
+      ID: 51
       Name: table<string,main.bigStruct>
       ByteSize: 32
       GoKind: 25
@@ -1145,7 +1145,7 @@ Types:
           Type: 7 BaseType int
         - Name: groups
           Offset: 16
-          Type: 54 GoSwissMapGroupsType groupReference<string,main.bigStruct>
+          Type: 56 GoSwissMapGroupsType groupReference<string,main.bigStruct>
     - __kind: BaseType
       ID: 17
       Name: uint

--- a/pkg/dyninst/irgen/testdata/snapshot/simple.arch=amd64,toolchain=go1.25.0.yaml
+++ b/pkg/dyninst/irgen/testdata/snapshot/simple.arch=amd64,toolchain=go1.25.0.yaml
@@ -11,7 +11,7 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 2}
+      subprogram: {subprogram: 11}
       events:
         - ID: 11
           Type: 86 EventRootType Probe[main.PointerChainArg]
@@ -28,7 +28,7 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 3}
+      subprogram: {subprogram: 12}
       events:
         - ID: 12
           Type: 87 EventRootType Probe[main.PointerSmallChainArg]
@@ -41,7 +41,7 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 12}
+      subprogram: {subprogram: 9}
       events:
         - ID: 9
           Type: 84 EventRootType Probe[main.bigMapArg]
@@ -55,7 +55,7 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 1}
+      subprogram: {subprogram: 10}
       events:
         - ID: 10
           Type: 85 EventRootType Probe[main.inlined]
@@ -72,7 +72,7 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 4}
+      subprogram: {subprogram: 1}
       events:
         - ID: 1
           Type: 76 EventRootType Probe[main.intArg]
@@ -85,7 +85,7 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 7}
+      subprogram: {subprogram: 4}
       events:
         - ID: 4
           Type: 79 EventRootType Probe[main.intArrayArg]
@@ -98,7 +98,7 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 10}
+      subprogram: {subprogram: 7}
       events:
         - ID: 7
           Type: 82 EventRootType Probe[main.stringArrayArgFrameless]
@@ -111,7 +111,7 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 6}
+      subprogram: {subprogram: 3}
       events:
         - ID: 3
           Type: 78 EventRootType Probe[main.intSliceArg]
@@ -124,7 +124,7 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 11}
+      subprogram: {subprogram: 8}
       events:
         - ID: 8
           Type: 83 EventRootType Probe[main.mapArg]
@@ -137,7 +137,7 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 5}
+      subprogram: {subprogram: 2}
       events:
         - ID: 2
           Type: 77 EventRootType Probe[main.stringArg]
@@ -150,7 +150,7 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 9}
+      subprogram: {subprogram: 6}
       events:
         - ID: 6
           Type: 81 EventRootType Probe[main.stringArrayArg]
@@ -163,32 +163,32 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 8}
+      subprogram: {subprogram: 5}
       events:
         - ID: 5
           Type: 80 EventRootType Probe[main.stringSliceArg]
           InjectionPoints: [{PC: "0x4ae8aa", Frameless: false}]
           Condition: null
 Subprograms:
-    - ID: 4
+    - ID: 1
       Name: main.intArg
       OutOfLinePCRanges: [0x4ae6a0..0x4ae702]
       InlinePCRanges: []
       Variables:
         - Name: x
-          Type: 1 BaseType int
+          Type: 7 BaseType int
           Locations:
             - Range: 0x4ae6a0..0x4ae6b9
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 5
+    - ID: 2
       Name: main.stringArg
       OutOfLinePCRanges: [0x4ae720..0x4ae791]
       InlinePCRanges: []
       Variables:
         - Name: s
-          Type: 7 GoStringHeaderType string
+          Type: 9 GoStringHeaderType string
           Locations:
             - Range: 0x4ae720..0x4ae73e
               Pieces:
@@ -198,13 +198,13 @@ Subprograms:
                   Op: {RegNo: 3, Shift: 0}
           IsParameter: true
           IsReturn: false
-    - ID: 6
+    - ID: 3
       Name: main.intSliceArg
       OutOfLinePCRanges: [0x4ae7a0..0x4ae81a]
       InlinePCRanges: []
       Variables:
         - Name: s
-          Type: 10 GoSliceHeaderType []int
+          Type: 33 GoSliceHeaderType []int
           Locations:
             - Range: 0x4ae7a0..0x4ae7be
               Pieces:
@@ -216,25 +216,25 @@ Subprograms:
                   Op: {RegNo: 2, Shift: 0}
           IsParameter: true
           IsReturn: false
-    - ID: 7
+    - ID: 4
       Name: main.intArrayArg
       OutOfLinePCRanges: [0x4ae820..0x4ae887]
       InlinePCRanges: []
       Variables:
         - Name: s
-          Type: 11 ArrayType [3]int
+          Type: 34 ArrayType [3]int
           Locations:
             - Range: 0x4ae820..0x4ae887
               Pieces: [{Size: 24, Op: {CfaOffset: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 8
+    - ID: 5
       Name: main.stringSliceArg
       OutOfLinePCRanges: [0x4ae8a0..0x4ae91a]
       InlinePCRanges: []
       Variables:
         - Name: s
-          Type: 12 GoSliceHeaderType []string
+          Type: 35 GoSliceHeaderType []string
           Locations:
             - Range: 0x4ae8a0..0x4ae8be
               Pieces:
@@ -246,49 +246,49 @@ Subprograms:
                   Op: {RegNo: 2, Shift: 0}
           IsParameter: true
           IsReturn: false
-    - ID: 9
+    - ID: 6
       Name: main.stringArrayArg
       OutOfLinePCRanges: [0x4ae920..0x4ae987]
       InlinePCRanges: []
       Variables:
         - Name: s
-          Type: 14 ArrayType [3]string
+          Type: 36 ArrayType [3]string
           Locations:
             - Range: 0x4ae920..0x4ae987
               Pieces: [{Size: 48, Op: {CfaOffset: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 10
+    - ID: 7
       Name: main.stringArrayArgFrameless
       OutOfLinePCRanges: [0x4ae9a0..0x4ae9a1]
       InlinePCRanges: []
       Variables:
         - Name: s
-          Type: 14 ArrayType [3]string
+          Type: 36 ArrayType [3]string
           Locations:
             - Range: 0x4ae9a0..0x4ae9a1
               Pieces: [{Size: 48, Op: {CfaOffset: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 11
+    - ID: 8
       Name: main.mapArg
       OutOfLinePCRanges: [0x4aea80..0x4aead6]
       InlinePCRanges: []
       Variables:
         - Name: m
-          Type: 15 GoMapType map[string]int
+          Type: 37 GoMapType map[string]int
           Locations:
             - Range: 0x4aea80..0x4aeaad
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 12
+    - ID: 9
       Name: main.bigMapArg
       OutOfLinePCRanges: [0x4aeae0..0x4aeb9b]
       InlinePCRanges: []
       Variables:
         - Name: m
-          Type: 30 GoMapType map[string]main.bigStruct
+          Type: 48 GoMapType map[string]main.bigStruct
           Locations:
             - Range: 0x4aeae0..0x4aeb13
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
@@ -296,7 +296,7 @@ Subprograms:
               Pieces: [{Size: 8, Op: {CfaOffset: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 1
+    - ID: 10
       Name: main.inlined
       OutOfLinePCRanges: [0x4ae9c0..0x4aea22]
       InlinePCRanges:
@@ -304,7 +304,7 @@ Subprograms:
           RootRanges: [0x4ae240..0x4ae69d]
       Variables:
         - Name: x
-          Type: 1 BaseType int
+          Type: 7 BaseType int
           Locations:
             - Range: 0x4ae3ce..0x4ae40f
               Pieces: []
@@ -312,7 +312,7 @@ Subprograms:
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 2
+    - ID: 11
       Name: main.PointerChainArg
       OutOfLinePCRanges: []
       InlinePCRanges:
@@ -320,13 +320,13 @@ Subprograms:
           RootRanges: [0x4ae240..0x4ae69d]
       Variables:
         - Name: ptr
-          Type: 2 PointerType *****int
+          Type: 62 PointerType *****int
           Locations:
             - Range: 0x4ae5df..0x4ae62b
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 3
+    - ID: 12
       Name: main.PointerSmallChainArg
       OutOfLinePCRanges: []
       InlinePCRanges:
@@ -334,7 +334,7 @@ Subprograms:
           RootRanges: [0x4ae240..0x4ae69d]
       Variables:
         - Name: ptr
-          Type: 5 PointerType **int
+          Type: 65 PointerType **int
           Locations:
             - Range: 0x4ae650..0x4ae68a
               Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
@@ -342,43 +342,43 @@ Subprograms:
           IsReturn: false
 Types:
     - __kind: PointerType
-      ID: 2
+      ID: 62
       Name: '*****int'
       ByteSize: 8
       GoRuntimeType: 36320
       GoKind: 22
-      Pointee: 3 PointerType ****int
+      Pointee: 63 PointerType ****int
     - __kind: PointerType
-      ID: 3
+      ID: 63
       Name: '****int'
       ByteSize: 8
       GoRuntimeType: 36256
       GoKind: 22
-      Pointee: 4 PointerType ***int
+      Pointee: 64 PointerType ***int
     - __kind: PointerType
-      ID: 4
+      ID: 64
       Name: '***int'
       ByteSize: 8
       GoRuntimeType: 36192
       GoKind: 22
-      Pointee: 5 PointerType **int
+      Pointee: 65 PointerType **int
     - __kind: PointerType
-      ID: 5
+      ID: 65
       Name: '**int'
       ByteSize: 8
       GoRuntimeType: 36128
       GoKind: 22
-      Pointee: 6 PointerType *int
+      Pointee: 26 PointerType *int
     - __kind: PointerType
-      ID: 20
+      ID: 40
       Name: '**table<string,int>'
       ByteSize: 8
-      Pointee: 21 PointerType *table<string,int>
+      Pointee: 41 PointerType *table<string,int>
     - __kind: PointerType
-      ID: 33
+      ID: 51
       Name: '**table<string,main.bigStruct>'
       ByteSize: 8
-      Pointee: 34 PointerType *table<string,main.bigStruct>
+      Pointee: 52 PointerType *table<string,main.bigStruct>
     - __kind: PointerType
       ID: 69
       Name: '*[]int.array'
@@ -390,145 +390,145 @@ Types:
       ByteSize: 8
       Pointee: 70 GoSliceDataType []string.array
     - __kind: PointerType
-      ID: 46
+      ID: 11
       Name: '*bool'
       ByteSize: 8
       GoRuntimeType: 30432
       GoKind: 22
-      Pointee: 29 BaseType bool
+      Pointee: 4 BaseType bool
     - __kind: PointerType
-      ID: 62
+      ID: 29
       Name: '*error'
       ByteSize: 8
       GoRuntimeType: 29344
       GoKind: 22
-      Pointee: 48 GoInterfaceType error
+      Pointee: 13 GoInterfaceType error
     - __kind: PointerType
-      ID: 63
+      ID: 30
       Name: '*float32'
       ByteSize: 8
       GoRuntimeType: 30304
       GoKind: 22
-      Pointee: 53 BaseType float32
+      Pointee: 18 BaseType float32
     - __kind: PointerType
-      ID: 59
+      ID: 25
       Name: '*float64'
       ByteSize: 8
       GoRuntimeType: 30368
       GoKind: 22
-      Pointee: 50 BaseType float64
+      Pointee: 15 BaseType float64
     - __kind: PointerType
-      ID: 6
+      ID: 26
       Name: '*int'
       ByteSize: 8
       GoRuntimeType: 29984
       GoKind: 22
-      Pointee: 1 BaseType int
+      Pointee: 7 BaseType int
     - __kind: PointerType
-      ID: 55
+      ID: 20
       Name: '*int32'
       ByteSize: 8
       GoRuntimeType: 29728
       GoKind: 22
-      Pointee: 45 BaseType int32
+      Pointee: 10 BaseType int32
     - __kind: PointerType
-      ID: 60
+      ID: 27
       Name: '*int64'
       ByteSize: 8
       GoRuntimeType: 29856
       GoKind: 22
-      Pointee: 47 BaseType int64
+      Pointee: 12 BaseType int64
     - __kind: PointerType
-      ID: 41
+      ID: 59
       Name: '*main.bigStruct'
       ByteSize: 8
       GoRuntimeType: 27808
       GoKind: 22
-      Pointee: 42 StructureType main.bigStruct
+      Pointee: 60 StructureType main.bigStruct
     - __kind: PointerType
-      ID: 16
+      ID: 38
       Name: '*map<string,int>'
       ByteSize: 8
-      Pointee: 17 GoSwissMapHeaderType map<string,int>
+      Pointee: 39 GoSwissMapHeaderType map<string,int>
     - __kind: PointerType
-      ID: 31
+      ID: 49
       Name: '*map<string,main.bigStruct>'
       ByteSize: 8
-      Pointee: 32 GoSwissMapHeaderType map<string,main.bigStruct>
+      Pointee: 50 GoSwissMapHeaderType map<string,main.bigStruct>
     - __kind: PointerType
-      ID: 25
+      ID: 44
       Name: '*noalg.map.group[string]int'
       ByteSize: 8
-      Pointee: 26 StructureType noalg.map.group[string]int
+      Pointee: 45 StructureType noalg.map.group[string]int
     - __kind: PointerType
-      ID: 37
+      ID: 55
       Name: '*noalg.map.group[string]main.bigStruct'
       ByteSize: 8
-      Pointee: 38 StructureType noalg.map.group[string]main.bigStruct
+      Pointee: 56 StructureType noalg.map.group[string]main.bigStruct
     - __kind: PointerType
-      ID: 13
+      ID: 22
       Name: '*string'
       ByteSize: 8
       GoRuntimeType: 29408
       GoKind: 22
-      Pointee: 7 GoStringHeaderType string
+      Pointee: 9 GoStringHeaderType string
     - __kind: PointerType
       ID: 67
       Name: '*string.str'
       ByteSize: 8
       Pointee: 66 GoStringDataType string.str
     - __kind: PointerType
-      ID: 21
+      ID: 41
       Name: '*table<string,int>'
       ByteSize: 8
-      Pointee: 22 StructureType table<string,int>
+      Pointee: 42 StructureType table<string,int>
     - __kind: PointerType
-      ID: 34
+      ID: 52
       Name: '*table<string,main.bigStruct>'
       ByteSize: 8
-      Pointee: 35 StructureType table<string,main.bigStruct>
+      Pointee: 53 StructureType table<string,main.bigStruct>
     - __kind: PointerType
-      ID: 64
+      ID: 31
       Name: '*uint'
       ByteSize: 8
       GoRuntimeType: 30048
       GoKind: 22
-      Pointee: 52 BaseType uint
+      Pointee: 17 BaseType uint
     - __kind: PointerType
-      ID: 65
+      ID: 32
       Name: '*uint16'
       ByteSize: 8
       GoRuntimeType: 29664
       GoKind: 22
-      Pointee: 23 BaseType uint16
+      Pointee: 6 BaseType uint16
     - __kind: PointerType
-      ID: 56
+      ID: 21
       Name: '*uint32'
       ByteSize: 8
       GoRuntimeType: 29792
       GoKind: 22
-      Pointee: 44 BaseType uint32
+      Pointee: 2 BaseType uint32
     - __kind: PointerType
-      ID: 61
+      ID: 28
       Name: '*uint64'
       ByteSize: 8
       GoRuntimeType: 29920
       GoKind: 22
-      Pointee: 18 BaseType uint64
+      Pointee: 8 BaseType uint64
     - __kind: PointerType
-      ID: 8
+      ID: 5
       Name: '*uint8'
       ByteSize: 8
       GoRuntimeType: 29536
       GoKind: 22
-      Pointee: 9 BaseType uint8
+      Pointee: 3 BaseType uint8
     - __kind: PointerType
-      ID: 54
+      ID: 19
       Name: '*uintptr'
       ByteSize: 8
       GoRuntimeType: 30112
       GoKind: 22
-      Pointee: 19 BaseType uintptr
+      Pointee: 1 BaseType uintptr
     - __kind: EventRootType
       ID: 86
       Name: Probe[main.PointerChainArg]
@@ -538,10 +538,10 @@ Types:
         - Name: ptr
           Offset: 1
           Expression:
-            Type: 2 PointerType *****int
+            Type: 62 PointerType *****int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 2, index: 0, name: ptr}
+                  Variable: {subprogram: 11, index: 0, name: ptr}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
@@ -553,10 +553,10 @@ Types:
         - Name: ptr
           Offset: 1
           Expression:
-            Type: 5 PointerType **int
+            Type: 65 PointerType **int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 3, index: 0, name: ptr}
+                  Variable: {subprogram: 12, index: 0, name: ptr}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
@@ -568,10 +568,10 @@ Types:
         - Name: m
           Offset: 1
           Expression:
-            Type: 30 GoMapType map[string]main.bigStruct
+            Type: 48 GoMapType map[string]main.bigStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 12, index: 0, name: m}
+                  Variable: {subprogram: 9, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
@@ -583,10 +583,10 @@ Types:
         - Name: x
           Offset: 1
           Expression:
-            Type: 1 BaseType int
+            Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 1, index: 0, name: x}
+                  Variable: {subprogram: 10, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
@@ -598,10 +598,10 @@ Types:
         - Name: x
           Offset: 1
           Expression:
-            Type: 1 BaseType int
+            Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 4, index: 0, name: x}
+                  Variable: {subprogram: 1, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
@@ -613,10 +613,10 @@ Types:
         - Name: s
           Offset: 1
           Expression:
-            Type: 11 ArrayType [3]int
+            Type: 34 ArrayType [3]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 7, index: 0, name: s}
+                  Variable: {subprogram: 4, index: 0, name: s}
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
@@ -628,10 +628,10 @@ Types:
         - Name: s
           Offset: 1
           Expression:
-            Type: 10 GoSliceHeaderType []int
+            Type: 33 GoSliceHeaderType []int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 6, index: 0, name: s}
+                  Variable: {subprogram: 3, index: 0, name: s}
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
@@ -643,10 +643,10 @@ Types:
         - Name: m
           Offset: 1
           Expression:
-            Type: 15 GoMapType map[string]int
+            Type: 37 GoMapType map[string]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 11, index: 0, name: m}
+                  Variable: {subprogram: 8, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
@@ -658,10 +658,10 @@ Types:
         - Name: s
           Offset: 1
           Expression:
-            Type: 7 GoStringHeaderType string
+            Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 5, index: 0, name: s}
+                  Variable: {subprogram: 2, index: 0, name: s}
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
@@ -673,10 +673,10 @@ Types:
         - Name: s
           Offset: 1
           Expression:
-            Type: 14 ArrayType [3]string
+            Type: 36 ArrayType [3]string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 10, index: 0, name: s}
+                  Variable: {subprogram: 7, index: 0, name: s}
                   Offset: 0
                   ByteSize: 48
     - __kind: EventRootType
@@ -688,10 +688,10 @@ Types:
         - Name: s
           Offset: 1
           Expression:
-            Type: 14 ArrayType [3]string
+            Type: 36 ArrayType [3]string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 9, index: 0, name: s}
+                  Variable: {subprogram: 6, index: 0, name: s}
                   Offset: 0
                   ByteSize: 48
     - __kind: EventRootType
@@ -703,51 +703,51 @@ Types:
         - Name: s
           Offset: 1
           Expression:
-            Type: 12 GoSliceHeaderType []string
+            Type: 35 GoSliceHeaderType []string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 8, index: 0, name: s}
+                  Variable: {subprogram: 5, index: 0, name: s}
                   Offset: 0
                   ByteSize: 24
     - __kind: ArrayType
-      ID: 43
+      ID: 61
       Name: '[128]uint8'
       ByteSize: 128
       GoRuntimeType: 47680
       GoKind: 17
       Count: 128
       HasCount: true
-      Element: 9 BaseType uint8
+      Element: 3 BaseType uint8
     - __kind: ArrayType
-      ID: 11
+      ID: 34
       Name: '[3]int'
       ByteSize: 24
       GoRuntimeType: 47392
       GoKind: 17
       Count: 3
       HasCount: true
-      Element: 1 BaseType int
+      Element: 7 BaseType int
     - __kind: ArrayType
-      ID: 14
+      ID: 36
       Name: '[3]string'
       ByteSize: 48
       GoRuntimeType: 47488
       GoKind: 17
       Count: 3
       HasCount: true
-      Element: 7 GoStringHeaderType string
+      Element: 9 GoStringHeaderType string
     - __kind: GoSliceDataType
       ID: 72
       Name: '[]*table<string,int>.array'
       ByteSize: 8192
-      Element: 21 PointerType *table<string,int>
+      Element: 41 PointerType *table<string,int>
     - __kind: GoSliceDataType
       ID: 74
       Name: '[]*table<string,main.bigStruct>.array'
       ByteSize: 8192
-      Element: 34 PointerType *table<string,main.bigStruct>
+      Element: 52 PointerType *table<string,main.bigStruct>
     - __kind: GoSliceHeaderType
-      ID: 10
+      ID: 33
       Name: '[]int'
       ByteSize: 24
       GoRuntimeType: 38816
@@ -755,31 +755,31 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 6 PointerType *int
+          Type: 26 PointerType *int
         - Name: len
           Offset: 8
-          Type: 1 BaseType int
+          Type: 7 BaseType int
         - Name: cap
           Offset: 16
-          Type: 1 BaseType int
+          Type: 7 BaseType int
       Data: 68 GoSliceDataType []int.array
     - __kind: GoSliceDataType
       ID: 68
       Name: '[]int.array'
       ByteSize: 2048
-      Element: 1 BaseType int
+      Element: 7 BaseType int
     - __kind: GoSliceDataType
       ID: 73
       Name: '[]noalg.map.group[string]int.array'
       ByteSize: 2048
-      Element: 26 StructureType noalg.map.group[string]int
+      Element: 45 StructureType noalg.map.group[string]int
     - __kind: GoSliceDataType
       ID: 75
       Name: '[]noalg.map.group[string]main.bigStruct.array'
       ByteSize: 2048
-      Element: 38 StructureType noalg.map.group[string]main.bigStruct
+      Element: 56 StructureType noalg.map.group[string]main.bigStruct
     - __kind: GoSliceHeaderType
-      ID: 12
+      ID: 35
       Name: '[]string'
       ByteSize: 24
       GoRuntimeType: 39072
@@ -787,39 +787,39 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 13 PointerType *string
+          Type: 22 PointerType *string
         - Name: len
           Offset: 8
-          Type: 1 BaseType int
+          Type: 7 BaseType int
         - Name: cap
           Offset: 16
-          Type: 1 BaseType int
+          Type: 7 BaseType int
       Data: 70 GoSliceDataType []string.array
     - __kind: GoSliceDataType
       ID: 70
       Name: '[]string.array'
       ByteSize: 2048
-      Element: 7 GoStringHeaderType string
+      Element: 9 GoStringHeaderType string
     - __kind: BaseType
-      ID: 29
+      ID: 4
       Name: bool
       ByteSize: 1
       GoRuntimeType: 43776
       GoKind: 1
     - __kind: BaseType
-      ID: 58
+      ID: 24
       Name: complex128
       ByteSize: 16
       GoRuntimeType: 43584
       GoKind: 16
     - __kind: BaseType
-      ID: 57
+      ID: 23
       Name: complex64
       ByteSize: 8
       GoRuntimeType: 43520
       GoKind: 15
     - __kind: GoInterfaceType
-      ID: 48
+      ID: 13
       Name: error
       ByteSize: 16
       GoRuntimeType: 65856
@@ -827,76 +827,76 @@ Types:
       RawFields:
         - Name: tab
           Offset: 0
-          Type: 49 VoidPointerType unsafe.Pointer
+          Type: 14 VoidPointerType unsafe.Pointer
         - Name: data
           Offset: 8
-          Type: 49 VoidPointerType unsafe.Pointer
+          Type: 14 VoidPointerType unsafe.Pointer
     - __kind: BaseType
-      ID: 53
+      ID: 18
       Name: float32
       ByteSize: 4
       GoRuntimeType: 43648
       GoKind: 13
     - __kind: BaseType
-      ID: 50
+      ID: 15
       Name: float64
       ByteSize: 8
       GoRuntimeType: 43712
       GoKind: 14
     - __kind: GoSwissMapGroupsType
-      ID: 24
+      ID: 43
       Name: groupReference<string,int>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 25 PointerType *noalg.map.group[string]int
+          Type: 44 PointerType *noalg.map.group[string]int
         - Name: lengthMask
           Offset: 8
-          Type: 18 BaseType uint64
-      GroupType: 26 StructureType noalg.map.group[string]int
+          Type: 8 BaseType uint64
+      GroupType: 45 StructureType noalg.map.group[string]int
       GroupSliceType: 73 GoSliceDataType []noalg.map.group[string]int.array
     - __kind: GoSwissMapGroupsType
-      ID: 36
+      ID: 54
       Name: groupReference<string,main.bigStruct>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 37 PointerType *noalg.map.group[string]main.bigStruct
+          Type: 55 PointerType *noalg.map.group[string]main.bigStruct
         - Name: lengthMask
           Offset: 8
-          Type: 18 BaseType uint64
-      GroupType: 38 StructureType noalg.map.group[string]main.bigStruct
+          Type: 8 BaseType uint64
+      GroupType: 56 StructureType noalg.map.group[string]main.bigStruct
       GroupSliceType: 75 GoSliceDataType []noalg.map.group[string]main.bigStruct.array
     - __kind: BaseType
-      ID: 1
+      ID: 7
       Name: int
       ByteSize: 8
       GoRuntimeType: 43328
       GoKind: 2
     - __kind: BaseType
-      ID: 45
+      ID: 10
       Name: int32
       ByteSize: 4
       GoRuntimeType: 43072
       GoKind: 5
     - __kind: BaseType
-      ID: 47
+      ID: 12
       Name: int64
       ByteSize: 8
       GoRuntimeType: 43200
       GoKind: 6
     - __kind: BaseType
-      ID: 51
+      ID: 16
       Name: int8
       ByteSize: 1
       GoRuntimeType: 42816
       GoKind: 3
     - __kind: StructureType
-      ID: 42
+      ID: 60
       Name: main.bigStruct
       ByteSize: 184
       GoRuntimeType: 124736
@@ -904,132 +904,132 @@ Types:
       RawFields:
         - Name: Field1
           Offset: 0
-          Type: 1 BaseType int
+          Type: 7 BaseType int
         - Name: Field2
           Offset: 8
-          Type: 1 BaseType int
+          Type: 7 BaseType int
         - Name: Field3
           Offset: 16
-          Type: 1 BaseType int
+          Type: 7 BaseType int
         - Name: Field4
           Offset: 24
-          Type: 1 BaseType int
+          Type: 7 BaseType int
         - Name: Field5
           Offset: 32
-          Type: 1 BaseType int
+          Type: 7 BaseType int
         - Name: Field6
           Offset: 40
-          Type: 1 BaseType int
+          Type: 7 BaseType int
         - Name: Field7
           Offset: 48
-          Type: 1 BaseType int
+          Type: 7 BaseType int
         - Name: data
           Offset: 56
-          Type: 43 ArrayType [128]uint8
+          Type: 61 ArrayType [128]uint8
     - __kind: GoSwissMapHeaderType
-      ID: 17
+      ID: 39
       Name: map<string,int>
       ByteSize: 48
       GoKind: 25
       RawFields:
         - Name: used
           Offset: 0
-          Type: 18 BaseType uint64
+          Type: 8 BaseType uint64
         - Name: seed
           Offset: 8
-          Type: 19 BaseType uintptr
+          Type: 1 BaseType uintptr
         - Name: dirPtr
           Offset: 16
-          Type: 20 PointerType **table<string,int>
+          Type: 40 PointerType **table<string,int>
         - Name: dirLen
           Offset: 24
-          Type: 1 BaseType int
+          Type: 7 BaseType int
         - Name: globalDepth
           Offset: 32
-          Type: 9 BaseType uint8
+          Type: 3 BaseType uint8
         - Name: globalShift
           Offset: 33
-          Type: 9 BaseType uint8
+          Type: 3 BaseType uint8
         - Name: writing
           Offset: 34
-          Type: 9 BaseType uint8
+          Type: 3 BaseType uint8
         - Name: tombstonePossible
           Offset: 35
-          Type: 29 BaseType bool
+          Type: 4 BaseType bool
         - Name: clearSeq
           Offset: 40
-          Type: 18 BaseType uint64
+          Type: 8 BaseType uint64
       TablePtrSliceType: 72 GoSliceDataType []*table<string,int>.array
-      GroupType: 26 StructureType noalg.map.group[string]int
+      GroupType: 45 StructureType noalg.map.group[string]int
     - __kind: GoSwissMapHeaderType
-      ID: 32
+      ID: 50
       Name: map<string,main.bigStruct>
       ByteSize: 48
       GoKind: 25
       RawFields:
         - Name: used
           Offset: 0
-          Type: 18 BaseType uint64
+          Type: 8 BaseType uint64
         - Name: seed
           Offset: 8
-          Type: 19 BaseType uintptr
+          Type: 1 BaseType uintptr
         - Name: dirPtr
           Offset: 16
-          Type: 33 PointerType **table<string,main.bigStruct>
+          Type: 51 PointerType **table<string,main.bigStruct>
         - Name: dirLen
           Offset: 24
-          Type: 1 BaseType int
+          Type: 7 BaseType int
         - Name: globalDepth
           Offset: 32
-          Type: 9 BaseType uint8
+          Type: 3 BaseType uint8
         - Name: globalShift
           Offset: 33
-          Type: 9 BaseType uint8
+          Type: 3 BaseType uint8
         - Name: writing
           Offset: 34
-          Type: 9 BaseType uint8
+          Type: 3 BaseType uint8
         - Name: tombstonePossible
           Offset: 35
-          Type: 29 BaseType bool
+          Type: 4 BaseType bool
         - Name: clearSeq
           Offset: 40
-          Type: 18 BaseType uint64
+          Type: 8 BaseType uint64
       TablePtrSliceType: 74 GoSliceDataType []*table<string,main.bigStruct>.array
-      GroupType: 38 StructureType noalg.map.group[string]main.bigStruct
+      GroupType: 56 StructureType noalg.map.group[string]main.bigStruct
     - __kind: GoMapType
-      ID: 15
+      ID: 37
       Name: map[string]int
       ByteSize: 8
       GoRuntimeType: 70080
       GoKind: 21
-      HeaderType: 17 GoSwissMapHeaderType map<string,int>
+      HeaderType: 39 GoSwissMapHeaderType map<string,int>
     - __kind: GoMapType
-      ID: 30
+      ID: 48
       Name: map[string]main.bigStruct
       ByteSize: 8
       GoRuntimeType: 70208
       GoKind: 21
-      HeaderType: 32 GoSwissMapHeaderType map<string,main.bigStruct>
+      HeaderType: 50 GoSwissMapHeaderType map<string,main.bigStruct>
     - __kind: ArrayType
-      ID: 39
+      ID: 57
       Name: noalg.[8]struct { key string; elem *main.bigStruct }
       ByteSize: 192
       GoRuntimeType: 47776
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 40 StructureType noalg.struct { key string; elem *main.bigStruct }
+      Element: 58 StructureType noalg.struct { key string; elem *main.bigStruct }
     - __kind: ArrayType
-      ID: 27
+      ID: 46
       Name: noalg.[8]struct { key string; elem int }
       ByteSize: 192
       GoRuntimeType: 47584
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 28 StructureType noalg.struct { key string; elem int }
+      Element: 47 StructureType noalg.struct { key string; elem int }
     - __kind: StructureType
-      ID: 26
+      ID: 45
       Name: noalg.map.group[string]int
       ByteSize: 200
       GoRuntimeType: 77248
@@ -1037,12 +1037,12 @@ Types:
       RawFields:
         - Name: ctrl
           Offset: 0
-          Type: 18 BaseType uint64
+          Type: 8 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 27 ArrayType noalg.[8]struct { key string; elem int }
+          Type: 46 ArrayType noalg.[8]struct { key string; elem int }
     - __kind: StructureType
-      ID: 38
+      ID: 56
       Name: noalg.map.group[string]main.bigStruct
       ByteSize: 200
       GoRuntimeType: 77504
@@ -1050,12 +1050,12 @@ Types:
       RawFields:
         - Name: ctrl
           Offset: 0
-          Type: 18 BaseType uint64
+          Type: 8 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 39 ArrayType noalg.[8]struct { key string; elem *main.bigStruct }
+          Type: 57 ArrayType noalg.[8]struct { key string; elem *main.bigStruct }
     - __kind: StructureType
-      ID: 40
+      ID: 58
       Name: noalg.struct { key string; elem *main.bigStruct }
       ByteSize: 24
       GoRuntimeType: 77376
@@ -1063,12 +1063,12 @@ Types:
       RawFields:
         - Name: key
           Offset: 0
-          Type: 7 GoStringHeaderType string
+          Type: 9 GoStringHeaderType string
         - Name: elem
           Offset: 16
-          Type: 41 PointerType *main.bigStruct
+          Type: 59 PointerType *main.bigStruct
     - __kind: StructureType
-      ID: 28
+      ID: 47
       Name: noalg.struct { key string; elem int }
       ByteSize: 24
       GoRuntimeType: 77120
@@ -1076,12 +1076,12 @@ Types:
       RawFields:
         - Name: key
           Offset: 0
-          Type: 7 GoStringHeaderType string
+          Type: 9 GoStringHeaderType string
         - Name: elem
           Offset: 16
-          Type: 1 BaseType int
+          Type: 7 BaseType int
     - __kind: GoStringHeaderType
-      ID: 7
+      ID: 9
       Name: string
       ByteSize: 16
       GoRuntimeType: 42752
@@ -1092,98 +1092,98 @@ Types:
           Type: 67 PointerType *string.str
         - Name: len
           Offset: 8
-          Type: 1 BaseType int
+          Type: 7 BaseType int
       Data: 66 GoStringDataType string.str
     - __kind: GoStringDataType
       ID: 66
       Name: string.str
       ByteSize: 2048
     - __kind: StructureType
-      ID: 22
+      ID: 42
       Name: table<string,int>
       ByteSize: 32
       GoKind: 25
       RawFields:
         - Name: used
           Offset: 0
-          Type: 23 BaseType uint16
+          Type: 6 BaseType uint16
         - Name: capacity
           Offset: 2
-          Type: 23 BaseType uint16
+          Type: 6 BaseType uint16
         - Name: growthLeft
           Offset: 4
-          Type: 23 BaseType uint16
+          Type: 6 BaseType uint16
         - Name: localDepth
           Offset: 6
-          Type: 9 BaseType uint8
+          Type: 3 BaseType uint8
         - Name: index
           Offset: 8
-          Type: 1 BaseType int
+          Type: 7 BaseType int
         - Name: groups
           Offset: 16
-          Type: 24 GoSwissMapGroupsType groupReference<string,int>
+          Type: 43 GoSwissMapGroupsType groupReference<string,int>
     - __kind: StructureType
-      ID: 35
+      ID: 53
       Name: table<string,main.bigStruct>
       ByteSize: 32
       GoKind: 25
       RawFields:
         - Name: used
           Offset: 0
-          Type: 23 BaseType uint16
+          Type: 6 BaseType uint16
         - Name: capacity
           Offset: 2
-          Type: 23 BaseType uint16
+          Type: 6 BaseType uint16
         - Name: growthLeft
           Offset: 4
-          Type: 23 BaseType uint16
+          Type: 6 BaseType uint16
         - Name: localDepth
           Offset: 6
-          Type: 9 BaseType uint8
+          Type: 3 BaseType uint8
         - Name: index
           Offset: 8
-          Type: 1 BaseType int
+          Type: 7 BaseType int
         - Name: groups
           Offset: 16
-          Type: 36 GoSwissMapGroupsType groupReference<string,main.bigStruct>
+          Type: 54 GoSwissMapGroupsType groupReference<string,main.bigStruct>
     - __kind: BaseType
-      ID: 52
+      ID: 17
       Name: uint
       ByteSize: 8
       GoRuntimeType: 43392
       GoKind: 7
     - __kind: BaseType
-      ID: 23
+      ID: 6
       Name: uint16
       ByteSize: 2
       GoRuntimeType: 43008
       GoKind: 9
     - __kind: BaseType
-      ID: 44
+      ID: 2
       Name: uint32
       ByteSize: 4
       GoRuntimeType: 43136
       GoKind: 10
     - __kind: BaseType
-      ID: 18
+      ID: 8
       Name: uint64
       ByteSize: 8
       GoRuntimeType: 43264
       GoKind: 11
     - __kind: BaseType
-      ID: 9
+      ID: 3
       Name: uint8
       ByteSize: 1
       GoRuntimeType: 42880
       GoKind: 8
     - __kind: BaseType
-      ID: 19
+      ID: 1
       Name: uintptr
       ByteSize: 8
       GoRuntimeType: 43456
       GoKind: 12
     - __kind: VoidPointerType
-      ID: 49
+      ID: 14
       Name: unsafe.Pointer
       ByteSize: 8
       GoRuntimeType: 43840

--- a/pkg/dyninst/irgen/testdata/snapshot/simple.arch=amd64,toolchain=go1.25.0.yaml
+++ b/pkg/dyninst/irgen/testdata/snapshot/simple.arch=amd64,toolchain=go1.25.0.yaml
@@ -354,9 +354,9 @@ Types:
       ByteSize: 8
       GoRuntimeType: 36256
       GoKind: 22
-      Pointee: 52 PointerType ***int
+      Pointee: 74 PointerType ***int
     - __kind: PointerType
-      ID: 52
+      ID: 74
       Name: '***int'
       ByteSize: 8
       GoRuntimeType: 36192
@@ -380,15 +380,15 @@ Types:
       ByteSize: 8
       Pointee: 46 PointerType *table<string,main.bigStruct>
     - __kind: PointerType
-      ID: 56
+      ID: 53
       Name: '*[]int.array'
       ByteSize: 8
-      Pointee: 55 GoSliceDataType []int.array
+      Pointee: 52 GoSliceDataType []int.array
     - __kind: PointerType
-      ID: 58
+      ID: 55
       Name: '*[]string.array'
       ByteSize: 8
-      Pointee: 57 GoSliceDataType []string.array
+      Pointee: 54 GoSliceDataType []string.array
     - __kind: PointerType
       ID: 11
       Name: '*bool'
@@ -439,12 +439,12 @@ Types:
       GoKind: 22
       Pointee: 12 BaseType int64
     - __kind: PointerType
-      ID: 71
+      ID: 70
       Name: '*main.bigStruct'
       ByteSize: 8
       GoRuntimeType: 27808
       GoKind: 22
-      Pointee: 72 StructureType main.bigStruct
+      Pointee: 71 StructureType main.bigStruct
     - __kind: PointerType
       ID: 38
       Name: '*map<string,int>'
@@ -456,15 +456,15 @@ Types:
       ByteSize: 8
       Pointee: 44 GoSwissMapHeaderType map<string,main.bigStruct>
     - __kind: PointerType
-      ID: 60
+      ID: 58
       Name: '*noalg.map.group[string]int'
       ByteSize: 8
-      Pointee: 61 StructureType noalg.map.group[string]int
+      Pointee: 59 StructureType noalg.map.group[string]int
     - __kind: PointerType
-      ID: 67
+      ID: 66
       Name: '*noalg.map.group[string]main.bigStruct'
       ByteSize: 8
-      Pointee: 68 StructureType noalg.map.group[string]main.bigStruct
+      Pointee: 67 StructureType noalg.map.group[string]main.bigStruct
     - __kind: PointerType
       ID: 22
       Name: '*string'
@@ -473,20 +473,20 @@ Types:
       GoKind: 22
       Pointee: 9 GoStringHeaderType string
     - __kind: PointerType
-      ID: 54
+      ID: 51
       Name: '*string.str'
       ByteSize: 8
-      Pointee: 53 GoStringDataType string.str
+      Pointee: 50 GoStringDataType string.str
     - __kind: PointerType
       ID: 41
       Name: '*table<string,int>'
       ByteSize: 8
-      Pointee: 50 StructureType table<string,int>
+      Pointee: 56 StructureType table<string,int>
     - __kind: PointerType
       ID: 46
       Name: '*table<string,main.bigStruct>'
       ByteSize: 8
-      Pointee: 51 StructureType table<string,main.bigStruct>
+      Pointee: 64 StructureType table<string,main.bigStruct>
     - __kind: PointerType
       ID: 31
       Name: '*uint'
@@ -737,12 +737,12 @@ Types:
       HasCount: true
       Element: 9 GoStringHeaderType string
     - __kind: GoSliceDataType
-      ID: 64
+      ID: 62
       Name: '[]*table<string,int>.array'
       ByteSize: 8192
       Element: 41 PointerType *table<string,int>
     - __kind: GoSliceDataType
-      ID: 73
+      ID: 72
       Name: '[]*table<string,main.bigStruct>.array'
       ByteSize: 8192
       Element: 46 PointerType *table<string,main.bigStruct>
@@ -762,22 +762,22 @@ Types:
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 55 GoSliceDataType []int.array
+      Data: 52 GoSliceDataType []int.array
     - __kind: GoSliceDataType
-      ID: 55
+      ID: 52
       Name: '[]int.array'
       ByteSize: 2048
       Element: 7 BaseType int
     - __kind: GoSliceDataType
-      ID: 65
+      ID: 63
       Name: '[]noalg.map.group[string]int.array'
       ByteSize: 2048
-      Element: 61 StructureType noalg.map.group[string]int
+      Element: 59 StructureType noalg.map.group[string]int
     - __kind: GoSliceDataType
-      ID: 74
+      ID: 73
       Name: '[]noalg.map.group[string]main.bigStruct.array'
       ByteSize: 2048
-      Element: 68 StructureType noalg.map.group[string]main.bigStruct
+      Element: 67 StructureType noalg.map.group[string]main.bigStruct
     - __kind: GoSliceHeaderType
       ID: 35
       Name: '[]string'
@@ -794,9 +794,9 @@ Types:
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 57 GoSliceDataType []string.array
+      Data: 54 GoSliceDataType []string.array
     - __kind: GoSliceDataType
-      ID: 57
+      ID: 54
       Name: '[]string.array'
       ByteSize: 2048
       Element: 9 GoStringHeaderType string
@@ -844,33 +844,33 @@ Types:
       GoRuntimeType: 43712
       GoKind: 14
     - __kind: GoSwissMapGroupsType
-      ID: 59
+      ID: 57
       Name: groupReference<string,int>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 60 PointerType *noalg.map.group[string]int
+          Type: 58 PointerType *noalg.map.group[string]int
         - Name: lengthMask
           Offset: 8
           Type: 8 BaseType uint64
-      GroupType: 61 StructureType noalg.map.group[string]int
-      GroupSliceType: 65 GoSliceDataType []noalg.map.group[string]int.array
+      GroupType: 59 StructureType noalg.map.group[string]int
+      GroupSliceType: 63 GoSliceDataType []noalg.map.group[string]int.array
     - __kind: GoSwissMapGroupsType
-      ID: 66
+      ID: 65
       Name: groupReference<string,main.bigStruct>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 67 PointerType *noalg.map.group[string]main.bigStruct
+          Type: 66 PointerType *noalg.map.group[string]main.bigStruct
         - Name: lengthMask
           Offset: 8
           Type: 8 BaseType uint64
-      GroupType: 68 StructureType noalg.map.group[string]main.bigStruct
-      GroupSliceType: 74 GoSliceDataType []noalg.map.group[string]main.bigStruct.array
+      GroupType: 67 StructureType noalg.map.group[string]main.bigStruct
+      GroupSliceType: 73 GoSliceDataType []noalg.map.group[string]main.bigStruct.array
     - __kind: BaseType
       ID: 7
       Name: int
@@ -896,7 +896,7 @@ Types:
       GoRuntimeType: 42816
       GoKind: 3
     - __kind: StructureType
-      ID: 72
+      ID: 71
       Name: main.bigStruct
       ByteSize: 184
       GoRuntimeType: 124736
@@ -959,8 +959,8 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 8 BaseType uint64
-      TablePtrSliceType: 64 GoSliceDataType []*table<string,int>.array
-      GroupType: 61 StructureType noalg.map.group[string]int
+      TablePtrSliceType: 62 GoSliceDataType []*table<string,int>.array
+      GroupType: 59 StructureType noalg.map.group[string]int
     - __kind: GoSwissMapHeaderType
       ID: 44
       Name: map<string,main.bigStruct>
@@ -994,8 +994,8 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 8 BaseType uint64
-      TablePtrSliceType: 73 GoSliceDataType []*table<string,main.bigStruct>.array
-      GroupType: 68 StructureType noalg.map.group[string]main.bigStruct
+      TablePtrSliceType: 72 GoSliceDataType []*table<string,main.bigStruct>.array
+      GroupType: 67 StructureType noalg.map.group[string]main.bigStruct
     - __kind: GoMapType
       ID: 37
       Name: map[string]int
@@ -1011,25 +1011,25 @@ Types:
       GoKind: 21
       HeaderType: 44 GoSwissMapHeaderType map<string,main.bigStruct>
     - __kind: ArrayType
-      ID: 69
+      ID: 68
       Name: noalg.[8]struct { key string; elem *main.bigStruct }
       ByteSize: 192
       GoRuntimeType: 47776
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 70 StructureType noalg.struct { key string; elem *main.bigStruct }
+      Element: 69 StructureType noalg.struct { key string; elem *main.bigStruct }
     - __kind: ArrayType
-      ID: 62
+      ID: 60
       Name: noalg.[8]struct { key string; elem int }
       ByteSize: 192
       GoRuntimeType: 47584
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 63 StructureType noalg.struct { key string; elem int }
+      Element: 61 StructureType noalg.struct { key string; elem int }
     - __kind: StructureType
-      ID: 61
+      ID: 59
       Name: noalg.map.group[string]int
       ByteSize: 200
       GoRuntimeType: 77248
@@ -1040,9 +1040,9 @@ Types:
           Type: 8 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 62 ArrayType noalg.[8]struct { key string; elem int }
+          Type: 60 ArrayType noalg.[8]struct { key string; elem int }
     - __kind: StructureType
-      ID: 68
+      ID: 67
       Name: noalg.map.group[string]main.bigStruct
       ByteSize: 200
       GoRuntimeType: 77504
@@ -1053,9 +1053,9 @@ Types:
           Type: 8 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 69 ArrayType noalg.[8]struct { key string; elem *main.bigStruct }
+          Type: 68 ArrayType noalg.[8]struct { key string; elem *main.bigStruct }
     - __kind: StructureType
-      ID: 70
+      ID: 69
       Name: noalg.struct { key string; elem *main.bigStruct }
       ByteSize: 24
       GoRuntimeType: 77376
@@ -1066,9 +1066,9 @@ Types:
           Type: 9 GoStringHeaderType string
         - Name: elem
           Offset: 16
-          Type: 71 PointerType *main.bigStruct
+          Type: 70 PointerType *main.bigStruct
     - __kind: StructureType
-      ID: 63
+      ID: 61
       Name: noalg.struct { key string; elem int }
       ByteSize: 24
       GoRuntimeType: 77120
@@ -1089,17 +1089,17 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 54 PointerType *string.str
+          Type: 51 PointerType *string.str
         - Name: len
           Offset: 8
           Type: 7 BaseType int
-      Data: 53 GoStringDataType string.str
+      Data: 50 GoStringDataType string.str
     - __kind: GoStringDataType
-      ID: 53
+      ID: 50
       Name: string.str
       ByteSize: 2048
     - __kind: StructureType
-      ID: 50
+      ID: 56
       Name: table<string,int>
       ByteSize: 32
       GoKind: 25
@@ -1121,9 +1121,9 @@ Types:
           Type: 7 BaseType int
         - Name: groups
           Offset: 16
-          Type: 59 GoSwissMapGroupsType groupReference<string,int>
+          Type: 57 GoSwissMapGroupsType groupReference<string,int>
     - __kind: StructureType
-      ID: 51
+      ID: 64
       Name: table<string,main.bigStruct>
       ByteSize: 32
       GoKind: 25
@@ -1145,7 +1145,7 @@ Types:
           Type: 7 BaseType int
         - Name: groups
           Offset: 16
-          Type: 66 GoSwissMapGroupsType groupReference<string,main.bigStruct>
+          Type: 65 GoSwissMapGroupsType groupReference<string,main.bigStruct>
     - __kind: BaseType
       ID: 17
       Name: uint

--- a/pkg/dyninst/irgen/testdata/snapshot/simple.arch=amd64,toolchain=go1.25.0.yaml
+++ b/pkg/dyninst/irgen/testdata/snapshot/simple.arch=amd64,toolchain=go1.25.0.yaml
@@ -380,15 +380,15 @@ Types:
       ByteSize: 8
       Pointee: 46 PointerType *table<string,main.bigStruct>
     - __kind: PointerType
-      ID: 69
+      ID: 56
       Name: '*[]int.array'
       ByteSize: 8
-      Pointee: 68 GoSliceDataType []int.array
+      Pointee: 55 GoSliceDataType []int.array
     - __kind: PointerType
-      ID: 71
+      ID: 58
       Name: '*[]string.array'
       ByteSize: 8
-      Pointee: 70 GoSliceDataType []string.array
+      Pointee: 57 GoSliceDataType []string.array
     - __kind: PointerType
       ID: 11
       Name: '*bool'
@@ -439,12 +439,12 @@ Types:
       GoKind: 22
       Pointee: 12 BaseType int64
     - __kind: PointerType
-      ID: 63
+      ID: 71
       Name: '*main.bigStruct'
       ByteSize: 8
       GoRuntimeType: 27808
       GoKind: 22
-      Pointee: 64 StructureType main.bigStruct
+      Pointee: 72 StructureType main.bigStruct
     - __kind: PointerType
       ID: 38
       Name: '*map<string,int>'
@@ -456,15 +456,15 @@ Types:
       ByteSize: 8
       Pointee: 44 GoSwissMapHeaderType map<string,main.bigStruct>
     - __kind: PointerType
-      ID: 54
+      ID: 60
       Name: '*noalg.map.group[string]int'
       ByteSize: 8
-      Pointee: 55 StructureType noalg.map.group[string]int
+      Pointee: 61 StructureType noalg.map.group[string]int
     - __kind: PointerType
-      ID: 57
+      ID: 67
       Name: '*noalg.map.group[string]main.bigStruct'
       ByteSize: 8
-      Pointee: 58 StructureType noalg.map.group[string]main.bigStruct
+      Pointee: 68 StructureType noalg.map.group[string]main.bigStruct
     - __kind: PointerType
       ID: 22
       Name: '*string'
@@ -473,10 +473,10 @@ Types:
       GoKind: 22
       Pointee: 9 GoStringHeaderType string
     - __kind: PointerType
-      ID: 67
+      ID: 54
       Name: '*string.str'
       ByteSize: 8
-      Pointee: 66 GoStringDataType string.str
+      Pointee: 53 GoStringDataType string.str
     - __kind: PointerType
       ID: 41
       Name: '*table<string,int>'
@@ -710,7 +710,7 @@ Types:
                   Offset: 0
                   ByteSize: 24
     - __kind: ArrayType
-      ID: 65
+      ID: 75
       Name: '[128]uint8'
       ByteSize: 128
       GoRuntimeType: 47680
@@ -737,12 +737,12 @@ Types:
       HasCount: true
       Element: 9 GoStringHeaderType string
     - __kind: GoSliceDataType
-      ID: 72
+      ID: 64
       Name: '[]*table<string,int>.array'
       ByteSize: 8192
       Element: 41 PointerType *table<string,int>
     - __kind: GoSliceDataType
-      ID: 74
+      ID: 73
       Name: '[]*table<string,main.bigStruct>.array'
       ByteSize: 8192
       Element: 46 PointerType *table<string,main.bigStruct>
@@ -762,22 +762,22 @@ Types:
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 68 GoSliceDataType []int.array
+      Data: 55 GoSliceDataType []int.array
     - __kind: GoSliceDataType
-      ID: 68
+      ID: 55
       Name: '[]int.array'
       ByteSize: 2048
       Element: 7 BaseType int
     - __kind: GoSliceDataType
-      ID: 73
+      ID: 65
       Name: '[]noalg.map.group[string]int.array'
       ByteSize: 2048
-      Element: 55 StructureType noalg.map.group[string]int
+      Element: 61 StructureType noalg.map.group[string]int
     - __kind: GoSliceDataType
-      ID: 75
+      ID: 74
       Name: '[]noalg.map.group[string]main.bigStruct.array'
       ByteSize: 2048
-      Element: 58 StructureType noalg.map.group[string]main.bigStruct
+      Element: 68 StructureType noalg.map.group[string]main.bigStruct
     - __kind: GoSliceHeaderType
       ID: 35
       Name: '[]string'
@@ -794,9 +794,9 @@ Types:
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 70 GoSliceDataType []string.array
+      Data: 57 GoSliceDataType []string.array
     - __kind: GoSliceDataType
-      ID: 70
+      ID: 57
       Name: '[]string.array'
       ByteSize: 2048
       Element: 9 GoStringHeaderType string
@@ -844,33 +844,33 @@ Types:
       GoRuntimeType: 43712
       GoKind: 14
     - __kind: GoSwissMapGroupsType
-      ID: 53
+      ID: 59
       Name: groupReference<string,int>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 54 PointerType *noalg.map.group[string]int
+          Type: 60 PointerType *noalg.map.group[string]int
         - Name: lengthMask
           Offset: 8
           Type: 8 BaseType uint64
-      GroupType: 55 StructureType noalg.map.group[string]int
-      GroupSliceType: 73 GoSliceDataType []noalg.map.group[string]int.array
+      GroupType: 61 StructureType noalg.map.group[string]int
+      GroupSliceType: 65 GoSliceDataType []noalg.map.group[string]int.array
     - __kind: GoSwissMapGroupsType
-      ID: 56
+      ID: 66
       Name: groupReference<string,main.bigStruct>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 57 PointerType *noalg.map.group[string]main.bigStruct
+          Type: 67 PointerType *noalg.map.group[string]main.bigStruct
         - Name: lengthMask
           Offset: 8
           Type: 8 BaseType uint64
-      GroupType: 58 StructureType noalg.map.group[string]main.bigStruct
-      GroupSliceType: 75 GoSliceDataType []noalg.map.group[string]main.bigStruct.array
+      GroupType: 68 StructureType noalg.map.group[string]main.bigStruct
+      GroupSliceType: 74 GoSliceDataType []noalg.map.group[string]main.bigStruct.array
     - __kind: BaseType
       ID: 7
       Name: int
@@ -896,7 +896,7 @@ Types:
       GoRuntimeType: 42816
       GoKind: 3
     - __kind: StructureType
-      ID: 64
+      ID: 72
       Name: main.bigStruct
       ByteSize: 184
       GoRuntimeType: 124736
@@ -925,7 +925,7 @@ Types:
           Type: 7 BaseType int
         - Name: data
           Offset: 56
-          Type: 65 ArrayType [128]uint8
+          Type: 75 ArrayType [128]uint8
     - __kind: GoSwissMapHeaderType
       ID: 39
       Name: map<string,int>
@@ -959,8 +959,8 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 8 BaseType uint64
-      TablePtrSliceType: 72 GoSliceDataType []*table<string,int>.array
-      GroupType: 55 StructureType noalg.map.group[string]int
+      TablePtrSliceType: 64 GoSliceDataType []*table<string,int>.array
+      GroupType: 61 StructureType noalg.map.group[string]int
     - __kind: GoSwissMapHeaderType
       ID: 44
       Name: map<string,main.bigStruct>
@@ -994,8 +994,8 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 8 BaseType uint64
-      TablePtrSliceType: 74 GoSliceDataType []*table<string,main.bigStruct>.array
-      GroupType: 58 StructureType noalg.map.group[string]main.bigStruct
+      TablePtrSliceType: 73 GoSliceDataType []*table<string,main.bigStruct>.array
+      GroupType: 68 StructureType noalg.map.group[string]main.bigStruct
     - __kind: GoMapType
       ID: 37
       Name: map[string]int
@@ -1011,25 +1011,25 @@ Types:
       GoKind: 21
       HeaderType: 44 GoSwissMapHeaderType map<string,main.bigStruct>
     - __kind: ArrayType
-      ID: 61
+      ID: 69
       Name: noalg.[8]struct { key string; elem *main.bigStruct }
       ByteSize: 192
       GoRuntimeType: 47776
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 62 StructureType noalg.struct { key string; elem *main.bigStruct }
+      Element: 70 StructureType noalg.struct { key string; elem *main.bigStruct }
     - __kind: ArrayType
-      ID: 59
+      ID: 62
       Name: noalg.[8]struct { key string; elem int }
       ByteSize: 192
       GoRuntimeType: 47584
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 60 StructureType noalg.struct { key string; elem int }
+      Element: 63 StructureType noalg.struct { key string; elem int }
     - __kind: StructureType
-      ID: 55
+      ID: 61
       Name: noalg.map.group[string]int
       ByteSize: 200
       GoRuntimeType: 77248
@@ -1040,9 +1040,9 @@ Types:
           Type: 8 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 59 ArrayType noalg.[8]struct { key string; elem int }
+          Type: 62 ArrayType noalg.[8]struct { key string; elem int }
     - __kind: StructureType
-      ID: 58
+      ID: 68
       Name: noalg.map.group[string]main.bigStruct
       ByteSize: 200
       GoRuntimeType: 77504
@@ -1053,9 +1053,9 @@ Types:
           Type: 8 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 61 ArrayType noalg.[8]struct { key string; elem *main.bigStruct }
+          Type: 69 ArrayType noalg.[8]struct { key string; elem *main.bigStruct }
     - __kind: StructureType
-      ID: 62
+      ID: 70
       Name: noalg.struct { key string; elem *main.bigStruct }
       ByteSize: 24
       GoRuntimeType: 77376
@@ -1066,9 +1066,9 @@ Types:
           Type: 9 GoStringHeaderType string
         - Name: elem
           Offset: 16
-          Type: 63 PointerType *main.bigStruct
+          Type: 71 PointerType *main.bigStruct
     - __kind: StructureType
-      ID: 60
+      ID: 63
       Name: noalg.struct { key string; elem int }
       ByteSize: 24
       GoRuntimeType: 77120
@@ -1089,13 +1089,13 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 67 PointerType *string.str
+          Type: 54 PointerType *string.str
         - Name: len
           Offset: 8
           Type: 7 BaseType int
-      Data: 66 GoStringDataType string.str
+      Data: 53 GoStringDataType string.str
     - __kind: GoStringDataType
-      ID: 66
+      ID: 53
       Name: string.str
       ByteSize: 2048
     - __kind: StructureType
@@ -1121,7 +1121,7 @@ Types:
           Type: 7 BaseType int
         - Name: groups
           Offset: 16
-          Type: 53 GoSwissMapGroupsType groupReference<string,int>
+          Type: 59 GoSwissMapGroupsType groupReference<string,int>
     - __kind: StructureType
       ID: 51
       Name: table<string,main.bigStruct>
@@ -1145,7 +1145,7 @@ Types:
           Type: 7 BaseType int
         - Name: groups
           Offset: 16
-          Type: 56 GoSwissMapGroupsType groupReference<string,main.bigStruct>
+          Type: 66 GoSwissMapGroupsType groupReference<string,main.bigStruct>
     - __kind: BaseType
       ID: 17
       Name: uint

--- a/pkg/dyninst/irgen/testdata/snapshot/simple.arch=amd64,toolchain=go1.25.0.yaml
+++ b/pkg/dyninst/irgen/testdata/snapshot/simple.arch=amd64,toolchain=go1.25.0.yaml
@@ -341,12 +341,6 @@ Subprograms:
           IsParameter: true
           IsReturn: false
 Types:
-    - __kind: BaseType
-      ID: 1
-      Name: int
-      ByteSize: 8
-      GoRuntimeType: 43328
-      GoKind: 2
     - __kind: PointerType
       ID: 2
       Name: '*****int'
@@ -376,26 +370,151 @@ Types:
       GoKind: 22
       Pointee: 6 PointerType *int
     - __kind: PointerType
+      ID: 20
+      Name: '**table<string,int>'
+      ByteSize: 8
+      Pointee: 21 PointerType *table<string,int>
+    - __kind: PointerType
+      ID: 33
+      Name: '**table<string,main.bigStruct>'
+      ByteSize: 8
+      Pointee: 34 PointerType *table<string,main.bigStruct>
+    - __kind: PointerType
+      ID: 69
+      Name: '*[]int.array'
+      ByteSize: 8
+      Pointee: 68 GoSliceDataType []int.array
+    - __kind: PointerType
+      ID: 71
+      Name: '*[]string.array'
+      ByteSize: 8
+      Pointee: 70 GoSliceDataType []string.array
+    - __kind: PointerType
+      ID: 46
+      Name: '*bool'
+      ByteSize: 8
+      GoRuntimeType: 30432
+      GoKind: 22
+      Pointee: 29 BaseType bool
+    - __kind: PointerType
+      ID: 62
+      Name: '*error'
+      ByteSize: 8
+      GoRuntimeType: 29344
+      GoKind: 22
+      Pointee: 48 GoInterfaceType error
+    - __kind: PointerType
+      ID: 63
+      Name: '*float32'
+      ByteSize: 8
+      GoRuntimeType: 30304
+      GoKind: 22
+      Pointee: 53 BaseType float32
+    - __kind: PointerType
+      ID: 59
+      Name: '*float64'
+      ByteSize: 8
+      GoRuntimeType: 30368
+      GoKind: 22
+      Pointee: 50 BaseType float64
+    - __kind: PointerType
       ID: 6
       Name: '*int'
       ByteSize: 8
       GoRuntimeType: 29984
       GoKind: 22
       Pointee: 1 BaseType int
-    - __kind: GoStringHeaderType
-      ID: 7
-      Name: string
-      ByteSize: 16
-      GoRuntimeType: 42752
-      GoKind: 24
-      RawFields:
-        - Name: str
-          Offset: 0
-          Type: 67 PointerType *string.str
-        - Name: len
-          Offset: 8
-          Type: 1 BaseType int
-      Data: 66 GoStringDataType string.str
+    - __kind: PointerType
+      ID: 55
+      Name: '*int32'
+      ByteSize: 8
+      GoRuntimeType: 29728
+      GoKind: 22
+      Pointee: 45 BaseType int32
+    - __kind: PointerType
+      ID: 60
+      Name: '*int64'
+      ByteSize: 8
+      GoRuntimeType: 29856
+      GoKind: 22
+      Pointee: 47 BaseType int64
+    - __kind: PointerType
+      ID: 41
+      Name: '*main.bigStruct'
+      ByteSize: 8
+      GoRuntimeType: 27808
+      GoKind: 22
+      Pointee: 42 StructureType main.bigStruct
+    - __kind: PointerType
+      ID: 16
+      Name: '*map<string,int>'
+      ByteSize: 8
+      Pointee: 17 GoSwissMapHeaderType map<string,int>
+    - __kind: PointerType
+      ID: 31
+      Name: '*map<string,main.bigStruct>'
+      ByteSize: 8
+      Pointee: 32 GoSwissMapHeaderType map<string,main.bigStruct>
+    - __kind: PointerType
+      ID: 25
+      Name: '*noalg.map.group[string]int'
+      ByteSize: 8
+      Pointee: 26 StructureType noalg.map.group[string]int
+    - __kind: PointerType
+      ID: 37
+      Name: '*noalg.map.group[string]main.bigStruct'
+      ByteSize: 8
+      Pointee: 38 StructureType noalg.map.group[string]main.bigStruct
+    - __kind: PointerType
+      ID: 13
+      Name: '*string'
+      ByteSize: 8
+      GoRuntimeType: 29408
+      GoKind: 22
+      Pointee: 7 GoStringHeaderType string
+    - __kind: PointerType
+      ID: 67
+      Name: '*string.str'
+      ByteSize: 8
+      Pointee: 66 GoStringDataType string.str
+    - __kind: PointerType
+      ID: 21
+      Name: '*table<string,int>'
+      ByteSize: 8
+      Pointee: 22 StructureType table<string,int>
+    - __kind: PointerType
+      ID: 34
+      Name: '*table<string,main.bigStruct>'
+      ByteSize: 8
+      Pointee: 35 StructureType table<string,main.bigStruct>
+    - __kind: PointerType
+      ID: 64
+      Name: '*uint'
+      ByteSize: 8
+      GoRuntimeType: 30048
+      GoKind: 22
+      Pointee: 52 BaseType uint
+    - __kind: PointerType
+      ID: 65
+      Name: '*uint16'
+      ByteSize: 8
+      GoRuntimeType: 29664
+      GoKind: 22
+      Pointee: 23 BaseType uint16
+    - __kind: PointerType
+      ID: 56
+      Name: '*uint32'
+      ByteSize: 8
+      GoRuntimeType: 29792
+      GoKind: 22
+      Pointee: 44 BaseType uint32
+    - __kind: PointerType
+      ID: 61
+      Name: '*uint64'
+      ByteSize: 8
+      GoRuntimeType: 29920
+      GoKind: 22
+      Pointee: 18 BaseType uint64
     - __kind: PointerType
       ID: 8
       Name: '*uint8'
@@ -403,12 +522,230 @@ Types:
       GoRuntimeType: 29536
       GoKind: 22
       Pointee: 9 BaseType uint8
-    - __kind: BaseType
-      ID: 9
-      Name: uint8
-      ByteSize: 1
-      GoRuntimeType: 42880
-      GoKind: 8
+    - __kind: PointerType
+      ID: 54
+      Name: '*uintptr'
+      ByteSize: 8
+      GoRuntimeType: 30112
+      GoKind: 22
+      Pointee: 19 BaseType uintptr
+    - __kind: EventRootType
+      ID: 86
+      Name: Probe[main.PointerChainArg]
+      ByteSize: 9
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: ptr
+          Offset: 1
+          Expression:
+            Type: 2 PointerType *****int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 2, index: 0, name: ptr}
+                  Offset: 0
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 87
+      Name: Probe[main.PointerSmallChainArg]
+      ByteSize: 9
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: ptr
+          Offset: 1
+          Expression:
+            Type: 5 PointerType **int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 3, index: 0, name: ptr}
+                  Offset: 0
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 84
+      Name: Probe[main.bigMapArg]
+      ByteSize: 9
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: m
+          Offset: 1
+          Expression:
+            Type: 30 GoMapType map[string]main.bigStruct
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 12, index: 0, name: m}
+                  Offset: 0
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 85
+      Name: Probe[main.inlined]
+      ByteSize: 9
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: x
+          Offset: 1
+          Expression:
+            Type: 1 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 1, index: 0, name: x}
+                  Offset: 0
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 76
+      Name: Probe[main.intArg]
+      ByteSize: 9
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: x
+          Offset: 1
+          Expression:
+            Type: 1 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 4, index: 0, name: x}
+                  Offset: 0
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 79
+      Name: Probe[main.intArrayArg]
+      ByteSize: 25
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: s
+          Offset: 1
+          Expression:
+            Type: 11 ArrayType [3]int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 7, index: 0, name: s}
+                  Offset: 0
+                  ByteSize: 24
+    - __kind: EventRootType
+      ID: 78
+      Name: Probe[main.intSliceArg]
+      ByteSize: 25
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: s
+          Offset: 1
+          Expression:
+            Type: 10 GoSliceHeaderType []int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 6, index: 0, name: s}
+                  Offset: 0
+                  ByteSize: 24
+    - __kind: EventRootType
+      ID: 83
+      Name: Probe[main.mapArg]
+      ByteSize: 9
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: m
+          Offset: 1
+          Expression:
+            Type: 15 GoMapType map[string]int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 11, index: 0, name: m}
+                  Offset: 0
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 77
+      Name: Probe[main.stringArg]
+      ByteSize: 17
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: s
+          Offset: 1
+          Expression:
+            Type: 7 GoStringHeaderType string
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 5, index: 0, name: s}
+                  Offset: 0
+                  ByteSize: 16
+    - __kind: EventRootType
+      ID: 82
+      Name: Probe[main.stringArrayArgFrameless]
+      ByteSize: 49
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: s
+          Offset: 1
+          Expression:
+            Type: 14 ArrayType [3]string
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 10, index: 0, name: s}
+                  Offset: 0
+                  ByteSize: 48
+    - __kind: EventRootType
+      ID: 81
+      Name: Probe[main.stringArrayArg]
+      ByteSize: 49
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: s
+          Offset: 1
+          Expression:
+            Type: 14 ArrayType [3]string
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 9, index: 0, name: s}
+                  Offset: 0
+                  ByteSize: 48
+    - __kind: EventRootType
+      ID: 80
+      Name: Probe[main.stringSliceArg]
+      ByteSize: 25
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: s
+          Offset: 1
+          Expression:
+            Type: 12 GoSliceHeaderType []string
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 8, index: 0, name: s}
+                  Offset: 0
+                  ByteSize: 24
+    - __kind: ArrayType
+      ID: 43
+      Name: '[128]uint8'
+      ByteSize: 128
+      GoRuntimeType: 47680
+      GoKind: 17
+      Count: 128
+      HasCount: true
+      Element: 9 BaseType uint8
+    - __kind: ArrayType
+      ID: 11
+      Name: '[3]int'
+      ByteSize: 24
+      GoRuntimeType: 47392
+      GoKind: 17
+      Count: 3
+      HasCount: true
+      Element: 1 BaseType int
+    - __kind: ArrayType
+      ID: 14
+      Name: '[3]string'
+      ByteSize: 48
+      GoRuntimeType: 47488
+      GoKind: 17
+      Count: 3
+      HasCount: true
+      Element: 7 GoStringHeaderType string
+    - __kind: GoSliceDataType
+      ID: 72
+      Name: '[]*table<string,int>.array'
+      ByteSize: 8192
+      Element: 21 PointerType *table<string,int>
+    - __kind: GoSliceDataType
+      ID: 74
+      Name: '[]*table<string,main.bigStruct>.array'
+      ByteSize: 8192
+      Element: 34 PointerType *table<string,main.bigStruct>
     - __kind: GoSliceHeaderType
       ID: 10
       Name: '[]int'
@@ -426,15 +763,21 @@ Types:
           Offset: 16
           Type: 1 BaseType int
       Data: 68 GoSliceDataType []int.array
-    - __kind: ArrayType
-      ID: 11
-      Name: '[3]int'
-      ByteSize: 24
-      GoRuntimeType: 47392
-      GoKind: 17
-      Count: 3
-      HasCount: true
+    - __kind: GoSliceDataType
+      ID: 68
+      Name: '[]int.array'
+      ByteSize: 2048
       Element: 1 BaseType int
+    - __kind: GoSliceDataType
+      ID: 73
+      Name: '[]noalg.map.group[string]int.array'
+      ByteSize: 2048
+      Element: 26 StructureType noalg.map.group[string]int
+    - __kind: GoSliceDataType
+      ID: 75
+      Name: '[]noalg.map.group[string]main.bigStruct.array'
+      ByteSize: 2048
+      Element: 38 StructureType noalg.map.group[string]main.bigStruct
     - __kind: GoSliceHeaderType
       ID: 12
       Name: '[]string'
@@ -452,34 +795,137 @@ Types:
           Offset: 16
           Type: 1 BaseType int
       Data: 70 GoSliceDataType []string.array
-    - __kind: PointerType
-      ID: 13
-      Name: '*string'
-      ByteSize: 8
-      GoRuntimeType: 29408
-      GoKind: 22
-      Pointee: 7 GoStringHeaderType string
-    - __kind: ArrayType
-      ID: 14
-      Name: '[3]string'
-      ByteSize: 48
-      GoRuntimeType: 47488
-      GoKind: 17
-      Count: 3
-      HasCount: true
+    - __kind: GoSliceDataType
+      ID: 70
+      Name: '[]string.array'
+      ByteSize: 2048
       Element: 7 GoStringHeaderType string
-    - __kind: GoMapType
-      ID: 15
-      Name: map[string]int
+    - __kind: BaseType
+      ID: 29
+      Name: bool
+      ByteSize: 1
+      GoRuntimeType: 43776
+      GoKind: 1
+    - __kind: BaseType
+      ID: 58
+      Name: complex128
+      ByteSize: 16
+      GoRuntimeType: 43584
+      GoKind: 16
+    - __kind: BaseType
+      ID: 57
+      Name: complex64
       ByteSize: 8
-      GoRuntimeType: 70080
-      GoKind: 21
-      HeaderType: 17 GoSwissMapHeaderType map<string,int>
-    - __kind: PointerType
-      ID: 16
-      Name: '*map<string,int>'
+      GoRuntimeType: 43520
+      GoKind: 15
+    - __kind: GoInterfaceType
+      ID: 48
+      Name: error
+      ByteSize: 16
+      GoRuntimeType: 65856
+      GoKind: 20
+      RawFields:
+        - Name: tab
+          Offset: 0
+          Type: 49 VoidPointerType unsafe.Pointer
+        - Name: data
+          Offset: 8
+          Type: 49 VoidPointerType unsafe.Pointer
+    - __kind: BaseType
+      ID: 53
+      Name: float32
+      ByteSize: 4
+      GoRuntimeType: 43648
+      GoKind: 13
+    - __kind: BaseType
+      ID: 50
+      Name: float64
       ByteSize: 8
-      Pointee: 17 GoSwissMapHeaderType map<string,int>
+      GoRuntimeType: 43712
+      GoKind: 14
+    - __kind: GoSwissMapGroupsType
+      ID: 24
+      Name: groupReference<string,int>
+      ByteSize: 16
+      GoKind: 25
+      RawFields:
+        - Name: data
+          Offset: 0
+          Type: 25 PointerType *noalg.map.group[string]int
+        - Name: lengthMask
+          Offset: 8
+          Type: 18 BaseType uint64
+      GroupType: 26 StructureType noalg.map.group[string]int
+      GroupSliceType: 73 GoSliceDataType []noalg.map.group[string]int.array
+    - __kind: GoSwissMapGroupsType
+      ID: 36
+      Name: groupReference<string,main.bigStruct>
+      ByteSize: 16
+      GoKind: 25
+      RawFields:
+        - Name: data
+          Offset: 0
+          Type: 37 PointerType *noalg.map.group[string]main.bigStruct
+        - Name: lengthMask
+          Offset: 8
+          Type: 18 BaseType uint64
+      GroupType: 38 StructureType noalg.map.group[string]main.bigStruct
+      GroupSliceType: 75 GoSliceDataType []noalg.map.group[string]main.bigStruct.array
+    - __kind: BaseType
+      ID: 1
+      Name: int
+      ByteSize: 8
+      GoRuntimeType: 43328
+      GoKind: 2
+    - __kind: BaseType
+      ID: 45
+      Name: int32
+      ByteSize: 4
+      GoRuntimeType: 43072
+      GoKind: 5
+    - __kind: BaseType
+      ID: 47
+      Name: int64
+      ByteSize: 8
+      GoRuntimeType: 43200
+      GoKind: 6
+    - __kind: BaseType
+      ID: 51
+      Name: int8
+      ByteSize: 1
+      GoRuntimeType: 42816
+      GoKind: 3
+    - __kind: StructureType
+      ID: 42
+      Name: main.bigStruct
+      ByteSize: 184
+      GoRuntimeType: 124736
+      GoKind: 25
+      RawFields:
+        - Name: Field1
+          Offset: 0
+          Type: 1 BaseType int
+        - Name: Field2
+          Offset: 8
+          Type: 1 BaseType int
+        - Name: Field3
+          Offset: 16
+          Type: 1 BaseType int
+        - Name: Field4
+          Offset: 24
+          Type: 1 BaseType int
+        - Name: Field5
+          Offset: 32
+          Type: 1 BaseType int
+        - Name: Field6
+          Offset: 40
+          Type: 1 BaseType int
+        - Name: Field7
+          Offset: 48
+          Type: 1 BaseType int
+        - Name: data
+          Offset: 56
+          Type: 43 ArrayType [128]uint8
     - __kind: GoSwissMapHeaderType
       ID: 17
       Name: map<string,int>
@@ -515,130 +961,6 @@ Types:
           Type: 18 BaseType uint64
       TablePtrSliceType: 72 GoSliceDataType []*table<string,int>.array
       GroupType: 26 StructureType noalg.map.group[string]int
-    - __kind: BaseType
-      ID: 18
-      Name: uint64
-      ByteSize: 8
-      GoRuntimeType: 43264
-      GoKind: 11
-    - __kind: BaseType
-      ID: 19
-      Name: uintptr
-      ByteSize: 8
-      GoRuntimeType: 43456
-      GoKind: 12
-    - __kind: PointerType
-      ID: 20
-      Name: '**table<string,int>'
-      ByteSize: 8
-      Pointee: 21 PointerType *table<string,int>
-    - __kind: PointerType
-      ID: 21
-      Name: '*table<string,int>'
-      ByteSize: 8
-      Pointee: 22 StructureType table<string,int>
-    - __kind: StructureType
-      ID: 22
-      Name: table<string,int>
-      ByteSize: 32
-      GoKind: 25
-      RawFields:
-        - Name: used
-          Offset: 0
-          Type: 23 BaseType uint16
-        - Name: capacity
-          Offset: 2
-          Type: 23 BaseType uint16
-        - Name: growthLeft
-          Offset: 4
-          Type: 23 BaseType uint16
-        - Name: localDepth
-          Offset: 6
-          Type: 9 BaseType uint8
-        - Name: index
-          Offset: 8
-          Type: 1 BaseType int
-        - Name: groups
-          Offset: 16
-          Type: 24 GoSwissMapGroupsType groupReference<string,int>
-    - __kind: BaseType
-      ID: 23
-      Name: uint16
-      ByteSize: 2
-      GoRuntimeType: 43008
-      GoKind: 9
-    - __kind: GoSwissMapGroupsType
-      ID: 24
-      Name: groupReference<string,int>
-      ByteSize: 16
-      GoKind: 25
-      RawFields:
-        - Name: data
-          Offset: 0
-          Type: 25 PointerType *noalg.map.group[string]int
-        - Name: lengthMask
-          Offset: 8
-          Type: 18 BaseType uint64
-      GroupType: 26 StructureType noalg.map.group[string]int
-      GroupSliceType: 73 GoSliceDataType []noalg.map.group[string]int.array
-    - __kind: PointerType
-      ID: 25
-      Name: '*noalg.map.group[string]int'
-      ByteSize: 8
-      Pointee: 26 StructureType noalg.map.group[string]int
-    - __kind: StructureType
-      ID: 26
-      Name: noalg.map.group[string]int
-      ByteSize: 200
-      GoRuntimeType: 77248
-      GoKind: 25
-      RawFields:
-        - Name: ctrl
-          Offset: 0
-          Type: 18 BaseType uint64
-        - Name: slots
-          Offset: 8
-          Type: 27 ArrayType noalg.[8]struct { key string; elem int }
-    - __kind: ArrayType
-      ID: 27
-      Name: noalg.[8]struct { key string; elem int }
-      ByteSize: 192
-      GoRuntimeType: 47584
-      GoKind: 17
-      Count: 8
-      HasCount: true
-      Element: 28 StructureType noalg.struct { key string; elem int }
-    - __kind: StructureType
-      ID: 28
-      Name: noalg.struct { key string; elem int }
-      ByteSize: 24
-      GoRuntimeType: 77120
-      GoKind: 25
-      RawFields:
-        - Name: key
-          Offset: 0
-          Type: 7 GoStringHeaderType string
-        - Name: elem
-          Offset: 16
-          Type: 1 BaseType int
-    - __kind: BaseType
-      ID: 29
-      Name: bool
-      ByteSize: 1
-      GoRuntimeType: 43776
-      GoKind: 1
-    - __kind: GoMapType
-      ID: 30
-      Name: map[string]main.bigStruct
-      ByteSize: 8
-      GoRuntimeType: 70208
-      GoKind: 21
-      HeaderType: 32 GoSwissMapHeaderType map<string,main.bigStruct>
-    - __kind: PointerType
-      ID: 31
-      Name: '*map<string,main.bigStruct>'
-      ByteSize: 8
-      Pointee: 32 GoSwissMapHeaderType map<string,main.bigStruct>
     - __kind: GoSwissMapHeaderType
       ID: 32
       Name: map<string,main.bigStruct>
@@ -674,16 +996,132 @@ Types:
           Type: 18 BaseType uint64
       TablePtrSliceType: 74 GoSliceDataType []*table<string,main.bigStruct>.array
       GroupType: 38 StructureType noalg.map.group[string]main.bigStruct
-    - __kind: PointerType
-      ID: 33
-      Name: '**table<string,main.bigStruct>'
+    - __kind: GoMapType
+      ID: 15
+      Name: map[string]int
       ByteSize: 8
-      Pointee: 34 PointerType *table<string,main.bigStruct>
-    - __kind: PointerType
-      ID: 34
-      Name: '*table<string,main.bigStruct>'
+      GoRuntimeType: 70080
+      GoKind: 21
+      HeaderType: 17 GoSwissMapHeaderType map<string,int>
+    - __kind: GoMapType
+      ID: 30
+      Name: map[string]main.bigStruct
       ByteSize: 8
-      Pointee: 35 StructureType table<string,main.bigStruct>
+      GoRuntimeType: 70208
+      GoKind: 21
+      HeaderType: 32 GoSwissMapHeaderType map<string,main.bigStruct>
+    - __kind: ArrayType
+      ID: 39
+      Name: noalg.[8]struct { key string; elem *main.bigStruct }
+      ByteSize: 192
+      GoRuntimeType: 47776
+      GoKind: 17
+      Count: 8
+      HasCount: true
+      Element: 40 StructureType noalg.struct { key string; elem *main.bigStruct }
+    - __kind: ArrayType
+      ID: 27
+      Name: noalg.[8]struct { key string; elem int }
+      ByteSize: 192
+      GoRuntimeType: 47584
+      GoKind: 17
+      Count: 8
+      HasCount: true
+      Element: 28 StructureType noalg.struct { key string; elem int }
+    - __kind: StructureType
+      ID: 26
+      Name: noalg.map.group[string]int
+      ByteSize: 200
+      GoRuntimeType: 77248
+      GoKind: 25
+      RawFields:
+        - Name: ctrl
+          Offset: 0
+          Type: 18 BaseType uint64
+        - Name: slots
+          Offset: 8
+          Type: 27 ArrayType noalg.[8]struct { key string; elem int }
+    - __kind: StructureType
+      ID: 38
+      Name: noalg.map.group[string]main.bigStruct
+      ByteSize: 200
+      GoRuntimeType: 77504
+      GoKind: 25
+      RawFields:
+        - Name: ctrl
+          Offset: 0
+          Type: 18 BaseType uint64
+        - Name: slots
+          Offset: 8
+          Type: 39 ArrayType noalg.[8]struct { key string; elem *main.bigStruct }
+    - __kind: StructureType
+      ID: 40
+      Name: noalg.struct { key string; elem *main.bigStruct }
+      ByteSize: 24
+      GoRuntimeType: 77376
+      GoKind: 25
+      RawFields:
+        - Name: key
+          Offset: 0
+          Type: 7 GoStringHeaderType string
+        - Name: elem
+          Offset: 16
+          Type: 41 PointerType *main.bigStruct
+    - __kind: StructureType
+      ID: 28
+      Name: noalg.struct { key string; elem int }
+      ByteSize: 24
+      GoRuntimeType: 77120
+      GoKind: 25
+      RawFields:
+        - Name: key
+          Offset: 0
+          Type: 7 GoStringHeaderType string
+        - Name: elem
+          Offset: 16
+          Type: 1 BaseType int
+    - __kind: GoStringHeaderType
+      ID: 7
+      Name: string
+      ByteSize: 16
+      GoRuntimeType: 42752
+      GoKind: 24
+      RawFields:
+        - Name: str
+          Offset: 0
+          Type: 67 PointerType *string.str
+        - Name: len
+          Offset: 8
+          Type: 1 BaseType int
+      Data: 66 GoStringDataType string.str
+    - __kind: GoStringDataType
+      ID: 66
+      Name: string.str
+      ByteSize: 2048
+    - __kind: StructureType
+      ID: 22
+      Name: table<string,int>
+      ByteSize: 32
+      GoKind: 25
+      RawFields:
+        - Name: used
+          Offset: 0
+          Type: 23 BaseType uint16
+        - Name: capacity
+          Offset: 2
+          Type: 23 BaseType uint16
+        - Name: growthLeft
+          Offset: 4
+          Type: 23 BaseType uint16
+        - Name: localDepth
+          Offset: 6
+          Type: 9 BaseType uint8
+        - Name: index
+          Offset: 8
+          Type: 1 BaseType int
+        - Name: groups
+          Offset: 16
+          Type: 24 GoSwissMapGroupsType groupReference<string,int>
     - __kind: StructureType
       ID: 35
       Name: table<string,main.bigStruct>
@@ -708,163 +1146,6 @@ Types:
         - Name: groups
           Offset: 16
           Type: 36 GoSwissMapGroupsType groupReference<string,main.bigStruct>
-    - __kind: GoSwissMapGroupsType
-      ID: 36
-      Name: groupReference<string,main.bigStruct>
-      ByteSize: 16
-      GoKind: 25
-      RawFields:
-        - Name: data
-          Offset: 0
-          Type: 37 PointerType *noalg.map.group[string]main.bigStruct
-        - Name: lengthMask
-          Offset: 8
-          Type: 18 BaseType uint64
-      GroupType: 38 StructureType noalg.map.group[string]main.bigStruct
-      GroupSliceType: 75 GoSliceDataType []noalg.map.group[string]main.bigStruct.array
-    - __kind: PointerType
-      ID: 37
-      Name: '*noalg.map.group[string]main.bigStruct'
-      ByteSize: 8
-      Pointee: 38 StructureType noalg.map.group[string]main.bigStruct
-    - __kind: StructureType
-      ID: 38
-      Name: noalg.map.group[string]main.bigStruct
-      ByteSize: 200
-      GoRuntimeType: 77504
-      GoKind: 25
-      RawFields:
-        - Name: ctrl
-          Offset: 0
-          Type: 18 BaseType uint64
-        - Name: slots
-          Offset: 8
-          Type: 39 ArrayType noalg.[8]struct { key string; elem *main.bigStruct }
-    - __kind: ArrayType
-      ID: 39
-      Name: noalg.[8]struct { key string; elem *main.bigStruct }
-      ByteSize: 192
-      GoRuntimeType: 47776
-      GoKind: 17
-      Count: 8
-      HasCount: true
-      Element: 40 StructureType noalg.struct { key string; elem *main.bigStruct }
-    - __kind: StructureType
-      ID: 40
-      Name: noalg.struct { key string; elem *main.bigStruct }
-      ByteSize: 24
-      GoRuntimeType: 77376
-      GoKind: 25
-      RawFields:
-        - Name: key
-          Offset: 0
-          Type: 7 GoStringHeaderType string
-        - Name: elem
-          Offset: 16
-          Type: 41 PointerType *main.bigStruct
-    - __kind: PointerType
-      ID: 41
-      Name: '*main.bigStruct'
-      ByteSize: 8
-      GoRuntimeType: 27808
-      GoKind: 22
-      Pointee: 42 StructureType main.bigStruct
-    - __kind: StructureType
-      ID: 42
-      Name: main.bigStruct
-      ByteSize: 184
-      GoRuntimeType: 124736
-      GoKind: 25
-      RawFields:
-        - Name: Field1
-          Offset: 0
-          Type: 1 BaseType int
-        - Name: Field2
-          Offset: 8
-          Type: 1 BaseType int
-        - Name: Field3
-          Offset: 16
-          Type: 1 BaseType int
-        - Name: Field4
-          Offset: 24
-          Type: 1 BaseType int
-        - Name: Field5
-          Offset: 32
-          Type: 1 BaseType int
-        - Name: Field6
-          Offset: 40
-          Type: 1 BaseType int
-        - Name: Field7
-          Offset: 48
-          Type: 1 BaseType int
-        - Name: data
-          Offset: 56
-          Type: 43 ArrayType [128]uint8
-    - __kind: ArrayType
-      ID: 43
-      Name: '[128]uint8'
-      ByteSize: 128
-      GoRuntimeType: 47680
-      GoKind: 17
-      Count: 128
-      HasCount: true
-      Element: 9 BaseType uint8
-    - __kind: BaseType
-      ID: 44
-      Name: uint32
-      ByteSize: 4
-      GoRuntimeType: 43136
-      GoKind: 10
-    - __kind: BaseType
-      ID: 45
-      Name: int32
-      ByteSize: 4
-      GoRuntimeType: 43072
-      GoKind: 5
-    - __kind: PointerType
-      ID: 46
-      Name: '*bool'
-      ByteSize: 8
-      GoRuntimeType: 30432
-      GoKind: 22
-      Pointee: 29 BaseType bool
-    - __kind: BaseType
-      ID: 47
-      Name: int64
-      ByteSize: 8
-      GoRuntimeType: 43200
-      GoKind: 6
-    - __kind: GoInterfaceType
-      ID: 48
-      Name: error
-      ByteSize: 16
-      GoRuntimeType: 65856
-      GoKind: 20
-      RawFields:
-        - Name: tab
-          Offset: 0
-          Type: 49 VoidPointerType unsafe.Pointer
-        - Name: data
-          Offset: 8
-          Type: 49 VoidPointerType unsafe.Pointer
-    - __kind: VoidPointerType
-      ID: 49
-      Name: unsafe.Pointer
-      ByteSize: 8
-      GoRuntimeType: 43840
-      GoKind: 26
-    - __kind: BaseType
-      ID: 50
-      Name: float64
-      ByteSize: 8
-      GoRuntimeType: 43712
-      GoKind: 14
-    - __kind: BaseType
-      ID: 51
-      Name: int8
-      ByteSize: 1
-      GoRuntimeType: 42816
-      GoKind: 3
     - __kind: BaseType
       ID: 52
       Name: uint
@@ -872,322 +1153,41 @@ Types:
       GoRuntimeType: 43392
       GoKind: 7
     - __kind: BaseType
-      ID: 53
-      Name: float32
+      ID: 23
+      Name: uint16
+      ByteSize: 2
+      GoRuntimeType: 43008
+      GoKind: 9
+    - __kind: BaseType
+      ID: 44
+      Name: uint32
       ByteSize: 4
-      GoRuntimeType: 43648
-      GoKind: 13
-    - __kind: PointerType
-      ID: 54
-      Name: '*uintptr'
-      ByteSize: 8
-      GoRuntimeType: 30112
-      GoKind: 22
-      Pointee: 19 BaseType uintptr
-    - __kind: PointerType
-      ID: 55
-      Name: '*int32'
-      ByteSize: 8
-      GoRuntimeType: 29728
-      GoKind: 22
-      Pointee: 45 BaseType int32
-    - __kind: PointerType
-      ID: 56
-      Name: '*uint32'
-      ByteSize: 8
-      GoRuntimeType: 29792
-      GoKind: 22
-      Pointee: 44 BaseType uint32
+      GoRuntimeType: 43136
+      GoKind: 10
     - __kind: BaseType
-      ID: 57
-      Name: complex64
+      ID: 18
+      Name: uint64
       ByteSize: 8
-      GoRuntimeType: 43520
-      GoKind: 15
+      GoRuntimeType: 43264
+      GoKind: 11
     - __kind: BaseType
-      ID: 58
-      Name: complex128
-      ByteSize: 16
-      GoRuntimeType: 43584
-      GoKind: 16
-    - __kind: PointerType
-      ID: 59
-      Name: '*float64'
+      ID: 9
+      Name: uint8
+      ByteSize: 1
+      GoRuntimeType: 42880
+      GoKind: 8
+    - __kind: BaseType
+      ID: 19
+      Name: uintptr
       ByteSize: 8
-      GoRuntimeType: 30368
-      GoKind: 22
-      Pointee: 50 BaseType float64
-    - __kind: PointerType
-      ID: 60
-      Name: '*int64'
+      GoRuntimeType: 43456
+      GoKind: 12
+    - __kind: VoidPointerType
+      ID: 49
+      Name: unsafe.Pointer
       ByteSize: 8
-      GoRuntimeType: 29856
-      GoKind: 22
-      Pointee: 47 BaseType int64
-    - __kind: PointerType
-      ID: 61
-      Name: '*uint64'
-      ByteSize: 8
-      GoRuntimeType: 29920
-      GoKind: 22
-      Pointee: 18 BaseType uint64
-    - __kind: PointerType
-      ID: 62
-      Name: '*error'
-      ByteSize: 8
-      GoRuntimeType: 29344
-      GoKind: 22
-      Pointee: 48 GoInterfaceType error
-    - __kind: PointerType
-      ID: 63
-      Name: '*float32'
-      ByteSize: 8
-      GoRuntimeType: 30304
-      GoKind: 22
-      Pointee: 53 BaseType float32
-    - __kind: PointerType
-      ID: 64
-      Name: '*uint'
-      ByteSize: 8
-      GoRuntimeType: 30048
-      GoKind: 22
-      Pointee: 52 BaseType uint
-    - __kind: PointerType
-      ID: 65
-      Name: '*uint16'
-      ByteSize: 8
-      GoRuntimeType: 29664
-      GoKind: 22
-      Pointee: 23 BaseType uint16
-    - __kind: GoStringDataType
-      ID: 66
-      Name: string.str
-      ByteSize: 2048
-    - __kind: PointerType
-      ID: 67
-      Name: '*string.str'
-      ByteSize: 8
-      Pointee: 66 GoStringDataType string.str
-    - __kind: GoSliceDataType
-      ID: 68
-      Name: '[]int.array'
-      ByteSize: 2048
-      Element: 1 BaseType int
-    - __kind: PointerType
-      ID: 69
-      Name: '*[]int.array'
-      ByteSize: 8
-      Pointee: 68 GoSliceDataType []int.array
-    - __kind: GoSliceDataType
-      ID: 70
-      Name: '[]string.array'
-      ByteSize: 2048
-      Element: 7 GoStringHeaderType string
-    - __kind: PointerType
-      ID: 71
-      Name: '*[]string.array'
-      ByteSize: 8
-      Pointee: 70 GoSliceDataType []string.array
-    - __kind: GoSliceDataType
-      ID: 72
-      Name: '[]*table<string,int>.array'
-      ByteSize: 8192
-      Element: 21 PointerType *table<string,int>
-    - __kind: GoSliceDataType
-      ID: 73
-      Name: '[]noalg.map.group[string]int.array'
-      ByteSize: 2048
-      Element: 26 StructureType noalg.map.group[string]int
-    - __kind: GoSliceDataType
-      ID: 74
-      Name: '[]*table<string,main.bigStruct>.array'
-      ByteSize: 8192
-      Element: 34 PointerType *table<string,main.bigStruct>
-    - __kind: GoSliceDataType
-      ID: 75
-      Name: '[]noalg.map.group[string]main.bigStruct.array'
-      ByteSize: 2048
-      Element: 38 StructureType noalg.map.group[string]main.bigStruct
-    - __kind: EventRootType
-      ID: 76
-      Name: Probe[main.intArg]
-      ByteSize: 9
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: x
-          Offset: 1
-          Expression:
-            Type: 1 BaseType int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 4, index: 0, name: x}
-                  Offset: 0
-                  ByteSize: 8
-    - __kind: EventRootType
-      ID: 77
-      Name: Probe[main.stringArg]
-      ByteSize: 17
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: s
-          Offset: 1
-          Expression:
-            Type: 7 GoStringHeaderType string
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 5, index: 0, name: s}
-                  Offset: 0
-                  ByteSize: 16
-    - __kind: EventRootType
-      ID: 78
-      Name: Probe[main.intSliceArg]
-      ByteSize: 25
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: s
-          Offset: 1
-          Expression:
-            Type: 10 GoSliceHeaderType []int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 6, index: 0, name: s}
-                  Offset: 0
-                  ByteSize: 24
-    - __kind: EventRootType
-      ID: 79
-      Name: Probe[main.intArrayArg]
-      ByteSize: 25
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: s
-          Offset: 1
-          Expression:
-            Type: 11 ArrayType [3]int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 7, index: 0, name: s}
-                  Offset: 0
-                  ByteSize: 24
-    - __kind: EventRootType
-      ID: 80
-      Name: Probe[main.stringSliceArg]
-      ByteSize: 25
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: s
-          Offset: 1
-          Expression:
-            Type: 12 GoSliceHeaderType []string
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 8, index: 0, name: s}
-                  Offset: 0
-                  ByteSize: 24
-    - __kind: EventRootType
-      ID: 81
-      Name: Probe[main.stringArrayArg]
-      ByteSize: 49
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: s
-          Offset: 1
-          Expression:
-            Type: 14 ArrayType [3]string
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 9, index: 0, name: s}
-                  Offset: 0
-                  ByteSize: 48
-    - __kind: EventRootType
-      ID: 82
-      Name: Probe[main.stringArrayArgFrameless]
-      ByteSize: 49
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: s
-          Offset: 1
-          Expression:
-            Type: 14 ArrayType [3]string
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 10, index: 0, name: s}
-                  Offset: 0
-                  ByteSize: 48
-    - __kind: EventRootType
-      ID: 83
-      Name: Probe[main.mapArg]
-      ByteSize: 9
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: m
-          Offset: 1
-          Expression:
-            Type: 15 GoMapType map[string]int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 11, index: 0, name: m}
-                  Offset: 0
-                  ByteSize: 8
-    - __kind: EventRootType
-      ID: 84
-      Name: Probe[main.bigMapArg]
-      ByteSize: 9
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: m
-          Offset: 1
-          Expression:
-            Type: 30 GoMapType map[string]main.bigStruct
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 12, index: 0, name: m}
-                  Offset: 0
-                  ByteSize: 8
-    - __kind: EventRootType
-      ID: 85
-      Name: Probe[main.inlined]
-      ByteSize: 9
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: x
-          Offset: 1
-          Expression:
-            Type: 1 BaseType int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 1, index: 0, name: x}
-                  Offset: 0
-                  ByteSize: 8
-    - __kind: EventRootType
-      ID: 86
-      Name: Probe[main.PointerChainArg]
-      ByteSize: 9
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: ptr
-          Offset: 1
-          Expression:
-            Type: 2 PointerType *****int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 2, index: 0, name: ptr}
-                  Offset: 0
-                  ByteSize: 8
-    - __kind: EventRootType
-      ID: 87
-      Name: Probe[main.PointerSmallChainArg]
-      ByteSize: 9
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: ptr
-          Offset: 1
-          Expression:
-            Type: 5 PointerType **int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 3, index: 0, name: ptr}
-                  Offset: 0
-                  ByteSize: 8
+      GoRuntimeType: 43840
+      GoKind: 26
 MaxTypeID: 87
 Issues: []
 GoModuledataInfo: {FirstModuledataAddr: "0x58c3a0", TypesOffset: 296}

--- a/pkg/dyninst/irgen/testdata/snapshot/simple.arch=arm64,toolchain=go1.23.11.yaml
+++ b/pkg/dyninst/irgen/testdata/snapshot/simple.arch=arm64,toolchain=go1.23.11.yaml
@@ -15,7 +15,7 @@ Probes:
       events:
         - ID: 11
           Type: 86 EventRootType Probe[main.PointerChainArg]
-          InjectionPoints: [{PC: 742200, Frameless: false}]
+          InjectionPoints: [{PC: "0xb5338", Frameless: false}]
           Condition: null
     - id: PointerSmallChainArg
       version: 0
@@ -32,7 +32,7 @@ Probes:
       events:
         - ID: 12
           Type: 87 EventRootType Probe[main.PointerSmallChainArg]
-          InjectionPoints: [{PC: 742256, Frameless: false}]
+          InjectionPoints: [{PC: "0xb5370", Frameless: false}]
           Condition: null
     - id: bigMapArg
       version: 0
@@ -45,7 +45,7 @@ Probes:
       events:
         - ID: 9
           Type: 84 EventRootType Probe[main.bigMapArg]
-          InjectionPoints: [{PC: 743456, Frameless: true}]
+          InjectionPoints: [{PC: "0xb5820", Frameless: true}]
           Condition: null
     - id: inlined
       version: 0
@@ -60,9 +60,9 @@ Probes:
         - ID: 10
           Type: 85 EventRootType Probe[main.inlined]
           InjectionPoints:
-            - PC: 743148
+            - PC: "0xb56ec"
               Frameless: true
-            - PC: 741708
+            - PC: "0xb514c"
               Frameless: false
           Condition: null
     - id: intArg
@@ -76,7 +76,7 @@ Probes:
       events:
         - ID: 1
           Type: 76 EventRootType Probe[main.intArg]
-          InjectionPoints: [{PC: 742348, Frameless: true}]
+          InjectionPoints: [{PC: "0xb53cc", Frameless: true}]
           Condition: null
     - id: intArrayArg
       version: 0
@@ -89,7 +89,7 @@ Probes:
       events:
         - ID: 4
           Type: 79 EventRootType Probe[main.intArrayArg]
-          InjectionPoints: [{PC: 742732, Frameless: true}]
+          InjectionPoints: [{PC: "0xb554c", Frameless: true}]
           Condition: null
     - id: intArrayArgFrameless
       version: 0
@@ -102,7 +102,7 @@ Probes:
       events:
         - ID: 7
           Type: 82 EventRootType Probe[main.stringArrayArgFrameless]
-          InjectionPoints: [{PC: 743120, Frameless: true}]
+          InjectionPoints: [{PC: "0xb56d0", Frameless: true}]
           Condition: null
     - id: intSliceArg
       version: 0
@@ -115,7 +115,7 @@ Probes:
       events:
         - ID: 3
           Type: 78 EventRootType Probe[main.intSliceArg]
-          InjectionPoints: [{PC: 742588, Frameless: true}]
+          InjectionPoints: [{PC: "0xb54bc", Frameless: true}]
           Condition: null
     - id: mapArg
       version: 0
@@ -128,7 +128,7 @@ Probes:
       events:
         - ID: 8
           Type: 83 EventRootType Probe[main.mapArg]
-          InjectionPoints: [{PC: 743340, Frameless: true}]
+          InjectionPoints: [{PC: "0xb57ac", Frameless: true}]
           Condition: null
     - id: stringArg
       version: 0
@@ -141,7 +141,7 @@ Probes:
       events:
         - ID: 2
           Type: 77 EventRootType Probe[main.stringArg]
-          InjectionPoints: [{PC: 742460, Frameless: true}]
+          InjectionPoints: [{PC: "0xb543c", Frameless: true}]
           Condition: null
     - id: stringArrayArg
       version: 0
@@ -154,7 +154,7 @@ Probes:
       events:
         - ID: 6
           Type: 81 EventRootType Probe[main.stringArrayArg]
-          InjectionPoints: [{PC: 743004, Frameless: true}]
+          InjectionPoints: [{PC: "0xb565c", Frameless: true}]
           Condition: null
     - id: stringSliceArg
       version: 0
@@ -167,7 +167,7 @@ Probes:
       events:
         - ID: 5
           Type: 80 EventRootType Probe[main.stringSliceArg]
-          InjectionPoints: [{PC: 742860, Frameless: true}]
+          InjectionPoints: [{PC: "0xb55cc", Frameless: true}]
           Condition: null
 Subprograms:
     - ID: 4
@@ -341,12 +341,6 @@ Subprograms:
           IsParameter: true
           IsReturn: false
 Types:
-    - __kind: BaseType
-      ID: 1
-      Name: int
-      ByteSize: 8
-      GoRuntimeType: 37984
-      GoKind: 2
     - __kind: PointerType
       ID: 2
       Name: '*****int'
@@ -376,26 +370,162 @@ Types:
       GoKind: 22
       Pointee: 6 PointerType *int
     - __kind: PointerType
+      ID: 30
+      Name: '**runtime.bmap'
+      ByteSize: 8
+      Pointee: 31 PointerType *runtime.bmap
+    - __kind: PointerType
+      ID: 28
+      Name: '*[]*runtime.bmap'
+      ByteSize: 8
+      GoRuntimeType: 35936
+      GoKind: 22
+      Pointee: 29 GoSliceHeaderType []*runtime.bmap
+    - __kind: PointerType
+      ID: 74
+      Name: '*[]*runtime.bmap.array'
+      ByteSize: 8
+      Pointee: 73 GoSliceDataType []*runtime.bmap.array
+    - __kind: PointerType
+      ID: 69
+      Name: '*[]int.array'
+      ByteSize: 8
+      Pointee: 68 GoSliceDataType []int.array
+    - __kind: PointerType
+      ID: 71
+      Name: '*[]string.array'
+      ByteSize: 8
+      Pointee: 70 GoSliceDataType []string.array
+    - __kind: PointerType
+      ID: 43
+      Name: '*bool'
+      ByteSize: 8
+      GoRuntimeType: 26912
+      GoKind: 22
+      Pointee: 42 BaseType bool
+    - __kind: PointerType
+      ID: 20
+      Name: '*bucket<string,int>'
+      ByteSize: 8
+      Pointee: 21 GoHMapBucketType bucket<string,int>
+    - __kind: PointerType
+      ID: 36
+      Name: '*bucket<string,main.bigStruct>'
+      ByteSize: 8
+      Pointee: 37 GoHMapBucketType bucket<string,main.bigStruct>
+    - __kind: PointerType
+      ID: 62
+      Name: '*error'
+      ByteSize: 8
+      GoRuntimeType: 25824
+      GoKind: 22
+      Pointee: 52 GoInterfaceType error
+    - __kind: PointerType
+      ID: 63
+      Name: '*float32'
+      ByteSize: 8
+      GoRuntimeType: 26784
+      GoKind: 22
+      Pointee: 50 BaseType float32
+    - __kind: PointerType
+      ID: 59
+      Name: '*float64'
+      ByteSize: 8
+      GoRuntimeType: 26848
+      GoKind: 22
+      Pointee: 51 BaseType float64
+    - __kind: PointerType
+      ID: 16
+      Name: '*hash<string,int>'
+      ByteSize: 8
+      Pointee: 17 GoHMapHeaderType hash<string,int>
+    - __kind: PointerType
+      ID: 34
+      Name: '*hash<string,main.bigStruct>'
+      ByteSize: 8
+      Pointee: 35 GoHMapHeaderType hash<string,main.bigStruct>
+    - __kind: PointerType
       ID: 6
       Name: '*int'
       ByteSize: 8
       GoRuntimeType: 26464
       GoKind: 22
       Pointee: 1 BaseType int
-    - __kind: GoStringHeaderType
-      ID: 7
-      Name: string
-      ByteSize: 16
-      GoRuntimeType: 37408
-      GoKind: 24
-      RawFields:
-        - Name: str
-          Offset: 0
-          Type: 67 PointerType *string.str
-        - Name: len
-          Offset: 8
-          Type: 1 BaseType int
-      Data: 66 GoStringDataType string.str
+    - __kind: PointerType
+      ID: 54
+      Name: '*int32'
+      ByteSize: 8
+      GoRuntimeType: 26208
+      GoKind: 22
+      Pointee: 47 BaseType int32
+    - __kind: PointerType
+      ID: 60
+      Name: '*int64'
+      ByteSize: 8
+      GoRuntimeType: 26336
+      GoKind: 22
+      Pointee: 48 BaseType int64
+    - __kind: PointerType
+      ID: 39
+      Name: '*main.bigStruct'
+      ByteSize: 8
+      GoRuntimeType: 24224
+      GoKind: 22
+      Pointee: 40 StructureType main.bigStruct
+    - __kind: PointerType
+      ID: 31
+      Name: '*runtime.bmap'
+      ByteSize: 8
+      GoRuntimeType: 66400
+      GoKind: 22
+      Pointee: 32 StructureType runtime.bmap
+    - __kind: PointerType
+      ID: 26
+      Name: '*runtime.mapextra'
+      ByteSize: 8
+      GoRuntimeType: 29728
+      GoKind: 22
+      Pointee: 27 StructureType runtime.mapextra
+    - __kind: PointerType
+      ID: 13
+      Name: '*string'
+      ByteSize: 8
+      GoRuntimeType: 25888
+      GoKind: 22
+      Pointee: 7 GoStringHeaderType string
+    - __kind: PointerType
+      ID: 67
+      Name: '*string.str'
+      ByteSize: 8
+      Pointee: 66 GoStringDataType string.str
+    - __kind: PointerType
+      ID: 64
+      Name: '*uint'
+      ByteSize: 8
+      GoRuntimeType: 26528
+      GoKind: 22
+      Pointee: 46 BaseType uint
+    - __kind: PointerType
+      ID: 65
+      Name: '*uint16'
+      ByteSize: 8
+      GoRuntimeType: 26144
+      GoKind: 22
+      Pointee: 18 BaseType uint16
+    - __kind: PointerType
+      ID: 55
+      Name: '*uint32'
+      ByteSize: 8
+      GoRuntimeType: 26272
+      GoKind: 22
+      Pointee: 19 BaseType uint32
+    - __kind: PointerType
+      ID: 61
+      Name: '*uint64'
+      ByteSize: 8
+      GoRuntimeType: 26400
+      GoKind: 22
+      Pointee: 45 BaseType uint64
     - __kind: PointerType
       ID: 8
       Name: '*uint8'
@@ -403,12 +533,261 @@ Types:
       GoRuntimeType: 26016
       GoKind: 22
       Pointee: 9 BaseType uint8
-    - __kind: BaseType
-      ID: 9
-      Name: uint8
-      ByteSize: 1
-      GoRuntimeType: 37536
-      GoKind: 8
+    - __kind: PointerType
+      ID: 44
+      Name: '*uintptr'
+      ByteSize: 8
+      GoRuntimeType: 26592
+      GoKind: 22
+      Pointee: 25 BaseType uintptr
+    - __kind: EventRootType
+      ID: 86
+      Name: Probe[main.PointerChainArg]
+      ByteSize: 9
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: ptr
+          Offset: 1
+          Expression:
+            Type: 2 PointerType *****int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 2, index: 0, name: ptr}
+                  Offset: 0
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 87
+      Name: Probe[main.PointerSmallChainArg]
+      ByteSize: 9
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: ptr
+          Offset: 1
+          Expression:
+            Type: 5 PointerType **int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 3, index: 0, name: ptr}
+                  Offset: 0
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 84
+      Name: Probe[main.bigMapArg]
+      ByteSize: 9
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: m
+          Offset: 1
+          Expression:
+            Type: 33 GoMapType map[string]main.bigStruct
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 12, index: 0, name: m}
+                  Offset: 0
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 85
+      Name: Probe[main.inlined]
+      ByteSize: 9
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: x
+          Offset: 1
+          Expression:
+            Type: 1 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 1, index: 0, name: x}
+                  Offset: 0
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 76
+      Name: Probe[main.intArg]
+      ByteSize: 9
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: x
+          Offset: 1
+          Expression:
+            Type: 1 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 4, index: 0, name: x}
+                  Offset: 0
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 79
+      Name: Probe[main.intArrayArg]
+      ByteSize: 25
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: s
+          Offset: 1
+          Expression:
+            Type: 11 ArrayType [3]int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 7, index: 0, name: s}
+                  Offset: 0
+                  ByteSize: 24
+    - __kind: EventRootType
+      ID: 78
+      Name: Probe[main.intSliceArg]
+      ByteSize: 25
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: s
+          Offset: 1
+          Expression:
+            Type: 10 GoSliceHeaderType []int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 6, index: 0, name: s}
+                  Offset: 0
+                  ByteSize: 24
+    - __kind: EventRootType
+      ID: 83
+      Name: Probe[main.mapArg]
+      ByteSize: 9
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: m
+          Offset: 1
+          Expression:
+            Type: 15 GoMapType map[string]int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 11, index: 0, name: m}
+                  Offset: 0
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 77
+      Name: Probe[main.stringArg]
+      ByteSize: 17
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: s
+          Offset: 1
+          Expression:
+            Type: 7 GoStringHeaderType string
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 5, index: 0, name: s}
+                  Offset: 0
+                  ByteSize: 16
+    - __kind: EventRootType
+      ID: 82
+      Name: Probe[main.stringArrayArgFrameless]
+      ByteSize: 49
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: s
+          Offset: 1
+          Expression:
+            Type: 14 ArrayType [3]string
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 10, index: 0, name: s}
+                  Offset: 0
+                  ByteSize: 48
+    - __kind: EventRootType
+      ID: 81
+      Name: Probe[main.stringArrayArg]
+      ByteSize: 49
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: s
+          Offset: 1
+          Expression:
+            Type: 14 ArrayType [3]string
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 9, index: 0, name: s}
+                  Offset: 0
+                  ByteSize: 48
+    - __kind: EventRootType
+      ID: 80
+      Name: Probe[main.stringSliceArg]
+      ByteSize: 25
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: s
+          Offset: 1
+          Expression:
+            Type: 12 GoSliceHeaderType []string
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 8, index: 0, name: s}
+                  Offset: 0
+                  ByteSize: 24
+    - __kind: ArrayType
+      ID: 41
+      Name: '[128]uint8'
+      ByteSize: 128
+      GoRuntimeType: 41856
+      GoKind: 17
+      Count: 128
+      HasCount: true
+      Element: 9 BaseType uint8
+    - __kind: ArrayType
+      ID: 11
+      Name: '[3]int'
+      ByteSize: 24
+      GoRuntimeType: 41376
+      GoKind: 17
+      Count: 3
+      HasCount: true
+      Element: 1 BaseType int
+    - __kind: ArrayType
+      ID: 14
+      Name: '[3]string'
+      ByteSize: 48
+      GoRuntimeType: 41472
+      GoKind: 17
+      Count: 3
+      HasCount: true
+      Element: 7 GoStringHeaderType string
+    - __kind: ArrayType
+      ID: 22
+      Name: '[8]uint8'
+      ByteSize: 8
+      GoRuntimeType: 41568
+      GoKind: 17
+      Count: 8
+      HasCount: true
+      Element: 9 BaseType uint8
+    - __kind: GoSliceHeaderType
+      ID: 29
+      Name: '[]*runtime.bmap'
+      ByteSize: 24
+      GoRuntimeType: 35872
+      GoKind: 23
+      RawFields:
+        - Name: array
+          Offset: 0
+          Type: 30 PointerType **runtime.bmap
+        - Name: len
+          Offset: 8
+          Type: 1 BaseType int
+        - Name: cap
+          Offset: 16
+          Type: 1 BaseType int
+      Data: 73 GoSliceDataType []*runtime.bmap.array
+    - __kind: GoSliceDataType
+      ID: 73
+      Name: '[]*runtime.bmap.array'
+      ByteSize: 2048
+      Element: 31 PointerType *runtime.bmap
+    - __kind: GoSliceDataType
+      ID: 72
+      Name: '[]bucket<string,int>.array'
+      ByteSize: 2048
+      Element: 21 GoHMapBucketType bucket<string,int>
+    - __kind: GoSliceDataType
+      ID: 75
+      Name: '[]bucket<string,main.bigStruct>.array'
+      ByteSize: 2048
+      Element: 37 GoHMapBucketType bucket<string,main.bigStruct>
     - __kind: GoSliceHeaderType
       ID: 10
       Name: '[]int'
@@ -426,15 +805,18 @@ Types:
           Offset: 16
           Type: 1 BaseType int
       Data: 68 GoSliceDataType []int.array
-    - __kind: ArrayType
-      ID: 11
-      Name: '[3]int'
-      ByteSize: 24
-      GoRuntimeType: 41376
-      GoKind: 17
-      Count: 3
-      HasCount: true
+    - __kind: GoSliceDataType
+      ID: 68
+      Name: '[]int.array'
+      ByteSize: 2048
       Element: 1 BaseType int
+    - __kind: ArrayType
+      ID: 23
+      Name: '[]key<string>'
+      ByteSize: 128
+      Count: 8
+      HasCount: true
+      Element: 7 GoStringHeaderType string
     - __kind: GoSliceHeaderType
       ID: 12
       Name: '[]string'
@@ -452,34 +834,106 @@ Types:
           Offset: 16
           Type: 1 BaseType int
       Data: 70 GoSliceDataType []string.array
-    - __kind: PointerType
-      ID: 13
-      Name: '*string'
-      ByteSize: 8
-      GoRuntimeType: 25888
-      GoKind: 22
-      Pointee: 7 GoStringHeaderType string
-    - __kind: ArrayType
-      ID: 14
-      Name: '[3]string'
-      ByteSize: 48
-      GoRuntimeType: 41472
-      GoKind: 17
-      Count: 3
-      HasCount: true
+    - __kind: GoSliceDataType
+      ID: 70
+      Name: '[]string.array'
+      ByteSize: 2048
       Element: 7 GoStringHeaderType string
-    - __kind: GoMapType
-      ID: 15
-      Name: map[string]int
+    - __kind: ArrayType
+      ID: 24
+      Name: '[]val<int>'
+      ByteSize: 64
+      Count: 8
+      HasCount: true
+      Element: 1 BaseType int
+    - __kind: ArrayType
+      ID: 38
+      Name: '[]val<main.bigStruct>'
+      ByteSize: 64
+      Count: 8
+      HasCount: true
+      Element: 39 PointerType *main.bigStruct
+    - __kind: BaseType
+      ID: 42
+      Name: bool
+      ByteSize: 1
+      GoRuntimeType: 38432
+      GoKind: 1
+    - __kind: GoHMapBucketType
+      ID: 21
+      Name: bucket<string,int>
+      ByteSize: 208
+      RawFields:
+        - Name: tophash
+          Offset: 0
+          Type: 22 ArrayType [8]uint8
+        - Name: keys
+          Offset: 8
+          Type: 23 ArrayType []key<string>
+        - Name: values
+          Offset: 136
+          Type: 24 ArrayType []val<int>
+        - Name: overflow
+          Offset: 200
+          Type: 20 PointerType *bucket<string,int>
+      KeyType: 7 GoStringHeaderType string
+      ValueType: 1 BaseType int
+    - __kind: GoHMapBucketType
+      ID: 37
+      Name: bucket<string,main.bigStruct>
+      ByteSize: 208
+      RawFields:
+        - Name: tophash
+          Offset: 0
+          Type: 22 ArrayType [8]uint8
+        - Name: keys
+          Offset: 8
+          Type: 23 ArrayType []key<string>
+        - Name: values
+          Offset: 136
+          Type: 38 ArrayType []val<main.bigStruct>
+        - Name: overflow
+          Offset: 200
+          Type: 36 PointerType *bucket<string,main.bigStruct>
+      KeyType: 7 GoStringHeaderType string
+      ValueType: 39 PointerType *main.bigStruct
+    - __kind: BaseType
+      ID: 58
+      Name: complex128
+      ByteSize: 16
+      GoRuntimeType: 38240
+      GoKind: 16
+    - __kind: BaseType
+      ID: 57
+      Name: complex64
       ByteSize: 8
-      GoRuntimeType: 54528
-      GoKind: 21
-      HeaderType: 17 GoHMapHeaderType hash<string,int>
-    - __kind: PointerType
-      ID: 16
-      Name: '*hash<string,int>'
+      GoRuntimeType: 38176
+      GoKind: 15
+    - __kind: GoInterfaceType
+      ID: 52
+      Name: error
+      ByteSize: 16
+      GoRuntimeType: 58880
+      GoKind: 20
+      RawFields:
+        - Name: tab
+          Offset: 0
+          Type: 53 VoidPointerType unsafe.Pointer
+        - Name: data
+          Offset: 8
+          Type: 53 VoidPointerType unsafe.Pointer
+    - __kind: BaseType
+      ID: 50
+      Name: float32
+      ByteSize: 4
+      GoRuntimeType: 38304
+      GoKind: 13
+    - __kind: BaseType
+      ID: 51
+      Name: float64
       ByteSize: 8
-      Pointee: 17 GoHMapHeaderType hash<string,int>
+      GoRuntimeType: 38368
+      GoKind: 14
     - __kind: GoHMapHeaderType
       ID: 17
       Name: hash<string,int>
@@ -514,152 +968,6 @@ Types:
           Type: 26 PointerType *runtime.mapextra
       BucketType: 21 GoHMapBucketType bucket<string,int>
       BucketsType: 72 GoSliceDataType []bucket<string,int>.array
-    - __kind: BaseType
-      ID: 18
-      Name: uint16
-      ByteSize: 2
-      GoRuntimeType: 37664
-      GoKind: 9
-    - __kind: BaseType
-      ID: 19
-      Name: uint32
-      ByteSize: 4
-      GoRuntimeType: 37792
-      GoKind: 10
-    - __kind: PointerType
-      ID: 20
-      Name: '*bucket<string,int>'
-      ByteSize: 8
-      Pointee: 21 GoHMapBucketType bucket<string,int>
-    - __kind: GoHMapBucketType
-      ID: 21
-      Name: bucket<string,int>
-      ByteSize: 208
-      RawFields:
-        - Name: tophash
-          Offset: 0
-          Type: 22 ArrayType [8]uint8
-        - Name: keys
-          Offset: 8
-          Type: 23 ArrayType []key<string>
-        - Name: values
-          Offset: 136
-          Type: 24 ArrayType []val<int>
-        - Name: overflow
-          Offset: 200
-          Type: 20 PointerType *bucket<string,int>
-      KeyType: 7 GoStringHeaderType string
-      ValueType: 1 BaseType int
-    - __kind: ArrayType
-      ID: 22
-      Name: '[8]uint8'
-      ByteSize: 8
-      GoRuntimeType: 41568
-      GoKind: 17
-      Count: 8
-      HasCount: true
-      Element: 9 BaseType uint8
-    - __kind: ArrayType
-      ID: 23
-      Name: '[]key<string>'
-      ByteSize: 128
-      Count: 8
-      HasCount: true
-      Element: 7 GoStringHeaderType string
-    - __kind: ArrayType
-      ID: 24
-      Name: '[]val<int>'
-      ByteSize: 64
-      Count: 8
-      HasCount: true
-      Element: 1 BaseType int
-    - __kind: BaseType
-      ID: 25
-      Name: uintptr
-      ByteSize: 8
-      GoRuntimeType: 38112
-      GoKind: 12
-    - __kind: PointerType
-      ID: 26
-      Name: '*runtime.mapextra'
-      ByteSize: 8
-      GoRuntimeType: 29728
-      GoKind: 22
-      Pointee: 27 StructureType runtime.mapextra
-    - __kind: StructureType
-      ID: 27
-      Name: runtime.mapextra
-      ByteSize: 24
-      GoRuntimeType: 87104
-      GoKind: 25
-      RawFields:
-        - Name: overflow
-          Offset: 0
-          Type: 28 PointerType *[]*runtime.bmap
-        - Name: oldoverflow
-          Offset: 8
-          Type: 28 PointerType *[]*runtime.bmap
-        - Name: nextOverflow
-          Offset: 16
-          Type: 31 PointerType *runtime.bmap
-    - __kind: PointerType
-      ID: 28
-      Name: '*[]*runtime.bmap'
-      ByteSize: 8
-      GoRuntimeType: 35936
-      GoKind: 22
-      Pointee: 29 GoSliceHeaderType []*runtime.bmap
-    - __kind: GoSliceHeaderType
-      ID: 29
-      Name: '[]*runtime.bmap'
-      ByteSize: 24
-      GoRuntimeType: 35872
-      GoKind: 23
-      RawFields:
-        - Name: array
-          Offset: 0
-          Type: 30 PointerType **runtime.bmap
-        - Name: len
-          Offset: 8
-          Type: 1 BaseType int
-        - Name: cap
-          Offset: 16
-          Type: 1 BaseType int
-      Data: 73 GoSliceDataType []*runtime.bmap.array
-    - __kind: PointerType
-      ID: 30
-      Name: '**runtime.bmap'
-      ByteSize: 8
-      Pointee: 31 PointerType *runtime.bmap
-    - __kind: PointerType
-      ID: 31
-      Name: '*runtime.bmap'
-      ByteSize: 8
-      GoRuntimeType: 66400
-      GoKind: 22
-      Pointee: 32 StructureType runtime.bmap
-    - __kind: StructureType
-      ID: 32
-      Name: runtime.bmap
-      ByteSize: 8
-      GoRuntimeType: 66272
-      GoKind: 25
-      RawFields:
-        - Name: tophash
-          Offset: 0
-          Type: 22 ArrayType [8]uint8
-    - __kind: GoMapType
-      ID: 33
-      Name: map[string]main.bigStruct
-      ByteSize: 8
-      GoRuntimeType: 54624
-      GoKind: 21
-      HeaderType: 35 GoHMapHeaderType hash<string,main.bigStruct>
-    - __kind: PointerType
-      ID: 34
-      Name: '*hash<string,main.bigStruct>'
-      ByteSize: 8
-      Pointee: 35 GoHMapHeaderType hash<string,main.bigStruct>
     - __kind: GoHMapHeaderType
       ID: 35
       Name: hash<string,main.bigStruct>
@@ -694,44 +1002,36 @@ Types:
           Type: 26 PointerType *runtime.mapextra
       BucketType: 37 GoHMapBucketType bucket<string,main.bigStruct>
       BucketsType: 75 GoSliceDataType []bucket<string,main.bigStruct>.array
-    - __kind: PointerType
-      ID: 36
-      Name: '*bucket<string,main.bigStruct>'
+    - __kind: BaseType
+      ID: 1
+      Name: int
       ByteSize: 8
-      Pointee: 37 GoHMapBucketType bucket<string,main.bigStruct>
-    - __kind: GoHMapBucketType
-      ID: 37
-      Name: bucket<string,main.bigStruct>
-      ByteSize: 208
-      RawFields:
-        - Name: tophash
-          Offset: 0
-          Type: 22 ArrayType [8]uint8
-        - Name: keys
-          Offset: 8
-          Type: 23 ArrayType []key<string>
-        - Name: values
-          Offset: 136
-          Type: 38 ArrayType []val<main.bigStruct>
-        - Name: overflow
-          Offset: 200
-          Type: 36 PointerType *bucket<string,main.bigStruct>
-      KeyType: 7 GoStringHeaderType string
-      ValueType: 39 PointerType *main.bigStruct
-    - __kind: ArrayType
-      ID: 38
-      Name: '[]val<main.bigStruct>'
-      ByteSize: 64
-      Count: 8
-      HasCount: true
-      Element: 39 PointerType *main.bigStruct
-    - __kind: PointerType
-      ID: 39
-      Name: '*main.bigStruct'
+      GoRuntimeType: 37984
+      GoKind: 2
+    - __kind: BaseType
+      ID: 56
+      Name: int16
+      ByteSize: 2
+      GoRuntimeType: 37600
+      GoKind: 4
+    - __kind: BaseType
+      ID: 47
+      Name: int32
+      ByteSize: 4
+      GoRuntimeType: 37728
+      GoKind: 5
+    - __kind: BaseType
+      ID: 48
+      Name: int64
       ByteSize: 8
-      GoRuntimeType: 24224
-      GoKind: 22
-      Pointee: 40 StructureType main.bigStruct
+      GoRuntimeType: 37856
+      GoKind: 6
+    - __kind: BaseType
+      ID: 49
+      Name: int8
+      ByteSize: 1
+      GoRuntimeType: 37472
+      GoKind: 3
     - __kind: StructureType
       ID: 40
       Name: main.bigStruct
@@ -763,41 +1063,64 @@ Types:
         - Name: data
           Offset: 56
           Type: 41 ArrayType [128]uint8
-    - __kind: ArrayType
-      ID: 41
-      Name: '[128]uint8'
-      ByteSize: 128
-      GoRuntimeType: 41856
-      GoKind: 17
-      Count: 128
-      HasCount: true
-      Element: 9 BaseType uint8
-    - __kind: BaseType
-      ID: 42
-      Name: bool
-      ByteSize: 1
-      GoRuntimeType: 38432
-      GoKind: 1
-    - __kind: PointerType
-      ID: 43
-      Name: '*bool'
+    - __kind: GoMapType
+      ID: 15
+      Name: map[string]int
       ByteSize: 8
-      GoRuntimeType: 26912
-      GoKind: 22
-      Pointee: 42 BaseType bool
-    - __kind: PointerType
-      ID: 44
-      Name: '*uintptr'
+      GoRuntimeType: 54528
+      GoKind: 21
+      HeaderType: 17 GoHMapHeaderType hash<string,int>
+    - __kind: GoMapType
+      ID: 33
+      Name: map[string]main.bigStruct
       ByteSize: 8
-      GoRuntimeType: 26592
-      GoKind: 22
-      Pointee: 25 BaseType uintptr
-    - __kind: BaseType
-      ID: 45
-      Name: uint64
+      GoRuntimeType: 54624
+      GoKind: 21
+      HeaderType: 35 GoHMapHeaderType hash<string,main.bigStruct>
+    - __kind: StructureType
+      ID: 32
+      Name: runtime.bmap
       ByteSize: 8
-      GoRuntimeType: 37920
-      GoKind: 11
+      GoRuntimeType: 66272
+      GoKind: 25
+      RawFields:
+        - Name: tophash
+          Offset: 0
+          Type: 22 ArrayType [8]uint8
+    - __kind: StructureType
+      ID: 27
+      Name: runtime.mapextra
+      ByteSize: 24
+      GoRuntimeType: 87104
+      GoKind: 25
+      RawFields:
+        - Name: overflow
+          Offset: 0
+          Type: 28 PointerType *[]*runtime.bmap
+        - Name: oldoverflow
+          Offset: 8
+          Type: 28 PointerType *[]*runtime.bmap
+        - Name: nextOverflow
+          Offset: 16
+          Type: 31 PointerType *runtime.bmap
+    - __kind: GoStringHeaderType
+      ID: 7
+      Name: string
+      ByteSize: 16
+      GoRuntimeType: 37408
+      GoKind: 24
+      RawFields:
+        - Name: str
+          Offset: 0
+          Type: 67 PointerType *string.str
+        - Name: len
+          Offset: 8
+          Type: 1 BaseType int
+      Data: 66 GoStringDataType string.str
+    - __kind: GoStringDataType
+      ID: 66
+      Name: string.str
+      ByteSize: 2048
     - __kind: BaseType
       ID: 46
       Name: uint
@@ -805,364 +1128,41 @@ Types:
       GoRuntimeType: 38048
       GoKind: 7
     - __kind: BaseType
-      ID: 47
-      Name: int32
+      ID: 18
+      Name: uint16
+      ByteSize: 2
+      GoRuntimeType: 37664
+      GoKind: 9
+    - __kind: BaseType
+      ID: 19
+      Name: uint32
       ByteSize: 4
-      GoRuntimeType: 37728
-      GoKind: 5
+      GoRuntimeType: 37792
+      GoKind: 10
     - __kind: BaseType
-      ID: 48
-      Name: int64
+      ID: 45
+      Name: uint64
       ByteSize: 8
-      GoRuntimeType: 37856
-      GoKind: 6
+      GoRuntimeType: 37920
+      GoKind: 11
     - __kind: BaseType
-      ID: 49
-      Name: int8
+      ID: 9
+      Name: uint8
       ByteSize: 1
-      GoRuntimeType: 37472
-      GoKind: 3
+      GoRuntimeType: 37536
+      GoKind: 8
     - __kind: BaseType
-      ID: 50
-      Name: float32
-      ByteSize: 4
-      GoRuntimeType: 38304
-      GoKind: 13
-    - __kind: BaseType
-      ID: 51
-      Name: float64
+      ID: 25
+      Name: uintptr
       ByteSize: 8
-      GoRuntimeType: 38368
-      GoKind: 14
-    - __kind: GoInterfaceType
-      ID: 52
-      Name: error
-      ByteSize: 16
-      GoRuntimeType: 58880
-      GoKind: 20
-      RawFields:
-        - Name: tab
-          Offset: 0
-          Type: 53 VoidPointerType unsafe.Pointer
-        - Name: data
-          Offset: 8
-          Type: 53 VoidPointerType unsafe.Pointer
+      GoRuntimeType: 38112
+      GoKind: 12
     - __kind: VoidPointerType
       ID: 53
       Name: unsafe.Pointer
       ByteSize: 8
       GoRuntimeType: 38496
       GoKind: 26
-    - __kind: PointerType
-      ID: 54
-      Name: '*int32'
-      ByteSize: 8
-      GoRuntimeType: 26208
-      GoKind: 22
-      Pointee: 47 BaseType int32
-    - __kind: PointerType
-      ID: 55
-      Name: '*uint32'
-      ByteSize: 8
-      GoRuntimeType: 26272
-      GoKind: 22
-      Pointee: 19 BaseType uint32
-    - __kind: BaseType
-      ID: 56
-      Name: int16
-      ByteSize: 2
-      GoRuntimeType: 37600
-      GoKind: 4
-    - __kind: BaseType
-      ID: 57
-      Name: complex64
-      ByteSize: 8
-      GoRuntimeType: 38176
-      GoKind: 15
-    - __kind: BaseType
-      ID: 58
-      Name: complex128
-      ByteSize: 16
-      GoRuntimeType: 38240
-      GoKind: 16
-    - __kind: PointerType
-      ID: 59
-      Name: '*float64'
-      ByteSize: 8
-      GoRuntimeType: 26848
-      GoKind: 22
-      Pointee: 51 BaseType float64
-    - __kind: PointerType
-      ID: 60
-      Name: '*int64'
-      ByteSize: 8
-      GoRuntimeType: 26336
-      GoKind: 22
-      Pointee: 48 BaseType int64
-    - __kind: PointerType
-      ID: 61
-      Name: '*uint64'
-      ByteSize: 8
-      GoRuntimeType: 26400
-      GoKind: 22
-      Pointee: 45 BaseType uint64
-    - __kind: PointerType
-      ID: 62
-      Name: '*error'
-      ByteSize: 8
-      GoRuntimeType: 25824
-      GoKind: 22
-      Pointee: 52 GoInterfaceType error
-    - __kind: PointerType
-      ID: 63
-      Name: '*float32'
-      ByteSize: 8
-      GoRuntimeType: 26784
-      GoKind: 22
-      Pointee: 50 BaseType float32
-    - __kind: PointerType
-      ID: 64
-      Name: '*uint'
-      ByteSize: 8
-      GoRuntimeType: 26528
-      GoKind: 22
-      Pointee: 46 BaseType uint
-    - __kind: PointerType
-      ID: 65
-      Name: '*uint16'
-      ByteSize: 8
-      GoRuntimeType: 26144
-      GoKind: 22
-      Pointee: 18 BaseType uint16
-    - __kind: GoStringDataType
-      ID: 66
-      Name: string.str
-      ByteSize: 2048
-    - __kind: PointerType
-      ID: 67
-      Name: '*string.str'
-      ByteSize: 8
-      Pointee: 66 GoStringDataType string.str
-    - __kind: GoSliceDataType
-      ID: 68
-      Name: '[]int.array'
-      ByteSize: 2048
-      Element: 1 BaseType int
-    - __kind: PointerType
-      ID: 69
-      Name: '*[]int.array'
-      ByteSize: 8
-      Pointee: 68 GoSliceDataType []int.array
-    - __kind: GoSliceDataType
-      ID: 70
-      Name: '[]string.array'
-      ByteSize: 2048
-      Element: 7 GoStringHeaderType string
-    - __kind: PointerType
-      ID: 71
-      Name: '*[]string.array'
-      ByteSize: 8
-      Pointee: 70 GoSliceDataType []string.array
-    - __kind: GoSliceDataType
-      ID: 72
-      Name: '[]bucket<string,int>.array'
-      ByteSize: 2048
-      Element: 21 GoHMapBucketType bucket<string,int>
-    - __kind: GoSliceDataType
-      ID: 73
-      Name: '[]*runtime.bmap.array'
-      ByteSize: 2048
-      Element: 31 PointerType *runtime.bmap
-    - __kind: PointerType
-      ID: 74
-      Name: '*[]*runtime.bmap.array'
-      ByteSize: 8
-      Pointee: 73 GoSliceDataType []*runtime.bmap.array
-    - __kind: GoSliceDataType
-      ID: 75
-      Name: '[]bucket<string,main.bigStruct>.array'
-      ByteSize: 2048
-      Element: 37 GoHMapBucketType bucket<string,main.bigStruct>
-    - __kind: EventRootType
-      ID: 76
-      Name: Probe[main.intArg]
-      ByteSize: 9
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: x
-          Offset: 1
-          Expression:
-            Type: 1 BaseType int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 4, index: 0, name: x}
-                  Offset: 0
-                  ByteSize: 8
-    - __kind: EventRootType
-      ID: 77
-      Name: Probe[main.stringArg]
-      ByteSize: 17
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: s
-          Offset: 1
-          Expression:
-            Type: 7 GoStringHeaderType string
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 5, index: 0, name: s}
-                  Offset: 0
-                  ByteSize: 16
-    - __kind: EventRootType
-      ID: 78
-      Name: Probe[main.intSliceArg]
-      ByteSize: 25
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: s
-          Offset: 1
-          Expression:
-            Type: 10 GoSliceHeaderType []int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 6, index: 0, name: s}
-                  Offset: 0
-                  ByteSize: 24
-    - __kind: EventRootType
-      ID: 79
-      Name: Probe[main.intArrayArg]
-      ByteSize: 25
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: s
-          Offset: 1
-          Expression:
-            Type: 11 ArrayType [3]int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 7, index: 0, name: s}
-                  Offset: 0
-                  ByteSize: 24
-    - __kind: EventRootType
-      ID: 80
-      Name: Probe[main.stringSliceArg]
-      ByteSize: 25
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: s
-          Offset: 1
-          Expression:
-            Type: 12 GoSliceHeaderType []string
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 8, index: 0, name: s}
-                  Offset: 0
-                  ByteSize: 24
-    - __kind: EventRootType
-      ID: 81
-      Name: Probe[main.stringArrayArg]
-      ByteSize: 49
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: s
-          Offset: 1
-          Expression:
-            Type: 14 ArrayType [3]string
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 9, index: 0, name: s}
-                  Offset: 0
-                  ByteSize: 48
-    - __kind: EventRootType
-      ID: 82
-      Name: Probe[main.stringArrayArgFrameless]
-      ByteSize: 49
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: s
-          Offset: 1
-          Expression:
-            Type: 14 ArrayType [3]string
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 10, index: 0, name: s}
-                  Offset: 0
-                  ByteSize: 48
-    - __kind: EventRootType
-      ID: 83
-      Name: Probe[main.mapArg]
-      ByteSize: 9
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: m
-          Offset: 1
-          Expression:
-            Type: 15 GoMapType map[string]int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 11, index: 0, name: m}
-                  Offset: 0
-                  ByteSize: 8
-    - __kind: EventRootType
-      ID: 84
-      Name: Probe[main.bigMapArg]
-      ByteSize: 9
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: m
-          Offset: 1
-          Expression:
-            Type: 33 GoMapType map[string]main.bigStruct
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 12, index: 0, name: m}
-                  Offset: 0
-                  ByteSize: 8
-    - __kind: EventRootType
-      ID: 85
-      Name: Probe[main.inlined]
-      ByteSize: 9
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: x
-          Offset: 1
-          Expression:
-            Type: 1 BaseType int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 1, index: 0, name: x}
-                  Offset: 0
-                  ByteSize: 8
-    - __kind: EventRootType
-      ID: 86
-      Name: Probe[main.PointerChainArg]
-      ByteSize: 9
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: ptr
-          Offset: 1
-          Expression:
-            Type: 2 PointerType *****int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 2, index: 0, name: ptr}
-                  Offset: 0
-                  ByteSize: 8
-    - __kind: EventRootType
-      ID: 87
-      Name: Probe[main.PointerSmallChainArg]
-      ByteSize: 9
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: ptr
-          Offset: 1
-          Expression:
-            Type: 5 PointerType **int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 3, index: 0, name: ptr}
-                  Offset: 0
-                  ByteSize: 8
 MaxTypeID: 87
 Issues: []
 GoModuledataInfo: {FirstModuledataAddr: "0x191240", TypesOffset: 296}

--- a/pkg/dyninst/irgen/testdata/snapshot/simple.arch=arm64,toolchain=go1.23.11.yaml
+++ b/pkg/dyninst/irgen/testdata/snapshot/simple.arch=arm64,toolchain=go1.23.11.yaml
@@ -14,7 +14,7 @@ Probes:
       subprogram: {subprogram: 11}
       events:
         - ID: 11
-          Type: 86 EventRootType Probe[main.PointerChainArg]
+          Type: 79 EventRootType Probe[main.PointerChainArg]
           InjectionPoints: [{PC: "0xb5338", Frameless: false}]
           Condition: null
     - id: PointerSmallChainArg
@@ -31,7 +31,7 @@ Probes:
       subprogram: {subprogram: 12}
       events:
         - ID: 12
-          Type: 87 EventRootType Probe[main.PointerSmallChainArg]
+          Type: 80 EventRootType Probe[main.PointerSmallChainArg]
           InjectionPoints: [{PC: "0xb5370", Frameless: false}]
           Condition: null
     - id: bigMapArg
@@ -44,7 +44,7 @@ Probes:
       subprogram: {subprogram: 9}
       events:
         - ID: 9
-          Type: 84 EventRootType Probe[main.bigMapArg]
+          Type: 77 EventRootType Probe[main.bigMapArg]
           InjectionPoints: [{PC: "0xb5820", Frameless: true}]
           Condition: null
     - id: inlined
@@ -58,7 +58,7 @@ Probes:
       subprogram: {subprogram: 10}
       events:
         - ID: 10
-          Type: 85 EventRootType Probe[main.inlined]
+          Type: 78 EventRootType Probe[main.inlined]
           InjectionPoints:
             - PC: "0xb56ec"
               Frameless: true
@@ -75,7 +75,7 @@ Probes:
       subprogram: {subprogram: 1}
       events:
         - ID: 1
-          Type: 76 EventRootType Probe[main.intArg]
+          Type: 69 EventRootType Probe[main.intArg]
           InjectionPoints: [{PC: "0xb53cc", Frameless: true}]
           Condition: null
     - id: intArrayArg
@@ -88,7 +88,7 @@ Probes:
       subprogram: {subprogram: 4}
       events:
         - ID: 4
-          Type: 79 EventRootType Probe[main.intArrayArg]
+          Type: 72 EventRootType Probe[main.intArrayArg]
           InjectionPoints: [{PC: "0xb554c", Frameless: true}]
           Condition: null
     - id: intArrayArgFrameless
@@ -101,7 +101,7 @@ Probes:
       subprogram: {subprogram: 7}
       events:
         - ID: 7
-          Type: 82 EventRootType Probe[main.stringArrayArgFrameless]
+          Type: 75 EventRootType Probe[main.stringArrayArgFrameless]
           InjectionPoints: [{PC: "0xb56d0", Frameless: true}]
           Condition: null
     - id: intSliceArg
@@ -114,7 +114,7 @@ Probes:
       subprogram: {subprogram: 3}
       events:
         - ID: 3
-          Type: 78 EventRootType Probe[main.intSliceArg]
+          Type: 71 EventRootType Probe[main.intSliceArg]
           InjectionPoints: [{PC: "0xb54bc", Frameless: true}]
           Condition: null
     - id: mapArg
@@ -127,7 +127,7 @@ Probes:
       subprogram: {subprogram: 8}
       events:
         - ID: 8
-          Type: 83 EventRootType Probe[main.mapArg]
+          Type: 76 EventRootType Probe[main.mapArg]
           InjectionPoints: [{PC: "0xb57ac", Frameless: true}]
           Condition: null
     - id: stringArg
@@ -140,7 +140,7 @@ Probes:
       subprogram: {subprogram: 2}
       events:
         - ID: 2
-          Type: 77 EventRootType Probe[main.stringArg]
+          Type: 70 EventRootType Probe[main.stringArg]
           InjectionPoints: [{PC: "0xb543c", Frameless: true}]
           Condition: null
     - id: stringArrayArg
@@ -153,7 +153,7 @@ Probes:
       subprogram: {subprogram: 6}
       events:
         - ID: 6
-          Type: 81 EventRootType Probe[main.stringArrayArg]
+          Type: 74 EventRootType Probe[main.stringArrayArg]
           InjectionPoints: [{PC: "0xb565c", Frameless: true}]
           Condition: null
     - id: stringSliceArg
@@ -166,7 +166,7 @@ Probes:
       subprogram: {subprogram: 5}
       events:
         - ID: 5
-          Type: 80 EventRootType Probe[main.stringSliceArg]
+          Type: 73 EventRootType Probe[main.stringSliceArg]
           InjectionPoints: [{PC: "0xb55cc", Frameless: true}]
           Condition: null
 Subprograms:
@@ -354,9 +354,9 @@ Types:
       ByteSize: 8
       GoRuntimeType: 32416
       GoKind: 22
-      Pointee: 63 PointerType ***int
+      Pointee: 67 PointerType ***int
     - __kind: PointerType
-      ID: 63
+      ID: 67
       Name: '***int'
       ByteSize: 8
       GoRuntimeType: 32352
@@ -370,32 +370,15 @@ Types:
       GoKind: 22
       Pointee: 28 PointerType *int
     - __kind: PointerType
-      ID: 72
-      Name: '**runtime.bmap'
-      ByteSize: 8
-      Pointee: 58 PointerType *runtime.bmap
-    - __kind: PointerType
       ID: 56
-      Name: '*[]*runtime.bmap'
-      ByteSize: 8
-      GoRuntimeType: 35936
-      GoKind: 22
-      Pointee: 57 GoSliceHeaderType []*runtime.bmap
-    - __kind: PointerType
-      ID: 75
-      Name: '*[]*runtime.bmap.array'
-      ByteSize: 8
-      Pointee: 74 GoSliceDataType []*runtime.bmap.array
-    - __kind: PointerType
-      ID: 67
       Name: '*[]int.array'
       ByteSize: 8
-      Pointee: 66 GoSliceDataType []int.array
+      Pointee: 55 GoSliceDataType []int.array
     - __kind: PointerType
-      ID: 69
+      ID: 58
       Name: '*[]string.array'
       ByteSize: 8
-      Pointee: 68 GoSliceDataType []string.array
+      Pointee: 57 GoSliceDataType []string.array
     - __kind: PointerType
       ID: 5
       Name: '*bool'
@@ -466,26 +449,19 @@ Types:
       GoKind: 22
       Pointee: 14 BaseType int64
     - __kind: PointerType
-      ID: 61
+      ID: 64
       Name: '*main.bigStruct'
       ByteSize: 8
       GoRuntimeType: 24224
       GoKind: 22
-      Pointee: 62 StructureType main.bigStruct
-    - __kind: PointerType
-      ID: 58
-      Name: '*runtime.bmap'
-      ByteSize: 8
-      GoRuntimeType: 66400
-      GoKind: 22
-      Pointee: 59 StructureType runtime.bmap
+      Pointee: 65 StructureType main.bigStruct
     - __kind: PointerType
       ID: 43
       Name: '*runtime.mapextra'
       ByteSize: 8
       GoRuntimeType: 29728
       GoKind: 22
-      Pointee: 44 StructureType runtime.mapextra
+      Pointee: 44 UnresolvedPointeeType runtime.mapextra
     - __kind: PointerType
       ID: 22
       Name: '*string'
@@ -494,10 +470,10 @@ Types:
       GoKind: 22
       Pointee: 10 GoStringHeaderType string
     - __kind: PointerType
-      ID: 65
+      ID: 54
       Name: '*string.str'
       ByteSize: 8
-      Pointee: 64 GoStringDataType string.str
+      Pointee: 53 GoStringDataType string.str
     - __kind: PointerType
       ID: 32
       Name: '*uint'
@@ -541,7 +517,7 @@ Types:
       GoKind: 22
       Pointee: 1 BaseType uintptr
     - __kind: EventRootType
-      ID: 86
+      ID: 79
       Name: Probe[main.PointerChainArg]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -556,7 +532,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 87
+      ID: 80
       Name: Probe[main.PointerSmallChainArg]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -571,7 +547,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 84
+      ID: 77
       Name: Probe[main.bigMapArg]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -586,7 +562,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 85
+      ID: 78
       Name: Probe[main.inlined]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -601,7 +577,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 76
+      ID: 69
       Name: Probe[main.intArg]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -616,7 +592,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 79
+      ID: 72
       Name: Probe[main.intArrayArg]
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -631,7 +607,7 @@ Types:
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 78
+      ID: 71
       Name: Probe[main.intSliceArg]
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -646,7 +622,7 @@ Types:
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 83
+      ID: 76
       Name: Probe[main.mapArg]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -661,7 +637,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 77
+      ID: 70
       Name: Probe[main.stringArg]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -676,7 +652,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 82
+      ID: 75
       Name: Probe[main.stringArrayArgFrameless]
       ByteSize: 49
       PresenceBitsetSize: 1
@@ -691,7 +667,7 @@ Types:
                   Offset: 0
                   ByteSize: 48
     - __kind: EventRootType
-      ID: 81
+      ID: 74
       Name: Probe[main.stringArrayArg]
       ByteSize: 49
       PresenceBitsetSize: 1
@@ -706,7 +682,7 @@ Types:
                   Offset: 0
                   ByteSize: 48
     - __kind: EventRootType
-      ID: 80
+      ID: 73
       Name: Probe[main.stringSliceArg]
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -721,7 +697,7 @@ Types:
                   Offset: 0
                   ByteSize: 24
     - __kind: ArrayType
-      ID: 73
+      ID: 68
       Name: '[128]uint8'
       ByteSize: 128
       GoRuntimeType: 41856
@@ -748,7 +724,7 @@ Types:
       HasCount: true
       Element: 10 GoStringHeaderType string
     - __kind: ArrayType
-      ID: 53
+      ID: 59
       Name: '[8]uint8'
       ByteSize: 8
       GoRuntimeType: 41568
@@ -756,35 +732,13 @@ Types:
       Count: 8
       HasCount: true
       Element: 3 BaseType uint8
-    - __kind: GoSliceHeaderType
-      ID: 57
-      Name: '[]*runtime.bmap'
-      ByteSize: 24
-      GoRuntimeType: 35872
-      GoKind: 23
-      RawFields:
-        - Name: array
-          Offset: 0
-          Type: 72 PointerType **runtime.bmap
-        - Name: len
-          Offset: 8
-          Type: 9 BaseType int
-        - Name: cap
-          Offset: 16
-          Type: 9 BaseType int
-      Data: 74 GoSliceDataType []*runtime.bmap.array
     - __kind: GoSliceDataType
-      ID: 74
-      Name: '[]*runtime.bmap.array'
-      ByteSize: 2048
-      Element: 58 PointerType *runtime.bmap
-    - __kind: GoSliceDataType
-      ID: 70
+      ID: 62
       Name: '[]bucket<string,int>.array'
       ByteSize: 2048
       Element: 42 GoHMapBucketType bucket<string,int>
     - __kind: GoSliceDataType
-      ID: 71
+      ID: 66
       Name: '[]bucket<string,main.bigStruct>.array'
       ByteSize: 2048
       Element: 49 GoHMapBucketType bucket<string,main.bigStruct>
@@ -804,14 +758,14 @@ Types:
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 66 GoSliceDataType []int.array
+      Data: 55 GoSliceDataType []int.array
     - __kind: GoSliceDataType
-      ID: 66
+      ID: 55
       Name: '[]int.array'
       ByteSize: 2048
       Element: 9 BaseType int
     - __kind: ArrayType
-      ID: 54
+      ID: 60
       Name: '[]key<string>'
       ByteSize: 128
       Count: 8
@@ -833,26 +787,26 @@ Types:
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 68 GoSliceDataType []string.array
+      Data: 57 GoSliceDataType []string.array
     - __kind: GoSliceDataType
-      ID: 68
+      ID: 57
       Name: '[]string.array'
       ByteSize: 2048
       Element: 10 GoStringHeaderType string
     - __kind: ArrayType
-      ID: 55
+      ID: 61
       Name: '[]val<int>'
       ByteSize: 64
       Count: 8
       HasCount: true
       Element: 9 BaseType int
     - __kind: ArrayType
-      ID: 60
+      ID: 63
       Name: '[]val<main.bigStruct>'
       ByteSize: 64
       Count: 8
       HasCount: true
-      Element: 61 PointerType *main.bigStruct
+      Element: 64 PointerType *main.bigStruct
     - __kind: BaseType
       ID: 4
       Name: bool
@@ -866,13 +820,13 @@ Types:
       RawFields:
         - Name: tophash
           Offset: 0
-          Type: 53 ArrayType [8]uint8
+          Type: 59 ArrayType [8]uint8
         - Name: keys
           Offset: 8
-          Type: 54 ArrayType []key<string>
+          Type: 60 ArrayType []key<string>
         - Name: values
           Offset: 136
-          Type: 55 ArrayType []val<int>
+          Type: 61 ArrayType []val<int>
         - Name: overflow
           Offset: 200
           Type: 41 PointerType *bucket<string,int>
@@ -885,18 +839,18 @@ Types:
       RawFields:
         - Name: tophash
           Offset: 0
-          Type: 53 ArrayType [8]uint8
+          Type: 59 ArrayType [8]uint8
         - Name: keys
           Offset: 8
-          Type: 54 ArrayType []key<string>
+          Type: 60 ArrayType []key<string>
         - Name: values
           Offset: 136
-          Type: 60 ArrayType []val<main.bigStruct>
+          Type: 63 ArrayType []val<main.bigStruct>
         - Name: overflow
           Offset: 200
           Type: 48 PointerType *bucket<string,main.bigStruct>
       KeyType: 10 GoStringHeaderType string
-      ValueType: 61 PointerType *main.bigStruct
+      ValueType: 64 PointerType *main.bigStruct
     - __kind: BaseType
       ID: 25
       Name: complex128
@@ -967,7 +921,7 @@ Types:
           Offset: 40
           Type: 43 PointerType *runtime.mapextra
       BucketType: 42 GoHMapBucketType bucket<string,int>
-      BucketsType: 70 GoSliceDataType []bucket<string,int>.array
+      BucketsType: 62 GoSliceDataType []bucket<string,int>.array
     - __kind: GoHMapHeaderType
       ID: 47
       Name: hash<string,main.bigStruct>
@@ -1001,7 +955,7 @@ Types:
           Offset: 40
           Type: 43 PointerType *runtime.mapextra
       BucketType: 49 GoHMapBucketType bucket<string,main.bigStruct>
-      BucketsType: 71 GoSliceDataType []bucket<string,main.bigStruct>.array
+      BucketsType: 66 GoSliceDataType []bucket<string,main.bigStruct>.array
     - __kind: BaseType
       ID: 9
       Name: int
@@ -1033,7 +987,7 @@ Types:
       GoRuntimeType: 37472
       GoKind: 3
     - __kind: StructureType
-      ID: 62
+      ID: 65
       Name: main.bigStruct
       ByteSize: 184
       GoRuntimeType: 110400
@@ -1062,7 +1016,7 @@ Types:
           Type: 9 BaseType int
         - Name: data
           Offset: 56
-          Type: 73 ArrayType [128]uint8
+          Type: 68 ArrayType [128]uint8
     - __kind: GoMapType
       ID: 38
       Name: map[string]int
@@ -1077,32 +1031,10 @@ Types:
       GoRuntimeType: 54624
       GoKind: 21
       HeaderType: 47 GoHMapHeaderType hash<string,main.bigStruct>
-    - __kind: StructureType
-      ID: 59
-      Name: runtime.bmap
-      ByteSize: 8
-      GoRuntimeType: 66272
-      GoKind: 25
-      RawFields:
-        - Name: tophash
-          Offset: 0
-          Type: 53 ArrayType [8]uint8
-    - __kind: StructureType
+    - __kind: UnresolvedPointeeType
       ID: 44
       Name: runtime.mapextra
-      ByteSize: 24
-      GoRuntimeType: 87104
-      GoKind: 25
-      RawFields:
-        - Name: overflow
-          Offset: 0
-          Type: 56 PointerType *[]*runtime.bmap
-        - Name: oldoverflow
-          Offset: 8
-          Type: 56 PointerType *[]*runtime.bmap
-        - Name: nextOverflow
-          Offset: 16
-          Type: 58 PointerType *runtime.bmap
+      ByteSize: 8
     - __kind: GoStringHeaderType
       ID: 10
       Name: string
@@ -1112,13 +1044,13 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 65 PointerType *string.str
+          Type: 54 PointerType *string.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 64 GoStringDataType string.str
+      Data: 53 GoStringDataType string.str
     - __kind: GoStringDataType
-      ID: 64
+      ID: 53
       Name: string.str
       ByteSize: 2048
     - __kind: BaseType
@@ -1163,6 +1095,6 @@ Types:
       ByteSize: 8
       GoRuntimeType: 38496
       GoKind: 26
-MaxTypeID: 87
+MaxTypeID: 80
 Issues: []
 GoModuledataInfo: {FirstModuledataAddr: "0x191240", TypesOffset: 296}

--- a/pkg/dyninst/irgen/testdata/snapshot/simple.arch=arm64,toolchain=go1.23.11.yaml
+++ b/pkg/dyninst/irgen/testdata/snapshot/simple.arch=arm64,toolchain=go1.23.11.yaml
@@ -11,7 +11,7 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 2}
+      subprogram: {subprogram: 11}
       events:
         - ID: 11
           Type: 86 EventRootType Probe[main.PointerChainArg]
@@ -28,7 +28,7 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 3}
+      subprogram: {subprogram: 12}
       events:
         - ID: 12
           Type: 87 EventRootType Probe[main.PointerSmallChainArg]
@@ -41,7 +41,7 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 12}
+      subprogram: {subprogram: 9}
       events:
         - ID: 9
           Type: 84 EventRootType Probe[main.bigMapArg]
@@ -55,7 +55,7 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 1}
+      subprogram: {subprogram: 10}
       events:
         - ID: 10
           Type: 85 EventRootType Probe[main.inlined]
@@ -72,7 +72,7 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 4}
+      subprogram: {subprogram: 1}
       events:
         - ID: 1
           Type: 76 EventRootType Probe[main.intArg]
@@ -85,7 +85,7 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 7}
+      subprogram: {subprogram: 4}
       events:
         - ID: 4
           Type: 79 EventRootType Probe[main.intArrayArg]
@@ -98,7 +98,7 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 10}
+      subprogram: {subprogram: 7}
       events:
         - ID: 7
           Type: 82 EventRootType Probe[main.stringArrayArgFrameless]
@@ -111,7 +111,7 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 6}
+      subprogram: {subprogram: 3}
       events:
         - ID: 3
           Type: 78 EventRootType Probe[main.intSliceArg]
@@ -124,7 +124,7 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 11}
+      subprogram: {subprogram: 8}
       events:
         - ID: 8
           Type: 83 EventRootType Probe[main.mapArg]
@@ -137,7 +137,7 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 5}
+      subprogram: {subprogram: 2}
       events:
         - ID: 2
           Type: 77 EventRootType Probe[main.stringArg]
@@ -150,7 +150,7 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 9}
+      subprogram: {subprogram: 6}
       events:
         - ID: 6
           Type: 81 EventRootType Probe[main.stringArrayArg]
@@ -163,32 +163,32 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 8}
+      subprogram: {subprogram: 5}
       events:
         - ID: 5
           Type: 80 EventRootType Probe[main.stringSliceArg]
           InjectionPoints: [{PC: "0xb55cc", Frameless: true}]
           Condition: null
 Subprograms:
-    - ID: 4
+    - ID: 1
       Name: main.intArg
       OutOfLinePCRanges: [0xb53c0..0xb5430]
       InlinePCRanges: []
       Variables:
         - Name: x
-          Type: 1 BaseType int
+          Type: 9 BaseType int
           Locations:
             - Range: 0xb53c0..0xb53e0
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 5
+    - ID: 2
       Name: main.stringArg
       OutOfLinePCRanges: [0xb5430..0xb54b0]
       InlinePCRanges: []
       Variables:
         - Name: s
-          Type: 7 GoStringHeaderType string
+          Type: 10 GoStringHeaderType string
           Locations:
             - Range: 0xb5430..0xb5454
               Pieces:
@@ -198,13 +198,13 @@ Subprograms:
                   Op: {RegNo: 1, Shift: 0}
           IsParameter: true
           IsReturn: false
-    - ID: 6
+    - ID: 3
       Name: main.intSliceArg
       OutOfLinePCRanges: [0xb54b0..0xb5540]
       InlinePCRanges: []
       Variables:
         - Name: s
-          Type: 10 GoSliceHeaderType []int
+          Type: 34 GoSliceHeaderType []int
           Locations:
             - Range: 0xb54b0..0xb54d4
               Pieces:
@@ -216,25 +216,25 @@ Subprograms:
                   Op: {RegNo: 2, Shift: 0}
           IsParameter: true
           IsReturn: false
-    - ID: 7
+    - ID: 4
       Name: main.intArrayArg
       OutOfLinePCRanges: [0xb5540..0xb55c0]
       InlinePCRanges: []
       Variables:
         - Name: s
-          Type: 11 ArrayType [3]int
+          Type: 35 ArrayType [3]int
           Locations:
             - Range: 0xb5540..0xb55c0
               Pieces: [{Size: 24, Op: {CfaOffset: 8}}]
           IsParameter: true
           IsReturn: false
-    - ID: 8
+    - ID: 5
       Name: main.stringSliceArg
       OutOfLinePCRanges: [0xb55c0..0xb5650]
       InlinePCRanges: []
       Variables:
         - Name: s
-          Type: 12 GoSliceHeaderType []string
+          Type: 36 GoSliceHeaderType []string
           Locations:
             - Range: 0xb55c0..0xb55e4
               Pieces:
@@ -246,49 +246,49 @@ Subprograms:
                   Op: {RegNo: 2, Shift: 0}
           IsParameter: true
           IsReturn: false
-    - ID: 9
+    - ID: 6
       Name: main.stringArrayArg
       OutOfLinePCRanges: [0xb5650..0xb56d0]
       InlinePCRanges: []
       Variables:
         - Name: s
-          Type: 14 ArrayType [3]string
+          Type: 37 ArrayType [3]string
           Locations:
             - Range: 0xb5650..0xb56d0
               Pieces: [{Size: 48, Op: {CfaOffset: 8}}]
           IsParameter: true
           IsReturn: false
-    - ID: 10
+    - ID: 7
       Name: main.stringArrayArgFrameless
       OutOfLinePCRanges: [0xb56d0..0xb56e0]
       InlinePCRanges: []
       Variables:
         - Name: s
-          Type: 14 ArrayType [3]string
+          Type: 37 ArrayType [3]string
           Locations:
             - Range: 0xb56d0..0xb56e0
               Pieces: [{Size: 48, Op: {CfaOffset: 8}}]
           IsParameter: true
           IsReturn: false
-    - ID: 11
+    - ID: 8
       Name: main.mapArg
       OutOfLinePCRanges: [0xb57a0..0xb5810]
       InlinePCRanges: []
       Variables:
         - Name: m
-          Type: 15 GoMapType map[string]int
+          Type: 38 GoMapType map[string]int
           Locations:
             - Range: 0xb57a0..0xb57d8
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 12
+    - ID: 9
       Name: main.bigMapArg
       OutOfLinePCRanges: [0xb5810..0xb58d0]
       InlinePCRanges: []
       Variables:
         - Name: m
-          Type: 33 GoMapType map[string]main.bigStruct
+          Type: 53 GoMapType map[string]main.bigStruct
           Locations:
             - Range: 0xb5810..0xb5848
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
@@ -296,7 +296,7 @@ Subprograms:
               Pieces: [{Size: 8, Op: {CfaOffset: 8}}]
           IsParameter: true
           IsReturn: false
-    - ID: 1
+    - ID: 10
       Name: main.inlined
       OutOfLinePCRanges: [0xb56e0..0xb5750]
       InlinePCRanges:
@@ -304,7 +304,7 @@ Subprograms:
           RootRanges: [0xb4fb0..0xb53c0]
       Variables:
         - Name: x
-          Type: 1 BaseType int
+          Type: 9 BaseType int
           Locations:
             - Range: 0xb514c..0xb518c
               Pieces: []
@@ -312,7 +312,7 @@ Subprograms:
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 2
+    - ID: 11
       Name: main.PointerChainArg
       OutOfLinePCRanges: []
       InlinePCRanges:
@@ -320,13 +320,13 @@ Subprograms:
           RootRanges: [0xb4fb0..0xb53c0]
       Variables:
         - Name: ptr
-          Type: 2 PointerType *****int
+          Type: 62 PointerType *****int
           Locations:
             - Range: 0xb5310..0xb5358
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 3
+    - ID: 12
       Name: main.PointerSmallChainArg
       OutOfLinePCRanges: []
       InlinePCRanges:
@@ -334,7 +334,7 @@ Subprograms:
           RootRanges: [0xb4fb0..0xb53c0]
       Variables:
         - Name: ptr
-          Type: 5 PointerType **int
+          Type: 65 PointerType **int
           Locations:
             - Range: 0xb5370..0xb53a0
               Pieces: [{Size: 8, Op: {RegNo: 5, Shift: 0}}]
@@ -342,45 +342,45 @@ Subprograms:
           IsReturn: false
 Types:
     - __kind: PointerType
-      ID: 2
+      ID: 62
       Name: '*****int'
       ByteSize: 8
       GoRuntimeType: 32480
       GoKind: 22
-      Pointee: 3 PointerType ****int
+      Pointee: 63 PointerType ****int
     - __kind: PointerType
-      ID: 3
+      ID: 63
       Name: '****int'
       ByteSize: 8
       GoRuntimeType: 32416
       GoKind: 22
-      Pointee: 4 PointerType ***int
+      Pointee: 64 PointerType ***int
     - __kind: PointerType
-      ID: 4
+      ID: 64
       Name: '***int'
       ByteSize: 8
       GoRuntimeType: 32352
       GoKind: 22
-      Pointee: 5 PointerType **int
+      Pointee: 65 PointerType **int
     - __kind: PointerType
-      ID: 5
+      ID: 65
       Name: '**int'
       ByteSize: 8
       GoRuntimeType: 32288
       GoKind: 22
-      Pointee: 6 PointerType *int
+      Pointee: 28 PointerType *int
     - __kind: PointerType
-      ID: 30
+      ID: 50
       Name: '**runtime.bmap'
       ByteSize: 8
-      Pointee: 31 PointerType *runtime.bmap
+      Pointee: 51 PointerType *runtime.bmap
     - __kind: PointerType
-      ID: 28
+      ID: 48
       Name: '*[]*runtime.bmap'
       ByteSize: 8
       GoRuntimeType: 35936
       GoKind: 22
-      Pointee: 29 GoSliceHeaderType []*runtime.bmap
+      Pointee: 49 GoSliceHeaderType []*runtime.bmap
     - __kind: PointerType
       ID: 74
       Name: '*[]*runtime.bmap.array'
@@ -397,149 +397,149 @@ Types:
       ByteSize: 8
       Pointee: 70 GoSliceDataType []string.array
     - __kind: PointerType
-      ID: 43
+      ID: 5
       Name: '*bool'
       ByteSize: 8
       GoRuntimeType: 26912
       GoKind: 22
-      Pointee: 42 BaseType bool
+      Pointee: 4 BaseType bool
     - __kind: PointerType
-      ID: 20
+      ID: 41
       Name: '*bucket<string,int>'
       ByteSize: 8
-      Pointee: 21 GoHMapBucketType bucket<string,int>
+      Pointee: 42 GoHMapBucketType bucket<string,int>
     - __kind: PointerType
-      ID: 36
+      ID: 56
       Name: '*bucket<string,main.bigStruct>'
       ByteSize: 8
-      Pointee: 37 GoHMapBucketType bucket<string,main.bigStruct>
+      Pointee: 57 GoHMapBucketType bucket<string,main.bigStruct>
     - __kind: PointerType
-      ID: 62
+      ID: 30
       Name: '*error'
       ByteSize: 8
       GoRuntimeType: 25824
       GoKind: 22
-      Pointee: 52 GoInterfaceType error
+      Pointee: 18 GoInterfaceType error
     - __kind: PointerType
-      ID: 63
+      ID: 31
       Name: '*float32'
       ByteSize: 8
       GoRuntimeType: 26784
       GoKind: 22
-      Pointee: 50 BaseType float32
+      Pointee: 16 BaseType float32
     - __kind: PointerType
-      ID: 59
+      ID: 26
       Name: '*float64'
       ByteSize: 8
       GoRuntimeType: 26848
       GoKind: 22
-      Pointee: 51 BaseType float64
+      Pointee: 17 BaseType float64
     - __kind: PointerType
-      ID: 16
+      ID: 39
       Name: '*hash<string,int>'
       ByteSize: 8
-      Pointee: 17 GoHMapHeaderType hash<string,int>
+      Pointee: 40 GoHMapHeaderType hash<string,int>
     - __kind: PointerType
-      ID: 34
+      ID: 54
       Name: '*hash<string,main.bigStruct>'
       ByteSize: 8
-      Pointee: 35 GoHMapHeaderType hash<string,main.bigStruct>
+      Pointee: 55 GoHMapHeaderType hash<string,main.bigStruct>
     - __kind: PointerType
-      ID: 6
+      ID: 28
       Name: '*int'
       ByteSize: 8
       GoRuntimeType: 26464
       GoKind: 22
-      Pointee: 1 BaseType int
+      Pointee: 9 BaseType int
     - __kind: PointerType
-      ID: 54
+      ID: 20
       Name: '*int32'
       ByteSize: 8
       GoRuntimeType: 26208
       GoKind: 22
-      Pointee: 47 BaseType int32
+      Pointee: 13 BaseType int32
     - __kind: PointerType
-      ID: 60
+      ID: 27
       Name: '*int64'
       ByteSize: 8
       GoRuntimeType: 26336
       GoKind: 22
-      Pointee: 48 BaseType int64
+      Pointee: 14 BaseType int64
     - __kind: PointerType
-      ID: 39
+      ID: 59
       Name: '*main.bigStruct'
       ByteSize: 8
       GoRuntimeType: 24224
       GoKind: 22
-      Pointee: 40 StructureType main.bigStruct
+      Pointee: 60 StructureType main.bigStruct
     - __kind: PointerType
-      ID: 31
+      ID: 51
       Name: '*runtime.bmap'
       ByteSize: 8
       GoRuntimeType: 66400
       GoKind: 22
-      Pointee: 32 StructureType runtime.bmap
+      Pointee: 52 StructureType runtime.bmap
     - __kind: PointerType
-      ID: 26
+      ID: 46
       Name: '*runtime.mapextra'
       ByteSize: 8
       GoRuntimeType: 29728
       GoKind: 22
-      Pointee: 27 StructureType runtime.mapextra
+      Pointee: 47 StructureType runtime.mapextra
     - __kind: PointerType
-      ID: 13
+      ID: 22
       Name: '*string'
       ByteSize: 8
       GoRuntimeType: 25888
       GoKind: 22
-      Pointee: 7 GoStringHeaderType string
+      Pointee: 10 GoStringHeaderType string
     - __kind: PointerType
       ID: 67
       Name: '*string.str'
       ByteSize: 8
       Pointee: 66 GoStringDataType string.str
     - __kind: PointerType
-      ID: 64
+      ID: 32
       Name: '*uint'
       ByteSize: 8
       GoRuntimeType: 26528
       GoKind: 22
-      Pointee: 46 BaseType uint
+      Pointee: 12 BaseType uint
     - __kind: PointerType
-      ID: 65
+      ID: 33
       Name: '*uint16'
       ByteSize: 8
       GoRuntimeType: 26144
       GoKind: 22
-      Pointee: 18 BaseType uint16
+      Pointee: 7 BaseType uint16
     - __kind: PointerType
-      ID: 55
+      ID: 21
       Name: '*uint32'
       ByteSize: 8
       GoRuntimeType: 26272
       GoKind: 22
-      Pointee: 19 BaseType uint32
+      Pointee: 2 BaseType uint32
     - __kind: PointerType
-      ID: 61
+      ID: 29
       Name: '*uint64'
       ByteSize: 8
       GoRuntimeType: 26400
       GoKind: 22
-      Pointee: 45 BaseType uint64
+      Pointee: 11 BaseType uint64
     - __kind: PointerType
-      ID: 8
+      ID: 6
       Name: '*uint8'
       ByteSize: 8
       GoRuntimeType: 26016
       GoKind: 22
-      Pointee: 9 BaseType uint8
+      Pointee: 3 BaseType uint8
     - __kind: PointerType
-      ID: 44
+      ID: 8
       Name: '*uintptr'
       ByteSize: 8
       GoRuntimeType: 26592
       GoKind: 22
-      Pointee: 25 BaseType uintptr
+      Pointee: 1 BaseType uintptr
     - __kind: EventRootType
       ID: 86
       Name: Probe[main.PointerChainArg]
@@ -549,10 +549,10 @@ Types:
         - Name: ptr
           Offset: 1
           Expression:
-            Type: 2 PointerType *****int
+            Type: 62 PointerType *****int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 2, index: 0, name: ptr}
+                  Variable: {subprogram: 11, index: 0, name: ptr}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
@@ -564,10 +564,10 @@ Types:
         - Name: ptr
           Offset: 1
           Expression:
-            Type: 5 PointerType **int
+            Type: 65 PointerType **int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 3, index: 0, name: ptr}
+                  Variable: {subprogram: 12, index: 0, name: ptr}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
@@ -579,10 +579,10 @@ Types:
         - Name: m
           Offset: 1
           Expression:
-            Type: 33 GoMapType map[string]main.bigStruct
+            Type: 53 GoMapType map[string]main.bigStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 12, index: 0, name: m}
+                  Variable: {subprogram: 9, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
@@ -594,10 +594,10 @@ Types:
         - Name: x
           Offset: 1
           Expression:
-            Type: 1 BaseType int
+            Type: 9 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 1, index: 0, name: x}
+                  Variable: {subprogram: 10, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
@@ -609,10 +609,10 @@ Types:
         - Name: x
           Offset: 1
           Expression:
-            Type: 1 BaseType int
+            Type: 9 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 4, index: 0, name: x}
+                  Variable: {subprogram: 1, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
@@ -624,10 +624,10 @@ Types:
         - Name: s
           Offset: 1
           Expression:
-            Type: 11 ArrayType [3]int
+            Type: 35 ArrayType [3]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 7, index: 0, name: s}
+                  Variable: {subprogram: 4, index: 0, name: s}
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
@@ -639,10 +639,10 @@ Types:
         - Name: s
           Offset: 1
           Expression:
-            Type: 10 GoSliceHeaderType []int
+            Type: 34 GoSliceHeaderType []int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 6, index: 0, name: s}
+                  Variable: {subprogram: 3, index: 0, name: s}
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
@@ -654,10 +654,10 @@ Types:
         - Name: m
           Offset: 1
           Expression:
-            Type: 15 GoMapType map[string]int
+            Type: 38 GoMapType map[string]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 11, index: 0, name: m}
+                  Variable: {subprogram: 8, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
@@ -669,10 +669,10 @@ Types:
         - Name: s
           Offset: 1
           Expression:
-            Type: 7 GoStringHeaderType string
+            Type: 10 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 5, index: 0, name: s}
+                  Variable: {subprogram: 2, index: 0, name: s}
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
@@ -684,10 +684,10 @@ Types:
         - Name: s
           Offset: 1
           Expression:
-            Type: 14 ArrayType [3]string
+            Type: 37 ArrayType [3]string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 10, index: 0, name: s}
+                  Variable: {subprogram: 7, index: 0, name: s}
                   Offset: 0
                   ByteSize: 48
     - __kind: EventRootType
@@ -699,10 +699,10 @@ Types:
         - Name: s
           Offset: 1
           Expression:
-            Type: 14 ArrayType [3]string
+            Type: 37 ArrayType [3]string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 9, index: 0, name: s}
+                  Variable: {subprogram: 6, index: 0, name: s}
                   Offset: 0
                   ByteSize: 48
     - __kind: EventRootType
@@ -714,50 +714,50 @@ Types:
         - Name: s
           Offset: 1
           Expression:
-            Type: 12 GoSliceHeaderType []string
+            Type: 36 GoSliceHeaderType []string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 8, index: 0, name: s}
+                  Variable: {subprogram: 5, index: 0, name: s}
                   Offset: 0
                   ByteSize: 24
     - __kind: ArrayType
-      ID: 41
+      ID: 61
       Name: '[128]uint8'
       ByteSize: 128
       GoRuntimeType: 41856
       GoKind: 17
       Count: 128
       HasCount: true
-      Element: 9 BaseType uint8
+      Element: 3 BaseType uint8
     - __kind: ArrayType
-      ID: 11
+      ID: 35
       Name: '[3]int'
       ByteSize: 24
       GoRuntimeType: 41376
       GoKind: 17
       Count: 3
       HasCount: true
-      Element: 1 BaseType int
+      Element: 9 BaseType int
     - __kind: ArrayType
-      ID: 14
+      ID: 37
       Name: '[3]string'
       ByteSize: 48
       GoRuntimeType: 41472
       GoKind: 17
       Count: 3
       HasCount: true
-      Element: 7 GoStringHeaderType string
+      Element: 10 GoStringHeaderType string
     - __kind: ArrayType
-      ID: 22
+      ID: 43
       Name: '[8]uint8'
       ByteSize: 8
       GoRuntimeType: 41568
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 9 BaseType uint8
+      Element: 3 BaseType uint8
     - __kind: GoSliceHeaderType
-      ID: 29
+      ID: 49
       Name: '[]*runtime.bmap'
       ByteSize: 24
       GoRuntimeType: 35872
@@ -765,31 +765,31 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 30 PointerType **runtime.bmap
+          Type: 50 PointerType **runtime.bmap
         - Name: len
           Offset: 8
-          Type: 1 BaseType int
+          Type: 9 BaseType int
         - Name: cap
           Offset: 16
-          Type: 1 BaseType int
+          Type: 9 BaseType int
       Data: 73 GoSliceDataType []*runtime.bmap.array
     - __kind: GoSliceDataType
       ID: 73
       Name: '[]*runtime.bmap.array'
       ByteSize: 2048
-      Element: 31 PointerType *runtime.bmap
+      Element: 51 PointerType *runtime.bmap
     - __kind: GoSliceDataType
       ID: 72
       Name: '[]bucket<string,int>.array'
       ByteSize: 2048
-      Element: 21 GoHMapBucketType bucket<string,int>
+      Element: 42 GoHMapBucketType bucket<string,int>
     - __kind: GoSliceDataType
       ID: 75
       Name: '[]bucket<string,main.bigStruct>.array'
       ByteSize: 2048
-      Element: 37 GoHMapBucketType bucket<string,main.bigStruct>
+      Element: 57 GoHMapBucketType bucket<string,main.bigStruct>
     - __kind: GoSliceHeaderType
-      ID: 10
+      ID: 34
       Name: '[]int'
       ByteSize: 24
       GoRuntimeType: 33952
@@ -797,28 +797,28 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 6 PointerType *int
+          Type: 28 PointerType *int
         - Name: len
           Offset: 8
-          Type: 1 BaseType int
+          Type: 9 BaseType int
         - Name: cap
           Offset: 16
-          Type: 1 BaseType int
+          Type: 9 BaseType int
       Data: 68 GoSliceDataType []int.array
     - __kind: GoSliceDataType
       ID: 68
       Name: '[]int.array'
       ByteSize: 2048
-      Element: 1 BaseType int
+      Element: 9 BaseType int
     - __kind: ArrayType
-      ID: 23
+      ID: 44
       Name: '[]key<string>'
       ByteSize: 128
       Count: 8
       HasCount: true
-      Element: 7 GoStringHeaderType string
+      Element: 10 GoStringHeaderType string
     - __kind: GoSliceHeaderType
-      ID: 12
+      ID: 36
       Name: '[]string'
       ByteSize: 24
       GoRuntimeType: 34272
@@ -826,91 +826,91 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 13 PointerType *string
+          Type: 22 PointerType *string
         - Name: len
           Offset: 8
-          Type: 1 BaseType int
+          Type: 9 BaseType int
         - Name: cap
           Offset: 16
-          Type: 1 BaseType int
+          Type: 9 BaseType int
       Data: 70 GoSliceDataType []string.array
     - __kind: GoSliceDataType
       ID: 70
       Name: '[]string.array'
       ByteSize: 2048
-      Element: 7 GoStringHeaderType string
+      Element: 10 GoStringHeaderType string
     - __kind: ArrayType
-      ID: 24
+      ID: 45
       Name: '[]val<int>'
       ByteSize: 64
       Count: 8
       HasCount: true
-      Element: 1 BaseType int
+      Element: 9 BaseType int
     - __kind: ArrayType
-      ID: 38
+      ID: 58
       Name: '[]val<main.bigStruct>'
       ByteSize: 64
       Count: 8
       HasCount: true
-      Element: 39 PointerType *main.bigStruct
+      Element: 59 PointerType *main.bigStruct
     - __kind: BaseType
-      ID: 42
+      ID: 4
       Name: bool
       ByteSize: 1
       GoRuntimeType: 38432
       GoKind: 1
     - __kind: GoHMapBucketType
-      ID: 21
+      ID: 42
       Name: bucket<string,int>
       ByteSize: 208
       RawFields:
         - Name: tophash
           Offset: 0
-          Type: 22 ArrayType [8]uint8
+          Type: 43 ArrayType [8]uint8
         - Name: keys
           Offset: 8
-          Type: 23 ArrayType []key<string>
+          Type: 44 ArrayType []key<string>
         - Name: values
           Offset: 136
-          Type: 24 ArrayType []val<int>
+          Type: 45 ArrayType []val<int>
         - Name: overflow
           Offset: 200
-          Type: 20 PointerType *bucket<string,int>
-      KeyType: 7 GoStringHeaderType string
-      ValueType: 1 BaseType int
+          Type: 41 PointerType *bucket<string,int>
+      KeyType: 10 GoStringHeaderType string
+      ValueType: 9 BaseType int
     - __kind: GoHMapBucketType
-      ID: 37
+      ID: 57
       Name: bucket<string,main.bigStruct>
       ByteSize: 208
       RawFields:
         - Name: tophash
           Offset: 0
-          Type: 22 ArrayType [8]uint8
+          Type: 43 ArrayType [8]uint8
         - Name: keys
           Offset: 8
-          Type: 23 ArrayType []key<string>
+          Type: 44 ArrayType []key<string>
         - Name: values
           Offset: 136
-          Type: 38 ArrayType []val<main.bigStruct>
+          Type: 58 ArrayType []val<main.bigStruct>
         - Name: overflow
           Offset: 200
-          Type: 36 PointerType *bucket<string,main.bigStruct>
-      KeyType: 7 GoStringHeaderType string
-      ValueType: 39 PointerType *main.bigStruct
+          Type: 56 PointerType *bucket<string,main.bigStruct>
+      KeyType: 10 GoStringHeaderType string
+      ValueType: 59 PointerType *main.bigStruct
     - __kind: BaseType
-      ID: 58
+      ID: 25
       Name: complex128
       ByteSize: 16
       GoRuntimeType: 38240
       GoKind: 16
     - __kind: BaseType
-      ID: 57
+      ID: 24
       Name: complex64
       ByteSize: 8
       GoRuntimeType: 38176
       GoKind: 15
     - __kind: GoInterfaceType
-      ID: 52
+      ID: 18
       Name: error
       ByteSize: 16
       GoRuntimeType: 58880
@@ -918,122 +918,122 @@ Types:
       RawFields:
         - Name: tab
           Offset: 0
-          Type: 53 VoidPointerType unsafe.Pointer
+          Type: 19 VoidPointerType unsafe.Pointer
         - Name: data
           Offset: 8
-          Type: 53 VoidPointerType unsafe.Pointer
+          Type: 19 VoidPointerType unsafe.Pointer
     - __kind: BaseType
-      ID: 50
+      ID: 16
       Name: float32
       ByteSize: 4
       GoRuntimeType: 38304
       GoKind: 13
     - __kind: BaseType
-      ID: 51
+      ID: 17
       Name: float64
       ByteSize: 8
       GoRuntimeType: 38368
       GoKind: 14
     - __kind: GoHMapHeaderType
-      ID: 17
+      ID: 40
       Name: hash<string,int>
       ByteSize: 48
       RawFields:
         - Name: count
           Offset: 0
-          Type: 1 BaseType int
+          Type: 9 BaseType int
         - Name: flags
           Offset: 8
-          Type: 9 BaseType uint8
+          Type: 3 BaseType uint8
         - Name: B
           Offset: 9
-          Type: 9 BaseType uint8
+          Type: 3 BaseType uint8
         - Name: noverflow
           Offset: 10
-          Type: 18 BaseType uint16
+          Type: 7 BaseType uint16
         - Name: hash0
           Offset: 12
-          Type: 19 BaseType uint32
+          Type: 2 BaseType uint32
         - Name: buckets
           Offset: 16
-          Type: 20 PointerType *bucket<string,int>
+          Type: 41 PointerType *bucket<string,int>
         - Name: oldbuckets
           Offset: 24
-          Type: 20 PointerType *bucket<string,int>
+          Type: 41 PointerType *bucket<string,int>
         - Name: nevacuate
           Offset: 32
-          Type: 25 BaseType uintptr
+          Type: 1 BaseType uintptr
         - Name: extra
           Offset: 40
-          Type: 26 PointerType *runtime.mapextra
-      BucketType: 21 GoHMapBucketType bucket<string,int>
+          Type: 46 PointerType *runtime.mapextra
+      BucketType: 42 GoHMapBucketType bucket<string,int>
       BucketsType: 72 GoSliceDataType []bucket<string,int>.array
     - __kind: GoHMapHeaderType
-      ID: 35
+      ID: 55
       Name: hash<string,main.bigStruct>
       ByteSize: 48
       RawFields:
         - Name: count
           Offset: 0
-          Type: 1 BaseType int
+          Type: 9 BaseType int
         - Name: flags
           Offset: 8
-          Type: 9 BaseType uint8
+          Type: 3 BaseType uint8
         - Name: B
           Offset: 9
-          Type: 9 BaseType uint8
+          Type: 3 BaseType uint8
         - Name: noverflow
           Offset: 10
-          Type: 18 BaseType uint16
+          Type: 7 BaseType uint16
         - Name: hash0
           Offset: 12
-          Type: 19 BaseType uint32
+          Type: 2 BaseType uint32
         - Name: buckets
           Offset: 16
-          Type: 36 PointerType *bucket<string,main.bigStruct>
+          Type: 56 PointerType *bucket<string,main.bigStruct>
         - Name: oldbuckets
           Offset: 24
-          Type: 36 PointerType *bucket<string,main.bigStruct>
+          Type: 56 PointerType *bucket<string,main.bigStruct>
         - Name: nevacuate
           Offset: 32
-          Type: 25 BaseType uintptr
+          Type: 1 BaseType uintptr
         - Name: extra
           Offset: 40
-          Type: 26 PointerType *runtime.mapextra
-      BucketType: 37 GoHMapBucketType bucket<string,main.bigStruct>
+          Type: 46 PointerType *runtime.mapextra
+      BucketType: 57 GoHMapBucketType bucket<string,main.bigStruct>
       BucketsType: 75 GoSliceDataType []bucket<string,main.bigStruct>.array
     - __kind: BaseType
-      ID: 1
+      ID: 9
       Name: int
       ByteSize: 8
       GoRuntimeType: 37984
       GoKind: 2
     - __kind: BaseType
-      ID: 56
+      ID: 23
       Name: int16
       ByteSize: 2
       GoRuntimeType: 37600
       GoKind: 4
     - __kind: BaseType
-      ID: 47
+      ID: 13
       Name: int32
       ByteSize: 4
       GoRuntimeType: 37728
       GoKind: 5
     - __kind: BaseType
-      ID: 48
+      ID: 14
       Name: int64
       ByteSize: 8
       GoRuntimeType: 37856
       GoKind: 6
     - __kind: BaseType
-      ID: 49
+      ID: 15
       Name: int8
       ByteSize: 1
       GoRuntimeType: 37472
       GoKind: 3
     - __kind: StructureType
-      ID: 40
+      ID: 60
       Name: main.bigStruct
       ByteSize: 184
       GoRuntimeType: 110400
@@ -1041,44 +1041,44 @@ Types:
       RawFields:
         - Name: Field1
           Offset: 0
-          Type: 1 BaseType int
+          Type: 9 BaseType int
         - Name: Field2
           Offset: 8
-          Type: 1 BaseType int
+          Type: 9 BaseType int
         - Name: Field3
           Offset: 16
-          Type: 1 BaseType int
+          Type: 9 BaseType int
         - Name: Field4
           Offset: 24
-          Type: 1 BaseType int
+          Type: 9 BaseType int
         - Name: Field5
           Offset: 32
-          Type: 1 BaseType int
+          Type: 9 BaseType int
         - Name: Field6
           Offset: 40
-          Type: 1 BaseType int
+          Type: 9 BaseType int
         - Name: Field7
           Offset: 48
-          Type: 1 BaseType int
+          Type: 9 BaseType int
         - Name: data
           Offset: 56
-          Type: 41 ArrayType [128]uint8
+          Type: 61 ArrayType [128]uint8
     - __kind: GoMapType
-      ID: 15
+      ID: 38
       Name: map[string]int
       ByteSize: 8
       GoRuntimeType: 54528
       GoKind: 21
-      HeaderType: 17 GoHMapHeaderType hash<string,int>
+      HeaderType: 40 GoHMapHeaderType hash<string,int>
     - __kind: GoMapType
-      ID: 33
+      ID: 53
       Name: map[string]main.bigStruct
       ByteSize: 8
       GoRuntimeType: 54624
       GoKind: 21
-      HeaderType: 35 GoHMapHeaderType hash<string,main.bigStruct>
+      HeaderType: 55 GoHMapHeaderType hash<string,main.bigStruct>
     - __kind: StructureType
-      ID: 32
+      ID: 52
       Name: runtime.bmap
       ByteSize: 8
       GoRuntimeType: 66272
@@ -1086,9 +1086,9 @@ Types:
       RawFields:
         - Name: tophash
           Offset: 0
-          Type: 22 ArrayType [8]uint8
+          Type: 43 ArrayType [8]uint8
     - __kind: StructureType
-      ID: 27
+      ID: 47
       Name: runtime.mapextra
       ByteSize: 24
       GoRuntimeType: 87104
@@ -1096,15 +1096,15 @@ Types:
       RawFields:
         - Name: overflow
           Offset: 0
-          Type: 28 PointerType *[]*runtime.bmap
+          Type: 48 PointerType *[]*runtime.bmap
         - Name: oldoverflow
           Offset: 8
-          Type: 28 PointerType *[]*runtime.bmap
+          Type: 48 PointerType *[]*runtime.bmap
         - Name: nextOverflow
           Offset: 16
-          Type: 31 PointerType *runtime.bmap
+          Type: 51 PointerType *runtime.bmap
     - __kind: GoStringHeaderType
-      ID: 7
+      ID: 10
       Name: string
       ByteSize: 16
       GoRuntimeType: 37408
@@ -1115,50 +1115,50 @@ Types:
           Type: 67 PointerType *string.str
         - Name: len
           Offset: 8
-          Type: 1 BaseType int
+          Type: 9 BaseType int
       Data: 66 GoStringDataType string.str
     - __kind: GoStringDataType
       ID: 66
       Name: string.str
       ByteSize: 2048
     - __kind: BaseType
-      ID: 46
+      ID: 12
       Name: uint
       ByteSize: 8
       GoRuntimeType: 38048
       GoKind: 7
     - __kind: BaseType
-      ID: 18
+      ID: 7
       Name: uint16
       ByteSize: 2
       GoRuntimeType: 37664
       GoKind: 9
     - __kind: BaseType
-      ID: 19
+      ID: 2
       Name: uint32
       ByteSize: 4
       GoRuntimeType: 37792
       GoKind: 10
     - __kind: BaseType
-      ID: 45
+      ID: 11
       Name: uint64
       ByteSize: 8
       GoRuntimeType: 37920
       GoKind: 11
     - __kind: BaseType
-      ID: 9
+      ID: 3
       Name: uint8
       ByteSize: 1
       GoRuntimeType: 37536
       GoKind: 8
     - __kind: BaseType
-      ID: 25
+      ID: 1
       Name: uintptr
       ByteSize: 8
       GoRuntimeType: 38112
       GoKind: 12
     - __kind: VoidPointerType
-      ID: 53
+      ID: 19
       Name: unsafe.Pointer
       ByteSize: 8
       GoRuntimeType: 38496

--- a/pkg/dyninst/irgen/testdata/snapshot/simple.arch=arm64,toolchain=go1.23.11.yaml
+++ b/pkg/dyninst/irgen/testdata/snapshot/simple.arch=arm64,toolchain=go1.23.11.yaml
@@ -288,7 +288,7 @@ Subprograms:
       InlinePCRanges: []
       Variables:
         - Name: m
-          Type: 53 GoMapType map[string]main.bigStruct
+          Type: 45 GoMapType map[string]main.bigStruct
           Locations:
             - Range: 0xb5810..0xb5848
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
@@ -320,7 +320,7 @@ Subprograms:
           RootRanges: [0xb4fb0..0xb53c0]
       Variables:
         - Name: ptr
-          Type: 62 PointerType *****int
+          Type: 50 PointerType *****int
           Locations:
             - Range: 0xb5310..0xb5358
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
@@ -334,7 +334,7 @@ Subprograms:
           RootRanges: [0xb4fb0..0xb53c0]
       Variables:
         - Name: ptr
-          Type: 65 PointerType **int
+          Type: 52 PointerType **int
           Locations:
             - Range: 0xb5370..0xb53a0
               Pieces: [{Size: 8, Op: {RegNo: 5, Shift: 0}}]
@@ -342,50 +342,50 @@ Subprograms:
           IsReturn: false
 Types:
     - __kind: PointerType
-      ID: 62
+      ID: 50
       Name: '*****int'
       ByteSize: 8
       GoRuntimeType: 32480
       GoKind: 22
-      Pointee: 63 PointerType ****int
+      Pointee: 51 PointerType ****int
     - __kind: PointerType
-      ID: 63
+      ID: 51
       Name: '****int'
       ByteSize: 8
       GoRuntimeType: 32416
       GoKind: 22
-      Pointee: 64 PointerType ***int
+      Pointee: 63 PointerType ***int
     - __kind: PointerType
-      ID: 64
+      ID: 63
       Name: '***int'
       ByteSize: 8
       GoRuntimeType: 32352
       GoKind: 22
-      Pointee: 65 PointerType **int
+      Pointee: 52 PointerType **int
     - __kind: PointerType
-      ID: 65
+      ID: 52
       Name: '**int'
       ByteSize: 8
       GoRuntimeType: 32288
       GoKind: 22
       Pointee: 28 PointerType *int
     - __kind: PointerType
-      ID: 50
+      ID: 64
       Name: '**runtime.bmap'
       ByteSize: 8
-      Pointee: 51 PointerType *runtime.bmap
+      Pointee: 58 PointerType *runtime.bmap
     - __kind: PointerType
-      ID: 48
+      ID: 56
       Name: '*[]*runtime.bmap'
       ByteSize: 8
       GoRuntimeType: 35936
       GoKind: 22
-      Pointee: 49 GoSliceHeaderType []*runtime.bmap
+      Pointee: 57 GoSliceHeaderType []*runtime.bmap
     - __kind: PointerType
-      ID: 74
+      ID: 75
       Name: '*[]*runtime.bmap.array'
       ByteSize: 8
-      Pointee: 73 GoSliceDataType []*runtime.bmap.array
+      Pointee: 74 GoSliceDataType []*runtime.bmap.array
     - __kind: PointerType
       ID: 69
       Name: '*[]int.array'
@@ -409,10 +409,10 @@ Types:
       ByteSize: 8
       Pointee: 42 GoHMapBucketType bucket<string,int>
     - __kind: PointerType
-      ID: 56
+      ID: 48
       Name: '*bucket<string,main.bigStruct>'
       ByteSize: 8
-      Pointee: 57 GoHMapBucketType bucket<string,main.bigStruct>
+      Pointee: 49 GoHMapBucketType bucket<string,main.bigStruct>
     - __kind: PointerType
       ID: 30
       Name: '*error'
@@ -440,10 +440,10 @@ Types:
       ByteSize: 8
       Pointee: 40 GoHMapHeaderType hash<string,int>
     - __kind: PointerType
-      ID: 54
+      ID: 46
       Name: '*hash<string,main.bigStruct>'
       ByteSize: 8
-      Pointee: 55 GoHMapHeaderType hash<string,main.bigStruct>
+      Pointee: 47 GoHMapHeaderType hash<string,main.bigStruct>
     - __kind: PointerType
       ID: 28
       Name: '*int'
@@ -466,26 +466,26 @@ Types:
       GoKind: 22
       Pointee: 14 BaseType int64
     - __kind: PointerType
-      ID: 59
+      ID: 61
       Name: '*main.bigStruct'
       ByteSize: 8
       GoRuntimeType: 24224
       GoKind: 22
-      Pointee: 60 StructureType main.bigStruct
+      Pointee: 62 StructureType main.bigStruct
     - __kind: PointerType
-      ID: 51
+      ID: 58
       Name: '*runtime.bmap'
       ByteSize: 8
       GoRuntimeType: 66400
       GoKind: 22
-      Pointee: 52 StructureType runtime.bmap
+      Pointee: 59 StructureType runtime.bmap
     - __kind: PointerType
-      ID: 46
+      ID: 43
       Name: '*runtime.mapextra'
       ByteSize: 8
       GoRuntimeType: 29728
       GoKind: 22
-      Pointee: 47 StructureType runtime.mapextra
+      Pointee: 44 StructureType runtime.mapextra
     - __kind: PointerType
       ID: 22
       Name: '*string'
@@ -549,7 +549,7 @@ Types:
         - Name: ptr
           Offset: 1
           Expression:
-            Type: 62 PointerType *****int
+            Type: 50 PointerType *****int
             Operations:
                 - __kind: LocationOp
                   Variable: {subprogram: 11, index: 0, name: ptr}
@@ -564,7 +564,7 @@ Types:
         - Name: ptr
           Offset: 1
           Expression:
-            Type: 65 PointerType **int
+            Type: 52 PointerType **int
             Operations:
                 - __kind: LocationOp
                   Variable: {subprogram: 12, index: 0, name: ptr}
@@ -579,7 +579,7 @@ Types:
         - Name: m
           Offset: 1
           Expression:
-            Type: 53 GoMapType map[string]main.bigStruct
+            Type: 45 GoMapType map[string]main.bigStruct
             Operations:
                 - __kind: LocationOp
                   Variable: {subprogram: 9, index: 0, name: m}
@@ -721,7 +721,7 @@ Types:
                   Offset: 0
                   ByteSize: 24
     - __kind: ArrayType
-      ID: 61
+      ID: 65
       Name: '[128]uint8'
       ByteSize: 128
       GoRuntimeType: 41856
@@ -748,7 +748,7 @@ Types:
       HasCount: true
       Element: 10 GoStringHeaderType string
     - __kind: ArrayType
-      ID: 43
+      ID: 53
       Name: '[8]uint8'
       ByteSize: 8
       GoRuntimeType: 41568
@@ -757,7 +757,7 @@ Types:
       HasCount: true
       Element: 3 BaseType uint8
     - __kind: GoSliceHeaderType
-      ID: 49
+      ID: 57
       Name: '[]*runtime.bmap'
       ByteSize: 24
       GoRuntimeType: 35872
@@ -765,29 +765,29 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 50 PointerType **runtime.bmap
+          Type: 64 PointerType **runtime.bmap
         - Name: len
           Offset: 8
           Type: 9 BaseType int
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 73 GoSliceDataType []*runtime.bmap.array
+      Data: 74 GoSliceDataType []*runtime.bmap.array
     - __kind: GoSliceDataType
-      ID: 73
+      ID: 74
       Name: '[]*runtime.bmap.array'
       ByteSize: 2048
-      Element: 51 PointerType *runtime.bmap
+      Element: 58 PointerType *runtime.bmap
     - __kind: GoSliceDataType
       ID: 72
       Name: '[]bucket<string,int>.array'
       ByteSize: 2048
       Element: 42 GoHMapBucketType bucket<string,int>
     - __kind: GoSliceDataType
-      ID: 75
+      ID: 73
       Name: '[]bucket<string,main.bigStruct>.array'
       ByteSize: 2048
-      Element: 57 GoHMapBucketType bucket<string,main.bigStruct>
+      Element: 49 GoHMapBucketType bucket<string,main.bigStruct>
     - __kind: GoSliceHeaderType
       ID: 34
       Name: '[]int'
@@ -811,7 +811,7 @@ Types:
       ByteSize: 2048
       Element: 9 BaseType int
     - __kind: ArrayType
-      ID: 44
+      ID: 54
       Name: '[]key<string>'
       ByteSize: 128
       Count: 8
@@ -840,19 +840,19 @@ Types:
       ByteSize: 2048
       Element: 10 GoStringHeaderType string
     - __kind: ArrayType
-      ID: 45
+      ID: 55
       Name: '[]val<int>'
       ByteSize: 64
       Count: 8
       HasCount: true
       Element: 9 BaseType int
     - __kind: ArrayType
-      ID: 58
+      ID: 60
       Name: '[]val<main.bigStruct>'
       ByteSize: 64
       Count: 8
       HasCount: true
-      Element: 59 PointerType *main.bigStruct
+      Element: 61 PointerType *main.bigStruct
     - __kind: BaseType
       ID: 4
       Name: bool
@@ -866,37 +866,37 @@ Types:
       RawFields:
         - Name: tophash
           Offset: 0
-          Type: 43 ArrayType [8]uint8
+          Type: 53 ArrayType [8]uint8
         - Name: keys
           Offset: 8
-          Type: 44 ArrayType []key<string>
+          Type: 54 ArrayType []key<string>
         - Name: values
           Offset: 136
-          Type: 45 ArrayType []val<int>
+          Type: 55 ArrayType []val<int>
         - Name: overflow
           Offset: 200
           Type: 41 PointerType *bucket<string,int>
       KeyType: 10 GoStringHeaderType string
       ValueType: 9 BaseType int
     - __kind: GoHMapBucketType
-      ID: 57
+      ID: 49
       Name: bucket<string,main.bigStruct>
       ByteSize: 208
       RawFields:
         - Name: tophash
           Offset: 0
-          Type: 43 ArrayType [8]uint8
+          Type: 53 ArrayType [8]uint8
         - Name: keys
           Offset: 8
-          Type: 44 ArrayType []key<string>
+          Type: 54 ArrayType []key<string>
         - Name: values
           Offset: 136
-          Type: 58 ArrayType []val<main.bigStruct>
+          Type: 60 ArrayType []val<main.bigStruct>
         - Name: overflow
           Offset: 200
-          Type: 56 PointerType *bucket<string,main.bigStruct>
+          Type: 48 PointerType *bucket<string,main.bigStruct>
       KeyType: 10 GoStringHeaderType string
-      ValueType: 59 PointerType *main.bigStruct
+      ValueType: 61 PointerType *main.bigStruct
     - __kind: BaseType
       ID: 25
       Name: complex128
@@ -965,11 +965,11 @@ Types:
           Type: 1 BaseType uintptr
         - Name: extra
           Offset: 40
-          Type: 46 PointerType *runtime.mapextra
+          Type: 43 PointerType *runtime.mapextra
       BucketType: 42 GoHMapBucketType bucket<string,int>
       BucketsType: 72 GoSliceDataType []bucket<string,int>.array
     - __kind: GoHMapHeaderType
-      ID: 55
+      ID: 47
       Name: hash<string,main.bigStruct>
       ByteSize: 48
       RawFields:
@@ -990,18 +990,18 @@ Types:
           Type: 2 BaseType uint32
         - Name: buckets
           Offset: 16
-          Type: 56 PointerType *bucket<string,main.bigStruct>
+          Type: 48 PointerType *bucket<string,main.bigStruct>
         - Name: oldbuckets
           Offset: 24
-          Type: 56 PointerType *bucket<string,main.bigStruct>
+          Type: 48 PointerType *bucket<string,main.bigStruct>
         - Name: nevacuate
           Offset: 32
           Type: 1 BaseType uintptr
         - Name: extra
           Offset: 40
-          Type: 46 PointerType *runtime.mapextra
-      BucketType: 57 GoHMapBucketType bucket<string,main.bigStruct>
-      BucketsType: 75 GoSliceDataType []bucket<string,main.bigStruct>.array
+          Type: 43 PointerType *runtime.mapextra
+      BucketType: 49 GoHMapBucketType bucket<string,main.bigStruct>
+      BucketsType: 73 GoSliceDataType []bucket<string,main.bigStruct>.array
     - __kind: BaseType
       ID: 9
       Name: int
@@ -1033,7 +1033,7 @@ Types:
       GoRuntimeType: 37472
       GoKind: 3
     - __kind: StructureType
-      ID: 60
+      ID: 62
       Name: main.bigStruct
       ByteSize: 184
       GoRuntimeType: 110400
@@ -1062,7 +1062,7 @@ Types:
           Type: 9 BaseType int
         - Name: data
           Offset: 56
-          Type: 61 ArrayType [128]uint8
+          Type: 65 ArrayType [128]uint8
     - __kind: GoMapType
       ID: 38
       Name: map[string]int
@@ -1071,14 +1071,14 @@ Types:
       GoKind: 21
       HeaderType: 40 GoHMapHeaderType hash<string,int>
     - __kind: GoMapType
-      ID: 53
+      ID: 45
       Name: map[string]main.bigStruct
       ByteSize: 8
       GoRuntimeType: 54624
       GoKind: 21
-      HeaderType: 55 GoHMapHeaderType hash<string,main.bigStruct>
+      HeaderType: 47 GoHMapHeaderType hash<string,main.bigStruct>
     - __kind: StructureType
-      ID: 52
+      ID: 59
       Name: runtime.bmap
       ByteSize: 8
       GoRuntimeType: 66272
@@ -1086,9 +1086,9 @@ Types:
       RawFields:
         - Name: tophash
           Offset: 0
-          Type: 43 ArrayType [8]uint8
+          Type: 53 ArrayType [8]uint8
     - __kind: StructureType
-      ID: 47
+      ID: 44
       Name: runtime.mapextra
       ByteSize: 24
       GoRuntimeType: 87104
@@ -1096,13 +1096,13 @@ Types:
       RawFields:
         - Name: overflow
           Offset: 0
-          Type: 48 PointerType *[]*runtime.bmap
+          Type: 56 PointerType *[]*runtime.bmap
         - Name: oldoverflow
           Offset: 8
-          Type: 48 PointerType *[]*runtime.bmap
+          Type: 56 PointerType *[]*runtime.bmap
         - Name: nextOverflow
           Offset: 16
-          Type: 51 PointerType *runtime.bmap
+          Type: 58 PointerType *runtime.bmap
     - __kind: GoStringHeaderType
       ID: 10
       Name: string

--- a/pkg/dyninst/irgen/testdata/snapshot/simple.arch=arm64,toolchain=go1.23.11.yaml
+++ b/pkg/dyninst/irgen/testdata/snapshot/simple.arch=arm64,toolchain=go1.23.11.yaml
@@ -370,7 +370,7 @@ Types:
       GoKind: 22
       Pointee: 28 PointerType *int
     - __kind: PointerType
-      ID: 64
+      ID: 72
       Name: '**runtime.bmap'
       ByteSize: 8
       Pointee: 58 PointerType *runtime.bmap
@@ -387,15 +387,15 @@ Types:
       ByteSize: 8
       Pointee: 74 GoSliceDataType []*runtime.bmap.array
     - __kind: PointerType
-      ID: 69
+      ID: 67
       Name: '*[]int.array'
       ByteSize: 8
-      Pointee: 68 GoSliceDataType []int.array
+      Pointee: 66 GoSliceDataType []int.array
     - __kind: PointerType
-      ID: 71
+      ID: 69
       Name: '*[]string.array'
       ByteSize: 8
-      Pointee: 70 GoSliceDataType []string.array
+      Pointee: 68 GoSliceDataType []string.array
     - __kind: PointerType
       ID: 5
       Name: '*bool'
@@ -494,10 +494,10 @@ Types:
       GoKind: 22
       Pointee: 10 GoStringHeaderType string
     - __kind: PointerType
-      ID: 67
+      ID: 65
       Name: '*string.str'
       ByteSize: 8
-      Pointee: 66 GoStringDataType string.str
+      Pointee: 64 GoStringDataType string.str
     - __kind: PointerType
       ID: 32
       Name: '*uint'
@@ -721,7 +721,7 @@ Types:
                   Offset: 0
                   ByteSize: 24
     - __kind: ArrayType
-      ID: 65
+      ID: 73
       Name: '[128]uint8'
       ByteSize: 128
       GoRuntimeType: 41856
@@ -765,7 +765,7 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 64 PointerType **runtime.bmap
+          Type: 72 PointerType **runtime.bmap
         - Name: len
           Offset: 8
           Type: 9 BaseType int
@@ -779,12 +779,12 @@ Types:
       ByteSize: 2048
       Element: 58 PointerType *runtime.bmap
     - __kind: GoSliceDataType
-      ID: 72
+      ID: 70
       Name: '[]bucket<string,int>.array'
       ByteSize: 2048
       Element: 42 GoHMapBucketType bucket<string,int>
     - __kind: GoSliceDataType
-      ID: 73
+      ID: 71
       Name: '[]bucket<string,main.bigStruct>.array'
       ByteSize: 2048
       Element: 49 GoHMapBucketType bucket<string,main.bigStruct>
@@ -804,9 +804,9 @@ Types:
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 68 GoSliceDataType []int.array
+      Data: 66 GoSliceDataType []int.array
     - __kind: GoSliceDataType
-      ID: 68
+      ID: 66
       Name: '[]int.array'
       ByteSize: 2048
       Element: 9 BaseType int
@@ -833,9 +833,9 @@ Types:
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 70 GoSliceDataType []string.array
+      Data: 68 GoSliceDataType []string.array
     - __kind: GoSliceDataType
-      ID: 70
+      ID: 68
       Name: '[]string.array'
       ByteSize: 2048
       Element: 10 GoStringHeaderType string
@@ -967,7 +967,7 @@ Types:
           Offset: 40
           Type: 43 PointerType *runtime.mapextra
       BucketType: 42 GoHMapBucketType bucket<string,int>
-      BucketsType: 72 GoSliceDataType []bucket<string,int>.array
+      BucketsType: 70 GoSliceDataType []bucket<string,int>.array
     - __kind: GoHMapHeaderType
       ID: 47
       Name: hash<string,main.bigStruct>
@@ -1001,7 +1001,7 @@ Types:
           Offset: 40
           Type: 43 PointerType *runtime.mapextra
       BucketType: 49 GoHMapBucketType bucket<string,main.bigStruct>
-      BucketsType: 73 GoSliceDataType []bucket<string,main.bigStruct>.array
+      BucketsType: 71 GoSliceDataType []bucket<string,main.bigStruct>.array
     - __kind: BaseType
       ID: 9
       Name: int
@@ -1062,7 +1062,7 @@ Types:
           Type: 9 BaseType int
         - Name: data
           Offset: 56
-          Type: 65 ArrayType [128]uint8
+          Type: 73 ArrayType [128]uint8
     - __kind: GoMapType
       ID: 38
       Name: map[string]int
@@ -1112,13 +1112,13 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 67 PointerType *string.str
+          Type: 65 PointerType *string.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 66 GoStringDataType string.str
+      Data: 64 GoStringDataType string.str
     - __kind: GoStringDataType
-      ID: 66
+      ID: 64
       Name: string.str
       ByteSize: 2048
     - __kind: BaseType

--- a/pkg/dyninst/irgen/testdata/snapshot/simple.arch=arm64,toolchain=go1.24.3.yaml
+++ b/pkg/dyninst/irgen/testdata/snapshot/simple.arch=arm64,toolchain=go1.24.3.yaml
@@ -288,7 +288,7 @@ Subprograms:
       InlinePCRanges: []
       Variables:
         - Name: m
-          Type: 49 GoMapType map[string]main.bigStruct
+          Type: 43 GoMapType map[string]main.bigStruct
           Locations:
             - Range: 0xb5680..0xb56b8
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
@@ -320,7 +320,7 @@ Subprograms:
           RootRanges: [0xb4e50..0xb5250]
       Variables:
         - Name: ptr
-          Type: 63 PointerType *****int
+          Type: 48 PointerType *****int
           Locations:
             - Range: 0xb51a4..0xb51ec
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
@@ -334,7 +334,7 @@ Subprograms:
           RootRanges: [0xb4e50..0xb5250]
       Variables:
         - Name: ptr
-          Type: 66 PointerType **int
+          Type: 50 PointerType **int
           Locations:
             - Range: 0xb5204..0xb5234
               Pieces: [{Size: 8, Op: {RegNo: 5, Shift: 0}}]
@@ -342,28 +342,28 @@ Subprograms:
           IsReturn: false
 Types:
     - __kind: PointerType
-      ID: 63
+      ID: 48
       Name: '*****int'
       ByteSize: 8
       GoRuntimeType: 35232
       GoKind: 22
-      Pointee: 64 PointerType ****int
+      Pointee: 49 PointerType ****int
     - __kind: PointerType
-      ID: 64
+      ID: 49
       Name: '****int'
       ByteSize: 8
       GoRuntimeType: 35168
       GoKind: 22
-      Pointee: 65 PointerType ***int
+      Pointee: 53 PointerType ***int
     - __kind: PointerType
-      ID: 65
+      ID: 53
       Name: '***int'
       ByteSize: 8
       GoRuntimeType: 35104
       GoKind: 22
-      Pointee: 66 PointerType **int
+      Pointee: 50 PointerType **int
     - __kind: PointerType
-      ID: 66
+      ID: 50
       Name: '**int'
       ByteSize: 8
       GoRuntimeType: 35040
@@ -375,10 +375,10 @@ Types:
       ByteSize: 8
       Pointee: 42 PointerType *table<string,int>
     - __kind: PointerType
-      ID: 52
+      ID: 46
       Name: '**table<string,main.bigStruct>'
       ByteSize: 8
-      Pointee: 53 PointerType *table<string,main.bigStruct>
+      Pointee: 47 PointerType *table<string,main.bigStruct>
     - __kind: PointerType
       ID: 70
       Name: '*[]int.array'
@@ -439,32 +439,32 @@ Types:
       GoKind: 22
       Pointee: 13 BaseType int64
     - __kind: PointerType
-      ID: 60
+      ID: 64
       Name: '*main.bigStruct'
       ByteSize: 8
       GoRuntimeType: 26912
       GoKind: 22
-      Pointee: 61 StructureType main.bigStruct
+      Pointee: 65 StructureType main.bigStruct
     - __kind: PointerType
       ID: 39
       Name: '*map<string,int>'
       ByteSize: 8
       Pointee: 40 GoSwissMapHeaderType map<string,int>
     - __kind: PointerType
-      ID: 50
+      ID: 44
       Name: '*map<string,main.bigStruct>'
       ByteSize: 8
-      Pointee: 51 GoSwissMapHeaderType map<string,main.bigStruct>
+      Pointee: 45 GoSwissMapHeaderType map<string,main.bigStruct>
     - __kind: PointerType
-      ID: 45
+      ID: 55
       Name: '*noalg.map.group[string]int'
       ByteSize: 8
-      Pointee: 46 StructureType noalg.map.group[string]int
+      Pointee: 56 StructureType noalg.map.group[string]int
     - __kind: PointerType
-      ID: 56
+      ID: 58
       Name: '*noalg.map.group[string]main.bigStruct'
       ByteSize: 8
-      Pointee: 57 StructureType noalg.map.group[string]main.bigStruct
+      Pointee: 59 StructureType noalg.map.group[string]main.bigStruct
     - __kind: PointerType
       ID: 22
       Name: '*string'
@@ -481,12 +481,12 @@ Types:
       ID: 42
       Name: '*table<string,int>'
       ByteSize: 8
-      Pointee: 43 StructureType table<string,int>
+      Pointee: 51 StructureType table<string,int>
     - __kind: PointerType
-      ID: 53
+      ID: 47
       Name: '*table<string,main.bigStruct>'
       ByteSize: 8
-      Pointee: 54 StructureType table<string,main.bigStruct>
+      Pointee: 52 StructureType table<string,main.bigStruct>
     - __kind: PointerType
       ID: 32
       Name: '*uint'
@@ -538,7 +538,7 @@ Types:
         - Name: ptr
           Offset: 1
           Expression:
-            Type: 63 PointerType *****int
+            Type: 48 PointerType *****int
             Operations:
                 - __kind: LocationOp
                   Variable: {subprogram: 11, index: 0, name: ptr}
@@ -553,7 +553,7 @@ Types:
         - Name: ptr
           Offset: 1
           Expression:
-            Type: 66 PointerType **int
+            Type: 50 PointerType **int
             Operations:
                 - __kind: LocationOp
                   Variable: {subprogram: 12, index: 0, name: ptr}
@@ -568,7 +568,7 @@ Types:
         - Name: m
           Offset: 1
           Expression:
-            Type: 49 GoMapType map[string]main.bigStruct
+            Type: 43 GoMapType map[string]main.bigStruct
             Operations:
                 - __kind: LocationOp
                   Variable: {subprogram: 9, index: 0, name: m}
@@ -710,7 +710,7 @@ Types:
                   Offset: 0
                   ByteSize: 24
     - __kind: ArrayType
-      ID: 62
+      ID: 66
       Name: '[128]uint8'
       ByteSize: 128
       GoRuntimeType: 46208
@@ -745,7 +745,7 @@ Types:
       ID: 75
       Name: '[]*table<string,main.bigStruct>.array'
       ByteSize: 8192
-      Element: 53 PointerType *table<string,main.bigStruct>
+      Element: 47 PointerType *table<string,main.bigStruct>
     - __kind: GoSliceHeaderType
       ID: 34
       Name: '[]int'
@@ -772,12 +772,12 @@ Types:
       ID: 74
       Name: '[]noalg.map.group[string]int.array'
       ByteSize: 2048
-      Element: 46 StructureType noalg.map.group[string]int
+      Element: 56 StructureType noalg.map.group[string]int
     - __kind: GoSliceDataType
       ID: 76
       Name: '[]noalg.map.group[string]main.bigStruct.array'
       ByteSize: 2048
-      Element: 57 StructureType noalg.map.group[string]main.bigStruct
+      Element: 59 StructureType noalg.map.group[string]main.bigStruct
     - __kind: GoSliceHeaderType
       ID: 36
       Name: '[]string'
@@ -844,32 +844,32 @@ Types:
       GoRuntimeType: 42304
       GoKind: 14
     - __kind: GoSwissMapGroupsType
-      ID: 44
+      ID: 54
       Name: groupReference<string,int>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 45 PointerType *noalg.map.group[string]int
+          Type: 55 PointerType *noalg.map.group[string]int
         - Name: lengthMask
           Offset: 8
           Type: 8 BaseType uint64
-      GroupType: 46 StructureType noalg.map.group[string]int
+      GroupType: 56 StructureType noalg.map.group[string]int
       GroupSliceType: 74 GoSliceDataType []noalg.map.group[string]int.array
     - __kind: GoSwissMapGroupsType
-      ID: 55
+      ID: 57
       Name: groupReference<string,main.bigStruct>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 56 PointerType *noalg.map.group[string]main.bigStruct
+          Type: 58 PointerType *noalg.map.group[string]main.bigStruct
         - Name: lengthMask
           Offset: 8
           Type: 8 BaseType uint64
-      GroupType: 57 StructureType noalg.map.group[string]main.bigStruct
+      GroupType: 59 StructureType noalg.map.group[string]main.bigStruct
       GroupSliceType: 76 GoSliceDataType []noalg.map.group[string]main.bigStruct.array
     - __kind: BaseType
       ID: 7
@@ -902,7 +902,7 @@ Types:
       GoRuntimeType: 41408
       GoKind: 3
     - __kind: StructureType
-      ID: 61
+      ID: 65
       Name: main.bigStruct
       ByteSize: 184
       GoRuntimeType: 119616
@@ -931,7 +931,7 @@ Types:
           Type: 7 BaseType int
         - Name: data
           Offset: 56
-          Type: 62 ArrayType [128]uint8
+          Type: 66 ArrayType [128]uint8
     - __kind: GoSwissMapHeaderType
       ID: 40
       Name: map<string,int>
@@ -963,9 +963,9 @@ Types:
           Offset: 40
           Type: 8 BaseType uint64
       TablePtrSliceType: 73 GoSliceDataType []*table<string,int>.array
-      GroupType: 46 StructureType noalg.map.group[string]int
+      GroupType: 56 StructureType noalg.map.group[string]int
     - __kind: GoSwissMapHeaderType
-      ID: 51
+      ID: 45
       Name: map<string,main.bigStruct>
       ByteSize: 48
       GoKind: 25
@@ -978,7 +978,7 @@ Types:
           Type: 1 BaseType uintptr
         - Name: dirPtr
           Offset: 16
-          Type: 52 PointerType **table<string,main.bigStruct>
+          Type: 46 PointerType **table<string,main.bigStruct>
         - Name: dirLen
           Offset: 24
           Type: 7 BaseType int
@@ -995,7 +995,7 @@ Types:
           Offset: 40
           Type: 8 BaseType uint64
       TablePtrSliceType: 75 GoSliceDataType []*table<string,main.bigStruct>.array
-      GroupType: 57 StructureType noalg.map.group[string]main.bigStruct
+      GroupType: 59 StructureType noalg.map.group[string]main.bigStruct
     - __kind: GoMapType
       ID: 38
       Name: map[string]int
@@ -1004,32 +1004,32 @@ Types:
       GoKind: 21
       HeaderType: 40 GoSwissMapHeaderType map<string,int>
     - __kind: GoMapType
-      ID: 49
+      ID: 43
       Name: map[string]main.bigStruct
       ByteSize: 8
       GoRuntimeType: 67264
       GoKind: 21
-      HeaderType: 51 GoSwissMapHeaderType map<string,main.bigStruct>
+      HeaderType: 45 GoSwissMapHeaderType map<string,main.bigStruct>
     - __kind: ArrayType
-      ID: 58
+      ID: 62
       Name: noalg.[8]struct { key string; elem *main.bigStruct }
       ByteSize: 192
       GoRuntimeType: 46304
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 59 StructureType noalg.struct { key string; elem *main.bigStruct }
+      Element: 63 StructureType noalg.struct { key string; elem *main.bigStruct }
     - __kind: ArrayType
-      ID: 47
+      ID: 60
       Name: noalg.[8]struct { key string; elem int }
       ByteSize: 192
       GoRuntimeType: 46112
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 48 StructureType noalg.struct { key string; elem int }
+      Element: 61 StructureType noalg.struct { key string; elem int }
     - __kind: StructureType
-      ID: 46
+      ID: 56
       Name: noalg.map.group[string]int
       ByteSize: 200
       GoRuntimeType: 74528
@@ -1040,9 +1040,9 @@ Types:
           Type: 8 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 47 ArrayType noalg.[8]struct { key string; elem int }
+          Type: 60 ArrayType noalg.[8]struct { key string; elem int }
     - __kind: StructureType
-      ID: 57
+      ID: 59
       Name: noalg.map.group[string]main.bigStruct
       ByteSize: 200
       GoRuntimeType: 74784
@@ -1053,9 +1053,9 @@ Types:
           Type: 8 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 58 ArrayType noalg.[8]struct { key string; elem *main.bigStruct }
+          Type: 62 ArrayType noalg.[8]struct { key string; elem *main.bigStruct }
     - __kind: StructureType
-      ID: 59
+      ID: 63
       Name: noalg.struct { key string; elem *main.bigStruct }
       ByteSize: 24
       GoRuntimeType: 74656
@@ -1066,9 +1066,9 @@ Types:
           Type: 9 GoStringHeaderType string
         - Name: elem
           Offset: 16
-          Type: 60 PointerType *main.bigStruct
+          Type: 64 PointerType *main.bigStruct
     - __kind: StructureType
-      ID: 48
+      ID: 61
       Name: noalg.struct { key string; elem int }
       ByteSize: 24
       GoRuntimeType: 74400
@@ -1099,7 +1099,7 @@ Types:
       Name: string.str
       ByteSize: 2048
     - __kind: StructureType
-      ID: 43
+      ID: 51
       Name: table<string,int>
       ByteSize: 32
       GoKind: 25
@@ -1121,9 +1121,9 @@ Types:
           Type: 7 BaseType int
         - Name: groups
           Offset: 16
-          Type: 44 GoSwissMapGroupsType groupReference<string,int>
+          Type: 54 GoSwissMapGroupsType groupReference<string,int>
     - __kind: StructureType
-      ID: 54
+      ID: 52
       Name: table<string,main.bigStruct>
       ByteSize: 32
       GoKind: 25
@@ -1145,7 +1145,7 @@ Types:
           Type: 7 BaseType int
         - Name: groups
           Offset: 16
-          Type: 55 GoSwissMapGroupsType groupReference<string,main.bigStruct>
+          Type: 57 GoSwissMapGroupsType groupReference<string,main.bigStruct>
     - __kind: BaseType
       ID: 10
       Name: uint

--- a/pkg/dyninst/irgen/testdata/snapshot/simple.arch=arm64,toolchain=go1.24.3.yaml
+++ b/pkg/dyninst/irgen/testdata/snapshot/simple.arch=arm64,toolchain=go1.24.3.yaml
@@ -15,7 +15,7 @@ Probes:
       events:
         - ID: 11
           Type: 87 EventRootType Probe[main.PointerChainArg]
-          InjectionPoints: [{PC: 741836, Frameless: false}]
+          InjectionPoints: [{PC: "0xb51cc", Frameless: false}]
           Condition: null
     - id: PointerSmallChainArg
       version: 0
@@ -32,7 +32,7 @@ Probes:
       events:
         - ID: 12
           Type: 88 EventRootType Probe[main.PointerSmallChainArg]
-          InjectionPoints: [{PC: 741892, Frameless: false}]
+          InjectionPoints: [{PC: "0xb5204", Frameless: false}]
           Condition: null
     - id: bigMapArg
       version: 0
@@ -45,7 +45,7 @@ Probes:
       events:
         - ID: 9
           Type: 85 EventRootType Probe[main.bigMapArg]
-          InjectionPoints: [{PC: 743056, Frameless: true}]
+          InjectionPoints: [{PC: "0xb5690", Frameless: true}]
           Condition: null
     - id: inlined
       version: 0
@@ -60,9 +60,9 @@ Probes:
         - ID: 10
           Type: 86 EventRootType Probe[main.inlined]
           InjectionPoints:
-            - PC: 742748
+            - PC: "0xb555c"
               Frameless: true
-            - PC: 741356
+            - PC: "0xb4fec"
               Frameless: false
           Condition: null
     - id: intArg
@@ -76,7 +76,7 @@ Probes:
       events:
         - ID: 1
           Type: 77 EventRootType Probe[main.intArg]
-          InjectionPoints: [{PC: 741980, Frameless: true}]
+          InjectionPoints: [{PC: "0xb525c", Frameless: true}]
           Condition: null
     - id: intArrayArg
       version: 0
@@ -89,7 +89,7 @@ Probes:
       events:
         - ID: 4
           Type: 80 EventRootType Probe[main.intArrayArg]
-          InjectionPoints: [{PC: 742348, Frameless: true}]
+          InjectionPoints: [{PC: "0xb53cc", Frameless: true}]
           Condition: null
     - id: intArrayArgFrameless
       version: 0
@@ -102,7 +102,7 @@ Probes:
       events:
         - ID: 7
           Type: 83 EventRootType Probe[main.stringArrayArgFrameless]
-          InjectionPoints: [{PC: 742720, Frameless: true}]
+          InjectionPoints: [{PC: "0xb5540", Frameless: true}]
           Condition: null
     - id: intSliceArg
       version: 0
@@ -115,7 +115,7 @@ Probes:
       events:
         - ID: 3
           Type: 79 EventRootType Probe[main.intSliceArg]
-          InjectionPoints: [{PC: 742220, Frameless: true}]
+          InjectionPoints: [{PC: "0xb534c", Frameless: true}]
           Condition: null
     - id: mapArg
       version: 0
@@ -128,7 +128,7 @@ Probes:
       events:
         - ID: 8
           Type: 84 EventRootType Probe[main.mapArg]
-          InjectionPoints: [{PC: 742940, Frameless: true}]
+          InjectionPoints: [{PC: "0xb561c", Frameless: true}]
           Condition: null
     - id: stringArg
       version: 0
@@ -141,7 +141,7 @@ Probes:
       events:
         - ID: 2
           Type: 78 EventRootType Probe[main.stringArg]
-          InjectionPoints: [{PC: 742092, Frameless: true}]
+          InjectionPoints: [{PC: "0xb52cc", Frameless: true}]
           Condition: null
     - id: stringArrayArg
       version: 0
@@ -154,7 +154,7 @@ Probes:
       events:
         - ID: 6
           Type: 82 EventRootType Probe[main.stringArrayArg]
-          InjectionPoints: [{PC: 742604, Frameless: true}]
+          InjectionPoints: [{PC: "0xb54cc", Frameless: true}]
           Condition: null
     - id: stringSliceArg
       version: 0
@@ -167,7 +167,7 @@ Probes:
       events:
         - ID: 5
           Type: 81 EventRootType Probe[main.stringSliceArg]
-          InjectionPoints: [{PC: 742476, Frameless: true}]
+          InjectionPoints: [{PC: "0xb544c", Frameless: true}]
           Condition: null
 Subprograms:
     - ID: 4
@@ -341,12 +341,6 @@ Subprograms:
           IsParameter: true
           IsReturn: false
 Types:
-    - __kind: BaseType
-      ID: 1
-      Name: int
-      ByteSize: 8
-      GoRuntimeType: 41920
-      GoKind: 2
     - __kind: PointerType
       ID: 2
       Name: '*****int'
@@ -376,445 +370,25 @@ Types:
       GoKind: 22
       Pointee: 6 PointerType *int
     - __kind: PointerType
-      ID: 6
-      Name: '*int'
-      ByteSize: 8
-      GoRuntimeType: 29088
-      GoKind: 22
-      Pointee: 1 BaseType int
-    - __kind: GoStringHeaderType
-      ID: 7
-      Name: string
-      ByteSize: 16
-      GoRuntimeType: 41344
-      GoKind: 24
-      RawFields:
-        - Name: str
-          Offset: 0
-          Type: 68 PointerType *string.str
-        - Name: len
-          Offset: 8
-          Type: 1 BaseType int
-      Data: 67 GoStringDataType string.str
-    - __kind: PointerType
-      ID: 8
-      Name: '*uint8'
-      ByteSize: 8
-      GoRuntimeType: 28640
-      GoKind: 22
-      Pointee: 9 BaseType uint8
-    - __kind: BaseType
-      ID: 9
-      Name: uint8
-      ByteSize: 1
-      GoRuntimeType: 41472
-      GoKind: 8
-    - __kind: GoSliceHeaderType
-      ID: 10
-      Name: '[]int'
-      ByteSize: 24
-      GoRuntimeType: 37664
-      GoKind: 23
-      RawFields:
-        - Name: array
-          Offset: 0
-          Type: 6 PointerType *int
-        - Name: len
-          Offset: 8
-          Type: 1 BaseType int
-        - Name: cap
-          Offset: 16
-          Type: 1 BaseType int
-      Data: 69 GoSliceDataType []int.array
-    - __kind: ArrayType
-      ID: 11
-      Name: '[3]int'
-      ByteSize: 24
-      GoRuntimeType: 45920
-      GoKind: 17
-      Count: 3
-      HasCount: true
-      Element: 1 BaseType int
-    - __kind: GoSliceHeaderType
-      ID: 12
-      Name: '[]string'
-      ByteSize: 24
-      GoRuntimeType: 37920
-      GoKind: 23
-      RawFields:
-        - Name: array
-          Offset: 0
-          Type: 13 PointerType *string
-        - Name: len
-          Offset: 8
-          Type: 1 BaseType int
-        - Name: cap
-          Offset: 16
-          Type: 1 BaseType int
-      Data: 71 GoSliceDataType []string.array
-    - __kind: PointerType
-      ID: 13
-      Name: '*string'
-      ByteSize: 8
-      GoRuntimeType: 28512
-      GoKind: 22
-      Pointee: 7 GoStringHeaderType string
-    - __kind: ArrayType
-      ID: 14
-      Name: '[3]string'
-      ByteSize: 48
-      GoRuntimeType: 46016
-      GoKind: 17
-      Count: 3
-      HasCount: true
-      Element: 7 GoStringHeaderType string
-    - __kind: GoMapType
-      ID: 15
-      Name: map[string]int
-      ByteSize: 8
-      GoRuntimeType: 67136
-      GoKind: 21
-      HeaderType: 17 GoSwissMapHeaderType map<string,int>
-    - __kind: PointerType
-      ID: 16
-      Name: '*map<string,int>'
-      ByteSize: 8
-      Pointee: 17 GoSwissMapHeaderType map<string,int>
-    - __kind: GoSwissMapHeaderType
-      ID: 17
-      Name: map<string,int>
-      ByteSize: 48
-      GoKind: 25
-      RawFields:
-        - Name: used
-          Offset: 0
-          Type: 18 BaseType uint64
-        - Name: seed
-          Offset: 8
-          Type: 19 BaseType uintptr
-        - Name: dirPtr
-          Offset: 16
-          Type: 20 PointerType **table<string,int>
-        - Name: dirLen
-          Offset: 24
-          Type: 1 BaseType int
-        - Name: globalDepth
-          Offset: 32
-          Type: 9 BaseType uint8
-        - Name: globalShift
-          Offset: 33
-          Type: 9 BaseType uint8
-        - Name: writing
-          Offset: 34
-          Type: 9 BaseType uint8
-        - Name: clearSeq
-          Offset: 40
-          Type: 18 BaseType uint64
-      TablePtrSliceType: 73 GoSliceDataType []*table<string,int>.array
-      GroupType: 26 StructureType noalg.map.group[string]int
-    - __kind: BaseType
-      ID: 18
-      Name: uint64
-      ByteSize: 8
-      GoRuntimeType: 41856
-      GoKind: 11
-    - __kind: BaseType
-      ID: 19
-      Name: uintptr
-      ByteSize: 8
-      GoRuntimeType: 42048
-      GoKind: 12
-    - __kind: PointerType
       ID: 20
       Name: '**table<string,int>'
       ByteSize: 8
       Pointee: 21 PointerType *table<string,int>
-    - __kind: PointerType
-      ID: 21
-      Name: '*table<string,int>'
-      ByteSize: 8
-      Pointee: 22 StructureType table<string,int>
-    - __kind: StructureType
-      ID: 22
-      Name: table<string,int>
-      ByteSize: 32
-      GoKind: 25
-      RawFields:
-        - Name: used
-          Offset: 0
-          Type: 23 BaseType uint16
-        - Name: capacity
-          Offset: 2
-          Type: 23 BaseType uint16
-        - Name: growthLeft
-          Offset: 4
-          Type: 23 BaseType uint16
-        - Name: localDepth
-          Offset: 6
-          Type: 9 BaseType uint8
-        - Name: index
-          Offset: 8
-          Type: 1 BaseType int
-        - Name: groups
-          Offset: 16
-          Type: 24 GoSwissMapGroupsType groupReference<string,int>
-    - __kind: BaseType
-      ID: 23
-      Name: uint16
-      ByteSize: 2
-      GoRuntimeType: 41600
-      GoKind: 9
-    - __kind: GoSwissMapGroupsType
-      ID: 24
-      Name: groupReference<string,int>
-      ByteSize: 16
-      GoKind: 25
-      RawFields:
-        - Name: data
-          Offset: 0
-          Type: 25 PointerType *noalg.map.group[string]int
-        - Name: lengthMask
-          Offset: 8
-          Type: 18 BaseType uint64
-      GroupType: 26 StructureType noalg.map.group[string]int
-      GroupSliceType: 74 GoSliceDataType []noalg.map.group[string]int.array
-    - __kind: PointerType
-      ID: 25
-      Name: '*noalg.map.group[string]int'
-      ByteSize: 8
-      Pointee: 26 StructureType noalg.map.group[string]int
-    - __kind: StructureType
-      ID: 26
-      Name: noalg.map.group[string]int
-      ByteSize: 200
-      GoRuntimeType: 74528
-      GoKind: 25
-      RawFields:
-        - Name: ctrl
-          Offset: 0
-          Type: 18 BaseType uint64
-        - Name: slots
-          Offset: 8
-          Type: 27 ArrayType noalg.[8]struct { key string; elem int }
-    - __kind: ArrayType
-      ID: 27
-      Name: noalg.[8]struct { key string; elem int }
-      ByteSize: 192
-      GoRuntimeType: 46112
-      GoKind: 17
-      Count: 8
-      HasCount: true
-      Element: 28 StructureType noalg.struct { key string; elem int }
-    - __kind: StructureType
-      ID: 28
-      Name: noalg.struct { key string; elem int }
-      ByteSize: 24
-      GoRuntimeType: 74400
-      GoKind: 25
-      RawFields:
-        - Name: key
-          Offset: 0
-          Type: 7 GoStringHeaderType string
-        - Name: elem
-          Offset: 16
-          Type: 1 BaseType int
-    - __kind: GoMapType
-      ID: 29
-      Name: map[string]main.bigStruct
-      ByteSize: 8
-      GoRuntimeType: 67264
-      GoKind: 21
-      HeaderType: 31 GoSwissMapHeaderType map<string,main.bigStruct>
-    - __kind: PointerType
-      ID: 30
-      Name: '*map<string,main.bigStruct>'
-      ByteSize: 8
-      Pointee: 31 GoSwissMapHeaderType map<string,main.bigStruct>
-    - __kind: GoSwissMapHeaderType
-      ID: 31
-      Name: map<string,main.bigStruct>
-      ByteSize: 48
-      GoKind: 25
-      RawFields:
-        - Name: used
-          Offset: 0
-          Type: 18 BaseType uint64
-        - Name: seed
-          Offset: 8
-          Type: 19 BaseType uintptr
-        - Name: dirPtr
-          Offset: 16
-          Type: 32 PointerType **table<string,main.bigStruct>
-        - Name: dirLen
-          Offset: 24
-          Type: 1 BaseType int
-        - Name: globalDepth
-          Offset: 32
-          Type: 9 BaseType uint8
-        - Name: globalShift
-          Offset: 33
-          Type: 9 BaseType uint8
-        - Name: writing
-          Offset: 34
-          Type: 9 BaseType uint8
-        - Name: clearSeq
-          Offset: 40
-          Type: 18 BaseType uint64
-      TablePtrSliceType: 75 GoSliceDataType []*table<string,main.bigStruct>.array
-      GroupType: 37 StructureType noalg.map.group[string]main.bigStruct
     - __kind: PointerType
       ID: 32
       Name: '**table<string,main.bigStruct>'
       ByteSize: 8
       Pointee: 33 PointerType *table<string,main.bigStruct>
     - __kind: PointerType
-      ID: 33
-      Name: '*table<string,main.bigStruct>'
+      ID: 70
+      Name: '*[]int.array'
       ByteSize: 8
-      Pointee: 34 StructureType table<string,main.bigStruct>
-    - __kind: StructureType
-      ID: 34
-      Name: table<string,main.bigStruct>
-      ByteSize: 32
-      GoKind: 25
-      RawFields:
-        - Name: used
-          Offset: 0
-          Type: 23 BaseType uint16
-        - Name: capacity
-          Offset: 2
-          Type: 23 BaseType uint16
-        - Name: growthLeft
-          Offset: 4
-          Type: 23 BaseType uint16
-        - Name: localDepth
-          Offset: 6
-          Type: 9 BaseType uint8
-        - Name: index
-          Offset: 8
-          Type: 1 BaseType int
-        - Name: groups
-          Offset: 16
-          Type: 35 GoSwissMapGroupsType groupReference<string,main.bigStruct>
-    - __kind: GoSwissMapGroupsType
-      ID: 35
-      Name: groupReference<string,main.bigStruct>
-      ByteSize: 16
-      GoKind: 25
-      RawFields:
-        - Name: data
-          Offset: 0
-          Type: 36 PointerType *noalg.map.group[string]main.bigStruct
-        - Name: lengthMask
-          Offset: 8
-          Type: 18 BaseType uint64
-      GroupType: 37 StructureType noalg.map.group[string]main.bigStruct
-      GroupSliceType: 76 GoSliceDataType []noalg.map.group[string]main.bigStruct.array
+      Pointee: 69 GoSliceDataType []int.array
     - __kind: PointerType
-      ID: 36
-      Name: '*noalg.map.group[string]main.bigStruct'
+      ID: 72
+      Name: '*[]string.array'
       ByteSize: 8
-      Pointee: 37 StructureType noalg.map.group[string]main.bigStruct
-    - __kind: StructureType
-      ID: 37
-      Name: noalg.map.group[string]main.bigStruct
-      ByteSize: 200
-      GoRuntimeType: 74784
-      GoKind: 25
-      RawFields:
-        - Name: ctrl
-          Offset: 0
-          Type: 18 BaseType uint64
-        - Name: slots
-          Offset: 8
-          Type: 38 ArrayType noalg.[8]struct { key string; elem *main.bigStruct }
-    - __kind: ArrayType
-      ID: 38
-      Name: noalg.[8]struct { key string; elem *main.bigStruct }
-      ByteSize: 192
-      GoRuntimeType: 46304
-      GoKind: 17
-      Count: 8
-      HasCount: true
-      Element: 39 StructureType noalg.struct { key string; elem *main.bigStruct }
-    - __kind: StructureType
-      ID: 39
-      Name: noalg.struct { key string; elem *main.bigStruct }
-      ByteSize: 24
-      GoRuntimeType: 74656
-      GoKind: 25
-      RawFields:
-        - Name: key
-          Offset: 0
-          Type: 7 GoStringHeaderType string
-        - Name: elem
-          Offset: 16
-          Type: 40 PointerType *main.bigStruct
-    - __kind: PointerType
-      ID: 40
-      Name: '*main.bigStruct'
-      ByteSize: 8
-      GoRuntimeType: 26912
-      GoKind: 22
-      Pointee: 41 StructureType main.bigStruct
-    - __kind: StructureType
-      ID: 41
-      Name: main.bigStruct
-      ByteSize: 184
-      GoRuntimeType: 119616
-      GoKind: 25
-      RawFields:
-        - Name: Field1
-          Offset: 0
-          Type: 1 BaseType int
-        - Name: Field2
-          Offset: 8
-          Type: 1 BaseType int
-        - Name: Field3
-          Offset: 16
-          Type: 1 BaseType int
-        - Name: Field4
-          Offset: 24
-          Type: 1 BaseType int
-        - Name: Field5
-          Offset: 32
-          Type: 1 BaseType int
-        - Name: Field6
-          Offset: 40
-          Type: 1 BaseType int
-        - Name: Field7
-          Offset: 48
-          Type: 1 BaseType int
-        - Name: data
-          Offset: 56
-          Type: 42 ArrayType [128]uint8
-    - __kind: ArrayType
-      ID: 42
-      Name: '[128]uint8'
-      ByteSize: 128
-      GoRuntimeType: 46208
-      GoKind: 17
-      Count: 128
-      HasCount: true
-      Element: 9 BaseType uint8
-    - __kind: BaseType
-      ID: 43
-      Name: uint32
-      ByteSize: 4
-      GoRuntimeType: 41728
-      GoKind: 10
-    - __kind: BaseType
-      ID: 44
-      Name: bool
-      ByteSize: 1
-      GoRuntimeType: 42368
-      GoKind: 1
-    - __kind: BaseType
-      ID: 45
-      Name: uint
-      ByteSize: 8
-      GoRuntimeType: 41984
-      GoKind: 7
+      Pointee: 71 GoSliceDataType []string.array
     - __kind: PointerType
       ID: 46
       Name: '*bool'
@@ -822,115 +396,6 @@ Types:
       GoRuntimeType: 29536
       GoKind: 22
       Pointee: 44 BaseType bool
-    - __kind: BaseType
-      ID: 47
-      Name: int32
-      ByteSize: 4
-      GoRuntimeType: 41664
-      GoKind: 5
-    - __kind: BaseType
-      ID: 48
-      Name: int64
-      ByteSize: 8
-      GoRuntimeType: 41792
-      GoKind: 6
-    - __kind: GoInterfaceType
-      ID: 49
-      Name: error
-      ByteSize: 16
-      GoRuntimeType: 63040
-      GoKind: 20
-      RawFields:
-        - Name: tab
-          Offset: 0
-          Type: 50 VoidPointerType unsafe.Pointer
-        - Name: data
-          Offset: 8
-          Type: 50 VoidPointerType unsafe.Pointer
-    - __kind: VoidPointerType
-      ID: 50
-      Name: unsafe.Pointer
-      ByteSize: 8
-      GoRuntimeType: 42432
-      GoKind: 26
-    - __kind: BaseType
-      ID: 51
-      Name: int8
-      ByteSize: 1
-      GoRuntimeType: 41408
-      GoKind: 3
-    - __kind: BaseType
-      ID: 52
-      Name: float32
-      ByteSize: 4
-      GoRuntimeType: 42240
-      GoKind: 13
-    - __kind: BaseType
-      ID: 53
-      Name: float64
-      ByteSize: 8
-      GoRuntimeType: 42304
-      GoKind: 14
-    - __kind: PointerType
-      ID: 54
-      Name: '*uintptr'
-      ByteSize: 8
-      GoRuntimeType: 29216
-      GoKind: 22
-      Pointee: 19 BaseType uintptr
-    - __kind: PointerType
-      ID: 55
-      Name: '*int32'
-      ByteSize: 8
-      GoRuntimeType: 28832
-      GoKind: 22
-      Pointee: 47 BaseType int32
-    - __kind: PointerType
-      ID: 56
-      Name: '*uint32'
-      ByteSize: 8
-      GoRuntimeType: 28896
-      GoKind: 22
-      Pointee: 43 BaseType uint32
-    - __kind: BaseType
-      ID: 57
-      Name: int16
-      ByteSize: 2
-      GoRuntimeType: 41536
-      GoKind: 4
-    - __kind: BaseType
-      ID: 58
-      Name: complex64
-      ByteSize: 8
-      GoRuntimeType: 42112
-      GoKind: 15
-    - __kind: BaseType
-      ID: 59
-      Name: complex128
-      ByteSize: 16
-      GoRuntimeType: 42176
-      GoKind: 16
-    - __kind: PointerType
-      ID: 60
-      Name: '*float64'
-      ByteSize: 8
-      GoRuntimeType: 29472
-      GoKind: 22
-      Pointee: 53 BaseType float64
-    - __kind: PointerType
-      ID: 61
-      Name: '*int64'
-      ByteSize: 8
-      GoRuntimeType: 28960
-      GoKind: 22
-      Pointee: 48 BaseType int64
-    - __kind: PointerType
-      ID: 62
-      Name: '*uint64'
-      ByteSize: 8
-      GoRuntimeType: 29024
-      GoKind: 22
-      Pointee: 18 BaseType uint64
     - __kind: PointerType
       ID: 63
       Name: '*error'
@@ -946,6 +411,83 @@ Types:
       GoKind: 22
       Pointee: 52 BaseType float32
     - __kind: PointerType
+      ID: 60
+      Name: '*float64'
+      ByteSize: 8
+      GoRuntimeType: 29472
+      GoKind: 22
+      Pointee: 53 BaseType float64
+    - __kind: PointerType
+      ID: 6
+      Name: '*int'
+      ByteSize: 8
+      GoRuntimeType: 29088
+      GoKind: 22
+      Pointee: 1 BaseType int
+    - __kind: PointerType
+      ID: 55
+      Name: '*int32'
+      ByteSize: 8
+      GoRuntimeType: 28832
+      GoKind: 22
+      Pointee: 47 BaseType int32
+    - __kind: PointerType
+      ID: 61
+      Name: '*int64'
+      ByteSize: 8
+      GoRuntimeType: 28960
+      GoKind: 22
+      Pointee: 48 BaseType int64
+    - __kind: PointerType
+      ID: 40
+      Name: '*main.bigStruct'
+      ByteSize: 8
+      GoRuntimeType: 26912
+      GoKind: 22
+      Pointee: 41 StructureType main.bigStruct
+    - __kind: PointerType
+      ID: 16
+      Name: '*map<string,int>'
+      ByteSize: 8
+      Pointee: 17 GoSwissMapHeaderType map<string,int>
+    - __kind: PointerType
+      ID: 30
+      Name: '*map<string,main.bigStruct>'
+      ByteSize: 8
+      Pointee: 31 GoSwissMapHeaderType map<string,main.bigStruct>
+    - __kind: PointerType
+      ID: 25
+      Name: '*noalg.map.group[string]int'
+      ByteSize: 8
+      Pointee: 26 StructureType noalg.map.group[string]int
+    - __kind: PointerType
+      ID: 36
+      Name: '*noalg.map.group[string]main.bigStruct'
+      ByteSize: 8
+      Pointee: 37 StructureType noalg.map.group[string]main.bigStruct
+    - __kind: PointerType
+      ID: 13
+      Name: '*string'
+      ByteSize: 8
+      GoRuntimeType: 28512
+      GoKind: 22
+      Pointee: 7 GoStringHeaderType string
+    - __kind: PointerType
+      ID: 68
+      Name: '*string.str'
+      ByteSize: 8
+      Pointee: 67 GoStringDataType string.str
+    - __kind: PointerType
+      ID: 21
+      Name: '*table<string,int>'
+      ByteSize: 8
+      Pointee: 22 StructureType table<string,int>
+    - __kind: PointerType
+      ID: 33
+      Name: '*table<string,main.bigStruct>'
+      ByteSize: 8
+      Pointee: 34 StructureType table<string,main.bigStruct>
+    - __kind: PointerType
       ID: 65
       Name: '*uint'
       ByteSize: 8
@@ -959,173 +501,62 @@ Types:
       GoRuntimeType: 28768
       GoKind: 22
       Pointee: 23 BaseType uint16
-    - __kind: GoStringDataType
-      ID: 67
-      Name: string.str
-      ByteSize: 2048
     - __kind: PointerType
-      ID: 68
-      Name: '*string.str'
+      ID: 56
+      Name: '*uint32'
       ByteSize: 8
-      Pointee: 67 GoStringDataType string.str
-    - __kind: GoSliceDataType
-      ID: 69
-      Name: '[]int.array'
-      ByteSize: 2048
-      Element: 1 BaseType int
+      GoRuntimeType: 28896
+      GoKind: 22
+      Pointee: 43 BaseType uint32
     - __kind: PointerType
-      ID: 70
-      Name: '*[]int.array'
+      ID: 62
+      Name: '*uint64'
       ByteSize: 8
-      Pointee: 69 GoSliceDataType []int.array
-    - __kind: GoSliceDataType
-      ID: 71
-      Name: '[]string.array'
-      ByteSize: 2048
-      Element: 7 GoStringHeaderType string
+      GoRuntimeType: 29024
+      GoKind: 22
+      Pointee: 18 BaseType uint64
     - __kind: PointerType
-      ID: 72
-      Name: '*[]string.array'
+      ID: 8
+      Name: '*uint8'
       ByteSize: 8
-      Pointee: 71 GoSliceDataType []string.array
-    - __kind: GoSliceDataType
-      ID: 73
-      Name: '[]*table<string,int>.array'
-      ByteSize: 8192
-      Element: 21 PointerType *table<string,int>
-    - __kind: GoSliceDataType
-      ID: 74
-      Name: '[]noalg.map.group[string]int.array'
-      ByteSize: 2048
-      Element: 26 StructureType noalg.map.group[string]int
-    - __kind: GoSliceDataType
-      ID: 75
-      Name: '[]*table<string,main.bigStruct>.array'
-      ByteSize: 8192
-      Element: 33 PointerType *table<string,main.bigStruct>
-    - __kind: GoSliceDataType
-      ID: 76
-      Name: '[]noalg.map.group[string]main.bigStruct.array'
-      ByteSize: 2048
-      Element: 37 StructureType noalg.map.group[string]main.bigStruct
+      GoRuntimeType: 28640
+      GoKind: 22
+      Pointee: 9 BaseType uint8
+    - __kind: PointerType
+      ID: 54
+      Name: '*uintptr'
+      ByteSize: 8
+      GoRuntimeType: 29216
+      GoKind: 22
+      Pointee: 19 BaseType uintptr
     - __kind: EventRootType
-      ID: 77
-      Name: Probe[main.intArg]
+      ID: 87
+      Name: Probe[main.PointerChainArg]
       ByteSize: 9
       PresenceBitsetSize: 1
       Expressions:
-        - Name: x
+        - Name: ptr
           Offset: 1
           Expression:
-            Type: 1 BaseType int
+            Type: 2 PointerType *****int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 4, index: 0, name: x}
+                  Variable: {subprogram: 2, index: 0, name: ptr}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 78
-      Name: Probe[main.stringArg]
-      ByteSize: 17
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: s
-          Offset: 1
-          Expression:
-            Type: 7 GoStringHeaderType string
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 5, index: 0, name: s}
-                  Offset: 0
-                  ByteSize: 16
-    - __kind: EventRootType
-      ID: 79
-      Name: Probe[main.intSliceArg]
-      ByteSize: 25
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: s
-          Offset: 1
-          Expression:
-            Type: 10 GoSliceHeaderType []int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 6, index: 0, name: s}
-                  Offset: 0
-                  ByteSize: 24
-    - __kind: EventRootType
-      ID: 80
-      Name: Probe[main.intArrayArg]
-      ByteSize: 25
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: s
-          Offset: 1
-          Expression:
-            Type: 11 ArrayType [3]int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 7, index: 0, name: s}
-                  Offset: 0
-                  ByteSize: 24
-    - __kind: EventRootType
-      ID: 81
-      Name: Probe[main.stringSliceArg]
-      ByteSize: 25
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: s
-          Offset: 1
-          Expression:
-            Type: 12 GoSliceHeaderType []string
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 8, index: 0, name: s}
-                  Offset: 0
-                  ByteSize: 24
-    - __kind: EventRootType
-      ID: 82
-      Name: Probe[main.stringArrayArg]
-      ByteSize: 49
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: s
-          Offset: 1
-          Expression:
-            Type: 14 ArrayType [3]string
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 9, index: 0, name: s}
-                  Offset: 0
-                  ByteSize: 48
-    - __kind: EventRootType
-      ID: 83
-      Name: Probe[main.stringArrayArgFrameless]
-      ByteSize: 49
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: s
-          Offset: 1
-          Expression:
-            Type: 14 ArrayType [3]string
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 10, index: 0, name: s}
-                  Offset: 0
-                  ByteSize: 48
-    - __kind: EventRootType
-      ID: 84
-      Name: Probe[main.mapArg]
+      ID: 88
+      Name: Probe[main.PointerSmallChainArg]
       ByteSize: 9
       PresenceBitsetSize: 1
       Expressions:
-        - Name: m
+        - Name: ptr
           Offset: 1
           Expression:
-            Type: 15 GoMapType map[string]int
+            Type: 5 PointerType **int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 11, index: 0, name: m}
+                  Variable: {subprogram: 3, index: 0, name: ptr}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
@@ -1159,35 +590,604 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 87
-      Name: Probe[main.PointerChainArg]
+      ID: 77
+      Name: Probe[main.intArg]
       ByteSize: 9
       PresenceBitsetSize: 1
       Expressions:
-        - Name: ptr
+        - Name: x
           Offset: 1
           Expression:
-            Type: 2 PointerType *****int
+            Type: 1 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 2, index: 0, name: ptr}
+                  Variable: {subprogram: 4, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 88
-      Name: Probe[main.PointerSmallChainArg]
+      ID: 80
+      Name: Probe[main.intArrayArg]
+      ByteSize: 25
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: s
+          Offset: 1
+          Expression:
+            Type: 11 ArrayType [3]int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 7, index: 0, name: s}
+                  Offset: 0
+                  ByteSize: 24
+    - __kind: EventRootType
+      ID: 79
+      Name: Probe[main.intSliceArg]
+      ByteSize: 25
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: s
+          Offset: 1
+          Expression:
+            Type: 10 GoSliceHeaderType []int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 6, index: 0, name: s}
+                  Offset: 0
+                  ByteSize: 24
+    - __kind: EventRootType
+      ID: 84
+      Name: Probe[main.mapArg]
       ByteSize: 9
       PresenceBitsetSize: 1
       Expressions:
-        - Name: ptr
+        - Name: m
           Offset: 1
           Expression:
-            Type: 5 PointerType **int
+            Type: 15 GoMapType map[string]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 3, index: 0, name: ptr}
+                  Variable: {subprogram: 11, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
+    - __kind: EventRootType
+      ID: 78
+      Name: Probe[main.stringArg]
+      ByteSize: 17
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: s
+          Offset: 1
+          Expression:
+            Type: 7 GoStringHeaderType string
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 5, index: 0, name: s}
+                  Offset: 0
+                  ByteSize: 16
+    - __kind: EventRootType
+      ID: 83
+      Name: Probe[main.stringArrayArgFrameless]
+      ByteSize: 49
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: s
+          Offset: 1
+          Expression:
+            Type: 14 ArrayType [3]string
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 10, index: 0, name: s}
+                  Offset: 0
+                  ByteSize: 48
+    - __kind: EventRootType
+      ID: 82
+      Name: Probe[main.stringArrayArg]
+      ByteSize: 49
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: s
+          Offset: 1
+          Expression:
+            Type: 14 ArrayType [3]string
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 9, index: 0, name: s}
+                  Offset: 0
+                  ByteSize: 48
+    - __kind: EventRootType
+      ID: 81
+      Name: Probe[main.stringSliceArg]
+      ByteSize: 25
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: s
+          Offset: 1
+          Expression:
+            Type: 12 GoSliceHeaderType []string
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 8, index: 0, name: s}
+                  Offset: 0
+                  ByteSize: 24
+    - __kind: ArrayType
+      ID: 42
+      Name: '[128]uint8'
+      ByteSize: 128
+      GoRuntimeType: 46208
+      GoKind: 17
+      Count: 128
+      HasCount: true
+      Element: 9 BaseType uint8
+    - __kind: ArrayType
+      ID: 11
+      Name: '[3]int'
+      ByteSize: 24
+      GoRuntimeType: 45920
+      GoKind: 17
+      Count: 3
+      HasCount: true
+      Element: 1 BaseType int
+    - __kind: ArrayType
+      ID: 14
+      Name: '[3]string'
+      ByteSize: 48
+      GoRuntimeType: 46016
+      GoKind: 17
+      Count: 3
+      HasCount: true
+      Element: 7 GoStringHeaderType string
+    - __kind: GoSliceDataType
+      ID: 73
+      Name: '[]*table<string,int>.array'
+      ByteSize: 8192
+      Element: 21 PointerType *table<string,int>
+    - __kind: GoSliceDataType
+      ID: 75
+      Name: '[]*table<string,main.bigStruct>.array'
+      ByteSize: 8192
+      Element: 33 PointerType *table<string,main.bigStruct>
+    - __kind: GoSliceHeaderType
+      ID: 10
+      Name: '[]int'
+      ByteSize: 24
+      GoRuntimeType: 37664
+      GoKind: 23
+      RawFields:
+        - Name: array
+          Offset: 0
+          Type: 6 PointerType *int
+        - Name: len
+          Offset: 8
+          Type: 1 BaseType int
+        - Name: cap
+          Offset: 16
+          Type: 1 BaseType int
+      Data: 69 GoSliceDataType []int.array
+    - __kind: GoSliceDataType
+      ID: 69
+      Name: '[]int.array'
+      ByteSize: 2048
+      Element: 1 BaseType int
+    - __kind: GoSliceDataType
+      ID: 74
+      Name: '[]noalg.map.group[string]int.array'
+      ByteSize: 2048
+      Element: 26 StructureType noalg.map.group[string]int
+    - __kind: GoSliceDataType
+      ID: 76
+      Name: '[]noalg.map.group[string]main.bigStruct.array'
+      ByteSize: 2048
+      Element: 37 StructureType noalg.map.group[string]main.bigStruct
+    - __kind: GoSliceHeaderType
+      ID: 12
+      Name: '[]string'
+      ByteSize: 24
+      GoRuntimeType: 37920
+      GoKind: 23
+      RawFields:
+        - Name: array
+          Offset: 0
+          Type: 13 PointerType *string
+        - Name: len
+          Offset: 8
+          Type: 1 BaseType int
+        - Name: cap
+          Offset: 16
+          Type: 1 BaseType int
+      Data: 71 GoSliceDataType []string.array
+    - __kind: GoSliceDataType
+      ID: 71
+      Name: '[]string.array'
+      ByteSize: 2048
+      Element: 7 GoStringHeaderType string
+    - __kind: BaseType
+      ID: 44
+      Name: bool
+      ByteSize: 1
+      GoRuntimeType: 42368
+      GoKind: 1
+    - __kind: BaseType
+      ID: 59
+      Name: complex128
+      ByteSize: 16
+      GoRuntimeType: 42176
+      GoKind: 16
+    - __kind: BaseType
+      ID: 58
+      Name: complex64
+      ByteSize: 8
+      GoRuntimeType: 42112
+      GoKind: 15
+    - __kind: GoInterfaceType
+      ID: 49
+      Name: error
+      ByteSize: 16
+      GoRuntimeType: 63040
+      GoKind: 20
+      RawFields:
+        - Name: tab
+          Offset: 0
+          Type: 50 VoidPointerType unsafe.Pointer
+        - Name: data
+          Offset: 8
+          Type: 50 VoidPointerType unsafe.Pointer
+    - __kind: BaseType
+      ID: 52
+      Name: float32
+      ByteSize: 4
+      GoRuntimeType: 42240
+      GoKind: 13
+    - __kind: BaseType
+      ID: 53
+      Name: float64
+      ByteSize: 8
+      GoRuntimeType: 42304
+      GoKind: 14
+    - __kind: GoSwissMapGroupsType
+      ID: 24
+      Name: groupReference<string,int>
+      ByteSize: 16
+      GoKind: 25
+      RawFields:
+        - Name: data
+          Offset: 0
+          Type: 25 PointerType *noalg.map.group[string]int
+        - Name: lengthMask
+          Offset: 8
+          Type: 18 BaseType uint64
+      GroupType: 26 StructureType noalg.map.group[string]int
+      GroupSliceType: 74 GoSliceDataType []noalg.map.group[string]int.array
+    - __kind: GoSwissMapGroupsType
+      ID: 35
+      Name: groupReference<string,main.bigStruct>
+      ByteSize: 16
+      GoKind: 25
+      RawFields:
+        - Name: data
+          Offset: 0
+          Type: 36 PointerType *noalg.map.group[string]main.bigStruct
+        - Name: lengthMask
+          Offset: 8
+          Type: 18 BaseType uint64
+      GroupType: 37 StructureType noalg.map.group[string]main.bigStruct
+      GroupSliceType: 76 GoSliceDataType []noalg.map.group[string]main.bigStruct.array
+    - __kind: BaseType
+      ID: 1
+      Name: int
+      ByteSize: 8
+      GoRuntimeType: 41920
+      GoKind: 2
+    - __kind: BaseType
+      ID: 57
+      Name: int16
+      ByteSize: 2
+      GoRuntimeType: 41536
+      GoKind: 4
+    - __kind: BaseType
+      ID: 47
+      Name: int32
+      ByteSize: 4
+      GoRuntimeType: 41664
+      GoKind: 5
+    - __kind: BaseType
+      ID: 48
+      Name: int64
+      ByteSize: 8
+      GoRuntimeType: 41792
+      GoKind: 6
+    - __kind: BaseType
+      ID: 51
+      Name: int8
+      ByteSize: 1
+      GoRuntimeType: 41408
+      GoKind: 3
+    - __kind: StructureType
+      ID: 41
+      Name: main.bigStruct
+      ByteSize: 184
+      GoRuntimeType: 119616
+      GoKind: 25
+      RawFields:
+        - Name: Field1
+          Offset: 0
+          Type: 1 BaseType int
+        - Name: Field2
+          Offset: 8
+          Type: 1 BaseType int
+        - Name: Field3
+          Offset: 16
+          Type: 1 BaseType int
+        - Name: Field4
+          Offset: 24
+          Type: 1 BaseType int
+        - Name: Field5
+          Offset: 32
+          Type: 1 BaseType int
+        - Name: Field6
+          Offset: 40
+          Type: 1 BaseType int
+        - Name: Field7
+          Offset: 48
+          Type: 1 BaseType int
+        - Name: data
+          Offset: 56
+          Type: 42 ArrayType [128]uint8
+    - __kind: GoSwissMapHeaderType
+      ID: 17
+      Name: map<string,int>
+      ByteSize: 48
+      GoKind: 25
+      RawFields:
+        - Name: used
+          Offset: 0
+          Type: 18 BaseType uint64
+        - Name: seed
+          Offset: 8
+          Type: 19 BaseType uintptr
+        - Name: dirPtr
+          Offset: 16
+          Type: 20 PointerType **table<string,int>
+        - Name: dirLen
+          Offset: 24
+          Type: 1 BaseType int
+        - Name: globalDepth
+          Offset: 32
+          Type: 9 BaseType uint8
+        - Name: globalShift
+          Offset: 33
+          Type: 9 BaseType uint8
+        - Name: writing
+          Offset: 34
+          Type: 9 BaseType uint8
+        - Name: clearSeq
+          Offset: 40
+          Type: 18 BaseType uint64
+      TablePtrSliceType: 73 GoSliceDataType []*table<string,int>.array
+      GroupType: 26 StructureType noalg.map.group[string]int
+    - __kind: GoSwissMapHeaderType
+      ID: 31
+      Name: map<string,main.bigStruct>
+      ByteSize: 48
+      GoKind: 25
+      RawFields:
+        - Name: used
+          Offset: 0
+          Type: 18 BaseType uint64
+        - Name: seed
+          Offset: 8
+          Type: 19 BaseType uintptr
+        - Name: dirPtr
+          Offset: 16
+          Type: 32 PointerType **table<string,main.bigStruct>
+        - Name: dirLen
+          Offset: 24
+          Type: 1 BaseType int
+        - Name: globalDepth
+          Offset: 32
+          Type: 9 BaseType uint8
+        - Name: globalShift
+          Offset: 33
+          Type: 9 BaseType uint8
+        - Name: writing
+          Offset: 34
+          Type: 9 BaseType uint8
+        - Name: clearSeq
+          Offset: 40
+          Type: 18 BaseType uint64
+      TablePtrSliceType: 75 GoSliceDataType []*table<string,main.bigStruct>.array
+      GroupType: 37 StructureType noalg.map.group[string]main.bigStruct
+    - __kind: GoMapType
+      ID: 15
+      Name: map[string]int
+      ByteSize: 8
+      GoRuntimeType: 67136
+      GoKind: 21
+      HeaderType: 17 GoSwissMapHeaderType map<string,int>
+    - __kind: GoMapType
+      ID: 29
+      Name: map[string]main.bigStruct
+      ByteSize: 8
+      GoRuntimeType: 67264
+      GoKind: 21
+      HeaderType: 31 GoSwissMapHeaderType map<string,main.bigStruct>
+    - __kind: ArrayType
+      ID: 38
+      Name: noalg.[8]struct { key string; elem *main.bigStruct }
+      ByteSize: 192
+      GoRuntimeType: 46304
+      GoKind: 17
+      Count: 8
+      HasCount: true
+      Element: 39 StructureType noalg.struct { key string; elem *main.bigStruct }
+    - __kind: ArrayType
+      ID: 27
+      Name: noalg.[8]struct { key string; elem int }
+      ByteSize: 192
+      GoRuntimeType: 46112
+      GoKind: 17
+      Count: 8
+      HasCount: true
+      Element: 28 StructureType noalg.struct { key string; elem int }
+    - __kind: StructureType
+      ID: 26
+      Name: noalg.map.group[string]int
+      ByteSize: 200
+      GoRuntimeType: 74528
+      GoKind: 25
+      RawFields:
+        - Name: ctrl
+          Offset: 0
+          Type: 18 BaseType uint64
+        - Name: slots
+          Offset: 8
+          Type: 27 ArrayType noalg.[8]struct { key string; elem int }
+    - __kind: StructureType
+      ID: 37
+      Name: noalg.map.group[string]main.bigStruct
+      ByteSize: 200
+      GoRuntimeType: 74784
+      GoKind: 25
+      RawFields:
+        - Name: ctrl
+          Offset: 0
+          Type: 18 BaseType uint64
+        - Name: slots
+          Offset: 8
+          Type: 38 ArrayType noalg.[8]struct { key string; elem *main.bigStruct }
+    - __kind: StructureType
+      ID: 39
+      Name: noalg.struct { key string; elem *main.bigStruct }
+      ByteSize: 24
+      GoRuntimeType: 74656
+      GoKind: 25
+      RawFields:
+        - Name: key
+          Offset: 0
+          Type: 7 GoStringHeaderType string
+        - Name: elem
+          Offset: 16
+          Type: 40 PointerType *main.bigStruct
+    - __kind: StructureType
+      ID: 28
+      Name: noalg.struct { key string; elem int }
+      ByteSize: 24
+      GoRuntimeType: 74400
+      GoKind: 25
+      RawFields:
+        - Name: key
+          Offset: 0
+          Type: 7 GoStringHeaderType string
+        - Name: elem
+          Offset: 16
+          Type: 1 BaseType int
+    - __kind: GoStringHeaderType
+      ID: 7
+      Name: string
+      ByteSize: 16
+      GoRuntimeType: 41344
+      GoKind: 24
+      RawFields:
+        - Name: str
+          Offset: 0
+          Type: 68 PointerType *string.str
+        - Name: len
+          Offset: 8
+          Type: 1 BaseType int
+      Data: 67 GoStringDataType string.str
+    - __kind: GoStringDataType
+      ID: 67
+      Name: string.str
+      ByteSize: 2048
+    - __kind: StructureType
+      ID: 22
+      Name: table<string,int>
+      ByteSize: 32
+      GoKind: 25
+      RawFields:
+        - Name: used
+          Offset: 0
+          Type: 23 BaseType uint16
+        - Name: capacity
+          Offset: 2
+          Type: 23 BaseType uint16
+        - Name: growthLeft
+          Offset: 4
+          Type: 23 BaseType uint16
+        - Name: localDepth
+          Offset: 6
+          Type: 9 BaseType uint8
+        - Name: index
+          Offset: 8
+          Type: 1 BaseType int
+        - Name: groups
+          Offset: 16
+          Type: 24 GoSwissMapGroupsType groupReference<string,int>
+    - __kind: StructureType
+      ID: 34
+      Name: table<string,main.bigStruct>
+      ByteSize: 32
+      GoKind: 25
+      RawFields:
+        - Name: used
+          Offset: 0
+          Type: 23 BaseType uint16
+        - Name: capacity
+          Offset: 2
+          Type: 23 BaseType uint16
+        - Name: growthLeft
+          Offset: 4
+          Type: 23 BaseType uint16
+        - Name: localDepth
+          Offset: 6
+          Type: 9 BaseType uint8
+        - Name: index
+          Offset: 8
+          Type: 1 BaseType int
+        - Name: groups
+          Offset: 16
+          Type: 35 GoSwissMapGroupsType groupReference<string,main.bigStruct>
+    - __kind: BaseType
+      ID: 45
+      Name: uint
+      ByteSize: 8
+      GoRuntimeType: 41984
+      GoKind: 7
+    - __kind: BaseType
+      ID: 23
+      Name: uint16
+      ByteSize: 2
+      GoRuntimeType: 41600
+      GoKind: 9
+    - __kind: BaseType
+      ID: 43
+      Name: uint32
+      ByteSize: 4
+      GoRuntimeType: 41728
+      GoKind: 10
+    - __kind: BaseType
+      ID: 18
+      Name: uint64
+      ByteSize: 8
+      GoRuntimeType: 41856
+      GoKind: 11
+    - __kind: BaseType
+      ID: 9
+      Name: uint8
+      ByteSize: 1
+      GoRuntimeType: 41472
+      GoKind: 8
+    - __kind: BaseType
+      ID: 19
+      Name: uintptr
+      ByteSize: 8
+      GoRuntimeType: 42048
+      GoKind: 12
+    - __kind: VoidPointerType
+      ID: 50
+      Name: unsafe.Pointer
+      ByteSize: 8
+      GoRuntimeType: 42432
+      GoKind: 26
 MaxTypeID: 88
 Issues: []
 GoModuledataInfo: {FirstModuledataAddr: "0x191340", TypesOffset: 296}

--- a/pkg/dyninst/irgen/testdata/snapshot/simple.arch=arm64,toolchain=go1.24.3.yaml
+++ b/pkg/dyninst/irgen/testdata/snapshot/simple.arch=arm64,toolchain=go1.24.3.yaml
@@ -354,9 +354,9 @@ Types:
       ByteSize: 8
       GoRuntimeType: 35168
       GoKind: 22
-      Pointee: 53 PointerType ***int
+      Pointee: 75 PointerType ***int
     - __kind: PointerType
-      ID: 53
+      ID: 75
       Name: '***int'
       ByteSize: 8
       GoRuntimeType: 35104
@@ -380,15 +380,15 @@ Types:
       ByteSize: 8
       Pointee: 47 PointerType *table<string,main.bigStruct>
     - __kind: PointerType
-      ID: 57
+      ID: 54
       Name: '*[]int.array'
       ByteSize: 8
-      Pointee: 56 GoSliceDataType []int.array
+      Pointee: 53 GoSliceDataType []int.array
     - __kind: PointerType
-      ID: 59
+      ID: 56
       Name: '*[]string.array'
       ByteSize: 8
-      Pointee: 58 GoSliceDataType []string.array
+      Pointee: 55 GoSliceDataType []string.array
     - __kind: PointerType
       ID: 11
       Name: '*bool'
@@ -439,12 +439,12 @@ Types:
       GoKind: 22
       Pointee: 13 BaseType int64
     - __kind: PointerType
-      ID: 72
+      ID: 71
       Name: '*main.bigStruct'
       ByteSize: 8
       GoRuntimeType: 26912
       GoKind: 22
-      Pointee: 73 StructureType main.bigStruct
+      Pointee: 72 StructureType main.bigStruct
     - __kind: PointerType
       ID: 39
       Name: '*map<string,int>'
@@ -456,15 +456,15 @@ Types:
       ByteSize: 8
       Pointee: 45 GoSwissMapHeaderType map<string,main.bigStruct>
     - __kind: PointerType
-      ID: 61
+      ID: 59
       Name: '*noalg.map.group[string]int'
       ByteSize: 8
-      Pointee: 62 StructureType noalg.map.group[string]int
+      Pointee: 60 StructureType noalg.map.group[string]int
     - __kind: PointerType
-      ID: 68
+      ID: 67
       Name: '*noalg.map.group[string]main.bigStruct'
       ByteSize: 8
-      Pointee: 69 StructureType noalg.map.group[string]main.bigStruct
+      Pointee: 68 StructureType noalg.map.group[string]main.bigStruct
     - __kind: PointerType
       ID: 22
       Name: '*string'
@@ -473,20 +473,20 @@ Types:
       GoKind: 22
       Pointee: 9 GoStringHeaderType string
     - __kind: PointerType
-      ID: 55
+      ID: 52
       Name: '*string.str'
       ByteSize: 8
-      Pointee: 54 GoStringDataType string.str
+      Pointee: 51 GoStringDataType string.str
     - __kind: PointerType
       ID: 42
       Name: '*table<string,int>'
       ByteSize: 8
-      Pointee: 51 StructureType table<string,int>
+      Pointee: 57 StructureType table<string,int>
     - __kind: PointerType
       ID: 47
       Name: '*table<string,main.bigStruct>'
       ByteSize: 8
-      Pointee: 52 StructureType table<string,main.bigStruct>
+      Pointee: 65 StructureType table<string,main.bigStruct>
     - __kind: PointerType
       ID: 32
       Name: '*uint'
@@ -737,12 +737,12 @@ Types:
       HasCount: true
       Element: 9 GoStringHeaderType string
     - __kind: GoSliceDataType
-      ID: 65
+      ID: 63
       Name: '[]*table<string,int>.array'
       ByteSize: 8192
       Element: 42 PointerType *table<string,int>
     - __kind: GoSliceDataType
-      ID: 74
+      ID: 73
       Name: '[]*table<string,main.bigStruct>.array'
       ByteSize: 8192
       Element: 47 PointerType *table<string,main.bigStruct>
@@ -762,22 +762,22 @@ Types:
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 56 GoSliceDataType []int.array
+      Data: 53 GoSliceDataType []int.array
     - __kind: GoSliceDataType
-      ID: 56
+      ID: 53
       Name: '[]int.array'
       ByteSize: 2048
       Element: 7 BaseType int
     - __kind: GoSliceDataType
-      ID: 66
+      ID: 64
       Name: '[]noalg.map.group[string]int.array'
       ByteSize: 2048
-      Element: 62 StructureType noalg.map.group[string]int
+      Element: 60 StructureType noalg.map.group[string]int
     - __kind: GoSliceDataType
-      ID: 75
+      ID: 74
       Name: '[]noalg.map.group[string]main.bigStruct.array'
       ByteSize: 2048
-      Element: 69 StructureType noalg.map.group[string]main.bigStruct
+      Element: 68 StructureType noalg.map.group[string]main.bigStruct
     - __kind: GoSliceHeaderType
       ID: 36
       Name: '[]string'
@@ -794,9 +794,9 @@ Types:
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 58 GoSliceDataType []string.array
+      Data: 55 GoSliceDataType []string.array
     - __kind: GoSliceDataType
-      ID: 58
+      ID: 55
       Name: '[]string.array'
       ByteSize: 2048
       Element: 9 GoStringHeaderType string
@@ -844,33 +844,33 @@ Types:
       GoRuntimeType: 42304
       GoKind: 14
     - __kind: GoSwissMapGroupsType
-      ID: 60
+      ID: 58
       Name: groupReference<string,int>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 61 PointerType *noalg.map.group[string]int
+          Type: 59 PointerType *noalg.map.group[string]int
         - Name: lengthMask
           Offset: 8
           Type: 8 BaseType uint64
-      GroupType: 62 StructureType noalg.map.group[string]int
-      GroupSliceType: 66 GoSliceDataType []noalg.map.group[string]int.array
+      GroupType: 60 StructureType noalg.map.group[string]int
+      GroupSliceType: 64 GoSliceDataType []noalg.map.group[string]int.array
     - __kind: GoSwissMapGroupsType
-      ID: 67
+      ID: 66
       Name: groupReference<string,main.bigStruct>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 68 PointerType *noalg.map.group[string]main.bigStruct
+          Type: 67 PointerType *noalg.map.group[string]main.bigStruct
         - Name: lengthMask
           Offset: 8
           Type: 8 BaseType uint64
-      GroupType: 69 StructureType noalg.map.group[string]main.bigStruct
-      GroupSliceType: 75 GoSliceDataType []noalg.map.group[string]main.bigStruct.array
+      GroupType: 68 StructureType noalg.map.group[string]main.bigStruct
+      GroupSliceType: 74 GoSliceDataType []noalg.map.group[string]main.bigStruct.array
     - __kind: BaseType
       ID: 7
       Name: int
@@ -902,7 +902,7 @@ Types:
       GoRuntimeType: 41408
       GoKind: 3
     - __kind: StructureType
-      ID: 73
+      ID: 72
       Name: main.bigStruct
       ByteSize: 184
       GoRuntimeType: 119616
@@ -962,8 +962,8 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 8 BaseType uint64
-      TablePtrSliceType: 65 GoSliceDataType []*table<string,int>.array
-      GroupType: 62 StructureType noalg.map.group[string]int
+      TablePtrSliceType: 63 GoSliceDataType []*table<string,int>.array
+      GroupType: 60 StructureType noalg.map.group[string]int
     - __kind: GoSwissMapHeaderType
       ID: 45
       Name: map<string,main.bigStruct>
@@ -994,8 +994,8 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 8 BaseType uint64
-      TablePtrSliceType: 74 GoSliceDataType []*table<string,main.bigStruct>.array
-      GroupType: 69 StructureType noalg.map.group[string]main.bigStruct
+      TablePtrSliceType: 73 GoSliceDataType []*table<string,main.bigStruct>.array
+      GroupType: 68 StructureType noalg.map.group[string]main.bigStruct
     - __kind: GoMapType
       ID: 38
       Name: map[string]int
@@ -1011,25 +1011,25 @@ Types:
       GoKind: 21
       HeaderType: 45 GoSwissMapHeaderType map<string,main.bigStruct>
     - __kind: ArrayType
-      ID: 70
+      ID: 69
       Name: noalg.[8]struct { key string; elem *main.bigStruct }
       ByteSize: 192
       GoRuntimeType: 46304
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 71 StructureType noalg.struct { key string; elem *main.bigStruct }
+      Element: 70 StructureType noalg.struct { key string; elem *main.bigStruct }
     - __kind: ArrayType
-      ID: 63
+      ID: 61
       Name: noalg.[8]struct { key string; elem int }
       ByteSize: 192
       GoRuntimeType: 46112
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 64 StructureType noalg.struct { key string; elem int }
+      Element: 62 StructureType noalg.struct { key string; elem int }
     - __kind: StructureType
-      ID: 62
+      ID: 60
       Name: noalg.map.group[string]int
       ByteSize: 200
       GoRuntimeType: 74528
@@ -1040,9 +1040,9 @@ Types:
           Type: 8 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 63 ArrayType noalg.[8]struct { key string; elem int }
+          Type: 61 ArrayType noalg.[8]struct { key string; elem int }
     - __kind: StructureType
-      ID: 69
+      ID: 68
       Name: noalg.map.group[string]main.bigStruct
       ByteSize: 200
       GoRuntimeType: 74784
@@ -1053,9 +1053,9 @@ Types:
           Type: 8 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 70 ArrayType noalg.[8]struct { key string; elem *main.bigStruct }
+          Type: 69 ArrayType noalg.[8]struct { key string; elem *main.bigStruct }
     - __kind: StructureType
-      ID: 71
+      ID: 70
       Name: noalg.struct { key string; elem *main.bigStruct }
       ByteSize: 24
       GoRuntimeType: 74656
@@ -1066,9 +1066,9 @@ Types:
           Type: 9 GoStringHeaderType string
         - Name: elem
           Offset: 16
-          Type: 72 PointerType *main.bigStruct
+          Type: 71 PointerType *main.bigStruct
     - __kind: StructureType
-      ID: 64
+      ID: 62
       Name: noalg.struct { key string; elem int }
       ByteSize: 24
       GoRuntimeType: 74400
@@ -1089,17 +1089,17 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 55 PointerType *string.str
+          Type: 52 PointerType *string.str
         - Name: len
           Offset: 8
           Type: 7 BaseType int
-      Data: 54 GoStringDataType string.str
+      Data: 51 GoStringDataType string.str
     - __kind: GoStringDataType
-      ID: 54
+      ID: 51
       Name: string.str
       ByteSize: 2048
     - __kind: StructureType
-      ID: 51
+      ID: 57
       Name: table<string,int>
       ByteSize: 32
       GoKind: 25
@@ -1121,9 +1121,9 @@ Types:
           Type: 7 BaseType int
         - Name: groups
           Offset: 16
-          Type: 60 GoSwissMapGroupsType groupReference<string,int>
+          Type: 58 GoSwissMapGroupsType groupReference<string,int>
     - __kind: StructureType
-      ID: 52
+      ID: 65
       Name: table<string,main.bigStruct>
       ByteSize: 32
       GoKind: 25
@@ -1145,7 +1145,7 @@ Types:
           Type: 7 BaseType int
         - Name: groups
           Offset: 16
-          Type: 67 GoSwissMapGroupsType groupReference<string,main.bigStruct>
+          Type: 66 GoSwissMapGroupsType groupReference<string,main.bigStruct>
     - __kind: BaseType
       ID: 10
       Name: uint

--- a/pkg/dyninst/irgen/testdata/snapshot/simple.arch=arm64,toolchain=go1.24.3.yaml
+++ b/pkg/dyninst/irgen/testdata/snapshot/simple.arch=arm64,toolchain=go1.24.3.yaml
@@ -380,15 +380,15 @@ Types:
       ByteSize: 8
       Pointee: 47 PointerType *table<string,main.bigStruct>
     - __kind: PointerType
-      ID: 70
+      ID: 57
       Name: '*[]int.array'
       ByteSize: 8
-      Pointee: 69 GoSliceDataType []int.array
+      Pointee: 56 GoSliceDataType []int.array
     - __kind: PointerType
-      ID: 72
+      ID: 59
       Name: '*[]string.array'
       ByteSize: 8
-      Pointee: 71 GoSliceDataType []string.array
+      Pointee: 58 GoSliceDataType []string.array
     - __kind: PointerType
       ID: 11
       Name: '*bool'
@@ -439,12 +439,12 @@ Types:
       GoKind: 22
       Pointee: 13 BaseType int64
     - __kind: PointerType
-      ID: 64
+      ID: 72
       Name: '*main.bigStruct'
       ByteSize: 8
       GoRuntimeType: 26912
       GoKind: 22
-      Pointee: 65 StructureType main.bigStruct
+      Pointee: 73 StructureType main.bigStruct
     - __kind: PointerType
       ID: 39
       Name: '*map<string,int>'
@@ -456,15 +456,15 @@ Types:
       ByteSize: 8
       Pointee: 45 GoSwissMapHeaderType map<string,main.bigStruct>
     - __kind: PointerType
-      ID: 55
+      ID: 61
       Name: '*noalg.map.group[string]int'
       ByteSize: 8
-      Pointee: 56 StructureType noalg.map.group[string]int
+      Pointee: 62 StructureType noalg.map.group[string]int
     - __kind: PointerType
-      ID: 58
+      ID: 68
       Name: '*noalg.map.group[string]main.bigStruct'
       ByteSize: 8
-      Pointee: 59 StructureType noalg.map.group[string]main.bigStruct
+      Pointee: 69 StructureType noalg.map.group[string]main.bigStruct
     - __kind: PointerType
       ID: 22
       Name: '*string'
@@ -473,10 +473,10 @@ Types:
       GoKind: 22
       Pointee: 9 GoStringHeaderType string
     - __kind: PointerType
-      ID: 68
+      ID: 55
       Name: '*string.str'
       ByteSize: 8
-      Pointee: 67 GoStringDataType string.str
+      Pointee: 54 GoStringDataType string.str
     - __kind: PointerType
       ID: 42
       Name: '*table<string,int>'
@@ -710,7 +710,7 @@ Types:
                   Offset: 0
                   ByteSize: 24
     - __kind: ArrayType
-      ID: 66
+      ID: 76
       Name: '[128]uint8'
       ByteSize: 128
       GoRuntimeType: 46208
@@ -737,12 +737,12 @@ Types:
       HasCount: true
       Element: 9 GoStringHeaderType string
     - __kind: GoSliceDataType
-      ID: 73
+      ID: 65
       Name: '[]*table<string,int>.array'
       ByteSize: 8192
       Element: 42 PointerType *table<string,int>
     - __kind: GoSliceDataType
-      ID: 75
+      ID: 74
       Name: '[]*table<string,main.bigStruct>.array'
       ByteSize: 8192
       Element: 47 PointerType *table<string,main.bigStruct>
@@ -762,22 +762,22 @@ Types:
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 69 GoSliceDataType []int.array
+      Data: 56 GoSliceDataType []int.array
     - __kind: GoSliceDataType
-      ID: 69
+      ID: 56
       Name: '[]int.array'
       ByteSize: 2048
       Element: 7 BaseType int
     - __kind: GoSliceDataType
-      ID: 74
+      ID: 66
       Name: '[]noalg.map.group[string]int.array'
       ByteSize: 2048
-      Element: 56 StructureType noalg.map.group[string]int
+      Element: 62 StructureType noalg.map.group[string]int
     - __kind: GoSliceDataType
-      ID: 76
+      ID: 75
       Name: '[]noalg.map.group[string]main.bigStruct.array'
       ByteSize: 2048
-      Element: 59 StructureType noalg.map.group[string]main.bigStruct
+      Element: 69 StructureType noalg.map.group[string]main.bigStruct
     - __kind: GoSliceHeaderType
       ID: 36
       Name: '[]string'
@@ -794,9 +794,9 @@ Types:
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 71 GoSliceDataType []string.array
+      Data: 58 GoSliceDataType []string.array
     - __kind: GoSliceDataType
-      ID: 71
+      ID: 58
       Name: '[]string.array'
       ByteSize: 2048
       Element: 9 GoStringHeaderType string
@@ -844,33 +844,33 @@ Types:
       GoRuntimeType: 42304
       GoKind: 14
     - __kind: GoSwissMapGroupsType
-      ID: 54
+      ID: 60
       Name: groupReference<string,int>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 55 PointerType *noalg.map.group[string]int
+          Type: 61 PointerType *noalg.map.group[string]int
         - Name: lengthMask
           Offset: 8
           Type: 8 BaseType uint64
-      GroupType: 56 StructureType noalg.map.group[string]int
-      GroupSliceType: 74 GoSliceDataType []noalg.map.group[string]int.array
+      GroupType: 62 StructureType noalg.map.group[string]int
+      GroupSliceType: 66 GoSliceDataType []noalg.map.group[string]int.array
     - __kind: GoSwissMapGroupsType
-      ID: 57
+      ID: 67
       Name: groupReference<string,main.bigStruct>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 58 PointerType *noalg.map.group[string]main.bigStruct
+          Type: 68 PointerType *noalg.map.group[string]main.bigStruct
         - Name: lengthMask
           Offset: 8
           Type: 8 BaseType uint64
-      GroupType: 59 StructureType noalg.map.group[string]main.bigStruct
-      GroupSliceType: 76 GoSliceDataType []noalg.map.group[string]main.bigStruct.array
+      GroupType: 69 StructureType noalg.map.group[string]main.bigStruct
+      GroupSliceType: 75 GoSliceDataType []noalg.map.group[string]main.bigStruct.array
     - __kind: BaseType
       ID: 7
       Name: int
@@ -902,7 +902,7 @@ Types:
       GoRuntimeType: 41408
       GoKind: 3
     - __kind: StructureType
-      ID: 65
+      ID: 73
       Name: main.bigStruct
       ByteSize: 184
       GoRuntimeType: 119616
@@ -931,7 +931,7 @@ Types:
           Type: 7 BaseType int
         - Name: data
           Offset: 56
-          Type: 66 ArrayType [128]uint8
+          Type: 76 ArrayType [128]uint8
     - __kind: GoSwissMapHeaderType
       ID: 40
       Name: map<string,int>
@@ -962,8 +962,8 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 8 BaseType uint64
-      TablePtrSliceType: 73 GoSliceDataType []*table<string,int>.array
-      GroupType: 56 StructureType noalg.map.group[string]int
+      TablePtrSliceType: 65 GoSliceDataType []*table<string,int>.array
+      GroupType: 62 StructureType noalg.map.group[string]int
     - __kind: GoSwissMapHeaderType
       ID: 45
       Name: map<string,main.bigStruct>
@@ -994,8 +994,8 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 8 BaseType uint64
-      TablePtrSliceType: 75 GoSliceDataType []*table<string,main.bigStruct>.array
-      GroupType: 59 StructureType noalg.map.group[string]main.bigStruct
+      TablePtrSliceType: 74 GoSliceDataType []*table<string,main.bigStruct>.array
+      GroupType: 69 StructureType noalg.map.group[string]main.bigStruct
     - __kind: GoMapType
       ID: 38
       Name: map[string]int
@@ -1011,25 +1011,25 @@ Types:
       GoKind: 21
       HeaderType: 45 GoSwissMapHeaderType map<string,main.bigStruct>
     - __kind: ArrayType
-      ID: 62
+      ID: 70
       Name: noalg.[8]struct { key string; elem *main.bigStruct }
       ByteSize: 192
       GoRuntimeType: 46304
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 63 StructureType noalg.struct { key string; elem *main.bigStruct }
+      Element: 71 StructureType noalg.struct { key string; elem *main.bigStruct }
     - __kind: ArrayType
-      ID: 60
+      ID: 63
       Name: noalg.[8]struct { key string; elem int }
       ByteSize: 192
       GoRuntimeType: 46112
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 61 StructureType noalg.struct { key string; elem int }
+      Element: 64 StructureType noalg.struct { key string; elem int }
     - __kind: StructureType
-      ID: 56
+      ID: 62
       Name: noalg.map.group[string]int
       ByteSize: 200
       GoRuntimeType: 74528
@@ -1040,9 +1040,9 @@ Types:
           Type: 8 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 60 ArrayType noalg.[8]struct { key string; elem int }
+          Type: 63 ArrayType noalg.[8]struct { key string; elem int }
     - __kind: StructureType
-      ID: 59
+      ID: 69
       Name: noalg.map.group[string]main.bigStruct
       ByteSize: 200
       GoRuntimeType: 74784
@@ -1053,9 +1053,9 @@ Types:
           Type: 8 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 62 ArrayType noalg.[8]struct { key string; elem *main.bigStruct }
+          Type: 70 ArrayType noalg.[8]struct { key string; elem *main.bigStruct }
     - __kind: StructureType
-      ID: 63
+      ID: 71
       Name: noalg.struct { key string; elem *main.bigStruct }
       ByteSize: 24
       GoRuntimeType: 74656
@@ -1066,9 +1066,9 @@ Types:
           Type: 9 GoStringHeaderType string
         - Name: elem
           Offset: 16
-          Type: 64 PointerType *main.bigStruct
+          Type: 72 PointerType *main.bigStruct
     - __kind: StructureType
-      ID: 61
+      ID: 64
       Name: noalg.struct { key string; elem int }
       ByteSize: 24
       GoRuntimeType: 74400
@@ -1089,13 +1089,13 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 68 PointerType *string.str
+          Type: 55 PointerType *string.str
         - Name: len
           Offset: 8
           Type: 7 BaseType int
-      Data: 67 GoStringDataType string.str
+      Data: 54 GoStringDataType string.str
     - __kind: GoStringDataType
-      ID: 67
+      ID: 54
       Name: string.str
       ByteSize: 2048
     - __kind: StructureType
@@ -1121,7 +1121,7 @@ Types:
           Type: 7 BaseType int
         - Name: groups
           Offset: 16
-          Type: 54 GoSwissMapGroupsType groupReference<string,int>
+          Type: 60 GoSwissMapGroupsType groupReference<string,int>
     - __kind: StructureType
       ID: 52
       Name: table<string,main.bigStruct>
@@ -1145,7 +1145,7 @@ Types:
           Type: 7 BaseType int
         - Name: groups
           Offset: 16
-          Type: 57 GoSwissMapGroupsType groupReference<string,main.bigStruct>
+          Type: 67 GoSwissMapGroupsType groupReference<string,main.bigStruct>
     - __kind: BaseType
       ID: 10
       Name: uint

--- a/pkg/dyninst/irgen/testdata/snapshot/simple.arch=arm64,toolchain=go1.24.3.yaml
+++ b/pkg/dyninst/irgen/testdata/snapshot/simple.arch=arm64,toolchain=go1.24.3.yaml
@@ -11,7 +11,7 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 2}
+      subprogram: {subprogram: 11}
       events:
         - ID: 11
           Type: 87 EventRootType Probe[main.PointerChainArg]
@@ -28,7 +28,7 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 3}
+      subprogram: {subprogram: 12}
       events:
         - ID: 12
           Type: 88 EventRootType Probe[main.PointerSmallChainArg]
@@ -41,7 +41,7 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 12}
+      subprogram: {subprogram: 9}
       events:
         - ID: 9
           Type: 85 EventRootType Probe[main.bigMapArg]
@@ -55,7 +55,7 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 1}
+      subprogram: {subprogram: 10}
       events:
         - ID: 10
           Type: 86 EventRootType Probe[main.inlined]
@@ -72,7 +72,7 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 4}
+      subprogram: {subprogram: 1}
       events:
         - ID: 1
           Type: 77 EventRootType Probe[main.intArg]
@@ -85,7 +85,7 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 7}
+      subprogram: {subprogram: 4}
       events:
         - ID: 4
           Type: 80 EventRootType Probe[main.intArrayArg]
@@ -98,7 +98,7 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 10}
+      subprogram: {subprogram: 7}
       events:
         - ID: 7
           Type: 83 EventRootType Probe[main.stringArrayArgFrameless]
@@ -111,7 +111,7 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 6}
+      subprogram: {subprogram: 3}
       events:
         - ID: 3
           Type: 79 EventRootType Probe[main.intSliceArg]
@@ -124,7 +124,7 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 11}
+      subprogram: {subprogram: 8}
       events:
         - ID: 8
           Type: 84 EventRootType Probe[main.mapArg]
@@ -137,7 +137,7 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 5}
+      subprogram: {subprogram: 2}
       events:
         - ID: 2
           Type: 78 EventRootType Probe[main.stringArg]
@@ -150,7 +150,7 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 9}
+      subprogram: {subprogram: 6}
       events:
         - ID: 6
           Type: 82 EventRootType Probe[main.stringArrayArg]
@@ -163,32 +163,32 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 8}
+      subprogram: {subprogram: 5}
       events:
         - ID: 5
           Type: 81 EventRootType Probe[main.stringSliceArg]
           InjectionPoints: [{PC: "0xb544c", Frameless: true}]
           Condition: null
 Subprograms:
-    - ID: 4
+    - ID: 1
       Name: main.intArg
       OutOfLinePCRanges: [0xb5250..0xb52c0]
       InlinePCRanges: []
       Variables:
         - Name: x
-          Type: 1 BaseType int
+          Type: 7 BaseType int
           Locations:
             - Range: 0xb5250..0xb5270
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 5
+    - ID: 2
       Name: main.stringArg
       OutOfLinePCRanges: [0xb52c0..0xb5340]
       InlinePCRanges: []
       Variables:
         - Name: s
-          Type: 7 GoStringHeaderType string
+          Type: 9 GoStringHeaderType string
           Locations:
             - Range: 0xb52c0..0xb52e4
               Pieces:
@@ -198,13 +198,13 @@ Subprograms:
                   Op: {RegNo: 1, Shift: 0}
           IsParameter: true
           IsReturn: false
-    - ID: 6
+    - ID: 3
       Name: main.intSliceArg
       OutOfLinePCRanges: [0xb5340..0xb53c0]
       InlinePCRanges: []
       Variables:
         - Name: s
-          Type: 10 GoSliceHeaderType []int
+          Type: 34 GoSliceHeaderType []int
           Locations:
             - Range: 0xb5340..0xb5364
               Pieces:
@@ -216,25 +216,25 @@ Subprograms:
                   Op: {RegNo: 2, Shift: 0}
           IsParameter: true
           IsReturn: false
-    - ID: 7
+    - ID: 4
       Name: main.intArrayArg
       OutOfLinePCRanges: [0xb53c0..0xb5440]
       InlinePCRanges: []
       Variables:
         - Name: s
-          Type: 11 ArrayType [3]int
+          Type: 35 ArrayType [3]int
           Locations:
             - Range: 0xb53c0..0xb5440
               Pieces: [{Size: 24, Op: {CfaOffset: 8}}]
           IsParameter: true
           IsReturn: false
-    - ID: 8
+    - ID: 5
       Name: main.stringSliceArg
       OutOfLinePCRanges: [0xb5440..0xb54c0]
       InlinePCRanges: []
       Variables:
         - Name: s
-          Type: 12 GoSliceHeaderType []string
+          Type: 36 GoSliceHeaderType []string
           Locations:
             - Range: 0xb5440..0xb5464
               Pieces:
@@ -246,49 +246,49 @@ Subprograms:
                   Op: {RegNo: 2, Shift: 0}
           IsParameter: true
           IsReturn: false
-    - ID: 9
+    - ID: 6
       Name: main.stringArrayArg
       OutOfLinePCRanges: [0xb54c0..0xb5540]
       InlinePCRanges: []
       Variables:
         - Name: s
-          Type: 14 ArrayType [3]string
+          Type: 37 ArrayType [3]string
           Locations:
             - Range: 0xb54c0..0xb5540
               Pieces: [{Size: 48, Op: {CfaOffset: 8}}]
           IsParameter: true
           IsReturn: false
-    - ID: 10
+    - ID: 7
       Name: main.stringArrayArgFrameless
       OutOfLinePCRanges: [0xb5540..0xb5550]
       InlinePCRanges: []
       Variables:
         - Name: s
-          Type: 14 ArrayType [3]string
+          Type: 37 ArrayType [3]string
           Locations:
             - Range: 0xb5540..0xb5550
               Pieces: [{Size: 48, Op: {CfaOffset: 8}}]
           IsParameter: true
           IsReturn: false
-    - ID: 11
+    - ID: 8
       Name: main.mapArg
       OutOfLinePCRanges: [0xb5610..0xb5680]
       InlinePCRanges: []
       Variables:
         - Name: m
-          Type: 15 GoMapType map[string]int
+          Type: 38 GoMapType map[string]int
           Locations:
             - Range: 0xb5610..0xb5648
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 12
+    - ID: 9
       Name: main.bigMapArg
       OutOfLinePCRanges: [0xb5680..0xb5740]
       InlinePCRanges: []
       Variables:
         - Name: m
-          Type: 29 GoMapType map[string]main.bigStruct
+          Type: 49 GoMapType map[string]main.bigStruct
           Locations:
             - Range: 0xb5680..0xb56b8
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
@@ -296,7 +296,7 @@ Subprograms:
               Pieces: [{Size: 8, Op: {CfaOffset: 8}}]
           IsParameter: true
           IsReturn: false
-    - ID: 1
+    - ID: 10
       Name: main.inlined
       OutOfLinePCRanges: [0xb5550..0xb55c0]
       InlinePCRanges:
@@ -304,7 +304,7 @@ Subprograms:
           RootRanges: [0xb4e50..0xb5250]
       Variables:
         - Name: x
-          Type: 1 BaseType int
+          Type: 7 BaseType int
           Locations:
             - Range: 0xb4fec..0xb5028
               Pieces: []
@@ -312,7 +312,7 @@ Subprograms:
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 2
+    - ID: 11
       Name: main.PointerChainArg
       OutOfLinePCRanges: []
       InlinePCRanges:
@@ -320,13 +320,13 @@ Subprograms:
           RootRanges: [0xb4e50..0xb5250]
       Variables:
         - Name: ptr
-          Type: 2 PointerType *****int
+          Type: 63 PointerType *****int
           Locations:
             - Range: 0xb51a4..0xb51ec
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 3
+    - ID: 12
       Name: main.PointerSmallChainArg
       OutOfLinePCRanges: []
       InlinePCRanges:
@@ -334,7 +334,7 @@ Subprograms:
           RootRanges: [0xb4e50..0xb5250]
       Variables:
         - Name: ptr
-          Type: 5 PointerType **int
+          Type: 66 PointerType **int
           Locations:
             - Range: 0xb5204..0xb5234
               Pieces: [{Size: 8, Op: {RegNo: 5, Shift: 0}}]
@@ -342,43 +342,43 @@ Subprograms:
           IsReturn: false
 Types:
     - __kind: PointerType
-      ID: 2
+      ID: 63
       Name: '*****int'
       ByteSize: 8
       GoRuntimeType: 35232
       GoKind: 22
-      Pointee: 3 PointerType ****int
+      Pointee: 64 PointerType ****int
     - __kind: PointerType
-      ID: 3
+      ID: 64
       Name: '****int'
       ByteSize: 8
       GoRuntimeType: 35168
       GoKind: 22
-      Pointee: 4 PointerType ***int
+      Pointee: 65 PointerType ***int
     - __kind: PointerType
-      ID: 4
+      ID: 65
       Name: '***int'
       ByteSize: 8
       GoRuntimeType: 35104
       GoKind: 22
-      Pointee: 5 PointerType **int
+      Pointee: 66 PointerType **int
     - __kind: PointerType
-      ID: 5
+      ID: 66
       Name: '**int'
       ByteSize: 8
       GoRuntimeType: 35040
       GoKind: 22
-      Pointee: 6 PointerType *int
+      Pointee: 28 PointerType *int
     - __kind: PointerType
-      ID: 20
+      ID: 41
       Name: '**table<string,int>'
       ByteSize: 8
-      Pointee: 21 PointerType *table<string,int>
+      Pointee: 42 PointerType *table<string,int>
     - __kind: PointerType
-      ID: 32
+      ID: 52
       Name: '**table<string,main.bigStruct>'
       ByteSize: 8
-      Pointee: 33 PointerType *table<string,main.bigStruct>
+      Pointee: 53 PointerType *table<string,main.bigStruct>
     - __kind: PointerType
       ID: 70
       Name: '*[]int.array'
@@ -390,145 +390,145 @@ Types:
       ByteSize: 8
       Pointee: 71 GoSliceDataType []string.array
     - __kind: PointerType
-      ID: 46
+      ID: 11
       Name: '*bool'
       ByteSize: 8
       GoRuntimeType: 29536
       GoKind: 22
-      Pointee: 44 BaseType bool
+      Pointee: 4 BaseType bool
     - __kind: PointerType
-      ID: 63
+      ID: 30
       Name: '*error'
       ByteSize: 8
       GoRuntimeType: 28448
       GoKind: 22
-      Pointee: 49 GoInterfaceType error
+      Pointee: 14 GoInterfaceType error
     - __kind: PointerType
-      ID: 64
+      ID: 31
       Name: '*float32'
       ByteSize: 8
       GoRuntimeType: 29408
       GoKind: 22
-      Pointee: 52 BaseType float32
+      Pointee: 17 BaseType float32
     - __kind: PointerType
-      ID: 60
+      ID: 26
       Name: '*float64'
       ByteSize: 8
       GoRuntimeType: 29472
       GoKind: 22
-      Pointee: 53 BaseType float64
+      Pointee: 18 BaseType float64
     - __kind: PointerType
-      ID: 6
+      ID: 28
       Name: '*int'
       ByteSize: 8
       GoRuntimeType: 29088
       GoKind: 22
-      Pointee: 1 BaseType int
+      Pointee: 7 BaseType int
     - __kind: PointerType
-      ID: 55
+      ID: 20
       Name: '*int32'
       ByteSize: 8
       GoRuntimeType: 28832
       GoKind: 22
-      Pointee: 47 BaseType int32
+      Pointee: 12 BaseType int32
     - __kind: PointerType
-      ID: 61
+      ID: 27
       Name: '*int64'
       ByteSize: 8
       GoRuntimeType: 28960
       GoKind: 22
-      Pointee: 48 BaseType int64
+      Pointee: 13 BaseType int64
     - __kind: PointerType
-      ID: 40
+      ID: 60
       Name: '*main.bigStruct'
       ByteSize: 8
       GoRuntimeType: 26912
       GoKind: 22
-      Pointee: 41 StructureType main.bigStruct
+      Pointee: 61 StructureType main.bigStruct
     - __kind: PointerType
-      ID: 16
+      ID: 39
       Name: '*map<string,int>'
       ByteSize: 8
-      Pointee: 17 GoSwissMapHeaderType map<string,int>
+      Pointee: 40 GoSwissMapHeaderType map<string,int>
     - __kind: PointerType
-      ID: 30
+      ID: 50
       Name: '*map<string,main.bigStruct>'
       ByteSize: 8
-      Pointee: 31 GoSwissMapHeaderType map<string,main.bigStruct>
+      Pointee: 51 GoSwissMapHeaderType map<string,main.bigStruct>
     - __kind: PointerType
-      ID: 25
+      ID: 45
       Name: '*noalg.map.group[string]int'
       ByteSize: 8
-      Pointee: 26 StructureType noalg.map.group[string]int
+      Pointee: 46 StructureType noalg.map.group[string]int
     - __kind: PointerType
-      ID: 36
+      ID: 56
       Name: '*noalg.map.group[string]main.bigStruct'
       ByteSize: 8
-      Pointee: 37 StructureType noalg.map.group[string]main.bigStruct
+      Pointee: 57 StructureType noalg.map.group[string]main.bigStruct
     - __kind: PointerType
-      ID: 13
+      ID: 22
       Name: '*string'
       ByteSize: 8
       GoRuntimeType: 28512
       GoKind: 22
-      Pointee: 7 GoStringHeaderType string
+      Pointee: 9 GoStringHeaderType string
     - __kind: PointerType
       ID: 68
       Name: '*string.str'
       ByteSize: 8
       Pointee: 67 GoStringDataType string.str
     - __kind: PointerType
-      ID: 21
+      ID: 42
       Name: '*table<string,int>'
       ByteSize: 8
-      Pointee: 22 StructureType table<string,int>
+      Pointee: 43 StructureType table<string,int>
     - __kind: PointerType
-      ID: 33
+      ID: 53
       Name: '*table<string,main.bigStruct>'
       ByteSize: 8
-      Pointee: 34 StructureType table<string,main.bigStruct>
+      Pointee: 54 StructureType table<string,main.bigStruct>
     - __kind: PointerType
-      ID: 65
+      ID: 32
       Name: '*uint'
       ByteSize: 8
       GoRuntimeType: 29152
       GoKind: 22
-      Pointee: 45 BaseType uint
+      Pointee: 10 BaseType uint
     - __kind: PointerType
-      ID: 66
+      ID: 33
       Name: '*uint16'
       ByteSize: 8
       GoRuntimeType: 28768
       GoKind: 22
-      Pointee: 23 BaseType uint16
+      Pointee: 6 BaseType uint16
     - __kind: PointerType
-      ID: 56
+      ID: 21
       Name: '*uint32'
       ByteSize: 8
       GoRuntimeType: 28896
       GoKind: 22
-      Pointee: 43 BaseType uint32
+      Pointee: 2 BaseType uint32
     - __kind: PointerType
-      ID: 62
+      ID: 29
       Name: '*uint64'
       ByteSize: 8
       GoRuntimeType: 29024
       GoKind: 22
-      Pointee: 18 BaseType uint64
+      Pointee: 8 BaseType uint64
     - __kind: PointerType
-      ID: 8
+      ID: 5
       Name: '*uint8'
       ByteSize: 8
       GoRuntimeType: 28640
       GoKind: 22
-      Pointee: 9 BaseType uint8
+      Pointee: 3 BaseType uint8
     - __kind: PointerType
-      ID: 54
+      ID: 19
       Name: '*uintptr'
       ByteSize: 8
       GoRuntimeType: 29216
       GoKind: 22
-      Pointee: 19 BaseType uintptr
+      Pointee: 1 BaseType uintptr
     - __kind: EventRootType
       ID: 87
       Name: Probe[main.PointerChainArg]
@@ -538,10 +538,10 @@ Types:
         - Name: ptr
           Offset: 1
           Expression:
-            Type: 2 PointerType *****int
+            Type: 63 PointerType *****int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 2, index: 0, name: ptr}
+                  Variable: {subprogram: 11, index: 0, name: ptr}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
@@ -553,10 +553,10 @@ Types:
         - Name: ptr
           Offset: 1
           Expression:
-            Type: 5 PointerType **int
+            Type: 66 PointerType **int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 3, index: 0, name: ptr}
+                  Variable: {subprogram: 12, index: 0, name: ptr}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
@@ -568,10 +568,10 @@ Types:
         - Name: m
           Offset: 1
           Expression:
-            Type: 29 GoMapType map[string]main.bigStruct
+            Type: 49 GoMapType map[string]main.bigStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 12, index: 0, name: m}
+                  Variable: {subprogram: 9, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
@@ -583,10 +583,10 @@ Types:
         - Name: x
           Offset: 1
           Expression:
-            Type: 1 BaseType int
+            Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 1, index: 0, name: x}
+                  Variable: {subprogram: 10, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
@@ -598,10 +598,10 @@ Types:
         - Name: x
           Offset: 1
           Expression:
-            Type: 1 BaseType int
+            Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 4, index: 0, name: x}
+                  Variable: {subprogram: 1, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
@@ -613,10 +613,10 @@ Types:
         - Name: s
           Offset: 1
           Expression:
-            Type: 11 ArrayType [3]int
+            Type: 35 ArrayType [3]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 7, index: 0, name: s}
+                  Variable: {subprogram: 4, index: 0, name: s}
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
@@ -628,10 +628,10 @@ Types:
         - Name: s
           Offset: 1
           Expression:
-            Type: 10 GoSliceHeaderType []int
+            Type: 34 GoSliceHeaderType []int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 6, index: 0, name: s}
+                  Variable: {subprogram: 3, index: 0, name: s}
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
@@ -643,10 +643,10 @@ Types:
         - Name: m
           Offset: 1
           Expression:
-            Type: 15 GoMapType map[string]int
+            Type: 38 GoMapType map[string]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 11, index: 0, name: m}
+                  Variable: {subprogram: 8, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
@@ -658,10 +658,10 @@ Types:
         - Name: s
           Offset: 1
           Expression:
-            Type: 7 GoStringHeaderType string
+            Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 5, index: 0, name: s}
+                  Variable: {subprogram: 2, index: 0, name: s}
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
@@ -673,10 +673,10 @@ Types:
         - Name: s
           Offset: 1
           Expression:
-            Type: 14 ArrayType [3]string
+            Type: 37 ArrayType [3]string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 10, index: 0, name: s}
+                  Variable: {subprogram: 7, index: 0, name: s}
                   Offset: 0
                   ByteSize: 48
     - __kind: EventRootType
@@ -688,10 +688,10 @@ Types:
         - Name: s
           Offset: 1
           Expression:
-            Type: 14 ArrayType [3]string
+            Type: 37 ArrayType [3]string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 9, index: 0, name: s}
+                  Variable: {subprogram: 6, index: 0, name: s}
                   Offset: 0
                   ByteSize: 48
     - __kind: EventRootType
@@ -703,51 +703,51 @@ Types:
         - Name: s
           Offset: 1
           Expression:
-            Type: 12 GoSliceHeaderType []string
+            Type: 36 GoSliceHeaderType []string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 8, index: 0, name: s}
+                  Variable: {subprogram: 5, index: 0, name: s}
                   Offset: 0
                   ByteSize: 24
     - __kind: ArrayType
-      ID: 42
+      ID: 62
       Name: '[128]uint8'
       ByteSize: 128
       GoRuntimeType: 46208
       GoKind: 17
       Count: 128
       HasCount: true
-      Element: 9 BaseType uint8
+      Element: 3 BaseType uint8
     - __kind: ArrayType
-      ID: 11
+      ID: 35
       Name: '[3]int'
       ByteSize: 24
       GoRuntimeType: 45920
       GoKind: 17
       Count: 3
       HasCount: true
-      Element: 1 BaseType int
+      Element: 7 BaseType int
     - __kind: ArrayType
-      ID: 14
+      ID: 37
       Name: '[3]string'
       ByteSize: 48
       GoRuntimeType: 46016
       GoKind: 17
       Count: 3
       HasCount: true
-      Element: 7 GoStringHeaderType string
+      Element: 9 GoStringHeaderType string
     - __kind: GoSliceDataType
       ID: 73
       Name: '[]*table<string,int>.array'
       ByteSize: 8192
-      Element: 21 PointerType *table<string,int>
+      Element: 42 PointerType *table<string,int>
     - __kind: GoSliceDataType
       ID: 75
       Name: '[]*table<string,main.bigStruct>.array'
       ByteSize: 8192
-      Element: 33 PointerType *table<string,main.bigStruct>
+      Element: 53 PointerType *table<string,main.bigStruct>
     - __kind: GoSliceHeaderType
-      ID: 10
+      ID: 34
       Name: '[]int'
       ByteSize: 24
       GoRuntimeType: 37664
@@ -755,31 +755,31 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 6 PointerType *int
+          Type: 28 PointerType *int
         - Name: len
           Offset: 8
-          Type: 1 BaseType int
+          Type: 7 BaseType int
         - Name: cap
           Offset: 16
-          Type: 1 BaseType int
+          Type: 7 BaseType int
       Data: 69 GoSliceDataType []int.array
     - __kind: GoSliceDataType
       ID: 69
       Name: '[]int.array'
       ByteSize: 2048
-      Element: 1 BaseType int
+      Element: 7 BaseType int
     - __kind: GoSliceDataType
       ID: 74
       Name: '[]noalg.map.group[string]int.array'
       ByteSize: 2048
-      Element: 26 StructureType noalg.map.group[string]int
+      Element: 46 StructureType noalg.map.group[string]int
     - __kind: GoSliceDataType
       ID: 76
       Name: '[]noalg.map.group[string]main.bigStruct.array'
       ByteSize: 2048
-      Element: 37 StructureType noalg.map.group[string]main.bigStruct
+      Element: 57 StructureType noalg.map.group[string]main.bigStruct
     - __kind: GoSliceHeaderType
-      ID: 12
+      ID: 36
       Name: '[]string'
       ByteSize: 24
       GoRuntimeType: 37920
@@ -787,39 +787,39 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 13 PointerType *string
+          Type: 22 PointerType *string
         - Name: len
           Offset: 8
-          Type: 1 BaseType int
+          Type: 7 BaseType int
         - Name: cap
           Offset: 16
-          Type: 1 BaseType int
+          Type: 7 BaseType int
       Data: 71 GoSliceDataType []string.array
     - __kind: GoSliceDataType
       ID: 71
       Name: '[]string.array'
       ByteSize: 2048
-      Element: 7 GoStringHeaderType string
+      Element: 9 GoStringHeaderType string
     - __kind: BaseType
-      ID: 44
+      ID: 4
       Name: bool
       ByteSize: 1
       GoRuntimeType: 42368
       GoKind: 1
     - __kind: BaseType
-      ID: 59
+      ID: 25
       Name: complex128
       ByteSize: 16
       GoRuntimeType: 42176
       GoKind: 16
     - __kind: BaseType
-      ID: 58
+      ID: 24
       Name: complex64
       ByteSize: 8
       GoRuntimeType: 42112
       GoKind: 15
     - __kind: GoInterfaceType
-      ID: 49
+      ID: 14
       Name: error
       ByteSize: 16
       GoRuntimeType: 63040
@@ -827,82 +827,82 @@ Types:
       RawFields:
         - Name: tab
           Offset: 0
-          Type: 50 VoidPointerType unsafe.Pointer
+          Type: 15 VoidPointerType unsafe.Pointer
         - Name: data
           Offset: 8
-          Type: 50 VoidPointerType unsafe.Pointer
+          Type: 15 VoidPointerType unsafe.Pointer
     - __kind: BaseType
-      ID: 52
+      ID: 17
       Name: float32
       ByteSize: 4
       GoRuntimeType: 42240
       GoKind: 13
     - __kind: BaseType
-      ID: 53
+      ID: 18
       Name: float64
       ByteSize: 8
       GoRuntimeType: 42304
       GoKind: 14
     - __kind: GoSwissMapGroupsType
-      ID: 24
+      ID: 44
       Name: groupReference<string,int>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 25 PointerType *noalg.map.group[string]int
+          Type: 45 PointerType *noalg.map.group[string]int
         - Name: lengthMask
           Offset: 8
-          Type: 18 BaseType uint64
-      GroupType: 26 StructureType noalg.map.group[string]int
+          Type: 8 BaseType uint64
+      GroupType: 46 StructureType noalg.map.group[string]int
       GroupSliceType: 74 GoSliceDataType []noalg.map.group[string]int.array
     - __kind: GoSwissMapGroupsType
-      ID: 35
+      ID: 55
       Name: groupReference<string,main.bigStruct>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 36 PointerType *noalg.map.group[string]main.bigStruct
+          Type: 56 PointerType *noalg.map.group[string]main.bigStruct
         - Name: lengthMask
           Offset: 8
-          Type: 18 BaseType uint64
-      GroupType: 37 StructureType noalg.map.group[string]main.bigStruct
+          Type: 8 BaseType uint64
+      GroupType: 57 StructureType noalg.map.group[string]main.bigStruct
       GroupSliceType: 76 GoSliceDataType []noalg.map.group[string]main.bigStruct.array
     - __kind: BaseType
-      ID: 1
+      ID: 7
       Name: int
       ByteSize: 8
       GoRuntimeType: 41920
       GoKind: 2
     - __kind: BaseType
-      ID: 57
+      ID: 23
       Name: int16
       ByteSize: 2
       GoRuntimeType: 41536
       GoKind: 4
     - __kind: BaseType
-      ID: 47
+      ID: 12
       Name: int32
       ByteSize: 4
       GoRuntimeType: 41664
       GoKind: 5
     - __kind: BaseType
-      ID: 48
+      ID: 13
       Name: int64
       ByteSize: 8
       GoRuntimeType: 41792
       GoKind: 6
     - __kind: BaseType
-      ID: 51
+      ID: 16
       Name: int8
       ByteSize: 1
       GoRuntimeType: 41408
       GoKind: 3
     - __kind: StructureType
-      ID: 41
+      ID: 61
       Name: main.bigStruct
       ByteSize: 184
       GoRuntimeType: 119616
@@ -910,126 +910,126 @@ Types:
       RawFields:
         - Name: Field1
           Offset: 0
-          Type: 1 BaseType int
+          Type: 7 BaseType int
         - Name: Field2
           Offset: 8
-          Type: 1 BaseType int
+          Type: 7 BaseType int
         - Name: Field3
           Offset: 16
-          Type: 1 BaseType int
+          Type: 7 BaseType int
         - Name: Field4
           Offset: 24
-          Type: 1 BaseType int
+          Type: 7 BaseType int
         - Name: Field5
           Offset: 32
-          Type: 1 BaseType int
+          Type: 7 BaseType int
         - Name: Field6
           Offset: 40
-          Type: 1 BaseType int
+          Type: 7 BaseType int
         - Name: Field7
           Offset: 48
-          Type: 1 BaseType int
+          Type: 7 BaseType int
         - Name: data
           Offset: 56
-          Type: 42 ArrayType [128]uint8
+          Type: 62 ArrayType [128]uint8
     - __kind: GoSwissMapHeaderType
-      ID: 17
+      ID: 40
       Name: map<string,int>
       ByteSize: 48
       GoKind: 25
       RawFields:
         - Name: used
           Offset: 0
-          Type: 18 BaseType uint64
+          Type: 8 BaseType uint64
         - Name: seed
           Offset: 8
-          Type: 19 BaseType uintptr
+          Type: 1 BaseType uintptr
         - Name: dirPtr
           Offset: 16
-          Type: 20 PointerType **table<string,int>
+          Type: 41 PointerType **table<string,int>
         - Name: dirLen
           Offset: 24
-          Type: 1 BaseType int
+          Type: 7 BaseType int
         - Name: globalDepth
           Offset: 32
-          Type: 9 BaseType uint8
+          Type: 3 BaseType uint8
         - Name: globalShift
           Offset: 33
-          Type: 9 BaseType uint8
+          Type: 3 BaseType uint8
         - Name: writing
           Offset: 34
-          Type: 9 BaseType uint8
+          Type: 3 BaseType uint8
         - Name: clearSeq
           Offset: 40
-          Type: 18 BaseType uint64
+          Type: 8 BaseType uint64
       TablePtrSliceType: 73 GoSliceDataType []*table<string,int>.array
-      GroupType: 26 StructureType noalg.map.group[string]int
+      GroupType: 46 StructureType noalg.map.group[string]int
     - __kind: GoSwissMapHeaderType
-      ID: 31
+      ID: 51
       Name: map<string,main.bigStruct>
       ByteSize: 48
       GoKind: 25
       RawFields:
         - Name: used
           Offset: 0
-          Type: 18 BaseType uint64
+          Type: 8 BaseType uint64
         - Name: seed
           Offset: 8
-          Type: 19 BaseType uintptr
+          Type: 1 BaseType uintptr
         - Name: dirPtr
           Offset: 16
-          Type: 32 PointerType **table<string,main.bigStruct>
+          Type: 52 PointerType **table<string,main.bigStruct>
         - Name: dirLen
           Offset: 24
-          Type: 1 BaseType int
+          Type: 7 BaseType int
         - Name: globalDepth
           Offset: 32
-          Type: 9 BaseType uint8
+          Type: 3 BaseType uint8
         - Name: globalShift
           Offset: 33
-          Type: 9 BaseType uint8
+          Type: 3 BaseType uint8
         - Name: writing
           Offset: 34
-          Type: 9 BaseType uint8
+          Type: 3 BaseType uint8
         - Name: clearSeq
           Offset: 40
-          Type: 18 BaseType uint64
+          Type: 8 BaseType uint64
       TablePtrSliceType: 75 GoSliceDataType []*table<string,main.bigStruct>.array
-      GroupType: 37 StructureType noalg.map.group[string]main.bigStruct
+      GroupType: 57 StructureType noalg.map.group[string]main.bigStruct
     - __kind: GoMapType
-      ID: 15
+      ID: 38
       Name: map[string]int
       ByteSize: 8
       GoRuntimeType: 67136
       GoKind: 21
-      HeaderType: 17 GoSwissMapHeaderType map<string,int>
+      HeaderType: 40 GoSwissMapHeaderType map<string,int>
     - __kind: GoMapType
-      ID: 29
+      ID: 49
       Name: map[string]main.bigStruct
       ByteSize: 8
       GoRuntimeType: 67264
       GoKind: 21
-      HeaderType: 31 GoSwissMapHeaderType map<string,main.bigStruct>
+      HeaderType: 51 GoSwissMapHeaderType map<string,main.bigStruct>
     - __kind: ArrayType
-      ID: 38
+      ID: 58
       Name: noalg.[8]struct { key string; elem *main.bigStruct }
       ByteSize: 192
       GoRuntimeType: 46304
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 39 StructureType noalg.struct { key string; elem *main.bigStruct }
+      Element: 59 StructureType noalg.struct { key string; elem *main.bigStruct }
     - __kind: ArrayType
-      ID: 27
+      ID: 47
       Name: noalg.[8]struct { key string; elem int }
       ByteSize: 192
       GoRuntimeType: 46112
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 28 StructureType noalg.struct { key string; elem int }
+      Element: 48 StructureType noalg.struct { key string; elem int }
     - __kind: StructureType
-      ID: 26
+      ID: 46
       Name: noalg.map.group[string]int
       ByteSize: 200
       GoRuntimeType: 74528
@@ -1037,12 +1037,12 @@ Types:
       RawFields:
         - Name: ctrl
           Offset: 0
-          Type: 18 BaseType uint64
+          Type: 8 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 27 ArrayType noalg.[8]struct { key string; elem int }
+          Type: 47 ArrayType noalg.[8]struct { key string; elem int }
     - __kind: StructureType
-      ID: 37
+      ID: 57
       Name: noalg.map.group[string]main.bigStruct
       ByteSize: 200
       GoRuntimeType: 74784
@@ -1050,12 +1050,12 @@ Types:
       RawFields:
         - Name: ctrl
           Offset: 0
-          Type: 18 BaseType uint64
+          Type: 8 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 38 ArrayType noalg.[8]struct { key string; elem *main.bigStruct }
+          Type: 58 ArrayType noalg.[8]struct { key string; elem *main.bigStruct }
     - __kind: StructureType
-      ID: 39
+      ID: 59
       Name: noalg.struct { key string; elem *main.bigStruct }
       ByteSize: 24
       GoRuntimeType: 74656
@@ -1063,12 +1063,12 @@ Types:
       RawFields:
         - Name: key
           Offset: 0
-          Type: 7 GoStringHeaderType string
+          Type: 9 GoStringHeaderType string
         - Name: elem
           Offset: 16
-          Type: 40 PointerType *main.bigStruct
+          Type: 60 PointerType *main.bigStruct
     - __kind: StructureType
-      ID: 28
+      ID: 48
       Name: noalg.struct { key string; elem int }
       ByteSize: 24
       GoRuntimeType: 74400
@@ -1076,12 +1076,12 @@ Types:
       RawFields:
         - Name: key
           Offset: 0
-          Type: 7 GoStringHeaderType string
+          Type: 9 GoStringHeaderType string
         - Name: elem
           Offset: 16
-          Type: 1 BaseType int
+          Type: 7 BaseType int
     - __kind: GoStringHeaderType
-      ID: 7
+      ID: 9
       Name: string
       ByteSize: 16
       GoRuntimeType: 41344
@@ -1092,98 +1092,98 @@ Types:
           Type: 68 PointerType *string.str
         - Name: len
           Offset: 8
-          Type: 1 BaseType int
+          Type: 7 BaseType int
       Data: 67 GoStringDataType string.str
     - __kind: GoStringDataType
       ID: 67
       Name: string.str
       ByteSize: 2048
     - __kind: StructureType
-      ID: 22
+      ID: 43
       Name: table<string,int>
       ByteSize: 32
       GoKind: 25
       RawFields:
         - Name: used
           Offset: 0
-          Type: 23 BaseType uint16
+          Type: 6 BaseType uint16
         - Name: capacity
           Offset: 2
-          Type: 23 BaseType uint16
+          Type: 6 BaseType uint16
         - Name: growthLeft
           Offset: 4
-          Type: 23 BaseType uint16
+          Type: 6 BaseType uint16
         - Name: localDepth
           Offset: 6
-          Type: 9 BaseType uint8
+          Type: 3 BaseType uint8
         - Name: index
           Offset: 8
-          Type: 1 BaseType int
+          Type: 7 BaseType int
         - Name: groups
           Offset: 16
-          Type: 24 GoSwissMapGroupsType groupReference<string,int>
+          Type: 44 GoSwissMapGroupsType groupReference<string,int>
     - __kind: StructureType
-      ID: 34
+      ID: 54
       Name: table<string,main.bigStruct>
       ByteSize: 32
       GoKind: 25
       RawFields:
         - Name: used
           Offset: 0
-          Type: 23 BaseType uint16
+          Type: 6 BaseType uint16
         - Name: capacity
           Offset: 2
-          Type: 23 BaseType uint16
+          Type: 6 BaseType uint16
         - Name: growthLeft
           Offset: 4
-          Type: 23 BaseType uint16
+          Type: 6 BaseType uint16
         - Name: localDepth
           Offset: 6
-          Type: 9 BaseType uint8
+          Type: 3 BaseType uint8
         - Name: index
           Offset: 8
-          Type: 1 BaseType int
+          Type: 7 BaseType int
         - Name: groups
           Offset: 16
-          Type: 35 GoSwissMapGroupsType groupReference<string,main.bigStruct>
+          Type: 55 GoSwissMapGroupsType groupReference<string,main.bigStruct>
     - __kind: BaseType
-      ID: 45
+      ID: 10
       Name: uint
       ByteSize: 8
       GoRuntimeType: 41984
       GoKind: 7
     - __kind: BaseType
-      ID: 23
+      ID: 6
       Name: uint16
       ByteSize: 2
       GoRuntimeType: 41600
       GoKind: 9
     - __kind: BaseType
-      ID: 43
+      ID: 2
       Name: uint32
       ByteSize: 4
       GoRuntimeType: 41728
       GoKind: 10
     - __kind: BaseType
-      ID: 18
+      ID: 8
       Name: uint64
       ByteSize: 8
       GoRuntimeType: 41856
       GoKind: 11
     - __kind: BaseType
-      ID: 9
+      ID: 3
       Name: uint8
       ByteSize: 1
       GoRuntimeType: 41472
       GoKind: 8
     - __kind: BaseType
-      ID: 19
+      ID: 1
       Name: uintptr
       ByteSize: 8
       GoRuntimeType: 42048
       GoKind: 12
     - __kind: VoidPointerType
-      ID: 50
+      ID: 15
       Name: unsafe.Pointer
       ByteSize: 8
       GoRuntimeType: 42432

--- a/pkg/dyninst/irgen/testdata/snapshot/simple.arch=arm64,toolchain=go1.25.0.yaml
+++ b/pkg/dyninst/irgen/testdata/snapshot/simple.arch=arm64,toolchain=go1.25.0.yaml
@@ -11,7 +11,7 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 2}
+      subprogram: {subprogram: 11}
       events:
         - ID: 11
           Type: 87 EventRootType Probe[main.PointerChainArg]
@@ -28,7 +28,7 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 3}
+      subprogram: {subprogram: 12}
       events:
         - ID: 12
           Type: 88 EventRootType Probe[main.PointerSmallChainArg]
@@ -41,7 +41,7 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 12}
+      subprogram: {subprogram: 9}
       events:
         - ID: 9
           Type: 85 EventRootType Probe[main.bigMapArg]
@@ -55,7 +55,7 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 1}
+      subprogram: {subprogram: 10}
       events:
         - ID: 10
           Type: 86 EventRootType Probe[main.inlined]
@@ -72,7 +72,7 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 4}
+      subprogram: {subprogram: 1}
       events:
         - ID: 1
           Type: 77 EventRootType Probe[main.intArg]
@@ -85,7 +85,7 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 7}
+      subprogram: {subprogram: 4}
       events:
         - ID: 4
           Type: 80 EventRootType Probe[main.intArrayArg]
@@ -98,7 +98,7 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 10}
+      subprogram: {subprogram: 7}
       events:
         - ID: 7
           Type: 83 EventRootType Probe[main.stringArrayArgFrameless]
@@ -111,7 +111,7 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 6}
+      subprogram: {subprogram: 3}
       events:
         - ID: 3
           Type: 79 EventRootType Probe[main.intSliceArg]
@@ -124,7 +124,7 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 11}
+      subprogram: {subprogram: 8}
       events:
         - ID: 8
           Type: 84 EventRootType Probe[main.mapArg]
@@ -137,7 +137,7 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 5}
+      subprogram: {subprogram: 2}
       events:
         - ID: 2
           Type: 78 EventRootType Probe[main.stringArg]
@@ -150,7 +150,7 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 9}
+      subprogram: {subprogram: 6}
       events:
         - ID: 6
           Type: 82 EventRootType Probe[main.stringArrayArg]
@@ -163,32 +163,32 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 8}
+      subprogram: {subprogram: 5}
       events:
         - ID: 5
           Type: 81 EventRootType Probe[main.stringSliceArg]
           InjectionPoints: [{PC: "0xb7fbc", Frameless: true}]
           Condition: null
 Subprograms:
-    - ID: 4
+    - ID: 1
       Name: main.intArg
       OutOfLinePCRanges: [0xb7de0..0xb7e50]
       InlinePCRanges: []
       Variables:
         - Name: x
-          Type: 1 BaseType int
+          Type: 7 BaseType int
           Locations:
             - Range: 0xb7de0..0xb7e00
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 5
+    - ID: 2
       Name: main.stringArg
       OutOfLinePCRanges: [0xb7e50..0xb7ec0]
       InlinePCRanges: []
       Variables:
         - Name: s
-          Type: 7 GoStringHeaderType string
+          Type: 9 GoStringHeaderType string
           Locations:
             - Range: 0xb7e50..0xb7e74
               Pieces:
@@ -198,13 +198,13 @@ Subprograms:
                   Op: {RegNo: 1, Shift: 0}
           IsParameter: true
           IsReturn: false
-    - ID: 6
+    - ID: 3
       Name: main.intSliceArg
       OutOfLinePCRanges: [0xb7ec0..0xb7f40]
       InlinePCRanges: []
       Variables:
         - Name: s
-          Type: 10 GoSliceHeaderType []int
+          Type: 34 GoSliceHeaderType []int
           Locations:
             - Range: 0xb7ec0..0xb7ee4
               Pieces:
@@ -216,25 +216,25 @@ Subprograms:
                   Op: {RegNo: 2, Shift: 0}
           IsParameter: true
           IsReturn: false
-    - ID: 7
+    - ID: 4
       Name: main.intArrayArg
       OutOfLinePCRanges: [0xb7f40..0xb7fb0]
       InlinePCRanges: []
       Variables:
         - Name: s
-          Type: 11 ArrayType [3]int
+          Type: 35 ArrayType [3]int
           Locations:
             - Range: 0xb7f40..0xb7fb0
               Pieces: [{Size: 24, Op: {CfaOffset: 8}}]
           IsParameter: true
           IsReturn: false
-    - ID: 8
+    - ID: 5
       Name: main.stringSliceArg
       OutOfLinePCRanges: [0xb7fb0..0xb8030]
       InlinePCRanges: []
       Variables:
         - Name: s
-          Type: 12 GoSliceHeaderType []string
+          Type: 36 GoSliceHeaderType []string
           Locations:
             - Range: 0xb7fb0..0xb7fd4
               Pieces:
@@ -246,49 +246,49 @@ Subprograms:
                   Op: {RegNo: 2, Shift: 0}
           IsParameter: true
           IsReturn: false
-    - ID: 9
+    - ID: 6
       Name: main.stringArrayArg
       OutOfLinePCRanges: [0xb8030..0xb80a0]
       InlinePCRanges: []
       Variables:
         - Name: s
-          Type: 14 ArrayType [3]string
+          Type: 37 ArrayType [3]string
           Locations:
             - Range: 0xb8030..0xb80a0
               Pieces: [{Size: 48, Op: {CfaOffset: 8}}]
           IsParameter: true
           IsReturn: false
-    - ID: 10
+    - ID: 7
       Name: main.stringArrayArgFrameless
       OutOfLinePCRanges: [0xb80a0..0xb80b0]
       InlinePCRanges: []
       Variables:
         - Name: s
-          Type: 14 ArrayType [3]string
+          Type: 37 ArrayType [3]string
           Locations:
             - Range: 0xb80a0..0xb80b0
               Pieces: [{Size: 48, Op: {CfaOffset: 8}}]
           IsParameter: true
           IsReturn: false
-    - ID: 11
+    - ID: 8
       Name: main.mapArg
       OutOfLinePCRanges: [0xb8170..0xb81e0]
       InlinePCRanges: []
       Variables:
         - Name: m
-          Type: 15 GoMapType map[string]int
+          Type: 38 GoMapType map[string]int
           Locations:
             - Range: 0xb8170..0xb81a4
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 12
+    - ID: 9
       Name: main.bigMapArg
       OutOfLinePCRanges: [0xb81e0..0xb8290]
       InlinePCRanges: []
       Variables:
         - Name: m
-          Type: 30 GoMapType map[string]main.bigStruct
+          Type: 49 GoMapType map[string]main.bigStruct
           Locations:
             - Range: 0xb81e0..0xb8218
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
@@ -296,7 +296,7 @@ Subprograms:
               Pieces: [{Size: 8, Op: {CfaOffset: 8}}]
           IsParameter: true
           IsReturn: false
-    - ID: 1
+    - ID: 10
       Name: main.inlined
       OutOfLinePCRanges: [0xb80b0..0xb8120]
       InlinePCRanges:
@@ -304,7 +304,7 @@ Subprograms:
           RootRanges: [0xb7a00..0xb7de0]
       Variables:
         - Name: x
-          Type: 1 BaseType int
+          Type: 7 BaseType int
           Locations:
             - Range: 0xb7b88..0xb7bbc
               Pieces: []
@@ -312,7 +312,7 @@ Subprograms:
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 2
+    - ID: 11
       Name: main.PointerChainArg
       OutOfLinePCRanges: []
       InlinePCRanges:
@@ -320,13 +320,13 @@ Subprograms:
           RootRanges: [0xb7a00..0xb7de0]
       Variables:
         - Name: ptr
-          Type: 2 PointerType *****int
+          Type: 63 PointerType *****int
           Locations:
             - Range: 0xb7d38..0xb7d7c
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 3
+    - ID: 12
       Name: main.PointerSmallChainArg
       OutOfLinePCRanges: []
       InlinePCRanges:
@@ -334,7 +334,7 @@ Subprograms:
           RootRanges: [0xb7a00..0xb7de0]
       Variables:
         - Name: ptr
-          Type: 5 PointerType **int
+          Type: 66 PointerType **int
           Locations:
             - Range: 0xb7d94..0xb7dc0
               Pieces: [{Size: 8, Op: {RegNo: 5, Shift: 0}}]
@@ -342,43 +342,43 @@ Subprograms:
           IsReturn: false
 Types:
     - __kind: PointerType
-      ID: 2
+      ID: 63
       Name: '*****int'
       ByteSize: 8
       GoRuntimeType: 36288
       GoKind: 22
-      Pointee: 3 PointerType ****int
+      Pointee: 64 PointerType ****int
     - __kind: PointerType
-      ID: 3
+      ID: 64
       Name: '****int'
       ByteSize: 8
       GoRuntimeType: 36224
       GoKind: 22
-      Pointee: 4 PointerType ***int
+      Pointee: 65 PointerType ***int
     - __kind: PointerType
-      ID: 4
+      ID: 65
       Name: '***int'
       ByteSize: 8
       GoRuntimeType: 36160
       GoKind: 22
-      Pointee: 5 PointerType **int
+      Pointee: 66 PointerType **int
     - __kind: PointerType
-      ID: 5
+      ID: 66
       Name: '**int'
       ByteSize: 8
       GoRuntimeType: 36096
       GoKind: 22
-      Pointee: 6 PointerType *int
+      Pointee: 27 PointerType *int
     - __kind: PointerType
-      ID: 20
+      ID: 41
       Name: '**table<string,int>'
       ByteSize: 8
-      Pointee: 21 PointerType *table<string,int>
+      Pointee: 42 PointerType *table<string,int>
     - __kind: PointerType
-      ID: 33
+      ID: 52
       Name: '**table<string,main.bigStruct>'
       ByteSize: 8
-      Pointee: 34 PointerType *table<string,main.bigStruct>
+      Pointee: 53 PointerType *table<string,main.bigStruct>
     - __kind: PointerType
       ID: 70
       Name: '*[]int.array'
@@ -390,145 +390,145 @@ Types:
       ByteSize: 8
       Pointee: 71 GoSliceDataType []string.array
     - __kind: PointerType
-      ID: 46
+      ID: 11
       Name: '*bool'
       ByteSize: 8
       GoRuntimeType: 30400
       GoKind: 22
-      Pointee: 29 BaseType bool
+      Pointee: 4 BaseType bool
     - __kind: PointerType
-      ID: 63
+      ID: 30
       Name: '*error'
       ByteSize: 8
       GoRuntimeType: 29312
       GoKind: 22
-      Pointee: 49 GoInterfaceType error
+      Pointee: 14 GoInterfaceType error
     - __kind: PointerType
-      ID: 64
+      ID: 31
       Name: '*float32'
       ByteSize: 8
       GoRuntimeType: 30272
       GoKind: 22
-      Pointee: 53 BaseType float32
+      Pointee: 18 BaseType float32
     - __kind: PointerType
-      ID: 60
+      ID: 26
       Name: '*float64'
       ByteSize: 8
       GoRuntimeType: 30336
       GoKind: 22
-      Pointee: 51 BaseType float64
+      Pointee: 16 BaseType float64
     - __kind: PointerType
-      ID: 6
+      ID: 27
       Name: '*int'
       ByteSize: 8
       GoRuntimeType: 29952
       GoKind: 22
-      Pointee: 1 BaseType int
+      Pointee: 7 BaseType int
     - __kind: PointerType
-      ID: 55
+      ID: 20
       Name: '*int32'
       ByteSize: 8
       GoRuntimeType: 29696
       GoKind: 22
-      Pointee: 47 BaseType int32
+      Pointee: 12 BaseType int32
     - __kind: PointerType
-      ID: 62
+      ID: 29
       Name: '*int64'
       ByteSize: 8
       GoRuntimeType: 29824
       GoKind: 22
-      Pointee: 48 BaseType int64
+      Pointee: 13 BaseType int64
     - __kind: PointerType
-      ID: 41
+      ID: 60
       Name: '*main.bigStruct'
       ByteSize: 8
       GoRuntimeType: 27776
       GoKind: 22
-      Pointee: 42 StructureType main.bigStruct
+      Pointee: 61 StructureType main.bigStruct
     - __kind: PointerType
-      ID: 16
+      ID: 39
       Name: '*map<string,int>'
       ByteSize: 8
-      Pointee: 17 GoSwissMapHeaderType map<string,int>
+      Pointee: 40 GoSwissMapHeaderType map<string,int>
     - __kind: PointerType
-      ID: 31
+      ID: 50
       Name: '*map<string,main.bigStruct>'
       ByteSize: 8
-      Pointee: 32 GoSwissMapHeaderType map<string,main.bigStruct>
+      Pointee: 51 GoSwissMapHeaderType map<string,main.bigStruct>
     - __kind: PointerType
-      ID: 25
+      ID: 45
       Name: '*noalg.map.group[string]int'
       ByteSize: 8
-      Pointee: 26 StructureType noalg.map.group[string]int
+      Pointee: 46 StructureType noalg.map.group[string]int
     - __kind: PointerType
-      ID: 37
+      ID: 56
       Name: '*noalg.map.group[string]main.bigStruct'
       ByteSize: 8
-      Pointee: 38 StructureType noalg.map.group[string]main.bigStruct
+      Pointee: 57 StructureType noalg.map.group[string]main.bigStruct
     - __kind: PointerType
-      ID: 13
+      ID: 22
       Name: '*string'
       ByteSize: 8
       GoRuntimeType: 29376
       GoKind: 22
-      Pointee: 7 GoStringHeaderType string
+      Pointee: 9 GoStringHeaderType string
     - __kind: PointerType
       ID: 68
       Name: '*string.str'
       ByteSize: 8
       Pointee: 67 GoStringDataType string.str
     - __kind: PointerType
-      ID: 21
+      ID: 42
       Name: '*table<string,int>'
       ByteSize: 8
-      Pointee: 22 StructureType table<string,int>
+      Pointee: 43 StructureType table<string,int>
     - __kind: PointerType
-      ID: 34
+      ID: 53
       Name: '*table<string,main.bigStruct>'
       ByteSize: 8
-      Pointee: 35 StructureType table<string,main.bigStruct>
+      Pointee: 54 StructureType table<string,main.bigStruct>
     - __kind: PointerType
-      ID: 65
+      ID: 32
       Name: '*uint'
       ByteSize: 8
       GoRuntimeType: 30016
       GoKind: 22
-      Pointee: 45 BaseType uint
+      Pointee: 10 BaseType uint
     - __kind: PointerType
-      ID: 66
+      ID: 33
       Name: '*uint16'
       ByteSize: 8
       GoRuntimeType: 29632
       GoKind: 22
-      Pointee: 23 BaseType uint16
+      Pointee: 6 BaseType uint16
     - __kind: PointerType
-      ID: 56
+      ID: 21
       Name: '*uint32'
       ByteSize: 8
       GoRuntimeType: 29760
       GoKind: 22
-      Pointee: 44 BaseType uint32
+      Pointee: 2 BaseType uint32
     - __kind: PointerType
-      ID: 61
+      ID: 28
       Name: '*uint64'
       ByteSize: 8
       GoRuntimeType: 29888
       GoKind: 22
-      Pointee: 18 BaseType uint64
+      Pointee: 8 BaseType uint64
     - __kind: PointerType
-      ID: 8
+      ID: 5
       Name: '*uint8'
       ByteSize: 8
       GoRuntimeType: 29504
       GoKind: 22
-      Pointee: 9 BaseType uint8
+      Pointee: 3 BaseType uint8
     - __kind: PointerType
-      ID: 54
+      ID: 19
       Name: '*uintptr'
       ByteSize: 8
       GoRuntimeType: 30080
       GoKind: 22
-      Pointee: 19 BaseType uintptr
+      Pointee: 1 BaseType uintptr
     - __kind: EventRootType
       ID: 87
       Name: Probe[main.PointerChainArg]
@@ -538,10 +538,10 @@ Types:
         - Name: ptr
           Offset: 1
           Expression:
-            Type: 2 PointerType *****int
+            Type: 63 PointerType *****int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 2, index: 0, name: ptr}
+                  Variable: {subprogram: 11, index: 0, name: ptr}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
@@ -553,10 +553,10 @@ Types:
         - Name: ptr
           Offset: 1
           Expression:
-            Type: 5 PointerType **int
+            Type: 66 PointerType **int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 3, index: 0, name: ptr}
+                  Variable: {subprogram: 12, index: 0, name: ptr}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
@@ -568,10 +568,10 @@ Types:
         - Name: m
           Offset: 1
           Expression:
-            Type: 30 GoMapType map[string]main.bigStruct
+            Type: 49 GoMapType map[string]main.bigStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 12, index: 0, name: m}
+                  Variable: {subprogram: 9, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
@@ -583,10 +583,10 @@ Types:
         - Name: x
           Offset: 1
           Expression:
-            Type: 1 BaseType int
+            Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 1, index: 0, name: x}
+                  Variable: {subprogram: 10, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
@@ -598,10 +598,10 @@ Types:
         - Name: x
           Offset: 1
           Expression:
-            Type: 1 BaseType int
+            Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 4, index: 0, name: x}
+                  Variable: {subprogram: 1, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
@@ -613,10 +613,10 @@ Types:
         - Name: s
           Offset: 1
           Expression:
-            Type: 11 ArrayType [3]int
+            Type: 35 ArrayType [3]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 7, index: 0, name: s}
+                  Variable: {subprogram: 4, index: 0, name: s}
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
@@ -628,10 +628,10 @@ Types:
         - Name: s
           Offset: 1
           Expression:
-            Type: 10 GoSliceHeaderType []int
+            Type: 34 GoSliceHeaderType []int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 6, index: 0, name: s}
+                  Variable: {subprogram: 3, index: 0, name: s}
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
@@ -643,10 +643,10 @@ Types:
         - Name: m
           Offset: 1
           Expression:
-            Type: 15 GoMapType map[string]int
+            Type: 38 GoMapType map[string]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 11, index: 0, name: m}
+                  Variable: {subprogram: 8, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
@@ -658,10 +658,10 @@ Types:
         - Name: s
           Offset: 1
           Expression:
-            Type: 7 GoStringHeaderType string
+            Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 5, index: 0, name: s}
+                  Variable: {subprogram: 2, index: 0, name: s}
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
@@ -673,10 +673,10 @@ Types:
         - Name: s
           Offset: 1
           Expression:
-            Type: 14 ArrayType [3]string
+            Type: 37 ArrayType [3]string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 10, index: 0, name: s}
+                  Variable: {subprogram: 7, index: 0, name: s}
                   Offset: 0
                   ByteSize: 48
     - __kind: EventRootType
@@ -688,10 +688,10 @@ Types:
         - Name: s
           Offset: 1
           Expression:
-            Type: 14 ArrayType [3]string
+            Type: 37 ArrayType [3]string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 9, index: 0, name: s}
+                  Variable: {subprogram: 6, index: 0, name: s}
                   Offset: 0
                   ByteSize: 48
     - __kind: EventRootType
@@ -703,51 +703,51 @@ Types:
         - Name: s
           Offset: 1
           Expression:
-            Type: 12 GoSliceHeaderType []string
+            Type: 36 GoSliceHeaderType []string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 8, index: 0, name: s}
+                  Variable: {subprogram: 5, index: 0, name: s}
                   Offset: 0
                   ByteSize: 24
     - __kind: ArrayType
-      ID: 43
+      ID: 62
       Name: '[128]uint8'
       ByteSize: 128
       GoRuntimeType: 47648
       GoKind: 17
       Count: 128
       HasCount: true
-      Element: 9 BaseType uint8
+      Element: 3 BaseType uint8
     - __kind: ArrayType
-      ID: 11
+      ID: 35
       Name: '[3]int'
       ByteSize: 24
       GoRuntimeType: 47360
       GoKind: 17
       Count: 3
       HasCount: true
-      Element: 1 BaseType int
+      Element: 7 BaseType int
     - __kind: ArrayType
-      ID: 14
+      ID: 37
       Name: '[3]string'
       ByteSize: 48
       GoRuntimeType: 47456
       GoKind: 17
       Count: 3
       HasCount: true
-      Element: 7 GoStringHeaderType string
+      Element: 9 GoStringHeaderType string
     - __kind: GoSliceDataType
       ID: 73
       Name: '[]*table<string,int>.array'
       ByteSize: 8192
-      Element: 21 PointerType *table<string,int>
+      Element: 42 PointerType *table<string,int>
     - __kind: GoSliceDataType
       ID: 75
       Name: '[]*table<string,main.bigStruct>.array'
       ByteSize: 8192
-      Element: 34 PointerType *table<string,main.bigStruct>
+      Element: 53 PointerType *table<string,main.bigStruct>
     - __kind: GoSliceHeaderType
-      ID: 10
+      ID: 34
       Name: '[]int'
       ByteSize: 24
       GoRuntimeType: 38784
@@ -755,31 +755,31 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 6 PointerType *int
+          Type: 27 PointerType *int
         - Name: len
           Offset: 8
-          Type: 1 BaseType int
+          Type: 7 BaseType int
         - Name: cap
           Offset: 16
-          Type: 1 BaseType int
+          Type: 7 BaseType int
       Data: 69 GoSliceDataType []int.array
     - __kind: GoSliceDataType
       ID: 69
       Name: '[]int.array'
       ByteSize: 2048
-      Element: 1 BaseType int
+      Element: 7 BaseType int
     - __kind: GoSliceDataType
       ID: 74
       Name: '[]noalg.map.group[string]int.array'
       ByteSize: 2048
-      Element: 26 StructureType noalg.map.group[string]int
+      Element: 46 StructureType noalg.map.group[string]int
     - __kind: GoSliceDataType
       ID: 76
       Name: '[]noalg.map.group[string]main.bigStruct.array'
       ByteSize: 2048
-      Element: 38 StructureType noalg.map.group[string]main.bigStruct
+      Element: 57 StructureType noalg.map.group[string]main.bigStruct
     - __kind: GoSliceHeaderType
-      ID: 12
+      ID: 36
       Name: '[]string'
       ByteSize: 24
       GoRuntimeType: 39040
@@ -787,39 +787,39 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 13 PointerType *string
+          Type: 22 PointerType *string
         - Name: len
           Offset: 8
-          Type: 1 BaseType int
+          Type: 7 BaseType int
         - Name: cap
           Offset: 16
-          Type: 1 BaseType int
+          Type: 7 BaseType int
       Data: 71 GoSliceDataType []string.array
     - __kind: GoSliceDataType
       ID: 71
       Name: '[]string.array'
       ByteSize: 2048
-      Element: 7 GoStringHeaderType string
+      Element: 9 GoStringHeaderType string
     - __kind: BaseType
-      ID: 29
+      ID: 4
       Name: bool
       ByteSize: 1
       GoRuntimeType: 43744
       GoKind: 1
     - __kind: BaseType
-      ID: 59
+      ID: 25
       Name: complex128
       ByteSize: 16
       GoRuntimeType: 43552
       GoKind: 16
     - __kind: BaseType
-      ID: 58
+      ID: 24
       Name: complex64
       ByteSize: 8
       GoRuntimeType: 43488
       GoKind: 15
     - __kind: GoInterfaceType
-      ID: 49
+      ID: 14
       Name: error
       ByteSize: 16
       GoRuntimeType: 65728
@@ -827,82 +827,82 @@ Types:
       RawFields:
         - Name: tab
           Offset: 0
-          Type: 50 VoidPointerType unsafe.Pointer
+          Type: 15 VoidPointerType unsafe.Pointer
         - Name: data
           Offset: 8
-          Type: 50 VoidPointerType unsafe.Pointer
+          Type: 15 VoidPointerType unsafe.Pointer
     - __kind: BaseType
-      ID: 53
+      ID: 18
       Name: float32
       ByteSize: 4
       GoRuntimeType: 43616
       GoKind: 13
     - __kind: BaseType
-      ID: 51
+      ID: 16
       Name: float64
       ByteSize: 8
       GoRuntimeType: 43680
       GoKind: 14
     - __kind: GoSwissMapGroupsType
-      ID: 24
+      ID: 44
       Name: groupReference<string,int>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 25 PointerType *noalg.map.group[string]int
+          Type: 45 PointerType *noalg.map.group[string]int
         - Name: lengthMask
           Offset: 8
-          Type: 18 BaseType uint64
-      GroupType: 26 StructureType noalg.map.group[string]int
+          Type: 8 BaseType uint64
+      GroupType: 46 StructureType noalg.map.group[string]int
       GroupSliceType: 74 GoSliceDataType []noalg.map.group[string]int.array
     - __kind: GoSwissMapGroupsType
-      ID: 36
+      ID: 55
       Name: groupReference<string,main.bigStruct>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 37 PointerType *noalg.map.group[string]main.bigStruct
+          Type: 56 PointerType *noalg.map.group[string]main.bigStruct
         - Name: lengthMask
           Offset: 8
-          Type: 18 BaseType uint64
-      GroupType: 38 StructureType noalg.map.group[string]main.bigStruct
+          Type: 8 BaseType uint64
+      GroupType: 57 StructureType noalg.map.group[string]main.bigStruct
       GroupSliceType: 76 GoSliceDataType []noalg.map.group[string]main.bigStruct.array
     - __kind: BaseType
-      ID: 1
+      ID: 7
       Name: int
       ByteSize: 8
       GoRuntimeType: 43296
       GoKind: 2
     - __kind: BaseType
-      ID: 57
+      ID: 23
       Name: int16
       ByteSize: 2
       GoRuntimeType: 42912
       GoKind: 4
     - __kind: BaseType
-      ID: 47
+      ID: 12
       Name: int32
       ByteSize: 4
       GoRuntimeType: 43040
       GoKind: 5
     - __kind: BaseType
-      ID: 48
+      ID: 13
       Name: int64
       ByteSize: 8
       GoRuntimeType: 43168
       GoKind: 6
     - __kind: BaseType
-      ID: 52
+      ID: 17
       Name: int8
       ByteSize: 1
       GoRuntimeType: 42784
       GoKind: 3
     - __kind: StructureType
-      ID: 42
+      ID: 61
       Name: main.bigStruct
       ByteSize: 184
       GoRuntimeType: 124608
@@ -910,132 +910,132 @@ Types:
       RawFields:
         - Name: Field1
           Offset: 0
-          Type: 1 BaseType int
+          Type: 7 BaseType int
         - Name: Field2
           Offset: 8
-          Type: 1 BaseType int
+          Type: 7 BaseType int
         - Name: Field3
           Offset: 16
-          Type: 1 BaseType int
+          Type: 7 BaseType int
         - Name: Field4
           Offset: 24
-          Type: 1 BaseType int
+          Type: 7 BaseType int
         - Name: Field5
           Offset: 32
-          Type: 1 BaseType int
+          Type: 7 BaseType int
         - Name: Field6
           Offset: 40
-          Type: 1 BaseType int
+          Type: 7 BaseType int
         - Name: Field7
           Offset: 48
-          Type: 1 BaseType int
+          Type: 7 BaseType int
         - Name: data
           Offset: 56
-          Type: 43 ArrayType [128]uint8
+          Type: 62 ArrayType [128]uint8
     - __kind: GoSwissMapHeaderType
-      ID: 17
+      ID: 40
       Name: map<string,int>
       ByteSize: 48
       GoKind: 25
       RawFields:
         - Name: used
           Offset: 0
-          Type: 18 BaseType uint64
+          Type: 8 BaseType uint64
         - Name: seed
           Offset: 8
-          Type: 19 BaseType uintptr
+          Type: 1 BaseType uintptr
         - Name: dirPtr
           Offset: 16
-          Type: 20 PointerType **table<string,int>
+          Type: 41 PointerType **table<string,int>
         - Name: dirLen
           Offset: 24
-          Type: 1 BaseType int
+          Type: 7 BaseType int
         - Name: globalDepth
           Offset: 32
-          Type: 9 BaseType uint8
+          Type: 3 BaseType uint8
         - Name: globalShift
           Offset: 33
-          Type: 9 BaseType uint8
+          Type: 3 BaseType uint8
         - Name: writing
           Offset: 34
-          Type: 9 BaseType uint8
+          Type: 3 BaseType uint8
         - Name: tombstonePossible
           Offset: 35
-          Type: 29 BaseType bool
+          Type: 4 BaseType bool
         - Name: clearSeq
           Offset: 40
-          Type: 18 BaseType uint64
+          Type: 8 BaseType uint64
       TablePtrSliceType: 73 GoSliceDataType []*table<string,int>.array
-      GroupType: 26 StructureType noalg.map.group[string]int
+      GroupType: 46 StructureType noalg.map.group[string]int
     - __kind: GoSwissMapHeaderType
-      ID: 32
+      ID: 51
       Name: map<string,main.bigStruct>
       ByteSize: 48
       GoKind: 25
       RawFields:
         - Name: used
           Offset: 0
-          Type: 18 BaseType uint64
+          Type: 8 BaseType uint64
         - Name: seed
           Offset: 8
-          Type: 19 BaseType uintptr
+          Type: 1 BaseType uintptr
         - Name: dirPtr
           Offset: 16
-          Type: 33 PointerType **table<string,main.bigStruct>
+          Type: 52 PointerType **table<string,main.bigStruct>
         - Name: dirLen
           Offset: 24
-          Type: 1 BaseType int
+          Type: 7 BaseType int
         - Name: globalDepth
           Offset: 32
-          Type: 9 BaseType uint8
+          Type: 3 BaseType uint8
         - Name: globalShift
           Offset: 33
-          Type: 9 BaseType uint8
+          Type: 3 BaseType uint8
         - Name: writing
           Offset: 34
-          Type: 9 BaseType uint8
+          Type: 3 BaseType uint8
         - Name: tombstonePossible
           Offset: 35
-          Type: 29 BaseType bool
+          Type: 4 BaseType bool
         - Name: clearSeq
           Offset: 40
-          Type: 18 BaseType uint64
+          Type: 8 BaseType uint64
       TablePtrSliceType: 75 GoSliceDataType []*table<string,main.bigStruct>.array
-      GroupType: 38 StructureType noalg.map.group[string]main.bigStruct
+      GroupType: 57 StructureType noalg.map.group[string]main.bigStruct
     - __kind: GoMapType
-      ID: 15
+      ID: 38
       Name: map[string]int
       ByteSize: 8
       GoRuntimeType: 69952
       GoKind: 21
-      HeaderType: 17 GoSwissMapHeaderType map<string,int>
+      HeaderType: 40 GoSwissMapHeaderType map<string,int>
     - __kind: GoMapType
-      ID: 30
+      ID: 49
       Name: map[string]main.bigStruct
       ByteSize: 8
       GoRuntimeType: 70080
       GoKind: 21
-      HeaderType: 32 GoSwissMapHeaderType map<string,main.bigStruct>
+      HeaderType: 51 GoSwissMapHeaderType map<string,main.bigStruct>
     - __kind: ArrayType
-      ID: 39
+      ID: 58
       Name: noalg.[8]struct { key string; elem *main.bigStruct }
       ByteSize: 192
       GoRuntimeType: 47744
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 40 StructureType noalg.struct { key string; elem *main.bigStruct }
+      Element: 59 StructureType noalg.struct { key string; elem *main.bigStruct }
     - __kind: ArrayType
-      ID: 27
+      ID: 47
       Name: noalg.[8]struct { key string; elem int }
       ByteSize: 192
       GoRuntimeType: 47552
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 28 StructureType noalg.struct { key string; elem int }
+      Element: 48 StructureType noalg.struct { key string; elem int }
     - __kind: StructureType
-      ID: 26
+      ID: 46
       Name: noalg.map.group[string]int
       ByteSize: 200
       GoRuntimeType: 77120
@@ -1043,12 +1043,12 @@ Types:
       RawFields:
         - Name: ctrl
           Offset: 0
-          Type: 18 BaseType uint64
+          Type: 8 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 27 ArrayType noalg.[8]struct { key string; elem int }
+          Type: 47 ArrayType noalg.[8]struct { key string; elem int }
     - __kind: StructureType
-      ID: 38
+      ID: 57
       Name: noalg.map.group[string]main.bigStruct
       ByteSize: 200
       GoRuntimeType: 77376
@@ -1056,12 +1056,12 @@ Types:
       RawFields:
         - Name: ctrl
           Offset: 0
-          Type: 18 BaseType uint64
+          Type: 8 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 39 ArrayType noalg.[8]struct { key string; elem *main.bigStruct }
+          Type: 58 ArrayType noalg.[8]struct { key string; elem *main.bigStruct }
     - __kind: StructureType
-      ID: 40
+      ID: 59
       Name: noalg.struct { key string; elem *main.bigStruct }
       ByteSize: 24
       GoRuntimeType: 77248
@@ -1069,12 +1069,12 @@ Types:
       RawFields:
         - Name: key
           Offset: 0
-          Type: 7 GoStringHeaderType string
+          Type: 9 GoStringHeaderType string
         - Name: elem
           Offset: 16
-          Type: 41 PointerType *main.bigStruct
+          Type: 60 PointerType *main.bigStruct
     - __kind: StructureType
-      ID: 28
+      ID: 48
       Name: noalg.struct { key string; elem int }
       ByteSize: 24
       GoRuntimeType: 76992
@@ -1082,12 +1082,12 @@ Types:
       RawFields:
         - Name: key
           Offset: 0
-          Type: 7 GoStringHeaderType string
+          Type: 9 GoStringHeaderType string
         - Name: elem
           Offset: 16
-          Type: 1 BaseType int
+          Type: 7 BaseType int
     - __kind: GoStringHeaderType
-      ID: 7
+      ID: 9
       Name: string
       ByteSize: 16
       GoRuntimeType: 42720
@@ -1098,98 +1098,98 @@ Types:
           Type: 68 PointerType *string.str
         - Name: len
           Offset: 8
-          Type: 1 BaseType int
+          Type: 7 BaseType int
       Data: 67 GoStringDataType string.str
     - __kind: GoStringDataType
       ID: 67
       Name: string.str
       ByteSize: 2048
     - __kind: StructureType
-      ID: 22
+      ID: 43
       Name: table<string,int>
       ByteSize: 32
       GoKind: 25
       RawFields:
         - Name: used
           Offset: 0
-          Type: 23 BaseType uint16
+          Type: 6 BaseType uint16
         - Name: capacity
           Offset: 2
-          Type: 23 BaseType uint16
+          Type: 6 BaseType uint16
         - Name: growthLeft
           Offset: 4
-          Type: 23 BaseType uint16
+          Type: 6 BaseType uint16
         - Name: localDepth
           Offset: 6
-          Type: 9 BaseType uint8
+          Type: 3 BaseType uint8
         - Name: index
           Offset: 8
-          Type: 1 BaseType int
+          Type: 7 BaseType int
         - Name: groups
           Offset: 16
-          Type: 24 GoSwissMapGroupsType groupReference<string,int>
+          Type: 44 GoSwissMapGroupsType groupReference<string,int>
     - __kind: StructureType
-      ID: 35
+      ID: 54
       Name: table<string,main.bigStruct>
       ByteSize: 32
       GoKind: 25
       RawFields:
         - Name: used
           Offset: 0
-          Type: 23 BaseType uint16
+          Type: 6 BaseType uint16
         - Name: capacity
           Offset: 2
-          Type: 23 BaseType uint16
+          Type: 6 BaseType uint16
         - Name: growthLeft
           Offset: 4
-          Type: 23 BaseType uint16
+          Type: 6 BaseType uint16
         - Name: localDepth
           Offset: 6
-          Type: 9 BaseType uint8
+          Type: 3 BaseType uint8
         - Name: index
           Offset: 8
-          Type: 1 BaseType int
+          Type: 7 BaseType int
         - Name: groups
           Offset: 16
-          Type: 36 GoSwissMapGroupsType groupReference<string,main.bigStruct>
+          Type: 55 GoSwissMapGroupsType groupReference<string,main.bigStruct>
     - __kind: BaseType
-      ID: 45
+      ID: 10
       Name: uint
       ByteSize: 8
       GoRuntimeType: 43360
       GoKind: 7
     - __kind: BaseType
-      ID: 23
+      ID: 6
       Name: uint16
       ByteSize: 2
       GoRuntimeType: 42976
       GoKind: 9
     - __kind: BaseType
-      ID: 44
+      ID: 2
       Name: uint32
       ByteSize: 4
       GoRuntimeType: 43104
       GoKind: 10
     - __kind: BaseType
-      ID: 18
+      ID: 8
       Name: uint64
       ByteSize: 8
       GoRuntimeType: 43232
       GoKind: 11
     - __kind: BaseType
-      ID: 9
+      ID: 3
       Name: uint8
       ByteSize: 1
       GoRuntimeType: 42848
       GoKind: 8
     - __kind: BaseType
-      ID: 19
+      ID: 1
       Name: uintptr
       ByteSize: 8
       GoRuntimeType: 43424
       GoKind: 12
     - __kind: VoidPointerType
-      ID: 50
+      ID: 15
       Name: unsafe.Pointer
       ByteSize: 8
       GoRuntimeType: 43808

--- a/pkg/dyninst/irgen/testdata/snapshot/simple.arch=arm64,toolchain=go1.25.0.yaml
+++ b/pkg/dyninst/irgen/testdata/snapshot/simple.arch=arm64,toolchain=go1.25.0.yaml
@@ -380,15 +380,15 @@ Types:
       ByteSize: 8
       Pointee: 47 PointerType *table<string,main.bigStruct>
     - __kind: PointerType
-      ID: 70
+      ID: 57
       Name: '*[]int.array'
       ByteSize: 8
-      Pointee: 69 GoSliceDataType []int.array
+      Pointee: 56 GoSliceDataType []int.array
     - __kind: PointerType
-      ID: 72
+      ID: 59
       Name: '*[]string.array'
       ByteSize: 8
-      Pointee: 71 GoSliceDataType []string.array
+      Pointee: 58 GoSliceDataType []string.array
     - __kind: PointerType
       ID: 11
       Name: '*bool'
@@ -439,12 +439,12 @@ Types:
       GoKind: 22
       Pointee: 13 BaseType int64
     - __kind: PointerType
-      ID: 64
+      ID: 72
       Name: '*main.bigStruct'
       ByteSize: 8
       GoRuntimeType: 27776
       GoKind: 22
-      Pointee: 65 StructureType main.bigStruct
+      Pointee: 73 StructureType main.bigStruct
     - __kind: PointerType
       ID: 39
       Name: '*map<string,int>'
@@ -456,15 +456,15 @@ Types:
       ByteSize: 8
       Pointee: 45 GoSwissMapHeaderType map<string,main.bigStruct>
     - __kind: PointerType
-      ID: 55
+      ID: 61
       Name: '*noalg.map.group[string]int'
       ByteSize: 8
-      Pointee: 56 StructureType noalg.map.group[string]int
+      Pointee: 62 StructureType noalg.map.group[string]int
     - __kind: PointerType
-      ID: 58
+      ID: 68
       Name: '*noalg.map.group[string]main.bigStruct'
       ByteSize: 8
-      Pointee: 59 StructureType noalg.map.group[string]main.bigStruct
+      Pointee: 69 StructureType noalg.map.group[string]main.bigStruct
     - __kind: PointerType
       ID: 22
       Name: '*string'
@@ -473,10 +473,10 @@ Types:
       GoKind: 22
       Pointee: 9 GoStringHeaderType string
     - __kind: PointerType
-      ID: 68
+      ID: 55
       Name: '*string.str'
       ByteSize: 8
-      Pointee: 67 GoStringDataType string.str
+      Pointee: 54 GoStringDataType string.str
     - __kind: PointerType
       ID: 42
       Name: '*table<string,int>'
@@ -710,7 +710,7 @@ Types:
                   Offset: 0
                   ByteSize: 24
     - __kind: ArrayType
-      ID: 66
+      ID: 76
       Name: '[128]uint8'
       ByteSize: 128
       GoRuntimeType: 47648
@@ -737,12 +737,12 @@ Types:
       HasCount: true
       Element: 9 GoStringHeaderType string
     - __kind: GoSliceDataType
-      ID: 73
+      ID: 65
       Name: '[]*table<string,int>.array'
       ByteSize: 8192
       Element: 42 PointerType *table<string,int>
     - __kind: GoSliceDataType
-      ID: 75
+      ID: 74
       Name: '[]*table<string,main.bigStruct>.array'
       ByteSize: 8192
       Element: 47 PointerType *table<string,main.bigStruct>
@@ -762,22 +762,22 @@ Types:
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 69 GoSliceDataType []int.array
+      Data: 56 GoSliceDataType []int.array
     - __kind: GoSliceDataType
-      ID: 69
+      ID: 56
       Name: '[]int.array'
       ByteSize: 2048
       Element: 7 BaseType int
     - __kind: GoSliceDataType
-      ID: 74
+      ID: 66
       Name: '[]noalg.map.group[string]int.array'
       ByteSize: 2048
-      Element: 56 StructureType noalg.map.group[string]int
+      Element: 62 StructureType noalg.map.group[string]int
     - __kind: GoSliceDataType
-      ID: 76
+      ID: 75
       Name: '[]noalg.map.group[string]main.bigStruct.array'
       ByteSize: 2048
-      Element: 59 StructureType noalg.map.group[string]main.bigStruct
+      Element: 69 StructureType noalg.map.group[string]main.bigStruct
     - __kind: GoSliceHeaderType
       ID: 36
       Name: '[]string'
@@ -794,9 +794,9 @@ Types:
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 71 GoSliceDataType []string.array
+      Data: 58 GoSliceDataType []string.array
     - __kind: GoSliceDataType
-      ID: 71
+      ID: 58
       Name: '[]string.array'
       ByteSize: 2048
       Element: 9 GoStringHeaderType string
@@ -844,33 +844,33 @@ Types:
       GoRuntimeType: 43680
       GoKind: 14
     - __kind: GoSwissMapGroupsType
-      ID: 54
+      ID: 60
       Name: groupReference<string,int>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 55 PointerType *noalg.map.group[string]int
+          Type: 61 PointerType *noalg.map.group[string]int
         - Name: lengthMask
           Offset: 8
           Type: 8 BaseType uint64
-      GroupType: 56 StructureType noalg.map.group[string]int
-      GroupSliceType: 74 GoSliceDataType []noalg.map.group[string]int.array
+      GroupType: 62 StructureType noalg.map.group[string]int
+      GroupSliceType: 66 GoSliceDataType []noalg.map.group[string]int.array
     - __kind: GoSwissMapGroupsType
-      ID: 57
+      ID: 67
       Name: groupReference<string,main.bigStruct>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 58 PointerType *noalg.map.group[string]main.bigStruct
+          Type: 68 PointerType *noalg.map.group[string]main.bigStruct
         - Name: lengthMask
           Offset: 8
           Type: 8 BaseType uint64
-      GroupType: 59 StructureType noalg.map.group[string]main.bigStruct
-      GroupSliceType: 76 GoSliceDataType []noalg.map.group[string]main.bigStruct.array
+      GroupType: 69 StructureType noalg.map.group[string]main.bigStruct
+      GroupSliceType: 75 GoSliceDataType []noalg.map.group[string]main.bigStruct.array
     - __kind: BaseType
       ID: 7
       Name: int
@@ -902,7 +902,7 @@ Types:
       GoRuntimeType: 42784
       GoKind: 3
     - __kind: StructureType
-      ID: 65
+      ID: 73
       Name: main.bigStruct
       ByteSize: 184
       GoRuntimeType: 124608
@@ -931,7 +931,7 @@ Types:
           Type: 7 BaseType int
         - Name: data
           Offset: 56
-          Type: 66 ArrayType [128]uint8
+          Type: 76 ArrayType [128]uint8
     - __kind: GoSwissMapHeaderType
       ID: 40
       Name: map<string,int>
@@ -965,8 +965,8 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 8 BaseType uint64
-      TablePtrSliceType: 73 GoSliceDataType []*table<string,int>.array
-      GroupType: 56 StructureType noalg.map.group[string]int
+      TablePtrSliceType: 65 GoSliceDataType []*table<string,int>.array
+      GroupType: 62 StructureType noalg.map.group[string]int
     - __kind: GoSwissMapHeaderType
       ID: 45
       Name: map<string,main.bigStruct>
@@ -1000,8 +1000,8 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 8 BaseType uint64
-      TablePtrSliceType: 75 GoSliceDataType []*table<string,main.bigStruct>.array
-      GroupType: 59 StructureType noalg.map.group[string]main.bigStruct
+      TablePtrSliceType: 74 GoSliceDataType []*table<string,main.bigStruct>.array
+      GroupType: 69 StructureType noalg.map.group[string]main.bigStruct
     - __kind: GoMapType
       ID: 38
       Name: map[string]int
@@ -1017,25 +1017,25 @@ Types:
       GoKind: 21
       HeaderType: 45 GoSwissMapHeaderType map<string,main.bigStruct>
     - __kind: ArrayType
-      ID: 62
+      ID: 70
       Name: noalg.[8]struct { key string; elem *main.bigStruct }
       ByteSize: 192
       GoRuntimeType: 47744
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 63 StructureType noalg.struct { key string; elem *main.bigStruct }
+      Element: 71 StructureType noalg.struct { key string; elem *main.bigStruct }
     - __kind: ArrayType
-      ID: 60
+      ID: 63
       Name: noalg.[8]struct { key string; elem int }
       ByteSize: 192
       GoRuntimeType: 47552
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 61 StructureType noalg.struct { key string; elem int }
+      Element: 64 StructureType noalg.struct { key string; elem int }
     - __kind: StructureType
-      ID: 56
+      ID: 62
       Name: noalg.map.group[string]int
       ByteSize: 200
       GoRuntimeType: 77120
@@ -1046,9 +1046,9 @@ Types:
           Type: 8 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 60 ArrayType noalg.[8]struct { key string; elem int }
+          Type: 63 ArrayType noalg.[8]struct { key string; elem int }
     - __kind: StructureType
-      ID: 59
+      ID: 69
       Name: noalg.map.group[string]main.bigStruct
       ByteSize: 200
       GoRuntimeType: 77376
@@ -1059,9 +1059,9 @@ Types:
           Type: 8 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 62 ArrayType noalg.[8]struct { key string; elem *main.bigStruct }
+          Type: 70 ArrayType noalg.[8]struct { key string; elem *main.bigStruct }
     - __kind: StructureType
-      ID: 63
+      ID: 71
       Name: noalg.struct { key string; elem *main.bigStruct }
       ByteSize: 24
       GoRuntimeType: 77248
@@ -1072,9 +1072,9 @@ Types:
           Type: 9 GoStringHeaderType string
         - Name: elem
           Offset: 16
-          Type: 64 PointerType *main.bigStruct
+          Type: 72 PointerType *main.bigStruct
     - __kind: StructureType
-      ID: 61
+      ID: 64
       Name: noalg.struct { key string; elem int }
       ByteSize: 24
       GoRuntimeType: 76992
@@ -1095,13 +1095,13 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 68 PointerType *string.str
+          Type: 55 PointerType *string.str
         - Name: len
           Offset: 8
           Type: 7 BaseType int
-      Data: 67 GoStringDataType string.str
+      Data: 54 GoStringDataType string.str
     - __kind: GoStringDataType
-      ID: 67
+      ID: 54
       Name: string.str
       ByteSize: 2048
     - __kind: StructureType
@@ -1127,7 +1127,7 @@ Types:
           Type: 7 BaseType int
         - Name: groups
           Offset: 16
-          Type: 54 GoSwissMapGroupsType groupReference<string,int>
+          Type: 60 GoSwissMapGroupsType groupReference<string,int>
     - __kind: StructureType
       ID: 52
       Name: table<string,main.bigStruct>
@@ -1151,7 +1151,7 @@ Types:
           Type: 7 BaseType int
         - Name: groups
           Offset: 16
-          Type: 57 GoSwissMapGroupsType groupReference<string,main.bigStruct>
+          Type: 67 GoSwissMapGroupsType groupReference<string,main.bigStruct>
     - __kind: BaseType
       ID: 10
       Name: uint

--- a/pkg/dyninst/irgen/testdata/snapshot/simple.arch=arm64,toolchain=go1.25.0.yaml
+++ b/pkg/dyninst/irgen/testdata/snapshot/simple.arch=arm64,toolchain=go1.25.0.yaml
@@ -288,7 +288,7 @@ Subprograms:
       InlinePCRanges: []
       Variables:
         - Name: m
-          Type: 49 GoMapType map[string]main.bigStruct
+          Type: 43 GoMapType map[string]main.bigStruct
           Locations:
             - Range: 0xb81e0..0xb8218
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
@@ -320,7 +320,7 @@ Subprograms:
           RootRanges: [0xb7a00..0xb7de0]
       Variables:
         - Name: ptr
-          Type: 63 PointerType *****int
+          Type: 48 PointerType *****int
           Locations:
             - Range: 0xb7d38..0xb7d7c
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
@@ -334,7 +334,7 @@ Subprograms:
           RootRanges: [0xb7a00..0xb7de0]
       Variables:
         - Name: ptr
-          Type: 66 PointerType **int
+          Type: 50 PointerType **int
           Locations:
             - Range: 0xb7d94..0xb7dc0
               Pieces: [{Size: 8, Op: {RegNo: 5, Shift: 0}}]
@@ -342,28 +342,28 @@ Subprograms:
           IsReturn: false
 Types:
     - __kind: PointerType
-      ID: 63
+      ID: 48
       Name: '*****int'
       ByteSize: 8
       GoRuntimeType: 36288
       GoKind: 22
-      Pointee: 64 PointerType ****int
+      Pointee: 49 PointerType ****int
     - __kind: PointerType
-      ID: 64
+      ID: 49
       Name: '****int'
       ByteSize: 8
       GoRuntimeType: 36224
       GoKind: 22
-      Pointee: 65 PointerType ***int
+      Pointee: 53 PointerType ***int
     - __kind: PointerType
-      ID: 65
+      ID: 53
       Name: '***int'
       ByteSize: 8
       GoRuntimeType: 36160
       GoKind: 22
-      Pointee: 66 PointerType **int
+      Pointee: 50 PointerType **int
     - __kind: PointerType
-      ID: 66
+      ID: 50
       Name: '**int'
       ByteSize: 8
       GoRuntimeType: 36096
@@ -375,10 +375,10 @@ Types:
       ByteSize: 8
       Pointee: 42 PointerType *table<string,int>
     - __kind: PointerType
-      ID: 52
+      ID: 46
       Name: '**table<string,main.bigStruct>'
       ByteSize: 8
-      Pointee: 53 PointerType *table<string,main.bigStruct>
+      Pointee: 47 PointerType *table<string,main.bigStruct>
     - __kind: PointerType
       ID: 70
       Name: '*[]int.array'
@@ -439,32 +439,32 @@ Types:
       GoKind: 22
       Pointee: 13 BaseType int64
     - __kind: PointerType
-      ID: 60
+      ID: 64
       Name: '*main.bigStruct'
       ByteSize: 8
       GoRuntimeType: 27776
       GoKind: 22
-      Pointee: 61 StructureType main.bigStruct
+      Pointee: 65 StructureType main.bigStruct
     - __kind: PointerType
       ID: 39
       Name: '*map<string,int>'
       ByteSize: 8
       Pointee: 40 GoSwissMapHeaderType map<string,int>
     - __kind: PointerType
-      ID: 50
+      ID: 44
       Name: '*map<string,main.bigStruct>'
       ByteSize: 8
-      Pointee: 51 GoSwissMapHeaderType map<string,main.bigStruct>
+      Pointee: 45 GoSwissMapHeaderType map<string,main.bigStruct>
     - __kind: PointerType
-      ID: 45
+      ID: 55
       Name: '*noalg.map.group[string]int'
       ByteSize: 8
-      Pointee: 46 StructureType noalg.map.group[string]int
+      Pointee: 56 StructureType noalg.map.group[string]int
     - __kind: PointerType
-      ID: 56
+      ID: 58
       Name: '*noalg.map.group[string]main.bigStruct'
       ByteSize: 8
-      Pointee: 57 StructureType noalg.map.group[string]main.bigStruct
+      Pointee: 59 StructureType noalg.map.group[string]main.bigStruct
     - __kind: PointerType
       ID: 22
       Name: '*string'
@@ -481,12 +481,12 @@ Types:
       ID: 42
       Name: '*table<string,int>'
       ByteSize: 8
-      Pointee: 43 StructureType table<string,int>
+      Pointee: 51 StructureType table<string,int>
     - __kind: PointerType
-      ID: 53
+      ID: 47
       Name: '*table<string,main.bigStruct>'
       ByteSize: 8
-      Pointee: 54 StructureType table<string,main.bigStruct>
+      Pointee: 52 StructureType table<string,main.bigStruct>
     - __kind: PointerType
       ID: 32
       Name: '*uint'
@@ -538,7 +538,7 @@ Types:
         - Name: ptr
           Offset: 1
           Expression:
-            Type: 63 PointerType *****int
+            Type: 48 PointerType *****int
             Operations:
                 - __kind: LocationOp
                   Variable: {subprogram: 11, index: 0, name: ptr}
@@ -553,7 +553,7 @@ Types:
         - Name: ptr
           Offset: 1
           Expression:
-            Type: 66 PointerType **int
+            Type: 50 PointerType **int
             Operations:
                 - __kind: LocationOp
                   Variable: {subprogram: 12, index: 0, name: ptr}
@@ -568,7 +568,7 @@ Types:
         - Name: m
           Offset: 1
           Expression:
-            Type: 49 GoMapType map[string]main.bigStruct
+            Type: 43 GoMapType map[string]main.bigStruct
             Operations:
                 - __kind: LocationOp
                   Variable: {subprogram: 9, index: 0, name: m}
@@ -710,7 +710,7 @@ Types:
                   Offset: 0
                   ByteSize: 24
     - __kind: ArrayType
-      ID: 62
+      ID: 66
       Name: '[128]uint8'
       ByteSize: 128
       GoRuntimeType: 47648
@@ -745,7 +745,7 @@ Types:
       ID: 75
       Name: '[]*table<string,main.bigStruct>.array'
       ByteSize: 8192
-      Element: 53 PointerType *table<string,main.bigStruct>
+      Element: 47 PointerType *table<string,main.bigStruct>
     - __kind: GoSliceHeaderType
       ID: 34
       Name: '[]int'
@@ -772,12 +772,12 @@ Types:
       ID: 74
       Name: '[]noalg.map.group[string]int.array'
       ByteSize: 2048
-      Element: 46 StructureType noalg.map.group[string]int
+      Element: 56 StructureType noalg.map.group[string]int
     - __kind: GoSliceDataType
       ID: 76
       Name: '[]noalg.map.group[string]main.bigStruct.array'
       ByteSize: 2048
-      Element: 57 StructureType noalg.map.group[string]main.bigStruct
+      Element: 59 StructureType noalg.map.group[string]main.bigStruct
     - __kind: GoSliceHeaderType
       ID: 36
       Name: '[]string'
@@ -844,32 +844,32 @@ Types:
       GoRuntimeType: 43680
       GoKind: 14
     - __kind: GoSwissMapGroupsType
-      ID: 44
+      ID: 54
       Name: groupReference<string,int>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 45 PointerType *noalg.map.group[string]int
+          Type: 55 PointerType *noalg.map.group[string]int
         - Name: lengthMask
           Offset: 8
           Type: 8 BaseType uint64
-      GroupType: 46 StructureType noalg.map.group[string]int
+      GroupType: 56 StructureType noalg.map.group[string]int
       GroupSliceType: 74 GoSliceDataType []noalg.map.group[string]int.array
     - __kind: GoSwissMapGroupsType
-      ID: 55
+      ID: 57
       Name: groupReference<string,main.bigStruct>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 56 PointerType *noalg.map.group[string]main.bigStruct
+          Type: 58 PointerType *noalg.map.group[string]main.bigStruct
         - Name: lengthMask
           Offset: 8
           Type: 8 BaseType uint64
-      GroupType: 57 StructureType noalg.map.group[string]main.bigStruct
+      GroupType: 59 StructureType noalg.map.group[string]main.bigStruct
       GroupSliceType: 76 GoSliceDataType []noalg.map.group[string]main.bigStruct.array
     - __kind: BaseType
       ID: 7
@@ -902,7 +902,7 @@ Types:
       GoRuntimeType: 42784
       GoKind: 3
     - __kind: StructureType
-      ID: 61
+      ID: 65
       Name: main.bigStruct
       ByteSize: 184
       GoRuntimeType: 124608
@@ -931,7 +931,7 @@ Types:
           Type: 7 BaseType int
         - Name: data
           Offset: 56
-          Type: 62 ArrayType [128]uint8
+          Type: 66 ArrayType [128]uint8
     - __kind: GoSwissMapHeaderType
       ID: 40
       Name: map<string,int>
@@ -966,9 +966,9 @@ Types:
           Offset: 40
           Type: 8 BaseType uint64
       TablePtrSliceType: 73 GoSliceDataType []*table<string,int>.array
-      GroupType: 46 StructureType noalg.map.group[string]int
+      GroupType: 56 StructureType noalg.map.group[string]int
     - __kind: GoSwissMapHeaderType
-      ID: 51
+      ID: 45
       Name: map<string,main.bigStruct>
       ByteSize: 48
       GoKind: 25
@@ -981,7 +981,7 @@ Types:
           Type: 1 BaseType uintptr
         - Name: dirPtr
           Offset: 16
-          Type: 52 PointerType **table<string,main.bigStruct>
+          Type: 46 PointerType **table<string,main.bigStruct>
         - Name: dirLen
           Offset: 24
           Type: 7 BaseType int
@@ -1001,7 +1001,7 @@ Types:
           Offset: 40
           Type: 8 BaseType uint64
       TablePtrSliceType: 75 GoSliceDataType []*table<string,main.bigStruct>.array
-      GroupType: 57 StructureType noalg.map.group[string]main.bigStruct
+      GroupType: 59 StructureType noalg.map.group[string]main.bigStruct
     - __kind: GoMapType
       ID: 38
       Name: map[string]int
@@ -1010,32 +1010,32 @@ Types:
       GoKind: 21
       HeaderType: 40 GoSwissMapHeaderType map<string,int>
     - __kind: GoMapType
-      ID: 49
+      ID: 43
       Name: map[string]main.bigStruct
       ByteSize: 8
       GoRuntimeType: 70080
       GoKind: 21
-      HeaderType: 51 GoSwissMapHeaderType map<string,main.bigStruct>
+      HeaderType: 45 GoSwissMapHeaderType map<string,main.bigStruct>
     - __kind: ArrayType
-      ID: 58
+      ID: 62
       Name: noalg.[8]struct { key string; elem *main.bigStruct }
       ByteSize: 192
       GoRuntimeType: 47744
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 59 StructureType noalg.struct { key string; elem *main.bigStruct }
+      Element: 63 StructureType noalg.struct { key string; elem *main.bigStruct }
     - __kind: ArrayType
-      ID: 47
+      ID: 60
       Name: noalg.[8]struct { key string; elem int }
       ByteSize: 192
       GoRuntimeType: 47552
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 48 StructureType noalg.struct { key string; elem int }
+      Element: 61 StructureType noalg.struct { key string; elem int }
     - __kind: StructureType
-      ID: 46
+      ID: 56
       Name: noalg.map.group[string]int
       ByteSize: 200
       GoRuntimeType: 77120
@@ -1046,9 +1046,9 @@ Types:
           Type: 8 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 47 ArrayType noalg.[8]struct { key string; elem int }
+          Type: 60 ArrayType noalg.[8]struct { key string; elem int }
     - __kind: StructureType
-      ID: 57
+      ID: 59
       Name: noalg.map.group[string]main.bigStruct
       ByteSize: 200
       GoRuntimeType: 77376
@@ -1059,9 +1059,9 @@ Types:
           Type: 8 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 58 ArrayType noalg.[8]struct { key string; elem *main.bigStruct }
+          Type: 62 ArrayType noalg.[8]struct { key string; elem *main.bigStruct }
     - __kind: StructureType
-      ID: 59
+      ID: 63
       Name: noalg.struct { key string; elem *main.bigStruct }
       ByteSize: 24
       GoRuntimeType: 77248
@@ -1072,9 +1072,9 @@ Types:
           Type: 9 GoStringHeaderType string
         - Name: elem
           Offset: 16
-          Type: 60 PointerType *main.bigStruct
+          Type: 64 PointerType *main.bigStruct
     - __kind: StructureType
-      ID: 48
+      ID: 61
       Name: noalg.struct { key string; elem int }
       ByteSize: 24
       GoRuntimeType: 76992
@@ -1105,7 +1105,7 @@ Types:
       Name: string.str
       ByteSize: 2048
     - __kind: StructureType
-      ID: 43
+      ID: 51
       Name: table<string,int>
       ByteSize: 32
       GoKind: 25
@@ -1127,9 +1127,9 @@ Types:
           Type: 7 BaseType int
         - Name: groups
           Offset: 16
-          Type: 44 GoSwissMapGroupsType groupReference<string,int>
+          Type: 54 GoSwissMapGroupsType groupReference<string,int>
     - __kind: StructureType
-      ID: 54
+      ID: 52
       Name: table<string,main.bigStruct>
       ByteSize: 32
       GoKind: 25
@@ -1151,7 +1151,7 @@ Types:
           Type: 7 BaseType int
         - Name: groups
           Offset: 16
-          Type: 55 GoSwissMapGroupsType groupReference<string,main.bigStruct>
+          Type: 57 GoSwissMapGroupsType groupReference<string,main.bigStruct>
     - __kind: BaseType
       ID: 10
       Name: uint

--- a/pkg/dyninst/irgen/testdata/snapshot/simple.arch=arm64,toolchain=go1.25.0.yaml
+++ b/pkg/dyninst/irgen/testdata/snapshot/simple.arch=arm64,toolchain=go1.25.0.yaml
@@ -354,9 +354,9 @@ Types:
       ByteSize: 8
       GoRuntimeType: 36224
       GoKind: 22
-      Pointee: 53 PointerType ***int
+      Pointee: 75 PointerType ***int
     - __kind: PointerType
-      ID: 53
+      ID: 75
       Name: '***int'
       ByteSize: 8
       GoRuntimeType: 36160
@@ -380,15 +380,15 @@ Types:
       ByteSize: 8
       Pointee: 47 PointerType *table<string,main.bigStruct>
     - __kind: PointerType
-      ID: 57
+      ID: 54
       Name: '*[]int.array'
       ByteSize: 8
-      Pointee: 56 GoSliceDataType []int.array
+      Pointee: 53 GoSliceDataType []int.array
     - __kind: PointerType
-      ID: 59
+      ID: 56
       Name: '*[]string.array'
       ByteSize: 8
-      Pointee: 58 GoSliceDataType []string.array
+      Pointee: 55 GoSliceDataType []string.array
     - __kind: PointerType
       ID: 11
       Name: '*bool'
@@ -439,12 +439,12 @@ Types:
       GoKind: 22
       Pointee: 13 BaseType int64
     - __kind: PointerType
-      ID: 72
+      ID: 71
       Name: '*main.bigStruct'
       ByteSize: 8
       GoRuntimeType: 27776
       GoKind: 22
-      Pointee: 73 StructureType main.bigStruct
+      Pointee: 72 StructureType main.bigStruct
     - __kind: PointerType
       ID: 39
       Name: '*map<string,int>'
@@ -456,15 +456,15 @@ Types:
       ByteSize: 8
       Pointee: 45 GoSwissMapHeaderType map<string,main.bigStruct>
     - __kind: PointerType
-      ID: 61
+      ID: 59
       Name: '*noalg.map.group[string]int'
       ByteSize: 8
-      Pointee: 62 StructureType noalg.map.group[string]int
+      Pointee: 60 StructureType noalg.map.group[string]int
     - __kind: PointerType
-      ID: 68
+      ID: 67
       Name: '*noalg.map.group[string]main.bigStruct'
       ByteSize: 8
-      Pointee: 69 StructureType noalg.map.group[string]main.bigStruct
+      Pointee: 68 StructureType noalg.map.group[string]main.bigStruct
     - __kind: PointerType
       ID: 22
       Name: '*string'
@@ -473,20 +473,20 @@ Types:
       GoKind: 22
       Pointee: 9 GoStringHeaderType string
     - __kind: PointerType
-      ID: 55
+      ID: 52
       Name: '*string.str'
       ByteSize: 8
-      Pointee: 54 GoStringDataType string.str
+      Pointee: 51 GoStringDataType string.str
     - __kind: PointerType
       ID: 42
       Name: '*table<string,int>'
       ByteSize: 8
-      Pointee: 51 StructureType table<string,int>
+      Pointee: 57 StructureType table<string,int>
     - __kind: PointerType
       ID: 47
       Name: '*table<string,main.bigStruct>'
       ByteSize: 8
-      Pointee: 52 StructureType table<string,main.bigStruct>
+      Pointee: 65 StructureType table<string,main.bigStruct>
     - __kind: PointerType
       ID: 32
       Name: '*uint'
@@ -737,12 +737,12 @@ Types:
       HasCount: true
       Element: 9 GoStringHeaderType string
     - __kind: GoSliceDataType
-      ID: 65
+      ID: 63
       Name: '[]*table<string,int>.array'
       ByteSize: 8192
       Element: 42 PointerType *table<string,int>
     - __kind: GoSliceDataType
-      ID: 74
+      ID: 73
       Name: '[]*table<string,main.bigStruct>.array'
       ByteSize: 8192
       Element: 47 PointerType *table<string,main.bigStruct>
@@ -762,22 +762,22 @@ Types:
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 56 GoSliceDataType []int.array
+      Data: 53 GoSliceDataType []int.array
     - __kind: GoSliceDataType
-      ID: 56
+      ID: 53
       Name: '[]int.array'
       ByteSize: 2048
       Element: 7 BaseType int
     - __kind: GoSliceDataType
-      ID: 66
+      ID: 64
       Name: '[]noalg.map.group[string]int.array'
       ByteSize: 2048
-      Element: 62 StructureType noalg.map.group[string]int
+      Element: 60 StructureType noalg.map.group[string]int
     - __kind: GoSliceDataType
-      ID: 75
+      ID: 74
       Name: '[]noalg.map.group[string]main.bigStruct.array'
       ByteSize: 2048
-      Element: 69 StructureType noalg.map.group[string]main.bigStruct
+      Element: 68 StructureType noalg.map.group[string]main.bigStruct
     - __kind: GoSliceHeaderType
       ID: 36
       Name: '[]string'
@@ -794,9 +794,9 @@ Types:
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 58 GoSliceDataType []string.array
+      Data: 55 GoSliceDataType []string.array
     - __kind: GoSliceDataType
-      ID: 58
+      ID: 55
       Name: '[]string.array'
       ByteSize: 2048
       Element: 9 GoStringHeaderType string
@@ -844,33 +844,33 @@ Types:
       GoRuntimeType: 43680
       GoKind: 14
     - __kind: GoSwissMapGroupsType
-      ID: 60
+      ID: 58
       Name: groupReference<string,int>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 61 PointerType *noalg.map.group[string]int
+          Type: 59 PointerType *noalg.map.group[string]int
         - Name: lengthMask
           Offset: 8
           Type: 8 BaseType uint64
-      GroupType: 62 StructureType noalg.map.group[string]int
-      GroupSliceType: 66 GoSliceDataType []noalg.map.group[string]int.array
+      GroupType: 60 StructureType noalg.map.group[string]int
+      GroupSliceType: 64 GoSliceDataType []noalg.map.group[string]int.array
     - __kind: GoSwissMapGroupsType
-      ID: 67
+      ID: 66
       Name: groupReference<string,main.bigStruct>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 68 PointerType *noalg.map.group[string]main.bigStruct
+          Type: 67 PointerType *noalg.map.group[string]main.bigStruct
         - Name: lengthMask
           Offset: 8
           Type: 8 BaseType uint64
-      GroupType: 69 StructureType noalg.map.group[string]main.bigStruct
-      GroupSliceType: 75 GoSliceDataType []noalg.map.group[string]main.bigStruct.array
+      GroupType: 68 StructureType noalg.map.group[string]main.bigStruct
+      GroupSliceType: 74 GoSliceDataType []noalg.map.group[string]main.bigStruct.array
     - __kind: BaseType
       ID: 7
       Name: int
@@ -902,7 +902,7 @@ Types:
       GoRuntimeType: 42784
       GoKind: 3
     - __kind: StructureType
-      ID: 73
+      ID: 72
       Name: main.bigStruct
       ByteSize: 184
       GoRuntimeType: 124608
@@ -965,8 +965,8 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 8 BaseType uint64
-      TablePtrSliceType: 65 GoSliceDataType []*table<string,int>.array
-      GroupType: 62 StructureType noalg.map.group[string]int
+      TablePtrSliceType: 63 GoSliceDataType []*table<string,int>.array
+      GroupType: 60 StructureType noalg.map.group[string]int
     - __kind: GoSwissMapHeaderType
       ID: 45
       Name: map<string,main.bigStruct>
@@ -1000,8 +1000,8 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 8 BaseType uint64
-      TablePtrSliceType: 74 GoSliceDataType []*table<string,main.bigStruct>.array
-      GroupType: 69 StructureType noalg.map.group[string]main.bigStruct
+      TablePtrSliceType: 73 GoSliceDataType []*table<string,main.bigStruct>.array
+      GroupType: 68 StructureType noalg.map.group[string]main.bigStruct
     - __kind: GoMapType
       ID: 38
       Name: map[string]int
@@ -1017,25 +1017,25 @@ Types:
       GoKind: 21
       HeaderType: 45 GoSwissMapHeaderType map<string,main.bigStruct>
     - __kind: ArrayType
-      ID: 70
+      ID: 69
       Name: noalg.[8]struct { key string; elem *main.bigStruct }
       ByteSize: 192
       GoRuntimeType: 47744
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 71 StructureType noalg.struct { key string; elem *main.bigStruct }
+      Element: 70 StructureType noalg.struct { key string; elem *main.bigStruct }
     - __kind: ArrayType
-      ID: 63
+      ID: 61
       Name: noalg.[8]struct { key string; elem int }
       ByteSize: 192
       GoRuntimeType: 47552
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 64 StructureType noalg.struct { key string; elem int }
+      Element: 62 StructureType noalg.struct { key string; elem int }
     - __kind: StructureType
-      ID: 62
+      ID: 60
       Name: noalg.map.group[string]int
       ByteSize: 200
       GoRuntimeType: 77120
@@ -1046,9 +1046,9 @@ Types:
           Type: 8 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 63 ArrayType noalg.[8]struct { key string; elem int }
+          Type: 61 ArrayType noalg.[8]struct { key string; elem int }
     - __kind: StructureType
-      ID: 69
+      ID: 68
       Name: noalg.map.group[string]main.bigStruct
       ByteSize: 200
       GoRuntimeType: 77376
@@ -1059,9 +1059,9 @@ Types:
           Type: 8 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 70 ArrayType noalg.[8]struct { key string; elem *main.bigStruct }
+          Type: 69 ArrayType noalg.[8]struct { key string; elem *main.bigStruct }
     - __kind: StructureType
-      ID: 71
+      ID: 70
       Name: noalg.struct { key string; elem *main.bigStruct }
       ByteSize: 24
       GoRuntimeType: 77248
@@ -1072,9 +1072,9 @@ Types:
           Type: 9 GoStringHeaderType string
         - Name: elem
           Offset: 16
-          Type: 72 PointerType *main.bigStruct
+          Type: 71 PointerType *main.bigStruct
     - __kind: StructureType
-      ID: 64
+      ID: 62
       Name: noalg.struct { key string; elem int }
       ByteSize: 24
       GoRuntimeType: 76992
@@ -1095,17 +1095,17 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 55 PointerType *string.str
+          Type: 52 PointerType *string.str
         - Name: len
           Offset: 8
           Type: 7 BaseType int
-      Data: 54 GoStringDataType string.str
+      Data: 51 GoStringDataType string.str
     - __kind: GoStringDataType
-      ID: 54
+      ID: 51
       Name: string.str
       ByteSize: 2048
     - __kind: StructureType
-      ID: 51
+      ID: 57
       Name: table<string,int>
       ByteSize: 32
       GoKind: 25
@@ -1127,9 +1127,9 @@ Types:
           Type: 7 BaseType int
         - Name: groups
           Offset: 16
-          Type: 60 GoSwissMapGroupsType groupReference<string,int>
+          Type: 58 GoSwissMapGroupsType groupReference<string,int>
     - __kind: StructureType
-      ID: 52
+      ID: 65
       Name: table<string,main.bigStruct>
       ByteSize: 32
       GoKind: 25
@@ -1151,7 +1151,7 @@ Types:
           Type: 7 BaseType int
         - Name: groups
           Offset: 16
-          Type: 67 GoSwissMapGroupsType groupReference<string,main.bigStruct>
+          Type: 66 GoSwissMapGroupsType groupReference<string,main.bigStruct>
     - __kind: BaseType
       ID: 10
       Name: uint

--- a/pkg/dyninst/irgen/testdata/snapshot/simple.arch=arm64,toolchain=go1.25.0.yaml
+++ b/pkg/dyninst/irgen/testdata/snapshot/simple.arch=arm64,toolchain=go1.25.0.yaml
@@ -15,7 +15,7 @@ Probes:
       events:
         - ID: 11
           Type: 87 EventRootType Probe[main.PointerChainArg]
-          InjectionPoints: [{PC: 752992, Frameless: false}]
+          InjectionPoints: [{PC: "0xb7d60", Frameless: false}]
           Condition: null
     - id: PointerSmallChainArg
       version: 0
@@ -32,7 +32,7 @@ Probes:
       events:
         - ID: 12
           Type: 88 EventRootType Probe[main.PointerSmallChainArg]
-          InjectionPoints: [{PC: 753044, Frameless: false}]
+          InjectionPoints: [{PC: "0xb7d94", Frameless: false}]
           Condition: null
     - id: bigMapArg
       version: 0
@@ -45,7 +45,7 @@ Probes:
       events:
         - ID: 9
           Type: 85 EventRootType Probe[main.bigMapArg]
-          InjectionPoints: [{PC: 754160, Frameless: true}]
+          InjectionPoints: [{PC: "0xb81f0", Frameless: true}]
           Condition: null
     - id: inlined
       version: 0
@@ -60,9 +60,9 @@ Probes:
         - ID: 10
           Type: 86 EventRootType Probe[main.inlined]
           InjectionPoints:
-            - PC: 753852
+            - PC: "0xb80bc"
               Frameless: true
-            - PC: 752520
+            - PC: "0xb7b88"
               Frameless: false
           Condition: null
     - id: intArg
@@ -76,7 +76,7 @@ Probes:
       events:
         - ID: 1
           Type: 77 EventRootType Probe[main.intArg]
-          InjectionPoints: [{PC: 753132, Frameless: true}]
+          InjectionPoints: [{PC: "0xb7dec", Frameless: true}]
           Condition: null
     - id: intArrayArg
       version: 0
@@ -89,7 +89,7 @@ Probes:
       events:
         - ID: 4
           Type: 80 EventRootType Probe[main.intArrayArg]
-          InjectionPoints: [{PC: 753484, Frameless: true}]
+          InjectionPoints: [{PC: "0xb7f4c", Frameless: true}]
           Condition: null
     - id: intArrayArgFrameless
       version: 0
@@ -102,7 +102,7 @@ Probes:
       events:
         - ID: 7
           Type: 83 EventRootType Probe[main.stringArrayArgFrameless]
-          InjectionPoints: [{PC: 753824, Frameless: true}]
+          InjectionPoints: [{PC: "0xb80a0", Frameless: true}]
           Condition: null
     - id: intSliceArg
       version: 0
@@ -115,7 +115,7 @@ Probes:
       events:
         - ID: 3
           Type: 79 EventRootType Probe[main.intSliceArg]
-          InjectionPoints: [{PC: 753356, Frameless: true}]
+          InjectionPoints: [{PC: "0xb7ecc", Frameless: true}]
           Condition: null
     - id: mapArg
       version: 0
@@ -128,7 +128,7 @@ Probes:
       events:
         - ID: 8
           Type: 84 EventRootType Probe[main.mapArg]
-          InjectionPoints: [{PC: 754044, Frameless: true}]
+          InjectionPoints: [{PC: "0xb817c", Frameless: true}]
           Condition: null
     - id: stringArg
       version: 0
@@ -141,7 +141,7 @@ Probes:
       events:
         - ID: 2
           Type: 78 EventRootType Probe[main.stringArg]
-          InjectionPoints: [{PC: 753244, Frameless: true}]
+          InjectionPoints: [{PC: "0xb7e5c", Frameless: true}]
           Condition: null
     - id: stringArrayArg
       version: 0
@@ -154,7 +154,7 @@ Probes:
       events:
         - ID: 6
           Type: 82 EventRootType Probe[main.stringArrayArg]
-          InjectionPoints: [{PC: 753724, Frameless: true}]
+          InjectionPoints: [{PC: "0xb803c", Frameless: true}]
           Condition: null
     - id: stringSliceArg
       version: 0
@@ -167,7 +167,7 @@ Probes:
       events:
         - ID: 5
           Type: 81 EventRootType Probe[main.stringSliceArg]
-          InjectionPoints: [{PC: 753596, Frameless: true}]
+          InjectionPoints: [{PC: "0xb7fbc", Frameless: true}]
           Condition: null
 Subprograms:
     - ID: 4
@@ -341,12 +341,6 @@ Subprograms:
           IsParameter: true
           IsReturn: false
 Types:
-    - __kind: BaseType
-      ID: 1
-      Name: int
-      ByteSize: 8
-      GoRuntimeType: 43296
-      GoKind: 2
     - __kind: PointerType
       ID: 2
       Name: '*****int'
@@ -376,26 +370,151 @@ Types:
       GoKind: 22
       Pointee: 6 PointerType *int
     - __kind: PointerType
+      ID: 20
+      Name: '**table<string,int>'
+      ByteSize: 8
+      Pointee: 21 PointerType *table<string,int>
+    - __kind: PointerType
+      ID: 33
+      Name: '**table<string,main.bigStruct>'
+      ByteSize: 8
+      Pointee: 34 PointerType *table<string,main.bigStruct>
+    - __kind: PointerType
+      ID: 70
+      Name: '*[]int.array'
+      ByteSize: 8
+      Pointee: 69 GoSliceDataType []int.array
+    - __kind: PointerType
+      ID: 72
+      Name: '*[]string.array'
+      ByteSize: 8
+      Pointee: 71 GoSliceDataType []string.array
+    - __kind: PointerType
+      ID: 46
+      Name: '*bool'
+      ByteSize: 8
+      GoRuntimeType: 30400
+      GoKind: 22
+      Pointee: 29 BaseType bool
+    - __kind: PointerType
+      ID: 63
+      Name: '*error'
+      ByteSize: 8
+      GoRuntimeType: 29312
+      GoKind: 22
+      Pointee: 49 GoInterfaceType error
+    - __kind: PointerType
+      ID: 64
+      Name: '*float32'
+      ByteSize: 8
+      GoRuntimeType: 30272
+      GoKind: 22
+      Pointee: 53 BaseType float32
+    - __kind: PointerType
+      ID: 60
+      Name: '*float64'
+      ByteSize: 8
+      GoRuntimeType: 30336
+      GoKind: 22
+      Pointee: 51 BaseType float64
+    - __kind: PointerType
       ID: 6
       Name: '*int'
       ByteSize: 8
       GoRuntimeType: 29952
       GoKind: 22
       Pointee: 1 BaseType int
-    - __kind: GoStringHeaderType
-      ID: 7
-      Name: string
-      ByteSize: 16
-      GoRuntimeType: 42720
-      GoKind: 24
-      RawFields:
-        - Name: str
-          Offset: 0
-          Type: 68 PointerType *string.str
-        - Name: len
-          Offset: 8
-          Type: 1 BaseType int
-      Data: 67 GoStringDataType string.str
+    - __kind: PointerType
+      ID: 55
+      Name: '*int32'
+      ByteSize: 8
+      GoRuntimeType: 29696
+      GoKind: 22
+      Pointee: 47 BaseType int32
+    - __kind: PointerType
+      ID: 62
+      Name: '*int64'
+      ByteSize: 8
+      GoRuntimeType: 29824
+      GoKind: 22
+      Pointee: 48 BaseType int64
+    - __kind: PointerType
+      ID: 41
+      Name: '*main.bigStruct'
+      ByteSize: 8
+      GoRuntimeType: 27776
+      GoKind: 22
+      Pointee: 42 StructureType main.bigStruct
+    - __kind: PointerType
+      ID: 16
+      Name: '*map<string,int>'
+      ByteSize: 8
+      Pointee: 17 GoSwissMapHeaderType map<string,int>
+    - __kind: PointerType
+      ID: 31
+      Name: '*map<string,main.bigStruct>'
+      ByteSize: 8
+      Pointee: 32 GoSwissMapHeaderType map<string,main.bigStruct>
+    - __kind: PointerType
+      ID: 25
+      Name: '*noalg.map.group[string]int'
+      ByteSize: 8
+      Pointee: 26 StructureType noalg.map.group[string]int
+    - __kind: PointerType
+      ID: 37
+      Name: '*noalg.map.group[string]main.bigStruct'
+      ByteSize: 8
+      Pointee: 38 StructureType noalg.map.group[string]main.bigStruct
+    - __kind: PointerType
+      ID: 13
+      Name: '*string'
+      ByteSize: 8
+      GoRuntimeType: 29376
+      GoKind: 22
+      Pointee: 7 GoStringHeaderType string
+    - __kind: PointerType
+      ID: 68
+      Name: '*string.str'
+      ByteSize: 8
+      Pointee: 67 GoStringDataType string.str
+    - __kind: PointerType
+      ID: 21
+      Name: '*table<string,int>'
+      ByteSize: 8
+      Pointee: 22 StructureType table<string,int>
+    - __kind: PointerType
+      ID: 34
+      Name: '*table<string,main.bigStruct>'
+      ByteSize: 8
+      Pointee: 35 StructureType table<string,main.bigStruct>
+    - __kind: PointerType
+      ID: 65
+      Name: '*uint'
+      ByteSize: 8
+      GoRuntimeType: 30016
+      GoKind: 22
+      Pointee: 45 BaseType uint
+    - __kind: PointerType
+      ID: 66
+      Name: '*uint16'
+      ByteSize: 8
+      GoRuntimeType: 29632
+      GoKind: 22
+      Pointee: 23 BaseType uint16
+    - __kind: PointerType
+      ID: 56
+      Name: '*uint32'
+      ByteSize: 8
+      GoRuntimeType: 29760
+      GoKind: 22
+      Pointee: 44 BaseType uint32
+    - __kind: PointerType
+      ID: 61
+      Name: '*uint64'
+      ByteSize: 8
+      GoRuntimeType: 29888
+      GoKind: 22
+      Pointee: 18 BaseType uint64
     - __kind: PointerType
       ID: 8
       Name: '*uint8'
@@ -403,12 +522,230 @@ Types:
       GoRuntimeType: 29504
       GoKind: 22
       Pointee: 9 BaseType uint8
-    - __kind: BaseType
-      ID: 9
-      Name: uint8
-      ByteSize: 1
-      GoRuntimeType: 42848
-      GoKind: 8
+    - __kind: PointerType
+      ID: 54
+      Name: '*uintptr'
+      ByteSize: 8
+      GoRuntimeType: 30080
+      GoKind: 22
+      Pointee: 19 BaseType uintptr
+    - __kind: EventRootType
+      ID: 87
+      Name: Probe[main.PointerChainArg]
+      ByteSize: 9
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: ptr
+          Offset: 1
+          Expression:
+            Type: 2 PointerType *****int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 2, index: 0, name: ptr}
+                  Offset: 0
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 88
+      Name: Probe[main.PointerSmallChainArg]
+      ByteSize: 9
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: ptr
+          Offset: 1
+          Expression:
+            Type: 5 PointerType **int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 3, index: 0, name: ptr}
+                  Offset: 0
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 85
+      Name: Probe[main.bigMapArg]
+      ByteSize: 9
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: m
+          Offset: 1
+          Expression:
+            Type: 30 GoMapType map[string]main.bigStruct
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 12, index: 0, name: m}
+                  Offset: 0
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 86
+      Name: Probe[main.inlined]
+      ByteSize: 9
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: x
+          Offset: 1
+          Expression:
+            Type: 1 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 1, index: 0, name: x}
+                  Offset: 0
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 77
+      Name: Probe[main.intArg]
+      ByteSize: 9
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: x
+          Offset: 1
+          Expression:
+            Type: 1 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 4, index: 0, name: x}
+                  Offset: 0
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 80
+      Name: Probe[main.intArrayArg]
+      ByteSize: 25
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: s
+          Offset: 1
+          Expression:
+            Type: 11 ArrayType [3]int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 7, index: 0, name: s}
+                  Offset: 0
+                  ByteSize: 24
+    - __kind: EventRootType
+      ID: 79
+      Name: Probe[main.intSliceArg]
+      ByteSize: 25
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: s
+          Offset: 1
+          Expression:
+            Type: 10 GoSliceHeaderType []int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 6, index: 0, name: s}
+                  Offset: 0
+                  ByteSize: 24
+    - __kind: EventRootType
+      ID: 84
+      Name: Probe[main.mapArg]
+      ByteSize: 9
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: m
+          Offset: 1
+          Expression:
+            Type: 15 GoMapType map[string]int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 11, index: 0, name: m}
+                  Offset: 0
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 78
+      Name: Probe[main.stringArg]
+      ByteSize: 17
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: s
+          Offset: 1
+          Expression:
+            Type: 7 GoStringHeaderType string
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 5, index: 0, name: s}
+                  Offset: 0
+                  ByteSize: 16
+    - __kind: EventRootType
+      ID: 83
+      Name: Probe[main.stringArrayArgFrameless]
+      ByteSize: 49
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: s
+          Offset: 1
+          Expression:
+            Type: 14 ArrayType [3]string
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 10, index: 0, name: s}
+                  Offset: 0
+                  ByteSize: 48
+    - __kind: EventRootType
+      ID: 82
+      Name: Probe[main.stringArrayArg]
+      ByteSize: 49
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: s
+          Offset: 1
+          Expression:
+            Type: 14 ArrayType [3]string
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 9, index: 0, name: s}
+                  Offset: 0
+                  ByteSize: 48
+    - __kind: EventRootType
+      ID: 81
+      Name: Probe[main.stringSliceArg]
+      ByteSize: 25
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: s
+          Offset: 1
+          Expression:
+            Type: 12 GoSliceHeaderType []string
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 8, index: 0, name: s}
+                  Offset: 0
+                  ByteSize: 24
+    - __kind: ArrayType
+      ID: 43
+      Name: '[128]uint8'
+      ByteSize: 128
+      GoRuntimeType: 47648
+      GoKind: 17
+      Count: 128
+      HasCount: true
+      Element: 9 BaseType uint8
+    - __kind: ArrayType
+      ID: 11
+      Name: '[3]int'
+      ByteSize: 24
+      GoRuntimeType: 47360
+      GoKind: 17
+      Count: 3
+      HasCount: true
+      Element: 1 BaseType int
+    - __kind: ArrayType
+      ID: 14
+      Name: '[3]string'
+      ByteSize: 48
+      GoRuntimeType: 47456
+      GoKind: 17
+      Count: 3
+      HasCount: true
+      Element: 7 GoStringHeaderType string
+    - __kind: GoSliceDataType
+      ID: 73
+      Name: '[]*table<string,int>.array'
+      ByteSize: 8192
+      Element: 21 PointerType *table<string,int>
+    - __kind: GoSliceDataType
+      ID: 75
+      Name: '[]*table<string,main.bigStruct>.array'
+      ByteSize: 8192
+      Element: 34 PointerType *table<string,main.bigStruct>
     - __kind: GoSliceHeaderType
       ID: 10
       Name: '[]int'
@@ -426,15 +763,21 @@ Types:
           Offset: 16
           Type: 1 BaseType int
       Data: 69 GoSliceDataType []int.array
-    - __kind: ArrayType
-      ID: 11
-      Name: '[3]int'
-      ByteSize: 24
-      GoRuntimeType: 47360
-      GoKind: 17
-      Count: 3
-      HasCount: true
+    - __kind: GoSliceDataType
+      ID: 69
+      Name: '[]int.array'
+      ByteSize: 2048
       Element: 1 BaseType int
+    - __kind: GoSliceDataType
+      ID: 74
+      Name: '[]noalg.map.group[string]int.array'
+      ByteSize: 2048
+      Element: 26 StructureType noalg.map.group[string]int
+    - __kind: GoSliceDataType
+      ID: 76
+      Name: '[]noalg.map.group[string]main.bigStruct.array'
+      ByteSize: 2048
+      Element: 38 StructureType noalg.map.group[string]main.bigStruct
     - __kind: GoSliceHeaderType
       ID: 12
       Name: '[]string'
@@ -452,34 +795,143 @@ Types:
           Offset: 16
           Type: 1 BaseType int
       Data: 71 GoSliceDataType []string.array
-    - __kind: PointerType
-      ID: 13
-      Name: '*string'
-      ByteSize: 8
-      GoRuntimeType: 29376
-      GoKind: 22
-      Pointee: 7 GoStringHeaderType string
-    - __kind: ArrayType
-      ID: 14
-      Name: '[3]string'
-      ByteSize: 48
-      GoRuntimeType: 47456
-      GoKind: 17
-      Count: 3
-      HasCount: true
+    - __kind: GoSliceDataType
+      ID: 71
+      Name: '[]string.array'
+      ByteSize: 2048
       Element: 7 GoStringHeaderType string
-    - __kind: GoMapType
-      ID: 15
-      Name: map[string]int
+    - __kind: BaseType
+      ID: 29
+      Name: bool
+      ByteSize: 1
+      GoRuntimeType: 43744
+      GoKind: 1
+    - __kind: BaseType
+      ID: 59
+      Name: complex128
+      ByteSize: 16
+      GoRuntimeType: 43552
+      GoKind: 16
+    - __kind: BaseType
+      ID: 58
+      Name: complex64
       ByteSize: 8
-      GoRuntimeType: 69952
-      GoKind: 21
-      HeaderType: 17 GoSwissMapHeaderType map<string,int>
-    - __kind: PointerType
-      ID: 16
-      Name: '*map<string,int>'
+      GoRuntimeType: 43488
+      GoKind: 15
+    - __kind: GoInterfaceType
+      ID: 49
+      Name: error
+      ByteSize: 16
+      GoRuntimeType: 65728
+      GoKind: 20
+      RawFields:
+        - Name: tab
+          Offset: 0
+          Type: 50 VoidPointerType unsafe.Pointer
+        - Name: data
+          Offset: 8
+          Type: 50 VoidPointerType unsafe.Pointer
+    - __kind: BaseType
+      ID: 53
+      Name: float32
+      ByteSize: 4
+      GoRuntimeType: 43616
+      GoKind: 13
+    - __kind: BaseType
+      ID: 51
+      Name: float64
       ByteSize: 8
-      Pointee: 17 GoSwissMapHeaderType map<string,int>
+      GoRuntimeType: 43680
+      GoKind: 14
+    - __kind: GoSwissMapGroupsType
+      ID: 24
+      Name: groupReference<string,int>
+      ByteSize: 16
+      GoKind: 25
+      RawFields:
+        - Name: data
+          Offset: 0
+          Type: 25 PointerType *noalg.map.group[string]int
+        - Name: lengthMask
+          Offset: 8
+          Type: 18 BaseType uint64
+      GroupType: 26 StructureType noalg.map.group[string]int
+      GroupSliceType: 74 GoSliceDataType []noalg.map.group[string]int.array
+    - __kind: GoSwissMapGroupsType
+      ID: 36
+      Name: groupReference<string,main.bigStruct>
+      ByteSize: 16
+      GoKind: 25
+      RawFields:
+        - Name: data
+          Offset: 0
+          Type: 37 PointerType *noalg.map.group[string]main.bigStruct
+        - Name: lengthMask
+          Offset: 8
+          Type: 18 BaseType uint64
+      GroupType: 38 StructureType noalg.map.group[string]main.bigStruct
+      GroupSliceType: 76 GoSliceDataType []noalg.map.group[string]main.bigStruct.array
+    - __kind: BaseType
+      ID: 1
+      Name: int
+      ByteSize: 8
+      GoRuntimeType: 43296
+      GoKind: 2
+    - __kind: BaseType
+      ID: 57
+      Name: int16
+      ByteSize: 2
+      GoRuntimeType: 42912
+      GoKind: 4
+    - __kind: BaseType
+      ID: 47
+      Name: int32
+      ByteSize: 4
+      GoRuntimeType: 43040
+      GoKind: 5
+    - __kind: BaseType
+      ID: 48
+      Name: int64
+      ByteSize: 8
+      GoRuntimeType: 43168
+      GoKind: 6
+    - __kind: BaseType
+      ID: 52
+      Name: int8
+      ByteSize: 1
+      GoRuntimeType: 42784
+      GoKind: 3
+    - __kind: StructureType
+      ID: 42
+      Name: main.bigStruct
+      ByteSize: 184
+      GoRuntimeType: 124608
+      GoKind: 25
+      RawFields:
+        - Name: Field1
+          Offset: 0
+          Type: 1 BaseType int
+        - Name: Field2
+          Offset: 8
+          Type: 1 BaseType int
+        - Name: Field3
+          Offset: 16
+          Type: 1 BaseType int
+        - Name: Field4
+          Offset: 24
+          Type: 1 BaseType int
+        - Name: Field5
+          Offset: 32
+          Type: 1 BaseType int
+        - Name: Field6
+          Offset: 40
+          Type: 1 BaseType int
+        - Name: Field7
+          Offset: 48
+          Type: 1 BaseType int
+        - Name: data
+          Offset: 56
+          Type: 43 ArrayType [128]uint8
     - __kind: GoSwissMapHeaderType
       ID: 17
       Name: map<string,int>
@@ -515,130 +967,6 @@ Types:
           Type: 18 BaseType uint64
       TablePtrSliceType: 73 GoSliceDataType []*table<string,int>.array
       GroupType: 26 StructureType noalg.map.group[string]int
-    - __kind: BaseType
-      ID: 18
-      Name: uint64
-      ByteSize: 8
-      GoRuntimeType: 43232
-      GoKind: 11
-    - __kind: BaseType
-      ID: 19
-      Name: uintptr
-      ByteSize: 8
-      GoRuntimeType: 43424
-      GoKind: 12
-    - __kind: PointerType
-      ID: 20
-      Name: '**table<string,int>'
-      ByteSize: 8
-      Pointee: 21 PointerType *table<string,int>
-    - __kind: PointerType
-      ID: 21
-      Name: '*table<string,int>'
-      ByteSize: 8
-      Pointee: 22 StructureType table<string,int>
-    - __kind: StructureType
-      ID: 22
-      Name: table<string,int>
-      ByteSize: 32
-      GoKind: 25
-      RawFields:
-        - Name: used
-          Offset: 0
-          Type: 23 BaseType uint16
-        - Name: capacity
-          Offset: 2
-          Type: 23 BaseType uint16
-        - Name: growthLeft
-          Offset: 4
-          Type: 23 BaseType uint16
-        - Name: localDepth
-          Offset: 6
-          Type: 9 BaseType uint8
-        - Name: index
-          Offset: 8
-          Type: 1 BaseType int
-        - Name: groups
-          Offset: 16
-          Type: 24 GoSwissMapGroupsType groupReference<string,int>
-    - __kind: BaseType
-      ID: 23
-      Name: uint16
-      ByteSize: 2
-      GoRuntimeType: 42976
-      GoKind: 9
-    - __kind: GoSwissMapGroupsType
-      ID: 24
-      Name: groupReference<string,int>
-      ByteSize: 16
-      GoKind: 25
-      RawFields:
-        - Name: data
-          Offset: 0
-          Type: 25 PointerType *noalg.map.group[string]int
-        - Name: lengthMask
-          Offset: 8
-          Type: 18 BaseType uint64
-      GroupType: 26 StructureType noalg.map.group[string]int
-      GroupSliceType: 74 GoSliceDataType []noalg.map.group[string]int.array
-    - __kind: PointerType
-      ID: 25
-      Name: '*noalg.map.group[string]int'
-      ByteSize: 8
-      Pointee: 26 StructureType noalg.map.group[string]int
-    - __kind: StructureType
-      ID: 26
-      Name: noalg.map.group[string]int
-      ByteSize: 200
-      GoRuntimeType: 77120
-      GoKind: 25
-      RawFields:
-        - Name: ctrl
-          Offset: 0
-          Type: 18 BaseType uint64
-        - Name: slots
-          Offset: 8
-          Type: 27 ArrayType noalg.[8]struct { key string; elem int }
-    - __kind: ArrayType
-      ID: 27
-      Name: noalg.[8]struct { key string; elem int }
-      ByteSize: 192
-      GoRuntimeType: 47552
-      GoKind: 17
-      Count: 8
-      HasCount: true
-      Element: 28 StructureType noalg.struct { key string; elem int }
-    - __kind: StructureType
-      ID: 28
-      Name: noalg.struct { key string; elem int }
-      ByteSize: 24
-      GoRuntimeType: 76992
-      GoKind: 25
-      RawFields:
-        - Name: key
-          Offset: 0
-          Type: 7 GoStringHeaderType string
-        - Name: elem
-          Offset: 16
-          Type: 1 BaseType int
-    - __kind: BaseType
-      ID: 29
-      Name: bool
-      ByteSize: 1
-      GoRuntimeType: 43744
-      GoKind: 1
-    - __kind: GoMapType
-      ID: 30
-      Name: map[string]main.bigStruct
-      ByteSize: 8
-      GoRuntimeType: 70080
-      GoKind: 21
-      HeaderType: 32 GoSwissMapHeaderType map<string,main.bigStruct>
-    - __kind: PointerType
-      ID: 31
-      Name: '*map<string,main.bigStruct>'
-      ByteSize: 8
-      Pointee: 32 GoSwissMapHeaderType map<string,main.bigStruct>
     - __kind: GoSwissMapHeaderType
       ID: 32
       Name: map<string,main.bigStruct>
@@ -674,16 +1002,132 @@ Types:
           Type: 18 BaseType uint64
       TablePtrSliceType: 75 GoSliceDataType []*table<string,main.bigStruct>.array
       GroupType: 38 StructureType noalg.map.group[string]main.bigStruct
-    - __kind: PointerType
-      ID: 33
-      Name: '**table<string,main.bigStruct>'
+    - __kind: GoMapType
+      ID: 15
+      Name: map[string]int
       ByteSize: 8
-      Pointee: 34 PointerType *table<string,main.bigStruct>
-    - __kind: PointerType
-      ID: 34
-      Name: '*table<string,main.bigStruct>'
+      GoRuntimeType: 69952
+      GoKind: 21
+      HeaderType: 17 GoSwissMapHeaderType map<string,int>
+    - __kind: GoMapType
+      ID: 30
+      Name: map[string]main.bigStruct
       ByteSize: 8
-      Pointee: 35 StructureType table<string,main.bigStruct>
+      GoRuntimeType: 70080
+      GoKind: 21
+      HeaderType: 32 GoSwissMapHeaderType map<string,main.bigStruct>
+    - __kind: ArrayType
+      ID: 39
+      Name: noalg.[8]struct { key string; elem *main.bigStruct }
+      ByteSize: 192
+      GoRuntimeType: 47744
+      GoKind: 17
+      Count: 8
+      HasCount: true
+      Element: 40 StructureType noalg.struct { key string; elem *main.bigStruct }
+    - __kind: ArrayType
+      ID: 27
+      Name: noalg.[8]struct { key string; elem int }
+      ByteSize: 192
+      GoRuntimeType: 47552
+      GoKind: 17
+      Count: 8
+      HasCount: true
+      Element: 28 StructureType noalg.struct { key string; elem int }
+    - __kind: StructureType
+      ID: 26
+      Name: noalg.map.group[string]int
+      ByteSize: 200
+      GoRuntimeType: 77120
+      GoKind: 25
+      RawFields:
+        - Name: ctrl
+          Offset: 0
+          Type: 18 BaseType uint64
+        - Name: slots
+          Offset: 8
+          Type: 27 ArrayType noalg.[8]struct { key string; elem int }
+    - __kind: StructureType
+      ID: 38
+      Name: noalg.map.group[string]main.bigStruct
+      ByteSize: 200
+      GoRuntimeType: 77376
+      GoKind: 25
+      RawFields:
+        - Name: ctrl
+          Offset: 0
+          Type: 18 BaseType uint64
+        - Name: slots
+          Offset: 8
+          Type: 39 ArrayType noalg.[8]struct { key string; elem *main.bigStruct }
+    - __kind: StructureType
+      ID: 40
+      Name: noalg.struct { key string; elem *main.bigStruct }
+      ByteSize: 24
+      GoRuntimeType: 77248
+      GoKind: 25
+      RawFields:
+        - Name: key
+          Offset: 0
+          Type: 7 GoStringHeaderType string
+        - Name: elem
+          Offset: 16
+          Type: 41 PointerType *main.bigStruct
+    - __kind: StructureType
+      ID: 28
+      Name: noalg.struct { key string; elem int }
+      ByteSize: 24
+      GoRuntimeType: 76992
+      GoKind: 25
+      RawFields:
+        - Name: key
+          Offset: 0
+          Type: 7 GoStringHeaderType string
+        - Name: elem
+          Offset: 16
+          Type: 1 BaseType int
+    - __kind: GoStringHeaderType
+      ID: 7
+      Name: string
+      ByteSize: 16
+      GoRuntimeType: 42720
+      GoKind: 24
+      RawFields:
+        - Name: str
+          Offset: 0
+          Type: 68 PointerType *string.str
+        - Name: len
+          Offset: 8
+          Type: 1 BaseType int
+      Data: 67 GoStringDataType string.str
+    - __kind: GoStringDataType
+      ID: 67
+      Name: string.str
+      ByteSize: 2048
+    - __kind: StructureType
+      ID: 22
+      Name: table<string,int>
+      ByteSize: 32
+      GoKind: 25
+      RawFields:
+        - Name: used
+          Offset: 0
+          Type: 23 BaseType uint16
+        - Name: capacity
+          Offset: 2
+          Type: 23 BaseType uint16
+        - Name: growthLeft
+          Offset: 4
+          Type: 23 BaseType uint16
+        - Name: localDepth
+          Offset: 6
+          Type: 9 BaseType uint8
+        - Name: index
+          Offset: 8
+          Type: 1 BaseType int
+        - Name: groups
+          Offset: 16
+          Type: 24 GoSwissMapGroupsType groupReference<string,int>
     - __kind: StructureType
       ID: 35
       Name: table<string,main.bigStruct>
@@ -708,107 +1152,18 @@ Types:
         - Name: groups
           Offset: 16
           Type: 36 GoSwissMapGroupsType groupReference<string,main.bigStruct>
-    - __kind: GoSwissMapGroupsType
-      ID: 36
-      Name: groupReference<string,main.bigStruct>
-      ByteSize: 16
-      GoKind: 25
-      RawFields:
-        - Name: data
-          Offset: 0
-          Type: 37 PointerType *noalg.map.group[string]main.bigStruct
-        - Name: lengthMask
-          Offset: 8
-          Type: 18 BaseType uint64
-      GroupType: 38 StructureType noalg.map.group[string]main.bigStruct
-      GroupSliceType: 76 GoSliceDataType []noalg.map.group[string]main.bigStruct.array
-    - __kind: PointerType
-      ID: 37
-      Name: '*noalg.map.group[string]main.bigStruct'
+    - __kind: BaseType
+      ID: 45
+      Name: uint
       ByteSize: 8
-      Pointee: 38 StructureType noalg.map.group[string]main.bigStruct
-    - __kind: StructureType
-      ID: 38
-      Name: noalg.map.group[string]main.bigStruct
-      ByteSize: 200
-      GoRuntimeType: 77376
-      GoKind: 25
-      RawFields:
-        - Name: ctrl
-          Offset: 0
-          Type: 18 BaseType uint64
-        - Name: slots
-          Offset: 8
-          Type: 39 ArrayType noalg.[8]struct { key string; elem *main.bigStruct }
-    - __kind: ArrayType
-      ID: 39
-      Name: noalg.[8]struct { key string; elem *main.bigStruct }
-      ByteSize: 192
-      GoRuntimeType: 47744
-      GoKind: 17
-      Count: 8
-      HasCount: true
-      Element: 40 StructureType noalg.struct { key string; elem *main.bigStruct }
-    - __kind: StructureType
-      ID: 40
-      Name: noalg.struct { key string; elem *main.bigStruct }
-      ByteSize: 24
-      GoRuntimeType: 77248
-      GoKind: 25
-      RawFields:
-        - Name: key
-          Offset: 0
-          Type: 7 GoStringHeaderType string
-        - Name: elem
-          Offset: 16
-          Type: 41 PointerType *main.bigStruct
-    - __kind: PointerType
-      ID: 41
-      Name: '*main.bigStruct'
-      ByteSize: 8
-      GoRuntimeType: 27776
-      GoKind: 22
-      Pointee: 42 StructureType main.bigStruct
-    - __kind: StructureType
-      ID: 42
-      Name: main.bigStruct
-      ByteSize: 184
-      GoRuntimeType: 124608
-      GoKind: 25
-      RawFields:
-        - Name: Field1
-          Offset: 0
-          Type: 1 BaseType int
-        - Name: Field2
-          Offset: 8
-          Type: 1 BaseType int
-        - Name: Field3
-          Offset: 16
-          Type: 1 BaseType int
-        - Name: Field4
-          Offset: 24
-          Type: 1 BaseType int
-        - Name: Field5
-          Offset: 32
-          Type: 1 BaseType int
-        - Name: Field6
-          Offset: 40
-          Type: 1 BaseType int
-        - Name: Field7
-          Offset: 48
-          Type: 1 BaseType int
-        - Name: data
-          Offset: 56
-          Type: 43 ArrayType [128]uint8
-    - __kind: ArrayType
-      ID: 43
-      Name: '[128]uint8'
-      ByteSize: 128
-      GoRuntimeType: 47648
-      GoKind: 17
-      Count: 128
-      HasCount: true
-      Element: 9 BaseType uint8
+      GoRuntimeType: 43360
+      GoKind: 7
+    - __kind: BaseType
+      ID: 23
+      Name: uint16
+      ByteSize: 2
+      GoRuntimeType: 42976
+      GoKind: 9
     - __kind: BaseType
       ID: 44
       Name: uint32
@@ -816,384 +1171,29 @@ Types:
       GoRuntimeType: 43104
       GoKind: 10
     - __kind: BaseType
-      ID: 45
-      Name: uint
+      ID: 18
+      Name: uint64
       ByteSize: 8
-      GoRuntimeType: 43360
-      GoKind: 7
-    - __kind: PointerType
-      ID: 46
-      Name: '*bool'
-      ByteSize: 8
-      GoRuntimeType: 30400
-      GoKind: 22
-      Pointee: 29 BaseType bool
+      GoRuntimeType: 43232
+      GoKind: 11
     - __kind: BaseType
-      ID: 47
-      Name: int32
-      ByteSize: 4
-      GoRuntimeType: 43040
-      GoKind: 5
+      ID: 9
+      Name: uint8
+      ByteSize: 1
+      GoRuntimeType: 42848
+      GoKind: 8
     - __kind: BaseType
-      ID: 48
-      Name: int64
+      ID: 19
+      Name: uintptr
       ByteSize: 8
-      GoRuntimeType: 43168
-      GoKind: 6
-    - __kind: GoInterfaceType
-      ID: 49
-      Name: error
-      ByteSize: 16
-      GoRuntimeType: 65728
-      GoKind: 20
-      RawFields:
-        - Name: tab
-          Offset: 0
-          Type: 50 VoidPointerType unsafe.Pointer
-        - Name: data
-          Offset: 8
-          Type: 50 VoidPointerType unsafe.Pointer
+      GoRuntimeType: 43424
+      GoKind: 12
     - __kind: VoidPointerType
       ID: 50
       Name: unsafe.Pointer
       ByteSize: 8
       GoRuntimeType: 43808
       GoKind: 26
-    - __kind: BaseType
-      ID: 51
-      Name: float64
-      ByteSize: 8
-      GoRuntimeType: 43680
-      GoKind: 14
-    - __kind: BaseType
-      ID: 52
-      Name: int8
-      ByteSize: 1
-      GoRuntimeType: 42784
-      GoKind: 3
-    - __kind: BaseType
-      ID: 53
-      Name: float32
-      ByteSize: 4
-      GoRuntimeType: 43616
-      GoKind: 13
-    - __kind: PointerType
-      ID: 54
-      Name: '*uintptr'
-      ByteSize: 8
-      GoRuntimeType: 30080
-      GoKind: 22
-      Pointee: 19 BaseType uintptr
-    - __kind: PointerType
-      ID: 55
-      Name: '*int32'
-      ByteSize: 8
-      GoRuntimeType: 29696
-      GoKind: 22
-      Pointee: 47 BaseType int32
-    - __kind: PointerType
-      ID: 56
-      Name: '*uint32'
-      ByteSize: 8
-      GoRuntimeType: 29760
-      GoKind: 22
-      Pointee: 44 BaseType uint32
-    - __kind: BaseType
-      ID: 57
-      Name: int16
-      ByteSize: 2
-      GoRuntimeType: 42912
-      GoKind: 4
-    - __kind: BaseType
-      ID: 58
-      Name: complex64
-      ByteSize: 8
-      GoRuntimeType: 43488
-      GoKind: 15
-    - __kind: BaseType
-      ID: 59
-      Name: complex128
-      ByteSize: 16
-      GoRuntimeType: 43552
-      GoKind: 16
-    - __kind: PointerType
-      ID: 60
-      Name: '*float64'
-      ByteSize: 8
-      GoRuntimeType: 30336
-      GoKind: 22
-      Pointee: 51 BaseType float64
-    - __kind: PointerType
-      ID: 61
-      Name: '*uint64'
-      ByteSize: 8
-      GoRuntimeType: 29888
-      GoKind: 22
-      Pointee: 18 BaseType uint64
-    - __kind: PointerType
-      ID: 62
-      Name: '*int64'
-      ByteSize: 8
-      GoRuntimeType: 29824
-      GoKind: 22
-      Pointee: 48 BaseType int64
-    - __kind: PointerType
-      ID: 63
-      Name: '*error'
-      ByteSize: 8
-      GoRuntimeType: 29312
-      GoKind: 22
-      Pointee: 49 GoInterfaceType error
-    - __kind: PointerType
-      ID: 64
-      Name: '*float32'
-      ByteSize: 8
-      GoRuntimeType: 30272
-      GoKind: 22
-      Pointee: 53 BaseType float32
-    - __kind: PointerType
-      ID: 65
-      Name: '*uint'
-      ByteSize: 8
-      GoRuntimeType: 30016
-      GoKind: 22
-      Pointee: 45 BaseType uint
-    - __kind: PointerType
-      ID: 66
-      Name: '*uint16'
-      ByteSize: 8
-      GoRuntimeType: 29632
-      GoKind: 22
-      Pointee: 23 BaseType uint16
-    - __kind: GoStringDataType
-      ID: 67
-      Name: string.str
-      ByteSize: 2048
-    - __kind: PointerType
-      ID: 68
-      Name: '*string.str'
-      ByteSize: 8
-      Pointee: 67 GoStringDataType string.str
-    - __kind: GoSliceDataType
-      ID: 69
-      Name: '[]int.array'
-      ByteSize: 2048
-      Element: 1 BaseType int
-    - __kind: PointerType
-      ID: 70
-      Name: '*[]int.array'
-      ByteSize: 8
-      Pointee: 69 GoSliceDataType []int.array
-    - __kind: GoSliceDataType
-      ID: 71
-      Name: '[]string.array'
-      ByteSize: 2048
-      Element: 7 GoStringHeaderType string
-    - __kind: PointerType
-      ID: 72
-      Name: '*[]string.array'
-      ByteSize: 8
-      Pointee: 71 GoSliceDataType []string.array
-    - __kind: GoSliceDataType
-      ID: 73
-      Name: '[]*table<string,int>.array'
-      ByteSize: 8192
-      Element: 21 PointerType *table<string,int>
-    - __kind: GoSliceDataType
-      ID: 74
-      Name: '[]noalg.map.group[string]int.array'
-      ByteSize: 2048
-      Element: 26 StructureType noalg.map.group[string]int
-    - __kind: GoSliceDataType
-      ID: 75
-      Name: '[]*table<string,main.bigStruct>.array'
-      ByteSize: 8192
-      Element: 34 PointerType *table<string,main.bigStruct>
-    - __kind: GoSliceDataType
-      ID: 76
-      Name: '[]noalg.map.group[string]main.bigStruct.array'
-      ByteSize: 2048
-      Element: 38 StructureType noalg.map.group[string]main.bigStruct
-    - __kind: EventRootType
-      ID: 77
-      Name: Probe[main.intArg]
-      ByteSize: 9
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: x
-          Offset: 1
-          Expression:
-            Type: 1 BaseType int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 4, index: 0, name: x}
-                  Offset: 0
-                  ByteSize: 8
-    - __kind: EventRootType
-      ID: 78
-      Name: Probe[main.stringArg]
-      ByteSize: 17
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: s
-          Offset: 1
-          Expression:
-            Type: 7 GoStringHeaderType string
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 5, index: 0, name: s}
-                  Offset: 0
-                  ByteSize: 16
-    - __kind: EventRootType
-      ID: 79
-      Name: Probe[main.intSliceArg]
-      ByteSize: 25
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: s
-          Offset: 1
-          Expression:
-            Type: 10 GoSliceHeaderType []int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 6, index: 0, name: s}
-                  Offset: 0
-                  ByteSize: 24
-    - __kind: EventRootType
-      ID: 80
-      Name: Probe[main.intArrayArg]
-      ByteSize: 25
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: s
-          Offset: 1
-          Expression:
-            Type: 11 ArrayType [3]int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 7, index: 0, name: s}
-                  Offset: 0
-                  ByteSize: 24
-    - __kind: EventRootType
-      ID: 81
-      Name: Probe[main.stringSliceArg]
-      ByteSize: 25
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: s
-          Offset: 1
-          Expression:
-            Type: 12 GoSliceHeaderType []string
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 8, index: 0, name: s}
-                  Offset: 0
-                  ByteSize: 24
-    - __kind: EventRootType
-      ID: 82
-      Name: Probe[main.stringArrayArg]
-      ByteSize: 49
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: s
-          Offset: 1
-          Expression:
-            Type: 14 ArrayType [3]string
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 9, index: 0, name: s}
-                  Offset: 0
-                  ByteSize: 48
-    - __kind: EventRootType
-      ID: 83
-      Name: Probe[main.stringArrayArgFrameless]
-      ByteSize: 49
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: s
-          Offset: 1
-          Expression:
-            Type: 14 ArrayType [3]string
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 10, index: 0, name: s}
-                  Offset: 0
-                  ByteSize: 48
-    - __kind: EventRootType
-      ID: 84
-      Name: Probe[main.mapArg]
-      ByteSize: 9
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: m
-          Offset: 1
-          Expression:
-            Type: 15 GoMapType map[string]int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 11, index: 0, name: m}
-                  Offset: 0
-                  ByteSize: 8
-    - __kind: EventRootType
-      ID: 85
-      Name: Probe[main.bigMapArg]
-      ByteSize: 9
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: m
-          Offset: 1
-          Expression:
-            Type: 30 GoMapType map[string]main.bigStruct
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 12, index: 0, name: m}
-                  Offset: 0
-                  ByteSize: 8
-    - __kind: EventRootType
-      ID: 86
-      Name: Probe[main.inlined]
-      ByteSize: 9
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: x
-          Offset: 1
-          Expression:
-            Type: 1 BaseType int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 1, index: 0, name: x}
-                  Offset: 0
-                  ByteSize: 8
-    - __kind: EventRootType
-      ID: 87
-      Name: Probe[main.PointerChainArg]
-      ByteSize: 9
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: ptr
-          Offset: 1
-          Expression:
-            Type: 2 PointerType *****int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 2, index: 0, name: ptr}
-                  Offset: 0
-                  ByteSize: 8
-    - __kind: EventRootType
-      ID: 88
-      Name: Probe[main.PointerSmallChainArg]
-      ByteSize: 9
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: ptr
-          Offset: 1
-          Expression:
-            Type: 5 PointerType **int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 3, index: 0, name: ptr}
-                  Offset: 0
-                  ByteSize: 8
 MaxTypeID: 88
 Issues: []
 GoModuledataInfo: {FirstModuledataAddr: "0x1a13a0", TypesOffset: 296}

--- a/pkg/dyninst/irgen/type_catalog.go
+++ b/pkg/dyninst/irgen/type_catalog.go
@@ -63,53 +63,76 @@ func newTypeCatalog(
 // if we reach a type that needs to be explored further. We'll need some
 // bookkeeping on the depth from which a type has been explored.
 
-func (c *typeCatalog) addType(offset dwarf.Offset) (_ ir.Type, retErr error) {
-	if id, ok := c.typesByDwarfType[offset]; ok {
-		return c.typesByID[id], nil
-	}
-
+func (c *typeCatalog) addType(offset dwarf.Offset) (ret ir.Type, retErr error) {
+	// At most there can be 2 "superficial" typedefs above a real type.  One can
+	// happen for structures and subprogram types, and another can happen around
+	// generic type parameters nested underneath subprograms (which may then
+	// point to the meaningless structure typedef). The depth here includes the
+	// two superficial typedefs and the offset of the real type.
+	const maxTypedefDepth = 3
+	type offsetArray [maxTypedefDepth]dwarf.Offset
+	offsets, numOffsets := offsetArray{0: offset}, 1
 	defer func() {
-		if retErr != nil {
-			retErr = fmt.Errorf("offset 0x%x: %w", offset, retErr)
+		if retErr == nil {
+			return
+		}
+		for ; numOffsets > 0; numOffsets-- {
+			retErr = fmt.Errorf("offset 0x%x: %w", offsets[numOffsets-1], retErr)
 		}
 	}()
-
-	reader := c.dwarf.Reader()
-	reader.Seek(offset)
-	entry, err := reader.Next()
-	if err != nil {
-		return nil, fmt.Errorf("failed to get next entry: %w", err)
-	}
-	if entry == nil {
-		return nil, fmt.Errorf("unexpected EOF while reading type")
-	}
-	// We need to figure out whether this is a meaningless typedef as exists
-	// for structure types, or if it's a special typedef that go uses for things
-	// like channels, interfaces, etc.
-	if entry.Tag == dwarf.TagTypedef && entry.AttrField(dwAtGoKind) == nil {
-		// We want to now look up the real type and use that instead.
-		typeVal := entry.Val(dwarf.AttrType)
-		if typeVal == nil {
-			// This case is possible in Dwarf, but not clear when it happens.
-			// For now, just return an error.
-			return nil, fmt.Errorf("missing type for typedef")
+	var r *dwarf.Reader
+	var entry *dwarf.Entry
+	var pt *pointeePlaceholderType
+	for {
+		offset := offsets[numOffsets-1]
+		tid, ok := c.typesByDwarfType[offset]
+		if ok {
+			t := c.typesByID[tid]
+			ppt, ok := t.(*pointeePlaceholderType)
+			if !ok {
+				return t, nil
+			}
+			if pt != nil && ppt != pt {
+				return nil, fmt.Errorf("bug: multiple pointee placeholder types found")
+			}
+			pt = ppt
 		}
-		typeOffset, ok := typeVal.(dwarf.Offset)
-		if !ok {
-			return nil, fmt.Errorf("invalid type for typedef: %T", typeVal)
+		if r == nil {
+			r = c.dwarf.Reader()
 		}
-		underlyingType, err := c.addType(typeOffset)
+		r.Seek(offset)
+		var err error
+		entry, err = r.Next()
 		if err != nil {
-			return nil, err
+			return nil, fmt.Errorf("failed to get next entry: %w", err)
 		}
-		c.typesByDwarfType[offset] = underlyingType.GetID()
-		return underlyingType, nil
+		if entry == nil {
+			return nil, fmt.Errorf("unexpected EOF while reading type")
+		}
+		if entry.Tag != dwarf.TagTypedef || entry.AttrField(dwAtGoKind) != nil {
+			break
+		}
+		typeOffset, err := getAttr[dwarf.Offset](entry, dwarf.AttrType)
+		if err != nil {
+			return nil, fmt.Errorf("failed to get type for typedef: %w", err)
+		}
+		if numOffsets++; numOffsets > maxTypedefDepth {
+			return nil, fmt.Errorf("long typedef chain detected")
+		}
+		offsets[numOffsets-1] = typeOffset
 	}
 
-	id := c.idAlloc.next()
-	c.typesByDwarfType[offset] = id
+	var id ir.TypeID
+	if pt != nil {
+		id = pt.id
+	} else {
+		id = c.idAlloc.next()
+	}
+	for _, offset := range offsets[:numOffsets] {
+		c.typesByDwarfType[offset] = id
+	}
 	c.typesByID[id] = &placeHolderType{id: id}
-	irType, err := c.buildType(id, entry, reader)
+	irType, err := c.buildType(id, entry, r)
 	if err != nil {
 		return nil, err
 	}
@@ -241,24 +264,70 @@ func (c *typeCatalog) buildType(
 		if err != nil {
 			return nil, err
 		}
+		if !hasPointee {
+			// unsafe.Pointer is a special case where the type is represented
+			// in DWARF as a PointerType, but without a pointee or specified Go kind.
+			goAttrs.GoKind = reflect.UnsafePointer
+			return &ir.VoidPointerType{
+				TypeCommon:       common,
+				GoTypeAttributes: goAttrs,
+			}, nil
+		}
+
+		// Resolve the pointee type.
 		var pointee ir.Type
-		if hasPointee {
-			pointee, err = c.addType(pointeeOffset)
+		if id, ok := c.typesByDwarfType[pointeeOffset]; ok {
+			pointee = c.typesByID[id]
+		} else {
+			// We need to check and see if underneath this pointer type there's
+			// a typedef that points to an offset for which we already have a
+			// type ID.
+			r := c.dwarf.Reader()
+			r.Seek(pointeeOffset)
+			pointeeEntry, err := r.Next()
 			if err != nil {
 				return nil, err
 			}
-			return &ir.PointerType{
-				TypeCommon:       common,
-				GoTypeAttributes: goAttrs,
-				Pointee:          pointee,
-			}, nil
+			if pointeeEntry == nil {
+				return nil, fmt.Errorf(
+					"unexpected EOF while reading pointee type",
+				)
+			}
+			var underlyingTypeOffset dwarf.Offset
+			var haveUnderlyingType bool
+			if pointeeEntry.Tag == dwarf.TagTypedef &&
+				pointeeEntry.AttrField(dwAtGoKind) == nil {
+				var err error
+				underlyingTypeOffset, err = getAttr[dwarf.Offset](pointeeEntry, dwarf.AttrType)
+				if err != nil {
+					return nil, err
+				}
+				if id, ok := c.typesByDwarfType[underlyingTypeOffset]; ok {
+					pointee = c.typesByID[id]
+				} else {
+					haveUnderlyingType = true
+				}
+			}
+			// If there was no type found, we need to allocate a new placeholder
+			// type.
+			if pointee == nil {
+				pt := &pointeePlaceholderType{
+					id:     c.idAlloc.next(),
+					offset: pointeeOffset,
+				}
+				pointee = pt
+				c.typesByID[pt.id] = pt
+				c.typesByDwarfType[pointeeOffset] = pt.id
+				if haveUnderlyingType {
+					pt.offset = underlyingTypeOffset
+					c.typesByDwarfType[underlyingTypeOffset] = pt.id
+				}
+			}
 		}
-		// unsafe.Pointer is a special case where the type is represented
-		// in DWARF as a PointerType, but without a pointee or specified Go kind.
-		goAttrs.GoKind = reflect.UnsafePointer
-		return &ir.VoidPointerType{
+		return &ir.PointerType{
 			TypeCommon:       common,
 			GoTypeAttributes: goAttrs,
+			Pointee:          pointee,
 		}, nil
 
 	case dwarf.TagStructType:
@@ -269,23 +338,16 @@ func (c *typeCatalog) buildType(
 		if err != nil {
 			return nil, err
 		}
-		// TODO: some of these structure types correspond actually to more
-		// Go-specific types like strings, slices, map internals etc.
+		// Note: some of these structure types correspond actually to more
+		// Go-specific types like strings, slices, map internals etc. If that's
+		// the case, there will be a typedef that carries that information. We
+		// handle this later when we finalize the types.
 		return &ir.StructureType{
 			TypeCommon:       common,
 			GoTypeAttributes: goAttrs,
 			RawFields:        fields,
 		}, nil
 	case dwarf.TagTypedef:
-		getUnderlyingType := func() (ir.Type, error) {
-			underlyingTypeOffset, err := getAttr[dwarf.Offset](
-				entry, dwarf.AttrType,
-			)
-			if err != nil {
-				return nil, err
-			}
-			return c.addType(underlyingTypeOffset)
-		}
 		switch goAttrs.GoKind {
 		case reflect.Chan:
 			return &ir.GoChannelType{
@@ -317,7 +379,13 @@ func (c *typeCatalog) buildType(
 				)
 			}
 		case reflect.Map:
-			underlyingType, err := getUnderlyingType()
+			underlyingTypeOffset, err := getAttr[dwarf.Offset](
+				entry, dwarf.AttrType,
+			)
+			if err != nil {
+				return nil, err
+			}
+			underlyingType, err := c.addType(underlyingTypeOffset)
 			if err != nil {
 				return nil, err
 			}
@@ -329,7 +397,15 @@ func (c *typeCatalog) buildType(
 					underlyingType,
 				)
 			}
-			headerType, ok := headerPtrType.Pointee.(*ir.StructureType)
+			pointee := c.typesByID[headerPtrType.Pointee.GetID()]
+			if ppt, ok := pointee.(*pointeePlaceholderType); ok {
+				pointee, err = c.addType(ppt.offset)
+				if err != nil {
+					return nil, err
+				}
+			}
+			headerPtrType.Pointee = pointee
+			headerType, ok := pointee.(*ir.StructureType)
 			if !ok {
 				return nil, fmt.Errorf(
 					"underlying type for map is not a structure type: %T",
@@ -628,5 +704,15 @@ type placeHolderType struct {
 }
 
 func (t *placeHolderType) GetID() ir.TypeID {
+	return t.id
+}
+
+type pointeePlaceholderType struct {
+	ir.Type
+	id     ir.TypeID
+	offset dwarf.Offset
+}
+
+func (t *pointeePlaceholderType) GetID() ir.TypeID {
 	return t.id
 }

--- a/pkg/dyninst/irgen/visit_type_references.go
+++ b/pkg/dyninst/irgen/visit_type_references.go
@@ -69,6 +69,7 @@ func visitTypeReferences(tc *typeCatalog, f func(t *ir.Type)) {
 		case *ir.GoSwissMapGroupsType:
 		case *ir.GoSwissMapHeaderType:
 		case *ir.VoidPointerType:
+		case *ir.UnresolvedPointeeType:
 		default:
 			panic(fmt.Sprintf("unexpected ir.Type to visit: %#v", t))
 		}

--- a/pkg/dyninst/irgen/visit_type_references.go
+++ b/pkg/dyninst/irgen/visit_type_references.go
@@ -18,9 +18,11 @@ import (
 // rewrites the references to the types to the actual types after
 func rewritePlaceholderReferences(tc *typeCatalog) {
 	visitTypeReferences(tc, func(t *ir.Type) {
-		if placeholder, ok := (*t).(*placeHolderType); ok {
-			(*t) = tc.typesByID[placeholder.id]
-			return
+		switch tt := (*t).(type) {
+		case *placeHolderType:
+			(*t) = tc.typesByID[tt.id]
+		case *pointeePlaceholderType:
+			(*t) = tc.typesByID[tt.id]
 		}
 	})
 }

--- a/pkg/dyninst/irprinter/example_test.go
+++ b/pkg/dyninst/irprinter/example_test.go
@@ -58,6 +58,13 @@ func ExamplePrintJSON() {
 	//   "Subprograms": [],
 	//   "Types": [
 	//     {
+	//       "__kind": "PointerType",
+	//       "ID": 3,
+	//       "Name": "*Node",
+	//       "ByteSize": 8,
+	//       "Pointee": "1 StructureType Node"
+	//     },
+	//     {
 	//       "__kind": "StructureType",
 	//       "ID": 1,
 	//       "Name": "Node",
@@ -81,13 +88,6 @@ func ExamplePrintJSON() {
 	//       "Name": "int",
 	//       "ByteSize": 8,
 	//       "GoKind": 2
-	//     },
-	//     {
-	//       "__kind": "PointerType",
-	//       "ID": 3,
-	//       "Name": "*Node",
-	//       "ByteSize": 8,
-	//       "Pointee": "1 StructureType Node"
 	//     }
 	//   ],
 	//   "MaxTypeID": 3,
@@ -97,7 +97,6 @@ func ExamplePrintJSON() {
 	//     "TypesOffset": 1234
 	//   }
 	// }
-
 }
 
 func ExamplePrintYAML() {
@@ -114,6 +113,11 @@ func ExamplePrintYAML() {
 	// Probes: []
 	// Subprograms: []
 	// Types:
+	//     - __kind: PointerType
+	//       ID: 3
+	//       Name: '*Node'
+	//       ByteSize: 8
+	//       Pointee: 1 StructureType Node
 	//     - __kind: StructureType
 	//       ID: 1
 	//       Name: Node
@@ -130,14 +134,10 @@ func ExamplePrintYAML() {
 	//       Name: int
 	//       ByteSize: 8
 	//       GoKind: 2
-	//     - __kind: PointerType
-	//       ID: 3
-	//       Name: '*Node'
-	//       ByteSize: 8
-	//       Pointee: 1 StructureType Node
 	// MaxTypeID: 3
 	// Issues: []
 	// GoModuledataInfo: {FirstModuledataAddr: "0xdeadbeef", TypesOffset: 1234}
+
 }
 
 func constructExampleProgram() *ir.Program {

--- a/pkg/dyninst/irprinter/json.go
+++ b/pkg/dyninst/irprinter/json.go
@@ -9,6 +9,7 @@ package irprinter
 
 import (
 	"bytes"
+	"cmp"
 	"fmt"
 	"reflect"
 	"slices"
@@ -73,7 +74,7 @@ func PrintJSON(p *ir.Program) ([]byte, error) {
 			return enc.WriteToken(jsontext.String(v.String()))
 		}),
 		json.MarshalToFunc(func(enc *jsontext.Encoder, v uint64) error {
-			if v < 1_000_000 {
+			if v < 10_000 {
 				return json.SkipFunc
 			}
 			return enc.WriteToken(jsontext.String(fmt.Sprintf("0x%x", v)))
@@ -157,7 +158,9 @@ func marshalTypeMap(enc *jsontext.Encoder, tm map[ir.TypeID]ir.Type) error {
 	for id := range tm {
 		ids = append(ids, id)
 	}
-	slices.Sort(ids)
+	slices.SortFunc(ids, func(a, b ir.TypeID) int {
+		return cmp.Compare(tm[a].GetName(), tm[b].GetName())
+	})
 	if err := enc.WriteToken(jsontext.BeginArray); err != nil {
 		return err
 	}

--- a/pkg/dyninst/irprinter/json.go
+++ b/pkg/dyninst/irprinter/json.go
@@ -262,6 +262,7 @@ var allTypes = []reflect.Type{
 	reflect.TypeOf((*ir.PointerType)(nil)),
 	reflect.TypeOf((*ir.StructureType)(nil)),
 	reflect.TypeOf((*ir.VoidPointerType)(nil)),
+	reflect.TypeOf((*ir.UnresolvedPointeeType)(nil)),
 }
 
 var typeMarshalers map[reflect.Type]*typeMarshaler

--- a/pkg/dyninst/symdb/testdata/snapshot/sample.arch=amd64,toolchain=go1.23.11.out
+++ b/pkg/dyninst/symdb/testdata/snapshot/sample.arch=amd64,toolchain=go1.23.11.out
@@ -108,11 +108,33 @@ Package: main
 		Arg: a: int (declared at line 93, available: [93-93])
 		Arg: b: error (declared at line 93, available: [93-93])
 		Arg: c: uint (declared at line 93, available: [93-93])
-	Function: executeComplexFuncs (main.executeComplexFuncs) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [96:146]
-		Var: o: main.outer (declared at line 97, available: )
-		Var: s: []*string (declared at line 108, available: )
-		Var: str: string (declared at line 107, available: [96-146])
-		Var: circ: main.circularReferenceType (declared at line 129, available: [96-146])
+	Function: init.0 (main.init.0) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [113:113]
+	Function: testDeepPtr1 (main.testDeepPtr1) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [116:116]
+		Arg: a: main.deepPtr1 (declared at line 116, available: [116-116])
+	Function: testDeepPtr7 (main.testDeepPtr7) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [119:119]
+		Arg: a: *main.deepPtr7 (declared at line 119, available: [119-119])
+	Function: init.1 (main.init.1) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [139:139]
+	Function: testDeepSlice1 (main.testDeepSlice1) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [142:142]
+		Arg: a: main.deepSlice1 (declared at line 142, available: [142-142])
+	Function: testDeepSlice7 (main.testDeepSlice7) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [145:145]
+		Arg: a: *main.deepSlice7 (declared at line 145, available: [145-145])
+	Function: init.2 (main.init.2) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [177:177]
+	Function: testDeepMap1 (main.testDeepMap1) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [180:180]
+		Arg: a: main.deepMap1 (declared at line 180, available: [180-180])
+	Function: testDeepMap7 (main.testDeepMap7) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [183:183]
+		Arg: a: *main.deepMap7 (declared at line 183, available: [183-183])
+	Function: testStringType1 (main.testStringType1) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [194:194]
+		Arg: a: *main.stringType1 (declared at line 194, available: [194-194])
+	Function: testStringType2 (main.testStringType2) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [200:200]
+		Arg: a: **main.stringType2 (declared at line 200, available: [200-200])
+	Function: executeComplexFuncs (main.executeComplexFuncs) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [203:267]
+		Var: o: main.outer (declared at line 204, available: )
+		Var: s: []*string (declared at line 215, available: )
+		Var: str: string (declared at line 214, available: [203-267])
+		Var: circ: main.circularReferenceType (declared at line 236, available: [203-267])
+		Var: s1: main.stringType1 (declared at line 262, available: [257-267])
+		Var: s2: main.stringType2 (declared at line 263, available: [257-267])
+		Var: s2p: *main.stringType2 (declared at line 264, available: [257-267])
 	Function: testEsotericStack (main.testEsotericStack) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/esoteric.go [42:44]
 		Arg: e: main.esotericStack (declared at line 42, available: [42-43])
 	Function: testEsotericHeap (main.testEsotericHeap) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/esoteric.go [47:49]
@@ -539,6 +561,18 @@ Package: main
 		Field: writer: io.Writer
 	Type: main.circularReferenceType
 		Field: t: *main.circularReferenceType
+	Type: main.deepPtr1
+		Field: a: *main.deepPtr2
+	Type: main.deepPtr7
+		Field: a: *main.deepPtr8
+	Type: main.deepSlice1
+		Field: a: []*main.deepSlice2
+	Type: main.deepSlice7
+		Field: a: []*main.deepSlice8
+	Type: main.deepMap1
+		Field: a: map[int]*main.deepMap2
+	Type: main.deepMap7
+		Field: a: map[int]*main.deepMap8
 	Type: main.somethingImpl
 		Function: Do (main.(*somethingImpl).Do) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/esoteric.go [21:21]
 			Arg: s: *main.somethingImpl (declared at line 21, available: [21-21])

--- a/pkg/dyninst/symdb/testdata/snapshot/sample.arch=amd64,toolchain=go1.24.3.out
+++ b/pkg/dyninst/symdb/testdata/snapshot/sample.arch=amd64,toolchain=go1.24.3.out
@@ -108,10 +108,32 @@ Package: main
 		Arg: a: int (declared at line 93, available: [93-93])
 		Arg: b: error (declared at line 93, available: [93-93])
 		Arg: c: uint (declared at line 93, available: [93-93])
-	Function: executeComplexFuncs (main.executeComplexFuncs) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [96:146]
-		Var: s: []*string (declared at line 108, available: )
-		Var: str: string (declared at line 107, available: [96-146])
-		Var: circ: main.circularReferenceType (declared at line 129, available: [96-146])
+	Function: init.0 (main.init.0) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [113:113]
+	Function: testDeepPtr1 (main.testDeepPtr1) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [116:116]
+		Arg: a: main.deepPtr1 (declared at line 116, available: [116-116])
+	Function: testDeepPtr7 (main.testDeepPtr7) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [119:119]
+		Arg: a: *main.deepPtr7 (declared at line 119, available: [119-119])
+	Function: init.1 (main.init.1) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [139:139]
+	Function: testDeepSlice1 (main.testDeepSlice1) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [142:142]
+		Arg: a: main.deepSlice1 (declared at line 142, available: [142-142])
+	Function: testDeepSlice7 (main.testDeepSlice7) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [145:145]
+		Arg: a: *main.deepSlice7 (declared at line 145, available: [145-145])
+	Function: init.2 (main.init.2) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [177:177]
+	Function: testDeepMap1 (main.testDeepMap1) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [180:180]
+		Arg: a: main.deepMap1 (declared at line 180, available: [180-180])
+	Function: testDeepMap7 (main.testDeepMap7) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [183:183]
+		Arg: a: *main.deepMap7 (declared at line 183, available: [183-183])
+	Function: testStringType1 (main.testStringType1) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [194:194]
+		Arg: a: *main.stringType1 (declared at line 194, available: [194-194])
+	Function: testStringType2 (main.testStringType2) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [200:200]
+		Arg: a: **main.stringType2 (declared at line 200, available: [200-200])
+	Function: executeComplexFuncs (main.executeComplexFuncs) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [203:267]
+		Var: s: []*string (declared at line 215, available: )
+		Var: str: string (declared at line 214, available: [203-267])
+		Var: circ: main.circularReferenceType (declared at line 236, available: [203-267])
+		Var: s1: main.stringType1 (declared at line 262, available: [257-267])
+		Var: s2: main.stringType2 (declared at line 263, available: [257-267])
+		Var: s2p: *main.stringType2 (declared at line 264, available: [257-267])
 	Function: testEsotericStack (main.testEsotericStack) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/esoteric.go [42:44]
 		Arg: e: main.esotericStack (declared at line 42, available: [42-43])
 	Function: testEsotericHeap (main.testEsotericHeap) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/esoteric.go [47:49]
@@ -526,6 +548,18 @@ Package: main
 		Field: writer: io.Writer
 	Type: main.circularReferenceType
 		Field: t: *main.circularReferenceType
+	Type: main.deepPtr1
+		Field: a: *main.deepPtr2
+	Type: main.deepPtr7
+		Field: a: *main.deepPtr8
+	Type: main.deepSlice1
+		Field: a: []*main.deepSlice2
+	Type: main.deepSlice7
+		Field: a: []*main.deepSlice8
+	Type: main.deepMap1
+		Field: a: map[int]*main.deepMap2
+	Type: main.deepMap7
+		Field: a: map[int]*main.deepMap8
 	Type: main.somethingImpl
 		Function: Do (main.(*somethingImpl).Do) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/esoteric.go [21:21]
 			Arg: s: *main.somethingImpl (declared at line 21, available: [21-21])

--- a/pkg/dyninst/symdb/testdata/snapshot/sample.arch=amd64,toolchain=go1.25.0.out
+++ b/pkg/dyninst/symdb/testdata/snapshot/sample.arch=amd64,toolchain=go1.25.0.out
@@ -108,10 +108,32 @@ Package: main
 		Arg: a: int (declared at line 93, available: [93-93])
 		Arg: b: error (declared at line 93, available: [93-93])
 		Arg: c: uint (declared at line 93, available: [93-93])
-	Function: executeComplexFuncs (main.executeComplexFuncs) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [96:146]
-		Var: s: []*string (declared at line 108, available: )
-		Var: str: string (declared at line 107, available: [96-146])
-		Var: circ: main.circularReferenceType (declared at line 129, available: [96-146])
+	Function: init.0 (main.init.0) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [113:113]
+	Function: testDeepPtr1 (main.testDeepPtr1) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [116:116]
+		Arg: a: main.deepPtr1 (declared at line 116, available: [116-116])
+	Function: testDeepPtr7 (main.testDeepPtr7) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [119:119]
+		Arg: a: *main.deepPtr7 (declared at line 119, available: [119-119])
+	Function: init.1 (main.init.1) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [139:139]
+	Function: testDeepSlice1 (main.testDeepSlice1) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [142:142]
+		Arg: a: main.deepSlice1 (declared at line 142, available: [142-142])
+	Function: testDeepSlice7 (main.testDeepSlice7) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [145:145]
+		Arg: a: *main.deepSlice7 (declared at line 145, available: [145-145])
+	Function: init.2 (main.init.2) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [177:177]
+	Function: testDeepMap1 (main.testDeepMap1) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [180:180]
+		Arg: a: main.deepMap1 (declared at line 180, available: [180-180])
+	Function: testDeepMap7 (main.testDeepMap7) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [183:183]
+		Arg: a: *main.deepMap7 (declared at line 183, available: [183-183])
+	Function: testStringType1 (main.testStringType1) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [194:194]
+		Arg: a: *main.stringType1 (declared at line 194, available: [194-194])
+	Function: testStringType2 (main.testStringType2) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [200:200]
+		Arg: a: **main.stringType2 (declared at line 200, available: [200-200])
+	Function: executeComplexFuncs (main.executeComplexFuncs) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [203:267]
+		Var: s: []*string (declared at line 215, available: )
+		Var: str: string (declared at line 214, available: [203-267])
+		Var: circ: main.circularReferenceType (declared at line 236, available: [203-267])
+		Var: s1: main.stringType1 (declared at line 262, available: [257-267])
+		Var: s2: main.stringType2 (declared at line 263, available: [257-267])
+		Var: s2p: *main.stringType2 (declared at line 264, available: [257-267])
 	Function: testEsotericStack (main.testEsotericStack) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/esoteric.go [42:44]
 		Arg: e: main.esotericStack (declared at line 42, available: [42-43])
 	Function: testEsotericHeap (main.testEsotericHeap) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/esoteric.go [47:49]
@@ -525,6 +547,18 @@ Package: main
 		Field: writer: io.Writer
 	Type: main.circularReferenceType
 		Field: t: *main.circularReferenceType
+	Type: main.deepPtr1
+		Field: a: *main.deepPtr2
+	Type: main.deepPtr7
+		Field: a: *main.deepPtr8
+	Type: main.deepSlice1
+		Field: a: []*main.deepSlice2
+	Type: main.deepSlice7
+		Field: a: []*main.deepSlice8
+	Type: main.deepMap1
+		Field: a: map[int]*main.deepMap2
+	Type: main.deepMap7
+		Field: a: map[int]*main.deepMap8
 	Type: main.somethingImpl
 		Function: Do (main.(*somethingImpl).Do) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/esoteric.go [21:21]
 			Arg: s: *main.somethingImpl (declared at line 21, available: [21-21])

--- a/pkg/dyninst/symdb/testdata/snapshot/sample.arch=arm64,toolchain=go1.23.11.out
+++ b/pkg/dyninst/symdb/testdata/snapshot/sample.arch=arm64,toolchain=go1.23.11.out
@@ -108,11 +108,33 @@ Package: main
 		Arg: a: int (declared at line 93, available: [93-93])
 		Arg: b: error (declared at line 93, available: [93-93])
 		Arg: c: uint (declared at line 93, available: [93-93])
-	Function: executeComplexFuncs (main.executeComplexFuncs) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [96:146]
-		Var: o: main.outer (declared at line 97, available: )
-		Var: s: []*string (declared at line 108, available: )
-		Var: str: string (declared at line 107, available: [96-146])
-		Var: circ: main.circularReferenceType (declared at line 129, available: [96-146])
+	Function: init.0 (main.init.0) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [113:113]
+	Function: testDeepPtr1 (main.testDeepPtr1) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [116:116]
+		Arg: a: main.deepPtr1 (declared at line 116, available: [116-116])
+	Function: testDeepPtr7 (main.testDeepPtr7) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [119:119]
+		Arg: a: *main.deepPtr7 (declared at line 119, available: [119-119])
+	Function: init.1 (main.init.1) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [139:139]
+	Function: testDeepSlice1 (main.testDeepSlice1) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [142:142]
+		Arg: a: main.deepSlice1 (declared at line 142, available: [142-142])
+	Function: testDeepSlice7 (main.testDeepSlice7) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [145:145]
+		Arg: a: *main.deepSlice7 (declared at line 145, available: [145-145])
+	Function: init.2 (main.init.2) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [177:177]
+	Function: testDeepMap1 (main.testDeepMap1) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [180:180]
+		Arg: a: main.deepMap1 (declared at line 180, available: [180-180])
+	Function: testDeepMap7 (main.testDeepMap7) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [183:183]
+		Arg: a: *main.deepMap7 (declared at line 183, available: [183-183])
+	Function: testStringType1 (main.testStringType1) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [194:194]
+		Arg: a: *main.stringType1 (declared at line 194, available: [194-194])
+	Function: testStringType2 (main.testStringType2) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [200:200]
+		Arg: a: **main.stringType2 (declared at line 200, available: [200-200])
+	Function: executeComplexFuncs (main.executeComplexFuncs) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [203:267]
+		Var: o: main.outer (declared at line 204, available: )
+		Var: s: []*string (declared at line 215, available: )
+		Var: str: string (declared at line 214, available: [203-267])
+		Var: circ: main.circularReferenceType (declared at line 236, available: [203-267])
+		Var: s1: main.stringType1 (declared at line 262, available: [257-267])
+		Var: s2: main.stringType2 (declared at line 263, available: [257-267])
+		Var: s2p: *main.stringType2 (declared at line 264, available: [257-267])
 	Function: testEsotericStack (main.testEsotericStack) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/esoteric.go [42:44]
 		Arg: e: main.esotericStack (declared at line 42, available: [42-43])
 	Function: testEsotericHeap (main.testEsotericHeap) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/esoteric.go [47:49]
@@ -539,6 +561,18 @@ Package: main
 		Field: writer: io.Writer
 	Type: main.circularReferenceType
 		Field: t: *main.circularReferenceType
+	Type: main.deepPtr1
+		Field: a: *main.deepPtr2
+	Type: main.deepPtr7
+		Field: a: *main.deepPtr8
+	Type: main.deepSlice1
+		Field: a: []*main.deepSlice2
+	Type: main.deepSlice7
+		Field: a: []*main.deepSlice8
+	Type: main.deepMap1
+		Field: a: map[int]*main.deepMap2
+	Type: main.deepMap7
+		Field: a: map[int]*main.deepMap8
 	Type: main.somethingImpl
 		Function: Do (main.(*somethingImpl).Do) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/esoteric.go [21:21]
 			Arg: s: *main.somethingImpl (declared at line 21, available: [21-21])

--- a/pkg/dyninst/symdb/testdata/snapshot/sample.arch=arm64,toolchain=go1.24.3.out
+++ b/pkg/dyninst/symdb/testdata/snapshot/sample.arch=arm64,toolchain=go1.24.3.out
@@ -108,10 +108,32 @@ Package: main
 		Arg: a: int (declared at line 93, available: [93-93])
 		Arg: b: error (declared at line 93, available: [93-93])
 		Arg: c: uint (declared at line 93, available: [93-93])
-	Function: executeComplexFuncs (main.executeComplexFuncs) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [96:146]
-		Var: s: []*string (declared at line 108, available: )
-		Var: str: string (declared at line 107, available: [96-146])
-		Var: circ: main.circularReferenceType (declared at line 129, available: [96-146])
+	Function: init.0 (main.init.0) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [113:113]
+	Function: testDeepPtr1 (main.testDeepPtr1) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [116:116]
+		Arg: a: main.deepPtr1 (declared at line 116, available: [116-116])
+	Function: testDeepPtr7 (main.testDeepPtr7) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [119:119]
+		Arg: a: *main.deepPtr7 (declared at line 119, available: [119-119])
+	Function: init.1 (main.init.1) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [139:139]
+	Function: testDeepSlice1 (main.testDeepSlice1) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [142:142]
+		Arg: a: main.deepSlice1 (declared at line 142, available: [142-142])
+	Function: testDeepSlice7 (main.testDeepSlice7) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [145:145]
+		Arg: a: *main.deepSlice7 (declared at line 145, available: [145-145])
+	Function: init.2 (main.init.2) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [177:177]
+	Function: testDeepMap1 (main.testDeepMap1) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [180:180]
+		Arg: a: main.deepMap1 (declared at line 180, available: [180-180])
+	Function: testDeepMap7 (main.testDeepMap7) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [183:183]
+		Arg: a: *main.deepMap7 (declared at line 183, available: [183-183])
+	Function: testStringType1 (main.testStringType1) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [194:194]
+		Arg: a: *main.stringType1 (declared at line 194, available: [194-194])
+	Function: testStringType2 (main.testStringType2) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [200:200]
+		Arg: a: **main.stringType2 (declared at line 200, available: [200-200])
+	Function: executeComplexFuncs (main.executeComplexFuncs) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [203:267]
+		Var: s: []*string (declared at line 215, available: )
+		Var: str: string (declared at line 214, available: [203-267])
+		Var: circ: main.circularReferenceType (declared at line 236, available: [203-267])
+		Var: s1: main.stringType1 (declared at line 262, available: [257-267])
+		Var: s2: main.stringType2 (declared at line 263, available: [257-267])
+		Var: s2p: *main.stringType2 (declared at line 264, available: [257-267])
 	Function: testEsotericStack (main.testEsotericStack) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/esoteric.go [42:44]
 		Arg: e: main.esotericStack (declared at line 42, available: [42-43])
 	Function: testEsotericHeap (main.testEsotericHeap) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/esoteric.go [47:49]
@@ -526,6 +548,18 @@ Package: main
 		Field: writer: io.Writer
 	Type: main.circularReferenceType
 		Field: t: *main.circularReferenceType
+	Type: main.deepPtr1
+		Field: a: *main.deepPtr2
+	Type: main.deepPtr7
+		Field: a: *main.deepPtr8
+	Type: main.deepSlice1
+		Field: a: []*main.deepSlice2
+	Type: main.deepSlice7
+		Field: a: []*main.deepSlice8
+	Type: main.deepMap1
+		Field: a: map[int]*main.deepMap2
+	Type: main.deepMap7
+		Field: a: map[int]*main.deepMap8
 	Type: main.somethingImpl
 		Function: Do (main.(*somethingImpl).Do) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/esoteric.go [21:21]
 			Arg: s: *main.somethingImpl (declared at line 21, available: [21-21])

--- a/pkg/dyninst/symdb/testdata/snapshot/sample.arch=arm64,toolchain=go1.25.0.out
+++ b/pkg/dyninst/symdb/testdata/snapshot/sample.arch=arm64,toolchain=go1.25.0.out
@@ -108,10 +108,32 @@ Package: main
 		Arg: a: int (declared at line 93, available: [93-93])
 		Arg: b: error (declared at line 93, available: [93-93])
 		Arg: c: uint (declared at line 93, available: [93-93])
-	Function: executeComplexFuncs (main.executeComplexFuncs) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [96:146]
-		Var: s: []*string (declared at line 108, available: )
-		Var: str: string (declared at line 107, available: [96-146])
-		Var: circ: main.circularReferenceType (declared at line 129, available: [96-146])
+	Function: init.0 (main.init.0) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [113:113]
+	Function: testDeepPtr1 (main.testDeepPtr1) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [116:116]
+		Arg: a: main.deepPtr1 (declared at line 116, available: [116-116])
+	Function: testDeepPtr7 (main.testDeepPtr7) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [119:119]
+		Arg: a: *main.deepPtr7 (declared at line 119, available: [119-119])
+	Function: init.1 (main.init.1) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [139:139]
+	Function: testDeepSlice1 (main.testDeepSlice1) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [142:142]
+		Arg: a: main.deepSlice1 (declared at line 142, available: [142-142])
+	Function: testDeepSlice7 (main.testDeepSlice7) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [145:145]
+		Arg: a: *main.deepSlice7 (declared at line 145, available: [145-145])
+	Function: init.2 (main.init.2) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [177:177]
+	Function: testDeepMap1 (main.testDeepMap1) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [180:180]
+		Arg: a: main.deepMap1 (declared at line 180, available: [180-180])
+	Function: testDeepMap7 (main.testDeepMap7) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [183:183]
+		Arg: a: *main.deepMap7 (declared at line 183, available: [183-183])
+	Function: testStringType1 (main.testStringType1) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [194:194]
+		Arg: a: *main.stringType1 (declared at line 194, available: [194-194])
+	Function: testStringType2 (main.testStringType2) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [200:200]
+		Arg: a: **main.stringType2 (declared at line 200, available: [200-200])
+	Function: executeComplexFuncs (main.executeComplexFuncs) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [203:267]
+		Var: s: []*string (declared at line 215, available: )
+		Var: str: string (declared at line 214, available: [203-267])
+		Var: circ: main.circularReferenceType (declared at line 236, available: [203-267])
+		Var: s1: main.stringType1 (declared at line 262, available: [257-267])
+		Var: s2: main.stringType2 (declared at line 263, available: [257-267])
+		Var: s2p: *main.stringType2 (declared at line 264, available: [257-267])
 	Function: testEsotericStack (main.testEsotericStack) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/esoteric.go [42:44]
 		Arg: e: main.esotericStack (declared at line 42, available: [42-43])
 	Function: testEsotericHeap (main.testEsotericHeap) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/esoteric.go [47:49]
@@ -525,6 +547,18 @@ Package: main
 		Field: writer: io.Writer
 	Type: main.circularReferenceType
 		Field: t: *main.circularReferenceType
+	Type: main.deepPtr1
+		Field: a: *main.deepPtr2
+	Type: main.deepPtr7
+		Field: a: *main.deepPtr8
+	Type: main.deepSlice1
+		Field: a: []*main.deepSlice2
+	Type: main.deepSlice7
+		Field: a: []*main.deepSlice8
+	Type: main.deepMap1
+		Field: a: map[int]*main.deepMap2
+	Type: main.deepMap7
+		Field: a: map[int]*main.deepMap8
 	Type: main.somethingImpl
 		Function: Do (main.(*somethingImpl).Do) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/esoteric.go [21:21]
 			Arg: s: *main.somethingImpl (declared at line 21, available: [21-21])

--- a/pkg/dyninst/symdb/testdata/snapshot/sample.streaming.arch=amd64,toolchain=go1.23.11.out
+++ b/pkg/dyninst/symdb/testdata/snapshot/sample.streaming.arch=amd64,toolchain=go1.23.11.out
@@ -108,11 +108,33 @@ Package: main
 		Arg: a: int (declared at line 93, available: [93-93])
 		Arg: b: error (declared at line 93, available: [93-93])
 		Arg: c: uint (declared at line 93, available: [93-93])
-	Function: executeComplexFuncs (main.executeComplexFuncs) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [96:146]
-		Var: o: main.outer (declared at line 97, available: )
-		Var: s: []*string (declared at line 108, available: )
-		Var: str: string (declared at line 107, available: [96-146])
-		Var: circ: main.circularReferenceType (declared at line 129, available: [96-146])
+	Function: init.0 (main.init.0) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [113:113]
+	Function: testDeepPtr1 (main.testDeepPtr1) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [116:116]
+		Arg: a: main.deepPtr1 (declared at line 116, available: [116-116])
+	Function: testDeepPtr7 (main.testDeepPtr7) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [119:119]
+		Arg: a: *main.deepPtr7 (declared at line 119, available: [119-119])
+	Function: init.1 (main.init.1) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [139:139]
+	Function: testDeepSlice1 (main.testDeepSlice1) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [142:142]
+		Arg: a: main.deepSlice1 (declared at line 142, available: [142-142])
+	Function: testDeepSlice7 (main.testDeepSlice7) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [145:145]
+		Arg: a: *main.deepSlice7 (declared at line 145, available: [145-145])
+	Function: init.2 (main.init.2) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [177:177]
+	Function: testDeepMap1 (main.testDeepMap1) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [180:180]
+		Arg: a: main.deepMap1 (declared at line 180, available: [180-180])
+	Function: testDeepMap7 (main.testDeepMap7) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [183:183]
+		Arg: a: *main.deepMap7 (declared at line 183, available: [183-183])
+	Function: testStringType1 (main.testStringType1) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [194:194]
+		Arg: a: *main.stringType1 (declared at line 194, available: [194-194])
+	Function: testStringType2 (main.testStringType2) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [200:200]
+		Arg: a: **main.stringType2 (declared at line 200, available: [200-200])
+	Function: executeComplexFuncs (main.executeComplexFuncs) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [203:267]
+		Var: o: main.outer (declared at line 204, available: )
+		Var: s: []*string (declared at line 215, available: )
+		Var: str: string (declared at line 214, available: [203-267])
+		Var: circ: main.circularReferenceType (declared at line 236, available: [203-267])
+		Var: s1: main.stringType1 (declared at line 262, available: [257-267])
+		Var: s2: main.stringType2 (declared at line 263, available: [257-267])
+		Var: s2p: *main.stringType2 (declared at line 264, available: [257-267])
 	Function: testEsotericStack (main.testEsotericStack) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/esoteric.go [42:44]
 		Arg: e: main.esotericStack (declared at line 42, available: [42-43])
 	Function: testEsotericHeap (main.testEsotericHeap) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/esoteric.go [47:49]
@@ -530,6 +552,20 @@ Package: main
 		Field: writer: io.Writer
 	Type: main.circularReferenceType
 		Field: t: *main.circularReferenceType
+	Type: main.deepPtr1
+		Field: a: *main.deepPtr2
+	Type: main.deepPtr7
+		Field: a: *main.deepPtr8
+	Type: main.deepSlice1
+		Field: a: []*main.deepSlice2
+	Type: main.deepSlice7
+		Field: a: []*main.deepSlice8
+	Type: main.deepMap1
+		Field: a: map[int]*main.deepMap2
+	Type: main.deepMap7
+		Field: a: map[int]*main.deepMap8
+	Type: main.stringType1
+	Type: main.stringType2
 	Type: main.somethingImpl
 		Function: Do (main.(*somethingImpl).Do) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/esoteric.go [21:21]
 			Arg: s: *main.somethingImpl (declared at line 21, available: [21-21])

--- a/pkg/dyninst/symdb/testdata/snapshot/sample.streaming.arch=amd64,toolchain=go1.24.3.out
+++ b/pkg/dyninst/symdb/testdata/snapshot/sample.streaming.arch=amd64,toolchain=go1.24.3.out
@@ -108,10 +108,32 @@ Package: main
 		Arg: a: int (declared at line 93, available: [93-93])
 		Arg: b: error (declared at line 93, available: [93-93])
 		Arg: c: uint (declared at line 93, available: [93-93])
-	Function: executeComplexFuncs (main.executeComplexFuncs) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [96:146]
-		Var: s: []*string (declared at line 108, available: )
-		Var: str: string (declared at line 107, available: [96-146])
-		Var: circ: main.circularReferenceType (declared at line 129, available: [96-146])
+	Function: init.0 (main.init.0) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [113:113]
+	Function: testDeepPtr1 (main.testDeepPtr1) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [116:116]
+		Arg: a: main.deepPtr1 (declared at line 116, available: [116-116])
+	Function: testDeepPtr7 (main.testDeepPtr7) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [119:119]
+		Arg: a: *main.deepPtr7 (declared at line 119, available: [119-119])
+	Function: init.1 (main.init.1) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [139:139]
+	Function: testDeepSlice1 (main.testDeepSlice1) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [142:142]
+		Arg: a: main.deepSlice1 (declared at line 142, available: [142-142])
+	Function: testDeepSlice7 (main.testDeepSlice7) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [145:145]
+		Arg: a: *main.deepSlice7 (declared at line 145, available: [145-145])
+	Function: init.2 (main.init.2) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [177:177]
+	Function: testDeepMap1 (main.testDeepMap1) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [180:180]
+		Arg: a: main.deepMap1 (declared at line 180, available: [180-180])
+	Function: testDeepMap7 (main.testDeepMap7) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [183:183]
+		Arg: a: *main.deepMap7 (declared at line 183, available: [183-183])
+	Function: testStringType1 (main.testStringType1) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [194:194]
+		Arg: a: *main.stringType1 (declared at line 194, available: [194-194])
+	Function: testStringType2 (main.testStringType2) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [200:200]
+		Arg: a: **main.stringType2 (declared at line 200, available: [200-200])
+	Function: executeComplexFuncs (main.executeComplexFuncs) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [203:267]
+		Var: s: []*string (declared at line 215, available: )
+		Var: str: string (declared at line 214, available: [203-267])
+		Var: circ: main.circularReferenceType (declared at line 236, available: [203-267])
+		Var: s1: main.stringType1 (declared at line 262, available: [257-267])
+		Var: s2: main.stringType2 (declared at line 263, available: [257-267])
+		Var: s2p: *main.stringType2 (declared at line 264, available: [257-267])
 	Function: testEsotericStack (main.testEsotericStack) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/esoteric.go [42:44]
 		Arg: e: main.esotericStack (declared at line 42, available: [42-43])
 	Function: testEsotericHeap (main.testEsotericHeap) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/esoteric.go [47:49]
@@ -517,6 +539,20 @@ Package: main
 		Field: writer: io.Writer
 	Type: main.circularReferenceType
 		Field: t: *main.circularReferenceType
+	Type: main.deepPtr1
+		Field: a: *main.deepPtr2
+	Type: main.deepPtr7
+		Field: a: *main.deepPtr8
+	Type: main.deepSlice1
+		Field: a: []*main.deepSlice2
+	Type: main.deepSlice7
+		Field: a: []*main.deepSlice8
+	Type: main.deepMap1
+		Field: a: map[int]*main.deepMap2
+	Type: main.deepMap7
+		Field: a: map[int]*main.deepMap8
+	Type: main.stringType1
+	Type: main.stringType2
 	Type: main.somethingImpl
 		Function: Do (main.(*somethingImpl).Do) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/esoteric.go [21:21]
 			Arg: s: *main.somethingImpl (declared at line 21, available: [21-21])

--- a/pkg/dyninst/symdb/testdata/snapshot/sample.streaming.arch=amd64,toolchain=go1.25.0.out
+++ b/pkg/dyninst/symdb/testdata/snapshot/sample.streaming.arch=amd64,toolchain=go1.25.0.out
@@ -108,10 +108,32 @@ Package: main
 		Arg: a: int (declared at line 93, available: [93-93])
 		Arg: b: error (declared at line 93, available: [93-93])
 		Arg: c: uint (declared at line 93, available: [93-93])
-	Function: executeComplexFuncs (main.executeComplexFuncs) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [96:146]
-		Var: s: []*string (declared at line 108, available: )
-		Var: str: string (declared at line 107, available: [96-146])
-		Var: circ: main.circularReferenceType (declared at line 129, available: [96-146])
+	Function: init.0 (main.init.0) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [113:113]
+	Function: testDeepPtr1 (main.testDeepPtr1) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [116:116]
+		Arg: a: main.deepPtr1 (declared at line 116, available: [116-116])
+	Function: testDeepPtr7 (main.testDeepPtr7) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [119:119]
+		Arg: a: *main.deepPtr7 (declared at line 119, available: [119-119])
+	Function: init.1 (main.init.1) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [139:139]
+	Function: testDeepSlice1 (main.testDeepSlice1) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [142:142]
+		Arg: a: main.deepSlice1 (declared at line 142, available: [142-142])
+	Function: testDeepSlice7 (main.testDeepSlice7) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [145:145]
+		Arg: a: *main.deepSlice7 (declared at line 145, available: [145-145])
+	Function: init.2 (main.init.2) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [177:177]
+	Function: testDeepMap1 (main.testDeepMap1) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [180:180]
+		Arg: a: main.deepMap1 (declared at line 180, available: [180-180])
+	Function: testDeepMap7 (main.testDeepMap7) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [183:183]
+		Arg: a: *main.deepMap7 (declared at line 183, available: [183-183])
+	Function: testStringType1 (main.testStringType1) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [194:194]
+		Arg: a: *main.stringType1 (declared at line 194, available: [194-194])
+	Function: testStringType2 (main.testStringType2) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [200:200]
+		Arg: a: **main.stringType2 (declared at line 200, available: [200-200])
+	Function: executeComplexFuncs (main.executeComplexFuncs) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [203:267]
+		Var: s: []*string (declared at line 215, available: )
+		Var: str: string (declared at line 214, available: [203-267])
+		Var: circ: main.circularReferenceType (declared at line 236, available: [203-267])
+		Var: s1: main.stringType1 (declared at line 262, available: [257-267])
+		Var: s2: main.stringType2 (declared at line 263, available: [257-267])
+		Var: s2p: *main.stringType2 (declared at line 264, available: [257-267])
 	Function: testEsotericStack (main.testEsotericStack) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/esoteric.go [42:44]
 		Arg: e: main.esotericStack (declared at line 42, available: [42-43])
 	Function: testEsotericHeap (main.testEsotericHeap) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/esoteric.go [47:49]
@@ -516,6 +538,20 @@ Package: main
 		Field: writer: io.Writer
 	Type: main.circularReferenceType
 		Field: t: *main.circularReferenceType
+	Type: main.deepPtr1
+		Field: a: *main.deepPtr2
+	Type: main.deepPtr7
+		Field: a: *main.deepPtr8
+	Type: main.deepSlice1
+		Field: a: []*main.deepSlice2
+	Type: main.deepSlice7
+		Field: a: []*main.deepSlice8
+	Type: main.deepMap1
+		Field: a: map[int]*main.deepMap2
+	Type: main.deepMap7
+		Field: a: map[int]*main.deepMap8
+	Type: main.stringType1
+	Type: main.stringType2
 	Type: main.somethingImpl
 		Function: Do (main.(*somethingImpl).Do) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/esoteric.go [21:21]
 			Arg: s: *main.somethingImpl (declared at line 21, available: [21-21])

--- a/pkg/dyninst/symdb/testdata/snapshot/sample.streaming.arch=arm64,toolchain=go1.23.11.out
+++ b/pkg/dyninst/symdb/testdata/snapshot/sample.streaming.arch=arm64,toolchain=go1.23.11.out
@@ -108,11 +108,33 @@ Package: main
 		Arg: a: int (declared at line 93, available: [93-93])
 		Arg: b: error (declared at line 93, available: [93-93])
 		Arg: c: uint (declared at line 93, available: [93-93])
-	Function: executeComplexFuncs (main.executeComplexFuncs) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [96:146]
-		Var: o: main.outer (declared at line 97, available: )
-		Var: s: []*string (declared at line 108, available: )
-		Var: str: string (declared at line 107, available: [96-146])
-		Var: circ: main.circularReferenceType (declared at line 129, available: [96-146])
+	Function: init.0 (main.init.0) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [113:113]
+	Function: testDeepPtr1 (main.testDeepPtr1) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [116:116]
+		Arg: a: main.deepPtr1 (declared at line 116, available: [116-116])
+	Function: testDeepPtr7 (main.testDeepPtr7) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [119:119]
+		Arg: a: *main.deepPtr7 (declared at line 119, available: [119-119])
+	Function: init.1 (main.init.1) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [139:139]
+	Function: testDeepSlice1 (main.testDeepSlice1) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [142:142]
+		Arg: a: main.deepSlice1 (declared at line 142, available: [142-142])
+	Function: testDeepSlice7 (main.testDeepSlice7) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [145:145]
+		Arg: a: *main.deepSlice7 (declared at line 145, available: [145-145])
+	Function: init.2 (main.init.2) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [177:177]
+	Function: testDeepMap1 (main.testDeepMap1) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [180:180]
+		Arg: a: main.deepMap1 (declared at line 180, available: [180-180])
+	Function: testDeepMap7 (main.testDeepMap7) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [183:183]
+		Arg: a: *main.deepMap7 (declared at line 183, available: [183-183])
+	Function: testStringType1 (main.testStringType1) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [194:194]
+		Arg: a: *main.stringType1 (declared at line 194, available: [194-194])
+	Function: testStringType2 (main.testStringType2) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [200:200]
+		Arg: a: **main.stringType2 (declared at line 200, available: [200-200])
+	Function: executeComplexFuncs (main.executeComplexFuncs) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [203:267]
+		Var: o: main.outer (declared at line 204, available: )
+		Var: s: []*string (declared at line 215, available: )
+		Var: str: string (declared at line 214, available: [203-267])
+		Var: circ: main.circularReferenceType (declared at line 236, available: [203-267])
+		Var: s1: main.stringType1 (declared at line 262, available: [257-267])
+		Var: s2: main.stringType2 (declared at line 263, available: [257-267])
+		Var: s2p: *main.stringType2 (declared at line 264, available: [257-267])
 	Function: testEsotericStack (main.testEsotericStack) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/esoteric.go [42:44]
 		Arg: e: main.esotericStack (declared at line 42, available: [42-43])
 	Function: testEsotericHeap (main.testEsotericHeap) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/esoteric.go [47:49]
@@ -530,6 +552,20 @@ Package: main
 		Field: writer: io.Writer
 	Type: main.circularReferenceType
 		Field: t: *main.circularReferenceType
+	Type: main.deepPtr1
+		Field: a: *main.deepPtr2
+	Type: main.deepPtr7
+		Field: a: *main.deepPtr8
+	Type: main.deepSlice1
+		Field: a: []*main.deepSlice2
+	Type: main.deepSlice7
+		Field: a: []*main.deepSlice8
+	Type: main.deepMap1
+		Field: a: map[int]*main.deepMap2
+	Type: main.deepMap7
+		Field: a: map[int]*main.deepMap8
+	Type: main.stringType1
+	Type: main.stringType2
 	Type: main.somethingImpl
 		Function: Do (main.(*somethingImpl).Do) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/esoteric.go [21:21]
 			Arg: s: *main.somethingImpl (declared at line 21, available: [21-21])

--- a/pkg/dyninst/symdb/testdata/snapshot/sample.streaming.arch=arm64,toolchain=go1.24.3.out
+++ b/pkg/dyninst/symdb/testdata/snapshot/sample.streaming.arch=arm64,toolchain=go1.24.3.out
@@ -108,10 +108,32 @@ Package: main
 		Arg: a: int (declared at line 93, available: [93-93])
 		Arg: b: error (declared at line 93, available: [93-93])
 		Arg: c: uint (declared at line 93, available: [93-93])
-	Function: executeComplexFuncs (main.executeComplexFuncs) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [96:146]
-		Var: s: []*string (declared at line 108, available: )
-		Var: str: string (declared at line 107, available: [96-146])
-		Var: circ: main.circularReferenceType (declared at line 129, available: [96-146])
+	Function: init.0 (main.init.0) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [113:113]
+	Function: testDeepPtr1 (main.testDeepPtr1) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [116:116]
+		Arg: a: main.deepPtr1 (declared at line 116, available: [116-116])
+	Function: testDeepPtr7 (main.testDeepPtr7) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [119:119]
+		Arg: a: *main.deepPtr7 (declared at line 119, available: [119-119])
+	Function: init.1 (main.init.1) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [139:139]
+	Function: testDeepSlice1 (main.testDeepSlice1) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [142:142]
+		Arg: a: main.deepSlice1 (declared at line 142, available: [142-142])
+	Function: testDeepSlice7 (main.testDeepSlice7) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [145:145]
+		Arg: a: *main.deepSlice7 (declared at line 145, available: [145-145])
+	Function: init.2 (main.init.2) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [177:177]
+	Function: testDeepMap1 (main.testDeepMap1) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [180:180]
+		Arg: a: main.deepMap1 (declared at line 180, available: [180-180])
+	Function: testDeepMap7 (main.testDeepMap7) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [183:183]
+		Arg: a: *main.deepMap7 (declared at line 183, available: [183-183])
+	Function: testStringType1 (main.testStringType1) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [194:194]
+		Arg: a: *main.stringType1 (declared at line 194, available: [194-194])
+	Function: testStringType2 (main.testStringType2) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [200:200]
+		Arg: a: **main.stringType2 (declared at line 200, available: [200-200])
+	Function: executeComplexFuncs (main.executeComplexFuncs) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [203:267]
+		Var: s: []*string (declared at line 215, available: )
+		Var: str: string (declared at line 214, available: [203-267])
+		Var: circ: main.circularReferenceType (declared at line 236, available: [203-267])
+		Var: s1: main.stringType1 (declared at line 262, available: [257-267])
+		Var: s2: main.stringType2 (declared at line 263, available: [257-267])
+		Var: s2p: *main.stringType2 (declared at line 264, available: [257-267])
 	Function: testEsotericStack (main.testEsotericStack) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/esoteric.go [42:44]
 		Arg: e: main.esotericStack (declared at line 42, available: [42-43])
 	Function: testEsotericHeap (main.testEsotericHeap) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/esoteric.go [47:49]
@@ -517,6 +539,20 @@ Package: main
 		Field: writer: io.Writer
 	Type: main.circularReferenceType
 		Field: t: *main.circularReferenceType
+	Type: main.deepPtr1
+		Field: a: *main.deepPtr2
+	Type: main.deepPtr7
+		Field: a: *main.deepPtr8
+	Type: main.deepSlice1
+		Field: a: []*main.deepSlice2
+	Type: main.deepSlice7
+		Field: a: []*main.deepSlice8
+	Type: main.deepMap1
+		Field: a: map[int]*main.deepMap2
+	Type: main.deepMap7
+		Field: a: map[int]*main.deepMap8
+	Type: main.stringType1
+	Type: main.stringType2
 	Type: main.somethingImpl
 		Function: Do (main.(*somethingImpl).Do) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/esoteric.go [21:21]
 			Arg: s: *main.somethingImpl (declared at line 21, available: [21-21])

--- a/pkg/dyninst/symdb/testdata/snapshot/sample.streaming.arch=arm64,toolchain=go1.25.0.out
+++ b/pkg/dyninst/symdb/testdata/snapshot/sample.streaming.arch=arm64,toolchain=go1.25.0.out
@@ -108,10 +108,32 @@ Package: main
 		Arg: a: int (declared at line 93, available: [93-93])
 		Arg: b: error (declared at line 93, available: [93-93])
 		Arg: c: uint (declared at line 93, available: [93-93])
-	Function: executeComplexFuncs (main.executeComplexFuncs) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [96:146]
-		Var: s: []*string (declared at line 108, available: )
-		Var: str: string (declared at line 107, available: [96-146])
-		Var: circ: main.circularReferenceType (declared at line 129, available: [96-146])
+	Function: init.0 (main.init.0) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [113:113]
+	Function: testDeepPtr1 (main.testDeepPtr1) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [116:116]
+		Arg: a: main.deepPtr1 (declared at line 116, available: [116-116])
+	Function: testDeepPtr7 (main.testDeepPtr7) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [119:119]
+		Arg: a: *main.deepPtr7 (declared at line 119, available: [119-119])
+	Function: init.1 (main.init.1) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [139:139]
+	Function: testDeepSlice1 (main.testDeepSlice1) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [142:142]
+		Arg: a: main.deepSlice1 (declared at line 142, available: [142-142])
+	Function: testDeepSlice7 (main.testDeepSlice7) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [145:145]
+		Arg: a: *main.deepSlice7 (declared at line 145, available: [145-145])
+	Function: init.2 (main.init.2) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [177:177]
+	Function: testDeepMap1 (main.testDeepMap1) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [180:180]
+		Arg: a: main.deepMap1 (declared at line 180, available: [180-180])
+	Function: testDeepMap7 (main.testDeepMap7) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [183:183]
+		Arg: a: *main.deepMap7 (declared at line 183, available: [183-183])
+	Function: testStringType1 (main.testStringType1) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [194:194]
+		Arg: a: *main.stringType1 (declared at line 194, available: [194-194])
+	Function: testStringType2 (main.testStringType2) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [200:200]
+		Arg: a: **main.stringType2 (declared at line 200, available: [200-200])
+	Function: executeComplexFuncs (main.executeComplexFuncs) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [203:267]
+		Var: s: []*string (declared at line 215, available: )
+		Var: str: string (declared at line 214, available: [203-267])
+		Var: circ: main.circularReferenceType (declared at line 236, available: [203-267])
+		Var: s1: main.stringType1 (declared at line 262, available: [257-267])
+		Var: s2: main.stringType2 (declared at line 263, available: [257-267])
+		Var: s2p: *main.stringType2 (declared at line 264, available: [257-267])
 	Function: testEsotericStack (main.testEsotericStack) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/esoteric.go [42:44]
 		Arg: e: main.esotericStack (declared at line 42, available: [42-43])
 	Function: testEsotericHeap (main.testEsotericHeap) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/esoteric.go [47:49]
@@ -516,6 +538,20 @@ Package: main
 		Field: writer: io.Writer
 	Type: main.circularReferenceType
 		Field: t: *main.circularReferenceType
+	Type: main.deepPtr1
+		Field: a: *main.deepPtr2
+	Type: main.deepPtr7
+		Field: a: *main.deepPtr8
+	Type: main.deepSlice1
+		Field: a: []*main.deepSlice2
+	Type: main.deepSlice7
+		Field: a: []*main.deepSlice8
+	Type: main.deepMap1
+		Field: a: map[int]*main.deepMap2
+	Type: main.deepMap7
+		Field: a: map[int]*main.deepMap8
+	Type: main.stringType1
+	Type: main.stringType2
 	Type: main.somethingImpl
 		Function: Do (main.(*somethingImpl).Do) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/esoteric.go [21:21]
 			Arg: s: *main.somethingImpl (declared at line 21, available: [21-21])

--- a/pkg/dyninst/testdata/decoded/sample/testDeepMap1.json
+++ b/pkg/dyninst/testdata/decoded/sample/testDeepMap1.json
@@ -4,7 +4,7 @@
     "ddsource": "dd_debugger",
     "logger": {
       "name": "",
-      "method": "main.testBigStruct",
+      "method": "main.testDeepMap1",
       "version": 0,
       "thread_id": 0,
       "thread_name": ""
@@ -16,14 +16,14 @@
         "language": "go",
         "stack": [
           {
-            "function": "main.testBigStruct",
+            "function": "main.testDeepMap1",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go",
-            "lineNumber": 81
+            "lineNumber": 180
           },
           {
             "function": "main.executeComplexFuncs",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go",
-            "lineNumber": 217
+            "lineNumber": 259
           },
           {
             "function": "main.main",
@@ -42,35 +42,32 @@
           }
         ],
         "probe": {
-          "id": "testBigStruct",
+          "id": "testDeepMap1",
           "location": {
-            "method": "main.testBigStruct"
+            "method": "main.testDeepMap1"
           }
         },
         "captures": {
           "entry": {
             "arguments": {
-              "b": {
-                "type": "main.bigStruct",
+              "a": {
+                "type": "main.deepMap1",
                 "fields": {
-                  "x": {
-                    "type": "[]*string",
+                  "a": {
+                    "type": "map[int]*main.deepMap2",
                     "size": "1",
-                    "elements": [
-                      {
-                        "type": "*string",
-                        "address": "[addr]",
-                        "value": "abc"
-                      }
+                    "entries": [
+                      [
+                        {
+                          "type": "int",
+                          "value": "2"
+                        },
+                        {
+                          "type": "*main.deepMap2",
+                          "notCapturedReason": "depth"
+                        }
+                      ]
                     ]
-                  },
-                  "z": {
-                    "type": "int",
-                    "value": "5"
-                  },
-                  "writer": {
-                    "type": "io.discard",
-                    "notCapturedReason": "missing type information"
                   }
                 }
               }

--- a/pkg/dyninst/testdata/decoded/sample/testDeepMap7.json
+++ b/pkg/dyninst/testdata/decoded/sample/testDeepMap7.json
@@ -1,0 +1,106 @@
+[
+  {
+    "service": "sample",
+    "ddsource": "dd_debugger",
+    "logger": {
+      "name": "",
+      "method": "main.testDeepMap7",
+      "version": 0,
+      "thread_id": 0,
+      "thread_name": ""
+    },
+    "debugger": {
+      "snapshot": {
+        "id": "[id]",
+        "timestamp": "[ts]",
+        "language": "go",
+        "stack": [
+          {
+            "function": "main.testDeepMap7",
+            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go",
+            "lineNumber": 183
+          },
+          {
+            "function": "main.executeComplexFuncs",
+            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go",
+            "lineNumber": 260
+          },
+          {
+            "function": "main.main",
+            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
+            "lineNumber": 36
+          },
+          {
+            "function": "runtime.main",
+            "fileName": "runtime/proc.go",
+            "lineNumber": "[lineNumber]"
+          },
+          {
+            "function": "runtime.goexit",
+            "fileName": "runtime/asm_[arch].s",
+            "lineNumber": "[lineNumber]"
+          }
+        ],
+        "probe": {
+          "id": "testDeepMap7",
+          "location": {
+            "method": "main.testDeepMap7"
+          }
+        },
+        "captures": {
+          "entry": {
+            "arguments": {
+              "a": {
+                "type": "*main.deepMap7",
+                "address": "[addr]",
+                "fields": {
+                  "a": {
+                    "type": "map[int]*main.deepMap8",
+                    "size": "1",
+                    "entries": [
+                      [
+                        {
+                          "type": "int",
+                          "value": "8"
+                        },
+                        {
+                          "type": "*main.deepMap8",
+                          "address": "[addr]",
+                          "fields": {
+                            "a": {
+                              "type": "map[int]*main.deepMap9",
+                              "size": "1",
+                              "entries": [
+                                [
+                                  {
+                                    "type": "int",
+                                    "value": "9"
+                                  },
+                                  {
+                                    "type": "*main.deepMap9",
+                                    "address": "[addr]",
+                                    "fields": {
+                                      "a": {
+                                        "type": "map[int]interface {}",
+                                        "notCapturedReason": "depth"
+                                      }
+                                    }
+                                  }
+                                ]
+                              ]
+                            }
+                          }
+                        }
+                      ]
+                    ]
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "timestamp": "[ts]"
+  }
+]

--- a/pkg/dyninst/testdata/decoded/sample/testDeepPtr1.json
+++ b/pkg/dyninst/testdata/decoded/sample/testDeepPtr1.json
@@ -4,7 +4,7 @@
     "ddsource": "dd_debugger",
     "logger": {
       "name": "",
-      "method": "main.testBigStruct",
+      "method": "main.testDeepPtr1",
       "version": 0,
       "thread_id": 0,
       "thread_name": ""
@@ -16,14 +16,14 @@
         "language": "go",
         "stack": [
           {
-            "function": "main.testBigStruct",
+            "function": "main.testDeepPtr1",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go",
-            "lineNumber": 81
+            "lineNumber": 116
           },
           {
             "function": "main.executeComplexFuncs",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go",
-            "lineNumber": 217
+            "lineNumber": 253
           },
           {
             "function": "main.main",
@@ -42,35 +42,26 @@
           }
         ],
         "probe": {
-          "id": "testBigStruct",
+          "id": "testDeepPtr1",
           "location": {
-            "method": "main.testBigStruct"
+            "method": "main.testDeepPtr1"
           }
         },
         "captures": {
           "entry": {
             "arguments": {
-              "b": {
-                "type": "main.bigStruct",
+              "a": {
+                "type": "main.deepPtr1",
                 "fields": {
-                  "x": {
-                    "type": "[]*string",
-                    "size": "1",
-                    "elements": [
-                      {
-                        "type": "*string",
-                        "address": "[addr]",
-                        "value": "abc"
+                  "a": {
+                    "type": "*main.deepPtr2",
+                    "address": "[addr]",
+                    "fields": {
+                      "a": {
+                        "type": "*main.deepPtr3",
+                        "notCapturedReason": "depth"
                       }
-                    ]
-                  },
-                  "z": {
-                    "type": "int",
-                    "value": "5"
-                  },
-                  "writer": {
-                    "type": "io.discard",
-                    "notCapturedReason": "missing type information"
+                    }
                   }
                 }
               }

--- a/pkg/dyninst/testdata/decoded/sample/testDeepPtr7.json
+++ b/pkg/dyninst/testdata/decoded/sample/testDeepPtr7.json
@@ -4,7 +4,7 @@
     "ddsource": "dd_debugger",
     "logger": {
       "name": "",
-      "method": "main.testBigStruct",
+      "method": "main.testDeepPtr7",
       "version": 0,
       "thread_id": 0,
       "thread_name": ""
@@ -16,14 +16,14 @@
         "language": "go",
         "stack": [
           {
-            "function": "main.testBigStruct",
+            "function": "main.testDeepPtr7",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go",
-            "lineNumber": 81
+            "lineNumber": 119
           },
           {
             "function": "main.executeComplexFuncs",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go",
-            "lineNumber": 217
+            "lineNumber": 254
           },
           {
             "function": "main.main",
@@ -42,35 +42,33 @@
           }
         ],
         "probe": {
-          "id": "testBigStruct",
+          "id": "testDeepPtr7",
           "location": {
-            "method": "main.testBigStruct"
+            "method": "main.testDeepPtr7"
           }
         },
         "captures": {
           "entry": {
             "arguments": {
-              "b": {
-                "type": "main.bigStruct",
+              "a": {
+                "type": "*main.deepPtr7",
+                "address": "[addr]",
                 "fields": {
-                  "x": {
-                    "type": "[]*string",
-                    "size": "1",
-                    "elements": [
-                      {
-                        "type": "*string",
+                  "a": {
+                    "type": "*main.deepPtr8",
+                    "address": "[addr]",
+                    "fields": {
+                      "a": {
+                        "type": "*main.deepPtr9",
                         "address": "[addr]",
-                        "value": "abc"
+                        "fields": {
+                          "a": {
+                            "type": "*main.deepPtr1",
+                            "notCapturedReason": "missing type information"
+                          }
+                        }
                       }
-                    ]
-                  },
-                  "z": {
-                    "type": "int",
-                    "value": "5"
-                  },
-                  "writer": {
-                    "type": "io.discard",
-                    "notCapturedReason": "missing type information"
+                    }
                   }
                 }
               }

--- a/pkg/dyninst/testdata/decoded/sample/testDeepSlice1.json
+++ b/pkg/dyninst/testdata/decoded/sample/testDeepSlice1.json
@@ -4,7 +4,7 @@
     "ddsource": "dd_debugger",
     "logger": {
       "name": "",
-      "method": "main.testBigStruct",
+      "method": "main.testDeepSlice1",
       "version": 0,
       "thread_id": 0,
       "thread_name": ""
@@ -16,14 +16,14 @@
         "language": "go",
         "stack": [
           {
-            "function": "main.testBigStruct",
+            "function": "main.testDeepSlice1",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go",
-            "lineNumber": 81
+            "lineNumber": 142
           },
           {
             "function": "main.executeComplexFuncs",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go",
-            "lineNumber": 217
+            "lineNumber": 256
           },
           {
             "function": "main.main",
@@ -42,35 +42,38 @@
           }
         ],
         "probe": {
-          "id": "testBigStruct",
+          "id": "testDeepSlice1",
           "location": {
-            "method": "main.testBigStruct"
+            "method": "main.testDeepSlice1"
           }
         },
         "captures": {
           "entry": {
             "arguments": {
-              "b": {
-                "type": "main.bigStruct",
+              "a": {
+                "type": "main.deepSlice1",
                 "fields": {
-                  "x": {
-                    "type": "[]*string",
+                  "a": {
+                    "type": "[]*main.deepSlice2",
                     "size": "1",
                     "elements": [
                       {
-                        "type": "*string",
+                        "type": "*main.deepSlice2",
                         "address": "[addr]",
-                        "value": "abc"
+                        "fields": {
+                          "a": {
+                            "type": "[]*main.deepSlice3",
+                            "size": "1",
+                            "elements": [
+                              {
+                                "type": "*main.deepSlice3",
+                                "notCapturedReason": "depth"
+                              }
+                            ]
+                          }
+                        }
                       }
                     ]
-                  },
-                  "z": {
-                    "type": "int",
-                    "value": "5"
-                  },
-                  "writer": {
-                    "type": "io.discard",
-                    "notCapturedReason": "missing type information"
                   }
                 }
               }

--- a/pkg/dyninst/testdata/decoded/sample/testDeepSlice7.json
+++ b/pkg/dyninst/testdata/decoded/sample/testDeepSlice7.json
@@ -4,7 +4,7 @@
     "ddsource": "dd_debugger",
     "logger": {
       "name": "",
-      "method": "main.testBigStruct",
+      "method": "main.testDeepSlice7",
       "version": 0,
       "thread_id": 0,
       "thread_name": ""
@@ -16,14 +16,14 @@
         "language": "go",
         "stack": [
           {
-            "function": "main.testBigStruct",
+            "function": "main.testDeepSlice7",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go",
-            "lineNumber": 81
+            "lineNumber": 145
           },
           {
             "function": "main.executeComplexFuncs",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go",
-            "lineNumber": 217
+            "lineNumber": 257
           },
           {
             "function": "main.main",
@@ -42,35 +42,51 @@
           }
         ],
         "probe": {
-          "id": "testBigStruct",
+          "id": "testDeepSlice7",
           "location": {
-            "method": "main.testBigStruct"
+            "method": "main.testDeepSlice7"
           }
         },
         "captures": {
           "entry": {
             "arguments": {
-              "b": {
-                "type": "main.bigStruct",
+              "a": {
+                "type": "*main.deepSlice7",
+                "address": "[addr]",
                 "fields": {
-                  "x": {
-                    "type": "[]*string",
+                  "a": {
+                    "type": "[]*main.deepSlice8",
                     "size": "1",
                     "elements": [
                       {
-                        "type": "*string",
+                        "type": "*main.deepSlice8",
                         "address": "[addr]",
-                        "value": "abc"
+                        "fields": {
+                          "a": {
+                            "type": "[]*main.deepSlice9",
+                            "size": "1",
+                            "elements": [
+                              {
+                                "type": "*main.deepSlice9",
+                                "address": "[addr]",
+                                "fields": {
+                                  "a": {
+                                    "type": "[]interface {}",
+                                    "size": "1",
+                                    "elements": [
+                                      {
+                                        "type": "*main.deepSlice1",
+                                        "notCapturedReason": "missing type information"
+                                      }
+                                    ]
+                                  }
+                                }
+                              }
+                            ]
+                          }
+                        }
                       }
                     ]
-                  },
-                  "z": {
-                    "type": "int",
-                    "value": "5"
-                  },
-                  "writer": {
-                    "type": "io.discard",
-                    "notCapturedReason": "missing type information"
                   }
                 }
               }

--- a/pkg/dyninst/testdata/decoded/sample/testStringType1.json
+++ b/pkg/dyninst/testdata/decoded/sample/testStringType1.json
@@ -4,7 +4,7 @@
     "ddsource": "dd_debugger",
     "logger": {
       "name": "",
-      "method": "main.testBigStruct",
+      "method": "main.testStringType1",
       "version": 0,
       "thread_id": 0,
       "thread_name": ""
@@ -16,14 +16,14 @@
         "language": "go",
         "stack": [
           {
-            "function": "main.testBigStruct",
+            "function": "main.testStringType1",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go",
-            "lineNumber": 81
+            "lineNumber": 194
           },
           {
             "function": "main.executeComplexFuncs",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go",
-            "lineNumber": 217
+            "lineNumber": 265
           },
           {
             "function": "main.main",
@@ -42,37 +42,18 @@
           }
         ],
         "probe": {
-          "id": "testBigStruct",
+          "id": "testStringType1",
           "location": {
-            "method": "main.testBigStruct"
+            "method": "main.testStringType1"
           }
         },
         "captures": {
           "entry": {
             "arguments": {
-              "b": {
-                "type": "main.bigStruct",
-                "fields": {
-                  "x": {
-                    "type": "[]*string",
-                    "size": "1",
-                    "elements": [
-                      {
-                        "type": "*string",
-                        "address": "[addr]",
-                        "value": "abc"
-                      }
-                    ]
-                  },
-                  "z": {
-                    "type": "int",
-                    "value": "5"
-                  },
-                  "writer": {
-                    "type": "io.discard",
-                    "notCapturedReason": "missing type information"
-                  }
-                }
+              "a": {
+                "type": "*main.stringType1",
+                "address": "[addr]",
+                "value": "s1"
               }
             }
           }

--- a/pkg/dyninst/testdata/decoded/sample/testStringType2.json
+++ b/pkg/dyninst/testdata/decoded/sample/testStringType2.json
@@ -4,7 +4,7 @@
     "ddsource": "dd_debugger",
     "logger": {
       "name": "",
-      "method": "main.testBigStruct",
+      "method": "main.testStringType2",
       "version": 0,
       "thread_id": 0,
       "thread_name": ""
@@ -16,14 +16,14 @@
         "language": "go",
         "stack": [
           {
-            "function": "main.testBigStruct",
+            "function": "main.testStringType2",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go",
-            "lineNumber": 81
+            "lineNumber": 200
           },
           {
             "function": "main.executeComplexFuncs",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go",
-            "lineNumber": 217
+            "lineNumber": 266
           },
           {
             "function": "main.main",
@@ -42,37 +42,17 @@
           }
         ],
         "probe": {
-          "id": "testBigStruct",
+          "id": "testStringType2",
           "location": {
-            "method": "main.testBigStruct"
+            "method": "main.testStringType2"
           }
         },
         "captures": {
           "entry": {
             "arguments": {
-              "b": {
-                "type": "main.bigStruct",
-                "fields": {
-                  "x": {
-                    "type": "[]*string",
-                    "size": "1",
-                    "elements": [
-                      {
-                        "type": "*string",
-                        "address": "[addr]",
-                        "value": "abc"
-                      }
-                    ]
-                  },
-                  "z": {
-                    "type": "int",
-                    "value": "5"
-                  },
-                  "writer": {
-                    "type": "io.discard",
-                    "notCapturedReason": "missing type information"
-                  }
-                }
+              "a": {
+                "type": "**main.stringType2",
+                "notCapturedReason": "depth"
               }
             }
           }

--- a/pkg/dyninst/testprogs/testdata/probes/sample.yaml
+++ b/pkg/dyninst/testprogs/testdata/probes/sample.yaml
@@ -737,3 +737,59 @@ probes:
   where:
     methodName: main.testFramelessArray
   captureSnapshot: true
+- id: testDeepPtr1
+  type: LOG_PROBE
+  where:
+    methodName: main.testDeepPtr1
+  captureSnapshot: true
+  capture:
+    maxReferenceDepth: 1
+- id: testDeepPtr7
+  type: LOG_PROBE
+  where:
+    methodName: main.testDeepPtr7
+  captureSnapshot: true
+  capture:
+    maxReferenceDepth: 5
+- id: testDeepSlice1
+  type: LOG_PROBE
+  where:
+    methodName: main.testDeepSlice1
+  captureSnapshot: true
+  capture:
+    maxReferenceDepth: 1
+- id: testDeepSlice7
+  type: LOG_PROBE
+  where:
+    methodName: main.testDeepSlice7
+  captureSnapshot: true
+  capture:
+    maxReferenceDepth: 5
+- id: testDeepMap1
+  type: LOG_PROBE
+  where:
+    methodName: main.testDeepMap1
+  captureSnapshot: true
+  capture:
+    maxReferenceDepth: 1
+- id: testDeepMap7
+  type: LOG_PROBE
+  where:
+    methodName: main.testDeepMap7
+  captureSnapshot: true
+  capture:
+    maxReferenceDepth: 5
+- id: testStringType1
+  type: LOG_PROBE
+  where:
+    methodName: main.testStringType1
+  captureSnapshot: true
+  capture:
+    maxReferenceDepth: 1
+- id: testStringType2
+  type: LOG_PROBE
+  where:
+    methodName: main.testStringType2
+  captureSnapshot: true
+  capture:
+    maxReferenceDepth: 1


### PR DESCRIPTION
Part of [DEBUG-4043](https://datadoghq.atlassian.net/browse/DEBUG-4043) to control the type graph explosion. Review as individual commits.

Fixes [DEBUG-4272](https://datadoghq.atlassian.net/browse/DEBUG-4272).

#### dyninst/testprogs: add deep type reference testing

This commit adds some deeply nested types to the complex scenario
in the sample testprog and rewrites the tests accordingly.

We see that the output only gets some of the chain.


#### dyninst/irgen: per-probe budgets in bfs

This reworks type expansion to use a BFS scheme that is respects
per-probe budgets. It also makes it straightforward to avoid expanding
non-parameter types that we do not need to expand.


#### dynisnt/ir,irgen: allow some pointers to not be resolved

This commit introduces the notion of an ir.UnresolvedPointeeType which
corresponds to a type we don't know anything about beyond its name, but
we might collect a pointer to it. Practically speaking we should never
be able to collect one of these because of pointer chasing limits in
bpf.

This new type is crucial to be able to have a well-formed type graph
without resolving everything.

This change doesn't perfectly model the minimal amount of type
resolution; it takes the maximum depth across all probes and then
resolves types to that depth.

For testing, this change now makes sure that as we increase the depth,
eventually we converge on the set of types we'd find if we have the
maximal depth we tend to use in our probes.


#### dyninst/irgen: chase the types more lazily

Before this change, whenever we'd add a type, we'd always recursively
add all the reachable types. This change refactors the code so that when
we add a type, if we get to a pointer, we just leave a placeholder for
the pointee that we can come back to later.

This change doesn't actually stop chasing anything based on depth, but
it sets the stage for that in a follow-up. Now to chase everything down
we keep processing types until we hit a fixed point with nothing left to
process.


#### dyninst/irgen: defer type creation

Before this change, we created types eagerly when we visited subprograms
and variables. This made it very hard to control the depth to which we
constructed the type graph. This refactor should have no functional
change, though it does rearrange the order in which we instantiate
types, and thus the type IDs.


#### dyninst/compiler: sort things

Sort the functions by name so there's a bit more stability
when the set of types changes.


#### dyninst/irprinter: sort types by name

We don't really care what IDs they get, do we? Or rather, when that
changes, let's not shuffle everything.


#### dyninst/irgen: do not reprocess map types

For whatever reason, we were revisiting map types which lead to duplicates
in the type graph.


[DEBUG-4043]: https://datadoghq.atlassian.net/browse/DEBUG-4043?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

[DEBUG-4272]: https://datadoghq.atlassian.net/browse/DEBUG-4272?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ